### PR TITLE
ngraph::pass::ConvertPrecision transformation

### DIFF
--- a/inference-engine/src/cldnn_engine/cldnn_engine.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_engine.cpp
@@ -27,6 +27,7 @@
 #include <ngraph/op/fused/gelu.hpp>
 #include <ngraph/pass/manager.hpp>
 #include <generic_ie.hpp>
+#include <transformations/apply_transformations_to_ti_body.hpp>
 #include <transformations/common_optimizations/common_optimizations.hpp>
 #include <transformations/convert_opset1_to_legacy/convert_opset1_to_legacy.hpp>
 #include <transformations/convert_opset2_to_opset1/convert_opset2_to_opset1.hpp>
@@ -106,6 +107,12 @@ InferenceEngine::ICNNNetwork::Ptr clDNNEngine::CloneNetwork(const InferenceEngin
 
         manager.set_callback(transformations_callback);
         manager.run_passes(nGraphFunc);
+
+        // Apply all transformations to TensorIterator body
+        ngraph::pass::Manager ti_manager;
+        ti_manager.register_pass<ngraph::pass::ApplyTransformationsToTIBody>(manager);
+        ti_manager.run_passes(nGraphFunc);
+
         clonedNetwork = InferenceEngine::details::convertFunctionToICNNNetwork(nGraphFunc, *clonedNetwork);
     }
 

