### PR TITLE
Enable tensorflow Inpaint model

### DIFF
--- a/model-optimizer/automation/package_BOM.txt
+++ b/model-optimizer/automation/package_BOM.txt
@@ -18,6 +18,7 @@ extensions/back/CorrectName.py
 extensions/back/CropToStridedSlice.py
 extensions/back/CutMemory.py
 extensions/back/disable_unsupported_ND_operations.py
+extensions/back/dynamic_convolution_transpose.py
 extensions/back/EnableConstantStridedSlice.py
 extensions/back/ForceStrictPrecision.py
 extensions/back/fuse_sub_div_min.py
@@ -382,6 +383,8 @@ extensions/front/tf/GatherTree_ext.py
 extensions/front/tf/GNMT_DynamicSequenceLengths.py
 extensions/front/tf/identity_ext.py
 extensions/front/tf/identityN_to_identity.py
+extensions/front/tf/inpaint.json
+extensions/front/tf/Inpaint.py
 extensions/front/tf/InterpolateTransposes.py
 extensions/front/tf/IteratorGetNext_ext.py
 extensions/front/tf/LoopCond_ext.py

--- a/model-optimizer/extensions/back/dynamic_convolution_transpose.py
+++ b/model-optimizer/extensions/back/dynamic_convolution_transpose.py
@@ -1,0 +1,39 @@
+"""
+ Copyright (C) 2020 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+from extensions.back.FuseTransposesSequence import FuseTransposesSequence
+from extensions.ops.transpose import Transpose
+from mo.front.common.partial_infer.utils import int64_array
+from mo.front.tf.graph_utils import create_op_node_with_second_input
+from mo.graph.graph import Graph
+from mo.back.replacement import BackReplacementPattern
+
+
+class ConvolutionWithDynamicWeightsTranspose(BackReplacementPattern):
+    enabled = True
+    graph_condition = [lambda graph: graph.graph['fw'] == 'tf']
+    force_shape_inference = True
+
+    def run_before(self):
+        return [FuseTransposesSequence]
+
+    def find_and_replace_pattern(self, graph: Graph):
+        for node in graph.get_op_nodes(type='Convolution'):
+            weights_node = node.in_port(1).get_source().node
+            if weights_node.soft_get('type') != 'Const' and weights_node.soft_get('type') != 'FakeQuantize':
+                transpose = create_op_node_with_second_input(graph, Transpose, int64_array([3, 2, 0, 1]), {'override_output_shape': True},
+                                                             input_node=node.in_port(1).get_source().node)
+                weights_node.out_port(0).get_connection().insert_node(transpose)
+

--- a/model-optimizer/extensions/front/tf/Inpaint.py
+++ b/model-optimizer/extensions/front/tf/Inpaint.py
@@ -1,0 +1,129 @@
+"""
+ Copyright (C) 2018-2020 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+import numpy as np
+
+from extensions.middle.InsertLayoutPropagationTransposes import mark_as_correct_data_layout
+from extensions.ops.normalize_l2 import NormalizeL2Op
+from mo.front.common.partial_infer.utils import int64_array
+from mo.front.tf.graph_utils import create_op_node_with_second_input
+from mo.front.tf.replacement import FrontReplacementFromConfigFileGeneral
+from mo.graph.graph import Graph, Node, rename_nodes
+from mo.middle.pattern_match import apply_pattern
+from mo.ops.const import Const
+from mo.ops.reshape import Reshape
+
+INPAINT_EIP1_PATTERN = {
+    'nodes': [
+        ('eip', dict(op='ExtractImagePatches')),
+        ('reshape', dict(op='Reshape')),
+        ('transpose', dict(op='Transpose')),
+        ('split', dict(op='Split')),
+        ('ss', dict(op='StridedSlice')),
+        ('square', dict(op='Pow')),
+        ('sum', dict(op='ReduceSum')),
+        ('sqrt', dict(op='Pow')),
+        ('max', dict(op='Maximum')),
+        ('div', dict(op='Div')),
+        ('reshape_const', dict(op='Const')),
+        ('transpose_const', dict(op='Const')),
+        ('sum_const', dict(op='Const')),
+    ],
+    'edges': [
+        ('eip', 'reshape', {'out': 0, 'in': 0}),
+        ('reshape_const', 'reshape', {'out': 0, 'in': 1}),
+        ('reshape', 'transpose', {'out': 0, 'in': 0}),
+        ('transpose_const', 'transpose', {'out': 0, 'in': 1}),
+        ('transpose', 'split', {'out': 0, 'in': 0}),
+        ('split', 'ss', {'out': 0, 'in': 0}),
+        ('ss', 'square', {'out': 0, 'in': 0}),
+        ('ss', 'div', {'out': 0, 'in': 0}),
+        ('square', 'sum', {'out': 0, 'in': 0}),
+        ('sum_const', 'sum', {'out': 0, 'in': 1}),
+        ('sum', 'sqrt', {'out': 0, 'in': 0}),
+        ('sqrt', 'max', {'out': 0, 'in': 0}),
+        ('max', 'div', {'out': 0, 'in': 1}),
+    ]
+}
+
+
+INPAINT_EIP2_PATTERN = {
+    'nodes': [
+        ('eip', dict(op='ExtractImagePatches')),
+        ('reshape', dict(op='Reshape')),
+        ('transpose', dict(op='Transpose')),
+        ('ss', dict(op='StridedSlice')),
+        ('mean', dict(op='ReduceMean')),
+        ('reshape_const', dict(op='Const')),
+        ('transpose_const', dict(op='Const')),
+        ('mean_const', dict(op='Const')),
+    ],
+    'edges': [
+        ('eip', 'reshape', {'out': 0, 'in': 0}),
+        ('reshape_const', 'reshape', {'out': 0, 'in': 1}),
+        ('reshape', 'transpose', {'out': 0, 'in': 0}),
+        ('transpose_const', 'transpose', {'out': 0, 'in': 1}),
+        ('transpose', 'ss', {'out': 0, 'in': 0}),
+        ('ss', 'mean', {'out': 0, 'in': 0}),
+        ('mean_const', 'mean', {'out': 0, 'in': 1}),
+    ]
+}
+
+
+class InpaintTransformation(FrontReplacementFromConfigFileGeneral):
+    replacement_id = 'Inpaint'
+
+    def transform_graph(self, graph: Graph, replacement_descriptions):
+        apply_pattern(graph, **INPAINT_EIP1_PATTERN, action=self.optimize_eip1)
+        apply_pattern(graph, **INPAINT_EIP2_PATTERN, action=self.optimize_eip2)
+
+    @staticmethod
+    def optimize_eip1(graph: Graph, match: dict):
+        eip = match['eip']
+        div = match['div']
+        maximum = match['max']
+
+        eip.out_port(0).disconnect()
+        new_reshape = create_op_node_with_second_input(graph, Reshape, int64_array([1, -1, 3 * 3 * 96]), input_node=eip)
+        normalize_l2 = create_op_node_with_second_input(graph, NormalizeL2Op, int64_array([-1]), {'eps_mode': 'max', 'eps': maximum.in_port(1).get_source().node.value})
+        normalize_l2.in_port(0).connect(new_reshape.out_port(0))
+        div.out_port(0).get_connection().set_source(normalize_l2.out_port(0))
+
+        rename_nodes([(div, div.id + '/TBR'), (normalize_l2, div.soft_get('name', div.id))])
+
+    @staticmethod
+    def optimize_eip2(graph: Graph, match: dict):
+        reshape_const = match['reshape_const']
+        transpose_const = match['transpose_const']
+        mean_const = match['mean_const']
+        if not np.array_equal(reshape_const.value, [1, -1, 3, 3, 1]):
+            return
+        if not np.array_equal(transpose_const.value, [0, 2, 3, 4, 1]):
+            return
+        if not np.array_equal(mean_const.value, [0, 1, 2]):
+            return
+
+        mean = match['mean']
+        eip = match['eip']
+
+        mean.in_port(0).disconnect()
+        eip.out_port(0).get_connection().set_destination(mean.in_port(0))
+
+        mean.in_port(1).disconnect()
+        mean.in_port(1).connect(Const(graph, {'value': int64_array([-1])}).create_node().out_port(0))
+        mean.out_port(0).get_connection().insert_node(
+            create_op_node_with_second_input(graph, Reshape, int64_array([1, 1, 1, -1])))
+
+        graph.remove_nodes_from([match['transpose'].id, match['ss'].id])

--- a/model-optimizer/extensions/front/tf/inpaint.json
+++ b/model-optimizer/extensions/front/tf/inpaint.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": "Inpaint",
+    "match_kind": "general",
+    "custom_attributes": {
+    }
+  }
+]


### PR DESCRIPTION
Description: Enable tf model Inpaint

JIRA: #26227


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py: N/A - no e2e test modifyed
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list: N/A - no new op
* [x]  Supported **public** models list
* [x]  New operations specification: N/A no new operations enabled
* [x]  Guide on how to convert the **public** model
* [x]  User guide update: N/A - not needed