### PR TITLE
[IE CLDNN] Fix for a few fp32 regressions after int8 batch 16 changes

### DIFF
--- a/inference-engine/thirdparty/clDNN/src/gpu/fully_connected_gpu.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/fully_connected_gpu.cpp
@@ -110,7 +110,6 @@ attach_fully_connected_gpu::attach_fully_connected_gpu() {
         {std::make_tuple(engine_types::ocl, data_types::f32, format::b_fs_yx_fsv4), val_fw},
         {std::make_tuple(engine_types::ocl, data_types::i8, format::b_fs_yx_fsv16), val_fw},
         {std::make_tuple(engine_types::ocl, data_types::u8, format::b_fs_yx_fsv16), val_fw},
-        {std::make_tuple(engine_types::ocl, data_types::f32, format::bs_fs_yx_bsv16_fsv16), val_fw},
         {std::make_tuple(engine_types::ocl, data_types::i8, format::bs_fs_yx_bsv16_fsv16), val_fw},
         {std::make_tuple(engine_types::ocl, data_types::u8, format::bs_fs_yx_bsv16_fsv16), val_fw},
         // fs_b_yx_fsv32


### PR DESCRIPTION
#632 patch adds fp32-bs_fs_yx_bsv16_fsv16 fully connected layer to the implementation map. That results in choosing reference FC kernel for some fp32 models. 
This is one line changes which restores previous behavior by disabling fp32-bs_fs_yx_bsv16_fsv16 for FC.
Jira: CVS-33417