### PR TITLE
Link CMAKE_DL_LIBS to IE

### DIFF
--- a/inference-engine/src/inference_engine/CMakeLists.txt
+++ b/inference-engine/src/inference_engine/CMakeLists.txt
@@ -159,7 +159,7 @@ add_library(${TARGET_NAME} SHARED
 
 set_ie_threading_interface_for(${TARGET_NAME})
 
-target_link_libraries(${TARGET_NAME} PRIVATE Threads::Threads pugixml openvino::itt
+target_link_libraries(${TARGET_NAME} PRIVATE ${CMAKE_DL_LIBS} Threads::Threads pugixml openvino::itt
                                              ${NGRAPH_LIBRARIES} inference_engine_transformations
                                      PUBLIC ${TARGET_NAME}_legacy)
 


### PR DESCRIPTION
`dladdr` is used in `file_utils.cpp` which is part of `inference_engine` library

It's strange that CI has not found any issues with that