### PR TITLE
Customer model compilation error - fix

### DIFF
--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/adjust_data_layout.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/adjust_data_layout.cpp
@@ -359,9 +359,16 @@ Data PassImpl::addConvertedData(
         const Model& model,
         const Data& orig,
         const StridesRequirement& reqs) {
-    auto data = model->duplicateData(
-        orig,
-        "@adjust-strides");
+    auto data = orig;
+
+    if (orig->usage() == DataUsage::Const) {
+        auto newData = model->addNewData(orig->name(), orig->desc());
+        newData->attrs().copyFrom(orig->attrs());
+        data = newData;
+    } else {
+        data = model->duplicateData(orig, "@adjust-strides");
+    }
+
     data->resetRequiredStrides();
     data->updateRequiredStrides(reqs);
 


### PR DESCRIPTION
#-36693

Description : One of the concat inputs is a constant. Adjust_data_layout pass tries to duplicate all inputs that do not meet the strides requirements, and then copy from the original input to the duplicate with strides.
But duplicateData with an argument in the form of a constant also creates a constant, and then, when Copy, an error appears, the presence of a constant output, which cannot be.
Proposed solution : In addConvertedData create an intermidiate date with the same description as the constant, and then copy the constant data into it with the required strides.