### PR TITLE
Added support of Output<Node> type for copy_runtime_info method

### DIFF
--- a/docs/template_plugin/src/template_pattern_transformation.cpp
+++ b/docs/template_plugin/src/template_pattern_transformation.cpp
@@ -37,7 +37,7 @@ ngraph::pass::DecomposeDivideMatcher::DecomposeDivideMatcher() {
         mul->set_friendly_name(div->get_friendly_name());
 
         // Copy runtime info attributes to newly created operation
-        ngraph::copy_runtime_info(div, {pow, mul});
+        ngraph::copy_runtime_info(div, NodeVector{pow, mul});
 
         // Replace Divide operation with Multiply
         ngraph::replace_node(div, mul);

--- a/inference-engine/src/transformations/include/transformations/convert_opset1_to_legacy/reshape_fc_fusion.hpp
+++ b/inference-engine/src/transformations/include/transformations/convert_opset1_to_legacy/reshape_fc_fusion.hpp
@@ -84,7 +84,7 @@ private:
                                                                fc->get_shape());
 
             new_fc->set_friendly_name(fc->get_friendly_name());
-            ngraph::copy_runtime_info({reshape, fc}, new_fc);
+            ngraph::copy_runtime_info(NodeVector{reshape, fc}, new_fc);
             ngraph::replace_node(fc, new_fc);
             return true;
         };

