### PR TITLE
Removed CMAKE_DL_LIBS from OpenVINO ITT wrapper

### DIFF
--- a/inference-engine/src/legacy_api/CMakeLists.txt
+++ b/inference-engine/src/legacy_api/CMakeLists.txt
@@ -52,7 +52,7 @@ add_library(${TARGET_NAME} SHARED
 
 set_ie_threading_interface_for(${TARGET_NAME})
 
-target_link_libraries(${TARGET_NAME} PRIVATE ${NGRAPH_LIBRARIES} inference_engine_transformations pugixml openvino::itt)
+target_link_libraries(${TARGET_NAME} PRIVATE ${CMAKE_DL_LIBS} ${NGRAPH_LIBRARIES} inference_engine_transformations pugixml openvino::itt)
 
 add_cpplint_target(${TARGET_NAME}_cpplint FOR_TARGETS ${TARGET_NAME} EXCLUDE_PATTERNS ${CMAKE_CURRENT_BINARY_DIR}/dummy.cpp)
 

--- a/openvino/itt/CMakeLists.txt
+++ b/openvino/itt/CMakeLists.txt
@@ -31,7 +31,7 @@ add_library(openvino::itt ALIAS ${TARGET_NAME})
 if (ENABLE_PROFILING_ITT AND INTEL_ITT_LIBS)
     target_include_directories(${TARGET_NAME} SYSTEM PRIVATE $<TARGET_PROPERTY:ittnotify,INTERFACE_INCLUDE_DIRECTORIES>)
     target_compile_definitions(${TARGET_NAME} PRIVATE $<TARGET_PROPERTY:ittnotify,INTERFACE_COMPILE_DEFINITIONS>)
-    target_link_libraries(${TARGET_NAME} PUBLIC ${INTEL_ITT_LIBS} ${CMAKE_DL_LIBS})
+    target_link_libraries(${TARGET_NAME} PUBLIC ${INTEL_ITT_LIBS})
 endif()
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/openvino/itt/cmake/FindITT.cmake
+++ b/openvino/itt/cmake/FindITT.cmake
@@ -52,5 +52,5 @@ if(ITT_FOUND)
                                                INTERFACE_INCLUDE_DIRECTORIES ${Located_ITT_INCLUDE_DIRS}
                                                INTERFACE_COMPILE_DEFINITIONS ENABLE_PROFILING_ITT)
 
-    set(INTEL_ITT_LIBS ittnotify ${CMAKE_DL_LIBS})
+    set(INTEL_ITT_LIBS ittnotify)
 endif()


### PR DESCRIPTION
And fixes missed `CMAKE_DL_LIBS` in `inference_engine_legacy` (see https://github.com/openvinotoolkit/openvino/pull/1633)