### PR TITLE
[Scripts] Fix setting PYTHONPATH logic on master

### DIFF
--- a/scripts/install_dependencies/install_openvino_dependencies.sh
+++ b/scripts/install_dependencies/install_openvino_dependencies.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2018 Intel Corporation
+# Copyright (c) 2018 - 2020 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/setupvars/setupvars.bat
+++ b/scripts/setupvars/setupvars.bat
@@ -21,8 +21,6 @@ set SCRIPT_NAME=%~nx0
 set "INTEL_OPENVINO_DIR=%ROOT%"
 set "INTEL_CVSDK_DIR=%INTEL_OPENVINO_DIR%"
 
-where /q libmmd.dll || echo Warning: libmmd.dll couldn't be found in %%PATH%%. Please check if the redistributable package for Intel(R) C++ Compiler is installed and the library path is added to the PATH environment variable. System reboot can be required to update the system environment.
-
 :: OpenCV
 if exist "%INTEL_OPENVINO_DIR%\opencv\setupvars.bat" (
 call "%INTEL_OPENVINO_DIR%\opencv\setupvars.bat"
@@ -52,14 +50,14 @@ set "ngraph_DIR=%INTEL_OPENVINO_DIR%\deployment_tools\ngraph\cmake"
 )
 
 :: Check if Python is installed
-python --version 2>NUL
+python3 --version 2>NUL
 if errorlevel 1 (
-   echo Error^: Python is not installed. Please install Python 3.5. or 3.6  ^(64-bit^) from https://www.python.org/downloads/
+   echo Error^: Python is not installed. Please install Python 3.6 or higher ^(64-bit^) from https://www.python.org/downloads/
    exit /B 1
 )
 
 :: Check Python version
-for /F "tokens=* USEBACKQ" %%F IN (`python --version 2^>^&1`) DO (
+for /F "tokens=* USEBACKQ" %%F IN (`python3 --version 2^>^&1`) DO (
    set version=%%F
 )
 
@@ -69,18 +67,18 @@ for /F "tokens=1,2,3 delims=. " %%a in ("%version%") do (
 )
 
 if "%Major%" geq "3" (
-   if "%Minor%" geq "5" (
+   if "%Minor%" geq "6" (
       set python_ver=okay
    )
 )
 
 if not "%python_ver%"=="okay" (
-   echo Unsupported Python version. Please install Python 3.5 or 3.6  ^(64-bit^) from https://www.python.org/downloads/
+   echo Unsupported Python version. Please install Python 3.6 or higher ^(64-bit^) from https://www.python.org/downloads/
    exit /B 1
 )
 
 :: Check Python bitness
-python -c "import sys; print(64 if sys.maxsize > 2**32 else 32)" 2 > NUL
+python3 -c "import sys; print(64 if sys.maxsize > 2**32 else 32)" 2 > NUL
 if errorlevel 1 (
    echo Error^: Error during installed Python bitness detection
    exit /B 1
@@ -91,7 +89,7 @@ for /F "tokens=* USEBACKQ" %%F IN (`python -c "import sys; print(64 if sys.maxsi
 )
 
 if not "%bitness%"=="64" (
-   echo Unsupported Python bitness. Please install Python 3.5 or 3.6  ^(64-bit^) from https://www.python.org/downloads/
+   echo Unsupported Python bitness. Please install Python 3.6 or higher ^(64-bit^) from https://www.python.org/downloads/
    exit /B 1
 )
 

--- a/scripts/setupvars/setupvars.sh
+++ b/scripts/setupvars/setupvars.sh
@@ -94,23 +94,7 @@ if [ -e $INTEL_OPENVINO_DIR/deployment_tools/tools/post_training_optimization_to
 fi
 
 if [ -z "$python_version" ]; then
-    if command -v python3.7 >/dev/null 2>&1; then
-        python_version=3.7
-        python_bitness=$(python3.7 -c 'import sys; print(64 if sys.maxsize > 2**32 else 32)')
-    elif command -v python3.6 >/dev/null 2>&1; then
-        python_version=3.6
-        python_bitness=$(python3.6 -c 'import sys; print(64 if sys.maxsize > 2**32 else 32)')
-    elif command -v python3.5 >/dev/null 2>&1; then
-        python_version=3.5
-        python_bitness=$(python3.5 -c 'import sys; print(64 if sys.maxsize > 2**32 else 32)')
-    elif command -v python3.4 >/dev/null 2>&1; then
-        python_version=3.4
-        python_bitness=$(python3.4 -c 'import sys; print(64 if sys.maxsize > 2**32 else 32)')
-    elif command -v python2.7 >/dev/null 2>&1; then
-        python_version=2.7
-    elif command -v python >/dev/null 2>&1; then
-        python_version=$(python -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
-    fi
+    python_version=$(python3 -c 'import sys; print(str(sys.version_info[0])+"."+str(sys.version_info[1]))')
 fi
 
 OS_NAME=""
@@ -118,17 +102,23 @@ if command -v lsb_release >/dev/null 2>&1; then
     OS_NAME=$(lsb_release -i -s)
 fi
 
+python_bitness=$(python3 -c 'import sys; print(64 if sys.maxsize > 2**32 else 32)')   
 if [ "$python_bitness" != "" ] && [ "$python_bitness" != "64" ] && [ "$OS_NAME" != "Raspbian" ]; then
     echo "[setupvars.sh] 64 bitness for Python" $python_version "is requred"
 fi
 
+MINIMUM_REQUIRED_PYTHON_VERSION="3.6"    
+if [[ ! -z "$python_version" && "$(printf '%s\n' "$python_version" "$MINIMUM_REQUIRED_PYTHON_VERSION" | sort -V | head -n 1)" != "$MINIMUM_REQUIRED_PYTHON_VERSION" ]]; then
+    echo "[setupvars.sh] Unsupported Python version. Please install Python 3.6 or higher (64-bit) from https://www.python.org/downloads/"
+fi
+
 if [ ! -z "$python_version" ]; then
-    if [ "$python_version" != "2.7" ]; then
-        # add path to OpenCV API for Python 3.x
-        export PYTHONPATH="$INTEL_OPENVINO_DIR/python/python3:$PYTHONPATH"
+    # add path to OpenCV API for Python 3.x
+    export PYTHONPATH="$INTEL_OPENVINO_DIR/python/python3:$PYTHONPATH"
+    if [[ -e $INTEL_OPENVINO_DIR/python/python$python_version ]]; then
+        # add path to Inference Engine Python API
+        export PYTHONPATH="$INTEL_OPENVINO_DIR/python/python$python_version:$PYTHONPATH"
     fi
-    # add path to Inference Engine Python API
-    export PYTHONPATH="$INTEL_OPENVINO_DIR/python/python$python_version:$PYTHONPATH"
 fi
 
 echo "[setupvars.sh] OpenVINO environment initialized"


### PR DESCRIPTION
install_openvino_dependencies: Updated copyrights
setupvars.bat: Updated notification about incorrect Python version. Removed checking ICC2019
setupvars.sh: Removed logic with choosing higher version of installed Python. Added dynamic detecting python3 major and minor version for setting path. Add checking minimum required Python version(now 3.6)