### PR TITLE
Cross compile and run DLDT for AARCH64

### DIFF
--- a/inference-engine/samples/speech_sample/main.cpp
+++ b/inference-engine/samples/speech_sample/main.cpp
@@ -259,7 +259,7 @@ float StdDevRelError(score_error_t error) {
                  - (error.sumRelError / error.numScores) * (error.sumRelError / error.numScores)));
 }
 
-#if !defined(__arm__) && !defined(_M_ARM)
+#if !defined(__arm__) && !defined(_M_ARM) && !defined(__aarch64__) && !defined(_M_ARM64)
 #if defined(_WIN32) || defined(WIN32)
 #include <intrin.h>
 #include <windows.h>
@@ -340,7 +340,7 @@ void printPerformanceCounters(std::map<std::string,
         InferenceEngine::InferenceEngineProfileInfo> const &utterancePerfMap,
                               size_t callsNum,
                               std::ostream &stream) {
-#if !defined(__arm__) && !defined(_M_ARM)
+#if !defined(__arm__) && !defined(_M_ARM) && !defined(__aarch64__) && !defined(_M_ARM64)
     stream << std::endl << "Performance counts:" << std::endl;
     stream << std::setw(10) << std::right << "" << "Counter descriptions";
     stream << std::setw(22) << "Utt scoring time";

--- a/inference-engine/thirdparty/mkl-dnn/src/common/utils.cpp
+++ b/inference-engine/thirdparty/mkl-dnn/src/common/utils.cpp
@@ -25,7 +25,10 @@
 #include <malloc.h>
 #include <windows.h>
 #endif
+
+#if defined(__x86_64__) || defined(_M_X64)
 #include "xmmintrin.h"
+#endif
 
 #include "utils.hpp"
 #include "mkldnn_thread.hpp"
@@ -92,6 +95,7 @@ FILE *mkldnn_fopen(const char *filename, const char *mode) {
 THREAD_LOCAL unsigned int mxcsr_save;
 
 void set_rnd_mode(round_mode_t rnd_mode) {
+#if defined(__x86_64__) || defined(_M_X64)
     mxcsr_save = _mm_getcsr();
     unsigned int mxcsr = mxcsr_save & ~(3u << 13);
     switch (rnd_mode) {
@@ -100,10 +104,13 @@ void set_rnd_mode(round_mode_t rnd_mode) {
     default: assert(!"unreachable");
     }
     if (mxcsr != mxcsr_save) _mm_setcsr(mxcsr);
+#endif
 }
 
 void restore_rnd_mode() {
+#if defined(__x86_64__) || defined(_M_X64)
     _mm_setcsr(mxcsr_save);
+#endif
 }
 
 void *malloc(size_t size, int alignment) {


### PR DESCRIPTION
This pull request cross compiled DLDT to AARCH64 so that we could run DLDT with mkl-dnn as the CPU plugin for AARCH64.

The xbyak part is already merged in https://github.com/herumi/xbyak/pull/71. This pull request back ported that patch into DLDT.

The mkl-dnn part will be merged when Evarist rebases xbyak at https://github.com/intel/mkl-dnn/pull/393.

The remaining change in DLDT is in inference-engine/samples/speech_sample/main.cpp, basically AARCH64 was added along with ARM.

The following command was used to configure DLDT to use MKL_DNN as the only plugin for AARCH64.
cmake -DENABLE_MKL_DNN=ON -DENABLE_GNA=OFF -DENABLE_CLDNN=OFF -DTHREADING=SEQ -DENABLE_PROFILING_ITT=OFF -DGEMM=OPENBLAS -DENABLE_SSE42=OFF ..