### PR TITLE
Fix that brings back the MULTI's ability to add/remove devices on the fly

### DIFF
--- a/inference-engine/src/multi_device/multi_device.cpp
+++ b/inference-engine/src/multi_device/multi_device.cpp
@@ -268,9 +268,9 @@ void MultiDeviceExecutableNetwork::SetConfig(const std::map<std::string, Inferen
         {
             std::lock_guard<std::mutex> lock{_mutex};
             for (auto && device : metaDevices) {
-                if (_devicePriorities.find(device.first) == _devicePriorities.end()) {
+                if (_networksPerDevice.find(device.first) == _networksPerDevice.end()) {
                     THROW_IE_EXCEPTION << NOT_FOUND_str << "You can only change device priorities but not add new devices with"
-                        << " the Network's SetConfig(MultiDeviceConfigParams::KEY_MULTI_DEVICE_PRIORITIES." << device.first <<
+                        << " the Network's SetConfig(MultiDeviceConfigParams::KEY_MULTI_DEVICE_PRIORITIES. " << device.first <<
                             " device was not in the original device list!";
                 }
             }


### PR DESCRIPTION
Fix that brings back the MULTI's ability to add/remove devices (to th……e priorities list) on the fly. Presumably was lost during refactoring.

the point is that we should check the ORIGINALLY (largest) list of the devices (actually ExecutableNetworks for them) to see if the device was initially used, then removed with SetConfig (that omits the device) and now just added BACK