### PR TITLE
[IE VPU] Disable Hw Avg Pooling for small output tensors if excludePad=true

### DIFF
--- a/inference-engine/src/vpu/graph_transformer/src/stages/pooling.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/pooling.cpp
@@ -117,11 +117,12 @@ bool canTryHW(const ie::PoolingLayer::PoolType poolType,
     }
 
     //  FIX #14949, enable HW AVG pooling, need SW postproc
-    if (excludePad && poolType == ie::PoolingLayer::PoolType::AVG) {
-        if (outputWidth == 5 &&
-            outputHeight == 5 &&
-            kernelSizeX == 5 &&
-            kernelSizeY == 5) {
+    //  HW AVG pooling will output wrong results in borders when excludePad=true
+    bool hasPad = padLeft || padTop || padRight || padBottom;
+    if (excludePad && hasPad && poolType == ie::PoolingLayer::PoolType::AVG) {
+        // Only apply to small output tensors for now
+        // May need to loose the condition if accuracy issues are met
+        if (outputWidth <= 5 && outputHeight <= 5) {
             tryHW = false;
         }
     }


### PR DESCRIPTION
When excludePad is set true, Hw Avg Pooling will output wrong values in borders.
For large pooling, the wrong values in borders may not impact the final results.
For small pooling like ones whose output dimension is 2x2, the wrong values in borders cannot be ignored