### PR TITLE
[ DYN NMS ] Static & Dynamic ops; DTS transformation; VPU tests

### DIFF
--- a/inference-engine/src/transformations/include/transformations/common_optimizations/common_optimizations_tbl.hpp
+++ b/inference-engine/src/transformations/include/transformations/common_optimizations/common_optimizations_tbl.hpp
@@ -17,6 +17,7 @@
 // This pass must be called first in pipeline
 NGRAPH_PASS(InitNodeInfo, ::ngraph::pass)
 NGRAPH_PASS(RemoveFilteringBoxesBySize, ::ngraph::pass) // Resolves dynamism (replaces NonZero), CF needed
+NGRAPH_PASS(UpgradeNMS3ToNMS4, ::ngraph::pass) // replaces v3::NMS with v4::NMS(always dyn output shape) if function has opset3::NonZero operation
 NGRAPH_PASS(ConstantFolding, ::ngraph::pass)
 NGRAPH_PASS(StridedSliceOptimization, ::ngraph::pass) // depends on CF
 NGRAPH_PASS(NopElimination, ::ngraph::pass) // may introduce fake dynamism

--- a/inference-engine/src/transformations/include/transformations/convert_nms_3_to_nms_v4.hpp
+++ b/inference-engine/src/transformations/include/transformations/convert_nms_3_to_nms_v4.hpp
@@ -1,0 +1,34 @@
+// Copyright (C) 2018-2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <vector>
+#include <memory>
+
+#include <transformations_visibility.hpp>
+
+#include <ngraph/pass/graph_rewrite.hpp>
+
+namespace ngraph {
+namespace pass {
+
+class TRANSFORMATIONS_API UpgradeNMS3ToNMS4;
+
+}  // namespace pass
+}  // namespace ngraph
+
+/*
+ * Description:
+ *      UpgradeNMS3ToNMS4 transformation upgrades NonMaxSuppression operations from v3 version to v4
+ *      in case function has at least one NonZero operation (dynamism marker).
+ *      NMS of version v4 always has dynamic output
+ */
+
+
+class ngraph::pass::UpgradeNMS3ToNMS4: public ngraph::pass::FunctionPass {
+public:
+    bool run_on_function(std::shared_ptr<ngraph::Function> f) override;
+};
+

--- a/inference-engine/src/transformations/src/transformations/common_optimizations/common_optimizations.cpp
+++ b/inference-engine/src/transformations/src/transformations/common_optimizations/common_optimizations.cpp
@@ -9,6 +9,7 @@
 #include "transformations/optimize_strided_slice.hpp"
 #include "transformations/convert_scatter_elements_to_scatter.hpp"
 #include "transformations/remove_filtering_boxes_by_size.hpp"
+#include "transformations/convert_nms_3_to_nms_v4.hpp"
 #include "transformations/init_node_info.hpp"
 
 #include <ngraph/pass/manager.hpp>

--- a/inference-engine/src/transformations/src/transformations/convert_nms_3_to_nms_4.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_nms_3_to_nms_4.cpp
@@ -1,0 +1,51 @@
+// Copyright (C) 2018-2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <memory>
+#include <vector>
+
+#include <ngraph/graph_util.hpp>
+#include <ngraph/opsets/opset3.hpp>
+#include <ngraph/rt_info.hpp>
+#include <transformations/utils/utils.hpp>
+
+#include "transformations/convert_nms_3_to_nms_v4.hpp"
+
+bool ngraph::pass::UpgradeNMS3ToNMS4::run_on_function(std::shared_ptr<ngraph::Function> f) {
+    bool rewritten = false;
+    if (!ngraph::op::util::has_op_with_type<ngraph::opset3::NonZero>(f)) {
+        return rewritten;
+    }
+
+    for (auto &node : f->get_ops()) {
+        auto nms_3 = ngraph::as_type_ptr<opset3::NonMaxSuppression>(node);
+        if (!nms_3)
+            continue;
+
+        const auto box_encoding = static_cast<const op::v4::NonMaxSuppression::BoxEncodingType>(nms_3->get_box_encoding());
+        const auto new_args = nms_3->input_values();
+        NODE_VALIDATION_CHECK(nms_3.get(),
+                              new_args.size() >= 2 && new_args.size() <= 5,
+                              "Number of inputs must be 2, 3, 4 or 5");
+        const auto& arg2 = new_args.size() > 2 ? new_args.at(2) : ngraph::opset3::Constant::create(element::i32, Shape{}, {0});
+        const auto& arg3 = new_args.size() > 3 ? new_args.at(3) : ngraph::opset3::Constant::create(element::f32, Shape{}, {.0f});
+        const auto& arg4 = new_args.size() > 4 ? new_args.at(4) : ngraph::opset3::Constant::create(element::f32, Shape{}, {.0f});
+
+        const auto nms_4 = std::make_shared<op::v4::NonMaxSuppression>(
+                new_args.at(0),
+                new_args.at(1),
+                arg2,
+                arg3,
+                arg4,
+                box_encoding,
+                nms_3->get_sort_result_descending(),
+                nms_3->get_output_type());
+
+        nms_4->set_friendly_name(nms_3->get_friendly_name());
+        ngraph::copy_runtime_info(nms_3, nms_4);
+        ngraph::replace_node(nms_3, nms_4);
+        rewritten = true;
+    }
+    return rewritten;
+}

