### PR TITLE
[IE CLDNN] Improve kernel selection for b_fs_yx_fsv16 layout and optimize Convolution kernels

### DIFF
--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/convolution_gpu_bfyx_f16_1x1.cl
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/convolution_gpu_bfyx_f16_1x1.cl
@@ -208,21 +208,10 @@ KERNEL(convolution_b_fs_yx_fsv16_1x1)(
 #endif
     {
 #if !PADDED_OUTPUT
-        if (xy * X_BLOCK_SIZE + X_BLOCK_SIZE <= OUTPUT_SIZE_X * OUTPUT_SIZE_Y) {
-#if HAS_FUSED_OPS
-            FUSED_OPS_VEC;
-            dst = FUSED_OPS_RESULT_VEC;
-#endif
-#if X_BLOCK_SIZE == 8
-            UNIT_BLOCK_WRITE8(output, output_offset + y * output_y_pitch + x * output_x_pitch, dst);
-#elif X_BLOCK_SIZE == 4
-            UNIT_BLOCK_WRITE4(output, output_offset + y * output_y_pitch + x * output_x_pitch, dst);
-#elif X_BLOCK_SIZE == 2
-            UNIT_BLOCK_WRITE2(output, output_offset + y * output_y_pitch + x * output_x_pitch, dst);
-#endif
-        } else {
+        if (xy * X_BLOCK_SIZE + X_BLOCK_SIZE <= OUTPUT_SIZE_X * OUTPUT_SIZE_Y || (OUTPUT_SIZE_X * OUTPUT_SIZE_Y) % X_BLOCK_SIZE == 0) {
 #else
-        if (x * X_BLOCK_SIZE + X_BLOCK_SIZE <= OUTPUT_SIZE_X) {
+        if (x + X_BLOCK_SIZE <= OUTPUT_SIZE_X || OUTPUT_SIZE_X % X_BLOCK_SIZE == 0) {
+#endif
 #if HAS_FUSED_OPS
             FUSED_OPS_VEC;
             dst = FUSED_OPS_RESULT_VEC;
@@ -235,7 +224,6 @@ KERNEL(convolution_b_fs_yx_fsv16_1x1)(
             UNIT_BLOCK_WRITE2(output, output_offset + y * output_y_pitch + x * output_x_pitch, dst);
 #endif
         } else {
-#endif
             for (int i = 0; i < X_BLOCK_SIZE; i++) {
                 if (xy * X_BLOCK_SIZE + i >= OUTPUT_SIZE_X * OUTPUT_SIZE_Y)
                     return;


### PR DESCRIPTION
This changes improve the heuristics for Convolution kernel selector (when tuning cache can't be used or is missing) and slightly optimize kernels.

Here are some improvements:

| Model               | Precision | SpeedUp |
|---------------------|-----------|---------|
| mobilenet-v2        | FP16      | 12%     |
| squeezenet1.1       | FP16      | 13%     |
| face-detection-0104 | FP16      | 18%     |
| mobilenet-v2        | FP32      | 7%      |
| face-detection-0104 | FP32      | 8%      |

JIRA: 30495