### PR TITLE
VPU: firmware 1381 (MDK R13 for OV 2021.1)

### DIFF
--- a/inference-engine/cmake/vpu_dependencies.cmake
+++ b/inference-engine/cmake/vpu_dependencies.cmake
@@ -19,7 +19,7 @@ set(VPU_SUPPORTED_FIRMWARES usb-ma2450 usb-ma2x8x pcie-ma248x)
 # Default packages
 #
 
-set(FIRMWARE_PACKAGE_VERSION 1370)
+set(FIRMWARE_PACKAGE_VERSION 1381)
 set(VPU_CLC_MA2X8X_VERSION "movi-cltools-20.09.1")
 
 #


### PR DESCRIPTION
VPU firmware 1381, built from final state of MDK R13 release branch

Details: #-39106