### PR TITLE
Cherry-pick fix OneHot transformation for Bert Squad opset 10

### DIFF
--- a/model-optimizer/automation/package_BOM.txt
+++ b/model-optimizer/automation/package_BOM.txt
@@ -222,6 +222,7 @@ extensions/front/mxnet/where_ext.py
 extensions/front/mxnet/yolo_v3_mobilenet1_voc.json
 extensions/front/mxnet/zeros_ext.py
 extensions/front/no_op_eraser.py
+extensions/front/OneHotDepthNormalizer.py
 extensions/front/onnx/__init__.py
 extensions/front/onnx/activation_ext.py
 extensions/front/onnx/affine_ext.py

--- a/model-optimizer/extensions/front/OneHotDepthNormalizer.py
+++ b/model-optimizer/extensions/front/OneHotDepthNormalizer.py
@@ -14,13 +14,9 @@
  limitations under the License.
 """
 
-import logging as log
-
-from extensions.back.ElementwiseOpsToEltwiseOps import SimpleEltwiseToEltwiseOp
-from extensions.back.ReshapeMutation import ReshapeMutation
 from mo.front.common.partial_infer.utils import int64_array
 from mo.front.common.replacement import FrontReplacementPattern
-from mo.front.tf.graph_utils import create_op_node_with_second_input, create_op_with_const_inputs
+from mo.front.tf.graph_utils import create_op_with_const_inputs
 from mo.graph.graph import Graph
 from mo.ops.reshape import Reshape
 

--- a/model-optimizer/extensions/front/OneHotDepthNormalizer.py
+++ b/model-optimizer/extensions/front/OneHotDepthNormalizer.py
@@ -1,0 +1,47 @@
+"""
+ Copyright (C) 2020 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import logging as log
+
+from extensions.back.ElementwiseOpsToEltwiseOps import SimpleEltwiseToEltwiseOp
+from extensions.back.ReshapeMutation import ReshapeMutation
+from mo.front.common.partial_infer.utils import int64_array
+from mo.front.common.replacement import FrontReplacementPattern
+from mo.front.tf.graph_utils import create_op_node_with_second_input, create_op_with_const_inputs
+from mo.graph.graph import Graph
+from mo.ops.reshape import Reshape
+
+
+class OneHotDepthNormalizer(FrontReplacementPattern):
+    """
+    Transformation performs safe replacement of the 0D constants with 1D for a specific operations. This transformation
+    allows to avoid problems with the fact that not all layers correctly handle 0D tensors during the constant folding.
+    """
+    enabled = True
+    force_clean_up = True
+
+    def pattern(self):
+        return dict(
+            nodes=[
+                ('onehot', dict(kind='op', type='OneHot'))],
+            edges=[]
+        )
+
+    @staticmethod
+    def replace_pattern(graph: Graph, match: dict):
+        node = match['onehot']
+        reshape = create_op_with_const_inputs(graph, Reshape, {1: int64_array([])})
+        node.in_port(1).get_connection().insert_node(reshape)

