### PR TITLE
Improve DepthToSpace tests

### DIFF
--- a/ngraph/frontend/onnx_import/src/op/depth_to_space.cpp
+++ b/ngraph/frontend/onnx_import/src/op/depth_to_space.cpp
@@ -28,11 +28,17 @@ namespace ngraph
                 OutputVector depth_to_space(const Node& node)
                 {
                     auto data = node.get_ng_inputs().at(0);
+                    NGRAPH_CHECK(data.get_shape().size() == 4, "Input must be 4-dimensional");
+
                     const auto mode = node.get_attribute_value<std::string>("mode", "DCR");
-                    const auto ngraph_mode =
-                        (mode == "DCR")
-                            ? default_opset::DepthToSpace::DepthToSpaceMode::BLOCKS_FIRST
-                            : default_opset::DepthToSpace::DepthToSpaceMode::DEPTH_FIRST;
+                    default_opset::DepthToSpace::DepthToSpaceMode ngraph_mode;
+                    if (mode == "DCR")
+                        ngraph_mode = default_opset::DepthToSpace::DepthToSpaceMode::BLOCKS_FIRST;
+                    else if (mode == "CRD")
+                        ngraph_mode = default_opset::DepthToSpace::DepthToSpaceMode::DEPTH_FIRST;
+                    else
+                        NGRAPH_CHECK(false, "only 'DCR' and 'CRD' modes are supported");
+
                     const auto block_size = node.get_attribute_value<std::int64_t>("blocksize");
                     return OutputVector{std::make_shared<default_opset::DepthToSpace>(
                         data, ngraph_mode, block_size)};

--- a/ngraph/test/models/onnx/depth_to_space.prototxt
+++ b/ngraph/test/models/onnx/depth_to_space.prototxt
@@ -12,7 +12,7 @@ graph {
     }
     attribute {
       name: "mode"
-      s: "blocks_first"
+      s: "DCR"
       type: STRING
     }
   }
@@ -27,7 +27,7 @@ graph {
             dim_value: 1
           }
           dim {
-            dim_value: 4
+            dim_value: 8
           }
           dim {
             dim_value: 2
@@ -49,7 +49,7 @@ graph {
             dim_value: 1
           }
           dim {
-            dim_value: 1
+            dim_value: 2
           }
           dim {
             dim_value: 4
@@ -63,5 +63,5 @@ graph {
   }
 }
 opset_import {
-  version: 1
+  version: 11
 }

--- a/ngraph/test/models/onnx/depth_to_space_bad_blocksize.prototxt
+++ b/ngraph/test/models/onnx/depth_to_space_bad_blocksize.prototxt
@@ -12,7 +12,7 @@ graph {
     }
     attribute {
       name: "mode"
-      s: "blocks_first"
+      s: "DCR"
       type: STRING
     }
   }
@@ -63,5 +63,5 @@ graph {
   }
 }
 opset_import {
-  version: 1
+  version: 11
 }

