### PR TITLE
drop unnecessary cmake dependency on ext_gtest

### DIFF
--- a/ngraph/test/util/CMakeLists.txt
+++ b/ngraph/test/util/CMakeLists.txt
@@ -36,6 +36,5 @@ if(NGRAPH_LIB_VERSIONING_ENABLE)
 endif()
 target_include_directories(ngraph_test_util PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/.. ${IE_MAIN_SOURCE_DIR}/include)
 target_link_libraries(ngraph_test_util PRIVATE ngraph ngraph_backend libgtest)
-add_dependencies(ngraph_test_util ext_gtest)
 
 install(TARGETS ngraph_test_util DESTINATION ${NGRAPH_INSTALL_LIB})


### PR DESCRIPTION
`ngraph_test_util` links `libgtest`, which depends on `ext_gtest` already. The additional, direct dependency is unnecessary.

If one ever were to remove the vendor copy of gtest, one would likely use `find_package` to locate it. Doing so would add an imported library `libgtest`, but the `ext_gtest` target would likely go missing. The target should be considered internal to the `external_gtest.cmake` file and not used beyond.