### PR TITLE
Disable eager execution of TensorFlow 2 environment

### DIFF
--- a/model-optimizer/extensions/load/tf/loader.py
+++ b/model-optimizer/extensions/load/tf/loader.py
@@ -16,6 +16,8 @@
 
 try:
     import tensorflow.compat.v1 as tf_v1
+    # disable eager execution of TensorFlow 2 environment immediately
+    tf_v1.disable_eager_execution()
 except ImportError:
     import tensorflow as tf_v1
 

--- a/model-optimizer/extensions/middle/CustomSubgraphCall.py
+++ b/model-optimizer/extensions/middle/CustomSubgraphCall.py
@@ -63,6 +63,8 @@ class CustomSubgraphCall(MiddleReplacementPattern):
         """
         try:
             import tensorflow.compat.v1 as tf_v1
+            # disable eager execution of TensorFlow 2 environment immediately
+            tf_v1.disable_eager_execution()
         except ImportError:
             import tensorflow as tf_v1
         from mo.front.common.layout import convert_shape, nhwc_to_nchw_permute, nchw_to_nhwc_permute
@@ -282,6 +284,8 @@ class CustomSubgraphCall(MiddleReplacementPattern):
         """
         try:
             import tensorflow.compat.v1 as tf_v1
+            # disable eager execution of TensorFlow 2 environment immediately
+            tf_v1.disable_eager_execution()
         except ImportError:
             import tensorflow as tf_v1
         from mo.front.tf.partial_infer.tf import get_subgraph_output_tensors, add_node_def_to_subgraph

--- a/model-optimizer/mo/front/tf/loader.py
+++ b/model-optimizer/mo/front/tf/loader.py
@@ -23,6 +23,8 @@ from mo.utils.utils import refer_to_faq_msg
 
 try:
     import tensorflow.compat.v1 as tf_v1
+    # disable eager execution of TensorFlow 2 environment immediately
+    tf_v1.disable_eager_execution()
     import tensorflow as tf
     from tensorflow.python.framework.convert_to_constants import convert_variables_to_constants_v2
 except ImportError:
@@ -231,8 +233,6 @@ def load_tf_graph_def(graph_file_name: str = "", is_binary: bool = True, checkpo
                 concrete_func = imported.signatures[tf.saved_model.DEFAULT_SERVING_SIGNATURE_DEF_KEY]
                 frozen_func = convert_variables_to_constants_v2(concrete_func, lower_control_flow=False) # pylint: disable=E1123
                 graph_def = frozen_func.graph.as_graph_def(add_shapes=True)
-                # disable eager execution to dump a graph for tensorboard
-                tf_v1.disable_eager_execution()                
                 return graph_def, variables_values
             except (TypeError, KeyError):
                 # code to extract GraphDef for TF 1.0 SavedModel format

--- a/model-optimizer/mo/front/tf/partial_infer/tf.py
+++ b/model-optimizer/mo/front/tf/partial_infer/tf.py
@@ -21,6 +21,8 @@ import numpy as np
 
 try:
     import tensorflow.compat.v1 as tf_v1
+    # disable eager execution of TensorFlow 2 environment immediately
+    tf_v1.disable_eager_execution()
 except ImportError:
     import tensorflow as tf_v1
 from google.protobuf import text_format

--- a/model-optimizer/mo/utils/convert.py
+++ b/model-optimizer/mo/utils/convert.py
@@ -20,6 +20,8 @@ import sys
 
 try:
     import tensorflow.compat.v1 as tf_v1
+    # disable eager execution of TensorFlow 2 environment immediately
+    tf_v1.disable_eager_execution()
 except ImportError:
     import tensorflow as tf_v1
 

--- a/model-optimizer/mo/utils/summarize_graph.py
+++ b/model-optimizer/mo/utils/summarize_graph.py
@@ -22,6 +22,8 @@ import sys
 
 try:
     import tensorflow.compat.v1 as tf_v1
+    # disable eager execution of TensorFlow 2 environment immediately
+    tf_v1.disable_eager_execution()
 except ImportError:
     import tensorflow as tf_v1
 

--- a/model-optimizer/mo/utils/tensorboard_util.py
+++ b/model-optimizer/mo/utils/tensorboard_util.py
@@ -16,6 +16,8 @@
 
 try:
     import tensorflow.compat.v1 as tf_v1
+    # disable eager execution of TensorFlow 2 environment immediately
+    tf_v1.disable_eager_execution()
 except ImportError:
     import tensorflow as tf_v1
 try:


### PR DESCRIPTION
Description: Eager execution of TensorFlow 2 environment must be switched off for model handling that includes using TFv1 API for placeholder creation and saving tensorboard logs

JIRA: 36906 and 35860


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list
* [x]  Supported **public** models list
* [x]  New operations specification
* [x]  Guide on how to convert the **public** model
* [x]  User guide update

Signed-off-by: Roman Kazantsev <roman.kazantsev@intel.com>