### PR TITLE
Fix Nop Squeeze Elimination

### DIFF
--- a/ngraph/src/ngraph/pass/nop_elimination.cpp
+++ b/ngraph/src/ngraph/pass/nop_elimination.cpp
@@ -331,8 +331,6 @@ static bool eliminate_squeeze(const std::shared_ptr<Node>& node)
 
     auto squeeze = as_type_ptr<opset3::Squeeze>(node);
     auto input = squeeze->input_value(0).get_node_shared_ptr();
-    auto data_shape = input->input_value(0).get_partial_shape();
-    auto unsqueeze = as_type_ptr<opset3::Unsqueeze>(input);
     auto replace_squeeze_only = [&](const vector<int64_t>& axes) {
         auto axes_const = opset3::Constant::create<int64_t>(element::i64, Shape{axes.size()}, axes);
         auto new_sq = make_shared<opset3::Squeeze>(input->input_value(0), axes_const);
@@ -343,8 +341,9 @@ static bool eliminate_squeeze(const std::shared_ptr<Node>& node)
         return false;
     };
     // eliminate redundant unsqueeze->squeeze
-    if (unsqueeze)
+    if (auto unsqueeze = as_type_ptr<opset3::Unsqueeze>(input))
     {
+        auto data_shape = input->input(0).get_partial_shape();
         if (ngraph::compare_constants(unsqueeze->input_value(1).get_node_shared_ptr(),
                                       squeeze->input_value(1).get_node_shared_ptr()))
         {
@@ -383,9 +382,9 @@ static bool eliminate_squeeze(const std::shared_ptr<Node>& node)
         return false;
     }
     // eliminate redundant squeeze->squeeze
-    auto squeeze_i = as_type_ptr<opset3::Squeeze>(input);
-    if (squeeze_i)
+    if (auto squeeze_i = as_type_ptr<opset3::Squeeze>(input))
     {
+        auto data_shape = input->input(0).get_partial_shape();
         if (data_shape.rank().is_dynamic() || out_shape.rank().is_dynamic())
         {
             return false;


### PR DESCRIPTION
In this PR I fix a bug when Squeeze input has no input ports (Parameter, Constant) and Nop Squeeze elimination pass tries to find Unsqueeze above Squeeze operation. 