### PR TITLE
First time to inference POC

### DIFF
--- a/tests/time_tests/CMakeLists.txt
+++ b/tests/time_tests/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright (C) 2018-2020 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+if(ENABLE_DOCKER)
+    cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
+else()
+    if (APPLE)
+        # due to https://cmake.org/cmake/help/v3.12/policy/CMP0068.html
+        cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+    else()
+        cmake_minimum_required(VERSION 3.7.2 FATAL_ERROR)
+    endif()
+endif()
+
+if (CMAKE_BUILD_TYPE STREQUAL "")
+    message(STATUS "CMAKE_BUILD_TYPE not defined, 'Release' will be used")
+    set(CMAKE_BUILD_TYPE "Release")
+endif()
+
+find_package(InferenceEngineDeveloperPackage REQUIRED)
+
+add_subdirectory(common)

--- a/tests/time_tests/common/CMakeLists.txt
+++ b/tests/time_tests/common/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright (C) 2018-2019 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set (TARGET_NAME "TimeTests")
+
+file (GLOB SRC
+        *.cpp
+        ../ftti_pipeline/*.cpp)
+
+file (GLOB HDR
+        *.h
+        ../ftti_pipeline/*.h)
+
+# Create library file from sources.
+add_executable(${TARGET_NAME} ${HDR} ${SRC})
+
+find_package(gflags REQUIRED)
+
+target_link_libraries(${TARGET_NAME}
+        gflags
+        ${InferenceEngine_LIBRARIES}
+        )

--- a/tests/time_tests/common/cli.h
+++ b/tests/time_tests/common/cli.h
@@ -1,0 +1,49 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <gflags/gflags.h>
+#include <iostream>
+
+/// @brief message for help argument
+static const char help_message[] = "Print a usage message";
+
+/// @brief message for model argument
+static const char model_message[] = "Required. Path to an .xml/.onnx/.prototxt file with a trained model or to a .blob files with a trained compiled model.";
+
+/// @brief message for target device argument
+static const char target_device_message[] = "Required. Specify a target device to infer on. " \
+"Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
+"Use \"-d MULTI:<comma-separated_devices_list>\" format to specify MULTI plugin. " \
+"The application looks for a suitable plugin for the specified device.";
+
+/// @brief Define flag for showing help message <br>
+DEFINE_bool(h, false, help_message);
+
+/// @brief Declare flag for showing help message <br>
+DECLARE_bool(help);
+
+/// @brief Define parameter for set model file <br>
+/// It is a required parameter
+DEFINE_string(m, "", model_message);
+
+/// @brief Define parameter for set target device to infer on <br>
+/// It is a required parameter
+DEFINE_string(d, "", target_device_message);
+
+/**
+* @brief This function show a help message
+*/
+static void showUsage() {
+    std::cout << std::endl;
+    std::cout << "TimeTests [OPTION]" << std::endl;
+    std::cout << "Options:" << std::endl;
+    std::cout << std::endl;
+    std::cout << "    -h, --help                " << help_message << std::endl;
+    std::cout << "    -m \"<path>\"               " << model_message << std::endl;
+    std::cout << "    -d \"<device>\"             " << target_device_message << std::endl;
+}

--- a/tests/time_tests/common/main.cpp
+++ b/tests/time_tests/common/main.cpp
@@ -1,0 +1,38 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "cli.h"
+#include "../ftti_pipeline/ftti_pipeline.h"
+
+#include <iostream>
+
+/**
+* @brief Parses command line and check required arguments
+*/
+bool parseAndCheckCommandLine(int argc, char **argv) {
+    gflags::ParseCommandLineNonHelpFlags(&argc, &argv, true);
+    if (FLAGS_help || FLAGS_h) {
+        showUsage();
+        return false;
+    }
+
+    if (FLAGS_m.empty())
+        throw std::logic_error("Model is required but not set. Please set -m option.");
+
+    if (FLAGS_d.empty())
+        throw std::logic_error("Device is required but not set. Please set -d option.");
+
+    return true;
+}
+
+
+/**
+* @brief Main entry point
+*/
+int main(int argc, char **argv) {
+    if (!parseAndCheckCommandLine(argc, argv))
+        return -1;
+
+    return runPipeline(FLAGS_m, FLAGS_d);
+}

--- a/tests/time_tests/common/timer.h
+++ b/tests/time_tests/common/timer.h
@@ -1,0 +1,45 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <string>
+#include <map>
+#include <chrono>
+#include <fstream>
+#include <memory>
+
+using time_point = std::chrono::high_resolution_clock::time_point;
+
+/**
+* @brief Class response for encapsulating time measurements.
+*
+* Object of a class measures time at start and finish of object's life cycle.
+* When deleting, reports duration.
+*/
+class Timer {
+private:
+    std::string name;
+    time_point start_time;
+
+public:
+    /**
+     * @brief Constructs Timer object and measures start time
+     */
+    Timer(const std::string &timer_name) {
+        name = timer_name;
+        start_time = std::chrono::high_resolution_clock::now();
+    }
+
+    /**
+     * @brief Destructs Timer object, measures duration and reports it
+     */
+    ~Timer(){
+        float duration = std::chrono::duration_cast<std::chrono::microseconds>(
+                std::chrono::high_resolution_clock::now() - start_time).count();
+        std::cout << name << ":" << duration << "\n"; // TODO: replace with writer
+    }
+};
+
+#define SCOPED_TIMER(timer_name) Timer timer_name(#timer_name);

--- a/tests/time_tests/ftti_pipeline/ftti_pipeline.h
+++ b/tests/time_tests/ftti_pipeline/ftti_pipeline.h
@@ -1,0 +1,49 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "../common/timer.h"
+
+#include <inference_engine.hpp>
+using namespace InferenceEngine;
+
+
+/**
+* @brief Function that contain executable pipeline which will be called from main().
+* The function should not throw any exceptions and responsible for handling it by itself.
+*/
+int runPipeline(const std::string &model, const std::string &device) {
+    auto pipeline = [](const std::string &model, const std::string &device){
+        SCOPED_TIMER(first_time_to_inference);
+
+        Core ie;
+        CNNNetwork cnnNetwork;
+        ExecutableNetwork exeNetwork;
+
+        {
+            SCOPED_TIMER(read_network);
+            cnnNetwork = ie.ReadNetwork(model);
+        }
+
+        {
+            SCOPED_TIMER(load_network);
+            ExecutableNetwork exeNetwork = ie.LoadNetwork(cnnNetwork, device);
+        }
+    };
+
+    try {
+        pipeline(model, device);
+    } catch (const InferenceEngine::details::InferenceEngineException& iex) {
+        std::cerr << "Inference Engine pipeline failed with Inference Engine exception:\n" << iex.what();
+        return 1;
+    } catch (const std::exception& ex) {
+        std::cerr << "Inference Engine pipeline failed with exception:\n" << ex.what();
+        return 2;
+    } catch (...) {
+        std::cerr << "Inference Engine pipeline failed\n";
+        return 3;
+    }
+    return 0;
+}


### PR DESCRIPTION
POC for FTTI:
1. CLI contains `-m` and `-d` required arguments.
2. `runPipeline` encapsulates IE pipeline (or any other pipeline) and measures time of a pipeline. According to this design, pipeline.h may be redefined via CMake to generate executables with different pipelines.
3. Also `runPipeline` shouldn't throw exceptions and should handle it by itself
4. For time measurement implemented `Timer` class which measures time at start and finish of object's life cycle. For a correct use of `Timer` need to use `SCOPED_TIMER` macros