### PR TITLE
[MO] Add explicit broadcasting mode

### DIFF
--- a/model-optimizer/mo/ops/broadcast.py
+++ b/model-optimizer/mo/ops/broadcast.py
@@ -18,7 +18,7 @@ from mo.graph.graph import Node, Graph
 from mo.graph.perm_inputs import PermuteInputs
 from mo.ops.op import Op
 from mo.utils.broadcasting import bi_directional_shape_broadcasting, uni_directional_shape_broadcasting, \
-    uni_directional_broadcasting, bi_directional_broadcasting
+    uni_directional_broadcasting, bi_directional_broadcasting, explicit_broadcasting, explicit_shape_broadcasting
 from mo.utils.error import Error
 
 
@@ -28,7 +28,7 @@ class Broadcast(Op):
         Inputs:
             [0] - tensor to be broadcasted
             [1] - shape to be broadcast to
-            [2] - optional axis parameter that which axis are allowed to be broadcasted
+            [2] - optional axes_mapping tensor
     """
 
     op = 'Broadcast'
@@ -69,6 +69,9 @@ class Broadcast(Op):
                 node.out_port(0).data.set_value(uni_directional_broadcasting(input_value, target_shape))
             elif node.mode == 'bidirectional':
                 node.out_port(0).data.set_value(bi_directional_broadcasting(input_value, target_shape))
+            elif node.mode == 'explicit' and node.in_port(2).data.get_value() is not None:
+                axes_mapping = node.in_port(2).data.get_value()
+                node.out_port(0).data.set_value(explicit_broadcasting(input_shape, target_shape, axes_mapping))
             else:
                 raise Error('The node "{}" has unsupported mode "{}"'.format(node_name, node.mode))
         else:
@@ -76,5 +79,8 @@ class Broadcast(Op):
                 node.out_port(0).data.set_shape(uni_directional_shape_broadcasting(input_shape, target_shape))
             elif node.mode == 'bidirectional':
                 node.out_port(0).data.set_shape(bi_directional_shape_broadcasting(input_shape, target_shape))
+            elif node.mode == 'explicit' and node.in_port(2).data.get_value() is not None:
+                axes_mapping = node.in_port(2).data.get_value()
+                node.out_port(0).data.set_shape(explicit_shape_broadcasting(input_shape, target_shape, axes_mapping))
             else:
                 raise Error('The node "{}" has unsupported mode "{}"'.format(node_name, node.mode))

--- a/model-optimizer/mo/ops/broadcast.py
+++ b/model-optimizer/mo/ops/broadcast.py
@@ -70,7 +70,9 @@ class Broadcast(Op):
             elif node.mode == 'bidirectional':
                 node.out_port(0).data.set_value(bi_directional_broadcasting(input_value, target_shape))
             elif node.mode == 'explicit':
-                assert node.in_port(2).data.get_value() is not None, 'Non-constant values for axes_mapping are not supported'
+                axes_mapping = node.in_port(2).data.get_value()
+                assert axes_mapping  is not None, 'Broadcast(mode="explicit") with dynamic axes_mapping input ' \
+                                                  'is not supported. Node: `{}`'.format(node_name)
                 PermuteInputs().set_input_permutation(node.in_node(2), node, 'output:0', 'axis')
                 axes_mapping = node.in_port(2).data.get_value()
                 node.out_port(0).data.set_value(explicit_broadcasting(input_value, target_shape, axes_mapping))
@@ -81,8 +83,12 @@ class Broadcast(Op):
                 node.out_port(0).data.set_shape(uni_directional_shape_broadcasting(input_shape, target_shape))
             elif node.mode == 'bidirectional':
                 node.out_port(0).data.set_shape(bi_directional_shape_broadcasting(input_shape, target_shape))
-            elif node.mode == 'explicit' and node.in_port(2).data.get_value() is not None:
+            elif node.mode == 'explicit':
                 axes_mapping = node.in_port(2).data.get_value()
-                node.out_port(0).data.set_shape(explicit_shape_broadcasting(input_shape, target_shape, axes_mapping))
+                assert axes_mapping is not None, 'Broadcast(mode="explicit") with dynamic axes_mapping input ' \
+                                                 'is not supported. Node: `{}`'.format(node_name)
+                axes_mapping = node.in_port(2).data.get_value()
+                new_shape,_ = explicit_shape_broadcasting(input_shape, target_shape, axes_mapping)
+                node.out_port(0).data.set_shape(new_shape)
             else:
                 raise Error('The node "{}" has unsupported mode "{}"'.format(node_name, node.mode))

--- a/model-optimizer/mo/ops/broadcast.py
+++ b/model-optimizer/mo/ops/broadcast.py
@@ -69,7 +69,9 @@ class Broadcast(Op):
                 node.out_port(0).data.set_value(uni_directional_broadcasting(input_value, target_shape))
             elif node.mode == 'bidirectional':
                 node.out_port(0).data.set_value(bi_directional_broadcasting(input_value, target_shape))
-            elif node.mode == 'explicit' and node.in_port(2).data.get_value() is not None:
+            elif node.mode == 'explicit':
+                assert node.in_port(2).data.get_value() is not None, 'Non-constant values for axes_mapping are not supported'
+                PermuteInputs().set_input_permutation(node.in_node(2), node, 'output:0', 'axis')
                 axes_mapping = node.in_port(2).data.get_value()
                 node.out_port(0).data.set_value(explicit_broadcasting(input_value, target_shape, axes_mapping))
             else:

--- a/model-optimizer/mo/ops/broadcast.py
+++ b/model-optimizer/mo/ops/broadcast.py
@@ -71,7 +71,7 @@ class Broadcast(Op):
                 node.out_port(0).data.set_value(bi_directional_broadcasting(input_value, target_shape))
             elif node.mode == 'explicit' and node.in_port(2).data.get_value() is not None:
                 axes_mapping = node.in_port(2).data.get_value()
-                node.out_port(0).data.set_value(explicit_broadcasting(input_shape, target_shape, axes_mapping))
+                node.out_port(0).data.set_value(explicit_broadcasting(input_value, target_shape, axes_mapping))
             else:
                 raise Error('The node "{}" has unsupported mode "{}"'.format(node_name, node.mode))
         else:

--- a/model-optimizer/mo/ops/broadcast_test.py
+++ b/model-optimizer/mo/ops/broadcast_test.py
@@ -1,0 +1,59 @@
+"""
+ Copyright (C) 2018-2020 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import unittest
+
+import numpy as np
+from generator import generator, generate
+
+from mo.front.common.partial_infer.utils import int64_array
+from mo.graph.graph import Node
+from mo.ops.broadcast import Broadcast
+from mo.utils.unittest.graph import build_graph, valued_const_with_data, regular_op_with_empty_data, \
+    shaped_data
+
+
+@generator
+class BroadcastTest(unittest.TestCase):
+    @generate(*[
+        ([1], [3, 3], [[1, 1, 1], [1, 1, 1], [1, 1, 1]], None, 'numpy', True),
+        ([1], [3, 3], [3, 3], None, 'numpy', False),
+        ([1], [2, 2], [[1, 1]], [0], 'explicit', True),
+        ([1], [2, 2], [1, 2], [0], 'explicit', False),
+    ])
+    def test_broadcast(self, data, target_shape, ref_out, axes_mapping=None, mode='numpy', val_broadcast=True):
+        input = valued_const_with_data('data', int64_array(data)) if val_broadcast else shaped_data('data', int64_array(data))
+        nodes = {
+            **input,
+            **valued_const_with_data('target_shape', int64_array(target_shape)),
+            **regular_op_with_empty_data('broadcast', {'op': 'Broadcast', 'mode': mode}),
+        }
+
+        edges = [('data', 'broadcast'),
+                 ('target_shape', 'broadcast'),
+                 ('broadcast', 'broadcast_d')]
+
+        if axes_mapping is not None:
+            nodes.update(**valued_const_with_data('axes_mapping', int64_array(axes_mapping)))
+            edges.append(('axes_mapping', 'broadcast'))
+        graph = build_graph(nodes, edges)
+
+        broadcast_node = Node(graph, 'broadcast')
+        Broadcast.infer(broadcast_node)
+        if val_broadcast:
+            self.assertTrue(np.array_equal(broadcast_node.out_node().value, np.array(ref_out)))
+        else:
+            self.assertTrue(np.array_equal(broadcast_node.out_node().shape, np.array(ref_out)))

