### PR TITLE
[IE CLDNN] Added fusing suport to all pooling kernels

### DIFF
--- a/inference-engine/src/cldnn_engine/cldnn_program.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_program.cpp
@@ -2735,6 +2735,8 @@ void Program::CreatePoolingPrimitive(cldnn::topology& topology, InferenceEngine:
             input_offset,
             CldnnTensorFromIEDims(poolLayer->outData[0]->getTensorDesc().getDims()),
             dt);
+        cldnn::tensor pad_end = { 0, 0, -TensorValue(poolLayer->_pads_end[X_AXIS]), -TensorValue(poolLayer->_pads_end[Y_AXIS]), 0 };
+        poolPrim.pad_end = pad_end;
         topology.add(poolPrim);
         primitiveIDs[poolLayerName] = poolLayerName;
     }

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/pooling.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/pooling.cpp
@@ -12,7 +12,6 @@ using namespace ngraph::helpers;
 using namespace LayerTestsDefinitions;
 
 namespace {
-
 const std::vector<InferenceEngine::Precision> netPrecisions = {
         InferenceEngine::Precision::FP32,
         InferenceEngine::Precision::FP16
@@ -28,6 +27,7 @@ const std::vector<std::vector<size_t >> padEnds = {{0, 0},
                                                           {0, 2}};
 const std::vector<ngraph::op::RoundingType> roundingTypes = {ngraph::op::RoundingType::CEIL,
                                                              ngraph::op::RoundingType::FLOOR};
+
 ////* ========== Max Polling ========== */
 /* +========== Explicit Pad Floor Rounding ========== */
 const auto maxPool_ExplicitPad_FloorRounding_Params = ::testing::Combine(
@@ -35,8 +35,7 @@ const auto maxPool_ExplicitPad_FloorRounding_Params = ::testing::Combine(
         ::testing::ValuesIn(kernels),
         ::testing::ValuesIn(strides),
         ::testing::ValuesIn(padBegins),
-        // TODO: Accuracy mismatch with non zero Pad Ends (tested with {0.2})
-        ::testing::Values(std::vector<size_t>({0, 0})),
+        ::testing::ValuesIn(padEnds),
         ::testing::Values(ngraph::op::RoundingType::FLOOR),
         ::testing::Values(ngraph::op::PadType::EXPLICIT),
         ::testing::Values(false)  // placeholder value - exclude pad not applicable for max pooling
@@ -57,8 +56,7 @@ const auto maxPool_ExplicitPad_CeilRounding_Params = ::testing::Combine(
         // TODO: Non 1 strides fails in ngraph reference implementation with error "The end corner is out of bounds at axis 3" thrown in the test body.
         ::testing::Values(std::vector<size_t>({1, 1})),
         ::testing::ValuesIn(padBegins),
-        // TODO: Accuracy mismatch with non zero Pad Ends (tested with {0.2})
-        ::testing::Values(std::vector<size_t>({0, 0})),
+        ::testing::ValuesIn(padEnds),
         ::testing::Values(ngraph::op::RoundingType::CEIL),
         ::testing::Values(ngraph::op::PadType::EXPLICIT),
         ::testing::Values(false)  // placeholder value - exclude pad not applicable for max pooling
@@ -80,9 +78,8 @@ const auto avgPoolExplicitPadCeilRoundingParams = ::testing::Combine(
         ::testing::ValuesIn(kernels),
         // TODO: Non 1 strides fails in ngraph reference implementation with error "The end corner is out of bounds at axis 3" thrown in the test body.
         ::testing::Values(std::vector<size_t>({1, 1})),
-        // TODO: Non zero pads excluded because of accuracy mismatch
-        ::testing::Values(std::vector<size_t>({0, 0})),
-        ::testing::Values(std::vector<size_t>({0, 0})),
+        ::testing::ValuesIn(padBegins),
+        ::testing::ValuesIn(padEnds),
         ::testing::Values(ngraph::op::RoundingType::CEIL),
         ::testing::Values(ngraph::op::PadType::EXPLICIT),
         ::testing::Values(true, false)
@@ -101,9 +98,8 @@ const auto avgPoolExplicitPadFloorRoundingParams = ::testing::Combine(
         ::testing::Values(PoolingTypes::AVG),
         ::testing::ValuesIn(kernels),
         ::testing::ValuesIn(strides),
-        // TODO: Non zero pads excluded because of accuracy mismatch
-        ::testing::Values(std::vector<size_t>({0, 0})),
-        ::testing::Values(std::vector<size_t>({0, 0})),
+        ::testing::ValuesIn(padBegins),
+        ::testing::ValuesIn(padEnds),
         ::testing::Values(ngraph::op::RoundingType::FLOOR),
         ::testing::Values(ngraph::op::PadType::EXPLICIT),
         ::testing::Values(true, false)
@@ -125,9 +121,9 @@ const auto allPools_ValidPad_Params = ::testing::Combine(
         ::testing::ValuesIn(kernels),
         ::testing::ValuesIn(strides),
         ::testing::Values(std::vector<size_t>({0, 0})),
-        ::testing::Values(std::vector<size_t>({0, 0})),
-        ::testing::Values(
-                ngraph::op::RoundingType::FLOOR),  // placeholder value - Rounding Type not applicable for Valid pad type
+        ::testing::ValuesIn(padEnds),
+        ::testing::Values(ngraph::op::RoundingType::FLOOR),  // placeholder value - Rounding Type not applicable for Valid pad type
+        // TODO: PadType::VALID seems not to ignore padBegins
         ::testing::Values(ngraph::op::PadType::VALID),
         ::testing::Values(false)  // placeholder value - exclude pad not applicable for max pooling
 );
@@ -139,6 +135,4 @@ INSTANTIATE_TEST_CASE_P(MAX_and_AVGPool_ValidPad, PoolingLayerTest,
                                 ::testing::Values(std::vector<size_t >({1, 3, 50, 50})),
                                 ::testing::Values(CommonTestUtils::DEVICE_GPU)),
                         PoolingLayerTest::getTestCaseName);
-
-
 }  // namespace

--- a/inference-engine/thirdparty/clDNN/api/pooling.hpp
+++ b/inference-engine/thirdparty/clDNN/api/pooling.hpp
@@ -188,6 +188,8 @@ struct pooling : public primitive_base<pooling> {
     bool with_output_size;
     /// @brief User-defined output data size of the primitive (w/o padding).
     tensor output_size;
+    /// @brief Defines a shift, relative to the end of padding shape.
+    tensor pad_end;
 
 protected:
     std::vector<std::reference_wrapper<const primitive_id>> get_dependencies() const override {

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_base.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_base.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016-2019 Intel Corporation
+﻿// Copyright (c) 2016-2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,24 +33,27 @@ bool PoolingKernelBase::Validate(const Params& p, const optional_params& o) cons
 }
 
 Datatype PoolingKernelBase::GetAccumulatorType(const pooling_params& params) const {
-    if (params.quantization != QuantizationType::NONE)
-        return Datatype::INT32;
+    const auto& input_dt = params.inputs[0].GetDType();
+    const auto& pool_type = params.poolType;
 
-    Datatype types[] = { Datatype::F32, Datatype::F16, Datatype::INT64, Datatype::INT32, Datatype::UINT32};
-
-    for (Datatype type : types)
-        for (auto& in : params.inputs)
-            if (in.GetDType() == type)
-                return type;
-
-    return Datatype::F32;
+    if (pool_type == PoolType::MAX) {
+        return input_dt;
+    } else {
+        switch (input_dt) {
+            case Datatype::F32: return Datatype::F32;
+            case Datatype::F16: return Datatype::F32;
+            case Datatype::INT8: return Datatype::INT32;
+            case Datatype::UINT8: return Datatype::INT32;
+            default: return Datatype::F32;
+        }
+    }
 }
 
 Datatype PoolingKernelBase::GetActivationType(const pooling_params& params) const {
-    if (params.quantization != QuantizationType::NONE)
+    if (params.output.GetDType() == Datatype::F16)
+        return Datatype::F16;
+    else
         return Datatype::F32;
-
-    return GetUnitType(params);
 }
 
 
@@ -78,11 +81,16 @@ JitConstants PoolingKernelBase::GetJitConstants(const pooling_params& pp, Poolin
 
 // Checks if we need boundary checking in kernel.
 bool PoolingKernelBase::NeedsBoundaryCheck(const pooling_params& pp) const {
+    const auto& input = pp.inputs[0];
+    const auto& output = pp.output;
+
     if (pp.poolPad.x != 0 || pp.poolPad.y != 0 || pp.poolPad.z != 0) {
         return true;
+    } else if ((((input.X().v - pp.poolSize.x) / pp.poolStride.x) + 1) < output.X().v ||
+               (((input.Y().v - pp.poolSize.y) / pp.poolStride.y) + 1) < output.Y().v ||
+               (((input.Z().v - pp.poolSize.z) / pp.poolStride.z) + 1) < output.Z().v) {
+        return true;
     }
-
-    const auto& input = pp.inputs[0];
 
     if (input.X().v < pp.poolSize.x || input.Y().v < pp.poolSize.y || input.Z().v < pp.poolSize.z) {
         return true;
@@ -99,7 +107,7 @@ bool PoolingKernelBase::NeedsBoundaryCheck(const pooling_params& pp) const {
     return mod_x || mod_y || mod_z;
 }
 
-bool PoolingKernelBase::EnableRound(const kernel_selector::pooling_params &params) const {
+bool PoolingKernelBase::EnableRound(const kernel_selector::pooling_params& params) const {
     bool has_fused_quantize_to_int8 = false;
     for (auto& op : params.fused_ops) {
         if (op.GetType() == FusedOpType::QUANTIZE &&
@@ -108,7 +116,8 @@ bool PoolingKernelBase::EnableRound(const kernel_selector::pooling_params &param
         }
     }
 
-    if (!has_fused_quantize_to_int8 && (params.output.GetDType() == Datatype::INT8 || params.output.GetDType() == Datatype::UINT8) &&
+    if (!has_fused_quantize_to_int8 &&
+        (params.output.GetDType() == Datatype::INT8 || params.output.GetDType() == Datatype::UINT8) &&
         params.poolType == PoolType::AVG) {
         return true;
     }

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_average_opt.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_average_opt.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016 Intel Corporation
+﻿// Copyright (c) 2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_b_fs_yx_fsv16.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_b_fs_yx_fsv16.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2018-2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,6 +30,11 @@ protected:
     bool Validate(const Params&, const optional_params&) const override;
     JitConstants GetJitConstants(const pooling_params& params, DispatchData kd) const override;
     DispatchData SetDefault(const pooling_params& params) const override;
+    std::vector<FusedOpType> GetSupportedFusedOps() const override {
+        return { FusedOpType::QUANTIZE,
+                 FusedOpType::SCALE,
+                 FusedOpType::ACTIVATION };
+    }
 
     size_t GetBlockSize(const pooling_params& params) const;
 };

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_b_fs_yx_fsv4.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_b_fs_yx_fsv4.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Intel Corporation
+// Copyright (c) 2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_bfyx_block_opt.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_bfyx_block_opt.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016 Intel Corporation
+﻿// Copyright (c) 2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ ParamsKey PoolingKernelGPUBfyxBlockOpt::GetSupportedKey() const {
     k.EnableInputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::F16);
     k.EnableOutputDataType(Datatype::F32);
+    k.EnableOutputDataType(Datatype::UINT8);
+    k.EnableOutputDataType(Datatype::INT8);
     k.EnableInputLayout(DataLayout::bfyx);
     k.EnableOutputLayout(DataLayout::bfyx);
     k.EnableTensorOffset();
@@ -48,12 +50,28 @@ PoolingKernelBase::DispatchData PoolingKernelGPUBfyxBlockOpt::SetDefault(const p
 }
 
 JitConstants PoolingKernelGPUBfyxBlockOpt::GetJitConstants(const pooling_params& params, DispatchData kd) const {
-    auto mem_consts = PoolingKernelBase::GetJitConstants(params, kd);
+    auto jit = PoolingKernelBase::GetJitConstants(params, kd);
 
-    mem_consts.AddConstant(
+    jit.AddConstant(
         MakeJitConstant("BLOCK_SIZE_Y", params.poolSize.y + params.poolSize.y * params.poolStride.y - 1));
+    jit.Merge(MakeTypeJitConstants(GetActivationType(params), "ACTIVATION"));
+    jit.Merge(MakeTypeJitConstants(GetAccumulatorType(params), "ACCUMULATOR"));
 
-    return mem_consts;
+    if (!params.fused_ops.empty()) {
+        auto input_dt = GetActivationType(params);
+        FusedOpsConfiguration conf = {"",
+                                     {"b", "f", "y + i", "x"},
+                                     "pool_result",
+                                     input_dt,
+                                     1,
+                                     LoadType::LT_UNALIGNED,
+                                     BoundaryCheck::ENABLED,
+                                     IndexType::TENSOR_COORD,
+                                     Tensor::DataChannelName::Y};
+        jit.Merge(MakeFusedOpsJitConstants(params, {conf}));
+    }
+
+    return jit;
 }
 
 bool PoolingKernelGPUBfyxBlockOpt::Validate(const Params& p, const optional_params& o) const {

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_bfyx_block_opt.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_bfyx_block_opt.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016 Intel Corporation
+﻿// Copyright (c) 2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,5 +30,10 @@ protected:
     bool Validate(const Params&, const optional_params&) const override;
     JitConstants GetJitConstants(const pooling_params& params, DispatchData kd) const override;
     DispatchData SetDefault(const pooling_params& params) const override;
+    std::vector<FusedOpType> GetSupportedFusedOps() const override {
+        return { FusedOpType::QUANTIZE,
+                 FusedOpType::SCALE,
+                 FusedOpType::ACTIVATION };
+    }
 };
 }  // namespace kernel_selector

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_bsv16_fsv16.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_bsv16_fsv16.h
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2019 Intel Corporation
+// Copyright (c) 2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,5 +34,10 @@ protected:
     bool Validate(const Params& p, const optional_params& o) const override;
     JitConstants GetJitConstants(const pooling_params& params, DispatchData kd) const override;
     DispatchData SetDefault(const pooling_params& params) const override;
+    std::vector<FusedOpType> GetSupportedFusedOps() const override {
+        return { FusedOpType::QUANTIZE,
+                 FusedOpType::SCALE,
+                 FusedOpType::ACTIVATION };
+    }
 };
 }  // namespace kernel_selector

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_byxf_af32.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_byxf_af32.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016 Intel Corporation
+﻿// Copyright (c) 2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -62,18 +62,20 @@ JitConstants PoolingKerneGPU_byxf_af32::GetJitConstants(const pooling_params& pa
     JitConstants jit = PoolingKernelBase::GetJitConstants(params, kd);
 
     jit.AddConstant(MakeJitConstant("AS_INPUT_TYPE(val)", "as_" + toCLType(params.inputs[0].GetDType()) + "4(val)"));
+    jit.Merge(MakeTypeJitConstants(GetActivationType(params), "ACTIVATION"));
+    jit.Merge(MakeTypeJitConstants(GetAccumulatorType(params), "ACCUMULATOR"));
 
     if (!params.fused_ops.empty()) {
-        auto input_dt = EnableRound(params) ? Datatype::INT32 : GetActivationType(params);
-        FusedOpsConfiguration conf = { "",
-                                       {"b", "f", "y", "x"},
-                                       "pool_result",
-                                       input_dt,
-                                       4,
-                                       LoadType::LT_UNALIGNED,
-                                       BoundaryCheck::ENABLED,
-                                       IndexType::TENSOR_COORD,
-                                       Tensor::DataChannelName::FEATURE };
+        auto input_dt = GetActivationType(params);
+        FusedOpsConfiguration conf = {"",
+                                     {"b", "f", "y", "x"},
+                                     "fused_pool_result",
+                                     input_dt,
+                                     4,
+                                     LoadType::LT_UNALIGNED,
+                                     BoundaryCheck::ENABLED,
+                                     IndexType::TENSOR_COORD,
+                                     Tensor::DataChannelName::FEATURE};
         jit.Merge(MakeFusedOpsJitConstants(params, { conf }));
     }
 

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_byxf_af32.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_byxf_af32.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016 Intel Corporation
+﻿// Copyright (c) 2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_byxf_opt.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_byxf_opt.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,10 +22,13 @@ ParamsKey PoolingKernelGPUByxfOpt::GetSupportedKey() const {
     k.EnableInputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::F16);
     k.EnableOutputDataType(Datatype::F32);
+    k.EnableOutputDataType(Datatype::UINT8);
+    k.EnableOutputDataType(Datatype::INT8);
     k.EnableInputLayout(DataLayout::byxf);
     k.EnableOutputLayout(DataLayout::byxf);
     k.EnableTensorOffset();
     k.EnableTensorPitches();
+    k.EnableDifferentTypes();
     k.EnableBatching();
     k.EnablePoolType(PoolType::MAX);
     k.EnablePoolType(PoolType::AVG);
@@ -46,9 +49,24 @@ PoolingKernelBase::DispatchData PoolingKernelGPUByxfOpt::SetDefault(const poolin
 }
 
 JitConstants PoolingKernelGPUByxfOpt::GetJitConstants(const pooling_params& params, DispatchData kd) const {
-    auto mem_consts = PoolingKernelBase::GetJitConstants(params, kd);
+    auto jit = PoolingKernelBase::GetJitConstants(params, kd);
+    jit.Merge(MakeTypeJitConstants(GetActivationType(params), "ACTIVATION"));
+    jit.Merge(MakeTypeJitConstants(GetAccumulatorType(params), "ACCUMULATOR"));
 
-    return mem_consts;
+    if (!params.fused_ops.empty()) {
+        auto input_dt = GetActivationType(params);
+        FusedOpsConfiguration conf = {"",
+                                     {"b", "f + i", "y", "x"},
+                                     "pool_result",
+                                     input_dt,
+                                     1,
+                                     LoadType::LT_UNALIGNED,
+                                     BoundaryCheck::ENABLED,
+                                     IndexType::TENSOR_COORD,
+                                     Tensor::DataChannelName::FEATURE};
+        jit.Merge(MakeFusedOpsJitConstants(params, {conf}));
+    }
+    return jit;
 }
 
 bool PoolingKernelGPUByxfOpt::Validate(const Params& p, const optional_params& o) const {

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_byxf_opt.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_byxf_opt.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,5 +30,10 @@ protected:
     bool Validate(const Params&, const optional_params&) const override;
     JitConstants GetJitConstants(const pooling_params& params, DispatchData kd) const override;
     DispatchData SetDefault(const pooling_params& params) const override;
+    std::vector<FusedOpType> GetSupportedFusedOps() const override {
+        return { FusedOpType::QUANTIZE,
+                 FusedOpType::SCALE,
+                 FusedOpType::ACTIVATION };
+    }
 };
 }  // namespace kernel_selector

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_byxf_padding_opt.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_byxf_padding_opt.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,5 +30,10 @@ protected:
     bool Validate(const Params&, const optional_params&) const override;
     JitConstants GetJitConstants(const pooling_params& params, DispatchData kd) const override;
     DispatchData SetDefault(const pooling_params& params) const override;
+    std::vector<FusedOpType> GetSupportedFusedOps() const override {
+        return { FusedOpType::QUANTIZE,
+                 FusedOpType::SCALE,
+                 FusedOpType::ACTIVATION };
+    }
 };
 }  // namespace kernel_selector

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_fs_b_yx_fsv32.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_fs_b_yx_fsv32.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Intel Corporation
+// Copyright (c) 2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,5 +30,10 @@ public:
 protected:
     bool Validate(const Params& p, const optional_params& o) const override;
     JitConstants GetJitConstants(const pooling_params& params, DispatchData kd) const override;
+    std::vector<FusedOpType> GetSupportedFusedOps() const override {
+        return { FusedOpType::QUANTIZE,
+                 FusedOpType::SCALE,
+                 FusedOpType::ACTIVATION };
+    }
 };
 }  // namespace kernel_selector

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_fs_bs_yx_bsv4_fsv32.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_fs_bs_yx_bsv4_fsv32.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2018 Intel Corporation
+﻿// Copyright (c) 2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,5 +29,11 @@ public:
 
 protected:
     JitConstants GetJitConstants(const pooling_params& params, DispatchData kd) const override;
+    bool Validate(const Params&, const optional_params&) const override;
+    std::vector<FusedOpType> GetSupportedFusedOps() const override {
+         return { FusedOpType::QUANTIZE,
+                  FusedOpType::SCALE,
+                  FusedOpType::ACTIVATION };
+    }
 };
 }  // namespace kernel_selector

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_fs_bs_yx_bsv4_fsv32_simd32.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_fs_bs_yx_bsv4_fsv32_simd32.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2018 Intel Corporation
+﻿// Copyright (c) 2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,5 +29,10 @@ public:
 
 protected:
     JitConstants GetJitConstants(const pooling_params& params, DispatchData kd) const override;
+        std::vector<FusedOpType> GetSupportedFusedOps() const override {
+        return { FusedOpType::QUANTIZE,
+                 FusedOpType::SCALE,
+                 FusedOpType::ACTIVATION };
+        }
 };
 }  // namespace kernel_selector

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_int8_ref.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_int8_ref.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016 Intel Corporation
+﻿// Copyright (c) 2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -63,9 +63,12 @@ KernelsData PoolingKernelGPUInt8Ref::GetKernelsData(const Params& params, const 
 
 JitConstants PoolingKernelGPUInt8Ref::GetJitConstants(const pooling_params& params, DispatchData kd) const {
     JitConstants jit = PoolingKernelBase::GetJitConstants(params, kd);
+    jit.Merge(MakeTypeJitConstants(GetActivationType(params), "ACTIVATION"));
+    jit.Merge(MakeTypeJitConstants(GetAccumulatorType(params), "ACCUMULATOR"));
 
     if (!params.fused_ops.empty()) {
-        auto input_dt = EnableRound(params) ? Datatype::INT32 : GetActivationType(params);
+        auto input_dt = GetActivationType(params);
+
         std::vector<std::string> idx_order;
         if (DataTensor::ChannelsCount(params.output.GetLayout()) == 4) {
             idx_order = {"b", "f", "y", "x"};
@@ -73,7 +76,7 @@ JitConstants PoolingKernelGPUInt8Ref::GetJitConstants(const pooling_params& para
             idx_order = {"b", "f", "z", "y", "x"};
         }
 
-        FusedOpsConfiguration conf = {"", idx_order, "pool_res", input_dt, 1 };
+        FusedOpsConfiguration conf = {"", idx_order, "pool_result", input_dt, 1 };
         jit.Merge(MakeFusedOpsJitConstants(params, {conf}));
     }
 
@@ -88,7 +91,8 @@ bool PoolingKernelGPUInt8Ref::Validate(const Params& params, const optional_para
 
     if (p.inputs[0].GetDType() == Datatype::INT8 || p.inputs[0].GetDType() == Datatype::UINT8) {
         // Max pooling doesn't change quantization ranges, so output data type should be the same as input
-        if ((p.poolType == PoolType::MAX || p.poolType == PoolType::MAX_WITH_ARGMAX) && p.output.GetDType() != p.inputs[0].GetDType())
+        if ((p.poolType == PoolType::MAX || p.poolType == PoolType::MAX_WITH_ARGMAX)
+            && (p.output.GetDType() != p.inputs[0].GetDType()) && p.quantization == QuantizationType::NONE)
             return false;
 //         Average pooling should produce FP by default. (u)int8 is possible when quantize op is fused.
 //        if (p.poolType == PoolType::AVG &&

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_int8_ref.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_int8_ref.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016 Intel Corporation
+﻿// Copyright (c) 2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,8 +29,7 @@ public:
     bool Validate(const Params&, const optional_params&) const override;
     JitConstants GetJitConstants(const pooling_params& params, DispatchData kd) const override;
     std::vector<FusedOpType> GetSupportedFusedOps() const override {
-        return { FusedOpType::ELTWISE,
-                 FusedOpType::QUANTIZE,
+        return { FusedOpType::QUANTIZE,
                  FusedOpType::SCALE,
                  FusedOpType::ACTIVATION };
     }

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_ref.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_gpu_ref.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016 Intel Corporation
+﻿// Copyright (c) 2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,5 +25,13 @@ public:
 
     KernelsData GetKernelsData(const Params& params, const optional_params& options) const override;
     ParamsKey GetSupportedKey() const override;
+    std::vector<FusedOpType> GetSupportedFusedOps() const override {
+        return { FusedOpType::QUANTIZE,
+                 FusedOpType::SCALE,
+                 FusedOpType::ACTIVATION };
+    }
+
+protected:
+    JitConstants GetJitConstants(const pooling_params& params, DispatchData kd) const override;
 };
 }  // namespace kernel_selector

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_selector.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/pooling/pooling_kernel_selector.cpp
@@ -32,7 +32,7 @@ namespace kernel_selector {
 
 pooling_kernel_selector::pooling_kernel_selector() {
     Attach<PoolingKernelGPURef>();
-    // Attach<PoolingKernelGPUAverageOpt>(); TODO: fix the kernel as it reads out of bounds now
+    //Attach<PoolingKernelGPUAverageOpt>(); TODO: fix the kernel as it reads out of bounds now
     Attach<PoolingKernelGPUByxfOpt>();
     Attach<PoolingKernelGPUBfyxBlockOpt>();
     Attach<PoolingKernelGPUByxfPaddingOpt>();

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/pooling_gpu_average_opt.cl
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/pooling_gpu_average_opt.cl
@@ -17,7 +17,10 @@
 
 __attribute__((intel_reqd_sub_group_size(SUB_GROUP_SIZE)))
 __attribute__((reqd_work_group_size(SUB_GROUP_SIZE, 1, 1)))
-KERNEL(pooling_gpu_average_opt)(const __global float* input, __global float* output)
+KERNEL(pooling_gpu_average_opt)(
+    const __global INPUT0_TYPE* input,
+     __global OUTPUT_TYPE* output
+)
 {
     int local_id = get_local_id(0);
     int tile_x = get_global_id(0);
@@ -39,7 +42,7 @@ KERNEL(pooling_gpu_average_opt)(const __global float* input, __global float* out
     // 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15
     // In the diagram above X represents the current work item.
 
-    const __global float* base_addr = input + offset + (start_y * INPUT0_SIZE_X + start_x) - 1;
+    const __global INPUT0_TYPE* base_addr = input + offset + (start_y * INPUT0_SIZE_X + start_x) - 1;
 
     float input_buffer[3];
     input_buffer[0] = as_float(intel_sub_group_block_read((const __global uint*)(base_addr - INPUT0_SIZE_X)));
@@ -92,10 +95,12 @@ KERNEL(pooling_gpu_average_opt)(const __global float* input, __global float* out
             res = (sum + sum_1 + sum_2) * ONE_OVER_POOL_SIZE;
         }
 #endif
+        OUTPUT_TYPE final_result;
 
         if ((local_id < TILE_WIDTH) && (offset_x < INPUT0_SIZE_X))
         {
-            output[offset + y * INPUT0_SIZE_X + offset_x] = ACTIVATION(res, ACTIVATION_PARAMS);
+            final_result = TO_OUTPUT_TYPE(ACTIVATION(res, ACTIVATION_PARAMS));
+            output[offset + y * INPUT0_SIZE_X + offset_x] = final_result;
         }
 
         first = (first + 1) % 3;

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/pooling_gpu_byxf_opt.cl
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/pooling_gpu_byxf_opt.cl
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,38 +15,48 @@
 
 #include "include/include_all.cl"
 
-#define VECTOR_TYPE MAKE_VECTOR_TYPE(UNIT_TYPE,8)
+#define INPUT_VEC8 MAKE_VECTOR_TYPE(INPUT0_TYPE, 8)
+
+#define ACCUMULATOR_VEC8 MAKE_VECTOR_TYPE(ACCUMULATOR_TYPE, 8)
+#define TO_ACCUMULATOR_VEC8 CAT(convert_, ACCUMULATOR_VEC8)
+
 #define FEATURE_PER_ITEM 8
 #define FEATURE_BLOCK_NUM (OUTPUT_FEATURE_NUM / 8)
 
-#if   defined MAX_POOLING
-    #define UNIT_INIT_VAL UNIT_VAL_MIN
-#elif defined AVG_POOLING
-    #define UNIT_INIT_VAL UNIT_VAL_ZERO
+#if MAX_POOLING
+    #define INIT_VAL ACCUMULATOR_VAL_MIN
+#elif AVG_POOLING
+    #define INIT_VAL ACCUMULATOR_VAL_ZERO
 #else
-#error
+    #error
 #endif
 
-inline VECTOR_TYPE FUNC(apply_pooling)(VECTOR_TYPE tmp, VECTOR_TYPE in)
+inline ACCUMULATOR_VEC8 FUNC(apply_pooling)(ACCUMULATOR_VEC8 tmp, ACCUMULATOR_VEC8 in)
 {
 #if defined MAX_POOLING
-    return max(tmp, in);
+    return ACCUMULATOR_MAX_FUNC(tmp, in);
 #elif defined AVG_POOLING
     return tmp + in;
 #endif
 }
 
-KERNEL(pooling_gpu_byxf_opt)(const __global UNIT_TYPE* input, __global UNIT_TYPE* output)
+KERNEL(pooling_gpu_byxf_opt)(
+    const __global INPUT0_TYPE* input,
+    __global OUTPUT_TYPE* output
+#if HAS_FUSED_OPS_DECLS
+    , FUSED_OPS_DECLS
+#endif
+)
 {
-    VECTOR_TYPE out;
     const uint x    = (uint)get_global_id(0);
     const uint y    = (uint)get_global_id(1);
     const uint bf   = (uint)get_global_id(2);
     const uint f    = bf / INPUT0_BATCH_NUM * FEATURE_PER_ITEM;
     const uint b    = bf % INPUT0_BATCH_NUM;
-    
-    VECTOR_TYPE feature_block;
-    
+
+    INPUT_VEC8 feature_block;
+    ACCUMULATOR_VEC8 result;
+
     if ((x >= OUTPUT_SIZE_X) || (y >= OUTPUT_SIZE_Y))
         return;
 
@@ -54,8 +64,8 @@ KERNEL(pooling_gpu_byxf_opt)(const __global UNIT_TYPE* input, __global UNIT_TYPE
     const int offset_y = (int)y*STRIDE_SIZE_Y;
 
     int input_idx = b*FEATURE_BLOCK_NUM*INPUT0_SIZE_X*INPUT0_SIZE_Y + FEATURE_BLOCK_NUM*INPUT0_SIZE_X*offset_y + FEATURE_BLOCK_NUM*offset_x + bf / INPUT0_BATCH_NUM;
-    
-    out = UNIT_INIT_VAL;
+
+    result = INIT_VAL;
 
     __attribute__((opencl_unroll_hint))
     for(uint j = 0; j < POOL_SIZE_Y; j++)
@@ -64,10 +74,12 @@ KERNEL(pooling_gpu_byxf_opt)(const __global UNIT_TYPE* input, __global UNIT_TYPE
         for(uint i = 0; i < POOL_SIZE_X; i++)
         {
             feature_block = vload8(input_idx+FEATURE_BLOCK_NUM*i, input);
-            out = FUNC_CALL(apply_pooling)(out, feature_block);
+            result = FUNC_CALL(apply_pooling)(result, TO_ACCUMULATOR_VEC8(feature_block));
         }
         input_idx += FEATURE_BLOCK_NUM*INPUT0_SIZE_X;
     }
+
+    OUTPUT_TYPE final_result;
 
     uint output_pos = GET_DATA_INDEX(OUTPUT, b, f, y, x);
     __attribute__((opencl_unroll_hint))
@@ -75,9 +87,23 @@ KERNEL(pooling_gpu_byxf_opt)(const __global UNIT_TYPE* input, __global UNIT_TYPE
     {
         if(f+i < INPUT0_FEATURE_NUM){
 #if defined MAX_POOLING
-            output[output_pos+i] = ACTIVATION(out[i], ACTIVATION_PARAMS);
+        ACTIVATION_TYPE pool_result = TO_ACTIVATION_TYPE(result[i]);
+    #if HAS_FUSED_OPS
+        FUSED_OPS;
+        final_result = FUSED_OPS_RESULT;
+    #else
+        final_result = TO_OUTPUT_TYPE(ACTIVATION(pool_result, ACTIVATION_PARAMS));
+    #endif
+        output[output_pos+i] = final_result;
 #elif defined AVG_POOLING
-            output[output_pos+i] = ACTIVATION(out[i]/(UNIT_TYPE)(POOL_SIZE_X*POOL_SIZE_Y), ACTIVATION_PARAMS);
+        ACTIVATION_TYPE pool_result = TO_ACTIVATION_TYPE(result[i]/(OUTPUT_TYPE)(POOL_SIZE_X*POOL_SIZE_Y));
+    #if HAS_FUSED_OPS
+        FUSED_OPS;
+        final_result = FUSED_OPS_RESULT;
+    #else
+        final_result = TO_OUTPUT_TYPE(ACTIVATION(pool_result, ACTIVATION_PARAMS));
+    #endif
+        output[output_pos+i] = final_result;
 #endif
         }
     }
@@ -85,5 +111,9 @@ KERNEL(pooling_gpu_byxf_opt)(const __global UNIT_TYPE* input, __global UNIT_TYPE
 
 #undef FEATURE_BLOCK_NUM
 #undef FEATURE_PER_ITEM
-#undef UNIT_INIT_VAL
-#undef VECTOR_TYPE
+
+#undef INIT_VAL
+#undef INPUT_VEC8
+
+#undef ACCUMULATOR_VEC8
+#undef TO_ACCUMULATOR_VEC8

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/pooling_gpu_byxf_padding_opt.cl
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/pooling_gpu_byxf_padding_opt.cl
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,38 +15,48 @@
 
 #include "include/include_all.cl"
 
-#define VECTOR_TYPE MAKE_VECTOR_TYPE(UNIT_TYPE,8)
-#define FEATURE_PER_ITEM 8
-#define FEATURE_BLOCK_NUM (OUTPUT_FEATURE_NUM / 8)
+#define INPUT0_VEC8 MAKE_VECTOR_TYPE(INPUT0_TYPE,8)
 
-#if   defined MAX_POOLING
-    #define UNIT_INIT_VAL UNIT_VAL_MIN
-#elif defined AVG_POOLING
-    #define UNIT_INIT_VAL UNIT_VAL_ZERO
+#define ACCUMULATOR_VEC8 MAKE_VECTOR_TYPE(ACCUMULATOR_TYPE, 8)
+#define TO_ACCUMULATOR_VEC8 CAT(convert_, ACCUMULATOR_VEC8)
+
+#define FEATURE_PER_ITEM 8
+#define FEATURE_BLOCK_NUM (INPUT0_FEATURE_NUM / 8)
+
+#if MAX_POOLING
+    #define INIT_VAL ACCUMULATOR_VAL_MIN
+#elif AVG_POOLING
+    #define INIT_VAL ACCUMULATOR_VAL_ZERO
 #else
-#error
+    #error
 #endif
 
-inline VECTOR_TYPE FUNC(apply_pooling)(VECTOR_TYPE tmp, VECTOR_TYPE in)
+inline ACCUMULATOR_VEC8 FUNC(apply_pooling)(ACCUMULATOR_VEC8 tmp, ACCUMULATOR_VEC8 in)
 {
 #if   defined MAX_POOLING
-    return max(tmp, in);
+    return ACCUMULATOR_MAX_FUNC(tmp, in);
 #elif defined AVG_POOLING
     return tmp + in;
 #endif
 }
 
-KERNEL(pooling_gpu_byxf_opt)(const __global UNIT_TYPE* input, __global UNIT_TYPE* output)
+KERNEL(pooling_gpu_byxf_opt)(
+    const __global INPUT0_TYPE* input,
+    __global OUTPUT_TYPE* output
+#if HAS_FUSED_OPS_DECLS
+    , FUSED_OPS_DECLS
+#endif
+)
 {
-    VECTOR_TYPE out;
     const uint x    = (uint)get_global_id(0);
     const uint y    = (uint)get_global_id(1);
     const uint bf   = (uint)get_global_id(2);
     const uint f    = bf / INPUT0_BATCH_NUM * FEATURE_PER_ITEM;
     const uint b    = bf % INPUT0_BATCH_NUM;
-    
-    VECTOR_TYPE feature_block;
-    
+
+    INPUT0_VEC8 feature_block;
+    ACCUMULATOR_VEC8 result;
+
     if ((x >= OUTPUT_SIZE_X) || (y >= OUTPUT_SIZE_Y))
         return;
 
@@ -62,7 +72,7 @@ KERNEL(pooling_gpu_byxf_opt)(const __global UNIT_TYPE* input, __global UNIT_TYPE
 #endif
     int input_idx = b*FEATURE_BLOCK_NUM*INPUT0_SIZE_X*INPUT0_SIZE_Y + FEATURE_BLOCK_NUM*INPUT0_SIZE_X*offset_y + FEATURE_BLOCK_NUM*offset_x + bf / INPUT0_BATCH_NUM;
 
-    out = UNIT_INIT_VAL;
+    result = INIT_VAL;
 
     __attribute__((opencl_unroll_hint))
     for(uint j = 0; j < POOL_SIZE_Y; j++)
@@ -79,12 +89,14 @@ KERNEL(pooling_gpu_byxf_opt)(const __global UNIT_TYPE* input, __global UNIT_TYPE
                 if (!zero)
                 {
                     feature_block = vload8(input_idx+FEATURE_BLOCK_NUM*i, input);
-                    out = FUNC_CALL(apply_pooling)(out, feature_block);
+                    result = FUNC_CALL(apply_pooling)(result, TO_ACCUMULATOR_VEC8(feature_block));
                 }
             }
         }
         input_idx += FEATURE_BLOCK_NUM*INPUT0_SIZE_X;
     }
+
+   OUTPUT_TYPE final_result;
 
     uint output_pos = GET_DATA_INDEX(OUTPUT, b, f, y, x);
     __attribute__((opencl_unroll_hint))
@@ -93,9 +105,23 @@ KERNEL(pooling_gpu_byxf_opt)(const __global UNIT_TYPE* input, __global UNIT_TYPE
         if(f+i < INPUT0_FEATURE_NUM)
         {
 #if defined MAX_POOLING
-            output[output_pos+i] = ACTIVATION(out[i], ACTIVATION_PARAMS);
+            ACTIVATION_TYPE pool_result = TO_ACTIVATION_TYPE(result[i]);
+        #if HAS_FUSED_OPS
+            FUSED_OPS;
+            final_result = FUSED_OPS_RESULT;
+        #else
+            final_result = TO_OUTPUT_TYPE(ACTIVATION(pool_result, ACTIVATION_PARAMS));
+        #endif
+            output[output_pos+i] = final_result;
 #elif defined AVG_POOLING
-            output[output_pos+i] = ACTIVATION(out[i]/(UNIT_TYPE)(POOL_SIZE_X*POOL_SIZE_Y), ACTIVATION_PARAMS);
+            ACTIVATION_TYPE pool_result = TO_ACTIVATION_TYPE(result[i]/(OUTPUT_TYPE)(POOL_SIZE_X*POOL_SIZE_Y));
+        #if HAS_FUSED_OPS
+            FUSED_OPS;
+            final_result = FUSED_OPS_RESULT;
+        #else
+            final_result = TO_OUTPUT_TYPE(ACTIVATION(pool_result, ACTIVATION_PARAMS));
+        #endif
+           output[output_pos+i] = final_result;
 #endif
         }
     }
@@ -103,5 +129,9 @@ KERNEL(pooling_gpu_byxf_opt)(const __global UNIT_TYPE* input, __global UNIT_TYPE
 
 #undef FEATURE_BLOCK_NUM
 #undef FEATURE_PER_ITEM
-#undef UNIT_INIT_VAL
-#undef VECTOR_TYPE
+
+#undef INIT_VAL
+#undef INPUT0_VEC8
+
+#undef ACCUMULATOR_VEC8
+#undef TO_ACCUMULATOR_VEC8

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/pooling_gpu_fs_bs_yx_bsv4_fsv32.cl
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/pooling_gpu_fs_bs_yx_bsv4_fsv32.cl
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,19 +15,26 @@
 
 #include "include/include_all.cl"
 
+#define ACTIVATION_VEC4 MAKE_VECTOR_TYPE(ACTIVATION_TYPE, 4)
+#define TO_ACTIVATION_VEC4 CAT(convert_, ACTIVATION_VEC4)
+
+#define ACCUMULATOR_VEC4 MAKE_VECTOR_TYPE(ACCUMULATOR_TYPE, 4)
+
+#define OUTPUT_VEC4 MAKE_VECTOR_TYPE(OUTPUT_TYPE,4)
+#define TO_OUTPUT_VEC4 CAT(convert_, OUTPUT_VEC4)
+
 #if MAX_POOLING
-    #define INIT_VAL CHAR_MIN
+    #define INIT_VAL ACCUMULATOR_VAL_MIN
 #elif AVG_POOLING
-    #define INIT_VAL 0
+    #define INIT_VAL ACCUMULATOR_VAL_ZERO
 #else
-#error
+    #error
 #endif
 
-
-inline int FUNC(apply_pooling)(int tmp, int in)
+inline ACCUMULATOR_TYPE FUNC(apply_pooling)(ACCUMULATOR_TYPE tmp, ACCUMULATOR_TYPE in)
 {
 #if MAX_POOLING
-    return max(tmp, in);
+    return ACCUMULATOR_MAX_FUNC(tmp, in);
 #elif AVG_POOLING
     return tmp + in;
 #endif
@@ -35,8 +42,12 @@ inline int FUNC(apply_pooling)(int tmp, int in)
 
 __attribute__((intel_reqd_sub_group_size(8)))
 KERNEL(pooling_gpu_fs_bs_yx_bsv4_fsv32)(
-    const __global UNIT_TYPE* input,
-    __global UNIT_TYPE* output)
+    const __global INPUT0_TYPE* input,
+    __global OUTPUT_TYPE* output
+#if HAS_FUSED_OPS_DECLS
+    , FUSED_OPS_DECLS
+#endif
+)
 {
     const uint x    = (uint)get_global_id(0);
     const uint y    = (uint)get_global_id(1);
@@ -44,8 +55,7 @@ KERNEL(pooling_gpu_fs_bs_yx_bsv4_fsv32)(
 	// we process 4 features per workitem that's why we need to divide it
     const uint aligned32_features = ((INPUT0_FEATURE_NUM + 31) / 32) * 32;
     const uint f    = ((uint)get_global_id(2) * 4) % aligned32_features;
-    const uint b = 4 * (((uint)get_global_id(2) * 4) / aligned32_features);
-    
+    const uint b    = 4 * (((uint)get_global_id(2) * 4) / aligned32_features);
     if (x >= OUTPUT_SIZE_X)
     {
         return;
@@ -53,8 +63,7 @@ KERNEL(pooling_gpu_fs_bs_yx_bsv4_fsv32)(
 
     const int offset_x = (int)x*STRIDE_SIZE_X - PADDING_SIZE_X;
     const int offset_y = (int)y*STRIDE_SIZE_Y - PADDING_SIZE_Y;
-    
-    int4 result[4] = { INIT_VAL };
+    ACCUMULATOR_VEC4 result[4] = { INIT_VAL };
 
 #ifdef CHECK_BOUNDRY
     if (offset_x + POOL_SIZE_X < 0 || offset_x >= INPUT0_SIZE_X ||
@@ -86,13 +95,12 @@ KERNEL(pooling_gpu_fs_bs_yx_bsv4_fsv32)(
                     for(uint b = 0; b < 4; b++)
                     {
                         char4 input_data = as_char4(int_data[b]);
-                        result[b][0] = FUNC_CALL(apply_pooling)(result[b][0], (int)input_data[0]);
-                        result[b][1] = FUNC_CALL(apply_pooling)(result[b][1], (int)input_data[1]);
-                        result[b][2] = FUNC_CALL(apply_pooling)(result[b][2], (int)input_data[2]);
-                        result[b][3] = FUNC_CALL(apply_pooling)(result[b][3], (int)input_data[3]);
-
+                        result[b][0] = FUNC_CALL(apply_pooling)(result[b][0], TO_ACCUMULATOR_TYPE(input_data[0]));
+                        result[b][1] = FUNC_CALL(apply_pooling)(result[b][1], TO_ACCUMULATOR_TYPE(input_data[1]));
+                        result[b][2] = FUNC_CALL(apply_pooling)(result[b][2], TO_ACCUMULATOR_TYPE(input_data[2]));
+                        result[b][3] = FUNC_CALL(apply_pooling)(result[b][3], TO_ACCUMULATOR_TYPE(input_data[3]));
                     }
-                    
+
 #ifdef DYNAMIC_KERNEL_DIVIDER
                     num_elementes++;
 #endif
@@ -116,54 +124,104 @@ KERNEL(pooling_gpu_fs_bs_yx_bsv4_fsv32)(
             for(uint b = 0; b < 4; b++)
             {
                 char4 input_data = as_char4(int_data[b]);
-                result[b][0] = FUNC_CALL(apply_pooling)(result[b][0], (int)input_data[0]);
-                result[b][1] = FUNC_CALL(apply_pooling)(result[b][1], (int)input_data[1]);
-                result[b][2] = FUNC_CALL(apply_pooling)(result[b][2], (int)input_data[2]);
-                result[b][3] = FUNC_CALL(apply_pooling)(result[b][3], (int)input_data[3]);
+                result[b][0] = FUNC_CALL(apply_pooling)(result[b][0], TO_ACCUMULATOR_TYPE(input_data[0]));
+                result[b][1] = FUNC_CALL(apply_pooling)(result[b][1], TO_ACCUMULATOR_TYPE(input_data[1]));
+                result[b][2] = FUNC_CALL(apply_pooling)(result[b][2], TO_ACCUMULATOR_TYPE(input_data[2]));
+                result[b][3] = FUNC_CALL(apply_pooling)(result[b][3], TO_ACCUMULATOR_TYPE(input_data[3]));
             }
 
             input_idx += IN_X_PITCH;
         }
         input_idx += (IN_Y_PITCH - POOL_SIZE_X*IN_X_PITCH);
     }
-    
+
 #if defined(DYNAMIC_KERNEL_DIVIDER) || defined(DYNAMIC_WITH_PADDING_KERNEL_DIVIDER)
     const uint num_elementes = POOL_SIZE_X*POOL_SIZE_Y;
 #endif
 #endif
 
 #if defined AVG_POOLING
-    #if defined(DYNAMIC_KERNEL_DIVIDER) || defined(DYNAMIC_WITH_PADDING_KERNEL_DIVIDER)
-        for(uint b = 0; b < 4; b++)
-        {
-            for(uint i = 0; i < 4; i++)
+    #if ENABLE_ROUND
+        #if defined(DYNAMIC_KERNEL_DIVIDER) || defined(DYNAMIC_WITH_PADDING_KERNEL_DIVIDER)
+            for(uint b = 0; b < 4; b++)
             {
-                result[b][i] = convert_int(round(((float)result[b][i] / max(num_elementes, (uint)1)));
+                for(uint i = 0; i < 4; i++)
+                {
+                    result[b][i] = TO_ACCUMULATOR_TYPE(round(((float)result[b][i] / max(num_elementes, (uint)1))));
+                }
             }
-        }
+        #else
+            for(uint b = 0; b < 4; b++)
+            {
+                for(uint i = 0; i < 4; i++)
+                {
+                    result[b][i] = TO_ACCUMULATOR_TYPE(round((float)result[b][i] / (int)(POOL_SIZE_Y * POOL_SIZE_X)));
+                }
+            }
+        #endif
     #else
-        for(uint b = 0; b < 4; b++)
-        {
-            for(uint i = 0; i < 4; i++)
+        #if defined(DYNAMIC_KERNEL_DIVIDER) || defined(DYNAMIC_WITH_PADDING_KERNEL_DIVIDER)
+            for(uint b = 0; b < 4; b++)
             {
-                result[b][i] = convert_int(round((float)result[b][i] / (int)(POOL_SIZE_Y * POOL_SIZE_X)));
+                for(uint i = 0; i < 4; i++)
+                {
+                    result[b][i] = TO_ACCUMULATOR_TYPE(((float)result[b][i] / max(num_elementes, (uint)1)));
+                }
             }
-        }
-    #endif
-#endif
+        #else
+            for(uint b = 0; b < 4; b++)
+            {
+                for(uint i = 0; i < 4; i++)
+                {
+                    result[b][i] = TO_ACCUMULATOR_TYPE((float)result[b][i] / (int)(POOL_SIZE_Y * POOL_SIZE_X));
+                }
+            }
+        #endif
+    #endif  // ENABLE_ROUND
+#endif  // AVG_POOLING
 
-    int4 char_result;
-    for(uint b = 0; b < 4; b++)
+#if OUTPUT_TYPE_SIZE == 1
+    int4 final_result;
+
+    for(uint bi = 0; bi < 4; bi++)
     {
-        char4 char_res = as_char4(char_result[b]);
-        for(uint op = 0; op < 4; op++)
-        {
-            char_res[op] = ACTIVATION(convert_char(result[b][op]), ACTIVATION_PARAMS);
-        }
-        char_result[b] = as_int(char_res);
+        #if HAS_FUSED_OPS
+            ACTIVATION_VEC4 char_result = TO_ACTIVATION_VEC4(convert_char4(result[bi]));
+            FUSED_OPS;
+            final_result[bi] = as_int(FUSED_OPS_RESULT);
+        #else
+            char4 char_result = ACTIVATION(convert_char4(result[bi]), ACTIVATION_PARAMS);
+            final_result[bi] = as_int(char_result);
+        #endif
     }
     const uint output_pos = GET_DATA_FS_BS_YX_BSV4_FSV32_INDEX(OUTPUT, b, f, y, x);
-    intel_sub_group_block_write4((__global uint*)(output + output_pos), as_uint4(char_result));																						
+    intel_sub_group_block_write4((__global uint*)(output + output_pos), as_uint4(final_result));
+
+#elif OUTPUT_TYPE_SIZE == 2 || OUTPUT_TYPE_SIZE == 4
+    OUTPUT_VEC4 final_result;
+
+    for(uint bi = 0; bi < 4; bi++)
+    {
+    #if HAS_FUSED_OPS
+        ACTIVATION_VEC4 char_result = TO_ACTIVATION_VEC4(TO_OUTPUT_VEC4(result[bi]));
+        FUSED_OPS;
+        final_result = FUSED_OPS_RESULT;
+    #else
+        char4 char_result = ACTIVATION(TO_OUTPUT_VEC4(result[bi]), ACTIVATION_PARAMS);
+        final_result = TO_OUTPUT_VEC4(char_result);
+    #endif
+        const uint output_pos = GET_DATA_FS_BS_YX_BSV4_FSV32_INDEX(OUTPUT, b + bi, f, y, x);
+        vstore4(final_result, 0, output + output_pos);
+    }
+#endif
 }
 
 #undef INIT_VAL
+#undef ACCUMULATOR_VEC4
+#undef ACCUMULATOR_VEC4
+
+#undef ACTIVATION_VEC4
+#undef TO_ACTIVATION_VEC4
+
+#undef OUTPUT_VEC4
+#undef TO_OUTPUT_VEC4

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/pooling_gpu_ref.cl
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/pooling_gpu_ref.cl
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 Intel Corporation
+// Copyright (c) 2016-2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,38 +16,42 @@
 #include "include/include_all.cl"
 
 #if MAX_POOLING || MAX_WITH_ARGMAX_POOLING
-    #define UNIT_INIT_VAL UNIT_VAL_MIN
+    #define INIT_VAL ACCUMULATOR_VAL_MIN
 #elif AVG_POOLING
-    #define UNIT_INIT_VAL UNIT_VAL_ZERO
+    #define INIT_VAL ACCUMULATOR_VAL_ZERO
 #else
-#error
+    #error
 #endif
-
 
 inline ACCUMULATOR_TYPE FUNC(apply_pooling)(ACCUMULATOR_TYPE tmp, ACCUMULATOR_TYPE in)
 {
 #if MAX_POOLING || MAX_WITH_ARGMAX_POOLING
-    return max(tmp, in);
+    return ACCUMULATOR_MAX_FUNC(tmp, in);
 #elif AVG_POOLING
     return tmp + in;
 #endif
 }
 
-KERNEL(pooling_gpu)(const __global UNIT_TYPE* input, __global UNIT_TYPE* output
+KERNEL(pooling_gpu)(
+    const __global INPUT0_TYPE* input,
+    __global OUTPUT_TYPE* output
 #if MAX_WITH_ARGMAX_POOLING
 , __global float* arg_max
 #endif
+#if HAS_FUSED_OPS_DECLS
+    , FUSED_OPS_DECLS
+#endif
 )
 {
-#if OUTPUT_LAYOUT_BFYX  || OUTPUT_LAYOUT_BYXF || OUTPUT_LAYOUT_BFZYX || OUTPUT_LAYOUT_B_FS_ZYX_FSV16 || OUTPUT_LAYOUT_BS_FS_ZYX_BSV16_FSV16 || \
-    OUTPUT_LAYOUT_B_FS_YX_FSV32 || OUTPUT_LAYOUT_B_FS_ZYX_FSV32
+#if OUTPUT_LAYOUT_BFYX  || OUTPUT_LAYOUT_BYXF || OUTPUT_LAYOUT_BFZYX ||\
+    OUTPUT_LAYOUT_B_FS_ZYX_FSV16 || OUTPUT_LAYOUT_BS_FS_ZYX_BSV16_FSV16
     const uint x    = (uint)get_global_id(0);
-#if  OUTPUT_DIMS < 5
-    const uint y    = (uint)get_global_id(1);
-    const uint z = 0;
+#if OUTPUT_DIMS == 5
+    const uint y   = (uint)get_global_id(1) % OUTPUT_SIZE_Y;
+    const uint z   = (uint)get_global_id(1) / OUTPUT_SIZE_Y;
 #else
-    const uint y = (uint)get_global_id(1) % OUTPUT_SIZE_Y;
-    const uint z = (uint)get_global_id(1) / OUTPUT_SIZE_Y;
+    const uint y   = (uint)get_global_id(1);
+    const uint z   = 0;
 #endif
     const uint bf   = (uint)get_global_id(2);
     const uint f    = bf % INPUT0_FEATURE_NUM;
@@ -57,32 +61,51 @@ KERNEL(pooling_gpu)(const __global UNIT_TYPE* input, __global UNIT_TYPE* output
     {
         return;
     }
+#elif OUTPUT_LAYOUT_B_FS_YX_FSV32 || OUTPUT_LAYOUT_B_FS_ZYX_FSV32
+    const uint fsv = get_global_id(0);
+    const uint zyx = get_global_id(1);
+    const uint fsb = get_global_id(2);
+
+    const uint x = zyx % OUTPUT_SIZE_X;
+#if OUTPUT_DIMS == 5
+    const uint y = zyx / OUTPUT_SIZE_X % OUTPUT_SIZE_Y;
+    const uint z = zyx / OUTPUT_SIZE_X / OUTPUT_SIZE_Y;
+#else
+    const uint y = zyx / OUTPUT_SIZE_X;
+    const uint z = 0;
+#endif
+    const uint fs = fsb % ((OUTPUT_FEATURE_NUM + 32 - 1) / 32);
+    const uint b = fsb / ((OUTPUT_FEATURE_NUM + 32 - 1) / 32);
+    const uint f = fs * 32 + fsv;
+
+    if (f >= OUTPUT_FEATURE_NUM) {
+        return;
+    }
 #elif OUTPUT_LAYOUT_YXFB
     const uint x    = (uint)get_global_id(1);
     const uint y    = (uint)get_global_id(2);
-    const uint z    = 0;
     const uint bf   = (uint)get_global_id(0);
     const uint f    = bf / INPUT0_BATCH_NUM;
     const uint b    = bf % INPUT0_BATCH_NUM;
+    const uint z    = 0;
+#else
+    #error "pooling_gpu_ref: unsupported layout"
 #endif
 
     const int offset_x = (int)x*STRIDE_SIZE_X - PADDING_SIZE_X;
     const int offset_y = (int)y*STRIDE_SIZE_Y - PADDING_SIZE_Y;
     const int offset_z = (int)z*STRIDE_SIZE_Z - PADDING_SIZE_Z;
 
-    ACCUMULATOR_TYPE result = UNIT_INIT_VAL;
+    ACCUMULATOR_TYPE result = INIT_VAL;
 
 #if MAX_WITH_ARGMAX_POOLING
     uint arg_max_idx = 0;
 #endif
 
 #ifdef CHECK_BOUNDRY
-    bool out_of_boundry = offset_x + POOL_SIZE_X < 0 || offset_x >= INPUT0_SIZE_X ||
-        offset_y + POOL_SIZE_Y < 0 || offset_y >= INPUT0_SIZE_Y;
-    #if  INPUT0_SIZE_Z != 1
-        out_of_boundry = out_of_boundry || offset_z + POOL_SIZE_Z < 0 || offset_z >= INPUT0_SIZE_Z;
-    #endif
-    if (out_of_boundry)
+    if (offset_x + POOL_SIZE_X < 0 || offset_x >= INPUT0_SIZE_X ||
+        offset_y + POOL_SIZE_Y < 0 || offset_y >= INPUT0_SIZE_Y ||
+        offset_z + POOL_SIZE_Z < 0 || offset_z >= INPUT0_SIZE_Z)
     {
         return;
     }
@@ -91,122 +114,140 @@ KERNEL(pooling_gpu)(const __global UNIT_TYPE* input, __global UNIT_TYPE* output
     uint num_elementes = 0;
 #endif
 
-    const uint batch_and_feature_offset = GET_DATA_INDEX(INPUT0, b, f, 0, 0);
-#if  OUTPUT_DIMS == 5  // 3D
-    for(uint k = 0; k < POOL_SIZE_Z; k++)
+#if OUTPUT_DIMS == 5
+    const uint batch_and_feature_offset = INPUT0_GET_INDEX(b, f, 0, 0, 0);
+#else
+    const uint batch_and_feature_offset = INPUT0_GET_INDEX(b, f, 0, 0);
+#endif
+
+#if OUTPUT_DIMS == 5
+    for(uint l = 0; l < POOL_SIZE_Z; l++)
     {
-        int input_offset_z = offset_z + k;
+        int input_offset_z = offset_z + l;
         bool zero_z = input_offset_z >= INPUT0_SIZE_Z || input_offset_z < 0;
-        if(!zero_z)
+        if (!zero_z)
         {
 #endif
-    for(uint j = 0; j < POOL_SIZE_Y; j++)
+            for(uint j = 0; j < POOL_SIZE_Y; j++)
+            {
+                int input_offset_y = offset_y + j;
+                bool zero_y = input_offset_y >= INPUT0_SIZE_Y || input_offset_y < 0;
+                if(!zero_y)
+                {
+                    for(uint i = 0; i < POOL_SIZE_X; i++)
+                    {
+                        int input_offset_x = offset_x + i;
+                        bool zero = input_offset_x >= INPUT0_SIZE_X || input_offset_x < 0;
+                        if(!zero)
+                        {
+#if OUTPUT_DIMS == 5
+    #if !INPUT0_SIMPLE
+                            const uint input_idx = INPUT0_GET_INDEX(b, f, input_offset_z, input_offset_y, input_offset_x);
+    #else
+                            const uint input_idx = batch_and_feature_offset + input_offset_z*INPUT0_Z_PITCH + input_offset_y*INPUT0_Y_PITCH + input_offset_x*INPUT0_X_PITCH;
+    #endif
+#else
+    #if !INPUT0_SIMPLE
+                            const uint input_idx = INPUT0_GET_INDEX(b, f, input_offset_y, input_offset_x);
+    #else
+                            const uint input_idx = batch_and_feature_offset + input_offset_y*INPUT0_Y_PITCH + input_offset_x*INPUT0_X_PITCH;
+    #endif
+#endif
+
+#if MAX_WITH_ARGMAX_POOLING
+                            if(input[input_idx] > result)
+                            {
+#if  OUTPUT_DIMS < 5
+                                const uint input_idx_bfyx_no_padding = input_offset_x + INPUT0_SIZE_X * (input_offset_y + INPUT0_SIZE_Y * (f + INPUT0_FEATURE_NUM * b));
+#else
+                                const uint input_idx_bfyx_no_padding = input_offset_x + INPUT0_SIZE_X * (input_offset_y + INPUT0_SIZE_Y *
+                                                               (input_offset_z + INPUT0_SIZE_Z * (f + INPUT0_FEATURE_NUM * b)));
+#endif
+                                arg_max_idx = input_idx_bfyx_no_padding;
+                            }
+#endif
+                            result = FUNC_CALL(apply_pooling)(result, TO_ACCUMULATOR_TYPE(input[input_idx]));
+
+#ifdef DYNAMIC_KERNEL_DIVIDER
+                            num_elementes++;
+#endif
+                        }
+                    }
+                }
+            }
+#if OUTPUT_DIMS == 5
+        }
+    }
+#endif
+
+#ifdef DYNAMIC_WITH_PADDING_KERNEL_DIVIDER
+    const int hend = min(offset_y + POOL_SIZE_Y, INPUT0_SIZE_Y + PADDING_SIZE_Y);
+    const int wend = min(offset_x + POOL_SIZE_X, INPUT0_SIZE_X + PADDING_SIZE_X);
+#if OUTPUT_DIMS == 5
+    const int zend = min(offset_z + POOL_SIZE_Z, INPUT0_SIZE_Z + PADDING_SIZE_Z);
+    const uint num_elementes = (hend - offset_y) * (wend - offset_x) * (zend - offset_z);
+#else
+    const uint num_elementes = (hend - offset_y) * (wend - offset_x);
+#endif
+
+#endif  // DYNAMIC_WITH_PADDING_KERNEL_DIVIDER
+
+#else  // CHECK_BOUNDRY
+
+#if  OUTPUT_DIMS == 5  // 3D
+    uint input_idx = INPUT0_GET_INDEX(b, f, offset_z, offset_y, offset_x);
+#else
+    uint input_idx = INPUT0_GET_INDEX(b, f, offset_y, offset_x);
+#endif
+
+#if MAX_WITH_ARGMAX_POOLING
+    #if  OUTPUT_DIMS < 5
+        uint input_idx_bfyx_no_padding = offset_x + INPUT0_SIZE_X * (offset_y + INPUT0_SIZE_Y * (f + INPUT0_FEATURE_NUM * b));
+    #else
+        uint input_idx_bfyx_no_padding = offset_x + INPUT0_SIZE_X * (offset_y + INPUT0_SIZE_Y * (offset_z + INPUT0_SIZE_Z *(f + INPUT0_FEATURE_NUM * b)));
+    #endif
+#endif
+
+#if OUTPUT_DIMS == 5
+    for(uint l = 0; l < POOL_SIZE_Z; l++)
     {
-        int input_offset_y = offset_y + j;
-        bool zero_y = input_offset_y >= INPUT0_SIZE_Y || input_offset_y < 0;
-        if(!zero_y)
+#endif
+        for(uint j = 0; j < POOL_SIZE_Y; j++)
         {
             for(uint i = 0; i < POOL_SIZE_X; i++)
             {
-                int input_offset_x = offset_x + i;
-                bool zero = input_offset_x >= INPUT0_SIZE_X || input_offset_x < 0;
-                if(!zero)
-                {
-#if  OUTPUT_DIMS < 5
-                    const uint input_idx = batch_and_feature_offset + input_offset_y*INPUT0_Y_PITCH + input_offset_x*INPUT0_X_PITCH;
-#else
-  #if OUTPUT_LAYOUT_B_FS_ZYX_FSV16
-                    const uint input_idx = GET_DATA_B_FS_ZYX_FSV16_INDEX(INPUT0, b, f, input_offset_z, input_offset_y, input_offset_x);
-  #elif OUTPUT_LAYOUT_BS_FS_ZYX_BSV16_FSV16
-                    const uint input_idx = GET_DATA_BS_FS_ZYX_BSV16_FSV16_INDEX(INPUT0, b, f, input_offset_z, input_offset_y, input_offset_x);
-  #else
-                    const uint input_idx = batch_and_feature_offset + input_offset_z*INPUT0_Z_PITCH + input_offset_y*INPUT0_Y_PITCH + input_offset_x*INPUT0_X_PITCH;
-  #endif
-#endif
-
-#if MAX_WITH_ARGMAX_POOLING
-                    if(input[input_idx] > result)
-                    {
-#if  OUTPUT_DIMS < 5
-                        const uint input_idx_bfyx_no_padding = input_offset_x + INPUT0_SIZE_X * (input_offset_y + INPUT0_SIZE_Y * (f + INPUT0_FEATURE_NUM * b));
-#else
-                        const uint input_idx_bfyx_no_padding = input_offset_x + INPUT0_SIZE_X * (input_offset_y + INPUT0_SIZE_Y *
-                                                               (input_offset_z + INPUT0_SIZE_Z * (f + INPUT0_FEATURE_NUM * b)));
-#endif
-                        arg_max_idx = input_idx_bfyx_no_padding;
-                    }
-#endif
-                    result = FUNC_CALL(apply_pooling)(result, input[input_idx]);
-
-#ifdef DYNAMIC_KERNEL_DIVIDER
-                    num_elementes++;
-#endif
-                }
-            }
-        }
-    }
-#if  OUTPUT_DIMS == 5 // 3D
-        }
-    }
-#endif
-#ifdef DYNAMIC_WITH_PADDING_KERNEL_DIVIDER
-#if  INPUT0_SIZE_Z != 1
-    const int dend = min(offset_z + POOL_SIZE_Z, INPUT0_SIZE_Z + PADDING_SIZE_Z);
-#endif
-    const int hend = min(offset_y + POOL_SIZE_Y, INPUT0_SIZE_Y + PADDING_SIZE_Y);
-    const int wend = min(offset_x + POOL_SIZE_X, INPUT0_SIZE_X + PADDING_SIZE_X);
-#if  INPUT0_SIZE_Z == 1
-    const uint num_elementes = (hend - offset_y) * (wend - offset_x);
-#else
-    const uint num_elementes = (dend - offset_z) * (hend - offset_y) * (wend - offset_x);
-#endif
-#endif
-#else
-#if  OUTPUT_DIMS == 5  // 3D
-    uint input_idx = GET_DATA_INDEX_5D(INPUT0, b, f, offset_z, offset_y, offset_x);
-#else
-    uint input_idx = GET_DATA_INDEX(INPUT0, b, f, offset_y, offset_x);
-#endif
-
-#if MAX_WITH_ARGMAX_POOLING
-#if  OUTPUT_DIMS < 5
-    uint input_idx_bfyx_no_padding = offset_x + INPUT0_SIZE_X * (offset_y + INPUT0_SIZE_Y * (f + INPUT0_FEATURE_NUM * b));
-#else
-    uint input_idx_bfyx_no_padding = offset_x + INPUT0_SIZE_X * (offset_y + INPUT0_SIZE_Y * (offset_z + INPUT0_SIZE_Z *(f + INPUT0_FEATURE_NUM * b)));
-#endif
-#endif
-
-#if  OUTPUT_DIMS == 5  // 3D
-    for(uint k = 0; k < POOL_SIZE_Z; k++)
-    {
-#endif
-    for(uint j = 0; j < POOL_SIZE_Y; j++)
-    {
-        for(uint i = 0; i < POOL_SIZE_X; i++)
-        {
-
 #if MAX_WITH_ARGMAX_POOLING
             if(input[input_idx] > result)
                 arg_max_idx = input_idx_bfyx_no_padding;
 #endif
 
-#if INPUT0_LAYOUT_B_FS_ZYX_FSV16
-            uint input1_idx = INPUT0_GET_INDEX(b, f, offset_z+k, offset_y+j, offset_x+i);
-            result = FUNC_CALL(apply_pooling)(result, input[input1_idx]);
+#if OUTPUT_DIMS == 5
+    #if !INPUT0_SIMPLE
+                uint input_idx = INPUT0_GET_INDEX(b, f, offset_z + l, offset_y + j, offset_x + i);
+                result = FUNC_CALL(apply_pooling)(result, TO_ACCUMULATOR_TYPE(input[input_idx]));
+    #else
+                result = FUNC_CALL(apply_pooling)(result, TO_ACCUMULATOR_TYPE(input[input_idx]));
+                input_idx += INPUT0_X_PITCH;
+    #endif
 #else
-            result = FUNC_CALL(apply_pooling)(result, input[input_idx]);
+    #if !INPUT0_SIMPLE
+                uint input_idx = INPUT0_GET_INDEX(b, f, offset_y + j, offset_x + i);
+                result = FUNC_CALL(apply_pooling)(result, TO_ACCUMULATOR_TYPE(input[input_idx]));
+    #else
+                result = FUNC_CALL(apply_pooling)(result, TO_ACCUMULATOR_TYPE(input[input_idx]));
+                input_idx += INPUT0_X_PITCH;
+    #endif
 #endif
 
-            input_idx += INPUT0_X_PITCH;
 #if MAX_WITH_ARGMAX_POOLING
-            input_idx_bfyx_no_padding++;
+                input_idx_bfyx_no_padding++;
+#endif
+            }
+            input_idx += (INPUT0_Y_PITCH - POOL_SIZE_X*INPUT0_X_PITCH);
+#if MAX_WITH_ARGMAX_POOLING
+            input_idx_bfyx_no_padding += (INPUT0_SIZE_X - POOL_SIZE_X);
 #endif
         }
-        input_idx += (INPUT0_Y_PITCH - POOL_SIZE_X*INPUT0_X_PITCH);
-#if MAX_WITH_ARGMAX_POOLING
-        input_idx_bfyx_no_padding += (INPUT0_SIZE_X - POOL_SIZE_X);
-#endif
-    }
 #if  OUTPUT_DIMS == 5  // 3D
         input_idx += (INPUT0_Z_PITCH - POOL_SIZE_Y*INPUT0_Y_PITCH);
 #if MAX_WITH_ARGMAX_POOLING
@@ -218,7 +259,8 @@ KERNEL(pooling_gpu)(const __global UNIT_TYPE* input, __global UNIT_TYPE* output
 #if defined(DYNAMIC_KERNEL_DIVIDER) || defined(DYNAMIC_WITH_PADDING_KERNEL_DIVIDER)
     const uint num_elementes = POOL_SIZE_X*POOL_SIZE_Y*POOL_SIZE_Z;
 #endif
-#endif
+
+#endif // CHECK_BOUNDRY
 
 #if defined AVG_POOLING
     #if defined(DYNAMIC_KERNEL_DIVIDER) || defined(DYNAMIC_WITH_PADDING_KERNEL_DIVIDER)
@@ -226,23 +268,30 @@ KERNEL(pooling_gpu)(const __global UNIT_TYPE* input, __global UNIT_TYPE* output
     #else
         result /= (ACCUMULATOR_TYPE)(POOL_SIZE_Z * POOL_SIZE_Y * POOL_SIZE_X);
     #endif
-#endif
+#endif  // defined AVG_POOLING
 
-#if OUTPUT_LAYOUT_B_FS_ZYX_FSV16
-    const uint output_pos = GET_DATA_B_FS_ZYX_FSV16_INDEX(OUTPUT, b, f, z, y, x);
-#elif OUTPUT_LAYOUT_BS_FS_ZYX_BSV16_FSV16
-    const uint output_pos = GET_DATA_BS_FS_ZYX_BSV16_FSV16_INDEX(OUTPUT, b, f, z, y, x);
+    OUTPUT_TYPE final_result;
+    ACTIVATION_TYPE pool_result = TO_ACTIVATION_TYPE(result);
+    
+#if HAS_FUSED_OPS
+      FUSED_OPS;
+      final_result = FUSED_OPS_RESULT;
+#else  // HAS_FUSED_OPS
+      final_result = TO_OUTPUT_TYPE(ACTIVATION(pool_result, ACTIVATION_PARAMS));
+#endif  // HAS_FUSED_OPS
+
+#if OUTPUT_DIMS == 5
+    const uint output_pos = OUTPUT_GET_INDEX(b, f, z, y, x);
 #else
-    const uint output_pos = GET_DATA_INDEX_5D(OUTPUT, b, f, z, y, x);
+    const uint output_pos = OUTPUT_GET_INDEX(b, f, y, x);
 #endif
-    output[output_pos] = ACTIVATION(TO_UNIT_TYPE(result), ACTIVATION_PARAMS);
+    output[output_pos] = final_result;
 
 #if MAX_WITH_ARGMAX_POOLING
     //INPUT1 macro stands for Argmax
     const uint arg_max_pos = GET_DATA_INDEX_5D(INPUT1, b, f, z, y, x);
     arg_max[arg_max_pos] = convert_float(arg_max_idx);
 #endif
-
 }
 
-#undef UNIT_INIT_VAL
+#undef INIT_VAL

--- a/inference-engine/thirdparty/clDNN/src/gpu/pooling_gpu.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/pooling_gpu.cpp
@@ -115,13 +115,13 @@ public:
         }
 
         // check if last pooling window goes outside of input size + padding. If so the avg pooling size will be
-        // adjusted to that.
+        // adjusted to that, to work properly this calculation must take pad_end into account.
         auto dynamic_mode = (((output_sizes.spatial[0] - 1) * stride.spatial[0]) + primitive->size.spatial[0]) >
-                                -2 * input_offset.spatial[0] + input_sizes.spatial[0] ||
+                                 (-input_offset.spatial[0] - primitive->pad_end.spatial[0]) + input_sizes.spatial[0] ||
                             (((output_sizes.spatial[1] - 1) * stride.spatial[1]) + primitive->size.spatial[1]) >
-                                -2 * input_offset.spatial[1] + input_sizes.spatial[1] ||
+                                 (-input_offset.spatial[1] - primitive->pad_end.spatial[1]) + input_sizes.spatial[1] ||
                             (((output_sizes.spatial[2] - 1) * stride.spatial[2]) + primitive->size.spatial[2]) >
-                                -2 * input_offset.spatial[2] + input_sizes.spatial[2];
+                                 (-input_offset.spatial[2] - primitive->pad_end.spatial[2]) + input_sizes.spatial[2];
 
         if (primitive->mode == pooling_mode::average && dynamic_mode)
             pp.divMode = kernel_selector::kernel_divider_mode::DYNAMIC_WITH_PADDING;
@@ -196,6 +196,7 @@ attach_pooling_gpu::attach_pooling_gpu() {
     implementation_map<pooling>::add(std::make_tuple(engine_types::ocl, data_types::f32, format::bs_fs_zyx_bsv16_fsv16), pooling_gpu::create);
     implementation_map<pooling>::add(std::make_tuple(engine_types::ocl, data_types::f16, format::bs_fs_zyx_bsv16_fsv16), pooling_gpu::create);
     implementation_map<pooling>::add(std::make_tuple(engine_types::ocl, data_types::i8, format::bs_fs_zyx_bsv16_fsv16), pooling_gpu::create);
+    implementation_map<pooling>::add(std::make_tuple(engine_types::ocl, data_types::u8, format::bs_fs_zyx_bsv16_fsv16), pooling_gpu::create);
     implementation_map<pooling>::add(std::make_tuple(engine_types::ocl, data_types::f32, format::bs_fs_yx_bsv16_fsv16), pooling_gpu::create);
     implementation_map<pooling>::add(std::make_tuple(engine_types::ocl, data_types::f16, format::bs_fs_yx_bsv16_fsv16), pooling_gpu::create);
     // MMAD
@@ -214,6 +215,9 @@ attach_pooling_gpu::attach_pooling_gpu() {
     implementation_map<pooling>::add(std::make_tuple(engine_types::ocl, data_types::f16, format::b_fs_zyx_fsv32), pooling_gpu::create);
     //
     implementation_map<pooling>::add(std::make_tuple(engine_types::ocl, data_types::f16, format::fs_b_yx_fsv32), pooling_gpu::create);
+    implementation_map<pooling>::add(std::make_tuple(engine_types::ocl, data_types::f32, format::fs_b_yx_fsv32), pooling_gpu::create);
+    implementation_map<pooling>::add(std::make_tuple(engine_types::ocl, data_types::u8, format::fs_b_yx_fsv32), pooling_gpu::create);
+    implementation_map<pooling>::add(std::make_tuple(engine_types::ocl, data_types::i8, format::fs_b_yx_fsv32), pooling_gpu::create);
 }
 
 }  // namespace detail

--- a/inference-engine/thirdparty/clDNN/src/gpu/quantize_gpu.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/quantize_gpu.cpp
@@ -104,6 +104,10 @@ attach_quantize_gpu::attach_quantize_gpu() {
     auto val_fw = quantize_gpu::create;
 
     implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::f16, format::fs_b_yx_fsv32), val_fw);
+    implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::f32, format::fs_b_yx_fsv32), val_fw);
+    implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::i8, format::fs_b_yx_fsv32), val_fw);
+    implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::u8, format::fs_b_yx_fsv32), val_fw);
+
     implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::f32, format::b_fs_yx_fsv16), val_fw);
     implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::f16, format::b_fs_yx_fsv16), val_fw);
     implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::i8, format::b_fs_yx_fsv16), val_fw);
@@ -134,11 +138,27 @@ attach_quantize_gpu::attach_quantize_gpu() {
     implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::u8, format::b_fs_zyx_fsv32), val_fw);
     implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::i8, format::b_fs_zyx_fsv32), val_fw);
 
+    implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::f32, format::bs_fs_yx_bsv16_fsv16), val_fw);
+    implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::f16, format::bs_fs_yx_bsv16_fsv16), val_fw);
+    implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::u8, format::bs_fs_yx_bsv16_fsv16), val_fw);
+    implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::i8, format::bs_fs_yx_bsv16_fsv16), val_fw);
+
+    implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::f32, format::bs_fs_zyx_bsv16_fsv16), val_fw);
+    implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::f16, format::bs_fs_zyx_bsv16_fsv16), val_fw);
+    implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::u8, format::bs_fs_zyx_bsv16_fsv16), val_fw);
+    implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::i8, format::bs_fs_zyx_bsv16_fsv16), val_fw);
+
     implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::f32, format::bfyx), val_fw);
     implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::f16, format::bfyx), val_fw);
     implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::i32, format::bfyx), val_fw);
     implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::u8, format::bfyx), val_fw);
     implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::i8, format::bfyx), val_fw);
