### PR TITLE
Subgraph Specific Metric and Unit Test

### DIFF
--- a/docs/template_plugin/tests/functional/shared_tests_instances/behavior/core_integration.cpp
+++ b/docs/template_plugin/tests/functional/shared_tests_instances/behavior/core_integration.cpp
@@ -160,6 +160,10 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::Values("TEMPLATE", "MULTI:TEMPLATE", "HETERO:TEMPLATE"));
 
 INSTANTIATE_TEST_CASE_P(
+        nightly_IEClassExecutableNetworkGetMetricTest, IEClassExecutableNetworkGetMetricTest_SUBGRAPH_METRIC,
+        ::testing::Values("HETERO:TEMPLATE"));
+
+INSTANTIATE_TEST_CASE_P(
         nightly_IEClassExecutableNetworkGetMetricTest_ThrowsUnsupported, IEClassExecutableNetworkGetMetricTest,
         ::testing::Values("TEMPLATE", "MULTI:TEMPLATE", "HETERO:TEMPLATE"));
 //

--- a/inference-engine/include/ie_plugin_config.hpp
+++ b/inference-engine/include/ie_plugin_config.hpp
@@ -156,6 +156,18 @@ DECLARE_METRIC_KEY(DEVICE_THERMAL, float);
  */
 DECLARE_EXEC_NETWORK_METRIC_KEY(OPTIMAL_NUMBER_OF_INFER_REQUESTS, unsigned int);
 
+/**
+ * @brief Metric to get for a specific subgraph.
+ */
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+#define METRIC_SUBGRAPH_TAG TOSTRING(METRIC_SUBGRAPH_)
+
+/**
+ * @brief Metric to get the number of partitions in a hetero executable network.
+ */
+DECLARE_EXEC_NETWORK_METRIC_KEY(NUMBER_OF_NETWORK_SUBGRAPHS, unsigned int);
+
 }  // namespace Metrics
 
 /**

--- a/inference-engine/src/hetero_plugin/hetero_executable_network.cpp
+++ b/inference-engine/src/hetero_plugin/hetero_executable_network.cpp
@@ -1067,6 +1067,30 @@ void HeteroExecutableNetwork::GetMetric(const std::string &name, InferenceEngine
             value = std::max(value, desc._network.GetMetric(METRIC_KEY(OPTIMAL_NUMBER_OF_INFER_REQUESTS)).as<unsigned int>());
         }
         result = IE_SET_METRIC(OPTIMAL_NUMBER_OF_INFER_REQUESTS, value);
+    } else if (name.rfind(METRIC_SUBGRAPH_TAG, 0) == 0) {
+        std::string partition_index_str = "";
+        unsigned int partition_index;
+        unsigned int i;
+        // retrieve a continuous string of numbers specifying the index of the partition
+        // for which the metric is requested for
+        for (i = strlen(METRIC_SUBGRAPH_TAG); i < name.length(); i++) {
+            if ( isdigit(name[i] ) ) {
+                partition_index_str += name[i];
+            } else if ( name[i] != '_' ) {
+                break;
+            }
+        }
+        std::string metric_name = name.substr(i);
+        if (partition_index_str.length()) {
+            partition_index = std::stoi(partition_index_str);
+            // auto value = networks[partition_index]._network.GetMetric(metric_name).as<double>();
+            result = networks[partition_index]._network.GetMetric(metric_name);
+            // if (METRIC_KEY(ESTIMATED_THROUGHPUT) == metric_name) {
+            //     result = IE_SET_METRIC(ESTIMATED_THROUGHPUT, value);
+            // }
+        } else {
+            THROW_IE_EXCEPTION << "Unsupported ExecutableNetwork metric: " << name;
+        }
     } else {
         // find metric key among plugin metrics
         for (auto&& desc : networks) {

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/behavior/core_integration.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/behavior/core_integration.cpp
@@ -98,6 +98,10 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::Values("CPU", "MULTI:CPU", "HETERO:CPU"));
 
 INSTANTIATE_TEST_CASE_P(
+        smoke_IEClassExecutableNetworkGetMetricTest, IEClassExecutableNetworkGetMetricTest_SUBGRAPH_METRIC,
+        ::testing::Values("HETERO:CPU"));
+
+INSTANTIATE_TEST_CASE_P(
         smoke_IEClassExecutableNetworkGetMetricTest, IEClassExecutableNetworkGetMetricTest_ThrowsUnsupported,
         ::testing::Values("CPU", "MULTI:CPU", "HETERO:CPU"));
 

--- a/inference-engine/tests/functional/plugin/shared/include/behavior/core_integration.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/behavior/core_integration.hpp
@@ -163,6 +163,7 @@ using IEClassExecutableNetworkGetMetricTest_SUPPORTED_CONFIG_KEYS = IEClassBaseT
 using IEClassExecutableNetworkGetMetricTest_SUPPORTED_METRICS = IEClassBaseTestP;
 using IEClassExecutableNetworkGetMetricTest_NETWORK_NAME = IEClassBaseTestP;
 using IEClassExecutableNetworkGetMetricTest_OPTIMAL_NUMBER_OF_INFER_REQUESTS = IEClassBaseTestP;
+using IEClassExecutableNetworkGetMetricTest_SUBGRAPH_METRIC = IEClassBaseTestP;
 using IEClassExecutableNetworkGetMetricTest_ThrowsUnsupported = IEClassBaseTestP;
 using IEClassExecutableNetworkGetConfigTest = IEClassBaseTestP;
 using IEClassExecutableNetworkSetConfigTest = IEClassBaseTestP;
@@ -947,6 +948,22 @@ TEST_P(IEClassExecutableNetworkGetMetricTest_OPTIMAL_NUMBER_OF_INFER_REQUESTS, G
     unsigned int value = p;
 
     std::cout << "Optimal number of Inference Requests: " << value << std::endl;
+    ASSERT_GE(value, 1u);
+    ASSERT_EXEC_METRIC_SUPPORTED(EXEC_NETWORK_METRIC_KEY(OPTIMAL_NUMBER_OF_INFER_REQUESTS));
+}
+
+TEST_P(IEClassExecutableNetworkGetMetricTest_SUBGRAPH_METRIC, GetMetricNoThrow) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED();
+    Core ie;
+    Parameter p;
+
+    ExecutableNetwork exeNetwork = ie.LoadNetwork(simpleNetwork, deviceName);
+
+    std::string partition_metric = METRIC_SUBGRAPH_TAG + std::to_string(0) + "_OPTIMAL_NUMBER_OF_INFER_REQUESTS";
+
+    ASSERT_NO_THROW(p = exeNetwork.GetMetric(partition_metric));
+    unsigned int value = p;
+
     ASSERT_GE(value, 1u);
     ASSERT_EXEC_METRIC_SUPPORTED(EXEC_NETWORK_METRIC_KEY(OPTIMAL_NUMBER_OF_INFER_REQUESTS));
 }


### PR DESCRIPTION
Allow users to specify a subgraph partition number and retrieve a metric for that subgraph.