### PR TITLE
[CMAKE] Introduce FASTER_BUILD experimental feature

### DIFF
--- a/cmake/developer_package.cmake
+++ b/cmake/developer_package.cmake
@@ -217,6 +217,7 @@ include(sdl)
 include(os_flags)
 include(sanitizer)
 include(cross_compiled_func)
+include(faster_build)
 
 function(set_ci_build_number)
     set(OpenVINO_MAIN_SOURCE_DIR "${CMAKE_SOURCE_DIR}")

--- a/cmake/faster_build.cmake
+++ b/cmake/faster_build.cmake
@@ -1,0 +1,26 @@
+# Copyright (C) 2020 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+include(CMakeParseArguments)
+
+function(ie_faster_build TARGET_NAME)
+    if(NOT ENABLE_FASTER_BUILD)
+        return()
+    endif()
+
+    cmake_parse_arguments(IE_FASTER_BUILD "UNITY" "" "PCH" ${ARGN})
+
+    if(IE_FASTER_BUILD_UNITY)
+        set_target_properties(${TARGET_NAME}
+            PROPERTIES
+                UNITY_BUILD ON
+        )
+    endif()
+
+    if(IE_FASTER_BUILD_PCH)
+        target_precompile_headers(${TARGET_NAME}
+            ${IE_FASTER_BUILD_PCH}
+        )
+    endif()
+endfunction()