--- a/ngraph/test/models/onnx/depth_to_space_bad_input_shape.prototxt
+++ b/ngraph/test/models/onnx/depth_to_space_bad_input_shape.prototxt
@@ -6,6 +6,11 @@ graph {
     output: "B"
     op_type: "DepthToSpace"
     attribute {
+      name: "blocksize"
+      i: 2
+      type: INT
+    }
+    attribute {
       name: "mode"
       s: "DCR"
       type: STRING
@@ -19,10 +24,7 @@ graph {
         elem_type: 1
         shape {
           dim {
-            dim_value: 1
-          }
-          dim {
-            dim_value: 4
+            dim_value: 8
           }
           dim {
             dim_value: 2
@@ -41,10 +43,7 @@ graph {
         elem_type: 1
         shape {
           dim {
-            dim_value: 1
-          }
-          dim {
-            dim_value: 1
+            dim_value: 2
           }
           dim {
             dim_value: 4

--- a/ngraph/test/models/onnx/depth_to_space_bad_mode.prototxt
+++ b/ngraph/test/models/onnx/depth_to_space_bad_mode.prototxt
@@ -6,8 +6,13 @@ graph {
     output: "B"
     op_type: "DepthToSpace"
     attribute {
+      name: "blocksize"
+      i: 2
+      type: INT
+    }
+    attribute {
       name: "mode"
-      s: "DCR"
+      s: "blocks_first"
       type: STRING
     }
   }
@@ -22,7 +27,7 @@ graph {
             dim_value: 1
           }
           dim {
-            dim_value: 4
+            dim_value: 8
           }
           dim {
             dim_value: 2
@@ -44,7 +49,7 @@ graph {
             dim_value: 1
           }
           dim {
-            dim_value: 1
+            dim_value: 2
           }
           dim {
             dim_value: 4

--- a/ngraph/test/models/onnx/depth_to_space_crd.prototxt
+++ b/ngraph/test/models/onnx/depth_to_space_crd.prototxt
@@ -12,7 +12,7 @@ graph {
     }
     attribute {
       name: "mode"
-      s: "blocks_first"
+      s: "CRD"
       type: STRING
     }
   }
@@ -24,7 +24,10 @@ graph {
         elem_type: 1
         shape {
           dim {
-            dim_value: 4
+            dim_value: 1
+          }
+          dim {
+            dim_value: 8
           }
           dim {
             dim_value: 2
@@ -46,6 +49,9 @@ graph {
             dim_value: 1
           }
           dim {
+            dim_value: 2
+          }
+          dim {
             dim_value: 4
           }
           dim {
@@ -57,5 +63,5 @@ graph {
   }
 }
 opset_import {
-  version: 1
+  version: 11
 }

--- a/ngraph/test/models/onnx/depth_to_space_v1.prototxt
+++ b/ngraph/test/models/onnx/depth_to_space_v1.prototxt
@@ -1,0 +1,62 @@
+ir_version: 3
+producer_name: "nGraph ONNX Importer"
+graph {
+  node {
+    input: "A"
+    output: "B"
+    op_type: "DepthToSpace"
+    attribute {
+      name: "blocksize"
+      i: 2
+      type: INT
+    }
+  }
+  name: "compute_graph"
+  input {
+    name: "A"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 8
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "B"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 1
+}

--- a/ngraph/test/onnx/onnx_import_reshape.in.cpp
+++ b/ngraph/test/onnx/onnx_import_reshape.in.cpp
@@ -219,11 +219,13 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_depth_to_space)
     auto function = onnx_import::import_onnx_model(
         file_util::path_join(SERIALIZED_ZOO, "onnx/depth_to_space.prototxt"));
 
-    std::vector<float> input{
-        0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f, 13.f, 14.f, 15.f};
+    std::vector<float> input{0.f,  1.f,  2.f,  3.f,  4.f,  5.f,  6.f,  7.f,  8.f,  9.f,  10.f,
+                             11.f, 12.f, 13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f,
+                             22.f, 23.f, 24.f, 25.f, 26.f, 27.f, 28.f, 29.f, 30.f, 31.f};
 
     std::vector<float> expected_output{
-        0.f, 4.f, 1.f, 5.f, 8.f, 12.f, 9.f, 13.f, 2.f, 6.f, 3.f, 7.f, 10.f, 14.f, 11.f, 15.f};
+        0.f, 8.f,  1.f, 9.f,  16.f, 24.f, 17.f, 25.f, 2.f, 10.f, 3.f, 11.f, 18.f, 26.f, 19.f, 27.f,
+        4.f, 12.f, 5.f, 13.f, 20.f, 28.f, 21.f, 29.f, 6.f, 14.f, 7.f, 15.f, 22.f, 30.f, 23.f, 31.f};
 
     auto test_case = test::TestCase<TestEngine>(function);
     test_case.add_input(input);
@@ -231,16 +233,19 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_depth_to_space)
     test_case.run();
 }
 
-NGRAPH_TEST(${BACKEND_NAME}, onnx_model_depth_to_space_chw)
+NGRAPH_TEST(${BACKEND_NAME}, onnx_model_depth_to_space_crd)
 {
     auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/depth_to_space_chw.prototxt"));
+        file_util::path_join(SERIALIZED_ZOO, "onnx/depth_to_space_crd.prototxt"));
 
-    std::vector<float> input{
-        0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f, 13.f, 14.f, 15.f};
+    std::vector<float> input{0.f,  1.f,  2.f,  3.f,  4.f,  5.f,  6.f,  7.f,  8.f,  9.f,  10.f,
+                             11.f, 12.f, 13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f,
+                             22.f, 23.f, 24.f, 25.f, 26.f, 27.f, 28.f, 29.f, 30.f, 31.f};
 
-    std::vector<float> expected_output{
-        0.f, 4.f, 1.f, 5.f, 8.f, 12.f, 9.f, 13.f, 2.f, 6.f, 3.f, 7.f, 10.f, 14.f, 11.f, 15.f};
+    std::vector<float> expected_output{0.f,  4.f,  1.f,  5.f,  8.f,  12.f, 9.f,  13.f,
+                                       2.f,  6.f,  3.f,  7.f,  10.f, 14.f, 11.f, 15.f,
+                                       16.f, 20.f, 17.f, 21.f, 24.f, 28.f, 25.f, 29.f,
+                                       18.f, 22.f, 19.f, 23.f, 26.f, 30.f, 27.f, 31.f};
 
     auto test_case = test::TestCase<TestEngine>(function);
     test_case.add_input(input);
@@ -263,6 +268,44 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_depth_to_space_no_blocksize)
     EXPECT_THROW(onnx_import::import_onnx_model(file_util::path_join(
                      SERIALIZED_ZOO, "onnx/depth_to_space_no_blocksize.prototxt")),
                  std::runtime_error);
+}
+
+NGRAPH_TEST(${BACKEND_NAME}, onnx_model_depth_to_space_bad_mode)
+{
+    try
+    {
+        onnx_import::import_onnx_model(
+            file_util::path_join(SERIALIZED_ZOO, "onnx/depth_to_space_bad_mode.prototxt"));
+        FAIL() << "The onnx_importer did not throw for unknown mode to DepthToSpace op";
+    }
+    catch (const ngraph::ngraph_error& e)
+    {
+        std::string msg{e.what()};
+        EXPECT_NE(msg.find("only 'DCR' and 'CRD' modes are supported"), std::string::npos);
+    }
+    catch (...)
+    {
+        FAIL() << "Expected ngraph_error exception";
+    }
+}
+
+NGRAPH_TEST(${BACKEND_NAME}, onnx_model_depth_to_space_bad_input_shape)
+{
+    try
+    {
+        onnx_import::import_onnx_model(
+            file_util::path_join(SERIALIZED_ZOO, "onnx/depth_to_space_bad_input_shape.prototxt"));
+        FAIL() << "The onnx_importer did not throw for invalid input shape to DepthToSpace op";
+    }
+    catch (const ngraph::ngraph_error& e)
+    {
+        std::string msg{e.what()};
+        EXPECT_NE(msg.find("Input must be 4-dimensional"), std::string::npos);
+    }
+    catch (...)
+    {
+        FAIL() << "Expected ngraph_error exception";
+    }
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_space_to_depth)

--- a/ngraph/test/onnx/onnx_import_reshape.in.cpp
+++ b/ngraph/test/onnx/onnx_import_reshape.in.cpp
@@ -219,9 +219,26 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_depth_to_space)
     auto function = onnx_import::import_onnx_model(
         file_util::path_join(SERIALIZED_ZOO, "onnx/depth_to_space.prototxt"));
 
-    std::vector<float> input{0.f,  1.f,  2.f,  3.f,  4.f,  5.f,  6.f,  7.f,  8.f,  9.f,  10.f,
-                             11.f, 12.f, 13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f,
-                             22.f, 23.f, 24.f, 25.f, 26.f, 27.f, 28.f, 29.f, 30.f, 31.f};
+    std::vector<float> input(32);
+    std::iota(input.begin(), input.end(), 0);
+
+    std::vector<float> expected_output{
+        0.f, 8.f,  1.f, 9.f,  16.f, 24.f, 17.f, 25.f, 2.f, 10.f, 3.f, 11.f, 18.f, 26.f, 19.f, 27.f,
+        4.f, 12.f, 5.f, 13.f, 20.f, 28.f, 21.f, 29.f, 6.f, 14.f, 7.f, 15.f, 22.f, 30.f, 23.f, 31.f};
+
+    auto test_case = test::TestCase<TestEngine>(function);
+    test_case.add_input(input);
+    test_case.add_expected_output(expected_output);
+    test_case.run();
+}
+
+NGRAPH_TEST(${BACKEND_NAME}, onnx_model_depth_to_space_v1)
+{
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(SERIALIZED_ZOO, "onnx/depth_to_space_v1.prototxt"));
+
+    std::vector<float> input(32);
+    std::iota(input.begin(), input.end(), 0);
 
     std::vector<float> expected_output{
         0.f, 8.f,  1.f, 9.f,  16.f, 24.f, 17.f, 25.f, 2.f, 10.f, 3.f, 11.f, 18.f, 26.f, 19.f, 27.f,
@@ -238,9 +255,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_depth_to_space_crd)
     auto function = onnx_import::import_onnx_model(
         file_util::path_join(SERIALIZED_ZOO, "onnx/depth_to_space_crd.prototxt"));
 
-    std::vector<float> input{0.f,  1.f,  2.f,  3.f,  4.f,  5.f,  6.f,  7.f,  8.f,  9.f,  10.f,
-                             11.f, 12.f, 13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f,
-                             22.f, 23.f, 24.f, 25.f, 26.f, 27.f, 28.f, 29.f, 30.f, 31.f};
+    std::vector<float> input(32);
+    std::iota(input.begin(), input.end(), 0);
 
     std::vector<float> expected_output{0.f,  4.f,  1.f,  5.f,  8.f,  12.f, 9.f,  13.f,
                                        2.f,  6.f,  3.f,  7.f,  10.f, 14.f, 11.f, 15.f,
@@ -313,9 +329,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_space_to_depth)
     auto function = onnx_import::import_onnx_model(
         file_util::path_join(SERIALIZED_ZOO, "onnx/space_to_depth.prototxt"));
 
-    std::vector<float> input{0.f,  1.f,  2.f,  3.f,  4.f,  5.f,  6.f,  7.f,  8.f,  9.f,  10.f,
-                             11.f, 12.f, 13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f,
-                             22.f, 23.f, 24.f, 25.f, 26.f, 27.f, 28.f, 29.f, 30.f, 31.f};
+    std::vector<float> input(32);
+    std::iota(input.begin(), input.end(), 0);
 
     std::vector<float> expected_output{
         0.f, 2.f, 8.f,  10.f, 16.f, 18.f, 24.f, 26.f, 1.f, 3.f, 9.f,  11.f, 17.f, 19.f, 25.f, 27.f,
@@ -333,9 +348,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_space_to_depth_chw)
     auto function = onnx_import::import_onnx_model(
         file_util::path_join(SERIALIZED_ZOO, "onnx/space_to_depth_chw.prototxt"));
 
-    std::vector<float> input{0.f,  1.f,  2.f,  3.f,  4.f,  5.f,  6.f,  7.f,  8.f,  9.f,  10.f,
-                             11.f, 12.f, 13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f,
-                             22.f, 23.f, 24.f, 25.f, 26.f, 27.f, 28.f, 29.f, 30.f, 31.f};
+    std::vector<float> input(32);
+    std::iota(input.begin(), input.end(), 0);
 
     std::vector<float> expected_output{
         0.f, 2.f, 8.f,  10.f, 16.f, 18.f, 24.f, 26.f, 1.f, 3.f, 9.f,  11.f, 17.f, 19.f, 25.f, 27.f,

--- a/ngraph/test/runtime/ie/unit_test.manifest
+++ b/ngraph/test/runtime/ie/unit_test.manifest
@@ -59,7 +59,6 @@ onnx_model_lstm_bdir_short_input_seq
 onnx_model_lstm_mixed_seq_reverse
 
 # Result mismatch
-onnx_model_depth_to_space_chw
 onnx_model_space_to_depth_chw
 onnx_model_split_equal_parts_default
 onnx_model_argmin_no_keepdims


### PR DESCRIPTION
- check in onnx_import if input is 4 dimensional.
- check in onnx_import if mode is either DCR or CRD.
- add negative tests for those checks.
- fix depth_to_space test cases to use correct mode attribute
- add test case for DepthToSpace with CRD mode