### PR TITLE
[ nGraph ] FP16 for evaluate

### DIFF
--- a/ngraph/src/ngraph/op/acosh.cpp
+++ b/ngraph/src/ngraph/op/acosh.cpp
@@ -71,6 +71,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg0, out);
             break;
+            TYPE_CASE(bf16)(arg0, out);
+            break;
+            TYPE_CASE(f16)(arg0, out);
+            break;
             TYPE_CASE(f32)(arg0, out);
             break;
             TYPE_CASE(f64)(arg0, out);

--- a/ngraph/src/ngraph/op/add.cpp
+++ b/ngraph/src/ngraph/op/add.cpp
@@ -108,6 +108,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
             break;
+            TYPE_CASE(bf16)(arg0, arg1, out, broadcast_spec);
+            break;
+            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
+            break;
             TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
             break;
             TYPE_CASE(f64)(arg0, arg1, out, broadcast_spec);

--- a/ngraph/src/ngraph/op/and.cpp
+++ b/ngraph/src/ngraph/op/and.cpp
@@ -87,6 +87,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
             break;
+            TYPE_CASE(bf16)(arg0, arg1, out, broadcast_spec);
+            break;
+            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
+            break;
             TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
             break;
             TYPE_CASE(f64)(arg0, arg1, out, broadcast_spec);

--- a/ngraph/src/ngraph/op/asinh.cpp
+++ b/ngraph/src/ngraph/op/asinh.cpp
@@ -71,6 +71,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg0, out);
             break;
+            TYPE_CASE(bf16)(arg0, out);
+            break;
+            TYPE_CASE(f16)(arg0, out);
+            break;
             TYPE_CASE(f32)(arg0, out);
             break;
             TYPE_CASE(f64)(arg0, out);

--- a/ngraph/src/ngraph/op/atanh.cpp
+++ b/ngraph/src/ngraph/op/atanh.cpp
@@ -71,6 +71,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg0, out);
             break;
+            TYPE_CASE(bf16)(arg0, out);
+            break;
+            TYPE_CASE(f16)(arg0, out);
+            break;
             TYPE_CASE(f32)(arg0, out);
             break;
             TYPE_CASE(f64)(arg0, out);

--- a/ngraph/src/ngraph/op/convert.cpp
+++ b/ngraph/src/ngraph/op/convert.cpp
@@ -99,6 +99,8 @@ namespace
             break;
             TYPE_OUT_CASE(bf16)(arg, out);
             break;
+            TYPE_OUT_CASE(f16)(arg, out);
+            break;
             TYPE_OUT_CASE(f32)(arg, out);
             break;
             TYPE_OUT_CASE(f64)(arg, out);
@@ -131,6 +133,8 @@ namespace
             TYPE_CASE(u64)(arg, out);
             break;
             TYPE_CASE(bf16)(arg, out);
+            break;
+            TYPE_CASE(f16)(arg, out);
             break;
             TYPE_CASE(f32)(arg, out);
             break;

--- a/ngraph/src/ngraph/op/divide.cpp
+++ b/ngraph/src/ngraph/op/divide.cpp
@@ -125,6 +125,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec, pythondiv);
             break;
+            TYPE_CASE(bf16)(arg0, arg1, out, broadcast_spec, pythondiv);
+            break;
+            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec, pythondiv);
+            break;
             TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec, pythondiv);
             break;
             TYPE_CASE(f64)(arg0, arg1, out, broadcast_spec, pythondiv);

--- a/ngraph/src/ngraph/op/equal.cpp
+++ b/ngraph/src/ngraph/op/equal.cpp
@@ -83,6 +83,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
             break;
+            TYPE_CASE(bf16)(arg0, arg1, out, broadcast_spec);
+            break;
+            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
+            break;
             TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
             break;
             TYPE_CASE(f64)(arg0, arg1, out, broadcast_spec);

--- a/ngraph/src/ngraph/op/fused/matmul.cpp
+++ b/ngraph/src/ngraph/op/fused/matmul.cpp
@@ -226,6 +226,8 @@ namespace
             break;
             TYPE_CASE(bf16)(arg0, arg1, output, transpose_a, transpose_b);
             break;
+            TYPE_CASE(f16)(arg0, arg1, output, transpose_a, transpose_b);
+            break;
             TYPE_CASE(f32)(arg0, arg1, output, transpose_a, transpose_b);
             break;
             TYPE_CASE(f64)(arg0, arg1, output, transpose_a, transpose_b);

