### PR TITLE
[IE CLDNN] Fix input feature padding handling in dw conv fsv16 kernel

### DIFF
--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/convolution_gpu_bfyx_f16_depthwise.cl
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/convolution_gpu_bfyx_f16_depthwise.cl
@@ -57,7 +57,6 @@ KERNEL(convolution_depthwise)(
     const uint input_fs_pad_before = INPUT0_PAD_BEFORE_FEATURE_NUM / FEATURE_SLICE_SIZE;
 
     const uint input_offset = b * input_b_pitch +
-                              input_fs_pad_before * input_fs_pitch +
                               INPUT0_PAD_BEFORE_SIZE_Y * input_y_pitch +
                               INPUT0_PAD_BEFORE_SIZE_X * input_x_pitch +
                               (f_block + input_fs_pad_before) * input_fs_pitch;

--- a/inference-engine/thirdparty/clDNN/tests/test_cases/convolution_gpu_test.cpp
+++ b/inference-engine/thirdparty/clDNN/tests/test_cases/convolution_gpu_test.cpp
@@ -6623,7 +6623,7 @@ TEST_P(convolution_depthwise_gpu_fsv16, depthwise_conv_b_fs_yx_fsv16)
 TEST(convolution_depthwise_gpu_fsv16, depthwise_conv_b_fs_yx_fsv16_in_feature_padding) {
     //  Input:                  1x32x2x1
     //  Input padding above:    0x16x0x0
-    //  Input padding below:    0x0x0x0
+    //  Input padding below:    0x64x0x0
     //  Groups:                 32
     //  Filter:                 32x1x1x1x1
     //  Output:                 1x32x2x1
@@ -6666,7 +6666,7 @@ TEST(convolution_depthwise_gpu_fsv16, depthwise_conv_b_fs_yx_fsv16_in_feature_pa
         -19,  21,  -7,   8,   3, -12,  12,  16,  -1,  -4,  -4, -12,   9,  13, -14, -14
     };
 
-    // reorder input to fsv16 format and introduce feature padding above
+    // reorder input to fsv16 format and introduce feature padding
     padding input_padding = padding(input_lower_sizes, input_upper_sizes);
     layout reordered_input_layout = layout(data_types::f32, format::b_fs_yx_fsv16, input_size, input_padding);
 


### PR DESCRIPTION
This patch is meant to fix handling of input feature padding in depthwise convolution kernel for blocked format.

JIRA: CVS-34305