### PR TITLE
[MO] Fix when Crop asks for MXNet specific arg --enable_ssd_gluoncv

### DIFF
--- a/model-optimizer/mo/ops/crop.py
+++ b/model-optimizer/mo/ops/crop.py
@@ -164,7 +164,7 @@ class Crop(Op):
         node['dim'] = dim
         node.out_node().shape = new_shape
 
-        if node.in_node(0).has_valid('value') and not node.graph.graph['cmd_params'].enable_ssd_gluoncv:
+        if node.in_node(0).has_valid('value') and not getattr(node.graph.graph['cmd_params'], 'enable_ssd_gluoncv', False):
             out_value = np.copy(node.in_node(0).value)
 
             slice_indexes = []

--- a/model-optimizer/mo/utils/cli_parser.py
+++ b/model-optimizer/mo/utils/cli_parser.py
@@ -614,7 +614,7 @@ def get_onnx_cli_parser(parser: argparse.ArgumentParser = None):
         parser = argparse.ArgumentParser(usage='%(prog)s [options]')
         get_common_cli_parser(parser=parser)
 
-    tf_group = parser.add_argument_group('ONNX*-specific parameters')
+    onnx_group = parser.add_argument_group('ONNX*-specific parameters')
 
     return parser
 


### PR DESCRIPTION
During shape inference on Crop node it asks for a MXNet specific cmd argument `enable_ssd_gluoncv` which is not set when `MO` was executed with framework specific postfix `mo_tf.py, mo_kaldi.py, mo_onnx.py, mo_caffe.py`. Fixed that.

ticket #38036