### PR TITLE
[IE VPU] Remove dataToShape edges from unsued data

### DIFF
--- a/inference-engine/src/vpu/graph_transformer/include/vpu/model/model.hpp
+++ b/inference-engine/src/vpu/graph_transformer/include/vpu/model/model.hpp
@@ -162,6 +162,7 @@ public:
             const Stage& newDependentStage);
 
     void removeStageDependency(const StageDependency& edge);
+    void removeStageDependency(const Stage& stage, const Data& dependency);
 
     //
     // Stage <-> Stage edges

--- a/inference-engine/src/vpu/graph_transformer/src/model/model.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/model/model.cpp
@@ -492,22 +492,6 @@ void ModelObj::replaceStageInput(
     IE_ASSERT(edge->_childEdge == nullptr);
 
     //
-    // New and old dynamic data must have the same parent shape data
-    //
-
-    if (edge->_input->parentDataToShapeEdge()) {
-        const auto& newParentDataToShapeEdge = newInput->parentDataToShapeEdge();
-        VPU_INTERNAL_CHECK(newParentDataToShapeEdge != nullptr,
-                "Replaced input data with name {} from {} stage with name {} has parentDataToShapeEdge, "
-                "but new input data with name {} has no parentDataToShapeEdge",
-                edge->_input->name(), edge->_consumer->type(), edge->_consumer->name(), newInput->name());
-        VPU_INTERNAL_CHECK(newParentDataToShapeEdge->parent() == edge->_input->parentDataToShapeEdge()->parent(),
-                "Replaced input data with name {} from {} stage with name {} and new input data with name must "
-                "have the same shape data",
-                edge->_input->name(), edge->_consumer->type(), edge->_consumer->name(), newInput->name());
-    }
-
-    //
     // Edge change affects the Stage order.
     //
 
@@ -603,15 +587,20 @@ void ModelObj::replaceStageOutput(
     // New and old dynamic data must have the same parent shape data
     //
 
-    if (edge->_output->parentDataToShapeEdge()) {
+    if (const auto& oldParentDataToShapeEdge = edge->_output->parentDataToShapeEdge()) {
         const auto& newParentDataToShapeEdge = newOutput->parentDataToShapeEdge();
         VPU_INTERNAL_CHECK(newParentDataToShapeEdge != nullptr,
                 "Replaced output data with name {} from {} stage with name {} has parentDataToShapeEdge, "
                 "but new output data with name {} has no parentDataToShapeEdge",
                 edge->_output->name(), edge->_producer->type(), edge->_producer->name(), newOutput->name());
-        VPU_INTERNAL_CHECK(newParentDataToShapeEdge->parent() == edge->_output->parentDataToShapeEdge()->parent(),
+        VPU_INTERNAL_CHECK(newParentDataToShapeEdge->parent() == oldParentDataToShapeEdge->parent(),
                 "Replaced output data with name {} from {} stage with name {} and new output data with name must "
                 "have the same shape data",
+                edge->_output->name(), edge->_producer->type(), edge->_producer->name(), newOutput->name());
+    } else {
+        VPU_INTERNAL_CHECK(newOutput->parentDataToShapeEdge() == nullptr,
+                "Replaced output data with name {} from {} stage with name {} has not parentDataToShapeEdge, "
+                "but new output data with name {} has",
                 edge->_output->name(), edge->_producer->type(), edge->_producer->name(), newOutput->name());
     }
 

--- a/inference-engine/src/vpu/graph_transformer/src/model/model.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/model/model.cpp
@@ -2146,8 +2146,8 @@ void ModelObj::removeUnusedData(const Data& data) {
         _allocator.setNeedToAllocNonIntermData();
     }
 
-    if (const auto dataToShapeEdge = data->_parentDataToShapeEdge) {
-        const auto& shape = dataToShapeEdge->parent();
+    if (const auto dataToShapeEdge = data->parentDataToShapeEdge()) {
+        const auto shape = dataToShapeEdge->parent();
         disconnectDatas(dataToShapeEdge);
         VPU_INTERNAL_CHECK(!shape->childDataToShapeEdges().empty() || !shape->consumerEdges().empty(),
                 "Removed unused data (with name {}) must have a shape data (with name {}) which is a shape "

--- a/inference-engine/src/vpu/graph_transformer/src/model/model.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/model/model.cpp
@@ -771,9 +771,9 @@ void ModelObj::removeStageDependency(const StageDependency& edge) {
 }
 
 void ModelObj::removeStageDependency(const Stage& stage, const Data& dependency) {
-    const auto &dependentStagesEdges = dependency->dependentStagesEdges();
+    const auto& dependentStagesEdges = dependency->dependentStagesEdges();
 
-    const auto it = std::find_if(dependentStagesEdges.begin(), dependentStagesEdges.end(), [&stage](const StageDependency &edge) {
+    const auto it = std::find_if(dependentStagesEdges.begin(), dependentStagesEdges.end(), [&stage](const StageDependency& edge) {
         return edge->dependentStage() == stage;
     });
 

--- a/inference-engine/src/vpu/graph_transformer/src/model/model.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/model/model.cpp
@@ -186,6 +186,10 @@ Data ModelObj::duplicateData(
     newData->_desc  = newDesc.numDims() != 0 ? newDesc : origData->desc();
     newData->_model = this;
 
+    if (const auto& parentDataToShapeEdge = origData->parentDataToShapeEdge()) {
+        connectDataWithShape(parentDataToShapeEdge->parent(), newData);
+    }
+
     if (newDataUsage == DataUsage::Const) {
         const auto& content = newContent != nullptr ? newContent : origData->content();
         const auto& desc = newDesc != DataDesc() ? newDesc : origData->desc();
@@ -492,6 +496,27 @@ void ModelObj::replaceStageInput(
     IE_ASSERT(edge->_childEdge == nullptr);
 
     //
+    // New and old dynamic data must have the same parent shape data
+    //
+
+    if (const auto& oldParentDataToShapeEdge = edge->input()->parentDataToShapeEdge()) {
+        const auto& newParentDataToShapeEdge = newInput->parentDataToShapeEdge();
+        VPU_THROW_UNLESS(newParentDataToShapeEdge != nullptr,
+                "Replaced input data with name {} from {} stage with name {} has parentDataToShapeEdge, "
+                "but new input data with name {} has no parentDataToShapeEdge",
+                edge->input()->name(), edge->consumer()->type(), edge->consumer()->name(), newInput->name());
+        VPU_THROW_UNLESS(newParentDataToShapeEdge->parent() == oldParentDataToShapeEdge->parent(),
+                "Replaced input data with name {} from {} stage with name {} and new input data with name must "
+                "have the same shape data",
+                edge->input()->name(), edge->consumer()->type(), edge->consumer()->name(), newInput->name());
+    } else {
+        VPU_THROW_UNLESS(newInput->parentDataToShapeEdge() == nullptr,
+                "Replaced input data with name {} from {} stage with name {} has not parentDataToShapeEdge, "
+                "but new input data with name {} has",
+                edge->input()->name(), edge->consumer()->type(), edge->consumer()->name(), newInput->name());
+    }
+
+    //
     // Edge change affects the Stage order.
     //
 
@@ -587,21 +612,21 @@ void ModelObj::replaceStageOutput(
     // New and old dynamic data must have the same parent shape data
     //
 
-    if (const auto& oldParentDataToShapeEdge = edge->_output->parentDataToShapeEdge()) {
+    if (const auto& oldParentDataToShapeEdge = edge->output()->parentDataToShapeEdge()) {
         const auto& newParentDataToShapeEdge = newOutput->parentDataToShapeEdge();
-        VPU_INTERNAL_CHECK(newParentDataToShapeEdge != nullptr,
+        VPU_THROW_UNLESS(newParentDataToShapeEdge != nullptr,
                 "Replaced output data with name {} from {} stage with name {} has parentDataToShapeEdge, "
                 "but new output data with name {} has no parentDataToShapeEdge",
-                edge->_output->name(), edge->_producer->type(), edge->_producer->name(), newOutput->name());
-        VPU_INTERNAL_CHECK(newParentDataToShapeEdge->parent() == oldParentDataToShapeEdge->parent(),
+                edge->output()->name(), edge->producer()->type(), edge->producer()->name(), newOutput->name());
+        VPU_THROW_UNLESS(newParentDataToShapeEdge->parent() == oldParentDataToShapeEdge->parent(),
                 "Replaced output data with name {} from {} stage with name {} and new output data with name must "
                 "have the same shape data",
-                edge->_output->name(), edge->_producer->type(), edge->_producer->name(), newOutput->name());
+                edge->output()->name(), edge->producer()->type(), edge->producer()->name(), newOutput->name());
     } else {
-        VPU_INTERNAL_CHECK(newOutput->parentDataToShapeEdge() == nullptr,
+        VPU_THROW_UNLESS(newOutput->parentDataToShapeEdge() == nullptr,
                 "Replaced output data with name {} from {} stage with name {} has not parentDataToShapeEdge, "
                 "but new output data with name {} has",
-                edge->_output->name(), edge->_producer->type(), edge->_producer->name(), newOutput->name());
+                edge->output()->name(), edge->producer()->type(), edge->producer()->name(), newOutput->name());
     }
 
     //
@@ -743,6 +768,19 @@ void ModelObj::removeStageDependency(const StageDependency& edge) {
         dependency->name(), dependency->usage(), dependentStage->name(), dependentStage->type());
 
     _stageDependencyEdgePtrList.erase(edge->_ptrPosInModel);
+}
+
+void ModelObj::removeStageDependency(const Stage& stage, const Data& dependency) {
+    const auto &dependentStagesEdges = dependency->dependentStagesEdges();
+
+    const auto it = std::find_if(dependentStagesEdges.begin(), dependentStagesEdges.end(), [&stage](const StageDependency &edge) {
+        return edge->dependentStage() == stage;
+    });
+
+    if (it != dependentStagesEdges.end()) {
+        const auto stageDependencyEdge = *it;
+        removeStageDependency(stageDependencyEdge);
+    }
 }
 
 ModelObj::InjectStageHelper::~InjectStageHelper() {
@@ -1677,18 +1715,8 @@ void ModelObj::replaceDataToShapeParent(
     newParent->_childDataToShapeEdges.push_back(edge);
 
     const auto& childProducer = child->producer();
-
     if (childProducer != nullptr) {
-        const auto& dependentStagesEdges = oldParent->dependentStagesEdges();
-
-        const auto it = std::find_if(dependentStagesEdges.begin(), dependentStagesEdges.end(), [&childProducer](const StageDependency& edge) {
-            return edge->dependentStage() == childProducer;
-        });
-
-        if (it != dependentStagesEdges.end()) {
-            const auto edge = *it;
-            removeStageDependency(edge);
-        }
+        removeStageDependency(childProducer, oldParent);
 
         if (isStageDependencyNeeded(childProducer, newParent)) {
             // Shape and data are produced from different stages, make sure that shape is calculated before data
@@ -1713,18 +1741,8 @@ void ModelObj::replaceDataToShapeChild(
     newChild->_parentDataToShapeEdge = edge;
 
     const auto& oldChildProducer = oldChild->producer();
-
     if (oldChildProducer != nullptr) {
-        const auto &dependentStagesEdges = parent->dependentStagesEdges();
-
-        const auto it = std::find_if(dependentStagesEdges.begin(), dependentStagesEdges.end(), [&oldChildProducer](const StageDependency &edge) {
-            return edge->dependentStage() == oldChildProducer;
-        });
-
-        if (it != dependentStagesEdges.end()) {
-            const auto edge = *it;
-            removeStageDependency(edge);
-        }
+        removeStageDependency(oldChildProducer, parent);
     }
 
     const auto& newChildProducer = newChild->producer();
@@ -1813,18 +1831,8 @@ void ModelObj::disconnectDatas(const DataToShapeAllocation& edge) {
     _shapeEdgePtrList.erase(edge->_ptrPosInModel);
 
     const auto& childProducer = child->producer();
-
     if (childProducer != nullptr) {
-        const auto &dependentStagesEdges = parent->dependentStagesEdges();
-
-        const auto it = std::find_if(dependentStagesEdges.begin(), dependentStagesEdges.end(), [&childProducer](const StageDependency &edge) {
-            return edge->dependentStage() == childProducer;
-        });
-
-        if (it != dependentStagesEdges.end()) {
-            const auto edge = *it;
-            removeStageDependency(edge);
-        }
+        removeStageDependency(childProducer, parent);
     }
 }
 
@@ -1877,17 +1885,7 @@ void ModelObj::disconnectStage(const Stage& stage) {
     for (const auto& outEdge : stage->_outputEdges) {
         // Disconnect from dependency
         if (const auto& dataToShapeEdge = outEdge->output()->parentDataToShapeEdge()) {
-            const auto& shape = dataToShapeEdge->parent();
-            const auto& dependentStagesEdges = shape->dependentStagesEdges();
-
-            const auto it = std::find_if(dependentStagesEdges.begin(), dependentStagesEdges.end(), [&stage](const StageDependency &edge) {
-                return edge->dependentStage() == stage;
-            });
-
-            if (it != dependentStagesEdges.end()) {
-                const auto edge = *it;
-                removeStageDependency(edge);
-            }
+            removeStageDependency(stage, dataToShapeEdge->parent());
         }
         // Disconnect from consumers
         for (const auto& consumerEdge : outEdge->_output->_consumerEdges) {


### PR DESCRIPTION
### Description
* Check equality of shape data for the replaced and replacement input/output data in model
* Connect data with shape in duplicateData method
* Disconnect shape with data which is being removed as unsued.
* Check that disconnected shape still have child dataToShape edges or consumers
* Refactor `cleanUp` to use `removeUnsuedData` and not duplicate code

### Task
#-34277