### PR TITLE
Resolve build failure due to warning C5208

### DIFF
--- a/ngraph/src/ngraph/op/detection_output.hpp
+++ b/ngraph/src/ngraph/op/detection_output.hpp
@@ -22,7 +22,7 @@ namespace ngraph
 {
     namespace op
     {
-        typedef struct
+        typedef struct DetectionOutputAttrs_
         {
             int num_classes;
             int background_label_id = 0;


### PR DESCRIPTION
> warning C5208: unnamed class used in typedef name cannot declare members other than non-static data members, member enumerations, or member classes

This commit adds a placeholder name to the struct definition
according to the accepted solution here:
https://developercommunity.visualstudio.com/content/problem/1034754/warning-c5208-a-c20-feature-occurs-when-compiling-1.html

Only applies to MSVC 19.26 or later. The alternative is to add a switch
`/Wv:19.25` to suppress the warning.