### PR TITLE
fix hetero to stop using deprectaed pugixml methods

### DIFF
--- a/inference-engine/src/hetero_plugin/hetero_executable_network.cpp
+++ b/inference-engine/src/hetero_plugin/hetero_executable_network.cpp
@@ -714,7 +714,7 @@ HeteroExecutableNetwork::HeteroExecutableNetwork(std::istream&                  
     std::getline(heteroModel, heteroXmlStr);
 
     pugi::xml_document heteroXmlDoc;
-    pugi::xml_parse_result res = heteroXmlDoc.load(heteroXmlStr.c_str());
+    pugi::xml_parse_result res = heteroXmlDoc.load_string(heteroXmlStr.c_str());
 
     if (res.status != pugi::status_ok) {
         THROW_IE_EXCEPTION << "Error reading HETERO plugin xml header";


### PR DESCRIPTION
OpenVINO uses a vendor copy of pugixml that is not entirely recent. Once updating pugixml (not requested here), the build fails, because `pugi::xml_document::load` is deprecated and the build turns deprecation warnings into errors. The vendored version of pugixml already provides the non-deprecated alternatives such as `load_string` and `load_file`. Therefore, we can switch the function used right now and avoid the future build failure.