### PR TITLE
avoid the useless reshape happened when convert the rnn/lstm

### DIFF
--- a/model-optimizer/mo/middle/passes/shape.py
+++ b/model-optimizer/mo/middle/passes/shape.py
@@ -456,6 +456,6 @@ def fuse_sequence_of_reshapes(graph: Graph):
 
         in_shape = reshape_node.in_port(0).get_connection().data.get_shape()
 
-        if np.array_equal(dim, in_shape) and len(reshape_node.out_nodes()):
+        if np.array_equal(dim, in_shape) and len(reshape_node.out_nodes()) and (reshape_node.in_port(0).get_source().node.op is not 'TensorIterator') :
             log.debug("Useless reshape with dim {} was deleted: {}".format(str(dim), reshape_node.name))
             reshape_node.out_port(0).get_connection().set_source(reshape_node.in_port(0).get_source())


### PR DESCRIPTION
For the MO convert the onnx model which include rnn/ lstm layer and its sequence is one, the part of this code will measure the reshape of output state was useless, however, it will make a core dump when inference since IE will check the dimension of input and output state were same or not.
By this patch, add the extra condition for “TensorIterator” to avoid this, and make it work well when inference.