### PR TITLE
Align MO requirements files

### DIFF
--- a/model-optimizer/requirements.txt
+++ b/model-optimizer/requirements.txt
@@ -1,7 +1,8 @@
 tensorflow>=1.2.0
 mxnet>=1.0.0,<=1.5.1
 networkx>=1.11
-numpy>=1.12.0
+numpy>=1.13.0
 protobuf==3.6.1
 onnx>=1.1.2
+test-generator==0.1.1
 defusedxml>=0.5.0

--- a/model-optimizer/requirements_caffe.txt
+++ b/model-optimizer/requirements_caffe.txt
@@ -1,4 +1,5 @@
 networkx>=1.11
-numpy>=1.12.0
+numpy>=1.13.0
 protobuf==3.6.1
+test-generator==0.1.1
 defusedxml>=0.5.0

--- a/model-optimizer/requirements_kaldi.txt
+++ b/model-optimizer/requirements_kaldi.txt
@@ -1,3 +1,4 @@
 networkx>=1.11
-numpy==1.13.0
+numpy>=1.13.0
+test-generator==0.1.1
 defusedxml>=0.5.0

--- a/model-optimizer/requirements_mxnet.txt
+++ b/model-optimizer/requirements_mxnet.txt
@@ -1,4 +1,5 @@
 mxnet>=1.0.0,<=1.5.1
 networkx>=1.11
-numpy>=1.12.0
+numpy>=1.13.0
+test-generator==0.1.1
 defusedxml>=0.5.0

--- a/model-optimizer/requirements_onnx.txt
+++ b/model-optimizer/requirements_onnx.txt
@@ -1,4 +1,5 @@
 onnx>=1.1.2
 networkx>=1.11
-numpy>=1.12.0
+numpy>=1.13.0
+test-generator==0.1.1
 defusedxml>=0.5.0

--- a/model-optimizer/requirements_tf.txt
+++ b/model-optimizer/requirements_tf.txt
@@ -1,4 +1,5 @@
 tensorflow>=1.2.0
 networkx>=1.11
-numpy>=1.12.0
+numpy>=1.13.0
+test-generator==0.1.1
 defusedxml>=0.5.0


### PR DESCRIPTION
This fixes an issue when you run the model conversion using the MO from github:
`ModuleNotFoundError: No module named 'generator'`