--- a/inference-engine/src/transformations/include/transformations/mul_add_squence_fusion.hpp
+++ b/inference-engine/src/transformations/include/transformations/mul_add_squence_fusion.hpp
@@ -99,7 +99,7 @@ bool fusion(std::shared_ptr<T> m_eltwise) {
             auto new_const = std::make_shared<T>(constant, res.second);
             auto new_eltwise = std::make_shared<T>(res.first, new_const);
 
-            copy_runtime_info(m_eltwise, {new_const, new_eltwise});
+            copy_runtime_info(m_eltwise, NodeVector{new_const, new_eltwise});
             replace_node(m_eltwise, new_eltwise);
             new_eltwise->set_op_annotations(std::make_shared<op::util::EltwiseAttrs>(m_attrs));
             new_eltwise->set_friendly_name(m_eltwise->get_friendly_name());
@@ -112,7 +112,7 @@ bool fusion(std::shared_ptr<T> m_eltwise) {
             auto new_const = std::make_shared<opset1::Multiply>(constant, res.second);
             auto new_add = std::make_shared<opset1::Add> (new_mul, new_const);
 
-            copy_runtime_info(m_eltwise, {new_mul, new_const, new_add});
+            copy_runtime_info(m_eltwise, NodeVector{new_mul, new_const, new_add});
             replace_node(m_eltwise, new_add);
 
             // We need to preserve op annotations and namings

--- a/inference-engine/src/transformations/src/transformations/batch_norm_decomposition.cpp
+++ b/inference-engine/src/transformations/src/transformations/batch_norm_decomposition.cpp
@@ -66,8 +66,8 @@ ngraph::pass::BatchNormDecomposition::BatchNormDecomposition() {
 
         add->set_friendly_name(m_bn->get_friendly_name());
 
-        copy_runtime_info(m_bn, {scale_add, scale, gamma_div_scale, gamma_div_scale_aligned,
-                                 beta_aligned, input_sub_mean, mul, add});
+        copy_runtime_info(m_bn, NodeVector{scale_add, scale, gamma_div_scale, gamma_div_scale_aligned,
+                                           beta_aligned, input_sub_mean, mul, add});
 
         replace_node(m_bn, add);
 

--- a/inference-engine/src/transformations/src/transformations/convert_depth_to_space.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_depth_to_space.cpp
@@ -93,7 +93,7 @@ ngraph::pass::ConvertDepthToSpace::ConvertDepthToSpace() {
         auto transpose = std::make_shared<ngraph::opset1::Transpose>(reshape_begin, create_constant(order));
         auto reshape_end = std::make_shared<ngraph::opset1::Reshape>(transpose, create_constant(shape_end), true);
         reshape_end->set_friendly_name(dts_node->get_friendly_name());
-        ngraph::copy_runtime_info(dts_node, {reshape_begin, transpose, reshape_end});
+        ngraph::copy_runtime_info(dts_node, NodeVector{reshape_begin, transpose, reshape_end});
         ngraph::replace_node(dts_node, reshape_end);
         return true;
     };

--- a/inference-engine/src/transformations/src/transformations/convert_divide.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_divide.cpp
@@ -27,7 +27,7 @@ ngraph::pass::ConvertDivide::ConvertDivide() {
         auto mul = std::make_shared<ngraph::opset1::Multiply>(div->input(0).get_source_output(), pow);
 
         mul->set_friendly_name(div->get_friendly_name());
-        ngraph::copy_runtime_info(div, {pow, mul});
+        ngraph::copy_runtime_info(div, NodeVector{pow, mul});
         ngraph::replace_node(div, mul);
         return true;
     };

--- a/inference-engine/src/transformations/src/transformations/convert_minimum_to_power_and_max.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_minimum_to_power_and_max.cpp
@@ -36,7 +36,7 @@ ngraph::pass::ConvertMinimum::ConvertMinimum() {
         auto neg_2 = std::make_shared<ngraph::opset1::Multiply>(max, opset1::Constant::create(max->get_element_type(), Shape{1}, {-1}));
 
         neg_2->set_friendly_name(minimum->get_friendly_name());
-        ngraph::copy_runtime_info(minimum, {neg_0, neg_1, max, neg_2});
+        ngraph::copy_runtime_info(minimum, NodeVector{neg_0, neg_1, max, neg_2});
         ngraph::replace_node(minimum, neg_2);
         return true;
     };

--- a/inference-engine/src/transformations/src/transformations/convert_mod.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_mod.cpp
@@ -38,7 +38,7 @@ ngraph::pass::ConvertMod::ConvertMod() {
         auto mul = std::make_shared<opset1::Multiply>(dividend_sign, sub);
 
         mul->set_friendly_name(mod->get_friendly_name());
-        ngraph::copy_runtime_info(mod, {dividend, dividend_sign, divisor, div, convert_to_i64, convert, multiplication, sub, mul});
+        ngraph::copy_runtime_info(mod, NodeVector{dividend, dividend_sign, divisor, div, convert_to_i64, convert, multiplication, sub, mul});
         ngraph::replace_node(mod, mul);
         return true;
     };

--- a/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_cells_to_cells_ie.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_cells_to_cells_ie.cpp
@@ -48,7 +48,7 @@ ngraph::pass::ConvertLSTMCellMatcher::ConvertLSTMCellMatcher() {
                                                                       lstm_cell->get_clip());
 
         lstm_cell_ie->set_friendly_name(lstm_cell->get_friendly_name());
-        ngraph::copy_runtime_info(lstm_cell, {concat, lstm_cell_ie});
+        ngraph::copy_runtime_info(lstm_cell, NodeVector{concat, lstm_cell_ie});
         ngraph::replace_node(m.get_match_root(), lstm_cell_ie);
         return true;
     };
@@ -89,7 +89,7 @@ ngraph::pass::ConvertGRUCellMatcher::ConvertGRUCellMatcher() {
                                                                    gru_cell->get_linear_before_reset());
 
         gru_cell_ie->set_friendly_name(gru_cell->get_friendly_name());
-        ngraph::copy_runtime_info(gru_cell, {concat, gru_cell_ie});
+        ngraph::copy_runtime_info(gru_cell, NodeVector{concat, gru_cell_ie});
         ngraph::replace_node(m.get_match_root(), gru_cell_ie);
         return true;
     };
@@ -129,7 +129,7 @@ ngraph::pass::ConvertRNNCellMatcher::ConvertRNNCellMatcher() {
                                                                     rnn_cell->get_clip());
 
         rnn_cell_ie->set_friendly_name(rnn_cell->get_friendly_name());
-        ngraph::copy_runtime_info(rnn_cell, {concat, rnn_cell_ie});
+        ngraph::copy_runtime_info(rnn_cell, NodeVector{concat, rnn_cell_ie});
         ngraph::replace_node(m.get_match_root(), rnn_cell_ie);
         return true;
     };

--- a/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_gathertree_to_gathertree_ie.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_gathertree_to_gathertree_ie.cpp
@@ -28,7 +28,7 @@ ngraph::pass::ConvertGatherTreeToGatherTreeIEMatcher::ConvertGatherTreeToGatherT
         auto gt_ie = std::make_shared<ngraph::op::GatherTreeIE>(gt->input_value(0), gt->input_value(1), gt->input_value(2), reshape);
 
         gt_ie->set_friendly_name(gt->get_friendly_name());
-        ngraph::copy_runtime_info(gt, {reshape, gt_ie});
+        ngraph::copy_runtime_info(gt, NodeVector{reshape, gt_ie});
         ngraph::replace_node(gt, gt_ie);
         return true;
     };

