### PR TITLE
ENABLE_PROFILING_ITT option is ignored if ITT library not found

### DIFF
--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -44,4 +44,4 @@ ie_dependent_option (ENABLE_AVX2 "Enable AVX2 optimizations" ON "X86_64 OR X86" 
 
 ie_dependent_option (ENABLE_AVX512F "Enable AVX512 optimizations" ON "X86_64 OR X86" OFF)
 
-ie_dependent_option (ENABLE_PROFILING_ITT "ITT tracing of IE and plugins internals" OFF "NOT CMAKE_CROSSCOMPILING" OFF)
+ie_dependent_option (ENABLE_PROFILING_ITT "ITT tracing of IE and plugins internals" ON "NOT CMAKE_CROSSCOMPILING" OFF)

--- a/openvino/itt/CMakeLists.txt
+++ b/openvino/itt/CMakeLists.txt
@@ -21,7 +21,10 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 file(GLOB_RECURSE SOURCES "src/*.cpp")
 
 if(ENABLE_PROFILING_ITT)
-    find_package(ITT REQUIRED)
+    find_package(ITT)
+    if(NOT ITT_FOUND)
+        message(WARNING "Profiling option enabled, but no ITT library was found")
+    endif()
 endif()
 
 add_library(${TARGET_NAME} STATIC ${SOURCES})


### PR DESCRIPTION
This fix ignores ENABLE_PROFILING_ITT option if ITT library not found. Thus, to build a project with ITT counters, the ENABLE_PROFILING_ITT option should be enabled, and the ittnotify library should be installed in the build environment.