### PR TITLE
Fix samples build script

### DIFF
--- a/inference-engine/samples/build_samples_msvc.bat
+++ b/inference-engine/samples/build_samples_msvc.bat
@@ -88,8 +88,9 @@ if !VSWHERE! == "true" (
          )
       )
    )
-   if exist "!VS_PATH!\MSBuild\14.0\Bin\MSBuild.exe" (
-      set "MSBUILD_BIN=!VS_PATH!\MSBuild\14.0\Bin\MSBuild.exe"
+   if exist "C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" (
+      set "MSBUILD_BIN=C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe"
+      set "MSBUILD_VERSION=14 2015"
    )
    if exist "!VS_PATH!\MSBuild\15.0\Bin\MSBuild.exe" (
       set "MSBUILD_BIN=!VS_PATH!\MSBuild\15.0\Bin\MSBuild.exe"


### PR DESCRIPTION
Fixed samples build script for Windows. 
Before script can not find visual studio 2015 on Windows 10.