### PR TITLE
[IE CLDNN] Memory allocation optimizations

### DIFF
--- a/inference-engine/thirdparty/clDNN/api/layout.hpp
+++ b/inference-engine/thirdparty/clDNN/api/layout.hpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2016-2019 Intel Corporation
+// Copyright (c) 2016-2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -406,6 +406,26 @@ struct layout {
             sizes[1] = align_to(sizes[1], 32);
         } else if (this->format == cldnn::format::image_2d_rgba) {
             sizes[1] = 4;
+        } else if (this->format == cldnn::format::gs_oi_yxs_gsv4_yxsv4 ||
+                   this->format == cldnn::format::gs_oi_yxs_gsv16_yxsv4 ||
+                   this->format == cldnn::format::gs_oi_yxs_gsv32_yxsv4) {
+            sizes[3] = align_to(sizes[2] * sizes[3], 4);
+            sizes[2] = 1;
+        } else if (this->format == cldnn::format::os_iyx_osv32__ai32 && !is_aligned_to(sizes[1], 32)) {
+            sizes[1] = align_to(sizes[1], 32);
+        } else if ((this->format == cldnn::format::iy_xs_os_xsv2_osv8__ao32 ||
+                    this->format == cldnn::format::iy_xs_os_xsv2_osv16__ao32 ||
+                    this->format == cldnn::format::giy_xs_os_xsv2_osv8__ao32 ||
+                    this->format == cldnn::format::giy_xs_os_xsv2_osv16__ao32) && !is_aligned_to(sizes[0], 32))  {
+            sizes[0] = align_to(sizes[0], 32);
+            sizes[3] = align_to(sizes[2] * sizes[3], 2);
+            sizes[2] = 1;
+        } else if (this->format == cldnn::format::i_yxs_os_yxsv2_osv16 || this->format == cldnn::format::gi_yxs_os_yxsv2_osv16) {
+            sizes[3] = align_to(sizes[2] * sizes[3], 2);
+            sizes[2] = 1;
+        } else if (this->format == cldnn::format::os_i_yxs_osv4_yxsv4) {
+            sizes[3] = align_to(sizes[2] * sizes[3], 4);
+            sizes[2] = 1;
         }
         size_t total = std::accumulate(
             sizes.begin(),

--- a/inference-engine/thirdparty/clDNN/src/gpu/memory_gpu.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/memory_gpu.cpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2016 Intel Corporation
+// Copyright (c) 2016-2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ gpu_buffer::gpu_buffer(const refcounted_obj_ptr<engine_impl>& engine,
                        bool reset)
     : lockable_gpu_mem(engine), memory_impl(engine, layout, net_id, allocation_type::cl_mem, false),
       _buffer(_context->context(), CL_MEM_READ_WRITE, size()) {
-    if (reset) zero_buffer();
+    if (reset && is_memory_reset_needed(_layout)) zero_buffer();
 }
 
 gpu_buffer::gpu_buffer(const refcounted_obj_ptr<engine_impl>& engine,
@@ -256,7 +256,7 @@ gpu_usm::gpu_usm(const refcounted_obj_ptr<engine_impl>& engine, const layout& la
             "Unknown unified shared memory type!");
     }
 
