### PR TITLE
 Remove deprecated layer test class

### DIFF
--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/bfloat16_helpers.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/bfloat16_helpers.hpp
@@ -132,15 +132,16 @@ typedef std::tuple<
  *
  * In 3rd stage do not forget bfloat16 preffix!
  */
-class BasicBF16Test : public LayerTestsUtils::LayerTestsCommonDeprecated<basicParams> {
+class BasicBF16Test : public testing::WithParamInterface<basicParams>,
+                      public CommonTestUtils::TestsCommon {
 protected:
     virtual std::shared_ptr<ngraph::Function> createGraph(InferenceEngine::Precision netPrecision) = 0;
 
 public:
     std::shared_ptr<ngraph::Function> fnPtr;
-    std::vector<float *> refOut;
+    std::string targetDevice;
     InferenceEngine::SizeVector inputShapes, newInputShapes;
-    InferenceEngine::SizeVector refOutShape;
+    InferenceEngine::Precision inputPrecision, netPrecision;
     std::map<std::string, std::string> expectedPrecisions;
     float threshold = 2e-2;  // Is enough for tensor having abs maximum values less than 1
 
@@ -161,6 +162,20 @@ public:
         result << "netPRC=" << netPrecision.name() << "_";
         result << "targetDevice=" << targetDevice;
         return result.str();
+    }
+
+    static void setNetInOutPrecision(InferenceEngine::CNNNetwork &cnnNet, InferenceEngine::Precision inPrc,
+                                     InferenceEngine::Precision outPrc = InferenceEngine::Precision::UNSPECIFIED) {
+        if (inPrc != InferenceEngine::Precision::UNSPECIFIED) {
+            for (const auto &inputItem : cnnNet.getInputsInfo()) {
+                inputItem.second->setPrecision(inPrc);
+            }
+        }
+        if (outPrc != InferenceEngine::Precision::UNSPECIFIED) {
+            for (const auto &output : cnnNet.getOutputsInfo()) {
+                output.second->setPrecision(outPrc);
+            }
+        }
     }
 
     void test() {

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/activation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/activation.cpp
@@ -34,7 +34,6 @@ const std::vector<ActivationTypes> activationTypes = {
 
 const auto basicCases = ::testing::Combine(
         ::testing::ValuesIn(activationTypes),
-        ::testing::ValuesIn(inputPrecisions),
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(std::vector<size_t >({1, 50}), std::vector<size_t >({1, 128})),
         ::testing::Values(CommonTestUtils::DEVICE_CPU)

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/activation.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/activation.cpp
@@ -22,7 +22,7 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
         // TODO: Issue:28036
         // InferenceEngine::Precision::FP16,
         InferenceEngine::Precision::I16,
-        InferenceEngine::Precision::I8
+        InferenceEngine::Precision::U8
 };
 
 const std::vector<ActivationTypes> activationTypes = {
@@ -37,11 +37,10 @@ const std::vector<ActivationTypes> activationTypes = {
 
 const auto basicCases = ::testing::Combine(
         ::testing::ValuesIn(activationTypes),
-        ::testing::ValuesIn(inputPrecisions),
         ::testing::ValuesIn(netPrecisions),
-        ::testing::Values(std::vector<size_t >({1, 50}),
-                std::vector<size_t >({1, 128}),
-                std::vector<size_t >({1, 10 * 1024})),
+        ::testing::Values(std::vector<size_t>({1, 50}),
+                          std::vector<size_t>({1, 128}),
+                          std::vector<size_t>({1, 10 * 1024})),
         ::testing::Values(CommonTestUtils::DEVICE_GNA)
 );
 

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/skip_tests_config.cpp
@@ -10,6 +10,8 @@
 std::vector<std::string> disabledTestPatterns() {
     return {
         // TODO: FIX BUG 31661
-        ".*Behavior.*CallbackThrowException.*"
+        ".*Behavior.*CallbackThrowException.*",
+        // TODO: FIX BUG 32210
+        R"(.*(Sigmoid|Tanh|Exp|Log).*)"
     };
 }

--- a/inference-engine/tests/functional/plugin/gpu/remote_blob_tests/cldnn_remote_blob_tests.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/remote_blob_tests/cldnn_remote_blob_tests.cpp
@@ -25,6 +25,7 @@ using namespace InferenceEngine::gpu;
 class RemoteBlob_Test : public CommonTestUtils::TestsCommon {
 protected:
     std::shared_ptr<ngraph::Function> fn_ptr;
+
     virtual void SetUp() {
         fn_ptr = ngraph::builder::subgraph::makeSplitMultiConvConcat();
     }
@@ -46,7 +47,8 @@ TEST_F(RemoteBlob_Test, canInputUserBlob) {
 
     // regular inference
     auto inf_req_regular = exec_net.CreateInferRequest();
-    InferenceEngine::Blob::Ptr fakeImageData = FuncTestUtils::createAndFillBlob(net.getInputsInfo().begin()->second->getTensorDesc());
+    InferenceEngine::Blob::Ptr fakeImageData = FuncTestUtils::createAndFillBlob(
+            net.getInputsInfo().begin()->second->getTensorDesc());
     inf_req_regular.SetBlob(net.getInputsInfo().begin()->first, fakeImageData);
 
     inf_req_regular.Infer();
@@ -64,11 +66,12 @@ TEST_F(RemoteBlob_Test, canInputUserBlob) {
 
     cl::Buffer shared_buffer(ocl_instance->_context, CL_MEM_READ_WRITE, imSize, NULL, &err);
     {
-        void* buffer = fakeImageData->buffer();
+        void *buffer = fakeImageData->buffer();
         ocl_instance->_queue.enqueueWriteBuffer(shared_buffer, true, 0, imSize, buffer);
     }
 
-    Blob::Ptr shared_blob = make_shared_blob(net.getInputsInfo().begin()->second->getTensorDesc(), cldnn_context, shared_buffer);
+    Blob::Ptr shared_blob = make_shared_blob(net.getInputsInfo().begin()->second->getTensorDesc(), cldnn_context,
+                                             shared_buffer);
     inf_req_shared.SetBlob(net.getInputsInfo().begin()->first, shared_blob);
 
     inf_req_shared.Infer();
@@ -132,9 +135,10 @@ class TwoNets_Test : public CommonTestUtils::TestsCommon, public testing::WithPa
                    ngraph::builder::subgraph::makeMultiSingleConv()};
     };
 public:
-    static std::string getTestCaseName(const testing::TestParamInfo<std::size_t> & obj) {
+    static std::string getTestCaseName(const testing::TestParamInfo<std::size_t> &obj) {
         return "num_streams_" + std::to_string(obj.param);
     }
+
 protected:
     size_t num_streams;
     std::vector<std::shared_ptr<ngraph::Function>> fn_ptrs;
@@ -150,7 +154,7 @@ TEST_P(TwoNets_Test, canInferTwoExecNets) {
 
     std::vector<std::string> outputs;
     std::vector<InferRequest> irs;
-    std::vector<std::shared_ptr<float*>> ref;
+    std::vector<std::vector<uint8_t>> ref;
     std::vector<int> outElementsCount;
 
     for (size_t i = 0; i < nets.size(); ++i) {
@@ -160,7 +164,7 @@ TEST_P(TwoNets_Test, canInferTwoExecNets) {
         net.getInputsInfo().begin()->second->setPrecision(Precision::FP32);
 
         auto exec_net = ie.LoadNetwork(net, CommonTestUtils::DEVICE_GPU,
-                               {{PluginConfigParams::KEY_GPU_THROUGHPUT_STREAMS, std::to_string(num_streams)}});
+                                       {{PluginConfigParams::KEY_GPU_THROUGHPUT_STREAMS, std::to_string(num_streams)}});
 
         for (int j = 0; j < num_streams; j++) {
             outputs.push_back(net.getOutputsInfo().begin()->first);
@@ -171,11 +175,14 @@ TEST_P(TwoNets_Test, canInferTwoExecNets) {
             auto blob = FuncTestUtils::createAndFillBlob(net.getInputsInfo().begin()->second->getTensorDesc());
             inf_req.SetBlob(net.getInputsInfo().begin()->first, blob);
 
-            outElementsCount.push_back(std::accumulate(begin(fn_ptrs[i]->get_output_shape(0)), end(fn_ptrs[i]->get_output_shape(0)), 1,
-                                                       std::multiplies<size_t>()));
-
-            std::shared_ptr<float*> reOutData = ngraph::helpers::inferFnWithInterp<ngraph::element::Type_t::f32>(
-                    fn_ptrs[i], {inf_req.GetBlob(net.getInputsInfo().begin()->first)->buffer()}).front();
+            outElementsCount.push_back(
+                    std::accumulate(begin(fn_ptrs[i]->get_output_shape(0)), end(fn_ptrs[i]->get_output_shape(0)), 1,
+                                    std::multiplies<size_t>()));
+            const auto inBlob = inf_req.GetBlob(net.getInputsInfo().begin()->first);
+            const auto blobSize = inBlob->byteSize();
+            const auto inBlobBuf = inBlob->cbuffer().as<uint8_t *>();
+            std::vector<uint8_t> inData(inBlobBuf, inBlobBuf + blobSize);
+            std::vector<uint8_t> reOutData = ngraph::helpers::interpreterFunction(fn_ptrs[i], {inData}).front();
             ref.push_back(reOutData);
         }
     }
@@ -191,13 +198,15 @@ TEST_P(TwoNets_Test, canInferTwoExecNets) {
         }
     }
 
-    for (auto& net : nets) {
+    for (auto &net : nets) {
         ASSERT_EQ(net.getOutputsInfo().begin()->second->getPrecision(), InferenceEngine::Precision::FP32);
     }
     auto thr = FuncTestUtils::GetComparisonThreshold(InferenceEngine::Precision::FP32);
     for (size_t i = 0; i < irs.size(); ++i) {
+        const auto &refBuffer = ref[i].data();
         ASSERT_EQ(outElementsCount[i], irs[i].GetBlob(outputs[i])->size());
-        FuncTestUtils::compareRawBuffers(irs[i].GetBlob(outputs[i])->buffer().as<float*>(), *ref[i], outElementsCount[i],
+        FuncTestUtils::compareRawBuffers(irs[i].GetBlob(outputs[i])->buffer().as<float *>(),
+                                         reinterpret_cast<const float *>(refBuffer), outElementsCount[i],
                                          outElementsCount[i],
                                          thr);
     }

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/activation.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/activation.cpp
@@ -9,11 +9,7 @@
 using namespace LayerTestsDefinitions;
 using namespace ngraph::helpers;
 namespace {
-// Common params
-const std::vector<InferenceEngine::Precision> inputPrecisions = {
-        InferenceEngine::Precision::FP32,
-        InferenceEngine::Precision::U8
-};
+
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
         InferenceEngine::Precision::FP32,
@@ -33,7 +29,6 @@ const std::vector<ActivationTypes> activationTypes = {
 
 const auto basicCases = ::testing::Combine(
         ::testing::ValuesIn(activationTypes),
-        ::testing::ValuesIn(inputPrecisions),
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(std::vector<size_t>({1, 50}), std::vector<size_t>({1, 128})),
         ::testing::Values(CommonTestUtils::DEVICE_GPU)

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/activation.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/activation.cpp
@@ -9,10 +9,6 @@
 using namespace LayerTestsDefinitions;
 using namespace ngraph::helpers;
 namespace {
-// Common params
-const std::vector<InferenceEngine::Precision> inputPrecisions = {
-        InferenceEngine::Precision::FP32,
-};
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
         InferenceEngine::Precision::FP32,
@@ -29,7 +25,6 @@ const std::vector<ActivationTypes> activationTypes = {
 
 const auto basicCases = ::testing::Combine(
         ::testing::ValuesIn(activationTypes),
-        ::testing::ValuesIn(inputPrecisions),
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(std::vector<size_t>({1, 50}), std::vector<size_t>({1, 128})),
         ::testing::Values(CommonTestUtils::DEVICE_MYRIAD)

--- a/inference-engine/tests/functional/plugin/shared/include/execution_graph_tests/unique_node_names.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/execution_graph_tests/unique_node_names.hpp
@@ -14,18 +14,15 @@
 
 namespace LayerTestsDefinitions {
 
-typedef std::tuple<
-        InferenceEngine::Precision,
-        InferenceEngine::Precision,
-        InferenceEngine::SizeVector,
-        std::string> basicParams;
-
-class ExecGraphUniqueNodeNames : public LayerTestsUtils::LayerTestsCommonDeprecated<LayerTestsUtils::basicParams> {
+class ExecGraphUniqueNodeNames : public testing::WithParamInterface<LayerTestsUtils::basicParams>,
+                                 public CommonTestUtils::TestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<LayerTestsUtils::basicParams> obj);
-
+    std::string targetDevice;
+    std::shared_ptr<ngraph::Function> fnPtr;
 protected:
     void SetUp() override;
+
     void TearDown() override;
 };
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/activation.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/activation.hpp
@@ -46,19 +46,19 @@ static std::map<ngraph::helpers::ActivationTypes, std::string> activationNames =
 typedef std::tuple<
         ngraph::helpers::ActivationTypes,
         InferenceEngine::Precision,
-        InferenceEngine::Precision,
         InferenceEngine::SizeVector,
         std::string> activationParams;
 
-class ActivationLayerTest
-        : public LayerTestsUtils::LayerTestsCommonDeprecated<activationParams> {
+class ActivationLayerTest : public testing::WithParamInterface<activationParams>,
+                            public LayerTestsUtils::LayerTestsCommon {
 public:
-    static std::string getTestCaseName(const testing::TestParamInfo<activationParams> &obj);
-
-protected:
-    InferenceEngine::SizeVector inputShapes;
     ngraph::helpers::ActivationTypes activationType;
 
+    static std::string getTestCaseName(const testing::TestParamInfo<activationParams> &obj);
+
+    virtual InferenceEngine::Blob::Ptr GenerateInput(const InferenceEngine::InputInfo &info) const;
+
+protected:
     void SetUp();
 };
 

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/activation.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/activation.cpp
@@ -6,8 +6,6 @@
 #include <tuple>
 #include <string>
 #include <vector>
-#include <functional>
-#include <cmath>
 #include <memory>
 #include <functional_test_utils/skip_tests_config.hpp>
 
@@ -15,8 +13,6 @@
 #include "ie_precision.hpp"
 
 #include "common_test_utils/common_utils.hpp"
-#include "functional_test_utils/blob_utils.hpp"
-#include "functional_test_utils/plugin_cache.hpp"
 #include "functional_test_utils/layer_test_utils.hpp"
 
 #include "single_layer_tests/activation.hpp"
@@ -24,55 +20,43 @@
 namespace LayerTestsDefinitions {
 
 std::string ActivationLayerTest::getTestCaseName(const testing::TestParamInfo<activationParams> &obj) {
-    InferenceEngine::Precision inputPrecision, netPrecision;
+    InferenceEngine::Precision netPrecision;
     InferenceEngine::SizeVector inputShapes;
     std::string targetDevice;
     ngraph::helpers::ActivationTypes activationType;
-    std::tie(activationType,
-             inputPrecision,
-             netPrecision,
-             inputShapes,
-             targetDevice) = obj.param;
+    std::tie(activationType, netPrecision, inputShapes, targetDevice) = obj.param;
 
     std::ostringstream result;
     const char separator = '_';
     result << activationNames[activationType] << separator;
     result << "IS=" << CommonTestUtils::vec2str(inputShapes) << separator;
-    result << "inPRC=" << inputPrecision.name() << separator;
     result << "netPRC=" << netPrecision.name() << separator;
     result << "targetDevice=" << targetDevice;
     return result.str();
 }
 
 void ActivationLayerTest::SetUp() {
-    std::tie(activationType, inputPrecision, netPrecision, inputShapes, targetDevice) = GetParam();
+    InferenceEngine::Precision netPrecision;
+    InferenceEngine::SizeVector inputShapes;
+    std::tie(activationType, netPrecision, inputShapes, targetDevice) = GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShapes});
     auto activation = ngraph::builder::makeActivation(params[0], ngPrc, activationType);
-    fnPtr = std::make_shared<ngraph::Function>(ngraph::NodeVector{activation}, params);
+    function = std::make_shared<ngraph::Function>(ngraph::NodeVector{activation}, params);
 }
 
-TEST_P(ActivationLayerTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-    InferenceEngine::CNNNetwork cnnNet(fnPtr);
-    setNetInOutPrecision(cnnNet, inputPrecision);
-    std::string inputName = cnnNet.getInputsInfo().begin()->first;
-    std::string outputName = cnnNet.getOutputsInfo().begin()->first;
-    auto ie = PluginCache::get().ie();
-    auto execNet = ie->LoadNetwork(cnnNet, targetDevice);
-    auto a = execNet.GetInputsInfo();
-    auto req = execNet.CreateInferRequest();
-
+InferenceEngine::Blob::Ptr ActivationLayerTest::GenerateInput(const InferenceEngine::InputInfo &info) const {
+    bool inPrcSigned = function->get_parameters()[0]->get_element_type().is_signed();
     uint32_t data_range = 20;
-    int32_t data_start_from = -10;
-    if (!inputPrecision.isSigned()) {
+    int32_t data_start_from = activationType == ngraph::helpers::ActivationTypes::Log ? 1 : -10;
+    if (!inPrcSigned) {
         data_range = 15;
         data_start_from = 0;
     }
     if (activationType == ngraph::helpers::ActivationTypes::Exp && targetDevice == CommonTestUtils::DEVICE_GNA) {
         const double max_result_on_GNA = 15.9;
         const double exp_inverse = std::round(std::log(max_result_on_GNA));
-        if (inputPrecision.isSigned()) {
+        if (inPrcSigned) {
             data_range = exp_inverse * 2.0;
             data_start_from = -exp_inverse;
         } else {
@@ -80,37 +64,13 @@ TEST_P(ActivationLayerTest, CompareWithRefs) {
             data_start_from = 0;
         }
     }
+    return FuncTestUtils::createAndFillBlob(info.getTensorDesc(), data_range,
+                                            data_start_from,
+                                            32768);
+}
 
-    InferenceEngine::Blob::Ptr inBlob = FuncTestUtils::createAndFillBlob({inputPrecision,
-                                                                          inputShapes,
-                                                                          InferenceEngine::TensorDesc::getLayoutByDims(
-                                                                                  inputShapes)},
-                                                                         data_range,
-                                                                         data_start_from,
-                                                                                          32768);
-    req.SetBlob(inputName, inBlob);
-    req.Infer();
-    auto outBlob = req.GetBlob(outputName);
-    std::vector<const float *> inRawData;
-    InferenceEngine::Blob::Ptr castedBlob = inBlob;
-    if (inputPrecision != InferenceEngine::Precision::FP32) {
-        castedBlob = FuncTestUtils::copyBlobWithCast<InferenceEngine::Precision::FP32>(inBlob);
-    }
-    inRawData.push_back(castedBlob->cbuffer().as<float *>());
-
-    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
-    convertFuncToF32(fnPtr, netPrecision);
-    auto refOutData = ngraph::helpers::inferFnWithInterp<ngraph::element::Type_t::f32>(fnPtr, inRawData);
-    float thr1, thr2;
-    FuncTestUtils::GetComparisonThreshold(netPrecision, thr1, thr2);
-
-    size_t outElementsCount = std::accumulate(begin(fnPtr->get_output_shape(0)), end(fnPtr->get_output_shape(0)), 1,
-                                              std::multiplies<size_t>());
-    FuncTestUtils::compareRawBuffers(outBlob->cbuffer().as<float *>(), *refOutData[0],
-                                                     outElementsCount, outElementsCount,
-                                                     FuncTestUtils::CompareType::ABS_AND_REL,
-                                                     thr1, thr2);
-    fnPtr.reset();
+TEST_P(ActivationLayerTest, CompareWithRefs) {
+    Run();
 }
 
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/ie_test_utils/functional_test_utils/layer_test_utils.hpp
+++ b/inference-engine/tests/ie_test_utils/functional_test_utils/layer_test_utils.hpp
@@ -28,197 +28,14 @@
 
 
 namespace LayerTestsUtils {
+
+using TargetDevice = std::string;
+
 typedef std::tuple<
         InferenceEngine::Precision,  // Network Precision
         InferenceEngine::SizeVector, // Input Shape
-        std::string                  // Target Device
+        TargetDevice                 // Target Device
 > basicParams;
-
-template<typename paramType>
-class LayerTestsCommonDeprecated : public CommonTestUtils::TestsCommon, public testing::WithParamInterface<paramType> {
-public:
-    InferenceEngine::Precision netPrecision;
-    InferenceEngine::Precision inputPrecision;
-    InferenceEngine::Precision outputPrecision;
-    InferenceEngine::Layout inputLayout;
-    InferenceEngine::Layout outputLayout;
-    std::string targetDevice;
-    std::shared_ptr<ngraph::Function> fnPtr;
-    std::map<std::string, std::string> config;
-
-    LayerTestsCommonDeprecated() {
-        netPrecision = InferenceEngine::Precision::UNSPECIFIED;
-        inputPrecision = InferenceEngine::Precision::UNSPECIFIED;
-        outputPrecision = InferenceEngine::Precision::UNSPECIFIED;
-        inputLayout = InferenceEngine::Layout::ANY;
-        outputLayout = InferenceEngine::Layout::ANY;
-    }
-
-    void inline inferAndValidate() {
-        // Skip test according to plugin specific disabledTestPatterns() (if any)
-        SKIP_IF_CURRENT_TEST_IS_DISABLED()
-        // Create CNNNetwork from ngraph::Function
-        InferenceEngine::CNNNetwork cnnNet(fnPtr);
-        // Set target input/output Precisions for the network
-        setNetInOutPrecision(cnnNet, inputPrecision, outputPrecision);
-        // Set target input Layouts for the network
-        setNetInOutLayout(cnnNet, inputLayout, outputLayout);
-
-        // Get Core from cache
-        auto ie = PluginCache::get().ie();
-        // Load config
-        if (!config.empty()) {
-            ie->SetConfig(config, targetDevice);
-        }
-        // Load CNNNetwork to target plugins
-        auto execNet = ie->LoadNetwork(cnnNet, targetDevice);
-        // Create InferRequest
-        auto req = execNet.CreateInferRequest();
-
-        // Create and set input blobs
-        std::vector<InferenceEngine::Blob::Ptr> inBlobs;
-        for (const auto &inputItem : cnnNet.getInputsInfo()) {
-            auto currentBlob = FuncTestUtils::createAndFillBlob(inputItem.second->getTensorDesc());
-            req.SetBlob(inputItem.first, currentBlob);
-            inBlobs.push_back(currentBlob);
-        }
-
-        // Create input vector with raw data for reference calculation
-        std::vector<const float *> inRawData;
-        // References are calculated in float precision, so blobs have to be copied and casted if required
-        std::vector<InferenceEngine::Blob::Ptr> castedBlobs;
-        for (size_t i = 0; i < inBlobs.size(); i++) {
-            const auto precision = inBlobs[i]->getTensorDesc().getPrecision();
-            const auto layout = inBlobs[i]->getTensorDesc().getLayout();
-            const auto defLayout = InferenceEngine::TensorDesc::getLayoutByDims(inBlobs[i]->getTensorDesc().getDims());
-
-            if (precision == InferenceEngine::Precision::FP32 && layout == defLayout) {
-                inRawData.push_back(inBlobs[i]->cbuffer().template as<const float *>());
-            } else {
-                auto castedBlob = FuncTestUtils::copyBlobWithCast<InferenceEngine::Precision::FP32>(inBlobs[i]);
-                castedBlob = FuncTestUtils::convertBlobLayout(castedBlob, defLayout);
-                inRawData.push_back(castedBlob->cbuffer().template as<const float *>());
-                castedBlobs.push_back(castedBlob);
-            }
-        }
-        // Run inference in IE
-        req.Infer();
-        // Reset PluginCash
-        if (!config.empty()) {
-            PluginCache::get().reset();
-        }
-        // Get output raw data from resulting output blobs
-        std::vector<float *> outBlobsRawData;
-        std::vector<size_t> outElementsCount;  // output elements count required for compareRawBuffers()
-        for (const auto &output : cnnNet.getOutputsInfo()) {
-            auto currentBlob = req.GetBlob(output.first);
-
-            outElementsCount.push_back(
-                    std::accumulate(
-                            std::begin(output.second->getDims()), std::end(output.second->getDims()),
-                            size_t{1}, std::multiplies<size_t>()));
-
-            const auto precision = currentBlob->getTensorDesc().getPrecision();
-            const auto layout = currentBlob->getTensorDesc().getLayout();
-            const auto defLayout = InferenceEngine::TensorDesc::getLayoutByDims(currentBlob->getTensorDesc().getDims());
-
-            if (precision == InferenceEngine::Precision::FP32 && layout == defLayout) {
-                outBlobsRawData.push_back(currentBlob->cbuffer().template as<float *>());
-            } else {
-                auto castedBlob = FuncTestUtils::copyBlobWithCast<InferenceEngine::Precision::FP32>(currentBlob);
-                castedBlob = FuncTestUtils::convertBlobLayout(castedBlob, defLayout);
-                outBlobsRawData.push_back(castedBlob->cbuffer().template as<float *>());
-                castedBlobs.push_back(castedBlob);
-            }
-        }
-
-        // Convert initial ngraph::Function to fp32 for references calculation
-        convertFuncToF32(fnPtr, netPrecision);
-        // Run ngraph Interpreter backend to calculate references
-        auto refOutData = ngraph::helpers::inferFnWithInterp<ngraph::element::Type_t::f32>(fnPtr, inRawData);
-        // Compare IE infer results vs ngraph Interpreter reference results
-        float thr1, thr2;
-        FuncTestUtils::GetComparisonThreshold(netPrecision, thr1, thr2);
-        FuncTestUtils::compareRawBuffers(outBlobsRawData, refOutData, outElementsCount, outElementsCount,
-                                                         FuncTestUtils::CompareType::ABS_AND_REL,
-                                                         thr1, thr2);
-        // Deallocate ngraph::Function pointer
-        fnPtr.reset();
-        if (targetDevice.find(CommonTestUtils::DEVICE_GPU) != std::string::npos) {
-            PluginCache::get().reset();
-        }
-    }
-
-protected:
-    static void setNetInOutPrecision(InferenceEngine::CNNNetwork &cnnNet, InferenceEngine::Precision inPrc,
-                                     InferenceEngine::Precision outPrc = InferenceEngine::Precision::UNSPECIFIED) {
-        if (inPrc != InferenceEngine::Precision::UNSPECIFIED) {
-            for (const auto &inputItem : cnnNet.getInputsInfo()) {
-                inputItem.second->setPrecision(inPrc);
-            }
-        }
-        if (outPrc != InferenceEngine::Precision::UNSPECIFIED) {
-            for (const auto &output : cnnNet.getOutputsInfo()) {
-                output.second->setPrecision(outPrc);
-            }
-        }
-    }
-
-    static void setNetInOutLayout(InferenceEngine::CNNNetwork &cnnNet, InferenceEngine::Layout inputLayout,
-                                  InferenceEngine::Layout outputLayout = InferenceEngine::Layout::ANY) {
-        if (inputLayout != InferenceEngine::Layout::ANY) {
-            for (const auto &inputItem : cnnNet.getInputsInfo()) {
-                inputItem.second->setLayout(inputLayout);
-            }
-        }
-        if (outputLayout != InferenceEngine::Layout::ANY) {
-            for (const auto &output : cnnNet.getOutputsInfo()) {
-                output.second->setLayout(outputLayout);
-            }
-        }
-    }
-
-    void convertFuncToF32(std::shared_ptr<ngraph::Function> fn, InferenceEngine::Precision prc) {
-        switch (prc) {
-            case InferenceEngine::Precision::FP32:
-                break;
-            case InferenceEngine::Precision::FP16:
-                ngraph::pass::ConvertPrecision<ngraph::element::Type_t::f16, ngraph::element::Type_t::f32>().run_on_function(
-                        fn);
-                break;
-            case InferenceEngine::Precision::I8:
-                ngraph::pass::ConvertPrecision<ngraph::element::Type_t::i8, ngraph::element::Type_t::f32>().run_on_function(
-                        fn);
-                break;
-            case InferenceEngine::Precision::I16:
-                ngraph::pass::ConvertPrecision<ngraph::element::Type_t::i16, ngraph::element::Type_t::f32>().run_on_function(
-                        fn);
-                break;
-            case InferenceEngine::Precision::U8:
-                ngraph::pass::ConvertPrecision<ngraph::element::Type_t::u8, ngraph::element::Type_t::f32>().run_on_function(
-                        fn);
-                break;
-            case InferenceEngine::Precision::U16:
-                ngraph::pass::ConvertPrecision<ngraph::element::Type_t::u16, ngraph::element::Type_t::f32>().run_on_function(
-                        fn);
-                break;
-            default:
-                throw std::runtime_error("Precision not handled");
-        }
-    }
-};
-
-template<class opType>
-inline std::vector<std::shared_ptr<ngraph::Node>> findTargetNodes(std::shared_ptr<ngraph::Function> fnPtr) {
-    std::vector<std::shared_ptr<ngraph::Node>> nodes;
-    for (const auto &op : fnPtr->get_ops()) {
-        auto convOp = std::dynamic_pointer_cast<opType>(op);
-        if (convOp) nodes.push_back(op);
-    }
-    return nodes;
-}
-
-using TargetDevice = std::string;
 
 enum RefMode {
     INTERPRETER,
@@ -232,7 +49,8 @@ public:
 
     virtual void Run();
 
-    virtual void Compare(const std::vector<std::vector<std::uint8_t>>& expectedOutputs, const std::vector<InferenceEngine::Blob::Ptr>& actualOutputs);
+    virtual void Compare(const std::vector<std::vector<std::uint8_t>> &expectedOutputs,
+                         const std::vector<InferenceEngine::Blob::Ptr> &actualOutputs);
 
     virtual void Compare(const std::vector<std::uint8_t> &expected, const InferenceEngine::Blob::Ptr &actual);
 

--- a/inference-engine/tests/ngraph_functions/include/ngraph_functions/utils/ngraph_helpers.hpp
+++ b/inference-engine/tests/ngraph_functions/include/ngraph_functions/utils/ngraph_helpers.hpp
@@ -97,10 +97,10 @@ enum QuantizationGranularity {
     Perchannel
 };
 
-inline std::string quantizationGranularityToString(const QuantizationGranularity& granularity) {
+inline std::string quantizationGranularityToString(const QuantizationGranularity &granularity) {
     static std::map<QuantizationGranularity, std::string> names = {
-        {Pertensor, "Pertensor"},
-        {Perchannel, "Perchannel"},
+            {Pertensor,  "Pertensor"},
+            {Perchannel, "Perchannel"},
     };
 
     auto i = names.find(granularity);
@@ -110,7 +110,7 @@ inline std::string quantizationGranularityToString(const QuantizationGranularity
         throw std::runtime_error("Unsupported QuantizationGranularity type");
 }
 
-inline std::ostream& operator<<(std::ostream& out, const QuantizationGranularity& granularity) {
+inline std::ostream &operator<<(std::ostream &out, const QuantizationGranularity &granularity) {
     return out << quantizationGranularityToString(granularity);
 }
 
@@ -125,43 +125,9 @@ inline ngraph::NodeVector castOps2Nodes(const std::vector<std::shared_ptr<opType
     return nodes;
 }
 
-template<ngraph::element::Type_t type>
-inline std::vector<std::shared_ptr<typename ngraph::helpers::nGraphTypesTrait<type>::value_type *>>
-inferFnWithInterp(const std::shared_ptr<ngraph::Function> &fn,
-                  std::vector<const typename ngraph::helpers::nGraphTypesTrait<type>::value_type *> inData) {
-    using stdType = typename ngraph::helpers::nGraphTypesTrait<type>::value_type;
-    ngraph::runtime::Backend::set_backend_shared_library_search_directory("");
-
-    auto backend = ngraph::runtime::Backend::create("INTERPRETER");
-
-    std::vector<std::shared_ptr<ngraph::runtime::Tensor>> inTensors;
-    auto params = fn->get_parameters();
-    for (size_t i = 0; i < params.size(); i++) {
-        auto t = backend->create_tensor(type, params[i]->get_shape());
-        t->write(inData[i], ngraph::shape_size(params[i]->get_shape()) * sizeof(stdType));
-        inTensors.push_back(t);
-    }
-
-    std::vector<std::shared_ptr<ngraph::runtime::Tensor>> outTensors;
-    for (size_t i = 0; i < fn->get_output_size(); i++) {
-        auto outShape = fn->get_output_shape(i);
-        outTensors.push_back(backend->create_tensor(type, outShape));
-    }
-
-    auto handle = backend->compile(fn);
-    handle->call_with_validate(outTensors, inTensors);
-    std::vector<std::shared_ptr<stdType *>> outData;
-    for (size_t i = 0; i < fn->get_output_size(); i++) {
-        size_t nOutElements = ngraph::shape_size(fn->get_output_shape(i));
-        auto outBuf = std::make_shared<stdType *>(new stdType[nOutElements]);
-        outTensors[i]->read(*outBuf, nOutElements * sizeof(stdType));
-        outData.push_back(outBuf);
-    }
-    return outData;
-}
-
-std::vector<std::vector<std::uint8_t>> interpreterFunction(const std::shared_ptr<Function> &function, const std::vector<std::vector<std::uint8_t>> &inputs,
-                                                                                                    element::Type_t convertType = element::Type_t::undefined);
+std::vector<std::vector<std::uint8_t>> interpreterFunction(const std::shared_ptr<Function> &function,
+                                                           const std::vector<std::vector<std::uint8_t>> &inputs,
+                                                           element::Type_t convertType = element::Type_t::undefined);
 
 //
 // This function compares two nGraph functions and requires them to have exactly one output
@@ -169,18 +135,22 @@ std::vector<std::vector<std::uint8_t>> interpreterFunction(const std::shared_ptr
 // Check number of inputs
 // Check shapes of each Node
 //
-void CompareFunctions(const Function& actual, const Function& expected);
+void CompareFunctions(const Function &actual, const Function &expected);
 
 
 std::shared_ptr<Function> foldFunction(const std::shared_ptr<Function> &function,
                                        const std::vector<std::vector<std::uint8_t>> &inputs);
 
-std::vector<std::vector<std::uint8_t>> getConstData(const std::shared_ptr<Function> &function, element::Type_t convertType = element::Type_t::undefined);
+std::vector<std::vector<std::uint8_t>> getConstData(const std::shared_ptr<Function> &function,
+                                                    element::Type_t convertType = element::Type_t::undefined);
 
-std::shared_ptr<ngraph::Node> getNodeSharedPtr(const ngraph::NodeTypeInfo &type_info, const ngraph::OutputVector &outputVector);
+std::shared_ptr<ngraph::Node> getNodeSharedPtr(const ngraph::NodeTypeInfo &type_info,
+                                               const ngraph::OutputVector &outputVector);
 
-std::vector<std::uint8_t> convertOutputPrecision(std::vector<std::uint8_t> &output, const element::Type_t &fromPrecision, const element::Type_t &toPrecision,
-                                                                                                                                  const size_t elementsCount);
+std::vector<std::uint8_t> convertOutputPrecision(std::vector<std::uint8_t> &output,
+                                                 const element::Type_t &fromPrecision,
+                                                 const element::Type_t &toPrecision,
+                                                 const size_t elementsCount);
 
 }  // namespace helpers
 }  // namespace ngraph

--- a/inference-engine/tests_deprecated/functional/shared_tests/inference_engine_regression_tests/common_dyn_batch_regression.hpp
+++ b/inference-engine/tests_deprecated/functional/shared_tests/inference_engine_regression_tests/common_dyn_batch_regression.hpp
@@ -17,30 +17,28 @@ public:
     int batch_limit;
     int cur_batch;
 
-    CommonDynBatchFuncTestParams(const std::string& _deviceName,
+    CommonDynBatchFuncTestParams(const std::string &_deviceName,
                                  int blimit,
                                  int batch,
-                                 double _nearValue = 0.01f):
+                                 double _nearValue = 0.01f) :
             deviceName(_deviceName),
-			batch_limit(blimit),
-			cur_batch(batch),
-            nearValue(_nearValue)
-    {}
+            batch_limit(blimit),
+            cur_batch(batch),
+            nearValue(_nearValue) {}
 };
 
-template <Precision::ePrecision P>
-class TestNoRegressionDynBatch : public Regression::RegressionTests, public WithParamInterface<CommonDynBatchFuncTestParams> {
+template<Precision::ePrecision P>
+class TestNoRegressionDynBatch : public Regression::RegressionTests,
+                                 public WithParamInterface<CommonDynBatchFuncTestParams> {
     std::string getDeviceName() const override {
         return GetParam().deviceName;
     }
 
 public:
-    double getNearValue() {
-        return GetParam().nearValue;
-    }
     int get_batch_limit() {
         return GetParam().batch_limit;
     }
+
     int get_cur_batch() {
         return GetParam().cur_batch;
     }
@@ -55,8 +53,9 @@ TEST_P(TestNoRegressionDynBatchFP32, dynBatch) {
 
     CNNNetwork net(fnPtr);
     auto ieCore = PluginCache::get().ie();
-    InferenceEngine::ExecutableNetwork exeNet = ieCore->LoadNetwork(net, GetParam().deviceName, {{PluginConfigParams::KEY_DYN_BATCH_ENABLED,
-                                                                                           PluginConfigParams::YES}});
+    InferenceEngine::ExecutableNetwork exeNet = ieCore->LoadNetwork(net, GetParam().deviceName,
+                                                                    {{PluginConfigParams::KEY_DYN_BATCH_ENABLED,
+                                                                             PluginConfigParams::YES}});
     InferenceEngine::InferRequest inferRequest = exeNet.CreateInferRequest();
 
     auto blob = FuncTestUtils::createAndFillBlob(net.getInputsInfo().begin()->second->getTensorDesc());
@@ -65,24 +64,26 @@ TEST_P(TestNoRegressionDynBatchFP32, dynBatch) {
     inferRequest.SetBlob(net.getInputsInfo().begin()->first, blob);
     inferRequest.Infer();
     auto *outRawData = inferRequest.GetBlob(net.getOutputsInfo().begin()->first)->cbuffer().as<float *>();
-
-    auto refOutData = ngraph::helpers::inferFnWithInterp<ngraph::element::Type_t::f32>(fnPtr,
-                                                                                       {blob->cbuffer().as<float *>()});
+    const auto blobSize = blob->byteSize();
+    const auto inBlobBuf = blob->cbuffer().as<uint8_t *>();
+    std::vector<uint8_t> inData(inBlobBuf, inBlobBuf + blobSize);
+    auto refOutData = ngraph::helpers::interpreterFunction(fnPtr, {inData});
 
     float thr1, thr2;
     FuncTestUtils::GetComparisonThreshold(InferenceEngine::Precision::FP32, thr1, thr2);
 
     std::vector<size_t> inShapeLimited{size_t(bsz), 4, 20, 20};
     size_t outElementsCount = std::accumulate(begin(inShapeLimited), end(inShapeLimited), 1, std::multiplies<size_t>());
-    FuncTestUtils::compareRawBuffers(outRawData, *refOutData[0], outElementsCount, outElementsCount,
-                                                     FuncTestUtils::CompareType::ABS_AND_REL,
-                                                     thr1, thr2);
+    FuncTestUtils::compareRawBuffers(outRawData, reinterpret_cast<const float *>(refOutData[0].data()),
+                                     outElementsCount, outElementsCount,
+                                     FuncTestUtils::CompareType::ABS_AND_REL,
+                                     thr1, thr2);
     if (GetParam().deviceName.find(CommonTestUtils::DEVICE_GPU) != std::string::npos) {
         PluginCache::get().reset();
     }
 }
 
-std::string  getTestCaseName(TestParamInfo<CommonDynBatchFuncTestParams> obj) {
+std::string getTestCaseName(TestParamInfo<CommonDynBatchFuncTestParams> obj) {
     return obj.param.deviceName + "_" + std::to_string(obj.param.batch_limit)
-        + "_" + std::to_string(obj.param.cur_batch);
+           + "_" + std::to_string(obj.param.cur_batch);
 }


### PR DESCRIPTION
Tests were refactored to get rid of the old LayerTestsComonDeprecated class.

**Internal validation expected to fail since an update of closed repos required**