### PR TITLE
Avoid `install_dependencies.sh` Ubuntu failures when the underlying CPU host isn't x86_64

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -22,6 +22,13 @@ yes_or_no() {
 # install dependencies
 if [ -f /etc/lsb-release ]; then
     # Ubuntu
+    host_cpu=$(uname -m)
+    if [ $host_cpu = x86_64 ]; then
+        x86_64_specific_packages="gcc-multilib g++-multilib"
+    else
+        x86_64_specific_packages=""
+    fi
+
     sudo -E apt update
     sudo -E apt-get install -y \
             build-essential \
@@ -32,8 +39,7 @@ if [ -f /etc/lsb-release ]; then
             ca-certificates \
             git \
             libboost-regex-dev \
-            gcc-multilib \
-            g++-multilib \
+            $x86_64_specific_packages \
             libgtk2.0-dev \
             pkg-config \
             unzip \


### PR DESCRIPTION
- The packages `gcc-multilib g++-multilib` are supported by `apt` only for x86_64 (and not, say, for `aarch64`) so we install 'em iff we detect x86_64 host CPU
- `chmod a+x` `install_dependencies.sh`