### PR TITLE
Virtual inheritance to allow inheriting test classes and overriding common logic

### DIFF
--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/conv_eltwise_depthwise.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/conv_eltwise_depthwise.cpp
@@ -27,7 +27,7 @@ namespace LayerTestsDefinitions {
 typedef std::tuple< Precision, SizeVector, string, size_t, CoordinateDiff, string> convEltwiseDepthwiseTestParamsSet;
 
 class ConvEltwiseDepthwise :
-    public testing::WithParamInterface<convEltwiseDepthwiseTestParamsSet>, public LayerTestsUtils::LayerTestsCommon {
+    public testing::WithParamInterface<convEltwiseDepthwiseTestParamsSet>, virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     std::shared_ptr<Function> fnPtr;
     SizeVector inputShapes;

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
@@ -21,7 +21,7 @@ typedef std::tuple<
         groupConvCPUSpecificParams> groupConvLayerCPUTestParamsSet;
 
 class GroupConvolutionLayerCPUTest : public testing::WithParamInterface<groupConvLayerCPUTestParamsSet>,
-                                     public LayerTestsUtils::LayerTestsCommon {
+                                     virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<groupConvLayerCPUTestParamsSet> obj) {
         groupConvLayerTestParamsSet basicParamsSet;

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/operations/dynamic_shape_resolver.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/operations/dynamic_shape_resolver.cpp
@@ -185,7 +185,7 @@ typedef std::tuple<
         InputData,
         std::string> dsrParams;
 
-class DynamicShapeResolverPluginTests : public testing::WithParamInterface<dsrParams>, public LayerTestsUtils::LayerTestsCommon {
+class DynamicShapeResolverPluginTests : public testing::WithParamInterface<dsrParams>, virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<dsrParams> &obj) {
         InputData inputData;

--- a/inference-engine/tests/functional/plugin/myriad/single_layer_tests/out_shape_of_reshape.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/single_layer_tests/out_shape_of_reshape.cpp
@@ -32,7 +32,7 @@ using OutShapeOfReshapeTestParam = std::tuple<
 namespace LayerTestsDefinitions {
 
 class OutShapeOfReshapeLayerTest : public testing::WithParamInterface<OutShapeOfReshapeTestParam>,
-                                   public LayerTestsUtils::LayerTestsCommon {
+                                   virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<OutShapeOfReshapeTestParam>& obj) {
         OutShapeOfReshapeParam shapesParam;

--- a/inference-engine/tests/functional/plugin/myriad/single_layer_tests/static_shape_broadcast.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/single_layer_tests/static_shape_broadcast.cpp
@@ -30,7 +30,7 @@ using StaticShapeBroadcastTestParam = std::tuple<
 namespace LayerTestsDefinitions {
 
 class StaticShapeBroadcastLayerTest : public testing::WithParamInterface<StaticShapeBroadcastTestParam>,
-                                      public LayerTestsUtils::LayerTestsCommon {
+                                      virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<StaticShapeBroadcastTestParam>& obj) {
         StaticShapeBroadcastParam shapes;

--- a/inference-engine/tests/functional/plugin/myriad/single_layer_tests/static_shape_nms.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/single_layer_tests/static_shape_nms.cpp
@@ -26,7 +26,7 @@ using StaticShapeNMSTestParam = std::tuple<
 namespace LayerTestsDefinitions {
 
 class StaticShapeNMSLayerTest : public testing::WithParamInterface<StaticShapeNMSTestParam>,
-                                      public LayerTestsUtils::LayerTestsCommon {
+                                      virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<StaticShapeNMSTestParam>& obj) {
         StaticShapeNMSParam NMSParams;

--- a/inference-engine/tests/functional/plugin/myriad/single_layer_tests/static_shape_nonzero.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/single_layer_tests/static_shape_nonzero.cpp
@@ -27,7 +27,7 @@ typedef std::tuple<
 namespace LayerTestsDefinitions {
 
 class StaticShapeNonZeroLayerTest : public testing::WithParamInterface<staticShapeNonZeroLayerTestParams>,
-                                    public LayerTestsUtils::LayerTestsCommon {
+                                    virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<staticShapeNonZeroLayerTestParams> obj) {
         InferenceEngine::SizeVector inputShape;

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_non_max_suppression.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_non_max_suppression.cpp
@@ -25,7 +25,7 @@ using Parameters = std::tuple<
 >;
 
 class DSR_NonMaxSuppression : public testing::WithParamInterface<Parameters>,
-        public LayerTestsUtils::LayerTestsCommon {
+        virtual public LayerTestsUtils::LayerTestsCommon {
 protected:
     void SetUp() override {
         const auto& parameters = GetParam();

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_reduce.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_reduce.cpp
@@ -71,7 +71,7 @@ using Parameters = std::tuple<
 >;
 
 class DSR_Reduce : public testing::WithParamInterface<Parameters>,
-        public LayerTestsUtils::LayerTestsCommon {
+        virtual public LayerTestsUtils::LayerTestsCommon {
 protected:
     void SetUp() override {
         const auto& parameters = GetParam();

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_roialign.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_roialign.cpp
@@ -26,7 +26,7 @@ using Parameters = std::tuple<
 >;
 
 class DSR_ROIAlignDataDSR : public testing::WithParamInterface<Parameters>,
-        public LayerTestsUtils::LayerTestsCommon {
+        virtual public LayerTestsUtils::LayerTestsCommon {
 protected:
     void SetUp() override {
         const auto& parameters = GetParam();
@@ -71,7 +71,7 @@ INSTANTIATE_TEST_CASE_P(DISABLED_DynamicROIAlignDataDSR, DSR_ROIAlignDataDSR,
 
 
 class DSR_ROIAlignROIDSR : public testing::WithParamInterface<Parameters>,
-        public LayerTestsUtils::LayerTestsCommon {
+        virtual public LayerTestsUtils::LayerTestsCommon {
 protected:
     void SetUp() override {
         const auto& parameters = GetParam();
@@ -115,7 +115,7 @@ INSTANTIATE_TEST_CASE_P(DISABLED_DynamicROIAlign, DSR_ROIAlignROIDSR,
         ::testing::Values(CommonTestUtils::DEVICE_MYRIAD)));
 
 class DSR_ROIAlign : public testing::WithParamInterface<Parameters>,
-        public LayerTestsUtils::LayerTestsCommon {
+        virtual public LayerTestsUtils::LayerTestsCommon {
 protected:
     void SetUp() override {
         const auto& parameters = GetParam();

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_scatter.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_scatter.cpp
@@ -25,7 +25,7 @@ using Parameters = std::tuple<
 >;
 
 class DSR_Scatter : public testing::WithParamInterface<Parameters>,
-        public LayerTestsUtils::LayerTestsCommon {
+        virtual public LayerTestsUtils::LayerTestsCommon {
 protected:
     void SetUp() override {
         const auto& parameters = GetParam();

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_tests_common.hpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_tests_common.hpp
@@ -25,7 +25,7 @@ struct DataShapeWithUpperBound {
     DataShape upperBoundShape;
 };
 
-class DSR_TestsCommon : public LayerTestsUtils::LayerTestsCommon {
+class DSR_TestsCommon : virtual public LayerTestsUtils::LayerTestsCommon {
 protected:
     std::unordered_map<std::string, DataShape> m_shapes;
     ngraph::ParameterVector m_parameterVector;

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_topk.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_topk.cpp
@@ -44,7 +44,7 @@ using Parameters = std::tuple<
 >;
 
 class DSR_TopK_Const : public testing::WithParamInterface<Parameters>,
-        public LayerTestsUtils::LayerTestsCommon {
+        virtual public LayerTestsUtils::LayerTestsCommon {
 protected:
     void SetUp() override {
         const auto& parameters = GetParam();
@@ -80,7 +80,7 @@ TEST_P(DSR_TopK_Const, CompareWithReference) {
 INSTANTIATE_TEST_CASE_P(DISABLED_DynamicTopKConst, DSR_TopK_Const, combinations);
 
 class DSR_TopK : public testing::WithParamInterface<Parameters>,
-        public LayerTestsUtils::LayerTestsCommon {
+        virtual public LayerTestsUtils::LayerTestsCommon {
 protected:
     void SetUp() override {
         const auto& parameters = GetParam();

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_unsqueeze.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_unsqueeze.cpp
@@ -24,7 +24,7 @@ using Parameters = std::tuple<
     LayerTestsUtils::TargetDevice
 >;
 
-class DSR_Unsqueeze : public testing::WithParamInterface<Parameters>, public LayerTestsUtils::LayerTestsCommon {
+class DSR_Unsqueeze : public testing::WithParamInterface<Parameters>, virtual public LayerTestsUtils::LayerTestsCommon {
 protected:
     void SetUp() override {
         const auto& parameters = GetParam();

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_variadic_split.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_variadic_split.cpp
@@ -46,7 +46,7 @@ using Parameters = std::tuple<
 >;
 
 class DSR_VariadicSplit : public testing::WithParamInterface<Parameters>,
-        public LayerTestsUtils::LayerTestsCommon {
+        virtual public LayerTestsUtils::LayerTestsCommon {
 protected:
     void SetUp() override {
         const auto& parameters = GetParam();

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/nms_nonzero.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/nms_nonzero.cpp
@@ -23,7 +23,7 @@ using Parameters = std::tuple<
 >;
 
 class NMS_NonZero : public testing::WithParamInterface<Parameters>,
-                    public LayerTestsUtils::LayerTestsCommon {
+                    virtual public LayerTestsUtils::LayerTestsCommon {
 protected:
     void SetUp() override {
         const auto& parameters = GetParam();

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/nonzero_broadcast.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/nonzero_broadcast.cpp
@@ -19,7 +19,7 @@ using BroadcastExplicitTestParams = std::tuple<
         TensorType, TensorShape, LayerTestsUtils::TargetDevice>;
 
 class NonZero_Broadcast : public testing::WithParamInterface<BroadcastExplicitTestParams>,
-                          public LayerTestsUtils::LayerTestsCommon {
+                          virtual public LayerTestsUtils::LayerTestsCommon {
 protected:
     void SetUp() override {
         SetRefMode(LayerTestsUtils::RefMode::CONSTANT_FOLDING);

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/nonzero_transpose.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/nonzero_transpose.cpp
@@ -17,7 +17,7 @@ using Parameters = std::tuple<
     DataDims,
     LayerTestsUtils::TargetDevice>;
 
-class NonZero_Transpose : public testing::WithParamInterface<Parameters>, public LayerTestsUtils::LayerTestsCommon {
+class NonZero_Transpose : public testing::WithParamInterface<Parameters>, virtual public LayerTestsUtils::LayerTestsCommon {
 protected:
     void SetUp() override {
         SetRefMode(LayerTestsUtils::RefMode::CONSTANT_FOLDING);

--- a/inference-engine/tests/functional/plugin/shared/include/behavior/stress_tests.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/behavior/stress_tests.hpp
@@ -19,7 +19,7 @@ typedef std::tuple<
 > MultipleAllocationsParams;
 
 class MultipleAllocations : public testing::WithParamInterface<MultipleAllocationsParams>,
-                        public LayerTestsUtils::LayerTestsCommon {
+                        virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<MultipleAllocationsParams>& obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/hetero/query_network.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/hetero/query_network.hpp
@@ -18,7 +18,7 @@ using QueryNetworkTestParameters = std::tuple<
 >;
 
 struct QueryNetworkTest : public testing::WithParamInterface<QueryNetworkTestParameters>,
-                          public LayerTestsUtils::LayerTestsCommon {
+                          virtual public LayerTestsUtils::LayerTestsCommon {
     enum {Plugin, Function};
     ~QueryNetworkTest() override = default;
     void SetUp() override;

--- a/inference-engine/tests/functional/plugin/shared/include/hetero/synthetic.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/hetero/synthetic.hpp
@@ -29,7 +29,7 @@ using HeteroSyntheticTestParameters = std::tuple<
 >;
 
 struct HeteroSyntheticTest : public testing::WithParamInterface<HeteroSyntheticTestParameters>,
-                             public LayerTestsUtils::LayerTestsCommon {
+                             virtual public LayerTestsUtils::LayerTestsCommon {
     enum {Plugin, Function};
     ~HeteroSyntheticTest() override = default;
     void SetUp() override;

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/activation.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/activation.hpp
@@ -78,7 +78,7 @@ typedef std::tuple<
         std::string> activationParams;
 
 class ActivationLayerTest : public testing::WithParamInterface<activationParams>,
-                            public LayerTestsUtils::LayerTestsCommon {
+                            virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     ngraph::helpers::ActivationTypes activationType;
     static std::string getTestCaseName(const testing::TestParamInfo<activationParams> &obj);

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/batch_to_space.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/batch_to_space.hpp
@@ -22,7 +22,7 @@ using batchToSpaceParamsTuple = typename std::tuple<
         std::string>;                      // Device name>;
 
 class BatchToSpaceLayerTest : public testing::WithParamInterface<batchToSpaceParamsTuple>,
-                              public LayerTestsUtils::LayerTestsCommon {
+                              virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<batchToSpaceParamsTuple> &obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/comparison.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/comparison.hpp
@@ -28,7 +28,7 @@ typedef std::tuple<
 > ComparisonTestParams;
 
 class ComparisonLayerTest : public testing::WithParamInterface<ComparisonTestParams>,
-    public LayerTestsUtils::LayerTestsCommon {
+    virtual public LayerTestsUtils::LayerTestsCommon {
 protected:
     void SetUp() override;
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/concat.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/concat.hpp
@@ -23,7 +23,7 @@ using concatParamsTuple = typename std::tuple<
         std::string>;                      // Device name
 
 class ConcatLayerTest : public testing::WithParamInterface<concatParamsTuple>,
-                        public LayerTestsUtils::LayerTestsCommon {
+                        virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<concatParamsTuple> &obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/convert.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/convert.hpp
@@ -22,7 +22,7 @@ using ConvertParamsTuple = typename std::tuple<
         std::string>;                      // Device name
 
 class ConvertLayerTest : public testing::WithParamInterface<ConvertParamsTuple>,
-                        public LayerTestsUtils::LayerTestsCommon {
+                        virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<ConvertParamsTuple> &obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/convert_like.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/convert_like.hpp
@@ -23,7 +23,7 @@ using ConvertLikeParamsTuple = typename std::tuple<
         std::string>;                      // Device name
 
 class ConvertLikeLayerTest : public testing::WithParamInterface<ConvertLikeParamsTuple>,
-                             public LayerTestsUtils::LayerTestsCommon {
+                             virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<ConvertLikeParamsTuple> &obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/convolution.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/convolution.hpp
@@ -33,7 +33,7 @@ namespace LayerTestsDefinitions {
 
 
 class ConvolutionLayerTest : public testing::WithParamInterface<convLayerTestParamsSet>,
-                             public LayerTestsUtils::LayerTestsCommon {
+                             virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<convLayerTestParamsSet> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/convolution_backprop_data.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/convolution_backprop_data.hpp
@@ -32,7 +32,7 @@ namespace LayerTestsDefinitions {
 
 
 class ConvolutionBackpropDataLayerTest : public testing::WithParamInterface<convBackpropDataLayerTestParamsSet>,
-                                         public LayerTestsUtils::LayerTestsCommon {
+                                         virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<convBackpropDataLayerTestParamsSet> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/ctc_greedy_decoder.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/ctc_greedy_decoder.hpp
@@ -37,7 +37,7 @@ typedef std::tuple<
 
 class CTCGreedyDecoderLayerTest
     :  public testing::WithParamInterface<ctcGreedyDecoderParams>,
-       public LayerTestsUtils::LayerTestsCommon {
+       virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<ctcGreedyDecoderParams>& obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/cum_sum.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/cum_sum.hpp
@@ -20,7 +20,7 @@ typedef std::tuple<
         bool,                        // Reverse
         std::string> cumSumParams;   // Device name
 
-class CumSumLayerTest : public testing::WithParamInterface<cumSumParams>, public LayerTestsUtils::LayerTestsCommon {
+class CumSumLayerTest : public testing::WithParamInterface<cumSumParams>, virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<cumSumParams> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/depth_to_space.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/depth_to_space.hpp
@@ -21,7 +21,7 @@ using depthToSpaceParamsTuple = typename std::tuple<
         std::string>;                                   // Device name>
 
 class DepthToSpaceLayerTest : public testing::WithParamInterface<depthToSpaceParamsTuple>,
-                              public LayerTestsUtils::LayerTestsCommon {
+                              virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<depthToSpaceParamsTuple> &obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/eltwise.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/eltwise.hpp
@@ -33,7 +33,7 @@ typedef std::tuple<
 > EltwiseTestParams;
 
 class EltwiseLayerTest : public testing::WithParamInterface<EltwiseTestParams>,
-    public LayerTestsUtils::LayerTestsCommon {
+    virtual public LayerTestsUtils::LayerTestsCommon {
 protected:
     void SetUp() override;
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/embedding_bag_offsets_sum.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/embedding_bag_offsets_sum.hpp
@@ -28,7 +28,7 @@ typedef std::tuple<
 namespace LayerTestsDefinitions {
 
 class EmbeddingBagOffsetsSumLayerTest : public testing::WithParamInterface<embeddingBagOffsetsSumLayerTestParamsSet>,
-            public LayerTestsUtils::LayerTestsCommon {
+            virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<embeddingBagOffsetsSumLayerTestParamsSet> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/embedding_bag_packed_sum.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/embedding_bag_packed_sum.hpp
@@ -25,7 +25,7 @@ typedef std::tuple<
 namespace LayerTestsDefinitions {
 
 class EmbeddingBagPackedSumLayerTest : public testing::WithParamInterface<embeddingBagPackedSumLayerTestParamsSet>,
-            public LayerTestsUtils::LayerTestsCommon {
+            virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<embeddingBagPackedSumLayerTestParamsSet> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/embedding_segments_sum.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/embedding_segments_sum.hpp
@@ -29,7 +29,7 @@ typedef std::tuple<
 namespace LayerTestsDefinitions {
 
 class EmbeddingSegmentsSumLayerTest : public testing::WithParamInterface<embeddingSegmentsSumLayerTestParamsSet>,
-            public LayerTestsUtils::LayerTestsCommon {
+            virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<embeddingSegmentsSumLayerTestParamsSet> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/equal.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/equal.hpp
@@ -24,7 +24,7 @@ using EqualTestParam = typename std::tuple<
         LayerTestsUtils::TargetDevice>;            // Config
 
 class EqualLayerTest : public testing::WithParamInterface<EqualTestParam>,
-                       public LayerTestsUtils::LayerTestsCommon {
+                       virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<EqualTestParam>& obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/extract_image_patches.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/extract_image_patches.hpp
@@ -23,7 +23,7 @@ using extractImagePatchesTuple = typename std::tuple<
         LayerTestsUtils::TargetDevice>;                      // Device name
 
 class ExtractImagePatchesTest : public testing::WithParamInterface<extractImagePatchesTuple>,
-                              public LayerTestsUtils::LayerTestsCommon {
+                              virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<extractImagePatchesTuple> &obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/fake_quantize.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/fake_quantize.hpp
@@ -27,7 +27,7 @@ namespace LayerTestsDefinitions {
 
 
 class FakeQuantizeLayerTest : public testing::WithParamInterface<fqLayerTestParamsSet>,
-                              public LayerTestsUtils::LayerTestsCommon {
+                              virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<fqLayerTestParamsSet> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/gather.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/gather.hpp
@@ -24,7 +24,7 @@ typedef std::tuple<
         std::string                        // Device name
 > gatherParamsTuple;
 class GatherLayerTest : public testing::WithParamInterface<gatherParamsTuple>,
-                        public LayerTestsUtils::LayerTestsCommon {
+                        virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<gatherParamsTuple> &obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/greater.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/greater.hpp
@@ -24,7 +24,7 @@ using GreaterTestParam = typename std::tuple<
         LayerTestsUtils::TargetDevice>;            // Config
 
 class GreaterLayerTest : public testing::WithParamInterface<GreaterTestParam>,
-                         public LayerTestsUtils::LayerTestsCommon {
+                         virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<GreaterTestParam>& obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/grn.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/grn.hpp
@@ -38,7 +38,7 @@ typedef std::tuple<
 
 class GrnLayerTest
     : public testing::WithParamInterface<grnParams>,
-      public LayerTestsUtils::LayerTestsCommon{
+      virtual public LayerTestsUtils::LayerTestsCommon{
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<grnParams>& obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/group_convolution.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/group_convolution.hpp
@@ -31,7 +31,7 @@ typedef std::tuple<
 namespace LayerTestsDefinitions {
 
 class GroupConvolutionLayerTest : public testing::WithParamInterface<groupConvLayerTestParamsSet>,
-                                  public LayerTestsUtils::LayerTestsCommon {
+                                  virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<groupConvLayerTestParamsSet> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/group_convolution_backprop_data.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/group_convolution_backprop_data.hpp
@@ -31,7 +31,7 @@ typedef std::tuple<
 namespace LayerTestsDefinitions {
 
 class GroupConvBackpropDataLayerTest : public testing::WithParamInterface<groupConvBackpropDataLayerTestParamsSet>,
-                                       public LayerTestsUtils::LayerTestsCommon {
+                                       virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<groupConvBackpropDataLayerTestParamsSet> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/interpolate.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/interpolate.hpp
@@ -36,7 +36,7 @@ typedef std::tuple<
 > InterpolateLayerTestParams;
 
 class InterpolateLayerTest : public testing::WithParamInterface<InterpolateLayerTestParams>,
-                             public LayerTestsUtils::LayerTestsCommon {
+                             virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<InterpolateLayerTestParams> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/logical.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/logical.hpp
@@ -28,7 +28,7 @@ typedef std::tuple<
 > LogicalTestParams;
 
 class LogicalLayerTest : public testing::WithParamInterface<LogicalTestParams>,
-    public LayerTestsUtils::LayerTestsCommon {
+    virtual public LayerTestsUtils::LayerTestsCommon {
 protected:
     void SetUp() override;
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/lrn.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/lrn.hpp
@@ -30,7 +30,7 @@ typedef std::tuple<
 
 class LrnLayerTest
         : public testing::WithParamInterface<lrnLayerTestParamsSet>,
-          public LayerTestsUtils::LayerTestsCommon {
+          virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<lrnLayerTestParamsSet> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/mat_mul.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/mat_mul.hpp
@@ -23,7 +23,7 @@ typedef std::tuple<
 
 namespace LayerTestsDefinitions {
 
-class MatMulTest : public testing::WithParamInterface<MatMulLayerTestParamsSet>, public LayerTestsUtils::LayerTestsCommon {
+class MatMulTest : public testing::WithParamInterface<MatMulLayerTestParamsSet>, virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<MatMulLayerTestParamsSet> &obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/minimum_maximum.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/minimum_maximum.hpp
@@ -23,7 +23,7 @@ using MaxMinParamsTuple = typename std::tuple<
 
 class MaxMinLayerTest:
         public testing::WithParamInterface<MaxMinParamsTuple>,
-        public LayerTestsUtils::LayerTestsCommon{
+        virtual public LayerTestsUtils::LayerTestsCommon{
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<MaxMinParamsTuple>& obj);
 protected:

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/mvn.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/mvn.hpp
@@ -22,7 +22,7 @@ typedef std::tuple<
         std::map<std::string, std::string>      // Config
         > mvnParams;
 
-class MvnLayerTest : public testing::WithParamInterface<mvnParams>, public LayerTestsUtils::LayerTestsCommon {
+class MvnLayerTest : public testing::WithParamInterface<mvnParams>, virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<mvnParams> obj);
 protected:

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/nonzero.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/nonzero.hpp
@@ -26,7 +26,7 @@ using NonZeroLayerTestParamsSet = typename std::tuple<
     ConfigMap>;                           // Additional network configuration
 
 class NonZeroLayerTest : public testing::WithParamInterface<NonZeroLayerTestParamsSet>,
-                         public LayerTestsUtils::LayerTestsCommon {
+                         virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<NonZeroLayerTestParamsSet> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/pooling.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/pooling.hpp
@@ -42,7 +42,7 @@ typedef std::tuple<
 > globalPoolLayerTestParamsSet;
 
 class PoolingLayerTest : public testing::WithParamInterface<poolLayerTestParamsSet>,
-                         public LayerTestsUtils::LayerTestsCommon {
+                         virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<poolLayerTestParamsSet> obj);
 
@@ -51,7 +51,7 @@ protected:
 };
 
 class GlobalPoolingLayerTest : public testing::WithParamInterface<globalPoolLayerTestParamsSet>,
-                               public LayerTestsUtils::LayerTestsCommon {
+                               virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<globalPoolLayerTestParamsSet> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/power.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/power.hpp
@@ -21,7 +21,7 @@ namespace LayerTestsDefinitions {
 
 class PowerLayerTest:
         public testing::WithParamInterface<PowerParamsTuple>,
-        public LayerTestsUtils::LayerTestsCommon{
+        virtual public LayerTestsUtils::LayerTestsCommon{
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<PowerParamsTuple> &obj);
 protected:

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/prior_box_clustered.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/prior_box_clustered.hpp
@@ -46,7 +46,7 @@ typedef std::tuple<
 namespace LayerTestsDefinitions {
 class PriorBoxClusteredLayerTest
     : public testing::WithParamInterface<priorBoxClusteredLayerParams>,
-      public LayerTestsUtils::LayerTestsCommon {
+      virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<priorBoxClusteredLayerParams>& obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/proposal.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/proposal.hpp
@@ -53,7 +53,7 @@ typedef std::tuple<
 
 class ProposalLayerTest
         : public testing::WithParamInterface<proposalLayerTestParamsSet>,
-          public LayerTestsUtils::LayerTestsCommon {
+          virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<proposalLayerTestParamsSet> obj);
     InferenceEngine::Blob::Ptr GenerateInput(const InferenceEngine::InputInfo &info) const override;

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/range.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/range.hpp
@@ -22,7 +22,7 @@ typedef std::tuple<
 > RangeParams;
 
 class RangeLayerTest : public testing::WithParamInterface<RangeParams>,
-                       public LayerTestsUtils::LayerTestsCommon {
+                       virtual public LayerTestsUtils::LayerTestsCommon {
     float start, stop, step;
 public:
     static std::string getTestCaseName(testing::TestParamInfo<RangeParams> obj);

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/reduce_ops.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/reduce_ops.hpp
@@ -24,7 +24,7 @@ typedef std::tuple<
 > reduceMeanParams;
 
 class ReduceOpsLayerTest : public testing::WithParamInterface<reduceMeanParams>,
-                           public LayerTestsUtils::LayerTestsCommon {
+                           virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<reduceMeanParams> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/reshape.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/reshape.hpp
@@ -24,7 +24,7 @@ typedef std::tuple<
 > reshapeParams;
 
 class ReshapeLayerTest : public testing::WithParamInterface<reshapeParams>,
-                         public LayerTestsUtils::LayerTestsCommon {
+                         virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<reshapeParams> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/scatter_ND_update.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/scatter_ND_update.hpp
@@ -25,7 +25,7 @@ using scatterNDUpdateParamsTuple = typename std::tuple<
         std::string>;                      // Device name
 
 class ScatterNDUpdateLayerTest : public testing::WithParamInterface<scatterNDUpdateParamsTuple>,
-                                 public LayerTestsUtils::LayerTestsCommon {
+                                 virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<scatterNDUpdateParamsTuple> &obj);
     static std::vector<sliceSelcetInShape> combineShapes(

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/scatter_elements_update.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/scatter_elements_update.hpp
@@ -25,7 +25,7 @@ using scatterElementsUpdateParamsTuple = typename std::tuple<
         std::string>;                      // Device name
 
 class ScatterElementsUpdateLayerTest : public testing::WithParamInterface<scatterElementsUpdateParamsTuple>,
-                                       public LayerTestsUtils::LayerTestsCommon {
+                                       virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<scatterElementsUpdateParamsTuple> &obj);
     static std::vector<axisShapeInShape> combineShapes(

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/scatter_update.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/scatter_update.hpp
@@ -26,7 +26,7 @@ using scatterUpdateParamsTuple = typename std::tuple<
         std::string>;                      // Device name
 
 class ScatterUpdateLayerTest : public testing::WithParamInterface<scatterUpdateParamsTuple>,
-                               public LayerTestsUtils::LayerTestsCommon {
+                               virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<scatterUpdateParamsTuple> &obj);
     static std::vector<axisShapeInShape> combineShapes(

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/select.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/select.hpp
@@ -18,7 +18,7 @@ typedef std::tuple<
         ngraph::op::AutoBroadcastSpec,     // broadcast
         std::string> selectTestParams;     // device name
 
-class SelectLayerTest : public testing::WithParamInterface<selectTestParams>, public LayerTestsUtils::LayerTestsCommon {
+class SelectLayerTest : public testing::WithParamInterface<selectTestParams>, virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo <selectTestParams> &obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/shape_of.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/shape_of.hpp
@@ -21,7 +21,7 @@ typedef std::tuple<
 > shapeOfParams;
 
 class ShapeOfLayerTest : public testing::WithParamInterface<shapeOfParams>,
-        public LayerTestsUtils::LayerTestsCommon {
+        virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<shapeOfParams> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/shuffle_channels.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/shuffle_channels.hpp
@@ -25,7 +25,7 @@ namespace LayerTestsDefinitions {
 
 
 class ShuffleChannelsLayerTest : public testing::WithParamInterface<shuffleChannelsLayerTestParamsSet>,
-                                 public LayerTestsUtils::LayerTestsCommon {
+                                 virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<shuffleChannelsLayerTestParamsSet> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/softmax.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/softmax.hpp
@@ -27,7 +27,7 @@ using softMaxLayerTestParams = std::tuple<
 >;
 
 class SoftMaxLayerTest : public testing::WithParamInterface<softMaxLayerTestParams>,
-                         public LayerTestsUtils::LayerTestsCommon {
+                         virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<softMaxLayerTestParams> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/space_to_batch.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/space_to_batch.hpp
@@ -22,7 +22,7 @@ using spaceToBatchParamsTuple = typename std::tuple<
         std::string>;                      // Device name>;
 
 class SpaceToBatchLayerTest : public testing::WithParamInterface<spaceToBatchParamsTuple>,
-                              public LayerTestsUtils::LayerTestsCommon {
+                              virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<spaceToBatchParamsTuple> &obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/space_to_depth.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/space_to_depth.hpp
@@ -21,7 +21,7 @@ using spaceToDepthParamsTuple = typename std::tuple<
         std::string>;                                   // Device name>
 
 class SpaceToDepthLayerTest : public testing::WithParamInterface<spaceToDepthParamsTuple>,
-                              public LayerTestsUtils::LayerTestsCommon {
+                              virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<spaceToDepthParamsTuple> &obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/split.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/split.hpp
@@ -23,7 +23,7 @@ typedef std::tuple<
 > splitParams;
 
 class SplitLayerTest : public testing::WithParamInterface<splitParams>,
-                       public LayerTestsUtils::LayerTestsCommon {
+                       virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<splitParams> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/squeeze_unsqueeze.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/squeeze_unsqueeze.hpp
@@ -23,7 +23,7 @@ typedef std::tuple<
 > squeezeParams;
 
 class SqueezeUnsqueezeLayerTest : public testing::WithParamInterface<squeezeParams>,
-                       public LayerTestsUtils::LayerTestsCommon {
+                       virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<squeezeParams> obj);
 protected:

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/strided_slice.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/strided_slice.hpp
@@ -33,7 +33,7 @@ using StridedSliceParams = std::tuple<
 >;
 
 class StridedSliceLayerTest : public testing::WithParamInterface<StridedSliceParams>,
-                              public LayerTestsUtils::LayerTestsCommon {
+                              virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<StridedSliceParams> &obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/transpose.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/transpose.hpp
@@ -22,7 +22,7 @@ typedef std::tuple<
 > transposeParams;
 
 class TransposeLayerTest : public testing::WithParamInterface<transposeParams>,
-                           public LayerTestsUtils::LayerTestsCommon {
+                           virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<transposeParams> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/concat_quantization.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/concat_quantization.hpp
@@ -22,7 +22,7 @@ typedef std::tuple<
 namespace LayerTestsDefinitions {
 
 class ConcatQuantization : public testing::WithParamInterface<concatQuantizationParams>,
-                        public LayerTestsUtils::LayerTestsCommon {
+                        virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<concatQuantizationParams> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/multioutput_eltwise_squeeze_eltwise.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/multioutput_eltwise_squeeze_eltwise.hpp
@@ -21,7 +21,7 @@ typedef std::tuple<
 
 class MultioutputEltwiseReshapeEltwise
         : public testing::WithParamInterface<MultioutputEltwiseReshapeEltwiseTuple>,
-          public LayerTestsUtils::LayerTestsCommon {
+          virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<MultioutputEltwiseReshapeEltwiseTuple> &obj);
 protected:

--- a/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/quantized_convolution_backprop_data.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/quantized_convolution_backprop_data.hpp
@@ -32,7 +32,7 @@ typedef std::tuple<
 namespace LayerTestsDefinitions {
 
 class QuantConvBackpropDataLayerTest : public testing::WithParamInterface<quantConvBackpropDataLayerTestParamsSet>,
-                                            public LayerTestsUtils::LayerTestsCommon {
+                                            virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<quantConvBackpropDataLayerTestParamsSet> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/quantized_group_convolution.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/quantized_group_convolution.hpp
@@ -33,7 +33,7 @@ typedef std::tuple<
 namespace LayerTestsDefinitions {
 
 class QuantGroupConvLayerTest : public testing::WithParamInterface<quantGroupConvLayerTestParamsSet>,
-                                            public LayerTestsUtils::LayerTestsCommon {
+                                            virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<quantGroupConvLayerTestParamsSet> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/quantized_group_convolution_backprop_data.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/quantized_group_convolution_backprop_data.hpp
@@ -33,7 +33,7 @@ typedef std::tuple<
 namespace LayerTestsDefinitions {
 
 class QuantGroupConvBackpropDataLayerTest : public testing::WithParamInterface<quantGroupConvBackpropDataLayerTestParamsSet>,
-                                            public LayerTestsUtils::LayerTestsCommon {
+                                            virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<quantGroupConvBackpropDataLayerTestParamsSet> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/quantized_mat_mul.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/quantized_mat_mul.hpp
@@ -25,7 +25,7 @@ typedef std::tuple<
 
 namespace LayerTestsDefinitions {
 
-class QuantMatMulTest : public testing::WithParamInterface<QuantMatMulLayerTestParamsSet>, public LayerTestsUtils::LayerTestsCommon {
+class QuantMatMulTest : public testing::WithParamInterface<QuantMatMulLayerTestParamsSet>, virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<QuantMatMulLayerTestParamsSet> &obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/range_add.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/range_add.hpp
@@ -17,7 +17,7 @@
 namespace LayerTestsDefinitions {
 
 class RangeAddSubgraphTest : public testing::WithParamInterface<RangeParams>,
-                             public LayerTestsUtils::LayerTestsCommon {
+                             virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<RangeParams> obj);
 protected:

--- a/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/relu_shape_of.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/relu_shape_of.hpp
@@ -17,7 +17,7 @@
 namespace LayerTestsDefinitions {
 
 class ReluShapeOfSubgraphTest : public testing::WithParamInterface<shapeOfParams>,
-        public LayerTestsUtils::LayerTestsCommon {
+        virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<shapeOfParams> obj);
 protected:

--- a/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/reshape_permute_reshape.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/reshape_permute_reshape.hpp
@@ -20,7 +20,7 @@ typedef std::tuple<
         > ReshapePermuteReshapeTuple;
 
 class ReshapePermuteReshape : public testing::WithParamInterface<ReshapePermuteReshapeTuple>,
-                              public LayerTestsUtils::LayerTestsCommon {
+                              virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<ReshapePermuteReshapeTuple> &obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/reshape_squeeze_reshape_relu.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/reshape_squeeze_reshape_relu.hpp
@@ -22,7 +22,7 @@ using ReshapeSqueezeReshapeReluTuple = typename std::tuple<
 
 class ReshapeSqueezeReshapeRelu
         : public testing::WithParamInterface<ReshapeSqueezeReshapeReluTuple>,
-          public LayerTestsUtils::LayerTestsCommon {
+          virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<ReshapeSqueezeReshapeReluTuple> &obj);
 protected:

--- a/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/scaleshift.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/scaleshift.hpp
@@ -22,7 +22,7 @@ using ScaleShiftParamsTuple = typename std::tuple<
 
 class ScaleShiftLayerTest:
         public testing::WithParamInterface<ScaleShiftParamsTuple>,
-        public LayerTestsUtils::LayerTestsCommon{
+        virtual public LayerTestsUtils::LayerTestsCommon{
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<ScaleShiftParamsTuple> &obj);
 protected:

--- a/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/split_conv_concat.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/split_conv_concat.hpp
@@ -16,7 +16,7 @@
 namespace LayerTestsDefinitions {
 
 class SplitConvConcat : public testing::WithParamInterface<LayerTestsUtils::basicParams>,
-                        public LayerTestsUtils::LayerTestsCommon {
+                        virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<LayerTestsUtils::basicParams> obj);
 

--- a/inference-engine/tests/ie_test_utils/common_test_utils/test_common.hpp
+++ b/inference-engine/tests/ie_test_utils/common_test_utils/test_common.hpp
@@ -8,7 +8,7 @@
 
 namespace CommonTestUtils {
 
-class TestsCommon : public ::testing::Test {
+class TestsCommon : virtual public ::testing::Test {
 protected:
     TestsCommon();
 

--- a/inference-engine/tests/ie_test_utils/functional_test_utils/low_precision_transformations/layer_transformation.hpp
+++ b/inference-engine/tests/ie_test_utils/functional_test_utils/low_precision_transformations/layer_transformation.hpp
@@ -32,7 +32,7 @@ public:
 
 IE_SUPPRESS_DEPRECATED_START
 
-class LayerTransformation : public LayerTestsUtils::LayerTestsCommon {
+class LayerTransformation : virtual public LayerTestsUtils::LayerTestsCommon {
 protected:
     LayerTransformation();
 


### PR DESCRIPTION
Avoid having multiple instances of base object within descendants.
Enabling tests in private repository.