### PR TITLE
[IE CLDNN] Add resample improvements

### DIFF
--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/resample/resample_kernel_base.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/resample/resample_kernel_base.h
@@ -58,5 +58,6 @@ protected:
     virtual JitConstants GetJitConstants(const resample_params& params) const;
     KernelsData GetCommonKernelsData(const Params& params, const optional_params& options) const;
     size_t GetFeatureBlockSize(const resample_params& params) const;
+    virtual Datatype GetAccumulatorType(const resample_params& params) const;
 };
 }  // namespace kernel_selector

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/resample/resample_kernel_opt.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/resample/resample_kernel_opt.cpp
@@ -106,8 +106,8 @@ JitConstants ResampleKernelOpt::GetJitConstants(const resample_params &params) c
     jit.AddConstant(MakeJitConstant("VEC_SIZE", vec_size));
 
     if (!params.fused_ops.empty()) {
-        std::vector<std::string> idx_order = {"b", "feature_num", "y", "(x + out_x)"};
-        FusedOpsConfiguration conf = {"", idx_order, "res", params.inputs[0].GetDType(), vec_size, LoadType::LT_ALIGNED_READ};
+        std::vector<std::string> idx_order = {"b", "feature_block", "y", "(x + out_x)"};
+        FusedOpsConfiguration conf = {"", idx_order, "res", GetAccumulatorType(params), vec_size, LoadType::LT_ALIGNED_READ};
         conf.SetVectorAxis(Tensor::DataChannelName::FEATURE);
         jit.Merge(MakeFusedOpsJitConstants(params, {conf}));
     }

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/resample/resample_kernel_ref.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/resample/resample_kernel_ref.cpp
@@ -115,7 +115,7 @@ JitConstants ResampleKernelRef::GetJitConstants(const resample_params& params) c
             idx_order = {"batch", "OF_ID", "oz", "oy", "ox"};
         }
 
-        FusedOpsConfiguration conf = {"", idx_order, "interp_val", params.inputs[0].GetDType(), 1};
+        FusedOpsConfiguration conf = {"", idx_order, "interp_val", GetAccumulatorType(params), 1};
         jit.Merge(MakeFusedOpsJitConstants(params, {conf}));
     }
 

--- a/inference-engine/thirdparty/clDNN/src/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/inference-engine/thirdparty/clDNN/src/graph_optimizer/prepare_buffer_fusing.cpp
@@ -27,6 +27,7 @@
 #include "reshape_inst.h"
 #include "scale_inst.h"
 #include "depth_to_space_inst.h"
+#include "resample_inst.h"
 
 #include "pass_manager.h"
 #include "program_helpers.h"
@@ -136,7 +137,8 @@ void prepare_buffer_fusing::run(program_impl& p) {
                     // todo: we need add padding support for all optimized kernels to remove this condition
                     if (!input->is_type<pooling>() && !input->is_type<convolution>() &&
                         !input->is_type<activation>() && !input->is_type<deconvolution>() &&
-                        !input->is_type<concatenation>() && !input->is_type<crop>() && !input->is_type<scale>())
+                        !input->is_type<concatenation>() && !input->is_type<crop>() && !input->is_type<scale>() &&
+                        !input->is_type<resample>())
                         return;
 
                     // if an input is marked as network output, prevent optimizations

