### PR TITLE
[IE][VPU][nGraph]: Fixes Reshape shape infer method

### DIFF
--- a/ngraph/src/ngraph/op/reshape.cpp
+++ b/ngraph/src/ngraph/op/reshape.cpp
@@ -338,6 +338,14 @@ void op::v1::Reshape::validate_and_infer_types()
                     }
                 }
             }
+
+            if (out_shape_val == std::vector<std::int64_t>{0, -1} &&
+                input_pshape.rank().is_static() && input_pshape.rank().get_length() == 2)
+            {
+                partial_shape[0] = input_pshape[0];
+                partial_shape[1] = input_pshape[1];
+            }
+
             set_output_type(0, get_input_element_type(0), PartialShape(partial_shape));
         }
     }


### PR DESCRIPTION
## Task

34787

## Description

Previously, if Reshape had input pattern with values [0, -1] - it propagated dynamic shape through a function. At the same time,
taking "0" and "-1" interpretation into consideration, it turns out in such cases we could just propagate the same input shape in case of 2D input.

For Faster-RCNN this fix makes static dimensions on dynamic paths static.