### PR TITLE
Reduce number of ops generated by ngraph::pass::BatchNormDecomposition

### DIFF
--- a/inference-engine/src/transformations/src/transformations/batch_norm_decomposition.cpp
+++ b/inference-engine/src/transformations/src/transformations/batch_norm_decomposition.cpp
@@ -39,47 +39,37 @@ ngraph::pass::BatchNormDecomposition::BatchNormDecomposition() {
             return false;
         }
 
-        // The code above represents this formulas
-        //  scale = 1. / np.sqrt(variance + eps)
-        //  shift = (mean * (-1)) * scale
-        auto input_type = m_input->get_element_type();
+        const auto& input_type = m_input->get_element_type();
+        // scale_add = variance + eps
         auto scale_add = make_shared<opset1::Add>(m_var, opset1::Constant::create(input_type, Shape{}, {m_bn->get_eps_value()}));
-        auto scale_power = make_shared<opset1::Power>(scale_add, opset1::Constant::create(input_type, Shape{}, {0.5}));
-        auto scale = make_shared<ngraph::opset1::Divide>(opset1::Constant::create(input_type, Shape{}, {1}), scale_power);
+        // scale = sqrt(variance + eps)
+        auto scale = make_shared<opset1::Sqrt>(scale_add);
+        // Divide `gamma` by `sqrt(variance + eps)`
+        auto gamma_div_scale = std::make_shared<opset1::Divide>(m_gamma, scale);
 
-        auto shift_mul = make_shared<opset1::Multiply>(m_mean, opset1::Constant::create(m_input->get_element_type(), Shape{}, {-1}));
-        auto shift = make_shared<opset1::Multiply>(scale, shift_mul);
-
-        // Expand Scale, Shift, Gamma and Beta to be aligned with layout
         size_t dims_to_add = m_input->get_shape().size() - 2;
-        Shape gamma_shape = m_gamma->get_shape();
-        for (size_t i = 0; i < dims_to_add; ++i) gamma_shape.push_back(1);
-        auto gamma_aligned = make_shared<opset1::Reshape>(m_gamma, opset1::Constant::create(element::i64, Shape{gamma_shape.size()}, gamma_shape), true);
+        Shape input_aligned_shape = m_gamma->get_shape();
+        for (size_t i = 0; i < dims_to_add; ++i)
+            input_aligned_shape.push_back(1);
+        auto new_shape = opset1::Constant::create(element::i64, Shape{input_aligned_shape.size()}, input_aligned_shape);
 
-        Shape beta_shape = m_beta->get_shape();
-        for (size_t i = 0; i < dims_to_add; ++i) beta_shape.push_back(1);
-        auto beta_aligned = make_shared<opset1::Reshape>(m_beta, opset1::Constant::create(element::i64, Shape{beta_shape.size()}, beta_shape), true);
+        auto gamma_div_scale_aligned = make_shared<opset1::Reshape>(gamma_div_scale, new_shape, true);
+        auto beta_aligned = make_shared<opset1::Reshape>(m_beta, new_shape, true);
+        auto mean_aligned = make_shared<opset1::Reshape>(m_mean, new_shape, true);
 
-        Shape scale_shape = scale->get_shape();
-        for (size_t i = 0; i < dims_to_add; ++i) scale_shape.push_back(1);
-        auto scale_aligned = make_shared<opset1::Reshape>(scale, opset1::Constant::create(element::i64, Shape{scale_shape.size()}, scale_shape), true);
+        // input_sub_mean = input - mean
+        auto input_sub_mean = std::make_shared<opset1::Subtract>(m_input, mean_aligned);
+        // Multiply  `input - mean` and `gamma / sqrt(variance + eps)`
+        auto mul = std::make_shared<opset1::Multiply>(input_sub_mean, gamma_div_scale_aligned);
+        // Add `(input - mean) * gamma / sqrt(variance + eps)` and `beta`
+        auto add = std::make_shared<opset1::Add>(mul, beta_aligned);
 
-        Shape shift_shape = scale->get_shape();
-        for (size_t i = 0; i < dims_to_add; ++i) shift_shape.push_back(1);
-        auto shift_aligned = make_shared<opset1::Reshape>(shift, opset1::Constant::create(element::i64, Shape{shift_shape.size()}, shift_shape), true);
+        add->set_friendly_name(m_bn->get_friendly_name());
 
-        // Connect: Mul(input, scale)->Add(mul, shift)->Mul(add, gamma)->Add(mul, beta)
-        auto mul1 = std::make_shared<opset1::Multiply>(m_input, scale_aligned);
-        auto add1 = std::make_shared<opset1::Add>(mul1, shift_aligned);
-        auto mul2 = std::make_shared<opset1::Multiply>(add1, gamma_aligned);
-        auto add2 = std::make_shared<opset1::Add>(mul2, beta_aligned);
+        copy_runtime_info(m_bn, {scale_add, scale, gamma_div_scale, gamma_div_scale_aligned,
+                                 beta_aligned, input_sub_mean, mul, add});
 