--- a/model-optimizer/mo/ops/broadcast_test.py
+++ b/model-optimizer/mo/ops/broadcast_test.py
@@ -31,8 +31,24 @@ class BroadcastTest(unittest.TestCase):
     @generate(*[
         ([1], [3, 3], [[1, 1, 1], [1, 1, 1], [1, 1, 1]], None, 'numpy', True),
         ([1], [3, 3], [3, 3], None, 'numpy', False),
-        ([1], [2, 2], [[1, 1]], [0], 'explicit', True),
+
+        # shape broadcasting
         ([1], [2, 2], [1, 2], [0], 'explicit', False),
+        ([1, 7], [5, 2, 7, 3], [5, 1, 7, 3], [1, 2], 'explicit', False),
+        ([2, 1, 3], [5, 2, 7, 3], [2, 1, 3, 3], [0, 1, 2], 'explicit', False),
+        ([2, 1, 3], [5, 2, 7, 3], [5, 2, 1, 3], [1, 2, 3], 'explicit', False),
+
+        # value broadcasting
+        ([1], [2, 2], [[1, 1]], [0], 'explicit', True),
+        ([[3, 1]], [2, 7, 3], [[[3, 1]], [[3, 1]]], [1, 2], 'explicit', True),  # ref_shape (2, 1, 2)
+
+        ([[[9, 5, 7]], [[9, 5, 7]]], [2, 2, 7, 3],
+         [[[[9, 5, 7]], [[9, 5, 7]]], [[[9, 5, 7]], [[9, 5, 7]]]],  # ref_out_value
+         [1, 2, 3], 'explicit', True),  # in_shape (2, 1, 3), ref_out_shape (2, 2, 1, 3)
+
+        ([[[9, 5, 7]], [[3, 4, 8]]], [2, 2, 7, 3],
+        [[[[9, 9, 9], [5, 5, 5], [7, 7, 7]]], [[[3, 3, 3], [4, 4, 4], [8, 8, 8]]]],  # ref_out_value
+         [0, 1, 2], 'explicit', True),  # in_shape (2, 1, 3), ref_out_shape (2, 1, 3, 3)
     ])
     def test_broadcast(self, data, target_shape, ref_out, axes_mapping=None, mode='numpy', val_broadcast=True):
         input = valued_const_with_data('data', int64_array(data)) if val_broadcast else shaped_data('data', int64_array(data))

