### PR TITLE
[IE CLDNN] Enable int8 activation for fsv16 format

### DIFF
--- a/inference-engine/thirdparty/clDNN/src/gpu/activation_gpu.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/activation_gpu.cpp
@@ -103,6 +103,8 @@ attach_activation_gpu::attach_activation_gpu() {
         // block f16 format
         {std::make_tuple(engine_types::ocl, data_types::f16, format::b_fs_yx_fsv16), val_fw},
         {std::make_tuple(engine_types::ocl, data_types::f32, format::b_fs_yx_fsv16), val_fw},
+        {std::make_tuple(engine_types::ocl, data_types::i8, format::b_fs_yx_fsv16), val_fw},
+        {std::make_tuple(engine_types::ocl, data_types::u8, format::b_fs_yx_fsv16), val_fw},
         // 3D
         {std::make_tuple(engine_types::ocl, data_types::f32, format::bfzyx), val_fw},
         {std::make_tuple(engine_types::ocl, data_types::f16, format::bfzyx), val_fw},


### PR DESCRIPTION
This change enables int8/uint8 standalone activation to use optimized
block format (b_fs_yx_fsv16). This should eliminate cases where such
activation had reorders before and after.

Support for this is already provided by activation_kernel_ref implementation.

Related JIRA: CVS-28494