--- a/ngraph/src/ngraph/op/fused/squeeze.cpp
+++ b/ngraph/src/ngraph/op/fused/squeeze.cpp
@@ -201,6 +201,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg0, out);
             break;
+            TYPE_CASE(bf16)(arg0, out);
+            break;
+            TYPE_CASE(f16)(arg0, out);
+            break;
             TYPE_CASE(f32)(arg0, out);
             break;
             TYPE_CASE(f64)(arg0, out);

--- a/ngraph/src/ngraph/op/fused/unsqueeze.cpp
+++ b/ngraph/src/ngraph/op/fused/unsqueeze.cpp
@@ -161,6 +161,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg0, out);
             break;
+            TYPE_CASE(bf16)(arg0, out);
+            break;
+            TYPE_CASE(f16)(arg0, out);
+            break;
             TYPE_CASE(f32)(arg0, out);
             break;
             TYPE_CASE(f64)(arg0, out);

--- a/ngraph/src/ngraph/op/gather.cpp
+++ b/ngraph/src/ngraph/op/gather.cpp
@@ -292,6 +292,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg0, arg1, out, axis);
             break;
+            TYPE_CASE(bf16)(arg0, arg1, out, axis);
+            break;
+            TYPE_CASE(f16)(arg0, arg1, out, axis);
+            break;
             TYPE_CASE(f32)(arg0, arg1, out, axis);
             break;
             TYPE_CASE(f64)(arg0, arg1, out, axis);

--- a/ngraph/src/ngraph/op/greater.cpp
+++ b/ngraph/src/ngraph/op/greater.cpp
@@ -83,6 +83,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
             break;
+            TYPE_CASE(bf16)(arg0, arg1, out, broadcast_spec);
+            break;
+            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
+            break;
             TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
             break;
             TYPE_CASE(f64)(arg0, arg1, out, broadcast_spec);

--- a/ngraph/src/ngraph/op/greater_eq.cpp
+++ b/ngraph/src/ngraph/op/greater_eq.cpp
@@ -83,6 +83,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
             break;
+            TYPE_CASE(bf16)(arg0, arg1, out, broadcast_spec);
+            break;
+            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
+            break;
             TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
             break;
             TYPE_CASE(f64)(arg0, arg1, out, broadcast_spec);

--- a/ngraph/src/ngraph/op/less.cpp
+++ b/ngraph/src/ngraph/op/less.cpp
@@ -83,6 +83,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
             break;
+            TYPE_CASE(bf16)(arg0, arg1, out, broadcast_spec);
+            break;
+            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
+            break;
             TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
             break;
             TYPE_CASE(f64)(arg0, arg1, out, broadcast_spec);

--- a/ngraph/src/ngraph/op/less_eq.cpp
+++ b/ngraph/src/ngraph/op/less_eq.cpp
@@ -83,6 +83,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
             break;
+            TYPE_CASE(bf16)(arg0, arg1, out, broadcast_spec);
+            break;
+            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
+            break;
             TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
             break;
             TYPE_CASE(f64)(arg0, arg1, out, broadcast_spec);

--- a/ngraph/src/ngraph/op/max.cpp
+++ b/ngraph/src/ngraph/op/max.cpp
@@ -117,6 +117,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg, out, axes);
             break;
+            TYPE_CASE(bf16)(arg, out, axes);
+            break;
+            TYPE_CASE(f16)(arg, out, axes);
+            break;
             TYPE_CASE(f32)(arg, out, axes);
             break;
             TYPE_CASE(f64)(arg, out, axes);

--- a/ngraph/src/ngraph/op/max_pool.cpp
+++ b/ngraph/src/ngraph/op/max_pool.cpp
@@ -562,6 +562,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg, out, out_shape, kernel, strides, pad_begin, pad_end);
             break;
+            TYPE_CASE(bf16)(arg, out, out_shape, kernel, strides, pad_begin, pad_end);
+            break;
+            TYPE_CASE(f16)(arg, out, out_shape, kernel, strides, pad_begin, pad_end);
+            break;
             TYPE_CASE(f32)(arg, out, out_shape, kernel, strides, pad_begin, pad_end);
             break;
             TYPE_CASE(f64)(arg, out, out_shape, kernel, strides, pad_begin, pad_end);