-    if (reset) zero_buffer();
+    if (reset && is_memory_reset_needed(_layout)) zero_buffer();
 }
 
 void* gpu_usm::lock() {

--- a/inference-engine/thirdparty/clDNN/src/kernel_selector_helper.cpp
+++ b/inference-engine/thirdparty/clDNN/src/kernel_selector_helper.cpp
@@ -343,13 +343,15 @@ cldnn::format::type from_weights_layout(kernel_selector::weights_layout l) {
         case kernel_selector::weights_layout::oyxi:
             return cldnn::format::byxf;
         case kernel_selector::weights_layout::io:
-            return cldnn::format::fyxb;
+            return cldnn::format::iyxo;
         case kernel_selector::weights_layout::iyxo:
-            return cldnn::format::fyxb;
+            return cldnn::format::iyxo;
         case kernel_selector::weights_layout::yxio:
             return cldnn::format::yxfb;
         case kernel_selector::weights_layout::os_iyx_osv16:
             return cldnn::format::os_iyx_osv16;
+        case kernel_selector::weights_layout::os_is_yx_isv16_osv16:
+            return cldnn::format::os_is_yx_isv16_osv16;
         case kernel_selector::weights_layout::os_is_yx_osv16_isv16:
             return cldnn::format::os_is_yx_osv16_isv16;
         case kernel_selector::weights_layout::os_iyx_osv32:
@@ -458,8 +460,46 @@ cldnn::format::type from_weights_layout(kernel_selector::weights_layout l) {
             return cldnn::format::g_os_zyx_is_osv32_isv16;
         case kernel_selector::weights_layout::g_os_zyx_is_osv32_isv32:
             return cldnn::format::g_os_zyx_is_osv32_isv32;
+        case kernel_selector::weights_layout::gs_oi_yxs_gsv4_yxsv4:
+            return cldnn::format::gs_oi_yxs_gsv4_yxsv4;
+        case kernel_selector::weights_layout::gs_oi_yxs_gsv16_yxsv4:
+            return cldnn::format::gs_oi_yxs_gsv16_yxsv4;
+        case kernel_selector::weights_layout::gs_oi_yxs_gsv32_yxsv4:
+            return cldnn::format::gs_oi_yxs_gsv32_yxsv4;
+        case kernel_selector::weights_layout::g_os_is_yx_osv16_isv4:
+            return cldnn::format::g_os_is_yx_osv16_isv4;
+        case kernel_selector::weights_layout::g_os_is_yx_isv16_osv16:
+            return cldnn::format::g_os_is_yx_isv16_osv16;
+        case kernel_selector::weights_layout::os_iyx_osv32__ai32:
+            return cldnn::format::os_iyx_osv32__ai32;
+        case kernel_selector::weights_layout::os_is_osv32_isv32_swizzled_by_4:
+            return cldnn::format::os_is_osv32_isv32_swizzled_by_4;
+        case kernel_selector::weights_layout::iy_xs_os_xsv2_osv16__ao32:
+            return cldnn::format::iy_xs_os_xsv2_osv16__ao32;
+        case kernel_selector::weights_layout::iy_xs_os_xsv2_osv8__ao32:
+            return cldnn::format::iy_xs_os_xsv2_osv8__ao32;
+        case kernel_selector::weights_layout::i_yxs_os_yxsv2_osv16:
+            return cldnn::format::i_yxs_os_yxsv2_osv16;
+        case kernel_selector::weights_layout::os_is_zyx_osv32_isv16:
+            return cldnn::format::os_is_zyx_osv32_isv16;
+        case kernel_selector::weights_layout::os_is_zyx_osv64_isv16:
+            return cldnn::format::os_is_zyx_osv64_isv16;
+        case kernel_selector::weights_layout::os_is_yx_isv8_osv16_isv2:
+            return cldnn::format::os_is_yx_isv8_osv16_isv2;
+        case kernel_selector::weights_layout::dlstm_dir_io:
+            return cldnn::format::lstm_weights_dio;
+        case kernel_selector::weights_layout::os_iyx_osv16_rotate_180:
+            return cldnn::format::os_iyx_osv16;
+        case kernel_selector::weights_layout::os_i_yxs_osv4_yxsv4:
+            return cldnn::format::os_i_yxs_osv4_yxsv4;
+        case kernel_selector::weights_layout::gi_yxs_os_yxsv2_osv16:
+            return cldnn::format::gi_yxs_os_yxsv2_osv16;
+        case kernel_selector::weights_layout::giy_xs_os_xsv2_osv8__ao32:
+            return cldnn::format::giy_xs_os_xsv2_osv8__ao32;
+        case kernel_selector::weights_layout::giy_xs_os_xsv2_osv16__ao32:
+            return cldnn::format::giy_xs_os_xsv2_osv16__ao32;
         default:
-            return cldnn::format::bfyx;
+            throw std::invalid_argument("Unable to convert kernel selector Weights layout " + std::to_string((int)l) + " to cldnn format");
     }
 }
 
@@ -561,14 +601,18 @@ layout from_weights_tensor(const kernel_selector::weights_tensor& l) {
     const auto format = from_weights_layout(l.GetLayout());
     const auto type = from_weights_type(l.GetDType());
 
-    tensor t = {static_cast<int>(l.OFM().v),
-                static_cast<int>(l.IFM().v),
-                static_cast<int>(l.X().v),
-                static_cast<int>(l.Y().v),
-                static_cast<int>(l.LX().v),
-                static_cast<int>(l.LY().v)};
+    tensor size(1);
 
-    return layout(type, format, t);
+    size.group[0] = static_cast<int32_t>(l.G().v);
+    size.batch[0] = static_cast<int32_t>(l.OFM().v);
+    size.feature[0] = static_cast<int32_t>(l.IFM().v);
+    size.spatial[0] = static_cast<int32_t>(l.X().v);
+    size.spatial[1] = static_cast<int32_t>(l.Y().v);
+    size.spatial[2] = static_cast<int32_t>(l.Z().v);
+    size.local[0] = static_cast<int32_t>(l.LX().v);
+    size.local[1] = static_cast<int32_t>(l.LY().v);
+
+    return layout(type, format, size);
 }
 
 kernel_selector::activation_function get_kernel_selector_activation_param(activation_func activation) {

--- a/inference-engine/thirdparty/clDNN/src/layout_optimizer.cpp
+++ b/inference-engine/thirdparty/clDNN/src/layout_optimizer.cpp
@@ -86,22 +86,7 @@ std::vector<std::pair<std::shared_ptr<primitive>, bool>> reorder_factory::get_we
         }
     }
 
