### PR TITLE
Build support with external TBB(retro) 

### DIFF
--- a/inference-engine/cmake/FindTBB.cmake
+++ b/inference-engine/cmake/FindTBB.cmake
@@ -1,0 +1,32 @@
+# Copyright (C) 2020 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+########################################################################
+#
+#  Perform search of TBB package corresponding with specified search order.
+#
+#  TBBROOT var is set into external package path or has a default value
+#  with IE own version of TBB. Search order is next:
+#   1) ${TBBROOT}/cmake
+#   2) ${TBBROOT} with IE own version of TBBConfig.cmake (actual for TBB < 2017.7)
+#
+
+## Path to IE own version of TBBConfig.cmake old TBB version without cmake config.
+if(APPLE)
+    set(IE_OWN_TBB_CONFIG tbb/mac)
+elseif(UNIX)
+    set(IE_OWN_TBB_CONFIG tbb/lnx)
+elseif(WIN)
+    set(IE_OWN_TBB_CONFIG tbb/win)
+else()
+    unset(IE_OWN_TBB_CONFIG)
+endif()
+
+find_package(TBB
+    CONFIG
+    NO_DEFAULT_PATH
+    PATHS ${TBBROOT}/cmake
+          ${CMAKE_CURRENT_LIST_DIR}/${IE_OWN_TBB_CONFIG}
+)
+find_package_handle_standard_args(TBB CONFIG_MODE)

--- a/inference-engine/cmake/dependencies.cmake
+++ b/inference-engine/cmake/dependencies.cmake
@@ -129,7 +129,7 @@ endif ()
 
 ## TBB package
 if (THREADING STREQUAL "TBB" OR THREADING STREQUAL "TBB_AUTO")
-    reset_deps_cache(TBBROOT TBB_DIR)
+    reset_deps_cache(TBBROOT)
 
     if(NOT DEFINED TBB_DIR AND NOT DEFINED ENV{TBB_DIR})
         if (WIN32 AND X86_64)
@@ -137,19 +137,16 @@ if (THREADING STREQUAL "TBB" OR THREADING STREQUAL "TBB_AUTO")
             RESOLVE_DEPENDENCY(TBB
                     ARCHIVE_WIN "tbb2020_20200415_win.zip"
                     TARGET_PATH "${TEMP}/tbb"
-                    ENVIRONMENT "TBBROOT"
-                    VERSION_REGEX ".*_([a-z]*_([a-z0-9]+\\.)*[0-9]+).*")
+                    ENVIRONMENT "TBBROOT")
         elseif(ANDROID)  # Should be before LINUX due LINUX is detected as well
             RESOLVE_DEPENDENCY(TBB
                     ARCHIVE_ANDROID "tbb2020_20200404_android.tgz"
                     TARGET_PATH "${TEMP}/tbb"
-                    ENVIRONMENT "TBBROOT"
-                    VERSION_REGEX ".*_([a-z]*_([a-z0-9]+\\.)*[0-9]+).*")
+                    ENVIRONMENT "TBBROOT")
         elseif(LINUX AND X86_64)
             RESOLVE_DEPENDENCY(TBB
                     ARCHIVE_LIN "tbb2020_20200415_lin_strip.tgz"
-                    TARGET_PATH "${TEMP}/tbb"
-                    ENVIRONMENT "TBBROOT")
+                    TARGET_PATH "${TEMP}/tbb")
         elseif(LINUX AND AARCH64)
             RESOLVE_DEPENDENCY(TBB
                     ARCHIVE_LIN "keembay/tbb2020_38404_kmb.tgz"
@@ -159,8 +156,7 @@ if (THREADING STREQUAL "TBB" OR THREADING STREQUAL "TBB_AUTO")
             RESOLVE_DEPENDENCY(TBB
                     ARCHIVE_MAC "tbb2020_20200404_mac.tgz"
                     TARGET_PATH "${TEMP}/tbb"
-                    ENVIRONMENT "TBBROOT"
-                    VERSION_REGEX ".*_([a-z]*_([a-z0-9]+\\.)*[0-9]+).*")
+                    ENVIRONMENT "TBBROOT")
         else()
             message(FATAL_ERROR "TBB is not available on current platform")
         endif()
@@ -173,12 +169,11 @@ if (THREADING STREQUAL "TBB" OR THREADING STREQUAL "TBB_AUTO")
     endif()
 
     update_deps_cache(TBBROOT "${TBB}" "Path to TBB root folder")
-    update_deps_cache(TBB_DIR "${TBBROOT}/cmake" "Path to TBB package folder")
 
     if (WIN32)
