### PR TITLE
Hide input redirection error

### DIFF
--- a/scripts/demo/demo_benchmark_app.bat
+++ b/scripts/demo/demo_benchmark_app.bat
@@ -107,42 +107,42 @@ echo python "%downloader_dir%\downloader.py" --name "%model_name%" --output_dir 
 python "%downloader_dir%\downloader.py" --name "%model_name%" --output_dir "%models_path%" --cache_dir "%models_cache%"
 echo %model_name% model downloading completed
 
-timeout 7
+CALL :delay 7
 
 if exist "%ir_dir%" (
     echo.
     echo Target folder %ir_dir% already exists. Skipping IR generation with Model Optimizer.
     echo If you want to convert a model again, remove the entire %ir_dir% folder.
-    timeout 7
+    CALL :delay 7
     GOTO buildSample
 )
 
 echo.
 echo ###############^|^| Install Model Optimizer prerequisites ^|^|###############
 echo.
-timeout 3
+CALL :delay 3
 cd "%INTEL_OPENVINO_DIR%\deployment_tools\model_optimizer\install_prerequisites"
 call install_prerequisites_caffe.bat
 if ERRORLEVEL 1 GOTO errorHandling
 
-timeout 7
+CALL :delay 7
 echo.
 echo ###############^|^| Run Model Optimizer ^|^|###############
 echo.
-timeout 3
+CALL :delay 3
 
 ::set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=cpp
 echo python "%downloader_dir%\converter.py" --mo "%INTEL_OPENVINO_DIR%\deployment_tools\model_optimizer\mo.py" --name "%model_name%" -d "%models_path%" -o "%irs_path%" --precisions "%TARGET_PRECISION%"
 python "%downloader_dir%\converter.py" --mo "%INTEL_OPENVINO_DIR%\deployment_tools\model_optimizer\mo.py" --name "%model_name%" -d "%models_path%" -o "%irs_path%" --precisions "%TARGET_PRECISION%"
 if ERRORLEVEL 1 GOTO errorHandling
 
-timeout 7
+CALL :delay 7
 
 :buildSample
 echo.
 echo ###############^|^| Generate VS solution for Inference Engine samples using cmake ^|^|###############
 echo.
