### PR TITLE
MO/IE: added support for RandomUniform and Floor

### DIFF
--- a/inference-engine/src/inference_engine/shape_infer/const_infer/ie_const_infer_holder.cpp
+++ b/inference-engine/src/inference_engine/shape_infer/const_infer/ie_const_infer_holder.cpp
@@ -29,6 +29,8 @@
 #include "ie_permute_const_infer.hpp"
 #include "ie_onehot_const_infer.hpp"
 #include "ie_reduce_const_infer.hpp"
+#include "ie_floor_const_infer.hpp"
+#include "ie_random_uniform_const_infer.hpp"
 #include <list>
 #include <memory>
 #include <string>
@@ -98,6 +100,7 @@ REG_CONST_INFER_FOR_TYPE(ReduceConstInfer, ReduceSum);
 REG_CONST_INFER_FOR_TYPE(ReduceConstInfer, ReduceSumSquare);
 REG_CONST_INFER_FOR_TYPE(PermuteConstInfer, Permute);
 REG_CONST_INFER_FOR_TYPE(ConvertConstInfer, Convert);
-
+REG_CONST_INFER_FOR_TYPE(FloorConstInfer, Floor);
+REG_CONST_INFER_FOR_TYPE(RandomUniformConstInfer, RandomUniform);
 }  // namespace ShapeInfer
 }  // namespace InferenceEngine

--- a/inference-engine/src/inference_engine/shape_infer/const_infer/ie_floor_const_infer.hpp
+++ b/inference-engine/src/inference_engine/shape_infer/const_infer/ie_floor_const_infer.hpp
@@ -1,0 +1,54 @@
+// Copyright (C) 2018-2019 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <ie_blob.h>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+#include <ie_layers.h>
+#include "precision_utils.h"
+#include "ie_parallel.hpp"
+
+using namespace InferenceEngine::PrecisionUtils;
+
+namespace InferenceEngine {
+namespace ShapeInfer {
+
+/**
+ *@brief Implementation of Const inference for TBD layer
+ */
+class FloorConstInfer : public ConstInferImpl {
+public:
+    explicit FloorConstInfer(const std::string& type) : ConstInferImpl(type) {}
+
+    void inferImpl(const std::vector<Blob::CPtr>& inData,
+                   const std::map<std::string, std::string>& params,
+                   const std::map<std::string, Blob::Ptr>& blobs,
+                   std::vector<Blob::Ptr>& outData) override {
+        SizeVector inShape = (*inData.begin())->getTensorDesc().getDims();
+        auto outBlob = *outData.begin();
+
+        if (outBlob->getTensorDesc().getPrecision() == Precision::FP16) {
+            const auto* inBuffer = inData[0]->cbuffer().as<ie_fp16*>();
+            auto* outBuffer = outData[0]->buffer().as<ie_fp16*>();
+            parallel_for(outBlob->size(), [&](size_t i) {
+                outBuffer[i] = floor(inBuffer[i]);
+            });
+        } else if (outBlob->getTensorDesc().getPrecision() == Precision::FP32) {
+            const auto* inBuffer = inData[0]->cbuffer().as<float*>();
+            auto* outBuffer = outData[0]->buffer().as<float*>();
+            parallel_for(outBlob->size(), [&](size_t i) {
+                outBuffer[i] = floor(inBuffer[i]);
+            });
+        } else {
+            THROW_IE_EXCEPTION << "data type not supported";
+	}
+    }
+};
+
+}  // namespace ShapeInfer
+}  // namespace InferenceEngine

--- a/inference-engine/src/inference_engine/shape_infer/const_infer/ie_random_uniform_const_infer.hpp
+++ b/inference-engine/src/inference_engine/shape_infer/const_infer/ie_random_uniform_const_infer.hpp
@@ -1,0 +1,76 @@
+// Copyright (C) 2018-2019 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <ie_blob.h>
+#include <map>
+#include <memory>
+#include <random>
+#include <string>
+#include <vector>
+#include <ie_layers.h>
+#include "precision_utils.h"
+#include "ie_parallel.hpp"
+
+using namespace InferenceEngine::PrecisionUtils;
+
+namespace InferenceEngine {
+namespace ShapeInfer {
+
+/**
+ *@brief Implementation of Const inference for TBD layer
+ */
+class RandomUniformConstInfer : public ConstInferImpl {
+public:
+    explicit RandomUniformConstInfer(const std::string& type) : ConstInferImpl(type) {}
+
+    void inferImpl(const std::vector<Blob::CPtr>& inData,
+                   const std::map<std::string, std::string>& params,
+                   const std::map<std::string, Blob::Ptr>& blobs,
+                   std::vector<Blob::Ptr>& outData) override {
+	// extract params from IR model, default values from
+	// tensorflow.python.ops.random_ops
+	// tensorflow.python.framework.random_seed
+	int seed = 0, seed2 = 0x7FFFffff;
+	if (params.find("seed") != params.end()) {
+	    seed = std::stoi(params.find("seed")->second);
+	}
+        if (params.find("seed2") != params.end()) {
+            seed2 = std::stoi(params.find("seed2")->second);
+        }
+	if (seed == 0 && seed2 == 0) {
+	    seed2 = 0x7FFFffff;
+	}
+	std::seed_seq s = {seed, seed2};
+        std::default_random_engine random(s);
+        float minval = 0.0, maxval = 1.0;
+        if (params.find("minval") != params.end()) {
+            minval = std::stof(params.find("minval")->second);
+        }
+        if (params.find("maxval") != params.end()) {
+            maxval = std::stof(params.find("maxval")->second);
+        }
+        std::uniform_real_distribution<float> dis(minval, maxval);
+
+	// execute
+	auto outBlob = *outData.begin();
+        if (outBlob->getTensorDesc().getPrecision() == Precision::FP16) {
+            const auto* inBuffer = inData[0]->cbuffer().as<ie_fp16*>();
+            auto* outBuffer = outData[0]->buffer().as<ie_fp16*>();
+            parallel_for(outBlob->size(), [&](size_t i) {
+                outBuffer[i] = f32tof16(dis(random));
+            });
+        } else {
+            const auto* inBuffer = inData[0]->cbuffer().as<float*>();
+            auto* outBuffer = outData[0]->buffer().as<float*>();
+            parallel_for(outBlob->size(), [&](size_t i) {
+                outBuffer[i] = dis(random);
+            });
+	}
+    }
+};
+
+}  // namespace ShapeInfer
+}  // namespace InferenceEngine

