### PR TITLE
[PP GAPI] - U16toF32 conversion kernel

### DIFF
--- a/inference-engine/src/preprocessing/ie_preprocess_gapi_kernels.cpp
+++ b/inference-engine/src/preprocessing/ie_preprocess_gapi_kernels.cpp
@@ -2208,6 +2208,27 @@ GAPI_FLUID_KERNEL(FI420toRGB, I420toRGB, false) {
         calculate_i420_to_rgb_fallback(y_rows, u_row, v_row, out_rows, buf_width);
     }
 };
+
+GAPI_FLUID_KERNEL(FU16toF32, U16toF32, false) {
+    static const int Window = 1;
+
+    static void run(const cv::gapi::fluid::View& src, cv::gapi::fluid::Buffer& dst) {
+        GAPI_Assert(src.meta().depth == CV_16U);
+        GAPI_Assert(dst.meta().depth == CV_32F);
+        GAPI_Assert(src.meta().chan == 1);
+        GAPI_Assert(dst.meta().chan == 1);
+        GAPI_Assert(src.length() == dst.length());
+
+        const auto *in  = src.InLine<uint16_t>(0);
+              auto *out = dst.OutLine<float>();
+
+        auto const width = dst.length();
+        for (int i = 0; i < width; i++) {
+            out[i] = in[i];
+        }
+    }
+};
+
 }  // namespace kernels
 
 //----------------------------------------------------------------------
@@ -2234,6 +2255,7 @@ cv::gapi::GKernelPackage preprocKernels() {
         , FSplit4
         , FNV12toRGB
         , FI420toRGB
+        , FU16toF32
         >();
 }
 

--- a/inference-engine/src/preprocessing/ie_preprocess_gapi_kernels.hpp
+++ b/inference-engine/src/preprocessing/ie_preprocess_gapi_kernels.hpp
@@ -143,6 +143,16 @@ namespace gapi {
         }
     };
 
+    G_TYPED_KERNEL(U16toF32, <cv::GMat(cv::GMat)>, "com.intel.ie.u16tof32") {
+        static cv::GMatDesc outMeta(const cv::GMatDesc& in) {
+            GAPI_Assert(in.depth == CV_16U);
+
+            return in.withDepth(CV_32F);
+        }
+    };
+
+
+
     cv::gapi::GKernelPackage preprocKernels();
 
 }  // namespace gapi

--- a/inference-engine/tests_deprecated/fluid_preproc/common/fluid_tests.cpp
+++ b/inference-engine/tests_deprecated/fluid_preproc/common/fluid_tests.cpp
@@ -624,6 +624,34 @@ TEST_P(I420toRGBTestGAPI, AccuracyTest)
         EXPECT_EQ(sz, out_mat_gapi.size());
     }
 }
+
+TEST_P(U16toF32TestGAPI, AccuracyTest)
+{
+    const auto params = GetParam();
+    cv::Size sz      = std::get<0>(params);
+    double tolerance = std::get<1>(params);
+
+    initMatrixRandU(CV_16UC1, sz, CV_32FC1);
+
+    // G-API code //////////////////////////////////////////////////////////////
+    FluidU16ToF32Computation cc(to_test(in_mat1), to_test(out_mat_gapi));
+    cc.warmUp();
+
+#if PERF_TEST
+    // iterate testing, and print performance
+    test_ms([&](){ cc.apply(); },
+        400, "U16ToF32 GAPI %s %dx%d", typeToString(CV_16UC1).c_str(), sz.width, sz.height);
+#endif
+
+    // OpenCV code /////////////////////////////////////////////////////////////
+    {
+        in_mat1.convertTo(out_mat_ocv, CV_32FC1);
+    }
+    // Comparison //////////////////////////////////////////////////////////////
+    {
+        EXPECT_LE(cv::norm(out_mat_ocv, out_mat_gapi, cv::NORM_INF), tolerance);
+    }
+}
 //----------------------------------------------------------------------
 
 TEST_P(ResizeTestIE, AccuracyTest)