-timeout 3
+CALL :delay 3
 
 if "%PROCESSOR_ARCHITECTURE%" == "AMD64" (
    set "PLATFORM=x64"
@@ -214,24 +214,24 @@ if exist "%SOLUTION_DIR64%\CMakeCache.txt" del "%SOLUTION_DIR64%\CMakeCache.txt"
 cd "%INTEL_OPENVINO_DIR%\deployment_tools\inference_engine\samples\cpp" && cmake -E make_directory "%SOLUTION_DIR64%" && cd "%SOLUTION_DIR64%" && cmake -G "Visual Studio !MSBUILD_VERSION!" -A %PLATFORM% "%INTEL_OPENVINO_DIR%\deployment_tools\inference_engine\samples\cpp"
 if ERRORLEVEL 1 GOTO errorHandling
 
-timeout 7
+CALL :delay 7
 
 echo.
 echo ###############^|^| Build Inference Engine samples using MS Visual Studio (MSBuild.exe) ^|^|###############
 echo.
-timeout 3
+CALL :delay 3
 echo "!MSBUILD_BIN!" Samples.sln /p:Configuration=Release /t:cpp_samples\benchmark_app /clp:ErrorsOnly /m
 "!MSBUILD_BIN!" Samples.sln /p:Configuration=Release /t:cpp_samples\benchmark_app /clp:ErrorsOnly /m
 
 if ERRORLEVEL 1 GOTO errorHandling
 
-timeout 7
+CALL :delay 7
 
 :runSample
 echo.
 echo ###############^|^| Run Inference Engine benchmark app ^|^|###############
 echo.
-timeout 3
+CALL :delay 3
 copy /Y "%ROOT_DIR%%model_name%.labels" "%ir_dir%"
 cd "%SOLUTION_DIR64%\intel64\Release"
 
@@ -243,7 +243,7 @@ if ERRORLEVEL 1 GOTO errorHandling
 echo.
 echo ###############^|^| Inference Engine benchmark app completed successfully ^|^|###############
 
-timeout 10
+CALL :delay 10
 cd "%ROOT_DIR%"
 
 goto :eof
@@ -251,3 +251,7 @@ goto :eof
 :errorHandling
 echo Error
 cd "%ROOT_DIR%"
+
+:delay
+timeout %~1 2> nul
+EXIT /B 0

--- a/scripts/demo/demo_security_barrier_camera.bat
+++ b/scripts/demo/demo_security_barrier_camera.bat
@@ -108,7 +108,7 @@ for /F "tokens=1,2 usebackq" %%a in ("%ROOT_DIR%demo_security_barrier_camera.con
 echo.
 echo ###############^|^| Generate VS solution for Inference Engine demos using cmake ^|^|###############
 echo.
-timeout 3
+CALL :delay 3
 
 if "%PROCESSOR_ARCHITECTURE%" == "AMD64" (
    set "PLATFORM=x64"
@@ -180,22 +180,22 @@ if exist "%SOLUTION_DIR64%\CMakeCache.txt" del "%SOLUTION_DIR64%\CMakeCache.txt"
 cd "%INTEL_OPENVINO_DIR%\deployment_tools\inference_engine\demos" && cmake -E make_directory "%SOLUTION_DIR64%" && cd "%SOLUTION_DIR64%" && cmake -G "Visual Studio !MSBUILD_VERSION!" -A %PLATFORM% "%INTEL_OPENVINO_DIR%\deployment_tools\inference_engine\demos"
 if ERRORLEVEL 1 GOTO errorHandling
 
-timeout 7
+CALL :delay 7
 echo.
 echo ###############^|^| Build Inference Engine demos using MS Visual Studio (MSBuild.exe) ^|^|###############
 echo.
-timeout 3
+CALL :delay 3
 echo "!MSBUILD_BIN!" Demos.sln /p:Configuration=Release /t:security_barrier_camera_demo /clp:ErrorsOnly /m
 "!MSBUILD_BIN!" Demos.sln /p:Configuration=Release /t:security_barrier_camera_demo /clp:ErrorsOnly /m
 if ERRORLEVEL 1 GOTO errorHandling
 
-timeout 7
+CALL :delay 7
 
 :runSample
 echo.
 echo ###############^|^| Run Inference Engine security barrier camera demo ^|^|###############
 echo.
-timeout 3
+CALL :delay 3
 cd "%SOLUTION_DIR64%\intel64\Release"
 if not exist security_barrier_camera_demo.exe (
    cd "%INTEL_OPENVINO_DIR%\inference_engine\demos\intel64\Release"
@@ -217,3 +217,7 @@ goto :eof
 :errorHandling
 echo Error
 cd "%ROOT_DIR%"
+
+:delay
+timeout %~1 2> nul
+EXIT /B 0

--- a/scripts/demo/demo_squeezenet_download_convert_run.bat
+++ b/scripts/demo/demo_squeezenet_download_convert_run.bat
@@ -102,42 +102,42 @@ echo python "%downloader_dir%\downloader.py" --name "%model_name%" --output_dir 
 python "%downloader_dir%\downloader.py" --name "%model_name%" --output_dir "%models_path%" --cache_dir "%models_cache%"
 echo %model_name% model downloading completed
 
-timeout 7
+CALL :delay 7
 
 if exist "%ir_dir%" (
     echo.
     echo Target folder %ir_dir% already exists. Skipping IR generation with Model Optimizer.
     echo If you want to convert a model again, remove the entire %ir_dir% folder.
-    timeout 7
+    CALL :delay 7
     GOTO buildSample
 )
 
 echo.
 echo ###############^|^| Install Model Optimizer prerequisites ^|^|###############
 echo.
-timeout 3
+CALL :delay 3
 cd "%INTEL_OPENVINO_DIR%\deployment_tools\model_optimizer\install_prerequisites"
 call install_prerequisites_caffe.bat
 if ERRORLEVEL 1 GOTO errorHandling
 
-timeout 7
+CALL :delay 7
 echo.
 echo ###############^|^| Run Model Optimizer ^|^|###############
 echo.
-timeout 3
+CALL :delay 3
 
 ::set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=cpp
 echo python "%downloader_dir%\converter.py" --mo "%INTEL_OPENVINO_DIR%\deployment_tools\model_optimizer\mo.py" --name "%model_name%" -d "%models_path%" -o "%irs_path%" --precisions "%TARGET_PRECISION%"
 python "%downloader_dir%\converter.py" --mo "%INTEL_OPENVINO_DIR%\deployment_tools\model_optimizer\mo.py" --name "%model_name%" -d "%models_path%" -o "%irs_path%" --precisions "%TARGET_PRECISION%"
 if ERRORLEVEL 1 GOTO errorHandling
 
-timeout 7
+CALL :delay 7
 
 :buildSample
 echo.
 echo ###############^|^| Generate VS solution for Inference Engine samples using cmake ^|^|###############
 echo.
-timeout 3
+CALL :delay 3
 
 if "%PROCESSOR_ARCHITECTURE%" == "AMD64" (
    set "PLATFORM=x64"
@@ -209,24 +209,24 @@ if exist "%SOLUTION_DIR64%\CMakeCache.txt" del "%SOLUTION_DIR64%\CMakeCache.txt"
 cd "%INTEL_OPENVINO_DIR%\deployment_tools\inference_engine\samples\cpp" && cmake -E make_directory "%SOLUTION_DIR64%" && cd "%SOLUTION_DIR64%" && cmake -G "Visual Studio !MSBUILD_VERSION!" -A %PLATFORM% "%INTEL_OPENVINO_DIR%\deployment_tools\inference_engine\samples\cpp"
 if ERRORLEVEL 1 GOTO errorHandling
 
-timeout 7
+CALL :delay 7
 
 echo.
 echo ###############^|^| Build Inference Engine samples using MS Visual Studio (MSBuild.exe) ^|^|###############
 echo.
-timeout 3
+CALL :delay 3
 echo "!MSBUILD_BIN!" Samples.sln /p:Configuration=Release /t:cpp_samples\classification_sample_async /clp:ErrorsOnly /m
 "!MSBUILD_BIN!" Samples.sln /p:Configuration=Release /t:cpp_samples\classification_sample_async /clp:ErrorsOnly /m
 
 if ERRORLEVEL 1 GOTO errorHandling
 
-timeout 7
+CALL :delay 7
 
 :runSample
 echo.
 echo ###############^|^| Run Inference Engine classification sample ^|^|###############
 echo.
-timeout 3
+CALL :delay 3
 copy /Y "%ROOT_DIR%%model_name%.labels" "%ir_dir%"
 cd "%SOLUTION_DIR64%\intel64\Release"
 if not exist classification_sample_async.exe (
@@ -240,7 +240,7 @@ if ERRORLEVEL 1 GOTO errorHandling
 echo.
 echo ###############^|^| Classification demo completed successfully ^|^|###############
 
-timeout 10
+CALL :delay 10
 cd "%ROOT_DIR%"
 
 goto :eof
@@ -248,3 +248,7 @@ goto :eof
 :errorHandling
 echo Error
 cd "%ROOT_DIR%"
+
+:delay
+timeout %~1 2> nul
+EXIT /B 0


### PR DESCRIPTION
timeout cmd can throw an input redirection error in background mode.
Replaced default timeout() with custom function delay()