### PR TITLE
Implement Bucketize in MO and MKLDNN for opset3

### DIFF
--- a/inference-engine/include/ie_layers.h
+++ b/inference-engine/include/ie_layers.h
@@ -1774,7 +1774,7 @@ public:
     /**
      * @brief Indicates whether the intervals include the right or the left bucket edge.
      */
-    bool with_right_bound = false;
+    bool with_right_bound = true;
 
     /**
     * @brief Creates a new BucketizeLayer instance.

--- a/inference-engine/src/legacy_api/src/ie_layer_validators.cpp
+++ b/inference-engine/src/legacy_api/src/ie_layer_validators.cpp
@@ -1776,7 +1776,7 @@ void BucketizeValidator::parseParams(CNNLayer* layer) {
         THROW_IE_EXCEPTION << layer->name << " Layer is not instance of Bucketize class";
     }
 
-    casted->with_right_bound = casted->GetParamAsBool("with_right_bound");
+    casted->with_right_bound = casted->GetParamAsBool("with_right_bound", true);
 }
 
 void BucketizeValidator::checkParams(const CNNLayer* layer) {

--- a/model-optimizer/automation/package_BOM.txt
+++ b/model-optimizer/automation/package_BOM.txt
@@ -936,6 +936,7 @@ mo/utils/ir_engine/ir_engine.py
 mo/utils/ir_reader/__init__.py
 mo/utils/ir_reader/extender.py
 mo/utils/ir_reader/extenders/binary_convolution_extender.py
+mo/utils/ir_reader/extenders/bucketize_extender.py
 mo/utils/ir_reader/extenders/conv_extender.py
 mo/utils/ir_reader/extenders/convert_extender.py
 mo/utils/ir_reader/extenders/deconvolution_extender.py

--- a/model-optimizer/extensions/ops/bucketize.py
+++ b/model-optimizer/extensions/ops/bucketize.py
@@ -17,6 +17,7 @@
 import numpy as np
 
 from mo.graph.graph import Node, Graph
+from mo.middle.passes.convert_data_type import np_data_type_to_destination_type
 from mo.ops.op import Op
 
 
@@ -28,28 +29,52 @@ class Bucketize(Op):
             'kind': 'op',
             'type': __class__.op,
             'op': __class__.op,
-            'version': 'extension',
+            'version': 'opset3',
+
             'type_infer': self.type_infer,
             'infer': self.infer,
+
             'in_ports_count': 2,
             'out_ports_count': 1,
         }
         super().__init__(graph, mandatory_props, attrs)
 
-    def supported_attrs(self):
-        return ["with_right_bound"]
+    def backend_attrs(self):
+        version = self.get_opset()
+        if version == "extension":
+            return ['with_right_bound']
+        else:
+            return [
+                'with_right_bound',
+                ('output_type', lambda node: np_data_type_to_destination_type(node.output_type)),
+            ]
 
     @staticmethod
     def type_infer(node):
         # the output is always integer since the layer outputs a bucket index
-        node.out_port(0).set_data_type(np.int32)
+        if node.get_opset() == "extension":
+            node.out_port(0).set_data_type(np.int32)
+        else:
+            assert node.output_type in [np.int64, np.int32], \
+                'Bucketize `output_type` attribute must be int32 or int64, `{}` found'.format(np.dtype(node.output_type).name)
+            node.out_port(0).set_data_type(node.output_type)
 
     @staticmethod
     def infer(node: Node):
+        node_name = node.soft_get('name', node.id)
         assert node.with_right_bound is not None, \
             "Attribute \"with_right_bound\" is not defined"
         assert len(node.in_nodes()) == 2, \
             "Incorrect number of inputs for {} node".format(node.id)
+        if node.get_opset() == "extension":
+            output_type = np.int32
+        else:
+            assert node.has_valid('output_type'), \
+                '`output_type` attribute is not set for Bucketize node `{}`'.format(node_name)
+            assert node.output_type in [np.int64, np.int32], \
+                'Bucketize `output_type` attribute must be int32 or int64, `{}` found'.format(np.dtype(node.output_type).name)
+            output_type = node.output_type
+
         output_shape = node.in_port(0).data.get_shape()
         node.out_port(0).data.set_shape(output_shape)
 
@@ -58,4 +83,4 @@ class Bucketize(Op):
 
         # compute if all input is constant
         if input_value is not None and buckets_value is not None:
-            node.out_port(0).data.set_value(np.digitize(input_value, buckets_value, right=node.with_right_bound))
+            node.out_port(0).data.set_value(np.array(np.digitize(input_value, buckets_value, right=node.with_right_bound), dtype=node.output_type))

--- a/model-optimizer/extensions/ops/bucketize_test.py
+++ b/model-optimizer/extensions/ops/bucketize_test.py
@@ -25,7 +25,7 @@ from mo.utils.unittest.graph import build_graph
 
 nodes_attributes = {'input_tensor': {'shape': None, 'value': None, 'kind': 'data'},
                     'input_buckets': {'shape': None, 'value': None, 'kind': 'data'},
-                    'bucketize_node': {'op': 'Bucketize', 'kind': 'op', 'with_right_bound': False},
+                    'bucketize_node': {'op': 'Bucketize', 'kind': 'op', 'with_right_bound': False, 'output_type': np.int32},
                     'output': {'shape': None, 'value': None, 'kind': 'data'}}
 
 # graph 1

--- a/model-optimizer/mo/utils/ir_reader/extenders/bucketize_extender.py
+++ b/model-optimizer/mo/utils/ir_reader/extenders/bucketize_extender.py
@@ -1,5 +1,5 @@
 """
- Copyright (C) 2018-2020 Intel Corporation
+ Copyright (C) 2020 Intel Corporation
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -13,19 +13,16 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
+from mo.middle.passes.convert_data_type import destination_type_to_np_data_type
 
-import numpy as np
-
-from extensions.ops.bucketize import Bucketize
-from mo.front.extractor import FrontExtractorOp
+from mo.utils.graph import Node
+from mo.utils.ir_reader.extender import Extender
 
 
-class BucketizeFrontExtractor(FrontExtractorOp):
+class BucketizeExtender(Extender):
     op = 'Bucketize'
-    enabled = True
 
-    @classmethod
-    def extract(cls, node):
-        boundaries = np.array(node.pb.attr['boundaries'].list.f, dtype=np.float)
-        Bucketize.update_node_stat(node, {'boundaries': boundaries, 'with_right_bound': False, 'output_type': np.int32})
-        return cls.enabled
+    @staticmethod
+    def extend(op: Node):
+        if op.get_opset() != "extension":
+            op['output_type'] = destination_type_to_np_data_type(op.output_type)


### PR DESCRIPTION
Reviewers: @elazarev, @mvafin, @ykruglov, @pesir

Code:

* [x] Comments
* [x] Code style (PEP8)
* [x] Transformation generates reshape-able IR
* [x] Transformation preserves node names

Validation:

* [x] Unit tests
* [x] Framework layer tests
* [x] Transformation tests: N/A
* [x] e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py: N/A
* [x] MO IR Reader check: manually checked for new graph of Wide and Deep

Documentation:

* [x] Supported frameworks operations list: Bucketize from TF marked as supported
* [x] Supported **public** models list: N/A
* [x] New operations specification
* [x] Guide on how to convert the **public** model: N/A
* [x] User guide update: N/A

Other:

* [x] Sample/Demo application to infer the model: N/A

Additional comments:

This operation is used for Wide and Deep Model. Checked that the model works correctly.
