### PR TITLE
Added default multi threaded configuration

### DIFF
--- a/inference-engine/src/plugin_api/threading/ie_istreams_executor.hpp
+++ b/inference-engine/src/plugin_api/threading/ie_istreams_executor.hpp
@@ -68,6 +68,14 @@ public:
         */
         Parameter GetConfig(const std::string& key);
 
+        /**
+        * @brief Create appropriate maltythreaded configuration
+        *        filing unconfigured values from initial configuration using hardware properties
+        * @param initial Inital configuration
+        * @return configured values
+        */
+        static Config MakeDefaultMultiThreaded(const Config& initial);
+
         std::string        _name;  //!< Used by `ITT` to name executor threads
         int                _streams                 = 1;  //!< Number of streams.
         int                _threadsPerStream        = 0;  //!< Number of threads per stream that executes `ie_parallel` calls

--- a/inference-engine/src/plugin_api/threading/ie_istreams_executor.hpp
+++ b/inference-engine/src/plugin_api/threading/ie_istreams_executor.hpp
@@ -69,7 +69,7 @@ public:
         Parameter GetConfig(const std::string& key);
 
         /**
-        * @brief Create appropriate maltythreaded configuration
+        * @brief Create appropriate multithreaded configuration
         *        filing unconfigured values from initial configuration using hardware properties
         * @param initial Inital configuration
         * @return configured values


### PR DESCRIPTION
This configuration is used in MKLDNN plugin by default and can be used in any other CPU plugin