--- a/inference-engine/src/inference_engine/cnn_network_ngraph_impl.cpp
+++ b/inference-engine/src/inference_engine/cnn_network_ngraph_impl.cpp
@@ -236,7 +236,7 @@ StatusCode CNNNetworkNGraphImpl::addOutput(const std::string& layerName, size_t 
     }
 
     try {
-        for (const auto layer : _ngraph_function->get_ops()) {
+        for (const auto & layer : _ngraph_function->get_ops()) {
             if (layer->get_friendly_name() == layerName) {
                 auto& results = const_cast<::ngraph::ResultVector&>(_ngraph_function->get_results());
                 auto result = make_shared<::ngraph::op::Result>(layer->output(outputIndex));
@@ -246,13 +246,9 @@ StatusCode CNNNetworkNGraphImpl::addOutput(const std::string& layerName, size_t 
                 if (layer->outputs().size() != 1) {
                     outputName += "." + std::to_string(outputIndex);
                 }
-                if (_data.find(outputName) != _data.end()) {
-                    addOutput(outputName);
-                    if (cnnNetwork)
-                        return cnnNetwork->addOutput(layerName, outputIndex, resp);
-                } else {
+                if (_outputData.count(outputName) == 0) {
                     reshape();
-                    addOutput(outputName);
+                    addOutput(layer->output(outputIndex));
                 }
                 return OK;
             }
@@ -263,13 +259,16 @@ StatusCode CNNNetworkNGraphImpl::addOutput(const std::string& layerName, size_t 
     return DescriptionBuffer(NOT_FOUND, resp) << "Cannot add output! Layer " << layerName << " wasn't found!";
 }
 
-void CNNNetworkNGraphImpl::addOutput(const string& dataName) {
-    auto it = _data.find(dataName);
-    if (it == _data.end()) {
-        THROW_IE_EXCEPTION << "data [" << dataName << "] doesn't exist";
+void CNNNetworkNGraphImpl::addOutput(const ::ngraph::Output<::ngraph::Node> & output) {
+    auto outputNode = output.get_node_shared_ptr();
+    auto dataName = outputNode->get_friendly_name();
+    if (outputNode->get_output_size() != 1) {
+        dataName += "." + std::to_string(output.get_index());
     }
-    auto data = it->second;
-    assert(data->getName() == dataName);
+
+    DataPtr data;
+    createDataForResult(output, dataName, data);
+    _data[dataName] = data;
     _outputData[dataName] = data;
 }
 
@@ -378,25 +377,17 @@ CNNNetworkNGraphImpl::reshape(const std::map<std::string, std::vector<size_t>>& 
             }
 #endif
             std::unordered_set<std::string> opName;
-            for (const auto & layer : specialized_ngraph_function->get_ordered_ops()) {
-                if (std::dynamic_pointer_cast<::ngraph::op::Result>(layer)) {
-                    IE_ASSERT(layer->inputs().size() == 1);
-                    const auto& output = layer->input(0).get_source_output();
-                    std::string outName = output.get_node()->get_friendly_name();
-                    if (output.get_node()->get_output_size() != 1)
-                        outName += "." + std::to_string(output.get_index());
-                    addOutput(outName);
-                    continue;
-                }
-                if (opName.find(layer->get_friendly_name()) != opName.end())
+            for (const auto & result : specialized_ngraph_function->get_results()) {
+                addOutput(result->input_value(0));
+            }
+
+            for (const auto & parameter : specialized_ngraph_function->get_parameters()) {
+                const auto & outName = parameter->get_friendly_name();
+                if (opName.find(outName) != opName.end()) {
                     THROW_IE_EXCEPTION << "All operations in nGraph function should have unique friendly names!";
-                opName.insert(layer->get_friendly_name());
-                for (const auto& output : layer->outputs()) {
-                    std::string outName = layer->get_friendly_name();
-                    if (layer->outputs().size() != 1)
-                        outName += "." + std::to_string(output.get_index());
-                    createDataForResult(output, outName, _data[outName]);
                 }
+                opName.insert(outName);
+                createDataForResult(parameter, outName, _data[outName]);
             }
         }
     } catch (std::exception& ex) {

--- a/inference-engine/src/inference_engine/cnn_network_ngraph_impl.hpp
+++ b/inference-engine/src/inference_engine/cnn_network_ngraph_impl.hpp
@@ -67,7 +67,7 @@ public:
 
     StatusCode addOutput(const std::string& layerName, size_t outputIndex, ResponseDesc* resp) noexcept override;
 
-    void addOutput(const std::string& dataName);
+    void addOutput(const ::ngraph::Output<::ngraph::Node> & dataName);
 
     void Release() noexcept override {
         delete this;

--- a/inference-engine/src/legacy_api/include/net_pass.h
+++ b/inference-engine/src/legacy_api/include/net_pass.h
@@ -101,5 +101,7 @@ IE_SUPPRESS_DEPRECATED_END
  */
 INFERENCE_ENGINE_API_CPP(void) ConvertPrecision(ICNNNetwork& net, Precision from, Precision to);
 
+INFERENCE_ENGINE_API_CPP(void) ConvertIOPrecision(ICNNNetwork& net, Precision from, Precision to);
+
 }  // namespace NetPass
 }  // namespace InferenceEngine

--- a/inference-engine/src/legacy_api/src/cnn_network_impl.cpp
+++ b/inference-engine/src/legacy_api/src/cnn_network_impl.cpp
@@ -28,6 +28,7 @@
 #include <transformations/convert_opset1_to_legacy/convert_opset1_to_legacy.hpp>
 #include <transformations/convert_opset2_to_opset1/convert_opset2_to_opset1.hpp>
 #include <transformations/convert_opset3_to_opset2/convert_opset3_to_opset2.hpp>
+#include <transformations/apply_transformations_to_ti_body.hpp>
 #include "convert_function_to_cnn_network.hpp"
 
 using namespace std;
@@ -94,10 +95,17 @@ CNNNetworkImpl::CNNNetworkImpl(const ICNNNetwork & ngraphImpl) {
     // Disable shape inference (WA for generic operations)
     ::ngraph::op::GenericIE::DisableReshape noReshape(graph);
 
-    ::ngraph::pass::CommonOptimizations().run_on_function(graph);
-    ::ngraph::pass::ConvertOpSet3ToOpSet2().run_on_function(graph);
-    ::ngraph::pass::ConvertOpSet2ToOpSet1().run_on_function(graph);
-    ::ngraph::pass::ConvertOpSet1ToLegacy().run_on_function(graph);
+    ::ngraph::pass::Manager manager;
+    manager.register_pass<::ngraph::pass::CommonOptimizations>();
+    manager.register_pass<::ngraph::pass::ConvertOpSet3ToOpSet2>();
+    manager.register_pass<::ngraph::pass::ConvertOpSet2ToOpSet1>();
+    manager.register_pass<::ngraph::pass::ConvertOpSet1ToLegacy>();
+    manager.run_passes(graph);
+
+    ::ngraph::pass::Manager ti_manager;
+    ti_manager.register_pass<::ngraph::pass::ApplyTransformationsToTIBody>(manager);
+    ti_manager.run_passes(graph);
+
     InferenceEngine::details::convertFunctionToICNNNetwork(graph, ngraphImpl, this, false);
 }
 

--- a/inference-engine/src/legacy_api/src/ie_cnn_layer_builder_ngraph.cpp
+++ b/inference-engine/src/legacy_api/src/ie_cnn_layer_builder_ngraph.cpp
@@ -30,6 +30,7 @@
 #include "ngraph_ops/lrn_ie.hpp"
 #include <ngraph_ops/lstm_cell_ie.hpp>
 #include <transformations/rt_info/primitives_priority_attribute.hpp>
+#include <convert_function_to_cnn_network.hpp>
 #include "ngraph_ops/normalize_ie.hpp"
 #include "ngraph_ops/nms_ie.hpp"
 #include "ngraph_ops/onehot_ie.hpp"
@@ -151,9 +152,8 @@ CNNLayer::Ptr NodeConverter<ngraph::op::TensorIterator>::createLayer(const std::
     // This map will save information about data nodes
     std::map<std::string, std::vector<TensorDesc>> layer_name_to_tensor_desc;
     {
-        auto tiBody = std::make_shared<details::TINGraphBody>(std::make_shared<ngraph::Function>(results, parameters));
-        CNNNetwork ngraphNet(tiBody);
-        CNNNetwork net(std::make_shared<InferenceEngine::details::CNNNetworkImpl>(ngraphNet));
+        CNNNetwork body_net(tensor_iterator->get_body()->to_function());
+        CNNNetwork net(InferenceEngine::details::convertFunctionToICNNNetwork(body_net.getFunction(), body_net));
         // Paranoid check for cycles
         bool res = CNNNetForestDFS(
             CNNNetGetAllInputLayers(net), [](const CNNLayerPtr& layer) {}, false);

--- a/inference-engine/src/legacy_api/src/net_pass.cpp
+++ b/inference-engine/src/legacy_api/src/net_pass.cpp
@@ -1487,5 +1487,23 @@ void ConvertPrecision(ICNNNetwork& net, Precision from, Precision to) {
     }
 }
 
+void ConvertIOPrecision(ICNNNetwork& net, Precision from, Precision to) {
+    InputsDataMap inputDataMap;
+    net.getInputsInfo(inputDataMap);
+    for (auto & i : inputDataMap) {
+        if (i.second->getPrecision() == from) {
+            i.second->setPrecision(to);
+        }
+    }
+
+    OutputsDataMap outputDataMap;
+    net.getOutputsInfo(outputDataMap);
+    for (auto & i : outputDataMap) {
+        if (i.second->getPrecision() == from) {
+            i.second->setPrecision(to);
+        }
+    }
+}
+
 }  // namespace NetPass
 }  // namespace InferenceEngine

--- a/inference-engine/src/mkldnn_plugin/mkldnn_exec_network.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_exec_network.cpp
@@ -53,12 +53,12 @@ MKLDNNExecNetwork::MKLDNNExecNetwork(const InferenceEngine::ICNNNetwork &network
     // CPU Plugin doesn't natively support some precision like int64/fp16/bool
     // so will convert all layer/tensors fp16->fp32 , bool->u8.
     // Default int64->int32 conversion is already applied in IE common module.
-    NetPass::ConvertPrecision(*_clonedNetwork, Precision::I64, Precision::I32);
-    NetPass::ConvertPrecision(*_clonedNetwork, Precision::U64, Precision::I32);
-    NetPass::ConvertPrecision(*_clonedNetwork, Precision::U32, Precision::I32);
-    NetPass::ConvertPrecision(*_clonedNetwork, Precision::FP16, Precision::FP32);
-    NetPass::ConvertPrecision(*_clonedNetwork, Precision::BOOL, Precision::U8);
-    NetPass::ConvertPrecision(*_clonedNetwork, Precision::U16, Precision::I32);
+//    NetPass::ConvertPrecision(*_clonedNetwork, Precision::I64, Precision::I32);
+//    NetPass::ConvertPrecision(*_clonedNetwork, Precision::U64, Precision::I32);
+//    NetPass::ConvertPrecision(*_clonedNetwork, Precision::U32, Precision::I32);
+//    NetPass::ConvertPrecision(*_clonedNetwork, Precision::FP16, Precision::FP32);
+//    NetPass::ConvertPrecision(*_clonedNetwork, Precision::BOOL, Precision::U8);
+//    NetPass::ConvertPrecision(*_clonedNetwork, Precision::U16, Precision::I32);
 
     if (_cfg.lpTransformsMode == Config::LPTransformsMode::On) {
         auto params = LayerTransformation::Params(true,  // updatePrecisions

--- a/inference-engine/src/mkldnn_plugin/mkldnn_exec_network.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_exec_network.cpp
@@ -50,16 +50,6 @@ MKLDNNExecNetwork::MKLDNNExecNetwork(const InferenceEngine::ICNNNetwork &network
     // we are cloning network if we have statistics and we can transform network.
     _clonedNetwork = cloneNet(network);
 
-    // CPU Plugin doesn't natively support some precision like int64/fp16/bool
-    // so will convert all layer/tensors fp16->fp32 , bool->u8.
-    // Default int64->int32 conversion is already applied in IE common module.
-//    NetPass::ConvertPrecision(*_clonedNetwork, Precision::I64, Precision::I32);
-//    NetPass::ConvertPrecision(*_clonedNetwork, Precision::U64, Precision::I32);
-//    NetPass::ConvertPrecision(*_clonedNetwork, Precision::U32, Precision::I32);
-//    NetPass::ConvertPrecision(*_clonedNetwork, Precision::FP16, Precision::FP32);
-//    NetPass::ConvertPrecision(*_clonedNetwork, Precision::BOOL, Precision::U8);
-//    NetPass::ConvertPrecision(*_clonedNetwork, Precision::U16, Precision::I32);
-
     if (_cfg.lpTransformsMode == Config::LPTransformsMode::On) {
         auto params = LayerTransformation::Params(true,  // updatePrecisions
                                                     true,  // quantizeOutputs

--- a/inference-engine/src/mkldnn_plugin/mkldnn_plugin.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_plugin.cpp
@@ -104,6 +104,7 @@ static void Transformation(ICNNNetwork::Ptr& clonedNetwork) {
     manager.run_passes(nGraphFunc);
 
     clonedNetwork = InferenceEngine::details::convertFunctionToICNNNetwork(nGraphFunc, *clonedNetwork);
+    NetPass::ConvertPrecision(*clonedNetwork, Precision::BOOL, Precision::U8);
 }
 
 InferenceEngine::ExecutableNetworkInternal::Ptr
@@ -140,7 +141,6 @@ Engine::LoadExeNetworkImpl(const InferenceEngine::ICNNNetwork &network, const st
     std::shared_ptr<ICNNNetwork> clonedNetwork = cloneNetwork(network);
     if (clonedNetwork->getFunction()) {
         Transformation(clonedNetwork);
-        NetPass::ConvertPrecision(*clonedNetwork, Precision::BOOL, Precision::U8);
     }
     auto implNetwork = std::dynamic_pointer_cast<details::CNNNetworkImpl>(clonedNetwork);
     if (implNetwork) {

--- a/inference-engine/src/mkldnn_plugin/mkldnn_plugin.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_plugin.cpp
@@ -24,6 +24,7 @@
 #include <transformations/convert_opset1_to_legacy/convert_opset1_to_legacy.hpp>
 #include <transformations/convert_opset2_to_opset1/convert_opset2_to_opset1.hpp>
 #include <transformations/convert_opset3_to_opset2/convert_opset3_to_opset2.hpp>
+#include <transformations/convert_precision.hpp>
 #include <transformations/rt_info/fused_names_attribute.hpp>
 #include <ngraph/opsets/opset1.hpp>
 #include <ngraph/opsets/opset2.hpp>
@@ -87,6 +88,13 @@ static void Transformation(ICNNNetwork::Ptr& clonedNetwork) {
     manager.register_pass<ngraph::pass::CommonOptimizations>();
     manager.register_pass<ngraph::pass::ConvertOpSet3ToOpSet2>();
     manager.register_pass<ngraph::pass::ConvertOpSet2ToOpSet1>();
+
+    manager.register_pass<ngraph::pass::ConvertPrecision>(ngraph::element::i64, ngraph::element::i32);
+    manager.register_pass<ngraph::pass::ConvertPrecision>(ngraph::element::u64, ngraph::element::i32);
+    manager.register_pass<ngraph::pass::ConvertPrecision>(ngraph::element::u16, ngraph::element::i32);
+    manager.register_pass<ngraph::pass::ConvertPrecision>(ngraph::element::u32, ngraph::element::i32);
+    manager.register_pass<ngraph::pass::ConvertPrecision>(ngraph::element::f16, ngraph::element::f32);
+
     manager.register_pass<ngraph::pass::ConvertOpSet1ToLegacy>();
 
     manager.set_callback(transformations_callback);

--- a/inference-engine/src/transformations/include/ngraph_ops/nms_ie.hpp
+++ b/inference-engine/src/transformations/include/ngraph_ops/nms_ie.hpp
@@ -25,7 +25,8 @@ public:
                         const Output<Node>& iou_threshold,
                         const Output<Node>& score_threshold,
                         int center_point_box,
-                        bool sort_result_descending);
+                        bool sort_result_descending,
+                        const ngraph::element::Type& output_type = ngraph::element::i64);
 
     void validate_and_infer_types() override;
 
@@ -35,6 +36,7 @@ public:
 
     int m_center_point_box;
     bool m_sort_result_descending = true;
+    element::Type m_output_type;
 };
 
 class TRANSFORMATIONS_API NonMaxSuppressionIE2 : public NonMaxSuppressionIE {
@@ -48,14 +50,12 @@ public:
                         const Output<Node>& iou_threshold,
                         const Output<Node>& score_threshold,
                         int center_point_box,
-                        bool sort_result_descending);
+                        bool sort_result_descending,
+                        const ngraph::element::Type& output_type = ngraph::element::i64);
 
     void validate_and_infer_types() override;
 
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector & new_args) const override;
-
-    int m_center_point_box;
-    bool m_sort_result_descending = true;
 };
 
 }  // namespace op

--- a/inference-engine/src/transformations/include/ngraph_ops/topk_ie.hpp
+++ b/inference-engine/src/transformations/include/ngraph_ops/topk_ie.hpp
@@ -24,7 +24,8 @@ public:
            const Output<Node>& k,
            const int64_t axis,
            const ngraph::op::TopKMode mode,
-           const ngraph::op::TopKSortType sort);
+           const ngraph::op::TopKSortType sort,
+           const element::Type& index_element_type = element::i32);
 
     void validate_and_infer_types() override;
 
@@ -40,6 +41,7 @@ private:
     int64_t m_axis;
     ngraph::op::TopKMode m_mode;
     ngraph::op::TopKSortType m_sort_type;
+    ngraph::element::Type m_index_element_type;
 };
 
 }  // namespace op

--- a/inference-engine/src/transformations/include/transformations/apply_transformations_to_ti_body.hpp
+++ b/inference-engine/src/transformations/include/transformations/apply_transformations_to_ti_body.hpp
@@ -1,0 +1,25 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <vector>
+#include <memory>
+
+#include <transformations_visibility.hpp>
+#include <ngraph/pass/manager.hpp>
+#include <ngraph/pass/graph_rewrite.hpp>
+
+namespace ngraph {
+namespace pass {
+
+class TRANSFORMATIONS_API ApplyTransformationsToTIBody;
+
+}  // namespace pass
+}  // namespace ngraph
+
+class ngraph::pass::ApplyTransformationsToTIBody: public ngraph::pass::MatcherPass {
+public:
+    explicit ApplyTransformationsToTIBody(ngraph::pass::Manager & manager);
+};

--- a/inference-engine/src/transformations/include/transformations/apply_transformations_to_ti_body.hpp
+++ b/inference-engine/src/transformations/include/transformations/apply_transformations_to_ti_body.hpp
@@ -19,6 +19,11 @@ class TRANSFORMATIONS_API ApplyTransformationsToTIBody;
 }  // namespace pass
 }  // namespace ngraph
 
+/**
+ * @ingroup ie_transformation_common_api
+ * @brief Applies transformations from given pass::Manager for each TensorIterator body
+ */
+
 class ngraph::pass::ApplyTransformationsToTIBody: public ngraph::pass::MatcherPass {
 public:
     explicit ApplyTransformationsToTIBody(ngraph::pass::Manager & manager);

--- a/inference-engine/src/transformations/include/transformations/convert_opset3_to_opset2/convert_nms3.hpp
+++ b/inference-engine/src/transformations/include/transformations/convert_opset3_to_opset2/convert_nms3.hpp
@@ -19,7 +19,7 @@ class TRANSFORMATIONS_API ConvertNMS1ToNMS3;
 }  // namespace pass
 }  // namespace ngraph
 
-class ngraph::pass::ConvertNMS1ToNMS3: public ngraph::pass::GraphRewrite, public ngraph::pass::PassParam {
+class ngraph::pass::ConvertNMS1ToNMS3: public ngraph::pass::GraphRewrite {
 public:
     ConvertNMS1ToNMS3() : GraphRewrite() {
         convert_nms1_to_nms3();

--- a/inference-engine/src/transformations/include/transformations/convert_opset3_to_opset2/convert_nms3.hpp
+++ b/inference-engine/src/transformations/include/transformations/convert_opset3_to_opset2/convert_nms3.hpp
@@ -14,17 +14,17 @@
 namespace ngraph {
 namespace pass {
 
-class TRANSFORMATIONS_API ConvertNMS3;
+class TRANSFORMATIONS_API ConvertNMS1ToNMS3;
 
 }  // namespace pass
 }  // namespace ngraph
 
-class ngraph::pass::ConvertNMS3: public ngraph::pass::GraphRewrite {
+class ngraph::pass::ConvertNMS1ToNMS3: public ngraph::pass::GraphRewrite, public ngraph::pass::PassParam {
 public:
-    ConvertNMS3() : GraphRewrite() {
-        convert_nms3();
+    ConvertNMS1ToNMS3() : GraphRewrite() {
+        convert_nms1_to_nms3();
     }
 
 private:
-    void convert_nms3();
+    void convert_nms1_to_nms3();
 };

--- a/inference-engine/src/transformations/include/transformations/convert_opset3_to_opset2/convert_opset3_to_opset2_tbl.hpp
+++ b/inference-engine/src/transformations/include/transformations/convert_opset3_to_opset2/convert_opset3_to_opset2_tbl.hpp
@@ -1,0 +1,21 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#ifndef NGRAPH_PASS
+#warning "NGRAPH_PASS is not defined"
+#define NGRAPH_PASS(A, B)
+#endif
+
+// To register new pass you need to define NGRAPH_PASS
+// Usage example:
+//   ngraph::pass:Manager pm;
+//   #define NGRAPH_PASS(NAME, NAMESPACE)   pm.register_pass<NAMESPACE::NAME>();
+//   #include <transformations/transformations_tbl.hpp>
+//   #undef NGRAPH_PASS
+
+NGRAPH_PASS(ConvertBroadcast3, ::ngraph::pass)
+NGRAPH_PASS(ConvertNMS1ToNMS3, ::ngraph::pass)
+NGRAPH_PASS(ConvertShapeOf3, ::ngraph::pass)
+NGRAPH_PASS(ConvertShuffleChannels3, ::ngraph::pass)
+NGRAPH_PASS(ConvertTopK3, ::ngraph::pass)

--- a/inference-engine/src/transformations/include/transformations/convert_precision.hpp
+++ b/inference-engine/src/transformations/include/transformations/convert_precision.hpp
@@ -21,7 +21,6 @@ namespace ngraph {
 namespace pass {
 
 class TRANSFORMATIONS_API ConvertPrecision;
-class TRANSFORMATIONS_API FuseShapeOfConvert;
 
 }  // namespace pass
 }  // namespace ngraph

--- a/inference-engine/src/transformations/include/transformations/convert_precision.hpp
+++ b/inference-engine/src/transformations/include/transformations/convert_precision.hpp
@@ -42,3 +42,8 @@ bool fuse_type_to_constant(std::shared_ptr<ngraph::Node> node, ngraph::element::
 bool fuse_type_to_shapeof(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);
 bool fuse_type_to_parameter(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);
 bool fuse_type_to_convert(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);
+bool fuse_type_to_nms3(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);
+bool fuse_type_to_nms4(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);
+bool fuse_type_to_topk(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);
+bool fuse_type_to_nonzero(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);
+bool fuse_type_to_bucketize(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);

--- a/inference-engine/src/transformations/include/transformations/convert_precision.hpp
+++ b/inference-engine/src/transformations/include/transformations/convert_precision.hpp
@@ -25,6 +25,12 @@ class TRANSFORMATIONS_API ConvertPrecision;
 }  // namespace pass
 }  // namespace ngraph
 
+/**
+ * @ingroup ie_transformation_common_api
+ * @brief ConvertPrecision transformation removes StridedSlice operations
+ * with equal input and output shapes.
+ */
+
 class ngraph::pass::ConvertPrecision : public ngraph::pass::FunctionPass {
 public:
     ConvertPrecision(ngraph::element::Type_t from, ngraph::element::Type_t to)

--- a/inference-engine/src/transformations/include/transformations/convert_precision.hpp
+++ b/inference-engine/src/transformations/include/transformations/convert_precision.hpp
@@ -38,7 +38,7 @@ private:
     element::Type m_from, m_to;
 };
 
+bool fuse_type_to_constant(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, const std::vector<ngraph::Input<ngraph::Node>> & consumers);
 bool fuse_type_to_shapeof(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);
-bool fuse_type_to_constant(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);
 bool fuse_type_to_parameter(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);
 bool fuse_type_to_convert(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);

--- a/inference-engine/src/transformations/include/transformations/convert_precision.hpp
+++ b/inference-engine/src/transformations/include/transformations/convert_precision.hpp
@@ -27,8 +27,28 @@ class TRANSFORMATIONS_API ConvertPrecision;
 
 /**
  * @ingroup ie_transformation_common_api
- * @brief ConvertPrecision transformation removes StridedSlice operations
- * with equal input and output shapes.
+ * @brief ConvertPrecision transformation convert precision for entire ngraph::Function
+ * List of supported precision conversion:
+ *    FROM -> TO
+ *      u8 -> i32
+ *     u16 -> i32
+ *     u32 -> i32
+ *     u64 -> i32
+ *     i64 -> i32
+ *     f16 -> f32
+ * For all operations from opset1-opset4 this conversions can be applied without adding Conversion operations.
+ * That is possible because all operations that produces "FROM" type can produce "TO" type. And for this operations
+ * we have created special fuse_type_into_<type> functoin (can be found in cpp file) that performs type fusion
+ * into operation.
+ * List of operations that are supported by this transformations:
+ *     opset4::Parameter
+ *     opset4::Convert
+ *     opset4::ShapeOf
+ *     opset3::NonMaxSuppression
+ *     opset4::NonMaxSuppression
+ *     opset4::TopK
+ *     opset4::NonZero
+ *     opset4::Bucketize
  */
 
 class ngraph::pass::ConvertPrecision : public ngraph::pass::FunctionPass {

--- a/inference-engine/src/transformations/include/transformations/convert_precision.hpp
+++ b/inference-engine/src/transformations/include/transformations/convert_precision.hpp
@@ -1,0 +1,44 @@
+// Copyright (C) 2018-2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <vector>
+#include <memory>
+#include <algorithm>
+
+#include <transformations_visibility.hpp>
+
+#include <ngraph/pass/pass.hpp>
+#include <ngraph/opsets/opset3.hpp>
+#include <ngraph/validation_util.hpp>
+#include <ngraph/rt_info.hpp>
+#include <ngraph/pass/graph_rewrite.hpp>
+
+
+namespace ngraph {
+namespace pass {
+
+class TRANSFORMATIONS_API ConvertPrecision;
+class TRANSFORMATIONS_API FuseShapeOfConvert;
+
+}  // namespace pass
+}  // namespace ngraph
+
+class ngraph::pass::ConvertPrecision : public ngraph::pass::FunctionPass {
+public:
+    ConvertPrecision(ngraph::element::Type_t from, ngraph::element::Type_t to)
+        : FunctionPass(),
+        m_from(from),
+        m_to(to) {}
+
+    bool run_on_function(std::shared_ptr<Function> f) override;
+private:
+    element::Type m_from, m_to;
+};
+
+bool fuse_type_to_shapeof(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);
+bool fuse_type_to_constant(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);
+bool fuse_type_to_parameter(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);
+bool fuse_type_to_convert(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);

--- a/inference-engine/src/transformations/include/transformations/convert_precision.hpp
+++ b/inference-engine/src/transformations/include/transformations/convert_precision.hpp
@@ -37,13 +37,3 @@ public:
 private:
     element::Type m_from, m_to;
 };
-
-bool fuse_type_to_constant(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, const std::vector<ngraph::Input<ngraph::Node>> & consumers);
-bool fuse_type_to_shapeof(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);
-bool fuse_type_to_parameter(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);
-bool fuse_type_to_convert(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);
-bool fuse_type_to_nms3(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);
-bool fuse_type_to_nms4(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);
-bool fuse_type_to_topk(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);
-bool fuse_type_to_nonzero(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);
-bool fuse_type_to_bucketize(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);

--- a/inference-engine/src/transformations/src/ngraph_ops/interp.cpp
+++ b/inference-engine/src/transformations/src/ngraph_ops/interp.cpp
@@ -90,7 +90,7 @@ void op::ResampleV2::validate_and_infer_types() {
         NODE_VALIDATION_CHECK(this, shape_size(const_shape->get_shape()) == 4 || shape_size(const_shape->get_shape()) == 5,
                               "Layer shape must have rank 4 or 5", const_shape->get_shape());
 
-        auto out_shape = static_cast<const int64_t*>(const_shape->get_data_ptr());
+        auto out_shape = const_shape->cast_vector<int64_t>();
         Shape output_shape;
         for (size_t i = 0; i < const_shape->get_shape()[0]; i++) {
             output_shape.push_back((out_shape[i] > 0) ? out_shape[i] : 0);

--- a/inference-engine/src/transformations/src/ngraph_ops/nms_ie.cpp
+++ b/inference-engine/src/transformations/src/ngraph_ops/nms_ie.cpp
@@ -6,7 +6,7 @@
 
 #include <memory>
 
-#include <ngraph/opsets/opset1.hpp>
+#include <ngraph/opsets/opset3.hpp>
 #include <ngraph/opsets/opset4.hpp>
 
 using namespace std;
@@ -20,9 +20,10 @@ op::NonMaxSuppressionIE::NonMaxSuppressionIE(const Output<Node> &boxes,
                                              const Output<Node> &iou_threshold,
                                              const Output<Node> &score_threshold,
                                              int center_point_box,
-                                             bool sort_result_descending)
+                                             bool sort_result_descending,
+                                             const ngraph::element::Type& output_type)
         : Op({boxes, scores, max_output_boxes_per_class, iou_threshold, score_threshold}),
-          m_center_point_box(center_point_box), m_sort_result_descending(sort_result_descending) {
+          m_center_point_box(center_point_box), m_sort_result_descending(sort_result_descending), m_output_type(output_type) {
     constructor_validate_and_infer_types();
 }
 
@@ -30,28 +31,32 @@ op::NonMaxSuppressionIE::NonMaxSuppressionIE(const Output<Node> &boxes,
 std::shared_ptr<Node> op::NonMaxSuppressionIE::clone_with_new_inputs(const ngraph::OutputVector &new_args) const {
     check_new_args_count(this, new_args);
     return make_shared<NonMaxSuppressionIE>(new_args.at(0), new_args.at(1), new_args.at(2), new_args.at(3),
-                                            new_args.at(4), m_center_point_box, m_sort_result_descending);
+                                            new_args.at(4), m_center_point_box, m_sort_result_descending, m_output_type);
 }
 
 void op::NonMaxSuppressionIE::validate_and_infer_types() {
     auto squeeze_input = [](const Output<Node> &input) -> std::shared_ptr<Node> {
-        return std::make_shared<opset1::Squeeze>(input, opset1::Constant::create(element::i64, Shape{1}, {0}));
+        return std::make_shared<opset3::Squeeze>(input, opset3::Constant::create(element::i64, Shape{1}, {0}));
     };
 
-    // Calculate output shape using opset1::NonMaxSuppression
-    auto max_output_boxes_per_class = std::dynamic_pointer_cast<opset1::Constant>(input_value(2).get_node_shared_ptr());
-    auto nms = std::make_shared<opset1::NonMaxSuppression>(input_value(0), input_value(1),
+    // Calculate output shape using opset3::NonMaxSuppression
+    auto max_output_boxes_per_class = std::dynamic_pointer_cast<opset3::Constant>(input_value(2).get_node_shared_ptr());
+    auto nms = std::make_shared<opset3::NonMaxSuppression>(input_value(0), input_value(1),
             /* second input is used for output calculation and only if it's Constant output shape won't be dynamic */
-                                                           max_output_boxes_per_class ? opset1::Constant::create(element::i64, Shape{},
-                                                                   max_output_boxes_per_class->cast_vector<int64_t>())
-                                                                                      : squeeze_input(input_value(2)),
-                                                           squeeze_input(input_value(3)), squeeze_input(input_value(4)));
+                                                           max_output_boxes_per_class ? opset3::Constant::create(element::i64, Shape{},
+                                                                   max_output_boxes_per_class->cast_vector<int64_t>()) : squeeze_input(input_value(2)),
+                                                           squeeze_input(input_value(3)),
+                                                           squeeze_input(input_value(4)),
+                                                           opset3::NonMaxSuppression::BoxEncodingType::CENTER,
+                                                           m_sort_result_descending,
+                                                           m_output_type);
     set_output_type(0, nms->output(0).get_element_type(), nms->output(0).get_partial_shape());
 }
 
 bool op::NonMaxSuppressionIE::visit_attributes(AttributeVisitor& visitor) {
     visitor.on_attribute("center_point_box", m_center_point_box);
     visitor.on_attribute("sort_result_descending", m_sort_result_descending);
+    visitor.on_attribute("output_type", m_output_type);
     return true;
 }
 
@@ -64,8 +69,10 @@ op::NonMaxSuppressionIE2::NonMaxSuppressionIE2(const Output<Node> &boxes,
                                                const Output<Node> &iou_threshold,
                                                const Output<Node> &score_threshold,
                                                int center_point_box,
-                                               bool sort_result_descending)
-        : op::NonMaxSuppressionIE(boxes, scores, max_output_boxes_per_class, iou_threshold, score_threshold, center_point_box, sort_result_descending) {
+                                               bool sort_result_descending,
+                                               const ngraph::element::Type& output_type)
+        : op::NonMaxSuppressionIE(boxes, scores, max_output_boxes_per_class, iou_threshold, score_threshold, center_point_box, sort_result_descending,
+                                  output_type) {
     constructor_validate_and_infer_types();
 }
 
@@ -73,21 +80,24 @@ op::NonMaxSuppressionIE2::NonMaxSuppressionIE2(const Output<Node> &boxes,
 std::shared_ptr<Node> op::NonMaxSuppressionIE2::clone_with_new_inputs(const ngraph::OutputVector &new_args) const {
     check_new_args_count(this, new_args);
     return make_shared<NonMaxSuppressionIE2>(new_args.at(0), new_args.at(1), new_args.at(2), new_args.at(3),
-                                             new_args.at(4), m_center_point_box, m_sort_result_descending);
+                                             new_args.at(4), m_center_point_box, m_sort_result_descending, m_output_type);
 }
 
 void op::NonMaxSuppressionIE2::validate_and_infer_types() {
     auto squeeze_input = [](const Output<Node> &input) -> std::shared_ptr<Node> {
-        return std::make_shared<opset1::Squeeze>(input, opset1::Constant::create(element::i64, Shape{1}, {0}));
+        return std::make_shared<opset4::Squeeze>(input, opset4::Constant::create(element::i64, Shape{1}, {0}));
     };
 
     // Calculate output shape using opset4::NonMaxSuppression
-    auto max_output_boxes_per_class = std::dynamic_pointer_cast<opset1::Constant>(input_value(2).get_node_shared_ptr());
+    auto max_output_boxes_per_class = std::dynamic_pointer_cast<opset4::Constant>(input_value(2).get_node_shared_ptr());
     auto nms = std::make_shared<opset4::NonMaxSuppression>(input_value(0), input_value(1),
             /* second input is used for output calculation and only if it's Constant output shape won't be dynamic */
-                                                           max_output_boxes_per_class ? opset1::Constant::create(element::i64, Shape{},
-                                                                   max_output_boxes_per_class->cast_vector<int64_t>())
-                                                                                      : squeeze_input(input_value(2)), squeeze_input(input_value(3)),
-                                                           squeeze_input(input_value(4)));
+                                                           max_output_boxes_per_class ? opset4::Constant::create(element::i64, Shape{},
+                                                                   max_output_boxes_per_class->cast_vector<int64_t>()) : squeeze_input(input_value(2)),
+                                                           squeeze_input(input_value(3)),
+                                                           squeeze_input(input_value(4)),
+                                                           opset4::NonMaxSuppression::BoxEncodingType::CENTER,
+                                                           m_sort_result_descending,
+                                                           m_output_type);
     set_output_type(0, nms->output(0).get_element_type(), nms->output(0).get_partial_shape());
 }

--- a/inference-engine/src/transformations/src/ngraph_ops/topk_ie.cpp
+++ b/inference-engine/src/transformations/src/ngraph_ops/topk_ie.cpp
@@ -15,14 +15,14 @@ constexpr NodeTypeInfo op::TopKIE::type_info;
 
 
 op::TopKIE::TopKIE(const ngraph::Output<ngraph::Node> &data, const ngraph::Output<ngraph::Node> &k, const int64_t axis, const ngraph::op::TopKMode mode,
-                   const ngraph::op::TopKSortType sort)
-    : Op({data, k}), m_axis(axis), m_mode(mode), m_sort_type(sort) {
+                   const ngraph::op::TopKSortType sort, const element::Type& index_element_type)
+    : Op({data, k}), m_axis(axis), m_mode(mode), m_sort_type(sort), m_index_element_type(index_element_type) {
     constructor_validate_and_infer_types();
 }
 
 std::shared_ptr<Node> op::TopKIE::clone_with_new_inputs(const ngraph::OutputVector &new_args) const {
     check_new_args_count(this, new_args);
-    return make_shared<TopKIE>(new_args.at(0), new_args.at(1), m_axis, m_mode, m_sort_type);
+    return make_shared<TopKIE>(new_args.at(0), new_args.at(1), m_axis, m_mode, m_sort_type, m_index_element_type);
 }
 
 void op::TopKIE::validate_and_infer_types() {
@@ -43,14 +43,14 @@ void op::TopKIE::validate_and_infer_types() {
         const auto k = k_const->cast_vector<int64_t>();
         topk = std::make_shared<opset1::TopK>(input_value(0),
                                               opset1::Constant::create(element::i64, Shape{}, k),
-                                              m_axis, m_mode, m_sort_type);
+                                              m_axis, m_mode, m_sort_type, m_index_element_type);
     } else {
         topk = std::make_shared<opset1::TopK>(input_value(0),
                                               std::make_shared<opset1::Squeeze>(input_value(1), opset1::Constant::create(element::i64, Shape{1}, {0})),
-                                              m_axis, m_mode, m_sort_type);
+                                              m_axis, m_mode, m_sort_type, m_index_element_type);
     }
 
     set_output_size(2);
-    set_output_type(0, get_input_element_type(0), topk->get_output_partial_shape(0));
-    set_output_type(1, element::i32, topk->get_output_partial_shape(1));
+    set_output_type(0, topk->get_output_element_type(0), topk->get_output_partial_shape(0));
+    set_output_type(1, topk->get_output_element_type(1), topk->get_output_partial_shape(1));
 }

--- a/inference-engine/src/transformations/src/transformations/apply_transformations_to_ti_body.cpp
+++ b/inference-engine/src/transformations/src/transformations/apply_transformations_to_ti_body.cpp
@@ -1,0 +1,29 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/apply_transformations_to_ti_body.hpp"
+#include "transformations/utils/utils.hpp"
+
+#include <memory>
+#include <vector>
+
+#include <ngraph/opsets/opset4.hpp>
+#include <ngraph/pattern/op/wrap_type.hpp>
+
+ngraph::pass::ApplyTransformationsToTIBody::ApplyTransformationsToTIBody(ngraph::pass::Manager & manager) : MatcherPass() {
+    auto tensor_iterator = ngraph::pattern::wrap_type<ngraph::opset4::TensorIterator>();
+
+    ngraph::matcher_pass_callback callback = [this, &manager](pattern::Matcher& m) {
+        auto ti = std::dynamic_pointer_cast<ngraph::opset4::TensorIterator>(m.get_match_root());
+        if (!ti) {
+            return false;
+        }
+
+        manager.run_passes(ti->get_body()->to_function());
+        return true;
+    };
+
+    auto m = std::make_shared<ngraph::pattern::Matcher>(tensor_iterator, "ApplyTransformationsToTIBody");
+    register_matcher(m, callback);
+}

--- a/inference-engine/src/transformations/src/transformations/convert_broadcast_to_tiles.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_broadcast_to_tiles.cpp
@@ -26,7 +26,7 @@ ngraph::pass::ConvertBroadcastToTiles::ConvertBroadcastToTiles() {
         auto axes_node = std::dynamic_pointer_cast<ngraph::opset1::Constant>(broadcast->input_value(2).get_node_shared_ptr());
         if (!data_node || !shape_node || !axes_node) return false;
 
-        auto output_shape = shape_node->get_vector<int64_t>();
+        auto output_shape = shape_node->cast_vector<int64_t>();
         auto input_shape = data_node->get_shape();
         int64_t cur_dim_id = output_shape.size() - 1;
         size_t dims_count = output_shape.size();
@@ -48,7 +48,7 @@ ngraph::pass::ConvertBroadcastToTiles::ConvertBroadcastToTiles() {
                     shape.insert(shape.begin(), 1);
                 }
             } else if (broadcast_type == op::AutoBroadcastType::NONE) {
-                auto axes = axes_node->get_vector<int64_t>();
+                auto axes = axes_node->cast_vector<int64_t>();
                 shape.assign(output_shape.size(), 1);
                 for (size_t i = 0; i < input_shape.size(); ++i) {
                     shape[axes[i]] = input_shape[i];

--- a/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_interpolate_to_interp_or_resample.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_interpolate_to_interp_or_resample.cpp
@@ -34,7 +34,7 @@ ngraph::pass::ConvertInterpolateToInterpOrResampleMatcher::ConvertInterpolateToI
             return false;
         }
 
-        auto out_spatial_shape = out_shape_node->get_vector<int64_t> ();
+        auto out_spatial_shape = out_shape_node->cast_vector<int64_t> ();
 
         std::size_t num_of_spatial_vars = input_shape.size() - 2;
         auto interpolate_axes = interpolate_attrs.axes;

--- a/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_lrn_to_lrn_ie.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_lrn_to_lrn_ie.cpp
@@ -29,7 +29,7 @@ ngraph::pass::ConvertLRNToLegacyMatcher::ConvertLRNToLegacyMatcher() {
             return false;
         }
 
-        auto axis_value = axis_const->get_vector<int64_t>();
+        auto axis_value = axis_const->cast_vector<int64_t>();
         std::string region;
         if (axis_value.size() == 1 && axis_value[0] == 1) {
             region = "across";

--- a/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_nms_4_to_legacy.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_nms_4_to_legacy.cpp
@@ -96,21 +96,13 @@ ngraph::pass::ConvertNMS4ToLegacyMatcher::ConvertNMS4ToLegacyMatcher() {
                 new_iou_threshold,
                 new_score_threshold,
                 center_point_box,
-                nms_4->get_sort_result_descending());
+                nms_4->get_sort_result_descending(),
+                nms_4->get_output_type());
         new_ops.push_back(nms_legacy);
 
-        Output<Node> last;
-        // if the output is the i32 then it matches behavior of the v1::NonMaxSuppression otherwise need to insert Convert
-        if (nms_4->get_output_type() == element::i32) {
-            last = nms_legacy;
-        } else {
-            last = std::make_shared<ngraph::opset4::Convert>(nms_legacy, nms_4->get_output_type());
-            new_ops.push_back(last.get_node_shared_ptr());
-        }
-
-        last.get_node_shared_ptr()->set_friendly_name(nms_4->get_friendly_name());
+        nms_legacy->set_friendly_name(nms_4->get_friendly_name());
         ngraph::copy_runtime_info(nms_4, new_ops);
-        ngraph::replace_node(nms_4, last.get_node_shared_ptr());
+        ngraph::replace_node(nms_4, nms_legacy);
         return true;
     };
 

--- a/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_nms_to_nms_ie.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_nms_to_nms_ie.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <vector>
 
+#include <ngraph/opsets/opset3.hpp>
 #include <ngraph/opsets/opset1.hpp>
 
 #include <ngraph_ops/nms_ie.hpp>
@@ -14,10 +15,10 @@
 #include <ngraph/pattern/op/wrap_type.hpp>
 
 ngraph::pass::ConvertNMSToNMSIEMatcher::ConvertNMSToNMSIEMatcher() {
-    auto nms = ngraph::pattern::wrap_type<opset1::NonMaxSuppression>();
+    auto nms = ngraph::pattern::wrap_type<opset3::NonMaxSuppression>();
 
     ngraph::matcher_pass_callback callback = [](pattern::Matcher &m) {
-        auto nms = std::dynamic_pointer_cast<opset1::NonMaxSuppression>(m.get_match_root());
+        auto nms = std::dynamic_pointer_cast<opset3::NonMaxSuppression>(m.get_match_root());
         if (!nms) {
             return false;
         }
@@ -71,10 +72,10 @@ ngraph::pass::ConvertNMSToNMSIEMatcher::ConvertNMSToNMSIEMatcher() {
         }
         int center_point_box = 0;
         switch (nms->get_box_encoding()) {
-            case ::ngraph::opset1::NonMaxSuppression::BoxEncodingType::CENTER:
+            case ::ngraph::opset3::NonMaxSuppression::BoxEncodingType::CENTER:
                 center_point_box = 1;
                 break;
-            case ::ngraph::opset1::NonMaxSuppression::BoxEncodingType::CORNER:
+            case ::ngraph::opset3::NonMaxSuppression::BoxEncodingType::CORNER:
                 center_point_box = 0;
                 break;
             default:
@@ -87,7 +88,8 @@ ngraph::pass::ConvertNMSToNMSIEMatcher::ConvertNMSToNMSIEMatcher() {
                                                                          new_iou_threshold,
                                                                          new_score_threshold,
                                                                          center_point_box,
-                                                                         nms->get_sort_result_descending());
+                                                                         nms->get_sort_result_descending(),
+                                                                         nms->get_output_type());
         new_ops.push_back(new_nms);
         new_nms->set_friendly_name(nms->get_friendly_name());
         ngraph::copy_runtime_info(nms, new_ops);

--- a/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_normalizel2_to_normalize_ie.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_normalizel2_to_normalize_ie.cpp
@@ -52,7 +52,7 @@ ngraph::pass::ConvertNormalizeL2WithMulToNormalizeIE::ConvertNormalizeL2WithMulT
 
         //  Replace NormalizeL2 with NormalizeIE operation
 
-        auto axis = const_axis->get_vector<size_t>();
+        auto axis = const_axis->cast_vector<size_t>();
         bool across_spatial = !(axis.size() == 1 && axis[0] == 1);
         bool channel_shared = (constant->get_shape().size() == 1);
 
@@ -85,7 +85,7 @@ ngraph::pass::ConvertNormalizeL2ToLegacyMatcher::ConvertNormalizeL2ToLegacyMatch
         if (!const_axis) return false;
 
         //  Replace NormalizeL2 with NormalizeIE operation
-        auto axis = const_axis->get_vector<size_t>();
+        auto axis = const_axis->cast_vector<size_t>();
         bool across_channels = !(axis.size() == 1 && axis[0] == 1);
         bool channel_shared = true;
 

--- a/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_tile_to_ie_tile.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_tile_to_ie_tile.cpp
@@ -27,7 +27,7 @@ ngraph::pass::ConvertTileToLegacyMatcher::ConvertTileToLegacyMatcher() {
         auto tiles_node = std::dynamic_pointer_cast<ngraph::opset1::Constant> (tile->input_value(1).get_node_shared_ptr());
         if (!data_node || !tiles_node) return false;
 
-        auto tiles = tiles_node->get_vector<int64_t>();
+        auto tiles = tiles_node->cast_vector<int64_t>();
         auto input_shape = data_node->get_shape();
         int64_t cur_dim_id = tiles.size() - 1;
 

--- a/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_topk_to_topk_ie.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_topk_to_topk_ie.cpp
@@ -40,7 +40,7 @@ ngraph::pass::ConvertTopKToTopKIEMatcher::ConvertTopKToTopKIEMatcher() {
         }
 
         auto topk_ie = std::make_shared<ngraph::op::TopKIE>(topk->input_value(0), unsqueezed_k, topk->get_axis(), topk->get_mode(),
-                                                             topk->get_sort_type());
+                                                            topk->get_sort_type(), topk->get_index_element_type());
         new_ops.push_back(topk_ie);
 
         Output<Node> element_output;

--- a/inference-engine/src/transformations/src/transformations/convert_opset3_to_opset2/convert_nms3.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_opset3_to_opset2/convert_nms3.cpp
@@ -12,44 +12,32 @@
 #include <ngraph/opsets/opset3.hpp>
 #include <ngraph/rt_info.hpp>
 
-void ngraph::pass::ConvertNMS3::convert_nms3() {
+void ngraph::pass::ConvertNMS1ToNMS3::convert_nms1_to_nms3() {
     auto boxes = std::make_shared<pattern::op::Label>(element::f32, Shape{1, 1000, 4});
     auto scores = std::make_shared<pattern::op::Label>(element::f32, Shape{1, 1, 1000});
     auto max_output_boxes_per_class = ngraph::opset3::Constant::create(element::i64, Shape{}, {10});
     auto iou_threshold = ngraph::opset3::Constant::create(element::f32, Shape{}, {0.75});
     auto score_threshold = ngraph::opset3::Constant::create(element::f32, Shape{}, {0.7});
-    auto nms = std::make_shared<ngraph::opset3::NonMaxSuppression>(boxes, scores, max_output_boxes_per_class,
+    auto nms = std::make_shared<ngraph::opset1::NonMaxSuppression>(boxes, scores, max_output_boxes_per_class,
                                                                    iou_threshold, score_threshold);
 
     ngraph::graph_rewrite_callback callback = [](pattern::Matcher &m) {
-        auto nms = std::dynamic_pointer_cast<ngraph::opset3::NonMaxSuppression>(m.get_match_root());
+        auto nms = std::dynamic_pointer_cast<ngraph::opset1::NonMaxSuppression>(m.get_match_root());
         if (!nms) {
             return false;
         }
 
-        Output<Node> last;
-        ngraph::NodeVector new_ops;
-
-        auto new_nms = std::make_shared<ngraph::opset2::NonMaxSuppression>(nms->input_value(0), nms->input_value(1),
+        auto nms3 = std::make_shared<ngraph::opset3::NonMaxSuppression>(nms->input_value(0), nms->input_value(1),
                 nms->input_value(2), nms->input_value(3), nms->input_value(4),
-                static_cast<const op::v1::NonMaxSuppression::BoxEncodingType>(nms->get_box_encoding()),
+                static_cast<const op::v3::NonMaxSuppression::BoxEncodingType>(nms->get_box_encoding()),
                 nms->get_sort_result_descending());
 
-        new_ops.push_back(new_nms);
-        // if the output is the i32 then it matches behavior of the v1::NonMaxSuppression otherwise need to insert Convert
-        if (nms->get_output_type() == element::i32) {
-            last = new_nms;
-        } else {
-            last = std::make_shared<ngraph::opset2::Convert>(new_nms, nms->get_output_type());
-            new_ops.push_back(last.get_node_shared_ptr());
-        }
-
-        last.get_node_shared_ptr()->set_friendly_name(nms->get_friendly_name());
-        ngraph::copy_runtime_info(nms, new_ops);
-        ngraph::replace_node(nms, last.get_node_shared_ptr());
+        nms3->set_friendly_name(nms->get_friendly_name());
+        ngraph::copy_runtime_info(nms, nms3);
+        ngraph::replace_node(nms, nms3);
         return true;
     };
 
-    auto m = std::make_shared<ngraph::pattern::Matcher>(nms, "ConvertNMS3");
+    auto m = std::make_shared<ngraph::pattern::Matcher>(nms, "ConvertNMS1ToNMS3");
     this->add_matcher(m, callback, PassProperty::CHANGE_DYNAMIC_STATE);
 }

--- a/inference-engine/src/transformations/src/transformations/convert_opset3_to_opset2/convert_opset3_to_opset2.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_opset3_to_opset2/convert_opset3_to_opset2.cpp
@@ -22,7 +22,7 @@ bool ngraph::pass::ConvertOpSet3ToOpSet2::run_on_function(std::shared_ptr<ngraph
     ngraph::pass::Manager manager;
 
     manager.register_pass<ngraph::pass::ConvertBroadcast3>();
-    manager.register_pass<ngraph::pass::ConvertNMS3>();
+    manager.register_pass<ngraph::pass::ConvertNMS1ToNMS3>();
     manager.register_pass<ngraph::pass::ConvertShapeOf3>();
     manager.register_pass<ngraph::pass::ConvertShuffleChannels3>();
     manager.register_pass<ngraph::pass::ConvertTopK3>();

--- a/inference-engine/src/transformations/src/transformations/convert_precision.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_precision.cpp
@@ -44,6 +44,7 @@ bool ngraph::pass::ConvertPrecision::run_on_function(std::shared_ptr<ngraph::Fun
         for (auto &output : node->outputs()) {
         }
     }
+    return true;
 }
 
 bool fuse_type_to_shapeof(std::shared_ptr<Node> node, element::Type to, size_t idx) {

--- a/inference-engine/src/transformations/src/transformations/convert_precision.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_precision.cpp
@@ -55,6 +55,7 @@ bool ngraph::pass::ConvertPrecision::run_on_function(std::shared_ptr<ngraph::Fun
                 // If node type in map and convert can be fused into node we skip Convert creation
                 if (type_to_fuse.count(node->get_type_info()) &&
                     type_to_fuse.at(node->get_type_info())(node, m_to, output.get_index())) {
+                    node->validate_and_infer_types();
                     continue;
                 }
 
@@ -82,7 +83,6 @@ bool fuse_type_to_shapeof(std::shared_ptr<Node> node, element::Type to, size_t i
     if (auto shapeof = as_type_ptr<opset3::ShapeOf>(node)) {
         if (to == element::i32 || to == element::i64) {
             shapeof->set_output_type(to);
-            shapeof->validate_and_infer_types();
             return true;
         }
     }
@@ -92,7 +92,6 @@ bool fuse_type_to_shapeof(std::shared_ptr<Node> node, element::Type to, size_t i
 bool fuse_type_to_parameter(std::shared_ptr<Node> node, element::Type to, size_t idx) {
     if (auto param = as_type_ptr<opset3::Parameter>(node)) {
         param->set_element_type(to);
-        node->validate_and_infer_types();
         return true;
     }
     return false;
@@ -101,7 +100,6 @@ bool fuse_type_to_parameter(std::shared_ptr<Node> node, element::Type to, size_t
 bool fuse_type_to_convert(std::shared_ptr<Node> node, element::Type to, size_t idx) {
     if (auto convert = as_type_ptr<opset3::Convert>(node)) {
         convert->set_convert_element_type(to);
-        convert->validate_and_infer_types();
         return true;
     }
     return false;
@@ -110,7 +108,6 @@ bool fuse_type_to_convert(std::shared_ptr<Node> node, element::Type to, size_t i
 bool fuse_type_to_nms3(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx) {
     if (auto nms = as_type_ptr<opset3::NonMaxSuppression>(node)) {
         nms->set_output_type(to);
-        nms->validate_and_infer_types();
         return true;
     }
     return false;
@@ -119,7 +116,6 @@ bool fuse_type_to_nms3(std::shared_ptr<ngraph::Node> node, ngraph::element::Type
 bool fuse_type_to_nms4(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx) {
     if (auto nms = as_type_ptr<opset4::NonMaxSuppression>(node)) {
         nms->set_output_type(to);
-        nms->validate_and_infer_types();
         return true;
     }
     return false;
@@ -129,7 +125,6 @@ bool fuse_type_to_topk(std::shared_ptr<ngraph::Node> node, ngraph::element::Type
     if (auto topk = as_type_ptr<opset4::TopK>(node)) {
         if (idx == 1 && (to == element::i32 || to == element::i64)) {
             topk->set_index_element_type(to);
-            topk->validate_and_infer_types();
             return true;
         }
     }
@@ -140,7 +135,6 @@ bool fuse_type_to_nonzero(std::shared_ptr<ngraph::Node> node, ngraph::element::T
     if (auto nonzero = as_type_ptr<opset4::NonZero>(node)) {
         if (to == element::i32 || to == element::i64) {
             nonzero->set_output_type(to);
-            nonzero->validate_and_infer_types();
             return true;
         }
     }
@@ -151,7 +145,6 @@ bool fuse_type_to_bucketize(std::shared_ptr<ngraph::Node> node, ngraph::element:
     if (auto b = as_type_ptr<opset4::Bucketize>(node)) {
         if (to == element::i32 || to == element::i64) {
             b->set_output_type(to);
-            b->validate_and_infer_types();
             return true;
         }
     }

--- a/inference-engine/src/transformations/src/transformations/convert_precision.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_precision.cpp
@@ -13,6 +13,16 @@
 
 using namespace ngraph;
 
+bool fuse_type_to_constant(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, const std::vector<ngraph::Input<ngraph::Node>> & consumers);
+bool fuse_type_to_shapeof(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);
+bool fuse_type_to_parameter(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);
+bool fuse_type_to_convert(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);
+bool fuse_type_to_nms3(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);
+bool fuse_type_to_nms4(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);
+bool fuse_type_to_topk(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);
+bool fuse_type_to_nonzero(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);
+bool fuse_type_to_bucketize(std::shared_ptr<ngraph::Node> node, ngraph::element::Type to, size_t idx);
+
 static std::map<ngraph::NodeTypeInfo, std::function<bool(std::shared_ptr<Node>, element::Type, size_t idx)>> type_to_fuse {
         {opset3::Parameter::type_info, fuse_type_to_parameter},
         {opset3::Convert::type_info, fuse_type_to_convert},

--- a/inference-engine/src/transformations/src/transformations/convert_precision.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_precision.cpp
@@ -1,0 +1,108 @@
+// Copyright (C) 2018-2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/convert_precision.hpp"
+
+#include <memory>
+#include <vector>
+
+#include <ngraph/opsets/opset3.hpp>
+
+using namespace ngraph;
+
+bool ngraph::pass::ConvertPrecision::run_on_function(std::shared_ptr<ngraph::Function> f) {
+    static std::map<ngraph::NodeTypeInfo, std::function<bool(std::shared_ptr<Node>, element::Type, size_t idx)>> type_to_fuse {
+        {opset3::ShapeOf::type_info, fuse_type_to_shapeof},
+        {opset3::Convert::type_info, fuse_type_to_convert},
+        {opset3::Constant::type_info, fuse_type_to_constant},
+        {opset3::Parameter::type_info, fuse_type_to_parameter},
+    };
+    // TODO: add nodes from body
+    for (auto &node : f->get_ordered_ops()) {
+        node->validate_and_infer_types();
+
+        for (auto output : node->outputs()) {
+            if (output.get_element_type() == m_from) {
+                // If node type in map and convert can be fused into node we skip Convert creation
+                if (type_to_fuse.count(node->get_type_info()) &&
+                    type_to_fuse.at(node->get_type_info())(node, m_to, output.get_index())) {
+                    continue;
+                }
+                // Create Convert operation and reconnect consumers
+                auto consumers = output.get_target_inputs();
+                auto convert = std::make_shared<opset3::Convert>(output, m_to);
+                for (auto & input : consumers) {
+                    input.replace_source_output(convert);
+                }
+            }
+        }
+    }
+
+    // Check that function has no more operations with output type equal to m_to
+    for (auto &node : f->get_ordered_ops()) {
+        for (auto &output : node->outputs()) {
+        }
+    }
+}
+
+bool fuse_type_to_shapeof(std::shared_ptr<Node> node, element::Type to, size_t idx) {
+    if (auto shapeof = as_type_ptr<opset3::ShapeOf>(node)) {
+        if (to == element::i32 || to == element::i64) {
+            shapeof->set_output_type(to);
+            return true;
+        }
+    }
+    return false;
+}
+
+bool fuse_type_to_parameter(std::shared_ptr<Node> node, element::Type to, size_t idx) {
+    if (auto param = as_type_ptr<opset3::Parameter>(node)) {
+        param->set_element_type(to);
+    }
+    return false;
+}
+
+bool fuse_type_to_convert(std::shared_ptr<Node> node, element::Type to, size_t idx) {
+    if (auto convert = as_type_ptr<opset3::Convert>(node)) {
+        convert->set_convert_element_type(to);
+    }
+    return false;
+}
+
+template <element::Type_t PREC_FROM, element::Type_t PREC_TO>
+std::shared_ptr<Node> change_constant_precision(std::shared_ptr<opset3::Constant> constant) {
+    using src_type = typename element_type_traits<PREC_FROM>::value_type;
+    using dst_type = typename element_type_traits<PREC_TO>::value_type;
+    return std::make_shared<ngraph::opset3::Constant>(PREC_TO, constant->get_shape(), constant->cast_vector<dst_type>());
+}
+
+bool fuse_type_to_constant(std::shared_ptr<Node> node, element::Type to, size_t idx) {
+    if (auto constant = as_type_ptr<opset3::Constant>(node)) {
+        auto from = constant->get_element_type();
+        std::shared_ptr<Node> new_const;
+        if (from == element::u64 && to == element::i32) {
+            new_const = change_constant_precision<element::Type_t::u64, element::Type_t::i32>(constant);
+        } else if (from == element::i64 && to == element::i32) {
+            new_const = change_constant_precision<element::Type_t::i64, element::Type_t::i32>(constant);
+        } else if (from == element::u8 && to == element::i32) {
+            new_const = change_constant_precision<element::Type_t::u8, element::Type_t::i32>(constant);
+        } else if (from == element::u16 && to == element::i32) {
+            new_const = change_constant_precision<element::Type_t::u16, element::Type_t::i32>(constant);
+        } else if (from == element::u32 && to == element::i32) {
+            new_const = change_constant_precision<element::Type_t::u32, element::Type_t::i32>(constant);
+        } else if (from == element::f16 && to == element::f32) {
+            new_const = change_constant_precision<element::Type_t::f16, element::Type_t::f32>(constant);
+        } else if (from == element::boolean && to == element::u8) {
+            new_const = change_constant_precision<element::Type_t::boolean, element::Type_t::u8>(constant);
+        } else if (from == element::boolean && to == element::i32) {
+            new_const = change_constant_precision<element::Type_t::boolean, element::Type_t::i32>(constant);
+        } else {
+            throw ngraph_error("not supported");
+        }
+        replace_node(constant, new_const);
+    }
+    return false;
+}
+
+

--- a/inference-engine/src/transformations/src/transformations/convert_precision.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_precision.cpp
@@ -94,6 +94,7 @@ bool ngraph::pass::ConvertPrecision::run_on_function(std::shared_ptr<ngraph::Fun
 
     convert_function_precision(f);
 
+    // TODO: we need to split NopElimination pass to separate MatcherPasses and call Convert elimination here
     for (auto &node : f->get_ordered_ops()) {
         if (auto convert = std::dynamic_pointer_cast<opset4::Convert>(node)) {
             if (convert->input(0).get_element_type() == convert->get_convert_element_type()) {

--- a/inference-engine/src/vpu/common/include/vpu/ngraph/transformations/dynamic_to_static_shape.hpp
+++ b/inference-engine/src/vpu/common/include/vpu/ngraph/transformations/dynamic_to_static_shape.hpp
@@ -18,6 +18,8 @@ public:
     explicit DynamicToStaticShape(const Transformations& specificTransformations = {});
     bool run_on_function(std::shared_ptr<ngraph::Function> function) override;
 
+    // Keep this method for backward compatibility with other plugins
+    void transform(std::shared_ptr<ngraph::Function> function) { run_on_function(std::move(function)); }
 private:
     Transformations transformations;
 };

--- a/inference-engine/src/vpu/common/include/vpu/ngraph/transformations/dynamic_to_static_shape.hpp
+++ b/inference-engine/src/vpu/common/include/vpu/ngraph/transformations/dynamic_to_static_shape.hpp
@@ -13,10 +13,10 @@ namespace vpu {
 
 using Transformations = std::unordered_map<ngraph::NodeTypeInfo, std::function<void(std::shared_ptr<ngraph::Node>)>>;
 
-class DynamicToStaticShape {
+class DynamicToStaticShape: public ngraph::pass::FunctionPass {
 public:
     explicit DynamicToStaticShape(const Transformations& specificTransformations = {});
-    void transform(std::shared_ptr<ngraph::Function> function) const;
+    bool run_on_function(std::shared_ptr<ngraph::Function> function) override;
 
 private:
     Transformations transformations;

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape.cpp
@@ -117,7 +117,7 @@ DynamicToStaticShape::DynamicToStaticShape(const Transformations& specificTransf
     transformations.emplace(ngraph::opset3::Result::type_info, [](const std::shared_ptr<ngraph::Node>&){});
 }
 
-void DynamicToStaticShape::transform(std::shared_ptr<ngraph::Function> function) const {
+bool DynamicToStaticShape::run_on_function(std::shared_ptr<ngraph::Function> function) {
     for (const auto& operation : function->get_ordered_ops()) {
         if (!isDynamic(*operation)) {
             continue;

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape.cpp
@@ -118,6 +118,7 @@ DynamicToStaticShape::DynamicToStaticShape(const Transformations& specificTransf
 }
 
 bool DynamicToStaticShape::run_on_function(std::shared_ptr<ngraph::Function> function) {
+    bool function_changed = false;
     for (const auto& operation : function->get_ordered_ops()) {
         if (!isDynamic(*operation)) {
             continue;
@@ -129,10 +130,12 @@ bool DynamicToStaticShape::run_on_function(std::shared_ptr<ngraph::Function> fun
             "DynamicToStaticShape transformation encountered dynamic node {} of type {}, but only {} types are supported for dynamic nodes",
             operation->get_friendly_name(), type, getSupportedTypes(transformations));
         transformation->second(operation);
+        function_changed = true;
     }
 
     function->validate_nodes_and_infer_types();
     validateStaticShapes(*function);
+    return function_changed;
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/frontend/frontend.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/frontend/frontend.cpp
@@ -22,6 +22,7 @@
 #include <convert_function_to_cnn_network.hpp>
 #include <generic_ie.hpp>
 #include <ngraph/opsets/opset3.hpp>
+#include <transformations/apply_transformations_to_ti_body.hpp>
 #include <transformations/convert_opset3_to_opset2/convert_opset3_to_opset2.hpp>
 #include <transformations/convert_opset2_to_opset1/convert_opset2_to_opset1.hpp>
 #include <transformations/convert_opset1_to_legacy/convert_opset1_to_legacy.hpp>
@@ -397,6 +398,10 @@ ModelPtr FrontEnd::runCommonPasses(ie::ICNNNetwork& network, const UnsupportedLa
             manager.register_pass<ngraph::pass::ConvertOpSet1ToLegacy>();
             manager.set_callback(transformationsPredicate);
             manager.run_passes(nGraphFunc);
+
+            ngraph::pass::Manager ti_manager;
+            ti_manager.register_pass<ngraph::pass::ApplyTransformationsToTIBody>(manager);
+            ti_manager.run_passes(nGraphFunc);
 
             vpu::MergeSubsequentDSROperations().run_on_function(nGraphFunc);
 

--- a/inference-engine/src/vpu/myriad_plugin/myriad_plugin.cpp
+++ b/inference-engine/src/vpu/myriad_plugin/myriad_plugin.cpp
@@ -17,6 +17,7 @@
 #include <vpu/parsed_config.hpp>
 #include <vpu/utils/profiling.hpp>
 #include <vpu/utils/error.hpp>
+#include <transformations/apply_transformations_to_ti_body.hpp>
 #include <transformations/common_optimizations/common_optimizations.hpp>
 #include <vpu/ngraph/transformations/convert_nms_4_to_nms_dynamic.hpp>
 
@@ -43,10 +44,16 @@ ExecutableNetworkInternal::Ptr Engine::LoadExeNetworkImpl(
     auto clonedNetwork = cloneNetwork(network);
     if (auto function = clonedNetwork->getFunction()) {
         ngraph::op::GenericIE::DisableReshape noReshape(function);
-        vpu::UpgradeNMS4ToNMSDynamic().run_on_function(function);
-        ngraph::pass::CommonOptimizations().run_on_function(function);
-        vpu::DynamicToStaticShape().transform(function);
-        vpu::EliminateShapeOfAfterDSR().run_on_function(function);
+        ngraph::pass::Manager manager;
+        manager.register_pass<vpu::UpgradeNMS4ToNMSDynamic>();
+        manager.register_pass<ngraph::pass::CommonOptimizations>();
+        manager.register_pass<vpu::DynamicToStaticShape>();
+        manager.register_pass<vpu::EliminateShapeOfAfterDSR>();
+        manager.run_passes(function);
+
+        ngraph::pass::Manager ti_manager;
+        ti_manager.register_pass<ngraph::pass::ApplyTransformationsToTIBody>(manager);
+        ti_manager.run_passes(function);
     }
 
     return std::make_shared<ExecutableNetwork>(*clonedNetwork,

--- a/inference-engine/tests/functional/inference_engine/keep_constant_inputs_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/keep_constant_inputs_tests.cpp
@@ -41,7 +41,7 @@ int numberOfInputsForLayerInCNNNetwork(const InferenceEngine::CNNNetwork& networ
     return numberOfInputs;
 }
 
-void transformNetwork(std::shared_ptr<InferenceEngine::ICNNNetwork> clonedNetwork, bool keep_constant_inputs) {
+void transformNetwork(std::shared_ptr<InferenceEngine::ICNNNetwork> & clonedNetwork, bool keep_constant_inputs) {
     if (clonedNetwork->getFunction()) {
         auto nGraphFunc = clonedNetwork->getFunction();
         ngraph::pass::CommonOptimizations().run_on_function(nGraphFunc);
@@ -52,58 +52,58 @@ void transformNetwork(std::shared_ptr<InferenceEngine::ICNNNetwork> clonedNetwor
     }
 }
 
-TEST(KeepConstantInputsTests, ConvertConvolutionPoolReluNetworkWithTrue) {
-    std::shared_ptr <ngraph::Function> f_ptr;
-    f_ptr = ngraph::builder::subgraph::makeConvPoolRelu();
-    InferenceEngine::CNNNetwork originalNetwork(f_ptr);
-    transformNetwork(originalNetwork, true);
-    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "Convolution"), 2);
-}
-
-TEST(KeepConstantInputsTests, ConvertConvolutionPoolReluNetworkWithFalse) {
-    std::shared_ptr <ngraph::Function> f_ptr;
-    f_ptr = ngraph::builder::subgraph::makeConvPoolRelu();
-    InferenceEngine::CNNNetwork originalNetwork(f_ptr);
-    transformNetwork(originalNetwork, false);
-    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "Convolution"), 1);
-}
-
-TEST(KeepConstantInputsTests, ConvertConvolutionBiasNetworkWithTrue) {
-    std::shared_ptr <ngraph::Function> f_ptr;
-    f_ptr = ngraph::builder::subgraph::makeConvBias();
-    InferenceEngine::CNNNetwork originalNetwork(f_ptr);
-    transformNetwork(originalNetwork, true);
-    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "Convolution"), 3);
-}
-
-TEST(KeepConstantInputsTests, ConvertConvolutionBiasNetworkWithFalse) {
-    std::shared_ptr <ngraph::Function> f_ptr;
-    f_ptr = ngraph::builder::subgraph::makeConvBias();
-    InferenceEngine::CNNNetwork originalNetwork(f_ptr);
-    transformNetwork(originalNetwork, false);
-    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "Convolution"), 1);
-}
-
-TEST(KeepConstantInputsTests, ConvertFullyConnectedNetworkWithTrue) {
-    std::shared_ptr <ngraph::Function> f_ptr;
-    auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 128});
-    auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{786, 128}, {1});
-    auto empty_bias = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{786}, {0});
-    auto fc = std::make_shared<ngraph::op::FullyConnected>(input1, weights, empty_bias, ngraph::Shape{1, 786});
-    f_ptr = std::make_shared<ngraph::Function>(ngraph::NodeVector{fc}, ngraph::ParameterVector{input1});
-    InferenceEngine::CNNNetwork originalNetwork(f_ptr);
-    transformNetwork(originalNetwork, true);
-    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "FullyConnected"), 3);
-}
-
-TEST(KeepConstantInputsTests, ConvertFullyConnectedNetworkWithFalse) {
-    std::shared_ptr <ngraph::Function> f_ptr;
-    auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 128});
-    auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{786, 128}, {1});
-    auto empty_bias = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{786}, {0});
-    auto fc = std::make_shared<ngraph::op::FullyConnected>(input1, weights, empty_bias, ngraph::Shape{1, 786});
-    f_ptr = std::make_shared<ngraph::Function>(ngraph::NodeVector{fc}, ngraph::ParameterVector{input1});
-    InferenceEngine::CNNNetwork originalNetwork(f_ptr);
-    transformNetwork(originalNetwork, false);
-    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "FullyConnected"), 1);
-}
+//TEST(KeepConstantInputsTests, ConvertConvolutionPoolReluNetworkWithTrue) {
+//    std::shared_ptr <ngraph::Function> f_ptr;
+//    f_ptr = ngraph::builder::subgraph::makeConvPoolRelu();
+//    InferenceEngine::CNNNetwork originalNetwork(f_ptr);
+//    transformNetwork(originalNetwork->get, true);
+//    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "Convolution"), 2);
+//}
+//
+//TEST(KeepConstantInputsTests, ConvertConvolutionPoolReluNetworkWithFalse) {
+//    std::shared_ptr <ngraph::Function> f_ptr;
+//    f_ptr = ngraph::builder::subgraph::makeConvPoolRelu();
+//    InferenceEngine::CNNNetwork originalNetwork(f_ptr);
+//    transformNetwork(originalNetwork, false);
+//    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "Convolution"), 1);
+//}
+//
+//TEST(KeepConstantInputsTests, ConvertConvolutionBiasNetworkWithTrue) {
+//    std::shared_ptr <ngraph::Function> f_ptr;
+//    f_ptr = ngraph::builder::subgraph::makeConvBias();
+//    InferenceEngine::CNNNetwork originalNetwork(f_ptr);
+//    transformNetwork(originalNetwork, true);
+//    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "Convolution"), 3);
+//}
+//
+//TEST(KeepConstantInputsTests, ConvertConvolutionBiasNetworkWithFalse) {
+//    std::shared_ptr <ngraph::Function> f_ptr;
+//    f_ptr = ngraph::builder::subgraph::makeConvBias();
+//    InferenceEngine::CNNNetwork originalNetwork(f_ptr);
+//    transformNetwork(originalNetwork, false);
+//    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "Convolution"), 1);
+//}
+//
+//TEST(KeepConstantInputsTests, ConvertFullyConnectedNetworkWithTrue) {
+//    std::shared_ptr <ngraph::Function> f_ptr;
+//    auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 128});
+//    auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{786, 128}, {1});
+//    auto empty_bias = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{786}, {0});
+//    auto fc = std::make_shared<ngraph::op::FullyConnected>(input1, weights, empty_bias, ngraph::Shape{1, 786});
+//    f_ptr = std::make_shared<ngraph::Function>(ngraph::NodeVector{fc}, ngraph::ParameterVector{input1});
+//    InferenceEngine::CNNNetwork originalNetwork(f_ptr);
+//    transformNetwork(originalNetwork, true);
+//    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "FullyConnected"), 3);
+//}
+//
+//TEST(KeepConstantInputsTests, ConvertFullyConnectedNetworkWithFalse) {
+//    std::shared_ptr <ngraph::Function> f_ptr;
+//    auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 128});
+//    auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{786, 128}, {1});
+//    auto empty_bias = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{786}, {0});
+//    auto fc = std::make_shared<ngraph::op::FullyConnected>(input1, weights, empty_bias, ngraph::Shape{1, 786});
+//    f_ptr = std::make_shared<ngraph::Function>(ngraph::NodeVector{fc}, ngraph::ParameterVector{input1});
+//    InferenceEngine::CNNNetwork originalNetwork(f_ptr);
+//    transformNetwork(originalNetwork, false);
+//    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "FullyConnected"), 1);
+//}

--- a/inference-engine/tests/functional/inference_engine/keep_constant_inputs_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/keep_constant_inputs_tests.cpp
@@ -26,11 +26,11 @@
 using namespace testing;
 using namespace InferenceEngine;
 
-int numberOfInputsForLayerInCNNNetwork(const InferenceEngine::CNNNetwork& network, std::string layerType) {
+int numberOfInputsForLayerInCNNNetwork(std::shared_ptr<InferenceEngine::ICNNNetwork> network, std::string layerType) {
     int numberOfInputs = 0;
 
     IE_SUPPRESS_DEPRECATED_START
-    for (auto it = details::CNNNetworkIterator(network); it != details::CNNNetworkIterator(); it++) {
+    for (auto it = details::CNNNetworkIterator(network.get()); it != details::CNNNetworkIterator(); it++) {
         InferenceEngine::CNNLayerPtr layer = *it;
         if (layer->type == layerType) {
             numberOfInputs = layer->insData.size();
@@ -52,58 +52,64 @@ void transformNetwork(std::shared_ptr<InferenceEngine::ICNNNetwork> & clonedNetw
     }
 }
 
-//TEST(KeepConstantInputsTests, ConvertConvolutionPoolReluNetworkWithTrue) {
-//    std::shared_ptr <ngraph::Function> f_ptr;
-//    f_ptr = ngraph::builder::subgraph::makeConvPoolRelu();
-//    InferenceEngine::CNNNetwork originalNetwork(f_ptr);
-//    transformNetwork(originalNetwork->get, true);
-//    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "Convolution"), 2);
-//}
-//
-//TEST(KeepConstantInputsTests, ConvertConvolutionPoolReluNetworkWithFalse) {
-//    std::shared_ptr <ngraph::Function> f_ptr;
-//    f_ptr = ngraph::builder::subgraph::makeConvPoolRelu();
-//    InferenceEngine::CNNNetwork originalNetwork(f_ptr);
-//    transformNetwork(originalNetwork, false);
-//    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "Convolution"), 1);
-//}
-//
-//TEST(KeepConstantInputsTests, ConvertConvolutionBiasNetworkWithTrue) {
-//    std::shared_ptr <ngraph::Function> f_ptr;
-//    f_ptr = ngraph::builder::subgraph::makeConvBias();
-//    InferenceEngine::CNNNetwork originalNetwork(f_ptr);
-//    transformNetwork(originalNetwork, true);
-//    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "Convolution"), 3);
-//}
-//
-//TEST(KeepConstantInputsTests, ConvertConvolutionBiasNetworkWithFalse) {
-//    std::shared_ptr <ngraph::Function> f_ptr;
-//    f_ptr = ngraph::builder::subgraph::makeConvBias();
-//    InferenceEngine::CNNNetwork originalNetwork(f_ptr);
-//    transformNetwork(originalNetwork, false);
-//    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "Convolution"), 1);
-//}
-//
-//TEST(KeepConstantInputsTests, ConvertFullyConnectedNetworkWithTrue) {
-//    std::shared_ptr <ngraph::Function> f_ptr;
-//    auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 128});
-//    auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{786, 128}, {1});
-//    auto empty_bias = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{786}, {0});
-//    auto fc = std::make_shared<ngraph::op::FullyConnected>(input1, weights, empty_bias, ngraph::Shape{1, 786});
-//    f_ptr = std::make_shared<ngraph::Function>(ngraph::NodeVector{fc}, ngraph::ParameterVector{input1});
-//    InferenceEngine::CNNNetwork originalNetwork(f_ptr);
-//    transformNetwork(originalNetwork, true);
-//    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "FullyConnected"), 3);
-//}
-//
-//TEST(KeepConstantInputsTests, ConvertFullyConnectedNetworkWithFalse) {
-//    std::shared_ptr <ngraph::Function> f_ptr;
-//    auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 128});
-//    auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{786, 128}, {1});
-//    auto empty_bias = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{786}, {0});
-//    auto fc = std::make_shared<ngraph::op::FullyConnected>(input1, weights, empty_bias, ngraph::Shape{1, 786});
-//    f_ptr = std::make_shared<ngraph::Function>(ngraph::NodeVector{fc}, ngraph::ParameterVector{input1});
-//    InferenceEngine::CNNNetwork originalNetwork(f_ptr);
-//    transformNetwork(originalNetwork, false);
-//    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "FullyConnected"), 1);
-//}
+TEST(KeepConstantInputsTests, ConvertConvolutionPoolReluNetworkWithTrue) {
+    std::shared_ptr <ngraph::Function> f_ptr;
+    f_ptr = ngraph::builder::subgraph::makeConvPoolRelu();
+    InferenceEngine::CNNNetwork network(f_ptr);
+    std::shared_ptr<InferenceEngine::ICNNNetwork> originalNetwork = network;
+    transformNetwork(originalNetwork, true);
+    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "Convolution"), 2);
+}
+
+TEST(KeepConstantInputsTests, ConvertConvolutionPoolReluNetworkWithFalse) {
+    std::shared_ptr <ngraph::Function> f_ptr;
+    f_ptr = ngraph::builder::subgraph::makeConvPoolRelu();
+    InferenceEngine::CNNNetwork network(f_ptr);
+    std::shared_ptr<InferenceEngine::ICNNNetwork> originalNetwork = network;
+    transformNetwork(originalNetwork, false);
+    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "Convolution"), 1);
+}
+
+TEST(KeepConstantInputsTests, ConvertConvolutionBiasNetworkWithTrue) {
+    std::shared_ptr <ngraph::Function> f_ptr;
+    f_ptr = ngraph::builder::subgraph::makeConvBias();
+    InferenceEngine::CNNNetwork network(f_ptr);
+    std::shared_ptr<InferenceEngine::ICNNNetwork> originalNetwork = network;
+    transformNetwork(originalNetwork, true);
+    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "Convolution"), 3);
+}
+
+TEST(KeepConstantInputsTests, ConvertConvolutionBiasNetworkWithFalse) {
+    std::shared_ptr <ngraph::Function> f_ptr;
+    f_ptr = ngraph::builder::subgraph::makeConvBias();
+    InferenceEngine::CNNNetwork network(f_ptr);
+    std::shared_ptr<InferenceEngine::ICNNNetwork> originalNetwork = network;
+    transformNetwork(originalNetwork, false);
+    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "Convolution"), 1);
+}
+
+TEST(KeepConstantInputsTests, ConvertFullyConnectedNetworkWithTrue) {
+    std::shared_ptr <ngraph::Function> f_ptr;
+    auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 128});
+    auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{786, 128}, {1});
+    auto empty_bias = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{786}, {0});
+    auto fc = std::make_shared<ngraph::op::FullyConnected>(input1, weights, empty_bias, ngraph::Shape{1, 786});
+    f_ptr = std::make_shared<ngraph::Function>(ngraph::NodeVector{fc}, ngraph::ParameterVector{input1});
+    InferenceEngine::CNNNetwork network(f_ptr);
+    std::shared_ptr<InferenceEngine::ICNNNetwork> originalNetwork = network;
+    transformNetwork(originalNetwork, true);
+    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "FullyConnected"), 3);
+}
+
+TEST(KeepConstantInputsTests, ConvertFullyConnectedNetworkWithFalse) {
+    std::shared_ptr <ngraph::Function> f_ptr;
+    auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 128});
+    auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{786, 128}, {1});
+    auto empty_bias = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{786}, {0});
+    auto fc = std::make_shared<ngraph::op::FullyConnected>(input1, weights, empty_bias, ngraph::Shape{1, 786});
+    f_ptr = std::make_shared<ngraph::Function>(ngraph::NodeVector{fc}, ngraph::ParameterVector{input1});
+    InferenceEngine::CNNNetwork network(f_ptr);
+    std::shared_ptr<InferenceEngine::ICNNNetwork> originalNetwork = network;
+    transformNetwork(originalNetwork, false);
+    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "FullyConnected"), 1);
+}

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_nms4_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_nms4_test.cpp
@@ -54,10 +54,9 @@ TEST(TransformationTests, ConvertNMS4ToNMSIEStatic) {
                                                               std::make_shared<opset4::Unsqueeze>(score_threshold,
                                                                                                   opset4::Constant::create(element::i64, Shape{1}, {0})),
                                                               0, true);
-        auto convert = std::make_shared<ngraph::opset4::Convert>(nms, element::i64);
-        convert->set_friendly_name("nms");
+        nms->set_friendly_name("nms");
 
-        f_ref = std::make_shared<Function>(NodeVector{convert}, ParameterVector{boxes, scores});
+        f_ref = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
         ASSERT_TRUE(f_ref->get_output_partial_shape(0).is_static()) << "Shape " << f_ref->get_output_partial_shape(0) << " should be static";
     }
 

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_nms_to_nms_ie_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_nms_to_nms_ie_test.cpp
@@ -10,6 +10,7 @@
 
 #include <ngraph/function.hpp>
 #include <ngraph/opsets/opset1.hpp>
+#include <ngraph/opsets/opset3.hpp>
 #include <transformations/convert_opset1_to_legacy/convert_nms_to_nms_ie.hpp>
 #include <transformations/init_node_info.hpp>
 #include <transformations/utils/utils.hpp>
@@ -30,8 +31,8 @@ TEST(TransformationTests, ConvertNMSToNMSIEStatic) {
         auto max_output_boxes_per_class = opset1::Constant::create(element::i64, Shape{}, {10});
         auto iou_threshold = opset1::Constant::create(element::f32, Shape{}, {0.75});
         auto score_threshold = opset1::Constant::create(element::f32, Shape{}, {0.7});
-        auto nms = std::make_shared<opset1::NonMaxSuppression>(boxes, scores, max_output_boxes_per_class,
-                iou_threshold, score_threshold, opset1::NonMaxSuppression::BoxEncodingType::CORNER, true);
+        auto nms = std::make_shared<opset3::NonMaxSuppression>(boxes, scores, max_output_boxes_per_class,
+                iou_threshold, score_threshold, opset3::NonMaxSuppression::BoxEncodingType::CORNER, true);
 
         f = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
 
@@ -71,8 +72,8 @@ TEST(TransformationTests, ConvertNMSToNMSIEDynamic1) {
         auto max_output_boxes_per_class = opset1::Constant::create(element::i64, Shape{}, {10});
         auto iou_threshold = opset1::Constant::create(element::f32, Shape{}, {0.75});
         auto score_threshold = opset1::Constant::create(element::f32, Shape{}, {0.7});
-        auto nms = std::make_shared<opset1::NonMaxSuppression>(boxes, scores, max_output_boxes_per_class,
-                iou_threshold, score_threshold, opset1::NonMaxSuppression::BoxEncodingType::CORNER, true);
+        auto nms = std::make_shared<opset3::NonMaxSuppression>(boxes, scores, max_output_boxes_per_class,
+                iou_threshold, score_threshold, opset3::NonMaxSuppression::BoxEncodingType::CORNER, true);
 
         f = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
 
@@ -110,8 +111,8 @@ TEST(TransformationTests, ConvertNMSToNMSIEDynamic2) {
         auto max_output_boxes_per_class = opset1::Constant::create(element::i64, Shape{}, {10});
         auto iou_threshold = opset1::Constant::create(element::f32, Shape{}, {0.75});
         auto score_threshold = opset1::Constant::create(element::f32, Shape{}, {0.7});
-        auto nms = std::make_shared<opset1::NonMaxSuppression>(boxes, scores, max_output_boxes_per_class,
-                iou_threshold, score_threshold, opset1::NonMaxSuppression::BoxEncodingType::CORNER, true);
+        auto nms = std::make_shared<opset3::NonMaxSuppression>(boxes, scores, max_output_boxes_per_class,
+                iou_threshold, score_threshold, opset3::NonMaxSuppression::BoxEncodingType::CORNER, true);
 
         f = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
 

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_precision.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_precision.cpp
@@ -1,0 +1,237 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <memory>
+#include <queue>
+#include <vector>
+
+#include <ngraph/function.hpp>
+#include <ngraph/opsets/opset1.hpp>
+#include <ngraph/opsets/opset3.hpp>
+#include <ngraph/opsets/opset4.hpp>
+#include <transformations/convert_precision.hpp>
+#include <transformations/utils/utils.hpp>
+#include <ngraph/pass/manager.hpp>
+
+#include "common_test_utils/ngraph_test_utils.hpp"
+
+using namespace testing;
+using namespace ngraph;
+
+template<ngraph::element::Type_t T>
+bool has_type(std::shared_ptr<ngraph::Function> f) {
+    for (auto & node : f->get_ordered_ops()) {
+        for (auto & input : node->inputs()) {
+            if (input.get_element_type() == element::Type(T)) {
+                return true;
+            }
+        }
+        for (auto & output : node->outputs()) {
+            if (output.get_element_type() == element::Type(T)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+TEST(TransformationTests, ConvertPrecision_NMS3) {
+    std::shared_ptr<Function> f(nullptr);
+    {
+        auto boxes = std::make_shared<opset3::Parameter>(element::f16, Shape{1, 1000, 4});
+        auto scores = std::make_shared<opset3::Parameter>(element::f16, Shape{1, 1, 1000});
+        auto max_output_boxes_per_class = opset3::Constant::create(element::i64, Shape{}, {10});
+        auto iou_threshold = opset3::Constant::create(element::f16, Shape{}, {0.75});
+        auto score_threshold = opset3::Constant::create(element::f16, Shape{}, {0.7});
+        auto nms = std::make_shared<opset3::NonMaxSuppression>(boxes, scores, max_output_boxes_per_class,
+                iou_threshold, score_threshold, opset3::NonMaxSuppression::BoxEncodingType::CORNER, true);
+
+        f = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
+
+        pass::Manager manager;
+        manager.register_pass<ngraph::pass::ConvertPrecision>(ngraph::element::i64, ngraph::element::i32);
+        manager.register_pass<ngraph::pass::ConvertPrecision>(ngraph::element::f16, ngraph::element::f32);
+        manager.run_passes(f);
+    }
+
+    ASSERT_FALSE(has_type<ngraph::element::Type_t::i64>(f));
+    ASSERT_FALSE(has_type<ngraph::element::Type_t::f16>(f));
+}
+
+TEST(TransformationTests, ConvertPrecision_NMS4) {
+    std::shared_ptr<Function> f(nullptr);
+    {
+        auto boxes = std::make_shared<opset4::Parameter>(element::f16, Shape{1, 1000, 4});
+        auto scores = std::make_shared<opset4::Parameter>(element::f16, Shape{1, 1, 1000});
+        auto max_output_boxes_per_class = opset4::Constant::create(element::i64, Shape{}, {10});
+        auto iou_threshold = opset4::Constant::create(element::f16, Shape{}, {0.75});
+        auto score_threshold = opset4::Constant::create(element::f16, Shape{}, {0.7});
+        auto nms = std::make_shared<opset4::NonMaxSuppression>(boxes, scores, max_output_boxes_per_class,
+                iou_threshold, score_threshold, opset4::NonMaxSuppression::BoxEncodingType::CORNER, true);
+
+        f = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
+
+        pass::Manager manager;
+        manager.register_pass<ngraph::pass::ConvertPrecision>(ngraph::element::i64, ngraph::element::i32);
+        manager.register_pass<ngraph::pass::ConvertPrecision>(ngraph::element::f16, ngraph::element::f32);
+        manager.run_passes(f);
+    }
+
+    ASSERT_FALSE(has_type<ngraph::element::Type_t::i64>(f));
+    ASSERT_FALSE(has_type<ngraph::element::Type_t::f16>(f));
+}
+
+TEST(TransformationTests, ConvertPrecision_ShapeOf) {
+    std::shared_ptr<Function> f(nullptr);
+    {
+        auto input = std::make_shared<opset4::Parameter>(element::f16, Shape{1, 1000, 4});
+        auto shape_of = std::make_shared<opset4::ShapeOf>(input);
+
+        f = std::make_shared<Function>(NodeVector{shape_of}, ParameterVector{input});
+
+        pass::Manager manager;
+        manager.register_pass<ngraph::pass::ConvertPrecision>(ngraph::element::i64, ngraph::element::i32);
+        manager.register_pass<ngraph::pass::ConvertPrecision>(ngraph::element::f16, ngraph::element::f32);
+        manager.run_passes(f);
+    }
+
+    ASSERT_FALSE(has_type<ngraph::element::Type_t::i64>(f));
+    ASSERT_FALSE(has_type<ngraph::element::Type_t::f16>(f));
+}
+
+TEST(TransformationTests, ConvertPrecision_Convert) {
+    std::shared_ptr<Function> f(nullptr);
+    {
+        auto input = std::make_shared<opset4::Parameter>(element::f16, Shape{1, 1000, 4});
+        auto convert = std::make_shared<opset4::Convert>(input, element::i64);
+
+        f = std::make_shared<Function>(NodeVector{convert}, ParameterVector{input});
+
+        pass::Manager manager;
+        manager.register_pass<ngraph::pass::ConvertPrecision>(ngraph::element::i64, ngraph::element::i32);
+        manager.register_pass<ngraph::pass::ConvertPrecision>(ngraph::element::f16, ngraph::element::f32);
+        manager.run_passes(f);
+    }
+
+    ASSERT_FALSE(has_type<ngraph::element::Type_t::f16>(f));
+    ASSERT_FALSE(has_type<ngraph::element::Type_t::i64>(f));
+}
+
+TEST(TransformationTests, ConvertPrecision_ConvertElimination) {
+    std::shared_ptr<Function> f(nullptr), f_ref(nullptr);
+    {
+        auto input = std::make_shared<opset4::Parameter>(element::f16, Shape{1, 1000, 4});
+        auto relu = std::make_shared<opset4::Relu>(input);
+        auto convert = std::make_shared<opset4::Convert>(relu, element::f32);
+
+        f = std::make_shared<Function>(NodeVector{convert}, ParameterVector{input});
+
+        pass::Manager manager;
+        manager.register_pass<ngraph::pass::ConvertPrecision>(ngraph::element::f16, ngraph::element::f32);
+        manager.run_passes(f);
+        ASSERT_FALSE(has_type<ngraph::element::Type_t::f16>(f));
+    }
+
+    {
+        auto input = std::make_shared<opset4::Parameter>(element::f32, Shape{1, 1000, 4});
+        auto relu = std::make_shared<opset4::Relu>(input);
+
+        f_ref = std::make_shared<Function>(NodeVector{relu}, ParameterVector{input});
+    }
+
+    auto res = compare_functions(f, f_ref);
+    ASSERT_TRUE(res.first) << res.second;
+}
+
+TEST(TransformationTests, ConvertPrecision_TopK) {
+    std::shared_ptr<Function> f(nullptr);
+    {
+        auto input = std::make_shared<ngraph::opset3::Parameter>(ngraph::element::f16, ngraph::Shape{15, 20, 3});
+        auto k = ngraph::opset3::Constant::create(ngraph::element::i64, ngraph::Shape{}, {10});
+        auto topk = std::make_shared<ngraph::opset3::TopK>(input, k, 1, "min", "value", ngraph::element::i64);
+
+        f = std::make_shared<Function>(OutputVector{topk->output(0), topk->output(1)}, ParameterVector{input});
+
+        pass::Manager manager;
+        manager.register_pass<ngraph::pass::ConvertPrecision>(ngraph::element::i64, ngraph::element::i32);
+        manager.register_pass<ngraph::pass::ConvertPrecision>(ngraph::element::f16, ngraph::element::f32);
+        manager.run_passes(f);
+    }
+
+    ASSERT_FALSE(has_type<ngraph::element::Type_t::f16>(f));
+    ASSERT_FALSE(has_type<ngraph::element::Type_t::i64>(f));
+}
+
+TEST(TransformationTests, ConvertPrecision_NonZero) {
+    std::shared_ptr<Function> f(nullptr);
+    {
+        auto input = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f16, ngraph::Shape{15, 20, 3});
+        auto non_zero = std::make_shared<ngraph::opset4::NonZero>(input, ngraph::element::i64);
+
+        f = std::make_shared<Function>(OutputVector{non_zero}, ParameterVector{input});
+
+        pass::Manager manager;
+        manager.register_pass<ngraph::pass::ConvertPrecision>(ngraph::element::i64, ngraph::element::i32);
+        manager.register_pass<ngraph::pass::ConvertPrecision>(ngraph::element::f16, ngraph::element::f32);
+        manager.run_passes(f);
+    }
+
+    ASSERT_FALSE(has_type<ngraph::element::Type_t::f16>(f));
+    ASSERT_FALSE(has_type<ngraph::element::Type_t::i64>(f));
+}
+
+TEST(TransformationTests, ConvertPrecision_Bucketize) {
+    std::shared_ptr<Function> f(nullptr);
+    {
+        auto input = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f16, ngraph::Shape{20});
+        auto k = ngraph::opset4::Constant::create(ngraph::element::i64, ngraph::Shape{1}, {10});
+        auto b = std::make_shared<ngraph::opset4::Bucketize>(input, k);
+
+        f = std::make_shared<Function>(OutputVector{b}, ParameterVector{input});
+
+        pass::Manager manager;
+        manager.register_pass<ngraph::pass::ConvertPrecision>(ngraph::element::i64, ngraph::element::i32);
+        manager.register_pass<ngraph::pass::ConvertPrecision>(ngraph::element::f16, ngraph::element::f32);
+        manager.run_passes(f);
+    }
+
+    ASSERT_FALSE(has_type<ngraph::element::Type_t::f16>(f));
+    ASSERT_FALSE(has_type<ngraph::element::Type_t::i64>(f));
+}
+
+TEST(TransformationTests, ConvertPrecision_Roundings) {
+    std::shared_ptr<Function> f(nullptr);
+    {
+        auto max_int64 = std::numeric_limits<int64_t>::max();
+        auto max_int32 = std::numeric_limits<int32_t>::max();
+
+        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f16, ngraph::Shape{5, 5, 5, 5});
+        auto begin = ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {0, 0, 0, 0});
+        auto end = ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {max_int64, max_int64, max_int64, max_int64});
+        auto stride = ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {1});
+
+        std::vector<int64_t> begin_mask = {0, 0, 0, 0};
+        std::vector<int64_t> end_mask = {0, 0, 0, 0};
+
+        auto ss = std::make_shared<ngraph::opset1::StridedSlice>(input, begin, end, stride, begin_mask, end_mask);
+
+        f = std::make_shared<Function>(OutputVector{ss}, ParameterVector{input});
+
+        pass::Manager manager;
+        manager.register_pass<ngraph::pass::ConvertPrecision>(ngraph::element::i64, ngraph::element::i32);
+        manager.register_pass<ngraph::pass::ConvertPrecision>(ngraph::element::f16, ngraph::element::f32);
+        manager.run_passes(f);
+
+        auto casted_end = std::dynamic_pointer_cast<opset1::Constant>(ss->input_value(2).get_node_shared_ptr());
+        ASSERT_TRUE(casted_end != nullptr);
+        ASSERT_EQ(casted_end->get_element_type(), element::i32);
+        ASSERT_EQ(casted_end->cast_vector<int32_t>(), std::vector<int32_t>({max_int32, max_int32, max_int32, max_int32}));
+    }
+
+    ASSERT_FALSE(has_type<ngraph::element::Type_t::f16>(f));
+    ASSERT_FALSE(has_type<ngraph::element::Type_t::i64>(f));
+}

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_binary_elementwise.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_binary_elementwise.cpp
@@ -62,7 +62,7 @@ protected:
         eltwise->set_output_type(0, eltwise->get_input_element_type(0), ngraph::PartialShape::dynamic(eltwise->get_output_partial_shape(0).rank()));
 
         const auto transformations = vpu::Transformations{{eltwiseType, vpu::dynamicToStaticShapeBinaryEltwise}};
-        vpu::DynamicToStaticShape(transformations).transform(function);
+        vpu::DynamicToStaticShape(transformations).run_on_function(function);
         return function;
     }
 
@@ -200,7 +200,7 @@ protected:
         eltwise->set_output_type(0, eltwise->get_input_element_type(0), ngraph::PartialShape::dynamic(eltwise->get_output_partial_shape(0).rank()));
 
         const auto transformations = vpu::Transformations{{eltwiseType, vpu::dynamicToStaticShapeBinaryEltwise}};
-        vpu::DynamicToStaticShape(transformations).transform(function);
+        vpu::DynamicToStaticShape(transformations).run_on_function(function);
         return function;
     }
 

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_broadcast.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_broadcast.cpp
@@ -85,7 +85,7 @@ protected:
 
         const auto transformations = vpu::Transformations{{
             ngraph::opset3::Broadcast::type_info, vpu::dynamicToStaticShapeBroadcast}};
-        vpu::DynamicToStaticShape(transformations).transform(function);
+        vpu::DynamicToStaticShape(transformations).run_on_function(function);
         return function;
     }
 

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_clamp.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_clamp.cpp
@@ -48,7 +48,7 @@ protected:
         node->set_output_type(0, dsr->get_input_element_type(0), ngraph::PartialShape::dynamic(outputShape.rank()));
 
         const auto transformations = vpu::Transformations{{ngraph::opset3::Clamp::type_info, vpu::dynamicToStaticUnaryElementwise}};
-        vpu::DynamicToStaticShape(transformations).transform(function);
+        vpu::DynamicToStaticShape(transformations).run_on_function(function);
         return function;
     }
 

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_concat.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_concat.cpp
@@ -78,7 +78,7 @@ protected:
 
         const auto transformations = vpu::Transformations{
             {ngraph::opset3::Concat::type_info, vpu::dynamicToStaticShapeConcat}};
-        vpu::DynamicToStaticShape(transformations).transform(function);
+        vpu::DynamicToStaticShape(transformations).run_on_function(function);
         return function;
     }
 

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_convert.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_convert.cpp
@@ -48,7 +48,7 @@ protected:
         convert->set_output_type(0, dsr->get_input_element_type(0), ngraph::PartialShape::dynamic(outputShape.rank()));
 
         const auto transformations = vpu::Transformations{{ngraph::opset3::Convert::type_info, vpu::dynamicToStaticUnaryElementwise}};
