### PR TITLE
[CPU][BF16] Default Optimisation Capability of BF16 was enabled on CPX

### DIFF
--- a/inference-engine/include/ie_plugin_config.hpp
+++ b/inference-engine/include/ie_plugin_config.hpp
@@ -92,6 +92,7 @@ DECLARE_METRIC_KEY(FULL_DEVICE_NAME, std::string);
  *
  * The possible values:
  *  - "FP32" - device can support FP32 models
+ *  - "BF16" - device can support BF16 models
  *  - "FP16" - device can support FP16 models
  *  - "INT8" - device can support models with INT8 layers
  *  - "BIN" - device can support models with BIN layers
@@ -100,6 +101,7 @@ DECLARE_METRIC_KEY(FULL_DEVICE_NAME, std::string);
 DECLARE_METRIC_KEY(OPTIMIZATION_CAPABILITIES, std::vector<std::string>);
 
 DECLARE_METRIC_VALUE(FP32);
+DECLARE_METRIC_VALUE(BF16);
 DECLARE_METRIC_VALUE(FP16);
 DECLARE_METRIC_VALUE(INT8);
 DECLARE_METRIC_VALUE(BIN);

--- a/inference-engine/samples/benchmark_app/benchmark_app.hpp
+++ b/inference-engine/samples/benchmark_app/benchmark_app.hpp
@@ -49,7 +49,8 @@ static const char infer_num_streams_message[] = "Optional. Number of streams to 
                                                 "very small networks. See sample's README for more details.";
 
 /// @brief message for enforcing of BF16 execution where it is possible
-static const char enforce_bf16_message[] = "Optional. Enforcing of floating point operations execution in bfloat16 precision where it is acceptable.";
+static const char enforce_bf16_message[] = "Optional, \"YES\" or \"NO\". Enforcing of floating point operations execution in bfloat16 precision " \
+                                           "where it is acceptable.";
 
 /// @brief message for user library argument
 static const char custom_cpu_library_message[] = "Required for CPU custom layers. Absolute path to a shared library with the kernels implementations.";
@@ -149,7 +150,7 @@ DEFINE_uint32(nthreads, 0, infer_num_threads_message);
 DEFINE_string(nstreams, "", infer_num_streams_message);
 
 /// @brief Enforces bf16 execution with bfloat16 precision on systems having this capability
-DEFINE_bool(enforcebf16, false, enforce_bf16_message);
+DEFINE_string(enforcebf16, "YES", enforce_bf16_message);
 
 /// @brief Define parameter for batch size <br>
 /// Default is 0 (that means don't specify)

