### PR TITLE
CPU plugin specific tensor desc refactoring

### DIFF
--- a/inference-engine/include/ie_layouts.h
+++ b/inference-engine/include/ie_layouts.h
@@ -161,13 +161,20 @@ public:
      */
     TensorDesc(const Precision& precision, const SizeVector& dims, const BlockingDesc& blockDesc);
     /**
-     * @brief The constructor creates the tensor descriptor using standard layout
+     * @brief The constructor creates the tensor descriptor using specified layout
      *
      * @param precision memory precision
      * @param dims memory dimensions
      * @param layout memory layout
      */
     TensorDesc(const Precision& precision, const SizeVector& dims, Layout layout);
+    /**
+     * @brief The constructor creates the tensor descriptor using standard plain layout
+     *
+     * @param precision memory precision
+     * @param dims memory dimensions
+     */
+    TensorDesc(const Precision& precision, const SizeVector &dims);
     /**
      * @brief The constructor creates the empty tensor descriptor with precision and layout
      *

--- a/inference-engine/src/inference_engine/ie_layouts.cpp
+++ b/inference-engine/src/inference_engine/ie_layouts.cpp
@@ -9,6 +9,9 @@
 
 using namespace InferenceEngine;
 
+TensorDesc::TensorDesc(const Precision& precision, const SizeVector& dims)
+        : dims(dims), precision(precision), layout(getLayoutByDims(dims)), blockingDesc(dims, getLayoutByDims(dims)) {}
+
 TensorDesc::TensorDesc(const Precision& precision, const SizeVector& dims, Layout layout)
     : precision(precision), blockingDesc(dims, layout) {
     this->dims = dims;

--- a/inference-engine/src/mkldnn_plugin/gp_utils.h
+++ b/inference-engine/src/mkldnn_plugin/gp_utils.h
@@ -1,0 +1,21 @@
+// Copyright (C) 2018-2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+/**
+ * @file contains general purpose utils without any MKLDNN or Neural Network inference specific
+ */
+
+template <typename T, typename U>
+inline T div_up(const T a, const U b) {
+    assert(b);
+    return (a + b - 1) / b;
+}
+
+template <typename T, typename U>
+inline T rnd_up(const T a, const U b) {
+    return div_up(a, b) * b;
+}
+

--- a/inference-engine/src/mkldnn_plugin/mkldnn_edge.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_edge.cpp
@@ -267,9 +267,20 @@ bool MKLDNNEdge::nodeCanChangeDesc(const MKLDNNNodePtr &node) const {
     return false;
 }
 
-/// In we have {any, any, any} -> {any} or {any} -> {any, any, any} or {any} -> {any} it means that
-/// layer doesn't change memory format
-/// We don't support {any, any, nchw} -> {any}
+/**
+ * The function return the selected layout for current Edge
+ * The decision based on layer configs info provided by each Node connected.
+ *
+ * General logic:
+ * If parent node strongly requests some layout it will be returned as result. If parent node can
+ * support any layout (just pass through it to parents), will ask layout recurrently while found
+ * strongly qualified.
+ *
+ * In we have {any, any, any} -> {any} or {any} -> {any, any, any} or {any} -> {any} it means that
+ * layer pass through layout.
+ *
+ * We don't support {any, any, nchw} -> {any}
+ */
 InferenceEngine::TensorDesc MKLDNNEdge::getSpecifiedInputDesc(std::map<mkldnn::memory::format, size_t> formats, size_t enterCountUp, size_t enterCountDown) {
     InferenceEngine::TensorDesc inDesc;
 
@@ -292,6 +303,8 @@ InferenceEngine::TensorDesc MKLDNNEdge::getSpecifiedInputDesc(std::map<mkldnn::m
     if (inDesc.getLayout() != InferenceEngine::Layout::ANY) {
         return inDesc;
     }
+
+    THROW_IE_EXCEPTION << "[AP] Guess this line will not reached ever. getSpecifiedInputDesc func.";
 
     bool isFormatChanging = nodeCanChangeDesc(parentPtr);
 
@@ -414,6 +427,8 @@ InferenceEngine::TensorDesc MKLDNNEdge::getSpecifiedOutputDesc(std::map<mkldnn::
     if (outDesc.getLayout() != InferenceEngine::Layout::ANY) {
         return outDesc;
     }
+
+    THROW_IE_EXCEPTION << "[AP] Guess this line will not reached ever. getSpecifiedOutputDesc func.";
 
     if (inputIdx >= parentPtr->getSelectedPrimitiveDescriptor()->getConfig().outConfs.size())
         inputIdx = 0;

--- a/inference-engine/src/mkldnn_plugin/mkldnn_layout_config.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_layout_config.cpp
@@ -1,0 +1,5 @@
+// Copyright (C) 2018-2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "mkldnn_layout_config.h"

--- a/inference-engine/src/mkldnn_plugin/mkldnn_layout_config.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_layout_config.h
@@ -1,0 +1,46 @@
+// Copyright (C) 2018-2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "mkldnn_memory.h"
+
+// TODO: remove this include after clean plugin code from IE::LayerConfig usage
+#include "ie_extension.h"
+
+namespace MKLDNNPlugin {
+
+class MKLDNNPortConfig {
+public:
+    /** Layout descriptor of corresponding node port */
+    MKLDNNMemoryDesc desc;
+
+    /** Index of in-place memory. If -1 memory cannot be in-place */
+    int inPlace = -1;
+
+    /** Flag describing that output tensor values depend only on input tensor shape. */
+    bool constant = false;
+};
+
+/**
+ * The descriptor of layout configuration for some node implementation
+ * Should describe some specific feature and requirements of future
+ * implementation instance if it will be selected.
+ */
+class MKLDNNLayoutConfig {
+public:
+    /** Flag describing support of dynamic batch. If false, dynamic batch is not supported */
+    bool dynBatchSupport = false;
+
+    /** Vector of input data configs */
+    std::vector<MKLDNNPortConfig> inConfs;
+
+    /** Vector of output data configs */
+    std::vector<MKLDNNPortConfig> outConfs;
+
+    // TODO: This constructor is only for compatibility with old version of initialization via IE::LayerConfig
+    MKLDNNLayoutConfig(const InferenceEngine::LayerConfig &ie_layer_config);
+};
+
+}  // namespace MKLDNNPlugin

--- a/inference-engine/src/mkldnn_plugin/mkldnn_memory.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_memory.cpp
@@ -10,6 +10,7 @@
 #include <utility>
 
 #include <mkldnn_types.h>
+#include <mkldnn_debug.h>
 #include "mkldnn_memory.h"
 #include "mkldnn_node.h"
 #include "mkldnn_extension_utils.h"
@@ -1399,5 +1400,15 @@ bool MKLDNNMemoryDesc::blocksExtended() const {
     }
     return false;
 }
+
+mkldnn::memory::format get_format_tag(const InferenceEngine::TensorDesc &tdesc) {
+    MKLDNNMemoryDesc mkldnn_tdesc(tdesc);
+    return mkldnn_tdesc.getFormat();
+}
+
+std::string format_tag_to_string(mkldnn::memory::format tag) {
+    return mkldnn_fmt2str(static_cast<mkldnn_memory_format_t>(tag));
+}
+
 
 }  // namespace MKLDNNPlugin

--- a/inference-engine/src/mkldnn_plugin/mkldnn_memory.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_memory.cpp
@@ -1487,14 +1487,4 @@ bool MKLDNNExtensionUtils::initTensorsAreEqual(const InferenceEngine::TensorDesc
              in1Block.getOffsetPadding() != uninitNum && in2Block.getOffsetPadding() != uninitNum);
 }
 
