### PR TITLE
[ MO ] Fix for remove_op_node_with_data_node

### DIFF
--- a/model-optimizer/extensions/middle/UselessMerge.py
+++ b/model-optimizer/extensions/middle/UselessMerge.py
@@ -40,5 +40,5 @@ class UselessMergeEraser(MiddleReplacementPattern):
 
     def replace_pattern(self, graph: Graph, match: dict):
         if len(graph.in_edges(match['merge'].id)) <= 1:
-            remove_op_node_with_data_node(graph, match['merge'])
+            remove_op_node_with_data_node(graph, match['merge'], match['merge'].in_nodes()[0])
             log.info("Useles Merge op and data nodes was deleted op='{}'".format(match['merge'].id))

--- a/model-optimizer/extensions/middle/UselessMerge.py
+++ b/model-optimizer/extensions/middle/UselessMerge.py
@@ -40,5 +40,5 @@ class UselessMergeEraser(MiddleReplacementPattern):
 
     def replace_pattern(self, graph: Graph, match: dict):
         if len(graph.in_edges(match['merge'].id)) <= 1:
-            remove_op_node_with_data_node(graph, match['merge'], match['merge'].in_nodes()[0])
+            remove_op_node_with_data_node(graph, match['merge'], list(match['merge'].in_nodes().values())[0])
             log.info("Useles Merge op and data nodes was deleted op='{}'".format(match['merge'].id))

--- a/model-optimizer/mo/middle/passes/eliminate.py
+++ b/model-optimizer/mo/middle/passes/eliminate.py
@@ -217,10 +217,11 @@ def merge_data_nodes(graph, survived, removed):
 
 
 # TODO: unit tests
-def remove_op_node_with_data_node(graph, node_to_remove):
+def remove_op_node_with_data_node(graph, node_to_remove, input_data_node=None):
     from mo.graph.graph import Node
     assert node_to_remove.kind == 'op'
-    input_data_node = node_to_remove.in_node()
+    if input_data_node is None:
+        input_data_node = node_to_remove.in_node()
     output_node = [v for _, v in graph.out_edges(node_to_remove.id)]
     assert len(output_node) == 1, "Cannot remove node producing two or more output tensors"
     output_node = Node(graph, output_node[0])


### PR DESCRIPTION
Description: Merge operation can have one input coming from input port #1. This caused an issue because `remove_op_node_with_data_node` used only #0 input which was missing

NOTE: It is reproducible without --static_shape key only because of lack of Merge operation testing variants. The issue is not connected to KSO/reshape.

JIRA: 37868

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list
* [x]  Supported **public** models list
* [x]  New operations specification
* [x]  Guide on how to convert the **public** model
* [x]  User guide update