### PR TITLE
 38009: InterpolateReshape fix for TensorFlow style Concat

### DIFF
--- a/model-optimizer/debug.log
+++ b/model-optimizer/debug.log
@@ -1,2 +1,0 @@
-[0902/132631.549:ERROR:exit_code_watcher_win.cc(87)] Failed to wait for process exit or stop event
-[0902/132632.817:ERROR:registration_protocol_win.cc(131)] TransactNamedPipe: The pipe has been ended. (0x6D)

--- a/model-optimizer/debug.log
+++ b/model-optimizer/debug.log
@@ -1,0 +1,2 @@
+[0902/132631.549:ERROR:exit_code_watcher_win.cc(87)] Failed to wait for process exit or stop event
+[0902/132632.817:ERROR:registration_protocol_win.cc(131)] TransactNamedPipe: The pipe has been ended. (0x6D)

--- a/model-optimizer/extensions/front/interpolate_reshape.py
+++ b/model-optimizer/extensions/front/interpolate_reshape.py
@@ -168,10 +168,6 @@ class InterpolateWithConcat(FrontReplacementPattern):
         interpolate.in_port(1).get_connection().set_source(gather.out_port(0))
 
     def find_and_replace_pattern(self, graph: Graph):
-        import os
-        os.environ["PATH"] += os.pathsep + 'C:/Program Files (x86)/Graphviz2.38/bin/'
-        graph.dump_graph_for_graphviz(save_to_svg=True)
-
         for interpolate in graph.get_op_nodes(type='Interpolate'):
             if interpolate.in_port(1).get_source().node.soft_get('type') != 'Const':
                 continue

--- a/model-optimizer/extensions/front/interpolate_reshape.py
+++ b/model-optimizer/extensions/front/interpolate_reshape.py
@@ -119,10 +119,13 @@ class InterpolateWithConcat(FrontReplacementPattern):
         or through identity operation sequence. Returns the list of Concat sources that satisfy the condition.
         """
         assert concat.soft_get('type') == 'Concat'
-        sources = []
+        sources, ports_to_omit = [], []
+        if concat.has_valid('N'):
+            # TODO: should be removed after Concat operation normalization
+            ports_to_omit.append(concat.N)
 
         for in_port in concat.in_ports().values():
-            if in_port.disconnected():
+            if in_port.disconnected() or in_port.idx in ports_to_omit:
                 continue
             next_node = in_port.get_source().node
             while next_node.soft_get('type') != 'Interpolate' and next_node.has_and_set('identity'):
@@ -165,6 +168,10 @@ class InterpolateWithConcat(FrontReplacementPattern):
         interpolate.in_port(1).get_connection().set_source(gather.out_port(0))
 
     def find_and_replace_pattern(self, graph: Graph):
+        import os
+        os.environ["PATH"] += os.pathsep + 'C:/Program Files (x86)/Graphviz2.38/bin/'
+        graph.dump_graph_for_graphviz(save_to_svg=True)
+
         for interpolate in graph.get_op_nodes(type='Interpolate'):
             if interpolate.in_port(1).get_source().node.soft_get('type') != 'Const':
                 continue


### PR DESCRIPTION
Description: InterpolateReshape pass wasn't taking TF style Concat into account

JIRA: 38009


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list
* [x]  Supported **public** models list
* [x]  New operations specification
* [x]  Guide on how to convert the **public** model
* [x]  User guide update