### PR TITLE
Enable read onnx model tensor FLOAT16 no raw data

### DIFF
--- a/ngraph/src/ngraph/frontend/onnx_import/core/tensor.hpp
+++ b/ngraph/src/ngraph/frontend/onnx_import/core/tensor.hpp
@@ -215,11 +215,16 @@ namespace ngraph
                 inline std::vector<ngraph::float16>
                     get_data(const ONNX_NAMESPACE::TensorProto& tensor)
                 {
-                    NGRAPH_CHECK(tensor.data_type() == ONNX_NAMESPACE::TensorProto_DataType_FLOAT16,
-                                 "Expected FLOAT16 data type");
-                    NGRAPH_CHECK(tensor.has_raw_data(), "Expected raw data for FLOAT16 data type");
-                    return detail::__get_raw_data<ngraph::float16>(tensor.raw_data(),
-                                                                   tensor.data_type());
+                    if (tensor.has_raw_data())
+                    {
+                        return detail::__get_raw_data<ngraph::float16>(tensor.raw_data(),
+                                                                       tensor.data_type());
+                    }
+                    if (tensor.data_type() == ONNX_NAMESPACE::TensorProto_DataType_FLOAT16)
+                    {
+                        return detail::__get_data<ngraph::float16>(tensor.int32_data());
+                    }
+                    throw error::tensor::invalid_data_type{tensor.data_type()};
                 }
 
                 template <>


### PR DESCRIPTION
Enable read onnx model tensor FLOAT16 no raw data by get int32_data.
It was a blocker for onnx model import with initializer data_type FLOAT16 and values stored as "int32_data" in onnx proto.