--- a/inference-engine/thirdparty/clDNN/src/resample.cpp
+++ b/inference-engine/thirdparty/clDNN/src/resample.cpp
@@ -32,6 +32,10 @@ layout resample_inst::calc_output_layout(resample_node const& node) {
     auto input_layout = node.input().get_output_layout();
 
     auto output_type = input_layout.data_type;
+    if ((input_layout.data_type == data_types::i8 || input_layout.data_type == data_types::u8)
+        && desc->operation_type != resample_type::nearest) {
+        output_type = data_types::f32;
+    }
     if (node.has_fused_primitives()) {
         output_type = node.get_fused_output_layout().data_type;
     }

--- a/inference-engine/thirdparty/clDNN/tests/test_cases/fusings_gpu_test.cpp
+++ b/inference-engine/thirdparty/clDNN/tests/test_cases/fusings_gpu_test.cpp
@@ -2332,6 +2332,16 @@ INSTANTIATE_TEST_CASE_P(fusings_gpu, gemm_int8_2in_act_scale_quantize_eltwise_i8
 #define CASE_RESAMPLE_FP16_9 {1, 16, 4, 5}, {1, 16, 7, 8}, data_types::f16, format::b_fs_yx_fsv16, resample_type::bilinear, data_types::f16, format::bfyx
 #define CASE_RESAMPLE_FP16_10 {2, 32, 4, 5}, {2, 32, 7, 8}, data_types::f16, format::fs_b_yx_fsv32, resample_type::bilinear, data_types::f16, format::bfyx
 
+#define CASE_RESAMPLE_I8_1 {1, 16, 4, 5}, {1, 16, 2, 3}, data_types::i8, format::b_fs_yx_fsv16, resample_type::nearest, data_types::f32, format::bfyx
+#define CASE_RESAMPLE_I8_2 {2, 32, 4, 5}, {2, 32, 2, 3}, data_types::i8, format::b_fs_yx_fsv16, resample_type::nearest, data_types::f32, format::bfyx
+#define CASE_RESAMPLE_I8_3 {1, 16, 4, 5}, {1, 16, 2, 3}, data_types::i8, format::b_fs_yx_fsv16, resample_type::bilinear, data_types::f32, format::bfyx
+#define CASE_RESAMPLE_I8_4 {2, 32, 4, 5}, {2, 32, 2, 3}, data_types::i8, format::b_fs_yx_fsv16, resample_type::bilinear, data_types::f32, format::bfyx
+
+#define CASE_RESAMPLE_U8_1 {1, 16, 4, 5}, {1, 16, 2, 3}, data_types::u8, format::b_fs_yx_fsv16, resample_type::nearest, data_types::f32, format::bfyx
+#define CASE_RESAMPLE_U8_2 {2, 32, 4, 5}, {2, 32, 2, 3}, data_types::u8, format::b_fs_yx_fsv16, resample_type::nearest, data_types::f32, format::bfyx
+#define CASE_RESAMPLE_U8_3 {1, 16, 4, 5}, {1, 16, 2, 3}, data_types::u8, format::b_fs_yx_fsv16, resample_type::bilinear, data_types::f32, format::bfyx
+#define CASE_RESAMPLE_U8_4 {2, 32, 4, 5}, {2, 32, 2, 3}, data_types::u8, format::b_fs_yx_fsv16, resample_type::bilinear, data_types::f32, format::bfyx
+
 class resample_quantize : public ResamplePrimitiveFusingTest {};
 TEST_P(resample_quantize, basic) {
     auto p = GetParam();
@@ -2410,6 +2420,126 @@ INSTANTIATE_TEST_CASE_P(fusings_gpu, resample_scale_activation,
                         resample_test_params{ CASE_RESAMPLE_FP16_8, 2, 4 },
                         resample_test_params{ CASE_RESAMPLE_FP16_9, 2, 4 },
                         resample_test_params{ CASE_RESAMPLE_FP16_10, 2, 4 },
+
+                        resample_test_params{ CASE_RESAMPLE_I8_1, 2, 4 },
+                        resample_test_params{ CASE_RESAMPLE_I8_2, 2, 4 },
+                        resample_test_params{ CASE_RESAMPLE_I8_3, 2, 4 },
+                        resample_test_params{ CASE_RESAMPLE_I8_4, 2, 4 },
+
+                        resample_test_params{ CASE_RESAMPLE_U8_1, 2, 4 },
+                        resample_test_params{ CASE_RESAMPLE_U8_2, 2, 4 },
+                        resample_test_params{ CASE_RESAMPLE_U8_3, 2, 4 },
+                        resample_test_params{ CASE_RESAMPLE_U8_4, 2, 4 },
+}), );
+
+class resample_quantize_concat : public ResamplePrimitiveFusingTest {};
+TEST_P(resample_quantize_concat, along_f) {
+    auto p = GetParam();
+    create_topologies(
+        input_layout("input", get_input_layout(p)),
+        resample("resample1", "input", p.out_shape, p.in_shape.feature[0], p.type),
+        data("in_lo_1", get_mem(get_per_channel_layout(p), min_random, 0)),
+        data("in_hi_1", get_mem(get_per_channel_layout(p), 1, max_random)),
+        data("out_lo_1", get_mem(get_single_element_layout(p), -128)),
+        data("out_hi_1", get_mem(get_single_element_layout(p), 127)),
+        quantize("quant1", "resample1", "in_lo_1", "in_hi_1", "out_lo_1", "out_hi_1", 256, data_types::i8),
+        resample("resample2", "input", p.out_shape, p.in_shape.feature[0], p.type),
+        data("in_lo_2", get_mem(get_per_channel_layout(p), min_random, 0)),
+        data("in_hi_2", get_mem(get_per_channel_layout(p), 1, max_random)),
+        data("out_lo_2", get_mem(get_single_element_layout(p), -127)),
+        data("out_hi_2", get_mem(get_single_element_layout(p), 127)),
+        quantize("quant2", "resample2", "in_lo_2", "in_hi_2", "out_lo_2", "out_hi_2", 255, data_types::i8),
+        concatenation("concat", { "quant1", "quant2" }, cldnn::concatenation::along_f),
+        reorder("reorder_bfyx", "concat", cldnn::format::bfyx, p.default_type)
+    );
+
+    tolerance = 1.f;
+    execute(p);
+}
+
+INSTANTIATE_TEST_CASE_P(fusings_gpu, resample_quantize_concat,
+    ::testing::ValuesIn(std::vector<resample_test_params>{
+                        resample_test_params{ CASE_RESAMPLE_FP32_1, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP32_2, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP32_3, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP32_4, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP32_5, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP32_6, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP32_7, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP32_8, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP32_9, 3, 6 },
+
+                        resample_test_params{ CASE_RESAMPLE_FP16_1, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP16_2, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP16_3, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP16_4, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP16_5, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP16_6, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP16_7, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP16_8, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP16_9, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP16_10, 3, 6 },
+
+                        resample_test_params{ CASE_RESAMPLE_I8_3, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_I8_4, 3, 6 },
+
+                        resample_test_params{ CASE_RESAMPLE_U8_3, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_U8_4, 3, 6 },
+}), );
+
+class resample_scale_concat : public ResamplePrimitiveFusingTest {};
+TEST_P(resample_scale_concat, along_f) {
+    auto p = GetParam();
+    create_topologies(
+        input_layout("input", get_input_layout(p)),
+        resample("resample1", "input", p.out_shape, p.in_shape.feature[0], p.type),
+        data("scale1_scale", get_mem(get_per_channel_layout(p), -10, 10)),
+        data("scale1_shift", get_mem(get_per_channel_layout(p), -10, 10)),
+        scale("scale1", "resample1", "scale1_scale", "scale1_shift"),
+        resample("resample2", "input", p.out_shape, p.in_shape.feature[0], p.type),
+        data("scale2_scale", get_mem(get_per_channel_layout(p), -10, 10)),
+        data("scale2_shift", get_mem(get_per_channel_layout(p), -10, 10)),
+        scale("scale2", "resample2", "scale2_scale", "scale2_shift"),
+        concatenation("concat", { "scale1", "scale2" }, cldnn::concatenation::along_f),
+        reorder("reorder_bfyx", "concat", cldnn::format::bfyx, p.default_type)
+    );
+
+    tolerance = 1e-5f;
+    execute(p);
+}
+
+INSTANTIATE_TEST_CASE_P(fusings_gpu, resample_scale_concat,
+    ::testing::ValuesIn(std::vector<resample_test_params>{
+                        resample_test_params{ CASE_RESAMPLE_FP32_1, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP32_2, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP32_3, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP32_4, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP32_5, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP32_6, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP32_7, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP32_8, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP32_9, 3, 6 },
+
+                        resample_test_params{ CASE_RESAMPLE_FP16_1, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP16_2, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP16_3, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP16_4, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP16_5, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP16_6, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP16_7, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP16_8, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP16_9, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_FP16_10, 3, 6 },
+
+                        resample_test_params{ CASE_RESAMPLE_I8_1, 3, 6},
+                        resample_test_params{ CASE_RESAMPLE_I8_2, 3, 6},
+                        resample_test_params{ CASE_RESAMPLE_I8_3, 3, 6},
+                        resample_test_params{ CASE_RESAMPLE_I8_4, 3, 6},
+
+                        resample_test_params{ CASE_RESAMPLE_U8_1, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_U8_2, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_U8_3, 3, 6 },
+                        resample_test_params{ CASE_RESAMPLE_U8_4, 3, 6 },
 }), );
 
 /* ----------------------------------------------------------------------------------------------------- */


### PR DESCRIPTION
This change:
- extends concat in-place optimization for resample on input
- adds resample primitive int8 support for bilinear mode
- fixes some potential issues with offset calculations in int8

JIRA: CVS-29775