### PR TITLE
[samples] Fix the case when run stage of verification scripts failed on Windows 10 due to invaild build directory

### DIFF
--- a/scripts/demo/demo_security_barrier_camera.bat
+++ b/scripts/demo/demo_security_barrier_camera.bat
@@ -197,7 +197,13 @@ echo ###############^|^| Run Inference Engine security barrier camera demo ^|^|#
 echo.
 timeout 3
 cd "%SOLUTION_DIR64%\intel64\Release"
-echo "%SOLUTION_DIR64%\intel64\Release\security_barrier_camera_demo.exe" -i "%target_image_path%" %model_args% -d !TARGET! -d_va !TARGET! -d_lpr !TARGET! !SAMPLE_OPTIONS!
+if not exist security_barrier_camera_demo.exe (
+   cd "%INTEL_OPENVINO_DIR%\inference_engine\demos\intel64\Release"
+   echo "%INTEL_OPENVINO_DIR%\inference_engine\demos\intel64\Release\security_barrier_camera_demo.exe" -i "%target_image_path%" %model_args% -d !TARGET! -d_va !TARGET! -d_lpr !TARGET! !SAMPLE_OPTIONS!
+)
+else (
+   echo "%SOLUTION_DIR64%\intel64\Release\security_barrier_camera_demo.exe" -i "%target_image_path%" %model_args% -d !TARGET! -d_va !TARGET! -d_lpr !TARGET! !SAMPLE_OPTIONS!
+)
 security_barrier_camera_demo.exe -i "%target_image_path%" %model_args% ^
                                  -d !TARGET! -d_va !TARGET! -d_lpr !TARGET! !SAMPLE_OPTIONS!
 if ERRORLEVEL 1 GOTO errorHandling

--- a/scripts/demo/demo_squeezenet_download_convert_run.bat
+++ b/scripts/demo/demo_squeezenet_download_convert_run.bat
@@ -229,7 +229,9 @@ echo.
 timeout 3
 copy /Y "%ROOT_DIR%%model_name%.labels" "%ir_dir%"
 cd "%SOLUTION_DIR64%\intel64\Release"
-
+if not exist classification_sample_async.exe (
+   cd "%INTEL_OPENVINO_DIR%\inference_engine\samples\cpp\intel64\Release"
+)
 echo classification_sample_async.exe -i "%target_image_path%" -m "%ir_dir%\%model_name%.xml" -d !TARGET! !SAMPLE_OPTIONS!
 classification_sample_async.exe -i "%target_image_path%" -m "%ir_dir%\%model_name%.xml" -d !TARGET! !SAMPLE_OPTIONS!
 


### PR DESCRIPTION
See #1473 
I've added checks whether executables exists in **%SOLUTION_DIR64%\intel64\Release** and if not then try 
**cd "%INTEL_OPENVINO_DIR%\inference_engine\samples\cpp\intel64\Release"** for **demo_squeezenet_download_convert_run.bat** and **"%INTEL_OPENVINO_DIR%\inference_engine\demos\intel64\Release"** for **demo_security_barrier_camera.bat**.