### PR TITLE
Add ONNX DequantizeLinear to MO

### DIFF
--- a/docs/MO_DG/prepare_model/Supported_Frameworks_Layers.md
+++ b/docs/MO_DG/prepare_model/Supported_Frameworks_Layers.md
@@ -306,7 +306,7 @@ Standard ONNX\* operators:
 | Cosh | No |
 | Crop | No |
 | CumSum | No |
-| DequantizeLinear | Only in combination with QuantizeLinear, refer to the desc of the latter |
+| DequantizeLinear | No |
 | DetectionOutput (Intel experimental) | No |
 | Div | No |
 | Dropout | Not needed for inference |

--- a/model-optimizer/automation/package_BOM.txt
+++ b/model-optimizer/automation/package_BOM.txt
@@ -242,6 +242,8 @@ extensions/front/onnx/crop_ext.py
 extensions/front/onnx/cumsum_ext.py
 extensions/front/onnx/deformable_conv_ext.py
 extensions/front/onnx/depth_to_space_ext.py
+extensions/front/onnx/dequantize_linear_ext.py
+extensions/front/onnx/dequantize_linear_resolver.py
 extensions/front/onnx/detection_output.py
 extensions/front/onnx/detectionoutput_ext.py
 extensions/front/onnx/dropout_ext.py
@@ -594,6 +596,7 @@ extensions/ops/ctc_greedy_decoder.py
 extensions/ops/cumsum.py
 extensions/ops/data_augmentation.py
 extensions/ops/depth_to_space.py
+extensions/ops/dequantize_linear.py
 extensions/ops/DetectionOutput.py
 extensions/ops/detectionoutput_onnx.py
 extensions/ops/elementwise.py

