### PR TITLE
Add Proposal-4 to MO

### DIFF
--- a/model-optimizer/extensions/back/ProposalMutation.py
+++ b/model-optimizer/extensions/back/ProposalMutation.py
@@ -75,8 +75,3 @@ class ProposalMutation(BackReplacementPattern):
             reshape = create_op_node_with_second_input(graph, Reshape, [im_info_shape[1]], {'name': 'im_info/Reshape'})
             node.in_port(2).get_connection().set_destination(reshape.in_port(0))
             reshape.out_port(0).connect(node.in_port(2))
-
-        if node.has_port('out', 1) and not node.out_port(1).disconnected():
-            # This is the case when Proposal layer is used from extension, not from opset.
-            # Setting version attribute is not recommended, this will be fixed after Proposal will be updated in IE.
-            graph.node[node.id]['version'] = 'extension'

--- a/model-optimizer/extensions/front/mxnet/custom_rpn_proposal.py
+++ b/model-optimizer/extensions/front/mxnet/custom_rpn_proposal.py
@@ -44,7 +44,6 @@ class RPNProposalMXNetFrontExtractor(MXNetCustomFrontExtractorOp):
             'pre_nms_topn': pre_nms_topn,
             'post_nms_topn': post_nms_topn,
             'nms_thresh': nms_thresh,
-            'for_deformable': 1,
         }
 
         ProposalOp.update_node_stat(node, node_attrs)

--- a/model-optimizer/extensions/ops/proposal.py
+++ b/model-optimizer/extensions/ops/proposal.py
@@ -32,7 +32,6 @@ class ProposalOp(Op):
             'infer': ProposalOp.proposal_infer,
             'in_ports_count': 3,
             'out_ports_count': 2,
-            'for_deformable': 0,
             'normalize': 0,
         }
         super().__init__(graph, mandatory_props, attrs)
@@ -65,7 +64,6 @@ class ProposalOp(Op):
             'normalize',
             'clip_after_nms',
             'clip_before_nms',
-            'for_deformable',
         ]
 
     @staticmethod

--- a/model-optimizer/extensions/ops/proposal.py
+++ b/model-optimizer/extensions/ops/proposal.py
@@ -27,7 +27,7 @@ class ProposalOp(Op):
         mandatory_props = {
             'type': __class__.op,
             'op': __class__.op,
-            'version': 'opset1',
+            'version': 'opset4',
             'post_nms_topn': 300,  # default in caffe-shared
             'infer': ProposalOp.proposal_infer,
             'in_ports_count': 3,


### PR DESCRIPTION
Description: Added Proposal-4 with two outputs to MO

#32966

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR -- no new transformations were added
* [x]  Transformation preserves original framework node names -- no new transformation were added

Validation:
* [x]  Unit tests: N/A -- no new unitests were added because old Proposal with extensions already had tests for 2 outputs
* [x]  Framework operation tests: N/A
* [x]  Transformation tests: N/A -- no new transformations were added
* [x]  e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py: N/A
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list: N/A
* [x]  Supported **public** models list: N/A
* [x]  New operations specification: https://github.com/openvinotoolkit/openvino/pull/1270
* [x]  Guide on how to convert the **public** model: N/A
* [x]  User guide update: N/A