### PR TITLE
Fix problem with renaming outputs from network

### DIFF
--- a/model-optimizer/automation/package_BOM.txt
+++ b/model-optimizer/automation/package_BOM.txt
@@ -120,6 +120,7 @@ extensions/front/disable_weights_quantize_value_propagation.py
 extensions/front/div.py
 extensions/front/eltwise_n.py
 extensions/front/ExpandDimsToUnsqueeze.py
+extensions/front/FakeOutputResolver.py
 extensions/front/FillToBroadcast.py
 extensions/front/flatten_to_reshape.py
 extensions/front/freeze_placeholder_value.py
@@ -608,6 +609,7 @@ extensions/ops/elementwise.py
 extensions/ops/embedding_bag.py
 extensions/ops/Enter.py
 extensions/ops/Exit.py
+extensions/ops/fake_output.py
 extensions/ops/fakequantize.py
 extensions/ops/gather.py
 extensions/ops/GatherNd.py

--- a/model-optimizer/extensions/front/FakeOutputResolver.py
+++ b/model-optimizer/extensions/front/FakeOutputResolver.py
@@ -1,0 +1,50 @@
+"""
+ Copyright (C) 2020 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+from extensions.ops.elementwise import Add
+from mo.front.common.replacement import FrontReplacementPattern
+from mo.front.common.partial_infer.utils import int64_array
+from mo.front.tf.graph_utils import create_op_with_const_inputs
+from mo.graph.graph import Graph, rename_nodes, rename_node
+
+
+class FakeOutputResolver(FrontReplacementPattern):
+    """
+    This transformation removes FakeOutput nodes. If producer of FakeOutput have only one consumer (FakeOutput itself)
+     the name of FakeOutput is inherited by its producer, otherwise FakeOutput is replaced with op which does nothing.
+    """
+    enabled = True
+
+    def find_and_replace_pattern(self, graph: Graph):
+        for fake_output in graph.get_op_nodes(op='FakeOutput'):
+            name = fake_output.soft_get('name', fake_output.id)
+
+            producer = fake_output.in_port(0).get_source().node
+            producer_outputs = 0
+            for port in producer.out_ports().values():
+                if not port.disconnected():
+                    producer_outputs += 1
+            if producer_outputs != 1:
+                # At this stage we don't know the type of output, so we rely on MO transformation which updates the
+                # Const type for elementwise operations in case of input data types mismatch
+                add = create_op_with_const_inputs(graph, Add, {1: int64_array(0)}, {'can_be_fused': False})
+                rename_nodes([(fake_output, name + '/TBD'), (add, name)])
+
+                fake_output.in_port(0).get_connection().set_destination(add.in_port(0))
+                fake_output.out_port(0).get_connection().set_source(add.out_port(0))
+            else:
+                graph.erase_node(fake_output)
+                rename_node(producer, name)

--- a/model-optimizer/extensions/front/FakeOutputResolver_test.py
+++ b/model-optimizer/extensions/front/FakeOutputResolver_test.py
@@ -1,0 +1,92 @@
+"""
+ Copyright (C) 2020 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import unittest
+
+from extensions.front.FakeOutputResolver import FakeOutputResolver
+from mo.front.common.partial_infer.utils import int64_array
+from mo.utils.ir_engine.compare_graphs import compare_graphs
+from mo.utils.unittest.graph import build_graph, result, regular_op, const
+
+
+class FakeOutputResolverTest(unittest.TestCase):
+    def test_one(self):
+        nodes = {
+            **regular_op('input', {'type': 'Parameter'}),
+            **regular_op('some_op', {'type': 'SomeOp', 'name': 'some_op_name'}),
+            **regular_op('fake_output', {'type': None, 'kind': 'op', 'op': 'FakeOutput', 'name': 'my_output_name'}),
+            **result('result'),
+        }
+        edges = [('input', 'some_op'),
+                 ('some_op', 'fake_output'),
+                 ('fake_output', 'result'),
+                 ]
+        graph = build_graph(nodes, edges)
+
+        graph.graph['layout'] = 'NCHW'
+        graph.stage = 'front'
+
+        edges_ref = [('input', 'some_op'),
+                     ('some_op', 'result'),
+                     ]
+
+        graph_ref = build_graph(nodes, edges_ref, {'some_op': {'name': 'my_output_name'}})
+
+        FakeOutputResolver().find_and_replace_pattern(graph)
+
+        (flag, resp) = compare_graphs(graph, graph_ref, 'result')
+        self.assertTrue(flag, resp)
+
+    def test_multi(self):
+        nodes = {
+            **regular_op('input', {'type': 'Parameter'}),
+            **regular_op('some_op', {'type': 'SomeOp', 'name': 'some_op_name'}),
+            **regular_op('fake_output1', {'type': None, 'kind': 'op', 'op': 'FakeOutput', 'name': 'my_output_name1'}),
+            **regular_op('fake_output2', {'type': None, 'kind': 'op', 'op': 'FakeOutput', 'name': 'my_output_name2'}),
+
+            **const('const1', int64_array(0)),
+            **const('const2', int64_array(0)),
+            **regular_op('add1', {'type': None, 'kind': 'op', 'op': 'Add', 'name': 'my_output_name1'}),
+            **regular_op('add2', {'type': None, 'kind': 'op', 'op': 'Add', 'name': 'my_output_name2'}),
+            **result('result1'),
+            **result('result2'),
+        }
+        edges = [('input', 'some_op'),
+                 ('some_op', 'fake_output1'),
+                 ('some_op', 'fake_output2'),
+                 ('fake_output1', 'result1'),
+                 ('fake_output2', 'result2'),
+                 ]
+        graph = build_graph(nodes, edges)
+
+        graph.graph['layout'] = 'NCHW'
+        graph.stage = 'front'
+
+        edges_ref = [('input', 'some_op'),
+                     ('some_op', 'add1'),
+                     ('const1', 'add1'),
+                     ('some_op', 'add2'),
+                     ('const2', 'add2'),
+                     ('add1', 'result1'),
+                     ('add2', 'result2'),
+                     ]
+
+        graph_ref = build_graph(nodes, edges_ref)
+
+        FakeOutputResolver().find_and_replace_pattern(graph)
+
+        (flag, resp) = compare_graphs(graph, graph_ref, 'result1')
+        self.assertTrue(flag, resp)

--- a/model-optimizer/extensions/ops/fake_output.py
+++ b/model-optimizer/extensions/ops/fake_output.py
@@ -1,0 +1,40 @@
+"""
+ Copyright (C) 2018-2020 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+from mo.graph.graph import Graph
+from mo.ops.op import Op
+
+
+class FakeOutput(Op):
+    """
+    This op is needed only to store the output name, it will be transformed into opset op and is doing nothing
+    """
+    op = 'FakeOutput'
+    enabled = False
+
+    def __init__(self, graph: Graph, attrs: dict):
+        super().__init__(graph, {
+            'op': self.op,
+            'type': None,
+            'version': None,
+
+            'infer': None,
+
+            'type_infer': None,
+
+            'in_ports_count': 1,
+            'out_ports_count': 1,
+        }, attrs)


### PR DESCRIPTION
Description: Fix wrong output names in IR if ONNX model has node names.

JIRA: #35487 and number of others


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests: N/A
* [x]  Transformation tests
* [x]  e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py: N/A - no e2e test modifyed
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list: N/A - no new op enabled
* [x]  Supported **public** models list: N/A - no new public model supported
* [x]  New operations specification: N/A - no new operation added to opset
* [x]  Guide on how to convert the **public** model: N/A - no new public model supported
* [x]  User guide update: N/A - not needed