### PR TITLE
Fix fusing Multiply node with Convolution in case group != 1

### DIFF
--- a/model-optimizer/mo/middle/passes/fusing/fuse_linear_ops.py
+++ b/model-optimizer/mo/middle/passes/fusing/fuse_linear_ops.py
@@ -110,7 +110,7 @@ def _fuse_mul(graph: Graph, node: Node, fuse_nodes: list, backward: bool = True)
         try:
             value = np.reshape(value, shape)
         except ValueError:
-            log.error("Cannot fuse cost from {} to {}. Reshape failed. Skipping.".format(
+            log.error("Cannot fuse const from {} to {}. Reshape failed. Skipping.".format(
                 node.soft_get('name', node.id),fuse_node.soft_get('name', fuse_node.id)), extra={'is_warning': True})
             return False
 

--- a/model-optimizer/mo/middle/passes/fusing/fuse_linear_ops.py
+++ b/model-optimizer/mo/middle/passes/fusing/fuse_linear_ops.py
@@ -18,10 +18,16 @@ import logging as log
 
 import numpy as np
 
-from mo.graph.graph import Node, Graph
+from extensions.ops.Cast import Cast
+from extensions.ops.elementwise import Mul
+from mo.front.common.partial_infer.utils import float_array
+from mo.front.tf.graph_utils import create_op_with_const_inputs
+from mo.graph.graph import Node, Graph, rename_nodes
 from mo.middle.passes.fusing.helpers import backward_bfs, forward_bfs, get_value_in_port, \
     get_tensor_in_port
 from mo.ops.const import Const
+from mo.ops.reshape import Reshape
+from mo.ops.shape import Shape
 
 
 def _fuse_mul(graph: Graph, node: Node, fuse_nodes: list, backward: bool = True):
@@ -75,6 +81,7 @@ def _fuse_mul(graph: Graph, node: Node, fuse_nodes: list, backward: bool = True)
 
     for fuse_node in fuse_nodes:
         weights_port = fuse_node.in_port(1)
+        wdims_number = weights_port.data.get_attr('dims_number')
         value = np.array(const_port.data.get_value())
 
         value = np.squeeze(value)
@@ -83,6 +90,36 @@ def _fuse_mul(graph: Graph, node: Node, fuse_nodes: list, backward: bool = True)
         # We will multiply weights according output/input channel dimension
         ch_dim = weights_port.data.get_attr('output_channel_dim' if backward else 'input_channel_dim')
         shape = np.array([weights_port.data.get_shape()[ch_dim]])
+
+        group = fuse_node.soft_get('group', 1)
+        if group != 1 and shape[0] % group != 0:
+            shape *= group
+            # reshape weights [I,O,H,W] -> [I/G,G*O,H,W]
+            weights_node = weights_port.get_connection().get_source().node
+            weights_name = weights_node.soft_get('name', weights_node.id)
+
+            shape_node = Shape(graph, {'name': weights_name + '/Shape'}).create_node()
+            shape_node.in_port(0).connect(weights_node.out_port(0))
+
+            reshape_before = Reshape(graph, {'name': weights_name + '/ReshapeBefore',
+                                             'override_output_shape': True}).create_node()
+            mul_const = float_array([1. / group, 1 * group])
+            for x in range(wdims_number - 2):
+                mul_const = np.append(mul_const, 1.)
+            mul = create_op_with_const_inputs(graph, Mul, {1: mul_const}, {'name': weights_name + '/Mul'})
+            mul.in_port(0).connect(shape_node.out_port(0))
+            mul.out_port(0).connect(reshape_before.in_port(1))
+
+            cast_shape = Cast(graph, {'dst_type': np.int64}).create_node()
+            reshape_before.in_port(1).get_connection().insert_node(cast_shape)
+
+            reshape_after = Reshape(graph, {'name': weights_name + '/ReshapeAfter'}).create_node()
+            reshape_after.in_port(1).connect(shape_node.out_port(0))
+            rename_nodes([(weights_node, weights_name + '/Weights'), (reshape_after, weights_name)])
+
+            weights_port.get_connection().insert_node(reshape_before)
+            weights_port.get_connection().insert_node(reshape_after)
+            weights_port = reshape_after.in_port(0)
 
         # Scalar broadcast
         if value.size == 1:
@@ -100,7 +137,6 @@ def _fuse_mul(graph: Graph, node: Node, fuse_nodes: list, backward: bool = True)
                 value = np.tile(value, int(cnt))
 
         # Expand dims for multiplication (ex. [38] to [38, 1, 1])
-        wdims_number = weights_port.data.get_attr('dims_number')
         for x in range(wdims_number - ch_dim - 1):
             shape = np.append(shape, 1)
 
@@ -111,7 +147,8 @@ def _fuse_mul(graph: Graph, node: Node, fuse_nodes: list, backward: bool = True)
         mul_name = node.name + '_copy'
         mul_const = Const(graph, {'value': value, 'name': mul_name + '/const'}).create_node()
         w_mul = node.copy_node({'name': mul_name, 'in_ports_count': len(node.in_ports()),
-                                'out_ports_count': len(node.out_ports()), 'can_be_fused': False})
+                                'out_ports_count': len(node.out_ports()), 'can_be_fused': False,
+                                'override_output_shape': True})
         w_mul.in_port(const_port.idx).connect(mul_const.out_port(0))
         w_const = weights_port.get_source()
         weights_port.get_connection().set_source(w_mul.out_port(0))
