### PR TITLE
[GNA] Added error trapping

### DIFF
--- a/inference-engine/src/gna_plugin/gna_graph_compiler.cpp
+++ b/inference-engine/src/gna_plugin/gna_graph_compiler.cpp
@@ -487,7 +487,8 @@ void GNAGraphCompiler::PowerPrimitive(InferenceEngine::CNNLayerPtr layer) {
     uint32_t num_padding = ALIGN(num_rows_in, 8) - num_rows_in;
 
     if (num_columns_in > 8) {
-        THROW_GNA_EXCEPTION << "Columns_in should be not greater than 8 and now columns_in = " << num_columns_in;
+        THROW_GNA_EXCEPTION << "The power layer doesn't support the first dimension greater than 8 (for 2D operation)" \
+                               " or the second dimension greater than 8 (for 3D operation).";
     }
 
     size_t num_data_bytes_out = InferenceEngine::details::product(begin(outputs->getDims()), end(outputs->getDims()))
@@ -988,7 +989,6 @@ void GNAGraphCompiler::EltwisePrimitive(InferenceEngine::CNNLayerPtr layer) {
     uint32_t num_columns_in = in_4b_batch;
     uint32_t num_rows_out = num_rows_in;
     uint32_t num_padding = ALIGN(num_rows_in, 8) - num_rows_in;
-
 
     void* ptr_inputs = nullptr;
     void* ptr_outputs = nullptr;

--- a/inference-engine/src/gna_plugin/gna_graph_compiler.cpp
+++ b/inference-engine/src/gna_plugin/gna_graph_compiler.cpp
@@ -486,6 +486,10 @@ void GNAGraphCompiler::PowerPrimitive(InferenceEngine::CNNLayerPtr layer) {
     uint32_t num_rows_out = num_rows_in;
     uint32_t num_padding = ALIGN(num_rows_in, 8) - num_rows_in;
 
+    if (num_columns_in > 8) {
+        THROW_GNA_EXCEPTION << "Columns_in should be not greater than 8 and now columns_in = " << num_columns_in;
+    }
+
     size_t num_data_bytes_out = InferenceEngine::details::product(begin(outputs->getDims()), end(outputs->getDims()))
         * outputs->getPrecision().size();
 
@@ -984,6 +988,7 @@ void GNAGraphCompiler::EltwisePrimitive(InferenceEngine::CNNLayerPtr layer) {
     uint32_t num_columns_in = in_4b_batch;
     uint32_t num_rows_out = num_rows_in;
     uint32_t num_padding = ALIGN(num_rows_in, 8) - num_rows_in;
+
 
     void* ptr_inputs = nullptr;
     void* ptr_outputs = nullptr;

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/behavior/exec_layers.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/behavior/exec_layers.cpp
@@ -1,0 +1,24 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "behavior/exec_layers.hpp"
+
+using namespace BehaviorTestsDefinitions;
+namespace {
+    const std::vector<InferenceEngine::Precision> netPrecisions = {
+            InferenceEngine::Precision::FP32,
+    };
+
+    const std::vector<std::map<std::string, std::string>> configs = {
+            {},
+    };
+
+    INSTANTIATE_TEST_CASE_P(smoke_BehaviorTests, ExecLayerTests,
+            ::testing::Combine(
+            ::testing::ValuesIn(netPrecisions),
+            ::testing::Values(CommonTestUtils::DEVICE_GNA),
+            ::testing::ValuesIn(configs)),
+            ExecLayerTests::getTestCaseName);
+
+}  // namespace

--- a/inference-engine/tests/functional/plugin/shared/include/behavior/exec_layers.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/behavior/exec_layers.hpp
@@ -1,0 +1,23 @@
+// Copyright (C) 2018-2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <functional_test_utils/behavior_test_utils.hpp>
+
+namespace BehaviorTestsDefinitions {
+    using ExecLayerTests = BehaviorTestsUtils::BehaviorTestsBasic;
+
+    TEST_P(ExecLayerTests, CheckMultiplyExecution) {
+        // Skip test according to plugin specific disabledTestPatterns() (if any)
+        SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+        // Create ngraph function
+        auto params = ngraph::builder::makeParams(ngraph::element::f32, {{9, 256}});
+        auto const_mult = ngraph::builder::makeConstant(ngraph::element::f32, {}, {-1.0f});
+        auto mult = std::make_shared<ngraph::opset1::Multiply>(params[0], const_mult);
+        auto func = std::make_shared<ngraph::Function>(mult, params);
+        auto ie = InferenceEngine::Core();
+        InferenceEngine::CNNNetwork cnnNet(func);
+        ASSERT_THROW(ie.LoadNetwork(cnnNet, targetDevice), InferenceEngine::details::InferenceEngineException);
+    }
+} // namespace BehaviorTestsDefinitions

--- a/inference-engine/tests_deprecated/unit/engines/gna/layers/gna_conv1d_test.cpp
+++ b/inference-engine/tests_deprecated/unit/engines/gna/layers/gna_conv1d_test.cpp
@@ -108,5 +108,5 @@ INSTANTIATE_TEST_CASE_P(
                 testing::Values(1, 3, 9, 16, 24, 32, 42, 64),
                 testing::Values(0, 1),
                 testing::Values(0),
-                testing::Values(32, 128, 512)),
+                testing::Values(2, 4, 6, 8)),
         GNAConv1DTest::getTestName);


### PR DESCRIPTION
Now, if colomns_in receives an input more than 8, then it will throw an error of an unsupported parameter.