### PR TITLE
Build cmake from source for Ubuntu 18.04

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -29,10 +29,24 @@ if [ -f /etc/lsb-release ]; then
         x86_64_specific_packages=""
     fi
 
+    [[ "$( cat /etc/os-release | grep VERSION_ID= )" =~ ^VERSION_ID=\"(.*)\"$ ]]
+    DISTRO_VERSION=${BASH_REMATCH[1]}
+
+    # Ubuntu 18.04 provides only cmake 3.10 but >= 3.11 is required
+    if [ $DISTRO_VERSION = 18.04 ]; then
+        wget https://cmake.org/files/v3.12/cmake-3.12.3.tar.gz
+        tar xf cmake-3.12.3.tar.gz
+        cd cmake-3.12.3
+        ./configure
+        make -j16
+        sudo -E make install
+    else
+        sudo -E apt-get install -y cmake
+    fi
+
     sudo -E apt update
     sudo -E apt-get install -y \
             build-essential \
-            cmake \
             curl \
             wget \
             libssl-dev \


### PR DESCRIPTION
Cmake 3.11 is required for [ngraph](https://github.com/openvinotoolkit/openvino/blob/master/ngraph/CMakeLists.txt) but Ubuntu 18.04 provides only cmake in version 3.10.2. This leads to a failure in the build process.

This PR builds cmake from source and installs it when Ubuntu 18.04 is used. The code to download/build cmake was copied from the CentOS 7.x part below in the code. I tested the changes on a clean Ubuntu 18.04 and now it compiles fine.