### PR TITLE
Revert "Header length for supported model detection is increased"

### DIFF
--- a/inference-engine/src/readers/ir_reader/ie_ir_version.hpp
+++ b/inference-engine/src/readers/ir_reader/ie_ir_version.hpp
@@ -5,7 +5,6 @@
 
 #include <fstream>
 #include <xml_parse_utils.h>
-#include <array>
 
 namespace InferenceEngine {
 namespace details {
@@ -20,14 +19,14 @@ inline size_t GetIRVersion(pugi::xml_node& root) {
  * @return IR version, 0 if model does represent IR
  */
 size_t GetIRVersion(std::istream& model) {
-    std::array<char, 512> header = {};
-
     model.seekg(0, model.beg);
-    model.read(header.data(), header.size());
+    const int header_size = 128;
+    std::string header(header_size, ' ');
+    model.read(&header[0], header_size);
     model.seekg(0, model.beg);
 
     pugi::xml_document doc;
-    auto res = doc.load_buffer(header.data(), header.size(), pugi::parse_default | pugi::parse_fragment, pugi::encoding_utf8);
+    auto res = doc.load_string(header.c_str(), pugi::parse_default | pugi::parse_fragment);
 
     if (res == pugi::status_ok) {
         pugi::xml_node root = doc.document_element();

--- a/inference-engine/tests/functional/inference_engine/net_reader_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/net_reader_test.cpp
@@ -198,19 +198,10 @@ TEST(NetReaderTest, IRSupportModelDetection) {
 </net>
 )V0G0N";
 
-    // For supported model detection the IRReader uses first 512 bytes from model.
-    // These headers shifts the trim place.
-
     std::string headers[] = {
         R"()",
-        R"(<!-- <net name="Network" version="10" some_attribute="Test Attribute"> -->)",
-        R"(<!-- <net name="Network" version="10" some_attribute="Test Attribute"> -->
-<!-- <net name="Network" version="10" some_attribute="Test Attribute"> -->
-<!-- <net name="Network" version="10" some_attribute="Test Attribute"> -->
-<!-- <net name="Network" version="10" some_attribute="Test Attribute"> -->
-<!-- The quick brown fox jumps over the lazy dog -->
-<!-- The quick brown fox jumps over the lazy dog -->
-<!-- The quick brown fox jumps over the lazy dog -->)"
+        R"(<!-- <net name="Network" version="100500"> -->)",
+        R"(<!-- <net name="Network" version="10" some_attribute="Test Attribute"> -->)"
     };
 
     InferenceEngine::Blob::CPtr weights;


### PR DESCRIPTION
Reverts openvinotoolkit/openvino#1340 to check if this is a case of regression in ONNX CI check