--- a/inference-engine/src/vpu/common/include/vpu/ngraph/operations/static_shape_non_maximum_suppression.hpp
+++ b/inference-engine/src/vpu/common/include/vpu/ngraph/operations/static_shape_non_maximum_suppression.hpp
@@ -1,0 +1,42 @@
+// Copyright (C) 2018-2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <ngraph/node.hpp>
+#include <ngraph/op/op.hpp>
+
+#include <memory>
+#include <vector>
+
+namespace ngraph { namespace vpu { namespace op {
+
+class StaticShapeNonMaxSuppression : public ngraph::op::v3::NonMaxSuppression {
+public:
+    static constexpr NodeTypeInfo type_info{"StaticShapeStaticShapeNonMaxSuppression", 0};
+    const NodeTypeInfo& get_type_info() const override { return type_info; }
+    StaticShapeNonMaxSuppression() = default;
+
+    StaticShapeNonMaxSuppression(const Output<Node>& boxes,
+                      const Output<Node>& scores,
+                      const Output<Node>& max_output_boxes_per_class,
+                      const Output<Node>& iou_threshold,
+                      const Output<Node>& score_threshold,
+                      const BoxEncodingType box_encoding = BoxEncodingType::CORNER,
+                      const bool sort_result_descending = true,
+                      const ngraph::element::Type& output_type = ngraph::element::i64);
+
+    StaticShapeNonMaxSuppression(const Output<Node>& boxes,
+                      const Output<Node>& scores,
+                      const BoxEncodingType box_encoding = BoxEncodingType::CORNER,
+                      const bool sort_result_descending = true,
+                      const ngraph::element::Type& output_type = ngraph::element::i64);
+
+    void validate_and_infer_types() override;
+    std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
+};
+
+}  // namespace op
+}  // namespace vpu
+}  // namespace ngraph

