### PR TITLE
Fix the case with nodes containing ":" in names

### DIFF
--- a/model-optimizer/mo/front/extractor_test.py
+++ b/model-optimizer/mo/front/extractor_test.py
@@ -19,8 +19,8 @@ import unittest
 import numpy as np
 from generator import generator, generate
 
-from mo.front.extractor import input_user_data_repack, output_user_data_repack, extract_port_from_string, \
-    update_ie_fields, add_input_op
+from mo.front.extractor import input_user_data_repack, output_user_data_repack, update_ie_fields, add_input_op, \
+    get_node_id_with_ports
 from mo.front.extractor import spatial_attr_getter, add_input_ops, attr_getter, CaffePythonFrontExtractorOp, \
     add_output_ops
 from mo.graph.graph import Node
@@ -443,6 +443,7 @@ class TestInputAddition(unittest.TestCase):
         self.assertTrue((new_input, 'conv_data') in graph.edges())
         self.assertTrue(('conv_1', 'conv_data') not in graph.edges())
 
+
 @generator
 class TestOutputCut(unittest.TestCase):
     # {'embeddings': [{'port': None}]}
@@ -601,29 +602,49 @@ class TestUserDataRepack(unittest.TestCase):
 
 
 class TestExtractPort(unittest.TestCase):
+    def setUp(self) -> None:
+        nodes = {
+            'input_id': {'type': 'Parameter', 'kind': 'op', 'op': 'Parameter', 'name': '1input1:0'},
+            'conv_id': {'type': 'Convolution', 'kind': 'op', 'op': 'NotPlaceholder', 'name': '1input1'},
+            'relu_id': {'type': 'ReLU', 'kind': 'op', 'op': 'NotPlaceholder', 'name': 'relu'},
+            'squeeze_id': {'type': 'Squeeze', 'kind': 'op', 'op': 'NotPlaceholder', 'name': 'relu:0'},
+        }
+        edges = [
+            ('input_id', 'conv_id'),
+            ('conv_id', 'relu_id'),
+            ('relu_id', 'squeeze_id'),
+        ]
+        self.graph = build_graph(nodes, edges)
+
     def test_out_port(self):
-        name, in_port, out_port = extract_port_from_string('node_name:1')
-        self.assertEqual(name, 'node_name')
-        self.assertEqual(in_port, None)
-        self.assertEqual(out_port, 1)
+        node_id, direction, port = get_node_id_with_ports(self.graph, '1input1:0:0')
+        self.assertEqual(node_id, 'input_id')
+        self.assertEqual(direction, 'out')
+        self.assertEqual(port, 0)
 
     def test_in_port(self):
-        name, in_port, out_port = extract_port_from_string('0:node_name')
-        self.assertEqual(name, 'node_name')
-        self.assertEqual(in_port, 0)
-        self.assertEqual(out_port, None)
+        node_id, direction, port = get_node_id_with_ports(self.graph, '0:1input1:0')
+        self.assertEqual(node_id, 'input_id')
+        self.assertEqual(direction, 'in')
+        self.assertEqual(port, 0)
 
-    def test_no_port(self):
-        name, in_port, out_port = extract_port_from_string('node_name')
-        self.assertEqual(name, 'node_name')
-        self.assertEqual(in_port, None)
-        self.assertEqual(out_port, None)
+    def test_no_port1(self):
+        node_id, direction, port = get_node_id_with_ports(self.graph, '1input1')
+        self.assertEqual(node_id, 'conv_id')
+        self.assertEqual(direction, 'port')
+        self.assertEqual(port, None)
+
+    def test_no_port2(self):
+        node_id, direction, port = get_node_id_with_ports(self.graph, '1input1:0')
+        self.assertEqual(node_id, 'input_id')
+        self.assertEqual(direction, 'port')
+        self.assertEqual(port, None)
 
     def test_non_int(self):
-        self.assertRaises(Error, extract_port_from_string, 'port:node_name')
+        self.assertRaises(Error, get_node_id_with_ports, self.graph, 'port:1input1')
 
     def test_two_ports(self):
