### PR TITLE
[IE][VPU]: Faster-RCNN fixes on myriad plugin side

### DIFF
--- a/inference-engine/src/vpu/graph_transformer/include/vpu/middleend/pass_manager.hpp
+++ b/inference-engine/src/vpu/graph_transformer/include/vpu/middleend/pass_manager.hpp
@@ -243,6 +243,8 @@ public:
 
     Pass::Ptr replaceGemmByConv();
 
+    Pass::Ptr propagateDynamismToOutputs();
+
 protected:
     StageBuilder::Ptr _stageBuilder;
     BackEnd::Ptr _backEnd;

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/pass_manager.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/pass_manager.cpp
@@ -91,11 +91,16 @@ PassSet::Ptr PassManager::buildMiddleEnd() {
     // Convert shape notation
     //
 
-    ADD_PASS(convertShapeNotation);
-    ADD_DUMP_PASS("convertShapeNotation");
 
+    // MyriadInferRequest::GetResult expects output shape data object
+    // to be in IE notation in case of dynamic data object
+    // propagateDynamismToOutputs must be applied before convertShapeNotation
+    // to mark shape in IE notation, not MDK notation as output
     ADD_PASS(propagateDynamismToOutputs);
     ADD_DUMP_PASS("propagateDynamismToOutputs");
+
+    ADD_PASS(convertShapeNotation);
+    ADD_DUMP_PASS("convertShapeNotation");
 
     //
     // Replace Global AvgPooling with ReduceMean

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/pass_manager.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/pass_manager.cpp
@@ -94,6 +94,9 @@ PassSet::Ptr PassManager::buildMiddleEnd() {
     ADD_PASS(convertShapeNotation);
     ADD_DUMP_PASS("convertShapeNotation");
 
+    ADD_PASS(propagateDynamismToOutputs);
+    ADD_DUMP_PASS("propagateDynamismToOutputs");
+
     //
     // Replace Global AvgPooling with ReduceMean
     //

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/propagate_dynamism_to_outputs.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/propagate_dynamism_to_outputs.cpp
@@ -1,0 +1,83 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "vpu/middleend/pass_manager.hpp"
+
+#include <set>
+#include <memory>
+
+namespace vpu {
+
+namespace {
+
+class PassImpl final : public Pass {
+public:
+    explicit PassImpl(StageBuilder::Ptr stageBuilder) : _stageBuilder(std::move(stageBuilder)) {}
+
+    void run(const Model& model) override {
+        static const std::unordered_set<StageType> types = {StageType::Convert};
+
+        for (auto const& data : model->datas()) {
+            if (data->usage() != DataUsage::Output || data->parentDataToShapeEdge() != nullptr) {
+                continue;
+            }
+
+            auto const& producer = data->producer();
+            VPU_THROW_UNLESS(producer, "Output data must have a producer, but {} doesn't have", data->name());
+
+            if (types.count(producer->type()) == 0) {
+                continue;
+            }
+
+            VPU_THROW_UNLESS(producer->numInputs() == 1,
+                "Only single input producers are supported, but {} has {} inputs",
+                producer->name(), producer->numInputs());
+
+            auto const& input = producer->input(0);
+            auto const& parentDataToShapeEdge = input->parentDataToShapeEdge();
+            if (parentDataToShapeEdge == nullptr) {
+                continue;
+            }
+            auto const parent = parentDataToShapeEdge->parent();
+
+            // Create the second output with shape in case of dynamic output
+            const auto& shapeOutput = model->addOutputData(parent->name() + "@output-dynamic-shape", parent->desc());
+
+            if (parent->numConsumers() > 0) {
+                _stageBuilder->addCopyStage(
+                    model,
+                    "copy-for-dynamic-output",
+                    nullptr,
+                    parent,
+                    shapeOutput,
+                    "PropogateDynamismToOutput");
+
+            } else {
+                auto const parentProducerEdge = parent->producerEdge();
+                VPU_THROW_UNLESS(parentProducerEdge != nullptr,
+                    "Data containing shape is expected to have a producer, but {} doesn't have", parent->name());
+
+                for (const auto& dataToShapeEdge : parent->childDataToShapeEdges()) {
+                    model->replaceDataToShapeParent(dataToShapeEdge, shapeOutput);
+                }
+
+                model->replaceStageOutput(parentProducerEdge, shapeOutput);
+                model->removeUnusedData(parent);
+            }
+
+            model->connectDataWithShape(shapeOutput, data);
+        }
+    }
+
+private:
+    StageBuilder::Ptr _stageBuilder;
+};
+
+}  // namespace
+
+Pass::Ptr PassManager::propagateDynamismToOutputs() {
+    return std::make_shared<PassImpl>(_stageBuilder);
+}
+
+}  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/propagate_dynamism_to_outputs.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/propagate_dynamism_to_outputs.cpp
@@ -40,7 +40,7 @@ public:
             auto const parent = parentDataToShapeEdge->parent();
 
             // Create the second output with shape in case of dynamic output
-            const auto& shapeOutput = model->addOutputData(parent->name() + "@output-dynamic-shape", parent->desc());
+            const auto& shapeOutput = model->addOutputData(parent->name() + "@shape", parent->desc());
 
             if (parent->numConsumers() > 0) {
                 _stageBuilder->addCopyStage(

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/propagate_dynamism_to_outputs.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/propagate_dynamism_to_outputs.cpp
@@ -16,8 +16,6 @@ public:
     explicit PassImpl(StageBuilder::Ptr stageBuilder) : _stageBuilder(std::move(stageBuilder)) {}
 
     void run(const Model& model) override {
-        static const std::unordered_set<StageType> types = {StageType::Convert};
-
         for (auto const& data : model->datas()) {
             if (data->usage() != DataUsage::Output || data->parentDataToShapeEdge() != nullptr) {
                 continue;
@@ -26,7 +24,7 @@ public:
             auto const& producer = data->producer();
             VPU_THROW_UNLESS(producer, "Output data must have a producer, but {} doesn't have", data->name());
 
-            if (types.count(producer->type()) == 0) {
+            if (producer->type() != StageType::Convert) {
                 continue;
             }
 
@@ -51,7 +49,7 @@ public:
                     nullptr,
                     parent,
                     shapeOutput,
-                    "PropogateDynamismToOutput");
+                    "PropagateDynamismToOutput");
 
             } else {
                 auto const parentProducerEdge = parent->producerEdge();

--- a/inference-engine/src/vpu/graph_transformer/src/stages/dynamic_shape_resolver.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/dynamic_shape_resolver.cpp
@@ -50,14 +50,13 @@ void FrontEnd::parseDSR(const Model& model, const ie::CNNLayerPtr& layer, const 
         // Create the second output with shape in case of dynamic output
         const auto& shapeOutput = model->addOutputData(dataOutput->name() + "@shape", shape->desc());
 
-        model->replaceStageOutput(shapeProducerEdge, shapeOutput);
-        model->connectDataWithShape(shapeOutput, dataOutput);
-
         for (const auto& dataToShapeEdge : shape->childDataToShapeEdges()) {
             model->replaceDataToShapeParent(dataToShapeEdge, shapeOutput);
         }
-
+        model->replaceStageOutput(shapeProducerEdge, shapeOutput);
         model->removeUnusedData(shape);
+
+        model->connectDataWithShape(shapeOutput, dataOutput);
     } else {
         model->connectDataWithShape(shape, dataOutput);
     }


### PR DESCRIPTION
## Task

#-32576

## Description

* Fixes parse DSR in case of output data
  Replacing stage output must be done after replacing data to shape parent, because the last one may access original parent producer, but after replacing stage output it'd not have one.

* Enables pass for propagating dynamism to network outputs
If network had dynamic output and then myriad Front-End inserted convert stage at the end (to convert FP16 -> FP32 - output precision) then dynamism would not be propagated - we have convert stage that has dynamic input, but static output. As a result, we have run-time error in Convert kernel: input and output shapes do not match.
At the moment, pass supports only Convert stage as output stage over which we should propagate dynamism to outputs.