### PR TITLE
[VPU][GT] Add convert shape notation pass

### DIFF
--- a/inference-engine/cmake/vpu_dependencies.cmake
+++ b/inference-engine/cmake/vpu_dependencies.cmake
@@ -19,7 +19,7 @@ set(VPU_SUPPORTED_FIRMWARES usb-ma2450 usb-ma2x8x pcie-ma248x)
 # Default packages
 #
 
-set(FIRMWARE_PACKAGE_VERSION 1163)
+set(FIRMWARE_PACKAGE_VERSION 1169)
 set(VPU_CLC_MA2X8X_VERSION "movi-cltools-20.02.0")
 
 #

--- a/inference-engine/src/vpu/common/src/ngraph/operations/static_shape_nonzero.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/operations/static_shape_nonzero.cpp
@@ -86,8 +86,8 @@ void staticShapeNonZeroReference(const InType* input, OutType* outIndices, OutTy
         }
     }
 
-    outShape[0] = nonZeroCount;
-    outShape[1] = inputShape.size();
+    outShape[0] = inputShape.size();
+    outShape[1] = nonZeroCount;
 }
 
 template <element::Type_t InType>

--- a/inference-engine/src/vpu/graph_transformer/include/vpu/middleend/pass_manager.hpp
+++ b/inference-engine/src/vpu/graph_transformer/include/vpu/middleend/pass_manager.hpp
@@ -119,6 +119,12 @@ public:
     Pass::Ptr adjustDataBatch();
 
     //
