### PR TITLE
Build security options required for win drivers

### DIFF
--- a/cmake/sdl.cmake
+++ b/cmake/sdl.cmake
@@ -37,7 +37,7 @@ if (CMAKE_BUILD_TYPE STREQUAL "Release")
             set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} -z noexecstack -z relro -z now")
         endif()
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-        set(IE_C_CXX_FLAGS "${IE_C_CXX_FLAGS} /sdl")
+        set(IE_C_CXX_FLAGS "${IE_C_CXX_FLAGS} /sdl /guard:cf")
     endif()
 
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${IE_C_CXX_FLAGS}")


### PR DESCRIPTION
Enable Control Flow Guard for Windows binaries
Control Flow Guard is a security option.

Implements for CVS-31331.