### PR TITLE
Temporary disable PriorBoxClustered tests due to rare sporadic failures

### DIFF
--- a/inference-engine/tests/functional/inference_engine/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/inference_engine/skip_tests_config.cpp
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+#include <string>
+
+#include "functional_test_utils/skip_tests_config.hpp"
+
+std::vector<std::string> disabledTestPatterns() {
+    return {
+        // TODO: FIX BUG 33375
+        // Disabled due to rare sporadic failures.
+        ".*TransformationTests\\.ConstFoldingPriorBoxClustered.*",
+    };
+}

--- a/inference-engine/tests/functional/inference_engine/transformations/const_folding_prior_box.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/const_folding_prior_box.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "common_test_utils/test_common.hpp"
+#include "functional_test_utils/skip_tests_config.hpp"
 #include <string>
 #include <memory>
 
@@ -61,8 +62,8 @@ TEST(TransformationTests, ConstFoldingPriorBox) {
     EXPECT_TRUE(fused->get_vector<float>() == ref->get_vector<float>());
 }
 
-// Disabled due to rare sporadic failures.
-TEST(TransformationTests, DISABLED_ConstFoldingPriorBoxClustered) {
+TEST(TransformationTests, ConstFoldingPriorBoxClustered) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
 
     {
@@ -162,10 +163,9 @@ TEST(TransformationTests, ConstFoldingPriorBoxSubgraph) {
     EXPECT_TRUE(fused->get_vector<float>() == ref->get_vector<float>());
 }
 
-// Disabled due to rare sporadic failures.
-TEST(TransformationTests, DISABLED_ConstFoldingPriorBoxClusteredSubgraph) {
+TEST(TransformationTests, ConstFoldingPriorBoxClusteredSubgraph) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
-
     {
         auto in = std::make_shared<ngraph::opset3::Parameter>(ngraph::element::i64, ngraph::Shape{2, 3, 2, 2});
         auto in_2 = std::make_shared<ngraph::opset3::Parameter>(ngraph::element::i64, ngraph::Shape{2, 3, 300, 300});

--- a/inference-engine/tests/functional/inference_engine/transformations/const_folding_prior_box.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/const_folding_prior_box.cpp
@@ -61,7 +61,8 @@ TEST(TransformationTests, ConstFoldingPriorBox) {
     EXPECT_TRUE(fused->get_vector<float>() == ref->get_vector<float>());
 }
 
-TEST(TransformationTests, ConstFoldingPriorBoxClustered) {
+// Disabled due to rare sporadic failures.
+TEST(TransformationTests, DISABLED_ConstFoldingPriorBoxClustered) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
 
     {
@@ -161,7 +162,8 @@ TEST(TransformationTests, ConstFoldingPriorBoxSubgraph) {
     EXPECT_TRUE(fused->get_vector<float>() == ref->get_vector<float>());
 }
 
-TEST(TransformationTests, ConstFoldingPriorBoxClusteredSubgraph) {
+// Disabled due to rare sporadic failures.
+TEST(TransformationTests, DISABLED_ConstFoldingPriorBoxClusteredSubgraph) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
 
     {


### PR DESCRIPTION
Disable sporadically falling tests. Investigating in progress. 
Current status: locally these tests pass (release/debug build gtests params: --gtest_repeat=100000 --gtest_break_on_failure on ubuntu 18) 
The root cause of the falls is unclear.