### PR TITLE
IECore.read_network: accept arbitrary PathLike objects and not just Path

### DIFF
--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pxd
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pxd
@@ -1,7 +1,7 @@
 from .cimport ie_api_impl_defs as C
 from .ie_api_impl_defs cimport CBlob, CTensorDesc, InputInfo, CPreProcessChannel, CPreProcessInfo
 
-from pathlib import Path
+import os
 
 from libcpp.string cimport string
 from libcpp.vector cimport vector
@@ -50,7 +50,7 @@ cdef class ExecutableNetwork:
 
 cdef class IECore:
     cdef C.IECore impl
-    cpdef IENetwork read_network(self, model : [str, bytes, Path], weights : [str, bytes, Path] = ?, bool init_from_buffer = ?)
+    cpdef IENetwork read_network(self, model : [str, bytes, os.PathLike], weights : [str, bytes, os.PathLike] = ?, bool init_from_buffer = ?)
     cpdef ExecutableNetwork load_network(self, IENetwork network, str device_name, config = ?, int num_requests = ?)
     cpdef ExecutableNetwork import_network(self, str model_file, str device_name, config = ?, int num_requests = ?)
 

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pyx
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pyx
@@ -13,7 +13,6 @@ from libc.string cimport memcpy
 
 import os
 from fnmatch import fnmatch
-from pathlib import Path
 import threading
 import warnings
 from copy import deepcopy
@@ -258,7 +257,7 @@ cdef class IECore:
     #  ie = IECore()
     #  net = ie.read_network(model=path_to_xml_file, weights=path_to_bin_file)
     #  ```
-    cpdef IENetwork read_network(self, model: [str, bytes, Path], weights: [str, bytes, Path] = "", init_from_buffer: bool = False):
+    cpdef IENetwork read_network(self, model: [str, bytes, os.PathLike], weights: [str, bytes, os.PathLike] = "", init_from_buffer: bool = False):
         cdef uint8_t*bin_buffer
         cdef string weights_
         cdef string model_
@@ -270,22 +269,18 @@ cdef class IECore:
             net.impl = self.impl.readNetwork(model_, bin_buffer, len(weights))
         else:
             weights_ = "".encode()
-            if isinstance(model, Path) and (isinstance(weights, Path) or not weights):
-                if not model.is_file():
-                    raise Exception("Path to the model {} doesn't exist or it's a directory".format(model))
-                if model.suffix not in [ ".onnx", ".prototxt"]:
-                    if not weights.is_file():
-                        raise Exception("Path to the weights {} doesn't exist or it's a directory".format(weights))
-                    weights_ = bytes(weights)
-                model_ = bytes(model)
-            else:
-                if not os.path.isfile(model):
-                    raise Exception("Path to the model {} doesn't exist or it's a directory".format(model))
-                if not (fnmatch(model, "*.onnx") or fnmatch(model, "*.prototxt")):
-                    if not os.path.isfile(weights):
-                        raise Exception("Path to the weights {} doesn't exist or it's a directory".format(weights))
-                    weights_ = weights.encode()
-                model_ = model.encode()
+
+            model = os.fspath(model)
+            if not os.path.isfile(model):
+                raise Exception("Path to the model {} doesn't exist or it's a directory".format(model))
+            model_ = model.encode()
+
+            if not (fnmatch(model, "*.onnx") or fnmatch(model, "*.prototxt")):
+                weights = os.fspath(weights)
+                if not os.path.isfile(weights):
+                    raise Exception("Path to the weights {} doesn't exist or it's a directory".format(weights))
+                weights_ = weights.encode()
+
             net.impl =  self.impl.readNetwork(model_, weights_)
         return net
 

--- a/inference-engine/ie_bridges/python/tests/test_IECore.py
+++ b/inference-engine/ie_bridges/python/tests/test_IECore.py
@@ -155,7 +155,11 @@ def test_read_network_from_xml():
 
 def test_read_network_as_path():
     ie = IECore()
-    net = ie.read_network(model=Path(model_path()[0]), weights=Path(test_net_bin))
+
+    net = ie.read_network(model=Path(test_net_xml), weights=test_net_bin)
+    assert isinstance(net, IENetwork)
+
+    net = ie.read_network(model=test_net_xml, weights=Path(test_net_bin))
     assert isinstance(net, IENetwork)
 
 


### PR DESCRIPTION
This also makes it work in cases when only one of (`model`, `weights`) is a `PathLike` object.