### PR TITLE
Introduce silent ConstantFolding for outputs calculation 

### DIFF
--- a/ngraph/src/ngraph/node_output.hpp
+++ b/ngraph/src/ngraph/node_output.hpp
@@ -114,6 +114,10 @@ namespace ngraph
         bool operator<=(const Output& other) const;
         bool operator>=(const Output& other) const;
 
+        /// \brief Tries to constant fold operation if it's not possible it recursively tries to
+        /// fold its inputs until they exists
+        Output<Node> get_constant_replacement();
+
     private:
         std::shared_ptr<Node> m_node;
         size_t m_index{0};

--- a/ngraph/src/ngraph/op/prior_box.cpp
+++ b/ngraph/src/ngraph/op/prior_box.cpp
@@ -60,7 +60,8 @@ void op::PriorBox::validate_and_infer_types()
 
     set_input_is_relevant_to_shape(0);
 
-    if (auto const_shape = as_type_ptr<op::Constant>(input_value(0).get_node_shared_ptr()))
+    Output<Node> input = input_value(0).get_constant_replacement();
+    if (auto const_shape = as_type_ptr<op::Constant>(input.get_node_shared_ptr()))
     {
         NODE_VALIDATION_CHECK(this,
                               shape_size(const_shape->get_shape()) == 2,

--- a/ngraph/src/ngraph/op/prior_box_clustered.cpp
+++ b/ngraph/src/ngraph/op/prior_box_clustered.cpp
@@ -67,7 +67,8 @@ void op::PriorBoxClustered::validate_and_infer_types()
 
     set_input_is_relevant_to_shape(0);
 
-    if (auto const_shape = as_type_ptr<op::Constant>(input_value(0).get_node_shared_ptr()))
+    Output<Node> input = input_value(0).get_constant_replacement();
+    if (auto const_shape = as_type_ptr<op::Constant>(input.get_node_shared_ptr()))
     {
         NODE_VALIDATION_CHECK(this,
                               shape_size(const_shape->get_shape()) == 2,

--- a/ngraph/src/ngraph/op/topk.cpp
+++ b/ngraph/src/ngraph/op/topk.cpp
@@ -500,10 +500,16 @@ void op::v1::TopK::validate_and_infer_types()
         }
         else
         {
-            auto max_k = maximum_value(input_value(1));
-            if (max_k.first)
+            auto max_k = input_value(1).get_constant_replacement();
+            if (auto max_k_const = as_type_ptr<op::Constant>(max_k.get_node_shared_ptr()))
             {
-                output_shape[m_normalized_axis] &= Dimension(0, max_k.second);
+                auto max_k_val = max_k_const->cast_vector<size_t>();
+                if (max_k_val.size() != 1)
+                {
+                    throw ngraph_error("Unexpected number of values for k input: " +
+                                       std::to_string(max_k_val.size()));
+                }
+                output_shape[m_normalized_axis] &= Dimension(0, max_k_val[0]);
             }
             else
             {


### PR DESCRIPTION
This is a replacement for partial ConstantFolding that is used for output calculation in shape infer functions (see topk shape inference changes).
I'm not using cashes for already folded operations because something may change in Function and this cashes becomes invalid.