### PR TITLE
Fix unsafe use of CPU_ISSET_S macro.

### DIFF
--- a/inference-engine/src/inference_engine/threading/ie_thread_affinity.cpp
+++ b/inference-engine/src/inference_engine/threading/ie_thread_affinity.cpp
@@ -57,10 +57,11 @@ bool PinThreadToVacantCore(int thrIdx, int hyperthreads, int ncores, const CpuSe
     }
 
     // Find index of 'cpu_idx'-th bit that equals to 1
-    int mapped_idx = -1;
+    int mapped_idx = 0;
     while (cpu_idx >= 0) {
-        if (CPU_ISSET_S(++mapped_idx, size, procMask.get()))
+        if (CPU_ISSET_S(mapped_idx, size, procMask.get()))
             --cpu_idx;
+        mapped_idx++;
     }
 
     CpuSet targetMask{CPU_ALLOC(ncores)};


### PR DESCRIPTION
Port of https://github.com/openvinotoolkit/openvino/pull/254/files

Don't increment mapped_idx via prefix increment within the argument of the
potentially unsafe CPU_ISSET_S macro. If the macro is expanded so that the
increment expression is evaluated multiple times, it will return unexpected
results.

While the glibc implementation of CPU_ISSET_S macro seems to be safe, the musl
libc (v1.1.23) version is unsafe and will evaluate the first argument of
CPU_ISSET_S three times.