### PR TITLE
[IE][VPU]: Merges transformations calls from LoadExeNetwork and Frontend

### DIFF
--- a/inference-engine/src/vpu/graph_transformer/src/frontend/frontend.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/frontend/frontend.cpp
@@ -29,6 +29,9 @@
 #include <transformations/convert_opset1_to_legacy/convert_opset1_to_legacy.hpp>
 #include <transformations/common_optimizations/common_optimizations.hpp>
 #include <vpu/ngraph/transformations/merge_subsequent_dsr_operations.hpp>
+#include <vpu/ngraph/transformations/convert_nms_4_to_nms_dynamic.hpp>
+#include "vpu/ngraph/transformations/dynamic_to_static_shape.hpp"
+#include "vpu/ngraph/transformations/eliminate_shapeof_after_dsr.hpp"
 #include <vpu/ngraph/operations/dynamic_shape_resolver.hpp>
 
 namespace vpu {
@@ -146,40 +149,43 @@ bool FrontEnd::isLayerSupported(const std::string& type) {
 }
 
 ie::ICNNNetwork::Ptr FrontEnd::convertNetwork(ie::ICNNNetwork& network) {
-        std::shared_ptr<ie::ICNNNetwork> convertedNetwork;
-        // disable transformations for some cases
-        const auto transformationsPredicate = [](const std::shared_ptr<const ngraph::Node> &node) -> bool {
-            const bool casesWithDynamicOrStaticUsage = std::dynamic_pointer_cast<const ngraph::opset3::Gelu>(node) ||
-                                                        std::dynamic_pointer_cast<const ngraph::opset4::SoftPlus>(node);
+    std::shared_ptr<ie::ICNNNetwork> convertedNetwork;
+    // disable transformations for some cases
+    const auto transformationsPredicate = [](const std::shared_ptr<const ngraph::Node>& node) -> bool {
+        const bool casesWithDynamicOrStaticUsage =
+            std::dynamic_pointer_cast<const ngraph::opset3::Gelu>(node) || std::dynamic_pointer_cast<const ngraph::opset4::SoftPlus>(node);
 
-            const bool casesWithOnlyDynamicUsage = (std::dynamic_pointer_cast<const ngraph::opset3::MatMul>(node) ||
-                                                    std::dynamic_pointer_cast<const ngraph::opset3::StridedSlice>(node)) &&
-                    std::dynamic_pointer_cast<const ngraph::vpu::op::DynamicShapeResolver>(node->input_value(0).get_node_shared_ptr());
+        const bool casesWithOnlyDynamicUsage =
+            (std::dynamic_pointer_cast<const ngraph::opset3::MatMul>(node) ||
+             std::dynamic_pointer_cast<const ngraph::opset3::StridedSlice>(node)) &&
+            std::dynamic_pointer_cast<const ngraph::vpu::op::DynamicShapeResolver>(node->input_value(0).get_node_shared_ptr());
 
-            return casesWithDynamicOrStaticUsage || casesWithOnlyDynamicUsage;
-        };
+        return casesWithDynamicOrStaticUsage || casesWithOnlyDynamicUsage;
+    };
 
-        auto nGraphFunc = network.getFunction();
-        // Disable shape inference (WA for generic operations)
-        ngraph::op::GenericIE::DisableReshape noReshape(nGraphFunc);
+    auto nGraphFunc = network.getFunction();
+    // Disable shape inference (WA for generic operations)
+    ngraph::op::GenericIE::DisableReshape noReshape(nGraphFunc);
 
-        ngraph::pass::Manager manager;
+    ngraph::pass::Manager manager;
+    manager.register_pass<vpu::UpgradeNMS4ToNMSDynamic>();
+    manager.register_pass<ngraph::pass::CommonOptimizations>();
+    manager.register_pass<vpu::DynamicToStaticShape>();
+    manager.register_pass<vpu::EliminateShapeOfAfterDSR>();
+    manager.register_pass<ngraph::pass::ConvertOpSet3ToOpSet2>();
+    manager.register_pass<ngraph::pass::ConvertOpSet2ToOpSet1>();
+    manager.register_pass<ngraph::pass::ConvertOpSet1ToLegacy>();
+    manager.set_callback(transformationsPredicate);
+    manager.run_passes(nGraphFunc);
 
-        manager.register_pass<ngraph::pass::CommonOptimizations>();
-        manager.register_pass<ngraph::pass::ConvertOpSet3ToOpSet2>();
-        manager.register_pass<ngraph::pass::ConvertOpSet2ToOpSet1>();
-        manager.register_pass<ngraph::pass::ConvertOpSet1ToLegacy>();
-        manager.set_callback(transformationsPredicate);
-        manager.run_passes(nGraphFunc);
+    ngraph::pass::Manager ti_manager;
+    ti_manager.register_pass<ngraph::pass::ApplyTransformationsToTIBody>(manager);
+    ti_manager.run_passes(nGraphFunc);
 
-        ngraph::pass::Manager ti_manager;
-        ti_manager.register_pass<ngraph::pass::ApplyTransformationsToTIBody>(manager);
-        ti_manager.run_passes(nGraphFunc);
+    vpu::MergeSubsequentDSROperations().run_on_function(nGraphFunc);
 
-        vpu::MergeSubsequentDSROperations().run_on_function(nGraphFunc);
-
-        convertedNetwork = InferenceEngine::details::convertFunctionToICNNNetwork(nGraphFunc, network);
-        return convertedNetwork;
+    convertedNetwork = InferenceEngine::details::convertFunctionToICNNNetwork(nGraphFunc, network);
+    return convertedNetwork;
 }
 
 std::set<std::string> FrontEnd::checkSupportedLayers(ie::ICNNNetwork& network) {


### PR DESCRIPTION
# Task

#-39023

# Description

There is no reason for calling `nGraph` transformations from 2 separate places (`LoadExeNetworkImpl` and `FrontEnd`), but this makes compilation pipeline more sophisticated

Validation is in progress, so additional changes may appear