--- a/ngraph/src/ngraph/op/maximum.cpp
+++ b/ngraph/src/ngraph/op/maximum.cpp
@@ -106,6 +106,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
             break;
+            TYPE_CASE(bf16)(arg0, arg1, out, broadcast_spec);
+            break;
+            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
+            break;
             TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
             break;
             TYPE_CASE(f64)(arg0, arg1, out, broadcast_spec);

--- a/ngraph/src/ngraph/op/min.cpp
+++ b/ngraph/src/ngraph/op/min.cpp
@@ -117,6 +117,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg, out, axes);
             break;
+            TYPE_CASE(bf16)(arg, out, axes);
+            break;
+            TYPE_CASE(f16)(arg, out, axes);
+            break;
             TYPE_CASE(f32)(arg, out, axes);
             break;
             TYPE_CASE(f64)(arg, out, axes);

--- a/ngraph/src/ngraph/op/minimum.cpp
+++ b/ngraph/src/ngraph/op/minimum.cpp
@@ -105,6 +105,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
             break;
+            TYPE_CASE(bf16)(arg0, arg1, out, broadcast_spec);
+            break;
+            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
+            break;
             TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
             break;
             TYPE_CASE(f64)(arg0, arg1, out, broadcast_spec);

--- a/ngraph/src/ngraph/op/multiply.cpp
+++ b/ngraph/src/ngraph/op/multiply.cpp
@@ -97,6 +97,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
             break;
+            TYPE_CASE(bf16)(arg0, arg1, out, broadcast_spec);
+            break;
+            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
+            break;
             TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
             break;
             TYPE_CASE(f64)(arg0, arg1, out, broadcast_spec);

--- a/ngraph/src/ngraph/op/non_zero.cpp
+++ b/ngraph/src/ngraph/op/non_zero.cpp
@@ -156,6 +156,8 @@ namespace
             break;
             TYPE_CASE(bf16)(input, output);
             break;
+            TYPE_CASE(f16)(input, output);
+            break;
             TYPE_CASE(f32)(input, output);
             break;
             TYPE_CASE(f64)(input, output);

--- a/ngraph/src/ngraph/op/not_equal.cpp
+++ b/ngraph/src/ngraph/op/not_equal.cpp
@@ -83,6 +83,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
             break;
+            TYPE_CASE(bf16)(arg0, arg1, out, broadcast_spec);
+            break;
+            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
+            break;
             TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
             break;
             TYPE_CASE(f64)(arg0, arg1, out, broadcast_spec);

--- a/ngraph/src/ngraph/op/or.cpp
+++ b/ngraph/src/ngraph/op/or.cpp
@@ -81,6 +81,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
             break;
+            TYPE_CASE(bf16)(arg0, arg1, out, broadcast_spec);
+            break;
+            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
+            break;
             TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
             break;
             TYPE_CASE(f64)(arg0, arg1, out, broadcast_spec);

--- a/ngraph/src/ngraph/op/power.cpp
+++ b/ngraph/src/ngraph/op/power.cpp
@@ -102,6 +102,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
             break;
+            TYPE_CASE(bf16)(arg0, arg1, out, broadcast_spec);
+            break;
+            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
+            break;
             TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
             break;
             TYPE_CASE(f64)(arg0, arg1, out, broadcast_spec);

--- a/ngraph/src/ngraph/op/product.cpp
+++ b/ngraph/src/ngraph/op/product.cpp
@@ -80,6 +80,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg, out, axes);
             break;
+            TYPE_CASE(bf16)(arg, out, axes);
+            break;
+            TYPE_CASE(f16)(arg, out, axes);
+            break;
             TYPE_CASE(f32)(arg, out, axes);
             break;
             TYPE_CASE(f64)(arg, out, axes);

--- a/ngraph/src/ngraph/op/reduce_mean.cpp
+++ b/ngraph/src/ngraph/op/reduce_mean.cpp
@@ -72,6 +72,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg, out, axes);
             break;
+            TYPE_CASE(bf16)(arg, out, axes);
+            break;
+            TYPE_CASE(f16)(arg, out, axes);
+            break;
             TYPE_CASE(f32)(arg, out, axes);
             break;
             TYPE_CASE(f64)(arg, out, axes);

--- a/ngraph/src/ngraph/op/reduce_prod.cpp
+++ b/ngraph/src/ngraph/op/reduce_prod.cpp
@@ -76,6 +76,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg, out, axes);
             break;
