### PR TITLE
Added conversion of execution graph to old representation

### DIFF
--- a/inference-engine/src/legacy_api/src/convert_function_to_cnn_network.cpp
+++ b/inference-engine/src/legacy_api/src/convert_function_to_cnn_network.cpp
@@ -644,6 +644,7 @@ void convertFunctionToICNNNetwork(const std::shared_ptr<const ::ngraph::Function
                 std::make_shared<Builder::NodeConverter<::ngraph::op::v1::ReduceLogicalAnd>>(),
                 std::make_shared<Builder::NodeConverter<::ngraph::op::v1::ReduceLogicalOr>>(),
                 std::make_shared<Builder::NodeConverter<::ngraph::op::ShuffleChannels>>(),
+                std::make_shared<Builder::NodeConverter<::ExecGraphInfoSerialization::ExecutionNode>>(),
         };
         CNNLayerPtr result;
 

--- a/inference-engine/src/legacy_api/src/ie_cnn_layer_builder_ngraph.cpp
+++ b/inference-engine/src/legacy_api/src/ie_cnn_layer_builder_ngraph.cpp
@@ -44,6 +44,7 @@
 #include "ngraph_ops/rnn_cell_ie.hpp"
 #include "ngraph_ops/hard_sigmoid_ie.hpp"
 #include "generic_ie.hpp"
+#include "exec_graph_info.hpp"
 
 #include "graph_transformer.h"
 
@@ -1719,6 +1720,40 @@ CNNLayer::Ptr NodeConverter<ngraph::op::MatMul>::createLayer(const std::shared_p
     auto res = std::make_shared<InferenceEngine::GemmLayer>(params);
     res->params["transpose_a"] = castedLayer->get_transpose_a() ? "True" : "False";
     res->params["transpose_b"] = castedLayer->get_transpose_b() ? "True" : "False";
+
+    return res;
+}
+
+template <>
+CNNLayer::Ptr NodeConverter<ExecGraphInfoSerialization::ExecutionNode>::createLayer(const std::shared_ptr<ngraph::Node>& layer) const {
+    auto castedLayer = ngraph::as_type_ptr<ExecGraphInfoSerialization::ExecutionNode>(layer);
+    if (castedLayer == nullptr)
+        THROW_IE_EXCEPTION << "Cannot convert " << layer->get_friendly_name() << " layer ";
+
+    auto & rtInfo = castedLayer->get_rt_info();
+    if (rtInfo.count(ExecGraphInfoSerialization::LAYER_TYPE) == 0) {
+        THROW_IE_EXCEPTION << "No " << ExecGraphInfoSerialization::LAYER_TYPE
+            << " attribute is set in " << layer->get_friendly_name() << " node";
+    }
+
+    auto getStringValue = [] (const std::shared_ptr<ngraph::Variant> & variant) {
+        auto castedVariant = std::dynamic_pointer_cast<ngraph::VariantImpl<std::string>>(variant);
+        IE_ASSERT(castedVariant != nullptr);
+        return castedVariant->get();
+    };
+
+    LayerParams params = { layer->get_friendly_name(),
+                           getStringValue(rtInfo[ExecGraphInfoSerialization::LAYER_TYPE]),
+                           details::convertPrecision(layer->get_output_element_type(0)) };
+    rtInfo.erase(ExecGraphInfoSerialization::LAYER_TYPE);
+
+    auto res = std::make_shared<InferenceEngine::CNNLayer>(params);
+    for (const auto & kvp : rtInfo) {
+        auto castedVariant = std::dynamic_pointer_cast<ngraph::VariantImpl<std::string>>(kvp.second);
+        // skip RT info which holds fusedNames, etc
+        if (castedVariant)
+            res->params[kvp.first] = getStringValue(castedVariant);
+    }
 
     return res;
 }

