### PR TITLE
Fixes for Mask-RCNN conversion

### DIFF
--- a/ngraph/src/ngraph/op/non_max_suppression.cpp
+++ b/ngraph/src/ngraph/op/non_max_suppression.cpp
@@ -139,18 +139,22 @@ void op::v1::NonMaxSuppression::validate_and_infer_types()
                           "Expected a scalar for the 'max_output_boxes_per_class' input. Got: ",
                           max_boxes_ps);
 
-    const auto iou_threshold_ps = get_input_partial_shape(3);
-    NODE_VALIDATION_CHECK(this,
-                          iou_threshold_ps.is_dynamic() || is_scalar(iou_threshold_ps.to_shape()),
-                          "Expected a scalar for the 'iou_threshold' input. Got: ",
-                          iou_threshold_ps);
+    if (get_inputs().size() >= 4) {
+        const auto iou_threshold_ps = get_input_partial_shape(3);
+        NODE_VALIDATION_CHECK(this,
+                              iou_threshold_ps.is_dynamic() || is_scalar(iou_threshold_ps.to_shape()),
+                              "Expected a scalar for the 'iou_threshold' input. Got: ",
+                              iou_threshold_ps);
+    }
 
-    const auto score_threshold_ps = get_input_partial_shape(4);
-    NODE_VALIDATION_CHECK(this,
-                          score_threshold_ps.is_dynamic() ||
-                              is_scalar(score_threshold_ps.to_shape()),
-                          "Expected a scalar for the 'score_threshold' input. Got: ",
-                          score_threshold_ps);
+    if (get_inputs().size() >= 5) {
+        const auto score_threshold_ps = get_input_partial_shape(4);
+        NODE_VALIDATION_CHECK(this,
+                              score_threshold_ps.is_dynamic() ||
+                                  is_scalar(score_threshold_ps.to_shape()),
+                              "Expected a scalar for the 'score_threshold' input. Got: ",
+                              score_threshold_ps);
+    }
 
     const auto num_batches_boxes = boxes_ps[0];
     const auto num_batches_scores = scores_ps[0];
@@ -349,18 +353,22 @@ void op::v3::NonMaxSuppression::validate_and_infer_types()
                           "Expected a scalar for the 'max_output_boxes_per_class' input. Got: ",
                           max_boxes_ps);
 
-    const auto iou_threshold_ps = get_input_partial_shape(3);
-    NODE_VALIDATION_CHECK(this,
-                          iou_threshold_ps.is_dynamic() || is_scalar(iou_threshold_ps.to_shape()),
-                          "Expected a scalar for the 'iou_threshold' input. Got: ",
-                          iou_threshold_ps);
+    if (get_inputs().size() >= 4) {
+        const auto iou_threshold_ps = get_input_partial_shape(3);
+        NODE_VALIDATION_CHECK(this,
+                              iou_threshold_ps.is_dynamic() || is_scalar(iou_threshold_ps.to_shape()),
+                              "Expected a scalar for the 'iou_threshold' input. Got: ",
+                              iou_threshold_ps);
+    }
 
-    const auto score_threshold_ps = get_input_partial_shape(4);
-    NODE_VALIDATION_CHECK(this,
-                          score_threshold_ps.is_dynamic() ||
-                              is_scalar(score_threshold_ps.to_shape()),
-                          "Expected a scalar for the 'score_threshold' input. Got: ",
-                          score_threshold_ps);
+    if (get_inputs().size() >= 5) {
+        const auto score_threshold_ps = get_input_partial_shape(4);
+        NODE_VALIDATION_CHECK(this,
+                              score_threshold_ps.is_dynamic() ||
+                                  is_scalar(score_threshold_ps.to_shape()),
+                              "Expected a scalar for the 'score_threshold' input. Got: ",
+                              score_threshold_ps);
+    }
 
     const auto num_batches_boxes = boxes_ps[0];
     const auto num_batches_scores = scores_ps[0];

--- a/ngraph/src/ngraph/op/non_max_suppression.cpp
+++ b/ngraph/src/ngraph/op/non_max_suppression.cpp
@@ -61,7 +61,7 @@ shared_ptr<Node>
 {
     check_new_args_count(this, new_args);
     NODE_VALIDATION_CHECK(
-        this, new_args.size() >= 3 && new_args.size() <= 5, "Number of inputs must be 3, 4 or 5");
+        this, new_args.size() >= 2 && new_args.size() <= 5, "Number of inputs must be 2, 3, 4 or 5");
     if (new_args.size() == 5)
     {
         return make_shared<op::v1::NonMaxSuppression>(new_args.at(0),
@@ -82,6 +82,17 @@ shared_ptr<Node>
             op::Constant::create(element::f32, Shape{}, {.0f}),
             m_box_encoding,
             m_sort_result_descending);
+    }
+    else if (new_args.size() == 3)
+    {
+        return make_shared<op::v1::NonMaxSuppression>(
+                new_args.at(0),
+                new_args.at(1),
+                op::Constant::create(element::i32, Shape{}, {0}),
+                op::Constant::create(element::f32, Shape{}, {.0f}),
+                op::Constant::create(element::f32, Shape{}, {.0f}),
+                m_box_encoding,
+                m_sort_result_descending);
     }
     else
     {
@@ -133,11 +144,13 @@ void op::v1::NonMaxSuppression::validate_and_infer_types()
                           "Expected a 3D tensor for the 'scores' input. Got: ",
                           scores_ps);
 
