### PR TITLE
[IE CLDNN] Fix for Eltwise fused ops

### DIFF
--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/eltwise/eltwise_kernel_ref.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/eltwise/eltwise_kernel_ref.cpp
@@ -70,8 +70,9 @@ JitConstants EltwiseKernelRef::GetJitConstants(const eltwise_params& params) con
             idx_order = {"d6", "d5", "d4", "d3", "d2", "d1"};
         }
 
-        FusedOpsConfiguration conf = {"", idx_order, "res", input_dt, 1};
-        jit.Merge(MakeFusedOpsJitConstants(params, {conf}));
+        FusedOpsConfiguration tensor_coord = {"_TENSOR", idx_order, "res", input_dt, 1};
+        FusedOpsConfiguration linear_coord = {"_LINEAR", {"d1"}, "res", input_dt, 1, LoadType::LT_UNALIGNED, BoundaryCheck::ENABLED, IndexType::LINEAR_OFFSET};
+        jit.Merge(MakeFusedOpsJitConstants(params, {tensor_coord, linear_coord}));
     }
 
     return jit;

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/generic_eltwise_ref.cl
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/generic_eltwise_ref.cl
@@ -117,8 +117,13 @@ KERNEL(eltwise)(
     DO_ELTWISE;
 
 #if HAS_FUSED_OPS
-    FUSED_OPS;
-    OUTPUT_TYPE out = FUSED_OPS_RESULT;
+    #if ELTWISE_NO_PITCH_SAME_DIMS
+        FUSED_OPS_LINEAR;
+        OUTPUT_TYPE out = FUSED_OPS_RESULT_LINEAR;
+    #else
+        FUSED_OPS_TENSOR;
+        OUTPUT_TYPE out = FUSED_OPS_RESULT_TENSOR;
+    #endif
 #else
     #define out res
 #endif

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/common/kernel_selector_utils.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/common/kernel_selector_utils.cpp
@@ -237,6 +237,19 @@ bool CheckInputsOutputNoPitchSameDims(const base_params& params) {
             (params.inputs[0].GetLayout() == DataLayout::b_fs_zyx_fsv16 && params.inputs[0].Feature().v % 16 != 0))
             return false;
 
+        if (params.fused_ops.size()) {
+            for (auto fused_op : params.fused_ops) {
+                for (size_t in = 0; in < fused_op.tensors.size(); in++) {
+                    if (fused_op.tensors[in].LogicalSize() == 1)
+                        continue;
+                    if ((fused_op.tensors[in].GetLayout() == DataLayout::b_fs_yx_fsv16 && fused_op.tensors[in].Feature().v % 16 != 0) ||
+                        (fused_op.tensors[in].GetLayout() == DataLayout::b_fs_zyx_fsv16 && fused_op.tensors[in].Feature().v % 16 != 0))
+                        return false;
+                    no_pitch_same_dims = no_pitch_same_dims && (params.inputs[0] == fused_op.tensors[in]);
+                }
+            }
+        }
+
         for (size_t i = 1; i < params.inputs.size(); i++) {
             no_pitch_same_dims = no_pitch_same_dims && (params.inputs[0] == params.inputs[i]);
 


### PR DESCRIPTION
These changes add additional condition for selecting NO_PITCHES_SAME_DIMS eltwise mode (when we can consider the data as a 1D array)
Jira: 39363 and 39607