### PR TITLE
Interpret empty dimension as Dimension::dynamic()

### DIFF
--- a/ngraph/src/ngraph/frontend/onnx_import/core/value_info.hpp
+++ b/ngraph/src/ngraph/frontend/onnx_import/core/value_info.hpp
@@ -126,7 +126,7 @@ namespace ngraph
                     {
                         dims.emplace_back(onnx_dim.dim_value());
                     }
-                    else if (onnx_dim.has_dim_param())
+                    else // has_dim_param() == true or it is empty dim
                     {
                         dims.push_back(Dimension::dynamic());
                     }


### PR DESCRIPTION
According to doc (https://github.com/onnx/onnx/blob/master/docs/IR.md): "A dimension MAY have neither dim_value nor dim_param set. Such a dimension represents an unknown dimension unrelated to other unknown dimensions."

Such case occurs in TinyYoloV3.