### PR TITLE
Fix output name collision for incorrect ONNX models

### DIFF
--- a/model-optimizer/mo/front/onnx/loader.py
+++ b/model-optimizer/mo/front/onnx/loader.py
@@ -85,7 +85,9 @@ def protobuf2nx(graph, pb):
     for outp in pb.graph.output:
         name = str(outp.name)
         if graph.has_node(name):
-            raise Error('Name {} of output node already exists in graph.', name)
+            log.error('Name {} of output node already exists in graph. Ignoring this output. If the output is required,'
+                      ' please rename it.'.format(name), extra={'is_warning': True})
+            continue
         else:
             # add fake node on output
             graph.add_node(name, kind='op', op='FakeOutput', pb=outp)


### PR DESCRIPTION
Description: Fix output name collision for incorrect ONNX models. There is a model that contains two outputs with the same name on the same node, previously the second output was ignored, but after fix for outputs name it produces error.

JIRA: #37325


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py: N/A - no e2e test modifyed
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list: N/A - no new op
* [x]  Supported **public** models list: N/A - no new public model enabled
* [x]  New operations specification: N/A no new operations enabled
* [x]  Guide on how to convert the **public** model: N/A - no new public model enabled
* [x]  User guide update: N/A - not needed