### PR TITLE
[VPU][GT] Add pass for reshape tensors

### DIFF
--- a/inference-engine/src/vpu/graph_transformer/include/vpu/middleend/pass_manager.hpp
+++ b/inference-engine/src/vpu/graph_transformer/include/vpu/middleend/pass_manager.hpp
@@ -111,6 +111,7 @@ public:
     Pass::Ptr splitHwConvAndPool();
     Pass::Ptr hwPadding();
     Pass::Ptr splitLargeKernelConv();
+    Pass::Ptr reshapeBeforeConvTiling();
 
     //
     // Batch support

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/pass_manager.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/pass_manager.cpp
@@ -176,11 +176,9 @@ PassSet::Ptr PassManager::buildMiddleEnd() {
         // "reshapeBeforeConvTiling" pass changes geometry of convolution stages in order
         // to get more efficient HW tiling (pass "hwConvTiling") using reshape stages.
         //
-        // Pass should be located before "adjustDataBatch" because "reshapeBeforeConvTiling"
-        // changes geometry of convolution. "adjustDataBatch" modifies stage "origConvOutput"
-        // attribute to the current convolution output at the time of execution of "adjustDataBatch" pass.
-        // "origConvOutput" attribute is used in "hwConvTiling" and
-        // "hwConvTiling" should be able to see the latest version of this attribute.
+        // Pass should be located before "adjustDataBatch" because "adjustDataBatch" specifies "origConvOutput" attribute
+        // for convolution in order to provide that information to "hwConvTiling" pass.
+        // Otherwise, "hwConvTiling" will see incorrect values in "origConvOutput" attribute.
         ADD_PASS(reshapeBeforeConvTiling);
         ADD_DUMP_PASS("reshapeBeforeConvTiling");
 

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/pass_manager.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/pass_manager.cpp
@@ -180,7 +180,7 @@ PassSet::Ptr PassManager::buildMiddleEnd() {
         // changes geometry of convolution. "adjustDataBatch" modifies stage "origConvOutput"
         // attribute to the current convolution output at the time of execution of "adjustDataBatch" pass.
         // "origConvOutput" attribute is used in "hwConvTiling" and
-        // "hwConvTiling" should be able to see the version of this attribute.
+        // "hwConvTiling" should be able to see the latest version of this attribute.
         ADD_PASS(reshapeBeforeConvTiling);
         ADD_DUMP_PASS("reshapeBeforeConvTiling");
 

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/pass_manager.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/pass_manager.cpp
@@ -172,6 +172,13 @@ PassSet::Ptr PassManager::buildMiddleEnd() {
         ADD_PASS(swapConcatAndHwOps);
         ADD_DUMP_PASS("swapConcatAndHwOps");
 
+        //
+        // "reshapeBeforeConvTiling" pass adds two reshape stages before and after
+        // the convolution stage that will trigger the "hwConvTiling" pass.
+        //
+        // This pass changes convolution input and output, width and height
+        // Pass needs to be placed before "adjustDataBatch",
+        // where changes original stage attributes
         ADD_PASS(reshapeBeforeConvTiling);
         ADD_DUMP_PASS("reshapeBeforeConvTiling");
 

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/pass_manager.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/pass_manager.cpp
@@ -172,6 +172,9 @@ PassSet::Ptr PassManager::buildMiddleEnd() {
         ADD_PASS(swapConcatAndHwOps);
         ADD_DUMP_PASS("swapConcatAndHwOps");
 
+        ADD_PASS(reshapeBeforeConvTiling);
+        ADD_DUMP_PASS("reshapeBeforeConvTiling");
+
         ADD_PASS(mergeHwStages);
         ADD_DUMP_PASS("mergeHwStages");
 

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/pass_manager.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/pass_manager.cpp
@@ -173,9 +173,14 @@ PassSet::Ptr PassManager::buildMiddleEnd() {
         ADD_DUMP_PASS("swapConcatAndHwOps");
 
         //
-        // "reshapeBeforeConvTiling" pass changes geometry of convolution stages in order to get more efficient HW tiling using reshape stages.
+        // "reshapeBeforeConvTiling" pass changes geometry of convolution stages in order
+        // to get more efficient HW tiling (pass "hwConvTiling") using reshape stages.
         //
-        // Pass needs to be placed before "adjustDataBatch", where changes stage "origConvOutput" attribute
+        // Pass should be located before "adjustDataBatch" because "reshapeBeforeConvTiling"
+        // changes geometry of convolution. "adjustDataBatch" modifies stage "origConvOutput"
+        // attribute to the current convolution output at the time of execution of "adjustDataBatch" pass.
+        // "origConvOutput" attribute is used in "hwConvTiling" and
+        // "hwConvTiling" should be able to see the version of this attribute.
         ADD_PASS(reshapeBeforeConvTiling);
         ADD_DUMP_PASS("reshapeBeforeConvTiling");
 

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/pass_manager.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/pass_manager.cpp
@@ -173,12 +173,9 @@ PassSet::Ptr PassManager::buildMiddleEnd() {
         ADD_DUMP_PASS("swapConcatAndHwOps");
 
         //
-        // "reshapeBeforeConvTiling" pass adds two reshape stages before and after
-        // the convolution stage that will trigger the "hwConvTiling" pass.
+        // "reshapeBeforeConvTiling" pass changes geometry of convolution stages in order to get more efficient HW tiling using reshape stages.
         //
-        // This pass changes convolution input and output, width and height
-        // Pass needs to be placed before "adjustDataBatch",
-        // where changes original stage attributes
+        // Pass needs to be placed before "adjustDataBatch", where changes stage "origConvOutput" attribute
         ADD_PASS(reshapeBeforeConvTiling);
         ADD_DUMP_PASS("reshapeBeforeConvTiling");
 

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/reshape_conv.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/reshape_conv.cpp
@@ -1,0 +1,98 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// This is the pass that finds the pattern which consists of a Convolution stage
+// with 2 consumers - Power and Concat stages (Power stage is also followed by Concat),
+// ScaleShift (or Scale, it depends on biases) which comes after Concat,
+// and the last one is Relu.
+
+#include <vpu/middleend/pass_manager.hpp>
+
+// #include <vpu/middleend/hw/conv_tiling/hw_stage_tiler.hpp>
+
+namespace vpu {
+
+namespace {
+
+class PassImpl final : public Pass {
+public:
+    explicit PassImpl(const StageBuilder::Ptr& stageBuilder) : _stageBuilder(stageBuilder) {}
+
+    void run(const Model& model) override;
+
+private:
+    StageBuilder::Ptr _stageBuilder;
+};
+
+void PassImpl::run(const Model& model) {
+    VPU_PROFILE(hwConvTiling);
+    for (const auto& stage : model->getStages()) {
+        if (stage->type() != StageType::StubConv) {
+            continue;
+        }
+
+        const auto tryHW = stage->attrs().getOrDefault<bool>("tryHW", false);
+        if (!tryHW) {
+            continue;
+        }
+
+        auto input = stage->input(0);
+        auto output = stage->output(0);
+
+        if (input->desc().dim(Dim::N) > 1) {
+            continue;
+        }
+
+        if ((input->desc().dimsOrder() != DimsOrder::NCHW)
+                || (output->desc().dimsOrder() != DimsOrder::NCHW)) {
+            continue;
+        }
+
+        if (input->desc().dim(Dim::W) != 60
+        || input->desc().dim(Dim::H) != 34
+        || input->desc().dim(Dim::C) != 608) {
+            continue;
+        }
+
+        if (output->desc().dim(Dim::C) != 10
+        && output->desc().dim(Dim::C) != 128
+        && output->desc().dim(Dim::C) != 490
+        ) {
+            continue;
+        }
+
+        auto newDesc_input = input->desc();
+        newDesc_input.setDim(Dim::W, 255);
+        newDesc_input.setDim(Dim::H, 8);
+
+        auto newDesc_output = output->desc();
+        newDesc_output.setDim(Dim::W, 255);
+        newDesc_output.setDim(Dim::H, 8);
+
+        auto newInput = model->duplicateData(input, "@input-data-after-reshape",
+                newDesc_input);
+
+        auto newOutput = model->duplicateData(output, "@output-data-before-reshape",
+                newDesc_output);
+
+        model->replaceStageInput(stage->inputEdge(0), newInput);
+        model->replaceStageOutput(stage->outputEdge(0), newOutput);
+
+        auto reshape_stage_before = _stageBuilder->addReshapeStage(model,
+                stage->name() + "@copy-reinterpret-input-data",
+                nullptr, input, newInput);
+
+        _stageBuilder->addReshapeStage(model,
+                stage->name() + "@copy-reinterpret-input-data",
+                nullptr, newOutput, output);
+    }
+}
+
+}  // namespace
+
+Pass::Ptr PassManager::reshapeBeforeConvTiling() {
+    return std::make_shared<PassImpl>(_stageBuilder);
+}
+
+}  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/reshape_conv.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/reshape_conv.cpp
@@ -55,7 +55,6 @@ void PassImpl::run(const Model& model) {
 
         const auto actualInputShape = inputDesc.dims();
         const auto expectedInputShape = DimValues{ {Dim::N, 1}, {Dim::C, 608}, {Dim::H, 34}, {Dim::W, 60} };
-        std::vector<size_t> outChannels{10, 128, 490};
 
         if (actualInputShape != expectedInputShape) {
             continue;
@@ -66,7 +65,9 @@ void PassImpl::run(const Model& model) {
             continue;
         }
 
-        if (std::find(outChannels.begin(), outChannels.end(), outputDesc.dim(Dim::C)) == outChannels.end()) {
+        std::map<size_t, size_t> outChannels{ {10, 1}, {128, 2}, {490, 3}};
+
+        if (outChannels.find(outputDesc.dim(Dim::C)) == outChannels.end()) {
             continue;
         }
 

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/reshape_conv.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/reshape_conv.cpp
@@ -2,10 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-// This is the pass that finds the pattern which consists of a Convolution stage
-// with 2 consumers - Power and Concat stages (Power stage is also followed by Concat),
-// ScaleShift (or Scale, it depends on biases) which comes after Concat,
-// and the last one is Relu.
+// This pass changes geometry of convolution stages in order
+// to get more efficient HW tiling (pass "hwConvTiling") using reshape stages.
 
 #include <vpu/middleend/pass_manager.hpp>
 

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/reshape_conv.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/reshape_conv.cpp
@@ -37,6 +37,11 @@ void PassImpl::run(const Model& model) {
             continue;
         }
 
+        if (stage->attrs().get<int>("kernelSizeX") != 1
+        || stage->attrs().get<int>("kernelSizeY") != 1) {
+            continue;
+        }
+
         auto input = stage->input(0);
         auto output = stage->output(0);
 
@@ -52,6 +57,11 @@ void PassImpl::run(const Model& model) {
         if (input->desc().dim(Dim::W) != 60
         || input->desc().dim(Dim::H) != 34
         || input->desc().dim(Dim::C) != 608) {
+            continue;
+        }
+
+        if (output->desc().dim(Dim::W) != 60
+        || output->desc().dim(Dim::H) != 34) {
             continue;
         }
 

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/reshape_conv.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/reshape_conv.cpp
@@ -38,6 +38,11 @@ void PassImpl::run(const Model& model) {
             continue;
         }
 
+        if (stage->attrs().get<int>("kernelStrideX") != 1 ||
+            stage->attrs().get<int>("kernelStrideY") != 1) {
+            continue;
+        }
+
         const auto input = stage->input(0);
         const auto output = stage->output(0);
 
@@ -53,11 +58,6 @@ void PassImpl::run(const Model& model) {
         const auto expectedInputShape = DimValues{ {Dim::N, 1}, {Dim::C, 608}, {Dim::H, 34}, {Dim::W, 60} };
 
         if (actualInputShape != expectedInputShape) {
-            continue;
-        }
-
-        if (outputDesc.dim(Dim::W) != inputDesc.dim(Dim::W) ||
-            outputDesc.dim(Dim::H) != inputDesc.dim(Dim::H)) {
             continue;
         }
 

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/reshape_conv.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/reshape_conv.cpp
@@ -9,8 +9,6 @@
 
 #include <vpu/middleend/pass_manager.hpp>
 
-// #include <vpu/middleend/hw/conv_tiling/hw_stage_tiler.hpp>
-
 namespace vpu {
 
 namespace {

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/convolution.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/convolution.cpp
@@ -28,6 +28,9 @@ const std::vector<std::vector<ptrdiff_t>> padEnds = {{0, 0},
 const std::vector<std::vector<size_t >> dilations = {{1, 1},
                                                             {3, 1}};
 const std::vector<size_t> numOutCannels = {1, 5};
+
+const std::vector<size_t> numOutCannelsReshapeConv = {10, 128, 490}; // For "reshapeBeforeConvTiling" pass
+
 const std::vector<ngraph::op::PadType> padTypes = {
         ngraph::op::PadType::EXPLICIT,
         ngraph::op::PadType::VALID  // FAILURE: Cannot create convolution forward descriptor for layer: Convolution_19010
@@ -59,6 +62,15 @@ const auto conv2DParams_BigDimensionValid = ::testing::Combine(
         ::testing::ValuesIn(std::vector<size_t>({64})),
         ::testing::Values(ngraph::op::PadType::VALID)
 );
+const auto conv2DParams_ReshapeBeforeConv = ::testing::Combine(
+        ::testing::ValuesIn(std::vector<std::vector<size_t>>({{1, 1}})), // kernel
+        ::testing::ValuesIn(std::vector<std::vector<size_t>>({{1, 1}})), // strides
+        ::testing::Values(std::vector<ptrdiff_t>({0, 0})),               // pad begin
+        ::testing::Values(std::vector<ptrdiff_t>({0, 0})),               // pad end
+        ::testing::ValuesIn(std::vector<std::vector<size_t>>({{1, 1}})), // dilation
+        ::testing::ValuesIn(numOutCannelsReshapeConv),
+        ::testing::Values(ngraph::op::PadType::NOTSET)
+);
 
 INSTANTIATE_TEST_CASE_P(Convolution2D_ExplicitPadding, ConvolutionLayerTest,
                         ::testing::Combine(
@@ -80,6 +92,14 @@ INSTANTIATE_TEST_CASE_P(Convolution2D_BigDimensionValid, ConvolutionLayerTest,
                                 conv2DParams_BigDimensionValid,
                                 ::testing::ValuesIn(netPrecisions),
                                 ::testing::Values(std::vector<size_t >({1, 3, 1, 2500})),
+                                ::testing::Values(CommonTestUtils::DEVICE_MYRIAD)),
+                        ConvolutionLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(Convolution2D_ReshapeBeforeConv, ConvolutionLayerTest,
+                        ::testing::Combine(
+                                conv2DParams_ReshapeBeforeConv,
+                                ::testing::ValuesIn(netPrecisions),
+                                ::testing::Values(std::vector<size_t >({1, 608, 34, 60})), // input tensor
                                 ::testing::Values(CommonTestUtils::DEVICE_MYRIAD)),
                         ConvolutionLayerTest::getTestCaseName);
 

--- a/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/reshape_before_conv.cpp
+++ b/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/reshape_before_conv.cpp
@@ -309,6 +309,14 @@ TEST_P(NoReshapeBeforeConvCases, NoChangesForOtherCases) {
     Validate();
 }
 
+static const std::vector<DimValues> noPatternDimsForOutput = {
+    DimValues{ {Dim::N, 1}, {Dim::C, 12}, {Dim::H, 34}, {Dim::W, 60} },
+    DimValues{ {Dim::N, 1}, {Dim::C, 11}, {Dim::H, 224}, {Dim::W, 60} },
+    DimValues{ {Dim::N, 1}, {Dim::C, 48}, {Dim::H, 34}, {Dim::W, 60} },
+    DimValues{ {Dim::N, 1}, {Dim::C, 440}, {Dim::H, 34}, {Dim::W, 60} },
+    DimValues{ {Dim::N, 1}, {Dim::C, 608}, {Dim::H, 22}, {Dim::W, 48} },
+};
+
 static const std::vector<DimValues> noPatternDims = {
     DimValues{ {Dim::N, 1}, {Dim::C, 12}, {Dim::H, 34}, {Dim::W, 60} },
     DimValues{ {Dim::N, 1}, {Dim::C, 128}, {Dim::H, 8}, {Dim::W, 64} },
@@ -324,7 +332,7 @@ static const std::vector<DimValues> noPatternDims = {
 INSTANTIATE_TEST_CASE_P(
         NontargetOutputCases, NoReshapeBeforeConvCases, testing::Combine(
     testing::ValuesIn(patternInputDims),
-    testing::ValuesIn(noPatternDims)));
+    testing::ValuesIn(noPatternDimsForOutput)));
 
 INSTANTIATE_TEST_CASE_P(
         NontargetInputCases, NoReshapeBeforeConvCases, testing::Combine(

--- a/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/reshape_before_conv.cpp
+++ b/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/reshape_before_conv.cpp
@@ -116,9 +116,9 @@ protected:
 
         pattern_datas.push_back(input);
         pattern_datas.push_back(output);
-        pattern_datas.push_back(fake);
-        pattern_datas.push_back(fake);
         pattern_datas.push_back(weights);
+        pattern_datas.push_back(fake);
+        pattern_datas.push_back(fake);
         pattern_datas.push_back(inputAfterReshape);
         pattern_datas.push_back(outputBeforeReshape);
 
@@ -161,12 +161,12 @@ protected:
         pattern_datas.push_back(input);
         pattern_datas.push_back(mid);
         pattern_datas.push_back(output);
-        pattern_datas.push_back(fake);
-        pattern_datas.push_back(fake);
         pattern_datas.push_back(firstWeights);
         pattern_datas.push_back(fake);
         pattern_datas.push_back(fake);
         pattern_datas.push_back(secondWeights);
+        pattern_datas.push_back(fake);
+        pattern_datas.push_back(fake);
 
         switch (current_case) {
         case ReshapeFirst:
@@ -212,9 +212,9 @@ protected:
 
         pattern_datas.push_back(input);
         pattern_datas.push_back(output);
-        pattern_datas.push_back(fake);
-        pattern_datas.push_back(fake);
         pattern_datas.push_back(weights);
+        pattern_datas.push_back(fake);
+        pattern_datas.push_back(fake);
 
         // duplicate to pattern additional not connected data
         pattern_datas.push_back(fake);

--- a/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/reshape_before_conv.cpp
+++ b/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/reshape_before_conv.cpp
@@ -73,8 +73,8 @@ protected:
 
         auto dataIter = datas.begin();
         for (auto patternIter = pattern_datas.begin(); patternIter != pattern_datas.end();
-                std::advance(dataIter, 1),
-                std::advance(patternIter, 1)) {
+                ++dataIter,
+                ++patternIter) {
             ASSERT_EQ((*dataIter)->desc(), (*patternIter)->desc());
             ASSERT_EQ((*dataIter)->name(), (*patternIter)->name());
         }
@@ -85,8 +85,8 @@ protected:
 
         auto patternIter = pattern_stages.begin();
         for (auto stageIter = stages.begin(); stageIter != stages.end();
-                std::advance(stageIter, 1),
-                std::advance(patternIter, 1)) {
+                ++stageIter,
+                ++patternIter) {
             ASSERT_EQ((*stageIter)->type(), *patternIter);
         }
     }

--- a/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/reshape_before_conv.cpp
+++ b/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/reshape_before_conv.cpp
@@ -68,8 +68,9 @@ protected:
         frontEnd->parseConvolution(_model, convLayer, { input }, { output });
     }
 
-    void CompareDataObjects(const details::ContainerRange<DataList, false>& datas) {
+    void Validate(const details::ContainerRange<DataList, false>& datas, const details::ContainerRange<StageList, false>& stages) {
         ASSERT_EQ(datas.size(), pattern_datas.size());
+        ASSERT_EQ(stages.size(), pattern_stages.size());
 
         auto dataIter = datas.begin();
         for (auto patternIter = pattern_datas.begin(); patternIter != pattern_datas.end();
@@ -78,13 +79,9 @@ protected:
             ASSERT_EQ((*dataIter)->desc(), (*patternIter)->desc());
             ASSERT_EQ((*dataIter)->name(), (*patternIter)->name());
         }
-    }
 
-    void CompareStages(const details::ContainerRange<StageList, false>& stages) {
-        ASSERT_EQ(stages.size(), pattern_stages.size());
-
-        auto patternIter = pattern_stages.begin();
-        for (auto stageIter = stages.begin(); stageIter != stages.end();
+        auto stageIter = stages.begin();
+        for (auto patternIter = pattern_stages.begin(); patternIter != pattern_stages.end();
                 ++stageIter,
                 ++patternIter) {
             ASSERT_EQ((*stageIter)->type(), *patternIter);
@@ -180,8 +177,7 @@ TEST_P(ReshapeBeforeConvCases, CompareCountOfLayersPatternCaseTest) {
 
     CreateCorrectPattern(input, output);
 
-    CompareStages(stages);
-    CompareDataObjects(datas);
+    Validate(datas, stages);
 }
 
 static const std::vector<DimValues> patternInputDims = {
@@ -221,8 +217,7 @@ TEST_F(NoReshapeBeforeConvCases, NoChangesForOtherConvKernel) {
 
     CreateIncorrectPattern(input, output, 3, 3);
 
-    CompareStages(stages);
-    CompareDataObjects(datas);
+    Validate(datas, stages);
 }
 
 TEST_P(NoReshapeBeforeConvCases, NoChangesForOtherCases) {
@@ -249,8 +244,7 @@ TEST_P(NoReshapeBeforeConvCases, NoChangesForOtherCases) {
 
     CreateIncorrectPattern(input, output);
 
-    CompareStages(stages);
-    CompareDataObjects(datas);
+    Validate(datas, stages);
 }
 
 static const std::vector<DimValues> noPatternDims = {
@@ -361,8 +355,7 @@ TEST_F(ReshapeBeforeConvTests, TwoTargetNotConnectedConvolutions) {
     pattern_stages.push_back(StageType::StubConv);
     pattern_stages.push_back(StageType::Reshape);
 
-    CompareStages(stages);
-    CompareDataObjects(datas);
+    Validate(datas, stages);
 }
 
 TEST_F(ReshapeBeforeConvTests, OneTargetAndOneNontargetNotConnectedConvolutions) {
@@ -434,8 +427,7 @@ TEST_F(ReshapeBeforeConvTests, OneTargetAndOneNontargetNotConnectedConvolutions)
     pattern_stages.push_back(StageType::StubConv);
     pattern_stages.push_back(StageType::Reshape);
 
-    CompareStages(stages);
-    CompareDataObjects(datas);
+    Validate(datas, stages);
 }
 
 TEST_F(ReshapeBeforeConvTests, TargetConvolutionBeforeNontarget) {
@@ -502,8 +494,7 @@ TEST_F(ReshapeBeforeConvTests, TargetConvolutionBeforeNontarget) {
     pattern_stages.push_back(StageType::Reshape);
     pattern_stages.push_back(StageType::StubConv);
 
-    CompareStages(stages);
-    CompareDataObjects(datas);
+    Validate(datas, stages);
 }
 
 TEST_F(ReshapeBeforeConvTests, TargetConvolutionAfterNontarget) {
@@ -570,8 +561,7 @@ TEST_F(ReshapeBeforeConvTests, TargetConvolutionAfterNontarget) {
     pattern_stages.push_back(StageType::StubConv);
     pattern_stages.push_back(StageType::Reshape);
 
-    CompareStages(stages);
-    CompareDataObjects(datas);
+    Validate(datas, stages);
 }
 
 } // namespace vpu

--- a/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/reshape_before_conv.cpp
+++ b/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/reshape_before_conv.cpp
@@ -70,7 +70,9 @@ protected:
         stage->attrs().set<bool>("tryHW", true);
     }
 
-    void Validate(const details::ContainerRange<DataList, false>& datas, const details::ContainerRange<StageList, false>& stages) {
+    void Validate() {
+        const auto datas = _model->datas();
+        const auto stages = _model->getStages();
         ASSERT_EQ(datas.size(), pattern_datas.size());
         ASSERT_EQ(stages.size(), pattern_stages.size());
 
@@ -174,12 +176,9 @@ TEST_P(ReshapeBeforeConvCases, CompareCountOfLayersPatternCaseTest) {
 
     ASSERT_NO_THROW(Compile());
 
-    auto datas = _model->datas();
-    auto stages = _model->getStages();
-
     CreateCorrectPattern(input, output);
 
-    Validate(datas, stages);
+    Validate();
 }
 
 static const std::vector<DimValues> patternInputDims = {
@@ -214,12 +213,9 @@ TEST_F(NoReshapeBeforeConvCases, NoChangesForOtherConvKernel) {
 
     ASSERT_NO_THROW(Compile());
 
-    const auto datas = _model->datas();
-    const auto stages = _model->getStages();
-
     CreateIncorrectPattern(input, output, 3, 5);
 
-    Validate(datas, stages);
+    Validate();
 }
 
 TEST_P(NoReshapeBeforeConvCases, NoChangesForOtherCases) {
@@ -241,12 +237,9 @@ TEST_P(NoReshapeBeforeConvCases, NoChangesForOtherCases) {
 
     ASSERT_NO_THROW(Compile());
 
-    const auto datas = _model->datas();
-    const auto stages = _model->getStages();
-
     CreateIncorrectPattern(input, output);
 
-    Validate(datas, stages);
+    Validate();
 }
 
 static const std::vector<DimValues> noPatternDims = {
@@ -303,9 +296,6 @@ TEST_F(ReshapeBeforeConvTests, TwoTargetNotConnectedConvolutions) {
 
     ASSERT_NO_THROW(Compile());
 
-    const auto datas = _model->datas();
-    const auto stages = _model->getStages();
-
     const Data fake = _model->addFakeData();
     const Data firstWeights = InitNewData(
             DimValues{ {Dim::N, 10}, {Dim::C, 608}, {Dim::H, 1}, {Dim::W, 1} },
@@ -357,7 +347,7 @@ TEST_F(ReshapeBeforeConvTests, TwoTargetNotConnectedConvolutions) {
     pattern_stages.push_back(StageType::StubConv);
     pattern_stages.push_back(StageType::Reshape);
 
-    Validate(datas, stages);
+    Validate();
 }
 
 TEST_F(ReshapeBeforeConvTests, OneTargetAndOneNontargetNotConnectedConvolutions) {
@@ -386,9 +376,6 @@ TEST_F(ReshapeBeforeConvTests, OneTargetAndOneNontargetNotConnectedConvolutions)
     InitConvStage(secondInput, secondOutput);
 
     ASSERT_NO_THROW(Compile());
-
-    const auto datas = _model->datas();
-    const auto stages = _model->getStages();
 
     const Data fake = _model->addFakeData();
     const Data firstWeights = InitNewData(
@@ -429,7 +416,7 @@ TEST_F(ReshapeBeforeConvTests, OneTargetAndOneNontargetNotConnectedConvolutions)
     pattern_stages.push_back(StageType::StubConv);
     pattern_stages.push_back(StageType::Reshape);
 
-    Validate(datas, stages);
+    Validate();
 }
 
 TEST_F(ReshapeBeforeConvTests, TargetConvolutionBeforeNontarget) {
@@ -454,9 +441,6 @@ TEST_F(ReshapeBeforeConvTests, TargetConvolutionBeforeNontarget) {
     InitConvStage(layerData, output);
 
     ASSERT_NO_THROW(Compile());
-
-    const auto datas = _model->datas();
-    const auto stages = _model->getStages();
 
     const Data fake = _model->addFakeData();
     const Data firstWeights = InitNewData(
@@ -496,7 +480,7 @@ TEST_F(ReshapeBeforeConvTests, TargetConvolutionBeforeNontarget) {
     pattern_stages.push_back(StageType::Reshape);
     pattern_stages.push_back(StageType::StubConv);
 
-    Validate(datas, stages);
+    Validate();
 }
 
 TEST_F(ReshapeBeforeConvTests, TargetConvolutionAfterNontarget) {
@@ -521,9 +505,6 @@ TEST_F(ReshapeBeforeConvTests, TargetConvolutionAfterNontarget) {
     InitConvStage(layerData, output);
 
     ASSERT_NO_THROW(Compile());
-
-    const auto datas = _model->datas();
-    const auto stages = _model->getStages();
 
     const Data fake = _model->addFakeData();
     const Data firstWeights = InitNewData(
@@ -563,7 +544,7 @@ TEST_F(ReshapeBeforeConvTests, TargetConvolutionAfterNontarget) {
     pattern_stages.push_back(StageType::StubConv);
     pattern_stages.push_back(StageType::Reshape);
 
-    Validate(datas, stages);
+    Validate();
 }
 
 } // namespace vpu

--- a/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/reshape_before_conv.cpp
+++ b/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/reshape_before_conv.cpp
@@ -1,0 +1,514 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "graph_transformer_tests.hpp"
+
+#include "ie_memcpy.h"
+
+namespace vpu {
+
+namespace ie = InferenceEngine;
+
+class ReshapeBeforeConvTests : public GraphTransformerTest,
+    public testing::WithParamInterface<size_t> {
+protected:
+    void SetUp() override {
+        ASSERT_NO_FATAL_FAILURE(GraphTransformerTest::SetUp());
+        ASSERT_NO_FATAL_FAILURE(InitCompileEnv());
+        ASSERT_NO_FATAL_FAILURE(InitPipeline());
+
+        _model = CreateModel();
+    }
+
+    void Compile() {
+        _pipeline.run(_model);
+    }
+
+    void InitPipeline() {
+        _pipeline = PassSet();
+        _pipeline.addPass(passManager->dumpModel("before-convert-shape-notation"));
+        _pipeline.addPass(passManager->initialCheck());
+        _pipeline.addPass(passManager->reshapeBeforeConvTiling());
+        _pipeline.addPass(passManager->dumpModel("after-convert-shape-notation"));
+    }
+
+    Data InitInputData(int inputW, int inputH, int inputC, int inputN) {
+        const auto inDims = DimValues{
+            {Dim::N, inputN},
+            {Dim::C, inputC},
+            {Dim::H, inputH},
+            {Dim::W, inputW}};
+        const auto inDesc = DataDesc(DataType::FP16, DimsOrder::NCHW, inDims);
+        return _model->addInputData("Input", inDesc);
+    }
+
+    Data InitOutputData(int outputW, int outputH, int outputC, int outputN) {
+        const auto outDims = DimValues{
+            {Dim::N, outputN},
+            {Dim::C, outputC},
+            {Dim::H, outputH},
+            {Dim::W, outputW}};
+        const auto outDesc = DataDesc(DataType::FP16, DimsOrder::NCHW, outDims);
+        return _model->addOutputData("Output", outDesc);
+    }
+
+    Data InitNewData(int dimW, int dimH, int dimC, int dimN, const std::string& name) {
+        const auto newDims = DimValues{
+                {Dim::N, dimN},
+                {Dim::C, dimC},
+                {Dim::H, dimH},
+                {Dim::W, dimW}};
+        const auto newDesc = DataDesc(DataType::FP16, DimsOrder::NCHW, newDims);
+        return _model->addNewData(name, newDesc);
+    }
+
+    void InitConvStage(const Data& input, const Data& output) {
+        auto convLayer = std::make_shared < ie::ConvolutionLayer
+                > (ie::LayerParams { "TestConvolution", "StubConv",
+                        ie::Precision::FP16 });
+        convLayer->_kernel_x = 1;
+        convLayer->_kernel_y = 1;
+        convLayer->_stride_x = 1;
+        convLayer->_stride_y = 1;
+        convLayer->_padding_x = 0;
+        convLayer->_padding_y = 0;
+
+        convLayer->_weights = ie::make_shared_blob<short>({
+            ie::Precision::FP16, {static_cast<size_t>(convLayer->_kernel_x * convLayer->_kernel_y *
+            input->desc().dim(Dim::C) * output->desc().dim(Dim::C))}, ie::Layout::C });
+        convLayer->_weights->allocate();
+
+        frontEnd->parseConvolution(_model, convLayer, { input }, { output });
+    }
+
+    void CompareDatas(const details::ContainerRange<IntrusiveHandleList<DataNode>, false>& datas,
+            const std::vector<Data>& pattern) {
+        ASSERT_EQ(datas.size(), pattern.size());
+
+        auto dataIter = datas.begin();
+        for (auto patternIter = pattern.begin(); patternIter != pattern.end();
+                std::advance(dataIter, 1),
+                std::advance(patternIter, 1)) {
+            ASSERT_EQ((*dataIter)->desc(), (*patternIter)->desc());
+            ASSERT_EQ((*dataIter)->name(), (*patternIter)->name());
+        }
+    }
+
+    void CompareStages(const details::ContainerRange<IntrusiveHandleList<StageNode>, false>& stages, const std::vector<StageType>& pattern) {
+        ASSERT_EQ(stages.size(), pattern.size());
+
+        auto patternIter = pattern.begin();
+        for (auto stageIter = stages.begin(); stageIter != stages.end();
+                std::advance(stageIter, 1),
+                std::advance(patternIter, 1)) {
+            ASSERT_EQ((*stageIter)->type(), *patternIter);
+        }
+    }
+
+protected:
+    PassSet _pipeline;
+    Model _model;
+};
+
+TEST_P(ReshapeBeforeConvTests, CompareCountOfLayersPatternCaseTest) {
+    //
+    //                          [Fake]              ->|
+    //                          [Weights]           ->|
+    //                          [Fake]              ->|
+    //  [Input] -> (Reshape) -> [InputAfterReshape] ->| -> (StubConv) -> [OutputBeforeReshape] -> (Reshape) -> [Output]
+    //
+    const auto& p = GetParam();
+
+    const auto input = InitInputData(60, 34, 608, 1);
+    _model->attrs().set<int>("numInputs", 1);
+    const auto output = InitOutputData(60, 34, p, 1);
+
+    InitConvStage(input, output);
+
+    ASSERT_NO_THROW(Compile());
+
+    const auto datas = _model->datas();
+    const auto stages = _model->getStages();
+    auto pattern_datas = std::vector<Data>();
+    auto pattern_stages = std::vector<StageType>();
+
+    // this adds to model additional not connected data
+    const Data fake = _model->addFakeData();
+    const Data weights = InitNewData(1, 1, 608, p, "TestConvolution@weights@conv");
+    const Data inputAfterReshape = InitNewData(255, 8, 608, 1, "Input@input-data-after-reshape");
+    const Data outputBeforeReshape = InitNewData(255, 8, p, 1, "Output@output-data-before-reshape");
+
+    pattern_datas.push_back(input);
+    pattern_datas.push_back(output);
+    pattern_datas.push_back(fake);
+    pattern_datas.push_back(weights);
+    pattern_datas.push_back(fake);
+    pattern_datas.push_back(inputAfterReshape);
+    pattern_datas.push_back(outputBeforeReshape);
+
+    // duplicate to pattern additional not connected data
+    pattern_datas.push_back(fake);
+    pattern_datas.push_back(weights);
+    pattern_datas.push_back(inputAfterReshape);
+    pattern_datas.push_back(outputBeforeReshape);
+
+    pattern_stages.push_back(StageType::Reshape);
+    pattern_stages.push_back(StageType::StubConv);
+    pattern_stages.push_back(StageType::Reshape);
+
+    CompareStages(stages, pattern_stages);
+    CompareDatas(datas, pattern_datas);
+}
+
+static const ie::SizeVector patternDims = {
+    10,
+    128,
+    490
+};
+
+INSTANTIATE_TEST_CASE_P(
+        accuracy, ReshapeBeforeConvTests,
+        ::testing::ValuesIn(patternDims));
+
+TEST_F(ReshapeBeforeConvTests, NoChangesForOtherChannel) {
+    //
+    //  [Fake]      ->|
+    //  [Weights]   ->|
+    //  [Fake]      ->|
+    //  [Input]     ->| -> (StubConv) -> [Output]
+    //
+
+    const auto input = InitInputData(60, 34, 608, 1);
+    _model->attrs().set<int>("numInputs", 1);
+    const auto output = InitOutputData(60, 34, 111, 1);
+
+    InitConvStage(input, output);
+
+    ASSERT_NO_THROW(Compile());
+
+    const auto datas = _model->datas();
+    const auto stages = _model->getStages();
+    auto pattern_datas = std::vector<Data>();
+    auto pattern_stages = std::vector<StageType>();
+
+    // this adds to model additional not connected data
+    const Data fake = _model->addFakeData();
+    const Data weights = InitNewData(1, 1, 608, 111, "TestConvolution@weights@conv");
+
+    pattern_datas.push_back(input);
+    pattern_datas.push_back(output);
+    pattern_datas.push_back(fake);
+    pattern_datas.push_back(weights);
+    pattern_datas.push_back(fake);
+
+    // duplicate to pattern additional not connected data
+    pattern_datas.push_back(fake);
+    pattern_datas.push_back(weights);
+
+    pattern_stages.push_back(StageType::StubConv);
+
+    CompareStages(stages, pattern_stages);
+    CompareDatas(datas, pattern_datas);
+}
+
+TEST_F(ReshapeBeforeConvTests, NoChangesForOtherDimensions) {
+    //
+    //  [Fake]      ->|
+    //  [Weights]   ->|
+    //  [Fake]      ->|
+    //  [Input]     ->| -> (StubConv) -> [Output]
+    //
+
+    const auto input = InitInputData(30, 68, 608, 1);
+    _model->attrs().set<int>("numInputs", 1);
+    const auto output = InitOutputData(30, 68, 10, 1);
+
+    InitConvStage(input, output);
+
+    ASSERT_NO_THROW(Compile());
+
+    const auto datas = _model->datas();
+    const auto stages = _model->getStages();
+    auto pattern_datas = std::vector<Data>();
+    auto pattern_stages = std::vector<StageType>();
+
+    // this adds to model additional not connected data
+    const Data fake = _model->addFakeData();
+    const Data weights = InitNewData(1, 1, 608, 10, "TestConvolution@weights@conv");
+
+    pattern_datas.push_back(input);
+    pattern_datas.push_back(output);
+    pattern_datas.push_back(fake);
+    pattern_datas.push_back(weights);
+    pattern_datas.push_back(fake);
+
+    // duplicate to pattern additional not connected data
+    pattern_datas.push_back(fake);
+    pattern_datas.push_back(weights);
+
+    pattern_stages.push_back(StageType::StubConv);
+
+    CompareStages(stages, pattern_stages);
+    CompareDatas(datas, pattern_datas);
+}
+
+TEST_F(ReshapeBeforeConvTests, TwoTargetNotConnectedConvolutions) {
+    //
+    //                               [Fake]                   ->|
+    //                               [FirstWeights]           ->|
+    //                               [Fake]                   ->|
+    //  [FirstInput] -> (Reshape) -> [FirstInputAfterReshape] ->| -> (StubConv) -> [FirstOutputBeforeReshape] -> (Reshape) -> [FirstOutput]
+    //
+    //                                [Fake]                    ->|
+    //                                [SecondWeights]           ->|
+    //                                [Fake]                    ->|
+    //  [SecondInput] -> (Reshape) -> [SecondInputAfterReshape] ->| -> (StubConv) -> [SecondOutputBeforeReshape] -> (Reshape) -> [SecondOutput]
+    //
+
+    const auto firstInput = InitInputData(60, 34, 608, 1);
+    const auto secondInput = InitInputData(60, 34, 608, 1);
+    _model->attrs().set<int>("numInputs", 2);
+    const auto firstOutput = InitOutputData(60, 34, 10, 1);
+    const auto secondOutput = InitOutputData(60, 34, 128, 1);
+
+    InitConvStage(firstInput, firstOutput);
+    InitConvStage(secondInput, secondOutput);
+
+    ASSERT_NO_THROW(Compile());
+
+    const auto datas = _model->datas();
+    const auto stages = _model->getStages();
+    auto pattern_datas = std::vector<Data>();
+    auto pattern_stages = std::vector<StageType>();
+
+    // this adds to model additional not connected data
+    const Data fake = _model->addFakeData();
+    const Data firstWeights = InitNewData(1, 1, 608, 10, "TestConvolution@weights@conv");
+    const Data secondWeights = InitNewData(1, 1, 608, 128, "TestConvolution@weights@conv");
+    const Data firstInputAfterReshape = InitNewData(255, 8, 608, 1, "Input@input-data-after-reshape");
+    const Data secondInputAfterReshape = InitNewData(255, 8, 608, 1, "Input@input-data-after-reshape");
+    const Data firstOutputBeforeReshape = InitNewData(255, 8, 10, 1, "Output@output-data-before-reshape");
+    const Data secondOutputBeforeReshape = InitNewData(255, 8, 128, 1, "Output@output-data-before-reshape");
+
+    pattern_datas.push_back(firstInput);
+    pattern_datas.push_back(secondInput);
+    pattern_datas.push_back(firstOutput);
+    pattern_datas.push_back(secondOutput);
+    pattern_datas.push_back(fake);
+    pattern_datas.push_back(firstWeights);
+    pattern_datas.push_back(fake);
+    pattern_datas.push_back(fake);
+    pattern_datas.push_back(secondWeights);
+    pattern_datas.push_back(fake);
+    pattern_datas.push_back(firstInputAfterReshape);
+    pattern_datas.push_back(firstOutputBeforeReshape);
+    pattern_datas.push_back(secondInputAfterReshape);
+    pattern_datas.push_back(secondOutputBeforeReshape);
+
+    // duplicate to pattern additional not connected data
+    pattern_datas.push_back(fake);
+    pattern_datas.push_back(firstWeights);
+    pattern_datas.push_back(secondWeights);
+    pattern_datas.push_back(firstInputAfterReshape);
+    pattern_datas.push_back(secondInputAfterReshape);
+    pattern_datas.push_back(firstOutputBeforeReshape);
+    pattern_datas.push_back(secondOutputBeforeReshape);
+
+    pattern_stages.push_back(StageType::Reshape);
+    pattern_stages.push_back(StageType::StubConv);
+    pattern_stages.push_back(StageType::Reshape);
+    pattern_stages.push_back(StageType::Reshape);
+    pattern_stages.push_back(StageType::StubConv);
+    pattern_stages.push_back(StageType::Reshape);
+
+    CompareStages(stages, pattern_stages);
+    CompareDatas(datas, pattern_datas);
+}
+
+TEST_F(ReshapeBeforeConvTests, OneTargetAndOneNontargetNotConnectedConvolutions) {
+    //
+    //                               [Fake]                   ->|
+    //                               [FirstWeights]           ->|
+    //                               [Fake]                   ->|
+    //  [FirstInput] -> (Reshape) -> [InputAfterReshape] ->| -> (StubConv) -> [OutputBeforeReshape] -> (Reshape) -> [FirstOutput]
+    //
+    //  [Fake]            ->|
+    //  [SecondWeights]   ->|
+    //  [Fake]            ->|
+    //  [SecondInput]     ->| -> (StubConv) -> [SecondOutput]
+    //
+
+    const auto firstInput = InitInputData(60, 34, 608, 1);
+    const auto secondInput = InitInputData(60, 34, 608, 1);
+    _model->attrs().set<int>("numInputs", 2);
+    const auto firstOutput = InitOutputData(60, 34, 10, 1);
+    const auto secondOutput = InitOutputData(60, 34, 222, 1);
+
+    InitConvStage(firstInput, firstOutput);
+    InitConvStage(secondInput, secondOutput);
+
+    ASSERT_NO_THROW(Compile());
+
+    const auto datas = _model->datas();
+    const auto stages = _model->getStages();
+    auto pattern_datas = std::vector<Data>();
+    auto pattern_stages = std::vector<StageType>();
+
+    // this adds to model additional not connected data
+    const Data fake = _model->addFakeData();
+    const Data firstWeights = InitNewData(1, 1, 608, 10, "TestConvolution@weights@conv");
+    const Data secondWeights = InitNewData(1, 1, 608, 222, "TestConvolution@weights@conv");
+    const Data inputAfterReshape = InitNewData(255, 8, 608, 1, "Input@input-data-after-reshape");
+    const Data outputBeforeReshape = InitNewData(255, 8, 10, 1, "Output@output-data-before-reshape");
+
+    pattern_datas.push_back(firstInput);
+    pattern_datas.push_back(secondInput);
+    pattern_datas.push_back(firstOutput);
+    pattern_datas.push_back(secondOutput);
+    pattern_datas.push_back(fake);
+    pattern_datas.push_back(firstWeights);
+    pattern_datas.push_back(fake);
+    pattern_datas.push_back(fake);
+    pattern_datas.push_back(secondWeights);
+    pattern_datas.push_back(fake);
+    pattern_datas.push_back(inputAfterReshape);
+    pattern_datas.push_back(outputBeforeReshape);
+
+    // duplicate to pattern additional not connected data
+    pattern_datas.push_back(fake);
+    pattern_datas.push_back(firstWeights);
+    pattern_datas.push_back(secondWeights);
+    pattern_datas.push_back(inputAfterReshape);
+    pattern_datas.push_back(outputBeforeReshape);
+
+    pattern_stages.push_back(StageType::StubConv);
+    pattern_stages.push_back(StageType::Reshape);
+    pattern_stages.push_back(StageType::StubConv);
+    pattern_stages.push_back(StageType::Reshape);
+
+    CompareStages(stages, pattern_stages);
+    CompareDatas(datas, pattern_datas);
+}
+
+TEST_F(ReshapeBeforeConvTests, TargetConvolutionBeforeNontarger) {
+    //
+    //                          [Fake]              ->|                                                           [Fake]          ->|
+    //                          [FirstWeights]      ->|                                                           [SecondWeights] ->|
+    //                          [Fake]              ->|                                                           [Fake]          ->|
+    //  [Input] -> (Reshape) -> [InputAfterReshape] ->| -> (StubConv) -> [LayerDataBeforeReshape] -> (Reshape) -> [LayerData]     ->| ->
+    //
+    //  -> (StubConv) -> [Output]
+    //
+
+    const auto input = InitInputData(60, 34, 608, 1);
+    _model->attrs().set<int>("numInputs", 1);
+    const auto layerData = InitNewData(60, 34, 490, 1, "Layer");
+    const auto output = InitOutputData(60, 34, 10, 1);
+
+    InitConvStage(input, layerData);
+    InitConvStage(layerData, output);
+
+    ASSERT_NO_THROW(Compile());
+
+    const auto datas = _model->datas();
+    const auto stages = _model->getStages();
+    auto pattern_datas = std::vector<Data>();
+    auto pattern_stages = std::vector<StageType>();
+
+    // this adds to model additional not connected data
+    const Data fake = _model->addFakeData();
+    const Data firstWeights = InitNewData(1, 1, 608, 490, "TestConvolution@weights@conv");
+    const Data secondWeights = InitNewData(1, 1, 490, 10, "TestConvolution@weights@conv");
+    const Data inputAfterReshape = InitNewData(255, 8, 608, 1, "Input@input-data-after-reshape");
+    const Data layerDataBeforeReshape = InitNewData(255, 8, 490, 1, "Layer@output-data-before-reshape");
+
+    pattern_datas.push_back(input);
+    pattern_datas.push_back(layerData);
+    pattern_datas.push_back(output);
+    pattern_datas.push_back(fake);
+    pattern_datas.push_back(firstWeights);
+    pattern_datas.push_back(fake);
+    pattern_datas.push_back(fake);
+    pattern_datas.push_back(secondWeights);
+    pattern_datas.push_back(fake);
+    pattern_datas.push_back(inputAfterReshape);
+    pattern_datas.push_back(layerDataBeforeReshape);
+
+    // duplicate to pattern additional not connected data
+    pattern_datas.push_back(fake);
+    pattern_datas.push_back(firstWeights);
+    pattern_datas.push_back(secondWeights);
+    pattern_datas.push_back(inputAfterReshape);
+    pattern_datas.push_back(layerDataBeforeReshape);
+
+    pattern_stages.push_back(StageType::Reshape);
+    pattern_stages.push_back(StageType::StubConv);
+    pattern_stages.push_back(StageType::Reshape);
+    pattern_stages.push_back(StageType::StubConv);
+
+    CompareStages(stages, pattern_stages);
+    CompareDatas(datas, pattern_datas);
+}
+
+TEST_F(ReshapeBeforeConvTests, TargetConvolutionAfterNontarger) {
+    //
+    //  [Fake]         ->|                                              [Fake]                  ->|
+    //  [FirstWeights] ->|                                              [SecondWeights]         ->|
+    //  [Fake]         ->|                                              [Fake]                  ->|
+    //  [Input]        ->| -> (StubConv) -> [LayerData] -> (Reshape) -> [LayerDataAfterReshape] ->| ->
+    //
+    //  -> (StubConv) -> [OutputBeforeReshape] -> (Reshape) -> [Output]
+    //
+
+    const auto input = InitInputData(60, 34, 800, 1);
+    _model->attrs().set<int>("numInputs", 1);
+    const auto layerData = InitNewData(60, 34, 608, 1, "Layer");
+    const auto output = InitOutputData(60, 34, 128, 1);
+
+    InitConvStage(input, layerData);
+    InitConvStage(layerData, output);
+
+    ASSERT_NO_THROW(Compile());
+
+    const auto datas = _model->datas();
+    const auto stages = _model->getStages();
+    auto pattern_datas = std::vector<Data>();
+    auto pattern_stages = std::vector<StageType>();
+
+    // this adds to model additional not connected data
+    const Data fake = _model->addFakeData();
+    const Data firstWeights = InitNewData(1, 1, 800, 608, "TestConvolution@weights@conv");
+    const Data secondWeights = InitNewData(1, 1, 608, 128, "TestConvolution@weights@conv");
+    const Data layerDataAfterReshape = InitNewData(255, 8, 608, 1, "Layer@input-data-after-reshape");
+    const Data outputBeforeReshape = InitNewData(255, 8, 128, 1, "Output@output-data-before-reshape");
+
+    pattern_datas.push_back(input);
+    pattern_datas.push_back(layerData);
+    pattern_datas.push_back(output);
+    pattern_datas.push_back(fake);
+    pattern_datas.push_back(firstWeights);
+    pattern_datas.push_back(fake);
+    pattern_datas.push_back(fake);
+    pattern_datas.push_back(secondWeights);
+    pattern_datas.push_back(fake);
+    pattern_datas.push_back(layerDataAfterReshape);
+    pattern_datas.push_back(outputBeforeReshape);
+
+    // duplicate to pattern additional not connected data
+    pattern_datas.push_back(fake);
+    pattern_datas.push_back(firstWeights);
+    pattern_datas.push_back(secondWeights);
+    pattern_datas.push_back(layerDataAfterReshape);
+    pattern_datas.push_back(outputBeforeReshape);
+
+    pattern_stages.push_back(StageType::StubConv);
+    pattern_stages.push_back(StageType::Reshape);
+    pattern_stages.push_back(StageType::StubConv);
+    pattern_stages.push_back(StageType::Reshape);
+
+    CompareStages(stages, pattern_stages);
+    CompareDatas(datas, pattern_datas);
+}
+
+} // namespace vpu


### PR DESCRIPTION
### Ticket
15076
### Description
Tiling for some tensors is more optimal, if these tensors were reshaped before tiling. This pass adds reshape stages for tensors from ticket .
Pass adds two reshape stages, before and after the convolution stage that will trigger the tiling pass.