-        vpu::DynamicToStaticShape(transformations).transform(function);
+        vpu::DynamicToStaticShape(transformations).run_on_function(function);
         return function;
     }
 

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_gather.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_gather.cpp
@@ -82,7 +82,7 @@ protected:
                 gather_setup.data_shape.size() + gather_setup.index_shape.size() - 1));
 
         const auto transformations = vpu::Transformations{{node->type_info, vpu::dynamicToStaticShapeGather}};
-        vpu::DynamicToStaticShape(transformations).transform(function);
+        vpu::DynamicToStaticShape(transformations).run_on_function(function);
         return function;
     }
 
@@ -171,7 +171,7 @@ protected:
                 gather_setup.data_shape.size() + gather_setup.index_shape.size() - 1));
 
         const auto transformations = vpu::Transformations{{node->type_info, vpu::dynamicToStaticShapeGather}};
-        vpu::DynamicToStaticShape(transformations).transform(function);
+        vpu::DynamicToStaticShape(transformations).run_on_function(function);
         return function;
     }
 
@@ -263,7 +263,7 @@ protected:
                 gather_setup.data_shape.size() + gather_setup.index_shape.size() - 1));
 
         const auto transformations = vpu::Transformations{{node->type_info, vpu::dynamicToStaticShapeGather}};
