### PR TITLE
[IE CLDNN] Enable I64 const inputs for batch_to_space

### DIFF
--- a/inference-engine/thirdparty/clDNN/src/batch_to_space.cpp
+++ b/inference-engine/thirdparty/clDNN/src/batch_to_space.cpp
@@ -42,8 +42,17 @@ layout batch_to_space_inst::calc_output_layout(batch_to_space_node const& node) 
     for (size_t i = 1; i < node.get_dependencies().size(); ++i) {
         auto& input = node.get_dependency(i).as<data>();
         auto& mem = input.get_attached_memory();
-        int32_t* data = static_cast<int32_t*>(mem.lock());
-        std::vector<int32_t> sizes = std::vector<int32_t>(data, data + input.get_output_layout().count());
+        std::vector<int32_t> sizes;
+        if (input.get_output_layout().data_type == cldnn::data_types::i64) {
+            int64_t* data = static_cast<int64_t*>(mem.lock());
+            std::vector<int64_t> sizes_i64 = std::vector<int64_t>(data, data + input.get_output_layout().count());
+            sizes.resize(sizes_i64.size());
+            for (size_t j = 0; j < sizes.size(); j++)
+                sizes[j] = static_cast<int32_t>(sizes_i64[j]);
+        } else {
+            int32_t* data = static_cast<int32_t*>(mem.lock());
+            sizes = std::vector<int32_t>(data, data + input.get_output_layout().count());
+        }
         args.push_back(sizes);
         mem.unlock();
     }

--- a/inference-engine/thirdparty/clDNN/src/gpu/batch_to_space_gpu.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/batch_to_space_gpu.cpp
@@ -42,9 +42,17 @@ public:
         for (size_t i = 1; i < arg.get_dependencies().size(); ++i) {
             auto& input = arg.get_dependency(i).as<data>();
             auto& mem = input.get_attached_memory();
-            int32_t* data = static_cast<int32_t*>(mem.lock());
-            std::vector<int32_t> sizes = std::vector<int32_t>(data, data + input.get_output_layout().count());
-
+            std::vector<int32_t> sizes;
+            if (input.get_output_layout().data_type == cldnn::data_types::i64) {
+                int64_t* data = static_cast<int64_t*>(mem.lock());
+                std::vector<int64_t> sizes_i64 = std::vector<int64_t>(data, data + input.get_output_layout().count());
+                sizes.resize(sizes_i64.size());
+                for (size_t j = 0; j < sizes.size(); j++)
+                    sizes[j] = static_cast<int32_t>(sizes_i64[j]);
+            } else {
+                int32_t* data = static_cast<int32_t*>(mem.lock());
+                sizes = std::vector<int32_t>(data, data + input.get_output_layout().count());
+            }
             batch_to_space_params.bts_params.push_back(sizes);
             mem.unlock();
         }


### PR DESCRIPTION
This patch adds missing support for I64 const inputs for batch_to_space operation.