-
-    /*
-     * @param blocked_dims blocked dimensions
-     * @param order the order of dimensions
-     * @param offset offset to the current memory block
-     * @param dimOffsets per-dimension offset from the padding to actual data,
-     * @param strides strides for each dimension
-     */
-
-
 }  // namespace MKLDNNPlugin

--- a/inference-engine/src/mkldnn_plugin/mkldnn_memory.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_memory.h
@@ -125,5 +125,10 @@ private:
     mkldnn::engine eng;
 };
 
+/***********************************
+ * Util section
+ ***********************************/
+mkldnn::memory::format get_format_tag(const InferenceEngine::TensorDesc &tdesc);
+std::string format_tag_to_string(mkldnn::memory::format tag);
 
 }  // namespace MKLDNNPlugin

--- a/inference-engine/src/mkldnn_plugin/mkldnn_memory.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_memory.h
@@ -79,11 +79,6 @@ private:
     mkldnn::memory::desc desc;
 };
 
-
-class MKLDNNMemory;
-
-using MKLDNNMemoryPtr = std::shared_ptr<MKLDNNMemory>;
-
 class MKLDNNMemory {
 public:
     explicit MKLDNNMemory(const mkldnn::engine& eng);
@@ -153,6 +148,8 @@ private:
     std::shared_ptr<mkldnn::memory> prim;
     mkldnn::engine eng;
 };
+
+using MKLDNNMemoryPtr = std::shared_ptr<MKLDNNMemory>;
 
 /***********************************
  * Util section

--- a/inference-engine/src/mkldnn_plugin/mkldnn_memory.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_memory.h
@@ -30,6 +30,23 @@ public:
     mkldnn::memory::data_type getDataType() const {
         return static_cast<mkldnn::memory::data_type>(desc.data.data_type);
     }
+    ////////////////////////////////////////////
+    /// TODO: Compatibility methods to simulate IE::TensorDesc API. Should be removed sometimes...
+    InferenceEngine::Precision getPrecision() const;
+    class BlkDesk {
+        BlkDesk();
+        mkldnn_blocking_desc_t _blk;
+    public:
+        bool operator == (const BlkDesk&& other) const;
+    };
+    BlkDesk getBlockingDesc() const;
+
+    // TODO: it should removed. Just for build
+    void setDataType(mkldnn::memory::data_type type) {
+        desc.data.data_type = static_cast<mkldnn_data_type_t>(type);
+        THROW_IE_EXCEPTION << "Should not be used";
+    }
+    ///////////
 
     MKLDNNDims getDims() const {
         return MKLDNNDims(desc.data.dims, desc.data.ndims);
@@ -45,6 +62,18 @@ public:
 
     operator mkldnn::memory::desc() const;
     operator InferenceEngine::TensorDesc() const;
+
+    bool isUnknown() const {
+        return getFormat() == mkldnn::memory::format::any;
+    }
+
+    bool isDefined() const {
+        return getFormat() != mkldnn::memory::format::any;
+    }
+
+    bool isUninit() const;
+
+    MKLDNNMemoryDesc create_uninit_version() const;
 
 private:
     mkldnn::memory::desc desc;
@@ -130,5 +159,7 @@ private:
  ***********************************/
 mkldnn::memory::format get_format_tag(const InferenceEngine::TensorDesc &tdesc);
 std::string format_tag_to_string(mkldnn::memory::format tag);
