### PR TITLE
Tests for keep_constant_inputs

### DIFF
--- a/inference-engine/tests/functional/inference_engine/keep_constant_inputs_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/keep_constant_inputs_tests.cpp
@@ -1,0 +1,102 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <cpp/ie_cnn_network.h>
+#include <cnn_network_impl.hpp>  // deprecated API
+
+#include <ngraph/function.hpp>
+#include <ngraph/opsets/opset1.hpp>
+#include <ngraph_ops/convolution_ie.hpp>
+#include <transformations/init_node_info.hpp>
+
+#include <ie_precision.hpp>
+#include <functional_test_utils/precision_utils.hpp>
+#include "ngraph_functions/builders.hpp"
+#include "ngraph_functions/subgraph_builders.hpp"
+#include "low_precision_transformations/network_helper.hpp"
+
+
+using namespace testing;
+using namespace InferenceEngine;
+
+bool isCNNNetworkQuantized(const InferenceEngine::CNNNetwork& network) {
+    CNNLayerPtr layerPtr = nullptr;
+    layerPtr = details::CNNNetworkHelper::getLayer(network, "FakeQuantize");
+    if (layerPtr != nullptr)
+        return true;
+    else
+        return false;
+}
+
+TEST(KeepConstantInputsTests, ConvertConvolutionNetwork) {
+    std::shared_ptr <ngraph::Function> f;
+    {
+        auto param1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 64, 64});
+        auto param2 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1});
+        auto convolution = std::make_shared<ngraph::op::ConvolutionIE>(param1, param2,
+                                                                       ngraph::Strides{1, 1},
+                                                                       ngraph::Strides{1, 1},
+                                                                       ngraph::CoordinateDiff{0, 0},
+                                                                       ngraph::CoordinateDiff{0, 0});
+        convolution->set_friendly_name("convolution");
+        auto result = std::make_shared<ngraph::op::Result>(convolution);
+
+        f = std::make_shared<ngraph::Function>(ngraph::ResultVector{result},
+                                               ngraph::ParameterVector{param1, param2});
+
+        ngraph::pass::InitNodeInfo().run_on_function(f);
+    }
+
+    InferenceEngine::CNNNetwork nGraphImpl(f);
+
+    ASSERT_FALSE(isCNNNetworkQuantized(nGraphImpl));
+
+//    try {
+//        auto net = std::make_shared<InferenceEngine::details::CNNNetworkImpl>(
+//                                                        static_cast<const InferenceEngine::ICNNNetwork &>(nGraphImpl));
+//    } catch (InferenceEngine::details::InferenceEngineException &err) {
+//        FAIL();
+//    }
+}
+
+
+TEST(KeepConstantInputsTests, ConvertConvolutionPoolReluNetwork) {
+    std::shared_ptr <ngraph::Function> f_ptr;
+
+    f_ptr = ngraph::builder::subgraph::makeConvPoolRelu();
+
+    ngraph::pass::InitNodeInfo().run_on_function(f_ptr);
+
+    InferenceEngine::CNNNetwork nGraphImpl(f_ptr);
+
+    ASSERT_FALSE(isCNNNetworkQuantized(nGraphImpl));
+
+//    try {
+//    auto net = std::make_shared<InferenceEngine::details::CNNNetworkImpl>(
+//                                                        static_cast<const InferenceEngine::ICNNNetwork &>(nGraphImpl));
+//    } catch (InferenceEngine::details::InferenceEngineException &err) {
+//        FAIL();
+//    }
+}
+
+TEST(KeepConstantInputsTests, ConvertConvBiasNetwork) {
+std::shared_ptr <ngraph::Function> f_ptr;
+
+f_ptr = ngraph::builder::subgraph::makeConvBias();
+
+ngraph::pass::InitNodeInfo().run_on_function(f_ptr);
+
+InferenceEngine::CNNNetwork nGraphImpl(f_ptr);
+
+ASSERT_FALSE(isCNNNetworkQuantized(nGraphImpl));
+
+//    try {
+//    auto net = std::make_shared<InferenceEngine::details::CNNNetworkImpl>(
+//                                                        static_cast<const InferenceEngine::ICNNNetwork &>(nGraphImpl));
+//    } catch (InferenceEngine::details::InferenceEngineException &err) {
+//        FAIL();
+//    }
+}

