### PR TITLE
Added link options for cross-compilation

### DIFF
--- a/inference-engine/cmake/config.cmake.in
+++ b/inference-engine/cmake/config.cmake.in
@@ -7,7 +7,7 @@ if(DEFINED IE_MAIN_SOURCE_DIR AND TARGET inference_engine)
                                   inference_engine_c_api)
 else()
     include("${CMAKE_CURRENT_LIST_DIR}/targets.cmake")
-    if(NOT WIN32)
+    if(NOT MSVC)
         set_target_properties(IE::inference_engine PROPERTIES INTERFACE_COMPILE_OPTIONS "-Wno-error=deprecated-declarations")
     endif()
 
@@ -31,4 +31,11 @@ else()
     get_target_property(InferenceEngine_INCLUDE_DIRS IE::inference_engine INTERFACE_INCLUDE_DIRECTORIES)
     set(InferenceEngine_LIBRARIES IE::inference_engine_legacy IE::inference_engine
                                   IE::inference_engine_c_api)
+
+    foreach(library IN LISTS InferenceEngine_LIBRARIES)
+        if(CMAKE_CROSSCOMPILING AND NOT MSVC)
+            set_property(TARGET ${library} PROPERTY
+                         INTERFACE_LINK_OPTIONS "-Wl,--allow-shlib-undefined")
+        endif()
+    endforeach()
 endif()

--- a/inference-engine/cmake/share/InferenceEngineConfig.cmake.in
+++ b/inference-engine/cmake/share/InferenceEngineConfig.cmake.in
@@ -154,6 +154,10 @@ else()
                 else()
                     set_target_properties(IE::inference_engine${ie_library_suffix} PROPERTIES
                             INTERFACE_COMPILE_OPTIONS "-Wno-error=deprecated-declarations")
+                    if(CMAKE_CROSSCOMPILING AND NOT MSVC)
+                        set_property(TARGET IE::inference_engine${ie_library_suffix} PROPERTY
+                                     INTERFACE_LINK_OPTIONS "-Wl,--allow-shlib-undefined")
+                    endif()
                 endif()
             endif()
         endforeach()


### PR DESCRIPTION
@ilyachur we probably need to add this for ngraph as well. E.g. once we enable TBB depeendency for ngraph, we can face the same issue 

This option allows to ignore private 3rd party dependencies for the libraries. Such dependencies are added to `LD_LIBRARY_PATH` on target machine after cross-compilation has passed.