### PR TITLE
[IE CLDNN] Extend Gather bfyx WA

### DIFF
--- a/inference-engine/src/cldnn_engine/cldnn_program.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_program.cpp
@@ -3807,7 +3807,8 @@ void Program::CreateGatherPrimitive(cldnn::topology& topology, InferenceEngine::
         if (inputDims.size() < 4) {
             inputDims.resize(4, 1);
         }
-        outDims[nonNegativeAxis + indicesDims.size()] = std::accumulate(outDims.begin() + nonNegativeAxis + indicesDims.size(), outDims.end(), 1, std::multiplies<size_t>());
+        outDims[nonNegativeAxis + indicesDims.size()] = std::accumulate(outDims.begin() + nonNegativeAxis + indicesDims.size(),
+                                                                        outDims.end(), 1, std::multiplies<size_t>());
         outDims.erase(outDims.begin() + nonNegativeAxis + indicesDims.size() + 1, outDims.end());
         if (outDims.size() < 4 + indicesDims.size() - 1) {
             outDims.resize(4 + indicesDims.size() - 1, 1);

--- a/inference-engine/src/cldnn_engine/cldnn_program.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_program.cpp
@@ -3843,6 +3843,9 @@ void Program::CreateGatherPrimitive(cldnn::topology& topology, InferenceEngine::
             }
             if (dimFoundAtIndex == -1) {
                 originalAxesIt = originalRequiredDims.insert(originalAxesIt, i);
+                if (originalRequiredDims.size() >= 4) {
+                    break;
+                }
             }
             originalAxesIt++;
         }

--- a/inference-engine/src/cldnn_engine/cldnn_program.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_program.cpp
@@ -3802,14 +3802,22 @@ void Program::CreateGatherPrimitive(cldnn::topology& topology, InferenceEngine::
 
     // following code is meant to support cases where we can merge dims after the one specified by 'axis'
     if (nonNegativeAxis < 3) {
-        inputDims[nonNegativeAxis + 1] = std::accumulate(inputDims.begin() + nonNegativeAxis + 1, inputDims.end(), 1, std::multiplies<size_t>());
-        inputDims.erase(inputDims.begin() + nonNegativeAxis + 2, inputDims.end());
+        if (inputDims.size() > nonNegativeAxis + 1) {
+            inputDims[nonNegativeAxis + 1] = std::accumulate(inputDims.begin() + nonNegativeAxis + 1, inputDims.end(), 1, std::multiplies<size_t>());
+        }
+        if (inputDims.size() > nonNegativeAxis + 2) {
+            inputDims.erase(inputDims.begin() + nonNegativeAxis + 2, inputDims.end());
+        }
         if (inputDims.size() < 4) {
             inputDims.resize(4, 1);
         }
-        outDims[nonNegativeAxis + indicesDims.size()] = std::accumulate(outDims.begin() + nonNegativeAxis + indicesDims.size(),
-                                                                        outDims.end(), 1, std::multiplies<size_t>());
-        outDims.erase(outDims.begin() + nonNegativeAxis + indicesDims.size() + 1, outDims.end());
+        if (outDims.size() > nonNegativeAxis + indicesDims.size()) {
+            outDims[nonNegativeAxis + indicesDims.size()] = std::accumulate(outDims.begin() + nonNegativeAxis + indicesDims.size(),
+                                                                            outDims.end(), 1, std::multiplies<size_t>());
+        }
+        if (outDims.size() > nonNegativeAxis + indicesDims.size() + 1) {
+            outDims.erase(outDims.begin() + nonNegativeAxis + indicesDims.size() + 1, outDims.end());
+        }
         if (outDims.size() < 4 + indicesDims.size() - 1) {
             outDims.resize(4 + indicesDims.size() - 1, 1);
         }

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/gather.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/gather.cpp
@@ -47,4 +47,211 @@ INSTANTIATE_TEST_CASE_P(
         GatherLayerTest::getTestCaseName
 );
 
+// TODO: remove additional bfyx WA tests below and add 5d/6d test cases to cartesian product above
+// when proper support of any inputs of that kind will be added to clDNN Gather primitive
+
+const std::vector<std::vector<size_t>> indicesShapes1d = {
+        std::vector<size_t>{4}
+};
+
+const std::vector<std::vector<size_t>> indicesShapes2d = {
+        std::vector<size_t>{2, 2}
+};
+
+// For axes 0, 1 and 2 we can provide pretty much any input, as dimensions after 'axis'
+// will be merged, so we will end up in bfyx format anyway
+
+const std::vector<std::vector<size_t>> inputShapesWAInd1dAxis012 = {
+        std::vector<size_t>{5, 6, 7, 8, 9},
+        std::vector<size_t>{5, 6, 7, 8, 9, 10},
+};
+
+const auto paramsWAInd1dAxis012 = testing::Combine(
+        testing::ValuesIn(indices),
+        testing::ValuesIn(indicesShapes1d),
+        testing::ValuesIn({0, 1, 2}),
+        testing::ValuesIn(inputShapesWAInd1dAxis012),
+        testing::ValuesIn(netPrecisions),
+        testing::Values(CommonTestUtils::DEVICE_GPU)
+);
+
+INSTANTIATE_TEST_CASE_P(
+        GatherBfyxWaInd1dAxis012,
+        GatherLayerTest,
+        paramsWAInd1dAxis012,
+        GatherLayerTest::getTestCaseName
+);
+
+const std::vector<std::vector<size_t>> inputShapesWAInd2dAxis012 = {
+        std::vector<size_t>{5, 6, 7, 8},
+        std::vector<size_t>{5, 6, 7, 8, 9},
+};
+
+const auto paramsWAInd2dAxis012 = testing::Combine(
+        testing::ValuesIn(indices),
+        testing::ValuesIn(indicesShapes2d),
+        testing::ValuesIn({0, 1, 2}),
+        testing::ValuesIn(inputShapesWAInd2dAxis012),
+        testing::ValuesIn(netPrecisions),
+        testing::Values(CommonTestUtils::DEVICE_GPU)
+);
+
+INSTANTIATE_TEST_CASE_P(
+        GatherBfyxWaInd2dAxis012,
+        GatherLayerTest,
+        paramsWAInd2dAxis012,
+        GatherLayerTest::getTestCaseName
+);
+
+// For axes 3, 4 and 5 we can still support some inputs, as long as
+// they have enough unit dimensions to convert whole operation to bfyx format
+
+const std::vector<std::vector<size_t>> inputShapesWAInd1dAxis3 = {
+        std::vector<size_t>{1, 6, 7, 8, 9},
+        std::vector<size_t>{5, 1, 7, 8, 9},
+        std::vector<size_t>{5, 6, 1, 8, 9},
+        std::vector<size_t>{5, 6, 7, 8, 1},
+        std::vector<size_t>{1, 1, 7, 8, 9, 10},
+        std::vector<size_t>{5, 1, 1, 8, 9, 10},
+        std::vector<size_t>{5, 6, 1, 8, 1, 10},
+        std::vector<size_t>{5, 6, 7, 8, 1, 1},
+        std::vector<size_t>{1, 6, 1, 8, 9, 10},
+        std::vector<size_t>{5, 1, 7, 8, 1, 10},
+        std::vector<size_t>{5, 6, 1, 8, 9, 1},
+        std::vector<size_t>{1, 6, 7, 8, 1, 10},
+        std::vector<size_t>{5, 1, 7, 8, 9, 1},
+        std::vector<size_t>{1, 6, 7, 8, 9, 1},
+};
+
+const auto paramsWAInd1dAxis3 = testing::Combine(
+        testing::ValuesIn(indices),
+        testing::ValuesIn(indicesShapes1d),
+        testing::ValuesIn({3}),
+        testing::ValuesIn(inputShapesWAInd1dAxis3),
+        testing::ValuesIn(netPrecisions),
+        testing::Values(CommonTestUtils::DEVICE_GPU)
+);
+
+INSTANTIATE_TEST_CASE_P(
+        GatherBfyxWaInd1dAxis3,
+        GatherLayerTest,
+        paramsWAInd1dAxis3,
+        GatherLayerTest::getTestCaseName
+);
+
+const std::vector<std::vector<size_t>> inputShapesWAInd2dAxis3 = {
+        std::vector<size_t>{1, 6, 7, 8},
+        std::vector<size_t>{5, 1, 7, 8},
+        std::vector<size_t>{5, 6, 1, 8},
+        std::vector<size_t>{1, 1, 7, 8, 9},
+        std::vector<size_t>{5, 1, 1, 8, 9},
+        std::vector<size_t>{5, 6, 1, 8, 1},
+        std::vector<size_t>{1, 6, 1, 8, 9},
+        std::vector<size_t>{5, 1, 7, 8, 1},
+        std::vector<size_t>{1, 6, 7, 8, 1},
+};
+
+const auto paramsWAInd2dAxis3 = testing::Combine(
+        testing::ValuesIn(indices),
+        testing::ValuesIn(indicesShapes2d),
+        testing::ValuesIn({3}),
+        testing::ValuesIn(inputShapesWAInd2dAxis3),
+        testing::ValuesIn(netPrecisions),
+        testing::Values(CommonTestUtils::DEVICE_GPU)
+);
+
+INSTANTIATE_TEST_CASE_P(
+        GatherBfyxWaInd2dAxis3,
+        GatherLayerTest,
+        paramsWAInd2dAxis3,
+        GatherLayerTest::getTestCaseName
+);
+
+const std::vector<std::vector<size_t>> inputShapesWAInd1dAxis4 = {
+        std::vector<size_t>{1, 6, 7, 8, 9},
+        std::vector<size_t>{5, 1, 7, 8, 9},
+        std::vector<size_t>{5, 6, 1, 8, 9},
+        std::vector<size_t>{5, 6, 7, 1, 9},
+        std::vector<size_t>{1, 1, 7, 8, 9, 10},
+        std::vector<size_t>{5, 1, 1, 8, 9, 10},
+        std::vector<size_t>{5, 6, 1, 1, 9, 10},
+        std::vector<size_t>{5, 6, 7, 1, 9, 1},
+        std::vector<size_t>{1, 6, 1, 8, 9, 10},
+        std::vector<size_t>{5, 1, 7, 1, 9, 10},
+        std::vector<size_t>{5, 6, 1, 8, 9, 1},
+        std::vector<size_t>{1, 6, 7, 1, 9, 10},
+        std::vector<size_t>{5, 1, 7, 8, 9, 1},
+        std::vector<size_t>{1, 6, 7, 8, 9, 1},
+};
+
+const auto paramsWAInd1dAxis4 = testing::Combine(
+        testing::ValuesIn(indices),
+        testing::ValuesIn(indicesShapes1d),
+        testing::ValuesIn({4}),
+        testing::ValuesIn(inputShapesWAInd1dAxis4),
+        testing::ValuesIn(netPrecisions),
+        testing::Values(CommonTestUtils::DEVICE_GPU)
+);
+
+INSTANTIATE_TEST_CASE_P(
+        GatherBfyxWaInd1dAxis4,
+        GatherLayerTest,
+        paramsWAInd1dAxis4,
+        GatherLayerTest::getTestCaseName
+);
+
+const std::vector<std::vector<size_t>> inputShapesWAInd2dAxis4 = {
+        std::vector<size_t>{1, 1, 7, 8, 9},
+        std::vector<size_t>{5, 1, 1, 8, 9},
+        std::vector<size_t>{5, 6, 1, 1, 9},
+        std::vector<size_t>{1, 6, 1, 8, 9},
+        std::vector<size_t>{5, 1, 7, 1, 9},
+        std::vector<size_t>{1, 6, 7, 1, 9},
+};
+
+const auto paramsWAInd2dAxis4 = testing::Combine(
+        testing::ValuesIn(indices),
+        testing::ValuesIn(indicesShapes2d),
+        testing::ValuesIn({4}),
+        testing::ValuesIn(inputShapesWAInd2dAxis4),
+        testing::ValuesIn(netPrecisions),
+        testing::Values(CommonTestUtils::DEVICE_GPU)
+);
+
+INSTANTIATE_TEST_CASE_P(
+        GatherBfyxWaInd2dAxis4,
+        GatherLayerTest,
+        paramsWAInd2dAxis4,
+        GatherLayerTest::getTestCaseName
+);
+
+const std::vector<std::vector<size_t>> inputShapesWAInd1dAxis5 = {
+        std::vector<size_t>{1, 1, 7, 8, 9, 10},
+        std::vector<size_t>{5, 1, 1, 8, 9, 10},
+        std::vector<size_t>{5, 6, 1, 1, 9, 10},
+        std::vector<size_t>{5, 6, 7, 1, 1, 10},
+        std::vector<size_t>{1, 6, 1, 8, 9, 10},
+        std::vector<size_t>{5, 1, 7, 1, 9, 10},
+        std::vector<size_t>{5, 6, 1, 8, 1, 10},
+        std::vector<size_t>{1, 6, 7, 1, 9, 10},
+        std::vector<size_t>{5, 1, 7, 8, 1, 10},
+        std::vector<size_t>{1, 6, 7, 8, 1, 10},
+};
+
+const auto paramsWAInd1dAxis5 = testing::Combine(
+        testing::ValuesIn(indices),
+        testing::ValuesIn(indicesShapes1d),
+        testing::ValuesIn({5}),
+        testing::ValuesIn(inputShapesWAInd1dAxis5),
+        testing::ValuesIn(netPrecisions),
+        testing::Values(CommonTestUtils::DEVICE_GPU)
+);
+
+INSTANTIATE_TEST_CASE_P(
+        GatherBfyxWaInd1dAxis5,
+        GatherLayerTest,
+        paramsWAInd1dAxis5,
+        GatherLayerTest::getTestCaseName
+);
+
 }  // namespace

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/gather.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/gather.cpp
@@ -61,6 +61,8 @@ const std::vector<std::vector<size_t>> indicesShapes2d = {
 // For axes 0, 1 and 2 we can provide pretty much any input, as dimensions after 'axis'
 // will be merged, so we will end up in bfyx format anyway
 
+const std::vector<int> axes012 = {0, 1, 2};
+
 const std::vector<std::vector<size_t>> inputShapesWAInd1dAxis012 = {
         std::vector<size_t>{5, 6, 7, 8, 9},
         std::vector<size_t>{5, 6, 7, 8, 9, 10},
@@ -69,7 +71,7 @@ const std::vector<std::vector<size_t>> inputShapesWAInd1dAxis012 = {
 const auto paramsWAInd1dAxis012 = testing::Combine(
         testing::ValuesIn(indices),
         testing::ValuesIn(indicesShapes1d),
-        testing::ValuesIn({0, 1, 2}),
+        testing::ValuesIn(axes012),
         testing::ValuesIn(inputShapesWAInd1dAxis012),
         testing::ValuesIn(netPrecisions),
         testing::Values(CommonTestUtils::DEVICE_GPU)
@@ -90,7 +92,7 @@ const std::vector<std::vector<size_t>> inputShapesWAInd2dAxis012 = {
 const auto paramsWAInd2dAxis012 = testing::Combine(
         testing::ValuesIn(indices),
         testing::ValuesIn(indicesShapes2d),
-        testing::ValuesIn({0, 1, 2}),
+        testing::ValuesIn(axes012),
         testing::ValuesIn(inputShapesWAInd2dAxis012),
         testing::ValuesIn(netPrecisions),
         testing::Values(CommonTestUtils::DEVICE_GPU)
@@ -105,6 +107,8 @@ INSTANTIATE_TEST_CASE_P(
 
 // For axes 3, 4 and 5 we can still support some inputs, as long as
 // they have enough unit dimensions to convert whole operation to bfyx format
+
+const std::vector<int> axis3 = {3};
 
 const std::vector<std::vector<size_t>> inputShapesWAInd1dAxis3 = {
         std::vector<size_t>{1, 6, 7, 8, 9},
@@ -126,7 +130,7 @@ const std::vector<std::vector<size_t>> inputShapesWAInd1dAxis3 = {
 const auto paramsWAInd1dAxis3 = testing::Combine(
         testing::ValuesIn(indices),
         testing::ValuesIn(indicesShapes1d),
-        testing::ValuesIn({3}),
+        testing::ValuesIn(axis3),
         testing::ValuesIn(inputShapesWAInd1dAxis3),
         testing::ValuesIn(netPrecisions),
         testing::Values(CommonTestUtils::DEVICE_GPU)
@@ -154,7 +158,7 @@ const std::vector<std::vector<size_t>> inputShapesWAInd2dAxis3 = {
 const auto paramsWAInd2dAxis3 = testing::Combine(
         testing::ValuesIn(indices),
         testing::ValuesIn(indicesShapes2d),
-        testing::ValuesIn({3}),
+        testing::ValuesIn(axis3),
         testing::ValuesIn(inputShapesWAInd2dAxis3),
         testing::ValuesIn(netPrecisions),
         testing::Values(CommonTestUtils::DEVICE_GPU)
@@ -166,6 +170,8 @@ INSTANTIATE_TEST_CASE_P(
         paramsWAInd2dAxis3,
         GatherLayerTest::getTestCaseName
 );
+
+const std::vector<int> axis4 = {4};
 
 const std::vector<std::vector<size_t>> inputShapesWAInd1dAxis4 = {
         std::vector<size_t>{1, 6, 7, 8, 9},
@@ -187,7 +193,7 @@ const std::vector<std::vector<size_t>> inputShapesWAInd1dAxis4 = {
 const auto paramsWAInd1dAxis4 = testing::Combine(
         testing::ValuesIn(indices),
         testing::ValuesIn(indicesShapes1d),
-        testing::ValuesIn({4}),
+        testing::ValuesIn(axis4),
         testing::ValuesIn(inputShapesWAInd1dAxis4),
         testing::ValuesIn(netPrecisions),
         testing::Values(CommonTestUtils::DEVICE_GPU)
@@ -212,7 +218,7 @@ const std::vector<std::vector<size_t>> inputShapesWAInd2dAxis4 = {
 const auto paramsWAInd2dAxis4 = testing::Combine(
         testing::ValuesIn(indices),
         testing::ValuesIn(indicesShapes2d),
-        testing::ValuesIn({4}),
+        testing::ValuesIn(axis4),
         testing::ValuesIn(inputShapesWAInd2dAxis4),
         testing::ValuesIn(netPrecisions),
         testing::Values(CommonTestUtils::DEVICE_GPU)
@@ -224,6 +230,8 @@ INSTANTIATE_TEST_CASE_P(
         paramsWAInd2dAxis4,
         GatherLayerTest::getTestCaseName
 );
+
+const std::vector<int> axis5 = {5};
 
 const std::vector<std::vector<size_t>> inputShapesWAInd1dAxis5 = {
         std::vector<size_t>{1, 1, 7, 8, 9, 10},
@@ -241,7 +249,7 @@ const std::vector<std::vector<size_t>> inputShapesWAInd1dAxis5 = {
 const auto paramsWAInd1dAxis5 = testing::Combine(
         testing::ValuesIn(indices),
         testing::ValuesIn(indicesShapes1d),
-        testing::ValuesIn({5}),
+        testing::ValuesIn(axis5),
         testing::ValuesIn(inputShapesWAInd1dAxis5),
         testing::ValuesIn(netPrecisions),
         testing::Values(CommonTestUtils::DEVICE_GPU)


### PR DESCRIPTION
This patch is meant to extend bf(w)zyx->bfyx fallback WA for Gather primitive by supporting cases where dimensions after the one specified by 'axis' may be merged together.

JIRA: CVS-35239