### PR TITLE
[IE CLDNN] WA to 1d input for concat

### DIFF
--- a/inference-engine/src/cldnn_engine/cldnn_program.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_program.cpp
@@ -3535,10 +3535,25 @@ void Program::AddConstantBlobInput(cldnn::topology& topology, InferenceEngine::C
         return false;
     };
 
+    // WA to inconsistency between input and const 1d tensors
+    // For Concat along batch we go with batch interpretation
+    bool concatAlongBatch = false;
+    if (constDims.size() == 1) {
+        for (auto next : GetNextLayers(layer->outData[0])) {
+            if (LayerTypeFromStr(next->type) == Concatenate) {
+                auto nextConcat = as<InferenceEngine::ConcatLayer*>(next);
+                if (nextConcat->_axis == cldnn::concatenation::concatenation_axis::along_b) {
+                    concatAlongBatch = true;
+                    break;
+                }
+            }
+        }
+    }
+
     // If quantize on weights has per-channel ranges, we have to swap channel and batch dimensions, because
     // quantization should be applied per output channel of weights
     // TODO: Check if it's still needed once LowPrecisionTransformations ready
-    if (inputToConstQuantize(layer)) {
+    if (inputToConstQuantize(layer) || concatAlongBatch) {
         constTensor.batch[0] = constTensor.count();
         constTensor.feature[0] = 1;
     }


### PR DESCRIPTION
This is a workaround to inconsistency between input and const 1d tensors.
For concatenation along batch we go with batch interpretation.
Jira: CVS-33081
PR to 2020.4 release is #1040