### PR TITLE
[nGraph] RTInfo refactor

### DIFF
--- a/ngraph/python/setup.py
+++ b/ngraph/python/setup.py
@@ -211,6 +211,7 @@ sources = [
     "pyngraph/types/element_type.cpp",
     "pyngraph/types/regmodule_pyngraph_types.cpp",
     "pyngraph/util.cpp",
+    "pyngraph/variant.cpp",
 ]
 
 packages = [

--- a/ngraph/python/setup.py
+++ b/ngraph/python/setup.py
@@ -211,7 +211,6 @@ sources = [
     "pyngraph/types/element_type.cpp",
     "pyngraph/types/regmodule_pyngraph_types.cpp",
     "pyngraph/util.cpp",
-    "pyngraph/variant.cpp",
 ]
 
 packages = [

--- a/ngraph/python/src/ngraph/__init__.py
+++ b/ngraph/python/src/ngraph/__init__.py
@@ -23,6 +23,7 @@ try:
 except DistributionNotFound:
     __version__ = "0.0.0.dev0"
 
+import ngraph.utils.rt_map
 from ngraph.impl import Node
 from ngraph.helpers import function_from_cnn
 

--- a/ngraph/python/src/ngraph/impl/__init__.py
+++ b/ngraph/python/src/ngraph/impl/__init__.py
@@ -45,5 +45,6 @@ from _pyngraph import CoordinateDiff
 from _pyngraph import AxisSet
 from _pyngraph import AxisVector
 from _pyngraph import Coordinate
+from _pyngraph import Variant
 
 from _pyngraph import util

--- a/ngraph/python/src/ngraph/impl/__init__.py
+++ b/ngraph/python/src/ngraph/impl/__init__.py
@@ -47,6 +47,5 @@ from _pyngraph import AxisVector
 from _pyngraph import Coordinate
 from _pyngraph import VariantString
 from _pyngraph import VariantInt
-from _pyngraph import PyRTMap
 
 from _pyngraph import util

--- a/ngraph/python/src/ngraph/impl/__init__.py
+++ b/ngraph/python/src/ngraph/impl/__init__.py
@@ -45,6 +45,8 @@ from _pyngraph import CoordinateDiff
 from _pyngraph import AxisSet
 from _pyngraph import AxisVector
 from _pyngraph import Coordinate
-from _pyngraph import Variant
+# from _pyngraph import Variant
+from _pyngraph import VariantString
+from _pyngraph import VariantInt
 
 from _pyngraph import util

--- a/ngraph/python/src/ngraph/impl/__init__.py
+++ b/ngraph/python/src/ngraph/impl/__init__.py
@@ -45,8 +45,8 @@ from _pyngraph import CoordinateDiff
 from _pyngraph import AxisSet
 from _pyngraph import AxisVector
 from _pyngraph import Coordinate
-# from _pyngraph import Variant
 from _pyngraph import VariantString
 from _pyngraph import VariantInt
+from _pyngraph import PyRTMap
 
 from _pyngraph import util

--- a/ngraph/python/src/ngraph/impl/op/__init__.py
+++ b/ngraph/python/src/ngraph/impl/op/__init__.py
@@ -33,4 +33,4 @@ from _pyngraph.op import Constant
 Constant.get_data = lambda self: np.array(self, copy=True)
 
 from _pyngraph.op import Parameter
-from _pyngraph.op import Result
+# from _pyngraph.op import Result

--- a/ngraph/python/src/ngraph/impl/op/__init__.py
+++ b/ngraph/python/src/ngraph/impl/op/__init__.py
@@ -33,4 +33,3 @@ from _pyngraph.op import Constant
 Constant.get_data = lambda self: np.array(self, copy=True)
 
 from _pyngraph.op import Parameter
-# from _pyngraph.op import Result

--- a/ngraph/python/src/ngraph/impl/op/__init__.py
+++ b/ngraph/python/src/ngraph/impl/op/__init__.py
@@ -33,3 +33,4 @@ from _pyngraph.op import Constant
 Constant.get_data = lambda self: np.array(self, copy=True)
 
 from _pyngraph.op import Parameter
+from _pyngraph.op import Result

--- a/ngraph/python/src/ngraph/utils/rt_map.py
+++ b/ngraph/python/src/ngraph/utils/rt_map.py
@@ -15,6 +15,8 @@
 # ******************************************************************************
 """Overrides pybind PyRTMap class methods."""
 
+from typing import Any
+
 import _pyngraph
 
 from _pyngraph import Variant
@@ -22,7 +24,7 @@ from ngraph.impl import VariantInt, VariantString
 from ngraph.exceptions import UserInputError
 
 
-def _convert_to_variant(item):
+def _convert_to_variant(item: Any) -> Variant:
     """Convert value to Variant class, otherwise throw error."""
     if isinstance(item, Variant):
         return item
@@ -42,7 +44,7 @@ def _convert_to_variant(item):
 binding_copy = _pyngraph.PyRTMap.__setitem__
 
 
-def _setitem(self, arg0: str, arg1) -> None:
+def _setitem(self: _pyngraph.PyRTMap, arg0: str, arg1: Any) -> None:
     """Override setting values in dictionary."""
     binding_copy(self, arg0, _convert_to_variant(arg1))
 

--- a/ngraph/python/src/ngraph/utils/rt_map.py
+++ b/ngraph/python/src/ngraph/utils/rt_map.py
@@ -26,10 +26,9 @@ def _convert_to_variant(item):
     """Convert value to Variant class, otherwise throw error."""
     if isinstance(item, Variant):
         return item
-    
     variant_mapping = {
-        int : VariantInt,
-        str : VariantString,
+        int: VariantInt,
+        str: VariantString,
     }
 
     new_type = variant_mapping.get(type(item), None)

--- a/ngraph/python/src/ngraph/utils/rt_map.py
+++ b/ngraph/python/src/ngraph/utils/rt_map.py
@@ -1,0 +1,51 @@
+# ******************************************************************************
+# Copyright 2017-2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ******************************************************************************
+"""Overrides pybind PyRTMap class methods."""
+
+import _pyngraph
+
+from _pyngraph import Variant
+from ngraph.impl import VariantInt, VariantString
+from ngraph.exceptions import UserInputError
+
+
+def _convert_to_variant(item):
+    """Convert value to Variant class, otherwise throw error."""
+    if isinstance(item, Variant):
+        return item
+    
+    variant_mapping = {
+        int : VariantInt,
+        str : VariantString,
+    }
+
+    new_type = variant_mapping.get(type(item), None)
+
+    if new_type is None:
+        raise UserInputError("Cannot map value to any of registered Variant classes", str(item))
+
+    return new_type(item)
+
+
+binding_copy = _pyngraph.PyRTMap.__setitem__
+
+
+def _setitem(self, arg0: str, arg1) -> None:
+    """Override setting values in dictionary."""
+    binding_copy(self, arg0, _convert_to_variant(arg1))
+
+
+_pyngraph.PyRTMap.__setitem__ = _setitem

--- a/ngraph/python/src/pyngraph/node.cpp
+++ b/ngraph/python/src/pyngraph/node.cpp
@@ -14,7 +14,9 @@
 // limitations under the License.
 //*****************************************************************************
 
+#include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
 
 #include "dict_attribute_visitor.hpp"
 #include "ngraph/node.hpp"
@@ -28,8 +30,14 @@
 
 namespace py = pybind11;
 
+using PyRTMap = std::map<std::string, std::shared_ptr<ngraph::Variant>>;
+
+PYBIND11_MAKE_OPAQUE(PyRTMap);
+
 void regclass_pyngraph_Node(py::module m)
 {
+    py::bind_map<PyRTMap>(m, "PyRTMap");
+
     py::class_<ngraph::Node, std::shared_ptr<ngraph::Node>> node(m, "Node", py::dynamic_attr());
     node.doc() = "ngraph.impl.Node wraps ngraph::Node";
     node.def("__add__",
@@ -90,12 +98,12 @@ void regclass_pyngraph_Node(py::module m)
              (std::vector<ngraph::Output<ngraph::Node>>(ngraph::Node::*)()) &
                  ngraph::Node::outputs);
     node.def("get_rt_info",
-             (ngraph::Node::RTMap & (ngraph::Node::*)()) & ngraph::Node::get_rt_info);
-    node.def("get_rt_info",
-             (const ngraph::Node::RTMap& (ngraph::Node::*)() const) & ngraph::Node::get_rt_info);
+             (PyRTMap & (ngraph::Node::*)()) & ngraph::Node::get_rt_info,
+             py::return_value_policy::reference_internal);
 
     node.def_property_readonly("shape", &ngraph::Node::get_shape);
     node.def_property_readonly("name", &ngraph::Node::get_name);
+    node.def_property_readonly("rt_info", (PyRTMap & (ngraph::Node::*)()) & ngraph::Node::get_rt_info);
     node.def_property(
         "friendly_name", &ngraph::Node::get_friendly_name, &ngraph::Node::set_friendly_name);
 

--- a/ngraph/python/src/pyngraph/node.cpp
+++ b/ngraph/python/src/pyngraph/node.cpp
@@ -36,7 +36,11 @@ PYBIND11_MAKE_OPAQUE(PyRTMap);
 
 void regclass_pyngraph_Node(py::module m)
 {
-    py::bind_map<PyRTMap>(m, "PyRTMap");
+    auto py_map = py::bind_map<PyRTMap>(m, "PyRTMap");
+    py_map.doc() =
+        "ngraph.impl.PyRTMap makes bindings for std::map<std::string, "
+        "std::shared_ptr<ngraph::Variant>>, which can later be used as ngraph::Node::RTMap";
+    // py_map.def("custom", [](const PyRTMap& self) { return std::string("test_text"); });
 
     py::class_<ngraph::Node, std::shared_ptr<ngraph::Node>> node(m, "Node", py::dynamic_attr());
     node.doc() = "ngraph.impl.Node wraps ngraph::Node";
@@ -103,7 +107,9 @@ void regclass_pyngraph_Node(py::module m)
 
     node.def_property_readonly("shape", &ngraph::Node::get_shape);
     node.def_property_readonly("name", &ngraph::Node::get_name);
-    node.def_property_readonly("rt_info", (PyRTMap & (ngraph::Node::*)()) & ngraph::Node::get_rt_info);
+    node.def_property_readonly("rt_info",
+                               (PyRTMap & (ngraph::Node::*)()) & ngraph::Node::get_rt_info,
+                               py::return_value_policy::reference_internal);
     node.def_property(
         "friendly_name", &ngraph::Node::get_friendly_name, &ngraph::Node::set_friendly_name);
 

--- a/ngraph/python/src/pyngraph/node.cpp
+++ b/ngraph/python/src/pyngraph/node.cpp
@@ -40,7 +40,6 @@ void regclass_pyngraph_Node(py::module m)
     py_map.doc() =
         "ngraph.impl.PyRTMap makes bindings for std::map<std::string, "
         "std::shared_ptr<ngraph::Variant>>, which can later be used as ngraph::Node::RTMap";
-    // py_map.def("custom", [](const PyRTMap& self) { return std::string("test_text"); });
 
     py::class_<ngraph::Node, std::shared_ptr<ngraph::Node>> node(m, "Node", py::dynamic_attr());
     node.doc() = "ngraph.impl.Node wraps ngraph::Node";

--- a/ngraph/python/src/pyngraph/node.cpp
+++ b/ngraph/python/src/pyngraph/node.cpp
@@ -18,11 +18,13 @@
 
 #include "dict_attribute_visitor.hpp"
 #include "ngraph/node.hpp"
+#include "ngraph/variant.hpp"
 #include "ngraph/op/add.hpp"
 #include "ngraph/op/divide.hpp"
 #include "ngraph/op/multiply.hpp"
 #include "ngraph/op/subtract.hpp"
 #include "pyngraph/node.hpp"
+#include "pyngraph/variant.hpp"
 
 namespace py = pybind11;
 
@@ -87,6 +89,7 @@ void regclass_pyngraph_Node(py::module m)
     node.def("outputs",
              (std::vector<ngraph::Output<ngraph::Node>>(ngraph::Node::*)()) &
                  ngraph::Node::outputs);
+    node.def("get_rt_info", (ngraph::Node::RTMap&(ngraph::Node::*)()) &ngraph::Node::get_rt_info);
 
     node.def_property_readonly("shape", &ngraph::Node::get_shape);
     node.def_property_readonly("name", &ngraph::Node::get_name);

--- a/ngraph/python/src/pyngraph/node.cpp
+++ b/ngraph/python/src/pyngraph/node.cpp
@@ -18,11 +18,11 @@
 
 #include "dict_attribute_visitor.hpp"
 #include "ngraph/node.hpp"
-#include "ngraph/variant.hpp"
 #include "ngraph/op/add.hpp"
 #include "ngraph/op/divide.hpp"
 #include "ngraph/op/multiply.hpp"
 #include "ngraph/op/subtract.hpp"
+#include "ngraph/variant.hpp"
 #include "pyngraph/node.hpp"
 #include "pyngraph/variant.hpp"
 
@@ -89,7 +89,10 @@ void regclass_pyngraph_Node(py::module m)
     node.def("outputs",
              (std::vector<ngraph::Output<ngraph::Node>>(ngraph::Node::*)()) &
                  ngraph::Node::outputs);
-    node.def("get_rt_info", (ngraph::Node::RTMap&(ngraph::Node::*)()) &ngraph::Node::get_rt_info);
+    node.def("get_rt_info",
+             (ngraph::Node::RTMap & (ngraph::Node::*)()) & ngraph::Node::get_rt_info);
+    node.def("get_rt_info",
+             (const ngraph::Node::RTMap& (ngraph::Node::*)() const) & ngraph::Node::get_rt_info);
 
     node.def_property_readonly("shape", &ngraph::Node::get_shape);
     node.def_property_readonly("name", &ngraph::Node::get_name);

--- a/ngraph/python/src/pyngraph/pyngraph.cpp
+++ b/ngraph/python/src/pyngraph/pyngraph.cpp
@@ -69,6 +69,7 @@ PYBIND11_MODULE(_pyngraph, m)
     regmodule_pyngraph_op_util(m_op);
     regmodule_pyngraph_passes(m);
     regmodule_pyngraph_util(m);
-    regclass_pyngraph_Variant<std::string>(m, std::string("String"));
-    regclass_pyngraph_Variant<int64_t>(m, std::string("Int"));
+    regclass_pyngraph_Variant(m);
+    regclass_pyngraph_VariantWrapper<std::string>(m, std::string("String"));
+    regclass_pyngraph_VariantWrapper<int64_t>(m, std::string("Int"));
 }

--- a/ngraph/python/src/pyngraph/pyngraph.cpp
+++ b/ngraph/python/src/pyngraph/pyngraph.cpp
@@ -69,5 +69,6 @@ PYBIND11_MODULE(_pyngraph, m)
     regmodule_pyngraph_op_util(m_op);
     regmodule_pyngraph_passes(m);
     regmodule_pyngraph_util(m);
-    regclass_pyngraph_Variant(m);
+    regclass_pyngraph_Variant<std::string>(m, std::string("String"));
+    regclass_pyngraph_Variant<int64_t>(m, std::string("Int"));
 }

--- a/ngraph/python/src/pyngraph/pyngraph.cpp
+++ b/ngraph/python/src/pyngraph/pyngraph.cpp
@@ -38,6 +38,7 @@
 #include "pyngraph/strides.hpp"
 #include "pyngraph/types/regmodule_pyngraph_types.hpp"
 #include "pyngraph/util.hpp"
+#include "pyngraph/variant.hpp"
 
 namespace py = pybind11;
 
@@ -68,4 +69,5 @@ PYBIND11_MODULE(_pyngraph, m)
     regmodule_pyngraph_op_util(m_op);
     regmodule_pyngraph_passes(m);
     regmodule_pyngraph_util(m);
+    regclass_pyngraph_Variant(m);
 }

