### PR TITLE
[IE][VPU][nGraph]: Enables merging subsequent DSR operations

### DIFF
--- a/inference-engine/src/vpu/common/include/vpu/ngraph/transformations/merge_subsequent_dsr_operations.hpp
+++ b/inference-engine/src/vpu/common/include/vpu/ngraph/transformations/merge_subsequent_dsr_operations.hpp
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "ngraph/pass/graph_rewrite.hpp"
+
+namespace vpu {
+
+class MergeSubsequentDSROperations : public ngraph::pass::GraphRewrite {
+public:
+    MergeSubsequentDSROperations();
+};
+
+}  // namespace vpu

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/merge_subsequent_dsr_operations.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/merge_subsequent_dsr_operations.cpp
@@ -1,0 +1,35 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "vpu/ngraph/transformations/merge_subsequent_dsr_operations.hpp"
+#include "vpu/ngraph/operations/dynamic_shape_resolver.hpp"
+
+namespace vpu {
+
+MergeSubsequentDSROperations::MergeSubsequentDSROperations() : ngraph::pass::GraphRewrite() {
+    ngraph::graph_rewrite_callback callback = [](ngraph::pattern::Matcher& m) {
+        const auto& dsr = std::dynamic_pointer_cast<ngraph::vpu::op::DynamicShapeResolver>(m.get_match_root());
+        if (!dsr) {
+            return false;
+        }
+
+        const auto& predecessor = std::dynamic_pointer_cast<ngraph::vpu::op::DynamicShapeResolver>(dsr->input_value(0).get_node_shared_ptr());
+        if (!predecessor) {
+            return false;
+        }
+
+        dsr->input(0).replace_source_output(predecessor->input_value(0));
+        return false;
+    };
+
+    const auto& label = std::make_shared<ngraph::pattern::op::Label>(
+        ngraph::element::i64,
+        ngraph::Shape{},
+        ngraph::pattern::has_class<ngraph::vpu::op::DynamicShapeResolver>());
+
+    const auto& matcher = std::make_shared<ngraph::pattern::Matcher>(label, "MergeSubsequentDSROperations");
+    add_matcher(matcher, callback, ngraph::pass::PassProperty::CHANGE_DYNAMIC_STATE);
+}
+
+}  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/frontend/frontend.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/frontend/frontend.cpp
@@ -24,6 +24,7 @@
 #include <transformations/convert_opset3_to_opset2/convert_opset3_to_opset2.hpp>
 #include <transformations/convert_opset2_to_opset1/convert_opset2_to_opset1.hpp>
 #include <transformations/convert_opset1_to_legacy/convert_opset1_to_legacy.hpp>
+#include <vpu/ngraph/transformations/merge_subsequent_dsr_operations.hpp>
 
 namespace vpu {
 
@@ -379,6 +380,9 @@ ModelPtr FrontEnd::runCommonPasses(ie::ICNNNetwork& network, const UnsupportedLa
             ngraph::pass::ConvertOpSet3ToOpSet2().run_on_function(nGraphFunc);
             ngraph::pass::ConvertOpSet2ToOpSet1().run_on_function(nGraphFunc);
             ngraph::pass::ConvertOpSet1ToLegacy().run_on_function(nGraphFunc);
+
+            vpu::MergeSubsequentDSROperations().run_on_function(nGraphFunc);
+
             convertedNetwork = InferenceEngine::details::convertFunctionToICNNNetwork(nGraphFunc, *originalOrConvertNetwork);
             originalOrConvertNetwork = convertedNetwork.get();
         };


### PR DESCRIPTION
## Task

35008

## Description

Myriad plugin treats DSR operation in a way removing such operations and connecting inputs with each other (replacing output with one of them). Semantic of connection is one inputs contains shape of another. Since the same data object can have exactly one shape it's prohibited to have DSR inputs connected with another data objects (the only exception is inputs are already connected between each other).

As a result of nGraph -> CNN conversion some operations could be optimized out which in turn could lead to subsequent DSR operations where each has its own shape sub-graph. Even if shape sub-graphs are identical it's not visible to plugin that sees incorrect inputs (inputs of DSR are already connected, but now with each other, when second DSR is parsed).

To overcome such issue (the reason is when operations are optimized out, their shape sub-graphs are still there), additional ngraph transformation should be introduced to merge subsequent DSR into single DSR operation.