### PR TITLE
Customer model compilation error - fix

### DIFF
--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/adjust_data_layout.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/adjust_data_layout.cpp
@@ -210,7 +210,14 @@ void PassImpl::run(const Model& model) {
                     }
                 }
                 if (newInput == nullptr) {
-                    newInput = addConvertedData(model, input, requiredStrides);
+                    if (input->usage() == DataUsage::Const) {
+                        auto dataNew = model->addNewData(input->name(), input->desc());
+                    
+                        dataNew->attrs().copyFrom(input->attrs());
+                        newInput = addConvertedData(model, dataNew, requiredStrides);
+                    } else {
+                        newInput = addConvertedData(model, input, requiredStrides);
+                    }
 
                     _stageBuilder->addCopyStage(
                         model,
@@ -359,23 +366,23 @@ Data PassImpl::addConvertedData(
         const Data& orig,
         const StridesRequirement& reqs) {
 
-    // auto data = nullptr;
-    if (orig->usage() == DataUsage::Const) {
-        auto newData = model->addNewData(orig->name(), orig->desc());
-        auto data = model->duplicateData(newData, "@adjust-strides");
-        data->resetRequiredStrides();
-        data->updateRequiredStrides(reqs);
-        return data;
-    } else {
+    // if (orig->usage() == DataUsage::Const) {
+    //     std::cout << "Const addConvertedData\n";
+    //     auto newData = model->addNewData(orig->name(), orig->desc());
+    //     newData->attrs().copyFrom(orig->attrs());
+    //     auto data = model->duplicateData(newData, "@adjust-strides");
+    //     data->resetRequiredStrides();
+    //     data->updateRequiredStrides(reqs);
+
+    //     return data;
+    // } else 
+    {
         auto data = model->duplicateData(orig, "@adjust-strides");
         data->resetRequiredStrides();
         data->updateRequiredStrides(reqs);
+
         return data;
     }
-    
-    // data->resetRequiredStrides();
-    // data->updateRequiredStrides(reqs);
-    // return data;
 }
 
 }  // namespace

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/adjust_data_layout.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/adjust_data_layout.cpp
@@ -359,7 +359,6 @@ Data PassImpl::addConvertedData(
         const Model& model,
         const Data& orig,
         const StridesRequirement& reqs) {
-
     auto data = orig;
 
     if (orig->usage() == DataUsage::Const) {

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/adjust_data_layout.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/adjust_data_layout.cpp
@@ -194,13 +194,11 @@ void PassImpl::run(const Model& model) {
                 }
 
                 if (input->checkStrides(requiredStrides)) {
-                    // printf("!!! checkStrides\n");
                     input->updateRequiredStrides(requiredStrides);
                     continue;
                 }
 
                 auto& convertedData = input->attrs().getOrSet<DataVector>("convertedData", DataVector());
-                // std::cout<<"size : "<<convertedData.size()<<"\n";
 
                 Data newInput = nullptr;
 
@@ -208,14 +206,11 @@ void PassImpl::run(const Model& model) {
                     if (data->desc().dimsOrder() == input->desc().dimsOrder() &&
                         data->checkStrides(requiredStrides)) {
                         newInput = data;
-                        // printf("newInput = data;\n");
                         break;
                     }
                 }
                 if (newInput == nullptr) {
                     newInput = addConvertedData(model, input, requiredStrides);
-
-                    // printf("newInput == nullptr\n");
 
                     _stageBuilder->addCopyStage(
                         model,
@@ -327,13 +322,6 @@ void PassImpl::run(const Model& model) {
                 }
 
                 if (inEdge->input()->usage() == DataUsage::Const) {
-                    if (!inEdge->input()->checkStrides(StridesRequirement::compact())) {
-                        // std::cout<<"Problematic const : "<<inEdge->input()->name()<<"\n";
-                        // return;
-                        Data newIn = addConvertedData(model, inEdge->input(), StridesRequirement::compact());
-                        // inEdge->input() = newIn;
-                        // model->replaceStageInput(inEdge->input(), newIn);
-                    }
                     IE_ASSERT(inEdge->input()->checkStrides(StridesRequirement::compact()));
                 }
             }
@@ -360,8 +348,6 @@ Data PassImpl::addConvertedData(
     auto newDesc = orig->desc();
     newDesc.reorder(order);
 
-    // std::cout<< "addConvData from " << orig->name() << "\n";
-
     return model->duplicateData(
         orig,
         formatString("@order=%s", order),
@@ -380,7 +366,6 @@ Data PassImpl::addConvertedData(
         data->resetRequiredStrides();
         data->updateRequiredStrides(reqs);
         return data;
-        // return orig;
     } else {
         auto data = model->duplicateData(orig, "@adjust-strides");
         data->resetRequiredStrides();
@@ -388,8 +373,6 @@ Data PassImpl::addConvertedData(
         return data;
     }
     
-    // std::cout<< "--- addConvData from " << orig->name() << "\n";
-
     // data->resetRequiredStrides();
     // data->updateRequiredStrides(reqs);
     // return data;

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/adjust_data_layout.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/adjust_data_layout.cpp
@@ -209,6 +209,7 @@ void PassImpl::run(const Model& model) {
                         break;
                     }
                 }
+
                 if (newInput == nullptr) {
                     newInput = addConvertedData(model, input, requiredStrides);
 
@@ -302,6 +303,7 @@ void PassImpl::run(const Model& model) {
     //
     // Final adjustment and check.
     //
+
     {
         for (const auto& stage : model->getStages()) {
             stage->finalizeDataLayout();


### PR DESCRIPTION
#-36693

_Description_ : One of the `concat` inputs is a constant. `Adjust_data_layout` pass tries to duplicate all inputs that do not meet the strides requirements, and then copy from the original input to the duplicate with strides.
But `duplicateData` with an argument in the form of a constant also creates a constant, and then, when `Copy`, an error appears, the presence of a constant output, which cannot be.
_Proposed solution_ : In `addConvertedData` create an `intermidiate` date with the same description as the constant, and then copy the constant data into it with the required strides.

Works with PrismCreek now.