### PR TITLE
[ICV] Fixes for IE windows build

### DIFF
--- a/inference-engine/samples/common/format_reader/bmp.h
+++ b/inference-engine/samples/common/format_reader/bmp.h
@@ -23,14 +23,14 @@ class BitMap : public Reader {
 private:
     static Register<BitMap> reg;
 
-    typedef struct {
+    typedef struct BmpHeaderType {
         unsigned short type   = 0u;              /* Magic identifier            */
         unsigned int size     = 0u;              /* File size in bytes          */
         unsigned int reserved = 0u;
         unsigned int offset   = 0u;              /* Offset to image data, bytes */
     } BmpHeader;
 
-    typedef struct {
+    typedef struct BmpInfoHeaderType {
         unsigned int size = 0u;                  /* Header size in bytes      */
         int width = 0, height = 0;               /* Width and height of image */
         unsigned short planes = 0u;              /* Number of colour planes   */

--- a/inference-engine/tests_deprecated/functional/vpu/shared_tests_instance/ie_class/ie_class.cpp
+++ b/inference-engine/tests_deprecated/functional/vpu/shared_tests_instance/ie_class/ie_class.cpp
@@ -66,8 +66,7 @@ TEST_P(IEClassNetworkTestP_VPU, smoke_ImportNetworkNoThrowWithDeviceName) {
     }
 }
 
-// #-29320
-TEST_P(IEClassNetworkTestP_VPU, DISABLED_smoke_ExportUsingFileNameImportFromStreamNoThrowWithDeviceName) {
+TEST_P(IEClassNetworkTestP_VPU, smoke_ExportUsingFileNameImportFromStreamNoThrowWithDeviceName) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
     Core ie;
     ExecutableNetwork executableNetwork;

--- a/inference-engine/thirdparty/movidius/mvnc/tests/cases/mvnc_common_test_cases.cpp
+++ b/inference-engine/thirdparty/movidius/mvnc/tests/cases/mvnc_common_test_cases.cpp
@@ -12,7 +12,7 @@ MvncTestsCommon::MvncTestsCommon() {
     // On linux we should use custom path to firmware due to another searching mechanism for library
     strcpy(firmwareDir, "./lib/");
 #else
-    firmwareDir[0] = "./";
+    strcpy(firmwareDir, "./");
 #endif
 }
 

--- a/inference-engine/thirdparty/movidius/mvnc/tests/mvnc_tests_usb.cpp
+++ b/inference-engine/thirdparty/movidius/mvnc/tests/mvnc_tests_usb.cpp
@@ -28,7 +28,7 @@ TEST_F(MvncOpenUSBDevice, ShouldOpenDeviceAfterChangeConnectTimeoutFromZero) {
 
     ASSERT_NO_ERROR(ncSetDeviceConnectTimeout(0));
     ASSERT_ERROR(ncDeviceOpen(&deviceHandle, deviceDesc, m_ncDeviceOpenParams));
-    std::this_thread::sleep_for(3_sec);
+    std::this_thread::sleep_for(5_sec);
     ASSERT_NO_ERROR(ncDeviceResetAll());
 
     ASSERT_NO_ERROR(ncSetDeviceConnectTimeout(30));

--- a/ngraph/src/ngraph/type/element_type.cpp
+++ b/ngraph/src/ngraph/type/element_type.cpp
@@ -325,6 +325,9 @@ size_t ngraph::compiler_byte_size(element::Type_t et)
     case element::Type_t::undefined: return 0;
     case element::Type_t::dynamic: return 0;
     }
+
+    throw ngraph_error("compiler_byte_size: Unsupported value of element::Type_t: " +
+                       std::to_string(static_cast<int>(et)));
 }
 
 namespace ngraph


### PR DESCRIPTION
- Named structures in bmp.h to avoid MSFT compiler error
- Fix for non-void function with missing return statement to avoid Intel compiler error
- Enabled "smoke_ExportUsingFileNameImportFromStreamNoThrowWithDeviceName" test
- Fix for MvncTest