--- a/inference-engine/src/vpu/common/src/ngraph/operations/static_shape_non_maximum_suppression.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/operations/static_shape_non_maximum_suppression.cpp
@@ -1,0 +1,80 @@
+// Copyright (C) 2018-2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <ngraph/opsets/opset3.hpp>
+#include "vpu/ngraph/operations/static_shape_non_maximum_suppression.hpp"
+
+#include "ngraph/runtime/host_tensor.hpp"
+
+namespace ngraph { namespace vpu { namespace op {
+
+constexpr NodeTypeInfo StaticShapeNonMaxSuppression::type_info;
+
+StaticShapeNonMaxSuppression::StaticShapeNonMaxSuppression(
+        const Output<Node>& boxes,
+        const Output<Node>& scores,
+        const Output<Node>& max_output_boxes_per_class,
+        const Output<Node>& iou_threshold,
+        const Output<Node>& score_threshold,
+        const StaticShapeNonMaxSuppression::BoxEncodingType box_encoding,
+        const bool sort_result_descending,
+        const element::Type& output_type)
+        : ngraph::op::v3::NonMaxSuppression({
+            boxes, scores, max_output_boxes_per_class, iou_threshold, score_threshold,
+            box_encoding, sort_result_descending, output_type}) {
+    constructor_validate_and_infer_types();
+}
+
+StaticShapeNonMaxSuppression::StaticShapeNonMaxSuppression(
+        const Output<Node>& boxes,
+        const Output<Node>& scores,
+        const StaticShapeNonMaxSuppression::BoxEncodingType box_encoding,
+        const bool sort_result_descending,
+        const element::Type& output_type)
+        : ngraph::op::v3::NonMaxSuppression({boxes,
+              scores,
+              ngraph::opset3::Constant::create(element::i64, Shape{}, {0}),
+              ngraph::opset3::Constant::create(element::f32, Shape{}, {.0f}),
+              ngraph::opset3::Constant::create(element::f32, Shape{}, {.0f}),
+              box_encoding, sort_result_descending, output_type}) {
+    constructor_validate_and_infer_types();
+}
+
+std::shared_ptr<Node>
+StaticShapeNonMaxSuppression::clone_with_new_inputs(const OutputVector& new_args) const {
+    check_new_args_count(this, new_args);
+    NODE_VALIDATION_CHECK(this,
+                          new_args.size() >= 2 && new_args.size() <= 5,
+                          "Number of inputs must be 2, 3, 4 or 5");
+
+    const auto& arg2 = new_args.size() > 2 ? new_args.at(2) : ngraph::opset3::Constant::create(element::i32, Shape{}, {0});
+    const auto& arg3 = new_args.size() > 3 ? new_args.at(3) : ngraph::opset3::Constant::create(element::f32, Shape{}, {.0f});
+    const auto& arg4 = new_args.size() > 4 ? new_args.at(4) : ngraph::opset3::Constant::create(element::f32, Shape{}, {.0f});
+
+    return std::make_shared<StaticShapeNonMaxSuppression>(
+          new_args.at(0),
+          new_args.at(1),
+          arg2,
+          arg3,
+          arg4,
+          m_box_encoding,
+          m_sort_result_descending,
+          m_output_type);
+}
+
+void StaticShapeNonMaxSuppression::validate_and_infer_types() {
+    ngraph::op::v3::NonMaxSuppression::validate_and_infer_types();
+
+    const auto out_shape = this->get_output_partial_shape(0);
+    NODE_VALIDATION_CHECK(this, out_shape.is_static(),
+                          "StaticShapeTopK output shape is not fully defined: ", out_shape);
+
+    set_output_size(2);
+    set_output_type(0, m_output_type, out_shape);
+    set_output_type(1, ngraph::element::i64, Shape{2});
+}
+
+}  // namespace op
+}  // namespace vpu
+} // namespace ngraph

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape.cpp
@@ -63,7 +63,7 @@ const Transformations& getDefaultTransformations() {
         {ngraph::opset3::Divide::type_info, dynamicToStaticShapeBinaryEltwise},
         {ngraph::opset3::Equal::type_info, dynamicToStaticShapeBinaryEltwise},
         {ngraph::opset3::Power::type_info, dynamicToStaticShapeBinaryEltwise},
-        {ngraph::opset3::NonMaxSuppression::type_info, dynamicToStaticNonMaxSuppression},
+        {ngraph::op::v4::NonMaxSuppression::type_info, dynamicToStaticNonMaxSuppression},
         {ngraph::opset3::NonZero::type_info,   dynamicToStaticShapeNonZero},
         {ngraph::opset3::TopK::type_info, dynamicToStaticShapeTopK},
         {ngraph::opset3::Transpose::type_info, dynamicToStaticShapeTranspose},

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_non_max_suppression.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_non_max_suppression.cpp
@@ -11,38 +11,30 @@
 #include "ngraph/opsets/opset3.hpp"
 
 #include <memory>
+#include <vpu/ngraph/operations/static_shape_non_maximum_suppression.hpp>
 
 namespace vpu {
 
-void dynamicToStaticNonMaxSuppression(std::shared_ptr<ngraph::Node> target) {
-    const auto dsr1 = target->input_value(1).get_node_shared_ptr();
-    VPU_THROW_UNLESS(std::dynamic_pointer_cast<ngraph::vpu::op::DynamicShapeResolver>(dsr1),
-                     "DynamicToStaticShape transformation for {} of type {} expects {} as input with index {}",
-                     target->get_friendly_name(), target->get_type_info(), ngraph::vpu::op::DynamicShapeResolver::type_info, 1);
+void dynamicToStaticNonMaxSuppression(std::shared_ptr<ngraph::Node> node) {
+    auto nms_4 = std::dynamic_pointer_cast<ngraph::op::v4::NonMaxSuppression>(node);
+    VPU_THROW_UNLESS(nms_4, "dynamicToStaticNonMaxSuppression transformation for {} of type {} expects {} as node for replacement",
+                     node->get_friendly_name(), node->get_type_info(), ngraph::op::v4::NonMaxSuppression::type_info);
 
-    const auto scores_shape = dsr1->input(1).get_source_output();
+    auto staticShapeNMS = std::make_shared<ngraph::vpu::op::StaticShapeNonMaxSuppression>(
+            nms_4->input_value(0),
+            nms_4->input_value(1),
+            nms_4->input_value(2),
+            nms_4->input_value(3),
+            nms_4->input_value(4),
+            nms_4->get_box_encoding(),
+            nms_4->get_sort_result_descending(),
+            nms_4->get_output_type());
 
-    const auto index_num_classes = ngraph::opset3::Constant::create(ngraph::element::i64, {1}, std::vector<int64_t>{1});
-    const auto axis_num_classes = ngraph::opset3::Constant::create(ngraph::element::i64, {}, std::vector<int64_t>{0});
-    const auto num_classes = std::make_shared<ngraph::opset3::Gather>(scores_shape, index_num_classes, axis_num_classes);
+    auto dynamicShapeResolver = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(
+            staticShapeNMS->output(0), staticShapeNMS->output(1));
+    dynamicShapeResolver->set_friendly_name(nms_4->get_friendly_name());
 
-    const auto index_num_boxes = ngraph::opset3::Constant::create(ngraph::element::i64, {1}, std::vector<int64_t>{2});
-    const auto axis_num_boxes = ngraph::opset3::Constant::create(ngraph::element::i64, {}, std::vector<int64_t>{0});
-    const auto num_boxes = std::make_shared<ngraph::opset3::Gather>(scores_shape, index_num_boxes, axis_num_boxes);
-
-    VPU_THROW_UNLESS(target->inputs().size() > 2,  "DynamicToStaticShape transformation for {} expects at least 3 inputs", target);
-    // originally 3rd input is a scalar of any integer type, so we cast and unsqueeze it to 1D
-    const auto max_output_boxes_per_class = std::make_shared<ngraph::opset3::Convert>(std::make_shared<ngraph::opset3::Unsqueeze>(
-            target->input_value(2).get_node_shared_ptr(), ngraph::opset3::Constant::create(ngraph::element::i32, {1}, {0})), scores_shape.get_element_type());
-
-    const auto max_output_boxes_overall = std::make_shared<ngraph::opset3::Multiply>(max_output_boxes_per_class, num_classes);
-    const auto num_selected_boxes = std::make_shared<ngraph::opset3::Minimum>(num_boxes, max_output_boxes_overall);
-
-    const auto triplet_const = ngraph::opset3::Constant::create(scores_shape.get_element_type(), {1}, std::vector<int64_t>{3});
-    const auto output_shape = std::make_shared<ngraph::opset3::Concat>(ngraph::OutputVector{num_selected_boxes, triplet_const}, 0);
-
-    const auto copied = target->clone_with_new_inputs(target->input_values());
-    ngraph::replace_node(target, std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(copied, output_shape));
+    ngraph::replace_node(std::move(nms_4), std::move(dynamicShapeResolver));
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_reshape.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_reshape.cpp
@@ -23,7 +23,7 @@ void dynamicToStaticShapeReshape(std::shared_ptr<ngraph::Node> target) {
 
     const auto outShapeDescriptor = target->get_argument(1);
     VPU_THROW_UNLESS(ngraph::as_type_ptr<ngraph::opset3::Constant>(outShapeDescriptor),
-                     "DynamicToStaticShape transformation for {] of type {} expects {} as input with index {}",
+                     "DynamicToStaticShape transformation for {} of type {} expects {} as input with index {}",
                      target->get_friendly_name(), target->get_type_info(), ngraph::opset3::Constant::type_info, 1);
 
     const auto reshape = std::dynamic_pointer_cast<ngraph::opset3::Reshape>(target);

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_non_max_suppression.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_non_max_suppression.cpp
@@ -48,12 +48,12 @@ protected:
         const auto dims = std::make_shared<ngraph::opset3::Parameter>(ngraph::element::i64, ngraph::Shape{3});
         const auto dsr = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(scores, dims);
 
-        const auto node = std::make_shared<ngraph::opset3::NonMaxSuppression>(
+        const auto node = std::make_shared<ngraph::op::v4::NonMaxSuppression>(
                 boxes, dsr, max_output_boxes_per_class, iou_threshold, score_threshold);
 
         const auto result = std::make_shared<ngraph::opset3::Result>(node);
         function = std::make_shared<ngraph::Function>(ngraph::ResultVector{result},
-                ngraph::ParameterVector{boxes, scores, dims}, "DSR-NMS");
+                ngraph::ParameterVector{boxes, scores, dims}, "DSR-v4::NMS");
     }
 };
 

--- a/ngraph/src/ngraph/op/non_max_suppression.cpp
+++ b/ngraph/src/ngraph/op/non_max_suppression.cpp
@@ -63,49 +63,19 @@ shared_ptr<Node>
     NODE_VALIDATION_CHECK(this,
                           new_args.size() >= 2 && new_args.size() <= 5,
                           "Number of inputs must be 2, 3, 4 or 5");
-    if (new_args.size() == 5)
-    {
-        return make_shared<op::v1::NonMaxSuppression>(new_args.at(0),
-                                                      new_args.at(1),
-                                                      new_args.at(2),
-                                                      new_args.at(3),
-                                                      new_args.at(4),
-                                                      m_box_encoding,
-                                                      m_sort_result_descending);
-    }
-    else if (new_args.size() == 4)
-    {
-        return make_shared<op::v1::NonMaxSuppression>(
-            new_args.at(0),
-            new_args.at(1),
-            new_args.at(2),
-            new_args.at(3),
-            op::Constant::create(element::f32, Shape{}, {.0f}),
-            m_box_encoding,
-            m_sort_result_descending);
-    }
-    else if (new_args.size() == 3)
-    {
-        return make_shared<op::v1::NonMaxSuppression>(
-            new_args.at(0),
-            new_args.at(1),
-            new_args.at(2),
-            op::Constant::create(element::f32, Shape{}, {.0f}),
-            op::Constant::create(element::f32, Shape{}, {.0f}),
-            m_box_encoding,
-            m_sort_result_descending);
-    }
-    else
-    {
-        return make_shared<op::v1::NonMaxSuppression>(
-            new_args.at(0),
-            new_args.at(1),
-            op::Constant::create(element::i32, Shape{}, {0}),
-            op::Constant::create(element::f32, Shape{}, {.0f}),
-            op::Constant::create(element::f32, Shape{}, {.0f}),
-            m_box_encoding,
-            m_sort_result_descending);
-    }
+
+    const auto& arg2 = new_args.size() > 2
+                           ? new_args.at(2)
+                           : ngraph::op::Constant::create(element::i32, Shape{}, {0});
+    const auto& arg3 = new_args.size() > 3
+                           ? new_args.at(3)
+                           : ngraph::op::Constant::create(element::f32, Shape{}, {.0f});
+    const auto& arg4 = new_args.size() > 4
+                           ? new_args.at(4)
+                           : ngraph::op::Constant::create(element::f32, Shape{}, {.0f});
+
+    return std::make_shared<op::v1::NonMaxSuppression>(
+        new_args.at(0), new_args.at(1), arg2, arg3, arg4, m_box_encoding, m_sort_result_descending);
 }
 
 bool ngraph::op::v1::NonMaxSuppression::visit_attributes(AttributeVisitor& visitor)
@@ -292,52 +262,25 @@ shared_ptr<Node>
     NODE_VALIDATION_CHECK(this,
                           new_args.size() >= 2 && new_args.size() <= 5,
                           "Number of inputs must be 2, 3, 4 or 5");
-    if (new_args.size() == 5)
-    {
-        return make_shared<op::v3::NonMaxSuppression>(new_args.at(0),
-                                                      new_args.at(1),
-                                                      new_args.at(2),
-                                                      new_args.at(3),
-                                                      new_args.at(4),
-                                                      m_box_encoding,
-                                                      m_sort_result_descending,
-                                                      m_output_type);
-    }
-    else if (new_args.size() == 4)
-    {
-        return make_shared<op::v3::NonMaxSuppression>(
-            new_args.at(0),
-            new_args.at(1),
-            new_args.at(2),
-            new_args.at(3),
-            op::Constant::create(element::f32, Shape{}, {.0f}),
-            m_box_encoding,
-            m_sort_result_descending,
-            m_output_type);
-    }
-    else if (new_args.size() == 3)
-    {
-        return make_shared<op::v3::NonMaxSuppression>(
-            new_args.at(0),
-            new_args.at(1),
-            new_args.at(2),
-            op::Constant::create(element::f32, Shape{}, {.0f}),
-            op::Constant::create(element::f32, Shape{}, {.0f}),
-            m_box_encoding,
-            m_sort_result_descending);
-    }
-    else
-    {
-        return make_shared<op::v3::NonMaxSuppression>(
-            new_args.at(0),
-            new_args.at(1),
-            op::Constant::create(element::i32, Shape{}, {0}),
-            op::Constant::create(element::f32, Shape{}, {.0f}),
-            op::Constant::create(element::f32, Shape{}, {.0f}),
-            m_box_encoding,
-            m_sort_result_descending,
-            m_output_type);
-    }
+
+    const auto& arg2 = new_args.size() > 2
+                           ? new_args.at(2)
+                           : ngraph::op::Constant::create(element::i32, Shape{}, {0});
+    const auto& arg3 = new_args.size() > 3
+                           ? new_args.at(3)
+                           : ngraph::op::Constant::create(element::f32, Shape{}, {.0f});
+    const auto& arg4 = new_args.size() > 4
+                           ? new_args.at(4)
+                           : ngraph::op::Constant::create(element::f32, Shape{}, {.0f});
+
+    return std::make_shared<op::v3::NonMaxSuppression>(new_args.at(0),
+                                                       new_args.at(1),
+                                                       arg2,
+                                                       arg3,
+                                                       arg4,
+                                                       m_box_encoding,
+                                                       m_sort_result_descending,
+                                                       m_output_type);
 }
 
 bool ngraph::op::v3::NonMaxSuppression::visit_attributes(AttributeVisitor& visitor)
@@ -440,7 +383,6 @@ void op::v3::NonMaxSuppression::validate_and_infer_types()
 
         out_shape[0] = std::min(num_boxes, max_output_boxes_per_class * num_classes);
     }
