### PR TITLE
[IE CLDNN] Fixed benchmark_app fails with 3221225725

### DIFF
--- a/inference-engine/thirdparty/clDNN/src/program.cpp
+++ b/inference-engine/thirdparty/clDNN/src/program.cpp
@@ -375,6 +375,11 @@ void program_impl::build_program(bool is_internal) {
 void program_impl::init_graph() {
     apply_opt_pass<graph_initializations>();
 
+    for (auto& node : processing_order) {
+        if (!node->is_type<internal_primitive>() && !node->is_type<data>())
+            node->get_output_layout();
+    }
+
     apply_opt_pass<calculate_prior_boxes>();
 
     apply_opt_pass<mark_nodes>();


### PR DESCRIPTION
[IE CLDNN] The problem behind this error was in program_impl::init_graph() where in calculate_prior_boxes we are trying to calculate output layout of an entire network recursively which causes stack overflow. Calculating output layouts beforehand in processing order fixes this issue.

Jira: CVS-31697