-        log_rpath_from_dir(TBB "${TBB_DIR}/../bin")
+        log_rpath_from_dir(TBB "${TBB}/bin")
     else ()
-        log_rpath_from_dir(TBB "${TBB_DIR}/../lib")
+        log_rpath_from_dir(TBB "${TBB}/lib")
     endif ()
     debug_message(STATUS "tbb=" ${TBB})
 endif ()

--- a/inference-engine/cmake/ie_parallel.cmake
+++ b/inference-engine/cmake/ie_parallel.cmake
@@ -2,6 +2,20 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+if (THREADING STREQUAL "TBB" OR THREADING STREQUAL "TBB_AUTO")
+    find_package(TBB COMPONENTS tbb tbbmalloc)
+    if (TBB_FOUND)
+        if (${TBB_VERSION} VERSION_LESS 2020)
+            ext_message(WARNING "TBB version is less than OpenVINO recommends to use.\
+                                 Some TBB related features like NUMA-aware tbb::task_arena\
+                                 execution will be disabled.")
+        endif()
+    else ()
+        ext_message(WARNING "TBB was not found by the configured TBB_DIR/TBBROOT path. \
+                             SEQ method will be used.")
+    endif ()
+endif()
+
 function(set_ie_threading_interface_for TARGET_NAME)
     get_target_property(target_type ${TARGET_NAME} TYPE)
     if(target_type STREQUAL "INTERFACE_LIBRARY")
@@ -48,7 +62,6 @@ function(set_ie_threading_interface_for TARGET_NAME)
     set(IE_THREAD_DEFINE "IE_THREAD_SEQ")
 
     if (THREADING STREQUAL "TBB" OR THREADING STREQUAL "TBB_AUTO")
-        find_package(TBB COMPONENTS tbb tbbmalloc)
         if (TBB_FOUND)
             set(IE_THREAD_DEFINE "IE_THREAD_TBB")
             ie_target_link_libraries(${TARGET_NAME} ${LINK_TYPE} ${TBB_IMPORTED_TARGETS})

