### PR TITLE
Fix eltwise linear operations serialization

### DIFF
--- a/model-optimizer/mo/ops/lin_op.py
+++ b/model-optimizer/mo/ops/lin_op.py
@@ -31,6 +31,9 @@ class LinOp(Op):
             'infer': None,
         }, attrs)
 
+    def supported_attrs(self):
+        return ['operation']
+
 
 class Add(LinOp):
     enabled = False


### PR DESCRIPTION
Hello, serializer skips `<data operation="op"/>` tags for eltwise linear operations. Faced this problem with eltwise Mul when tried onnx model optimizer (sample onnx to reproduce problem is attached). Adding `operation` in LinOp supported attrs seems to fix this issue. 
[sample.zip](https://github.com/opencv/dldt/files/2671322/sample.zip)

