### PR TITLE
[IE VPU] Enable variable number of inputs for ExpPriorGridGenerator

### DIFF
--- a/inference-engine/tests_deprecated/functional/vpu/common/layers/myriad_layers_exp_priorgridgenerator_test.cpp
+++ b/inference-engine/tests_deprecated/functional/vpu/common/layers/myriad_layers_exp_priorgridgenerator_test.cpp
@@ -4,8 +4,20 @@
 
 #include "myriad_layers_exp_priorgridgenerator_test.hpp"
 
-INSTANTIATE_TEST_CASE_P(accuracy, myriadLayersTestsExpPriorGridGenerator_smoke,
+INSTANTIATE_TEST_CASE_P(accuracy, myriadLayersTestsExpPriorGridGeneratorAllInputs_smoke,
     ::testing::Combine(
         ::testing::ValuesIn(s_ExpPriorGridGeneratorLayerInputs),
         ::testing::ValuesIn(s_ExpPriorGridGeneratorLayerParam))
+);
+
+INSTANTIATE_TEST_CASE_P(accuracy, myriadLayersTestsExpPriorGridGeneratorNoFeatureMap_smoke,
+    ::testing::Combine(
+        ::testing::ValuesIn(s_ExpPriorGridGenLayerNoFMInputs),
+        ::testing::ValuesIn(s_ExpPriorGridGenLayerNoFMParam))
+);
+
+INSTANTIATE_TEST_CASE_P(accuracy, myriadLayersTestsExpPriorGridGeneratorNoInputImage_smoke,
+    ::testing::Combine(
+        ::testing::ValuesIn(s_ExpPriorGridGenLayerNoInputImage),
+        ::testing::ValuesIn(s_ExpPriorGridGenLayerNoInputImageParam))
 );

--- a/inference-engine/tests_deprecated/functional/vpu/common/layers/myriad_layers_exp_priorgridgenerator_test.hpp
+++ b/inference-engine/tests_deprecated/functional/vpu/common/layers/myriad_layers_exp_priorgridgenerator_test.hpp
@@ -11,6 +11,10 @@ using namespace InferenceEngine;
 #define NUM_ELEMS_PRIORS (4)
 #define ERROR_BOUND (2.5e-3f)
 
+extern const char ALL_INPUTS[] = "all_inputs";
+extern const char MISSING_FEATURE_MAP[] = "no_feature_map";
+extern const char MISSING_INPUT_IMAGE[] = "no_input_image";
+
 struct PriorGridGeneratorParam {
     int               flatten;
     int               grid_w;
@@ -42,102 +46,138 @@ struct InputDims {
 
 using ExpPriorGridGeneratorTestParams = std::tuple<InputDims, PriorGridGeneratorParam>;
 
-typedef myriadLayerTestBaseWithParam<ExpPriorGridGeneratorTestParams> myriadLayersTestsExpPriorGridGenerator_smoke;
+template <const char* InputsAvailable>
+class myriadLayersTestsExpPriorGridGen : public myriadLayerTestBaseWithParam<ExpPriorGridGeneratorTestParams> {
+    protected:
+        void genPriors(InferenceEngine::Blob::Ptr rois,
+                       const int width,
+                       const int height,
+                       const uint32_t numPriors) {
+            ie_fp16 *roisBlobData = rois->buffer().as<ie_fp16*>();
+            const int maxRangeWidth  = width * 4 / 5;
+            const int maxRangeHeight = height * 4 / 5;
 
-static void genPriors(InferenceEngine::Blob::Ptr rois,
-                    const tensor_test_params& params,
-                    const uint32_t numPriors) {
-    ie_fp16 *roisBlobData = rois->buffer().as<ie_fp16*>();
-    const int maxRangeWidth  = params.w * 4 / 5;
-    const int maxRangeHeight = params.h * 4 / 5;
+            for (int i = 0; i < numPriors; i++) {
+                int x0 = std::rand() % maxRangeWidth;
+                int x1 = x0 + (std::rand() % (width - x0 - 1)) + 1;
+                int y0 = std::rand() % maxRangeHeight;
+                int y1 = y0 + (std::rand() % (height - y0 - 1)) + 1;
 
-    for (int i = 0; i < numPriors; i++) {
-        int x0 = std::rand() % maxRangeWidth;
-        int x1 = x0 + (std::rand() % (params.w - x0 - 1)) + 1;
-        int y0 = std::rand() % maxRangeHeight;
-        int y1 = y0 + (std::rand() % (params.h - y0 - 1)) + 1;
+                roisBlobData[i * NUM_ELEMS_PRIORS + 0] = PrecisionUtils::f32tof16((float)x0);
+                roisBlobData[i * NUM_ELEMS_PRIORS + 1] = PrecisionUtils::f32tof16((float)y0);
+                roisBlobData[i * NUM_ELEMS_PRIORS + 2] = PrecisionUtils::f32tof16((float)x1);
+                roisBlobData[i * NUM_ELEMS_PRIORS + 3] = PrecisionUtils::f32tof16((float)y1);
+            }
+        }
 
-        roisBlobData[i * NUM_ELEMS_PRIORS + 0] = PrecisionUtils::f32tof16((float)x0);
-        roisBlobData[i * NUM_ELEMS_PRIORS + 1] = PrecisionUtils::f32tof16((float)y0);
-        roisBlobData[i * NUM_ELEMS_PRIORS + 2] = PrecisionUtils::f32tof16((float)x1);
-        roisBlobData[i * NUM_ELEMS_PRIORS + 3] = PrecisionUtils::f32tof16((float)y1);
-    }
+        void runTest() {
+            InputDims inputTensorsDims = std::get<0>(GetParam());
+            PriorGridGeneratorParam opParams = std::get<1>(GetParam());
+
+            const auto numPriors = inputTensorsDims.priors.n;
+
+            _config[VPU_CONFIG_KEY(DETECT_NETWORK_BATCH)] = CONFIG_VALUE(NO);
+
+            IN_OUT_desc inputTensors, outputTensors;
+            inputTensors.push_back({inputTensorsDims.priors.n, inputTensorsDims.priors.c});
+            inputTensors.push_back({inputTensorsDims.featureMap.n,
+                                    inputTensorsDims.featureMap.c,
+                                    inputTensorsDims.featureMap.h,
+                                    inputTensorsDims.featureMap.w});
+            inputTensors.push_back({inputTensorsDims.imData.n,
+                                    inputTensorsDims.imData.c,
+                                    inputTensorsDims.imData.h,
+                                    inputTensorsDims.imData.w});
+
+            const int gridWidth  = opParams.grid_w ? opParams.grid_w : inputTensorsDims.featureMap.w;
+            const int gridHeight = opParams.grid_h ? opParams.grid_h : inputTensorsDims.featureMap.h;
+
+            outputTensors.push_back({numPriors * gridHeight * gridWidth, inputTensorsDims.priors.c});
+
+            SetInputTensors(inputTensors);
+            SetOutputTensors(outputTensors);
+
+            std::map<std::string, std::string> layerParams = {
+                {"flatten",  std::to_string(opParams.flatten)},
+                {"h",        std::to_string(opParams.grid_h)},
+                {"w",        std::to_string(opParams.grid_w)},
+                {"stride_y", std::to_string(opParams.stride_h)},
+                {"stride_x", std::to_string(opParams.stride_w)}
+            };
+
+            ASSERT_NO_FATAL_FAILURE(makeSingleLayerNetwork(LayerInitParams("ExperimentalDetectronPriorGridGenerator").params(layerParams)));
+
+            /* Input data generating */
+            for (auto blob : _inputMap) {
+                if (blob.second == _inputMap.begin()->second) {
+                    int w = inputTensorsDims.featureMap.w;
+                    int h = inputTensorsDims.featureMap.h;
+
+                    if (strcmp(InputsAvailable, MISSING_FEATURE_MAP) == 0) {
+                        w = opParams.grid_w;
+                        h = opParams.grid_h;
+                    }
+
+                    genPriors(blob.second, w, h, numPriors);
+                } else {
+                    GenRandomData(blob.second);
+                }
+            }
+
+            std::vector<InferenceEngine::Blob::Ptr> refInputBlobs;
+            std::vector<InferenceEngine::Blob::Ptr> refOutputBlobs;
+
+            for (auto blob : _inputMap) {
+                auto _refInputBlob = make_shared_blob<ie_fp16>({Precision::FP16,
+                                                                blob.second->getTensorDesc().getDims(),
+                                                                blob.second->getTensorDesc().getLayout()},
+                                                                blob.second->buffer());
+                refInputBlobs.push_back(_refInputBlob);
+            }
+
+            for (auto blob : _outputMap) {
+                auto refOutputBlob = make_shared_blob<ie_fp16>({Precision::FP16,
+                                                                blob.second->getTensorDesc().getDims(),
+                                                                blob.second->getTensorDesc().getLayout()});
+                refOutputBlob->allocate();
+                refOutputBlobs.push_back(refOutputBlob);
+            }
+
+            ref_ExpPriorGridGenerator(refInputBlobs,
+                                      refOutputBlobs,
+                                      opParams.grid_w,
+                                      opParams.grid_h,
+                                      opParams.stride_w,
+                                      opParams.stride_h);
+
+            ASSERT_TRUE(Infer());
+            CompareCommonAbsolute(_outputMap.begin()->second, refOutputBlobs[0], ERROR_BOUND);
+        }
+};
+
+class myriadLayersTestsExpPriorGridGeneratorAllInputs_smoke : public myriadLayersTestsExpPriorGridGen<ALL_INPUTS>
+{
+};
+
+class myriadLayersTestsExpPriorGridGeneratorNoFeatureMap_smoke : public myriadLayersTestsExpPriorGridGen<MISSING_FEATURE_MAP>
+{
+};
+
+class myriadLayersTestsExpPriorGridGeneratorNoInputImage_smoke : public myriadLayersTestsExpPriorGridGen<MISSING_INPUT_IMAGE>
+{
+};
+
+
+TEST_P(myriadLayersTestsExpPriorGridGeneratorAllInputs_smoke, AllThreeInputs) {
+    runTest();
 }
 
-TEST_P(myriadLayersTestsExpPriorGridGenerator_smoke, ExpPriorGridGenerator) {
-    InputDims inputTensorsDims = std::get<0>(GetParam());
-    PriorGridGeneratorParam opParams = std::get<1>(GetParam());
+TEST_P(myriadLayersTestsExpPriorGridGeneratorNoFeatureMap_smoke, MissingFeatureMap) {
+    runTest();
+}
 
-    const auto numPriors = inputTensorsDims.priors.n;
-
-    _config[VPU_CONFIG_KEY(DETECT_NETWORK_BATCH)] = CONFIG_VALUE(NO);
-
-    IN_OUT_desc inputTensors, outputTensors;
-    inputTensors.push_back({inputTensorsDims.priors.n, inputTensorsDims.priors.c});
-    inputTensors.push_back({inputTensorsDims.featureMap.n,
-                             inputTensorsDims.featureMap.c,
-                             inputTensorsDims.featureMap.h,
-                             inputTensorsDims.featureMap.w});
-    inputTensors.push_back({inputTensorsDims.imData.n,
-                             inputTensorsDims.imData.c,
-                             inputTensorsDims.imData.h,
-                             inputTensorsDims.imData.w});
-
-    const int gridWidth  = opParams.grid_w ? opParams.grid_w : inputTensorsDims.featureMap.w;
-    const int gridHeight = opParams.grid_h ? opParams.grid_h : inputTensorsDims.featureMap.h;
-
-    outputTensors.push_back({numPriors * gridHeight * gridWidth, inputTensorsDims.priors.c});
-
-    SetInputTensors(inputTensors);
-    SetOutputTensors(outputTensors);
-
-    std::map<std::string, std::string> layerParams = {
-        {"flatten",  std::to_string(opParams.flatten)},
-        {"h",        std::to_string(opParams.grid_h)},
-        {"w",        std::to_string(opParams.grid_w)},
-        {"stride_y", std::to_string(opParams.stride_h)},
-        {"stride_x", std::to_string(opParams.stride_w)}
-    };
-
-    ASSERT_NO_FATAL_FAILURE(makeSingleLayerNetwork(LayerInitParams("ExperimentalDetectronPriorGridGenerator").params(layerParams)));
-
-    /* Input data generating */
-    for (auto blob : _inputMap) {
-        if (blob.second == _inputMap.begin()->second) {
-            genPriors(blob.second, inputTensorsDims.featureMap, numPriors);
-        } else {
-            GenRandomData(blob.second);
-        }
-    }
-
-    std::vector<InferenceEngine::Blob::Ptr> refInputBlobs;
-    std::vector<InferenceEngine::Blob::Ptr> refOutputBlobs;
-
-    for (auto blob : _inputMap) {
-        auto _refInputBlob = make_shared_blob<ie_fp16>({Precision::FP16,
-                                                        blob.second->getTensorDesc().getDims(),
-                                                        blob.second->getTensorDesc().getLayout()},
-                                                        blob.second->buffer());
-        refInputBlobs.push_back(_refInputBlob);
-    }
-
-    for (auto blob : _outputMap) {
-        auto refOutputBlob = make_shared_blob<ie_fp16>({Precision::FP16,
-                                                      blob.second->getTensorDesc().getDims(),
-                                                      blob.second->getTensorDesc().getLayout()});
-        refOutputBlob->allocate();
-        refOutputBlobs.push_back(refOutputBlob);
-    }
-
-    ref_ExpPriorGridGenerator(refInputBlobs,
-                              refOutputBlobs,
-                              opParams.grid_w,
-                              opParams.grid_h,
-                              opParams.stride_w,
-                              opParams.stride_h);
-
-    ASSERT_TRUE(Infer());
-    CompareCommonAbsolute(_outputMap.begin()->second, refOutputBlobs[0], ERROR_BOUND);
+TEST_P(myriadLayersTestsExpPriorGridGeneratorNoInputImage_smoke, MissingImageInput) {
+    runTest();
 }
 
 static std::vector<InputDims> s_ExpPriorGridGeneratorLayerInputs = {
@@ -174,4 +214,39 @@ static std::vector<InputDims> s_ExpPriorGridGeneratorLayerInputs = {
 static std::vector<PriorGridGeneratorParam> s_ExpPriorGridGeneratorLayerParam = {
     {1, 0, 0, 16.0f, 16.0f}, {1, 0, 0, 8.0f, 8.0f}, {1, 0, 0, 4.0f, 4.0f},
     {1, 8, 8, 64.0f, 64.0f}, {1, 10, 16, 0.0f, 0.0f}
+};
+
+static std::vector<InputDims> s_ExpPriorGridGenLayerNoFMInputs = {
+    {
+        InputDims(
+            Dims({3, 4}),           // priors
+            Dims({1, 1, 1, 1}),     // feature map
+            Dims({1, 3, 512, 512})  // im_data
+        )
+    }
+};
+
+static std::vector<PriorGridGeneratorParam> s_ExpPriorGridGenLayerNoFMParam = {
+    {1, 16, 16, .0f, .0f}, {1, 32, 32, 4.0f, 4.0f}
+};
+
+static std::vector<InputDims> s_ExpPriorGridGenLayerNoInputImage = {
+    {
+        InputDims(
+            Dims({3, 4}),           // priors
+            Dims({1, 128, 60, 60}), // feature map
+            Dims({1, 1, 1, 1})      // im_data
+        )
+    },
+    {
+        InputDims(
+            Dims({64, 4}),          // priors
+            Dims({1, 128, 16, 16}), // feature map
+            Dims({1, 3, 480, 480})  // im_data
+        )
+    },
+};
+
+static std::vector<PriorGridGeneratorParam> s_ExpPriorGridGenLayerNoInputImageParam = {
+    {1, 0, 0, 8.0f, 8.0f}, {1, 32, 32, 4.0f, 4.0f}
 };


### PR DESCRIPTION
**Description**

ExperimentalPriorGridGenerator layer has at least one input tensor and at most three. The second and third tensors are required only if the parameters `w`, `h` and `stride_x`, `stride_y`, respectively, are zero. In such cases, the width/height dimensions of the last two layers are used to compute replacements for the parameters. 

In the current implementation, graph transformer does not allow the ExperimentalPriorGridGenerator layer to have less then three inputs.

Here is an example of how an ExpPriorGridGenerator layer with two inputs is described in xml:

```
<layer id=*id* name=*layer_name* type="ExperimentalDetectronPriorGridGenerator" version="experimental">
    <data flatten="1" h="0" stride_x=*stride_x* stride_y=*stride_y* w="0"/>
    <input>
            <port id="0">
                    <dim> *anchors_num* </dim>
                    <dim>4</dim>
            </port>
            <port id="1">
                    <dim>1</dim>
                    <dim>*feature map channels num*</dim>
                    <dim>*layer_height*</dim>
                    <dim>*layer_width*</dim>
            </port>
            <port id="2">
                    <dim>1</dim>
                    <dim>1</dim>
                    <dim>1</dim>
                    <dim>1</dim>
            </port>
    </input>
    <output>
            <port id="3" precision="FP32">
                    <dim>*num_boxes*</dim>
                    <dim>4</dim>
            </port>
    </output>
</layer>

```