--- a/inference-engine/cmake/tbb/lnx/TBBConfig.cmake
+++ b/inference-engine/cmake/tbb/lnx/TBBConfig.cmake
@@ -1,0 +1,196 @@
+#===============================================================================
+# Copyright 2017-2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+# TBB_FOUND should not be set explicitly. It is defined automatically by CMake.
+# Handling of TBB_VERSION is in TBBConfigVersion.cmake.
+
+if (NOT TBB_FIND_COMPONENTS)
+    set(TBB_FIND_COMPONENTS "tbb;tbbmalloc;tbbmalloc_proxy")
+    foreach (_tbb_component ${TBB_FIND_COMPONENTS})
+        set(TBB_FIND_REQUIRED_${_tbb_component} 1)
+    endforeach()
+endif()
+
+# Add components with internal dependencies: tbbmalloc_proxy -> tbbmalloc
+list(FIND TBB_FIND_COMPONENTS tbbmalloc_proxy _tbbmalloc_proxy_ix)
+if (NOT _tbbmalloc_proxy_ix EQUAL -1)
+    list(FIND TBB_FIND_COMPONENTS tbbmalloc _tbbmalloc_ix)
+    if (_tbbmalloc_ix EQUAL -1)
+        list(APPEND TBB_FIND_COMPONENTS tbbmalloc)
+        set(TBB_FIND_REQUIRED_tbbmalloc ${TBB_FIND_REQUIRED_tbbmalloc_proxy})
+    endif()
+endif()
+
+if (NOT TBBROOT)
+    if(DEFINED ENV{TBBROOT})
+        set (TBBROOT $ENV{TBBROOT})
+    endif()
+endif()
+
+set(_tbb_root ${TBBROOT})
+
+set(_tbb_x32_subdir ia32)
+set(_tbb_x64_subdir intel64)
+
+if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(_tbb_arch_subdir ${_tbb_x64_subdir})
+else()
+    set(_tbb_arch_subdir ${_tbb_x32_subdir})
+endif()
+
+if (CMAKE_CXX_COMPILER_LOADED)
+    set(_tbb_compiler_id ${CMAKE_CXX_COMPILER_ID})
+    set(_tbb_compiler_ver ${CMAKE_CXX_COMPILER_VERSION})
+elseif (CMAKE_C_COMPILER_LOADED)
+    set(_tbb_compiler_id ${CMAKE_C_COMPILER_ID})
+    set(_tbb_compiler_ver ${CMAKE_C_COMPILER_VERSION})
+endif()
+
+# For non-GCC compilers try to find version of system GCC to choose right compiler subdirectory.
+if (NOT _tbb_compiler_id STREQUAL "GNU")
+    execute_process(COMMAND gcc --version OUTPUT_VARIABLE _tbb_gcc_ver_output ERROR_QUIET)
+    string(REGEX REPLACE ".*gcc.*([0-9]+\\.[0-9]+)\\.[0-9]+.*" "\\1" _tbb_compiler_ver "${_tbb_gcc_ver_output}")
+    if (NOT _tbb_compiler_ver)
+        message(FATAL_ERROR "This Intel TBB package is intended to be used only environment with available 'gcc'")
+    endif()
+    unset(_tbb_gcc_ver_output)
+endif()
+
+if (EXISTS "${_tbb_root}/lib/${_tbb_arch_subdir}")
+    set(_tbb_lib ${_tbb_root}/lib/${_tbb_arch_subdir})
+    set(_tbb_inc ${_tbb_root}/include)
+
+    file(GLOB _tbb_gcc_versions_available RELATIVE ${_tbb_lib} ${_tbb_lib}/*)
+    # shall we check _tbb_gcc_versions_available is not empty?
+    foreach (_tbb_gcc_version ${_tbb_gcc_versions_available})
+        string(SUBSTRING ${_tbb_gcc_version} 3 -1 _tbb_gcc_version_number)
+        if (NOT _tbb_compiler_ver VERSION_LESS _tbb_gcc_version_number)
+            set(_tbb_compiler_subdir ${_tbb_gcc_version})
+        endif()
+    endforeach()
+else()
+    if (TBBROOT)
+        set(__tbb_hint_path "${TBBROOT}")
+    else()
+        set(__tbb_hint_path "/non/existing/path")
+    endif()
+
+    # try to find TBB in the system
+    find_library(_tbb_lib NAMES tbb
+        HINTS "${__tbb_hint_path}"
+        PATH_SUFFIXES lib lib64)
+    find_path(_tbb_inc NAMES tbb.h
+        HINTS "${__tbb_hint_path}"
+        PATH_SUFFIXES include tbb include/tbb)
+    unset(__tbb_hint_path)
+
+    if (NOT _tbb_lib OR NOT _tbb_inc)
+        message("FATAL_ERROR" "Cannot find TBB")
+    endif()
+
+    get_filename_component(_tbb_lib "${_tbb_lib}" PATH)
+    get_filename_component(_tbb_inc "${_tbb_inc}" PATH)
+
+    set(_tbb_arch_subdir "")
+    set(_tbb_compiler_subdir "")
+endif()
+
+unset(_tbb_gcc_version_number)
+unset(_tbb_compiler_id)
+unset(_tbb_compiler_ver)
+
+# Now we check that all the needed component are present
+get_filename_component(_tbb_lib_path "${_tbb_lib}/${_tbb_compiler_subdir}" ABSOLUTE)
+
+if (TBB_FOUND)
+    return()
+endif()
+
+# detect version
+find_file(_tbb_def_header tbb_stddef.h HINTS "${_tbb_root}/include/tbb")
+
+if (_tbb_def_header)
+    file(READ "${_tbb_def_header}" _tbb_def_content)
+    string(REGEX MATCH "TBB_VERSION_MAJOR[ ]*[0-9]*" _tbb_version_major ${_tbb_def_content})
+    string(REGEX MATCH "[0-9][0-9]*" _tbb_version_major ${_tbb_version_major})
+
+    string(REGEX MATCH "TBB_VERSION_MINOR[ ]*[0-9]" _tbb_version_minor ${_tbb_def_content})
+    string(REGEX MATCH "[0-9][0-9]*" _tbb_version_minor ${_tbb_version_minor})
+
+    set(TBB_VERSION "${_tbb_version_major}.${_tbb_version_minor}")
+else()
+    set(TBB_VERSION "")
+endif()
+
+foreach (_tbb_soversion 2 12)
+foreach (_tbb_component ${TBB_FIND_COMPONENTS})
+    set(_tbb_release_lib
+        "${_tbb_lib_path}/lib${_tbb_component}.so.${_tbb_soversion}")
+    set(_tbb_debug_lib
+        "${_tbb_lib_path}/lib${_tbb_component}_debug.so.${_tbb_soversion}")
+
+    # oneDNN change: check library existence (BUILD_MODE related only, not both)
+    string(TOUPPER "${CMAKE_BUILD_TYPE}" UPPERCASE_CMAKE_BUILD_TYPE)
+    if (UPPERCASE_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+        if (EXISTS "${_tbb_debug_lib}")
+            set(_lib_exists TRUE)
+        elseif (EXISTS "${_tbb_release_lib}")
+            message(FATAL_ERROR
+                "Intel TBB release library is found here: ${_tbb_release_lib}. "
+                "But the debug library
+                (lib${_tbb_component}_debug.so.${_tbb_soversion}) is missing.")
+        endif()
+    else()
+        if (EXISTS "${_tbb_release_lib}")
+            set(_lib_exists TRUE)
+        endif()
+    endif()
+
+    if (_lib_exists)
+        if (NOT TARGET TBB::${_tbb_component})
+            add_library(TBB::${_tbb_component} SHARED IMPORTED)
+            set_target_properties(TBB::${_tbb_component} PROPERTIES
+                                  IMPORTED_CONFIGURATIONS "RELEASE;DEBUG"
+                                  IMPORTED_LOCATION_RELEASE     "${_tbb_release_lib}"
+                                  IMPORTED_LOCATION_DEBUG       "${_tbb_debug_lib}"
+                                  INTERFACE_INCLUDE_DIRECTORIES "${_tbb_inc}")
+
+            # Add internal dependencies for imported targets: TBB::tbbmalloc_proxy -> TBB::tbbmalloc
+            if (_tbb_component STREQUAL tbbmalloc_proxy)
+                set_target_properties(TBB::tbbmalloc_proxy PROPERTIES INTERFACE_LINK_LIBRARIES TBB::tbbmalloc)
+            endif()
+
+            list(APPEND TBB_IMPORTED_TARGETS TBB::${_tbb_component})
+            set(TBB_${_tbb_component}_FOUND 1)
+        endif()
+        break()
+    endif()
+endforeach()
+endforeach()
+
+if (NOT _lib_exists AND TBB_FIND_REQUIRED AND TBB_FIND_REQUIRED_${_tbb_component})
+    message(FATAL_ERROR "Missed required Intel TBB component: ${_tbb_component}")
+endif()
+
+unset(_tbb_x32_subdir)
+unset(_tbb_x64_subdir)
+unset(_tbb_arch_subdir)
+unset(_tbb_compiler_subdir)
+unset(_tbbmalloc_proxy_ix)
+unset(_tbbmalloc_ix)
+unset(_tbb_lib_path)
+unset(_tbb_release_lib)
+unset(_tbb_debug_lib)

--- a/inference-engine/cmake/tbb/mac/TBBConfig.cmake
+++ b/inference-engine/cmake/tbb/mac/TBBConfig.cmake
@@ -1,0 +1,114 @@
+#===============================================================================
+# Copyright 2017-2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+# TBB_FOUND should not be set explicitly. It is defined automatically by CMake.
+# Handling of TBB_VERSION is in TBBConfigVersion.cmake.
+
+if (NOT TBB_FIND_COMPONENTS)
+    set(TBB_FIND_COMPONENTS "tbb;tbbmalloc;tbbmalloc_proxy")
+    foreach (_tbb_component ${TBB_FIND_COMPONENTS})
+        set(TBB_FIND_REQUIRED_${_tbb_component} 1)
+    endforeach()
+endif()
+
+# Add components with internal dependencies: tbbmalloc_proxy -> tbbmalloc
+list(FIND TBB_FIND_COMPONENTS tbbmalloc_proxy _tbbmalloc_proxy_ix)
+if (NOT _tbbmalloc_proxy_ix EQUAL -1)
+    list(FIND TBB_FIND_COMPONENTS tbbmalloc _tbbmalloc_ix)
+    if (_tbbmalloc_ix EQUAL -1)
+        list(APPEND TBB_FIND_COMPONENTS tbbmalloc)
+        set(TBB_FIND_REQUIRED_tbbmalloc ${TBB_FIND_REQUIRED_tbbmalloc_proxy})
+    endif()
+endif()
+
+if (NOT TBBROOT)
+    if(DEFINED ENV{TBBROOT})
+        set (TBBROOT $ENV{TBBROOT})
+    else()
+        message("FATAL_ERROR" "TBBROOT is unset")
+    endif()
+endif()
+
+set(_tbb_root ${TBBROOT})
+
+set(_tbb_x32_subdir .)
+set(_tbb_x64_subdir .)
+
+if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(_tbb_arch_subdir ${_tbb_x64_subdir})
+else()
+    set(_tbb_arch_subdir ${_tbb_x32_subdir})
+endif()
+
+set(_tbb_compiler_subdir .)
+
+get_filename_component(_tbb_lib_path "${_tbb_root}/lib/${_tbb_arch_subdir}/${_tbb_compiler_subdir}" ABSOLUTE)
+
+if (TBB_FOUND)
+    return()
+endif()
+
+# detect version
+find_file(_tbb_def_header tbb_stddef.h HINTS "${_tbb_root}/include/tbb")
+
+if (_tbb_def_header)
+    file(READ "${_tbb_def_header}" _tbb_def_content)
+    string(REGEX MATCH "TBB_VERSION_MAJOR[ ]*[0-9]*" _tbb_version_major ${_tbb_def_content})
+    string(REGEX MATCH "[0-9][0-9]*" _tbb_version_major ${_tbb_version_major})
+
+    string(REGEX MATCH "TBB_VERSION_MINOR[ ]*[0-9]" _tbb_version_minor ${_tbb_def_content})
+    string(REGEX MATCH "[0-9][0-9]*" _tbb_version_minor ${_tbb_version_minor})
+
+    set(TBB_VERSION "${_tbb_version_major}.${_tbb_version_minor}")
+else()
+    set(TBB_VERSION "")
+endif()
+
+foreach (_tbb_component ${TBB_FIND_COMPONENTS})
+    set(_tbb_release_lib "${_tbb_lib_path}/lib${_tbb_component}.dylib")
+    set(_tbb_debug_lib "${_tbb_lib_path}/lib${_tbb_component}_debug.dylib")
+
+    if (EXISTS "${_tbb_release_lib}" AND EXISTS "${_tbb_debug_lib}")
+        if (NOT TARGET TBB::${_tbb_component})
+            add_library(TBB::${_tbb_component} SHARED IMPORTED)
+            set_target_properties(TBB::${_tbb_component} PROPERTIES
+                                  IMPORTED_CONFIGURATIONS "RELEASE;DEBUG"
+                                  IMPORTED_LOCATION_RELEASE     "${_tbb_release_lib}"
+                                  IMPORTED_LOCATION_DEBUG       "${_tbb_debug_lib}"
+                                  INTERFACE_INCLUDE_DIRECTORIES "${_tbb_root}/include")
+
+            # Add internal dependencies for imported targets: TBB::tbbmalloc_proxy -> TBB::tbbmalloc
+            if (_tbb_component STREQUAL tbbmalloc_proxy)
+                set_target_properties(TBB::tbbmalloc_proxy PROPERTIES INTERFACE_LINK_LIBRARIES TBB::tbbmalloc)
+            endif()
+
+            list(APPEND TBB_IMPORTED_TARGETS TBB::${_tbb_component})
+            set(TBB_${_tbb_component}_FOUND 1)
+        endif()
+    elseif (TBB_FIND_REQUIRED AND TBB_FIND_REQUIRED_${_tbb_component})
+        message(FATAL_ERROR "Missed required Intel TBB component: ${_tbb_component}")
+    endif()
+endforeach()
+
+unset(_tbb_x32_subdir)
+unset(_tbb_x64_subdir)
+unset(_tbb_arch_subdir)
+unset(_tbb_compiler_subdir)
+unset(_tbbmalloc_proxy_ix)
+unset(_tbbmalloc_ix)
+unset(_tbb_lib_path)
+unset(_tbb_release_lib)
+unset(_tbb_debug_lib)

--- a/inference-engine/cmake/tbb/win/TBBConfig.cmake
+++ b/inference-engine/cmake/tbb/win/TBBConfig.cmake
@@ -1,0 +1,140 @@
+#===============================================================================
+# Copyright 2017-2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+# TBB_FOUND should not be set explicitly. It is defined automatically by CMake.
+# Handling of TBB_VERSION is in TBBConfigVersion.cmake.
+
+if (NOT TBB_FIND_COMPONENTS)
+    set(TBB_FIND_COMPONENTS "tbb;tbbmalloc;tbbmalloc_proxy")
+    foreach (_tbb_component ${TBB_FIND_COMPONENTS})
+        set(TBB_FIND_REQUIRED_${_tbb_component} 1)
+    endforeach()
+endif()
+
+# Add components with internal dependencies: tbbmalloc_proxy -> tbbmalloc
+list(FIND TBB_FIND_COMPONENTS tbbmalloc_proxy _tbbmalloc_proxy_ix)
+if (NOT _tbbmalloc_proxy_ix EQUAL -1)
+    list(FIND TBB_FIND_COMPONENTS tbbmalloc _tbbmalloc_ix)
+    if (_tbbmalloc_ix EQUAL -1)
+        list(APPEND TBB_FIND_COMPONENTS tbbmalloc)
+        set(TBB_FIND_REQUIRED_tbbmalloc ${TBB_FIND_REQUIRED_tbbmalloc_proxy})
+    endif()
+endif()
+
+if (NOT TBBROOT)
+    if(DEFINED ENV{TBBROOT})
+        set (TBBROOT $ENV{TBBROOT})
+    else()
+        message("FATAL_ERROR" "TBBROOT is unset")
+    endif()
+endif()
+
+set(_tbb_root ${TBBROOT})
+
+set(_tbb_x32_subdir ia32)
+set(_tbb_x64_subdir intel64)
+
+if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(_tbb_arch_subdir ${_tbb_x64_subdir})
+else()
+    set(_tbb_arch_subdir ${_tbb_x32_subdir})
+endif()
+
+if (NOT MSVC)
+    message(FATAL_ERROR "This Intel TBB package is intended to be used only in the project with MSVC")
+endif()
+
+# Detect the most relevant MSVC subdirectory
+set(_tbb_msvc_1700_subdir vc11)
+set(_tbb_msvc_1800_subdir vc12)
+set(_tbb_msvc_1900_subdir vc14)
+set(_tbb_msvc_ver ${MSVC_VERSION})
+if (MSVC_VERSION VERSION_LESS 1700)
+    message(FATAL_ERROR "This Intel TBB package is intended to be used only in the project with MSVC version 1700 (vc11) or higher")
+elseif (MSVC_VERSION VERSION_GREATER 1900)
+    set(_tbb_msvc_ver 1900)
+endif()
+set(_tbb_compiler_subdir ${_tbb_msvc_${_tbb_msvc_ver}_subdir})
+unset(_tbb_msvc_1700_subdir)
+unset(_tbb_msvc_1800_subdir)
+unset(_tbb_msvc_1900_subdir)
+
+if (WINDOWS_STORE)
+    set(_tbb_compiler_subdir ${_tbb_compiler_subdir}_ui)
+endif()
+
+#set conveniance variable to locate TBB files (these are used for a PSXE install)
+get_filename_component(_tbb_lib_path "${_tbb_root}/lib/${_tbb_arch_subdir}/${_tbb_compiler_subdir}" ABSOLUTE)
+get_filename_component(_tbb_inc_path "${_tbb_root}/include/" ABSOLUTE)
+
+if (TBB_FOUND)
+    return()
+endif()
+
+# detect version
+find_file(_tbb_def_header tbb_stddef.h HINTS "${_tbb_root}/include/tbb")
+
+if (_tbb_def_header)
+    file(READ "${_tbb_def_header}" _tbb_def_content)
+    string(REGEX MATCH "TBB_VERSION_MAJOR[ ]*[0-9]*" _tbb_version_major ${_tbb_def_content})
+    string(REGEX MATCH "[0-9][0-9]*" _tbb_version_major ${_tbb_version_major})
+
+    string(REGEX MATCH "TBB_VERSION_MINOR[ ]*[0-9]" _tbb_version_minor ${_tbb_def_content})
+    string(REGEX MATCH "[0-9][0-9]*" _tbb_version_minor ${_tbb_version_minor})
+
+    set(TBB_VERSION "${_tbb_version_major}.${_tbb_version_minor}")
+else()
+    set(TBB_VERSION "")
+endif()
+
+foreach (_tbb_component ${TBB_FIND_COMPONENTS})
+    set(_tbb_release_lib "${_tbb_lib_path}/${_tbb_component}.lib")
+    set(_tbb_debug_lib "${_tbb_lib_path}/${_tbb_component}_debug.lib")
+
+    if (EXISTS "${_tbb_release_lib}" AND EXISTS "${_tbb_debug_lib}")
+        if (NOT TARGET TBB::${_tbb_component})
+            add_library(TBB::${_tbb_component} SHARED IMPORTED)
+            set_target_properties(TBB::${_tbb_component} PROPERTIES
+                                  IMPORTED_CONFIGURATIONS "RELEASE;DEBUG"
+                                  IMPORTED_LOCATION_RELEASE     "${_tbb_release_lib}"
+                                  IMPORTED_LOCATION_DEBUG       "${_tbb_debug_lib}"
+                                  INTERFACE_INCLUDE_DIRECTORIES "${_tbb_inc_path}"
+                                  IMPORTED_IMPLIB_RELEASE       "${_tbb_release_lib}"
+                                  IMPORTED_IMPLIB_DEBUG         "${_tbb_debug_lib}"
+                                  INTERFACE_COMPILE_DEFINITIONS "__TBB_NO_IMPLICIT_LINKAGE=1")
+
+            # Add internal dependencies for imported targets: TBB::tbbmalloc_proxy -> TBB::tbbmalloc
+            if (_tbb_component STREQUAL tbbmalloc_proxy)
+                set_target_properties(TBB::tbbmalloc_proxy PROPERTIES INTERFACE_LINK_LIBRARIES TBB::tbbmalloc)
+            endif()
+
+            list(APPEND TBB_IMPORTED_TARGETS TBB::${_tbb_component})
+            set(TBB_${_tbb_component}_FOUND 1)
+        endif()
+    elseif (TBB_FIND_REQUIRED AND TBB_FIND_REQUIRED_${_tbb_component})
+        message(FATAL_ERROR "Missed required Intel TBB component: ${_tbb_component}")
+    endif()
+endforeach()
+
+unset(_tbb_x32_subdir)
+unset(_tbb_x64_subdir)
+unset(_tbb_arch_subdir)
+unset(_tbb_compiler_subdir)
+unset(_tbbmalloc_proxy_ix)
+unset(_tbbmalloc_ix)
+unset(_tbb_lib_path)
+unset(_tbb_release_lib)
+unset(_tbb_debug_lib)

--- a/inference-engine/include/ie_plugin_config.hpp
+++ b/inference-engine/include/ie_plugin_config.hpp
@@ -194,7 +194,7 @@ DECLARE_CONFIG_KEY(CPU_THREADS_NUM);
  *
  * It is passed to Core::SetConfig(), this option should be used with values:
  * PluginConfigParams::YES (pinning threads to cores, best for static benchmarks),
- * PluginConfigParams::NUMA (pinning therads to NUMA nodes, best for real-life, contented cases)
+ * PluginConfigParams::NUMA (pinning threads to NUMA nodes, best for real-life, contented cases)
  * this is TBB-specific knob, and the only pinning option (beyond 'NO', below) on the Windows*
  * PluginConfigParams::NO (no pinning for CPU inference threads)
  * All settings are ignored, if the OpenVINO compiled with OpenMP threading and any affinity-related OpenMP's
@@ -207,7 +207,7 @@ DECLARE_CONFIG_VALUE(NUMA);
  * @brief Optimize CPU execution to maximize throughput.
  *
  * It is passed to Core::SetConfig(), this option should be used with values:
- * - KEY_CPU_THROUGHPUT_NUMA creates as many streams as needed to accomodate NUMA and avoid associated penalties
+ * - KEY_CPU_THROUGHPUT_NUMA creates as many streams as needed to accommodate NUMA and avoid associated penalties
  * - KEY_CPU_THROUGHPUT_AUTO creates bare minimum of streams to improve the performance,
  *   this is the most portable option if you have no insights into how many cores you target machine will have
  *   (and what is the optimal number of streams)

--- a/inference-engine/src/inference_engine/ie_system_conf.cpp
+++ b/inference-engine/src/inference_engine/ie_system_conf.cpp
@@ -146,7 +146,11 @@ std::vector<int> getAvailableNUMANodes() { return {0}; }
 
 #if ((IE_THREAD == IE_THREAD_TBB) || (IE_THREAD == IE_THREAD_TBB_AUTO))
 std::vector<int> getAvailableNUMANodes() {
+#if TBB_INTERFACE_VERSION >= 11100
     return tbb::info::numa_nodes();
+#else
+    return {0};
+#endif
 }
 #endif
 

--- a/inference-engine/src/inference_engine/threading/ie_cpu_streams_executor.cpp
+++ b/inference-engine/src/inference_engine/threading/ie_cpu_streams_executor.cpp
@@ -72,7 +72,11 @@ struct CPUStreamsExecutor::Impl {
 #if IE_THREAD == IE_THREAD_TBB || IE_THREAD == IE_THREAD_TBB_AUTO
             auto concurrency = (0 == _impl->_config._threadsPerStream) ? tbb::task_arena::automatic : _impl->_config._threadsPerStream;
             if (ThreadBindingType::NUMA == _impl->_config._threadBindingType) {
+#if TBB_INTERFACE_VERSION >= 11100  // TBB has numa aware task_arena api
                 _taskArena.reset(new tbb::task_arena{tbb::task_arena::constraints{_numaNodeId, concurrency}});
+#else
+                _taskArena.reset(new tbb::task_arena{concurrency});
+#endif
             } else if ((0 != _impl->_config._threadsPerStream) || (ThreadBindingType::CORES == _impl->_config._threadBindingType)) {
                 _taskArena.reset(new tbb::task_arena{concurrency});
                 if (ThreadBindingType::CORES == _impl->_config._threadBindingType) {

--- a/inference-engine/src/inference_engine/threading/ie_istreams_executor.cpp
+++ b/inference-engine/src/inference_engine/threading/ie_istreams_executor.cpp
@@ -30,6 +30,13 @@ std::vector<std::string> IStreamsExecutor::Config::SupportedKeys() {
 void IStreamsExecutor::Config::SetConfig(const std::string& key, const std::string& value) {
         if (key == CONFIG_KEY(CPU_BIND_THREAD)) {
             if (value == CONFIG_VALUE(YES) || value == CONFIG_VALUE(NUMA)) {
+#if (IE_THREAD == IE_THREAD_TBB || IE_THREAD == IE_THREAD_TBB_AUTO) && (TBB_INTERFACE_VERSION < 11100)
+                if (value == CONFIG_VALUE(NUMA))
+                    THROW_IE_EXCEPTION << CONFIG_KEY(CPU_BIND_THREAD) << " property value was set to NUMA. But IE was built with "
+                                       << "TBB version without NUMA-aware API. Current TBB API version is " << TBB_INTERFACE_VERSION
+                                       << ", required API version 11100 or greater.";
+#endif
+
 #if (defined(__APPLE__) || defined(_WIN32))
                 // on the Windows and Apple the CORES and NUMA pinning options are the same
                 _threadBindingType = IStreamsExecutor::ThreadBindingType::NUMA;

--- a/inference-engine/src/mkldnn_plugin/config.cpp
+++ b/inference-engine/src/mkldnn_plugin/config.cpp
@@ -24,6 +24,22 @@ namespace MKLDNNPlugin {
 
 using namespace InferenceEngine;
 
+Config::Config() {
+#if (defined(__APPLE__) || defined(_WIN32))
+#if (IE_THREAD == IE_THREAD_TBB || IE_THREAD == IE_THREAD_TBB_AUTO) && (TBB_INTERFACE_VERSION >= 11100)
+    // If we sure that TBB has NUMA aware API part.
+    streamExecutorConfig._threadBindingType = InferenceEngine::IStreamsExecutor::NUMA;
+#else
+    streamExecutorConfig._threadBindingType = InferenceEngine::IStreamsExecutor::NONE;
+#endif
+#else
+    streamExecutorConfig._threadBindingType = InferenceEngine::IStreamsExecutor::CORES;
+#endif
+
+    updateProperties();
+}
+
+
 void Config::readProperties(const std::map<std::string, std::string> &prop) {
     auto streamExecutorConfigKeys = streamExecutorConfig.SupportedKeys();
     for (auto& kvp : prop) {

--- a/inference-engine/src/mkldnn_plugin/config.h
+++ b/inference-engine/src/mkldnn_plugin/config.h
@@ -11,14 +11,7 @@
 namespace MKLDNNPlugin {
 
 struct Config {
-    Config() {
-#if (defined(__APPLE__) || defined(_WIN32))
-        streamExecutorConfig._threadBindingType = InferenceEngine::IStreamsExecutor::NUMA;
-#else
-        streamExecutorConfig._threadBindingType = InferenceEngine::IStreamsExecutor::CORES;
-#endif
-        updateProperties();
-    }
+    Config();
 
     enum LPTransformsMode {
         Off,

--- a/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/convolution_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/convolution_transformation.cpp
@@ -98,7 +98,7 @@ void ConvolutionTransformation::validate() {
     std::map<std::string, InferenceEngine::DataPtr>::iterator it = outputs.begin();
     const InferenceEngine::CNNLayerPtr outputLayer = getCreatorLayer(it->second).lock();
     EXPECT_TRUE(outputLayer != nullptr);
-    EXPECT_EQ(fqOnActivations & fqOnWeights ? "ScaleShift" : "Convolution", outputLayer->type);
+    EXPECT_EQ((fqOnActivations & fqOnWeights) ? "ScaleShift" : "Convolution", outputLayer->type);
 
     if (fqOnActivations & fqOnWeights) {
         const InferenceEngine::CNNLayerPtr layer = InferenceEngine::details::CNNNetworkHelper::getParent(*outputLayer);


### PR DESCRIPTION
Allow to specify older TBB version to use in build. It's required to keep compatibility with applications built on top of old TBB version without NUMA and other new come features.     

To enable OpenVINO build with external TBB version customer should provide path to corresponding TBB package via:
1. TBB_DIR cmake or env variable. Contains path to corresponding TBBConfig.cmake 
2. TBBROOT cmake or env variable. Contains path to corresponding TBB package.
   * If it contains 'cmake' folder with TBBConfig.cmake it will be used. Actual for tbb version >= 2017.7
   * If it has no cmake config file the OpenVINO will browsed content to find required headers and shared modules. Actual for tbb version < 2017.7

Cmake will print selected TBB version and show warning message if some features cannot be enabled (like NUMA node support)

**NB!** Fallback policy for NUMA-aware OpenVINO code is next. The system will be considered as single socket(NUMA instance) machine, and **no numa specific optimization will be applied**.