--- a/ngraph/python/src/pyngraph/variant.cpp
+++ b/ngraph/python/src/pyngraph/variant.cpp
@@ -1,0 +1,34 @@
+//*****************************************************************************
+// Copyright 2017-2020 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <iterator>
+#include <sstream>
+#include <string>
+
+#include "ngraph/variant.hpp" // ngraph::Variant
+#include "pyngraph/variant.hpp"
+
+namespace py = pybind11;
+
+template <typename T>
+void regclass_pyngraph_Variant(py::module m)
+{
+    py::class_<ngraph::VariantImpl<T>, std::shared_ptr<ngraph::VariantImpl<T>>> shape(m, "Variant");
+    shape.doc() = "ngraph.impl.Variant wraps ngraph::Variant";
+}

--- a/ngraph/python/src/pyngraph/variant.cpp
+++ b/ngraph/python/src/pyngraph/variant.cpp
@@ -15,45 +15,17 @@
 //*****************************************************************************
 
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-
-#include <iterator>
-#include <sstream>
-#include <string>
-
-#include "ngraph/ngraph_visibility.hpp"
-#include "ngraph/node.hpp"
-#include "ngraph/type.hpp"
 
 #include "ngraph/variant.hpp" // ngraph::Variant
 #include "pyngraph/variant.hpp"
 
 namespace py = pybind11;
 
