### PR TITLE
re-enable the myriadMultipleGraphsTests_nightly

### DIFF
--- a/inference-engine/cmake/vpu_dependencies.cmake
+++ b/inference-engine/cmake/vpu_dependencies.cmake
@@ -19,7 +19,7 @@ set(VPU_SUPPORTED_FIRMWARES usb-ma2450 usb-ma2x8x pcie-ma248x)
 # Default packages
 #
 
-set(FIRMWARE_PACKAGE_VERSION 1303)
+set(FIRMWARE_PACKAGE_VERSION 1307)
 set(VPU_CLC_MA2X8X_VERSION "movi-cltools-20.02.0")
 
 #

--- a/inference-engine/tests_deprecated/functional/vpu/myriad_tests/myriad_multiple_graph_tests.cpp
+++ b/inference-engine/tests_deprecated/functional/vpu/myriad_tests/myriad_multiple_graph_tests.cpp
@@ -27,8 +27,5 @@ TEST_P(myriadMultipleGraphsTests_nightly, LoadGraphsOnDevice) {
 }
 
 INSTANTIATE_TEST_CASE_P(numerOfGraphs, myriadMultipleGraphsTests_nightly,
-//  Exclude the test cases failing due to known bug:
-//  #-37268: [IE][Myriad] assertion "0 == semInit(&semUsed, 0)" and "stack smashing"
-//  ::testing::Values(2, 4, 10)
-    ::testing::Values(2)
+    ::testing::Values(2, 4, 10)
 );


### PR DESCRIPTION
Re-enables the tests disabled due to #-37268
Corresponding MDK pull-request is #-14529
