### PR TITLE
Update ShapeOf extender

### DIFF
--- a/model-optimizer/mo/utils/ir_reader/extenders/shape_of_extender.py
+++ b/model-optimizer/mo/utils/ir_reader/extenders/shape_of_extender.py
@@ -24,4 +24,5 @@ class ShapeOfExtender(Extender):
 
     @staticmethod
     def extend(op: Node):
-        op['output_type'] = destination_type_to_np_data_type(op.output_type)
+        if op.has_valid('output_type'):
+            op['output_type'] = destination_type_to_np_data_type(op.output_type)


### PR DESCRIPTION
Description: Update ShapeOf extender in MO IR Reader

JIRA: CVS-35443


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names


Validation:
* [x]  Unit tests: Not needed - nothing to update
* [x]  Framework operation tests: Not needed - no new 
* [x]  Transformation tests: Not needed - no new transformation enabled
* [x]  e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py: Not needed - nothing to update
* [x]  Model Optimizer IR Reader check: Done

Documentation:
* [x]  Supported frameworks operations list: Not needed - nothing to update
* [x]  Supported **public** models list: Not needed - nothing to update
* [x]  New operations specification: Not needed - no new operations
* [x]  Guide on how to convert the **public** model: Not needed - no new supported models
* [x]  User guide update: Not needed - nothing to update