### PR TITLE
Header length for supported model detection is increased

### DIFF
--- a/inference-engine/src/readers/ir_reader/ie_ir_version.hpp
+++ b/inference-engine/src/readers/ir_reader/ie_ir_version.hpp
@@ -5,6 +5,7 @@
 
 #include <fstream>
 #include <xml_parse_utils.h>
+#include <array>
 
 namespace InferenceEngine {
 namespace details {
@@ -19,14 +20,14 @@ inline size_t GetIRVersion(pugi::xml_node& root) {
  * @return IR version, 0 if model does represent IR
  */
 size_t GetIRVersion(std::istream& model) {
+    std::array<char, 512> header = {};
+
     model.seekg(0, model.beg);
-    const int header_size = 128;
-    std::string header(header_size, ' ');
-    model.read(&header[0], header_size);
+    model.read(header.data(), header.size());
     model.seekg(0, model.beg);
 
     pugi::xml_document doc;
-    auto res = doc.load_string(header.c_str(), pugi::parse_default | pugi::parse_fragment);
+    auto res = doc.load_buffer(header.data(), header.size(), pugi::parse_default | pugi::parse_fragment, pugi::encoding_utf8);
 
     if (res == pugi::status_ok) {
         pugi::xml_node root = doc.document_element();

--- a/inference-engine/tests/functional/inference_engine/net_reader_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/net_reader_test.cpp
@@ -198,10 +198,19 @@ TEST(NetReaderTest, IRSupportModelDetection) {
 </net>
 )V0G0N";
 
+    // For supported model detection the IRReader uses first 512 bytes from model.
+    // These headers shifts the trim place.
+
     std::string headers[] = {
         R"()",
-        R"(<!-- <net name="Network" version="100500"> -->)",
-        R"(<!-- <net name="Network" version="10" some_attribute="Test Attribute"> -->)"
+        R"(<!-- <net name="Network" version="10" some_attribute="Test Attribute"> -->)",
+        R"(<!-- <net name="Network" version="10" some_attribute="Test Attribute"> -->
+<!-- <net name="Network" version="10" some_attribute="Test Attribute"> -->
+<!-- <net name="Network" version="10" some_attribute="Test Attribute"> -->
+<!-- <net name="Network" version="10" some_attribute="Test Attribute"> -->
+<!-- The quick brown fox jumps over the lazy dog -->
+<!-- The quick brown fox jumps over the lazy dog -->
+<!-- The quick brown fox jumps over the lazy dog -->)"
     };
 
     InferenceEngine::Blob::CPtr weights;


### PR DESCRIPTION
For some cases 128 byte header length is too short for support model detection. Therefore the header size is increased till 512 bytes.