### PR TITLE
[IE CLDNN] Use fsv4 instead of af32 layout for imad case

### DIFF
--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/include/fetch.cl
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/include/fetch.cl
@@ -193,6 +193,38 @@ inline uint FUNC(get_b_fs_yx_fsv_index_safe)(uint b, uint f, uint y, uint x,
         CAT(prefix, _PAD_BEFORE_SIZE_X),                      \
         CAT(prefix, _PAD_AFTER_SIZE_X), 16)
 
+#define GET_DATA_B_FS_YX_FSV4_INDEX(prefix, b, f, y, x) \
+    FUNC_CALL(get_b_fs_yx_fsv_index)(                   \
+        b, f, y, x,                                     \
+        CAT(prefix, _SIZE_X ),                          \
+        CAT(prefix, _SIZE_Y),                           \
+        CAT(prefix, _FEATURE_NUM),                      \
+        CAT(prefix, _BATCH_NUM),                        \
+        CAT(prefix, _PAD_BEFORE_BATCH_NUM),             \
+        CAT(prefix, _PAD_AFTER_BATCH_NUM),              \
+        CAT(prefix, _PAD_BEFORE_FEATURE_NUM),           \
+        CAT(prefix, _PAD_AFTER_FEATURE_NUM),            \
+        CAT(prefix, _PAD_BEFORE_SIZE_Y),                \
+        CAT(prefix, _PAD_AFTER_SIZE_Y),                 \
+        CAT(prefix, _PAD_BEFORE_SIZE_X),                \
+        CAT(prefix, _PAD_AFTER_SIZE_X), 4)
+
+#define GET_DATA_B_FS_YX_FSV4_INDEX_SAFE(prefix, b, f, y, x) \
+    FUNC_CALL(get_b_fs_yx_fsv_index_safe)(                   \
+        b, f, y, x,                                          \
+        CAT(prefix, _SIZE_X ),                               \
+        CAT(prefix, _SIZE_Y),                                \
+        CAT(prefix, _FEATURE_NUM),                           \
+        CAT(prefix, _BATCH_NUM),                             \
+        CAT(prefix, _PAD_BEFORE_BATCH_NUM),                  \
+        CAT(prefix, _PAD_AFTER_BATCH_NUM),                   \
+        CAT(prefix, _PAD_BEFORE_FEATURE_NUM),                \
+        CAT(prefix, _PAD_AFTER_FEATURE_NUM),                 \
+        CAT(prefix, _PAD_BEFORE_SIZE_Y),                     \
+        CAT(prefix, _PAD_AFTER_SIZE_Y),                      \
+        CAT(prefix, _PAD_BEFORE_SIZE_X),                     \
+        CAT(prefix, _PAD_AFTER_SIZE_X), 4)
+
 #define GET_DATA_B_FS_YX_FSV32_INDEX(prefix, b, f, y, x) \
     FUNC_CALL(get_b_fs_yx_fsv_index)(                    \
         b, f, y, x,                                      \
@@ -880,42 +912,6 @@ inline uint FUNC(get_os_is_y_x8_osv8_isv4_swizzled_by_4_index)(uint o, uint i, u
         CAT(prefix, _SIZE_X),                                             \
         CAT(prefix, _SIZE_Y))
 
-
-#define GET_DATA_B_FS_YX_FSV4_INDEX(prefix, o, i, y, x) \
-    FUNC_CALL(get_b_fs_yx_fsv4)(                        \
-        o, i, y, x,                                     \
-        CAT(prefix, _FEATURE_NUM),                      \
-        CAT(prefix, _PAD_BEFORE_SIZE_Y),                \
-        CAT(prefix, _SIZE_Y),                           \
-        CAT(prefix, _PAD_AFTER_SIZE_Y),                 \
-        CAT(prefix, _PAD_BEFORE_SIZE_X),                \
-        CAT(prefix, _SIZE_X),                           \
-        CAT(prefix, _PAD_AFTER_SIZE_X))
-
-inline uint FUNC(get_b_fs_yx_fsv4)(uint o, uint i, uint y, uint x,
-                                   uint feature_num,
-                                   uint pad_before_size_y, uint size_y, uint pad_after_size_y,
-                                   uint pad_before_size_x, uint size_x, uint pad_after_size_x)
-{
-    const uint tile = 4;
-    uint id_tile = i / tile;
-    uint id      = i - id_tile * tile;
-
-    const uint feature_num_aligned4 = ((feature_num + 3) / 4) * 4;
-
-    uint idx = o * (feature_num_aligned4 / tile) *
-                   (pad_before_size_y + size_y + pad_after_size_y) *
-                   (pad_before_size_x + size_x + pad_after_size_x) * tile
-               + id_tile * (pad_before_size_y + size_y + pad_after_size_y) *
-                           (pad_before_size_x + size_x + pad_after_size_x) * tile
-               + pad_before_size_y * (pad_before_size_x + size_x + pad_after_size_x) * tile
-               + y * (pad_before_size_x + size_x + pad_after_size_x) * tile
-               + pad_before_size_x * tile
-               + x * tile
-               + id;
-
-    return idx;
-}
 
 #define GET_FILTER_G_OS_IS_YX_OSV16_ISV4_INDEX(prefix, g, o, i, y, x) \
     FUNC_CALL(get_g_os_is_yx_osv16_isv4)(                         \

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/common/jitter.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/common/jitter.cpp
@@ -338,7 +338,10 @@ JitDefinitions DataTensorJitConstant::GetDefinitions() const {
                 auto layout_str = toString(layout);
                 index_func_val = "GET_DATA_" + layout_str + "_INDEX(" + _name + ", b, f, y, x)";
                 raw_index_func_val = "GET_DATA_" + layout_str + "_INDEX(" + _name + ", b, f, y, x)";
-                if (layout == DataLayout::b_fs_yx_fsv16 || layout == DataLayout::b_fs_yx_fsv32 || layout == DataLayout::bs_fs_yx_bsv16_fsv16)
+                if (layout == DataLayout::b_fs_yx_fsv16 ||
+                    layout == DataLayout::b_fs_yx_fsv32 ||
+                    layout == DataLayout::b_fs_yx_fsv4  ||
+                    layout == DataLayout::bs_fs_yx_bsv16_fsv16)
                     safe_index_func_val = "GET_DATA_" + layout_str + "_INDEX_SAFE(" + _name + ", b, f, y, x)";
                 else
                     safe_index_func_val = "GET_DATA_" + layout_str + "_INDEX(" + _name + ", b, f, y, x)";

--- a/inference-engine/thirdparty/clDNN/src/layout_optimizer.cpp
+++ b/inference-engine/thirdparty/clDNN/src/layout_optimizer.cpp
@@ -604,10 +604,6 @@ bool layout_optimizer::deps_for_convolution_byxf_opt(program_node const& node, u
 }
 
 format layout_optimizer::imad_case(convolution_node const& node) const {
-    auto stride = node.get_primitive()->stride;
-    auto out_size = node.get_output_layout().size;
-    auto weights_dt = node.get_dependency(1).get_output_layout().data_type;
-
     auto dims_count = format::dimension(node.input().get_output_layout().format);
 
     bool is_grouped = node.get_split() > 1 || node.get_groups() > 1;
@@ -631,15 +627,6 @@ format layout_optimizer::imad_case(convolution_node const& node) const {
 
     if (dims_count == 5) {
         return format::bfzyx;
-    }
-
-    if ((out_size.feature[0] == 8 || out_size.feature[0] == 12) && out_size.spatial[1] > 512) {
-        return format::b_fs_yx_fsv4;
-    }
-
-    if (stride.spatial[0] != stride.spatial[1] || out_size.spatial[0] != out_size.spatial[1] ||
-        (weights_dt != data_types::u8 && weights_dt != data_types::i8)) {
-        return format::byxf_af32;
     }
 
     return format::b_fs_yx_fsv4;


### PR DESCRIPTION
Improves the performance on several super-resolution models