### PR TITLE
Support python 3.8 by the Model Optimizer tool in default configuration

### DIFF
--- a/model-optimizer/mo/utils/versions_checker.py
+++ b/model-optimizer/mo/utils/versions_checker.py
@@ -44,7 +44,7 @@ def check_python_version():
         return 1
 
 
-def parse_versions_list(required_fw_versions, version_list, env_params=dict()):
+def parse_versions_list(required_fw_versions, version_list, env_params):
     """
     Please do not add parameter type annotations (param:type).
     Because we import this file while checking Python version.
@@ -121,7 +121,7 @@ def parse_versions_list(required_fw_versions, version_list, env_params=dict()):
     return version_list
 
 
-def get_module_version_list_from_file(file_name, env_params=dict()):
+def get_module_version_list_from_file(file_name, env_params):
     """
     Please do not add parameter type annotations (param:type).
     Because we import this file while checking Python version.
@@ -187,17 +187,16 @@ def version_check(name, installed_v, required_v, sign, not_satisfied_v, exit_cod
     return exit_code
 
 
-def get_environment_variables():
+def get_environment_setup():
     """
+    Get environment setup such as python version
     Checks if installed modules versions satisfy required versions in requirements file
     :return: a dictionary of environment variables
     """
     env_params = dict()
-    exec("import sys")
     python_version = "{}.{}.{}".format(sys.version_info.major,
                                        sys.version_info.minor,
                                        sys.version_info.micro)
-    exec("del sys")
     env_params['python_version'] = python_version
     return env_params
 
@@ -220,20 +219,19 @@ def check_requirements(framework=None):
         try:
             exec("import tensorflow")
             tf_version = sys.modules["tensorflow"].__version__
-            if tf_version < "2.0.0":
+            if tf_version < LooseVersion("2.0.0"):
                 framework_suffix = "_tf"
             else:
                 framework_suffix = "_tf2"
             exec("del tensorflow")
-        except ImportError:
-            log.error("TensorFlow is not installed.")
-            return 1
+        except (AttributeError, ImportError):
+            framework_suffix = "_tf"
     else:
         framework_suffix = "_{}".format(framework)
 
     file_name = "requirements{}.txt".format(framework_suffix)
     requirements_file = os.path.realpath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, file_name))
-    env_params = get_environment_variables()
+    env_params = get_environment_setup()
     requirements_list = get_module_version_list_from_file(requirements_file, env_params)
     not_satisfied_versions = []
     exit_code = 0

--- a/model-optimizer/mo/utils/versions_checker_test.py
+++ b/model-optimizer/mo/utils/versions_checker_test.py
@@ -18,7 +18,7 @@ import unittest
 import unittest.mock as mock
 from unittest.mock import mock_open
 
-from mo.utils.versions_checker import get_module_version_list_from_file, parse_versions_list
+from mo.utils.versions_checker import get_module_version_list_from_file, parse_and_filter_versions_list
 
 
 class TestingVersionsChecker(unittest.TestCase):
@@ -82,7 +82,7 @@ class TestingVersionsChecker(unittest.TestCase):
     def test_append_version_list(self):
         v1 = 'mxnet>=1.0.0,<=1.3.1'
         req_list = list()
-        parse_versions_list(v1, req_list, {})
+        parse_and_filter_versions_list(v1, req_list, {})
         ref_list = [('mxnet', '>=', '1.0.0'),
                     ('mxnet', '<=', '1.3.1')]
         for i, v in enumerate(req_list):

--- a/model-optimizer/mo/utils/versions_checker_test.py
+++ b/model-optimizer/mo/utils/versions_checker_test.py
@@ -30,7 +30,7 @@ class TestingVersionsChecker(unittest.TestCase):
         ref_list =[('mxnet', '>=', '1.0.0'), ('mxnet', '<=', '1.3.1'),
                           ('networkx', '>=', '1.11'),
                           ('numpy', '==', '1.12.0'), ('defusedxml', '<=', '0.5.0')]
-        version_list = get_module_version_list_from_file('mock_file')
+        version_list = get_module_version_list_from_file('mock_file', {})
         self.assertEqual(len(version_list), 5)
         for i, version_dict in enumerate(version_list):
             self.assertTupleEqual(ref_list[i], version_dict)
@@ -74,7 +74,7 @@ class TestingVersionsChecker(unittest.TestCase):
         mock_open.return_value.__iter__ = mock.Mock(
             return_value=iter(['mxnet']))
         ref_list = [('mxnet', None, None)]
-        version_list = get_module_version_list_from_file('mock_file')
+        version_list = get_module_version_list_from_file('mock_file', {})
         self.assertEqual(len(version_list), 1)
         for i, version_dict in enumerate(version_list):
             self.assertTupleEqual(ref_list[i], version_dict)
