### PR TITLE
[Python API] Add InputInfo and PreProcessInfo

### DIFF
--- a/inference-engine/ie_bridges/python/sample/classification_sample/classification_sample.py
+++ b/inference-engine/ie_bridges/python/sample/classification_sample/classification_sample.py
@@ -73,16 +73,16 @@ def main():
                       "or --cpu_extension command line argument")
             sys.exit(1)
 
-    assert len(net.inputs.keys()) == 1, "Sample supports only single input topologies"
+    assert len(net.input_info.keys()) == 1, "Sample supports only single input topologies"
     assert len(net.outputs) == 1, "Sample supports only single output topologies"
 
     log.info("Preparing input blobs")
-    input_blob = next(iter(net.inputs))
+    input_blob = next(iter(net.input_info))
     out_blob = next(iter(net.outputs))
     net.batch_size = len(args.input)
 
     # Read and pre-process input images
-    n, c, h, w = net.inputs[input_blob].shape
+    n, c, h, w = net.input_info[input_blob].input_data.shape
     images = np.ndarray(shape=(n, c, h, w))
     for i in range(n):
         image = cv2.imread(args.input[i])

--- a/inference-engine/ie_bridges/python/sample/classification_sample_async/classification_sample_async.py
+++ b/inference-engine/ie_bridges/python/sample/classification_sample_async/classification_sample_async.py
@@ -117,16 +117,16 @@ def main():
             log.error("Please try to specify cpu extensions library path in sample's command line parameters using -l "
                       "or --cpu_extension command line argument")
             sys.exit(1)
-    assert len(net.inputs.keys()) == 1, "Sample supports only single input topologies"
+    assert len(net.input_info.keys()) == 1, "Sample supports only single input topologies"
     assert len(net.outputs) == 1, "Sample supports only single output topologies"
 
     log.info("Preparing input blobs")
-    input_blob = next(iter(net.inputs))
+    input_blob = next(iter(net.input_info))
     out_blob = next(iter(net.outputs))
     net.batch_size = len(args.input)
 
     # Read and pre-process input images
-    n, c, h, w = net.inputs[input_blob].shape
+    n, c, h, w = net.input_info[input_blob].input_data.shape
     images = np.ndarray(shape=(n, c, h, w))
     for i in range(n):
         image = cv2.imread(args.input[i])
@@ -143,7 +143,7 @@ def main():
 
     # create one inference request for asynchronous execution
     request_id = 0
-    infer_request = exec_net.requests[request_id];
+    infer_request = exec_net.requests[request_id]
 
     num_iter = 10
     request_wrap = InferReqWrap(infer_request, request_id, num_iter)

--- a/inference-engine/ie_bridges/python/sample/object_detection_sample_ssd/object_detection_sample_ssd.py
+++ b/inference-engine/ie_bridges/python/sample/object_detection_sample_ssd/object_detection_sample_ssd.py
@@ -84,13 +84,13 @@ def main():
 
     # --------------------------- 3. Read and preprocess input --------------------------------------------
 
-    print("inputs number: " + str(len(net.inputs.keys())))
+    print("inputs number: " + str(len(net.input_info.keys())))
 
-    for input_key in net.inputs:
-        print("input shape: " + str(net.inputs[input_key].shape))
+    for input_key in net.input_info:
+        print("input shape: " + str(net.input_info[input_key].input_data.shape))
         print("input key: " + input_key)
-        if len(net.inputs[input_key].layout) == 4:
-            n, c, h, w = net.inputs[input_key].shape
+        if len(net.input_info[input_key].input_data.layout) == 4:
+            n, c, h, w = net.input_info[input_key].input_data.shape
 
     images = np.ndarray(shape=(n, c, h, w))
     images_hw = []
@@ -111,21 +111,21 @@ def main():
     # --------------------------- 4. Configure input & output ---------------------------------------------
     # --------------------------- Prepare input blobs -----------------------------------------------------
     log.info("Preparing input blobs")
-    assert (len(net.inputs.keys()) == 1 or len(
-        net.inputs.keys()) == 2), "Sample supports topologies only with 1 or 2 inputs"
+    assert (len(net.input_info.keys()) == 1 or len(
+        net.input_info.keys()) == 2), "Sample supports topologies only with 1 or 2 inputs"
     out_blob = next(iter(net.outputs))
     input_name, input_info_name = "", ""
 
-    for input_key in net.inputs:
-        if len(net.inputs[input_key].layout) == 4:
+    for input_key in net.input_info:
+        if len(net.input_info[input_key].layout) == 4:
             input_name = input_key
             log.info("Batch size is {}".format(net.batch_size))
-            net.inputs[input_key].precision = 'U8'
-        elif len(net.inputs[input_key].layout) == 2:
+            net.input_info[input_key].precision = 'U8'
+        elif len(net.input_info[input_key].layout) == 2:
             input_info_name = input_key
-            net.inputs[input_key].precision = 'FP32'
-            if net.inputs[input_key].shape[1] != 3 and net.inputs[input_key].shape[1] != 6 or \
-                net.inputs[input_key].shape[0] != 1:
+            net.input_info[input_key].precision = 'FP32'
+            if net.input_info[input_key].input_data.shape[1] != 3 and net.input_info[input_key].input_data.shape[1] != 6 or \
+                net.input_info[input_key].input_data.shape[0] != 1:
                 log.error('Invalid input info. Should be 3 or 6 values length.')
 
     data = {}

--- a/inference-engine/ie_bridges/python/sample/style_transfer_sample/style_transfer_sample.py
+++ b/inference-engine/ie_bridges/python/sample/style_transfer_sample/style_transfer_sample.py
@@ -77,16 +77,16 @@ def main():
                       "or --cpu_extension command line argument")
             sys.exit(1)
 
