### PR TITLE
Fixed addOutput

### DIFF
--- a/inference-engine/src/inference_engine/cnn_network_ngraph_impl.cpp
+++ b/inference-engine/src/inference_engine/cnn_network_ngraph_impl.cpp
@@ -248,9 +248,6 @@ StatusCode CNNNetworkNGraphImpl::addOutput(const std::string& layerName, size_t 
                 if (_outputData.count(outputName) == 0) {
                     reshape();
                 }
-                if (_outputData.count(outputName) == 0) {
-                    addOutput(layer->output(outputIndex));
-                }
                 return OK;
             }
         }

--- a/inference-engine/src/inference_engine/cnn_network_ngraph_impl.cpp
+++ b/inference-engine/src/inference_engine/cnn_network_ngraph_impl.cpp
@@ -247,6 +247,8 @@ StatusCode CNNNetworkNGraphImpl::addOutput(const std::string& layerName, size_t 
                 }
                 if (_outputData.count(outputName) == 0) {
                     reshape();
+                }
+                if (_outputData.count(outputName) == 0) {
                     addOutput(layer->output(outputIndex));
                 }
                 return OK;

--- a/inference-engine/tests/functional/inference_engine/cnn_network/cnn_ngraph_impl_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/cnn_network/cnn_ngraph_impl_tests.cpp
@@ -28,6 +28,7 @@
 #include <ngraph/op/relu.hpp>
 #include <ngraph/op/prelu.hpp>
 #include <ngraph/op/result.hpp>
+#include <common_test_utils/ngraph_test_utils.hpp>
 
 #include "common_test_utils/file_utils.hpp"
 #include "common_test_utils/common_utils.hpp"
@@ -656,6 +657,61 @@ TEST(CNNNGraphImplTests, CanSetBatchReadValue) {
     auto convertedNet = std::make_shared<details::CNNNetworkImpl>(cnnNet);
     auto status = convertedNet->setBatchSize(4, nullptr);
     EXPECT_EQ(status, StatusCode::OK);
+}
+
+TEST(CNNNGraphImplTests, addSameOutput) {
+    std::shared_ptr<ngraph::Function> ngraph;
+    {
+        ngraph::PartialShape shape({1, 3, 22, 22});
+        ngraph::element::Type type(ngraph::element::Type_t::f32);
+        auto param = std::make_shared<ngraph::opset3::Parameter>(type, shape);
+        auto relu = std::make_shared<ngraph::opset3::Relu>(param);
+        auto shapeof = std::make_shared<ngraph::opset3::ShapeOf>(param);
+        auto reshape = std::make_shared<ngraph::opset3::Reshape>(relu, shapeof, true);
+        reshape->set_friendly_name("reshape");
+        auto result = std::make_shared<ngraph::op::Result>(reshape);
+
+        ngraph::ParameterVector params = {param};
+        ngraph::ResultVector results = {result};
+
+        ngraph = std::make_shared<ngraph::Function>(results, params);
+    }
+
+    CNNNetwork cnnNetwork(ngraph);
+    cnnNetwork.addOutput("reshape");
+    auto outputs = cnnNetwork.getOutputsInfo();
+
+    ASSERT_EQ(outputs.size(), 1);
+    ASSERT_EQ(outputs.count("reshape"), 1);
+    ASSERT_EQ(outputs["reshape"]->getLayout(), InferenceEngine::Layout::NCHW);
+}
+
+TEST(CNNNGraphImplTests, addOutput) {
+    std::shared_ptr<ngraph::Function> ngraph;
+    {
+        ngraph::PartialShape shape({1, 3, 22, 22});
+        ngraph::element::Type type(ngraph::element::Type_t::f32);
+        auto param = std::make_shared<ngraph::opset3::Parameter>(type, shape);
+        auto relu = std::make_shared<ngraph::opset3::Relu>(param);
+        auto shapeof = std::make_shared<ngraph::opset3::ShapeOf>(param);
+        auto reshape = std::make_shared<ngraph::opset3::Reshape>(relu, shapeof, true);
+        reshape->set_friendly_name("reshape");
+        auto relu2 = std::make_shared<ngraph::opset3::Relu>(reshape);
+        auto result = std::make_shared<ngraph::op::Result>(relu2);
+
+        ngraph::ParameterVector params = {param};
+        ngraph::ResultVector results = {result};
+
+        ngraph = std::make_shared<ngraph::Function>(results, params);
+    }
+
+    CNNNetwork cnnNetwork(ngraph);
+    cnnNetwork.addOutput("reshape");
+    auto outputs = cnnNetwork.getOutputsInfo();
+
+    ASSERT_EQ(outputs.size(), 2);
+    ASSERT_EQ(outputs.count("reshape"), 1);
+    ASSERT_EQ(outputs["reshape"]->getLayout(), InferenceEngine::Layout::NCHW);
 }
 
 IE_SUPPRESS_DEPRECATED_END


### PR DESCRIPTION
In case if initial model has dynamic batch and we addOutput for some intermediate operation then reshape() will be called fist and data will be added properly but after another addOutput will be called and already created data will be overridden by wrong data. So I check that data do not exist and only in this case addOutput will be called.