### PR TITLE
[IE Myriad] Correct destruction order in functional tests with DISABLE_PLUGIN_CACHE  env. variable

### DIFF
--- a/inference-engine/tests/ie_test_utils/functional_test_utils/layer_test_utils.cpp
+++ b/inference-engine/tests/ie_test_utils/functional_test_utils/layer_test_utils.cpp
@@ -7,7 +7,7 @@
 namespace LayerTestsUtils {
 
 LayerTestsCommon::LayerTestsCommon() {
-    core = PluginCache::get().ie(targetDevice).get();
+    core = PluginCache::get().ie(targetDevice);
 }
 
 void LayerTestsCommon::Run() {

--- a/inference-engine/tests/ie_test_utils/functional_test_utils/layer_test_utils.hpp
+++ b/inference-engine/tests/ie_test_utils/functional_test_utils/layer_test_utils.hpp
@@ -293,7 +293,7 @@ private:
 
     std::vector<InferenceEngine::Blob::Ptr> GetOutputs();
 
-    InferenceEngine::Core *core = nullptr;
+    std::shared_ptr<InferenceEngine::Core> core;
     InferenceEngine::CNNNetwork cnnNetwork;
     InferenceEngine::InferRequest inferRequest;
     RefMode refMode = RefMode::INTERPRETER;

--- a/inference-engine/tests_deprecated/functional/ie_tests/include/ie_core_adapter.hpp
+++ b/inference-engine/tests_deprecated/functional/ie_tests/include/ie_core_adapter.hpp
@@ -34,6 +34,10 @@ public:
     InferenceEngine::ExecutableNetwork ImportNetwork(std::istream& networkModel,
         const std::map<std::string, std::string>& config = {});
 
+    std::shared_ptr<InferenceEngine::Core>& ieCore() {
+        return m_ieCore;
+    }
+
 private:
     std::shared_ptr<InferenceEngine::Core> m_ieCore;
     std::string m_deviceName;

--- a/inference-engine/tests_deprecated/functional/vpu/vpu_base/vpu_layers_tests.cpp
+++ b/inference-engine/tests_deprecated/functional/vpu/vpu_base/vpu_layers_tests.cpp
@@ -53,7 +53,11 @@ void vpuLayersTests::TearDown() {
         }
     }
 
-    _vpuPluginPtr = {};
+    _exeNetwork = {};
+    _inferRequest = {};
+    _refBlob = {};
+
+    TestsCommon::TearDown();
 }
 
 bool vpuLayersTests::CheckMyriadX() {
@@ -229,7 +233,7 @@ void vpuLayersTests::makeSingleLayerNetworkImpl(const LayerParams& layerParams,
 }
 
 void vpuLayersTests::readNetwork(const std::string& model, const WeightsBlob::Ptr& modelWeights) {
-    _cnnNetwork = PluginCache::get().ie()->ReadNetwork(model, modelWeights);
+    _cnnNetwork = _vpuPluginPtr->ieCore()->ReadNetwork(model, modelWeights);
 
     ASSERT_NO_THROW(_inputsInfo = _cnnNetwork.getInputsInfo());
     ASSERT_NO_THROW(_outputsInfo = _cnnNetwork.getOutputsInfo());


### PR DESCRIPTION
#-25382
During the research, the problem was found that libusb crush - only consequence of destruction order problem.