--- a/model-optimizer/extensions/front/onnx/dequantize_linear_ext.py
+++ b/model-optimizer/extensions/front/onnx/dequantize_linear_ext.py
@@ -1,0 +1,32 @@
+"""
+ Copyright (C) 2020 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+from extensions.ops.dequantize_linear import DequantizeLinear
+from mo.front.extractor import FrontExtractorOp
+from mo.front.onnx.extractors.utils import onnx_attr, get_onnx_opset_version
+
+
+class DequantizeLinearFrontExtractor(FrontExtractorOp):
+    op = 'DequantizeLinear'
+    enabled = True
+
+    @classmethod
+    def extract(cls, node):
+        attrs = {}
+        if get_onnx_opset_version(node) >= 13:
+            axis = onnx_attr(node, 'axis', 'i', default=1)
+            attrs.update(axis=axis)
+        DequantizeLinear.update_node_stat(node, attrs)
+        return cls.enabled

--- a/model-optimizer/extensions/front/onnx/dequantize_linear_ext.py
+++ b/model-optimizer/extensions/front/onnx/dequantize_linear_ext.py
@@ -13,6 +13,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
+import logging as log
+
 from extensions.ops.dequantize_linear import DequantizeLinear
 from mo.front.extractor import FrontExtractorOp
 from mo.front.onnx.extractors.utils import onnx_attr, get_onnx_opset_version
@@ -24,9 +26,8 @@ class DequantizeLinearFrontExtractor(FrontExtractorOp):
 
     @classmethod
     def extract(cls, node):
-        attrs = {}
         if get_onnx_opset_version(node) >= 13:
-            axis = onnx_attr(node, 'axis', 'i', default=1)
-            attrs.update(axis=axis)
-        DequantizeLinear.update_node_stat(node, attrs)
+            log.warning('Ignoring "axis" attribute for DequantizeLinear-{} node, inference might be incorrect.'.format(
+                get_onnx_opset_version(node)))
+        DequantizeLinear.update_node_stat(node)
         return cls.enabled

--- a/model-optimizer/extensions/front/onnx/dequantize_linear_resolver.py
+++ b/model-optimizer/extensions/front/onnx/dequantize_linear_resolver.py
@@ -1,0 +1,73 @@
+"""
+ Copyright (C) 2020 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+import numpy as np
+
+from extensions.front.onnx.quantize_dequantize_linear import QuantizeDequantizeLinear
+from extensions.ops.Cast import Cast
+from extensions.ops.elementwise import Mul, Sub
+from mo.front.common.partial_infer.utils import int64_array
+from mo.front.common.replacement import FrontReplacementOp
+from mo.front.tf.graph_utils import create_op_with_const_inputs
+from mo.graph.graph import Graph, Node, rename_nodes
+from mo.ops.broadcast import Broadcast
+from mo.ops.shape import Shape
+
+
+class DequantizeLinearResolver(FrontReplacementOp):
+    """
+    DequantizeLinear can be replace with the following formula: y = (x - x_zero_point) * x_scale
+    """
+    op = "DequantizeLinear"
+    enabled = True
+
+    def run_after(self):
+        return [QuantizeDequantizeLinear]
+
+    def replace_op(self, graph: Graph, node: Node):
+        node_name = node.soft_get('name', node.id)
+        cast = Cast(graph, {'dst_type': np.float32, 'name': node_name + '/Cast'}).create_node()
+        node.in_port(0).get_connection().set_destination(cast.in_port(0))
+        mul = Mul(graph, {}).create_node()
+
+        if node.has_valid('axis'):
+            shape = Shape(graph, {'name': node_name + '/Shape'}).create_node()
+            cast.in_port(0).get_connection().add_destination(shape.in_port(0))
+
+        if node.is_in_port_connected(2):
+            sub = Sub(graph, {'name': node_name + '/Sub'}).create_node()
+            cast.out_port(0).connect(sub.in_port(0))
+            if node.has_valid('axis'):
+                bc2 = create_op_with_const_inputs(graph, Broadcast, {2: int64_array(node['axis'])},
+                                                  {'mode': 'explicit', 'name': node_name + '/BC2'})
+                node.in_port(2).get_connection().set_destination(bc2.in_port(0))
+                shape.out_port(0).connect(bc2.in_port(1))
+                bc2.out_port(0).connect(sub.in_port(1))
+            else:
+                node.in_port(2).get_connection().set_destination(sub.in_port(1))
+            sub.out_port(0).connect(mul.in_port(0))
+        else:
+            cast.out_port(0).connect(mul.in_port(0))
+        if node.has_valid('axis'):
+            bc1 = create_op_with_const_inputs(graph, Broadcast, {2: int64_array(node['axis'])},
+                                              {'mode': 'explicit', 'name': node_name + '/BC1'})
+            node.in_port(1).get_connection().set_destination(bc1.in_port(0))
+            shape.out_port(0).get_connection().add_destination(bc1.in_port(1))
+            bc1.out_port(0).connect(mul.in_port(1))
+        else:
+            node.in_port(1).get_connection().set_destination(mul.in_port(1))
+        rename_nodes([(node, node_name + '/TBD'), (mul, node_name)])
+
+        return [mul.id]

--- a/model-optimizer/extensions/front/onnx/dequantize_linear_resolver.py
+++ b/model-optimizer/extensions/front/onnx/dequantize_linear_resolver.py
@@ -13,18 +13,13 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-import numpy as np
 
 from extensions.front.onnx.quantize_dequantize_linear import QuantizeDequantizeLinear
 from extensions.ops.Cast import Cast
 from extensions.ops.elementwise import Mul, Sub
-from mo.front.common.partial_infer.utils import int64_array
 from mo.front.common.replacement import FrontReplacementOp
-from mo.front.tf.graph_utils import create_op_with_const_inputs
 from mo.graph.graph import Graph, Node, rename_nodes
 from mo.middle.passes.convert_data_type import data_type_str_to_np
-from mo.ops.broadcast import Broadcast
-from mo.ops.shape import Shape
 
 
 class DequantizeLinearResolver(FrontReplacementOp):
@@ -44,35 +39,15 @@ class DequantizeLinearResolver(FrontReplacementOp):
         node.in_port(0).get_connection().set_destination(cast.in_port(0))
         mul = Mul(graph, {}).create_node()
 
