### PR TITLE
[IE Common] Replace static_cast with saturated one

### DIFF
--- a/inference-engine/src/legacy_api/src/net_pass.cpp
+++ b/inference-engine/src/legacy_api/src/net_pass.cpp
@@ -1330,13 +1330,28 @@ bool UnrollRNN_if(TensorIterator::Body& net, const std::function<bool(const RNNC
 
 namespace {
 
+template <typename TO, typename FROM>
+bool isConversionNarrowing(FROM from) {
+    return from == (static_cast<FROM>(static_cast<TO>(from)));
+}
+
+template <typename TO, typename FROM>
+TO saturatedCast(FROM from) {
+    FROM max = isConversionNarrowing<FROM>(std::numeric_limits<TO>::max()) ? std::numeric_limits<FROM>::max() :
+                                                                             static_cast<FROM>(std::numeric_limits<TO>::max());
+    FROM min = isConversionNarrowing<FROM>(std::numeric_limits<TO>::min()) ? std::numeric_limits<FROM>::min() :
+                                                                             static_cast<FROM>(std::numeric_limits<TO>::min());
+
+    return static_cast<TO>(std::min(std::max(from, min), max));
+}
+
 template <Precision::ePrecision PREC_FROM, Precision::ePrecision PREC_TO>
 void convertArrayPrecision(typename PrecisionTrait<PREC_TO>::value_type* dst,
                            const typename PrecisionTrait<PREC_FROM>::value_type* src, size_t nelem) {
     using dst_type = typename PrecisionTrait<PREC_TO>::value_type;
 
     for (size_t i = 0; i < nelem; i++) {
-        dst[i] = static_cast<dst_type>(src[i]);
+        dst[i] = saturatedCast<dst_type>(src[i]);
     }
 }
 


### PR DESCRIPTION
`static_cast` behavior is unspecified if the conversion is narrowing. Apply saturated approach to this cast.