### PR TITLE
Update the menu to align with POT doc headers

### DIFF
--- a/docs/doxygen/ie_docs.xml
+++ b/docs/doxygen/ie_docs.xml
@@ -481,23 +481,22 @@
                     <tab type="user" title="Readers" url="@ref omz_tools_accuracy_checker_accuracy_checker_data_readers_README"/>
                     <tab type="user" title="Caffe* Installation Tips" url="@ref omz_tools_accuracy_checker_accuracy_checker_launcher_caffe_installation_readme"/>
                 </tab>
-                <tab type="usergroup" title="Post-Training Optimization Tool" url="@ref pot_README">
+                <tab type="usergroup" title="Post-Training Optimization Toolkit" url="@ref pot_README">
                   <tab type="usergroup" title="Quantization" url="@ref pot_compression_algorithms_quantization_README">
                     <tab type="user" title="DefaultQuantization Algorithm" url="@ref pot_compression_algorithms_quantization_default_README"/>
                     <tab type="user" title="AccuracyAwareQuantization Algorithm" url="@ref pot_compression_algorithms_quantization_accuracy_aware_README"/>
                     <tab type="user" title="TunableQuantization Algorithm" url="@ref pot_compression_algorithms_quantization_tunable_quantization_README"/>
                   </tab>
-                  <tab type="usergroup" title="Quantization Hyperparameters Optimization" url="@ref pot_compression_optimization_README">
-                    <tab type="usergroup" title="Tree-structured Parzen Estimator (TPE)" url="@ref pot_compression_optimization_tpe_README">
+                  <tab type="usergroup" title="Global Optimization" url="@ref pot_compression_optimization_README">
+                    <tab type="usergroup" title="Tree-Structured Parzen Estimator (TPE)" url="@ref pot_compression_optimization_tpe_README">
                       <tab type="user" title="TPE Multiple Node Configuration Based on MongoDB Database" url="@ref pot_compression_optimization_tpe_multinode"/>
                     </tab>
                   </tab>
-                  <tab type="usergroup" title="Low Precision Optimization Guide" url="@ref pot_docs_LowPrecisionOptimizationGuide">
-                    <tab type="user" title="Post-Training Optimization Best Practices" url="@ref pot_docs_BestPractices"/>
-                  </tab>
+                  <tab type="user" title="Low Precision Optimization Guide" url="@ref pot_docs_LowPrecisionOptimizationGuide"/>
+                  <tab type="user" title="Post-Training Optimization Best Practices" url="@ref pot_docs_BestPractices"/>
                   <tab type="user" title="Use Post-Training Optimization Toolkit API" url="@ref pot_compression_api_README"/>
-                  <tab type="usergroup" title="Define Configuration Files" url="@ref pot_configs_README">
-                    <tab type="user" title="Examples of Configuration Files" url="@ref pot_configs_examples_README"/>
+                  <tab type="usergroup" title="Configuration File Description" url="@ref pot_configs_README">
+                    <tab type="user" title="Run Examples" url="@ref pot_configs_examples_README"/>
                   </tab>
                 </tab>
                 <tab type="user" title="Model Downloader" url="@ref omz_tools_downloader_README"/>

--- a/docs/doxygen/ie_docs.xml
+++ b/docs/doxygen/ie_docs.xml
@@ -496,7 +496,7 @@
                   <tab type="user" title="Post-Training Optimization Best Practices" url="@ref pot_docs_BestPractices"/>
                   <tab type="user" title="Use Post-Training Optimization Toolkit API" url="@ref pot_compression_api_README"/>
                   <tab type="usergroup" title="Configuration File Description" url="@ref pot_configs_README">
-                    <tab type="user" title="Run Examples" url="@ref pot_configs_examples_README"/>
+                    <tab type="user" title="How to Run Examples" url="@ref pot_configs_examples_README"/>
                   </tab>
                 </tab>
                 <tab type="user" title="Model Downloader" url="@ref omz_tools_downloader_README"/>


### PR DESCRIPTION
It changes the menu to align with Post-training Optimization Toolkit documentation titles.