### PR TITLE
MO: Flush after dumping the arguments to stdout

### DIFF
--- a/model-optimizer/mo/main.py
+++ b/model-optimizer/mo/main.py
@@ -92,7 +92,7 @@ def print_argv(argv: argparse.Namespace, is_caffe: bool, is_tf: bool, is_mxnet: 
                         continue
                 lines.append('\t{}: \t{}'.format(desc, getattr(argv, op, 'NONE')))
     lines.append('Model Optimizer version: \t{}'.format(get_version()))
-    print('\n'.join(lines))
+    print('\n'.join(lines), flush=True)
 
 
 def prepare_ir(argv: argparse.Namespace):


### PR DESCRIPTION
When stdout is not a terminal, Python will buffer it by default. This means that a consumer of MO's output will not see the argument information until the buffer is flushed, which will normally only happen once MO finishes (which might take a while).

Flushing stdout explicitly allows the consumer to see this info as soon as it's printed.