### PR TITLE
[VPU][GT] Fix different blobs for the same network

### DIFF
--- a/inference-engine/src/vpu/graph_transformer/include/vpu/frontend/ie_parsed_network.hpp
+++ b/inference-engine/src/vpu/graph_transformer/include/vpu/frontend/ie_parsed_network.hpp
@@ -17,7 +17,7 @@ namespace ie = InferenceEngine;
 struct IeParsedNetwork final {
     ie::InputsDataMap networkInputs;
     ie::OutputsDataMap networkOutputs;
-    std::unordered_map<ie::DataPtr, ie::Blob::Ptr> constDatas;
+    std::vector<std::pair<ie::DataPtr, ie::Blob::Ptr>> constDatas;
     std::vector<ie::CNNLayerPtr> orderedLayers;
 };
 

--- a/inference-engine/src/vpu/graph_transformer/src/frontend/ie_parsed_network.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/frontend/ie_parsed_network.cpp
@@ -66,7 +66,7 @@ IeParsedNetwork parseNetwork(const ie::ICNNNetwork& network) {
             const auto constBlob = layer->blobs.begin()->second;
             IE_ASSERT(constBlob != nullptr);
 
-            out.constDatas[constData] = constBlob;
+            out.constDatas.emplace_back(constData, constBlob);
 
             continue;
         }


### PR DESCRIPTION
Ticket - #-36845
Use `vector` instead of `unordered_map` in order to get stable blob serialization.