### PR TITLE
Remove Safety dependency

### DIFF
--- a/model-optimizer/README.md
+++ b/model-optimizer/README.md
@@ -192,7 +192,7 @@ of the tool and can not be applied to the current version of Model Optimizer.
 
 1. Run the following command:
 <pre>
-    safety check -r requirements_file
+    cat requirements_file | docker run -i --rm pyupio/safety safety check --stdin
 </pre>
 
 > **NOTE**: here <code>requirements_file</code> is one of the following: <code>requirements.txt</code>, <code>requirements_caffe.txt</code>, <code>requirements_tf.txt</code>, <code>requirements_mxnet.txt</code>, <code>requirements_dev.txt</code>.

--- a/model-optimizer/requirements_dev.txt
+++ b/model-optimizer/requirements_dev.txt
@@ -4,6 +4,5 @@ pyenchant==1.6.11
 astroid==2.1.0
 pylint==2.1.1
 Sphinx==1.6.5
-safety==1.8.5
 test-generator==0.1.1
 defusedxml>=0.5.0


### PR DESCRIPTION
Safety tool should be isolated from the environment it is validating:
https://github.com/pyupio/safety/security/advisories/GHSA-7q25-qrjw-6fg2

Suggesting docker solution by default.