### PR TITLE
[IE VPU] Avoid duplicate data during reshapeDilation

### DIFF
--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/reshape_dilation_conv.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/reshape_dilation_conv.cpp
@@ -305,16 +305,8 @@ void PassImpl::run(const Model& model) {
         DataVector V_Sub_outputdata;
         std::vector<DimValues> V_Sub_outputdatasOffsets;
 
-        DataVector V_newWeights;
-        DataVector V_newbiases;
-        DataVector V_newscales;
-
         V_Sub_inputdata.reserve(Sub_output_dilationX_dimenion * Sub_output_dilationY_dimenion);
         V_Sub_inputdatasOffsets.reserve(Sub_output_dilationX_dimenion * Sub_output_dilationY_dimenion);
-
-        V_newWeights.reserve(Sub_output_dilationX_dimenion * Sub_output_dilationY_dimenion);
-        V_newbiases.reserve(Sub_output_dilationX_dimenion * Sub_output_dilationY_dimenion);
-        V_newscales.reserve(Sub_output_dilationX_dimenion * Sub_output_dilationY_dimenion);
 
         V_Sub_outputdata.reserve(Sub_output_dilationX_dimenion * Sub_output_dilationY_dimenion);
         V_Sub_outputdatasOffsets.reserve(Sub_output_dilationX_dimenion * Sub_output_dilationY_dimenion);
@@ -346,18 +338,6 @@ void PassImpl::run(const Model& model) {
 
                 V_Sub_outputdata.emplace_back(Real_sub_outputdata);
                 V_Sub_outputdatasOffsets.emplace_back(Sub_outputdatasOffsets);
-
-                // reuse weights and biases and scales
-                auto newWeights = model->duplicateData(weights, "@NewWeights",
-                        weights->desc());
-                auto newbiases = model->duplicateData(biases, "@Newbiases",
-                        biases->desc());
-                auto newscales = model->duplicateData(scales, "@Newscales",
-                        scales->desc());
-
-                V_newWeights.emplace_back(newWeights);
-                V_newbiases.emplace_back(newbiases);
-                V_newscales.emplace_back(newscales);
             }
         }
 
@@ -382,9 +362,9 @@ void PassImpl::run(const Model& model) {
                     stage->origLayerName() + "@SubDataConv",
                     StageType::StubConv, stage->origLayer(), {
                             V_Sub_inputdata[Sub_output_XInd * Sub_output_dilationY_dimenion + Sub_output_YInd],
-                            V_newWeights[Sub_output_XInd * Sub_output_dilationY_dimenion + Sub_output_YInd],
-                            V_newbiases[Sub_output_XInd * Sub_output_dilationY_dimenion + Sub_output_YInd],
-                            V_newscales[Sub_output_XInd * Sub_output_dilationY_dimenion + Sub_output_YInd] }, { Sub_outputdata });
+                            weights,
+                            biases,
+                            scales }, { Sub_outputdata });
 
             newStage->attrs().set<int>("kernelSizeX", kernelSizeX);
             newStage->attrs().set<int>("kernelSizeY", kernelSizeY);


### PR DESCRIPTION
Weights, biases and scales are all duplicates for sub-convolutions, which makes the blob unnecessarily large. Use only one duplicate instead.

Also, currently hwDilation is disabled by default. Any reason for that?

Ticket #-32508