-    set_output_size(1);
     set_output_type(0, m_output_type, out_shape);
 }
 
@@ -477,3 +419,83 @@ namespace ngraph
         return s << as_string(type);
     }
 } // namespace ngraph
+
+// ------------------------------ V4 ------------------------------
+
+constexpr NodeTypeInfo op::v4::NonMaxSuppression::type_info;
+
+op::v4::NonMaxSuppression::NonMaxSuppression(
+    const Output<Node>& boxes,
+    const Output<Node>& scores,
+    const Output<Node>& max_output_boxes_per_class,
+    const Output<Node>& iou_threshold,
+    const Output<Node>& score_threshold,
+    const op::v4::NonMaxSuppression::BoxEncodingType box_encoding,
+    const bool sort_result_descending,
+    const element::Type& output_type)
+    : op::v3::NonMaxSuppression({boxes,
+                                 scores,
+                                 max_output_boxes_per_class,
+                                 iou_threshold,
+                                 score_threshold,
+                                 box_encoding,
+                                 sort_result_descending,
+                                 output_type})
+{
+    constructor_validate_and_infer_types();
+}
+
+op::v4::NonMaxSuppression::NonMaxSuppression(
+    const Output<Node>& boxes,
+    const Output<Node>& scores,
+    const op::v4::NonMaxSuppression::BoxEncodingType box_encoding,
+    const bool sort_result_descending,
+    const element::Type& output_type)
+    : op::v3::NonMaxSuppression({boxes,
+                                 scores,
+                                 op::Constant::create(element::i64, Shape{}, {0}),
+                                 op::Constant::create(element::f32, Shape{}, {.0f}),
+                                 op::Constant::create(element::f32, Shape{}, {.0f}),
+                                 box_encoding,
+                                 sort_result_descending,
+                                 output_type})
+{
+    constructor_validate_and_infer_types();
+}
+
+shared_ptr<Node>
+    op::v4::NonMaxSuppression::clone_with_new_inputs(const OutputVector& new_args) const
+{
+    check_new_args_count(this, new_args);
+    NODE_VALIDATION_CHECK(this,
+                          new_args.size() >= 2 && new_args.size() <= 5,
+                          "Number of inputs must be 2, 3, 4 or 5");
+
+    const auto& arg2 = new_args.size() > 2
+                           ? new_args.at(2)
+                           : ngraph::op::Constant::create(element::i32, Shape{}, {0});
+    const auto& arg3 = new_args.size() > 3
+                           ? new_args.at(3)
+                           : ngraph::op::Constant::create(element::f32, Shape{}, {.0f});
+    const auto& arg4 = new_args.size() > 4
+                           ? new_args.at(4)
+                           : ngraph::op::Constant::create(element::f32, Shape{}, {.0f});
+
+    return std::make_shared<op::v3::NonMaxSuppression>(new_args.at(0),
+                                                       new_args.at(1),
+                                                       arg2,
+                                                       arg3,
+                                                       arg4,
+                                                       m_box_encoding,
+                                                       m_sort_result_descending,
+                                                       m_output_type);
+}
+
+void op::v4::NonMaxSuppression::validate_and_infer_types()
+{
+    op::v3::NonMaxSuppression::validate_and_infer_types();
+
+    // NonMaxSuppression produces triplets
+    // that have the following format: [batch_index, class_index, box_index]
+    set_output_type(0, m_output_type, PartialShape{Dimension::dynamic(), 3});
+}

