### PR TITLE
[PYTHON][nGraph] add get_type_name for element type

### DIFF
--- a/ngraph/python/src/pyngraph/types/element_type.cpp
+++ b/ngraph/python/src/pyngraph/types/element_type.cpp
@@ -55,4 +55,5 @@ void regclass_pyngraph_Type(py::module m)
 
     type.def_property_readonly("bitwidth", &ngraph::element::Type::bitwidth);
     type.def_property_readonly("is_real", &ngraph::element::Type::is_real);
+    type.def("get_type_name", &ngraph::element::Type::get_type_name);
 }


### PR DESCRIPTION
Adds possibility to have the type name for element type in python like in C++.