+            TYPE_CASE(bf16)(arg, out, axes);
+            break;
+            TYPE_CASE(f16)(arg, out, axes);
+            break;
             TYPE_CASE(f32)(arg, out, axes);
             break;
             TYPE_CASE(f64)(arg, out, axes);

--- a/ngraph/src/ngraph/op/reduce_sum.cpp
+++ b/ngraph/src/ngraph/op/reduce_sum.cpp
@@ -87,6 +87,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg, out, axes);
             break;
+            TYPE_CASE(bf16)(arg, out, axes);
+            break;
+            TYPE_CASE(f16)(arg, out, axes);
+            break;
             TYPE_CASE(f32)(arg, out, axes);
             break;
             TYPE_CASE(f64)(arg, out, axes);

--- a/ngraph/src/ngraph/op/scatter_elements_update.cpp
+++ b/ngraph/src/ngraph/op/scatter_elements_update.cpp
@@ -267,6 +267,8 @@ namespace
             break;
             TYPE_CASE(bf16)(arg0, arg1, arg2, arg3, out, normalized_axis);
             break;
+            TYPE_CASE(f16)(arg0, arg1, arg2, arg3, out, normalized_axis);
+            break;
             TYPE_CASE(f32)(arg0, arg1, arg2, arg3, out, normalized_axis);
             break;
             TYPE_CASE(f64)(arg0, arg1, arg2, arg3, out, normalized_axis);

--- a/ngraph/src/ngraph/op/softmax.cpp
+++ b/ngraph/src/ngraph/op/softmax.cpp
@@ -173,7 +173,8 @@ namespace
     bool evaluate_softmax(const HostTensorPtr& arg, const HostTensorPtr& out, const AxisSet& axes)
     {
         auto shape = out->get_shape();
-        return try_evaluate_softmax<element::Type_t::f32>(arg, out, shape, axes) ||
+        return try_evaluate_softmax<element::Type_t::f16>(arg, out, shape, axes) ||
+               try_evaluate_softmax<element::Type_t::f32>(arg, out, shape, axes) ||
                try_evaluate_softmax<element::Type_t::f64>(arg, out, shape, axes);
     }
 }

--- a/ngraph/src/ngraph/op/strided_slice.cpp
+++ b/ngraph/src/ngraph/op/strided_slice.cpp
@@ -291,6 +291,8 @@ namespace
             break;
             TYPE_CASE(bf16)(in, slice_plan, out);
             break;
+            TYPE_CASE(f16)(in, slice_plan, out);
+            break;
             TYPE_CASE(f32)(in, slice_plan, out);
             break;
             TYPE_CASE(f64)(in, slice_plan, out);

--- a/ngraph/src/ngraph/op/subtract.cpp
+++ b/ngraph/src/ngraph/op/subtract.cpp
@@ -103,6 +103,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
             break;
+            TYPE_CASE(bf16)(arg0, arg1, out, broadcast_spec);
+            break;
+            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
+            break;
             TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
             break;
             TYPE_CASE(f64)(arg0, arg1, out, broadcast_spec);

--- a/ngraph/src/ngraph/op/sum.cpp
+++ b/ngraph/src/ngraph/op/sum.cpp
@@ -91,6 +91,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg, out, axes);
             break;
+            TYPE_CASE(bf16)(arg, out, axes);
+            break;
+            TYPE_CASE(f16)(arg, out, axes);
+            break;
             TYPE_CASE(f32)(arg, out, axes);
             break;
             TYPE_CASE(f64)(arg, out, axes);

--- a/ngraph/src/ngraph/op/xor.cpp
+++ b/ngraph/src/ngraph/op/xor.cpp
@@ -87,6 +87,10 @@ namespace
             break;
             TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
             break;
+            TYPE_CASE(bf16)(arg0, arg1, out, broadcast_spec);
+            break;
+            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
+            break;
             TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
             break;
             TYPE_CASE(f64)(arg0, arg1, out, broadcast_spec);

--- a/ngraph/src/ngraph/type/float16.cpp
+++ b/ngraph/src/ngraph/type/float16.cpp
@@ -138,38 +138,6 @@ size_t float16::size() const
     return sizeof(m_value);
 }
 
