### PR TITLE
Fix preserving names of output layers after TopK NGraph transformation

### DIFF
--- a/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_topk_to_topk_ie.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_topk_to_topk_ie.cpp
@@ -50,13 +50,13 @@ void ngraph::pass::ConvertTopKToTopKIE::convert_topk_to_topk_ie() {
             index_output = topk_ie->output(1);
             topk_ie->set_friendly_name(topk->get_friendly_name());
         } else {
-            // create fake convert for 0 output in purpose of correct output names preserving
+            // create fake convert for 0 output, it is a workaround in purpose of correct output names preserving
             element_output = std::make_shared<opset1::Convert>(topk_ie->output(0), topk->get_output_element_type(0));
             index_output = std::make_shared<opset1::Convert>(topk_ie->output(1), topk->get_index_element_type());
             new_ops.push_back(element_output.get_node_shared_ptr());
             new_ops.push_back(index_output.get_node_shared_ptr());
 
-            topk_ie->set_friendly_name(topk->get_friendly_name() + "_before");
+            // workaround for naming two outputs of TopK
             element_output.get_node_shared_ptr()->set_friendly_name(topk->get_friendly_name() + ".0");
             index_output.get_node_shared_ptr()->set_friendly_name(topk->get_friendly_name() + ".1");
         }

