### PR TITLE
[LPT] Symmetric quantization support for efficientnet-b0

### DIFF
--- a/inference-engine/src/low_precision_transformations/src/layer_transformation.cpp
+++ b/inference-engine/src/low_precision_transformations/src/layer_transformation.cpp
@@ -41,7 +41,7 @@ LayerTransformation::LayerTransformation(const Params& params) :
     precisionsOnWeights(params.precisionsOnWeights),
     layerTransformationsManager(nullptr),
     paramsManager(nullptr),
-    quantizationIntervalAsymmetryThreshold(2.e-4),
+    quantizationIntervalAsymmetryThreshold(0.002f),
     zeroThreshold(1.e-6f),
     dequantizationShiftToZeroRatioTreshold(4.e-4f),
     minQuantizationLevels(2ul) {}


### PR DESCRIPTION
Bug 32484: [LPT] Invalid asymmetric quantization usage for efficientnet models on GPU