-template <typename VT>
-void regclass_pyngraph_Variant(py::module m, std::string typestring)
+void regclass_pyngraph_Variant(py::module m)
 {
-    std::string pyclass_name = std::string("Variant") + typestring;
-    py::class_<ngraph::VariantWrapper<VT>> variant(m, pyclass_name);
-    variant.doc() = "ngraph.impl.Variant(typestring) wraps ngraph::VariantWrapper";
-
-    variant.def(py::init<>());
-    variant.def(py::init<const VT&>());
-    variant.def("init", &ngraph::VariantWrapper<VT>::init);
-    variant.def("merge", &ngraph::VariantWrapper<VT>::merge);
-    variant.def("get_type_info", &ngraph::VariantWrapper<VT>::get_type_info);
-    variant.def("get",
-                (const VT& (ngraph::VariantWrapper<VT>::*)() const) &
-                    ngraph::VariantWrapper<VT>::get);
-    variant.def("get", (VT & (ngraph::VariantWrapper<VT>::*)()) & ngraph::VariantWrapper<VT>::get);
-    variant.def("set", &ngraph::VariantWrapper<VT>::set);
-
-    variant.def_property("m_value",
-                         (const VT& (ngraph::VariantWrapper<VT>::*)() const) &
-                             ngraph::VariantWrapper<VT>::get,
-                         &ngraph::VariantWrapper<VT>::set);
-    variant.def_property_readonly("type_info", &ngraph::VariantWrapper<VT>::get_type_info);
+    py::class_<ngraph::Variant, std::shared_ptr<ngraph::Variant>> variant_base(m, "Variant");
+    variant_base.doc() = "ngraph.impl.Variant wraps ngraph::Variant";
 }
 
