### PR TITLE
Fix tile layer test header

### DIFF
--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/tile.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/tile.hpp
@@ -12,6 +12,8 @@
 #include "functional_test_utils/layer_test_utils.hpp"
 #include "ngraph_functions/builders.hpp"
 
+namespace LayerTestsDefinitions {
+
 typedef std::vector<size_t> TileSpecificParams;
 typedef std::tuple<
         TileSpecificParams,
@@ -20,10 +22,8 @@ typedef std::tuple<
         LayerTestsUtils::TargetDevice  // Device name
 > TileLayerTestParamsSet;
 
-namespace LayerTestsDefinitions {
-
 class TileLayerTest : public testing::WithParamInterface<TileLayerTestParamsSet>,
-                      public LayerTestsUtils::LayerTestsCommon {
+                      virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<TileLayerTestParamsSet> obj);
 


### PR DESCRIPTION
Align Tile layer test header with others, it is needed to nest this test in plugin correctly.