### PR TITLE
VPU: Reduce memory consumption in temporary buffers

### DIFF
--- a/inference-engine/src/vpu/graph_transformer/include/vpu/model/model.hpp
+++ b/inference-engine/src/vpu/graph_transformer/include/vpu/model/model.hpp
@@ -146,6 +146,10 @@ public:
             const Stage& stage,
             const DataDesc& desc);
 
+    StageTempBuffer addTempBuffer(
+            const Stage& stage,
+            size_t bufferSize);
+
     void replaceStageInput(
             const StageInput& edge,
             const Data& newInput);

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/sw_conv_adaptation.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/sw_conv_adaptation.cpp
@@ -134,8 +134,8 @@ private:
                         std::make_shared<ConvIm2ColWeightsContent>(weights->content(), newWeightsDesc));
 
                     double im2ColBufSizeF = static_cast<double>(kernelSizeX) * kernelSizeY *
-                        output->desc().dim(Dim::W) * output->desc().dim(Dim::H) * input->desc().dim(Dim::C)
-                        + 32;
+                        output->desc().dim(Dim::W) * output->desc().dim(Dim::H) * input->desc().dim(Dim::C) * sizeof(int16_t)
+                        + 64;
 
                     if (im2ColBufSizeF >= std::numeric_limits<int>::max()) {
                         VPU_THROW_EXCEPTION << "stage: " << name() << ", im2col bufferSize cannot fit 32s: "
@@ -144,7 +144,7 @@ private:
                             << output->desc().dim(Dim::W) << "x" << output->desc().dim(Dim::H) << "x" << output->desc().dim(Dim::C) << ")";
                     }
 
-                    model()->addTempBuffer(this, DataDesc({static_cast<int>(im2ColBufSizeF)}));
+                    model()->addTempBuffer(this, static_cast<int>(im2ColBufSizeF));
                 }
 
                 weights->attrs().set<Data>("swWeights", swWeights);

--- a/inference-engine/src/vpu/graph_transformer/src/model/model.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/model/model.cpp
@@ -425,6 +425,13 @@ StageDependency ModelObj::addStageDependency(const Stage& stage, const Data& dat
 
 StageTempBuffer ModelObj::addTempBuffer(
         const Stage& stage,
+        size_t bufferSize) {
+    auto desc = DataDesc(DataType::U8, DimsOrder::C, {bufferSize});
+    return addTempBuffer(stage, desc);
+}
+
+StageTempBuffer ModelObj::addTempBuffer(
+        const Stage& stage,
         const DataDesc& desc) {
     //
     // Check that objects belong to the same Model.

--- a/inference-engine/src/vpu/graph_transformer/src/stages/custom.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/custom.cpp
@@ -478,9 +478,7 @@ void FrontEnd::parseCustom(const Model& model, const ie::CNNLayerPtr& layer, con
         stage->attrs().set("outputOrders", std::move(outputOrders));
 
         int buffer_size = kernel.kernelBinary().length() + 1024;
-        model->addTempBuffer(
-            stage,
-            DataDesc({buffer_size}));
+        model->addTempBuffer(stage, buffer_size);
     }
 }
 

--- a/inference-engine/src/vpu/graph_transformer/src/stages/detection_output.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/detection_output.cpp
@@ -240,7 +240,7 @@ void FrontEnd::parseDetectionOutput(const Model& model, const ie::CNNLayerPtr& l
         size_num_priors_actual_buf +
         size_temp_data_buf;
 
-    model->addTempBuffer(stage, DataDesc({buffer_size}));
+    model->addTempBuffer(stage, buffer_size);
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/proposal.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/proposal.cpp
@@ -183,9 +183,7 @@ void FrontEnd::parseProposal(const Model& model, const ie::CNNLayerPtr& layer, c
     const auto& env = CompileEnv::get();
     const int required_cmx_buffer_size = env.resources.numSHAVEs * required_cmx_size_per_shave;
 
-    model->addTempBuffer(
-        stage,
-        DataDesc({buffer_size + required_cmx_buffer_size}));
+    model->addTempBuffer(stage, buffer_size + required_cmx_buffer_size);
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/rnn.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/rnn.cpp
@@ -197,7 +197,7 @@ void FrontEnd::parseRNN(const Model& model, const ie::CNNLayerPtr& _layer, const
         outputData);
 
     if (nCells > 1)
-        model->addTempBuffer(stage, DataDesc({stateSize}));
+        model->addTempBuffer(stage, sizeof(uint16_t) * stateSize);
 
     bool RNNForward = layer->direction == ie::RNNSequenceLayer::FWD;
     stage->attrs().set<bool>("RNNForward", RNNForward);

--- a/inference-engine/src/vpu/graph_transformer/src/stages/roi_feature_extractor.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/roi_feature_extractor.cpp
@@ -149,7 +149,7 @@ void FrontEnd::parseROIFeatureExtractor(const Model& model, const ie::CNNLayerPt
                       size_dummy_mapping_buf +
                       size_repacked_buf;
 
-    model->addTempBuffer(stage, DataDesc({buffer_size}));
+    model->addTempBuffer(stage, buffer_size);
 }
 
 }  // namespace vpu


### PR DESCRIPTION
- 39084

Reduce memory size for temporary buffers (now layers consume 2x bigger memory than necessary)