--- a/inference-engine/samples/benchmark_app/main.cpp
+++ b/inference-engine/samples/benchmark_app/main.cpp
@@ -244,7 +244,7 @@ int main(int argc, char *argv[]) {
                     device_config[CONFIG_KEY(CPU_THREADS_NUM)] = std::to_string(FLAGS_nthreads);
 
                 if (isFlagSetInCommandLine("enforcebf16"))
-                    device_config[CONFIG_KEY(ENFORCE_BF16)] = FLAGS_enforcebf16 ? CONFIG_VALUE(YES) : CONFIG_VALUE(NO);
+                    device_config[CONFIG_KEY(ENFORCE_BF16)] = FLAGS_enforcebf16;
 
                 if (isFlagSetInCommandLine("pin")) {
                     // set to user defined value

--- a/inference-engine/src/mkldnn_plugin/config.cpp
+++ b/inference-engine/src/mkldnn_plugin/config.cpp
@@ -73,11 +73,17 @@ void Config::readProperties(const std::map<std::string, std::string> &prop) {
         } else if (key.compare(PluginConfigParams::KEY_DUMP_QUANTIZED_GRAPH_AS_IR) == 0) {
             dumpQuantizedGraphToIr = val;
         } else if (key == PluginConfigParams::KEY_ENFORCE_BF16) {
-            if (val == PluginConfigParams::YES) enforceBF16 = true;
-            else if (val == PluginConfigParams::NO) enforceBF16 = false;
-            else
+            if (val == PluginConfigParams::YES) {
+                if (with_cpu_x86_bfloat16())
+                    enforceBF16 = true;
+                else
+                    THROW_IE_EXCEPTION << "Platform doesn't support BF16 format";
+            } else if (val == PluginConfigParams::NO) {
+                enforceBF16 = false;
+            } else {
                 THROW_IE_EXCEPTION << "Wrong value for property key " << PluginConfigParams::KEY_ENFORCE_BF16
                     << ". Expected only YES/NO";
+            }
         } else {
             THROW_IE_EXCEPTION << NOT_FOUND_str << "Unsupported property " << key << " by CPU plugin";
         }
@@ -118,6 +124,8 @@ void Config::updateProperties() {
         _config.insert({ PluginConfigParams::KEY_CPU_THROUGHPUT_STREAMS, std::to_string(streamExecutorConfig._streams) });
         _config.insert({ PluginConfigParams::KEY_CPU_THREADS_NUM, std::to_string(streamExecutorConfig._threads) });
         _config.insert({ PluginConfigParams::KEY_DUMP_EXEC_GRAPH_AS_DOT, dumpToDot });
+        if (!with_cpu_x86_bfloat16())
+            enforceBF16 = false;
         if (enforceBF16)
             _config.insert({ PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES });
         else

--- a/inference-engine/src/mkldnn_plugin/config.h
+++ b/inference-engine/src/mkldnn_plugin/config.h
@@ -32,14 +32,15 @@ struct Config {
     std::string dumpQuantizedGraphToDot = "";
     std::string dumpQuantizedGraphToIr = "";
     int batchLimit = 0;
-    bool enforceBF16 = false;
     InferenceEngine::IStreamsExecutor::Config streamExecutorConfig;
 
 #if defined(__arm__) || defined(__aarch64__)
     // Currently INT8 mode is not optimized on ARM, fallback to FP32 mode.
     LPTransformsMode lpTransformsMode = LPTransformsMode::Off;
+    bool enforceBF16 = false;
 #else
     LPTransformsMode lpTransformsMode = LPTransformsMode::On;
+    bool enforceBF16 = true;
 #endif
 
     void readProperties(const std::map<std::string, std::string> &config);

--- a/inference-engine/src/mkldnn_plugin/mkldnn_exec_network.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_exec_network.cpp
@@ -98,10 +98,10 @@ MKLDNNExecNetwork::MKLDNNExecNetwork(const InferenceEngine::ICNNNetwork &network
                 i++;
             }
 
-            if (with_cpu_x86_bfloat16() && isFloatModel) {
+            if (_cfg.enforceBF16 && isFloatModel) {
                 BF16Transformer bf16Transformer;
                 CNNNetwork cnnetwork(_clonedNetwork);
-                if (cfg.enforceBF16 == true) {
+                if (_cfg.enforceBF16 == true) {
                     bf16Transformer.convertToBFloat16(cnnetwork);
                 } else {
                     bf16Transformer.optimizeToFloat(cnnetwork);

--- a/inference-engine/src/mkldnn_plugin/mkldnn_plugin.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_plugin.cpp
@@ -175,6 +175,8 @@ Parameter Engine::GetMetric(const std::string& name, const std::map<std::string,
         IE_SET_METRIC_RETURN(AVAILABLE_DEVICES, availableDevices);
     } else if (name == METRIC_KEY(OPTIMIZATION_CAPABILITIES)) {
         std::vector<std::string> capabilities;
+        if (with_cpu_x86_bfloat16())
+            capabilities.push_back(METRIC_VALUE(BF16));
         if (hasAVX512())
             capabilities.push_back(METRIC_VALUE(WINOGRAD));
         capabilities.push_back(METRIC_VALUE(FP32));


### PR DESCRIPTION
1. Bfloat16 format support was added by default on CPX platrforms
2. BF16 capability was added to OPTIMIZATION_CAPABILITIES list on CPX platforms
3. Added an exception with message "Platform doesn't support BF16 format" in case of setting KEY_ENFORCE_BF16 to YES on non-CPX platforms
4. Flag "-enforcebf16" behaviour was changed in benchmark_app. Now, by default KEY_ENFORCE_BF16=YES on CPX and KEY_ENFORCE_BF16=NO on non-CPX platforms. Added an ability to disable BF16 on CPX by setting option "-enforcebf16 NO" and return to enable state by setting option "-enforcebf16 YES"