-        add2->set_friendly_name(m_bn->get_friendly_name());
-
-        copy_runtime_info(m_bn, {mul1, add1, mul2, add2,
-                                 gamma_aligned, beta_aligned, scale_aligned, shift_aligned,
-                                 scale_add, scale_power, scale, shift_mul, shift});
-        replace_node(m_bn, add2);
+        replace_node(m_bn, add);
 
         return true;
     };

--- a/inference-engine/src/transformations/src/transformations/batch_norm_decomposition.cpp
+++ b/inference-engine/src/transformations/src/transformations/batch_norm_decomposition.cpp
@@ -23,7 +23,7 @@ ngraph::pass::BatchNormDecomposition::BatchNormDecomposition() {
     auto beta = make_shared<pattern::op::Label>(element::f32, beta_shape);
     auto bn = make_shared<opset1::BatchNormInference>(input, gamma, beta, mean, var, 0.001);
 
-    ngraph::graph_rewrite_callback callback = [input, gamma, beta, mean, var](ngraph::pattern::Matcher &m) {
+    ngraph::graph_rewrite_callback callback = [this, input, gamma, beta, mean, var](ngraph::pattern::Matcher &m) {
         auto pattern_map = m.get_pattern_map();
 
         auto m_input = pattern_map[input];
@@ -58,7 +58,7 @@ ngraph::pass::BatchNormDecomposition::BatchNormDecomposition() {
         auto mean_aligned = make_shared<opset1::Reshape>(m_mean, new_shape, true);
 
         // input_sub_mean = input - mean
-        auto input_sub_mean = std::make_shared<opset1::Subtract>(m_input, mean_aligned);
+        auto input_sub_mean = register_new_node<opset1::Subtract>(m_input, mean_aligned);
         // Multiply  `input - mean` and `gamma / sqrt(variance + eps)`
         auto mul = std::make_shared<opset1::Multiply>(input_sub_mean, gamma_div_scale_aligned);
         // Add `(input - mean) * gamma / sqrt(variance + eps)` and `beta`

--- a/ngraph/test/backend/batch_norm.in.cpp
+++ b/ngraph/test/backend/batch_norm.in.cpp
@@ -324,14 +324,14 @@ NGRAPH_TEST(${BACKEND_NAME}, batch_norm_fprop_inference_b2c2h2w1)
 {
     auto input_shape = Shape{2, 2, 2, 1};
     auto input = make_shared<op::Parameter>(element::f32, input_shape);
-    auto mean_shape = Shape{2};
-    auto mean = make_shared<op::Parameter>(element::f32, mean_shape);
-    auto var_shape = Shape{2};
-    auto var = make_shared<op::Parameter>(element::f32, var_shape);
     auto gamma_shape = Shape{2};
     auto gamma = make_shared<op::Parameter>(element::f32, gamma_shape);
     auto beta_shape = Shape{2};
     auto beta = make_shared<op::Parameter>(element::f32, beta_shape);
+    auto mean_shape = Shape{2};
+    auto mean = make_shared<op::Parameter>(element::f32, mean_shape);
+    auto var_shape = Shape{2};
+    auto var = make_shared<op::Parameter>(element::f32, var_shape);
     double eps = 0.001;
     auto shape_r = Shape{2, 2, 2, 1};
     auto bn = make_shared<op::BatchNormInference>(input, gamma, beta, mean, var, eps);

--- a/ngraph/test/runtime/ie/unit_test.manifest
+++ b/ngraph/test/runtime/ie/unit_test.manifest
@@ -63,7 +63,6 @@ onnx_model_depth_to_space_chw
 onnx_model_space_to_depth_chw
 onnx_model_split_equal_parts_default
 onnx_model_argmin_no_keepdims
-onnx_model_batch_norm_default
 onnx_model_softmax
 onnx_model_elu
 onnx_model_top_k
@@ -949,17 +948,14 @@ gelu_f32
 gelu_f64
 gelu_backprop_factor_f32
 gelu_backprop_factor_f64
+
+# Incorrect precision f64!
 batch_norm_inference_0eps_f64
 batch_norm_inference_f64
 batch_norm_training_0eps_f64
-batch_norm_training_0eps_f32
+
+# Function inputs number differ from number of given inputs
 batch_norm_inference_parameters_duplication
-batch_norm_fprop_b1c2h2w2
-batch_norm_fprop_b2c2h2w1
-batch_norm_fprop_b2c2d2h1w1
-batch_norm_bprop_n4c3h2w2
-batch_norm_fprop_inference_b2c2h2w1
-dyn_batch_norm_fprop_b1c2h2w2
 
 backwards_abs
 backwards_acos
@@ -1016,8 +1012,6 @@ backwards_abc
 backwards_reverse_3d_02
 backwards_maxpool_n4c1h4w4_kh2kw2_sh1sw1
 backwards_maxpool_n2c1h5w5_kh3kw3_sh2sw2
-backwards_batch_norm_training_4d
-backwards_batch_norm_training_3d
 backwards_reverse_sequence_n3_c2_h3
 backwards_reverse_sequence_n4d2c3h2w2
 backwards_gelu_f32


### PR DESCRIPTION
Number of ops went down by 4.
Also fewer floating point operations improves precision here, so we're able
to unblock some test cases from ngraph's suite.