### PR TITLE
unicode firmware support

### DIFF
--- a/inference-engine/tests/functional/plugin/myriad/unicode_firmware_location.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/unicode_firmware_location.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //
+#if defined(ENABLE_UNICODE_PATH_SUPPORT) || defined(_WIN32)
 
 #include "functional_test_utils/skip_tests_config.hpp"
 #include "functional_test_utils/layer_test_utils.hpp"
@@ -211,3 +212,5 @@ const auto basicCases = ::testing::Combine(
 INSTANTIATE_TEST_CASE_P(Environment, UnicodeLocationTest, basicCases);
 
 INSTANTIATE_TEST_CASE_P(Environment, UnicodeLocationTestUnexistent, basicCases);
+
+#endif

--- a/inference-engine/tests/functional/plugin/myriad/unicode_firmware_location.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/unicode_firmware_location.cpp
@@ -1,0 +1,213 @@
+// Copyright (C) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "functional_test_utils/skip_tests_config.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+
+#include "ie_core.hpp"
+#include "ie_precision.hpp"
+#include "file_utils.h"
+#include "details/os/os_filesystem.hpp"
+
+#include "common_test_utils/unicode_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+
+#include <gtest/gtest.h>
+#include <stdlib.h>
+#ifndef _WIN32
+#include <dirent.h>
+#endif
+
+using activationParams = std::tuple<std::wstring, InferenceEngine::SizeVector>;
+
+namespace {
+
+const wchar_t pathSeparator =
+#ifdef _WIN32
+    L'\\';
+#else
+    L'/';
+#endif
+
+std::vector<std::wstring> listFiles(const std::wstring& path, const std::wstring& extension) {
+    std::vector<std::wstring> result;
+#ifdef _WIN32
+    HANDLE hFind = INVALID_HANDLE_VALUE;
+    WIN32_FIND_DATAW ffd;
+    hFind = FindFirstFileW((path + L"\\*." + extension).c_str(), &ffd);
+
+    if (INVALID_HANDLE_VALUE == hFind)
+        return result;
+
+    do {
+        result.push_back(ffd.cFileName);
+    } while (FindNextFileW(hFind, &ffd) != 0);
+#else
+    DIR* dir = nullptr;
+    dirent* ent = nullptr;
+
+    if ((dir = opendir(InferenceEngine::details::wStringtoMBCSstringChar(path).c_str())) != nullptr) {
+        while ((ent = readdir(dir)) != nullptr) {
+            const auto wname = InferenceEngine::details::multiByteCharToWString(ent->d_name);
+            if (wname.rfind(extension) == wname.size() - extension.size()) // not the efficient one, but ok for tests
+                result.push_back(wname);
+        }
+        closedir(dir);
+    }
+#endif
+    return result;
+}
+
+std::vector<std::wstring> getAllFirmwareNames(const std::wstring& path) {
+    auto result = listFiles(path, L"mvcmd");
+#ifdef _WIN32
+    const auto elfFiles = listFiles(path, L"elf");
+    result.insert(result.end(), elfFiles.begin(), elfFiles.end());
+#endif
+    return result;
+}
+
+bool unicodeSetEnv(const std::wstring& key, const std::wstring& value) {
+#ifdef _WIN32
+    return SetEnvironmentVariableW(key.c_str(), value.c_str());
+#else
+    return 0 == setenv(InferenceEngine::details::wStringtoMBCSstringChar(key).c_str(), InferenceEngine::details::wStringtoMBCSstringChar(value).c_str(), 1);
+#endif
+}
+
+} // namespace
+
+class TemporaryFirmwareDir {
+    std::wstring m_tempDirPath;
+    std::vector<std::wstring> m_filenames;
+
+public:
+    TemporaryFirmwareDir(const std::wstring& tempDirPath,
+                         const std::wstring& sourceDir,
+                         const std::vector<std::wstring>& filenames)
+        : m_tempDirPath(tempDirPath), m_filenames(filenames) {
+        #ifdef _WIN32
+            _wmkdir(m_tempDirPath.c_str());
+        #else
+            mkdir(InferenceEngine::details::wStringtoMBCSstringChar(m_tempDirPath).c_str(), 0755);
+        #endif
+
+        for (const auto& filename : m_filenames) {
+            CommonTestUtils::copyFile(sourceDir + pathSeparator + filename, m_tempDirPath + pathSeparator + filename);
+        }
+    }
+
+    ~TemporaryFirmwareDir() {
+#ifdef _WIN32
+        for (const auto& filename : m_filenames) {
+            _wunlink((m_tempDirPath + pathSeparator + filename).c_str());
+        }
+        _wrmdir(m_tempDirPath.c_str());
+#else
+        for (const auto& filename : m_filenames) {
+            unlink(InferenceEngine::details::wStringtoMBCSstringChar(m_tempDirPath + pathSeparator + filename).c_str());
+        }
+        rmdir(InferenceEngine::details::wStringtoMBCSstringChar(m_tempDirPath).c_str());
+#endif
+    }
+};
+
+class UnicodeLocationTest
+        : public LayerTestsUtils::LayerTestsCommonDeprecated<activationParams> {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<activationParams> &obj);
+
+protected:
+    InferenceEngine::SizeVector inputShapes;
+    std::unique_ptr<TemporaryFirmwareDir> tempDir;
+
+    virtual void envSetup() {
+        const std::wstring testSubdir = std::get<0>(GetParam());
+        const std::wstring libPath = InferenceEngine::getIELibraryPathW();
+        const std::wstring tempPath = libPath + pathSeparator + testSubdir;
+        tempDir.reset(new TemporaryFirmwareDir(tempPath, libPath, getAllFirmwareNames(libPath)));
+        unicodeSetEnv(L"IE_VPU_FIRMWARE_DIR", tempPath);
+    }
+
+    void SetUp() override {
+        envSetup();
+
+        inputPrecision = InferenceEngine::Precision::FP32;
+        netPrecision = InferenceEngine::Precision::FP32;
+        inputShapes = std::get<1>(GetParam());
+        targetDevice = CommonTestUtils::DEVICE_MYRIAD;
+
+        const auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+        const auto params = ngraph::builder::makeParams(ngPrc, {inputShapes});
+        const auto activation = ngraph::builder::makeActivation(params[0], ngPrc, ngraph::helpers::Tanh);
+        fnPtr = std::make_shared<ngraph::Function>(ngraph::NodeVector{activation}, params);
+    }
+};
+class UnicodeLocationTestUnexistent : public UnicodeLocationTest {
+    void envSetup() override {
+        const std::wstring testSubdir = std::get<0>(GetParam());
+        const std::wstring tempPath = std::wstring(L"unexistent_path") + pathSeparator + testSubdir;
+        unicodeSetEnv(L"IE_VPU_FIRMWARE_DIR", tempPath);
+    }
+};
+
+
+TEST_P(UnicodeLocationTest, Basic) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+    InferenceEngine::CNNNetwork cnnNet(fnPtr);
+    setNetInOutPrecision(cnnNet, inputPrecision);
+    const std::string inputName = cnnNet.getInputsInfo().begin()->first;
+    const std::string outputName = cnnNet.getOutputsInfo().begin()->first;
+    const auto ie = PluginCache::get().ie();
+    auto execNet = ie->LoadNetwork(cnnNet, targetDevice);
+    const auto a = execNet.GetInputsInfo();
+    auto req = execNet.CreateInferRequest();
+
+    const uint32_t data_range = 20;
+    const int32_t data_start_from = -10;
+
+    InferenceEngine::Blob::Ptr inBlob = FuncTestUtils::createAndFillBlob({inputPrecision,
+                                                                          inputShapes,
+                                                                          InferenceEngine::TensorDesc::getLayoutByDims(
+                                                                          inputShapes)},
+                                                                         data_range,
+                                                                         data_start_from,
+                                                                         32768);
+    req.SetBlob(inputName, inBlob);
+    req.Infer();
+    const auto outBlob = req.GetBlob(outputName);
+    std::vector<const float *> inRawData;
+    InferenceEngine::Blob::Ptr castedBlob = inBlob;
+    inRawData.push_back(castedBlob->cbuffer().as<float *>());
+
+    const auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+    convertFuncToF32(fnPtr, netPrecision);
+    const auto refOutData = ngraph::helpers::inferFnWithInterp<ngraph::element::Type_t::f32>(fnPtr, inRawData);
+    const auto thr = FuncTestUtils::GetComparisonThreshold(InferenceEngine::Precision::FP16);
+    const size_t outElementsCount = std::accumulate(begin(fnPtr->get_output_shape(0)), end(fnPtr->get_output_shape(0)), 1,
+                                              std::multiplies<size_t>());
+    FuncTestUtils::compareRawBuffers(outBlob->cbuffer().as<float *>(), *refOutData[0], outElementsCount,
+                                     outElementsCount,
+                                     thr);
+    fnPtr.reset();
+}
+
+TEST_P(UnicodeLocationTestUnexistent, Basic) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+    InferenceEngine::CNNNetwork cnnNet(fnPtr);
+    setNetInOutPrecision(cnnNet, inputPrecision);
+    const auto ie = PluginCache::get().ie();
+
+    ASSERT_THROW(ie->LoadNetwork(cnnNet, targetDevice),
+                 InferenceEngine::details::InferenceEngineException);
+}
+
+const auto basicCases = ::testing::Combine(
+    ::testing::ValuesIn(CommonTestUtils::test_unicode_postfix_vector),
+    ::testing::Values(std::vector<size_t>({1, 50})));
+
+INSTANTIATE_TEST_CASE_P(Environment, UnicodeLocationTest, basicCases);
+
+INSTANTIATE_TEST_CASE_P(Environment, UnicodeLocationTestUnexistent, basicCases);