--- a/ngraph/src/ngraph/op/non_max_suppression.hpp
+++ b/ngraph/src/ngraph/op/non_max_suppression.hpp
@@ -182,6 +182,60 @@ namespace ngraph
                 int64_t max_boxes_output_from_input() const;
             };
         } // namespace v3
+
+        namespace v4
+        {
+            /// \brief NonMaxSuppression operation
+            ///
+            class NGRAPH_API NonMaxSuppression : public op::v3::NonMaxSuppression
+            {
+            public:
+                static constexpr NodeTypeInfo type_info{"NonMaxSuppression", 4};
+                const NodeTypeInfo& get_type_info() const override { return type_info; }
+                NonMaxSuppression() = default;
+
+                /// \brief Constructs a NonMaxSuppression operation.
+                ///
+                /// \param boxes Node producing the box coordinates
+                /// \param scores Node producing the box scores
+                /// \param max_output_boxes_per_class Node producing maximum number of boxes to be
+                /// selected per class
+                /// \param iou_threshold Node producing intersection over union threshold
+                /// \param score_threshold Node producing minimum score threshold
+                /// \param box_encoding Specifies the format of boxes data encoding
+                /// \param sort_result_descending Specifies whether it is necessary to sort selected
+                /// boxes across batches
+                /// \param output_type Specifies the output tensor type
+                NonMaxSuppression(const Output<Node>& boxes,
+                                  const Output<Node>& scores,
+                                  const Output<Node>& max_output_boxes_per_class,
+                                  const Output<Node>& iou_threshold,
+                                  const Output<Node>& score_threshold,
+                                  const BoxEncodingType box_encoding = BoxEncodingType::CORNER,
+                                  const bool sort_result_descending = true,
+                                  const ngraph::element::Type& output_type = ngraph::element::i64);
+
+                /// \brief Constructs a NonMaxSuppression operation with default values for the last
+                ///        3 inputs
+                ///
+                /// \param boxes Node producing the box coordinates
+                /// \param scores Node producing the box coordinates
+                /// \param box_encoding Specifies the format of boxes data encoding
+                /// \param sort_result_descending Specifies whether it is necessary to sort selected
+                /// boxes across batches
+                /// \param output_type Specifies the output tensor type
+                NonMaxSuppression(const Output<Node>& boxes,
+                                  const Output<Node>& scores,
+                                  const BoxEncodingType box_encoding = BoxEncodingType::CORNER,
+                                  const bool sort_result_descending = true,
+                                  const ngraph::element::Type& output_type = ngraph::element::i64);
+
+                void validate_and_infer_types() override;
+
+                std::shared_ptr<Node>
+                    clone_with_new_inputs(const OutputVector& new_args) const override;
+            };
+        } // namespace v4
     }     // namespace op
 
     NGRAPH_API


### PR DESCRIPTION
**Change list:**
1. Introduces `v4::NMS` operation that is out of the scope of existing opsets. It is inherrited from `opset3::NMS` with the only difference -- the output shape of this operation is always `PartialShape{?, 3}.`
2. `v3::NMS -> v4::NMS` transformation is added into the common transformations pipeline with the check if there is at least one NonZero operation inside the model to trigger the transformation.
3. Introduces `ngraph::vpu::op::StaticShapeNonMaxSuppression` -- it is inherrited from `opset3::NMS` with the assert that output shape is always static. 
4. Added DTS for `v4::NMS` covered by both graph comparison test & inference test (which is disabled)
  