### PR TITLE
[IE CLDNN] Permute fused ops support

### DIFF
--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/permute/permute_kernel_ref.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/permute/permute_kernel_ref.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016-2019 Intel Corporation
+﻿// Copyright (c) 2016-2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ ParamsKey PermuteKernelRef::GetSupportedKey() const {
     k.EnableOutputDataType(Datatype::UINT8);
     k.EnableOutputDataType(Datatype::INT32);
     k.EnableOutputDataType(Datatype::INT64);
+    k.EnableDifferentTypes();
     k.EnableAllInputLayout();
     k.EnableAllOutputLayout();
     k.EnableTensorOffset();

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/permute/permute_kernel_ref.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/permute/permute_kernel_ref.cpp
@@ -66,6 +66,20 @@ JitConstants PermuteKernelRef::GetJitConstants(const permute_params& params) con
     jit.AddConstant(MakeJitConstant("IN_IDX", "INPUT0_GET_INDEX(" + input_order + ")"));
     jit.AddConstant(MakeJitConstant("OUT_IDX", "OUTPUT_GET_INDEX(" + output_order + ")"));
 
+    if (!params.fused_ops.empty()) {
+        if (out_idx.size() == 4)
+            std::swap(out_idx[2], out_idx[3]);
+        else if (out_idx.size() == 5)
+            std::swap(out_idx[2], out_idx[4]);
+        else if (out_idx.size() == 6) {
+            std::swap(out_idx[2], out_idx[5]);
+            std::swap(out_idx[3], out_idx[4]);
+        }
+
+        FusedOpsConfiguration conf = {"", out_idx, "input_var", GetUnitType(params), 1};
+        jit.Merge(MakeFusedOpsJitConstants(params, {conf}));
+    }
+
     return jit;
 }
 
