### PR TITLE
Updated a link to MO FAQ

### DIFF
--- a/model-optimizer/mo/utils/utils.py
+++ b/model-optimizer/mo/utils/utils.py
@@ -22,9 +22,9 @@ import numpy as np
 
 
 def refer_to_faq_msg(question_num: int):
-    return '\n For more information please refer to Model Optimizer FAQ' \
-           ' (https://docs.openvinotoolkit.org/latest/_docs_MO_DG_prepare_model_Model_Optimizer_FAQ.html),' \
-           ' question #{}. '.format(question_num)
+    return '\n For more information please refer to Model Optimizer FAQ, question #{0}. ' \
+           '(https://docs.openvinotoolkit.org/latest/openvino_docs_MO_DG_prepare_model_Model_Optimizer_FAQ.html' \
+           '?question={0}#question-{0})'.format(question_num)
 
 
 class NamedAttrsClass:


### PR DESCRIPTION
This is a joint change to the https://github.com/openvinotoolkit/openvino/pull/1749/ tracked with ticket #36169.
Locally verified that the produced error message and the link are correct:

```
For more information please refer to Model Optimizer FAQ, question #38. (https://docs.openvinotoolkit.org/latest/openvino_docs_MO_DG_prepare_model_Model_Optimizer_FAQ.html?question=38#question-38)
```