+    // Dynamic shape adaptation
+    //
+
+    Pass::Ptr convertShapeNotation();
+
+    //
     // HW stages tiling
     //
 

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/pass_manager.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/pass_manager.cpp
@@ -88,6 +88,13 @@ PassSet::Ptr PassManager::buildMiddleEnd() {
     ADD_DUMP_PASS("initial");
 
     //
+    // Convert shape notation
+    //
+
+    ADD_PASS(convertShapeNotation);
+    ADD_DUMP_PASS("convertShapeNotation");
+
+    //
     // Replace Global AvgPooling with ReduceMean
     //
 

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/allocate_resources.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/allocate_resources.cpp
@@ -188,7 +188,7 @@ AllocationResult runAllocator(const Model& model, bool onlyCheckCMX) {
     // Clean up undeallocated shapes
     //
 
-    for (auto data : model->datas()) {
+    for (const auto& data : model->datas()) {
         if (data->childDataToShapeEdges().empty()) {
             continue;
         }

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/allocate_resources.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/allocate_resources.cpp
@@ -185,6 +185,27 @@ AllocationResult runAllocator(const Model& model, bool onlyCheckCMX) {
     }
 
     //
+    // Clean up undeallocated shapes
+    //
+
+    for (auto data : model->datas()) {
+        if (data->childDataToShapeEdges().empty()) {
+            continue;
+        }
+
+        if (data->usage() != DataUsage::Intermediate) {
+            continue;
+        }
+
+        for (const auto& dataToShapeEdge : data->childDataToShapeEdges()) {
+            if (dataToShapeEdge->child()->usage() == DataUsage::Output) {
+                allocator.freeData(data);
+                break;
+            }
+        }
+    }
+
+    //
     // Allocate shape for all datas
     //
 

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/convert_shape_notation.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/convert_shape_notation.cpp
@@ -1,0 +1,94 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vpu/middleend/pass_manager.hpp>
+
+namespace vpu {
+
+namespace {
+
+class PassImpl final : public Pass {
+public:
+    explicit PassImpl(StageBuilder::Ptr stageBuilder) : _stageBuilder(std::move(stageBuilder)) {}
+
+    void run(const Model& model) override;
+
+private:
+    StageBuilder::Ptr _stageBuilder;
+};
+
+void PassImpl::run(const Model& model) {
+    VPU_PROFILE(convertShapeNotation);
+
+    // Save all the datas to process before the main loop as in the main loop we will
+    // modify the datas list and we will get into the infinite loop
+    DataVector shapes;
+
+    for (const auto& data : model->datas()) {
+        if (!data->childDataToShapeEdges().empty()) {
+            shapes.push_back(data);
+        }
+    }
+
+    for (const auto& shape : shapes) {
+        // Revert shape from IE to MDK notation
+        auto convertedShape = model->duplicateData(shape, "@converted-notation");
+
+        const auto generator = [&convertedShape](const ie::Blob::Ptr& blob) {
+            std::vector<int32_t> gatherIndices(static_cast<size_t>(convertedShape->desc().totalDimSize()));
+            std::iota(gatherIndices.rbegin(), gatherIndices.rend(), 0);
+
+            auto buffer = blob->buffer().as<int32_t*>();
+
+            std::copy(gatherIndices.begin(), gatherIndices.end(), buffer);
+        };
+
+        auto gatherIndices = model->addConstData(shape->name() + "@gather-indices",
+                                                 DataDesc(DataType::S32, DimsOrder::C, {convertedShape->desc().totalDimSize()}),
+                                                 generator);
+
+        _stageBuilder->addGatherStage(model,
+                                      shape->name() + "@convert-notation",
+                                      nullptr,
+                                      shape,
+                                      gatherIndices,
+                                      convertedShape,
+                                      Dim::C);
+
+        for (const auto& dataToShapeEdge : shape->childDataToShapeEdges()) {
+            model->replaceDataToShapeParent(dataToShapeEdge, convertedShape);
+        }
+
+        // In case if data and shape had the same producer
+        // Topological order (nextStages/previousStages) needs to be updated
+        for (const auto& dataToShapeEdge : convertedShape->childDataToShapeEdges()) {
+            const auto& child = dataToShapeEdge->child();
+
+            if (!child->producer() || child->producer() != shape->producer()) {
+                continue;
+            }
+
+            const auto& dependentStagesEdges = convertedShape->dependentStagesEdges();
+
+            for (const auto& consumer : child->consumers()) {
+                const auto it = std::find_if(dependentStagesEdges.begin(), dependentStagesEdges.end(), [&consumer](const StageDependency& edge) {
+                    return edge->dependentStage() == consumer;
+                });
+
+                if (it != dependentStagesEdges.end()) {
+                    continue;
+                }
+
+                model->addStageDependency(consumer, convertedShape);
+            }
+        }
+    }
+}
+}  // namespace
+
+Pass::Ptr PassManager::convertShapeNotation() {
+    return std::make_shared<PassImpl>(_stageBuilder);
+}
+
+}  // namespace vpu

--- a/inference-engine/src/vpu/myriad_plugin/myriad_infer_request.cpp
+++ b/inference-engine/src/vpu/myriad_plugin/myriad_infer_request.cpp
@@ -246,7 +246,7 @@ void MyriadInferRequest::GetResult() {
             auto shapeRank = dynOutputDesc.getDims().size();
             ieOutDims.resize(shapeRank);
             for (size_t idx = 0; idx < shapeRank; ++idx) {
-                ieOutDims[idx] = shapePtr[shapeRank - idx - 1];
+                ieOutDims[idx] = shapePtr[idx];
             }
 
             outData->setDims(ieOutDims);

--- a/inference-engine/tests/functional/plugin/myriad/single_layer_tests/static_shape_nonzero.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/single_layer_tests/static_shape_nonzero.cpp
@@ -79,8 +79,8 @@ protected:
 
         const auto totalDimsSize = actualIndices->getTensorDesc().getDims()[1];
 
-        for (int axis = 0; axis < actualDimsPtr[1]; ++axis) {
-            for (int i = 0; i < actualDimsPtr[0]; ++i) {
+        for (int axis = 0; axis < actualDimsPtr[0]; ++axis) {
+            for (int i = 0; i < actualDimsPtr[1]; ++i) {
                 const auto idx = i + axis * totalDimsSize;
                 ASSERT_EQ(expectedIndicesPtr[idx], actualIndicesPtr[idx]);
             }

--- a/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/convert_shape_notation.cpp
+++ b/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/convert_shape_notation.cpp
@@ -1,0 +1,435 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "graph_transformer_tests.hpp"
+
+#include "ie_memcpy.h"
+
+namespace vpu {
+
+namespace ie = InferenceEngine;
+
+class ConvertShapeNotationTests : public GraphTransformerTest {
+protected:
+    void SetUp() override {
+        ASSERT_NO_FATAL_FAILURE(GraphTransformerTest::SetUp());
+        ASSERT_NO_FATAL_FAILURE(InitCompileEnv());
+        ASSERT_NO_FATAL_FAILURE(InitPipeline());
+
+        _testModel = CreateTestModel();
+    }
+
+    void Compile() {
+        _pipeline.run(_testModel.getBaseModel());
+    }
+
+    void InitPipeline() {
+        _pipeline = PassSet();
+        _pipeline.addPass(passManager->dumpModel("before-convert-shape-notation"));
+        _pipeline.addPass(passManager->initialCheck());
+        _pipeline.addPass(passManager->convertShapeNotation());
+        _pipeline.addPass(passManager->dumpModel("after-convert-shape-notation"));
+    }
+
+    int getGathersCount() {
+        int gathersCount = 0;
+
+        for (const auto& stage : _testModel.getBaseModel()->getStages()) {
+            if (stage->type() == StageType::Gather) {
+                gathersCount++;
+            }
+        }
+
+        return gathersCount;
+    }
+
+    void checkGatherParams() {
+        for (const auto& gather : _testModel.getBaseModel()->getStages()) {
+            if (gather->type() != StageType::Gather) {
+                continue;
+            }
+
+            const auto gatherIndices = gather->input(1);
+            ASSERT_NE(gatherIndices, nullptr);
+
+            const auto indicesDesc = gatherIndices->desc();
+            ASSERT_EQ(indicesDesc.type(), DataType::S32);
+            ASSERT_EQ(indicesDesc.dims().size(), 1);
+
+            const auto indicesCount = static_cast<size_t>(indicesDesc.totalDimSize());
+            const auto indicesBuffer = gatherIndices->content()->get<int32_t*>();
+
+            std::vector<int32_t> expectedIndices(indicesCount);
+            std::iota(expectedIndices.rbegin(), expectedIndices.rend(), 0);
+
+            std::vector<int32_t> actualIndices(indicesCount);
+            ie_memcpy(actualIndices.data(), indicesCount, indicesBuffer, indicesCount);
+
+            ASSERT_TRUE(std::equal(actualIndices.begin(), actualIndices.end(), expectedIndices.begin()));
+        }
+    }
+
+    Data findConvertedShape(const Data& shape) {
+        for (const auto& consumer : shape->consumers()) {
+            if (consumer->type() == StageType::Gather) {
+                return consumer->output(0);
+            }
+        }
+        return nullptr;
+    }
+
+    void checkDataToShapeDependency(const Data& shape, const Data& data) {
+        ASSERT_FALSE(shape->childDataToShapeEdges().empty());
+        ASSERT_NE(data->parentDataToShapeEdge(), nullptr);
+
+        const auto& edge = data->parentDataToShapeEdge();
+
+        ASSERT_EQ(edge->child(), data);
+        ASSERT_EQ(edge->parent(), shape);
+    }
+
+    void checkStageDependency(const Data& shape, const Stage& stage) {
+        ASSERT_FALSE(shape->dependentStagesEdges().empty());
+        const auto& dependentStagesEdges = shape->dependentStagesEdges();
+
+        auto it = std::find_if(dependentStagesEdges.begin(), dependentStagesEdges.end(),
+                               [&stage](const StageDependency& edge) {
+                                   return edge->dependentStage() == stage;
+                               });
+
+        ASSERT_NE(it, dependentStagesEdges.end());
+    }
+
+    void checkNoDataToShapeDependency(const Data& shape, const Data& data) {
+        ASSERT_TRUE(!data->parentDataToShapeEdge() || data->parentDataToShapeEdge()->parent() != shape);
+
+        const auto& childDataToShapeEdges = shape->childDataToShapeEdges();
+
+        auto it = std::find_if(childDataToShapeEdges.begin(), childDataToShapeEdges.end(),
+                               [&data](const DataToShapeAllocation& edge) {
+                                   return edge->child() == data;
+                               });
+
+        ASSERT_EQ(it, childDataToShapeEdges.end());
+    }
+
+    void checkNoStageDependency(const Data& shape, const Stage& stage) {
+        const auto& dependentStagesEdges = shape->dependentStagesEdges();
+
+        auto it = std::find_if(dependentStagesEdges.begin(), dependentStagesEdges.end(),
+                               [&stage](const StageDependency& edge) {
+                                   return edge->dependentStage() == stage;
+                               });
+
+        ASSERT_EQ(it, shape->dependentStagesEdges().end());
+    }
+
+    void checkGathers(int gathersCount) {
+        ASSERT_EQ(getGathersCount(), gathersCount);
+        checkGatherParams();
+    }
+
+    void checkShapeWithConsumers(const Data& shape, const DataVector& datasConsumingShape) {
+        const auto convertedShape = findConvertedShape(shape);
+
+        for (const auto& dataConsumingShape : datasConsumingShape) {
+            checkDataToShapeDependency(convertedShape, dataConsumingShape);
+            checkNoDataToShapeDependency(shape, dataConsumingShape);
+
+            Stage dependentStage;
+            if (shape->producer() && shape->producer() == dataConsumingShape->producer()) {
+                dependentStage = dataConsumingShape->singleConsumer();
+            } else {
+                ASSERT_NE(dataConsumingShape->producer(), nullptr);
+                dependentStage = dataConsumingShape->producer();
+            }
+
+            checkStageDependency(convertedShape, dependentStage);
+            checkNoStageDependency(shape, dependentStage);
+        }
+    }
+
+protected:
+    PassSet _pipeline;
+    TestModel _testModel;
+};
+
+TEST_F(ConvertShapeNotationTests, BothDataAndShapeIntermediate) {
+    //
+    //                    -> [Shape] -> (Stage) -> [Output]
+    // [Input] -> (Stage)       |
+    //                    -> [Data]  -> (Stage) -> [Output]
+    //
+
+    const DataDesc desc{1};
+
+    _testModel.createInputs({desc});
+    _testModel.createOutputs({desc, desc});
+
+    auto shapeProducer = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
+                                                                          OutputInfo::intermediate(desc)});
+    _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
+    _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
+
+    auto model = _testModel.getBaseModel();
+
+    ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(0)));
+
+    ASSERT_NO_THROW(Compile());
+
+    checkGathers(1);
+    checkShapeWithConsumers(shapeProducer->output(1), {shapeProducer->output(0)});
+}
+
+TEST_F(ConvertShapeNotationTests, DataOutputShapeIntermediate) {
+    //
+    //                    -> [Shape] -> (Stage) -> [Output]
+    // [Input] -> (Stage)       |
+    //                    -> [Data]
+    //
+
+    const DataDesc desc{1};
+
+    _testModel.createInputs({desc});
+    _testModel.createOutputs({desc, desc});
+
+    auto shapeProducer = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(0),
+                                                                          OutputInfo::intermediate(desc)});
+    _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
+
+    auto model = _testModel.getBaseModel();
+
+    ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(0)));
+
+    ASSERT_NO_THROW(Compile());
+
+    checkGathers(1);
+    checkShapeWithConsumers(shapeProducer->output(1), {});
+}
+
+TEST_F(ConvertShapeNotationTests, DataIntermediateShapeOutput) {
+    //
+    //                    -> [Shape]
+    // [Input] -> (Stage)       |
+    //                    -> [Data]  -> (Stage) -> [Output]
+    //
+
+    const DataDesc desc{1};
+
+    _testModel.createInputs({desc});
+    _testModel.createOutputs({desc, desc});
+
+    auto shapeProducer = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
+                                                                          OutputInfo::fromNetwork(1)});
+    _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
+
+    auto model = _testModel.getBaseModel();
+
+    ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(0)));
+
+    ASSERT_NO_THROW(Compile());
+
+    checkGathers(1);
+    checkShapeWithConsumers(shapeProducer->output(1), {shapeProducer->output(0)});
+}
+
+TEST_F(ConvertShapeNotationTests, BothDataAndShapeOutput) {
+    //
+    //                    -> [Shape]
+    // [Input] -> (Stage)       |
+    //                    -> [Data]
+    //
+
+    const DataDesc desc{1};
+
+    _testModel.createInputs({desc});
+    _testModel.createOutputs({desc, desc});
+
+    auto shapeProducer = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(0),
+                                                                          OutputInfo::fromNetwork(1)});
+
+    auto model = _testModel.getBaseModel();
+
+    ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(0)));
+
+    ASSERT_NO_THROW(Compile());
+
+    checkGathers(1);
+    checkShapeWithConsumers(shapeProducer->output(1), {});
+}
+
+TEST_F(ConvertShapeNotationTests, TwoShapeConsumersAllInterm) {
+    //
+    //                    -> [Data]  -> (Stage) -> [Output]
+    //                          |
+    // [Input] -> (Stage) -> [Shape] -> (Stage) -> [Output]
+    //                          |
+    //                    -> [Data]  -> (Stage) -> [Output]
+    //
+
+    const DataDesc desc{1};
+
+    _testModel.createInputs({desc});
+    _testModel.createOutputs({desc, desc, desc});
+
+    auto shapeProducer = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
+                                                                          OutputInfo::intermediate(desc),
+                                                                          OutputInfo::intermediate(desc)});
+    _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
+    _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
+    _testModel.addStage({InputInfo::fromPrevStage(0).output(2)}, {OutputInfo::fromNetwork(2)});
+
+    auto model = _testModel.getBaseModel();
+
+    ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(0)));
+    ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(2)));
+
+    ASSERT_NO_THROW(Compile());
+
+    checkGathers(1);
+    checkShapeWithConsumers(shapeProducer->output(1), {shapeProducer->output(0), shapeProducer->output(2)});
+}
+
+TEST_F(ConvertShapeNotationTests, TwoShapeConsumersShapeOutput) {
+    //
+    //                    -> [Data]  -> (Stage) -> [Output]
+    //                          |
+    // [Input] -> (Stage) -> [Shape]
+    //                          |
+    //                    -> [Data]  -> (Stage) -> [Output]
+    //
+
+    const DataDesc desc{1};
+
+    _testModel.createInputs({desc});
+    _testModel.createOutputs({desc, desc, desc});
+
+    auto shapeProducer = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
+                                                                          OutputInfo::fromNetwork(1),
+                                                                          OutputInfo::intermediate(desc)});
+    _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
+    _testModel.addStage({InputInfo::fromPrevStage(0).output(2)}, {OutputInfo::fromNetwork(2)});
+
+    auto model = _testModel.getBaseModel();
+
+    ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(0)));
+    ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(2)));
+
+    ASSERT_NO_THROW(Compile());
+
+    checkGathers(1);
+    checkShapeWithConsumers(shapeProducer->output(1), {shapeProducer->output(0), shapeProducer->output(2)});
+}
+
+TEST_F(ConvertShapeNotationTests, DataAndShapeHaveDifferentProducers) {
+    //
+    //                       [Shape] -> (Stage) -> [Shape]
+    // [Input] -> (Stage) ->                          |
+    //                       [Data]  -> (Stage) -> [Data]  -> (Stage) -> [Output]
+    //
+
+    const DataDesc desc{1};
+
+    _testModel.createInputs({desc});
+    _testModel.createOutputs({desc, desc});
+
+    _testModel.addStage({InputInfo::fromNetwork(0)}, {OutputInfo::intermediate(desc), OutputInfo::intermediate(desc)});
+    auto dataProducer = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::intermediate(desc)});
+    auto shapeProducer = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
+    _testModel.addStage({InputInfo::fromPrevStage(1)}, {OutputInfo::fromNetwork(0)});
+
+    auto model = _testModel.getBaseModel();
+
+    ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(0), dataProducer->output(0)));
+
+    ASSERT_NO_THROW(Compile());
+
+    checkGathers(1);
+    checkShapeWithConsumers(shapeProducer->output(0), {dataProducer->output(0)});
+}
+
+TEST_F(ConvertShapeNotationTests, TwoConsumersWithSameShape) {
+    //
+    //                       [Shape]-------------------
+    // [Input] -> (Stage) ->    |                     |
+    //                       [Data]  -> (Stage) -> [Output]
+    //
+
+    const DataDesc desc{1};
+
+    _testModel.createInputs({desc});
+    _testModel.createOutputs({desc, desc});
+
+    auto shapeProducer = _testModel.addStage({InputInfo::fromNetwork(0)}, {OutputInfo::intermediate(desc), OutputInfo::fromNetwork(1)});
+    auto dataProcessor = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
+
+    auto model = _testModel.getBaseModel();
+
+    ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(0)));
+    ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), dataProcessor->output(0)));
+
+    ASSERT_NO_THROW(Compile());
+
+    checkGathers(1);
+    checkShapeWithConsumers(shapeProducer->output(1), {shapeProducer->output(0), dataProcessor->output(0)});
+}
+
+TEST_F(ConvertShapeNotationTests, ThreeConsumersWithSameShape) {
+    //
+    //                       [Shape]-----------------------------------------
+    // [Input] -> (Stage) ->    |                     |                     |
+    //                       [Data]  -> (Stage) -> [Data] -> (Stage) -> [Output]
+    //
+
+    const DataDesc desc{1};
+
+    _testModel.createInputs({desc});
+    _testModel.createOutputs({desc, desc});
+
+    auto shapeProducer = _testModel.addStage({InputInfo::fromNetwork(0)}, {OutputInfo::intermediate(desc), OutputInfo::fromNetwork(1)});
+    auto firstDataProcessor = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::intermediate(desc)});
+    auto secondDataProcessor = _testModel.addStage({InputInfo::fromPrevStage(1).output(0)}, {OutputInfo::fromNetwork(0)});
+
+    auto model = _testModel.getBaseModel();
+
+    ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(0)));
+    ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), firstDataProcessor->output(0)));
+    ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), secondDataProcessor->output(0)));
+
+    ASSERT_NO_THROW(Compile());
+
+    checkGathers(1);
+    checkShapeWithConsumers(shapeProducer->output(1), {shapeProducer->output(0), firstDataProcessor->output(0), secondDataProcessor->output(0)});
+}
+
+TEST_F(ConvertShapeNotationTests, TwoShapesTwoConsumers) {
+    //
+    //                       [Shape] -> (Stage) -> [Shape]
+    // [Input] -> (Stage) ->    |                     |
+    //                       [Data]  -> (Stage) -> [Data]  -> (Stage) -> [Output]
+    //
+
+    const DataDesc desc{1};
+
+    _testModel.createInputs({desc});
+    _testModel.createOutputs({desc, desc});
+
+    auto firstShapeProducer = _testModel.addStage({InputInfo::fromNetwork(0)}, {OutputInfo::intermediate(desc), OutputInfo::intermediate(desc)});
+    auto firstDataProducer = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::intermediate(desc)});
+    auto secondShapeProducer = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
+    auto secondDataProducer = _testModel.addStage({InputInfo::fromPrevStage(1)}, {OutputInfo::fromNetwork(0)});
+
+    auto model = _testModel.getBaseModel();
+
+    ASSERT_NO_THROW(model->connectDataWithShape(firstShapeProducer->output(1), firstShapeProducer->output(0)));
+    ASSERT_NO_THROW(model->connectDataWithShape(secondShapeProducer->output(0), firstDataProducer->output(0)));
+
+    ASSERT_NO_THROW(Compile());
+
+    checkGathers(2);
+    checkShapeWithConsumers(firstShapeProducer->output(1), {firstShapeProducer->output(0)});
+    checkShapeWithConsumers(secondShapeProducer->output(0), {firstDataProducer->output(0)});
+}
+
+} // namespace vpu