--- a/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_gelu.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_gelu.cpp
@@ -30,7 +30,7 @@ void ngraph::pass::ConvertGELU::convert_gelu() {
         auto res = std::make_shared<ngraph::opset1::Multiply>(mul, add);
 
         res->set_friendly_name(gelu->get_friendly_name());
-        ngraph::copy_runtime_info(gelu, {mul, sq2, div, erf, add, res});
+        ngraph::copy_runtime_info(gelu, NodeVector{mul, sq2, div, erf, add, res});
         ngraph::replace_node(gelu, res);
         return true;
     };

--- a/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_mul_add_to_scaleshift_or_power.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_mul_add_to_scaleshift_or_power.cpp
@@ -175,7 +175,7 @@ void ngraph::pass::ConvertMulAddToScaleShiftOrPower::convert_mul_add_to_scaleshi
 
             auto power = std::make_shared<ngraph::op::PowerIE>(data_node, 1., scale, shift);
             power->set_friendly_name(add_node->get_friendly_name());
-            ngraph::copy_runtime_info({mul_node, add_node}, power);
+            ngraph::copy_runtime_info(NodeVector{mul_node, add_node}, power);
             ngraph::replace_node(m.get_match_root(), power);
         }
 

--- a/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_normalizel2_to_normalize_ie.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_normalizel2_to_normalize_ie.cpp
@@ -63,7 +63,7 @@ ngraph::pass::ConvertNormalizeL2WithMulToNormalizeIE::ConvertNormalizeL2WithMulT
                                                                        channel_shared);
 
         normalize_ie->set_friendly_name(mul->get_friendly_name());
-        ngraph::copy_runtime_info({normalize, mul}, normalize_ie);
+        ngraph::copy_runtime_info(NodeVector{normalize, mul}, normalize_ie);
         ngraph::replace_node(mul, normalize_ie);
         return true;
     };

