### PR TITLE
VPU: firmware 1378 (MDK develop for OV 2021.2)

### DIFF
--- a/inference-engine/cmake/vpu_dependencies.cmake
+++ b/inference-engine/cmake/vpu_dependencies.cmake
@@ -19,7 +19,7 @@ set(VPU_SUPPORTED_FIRMWARES usb-ma2450 usb-ma2x8x pcie-ma248x)
 # Default packages
 #
 
-set(FIRMWARE_PACKAGE_VERSION 1370)
+set(FIRMWARE_PACKAGE_VERSION 1378)
 set(VPU_CLC_MA2X8X_VERSION "movi-cltools-20.09.1")
 
 #


### PR DESCRIPTION
Update VPU firmware built from fresh MDK develop (to gain all commits we made to R13 and 2021.1)

Details: #-39108