### PR TITLE
[IE Tests] Added test filters for gnaFuncTests target

### DIFF
--- a/inference-engine/tests/functional/plugin/gna/import_export_network.cpp
+++ b/inference-engine/tests/functional/plugin/gna/import_export_network.cpp
@@ -179,7 +179,7 @@ class ImportNetworkTest : public testing::WithParamInterface<exportImportNetwork
         },
     };
 
-    INSTANTIATE_TEST_CASE_P(ImportNetworkCase, ImportNetworkTest,
+    INSTANTIATE_TEST_CASE_P(smoke_ImportNetworkCase, ImportNetworkTest,
         ::testing::Combine(
             ::testing::ValuesIn(netPrecisions),
             ::testing::Values(CommonTestUtils::DEVICE_GNA),

--- a/inference-engine/tests/functional/plugin/gna/pass_tests/4d_eltwise.cpp
+++ b/inference-engine/tests/functional/plugin/gna/pass_tests/4d_eltwise.cpp
@@ -157,7 +157,7 @@ protected:
         ngraph::helpers::EltwiseTypes::ADD
     };
 
-    INSTANTIATE_TEST_CASE_P(Eltwise4d, Eltwise4dBroadcast,
+    INSTANTIATE_TEST_CASE_P(smoke_Eltwise4d, Eltwise4dBroadcast,
         ::testing::Combine(
             ::testing::ValuesIn(netPrecisions),
             ::testing::Values(CommonTestUtils::DEVICE_GNA),
@@ -165,7 +165,7 @@ protected:
             ::testing::ValuesIn(eltwiseOpTypes)),
         Eltwise4dBroadcast::getTestCaseName);
 
-    INSTANTIATE_TEST_CASE_P(Eltwise4d, Eltwise4dMultipleInput,
+    INSTANTIATE_TEST_CASE_P(smoke_Eltwise4d, Eltwise4dMultipleInput,
         ::testing::Combine(
             ::testing::ValuesIn(netPrecisions),
             ::testing::Values(CommonTestUtils::DEVICE_GNA),

--- a/inference-engine/tests/functional/plugin/gna/pass_tests/eltwise_split_over_channels_pass.cpp
+++ b/inference-engine/tests/functional/plugin/gna/pass_tests/eltwise_split_over_channels_pass.cpp
@@ -71,7 +71,7 @@ const std::vector<std::map<std::string, std::string>> configs = {
         }
 };
 
-INSTANTIATE_TEST_CASE_P(EltwiseSplitOverChennels, EltwiseSplitOverChannelsPassTest,
+INSTANTIATE_TEST_CASE_P(smoke_EltwiseSplitOverChennels, EltwiseSplitOverChannelsPassTest,
                         ::testing::Combine(
                                 ::testing::ValuesIn(netPrecisions),
                                 ::testing::Values(CommonTestUtils::DEVICE_GNA),

--- a/inference-engine/tests/functional/plugin/gna/pass_tests/remove_permutations_NHWC_to_NCHW_pass.cpp
+++ b/inference-engine/tests/functional/plugin/gna/pass_tests/remove_permutations_NHWC_to_NCHW_pass.cpp
@@ -145,14 +145,14 @@ protected:
         }
     };
 
-    INSTANTIATE_TEST_CASE_P(PermutationPass, RemovePermutationsNHWCToNCHWPassTest,
+    INSTANTIATE_TEST_CASE_P(smoke_PermutationPass, RemovePermutationsNHWCToNCHWPassTest,
         ::testing::Combine(
             ::testing::ValuesIn(netPrecisions),
             ::testing::Values(CommonTestUtils::DEVICE_GNA),
             ::testing::ValuesIn(configs)),
         RemovePermutationsNHWCToNCHWPassTest::getTestCaseName);
 
-    INSTANTIATE_TEST_CASE_P(PermutationPass, RemovePermutationsNHWCToNCHWPass4DOutputTest,
+    INSTANTIATE_TEST_CASE_P(smoke_PermutationPass, RemovePermutationsNHWCToNCHWPass4DOutputTest,
         ::testing::Combine(
             ::testing::ValuesIn(netPrecisions),
             ::testing::Values(CommonTestUtils::DEVICE_GNA),

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/behavior/add_output.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/behavior/add_output.cpp
@@ -17,6 +17,6 @@ std::vector<addOutputsParams> testCases = {
         addOutputsParams(getTargetNetwork(), {"Memory_1"}, CommonTestUtils::DEVICE_GNA)
 };
 
-INSTANTIATE_TEST_CASE_P(AddOutputBasic, AddOutputsTest,
+INSTANTIATE_TEST_CASE_P(smoke_AddOutputBasic, AddOutputsTest,
         ::testing::ValuesIn(testCases),
         AddOutputsTest::getTestCaseName);

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/behavior/core_integration.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/behavior/core_integration.cpp
@@ -19,7 +19,7 @@ INSTANTIATE_TEST_CASE_P(
 
 // TODO
 INSTANTIATE_TEST_CASE_P(
-        DISABLED_IEClassNetworkTestP, IEClassNetworkTestP,
+        DISABLED_smoke_IEClassNetworkTestP, IEClassNetworkTestP,
         ::testing::Values("GNA"));
 
 //
@@ -44,12 +44,12 @@ INSTANTIATE_TEST_CASE_P(
 
 // TODO: Issue: 30198
 INSTANTIATE_TEST_CASE_P(
-        DISABLED_IEClassGetMetricTest, IEClassGetMetricTest_OPTIMIZATION_CAPABILITIES,
+        DISABLED_smoke_IEClassGetMetricTest, IEClassGetMetricTest_OPTIMIZATION_CAPABILITIES,
         ::testing::Values("GNA"));
 
 // TODO: Issue: 30199
 INSTANTIATE_TEST_CASE_P(
-        DISABLED_IEClassGetMetricTest, IEClassGetMetricTest_RANGE_FOR_ASYNC_INFER_REQUESTS,
+        DISABLED_smoke_IEClassGetMetricTest, IEClassGetMetricTest_RANGE_FOR_ASYNC_INFER_REQUESTS,
         ::testing::Values("GNA"));
 
 INSTANTIATE_TEST_CASE_P(
@@ -78,27 +78,27 @@ INSTANTIATE_TEST_CASE_P(
 
 // TODO: Convolution with 3D input is not supported on GNA
 INSTANTIATE_TEST_CASE_P(
-        DISABLED_IEClassExecutableNetworkGetMetricTest, IEClassExecutableNetworkGetMetricTest_SUPPORTED_CONFIG_KEYS,
+        DISABLED_smoke_IEClassExecutableNetworkGetMetricTest, IEClassExecutableNetworkGetMetricTest_SUPPORTED_CONFIG_KEYS,
         ::testing::Values("GNA" /*, "MULTI:GNA", "HETERO:GNA" */));
 
 // TODO: Convolution with 3D input is not supported on GNA
 INSTANTIATE_TEST_CASE_P(
-        DISABLED_IEClassExecutableNetworkGetMetricTest, IEClassExecutableNetworkGetMetricTest_SUPPORTED_METRICS,
+        DISABLED_smoke_IEClassExecutableNetworkGetMetricTest, IEClassExecutableNetworkGetMetricTest_SUPPORTED_METRICS,
         ::testing::Values("GNA" /*, "MULTI:GNA",  "HETERO:GNA" */));
 
 // TODO: this metric is not supported by the plugin
 INSTANTIATE_TEST_CASE_P(
-        DISABLED_IEClassExecutableNetworkGetMetricTest, IEClassExecutableNetworkGetMetricTest_NETWORK_NAME,
+        DISABLED_smoke_IEClassExecutableNetworkGetMetricTest, IEClassExecutableNetworkGetMetricTest_NETWORK_NAME,
         ::testing::Values("GNA", "MULTI:GNA", "HETERO:GNA"));
 
 // TODO: Convolution with 3D input is not supported on GNA
 INSTANTIATE_TEST_CASE_P(
-        DISABLED_IEClassExecutableNetworkGetMetricTest, IEClassExecutableNetworkGetMetricTest_OPTIMAL_NUMBER_OF_INFER_REQUESTS,
+        DISABLED_smoke_IEClassExecutableNetworkGetMetricTest, IEClassExecutableNetworkGetMetricTest_OPTIMAL_NUMBER_OF_INFER_REQUESTS,
         ::testing::Values("GNA"/*, "MULTI:GNA", "HETERO:GNA" */));
 
 // TODO: Convolution with 3D input is not supported on GNA
 INSTANTIATE_TEST_CASE_P(
-        DISABLED_IEClassExecutableNetworkGetMetricTest, IEClassExecutableNetworkGetMetricTest_ThrowsUnsupported,
+        DISABLED_smoke_IEClassExecutableNetworkGetMetricTest, IEClassExecutableNetworkGetMetricTest_ThrowsUnsupported,
         ::testing::Values("GNA", /* "MULTI:GNA", */ "HETERO:GNA"));
 
 //
@@ -107,17 +107,17 @@ INSTANTIATE_TEST_CASE_P(
 
 // TODO: Convolution with 3D input is not supported on GNA
 INSTANTIATE_TEST_CASE_P(
-        DISABLED_IEClassExecutableNetworkGetConfigTest, IEClassExecutableNetworkGetConfigTest,
+        DISABLED_smoke_IEClassExecutableNetworkGetConfigTest, IEClassExecutableNetworkGetConfigTest,
         ::testing::Values("GNA"));
 
 // TODO: Convolution with 3D input is not supported on GNA
 INSTANTIATE_TEST_CASE_P(
-        DISABLED_IEClassExecutableNetworkSetConfigTest, IEClassExecutableNetworkSetConfigTest,
+        DISABLED_smoke_IEClassExecutableNetworkSetConfigTest, IEClassExecutableNetworkSetConfigTest,
         ::testing::Values("GNA"));
 
 // TODO: Convolution with 3D input is not supported on GNA
 INSTANTIATE_TEST_CASE_P(
-        DISABLED_IEClassExecutableNetworkSupportedConfigTest, IEClassExecutableNetworkSupportedConfigTest,
+        DISABLED_smoke_IEClassExecutableNetworkSupportedConfigTest, IEClassExecutableNetworkSupportedConfigTest,
         ::testing::Combine(::testing::Values("GNA"),
                            ::testing::Values(std::make_pair(GNA_CONFIG_KEY(DEVICE_MODE), GNAConfigParams::GNA_HW),
                                              std::make_pair(GNA_CONFIG_KEY(DEVICE_MODE), GNAConfigParams::GNA_SW),
@@ -126,7 +126,7 @@ INSTANTIATE_TEST_CASE_P(
 
 // TODO: Convolution with 3D input is not supported on GNA
 INSTANTIATE_TEST_CASE_P(
-        DISABLED_IEClassExecutableNetworkUnsupportedConfigTest, IEClassExecutableNetworkUnsupportedConfigTest,
+        DISABLED_smoke_IEClassExecutableNetworkUnsupportedConfigTest, IEClassExecutableNetworkUnsupportedConfigTest,
         ::testing::Combine(::testing::Values("GNA"),
                            ::testing::Values(std::make_pair(GNA_CONFIG_KEY(DEVICE_MODE), GNAConfigParams::GNA_SW_FP32),
                                              std::make_pair(GNA_CONFIG_KEY(SCALE_FACTOR), "5"),
@@ -147,7 +147,7 @@ TEST_P(IEClassExecutableNetworkSetConfigFromFp32Test, SetConfigFromFp32Throws) {
 
 // TODO: Convolution with 3D input is not supported on GNA
 INSTANTIATE_TEST_CASE_P(
-        DISABLED_IEClassExecutableNetworkSetConfigFromFp32Test, IEClassExecutableNetworkSetConfigFromFp32Test,
+        DISABLED_smoke_IEClassExecutableNetworkSetConfigFromFp32Test, IEClassExecutableNetworkSetConfigFromFp32Test,
         ::testing::Combine(::testing::Values("GNA"),
                            ::testing::Values(std::make_pair(GNA_CONFIG_KEY(DEVICE_MODE), GNAConfigParams::GNA_HW),
                                              std::make_pair(GNA_CONFIG_KEY(DEVICE_MODE), GNAConfigParams::GNA_SW),
@@ -158,13 +158,13 @@ INSTANTIATE_TEST_CASE_P(
 // IE Class Query network
 
 INSTANTIATE_TEST_CASE_P(
-        IEClassQueryNetworkTest, IEClassQueryNetworkTest,
+        smoke_IEClassQueryNetworkTest, IEClassQueryNetworkTest,
         ::testing::Values("GNA"));
 
 // IE Class Load network
 
 INSTANTIATE_TEST_CASE_P(
-        IEClassLoadNetworkTest, IEClassLoadNetworkTest,
+        smoke_IEClassLoadNetworkTest, IEClassLoadNetworkTest,
         ::testing::Values("GNA"));
 
 //
@@ -173,20 +173,20 @@ INSTANTIATE_TEST_CASE_P(
 
 // TODO: verify hetero interop
 INSTANTIATE_TEST_CASE_P(
-        DISABLED_IEClassHeteroExecutableNetworlGetMetricTest, IEClassHeteroExecutableNetworkGetMetricTest_SUPPORTED_CONFIG_KEYS,
+        DISABLED_smoke_IEClassHeteroExecutableNetworlGetMetricTest, IEClassHeteroExecutableNetworkGetMetricTest_SUPPORTED_CONFIG_KEYS,
         ::testing::Values("GNA"));
 
 // TODO: verify hetero interop
 INSTANTIATE_TEST_CASE_P(
-        DISABLED_IEClassHeteroExecutableNetworlGetMetricTest, IEClassHeteroExecutableNetworkGetMetricTest_SUPPORTED_METRICS,
+        DISABLED_smoke_IEClassHeteroExecutableNetworlGetMetricTest, IEClassHeteroExecutableNetworkGetMetricTest_SUPPORTED_METRICS,
         ::testing::Values("GNA"));
 
 // TODO: verify hetero interop
 INSTANTIATE_TEST_CASE_P(
-        DISABLED_IEClassHeteroExecutableNetworlGetMetricTest, IEClassHeteroExecutableNetworkGetMetricTest_NETWORK_NAME,
+        DISABLED_smoke_IEClassHeteroExecutableNetworlGetMetricTest, IEClassHeteroExecutableNetworkGetMetricTest_NETWORK_NAME,
         ::testing::Values("GNA"));
 
 INSTANTIATE_TEST_CASE_P(
-        IEClassHeteroExecutableNetworlGetMetricTest, IEClassHeteroExecutableNetworkGetMetricTest_TARGET_FALLBACK,
+        smoke_IEClassHeteroExecutableNetworlGetMetricTest, IEClassHeteroExecutableNetworkGetMetricTest_TARGET_FALLBACK,
         ::testing::Values("GNA"));
 } // namespace

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/behavior/memory_states.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/behavior/memory_states.cpp
@@ -17,6 +17,6 @@ std::vector<memoryStateParams> memoryStateTestCases = {
         memoryStateParams(getNetwork(), {"c_1-3", "r_1-3"}, CommonTestUtils::DEVICE_GNA)
 };
 
-INSTANTIATE_TEST_CASE_P(MemoryStateBasic, MemoryStateTest,
+INSTANTIATE_TEST_CASE_P(smoke_MemoryStateBasic, MemoryStateTest,
         ::testing::ValuesIn(memoryStateTestCases),
         MemoryStateTest::getTestCaseName);

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/activation.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/activation.cpp
@@ -49,6 +49,6 @@ const auto basicCases = ::testing::Combine(
 );
 
 
-INSTANTIATE_TEST_CASE_P(Activation_Basic, ActivationLayerTest, basicCases, ActivationLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_Activation_Basic, ActivationLayerTest, basicCases, ActivationLayerTest::getTestCaseName);
 
 }  // namespace

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/concat.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/concat.cpp
@@ -24,7 +24,7 @@ std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precis
                                                          InferenceEngine::Precision::FP16};
 
 // TODO: Issue:  26421
-INSTANTIATE_TEST_CASE_P(DISABLED_NoReshape, ConcatLayerTest,
+INSTANTIATE_TEST_CASE_P(DISABLED_smoke_NoReshape, ConcatLayerTest,
                         ::testing::Combine(
                                 ::testing::ValuesIn(axes),
                                 ::testing::ValuesIn(inShapes),

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/convolution.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/convolution.cpp
@@ -53,7 +53,7 @@ const auto conv2DParams_AutoPadValid = ::testing::Combine(
 );
 
 // TODO: Issue:  26417
-INSTANTIATE_TEST_CASE_P(DISABLED_Convolution2D_ExplicitPadding, ConvolutionLayerTest,
+INSTANTIATE_TEST_CASE_P(DISABLED_smoke_Convolution2D_ExplicitPadding, ConvolutionLayerTest,
                         ::testing::Combine(
                                 conv2DParams_ExplicitPadding,
                                 ::testing::ValuesIn(netPrecisions),
@@ -65,7 +65,7 @@ INSTANTIATE_TEST_CASE_P(DISABLED_Convolution2D_ExplicitPadding, ConvolutionLayer
                                 ::testing::Values(CommonTestUtils::DEVICE_GNA)),
                         ConvolutionLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(DISABLED_Convolution2D_AutoPadValid, ConvolutionLayerTest,
+INSTANTIATE_TEST_CASE_P(DISABLED_smoke_Convolution2D_AutoPadValid, ConvolutionLayerTest,
                         ::testing::Combine(
                                 conv2DParams_AutoPadValid,
                                 ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/eltwise.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/eltwise.cpp
@@ -56,5 +56,5 @@ const auto multiply_params = ::testing::Combine(
         ::testing::Values(CommonTestUtils::DEVICE_GNA),
         ::testing::Values(additional_config));
 
-INSTANTIATE_TEST_CASE_P(CompareWithRefs, EltwiseLayerTest, multiply_params, EltwiseLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_CompareWithRefs, EltwiseLayerTest, multiply_params, EltwiseLayerTest::getTestCaseName);
 }  // namespace

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/fake_quantize.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/fake_quantize.cpp
@@ -56,7 +56,7 @@ const auto fqParams = ::testing::Combine(
     ::testing::ValuesIn(inputParams)
 );
 
-INSTANTIATE_TEST_CASE_P(FakeQuantize, FakeQuantizeLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_FakeQuantize, FakeQuantizeLayerTest,
     ::testing::Combine(
     fqParams,
     ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/pooling.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/pooling.cpp
@@ -41,7 +41,7 @@ const auto maxPool_ExplicitPad_FloorRounding_Params = ::testing::Combine(
 );
 
 // TODO: Issue:  26503
-INSTANTIATE_TEST_CASE_P(DISABLED_MaxPool_ExplicitPad_FloorRpunding, PoolingLayerTest,
+INSTANTIATE_TEST_CASE_P(DISABLED_smoke_MaxPool_ExplicitPad_FloorRpunding, PoolingLayerTest,
                         ::testing::Combine(
                                 maxPool_ExplicitPad_FloorRounding_Params,
                                 ::testing::ValuesIn(netPrecisions),
@@ -62,7 +62,7 @@ const auto maxPool_ExplicitPad_CeilRounding_Params = ::testing::Combine(
         ::testing::Values(false)  // placeholder value - exclude pad not applicable for max pooling
 );
 // TODO: Issue:  26503
-INSTANTIATE_TEST_CASE_P(DISABLED_MaxPool_ExplicitPad_CeilRpunding, PoolingLayerTest,
+INSTANTIATE_TEST_CASE_P(DISABLED_smoke_MaxPool_ExplicitPad_CeilRpunding, PoolingLayerTest,
                         ::testing::Combine(
                                 maxPool_ExplicitPad_CeilRounding_Params,
                                 ::testing::ValuesIn(netPrecisions),
@@ -86,7 +86,7 @@ const auto avgPoolExplicitPadCeilRoundingParams = ::testing::Combine(
         ::testing::Values(true, false)
 );
 // TODO: Issue:  26503
-INSTANTIATE_TEST_CASE_P(DISABLED_AvgPool_ExplicitPad_CeilRounding, PoolingLayerTest,
+INSTANTIATE_TEST_CASE_P(DISABLED_smoke_AvgPool_ExplicitPad_CeilRounding, PoolingLayerTest,
                         ::testing::Combine(
                                 avgPoolExplicitPadCeilRoundingParams,
                                 ::testing::ValuesIn(netPrecisions),
@@ -107,7 +107,7 @@ const auto avgPoolExplicitPadFloorRoundingParams = ::testing::Combine(
 );
 
 // TODO: Issue:  26503
-INSTANTIATE_TEST_CASE_P(DISABLED_AvgPool_ExplicitPad_FloorRounding, PoolingLayerTest,
+INSTANTIATE_TEST_CASE_P(DISABLED_smoke_AvgPool_ExplicitPad_FloorRounding, PoolingLayerTest,
                         ::testing::Combine(
                                 avgPoolExplicitPadFloorRoundingParams,
                                 ::testing::ValuesIn(netPrecisions),
@@ -129,7 +129,7 @@ const auto allPools_ValidPad_Params = ::testing::Combine(
         ::testing::Values(false)  // placeholder value - exclude pad not applicable for max pooling
 );
 // TODO: Issue:  26503
-INSTANTIATE_TEST_CASE_P(DISABLED_MAX_and_AVGPool_ValidPad, PoolingLayerTest,
+INSTANTIATE_TEST_CASE_P(DISABLED_smoke_MAX_and_AVGPool_ValidPad, PoolingLayerTest,
                         ::testing::Combine(
                                 allPools_ValidPad_Params,
                                 ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/power.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/power.cpp
@@ -34,7 +34,7 @@ namespace {
                                                              InferenceEngine::Precision::FP16,
     };
 
-    INSTANTIATE_TEST_CASE_P(power, PowerLayerTest,
+    INSTANTIATE_TEST_CASE_P(smoke_power, PowerLayerTest,
                             ::testing::Combine(
                                     ::testing::ValuesIn(inShapes),
                                     ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/split.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/split.cpp
@@ -16,7 +16,7 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
 };
 
 // TODO: Issue:  26411
-INSTANTIATE_TEST_CASE_P(DISABLED_NumSplitsCheck, SplitLayerTest,
+INSTANTIATE_TEST_CASE_P(DISABLED_smoke_NumSplitsCheck, SplitLayerTest,
                         ::testing::Combine(
                                 ::testing::Values(1),
                                 ::testing::Values(0, 1),

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/basic_lstm.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/basic_lstm.cpp
@@ -22,7 +22,7 @@ const std::vector<std::map<std::string, std::string>> configs = {
     }
 };
 
-INSTANTIATE_TEST_CASE_P(BasicLSTM, Basic_LSTM_S,
+INSTANTIATE_TEST_CASE_P(smoke_BasicLSTM, Basic_LSTM_S,
                         ::testing::Combine(
                             ::testing::ValuesIn(netPrecisions),
                             ::testing::Values(CommonTestUtils::DEVICE_GNA),

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/cascade_concat.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/cascade_concat.cpp
@@ -41,7 +41,7 @@ namespace {
             {"GNA_SCALE_FACTOR_2", "1"}
     };
 
-    INSTANTIATE_TEST_CASE_P(cascade_concat, CascadeConcat,
+    INSTANTIATE_TEST_CASE_P(smoke_cascade_concat, CascadeConcat,
                             ::testing::Combine(
                                     ::testing::ValuesIn(shape1),
                                     ::testing::ValuesIn(shape2),
@@ -52,7 +52,7 @@ namespace {
                                     ::testing::Values(additional_config)),
                             CascadeConcat::getTestCaseName);
 
-    INSTANTIATE_TEST_CASE_P(cascade_concat_multioutput, CascadeConcat,
+    INSTANTIATE_TEST_CASE_P(smoke_cascade_concat_multioutput, CascadeConcat,
                             ::testing::Combine(
                                     ::testing::ValuesIn(shape1),
                                     ::testing::ValuesIn(shape2),

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/concat_multi_input.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/concat_multi_input.cpp
@@ -32,7 +32,7 @@ std::map<std::string, std::string> additional_config = {
     {"GNA_PRECISION", "I16"},
 };
 
-INSTANTIATE_TEST_CASE_P(concat_multi_input, ConcatMultiInput,
+INSTANTIATE_TEST_CASE_P(smoke_concat_multi_input, ConcatMultiInput,
     ::testing::Combine(
         ::testing::ValuesIn(inShapes),
         ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/handling_orientation_conv.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/handling_orientation_conv.cpp
@@ -21,7 +21,7 @@ const std::vector<std::map<std::string, std::string>> configs = {
         }
 };
 
-INSTANTIATE_TEST_CASE_P(handling_orientation, HandlingOrientationClass,
+INSTANTIATE_TEST_CASE_P(smoke_handling_orientation, HandlingOrientationClass,
                         ::testing::Combine(
                                 ::testing::ValuesIn(netPrecisions),
                                 ::testing::Values(CommonTestUtils::DEVICE_GNA),

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/matmul_squeeze_add.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/matmul_squeeze_add.cpp
@@ -39,7 +39,7 @@ std::vector<size_t> output_sizes = {
     8
 };
 
-INSTANTIATE_TEST_CASE_P(MatmulSqueezeAdd, MatmulSqueezeAddTest,
+INSTANTIATE_TEST_CASE_P(smoke_MatmulSqueezeAdd, MatmulSqueezeAddTest,
                         ::testing::Combine(
                             ::testing::ValuesIn(netPrecisions),
                             ::testing::Values(CommonTestUtils::DEVICE_GNA),

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/memory_LSTMCell.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/memory_LSTMCell.cpp
@@ -26,7 +26,7 @@ namespace SubgraphTestsDefinitions {
         {"GNA_SCALE_FACTOR_0", "1638.4"},
     };
 
-    INSTANTIATE_TEST_CASE_P(MemoryLSTMCellTest, MemoryLSTMCellTest,
+    INSTANTIATE_TEST_CASE_P(smoke_MemoryLSTMCellTest, MemoryLSTMCellTest,
         ::testing::Combine(
             ::testing::Values(CommonTestUtils::DEVICE_GNA),
             ::testing::Values(InferenceEngine::Precision::FP32),

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/multioutput_eltwise_squeeze_eltwise.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/multioutput_eltwise_squeeze_eltwise.cpp
@@ -29,7 +29,7 @@ namespace {
                                                              InferenceEngine::Precision::FP16,
     };
 
-    INSTANTIATE_TEST_CASE_P(multioutput_eltwise_identity, MultioutputEltwiseReshapeEltwise,
+    INSTANTIATE_TEST_CASE_P(smoke_multioutput_eltwise_identity, MultioutputEltwiseReshapeEltwise,
                             ::testing::Combine(
                                     ::testing::ValuesIn(inputs),
                                     ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/reshape_permute_conv_permute_reshape_act.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/reshape_permute_conv_permute_reshape_act.cpp
@@ -33,7 +33,7 @@ std::map<std::string, std::string> additional_config = {
 };
 
 namespace LayerTestsDefinitions {
-    INSTANTIATE_TEST_CASE_P(basic, ConvReshapeAct,
+    INSTANTIATE_TEST_CASE_P(smoke_basic, ConvReshapeAct,
         ::testing::Combine(
             ::testing::ValuesIn(netPrecisions),
             ::testing::Values(CommonTestUtils::DEVICE_GNA),

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/reshape_squeeze_reshape_relu.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/reshape_squeeze_reshape_relu.cpp
@@ -36,7 +36,7 @@ namespace {
             ngraph::helpers::SqueezeOpType::UNSQUEEZE
     };
 
-    INSTANTIATE_TEST_CASE_P(reshape_squeeze_reshape_relu, ReshapeSqueezeReshapeRelu,
+    INSTANTIATE_TEST_CASE_P(smoke_reshape_squeeze_reshape_relu, ReshapeSqueezeReshapeRelu,
                             ::testing::Combine(
                                     ::testing::ValuesIn(inputs),
                                     ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/reshapre_permute_reshape.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/reshapre_permute_reshape.cpp
@@ -20,7 +20,7 @@ namespace {
                                                              InferenceEngine::Precision::FP16,
     };
 
-    INSTANTIATE_TEST_CASE_P(reshape_permute_reshape, ReshapePermuteReshape,
+    INSTANTIATE_TEST_CASE_P(smoke_reshape_permute_reshape, ReshapePermuteReshape,
                             ::testing::Combine(
                                     ::testing::ValuesIn(inputs),
                                     ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/scale_shift.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/scale_shift.cpp
@@ -42,7 +42,7 @@ namespace {
                                                              InferenceEngine::Precision::FP16,
     };
 
-    INSTANTIATE_TEST_CASE_P(scale_shift, ScaleShiftLayerTest,
+    INSTANTIATE_TEST_CASE_P(smoke_scale_shift, ScaleShiftLayerTest,
                             ::testing::Combine(
                                     ::testing::ValuesIn(inShapes),
                                     ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/split_conv_concat.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/split_conv_concat.cpp
@@ -13,7 +13,7 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
         InferenceEngine::Precision::FP16
 };
 // TODO: Issue:  26421 (Concat issue)
-INSTANTIATE_TEST_CASE_P(DISABLED_ReshapeNoReshape, SplitConvConcat,
+INSTANTIATE_TEST_CASE_P(DISABLED_smoke_ReshapeNoReshape, SplitConvConcat,
                         ::testing::Combine(
                                 ::testing::ValuesIn(netPrecisions),
                                 ::testing::Values(std::vector<size_t >({1, 6, 40, 40})),

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/split_relu.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/split_relu.cpp
@@ -45,7 +45,7 @@ namespace {
             {std::string(GNA_CONFIG_KEY(COMPACT_MODE)), "NO"}
     };
 
-    INSTANTIATE_TEST_CASE_P(split_connected, SplitRelu,
+    INSTANTIATE_TEST_CASE_P(smoke_split_connected, SplitRelu,
                             ::testing::Combine(
                                     ::testing::ValuesIn(inputs),
                                     ::testing::ValuesIn(connect_index),


### PR DESCRIPTION
Separation functional tests to the pre-commit (`gtest_filter=*smoke*`) and nightly scope (`gtest_filter=*nightly *`).
Default value is `smoke`. But after this merge you could change it.
CC @azhogov @mikhail-treskin 