--- a/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_topk_to_topk_ie.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_topk_to_topk_ie.cpp
@@ -44,11 +44,17 @@ void ngraph::pass::ConvertTopKToTopKIE::convert_topk_to_topk_ie() {
 
         Output<Node> element_output;
         Output<Node> index_output;
-        // insert Convert if index element type not equal to i32
-        if (topk->get_index_element_type() == element::i32) {
+        // insert Convert if index element type not equal to i32 and output #1 of TopK has consumers
+        if (topk->get_index_element_type() == element::i32 || topk->get_output_target_inputs(1).size() == 0) {
             element_output = topk_ie->output(0);
             index_output = topk_ie->output(1);
             topk_ie->set_friendly_name(topk->get_friendly_name());
+        } else if (topk->get_output_target_inputs(0).size() == 0) {
+            index_output = std::make_shared<opset1::Convert>(topk_ie->output(1), topk->get_index_element_type());
+            new_ops.push_back(index_output.get_node_shared_ptr());
+
+            // workaround for naming output #1 of TopK
+            index_output.get_node_shared_ptr()->set_friendly_name(topk->get_friendly_name() + ".1");
         } else {
             // create fake convert for 0 output, it is a workaround in purpose of correct output names preserving
             element_output = std::make_shared<opset1::Convert>(topk_ie->output(0), topk->get_output_element_type(0));

--- a/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_topk_to_topk_ie.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_topk_to_topk_ie.cpp
@@ -42,18 +42,27 @@ void ngraph::pass::ConvertTopKToTopKIE::convert_topk_to_topk_ie() {
                                                              topk->get_sort_type());
         new_ops.push_back(topk_ie);
 
+        Output<Node> element_output;
         Output<Node> index_output;
         // insert Convert if index element type not equal to i32
         if (topk->get_index_element_type() == element::i32) {
+            element_output = topk_ie->output(0);
             index_output = topk_ie->output(1);
+            topk_ie->set_friendly_name(topk->get_friendly_name());
         } else {
+            // create fake convert for 0 output in purpose of correct output names preserving
+            element_output = std::make_shared<opset1::Convert>(topk_ie->output(0), topk->get_output_element_type(0));
             index_output = std::make_shared<opset1::Convert>(topk_ie->output(1), topk->get_index_element_type());
+            new_ops.push_back(element_output.get_node_shared_ptr());
             new_ops.push_back(index_output.get_node_shared_ptr());
+
+            topk_ie->set_friendly_name(topk->get_friendly_name() + "_before");
+            element_output.get_node_shared_ptr()->set_friendly_name(topk->get_friendly_name() + ".0");
+            index_output.get_node_shared_ptr()->set_friendly_name(topk->get_friendly_name() + ".1");
         }
 
-        topk_ie->set_friendly_name(topk->get_friendly_name());
         ngraph::copy_runtime_info(topk, new_ops);
-        topk->output(0).replace(topk_ie->output(0));
+        topk->output(0).replace(element_output);
         topk->output(1).replace(index_output);
         return true;
     };

--- a/inference-engine/src/transformations/src/transformations/convert_opset3_to_opset2/convert_topk3.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_opset3_to_opset2/convert_topk3.cpp
@@ -27,11 +27,18 @@ void ngraph::pass::ConvertTopK3::convert_topk3() {
         auto new_topk = std::make_shared<ngraph::opset2::TopK>(topk->input_value(0), topk->input_value(1),
                 topk->get_axis(), topk->get_mode(), topk->get_sort_type(), element::i32);
         new_ops.push_back(new_topk);
-        // if the output is the i32 then it matches behavior of the v1::TopK otherwise need to insert Convert
-        if (topk->get_index_element_type() == element::i32) {
+        // if the output is the i32 or output #1 has no consumers
+        // then it matches behavior of the v1::TopK otherwise need to insert Convert
+        if (topk->get_index_element_type() == element::i32 || topk->get_output_target_inputs(1).size() == 0) {
             last0 = new_topk->output(0);
             last1 = new_topk->output(1);
             new_topk->set_friendly_name(topk->get_friendly_name());
+        } else if (topk->get_output_target_inputs(0).size() == 0) {
+            last1 = std::make_shared<ngraph::opset2::Convert>(new_topk->output(1), topk->get_index_element_type());
+            new_ops.push_back(last1.get_node_shared_ptr());
+
+            // workaround for naming two outputs of TopK
+            last1.get_node_shared_ptr()->set_friendly_name(topk->get_friendly_name() + ".1");
         } else {
             // create fake convert for 0 output, it is a workaround in purpose of correct output names preserving
             last0 = std::make_shared<ngraph::opset2::Convert>(new_topk->output(0), topk->get_output_element_type(0));

--- a/inference-engine/src/transformations/src/transformations/convert_opset3_to_opset2/convert_topk3.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_opset3_to_opset2/convert_topk3.cpp
@@ -33,13 +33,13 @@ void ngraph::pass::ConvertTopK3::convert_topk3() {
             last1 = new_topk->output(1);
             new_topk->set_friendly_name(topk->get_friendly_name());
         } else {
-            // create fake convert for 0 output in purpose of correct output names preserving
+            // create fake convert for 0 output, it is a workaround in purpose of correct output names preserving
             last0 = std::make_shared<ngraph::opset2::Convert>(new_topk->output(0), topk->get_output_element_type(0));
             last1 = std::make_shared<ngraph::opset2::Convert>(new_topk->output(1), topk->get_index_element_type());
             new_ops.push_back(last0.get_node_shared_ptr());
             new_ops.push_back(last1.get_node_shared_ptr());
 
-            new_topk->set_friendly_name(topk->get_friendly_name() + "_before");
+            // workaround for naming two outputs of TopK
             last0.get_node_shared_ptr()->set_friendly_name(topk->get_friendly_name() + ".0");
             last1.get_node_shared_ptr()->set_friendly_name(topk->get_friendly_name() + ".1");
         }

--- a/inference-engine/src/transformations/src/transformations/convert_opset3_to_opset2/convert_topk3.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_opset3_to_opset2/convert_topk3.cpp
@@ -20,7 +20,8 @@ void ngraph::pass::ConvertTopK3::convert_topk3() {
         if (!topk) {
             return false;
         }
-        Output<Node> last;
+        Output<Node> last0;
+        Output<Node> last1;
         ngraph::NodeVector new_ops;
 
         auto new_topk = std::make_shared<ngraph::opset2::TopK>(topk->input_value(0), topk->input_value(1),
@@ -28,16 +29,24 @@ void ngraph::pass::ConvertTopK3::convert_topk3() {
         new_ops.push_back(new_topk);
         // if the output is the i32 then it matches behavior of the v1::TopK otherwise need to insert Convert
         if (topk->get_index_element_type() == element::i32) {
-            last = new_topk->output(1);
+            last0 = new_topk->output(0);
+            last1 = new_topk->output(1);
+            new_topk->set_friendly_name(topk->get_friendly_name());
         } else {
-            last = std::make_shared<ngraph::opset2::Convert>(new_topk->output(1), topk->get_index_element_type());
-            new_ops.push_back(last.get_node_shared_ptr());
+            // create fake convert for 0 output in purpose of correct output names preserving
+            last0 = std::make_shared<ngraph::opset2::Convert>(new_topk->output(0), topk->get_output_element_type(0));
+            last1 = std::make_shared<ngraph::opset2::Convert>(new_topk->output(1), topk->get_index_element_type());
+            new_ops.push_back(last0.get_node_shared_ptr());
+            new_ops.push_back(last1.get_node_shared_ptr());
+
+            new_topk->set_friendly_name(topk->get_friendly_name() + "_before");
+            last0.get_node_shared_ptr()->set_friendly_name(topk->get_friendly_name() + ".0");
+            last1.get_node_shared_ptr()->set_friendly_name(topk->get_friendly_name() + ".1");
         }
 
-        new_topk->set_friendly_name(topk->get_friendly_name());
         ngraph::copy_runtime_info(topk, new_ops);
-        topk->output(0).replace(new_topk->output(0));
-        topk->output(1).replace(last);
+        topk->output(0).replace(last0);
+        topk->output(1).replace(last1);
         return true;
     };
 

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_topk3_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_topk3_test.cpp
@@ -111,19 +111,18 @@ TEST(TransformationTests, ConvertTopK3I64Output0) {
         auto input = std::make_shared<ngraph::opset3::Parameter>(ngraph::element::f32, ngraph::Shape{15, 20, 3});
         auto k = ngraph::opset3::Constant::create(ngraph::element::i64, ngraph::Shape{}, {10});
         auto topk = std::make_shared<ngraph::opset2::TopK>(input, k, 1, "min", "value", ngraph::element::i32);
-        auto convert = std::make_shared<ngraph::opset2::Convert>(topk->output(0), ngraph::element::i32);
-        convert->set_friendly_name("topk.0");
+        topk->set_friendly_name("topk");
 
         // due to the 'compare_functions' limitation we will check only one output
-        f_ref = std::make_shared<ngraph::Function>(ngraph::OutputVector{convert->output(0)}, ngraph::ParameterVector{input});
+        f_ref = std::make_shared<ngraph::Function>(ngraph::OutputVector{topk->output(0)}, ngraph::ParameterVector{input});
     }
 
     auto res = compare_functions(f, f_ref);
     ASSERT_TRUE(res.first) << res.second;
 
     auto result_node_of_converted_f = f->get_output_op(0);
-    auto convert_node = result_node_of_converted_f->input(0).get_source_output().get_node_shared_ptr();
-    ASSERT_TRUE(convert_node->get_friendly_name() == "topk.0") << "Transformation ConvertTopK3 should keep output names.\n";
+    auto topk_node = result_node_of_converted_f->input(0).get_source_output().get_node_shared_ptr();
+    ASSERT_TRUE(topk_node->get_friendly_name() == "topk") << "Transformation ConvertTopK3 should keep output names.\n";
 }
 
 // check that the second output from the TopK-3 with I64 output indices is equal to the TopK-1 second output converted to I64
@@ -158,5 +157,6 @@ TEST(TransformationTests, ConvertTopK3I64Output1) {
     ASSERT_TRUE(res.first) << res.second;
 
     auto result_node_of_converted_f = f->get_output_op(0);
-    auto topk_node = result_node_of_converted_f->input(0).get_source_output().get_node_shared_ptr();
+    auto convert_node = result_node_of_converted_f->input(0).get_source_output().get_node_shared_ptr();
+    ASSERT_TRUE(convert_node->get_friendly_name() == "topk.1") << "Transformation ConvertTopK3 should keep output names.\n";
 }

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_topk3_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_topk3_test.cpp
@@ -111,18 +111,19 @@ TEST(TransformationTests, ConvertTopK3I64Output0) {
         auto input = std::make_shared<ngraph::opset3::Parameter>(ngraph::element::f32, ngraph::Shape{15, 20, 3});
         auto k = ngraph::opset3::Constant::create(ngraph::element::i64, ngraph::Shape{}, {10});
         auto topk = std::make_shared<ngraph::opset2::TopK>(input, k, 1, "min", "value", ngraph::element::i32);
-        topk->set_friendly_name("topk");
+        auto convert = std::make_shared<ngraph::opset2::Convert>(topk->output(0), ngraph::element::i32);
+        convert->set_friendly_name("topk.0");
 
         // due to the 'compare_functions' limitation we will check only one output
-        f_ref = std::make_shared<ngraph::Function>(ngraph::OutputVector{topk->output(0)}, ngraph::ParameterVector{input});
+        f_ref = std::make_shared<ngraph::Function>(ngraph::OutputVector{convert->output(0)}, ngraph::ParameterVector{input});
     }
 
     auto res = compare_functions(f, f_ref);
     ASSERT_TRUE(res.first) << res.second;
 
     auto result_node_of_converted_f = f->get_output_op(0);
-    auto topk_node = result_node_of_converted_f->input(0).get_source_output().get_node_shared_ptr();
-    ASSERT_TRUE(topk_node->get_friendly_name() == "topk") << "Transformation ConvertTopK3 should keep output names.\n";
+    auto convert_node = result_node_of_converted_f->input(0).get_source_output().get_node_shared_ptr();
+    ASSERT_TRUE(convert_node->get_friendly_name() == "topk.0") << "Transformation ConvertTopK3 should keep output names.\n";
 }
 
 // check that the second output from the TopK-3 with I64 output indices is equal to the TopK-1 second output converted to I64


### PR DESCRIPTION
It helps to infer semantic-segmentation-adas-0001 model. See CVS-31977.

Signed-off-by: Roman Kazantsev <roman.kazantsev@intel.com>