@@ -85,7 +99,7 @@ KernelsData PermuteKernelRef::GetKernelsData(const Params& params, const optiona
     kernel.workGroups.global = {in.X().v, in.Y().v * in.Z().v * in.W().v, in.Feature().v * in.Batch().v};
     kernel.workGroups.local = GetOptimalLocalWorkGroupSizes(kernel.workGroups.global, params.engineInfo);
     kernel.kernelString = GetKernelString(kernelName, jit, entry_point, params.engineInfo, DEFAULT);
-    kernel.arguments = GetArgsDesc(1, false, false);
+    kernel.arguments = GetArgsDesc(1, false, false, false, false, GetFusedPrimitiveInputsCount(params));
 
     kd.estimatedTime = DONT_USE_IF_HAVE_SOMETHING_ELSE;
 

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/permute_ref.cl
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/permute_ref.cl
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 Intel Corporation
+// Copyright (c) 2017-2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
 #include "include/include_all.cl"
 
 KERNEL (permute_ref)(
-    const __global UNIT_TYPE* input,
-    __global UNIT_TYPE* output
+    const __global INPUT0_TYPE* input,
+    __global OUTPUT_TYPE* output
 #if HAS_FUSED_OPS_DECLS
     , FUSED_OPS_DECLS
 #endif

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/permute_ref.cl
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/permute_ref.cl
@@ -14,7 +14,13 @@
 
 #include "include/include_all.cl"
 
-KERNEL (permute_ref)(const __global UNIT_TYPE* input, __global UNIT_TYPE* output)
+KERNEL (permute_ref)(
+    const __global UNIT_TYPE* input,
+    __global UNIT_TYPE* output
+#if HAS_FUSED_OPS_DECLS
+    , FUSED_OPS_DECLS
+#endif
+    )
 {
     //gws(x, y * z * w, b*f)
     const uint gid_0 = get_global_id(1);
@@ -22,16 +28,23 @@ KERNEL (permute_ref)(const __global UNIT_TYPE* input, __global UNIT_TYPE* output
     const uint y = gid_0;
 #elif INPUT0_DIMS == 5 && OUTPUT0_DIMS == 5
     const uint z = gid_0 / INPUT0_SIZE_Y;
-    const uint y = gid_0 % INPUT0_SIZE_Y;
+    const uint y = gid_0 % INPUT0_SIZE_Y;   
 #else
     const uint w = gid_0 / (INPUT0_SIZE_Y * INPUT0_SIZE_Z) % INPUT0_SIZE_W;
     const uint z = gid_0 / INPUT0_SIZE_Y % INPUT0_SIZE_Z;
     const uint y = gid_0 % INPUT0_SIZE_Y;
 #endif
-
+    
     const uint x = get_global_id(0);
     const uint f = (uint)get_global_id(2) % INPUT0_FEATURE_NUM;
     const uint b = (uint)get_global_id(2) / INPUT0_FEATURE_NUM;
+    
+    INPUT0_TYPE input_var = input[IN_IDX];
 
+#if HAS_FUSED_OPS
+    FUSED_OPS;
+    output[OUT_IDX] = FUSED_OPS_RESULT;
+#else
     output[OUT_IDX] = ACTIVATION(input[IN_IDX], ACTIVATION_PARAMS);
+#endif
 }

--- a/inference-engine/thirdparty/clDNN/src/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/inference-engine/thirdparty/clDNN/src/graph_optimizer/prepare_primitive_fusing.cpp
@@ -360,6 +360,8 @@ void prepare_primitive_fusing::fuse_simple_primitives(program_impl &p) {
             should_fuse |= input_data.is_type<mvn>();
 
             should_fuse |= input_data.is_type<deconvolution>();
+            
+            should_fuse |= input_data.is_type<permute>();
 
             should_fuse |= input_data.is_type<activation>();
 
@@ -395,6 +397,8 @@ void prepare_primitive_fusing::fuse_simple_primitives(program_impl &p) {
             should_fuse |= input_data.is_type<mvn>() && mvn_supports_fusings(input_data.as<mvn>());
 
             should_fuse |= input_data.is_type<deconvolution>();
+            
+            should_fuse |= input_data.is_type<permute>();
 
             should_fuse |= input_data.is_type<activation>();
 
@@ -467,6 +471,9 @@ void prepare_primitive_fusing::fuse_simple_primitives(program_impl &p) {
                             input_data.get_dependency(0).get_output_layout().data_type == data_types::i8 ||
                             input_data.get_output_layout().data_type == out_layout.data_type);
 
+            should_fuse |= input_data.is_type<permute>() &&
+                            quantize_node.get_scale_shift_opt();
+
             if (!should_fuse)
                 return;
 
@@ -487,11 +494,11 @@ void prepare_primitive_fusing::fuse_simple_primitives(program_impl &p) {
 
             bool can_fuse_parent1 = (parent1->is_type<convolution>() && conv_supports_fusings(parent1->as<convolution>())) ||
                                     (parent1->is_type<mvn>() && mvn_supports_fusings(parent1->as<mvn>())) ||
-                                    (parent1->is_type<deconvolution>());
+                                    (parent1->is_type<deconvolution>()) || (parent1->is_type<permute>());
 
             bool can_fuse_parent2 = (parent2->is_type<convolution>() && conv_supports_fusings(parent2->as<convolution>())) ||
                                     (parent2->is_type<mvn>() && mvn_supports_fusings(parent2->as<mvn>())) ||
-                                    (parent2->is_type<deconvolution>());
+                                    (parent2->is_type<deconvolution>()) || (parent2->is_type<permute>());
 
             std::vector<bool> can_fuse_parents = { can_fuse_parent1, can_fuse_parent2 };
 

--- a/inference-engine/thirdparty/clDNN/src/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/inference-engine/thirdparty/clDNN/src/graph_optimizer/prepare_primitive_fusing.cpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2018-2019 Intel Corporation
+// Copyright (c) 2018-2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -472,7 +472,7 @@ void prepare_primitive_fusing::fuse_simple_primitives(program_impl &p) {
                             input_data.get_output_layout().data_type == out_layout.data_type);
 
             should_fuse |= input_data.is_type<permute>() &&
-                            quantize_node.get_scale_shift_opt();
+                           quantize_node.get_scale_shift_opt();
 
             if (!should_fuse)
                 return;

--- a/inference-engine/thirdparty/clDNN/src/permute.cpp
+++ b/inference-engine/thirdparty/clDNN/src/permute.cpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2016-2019 Intel Corporation
+// Copyright (c) 2016-2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -44,6 +44,10 @@ layout permute_inst::calc_output_layout(permute_node const& node) {
 
     auto input_size = tensor(output_sizes);
     auto op = node.get_primitive()->output_padding;
+
+    if (node.has_fused_primitives()) {
+        input_layout.data_type = node.get_fused_output_layout().data_type;
+    }
 
     return layout(input_layout.data_type, input_layout.format, input_size, op);
 }

--- a/inference-engine/thirdparty/clDNN/tests/test_cases/fusings_gpu_test.cpp
+++ b/inference-engine/thirdparty/clDNN/tests/test_cases/fusings_gpu_test.cpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2020 Intel Corporation
+// Copyright (c) 2019-2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -88,7 +88,9 @@ struct gemm_test_params {
 template<typename T>
 class BaseFusingTest : public ::testing::TestWithParam<T> {
 public:
+    // const engine_configuration configuration = engine_configuration(false,false,false,std::string(),std::string(),true,std::string(),"C:\\Users\\ldebski\\src_dumpster");
     cldnn::engine engine;
+    // cldnn::engine engine(sources_dumps_dir = "C:\\Users\\ldebski\\src_dumpster");
     cldnn::topology topology_fused;
     cldnn::topology topology_non_fused;
     cldnn::build_options bo_fused;
@@ -101,6 +103,7 @@ public:
 
     void SetUp() override {
         bo_fused.set_option(build_option::optimize_data(true));
+        bo_fused.set_option(build_option::graph_dumps_dir("graph_dumps/"));
         bo_not_fused.set_option(build_option::optimize_data(false));
         bo_not_fused.set_option(build_option::allow_static_input_reorder(true));
     }
@@ -4079,10 +4082,10 @@ struct permute_params {
 #define CASE_PERMUTE_F16_5 {1, 15, 1, 2}, {15, 2, 1, 1}, {1, 3, 2, 0}, tensor{0}, data_types::f16, format::bfyx, data_types::f32, format::bfyx
 #define CASE_PERMUTE_F16_6 {1, 15, 4, 4}, {4, 4, 1, 15}, {2, 3, 0, 1}, tensor{0}, data_types::f16, format::bfyx, data_types::f32, format::bfyx
 
-#define CASE_PERMUTE_i8_0 {1, 15, 4, 5}, {1, 15, 4, 5}, {0, 1, 2, 3}, tensor{0}, data_types::i8, format::bfyx, data_types::f32, format::bfyx
-#define CASE_PERMUTE_i8_1 {1, 15, 4, 5}, {5, 4, 15, 1}, {3, 2, 1, 0}, tensor{0}, data_types::i8, format::bfyx, data_types::f32, format::bfyx
-#define CASE_PERMUTE_i8_2 {1, 16, 1, 2}, {1, 1, 16, 2}, {2, 0, 1, 3}, tensor{0}, data_types::i8, format::b_fs_yx_fsv16, data_types::f32, format::bfyx
-#define CASE_PERMUTE_i8_3 {1, 16, 2, 2}, {2, 2, 16, 1}, {2, 3, 1, 0}, tensor{0}, data_types::i8, format::b_fs_yx_fsv16, data_types::f32, format::bfyx
+#define CASE_PERMUTE_S8_0 {1, 15, 4, 5}, {1, 15, 4, 5}, {0, 1, 2, 3}, tensor{0}, data_types::i8, format::bfyx, data_types::f32, format::bfyx
+#define CASE_PERMUTE_S8_1 {1, 15, 4, 5}, {5, 4, 15, 1}, {3, 2, 1, 0}, tensor{0}, data_types::i8, format::bfyx, data_types::f32, format::bfyx
+#define CASE_PERMUTE_S8_2 {1, 16, 1, 2}, {1, 1, 16, 2}, {2, 0, 1, 3}, tensor{0}, data_types::i8, format::b_fs_yx_fsv16, data_types::f32, format::bfyx
+#define CASE_PERMUTE_S8_3 {1, 16, 2, 2}, {2, 2, 16, 1}, {2, 3, 1, 0}, tensor{0}, data_types::i8, format::b_fs_yx_fsv16, data_types::f32, format::bfyx
 #define CASE_PERMUTE_u8_0 {1, 15, 4, 5}, {15, 5, 1, 4}, {1, 3, 0, 2}, tensor{0}, data_types::u8, format::bfyx, data_types::f32, format::bfyx
 #define CASE_PERMUTE_u8_1 {1, 15, 16, 16}, {15, 16, 1, 16}, {1, 2, 0, 3}, tensor{0}, data_types::u8, format::bfyx, data_types::f32, format::bfyx
 #define CASE_PERMUTE_u8_2 {1, 32, 5, 4}, {1, 32, 5, 4}, {0, 1, 2, 3}, tensor{0}, data_types::u8, format::b_fs_yx_fsv16, data_types::f32, format::bfyx
@@ -4101,10 +4104,10 @@ struct permute_params {
 #define CASE_PERMUTE_F16_3D_3 {1, 32, 4, 2, 1}, {2, 32, 4, 1, 1}, {3, 1, 2, 4, 0}, tensor{0}, data_types::f16, format::bfzyx, data_types::f32, format::bfzyx
 #define CASE_PERMUTE_F16_3D_4 {16, 16, 1, 1, 1},{1, 16, 1, 1, 16},{4, 0, 3, 2, 1}, tensor{0}, data_types::f16, format::bfzyx, data_types::f32, format::bfzyx
 
-#define CASE_PERMUTE_i8_3D_0 {1, 15, 4, 4, 5}, {1, 15, 4, 4, 5}, {0, 1, 2, 3, 4}, tensor{0}, data_types::i8, format::bfzyx, data_types::f32, format::bfzyx
-#define CASE_PERMUTE_i8_3D_1 {2, 15, 4, 3, 4}, {4, 4, 15, 2, 3}, {4, 2, 1, 0, 3}, tensor{0}, data_types::i8, format::bfzyx, data_types::f32, format::bfzyx
-#define CASE_PERMUTE_i8_3D_2 {2, 16, 4, 4, 3}, {2, 4, 3, 16, 4}, {0, 3, 4, 1, 2}, tensor{0}, data_types::i8, format::bfzyx, data_types::f32, format::bfzyx
-#define CASE_PERMUTE_i8_3D_3 {1, 32, 4, 2, 1}, {2, 32, 4, 1, 1}, {3, 1, 2, 4, 0}, tensor{0}, data_types::i8, format::bfzyx, data_types::f32, format::bfzyx
+#define CASE_PERMUTE_S8_3D_0 {1, 15, 4, 4, 5}, {1, 15, 4, 4, 5}, {0, 1, 2, 3, 4}, tensor{0}, data_types::i8, format::bfzyx, data_types::f32, format::bfzyx
+#define CASE_PERMUTE_S8_3D_1 {2, 15, 4, 3, 4}, {4, 4, 15, 2, 3}, {4, 2, 1, 0, 3}, tensor{0}, data_types::i8, format::bfzyx, data_types::f32, format::bfzyx
+#define CASE_PERMUTE_S8_3D_2 {2, 16, 4, 4, 3}, {2, 4, 3, 16, 4}, {0, 3, 4, 1, 2}, tensor{0}, data_types::i8, format::bfzyx, data_types::f32, format::bfzyx
+#define CASE_PERMUTE_S8_3D_3 {1, 32, 4, 2, 1}, {2, 32, 4, 1, 1}, {3, 1, 2, 4, 0}, tensor{0}, data_types::i8, format::bfzyx, data_types::f32, format::bfzyx
 #define CASE_PERMUTE_u8_3D_0 {16, 16, 1, 1, 1}, {1, 1, 16, 16, 1}, {2, 4, 0, 1, 3}, tensor{0}, data_types::u8, format::bfzyx, data_types::f32, format::bfzyx
 #define CASE_PERMUTE_u8_3D_1 {16, 16, 1, 1, 1}, {1, 1, 1, 16, 16}, {4, 3, 2, 1, 0}, tensor{0}, data_types::u8, format::bfzyx, data_types::f32, format::bfzyx
 #define CASE_PERMUTE_u8_3D_2 {2, 16, 4, 4, 3}, {4, 2, 4, 3, 16}, {3, 0, 2, 4, 1}, tensor{0}, data_types::u8, format::bfzyx, data_types::f32, format::bfzyx
@@ -4124,17 +4127,7 @@ public:
     }
 
     layout get_input_layout(permute_params& p) {
-        // auto pad = tensor{0}.negate();
-        std::vector<int> pad_ = { 0, 0, 0, 0 };
-        return layout{ p.data_type, p.input_format, p.in_shape, padding{pad_} };
-    }
-
-    layout get_eltw_input_shape(permute_params& p) {
-            return layout{ p.data_type, p.input_format, p.eltw_in_shape};
-    }
-
-    layout get_basic_layout(permute_params& p, tensor& t) {
-        return layout{p.data_type, p.default_format, t}; 
+        return layout{ p.data_type, p.input_format, p.in_shape, padding{} };
     }
 
     layout get_per_channel_layout(permute_params& p) {
@@ -4153,11 +4146,11 @@ TEST_P(permute_activation_scale_eltwise, basic) {
             permute("permute", "input", p.permute_order),
             scale("scale", "permute", "scale_data"),
             activation("actv", "scale", activation_func::relu),
-            eltwise("eltwise", "actv", "eltwise_data", eltwise_mode::sum),
+            eltwise("eltwise", {"actv", "eltwise_data"}, eltwise_mode::sum, p.data_type),
             reorder("reorder_bfyx", "eltwise", p.default_format, p.default_type)
         );
 
-        tolerance = 1.f;
+        tolerance = 1e-5f;
         execute(p);
 }
 
@@ -4180,10 +4173,10 @@ INSTANTIATE_TEST_CASE_P(fusings_gpu, permute_activation_scale_eltwise,
                             permute_params{CASE_PERMUTE_F16_5, 2, 5},
                             permute_params{CASE_PERMUTE_F16_6, 2, 5},
                             
-                            permute_params{CASE_PERMUTE_i8_0, 2, 5},
-                            permute_params{CASE_PERMUTE_i8_1, 2, 5},
-                            permute_params{CASE_PERMUTE_i8_2, 2, 5},
-                            permute_params{CASE_PERMUTE_i8_3, 2, 5},
+                            permute_params{CASE_PERMUTE_S8_0, 2, 5},
+                            permute_params{CASE_PERMUTE_S8_1, 2, 5},
+                            permute_params{CASE_PERMUTE_S8_2, 2, 5},
+                            permute_params{CASE_PERMUTE_S8_3, 2, 5},
                                                                  
                             permute_params{CASE_PERMUTE_u8_0, 2, 5},
                             permute_params{CASE_PERMUTE_u8_1, 2, 5},
@@ -4202,17 +4195,16 @@ INSTANTIATE_TEST_CASE_P(fusings_gpu, permute_activation_scale_eltwise,
                             permute_params{CASE_PERMUTE_F16_3D_3, 2, 5},
                             permute_params{CASE_PERMUTE_F16_3D_4, 2, 5},
                             
-                            permute_params{CASE_PERMUTE_i8_3D_0, 2, 5},
-                            permute_params{CASE_PERMUTE_i8_3D_1, 2, 5},
-                            permute_params{CASE_PERMUTE_i8_3D_2, 2, 5},
-                            permute_params{CASE_PERMUTE_i8_3D_3, 2, 5},
+                            permute_params{CASE_PERMUTE_S8_3D_0, 2, 5},
+                            permute_params{CASE_PERMUTE_S8_3D_1, 2, 5},
+                            permute_params{CASE_PERMUTE_S8_3D_2, 2, 5},
+                            permute_params{CASE_PERMUTE_S8_3D_3, 2, 5},
                                                                  
                             permute_params{CASE_PERMUTE_u8_3D_0, 2, 5},
                             permute_params{CASE_PERMUTE_u8_3D_1, 2, 5},
                             permute_params{CASE_PERMUTE_u8_3D_2, 2, 5},
                             permute_params{CASE_PERMUTE_u8_3D_3, 2, 5},
                         }), );
-
 
 class permute_quant_f32_eltwise_quant_i8: public PermuteFusingTest {};
 TEST_P(permute_quant_f32_eltwise_quant_i8, vector_ops) {
@@ -4274,7 +4266,6 @@ INSTANTIATE_TEST_CASE_P(fusings_gpu, permute_quant_f32_eltwise_quant_i8,
                             permute_params{CASE_PERMUTE_F16_3D_3, 5, 6},
                             permute_params{CASE_PERMUTE_F16_3D_4, 5, 6},
                         }), );
-
 
 class permute_scale_actv_quant_f32_eltw_scale_actv_quant_i8: public PermuteFusingTest {};
 TEST_P(permute_scale_actv_quant_f32_eltw_scale_actv_quant_i8, basic) {
@@ -4341,11 +4332,9 @@ INSTANTIATE_TEST_CASE_P(fusings_gpu, permute_scale_actv_quant_f32_eltw_scale_act
                             permute_params{CASE_PERMUTE_F16_3D_4, 6, 9},
                         }), );
 
-
-
 class permute_scale_eltwise_actv_scale_actv: public PermuteFusingTest {};
 TEST_P(permute_scale_eltwise_actv_scale_actv, basic) {
-        auto p = GetParam();
+    auto p = GetParam();
 
         create_topologies(
             input_layout("input", get_input_layout(p)),
@@ -4355,13 +4344,13 @@ TEST_P(permute_scale_eltwise_actv_scale_actv, basic) {
             permute("permute", "input", p.permute_order),
             scale("scale1", "permute", "scale_data1"),
             activation("actv1", "scale1", activation_func::relu),
-            eltwise("eltwise", "actv1", "eltwise_data", eltwise_mode::sum),
+            eltwise("eltwise", {"actv1", "eltwise_data"}, eltwise_mode::sum, p.default_type),
             scale("scale2", "eltwise", "scale_data2"),
             activation("actv2", "scale2", activation_func::relu),
             reorder("reorder_bfyx", "actv2", p.default_format, p.default_type)
         );
 
-        tolerance = 1.f;
+        tolerance = 1e-5f;
         execute(p);
 }
 
@@ -4384,10 +4373,10 @@ INSTANTIATE_TEST_CASE_P(fusings_gpu, permute_scale_eltwise_actv_scale_actv,
                             permute_params{CASE_PERMUTE_F16_5, 2, 7},
                             permute_params{CASE_PERMUTE_F16_6, 2, 7},
                             
-                            permute_params{CASE_PERMUTE_i8_0, 2, 7},
-                            permute_params{CASE_PERMUTE_i8_1, 2, 7},
-                            permute_params{CASE_PERMUTE_i8_2, 2, 7},
-                            permute_params{CASE_PERMUTE_i8_3, 2, 7},
+                            permute_params{CASE_PERMUTE_S8_0, 2, 7},
+                            permute_params{CASE_PERMUTE_S8_1, 2, 7},
+                            permute_params{CASE_PERMUTE_S8_2, 2, 7},
+                            permute_params{CASE_PERMUTE_S8_3, 2, 7},
                                                                  
                             permute_params{CASE_PERMUTE_u8_0, 2, 7},
                             permute_params{CASE_PERMUTE_u8_1, 2, 7},
@@ -4406,10 +4395,10 @@ INSTANTIATE_TEST_CASE_P(fusings_gpu, permute_scale_eltwise_actv_scale_actv,
                             permute_params{CASE_PERMUTE_F16_3D_3, 2, 7},
                             permute_params{CASE_PERMUTE_F16_3D_4, 2, 7},
                             
-                            permute_params{CASE_PERMUTE_i8_3D_0, 2, 7},
-                            permute_params{CASE_PERMUTE_i8_3D_1, 2, 7},
-                            permute_params{CASE_PERMUTE_i8_3D_2, 2, 7},
-                            permute_params{CASE_PERMUTE_i8_3D_3, 2, 7},
+                            permute_params{CASE_PERMUTE_S8_3D_0, 2, 7},
+                            permute_params{CASE_PERMUTE_S8_3D_1, 2, 7},
+                            permute_params{CASE_PERMUTE_S8_3D_2, 2, 7},
+                            permute_params{CASE_PERMUTE_S8_3D_3, 2, 7},
                                                                     
                             permute_params{CASE_PERMUTE_u8_3D_0, 2, 7},
                             permute_params{CASE_PERMUTE_u8_3D_1, 2, 7},

--- a/inference-engine/thirdparty/clDNN/tests/test_cases/fusings_gpu_test.cpp
+++ b/inference-engine/thirdparty/clDNN/tests/test_cases/fusings_gpu_test.cpp
@@ -4236,16 +4236,14 @@ INSTANTIATE_TEST_CASE_P(fusings_gpu, permute_scale_eltwise_quant_u8,
                             permute_params{CASE_PERMUTE_F32_6, 2, 5},
                             permute_params{CASE_PERMUTE_F32_7, 2, 5},
                                                                   
-                            // quantize f16 fusing not supported  
-                            permute_params{CASE_PERMUTE_F16_0, 3, 5},
-                            permute_params{CASE_PERMUTE_F16_1, 3, 5},
-                            permute_params{CASE_PERMUTE_F16_2, 3, 5},
-                            permute_params{CASE_PERMUTE_F16_3, 3, 5},
-                            permute_params{CASE_PERMUTE_F16_4, 3, 5},
-                            permute_params{CASE_PERMUTE_F16_5, 3, 5},
-                            permute_params{CASE_PERMUTE_F16_6, 3, 5},
+                            permute_params{CASE_PERMUTE_F16_0, 2, 5},
+                            permute_params{CASE_PERMUTE_F16_1, 2, 5},
+                            permute_params{CASE_PERMUTE_F16_2, 2, 5},
+                            permute_params{CASE_PERMUTE_F16_3, 2, 5},
+                            permute_params{CASE_PERMUTE_F16_4, 2, 5},
+                            permute_params{CASE_PERMUTE_F16_5, 2, 5},
+                            permute_params{CASE_PERMUTE_F16_6, 2, 5},
 
-                            
                             permute_params{CASE_PERMUTE_S8_0, 2, 5},
                             permute_params{CASE_PERMUTE_S8_1, 2, 5},
                             permute_params{CASE_PERMUTE_S8_2, 2, 5},
@@ -4262,12 +4260,11 @@ INSTANTIATE_TEST_CASE_P(fusings_gpu, permute_scale_eltwise_quant_u8,
                             permute_params{CASE_PERMUTE_F32_3D_3, 2, 5},
                             permute_params{CASE_PERMUTE_F32_3D_4, 2, 5},
                                                                      
-                            // quantize f16 fusing not supported     
-                            permute_params{CASE_PERMUTE_F16_3D_0, 3, 5},
-                            permute_params{CASE_PERMUTE_F16_3D_1, 3, 5},
-                            permute_params{CASE_PERMUTE_F16_3D_2, 3, 5},
-                            permute_params{CASE_PERMUTE_F16_3D_3, 3, 5},
-                            permute_params{CASE_PERMUTE_F16_3D_4, 3, 5},
+                            permute_params{CASE_PERMUTE_F16_3D_0, 2, 5},
+                            permute_params{CASE_PERMUTE_F16_3D_1, 2, 5},
+                            permute_params{CASE_PERMUTE_F16_3D_2, 2, 5},
+                            permute_params{CASE_PERMUTE_F16_3D_3, 2, 5},
+                            permute_params{CASE_PERMUTE_F16_3D_4, 2, 5},
 
                             permute_params{CASE_PERMUTE_S8_3D_0, 2, 5},
                             permute_params{CASE_PERMUTE_S8_3D_1, 2, 5},
@@ -4316,15 +4313,14 @@ INSTANTIATE_TEST_CASE_P(fusings_gpu, permute_scale_actv_eltw_scale_actv_quant_i8
                             permute_params{CASE_PERMUTE_F32_5, 2, 8},
                             permute_params{CASE_PERMUTE_F32_6, 2, 8},
                             permute_params{CASE_PERMUTE_F32_7, 2, 8},
-                                                                  
-                            // quantize f16 fusing not supported
-                            permute_params{CASE_PERMUTE_F16_0, 3, 8},
-                            permute_params{CASE_PERMUTE_F16_1, 3, 8},
-                            permute_params{CASE_PERMUTE_F16_2, 3, 8},
-                            permute_params{CASE_PERMUTE_F16_3, 3, 8},
-                            permute_params{CASE_PERMUTE_F16_4, 3, 8},
-                            permute_params{CASE_PERMUTE_F16_5, 3, 8},
-                            permute_params{CASE_PERMUTE_F16_6, 3, 8},
+
+                            permute_params{CASE_PERMUTE_F16_0, 2, 8},
+                            permute_params{CASE_PERMUTE_F16_1, 2, 8},
+                            permute_params{CASE_PERMUTE_F16_2, 2, 8},
+                            permute_params{CASE_PERMUTE_F16_3, 2, 8},
+                            permute_params{CASE_PERMUTE_F16_4, 2, 8},
+                            permute_params{CASE_PERMUTE_F16_5, 2, 8},
+                            permute_params{CASE_PERMUTE_F16_6, 2, 8},
                                 
                             permute_params{CASE_PERMUTE_S8_0, 2, 8},
                             permute_params{CASE_PERMUTE_S8_1, 2, 8},
@@ -4341,13 +4337,12 @@ INSTANTIATE_TEST_CASE_P(fusings_gpu, permute_scale_actv_eltw_scale_actv_quant_i8
                             permute_params{CASE_PERMUTE_F32_3D_2, 2, 8},
                             permute_params{CASE_PERMUTE_F32_3D_3, 2, 8},
                             permute_params{CASE_PERMUTE_F32_3D_4, 2, 8},
-                            
-                            // quantize f16 fusing not supported
-                            permute_params{CASE_PERMUTE_F16_3D_0, 3, 8},
-                            permute_params{CASE_PERMUTE_F16_3D_1, 3, 8},
-                            permute_params{CASE_PERMUTE_F16_3D_2, 3, 8},
-                            permute_params{CASE_PERMUTE_F16_3D_3, 3, 8},
-                            permute_params{CASE_PERMUTE_F16_3D_4, 3, 8},
+
+                            permute_params{CASE_PERMUTE_F16_3D_0, 2, 8},
+                            permute_params{CASE_PERMUTE_F16_3D_1, 2, 8},
+                            permute_params{CASE_PERMUTE_F16_3D_2, 2, 8},
+                            permute_params{CASE_PERMUTE_F16_3D_3, 2, 8},
+                            permute_params{CASE_PERMUTE_F16_3D_4, 2, 8},
 
                             permute_params{CASE_PERMUTE_S8_3D_0, 2, 8},
                             permute_params{CASE_PERMUTE_S8_3D_1, 2, 8},

--- a/inference-engine/thirdparty/clDNN/tests/test_cases/fusings_gpu_test.cpp
+++ b/inference-engine/thirdparty/clDNN/tests/test_cases/fusings_gpu_test.cpp
@@ -4086,10 +4086,10 @@ struct permute_params {
 #define CASE_PERMUTE_S8_1 {1, 15, 4, 5}, {5, 4, 15, 1}, {3, 2, 1, 0}, tensor{0}, data_types::i8, format::bfyx, data_types::f32, format::bfyx
 #define CASE_PERMUTE_S8_2 {1, 16, 1, 2}, {1, 1, 16, 2}, {2, 0, 1, 3}, tensor{0}, data_types::i8, format::b_fs_yx_fsv16, data_types::f32, format::bfyx
 #define CASE_PERMUTE_S8_3 {1, 16, 2, 2}, {2, 2, 16, 1}, {2, 3, 1, 0}, tensor{0}, data_types::i8, format::b_fs_yx_fsv16, data_types::f32, format::bfyx
-#define CASE_PERMUTE_u8_0 {1, 15, 4, 5}, {15, 5, 1, 4}, {1, 3, 0, 2}, tensor{0}, data_types::u8, format::bfyx, data_types::f32, format::bfyx
-#define CASE_PERMUTE_u8_1 {1, 15, 16, 16}, {15, 16, 1, 16}, {1, 2, 0, 3}, tensor{0}, data_types::u8, format::bfyx, data_types::f32, format::bfyx
-#define CASE_PERMUTE_u8_2 {1, 32, 5, 4}, {1, 32, 5, 4}, {0, 1, 2, 3}, tensor{0}, data_types::u8, format::b_fs_yx_fsv16, data_types::f32, format::bfyx
-#define CASE_PERMUTE_u8_3 {1, 16, 4, 5}, {5, 4, 16, 1}, {3, 2, 1, 0}, tensor{0}, data_types::u8, format::b_fs_yx_fsv16, data_types::f32, format::bfyx
+#define CASE_PERMUTE_U8_0 {1, 15, 4, 5}, {15, 5, 1, 4}, {1, 3, 0, 2}, tensor{0}, data_types::u8, format::bfyx, data_types::f32, format::bfyx
+#define CASE_PERMUTE_U8_1 {1, 15, 16, 16}, {15, 16, 1, 16}, {1, 2, 0, 3}, tensor{0}, data_types::u8, format::bfyx, data_types::f32, format::bfyx
+#define CASE_PERMUTE_U8_2 {1, 32, 5, 4}, {1, 32, 5, 4}, {0, 1, 2, 3}, tensor{0}, data_types::u8, format::b_fs_yx_fsv16, data_types::f32, format::bfyx
+#define CASE_PERMUTE_U8_3 {1, 16, 4, 5}, {5, 4, 16, 1}, {3, 2, 1, 0}, tensor{0}, data_types::u8, format::b_fs_yx_fsv16, data_types::f32, format::bfyx
 
 // 3d
 #define CASE_PERMUTE_F32_3D_0 {1, 15, 4, 4, 5}, {1, 15, 4, 4, 5}, {0, 1, 2, 3, 4}, tensor{0}, data_types::f32, format::bfzyx, data_types::f32, format::bfzyx
@@ -4108,10 +4108,10 @@ struct permute_params {
 #define CASE_PERMUTE_S8_3D_1 {2, 15, 4, 3, 4}, {4, 4, 15, 2, 3}, {4, 2, 1, 0, 3}, tensor{0}, data_types::i8, format::bfzyx, data_types::f32, format::bfzyx
 #define CASE_PERMUTE_S8_3D_2 {2, 16, 4, 4, 3}, {2, 4, 3, 16, 4}, {0, 3, 4, 1, 2}, tensor{0}, data_types::i8, format::bfzyx, data_types::f32, format::bfzyx
 #define CASE_PERMUTE_S8_3D_3 {1, 32, 4, 2, 1}, {2, 32, 4, 1, 1}, {3, 1, 2, 4, 0}, tensor{0}, data_types::i8, format::bfzyx, data_types::f32, format::bfzyx
-#define CASE_PERMUTE_u8_3D_0 {16, 16, 1, 1, 1}, {1, 1, 16, 16, 1}, {2, 4, 0, 1, 3}, tensor{0}, data_types::u8, format::bfzyx, data_types::f32, format::bfzyx
-#define CASE_PERMUTE_u8_3D_1 {16, 16, 1, 1, 1}, {1, 1, 1, 16, 16}, {4, 3, 2, 1, 0}, tensor{0}, data_types::u8, format::bfzyx, data_types::f32, format::bfzyx
-#define CASE_PERMUTE_u8_3D_2 {2, 16, 4, 4, 3}, {4, 2, 4, 3, 16}, {3, 0, 2, 4, 1}, tensor{0}, data_types::u8, format::bfzyx, data_types::f32, format::bfzyx
-#define CASE_PERMUTE_u8_3D_3 {1, 32, 4, 2, 1}, {1, 2, 32, 1, 4}, {4, 3, 1, 0, 2}, tensor{0}, data_types::u8, format::bfzyx, data_types::f32, format::bfzyx
+#define CASE_PERMUTE_U8_3D_0 {16, 16, 1, 1, 1}, {1, 1, 16, 16, 1}, {2, 4, 0, 1, 3}, tensor{0}, data_types::u8, format::bfzyx, data_types::f32, format::bfzyx
+#define CASE_PERMUTE_U8_3D_1 {16, 16, 1, 1, 1}, {1, 1, 1, 16, 16}, {4, 3, 2, 1, 0}, tensor{0}, data_types::u8, format::bfzyx, data_types::f32, format::bfzyx
+#define CASE_PERMUTE_U8_3D_2 {2, 16, 4, 4, 3}, {4, 2, 4, 3, 16}, {3, 0, 2, 4, 1}, tensor{0}, data_types::u8, format::bfzyx, data_types::f32, format::bfzyx
+#define CASE_PERMUTE_U8_3D_3 {1, 32, 4, 2, 1}, {1, 2, 32, 1, 4}, {4, 3, 1, 0, 2}, tensor{0}, data_types::u8, format::bfzyx, data_types::f32, format::bfzyx
 
 class PermuteFusingTest : public ::BaseFusingTest<permute_params> {
 public:
@@ -4178,10 +4178,10 @@ INSTANTIATE_TEST_CASE_P(fusings_gpu, permute_activation_scale_eltwise,
                             permute_params{CASE_PERMUTE_S8_2, 2, 5},
                             permute_params{CASE_PERMUTE_S8_3, 2, 5},
                                                                  
-                            permute_params{CASE_PERMUTE_u8_0, 2, 5},
-                            permute_params{CASE_PERMUTE_u8_1, 2, 5},
-                            permute_params{CASE_PERMUTE_u8_2, 2, 5},
-                            permute_params{CASE_PERMUTE_u8_3, 2, 5},
+                            permute_params{CASE_PERMUTE_U8_0, 2, 5},
+                            permute_params{CASE_PERMUTE_U8_1, 2, 5},
+                            permute_params{CASE_PERMUTE_U8_2, 2, 5},
+                            permute_params{CASE_PERMUTE_U8_3, 2, 5},
                             
                             permute_params{CASE_PERMUTE_F32_3D_0, 2, 5},
                             permute_params{CASE_PERMUTE_F32_3D_1, 2, 5},
@@ -4200,10 +4200,10 @@ INSTANTIATE_TEST_CASE_P(fusings_gpu, permute_activation_scale_eltwise,
                             permute_params{CASE_PERMUTE_S8_3D_2, 2, 5},
                             permute_params{CASE_PERMUTE_S8_3D_3, 2, 5},
                                                                  
-                            permute_params{CASE_PERMUTE_u8_3D_0, 2, 5},
-                            permute_params{CASE_PERMUTE_u8_3D_1, 2, 5},
-                            permute_params{CASE_PERMUTE_u8_3D_2, 2, 5},
-                            permute_params{CASE_PERMUTE_u8_3D_3, 2, 5},
+                            permute_params{CASE_PERMUTE_U8_3D_0, 2, 5},
+                            permute_params{CASE_PERMUTE_U8_3D_1, 2, 5},
+                            permute_params{CASE_PERMUTE_U8_3D_2, 2, 5},
+                            permute_params{CASE_PERMUTE_U8_3D_3, 2, 5},
                         }), );
 
 class permute_quant_f32_eltwise_quant_i8: public PermuteFusingTest {};
@@ -4378,10 +4378,10 @@ INSTANTIATE_TEST_CASE_P(fusings_gpu, permute_scale_eltwise_actv_scale_actv,
                             permute_params{CASE_PERMUTE_S8_2, 2, 7},
                             permute_params{CASE_PERMUTE_S8_3, 2, 7},
                                                                  
-                            permute_params{CASE_PERMUTE_u8_0, 2, 7},
-                            permute_params{CASE_PERMUTE_u8_1, 2, 7},
-                            permute_params{CASE_PERMUTE_u8_2, 2, 7},
-                            permute_params{CASE_PERMUTE_u8_3, 2, 7},
+                            permute_params{CASE_PERMUTE_U8_0, 2, 7},
+                            permute_params{CASE_PERMUTE_U8_1, 2, 7},
+                            permute_params{CASE_PERMUTE_U8_2, 2, 7},
+                            permute_params{CASE_PERMUTE_U8_3, 2, 7},
                             
                             permute_params{CASE_PERMUTE_F32_3D_0, 2, 7},
                             permute_params{CASE_PERMUTE_F32_3D_1, 2, 7},
@@ -4400,8 +4400,8 @@ INSTANTIATE_TEST_CASE_P(fusings_gpu, permute_scale_eltwise_actv_scale_actv,
                             permute_params{CASE_PERMUTE_S8_3D_2, 2, 7},
                             permute_params{CASE_PERMUTE_S8_3D_3, 2, 7},
                                                                     
-                            permute_params{CASE_PERMUTE_u8_3D_0, 2, 7},
-                            permute_params{CASE_PERMUTE_u8_3D_1, 2, 7},
-                            permute_params{CASE_PERMUTE_u8_3D_2, 2, 7},
-                            permute_params{CASE_PERMUTE_u8_3D_3, 2, 7},
+                            permute_params{CASE_PERMUTE_U8_3D_0, 2, 7},
+                            permute_params{CASE_PERMUTE_U8_3D_1, 2, 7},
+                            permute_params{CASE_PERMUTE_U8_3D_2, 2, 7},
+                            permute_params{CASE_PERMUTE_U8_3D_3, 2, 7},
                         }), );


### PR DESCRIPTION
[IE CLDNN] Addition of permute fused ops support and tests for this situation. This fusion can be perform with simple primitives (activation, quantization, eltwise, scale).

JIRA: CVS-29383