### PR TITLE
[IE][Myriad][MvTensor] LSTMCell: do not check data type of temp buffer

### DIFF
--- a/inference-engine/cmake/vpu_dependencies.cmake
+++ b/inference-engine/cmake/vpu_dependencies.cmake
@@ -19,7 +19,7 @@ set(VPU_SUPPORTED_FIRMWARES usb-ma2450 usb-ma2x8x pcie-ma248x)
 # Default packages
 #
 
-set(FIRMWARE_PACKAGE_VERSION 1395)
+set(FIRMWARE_PACKAGE_VERSION 1397)
 set(VPU_CLC_MA2X8X_VERSION "movi-cltools-20.09.1")
 
 #

--- a/inference-engine/cmake/vpu_dependencies.cmake
+++ b/inference-engine/cmake/vpu_dependencies.cmake
@@ -19,7 +19,7 @@ set(VPU_SUPPORTED_FIRMWARES usb-ma2450 usb-ma2x8x pcie-ma248x)
 # Default packages
 #
 
-set(FIRMWARE_PACKAGE_VERSION 1390)
+set(FIRMWARE_PACKAGE_VERSION 1396)
 set(VPU_CLC_MA2X8X_VERSION "movi-cltools-20.09.1")
 
 #


### PR DESCRIPTION
Issue: 39681

Fix test failure:  
MyriadFunctionalTests --gtest=myriadLayersTests_nightly.LSTMCellSequenceNet fails due to needless check of temp buffer data type in low-level kernel for LSTMCell inside VPU firmware

I fix it by removing the needless type check inside VPU firmware. This PR replaces VPU firmawe with fixed version