### PR TITLE
Clang compilation error fix for Linux

### DIFF
--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/bfloat16_helpers.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/bfloat16_helpers.hpp
@@ -51,7 +51,7 @@ public:
     static float getMaxAbsValue(const float* data, size_t size) {
         float maxVal = 0.f;
         for (size_t i = 0; i < size; i++) {
-            if (fabs(data[i] > maxVal)) {
+            if (fabs(data[i]) > maxVal) {
                 maxVal = fabs(data[i]);
             }
         }

--- a/inference-engine/tests_deprecated/helpers/tests_common_func.cpp
+++ b/inference-engine/tests_deprecated/helpers/tests_common_func.cpp
@@ -255,7 +255,7 @@ bool TestsCommonFunc::compareTop(
 #endif
 
         for (size_t i = 0; i < blob.size(); ++i) {
-            if (abs(ref_top[i].second - buffer[i]) > threshold) {
+            if (std::abs(ref_top[i].second - buffer[i]) > threshold) {
                 return false;
             }
         }


### PR DESCRIPTION
The fix in bfloat16 helpers is actually a compiler error fix but also a bugfix - the closing parenthesis was in a wrong place and the function (which is currently unused) worked incorrectly. The other file just caused a warning that is treated as an error by clang on Linux.