-    // TODO: Add conversion of WeightsTensor to cldnn::tensor to have not flattened shape
-    // layout expected_layout = from_weights_tensor(reorder_params.dest);
-
-    auto new_dtype = from_weights_type(reorder_params.dest.GetDType());
-    const auto bpp = data_type_traits::size_of(new_dtype);
-    tensor expected_size = { 1, 1, 1, (tensor::value_type)(reorder_params.dest.PhysicalSizeInBytes() / bpp) };
-
-    bool toImageType = IsImageType(reorder_params.dest.GetLayout());
-    bool toDynamicLSTMType = IsDynamicLSTMType(reorder_params.dest.GetLayout());
-    if (toImageType || toDynamicLSTMType)
-        expected_size = old_layout.size;
-
-    layout expected_layout = { new_dtype,
-                              toImageType ? from_weights_layout(reorder_params.dest.GetLayout())
-                                          : format::bfyx,  // simple linear format (flatten to x channel)
-                              expected_size };
+    layout expected_layout = from_weights_tensor(reorder_params.dest);
 
     cache_key ckey{ input_id, expected_layout };
     auto itr = _cached_generic_reorders.find(ckey);

--- a/inference-engine/thirdparty/clDNN/src/lstm_dynamic_input.cpp
+++ b/inference-engine/thirdparty/clDNN/src/lstm_dynamic_input.cpp
@@ -96,7 +96,7 @@ lstm_dynamic_input_inst::typed_primitive_inst(network_impl& network, lstm_dynami
                                   "weights format",
                                   node.weights().get_output_layout().format.value,
                                   "expected bfyx format",
-                                  format::bfyx);
+                                  format::oiyx, format::lstm_weights_dio, format::bfyx);
     CLDNN_ERROR_NOT_EQUAL(node.id(),
                           "Weights batch size",
                           weights_tensor.batch[0],


### PR DESCRIPTION
These changes add new function `is_memory_reset_needed` that provide ability to skip memory filling with zero values.