### PR TITLE
[PP GAPI] - Generic precision conversion kernel

### DIFF
--- a/inference-engine/src/preprocessing/ie_preprocess_gapi_kernels.hpp
+++ b/inference-engine/src/preprocessing/ie_preprocess_gapi_kernels.hpp
@@ -143,11 +143,12 @@ namespace gapi {
         }
     };
 
-    G_TYPED_KERNEL(U16toF32, <cv::GMat(cv::GMat)>, "com.intel.ie.u16tof32") {
-        static cv::GMatDesc outMeta(const cv::GMatDesc& in) {
-            GAPI_Assert(in.depth == CV_16U);
+    G_TYPED_KERNEL(ConvertDepth, <cv::GMat(cv::GMat, int depth)>, "com.intel.ie.ConvertDepth") {
+        static cv::GMatDesc outMeta(const cv::GMatDesc& in, int depth) {
+            GAPI_Assert(in.depth == CV_16U || in.depth == CV_32F);
+            GAPI_Assert(depth == CV_32F || depth == CV_16U);
 
-            return in.withDepth(CV_32F);
+            return in.withDepth(depth);
         }
     };
 

--- a/inference-engine/src/preprocessing/ie_preprocess_gapi_kernels_impl.hpp
+++ b/inference-engine/src/preprocessing/ie_preprocess_gapi_kernels_impl.hpp
@@ -38,7 +38,10 @@ template<> inline short saturate_cast(int x) { return (std::min)(SHRT_MAX, (std:
 template<> inline short saturate_cast(float x) { return saturate_cast<short>(static_cast<int>(std::rint(x))); }
 template<> inline float saturate_cast(float x) { return x; }
 template<> inline short saturate_cast(short x) { return x; }
+template<> inline uint16_t saturate_cast(uint16_t x) { return x; }
+template<> inline float    saturate_cast(uint16_t x) { return x; }
 template<> inline uint16_t saturate_cast(int x) { return (std::min)(USHRT_MAX, (std::max)(0, x)); }
+template<> inline uint16_t saturate_cast(float x)    { return saturate_cast<uint16_t>(static_cast<int>(std::rint(x))); }
 template<> inline uchar saturate_cast<uchar>(int v) { return (uchar)((unsigned)v <= UCHAR_MAX ? v : v > 0 ? UCHAR_MAX : 0); }
 
 //------------------------------------------------------------------------------

--- a/inference-engine/tests_deprecated/fluid_preproc/common/fluid_tests.cpp
+++ b/inference-engine/tests_deprecated/fluid_preproc/common/fluid_tests.cpp
@@ -625,27 +625,31 @@ TEST_P(I420toRGBTestGAPI, AccuracyTest)
     }
 }
 
-TEST_P(U16toF32TestGAPI, AccuracyTest)
+TEST_P(ConvertDepthTestGAPI, AccuracyTest)
 {
     const auto params = GetParam();
-    cv::Size sz      = std::get<0>(params);
-    double tolerance = std::get<1>(params);
+    int in_depth      = std::get<0>(params);
+    int out_depth     = std::get<1>(params);
+    cv::Size sz       = std::get<2>(params);
+    double tolerance  = std::get<3>(params);
 
-    initMatrixRandU(CV_16UC1, sz, CV_32FC1);
+    const int out_type = CV_MAKETYPE(out_depth,1);
+
+    initMatrixRandU(CV_MAKETYPE(in_depth,1), sz, out_type);
 
     // G-API code //////////////////////////////////////////////////////////////
-    FluidU16ToF32Computation cc(to_test(in_mat1), to_test(out_mat_gapi));
+    ConvertDepthComputation cc(to_test(in_mat1), to_test(out_mat_gapi), out_mat_gapi.depth());
     cc.warmUp();
 
 #if PERF_TEST
     // iterate testing, and print performance
     test_ms([&](){ cc.apply(); },
-        400, "U16ToF32 GAPI %s %dx%d", typeToString(CV_16UC1).c_str(), sz.width, sz.height);
+        400, "ConvDepth GAPI %s to %s %dx%d", depthToString(in_mat1.depth()).c_str(), depthToString(out_mat_gapi.depth()).c_str(), sz.width, sz.height);
 #endif
 
     // OpenCV code /////////////////////////////////////////////////////////////
     {
-        in_mat1.convertTo(out_mat_ocv, CV_32FC1);
+        in_mat1.convertTo(out_mat_ocv, out_type);
     }
     // Comparison //////////////////////////////////////////////////////////////
     {

--- a/inference-engine/tests_deprecated/fluid_preproc/common/fluid_tests.hpp
+++ b/inference-engine/tests_deprecated/fluid_preproc/common/fluid_tests.hpp
@@ -19,7 +19,12 @@ struct NV12toRGBTestGAPI: public TestParams<std::tuple<cv::Size, double>> {};
 struct I420toRGBTestGAPI: public TestParams<std::tuple<cv::Size, double>> {};
 struct ResizeRoiTestGAPI: public testing::TestWithParam<std::tuple<int, int, std::pair<cv::Size, cv::Size>, cv::Rect, double>> {};
 struct ResizeRGB8URoiTestGAPI: public testing::TestWithParam<std::tuple<int, int, std::pair<cv::Size, cv::Size>, cv::Rect, double>> {};
-struct U16toF32TestGAPI: public TestParams<std::tuple<cv::Size, double>> {};
+struct ConvertDepthTestGAPI: public TestParams<std::tuple<
+                            int,  // input matrix depth
+                            int,  // output matrix depth
+                            cv::Size,
+                            double>>   // tolerance
+{};
 //------------------------------------------------------------------------------
 
 struct ResizeTestIE: public testing::TestWithParam<std::tuple<int, int, std::pair<cv::Size, cv::Size>, double>> {};

--- a/inference-engine/tests_deprecated/fluid_preproc/cpu/fluid_tests_cpu.cpp
+++ b/inference-engine/tests_deprecated/fluid_preproc/cpu/fluid_tests_cpu.cpp
@@ -170,8 +170,10 @@ INSTANTIATE_TEST_CASE_P(I420toRGBTestFluid, I420toRGBTestGAPI,
                                        cv::Size( 320,  200)),
                                 Values(0)));
 
-INSTANTIATE_TEST_CASE_P(U16toF32TestGAPIFluid, U16toF32TestGAPI,
-                        Combine(Values(cv::Size(3840, 2160),
+INSTANTIATE_TEST_CASE_P(ConvertDepthFluid, ConvertDepthTestGAPI,
+                        Combine(Values(CV_16U, CV_32F),
+                                Values(CV_32F, CV_16U),
+                                Values(cv::Size(3840, 2160),
                                        cv::Size(1920, 1080),
                                        cv::Size(1280,  720),
                                        cv::Size(1280,  960),
@@ -179,7 +181,7 @@ INSTANTIATE_TEST_CASE_P(U16toF32TestGAPIFluid, U16toF32TestGAPI,
                                        cv::Size( 640,  480),
                                        cv::Size( 300,  300),
                                        cv::Size( 320,  200)),
-                                Values(0)));
+                                Values(1)));
 
 INSTANTIATE_TEST_CASE_P(ResizeRoiTestFluid, ResizeRoiTestGAPI,
                         Combine(Values(CV_8UC1, CV_8UC3),

--- a/inference-engine/tests_deprecated/fluid_preproc/fluid_test_computations/fluid_test_computations.cpp
+++ b/inference-engine/tests_deprecated/fluid_preproc/fluid_test_computations/fluid_test_computations.cpp
@@ -214,14 +214,14 @@ FluidI420toRGBComputation::FluidI420toRGBComputation(test::Mat inMat_y, test::Ma
                                })
 {}
 
-FluidU16ToF32Computation::FluidU16ToF32Computation(test::Mat inMatU16, test::Mat outMatF32)
-    : FluidComputation(new Priv{ []()-> cv::GComputation {
-                                    cv::GMat in_U16;
-                                    cv::GMat outf32 = InferenceEngine::gapi::U16toF32::on(in_U16);
-                                    return cv::GComputation(cv::GIn(in_U16), cv::GOut(outf32));
+ConvertDepthComputation::ConvertDepthComputation(test::Mat inMat, test::Mat outMat,  int depth)
+    : FluidComputation(new Priv{ [depth]()-> cv::GComputation {
+                                    cv::GMat in;
+                                    cv::GMat out = InferenceEngine::gapi::ConvertDepth::on(in, depth);
+                                    return cv::GComputation(cv::GIn(in), cv::GOut(out));
                                  }()
-                               , {to_own(inMatU16)}
-                               , {to_own(outMatF32)}
+                               , {to_own(inMat)}
+                               , {to_own(outMat)}
                                })
 {}
 

--- a/inference-engine/tests_deprecated/fluid_preproc/fluid_test_computations/fluid_test_computations.hpp
+++ b/inference-engine/tests_deprecated/fluid_preproc/fluid_test_computations/fluid_test_computations.hpp
@@ -98,10 +98,10 @@ public:
     FluidI420toRGBComputation(test::Mat inMat_y, test::Mat inMat_u, test::Mat inMat_v, test::Mat outMat);
 };
 
-class FLUID_COMPUTATION_VISIBILITY FluidU16ToF32Computation : public FluidComputation
+class FLUID_COMPUTATION_VISIBILITY ConvertDepthComputation : public FluidComputation
 {
 public:
-    FluidU16ToF32Computation(test::Mat inMatU16, test::Mat outMatF32);
+    ConvertDepthComputation(test::Mat inMat, test::Mat outMat, int depth);
 };
 
 #endif // FLUID_TEST_COMPUTATIONS_HPP


### PR DESCRIPTION
- U16toF32 conversion kernel converted to more generic ConvDepth one
- U16 <-> F32 conversion only are supported for now
- kernel is not used in the preprocessing graph yet
- tests are extended