### PR TITLE
[GNA] fixed conversion from fp16 to fp32 networks in case of const blobs

### DIFF
--- a/inference-engine/src/gna_plugin/frontend/weights_converter.hpp
+++ b/inference-engine/src/gna_plugin/frontend/weights_converter.hpp
@@ -50,15 +50,10 @@ inline bool convertWeights(InferenceEngine::CNNLayer* lp) {
     for (auto& dataItem : lp->outData) {
         dataItem->setPrecision(InferenceEngine::Precision::FP32);
     }
-    InferenceEngine::BlobMap newBlobs;
     for (auto& blob_pair : lp->blobs) {
-        auto blob_name = blob_pair.first;
-        auto blob_ptr = blob_pair.second;
+        auto &blob_ptr = blob_pair.second;
         if (blob_ptr->getTensorDesc().getPrecision() == InferenceEngine::Precision::FP16) {
-            auto new_blob = make_fp32_blob(blob_ptr);
-            newBlobs[blob_name] = new_blob;
-        } else {
-            newBlobs[blob_name] = blob_ptr;
+            blob_ptr = make_fp32_blob(blob_ptr);
         }
     }
 

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/fake_quantize.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/fake_quantize.cpp
@@ -13,7 +13,7 @@ using namespace LayerTestsDefinitions;
 namespace {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
-    InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP32, InferenceEngine::Precision::FP16
 };
 
 using ConfigType = std::map<std::string, std::string>;


### PR DESCRIPTION
reproduced fin on fake quantize layer since it checks for inputs blob precision