### PR TITLE
Removed MO conversion of i64 inputs to i32

### DIFF
--- a/model-optimizer/extensions/front/ChangePlaceholderTypes.py
+++ b/model-optimizer/extensions/front/ChangePlaceholderTypes.py
@@ -48,10 +48,6 @@ class ChangePlaceholderTypes(FrontReplacementPattern):
                             op.out_port(0).connect(dst_port)
 
                         graph.remove_node(convert_node.id)
-            if op.soft_get('data_type') == np.int64:
-                op.data_type = np.int32
-                log.error('Convert data type of Parameter "{}" to int32'.format(op.soft_get('name', op.id)),
-                          extra={'is_warning': True})
 
             if op.soft_get('data_type') == np.uint8:
                 op.data_type = np.float32


### PR DESCRIPTION
Description: Disable conversion of i64 inputs to i32.

Executed several benchmark runs on CPU/GPU/VPUx and there are no regressions.