### PR TITLE
[IE CLDNN] Fixing blocked format opting for strided_slice

### DIFF
--- a/inference-engine/thirdparty/clDNN/src/program.cpp
+++ b/inference-engine/thirdparty/clDNN/src/program.cpp
@@ -61,6 +61,7 @@
 #include "split_inst.h"
 #include "mvn_inst.h"
 #include "reduce_inst.h"
+#include "strided_slice_inst.h"
 #include "to_string_utils.h"
 #include "gpu/memory_gpu.h"
 
@@ -1168,7 +1169,8 @@ void program_impl::set_layout_optimizer_attributes(layout_optimizer& lo) {
              || prim.as<mvn>().get_primitive()->across_channels) &&
             prim.type() != cldnn::arg_max_min::type_id() &&
             prim.type() != cldnn::mutable_data::type_id() &&
-            prim.type() != cldnn::reduce::type_id())
+            prim.type() != cldnn::reduce::type_id() &&
+            prim.type() != cldnn::strided_slice::type_id())
             can_use_fsv16 = false;
 
         if (prim.type() == cldnn::quantize::type_id() &&


### PR DESCRIPTION
Strided_slice primitive was blocking fsv16 format.

Jira: CVS-33090