-        vpu::DynamicToStaticShape(transformations).transform(function);
+        vpu::DynamicToStaticShape(transformations).run_on_function(function);
         return function;
     }
 

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_matmul.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_matmul.cpp
@@ -133,7 +133,7 @@ protected:
         node->set_output_type(0, node->get_output_element_type(0), ngraph::PartialShape::dynamic(node->get_output_partial_shape(0).rank()));
 
         const auto transformations = vpu::Transformations{{ngraph::opset3::MatMul::type_info, vpu::dynamicToStaticShapeMatMul}};
-        vpu::DynamicToStaticShape(transformations).transform(function);
+        vpu::DynamicToStaticShape(transformations).run_on_function(function);
         return function;
     }
 

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_non_max_suppression.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_non_max_suppression.cpp
@@ -68,7 +68,7 @@ protected:
         node->set_output_type(0, dsr->get_input_element_type(0), ngraph::PartialShape::dynamic(outputShape.rank()));
 
         const auto transformations = vpu::Transformations{{node->type_info, vpu::dynamicToStaticNonMaxSuppression}};
-        vpu::DynamicToStaticShape(transformations).transform(function);
+        vpu::DynamicToStaticShape(transformations).run_on_function(function);
         return function;
     }
 

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_nonzero.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_nonzero.cpp
@@ -49,7 +49,7 @@ public:
 
             actual = std::make_shared<ngraph::Function>(ngraph::NodeVector{nonZero}, ngraph::ParameterVector{input});
             const auto transformation = vpu::Transformations{{ngraph::opset3::NonZero::type_info, vpu::dynamicToStaticShapeNonZero}};
