### PR TITLE
Optimisations for binary operations broadcast. Phase 2.

### DIFF
--- a/ngraph/src/ngraph/coordinate_transform.hpp
+++ b/ngraph/src/ngraph/coordinate_transform.hpp
@@ -60,17 +60,16 @@ namespace ngraph
 
         /// \brief Increments iterator using specified axis of the shape n times.
         /// \param axis index used for iteration
-        void advance(size_t axis) noexcept;
+        size_t advance(size_t axis) noexcept;
 
         /// \brief Useful function to build the last iterator.
         ///        Returns a singleton that points to the last iterator.
         static const CoordinateIterator& end();
 
     private:
-        Shape m_target_shape;
+        const Shape& m_target_shape;
         Coordinate m_coordinate;
         bool m_oob;
-        bool m_empty;
     };
 
     /// \brief Class which allows to calculate item index with given coordinates in tensor


### PR DESCRIPTION
The calculation of the indices of tensor elements has been simplified and the following performance results has been achieved:

1000000 additions of 2 tensors with different dimensions.

Tensor shapes                                        | Speed-up
-------------------------------------------|-------------
{4} x {}                                                     | +30%
{3, 2, 1} x {1, 6}                                        | +40%
{2, 12, 1, 1, 1} x {1, 1, 1, 8}                       | +39%
{3, 24, 1, 1, 1, 1, 1} x {1, 1, 1, 1, 1, 64}      | +44%
{2, 12, 1, 2, 8} x {1, 1, 2, 8}                       | +35%
{3, 2, 8} x {3, 2, 8}                                    | -18%
{1, 3, 2, 8, 1, 1, 1} x {1, 3, 2, 8, 1, 1, 1}      | -10%

Last two test are degraded due the extra vector allocation before the applying of tensor operation. It could be avoided using alloca() function or variable length arrays.