### PR TITLE
Simplify searching for firmware files

### DIFF
--- a/inference-engine/cmake/vpu_dependencies.cmake
+++ b/inference-engine/cmake/vpu_dependencies.cmake
@@ -4,52 +4,29 @@
 
 set(VPU_SUPPORTED_SOC ma2450 ma2x8x mv0262)
 
-#
-# Default firmware packages
-#
-
-RESOLVE_DEPENDENCY(VPU_FIRMWARE_MA2450
-    ARCHIVE_UNIFIED firmware_ma2450_759W.zip
-    TARGET_PATH "${TEMP}/vpu/firmware/ma2450"
-    ENVIRONMENT "VPU_FIRMWARE_MA2450"
-    FOLDER)
-debug_message(STATUS "ma2450=" ${VPU_FIRMWARE_MA2450})
-
-RESOLVE_DEPENDENCY(VPU_FIRMWARE_MV0262
-    ARCHIVE_UNIFIED firmware_mv0262_mdk_R9.8.zip
-    TARGET_PATH "${TEMP}/vpu/firmware/mv0262"
-    ENVIRONMENT "VPU_FIRMWARE_MV0262"
-    FOLDER)
-debug_message(STATUS "mv0262=" ${VPU_FIRMWARE_MV0262})
-
-RESOLVE_DEPENDENCY(VPU_FIRMWARE_MA2X8X
-    ARCHIVE_UNIFIED firmware_ma2x8x_mdk_R9.8.zip
-    TARGET_PATH "${TEMP}/vpu/firmware/ma2x8x"
-    ENVIRONMENT "VPU_FIRMWARE_MA2X8X"
-    FOLDER)
-debug_message(STATUS "ma2x8x=" ${VPU_FIRMWARE_MA2X8X})
-
-#
-# CMake variables to override default firmware files
-#
-
 foreach(soc IN LISTS VPU_SUPPORTED_SOC)
     string(TOUPPER "${soc}" soc_upper)
-    set(var_name VPU_FIRMWARE_${soc_upper}_FILE)
-
-    find_file(${var_name} MvNCAPI-${soc}.mvcmd "${VPU_FIRMWARE_${soc_upper}}/mvnc")
-    if(NOT ${var_name})
-        message(FATAL_ERROR "[VPU] Missing ${soc} firmware")
+    set(var_name_file VPU_FIRMWARE_${soc_upper}_FILE)
+    set(var_name VPU_FIRMWARE_${soc_upper})
+    set(var_name_zip firmware_${soc}_mdk_R9.8.zip)
+    if(${soc} STREQUAL "ma2450")
+        set(var_name_zip firmware_${soc}_759W.zip)
     endif()
-endforeach()
 
-#
-# `vpu_copy_firmware` CMake target
-#
+    if(NOT DEFINED ${var_name_file})
+        RESOLVE_DEPENDENCY(${var_name}
+            ARCHIVE_UNIFIED ${var_name_zip}
+            TARGET_PATH "${TEMP}/vpu/firmware/${soc}"
+            ENVIRONMENT "${var_name}"
+            FOLDER)
+        find_file(${var_name_file} NAMES "MvNCAPI-${soc}.mvcmd" PATHS "${VPU_FIRMWARE_${soc_upper}}/mvnc" NO_CMAKE_FIND_ROOT_PATH)
+    endif()
 
-foreach(soc IN LISTS VPU_SUPPORTED_SOC)
-    string(TOUPPER "${soc}" soc_upper)
-    set(var_name VPU_FIRMWARE_${soc_upper}_FILE)
+    if(NOT ${var_name_file})
+        message(FATAL_ERROR "[VPU] Missing ${soc} firmware, MvNCAPI-${soc}.mvcmd not found in ${VPU_FIRMWARE_${soc_upper}}/mvnc env $ENV{${var_name}} ")
+    endif()
+
+    debug_message(STATUS "${soc}=" ${${var_name_file}})
 
     set(firmware_out_file "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/MvNCAPI-${soc}.mvcmd")
     list(APPEND all_firmware_files ${firmware_out_file})
@@ -57,9 +34,9 @@ foreach(soc IN LISTS VPU_SUPPORTED_SOC)
     add_custom_command(
         OUTPUT ${firmware_out_file}
         COMMAND
-            ${CMAKE_COMMAND} -E copy ${${var_name}} ${firmware_out_file}
-        MAIN_DEPENDENCY ${${var_name}}
-        COMMENT "[VPU] Copy ${${var_name}} to ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
+            ${CMAKE_COMMAND} -E copy ${${var_name_file}} ${firmware_out_file}
+        MAIN_DEPENDENCY ${${var_name_file}}
+        COMMENT "[VPU] Copy ${${var_name_file}} to ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
         VERBATIM)
 endforeach()
 


### PR DESCRIPTION
Disable runtime fetching when VPU_FIRMWARE_*_FILE variables are defined
and point to already fetched firmware instead.

Do it all in one foreach loop.

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>