### PR TITLE
fix for typo in inference_engine/src/inference_engine/CMakeLists.txt

### DIFF
--- a/inference-engine/src/inference_engine/CMakeLists.txt
+++ b/inference-engine/src/inference_engine/CMakeLists.txt
@@ -77,7 +77,7 @@ if(ENABLE_SSE42)
 endif()
 
 if(ENABLE_V7_SERIALIZE)
-    set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/src/cnn_network_ngraph_impl.cpp"
+    set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/cnn_network_ngraph_impl.cpp"
         PROPERTIES COMPILE_DEFINITIONS ENABLE_V7_SERIALIZE)
 endif()
 


### PR DESCRIPTION
Fix for typo in inference_engine/src/inference_engine/CMakeLists.txt, there was wrong path for cpp file in `if(ENABLE_V7_SERIALIZE)`, so adding   `-DENABLE_V7_SERIALIZE=ON` as cmake option wasn't working correctly.