### PR TITLE
[NGRAPH] Fix system protoc version check in CMake

### DIFF
--- a/ngraph/cmake/external_protobuf.cmake
+++ b/ngraph/cmake/external_protobuf.cmake
@@ -50,9 +50,15 @@ if(CMAKE_CROSSCOMPILING)
     find_program(SYSTEM_PROTOC protoc PATHS ENV PATH)
 
     if(SYSTEM_PROTOC)
-        execute_process(COMMAND ${SYSTEM_PROTOC} --version OUTPUT_VARIABLE PROTOC_VERSION)
+        execute_process(
+            COMMAND ${SYSTEM_PROTOC} --version
+            OUTPUT_VARIABLE PROTOC_VERSION
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+
         string(REPLACE " " ";" PROTOC_VERSION ${PROTOC_VERSION})
         list(GET PROTOC_VERSION -1 PROTOC_VERSION)
+
         message("Detected system protoc version: ${PROTOC_VERSION}")
 
         if(${PROTOC_VERSION} VERSION_EQUAL "3.0.0")


### PR DESCRIPTION
Add `OUTPUT_STRIP_TRAILING_WHITESPACE` option to `execute_process` command.

Latest CMake (tested 3.18.1) doesn't strip new line from `protoc --version` call,
which leads to wrong `PROTOC_VERSION` variable and failure on git fetch step.