### PR TITLE
Implement LookupTableInsert shape inference

### DIFF
--- a/model-optimizer/automation/package_BOM.txt
+++ b/model-optimizer/automation/package_BOM.txt
@@ -390,6 +390,7 @@ extensions/front/tf/identity_ext.py
 extensions/front/tf/identityN_to_identity.py
 extensions/front/tf/InterpolateTransposes.py
 extensions/front/tf/IteratorGetNext_ext.py
+extensions/front/tf/LookupTableInsert_ext.py
 extensions/front/tf/LoopCond_ext.py
 extensions/front/tf/lrn_ext.py
 extensions/front/tf/mask_rcnn_support.json

--- a/model-optimizer/automation/package_BOM.txt
+++ b/model-optimizer/automation/package_BOM.txt
@@ -630,6 +630,7 @@ extensions/ops/identity.py
 extensions/ops/instance_normalization.py
 extensions/ops/interp.py
 extensions/ops/interpolate.py
+extensions/ops/LookupTableInsert.py
 extensions/ops/LSTM.py
 extensions/ops/lstm_cell.py
 extensions/ops/lstm_sequence.py

--- a/model-optimizer/extensions/front/tf/LookupTableInsert_ext.py
+++ b/model-optimizer/extensions/front/tf/LookupTableInsert_ext.py
@@ -14,7 +14,7 @@
  limitations under the License.
 """
 
-from extensions.ops.LookupTableInsert import LookupTableInsert, LookupTableInsertV2
+from extensions.ops.LookupTableInsert import LookupTableInsert
 from mo.front.extractor import FrontExtractorOp
 
 
@@ -34,5 +34,5 @@ class LookupTableInsertV2FrontExtractor(FrontExtractorOp):
 
     @classmethod
     def extract(cls, node):
-        LookupTableInsertV2.update_node_stat(node, {})
+        LookupTableInsert.update_node_stat(node, {})
         return cls.enabled

--- a/model-optimizer/extensions/front/tf/LookupTableInsert_ext.py
+++ b/model-optimizer/extensions/front/tf/LookupTableInsert_ext.py
@@ -1,0 +1,38 @@
+"""
+ Copyright (C) 2020 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+from extensions.ops.LookupTableInsert import LookupTableInsert, LookupTableInsertV2
+from mo.front.extractor import FrontExtractorOp
+
+
+class LookupTableInsertFrontExtractor(FrontExtractorOp):
+    op = 'LookupTableInsert'
+    enabled = True
+
+    @classmethod
+    def extract(cls, node):
+        LookupTableInsert.update_node_stat(node, {})
+        return cls.enabled
+
+
+class LookupTableInsertV2FrontExtractor(FrontExtractorOp):
+    op = 'LookupTableInsertV2'
+    enabled = True
+
+    @classmethod
+    def extract(cls, node):
+        LookupTableInsertV2.update_node_stat(node, {})
+        return cls.enabled