+
+    implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::f32, format::byxf), val_fw);
+    implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::f16, format::byxf), val_fw);
+    implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::i32, format::byxf), val_fw);
+    implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::u8, format::byxf), val_fw);
+    implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::i8, format::byxf), val_fw);
 
     implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::f32, format::yxfb), val_fw);
     implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::f16, format::yxfb), val_fw);

--- a/inference-engine/thirdparty/clDNN/tests/test_cases/pooling_gpu_test.cpp
+++ b/inference-engine/thirdparty/clDNN/tests/test_cases/pooling_gpu_test.cpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2016-2019 Intel Corporation
+// Copyright (c) 2016-2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,6 +30,14 @@
 
 using namespace cldnn;
 using namespace tests;
+
+namespace cldnn {
+template <>
+struct type_to_data_type<FLOAT16> {
+    static const data_types value = data_types::f16;
+};
+}  // namespace cldnn
+
 
 template <typename InputT, pooling_mode Mode>
 struct pooling_mode_output {
@@ -71,7 +79,7 @@ template <typename InputT>
 struct pooling_accumulator<InputT, pooling_mode::max> {
     using output_t = typename pooling_mode_output<InputT, pooling_mode::max>::type;
 
-    pooling_accumulator() : _acc(std::numeric_limits<InputT>::min()) {}
+    pooling_accumulator() : _acc(std::numeric_limits<InputT>::lowest()) {}
 
     void accumulate(const InputT& val) {
         using std::max;
@@ -82,7 +90,7 @@ struct pooling_accumulator<InputT, pooling_mode::max> {
         return static_cast<output_t>(_acc);
     }
 
-    void reset() { _acc = std::numeric_limits<InputT>::min(); }
+    void reset() { _acc = std::numeric_limits<InputT>::lowest(); }
 
     InputT _acc;
 };
@@ -121,7 +129,7 @@ struct pooling_accumulator<InputT, pooling_mode::average> {
     }
 
     output_t get(size_t pool_x, size_t pool_y) {
-        return static_cast<output_t>(_acc / (pool_x * pool_y));
+        return static_cast<output_t>(_acc / static_cast<InputT>(pool_x * pool_y));
     }
 
     void reset() {
@@ -2351,6 +2359,7 @@ public:
         auto input_lay = layout(input_type(),
                                 input_format(),
                                 input_size);
+
         auto topo = topology(
             input_layout("input", input_lay),
             pooling("pool",
@@ -2397,11 +2406,22 @@ public:
         auto out_lay = out_mem.get_layout();
         auto out_ptr = out_mem.cldnn::memory::template pointer<output_t>();
 
+        std::string kernel;
+        for (auto i : net.get_primitives_info()) {
+            if (i.original_id == "pool") {
+                kernel = i.kernel_id;
+            }
+        }
+        std::cout << kernel << std::endl;
+        SCOPED_TRACE("\nkernel: " + kernel);
+
         ASSERT_EQ(out_lay.data_type, output_type());
         ASSERT_EQ(out_lay.size.batch[0], expected.size());
         ASSERT_EQ(out_lay.size.feature[0], expected[0].size());
         ASSERT_EQ(out_lay.size.spatial[1], expected[0][0].size());
         ASSERT_EQ(out_lay.size.spatial[0], expected[0][0][0].size());
+
+        bool compare_with_tolerance = input_type() == data_types::f16;
 
         for (size_t bi = 0; bi < batch_num(); ++bi)
             for (size_t fi = 0; fi < expected[0].size(); ++fi)
@@ -2411,9 +2431,14 @@ public:
                         size_t offset = out_lay.get_linear_offset(coords);
                         auto ref_val = static_cast<float>(expected[bi][fi][yi][xi]);
                         auto actual_val = static_cast<float>(out_ptr[offset]);
-
-                        EXPECT_TRUE(are_equal(ref_val, actual_val))
-                            << "at b= " << bi << ", f= " << fi << ", y= " << yi << ", x= " << xi;
+                        if (compare_with_tolerance) {
+                            auto tolerance = 1;
+                            ASSERT_NEAR(ref_val, actual_val, tolerance)
+                                << "at b= " << bi << ", f= " << fi << ", y= " << yi << ", x= " << xi;
+                        } else {
+                            EXPECT_TRUE(are_equal(ref_val, actual_val))
+                                << "at b= " << bi << ", f= " << fi << ", y= " << yi << ", x= " << xi;
+                        }
                     }
 
     }
@@ -2560,16 +2585,19 @@ TEST_P(pooling_random_test, avg_u8) {
 INSTANTIATE_TEST_CASE_P(
     smoke_low_precision,
     pooling_random_test,
-    testing::Combine(
-        testing::Values(1, 2),
-        testing::Values(3, 32),
-        testing::Values(std::tuple<size_t, size_t>(3, 3), std::tuple<size_t, size_t>(8, 8)),
-        testing::Values(std::tuple<size_t, size_t>(1, 1), std::tuple<size_t, size_t>(3, 3)),
-        testing::Values(std::tuple<int, int>(1, 1)),
-        testing::Values(std::tuple<int, int>(0, 0)),
-        testing::Values(format::bfyx, format::b_fs_yx_fsv4, format::byxf_af32, format::b_fs_yx_fsv32)
-    ),
-    testing::internal::DefaultParamName<pooling_random_test_params>);
+    testing::Combine(testing::Values(1, 2),
+                     testing::Values(3, 8),
+                     testing::Values(std::tuple<size_t, size_t>(12, 12), std::tuple<size_t, size_t>(24, 24)),
+                     testing::Values(std::tuple<size_t, size_t>(4, 4), std::tuple<size_t, size_t>(2, 2)),
+                     testing::Values(std::tuple<int, int>(2, 2)),
+                     testing::Values(std::tuple<int, int>(0, 0)),
+                     testing::Values(format::yxfb,
+                                     format::bfyx,
+                                     format::byxf_af32,
+                                     format::b_fs_yx_fsv4,
+                                     format::b_fs_yx_fsv16,
+                                     format::b_fs_yx_fsv32)),
+                    testing::internal::DefaultParamName<pooling_random_test_params>);
 
 template <typename InputT, pooling_mode Mode>
 class pooling_scale_random_test_base : public pooling_random_test_base<InputT, Mode> {
@@ -2619,30 +2647,44 @@ private:
     VF<output_t> _shift;
 };
 
-using pooling_scale_random_test = pooling_random_test;
+using pooling_random_test_fp16_fp32 = pooling_random_test;
 
-TEST_P(pooling_scale_random_test, avg_i8) {
-    auto test_case = pooling_scale_random_test_base<int8_t, pooling_mode::average>();
+TEST_P(pooling_random_test_fp16_fp32, avg_fp16) {
+    auto test_case = pooling_random_test_base<FLOAT16, pooling_mode::average>();
     ASSERT_NO_FATAL_FAILURE(test_case.run_random(GetParam()));
 }
 
-TEST_P(pooling_scale_random_test, avg_u8) {
-    auto test_case = pooling_scale_random_test_base<uint8_t, pooling_mode::average>();
+TEST_P(pooling_random_test_fp16_fp32, max_fp16) {
+    auto test_case = pooling_random_test_base<FLOAT16, pooling_mode::max>();
+    ASSERT_NO_FATAL_FAILURE(test_case.run_random(GetParam()));
+}
+
+TEST_P(pooling_random_test_fp16_fp32, avg_fp32) {
+    auto test_case = pooling_random_test_base<float, pooling_mode::average>();
+    ASSERT_NO_FATAL_FAILURE(test_case.run_random(GetParam()));
+}
+
+TEST_P(pooling_random_test_fp16_fp32, max_fp32) {
+    auto test_case = pooling_random_test_base<float, pooling_mode::max>();
     ASSERT_NO_FATAL_FAILURE(test_case.run_random(GetParam()));
 }
 
 INSTANTIATE_TEST_CASE_P(
     smoke_low_precision,
-    pooling_scale_random_test,
-    testing::Combine(
-        testing::Values(1, 2),
-        testing::Values(3, 32),
-        testing::Values(std::tuple<size_t, size_t>(3, 3), std::tuple<size_t, size_t>(8, 8)),
-        testing::Values(std::tuple<size_t, size_t>(1, 1), std::tuple<size_t, size_t>(3, 3)),
-        testing::Values(std::tuple<int, int>(1, 1)),
-        testing::Values(std::tuple<int, int>(0, 0)),
-        testing::Values(format::bfyx, format::b_fs_yx_fsv4, format::byxf_af32, format::b_fs_yx_fsv32)
-    ),
+    pooling_random_test_fp16_fp32,
+    testing::Combine(testing::Values(1, 2),
+                     testing::Values(3, 8),
+                     testing::Values(std::tuple<size_t, size_t>(12, 12), std::tuple<size_t, size_t>(24, 24)),
+                     testing::Values(std::tuple<size_t, size_t>(4, 4), std::tuple<size_t, size_t>(2, 2)),
+                     testing::Values(std::tuple<int, int>(2, 2)),
+                     testing::Values(std::tuple<int, int>(0, 0)),
+                     testing::Values(format::yxfb,
+                                     format::bfyx,
+                                     format::byxf,
+                                     format::b_fs_yx_fsv16,
+                                     format::fs_b_yx_fsv32,
+                                     format::b_fs_yx_fsv32,
+                                     format::fs_bs_yx_bsv4_fsv32)),
     testing::internal::DefaultParamName<pooling_random_test_params>);
 
 TEST(pooling_forward_gpu, bsv16_fsv16_max_16x16x8x8_input_2x2_pool_2x2_stride)

--- a/inference-engine/thirdparty/clDNN/tests/test_utils/float16.h
+++ b/inference-engine/thirdparty/clDNN/tests/test_utils/float16.h
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,120 +17,96 @@
 #pragma once
 #include "include/math_utils.h"
 
-struct FLOAT16
-{
-    struct representation
-    {
-        uint16_t significand : 10;
-        uint16_t exponent : 5;
+struct FLOAT16 {
+    struct representation {
         uint16_t sign : 1;
+        uint16_t exponent : 5;
+        uint16_t significand : 10;
     };
 
-    union
-    {
-        uint16_t v = 0;
-        representation format; // added this struct for the .natvis file (for debug)
+    union {
+        uint16_t v;
+        representation format;  // added this struct for the .natvis file (for debug)
     };
 
-    static FLOAT16 min_val()
-    {
-        FLOAT16 f16;
-        f16.v = 0xFC00;
-        return f16;
+    static constexpr FLOAT16 min_val() { return FLOAT16((uint16_t)(0x0400)); }
+
+    static constexpr FLOAT16 lowest_val() { return FLOAT16((uint16_t)(0xfbff)); }
+
+    operator double() const {
+        double d = (double)float16_to_float32(v);
+        return d;
     }
-
-    operator double() const { double d = (double)float16_to_float32(v); return d; }
-    operator float() const { float f = float16_to_float32(v); return f; }
-    operator int16_t() const { return *(int16_t*)(&v); }
+    operator float() const {
+        float f = float16_to_float32(v);
+        return f;
+    }
+    operator int16_t() const { return *(int16_t *)(&v); }
     operator long long int() const { return v; }
     operator uint32_t() const { return v; }
     FLOAT16(float f) { v = float32_to_float16(f); }
+    FLOAT16(size_t s) { v = float32_to_float16(float(s)); }
     FLOAT16(int i) { v = float32_to_float16(float(i)); }
-    explicit FLOAT16(int16_t d) : v(d) {}
-    friend FLOAT16 operator +(const FLOAT16 &v1, const FLOAT16 &v2);
-    friend FLOAT16 operator -(const FLOAT16 &v1, const FLOAT16 &v2);
-    friend FLOAT16 operator *(const FLOAT16 &v1, const FLOAT16 &v2);
-    friend FLOAT16 operator /(const FLOAT16 &v1, const FLOAT16 &v2);
-    friend bool operator >(const FLOAT16 &v1, const FLOAT16 &v2);
-    friend bool operator >=(const FLOAT16 &v1, const FLOAT16 &v2);
-    friend bool operator <(const FLOAT16 &v1, const FLOAT16 &v2);
-    friend bool operator >(const FLOAT16 &v1, const float &v2);
-    friend bool operator <(const FLOAT16 &v1, const float &v2);
-    friend bool operator ==(const FLOAT16 &v1, const FLOAT16 &v2);
-    friend bool operator !=(const FLOAT16 &v1, const FLOAT16 &v2);
+    // TODO Below should have constructor tag to avoid ambigious behaviour, ex FLOAT16(16.f) != FLOAT16((uint16_t)16)
+    explicit constexpr FLOAT16(int16_t d) : v(d) {}
+    explicit constexpr FLOAT16(uint16_t d) : v(d) {}
+    friend FLOAT16 operator+(const FLOAT16 &v1, const FLOAT16 &v2);
+    friend FLOAT16 operator-(const FLOAT16 &v1, const FLOAT16 &v2);
+    friend FLOAT16 operator*(const FLOAT16 &v1, const FLOAT16 &v2);
+    friend FLOAT16 operator/(const FLOAT16 &v1, const FLOAT16 &v2);
+    friend bool operator>(const FLOAT16 &v1, const FLOAT16 &v2);
+    friend bool operator>=(const FLOAT16 &v1, const FLOAT16 &v2);
+    friend bool operator<(const FLOAT16 &v1, const FLOAT16 &v2);
+    friend bool operator>(const FLOAT16 &v1, const float &v2);
+    friend bool operator<(const FLOAT16 &v1, const float &v2);
+    friend bool operator==(const FLOAT16 &v1, const FLOAT16 &v2);
+    friend bool operator!=(const FLOAT16 &v1, const FLOAT16 &v2);
 
-    FLOAT16() {}
+    FLOAT16() { v = 0; }
 
-    FLOAT16& operator +=(const FLOAT16 &v1)
-    {
-            *this = (float)*this + (float)v1;
-            return *this;
+    FLOAT16 &operator+=(const FLOAT16 &v1) {
+        *this = (float)*this + (float)v1;
+        return *this;
     }
 
-    FLOAT16& operator /=(const FLOAT16 &v1)
-    {
-            *this = (float)*this / (float)v1;
-            return *this;
+    FLOAT16 &operator/=(const FLOAT16 &v1) {
+        *this = (float)*this / (float)v1;
+        return *this;
     }
 
-    FLOAT16& operator *=(const FLOAT16 &v1)
-    {
+    FLOAT16 &operator*=(const FLOAT16 &v1) {
         *this = (float)*this * (float)v1;
         return *this;
     }
 };
 
-inline FLOAT16 operator +(const FLOAT16 &v1, const FLOAT16 &v2)
-{
-    return (float)v1 + (float)v2;
-}
+inline FLOAT16 operator+(const FLOAT16 &v1, const FLOAT16 &v2) { return (float)v1 + (float)v2; }
 
-inline FLOAT16 operator -(const FLOAT16 &v1, const FLOAT16 &v2)
-{
-    return (float)v1 - (float)v2;
-}
+inline FLOAT16 operator-(const FLOAT16 &v1, const FLOAT16 &v2) { return (float)v1 - (float)v2; }
 
-inline FLOAT16 operator *(const FLOAT16 &v1, const FLOAT16 &v2)
-{
-    return (float)v1 * (float)v2;
-}
+inline FLOAT16 operator*(const FLOAT16 &v1, const FLOAT16 &v2) { return (float)v1 * (float)v2; }
 
-inline FLOAT16 operator /(const FLOAT16 &v1, const FLOAT16 &v2)
-{
-    return (float)v1 / (float)v2;
-}
+inline FLOAT16 operator/(const FLOAT16 &v1, const FLOAT16 &v2) { return (float)v1 / (float)v2; }
 
-inline bool operator >(const FLOAT16 &v1, const FLOAT16 &v2)
-{
-    return (float)v1 > (float)v2;
-}
+inline bool operator>(const FLOAT16 &v1, const FLOAT16 &v2) { return (float)v1 > (float)v2; }
 
-inline bool operator >=(const FLOAT16 &v1, const FLOAT16 &v2)
-{
-    return (float)v1 >= (float)v2;
-}
+inline bool operator>=(const FLOAT16 &v1, const FLOAT16 &v2) { return (float)v1 >= (float)v2; }
 
-inline bool operator <(const FLOAT16 &v1, const FLOAT16 &v2)
-{
-    return (float)v1 < (float)v2;
-}
+inline bool operator<(const FLOAT16 &v1, const FLOAT16 &v2) { return (float)v1 < (float)v2; }
 
-inline bool operator >(const FLOAT16 &v1, const float &v2)
-{
-    return (float)v1 > v2;
-}
+inline bool operator>(const FLOAT16 &v1, const float &v2) { return (float)v1 > v2; }
 
-inline bool operator <(const FLOAT16 &v1, const float &v2)
-{
-    return (float)v1 < v2;
-}
+inline bool operator<(const FLOAT16 &v1, const float &v2) { return (float)v1 < v2; }
 
-inline bool operator ==(const FLOAT16 &v1, const FLOAT16 &v2)
-{
-    return v1.v == v2.v;
-}
+inline bool operator==(const FLOAT16 &v1, const FLOAT16 &v2) { return v1.v == v2.v; }
 
-inline bool operator !=(const FLOAT16 &v1, const FLOAT16 &v2)
-{
-    return v1.v != v2.v;
-}
+inline bool operator!=(const FLOAT16 &v1, const FLOAT16 &v2) { return v1.v != v2.v; }
+
+namespace std {
+
+template <>
+struct numeric_limits<FLOAT16> {
+    static constexpr FLOAT16 lowest() { return FLOAT16::lowest_val(); }
+};
+
+}  // namespace std


### PR DESCRIPTION
This change:

* adds fusing support to all available pooling kernels
* tests all possible input type/output type configurations
* fixes minor bug in max pooling in pooling_gpu_test.cpp
* fixed minor bug with yxbf format in pooling_gpu_ref and pooling_gpu_int8_ref kernels
* fixes bug with b_fs_yx_fsv32 format in pooling_gpu kernel
* resolves bug with max pooling accuracy missmatch in case of non zero pad end layer parameter
* resolves average pooling accuracy missmatch in case of non zero pad end layer parameter

JIRA: 27993, 26266

Please review: @vparamuz @jhajducz @kdobros