### PR TITLE
[IE][VPU] ROIAlign: 2 stages pipeline (repacking + ROIAlign)

### DIFF
--- a/inference-engine/cmake/vpu_dependencies.cmake
+++ b/inference-engine/cmake/vpu_dependencies.cmake
@@ -19,7 +19,7 @@ set(VPU_SUPPORTED_FIRMWARES usb-ma2450 usb-ma2x8x pcie-ma248x)
 # Default packages
 #
 
-set(FIRMWARE_PACKAGE_VERSION 1378)
+set(FIRMWARE_PACKAGE_VERSION 1388)
 set(VPU_CLC_MA2X8X_VERSION "movi-cltools-20.09.1")
 
 #

--- a/inference-engine/tests_deprecated/functional/vpu/common/layers/myriad_layers_roi_align_test.cpp
+++ b/inference-engine/tests_deprecated/functional/vpu/common/layers/myriad_layers_roi_align_test.cpp
@@ -11,3 +11,11 @@ INSTANTIATE_TEST_CASE_P(accuracy, myriadLayersTestsROIAlign_smoke,
         ::testing::ValuesIn(s_ROIAlignNumROIs),
         ::testing::ValuesIn(s_ROIAlignMode)),
 );
+
+INSTANTIATE_TEST_CASE_P(accuracy_faster, myriadLayersTestsROIAlign_smoke,
+    ::testing::Combine(
+        ::testing::ValuesIn(s_ROIAlignLayerInput_Faster),
+        ::testing::ValuesIn(s_ROIAlignLayerParam_Faster),
+        ::testing::ValuesIn(s_ROIAlignNumROIs_Faster),
+        ::testing::ValuesIn(s_ROIAlignMode_Faster)),
+);

--- a/inference-engine/tests_deprecated/functional/vpu/common/layers/myriad_layers_roi_align_test.hpp
+++ b/inference-engine/tests_deprecated/functional/vpu/common/layers/myriad_layers_roi_align_test.hpp
@@ -243,16 +243,26 @@ TEST_P(myriadLayersTestsROIAlign_smoke, ROIAlign) {
 static std::vector<Dims> s_ROIAlignLayerInput = {
     {{5, 256, 160, 157}},
 };
-
 static std::vector<roi_align_param> s_ROIAlignLayerParam = {
     {{640, 640, 7, 9, 2, 1.4f}},
 };
-
 static std::vector<number_rois> s_ROIAlignNumROIs = {
     53
 };
-
 static std::vector<roi_align_mode> s_ROIAlignMode = {
-        std::string("avg"),
-        std::string("max")
+    std::string("avg"),
+    std::string("max")
+};
+
+static std::vector<Dims> s_ROIAlignLayerInput_Faster = {
+    {{1, 256, 200, 257}},
+};
+static std::vector<roi_align_param> s_ROIAlignLayerParam_Faster = {
+    {{640, 640, 7, 7, 2, 0.25f}},
+};
+static std::vector<number_rois> s_ROIAlignNumROIs_Faster = {
+    750
+};
+static std::vector<roi_align_mode> s_ROIAlignMode_Faster = {
+    std::string("avg")
 };


### PR DESCRIPTION
[IE][VPU]: Enables ROIAlign data repacking in a separate stage to enable Faster R-CNN on ma2485
- 38280