### PR TITLE
[IE][VPU][nGraph]: Fixes DTS transformations to properly keep outputs names

### DIFF
--- a/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_broadcast.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_broadcast.cpp
@@ -36,7 +36,6 @@ void dynamicToStaticShapeBroadcast(std::shared_ptr<ngraph::Node> target) {
         VPU_THROW_FORMAT("dynamicToStaticShapeBroadcast supports only explicit and numpy modes,"
                          "provided {}", broadcast->get_broadcast_spec().m_type);
     }
-    staticShapeBroadcast->set_friendly_name("");
 
     auto dsr = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(
             staticShapeBroadcast->output(0), broadcast->input_value(1));

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_broadcast.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_broadcast.cpp
@@ -36,9 +36,11 @@ void dynamicToStaticShapeBroadcast(std::shared_ptr<ngraph::Node> target) {
         VPU_THROW_FORMAT("dynamicToStaticShapeBroadcast supports only explicit and numpy modes,"
                          "provided {}", broadcast->get_broadcast_spec().m_type);
     }
+    staticShapeBroadcast->set_friendly_name("");
 
     auto dsr = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(
             staticShapeBroadcast->output(0), broadcast->input_value(1));
+    dsr->set_friendly_name(broadcast->get_friendly_name());
 
     ngraph::replace_node(std::move(target), std::move(dsr));
 }

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_concat.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_concat.cpp
@@ -106,9 +106,11 @@ void dynamicToStaticShapeConcat(std::shared_ptr<ngraph::Node> target) {
         accumulatedShape = sumOfShapes(accumulatedShape, accumulatedStaticShape);
     }
 
-    const auto copied = target->clone_with_new_inputs(target->input_values());
-    const auto outDsr = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(
+    auto copied = target->clone_with_new_inputs(target->input_values());
+    copied->set_friendly_name("");
+    auto outDsr = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(
             copied, accumulatedShape);
+    outDsr->set_friendly_name(copied->get_friendly_name());
 
     ngraph::replace_node(std::move(target), outDsr);
 }

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_concat.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_concat.cpp
@@ -106,11 +106,10 @@ void dynamicToStaticShapeConcat(std::shared_ptr<ngraph::Node> target) {
         accumulatedShape = sumOfShapes(accumulatedShape, accumulatedStaticShape);
     }
 
-    auto copied = target->clone_with_new_inputs(target->input_values());
-    copied->set_friendly_name("");
+    const auto copied = target->clone_with_new_inputs(target->input_values());
     auto outDsr = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(
             copied, accumulatedShape);
-    outDsr->set_friendly_name(copied->get_friendly_name());
+    outDsr->set_friendly_name(target->get_friendly_name());
 
     ngraph::replace_node(std::move(target), outDsr);
 }

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_gather.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_gather.cpp
@@ -40,7 +40,8 @@ void dynamicToStaticShapeGather(std::shared_ptr<ngraph::Node> target) {
     const auto data_shape = dataDSR ? dataDSR->input_value(1) : shapeToConstant(gather->input_value(0));
     const auto indices_shape = idxDSR ? idxDSR->input_value(1) : shapeToConstant(gather->input_value(1));
 
-    const auto copied = target->clone_with_new_inputs(target->input_values());
+    auto copied = target->clone_with_new_inputs(target->input_values());
+    copied->set_friendly_name("");
 
 
     const auto & data_rank = data_shape.get_partial_shape();
@@ -72,7 +73,9 @@ void dynamicToStaticShapeGather(std::shared_ptr<ngraph::Node> target) {
         output_dims.push_back(second_data_shape_part);
     }
     const auto output_shape = std::make_shared<ngraph::opset3::Concat>(output_dims, 0);
-    ngraph::replace_node(target, std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(copied, output_shape));
+    auto outDsr = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(copied, output_shape);
+    outDsr->set_friendly_name(copied->get_friendly_name());
+    ngraph::replace_node(target, outDsr);
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_gather.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_gather.cpp
@@ -40,12 +40,10 @@ void dynamicToStaticShapeGather(std::shared_ptr<ngraph::Node> target) {
     const auto data_shape = dataDSR ? dataDSR->input_value(1) : shapeToConstant(gather->input_value(0));
     const auto indices_shape = idxDSR ? idxDSR->input_value(1) : shapeToConstant(gather->input_value(1));
 
-    auto copied = target->clone_with_new_inputs(target->input_values());
-    copied->set_friendly_name("");
+    const auto copied = target->clone_with_new_inputs(target->input_values());
 
-
-    const auto & data_rank = data_shape.get_partial_shape();
-    const auto & indices_rank = indices_shape.get_partial_shape();
+    const auto& data_rank = data_shape.get_partial_shape();
+    const auto& indices_rank = indices_shape.get_partial_shape();
     VPU_THROW_UNLESS(data_rank.is_static() && indices_rank.is_static(),
             "DynamicToStaticShape transformation for {} doesn't support dynamic rank", gather);
 
@@ -74,7 +72,7 @@ void dynamicToStaticShapeGather(std::shared_ptr<ngraph::Node> target) {
     }
     const auto output_shape = std::make_shared<ngraph::opset3::Concat>(output_dims, 0);
     auto outDsr = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(copied, output_shape);
-    outDsr->set_friendly_name(copied->get_friendly_name());
+    outDsr->set_friendly_name(target->get_friendly_name());
     ngraph::replace_node(target, outDsr);
 }
 

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_nonzero.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_nonzero.cpp
@@ -21,11 +21,11 @@ void dynamicToStaticShapeNonZero(std::shared_ptr<ngraph::Node> node) {
                      node->get_friendly_name(), node->get_type_info(), ngraph::op::v3::NonZero::type_info);
 
     auto staticShapeNonZero = std::make_shared<ngraph::vpu::op::StaticShapeNonZero>(nonZero->input(0).get_source_output(), nonZero->get_output_type());
-    staticShapeNonZero->set_friendly_name(nonZero->get_friendly_name() + "/static_shape");
+    staticShapeNonZero->set_friendly_name("");
 
     auto dynamicShapeResolver = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(
         staticShapeNonZero->output(0), staticShapeNonZero->output(1));
-    dynamicShapeResolver->set_friendly_name(nonZero->get_friendly_name() + "/resolve_shape");
+    dynamicShapeResolver->set_friendly_name(nonZero->get_friendly_name());
 
     ngraph::replace_node(std::move(nonZero), std::move(dynamicShapeResolver));
 }

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_nonzero.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_nonzero.cpp
@@ -21,7 +21,6 @@ void dynamicToStaticShapeNonZero(std::shared_ptr<ngraph::Node> node) {
                      node->get_friendly_name(), node->get_type_info(), ngraph::op::v3::NonZero::type_info);
 
     auto staticShapeNonZero = std::make_shared<ngraph::vpu::op::StaticShapeNonZero>(nonZero->input(0).get_source_output(), nonZero->get_output_type());
