### PR TITLE
Fixed order of transformation to convert the TF OD API SSD models

### DIFF
--- a/model-optimizer/extensions/front/tf/ObjectDetectionAPI.py
+++ b/model-optimizer/extensions/front/tf/ObjectDetectionAPI.py
@@ -25,6 +25,7 @@ from extensions.front.split_normalizer import SqueezeAxis
 from extensions.front.standalone_const_eraser import StandaloneConstEraser
 from extensions.front.tf.CropAndResizeReplacement import CropAndResizeReplacement
 from extensions.front.tf.FakeQuantWithMinMaxVars import FakeQuantWithMinMaxVarsToQuantize
+from extensions.front.tf.TFSliceToSlice import TFSliceToSliceReplacer
 from extensions.front.tf.pad_tf_to_pad import PadTFToPad
 from extensions.middle.InsertLayoutPropagationTransposes import mark_as_correct_data_layout, \
     mark_input_as_in_correct_layout, mark_output_as_in_correct_layout
@@ -967,7 +968,7 @@ class ObjectDetectionAPISSDPostprocessorReplacement(FrontReplacementFromConfigFi
         return [ObjectDetectionAPIPreprocessorReplacement, FakeQuantWithMinMaxVarsToQuantize]
 
     def run_before(self):
-        return [StandaloneConstEraser, TransposeOrderNormalizer]
+        return [StandaloneConstEraser, TransposeOrderNormalizer, TFSliceToSliceReplacer]
 
     def output_edges_match(self, graph: Graph, match: SubgraphMatch, new_sub_graph: dict):
         # the DetectionOutput in IE produces single tensor, but in TF it produces two tensors, so create only one output

--- a/model-optimizer/extensions/front/tf/ObjectDetectionAPI.py
+++ b/model-optimizer/extensions/front/tf/ObjectDetectionAPI.py
@@ -44,7 +44,7 @@ from mo.front.common.partial_infer.utils import int64_array
 from mo.front.extractor import output_user_data_repack, add_output_ops
 from mo.front.subgraph_matcher import SubgraphMatch
 from mo.front.tf.graph_utils import add_activation_function_after_node, add_convolution_to_swap_xy_coordinates, \
-    squeeze_reshape_and_concat, add_fake_background_loc, create_op_node_with_second_input
+    mark_squeeze_reshape_concat_before_detection_output, add_fake_background_loc, create_op_node_with_second_input
 from mo.front.tf.replacement import FrontReplacementFromConfigFileSubGraph, FrontReplacementFromConfigFileGeneral
 from mo.graph.graph import Graph, Node
 from mo.ops.concat import Concat
@@ -1074,7 +1074,7 @@ class ObjectDetectionAPISSDPostprocessorReplacement(FrontReplacementFromConfigFi
         node.old_infer(node)
 
         conv_nodes = backward_bfs_for_operation(node.in_node(0), ['Conv2D'])
-        squeeze_reshape_and_concat(conv_nodes)
+        mark_squeeze_reshape_concat_before_detection_output(conv_nodes)
 
 
 class ObjectDetectionAPIOutputReplacement(FrontReplacementFromConfigFileGeneral):


### PR DESCRIPTION
Description: 
1. The TF OD API SSD model has a reference to a Slice operation in the json configuration file. This Split operation is replaced with another one in the TFSliceToSliceReplacer with an operation with updated `id`. Thus the sub-graph replacement does not find the operation and fails. This is a sporadic issue and reproduces when the front transformations are executed in a specific order.
2. Refactored the function which previously modified the original model to make the part of the model to run in original layout by removing one dimension in a couple of operations. Now the part of the models are marked with correct layout and attribute 'nchw_layout' to not permute the attributes. This change works for both cases when the data is squeezed first and then concatenated and in a new case when data is concatenated first and the squeezed. This change helps to enable the model mentioned in the 37277.

JIRA: 37277

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR: N/A
* [x]  Transformation preserves original framework node names: N/A


Validation:
* [x]  Unit tests: N/A
* [x]  Framework operation tests: N/A
* [x]  Transformation tests: N/A
* [x]  e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py: model already exists
* [x]  Model Optimizer IR Reader check N/A

Documentation:
* [x]  Supported frameworks operations list N/A
* [x]  Supported **public** models list N/A
* [x]  New operations specification N/A
* [x]  Guide on how to convert the **public** model N/A
* [x]  User guide update: N/A