### PR TITLE
Updated requiremnets.txt

### DIFF
--- a/model-optimizer/requirements.txt
+++ b/model-optimizer/requirements.txt
@@ -1,4 +1,4 @@
-tensorflow>=1.2.0,<2.0.0
+tensorflow>=1.2.0
 mxnet>=1.0.0,<=1.5.1
 networkx>=1.11
 numpy>=1.12.0


### PR DESCRIPTION
Removed the upper limit for the TensorFlow versions as the latest versions of python do not support any TensorFlow version before 2.2
This change makes configuration of the Model Optimizer universal and solves the error for users with  python versions >=3.8