### PR TITLE
Add dlclose hook

### DIFF
--- a/inference-engine/tests/CMakeLists.txt
+++ b/inference-engine/tests/CMakeLists.txt
@@ -21,3 +21,7 @@ endif()
 if (ENABLE_FUNCTIONAL_TESTS)
     add_subdirectory(functional)
 endif()
+
+if (NOT WIN32 AND (ENABLE_SANITIZER OR ENABLE_THREAD_SANITIZER))
+    add_subdirectory(sanitizer/dlclose_hook)
+endif()

--- a/inference-engine/tests/sanitizer/dlclose_hook/CMakeLists.txt
+++ b/inference-engine/tests/sanitizer/dlclose_hook/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (C) 2018-2020 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set (TARGET_NAME "dlclose_hook")
+
+file (GLOB SRC ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
+
+add_library(${TARGET_NAME} SHARED ${SRC})

--- a/inference-engine/tests/sanitizer/dlclose_hook/dlclose_hook.c
+++ b/inference-engine/tests/sanitizer/dlclose_hook/dlclose_hook.c
@@ -1,0 +1,5 @@
+// Copyright (C) 2018-2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+int dlclose(void *ptr) { return 0; }


### PR DESCRIPTION
OpenVINO on plugin unloading ruins the symbols in the
sanitizer stack trace. The solution is to ensure shared libraries
is kept loaded untill the app termination.

When running with sanitizer one can LD_PRELOAD dlclose_hook
library which prevents plugins to be unloaded.