@@ -82,7 +82,7 @@ class TestingVersionsChecker(unittest.TestCase):
     def test_append_version_list(self):
         v1 = 'mxnet>=1.0.0,<=1.3.1'
         req_list = list()
-        parse_versions_list(v1, req_list)
+        parse_versions_list(v1, req_list, {})
         ref_list = [('mxnet', '>=', '1.0.0'),
                     ('mxnet', '<=', '1.3.1')]
         for i, v in enumerate(req_list):

--- a/model-optimizer/mo/utils/versions_checker_test.py
+++ b/model-optimizer/mo/utils/versions_checker_test.py
@@ -36,6 +36,39 @@ class TestingVersionsChecker(unittest.TestCase):
             self.assertTupleEqual(ref_list[i], version_dict)
 
     @mock.patch('builtins.open', new_callable=mock_open, create=True)
+    def test_get_module_version_list_from_file2(self, mock_open):
+        mock_open.return_value.__enter__ = mock_open
+        mock_open.return_value.__iter__ = mock.Mock(
+            return_value=iter(['tensorflow>=1.15.2,<2.0; python_version < "3.8"',
+                               'tensorflow>=2.0; python_version >= "3.8"',
+                               'numpy==1.12.0',
+                               'defusedxml<=0.5.0']))
+        ref_list =[('tensorflow', '>=', '1.15.2'),
+                   ('tensorflow', '<', '2.0'),
+                   ('numpy', '==', '1.12.0'),
+                   ('defusedxml', '<=', '0.5.0')]
+        version_list = get_module_version_list_from_file('mock_file', {'python_version': '3.7.0'})
+        self.assertEqual(len(version_list), 4)
+        for i, version_dict in enumerate(version_list):
+            self.assertTupleEqual(ref_list[i], version_dict)
+
+    @mock.patch('builtins.open', new_callable=mock_open, create=True)
+    def test_get_module_version_list_from_file3(self, mock_open):
+        mock_open.return_value.__enter__ = mock_open
+        mock_open.return_value.__iter__ = mock.Mock(
+            return_value=iter(['tensorflow>=1.15.2,<2.0; python_version < "3.8"',
+                               'tensorflow>=2.0; python_version >= "3.8"',
+                               'numpy==1.12.0',
+                               'defusedxml<=0.5.0']))
+        ref_list =[('tensorflow', '>=', '2.0'),
+                   ('numpy', '==', '1.12.0'),
+                   ('defusedxml', '<=', '0.5.0')]
+        version_list = get_module_version_list_from_file('mock_file', {'python_version': '3.8.1'})
+        self.assertEqual(len(version_list), 3)
+        for i, version_dict in enumerate(version_list):
+            self.assertTupleEqual(ref_list[i], version_dict)
+
+    @mock.patch('builtins.open', new_callable=mock_open, create=True)
     def test_get_module_version_list_from_file_with_fw_name(self, mock_open):
         mock_open.return_value.__enter__ = mock_open
         mock_open.return_value.__iter__ = mock.Mock(

--- a/model-optimizer/requirements.txt
+++ b/model-optimizer/requirements.txt
@@ -1,4 +1,5 @@
-tensorflow>=1.15.2,<2.0
+tensorflow>=1.15.2,<2.0; python_version < "3.8"
+tensorflow>=2.0; python_version >= "3.8"
 mxnet>=1.0.0,<=1.5.1
 networkx>=1.11
 numpy>=1.13.0

--- a/model-optimizer/requirements_tf.txt
+++ b/model-optimizer/requirements_tf.txt
@@ -1,4 +1,5 @@
-tensorflow>=1.15.2,<2.0
+tensorflow>=1.15.2,<2.0; python_version < "3.8"
+tensorflow>=2.0; python_version >= "3.8"
 networkx>=1.11
 numpy>=1.13.0
 test-generator==0.1.1


### PR DESCRIPTION
Description: This change makes the MO tool to support python 3.8 in default configuration

JIRA: 38049


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR - N/A
* [x]  Transformation preserves original framework node names - N/A


Validation:
* [x]  Unit tests
* [x]  Framework operation tests - N/A
* [x]  Transformation tests - N/A
* [x]  e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py - N/A
* [x]  Model Optimizer IR Reader check - N/A

Documentation:
* [x]  Supported frameworks operations list - N/A
* [x]  Supported **public** models list - N/A
* [x]  New operations specification - N/A
* [x]  Guide on how to convert the **public** model - N/A
* [x]  User guide update - N/A

Signed-off-by: Roman Kazantsev <roman.kazantsev@intel.com>