### PR TITLE
[IE CLDNN] Optimized FQ kernel in fsv16 layout

### DIFF
--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/activation/activation_kernel_opt.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/activation/activation_kernel_opt.cpp
@@ -76,11 +76,13 @@ bool ActivationKernelOpt::Validate(const Params& p, const optional_params& o) co
         return false;
     }
 
+
     if (params.output.GetLayout() != params.inputs[0].GetLayout())
         return false;
 
-    if (!params.fused_ops.empty() && params.output.GetLayout() != DataLayout::bfyx &&
-        params.output.GetLayout() != DataLayout::bfzyx)
+    if (!params.fused_ops.empty() &&
+        ((params.output.GetLayout() != DataLayout::bfyx && params.output.GetLayout() != DataLayout::bfzyx) ||
+        ((params.output.X().v * params.output.Y().v) % 4 != 0)))
         return false;
 
     return true;

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/quantize/quantize_kernel_base.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/quantize/quantize_kernel_base.cpp
@@ -33,7 +33,7 @@ bool QuantizeKernelBase::Validate(const Params& p, const optional_params&) const
     return true;
 }
 
-JitConstants QuantizeKernelBase::GetJitConstants(const quantize_params& params) const {
+JitConstants QuantizeKernelBase::GetJitConstants(const quantize_params& params, const CommonDispatchData& runInfo) const {
     JitConstants jit = MakeBaseParamsJitConstants(params);
 
     if (params.packed_binary_output) {
@@ -55,6 +55,10 @@ JitConstants QuantizeKernelBase::GetJitConstants(const quantize_params& params) 
 
     jit.AddConstant(MakeJitConstant("LEVELS", static_cast<float>(params.levels)));
 
+    jit.AddConstant(MakeJitConstant("LWS_0", runInfo.lws0));
+    jit.AddConstant(MakeJitConstant("LWS_1", runInfo.lws1));
+    jit.AddConstant(MakeJitConstant("LWS_2", runInfo.lws2));
+
     return jit;
 }
 
@@ -70,7 +74,7 @@ KernelsData QuantizeKernelBase::GetKernelsData(const Params& params, const optio
 
     auto runInfo = SetDefault(newParams, options);
     auto entry_point = GetEntryPoint(kernelName, newParams.layerID, options);
-    auto cldnn_jit = GetJitConstants(newParams);
+    auto cldnn_jit = GetJitConstants(newParams, runInfo);
     std::string jit = CreateJit(kernelName, cldnn_jit, entry_point);
 
     auto& kernel = kd.kernels[0];

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/quantize/quantize_kernel_base.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/quantize/quantize_kernel_base.h
@@ -25,9 +25,11 @@ public:
     using common_kernel_base::common_kernel_base;
     virtual ~QuantizeKernelBase() {}
 
-    virtual JitConstants GetJitConstants(const quantize_params& params) const;
-    virtual CommonDispatchData SetDefault(const quantize_params& params, const optional_params&) const = 0;
     bool Validate(const Params& p, const optional_params& o) const override;
     KernelsData GetKernelsData(const Params& params, const optional_params& options) const override;
+
+protected:
+    virtual JitConstants GetJitConstants(const quantize_params& params, const CommonDispatchData& runInfo) const;
+    virtual CommonDispatchData SetDefault(const quantize_params& params, const optional_params&) const = 0;
 };
 }  // namespace kernel_selector

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/quantize/quantize_kernel_params.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/quantize/quantize_kernel_params.h
@@ -22,12 +22,47 @@ namespace kernel_selector {
 // quantize_params
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 struct quantize_params : public base_params {
-    quantize_params() : base_params(KernelType::QUANTIZE),
-    levels(0), packed_binary_output(false), scale_shift_opt(false) {}
+    quantize_params()
+    : base_params(KernelType::QUANTIZE)
+    , levels(0)
+    , packed_binary_output(false)
+    , scale_shift_opt(false)
+    , has_post_scale(true)
+    , has_post_shift(true)
+    , has_pre_shift(true)
+    , has_clamp(true)
+    , per_tensor_input_range(false)
+    , per_tensor_input_scale(false)
+    , per_tensor_input_shift(false)
+    , per_tensor_output_scale(false)
+    , per_tensor_output_shift(false)
+    , in_lo(0.0f)
+    , in_hi(0.0f)
+    , in_scale(0.0f)
+    , in_shift(0.0f)
+    , out_scale(0.0f)
+    , out_shift(0.0f) { }
 
     int levels;
     bool packed_binary_output;
     bool scale_shift_opt;
+    bool has_post_scale;
+    bool has_post_shift;
+    bool has_pre_shift;
+    bool has_clamp;
+
+    bool per_tensor_input_range;
+    bool per_tensor_input_scale;
+    bool per_tensor_input_shift;
+    bool per_tensor_output_scale;
+    bool per_tensor_output_shift;
+
+    float in_lo;
+    float in_hi;
+    float in_scale;
+    float in_shift;
+    float out_scale;
+    float out_shift;
 
     virtual ParamsKey GetParamsKey() const {
         auto k = base_params::GetParamsKey();

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/quantize/quantize_kernel_ref.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/quantize/quantize_kernel_ref.h
@@ -26,7 +26,7 @@ public:
     QuantizeKernelRef() : QuantizeKernelBase("quantize_gpu_ref") {}
     virtual ~QuantizeKernelRef() {}
 
-    JitConstants GetJitConstants(const quantize_params& params) const override;
+    JitConstants GetJitConstants(const quantize_params& params, const CommonDispatchData& runInfo) const override;
     CommonDispatchData SetDefault(const quantize_params& params, const optional_params&) const override;
     bool Validate(const Params& p, const optional_params& o) const override;
     ParamsKey GetSupportedKey() const override;

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/quantize/quantize_kernel_scale_shift_opt.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/quantize/quantize_kernel_scale_shift_opt.cpp
@@ -18,6 +18,8 @@
 #include "kernel_selector_utils.h"
 #include <string>
 
+static const size_t sub_group_size = 32;
+
 namespace kernel_selector {
 ParamsKey QuantizeKernelScaleShift::GetSupportedKey() const {
     ParamsKey k;
@@ -60,27 +62,60 @@ CommonDispatchData QuantizeKernelScaleShift::SetDefault(const quantize_params& p
 
     auto output = params.output;
 
-    auto global = GetTensorFriendlyWorkGroups(output);
-    auto local = GetOptimalLocalWorkGroupSizes(global, params.engineInfo);
+    if (output.GetLayout() == DataLayout::b_fs_yx_fsv16) {
+        runInfo.gws0 = output.Y().v * output.X().v;
+        runInfo.gws1 = Align(output.Feature().v, sub_group_size);
+        runInfo.gws2 = output.Batch().v;
 
-    runInfo.gws0 = global[0];
-    runInfo.gws1 = global[1];
-    runInfo.gws2 = global[2];
+        runInfo.lws0 = 1;
+        runInfo.lws1 = sub_group_size;
+        runInfo.lws2 = 1;
+    } else {
+        auto global = GetTensorFriendlyWorkGroups(output);
+        auto local = GetOptimalLocalWorkGroupSizes(global, params.engineInfo);
 
-    runInfo.lws0 = local[0];
-    runInfo.lws1 = local[1];
-    runInfo.lws2 = local[2];
+        runInfo.gws0 = global[0];
+        runInfo.gws1 = global[1];
+        runInfo.gws2 = global[2];
+
+        runInfo.lws0 = local[0];
+        runInfo.lws1 = local[1];
+        runInfo.lws2 = local[2];
+    }
 
     runInfo.fp16UnitUsed = params.inputs[0].GetDType() == Datatype::F16;
 
     return runInfo;
 }
 
-JitConstants QuantizeKernelScaleShift::GetJitConstants(const quantize_params& params) const {
-    JitConstants jit = Parent::GetJitConstants(params);
+JitConstants QuantizeKernelScaleShift::GetJitConstants(const quantize_params& params, const CommonDispatchData& runInfo) const {
+    JitConstants jit = Parent::GetJitConstants(params, runInfo);
 
-    auto tensor_jits = GetTensorFriendlyWorkGroupsJit(params.output);
-    jit.Merge(tensor_jits);
+    if (params.output.GetLayout() == DataLayout::b_fs_yx_fsv16) {
+        jit.AddConstant(MakeJitConstant("GWS_BATCH", 2));
+        jit.AddConstant(MakeJitConstant("GWS_FEATURE", 1));
+        jit.AddConstant(MakeJitConstant("GWS_YX", 0));
+        jit.AddConstant(MakeJitConstant("SUB_GROUP_SIZE", sub_group_size));
+    } else {
+        auto tensor_jits = GetTensorFriendlyWorkGroupsJit(params.output);
+        jit.Merge(tensor_jits);
+    }
+
+    jit.AddConstant(MakeJitConstant("HAS_POST_SCALE", params.has_post_scale));
+    jit.AddConstant(MakeJitConstant("HAS_POST_SHIFT", params.has_post_shift));
+    jit.AddConstant(MakeJitConstant("HAS_PRE_SHIFT", params.has_pre_shift));
+    jit.AddConstant(MakeJitConstant("HAS_CLAMP", params.has_clamp));
+    jit.AddConstant(MakeJitConstant("PER_TENSOR_INPUT_RANGE", params.per_tensor_input_range));
+    jit.AddConstant(MakeJitConstant("PER_TENSOR_INPUT_SCALE", params.per_tensor_input_scale));
+    jit.AddConstant(MakeJitConstant("PER_TENSOR_INPUT_SHIFT", params.per_tensor_input_shift));
+    jit.AddConstant(MakeJitConstant("PER_TENSOR_OUTPUT_SCALE", params.per_tensor_output_scale));
+    jit.AddConstant(MakeJitConstant("PER_TENSOR_OUTPUT_SHIFT", params.per_tensor_output_shift));
+    jit.AddConstant(MakeJitConstant("IN_LO_VAL", params.in_lo));
+    jit.AddConstant(MakeJitConstant("IN_HI_VAL", params.in_hi));
+    jit.AddConstant(MakeJitConstant("IN_SCALE_VAL", params.in_scale));
+    jit.AddConstant(MakeJitConstant("IN_SHIFT_VAL", params.in_shift));
+    jit.AddConstant(MakeJitConstant("OUT_SCALE_VAL", params.out_scale));
+    jit.AddConstant(MakeJitConstant("OUT_SHIFT_VAL", params.out_shift));
 
     return jit;
 }

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/quantize/quantize_kernel_scale_shift_opt.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/quantize/quantize_kernel_scale_shift_opt.h
@@ -26,7 +26,7 @@ public:
     QuantizeKernelScaleShift() : QuantizeKernelBase("quantize_gpu_scale_shift_opt") {}
     virtual ~QuantizeKernelScaleShift() {}
 
-    JitConstants GetJitConstants(const quantize_params& params) const override;
+    JitConstants GetJitConstants(const quantize_params& params, const CommonDispatchData& runInfo) const override;
     CommonDispatchData SetDefault(const quantize_params& params, const optional_params&) const override;
     bool Validate(const Params& p, const optional_params& o) const override;
     ParamsKey GetSupportedKey() const override;

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/quantize_gpu_scale_shift_opt.cl
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/quantize_gpu_scale_shift_opt.cl
@@ -16,6 +16,10 @@
 #include "include/data_types.cl"
 #include "include/fetch.cl"
 
+#ifdef SUB_GROUP_SIZE
+__attribute__((intel_reqd_sub_group_size(SUB_GROUP_SIZE)))
+#endif
+__attribute__((reqd_work_group_size(LWS_0, LWS_1, LWS_2)))
 KERNEL(quantize_gpu_scale_shift_opt)(const __global INPUT0_TYPE* input,
                                      const __global INPUT1_TYPE* input_low,
                                      const __global INPUT2_TYPE* input_high,
@@ -52,10 +56,12 @@ KERNEL(quantize_gpu_scale_shift_opt)(const __global INPUT0_TYPE* input,
     const int output_offset = OUTPUT_GET_INDEX(b, of, y, x);
 #endif
 
+#if HAS_CLAMP && !PER_TENSOR_INPUT_RANGE
 #if INPUT1_DIMS == 4
     const int in_range_offset = INPUT1_GET_INDEX_SAFE(b, of, y, x);
 #elif INPUT1_DIMS == 5
     const int in_range_offset = INPUT1_GET_INDEX_SAFE(b, of, z, y, x);
+#endif
 #endif
 
 #if INPUT7_DIMS == 4
@@ -64,17 +70,61 @@ KERNEL(quantize_gpu_scale_shift_opt)(const __global INPUT0_TYPE* input,
     const int scales_offset = INPUT7_GET_INDEX_SAFE(b, of, z, y, x);
 #endif
 
+#if PER_TENSOR_INPUT_SCALE
+    INPUT1_TYPE input_scale_val  = IN_SCALE_VAL;
+#else
     INPUT1_TYPE input_scale_val  = input_scale[scales_offset];
+#endif
+#if PER_TENSOR_INPUT_SHIFT
+    INPUT1_TYPE input_shift_val  = IN_SHIFT_VAL;
+#else
     INPUT1_TYPE input_shift_val  = input_shift[scales_offset];
+#endif
+
+#if PER_TENSOR_OUTPUT_SCALE
+    INPUT1_TYPE output_scale_val = OUT_SCALE_VAL;
+#else
     INPUT1_TYPE output_scale_val = output_scale[scales_offset];
+#endif
+
+#if PER_TENSOR_OUTPUT_SHIFT
+    INPUT1_TYPE output_shift_val = OUT_SHIFT_VAL;
+#else
     INPUT1_TYPE output_shift_val = output_shift[scales_offset];
+#endif
+
+#if PER_TENSOR_INPUT_RANGE && HAS_CLAMP
+    INPUT1_TYPE input_low_val    = IN_LO_VAL;
+    INPUT1_TYPE input_high_val   = IN_HI_VAL;
+#elif HAS_CLAMP
     INPUT1_TYPE input_low_val    = input_low[in_range_offset];
     INPUT1_TYPE input_high_val   = input_high[in_range_offset];
-    INPUT1_TYPE val = min(max(TO_INPUT1_TYPE(input[input_offset]),input_low_val), input_high_val);
-#if OUTPUT_IS_FP
-    output[output_offset] = TO_OUTPUT_TYPE_SAT(round(val * input_scale_val + input_shift_val) * output_scale_val + output_shift_val);
+#endif
+
+#if HAS_CLAMP
+    INPUT1_TYPE val = min(max(TO_INPUT1_TYPE(input[input_offset]), input_low_val), input_high_val);
 #else
-    // TODO: the outer round should be deleted once output range is correct
-    output[output_offset] = TO_OUTPUT_TYPE_SAT(round(round(val * input_scale_val + input_shift_val) * output_scale_val + output_shift_val));
+    INPUT1_TYPE val = TO_INPUT1_TYPE(input[input_offset]);
+#endif
+#if HAS_PRE_SHIFT
+    val = round(val * input_scale_val + input_shift_val);
+#else
+    val = round(val * input_scale_val);
+#endif
+
+#if HAS_POST_SCALE
+    val = val*output_scale_val;
+#endif
+#if HAS_POST_SHIFT
+    val += output_shift_val;
+#endif
+
+#if OUTPUT_LAYOUT_B_FS_YX_FSV16
+    if (of < OUTPUT_FEATURE_NUM)
+#endif
+#if OUTPUT_IS_FP
+    output[output_offset] = TO_OUTPUT_TYPE_SAT(val);
+#else
+    output[output_offset] = TO_OUTPUT_TYPE_SAT(round(val));
 #endif
 }

--- a/inference-engine/thirdparty/clDNN/src/gpu/quantize_gpu.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/quantize_gpu.cpp
@@ -57,9 +57,26 @@ public:
         auto quantize_optional_params =
             get_default_optional_params<kernel_selector::quantize_optional_params>(arg.get_program());
 
-        quantize_params.levels = arg.get_primitive()->levels;
-        quantize_params.packed_binary_output = arg.get_output_layout().data_type == data_types::bin;
+        quantize_params.levels = arg.get_levels();
+        quantize_params.packed_binary_output = arg.get_packed_binary_output();
         quantize_params.scale_shift_opt = arg.get_scale_shift_opt();
+        quantize_params.has_post_scale = arg.get_need_post_scale();
+        quantize_params.has_post_shift = arg.get_need_post_shift();
+        quantize_params.has_pre_shift = arg.get_need_pre_shift();
+        quantize_params.has_clamp = arg.get_need_clamp();
+
+        quantize_params.per_tensor_input_range = arg.get_per_tensor_input_range();
+        quantize_params.per_tensor_input_scale = arg.get_per_tensor_input_scale();
+        quantize_params.per_tensor_input_shift = arg.get_per_tensor_input_shift();
+        quantize_params.per_tensor_output_scale = arg.get_per_tensor_output_scale();
+        quantize_params.per_tensor_output_shift = arg.get_per_tensor_output_shift();
+
+        quantize_params.in_lo = arg.get_input_lo_val();
+        quantize_params.in_hi = arg.get_input_hi_val();
+        quantize_params.in_scale = arg.get_input_scale_val();
+        quantize_params.in_shift = arg.get_input_shift_val();
+        quantize_params.out_scale = arg.get_output_scale_val();
+        quantize_params.out_shift = arg.get_output_shift_val();
 
         for (size_t i = 1; i < arg.inputs_count(); i++) {
             quantize_params.inputs.push_back(convert_data_tensor(arg.input(i).get_output_layout()));

--- a/inference-engine/thirdparty/clDNN/src/graph_optimizer/prepare_quantization.cpp
+++ b/inference-engine/thirdparty/clDNN/src/graph_optimizer/prepare_quantization.cpp
@@ -111,9 +111,6 @@ void prepare_quantization::prepare_scale_shift_opt(program_impl &p) {
             if (levels == 2 || levels > 256 || quantize_node.get_scale_shift_opt() || quantize_node.is_constant())
                 return;
 
-            if (quantize_node.input().get_output_layout().data_type == data_types::f16)
-                return;
-
             auto &input_low = quantize_node.get_dependency(1).template as<data>();
             auto &input_high = quantize_node.get_dependency(2).template as<data>();
             auto &output_low = quantize_node.get_dependency(3).template as<data>();

--- a/inference-engine/thirdparty/clDNN/src/include/quantize_inst.h
+++ b/inference-engine/thirdparty/clDNN/src/include/quantize_inst.h
@@ -34,8 +34,25 @@ public:
 
     program_node& input(size_t index = 0) const { return get_dependency(index); }
     size_t inputs_count() const { return get_dependencies().size(); }
+    int get_levels() const { return get_primitive()->levels; }
+    bool get_packed_binary_output() const { return get_output_layout().data_type == data_types::bin; }
     bool get_scale_shift_opt() const { return scale_shift_opt; }
-    bool get_need_pre_shift() { return need_pre_shift; }
+    bool get_need_pre_shift() const { return need_pre_shift; }
+    bool get_need_post_scale() const { return need_post_scale; }
+    bool get_need_post_shift() const { return need_post_shift; }
+    bool get_need_clamp() const { return need_clamp; }
+    bool get_per_tensor_input_scale() const { return per_tensor_input_scale; }
+    bool get_per_tensor_input_shift() const { return per_tensor_input_shift; }
+    bool get_per_tensor_input_range() const { return per_tensor_input_range; }
+    bool get_per_tensor_output_scale() const { return per_tensor_output_scale; }
+    bool get_per_tensor_output_shift() const { return per_tensor_output_shift; }
+    float get_input_scale_val() const { return in_scale; }
+    float get_input_shift_val() const { return in_shift; }
+    float get_input_lo_val() const { return in_lo; }
+    float get_input_hi_val() const { return in_hi; }
+    float get_output_scale_val() const { return out_scale; }
+    float get_output_shift_val() const { return out_shift; }
+
     void set_scale_shift_opt() { scale_shift_opt = true; }
     void set_need_post_scale() { need_post_scale = true; }
     void set_need_post_shift() { need_post_shift = true; }


### PR DESCRIPTION
- Changed lws for fsv16 quantize kernels to improve the performance of standalone FQ layers
- Enable scale-shift opt for fp16. This is needed to fuse FQ to FP16 operations on legacy HW to minimize the difference between quantized and non-quantized models performance