### PR TITLE
[IE CLDNN] Forcing bfzyx format in MVN layer

### DIFF
--- a/inference-engine/thirdparty/clDNN/src/layout_optimizer.cpp
+++ b/inference-engine/thirdparty/clDNN/src/layout_optimizer.cpp
@@ -852,6 +852,11 @@ format layout_optimizer::get_preferred_format(program_node& node) {
         auto& deconv_node = node.as<deconvolution>();
         auto weights_layout = deconv_node.weights(0).get_output_layout();
         expected = get_expected_layout(output_layout, deconv_node, weights_layout).format;
+    } else if (node.is_type<mvn>()) {
+        auto input_layout = node.get_dependency(0).get_output_layout();
+        if (input_layout.format.dimension() == 5 &&
+            (input_layout.data_type == data_types::f32 || input_layout.data_type == data_types::f16 ))
+            expected = format::bfzyx;
     }
 
     return expected;


### PR DESCRIPTION
Currently we don't have a proper mvn kernel for blocked 5d formats with f16/f32 inputs. Those changes are forcing reorders to bfzyx format in mvn layers, since optimized bfzyx format with reorders is faster than ref_mvn kernel.

I run benchmark for master and this branch and there are no regressions. There is ~70% increase in performance for brain-tumor-segmentation-0001 model.