--- a/inference-engine/tests_deprecated/functional/vpu/common/layers/myriad_layers_nonzero_test.hpp
+++ b/inference-engine/tests_deprecated/functional/vpu/common/layers/myriad_layers_nonzero_test.hpp
@@ -62,8 +62,8 @@ protected:
 
         const auto totalDimsSize = refIndicesBlob->getTensorDesc().getDims()[1];
 
-        for (int axis = 0; axis < outputDimsPtr[1]; ++axis) {
-            for (int i = 0; i < outputDimsPtr[0]; ++i) {
+        for (int axis = 0; axis < outputDimsPtr[0]; ++axis) {
+            for (int i = 0; i < outputDimsPtr[1]; ++i) {
                 const auto idx = i + axis * totalDimsSize;
                 ASSERT_EQ(outputIndicesPtr[idx], refIndicesPtr[idx]);
             }

--- a/inference-engine/tests_deprecated/functional/vpu/vpu_base/myriad_layers_reference_functions.cpp
+++ b/inference-engine/tests_deprecated/functional/vpu/vpu_base/myriad_layers_reference_functions.cpp
@@ -3006,6 +3006,6 @@ void ref_nonZero(const InferenceEngine::Blob::Ptr& src,
         }
     }
 
-    outDimsPtr[0] = numNonZeros;
-    outDimsPtr[1] = src->getTensorDesc().getDims().size();
+    outDimsPtr[0] = src->getTensorDesc().getDims().size();
+    outDimsPtr[1] = numNonZeros;
 }


### PR DESCRIPTION
Ticket: #-31394
Changes:
- Add pass for converting shape notation (from IE to MDK one)
- Reflect changes on device side (NonZero now gives shape in IE notation)