--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -48,3 +48,5 @@ ie_dependent_option (ENABLE_PROFILING_ITT "ITT tracing of IE and plugins interna
 
 # Documentation build
 ie_option (ENABLE_DOCS "build docs using Doxygen" OFF)
+
+ie_dependent_option (ENABLE_FASTER_BUILD "Enable build features (PCH, UNITY) to speed up build time" OFF "CMAKE_VERSION VERSION_GREATER_EQUAL 3.16" OFF)

--- a/inference-engine/src/inference_engine/CMakeLists.txt
+++ b/inference-engine/src/inference_engine/CMakeLists.txt
@@ -122,6 +122,11 @@ add_cpplint_target(${TARGET_NAME}_plugin_api_cpplint FOR_SOURCES ${plugin_api_sr
 add_library(${TARGET_NAME}_common_obj OBJECT
             ${IE_BASE_SOURCE_FILES})
 
+ie_faster_build(${TARGET_NAME}_common_obj
+    UNITY
+    PCH PRIVATE "precomp.hpp"
+)
+
 target_compile_definitions(${TARGET_NAME}_common_obj PRIVATE IMPLEMENT_INFERENCE_ENGINE_API)
 target_include_directories(${TARGET_NAME}_common_obj PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}"
@@ -138,6 +143,10 @@ add_library(${TARGET_NAME}_obj OBJECT
             ${LIBRARY_SRC}
             ${LIBRARY_HEADERS}
             ${PUBLIC_HEADERS})
+
+ie_faster_build(${TARGET_NAME}_obj
+    UNITY
+)
 
 target_compile_definitions(${TARGET_NAME}_obj PRIVATE IMPLEMENT_INFERENCE_ENGINE_API)
 

--- a/inference-engine/src/inference_engine/precomp.hpp
+++ b/inference-engine/src/inference_engine/precomp.hpp
@@ -1,0 +1,32 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <ngraph/ngraph.hpp>
+#include <ngraph/ops.hpp>
+
+#include <algorithm>
+#include <functional>
+#include <initializer_list>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <ostream>
+#include <set>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <typeinfo>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <cassert>
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>

--- a/inference-engine/src/inference_engine/threading/ie_cpu_streams_executor.cpp
+++ b/inference-engine/src/inference_engine/threading/ie_cpu_streams_executor.cpp
@@ -161,7 +161,7 @@ struct CPUStreamsExecutor::Impl {
         }
         for (auto streamId = 0; streamId < _config._streams; ++streamId) {
             _threads.emplace_back([this, streamId] {
-                itt::threadName(_config._name + "_" + std::to_string(streamId));
+                openvino::itt::threadName(_config._name + "_" + std::to_string(streamId));
                 for (bool stopped = false; !stopped;) {
                     Task task;
                     {

--- a/inference-engine/src/legacy_api/CMakeLists.txt
+++ b/inference-engine/src/legacy_api/CMakeLists.txt
@@ -30,6 +30,10 @@ add_library(${TARGET_NAME}_obj OBJECT
             ${LIBRARY_SRC}
             ${PUBLIC_HEADERS})
 
+ie_faster_build(${TARGET_NAME}_obj
+    PCH PRIVATE "src/precomp.hpp"
+)
+
 set_ie_threading_interface_for(${TARGET_NAME}_obj)
 
 target_compile_definitions(${TARGET_NAME}_obj PRIVATE IMPLEMENT_INFERENCE_ENGINE_API)

--- a/inference-engine/src/legacy_api/src/precomp.hpp
+++ b/inference-engine/src/legacy_api/src/precomp.hpp
@@ -1,0 +1,29 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <algorithm>
+#include <functional>
+#include <initializer_list>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <ostream>
+#include <set>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <typeinfo>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <cassert>
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>

--- a/inference-engine/src/low_precision_transformations/CMakeLists.txt
+++ b/inference-engine/src/low_precision_transformations/CMakeLists.txt
@@ -25,6 +25,11 @@ add_library(${TARGET_NAME} SHARED
             ${LIBRARY_SRC}
             ${PUBLIC_HEADERS})
 
+ie_faster_build(${TARGET_NAME}
+    UNITY
+    PCH PRIVATE "src/precomp.hpp"
+)
+
 target_compile_definitions(${TARGET_NAME} PRIVATE IMPLEMENT_INFERENCE_ENGINE_API)
 
 target_link_libraries(${TARGET_NAME} PRIVATE inference_engine openvino::itt)

--- a/inference-engine/src/low_precision_transformations/src/precomp.hpp
+++ b/inference-engine/src/low_precision_transformations/src/precomp.hpp
@@ -1,0 +1,29 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <algorithm>
+#include <functional>
+#include <initializer_list>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <ostream>
+#include <set>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <typeinfo>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <cassert>
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>

--- a/inference-engine/src/transformations/CMakeLists.txt
+++ b/inference-engine/src/transformations/CMakeLists.txt
@@ -23,6 +23,10 @@ source_group("include" FILES ${PUBLIC_HEADERS})
 
 add_library(${TARGET_NAME} SHARED ${LIBRARY_SRC} ${PUBLIC_HEADERS})
 
+ie_faster_build(${TARGET_NAME}
+    PCH PRIVATE "src/precomp.hpp"
+)
+
 target_link_libraries(${TARGET_NAME} PUBLIC ${NGRAPH_LIBRARIES}
                                      PRIVATE openvino::itt ngraph::builder)
 

--- a/inference-engine/src/transformations/include/transformations/rt_info/primitives_priority_attribute.hpp
+++ b/inference-engine/src/transformations/include/transformations/rt_info/primitives_priority_attribute.hpp
@@ -7,6 +7,8 @@
  * @file primitives_priority_attribute.hpp
  */
 
+#pragma once
+
 #include <assert.h>
 #include <functional>
 #include <memory>

--- a/inference-engine/src/transformations/src/precomp.hpp
+++ b/inference-engine/src/transformations/src/precomp.hpp
@@ -1,0 +1,32 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <ngraph/ngraph.hpp>
+#include <ngraph/ops.hpp>
+
+#include <algorithm>
+#include <functional>
+#include <initializer_list>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <ostream>
+#include <set>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <typeinfo>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <cassert>
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>

--- a/inference-engine/tests/functional/inference_engine/CMakeLists.txt
+++ b/inference-engine/tests/functional/inference_engine/CMakeLists.txt
@@ -28,6 +28,10 @@ addIeTargetTest(
             IE
 )
 
+ie_faster_build(${TARGET_NAME}
+    PCH PRIVATE "precomp.hpp"
+)
+
 if(TARGET inference_engine_onnx_reader)
     add_dependencies(${TARGET_NAME} inference_engine_onnx_reader)
 endif()

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/ngraph_reader_tests.hpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/ngraph_reader_tests.hpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#pragma once
+
 #include <gtest/gtest.h>
 
 #include <vector>

--- a/inference-engine/tests/functional/inference_engine/precomp.hpp
+++ b/inference-engine/tests/functional/inference_engine/precomp.hpp
@@ -1,0 +1,34 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <ngraph/ngraph.hpp>
+#include <ngraph/ops.hpp>
+
+#include <algorithm>
+#include <functional>
+#include <initializer_list>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <ostream>
+#include <set>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <typeinfo>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <cassert>
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>

--- a/inference-engine/tests/functional/plugin/shared/CMakeLists.txt
+++ b/inference-engine/tests/functional/plugin/shared/CMakeLists.txt
@@ -28,6 +28,10 @@ addIeTarget(
             ${EXPORT_DEPENDENCIES}
 )
 
+ie_faster_build(${TARGET_NAME}
+    PCH PRIVATE "src/precomp.hpp"
+)
+
 if (TARGET MKLDNNPlugin)
     add_dependencies(${TARGET_NAME} MKLDNNPlugin)
 endif()

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/scatter_update.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/scatter_update.hpp
@@ -12,14 +12,14 @@
 #include "functional_test_utils/layer_test_utils.hpp"
 
 namespace LayerTestsDefinitions {
-using axisShapeInShape = std::tuple<
+using axisUpdateShapeInShape = std::tuple<
         std::vector<size_t>,    // input shape
         std::vector<size_t>,    // indices shape
         std::vector<size_t>,    // update shape
         int>;                   // axis
 
 using scatterUpdateParamsTuple = typename std::tuple<
-        axisShapeInShape,                  // shape description
+        axisUpdateShapeInShape,                  // shape description
         std::vector<size_t>,               // indices value
         InferenceEngine::Precision,        // input precision
         InferenceEngine::Precision,        // indices precision
@@ -29,7 +29,7 @@ class ScatterUpdateLayerTest : public testing::WithParamInterface<scatterUpdateP
                                virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<scatterUpdateParamsTuple> &obj);
-    static std::vector<axisShapeInShape> combineShapes(
+    static std::vector<axisUpdateShapeInShape> combineShapes(
         const std::map<std::vector<size_t>, std::map<std::vector<size_t>, std::vector<int>>>& inputShapes);
 
 protected:

--- a/inference-engine/tests/functional/plugin/shared/src/precomp.hpp
+++ b/inference-engine/tests/functional/plugin/shared/src/precomp.hpp
@@ -1,0 +1,35 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <ngraph/ngraph.hpp>
+#include <ngraph/ops.hpp>
+#include <ngraph/type/float16.hpp>
+
+#include <algorithm>
+#include <functional>
+#include <initializer_list>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <ostream>
+#include <set>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <typeinfo>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <cassert>
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/scatter_update.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/scatter_update.cpp
@@ -23,7 +23,7 @@ using namespace ngraph::opset3;
 namespace LayerTestsDefinitions {
 
 std::string ScatterUpdateLayerTest::getTestCaseName(const testing::TestParamInfo<scatterUpdateParamsTuple> &obj) {
-    axisShapeInShape shapeDescript;
+    axisUpdateShapeInShape shapeDescript;
     std::vector<size_t> inShape;
     std::vector<size_t> indicesShape;
     std::vector<size_t> updateShape;
@@ -46,9 +46,9 @@ std::string ScatterUpdateLayerTest::getTestCaseName(const testing::TestParamInfo
     return result.str();
 }
 
-std::vector<axisShapeInShape> ScatterUpdateLayerTest::combineShapes(
+std::vector<axisUpdateShapeInShape> ScatterUpdateLayerTest::combineShapes(
     const std::map<std::vector<size_t>, std::map<std::vector<size_t>, std::vector<int>>>& inputShapes) {
-    std::vector<axisShapeInShape> resVec;
+    std::vector<axisUpdateShapeInShape> resVec;
     for (auto& inputShape : inputShapes) {
         auto srcShape = inputShape.first;
         auto srcRank = srcShape.size();
@@ -75,7 +75,7 @@ std::vector<axisShapeInShape> ScatterUpdateLayerTest::combineShapes(
 }
 
 void ScatterUpdateLayerTest::SetUp() {
-    axisShapeInShape shapeDescript;
+    axisUpdateShapeInShape shapeDescript;
     InferenceEngine::SizeVector inShape;
     InferenceEngine::SizeVector indicesShape;
     InferenceEngine::SizeVector updateShape;

--- a/inference-engine/tests/ie_test_utils/common_test_utils/CMakeLists.txt
+++ b/inference-engine/tests/ie_test_utils/common_test_utils/CMakeLists.txt
@@ -54,6 +54,11 @@ function(add_common_utils ADD_TARGET_NAME)
                 ${EXPORT_DEPENDENCIES}
     )
 
+    ie_faster_build(${ADD_TARGET_NAME}
+        UNITY
+        PCH PRIVATE "precomp.hpp"
+    )
+
     # detecting regex support
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9)
         set(USE_BOOST_RE ON)

--- a/inference-engine/tests/ie_test_utils/common_test_utils/precomp.hpp
+++ b/inference-engine/tests/ie_test_utils/common_test_utils/precomp.hpp
@@ -1,0 +1,35 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <ngraph/ngraph.hpp>
+#include <ngraph/ops.hpp>
+#include <ngraph/type/float16.hpp>
+
+#include <algorithm>
+#include <functional>
+#include <initializer_list>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <ostream>
+#include <set>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <typeinfo>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <cassert>
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>

--- a/inference-engine/tests/ie_test_utils/functional_test_utils/CMakeLists.txt
+++ b/inference-engine/tests/ie_test_utils/functional_test_utils/CMakeLists.txt
@@ -17,6 +17,10 @@ addIeTarget(
     EXPORT_DEPENDENCIES ${EXPORT_DEPENDENCIES}
 )
 
+ie_faster_build(${TARGET_NAME}
+    PCH PRIVATE "precomp.hpp"
+)
+
 target_include_directories(${TARGET_NAME} PUBLIC
     $<TARGET_PROPERTY:inference_engine_plugin_api,INTERFACE_INCLUDE_DIRECTORIES>
     $<TARGET_PROPERTY:inference_engine_transformations,INTERFACE_INCLUDE_DIRECTORIES>

--- a/inference-engine/tests/ie_test_utils/functional_test_utils/precomp.hpp
+++ b/inference-engine/tests/ie_test_utils/functional_test_utils/precomp.hpp
@@ -1,0 +1,35 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <ngraph/ngraph.hpp>
+#include <ngraph/ops.hpp>
+#include <ngraph/type/float16.hpp>
+
+#include <algorithm>
+#include <functional>
+#include <initializer_list>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <ostream>
+#include <set>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <typeinfo>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <cassert>
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>

--- a/inference-engine/tests/ngraph_functions/CMakeLists.txt
+++ b/inference-engine/tests/ngraph_functions/CMakeLists.txt
@@ -24,6 +24,11 @@ addIeTarget(
             ${EXPORT_DEPENDENCIES}
 )
 
+ie_faster_build(${TARGET_NAME}
+    UNITY
+    PCH PRIVATE "src/precomp.hpp"
+)
+
 target_include_directories(${TARGET_NAME} PUBLIC ${PUBLIC_HEADERS_DIR})
 
 target_link_libraries(${TARGET_NAME} PUBLIC ${EXPORT_DEPENDENCIES})

--- a/inference-engine/tests/ngraph_functions/src/precomp.hpp
+++ b/inference-engine/tests/ngraph_functions/src/precomp.hpp
@@ -1,0 +1,32 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <ngraph/ngraph.hpp>
+#include <ngraph/ops.hpp>
+
+#include <algorithm>
+#include <functional>
+#include <initializer_list>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <ostream>
+#include <set>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <typeinfo>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <cassert>
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>

--- a/inference-engine/tests_deprecated/functional/shared_tests/CMakeLists.txt
+++ b/inference-engine/tests_deprecated/functional/shared_tests/CMakeLists.txt
@@ -26,6 +26,11 @@ file(GLOB SHARED_TESTS_SRC
 add_library(${TARGET_NAME} STATIC ${SHARED_TESTS_SRC})
 add_dependencies(${TARGET_NAME} inference_engine_preproc MultiDevicePlugin mock_engine)
 
+ie_faster_build(${TARGET_NAME}
+    UNITY
+    PCH PRIVATE "precomp.hpp"
+)
+
 if(ENABLE_MKL_DNN)
     add_dependencies(${TARGET_NAME} MKLDNNPlugin)
     target_compile_definitions(${TARGET_NAME} PUBLIC ENABLE_MKL_DNN)

--- a/inference-engine/tests_deprecated/functional/shared_tests/precomp.hpp
+++ b/inference-engine/tests_deprecated/functional/shared_tests/precomp.hpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <functional>
+#include <initializer_list>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <ostream>
+#include <set>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <typeinfo>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <cassert>
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>

--- a/ngraph/core/CMakeLists.txt
+++ b/ngraph/core/CMakeLists.txt
@@ -36,6 +36,12 @@ configure_file(include/ngraph/version.in.hpp include/ngraph/version.hpp)
 # Create shared library
 add_library(ngraph SHARED ${LIBRARY_SRC} ${PUBLIC_HEADERS})
 
+if(COMMAND ie_faster_build)
+    ie_faster_build(ngraph
+        PCH PRIVATE "src/precomp.hpp"
+    )
+endif()
+
 set_target_properties(ngraph PROPERTIES
                       CXX_VISIBILITY_PRESET hidden
                       C_VISIBILITY_PRESET hidden

--- a/ngraph/core/builder/CMakeLists.txt
+++ b/ngraph/core/builder/CMakeLists.txt
@@ -30,6 +30,13 @@ source_group("include" FILES ${PUBLIC_HEADERS})
 # Create shared library
 add_library(${TARGET_NAME} STATIC ${LIBRARY_SRC} ${PUBLIC_HEADERS})
 
+if(COMMAND ie_faster_build)
+    ie_faster_build(${TARGET_NAME}
+        UNITY
+        PCH PRIVATE "src/precomp.hpp"
+    )
+endif()
+
 # Defines macro in C++ to load backend plugin
 target_include_directories(${TARGET_NAME} PUBLIC ${BUILDER_INCLUDE_DIR})
 target_include_directories(${TARGET_NAME} PRIVATE ${NGRAPH_INCLUDE_PATH}

--- a/ngraph/core/builder/src/precomp.hpp
+++ b/ngraph/core/builder/src/precomp.hpp
@@ -1,0 +1,28 @@
+//*****************************************************************************
+// Copyright 2020 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+
+#pragma once
+
+#include <algorithm>
+#include <functional>
+#include <iterator>
+#include <memory>
+#include <numeric>
+#include <sstream>
+#include <utility>
+#include <vector>
+
+#include <cstddef>

--- a/ngraph/core/reference/CMakeLists.txt
+++ b/ngraph/core/reference/CMakeLists.txt
@@ -30,6 +30,12 @@ source_group("include" FILES ${PUBLIC_HEADERS})
 # Create shared library
 add_library(${TARGET_NAME} STATIC ${LIBRARY_SRC} ${PUBLIC_HEADERS})
 
+if(COMMAND ie_faster_build)
+    ie_faster_build(${TARGET_NAME}
+        PCH PRIVATE "src/precomp.hpp"
+    )
+endif()
+
 # Defines macro in C++ to load backend plugin
 target_include_directories(${TARGET_NAME} PUBLIC ${REF_IMPL_INCLUDE_DIR})
 target_include_directories(${TARGET_NAME} PRIVATE ${NGRAPH_INCLUDE_PATH}

--- a/ngraph/core/reference/src/precomp.hpp
+++ b/ngraph/core/reference/src/precomp.hpp
@@ -1,0 +1,29 @@
+//*****************************************************************************
+// Copyright 2020 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+
+#pragma once
+
+#include <algorithm>
+#include <numeric>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include <cfenv>
+#include <cmath>
+#include <cstddef>
+#include <cstdio>
+#include <cstring>

--- a/ngraph/core/src/precomp.hpp
+++ b/ngraph/core/src/precomp.hpp
@@ -1,0 +1,55 @@
+//*****************************************************************************
+// Copyright 2020 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+
+#pragma once
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <deque>
+#include <fstream>
+#include <functional>
+#include <initializer_list>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <list>
+#include <locale>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <ostream>
+#include <set>
+#include <sstream>
+#include <stack>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <tuple>
+#include <type_traits>
+#include <typeindex>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <cstdarg>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>

--- a/ngraph/frontend/onnx_import/CMakeLists.txt
+++ b/ngraph/frontend/onnx_import/CMakeLists.txt
@@ -20,12 +20,12 @@ file(GLOB_RECURSE LIBRARY_SRC ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 file(GLOB_RECURSE PUBLIC_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp)
 
 # Remove disabled ops
-list(REMOVE_ITEM LIBRARY_SRC 
+list(REMOVE_ITEM LIBRARY_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/src/op/conv_integer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/op/gather_nd.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/op/quant_conv.cpp
     )
-list(REMOVE_ITEM PUBLIC_HEADERS 
+list(REMOVE_ITEM PUBLIC_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/include/onnx_import/op/conv_integer.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/onnx_import/op/gather_nd.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/onnx_import/op/quant_conv.hpp
@@ -42,6 +42,12 @@ source_group("include" FILES ${PUBLIC_HEADERS})
 # Create shared library
 add_library(onnx_importer SHARED ${LIBRARY_SRC} ${PUBLIC_HEADERS})
 
+if(COMMAND ie_faster_build)
+    ie_faster_build(onnx_importer
+        PCH PRIVATE "src/precomp.hpp"
+    )
+endif()
+
 target_link_libraries(onnx_importer PRIVATE onnx onnx_proto ${Protobuf_LIBRARIES} ngraph::builder)
 target_link_libraries(onnx_importer PUBLIC ngraph)
 
@@ -54,7 +60,7 @@ target_include_directories(onnx_importer SYSTEM PUBLIC $<BUILD_INTERFACE:${ONNX_
                                                        $<INSTALL_INTERFACE:include/ngraph/frontend/>)
 target_include_directories(onnx_importer SYSTEM PRIVATE ${NGRAPH_INCLUDE_PATH} ${NGRAPH_INCLUDE_PATH}/ngraph
         ${ONNX_INCLUDE_DIR} ${ONNX_PROTO_INCLUDE_DIR} ${Protobuf_INCLUDE_DIRS})
-target_include_directories(onnx_importer PRIVATE ${ONNX_IMPORT_INCLUDE_DIR}/onnx_import/core 
+target_include_directories(onnx_importer PRIVATE ${ONNX_IMPORT_INCLUDE_DIR}/onnx_import/core
                                                  ${ONNX_IMPORT_INCLUDE_DIR}/onnx_import/op
                                                  ${ONNX_IMPORT_INCLUDE_DIR}/onnx_import/utils)
 

--- a/ngraph/frontend/onnx_import/src/precomp.hpp
+++ b/ngraph/frontend/onnx_import/src/precomp.hpp
@@ -1,0 +1,57 @@
+//*****************************************************************************
+// Copyright 2020 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+
+#pragma once
+
+#include <onnx/onnx_pb.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <deque>
+#include <fstream>
+#include <functional>
+#include <initializer_list>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <list>
+#include <locale>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <ostream>
+#include <set>
+#include <sstream>
+#include <stack>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <tuple>
+#include <type_traits>
+#include <typeindex>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <cstdarg>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>


### PR DESCRIPTION
It uses CMake 3.16 built-in utilities to speed up build time:

* [Unity builds](https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html)
* [Precompiled headers](https://cmake.org/cmake/help/latest/command/target_precompile_headers.html)

The feature is controlled via `ENABLE_FASTER_BUILD` CMake option (disabled by default).
The option avaialble only on CMake >= 3.16.
The feature is enabled per-target via `ie_faster_build` function.

Some observations:

* Don't have actual numbers for compile time, but subjectively can see speed up locally with VS 2019.
* Unity builds gives much more effect, but has some restriction on source files, so are not used everywhere.