### PR TITLE
[VPU] Update DTS transformations to keep ngraph ops names

### DIFF
--- a/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_binary_elementwise.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_binary_elementwise.cpp
@@ -44,7 +44,9 @@ void dynamicToStaticShapeBinaryEltwise(std::shared_ptr<ngraph::Node> eltwise) {
     }
 
     const auto shape = std::make_shared<ngraph::opset3::Maximum>(lhsInput, rhsInput);
-    ngraph::replace_node(std::move(eltwise), std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(copied, shape));
+    auto outDsr = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(copied, shape);
+    outDsr->set_friendly_name(eltwise->get_friendly_name());
+    ngraph::replace_node(std::move(eltwise), outDsr);
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_reduce.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_reduce.cpp
@@ -66,6 +66,8 @@ void dynamicToStaticShapeReduce(std::shared_ptr<ngraph::Node> target) {
                 ngraph::opset3::Constant::create(ngraph::element::i64, {1}, {0}));
     }
     const auto copied = target->clone_with_new_inputs(target->input_values());
-    ngraph::replace_node(target, std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(copied, output_shape));
+    const auto outDsr = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(copied, output_shape);
+    outDsr->set_friendly_name(target->get_friendly_name());
+    ngraph::replace_node(target, outDsr);
 }
 }  // namespace vpu

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_reshape.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_reshape.cpp
@@ -33,8 +33,9 @@ void dynamicToStaticShapeReshape(std::shared_ptr<ngraph::Node> target) {
     const auto outShapeOfReshape = std::make_shared<ngraph::vpu::op::OutShapeOfReshape>(
             inDataShape, outShapeDescriptor, reshape->get_special_zero());
 
-    ngraph::replace_node(std::move(target), std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(
-            copied, outShapeOfReshape));
+    auto outDsr = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(copied, outShapeOfReshape);
+    outDsr->set_friendly_name(target->get_friendly_name());
+    ngraph::replace_node(std::move(target), outDsr);
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_roialign.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_roialign.cpp
@@ -49,7 +49,9 @@ void dynamicToStaticShapeROIAlign(std::shared_ptr<ngraph::Node> target) {
             ngraph::OutputVector{num_rois, c, pooled_h, pooled_w}, 0);
 
     const auto copied = target->clone_with_new_inputs(target->input_values());
-    ngraph::replace_node(target, std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(copied, output_shape));
+    auto outDsr = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(copied, output_shape);
+    outDsr->set_friendly_name(target->get_friendly_name());
+    ngraph::replace_node(target, outDsr);
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_squeeze.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_squeeze.cpp
@@ -53,7 +53,9 @@ void dynamicToStaticShapeSqueeze(std::shared_ptr<ngraph::Node> target) {
     const auto axis = std::make_shared<ngraph::opset3::Constant>(
             ngraph::element::i64, ngraph::Shape{1}, std::vector<int64_t>{0});
     const auto squeeze_output_shape = std::make_shared<ngraph::opset3::Gather>(shape, index, axis);
-    ngraph::replace_node(std::move(target), std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(copied, squeeze_output_shape));
+    auto outDsr = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(copied, squeeze_output_shape);
+    outDsr->set_friendly_name(target->get_friendly_name());
+    ngraph::replace_node(std::move(target), outDsr);
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_strided_slice.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_strided_slice.cpp
@@ -137,7 +137,9 @@ void dynamicToStaticShapeStridedSlice(std::shared_ptr<ngraph::Node> target) {
             input_shape);
 
     const auto copied = ss->clone_with_new_inputs(target->input_values());
-    ngraph::replace_node(std::move(target), std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(copied, output_shape));
+    auto outDsr = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(copied, output_shape);
+    outDsr->set_friendly_name(target->get_friendly_name());
+    ngraph::replace_node(std::move(target), outDsr);
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_transpose.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_transpose.cpp
@@ -34,7 +34,9 @@ void dynamicToStaticShapeTranspose(std::shared_ptr<ngraph::Node> target) {
         ngraph::Shape{std::initializer_list<std::size_t>{1}},
         std::vector<std::int64_t>{0});
     const auto scatterElementsUpdate = std::make_shared<ngraph::opset3::ScatterElementsUpdate>(shape, transposition, shape, axis);
-    ngraph::replace_node(std::move(target), std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(copied, scatterElementsUpdate));
+    auto outDsr = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(copied, scatterElementsUpdate);
+    outDsr->set_friendly_name(target->get_friendly_name());
+    ngraph::replace_node(std::move(target), outDsr);
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_unary_elementwise.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_unary_elementwise.cpp
@@ -22,7 +22,9 @@ void dynamicToStaticUnaryElementwise(std::shared_ptr<ngraph::Node> target) {
 
     const auto shape = dsr->input(1).get_source_output();
     const auto copied = target->clone_with_new_inputs(target->input_values());
-    ngraph::replace_node(target, std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(copied, shape));
+    auto outDsr = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(copied, shape);
+    outDsr->set_friendly_name(target->get_friendly_name());
+    ngraph::replace_node(target, outDsr);
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_unsqueeze.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_unsqueeze.cpp
@@ -58,7 +58,9 @@ void dynamicToStaticShapeUnsqueeze(std::shared_ptr<ngraph::Node> target) {
         new_shape_dims.insert(new_shape_dims.begin() + i, new_dim);
     }
     const auto unsqueeze_output_shape = std::make_shared<ngraph::opset3::Concat>(new_shape_dims, 0);
-    ngraph::replace_node(std::move(target), std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(copied, unsqueeze_output_shape));
+    auto outDsr = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(copied, unsqueeze_output_shape);
+    outDsr->set_friendly_name(target->get_friendly_name());
+    ngraph::replace_node(std::move(target), outDsr);
 }
 
 }  // namespace vpu


### PR DESCRIPTION
Task #-31385

Naming in outputs of DTS transformations has been updated:
* BinaryEltwise
* Reshape
* ROIAlign
* Squeeze
* StridedSlice
* Transpose
* UnaryEltwise
* Unsqueeze
* Reduce