--- a/inference-engine/tests/functional/plugin/shared/src/execution_graph_tests/num_inputs_fusing_bin_conv.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/execution_graph_tests/num_inputs_fusing_bin_conv.cpp
@@ -87,6 +87,7 @@ TEST_P(ExecGraphInputsFusingBinConv, CheckNumInputsInBinConvFusingWithConv) {
             if (ngraph::op::is_output(op))
                 continue;
 
+            IE_SUPPRESS_DEPRECATED_START
             InferenceEngine::CNNLayerPtr cnnLayer;
             ASSERT_NO_THROW(cnnLayer = CommonTestUtils::getLayerByName(convertedExecGraph.get(), op->get_friendly_name()));
             ASSERT_EQ(cnnLayer->name, op->get_friendly_name());
@@ -98,6 +99,7 @@ TEST_P(ExecGraphInputsFusingBinConv, CheckNumInputsInBinConvFusingWithConv) {
                 auto variant = std::dynamic_pointer_cast<ngraph::VariantImpl<std::string>>(op->get_rt_info()[kvp.first]);
                 ASSERT_EQ(variant->get(), kvp.second);
             }
+            IE_SUPPRESS_DEPRECATED_END
         }
     } else {
         IE_SUPPRESS_DEPRECATED_START

--- a/inference-engine/tests/functional/plugin/shared/src/execution_graph_tests/num_inputs_fusing_bin_conv.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/execution_graph_tests/num_inputs_fusing_bin_conv.cpp
@@ -5,12 +5,14 @@
 #include <vector>
 
 #include <ie_core.hpp>
+#include <exec_graph_info.hpp>
 
 #include <ngraph/function.hpp>
 #include <ngraph/variant.hpp>
 
 #include "functional_test_utils/plugin_cache.hpp"
 #include "functional_test_utils/layer_test_utils.hpp"
+#include "common_test_utils/common_utils.hpp"
 
 #include "execution_graph_tests/num_inputs_fusing_bin_conv.hpp"
 
@@ -55,9 +57,15 @@ TEST_P(ExecGraphInputsFusingBinConv, CheckNumInputsInBinConvFusingWithConv) {
     InferenceEngine::CNNNetwork execGraphInfo = execNet.GetExecGraphInfo();
 
     if (auto function = execGraphInfo.getFunction()) {
+        // try to convert to old representation and check that conversion passed well
+        std::shared_ptr<InferenceEngine::details::CNNNetworkImpl> convertedExecGraph;
+        ASSERT_NO_THROW(convertedExecGraph = std::make_shared<InferenceEngine::details::CNNNetworkImpl>(execGraphInfo));
+        // serialization for IR-v7 like execution graph is still supported for compatibility
+        ASSERT_NO_THROW(convertedExecGraph->serialize("exeNetwork.xml", "exeNetwork.bin", nullptr));
+        ASSERT_EQ(0, std::remove("exeNetwork.xml"));
+
         for (const auto & op : function->get_ops()) {
             const auto & rtInfo = op->get_rt_info();
-
             auto getExecValue = [&rtInfo](const std::string & paramName) -> std::string {
                 auto it = rtInfo.find(paramName);
                 IE_ASSERT(rtInfo.end() != it);
@@ -73,6 +81,22 @@ TEST_P(ExecGraphInputsFusingBinConv, CheckNumInputsInBinConvFusingWithConv) {
                 ASSERT_TRUE(originalLayersNames.find("BinaryConvolution") != std::string::npos);
                 ASSERT_TRUE(originalLayersNames.find("Add") != std::string::npos);
                 ASSERT_EQ(op->get_input_size(), 1);
+            }
+
+            // IR v7 does not have output nodes
+            if (ngraph::op::is_output(op))
+                continue;
+
+            InferenceEngine::CNNLayerPtr cnnLayer;
+            ASSERT_NO_THROW(cnnLayer = CommonTestUtils::getLayerByName(convertedExecGraph.get(), op->get_friendly_name()));
+            ASSERT_EQ(cnnLayer->name, op->get_friendly_name());
+            auto variantType = std::dynamic_pointer_cast<ngraph::VariantImpl<std::string>>(
+                op->get_rt_info()[ExecGraphInfoSerialization::LAYER_TYPE]);;
+            ASSERT_EQ(cnnLayer->type, variantType->get());
+
+            for (const auto & kvp : cnnLayer->params) {
+                auto variant = std::dynamic_pointer_cast<ngraph::VariantImpl<std::string>>(op->get_rt_info()[kvp.first]);
+                ASSERT_EQ(variant->get(), kvp.second);
             }
         }
     } else {


### PR DESCRIPTION
This is needed for compatibility with Workbench which uses Python API, while Python API does not allow to access ngraph runtime info. So, we need a conversion to old representation until RT info is implemented in ngraph python api.