@@ -122,9 +159,6 @@ def _fuse_mul(graph: Graph, node: Node, fuse_nodes: list, backward: bool = True)
                 not fuse_node.has_and_set('shape_input'):
             conv_bias = fuse_node.in_port(2)
             conv_bias.data.set_value(conv_bias.data.get_value() * np.squeeze(mul_val))
-
-        mul_const.infer(mul_const)
-        w_mul.infer(w_mul)
 
         log.debug('Fused: {} to {}'.format(node.name, fuse_node.name))
         is_fused = True

--- a/model-optimizer/mo/middle/passes/fusing/fuse_linear_ops_test.py
+++ b/model-optimizer/mo/middle/passes/fusing/fuse_linear_ops_test.py
@@ -22,7 +22,7 @@ from mo.front.common.partial_infer.eltwise import eltwise_infer
 from mo.graph.graph import Node
 from mo.middle.passes.fusing.fuse_linear_ops import _fuse_mul, fuse_linear_ops
 from mo.utils.ir_engine.compare_graphs import compare_graphs
-from mo.utils.unittest.graph import build_graph
+from mo.utils.unittest.graph import build_graph, regular_op_with_empty_data, const_with_data, connect
 
 nodes_attributes = {
     'placeholder_1': {'shape': None, 'type': 'Parameter', 'kind': 'op', 'op': 'Parameter'},
@@ -36,7 +36,7 @@ nodes_attributes = {
     'scaleshift_1_data': {'value': None, 'shape': None, 'kind': 'data'},
     # Mul and Add operations
     'mul_1': {'type': 'Mul', 'kind': 'op', 'op': 'Mul', 'can_be_fused': True,
-              'infer': lambda node: eltwise_infer(node, lambda a, b: a*b)},
+              'infer': lambda node: eltwise_infer(node, lambda a, b: a * b)},
     'mul_1_w': {'value': None, 'shape': None, 'kind': 'data', 'data_type': None},
     'const_mul_1_w': {'value': None, 'shape': None, 'kind': 'op', 'data_type': None, 'op': 'Const'},
     'mul_1_data': {'value': None, 'shape': None, 'kind': 'data', 'data_type': None},
@@ -69,6 +69,12 @@ nodes_attributes = {
     'const_conv_2_w': {'value': None, 'shape': None, 'kind': 'op', 'data_type': None, 'op': 'Const'},
     'const_conv_2_b': {'value': None, 'shape': None, 'kind': 'op', 'data_type': None, 'op': 'Const'},
     'conv_2_data': {'value': None, 'shape': None, 'kind': 'data'},
+    'deconv': {'type': 'Deconvolution', 'kind': 'op', 'op': 'Deconv2D', 'layout': 'NHWC'},
+    'deconv_w': {'value': None, 'shape': None, 'kind': 'data'},
+    'deconv_b': {'value': None, 'shape': None, 'kind': 'data'},
+    'const_deconv_w': {'value': None, 'shape': None, 'kind': 'op', 'data_type': None, 'op': 'Const'},
+    'const_deconv_b': {'value': None, 'shape': None, 'kind': 'op', 'data_type': None, 'op': 'Const'},
+    'deconv_data': {'value': None, 'shape': None, 'kind': 'data'},
     # MatMul
     'fc_1': {'type': 'MatMul', 'kind': 'op', 'layout': 'NHWC', 'op': 'MatMul'},
     'fc_1_w': {'value': None, 'shape': None, 'kind': 'data'},
@@ -670,7 +676,8 @@ class FuseMulTests(unittest.TestCase):
                                  'const_mul_1_w': {'shape': np.array([]), 'value': np.array(6)},
                                  'mul_1_w': {'shape': np.array([]), 'value': np.array(6)},
                                  'conv_1': {'can_be_fused': False},
-                                 'const_conv_1_w': {'shape': np.array([11, 11, 3, 96]), 'value': np.ones((11, 11, 3, 96))},
+                                 'const_conv_1_w': {'shape': np.array([11, 11, 3, 96]),
+                                                    'value': np.ones((11, 11, 3, 96))},
                                  'conv_1_w': {'shape': np.array([11, 11, 3, 96]), 'value': np.ones((11, 11, 3, 96)),
                                               'output_channel_dim': 3, 'input_channel_dim': 2,
                                               'dims_number': 4},
@@ -778,6 +785,80 @@ class FuseMulTests(unittest.TestCase):
                                  })
 
         _fuse_mul(graph, Node(graph, 'mul_1'), [Node(graph, 'conv_1')], backward=True)
