### PR TITLE
[ MO ] Memory usage

### DIFF
--- a/model-optimizer/mo/front/common/partial_infer/concat.py
+++ b/model-optimizer/mo/front/common/partial_infer/concat.py
@@ -69,7 +69,7 @@ def concat_infer(node):
     if any(v is None for v in values):
         return
 
-    node.out_node(0).value = np.array(np.concatenate(values, axis=node.axis), dtype=values[0].dtype)
+    node.out_node(0).value = np.concatenate(values, axis=node.axis).astype(values[0].dtype, copy=False)
     node.out_node(0).shape = np.array(node.out_node(0).value.shape, dtype=np.int64)
 
 


### PR DESCRIPTION
**Description:**
1. Concat value inference 
2. Calculating hash without a data copy

**Ticket:** CVS-27846

**Code:**
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves node names

**Validation:**
* [x]  Unit tests: **Units are too small to test**
* [x]  Framework layer tests: **N/A**
* [x]  Transformation tests: **N/A**
* [x]  e2e model test with an update of reshape_utils.py: **N/A**
* [x]  MO IR Reader check: **N/A**

**Documentation:**
* [x]  Supported frameworks operations list: **N/A**
* [x]  Supported **public** models list: **N/A**
* [x]  New operations specification **N/A**
* [x]  Guide on how to convert the **public** model: **N/A**
* [x]  User guide update: **N/A**

Other:
* [x]  Sample/Demo application to infer the model: **N/A**