### PR TITLE
support for conversion between fp32 and fp16 types for ngraph_helpers

### DIFF
--- a/inference-engine/tests/ngraph_functions/src/utils/ngraph_helpers.cpp
+++ b/inference-engine/tests/ngraph_functions/src/utils/ngraph_helpers.cpp
@@ -491,6 +491,10 @@ std::vector<std::uint8_t> convertOutputPrecision(std::vector<std::uint8_t> &outp
             case element::Type_t::f32: {
                 return convertPrecision<float, float>(output, elementsCount, element::Type(toPrecision).size());
             }
+            case element::Type_t::f16: {
+                // ngraph float16 has single ctor from float
+              return convertPrecision<float, ngraph::float16>(output, elementsCount, element::Type(toPrecision).size());
+            }
             case element::Type_t::u64: {
                 return convertPrecision<float, uint64_t>(output, elementsCount, element::Type(toPrecision).size());
             }


### PR DESCRIPTION
for calc ngraph reference in cases where network has fp16 outputs