--- a/model-optimizer/extensions/front/tf/floor_ext.py
+++ b/model-optimizer/extensions/front/tf/floor_ext.py
@@ -1,0 +1,27 @@
+"""
+ Copyright (c) 2019 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+from extensions.ops.activation_ops import Floor
+from mo.front.extractor import FrontExtractorOp
+
+class FloorExtractor(FrontExtractorOp):
+    op = 'Floor'
+    enabled = True
+
+    @staticmethod
+    def extract(node):
+        Floor.update_node_stat(node)
+        return __class__.enabled

--- a/model-optimizer/extensions/front/tf/random_uniform_ext.py
+++ b/model-optimizer/extensions/front/tf/random_uniform_ext.py
@@ -1,0 +1,51 @@
+"""
+ Copyright (c) 2019 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+from extensions.ops.random_uniform_ops import RandomUniform
+from mo.front.extractor import FrontExtractorOp
+from tensorflow.core.framework import types_pb2 as tf_types
+from tensorflow.python.framework import tensor_util
+
+class RandomUniformExtractor(FrontExtractorOp):
+    op = 'RandomUniform'
+    enabled = True
+
+    @staticmethod
+    def extract(node):
+        pb = node.pb
+        dtype = tf_types.DT_FLOAT
+        attrs = {}
+        if "T" in pb.attr.keys():
+            attrs['T'] = pb.attr["T"].type
+        if "dtype" in pb.attr.keys():
+            dtype = pb.attr["dtype"].type
+            attrs['dtype'] = dtype
+        if "seed" in pb.attr.keys():
+            attrs['seed'] = pb.attr["seed"].i
+        if "seed2" in pb.attr.keys():
+            attrs['seed2'] = pb.attr["seed2"].i
+        if "minval" in pb.attr.keys():
+            minval = pb.attr["minval"].f \
+                if (dtype == tf_types.DT_FLOAT or dtype == tf_types.DT_DOUBLE) \
+                else pb.attr["minval"].i
+            attrs['minval'] = minval
+        if "maxval" in pb.attr.keys():
+            maxval = pb.attr["maxval"].f \
+                if (dtype == tf_types.DT_FLOAT or dtype == tf_types.DT_DOUBLE) \
+                else pb.attr["maxval"].i
+            attrs['maxval'] = maxval
+        RandomUniform.update_node_stat(node, attrs)
+        return __class__.enabled

--- a/model-optimizer/extensions/ops/random_uniform_ops.py
+++ b/model-optimizer/extensions/ops/random_uniform_ops.py
@@ -1,0 +1,52 @@
+"""
+ Copyright (c) 2019 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+from mo.graph.graph import Graph
+from mo.ops.op import Op
+from mo.front.common.partial_infer.random_uniform import tf_random_uniform_infer
+
+class RandomUniform(Op):
+    op = 'RandomUniform'
+    enabled = True
+
+    def __init__(self, graph: Graph, attrs: dict):
+        super().__init__(graph, {
+            'type': __class__.op,
+            'op': __class__.op,
+            'infer': tf_random_uniform_infer,
+            'in_ports_count': 1,
+            'out_ports_count': 1,
+        }, attrs)
+
+    def supported_attrs(self):
+        return [
+            'T',
+            'dtype',
+            'seed',
+            'seed2',
+            'minval',
+            'maxval'
+        ]
+
+    def backend_attrs(self):
+        return [
+            'T',
+            'dtype',
+            'seed',
+            'seed2',
+            'minval',
+            'maxval'
+        ]


### PR DESCRIPTION
This PR added supports for two layers in Tensorflow framework: RandomUniform and Floor.
Tested with FP32 and FP16, on CPU, GPU, and MYRIAD.

Fix issue https://github.com/opencv/dldt/issues/328