--- a/inference-engine/tests/ie_test_utils/common_test_utils/unicode_utils.hpp
+++ b/inference-engine/tests/ie_test_utils/common_test_utils/unicode_utils.hpp
@@ -74,14 +74,14 @@ static void removeFile(std::wstring path) {
 }
 
 static const std::vector<std::wstring> test_unicode_postfix_vector = {
-        L"unicode_Яㅎあ",
-        L"ひらがな日本語",
-        L"大家有天分",
-        L"עפצקרשתםןףץ",
-        L"ث خ ذ ض ظ غ",
-        L"그것이정당하다",
-        L"АБВГДЕЁЖЗИЙ",
-        L"СТУФХЦЧШЩЬЮЯ"
+        InferenceEngine::details::multiByteCharToWString("unicode_Яㅎあ"),
+        InferenceEngine::details::multiByteCharToWString("ひらがな日本語"),
+        InferenceEngine::details::multiByteCharToWString("大家有天分"),
+        InferenceEngine::details::multiByteCharToWString("עפצקרשתםןףץ"),
+        InferenceEngine::details::multiByteCharToWString("ث خ ذ ض ظ غ"),
+        InferenceEngine::details::multiByteCharToWString("그것이정당하다"),
+        InferenceEngine::details::multiByteCharToWString("АБВГДЕЁЖЗИЙ"),
+        InferenceEngine::details::multiByteCharToWString("СТУФХЦЧШЩЬЮЯ")
 };
 
 }  // namespace CommonTestUtils

