### PR TITLE
[IE CLDNN] Fix activation implementation for fsv16 format

### DIFF
--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/activation_ref.cl
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/activation_ref.cl
@@ -79,6 +79,12 @@ KERNEL(activation)(
 #endif
 #endif
 
+#if defined(OUTPUT_LAYOUT_B_FS_YX_FSV16) && OUTPUT_FEATURE_NUM % 16 != 0
+    // b_fs_yx_fsv16 has dispatch features aligned to multiple of 16
+    if (feature >= OUTPUT_FEATURE_NUM)
+        return;
+#endif
+
     const unsigned src_index = GET_INDEX(INPUT,0,ORDER);
     const unsigned dst_index = GET_INDEX(OUTPUT,,ORDER);
 


### PR DESCRIPTION
For b_fs_yx_fsv16 format in reference kernel features for dispatch are
rounded to multiple of 16. This change adds correct check in kernel to
return work-items that are inside this dispatch padding.
Previously those work-items could corrupt memory expected to be filled
with 0s, and for parametrized activation due to bounds checking with
modulo operator they could have been corrupting actual layer output.

Issue: CVS-27672

master PR: #1037 