### PR TITLE
Support BOOL tensors

### DIFF
--- a/inference-engine/src/inference_engine/cnn_network_ngraph_impl.cpp
+++ b/inference-engine/src/inference_engine/cnn_network_ngraph_impl.cpp
@@ -136,11 +136,15 @@ CNNNetworkNGraphImpl::CNNNetworkNGraphImpl(const std::shared_ptr<Function>& nGra
         keep_input_info(*this, ptr);
     }
     for (auto& output : _outputData) {
+        if (output.second->getPrecision() == Precision::FP32 ||
+            output.second->getPrecision() == Precision::I32 ||
+            output.second->getPrecision() == Precision::BOOL) {
+            continue;
+        }
         // Convert precision into native format. Be consistent with possible conversion to CNNNetwork later.
         if (output.second->getPrecision() == Precision::I64) {
             output.second->setPrecision(Precision::I32);
-        } else if (output.second->getPrecision() != Precision::FP32 &&
-            output.second->getPrecision() != Precision::I32) {
+        } else {
             output.second->setPrecision(Precision::FP32);
         }
     }


### PR DESCRIPTION
Added support for BOOL and simplified logic.
Problem: While running unit test case for TensorFlow "NotEqual" Op, we see errors like:
Function_0 Calling m_infer_req.SetBlob for output NotEqual/NotEqual_2, count=4, network precision=FP32, tensor type=boolean
Failed
Exception while executing on nGraph [PARAMETER_MISMATCH] Failed to set Blob with precision not corresponding to user output precision
/localdisk/.../openvino/inference-engine/src/mkldnn_plugin/mkldnn_infer_request.cpp:316
/localdisk/.../build_cmake/artifacts/openvino/deployment_tools/inference_engine/include/details/ie_exception_conversion.hpp:62