--- a/inference-engine/tests_deprecated/behavior/vpu/myriad_tests/aot_behavior_tests.cpp
+++ b/inference-engine/tests_deprecated/behavior/vpu/myriad_tests/aot_behavior_tests.cpp
@@ -133,12 +133,8 @@ class AOTBehaviorTests : public BehaviorPluginTest {
         ncStatus_t statusOpen = NC_ERROR;
         std::cout << "Opening device" << std::endl;
 
-#ifdef  _WIN32
-        const char* pathToFw = nullptr;
-#else
-        std::string absPathToFw = getIELibraryPath();
-        const char* pathToFw = absPathToFw.c_str();
-#endif //  _WIN32
+        const std::string absPathToFw = getIELibraryPath();
+
         ncDeviceDescr_t deviceDesc = {};
         deviceDesc.protocol = NC_ANY_PROTOCOL;
         deviceDesc.platform = NC_ANY_PLATFORM;
@@ -146,7 +142,7 @@ class AOTBehaviorTests : public BehaviorPluginTest {
         ncDeviceOpenParams_t deviceOpenParams = {};
         deviceOpenParams.watchdogHndl = m_watchdogHndl;
         deviceOpenParams.watchdogInterval = 1000;
-        deviceOpenParams.customFirmwareDirectory = pathToFw;
+        deviceOpenParams.customFirmwareDirectory = absPathToFw.c_str();
 
         statusOpen = ncDeviceOpen(&device, deviceDesc, deviceOpenParams);
 

--- a/inference-engine/tests_deprecated/behavior/vpu/myriad_tests/vpu_watchdog_tests.cpp
+++ b/inference-engine/tests_deprecated/behavior/vpu/myriad_tests/vpu_watchdog_tests.cpp
@@ -73,12 +73,8 @@ class MYRIADWatchdog :  public BehaviorPluginTest,
     void bootOneDevice(int watchdogInterval, void* ptr_in_dll) {
         ncStatus_t statusOpen = NC_ERROR;
         std::cout << "Opening device" << std::endl;
-#ifdef  _WIN32
-        const char* pathToFw = nullptr;
-#else
-        std::string absPathToFw = getIELibraryPath();
-        const char* pathToFw = absPathToFw.c_str();
-#endif //  _WIN32
+
+        const std::string absPathToFw = getIELibraryPath();
 
         ncDeviceDescr_t deviceDesc = {};
         deviceDesc.protocol = NC_ANY_PROTOCOL;
@@ -87,7 +83,7 @@ class MYRIADWatchdog :  public BehaviorPluginTest,
         ncDeviceOpenParams_t deviceOpenParams = {};
         deviceOpenParams.watchdogHndl = m_watchdogHndl;
         deviceOpenParams.watchdogInterval = watchdogInterval;
-        deviceOpenParams.customFirmwareDirectory = pathToFw;
+        deviceOpenParams.customFirmwareDirectory = absPathToFw.c_str();
 
         statusOpen = ncDeviceOpen(&device, deviceDesc, deviceOpenParams);
 

--- a/inference-engine/thirdparty/movidius/XLink/XLink.cmake
+++ b/inference-engine/thirdparty/movidius/XLink/XLink.cmake
@@ -11,8 +11,8 @@ set(XLINK_INCLUDE
 set(XLINK_PRIVATE_INCLUDE)
 
 file(GLOB PC_SRC             "${XLINK_ROOT_DIR}/pc/*.c")
-file(GLOB PC_PROTO_SRC       "${XLINK_ROOT_DIR}/pc/protocols/*.c")
-file(GLOB_RECURSE SHARED_SRC "${XLINK_ROOT_DIR}/shared/*.c")
+file(GLOB PC_PROTO_SRC       "${XLINK_ROOT_DIR}/pc/protocols/*.c" "${XLINK_ROOT_DIR}/pc/protocols/*.h")
+file(GLOB_RECURSE SHARED_SRC "${XLINK_ROOT_DIR}/shared/*.c" "${XLINK_ROOT_DIR}/shared/*.h")
 
 list(APPEND XLINK_SOURCES ${PC_SRC} ${PC_PROTO_SRC} ${SHARED_SRC})
 
@@ -20,7 +20,7 @@ if(WIN32)
     set(XLINK_PLATFORM_INCLUDE
             ${XLINK_ROOT_DIR}/pc/Win/include)
 
-    file(GLOB XLINK_PLATFORM_SRC "${XLINK_ROOT_DIR}/pc/Win/src/*.c")
+    file(GLOB XLINK_PLATFORM_SRC "${XLINK_ROOT_DIR}/pc/Win/src/*.c" "${XLINK_ROOT_DIR}/pc/Win/include/*.h")
     list(APPEND XLINK_SOURCES ${XLINK_PLATFORM_SRC})
 else()
     find_package(Threads REQUIRED)

--- a/inference-engine/thirdparty/movidius/XLink/pc/PlatformDeviceControl.c
+++ b/inference-engine/thirdparty/movidius/XLink/pc/PlatformDeviceControl.c
@@ -8,6 +8,7 @@
 #include "XLinkPlatformErrorUtils.h"
 #include "usb_boot.h"
 #include "pcie_host.h"
+#include "XLinkFileUtils.h"
 #include "XLinkStringUtils.h"
 
 #define MVLOG_UNIT_NAME PlatformDeviceControl
@@ -92,7 +93,7 @@ void XLinkPlatformInit()
 #endif
 }
 
-int XLinkPlatformBootRemote(deviceDesc_t* deviceDesc, const char* binaryPath)
+int XLinkPlatformBootRemote(deviceDesc_t* deviceDesc, const char* binaryPathUtf8)
 {
     int rc = 0;
     FILE *file;
@@ -101,11 +102,11 @@ int XLinkPlatformBootRemote(deviceDesc_t* deviceDesc, const char* binaryPath)
     void *image_buffer;
 
     /* Open the mvcmd file */
-    file = fopen(binaryPath, "rb");
+    file = utf8_fopen(binaryPathUtf8, "rb");
 
     if(file == NULL) {
         if(usb_loglevel)
-            perror(binaryPath);
+            perror(binaryPathUtf8);
         return -7;
     }
 
@@ -122,7 +123,7 @@ int XLinkPlatformBootRemote(deviceDesc_t* deviceDesc, const char* binaryPath)
     if(fread(image_buffer, 1, file_size, file) != file_size)
     {
         if(usb_loglevel)
-            perror(binaryPath);
+            perror(binaryPathUtf8);
         fclose(file);
         free(image_buffer);
         return -7;

--- a/inference-engine/thirdparty/movidius/XLink/shared/include/XLinkFileUtils.h
+++ b/inference-engine/thirdparty/movidius/XLink/shared/include/XLinkFileUtils.h
@@ -1,0 +1,37 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#ifndef _XLINK_FILE_UTILS_H
+#define _XLINK_FILE_UTILS_H
+
+#include <stddef.h>
+#include <stdio.h>
+
+#ifdef _WIN32
+#include <wchar.h>
+#else
+#include <unistd.h>
+#include <fcntl.h>
+#endif
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+FILE* utf8_fopen(const char* filename, const char* mode);
+int utf8_open(const char* filename, int flag, int mode);
+int utf8_access(const char* filename, int mode);
+
+/// Returns 1 on success, 0 on failure.
+int utf8_getenv_s(size_t bufferSize, char* buffer, const char* varName);
+
+/// Returns 1 on success, 0 on failure.
+int utf8_shared_lib_path(size_t bufferSize, char* buffer);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //_XLINK_FILE_UTILS_H

--- a/inference-engine/thirdparty/movidius/XLink/shared/include/XLinkPlatform.h
+++ b/inference-engine/thirdparty/movidius/XLink/shared/include/XLinkPlatform.h
@@ -50,7 +50,7 @@ xLinkPlatformErrorCode_t XLinkPlatformFindArrayOfDevicesNames(
     const unsigned int devicesArraySize,
     unsigned int *out_amountOfFoundDevices);
 
-int XLinkPlatformBootRemote(deviceDesc_t* deviceDesc, const char* binaryPath);
+int XLinkPlatformBootRemote(deviceDesc_t* deviceDesc, const char* binaryPathUtf8);
 int XLinkPlatformConnect(const char* devPathRead, const char* devPathWrite,
                          XLinkProtocol_t protocol, void** fd);
 #endif // __PC__

--- a/inference-engine/thirdparty/movidius/XLink/shared/src/XLinkFileUtils.c
+++ b/inference-engine/thirdparty/movidius/XLink/shared/src/XLinkFileUtils.c
@@ -1,0 +1,170 @@
+// Copyright (C) 020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#include "XLinkFileUtils.h"
+#include "XLinkStringUtils.h"
+
+#include <string.h>
+
+#ifdef _WIN32
+#include <Windows.h>
+#else
+#define __USE_GNU
+#include <dlfcn.h>      // For dladdr
+#include <stdlib.h>
+#endif
+
+#ifdef _WIN32
+static int convertCharToWide(const char* const str, wchar_t** dest)
+{
+    const int srcLen = MultiByteToWideChar( CP_UTF8 , 0 , str , -1, NULL , 0 ) + 1;
+    *dest = NULL;
+    wchar_t* tempDest = (wchar_t *)malloc(srcLen * sizeof(wchar_t));
+    if (!tempDest)
+        return 0;
+
+    if (!MultiByteToWideChar(CP_UTF8, 0, str, -1, tempDest, srcLen)) {
+        free(tempDest);
+        return 0;
+    }
+    *dest = tempDest;
+    return 1;
+}
+
+static int convertWideToChar(const wchar_t* const str, char* dest, int destSize)
+{
+    const int srcLen = (int)wcslen(str) + 1;
+    if (!WideCharToMultiByte(CP_UTF8, 0, str, srcLen, dest, destSize, NULL, NULL))
+        return 0;
+
+    return 1;
+}
+#endif
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+FILE* utf8_fopen(const char* filename, const char* mode)
+{
+#ifdef _WIN32
+    wchar_t *wfilename = NULL, *wmode = NULL;
+    if (!convertCharToWide(filename, &wfilename))
+        return NULL;
+    if (!convertCharToWide(mode, &wmode)) {
+        free(wfilename);
+        return NULL;
+    }
+    FILE* res = _wfopen(wfilename, wmode);
+    free(wfilename);
+    free(wmode);
+    return res;
+#else
+    return fopen(filename, mode);
+#endif
+}
+
+int utf8_open(const char* filename, int flag, int mode)
+{
+#ifdef _WIN32
+    wchar_t* wfilename = NULL;
+    if (!convertCharToWide(filename, &wfilename))
+        return -1;
+
+    int res = _wopen(wfilename, flag, mode);
+    free(wfilename);
+    return res;
+#else
+    return open(filename, flag, mode);
+#endif
+}
+
+int utf8_access(const char* filename, int mode)
+{
+#ifdef _WIN32
+    wchar_t* wfilename = NULL;
+    if (!convertCharToWide(filename, &wfilename))
+        return -1;
+
+    int res = _waccess(wfilename, mode);
+    free(wfilename);
+    return res;
+#else
+    return access(filename, mode);
+#endif
+}
+
+int utf8_getenv_s(size_t bufferSize, char* buffer, const char* varName)
+{
+#ifdef _WIN32
+    wchar_t* wvarName = NULL;
+    if (!convertCharToWide(varName, &wvarName))
+        return 0;
+
+    wchar_t* wbuffer = (wchar_t *)malloc(bufferSize * sizeof(wchar_t));
+    if (!wbuffer) {
+        free(wvarName);
+        return 0;
+    }
+
+    size_t returnValue = 0;
+    int res = _wgetenv_s(&returnValue, wbuffer, bufferSize, wvarName);
+    free(wvarName);
+    if (returnValue == 0) // returnValue == 0 means "variable not found"
+        res = 1;
+
+    if (res == 0) {
+        if (!convertWideToChar(wbuffer, buffer, (int)bufferSize))
+            res = 1;
+    }
+    free(wbuffer);
+    return res == 0;
+#else
+    char* value = getenv(varName);
+    if (!value)
+        return 0;
+
+    const size_t len = strlen(value);
+    if (mv_strncpy(buffer, bufferSize, value, len + 1) != 0)
+        return 0;
+
+    return 1;
+#endif
+}
+
+int utf8_shared_lib_path(size_t bufferSize, char* buffer)
+{
+#ifdef _WIN32
+    HMODULE hm = NULL;
+    if (!GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                            GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                            L"utf8_getenv_s", &hm)) {
+        return 0;
+    }
+    wchar_t* wbuffer = (wchar_t *)malloc(bufferSize * sizeof(wchar_t));
+    if (!wbuffer) {
+        return 0;
+    }
+    if (!GetModuleFileNameW(hm, wbuffer, (DWORD)bufferSize - 1)) {
+        free(wbuffer);
+        return 0;
+    }
+    int res = convertWideToChar(wbuffer, buffer, (int)bufferSize);
+    free(wbuffer);
+
+    return res;
+#else
+    Dl_info info;
+    dladdr((void*)&utf8_getenv_s, &info);
+    int rc = mv_strncpy(buffer, bufferSize, info.dli_fname, bufferSize - 1);
+    if (rc != 0) {
+        return 0;
+    }
+    return 1;
+#endif
+}
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/inference-engine/thirdparty/movidius/mvnc/include/mvnc.h
+++ b/inference-engine/thirdparty/movidius/mvnc/include/mvnc.h
@@ -205,7 +205,7 @@ MVNC_EXPORT_API ncStatus_t ncSetDeviceConnectTimeout(int deviceConnectTimeoutSec
  * @brief Create handle and open any free device
  * @param in_ncDeviceDesc a set of parameters that the device must comply with
  * @param watchdogInterval Time interval to ping device in milliseconds. 0 to disable watchdog.
- * @param customFirmwareDirectory Custom path to directory with firmware.
+ * @param customFirmwareDirectory Custom path to directory with firmware (in utf-8).
  *          If NULL or empty, default path searching behavior will be used.
  */
 MVNC_EXPORT_API ncStatus_t ncDeviceOpen(struct ncDeviceHandle_t **deviceHandlePtr,

--- a/inference-engine/thirdparty/movidius/mvnc/include/mvnc_env.h
+++ b/inference-engine/thirdparty/movidius/mvnc/include/mvnc_env.h
@@ -1,0 +1,23 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#ifndef __NC_ENV_H_INCLUDED__
+#define __NC_ENV_H_INCLUDED__
+
+#include <stddef.h>
+#include "mvnc.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/// Returns 1 on success, 0 on failure.
+MVNC_EXPORT_API int utf8_getenv_s(size_t bufferSize, char* buffer, const char* varName);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // __NC_ENV_H_INCLUDED__

--- a/inference-engine/thirdparty/movidius/mvnc/include/mvnc_ext.h
+++ b/inference-engine/thirdparty/movidius/mvnc/include/mvnc_ext.h
@@ -14,7 +14,7 @@ extern "C"
 /**
  * @brief Boot device with firmware without creating handler for it
  * @param devicePlatform Platform to boot
- * @param customFirmwareDir Path to directory with firmware to load. If NULL, use default
+ * @param customFirmwareDir Path to directory with firmware to load (in utf-8). If NULL, use default
  */
 MVNC_EXPORT_API ncStatus_t ncDeviceLoadFirmware(const ncDevicePlatform_t devicePlatform, const char* customFirmwareDir);
 

--- a/inference-engine/thirdparty/movidius/tests/XLink/CMakeLists.txt
+++ b/inference-engine/thirdparty/movidius/tests/XLink/CMakeLists.txt
@@ -27,6 +27,12 @@ target_link_libraries(${TARGET_NAME}
         PRIVATE
         XLink gtest gtest_main)
 
+if(NOT WIN32)
+    target_link_libraries(${TARGET_NAME}
+            PUBLIC
+            ${CMAKE_DL_LIBS})
+endif()
+
 set_target_properties(${TARGET_NAME} PROPERTIES
         POSITION_INDEPENDENT_CODE TRUE
         COMPILE_PDB_NAME ${TARGET_NAME})


### PR DESCRIPTION
#25095

Main goal is moving to consistent form of firmware path support: default is absolute path to myriad_plugin shared library, and opt-in to environment variable (with possible unicode characters). Windows support uses UTF-16 API where possible; on other platforms we just assume UTF-8 locale is set.
