### PR TITLE
Downgrade cmake for samples (#2372)

### DIFF
--- a/build-instruction.md
+++ b/build-instruction.md
@@ -57,10 +57,11 @@ The software was validated on:
 - CentOS\* 7.4 (64-bit) with default GCC\* 4.8.5
 
 ### Software Requirements
-- [CMake]\* 3.11 or higher
+- [CMake]\* 3.13 or higher
 - GCC\* 4.8 or higher to build the Inference Engine
-- Python 3.5 or higher for Inference Engine Python API wrapper
+- Python 3.6 or higher for Inference Engine Python API wrapper
 - (Optional) [Install Intel® Graphics Compute Runtime for OpenCL™ Driver package 19.41.14441].
+> **NOTE**: Building samples and demos from the Intel® Distribution of OpenVINO™ toolkit package requires CMake\* 3.10 or higher. 
 
 ### Build Steps
 1. Clone submodules:
@@ -335,10 +336,11 @@ The software was validated on:
   Compiler 2018 Update 3
 
 ### Software Requirements
-- [CMake]\*3.11 or higher
+- [CMake]\*3.13 or higher
 - Microsoft\* Visual Studio 2017, 2019 or [Intel® C++ Compiler] 18.0
 - (Optional) Intel® Graphics Driver for Windows* (26.20) [driver package].
-- Python 3.5 or higher for Inference Engine Python API wrapper
+- Python 3.6 or higher for Inference Engine Python API wrapper
+> **NOTE**: Building samples and demos from the Intel® Distribution of OpenVINO™ toolkit package requires CMake\* 3.10 or higher. 
 
 ### Build Steps
 
@@ -452,9 +454,10 @@ The software was validated on:
 
 ### Software Requirements
 
-- [CMake]\* 3.11 or higher
+- [CMake]\* 3.13 or higher
 - Clang\* compiler from Xcode\* 10.1 or higher
-- Python\* 3.5 or higher for the Inference Engine Python API wrapper
+- Python\* 3.6 or higher for the Inference Engine Python API wrapper
+> **NOTE**: Building samples and demos from the Intel® Distribution of OpenVINO™ toolkit package requires CMake\* 3.10 or higher. 
 
 ### Build Steps
 
@@ -527,8 +530,9 @@ This section describes how to build Inference Engine for Android x86 (64-bit) op
 
 ### Software Requirements
 
-- [CMake]\* 3.11 or higher
+- [CMake]\* 3.13 or higher
 - Android NDK (this guide has been validated with r20 release)
+> **NOTE**: Building samples and demos from the Intel® Distribution of OpenVINO™ toolkit package requires CMake\* 3.10 or higher. 
 
 ### Build Steps
 

--- a/inference-engine/samples/CMakeLists.txt
+++ b/inference-engine/samples/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-cmake_minimum_required (VERSION 3.13)
+cmake_minimum_required (VERSION 3.10)
 
 project(Samples)
 


### PR DESCRIPTION
Merged #2372
* Downgrade cmake for samples

Downgraded cmake version to default version for Ubuntu 18.04

* Updated supported python version

The minimal python version in 2021.1 is 3.5

* Added notes about cmake requirements for samples and demo