### PR TITLE
[IE][Tests]: Fixes dangling reference access in nGraph function c…

### DIFF
--- a/inference-engine/tests/ngraph_functions/src/utils/ngraph_helpers.cpp
+++ b/inference-engine/tests/ngraph_functions/src/utils/ngraph_helpers.cpp
@@ -211,9 +211,8 @@ void CompareFunctions(const Function& actual, const Function& expected) {
     std::queue<ComparingNodesPair> nodes;
     nodes.emplace(actualResult, expectedResult);
     while (!nodes.empty()) {
-        const auto& checkingNodes = nodes.front();
-        const auto& actualNode    = checkingNodes.first;
-        const auto& expectedNode  = checkingNodes.second;
+        const auto actualNode   = nodes.front().first;
+        const auto expectedNode = nodes.front().second;
         nodes.pop();
 
         CompareNodes(*actualNode, *expectedNode);


### PR DESCRIPTION
# Task

#-38517

# Description

```cpp
const auto& checkingNodes = nodes.front();
const auto& actualNode    = checkingNodes.first;  // here we save a reference to front element in container
const auto& expectedNode  = checkingNodes.second; // here we save a reference to front element in container
nodes.pop();                                      // remove front element from container - invalidates all references to it (checkingNodes, actualNode, expectedNode)
CompareNodes(*actualNode, *expectedNode);         // dangling reference access - Undefined Behavior

// correct version
const auto actualNode   = nodes.front().first;    // here we copy from front element in container (it's possible to move here as optimization)
const auto expectedNode = nodes.front().second;   // here we copy from front element in container (it's possible to move here as optimization)
nodes.pop();                                      // remove front element from container - invalidates all references to it
CompareNodes(*actualNode, *expectedNode);         // OK
```