### PR TITLE
Fix unsafe use of CPU_ISSET_S macro.

### DIFF
--- a/inference-engine/src/mkldnn_plugin/mkldnn_streams.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_streams.cpp
@@ -76,10 +76,11 @@ bool pin_thread_to_vacant_core(int thr_idx, int hyperthreads, int ncores, const 
     }
 
     // Find index of 'cpu_idx'-th bit that equals to 1
-    int mapped_idx = -1;
+    int mapped_idx = 0;
     while (cpu_idx >= 0) {
-        if (CPU_ISSET_S(++mapped_idx, size, proc_mask))
+        if (CPU_ISSET_S(mapped_idx, size, proc_mask))
             --cpu_idx;
+        mapped_idx++;
     }
 
     cpu_set_t *target_mask = CPU_ALLOC(ncores);


### PR DESCRIPTION
Don't increment mapped_idx via prefix increment within the argument of the
potentially unsafe CPU_ISSET_S macro. If the macro is expanded so that the
increment expression is evaluated multiple times, it will return unexpected
results.

While the glibc implementation of CPU_ISSET_S macro seems to be safe, the musl
libc (v1.1.23) version is unsafe and will evaluate the first argument of
CPU_ISSET_S three times.