### PR TITLE
[IE CLDNN] Add support for I64 data type in clDNN plugin

### DIFF
--- a/inference-engine/src/cldnn_engine/cldnn_engine.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_engine.cpp
@@ -149,7 +149,8 @@ auto check_inputs = [](InferenceEngine::InputsDataMap _networkInputs) {
         auto input_precision = ii.second->getTensorDesc().getPrecision();
         if (input_precision != InferenceEngine::Precision::FP16 && input_precision != InferenceEngine::Precision::I16
             && input_precision != InferenceEngine::Precision::FP32 && input_precision != InferenceEngine::Precision::U8
-            && input_precision != InferenceEngine::Precision::I32 && input_precision != InferenceEngine::Precision::BOOL) {
+            && input_precision != InferenceEngine::Precision::I32 && input_precision != InferenceEngine::Precision::I64
+            && input_precision != InferenceEngine::Precision::BOOL) {
             THROW_IE_EXCEPTION << NOT_IMPLEMENTED_str
                 << "Input image format " << input_precision << " is not supported yet...";
         }

--- a/inference-engine/src/cldnn_engine/cldnn_executable_network.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_executable_network.cpp
@@ -59,9 +59,6 @@ CLDNNExecNetwork::CLDNNExecNetwork(InferenceEngine::ICNNNetwork &network, Remote
 
     m_context = casted_context;
 
-    NetPass::ConvertPrecision(network, Precision::I64, Precision::I32);
-    NetPass::ConvertPrecision(network, Precision::U64, Precision::I32);
-
     auto graph_base = std::make_shared<CLDNNGraph>(network, m_context, m_config, 0);
     for (uint16_t n = 0; n < m_config.throughput_streams; n++) {
         auto graph = n == 0 ? graph_base : std::make_shared<CLDNNGraph>(graph_base, n);

--- a/inference-engine/src/cldnn_engine/cldnn_graph.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_graph.cpp
@@ -122,6 +122,7 @@ InferenceEngine::ICNNNetwork::Ptr CLDNNGraph::GetExecGraphInfoByPrimitivesInfo(s
             case cldnn::data_types::f32: return Precision::FP32;
             case cldnn::data_types::f16: return Precision::FP16;
             case cldnn::data_types::i32: return Precision::I32;
+            case cldnn::data_types::i64: return Precision::I64;
             case cldnn::data_types::u8: return Precision::U8;
             case cldnn::data_types::i8: return Precision::I8;
             default: return Precision::UNSPECIFIED;

--- a/inference-engine/src/cldnn_engine/cldnn_program.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_program.cpp
@@ -4437,11 +4437,45 @@ void Program::CreateCumSumPrimitive(cldnn::topology& topology, InferenceEngine::
         if (axesInputCreator->blobs.size() == 1) {
             auto constantBlob = axesInputCreator->blobs.begin()->second;
             auto axesPrecision = constantBlob->getTensorDesc().getPrecision();
-            if (axesPrecision == InferenceEngine::Precision::I32) {
-                auto data = constantBlob->buffer().as<int32_t*>();
-                axis = data[0];
-            } else {
-                THROW_IE_EXCEPTION << layer->name << " Incorrect CumSum axes input Precision";
+            switch (axesPrecision) {
+                case InferenceEngine::Precision::U8: {
+                    auto data = constantBlob->buffer().as<uint8_t*>();
+                    axis = static_cast<int32_t>(data[0]);
+                    break;
+                }
+                case InferenceEngine::Precision::I8: {
+                    auto data = constantBlob->buffer().as<int8_t*>();
+                    axis = static_cast<int32_t>(data[0]);
+                    break;
+                }
+                case InferenceEngine::Precision::U16: {
+                    auto data = constantBlob->buffer().as<uint16_t*>();
+                    axis = static_cast<int32_t>(data[0]);
+                    break;
+                }
+                case InferenceEngine::Precision::I16: {
+                    auto data = constantBlob->buffer().as<int16_t*>();
+                    axis = static_cast<int32_t>(data[0]);
+                    break;
+                }
+                case InferenceEngine::Precision::I32: {
+                    auto data = constantBlob->buffer().as<int32_t*>();
+                    axis = data[0];
+                    break;
+                }
+                case InferenceEngine::Precision::U64: {
+                    auto data = constantBlob->buffer().as<uint64_t*>();
+                    axis = static_cast<int32_t>(data[0]);
+                    break;
+                }
+                case InferenceEngine::Precision::I64: {
+                    auto data = constantBlob->buffer().as<int64_t*>();
+                    axis = static_cast<int32_t>(data[0]);
+                    break;
+                }
+                default: {
+                    THROW_IE_EXCEPTION << layer->name << " Incorrect CumSum axes input Precision";
+                }
             }
         }
     }

--- a/inference-engine/src/cldnn_engine/cldnn_program.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_program.cpp
@@ -4473,9 +4473,8 @@ void Program::CreateCumSumPrimitive(cldnn::topology& topology, InferenceEngine::
                     axis = static_cast<int32_t>(data[0]);
                     break;
                 }
-                default: {
+                default:
                     THROW_IE_EXCEPTION << layer->name << " Incorrect CumSum axes input Precision";
-                }
             }
         }
     }

--- a/inference-engine/src/cldnn_engine/cldnn_program.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_program.cpp
@@ -3218,6 +3218,10 @@ void Program::CreateTopKPrimitive(cldnn::topology& topology, InferenceEngine::CN
             auto data = constantBlob->buffer().as<int32_t*>();
             for (size_t i = 0; i < constantBlob->size(); ++i)
                 topk.push_back(data[i]);
+        } else if (axesPrecision == InferenceEngine::Precision::I64) {
+            auto data = constantBlob->buffer().as<int64_t*>();
+            for (size_t i = 0; i < constantBlob->size(); ++i)
+                topk.push_back(static_cast<int32_t>(data[i]));
         } else {
             THROW_IE_EXCEPTION << layer->name << " Incorrect TopK input Precision";
         }

--- a/inference-engine/src/cldnn_engine/cldnn_program.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_program.cpp
@@ -4247,7 +4247,7 @@ void Program::CreateNonMaxSuppressionPrimitive(cldnn::topology& topology, Infere
     std::vector<cldnn::primitive_id> reorderedInputs;
     reorderedInputs.resize(inputPrimitives.size());
 
-    for (size_t portIndex=0; portIndex<inputPrimitives.size(); portIndex++) {
+    for (size_t portIndex = 0; portIndex < inputPrimitives.size(); portIndex++) {
         auto inputDataType = DataTypeFromPrecision(layer->insData[portIndex].lock()->getPrecision());
         if ((portIndex == 2) && (inputDataType == cldnn::data_types::i64)) {
             // clDNN primitive supports only i32 data type for 'max_output_boxes_per_class' input
@@ -4587,7 +4587,7 @@ void Program::CreateEmbeddingBagPackedSumPrimitive(cldnn::topology& topology, In
     std::vector<cldnn::primitive_id> reorderedInputs;
     reorderedInputs.resize(inputPrimitives.size());
 
-    for (size_t portIndex=0; portIndex<inputPrimitives.size(); portIndex++) {
+    for (size_t portIndex = 0; portIndex < inputPrimitives.size(); portIndex++) {
         auto inputDataType = DataTypeFromPrecision(layer->insData[portIndex].lock()->getPrecision());
         if ((portIndex == 1) && (inputDataType == cldnn::data_types::i64)) {
             // clDNN primitive supports only i32 data type for indices input,
@@ -4646,7 +4646,7 @@ void Program::CreateEmbeddingBagOffsetsSumPrimitive(cldnn::topology& topology, I
     std::vector<cldnn::primitive_id> reorderedInputs;
     reorderedInputs.resize(inputPrimitives.size());
 
-    for (size_t portIndex=0; portIndex<inputPrimitives.size(); portIndex++) {
+    for (size_t portIndex = 0; portIndex < inputPrimitives.size(); portIndex++) {
         auto inputDataType = DataTypeFromPrecision(layer->insData[portIndex].lock()->getPrecision());
         if (((portIndex == 1) || (portIndex == 2)) && (inputDataType == cldnn::data_types::i64)) {
             // clDNN primitive supports only i32 data type for indices inputs,
@@ -4709,7 +4709,7 @@ void Program::CreateEmbeddingSegmentsSumPrimitive(cldnn::topology& topology, Inf
     std::vector<cldnn::primitive_id> reorderedInputs;
     reorderedInputs.resize(inputPrimitives.size());
 
-    for (size_t portIndex=0; portIndex<inputPrimitives.size(); portIndex++) {
+    for (size_t portIndex = 0; portIndex < inputPrimitives.size(); portIndex++) {
         auto inputDataType = DataTypeFromPrecision(layer->insData[portIndex].lock()->getPrecision());
         if (((portIndex == 1) || (portIndex == 2)) && (inputDataType == cldnn::data_types::i64)) {
             // clDNN primitive supports only i32 data type for indices inputs,

--- a/inference-engine/src/cldnn_engine/cldnn_program.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_program.cpp
@@ -4067,6 +4067,10 @@ void Program::CreateReducePrimitive(cldnn::topology& topology, InferenceEngine::
             auto data = constantBlob->buffer().as<int32_t*>();
             for (size_t i = 0; i < constantBlob->size(); ++i)
                 rawAxes.push_back(data[i]);
+        } else if (axesPrecision == InferenceEngine::Precision::I64) {
+            auto data = constantBlob->buffer().as<int64_t*>();
+            for (size_t i = 0; i < constantBlob->size(); ++i)
+                rawAxes.push_back(static_cast<int32_t>(data[i]));
         } else {
             THROW_IE_EXCEPTION << layer->name << " Incorrect Reduce axes input Precision";
         }

--- a/inference-engine/src/cldnn_engine/cldnn_program.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_program.cpp
@@ -1377,8 +1377,13 @@ void Program::CreateProposalPrimitive(cldnn::topology& topology, InferenceEngine
     const bool for_deformable = layer->GetParamAsBool("for_deformable", 0);
 
     if (layer->outData.size() == 2) {
+        auto mutable_precision = layer->outData[1]->getPrecision();
+        if (mutable_precision == Precision::I64) {
+            mutable_precision = Precision::I32;
+        }
+
         cldnn::layout mutableLayout = cldnn::layout(
-                DataTypeFromPrecision(layer->outData[1]->getPrecision()),
+                DataTypeFromPrecision(mutable_precision),
                 m_defaultFormat,
                 CldnnTensorFromIEDims(layer->outData[1]->getDims()));
 
@@ -3252,8 +3257,13 @@ void Program::CreateTopKPrimitive(cldnn::topology& topology, InferenceEngine::CN
     }
 
     if (layer->outData.size() == 2) {
+        auto mutable_precision = layer->outData[1]->getPrecision();
+        if (mutable_precision == Precision::I64) {
+            mutable_precision = Precision::I32;
+        }
+
         cldnn::layout mutableLayout = cldnn::layout(
-                DataTypeFromPrecision(layer->outData[1]->getPrecision()),
+                DataTypeFromPrecision(mutable_precision),
                 defaultFormatForDims(layer->outData[1]->getDims().size()),
                 CldnnTensorFromIEDims(layer->outData[1]->getDims()));
 

--- a/inference-engine/src/readers/ir_reader/ie_format_parser.cpp
+++ b/inference-engine/src/readers/ir_reader/ie_format_parser.cpp
@@ -462,7 +462,9 @@ CNNNetworkImplPtr FormatParser::Parse(pugi::xml_node& root) {
     OutputsDataMap outputsInfo;
     _network->getOutputsInfo(outputsInfo);
     for (auto outputInfo : outputsInfo) {
-        if (outputInfo.second->getPrecision() != Precision::FP32 &&
+        if (outputInfo.second->getPrecision() == Precision::I64) {
+            outputInfo.second->setPrecision(Precision::I32);
+        } else if (outputInfo.second->getPrecision() != Precision::FP32 &&
             outputInfo.second->getPrecision() != Precision::I32) {
             outputInfo.second->setPrecision(Precision::FP32);
         }

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/concat.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/concat.cpp
@@ -20,7 +20,8 @@ std::vector<std::vector<std::vector<size_t>>> inShapes = {
         {{10, 10, 10, 10}, {10, 10, 10, 10}, {10, 10, 10, 10}, {10, 10, 10, 10}, {10, 10, 10, 10}}
 };
 std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP32,
-                                                         InferenceEngine::Precision::FP16};
+                                                         InferenceEngine::Precision::FP16,
+                                                         InferenceEngine::Precision::I64};
 
 
 INSTANTIATE_TEST_CASE_P(NoReshape, ConcatLayerTest,

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/eltwise.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/eltwise.cpp
@@ -27,6 +27,7 @@ std::vector<std::vector<std::vector<size_t>>> inShapes = {
 std::vector<InferenceEngine::Precision> netPrecisions = {
         InferenceEngine::Precision::FP32,
         InferenceEngine::Precision::FP16,
+        InferenceEngine::Precision::I64,
 };
 
 std::vector<InputLayerType> secondaryInputTypes = {

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/reshape.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/reshape.cpp
@@ -11,7 +11,8 @@ using namespace LayerTestsDefinitions;
 namespace {
 const std::vector<InferenceEngine::Precision> netPrecisions = {
             InferenceEngine::Precision::FP32,
-            InferenceEngine::Precision::FP16
+            InferenceEngine::Precision::FP16,
+            InferenceEngine::Precision::I64
 };
 
 //TODO: Issue : - 28981

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/split.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/split.cpp
@@ -13,7 +13,8 @@ namespace {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
         InferenceEngine::Precision::FP32,
-        InferenceEngine::Precision::FP16
+        InferenceEngine::Precision::FP16,
+        InferenceEngine::Precision::I64
 };
 
 INSTANTIATE_TEST_CASE_P(NumSplitsCheck, SplitLayerTest,

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/strided_slice.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/strided_slice.cpp
@@ -33,6 +33,15 @@ stridedSliceParamsTuple ss_only_test_cases[] = {
         stridedSliceParamsTuple({ 2, 2, 4, 2 }, { 1, 0, 0, 0 }, { 1, 2, 4, 2 }, { 1, 1, -2, -1 },
                        {0, 1, 1, 1}, {1, 1, 1, 1},  {1, 1, 1, 1},  {1, 1, 1, 1},  {1, 1, 1, 1},
                                 InferenceEngine::Precision::FP32, CommonTestUtils::DEVICE_GPU),
+        stridedSliceParamsTuple({ 2, 2, 2, 2 }, { 0, 0, 0, 0 }, { 2, 2, 2, 2 }, { 1, 1, 1, 1 },
+                       {1, 1, 1, 1}, {1, 1, 1, 1},  {1, 1, 1, 1},  {1, 1, 1, 1},  {1, 1, 1, 1},
+                                InferenceEngine::Precision::I64, CommonTestUtils::DEVICE_GPU),
+        stridedSliceParamsTuple({ 2, 2, 2, 2 }, { 1, 1, 1, 1 }, { 2, 2, 2, 2 }, { 1, 1, 1, 1 },
+                       {0, 0, 0, 0}, {1, 1, 1, 1},  {1, 1, 1, 1},  {1, 1, 1, 1},  {1, 1, 1, 1},
+                                InferenceEngine::Precision::I64, CommonTestUtils::DEVICE_GPU),
+        stridedSliceParamsTuple({ 2, 2, 2, 2 }, { 1, 1, 1, 1 }, { 2, 2, 2, 2 }, { 1, 1, 1, 1 },
+                       {0, 0, 0, 0}, {0, 0, 0, 0},  {1, 1, 1, 1},  {1, 1, 1, 1},  {1, 1, 1, 1},
+                                InferenceEngine::Precision::I64, CommonTestUtils::DEVICE_GPU),
 };
 
 INSTANTIATE_TEST_CASE_P(

--- a/inference-engine/thirdparty/clDNN/src/gpu/strided_slice_gpu.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/strided_slice_gpu.cpp
@@ -44,15 +44,15 @@ public:
             auto& input = arg.get_dependency(i).as<data>();
             auto& mem = input.get_attached_memory();
             std::vector<int32_t> sizes;
-            if (input.get_output_layout().data_type == cldnn::data_types::i32) {
-                int32_t* data = static_cast<int32_t*>(mem.lock());
-                sizes = std::vector<int32_t>(data, data + input.get_output_layout().count());
-            } else if (input.get_output_layout().data_type == cldnn::data_types::i64) {
+            if (input.get_output_layout().data_type == cldnn::data_types::i64) {
                 int64_t* data = static_cast<int64_t*>(mem.lock());
                 std::vector<int64_t> sizes_i64 = std::vector<int64_t>(data, data + input.get_output_layout().count());
                 sizes.resize(sizes_i64.size());
                 for (size_t j = 0; j < sizes.size(); j++)
                     sizes[j] = static_cast<int32_t>(sizes_i64[j]);
+            } else {
+                int32_t* data = static_cast<int32_t*>(mem.lock());
+                sizes = std::vector<int32_t>(data, data + input.get_output_layout().count());
             }
             pad_vector_to_size(sizes, dims_num, i != 1);  // for "begin" completion used 0 value, for other - 1
             params.striding_params.push_back(sizes);

--- a/inference-engine/thirdparty/clDNN/src/graph_optimizer/add_required_reorders.cpp
+++ b/inference-engine/thirdparty/clDNN/src/graph_optimizer/add_required_reorders.cpp
@@ -63,7 +63,6 @@ void add_required_reorders::run(program_impl& p) {
     auto usr_itr = p.get_processing_order().begin();
     while (usr_itr != p.get_processing_order().end()) {
         auto& usr = *usr_itr++;
-
         if (usr->get_dependencies().size() == 0)
             continue;  // only nodes with dependencies
         if (usr->is_type<internal_primitive>() || usr->is_type<data>())
@@ -204,9 +203,8 @@ void add_required_reorders::run(program_impl& p) {
         auto dep_itr = usr->get_dependencies().begin();
         while (dep_itr != usr->get_dependencies().end()) {
             auto node = *dep_itr++;
-
-            // do not add reorder if usr primitive is a reorder already
-            if (!usr->is_type<reorder>()) {
+            // do not add a reorder if usr or node are reorders or does not belong to data_flow
+            if (!usr->is_type<reorder>() && node->is_in_data_flow()) {
                 if ((usr->get_output_layout() != node->get_output_layout())) {
                     add_reorder(p, node, usr);
                 }

--- a/inference-engine/thirdparty/clDNN/src/include/pass_manager.h
+++ b/inference-engine/thirdparty/clDNN/src/include/pass_manager.h
@@ -64,7 +64,7 @@ public:
 
 private:
     void run(program_impl& p) override;
-    void add_reorder(program_impl& p, program_node* node, program_node* usr, const layout& reorder_layout);
+    void add_reorder(program_impl& p, program_node* node, program_node* usr);
 };
 
 class add_reshape_to_primitives : public base_pass {

--- a/inference-engine/thirdparty/clDNN/src/strided_slice.cpp
+++ b/inference-engine/thirdparty/clDNN/src/strided_slice.cpp
@@ -41,15 +41,15 @@ layout strided_slice_inst::calc_output_layout(strided_slice_node const& node) {
         auto& input = node.get_dependency(i).as<data>();
         auto& mem = input.get_attached_memory();
         std::vector<int32_t> sizes;
-        if (input.get_output_layout().data_type == cldnn::data_types::i32) {
-            int32_t* data = static_cast<int32_t*>(mem.lock());
-            sizes = std::vector<int32_t>(data, data + input.get_output_layout().count());
-        } else if (input.get_output_layout().data_type == cldnn::data_types::i64) {
+        if (input.get_output_layout().data_type == cldnn::data_types::i64) {
             int64_t* data = static_cast<int64_t*>(mem.lock());
             std::vector<int64_t> sizes_i64 = std::vector<int64_t>(data, data + input.get_output_layout().count());
             sizes.resize(sizes_i64.size());
             for (size_t j = 0; j < sizes.size(); j++)
                 sizes[j] = static_cast<int32_t>(sizes_i64[j]);
+        } else {
+            int32_t* data = static_cast<int32_t*>(mem.lock());
+            sizes = std::vector<int32_t>(data, data + input.get_output_layout().count());
         }
         pad_vector_to_size(sizes, dims_num, i != 1);  // for "begin" completion used 0 value, for other - 1
         args.push_back(sizes);

--- a/inference-engine/thirdparty/clDNN/src/strided_slice.cpp
+++ b/inference-engine/thirdparty/clDNN/src/strided_slice.cpp
@@ -40,8 +40,17 @@ layout strided_slice_inst::calc_output_layout(strided_slice_node const& node) {
     for (size_t i = 1; i < node.get_dependencies().size(); ++i) {
         auto& input = node.get_dependency(i).as<data>();
         auto& mem = input.get_attached_memory();
-        int32_t* data = static_cast<int32_t*>(mem.lock());
-        std::vector<int32_t> sizes = std::vector<int32_t>(data, data + input.get_output_layout().count());
+        std::vector<int32_t> sizes;
+        if (input.get_output_layout().data_type == cldnn::data_types::i32) {
+            int32_t* data = static_cast<int32_t*>(mem.lock());
+            sizes = std::vector<int32_t>(data, data + input.get_output_layout().count());
+        } else if (input.get_output_layout().data_type == cldnn::data_types::i64) {
+            int64_t* data = static_cast<int64_t*>(mem.lock());
+            std::vector<int64_t> sizes_i64 = std::vector<int64_t>(data, data + input.get_output_layout().count());
+            sizes.resize(sizes_i64.size());
+            for (size_t j = 0; j < sizes.size(); j++)
+                sizes[j] = static_cast<int32_t>(sizes_i64[j]);
+        }
         pad_vector_to_size(sizes, dims_num, i != 1);  // for "begin" completion used 0 value, for other - 1
         args.push_back(sizes);
         mem.unlock();

--- a/inference-engine/thirdparty/clDNN/tests/test_cases/broadcast_gpu_test.cpp
+++ b/inference-engine/thirdparty/clDNN/tests/test_cases/broadcast_gpu_test.cpp
@@ -160,6 +160,11 @@ TEST(broadcast_gpu_uint8_t, bfyx_1_to_5_w_b_axes_0) {
     start_broadcast_test<uint8_t>(data_types::u8, {5}, {1}, {0}, golden_data);
 }
 
+TEST(broadcast_gpu_int64_t, bfyx_1_to_5_w_b_axes_0) {
+    std::vector<int64_t> golden_data = {1, 1, 1, 1, 1};
+    start_broadcast_test<int64_t>(data_types::i64, {5}, {1}, {0}, golden_data);
+}
+
 TEST(broadcast_gpu_float, bfyx_1_to_4x5_w_b_axes_0x1) {
     std::vector<float> golden_data = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
                                       1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
@@ -170,6 +175,12 @@ TEST(broadcast_gpu_uint8_t, bfyx_1_to_4x5_w_b_axes_0x1) {
     std::vector<uint8_t> golden_data = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                                         1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
     start_broadcast_test<uint8_t>(data_types::u8, {4, 5}, {1}, {0, 1}, golden_data);
+}
+
+TEST(broadcast_gpu_int64_t, bfyx_1_to_4x5_w_b_axes_0x1) {
+    std::vector<int64_t> golden_data = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+    start_broadcast_test<int64_t>(data_types::i64, {4, 5}, {1}, {0, 1}, golden_data);
 }
 
 TEST(broadcast_gpu_float, bfyx_1_to_3x4x5_w_b_axes_0x1x2) {
@@ -190,6 +201,16 @@ TEST(broadcast_gpu_uint8_t, bfyx_1_to_3x4x5_w_b_axes_0x1x2) {
                                         1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                                         1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
     start_broadcast_test<uint8_t>(data_types::u8, {3, 4, 5}, {1}, {0, 1, 2}, golden_data);
+}
+
+TEST(broadcast_gpu_int64_t, bfyx_1_to_3x4x5_w_b_axes_0x1x2) {
+    std::vector<int64_t> golden_data = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+    start_broadcast_test<int64_t>(data_types::i64, {3, 4, 5}, {1}, {0, 1, 2}, golden_data);
 }
 
 TEST(broadcast_gpu_float, bfyx_1_to_2x3x4x5_w_b_axes_0x1x2x3) {
@@ -224,6 +245,22 @@ TEST(broadcast_gpu_uint8_t, bfyx_1_to_2x3x4x5_w_b_axes_0x1x2x3) {
     start_broadcast_test<uint8_t>(data_types::u8, {2, 3, 4, 5}, {1}, {0, 1, 2, 3}, golden_data);
 }
 
+TEST(broadcast_gpu_int64_t, bfyx_1_to_2x3x4x5_w_b_axes_0x1x2x3) {
+    std::vector<int64_t> golden_data = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+    start_broadcast_test<int64_t>(data_types::i64, {2, 3, 4, 5}, {1}, {0, 1, 2, 3}, golden_data);
+}
+
 TEST(broadcast_gpu_float, bfyx_1_to_5_w_o_b_axes) {
     std::vector<float> golden_data = {1.0, 1.0, 1.0, 1.0, 1.0};
     start_broadcast_test<float>(data_types::f32, {5}, {1}, {}, golden_data);
@@ -232,6 +269,11 @@ TEST(broadcast_gpu_float, bfyx_1_to_5_w_o_b_axes) {
 TEST(broadcast_gpu_uint8_t, bfyx_1_to_5_w_o_b_axes) {
     std::vector<uint8_t> golden_data = {1, 1, 1, 1, 1};
     start_broadcast_test<uint8_t>(data_types::u8, {5}, {1}, {}, golden_data);
+}
+
+TEST(broadcast_gpu_int64_t, bfyx_1_to_5_w_o_b_axes) {
+    std::vector<int64_t> golden_data = {1, 1, 1, 1, 1};
+    start_broadcast_test<int64_t>(data_types::i64, {5}, {1}, {}, golden_data);
 }
 
 TEST(broadcast_gpu_float, bfyx_3_to_12_w_o_b_axes) {
@@ -244,6 +286,11 @@ TEST(broadcast_gpu_uint8_t, bfyx_3_to_12_w_o_b_axes) {
     start_broadcast_test<uint8_t>(data_types::u8, {12}, {3}, {}, golden_data);
 }
 
+TEST(broadcast_gpu_int64_t, bfyx_3_to_12_w_o_b_axes) {
+    std::vector<int64_t> golden_data = {1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3};
+    start_broadcast_test<int64_t>(data_types::i64, {12}, {3}, {}, golden_data);
+}
+
 TEST(broadcast_gpu_float, bfyx_1x1_to_4x5_w_o_b_axes) {
     std::vector<float> golden_data = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
                                       1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
@@ -254,6 +301,12 @@ TEST(broadcast_gpu_uint8_t, bfyx_1x1_to_4x5_w_o_b_axes) {
     std::vector<uint8_t> golden_data = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                                         1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
     start_broadcast_test<uint8_t>(data_types::u8, {4, 5}, {1, 1}, {}, golden_data);
+}
+
+TEST(broadcast_gpu_int64_t, bfyx_1x1_to_4x5_w_o_b_axes) {
+    std::vector<int64_t> golden_data = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+    start_broadcast_test<int64_t>(data_types::i64, {4, 5}, {1, 1}, {}, golden_data);
 }
 
 TEST(broadcast_gpu_float, bfyx_2x3_to_8x6_w_o_b_axes) {
@@ -270,6 +323,14 @@ TEST(broadcast_gpu_uint8_t, bfyx_2x3_to_8x6_w_o_b_axes) {
                                         1, 2, 3, 1, 2, 3, 4, 5, 6, 4, 5, 6,
                                         1, 2, 3, 1, 2, 3, 4, 5, 6, 4, 5, 6};
     start_broadcast_test<uint8_t>(data_types::u8, {8, 6}, {2, 3}, {}, golden_data);
+}
+
+TEST(broadcast_gpu_int64_t, bfyx_2x3_to_8x6_w_o_b_axes) {
+    std::vector<int64_t> golden_data = {1, 2, 3, 1, 2, 3, 4, 5, 6, 4, 5, 6,
+                                        1, 2, 3, 1, 2, 3, 4, 5, 6, 4, 5, 6,
+                                        1, 2, 3, 1, 2, 3, 4, 5, 6, 4, 5, 6,
+                                        1, 2, 3, 1, 2, 3, 4, 5, 6, 4, 5, 6};
+    start_broadcast_test<int64_t>(data_types::i64, {8, 6}, {2, 3}, {}, golden_data);
 }
 
 TEST(broadcast_gpu_float, bfyx_2x3x4_to_6x6x4_w_o_b_axes) {
@@ -302,6 +363,22 @@ TEST(broadcast_gpu_uint8_t, bfyx_2x3x4_to_6x6x4_w_o_b_axes) {
                                         13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
                                         13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24};
     start_broadcast_test<uint8_t>(data_types::u8, {6, 6, 4}, {2, 3, 4}, {}, golden_data);
+}
+
+TEST(broadcast_gpu_int64_t, bfyx_2x3x4_to_6x6x4_w_o_b_axes) {
+    std::vector<int64_t> golden_data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+                                        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+                                        13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+                                        13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+                                        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+                                        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+                                        13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+                                        13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+                                        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+                                        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+                                        13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+                                        13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24};
+    start_broadcast_test<int64_t>(data_types::i64, {6, 6, 4}, {2, 3, 4}, {}, golden_data);
 }
 
 TEST(broadcast_gpu_float, bfyx_2x3x4x5_to_2x9x8x5_w_o_b_axes) {
@@ -456,6 +533,82 @@ TEST(broadcast_gpu_uint8_t, bfyx_2x3x4x5_to_2x9x8x5_w_o_b_axes) {
     start_broadcast_test<uint8_t>(data_types::u8, {2, 9, 8, 5}, {2, 3, 4, 5}, {}, golden_data);
 }
 
+TEST(broadcast_gpu_int64_t, bfyx_2x3x4x5_to_2x9x8x5_w_o_b_axes) {
+    std::vector<int64_t> golden_data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+                                        11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+                                        1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+                                        11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+                                        21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+                                        31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+                                        21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+                                        31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+                                        41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
+                                        51, 52, 53, 54, 55, 56, 57, 58, 59, 60,
+                                        41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
+                                        51, 52, 53, 54, 55, 56, 57, 58, 59, 60,
+                                        1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+                                        11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+                                        1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+                                        11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+                                        21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+                                        31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+                                        21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+                                        31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+                                        41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
+                                        51, 52, 53, 54, 55, 56, 57, 58, 59, 60,
+                                        41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
+                                        51, 52, 53, 54, 55, 56, 57, 58, 59, 60,
+                                        1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+                                        11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+                                        1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+                                        11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+                                        21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+                                        31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+                                        21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+                                        31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+                                        41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
+                                        51, 52, 53, 54, 55, 56, 57, 58, 59, 60,
+                                        41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
+                                        51, 52, 53, 54, 55, 56, 57, 58, 59, 60,
+                                        61, 62, 63, 64, 65, 66, 67, 68, 69, 70,
+                                        71, 72, 73, 74, 75, 76, 77, 78, 79, 80,
+                                        61, 62, 63, 64, 65, 66, 67, 68, 69, 70,
+                                        71, 72, 73, 74, 75, 76, 77, 78, 79, 80,
+                                        81, 82, 83, 84, 85, 86, 87, 88, 89, 90,
+                                        91, 92, 93, 94, 95, 96, 97, 98, 99, 100,
+                                        81, 82, 83, 84, 85, 86, 87, 88, 89, 90,
+                                        91, 92, 93, 94, 95, 96, 97, 98, 99, 100,
+                                        101, 102, 103, 104, 105, 106, 107, 108, 109, 110,
+                                        111, 112, 113, 114, 115, 116, 117, 118, 119, 120,
+                                        101, 102, 103, 104, 105, 106, 107, 108, 109, 110,
+                                        111, 112, 113, 114, 115, 116, 117, 118, 119, 120,
+                                        61, 62, 63, 64, 65, 66, 67, 68, 69, 70,
+                                        71, 72, 73, 74, 75, 76, 77, 78, 79, 80,
+                                        61, 62, 63, 64, 65, 66, 67, 68, 69, 70,
+                                        71, 72, 73, 74, 75, 76, 77, 78, 79, 80,
+                                        81, 82, 83, 84, 85, 86, 87, 88, 89, 90,
+                                        91, 92, 93, 94, 95, 96, 97, 98, 99, 100,
+                                        81, 82, 83, 84, 85, 86, 87, 88, 89, 90,
+                                        91, 92, 93, 94, 95, 96, 97, 98, 99, 100,
+                                        101, 102, 103, 104, 105, 106, 107, 108, 109, 110,
+                                        111, 112, 113, 114, 115, 116, 117, 118, 119, 120,
+                                        101, 102, 103, 104, 105, 106, 107, 108, 109, 110,
+                                        111, 112, 113, 114, 115, 116, 117, 118, 119, 120,
+                                        61, 62, 63, 64, 65, 66, 67, 68, 69, 70,
+                                        71, 72, 73, 74, 75, 76, 77, 78, 79, 80,
+                                        61, 62, 63, 64, 65, 66, 67, 68, 69, 70,
+                                        71, 72, 73, 74, 75, 76, 77, 78, 79, 80,
+                                        81, 82, 83, 84, 85, 86, 87, 88, 89, 90,
+                                        91, 92, 93, 94, 95, 96, 97, 98, 99, 100,
+                                        81, 82, 83, 84, 85, 86, 87, 88, 89, 90,
+                                        91, 92, 93, 94, 95, 96, 97, 98, 99, 100,
+                                        101, 102, 103, 104, 105, 106, 107, 108, 109, 110,
+                                        111, 112, 113, 114, 115, 116, 117, 118, 119, 120,
+                                        101, 102, 103, 104, 105, 106, 107, 108, 109, 110,
+                                        111, 112, 113, 114, 115, 116, 117, 118, 119, 120};
+    start_broadcast_test<int64_t>(data_types::i64, {2, 9, 8, 5}, {2, 3, 4, 5}, {}, golden_data);
+}
+
 TEST(broadcast_gpu_float, bfyx_3_to_2x3_w_b_axes_0) {
     std::vector<float> golden_data = {1.0, 2.0, 3.0, 1.0, 2.0, 3.0};
     start_broadcast_test<float>(data_types::f32, {2, 3}, {3}, {0}, golden_data);
@@ -464,6 +617,11 @@ TEST(broadcast_gpu_float, bfyx_3_to_2x3_w_b_axes_0) {
 TEST(broadcast_gpu_uint8_t, bfyx_3_to_2x3_w_b_axes_0) {
     std::vector<uint8_t> golden_data = {1, 2, 3, 1, 2, 3};
     start_broadcast_test<uint8_t>(data_types::u8, {2, 3}, {3}, {0}, golden_data);
+}
+
+TEST(broadcast_gpu_int64_t, bfyx_3_to_2x3_w_b_axes_0) {
+    std::vector<int64_t> golden_data = {1, 2, 3, 1, 2, 3};
+    start_broadcast_test<int64_t>(data_types::i64, {2, 3}, {3}, {0}, golden_data);
 }
 
 TEST(broadcast_gpu_float, bfyx_3_to_2x6_w_b_axes_0) {
@@ -476,6 +634,11 @@ TEST(broadcast_gpu_uint8_t, bfyx_3_to_2x6_w_b_axes_0) {
     start_broadcast_test<uint8_t>(data_types::u8, {2, 6}, {3}, {0}, golden_data);
 }
 
+TEST(broadcast_gpu_int64_t, bfyx_3_to_2x6_w_b_axes_0) {
+    std::vector<int64_t> golden_data = {1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3};
+    start_broadcast_test<int64_t>(data_types::i64, {2, 6}, {3}, {0}, golden_data);
+}
+
 TEST(broadcast_gpu_float, bfyx_2_to_2x3_w_b_axes_1) {
     std::vector<float> golden_data = {1.0, 1.0, 1.0, 2.0, 2.0, 2.0};
     start_broadcast_test<float>(data_types::f32, {2, 3}, {2}, {1}, golden_data);
@@ -484,6 +647,11 @@ TEST(broadcast_gpu_float, bfyx_2_to_2x3_w_b_axes_1) {
 TEST(broadcast_gpu_uint8_t, bfyx_2_to_2x3_w_b_axes_1) {
     std::vector<uint8_t> golden_data = {1, 1, 1, 2, 2, 2};
     start_broadcast_test<uint8_t>(data_types::u8, {2, 3}, {2}, {1}, golden_data);
+}
+
+TEST(broadcast_gpu_int64_t, bfyx_2_to_2x3_w_b_axes_1) {
+    std::vector<int64_t> golden_data = {1, 1, 1, 2, 2, 2};
+    start_broadcast_test<int64_t>(data_types::i64, {2, 3}, {2}, {1}, golden_data);
 }
 
 TEST(broadcast_gpu_float, bfyx_2_to_6x3_w_b_axes_1) {
@@ -498,6 +666,12 @@ TEST(broadcast_gpu_uint8_t, bfyx_2_to_6x3_w_b_axes_1) {
     start_broadcast_test<uint8_t>(data_types::u8, {6, 3}, {2}, {1}, golden_data);
 }
 
+TEST(broadcast_gpu_int64_t, bfyx_2_to_6x3_w_b_axes_1) {
+    std::vector<int64_t> golden_data = {1, 1, 1, 2, 2, 2, 1, 1, 1,
+                                        2, 2, 2, 1, 1, 1, 2, 2, 2};
+    start_broadcast_test<int64_t>(data_types::i64, {6, 3}, {2}, {1}, golden_data);
+}
+
 TEST(broadcast_gpu_float, bfyx_3x4_to_2x3x4_w_b_axes_0) {
     std::vector<float> golden_data = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
                                       1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0};
@@ -508,6 +682,12 @@ TEST(broadcast_gpu_uint8_t, bfyx_3x4_to_2x3x4_w_b_axes_0) {
     std::vector<uint8_t> golden_data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
                                         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     start_broadcast_test<uint8_t>(data_types::u8, {2, 3, 4}, {3, 4}, {0}, golden_data);
+}
+
+TEST(broadcast_gpu_int64_t, bfyx_3x4_to_2x3x4_w_b_axes_0) {
+    std::vector<int64_t> golden_data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+                                        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    start_broadcast_test<int64_t>(data_types::i64, {2, 3, 4}, {3, 4}, {0}, golden_data);
 }
 
 TEST(broadcast_gpu_float, bfyx_2x4_to_2x3x4_w_b_axes_1) {
@@ -522,6 +702,12 @@ TEST(broadcast_gpu_uint8_t, bfyx_2x4_to_2x3x4_w_b_axes_1) {
     start_broadcast_test<uint8_t>(data_types::u8, {2, 3, 4}, {2, 4}, {1}, golden_data);
 }
 
+TEST(broadcast_gpu_int64_t, bfyx_2x4_to_2x3x4_w_b_axes_1) {
+    std::vector<int64_t> golden_data = {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4,
+                                        5, 6, 7, 8, 5, 6, 7, 8, 5, 6, 7, 8};
+    start_broadcast_test<int64_t>(data_types::i64, {2, 3, 4}, {2, 4}, {1}, golden_data);
+}
+
 TEST(broadcast_gpu_float, bfyx_2x3_to_2x3x4_w_b_axes_2) {
     std::vector<float> golden_data = {1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0, 3.0,
                                       4.0, 4.0, 4.0, 4.0, 5.0, 5.0, 5.0, 5.0, 6.0, 6.0, 6.0, 6.0};
@@ -532,6 +718,12 @@ TEST(broadcast_gpu_uint8_t, bfyx_2x3_to_2x3x4_w_b_axes_2) {
     std::vector<uint8_t> golden_data = {1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3,
                                         4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6};
     start_broadcast_test<uint8_t>(data_types::u8, {2, 3, 4}, {2, 3}, {2}, golden_data);
+}
+
+TEST(broadcast_gpu_int64_t, bfyx_2x3_to_2x3x4_w_b_axes_2) {
+    std::vector<int64_t> golden_data = {1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3,
+                                        4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6};
+    start_broadcast_test<int64_t>(data_types::i64, {2, 3, 4}, {2, 3}, {2}, golden_data);
 }
 
 TEST(broadcast_gpu_float, bfyx_4_to_2x3x4_w_b_axes_0_1) {
@@ -546,6 +738,12 @@ TEST(broadcast_gpu_uint8_t, bfyx_4_to_2x3x4_w_b_axes_0_1) {
     start_broadcast_test<uint8_t>(data_types::u8, {2, 3, 4}, {4}, {0, 1}, golden_data);
 }
 
+TEST(broadcast_gpu_int64_t, bfyx_4_to_2x3x4_w_b_axes_0_1) {
+    std::vector<int64_t> golden_data = {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4,
+                                        1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4};
+    start_broadcast_test<int64_t>(data_types::i64, {2, 3, 4}, {4}, {0, 1}, golden_data);
+}
+
 TEST(broadcast_gpu_float, bfyx_3_to_2x3x4_w_b_axes_0_2) {
     std::vector<float> golden_data = {1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0, 3.0,
                                       1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0, 3.0};
@@ -558,6 +756,12 @@ TEST(broadcast_gpu_uint8_t, bfyx_3_to_2x3x4_w_b_axes_0_2) {
     start_broadcast_test<uint8_t>(data_types::u8, {2, 3, 4}, {3}, {0, 2}, golden_data);
 }
 
+TEST(broadcast_gpu_int64_t, bfyx_3_to_2x3x4_w_b_axes_0_2) {
+    std::vector<int64_t> golden_data = {1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3,
+                                        1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3};
+    start_broadcast_test<int64_t>(data_types::i64, {2, 3, 4}, {3}, {0, 2}, golden_data);
+}
+
 TEST(broadcast_gpu_float, bfyx_2_to_2x3x4_w_b_axes_1_2) {
     std::vector<float> golden_data = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
                                       2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0};
@@ -568,6 +772,12 @@ TEST(broadcast_gpu_uint8_t, bfyx_2_to_2x3x4_w_b_axes_1_2) {
     std::vector<uint8_t> golden_data = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                                         2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2};
     start_broadcast_test<uint8_t>(data_types::u8, {2, 3, 4}, {2}, {1, 2}, golden_data);
+}
+
+TEST(broadcast_gpu_int64_t, bfyx_2_to_2x3x4_w_b_axes_1_2) {
+    std::vector<int64_t> golden_data = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2};
+    start_broadcast_test<int64_t>(data_types::i64, {2, 3, 4}, {2}, {1, 2}, golden_data);
 }
 
 TEST(broadcast_gpu_float, bfyx_3x4x5_to_2x3x4x5_w_b_axes_0) {
@@ -596,6 +806,20 @@ TEST(broadcast_gpu_uint8_t, bfyx_3x4x5_to_2x3x4x5_w_b_axes_0) {
                                         37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
                                         49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60};
     start_broadcast_test<uint8_t>(data_types::u8, {2, 3, 4, 5}, {3, 4, 5}, {0}, golden_data);
+}
+
+TEST(broadcast_gpu_int64_t, bfyx_3x4x5_to_2x3x4x5_w_b_axes_0) {
+    std::vector<int64_t> golden_data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+                                        13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+                                        25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36,
+                                        37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
+                                        49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60,
+                                        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+                                        13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+                                        25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36,
+                                        37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
+                                        49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60};
+    start_broadcast_test<int64_t>(data_types::i64, {2, 3, 4, 5}, {3, 4, 5}, {0}, golden_data);
 }
 
 TEST(broadcast_gpu_float, bfyx_2x4x5_to_2x3x4x5_w_b_axes_1) {
@@ -630,6 +854,22 @@ TEST(broadcast_gpu_uint8_t, bfyx_2x4x5_to_2x3x4x5_w_b_axes_1) {
     start_broadcast_test<uint8_t>(data_types::u8, {2, 3, 4, 5}, {2, 4, 5}, {1}, golden_data);
 }
 
+TEST(broadcast_gpu_int64_t, bfyx_2x4x5_to_2x3x4x5_w_b_axes_1) {
+    std::vector<int64_t> golden_data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+                                        11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+                                        1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+                                        11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+                                        1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+                                        11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+                                        21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+                                        31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+                                        21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+                                        31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+                                        21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+                                        31, 32, 33, 34, 35, 36, 37, 38, 39, 40};
+    start_broadcast_test<int64_t>(data_types::i64, {2, 3, 4, 5}, {2, 4, 5}, {1}, golden_data);
+}
+
 TEST(broadcast_gpu_float, bfyx_2x3x5_to_2x3x4x5_w_b_axes_2) {
     std::vector<float> golden_data = {1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 2.0, 3.0, 4.0, 5.0,
                                       1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 2.0, 3.0, 4.0, 5.0,
@@ -660,6 +900,22 @@ TEST(broadcast_gpu_uint8_t, bfyx_2x3x5_to_2x3x4x5_w_b_axes_2) {
                                         26, 27, 28, 29, 30, 26, 27, 28, 29, 30,
                                         26, 27, 28, 29, 30, 26, 27, 28, 29, 30};
     start_broadcast_test<uint8_t>(data_types::u8, {2, 3, 4, 5}, {2, 3, 5}, {2}, golden_data);
+}
+
+TEST(broadcast_gpu_int64_t, bfyx_2x3x5_to_2x3x4x5_w_b_axes_2) {
+    std::vector<int64_t> golden_data = {1, 2, 3, 4, 5, 1, 2, 3, 4, 5,
+                                        1, 2, 3, 4, 5, 1, 2, 3, 4, 5,
+                                        6, 7, 8, 9, 10, 6, 7, 8, 9, 10,
+                                        6, 7, 8, 9, 10, 6, 7, 8, 9, 10,
+                                        11, 12, 13, 14, 15, 11, 12, 13, 14, 15,
+                                        11, 12, 13, 14, 15, 11, 12, 13, 14, 15,
+                                        16, 17, 18, 19, 20, 16, 17, 18, 19, 20,
+                                        16, 17, 18, 19, 20, 16, 17, 18, 19, 20,
+                                        21, 22, 23, 24, 25, 21, 22, 23, 24, 25,
+                                        21, 22, 23, 24, 25, 21, 22, 23, 24, 25,
+                                        26, 27, 28, 29, 30, 26, 27, 28, 29, 30,
+                                        26, 27, 28, 29, 30, 26, 27, 28, 29, 30};
+    start_broadcast_test<int64_t>(data_types::i64, {2, 3, 4, 5}, {2, 3, 5}, {2}, golden_data);
 }
 
 TEST(broadcast_gpu_float, bfyx_2x3x4_to_2x3x4x5_w_b_axes_3) {
@@ -694,6 +950,22 @@ TEST(broadcast_gpu_uint8_t, bfyx_2x3x4_to_2x3x4x5_w_b_axes_3) {
     start_broadcast_test<uint8_t>(data_types::u8, {2, 3, 4, 5}, {2, 3, 4}, {3}, golden_data);
 }
 
+TEST(broadcast_gpu_int64_t, bfyx_2x3x4_to_2x3x4x5_w_b_axes_3) {
+    std::vector<int64_t> golden_data = {1, 1, 1, 1, 1, 2, 2, 2, 2, 2,
+                                        3, 3, 3, 3, 3, 4, 4, 4, 4, 4,
+                                        5, 5, 5, 5, 5, 6, 6, 6, 6, 6,
+                                        7, 7, 7, 7, 7, 8, 8, 8, 8, 8,
+                                        9, 9, 9, 9, 9, 10, 10, 10, 10, 10,
+                                        11, 11, 11, 11, 11, 12, 12, 12, 12, 12,
+                                        13, 13, 13, 13, 13, 14, 14, 14, 14, 14,
+                                        15, 15, 15, 15, 15, 16, 16, 16, 16, 16,
+                                        17, 17, 17, 17, 17, 18, 18, 18, 18, 18,
+                                        19, 19, 19, 19, 19, 20, 20, 20, 20, 20,
+                                        21, 21, 21, 21, 21, 22, 22, 22, 22, 22,
+                                        23, 23, 23, 23, 23, 24, 24, 24, 24, 24};
+    start_broadcast_test<int64_t>(data_types::i64, {2, 3, 4, 5}, {2, 3, 4}, {3}, golden_data);
+}
+
 TEST(broadcast_gpu_float, bfyx_4x5_to_2x3x4x5_w_b_axes_0_1) {
     std::vector<float> golden_data = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0,
                                       11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0,
@@ -724,6 +996,22 @@ TEST(broadcast_gpu_uint8_t, bfyx_4x5_to_2x3x4x5_w_b_axes_0_1) {
                                         1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
                                         11, 12, 13, 14, 15, 16, 17, 18, 19, 20};
     start_broadcast_test<uint8_t>(data_types::u8, {2, 3, 4, 5}, {4, 5}, {0, 1}, golden_data);
+}
+
+TEST(broadcast_gpu_int64_t, bfyx_4x5_to_2x3x4x5_w_b_axes_0_1) {
+    std::vector<int64_t> golden_data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+                                        11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+                                        1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+                                        11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+                                        1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+                                        11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+                                        1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+                                        11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+                                        1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+                                        11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+                                        1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+                                        11, 12, 13, 14, 15, 16, 17, 18, 19, 20};
+    start_broadcast_test<int64_t>(data_types::i64, {2, 3, 4, 5}, {4, 5}, {0, 1}, golden_data);
 }
 
 TEST(broadcast_gpu_float, bfyx_3x5_to_2x3x4x5_w_b_axes_0_2) {
@@ -758,6 +1046,22 @@ TEST(broadcast_gpu_uint8_t, bfyx_3x5_to_2x3x4x5_w_b_axes_0_2) {
     start_broadcast_test<uint8_t>(data_types::u8, {2, 3, 4, 5}, {3, 5}, {0, 2}, golden_data);
 }
 
+TEST(broadcast_gpu_int64_t, bfyx_3x5_to_2x3x4x5_w_b_axes_0_2) {
+    std::vector<int64_t> golden_data = {1, 2, 3, 4, 5, 1, 2, 3, 4, 5,
+                                        1, 2, 3, 4, 5, 1, 2, 3, 4, 5,
+                                        6, 7, 8, 9, 10, 6, 7, 8, 9, 10,
+                                        6, 7, 8, 9, 10, 6, 7, 8, 9, 10,
+                                        11, 12, 13, 14, 15, 11, 12, 13, 14, 15,
+                                        11, 12, 13, 14, 15, 11, 12, 13, 14, 15,
+                                        1, 2, 3, 4, 5, 1, 2, 3, 4, 5,
+                                        1, 2, 3, 4, 5, 1, 2, 3, 4, 5,
+                                        6, 7, 8, 9, 10, 6, 7, 8, 9, 10,
+                                        6, 7, 8, 9, 10, 6, 7, 8, 9, 10,
+                                        11, 12, 13, 14, 15, 11, 12, 13, 14, 15,
+                                        11, 12, 13, 14, 15, 11, 12, 13, 14, 15};
+    start_broadcast_test<int64_t>(data_types::i64, {2, 3, 4, 5}, {3, 5}, {0, 2}, golden_data);
+}
+
 TEST(broadcast_gpu_float, bfyx_3x4_to_2x3x4x5_w_b_axes_0_3) {
     std::vector<float> golden_data = {1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0,
                                       3.0, 3.0, 3.0, 3.0, 3.0, 4.0, 4.0, 4.0, 4.0, 4.0,
@@ -788,6 +1092,22 @@ TEST(broadcast_gpu_uint8_t, bfyx_3x4_to_2x3x4x5_w_b_axes_0_3) {
                                         9, 9, 9, 9, 9, 10, 10, 10, 10, 10,
                                         11, 11, 11, 11, 11, 12, 12, 12, 12, 12};
     start_broadcast_test<uint8_t>(data_types::u8, {2, 3, 4, 5}, {3, 4}, {0, 3}, golden_data);
+}
+
+TEST(broadcast_gpu_int64_t, bfyx_3x4_to_2x3x4x5_w_b_axes_0_3) {
+    std::vector<int64_t> golden_data = {1, 1, 1, 1, 1, 2, 2, 2, 2, 2,
+                                        3, 3, 3, 3, 3, 4, 4, 4, 4, 4,
+                                        5, 5, 5, 5, 5, 6, 6, 6, 6, 6,
+                                        7, 7, 7, 7, 7, 8, 8, 8, 8, 8,
+                                        9, 9, 9, 9, 9, 10, 10, 10, 10, 10,
+                                        11, 11, 11, 11, 11, 12, 12, 12, 12, 12,
+                                        1, 1, 1, 1, 1, 2, 2, 2, 2, 2,
+                                        3, 3, 3, 3, 3, 4, 4, 4, 4, 4,
+                                        5, 5, 5, 5, 5, 6, 6, 6, 6, 6,
+                                        7, 7, 7, 7, 7, 8, 8, 8, 8, 8,
+                                        9, 9, 9, 9, 9, 10, 10, 10, 10, 10,
+                                        11, 11, 11, 11, 11, 12, 12, 12, 12, 12};
+    start_broadcast_test<int64_t>(data_types::i64, {2, 3, 4, 5}, {3, 4}, {0, 3}, golden_data);
 }
 
 TEST(broadcast_gpu_float, bfyx_2x5_to_2x3x4x5_w_b_axes_1_2) {
@@ -822,6 +1142,22 @@ TEST(broadcast_gpu_uint8_t, bfyx_2x5_to_2x3x4x5_w_b_axes_1_2) {
     start_broadcast_test<uint8_t>(data_types::u8, {2, 3, 4, 5}, {2, 5}, {1, 2}, golden_data);
 }
 
+TEST(broadcast_gpu_int64_t, bfyx_2x5_to_2x3x4x5_w_b_axes_1_2) {
+    std::vector<int64_t> golden_data = {1, 2, 3, 4, 5, 1, 2, 3, 4, 5,
+                                        1, 2, 3, 4, 5, 1, 2, 3, 4, 5,
+                                        1, 2, 3, 4, 5, 1, 2, 3, 4, 5,
+                                        1, 2, 3, 4, 5, 1, 2, 3, 4, 5,
+                                        1, 2, 3, 4, 5, 1, 2, 3, 4, 5,
+                                        1, 2, 3, 4, 5, 1, 2, 3, 4, 5,
+                                        6, 7, 8, 9, 10, 6, 7, 8, 9, 10,
+                                        6, 7, 8, 9, 10, 6, 7, 8, 9, 10,
+                                        6, 7, 8, 9, 10, 6, 7, 8, 9, 10,
+                                        6, 7, 8, 9, 10, 6, 7, 8, 9, 10,
+                                        6, 7, 8, 9, 10, 6, 7, 8, 9, 10,
+                                        6, 7, 8, 9, 10, 6, 7, 8, 9, 10};
+    start_broadcast_test<int64_t>(data_types::i64, {2, 3, 4, 5}, {2, 5}, {1, 2}, golden_data);
+}
+
 TEST(broadcast_gpu_float, bfyx_2x4_to_2x3x4x5_w_b_axes_1_3) {
     std::vector<float> golden_data = {1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0,
                                       3.0, 3.0, 3.0, 3.0, 3.0, 4.0, 4.0, 4.0, 4.0, 4.0,
@@ -852,6 +1188,22 @@ TEST(broadcast_gpu_uint8_t, bfyx_2x4_to_2x3x4x5_w_b_axes_1_3) {
                                         5, 5, 5, 5, 5, 6, 6, 6, 6, 6,
                                         7, 7, 7, 7, 7, 8, 8, 8, 8, 8};
     start_broadcast_test<uint8_t>(data_types::u8, {2, 3, 4, 5}, {2, 4}, {1, 3}, golden_data);
+}
+
+TEST(broadcast_gpu_int64_t, bfyx_2x4_to_2x3x4x5_w_b_axes_1_3) {
+    std::vector<int64_t> golden_data = {1, 1, 1, 1, 1, 2, 2, 2, 2, 2,
+                                        3, 3, 3, 3, 3, 4, 4, 4, 4, 4,
+                                        1, 1, 1, 1, 1, 2, 2, 2, 2, 2,
+                                        3, 3, 3, 3, 3, 4, 4, 4, 4, 4,
+                                        1, 1, 1, 1, 1, 2, 2, 2, 2, 2,
+                                        3, 3, 3, 3, 3, 4, 4, 4, 4, 4,
+                                        5, 5, 5, 5, 5, 6, 6, 6, 6, 6,
+                                        7, 7, 7, 7, 7, 8, 8, 8, 8, 8,
+                                        5, 5, 5, 5, 5, 6, 6, 6, 6, 6,
+                                        7, 7, 7, 7, 7, 8, 8, 8, 8, 8,
+                                        5, 5, 5, 5, 5, 6, 6, 6, 6, 6,
+                                        7, 7, 7, 7, 7, 8, 8, 8, 8, 8};
+    start_broadcast_test<int64_t>(data_types::i64, {2, 3, 4, 5}, {2, 4}, {1, 3}, golden_data);
 }
 
 TEST(broadcast_gpu_float, bfyx_2x3_to_2x3x4x5_w_b_axes_2_3) {
@@ -886,6 +1238,22 @@ TEST(broadcast_gpu_uint8_t, bfyx_2x3_to_2x3x4x5_w_b_axes_2_3) {
     start_broadcast_test<uint8_t>(data_types::u8, {2, 3, 4, 5}, {2, 3}, {2, 3}, golden_data);
 }
 
+TEST(broadcast_gpu_int64_t, bfyx_2x3_to_2x3x4x5_w_b_axes_2_3) {
+    std::vector<int64_t> golden_data = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                                        2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                                        3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+                                        3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+                                        4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+                                        4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+                                        5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+                                        5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+                                        6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
+                                        6, 6, 6, 6, 6, 6, 6, 6, 6, 6};
+    start_broadcast_test<int64_t>(data_types::i64, {2, 3, 4, 5}, {2, 3}, {2, 3}, golden_data);
+}
+
 TEST(broadcast_gpu_float, bfyx_5_to_2x3x4x5_w_b_axes_0_1_2) {
     std::vector<float> golden_data = {1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 2.0, 3.0, 4.0, 5.0,
                                       1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 2.0, 3.0, 4.0, 5.0,
@@ -916,6 +1284,22 @@ TEST(broadcast_gpu_uint8_t, bfyx_5_to_2x3x4x5_w_b_axes_0_1_2) {
                                         1, 2, 3, 4, 5, 1, 2, 3, 4, 5,
                                         1, 2, 3, 4, 5, 1, 2, 3, 4, 5};
     start_broadcast_test<uint8_t>(data_types::u8, {2, 3, 4, 5}, {5}, {0, 1, 2}, golden_data);
+}
+
+TEST(broadcast_gpu_int64_t, bfyx_5_to_2x3x4x5_w_b_axes_0_1_2) {
+    std::vector<int64_t> golden_data = {1, 2, 3, 4, 5, 1, 2, 3, 4, 5,
+                                        1, 2, 3, 4, 5, 1, 2, 3, 4, 5,
+                                        1, 2, 3, 4, 5, 1, 2, 3, 4, 5,
+                                        1, 2, 3, 4, 5, 1, 2, 3, 4, 5,
+                                        1, 2, 3, 4, 5, 1, 2, 3, 4, 5,
+                                        1, 2, 3, 4, 5, 1, 2, 3, 4, 5,
+                                        1, 2, 3, 4, 5, 1, 2, 3, 4, 5,
+                                        1, 2, 3, 4, 5, 1, 2, 3, 4, 5,
+                                        1, 2, 3, 4, 5, 1, 2, 3, 4, 5,
+                                        1, 2, 3, 4, 5, 1, 2, 3, 4, 5,
+                                        1, 2, 3, 4, 5, 1, 2, 3, 4, 5,
+                                        1, 2, 3, 4, 5, 1, 2, 3, 4, 5};
+    start_broadcast_test<int64_t>(data_types::i64, {2, 3, 4, 5}, {5}, {0, 1, 2}, golden_data);
 }
 
 TEST(broadcast_gpu_float, bfyx_4_to_2x3x4x5_w_b_axes_0_1_3) {
@@ -950,6 +1334,22 @@ TEST(broadcast_gpu_uint8_t, bfyx_4_to_2x3x4x5_w_b_axes_0_1_3) {
     start_broadcast_test<uint8_t>(data_types::u8, {2, 3, 4, 5}, {4}, {0, 1, 3}, golden_data);
 }
 
+TEST(broadcast_gpu_int64_t, bfyx_4_to_2x3x4x5_w_b_axes_0_1_3) {
+    std::vector<int64_t> golden_data = {1, 1, 1, 1, 1, 2, 2, 2, 2, 2,
+                                        3, 3, 3, 3, 3, 4, 4, 4, 4, 4,
+                                        1, 1, 1, 1, 1, 2, 2, 2, 2, 2,
+                                        3, 3, 3, 3, 3, 4, 4, 4, 4, 4,
+                                        1, 1, 1, 1, 1, 2, 2, 2, 2, 2,
+                                        3, 3, 3, 3, 3, 4, 4, 4, 4, 4,
+                                        1, 1, 1, 1, 1, 2, 2, 2, 2, 2,
+                                        3, 3, 3, 3, 3, 4, 4, 4, 4, 4,
+                                        1, 1, 1, 1, 1, 2, 2, 2, 2, 2,
+                                        3, 3, 3, 3, 3, 4, 4, 4, 4, 4,
+                                        1, 1, 1, 1, 1, 2, 2, 2, 2, 2,
+                                        3, 3, 3, 3, 3, 4, 4, 4, 4, 4};
+    start_broadcast_test<int64_t>(data_types::i64, {2, 3, 4, 5}, {4}, {0, 1, 3}, golden_data);
+}
+
 TEST(broadcast_gpu_float, bfyx_3_to_2x3x4x5_w_b_axes_0_2_3) {
     std::vector<float> golden_data = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
                                       1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
@@ -982,6 +1382,22 @@ TEST(broadcast_gpu_uint8_t, bfyx_3_to_2x3x4x5_w_b_axes_0_2_3) {
     start_broadcast_test<uint8_t>(data_types::u8, {2, 3, 4, 5}, {3}, {0, 2, 3}, golden_data);
 }
 
+TEST(broadcast_gpu_int64_t, bfyx_3_to_2x3x4x5_w_b_axes_0_2_3) {
+    std::vector<int64_t> golden_data = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                                        2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                                        3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+                                        3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+                                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                                        2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                                        3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+                                        3, 3, 3, 3, 3, 3, 3, 3, 3, 3};
+    start_broadcast_test<int64_t>(data_types::i64, {2, 3, 4, 5}, {3}, {0, 2, 3}, golden_data);
+}
+
 TEST(broadcast_gpu_float, bfyx_2_to_2x3x4x5_w_b_axes_1_2_3) {
     std::vector<float> golden_data = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
                                       1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
@@ -1012,6 +1428,22 @@ TEST(broadcast_gpu_uint8_t, bfyx_2_to_2x3x4x5_w_b_axes_1_2_3) {
                                         2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
                                         2, 2, 2, 2, 2, 2, 2, 2, 2, 2};
     start_broadcast_test<uint8_t>(data_types::u8, {2, 3, 4, 5}, {2}, {1, 2, 3}, golden_data);
+}
+
+TEST(broadcast_gpu_int64_t, bfyx_2_to_2x3x4x5_w_b_axes_1_2_3) {
+    std::vector<int64_t> golden_data = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                                        2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                                        2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                                        2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                                        2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                                        2, 2, 2, 2, 2, 2, 2, 2, 2, 2};
+    start_broadcast_test<int64_t>(data_types::i64, {2, 3, 4, 5}, {2}, {1, 2, 3}, golden_data);
 }
 
 TEST(broadcast_gpu, basic_error_wrong_b_axes_size) {
@@ -1110,10 +1542,32 @@ TEST(broadcast_gpu_float, bfzyx_1_to_5_w_b_axes_0) {
     start_broadcast_test_5d<float>(data_types::f32, { 5 }, { 1 }, { 0 }, golden_data);
 }
 
+TEST(broadcast_gpu_uint8_t, bfzyx_1_to_5_w_b_axes_0) {
+    std::vector<uint8_t> golden_data = { 1, 1, 1, 1, 1 };
+    start_broadcast_test_5d<uint8_t>(data_types::u8, { 5 }, { 1 }, { 0 }, golden_data);
+}
+
+TEST(broadcast_gpu_int64_t, bfzyx_1_to_5_w_b_axes_0) {
+    std::vector<int64_t> golden_data = { 1, 1, 1, 1, 1 };
+    start_broadcast_test_5d<int64_t>(data_types::i64, { 5 }, { 1 }, { 0 }, golden_data);
+}
+
 TEST(broadcast_gpu_float, bfzyx_1_to_4x5_w_b_axes_0x1) {
     std::vector<float> golden_data = { 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
         1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0 };
     start_broadcast_test_5d<float>(data_types::f32, { 4, 5 }, { 1 }, { 0, 1 }, golden_data);
+}
+
+TEST(broadcast_gpu_uint8_t, bfzyx_1_to_4x5_w_b_axes_0x1) {
+    std::vector<uint8_t> golden_data = { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1 };
+    start_broadcast_test_5d<uint8_t>(data_types::u8, { 4, 5 }, { 1 }, { 0, 1 }, golden_data);
+}
+
+TEST(broadcast_gpu_int64_t, bfzyx_1_to_4x5_w_b_axes_0x1) {
+    std::vector<int64_t> golden_data = { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1 };
+    start_broadcast_test_5d<int64_t>(data_types::i64, { 4, 5 }, { 1 }, { 0, 1 }, golden_data);
 }
 
 TEST(broadcast_gpu_float, bfyx_1_to_2x3x4x5x2_w_b_axes_0x1x2x3x4) {
@@ -1142,4 +1596,60 @@ TEST(broadcast_gpu_float, bfyx_1_to_2x3x4x5x2_w_b_axes_0x1x2x3x4) {
         1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
         1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0 };
     start_broadcast_test_5d<float>(data_types::f32, { 2, 3, 4, 5, 2 }, { 1 }, { 0, 1, 2, 3, 4 }, golden_data);
+}
+
+TEST(broadcast_gpu_uint8_t, bfyx_1_to_2x3x4x5x2_w_b_axes_0x1x2x3x4) {
+    std::vector<uint8_t> golden_data = { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1 };
+    start_broadcast_test_5d<uint8_t>(data_types::u8, { 2, 3, 4, 5, 2 }, { 1 }, { 0, 1, 2, 3, 4 }, golden_data);
+}
+
+TEST(broadcast_gpu_int64_t, bfyx_1_to_2x3x4x5x2_w_b_axes_0x1x2x3x4) {
+    std::vector<int64_t> golden_data = { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1 };
+    start_broadcast_test_5d<int64_t>(data_types::i64, { 2, 3, 4, 5, 2 }, { 1 }, { 0, 1, 2, 3, 4 }, golden_data);
 }

--- a/inference-engine/thirdparty/clDNN/tests/test_cases/concatenation_gpu_test.cpp
+++ b/inference-engine/thirdparty/clDNN/tests/test_cases/concatenation_gpu_test.cpp
@@ -52,6 +52,7 @@ TEST(concat_gpu, mixed_input_types) {
     auto input1 = memory::allocate(engine, { data_types::i32, format::bfyx, { 1, 1, 4, 3 } });
     auto input2 = memory::allocate(engine, { data_types::i8, format::bfyx, { 1, 1, 4, 3 } });
     auto input3 = memory::allocate(engine, { data_types::f16, format::bfyx, { 1, 1, 4, 3 } });
+    auto input4 = memory::allocate(engine, { data_types::i64, format::bfyx, { 1, 1, 4, 3 } });
 
     set_values<float>(input0, { 1.0f, 2.0f, 3.0f, 4.0f, 2.0f, 2.0f, 3.0f, 4.0f, 3.0f, 3.0f, 3.0f, 5.0f });
     set_values<int32_t>(input1, { 11, 12, 13, 14, 12, 12, 13, 14, 13, 13, 13, 15 });
@@ -60,20 +61,23 @@ TEST(concat_gpu, mixed_input_types) {
                          half_t(34.f), half_t(32.f), half_t(32.f),
                          half_t(33.f), half_t(34.f), half_t(33.f),
                          half_t(33.f), half_t(33.f), half_t(35.f) });
+    set_values<int64_t>(input4, { 41, 42, 43, 44, 42, 42, 43, 44, 43, 43, 43, 45 });
 
     VF<float> output_vec = {
             1.0f, 2.0f, 3.0f, 4.0f, 2.0f, 2.0f, 3.0f, 4.0f, 3.0f, 3.0f, 3.0f, 5.0f,
             11.0f, 12.0f, 13.0f, 14.0f, 12.0f, 12.0f, 13.0f, 14.0f, 13.0f, 13.0f, 13.0f, 15.0f,
             21.0f, 22.0f, 23.0f, 24.0f, 22.0f, 22.0f, 23.0f, 24.0f, 23.0f, 23.0f, 23.0f, 25.0f,
-            31.0f, 32.0f, 33.0f, 34.0f, 32.0f, 32.0f, 33.0f, 34.0f, 33.0f, 33.0f, 33.0f, 35.0f };
+            31.0f, 32.0f, 33.0f, 34.0f, 32.0f, 32.0f, 33.0f, 34.0f, 33.0f, 33.0f, 33.0f, 35.0f,
+            41.0f, 42.0f, 43.0f, 44.0f, 42.0f, 42.0f, 43.0f, 44.0f, 43.0f, 43.0f, 43.0f, 45.0f };
 
     topology topology(
             input_layout("input0", input0.get_layout()),
             input_layout("input1", input1.get_layout()),
             input_layout("input2", input2.get_layout()),
             input_layout("input3", input3.get_layout()),
+            input_layout("input4", input4.get_layout()),
             concatenation("concat",
-                          { "input0", "input1", "input2", "input3" },
+                          { "input0", "input1", "input2", "input3", "input4" },
                           concatenation::concatenation_axis::along_f,
                           data_types::f32,
                           padding{ { 0,0,0,0 }, 0 })
@@ -84,6 +88,7 @@ TEST(concat_gpu, mixed_input_types) {
     network.set_input_data("input1", input1);
     network.set_input_data("input2", input2);
     network.set_input_data("input3", input3);
+    network.set_input_data("input4", input4);
 
     auto outputs = network.execute();
     EXPECT_EQ(outputs.size(), size_t(1));
@@ -100,7 +105,7 @@ TEST(concat_gpu, mixed_input_types) {
     EXPECT_EQ(output_layout.format, format::bfyx);
     EXPECT_EQ(y_size, 3);
     EXPECT_EQ(x_size, 4);
-    EXPECT_EQ(f_size, 4);
+    EXPECT_EQ(f_size, 5);
     EXPECT_EQ(b_size, 1);
 
     for (size_t x = 0; x < output_layout.count(); ++x) {

--- a/inference-engine/thirdparty/clDNN/tests/test_cases/contract_gpu_test.cpp
+++ b/inference-engine/thirdparty/clDNN/tests/test_cases/contract_gpu_test.cpp
@@ -297,6 +297,18 @@ TEST(contract_gpu_i32, generic_f_max) {
     generic_contract_test_int<int32_t>(format::bfyx, 5, 5, 5, 5, contract_mode::max, { 1 });
 }
 
+TEST(contract_gpu_i64, generic_f_max) {
+    generic_contract_test_int<int64_t>(format::bfyx, 5, 5, 5, 5, contract_mode::max, { 1 });
+}
+
+TEST(contract_gpu_i64, generic_x_sum) {
+    generic_contract_test_int<int64_t>(format::bfyx, 5, 5, 5, 5, contract_mode::sum, { 3 });
+}
+
+TEST(contract_gpu_i64, generic_fy_any) {
+    generic_contract_test_int<int64_t>(format::bfyx, 5, 5, 5, 5, contract_mode::any, { 1, 2 });
+}
+
 TEST(contract_error, basic_error_empty_r_axes) {
 
     const auto& engine = get_test_engine();

--- a/inference-engine/thirdparty/clDNN/tests/test_cases/one_hot_gpu_test.cpp
+++ b/inference-engine/thirdparty/clDNN/tests/test_cases/one_hot_gpu_test.cpp
@@ -154,6 +154,13 @@ TEST(one_hot_gpu_i32, generic) {
     generic_one_hot_test_int<int32_t>(format::bfyx, 2, 2, 1, 1, tensor(2, 2, 4, 1), 3);
 }
 
+TEST(one_hot_gpu_i64, generic) {
+    generic_one_hot_test_int<int64_t>(format::bfyx, 2, 2, 1, 1, tensor(5, 2, 1, 2), 0);
+    generic_one_hot_test_int<int64_t>(format::bfyx, 1, 2, 3, 1, tensor(1, 5, 3, 2), 1);
+    generic_one_hot_test_int<int64_t>(format::bfyx, 2, 2, 1, 1, tensor(2, 2, 1, 4), 2);
+    generic_one_hot_test_int<int64_t>(format::bfyx, 2, 2, 1, 1, tensor(2, 2, 4, 1), 3);
+}
+
 TEST(one_hot_gpu_i32, bfzyx_ax4) {
     // input: 1x1x2x1
     // axis: 4
@@ -213,6 +220,65 @@ TEST(one_hot_gpu_i32, bfzyx_ax4) {
     EXPECT_EQ(test_is_correct, true);
 }
 
+TEST(one_hot_gpu_i64, bfzyx_ax4) {
+    // input: 1x1x2x1
+    // axis: 4
+    // output: 1x1x2x1x5
+    int in_b = 1;
+    int in_f = 1;
+    int in_y = 2;
+    int in_x = 1;
+    tensor shape(in_b, in_f, 5, in_x, in_y);
+    uint16_t one_hot_axis = 4;
+    std::vector<tensor::value_type> output_dims = { shape.batch[0], shape.feature[0],
+                                                    shape.spatial[2], shape.spatial[1], shape.spatial[0] };
+
+    VF<int64_t> input_rnd_vec = {0, 1};
+
+    const auto& engine = get_test_engine();
+    tensor input_tensor(in_b, in_f, in_x, in_y);
+    auto input = memory::allocate(engine, { data_types::i64, format::bfyx, input_tensor });
+    topology topology;
+    topology.add(input_layout("input", input.get_layout()));
+    topology.add(one_hot("output","input", shape, one_hot_axis));
+
+    set_values(input, input_rnd_vec);
+
+    network network(engine, topology);
+    network.set_input_data("input", input);
+    auto outputs = network.execute();
+    EXPECT_EQ(outputs.size(), size_t(1));
+    EXPECT_EQ(outputs.begin()->first, "output");
+
+    auto output_memory = outputs.at("output").get_memory();
+    auto output_layout = output_memory.get_layout();
+    auto output_ptr = output_memory.pointer<int64_t>();
+
+    tensor output_tensor = output_layout.get_buffer_size();
+    int z_size = output_tensor.spatial[2];
+    int y_size = output_tensor.spatial[1];
+    int x_size = output_tensor.spatial[0];
+    int f_size = output_tensor.feature[0];
+    int b_size = output_tensor.batch[0];
+    EXPECT_EQ(z_size, 2);
+    EXPECT_EQ(y_size, 1);
+    EXPECT_EQ(x_size, 5);
+    EXPECT_EQ(f_size, 1);
+    EXPECT_EQ(b_size, 1);
+
+    bool test_is_correct = true;
+
+    std::vector<int64_t> output_cpu_vec = {1, 0, 0, 0, 0,
+                                           0, 1, 0, 0, 0};
+
+    for (size_t i = 0; i < output_cpu_vec.size(); ++i) {
+        if (output_cpu_vec[i] != output_ptr[i]) {
+            test_is_correct = false;
+        }
+    }
+    EXPECT_EQ(test_is_correct, true);
+}
+
 TEST(one_hot_gpu_i32_to_f32, bfyx_ax4) {
     // input: 1x1x2x1
     // axis: 4
@@ -231,6 +297,60 @@ TEST(one_hot_gpu_i32_to_f32, bfyx_ax4) {
     const auto& engine = get_test_engine();
     tensor input_tensor(in_b, in_f, in_x, in_y);
     auto input = memory::allocate(engine, { data_types::i32, format::bfyx, input_tensor });
+    topology topology;
+    topology.add(input_layout("input", input.get_layout()));
+    topology.add(one_hot("output","input", shape, data_types::f32, one_hot_axis));
+
+    set_values(input, input_rnd_vec);
+
+    network network(engine, topology);
+    network.set_input_data("input", input);
+    auto outputs = network.execute();
+    EXPECT_EQ(outputs.size(), size_t(1));
+    EXPECT_EQ(outputs.begin()->first, "output");
+
+    auto output_memory = outputs.at("output").get_memory();
+    auto output_layout = output_memory.get_layout();
+    auto output_ptr = output_memory.pointer<float>();
+
+    tensor output_tensor = output_layout.get_buffer_size();
+    int z_size = output_tensor.spatial[2];
+    int y_size = output_tensor.spatial[1];
+    int x_size = output_tensor.spatial[0];
+    int f_size = output_tensor.feature[0];
+    int b_size = output_tensor.batch[0];
+    EXPECT_EQ(z_size, 2);
+    EXPECT_EQ(y_size, 1);
+    EXPECT_EQ(x_size, 5);
+    EXPECT_EQ(f_size, 1);
+    EXPECT_EQ(b_size, 1);
+
+    std::vector<float> output_cpu_vec = {1.f, 0.f, 0.f, 0.f, 0.f,
+                                         0.f, 1.f, 0.f, 0.f, 0.f};
+
+    for (size_t i = 0; i < output_cpu_vec.size(); ++i) {
+        ASSERT_EQ(output_cpu_vec[i], output_ptr[i]);
+    }
+}
+
+TEST(one_hot_gpu_i64_to_f32, bfyx_ax4) {
+    // input: 1x1x2x1
+    // axis: 4
+    // output: 1x1x2x1x5
+    int in_b = 1;
+    int in_f = 1;
+    int in_y = 2;
+    int in_x = 1;
+    tensor shape(in_b, in_f, 5, in_x, in_y);
+    uint16_t one_hot_axis = 4;
+    std::vector<tensor::value_type> output_dims = { shape.batch[0], shape.feature[0],
+                                                    shape.spatial[2], shape.spatial[1], shape.spatial[0] };
+
+    VF<int64_t> input_rnd_vec = {0, 1};
+
+    const auto& engine = get_test_engine();
+    tensor input_tensor(in_b, in_f, in_x, in_y);
+    auto input = memory::allocate(engine, { data_types::i64, format::bfyx, input_tensor });
     topology topology;
     topology.add(input_layout("input", input.get_layout()));
     topology.add(one_hot("output","input", shape, data_types::f32, one_hot_axis));
@@ -322,6 +442,61 @@ TEST(one_hot_gpu_i32, bfzyx_ax0) {
     EXPECT_EQ(test_is_correct, true);
 }
 
+TEST(one_hot_gpu_i64, bfzyx_ax0) {
+    int in_b = 1;
+    int in_f = 1;
+    int in_y = 1;
+    int in_x = 2;
+    tensor shape(3, in_b, in_x, in_y, in_f);
+    uint16_t one_hot_axis = 0;
+    std::vector<tensor::value_type> output_dims = { shape.batch[0], shape.feature[0],
+                                                    shape.spatial[2], shape.spatial[1], shape.spatial[0] };
+
+    VF<int64_t> input_rnd_vec = {0, 1};
+
+    const auto& engine = get_test_engine();
+    tensor input_tensor(in_b, in_f, in_x, in_y);
+    auto input = memory::allocate(engine, { data_types::i64, format::bfyx, input_tensor });
+    topology topology;
+    topology.add(input_layout("input", input.get_layout()));
+    topology.add(one_hot("output","input", shape, one_hot_axis));
+
+    set_values(input, input_rnd_vec);
+
+    network network(engine, topology);
+    network.set_input_data("input", input);
+    auto outputs = network.execute();
+    EXPECT_EQ(outputs.size(), size_t(1));
+    EXPECT_EQ(outputs.begin()->first, "output");
+
+    auto output_memory = outputs.at("output").get_memory();
+    auto output_layout = output_memory.get_layout();
+    auto output_ptr = output_memory.pointer<int64_t>();
+
+    tensor output_tensor = output_layout.get_buffer_size();
+    int z_size = output_tensor.spatial[2];
+    int y_size = output_tensor.spatial[1];
+    int x_size = output_tensor.spatial[0];
+    int f_size = output_tensor.feature[0];
+    int b_size = output_tensor.batch[0];
+    EXPECT_EQ(z_size, 1);
+    EXPECT_EQ(y_size, 1);
+    EXPECT_EQ(x_size, 2);
+    EXPECT_EQ(f_size, 1);
+    EXPECT_EQ(b_size, 3);
+
+    bool test_is_correct = true;
+
+    std::vector<int64_t> output_cpu_vec = {1, 0, 0, 1, 0, 0};
+
+    for (size_t i = 0; i < output_cpu_vec.size(); ++i) {
+        if (output_cpu_vec[i] != output_ptr[i]) {
+            test_is_correct = false;
+        }
+    }
+    EXPECT_EQ(test_is_correct, true);
+}
+
 TEST(one_hot_gpu_i32, bfzyx_ax1) {
     int in_b = 1;
     int in_f = 1;
@@ -368,6 +543,61 @@ TEST(one_hot_gpu_i32, bfzyx_ax1) {
     bool test_is_correct = true;
 
     std::vector<int32_t> output_cpu_vec = {1, 0, 0, 1, 0, 0};
+
+    for (size_t i = 0; i < output_cpu_vec.size(); ++i) {
+        if (output_cpu_vec[i] != output_ptr[i]) {
+            test_is_correct = false;
+        }
+    }
+    EXPECT_EQ(test_is_correct, true);
+}
+
+TEST(one_hot_gpu_i64, bfzyx_ax1) {
+    int in_b = 1;
+    int in_f = 1;
+    int in_y = 1;
+    int in_x = 2;
+    tensor shape(in_b, 3, in_x, in_y, in_f);
+    uint16_t one_hot_axis = 1;
+    std::vector<tensor::value_type> output_dims = { shape.batch[0], shape.feature[0],
+                                                    shape.spatial[2], shape.spatial[1], shape.spatial[0] };
+
+    VF<int64_t> input_rnd_vec = {0, 1};
+
+    const auto& engine = get_test_engine();
+    tensor input_tensor(in_b, in_f, in_x, in_y);
+    auto input = memory::allocate(engine, { data_types::i64, format::bfyx, input_tensor });
+    topology topology;
+    topology.add(input_layout("input", input.get_layout()));
+    topology.add(one_hot("output","input", shape, one_hot_axis));
+
+    set_values(input, input_rnd_vec);
+
+    network network(engine, topology);
+    network.set_input_data("input", input);
+    auto outputs = network.execute();
+    EXPECT_EQ(outputs.size(), size_t(1));
+    EXPECT_EQ(outputs.begin()->first, "output");
+
+    auto output_memory = outputs.at("output").get_memory();
+    auto output_layout = output_memory.get_layout();
+    auto output_ptr = output_memory.pointer<int64_t>();
+
+    tensor output_tensor = output_layout.get_buffer_size();
+    int z_size = output_tensor.spatial[2];
+    int y_size = output_tensor.spatial[1];
+    int x_size = output_tensor.spatial[0];
+    int f_size = output_tensor.feature[0];
+    int b_size = output_tensor.batch[0];
+    EXPECT_EQ(z_size, 1);
+    EXPECT_EQ(y_size, 1);
+    EXPECT_EQ(x_size, 2);
+    EXPECT_EQ(f_size, 3);
+    EXPECT_EQ(b_size, 1);
+
+    bool test_is_correct = true;
+
+    std::vector<int64_t> output_cpu_vec = {1, 0, 0, 1, 0, 0};
 
     for (size_t i = 0; i < output_cpu_vec.size(); ++i) {
         if (output_cpu_vec[i] != output_ptr[i]) {
@@ -432,6 +662,61 @@ TEST(one_hot_gpu_i32, bfzyx_ax2) {
     EXPECT_EQ(test_is_correct, true);
 }
 
+TEST(one_hot_gpu_i64, bfzyx_ax2) {
+    int in_b = 1;
+    int in_f = 1;
+    int in_y = 1;
+    int in_x = 2;
+    tensor shape(in_b, in_f, in_x, in_y, 3);
+    uint16_t one_hot_axis = 2;
+    std::vector<tensor::value_type> output_dims = { shape.batch[0], shape.feature[0],
+                                                    shape.spatial[2], shape.spatial[1], shape.spatial[0] };
+
+    VF<int64_t> input_rnd_vec = {0, 1};
+
+    const auto& engine = get_test_engine();
+    tensor input_tensor(in_b, in_f, in_x, in_y);
+    auto input = memory::allocate(engine, { data_types::i64, format::bfyx, input_tensor });
+    topology topology;
+    topology.add(input_layout("input", input.get_layout()));
+    topology.add(one_hot("output","input", shape, one_hot_axis));
+
+    set_values(input, input_rnd_vec);
+
+    network network(engine, topology);
+    network.set_input_data("input", input);
+    auto outputs = network.execute();
+    EXPECT_EQ(outputs.size(), size_t(1));
+    EXPECT_EQ(outputs.begin()->first, "output");
+
+    auto output_memory = outputs.at("output").get_memory();
+    auto output_layout = output_memory.get_layout();
+    auto output_ptr = output_memory.pointer<int64_t>();
+
+    tensor output_tensor = output_layout.get_buffer_size();
+    int z_size = output_tensor.spatial[2];
+    int y_size = output_tensor.spatial[1];
+    int x_size = output_tensor.spatial[0];
+    int f_size = output_tensor.feature[0];
+    int b_size = output_tensor.batch[0];
+    EXPECT_EQ(z_size, 3);
+    EXPECT_EQ(y_size, 1);
+    EXPECT_EQ(x_size, 2);
+    EXPECT_EQ(f_size, 1);
+    EXPECT_EQ(b_size, 1);
+
+    bool test_is_correct = true;
+
+    std::vector<int64_t> output_cpu_vec = {1, 0, 0, 1, 0, 0};
+
+    for (size_t i = 0; i < output_cpu_vec.size(); ++i) {
+        if (output_cpu_vec[i] != output_ptr[i]) {
+            test_is_correct = false;
+        }
+    }
+    EXPECT_EQ(test_is_correct, true);
+}
+
 TEST(one_hot_gpu_i32, bfzyx_ax3) {
     int in_b = 1;
     int in_f = 1;
@@ -478,6 +763,61 @@ TEST(one_hot_gpu_i32, bfzyx_ax3) {
     bool test_is_correct = true;
 
     std::vector<int32_t> output_cpu_vec = {1, 0, 0, 1, 0, 0};
+
+    for (size_t i = 0; i < output_cpu_vec.size(); ++i) {
+        if (output_cpu_vec[i] != output_ptr[i]) {
+            test_is_correct = false;
+        }
+    }
+    EXPECT_EQ(test_is_correct, true);
+}
+
+TEST(one_hot_gpu_i64, bfzyx_ax3) {
+    int in_b = 1;
+    int in_f = 1;
+    int in_y = 1;
+    int in_x = 2;
+    tensor shape(in_b, in_f, in_x, 3, in_y);
+    uint16_t one_hot_axis = 3;
+    std::vector<tensor::value_type> output_dims = { shape.batch[0], shape.feature[0],
+                                                    shape.spatial[2], shape.spatial[1], shape.spatial[0] };
+
+    VF<int64_t> input_rnd_vec = {0, 1};
+
+    const auto& engine = get_test_engine();
+    tensor input_tensor(in_b, in_f, in_x, in_y);
+    auto input = memory::allocate(engine, { data_types::i64, format::bfyx, input_tensor });
+    topology topology;
+    topology.add(input_layout("input", input.get_layout()));
+    topology.add(one_hot("output","input", shape, one_hot_axis));
+
+    set_values(input, input_rnd_vec);
+
+    network network(engine, topology);
+    network.set_input_data("input", input);
+    auto outputs = network.execute();
+    EXPECT_EQ(outputs.size(), size_t(1));
+    EXPECT_EQ(outputs.begin()->first, "output");
+
+    auto output_memory = outputs.at("output").get_memory();
+    auto output_layout = output_memory.get_layout();
+    auto output_ptr = output_memory.pointer<int64_t>();
+
+    tensor output_tensor = output_layout.get_buffer_size();
+    int z_size = output_tensor.spatial[2];
+    int y_size = output_tensor.spatial[1];
+    int x_size = output_tensor.spatial[0];
+    int f_size = output_tensor.feature[0];
+    int b_size = output_tensor.batch[0];
+    EXPECT_EQ(z_size, 1);
+    EXPECT_EQ(y_size, 3);
+    EXPECT_EQ(x_size, 2);
+    EXPECT_EQ(f_size, 1);
+    EXPECT_EQ(b_size, 1);
+
+    bool test_is_correct = true;
+
+    std::vector<int64_t> output_cpu_vec = {1, 0, 0, 1, 0, 0};
 
     for (size_t i = 0; i < output_cpu_vec.size(); ++i) {
         if (output_cpu_vec[i] != output_ptr[i]) {

--- a/inference-engine/thirdparty/clDNN/tests/test_cases/strided_slice_gpu_test.cpp
+++ b/inference-engine/thirdparty/clDNN/tests/test_cases/strided_slice_gpu_test.cpp
@@ -27,7 +27,7 @@
 using namespace cldnn;
 using namespace tests;
 
-TEST(strided_slice_gpu_f32, test_2x2x2x2_full) {
+TEST(strided_slice_gpu_f32_i32, test_2x2x2x2_full) {
     // Input (BFYX): 2x2x2x2
     // Begin (BFYX): 0x0x0x0
     // End (BFYX): 2x2x2x2
@@ -84,7 +84,64 @@ TEST(strided_slice_gpu_f32, test_2x2x2x2_full) {
     }
 }
 
-TEST(strided_slice_gpu_f32, test_2x2x2x2_ignore) {
+TEST(strided_slice_gpu_f32_i64, test_2x2x2x2_full) {
+    // Input (BFYX): 2x2x2x2
+    // Begin (BFYX): 0x0x0x0
+    // End (BFYX): 2x2x2x2
+    // Stride (BFYX): 1x1x1x1
+    // Output (BFYX): 2x2x2x2
+
+    const auto& engine = get_test_engine();
+    auto input = memory::allocate(engine, { data_types::f32, format::bfyx, { 2, 2, 2, 2 } });
+    auto begin = memory::allocate(engine, { data_types::i64, format::bfyx, { 4, 1, 1, 1 } });
+    auto end = memory::allocate(engine, { data_types::i64, format::bfyx, { 4, 1, 1, 1 } });
+    auto strides = memory::allocate(engine, { data_types::i64, format::bfyx, { 4, 1, 1, 1 } });
+
+    set_values(input, {
+            0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f,
+            9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
+    });
+    set_values(begin, {
+            0, 0, 0, 0
+    });
+    set_values(end, {
+            2, 2, 2, 2
+    });
+    set_values(strides, {
+            1, 1, 1, 1
+    });
+
+    topology topology;
+    topology.add(input_layout("input", input.get_layout()));
+    topology.add(data("input2", begin));
+    topology.add(data("input3", end));
+    topology.add(data("input4", strides));
+    topology.add(strided_slice("strided_slice", "input", "input2", "input3", "input4", {}, {}, {}, {}, {}));
+
+    network network(engine, topology);
+
+    network.set_input_data("input", input);
+
+    auto outputs = network.execute();
+
+    EXPECT_EQ(outputs.size(), size_t(1));
+    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+
+    auto output = outputs.at("strided_slice").get_memory();
+
+    std::vector<float> answers = {
+            0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f, 13.f, 14.f, 15.f };
+
+    auto output_ptr = output.pointer<float>();
+
+    ASSERT_EQ(output_ptr.size(), answers.size());
+    for (size_t i = 0; i < answers.size(); ++i)
+    {
+        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+    }
+}
+
+TEST(strided_slice_gpu_f32_i32, test_2x2x2x2_ignore) {
     // Input (BFYX): 2x2x2x2
     // Begin (BFYX): 1x1x1x1
     // End (BFYX): 2x2x2x2
@@ -143,7 +200,66 @@ TEST(strided_slice_gpu_f32, test_2x2x2x2_ignore) {
     }
 }
 
-TEST(strided_slice_gpu_f32, test_2x2x2x2_single) {
+TEST(strided_slice_gpu_f32_i64, test_2x2x2x2_ignore) {
+    // Input (BFYX): 2x2x2x2
+    // Begin (BFYX): 1x1x1x1
+    // End (BFYX): 2x2x2x2
+    // Stride (BFYX): 1x1x1x1
+    // Output (BFYX): 2x2x2x2
+
+    const auto& engine = get_test_engine();
+    auto input = memory::allocate(engine, { data_types::f32, format::bfyx, { 2, 2, 2, 2 } });
+    auto begin = memory::allocate(engine, { data_types::i64, format::bfyx, { 4, 1, 1, 1 } });
+    auto end = memory::allocate(engine, { data_types::i64, format::bfyx, { 4, 1, 1, 1 } });
+    auto strides = memory::allocate(engine, { data_types::i64, format::bfyx, { 4, 1, 1, 1 } });
+
+    set_values(input, {
+            0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f,
+            9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
+    });
+    set_values(begin, {
+            1, 1, 1, 1
+    });
+    set_values(end, {
+            2, 2, 2, 2
+    });
+    set_values(strides, {
+            1, 1, 1, 1
+    });
+
+    topology topology;
+    topology.add(input_layout("input", input.get_layout()));
+    topology.add(data("input2", begin));
+    topology.add(data("input3", end));
+    topology.add(data("input4", strides));
+    topology.add(strided_slice("strided_slice", "input", "input2", "input3", "input4", {0, 0, 0, 0}, {0, 0, 0, 0}, {}, {}, {}));
+
+    network network(engine, topology);
+
+    network.set_input_data("input", input);
+
+    auto outputs = network.execute();
+
+    EXPECT_EQ(outputs.size(), size_t(1));
+    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+
+    auto output = outputs.at("strided_slice").get_memory();
+
+    std::vector<float> answers = {
+        0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f,
+        9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
+    };
+
+    auto output_ptr = output.pointer<float>();
+
+    ASSERT_EQ(output_ptr.size(), answers.size());
+    for (size_t i = 0; i < answers.size(); ++i)
+    {
+        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+    }
+}
+
+TEST(strided_slice_gpu_f32_i32, test_2x2x2x2_single) {
     // Input (BFYX): 2x2x2x2
     // Begin (BFYX): 1x1x1x1
     // End (BFYX): 2x2x2x2
@@ -199,7 +315,63 @@ TEST(strided_slice_gpu_f32, test_2x2x2x2_single) {
     }
 }
 
-TEST(strided_slice_gpu_f32, test_2x2x4x3_stride) {
+TEST(strided_slice_gpu_f32_i64, test_2x2x2x2_single) {
+    // Input (BFYX): 2x2x2x2
+    // Begin (BFYX): 1x1x1x1
+    // End (BFYX): 2x2x2x2
+    // Stride (BFYX): 1x1x1x1
+    // Output (BFYX): 1x1x1x1
+
+    const auto& engine = get_test_engine();
+    auto input = memory::allocate(engine, { data_types::f32, format::bfyx, { 2, 2, 2, 2 } });
+    auto begin = memory::allocate(engine, { data_types::i64, format::bfyx, { 4, 1, 1, 1 } });
+    auto end = memory::allocate(engine, { data_types::i64, format::bfyx, { 4, 1, 1, 1 } });
+    auto strides = memory::allocate(engine, { data_types::i64, format::bfyx, { 4, 1, 1, 1 } });
+
+    set_values(input, {
+            0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f,
+            9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
+               });
+    set_values(begin, {
+            1, 1, 1, 1
+               });
+    set_values(end, {
+            2, 2, 2, 2
+               });
+    set_values(strides, {
+            1, 1, 1, 1
+               });
+
+    topology topology;
+    topology.add(input_layout("input", input.get_layout()));
+    topology.add(data("input2", begin));
+    topology.add(data("input3", end));
+    topology.add(data("input4", strides));
+    topology.add(strided_slice("strided_slice", "input", "input2", "input3", "input4", {}, {}, {}, {}, {}));
+
+    network network(engine, topology);
+
+    network.set_input_data("input", input);
+
+    auto outputs = network.execute();
+
+    EXPECT_EQ(outputs.size(), size_t(1));
+    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+
+    auto output = outputs.at("strided_slice").get_memory();
+
+    std::vector<float> answers = { 15.f };
+
+    auto output_ptr = output.pointer<float>();
+
+    ASSERT_EQ(output_ptr.size(), answers.size());
+    for (size_t i = 0; i < answers.size(); ++i)
+    {
+        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+    }
+}
+
+TEST(strided_slice_gpu_f32_i32, test_2x2x4x3_stride) {
     // Input (BFYX): 2x2x4x3
     // Begin (BFYX): 0x0x0x0
     // End (BFYX): 2x2x4x3
@@ -262,7 +434,70 @@ TEST(strided_slice_gpu_f32, test_2x2x4x3_stride) {
     }
 }
 
-TEST(strided_slice_gpu_f32, test_2x2x4x4_part_stride) {
+TEST(strided_slice_gpu_f32_i64, test_2x2x4x3_stride) {
+    // Input (BFYX): 2x2x4x3
+    // Begin (BFYX): 0x0x0x0
+    // End (BFYX): 2x2x4x3
+    // Stride (BFYX): 1x1x2x1
+    // Output (BFYX): 2x2x2x3
+
+    const auto& engine = get_test_engine();
+    auto input = memory::allocate(engine, { data_types::f32, format::bfyx, { 2, 2, 3, 4 } });
+    auto begin = memory::allocate(engine, { data_types::i64, format::bfyx, { 4, 1, 1, 1 } });
+    auto end = memory::allocate(engine, { data_types::i64, format::bfyx, { 4, 1, 1, 1 } });
+    auto strides = memory::allocate(engine, { data_types::i64, format::bfyx, { 4, 1, 1, 1 } });
+
+    set_values(input, {
+            0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f,
+            9.f, 10.f, 11.f, 12.f, 13.f, 14.f, 15.f, 16.f, 17.f,
+            18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f, 25.f, 26.f,
+            27.f, 28.f, 29.f, 30.f, 31.f, 32.f, 33.f, 34.f, 35.f,
+            36.f, 37.f, 38.f, 39.f, 40.f, 41.f, 42.f, 43.f, 44.f,
+            45.f, 46.f, 47.f
+    });
+    set_values(begin, {
+            0, 0, 0, 0
+    });
+    set_values(end, {
+            2, 2, 4, 3
+    });
+    set_values(strides, {
+            1, 1, 2, 1
+    });
+
+    topology topology;
+    topology.add(input_layout("input", input.get_layout()));
+    topology.add(data("input2", begin));
+    topology.add(data("input3", end));
+    topology.add(data("input4", strides));
+    topology.add(strided_slice("strided_slice", "input", "input2", "input3", "input4", {0, 0, 0, 0}, {0, 0, 0, 0}, {}, {}, {}));
+
+    network network(engine, topology);
+
+    network.set_input_data("input", input);
+
+    auto outputs = network.execute();
+
+    EXPECT_EQ(outputs.size(), size_t(1));
+    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+
+    auto output = outputs.at("strided_slice").get_memory();
+
+    std::vector<float> answers = {
+            0.f, 1.f, 2.f, 6.f, 7.f, 8.f, 12.f, 13.f, 14.f, 18.f, 19.f, 20.f,
+            24.f, 25.f, 26.f, 30.f, 31.f, 32.f, 36.f, 37.f, 38.f, 42.f, 43.f, 44.f
+    };
+
+    auto output_ptr = output.pointer<float>();
+
+    ASSERT_EQ(output_ptr.size(), answers.size());
+    for (size_t i = 0; i < answers.size(); ++i)
+    {
+        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+    }
+}
+
+TEST(strided_slice_gpu_f32_i32, test_2x2x4x4_part_stride) {
     // Input (BFYX): 2x2x4x4
     // Begin (BFYX): 1x0x0x1
     // End (BFYX): 2x2x4x4
@@ -345,7 +580,90 @@ TEST(strided_slice_gpu_f32, test_2x2x4x4_part_stride) {
     }
 }
 
-TEST(strided_slice_gpu_f32, test_2x2x4x1_new_axis_mask) {
+TEST(strided_slice_gpu_f32_i64, test_2x2x4x4_part_stride) {
+    // Input (BFYX): 2x2x4x4
+    // Begin (BFYX): 1x0x0x1
+    // End (BFYX): 2x2x4x4
+    // Stride (BFYX): 1x1x1x2
+    // Output (BFYX): 1x2x4x2
+
+    const auto& engine = get_test_engine();
+    auto input = memory::allocate(engine, { data_types::f32, format::bfyx, { 2, 2, 4, 4 } });
+    auto begin = memory::allocate(engine, { data_types::i64, format::bfyx, { 4, 1, 1, 1 } });
+    auto end = memory::allocate(engine, { data_types::i64, format::bfyx, { 4, 1, 1, 1 } });
+    auto strides = memory::allocate(engine, { data_types::i64, format::bfyx, { 4, 1, 1, 1 } });
+
+    set_values(input, {
+            0.0f, 1.0f, 2.0f, 3.0f,
+            4.0f, 5.0f, 6.0f, 7.0f,
+            8.0f, 9.0f, 10.0f, 11.0f,
+            12.0f, 13.0f, 14.0f, 15.0f,
+
+            16.0f, 17.0f, 18.0f, 19.0f,
+            20.0f, 21.0f, 22.0f, 23.0f,
+            24.0f, 25.0f, 26.0f, 27.0f,
+            28.0f, 29.0f, 30.0f, 31.0f,
+
+            32.0f, 33.0f, 34.0f, 35.0f,
+            36.0f, 37.0f, 38.0f, 39.0f,
+            40.0f, 41.0f, 42.0f, 43.0f,
+            44.0f, 45.0f, 46.0f, 47.0f,
+
+            48.0f, 49.0f, 50.0f, 51.0f,
+            52.0f, 53.0f, 54.0f, 55.0f,
+            56.0f, 57.0f, 58.0f, 59.0f,
+            60.0f, 61.0f, 62.0f, 63.0f
+    });
+    set_values(begin, {
+            1, 0, 0, 1
+    });
+    set_values(end, {
+            2, 2, 4, 4
+    });
+    set_values(strides, {
+            1, 1, 1, 2
+    });
+
+    topology topology;
+    topology.add(input_layout("input", input.get_layout()));
+    topology.add(data("input2", begin));
+    topology.add(data("input3", end));
+    topology.add(data("input4", strides));
+    topology.add(strided_slice("strided_slice", "input", "input2", "input3", "input4", {1, 0, 0, 1}, {}, {}, {}, {}));
+
+    network network(engine, topology);
+
+    network.set_input_data("input", input);
+
+    auto outputs = network.execute();
+
+    EXPECT_EQ(outputs.size(), size_t(1));
+    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+
+    auto output = outputs.at("strided_slice").get_memory();
+
+    std::vector<float> answers = {
+            33.0f, 35.0f,
+            37.0f, 39.0f,
+            41.0f, 43.0f,
+            45.0f, 47.0f,
+
+            49.0f, 51.0f,
+            53.0f, 55.0f,
+            57.0f, 59.0f,
+            61.0f, 63.0f
+    };
+
+    auto output_ptr = output.pointer<float>();
+
+    ASSERT_EQ(output_ptr.size(), answers.size());
+    for (size_t i = 0; i < answers.size(); ++i)
+    {
+        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+    }
+}
+
+TEST(strided_slice_gpu_f32_i32, test_2x2x4x1_new_axis_mask) {
     // Input (BFYX): 2x2x4x1
     // New_axis_mask: 1
     // Output (BFYX): 1x2x2x4
@@ -401,7 +719,63 @@ TEST(strided_slice_gpu_f32, test_2x2x4x1_new_axis_mask) {
     }
 }
 
-TEST(strided_slice_gpu_f32, test_2x2x1x1_new_axis_mask_2) {
+TEST(strided_slice_gpu_f32_i64, test_2x2x4x1_new_axis_mask) {
+    // Input (BFYX): 2x2x4x1
+    // New_axis_mask: 1
+    // Output (BFYX): 1x2x2x4
+
+    const auto& engine = get_test_engine();
+    auto input = memory::allocate(engine, { data_types::f32, format::bfyx, { 2, 2, 1, 4 } });
+    auto begin = memory::allocate(engine, { data_types::i64, format::bfyx, { 4, 1, 1, 1 } });
+    auto end = memory::allocate(engine, { data_types::i64, format::bfyx, { 4, 1, 1, 1 } });
+    auto strides = memory::allocate(engine, { data_types::i64, format::bfyx, { 4, 1, 1, 1 } });
+
+    set_values(input, {
+            0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f,
+            10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
+    });
+    set_values(begin, {
+            1, 0, 1, 0
+    });
+    set_values(end, {
+            2, 2, 4, 4
+    });
+    set_values(strides, {
+            1, 1, 1, 2
+    });
+
+    topology topology;
+    topology.add(input_layout("input", input.get_layout()));
+    topology.add(data("input2", begin));
+    topology.add(data("input3", end));
+    topology.add(data("input4", strides));
+    topology.add(strided_slice("strided_slice", "input", "input2", "input3", "input4", {}, {}, { 1 }, {}));
+
+    network network(engine, topology);
+
+    network.set_input_data("input", input);
+
+    auto outputs = network.execute();
+
+    EXPECT_EQ(outputs.size(), size_t(1));
+    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+
+    auto output = outputs.at("strided_slice").get_memory();
+
+    std::vector<float> answers = {
+            0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f,
+            10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
+    };
+
+    auto output_ptr = output.pointer<float>();
+
+    for (size_t i = 0; i < answers.size(); ++i)
+    {
+        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+    }
+}
+
+TEST(strided_slice_gpu_f32_i32, test_2x2x1x1_new_axis_mask_2) {
     // Input (BFYX): 2x2x1x1
     // New_axis_mask: 101
     // Output (BFYX): 1x2x1x2
@@ -455,8 +829,61 @@ TEST(strided_slice_gpu_f32, test_2x2x1x1_new_axis_mask_2) {
     }
 }
 
+TEST(strided_slice_gpu_f32_i64, test_2x2x1x1_new_axis_mask_2) {
+    // Input (BFYX): 2x2x1x1
+    // New_axis_mask: 101
+    // Output (BFYX): 1x2x1x2
 
-TEST(strided_slice_gpu_f32, test_2x2x1x1) {
+    const auto& engine = get_test_engine();
+    auto input = memory::allocate(engine, { data_types::f32, format::bfyx, { 2, 2, 1, 1 } });
+    auto begin = memory::allocate(engine, { data_types::i64, format::bfyx, { 4, 1, 1, 1 } });
+    auto end = memory::allocate(engine, { data_types::i64, format::bfyx, { 4, 1, 1, 1 } });
+    auto strides = memory::allocate(engine, { data_types::i64, format::bfyx, { 4, 1, 1, 1 } });
+
+    set_values(input, {
+            0.0f, 1.0f, 2.0f, 3.0f
+    });
+    set_values(begin, {
+            1, 0, 1, 0
+    });
+    set_values(end, {
+            2, 2, 4, 4
+    });
+    set_values(strides, {
+            1, 1, 1, 2
+    });
+
+    topology topology;
+    topology.add(input_layout("input", input.get_layout()));
+    topology.add(data("input2", begin));
+    topology.add(data("input3", end));
+    topology.add(data("input4", strides));
+    topology.add(strided_slice("strided_slice", "input", "input2", "input3", "input4", {}, {}, { 1, 0, 1 }, {}));
+
+    network network(engine, topology);
+
+    network.set_input_data("input", input);
+
+    auto outputs = network.execute();
+
+    EXPECT_EQ(outputs.size(), size_t(1));
+    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+
+    auto output = outputs.at("strided_slice").get_memory();
+
+    std::vector<float> answers = {
+            0.0f, 1.0f, 2.0f, 3.0f
+    };
+
+    auto output_ptr = output.pointer<float>();
+
+    for (size_t i = 0; i < answers.size(); ++i)
+    {
+        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+    }
+}
+
+TEST(strided_slice_gpu_f32_i32, test_2x2x1x1) {
     // Input (BFYX): 2x2x1x1
     // Output (BFYX): 2x2x1x1
 
@@ -509,7 +936,60 @@ TEST(strided_slice_gpu_f32, test_2x2x1x1) {
     }
 }
 
-TEST(strided_slice_gpu_f32, test_2x2x2x1x1) {
+TEST(strided_slice_gpu_f32_i64, test_2x2x1x1) {
+    // Input (BFYX): 2x2x1x1
+    // Output (BFYX): 2x2x1x1
+
+    const auto& engine = get_test_engine();
+    auto input = memory::allocate(engine, { data_types::f32, format::bfyx, { 2, 2, 1, 1 } });
+    auto begin = memory::allocate(engine, { data_types::i64, format::bfyx, { 2, 1, 1, 1 } });
+    auto end = memory::allocate(engine, { data_types::i64, format::bfyx, { 2, 1, 1, 1 } });
+    auto strides = memory::allocate(engine, { data_types::i64, format::bfyx, { 2, 1, 1, 1 } });
+
+    set_values(input, {
+            0.0f, 1.0f, 2.0f, 3.0f
+    });
+    set_values(begin, {
+            0, 0
+    });
+    set_values(end, {
+            2, 2
+    });
+    set_values(strides, {
+            1, 1
+    });
+
+    topology topology;
+    topology.add(input_layout("input", input.get_layout()));
+    topology.add(data("input2", begin));
+    topology.add(data("input3", end));
+    topology.add(data("input4", strides));
+    topology.add(strided_slice("strided_slice", "input", "input2", "input3", "input4", {0,1}, {}, {}, {}));
+
+    network network(engine, topology);
+
+    network.set_input_data("input", input);
+
+    auto outputs = network.execute();
+
+    EXPECT_EQ(outputs.size(), size_t(1));
+    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+
+    auto output = outputs.at("strided_slice").get_memory();
+
+    std::vector<float> answers = {
+            0.0f, 1.0f, 2.0f, 3.0f
+    };
+
+    auto output_ptr = output.pointer<float>();
+
+    for (size_t i = 0; i < answers.size(); ++i)
+    {
+        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+    }
+}
+
+TEST(strided_slice_gpu_f32_i32, test_2x2x2x1x1) {
     // Input (BFZYX): 2x2x2x1x1
     // Output (BFZYX): 1x2x2x1x1
 
@@ -562,7 +1042,60 @@ TEST(strided_slice_gpu_f32, test_2x2x2x1x1) {
     }
 }
 
-TEST(strided_slice_gpu_f32, test_2x2x2x1x1_2) {
+TEST(strided_slice_gpu_f32_i64, test_2x2x2x1x1) {
+    // Input (BFZYX): 2x2x2x1x1
+    // Output (BFZYX): 1x2x2x1x1
+
+    const auto& engine = get_test_engine();
+    auto input = memory::allocate(engine, { data_types::f32, format::bfzyx, { 2, 2, 1, 1, 2 } });
+    auto begin = memory::allocate(engine, { data_types::i64, format::bfyx, { 3, 1, 1, 1 } });
+    auto end = memory::allocate(engine, { data_types::i64, format::bfyx, { 3, 1, 1, 1 } });
+    auto strides = memory::allocate(engine, { data_types::i64, format::bfyx, { 3, 1, 1, 1 } });
+
+    set_values(input, {
+            0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f
+    });
+    set_values(begin, {
+            0, 0, 0
+    });
+    set_values(end, {
+            1, 2, 2
+    });
+    set_values(strides, {
+            1, 1, 1
+    });
+
+    topology topology;
+    topology.add(input_layout("input", input.get_layout()));
+    topology.add(data("input2", begin));
+    topology.add(data("input3", end));
+    topology.add(data("input4", strides));
+    topology.add(strided_slice("strided_slice", "input", "input2", "input3", "input4", {}, {}, {}, {}));
+
+    network network(engine, topology);
+
+    network.set_input_data("input", input);
+
+    auto outputs = network.execute();
+
+    EXPECT_EQ(outputs.size(), size_t(1));
+    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+
+    auto output = outputs.at("strided_slice").get_memory();
+
+    std::vector<float> answers = {
+            0.0f, 1.0f, 2.0f, 3.0f
+    };
+
+    auto output_ptr = output.pointer<float>();
+
+    for (size_t i = 0; i < answers.size(); ++i)
+    {
+        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+    }
+}
+
+TEST(strided_slice_gpu_f32_i32, test_2x2x2x1x1_2) {
     // Input (BFZYX): 2x2x2x1x1
     // Output (BFZYX): 2x1x1x1x1
 
@@ -615,7 +1148,60 @@ TEST(strided_slice_gpu_f32, test_2x2x2x1x1_2) {
     }
 }
 
-TEST(strided_slice_gpu_f32, test_2x2x2x2_full_negative_stride) {
+TEST(strided_slice_gpu_f32_i64, test_2x2x2x1x1_2) {
+    // Input (BFZYX): 2x2x2x1x1
+    // Output (BFZYX): 2x1x1x1x1
+
+    const auto& engine = get_test_engine();
+    auto input = memory::allocate(engine, { data_types::f32, format::bfzyx, { 2, 2, 1, 1, 2 } });
+    auto begin = memory::allocate(engine, { data_types::i64, format::bfyx, { 3, 1, 1, 1 } });
+    auto end = memory::allocate(engine, { data_types::i64, format::bfyx, { 3, 1, 1, 1 } });
+    auto strides = memory::allocate(engine, { data_types::i64, format::bfyx, { 3, 1, 1, 1 } });
+
+    set_values(input, {
+            0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f
+    });
+    set_values(begin, {
+            0, 0, 0
+    });
+    set_values(end, {
+            2, 2, 2
+    });
+    set_values(strides, {
+            1, 2, 2
+    });
+
+    topology topology;
+    topology.add(input_layout("input", input.get_layout()));
+    topology.add(data("input2", begin));
+    topology.add(data("input3", end));
+    topology.add(data("input4", strides));
+    topology.add(strided_slice("strided_slice", "input", "input2", "input3", "input4", {}, {}, {}, {}));
+
+    network network(engine, topology);
+
+    network.set_input_data("input", input);
+
+    auto outputs = network.execute();
+
+    EXPECT_EQ(outputs.size(), size_t(1));
+    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+
+    auto output = outputs.at("strided_slice").get_memory();
+
+    std::vector<float> answers = {
+            0.0f, 4.0f
+    };
+
+    auto output_ptr = output.pointer<float>();
+
+    for (size_t i = 0; i < answers.size(); ++i)
+    {
+        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+    }
+}
+
+TEST(strided_slice_gpu_f32_i32, test_2x2x2x2_full_negative_stride) {
     // Input (BFYX): 2x2x2x2
     // Begin (BFYX): 0x0x0x0
     // End (BFYX): 2x2x2x2
@@ -672,7 +1258,64 @@ TEST(strided_slice_gpu_f32, test_2x2x2x2_full_negative_stride) {
     }
 }
 
-TEST(strided_slice_gpu_f32, test_2x2x2x1x1_2_negative_all) {
+TEST(strided_slice_gpu_f32_i64, test_2x2x2x2_full_negative_stride) {
+    // Input (BFYX): 2x2x2x2
+    // Begin (BFYX): 0x0x0x0
+    // End (BFYX): 2x2x2x2
+    // Stride (BFYX): -1x1x1x1
+    // Output (BFYX): 2x2x2x2
+
+    const auto& engine = get_test_engine();
+    auto input = memory::allocate(engine, { data_types::f32, format::bfyx, { 2, 2, 2, 2 } });
+    auto begin = memory::allocate(engine, { data_types::i64, format::bfyx, { 4, 1, 1, 1 } });
+    auto end = memory::allocate(engine, { data_types::i64, format::bfyx, { 4, 1, 1, 1 } });
+    auto strides = memory::allocate(engine, { data_types::i64, format::bfyx, { 4, 1, 1, 1 } });
+
+    set_values(input, {
+            0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f,
+            9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
+    });
+    set_values(begin, {
+            0, 0, 0, 0
+    });
+    set_values(end, {
+            2, 2, 2, 2
+    });
+    set_values(strides, {
+            -1, -1, 1, 1
+    });
+
+    topology topology;
+    topology.add(input_layout("input", input.get_layout()));
+    topology.add(data("input2", begin));
+    topology.add(data("input3", end));
+    topology.add(data("input4", strides));
+    topology.add(strided_slice("strided_slice", "input", "input2", "input3", "input4", {}, {}, {}, {}, {}));
+
+    network network(engine, topology);
+
+    network.set_input_data("input", input);
+
+    auto outputs = network.execute();
+
+    EXPECT_EQ(outputs.size(), size_t(1));
+    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+
+    auto output = outputs.at("strided_slice").get_memory();
+
+    std::vector<float> answers = {
+            12.f, 13.f, 14.f, 15.f, 8.f, 9.f, 10.f, 11.f, 4.f, 5.f, 6.f, 7.f, 0.f, 1.f, 2.f, 3.f };
+
+    auto output_ptr = output.pointer<float>();
+
+    ASSERT_EQ(output_ptr.size(), answers.size());
+    for (size_t i = 0; i < answers.size(); ++i)
+    {
+        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+    }
+}
+
+TEST(strided_slice_gpu_f32_i32, test_2x2x2x1x1_2_negative_all) {
     // Input (BFZYX): 2x2x2x1x1
     // Output (BFZYX): 2x1x1x1x1
 
@@ -681,6 +1324,59 @@ TEST(strided_slice_gpu_f32, test_2x2x2x1x1_2_negative_all) {
     auto begin = memory::allocate(engine, { data_types::i32, format::bfyx, { 3, 1, 1, 1 } });
     auto end = memory::allocate(engine, { data_types::i32, format::bfyx, { 3, 1, 1, 1 } });
     auto strides = memory::allocate(engine, { data_types::i32, format::bfyx, { 3, 1, 1, 1 } });
+
+    set_values(input, {
+            0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f
+    });
+    set_values(begin, {
+            0, 0, 0
+    });
+    set_values(end, {
+            2, 2, 2
+    });
+    set_values(strides, {
+            1, 2, 2
+    });
+
+    topology topology;
+    topology.add(input_layout("input", input.get_layout()));
+    topology.add(data("input2", begin));
+    topology.add(data("input3", end));
+    topology.add(data("input4", strides));
+    topology.add(strided_slice("strided_slice", "input", "input2", "input3", "input4", {}, {}, {}, {}));
+
+    network network(engine, topology);
+
+    network.set_input_data("input", input);
+
+    auto outputs = network.execute();
+
+    EXPECT_EQ(outputs.size(), size_t(1));
+    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+
+    auto output = outputs.at("strided_slice").get_memory();
+
+    std::vector<float> answers = {
+            0.0f, 4.0f
+    };
+
+    auto output_ptr = output.pointer<float>();
+
+    for (size_t i = 0; i < answers.size(); ++i)
+    {
+        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+    }
+}
+
+TEST(strided_slice_gpu_f32_i64, test_2x2x2x1x1_2_negative_all) {
+    // Input (BFZYX): 2x2x2x1x1
+    // Output (BFZYX): 2x1x1x1x1
+
+    const auto& engine = get_test_engine();
+    auto input = memory::allocate(engine, { data_types::f32, format::bfzyx, { 2, 2, 1, 1, 2 } });
+    auto begin = memory::allocate(engine, { data_types::i64, format::bfyx, { 3, 1, 1, 1 } });
+    auto end = memory::allocate(engine, { data_types::i64, format::bfyx, { 3, 1, 1, 1 } });
+    auto strides = memory::allocate(engine, { data_types::i64, format::bfyx, { 3, 1, 1, 1 } });
 
     set_values(input, {
             0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f

--- a/inference-engine/thirdparty/clDNN/tests/test_cases/strided_slice_gpu_test.cpp
+++ b/inference-engine/thirdparty/clDNN/tests/test_cases/strided_slice_gpu_test.cpp
@@ -101,13 +101,13 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x2x2_full) {
             0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f,
             9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
     });
-    set_values(begin, {
+    set_values<int64_t>(begin, {
             0, 0, 0, 0
     });
-    set_values(end, {
+    set_values<int64_t>(end, {
             2, 2, 2, 2
     });
-    set_values(strides, {
+    set_values<int64_t>(strides, {
             1, 1, 1, 1
     });
 
@@ -217,13 +217,13 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x2x2_ignore) {
             0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f,
             9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
     });
-    set_values(begin, {
+    set_values<int64_t>(begin, {
             1, 1, 1, 1
     });
-    set_values(end, {
+    set_values<int64_t>(end, {
             2, 2, 2, 2
     });
-    set_values(strides, {
+    set_values<int64_t>(strides, {
             1, 1, 1, 1
     });
 
@@ -332,13 +332,13 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x2x2_single) {
             0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f,
             9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
                });
-    set_values(begin, {
+    set_values<int64_t>(begin, {
             1, 1, 1, 1
                });
-    set_values(end, {
+    set_values<int64_t>(end, {
             2, 2, 2, 2
                });
-    set_values(strides, {
+    set_values<int64_t>(strides, {
             1, 1, 1, 1
                });
 
@@ -455,13 +455,13 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x4x3_stride) {
             36.f, 37.f, 38.f, 39.f, 40.f, 41.f, 42.f, 43.f, 44.f,
             45.f, 46.f, 47.f
     });
-    set_values(begin, {
+    set_values<int64_t>(begin, {
             0, 0, 0, 0
     });
-    set_values(end, {
+    set_values<int64_t>(end, {
             2, 2, 4, 3
     });
-    set_values(strides, {
+    set_values<int64_t>(strides, {
             1, 1, 2, 1
     });
 
@@ -614,13 +614,13 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x4x4_part_stride) {
             56.0f, 57.0f, 58.0f, 59.0f,
             60.0f, 61.0f, 62.0f, 63.0f
     });
-    set_values(begin, {
+    set_values<int64_t>(begin, {
             1, 0, 0, 1
     });
-    set_values(end, {
+    set_values<int64_t>(end, {
             2, 2, 4, 4
     });
-    set_values(strides, {
+    set_values<int64_t>(strides, {
             1, 1, 1, 2
     });
 
@@ -734,13 +734,13 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x4x1_new_axis_mask) {
             0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f,
             10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
     });
-    set_values(begin, {
+    set_values<int64_t>(begin, {
             1, 0, 1, 0
     });
-    set_values(end, {
+    set_values<int64_t>(end, {
             2, 2, 4, 4
     });
-    set_values(strides, {
+    set_values<int64_t>(strides, {
             1, 1, 1, 2
     });
 
@@ -843,13 +843,13 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x1x1_new_axis_mask_2) {
     set_values(input, {
             0.0f, 1.0f, 2.0f, 3.0f
     });
-    set_values(begin, {
+    set_values<int64_t>(begin, {
             1, 0, 1, 0
     });
-    set_values(end, {
+    set_values<int64_t>(end, {
             2, 2, 4, 4
     });
-    set_values(strides, {
+    set_values<int64_t>(strides, {
             1, 1, 1, 2
     });
 
@@ -949,13 +949,13 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x1x1) {
     set_values(input, {
             0.0f, 1.0f, 2.0f, 3.0f
     });
-    set_values(begin, {
+    set_values<int64_t>(begin, {
             0, 0
     });
-    set_values(end, {
+    set_values<int64_t>(end, {
             2, 2
     });
-    set_values(strides, {
+    set_values<int64_t>(strides, {
             1, 1
     });
 
@@ -1055,13 +1055,13 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x2x1x1) {
     set_values(input, {
             0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f
     });
-    set_values(begin, {
+    set_values<int64_t>(begin, {
             0, 0, 0
     });
-    set_values(end, {
+    set_values<int64_t>(end, {
             1, 2, 2
     });
-    set_values(strides, {
+    set_values<int64_t>(strides, {
             1, 1, 1
     });
 
@@ -1161,13 +1161,13 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x2x1x1_2) {
     set_values(input, {
             0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f
     });
-    set_values(begin, {
+    set_values<int64_t>(begin, {
             0, 0, 0
     });
-    set_values(end, {
+    set_values<int64_t>(end, {
             2, 2, 2
     });
-    set_values(strides, {
+    set_values<int64_t>(strides, {
             1, 2, 2
     });
 
@@ -1275,13 +1275,13 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x2x2_full_negative_stride) {
             0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f,
             9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
     });
-    set_values(begin, {
+    set_values<int64_t>(begin, {
             0, 0, 0, 0
     });
-    set_values(end, {
+    set_values<int64_t>(end, {
             2, 2, 2, 2
     });
-    set_values(strides, {
+    set_values<int64_t>(strides, {
             -1, -1, 1, 1
     });
 
@@ -1381,13 +1381,13 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x2x1x1_2_negative_all) {
     set_values(input, {
             0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f
     });
-    set_values(begin, {
+    set_values<int64_t>(begin, {
             0, 0, 0
     });
-    set_values(end, {
+    set_values<int64_t>(end, {
             2, 2, 2
     });
-    set_values(strides, {
+    set_values<int64_t>(strides, {
             1, 2, 2
     });
 

--- a/inference-engine/thirdparty/clDNN/tests/test_utils/test_utils.h
+++ b/inference-engine/thirdparty/clDNN/tests/test_utils/test_utils.h
@@ -254,7 +254,8 @@ void set_values_per_batch_and_feature(const cldnn::memory& mem, std::vector<T> a
 
 }
 
-template<typename T>
+template<typename T, typename std::enable_if<std::is_floating_point<T>::value ||
+                                             std::is_same<T, FLOAT16>::value>::type* = nullptr>
 void set_random_values(const cldnn::memory& mem, bool sign = false, unsigned significand_bit = 8, unsigned scale = 1)
 {
     auto ptr = mem.pointer<T>();
@@ -263,6 +264,19 @@ void set_random_values(const cldnn::memory& mem, bool sign = false, unsigned sig
     for (auto it = ptr.begin(); it != ptr.end(); ++it)
     {
         *it = rnd_generators::gen_number<T>(gen, significand_bit, sign, false, scale);
+    }
+}
+
+template<class T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
+void set_random_values(const cldnn::memory& mem)
+{
+    auto ptr = mem.pointer<T>();
+
+    std::mt19937 gen;
+    static std::uniform_int_distribution<T> uid(std::numeric_limits<T>::min(), std::numeric_limits<T>::max());
+    for (auto it = ptr.begin(); it != ptr.end(); ++it)
+    {
+        *it = uid(gen);
     }
 }
 


### PR DESCRIPTION
At this moment we do i64,u64 -> i32 conversion for the whole network in the plugin and it might not work well if model has i64 input or output (data types in original network and type expected by the plugin might mismatch). This change it meant to add i64/u64 support for dynamic inputs and outputs.

JIRA: CVS-25247