+
+bool initTensorsAreEqual(const MKLDNNMemoryDesc left, const MKLDNNMemoryDesc right);
 
 }  // namespace MKLDNNPlugin

--- a/inference-engine/src/mkldnn_plugin/mkldnn_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_node.cpp
@@ -549,7 +549,7 @@ void MKLDNNNode::initSupportedPrimitiveDescriptors() {
             }
             impl_desc_type impl_type = parse_impl_name(itpd.get_impl_info_str());
 
-            supportedPrimitiveDescriptors.emplace_back(config, impl_type, outFormats);
+            supportedPrimitiveDescriptors.emplace_back(config, impl_type);
             itpd++;
         }
     }

--- a/inference-engine/src/mkldnn_plugin/mkldnn_node.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_node.h
@@ -165,20 +165,8 @@ static std::string NameFromType(Type type) {
 
 class PrimitiveDescInfo {
 public:
-    PrimitiveDescInfo(const InferenceEngine::LayerConfig conf, impl_desc_type type): config(conf) {
-        implementationType = type;
-    }
-
-    PrimitiveDescInfo(const InferenceEngine::LayerConfig conf, impl_desc_type type, std::vector<mkldnn::memory::format> outFmts): config(conf) {
-        implementationType = type;
-        outputLayouts = outFmts;
-    }
-
-    PrimitiveDescInfo(const InferenceEngine::LayerConfig conf, impl_desc_type type, mkldnn::memory::format outFmt): config(conf) {
-        implementationType = type;
-
-        setOutputLayouts(outFmt);
-    }
+    PrimitiveDescInfo(const InferenceEngine::LayerConfig conf, impl_desc_type type) :
+            config(conf), implementationType(type) {}
 
     PrimitiveDescInfo(const PrimitiveDescInfo &descInfo) = default;
     PrimitiveDescInfo(PrimitiveDescInfo &&descInfo) = default;
@@ -196,26 +184,13 @@ public:
         return implementationType;
     }
 
-    const std::vector<mkldnn::memory::format>& getOutputLayouts() const {
-        return outputLayouts;
-    }
-
     void setImplementationType(impl_desc_type type) {
         implementationType = type;
-    }
-
-    void setOutputLayouts(mkldnn::memory::format outFmt) {
-        outputLayouts.clear();
-
-        for (int i = 0; i < config.outConfs.size(); i++) {
-            outputLayouts.push_back(outFmt);
-        }
     }
 
 private:
     InferenceEngine::LayerConfig config;
     impl_desc_type implementationType;
-    std::vector<mkldnn::memory::format> outputLayouts;
 };
 
 class MKLDNNNode : public InferenceEngine::details::no_copy {

--- a/inference-engine/src/mkldnn_plugin/nodes/base.hpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/base.hpp
@@ -7,6 +7,7 @@
 #include <ie_iextension.h>
 #include "ie_util_internal.hpp"
 #include "nodes/list.hpp"
+#include "gp_utils.h"
 
 #include <string>
 #include <vector>
@@ -81,11 +82,6 @@ protected:
 
         // Fill tensor parameters into config
         auto fill_port = [] (std::vector<DataConfig>& port, DataConfigurator conf, const DataPtr& data) {
-            auto div_up = [](const int a, const int b) -> int {
-                if (!b)
-                    return 0;
-                return (a + b - 1) / b;
-            };
             if (!data) THROW_IE_EXCEPTION << "Cannot get input data!";
 
             DataConfig dataConfig;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_batchnorm_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_batchnorm_node.cpp
@@ -216,13 +216,13 @@ void MKLDNNBatchNormalizationNode::initOptimalPrimitiveDescriptor() {
     if (isInitConfig(config))
         return;
 
-    if (config.inConfs.size() != 1 || config.outConfs.size() != 1 || (!isUninitTensorDesc(config.inConfs[0].desc) &&
-            !isUninitTensorDesc(config.outConfs[0].desc) && config.inConfs[0].desc != config.outConfs[0].desc))
+    if (config.inConfs.size() != 1 || config.outConfs.size() != 1 || (!config.inConfs[0].desc.isUninit() &&
+            !config.outConfs[0].desc.isUninit() && config.inConfs[0].desc != config.outConfs[0].desc))
         THROW_IE_EXCEPTION << "Layer " << getName() << " has incorrect selected config!";
 
-    if (!isUninitTensorDesc(config.inConfs[0].desc)) {
+    if (!config.inConfs[0].desc.isUninit()) {
         config.outConfs[0].desc = config.inConfs[0].desc;
-    } else if (!isUninitTensorDesc(config.outConfs[0].desc)) {
+    } else if (!config.outConfs[0].desc.isUninit()) {
         config.inConfs[0].desc = config.outConfs[0].desc;
     } else {
         config.outConfs[0].desc = config.inConfs[0].desc = getConfiguredInputDesc(config, 0);

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_batchnorm_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_batchnorm_node.cpp
@@ -261,7 +261,7 @@ void MKLDNNBatchNormalizationNode::initSupportedPrimitiveDescriptors() {
             }
             impl_desc_type impl_type = parse_impl_name(itpd.get_impl_info_str());
 
-            supportedPrimitiveDescriptors.emplace_back(config, impl_type, outFormats);
+            supportedPrimitiveDescriptors.emplace_back(config, impl_type);
             itpd++;
         }
     }

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_bin_conv_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_bin_conv_node.cpp
@@ -415,7 +415,7 @@ void MKLDNNBinaryConvolutionNode::initSupportedPrimitiveDescriptors() {
             }
             impl_desc_type impl_type = parse_impl_name(itpd.get_impl_info_str());
 
-            supportedPrimitiveDescriptors.emplace_back(config, impl_type, outFormats);
+            supportedPrimitiveDescriptors.emplace_back(config, impl_type);
             itpd++;
         }
     }

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_bin_conv_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_bin_conv_node.h
@@ -20,7 +20,7 @@ public:
     void getSupportedDescriptors() override;
     void createDescriptor(const std::vector<InferenceEngine::TensorDesc>& inputDesc,
                           const std::vector<InferenceEngine::TensorDesc>& outputDesc) override;
-    void initDescriptor(const InferenceEngine::LayerConfig& config) override;
+    void initDescriptor(const MKLDNNLayoutConfig& config) override;
     void createPrimitive() override;
     void initSupportedPrimitiveDescriptors() override;
     bool created() const override;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_concat_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_concat_node.cpp
@@ -123,31 +123,31 @@ void MKLDNNConcatNode::initSupportedPrimitiveDescriptors() {
                                                                                         : MKLDNNMemory::GetPlainFormat(dims);
 
         config.outConfs[0].desc = MKLDNNExtensionUtils::getUninitTensorDesc(MKLDNNMemoryDesc(dims, outputDataType, fmt));
-        supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::ref, fmt);
+        supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::ref);
 
         if (inputPrecision != Precision::U8 && inputPrecision != Precision::I8) {
             if (dims.ndims() == 4) {
                 if (dims[1] % 8 == 0) {
                     config.outConfs[0].desc = MKLDNNExtensionUtils::getUninitTensorDesc(
                             MKLDNNMemoryDesc(dims, outputDataType, mkldnn::memory::nChw8c));
-                    supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::ref, mkldnn::memory::nChw8c);
+                    supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::ref);
 
                     if (dims[1] % 16 == 0) {
                         config.outConfs[0].desc = MKLDNNExtensionUtils::getUninitTensorDesc(
                                 MKLDNNMemoryDesc(dims, outputDataType, mkldnn::memory::nChw16c));
-                        supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::ref, mkldnn::memory::nChw16c);
+                        supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::ref);
                     }
                 }
             } else if (dims.ndims() == 5) {
                 if (dims[1] % 8 == 0) {
                     config.outConfs[0].desc = MKLDNNExtensionUtils::getUninitTensorDesc(
                             MKLDNNMemoryDesc(dims, outputDataType, mkldnn::memory::nCdhw8c));
-                    supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::ref, mkldnn::memory::nCdhw8c);
+                    supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::ref);
 
                     if (dims[1] % 16 == 0) {
                         config.outConfs[0].desc = MKLDNNExtensionUtils::getUninitTensorDesc(
                                 MKLDNNMemoryDesc(dims, outputDataType, mkldnn::memory::nCdhw16c));
-                        supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::ref, mkldnn::memory::nCdhw16c);
+                        supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::ref);
                     }
                 }
             }
