### PR TITLE
[IE CLDNN] Add additional check for local block io support

### DIFF
--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/include/mmad.cl
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/include/mmad.cl
@@ -555,7 +555,7 @@ inline uchar16 FUNC(sub_group_block_read_uchar16)(const __global uchar* ptr) __a
 
 inline uchar16 FUNC(sub_group_block_read_uchar16)(const __local uchar* ptr) __attribute__((overloadable))
 {
-#if defined(cl_intel_subgroup_local_block_io) && defined(cl_intel_subgroups_char)
+#if LOCAL_BLOCK_IO_SUPPORTED && defined(cl_intel_subgroup_local_block_io) && defined(cl_intel_subgroups_char)
     // WA for compiler support
     // return intel_sub_group_block_read_uc16(ptr);
     return (uchar16)(intel_sub_group_block_read_uc8(ptr), intel_sub_group_block_read_uc8(ptr + 8 * get_max_sub_group_size()));
@@ -627,7 +627,7 @@ inline uchar8 FUNC(sub_group_block_read_uchar8)(const __global uchar* ptr) __att
 
 inline uchar8 FUNC(sub_group_block_read_uchar8)(const __local uchar* ptr) __attribute__((overloadable))
 {
-#if defined(cl_intel_subgroup_local_block_io) && defined(cl_intel_subgroups_char)
+#if LOCAL_BLOCK_IO_SUPPORTED && defined(cl_intel_subgroup_local_block_io) && defined(cl_intel_subgroups_char)
     return intel_sub_group_block_read_uc8(ptr);
 #else
     uint idx = get_sub_group_local_id();
@@ -681,7 +681,7 @@ inline uchar4 FUNC(sub_group_block_read_uchar4)(const __global uchar* ptr) __att
 
 inline uchar4 FUNC(sub_group_block_read_uchar4)(const __local uchar* ptr) __attribute__((overloadable))
 {
-#if defined(cl_intel_subgroup_local_block_io) && defined(cl_intel_subgroups_char)
+#if LOCAL_BLOCK_IO_SUPPORTED && defined(cl_intel_subgroup_local_block_io) && defined(cl_intel_subgroups_char)
     return intel_sub_group_block_read_uc4(ptr);
 #else
     uint idx = get_sub_group_local_id();
@@ -727,7 +727,7 @@ inline uchar2 FUNC(sub_group_block_read_uchar2)(const __global uchar* ptr) __att
 
 inline uchar2 FUNC(sub_group_block_read_uchar2)(const __local uchar* ptr) __attribute__((overloadable))
 {
-#if defined(cl_intel_subgroup_local_block_io) && defined(cl_intel_subgroups_char)
+#if LOCAL_BLOCK_IO_SUPPORTED && defined(cl_intel_subgroup_local_block_io) && defined(cl_intel_subgroups_char)
     return intel_sub_group_block_read_uc2(ptr);
 #else
     uint idx = get_sub_group_local_id();
@@ -769,7 +769,7 @@ inline uchar FUNC(sub_group_block_read_uchar)(const __global uchar* ptr) __attri
 
 inline uchar FUNC(sub_group_block_read_uchar)(const __local uchar* ptr) __attribute__((overloadable))
 {
-#if defined(cl_intel_subgroup_local_block_io) && defined(cl_intel_subgroups_char)
+#if LOCAL_BLOCK_IO_SUPPORTED && defined(cl_intel_subgroup_local_block_io) && defined(cl_intel_subgroups_char)
     return intel_sub_group_block_read_uc(ptr);
 #else
     uint idx = get_sub_group_local_id();

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/common/common_kernel_base.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/common/common_kernel_base.cpp
@@ -152,7 +152,7 @@ std::shared_ptr<KernelString> common_kernel_base::GetKernelString(const std::str
         if (engine_info.bOptHintsSupport)
             kernel_string->options += " -DOPT_HINS_SUPPORTED=1";
         if (engine_info.bLocalBlockIOSupport)
-            kernel_string->options += " -Dcl_intel_subgroup_local_block_io";
+            kernel_string->options += " -Dcl_intel_subgroup_local_block_io -DLOCAL_BLOCK_IO_SUPPORTED=1";
         kernel_string->entry_point = entry_point;
         kernel_string->batch_compilation = true;
     }


### PR DESCRIPTION
This change is needed, because some ocl compiler versions may advertise
support for extension, but fail to compile some of the functions.
Additionally it may enable the extension by default, which necessitates extra
define `LOCAL_BLOCK_IO_SUPPORTED` to manually enable/disable it in such cases.

Issue: CVS-34385