### PR TITLE
[IE CLDNN] Enable fsv16 format for all quantized models

### DIFF
--- a/inference-engine/thirdparty/clDNN/src/program.cpp
+++ b/inference-engine/thirdparty/clDNN/src/program.cpp
@@ -1089,6 +1089,7 @@ void program_impl::set_layout_optimizer_attributes(layout_optimizer& lo) {
     // first pass to set layout optimization_attributes for topology
     bool can_use_fsv16 = true;
     bool can_use_bs_fs_yx_bsv16_fsv16 = true;
+    bool is_quantized_int8_model = false;
     size_t total_asym_quantized_conv_layers = 0;
     size_t total_dw_conv_layers = 0;
     size_t total_dw_splitted_conv_layers = 0;
@@ -1168,6 +1169,11 @@ void program_impl::set_layout_optimizer_attributes(layout_optimizer& lo) {
             prim.type() != cldnn::mutable_data::type_id())
             can_use_fsv16 = false;
 
+        if (prim.type() == cldnn::quantize::type_id() &&
+            (prim.get_output_layout().data_type == data_types::i8 || prim.get_output_layout().data_type == data_types::u8)) {
+            is_quantized_int8_model = true;
+        }
+
         // WA to keep fsv16 layout disabled for some topologies where it leads to regressions.
         // For reshape bfy*x is preferred, as fsv16 introduces extra reorders
         if (prim.type() == cldnn::crop::type_id()) {
@@ -1200,9 +1206,10 @@ void program_impl::set_layout_optimizer_attributes(layout_optimizer& lo) {
     // will be performed if at least half of layers can use b_fs_yx_fsv16.
     const float cond_denom = total_conv_layers > 0 ? 1.0f / static_cast<float>(total_conv_layers) : 1.0f;
 
-    bool should_use_b_fs_yx_fsv16_conv = can_use_fsv16 &&
-                                         total_conv_layers > 11 &&
-                                         lo.get_optimized_conv_count({format::b_fs_yx_fsv16, false}) * cond_denom > 0.5f;
+    bool should_use_b_fs_yx_fsv16_conv = is_quantized_int8_model ||
+                                         (can_use_fsv16 &&
+                                          total_conv_layers > 11 &&
+                                          lo.get_optimized_conv_count({format::b_fs_yx_fsv16, false}) * cond_denom > 0.5f);
 
     bool should_use_fs_b_yx_fsv32_conv = total_conv_layers > 11 &&
                                          total_grouped_conv_layers == 0 &&

--- a/inference-engine/thirdparty/clDNN/tests/test_cases/fusings_gpu_test.cpp
+++ b/inference-engine/thirdparty/clDNN/tests/test_cases/fusings_gpu_test.cpp
@@ -3752,7 +3752,28 @@ using deconv_test_params = bc_test_params;
 #define CASE_DECONV_ELTW_i8_5 {1, 16, 2, 4}, {1, 16, 4, 6}, {1, 16, 4, 1}, {1, 1, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 1, data_types::i8, format::b_fs_yx_fsv16, data_types::i8, format::os_is_yx_osv16_isv16, data_types::f32, format::bfyx
 
 
-class DeconvolutionFusingTest : public ::WeightsPrimitiveFusingTest {};
+class DeconvolutionFusingTest : public ::WeightsPrimitiveFusingTest {
+public:
+    void execute(deconv_test_params& p) {
+        auto input_prim = get_mem(get_input_layout(p));
+        network network_not_fused(this->engine, this->topology_non_fused, bo_not_fused);
+        network network_fused(this->engine, this->topology_fused, bo_fused);
+        network_fused.set_input_data("input", input_prim);
+        network_not_fused.set_input_data("input", input_prim);
+
+        compare(network_not_fused, network_fused, p);
+        auto find_conv = [](primitive_info& p) -> bool {
+            if (p.original_id == "deconv")
+                return true;
+            return false;
+        };
+
+        auto pi_fused = network_fused.get_primitives_info();
+        auto info_fused = std::find_if(pi_fused.begin(), pi_fused.end(), find_conv);
+        if (info_fused != pi_fused.end())
+            std::cout << "kernel: " << info_fused->kernel_id << std::endl;
+    }
+};
 
 class deconv_actv : public DeconvolutionFusingTest {};
 TEST_P(deconv_actv, basic) {
@@ -3966,9 +3987,7 @@ TEST_P(deconv_scale_actv_quant_i8, basic) {
 
 INSTANTIATE_TEST_CASE_P(fusings_gpu, deconv_scale_actv_quant_i8,
     ::testing::ValuesIn(std::vector<deconv_test_params>{
-        // Some fusings disabled under deconvolution -> convolution optimization
-        // Quantize fusing disabled for fp16/fp32 for performance reasons
-        deconv_test_params{ CASE_DECONV_FP32_1, 4, 5 },
+        deconv_test_params{ CASE_DECONV_FP32_1, 3, 5 },
         deconv_test_params{ CASE_DECONV_FP32_2, 3, 5 },
         deconv_test_params{ CASE_DECONV_FP32_3, 3, 5 },
         deconv_test_params{ CASE_DECONV_FP32_4, 3, 5 },
@@ -3977,7 +3996,7 @@ INSTANTIATE_TEST_CASE_P(fusings_gpu, deconv_scale_actv_quant_i8,
         deconv_test_params{ CASE_DECONV_FP32_7, 3, 5 },
         deconv_test_params{ CASE_DECONV_FP32_8, 3, 5 },
 
-        deconv_test_params{ CASE_DECONV_FP16_1, 4, 5 },
+        deconv_test_params{ CASE_DECONV_FP16_1, 3, 5 },
         deconv_test_params{ CASE_DECONV_FP16_2, 3, 5 },
         deconv_test_params{ CASE_DECONV_FP16_3, 3, 5 },
         deconv_test_params{ CASE_DECONV_FP16_4, 3, 5 },
@@ -4079,9 +4098,7 @@ TEST_P(deconv_scale_actv_quant_u8_eltw_scale_actv_quant_i8, basic) {
 
 INSTANTIATE_TEST_CASE_P(fusings_gpu, deconv_scale_actv_quant_u8_eltw_scale_actv_quant_i8,
     ::testing::ValuesIn(std::vector<deconv_test_params>{
-        // Some fusings disabled under deconvolution -> convolution optimization
-        // Quantize fusing disabled for fp16/fp32 for performance reasons
-        deconv_test_params{ CASE_DECONV_FP32_1, 7, 9 },
+        deconv_test_params{ CASE_DECONV_FP32_1, 6, 9 },
         deconv_test_params{ CASE_DECONV_FP32_2, 6, 9 },
         deconv_test_params{ CASE_DECONV_FP32_3, 6, 9 },
         deconv_test_params{ CASE_DECONV_FP32_4, 6, 9 },
@@ -4090,7 +4107,7 @@ INSTANTIATE_TEST_CASE_P(fusings_gpu, deconv_scale_actv_quant_u8_eltw_scale_actv_
         deconv_test_params{ CASE_DECONV_FP32_7, 6, 9 },
         deconv_test_params{ CASE_DECONV_FP32_8, 6, 9 },
 
-        deconv_test_params{ CASE_DECONV_FP16_1, 7, 9 },
+        deconv_test_params{ CASE_DECONV_FP16_1, 6, 9 },
         deconv_test_params{ CASE_DECONV_FP16_2, 6, 9 },
         deconv_test_params{ CASE_DECONV_FP16_3, 6, 9 },
         deconv_test_params{ CASE_DECONV_FP16_4, 6, 9 },


### PR DESCRIPTION
- Enabled fsv16 format for all quantized int8 models to be able to use the most performant kernels.