@@ -198,7 +198,7 @@ void MKLDNNConcatNode::initSupportedPrimitiveDescriptors() {
                                                     {blkDims, order, offset, offsets, strides});
             }
 
-            supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::ref, mkldnn::memory::nhwc);
+            supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::ref);
 
             return;
         } else if (numOfDim == 5) {
@@ -232,7 +232,7 @@ void MKLDNNConcatNode::initSupportedPrimitiveDescriptors() {
                                                     {blkDims, order, offset, offsets, strides});
             }
 
-            supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::ref, mkldnn::memory::ndhwc);
+            supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::ref);
 
             return;
         }
@@ -259,7 +259,7 @@ void MKLDNNConcatNode::initSupportedPrimitiveDescriptors() {
                                             {parentEdge->getDims().ToSizeVector(), order, offset, offsets, strides});
     }
 
-    supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::unknown, MKLDNNMemory::Convert(config.outConfs[0].desc.getLayout()));
+    supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::unknown);
 
     if (numOfDim == 4lu || numOfDim == 5lu) {
         size_t blkDimsLen = numOfDim + 1;
@@ -304,9 +304,7 @@ void MKLDNNConcatNode::initSupportedPrimitiveDescriptors() {
                                                      {blkDims, order, offset, offsets, strides});
             }
             if (canInplace) {
-                auto dstFormat = numOfDim == 4lu ? sizeS == 8lu ? mkldnn::memory::nChw8c : mkldnn::memory::nChw16c
-                                                 : sizeS == 8lu ? mkldnn::memory::nCdhw8c : mkldnn::memory::nCdhw16c;
-                supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::unknown, dstFormat);
+                supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::unknown);
             }
         }
     }

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_concat_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_concat_node.cpp
@@ -552,6 +552,8 @@ void MKLDNNConcatNode::initOptimalPrimitiveDescriptor() {
     if (isInitConfig(config))
         return;
 
+    // TODO: [AP] concat has only one output..
+    //       Also I'm not sure that this code is reachable. May we delete this?
     for (size_t i = 0; i < config.outConfs.size(); i++) {
         if (config.outConfs[i].desc.isUnknown() ||
                 !config.outConfs[i].desc.isUninit())
@@ -566,8 +568,7 @@ void MKLDNNConcatNode::initOptimalPrimitiveDescriptor() {
                 if (childConf.desc.isUninit() && childConf.inPlace >= 0)
                     getChildEdgeAt(i)->getChild()->initOptimalPrimitiveDescriptor();
 
-                if (!childConf.desc.isUninit()) &&
-                        MKLDNNExtensionUtils::initTensorsAreEqual(childConf.desc, config.outConfs[i].desc)) {
+                if (!childConf.desc.isUninit() && initTensorsAreEqual(childConf.desc, config.outConfs[i].desc)) {
                     config.outConfs[i].desc = childConf.desc;
                     continue;
                 }
@@ -575,8 +576,8 @@ void MKLDNNConcatNode::initOptimalPrimitiveDescriptor() {
         }
         config.outConfs[i].desc = InferenceEngine::TensorDesc(config.outConfs[i].desc.getPrecision(),
                                                               config.outConfs[i].desc.getDims(), {
-                                                                      config.outConfs[i].desc.getBlockingDesc().getBlockDims(),
-                                                                      config.outConfs[i].desc.getBlockingDesc().getOrder()
+                                                                  config.outConfs[i].desc.getBlockingDesc().getBlockDims(),
+                                                                  config.outConfs[i].desc.getBlockingDesc().getOrder()
                                                               });
     }
     size_t offset = 0;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
@@ -622,7 +622,7 @@ void MKLDNNConvolutionNode::initSupportedPrimitiveDescriptors() {
             if (impl_type & jit)
                 containJitImpl = true;
 
-            supportedPrimitiveDescriptors.emplace_back(config, impl_type, outFormats);
+            supportedPrimitiveDescriptors.emplace_back(config, impl_type);
             itpd++;
         }
     }

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.h
@@ -22,7 +22,7 @@ public:
     void getSupportedDescriptors() override;
     void createDescriptor(const std::vector<InferenceEngine::TensorDesc>& inputDesc,
                           const std::vector<InferenceEngine::TensorDesc>& outputDesc) override;
-    void initDescriptor(const InferenceEngine::LayerConfig& config) override;
+    void initDescriptor(const MKLDNNLayoutConfig& config) override;
     void createPrimitive() override;
     void initSupportedPrimitiveDescriptors() override;
     void filterSupportedPrimitiveDescriptors() override;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_crop_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_crop_node.cpp
@@ -90,18 +90,18 @@ void MKLDNNCropNode::initSupportedPrimitiveDescriptors() {
     config.outConfs[0].constant = false;
     config.outConfs[0].desc = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, fmt);
 
-    supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::unknown, fmt);
+    supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::unknown);
 
     if ((inDims.ndims() == 4 || inDims.ndims() == 5) && channelAxis >= 0 && dims[channelAxis] % 8 == 0) {
         fmt = inDims.ndims() == 5 ? memory::format::nCdhw8c : memory::format::nChw8c;
         config.inConfs[0].desc = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, fmt);
         config.outConfs[0].desc = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, fmt);