-    const auto max_boxes_ps = get_input_partial_shape(2);
-    NODE_VALIDATION_CHECK(this,
-                          max_boxes_ps.is_dynamic() || is_scalar(max_boxes_ps.to_shape()),
-                          "Expected a scalar for the 'max_output_boxes_per_class' input. Got: ",
-                          max_boxes_ps);
+    if (get_inputs().size() >= 3) {
+        const auto max_boxes_ps = get_input_partial_shape(2);
+        NODE_VALIDATION_CHECK(this,
+                              max_boxes_ps.is_dynamic() || is_scalar(max_boxes_ps.to_shape()),
+                              "Expected a scalar for the 'max_output_boxes_per_class' input. Got: ",
+                              max_boxes_ps);
+    }
 
     if (get_inputs().size() >= 4) {
         const auto iou_threshold_ps = get_input_partial_shape(3);
@@ -272,7 +285,7 @@ shared_ptr<Node>
 {
     check_new_args_count(this, new_args);
     NODE_VALIDATION_CHECK(
-        this, new_args.size() >= 3 && new_args.size() <= 5, "Number of inputs must be 3, 4 or 5");
+        this, new_args.size() >= 2 && new_args.size() <= 5, "Number of inputs must be 2, 3, 4 or 5");
     if (new_args.size() == 5)
     {
         return make_shared<op::v3::NonMaxSuppression>(new_args.at(0),
@@ -296,12 +309,23 @@ shared_ptr<Node>
             m_sort_result_descending,
             m_output_type);
     }
-    else
+    else if (new_args.size() == 3)
     {
         return make_shared<op::v3::NonMaxSuppression>(
             new_args.at(0),
             new_args.at(1),
             new_args.at(2),
+            op::Constant::create(element::f32, Shape{}, {.0f}),
+            op::Constant::create(element::f32, Shape{}, {.0f}),
+            m_box_encoding,
+            m_sort_result_descending);
+    }
+    else
+    {
+        return make_shared<op::v3::NonMaxSuppression>(
+            new_args.at(0),
+            new_args.at(1),
+            op::Constant::create(element::i32, Shape{}, {0}),
             op::Constant::create(element::f32, Shape{}, {.0f}),
             op::Constant::create(element::f32, Shape{}, {.0f}),
             m_box_encoding,
@@ -347,11 +371,13 @@ void op::v3::NonMaxSuppression::validate_and_infer_types()
                           "Expected a 3D tensor for the 'scores' input. Got: ",
                           scores_ps);
 
-    const auto max_boxes_ps = get_input_partial_shape(2);
-    NODE_VALIDATION_CHECK(this,
-                          max_boxes_ps.is_dynamic() || is_scalar(max_boxes_ps.to_shape()),
-                          "Expected a scalar for the 'max_output_boxes_per_class' input. Got: ",
-                          max_boxes_ps);
+    if (get_inputs().size() >= 3) {
+        const auto max_boxes_ps = get_input_partial_shape(2);
+        NODE_VALIDATION_CHECK(this,
+                              max_boxes_ps.is_dynamic() || is_scalar(max_boxes_ps.to_shape()),
+                              "Expected a scalar for the 'max_output_boxes_per_class' input. Got: ",
+                              max_boxes_ps);
+    }
 
     if (get_inputs().size() >= 4) {
         const auto iou_threshold_ps = get_input_partial_shape(3);

--- a/ngraph/src/ngraph/op/non_max_suppression.cpp
+++ b/ngraph/src/ngraph/op/non_max_suppression.cpp
@@ -86,20 +86,20 @@ shared_ptr<Node>
     else if (new_args.size() == 3)
     {
         return make_shared<op::v1::NonMaxSuppression>(
-                new_args.at(0),
-                new_args.at(1),
-                op::Constant::create(element::i32, Shape{}, {0}),
-                op::Constant::create(element::f32, Shape{}, {.0f}),
-                op::Constant::create(element::f32, Shape{}, {.0f}),
-                m_box_encoding,
-                m_sort_result_descending);
+            new_args.at(0),
+            new_args.at(1),
+            new_args.at(2),
+            op::Constant::create(element::f32, Shape{}, {.0f}),
+            op::Constant::create(element::f32, Shape{}, {.0f}),
+            m_box_encoding,
+            m_sort_result_descending);
     }
     else
     {
         return make_shared<op::v1::NonMaxSuppression>(
             new_args.at(0),
             new_args.at(1),
-            new_args.at(2),
+            op::Constant::create(element::i32, Shape{}, {0}),
             op::Constant::create(element::f32, Shape{}, {.0f}),
             op::Constant::create(element::f32, Shape{}, {.0f}),
             m_box_encoding,


### PR DESCRIPTION
Description:
* Added dependency for transformation of Mask-RCNN model to run before transformation for SoftMaxONNX
* Added conversion of output from ExperimentalDetectronDetectionOutput with indices to i64 to be consistent with consumer of this output.
* Fixed validate_and_infer_types for NMS ops.

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR: N/A
* [x]  Transformation preserves node names: N/A

Validation:
* [x]  Unit tests: N/A
* [x]  Framework layer tests: N/A
* [x]  Transformation tests: N/A
* [x]  e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py: N/A not a new model
* [x]  MO IR Reader check: N/A not a new model

Documentation:
* [x]  Supported frameworks operations list: N/A
* [x]  Supported **public** models list: N/A
* [x]  New operations specification: N/A
* [x]  Guide on how to convert the **public** model: N/A
* [x]  User guide update: N/A