--- a/model-optimizer/mo/ops/broadcast_test.py
+++ b/model-optimizer/mo/ops/broadcast_test.py
@@ -34,6 +34,7 @@ class BroadcastTest(unittest.TestCase):
 
         # shape broadcasting
         ([1], [1, 2], [0], 'explicit'),
+        ([1], [1, 2], [-2], 'explicit'),
         ([1, 7], [5, 1, 7, 3], [1, 2], 'explicit'),
         ([2, 1, 3], [2, 1, 3, 3], [0, 1, 2], 'explicit'),
         ([2, 1, 3], [5, 2, 1, 3], [1, 2, 3], 'explicit'),
@@ -42,6 +43,8 @@ class BroadcastTest(unittest.TestCase):
         ([1], [1, 2], [0], 'explicit', [[1, 1]]),
 
         ([[3, 1]], [2, 1, 2], [1, 2], 'explicit', [[[3, 1]], [[3, 1]]]),  # ref_shape (2, 1, 2)
+
+        ([[3, 1]], [2, 1, 2], [-2, -1], 'explicit', [[[3, 1]], [[3, 1]]]),  # ref_shape (2, 1, 2)
 
         ([[[9, 5, 7]], [[9, 5, 7]]], [2, 2, 1, 3], [1, 2, 3], 'explicit',  # in_shape (2, 1, 3)
          [[[[9, 5, 7]], [[9, 5, 7]]], [[[9, 5, 7]], [[9, 5, 7]]]]),        # ref_out_shape (2, 2, 1, 3)
@@ -52,6 +55,8 @@ class BroadcastTest(unittest.TestCase):
         # negative tests
         ([1], [2, 2], [0], 'explicit', None, True),
         ([1, 7], [5, 2, 7, 3], [1, 2], 'explicit', None, True),
