### PR TITLE
Bugfix: Shape mismatch when converting Slice op from ONNX to IR.

### DIFF
--- a/model-optimizer/extensions/middle/SliceConverter.py
+++ b/model-optimizer/extensions/middle/SliceConverter.py
@@ -71,13 +71,13 @@ class ConvertSlice(MiddleReplacementPattern):
         dims = 0
         axes = np.zeros(begin.size)
         for i in range(len(axis)):
-            if begin[i] != 0 or end[i] < input.shape[i]:
+            if begin[i] != 0 or end[i] < input.shape[axis[i]]:
                 dims += 1
                 axes[i] = 1
                 if begin[i] != 0:
                     axes_begin[axis[i]] = 1
                     begin_ext[axis[i]] = begin[i]
-                if end[i] < input.shape[i]:
+                if end[i] < input.shape[axis[i]]:
                     axes_end[axis[i]] = 1
                     end_ext[axis[i]] = end[i]
         axes = np.array(axes, dtype=bool)


### PR DESCRIPTION
In model-optimizer/extensions/middle/SliceConverter.py, there is an error when parsing the end-slice of the slice. When comparing end-slice with input shape, input shape of the dimension which match the end-slice's dimension should have been used. However, the indexing of input shape is wrong.

This bugfix changes two lines, fixing the wrong indexing.