### PR TITLE
Fix link to Linux Guide

### DIFF
--- a/build-instruction.md
+++ b/build-instruction.md
@@ -679,7 +679,7 @@ or Intel® Neural Compute Stick 2.
 Congratulations, you have built the Inference Engine. To get started with the
 OpenVINO™, proceed to the Get Started guides:
 
-* [Get Started with Deep Learning Deployment Toolkit on Linux*](../get-started-linux.md)
+* [Get Started with Deep Learning Deployment Toolkit on Linux*](get-started-linux.md)
 
 ## Notice
 


### PR DESCRIPTION
Fix hyperlink, previously was broken (at least on the 2020 branch)