--- a/model-optimizer/extensions/ops/LookupTableInsert.py
+++ b/model-optimizer/extensions/ops/LookupTableInsert.py
@@ -1,0 +1,57 @@
+"""
+ Copyright (C) 2020 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import numpy as np
+
+from mo.front.common.partial_infer.utils import int64_array
+from mo.graph.graph import Node, Graph
+from mo.ops.op import Op
+
+
+class LookupTableInsertV2(Op):
+    '''
+    Implementation of a shape inference for LookupTableInsertV2 here is also needed
+    if other nodes not being pruned have a conditional dependence on LookupTableInsertV2 node
+    '''
+    op = 'LookupTableInsertV2'
+
+    def __init__(self, graph: Graph, attrs: dict):
+        mandatory_props = {
+            'kind': 'op',
+            'type': __class__.op,
+            'op': __class__.op,
+            'infer': self.infer,
+            'in_ports_count': 3,
+            'out_ports_count': 1,
+        }
+        super().__init__(graph, mandatory_props, attrs)
+
+    @staticmethod
+    def infer(node: Node):
+        node_name = node.soft_get('name', node.id)
+        connected_in_ports = [port for port in node.in_ports().values() if not port.disconnected()]
+        assert len(connected_in_ports) == 3, \
+            "Incorrect number of inputs for {} node".format(node_name)
+
+        # check shapes of input tensors
+        keys_shape = node.in_port(1).data.get_shape()
+        values_shape = node.in_port(2).data.get_shape()
+        assert np.array_equal(keys_shape, values_shape), \
+            'Shapes of tensors with keys and values must be equal for {} node'.format(node_name)
+
+        # set output shape that must be empty
+        # since output is not a tensor
+        node.out_port(0).data.set_shape(int64_array([]))

--- a/model-optimizer/extensions/ops/LookupTableInsert.py
+++ b/model-optimizer/extensions/ops/LookupTableInsert.py
@@ -21,17 +21,19 @@ from mo.graph.graph import Node, Graph
 from mo.ops.op import Op
 
 
-class LookupTableInsertV2(Op):
+class LookupTableInsert(Op):
     '''
-    Implementation of a shape inference for LookupTableInsertV2 here is also needed
-    if other nodes not being pruned have a conditional dependence on LookupTableInsertV2 node
+    In some models this operation has only output control flow edges and no output data edges.
+    And for these cases implementation of the shape inference is needed since the shape inference is executed
+    before control flow edges resolving. This operation has non-tensor output so the output shape is empty.
     '''
-    op = 'LookupTableInsertV2'
+    enabled = False
+    op = 'LookupTableInsert'
 
     def __init__(self, graph: Graph, attrs: dict):
         mandatory_props = {
-            'kind': 'op',
-            'op': __class__.op,
+            'type': None,
+            'op': self.op,
             'infer': self.infer,
             'in_ports_count': 3,
             'out_ports_count': 1,
@@ -54,3 +56,8 @@ class LookupTableInsertV2(Op):
         # set output shape that must be empty
         # since output is not a tensor
         node.out_port(0).data.set_shape(int64_array([]))
+
+
+class LookupTableInsertV2(LookupTableInsert):
+    enabled = False
+    op = 'LookupTableInsertV2'

--- a/model-optimizer/extensions/ops/LookupTableInsert.py
+++ b/model-optimizer/extensions/ops/LookupTableInsert.py
@@ -31,7 +31,6 @@ class LookupTableInsertV2(Op):
     def __init__(self, graph: Graph, attrs: dict):
         mandatory_props = {
             'kind': 'op',
-            'type': __class__.op,
             'op': __class__.op,
             'infer': self.infer,
             'in_ports_count': 3,

--- a/model-optimizer/extensions/ops/LookupTableInsert.py
+++ b/model-optimizer/extensions/ops/LookupTableInsert.py
@@ -23,7 +23,7 @@ from mo.ops.op import Op
 
 class LookupTableInsert(Op):
     '''
-    In some models this operation has only output control flow edges and no output data edges.
+    This operation has only output control flow edges and no output data edges in some models.
     And for these cases implementation of the shape inference is needed since the shape inference is executed
     before control flow edges resolving. This operation has non-tensor output so the output shape is empty.
     '''
@@ -56,8 +56,3 @@ class LookupTableInsert(Op):
         # set output shape that must be empty
         # since output is not a tensor
         node.out_port(0).data.set_shape(int64_array([]))
-
-
-class LookupTableInsertV2(LookupTableInsert):
-    enabled = False
-    op = 'LookupTableInsertV2'

--- a/model-optimizer/extensions/ops/LookupTableInsert_test.py
+++ b/model-optimizer/extensions/ops/LookupTableInsert_test.py
@@ -18,7 +18,7 @@ import unittest
 
 import numpy as np
 
-from extensions.ops.LookupTableInsert import LookupTableInsertV2
+from extensions.ops.LookupTableInsert import LookupTableInsert
 from mo.front.common.partial_infer.utils import int64_array
 from mo.graph.graph import Node
 from mo.utils.unittest.graph import build_graph
@@ -29,17 +29,17 @@ nodes_attributes = {'table': {'kind': 'op'},
                     'keys_data': {'shape': None, 'value': None, 'kind': 'data'},
                     'values': {'kind': 'op'},
                     'values_data': {'shape': None, 'value': None, 'kind': 'data'},
-                    'lookuptableinsertv2_node': {'op': 'LookupTableInsertV2', 'kind': 'op'},
+                    'lookuptableinsert_node': {'op': 'LookupTableInsert', 'kind': 'op'},
                     'output': {'shape': None, 'value': None, 'kind': 'data'}}
 
 # graph 1
 edges1 = [('table', 'table_data'),
           ('keys', 'keys_data'),
           ('values', 'values_data'),
-          ('table_data', 'lookuptableinsertv2_node', {'in': 0}),
-          ('keys_data', 'lookuptableinsertv2_node', {'in': 1}),
-          ('values_data', 'lookuptableinsertv2_node', {'in': 2}),
-          ('lookuptableinsertv2_node', 'output')]
+          ('table_data', 'lookuptableinsert_node', {'in': 0}),
+          ('keys_data', 'lookuptableinsert_node', {'in': 1}),
+          ('values_data', 'lookuptableinsert_node', {'in': 2}),
+          ('lookuptableinsert_node', 'output')]
 
 # valid test case
 inputs1 = {'table_data': {},
@@ -51,11 +51,11 @@ inputs2 = {'table_data': {},
            'keys_data': {'shape': int64_array([5, 2])},
            'values_data': {'shape': int64_array([4])}}
 
-class TestLookupTableInsertV2(unittest.TestCase):
+class TestLookupTableInsert(unittest.TestCase):
     def test_infer1(self):
         graph = build_graph(nodes_attributes, edges1, inputs1)
-        lookuptableinsertv2_node = Node(graph, 'lookuptableinsertv2_node')
-        LookupTableInsertV2.infer(lookuptableinsertv2_node)
+        lookuptableinsert_node = Node(graph, 'lookuptableinsert_node')
+        LookupTableInsert.infer(lookuptableinsert_node)
 
         # prepare reference results
         ref_output_shape = int64_array([])
@@ -68,5 +68,5 @@ class TestLookupTableInsertV2(unittest.TestCase):
 
     def test_infer_invalid1(self):
         graph = build_graph(nodes_attributes, edges1, inputs2)
-        lookuptableinsertv2_node = Node(graph, 'lookuptableinsertv2_node')
-        self.assertRaises(AssertionError, LookupTableInsertV2.infer, lookuptableinsertv2_node)
+        lookuptableinsert_node = Node(graph, 'lookuptableinsert_node')
+        self.assertRaises(AssertionError, LookupTableInsert.infer, lookuptableinsert_node)

--- a/model-optimizer/extensions/ops/LookupTableInsert_test.py
+++ b/model-optimizer/extensions/ops/LookupTableInsert_test.py
@@ -1,0 +1,72 @@
+"""
+ Copyright (C) 2020 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import unittest
+
+import numpy as np
+
+from extensions.ops.LookupTableInsert import LookupTableInsertV2
+from mo.front.common.partial_infer.utils import int64_array
+from mo.graph.graph import Node
+from mo.utils.unittest.graph import build_graph
+
+nodes_attributes = {'table': {'kind': 'op'},
+                    'table_data': {'shape': None, 'value': None, 'kind': 'data'},
+                    'keys': {'kind': 'op'},
+                    'keys_data': {'shape': None, 'value': None, 'kind': 'data'},
+                    'values': {'kind': 'op'},
+                    'values_data': {'shape': None, 'value': None, 'kind': 'data'},
+                    'lookuptableinsertv2_node': {'op': 'LookupTableInsertV2', 'kind': 'op'},
+                    'output': {'shape': None, 'value': None, 'kind': 'data'}}
+
+# graph 1
+edges1 = [('table', 'table_data'),
+          ('keys', 'keys_data'),
+          ('values', 'values_data'),
+          ('table_data', 'lookuptableinsertv2_node', {'in': 0}),
+          ('keys_data', 'lookuptableinsertv2_node', {'in': 1}),
+          ('values_data', 'lookuptableinsertv2_node', {'in': 2}),
+          ('lookuptableinsertv2_node', 'output')]
+
+# valid test case
+inputs1 = {'table_data': {},
+           'keys_data': {'shape': int64_array([4])},
+           'values_data': {'shape': int64_array([4])}}
+
+# invalid test case
+inputs2 = {'table_data': {},
+           'keys_data': {'shape': int64_array([5, 2])},
+           'values_data': {'shape': int64_array([4])}}
+
+class TestLookupTableInsertV2(unittest.TestCase):
+    def test_infer1(self):
+        graph = build_graph(nodes_attributes, edges1, inputs1)
+        lookuptableinsertv2_node = Node(graph, 'lookuptableinsertv2_node')
+        LookupTableInsertV2.infer(lookuptableinsertv2_node)
+
+        # prepare reference results
+        ref_output_shape = int64_array([])
+
+        # get the result
+        res_output_shape = graph.node['output']['shape']
+
+        self.assertTrue(np.array_equal(ref_output_shape, res_output_shape),
+                        'shapes do not match expected: {} and given: {}'.format(ref_output_shape, res_output_shape))
+
+    def test_infer_invalid1(self):
+        graph = build_graph(nodes_attributes, edges1, inputs2)
+        lookuptableinsertv2_node = Node(graph, 'lookuptableinsertv2_node')
+        self.assertRaises(AssertionError, LookupTableInsertV2.infer, lookuptableinsertv2_node)


### PR DESCRIPTION
Description: In some OCR model Nodes not being pruned in a graph have a conditional dependence on LookupTableInsert node and it requires a shape inference for this node before conditional resolving pass.

JIRA: 38082

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR - N/A. it does not introduce new transformations
* [x]  Transformation preserves original framework node names - N/A. it does not introduce new transformations


Validation:
* [x]  Unit tests
* [x]  Framework operation tests - N/A. it does not implement any framework operations
* [x]  Transformation tests - N/A
* [x]  e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py - it will be in a separate ticket
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list - it does not introduce new operations in out opset
* [x]  Supported **public** models list - it is not a public model
* [x]  New operations specification - it does not introduce new operations in out opset
* [x]  Guide on how to convert the **public** model - it is not a public model
* [x]  User guide update - it is not a public model

Signed-off-by: Roman Kazantsev <roman.kazantsev@intel.com>