-// template void regclass_pyngraph_Variant<std::string>(py::module m, std::string typestring);
-// template void regclass_pyngraph_Variant<int64_t>(py::module m, std::string typestring);
+template void regclass_pyngraph_VariantWrapper<std::string>(py::module m, std::string typestring);
+template void regclass_pyngraph_VariantWrapper<int64_t>(py::module m, std::string typestring);

--- a/ngraph/python/src/pyngraph/variant.hpp
+++ b/ngraph/python/src/pyngraph/variant.hpp
@@ -17,7 +17,53 @@
 #pragma once
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <iterator>
+#include <sstream>
+#include <string>
+
+#include "ngraph/ngraph_visibility.hpp"
+#include "ngraph/node.hpp"
+#include "ngraph/type.hpp"
+
+#include "ngraph/variant.hpp" // ngraph::Variant
 
 namespace py = pybind11;
 
-void regclass_pyngraph_Variant(py::module m);
+// template <typename VT>
+// extern void regclass_pyngraph_Variant(py::module m, std::string typestring);
+template <typename VT>
+extern void regclass_pyngraph_Variant(py::module m, std::string typestring)
+{
+    // a = Variant<string>("aaa");
+    // b = Variant<int>(111);
+
+    // VariantString
+    // VariantInt
+
+    auto pyclass_name = py::detail::c_str((std::string("Variant") + typestring));
+    py::class_<ngraph::VariantWrapper<VT>, std::shared_ptr<ngraph::VariantWrapper<VT>>> variant(
+        m, pyclass_name);
+    variant.doc() = "ngraph.impl.Variant wraps ngraph::VariantWrapper";
+
+    // variant.def(py::init<>());
+    variant.def(py::init<const VT&>());
+    variant.def("init", &ngraph::VariantWrapper<VT>::init);
+    variant.def("merge", &ngraph::VariantWrapper<VT>::merge);
+    variant.def("get_type_info", &ngraph::VariantWrapper<VT>::get_type_info);
+    variant.def("get",
+                (const VT& (ngraph::VariantWrapper<VT>::*)() const) &
+                    ngraph::VariantWrapper<VT>::get);
+    variant.def("get", (VT & (ngraph::VariantWrapper<VT>::*)()) & ngraph::VariantWrapper<VT>::get);
+    variant.def("set", &ngraph::VariantWrapper<VT>::set);
+
+    variant.def_property("m_value",
+                         (const VT& (ngraph::VariantWrapper<VT>::*)() const) &
+                             ngraph::VariantWrapper<VT>::get,
+                         &ngraph::VariantWrapper<VT>::set);
+    variant.def_property_readonly("type_info", &ngraph::VariantWrapper<VT>::get_type_info);
+}
+
+template void regclass_pyngraph_Variant<std::string>(py::module m, std::string typestring);
+template void regclass_pyngraph_Variant<int64_t>(py::module m, std::string typestring);

