### PR TITLE
Fixed compilation with private plugins

### DIFF
--- a/inference-engine/src/vpu/common/CMakeLists.txt
+++ b/inference-engine/src/vpu/common/CMakeLists.txt
@@ -34,6 +34,7 @@ function(add_common_target TARGET_NAME STATIC_IE)
             "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
     target_include_directories(${TARGET_NAME} SYSTEM PUBLIC
+            $<TARGET_PROPERTY:${NGRAPH_LIBRARIES},INTERFACE_INCLUDE_DIRECTORIES>
             $<TARGET_PROPERTY:inference_engine_plugin_api,INTERFACE_INCLUDE_DIRECTORIES>)
 
     if(WIN32)

--- a/inference-engine/tests_deprecated/functional/ie_tests/include/regression_config.hpp
+++ b/inference-engine/tests_deprecated/functional/ie_tests/include/regression_config.hpp
@@ -120,11 +120,11 @@ struct RegressionConfig {
         bool reset = false;
         bool fetchMore = false;
         bool fetched = true;
-        bool hasResult = true;
         int frameNumber = 0;
+        bool hasResult = true;
         InputFetcherResult() = default;
         InputFetcherResult(bool reset, bool fetchMore=false, bool fetched=true, int frameNumber = 0, bool hasResult = true)
-                : reset(reset), fetchMore(fetchMore), fetched(fetched), hasResult(hasResult) {}
+                : reset(reset), fetchMore(fetchMore), fetched(fetched), frameNumber(frameNumber), hasResult(hasResult) {}
     };
     using input_fetcher = std::function<InputFetcherResult (const InferenceContext & )>;
     using model_maker = std::function<void(const InferenceContext & )>;


### PR DESCRIPTION
Private plugins require compilation with different gcc flags like `-Wall`, so, we need to add ngraph headers as `SYSTEM` not to fail in private plugins.