### PR TITLE
WIP: [IE CORE]  enable plugins & dependent libs loading using absolute path

### DIFF
--- a/inference-engine/src/inference_engine/os/win/win_shared_object_loader.cpp
+++ b/inference-engine/src/inference_engine/os/win/win_shared_object_loader.cpp
@@ -12,8 +12,11 @@
 namespace InferenceEngine {
 namespace details {
 
+/**
+ * @brief WINAPI based implementation for loading a shared object
+ */
 class SharedObjectLoader::Impl {
-private:
+ private:
     HMODULE shared_object;
 
     void ExcludeCurrentDirectory() {
@@ -28,12 +31,76 @@ private:
         }
     }
 
-public:
+    static const char  kPathSeparator = '\\';
+
+    static const char* FindLastPathSeparator(LPCSTR path) {
+        const char* const last_sep = strchr(path, kPathSeparator);
+        return last_sep;
+    }
+
 #ifdef ENABLE_UNICODE_PATH_SUPPORT
+    static const wchar_t* FindLastPathSeparator(LPCWSTR path) {
+        const char* const last_sep = wcsrchr(path, kPathSeparator);
+        return last_sep;
+    }
+
+    std::basic_string<WCHAR> GetDirname(LPCWSTR path) {
+        auto pos = FindLastPathSeparator(path);
+        if (pos==nullptr) {
+            return path;
+        }
+        std::basic_string<WCHAR> original(path);
+        original[pos] = 0;
+        return original;
+    }
+
+    std::basic_string<WCHAR> IncludePluginDirectory(LPCWSTR path) {
+        std::basic_string<WCHAR> lpBuffer(path);
+        DWORD nBufferLength;
+
+        nBufferLength = GetDllDirectoryW(0, nullptr);
+        std::vector<WCHAR> lpBuffer(nBufferLength);
+        GetDllDirectoryW(nBufferLength, &lpBuffer.front());
+
+        auto dirname = GetDirname(path);
+        SetDllDirectoryW(dirname.c_str());
+
+        return &lpBuffer.front();
+    }
+#endif
+    std::basic_string<CHAR> IncludePluginDirectory(LPCSTR path) {
+        std::basic_string<CHAR> lpBuffer(path);
+        DWORD nBufferLength;
+
+        nBufferLength = GetDllDirectoryW(0, nullptr);
+        std::vector<CHAR> lpBuffer(nBufferLength);
+        GetDllDirectoryW(nBufferLength, &lpBuffer.front());
+
+        auto dirname = GetDirname(path);
+        SetDllDirectoryW(dirname.c_str());
+
+        return &lpBuffer.front();
+    }
+
+ public:
+    /**
+     * @brief A shared pointer to SharedObjectLoader
+     */
+    using Ptr = std::shared_ptr<SharedObjectLoader>;
+
+#ifdef ENABLE_UNICODE_PATH_SUPPORT
+    /**
+     * @brief Loads a library with the name specified. The library is loaded according to the
+     *        WinAPI LoadLibrary rules
+     * @param pluginName Full or relative path to the plugin library
+     */
     explicit Impl(const wchar_t* pluginName) {
         ExcludeCurrentDirectory();
+        auto oldDir = IncludePluginDirectory(pluginName);
 
         shared_object = LoadLibraryW(pluginName);
+
+        SetDllDirectoryW(oldDir.c_str());
         if (!shared_object) {
             char cwd[1024];
             THROW_IE_EXCEPTION << "Cannot load library '" << FileUtils::wStringtoMBCSstringChar(std::wstring(pluginName)) << "': " << GetLastError()
@@ -44,8 +111,12 @@ public:
 
     explicit Impl(const char* pluginName) {
         ExcludeCurrentDirectory();
+        auto oldDir = IncludePluginDirectory(pluginName);
+        IncludePluginDirectory(pluginName);
 
         shared_object = LoadLibraryA(pluginName);
+
+        SetDllDirectoryW(oldDir.c_str());
         if (!shared_object) {
             char cwd[1024];
             THROW_IE_EXCEPTION << "Cannot load library '" << pluginName << "': " << GetLastError()
@@ -57,6 +128,12 @@ public:
         FreeLibrary(shared_object);
     }
 
+    /**
+     * @brief Searches for a function symbol in the loaded module
+     * @param symbolName Name of function to find
+     * @return A pointer to the function if found
+     * @throws InferenceEngineException if the function is not found
+     */
     void* get_symbol(const char* symbolName) const {
         if (!shared_object) {
             THROW_IE_EXCEPTION << "Cannot get '" << symbolName << "' content from unknown library!";

--- a/inference-engine/src/inference_engine/os/win/win_shared_object_loader.cpp
+++ b/inference-engine/src/inference_engine/os/win/win_shared_object_loader.cpp
@@ -38,19 +38,29 @@ class SharedObjectLoader::Impl {
         return last_sep;
     }
 
+    std::basic_string<CHAR> GetDirname(LPCSTR path) {
+        auto pos = FindLastPathSeparator(path);
+        if (pos == nullptr) {
+            return path;
+        }
+        std::basic_string<СHAR> original(path);
+        original[pos - path] = 0;
+        return original;
+    }
+
 #ifdef ENABLE_UNICODE_PATH_SUPPORT
     static const wchar_t* FindLastPathSeparator(LPCWSTR path) {
-        const char* const last_sep = wcsrchr(path, kPathSeparator);
+        const wchar_t* const last_sep = wcsrchr(path, kPathSeparator);
         return last_sep;
     }
 
     std::basic_string<WCHAR> GetDirname(LPCWSTR path) {
         auto pos = FindLastPathSeparator(path);
-        if (pos==nullptr) {
+        if (pos == nullptr) {
             return path;
         }
         std::basic_string<WCHAR> original(path);
-        original[pos] = 0;
+        original[pos - path] = 0;
         return original;
     }
 
@@ -146,18 +156,17 @@ class SharedObjectLoader::Impl {
     }
 };
 
-#ifdef ENABLE_UNICODE_PATH_SUPPORT
-SharedObjectLoader::SharedObjectLoader(const wchar_t* pluginName) {
-    _impl = std::make_shared<Impl>(pluginName);
-}
-#endif
-
 SharedObjectLoader::~SharedObjectLoader() noexcept(false) {
 }
 
 SharedObjectLoader::SharedObjectLoader(const char * pluginName) {
     _impl = std::make_shared<Impl>(pluginName);
 }
+#ifdef ENABLE_UNICODE_PATH_SUPPORT
+SharedObjectLoader::SharedObjectLoader(const wchar_t* pluginName) {
+    _impl = std::make_shared<Impl>(pluginName);
+}
+#endif
 
 void* SharedObjectLoader::get_symbol(const char* symbolName) const {
     return _impl->get_symbol(symbolName);

--- a/inference-engine/src/inference_engine/os/win/win_shared_object_loader.cpp
+++ b/inference-engine/src/inference_engine/os/win/win_shared_object_loader.cpp
@@ -72,12 +72,12 @@ class SharedObjectLoader::Impl {
         std::basic_string<CHAR> lpBuffer(path);
         DWORD nBufferLength;
 
-        nBufferLength = GetDllDirectoryW(0, nullptr);
+        nBufferLength = GetDllDirectoryA(0, nullptr);
         std::vector<CHAR> lpBuffer(nBufferLength);
-        GetDllDirectoryW(nBufferLength, &lpBuffer.front());
+        GetDllDirectoryA(nBufferLength, &lpBuffer.front());
 
         auto dirname = GetDirname(path);
-        SetDllDirectoryW(dirname.c_str());
+        SetDllDirectoryA(dirname.c_str());
 
         return &lpBuffer.front();
     }


### PR DESCRIPTION
not sure about extra safety, but please give feed back about general idea
Currently this allowed to use plugins.xml file to specify full path to specific plugin with it's all dependency, not to be persisted in CWD or in PATH. Since that requires physical access to settings xml, i doubt we broke something.