### PR TITLE
Add GitHub Actions workflow to run pylint against model optimizer

### DIFF
--- a/.github/workflows/mo-pylint.yml
+++ b/.github/workflows/mo-pylint.yml
@@ -1,0 +1,40 @@
+name: pylint
+on:
+  push:
+    paths:
+      - 'model-optimizer/**'
+jobs:
+  pylint:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6
+
+      - name: Cache pip
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('model-optimizer/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
+
+        # tensorflow 1.15 causes modules import
+        # errors, most likely due to https://github.com/PyCQA/pylint/issues/2603
+        # for tensorflow.core.framework and tensorflow.contrib
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools
+          pip install tensorflow==1.14.0 tensorboard==1.14.0 tensorflow-estimator==1.14.0
+          pip install -r requirements.txt
+          pip install -r requirements_dev.txt
+        working-directory: model-optimizer
+
+
+
+      - name: Run pylint
+        run: pylint --ignored-modules=tensorflow.core.framework --ignored-modules=tensorflow.contrib -d C,R,W mo/ mo.py extensions/
+        working-directory: model-optimizer


### PR DESCRIPTION
The only issue is that we need to force-install tensorflow 1.14.0 because with tensorflow 1.15.3 pylint gives module import errors. It looks like this https://github.com/PyCQA/pylint/issues/2603