### PR TITLE
Do not fail for split not followed by convolution

### DIFF
--- a/inference-engine/src/cldnn_engine/cldnn_graph.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_graph.cpp
@@ -3339,9 +3339,9 @@ bool CLDNNGraph::IsValidSplitConvMerge(const InferenceEngine::SplitLayer *splitL
     }
 
     auto convLayer1 =
-        as<InferenceEngine::ConvolutionLayer *> (GetNextSingleLayer(splitLayer->outData[0]));
+        dynamic_cast<InferenceEngine::ConvolutionLayer *> (GetNextSingleLayer(splitLayer->outData[0]).get());
     auto convLayer2 =
-        as<InferenceEngine::ConvolutionLayer *> (GetNextSingleLayer(splitLayer->outData[1]));
+        dynamic_cast<InferenceEngine::ConvolutionLayer *> (GetNextSingleLayer(splitLayer->outData[1]).get());
     if (!convLayer1 || !convLayer2) {   // outputs aren't convolutions
         return false;
     }

--- a/inference-engine/src/cldnn_engine/cldnn_graph.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_graph.cpp
@@ -1926,7 +1926,7 @@ void CLDNNGraph::CreateSplitPrimitive(InferenceEngine::CNNLayerPtr &layer) {
     ValidateLayer(layer, 1);
     auto splitLayer = as<InferenceEngine::SplitLayer *> (layer);
     if (IsValidSplitConvMerge(splitLayer)) {
-        // AlextNet style split->conv*2->merge
+        // AlexNet style split->conv*2->merge
         CreateFusedSplitConvMergePrimitive(layer);
     } else {
 #ifdef _USE_SPLIT_PRIMITIVE


### PR DESCRIPTION
Before this change, IsValidSplitConvMerge was calling `as`
instead of dynamic_cast to check RTTIs of layers after split
so it throws an exception. This was a problem for shufflenet
units, in which concatenation can be connected directly after
split.

Example model: http://shinh.skr.jp/t/shufflenetv2.xml