--- a/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_one_hot_to_one_hot_ie.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_one_hot_to_one_hot_ie.cpp
@@ -45,7 +45,7 @@ ngraph::pass::ConvertOneHotToOneHotIEMatcher::ConvertOneHotToOneHotIEMatcher() {
         if (on_value_node->get_element_type() != m_output_type) {
             auto convert = std::make_shared<ngraph::opset1::Convert>(one_hot_ie, on_value_node->get_element_type());
             convert->set_friendly_name(one_hot->get_friendly_name() + "/Convert");
-            ngraph::copy_runtime_info(one_hot, {one_hot_ie, convert});
+            ngraph::copy_runtime_info(one_hot, NodeVector{one_hot_ie, convert});
             ngraph::replace_node(m.get_match_root(), convert);
         } else {
             ngraph::copy_runtime_info(one_hot, one_hot_ie);

--- a/inference-engine/src/transformations/src/transformations/convert_opset3_to_opset2/convert_broadcast3.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_opset3_to_opset2/convert_broadcast3.cpp
@@ -40,7 +40,7 @@ void ngraph::pass::ConvertBroadcast3::convert_broadcast3() {
             auto constant_one = std::make_shared<ngraph::opset1::Constant>(input.get_element_type(), Shape({1}), std::vector<int>{1});
             auto broadcast_ones = std::make_shared<ngraph::opset1::Broadcast>(constant_one, target_shape, op::AutoBroadcastType::NUMPY);
             last_node = std::make_shared<ngraph::opset1::Multiply>(input, broadcast_ones);
-            ngraph::copy_runtime_info(broadcast, {last_node, broadcast_ones, constant_one});
+            ngraph::copy_runtime_info(broadcast, NodeVector{last_node, broadcast_ones, constant_one});
         }
 
         last_node->set_friendly_name(broadcast->get_friendly_name());

--- a/inference-engine/src/transformations/src/transformations/convert_space_to_depth.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_space_to_depth.cpp
@@ -82,7 +82,7 @@ ngraph::pass::ConvertSpaceToDepth::ConvertSpaceToDepth() {
         auto transpose = std::make_shared<ngraph::opset1::Transpose>(reshape_begin, create_constant(order));
         auto reshape_end = std::make_shared<ngraph::opset1::Reshape>(transpose, create_constant(shape_end), true);
         reshape_end->set_friendly_name(std_node->get_friendly_name());
-        ngraph::copy_runtime_info(std_node, {reshape_begin, transpose, reshape_end});
+        ngraph::copy_runtime_info(std_node, NodeVector{reshape_begin, transpose, reshape_end});
         ngraph::replace_node(std_node, reshape_end);
         return true;
     };

--- a/inference-engine/src/transformations/src/transformations/convert_subtract.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_subtract.cpp
@@ -26,7 +26,7 @@ ngraph::pass::ConvertSubtract::ConvertSubtract() {
         auto add = std::make_shared<ngraph::opset1::Add>(sub->input(0).get_source_output(), neg);
 
         add->set_friendly_name(sub->get_friendly_name());
-        ngraph::copy_runtime_info(sub, {neg, add});
+        ngraph::copy_runtime_info(sub, NodeVector{neg, add});
         ngraph::replace_node(sub, add);
         return true;
     };

--- a/inference-engine/src/transformations/src/transformations/depth_to_space_fusion.cpp
+++ b/inference-engine/src/transformations/src/transformations/depth_to_space_fusion.cpp
@@ -152,7 +152,7 @@ void ngraph::pass::DepthToSpaceFusion::depth_to_space_fusion() {
         auto depth_to_space =
                 std::make_shared<ngraph::opset3::DepthToSpace>(reshape_before->input_value(0), mode, block_size);
         depth_to_space->set_friendly_name(reshape_after->get_friendly_name());
-        ngraph::copy_runtime_info({reshape_before, permute, reshape_after}, depth_to_space);
+        ngraph::copy_runtime_info(NodeVector{reshape_before, permute, reshape_after}, depth_to_space);
 
         if (!m_transformation_callback(depth_to_space)) {
             return false;

--- a/inference-engine/src/transformations/src/transformations/lin_op_sequence_fusion.cpp
+++ b/inference-engine/src/transformations/src/transformations/lin_op_sequence_fusion.cpp
@@ -53,7 +53,7 @@ ngraph::pass::AddMultiplyFusion::AddMultiplyFusion() {
         // Add two constants using opset3::Add constant folding and create new Add operation
         auto new_add = std::make_shared<opset3::Add>(new_mul, eltwise_fold<opset3::Multiply>(add_const, mul_const));
 
-        copy_runtime_info({add, mul}, {new_mul, new_add});
+        copy_runtime_info(NodeVector{add, mul}, NodeVector{new_mul, new_add});
         new_add->set_friendly_name(mul->get_friendly_name());
         replace_node(mul, new_add);
         return true;
@@ -85,7 +85,7 @@ ngraph::pass::AddAddFusion::AddAddFusion() {
         // Add operation will be added to the list of ops requested for pattern matching
         auto new_add = register_new_node<opset3::Add>(input, eltwise_fold<opset3::Add>(add1_const, add2_const));
 
-        copy_runtime_info({add1, add2}, new_add);
+        copy_runtime_info(NodeVector{add1, add2}, new_add);
         new_add->set_friendly_name(add2->get_friendly_name());
         replace_node(add2, new_add);
         return true;
@@ -117,7 +117,7 @@ ngraph::pass::MultiplyMultiplyFusion::MultiplyMultiplyFusion() {
         // Multiply operation will be added to the list of ops requested for pattern matching
         auto new_mul = register_new_node<opset3::Multiply>(input, eltwise_fold<opset3::Multiply>(mul1_const, mul2_const));
 
-        copy_runtime_info({mul1, mul2}, new_mul);
+        copy_runtime_info(NodeVector{mul1, mul2}, new_mul);
         new_mul->set_friendly_name(mul2->get_friendly_name());
         replace_node(mul2, new_mul);
         return true;

--- a/inference-engine/src/transformations/src/transformations/mish_fusion.cpp
+++ b/inference-engine/src/transformations/src/transformations/mish_fusion.cpp
@@ -26,11 +26,11 @@ ngraph::pass::MishFusion::MishFusion() {
         auto mish = std::make_shared<ngraph::opset4::Mish>(exp_input);
 
         mish->set_friendly_name(m.get_match_root()->get_friendly_name());
-        ngraph::copy_runtime_info({pattern_to_output.at(mul).get_node_shared_ptr(),
-                                   pattern_to_output.at(tanh).get_node_shared_ptr(),
-                                   pattern_to_output.at(log).get_node_shared_ptr(),
-                                   pattern_to_output.at(add).get_node_shared_ptr(),
-                                   pattern_to_output.at(exp).get_node_shared_ptr()}, mish);
+        ngraph::copy_runtime_info({pattern_to_output.at(mul),
+                                   pattern_to_output.at(tanh),
+                                   pattern_to_output.at(log),
+                                   pattern_to_output.at(add),
+                                   pattern_to_output.at(exp)}, mish);
         ngraph::replace_node(m.get_match_root(), mish);
         return true;
     };

--- a/inference-engine/src/transformations/src/transformations/swish_fusion.cpp
+++ b/inference-engine/src/transformations/src/transformations/swish_fusion.cpp
@@ -54,8 +54,8 @@ ngraph::pass::SwishFusionWithSigmoid::SwishFusionWithSigmoid() {
         auto swish = std::make_shared<ngraph::opset4::Swish>(exp_input);
 
         swish->set_friendly_name(m.get_match_root()->get_friendly_name());
-        ngraph::copy_runtime_info({pattern_to_output.at(sigmoid).get_node_shared_ptr(),
-                                   pattern_to_output.at(mul).get_node_shared_ptr()},
+        ngraph::copy_runtime_info({pattern_to_output.at(sigmoid),
+                                   pattern_to_output.at(mul)},
                                   swish);
         ngraph::replace_node(m.get_match_root(), swish);
         return true;
@@ -97,9 +97,7 @@ ngraph::pass::SwishFusionWithSigmoidWithBeta::SwishFusionWithSigmoidWithBeta() {
         auto swish = std::make_shared<ngraph::opset4::Swish>(exp_input, new_beta);
 
         swish->set_friendly_name(m.get_match_root()->get_friendly_name());
-        ngraph::copy_runtime_info({pattern_to_output.at(sigmoid).get_node_shared_ptr(),
-                                   pattern_to_output.at(mul).get_node_shared_ptr()},
-                                  swish);
+        ngraph::copy_runtime_info({pattern_to_output.at(sigmoid), pattern_to_output.at(mul)}, swish);
         ngraph::replace_node(m.get_match_root(), swish);
         return true;
     };
@@ -131,13 +129,13 @@ ngraph::pass::SwishFusionWithBeta::SwishFusionWithBeta() {
         auto swish = std::make_shared<ngraph::opset4::Swish>(exp_input, pattern_to_output.at(beta));
 
         swish->set_friendly_name(m.get_match_root()->get_friendly_name());
-        ngraph::copy_runtime_info({pattern_to_output.at(beta).get_node_shared_ptr(),
-                                   pattern_to_output.at(mul).get_node_shared_ptr(),
-                                   pattern_to_output.at(neg).get_node_shared_ptr(),
-                                   pattern_to_output.at(exp).get_node_shared_ptr(),
-                                   pattern_to_output.at(add_constant).get_node_shared_ptr(),
-                                   pattern_to_output.at(add).get_node_shared_ptr(),
-                                   pattern_to_output.at(div).get_node_shared_ptr()},
+        ngraph::copy_runtime_info({pattern_to_output.at(beta),
+                                   pattern_to_output.at(mul),
+                                   pattern_to_output.at(neg),
+                                   pattern_to_output.at(exp),
+                                   pattern_to_output.at(add_constant),
+                                   pattern_to_output.at(add),
+                                   pattern_to_output.at(div)},
                                   swish);
         ngraph::replace_node(m.get_match_root(), swish);
         return true;
@@ -168,11 +166,11 @@ ngraph::pass::SwishFusionWithoutBeta::SwishFusionWithoutBeta() {
         auto swish = std::make_shared<ngraph::opset4::Swish>(exp_input);
 
         swish->set_friendly_name(m.get_match_root()->get_friendly_name());
-        ngraph::copy_runtime_info({pattern_to_output.at(neg).get_node_shared_ptr(),
-                                   pattern_to_output.at(exp).get_node_shared_ptr(),
-                                   pattern_to_output.at(add_constant).get_node_shared_ptr(),
-                                   pattern_to_output.at(add).get_node_shared_ptr(),
-                                   pattern_to_output.at(div).get_node_shared_ptr()},
+        ngraph::copy_runtime_info({pattern_to_output.at(neg),
+                                   pattern_to_output.at(exp),
+                                   pattern_to_output.at(add_constant),
+                                   pattern_to_output.at(add),
+                                   pattern_to_output.at(div)},
                                    swish);
         ngraph::replace_node(m.get_match_root(), swish);
         return true;

--- a/ngraph/core/include/ngraph/rt_info.hpp
+++ b/ngraph/core/include/ngraph/rt_info.hpp
@@ -25,14 +25,23 @@
 namespace ngraph
 {
     NGRAPH_API
-    void copy_runtime_info(std::shared_ptr<ngraph::Node> from, std::shared_ptr<ngraph::Node> to);
+    void copy_runtime_info(Output<ngraph::Node> from, Output<ngraph::Node> to);
 
     NGRAPH_API
     void copy_runtime_info(std::shared_ptr<ngraph::Node> from, ngraph::NodeVector to);
 
     NGRAPH_API
+    void copy_runtime_info(Output<ngraph::Node> from, ngraph::OutputVector to);
+
+    NGRAPH_API
     void copy_runtime_info(const ngraph::NodeVector& from, std::shared_ptr<ngraph::Node> to);
 
     NGRAPH_API
+    void copy_runtime_info(const ngraph::OutputVector& from, Output<ngraph::Node> to);
+
+    NGRAPH_API
     void copy_runtime_info(const ngraph::NodeVector& from, ngraph::NodeVector to);
+
+    NGRAPH_API
+    void copy_runtime_info(const ngraph::OutputVector& from, ngraph::OutputVector to);
 }

--- a/ngraph/core/src/graph_util.cpp
+++ b/ngraph/core/src/graph_util.cpp
@@ -900,8 +900,7 @@ bool ngraph::replace_output_update_name(Output<Node> output, const Output<Node>&
         if (has_result_output && !is_type<ngraph::op::Parameter>(replacement.get_node()))
         {
             replacement.get_node()->set_friendly_name(output.get_node()->get_friendly_name());
-            copy_runtime_info({replacement.get_node_shared_ptr(), output.get_node_shared_ptr()},
-                              replacement.get_node_shared_ptr());
+            copy_runtime_info(OutputVector{replacement, output}, replacement.get_node_shared_ptr());
         }
         output.replace(replacement);
         return true;

--- a/ngraph/core/src/rt_info.cpp
+++ b/ngraph/core/src/rt_info.cpp
@@ -41,10 +41,10 @@ ngraph::Node::RTMap mergeRuntimeInfo(const ngraph::NodeVector& nodes)
     return newInfo;
 }
 
-void ngraph::copy_runtime_info(std::shared_ptr<ngraph::Node> from, std::shared_ptr<ngraph::Node> to)
+void ngraph::copy_runtime_info(Output<ngraph::Node> from, Output<ngraph::Node> to)
 {
-    auto& rtInfoFrom = from->get_rt_info();
-    auto& rtInfoTo = to->get_rt_info();
+    auto& rtInfoFrom = from.get_node_shared_ptr()->get_rt_info();
+    auto& rtInfoTo = to.get_node_shared_ptr()->get_rt_info();
     rtInfoTo = rtInfoFrom;
 }
 
@@ -56,10 +56,24 @@ void ngraph::copy_runtime_info(std::shared_ptr<ngraph::Node> from, ngraph::NodeV
     }
 }
 
+void ngraph::copy_runtime_info(Output<ngraph::Node> from, ngraph::OutputVector to)
+{
+    for (auto& op : to)
+    {
+        copy_runtime_info(from.get_node_shared_ptr(), op.get_node_shared_ptr());
+    }
+}
+
 void ngraph::copy_runtime_info(const ngraph::NodeVector& from, std::shared_ptr<ngraph::Node> to)
 {
     auto& rtInfoTo = to->get_rt_info();
     rtInfoTo = mergeRuntimeInfo(from);
+}
+
+void ngraph::copy_runtime_info(const ngraph::OutputVector& from, Output<ngraph::Node> to)
+{
+    auto& rtInfoTo = to.get_node_shared_ptr()->get_rt_info();
+    rtInfoTo = mergeRuntimeInfo(as_node_vector(from));
 }
 
 void ngraph::copy_runtime_info(const ngraph::NodeVector& from, ngraph::NodeVector to)
@@ -68,6 +82,16 @@ void ngraph::copy_runtime_info(const ngraph::NodeVector& from, ngraph::NodeVecto
     for (auto& node : to)
     {
         auto& rtInfoTo = node->get_rt_info();
+        rtInfoTo = mergedInfo;
+    }
+}
+
+void ngraph::copy_runtime_info(const ngraph::OutputVector& from, ngraph::OutputVector to)
+{
+    auto mergedInfo = mergeRuntimeInfo(as_node_vector(from));
+    for (auto& node : to)
+    {
+        auto& rtInfoTo = node.get_node_shared_ptr()->get_rt_info();
         rtInfoTo = mergedInfo;
     }
 }


### PR DESCRIPTION
As we are using Output<Node> class we need to have direct support of this type in copy_rt_info function for convenience.