-bool float16::operator==(const float16& other) const
-{
-#if defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wfloat-equal"
-#endif
-    return (static_cast<float>(*this) == static_cast<float>(other));
-#if defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
-}
-
-bool float16::operator<(const float16& other) const
-{
-    return (static_cast<float>(*this) < static_cast<float>(other));
-}
-
-bool float16::operator<=(const float16& other) const
-{
-    return (static_cast<float>(*this) <= static_cast<float>(other));
-}
-
-bool float16::operator>(const float16& other) const
-{
-    return (static_cast<float>(*this) > static_cast<float>(other));
-}
-
-bool float16::operator>=(const float16& other) const
-{
-    return (static_cast<float>(*this) >= static_cast<float>(other));
-}
-
 float16::operator float() const
 {
     union {

--- a/ngraph/src/ngraph/type/float16.hpp
+++ b/ngraph/src/ngraph/type/float16.hpp
@@ -50,12 +50,20 @@ namespace ngraph
 
         std::string to_string() const;
         size_t size() const;
-        bool operator==(const float16& other) const;
-        bool operator!=(const float16& other) const { return !(*this == other); }
-        bool operator<(const float16& other) const;
-        bool operator<=(const float16& other) const;
-        bool operator>(const float16& other) const;
-        bool operator>=(const float16& other) const;
+        template<typename T> bool operator==(const T& other) const;
+        template<typename T> bool operator!=(const T& other) const { return !(*this == other); }
+        template<typename T> bool operator<(const T& other) const;
+        template<typename T> bool operator<=(const T& other) const;
+        template<typename T> bool operator>(const T& other) const;
+        template<typename T> bool operator>=(const T& other) const;
+        template<typename T> float16 operator+(const T& other) const;
+        template<typename T> float16 operator+=(const T& other);
+        template<typename T> float16 operator-(const T& other) const;
+        template<typename T> float16 operator-=(const T& other);
+        template<typename T> float16 operator*(const T& other) const;
+        template<typename T> float16 operator*=(const T& other);
+        template<typename T> float16 operator/(const T& other) const;
+        template<typename T> float16 operator/=(const T& other);
         operator float() const;
 
         static constexpr float16 from_bits(uint16_t bits) { return float16(bits, true); }
@@ -86,6 +94,91 @@ namespace ngraph
 
         uint16_t m_value;
     };
+
+    template<typename T>
+    bool float16::operator==(const T& other) const
+    {
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#endif
+        return (static_cast<float>(*this) == static_cast<float>(other));
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+    }
+
+    template<typename T>
+    bool float16::operator<(const T& other) const
+    {
+        return (static_cast<float>(*this) < static_cast<float>(other));
+    }
+
+    template<typename T>
+    bool float16::operator<=(const T& other) const
+    {
+        return (static_cast<float>(*this) <= static_cast<float>(other));
+    }
+
+    template<typename T>
+    bool float16::operator>(const T& other) const
+    {
+        return (static_cast<float>(*this) > static_cast<float>(other));
+    }
+
+    template<typename T>
+    bool float16::operator>=(const T& other) const
+    {
+        return (static_cast<float>(*this) >= static_cast<float>(other));
+    }
+
+    template<typename T>
+    float16 float16::operator+(const T& other) const
+    {
+        return {static_cast<float>(*this) + static_cast<float>(other)};
+    }
+
+    template<typename T>
+    float16 float16::operator+=(const T& other)
+    {
+        return *this = *this + other;
+    }
+
+    template<typename T>
+    float16 float16::operator-(const T& other) const
+    {
+        return {static_cast<float>(*this) - static_cast<float>(other)};
+    }
+
+    template<typename T>
+    float16 float16::operator-=(const T& other)
+    {
+        return *this = *this - other;
+    }
+
+    template<typename T>
+    float16 float16::operator*(const T& other) const
+    {
+        return {static_cast<float>(*this) * static_cast<float>(other)};
+    }
+
+    template<typename T>
+    float16 float16::operator*=(const T& other)
+    {
+        return *this = *this * other;
+    }
+
+    template<typename T>
+    float16 float16::operator/(const T& other) const
+    {
+        return {static_cast<float>(*this) / static_cast<float>(other)};
+    }
+
+    template<typename T>
+    float16 float16::operator/=(const T& other)
+    {
+        return *this = *this / other;
+    }
 }
 
 namespace std


### PR DESCRIPTION
1. Introduced mathematical binary operators for `ngraph::float16` class
2. Added `f16` and `bf16` branches for evaluate switches  

---
FYI @mikhail-treskin, @iefode -- evaluate functions are used a lot in validation.

FYI @myshevts -- closes CVS-32325