### PR TITLE
Add fixedscale(bias) components to Kaldi

### DIFF
--- a/model-optimizer/automation/package_BOM.txt
+++ b/model-optimizer/automation/package_BOM.txt
@@ -780,6 +780,7 @@ mo/front/kaldi/extractors/affine_component_preconditioned_online_ext.py
 mo/front/kaldi/extractors/affine_transform_ext.py
 mo/front/kaldi/extractors/backproptruncation_ext.py
 mo/front/kaldi/extractors/batchnorm_component_ext.py
+mo/front/kaldi/extractors/bias_component_ext.py
 mo/front/kaldi/extractors/clip_ext.py
 mo/front/kaldi/extractors/concat_ext.py
 mo/front/kaldi/extractors/convolutional_1d_component_ext.py

--- a/model-optimizer/mo/front/kaldi/extractors/add_shift_ext.py
+++ b/model-optimizer/mo/front/kaldi/extractors/add_shift_ext.py
@@ -39,7 +39,7 @@ class AddShiftFrontExtractor(FrontExtractorOp):
         return cls.enabled
 
 
-class FixedShiftComponentFrontExtractor(FrontExtractorOp):
+class FixedBiasComponentFrontExtractor(FrontExtractorOp):
     op = 'fixedbiascomponent'
     enabled = True
 
@@ -52,7 +52,9 @@ class FixedShiftComponentFrontExtractor(FrontExtractorOp):
         read_placeholder(pb, 1)
 
         mapping_rule = {
-            'layout': 'NCHW'
+            'layout': 'NCHW',
+            'bias_term': True,
+            'out-size': biases.shape[0],
         }
         embed_input(mapping_rule, 1, 'biases', biases)
 

--- a/model-optimizer/mo/front/kaldi/extractors/bias_component_ext.py
+++ b/model-optimizer/mo/front/kaldi/extractors/bias_component_ext.py
@@ -38,7 +38,7 @@ class FixedBiasComponentFrontExtractor(FrontExtractorOp):
             'bias_term': True,
             'out-size': biases.shape[0],
         }
-        embed_input(mapping_rule, 1, 'biases', biases)
+        embed_input(mapping_rule, 2, 'biases', biases)
 
         ScaleShiftOp.update_node_stat(node, mapping_rule)
         return cls.enabled

--- a/model-optimizer/mo/front/kaldi/extractors/bias_component_ext_test.py
+++ b/model-optimizer/mo/front/kaldi/extractors/bias_component_ext_test.py
@@ -1,0 +1,53 @@
+"""
+ Copyright (C) 2018-2020 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import numpy as np
+
+from mo.front.kaldi.extractors.bias_component_ext import FixedBiasComponentFrontExtractor
+from mo.front.kaldi.extractors.common_ext_test import KaldiFrontExtractorTest
+from mo.front.kaldi.loader.utils_test import TestKaldiUtilsLoading
+from mo.ops.op import Op
+from mo.ops.scale_shift import ScaleShiftOp
+
+
+class FixedBiasComponentFrontExtractorTest(KaldiFrontExtractorTest):
+    @classmethod
+    def register_op(cls):
+        Op.registered_ops['ScaleShift'] = ScaleShiftOp
+
+    @classmethod
+    def create_pb_for_test_node(cls):
+        cls.input_shape = 10
+
+        pb = b'<FixedBiasComponent> <Bias> '
+        pb += KaldiFrontExtractorTest.generate_vector(cls.input_shape)
+        pb += b'</FixedBiasComponent>'
+
+        cls.test_node['parameters'] = TestKaldiUtilsLoading.bytesio_from(pb)
+        FixedBiasComponentFrontExtractor.extract(cls.test_node)
+
+    def test_fixedbias_extractor(self):
+        input_shape = FixedBiasComponentFrontExtractorTest.input_shape
+
+        exp_res = {
+            'op': 'ScaleShift',
+            'layout': 'NCHW',
+            'bias_term': True,
+            'out-size': input_shape,
+            'biases': np.arange(input_shape)
+        }
+
+        self.compare_node_attrs(exp_res)

--- a/model-optimizer/mo/front/kaldi/extractors/common_ext_test.py
+++ b/model-optimizer/mo/front/kaldi/extractors/common_ext_test.py
@@ -127,3 +127,11 @@ class KaldiFrontExtractorTest(unittest.TestCase):
     def write_str_value(value) -> bytes:
         pb = bytes(value, 'ascii')
         return pb
+
+    def compare_node_attrs(self, exp_res):
+        node = self.test_node
+        for key in exp_res.keys():
+            if type(node[key]) in [list, np.ndarray]:
+                self.assertTrue(np.array_equal(np.array(node[key]), np.array(exp_res[key])))
+            else:
+                self.assertEqual(node[key], exp_res[key])

--- a/model-optimizer/mo/front/kaldi/extractors/scale_component_ext.py
+++ b/model-optimizer/mo/front/kaldi/extractors/scale_component_ext.py
@@ -55,7 +55,8 @@ class FixedScaleComponentFrontExtractor(FrontExtractorOp):
         read_placeholder(pb, 1)
 
         mapping_rule = {
-            'layout': 'NCHW'
+            'layout': 'NCHW',
+            'out-size': weights.shape[0],
         }
         embed_input(mapping_rule, 1, 'weights', weights)
 

--- a/model-optimizer/mo/front/kaldi/extractors/scale_component_ext.py
+++ b/model-optimizer/mo/front/kaldi/extractors/scale_component_ext.py
@@ -40,3 +40,24 @@ class NaturalGradientPerElementScaleComponentFrontExtractor(FrontExtractorOp):
 
         ScaleShiftOp.update_node_stat(node, mapping_rule)
         return cls.enabled
+
+
+class FixedScaleComponentFrontExtractor(FrontExtractorOp):
+    op = 'fixedscalecomponent'
+    enabled = True
+
+    @classmethod
+    def extract(cls, node):
+        pb = node.parameters
+        collect_until_token(pb, b'<Scales>')
+        weights = read_binary_vector(pb)
+        find_next_tag(pb)
+        read_placeholder(pb, 1)
+
+        mapping_rule = {
+            'layout': 'NCHW'
+        }
+        embed_input(mapping_rule, 1, 'weights', weights)
+
+        ScaleShiftOp.update_node_stat(node, mapping_rule)
+        return cls.enabled

--- a/model-optimizer/mo/front/kaldi/extractors/scale_component_ext_test.py
+++ b/model-optimizer/mo/front/kaldi/extractors/scale_component_ext_test.py
@@ -1,0 +1,52 @@
+"""
+ Copyright (C) 2018-2020 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import numpy as np
+
+from mo.front.kaldi.extractors.scale_component_ext import FixedScaleComponentFrontExtractor
+from mo.front.kaldi.extractors.common_ext_test import KaldiFrontExtractorTest
+from mo.front.kaldi.loader.utils_test import TestKaldiUtilsLoading
+from mo.ops.op import Op
+from mo.ops.scale_shift import ScaleShiftOp
+
+
+class FixedScaleComponentFrontExtractorTest(KaldiFrontExtractorTest):
+    @classmethod
+    def register_op(cls):
+        Op.registered_ops['ScaleShift'] = ScaleShiftOp
+
+    @classmethod
+    def create_pb_for_test_node(cls):
+        cls.input_shape = 10
+
+        pb = b'<FixedScaleComponent> <Scales> '
+        pb += KaldiFrontExtractorTest.generate_vector(cls.input_shape)
+        pb += b'</FixedScaleComponent>'
+
+        cls.test_node['parameters'] = TestKaldiUtilsLoading.bytesio_from(pb)
+        FixedScaleComponentFrontExtractor.extract(cls.test_node)
+
+    def test_fixedscale_extractor(self):
+        input_shape = FixedScaleComponentFrontExtractorTest.input_shape
+
+        exp_res = {
+            'op': 'ScaleShift',
+            'layout': 'NCHW',
+            'out-size': input_shape,
+            'weights': np.arange(input_shape)
+        }
+
+        self.compare_node_attrs(exp_res)

