### PR TITLE
[IE CLDNN] Set arguments once when possible

### DIFF
--- a/inference-engine/thirdparty/clDNN/common/khronos_ocl_clhpp/cl2_ext.hpp
+++ b/inference-engine/thirdparty/clDNN/common/khronos_ocl_clhpp/cl2_ext.hpp
@@ -662,6 +662,13 @@ typedef CL_API_ENTRY cl_mem(CL_API_CALL * PFN_clCreateFromMediaSurfaceINTEL)(
             fn = supports_usm ? load_entrypoint<PFN_clSetKernelArgMemPointerINTEL>(get(), "clSetKernelArgMemPointerINTEL") : nullptr;
         }
 
+        KernelIntel(const Kernel &other, PFN_clSetKernelArgMemPointerINTEL fn) : Kernel(other), fn(fn) { }
+
+        KernelIntel clone() const {
+            Kernel cloned_kernel(this->getInfo<CL_KERNEL_PROGRAM>(), this->getInfo<CL_KERNEL_FUNCTION_NAME>().c_str());
+            return KernelIntel(cloned_kernel, fn);
+        }
+
         cl_int setArgUsm(cl_uint index, const UsmMemory& mem) {
             if (!fn)
                 throw std::runtime_error("[CL ext] clSetKernelArgMemPointerINTEL function ptr is null. Can not set USM arg.");

--- a/inference-engine/thirdparty/clDNN/src/gpu/custom_gpu_primitive_gpu.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/custom_gpu_primitive_gpu.cpp
@@ -51,16 +51,26 @@ struct custom_gpu_primitive_gpu : typed_primitive_impl<custom_gpu_primitive> {
                   arg.get_program().get_id(),
                   arg.get_program().get_engine().get_context()->get_configuration().dump_custom_program) {}
 
-    event_impl::ptr execute_impl(const std::vector<event_impl::ptr>& events,
-                                 custom_gpu_primitive_inst& instance) override {
+    void set_arguments_impl(custom_gpu_primitive_inst& instance) override {
         auto net_id = instance.get_network().get_id();
         gpu::kernel::kernel_arguments_data args;
         for (auto& dep : instance.dependencies()) {
             args.inputs.push_back((memory_impl::cptr) &(dep->output_memory()));
         }
         args.output = (memory_impl::cptr) &instance.output_memory();
+        _kernel.set_arguments(net_id, *cl_kernel.get(), args);
+    }
+
+    void cleanup_impl(custom_gpu_primitive_inst& instance) override {
+        auto net_id = instance.get_network().get_id();
+        _kernel.cleanup(net_id);
+    }
+
+    event_impl::ptr execute_impl(const std::vector<event_impl::ptr>& events,
+                                 custom_gpu_primitive_inst& instance) override {
+        auto net_id = instance.get_network().get_id();
         _kernel.set_output_event(net_id, instance.node.is_output());
-        return _kernel.run(net_id, *cl_kernel.get(), events, args);
+        return _kernel.run(net_id, *cl_kernel.get(), events);
     }
 };
 

--- a/inference-engine/thirdparty/clDNN/src/gpu/kernel.h
+++ b/inference-engine/thirdparty/clDNN/src/gpu/kernel.h
@@ -35,20 +35,26 @@ class kernel : public context_holder {
     bool _one_time_kernel;  // If this flag is true, the kernel is intended to be executed only once (can be removed
                             // later from the cache).
 
+    std::map<uint32_t, kernels_cache::kernel_type> _cl_kernels;
+
 public:
     explicit kernel(std::shared_ptr<gpu_toolkit> context,
                     const std::shared_ptr<kernel_selector::kernel_string>& kernel_string,
                     uint32_t prog_id,
                     bool dump_custom_program = false,
                     bool one_time_kernel = false)
-        : context_holder(context),
-          _prog_id(prog_id),
-          _kernel_id(
-              context->get_kernels_cache(prog_id).set_kernel_source(kernel_string, dump_custom_program, one_time_kernel)),
-          _one_time_kernel(one_time_kernel) {}
+        : context_holder(context)
+        , _prog_id(prog_id)
+        , _kernel_id(context->get_kernels_cache(prog_id).set_kernel_source(kernel_string, dump_custom_program, one_time_kernel))
+        , _one_time_kernel(one_time_kernel)
+        , _cl_kernels({}) {}
 
     kernel(const kernel& other)
-        : context_holder(other.context()), _prog_id(other._prog_id), _kernel_id(other._kernel_id), _one_time_kernel(other._one_time_kernel) {}
+        : context_holder(other.context())
+        , _prog_id(other._prog_id)
+        , _kernel_id(other._kernel_id)
+        , _one_time_kernel(other._one_time_kernel)
+        , _cl_kernels(other._cl_kernels) {}
 
     kernel& operator=(const kernel& other) {
         if (this == &other) {
@@ -58,6 +64,7 @@ public:
         _kernel_id = other._kernel_id;
         _prog_id = other._prog_id;
         _one_time_kernel = other._one_time_kernel;
+        _cl_kernels = other._cl_kernels;
 
         return *this;
     }
@@ -88,10 +95,13 @@ public:
         context()->set_output_event(net_id, is_out_event);
     }
 
+    void cleanup(uint32_t queue_id);
+    void set_arguments(uint32_t queue_id,
+                       const kernel_selector::cl_kernel_data& kernel_data,
+                       const kernel_arguments_data& args);
     event_impl::ptr run(uint32_t queue_id,
                         const kernel_selector::cl_kernel_data& kernel_data,
-                        const std::vector<event_impl::ptr>& dependencies,
-                        const kernel_arguments_data& args) const;
+                        const std::vector<event_impl::ptr>& dependencies) const;
 };
 
 }  // namespace gpu