-            vpu::DynamicToStaticShape(transformation).transform(actual);
+            vpu::DynamicToStaticShape(transformation).run_on_function(actual);
         }
 
         // Create a reference function

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_reduce.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_reduce.cpp
@@ -111,7 +111,7 @@ protected:
             "Actual");
         node->set_output_type(0, data_type, ngraph::PartialShape::dynamic(node->get_output_partial_shape(0).rank()));
         const auto transformations = vpu::Transformations{{type_info, vpu::dynamicToStaticShapeReduce}};
-        vpu::DynamicToStaticShape(transformations).transform(function);
+        vpu::DynamicToStaticShape(transformations).run_on_function(function);
         return function;
     }
 

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_reshape.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_reshape.cpp
@@ -55,7 +55,7 @@ protected:
             ngraph::PartialShape::dynamic(outShapeDescriptorParam->get_output_partial_shape(0).rank()));
 
         const auto transformations = vpu::Transformations{{ngraph::op::v1::Reshape::type_info, vpu::dynamicToStaticShapeReshape}};
-        vpu::DynamicToStaticShape(transformations).transform(function);
+        vpu::DynamicToStaticShape(transformations).run_on_function(function);
         return function;
     }
 

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_roialign.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_roialign.cpp
@@ -62,7 +62,7 @@ protected:
         node->set_output_type(0, dsr->get_input_element_type(0), ngraph::PartialShape::dynamic(outputShape.rank()));
 
         const auto transformations = vpu::Transformations{{node->type_info, vpu::dynamicToStaticShapeROIAlign}};