-        self.assertRaises(Error, extract_port_from_string, '1:node_name:0')
+        self.assertRaises(Error, get_node_id_with_ports, self.graph, '0:1input1:1')
 
 
 class TestCaffePythonFrontExtractorOp(unittest.TestCase):

--- a/model-optimizer/mo/front/extractor_test.py
+++ b/model-optimizer/mo/front/extractor_test.py
@@ -622,7 +622,13 @@ class TestExtractPort(unittest.TestCase):
         self.assertEqual(direction, 'out')
         self.assertEqual(port, 0)
 
-    def test_in_port(self):
+    def test_in_port1(self):
+        node_id, direction, port = get_node_id_with_ports(self.graph, '0:1input1')
+        self.assertEqual(node_id, 'conv_id')
+        self.assertEqual(direction, 'in')
+        self.assertEqual(port, 0)
+
+    def test_in_port2(self):
         node_id, direction, port = get_node_id_with_ports(self.graph, '0:1input1:0')
         self.assertEqual(node_id, 'input_id')
         self.assertEqual(direction, 'in')
@@ -635,10 +641,7 @@ class TestExtractPort(unittest.TestCase):
         self.assertEqual(port, None)
 
     def test_no_port2(self):
-        node_id, direction, port = get_node_id_with_ports(self.graph, '1input1:0')
-        self.assertEqual(node_id, 'input_id')
-        self.assertEqual(direction, 'port')
-        self.assertEqual(port, None)
+        self.assertRaises(Error, get_node_id_with_ports, self.graph, '1input1:0')
 
     def test_non_int(self):
         self.assertRaises(Error, get_node_id_with_ports, self.graph, 'port:1input1')

--- a/model-optimizer/mo/utils/unittest/graph.py
+++ b/model-optimizer/mo/utils/unittest/graph.py
@@ -19,7 +19,6 @@ from copy import deepcopy
 import networkx as nx
 
 from mo.front.common.partial_infer.utils import int64_array
-from mo.front.extractor import extract_port_from_string
 from mo.graph.graph import Node, Graph
 from mo.middle.pattern_match import all_edges_in_nodes
 from mo.ops.const import Const
@@ -285,6 +284,37 @@ shaped_const_with_data = lambda name, shape: {**fake_const(name, shape), **shape
 valued_const_with_data = lambda name, value: {**const(name, value), **valued_data(name + '_d', value)}
 
 const_with_data = lambda name, value: {**const(name, value), **valued_data(name + '_d', value)}
+
+
+def extract_port_from_string(node_name: str):
+    """
+    Extracts port and node name from string
+
+    Raises if node name was not provided in the expected format:
+    NODE:OUT_PORT
+        or
+    IN_PORT:NODE
+
+    :param node_name: string value provided by user
+    :return: node name, input port and output port
+    """
+    parts = node_name.split(':')
+    if len(parts) > 2:
+        raise Error("Please provide only one port number for {}. Expected format is NODE:OUT_PORT or IN_PORT:NODE, "
+                    "where IN_PORT and OUTPUT_PORT are integers".format(node_name))
+    if len(parts) == 1:
+        return node_name, None, None
+    else:
+        in_port, out_port, name = None, None, None
+        try:
+            in_port, name = int(parts[0]), parts[1]
+        except ValueError:
+            try:
+                out_port, name = int(parts[1]), parts[0]
+            except ValueError:
+                raise Error("Non integer port number in {}. Expected format is NODE:OUT_PORT or IN_PORT:NODE, where "
+                            "IN_PORT and OUTPUT_PORT are integers".format(node_name))
+        return name, in_port, out_port
 
 
 def get_name_and_port(tensor_name):


### PR DESCRIPTION
Description: Rework extracing port number from --input/--output options

JIRA: CVS-33741, CVS-33838


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests: N/A - not a new operation
* [x]  Transformation tests: N/A - no transformation changed/added
* [x]  e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py: N/A - no e2e test modifyed
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list: N/A - no new operation supported
* [x]  Supported **public** models list: N/A - no new public model supported
* [x]  New operations specification: N/A - no new operation added
* [x]  Guide on how to convert the **public** model: N/A - no new public model supported
* [x]  User guide update: N/A - not needed