--- a/model-optimizer/mo/front/kaldi/loader/utils.py
+++ b/model-optimizer/mo/front/kaldi/loader/utils.py
@@ -38,6 +38,8 @@ supported_components = [
     'copy',
     'elementwiseproductcomponent',
     'fixedaffinecomponent',
+    'fixedscalecomponent',
+    'fixedbiascomponent',
     'linearcomponent',
     'logsoftmaxcomponent',
     'lstmnonlinearitycomponent',

--- a/model-optimizer/mo/ops/memoryoffset.py
+++ b/model-optimizer/mo/ops/memoryoffset.py
@@ -58,7 +58,7 @@ class MemoryOffset(Op):
             elif pair_node.in_port(0).get_source().node.has_valid('out-size') :
                 out_size = pair_node.in_port(0).get_source().node['out-size']
                 node.out_port(0).data.set_shape(np.array([1, out_size]))
-            elif pair_node.in_port(0).get_source().node.op == "Add" and \
+            elif pair_node.in_port(0).get_source().node.op in ["Add", "ReLU"] and \
                     pair_node.in_port(0).get_source().node.in_port(0).get_source().node.has_valid('out-size'):
                 out_size = pair_node.in_port(0).get_source().node.in_port(0).get_source().node['out-size']
                 node.out_port(0).data.set_shape(np.array([1, out_size]))

--- a/model-optimizer/mo/ops/memoryoffset.py
+++ b/model-optimizer/mo/ops/memoryoffset.py
@@ -55,7 +55,7 @@ class MemoryOffset(Op):
             elif pair_node.has_valid('element_size'):
                 # TODO Add here real batch
                 node.out_port(0).data.set_shape(np.array([1, pair_node['element_size']]))
-            elif pair_node.in_port(0).get_source().node.has_valid('out-size') :
+            elif pair_node.in_port(0).get_source().node.has_valid('out-size'):
                 out_size = pair_node.in_port(0).get_source().node['out-size']
                 node.out_port(0).data.set_shape(np.array([1, out_size]))
             elif pair_node.in_port(0).get_source().node.op in ["Add", "ReLU"] and \


### PR DESCRIPTION
Description: Add extractors for the following Kaldi components: fixedscalecomponent, fixedbiascomponent 

ticket no: CVS-31094, CVS-32159

Reviewers: @achetver @jane-intel @sadolini 

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves node names


Validation:
* [x]  Unit tests
* [x]  Framework layer tests: N/A
* [x]  Transformation tests: N/A
* [x]  e2e model test with an update: N/A
* [x]  MO IR Reader check: N/A

Documentation:
* [x]  Supported frameworks operations list: N/A
* [x]  Supported **public** models list: N/A
* [x]  New operations specification: N/A
* [x]  Guide on how to convert the **public** model: N/A
* [x]  User guide update: N/A

Other:
* [x]  Sample/Demo application to infer the model: N/A