-        vpu::DynamicToStaticShape(transformations).transform(function);
+        vpu::DynamicToStaticShape(transformations).run_on_function(function);
         return function;
     }
 
@@ -150,7 +150,7 @@ protected:
         node->set_output_type(0, dsr->get_input_element_type(0), ngraph::PartialShape::dynamic(outputShape.rank()));
 
         const auto transformations = vpu::Transformations{{node->type_info, vpu::dynamicToStaticShapeROIAlign}};
-        vpu::DynamicToStaticShape(transformations).transform(function);
+        vpu::DynamicToStaticShape(transformations).run_on_function(function);
         return function;
     }
 
@@ -241,7 +241,7 @@ protected:
         node->set_output_type(0, data_dsr->get_input_element_type(0), ngraph::PartialShape::dynamic(outputShape.rank()));
 
         const auto transformations = vpu::Transformations{{node->type_info, vpu::dynamicToStaticShapeROIAlign}};
-        vpu::DynamicToStaticShape(transformations).transform(function);
+        vpu::DynamicToStaticShape(transformations).run_on_function(function);
         return function;
     }
 

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_scatter.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_scatter.cpp
@@ -61,7 +61,7 @@ protected:
         node->set_output_type(0, dsr->get_input_element_type(0), ngraph::PartialShape::dynamic(outputShape.rank()));
 
         const auto transformations = vpu::Transformations{{scatter_setup.scatter_type_info, vpu::dynamicToStaticUnaryElementwise}};