-        supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::unknown, fmt);
+        supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::unknown);
         if (dims[channelAxis] % 16 == 0) {
             fmt = inDims.ndims() == 5 ? memory::format::nCdhw16c : memory::format::nChw16c;
             config.inConfs[0].desc = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, fmt);
             config.outConfs[0].desc = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, fmt);
-            supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::unknown, fmt);
+            supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::unknown);
         }
     }
 }

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_def_conv_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_def_conv_node.cpp
@@ -151,7 +151,7 @@ void MKLDNNDeformableConvolutionNode::initSupportedPrimitiveDescriptors() {
             }
             impl_desc_type impl_type = parse_impl_name(itpd.get_impl_info_str());
 
-            supportedPrimitiveDescriptors.emplace_back(config, impl_type, outFormats);
+            supportedPrimitiveDescriptors.emplace_back(config, impl_type);
             itpd++;
         }
     }

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_def_conv_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_def_conv_node.h
@@ -20,7 +20,7 @@ public:
     void getSupportedDescriptors() override;
     void createDescriptor(const std::vector<InferenceEngine::TensorDesc>& inputDesc,
                           const std::vector<InferenceEngine::TensorDesc>& outputDesc) override;
-    void initDescriptor(const InferenceEngine::LayerConfig& config) override;
+    void initDescriptor(const MKLDNNLayoutConfig& config) override;
     void createPrimitive() override;
     void initSupportedPrimitiveDescriptors() override;
     bool created() const override;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_eltwise_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_eltwise_node.cpp
