### PR TITLE
[IE] Add static version of low_precision_transformation library

### DIFF
--- a/inference-engine/src/low_precision_transformations/CMakeLists.txt
+++ b/inference-engine/src/low_precision_transformations/CMakeLists.txt
@@ -19,24 +19,60 @@ file(GLOB_RECURSE PUBLIC_HEADERS ${PUBLIC_HEADERS_DIR}/low_precision_transformat
 source_group("src" FILES ${LIBRARY_SRC})
 source_group("include" FILES ${PUBLIC_HEADERS})
 
-# Create shared library
+# Create object library
+
+add_library(${TARGET_NAME}_obj OBJECT
+            ${LIBRARY_SRC}
+            ${LIBRARY_HEADERS})
+
+set_ie_threading_interface_for(${TARGET_NAME}_obj)
+
+target_compile_definitions(${TARGET_NAME}_obj PRIVATE IMPLEMENT_INFERENCE_ENGINE_API
+                                                      $<TARGET_PROPERTY:inference_engine,INTERFACE_COMPILE_DEFINITIONS>
+                                                      $<TARGET_PROPERTY:openvino::itt,INTERFACE_COMPILE_DEFINITIONS>)
+
+target_include_directories(${TARGET_NAME}_obj PRIVATE ${PUBLIC_HEADERS_DIR}
+                                                      $<TARGET_PROPERTY:inference_engine_plugin_api,INTERFACE_INCLUDE_DIRECTORIES>
+                                                      $<TARGET_PROPERTY:inference_engine,INTERFACE_INCLUDE_DIRECTORIES>
+                                                      $<TARGET_PROPERTY:openvino::itt,INTERFACE_INCLUDE_DIRECTORIES>)
+
+add_cpplint_target(${TARGET_NAME}_cpplint FOR_TARGETS ${TARGET_NAME}_obj)
+
+# Create shared library file from object library
+
+file(TOUCH ${CMAKE_CURRENT_BINARY_DIR}/dummy.cpp)
 
 add_library(${TARGET_NAME} SHARED
-            ${LIBRARY_SRC}
-            ${PUBLIC_HEADERS})
+            # according to https://cmake.org/cmake/help/latest/command/add_library.html#id4
+            # Some native build systems (such as Xcode) may not like targets that have only
+            # object files, so consider adding at least one real source file to any target that
+            # references $<TARGET_OBJECTS:objlib>.
+            ${CMAKE_CURRENT_BINARY_DIR}/dummy.cpp
+            $<TARGET_OBJECTS:${TARGET_NAME}_obj>)
 
-target_compile_definitions(${TARGET_NAME} PRIVATE IMPLEMENT_INFERENCE_ENGINE_API)
+set_ie_threading_interface_for(${TARGET_NAME})
+
+target_include_directories(${TARGET_NAME} INTERFACE ${PUBLIC_HEADERS_DIR}
+                                                    $<TARGET_PROPERTY:inference_engine_plugin_api,INTERFACE_INCLUDE_DIRECTORIES>)
 
 target_link_libraries(${TARGET_NAME} PRIVATE inference_engine openvino::itt)
 
-target_include_directories(${TARGET_NAME} PUBLIC ${PUBLIC_HEADERS_DIR}
-	$<TARGET_PROPERTY:inference_engine_plugin_api,INTERFACE_INCLUDE_DIRECTORIES>)
+# Static library used for unit tests which are always built
 
-add_cpplint_target(${TARGET_NAME}_cpplint FOR_TARGETS ${TARGET_NAME})
+add_library(${TARGET_NAME}_s STATIC $<TARGET_OBJECTS:${TARGET_NAME}_obj>)
+
+set_ie_threading_interface_for(${TARGET_NAME}_s)
+
+target_compile_definitions(${TARGET_NAME}_s INTERFACE USE_STATIC_IE)
+
+target_include_directories(${TARGET_NAME}_s INTERFACE ${PUBLIC_HEADERS_DIR}
+                                                      $<TARGET_PROPERTY:inference_engine_plugin_api,INTERFACE_INCLUDE_DIRECTORIES>)
+
+target_link_libraries(${TARGET_NAME}_s PUBLIC inference_engine_s openvino::itt)
 
 # developer package
 
-ie_developer_export_targets(${TARGET_NAME})
+ie_developer_export_targets(${TARGET_NAME} ${TARGET_NAME}_s)
 
 # install
 

--- a/inference-engine/tests/ie_test_utils/unit_test_utils/CMakeLists.txt
+++ b/inference-engine/tests/ie_test_utils/unit_test_utils/CMakeLists.txt
@@ -9,7 +9,7 @@ add_subdirectory(mocks/mock_engine)
 list(APPEND EXPORT_DEPENDENCIES
         commonTestUtils_s
         inference_engine_s
-        inference_engine_lp_transformations
+        inference_engine_lp_transformations_s
         gmock)
 
 addIeTarget(


### PR DESCRIPTION
Use it for unit tests. Otherwise this will link `inference_engine` library twice : static (direct target link) and shared (low_precision_transformation library dependency).