### PR TITLE
[GNA] Fix cases when Gna2ModelGetLastError() returns unknown error

### DIFF
--- a/inference-engine/src/gna_plugin/gna_device.cpp
+++ b/inference-engine/src/gna_plugin/gna_device.cpp
@@ -123,7 +123,10 @@ void GNADeviceHelper::checkGna2Status(Gna2Status status, const Gna2Model& gnaMod
         }
 
         Gna2ModelError error;
-        Gna2ModelGetLastError(&error);
+        auto getLastErrorStatus = Gna2ModelGetLastError(&error);
+        if (!Gna2StatusIsSuccessful(getLastErrorStatus)) {
+            THROW_GNA_EXCEPTION << "\nUnsuccessful Gna2Status: (" << status << ") " << gna2StatusBuffer.data();
+        }
 
         std::stringstream ss;
         ss << "\n GNA Library Error:\n";


### PR DESCRIPTION
Will fix where overflow happend while processing errors in cases where too big networks were being run. Will not fix cases when overflow appear in DFS and/or Destructors of CNNLayer