### PR TITLE
[IE][VPU]: Faster-RCNN fixes on myriad plugin side

### DIFF
--- a/inference-engine/src/vpu/graph_transformer/src/middleend/allocator/allocator.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/allocator/allocator.cpp
@@ -92,6 +92,27 @@ void updateChildDataAllocation(const Data& data, int offsetLimitation) {
     }
 }
 
+int getInUse(const Data& data) {
+    int inUse = 0;
+    inUse += data->numConsumers();
+    for (const auto& childData : data->childDatas()) {
+        inUse += getInUse(childData);
+    }
+    for (const auto& childEdge : data->childDataToShapeEdges()) {
+        auto const& child = childEdge->child();
+        if (child->usage() == DataUsage::Output) {
+            VPU_THROW_UNLESS(child->parentData() == nullptr, "Output data object must not have parent");
+            inUse++;
+        } else if (child->getTopParentData() == child) {
+            inUse += getInUse(child);
+        } else {
+            inUse += child->numConsumers();
+        }
+    }
+    return inUse;
+}
+
+
 }  // namespace
 
 bool Allocator::allocateData(const Data& data) {
@@ -247,13 +268,8 @@ bool Allocator::allocateData(const Data& data) {
     if (data->usage() == DataUsage::Temp) {
         inUse = 1;
     } else {
-        loopOverData(data, [&inUse](const Data& subData) {
-            inUse += subData->numConsumers();
-            return DataLoopStatus::NextChild;
-        });
+        inUse = getInUse(data);
     }
-
-    inUse += data->childDataToShapeEdges().size();
 
     VPU_INTERNAL_CHECK(inUse >= 1,
         "allocateData failed: data {} with usage {} isn't used by anything",
@@ -356,16 +372,18 @@ void Allocator::freeData(const Data& data, DeallocationMode mode) {
     // Release the chunk
     //
 
-    if (const auto& parentDataToShapeEdge = data->parentDataToShapeEdge()) {
-        auto const& parent = parentDataToShapeEdge->parent();
+    auto topParent = data->getTopParentData();
+    if (topParent != data) {
+        if (const auto& parentDataToShapeEdge = data->parentDataToShapeEdge()) {
+            const auto& parent = parentDataToShapeEdge->parent();
 
-        if (parent->usage() == DataUsage::Intermediate || parent->usage() == DataUsage::Temp) {
-            auto chunk = getChunk(parent);
-            decreaseChunkUsage(chunk, parent);
+            if (parent->usage() == DataUsage::Intermediate || parent->usage() == DataUsage::Temp) {
+                const auto dtopParent = parent->getTopParentData();
+                const auto chunk = getChunk(dtopParent);
+                decreaseChunkUsage(chunk, dtopParent);
+            }
         }
     }
-
-    auto topParent = data->getTopParentData();
 
     if (topParent->usage() == DataUsage::Intermediate ||
         topParent->usage() == DataUsage::Temp) {
@@ -373,6 +391,16 @@ void Allocator::freeData(const Data& data, DeallocationMode mode) {
 
         switch (mode) {
         case DeallocationMode::JustFree: {
+            if (const auto& parentDataToShapeEdge = topParent->parentDataToShapeEdge()) {
+                const auto& parent = parentDataToShapeEdge->parent();
+
+                if (parent->usage() == DataUsage::Intermediate || parent->usage() == DataUsage::Temp) {
+                    const auto dtopParent = parent->getTopParentData();
+                    const auto dchunk = getChunk(dtopParent);
+                    decreaseChunkUsage(dchunk, dtopParent);
+                }
+            }
+
             decreaseChunkUsage(chunk, topParent);
             break;
         }


### PR DESCRIPTION
## Ticket

#-32343

## Description

* Fixes deallocation data for cases of `CMX` allocator run
  The final loop tries to deallocate data objects that keep shape values for other data objects that're outputs of a model. But the case when allocator takes only `CMX` data into consideration was not handled and since allocation could not happen, it lead to fail on deallocation of a data object that has not been allocated.

* Fixes allocator with work on data to shape edges
  Since there is new relationship between data objects: some data objects may contain shape of other data object - allocator must properly respect that. The thing is if 2 data objects are connected in such a way, they represent unite entity (dynamic data object) and should have the same lifetime.