### PR TITLE
[PP GAPI] Extended preprocessing graph to support precision conversions

### DIFF
--- a/inference-engine/src/preprocessing/ie_preprocess_gapi.cpp
+++ b/inference-engine/src/preprocessing/ie_preprocess_gapi.cpp
@@ -29,10 +29,12 @@
 
 namespace InferenceEngine {
 namespace {
+int get_cv_depth(const TensorDesc &ie_desc);
+
 namespace G {
     struct Strides {int N; int C; int H; int W;};
     struct Dims    {int N; int C; int H; int W;};
-    struct Desc    {Dims d; Strides s;};
+    struct Desc    {Dims d; Strides s; int prec;};
 
     void fix_strides_nhwc(const Dims &d, Strides &s) {
         if (s.W > d.C) {
@@ -65,7 +67,7 @@ namespace G {
 
         if (nhwc_layout) fix_strides_nhwc(d, s);
 
-        return Desc{d, s};
+        return Desc{d, s, get_cv_depth(ie_desc)};
     }
 
     Desc decompose(const Blob::Ptr& blob) {
@@ -77,6 +79,8 @@ inline int get_cv_depth(const TensorDesc &ie_desc) {
     switch (ie_desc.getPrecision()) {
     case Precision::U8:   return CV_8U;
     case Precision::FP32: return CV_32F;
+    case Precision::U16:  return CV_16U;
+
     default: THROW_IE_EXCEPTION << "Unsupported data type";
     }
 }
@@ -370,6 +374,7 @@ G::Desc getGDesc(G::Desc in_desc_y, const NV12Blob::Ptr &) {
     auto nv12_desc = G::Desc{};
     nv12_desc.d = in_desc_y.d;
     nv12_desc.d.C = 2;
+    nv12_desc.prec = in_desc_y.prec;
 
     return nv12_desc;
 }
@@ -378,6 +383,7 @@ G::Desc getGDesc(G::Desc in_desc_y, const I420Blob::Ptr &) {
     auto i420_desc = G::Desc{};
     i420_desc.d = in_desc_y.d;
     i420_desc.d.C = 3;
+    i420_desc.prec = in_desc_y.prec;
 
     return i420_desc;
 }
@@ -542,8 +548,7 @@ cv::GComputation buildGraph(const G::Desc &in_desc,
                             Layout out_layout,
                             ResizeAlgorithm algorithm,
                             ColorFormat input_color_format,
-                            ColorFormat output_color_format,
-                            int precision) {
+                            ColorFormat output_color_format) {
     // perform basic validation to ensure our assumptions about input and output are correct
     validateColorFormats(in_desc, out_desc, in_layout, out_layout, input_color_format,
         output_color_format);
@@ -568,7 +573,7 @@ cv::GComputation buildGraph(const G::Desc &in_desc,
                               (io_color_formats == std::make_tuple(ColorFormat::BGRX, ColorFormat::BGR));
     const bool specific_case_of_preproc = ((in_layout == NHWC || specific_yuv420_input_handling)
                                         && (in_desc.d.C == 3 || specific_yuv420_input_handling || drop_channel)
-                                        && (precision == CV_8U)
+                                        && ((in_desc.prec == CV_8U) && (in_desc.prec == out_desc.prec))
                                         && (algorithm == RESIZE_BILINEAR)
                                         && (input_color_format == ColorFormat::RAW
                                             || input_color_format == output_color_format
@@ -590,9 +595,9 @@ cv::GComputation buildGraph(const G::Desc &in_desc,
 
         auto planes = drop_channel ?
                 to_vec(gapi::ScalePlanes4:: on(
-                        color_converted_input[0], precision, input_sz, scale_sz, cv::INTER_LINEAR))
+                        color_converted_input[0], in_desc.prec, input_sz, scale_sz, cv::INTER_LINEAR))
               : to_vec(gapi::ScalePlanes  ::on(
-                        color_converted_input[0], precision, input_sz, scale_sz, cv::INTER_LINEAR));
+                        color_converted_input[0], in_desc.prec, input_sz, scale_sz, cv::INTER_LINEAR));
 
         if (drop_channel) {
             planes.pop_back();
@@ -622,8 +627,13 @@ cv::GComputation buildGraph(const G::Desc &in_desc,
                            << number_of_planes << " != " << out_desc.d.C;
     }
 
+    const int tmp_prec = CV_32F;
+
     std::vector<cv::GMat> outputs;
-    if (algorithm != NO_RESIZE) {
+    const bool resize_needed = (algorithm != NO_RESIZE);
+    const bool need_tmp_prec_conv = resize_needed && (in_desc.prec != CV_8U) && (in_desc.prec != CV_32F);
+
+    if (resize_needed) {
         // resize every plane
         std::vector<cv::GMat> out_planes;
         out_planes.reserve(planes.size());
@@ -634,18 +644,36 @@ cv::GComputation buildGraph(const G::Desc &in_desc,
             default: THROW_IE_EXCEPTION << "Unsupported resize operation";
             }
         } (algorithm);
-        const auto input_sz  = cv::gapi::own::Size(in_desc.d.W, in_desc.d.H);
-        const auto scale_sz  = cv::gapi::own::Size(out_desc.d.W, out_desc.d.H);
-        const auto scale_fcn = std::bind(&gapi::ScalePlane::on,
-                                        std::placeholders::_1,
-                                        precision,
-                                        input_sz, scale_sz, interp_type);
-        std::transform(planes.begin(), planes.end(), std::back_inserter(out_planes), scale_fcn);
+
+        std::transform(planes.begin(), planes.end(), std::back_inserter(out_planes), [&](const cv::GMat& m) {
+            const auto input_sz  = cv::gapi::own::Size(in_desc.d.W, in_desc.d.H);
+            const auto scale_sz  = cv::gapi::own::Size(out_desc.d.W, out_desc.d.H);
+
+            cv::GMat converted = m;
+            int prec = in_desc.prec;
+
+            if (need_tmp_prec_conv) {
+                std::tie(converted, prec) = std::make_tuple(gapi::ConvertDepth::on(m, tmp_prec), tmp_prec);
+            }
+
+            return gapi::ScalePlane::on(converted, prec, input_sz, scale_sz, interp_type);
+        });
         outputs = out_planes;
     } else {
         outputs = planes;
     }
 
+    if ((in_desc.prec != out_desc.prec) || need_tmp_prec_conv) {
+        auto convert_prec = [](const std::vector<cv::GMat> & src_gmats, int dst_precision) {
+            std::vector<cv::GMat> dst_gmats;
+            std::transform(src_gmats.begin(), src_gmats.end(), std::back_inserter(dst_gmats), [&](cv::GMat const& m){
+                return gapi::ConvertDepth::on(m, dst_precision);
+            });
+            return dst_gmats;
+        };
+
+        outputs = convert_prec(outputs, out_desc.prec);
+    }
     // convert to interleaved if NHWC is required as output
     if (out_layout == NHWC) {
         outputs = merge(outputs, out_desc.d.C);
@@ -938,8 +966,7 @@ bool PreprocEngine::preprocessBlob(const BlobTypePtr &inBlob, MemoryBlob::Ptr &o
                            out_layout,
                            algorithm,
                            in_fmt,
-                           out_fmt,
-                           get_cv_depth(in_desc_ie)));
+                           out_fmt));
         }
     }
 
@@ -952,7 +979,7 @@ bool PreprocEngine::preprocessBlob(const BlobTypePtr &inBlob, MemoryBlob::Ptr &o
     return true;
 }
 
-bool PreprocEngine::preprocessWithGAPI(Blob::Ptr &inBlob, Blob::Ptr &outBlob,
+bool PreprocEngine::preprocessWithGAPI(const Blob::Ptr &inBlob, Blob::Ptr &outBlob,
         const ResizeAlgorithm& algorithm, ColorFormat in_fmt, bool omp_serial, int batch_size) {
     if (!useGAPI()) {
         return false;

--- a/inference-engine/src/preprocessing/ie_preprocess_gapi.hpp
+++ b/inference-engine/src/preprocessing/ie_preprocess_gapi.hpp
@@ -54,7 +54,7 @@ public:
     static bool useGAPI();
     static void checkApplicabilityGAPI(const Blob::Ptr &src, const Blob::Ptr &dst);
     static int getCorrectBatchSize(int batch_size, const Blob::Ptr& roiBlob);
-    bool preprocessWithGAPI(Blob::Ptr &inBlob, Blob::Ptr &outBlob, const ResizeAlgorithm &algorithm,
+    bool preprocessWithGAPI(const Blob::Ptr &inBlob, Blob::Ptr &outBlob, const ResizeAlgorithm &algorithm,
         ColorFormat in_fmt, bool omp_serial, int batch_size = -1);
 };
 

--- a/inference-engine/tests_deprecated/fluid_preproc/common/fluid_tests.hpp
+++ b/inference-engine/tests_deprecated/fluid_preproc/common/fluid_tests.hpp
@@ -48,9 +48,16 @@ struct ColorConvertYUV420TestIE:
                                              double>>                       // tolerance
 {};
 
+struct PrecisionConvertTestIE: public TestParams<std::tuple<cv::Size,
+                                                            int,     // input  matrix depth
+                                                            int,     // output matrix depth
+                                                            double>> // tolerance
+{};
+
 //------------------------------------------------------------------------------
 
-using PreprocParams = std::tuple< InferenceEngine::Precision     // input-output data type
+using PreprocParams = std::tuple< std::pair<InferenceEngine::Precision     // input data type
+                                           , InferenceEngine::Precision>   // output data type
                                 , InferenceEngine::ResizeAlgorithm // resize algorithm, if needed
                                 , InferenceEngine::ColorFormat // input color format, if needed
                                 , InferenceEngine::Layout        // input tensor layout

--- a/inference-engine/tests_deprecated/fluid_preproc/cpu/fluid_tests_cpu.cpp
+++ b/inference-engine/tests_deprecated/fluid_preproc/cpu/fluid_tests_cpu.cpp
@@ -323,8 +323,12 @@ static const auto PATCH_SIZES =
                           cv::Size(80, 160))); // 80 - person-attributes-recognition-crossroad-0031
                                                // 64 - person-reidentification-retail-0079
 
+static const auto U8toU8 = std::make_pair(IE::Precision::U8,IE::Precision::U8);
+
+static const auto PRECISIONS = Values(U8toU8, std::make_pair(IE::Precision::FP32,IE::Precision::FP32));
+
 INSTANTIATE_TEST_CASE_P(ReorderResize_Frame, PreprocTest,
-                        Combine(Values(IE::Precision::U8, IE::Precision::FP32),
+                        Combine(PRECISIONS,
                                 Values(IE::ResizeAlgorithm::RESIZE_BILINEAR), // AREA is not there yet
                                 Values(IE::ColorFormat::RAW),
                                 Values(IE::Layout::NHWC),
@@ -333,7 +337,7 @@ INSTANTIATE_TEST_CASE_P(ReorderResize_Frame, PreprocTest,
                                 FRAME_SIZES));
 
 INSTANTIATE_TEST_CASE_P(Scale3ch_Frame, PreprocTest,
-                        Combine(Values(IE::Precision::U8, IE::Precision::FP32),
+                        Combine(PRECISIONS,
                                 Values(IE::ResizeAlgorithm::RESIZE_BILINEAR), // AREA is not there yet
                                 Values(IE::ColorFormat::RAW),
                                 Values(IE::Layout::NHWC),
@@ -342,7 +346,7 @@ INSTANTIATE_TEST_CASE_P(Scale3ch_Frame, PreprocTest,
                                 FRAME_SIZES));
 
 INSTANTIATE_TEST_CASE_P(ReorderResize_Patch, PreprocTest,
-                        Combine(Values(IE::Precision::U8, IE::Precision::FP32),
+                        Combine(PRECISIONS,
                                 Values(IE::ResizeAlgorithm::RESIZE_BILINEAR), // AREA is not there yet
                                 Values(IE::ColorFormat::RAW),
                                 Values(IE::Layout::NHWC),
@@ -351,7 +355,7 @@ INSTANTIATE_TEST_CASE_P(ReorderResize_Patch, PreprocTest,
                                 PATCH_SIZES));
 
 INSTANTIATE_TEST_CASE_P(Everything_Resize, PreprocTest,
-                        Combine(Values(IE::Precision::U8, IE::Precision::FP32),
+                        Combine(PRECISIONS,
                                 Values(IE::ResizeAlgorithm::RESIZE_BILINEAR, IE::ResizeAlgorithm::RESIZE_AREA),
                                 Values(IE::ColorFormat::RAW),
                                 Values(IE::Layout::NHWC, IE::Layout::NCHW),
@@ -363,7 +367,7 @@ INSTANTIATE_TEST_CASE_P(Everything_Resize, PreprocTest,
                                 Values(TEST_SIZES_PREPROC)));
 
 INSTANTIATE_TEST_CASE_P(ColorFormats_3ch, PreprocTest,
-                        Combine(Values(IE::Precision::U8, IE::Precision::FP32),
+                        Combine(PRECISIONS,
                                 Values(IE::ResizeAlgorithm::RESIZE_BILINEAR, IE::ResizeAlgorithm::RESIZE_AREA),
                                 Values(IE::ColorFormat::RGB),
                                 Values(IE::Layout::NHWC, IE::Layout::NCHW),
@@ -372,7 +376,7 @@ INSTANTIATE_TEST_CASE_P(ColorFormats_3ch, PreprocTest,
                                 Values(TEST_SIZES_PREPROC)));
 
 INSTANTIATE_TEST_CASE_P(ColorFormats_4ch, PreprocTest,
-                        Combine(Values(IE::Precision::U8, IE::Precision::FP32),
+                        Combine(PRECISIONS,
                                 Values(IE::ResizeAlgorithm::RESIZE_BILINEAR, IE::ResizeAlgorithm::RESIZE_AREA),
                                 Values(IE::ColorFormat::BGRX, IE::ColorFormat::RGBX),
                                 Values(IE::Layout::NHWC),
@@ -381,10 +385,35 @@ INSTANTIATE_TEST_CASE_P(ColorFormats_4ch, PreprocTest,
                                 Values(TEST_SIZES_PREPROC)));
 
 INSTANTIATE_TEST_CASE_P(ColorFormat_NV12, PreprocTest,
-                        Combine(Values(IE::Precision::U8),
+                        Combine(Values(U8toU8),
                                 Values(IE::ResizeAlgorithm::RESIZE_BILINEAR, IE::ResizeAlgorithm::RESIZE_AREA),
                                 Values(IE::ColorFormat::NV12),
                                 Values(IE::Layout::NCHW),
                                 Values(IE::Layout::NHWC, IE::Layout::NCHW),
                                 Values(std::make_pair(1, 3)),
+                                Values(TEST_SIZES_PREPROC)));
+
+
+INSTANTIATE_TEST_CASE_P(DISABLED_PlainPrecisionConversions, PreprocTest,
+                        Combine(Values(std::make_pair(IE::Precision::U16,IE::Precision::FP32),
+                                       std::make_pair(IE::Precision::FP32,IE::Precision::U16)
+                                ),
+                                Values(IE::ResizeAlgorithm::NO_RESIZE),
+                                Values(IE::ColorFormat::RAW),
+                                Values(IE::Layout::NHWC),
+                                Values(IE::Layout::NHWC),
+                                Values(std::make_pair(1, 1)),
+                                Values(std::make_pair(cv::Size(640,480), cv::Size(640,480)))));
+
+
+INSTANTIATE_TEST_CASE_P(PrecisionConversionsPipelines, PreprocTest,
+                        Combine(Values(std::make_pair(IE::Precision::U16, IE::Precision::FP32),
+                                       std::make_pair(IE::Precision::FP32,IE::Precision::U8),
+                                       std::make_pair(IE::Precision::U8,  IE::Precision::FP32)
+                                ),
+                                Values(IE::ResizeAlgorithm::RESIZE_BILINEAR),
+                                Values(IE::ColorFormat::RAW),
+                                Values(IE::Layout::NHWC, IE::Layout::NCHW),
+                                Values(IE::Layout::NHWC, IE::Layout::NCHW),
+                                Values(std::make_pair(1, 1)/*, std::make_pair(3, 3)*/), //U16 Split and Merge are not there
                                 Values(TEST_SIZES_PREPROC)));


### PR DESCRIPTION
The PP graph was extended to support precision conversion as well
- partly visible via plugin interface (Pure precision conversion without other operations is not permitted)
- as resize natively supports U8 and FP32 only,  non U8 input is converted to  FP32
- cover non optimized version only
- tests