--- a/model-optimizer/extensions/front/OneHotDepthNormalizer_test.py
+++ b/model-optimizer/extensions/front/OneHotDepthNormalizer_test.py
@@ -1,0 +1,58 @@
+"""
+ Copyright (C) 2020 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import unittest
+
+from extensions.front.OneHotDepthNormalizer import OneHotDepthNormalizer
+from mo.front.common.partial_infer.utils import int64_array
+from mo.utils.ir_engine.compare_graphs import compare_graphs
+from mo.utils.unittest.graph import build_graph, result, \
+    regular_op, const
+
+
+class OneHotDepthNormalizerTest(unittest.TestCase):
+    def test(self):
+        nodes = {
+            **regular_op('input', {'type': 'Parameter'}),
+            **const('depth', int64_array([2])),
+            **regular_op('onehot', {'type': 'OneHot', 'kind': 'op', 'op': 'OneHot'}),
+
+            **regular_op('reshape', {'type': 'Reshape', 'kind': 'op', 'op': 'Reshape'}),
+            **const('reshape_dims', int64_array([])),
+            **result('result'),
+        }
+        edges = [('input', 'onehot'),
+                 ('depth', 'onehot'),
+                 ('onehot', 'result'),
+                 ]
+        graph = build_graph(nodes, edges)
+
+        graph.graph['layout'] = 'NCHW'
+        graph.stage = 'front'
+
+        edges_ref = [('input', 'onehot'),
+                     ('depth', 'reshape'),
+                     ('reshape_dims', 'reshape'),
+                     ('reshape', 'onehot'),
+                     ('onehot', 'result'),
+                     ]
+
+        graph_ref = build_graph(nodes, edges_ref)
+
+        OneHotDepthNormalizer().find_and_replace_pattern(graph)
+
+        (flag, resp) = compare_graphs(graph, graph_ref, 'result')
+        self.assertTrue(flag, resp)

--- a/model-optimizer/extensions/front/split_normalizer_test.py
+++ b/model-optimizer/extensions/front/split_normalizer_test.py
@@ -1,0 +1,95 @@
+"""
+ Copyright (C) 2020 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import unittest
+
+from extensions.front.split_normalizer import SqueezeAxis
+from mo.front.common.partial_infer.utils import int64_array
+from mo.utils.ir_engine.compare_graphs import compare_graphs
+from mo.utils.unittest.graph import build_graph, const
+
+nodes_attributes = {
+    'placeholder': {'shape': None, 'type': 'Parameter', 'kind': 'op', 'op': 'Parameter'},
+    'attr_split': {'type': None, 'kind': 'op', 'op': 'AttributedSplit', 'axis': 0, 'num_splits': 2,
+                   'squeeze_axis': True},
+    'split': {'type': 'Split', 'kind': 'op', 'op': 'Split', 'num_splits': 2, 'squeeze_axis': True},
+    **const('split_axis', int64_array(0)),
+    'concat': {'type': 'Concat', 'kind': 'op', 'op': 'Concat', 'axis': 0},
+    'result': {'type': 'Result', 'value': None, 'kind': 'op', 'op': 'Result'},
+
+    'squeeze1': {'type': 'Squeeze', 'kind': 'op', 'op': 'Squeeze'},
+    'squeeze2': {'type': 'Squeeze', 'kind': 'op', 'op': 'Squeeze'},
+    **const('squeeze1_axis', int64_array(0)),
+    **const('squeeze2_axis', int64_array(0)),
+}
+
+
+class SqueezeAxisTest(unittest.TestCase):
+    def test_attributed(self):
+        graph = build_graph(nodes_attributes,
+                            [('placeholder', 'attr_split', {'in': 0, 'out': 0}),
+                             ('attr_split', 'concat', {'in': 0, 'out': 0}),
+                             ('attr_split', 'concat', {'in': 1, 'out': 1}),
+                             ('concat', 'result', {'in': 0, 'out': 0}),
+                             ], nodes_with_edges_only=True)
+
+        graph_ref = build_graph(nodes_attributes,
+                                [('placeholder', 'attr_split', {'in': 0, 'out': 0}),
+                                 ('attr_split', 'squeeze1', {'in': 0, 'out': 0}),
+                                 ('squeeze1_axis', 'squeeze1', {'in': 1, 'out': 0}),
+                                 ('attr_split', 'squeeze2', {'in': 0, 'out': 1}),
+                                 ('squeeze2_axis', 'squeeze2', {'in': 1, 'out': 0}),
+                                 ('squeeze1', 'concat', {'in': 0, 'out': 0}),
+                                 ('squeeze2', 'concat', {'in': 1, 'out': 0}),
+                                 ('concat', 'result', {'in': 0, 'out': 0}),
+                                 ], nodes_with_edges_only=True)
+
+        graph.graph['layout'] = 'NCHW'
+        graph.stage = 'front'
+
+        SqueezeAxis().find_and_replace_pattern(graph)
+
+        (flag, resp) = compare_graphs(graph, graph_ref, 'result', check_op_attrs=True)
+        self.assertTrue(flag, resp)
+
+    def test_split(self):
+        graph = build_graph(nodes_attributes,
+                            [('placeholder', 'split', {'in': 0, 'out': 0}),
+                             ('split_axis', 'split', {'in': 1, 'out': 0}),
+                             ('split', 'concat', {'in': 0, 'out': 0}),
+                             ('split', 'concat', {'in': 1, 'out': 1}),
+                             ('concat', 'result', {'in': 0, 'out': 0}),
+                             ], nodes_with_edges_only=True)
+
+        graph_ref = build_graph(nodes_attributes,
+                                [('placeholder', 'split', {'in': 0, 'out': 0}),
+                                 ('split_axis', 'split', {'in': 1, 'out': 0}),
+                                 ('split', 'squeeze1', {'in': 0, 'out': 0}),
+                                 ('split_axis', 'squeeze1', {'in': 1, 'out': 0}),
+                                 ('split', 'squeeze2', {'in': 0, 'out': 1}),
+                                 ('split_axis', 'squeeze2', {'in': 1, 'out': 0}),
+                                 ('squeeze1', 'concat', {'in': 0, 'out': 0}),
+                                 ('squeeze2', 'concat', {'in': 1, 'out': 0}),
+                                 ('concat', 'result', {'in': 0, 'out': 0}),
+                                 ], nodes_with_edges_only=True)
+
+        graph.graph['layout'] = 'NCHW'
+        graph.stage = 'front'
+
+        SqueezeAxis().find_and_replace_pattern(graph)
+
+        (flag, resp) = compare_graphs(graph, graph_ref, 'result', check_op_attrs=True)
+        self.assertTrue(flag, resp)

