### PR TITLE
[IE CLDNN] Update tuning cache and enable tuning for fsv16 format

### DIFF
--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_kernel_bfyx_os_iyx_osv16.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_kernel_bfyx_os_iyx_osv16.cpp
@@ -219,7 +219,6 @@ JitConstants ConvolutionKernel_bfyx_os_iyx_osv16::GetJitConstants(const convolut
         jit.Merge(MakeFusedOpsJitConstants(params, {conf_scalar}));
     }
 
-
     jit.AddConstant(MakeJitConstant("SUB_GROUP_SIZE", runInfo.lws2));
     jit.AddConstant(MakeJitConstant("OUTPUT_BLOCK_WIDTH", runInfo.cldnnStyle.blockWidth));
     jit.AddConstant(MakeJitConstant("OUTPUT_BLOCK_HEIGHT", runInfo.cldnnStyle.blockHeight));
@@ -242,6 +241,13 @@ WeightsLayout ConvolutionKernel_bfyx_os_iyx_osv16::GetPreferredWeightsLayout(
 KernelsData ConvolutionKernel_bfyx_os_iyx_osv16::GetKernelsData(const Params& params,
                                                                 const optional_params& options) const {
     return GetTunedKernelsDataByIndex(params, options);
+}
+
+KernelsData ConvolutionKernel_bfyx_os_iyx_osv16::GetTunedKernelsDataByIndex(const Params& params,
+                                                                            const optional_params& options,
+                                                                            const int autoTuneIndex) const {
+    auto autoTuneOption = GetAutoTuneOptions(params, autoTuneIndex);
+    return GetCommonKernelsData(params, options, autoTuneOption.exeMode, autoTuneIndex);
 }
 
 KernelsData ConvolutionKernel_bfyx_os_iyx_osv16::GetKernelsDataForAutoTune(const Params& params,

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_kernel_bfyx_os_iyx_osv16.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_kernel_bfyx_os_iyx_osv16.h
@@ -28,6 +28,7 @@ public:
     virtual ~ConvolutionKernel_bfyx_os_iyx_osv16() {}
 
     KernelsData GetKernelsData(const Params& params, const optional_params& options) const override;
+    KernelsData GetTunedKernelsDataByIndex(const Params& params, const optional_params& options, int autoTuneIndex = -1) const override;
     KernelsData GetKernelsDataForAutoTune(const Params& params, const optional_params& options) const override;
     ParamsKey GetSupportedKey() const override;
 

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/auto_tuner.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/auto_tuner.h
@@ -61,6 +61,7 @@ public:
 private:
     Entry LoadKernel_v1(const Params& params, uint32_t computeUnitsCount);
     Entry LoadKernel_v2(const Params& params, uint32_t computeUnitsCount);
+    Entry LoadKernel_v2_wa(const Params& params, uint32_t computeUnitsCount, std::string wa_name);
 
     bool RemoveKernel_v1(const Params& params, uint32_t computeUnitsCount);
     bool RemoveKernel_v2(const Params& params, uint32_t computeUnitsCount);

--- a/inference-engine/thirdparty/clDNN/src/gpu/kernel_runner.h
+++ b/inference-engine/thirdparty/clDNN/src/gpu/kernel_runner.h
@@ -33,8 +33,8 @@ public:
     std::vector<std::chrono::nanoseconds> run_kernels(const kernel_selector::KernelsData& kernelsData) override;
 
 private:
-    const int compilation_batch_size = 50;
-    const int runs_per_kernel = 15;
+    const int compilation_batch_size = 9;
+    const int runs_per_kernel = 5;
 
     void prepare_kernel_args(const kernel_selector::KernelsData& kernels_data,
                              gpu::kernel::kernel_arguments_data& args);

--- a/inference-engine/thirdparty/clDNN/tests/test_cases/cache_test.cpp
+++ b/inference-engine/thirdparty/clDNN/tests/test_cases/cache_test.cpp
@@ -77,7 +77,7 @@ R"__a({
     "version_2": {
         "__EUs__": {
             "CONVOLUTION": {
-                "F32_BFYX_v3_p0_0_v3_p0_0_v16_p0_0_v1_p0_0;F32_BFYX_v3_p0_0_v3_p0_0_v16_p0_0_v1_p0_0;1_1_1;1_1_1;1_1_1;0_0_0;1;1": ["fused_conv_eltwise_gpu_ref", 0]
+                "F32_BFYX_v3_p0_0_v3_p0_0_v16_p0_0_v1_p0_0;F32_BFYX_v3_p0_0_v3_p0_0_v16_p0_0_v1_p0_0;1_1_1;1_1_1;1_1_1;0_0_0;1;1;no_fused_ops": ["fused_conv_eltwise_gpu_ref", 0]
             }
         }
     },


### PR DESCRIPTION
This patch has been implemented by @leszczyn and is meant to:
- Enable tuning for blocked format (fsv16)
- Update cache file
- Remove WAs for old cache
- Replace old v1 cache lines with the new v2 ones

JIRA: CVS-29077