@@ -488,7 +488,7 @@ void MKLDNNEltwiseNode::initSupportedPrimitiveDescriptors() {
             dataConfig.constant = false;
             dataConfig.desc = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDT, format);
             config.outConfs.push_back(dataConfig);
-        return {config, impl_type, format};
+        return {config, impl_type};
     };
 
     if (fusedWith.empty()) {
@@ -553,7 +553,7 @@ void MKLDNNEltwiseNode::initSupportedPrimitiveDescriptors() {
         dataConfig.desc = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDT, format);
         config.outConfs.push_back(dataConfig);
 
-        supportedPrimitiveDescriptors.push_back({config, impl_type, format});
+        supportedPrimitiveDescriptors.push_back({config, impl_type});
 
         jep.src0_step = config.inConfs[0].desc.getDims()[1] == 1 ? 0 : 1;
         jep.src1_step = config.inConfs[1].desc.getDims()[1] == 1 ? 0 : 1;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_gemm_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_gemm_node.cpp
@@ -150,7 +150,7 @@ void MKLDNNGemmNode::initSupportedPrimitiveDescriptors() {
 
     config.outConfs.push_back(createDataConfig(getChildEdgeAt(0)->getDims(), outputDataType));
 
-    supportedPrimitiveDescriptors.push_back(PrimitiveDescInfo(config, impl_desc_type::gemm_any, MKLDNNMemory::GetPlainFormat(getChildEdgeAt(0)->getDims())));
+    supportedPrimitiveDescriptors.push_back(PrimitiveDescInfo(config, impl_desc_type::gemm_any));
 }
 
 void MKLDNNGemmNode::initOptimalPrimitiveDescriptor() {

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_generic_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_generic_node.cpp
@@ -55,12 +55,7 @@ void MKLDNNGenericNode::initSupportedPrimitiveDescriptors() {
         }
 
         for (auto& config : configs) {
-            std::vector<memory::format> outFormats;
-            for (auto& outConfig : config.outConfs) {
-                outFormats.push_back(MKLDNNMemory::Convert(outConfig.desc.getLayout()));
-            }
-
-            supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::unknown, outFormats);
+            supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::unknown);
         }
     }
     if (impls.empty()) {

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_generic_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_generic_node.h
@@ -30,7 +30,7 @@ public:
         return false;
     }
 
-    void initDescriptor(const InferenceEngine::LayerConfig& config) override;
+    void initDescriptor(const MKLDNNLayoutConfig& config) override;
 
     void execLayer();
     void cleanup() override;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_input_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_input_node.cpp
@@ -71,7 +71,7 @@ void MKLDNNInputNode::initSupportedPrimitiveDescriptors() {
         dataConfig.desc = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, outFormat);
         config.inConfs.push_back(dataConfig);
     }
-    supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::unknown, outFormat);
+    supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::unknown);
 }
 
 void MKLDNNInputNode::createPrimitive() {

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_memory_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_memory_node.cpp
@@ -40,7 +40,7 @@ void MKLDNNMemoryOutputNode::initSupportedPrimitiveDescriptors() {
     config.inConfs[0].inPlace = -1;
     config.inConfs[0].constant = false;
     config.inConfs[0].desc = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format::any);
-    supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::unknown, memory::format::any);
+    supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::unknown);
 }
 
 const MKLDNNEdgePtr MKLDNNMemoryOutputNode::getChildEdgeAt(size_t idx) const {

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_mvn_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_mvn_node.cpp
@@ -502,7 +502,7 @@ void MKLDNNMVNNode::initSupportedPrimitiveDescriptors() {
     auto pushDesc = [&](memory::format format) {
         config.inConfs[0].desc = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, format);
         config.outConfs[0].desc = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), outputDataType, format);
-        supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown, format});
+        supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown});
     };
 
     if (across_channels == 0 && normalize_variance == 1) {

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_normalize_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_normalize_node.cpp
@@ -769,7 +769,7 @@ void MKLDNNNormalizeNode::initSupportedPrimitiveDescriptors() {
     auto pushDesc = [&](memory::format format) {
         config.inConfs[0].desc = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, format);
         config.outConfs[0].desc = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), outputDataType, format);
-        supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown, format});
+        supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown});
     };
 
     // only plain layout support when w/o sse42

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_permute_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_permute_node.cpp
@@ -169,50 +169,50 @@ void MKLDNNPermuteNode::initSupportedPrimitiveDescriptors() {
     if (getParentEdgeAt(0)->getDims().ndims() == 4) {
         config.inConfs[0].desc = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::nchw);
         config.outConfs[0].desc = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::nchw);
-        supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown, memory::nchw});
+        supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown});
 
         auto srcDims = getParentEdgeAt(0)->getDims();
         if (srcDims[1] % 8 == 0) {
             config.inConfs[0].desc = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::nChw8c);
-            supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown, memory::nChw8c});
+            supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown});
         }
 
         if (srcDims[1] % 16 == 0) {
             config.inConfs[0].desc = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::nChw16c);
