### PR TITLE
[IE][TESTS] Test params generator: fixed conversion from map of empty vectors …

### DIFF
--- a/inference-engine/tests/ie_test_utils/common_test_utils/common_utils.hpp
+++ b/inference-engine/tests/ie_test_utils/common_test_utils/common_utils.hpp
@@ -75,6 +75,9 @@ std::vector<std::pair<master, slave>> combineParams(
     const std::map<master, std::vector<slave>>& keyValueSets) {
     std::vector<std::pair<master, slave>> resVec;
     for (auto& keyValues : keyValueSets) {
+        if (keyValues.second.empty()) {
+            resVec.push_back({keyValues.first, {}});
+        }
         for (auto& item : keyValues.second) {
             resVec.push_back({keyValues.first, item});
         }


### PR DESCRIPTION
Fixed conversion of map with key equal to empty vector, into vector of pairs
this restores activations tests that were disabled by PR: https://github.com/openvinotoolkit/openvino/pull/2071