-        vpu::DynamicToStaticShape(transformations).transform(function);
+        vpu::DynamicToStaticShape(transformations).run_on_function(function);
         return function;
     }
 

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_squeeze.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_squeeze.cpp
@@ -65,7 +65,7 @@ protected:
         node->set_output_type(0, dsr->get_input_element_type(0), ngraph::PartialShape::dynamic(node->get_output_partial_shape(0).rank()));
 
         const auto transformations = vpu::Transformations{{node->type_info, vpu::dynamicToStaticShapeSqueeze}};
-        vpu::DynamicToStaticShape(transformations).transform(function);
+        vpu::DynamicToStaticShape(transformations).run_on_function(function);
         return function;
     }
 

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_topk.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_topk.cpp
@@ -87,7 +87,7 @@ protected:
         node->set_output_type(0, dsr->get_input_element_type(0), ngraph::PartialShape::dynamic(topk_setup.data_shape.size()));
 
         const auto transformations = vpu::Transformations{{node->type_info, vpu::dynamicToStaticShapeTopK}};
-        vpu::DynamicToStaticShape(transformations).transform(function);
+        vpu::DynamicToStaticShape(transformations).run_on_function(function);
         return function;
     }
 
@@ -204,7 +204,7 @@ protected:
         node->set_output_type(0, dsr->get_input_element_type(0), ngraph::PartialShape::dynamic(topk_setup.data_shape.size()));
 
         const auto transformations = vpu::Transformations{{node->type_info, vpu::dynamicToStaticShapeTopK}};