-            supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown, memory::nChw16c});
+            supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown});
         }
 
         if (prec == Precision::I8 || prec == Precision::U8) {
             config.inConfs[0].desc = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::nhwc);
             config.outConfs[0].desc = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::nhwc);
-            supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown, memory::nhwc});
+            supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown});
         }
     } else if (getParentEdgeAt(0)->getDims().ndims() == 5) {
         config.inConfs[0].desc = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::ncdhw);
         config.outConfs[0].desc = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::ncdhw);
-        supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown, memory::ncdhw});
+        supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown});
 
         auto srcDims = getParentEdgeAt(0)->getDims();
         if (srcDims[1] % 8 == 0) {
             config.inConfs[0].desc = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::nCdhw8c);
-            supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown, memory::nCdhw8c});
+            supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown});
         }
 
         if (srcDims[1] % 16 == 0) {
             config.inConfs[0].desc = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::nCdhw16c);
-            supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown, memory::nCdhw16c});
+            supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown});
         }
 
         if (prec == Precision::I8 || prec == Precision::U8) {
             config.inConfs[0].desc = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::ndhwc);
             config.outConfs[0].desc = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::ndhwc);
-            supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown, memory::ndhwc});
+            supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown});
         }
     } else {
         config.inConfs[0].desc = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::any);
         config.outConfs[0].desc = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType,
                                                    MKLDNNMemory::GetPlainFormat(getChildEdgeAt(0)->getDims()));
-        supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown, MKLDNNMemory::GetPlainFormat(getChildEdgeAt(0)->getDims())});
+        supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown});
     }
 }
 

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_pooling_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_pooling_node.cpp
@@ -229,7 +229,7 @@ void MKLDNNPoolingNode::initSupportedPrimitiveDescriptors() {
             }
             impl_desc_type impl_type = parse_impl_name(itpd.get_impl_info_str());
 
-            supportedPrimitiveDescriptors.emplace_back(config, impl_type, outFormats);
+            supportedPrimitiveDescriptors.emplace_back(config, impl_type);
             itpd++;
         }
     }

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_pooling_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_pooling_node.h
@@ -21,7 +21,7 @@ public:
                           const std::vector<InferenceEngine::TensorDesc>& outputDesc) override;
     void getSupportedDescriptors() override;
     void initSupportedPrimitiveDescriptors() override;
-    void initDescriptor(const InferenceEngine::LayerConfig &config) override;
+    void initDescriptor(const MKLDNNLayoutConfig& config) override;
     void createPrimitive() override;
     bool created() const override;
     bool canBeInPlace() const override {

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_power_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_power_node.cpp
@@ -71,7 +71,7 @@ void MKLDNNPowerNode::initSupportedPrimitiveDescriptors() {
                                                                           (std::numeric_limits<size_t>::max)()
                                                                   });
         }
-        supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::unknown, format);
+        supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::unknown);
     }
 }
 

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_quantize_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_quantize_node.cpp
@@ -348,7 +348,7 @@ void MKLDNNQuantizeNode::initSupportedPrimitiveDescriptors() {
             dataConfig.constant = false;
             dataConfig.desc = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, fmt);
             config.outConfs.push_back(dataConfig);
-        return {config, impl, fmt};
+        return {config, impl};
     };
 
     if (!descs.empty()) {

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reorder_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reorder_node.cpp
@@ -58,7 +58,7 @@ void MKLDNNReorderNode::initSupportedPrimitiveDescriptors() {
         config.outConfs[0].desc = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format::any);
     }
 