--- a/model-optimizer/extensions/ops/one_hot.py
+++ b/model-optimizer/extensions/ops/one_hot.py
@@ -17,6 +17,7 @@ import numpy as np
 
 from mo.graph.graph import Node, Graph
 from mo.ops.op import Op
+from mo.utils.error import Error
 
 
 class OneHot(Op):
@@ -42,7 +43,7 @@ class OneHot(Op):
 
     def supported_attrs(self):
         if self.ir_version < 10:
-            return ['axis', 'on_value', 'off_value', 'depth',]
+            return ['axis', 'on_value', 'off_value', 'depth', ]
         else:
             return ['axis']
 
@@ -51,14 +52,15 @@ class OneHot(Op):
         indices_shape = node.in_port(0).data.get_shape()
         assert indices_shape is not None
         dim = indices_shape.size
+        node_name = node.soft_get('name', node.id)
 
         if node.in_port(1).disconnected():  # IR v7 version
-            assert node.has_valid('depth'), 'The node "{}" must have attribute "depth"'.format(node.name)
+            assert node.has_valid('depth'), 'The node "{}" must have attribute "depth"'.format(node_name)
             depth = node.depth
         else:
-            assert_msg = "OneHot `{0}` ({1} input port value) should be scalar: node: `{2}`, {0} value: `{3}`"
+            assert_msg = "OneHot `{0}` (1 input port value) should be scalar: node: `{1}`, {0} value: `{2}`"
             depth = node.in_port(1).data.get_value()
-            assert depth is not None and depth.ndim == 0, assert_msg.format('depth', '1', node.name, depth)
+            assert depth is not None and depth.size == 1, assert_msg.format('depth', node_name, depth)
             depth = depth.item(0)
 
         assert node.has_valid('axis')

--- a/model-optimizer/extensions/ops/one_hot.py
+++ b/model-optimizer/extensions/ops/one_hot.py
@@ -17,7 +17,6 @@ import numpy as np
 
 from mo.graph.graph import Node, Graph
 from mo.ops.op import Op
-from mo.utils.error import Error
 
 
 class OneHot(Op):
@@ -43,7 +42,7 @@ class OneHot(Op):
 
     def supported_attrs(self):
         if self.ir_version < 10:
-            return ['axis', 'on_value', 'off_value', 'depth', ]
+            return ['axis', 'on_value', 'off_value', 'depth',]
         else:
             return ['axis']
 
@@ -52,15 +51,14 @@ class OneHot(Op):
         indices_shape = node.in_port(0).data.get_shape()
         assert indices_shape is not None
         dim = indices_shape.size
-        node_name = node.soft_get('name', node.id)
 
         if node.in_port(1).disconnected():  # IR v7 version
-            assert node.has_valid('depth'), 'The node "{}" must have attribute "depth"'.format(node_name)
+            assert node.has_valid('depth'), 'The node "{}" must have attribute "depth"'.format(node.name)
             depth = node.depth
         else:
-            assert_msg = "OneHot `{0}` (1 input port value) should be scalar: node: `{1}`, {0} value: `{2}`"
+            assert_msg = "OneHot `{0}` ({1} input port value) should be scalar: node: `{2}`, {0} value: `{3}`"
             depth = node.in_port(1).data.get_value()
-            assert depth is not None and depth.size == 1, assert_msg.format('depth', node_name, depth)
+            assert depth is not None and depth.ndim == 0, assert_msg.format('depth', '1', node.name, depth)
             depth = depth.item(0)
 
         assert node.has_valid('axis')


### PR DESCRIPTION
Bertsquad opset 10 from ONNX model zoo has OneHot with depth [2].

Code:

* [x] Comments
* [x] Code style (PEP8)
* [x] Transformation generates reshape-able IR
* [x] Transformation preserves node names

Validation:

* [x] Unit tests
* [x] Transformation tests
* [x] MO IR Reader check

Documentation:

* [x] Supported frameworks operations list: N/A - no new operation
* [x] Supported **public** models list: N/A - no docs in opensource
* [x] New operations specification: N/A - no new operation
* [x] Guide on how to convert the **public** model: N/A - no guide needed
* [x] User guide update: N/A - no update needed

Other:

* [x] Sample/Demo application to infer the model: N/A - no sample needed
