### PR TITLE
[GNA] Workaround support for callbacks

### DIFF
--- a/inference-engine/src/gna_plugin/gna_infer_request.hpp
+++ b/inference-engine/src/gna_plugin/gna_infer_request.hpp
@@ -69,6 +69,13 @@ class GNAInferRequest : public InferenceEngine::AsyncInferRequestInternal {
         // execute input pre-processing.
         execDataPreprocessing(_inputs);
         inferRequestIdx = plg->QueueInference(_inputs, _outputs);
+        // workaround to unblock callback-based flows
+        if (_callback) {
+            auto infer_request = _publicInterface.lock();
+            IE_ASSERT(infer_request != nullptr);
+            auto res = Wait(0);
+            _callback(infer_request, res);
+        }
     }
 
     InferenceEngine::StatusCode Wait(int64_t millis_timeout) override {

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/skip_tests_config.cpp
@@ -10,6 +10,6 @@
 std::vector<std::string> disabledTestPatterns() {
     return {
         // TODO: FIX BUG 31661
-        ".*Behavior.*Callback.*"
+        ".*Behavior.*CallbackThrowException.*"
     };
 }


### PR DESCRIPTION
This is a workaround to unblock pipelines using callbacks (like benchmarking in async mode). GNA plugin has never supported callbacks, so waiting for a callback currently just leads to hangs. At the end, we should switch to the default implementation for async requests. 