### PR TITLE
Allow descendants to reuse LayerTestsCommon

### DIFF
--- a/inference-engine/tests/ie_test_utils/functional_test_utils/layer_test_utils.hpp
+++ b/inference-engine/tests/ie_test_utils/functional_test_utils/layer_test_utils.hpp
@@ -86,7 +86,13 @@ protected:
         return refMode;
     }
 
+    std::shared_ptr<InferenceEngine::Core> getCore() {
+        return core;
+    }
+
     void ConfigurePlugin();
+
+    void ConfigureNetwork() const;
 
     void LoadNetwork();
 
@@ -111,8 +117,6 @@ protected:
     InferenceEngine::InferRequest inferRequest;
 
 private:
-    void ConfigureNetwork() const;
-
     std::vector<InferenceEngine::Blob::Ptr> GetOutputs();
     std::shared_ptr<InferenceEngine::Core> core;
     RefMode refMode = RefMode::INTERPRETER;


### PR DESCRIPTION
Use member and method in descendant classes.