### PR TITLE
[Custom CL] Fix binary convolution 3x3 kernel

### DIFF
--- a/inference-engine/cmake/vpu_dependencies.cmake
+++ b/inference-engine/cmake/vpu_dependencies.cmake
@@ -191,7 +191,7 @@ function(add_vpu_compile_custom_kernels)
                     "SHAVE_MA2X8XLIBS_DIR=${VPU_CLC_MA2X8X}/lib"
                     "SHAVE_MOVIASM_DIR=${VPU_CLC_MA2X8X}/bin"
                     "SHAVE_MYRIAD_LD_DIR=${VPU_CLC_MA2X8X}/bin"
-                ${VPU_CLC_MA2X8X_COMMAND} --strip-binary-header ${cl_file} -o ${out_file}
+                ${VPU_CLC_MA2X8X_COMMAND} --strip-binary-header -w ${cl_file} -o ${out_file}
             MAIN_DEPENDENCY ${cl_file}
             DEPENDS ${VPU_CLC_MA2X8X_COMMAND}
             COMMENT "[VPU] Compile ${cl_file}"

--- a/inference-engine/src/vpu/custom_kernels/binary_convolution3x3.cl
+++ b/inference-engine/src/vpu/custom_kernels/binary_convolution3x3.cl
@@ -53,7 +53,7 @@ __kernel void binary_convolution(
             DH * IW - IW, // src_line_stride
             0, // dst_line_stride
             IC / GC, // num planes
-            IH * IW - 3 * IW, // src plane stride
+            IH * IW - 3 * DH * IW, // src plane stride
             0, // dst plane stride
             0);
         wait_group_events(1, &e);

--- a/inference-engine/tests_deprecated/functional/vpu/common/layers/myriad_layers_custom_test.hpp
+++ b/inference-engine/tests_deprecated/functional/vpu/common/layers/myriad_layers_custom_test.hpp
@@ -1057,10 +1057,6 @@ TEST_P(myriadLayersTestsBinaryConvolution_smoke, BinaryConvolution) {
     }
     _config[InferenceEngine::MYRIAD_CUSTOM_LAYERS] = customConfig;
 
-    if (kernel.x == 3 && kernel.y == 3 && dilations == 2) {
-        GTEST_SKIP() << "Computing wrong after hoisting";
-    }
-
     SetInputTensor(dims);
     auto dimsOutput = dims;
     dimsOutput.h = (dims.h) / strides;


### PR DESCRIPTION
Fixes 3D transaction in binary_convolution.cl kernel.
Pass -w argument to OCL compiler to mute warnings, currently ignored by compiler.