### PR TITLE
[VPU][GT] Use topological order in shape allocation

### DIFF
--- a/inference-engine/src/vpu/graph_transformer/include/vpu/middleend/allocator/allocator.hpp
+++ b/inference-engine/src/vpu/graph_transformer/include/vpu/middleend/allocator/allocator.hpp
@@ -77,7 +77,7 @@ public:
      * Allocates memory for single data node
      */
     bool allocateData(const Data& data);
-    ShapeLocation allocateShape(Data& data);
+    ShapeLocation allocateShape(const Data& data);
     void freeData(const Data& data, DeallocationMode mode = DeallocationMode::JustFree);
 
     void selfCheck();

--- a/inference-engine/src/vpu/graph_transformer/include/vpu/model/data.hpp
+++ b/inference-engine/src/vpu/graph_transformer/include/vpu/model/data.hpp
@@ -83,17 +83,17 @@ struct ShapeLocation final {
     Location stridesLocation;
     int stridesOffset;
 
-    bool operator==(const ShapeLocation& shapeLocation) {
+    bool operator==(const ShapeLocation& shapeLocation) const {
         return std::tie(dimsLocation, dimsOffset, stridesLocation, stridesOffset) ==
                std::tie(shapeLocation.dimsLocation, shapeLocation.dimsOffset, shapeLocation.stridesLocation, shapeLocation.stridesOffset);
     }
 
-    bool operator!=(const ShapeLocation& shapeLocation) {
+    bool operator!=(const ShapeLocation& shapeLocation) const {
         return !(*this == shapeLocation);
     }
 };
 
-static const ShapeLocation defaultShapeLocation = {
+static constexpr ShapeLocation defaultShapeLocation = {
     Location::None, 0, Location::None, 0
 };
 
@@ -260,7 +260,7 @@ public:
 
     void setShapeAllocationInfo(const ShapeLocation& shapeLocation);
 
-    bool isShapeAllocated();
+    bool isShapeAllocated() const;
 
     //
     // Backend utilities

--- a/inference-engine/src/vpu/graph_transformer/include/vpu/model/data.hpp
+++ b/inference-engine/src/vpu/graph_transformer/include/vpu/model/data.hpp
@@ -82,10 +82,19 @@ struct ShapeLocation final {
     int dimsOffset;
     Location stridesLocation;
     int stridesOffset;
+
+    bool operator==(const ShapeLocation& shapeLocation) {
+        return std::tie(dimsLocation, dimsOffset, stridesLocation, stridesOffset) ==
+               std::tie(shapeLocation.dimsLocation, shapeLocation.dimsOffset, shapeLocation.stridesLocation, shapeLocation.stridesOffset);
+    }
+
+    bool operator!=(const ShapeLocation& shapeLocation) {
+        return !(*this == shapeLocation);
+    }
 };
 
-static constexpr ShapeLocation defaultShapeLocation = {
-        Location::None, 0, Location::None, 0
+static const ShapeLocation defaultShapeLocation = {
+    Location::None, 0, Location::None, 0
 };
 
 //
@@ -250,6 +259,8 @@ public:
     void setDataAllocationInfo(const DataLocation& dataLocation);
 
     void setShapeAllocationInfo(const ShapeLocation& shapeLocation);
+
+    bool isShapeAllocated();
 
     //
     // Backend utilities

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/allocator/allocator.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/allocator/allocator.cpp
@@ -296,7 +296,7 @@ bool Allocator::allocateData(const Data& data) {
     return chunk->memType == memoryType;
 }
 
-ShapeLocation Allocator::allocateShape(Data& data) {
+ShapeLocation Allocator::allocateShape(const Data& data) {
     ShapeLocation shapeLocation;
 
     const auto dimsByteSize = data->desc().dimsByteSize();

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/allocate_resources.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/allocate_resources.cpp
@@ -206,14 +206,11 @@ AllocationResult runAllocator(const Model& model, EnableShapeAllocation enableSh
     //
 
     if (enableShapeAllocation == EnableShapeAllocation::YES) {
-        DataSet datasWithAllocatedShape;
-
         for (const auto& stage : model->getStages()) {
-            const auto& allocateShape = [&datasWithAllocatedShape, &allocator](const Data& data) {
-                if (datasWithAllocatedShape.count(data) == 0) {
+            const auto& allocateShape = [&allocator](const Data& data) {
+                if (!data->isShapeAllocated()) {
                     const auto shapeLocation = allocator.allocateShape(data);
                     data->setShapeAllocationInfo(shapeLocation);
-                    datasWithAllocatedShape.insert(data);
                 }
             };
 
@@ -227,10 +224,6 @@ AllocationResult runAllocator(const Model& model, EnableShapeAllocation enableSh
                 allocateShape(tempBuffer);
             }
         }
-
-        VPU_THROW_UNLESS(model->numDatas() == datasWithAllocatedShape.size(),
-            "Shape allocation failed: there are still unallocated data objects ({} were allocated, while there are {} in the model)",
-            datasWithAllocatedShape.size(), model->numDatas());
     }
 
     return AllocationResult();

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/allocate_resources.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/allocate_resources.cpp
@@ -210,8 +210,7 @@ AllocationResult runAllocator(const Model& model, EnableShapeAllocation enableSh
 
         for (const auto& stage : model->getStages()) {
             const auto& allocateShape = [&datasWithAllocatedShape, &allocator](const Data& data) {
-                if (std::find(datasWithAllocatedShape.begin(), datasWithAllocatedShape.end(), data) ==
-                    datasWithAllocatedShape.end()) {
+                if (datasWithAllocatedShape.count(data) == 0) {
                     const auto shapeLocation = allocator.allocateShape(data);
                     data->setShapeAllocationInfo(shapeLocation);
                     datasWithAllocatedShape.insert(data);

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/allocate_resources.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/allocate_resources.cpp
@@ -230,7 +230,7 @@ AllocationResult runAllocator(const Model& model, EnableShapeAllocation enableSh
         }
 
         VPU_THROW_UNLESS(model->numDatas() == datasWithAllocatedShape.size(),
-            "Shape allocation failed: shape was allocated for {} datas, while there are {} in the model",
+            "Shape allocation failed: there are still unallocated data objects ({} were allocated, while there are {} in the model)",
             datasWithAllocatedShape.size(), model->numDatas());
     }
 

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/allocate_resources.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/allocate_resources.cpp
@@ -206,10 +206,32 @@ AllocationResult runAllocator(const Model& model, EnableShapeAllocation enableSh
     //
 
     if (enableShapeAllocation == EnableShapeAllocation::YES) {
-        for (auto data : model->datas()) {
-            const auto shapeLocation = allocator.allocateShape(data);
-            data->setShapeAllocationInfo(shapeLocation);
+        DataSet datasWithAllocatedShape;
+
+        for (const auto& stage : model->getStages()) {
+            const auto& allocateShape = [&datasWithAllocatedShape, &allocator](const Data& data) {
+                if (std::find(datasWithAllocatedShape.begin(), datasWithAllocatedShape.end(), data) ==
+                    datasWithAllocatedShape.end()) {
+                    const auto shapeLocation = allocator.allocateShape(data);
+                    data->setShapeAllocationInfo(shapeLocation);
+                    datasWithAllocatedShape.insert(data);
+                }
+            };
+
+            for (const auto& input : stage->inputs()) {
+                allocateShape(input);
+            }
+            for (const auto& output : stage->outputs()) {
+                allocateShape(output);
+            }
+            for (const auto& tempBuffer : stage->tempBuffers()) {
+                allocateShape(tempBuffer);
+            }
         }
+
+        VPU_THROW_UNLESS(model->numDatas() == datasWithAllocatedShape.size(),
+            "Shape allocation failed: shape was allocated for {} datas, while there are {} in the model",
+            datasWithAllocatedShape.size(), model->numDatas());
     }
 
     return AllocationResult();

--- a/inference-engine/src/vpu/graph_transformer/src/model/data.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/model/data.cpp
@@ -176,6 +176,10 @@ void DataNode::setShapeAllocationInfo(const ShapeLocation& shapeLocation) {
     _shapeLocation = shapeLocation;
 }
 
+bool DataNode::isShapeAllocated() {
+    return _shapeLocation != defaultShapeLocation;
+}
+
 void DataNode::serializeBuffer(
         BlobSerializer& serializer) {
     serializeDescImpl(serializer, _desc, this->shapeLocation());

--- a/inference-engine/src/vpu/graph_transformer/src/model/data.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/model/data.cpp
@@ -176,7 +176,7 @@ void DataNode::setShapeAllocationInfo(const ShapeLocation& shapeLocation) {
     _shapeLocation = shapeLocation;
 }
 
-bool DataNode::isShapeAllocated() {
+bool DataNode::isShapeAllocated() const {
     return _shapeLocation != defaultShapeLocation;
 }
 


### PR DESCRIPTION
Ticket - #-33917
Problem: for some networks GT generates blob with different md5 hash values.
Reason: I've found a pass that creates datas duplicate with different order from time to time (because of unordered_set usage). It leads to different order in `model->datas()` list and affects shape allocation process which rely on this order.
Solution: make shape allocation be relied on topological order of datas which is stable and doesn't depend on order datas creation during different passes.