### PR TITLE
[LPT] Symmetric quantization support for efficientnet-b0 (cherry-pick to master)

### DIFF
--- a/inference-engine/src/low_precision_transformations/src/layer_transformation.cpp
+++ b/inference-engine/src/low_precision_transformations/src/layer_transformation.cpp
@@ -354,12 +354,11 @@ LayerTransformation::PrecisionDetails LayerTransformation::getPrecisionDetails(c
 
             const float expectedRatio = quantizationDetails.levels == 256 ? asymmetricIntervalSideRatio256 : -1.f;
             const float actualRatio = quantizationDetails.outputLowValues[i] / quantizationDetails.outputHighValues[i];
-            const float actual = std::fabs(
-                (actualRatio - expectedRatio) /
-                std::max(fabs(quantizationDetails.outputLowValues[i]), fabs(quantizationDetails.outputHighValues[i])));
+            const float actual = std::fabs((actualRatio - expectedRatio) / std::min(actualRatio, expectedRatio));
             if (actual > quantizationIntervalAsymmetryThreshold) {
                 hasZeroPoint = true;
             }
+
 #ifdef LPT_PRINT_DEQUANTIZATION_INFO
             if (hasZeroPoint) {
                 std::cout << "   actual: " << actual << ", threshold: " << quantizationIntervalAsymmetryThreshold << std::endl;

--- a/inference-engine/src/low_precision_transformations/src/layer_transformation.cpp
+++ b/inference-engine/src/low_precision_transformations/src/layer_transformation.cpp
@@ -41,7 +41,7 @@ LayerTransformation::LayerTransformation(const Params& params) :
     precisionsOnWeights(params.precisionsOnWeights),
     layerTransformationsManager(nullptr),
     paramsManager(nullptr),
-    quantizationIntervalAsymmetryThreshold(2.e-4),
+    quantizationIntervalAsymmetryThreshold(0.002f),
     zeroThreshold(1.e-6f),
     dequantizationShiftToZeroRatioTreshold(4.e-4f),
     minQuantizationLevels(2ul) {}


### PR DESCRIPTION
Issue 32484: [LPT] Invalid asymmetric quantization usage for efficientnet models on GPU
Validation:  
 * performance/185/  
 * accuracy/34/