+        ([1, 7], [5, 2, 7, 3], [2, 1], 'explicit', None, True),
+        ([1, 7], [5, 2, 7, 3], [-3, -2], 'explicit', None, True),
     ])
     def test_broadcast(self, data, target_shape, axes_mapping=None, mode='numpy', ref_out=None, test_raising=False):
         if ref_out is not None:

--- a/model-optimizer/mo/ops/broadcast_test.py
+++ b/model-optimizer/mo/ops/broadcast_test.py
@@ -29,29 +29,36 @@ from mo.utils.unittest.graph import build_graph, valued_const_with_data, regular
 @generator
 class BroadcastTest(unittest.TestCase):
     @generate(*[
-        ([1], [3, 3], [[1, 1, 1], [1, 1, 1], [1, 1, 1]], None, 'numpy', True),
-        ([1], [3, 3], [3, 3], None, 'numpy', False),
+        ([1], [3, 3], None, 'numpy', [[1, 1, 1], [1, 1, 1], [1, 1, 1]]),
+        ([1], [3, 3], None, 'numpy'),
 
         # shape broadcasting
-        ([1], [2, 2], [1, 2], [0], 'explicit', False),
-        ([1, 7], [5, 2, 7, 3], [5, 1, 7, 3], [1, 2], 'explicit', False),
-        ([2, 1, 3], [5, 2, 7, 3], [2, 1, 3, 3], [0, 1, 2], 'explicit', False),
-        ([2, 1, 3], [5, 2, 7, 3], [5, 2, 1, 3], [1, 2, 3], 'explicit', False),
+        ([1], [1, 2], [0], 'explicit'),
+        ([1, 7], [5, 1, 7, 3], [1, 2], 'explicit'),
+        ([2, 1, 3], [2, 1, 3, 3], [0, 1, 2], 'explicit'),
+        ([2, 1, 3], [5, 2, 1, 3], [1, 2, 3], 'explicit'),
 
         # value broadcasting
-        ([1], [2, 2], [[1, 1]], [0], 'explicit', True),
-        ([[3, 1]], [2, 7, 3], [[[3, 1]], [[3, 1]]], [1, 2], 'explicit', True),  # ref_shape (2, 1, 2)
+        ([1], [1, 2], [0], 'explicit', [[1, 1]]),
 
-        ([[[9, 5, 7]], [[9, 5, 7]]], [2, 2, 7, 3],
-         [[[[9, 5, 7]], [[9, 5, 7]]], [[[9, 5, 7]], [[9, 5, 7]]]],  # ref_out_value
-         [1, 2, 3], 'explicit', True),  # in_shape (2, 1, 3), ref_out_shape (2, 2, 1, 3)
+        ([[3, 1]], [2, 1, 2], [1, 2], 'explicit', [[[3, 1]], [[3, 1]]]),  # ref_shape (2, 1, 2)
 
-        ([[[9, 5, 7]], [[3, 4, 8]]], [2, 2, 7, 3],
-        [[[[9, 9, 9], [5, 5, 5], [7, 7, 7]]], [[[3, 3, 3], [4, 4, 4], [8, 8, 8]]]],  # ref_out_value
-         [0, 1, 2], 'explicit', True),  # in_shape (2, 1, 3), ref_out_shape (2, 1, 3, 3)
+        ([[[9, 5, 7]], [[9, 5, 7]]], [2, 2, 1, 3], [1, 2, 3], 'explicit',  # in_shape (2, 1, 3)
+         [[[[9, 5, 7]], [[9, 5, 7]]], [[[9, 5, 7]], [[9, 5, 7]]]]),        # ref_out_shape (2, 2, 1, 3)
+
+        ([[[9, 5, 7]], [[3, 4, 8]]], [2, 1, 3, 3], [0, 1, 2], 'explicit',             # in_shape (2, 1, 3)
+         [[[[9, 9, 9], [5, 5, 5], [7, 7, 7]]], [[[3, 3, 3], [4, 4, 4], [8, 8, 8]]]]), # ref_out_shape (2, 1, 3, 3)
+
+        # negative tests
+        ([1], [2, 2], [0], 'explicit', None, True),
+        ([1, 7], [5, 2, 7, 3], [1, 2], 'explicit', None, True),
     ])
