### PR TITLE
Fix virtual class inheritance for single layer test detection output

### DIFF
--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/detection_output.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/detection_output.hpp
@@ -57,7 +57,7 @@ using DetectionOutputParams = std::tuple<
     std::string // Device name
 >;
 
-class DetectionOutputLayerTest : public testing::WithParamInterface<DetectionOutputParams>, public LayerTestsUtils::LayerTestsCommon {
+class DetectionOutputLayerTest : public testing::WithParamInterface<DetectionOutputParams>, virtual public LayerTestsUtils::LayerTestsCommon {
   public:
     static std::string getTestCaseName(testing::TestParamInfo<DetectionOutputParams> obj);
     ngraph::op::DetectionOutputAttrs attrs;


### PR DESCRIPTION
## Summary
Fix virtual class inheritance for single layer test detection output