### PR TITLE
[IE][VPU]: Remove the second call of ngraph::CommonOptimizations

### DIFF
--- a/inference-engine/src/vpu/graph_transformer/src/frontend/frontend.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/frontend/frontend.cpp
@@ -27,7 +27,6 @@
 #include <transformations/convert_opset3_to_opset2/convert_opset3_to_opset2.hpp>
 #include <transformations/convert_opset2_to_opset1/convert_opset2_to_opset1.hpp>
 #include <transformations/convert_opset1_to_legacy/convert_opset1_to_legacy.hpp>
-#include <transformations/common_optimizations/common_optimizations.hpp>
 #include <vpu/ngraph/transformations/merge_subsequent_dsr_operations.hpp>
 #include <vpu/ngraph/operations/dynamic_shape_resolver.hpp>
 

--- a/inference-engine/src/vpu/graph_transformer/src/frontend/frontend.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/frontend/frontend.cpp
@@ -165,7 +165,6 @@ ie::ICNNNetwork::Ptr FrontEnd::convertNetwork(ie::ICNNNetwork& network) {
 
         ngraph::pass::Manager manager;
 
-        manager.register_pass<ngraph::pass::CommonOptimizations>();
         manager.register_pass<ngraph::pass::ConvertOpSet3ToOpSet2>();
         manager.register_pass<ngraph::pass::ConvertOpSet2ToOpSet1>();
         manager.register_pass<ngraph::pass::ConvertOpSet1ToLegacy>();

--- a/inference-engine/src/vpu/myriad_plugin/myriad_plugin.cpp
+++ b/inference-engine/src/vpu/myriad_plugin/myriad_plugin.cpp
@@ -36,6 +36,23 @@ using namespace InferenceEngine::PluginConfigParams;
 using namespace InferenceEngine::VPUConfigParams;
 using namespace vpu::MyriadPlugin;
 
+namespace {
+
+static void transformNGraphFunction(const std::shared_ptr<ngraph::Function>& function) {
+    ngraph::op::GenericIE::DisableReshape noReshape(function);
+    ngraph::pass::Manager manager;
+    manager.register_pass<vpu::UpgradeNMS4ToNMSDynamic>();
+    manager.register_pass<ngraph::pass::CommonOptimizations>();
+    manager.register_pass<vpu::DynamicToStaticShape>();
+    manager.register_pass<vpu::EliminateShapeOfAfterDSR>();
+    manager.run_passes(function);
+
+    ngraph::pass::Manager ti_manager;
+    ti_manager.register_pass<ngraph::pass::ApplyTransformationsToTIBody>(manager);
+    ti_manager.run_passes(function);
+}
+
+}  // namespace
 
 ExecutableNetworkInternal::Ptr Engine::LoadExeNetworkImpl(
         const ICNNNetwork& network,
@@ -47,17 +64,7 @@ ExecutableNetworkInternal::Ptr Engine::LoadExeNetworkImpl(
 
     auto clonedNetwork = cloneNetwork(network);
     if (auto function = clonedNetwork->getFunction()) {
-        ngraph::op::GenericIE::DisableReshape noReshape(function);
-        ngraph::pass::Manager manager;
-        manager.register_pass<vpu::UpgradeNMS4ToNMSDynamic>();
-        manager.register_pass<ngraph::pass::CommonOptimizations>();
-        manager.register_pass<vpu::DynamicToStaticShape>();
-        manager.register_pass<vpu::EliminateShapeOfAfterDSR>();
-        manager.run_passes(function);
-
-        ngraph::pass::Manager ti_manager;
-        ti_manager.register_pass<ngraph::pass::ApplyTransformationsToTIBody>(manager);
-        ti_manager.run_passes(function);
+        transformNGraphFunction(function);
     }
 
     return std::make_shared<ExecutableNetwork>(*clonedNetwork,
@@ -110,6 +117,9 @@ void Engine::QueryNetwork(
         }
 
         auto clonedNetwork = cloneNetwork(network);
+
+        transformNGraphFunction(clonedNetwork->getFunction());
+
         auto convertedNetwork = vpu::FrontEnd::convertNetwork(*clonedNetwork);
 
         std::unordered_set<std::string> supported;

--- a/inference-engine/src/vpu/myriad_plugin/myriad_plugin.cpp
+++ b/inference-engine/src/vpu/myriad_plugin/myriad_plugin.cpp
@@ -38,7 +38,7 @@ using namespace vpu::MyriadPlugin;
 
 namespace {
 
-static void transformNGraphFunction(const std::shared_ptr<ngraph::Function>& function) {
+void transformNGraphFunction(const std::shared_ptr<ngraph::Function>& function) {
     ngraph::op::GenericIE::DisableReshape noReshape(function);
     ngraph::pass::Manager manager;
     manager.register_pass<vpu::UpgradeNMS4ToNMSDynamic>();


### PR DESCRIPTION
### Description
* Remove the second call of ngraph::CommonOptimizations
* Some ngraph transformations are called in myriad `LoadExeNetworkImpl` and some of them are called at the vpu graph transformer's frontend. This logic should be refactored (#-39023). But to minimize risks, this one-line hotfix is proposed to merge in the release branch
* It affects the working capacity of Faster-RCNN which is in 2021.1 roadmap

### Task
#-39022