### PR TITLE
[IE CLDNN] Disable unsupported blocked formats for softmax

### DIFF
--- a/inference-engine/thirdparty/clDNN/src/gpu/softmax_gpu.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/softmax_gpu.cpp
@@ -100,10 +100,6 @@ attach_softmax_gpu::attach_softmax_gpu() {
     implementation_map<softmax>::add(std::make_tuple(engine_types::ocl, data_types::f16, format::byxf), val_fw);
     implementation_map<softmax>::add(std::make_tuple(engine_types::ocl, data_types::f32, format::bfzyx), val_fw);
     implementation_map<softmax>::add(std::make_tuple(engine_types::ocl, data_types::f16, format::bfzyx), val_fw);
-    implementation_map<softmax>::add(std::make_tuple(engine_types::ocl, data_types::f32, format::b_fs_zyx_fsv16), val_fw);
-    implementation_map<softmax>::add(std::make_tuple(engine_types::ocl, data_types::f16, format::b_fs_zyx_fsv16), val_fw);
-    implementation_map<softmax>::add(std::make_tuple(engine_types::ocl, data_types::f32, format::bs_fs_zyx_bsv16_fsv16), val_fw);
-    implementation_map<softmax>::add(std::make_tuple(engine_types::ocl, data_types::f16, format::bs_fs_zyx_bsv16_fsv16), val_fw);
 }
 
 }  // namespace detail


### PR DESCRIPTION
- There's no softmax kernel that can correctly process blocked formats, and these lines leads to accuracy regressions.
JIRA: 38108