### PR TITLE
Remove TestMode restriction for BatchNorm in Kaldi

### DIFF
--- a/model-optimizer/mo/front/kaldi/extractors/batchnorm_component_ext.py
+++ b/model-optimizer/mo/front/kaldi/extractors/batchnorm_component_ext.py
@@ -51,9 +51,6 @@ class BatchNormComponentFrontExtractor(FrontExtractorOp):
         collect_until_token(pb, b'<TestMode>')
         test_mode = read_binary_bool_token(pb)
 
-        if test_mode is not False:
-            raise Error("Test mode True for BatchNorm is not supported")
-
         collect_until_token(pb, b'<StatsMean>')
         mean = read_binary_vector(pb)
 


### PR DESCRIPTION
Description: Removed TestMode restriction for BatchNorm in Kaldi models.

#27949

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR: N/A -- no new transformations were added
* [x]  Transformation preserves original framework node names: N/A -- no new transformation were added

Validation:
* [x]  Unit tests: N/A
* [x]  Framework operation tests: N/A -- no new operations were added
* [x]  Transformation tests: N/A -- no new transformations were added
* [x]  e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py: N/A
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list: N/A
* [x]  Supported **public** models list: N/A
* [x]  New operations specification: N/A
* [x]  Guide on how to convert the **public** model: N/A
* [x]  User guide update: N/A