### PR TITLE
Show error message if output file is not writable

### DIFF
--- a/inference-engine/tools/compile_tool/main.cpp
+++ b/inference-engine/tools/compile_tool/main.cpp
@@ -351,7 +351,12 @@ int main(int argc, char *argv[]) {
             outputName = getFileNameFromPath(fileNameNoExt(FLAGS_m)) + ".blob";
         }
         std::ofstream outputFile{outputName};
-        executableNetwork.Export(outputFile);
+        if (!outputFile) {
+            std::cout << "Output file " << outputName << " can't be opened for writing" << std::endl;
+            return EXIT_FAILURE;
+        } else {
+            executableNetwork.Export(outputFile);
+        }
     } catch (const std::exception &error) {
         std::cerr << error.what() << std::endl;
         return EXIT_FAILURE;


### PR DESCRIPTION
We should show error message and return error status instead of silently swallow error