### PR TITLE
[GNA]Added error trapping

### DIFF
--- a/inference-engine/src/gna_plugin/gna_graph_compiler.cpp
+++ b/inference-engine/src/gna_plugin/gna_graph_compiler.cpp
@@ -351,6 +351,10 @@ void GNAGraphCompiler::PowerPrimitive(InferenceEngine::CNNLayerPtr layer) {
     uint32_t num_rows_out = num_rows_in;
     uint32_t num_padding = ALIGN(num_rows_in, 8) - num_rows_in;
 
+    if (num_columns_in > 8) {
+        THROW_GNA_EXCEPTION << "GNA colomns_in should be less than 8 and now colomns_in = " << num_columns_in;
+    }
+
     void* ptr_inputs = nullptr;
     void* ptr_outputs = nullptr;
     void* ptr_weights = nullptr;

--- a/inference-engine/tests_deprecated/unit/engines/gna/layers/gna_conv1d_test.cpp
+++ b/inference-engine/tests_deprecated/unit/engines/gna/layers/gna_conv1d_test.cpp
@@ -108,5 +108,5 @@ INSTANTIATE_TEST_CASE_P(
                 testing::Values(1, 3, 9, 16, 24, 32, 42, 64),
                 testing::Values(0, 1),
                 testing::Values(0),
-                testing::Values(32, 128, 512)),
+                testing::Values(2, 4, 6, 8)),
         GNAConv1DTest::getTestName);


### PR DESCRIPTION
Now, if colomns_in receives an input more than 8, then it will throw an error of an unsupported parameter.