-    supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::reorder, MKLDNNMemory::Convert(config.outConfs[0].desc.getLayout()));
+    supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::reorder);
 }
 
 void MKLDNNReorderNode::createPrimitive() {
@@ -108,7 +108,6 @@ void MKLDNNReorderNode::createReorderPrimitive(const mkldnn::memory::desc &srcDe
         const char *info;
         mkldnn_primitive_desc_query(pd.get(), mkldnn::convert_to_c(impl_info_str), 0, &info);
         supportedPrimitiveDescriptors[0].setImplementationType(parse_impl_name(std::string(info)));
-        supportedPrimitiveDescriptors[0].setOutputLayouts(static_cast<memory::format>(dstDesc.data.format));
 
         prim.reset(new mkldnn::reorder(pd, src_blocked->GetPrimitive(), dst_blocked->GetPrimitive()));
     };

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_resample_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_resample_node.cpp
@@ -349,7 +349,7 @@ void MKLDNNResampleNode::initSupportedPrimitiveDescriptors() {
     auto pushDesc = [&](memory::format format) {
         config.inConfs[0].desc = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, format);
         config.outConfs[0].desc = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, format);
-        supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown, format});
+        supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown});
     };
 
     if (type == "caffe.ResampleParameter.NEAREST") {

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reshape_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reshape_node.cpp
@@ -51,7 +51,7 @@ void MKLDNNReshapeNode::initSupportedPrimitiveDescriptors() {
     config.outConfs[0].inPlace = 0;
     config.outConfs[0].constant = false;
     config.outConfs[0].desc = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, outFormat);
-    supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::unknown, outFormat);
+    supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::unknown);
 }
 
 void MKLDNNReshapeNode::createPrimitive() {

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_rnn.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_rnn.cpp
@@ -149,19 +149,16 @@ void MKLDNNRNN::fillCellDesc() {
         w_bias_d = {{L, D, Gb, SC}, memory::f32, memory::ldgo};
 
     std::vector<TensorDesc> in_candidate, out_candidate;
-    std::vector<memory::format> outputFormats;
     in_candidate.emplace_back(MKLDNNMemoryDesc {D_shape, memory::f32, memory::nc});
     in_candidate.emplace_back(MKLDNNMemoryDesc {S_shape, memory::f32, memory::nc});
     out_candidate.emplace_back(MKLDNNMemoryDesc {S_shape, memory::f32, memory::nc});
-    outputFormats.emplace_back(memory::nc);
 
     if (S == 2) {
         in_candidate.emplace_back(MKLDNNMemoryDesc {S_shape, memory::f32, memory::nc});
         out_candidate.emplace_back(MKLDNNMemoryDesc {S_shape, memory::f32, memory::nc});
-        outputFormats.emplace_back(memory::nc);
     }
 
-    createDescriptor(in_candidate, out_candidate, outputFormats);
+    createDescriptor(in_candidate, out_candidate);
 }
 
 void MKLDNNRNN::fillSeqDesc() {
@@ -275,26 +272,21 @@ void MKLDNNRNN::fillSeqDesc() {
         in_candidate.emplace_back(MKLDNNMemoryDesc {S_shape, memory::f32, memory::nc});
 
     std::vector<TensorDesc> out_candidate;
-    std::vector<memory::format> outputFormats;
     if (nativeOrder) {
         out_candidate.push_back(out_data_d);
-        outputFormats.push_back(out_data_d.getFormat());
     } else {
         out_candidate.push_back(MKLDNNMemoryDesc{{N, T, SC}, memory::f32, memory::ntc});
-        outputFormats.push_back(memory::ntc);
     }
 
     for (int i = 1; i < outs.size(); i++) {
         out_candidate.emplace_back(MKLDNNMemoryDesc{S_shape, memory::f32, memory::nc});
-        outputFormats.push_back(memory::nc);
     }
 
-    createDescriptor(in_candidate, out_candidate, outputFormats);
+    createDescriptor(in_candidate, out_candidate);
 }
 
 void MKLDNNRNN::createDescriptor(const std::vector<TensorDesc> &inputDesc,
-                                 const std::vector<TensorDesc> &outputDesc,
-                                 const std::vector<memory::format> &outputFormats) {
+                                 const std::vector<TensorDesc> &outputDesc) {
     MKLDNNDescriptor desc(std::shared_ptr<rnn_forward::desc>(
             new rnn_forward::desc(forward_scoring, cell_desc,
                     direction,
@@ -326,7 +318,7 @@ void MKLDNNRNN::createDescriptor(const std::vector<TensorDesc> &inputDesc,
         config.outConfs.push_back(dataConfig);
     }
 
-    supportedPrimitiveDescriptors.emplace_back(config, ref_any, outputFormats);
+    supportedPrimitiveDescriptors.emplace_back(config, ref_any);
 }
 
 void MKLDNNRNN::createPrimitive() {

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_rnn.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_rnn.h
@@ -22,8 +22,7 @@ public:
     bool created() const override;
     using MKLDNNNode::createDescriptor;
     void createDescriptor(const std::vector<InferenceEngine::TensorDesc>& inputDesc,
-                          const std::vector<InferenceEngine::TensorDesc>& outputDesc,
-                          const std::vector<mkldnn::memory::format> &outputFormats);
+                          const std::vector<InferenceEngine::TensorDesc>& outputDesc) override;
 
     void execute(mkldnn::stream strm) override;
 

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_tile_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_tile_node.cpp
@@ -70,7 +70,7 @@ void MKLDNNTileNode::initSupportedPrimitiveDescriptors() {
     config.outConfs[0].inPlace = -1;
     config.outConfs[0].constant = false;
     config.outConfs[0].desc = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, fmt);
-    supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown, fmt});
+    supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown});
 }
 
 void MKLDNNTileNode::createPrimitive() {

--- a/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/convolution_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/convolution_transformation.cpp
@@ -98,7 +98,7 @@ void ConvolutionTransformation::validate() {
     std::map<std::string, InferenceEngine::DataPtr>::iterator it = outputs.begin();
     const InferenceEngine::CNNLayerPtr outputLayer = it->second->getCreatorLayer().lock();
     EXPECT_TRUE(outputLayer != nullptr);
-    EXPECT_EQ(fqOnActivations & fqOnWeights ? "ScaleShift" : "Convolution", outputLayer->type);
+    EXPECT_EQ((fqOnActivations & fqOnWeights) ? "ScaleShift" : "Convolution", outputLayer->type);
 
     if (fqOnActivations & fqOnWeights) {
         const InferenceEngine::CNNLayerPtr layer = InferenceEngine::details::CNNNetworkHelper::getParent(*outputLayer);


### PR DESCRIPTION
This is a part of changes required for switching into new one dnnl api version (> v1.0).

This patch try yo isolate all DNNL specific api call into corresponding Memory object. No explicit processing of "blocking descriptor" and others specific structures.