-    assert len(net.inputs.keys()) == 1, "Sample supports only single input topologies"
+    assert len(net.input_info.keys()) == 1, "Sample supports only single input topologies"
     assert len(net.outputs) == 1, "Sample supports only single output topologies"
 
     log.info("Preparing input blobs")
-    input_blob = next(iter(net.inputs))
+    input_blob = next(iter(net.input_info))
     out_blob = next(iter(net.outputs))
     net.batch_size = len(args.input)
 
     # Read and pre-process input images
-    n, c, h, w = net.inputs[input_blob].shape
+    n, c, h, w = net.input_info[input_blob].input_data.shape
     images = np.ndarray(shape=(n, c, h, w))
     for i in range(n):
         image = cv2.imread(args.input[i])

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/__init__.py
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/__init__.py
@@ -1,4 +1,4 @@
 from .ie_api import *
-__all__ = ['IENetwork', "IETensorDesc", "IECore", "IEBlob", "get_version"]
+__all__ = ['IENetwork', "TensorDesc", "IECore", "Blob", "get_version"]
 __version__ = get_version()
 

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/constants.pyx
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/constants.pyx
@@ -16,6 +16,7 @@
 from .cimport ie_api_impl_defs as C
 
 import numpy as np
+from enum import Enum
 
 supported_precisions = ["FP32", "FP16", "I64", "U64", "I32", "I16", "I8", "U16", "U8"]
 
@@ -54,6 +55,28 @@ layout_str_to_enum = {'ANY': C.Layout.ANY,
                       }
 
 
+class MeanVariant(Enum):
+    MEAN_IMAGE = 0
+    MEAN_VALUE = 1
+    NONE = 2
+
+
+class ResizeAlgorithm(Enum):
+    NO_RESIZE = 0
+    RESIZE_BILINEAR = 1
+    RESIZE_AREA = 2
+
+
+class ColorFormat(Enum):
+    RAW = 0
+    RGB = 1
+    BGR = 2
+    RGBX = 3
+    BGRX = 4
+    NV12 = 5
+    I420 = 6
+
+
 cpdef enum StatusCode:
     OK = 0
     GENERAL_ERROR = -1
@@ -68,6 +91,7 @@ cpdef enum StatusCode:
     NOT_ALLOCATED = -10
     INFER_NOT_STARTED = -11
     NETWORK_NOT_READ = -12
+
 
 cpdef enum WaitMode:
     RESULT_READY = -1

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pxd
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pxd
@@ -1,5 +1,5 @@
 from .cimport ie_api_impl_defs as C
-from .ie_api_impl_defs cimport Blob, TensorDesc
+from .ie_api_impl_defs cimport CBlob, CTensorDesc, InputInfo, CPreProcessChannel, CPreProcessInfo
 
 from pathlib import Path
 
@@ -8,18 +8,18 @@ from libcpp.vector cimport vector
 from libcpp cimport bool
 from libcpp.memory cimport unique_ptr, shared_ptr
 
-cdef class IEBlob:
-    cdef Blob.Ptr _ptr
+cdef class Blob:
+    cdef CBlob.Ptr _ptr
     cdef public object _array_data
     cdef public object _initial_shape
 
 cdef class BlobBuffer:
-    cdef Blob.Ptr ptr
+    cdef CBlob.Ptr ptr
     cdef char*format
     cdef vector[Py_ssize_t] shape
     cdef vector[Py_ssize_t] strides
-    cdef reset(self, Blob.Ptr &, vector[size_t] representation_shape = ?)
-    cdef char*_get_blob_format(self, const TensorDesc & desc)
+    cdef reset(self, CBlob.Ptr &, vector[size_t] representation_shape = ?)
+    cdef char*_get_blob_format(self, const CTensorDesc & desc)
 
     cdef public:
         total_stride, item_size
@@ -76,5 +76,17 @@ cdef class CDataPtr:
 cdef class IENetLayer:
     cdef C.CNNLayerPtr _ptr
 
-cdef class IETensorDesc:
-    cdef C.TensorDesc impl
+cdef class TensorDesc:
+    cdef C.CTensorDesc impl
+
+cdef class InputInfoPtr:
+    cdef InputInfo.Ptr _ptr
+
+cdef class InputInfoCPtr:
+    cdef InputInfo.CPtr _ptr
+
+cdef class PreProcessInfo:
+    cdef CPreProcessInfo* _ptr
+
+cdef class PreProcessChannel:
+    cdef CPreProcessChannel.Ptr _ptr

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.cpp
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.cpp
@@ -261,6 +261,15 @@ PyObject* InferenceEnginePython::IENetwork::getFunction() {
     }
 }
 