+        graph.clean_up()
+
+        (flag, resp) = compare_graphs(graph, graph_ref, 'placeholder_1', 'placeholder_1')
+        self.assertTrue(flag, resp)
+
+    # Deconv(w)->Mul(array)
+    def test_fuse_mul_to_deconv_1(self):
+        # Placeholder->Deonv->Mul
+        in_shape = np.array([1, 20, 10, 10])
+        w_shape = np.array([20, 2, 3, 3])
+        out_shape = np.array([1, 10, 21, 21])
+        mul_const = np.array(range(10))
+        graph = build_graph(nodes_attributes,
+                            [('placeholder_1', 'placeholder_1_data'),
+                             ('placeholder_1_data', 'deconv'),
+                             ('const_deconv_w', 'deconv_w'),
+                             ('deconv_w', 'deconv'),
+                             ('deconv', 'deconv_data'),
+                             ('deconv_data', 'mul_1'),
+                             ('const_mul_1_w', 'mul_1_w'),
+                             ('mul_1_w', 'mul_1'),
+                             ('mul_1', 'mul_1_data'),
+                             ('mul_1_data', 'op_output')
+                             ],
+                            {'placeholder_1_data': {'shape': in_shape},
+                             'const_conv_1_w': {'shape': w_shape, 'value': np.ones(w_shape)},
+                             'deconv': {'group': 5},
+                             'deconv_w': {'shape': w_shape, 'value': np.ones(w_shape),
+                                          'output_channel_dim': 1, 'input_channel_dim': 0,
+                                          'dims_number': 4},
+                             'deconv_data': {'shape': out_shape},
+                             'mul_1_data': {'shape': mul_const.shape},
+                             'const_mul_1_w': {'shape': mul_const.shape, 'value': mul_const},
+                             'mul_1_w': {'shape': mul_const.shape, 'value': mul_const},
+                             })
+
+        nodes_attributes_ref = {
+            **const_with_data('div_const', np.array([0.2, 5., 1., 1.])),
+            **regular_op_with_empty_data('shape', {'type': 'ShapeOf'}),
+            **regular_op_with_empty_data('div', {'type': 'Mul'}),
+            **regular_op_with_empty_data('cast', {'type': 'Convert'}),
+            **regular_op_with_empty_data('r_before', {'type': 'Reshape'}),
+            **regular_op_with_empty_data('r_after', {'type': 'Reshape'}),
+        }
+        nodes_attributes_ref.update(nodes_attributes)
+
+        graph_ref = build_graph(nodes_attributes_ref,
+                                [('placeholder_1', 'placeholder_1_data'),
+                                 ('const_deconv_w', 'deconv_w'),
+                                 ('deconv_w', 'shape'),
+                                 *connect('shape', '0:div'),
+                                 *connect('div_const', '1:div'),
+                                 *connect('div', 'cast'),
+                                 ('deconv_w', 'r_before'),
+                                 *connect('cast', '1:r_before'),
+                                 *connect('r_before', 'mul_1'),
+                                 ('const_mul_1_w', 'mul_1_w'),
+                                 ('mul_1_w', 'mul_1'),
+                                 ('mul_1', 'mul_1_data'),
+                                 ('mul_1_data', 'r_after'),
+                                 ('shape_d', 'r_after'),
+                                 ('placeholder_1_data', 'deconv'),
+                                 *connect('r_after', '1:deconv'),
+                                 ('deconv', 'deconv_data'),
+                                 ('deconv_data', 'op_output')
+                                 ],
+                                {'placeholder_1_data': {'shape': in_shape},
+                                 'deconv_w': {'shape': w_shape, 'value': np.ones(w_shape),
+                                              'output_channel_dim': 1, 'input_channel_dim': 0,
+                                              'dims_number': 4},
+                                 'mul_1': {'can_be_fused': False}
+                                 })
+
+        _fuse_mul(graph, Node(graph, 'mul_1'), [Node(graph, 'deconv')], backward=True)
         graph.clean_up()
 
         (flag, resp) = compare_graphs(graph, graph_ref, 'placeholder_1', 'placeholder_1')