--- a/inference-engine/tests/functional/inference_engine/keep_constant_inputs_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/keep_constant_inputs_tests.cpp
@@ -43,31 +43,11 @@ int numberOfInputsForLayerInCNNNetwork(const InferenceEngine::CNNNetwork& networ
 
 void transformNetwork(std::shared_ptr<InferenceEngine::ICNNNetwork> clonedNetwork, bool keep_constant_inputs) {
     if (clonedNetwork->getFunction()) {
-        const auto transformations_callback = [](const std::shared_ptr<const ::ngraph::Node> &node) -> bool {
-            // DepthToSpace node implementation supports only equal input/output tensors with rank <= 5
-            if (auto dtsOp = std::dynamic_pointer_cast<const ::ngraph::opset3::DepthToSpace>(node)) {
-                return dtsOp->input_value(0).get_shape().size() <= 5lu &&
-                       dtsOp->input_value(0).get_shape().size() == dtsOp->get_output_shape(0).size();
-            }
-
-            // SpaceToDepth node implementation supports only equal input/output tensors with rank <= 5
-            if (auto stdOp = std::dynamic_pointer_cast<const ::ngraph::opset3::SpaceToDepth>(node)) {
-                return stdOp->input_value(0).get_shape().size() <= 5lu &&
-                       stdOp->input_value(0).get_shape().size() == stdOp->get_output_shape(0).size();
-            }
-
-            return std::dynamic_pointer_cast<const ::ngraph::opset2::Gelu>(node) ||
-                   std::dynamic_pointer_cast<const ::ngraph::opset2::BatchToSpace>(node) ||
-                   std::dynamic_pointer_cast<const ::ngraph::opset2::SpaceToBatch>(node) ||
-                   std::dynamic_pointer_cast<const ::ngraph::opset3::ShuffleChannels>(node);
-        };
         auto nGraphFunc = clonedNetwork->getFunction();
-
-        // Note: instead of running all Conversion Transformations you can make up your own transformation pipeline
-        ngraph::pass::CommonOptimizations(transformations_callback).run_on_function(nGraphFunc);
-        ngraph::pass::ConvertOpSet3ToOpSet2(transformations_callback).run_on_function(nGraphFunc);
-        ngraph::pass::ConvertOpSet2ToOpSet1(transformations_callback).run_on_function(nGraphFunc);
-        ngraph::pass::ConvertOpSet1ToLegacy(transformations_callback).run_on_function(nGraphFunc);
+        ngraph::pass::CommonOptimizations().run_on_function(nGraphFunc);
+        ngraph::pass::ConvertOpSet3ToOpSet2().run_on_function(nGraphFunc);
+        ngraph::pass::ConvertOpSet2ToOpSet1().run_on_function(nGraphFunc);
+        ngraph::pass::ConvertOpSet1ToLegacy().run_on_function(nGraphFunc);
         clonedNetwork = InferenceEngine::details::convertFunctionToICNNNetwork(nGraphFunc, *clonedNetwork, keep_constant_inputs);
     }
 }

--- a/inference-engine/tests/functional/inference_engine/keep_constant_inputs_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/keep_constant_inputs_tests.cpp
@@ -30,7 +30,7 @@
 using namespace testing;
 using namespace InferenceEngine;
 
-int isInputConstLayersInCNNNetwork(const InferenceEngine::CNNNetwork& network, std::string layerType) {
+int numberOfInputsForLayerInCNNNetwork(const InferenceEngine::CNNNetwork& network, std::string layerType) {
     int numberOfInputs = 0;
     InferenceEngine::CNNLayerPtr layer = nullptr;
 
@@ -89,7 +89,7 @@ TEST(KeepConstantInputsTests, ConvertConvolutionPoolReluNetworkWithTrue) {
     transformNetwork(clonedNetwork, true);
     InferenceEngine::CNNNetwork convertedNetwork(clonedNetwork);
     std::cout << "Check for conversion of ConvolutionPoolRelu Network with keep_constant_inputs = true" << std::endl;
-    ASSERT_GT(isInputConstLayersInCNNNetwork(convertedNetwork, "Convolution"), 1);
+    ASSERT_GT(numberOfInputsForLayerInCNNNetwork(convertedNetwork, "Convolution"), 1);
 }
 
 TEST(KeepConstantInputsTests, ConvertConvolutionPoolReluNetworkWithFalse) {
@@ -100,7 +100,7 @@ TEST(KeepConstantInputsTests, ConvertConvolutionPoolReluNetworkWithFalse) {
     transformNetwork(clonedNetwork, false);
     InferenceEngine::CNNNetwork convertedNetwork(clonedNetwork);
     std::cout << "Check for conversion of ConvolutionPoolRelu Network with keep_constant_inputs = false" << std::endl;
-    ASSERT_EQ(isInputConstLayersInCNNNetwork(convertedNetwork, "Convolution"), 1);
+    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(convertedNetwork, "Convolution"), 1);
 }
 
 TEST(KeepConstantInputsTests, ConvertConvolutionBiasNetworkWithTrue) {
@@ -111,7 +111,7 @@ TEST(KeepConstantInputsTests, ConvertConvolutionBiasNetworkWithTrue) {
     transformNetwork(clonedNetwork, true);
     InferenceEngine::CNNNetwork convertedNetwork(clonedNetwork);
     std::cout << "Check for conversion of ConvolutionBias Network with keep_constant_inputs = true" << std::endl;
-    ASSERT_GT(isInputConstLayersInCNNNetwork(convertedNetwork, "Convolution"), 1);
+    ASSERT_GT(numberOfInputsForLayerInCNNNetwork(convertedNetwork, "Convolution"), 1);
 }
 
 TEST(KeepConstantInputsTests, ConvertConvolutionBiasNetworkWithFalse) {
@@ -122,7 +122,7 @@ TEST(KeepConstantInputsTests, ConvertConvolutionBiasNetworkWithFalse) {
     transformNetwork(clonedNetwork, false);
     InferenceEngine::CNNNetwork convertedNetwork(clonedNetwork);
     std::cout << "Check for conversion of ConvolutionBias Network with keep_constant_inputs = false" << std::endl;
-    ASSERT_EQ(isInputConstLayersInCNNNetwork(convertedNetwork, "Convolution"), 1);
+    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(convertedNetwork, "Convolution"), 1);
 }
 
 TEST(KeepConstantInputsTests, ConvertFullyConnectedNetworkWithTrue) {
@@ -137,7 +137,7 @@ TEST(KeepConstantInputsTests, ConvertFullyConnectedNetworkWithTrue) {
     transformNetwork(clonedNetwork, true);
     InferenceEngine::CNNNetwork convertedNetwork(clonedNetwork);
     std::cout << "Check for conversion of FullyConnected Network with keep_constant_inputs = true" << std::endl;
-    ASSERT_GT(isInputConstLayersInCNNNetwork(convertedNetwork, "FullyConnected"), 1);
+    ASSERT_GT(numberOfInputsForLayerInCNNNetwork(convertedNetwork, "FullyConnected"), 1);
 }
 
 TEST(KeepConstantInputsTests, ConvertFullyConnectedNetworkWithFalse) {
@@ -152,5 +152,5 @@ TEST(KeepConstantInputsTests, ConvertFullyConnectedNetworkWithFalse) {
     transformNetwork(clonedNetwork, false);
     InferenceEngine::CNNNetwork convertedNetwork(clonedNetwork);
     std::cout << "Check for conversion of FullyConnected Network with keep_constant_inputs = false" << std::endl;
-    ASSERT_EQ(isInputConstLayersInCNNNetwork(convertedNetwork, "FullyConnected"), 1);
+    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(convertedNetwork, "FullyConnected"), 1);
 }

--- a/inference-engine/tests/functional/inference_engine/keep_constant_inputs_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/keep_constant_inputs_tests.cpp
@@ -17,15 +17,27 @@
 #include "ngraph_functions/builders.hpp"
 #include "ngraph_functions/subgraph_builders.hpp"
 #include "low_precision_transformations/network_helper.hpp"
-#include "convert_function_to_cnn_network.hpp"
+#include <convert_function_to_cnn_network.hpp>
+#include <transformations/common_optimizations/common_optimizations.hpp>
+#include <transformations/convert_opset1_to_legacy/convert_opset1_to_legacy.hpp>
+#include <transformations/convert_opset2_to_opset1/convert_opset2_to_opset1.hpp>
+#include <transformations/convert_opset3_to_opset2/convert_opset3_to_opset2.hpp>
+#include "generic_ie.hpp"
 #include "graph_tools.hpp"
+#include "functional_test_utils/low_precision_transformations/layer_transformation.hpp"
 
 using namespace testing;
 using namespace InferenceEngine;
 
 bool isInputConstLayersInCNNNetwork(const InferenceEngine::CNNNetwork& network, const std::string& layerType) {
     int numberOfInputs = 0;
-    auto layersInNetwork = network.getFunction()->get_ordered_ops();
+
+    if (network.getFunction())
+        std::cout << "network.getFunction() - success" << std::endl;
+    else
+        std::cout << "network.getFunction() - fails" << std::endl;
+
+    auto layersInNetwork = network.getFunction()->get_ops();
     for (auto layer : layersInNetwork) {
         if (std::string(layer->get_type_name()) == layerType) {
             std::cout << "Found layer " << layerType << std::endl;
@@ -41,12 +53,43 @@ TEST(KeepConstantInputsTests, ConvertConvolutionPoolReluNetworkWithTrue) {
     std::shared_ptr <ngraph::Function> f_ptr;
     f_ptr = ngraph::builder::subgraph::makeConvPoolRelu();
     InferenceEngine::CNNNetwork originalNetwork(f_ptr);
-    std::shared_ptr<ICNNNetwork> ptrToConvertedNetwork;
-//    ptrToConvertedNetwork = InferenceEngine::details::convertFunctionToICNNNetwork(f_ptr, originalNetwork, true);
-//    InferenceEngine::CNNNetwork convertedNetwork(ptrToConvertedNetwork->getFunction());
+
+    std::shared_ptr<InferenceEngine::ICNNNetwork> clonedNetwork = InferenceEngine::cloneNetwork(originalNetwork);
+
+    if (clonedNetwork->getFunction()) {
+        const auto transformations_callback = [](const std::shared_ptr<const ::ngraph::Node> &node) -> bool {
+            // DepthToSpace node implementation supports only equal input/output tensors with rank <= 5
+            if (auto dtsOp = std::dynamic_pointer_cast<const ::ngraph::opset3::DepthToSpace>(node)) {
+                return dtsOp->input_value(0).get_shape().size() <= 5lu &&
+                       dtsOp->input_value(0).get_shape().size() == dtsOp->get_output_shape(0).size();
+            }
+
+            // SpaceToDepth node implementation supports only equal input/output tensors with rank <= 5
+            if (auto stdOp = std::dynamic_pointer_cast<const ::ngraph::opset3::SpaceToDepth>(node)) {
+                return stdOp->input_value(0).get_shape().size() <= 5lu &&
+                       stdOp->input_value(0).get_shape().size() == stdOp->get_output_shape(0).size();
+            }
+
+            return std::dynamic_pointer_cast<const ::ngraph::opset2::Gelu>(node) ||
+                   std::dynamic_pointer_cast<const ::ngraph::opset2::BatchToSpace>(node) ||
+                   std::dynamic_pointer_cast<const ::ngraph::opset2::SpaceToBatch>(node) ||
+                   std::dynamic_pointer_cast<const ::ngraph::opset3::ShuffleChannels>(node);
+        };
+        auto nGraphFunc = clonedNetwork->getFunction();
+        // Disable shape inference (WA for generic operations)
+        ::ngraph::op::GenericIE::DisableReshape noReshape(nGraphFunc);
+
+        // Note: instead of running all Conversion Transformations you can make up your own transformation pipeline
+        ngraph::pass::CommonOptimizations(transformations_callback).run_on_function(nGraphFunc);
+        ngraph::pass::ConvertOpSet3ToOpSet2(transformations_callback).run_on_function(nGraphFunc);
+        ngraph::pass::ConvertOpSet2ToOpSet1(transformations_callback).run_on_function(nGraphFunc);
+        ngraph::pass::ConvertOpSet1ToLegacy(transformations_callback).run_on_function(nGraphFunc);
+        clonedNetwork = InferenceEngine::details::convertFunctionToICNNNetwork(nGraphFunc, *clonedNetwork, true);
+    }
+    InferenceEngine::CNNNetwork convertedNetwork(clonedNetwork);
 
     ASSERT_TRUE(isInputConstLayersInCNNNetwork(originalNetwork, "Convolution"));
-//    ASSERT_TRUE(isInputConstLayersInCNNNetwork(convertedNetwork, "Convvolution"));
+    ASSERT_TRUE(isInputConstLayersInCNNNetwork(convertedNetwork, "Convolution"));
 }
 
 //TEST(KeepConstantInputsTests, ConvertConvolutionPoolReluNetworkWithFalse) {

--- a/inference-engine/tests/functional/inference_engine/keep_constant_inputs_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/keep_constant_inputs_tests.cpp
@@ -57,7 +57,7 @@ TEST(KeepConstantInputsTests, ConvertConvolutionPoolReluNetworkWithTrue) {
     f_ptr = ngraph::builder::subgraph::makeConvPoolRelu();
     InferenceEngine::CNNNetwork originalNetwork(f_ptr);
     transformNetwork(originalNetwork, true);
-    ASSERT_GT(numberOfInputsForLayerInCNNNetwork(originalNetwork, "Convolution"), 1);
+    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "Convolution"), 2);
 }
 
 TEST(KeepConstantInputsTests, ConvertConvolutionPoolReluNetworkWithFalse) {
@@ -73,7 +73,7 @@ TEST(KeepConstantInputsTests, ConvertConvolutionBiasNetworkWithTrue) {
     f_ptr = ngraph::builder::subgraph::makeConvBias();
     InferenceEngine::CNNNetwork originalNetwork(f_ptr);
     transformNetwork(originalNetwork, true);
-    ASSERT_GT(numberOfInputsForLayerInCNNNetwork(originalNetwork, "Convolution"), 1);
+    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "Convolution"), 3);
 }
 
 TEST(KeepConstantInputsTests, ConvertConvolutionBiasNetworkWithFalse) {
@@ -93,7 +93,7 @@ TEST(KeepConstantInputsTests, ConvertFullyConnectedNetworkWithTrue) {
     f_ptr = std::make_shared<ngraph::Function>(ngraph::NodeVector{fc}, ngraph::ParameterVector{input1});
     InferenceEngine::CNNNetwork originalNetwork(f_ptr);
     transformNetwork(originalNetwork, true);
-    ASSERT_GT(numberOfInputsForLayerInCNNNetwork(originalNetwork, "FullyConnected"), 1);
+    ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "FullyConnected"), 3);
 }
 
 TEST(KeepConstantInputsTests, ConvertFullyConnectedNetworkWithFalse) {

--- a/inference-engine/tests/functional/inference_engine/keep_constant_inputs_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/keep_constant_inputs_tests.cpp
@@ -23,21 +23,16 @@
 using namespace testing;
 using namespace InferenceEngine;
 
-bool isInputConstLayersInCNNNetwork(const InferenceEngine::CNNNetwork& network, const std::string& layerName) {
+bool isInputConstLayersInCNNNetwork(const InferenceEngine::CNNNetwork& network, const std::string& layerType) {
     int numberOfInputs = 0;
-    CNNLayerPtr layerPtr = nullptr, parentLayerPtr = nullptr;
-    layerPtr = details::CNNNetworkHelper::getLayer(network, layerName);
-    if (layerPtr != nullptr) {
-        std::cout << "Found layer: " << layerPtr->name << ", type: " << layerPtr->type << std::endl;
-        std::cout << "Input dimensions: {";
-        for (auto dimention : layerPtr->input()->getDims()) {
-            std::cout << dimention << ", ";
+    auto layersInNetwork = network.getFunction()->get_ordered_ops();
+    for (auto layer : layersInNetwork) {
+        if (std::string(layer->get_type_name()) == layerType) {
+            std::cout << "Found layer " << layerType << std::endl;
+            numberOfInputs = layer->get_input_size();
+            std::cout << "Number of inputs in " << layerType << " = " << numberOfInputs << std::endl;
+            break;
         }
-        std::cout << "\b\b}" << std::endl;
-        numberOfInputs = layerPtr->input()->getDims().size() / 2;
-//        std::cout << "Input dims size: " << layerPtr->input()->getDims().size() << std::endl;
-//        std::cout << "Input layout: " << layerPtr->input()->getLayout() << std::endl;
-        std::cout << "Number of inputs: " << numberOfInputs << std::endl;
     }
     return  numberOfInputs > 1;
 }
@@ -50,8 +45,8 @@ TEST(KeepConstantInputsTests, ConvertConvolutionPoolReluNetworkWithTrue) {
 //    ptrToConvertedNetwork = InferenceEngine::details::convertFunctionToICNNNetwork(f_ptr, originalNetwork, true);
 //    InferenceEngine::CNNNetwork convertedNetwork(ptrToConvertedNetwork->getFunction());
 
-    ASSERT_TRUE(isInputConstLayersInCNNNetwork(originalNetwork, "Conv_1"));
-//    ASSERT_TRUE(isInputConstLayersInCNNNetwork(convertedNetwork, "Conv_1"));
+    ASSERT_TRUE(isInputConstLayersInCNNNetwork(originalNetwork, "Convolution"));
+//    ASSERT_TRUE(isInputConstLayersInCNNNetwork(convertedNetwork, "Convvolution"));
 }
 
 //TEST(KeepConstantInputsTests, ConvertConvolutionPoolReluNetworkWithFalse) {


### PR DESCRIPTION
There are six tests for checking bool variable keep_constant_inputs in function InferenceEngine::details::convertFunctionToICNNNetwork().