### PR TITLE
Enable reading IR weights from a buffer

### DIFF
--- a/inference-engine/include/cpp/ie_cnn_net_reader.h
+++ b/inference-engine/include/cpp/ie_cnn_net_reader.h
@@ -68,6 +68,14 @@ public:
     }
 
     /**
+     * @brief Wraps original method
+     * ICNNNetReader::ReadWeights(const void*, size_t, ResponseDesc*)
+     */
+    void ReadWeights(const void *weights, size_t size) {
+        CALL_STATUS_FNC(ReadWeights, weights, size);
+    }
+
+    /**
     * @brief Gets a copy of built network object
     * @return A copy of the CNNNetwork object to be loaded
      */

--- a/inference-engine/include/ie_icnn_net_reader.h
+++ b/inference-engine/include/ie_icnn_net_reader.h
@@ -66,6 +66,18 @@ public:
     virtual StatusCode ReadWeights(const char *filepath, ResponseDesc *resp) noexcept = 0;
 
     /**
+     * @brief Loads and sets the weights buffer directly from the memory contains the .bin file.
+     * Weights Blob must always be of bytes - the casting to precision is done per-layer to support mixed
+     * networks and to ease of use.
+     * This method can be called more than once to reflect updates in the .bin.
+     * @param weights Pointer to a bytes array with the weights
+     * @param size Size of the bytes array in bytes
+     * @param resp Response message
+     * @return Result code
+     */
+    virtual StatusCode ReadWeights(const void *weights, size_t size, ResponseDesc *resp) noexcept = 0;
+
+    /**
      * @brief Returns a pointer to the built network
      * @param resp Response message
      */

--- a/inference-engine/src/inference_engine/ie_cnn_net_reader_impl.cpp
+++ b/inference-engine/src/inference_engine/ie_cnn_net_reader_impl.cpp
@@ -96,6 +96,27 @@ StatusCode CNNNetReaderImpl::ReadWeights(const char* filepath, ResponseDesc* res
     return SetWeights(weightsPtr, resp);
 }
 
+StatusCode CNNNetReaderImpl::ReadWeights(const void* weights, size_t size, ResponseDesc* resp) noexcept {
+    if (size < 0) {
+        return DescriptionBuffer(resp) << "Weights buffer size - " << size <<
+                                     "<0. Please, check the weights buffer and size.";
+    }
+
+    if (NULL == weights) {
+        return DescriptionBuffer(resp) << "Weights buffer is null";
+    }
+
+    if (network.get() == nullptr) {
+        return DescriptionBuffer(resp) << "network is empty";
+    }
+
+    TBlob<uint8_t>::Ptr weightsPtr(new TBlob<uint8_t>(Precision::U8, C, {size}));
+    weightsPtr->allocate();
+    memcpy(weightsPtr->buffer(), weights, size);
+
+    return SetWeights(weightsPtr, resp);
+}
+
 StatusCode CNNNetReaderImpl::ReadNetwork(const char* filepath, ResponseDesc* resp) noexcept {
     if (network) {
         return DescriptionBuffer(NETWORK_NOT_READ, resp) << "Network has been read already, use new reader instance to read new network.";

--- a/inference-engine/src/inference_engine/ie_cnn_net_reader_impl.h
+++ b/inference-engine/src/inference_engine/ie_cnn_net_reader_impl.h
@@ -43,6 +43,8 @@ public:
 
     StatusCode ReadWeights(const char *filepath, ResponseDesc *resp) noexcept override;
 
+    StatusCode ReadWeights(const void *weights, size_t size, ResponseDesc *resp)noexcept override;
+
     ICNNNetwork *getNetwork(ResponseDesc *resp) noexcept override {
         return network.get();
     }


### PR DESCRIPTION
Enable reading IR weights from a buffer, given a buffer and its size - similar to the existing overload of ReadNetwork.