### PR TITLE
[IE CLDNN] Fixes for 1d ScaleShift and Eltwise

### DIFF
--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/skip_tests_config.cpp
@@ -9,9 +9,6 @@
 
 std::vector<std::string> disabledTestPatterns() {
     return {
-            // cldnn treats 1d constant as [1, f, 1, 1] tensor instead of [b, 1, 1, 1] which leads to fails of these tests
-            R"(.*(EltwiseLayerTest).*IS=\(.*\..*\..*\..*\..*\).*secondaryInputType=CONSTANT.*opType=SCALAR.*)",
-            R"(.*(EltwiseLayerTest).*IS=\(.*\).*secondaryInputType=CONSTANT.*)",
             // Issues - 34059
             ".*BehaviorTests\\.pluginDoesNotChangeOriginalNetwork.*",
             //TODO: Issue: 34349

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/subgraph_tests/scale_shift.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/subgraph_tests/scale_shift.cpp
@@ -1,0 +1,57 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+#include "subgraph_tests/scaleshift.hpp"
+#include "common_test_utils/test_constants.hpp"
+
+using namespace LayerTestsDefinitions;
+
+namespace {
+
+std::vector<std::vector<std::vector<size_t>>> inShapes = {
+        {{100}},
+        {{100}, {100}},
+        {{1, 8}},
+        {{2, 16}},
+        {{3, 32}},
+        {{4, 64}},
+        {{4, 64}, {64}},
+        {{5, 128}},
+        {{6, 256}},
+        {{7, 512}},
+        {{8, 1024}}
+};
+
+std::vector<std::vector<float>> Scales = {
+        {2.0f},
+        {3.0f},
+        {-1.0f},
+        {-2.0f},
+        {-3.0f}
+};
+
+std::vector<std::vector<float>> Shifts = {
+        {1.0f},
+        {2.0f},
+        {3.0f},
+        {-1.0f},
+        {-2.0f},
+        {-3.0f}
+};
+
+std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP32,
+                                                         InferenceEngine::Precision::FP16,
+};
+
+}  // namespace
+
+INSTANTIATE_TEST_CASE_P(ScaleShift, ScaleShiftLayerTest,
+                        ::testing::Combine(
+                                ::testing::ValuesIn(inShapes),
+                                ::testing::ValuesIn(netPrecisions),
+                                ::testing::Values(CommonTestUtils::DEVICE_GPU),
+                                ::testing::ValuesIn(Scales),
+                                ::testing::ValuesIn(Shifts)),
+                        ScaleShiftLayerTest::getTestCaseName);

--- a/inference-engine/tests/functional/plugin/shared/src/subgraph_tests/scale_shift.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/subgraph_tests/scale_shift.cpp
@@ -29,11 +29,14 @@ namespace LayerTestsDefinitions {
         InferenceEngine::Precision netPrecision;
         std::vector<float> scale, shift;
         std::tie(inputShapes, netPrecision, targetDevice, scale, shift) = this->GetParam();
+        auto paramsShape = ngraph::Shape{1};
+        if (inputShapes.size() > 1)
+            paramsShape = ngraph::Shape(inputShapes[1]);
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         auto paramsIn = ngraph::builder::makeParams(ngPrc, {inputShapes[0]});
-        auto mul_const = std::make_shared<ngraph::op::Constant>(ngPrc, ngraph::Shape{1}, scale);
+        auto mul_const = std::make_shared<ngraph::op::Constant>(ngPrc, paramsShape, scale);
         auto mul = std::make_shared<ngraph::opset1::Multiply>(paramsIn[0], mul_const);
-        auto add_const = std::make_shared<ngraph::op::Constant>(ngPrc, ngraph::Shape{1}, shift);
+        auto add_const = std::make_shared<ngraph::op::Constant>(ngPrc, paramsShape, shift);
         auto add = std::make_shared<ngraph::opset1::Add>(mul, add_const);
         function = std::make_shared<ngraph::Function>(add, paramsIn, "scale_shift");
     }


### PR DESCRIPTION
- ScaleShift weights for 1d input and const inputs to 1d Elwise have batch interpretation now

Issue: CVS-33111