### PR TITLE
[IE CLDNN] Add some auto-tuning improvements

### DIFF
--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_params.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_params.cpp
@@ -41,7 +41,7 @@ std::string convolution_params::to_string() const {
 std::string convolution_params::to_cache_string_v2() const {
     std::stringstream s;
 
-    s << weight_bias_params::to_cache_string_v2() << ";";
+    s << parent::to_cache_string_v2() << ";";
     s << filterSize.x << "_" << filterSize.y << "_" << filterSize.z << ";";
     s << stride.x << "_" << stride.y << "_" << stride.z << ";";
     s << dilation.x << "_" << dilation.y << "_" << dilation.z << ";";

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/common/weight_bias_params.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/common/weight_bias_params.cpp
@@ -15,6 +15,7 @@
 */
 
 #include "weight_bias_params.h"
+#include <sstream>
 
 namespace kernel_selector {
 ParamsKey weight_bias_params::GetParamsKey() const {
@@ -37,4 +38,19 @@ ParamsKey weight_bias_params::GetParamsKey() const {
 
     return k;
 }
+
+std::string weight_bias_zero_point_params::to_cache_string_v2() const {
+    std::stringstream s;
+
+    s << weight_bias_params::to_cache_string_v2();
+    if (!activations_zero_points.empty())
+        s << ";activation_zp";
+    if (!weights_zero_points.empty())
+        s << ";weights_zp";
+    if (HasCompensation())
+        s << ";compensation";
+
+    return s.str();
+}
+
 }  // namespace kernel_selector

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/common/weight_bias_params.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/common/weight_bias_params.h
@@ -43,6 +43,7 @@ struct weight_bias_zero_point_params : public weight_bias_params {
     MultiDataTensor compensation;
 
     bool HasCompensation() const { return !compensation.empty(); }
+    std::string to_cache_string_v2() const override;
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/inference-engine/thirdparty/clDNN/src/gpu/kernel.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/kernel.cpp
@@ -306,7 +306,7 @@ void set_arguments(kernels_cache::kernel_type& kernel,
         }
 
         if (status != CL_SUCCESS) {
-            throw std::runtime_error("Error set args\n");
+            throw std::runtime_error("Error set arg " + std::to_string(i) + ", error code: " + std::to_string(status) + "\n");
         }
     }
 }


### PR DESCRIPTION
- add error reporting for failed kernel runs during auto-tune
- fix auto-tuning for asymmetric quantization
- add asymmetric quantization information to cache
- change auto-tuning metric from average to min

Change auto-tuning metric to minimum instead of average improves
repeatability across several auto-tune runs.
Example for b_fs_yx_fsv_16_32_imad_dw (100 tunings):
avg - unique: 10; best: 7211 (x34), 6203(x34); entropy: 2.38
median - unique: 6; best: 6203 (x70); entropy: 1.13
min - unique: 4; best: 6203 (x86); entropy: 0.69

Collateral from: CVS-25122