### PR TITLE
mkldnn_memory_solver.hpp: include stdint.h to avoid build error

### DIFF
--- a/inference-engine/src/mkldnn_plugin/mkldnn_memory_solver.hpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_memory_solver.hpp
@@ -10,6 +10,8 @@
 
 #include "ie_api.h"
 
+#include <stdint.h>
+
 #include <vector>
 #include <map>
 


### PR DESCRIPTION
fix the following compile error:

inference-engine/src/mkldnn_plugin/mkldnn_memory_solver.hpp:60:9: error: 'int64_t' does not name a type
|    60 |         int64_t size;
|       |         ^~~~~~~

include stdint.h to fix this.

Signed-off-by: Liwei Song <liwei.song@windriver.com>