### PR TITLE
[IE][VPU]: Reduce tests execution time

### DIFF
--- a/inference-engine/tests/functional/plugin/gna/import_export_network.cpp
+++ b/inference-engine/tests/functional/plugin/gna/import_export_network.cpp
@@ -49,7 +49,6 @@ class ImportNetworkTest : public testing::WithParamInterface<exportImportNetwork
         void Run() override {
             SKIP_IF_CURRENT_TEST_IS_DISABLED()
 
-            ConfigurePlugin();
             LoadNetwork();
             Infer();
             executableNetwork.Export("exported_model.blob");

--- a/inference-engine/tests/functional/plugin/shared/src/behavior/stress_tests.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/behavior/stress_tests.cpp
@@ -26,14 +26,12 @@ void MultipleAllocations::SetUp() {
 TEST_P(MultipleAllocations, InferWorksCorrectAfterAllocations) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 
-    ConfigurePlugin();
-
     InferenceEngine::CNNNetwork cnnNet(function);
     auto ie = PluginCache::get().ie();
 
     std::cout << "Load the network " << m_allocationsCount << " times..." << std::flush;
     for (int i = 0; i < m_allocationsCount; ++i) {
-        ie->LoadNetwork(cnnNet, targetDevice);
+        ie->LoadNetwork(cnnNet, targetDevice, configuration);
     }
 
     std::cout << "\nCheck inference.\n";

--- a/inference-engine/tests/functional/plugin/shared/src/subgraph_tests/basic_lstm.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/subgraph_tests/basic_lstm.cpp
@@ -103,7 +103,6 @@ void Basic_LSTM_S::SetUp() {
 void Basic_LSTM_S::Run() {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 
-    ConfigurePlugin();
     LoadNetwork();
     Infer();
 

--- a/inference-engine/tests/functional/plugin/shared/src/subgraph_tests/memory_LSTMCell.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/subgraph_tests/memory_LSTMCell.cpp
@@ -197,7 +197,6 @@ namespace SubgraphTestsDefinitions {
     void MemoryLSTMCellTest::Run() {
         SKIP_IF_CURRENT_TEST_IS_DISABLED()
 
-        ConfigurePlugin();
         LoadNetwork();
         auto states = executableNetwork.QueryState();
         for (auto& state : states) {

--- a/inference-engine/tests/functional/plugin/shared/src/subgraph_tests/reshape_permute_conv_permute_reshape_act.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/subgraph_tests/reshape_permute_conv_permute_reshape_act.cpp
@@ -87,7 +87,6 @@ namespace LayerTestsDefinitions {
     void ConvReshapeAct::Run() {
         SKIP_IF_CURRENT_TEST_IS_DISABLED()
 
-        ConfigurePlugin();
         LoadNetwork();
 
         inferRequest = executableNetwork.CreateInferRequest();

--- a/inference-engine/tests/ie_test_utils/functional_test_utils/layer_test_utils.cpp
+++ b/inference-engine/tests/ie_test_utils/functional_test_utils/layer_test_utils.cpp
@@ -16,16 +16,9 @@ LayerTestsCommon::LayerTestsCommon() : threshold(1e-2f) {
 void LayerTestsCommon::Run() {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 
-    ConfigurePlugin();
     LoadNetwork();
     Infer();
     Validate();
-}
-
-LayerTestsCommon::~LayerTestsCommon() {
-    if (!configuration.empty()) {
-        PluginCache::get().reset();
-    }
 }
 
 InferenceEngine::Blob::Ptr LayerTestsCommon::GenerateInput(const InferenceEngine::InputInfo &info) const {
@@ -83,12 +76,6 @@ void LayerTestsCommon::Compare(const InferenceEngine::Blob::Ptr &expected, const
     }
 }
 
-void LayerTestsCommon::ConfigurePlugin() {
-    if (!configuration.empty()) {
-        core->SetConfig(configuration, targetDevice);
-    }
-}
-
 void LayerTestsCommon::ConfigureNetwork() const {
     for (const auto &in : cnnNetwork.getInputsInfo()) {
         if (inLayout != InferenceEngine::Layout::ANY) {
@@ -112,7 +99,7 @@ void LayerTestsCommon::ConfigureNetwork() const {
 void LayerTestsCommon::LoadNetwork() {
     cnnNetwork = InferenceEngine::CNNNetwork{function};
     ConfigureNetwork();
-    executableNetwork = core->LoadNetwork(cnnNetwork, targetDevice);
+    executableNetwork = core->LoadNetwork(cnnNetwork, targetDevice, configuration);
 }
 
 void LayerTestsCommon::Infer() {

--- a/inference-engine/tests/ie_test_utils/functional_test_utils/layer_test_utils.hpp
+++ b/inference-engine/tests/ie_test_utils/functional_test_utils/layer_test_utils.hpp
@@ -63,7 +63,7 @@ public:
 protected:
     LayerTestsCommon();
 
-    ~LayerTestsCommon() override;
+    ~LayerTestsCommon() override = default;
 
     template<class T>
     void Compare(const T *expected, const T *actual, std::size_t size, T threshold) {
@@ -91,8 +91,6 @@ protected:
     std::shared_ptr<InferenceEngine::Core> getCore() {
         return core;
     }
-
-    void ConfigurePlugin();
 
     void ConfigureNetwork() const;
 

--- a/inference-engine/tests/ie_test_utils/functional_test_utils/layer_test_utils.hpp
+++ b/inference-engine/tests/ie_test_utils/functional_test_utils/layer_test_utils.hpp
@@ -63,7 +63,6 @@ public:
 protected:
     LayerTestsCommon();
 
-    ~LayerTestsCommon() override = default;
 
     template<class T>
     void Compare(const T *expected, const T *actual, std::size_t size, T threshold) {

--- a/inference-engine/tests_deprecated/functional/vpu/common/layers/myriad_layers_convolution_test.cpp
+++ b/inference-engine/tests_deprecated/functional/vpu/common/layers/myriad_layers_convolution_test.cpp
@@ -4,13 +4,11 @@
 
 #include "myriad_layers_convolution_test.hpp"
 
-INSTANTIATE_TEST_CASE_P(accuracy_chw_dilation, myriadLayerConvolution,
+INSTANTIATE_TEST_CASE_P(accuracy_chw_dilation, myriadLayerConvolution_smoke,
         ::testing::Combine(
             ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 37, 43, 43)
                                        , MAKE_STRUCT(tensor_test_params, 1, 37, 19, 19))
-          , ::testing::Values<kernel>(
-                                      MAKE_STRUCT(param_size, 3, 3)
-                                     )
+          , ::testing::Values<kernel>(MAKE_STRUCT(param_size, 3, 3))
           , ::testing::Values<stride>(MAKE_STRUCT(param_size, 1, 1)
                                     , MAKE_STRUCT(param_size, 2, 2)
                                     , MAKE_STRUCT(param_size, 3, 3)
@@ -451,8 +449,23 @@ INSTANTIATE_TEST_CASE_P(accuracy_any_group, myriadLayerConvolution_smoke,
           , ::testing::Values<out_channels>(32)
           , ::testing::Values<group>(2, 4, 16)
           , ::testing::Values<dilation_factor>(MAKE_STRUCT(param_size, 1, 2), MAKE_STRUCT(param_size, 2, 3), MAKE_STRUCT(param_size, 3, 4)),
-            ::testing::Values<layoutPreference>(vpu::LayoutPreference::ChannelMinor,
-                                                vpu::LayoutPreference::ChannelMajor)
+            ::testing::Values<layoutPreference>(vpu::LayoutPreference::ChannelMajor)
+        )
+);
+
+INSTANTIATE_TEST_CASE_P(accuracy_any_group, myriadLayerConvolution,
+        ::testing::Combine(
+            ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 32, 64,  77))
+          , ::testing::Values<kernel>(MAKE_STRUCT(param_size, 3, 3))
+          , ::testing::Values<stride>(MAKE_STRUCT(param_size, 1, 1)
+                                    , MAKE_STRUCT(param_size, 2, 2))
+          , ::testing::Values<pad>(MAKE_STRUCT(param_size, 1, 1)
+                                 , MAKE_STRUCT(param_size, 0, 0)
+                                 , MAKE_STRUCT(param_size, 2, 2))
+          , ::testing::Values<out_channels>(32)
+          , ::testing::Values<group>(2, 4, 16)
+          , ::testing::Values<dilation_factor>(MAKE_STRUCT(param_size, 1, 2), MAKE_STRUCT(param_size, 2, 3), MAKE_STRUCT(param_size, 3, 4)),
+            ::testing::Values<layoutPreference>(vpu::LayoutPreference::ChannelMinor)
         )
 );
 
@@ -544,8 +557,24 @@ INSTANTIATE_TEST_CASE_P(accuracy_5x5, myriadLayerConvolution_smoke,
           , ::testing::Values<out_channels>(16, 32)
           , ::testing::Values<group>(1)
           , ::testing::Values<dilation_factor>(MAKE_STRUCT(param_size, 1, 2)),
-            ::testing::Values<layoutPreference>(vpu::LayoutPreference::ChannelMinor,
-                                                vpu::LayoutPreference::ChannelMajor)
+            ::testing::Values<layoutPreference>(vpu::LayoutPreference::ChannelMajor)
+        )
+);
+
+INSTANTIATE_TEST_CASE_P(accuracy_5x5, myriadLayerConvolution,
+        ::testing::Combine(
+            ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 16, 32, 32)
+                                     /*, MAKE_STRUCT(tensor_test_params, 1, 8, 511, 399) failed*/)
+          , ::testing::Values<kernel>(MAKE_STRUCT(param_size, 5, 5))
+          , ::testing::Values<stride>(MAKE_STRUCT(param_size, 1, 1)
+                                    , MAKE_STRUCT(param_size, 2, 2))
+          , ::testing::Values<pad>(MAKE_STRUCT(param_size, 0, 0)
+                               /*, MAKE_STRUCT(param_size, 1, 1) failed*/
+                                 , MAKE_STRUCT(param_size, 2, 2))
+          , ::testing::Values<out_channels>(16, 32)
+          , ::testing::Values<group>(1)
+          , ::testing::Values<dilation_factor>(MAKE_STRUCT(param_size, 1, 2)),
+            ::testing::Values<layoutPreference>(vpu::LayoutPreference::ChannelMinor)
         )
 );
 

--- a/inference-engine/tests_deprecated/functional/vpu/common/layers/myriad_layers_convolution_test.cpp
+++ b/inference-engine/tests_deprecated/functional/vpu/common/layers/myriad_layers_convolution_test.cpp
@@ -4,7 +4,7 @@
 
 #include "myriad_layers_convolution_test.hpp"
 
-INSTANTIATE_TEST_CASE_P(accuracy_chw_dilation, myriadLayerConvolution_smoke,
+INSTANTIATE_TEST_CASE_P(accuracy_chw_dilation, myriadLayerConvolution,
         ::testing::Combine(
             ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 37, 43, 43)
                                        , MAKE_STRUCT(tensor_test_params, 1, 37, 19, 19))
@@ -251,7 +251,7 @@ INSTANTIATE_TEST_CASE_P(accuracy, myriadLayers_3X3X3_ConstInput_smoke,
           )
 );
 
-INSTANTIATE_TEST_CASE_P(accuracy_crossroad_spatialConv, myriadLayerConvolutionTensorFlow_smoke,
+INSTANTIATE_TEST_CASE_P(accuracy_crossroad_spatialConv, myriadLayerConvolutionTensorFlow,
         ::testing::Combine(
             ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 3, 1024, 1024))
           , ::testing::Values<DimsOutput>(MAKE_STRUCT(tensor_test_params, 1, 3, 512, 512))
@@ -264,7 +264,7 @@ INSTANTIATE_TEST_CASE_P(accuracy_crossroad_spatialConv, myriadLayerConvolutionTe
           )
 );
 
-INSTANTIATE_TEST_CASE_P(accuracy_inception_v2, myriadLayerConvolutionTensorFlow_smoke,
+INSTANTIATE_TEST_CASE_P(accuracy_inception_v2, myriadLayerConvolutionTensorFlow,
         ::testing::Combine(
             ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 16, 28, 28))
           , ::testing::Values<DimsOutput>(MAKE_STRUCT(tensor_test_params, 1, 64, 14, 14))
@@ -277,7 +277,7 @@ INSTANTIATE_TEST_CASE_P(accuracy_inception_v2, myriadLayerConvolutionTensorFlow_
           )
 );
 
-INSTANTIATE_TEST_CASE_P(accuracy_inception_v1, myriadLayerConvolutionTensorFlow_smoke,
+INSTANTIATE_TEST_CASE_P(accuracy_inception_v1, myriadLayerConvolutionTensorFlow,
         ::testing::Combine(
             ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 3, 224, 224),
                                          MAKE_STRUCT(tensor_test_params, 1, 32, 224, 224)
@@ -292,7 +292,7 @@ INSTANTIATE_TEST_CASE_P(accuracy_inception_v1, myriadLayerConvolutionTensorFlow_
           )
 );
 
-INSTANTIATE_TEST_CASE_P(test_3x3_SSD_dilation, myriadLayerConvolution_smoke,
+INSTANTIATE_TEST_CASE_P(test_3x3_SSD_dilation, myriadLayerConvolution,
         ::testing::Combine(
             ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 512, 19, 19))
           , ::testing::Values<kernel>(MAKE_STRUCT(param_size, 3, 3))
@@ -317,7 +317,7 @@ INSTANTIATE_TEST_CASE_P(test_TF_Resnet_50, myriadLayers_IR3_ConvTests_smoke,
           )
 );
 
-INSTANTIATE_TEST_CASE_P(test_3x3_icvnet_dilation, myriadLayerConvolution_smoke,
+INSTANTIATE_TEST_CASE_P(test_3x3_icvnet_dilation, myriadLayerConvolution,
         ::testing::Combine(
             ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 24, 20, 20))
           , ::testing::Values<kernel>(MAKE_STRUCT(param_size, 3, 3))
@@ -332,7 +332,7 @@ INSTANTIATE_TEST_CASE_P(test_3x3_icvnet_dilation, myriadLayerConvolution_smoke,
           )
 );
 
-INSTANTIATE_TEST_CASE_P(test_5x5_with_dilation, myriadLayerConvolution_smoke,
+INSTANTIATE_TEST_CASE_P(test_5x5_with_dilation, myriadLayerConvolution,
         ::testing::Combine(
             ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 32, 64,  77))
           , ::testing::Values<kernel>(MAKE_STRUCT(param_size, 5, 5))
@@ -348,7 +348,7 @@ INSTANTIATE_TEST_CASE_P(test_5x5_with_dilation, myriadLayerConvolution_smoke,
           )
 );
 
-INSTANTIATE_TEST_CASE_P(test_7x7_with_dilation, myriadLayerConvolution_smoke,
+INSTANTIATE_TEST_CASE_P(test_7x7_with_dilation, myriadLayerConvolution,
         ::testing::Combine(
             ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 32, 64,  77))
           , ::testing::Values<kernel>(MAKE_STRUCT(param_size, 7, 7))
@@ -365,7 +365,7 @@ INSTANTIATE_TEST_CASE_P(test_7x7_with_dilation, myriadLayerConvolution_smoke,
 );
 
 
-INSTANTIATE_TEST_CASE_P(test_conv1x1, myriadLayerConvolution_smoke,
+INSTANTIATE_TEST_CASE_P(test_conv1x1, myriadLayerConvolution,
         ::testing::Combine(
             ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 10, 13, 13))
           , ::testing::Values<kernel>(MAKE_STRUCT(param_size, 1, 1))
@@ -379,7 +379,7 @@ INSTANTIATE_TEST_CASE_P(test_conv1x1, myriadLayerConvolution_smoke,
            )
 );
 
-INSTANTIATE_TEST_CASE_P(test_yolo_tiny_2_512x13x13_use_3x3_convolution, myriadLayerConvolution_smoke,
+INSTANTIATE_TEST_CASE_P(test_yolo_tiny_2_512x13x13_use_3x3_convolution, myriadLayerConvolution,
         ::testing::Combine(
             ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 512, 13, 13))
           , ::testing::Values<kernel>(MAKE_STRUCT(param_size, 3, 3))
@@ -392,7 +392,7 @@ INSTANTIATE_TEST_CASE_P(test_yolo_tiny_2_512x13x13_use_3x3_convolution, myriadLa
            )
 );
 
-INSTANTIATE_TEST_CASE_P(test_yolo_tiny_2_512x13x13_use_1x1_convolution, myriadLayerConvolution_smoke,
+INSTANTIATE_TEST_CASE_P(test_yolo_tiny_2_512x13x13_use_1x1_convolution, myriadLayerConvolution,
         ::testing::Combine(
             ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 4608, 13, 13))
           , ::testing::Values<kernel>(MAKE_STRUCT(param_size, 1, 1))
@@ -405,7 +405,7 @@ INSTANTIATE_TEST_CASE_P(test_yolo_tiny_2_512x13x13_use_1x1_convolution, myriadLa
            )
 );
 
-INSTANTIATE_TEST_CASE_P(accuracy_group, myriadLayerConvolution_smoke,
+INSTANTIATE_TEST_CASE_P(accuracy_group, myriadLayerConvolution,
         ::testing::Combine(
             ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 32, 64,  77)
                                        , MAKE_STRUCT(tensor_test_params, 1, 32, 112, 96))
@@ -424,7 +424,7 @@ INSTANTIATE_TEST_CASE_P(accuracy_group, myriadLayerConvolution_smoke,
           )
 );
 
-INSTANTIATE_TEST_CASE_P(accuracy_group_large_input, myriadLayerConvolution_smoke,
+INSTANTIATE_TEST_CASE_P(accuracy_group_large_input, myriadLayerConvolution,
         ::testing::Combine(
             ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 32, 192, 336))
           , ::testing::Values<kernel>(MAKE_STRUCT(param_size, 3, 3))
@@ -456,7 +456,7 @@ INSTANTIATE_TEST_CASE_P(accuracy_any_group, myriadLayerConvolution_smoke,
         )
 );
 
-INSTANTIATE_TEST_CASE_P(set_optimization_for_3x3_with_group, myriadLayerConvolution_smoke,
+INSTANTIATE_TEST_CASE_P(set_optimization_for_3x3_with_group, myriadLayerConvolution,
         ::testing::Combine(
             ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 24, 80, 80)
                                        , MAKE_STRUCT(tensor_test_params, 1, 36, 80, 80))
@@ -471,7 +471,7 @@ INSTANTIATE_TEST_CASE_P(set_optimization_for_3x3_with_group, myriadLayerConvolut
           )
 );
 
-INSTANTIATE_TEST_CASE_P(set_optimization_for_3x3s1, myriadLayerConvolution_smoke,
+INSTANTIATE_TEST_CASE_P(set_optimization_for_3x3s1, myriadLayerConvolution,
         ::testing::Combine(
             ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 24, 80, 80))
           , ::testing::Values<kernel>(MAKE_STRUCT(param_size, 3, 3))
@@ -484,7 +484,7 @@ INSTANTIATE_TEST_CASE_P(set_optimization_for_3x3s1, myriadLayerConvolution_smoke
           )
 );
 
-INSTANTIATE_TEST_CASE_P(accuracy_1x1, myriadLayerConvolution_smoke,
+INSTANTIATE_TEST_CASE_P(accuracy_1x1, myriadLayerConvolution,
         ::testing::Combine(
             ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 16, 64, 64)
                                        , MAKE_STRUCT(tensor_test_params, 1, 32, 1, 1))
@@ -501,7 +501,7 @@ INSTANTIATE_TEST_CASE_P(accuracy_1x1, myriadLayerConvolution_smoke,
           )
 );
 
-INSTANTIATE_TEST_CASE_P(accuracy_3x3, myriadLayerConvolution_smoke,
+INSTANTIATE_TEST_CASE_P(accuracy_3x3, myriadLayerConvolution,
         ::testing::Combine(
             ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 8, 16, 16)
                                        , MAKE_STRUCT(tensor_test_params, 1, 8, 59, 73))
@@ -517,7 +517,7 @@ INSTANTIATE_TEST_CASE_P(accuracy_3x3, myriadLayerConvolution_smoke,
           )
 );
 
-INSTANTIATE_TEST_CASE_P(accuracy_1x3, myriadLayerConvolution_smoke,
+INSTANTIATE_TEST_CASE_P(accuracy_1x3, myriadLayerConvolution,
         ::testing::Combine(
             ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 8, 59, 73))
           , ::testing::Values<kernel>(MAKE_STRUCT(param_size, 1, 3), MAKE_STRUCT(param_size, 3, 1))
@@ -549,7 +549,7 @@ INSTANTIATE_TEST_CASE_P(accuracy_5x5, myriadLayerConvolution_smoke,
         )
 );
 
-INSTANTIATE_TEST_CASE_P(accuracy_7x7, myriadLayerConvolution_smoke,
+INSTANTIATE_TEST_CASE_P(accuracy_7x7, myriadLayerConvolution,
         ::testing::Combine(
             ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 8, 32, 32)
                                      /*, MAKE_STRUCT(tensor_test_params, 1, 8, 511, 399) failed*/)
@@ -566,7 +566,7 @@ INSTANTIATE_TEST_CASE_P(accuracy_7x7, myriadLayerConvolution_smoke,
           )
 );
 
-INSTANTIATE_TEST_CASE_P(accuracy_3x3_large_input_1, myriadLayerConvolution_smoke,
+INSTANTIATE_TEST_CASE_P(accuracy_3x3_large_input_1, myriadLayerConvolution,
         ::testing::Combine(
             ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 3, 720, 1280))
           , ::testing::Values<kernel>(MAKE_STRUCT(param_size, 3, 3))
@@ -579,7 +579,7 @@ INSTANTIATE_TEST_CASE_P(accuracy_3x3_large_input_1, myriadLayerConvolution_smoke
           )
 );
 
-INSTANTIATE_TEST_CASE_P(accuracy_3x3_large_input_2, myriadLayerConvolution_smoke,
+INSTANTIATE_TEST_CASE_P(accuracy_3x3_large_input_2, myriadLayerConvolution,
         ::testing::Combine(
             ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 24, 357, 637))
           , ::testing::Values<kernel>(MAKE_STRUCT(param_size, 3, 3))
@@ -593,7 +593,7 @@ INSTANTIATE_TEST_CASE_P(accuracy_3x3_large_input_2, myriadLayerConvolution_smoke
 );
 
 
-INSTANTIATE_TEST_CASE_P(accuracy_3x3_large_input_3, myriadLayerConvolution_smoke,
+INSTANTIATE_TEST_CASE_P(accuracy_3x3_large_input_3, myriadLayerConvolution,
         ::testing::Combine(
             ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 16, 359, 639))
           , ::testing::Values<kernel>(MAKE_STRUCT(param_size, 3, 3))
@@ -606,7 +606,7 @@ INSTANTIATE_TEST_CASE_P(accuracy_3x3_large_input_3, myriadLayerConvolution_smoke
           )
 );
 
-INSTANTIATE_TEST_CASE_P(accuracy_1x1_large_input, myriadLayerConvolution_smoke,
+INSTANTIATE_TEST_CASE_P(accuracy_1x1_large_input, myriadLayerConvolution,
         ::testing::Combine(
             ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 24, 355, 635))
           , ::testing::Values<kernel>(MAKE_STRUCT(param_size, 1, 1))
@@ -619,7 +619,7 @@ INSTANTIATE_TEST_CASE_P(accuracy_1x1_large_input, myriadLayerConvolution_smoke,
           )
 );
 
-INSTANTIATE_TEST_CASE_P(accuracy_small_input_0, myriadLayerConvolution_smoke,
+INSTANTIATE_TEST_CASE_P(accuracy_small_input_0, myriadLayerConvolution,
         ::testing::Combine(
             ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 128, 38, 38))
           , ::testing::Values<kernel>(MAKE_STRUCT(param_size, 3, 3))
@@ -631,7 +631,7 @@ INSTANTIATE_TEST_CASE_P(accuracy_small_input_0, myriadLayerConvolution_smoke,
           , ::testing::Values<layoutPreference>(vpu::LayoutPreference::ChannelMinor)
           )
 );
-INSTANTIATE_TEST_CASE_P(accuracy_small_input_1, myriadLayerConvolution_smoke,
+INSTANTIATE_TEST_CASE_P(accuracy_small_input_1, myriadLayerConvolution,
         ::testing::Combine(
             ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 256, 2, 3))
           , ::testing::Values<kernel>(MAKE_STRUCT(param_size, 3, 3))
@@ -643,7 +643,7 @@ INSTANTIATE_TEST_CASE_P(accuracy_small_input_1, myriadLayerConvolution_smoke,
           , ::testing::Values<layoutPreference>(vpu::LayoutPreference::ChannelMinor)
           )
 );
-INSTANTIATE_TEST_CASE_P(accuracy_small_input_2, myriadLayerConvolution_smoke,
+INSTANTIATE_TEST_CASE_P(accuracy_small_input_2, myriadLayerConvolution,
         ::testing::Combine(
             ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 256, 2, 2))
           , ::testing::Values<kernel>(MAKE_STRUCT(param_size, 3, 3))
@@ -655,7 +655,7 @@ INSTANTIATE_TEST_CASE_P(accuracy_small_input_2, myriadLayerConvolution_smoke,
           , ::testing::Values<layoutPreference>(vpu::LayoutPreference::ChannelMinor)
           )
 );
-INSTANTIATE_TEST_CASE_P(accuracy_small_input_3, myriadLayerConvolution_smoke,
+INSTANTIATE_TEST_CASE_P(accuracy_small_input_3, myriadLayerConvolution,
         ::testing::Combine(
             ::testing::Values<DimsInput>(MAKE_STRUCT(tensor_test_params, 1, 256, 1, 1))
           , ::testing::Values<kernel>(MAKE_STRUCT(param_size, 3, 3))

--- a/inference-engine/tests_deprecated/functional/vpu/common/layers/myriad_layers_convolution_test.hpp
+++ b/inference-engine/tests_deprecated/functional/vpu/common/layers/myriad_layers_convolution_test.hpp
@@ -21,75 +21,91 @@ PRETTY_PARAM(group, int);
 PRETTY_PARAM(dilation_factor, param_size);
 PRETTY_PARAM(layoutPreference, vpu::LayoutPreference);
 
-typedef myriadLayerTestBaseWithParam<tuple<DimsInput, kernel, stride, pad
-        , out_channels, group, dilation_factor, layoutPreference >> myriadLayerConvolution_smoke;
+class myriadLayerConvolutionBase : public myriadLayerTestBaseWithParam<
+        tuple<DimsInput, kernel, stride, pad, out_channels, group, dilation_factor, layoutPreference>>
+{
+public:
+    void testConvolution() {
+        tensor_test_params input_dims = get<0>(GetParam());
+        param_size kernel = get<1>(GetParam());
+        param_size stride = get<2>(GetParam());
+        param_size pad = get<3>(GetParam());
+        size_t out_channels = get<4>(GetParam());
+        size_t group = get<5>(GetParam());
+        param_size dilation_factor = get<6>(GetParam());
+        vpu::LayoutPreference layoutPreference = get<7>(GetParam());
 
-typedef myriadLayerTestBaseWithParam<tuple<DimsInput, DimsOutput, kernel, stride, pad
-        , group, dilation_factor, layoutPreference >> myriadLayerConvolutionTensorFlow_smoke;
+        size_t out_w = (input_dims.w + 2 * pad.x - dilation_factor.x * (kernel.x - 1) - 1 + stride.x) / stride.x;
+        size_t out_h = (input_dims.h + 2 * pad.y - dilation_factor.y * (kernel.y - 1) - 1 + stride.y) / stride.y;
 
-TEST_P(myriadLayerConvolution_smoke, Convolution) {
-    tensor_test_params input_dims = get<0>(GetParam());
-    param_size kernel = get<1>(GetParam());
-    param_size stride = get<2>(GetParam());
-    param_size pad = get<3>(GetParam());
-    size_t out_channels = get<4>(GetParam());
-    size_t group = get<5>(GetParam());
-    param_size dilation_factor = get<6>(GetParam());
-    vpu::LayoutPreference layoutPreference = get<7>(GetParam());
+        tensor_test_params output_dims = {1, out_channels, out_h, out_w};
 
-    size_t out_w = (input_dims.w + 2 * pad.x - dilation_factor.x * (kernel.x - 1) - 1 + stride.x) / stride.x;
-    size_t out_h = (input_dims.h + 2 * pad.y - dilation_factor.y * (kernel.y - 1) - 1 + stride.y) / stride.y;
+        SetInputTensor(input_dims);
+        SetOutputTensor(output_dims);
 
-    tensor_test_params output_dims = {1, out_channels, out_h, out_w};
+        size_t num_weights = kernel.x * kernel.y * (input_dims.c / group) * output_dims.c;
+        size_t num_bias = output_dims.c;
 
-    SetInputTensor(input_dims);
-    SetOutputTensor(output_dims);
+        InferenceEngine::TBlob<uint8_t>::Ptr weights_ptr =
+                InferenceEngine::TBlob<uint8_t>::Ptr(GenWeights(num_weights + num_bias));
+        ie_fp16* weights = weights_ptr->data().as<ie_fp16*>();
+        ie_fp16* bias = weights + num_weights;
 
-    size_t num_weights = kernel.x * kernel.y * (input_dims.c / group) * output_dims.c;
-    size_t num_bias = output_dims.c;
+        std::map<std::string, std::string> layer_params = {
+                  {"kernel-x", std::to_string(kernel.x)}
+                , {"kernel-y", std::to_string(kernel.y)}
+                , {"stride-x", std::to_string(stride.x)}
+                , {"stride-y", std::to_string(stride.y)}
+                , {"pad-x", std::to_string(pad.x)}
+                , {"pad-y", std::to_string(pad.y)}
+                , {"output", std::to_string(out_channels)}
+                , {"group", std::to_string(group)}
+                , {"dilation-x", std::to_string(dilation_factor.x)}
+                , {"dilation-y", std::to_string(dilation_factor.y)}
+        };
+        ASSERT_NO_FATAL_FAILURE(makeSingleLayerNetwork(LayerInitParams("Convolution")
+                                                               .params(layer_params)
+                                                               .weights(num_weights)
+                                                               .biases(num_bias),
+                                                       {},
+                                                       weights_ptr));
+        SetFirstInputToRange(-0.9f, 0.9f);
 
-    InferenceEngine::TBlob<uint8_t>::Ptr weights_ptr =
-            InferenceEngine::TBlob<uint8_t>::Ptr(GenWeights(num_weights + num_bias));
-    ie_fp16* weights = weights_ptr->data().as<ie_fp16*>();
-    ie_fp16* bias = weights + num_weights;
+        ASSERT_TRUE(Infer());
+        auto inputBlob = _inputMap.begin()->second;
+        auto outputBlob = _outputMap.begin()->second;
 
-    std::map<std::string, std::string> layer_params = {
-              {"kernel-x", std::to_string(kernel.x)}
-            , {"kernel-y", std::to_string(kernel.y)}
-            , {"stride-x", std::to_string(stride.x)}
-            , {"stride-y", std::to_string(stride.y)}
-            , {"pad-x", std::to_string(pad.x)}
-            , {"pad-y", std::to_string(pad.y)}
-            , {"output", std::to_string(out_channels)}
-            , {"group", std::to_string(group)}
-            , {"dilation-x", std::to_string(dilation_factor.x)}
-            , {"dilation-y", std::to_string(dilation_factor.y)}
-    };
-    ASSERT_NO_FATAL_FAILURE(makeSingleLayerNetwork(LayerInitParams("Convolution")
-                                        .params(layer_params)
-                                        .weights(num_weights)
-                                        .biases(num_bias),
-                                        {},
-                                        weights_ptr));
-    SetFirstInputToRange(-0.9f, 0.9f);
+        ref_convolution(inputBlob, _refBlob, weights, bias, kernel, stride, pad, group, dilation_factor);
 
-    ASSERT_TRUE(Infer());
-    auto inputBlob = _inputMap.begin()->second;
-    auto outputBlob = _outputMap.begin()->second;
+        float maxerr = 0;
 
-    ref_convolution(inputBlob, _refBlob, weights, bias, kernel, stride, pad, group, dilation_factor);
+        if (group == 1)
+            maxerr = 0.00055 * input_dims.c * kernel.x * kernel.y;
+        else // TODO: currently dephConv is slightly less accurate
+            maxerr = 0.00066 * (input_dims.c / group) * kernel.x * kernel.y;
 
-    float maxerr = 0;
+        CompareCommonAbsolute(outputBlob, _refBlob, maxerr);
+    }
+};
 
-    if (group == 1)
-        maxerr = 0.00055 * input_dims.c * kernel.x * kernel.y;
-    else // TODO: currently dephConv is slightly less accurate
-        maxerr = 0.00066 * (input_dims.c / group) * kernel.x * kernel.y;
+class myriadLayerConvolution : public myriadLayerConvolutionBase {};
 
-    CompareCommonAbsolute(outputBlob, _refBlob, maxerr);
+TEST_P(myriadLayerConvolution, Convolution) {
+    testConvolution();
 }
 
-TEST_P(myriadLayerConvolutionTensorFlow_smoke, Convolution) {
+class myriadLayerConvolution_smoke : public myriadLayerConvolutionBase {};
+
+TEST_P(myriadLayerConvolution_smoke, Convolution) {
+    testConvolution();
+}
+
+
+class myriadLayerConvolutionTensorFlow :
+        public myriadLayerTestBaseWithParam<tuple<DimsInput, DimsOutput, kernel, stride,
+                                                  pad, group, dilation_factor, layoutPreference >> {};
+
+TEST_P(myriadLayerConvolutionTensorFlow, Convolution) {
     tensor_test_params input_dims = get<0>(GetParam());
     tensor_test_params output_dims = get<1>(GetParam());
     param_size kernel = get<2>(GetParam());


### PR DESCRIPTION
### Description
* It's a copy of this [PR](https://github.com/openvinotoolkit/openvino/pull/2311)
* Setting configuration map through LoadNetwork in functional tests setup is suggested in this commit. In such a case, we don't need to reset plugin cache after each test so that myriad plugin (and not only) are not destroyed after each test. Thus there is no closing connection with device and we can save about 1,5s to open/close vpu device for each test. As a result, myriadx jobs takes about 20-22 minutes instead 40 minutes.
* All deprecated smoke convolution tests with ChannelMinor moved to non-smoke, so it isn't run on a pre-commit. CannelMinor is specific for myriad2 devices which are deprecated.

### Task
#-38654

### Internal CI
#-1778

### Pre-commit via product configs
!916