### PR TITLE
[IE CLDNN] -Werror=pessimizing-move GCC-9 compiler fix

### DIFF
--- a/inference-engine/thirdparty/clDNN/common/khronos_ocl_clhpp/cl2.hpp
+++ b/inference-engine/thirdparty/clDNN/common/khronos_ocl_clhpp/cl2.hpp
@@ -1896,6 +1896,9 @@ struct ImageFormat : public cl_image_format
         image_channel_data_type = type;
     }
 
+    //! \brief Default constexpr copy constructor.
+    constexpr ImageFormat(const ImageFormat& rhs) = default;
+
     //! \brief Assignment operator.
     ImageFormat& operator = (const ImageFormat& rhs)
     {

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/fully_connected/fully_connected_kernel_fs_byx_fsv32.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/fully_connected/fully_connected_kernel_fs_byx_fsv32.cpp
@@ -60,7 +60,7 @@ FullyConnected_fs_byx_fsv32::Parent::DispatchData FullyConnected_fs_byx_fsv32::S
 
     runInfo.efficiency = FORCE_PRIORITY_5;
 
-    return std::move(runInfo);
+    return runInfo;
 }
 
 JitConstants FullyConnected_fs_byx_fsv32::GetJitConstants(const fully_connected_params& params,

--- a/inference-engine/thirdparty/clDNN/src/gpu/kernels_cache.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/kernels_cache.cpp
@@ -74,7 +74,7 @@ std::string get_undef_jit(kernels_cache::source_code org_source_code) {
         undefs += "#endif\n";
     }
 
-    return std::move(undefs);
+    return undefs;
 }
 
 std::string reorder_options(const std::string& org_options) {
@@ -159,7 +159,7 @@ kernels_cache::sorted_code kernels_cache::get_program_source(const kernels_code&
         current_bucket.kernels_counter++;
     }
 
-    return std::move(scode);
+    return scode;
 }
 
 kernels_cache::kernels_cache(gpu_toolkit& context, uint32_t prog_id) : _context(context), _prog_id(prog_id) {}


### PR DESCRIPTION
These changes fix incorrect usage of std::move() function that prevented to apply return value optimization for an object to be returned to the caller without needing to copy that object.

JIRA: 35519