--- a/inference-engine/tests_deprecated/fluid_preproc/common/fluid_tests.hpp
+++ b/inference-engine/tests_deprecated/fluid_preproc/common/fluid_tests.hpp
@@ -19,7 +19,7 @@ struct NV12toRGBTestGAPI: public TestParams<std::tuple<cv::Size, double>> {};
 struct I420toRGBTestGAPI: public TestParams<std::tuple<cv::Size, double>> {};
 struct ResizeRoiTestGAPI: public testing::TestWithParam<std::tuple<int, int, std::pair<cv::Size, cv::Size>, cv::Rect, double>> {};
 struct ResizeRGB8URoiTestGAPI: public testing::TestWithParam<std::tuple<int, int, std::pair<cv::Size, cv::Size>, cv::Rect, double>> {};
-
+struct U16toF32TestGAPI: public TestParams<std::tuple<cv::Size, double>> {};
 //------------------------------------------------------------------------------
 
 struct ResizeTestIE: public testing::TestWithParam<std::tuple<int, int, std::pair<cv::Size, cv::Size>, double>> {};

--- a/inference-engine/tests_deprecated/fluid_preproc/cpu/fluid_tests_cpu.cpp
+++ b/inference-engine/tests_deprecated/fluid_preproc/cpu/fluid_tests_cpu.cpp
@@ -170,6 +170,16 @@ INSTANTIATE_TEST_CASE_P(I420toRGBTestFluid, I420toRGBTestGAPI,
                                        cv::Size( 320,  200)),
                                 Values(0)));
 
+INSTANTIATE_TEST_CASE_P(U16toF32TestGAPIFluid, U16toF32TestGAPI,
+                        Combine(Values(cv::Size(3840, 2160),
+                                       cv::Size(1920, 1080),
+                                       cv::Size(1280,  720),
+                                       cv::Size(1280,  960),
+                                       cv::Size( 960,  720),
+                                       cv::Size( 640,  480),
+                                       cv::Size( 300,  300),
+                                       cv::Size( 320,  200)),
+                                Values(0)));
 
 INSTANTIATE_TEST_CASE_P(ResizeRoiTestFluid, ResizeRoiTestGAPI,
                         Combine(Values(CV_8UC1, CV_8UC3),

--- a/inference-engine/tests_deprecated/fluid_preproc/fluid_test_computations/fluid_test_computations.cpp
+++ b/inference-engine/tests_deprecated/fluid_preproc/fluid_test_computations/fluid_test_computations.cpp
@@ -213,3 +213,15 @@ FluidI420toRGBComputation::FluidI420toRGBComputation(test::Mat inMat_y, test::Ma
                                ,{to_own(outMat)}
                                })
 {}
+
+FluidU16ToF32Computation::FluidU16ToF32Computation(test::Mat inMatU16, test::Mat outMatF32)
+    : FluidComputation(new Priv{ []()-> cv::GComputation {
+                                    cv::GMat in_U16;
+                                    cv::GMat outf32 = InferenceEngine::gapi::U16toF32::on(in_U16);
+                                    return cv::GComputation(cv::GIn(in_U16), cv::GOut(outf32));
+                                 }()
+                               , {to_own(inMatU16)}
+                               , {to_own(outMatF32)}
+                               })
+{}
+

--- a/inference-engine/tests_deprecated/fluid_preproc/fluid_test_computations/fluid_test_computations.hpp
+++ b/inference-engine/tests_deprecated/fluid_preproc/fluid_test_computations/fluid_test_computations.hpp
@@ -98,4 +98,10 @@ public:
     FluidI420toRGBComputation(test::Mat inMat_y, test::Mat inMat_u, test::Mat inMat_v, test::Mat outMat);
 };
 
+class FLUID_COMPUTATION_VISIBILITY FluidU16ToF32Computation : public FluidComputation
+{
+public:
+    FluidU16ToF32Computation(test::Mat inMatU16, test::Mat outMatF32);
+};
+
 #endif // FLUID_TEST_COMPUTATIONS_HPP


### PR DESCRIPTION
This patch adds : 
- the U16 to F32 conversion kernel itself, which  is not yet used in the preprocessing 
- tests for it