-    staticShapeNonZero->set_friendly_name("");
 
     auto dynamicShapeResolver = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(
         staticShapeNonZero->output(0), staticShapeNonZero->output(1));

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_nonzero.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_nonzero.cpp
@@ -57,10 +57,9 @@ public:
             const auto input = std::make_shared<ngraph::opset1::Parameter>(inputType, inputShape);
 
             const auto staticShapeNonZero = std::make_shared<ngraph::vpu::op::StaticShapeNonZero>(input, resultType);
-            staticShapeNonZero->set_friendly_name(std::string(s_FriendlyName) + "/static_shape");
             const auto dynamicShapeResolver = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(
                     staticShapeNonZero->output(0), staticShapeNonZero->output(1));
-            dynamicShapeResolver->set_friendly_name(std::string(s_FriendlyName) + "/resolve_shape");
+            dynamicShapeResolver->set_friendly_name(std::string(s_FriendlyName));
 
             expected = std::make_shared<ngraph::Function>(ngraph::NodeVector{dynamicShapeResolver}, ngraph::ParameterVector{input});
         }
@@ -69,16 +68,13 @@ public:
     void compareFunctions() {
         ASSERT_NO_THROW(ngraph::helpers::CompareFunctions(*actual, *expected));
 
-        auto actualResultNode = actual->get_output_op(0);
-        auto actualResolverNode = actualResultNode->input(0).get_source_output().get_node_shared_ptr();
-        auto actualNonZeroNode = actualResolverNode->input(0).get_source_output().get_node_shared_ptr();
+        const auto actualResultNode = actual->get_output_op(0);
+        const auto actualResolverNode = actualResultNode->input(0).get_source_output().get_node_shared_ptr();
 
-        auto expectedResultNode = expected->get_output_op(0);
-        auto expectedResolverNode = expectedResultNode->input(0).get_source_output().get_node_shared_ptr();
-        auto expectedNonZeroNode = expectedResolverNode->input(0).get_source_output().get_node_shared_ptr();
+        const auto expectedResultNode = expected->get_output_op(0);
+        const auto expectedResolverNode = expectedResultNode->input(0).get_source_output().get_node_shared_ptr();
 
         EXPECT_EQ(actualResolverNode->get_friendly_name(), expectedResolverNode->get_friendly_name());
-        EXPECT_EQ(actualNonZeroNode->get_friendly_name(), expectedNonZeroNode->get_friendly_name());
     }
 
 protected:


### PR DESCRIPTION
## Task

#-31385

## Description

Enables operations names handling in DTS transformations. It's required to keep outputs names the same as in original model. It's important because end-user has access only to the output names from original model, so he will use it to access inference result. This way, plugin in order to be able to return correct output blobs must keep that information consistent.

Updated DTS:

* NonZero
* Broadcast
* Concat
* Gather

It's enough to enable Faster-RCNN inference on VPU. Original commits has been cherry-picked from internal branch of @rvyunov and then fixes have been applied.