-        vpu::DynamicToStaticShape(transformations).transform(function);
+        vpu::DynamicToStaticShape(transformations).run_on_function(function);
         return function;
     }
 

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_transpose.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_transpose.cpp
@@ -73,7 +73,7 @@ protected:
         transpose->set_output_type(0, dsr->get_input_element_type(0), makeDynamicShape(transposition->get_output_partial_shape(0)));
 
         const auto transformations = vpu::Transformations{{ngraph::opset3::Transpose::type_info, vpu::dynamicToStaticShapeTranspose}};
-        vpu::DynamicToStaticShape(transformations).transform(function);
+        vpu::DynamicToStaticShape(transformations).run_on_function(function);
         return function;
     }
 

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_unary_elementwise.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_unary_elementwise.cpp
@@ -50,7 +50,7 @@ protected:
         node->set_output_type(0, dsr->get_input_element_type(0), ngraph::PartialShape::dynamic(outputShape.rank()));
 
         const auto transformations = vpu::Transformations{{type_info, vpu::dynamicToStaticUnaryElementwise}};
-        vpu::DynamicToStaticShape(transformations).transform(function);
+        vpu::DynamicToStaticShape(transformations).run_on_function(function);
         return function;
     }
 

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_unsqueeze.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_unsqueeze.cpp
@@ -67,7 +67,7 @@ protected:
                 ngraph::PartialShape::dynamic(node->get_output_partial_shape(0).rank() + unsqueeze_axes.size()));
 
         const auto transformations = vpu::Transformations{{node->type_info, vpu::dynamicToStaticShapeUnsqueeze}};
-        vpu::DynamicToStaticShape(transformations).transform(function);
+        vpu::DynamicToStaticShape(transformations).run_on_function(function);
         return function;
     }
 

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_variadic_split.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_variadic_split.cpp
@@ -84,7 +84,7 @@ protected:
         node->set_output_type(0, dsr->get_input_element_type(0), ngraph::PartialShape::dynamic(variadic_split_setup.data_shape.size()));
 
         const auto transformations = vpu::Transformations{{node->type_info, vpu::dynamicToStaticShapeVariadicSplit}};
-        vpu::DynamicToStaticShape(transformations).transform(function);
+        vpu::DynamicToStaticShape(transformations).run_on_function(function);
         return function;
     }
 

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_tests_common.hpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_tests_common.hpp
@@ -90,7 +90,7 @@ protected:
         switchDSRMode(ngraph::vpu::op::DynamicShapeResolverMode::INFER_UPPER_BOUND_SHAPE);
         testedOp->set_output_type(0, testedOp->get_input_element_type(0), outputDynamicShape);
 
-        ::vpu::DynamicToStaticShape().transform(function);
+        ::vpu::DynamicToStaticShape().run_on_function(function);
     }
 
     InferenceEngine::Blob::Ptr GenerateInput(const InferenceEngine::InputInfo& info) const override {

--- a/ngraph/src/ngraph/op/tensor_iterator.hpp
+++ b/ngraph/src/ngraph/op/tensor_iterator.hpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "ngraph/factory_adapter.hpp"
+#include "ngraph/function.hpp"
 #include "ngraph/lambda.hpp"
 #include "ngraph/op/parameter.hpp"
 #include "ngraph/op/util/fused_op.hpp"

--- a/ngraph/src/ngraph/op/tensor_iterator.hpp
+++ b/ngraph/src/ngraph/op/tensor_iterator.hpp
@@ -60,6 +60,10 @@ namespace ngraph
                     }
                     BodyLambda() = default;
                     virtual bool visit_attributes(AttributeVisitor& visitor);
+                    std::shared_ptr<Function> to_function()
+                    {
+                        return std::make_shared<Function>(get_results(), get_parameters());
+                    }
                 };
 
                 /// \brief Describes a connection between a TensorIterator input and the body.

--- a/ngraph/src/ngraph/op/tile.cpp
+++ b/ngraph/src/ngraph/op/tile.cpp
@@ -41,8 +41,8 @@ void op::Tile::validate_and_infer_types()
     // Repeats should have integer data type. For now we only allow i64
     auto repeats_et = get_input_element_type(1);
     NODE_VALIDATION_CHECK(this,
-                          repeats_et.compatible(element::Type_t::i64),
-                          "Tile repeats must have element type i64, but has ",
+                          repeats_et.is_integral(),
+                          "Tile repeats must have any integer element type, but has ",
                           repeats_et);
 
     auto arg_shape = get_input_partial_shape(0);


### PR DESCRIPTION
Within this changes Im going to replace CNNNetwork ConvertPrecision pass with ngraph transformation.
List of current precision conversions:
1. Precision::U64, Precision::I32
2. Precision::I64, Precision::I32
3. Precision::BOOL, Precision::U8
4. Precision::BOOL, Precision::I32
5. Precision::FP16, Precision::FP32
6. Precision::U8, Precision::I32
7. Precision::U16, Precision::I32

To convert operation output precision from X to Y we can insert Convert operations but it requires consumer operation support Y input type. I've made an analysis of operations input/output types from opset3 and in all cases if operation consumers integer type it can be i32. That makes conversion possible. The same story with f16 to f32 conversion.

List of operations that can produce integer type:
1. Bucketize
2. Constant
3. Convert
4. NonMaxSuppression
5. NonZero
6. Parameter
7. ShapeOf
8. TopK

Fortunately all this ops produce either any numeric type of  i32/i64 and type can be specified via attribute. So we can fuse Convert to i32 type into this operations.

The only problem remains with bool conversion as operations that produce bool type can't be modified to produce other type.

Plugins and ConvertPrecision usage:
CLDNN
* FP16 -> FP32

GNA
* I64 -> I32
* U64 -> I32

MKLDNN
* I64 -> I32
* U64 -> I32
* U16 -> I32
* F16 -> F32
* BOOL -> U8

VPU
* I64 -> I32
* U64 -> I32
* BOOL -> I32

**Update:**
In this PR I'll add ngraph::pass::ConvertPrecision transformation and change only CPU Plugin to decrease number of changes. Other plugins will be updated in separate PR.

**Update:**
This PR also includes changes for TI body transformations. We need to call the same sequence of transformations including ConvertPrecision for TI body.