-    def test_broadcast(self, data, target_shape, ref_out, axes_mapping=None, mode='numpy', val_broadcast=True):
-        input = valued_const_with_data('data', int64_array(data)) if val_broadcast else shaped_data('data', int64_array(data))
+    def test_broadcast(self, data, target_shape, axes_mapping=None, mode='numpy', ref_out=None, test_raising=False):
+        if ref_out is not None:
+            input = valued_const_with_data('data', int64_array(data))
+        else:
+            input = shaped_data('data', int64_array(data))
+
         nodes = {
             **input,
             **valued_const_with_data('target_shape', int64_array(target_shape)),
@@ -68,8 +75,12 @@ class BroadcastTest(unittest.TestCase):
         graph = build_graph(nodes, edges)
 
         broadcast_node = Node(graph, 'broadcast')
+        if test_raising:
+            self.assertRaises(AssertionError, Broadcast.infer, broadcast_node)
+            return
+
         Broadcast.infer(broadcast_node)
-        if val_broadcast:
+        if ref_out is not None:
             self.assertTrue(np.array_equal(broadcast_node.out_node().value, np.array(ref_out)))
         else:
-            self.assertTrue(np.array_equal(broadcast_node.out_node().shape, np.array(ref_out)))
+            self.assertTrue(np.array_equal(broadcast_node.out_node().shape, np.array(target_shape)))

--- a/model-optimizer/mo/utils/broadcasting.py
+++ b/model-optimizer/mo/utils/broadcasting.py
@@ -79,6 +79,23 @@ def bi_directional_shape_broadcasting(input_shape_1: np.array, input_shape_2: np
     return np.maximum(shape_1, shape_2)
 
 
+def explicit_shape_broadcasting(input_shape: np.array, target_shape: np.array, axes_mapping: np.array) -> np.array:
+    """
+    Explicit shape broadcasting of input tensor. Resulting shape is equal to target_shape except for axes specified in axes_mapping
+    :param input_value: input value to broadcast
+    :param target_shape: target shape
+    :param axes_mapping: a list of axis indices, each index maps an axis from the input_value to axis in the output
+    :return: broadcasted shape
+    """
+    assert np.all(np.diff(axes_mapping) >= 0), "axes_mapping is not sorted"
+
+    res = target_shape.copy()
+    for i, axis in enumerate(axes_mapping):
+        assert axis < len(res), "axis value from axes_mapping exceeds rank of target_shape"
+        res[axis] = input_shape[i]
+    return res
+
+
 def uni_directional_broadcasting(input_value: np.array, target_shape: np.array):
     """
     Uni-directional broadcasting of input tensor to target shape following the numpy semantic
@@ -103,3 +120,18 @@ def bi_directional_broadcasting(input_value: np.array, second_shape: np.array):
         'The tensor of shape "{}" cannot be bi-directionally broadcasted to shape "{}"'.format(input_value.shape,
                                                                                                second_shape)
     return np.array(input_value * np.ones(second_shape), dtype=input_value.dtype)
+
+
+def explicit_broadcasting(input_value: np.array, target_shape: np.array, axes_mapping: np.array) -> np.array:
+    """
+    Explicit broadcasting of input tensor. Resulting shape is equal to target_shape except for axes specified in axes_mapping
+    :param input_value: input value to broadcast
+    :param target_shape: target shape
+    :param axes_mapping: a list of axis indices, each index maps an axis from the input_value to axis in the output
+    :return: broadcasted value
+    """
+    res_shape = explicit_shape_broadcasting(input_value, target_shape, axes_mapping)
+    expand_dim_axis = set(np.arange(len(target_shape))) - set(axes_mapping)
+
+    input_expanded = np.expand_dims(input_value.copy(), axis=list(expand_dim_axis))
+    return np.broadcast_to(input_expanded, res_shape)

--- a/model-optimizer/mo/utils/broadcasting.py
+++ b/model-optimizer/mo/utils/broadcasting.py
@@ -133,6 +133,7 @@ def explicit_broadcasting(input_value: np.array, target_shape: np.array, axes_ma
     :return: broadcasted value
     """
     res_shape = explicit_shape_broadcasting(input_value.shape, target_shape, axes_mapping)
+    axes_mapping = map(lambda axis: axis + len(target_shape) if axis < 0 else axis, axes_mapping)
     expand_dim_axis = set(np.arange(len(target_shape))) - set(axes_mapping)
 
     input_expanded = np.expand_dims(input_value.copy(), axis=list(expand_dim_axis))

--- a/model-optimizer/mo/utils/broadcasting.py
+++ b/model-optimizer/mo/utils/broadcasting.py
@@ -81,19 +81,20 @@ def bi_directional_shape_broadcasting(input_shape_1: np.array, input_shape_2: np
 
 def explicit_shape_broadcasting(input_shape: np.array, target_shape: np.array, axes_mapping: np.array) -> np.array:
     """
-    Explicit shape broadcasting of input tensor. Resulting shape is equal to target_shape except for axes specified in axes_mapping
+    Explicit shape broadcasting of input tensor. Function only asserts that values are correct.
+    Resulting shape is equal to target_shape.
     :param input_value: input value to broadcast
     :param target_shape: target shape
     :param axes_mapping: a list of axis indices, each index maps an axis from the input_value to axis in the output
     :return: broadcasted shape
     """
     assert np.all(np.diff(axes_mapping) >= 0), "axes_mapping is not sorted"
-    assert axes_mapping == input_shape, "size of axes_mapping does not match to rank of input"
+    assert len(axes_mapping) == len(input_shape), "size of axes_mapping does not match to rank of input"
 
     res = target_shape.copy()
     for i, axis in enumerate(axes_mapping):
         assert axis < len(res), "axis value from axes_mapping exceeds rank of target_shape"
-        res[axis] = input_shape[i]
+        assert res[axis] == input_shape[i], "specified mapping axis in target_shape differs from axis in input_shape"
     return res
 
 

--- a/model-optimizer/mo/utils/broadcasting.py
+++ b/model-optimizer/mo/utils/broadcasting.py
@@ -88,6 +88,7 @@ def explicit_shape_broadcasting(input_shape: np.array, target_shape: np.array, a
     :return: broadcasted shape
     """
     assert np.all(np.diff(axes_mapping) >= 0), "axes_mapping is not sorted"
+    assert axes_mapping == input_shape, "size of axes_mapping does not match to rank of input"
 
     res = target_shape.copy()
     for i, axis in enumerate(axes_mapping):
@@ -130,7 +131,7 @@ def explicit_broadcasting(input_value: np.array, target_shape: np.array, axes_ma
     :param axes_mapping: a list of axis indices, each index maps an axis from the input_value to axis in the output
     :return: broadcasted value
     """
-    res_shape = explicit_shape_broadcasting(input_value, target_shape, axes_mapping)
+    res_shape = explicit_shape_broadcasting(input_value.shape, target_shape, axes_mapping)
     expand_dim_axis = set(np.arange(len(target_shape))) - set(axes_mapping)
 
     input_expanded = np.expand_dims(input_value.copy(), axis=list(expand_dim_axis))

--- a/model-optimizer/mo/utils/broadcasting.py
+++ b/model-optimizer/mo/utils/broadcasting.py
@@ -90,7 +90,7 @@ def explicit_shape_broadcasting(input_shape: np.array, target_shape: np.array, a
     """
     assert np.all(np.diff(axes_mapping) >= 0), "axes_mapping is not sorted"
     assert len(axes_mapping) == len(input_shape), "size of axes_mapping does not match to rank of input"
-    axes_mapping = np.array([*map(lambda axis: axis + len(target_shape) if axis < 0 else axis, axes_mapping)])
+    axes_mapping = np.array(list(map(lambda axis: axis + len(target_shape) if axis < 0 else axis, axes_mapping)))
 
     res = target_shape.copy()
     for i, axis in enumerate(axes_mapping):


### PR DESCRIPTION
Description: Added explicit broadcasting mode support to MO

Ticket: #35706

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR: N/A -- no new transformations were added
* [x]  Transformation preserves original framework node names: N/A -- because no transformation were added

Validation:
* [x]  Unit tests:
* [x]  Framework operation tests: N/A -- no new operations were added
* [x]  Transformation tests: N/A -- no new transformations were added
* [x]  e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py: N/A
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list: N/A
* [x]  Supported **public** models list: N/A
* [x]  New operations specification: N/A
* [x]  Guide on how to convert the **public** model: N/A
* [x]  User guide update: N/A