### PR TITLE
[IE CLDNN] Fix fused ops data loading in 1x1 conv fsv16 kernel

### DIFF
--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/convolution_gpu_bfyx_f16_1x1.cl
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/convolution_gpu_bfyx_f16_1x1.cl
@@ -207,7 +207,7 @@ KERNEL(convolution_b_fs_yx_fsv16_1x1)(
     else
 #endif
     {
-#if !PADDED_OUTPUT
+#if !PADDED_OUTPUT && !NON_UNIT_FUSED_OP_SPATIAL
         if (xy * X_BLOCK_SIZE + X_BLOCK_SIZE <= OUTPUT_SIZE_X * OUTPUT_SIZE_Y || (OUTPUT_SIZE_X * OUTPUT_SIZE_Y) % X_BLOCK_SIZE == 0) {
 #else
         if (x + X_BLOCK_SIZE <= OUTPUT_SIZE_X || OUTPUT_SIZE_X % X_BLOCK_SIZE == 0) {


### PR DESCRIPTION
This patch is meant to fix fused ops data loading in 1x1 convolution kernel for blocked format. Currently EAST model is failing because of incorrect values produced in this kernel after fused eltwise operation.

JIRA: CVS-34755