### PR TITLE
allocate maximum shaves for mish activation

### DIFF
--- a/inference-engine/src/vpu/graph_transformer/src/stages/mish.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/mish.cpp
@@ -20,6 +20,10 @@ private:
 
     void serializeParamsImpl(BlobSerializer&) const override {
     }
+
+    StageSHAVEsRequirements getSHAVEsRequirementsImpl() const override {
+        return StageSHAVEsRequirements::NeedMax;
+    }
 };
 
 }  // namespace


### PR DESCRIPTION
Mish activation calculation cost more time than memory copy, so
allocate more shaves mish activation.