### PR TITLE
[IE CLDNN] Fix device release with static plugin instance

### DIFF
--- a/inference-engine/tests/functional/plugin/gpu/remote_blob_tests/cldnn_remote_blob_tests.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/remote_blob_tests/cldnn_remote_blob_tests.cpp
@@ -98,8 +98,8 @@ TEST_F(RemoteBlob_Test, canInferOnUserContext) {
 
     auto blob = FuncTestUtils::createAndFillBlob(net.getInputsInfo().begin()->second->getTensorDesc());
 
-    auto ie = InferenceEngine::Core();
-    auto exec_net_regular = ie.LoadNetwork(net, CommonTestUtils::DEVICE_GPU);
+    auto ie = PluginCache::get().ie();
+    auto exec_net_regular = ie->LoadNetwork(net, CommonTestUtils::DEVICE_GPU);
 
     // regular inference
     auto inf_req_regular = exec_net_regular.CreateInferRequest();
@@ -111,8 +111,8 @@ TEST_F(RemoteBlob_Test, canInferOnUserContext) {
 
     // inference using remote blob
     auto ocl_instance = std::make_shared<OpenCL>();
-    auto remote_context = make_shared_context(ie, CommonTestUtils::DEVICE_GPU, ocl_instance->_context.get());
-    auto exec_net_shared = ie.LoadNetwork(net, remote_context);
+    auto remote_context = make_shared_context(*ie, CommonTestUtils::DEVICE_GPU, ocl_instance->_context.get());
+    auto exec_net_shared = ie->LoadNetwork(net, remote_context);
     auto inf_req_shared = exec_net_shared.CreateInferRequest();
     inf_req_shared.SetBlob(net.getInputsInfo().begin()->first, fakeImageData);
 

--- a/inference-engine/tests/functional/plugin/shared/src/execution_graph_tests/num_inputs_fusing_bin_conv.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/execution_graph_tests/num_inputs_fusing_bin_conv.cpp
@@ -45,9 +45,6 @@ void ExecGraphInputsFusingBinConv::SetUp() {
 }
 
 void ExecGraphInputsFusingBinConv::TearDown() {
-    if (targetDevice.find(CommonTestUtils::DEVICE_GPU) != std::string::npos) {
-        PluginCache::get().reset();
-    }
 }
 
 TEST_P(ExecGraphInputsFusingBinConv, CheckNumInputsInBinConvFusingWithConv) {

--- a/inference-engine/tests/functional/plugin/shared/src/execution_graph_tests/unique_node_names.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/execution_graph_tests/unique_node_names.cpp
@@ -57,9 +57,6 @@ void ExecGraphUniqueNodeNames::SetUp() {
 }
 
 void ExecGraphUniqueNodeNames::TearDown() {
-    if (targetDevice.find(CommonTestUtils::DEVICE_GPU) != std::string::npos) {
-        PluginCache::get().reset();
-    }
 }
 
 TEST_P(ExecGraphUniqueNodeNames, CheckUniqueNodeNames) {

--- a/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/convolution_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/convolution_transformation.cpp
@@ -117,10 +117,6 @@ void ConvolutionTransformation::validate() {
 
 TEST_P(ConvolutionTransformation, CompareWithRefImpl) {
     Run();
-
-    if (targetDevice == std::string{CommonTestUtils::DEVICE_GPU}) {
-        PluginCache::get().reset();
-    }
 };
 
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/permute_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/permute_transformation.cpp
@@ -98,10 +98,6 @@ void PermuteTransformation::validate() {
 
 TEST_P(PermuteTransformation, CompareWithRefImpl) {
     Run();
-
-    if (targetDevice == std::string{CommonTestUtils::DEVICE_GPU}) {
-        PluginCache::get().reset();
-    }
 };
 
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/reshape_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/reshape_transformation.cpp
@@ -99,10 +99,6 @@ void ReshapeTransformation::validate() {
 
 TEST_P(ReshapeTransformation, CompareWithRefImpl) {
     Run();
-
-    if (targetDevice == std::string{CommonTestUtils::DEVICE_GPU}) {
-        PluginCache::get().reset();
-    }
 };
 
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/equal.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/equal.cpp
@@ -52,9 +52,5 @@ void EqualLayerTest::SetUp() {
 
 TEST_P(EqualLayerTest, CompareWithRefs) {
     Run();
-
-    if (targetDevice == std::string{CommonTestUtils::DEVICE_GPU}) {
-        PluginCache::get().reset();
-    }
 }
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/greater.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/greater.cpp
@@ -52,9 +52,5 @@ void GreaterLayerTest::SetUp() {
 
 TEST_P(GreaterLayerTest, CompareWithRefs) {
     Run();
-
-    if (targetDevice == std::string{CommonTestUtils::DEVICE_GPU}) {
-        PluginCache::get().reset();
-    }
 }
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/select.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/select.cpp
@@ -61,10 +61,6 @@ namespace LayerTestsDefinitions {
 
     TEST_P(SelectLayerTest, CompareWithRefImpl) {
         Run();
-
-        if (targetDevice == std::string{CommonTestUtils::DEVICE_GPU}) {
-            PluginCache::get().reset();
-        }
     }
 
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/subgraph_tests/concat_qunatization.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/subgraph_tests/concat_qunatization.cpp
@@ -82,10 +82,6 @@ TEST_P(ConcatQuantization, CompareWithRefImpl) {
     catch (InferenceEngine::details::InferenceEngineException ex) {
         FAIL() << ex.what();
     }
-
-    if (targetDevice == std::string{CommonTestUtils::DEVICE_GPU}) {
-        PluginCache::get().reset();
-    }
 };
 
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/subgraph_tests/reshape_permute_reshape.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/subgraph_tests/reshape_permute_reshape.cpp
@@ -48,9 +48,7 @@ namespace LayerTestsDefinitions {
         function = std::make_shared<ngraph::Function>(reshape2, input, "reshape_permute_reshape");
     }
 
-    TEST_P(ReshapePermuteReshape, CompareWithRefs){
+    TEST_P(ReshapePermuteReshape, CompareWithRefs) {
         Run();
-        if (targetDevice == std::string{CommonTestUtils::DEVICE_GPU}) {
-            PluginCache::get().reset();
-        }    };
+    }
 } // namespace LayerTestsDefinitions

--- a/inference-engine/tests/ie_test_utils/functional_test_utils/behavior_test_utils.hpp
+++ b/inference-engine/tests/ie_test_utils/functional_test_utils/behavior_test_utils.hpp
@@ -58,7 +58,7 @@ public:
     }
 
     void TearDown() override {
-        if ((targetDevice == CommonTestUtils::DEVICE_GPU) || (!configuration.empty())) {
+        if (!configuration.empty()) {
             PluginCache::get().reset();
         }
         function.reset();

--- a/inference-engine/tests/ie_test_utils/functional_test_utils/layer_test_utils.cpp
+++ b/inference-engine/tests/ie_test_utils/functional_test_utils/layer_test_utils.cpp
@@ -20,7 +20,7 @@ void LayerTestsCommon::Run() {
 }
 
 LayerTestsCommon::~LayerTestsCommon() {
-    if (!configuration.empty() || targetDevice.find(CommonTestUtils::DEVICE_GPU) != std::string::npos) {
+    if (!configuration.empty()) {
         PluginCache::get().reset();
     }
 }

--- a/inference-engine/tests_deprecated/functional/shared_tests/inference_engine_regression_tests/common_dyn_batch_regression.hpp
+++ b/inference-engine/tests_deprecated/functional/shared_tests/inference_engine_regression_tests/common_dyn_batch_regression.hpp
@@ -78,9 +78,6 @@ TEST_P(TestNoRegressionDynBatchFP32, dynBatch) {
                                      outElementsCount, outElementsCount,
                                      FuncTestUtils::CompareType::ABS_AND_REL,
                                      thr1, thr2);
-    if (GetParam().deviceName.find(CommonTestUtils::DEVICE_GPU) != std::string::npos) {
-        PluginCache::get().reset();
-    }
 }
 
 std::string getTestCaseName(TestParamInfo<CommonDynBatchFuncTestParams> obj) {

--- a/inference-engine/tests_deprecated/functional/shared_tests/io_blob_tests/cropResize_tests.hpp
+++ b/inference-engine/tests_deprecated/functional/shared_tests/io_blob_tests/cropResize_tests.hpp
@@ -131,9 +131,6 @@ protected:
     }
 
     void TearDown() override {
-        if (_device.find(CommonTestUtils::DEVICE_GPU) != std::string::npos) {
-            PluginCache::get().reset();
-        }
     }
 
 public:

--- a/inference-engine/tests_deprecated/functional/shared_tests/io_blob_tests/dims_tests.hpp
+++ b/inference-engine/tests_deprecated/functional/shared_tests/io_blob_tests/dims_tests.hpp
@@ -49,11 +49,7 @@ protected:
     }
 
     void TearDown() override {
-        if (deviceName.find(CommonTestUtils::DEVICE_GPU) != std::string::npos) {
-            PluginCache::get().reset();
-        }
     }
-
 
     std::string ConvNet(const int batch, TBlob<uint8_t>::Ptr &weights) {
         if (netPrc == Precision::FP32) {

--- a/inference-engine/tests_deprecated/functional/shared_tests/io_blob_tests/layout_tests.hpp
+++ b/inference-engine/tests_deprecated/functional/shared_tests/io_blob_tests/layout_tests.hpp
@@ -139,9 +139,6 @@ protected:
     }
 
     void TearDown() override {
-        if (_device.find(CommonTestUtils::DEVICE_GPU) != std::string::npos) {
-            PluginCache::get().reset();
-        }
     }
 
     template <Precision::ePrecision PRC>

--- a/inference-engine/thirdparty/clDNN/src/include/device_impl.h
+++ b/inference-engine/thirdparty/clDNN/src/include/device_impl.h
@@ -87,7 +87,7 @@ private:
 struct device_impl : public refcounted_obj<device_impl> {
 public:
     explicit device_impl(const cl::Device dev, const cl::Context& ctx, const cl_platform_id platform, const gpu::device_info_internal& info)
-        : _device(dev), _context(ctx), _platform(platform), _info(info), _mem_caps(_info.supports_usm, _device) { }
+        : _context(ctx), _device(dev), _platform(platform), _info(info), _mem_caps(_info.supports_usm, _device) { }
 
     gpu::device_info_internal get_info() const { return _info; }
     cl::Device get_device() const { return _device; }
@@ -98,8 +98,8 @@ public:
     ~device_impl() = default;
 
 private:
-    cl::Device _device;
     cl::Context _context;
+    cl::Device _device;
     cl_platform_id _platform;
     gpu::device_info_internal _info;
     memory_capabilities _mem_caps;


### PR DESCRIPTION
The problem was in order of freeing memory. _context was removed before
_device and it looks like cl::Device in destructor tries to read some
info from cl::Context. And in this case we got this problem with
addressing because the memory already was freed.

For fixing the problem I changed the order of constructing members. And
based on principle: "First constructed, last destructed", the problem
was fixed.

JIRA: 29649