### PR TITLE
[PP GAPI] Split/Merge kernels; support for 8S, 16U, 16S, 32S

### DIFF
--- a/inference-engine/tests_deprecated/fluid_preproc/cpu/fluid_tests_cpu.cpp
+++ b/inference-engine/tests_deprecated/fluid_preproc/cpu/fluid_tests_cpu.cpp
@@ -132,7 +132,7 @@ INSTANTIATE_TEST_CASE_P(ResizeTestFluid_F32, ResizeTestGAPI,
 
 INSTANTIATE_TEST_CASE_P(SplitTestFluid, SplitTestGAPI,
                         Combine(Values(2, 3, 4),
-                                Values(CV_8U, CV_32F),
+                                Values(CV_8U, CV_8S, CV_16U, CV_16S, CV_32F, CV_32S),
                                 Values(TEST_SIZES),
                                 Values(0)));
 
@@ -144,7 +144,7 @@ INSTANTIATE_TEST_CASE_P(ChanToPlaneTestFluid, ChanToPlaneTestGAPI,
 
 INSTANTIATE_TEST_CASE_P(MergeTestFluid, MergeTestGAPI,
                         Combine(Values(2, 3, 4),
-                                Values(CV_8U, CV_32F),
+                                Values(CV_8U, CV_8S, CV_16U, CV_16S, CV_32F, CV_32S),
                                 Values(TEST_SIZES),
                                 Values(0)));
 


### PR DESCRIPTION
 - introduced type_dispatch primitive
 - refactored SplitX and MergeX kernels to use type_dispatch
 - extended SplitX and MergeX to support 8S, 16U, 16S, 32S types