### PR TITLE
[ MO ] Reinfer shape sub-graphs once

### DIFF
--- a/model-optimizer/extensions/middle/ApplyPermutations.py
+++ b/model-optimizer/extensions/middle/ApplyPermutations.py
@@ -148,5 +148,11 @@ class ApplyPermutation(MiddleReplacementPattern):
         shape_ops = graph.get_op_nodes(op='ShapeOf')
         for shape in shape_ops:
             shape.infer(shape)
+
+        def reinfer_once(in_port):
+            if not in_port.node.soft_get('reinfered', False):
+                in_port.node.infer(in_port.node)
+                in_port.node['reinfered'] = True
+
         LayoutChangeForConstantShapePaths().find_shape_subgraph_endpoints(
-            [shape.out_port(0) for shape in shape_ops], None, lambda in_port: in_port.node.infer(in_port.node))
+            out_ports=[shape.out_port(0) for shape in shape_ops], action=reinfer_once)

--- a/model-optimizer/extensions/middle/ApplyPermutations.py
+++ b/model-optimizer/extensions/middle/ApplyPermutations.py
@@ -24,6 +24,7 @@ from extensions.middle.LayoutChangeForConstantShapePaths import LayoutChangeForC
 from extensions.middle.pass_separator import PostMiddleStart
 from mo.front.common.partial_infer.utils import int64_array
 from mo.graph.graph import Graph, Node
+from mo.graph.port import Port
 from mo.middle.replacement import MiddleReplacementPattern
 from mo.utils.error import Error
 
@@ -149,7 +150,7 @@ class ApplyPermutation(MiddleReplacementPattern):
         for shape in shape_ops:
             shape.infer(shape)
 
-        def reinfer_once(in_port):
+        def reinfer_once(in_port: Port):
             node = in_port.node
             if not node.soft_get('reinferred', False):
                 node.infer(node)

--- a/model-optimizer/extensions/middle/ApplyPermutations.py
+++ b/model-optimizer/extensions/middle/ApplyPermutations.py
@@ -150,9 +150,10 @@ class ApplyPermutation(MiddleReplacementPattern):
             shape.infer(shape)
 
         def reinfer_once(in_port):
-            if not in_port.node.soft_get('reinfered', False):
-                in_port.node.infer(in_port.node)
-                in_port.node['reinfered'] = True
+            node = in_port.node
+            if not node.soft_get('reinferred', False):
+                node.infer(node)
+                node['reinferred'] = True
 
         LayoutChangeForConstantShapePaths().find_shape_subgraph_endpoints(
             out_ports=[shape.out_port(0) for shape in shape_ops], action=reinfer_once)


### PR DESCRIPTION
Description: Minimize node re-inferences while `shape_of_sub_graph_reinference`

JIRA: 37779


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list
* [x]  Supported **public** models list
* [x]  New operations specification
* [x]  Guide on how to convert the **public** model
* [x]  User guide update