### PR TITLE
[IE] Another proposal for Blob ROI API

### DIFF
--- a/inference-engine/include/ie_compound_blob.h
+++ b/inference-engine/include/ie_compound_blob.h
@@ -117,6 +117,8 @@ public:
      */
     virtual Blob::Ptr getBlob(size_t i) const noexcept;
 
+    Blob::Ptr createROI(const ROI& roi) const override;
+
 protected:
     /**
      * @brief A default constructor
@@ -219,6 +221,8 @@ public:
      * @brief Returns a shared pointer to UV plane
      */
     virtual const Blob::Ptr& uv() const noexcept;
+
+    Blob::Ptr createROI(const ROI& roi) const override;
 };
 
 /**
@@ -342,5 +346,7 @@ public:
      * @return constant reference to shared pointer object of V plane
      */
     const Blob::Ptr& v() const noexcept;
+
+    Blob::Ptr createROI(const ROI& roi) const override;
 };
 }  // namespace InferenceEngine

--- a/inference-engine/include/ie_layouts.h
+++ b/inference-engine/include/ie_layouts.h
@@ -318,4 +318,36 @@ private:
     BlockingDesc blockingDesc;
 };
 
+/**
+ * @brief This structure describes ROI data for image-like tensors.
+ */
+struct ROI {
+    size_t id = 0;      //!< ID of a ROI (offset over batch dimension)
+    size_t posX = 0;    //!< W upper left coordinate of ROI
+    size_t posY = 0;    //!< H upper left coordinate of ROI
+    size_t sizeX = 0;   //!< W size of ROI
+    size_t sizeY = 0;   //!< H size of ROI
+
+    ROI() = default;
+
+    ROI(size_t id, size_t posX, size_t posY, size_t sizeX, size_t sizeY) :
+        id(id), posX(posX), posY(posY), sizeX(sizeX), sizeY(sizeY) {
+    }
+};
+
+/**
+ * @brief Creates a TensorDesc object for ROI.
+ *
+ * @param origDesc original TensorDesc object.
+ * @param roi An image ROI object inside of the original object.
+ * @param useOrigMemDesc Flag to use original memory description (strides/offset).
+ *     Should be set if the new TensorDesc describes shared memory.
+ *
+ * @return A newly created TensorDesc object representing ROI.
+ */
+INFERENCE_ENGINE_API_CPP(TensorDesc) make_roi_desc(
+        const TensorDesc& origDesc,
+        const ROI& roi,
+        bool useOrigMemDesc);
+
 }  // namespace InferenceEngine

--- a/inference-engine/src/inference_engine/CMakeLists.txt
+++ b/inference-engine/src/inference_engine/CMakeLists.txt
@@ -20,6 +20,7 @@ set(IE_BASE_SOURCE_FILES
       ${CMAKE_CURRENT_SOURCE_DIR}/cnn_network_ngraph_impl.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/generic_ie.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/blob_factory.cpp
+      ${CMAKE_CURRENT_SOURCE_DIR}/ie_blob_common.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/ie_data.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/ie_layouts.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/ie_memcpy.cpp

--- a/inference-engine/src/inference_engine/ie_blob_common.cpp
+++ b/inference-engine/src/inference_engine/ie_blob_common.cpp
@@ -2,61 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "ie_blob.h"
+
 #include <memory>
 #include <utility>
 #include <vector>
 
-#include "blob_factory.hpp"
-#include "ie_blob.h"
-#include "ie_compound_blob.h"
-
 namespace InferenceEngine {
 
+Blob::Ptr Blob::createROI(const ROI&) const {
+    THROW_IE_EXCEPTION << "[NOT_IMPLEMENTED] createROI is not implemented for current type of Blob";
+}
+
 Blob::Ptr make_shared_blob(const Blob::Ptr& inputBlob, const ROI& roi) {
-    // reject compound blobs
-    if (inputBlob->is<CompoundBlob>()) {
-        THROW_IE_EXCEPTION << "Compound blobs do not support ROI";
-    }
-
-    size_t blkDimsH = roi.sizeY;
-    size_t blkDimsW = roi.sizeX;
-    size_t blkDimsC = inputBlob->getTensorDesc().getDims()[1];
-    size_t blkOffset;
-    SizeVector blkOrder;
-    SizeVector blkDims;
-
-    if (roi.posX + roi.sizeX > inputBlob->getTensorDesc().getDims()[3] ||
-        roi.posY + roi.sizeY > inputBlob->getTensorDesc().getDims()[2]) {
-        THROW_IE_EXCEPTION << "passed ROI coordinates are inconsistent to input size";
-    }
-
-    Layout blobLayout = inputBlob->getTensorDesc().getLayout();
-    switch (blobLayout) {
-    case NCHW: {
-        blkOffset = inputBlob->getTensorDesc().getDims()[3] * roi.posY + roi.posX;
-        blkOrder = {0, 1, 2, 3};
-        blkDims = {1, blkDimsC, blkDimsH, blkDimsW};  // we use BlockingDesc for 1 cropped image only
-    } break;
-    case NHWC: {
-        blkOffset = blkDimsC * (inputBlob->getTensorDesc().getDims()[3] * roi.posY + roi.posX);
-        blkOrder = {0, 2, 3, 1};
-        blkDims = {1, blkDimsH, blkDimsW, blkDimsC};  // we use BlockingDesc for 1 cropped image only
-    } break;
-    default: {
-        THROW_IE_EXCEPTION << "ROI could not be cropped due to inconsistent input layout: " << blobLayout;
-    }
-    }
-
-    // the strides are the same because ROI blob uses the same memory buffer as original input blob.
-    SizeVector blkStrides(inputBlob->getTensorDesc().getBlockingDesc().getStrides());
-
-    SizeVector blkDimsOffsets = {0, 0, 0, 0};  // no offset per dims by default
-
-    BlockingDesc blkDesc(blkDims, blkOrder, blkOffset, blkDimsOffsets, blkStrides);
-    TensorDesc tDesc(inputBlob->getTensorDesc().getPrecision(), {1, blkDimsC, blkDimsH, blkDimsW}, blkDesc);
-    tDesc.setLayout(blobLayout);
-
-    return make_blob_with_precision(tDesc, inputBlob->buffer());
+    return inputBlob->createROI(roi);
 }
 
 }  // namespace InferenceEngine


### PR DESCRIPTION
* Add default implementation that throws exception.
* Implement `createROI` for `TBlob` and existing compound blobs.
* Use reference couting for TBlob memory buffer to prolong its life time for ROI blobs.
* Add private extension for ND ROI and use it as implementation detail for now:
  * Add `DimSlice` and `TensorSlice` structures for generic ND ROI support.
  * Add `make_roi_desc` function to create `TensorDesc` for ROI.