-        if node.has_valid('axis'):
-            # add Shape node if DequantizeLinear has "axis" attribute to perform correct broadcasting
-            shape = Shape(graph, {'name': node_name + '/Shape'}).create_node()
-            cast.in_port(0).get_connection().add_destination(shape.in_port(0))
-
         if node.is_in_port_connected(2):
             sub = Sub(graph, {'name': node_name + '/Sub'}).create_node()
             cast.out_port(0).connect(sub.in_port(0))
-            if node.has_valid('axis'):
-                # Broadcast y_zero_point input if DequantizeLinear has "axis" attribute
-                bc2 = create_op_with_const_inputs(graph, Broadcast, {2: int64_array(node['axis'])},
-                                                  {'mode': 'explicit', 'name': node_name + '/BC2'})
-                node.in_port(2).get_connection().set_destination(bc2.in_port(0))
-                shape.out_port(0).connect(bc2.in_port(1))
-                bc2.out_port(0).connect(sub.in_port(1))
-            else:
-                node.in_port(2).get_connection().set_destination(sub.in_port(1))
+            node.in_port(2).get_connection().set_destination(sub.in_port(1))
             sub.out_port(0).connect(mul.in_port(0))
         else:
             cast.out_port(0).connect(mul.in_port(0))
-        if node.has_valid('axis'):
-            # Broadcast y_scale input if DequantizeLinear has "axis" attribute
-            bc1 = create_op_with_const_inputs(graph, Broadcast, {2: int64_array(node['axis'])},
-                                              {'mode': 'explicit', 'name': node_name + '/BC1'})
-            node.in_port(1).get_connection().set_destination(bc1.in_port(0))
-            shape.out_port(0).get_connection().add_destination(bc1.in_port(1))
-            bc1.out_port(0).connect(mul.in_port(1))
-        else:
-            node.in_port(1).get_connection().set_destination(mul.in_port(1))
+
+        node.in_port(1).get_connection().set_destination(mul.in_port(1))
         rename_nodes([(node, node_name + '/TBD'), (mul, node_name)])
 
         return [mul.id]

--- a/model-optimizer/extensions/front/onnx/dequantize_linear_resolver_test.py
+++ b/model-optimizer/extensions/front/onnx/dequantize_linear_resolver_test.py
@@ -59,7 +59,7 @@ class TestDequantizeLinearResolver(unittest.TestCase):
                             {'scale_param_dq': {'shape': np.array([]), 'value': np.float32(1.0 / 255)},
                              'zerop_param_dq': {'shape': np.array([]), 'value': np.uint8(0)},
                              }, nodes_with_edges_only=True)
-        graph.graph['cmd_params'] = Namespace(keep_shape_ops=True)
+        graph.graph['cmd_params'] = Namespace(keep_shape_ops=True, data_type='FP32')
 
         graph_ref = build_graph(nodes_ref_attributes,
                                 [('input', 'cast'),
@@ -87,7 +87,7 @@ class TestDequantizeLinearResolver(unittest.TestCase):
                              ],
                             {'scale_param_dq': {'shape': np.array([]), 'value': np.float32(1.0 / 255)},
                              }, nodes_with_edges_only=True)
-        graph.graph['cmd_params'] = Namespace(keep_shape_ops=True)
+        graph.graph['cmd_params'] = Namespace(keep_shape_ops=True, data_type='FP32')
 
         graph_ref = build_graph(nodes_ref_attributes,
                                 [('input', 'cast'),
@@ -115,7 +115,7 @@ class TestDequantizeLinearResolver(unittest.TestCase):
                              'scale_param_dq': {'shape': np.array([]), 'value': np.float32(1.0 / 255)},
                              'zerop_param_dq': {'shape': np.array([]), 'value': np.uint8(0)},
                              }, nodes_with_edges_only=True)
