### PR TITLE
Fix ReduceSum decompose pass

### DIFF
--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/reduce_ops.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/reduce_ops.cpp
@@ -152,4 +152,20 @@ INSTANTIATE_TEST_CASE_P(
         params_ReductionTypes,
         ReduceOpsLayerTest::getTestCaseName
 );
+
+INSTANTIATE_TEST_CASE_P(
+        Reduce,
+        ReduceOpsLayerWithSpecificInputTest,
+        testing::Combine(
+                testing::ValuesIn(decltype(axes) {{0}, {1}}),
+                testing::Values(opTypes[1]),
+                testing::Values(true),
+                testing::Values(ngraph::helpers::ReductionType::Sum),
+                testing::Values(InferenceEngine::Precision::FP32,
+                                InferenceEngine::Precision::I32),
+                testing::Values(std::vector<size_t> {2, 10}),
+                testing::Values(CommonTestUtils::DEVICE_CPU)),
+        ReduceOpsLayerWithSpecificInputTest::getTestCaseName
+);
+
 }  // namespace

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/reduce_ops.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/reduce_ops.hpp
@@ -34,4 +34,9 @@ protected:
     void SetUp() override;
 };
 
+class ReduceOpsLayerWithSpecificInputTest : public ReduceOpsLayerTest {
+protected:
+    InferenceEngine::Blob::Ptr GenerateInput(const InferenceEngine::InputInfo &info) const override;
+};
+
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/reduce_ops.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/reduce_ops.cpp
@@ -80,6 +80,28 @@ void ReduceOpsLayerTest::SetUp() {
 
 TEST_P(ReduceOpsLayerTest, CompareWithRefs) {
     Run();
-};
+}
+
+InferenceEngine::Blob::Ptr ReduceOpsLayerWithSpecificInputTest::GenerateInput(const InferenceEngine::InputInfo &info) const {
+    auto axis_vec = std::get<0>(GetParam());
+    IE_ASSERT(axis_vec.size() == 1);
+
+    auto axis = axis_vec[0];
+    auto td = info.getTensorDesc();
+    auto dims = td.getDims();
+
+    // Slice of tensor through axis is {1, 0, 0, ....}, the mean value is 1/slice_size
+    auto raw_values = std::vector<float>(dims[axis], 0);
+    raw_values[0] = 1;
+
+    auto blob = make_blob_with_precision(td);
+    blob->allocate();
+    CommonTestUtils::fill_data_with_broadcast(blob, axis, raw_values);
+    return blob;
+}
+
+TEST_P(ReduceOpsLayerWithSpecificInputTest, CompareWithRefs) {
+    Run();
+}
 
 }  // namespace LayerTestsDefinitions


### PR DESCRIPTION
**Summary** 
This patch introduce precision fallback into FP32 in case of integer input type.

**Justification**
Originally ReduceSum operation was decomposed as: In -> AvgPool -> Mul -> Out. 
It keeps original precision for all intermediate tensors. In case of integer types AvgPool may drop some information and lead to incorrect output. Example:
* **Input**
  shape [1,1000] 
  values {{ 1, 0, 0 .... 0}}
* **AvgPool**: 
  shape [1,1] 
  value as FP32  {{ 0.001}}
  value as I32  {{ 0 }} <- NB! cast to int drops correctness.
