### PR TITLE
Added default value for the attribute 'aligned' 

### DIFF
--- a/inference-engine/src/mkldnn_plugin/nodes/roifeatureextractor_onnx.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/roifeatureextractor_onnx.cpp
@@ -323,7 +323,7 @@ public:
             output_dim_ = layer->GetParamAsInt("output_size");
             pyramid_scales_ = layer->GetParamAsInts("pyramid_scales");
             sampling_ratio_ = layer->GetParamAsInt("sampling_ratio");
-            aligned_ = layer->GetParamAsBool("aligned");
+            aligned_ = layer->GetParamAsBool("aligned", false);
             pooled_height_ = output_dim_;
             pooled_width_ = output_dim_;
 


### PR DESCRIPTION
Added default value for the attribute 'aligned' in the ExperimentalDetectronROIFeatureExtractor for backward compatibility.