### PR TITLE
[IE][CMAKE] Add some libraries to ie_developer export list

### DIFF
--- a/inference-engine/src/vpu/common/CMakeLists.txt
+++ b/inference-engine/src/vpu/common/CMakeLists.txt
@@ -45,9 +45,9 @@ function(add_common_target TARGET_NAME STATIC_IE)
 
     if(NOT STATIC_IE)
         add_cpplint_target(${TARGET_NAME}_cpplint FOR_TARGETS ${TARGET_NAME} CUSTOM_FILTERS "+runtime/explicit")
-
-        ie_developer_export_targets(${TARGET_NAME})
     endif()
+
+    ie_developer_export_targets(${TARGET_NAME})
 
     target_link_libraries(${TARGET_NAME} PUBLIC ${NGRAPH_LIBRARIES} inference_engine_transformations
                                          PRIVATE openvino::itt)

--- a/inference-engine/tests_deprecated/functional/ie_tests/CMakeLists.txt
+++ b/inference-engine/tests_deprecated/functional/ie_tests/CMakeLists.txt
@@ -28,4 +28,4 @@ target_link_libraries(${TARGET_NAME} PUBLIC
 
 # developer package
 
-ie_developer_export_targets(${TARGET_NAME} ${EXPORT_DEPENDENCIES})
+ie_developer_export_targets(${TARGET_NAME} ${EXPORT_DEPENDENCIES} ieTestHelpers_s)


### PR DESCRIPTION
The following libraries:

* `vpu_common_lib_test_static`
* `ieTestHelpers_s`

Those libraries might be helpful for standalone plugins tests.