--- a/inference-engine/thirdparty/clDNN/src/gpu/kernel_runner.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/kernel_runner.cpp
@@ -214,7 +214,8 @@ std::vector<std::chrono::nanoseconds> kernel_runner::run_kernels(const kernel_se
             for (int iteration = 0; iteration < runs_per_kernel; iteration++) {
                 event_impl::ptr event;
                 try {
-                    event = kernels[i].run(0, it->kernels[0], {}, args);
+                    kernels[i].set_arguments(0, it->kernels[0], args);
+                    event = kernels[i].run(0, it->kernels[0], {});
                 } catch (std::exception& e) {
                     std::cout << "[clDNN] Could not run kernel for auto-tune: " << it->kernelName
                               << " with auto-tune index " << it->autoTuneIndex << std::endl

--- a/inference-engine/thirdparty/clDNN/src/gpu/wait_for_events_gpu.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/wait_for_events_gpu.cpp
@@ -32,6 +32,9 @@ class wait_for_events_gpu : public primitive_impl {
 public:
     explicit wait_for_events_gpu(const program_node& /*node*/) {}
 
+    void set_arguments(primitive_inst& /*instance*/) override {}
+    void cleanup(primitive_inst& /*instance*/) override {}
+
     event_impl::ptr execute(const std::vector<event_impl::ptr>& events, primitive_inst& instance) override {
         uint32_t net_id = instance.get_network().get_id();
         events_waiter events_waiter(instance.get_network().get_engine().get_context());

--- a/inference-engine/thirdparty/clDNN/src/include/network_impl.h
+++ b/inference-engine/thirdparty/clDNN/src/include/network_impl.h
@@ -76,6 +76,7 @@ public:
     const program_impl::graph_optimizer_info& get_optimizer_passes_info() const;
     void execute(const std::vector<event_impl::ptr>& events);
     void validate_primitives();
+    void set_arguments();
     // Implementation specific calls
     std::shared_ptr<primitive_inst> get_primitive(const primitive_id& id);
     std::string get_primitive_info(const primitive_id& id) const;
@@ -97,6 +98,7 @@ private:
     const program_impl::cptr _program;
     uint16_t _stream_id;
     bool _internal;
+    bool _reset_arguments;
     float _learning_rate = static_cast<float>(0.00001);
 
     std::map<primitive_id, std::shared_ptr<primitive_inst>> _primitives;

--- a/inference-engine/thirdparty/clDNN/src/primitive_inst.cpp
+++ b/inference-engine/thirdparty/clDNN/src/primitive_inst.cpp
@@ -109,6 +109,20 @@ event_impl::ptr primitive_inst::execute(const std::vector<event_impl::ptr>& even
     return _impl->execute(dependencies, *this);
 }
 
+void primitive_inst::set_arguments() {
+    const auto primitive_id = id();
+    CLDNN_ERROR_BOOL(primitive_id,
+                     "Invalid/unset input",
+                     !_has_valid_input,
+                     "Cannot set arguments for primitive " + primitive_id + " with invalid/unset input");
+
+    _impl->set_arguments(*this);
+}
+
+void primitive_inst::cleanup() {
+    _impl->cleanup(*this);
+}
+
 void primitive_inst::build_deps() {
     if (_deps.empty() && !_node.get_dependencies().empty()) {
         _deps = _network.get_primitives(_node.get_dependencies());


### PR DESCRIPTION
setArg call is expensive on gen12, so this patch changes the logic for kernel arguments setup to make it only once for most of the nodes.
Now set_arguments is called for all nodes on the first execution, and then only nodes with mutable inputs/outputs are updated on further runs (e.g. input nodes where we can have different buffer on each iteration). 