-        graph.graph['cmd_params'] = Namespace(keep_shape_ops=True)
+        graph.graph['cmd_params'] = Namespace(keep_shape_ops=True, data_type='FP32')
 
         graph_ref = build_graph(nodes_ref_attributes,
                                 [('input', 'cast', {'out': 0}),
@@ -153,7 +153,7 @@ class TestDequantizeLinearResolver(unittest.TestCase):
                             {'dequantize': {'axis': 1},
                              'scale_param_dq': {'shape': np.array([]), 'value': np.float32(1.0 / 255)},
                              }, nodes_with_edges_only=True)
-        graph.graph['cmd_params'] = Namespace(keep_shape_ops=True)
+        graph.graph['cmd_params'] = Namespace(keep_shape_ops=True, data_type='FP32')
 
         graph_ref = build_graph(nodes_ref_attributes,
                                 [('input', 'cast', {'out': 0}),

--- a/model-optimizer/extensions/front/onnx/dequantize_linear_resolver_test.py
+++ b/model-optimizer/extensions/front/onnx/dequantize_linear_resolver_test.py
@@ -1,0 +1,176 @@
+"""
+ Copyright (C) 2020 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import unittest
+from argparse import Namespace
+
+import numpy as np
+
+from extensions.front.onnx.dequantize_linear_resolver import DequantizeLinearResolver
+from mo.utils.ir_engine.compare_graphs import compare_graphs
+from mo.utils.unittest.graph import build_graph
+
+nodes1_attributes = {
+    'input': {'kind': 'op', 'op': 'AnyOp'},
+    'dequantize': {'kind': 'op', 'op': 'DequantizeLinear'},
+    'scale_param_dq': {'kind': 'op', 'type': 'Const', 'op': 'Const'},
+    'zerop_param_dq': {'kind': 'op', 'type': 'Const', 'op': 'Const'},
+    'out': {'kind': 'op', 'op': 'AnyOp'},
+}
+
+nodes_ref_attributes = {
+    'input': {'kind': 'op', 'op': 'AnyOp'},
+    'cast': {'kind': 'op', 'op': 'Cast', 'type': 'Convert'},
+    'shape': {'kind': 'op', 'op': 'ShapeOf', 'type': 'ShapeOf'},
+    'bc1': {'kind': 'op', 'op': 'Broadcast', 'type': 'Broadcast'},
+    'bc2': {'kind': 'op', 'op': 'Broadcast', 'type': 'Broadcast'},
+    'sub': {'kind': 'op', 'op': 'Sub', 'type': 'Subtract'},
+    'mul': {'kind': 'op', 'op': 'Mul', 'type': 'Multiply'},
+    'scale_param_dq': {'kind': 'op', 'type': 'Const', 'op': 'Const'},
+    'zerop_param_dq': {'kind': 'op', 'type': 'Const', 'op': 'Const'},
+    'axis1': {'kind': 'op', 'type': 'Const', 'op': 'Const'},
+    'axis2': {'kind': 'op', 'type': 'Const', 'op': 'Const'},
+    'out': {'kind': 'op', 'op': 'AnyOp'},
+}
+
+
+class TestDequantizeLinearResolver(unittest.TestCase):
+
+    def test_dequantize(self):
+        graph = build_graph(nodes1_attributes,
+                            [('input', 'dequantize'),
+                             ('scale_param_dq', 'dequantize'),
+                             ('zerop_param_dq', 'dequantize'),
+                             ('dequantize', 'out'),
+                             ],
+                            {'scale_param_dq': {'shape': np.array([]), 'value': np.float32(1.0 / 255)},
+                             'zerop_param_dq': {'shape': np.array([]), 'value': np.uint8(0)},
+                             }, nodes_with_edges_only=True)
+        graph.graph['cmd_params'] = Namespace(keep_shape_ops=True)
+
+        graph_ref = build_graph(nodes_ref_attributes,
+                                [('input', 'cast'),
+                                 ('cast', 'sub'),
+                                 ('zerop_param_dq', 'sub'),
+                                 ('sub', 'mul'),
+                                 ('scale_param_dq', 'mul'),
+                                 ('mul', 'out'),
+                                 ],
+                                {'scale_param_dq': {'shape': np.array([]), 'value': np.float32(1.0 / 255)},
+                                 'zerop_param_dq': {'shape': np.array([]), 'value': np.uint8(0)}
+                                 }, nodes_with_edges_only=True)
+
+        graph.stage = 'front'
+        DequantizeLinearResolver().find_and_replace_pattern(graph)
+
+        (flag, resp) = compare_graphs(graph, graph_ref, 'out', check_op_attrs=True)
+        self.assertTrue(flag, resp)
+
+    def test_dequantize_no_zerop(self):
+        graph = build_graph(nodes1_attributes,
+                            [('input', 'dequantize'),
+                             ('scale_param_dq', 'dequantize'),
+                             ('dequantize', 'out'),
+                             ],
+                            {'scale_param_dq': {'shape': np.array([]), 'value': np.float32(1.0 / 255)},
+                             }, nodes_with_edges_only=True)
+        graph.graph['cmd_params'] = Namespace(keep_shape_ops=True)
+
+        graph_ref = build_graph(nodes_ref_attributes,
+                                [('input', 'cast'),
+                                 ('cast', 'mul'),
+                                 ('scale_param_dq', 'mul'),
+                                 ('mul', 'out'),
+                                 ],
+                                {'scale_param_dq': {'shape': np.array([]), 'value': np.float32(1.0 / 255)}
+                                 }, nodes_with_edges_only=True)
+
+        graph.stage = 'front'
+        DequantizeLinearResolver().find_and_replace_pattern(graph)
+
+        (flag, resp) = compare_graphs(graph, graph_ref, 'out', check_op_attrs=True)
+        self.assertTrue(flag, resp)
+
+    def test_dequantize_axis(self):
+        graph = build_graph(nodes1_attributes,
+                            [('input', 'dequantize'),
+                             ('scale_param_dq', 'dequantize'),
+                             ('zerop_param_dq', 'dequantize'),
+                             ('dequantize', 'out'),
+                             ],
+                            {'dequantize': {'axis': 1},
+                             'scale_param_dq': {'shape': np.array([]), 'value': np.float32(1.0 / 255)},
+                             'zerop_param_dq': {'shape': np.array([]), 'value': np.uint8(0)},
+                             }, nodes_with_edges_only=True)
+        graph.graph['cmd_params'] = Namespace(keep_shape_ops=True)
+
+        graph_ref = build_graph(nodes_ref_attributes,
+                                [('input', 'cast', {'out': 0}),
+                                 ('input', 'shape', {'out': 0}),
+                                 ('cast', 'sub'),
+                                 ('zerop_param_dq', 'bc2'),
+                                 ('shape', 'bc2', {'out': 0}),
+                                 ('axis2', 'bc2'),
+                                 ('bc2', 'sub'),
+                                 ('sub', 'mul'),
+                                 ('scale_param_dq', 'bc1'),
+                                 ('shape', 'bc1', {'out': 0}),
+                                 ('axis1', 'bc1'),
+                                 ('bc1', 'mul'),
+                                 ('mul', 'out'),
+                                 ],
+                                {'scale_param_dq': {'shape': np.array([]), 'value': np.float32(1.0 / 255)},
+                                 'zerop_param_dq': {'shape': np.array([]), 'value': np.uint8(0)},
+                                 'axis1': {'shape': np.array([]), 'value': np.int64(1)},
+                                 'axis2': {'shape': np.array([]), 'value': np.int64(1)}
+                                 }, nodes_with_edges_only=True)
+
+        graph.stage = 'front'
+        DequantizeLinearResolver().find_and_replace_pattern(graph)
+
+        (flag, resp) = compare_graphs(graph, graph_ref, 'out', check_op_attrs=True)
+        self.assertTrue(flag, resp)
+
+    def test_dequantize_axis_no_zerop(self):
+        graph = build_graph(nodes1_attributes,
+                            [('input', 'dequantize'),
+                             ('scale_param_dq', 'dequantize'),
+                             ('dequantize', 'out'),
+                             ],
+                            {'dequantize': {'axis': 1},
+                             'scale_param_dq': {'shape': np.array([]), 'value': np.float32(1.0 / 255)},
+                             }, nodes_with_edges_only=True)
+        graph.graph['cmd_params'] = Namespace(keep_shape_ops=True)
+
+        graph_ref = build_graph(nodes_ref_attributes,
+                                [('input', 'cast', {'out': 0}),
+                                 ('input', 'shape', {'out': 0}),
+                                 ('cast', 'mul'),
+                                 ('scale_param_dq', 'bc1'),
+                                 ('shape', 'bc1', {'out': 0}),
+                                 ('axis1', 'bc1'),
+                                 ('bc1', 'mul'),
+                                 ('mul', 'out'),
+                                 ],
+                                {'scale_param_dq': {'shape': np.array([]), 'value': np.float32(1.0 / 255)},
+                                 'axis1': {'shape': np.array([]), 'value': np.int64(1)}
+                                 }, nodes_with_edges_only=True)
+
+        graph.stage = 'front'
+        DequantizeLinearResolver().find_and_replace_pattern(graph)
+
+        (flag, resp) = compare_graphs(graph, graph_ref, 'out', check_op_attrs=True)
+        self.assertTrue(flag, resp)

--- a/model-optimizer/extensions/front/onnx/dequantize_linear_resolver_test.py
+++ b/model-optimizer/extensions/front/onnx/dequantize_linear_resolver_test.py
@@ -34,15 +34,10 @@ nodes1_attributes = {
 nodes_ref_attributes = {
     'input': {'kind': 'op', 'op': 'AnyOp'},
     'cast': {'kind': 'op', 'op': 'Cast', 'type': 'Convert'},
-    'shape': {'kind': 'op', 'op': 'ShapeOf', 'type': 'ShapeOf'},
-    'bc1': {'kind': 'op', 'op': 'Broadcast', 'type': 'Broadcast'},
-    'bc2': {'kind': 'op', 'op': 'Broadcast', 'type': 'Broadcast'},
     'sub': {'kind': 'op', 'op': 'Sub', 'type': 'Subtract'},
     'mul': {'kind': 'op', 'op': 'Mul', 'type': 'Multiply'},
     'scale_param_dq': {'kind': 'op', 'type': 'Const', 'op': 'Const'},
     'zerop_param_dq': {'kind': 'op', 'type': 'Const', 'op': 'Const'},
-    'axis1': {'kind': 'op', 'type': 'Const', 'op': 'Const'},
-    'axis2': {'kind': 'op', 'type': 'Const', 'op': 'Const'},
     'out': {'kind': 'op', 'op': 'AnyOp'},
 }
 
@@ -96,77 +91,6 @@ class TestDequantizeLinearResolver(unittest.TestCase):
                                  ('mul', 'out'),
                                  ],
                                 {'scale_param_dq': {'shape': np.array([]), 'value': np.float32(1.0 / 255)}
-                                 }, nodes_with_edges_only=True)
-
-        graph.stage = 'front'
-        DequantizeLinearResolver().find_and_replace_pattern(graph)
-
-        (flag, resp) = compare_graphs(graph, graph_ref, 'out', check_op_attrs=True)
-        self.assertTrue(flag, resp)
-
-    def test_dequantize_axis(self):
-        graph = build_graph(nodes1_attributes,
-                            [('input', 'dequantize'),
-                             ('scale_param_dq', 'dequantize'),
-                             ('zerop_param_dq', 'dequantize'),
-                             ('dequantize', 'out'),
-                             ],
-                            {'dequantize': {'axis': 1},
-                             'scale_param_dq': {'shape': np.array([]), 'value': np.float32(1.0 / 255)},
-                             'zerop_param_dq': {'shape': np.array([]), 'value': np.uint8(0)},
-                             }, nodes_with_edges_only=True)
-        graph.graph['cmd_params'] = Namespace(keep_shape_ops=True, data_type='FP32')
-
-        graph_ref = build_graph(nodes_ref_attributes,
-                                [('input', 'cast', {'out': 0}),
-                                 ('input', 'shape', {'out': 0}),
-                                 ('cast', 'sub'),
-                                 ('zerop_param_dq', 'bc2'),
-                                 ('shape', 'bc2', {'out': 0}),
-                                 ('axis2', 'bc2'),
-                                 ('bc2', 'sub'),
-                                 ('sub', 'mul'),
-                                 ('scale_param_dq', 'bc1'),
-                                 ('shape', 'bc1', {'out': 0}),
-                                 ('axis1', 'bc1'),
-                                 ('bc1', 'mul'),
-                                 ('mul', 'out'),
-                                 ],
-                                {'scale_param_dq': {'shape': np.array([]), 'value': np.float32(1.0 / 255)},
-                                 'zerop_param_dq': {'shape': np.array([]), 'value': np.uint8(0)},
-                                 'axis1': {'shape': np.array([]), 'value': np.int64(1)},
-                                 'axis2': {'shape': np.array([]), 'value': np.int64(1)}
-                                 }, nodes_with_edges_only=True)
-
-        graph.stage = 'front'
-        DequantizeLinearResolver().find_and_replace_pattern(graph)
-
-        (flag, resp) = compare_graphs(graph, graph_ref, 'out', check_op_attrs=True)
-        self.assertTrue(flag, resp)
-
-    def test_dequantize_axis_no_zerop(self):
-        graph = build_graph(nodes1_attributes,
-                            [('input', 'dequantize'),
-                             ('scale_param_dq', 'dequantize'),
-                             ('dequantize', 'out'),
-                             ],
-                            {'dequantize': {'axis': 1},
-                             'scale_param_dq': {'shape': np.array([]), 'value': np.float32(1.0 / 255)},
-                             }, nodes_with_edges_only=True)
-        graph.graph['cmd_params'] = Namespace(keep_shape_ops=True, data_type='FP32')
-
-        graph_ref = build_graph(nodes_ref_attributes,
-                                [('input', 'cast', {'out': 0}),
-                                 ('input', 'shape', {'out': 0}),
-                                 ('cast', 'mul'),
-                                 ('scale_param_dq', 'bc1'),
-                                 ('shape', 'bc1', {'out': 0}),
-                                 ('axis1', 'bc1'),
-                                 ('bc1', 'mul'),
-                                 ('mul', 'out'),
-                                 ],
-                                {'scale_param_dq': {'shape': np.array([]), 'value': np.float32(1.0 / 255)},
-                                 'axis1': {'shape': np.array([]), 'value': np.int64(1)}
                                  }, nodes_with_edges_only=True)
 
         graph.stage = 'front'

--- a/model-optimizer/extensions/ops/dequantize_linear.py
+++ b/model-optimizer/extensions/ops/dequantize_linear.py
@@ -13,28 +13,23 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-import numpy as np
 
-from mo.graph.graph import Node, Graph
+from mo.graph.graph import Graph
 from mo.ops.op import Op
 
 
 class DequantizeLinear(Op):
     op = 'DequantizeLinear'
-    enabled = True
+    enabled = False
 
     def __init__(self, graph: Graph, attrs: dict):
         mandatory_props = {
             'type': None,
-            'op': __class__.op,
+            'op': self.op,
             'version': None,
             'infer': None,
-            'on_value': None,
-            'off_value': None,
             'out_ports_count': 1,
             'in_ports_count': 3,
-            'data_type': None,
-            'type_infer': None,
         }
         super().__init__(graph, mandatory_props, attrs)
 

--- a/model-optimizer/extensions/ops/dequantize_linear.py
+++ b/model-optimizer/extensions/ops/dequantize_linear.py
@@ -1,0 +1,42 @@
+"""
+ Copyright (C) 2020 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+import numpy as np
+
+from mo.graph.graph import Node, Graph
+from mo.ops.op import Op
+
+
+class DequantizeLinear(Op):
+    op = 'DequantizeLinear'
+    enabled = True
+
+    def __init__(self, graph: Graph, attrs: dict):
+        mandatory_props = {
+            'type': None,
+            'op': __class__.op,
+            'version': None,
+            'infer': None,
+            'on_value': None,
+            'off_value': None,
+            'out_ports_count': 1,
+            'in_ports_count': 3,
+            'data_type': None,
+            'type_infer': None,
+        }
+        super().__init__(graph, mandatory_props, attrs)
+
+    def supported_attrs(self):
+        return ['axis']


### PR DESCRIPTION
Description: Decompose ONNX DequantizeLinear to supported ops

JIRA: CVS-34119


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py: N/A - no e2e test modifyed
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list: N/A - docs in other repo
* [x]  Supported **public** models list: N/A - no new public model supported
* [x]  New operations specification: N/A - no new operation added to opset
* [x]  Guide on how to convert the **public** model: N/A - no new public model supported
* [x]  User guide update: N/A - not needed