### PR TITLE
Reduce number of ops needed to create InstanceNorm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,5 +69,3 @@ ngraph/src/ngraphConfigVersion.cmake
 ngraph/src/protobuf/
 ngraph/src/src/
 ngraph/src/test/
-*.svg.dot
-*.svg

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ ngraph/src/ngraphConfigVersion.cmake
 ngraph/src/protobuf/
 ngraph/src/src/
 ngraph/src/test/
+*.svg.dot
+*.svg

--- a/ngraph/test/runtime/ie/unit_test.manifest
+++ b/ngraph/test/runtime/ie/unit_test.manifest
@@ -1056,7 +1056,6 @@ IE_CPU.fused_clamp_uint32
 IE_CPU/FlattenTest.flatten
 
 # Segfault
-IE_CPU.onnx_model_instance_normalization
 IE_CPU.onnx_model_reverse_sequence_1_batch_0
 IE_CPU.onnx_model_reverse_sequence_0_batch_1
 IE_CPU.cum_sum_2dim_default_axis


### PR DESCRIPTION
InstanceNorm in onnx importer creates the same subgraph for Mean twice - once for Variance and once for actual Mean.
This change makes InstanceNorm to use single Mean which is shared by numerator and Variance.

Also enables IE_CPU.onnx_model_instance_normalization test case