### PR TITLE
Disable tests cause heap overflow

### DIFF
--- a/inference-engine/tests/unit/vpu/middleend_tests/edges_tests/data_to_shape_edge.cpp
+++ b/inference-engine/tests/unit/vpu/middleend_tests/edges_tests/data_to_shape_edge.cpp
@@ -176,7 +176,7 @@ TEST_F(DataToShapeEdgeProcessingTests, ShapeProcessingOnceSharesMemory) {
     ASSERT_EQ(processedShapeDataLocation.offset, processedDataShapeLocation.dimsOffset);
 }
 
-TEST_F(DataToShapeEdgeProcessingTests, ShapeProcessingOnceHasCorrectExecutionOrder) {
+TEST_F(DataToShapeEdgeProcessingTests, DISABLED_ShapeProcessingOnceHasCorrectExecutionOrder) {
     setupNetWithShapeBeingProcessedOnce();
 
     const auto& model = _testModel.getBaseModel();
@@ -250,7 +250,7 @@ TEST_F(DataToShapeEdgeProcessingTests, ShapeProcessingTwiceSharesMemory) {
     ASSERT_EQ(processedShapeDataLocation.offset, processedDataShapeLocation.dimsOffset);
 }
 
-TEST_F(DataToShapeEdgeProcessingTests, ShapeProcessingTwiceHasCorrectExecutionOrder) {
+TEST_F(DataToShapeEdgeProcessingTests, DISABLED_ShapeProcessingTwiceHasCorrectExecutionOrder) {
     setupNetWithShapeBeingProcessedTwice();
 
     const auto& model = _testModel.getBaseModel();

--- a/inference-engine/tests/unit/vpu/middleend_tests/edges_tests/stage_dependency_edge.cpp
+++ b/inference-engine/tests/unit/vpu/middleend_tests/edges_tests/stage_dependency_edge.cpp
@@ -46,7 +46,7 @@ TEST_F(StageDependencyEdgeProcessingTests, AddStageDependencyDoesNotAssertOnOutp
     ASSERT_NO_THROW(model->addStageDependency(dependentStage, dependencyProducer->output(0)));
 }
 
-TEST_F(StageDependencyEdgeProcessingTests, NetWithTwoStagesHasCorrectExecOrder) {
+TEST_F(StageDependencyEdgeProcessingTests, DISABLED_NetWithTwoStagesHasCorrectExecOrder) {
     //
     //                    -> [Data] -> (Stage) -> [Data] -> (Stage) -> [Output]
     // [Input] -> (Stage)                            |
@@ -73,7 +73,7 @@ TEST_F(StageDependencyEdgeProcessingTests, NetWithTwoStagesHasCorrectExecOrder) 
     ASSERT_TRUE(checkExecutionOrder(model, {dependencyProducer->id(), dependentStage->id()}));
 }
 
-TEST_F(StageDependencyEdgeProcessingTests, NetWithThreeStagesHasCorrectExecOrder) {
+TEST_F(StageDependencyEdgeProcessingTests, DISABLED_NetWithThreeStagesHasCorrectExecOrder) {
     //
     //                    -> [Data] -> (Stage) -> [Data] -> (Stage) -> [Data] -> (Stage) -> [Output]
     // [Input] -> (Stage)                                                 |


### PR DESCRIPTION
CVS-32231 created for tracking.