--- a/ngraph/python/src/pyngraph/variant.hpp
+++ b/ngraph/python/src/pyngraph/variant.hpp
@@ -1,0 +1,23 @@
+//*****************************************************************************
+// Copyright 2017-2020 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+void regclass_pyngraph_Variant(py::module m);

--- a/ngraph/python/src/pyngraph/variant.hpp
+++ b/ngraph/python/src/pyngraph/variant.hpp
@@ -31,39 +31,30 @@
 
 namespace py = pybind11;
 
-// template <typename VT>
-// extern void regclass_pyngraph_Variant(py::module m, std::string typestring);
+void regclass_pyngraph_Variant(py::module m);
+
 template <typename VT>
-extern void regclass_pyngraph_Variant(py::module m, std::string typestring)
+extern void regclass_pyngraph_VariantWrapper(py::module m, std::string typestring)
 {
-    // a = Variant<string>("aaa");
-    // b = Variant<int>(111);
-
-    // VariantString
-    // VariantInt
-
     auto pyclass_name = py::detail::c_str((std::string("Variant") + typestring));
-    py::class_<ngraph::VariantWrapper<VT>, std::shared_ptr<ngraph::VariantWrapper<VT>>> variant(
-        m, pyclass_name);
-    variant.doc() = "ngraph.impl.Variant wraps ngraph::VariantWrapper";
+    py::class_<ngraph::VariantWrapper<VT>,
+               std::shared_ptr<ngraph::VariantWrapper<VT>>,
+               ngraph::Variant>
+        variant_wrapper(m, pyclass_name);
+    variant_wrapper.doc() = "ngraph.impl.Variant[typestring] wraps ngraph::VariantWrapper<typestring>";
 
-    // variant.def(py::init<>());
-    variant.def(py::init<const VT&>());
-    variant.def("init", &ngraph::VariantWrapper<VT>::init);
-    variant.def("merge", &ngraph::VariantWrapper<VT>::merge);
-    variant.def("get_type_info", &ngraph::VariantWrapper<VT>::get_type_info);
-    variant.def("get",
-                (const VT& (ngraph::VariantWrapper<VT>::*)() const) &
-                    ngraph::VariantWrapper<VT>::get);
-    variant.def("get", (VT & (ngraph::VariantWrapper<VT>::*)()) & ngraph::VariantWrapper<VT>::get);
-    variant.def("set", &ngraph::VariantWrapper<VT>::set);
+    variant_wrapper.def(py::init<const VT&>());
+    // variant_wrapper.def("get_type_info", &ngraph::VariantWrapper<VT>::get_type_info);
+    variant_wrapper.def("get",
+                        (const VT& (ngraph::VariantWrapper<VT>::*)() const) &
+                            ngraph::VariantWrapper<VT>::get);
+    variant_wrapper.def("get",
+                        (VT & (ngraph::VariantWrapper<VT>::*)()) & ngraph::VariantWrapper<VT>::get);
+    variant_wrapper.def("set", &ngraph::VariantWrapper<VT>::set);
 
-    variant.def_property("m_value",
-                         (const VT& (ngraph::VariantWrapper<VT>::*)() const) &
-                             ngraph::VariantWrapper<VT>::get,
-                         &ngraph::VariantWrapper<VT>::set);
-    variant.def_property_readonly("type_info", &ngraph::VariantWrapper<VT>::get_type_info);
+    variant_wrapper.def_property("m_value",
+                                 (const VT& (ngraph::VariantWrapper<VT>::*)() const) &
+                                     ngraph::VariantWrapper<VT>::get,
+                                 &ngraph::VariantWrapper<VT>::set);
+    // variant_wrapper.def_property_readonly("type_info", &ngraph::VariantWrapper<VT>::get_type_info);
 }