+const std::map <std::string, InferenceEngine::InputInfo::Ptr> InferenceEnginePython::IENetwork::getInputsInfo() {
+    std::map <std::string, InferenceEngine::InputInfo::Ptr> inputs;
+    const InferenceEngine::InputsDataMap &inputsInfo = actual->getInputsInfo();
+    for (auto &in : inputsInfo) {
+        inputs[in.first] = in.second;
+    }
+    return inputs;
+}
+
 const std::map <std::string, InferenceEngine::DataPtr> InferenceEnginePython::IENetwork::getInputs() {
     std::map <std::string, InferenceEngine::DataPtr> inputs;
     const InferenceEngine::InputsDataMap &inputsInfo = actual->getInputsInfo();
@@ -457,6 +466,17 @@ std::map <std::string, InferenceEngine::DataPtr> InferenceEnginePython::IEExecNe
     std::map <std::string, InferenceEngine::DataPtr> pyInputs;
     for (const auto &item : inputsDataMap) {
         pyInputs[item.first] = item.second->getInputData();
+    }
+    return pyInputs;
+}
+
+std::map <std::string, InferenceEngine::InputInfo::CPtr> InferenceEnginePython::IEExecNetwork::getInputsInfo() {
+    InferenceEngine::ConstInputsDataMap inputsDataMap;
+    InferenceEngine::ResponseDesc response;
+    IE_CHECK_CALL(actual->GetInputsInfo(inputsDataMap, &response));
+    std::map <std::string, InferenceEngine::InputInfo::CPtr> pyInputs;
+    for (const auto &item : inputsDataMap) {
+        pyInputs[item.first] = item.second;
     }
     return pyInputs;
 }

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.hpp
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.hpp
@@ -52,6 +52,8 @@ struct IENetwork {
 
     const std::vector <InferenceEngine::CNNLayerPtr> getLayers();
 
+    const std::map<std::string, InferenceEngine::InputInfo::Ptr> getInputsInfo();
+
     const std::map<std::string, InferenceEngine::DataPtr> getInputs();
 
     const std::map<std::string, InferenceEngine::DataPtr> getOutputs();
@@ -134,6 +136,7 @@ struct IEExecNetwork {
     void infer();
     void exportNetwork(const std::string & model_file);
 
+    std::map<std::string, InferenceEngine::InputInfo::CPtr> getInputsInfo();
     std::map<std::string, InferenceEngine::DataPtr> getInputs();
     std::map<std::string, InferenceEngine::CDataPtr> getOutputs();
 

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl_defs.pxd
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl_defs.pxd
@@ -15,19 +15,19 @@ cdef extern from "<inference_engine.hpp>" namespace "InferenceEngine":
     cdef cppclass TBlob[T]:
         ctypedef shared_ptr[TBlob[T]] Ptr
 
-    cdef cppclass Blob:
-        ctypedef shared_ptr[Blob] Ptr
-        const TensorDesc& getTensorDesc()  except +
+    cdef cppclass CBlob "InferenceEngine::Blob":
+        ctypedef shared_ptr[CBlob] Ptr
+        const CTensorDesc& getTensorDesc()  except +
         size_t element_size()  except +
         void allocate()
 
-    cdef TBlob[Type].Ptr make_shared_blob[Type](const TensorDesc& tensorDesc)
+    cdef TBlob[Type].Ptr make_shared_blob[Type](const CTensorDesc& tensorDesc)
 
-    cdef TBlob[Type].Ptr make_shared_blob[Type](const TensorDesc& tensorDesc, Type* ptr, size_t size)
+    cdef TBlob[Type].Ptr make_shared_blob[Type](const CTensorDesc& tensorDesc, Type* ptr, size_t size)
 
-    cdef cppclass TensorDesc:
-        TensorDesc() except +
-        TensorDesc(const Precision& precision, SizeVector dims, Layout layout) except +
+    cdef cppclass CTensorDesc "InferenceEngine::TensorDesc":
+        CTensorDesc() except +
+        CTensorDesc(const Precision& precision, SizeVector dims, Layout layout) except +
         SizeVector& getDims() except +
         void setDims(const SizeVector& dims) except +
         Layout getLayout() except +
@@ -52,6 +52,42 @@ cdef extern from "<inference_engine.hpp>" namespace "InferenceEngine":
     ctypedef shared_ptr[const Data] CDataPtr
 
 
+    cdef cppclass InputInfo:
+        ctypedef shared_ptr[InputInfo] Ptr
+        ctypedef shared_ptr[const InputInfo] CPtr
+        Precision getPrecision() const
+        void setPrecision(Precision p)
+        Layout getLayout()
+        void setLayout(Layout l)
+        const string& name() const
+        DataPtr getInputData() const
+        CPreProcessInfo& getPreProcess()
+        const CTensorDesc& getTensorDesc() const
+        void setInputData(DataPtr inputPtr)
+
+
+    cdef cppclass CPreProcessChannel "InferenceEngine::PreProcessChannel":
+        ctypedef shared_ptr[CPreProcessChannel] Ptr
+        CBlob.Ptr meanData
+        float stdScale
+        float meanValue
+
+    cdef cppclass CPreProcessInfo "InferenceEngine::PreProcessInfo":
+        CPreProcessChannel.Ptr& operator[](size_t index)
+        size_t getNumberOfChannels() const
+        void init(const size_t numberOfChannels)
+        void setMeanImage(const CBlob.Ptr& meanImage)
+        void setMeanImageForChannel(const CBlob.Ptr& meanImage, const size_t channel)
+        vector[CPreProcessChannel.Ptr] _channelsInfo
+        ColorFormat getColorFormat() const
+        void setColorFormat(ColorFormat fmt)
+        ResizeAlgorithm getResizeAlgorithm() const
+        void setResizeAlgorithm(const ResizeAlgorithm& alg)
+        MeanVariant getMeanVariant() const
+        void setVariant(const MeanVariant& variant)
+
+    ctypedef map[string, InputInfo.CPtr] InputsDataMap
+
     cdef cppclass Precision:
         const char*name() const
         @staticmethod
@@ -65,7 +101,7 @@ cdef extern from "<inference_engine.hpp>" namespace "InferenceEngine":
         vector[DataWeakPtr] insData
         string affinity
         map[string, string] params
-        map[string, Blob.Ptr] blobs
+        map[string, CBlob.Ptr] blobs
 
     ctypedef weak_ptr[CNNLayer] CNNLayerWeakPtr
     ctypedef shared_ptr[CNNLayer] CNNLayerPtr
@@ -79,6 +115,25 @@ cdef extern from "<inference_engine.hpp>" namespace "InferenceEngine":
         const char *buildNumber
         const char *description
         apiVersion apiVersion
+
+    cpdef enum MeanVariant:
+        MEAN_IMAGE
+        MEAN_VALUE
+        NONE
+
+    cpdef enum ResizeAlgorithm:
+        NO_RESIZE
+        RESIZE_BILINEAR
+        RESIZE_AREA
+
+    cpdef enum ColorFormat:
+        RAW
+        RGB
+        BGR
+        RGBX
+        BGRX
+        NV12
+        I420
 
     cdef enum Layout:
         ANY
@@ -109,15 +164,16 @@ cdef extern from "ie_api_impl.hpp" namespace "InferenceEnginePython":
         unsigned int execution_index
 
     cdef cppclass WeightsInfo:
-        Blob.Ptr & weights;
-        Blob.Ptr & biases;
-        map[string, Blob.Ptr] custom_blobs;
+        CBlob.Ptr & weights;
+        CBlob.Ptr & biases;
+        map[string, CBlob.Ptr] custom_blobs;
 
     cdef cppclass IEExecNetwork:
         vector[InferRequestWrap] infer_requests
         IENetwork GetExecGraphInfo() except +
         map[string, DataPtr] getInputs() except +
         map[string, CDataPtr] getOutputs() except +
+        map[string, InputInfo.CPtr] getInputsInfo()
         void exportNetwork(const string & model_file) except +
         object getMetric(const string & metric_name) except +
         object getConfig(const string & metric_name) except +
@@ -133,7 +189,8 @@ cdef extern from "ie_api_impl.hpp" namespace "InferenceEnginePython":
         string precision
         map[string, vector[size_t]] inputs
         const vector[CNNLayerPtr] getLayers() except +
-        map[string, DataPtr] getInputs() except +
+        const map[string, InputInfo.Ptr] getInputsInfo() except +
+        const map[string, DataPtr] getInputs() except +
         map[string, DataPtr] getOutputs() except +
         void addOutput(string &, size_t) except +
         void setAffinity(map[string, string] & types_affinity_map, map[string, string] & layers_affinity_map) except +
@@ -161,8 +218,8 @@ cdef extern from "ie_api_impl.hpp" namespace "InferenceEnginePython":
     cdef cppclass InferRequestWrap:
         double exec_time;
         int index;
-        void getBlobPtr(const string & blob_name, Blob.Ptr & blob_ptr) except +
-        void setBlob(const string & blob_name, const Blob.Ptr & blob_ptr) except +
+        void getBlobPtr(const string & blob_name, CBlob.Ptr & blob_ptr) except +
+        void setBlob(const string & blob_name, const CBlob.Ptr & blob_ptr) except +
         map[string, ProfileInfo] getPerformanceCounts() except +
         void infer() except +
         void infer_async() except +
@@ -191,6 +248,6 @@ cdef extern from "ie_api_impl.hpp" namespace "InferenceEnginePython":
         object getMetric(const string & deviceName, const string & name) except +
         object getConfig(const string & deviceName, const string & name) except +
 
-    cdef T*get_buffer[T](Blob &)
+    cdef T*get_buffer[T](CBlob &)
 
     cdef string get_version()

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl_defs.pxd
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl_defs.pxd
@@ -117,23 +117,13 @@ cdef extern from "<inference_engine.hpp>" namespace "InferenceEngine":
         apiVersion apiVersion
 
     cpdef enum MeanVariant:
-        MEAN_IMAGE
-        MEAN_VALUE
-        NONE
+        pass
 
     cpdef enum ResizeAlgorithm:
-        NO_RESIZE
-        RESIZE_BILINEAR
-        RESIZE_AREA
+        pass
 
     cpdef enum ColorFormat:
-        RAW
-        RGB
-        BGR
-        RGBX
-        BGRX
-        NV12
-        I420
+        pass
 
     cdef enum Layout:
         ANY

--- a/inference-engine/ie_bridges/python/tests/test_Blob.py
+++ b/inference-engine/ie_bridges/python/tests/test_Blob.py
@@ -2,111 +2,122 @@ import pytest
 
 import numpy as np
 
-from openvino.inference_engine import IETensorDesc, IEBlob
+from openvino.inference_engine import TensorDesc, Blob
 from conftest import image_path
 
 
 path_to_image = image_path()
 
+
 def test_init_with_tensor_desc():
-    tensor_desc = IETensorDesc("FP32", [1, 3, 127, 127], "NHWC")
-    blob = IEBlob(tensor_desc)
+    tensor_desc = TensorDesc("FP32", [1, 3, 127, 127], "NHWC")
+    blob = Blob(tensor_desc)
     assert isinstance(blob.buffer, np.ndarray)
     assert blob.tensor_desc == tensor_desc
 
 
 def test_init_with_numpy():
-    tensor_desc = IETensorDesc("FP32", [1, 3, 127, 127], "NCHW")
+    tensor_desc = TensorDesc("FP32", [1, 3, 127, 127], "NCHW")
     array = np.ones(shape=(1, 3, 127, 127), dtype=np.float32)
-    blob = IEBlob(tensor_desc, array)
+    blob = Blob(tensor_desc, array)
     assert isinstance(blob.buffer, np.ndarray)
     assert blob.tensor_desc == tensor_desc
 
 
 def test_get_tensor_desc():
-    tensor_desc = IETensorDesc("FP32", [1, 127, 127, 3], "NHWC")
-    blob = IEBlob(tensor_desc)
+    tensor_desc = TensorDesc("FP32", [1, 127, 127, 3], "NHWC")
+    blob = Blob(tensor_desc)
     assert blob.tensor_desc == tensor_desc
 
 
 def test_get_buffer():
-    tensor_desc = IETensorDesc("FP32", [1, 3, 127, 127], "NCHW")
+    tensor_desc = TensorDesc("FP32", [1, 3, 127, 127], "NCHW")
     array = np.ones(shape=(1, 3, 127, 127), dtype=np.float32)
-    blob = IEBlob(tensor_desc, array)
+    blob = Blob(tensor_desc, array)
     assert np.array_equal(blob.buffer, array)
 
+
 def test_write_to_buffer_fp32():
-    tensor_desc = IETensorDesc("FP32", [1, 3, 127, 127], "NCHW")
+    tensor_desc = TensorDesc("FP32", [1, 3, 127, 127], "NCHW")
     array = np.zeros(shape=(1, 3, 127, 127), dtype=np.float32)
-    blob = IEBlob(tensor_desc, array)
+    blob = Blob(tensor_desc, array)
     ones_arr = np.ones(shape=(1, 3, 127, 127), dtype=np.float32)
     blob.buffer[:] = ones_arr
-    assert  np.array_equal(blob.buffer, ones_arr)
+    assert np.array_equal(blob.buffer, ones_arr)
+
 
 @pytest.mark.skip(reason="Need to figure out how to implement right conversion")
 def test_write_to_buffer_fp16():
-    tensor_desc = IETensorDesc("FP16", [1, 3, 127, 127], "NCHW")
+    tensor_desc = TensorDesc("FP16", [1, 3, 127, 127], "NCHW")
     array = np.zeros(shape=(1, 3, 127, 127), dtype=np.float16)
-    blob = IEBlob(tensor_desc, array)
+    blob = Blob(tensor_desc, array)
     ones_arr = np.ones(shape=(1, 3, 127, 127), dtype=np.float16)
     blob.buffer[:] = ones_arr
-    assert  np.array_equal(blob.buffer, ones_arr)
+    assert np.array_equal(blob.buffer, ones_arr)
+
 
 def test_write_to_buffer_int8():
-    tensor_desc = IETensorDesc("I8", [1, 3, 127, 127], "NCHW")
+    tensor_desc = TensorDesc("I8", [1, 3, 127, 127], "NCHW")
     array = np.zeros(shape=(1, 3, 127, 127), dtype=np.int8)
-    blob = IEBlob(tensor_desc, array)
+    blob = Blob(tensor_desc, array)
     ones_arr = np.ones(shape=(1, 3, 127, 127), dtype=np.int8)
     blob.buffer[:] = ones_arr
-    assert  np.array_equal(blob.buffer, ones_arr)
+    assert np.array_equal(blob.buffer, ones_arr)
+
 
 def test_write_to_buffer_uint8():
-    tensor_desc = IETensorDesc("U8", [1, 3, 127, 127], "NCHW")
+    tensor_desc = TensorDesc("U8", [1, 3, 127, 127], "NCHW")
     array = np.zeros(shape=(1, 3, 127, 127), dtype=np.uint8)
-    blob = IEBlob(tensor_desc, array)
+    blob = Blob(tensor_desc, array)
     ones_arr = np.ones(shape=(1, 3, 127, 127), dtype=np.uint8)
     blob.buffer[:] = ones_arr
-    assert  np.array_equal(blob.buffer, ones_arr)
+    assert np.array_equal(blob.buffer, ones_arr)
+
 
 def test_write_to_buffer_int32():
-    tensor_desc = IETensorDesc("I32", [1, 3, 127, 127], "NCHW")
+    tensor_desc = TensorDesc("I32", [1, 3, 127, 127], "NCHW")
     array = np.zeros(shape=(1, 3, 127, 127), dtype=np.int32)
-    blob = IEBlob(tensor_desc, array)
+    blob = Blob(tensor_desc, array)
     ones_arr = np.ones(shape=(1, 3, 127, 127), dtype=np.int32)
     blob.buffer[:] = ones_arr
-    assert  np.array_equal(blob.buffer, ones_arr)
+    assert np.array_equal(blob.buffer, ones_arr)
+
 
 def test_write_to_buffer_int16():
-    tensor_desc = IETensorDesc("I16", [1, 3, 127, 127], "NCHW")
+    tensor_desc = TensorDesc("I16", [1, 3, 127, 127], "NCHW")
     array = np.zeros(shape=(1, 3, 127, 127), dtype=np.int16)
-    blob = IEBlob(tensor_desc, array)
-    ones_arr = np.ones(shape=(1, 3, 127, 127), dtype= np.int16)
+    blob = Blob(tensor_desc, array)
+    ones_arr = np.ones(shape=(1, 3, 127, 127), dtype=np.int16)
     blob.buffer[:] = ones_arr
-    assert  np.array_equal(blob.buffer, ones_arr)
+    assert np.array_equal(blob.buffer, ones_arr)
+
 
 def test_write_to_buffer_uint16():
-    tensor_desc = IETensorDesc("U16", [1, 3, 127, 127], "NCHW")
+    tensor_desc = TensorDesc("U16", [1, 3, 127, 127], "NCHW")
     array = np.zeros(shape=(1, 3, 127, 127), dtype=np.uint16)
-    blob = IEBlob(tensor_desc, array)
+    blob = Blob(tensor_desc, array)
     ones_arr = np.ones(shape=(1, 3, 127, 127), dtype=np.uint16)
     blob.buffer[:] = ones_arr
-    assert  np.array_equal(blob.buffer, ones_arr)
+    assert np.array_equal(blob.buffer, ones_arr)
+
 
 def test_write_to_buffer_int64():
-    tensor_desc = IETensorDesc("I64", [1, 3, 127, 127], "NCHW")
+    tensor_desc = TensorDesc("I64", [1, 3, 127, 127], "NCHW")
     array = np.zeros(shape=(1, 3, 127, 127), dtype=np.int64)
-    blob = IEBlob(tensor_desc, array)
+    blob = Blob(tensor_desc, array)
     ones_arr = np.ones(shape=(1, 3, 127, 127), dtype=np.int64)
     blob.buffer[:] = ones_arr
-    assert  np.array_equal(blob.buffer, ones_arr)
+    assert np.array_equal(blob.buffer, ones_arr)
+
 
 def test_incompatible_array_and_td():
-    tensor_desc = IETensorDesc("FP32", [1, 3, 127, 127], "NCHW")
+    tensor_desc = TensorDesc("FP32", [1, 3, 127, 127], "NCHW")
     array = np.zeros(shape=(1, 2, 3, 4), dtype=np.float32)
     with pytest.raises(AttributeError) as e:
-        IEBlob(tensor_desc, array)
+        Blob(tensor_desc, array)
     assert "Number of elements in provided numpy array 24 and " \
            "required by TensorDesc 48387 are not equal" in str(e.value)
+
 
 def test_incompatible_input_precision():
     import cv2
@@ -118,8 +129,8 @@ def test_incompatible_input_precision():
     image = cv2.resize(image, (h, w))
     image = image.transpose((2, 0, 1))
     image = image.reshape((n, c, h, w))
-    tensor_desc = IETensorDesc("FP32", [1, 3, 32, 32], "NCHW")
+    tensor_desc = TensorDesc("FP32", [1, 3, 32, 32], "NCHW")
     with pytest.raises(ValueError) as e:
-        IEBlob(tensor_desc, image)
+        Blob(tensor_desc, image)
     assert "Data type float64 of provided numpy array " \
            "doesn't match to TensorDesc precision FP32" in str(e.value)

--- a/inference-engine/ie_bridges/python/tests/test_CDataPtr.py
+++ b/inference-engine/ie_bridges/python/tests/test_CDataPtr.py
@@ -6,6 +6,7 @@ from conftest import model_path
 
 test_net_xml, test_net_bin = model_path()
 
+
 def test_name(device):
     ie = IECore()
     net = ie.read_network(model=test_net_xml, weights=test_net_bin)

--- a/inference-engine/ie_bridges/python/tests/test_DataPtr.py
+++ b/inference-engine/ie_bridges/python/tests/test_DataPtr.py
@@ -6,6 +6,7 @@ from conftest import model_path
 
 test_net_xml, test_net_bin = model_path()
 
+
 def layer_out_data():
     ie = IECore()
     net = ie.read_network(model=test_net_xml, weights=test_net_bin)

--- a/inference-engine/ie_bridges/python/tests/test_IENetLayer.py
+++ b/inference-engine/ie_bridges/python/tests/test_IENetLayer.py
@@ -7,6 +7,7 @@ from conftest import model_path
 
 test_net_xml, test_net_bin = model_path()
 
+
 def test_name():
     ie = IECore()
     net = ie.read_network(model=test_net_xml, weights=test_net_bin)
@@ -27,6 +28,7 @@ def test_precision_getter(recwarn):
     assert len(recwarn) == 1
     assert recwarn.pop(DeprecationWarning)
 
+
 def test_precision_setter(recwarn):
     warnings.simplefilter("always")
     ie = IECore()
@@ -35,6 +37,7 @@ def test_precision_setter(recwarn):
     assert net.layers['27'].precision == "I8"
     assert len(recwarn) == 1
     assert recwarn.pop(DeprecationWarning)
+
 
 def test_affinuty_getter():
     ie = IECore()
@@ -56,6 +59,7 @@ def test_blobs():
     assert isinstance(net.layers['19/Fused_Add_'].blobs["weights"], numpy.ndarray)
     assert net.layers['19/Fused_Add_'].blobs["biases"].size != 0
     assert net.layers['19/Fused_Add_'].blobs["weights"].size != 0
+
 
 def test_weights(recwarn):
     warnings.simplefilter("always")
@@ -123,6 +127,7 @@ def test_out_data():
     ie = IECore()
     net = ie.read_network(model=test_net_xml, weights=test_net_bin)
     assert isinstance(net.layers['27'].out_data[0], DataPtr)
+
 
 def test_in_data():
     ie = IECore()

--- a/inference-engine/ie_bridges/python/tests/test_IEPlugin.py
+++ b/inference-engine/ie_bridges/python/tests/test_IEPlugin.py
@@ -7,6 +7,7 @@ from conftest import model_path
 
 test_net_xml, test_net_bin = model_path()
 
+
 def test_init_plugin(device):
     with warnings.catch_warnings(record=True) as w:
         plugin = IEPlugin(device, None)

--- a/inference-engine/ie_bridges/python/tests/test_InputInfoCPtr.py
+++ b/inference-engine/ie_bridges/python/tests/test_InputInfoCPtr.py
@@ -1,0 +1,54 @@
+import pytest
+
+from openvino.inference_engine import InputInfoCPtr, DataPtr, IECore, TensorDesc
+from conftest import model_path
+
+
+test_net_xml, test_net_bin = model_path()
+
+
+def test_name(device):
+    ie = IECore()
+    net = ie.read_network(model=test_net_xml, weights=test_net_bin)
+    exec_net = ie.load_network(net, device, num_requests=5)
+    assert isinstance(exec_net.input_info['data'], InputInfoCPtr)
+    assert exec_net.input_info['data'].name == "data", "Incorrect name"
+    del exec_net
+
+
+def test_precision(device):
+    ie = IECore()
+    net = ie.read_network(model=test_net_xml, weights=test_net_bin)
+    exec_net = ie.load_network(net, device, num_requests=5)
+    assert isinstance(exec_net.input_info['data'], InputInfoCPtr)
+    assert exec_net.input_info['data'].precision == "FP32", "Incorrect precision"
+    del exec_net
+
+
+def test_no_precision_setter(device):
+    ie = IECore()
+    net = ie.read_network(model=test_net_xml, weights=test_net_bin)
+    exec_net = ie.load_network(net, device, num_requests=5)
+    with pytest.raises(AttributeError) as e:
+        exec_net.input_info['data'].precision = "I8"
+    assert "attribute 'precision' of 'openvino.inference_engine.ie_api.InputInfoCPtr' " \
+           "objects is not writable" in str(e.value)
+    del exec_net
+
+
+def test_input_data(device):
+    ie = IECore()
+    net = ie.read_network(model=test_net_xml, weights=test_net_bin)
+    exec_net = ie.load_network(net, device, num_requests=5)
+    assert isinstance(exec_net.input_info['data'], InputInfoCPtr)
+    assert isinstance(exec_net.input_info['data'].input_data, DataPtr), "Incorrect precision for layer 'fc_out'"
+    del exec_net
+
+
+def test_tensor_desc(device):
+    ie = IECore()
+    net = ie.read_network(model=test_net_xml, weights=test_net_bin)
+    exec_net = ie.load_network(net, device, num_requests=5)
+    tensor_desc = exec_net.input_info['data'].tensor_desc
+    assert isinstance(tensor_desc, TensorDesc)
+    assert tensor_desc.layout == "NCHW"

--- a/inference-engine/ie_bridges/python/tests/test_InputInfoPtr.py
+++ b/inference-engine/ie_bridges/python/tests/test_InputInfoPtr.py
@@ -1,0 +1,84 @@
+import pytest
+
+from openvino.inference_engine import InputInfoPtr, PreProcessInfo, DataPtr, IECore, TensorDesc, ColorFormat
+from conftest import model_path
+
+
+test_net_xml, test_net_bin = model_path()
+
+
+def get_input_info():
+    ie = IECore()
+    net = ie.read_network(model=test_net_xml, weights=test_net_bin)
+    return net.input_info["data"]
+
+
+def test_input_info():
+    assert isinstance(get_input_info(), InputInfoPtr)
+
+
+def test_input_data():
+    assert isinstance(get_input_info().input_data, DataPtr)
+
+
+def test_input_data_setter():
+    ie = IECore()
+    net = ie.read_network(model=test_net_xml, weights=test_net_bin)
+    input_info = net.input_info["data"]
+    other_input_data = net.outputs["fc_out"]
+    input_info.input_data = other_input_data
+    assert input_info.input_data.name == "fc_out"
+
+
+def test_incorrect_input_info_setter():
+    with pytest.raises(TypeError) as e:
+        get_input_info().input_data = "dfds"
+    assert "Argument 'input_ptr' has incorrect type" in str(e.value)
+
+
+def test_name():
+    assert get_input_info().name == "data"
+
+
+def test_precision():
+    assert get_input_info().precision == "FP32"
+
+
+def test_precision_setter():
+    input_info = get_input_info()
+    input_info.precision = "I8"
+    assert input_info.precision == "I8", "Incorrect precision"
+
+
+def test_incorrect_precision_setter():
+    with pytest.raises(ValueError) as e:
+        get_input_info().precision = "123"
+    assert "Unsupported precision 123! List of supported precisions:" in str(e.value)
+
+
+def test_layout():
+    assert get_input_info().layout == "NCHW"
+
+
+def test_layout_setter():
+    input_info = get_input_info()
+    input_info.layout = "NHWC"
+    assert input_info.layout == "NHWC", "Incorrect layout"
+
+
+def test_incorrect_layout_setter():
+    with pytest.raises(ValueError) as e:
+        get_input_info().layout = "123"
+    assert "Unsupported layout 123! List of supported layouts:" in str(e.value)
+
+
+def test_preprocess_info():
+    preprocess_info = get_input_info().preprocess_info
+    assert isinstance(preprocess_info, PreProcessInfo)
+    assert preprocess_info.color_format == ColorFormat.RAW
+
+
+def test_tensor_desc():
+    tensor_desc = get_input_info().tensor_desc
+    assert isinstance(tensor_desc, TensorDesc)
+    assert tensor_desc.layout == "NCHW"

--- a/inference-engine/ie_bridges/python/tests/test_PreProcessInfo.py
+++ b/inference-engine/ie_bridges/python/tests/test_PreProcessInfo.py
@@ -1,0 +1,97 @@
+import pytest
+
+from openvino.inference_engine import PreProcessInfo, IECore, TensorDesc, Blob, PreProcessChannel,\
+    MeanVariant, ResizeAlgorithm, ColorFormat
+from conftest import model_path
+
+
+test_net_xml, test_net_bin = model_path()
+
+
+def get_preprocess_info():
+    ie_core = IECore()
+    net = ie_core.read_network(model=test_net_xml, weights=test_net_bin)
+    return net.input_info["data"].preprocess_info
+
+
+def test_preprocess_info():
+    assert isinstance(get_preprocess_info(), PreProcessInfo)
+
+
+def test_color_format():
+    preprocess_info = get_preprocess_info()
+    assert preprocess_info.color_format == ColorFormat.RAW
+
+
+def test_color_format_setter():
+    preprocess_info = get_preprocess_info()
+    preprocess_info.color_format = ColorFormat.BGR
+    assert preprocess_info.color_format == ColorFormat.BGR
+
+
+def test_resize_algorithm():
+    preprocess_info = get_preprocess_info()
+    assert preprocess_info.resize_algorithm == ResizeAlgorithm.NO_RESIZE
+
+
+def test_resize_algorithm_setter():
+    preprocess_info = get_preprocess_info()
+    preprocess_info.resize_algorithm = ResizeAlgorithm.RESIZE_BILINEAR
+    assert preprocess_info.resize_algorithm == ResizeAlgorithm.RESIZE_BILINEAR
+
+
+def test_mean_variant():
+    preprocess_info = get_preprocess_info()
+    assert preprocess_info.mean_variant == MeanVariant.NONE
+
+
+def test_mean_variant_setter():
+    preprocess_info = get_preprocess_info()
+    preprocess_info.mean_variant = MeanVariant.MEAN_IMAGE
+    assert preprocess_info.mean_variant == MeanVariant.MEAN_IMAGE
+
+
+def test_get_number_of_channels():
+    ie_core = IECore()
+    net = ie_core.read_network(model=test_net_xml, weights=test_net_bin)
+    assert net.input_info["data"].preprocess_info.get_number_of_channels() == 0
+
+
+def test_init():
+    ie_core = IECore()
+    net = ie_core.read_network(model=test_net_xml, weights=test_net_bin)
+    net.input_info['data'].preprocess_info.init(5)
+    assert net.input_info["data"].preprocess_info.get_number_of_channels() == 5
+
+
+def test_set_mean_image():
+    ie_core = IECore()
+    net = ie_core.read_network(model=test_net_xml, weights=test_net_bin)
+    tensor_desc = TensorDesc("FP32", [0, 127, 127], "CHW")
+    mean_image_blob = Blob(tensor_desc)
+    preprocess_info = net.input_info["data"].preprocess_info
+    preprocess_info.set_mean_image(mean_image_blob)
+    assert preprocess_info.mean_variant == MeanVariant.MEAN_IMAGE
+
+
+def test_get_pre_process_channel():
+    ie_core = IECore()
+    net = ie_core.read_network(model=test_net_xml, weights=test_net_bin)
+    preprocess_info = net.input_info["data"].preprocess_info
+    preprocess_info.init(1)
+    pre_process_channel = preprocess_info[0]
+    assert isinstance(pre_process_channel, PreProcessChannel)
+
+
+def test_set_mean_image_for_channel():
+    ie_core = IECore()
+    net = ie_core.read_network(model=test_net_xml, weights=test_net_bin)
+    tensor_desc = TensorDesc("FP32", [127, 127], "HW")
+    mean_image_blob = Blob(tensor_desc)
+    preprocess_info = net.input_info["data"].preprocess_info
+    preprocess_info.init(1)
+    preprocess_info.set_mean_image_for_channel(mean_image_blob, 0)
+    pre_process_channel = preprocess_info[0]
+    assert isinstance(pre_process_channel.mean_data, Blob)
+    assert pre_process_channel.mean_data.tensor_desc.dims == [127, 127]
+    assert preprocess_info.mean_variant == MeanVariant.MEAN_IMAGE

--- a/inference-engine/ie_bridges/python/tests/test_TensorDesk.py
+++ b/inference-engine/ie_bridges/python/tests/test_TensorDesk.py
@@ -1,37 +1,37 @@
 import pytest
 
-from openvino.inference_engine import IETensorDesc
+from openvino.inference_engine import TensorDesc
 
 
 def test_init():
-    tensor_desc = IETensorDesc("FP32", [1, 127, 127, 3], "NHWC")
-    assert isinstance(tensor_desc, IETensorDesc)
+    tensor_desc = TensorDesc("FP32", [1, 127, 127, 3], "NHWC")
+    assert isinstance(tensor_desc, TensorDesc)
 
 
 def test_precision():
-    tensor_desc = IETensorDesc("FP32", [1, 127, 127, 3], "NHWC")
+    tensor_desc = TensorDesc("FP32", [1, 127, 127, 3], "NHWC")
     assert tensor_desc.precision == "FP32"
 
 
 def test_layout():
-    tensor_desc = IETensorDesc("FP32", [1, 127, 127, 3], "NHWC")
+    tensor_desc = TensorDesc("FP32", [1, 127, 127, 3], "NHWC")
     assert tensor_desc.layout == "NHWC"
 
 
 def test_dims():
-    tensor_desc = IETensorDesc("FP32", [1, 127, 127, 3], "NHWC")
+    tensor_desc = TensorDesc("FP32", [1, 127, 127, 3], "NHWC")
     assert tensor_desc.dims == [1, 127, 127, 3]
 
 
 def test_incorrect_precision_setter():
-    tensor_desc = IETensorDesc("FP32", [1, 127, 127, 3], "NHWC")
+    tensor_desc = TensorDesc("FP32", [1, 127, 127, 3], "NHWC")
     with pytest.raises(ValueError) as e:
         tensor_desc.precision = "123"
     assert "Unsupported precision 123! List of supported precisions:" in str(e.value)
 
 
 def test_incorrect_layout_setter():
-    tensor_desc = IETensorDesc("FP32", [1, 127, 127, 3], "NHWC")
+    tensor_desc = TensorDesc("FP32", [1, 127, 127, 3], "NHWC")
     with pytest.raises(ValueError) as e:
         tensor_desc.layout = "123"
     assert "Unsupported layout 123! List of supported layouts: " in str(e.value)
@@ -39,17 +39,17 @@ def test_incorrect_layout_setter():
 
 def test_init_incorrect_precision():
     with pytest.raises(ValueError) as e:
-        IETensorDesc("123", [1, 127, 127, 3], "NHWC")
+        TensorDesc("123", [1, 127, 127, 3], "NHWC")
     assert "Unsupported precision 123! List of supported precisions: " in str(e.value)
 
 
 def test_eq_operator():
-    tensor_desc = IETensorDesc("FP32", [1, 3, 127, 127], "NHWC")
-    tensor_desc_2 = IETensorDesc("FP32", [1, 3, 127, 127], "NHWC")
+    tensor_desc = TensorDesc("FP32", [1, 3, 127, 127], "NHWC")
+    tensor_desc_2 = TensorDesc("FP32", [1, 3, 127, 127], "NHWC")
     assert tensor_desc == tensor_desc_2
 
 
 def test_ne_operator():
-    tensor_desc = IETensorDesc("FP32", [1, 3, 127, 127], "NHWC")
-    tensor_desc_2 = IETensorDesc("FP32", [1, 3, 127, 127], "NCHW")
+    tensor_desc = TensorDesc("FP32", [1, 3, 127, 127], "NHWC")
+    tensor_desc_2 = TensorDesc("FP32", [1, 3, 127, 127], "NCHW")
     assert tensor_desc != tensor_desc_2


### PR DESCRIPTION
25481
Deprecate inputs property of IENetwork and ExecutableNetwork and provide inputs_info property instead. This allowed to align Python API with C++ API and get access to PreProcessInfo.
Reviewed  id: !5772