@@ -1011,7 +1092,6 @@ class FuseLinOpsTests(unittest.TestCase):
         (flag, resp) = compare_graphs(graph, graph_ref, 'concat_1_data')
         # TODO: refactor this test
         # self.assertTrue(flag, resp)
-        
 
     # Op->Mul(array)-+->Conv(w+b)------+->Concat
     #                |                 |         =>  Same('can_be_fused': False)
@@ -1090,7 +1170,8 @@ class FuseLinOpsTests(unittest.TestCase):
                                  'mul_1_data': {'shape': np.array([1, 227, 227, 3])},
                                  'const_mul_1_w': {'shape': np.array([3]), 'value': np.array([1, 2, 3])},
                                  'mul_1_w': {'shape': np.array([3]), 'value': np.array([1, 2, 3])},
-                                 'const_conv_1_w': {'shape': np.array([11, 11, 3, 96]), 'value': np.ones((11, 11, 3, 96))},
+                                 'const_conv_1_w': {'shape': np.array([11, 11, 3, 96]),
+                                                    'value': np.ones((11, 11, 3, 96))},
                                  'conv_1_w': {'shape': np.array([11, 11, 3, 96]), 'value': np.ones((11, 11, 3, 96)),
                                               'output_channel_dim': 3, 'input_channel_dim': 2,
                                               'dims_number': 4},
@@ -1098,7 +1179,8 @@ class FuseLinOpsTests(unittest.TestCase):
                                  'conv_1_b': {'shape': np.array([96]), 'value': np.zeros(96)},
                                  'conv_1_data': {'shape': np.array([1, 55, 55, 96])},
                                  'conv_2': {'can_be_fused': False},
-                                 'const_conv_2_w': {'shape': np.array([11, 11, 3, 96]), 'value': np.ones((11, 11, 3, 96))},
+                                 'const_conv_2_w': {'shape': np.array([11, 11, 3, 96]),
+                                                    'value': np.ones((11, 11, 3, 96))},
                                  'conv_2_w': {'shape': np.array([11, 11, 3, 96]), 'value': np.ones((11, 11, 3, 96)),
                                               'output_channel_dim': 3, 'input_channel_dim': 2,
                                               'dims_number': 4},
@@ -1191,14 +1273,16 @@ class FuseLinOpsTests(unittest.TestCase):
                                  'mul_1_data': {'shape': np.array([1, 227, 227, 3])},
                                  'const_mul_1_w': {'shape': np.array([3]), 'value': np.array([1, 2, 3])},
                                  'mul_1_w': {'shape': np.array([3]), 'value': np.array([1, 2, 3])},
-                                 'const_conv_1_w': {'shape': np.array([11, 11, 3, 96]), 'value': np.ones((11, 11, 3, 96))},
+                                 'const_conv_1_w': {'shape': np.array([11, 11, 3, 96]),
+                                                    'value': np.ones((11, 11, 3, 96))},
                                  'conv_1_w': {'shape': np.array([11, 11, 3, 96]), 'value': np.ones((11, 11, 3, 96)),
                                               'output_channel_dim': 3, 'input_channel_dim': 2,
                                               'dims_number': 4},
                                  'const_conv_1_b': {'shape': np.array([96]), 'value': np.zeros(96)},
                                  'conv_1_b': {'shape': np.array([96]), 'value': np.zeros(96)},
                                  'conv_1_data': {'shape': np.array([1, 55, 55, 96])},
-                                 'const_conv_2_w': {'shape': np.array([11, 11, 3, 96]), 'value': np.ones((11, 11, 3, 96))},
+                                 'const_conv_2_w': {'shape': np.array([11, 11, 3, 96]),
+                                                    'value': np.ones((11, 11, 3, 96))},
                                  'conv_2_w': {'shape': np.array([11, 11, 3, 96]), 'value': np.ones((11, 11, 3, 96)),
                                               'output_channel_dim': 3, 'input_channel_dim': 2,
                                               'dims_number': 4},


### PR DESCRIPTION
Description: Fix fusing Multiply node with Convolution in case group != 1

JIRA: #36085

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list: N/A - no new op
* [x]  Supported **public** models list: N/A - no new public model supported
* [x]  New operations specification: N/A no new operations enabled
* [x]  Guide on how to convert the **public** model: N/A - not needed
* [x]  User guide update: N/A - not needed