-
-template void regclass_pyngraph_Variant<std::string>(py::module m, std::string typestring);
-template void regclass_pyngraph_Variant<int64_t>(py::module m, std::string typestring);

--- a/ngraph/python/src/pyngraph/variant.hpp
+++ b/ngraph/python/src/pyngraph/variant.hpp
@@ -19,13 +19,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-#include <iterator>
-#include <sstream>
 #include <string>
-
-#include "ngraph/ngraph_visibility.hpp"
-#include "ngraph/node.hpp"
-#include "ngraph/type.hpp"
 
 #include "ngraph/variant.hpp" // ngraph::Variant
 
@@ -41,20 +35,16 @@ extern void regclass_pyngraph_VariantWrapper(py::module m, std::string typestrin
                std::shared_ptr<ngraph::VariantWrapper<VT>>,
                ngraph::Variant>
         variant_wrapper(m, pyclass_name);
-    variant_wrapper.doc() = "ngraph.impl.Variant[typestring] wraps ngraph::VariantWrapper<typestring>";
+    variant_wrapper.doc() =
+        "ngraph.impl.Variant[typestring] wraps ngraph::VariantWrapper<typestring>";
 
     variant_wrapper.def(py::init<const VT&>());
-    // variant_wrapper.def("get_type_info", &ngraph::VariantWrapper<VT>::get_type_info);
-    variant_wrapper.def("get",
-                        (const VT& (ngraph::VariantWrapper<VT>::*)() const) &
-                            ngraph::VariantWrapper<VT>::get);
     variant_wrapper.def("get",
                         (VT & (ngraph::VariantWrapper<VT>::*)()) & ngraph::VariantWrapper<VT>::get);
     variant_wrapper.def("set", &ngraph::VariantWrapper<VT>::set);
 
-    variant_wrapper.def_property("m_value",
-                                 (const VT& (ngraph::VariantWrapper<VT>::*)() const) &
+    variant_wrapper.def_property("value",
+                                 (VT & (ngraph::VariantWrapper<VT>::*)()) &
                                      ngraph::VariantWrapper<VT>::get,
                                  &ngraph::VariantWrapper<VT>::set);
-    // variant_wrapper.def_property_readonly("type_info", &ngraph::VariantWrapper<VT>::get_type_info);
 }

--- a/ngraph/python/tests/test_ngraph/test_basic.py
+++ b/ngraph/python/tests/test_ngraph/test_basic.py
@@ -32,7 +32,7 @@ from tests import (xfail_issue_34323,
                    xfail_issue_36479,
                    xfail_issue_36480)
 
-from openvino.inference_engine import IECore, IENetwork
+from openvino.inference_engine import IENetwork
 
 
 def test_ngraph_function_api():

--- a/ngraph/python/tests/test_ngraph/test_basic.py
+++ b/ngraph/python/tests/test_ngraph/test_basic.py
@@ -23,7 +23,6 @@ from ngraph.exceptions import UserInputError
 from ngraph.impl import Function, PartialShape, Shape
 from tests.runtime import get_runtime
 from tests.test_ngraph.util import run_op_node
-<<<<<<< HEAD
 from tests import (xfail_issue_34323,
                    xfail_issue_35929,
                    xfail_issue_35926,
@@ -32,10 +31,8 @@ from tests import (xfail_issue_34323,
                    xfail_issue_36479,
                    xfail_issue_36480)
 
-=======
 from ngraph.impl import Type, VariantString
-from ngraph.impl.op import Parameter, Result
->>>>>>> a557aae5... Worksave
+from ngraph.impl.op import Parameter
 
 def test_ngraph_function_api():
     shape = [2, 2]
@@ -404,16 +401,18 @@ def test_runtime_info():
     test_param = Parameter(test_type, test_shape)
     relu_node = ng.relu(test_param)
     rtInfo = relu_node.get_rt_info()
+    print(rtInfo)
     rtInfo["affinity"] = VariantString("testAffinity")
+    print(rtInfo)
     relu_node.set_friendly_name("testReLU")
-    result = Result(relu_node)
+    # result = Result(relu_node)
 
     params = [test_param]
-    results = [result]
+    results = [relu_node]
 
-    ngraph = Function(results, params)
+    ngraph = Function(results, params, "testFunc")
 
     # cnnNet = ie.CNNNetwork(ngraph)
-    # # cnnLayer = CommonTestUtils::getLayerByName(cnnNet, "testReLU") # TODO
+    # cnnLayer = CommonTestUtils::getLayerByName(cnnNet, "testReLU") # TODO
     # ASSERT_NE(nullptr, cnnLayer)
     # ASSERT_EQ(cnnLayer[affinity], test_string)

--- a/ngraph/python/tests/test_ngraph/test_basic.py
+++ b/ngraph/python/tests/test_ngraph/test_basic.py
@@ -427,5 +427,5 @@ def test_runtime_info():
     capsule = Function.to_capsule(ng_function)
     cnn_network = IENetwork(capsule)
     cnn_layer = cnn_network.layers["testReLU"]
-    assert None != cnn_layer
+    assert cnn_layer is not None
     assert cnn_layer.affinity == "test_affinity"

--- a/ngraph/python/tests/test_ngraph/test_basic.py
+++ b/ngraph/python/tests/test_ngraph/test_basic.py
@@ -20,9 +20,11 @@ import pytest
 
 import ngraph as ng
 from ngraph.exceptions import UserInputError
-from ngraph.impl import Function, PartialShape, Shape
+from ngraph.impl import Function, PartialShape, Shape, Type, VariantInt, VariantString
+from ngraph.impl.op import Parameter
 from tests.runtime import get_runtime
 from tests.test_ngraph.util import run_op_node
+<<<<<<< HEAD
 from tests import (xfail_issue_34323,
                    xfail_issue_35929,
                    xfail_issue_35926,
@@ -33,7 +35,10 @@ from tests import (xfail_issue_34323,
 
 from ngraph.impl import Type, VariantString
 from ngraph.impl.op import Parameter
+=======
+>>>>>>> a5ee0095... Re-work of monkey patch and clean-up
 from openvino.inference_engine import IECore, IENetwork
+
 
 def test_ngraph_function_api():
     shape = [2, 2]
@@ -393,19 +398,31 @@ def test_node_target_inputs_soruce_output():
     assert np.equal([in_model1.get_shape()], [model.get_output_shape(0)]).all()
 
 
-def test_runtime_info():
-    test_string = "testAffinity"
+def test_variants():
+    variant_int = VariantInt(32)
+    variant_str = VariantString("test_text")
 
+    assert variant_int.get() == 32
+    assert variant_str.get() == "test_text"
+
+    variant_int.set(777)
+    variant_str.set("another_text")
+
+    assert variant_int.get() == 777
+    assert variant_str.get() == "another_text"
+
+
+def test_runtime_info():
     test_shape = PartialShape([1, 3, 22, 22])
     test_type = Type.f32
     test_param = Parameter(test_type, test_shape)
     relu_node = ng.relu(test_param)
-    rtInfo = relu_node.get_rt_info()
-    rtInfo["affinity"] = VariantString("testAffinity")
+    runtime_info = relu_node.get_rt_info()
+    runtime_info["affinity"] = "test_affinity"
     relu_node.set_friendly_name("testReLU")
-    rtInfo_after = relu_node.get_rt_info()
+    runtime_info_after = relu_node.get_rt_info()
 
-    assert rtInfo == rtInfo_after
+    assert runtime_info == runtime_info_after
 
     params = [test_param]
     results = [relu_node]
@@ -416,4 +433,4 @@ def test_runtime_info():
     cnn_network = IENetwork(capsule)
     cnn_layer = cnn_network.layers["testReLU"]
     assert None != cnn_layer
-    assert cnn_layer.affinity == test_string
+    assert cnn_layer.affinity == "test_affinity"

--- a/ngraph/python/tests/test_ngraph/test_basic.py
+++ b/ngraph/python/tests/test_ngraph/test_basic.py
@@ -23,6 +23,7 @@ from ngraph.exceptions import UserInputError
 from ngraph.impl import Function, PartialShape, Shape
 from tests.runtime import get_runtime
 from tests.test_ngraph.util import run_op_node
+<<<<<<< HEAD
 from tests import (xfail_issue_34323,
                    xfail_issue_35929,
                    xfail_issue_35926,
@@ -31,6 +32,10 @@ from tests import (xfail_issue_34323,
                    xfail_issue_36479,
                    xfail_issue_36480)
 
+=======
+from ngraph.impl import Type, VariantString
+from ngraph.impl.op import Parameter, Result
+>>>>>>> a557aae5... Worksave
 
 def test_ngraph_function_api():
     shape = [2, 2]
@@ -388,3 +393,27 @@ def test_node_target_inputs_soruce_output():
     assert in_model1.get_node().name == parameter_b.name
     assert np.equal([in_model0.get_shape()], [model.get_output_shape(0)]).all()
     assert np.equal([in_model1.get_shape()], [model.get_output_shape(0)]).all()
+
+
+def test_runtime_info():
+    test_string = "testAffinity"
+
+    test_shape = PartialShape([1, 3, 22, 22])
+    test_type = Type.f32
+    # test_param = ng.parameter(test_shape, dtype=Type.f32, name="param_a")
+    test_param = Parameter(test_type, test_shape)
+    relu_node = ng.relu(test_param)
+    rtInfo = relu_node.get_rt_info()
+    rtInfo["affinity"] = VariantString("testAffinity")
+    relu_node.set_friendly_name("testReLU")
+    result = Result(relu_node)
+
+    params = [test_param]
+    results = [result]
+
+    ngraph = Function(results, params)
+
+    # cnnNet = ie.CNNNetwork(ngraph)
+    # # cnnLayer = CommonTestUtils::getLayerByName(cnnNet, "testReLU") # TODO
+    # ASSERT_NE(nullptr, cnnLayer)
+    # ASSERT_EQ(cnnLayer[affinity], test_string)

--- a/ngraph/python/tests/test_ngraph/test_basic.py
+++ b/ngraph/python/tests/test_ngraph/test_basic.py
@@ -24,7 +24,6 @@ from ngraph.impl import Function, PartialShape, Shape, Type, VariantInt, Variant
 from ngraph.impl.op import Parameter
 from tests.runtime import get_runtime
 from tests.test_ngraph.util import run_op_node
-<<<<<<< HEAD
 from tests import (xfail_issue_34323,
                    xfail_issue_35929,
                    xfail_issue_35926,
@@ -33,10 +32,6 @@ from tests import (xfail_issue_34323,
                    xfail_issue_36479,
                    xfail_issue_36480)
 
-from ngraph.impl import Type, VariantString
-from ngraph.impl.op import Parameter
-=======
->>>>>>> a5ee0095... Re-work of monkey patch and clean-up
 from openvino.inference_engine import IECore, IENetwork
 
 


### PR DESCRIPTION
Refactor code of RTMap. Variant class is no longer explicitly exposed to PyAPI, __setitem__ method overrides PyBind Map implementation, RTMap methods are not longer loading in Python runtime, and test refactor.