### PR TITLE
[IE CLDNN] Disabled choose_impl call for generic nodes in some cases

### DIFF
--- a/inference-engine/thirdparty/clDNN/src/graph_optimizer/post_optimize_weights.cpp
+++ b/inference-engine/thirdparty/clDNN/src/graph_optimizer/post_optimize_weights.cpp
@@ -64,7 +64,11 @@ void post_optimize_weights::optimize_weights(T& node, program_impl& p) {
             // set generic_layer's node output layout and implementation
             auto& g_node = node.get_dependency(i);
             g_node.get_output_layout(false);
-            g_node.selected_impl = g_node.type()->choose_impl(p.get_engine(), g_node);
+
+            // Don't run impl selection to avoid double compilation of reorder kernels
+            // in main program and internal program for constant propagation
+            if (!g_node.is_constant())
+                g_node.selected_impl = g_node.type()->choose_impl(p.get_engine(), g_node);
         }
     }
 


### PR DESCRIPTION
This patch allows to avoid double compilation of reorder_weights kernels. If choose_impl is called in the main program, then kernels are added into it's sources pool. Then we create internal program for constant propagation and add these kernels once again, thus kernels are are compiled twice. 

Load time measurements with this patch can be found in 32607 ticket