### PR TITLE
[IE CLDNN] Added 6d tensor support in eltwise/scale primitives

### DIFF
--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/eltwise.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/eltwise.cpp
@@ -20,8 +20,8 @@ std::vector<std::vector<std::vector<size_t>>> inShapes = {
         {{1, 2, 4}},
         {{1, 4, 4}},
         {{1, 4, 4, 1}},
-        {{1, 1, 1, 1, 1, 1, 3}},
-        {{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}}
+        {{1, 4, 3, 2, 1, 3}},
+        {{1, 3, 1, 1, 1, 3}, {1, 3, 1, 1, 1, 1}},
 };
 
 std::vector<InferenceEngine::Precision> netPrecisions = {
@@ -53,7 +53,7 @@ const auto multiply_params = ::testing::Combine(
         ::testing::ValuesIn(secondaryInputTypes),
         ::testing::ValuesIn(opTypes),
         ::testing::ValuesIn(netPrecisions),
-        ::testing::Values(CommonTestUtils::DEVICE_CPU),
+        ::testing::Values(CommonTestUtils::DEVICE_GPU),
         ::testing::Values(additional_config));
 
 INSTANTIATE_TEST_CASE_P(CompareWithRefs, EltwiseLayerTest, multiply_params, EltwiseLayerTest::getTestCaseName);

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/skip_tests_config.cpp
@@ -9,6 +9,8 @@
 
 std::vector<std::string> disabledTestPatterns() {
     return {
-            R"(.*(EltwiseLayerTest).*IS=\(.*\..*\..*\..*\..*\).*secondaryInputType=PARAMETER.*opType=SCALAR.*)",
+            // cldnn treats 1d constant as [1, f, 1, 1] tensor instead of [b, 1, 1, 1] which leads to fails of these tests
+            R"(.*(EltwiseLayerTest).*IS=\(.*\..*\..*\..*\..*\).*secondaryInputType=CONSTANT.*opType=SCALAR.*)",
+            R"(.*(EltwiseLayerTest).*IS=\(.*\).*secondaryInputType=CONSTANT.*)",
     };
 }

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/permute/permute_kernel_ref.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/permute/permute_kernel_ref.cpp
@@ -52,6 +52,7 @@ JitConstants PermuteKernelRef::GetJitConstants(const permute_params& params) con
         default: in_idx = {"b", "f", "x", "y" }; break;
     }
 
+    assert(params.order.size() == in_idx.size());
     for (auto& o : params.order) {
         out_idx.push_back(in_idx[o]);
     }

--- a/inference-engine/thirdparty/clDNN/src/gpu/eltwise_gpu.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/eltwise_gpu.cpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2019 Intel Corporation
+// Copyright (c) 2019-2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -255,6 +255,13 @@ attach_eltwise_gpu::attach_eltwise_gpu() {
          { std::make_tuple(engine_types::ocl, data_types::u8, format::bfzyx), eltwise_gpu::create },
          { std::make_tuple(engine_types::ocl, data_types::i32, format::bfzyx), eltwise_gpu::create },
          { std::make_tuple(engine_types::ocl, data_types::i64, format::bfzyx), eltwise_gpu::create },
+         // 4D
+         { std::make_tuple(engine_types::ocl, data_types::f32, format::bfwzyx), eltwise_gpu::create },
+         { std::make_tuple(engine_types::ocl, data_types::f16, format::bfwzyx), eltwise_gpu::create },
+         { std::make_tuple(engine_types::ocl, data_types::i8, format::bfwzyx), eltwise_gpu::create },
+         { std::make_tuple(engine_types::ocl, data_types::u8, format::bfwzyx), eltwise_gpu::create },
+         { std::make_tuple(engine_types::ocl, data_types::i32, format::bfwzyx), eltwise_gpu::create },
+         { std::make_tuple(engine_types::ocl, data_types::i64, format::bfwzyx), eltwise_gpu::create },
 
          { std::make_tuple(engine_types::ocl, data_types::f32, format::b_fs_zyx_fsv16), eltwise_gpu::create },
          { std::make_tuple(engine_types::ocl, data_types::f16, format::b_fs_zyx_fsv16), eltwise_gpu::create },

--- a/inference-engine/thirdparty/clDNN/src/gpu/scale_gpu.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/scale_gpu.cpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2016-2019 Intel Corporation
+// Copyright (c) 2016-2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -97,6 +97,11 @@ attach_scale_gpu::attach_scale_gpu() {
     implementation_map<scale>::add(std::make_tuple(engine_types::ocl, data_types::f16, format::bfzyx), val_fw);
     implementation_map<scale>::add(std::make_tuple(engine_types::ocl, data_types::u8, format::bfzyx), val_fw);
     implementation_map<scale>::add(std::make_tuple(engine_types::ocl, data_types::i8, format::bfzyx), val_fw);
+
+    implementation_map<scale>::add(std::make_tuple(engine_types::ocl, data_types::f32, format::bfwzyx), val_fw);
+    implementation_map<scale>::add(std::make_tuple(engine_types::ocl, data_types::f16, format::bfwzyx), val_fw);
+    implementation_map<scale>::add(std::make_tuple(engine_types::ocl, data_types::u8, format::bfwzyx), val_fw);
+    implementation_map<scale>::add(std::make_tuple(engine_types::ocl, data_types::i8, format::bfwzyx), val_fw);
 
     implementation_map<scale>::add(std::make_tuple(engine_types::ocl, data_types::f32, format::b_fs_yx_fsv16), val_fw);
     implementation_map<scale>::add(std::make_tuple(engine_types::ocl, data_types::f16, format::b_fs_yx_fsv16), val_fw);

--- a/inference-engine/thirdparty/clDNN/tests/test_utils/test_utils.h
+++ b/inference-engine/thirdparty/clDNN/tests/test_utils/test_utils.h
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2016-2019 Intel Corporation
+// Copyright (c) 2016-2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -121,6 +121,33 @@ inline VF<T> flatten_4d(cldnn::format input_format, VVVVF<T> &data) {
                             vec[idx++] = data[bi][fi][yi][xi];
             break;
 
+        default:
+            assert(0);
+    }
+    return vec;
+}
+
+template<typename T>
+inline VF<T> flatten_6d(cldnn::format input_format, VVVVVVF<T> &data) {
+    size_t a = data.size();
+    size_t b = data[0].size();
+    size_t c = data[0][0].size();
+    size_t d = data[0][0][0].size();
+    size_t e = data[0][0][0][0].size();
+    size_t f = data[0][0][0][0][0].size();
+    VF<T> vec(a * b * c * d * e * f, (T)(0.0f));
+    size_t idx = 0;
+
+    switch (input_format.value) {
+        case cldnn::format::bfwzyx:
+            for (size_t bi = 0; bi < a; ++bi)
+                for (size_t fi = 0; fi < b; ++fi)
+                    for (size_t wi = 0; wi < c; ++wi)
+                        for (size_t zi = 0; zi < d; ++zi)
+                            for (size_t yi = 0; yi < e; ++yi)
+                                for (size_t xi = 0; xi < f; ++xi)
+                                    vec[idx++] = data[bi][fi][wi][zi][yi][xi];
+            break;
         default:
             assert(0);
     }


### PR DESCRIPTION
- Added 6d tensors support in eltwise/scale primitives
- Fixed crash on several quantized models
- Fixed eltwise func tests for gpu plugin.