### PR TITLE
[IE CLDNN] Fix Android build error: braces around scalar initializer

### DIFF
--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_kernel_imad_bs_fs_yx_bsv16_fsv16_1x1.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_kernel_imad_bs_fs_yx_bsv16_fsv16_1x1.h
@@ -36,7 +36,7 @@ protected:
     DispatchData SetDefault(const convolution_params& params, int autoTuneIndex = -1) const override;
     bool NeedPaddedInput() const override { return true; }
     WeightsLayout GetPreferredWeightsLayout(const convolution_params&) const override {
-        return { WeightsLayout::os_is_yx_osv16_isv16 };
+        return WeightsLayout::os_is_yx_osv16_isv16;
     }
 
     std::vector<FusedOpType> GetSupportedFusedOps() const override {

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_kernel_imad_bs_fs_yx_bsv16_fsv16_3x3.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_kernel_imad_bs_fs_yx_bsv16_fsv16_3x3.h
@@ -36,7 +36,7 @@ protected:
     DispatchData SetDefault(const convolution_params& params, int autoTuneIndex = -1) const override;
     bool NeedPaddedInput() const override { return true; }
     WeightsLayout GetPreferredWeightsLayout(const convolution_params&) const override {
-        return { WeightsLayout::os_is_yx_osv16_isv16 };
+        return WeightsLayout::os_is_yx_osv16_isv16;
     }
 
     std::vector<FusedOpType> GetSupportedFusedOps() const override {


### PR DESCRIPTION
Android build breaks because of new files introduced by #632, clang reports an error: braces around scalar initializer.
The change addresses this issue.