### PR TITLE
Windows build fix

### DIFF
--- a/ngraph/test/attributes.cpp
+++ b/ngraph/test/attributes.cpp
@@ -1105,11 +1105,11 @@ TEST(attributes, lstm_sequence_op)
 {
     FactoryRegistry<Node>::get().register_factory<opset1::LSTMSequence>();
 
-    const auto batch_size = 4;
-    const auto num_directions = 2;
-    const auto seq_length = 8;
-    const auto input_size = 16;
-    const auto hidden_size = 64;
+    const size_t batch_size = 4;
+    const size_t num_directions = 2;
+    const size_t seq_length = 8;
+    const size_t input_size = 16;
+    const size_t hidden_size = 64;
 
     const auto X =
         make_shared<op::Parameter>(element::f32, Shape{batch_size, seq_length, input_size});

--- a/ngraph/test/type_prop/lstm_sequence.cpp
+++ b/ngraph/test/type_prop/lstm_sequence.cpp
@@ -23,11 +23,11 @@ using namespace ngraph;
 
 TEST(type_prop, lstm_sequence_forward)
 {
-    const auto batch_size = 8;
-    const auto num_directions = 1;
-    const auto seq_length = 6;
-    const auto input_size = 4;
-    const auto hidden_size = 128;
+    const size_t batch_size = 8;
+    const size_t num_directions = 1;
+    const size_t seq_length = 6;
+    const size_t input_size = 4;
+    const size_t hidden_size = 128;
 
     const auto X =
         make_shared<op::Parameter>(element::f32, Shape{batch_size, seq_length, input_size});
@@ -75,11 +75,11 @@ TEST(type_prop, lstm_sequence_forward)
 
 TEST(type_prop, lstm_sequence_bidirectional)
 {
-    const auto batch_size = 24;
-    const auto num_directions = 2;
-    const auto seq_length = 12;
-    const auto input_size = 8;
-    const auto hidden_size = 256;
+    const size_t batch_size = 24;
+    const size_t num_directions = 2;
+    const size_t seq_length = 12;
+    const size_t input_size = 8;
+    const size_t hidden_size = 256;
 
     const auto X =
         make_shared<op::Parameter>(element::f32, Shape{batch_size, seq_length, input_size});


### PR DESCRIPTION
With `auto` the deduced type is `int` which does not match the `Shape` class constructor and that causes a warning. On my machine this warning is treated as an error and causes a build break.