### PR TITLE
Decreased default NMS threshold for RetinaNet model conversion

### DIFF
--- a/model-optimizer/extensions/front/tf/retinanet.json
+++ b/model-optimizer/extensions/front/tf/retinanet.json
@@ -7,7 +7,7 @@
             "confidence_threshold": 0.05,
             "top_k": 6000,
             "keep_top_k": 300,
-            "nms_threshold": 0.5,
+            "nms_threshold": 0.05,
             "variance": [0.2, 0.2, 0.2, 0.2]
         },
         "include_inputs_to_sub_graph": true,


### PR DESCRIPTION
Ticket 34761.
Decrease NMS threshold for the Detection Output to filter out predictions with probability less than 0.05 instead of 0.5.