### PR TITLE
[IE Tests] Added test filters for myriadFuncTests target

### DIFF
--- a/inference-engine/tests/functional/plugin/myriad/ngraph/conversions/dynamic_shape_resolver.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/conversions/dynamic_shape_resolver.cpp
@@ -53,7 +53,7 @@ private:
 
 const char DynamicShapeResolverTests::s_FriendlyName[] = "DSR";
 
-TEST_F(DynamicShapeResolverTests, NGraphFunctionCanBeConvertedToCNNNetwork) {
+TEST_F(DynamicShapeResolverTests, smoke_NGraphFunctionCanBeConvertedToCNNNetwork) {
     ASSERT_EQ(cnnNetwork.getInputsInfo().size(), 2);
     ASSERT_EQ(cnnNetwork.layerCount(), cnnNetwork.getInputsInfo().size() + 1);
     ASSERT_EQ(cnnNetwork.getOutputsInfo().size(), 1);

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/operations/dynamic_shape_resolver.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/operations/dynamic_shape_resolver.cpp
@@ -88,7 +88,7 @@ std::set<ngraph::element::Type_t> allNGraphStaticTypes() {
     return staticTypes;
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicShapeResolverTests, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicShapeResolverTests, testing::Combine(
     testing::ValuesIn(allNGraphStaticTypes()),
     testing::Values(DataShape{1, 800}, DataShape{1, 1})));
 
@@ -120,7 +120,7 @@ TEST_P(DynamicShapeResolverNegativeTestsDataType, ThrowsOnInvalidDimsType) {
     ASSERT_THROW(std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(data, dims), ngraph::ngraph_error);
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicShapeResolverNegativeTestsDataType, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicShapeResolverNegativeTestsDataType, testing::Combine(
     testing::Values(ngraph::element::dynamic),
     testing::Values(ngraph::element::i64),
     testing::Values(DataPartialShape{1, 800}),
@@ -140,7 +140,7 @@ std::set<ngraph::element::Type_t> allNGraphNotIntegralTypes() {
     return notIntegralTypes;
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicShapeResolverNegativeTestsDimsType, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicShapeResolverNegativeTestsDimsType, testing::Combine(
     testing::ValuesIn(allNGraphStaticTypes()),
     testing::ValuesIn(allNGraphNotIntegralTypes()),
     testing::Values(DataPartialShape{1, 800}),
@@ -151,7 +151,7 @@ TEST_P(DynamicShapeResolverNegativeTestsDataShape, ThrowsOnInvalidDimsType) {
     ASSERT_THROW(std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(data, dims), ngraph::ngraph_error);
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicShapeResolverNegativeTestsDataShape, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicShapeResolverNegativeTestsDataShape, testing::Combine(
     testing::ValuesIn(allNGraphStaticTypes()),
     testing::Values(ngraph::element::i64),
     testing::Values(
@@ -166,7 +166,7 @@ TEST_P(DynamicShapeResolverNegativeTestsDimsShape, ThrowsOnInvalidDimsType) {
     ASSERT_THROW(std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(data, dims), ngraph::ngraph_error);
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicShapeResolverNegativeTestsDimsShape, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicShapeResolverNegativeTestsDimsShape, testing::Combine(
     testing::ValuesIn(allNGraphTypes()),
     testing::Values(ngraph::element::i64),
     testing::Values(DataShape{1, 800}),
@@ -276,7 +276,7 @@ const auto basicCases = ::testing::Combine(
 );
 
 
-INSTANTIATE_TEST_CASE_P(DynamicShapeResolverPluginTests, DynamicShapeResolverPluginTests,
+INSTANTIATE_TEST_CASE_P(smoke_DynamicShapeResolverPluginTests, DynamicShapeResolverPluginTests,
                         ::testing::Combine(
                                 ::testing::ValuesIn(inputDatas),
                                 ::testing::Values(CommonTestUtils::DEVICE_MYRIAD)),

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/operations/out_shape_of_reshape.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/operations/out_shape_of_reshape.cpp
@@ -99,7 +99,7 @@ TEST_P(OutShapeOfReshapeTests, CanValidateAndInferTypes) {
             ngraph::ParameterVector{m_inDataShapeParam, m_outShapeDescriptorParam}));
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, OutShapeOfReshapeTests, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, OutShapeOfReshapeTests, testing::Combine(
         testing::ValuesIn(tensorShapes),
         testing::ValuesIn(allNGraphIntegralNumberTypes()),
         testing::ValuesIn(tensorShapes),
@@ -126,7 +126,7 @@ TEST_P(OutShapeOfReshapeTestsNegativeDataType, ThrowsOnInvalidDataType) {
             m_inDataShapeParam, m_outShapeDescriptorParam, true),
                  ngraph::NodeValidationFailure);
 }
-INSTANTIATE_TEST_CASE_P(InvalidInDataShapeTensorType, OutShapeOfReshapeTestsNegativeDataType,
+INSTANTIATE_TEST_CASE_P(smoke_InvalidInDataShapeTensorType, OutShapeOfReshapeTestsNegativeDataType,
         testing::Combine(
             testing::Values(TensorShape{4}),
             testing::ValuesIn(allNGraphNotIntegralTypes()),
@@ -134,7 +134,7 @@ INSTANTIATE_TEST_CASE_P(InvalidInDataShapeTensorType, OutShapeOfReshapeTestsNega
             testing::Values(ngraph::element::i64))
 );
 
-INSTANTIATE_TEST_CASE_P(InvalidOutShapeDescriptorTensorType, OutShapeOfReshapeTestsNegativeDataType,
+INSTANTIATE_TEST_CASE_P(smoke_InvalidOutShapeDescriptorTensorType, OutShapeOfReshapeTestsNegativeDataType,
         testing::Combine(
             testing::Values(TensorShape{4}),
             testing::Values(ngraph::element::i64),
@@ -156,7 +156,7 @@ TEST_P(OutShapeOfReshapeTestsNegativeDataShape, ThrowsOnInvalidDataShape) {
                  ngraph::NodeValidationFailure);
 }
 
-INSTANTIATE_TEST_CASE_P(InvalidInDataShapeTensorShape, OutShapeOfReshapeTestsNegativeDataShape,
+INSTANTIATE_TEST_CASE_P(smoke_InvalidInDataShapeTensorShape, OutShapeOfReshapeTestsNegativeDataShape,
         testing::Combine(
             testing::ValuesIn(invalidTensorShapes),
             testing::Values(ngraph::element::i64),
@@ -164,7 +164,7 @@ INSTANTIATE_TEST_CASE_P(InvalidInDataShapeTensorShape, OutShapeOfReshapeTestsNeg
             testing::Values(ngraph::element::i64))
 );
 
-INSTANTIATE_TEST_CASE_P(InvalidOutShapeDescriptorTensorShape, OutShapeOfReshapeTestsNegativeDataShape,
+INSTANTIATE_TEST_CASE_P(smoke_InvalidOutShapeDescriptorTensorShape, OutShapeOfReshapeTestsNegativeDataShape,
         testing::Combine(
             testing::ValuesIn(tensorShapes),
             testing::Values(ngraph::element::i64),

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/operations/static_shape_broadcast.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/operations/static_shape_broadcast.cpp
@@ -116,7 +116,7 @@ TEST_P(StaticShapeBroadcastNumpyTests, CanValidateAndInferTypes) {
     ASSERT_EQ(m_tensorWithTargetShape->get_shape(), op->output(0).get_shape());
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, StaticShapeBroadcastNumpyTests, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, StaticShapeBroadcastNumpyTests, testing::Combine(
         testing::ValuesIn(testNGraphNumericTypes),
         testing::ValuesIn(testNumpyStaticShapes))
 );
@@ -132,7 +132,7 @@ TEST_P(StaticShapeBroadcastExplicitTests, CanValidateAndInferTypes) {
     ASSERT_EQ(m_tensorWithTargetShape->get_shape(), op->output(0).get_shape());
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, StaticShapeBroadcastExplicitTests, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, StaticShapeBroadcastExplicitTests, testing::Combine(
         testing::ValuesIn(testNGraphNumericTypes),
         testing::ValuesIn(testExplicitStaticShapes))
 );
@@ -152,7 +152,7 @@ TEST_P(StaticShapeBroadcastNumpyTestsNegativeNumInputs, ThrowsOnInvalidNumInputs
                  ngraph::NodeValidationFailure);
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, StaticShapeBroadcastNumpyTestsNegativeNumInputs, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, StaticShapeBroadcastNumpyTestsNegativeNumInputs, testing::Combine(
         testing::Values(ngraph::element::f16),
         testing::Values(testNumpyStaticShapes[0]))
 );
@@ -166,7 +166,7 @@ TEST_P(StaticShapeBroadcastExplicitTestsNegativeNumInputs, ThrowsOnInvalidNumInp
                  ngraph::NodeValidationFailure);
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, StaticShapeBroadcastExplicitTestsNegativeNumInputs, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, StaticShapeBroadcastExplicitTestsNegativeNumInputs, testing::Combine(
         testing::Values(ngraph::element::f16),
         testing::Values(testExplicitStaticShapes[0]))
 );
@@ -180,7 +180,7 @@ TEST_P(StaticShapeBroadcastTestsNegativeMode, ThrowsOnInvalidMode) {
                  ngraph::NodeValidationFailure);
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, StaticShapeBroadcastTestsNegativeMode, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, StaticShapeBroadcastTestsNegativeMode, testing::Combine(
         testing::Values(ngraph::element::f16),
         testing::Values(testNumpyStaticShapes[0]))
 );
@@ -194,7 +194,7 @@ TEST_P(StaticShapeBroadcastTestsNegativeEvaluate, ThrowsOnInvalidMode) {
             m_tensor, targetShape), ngraph::NodeValidationFailure);
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, StaticShapeBroadcastTestsNegativeEvaluate, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, StaticShapeBroadcastTestsNegativeEvaluate, testing::Combine(
         testing::Values(ngraph::element::f16),
         testing::Values(testNumpyStaticShapes[0]))
 );

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/operations/static_shape_nonzero.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/operations/static_shape_nonzero.cpp
@@ -89,7 +89,7 @@ TEST_P(StaticShapeNonZeroTests, CanValidateAndInferTypes) {
             ngraph::ParameterVector{m_param}));
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, StaticShapeNonZeroTests, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, StaticShapeNonZeroTests, testing::Combine(
         testing::ValuesIn(testNGraphNumericTypes),
         testing::ValuesIn(testStaticShapes),
         testing::ValuesIn(outputTypes))
@@ -106,7 +106,7 @@ TEST_P(StaticShapeNonZeroTestsNegativeInputDataType, ThrowsOnInvalidInputType) {
                  ngraph::NodeValidationFailure);
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, StaticShapeNonZeroTestsNegativeInputDataType, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, StaticShapeNonZeroTestsNegativeInputDataType, testing::Combine(
         testing::Values(ngraph::element::dynamic),
         testing::ValuesIn(testStaticShapes),
         testing::ValuesIn(outputTypes))
@@ -119,7 +119,7 @@ TEST_P(StaticShapeNonZeroTestsNegativeDataShape, ThrowsOnInvalidDataShape) {
                  ngraph::NodeValidationFailure);
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, StaticShapeNonZeroTestsNegativeDataShape, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, StaticShapeNonZeroTestsNegativeDataShape, testing::Combine(
         testing::ValuesIn(testNGraphNumericTypes),
         testing::ValuesIn(testDynamicShapes),
         testing::ValuesIn(outputTypes))
@@ -132,7 +132,7 @@ TEST_P(StaticShapeNonZeroTestsNegativeOutputDataType, ThrowsOnInvalidOutputType)
                  ngraph::NodeValidationFailure);
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, StaticShapeNonZeroTestsNegativeOutputDataType, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, StaticShapeNonZeroTestsNegativeOutputDataType, testing::Combine(
         testing::ValuesIn(testNGraphNumericTypes),
         testing::ValuesIn(testStaticShapes),
         testing::Values(ngraph::element::boolean))

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_binary_elementwise.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_binary_elementwise.cpp
@@ -300,7 +300,7 @@ public:
 TEST_P(DynamicToStaticShapeEltwise, CompareFunctions) {
 }
 
-INSTANTIATE_TEST_CASE_P(EltwiseBroadcast, DynamicToStaticShapeEltwise, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_EltwiseBroadcast, DynamicToStaticShapeEltwise, testing::Combine(
     testing::Values(
         ngraph::element::f16,
         ngraph::element::f32,
@@ -327,7 +327,7 @@ INSTANTIATE_TEST_CASE_P(EltwiseBroadcast, DynamicToStaticShapeEltwise, testing::
 TEST_P(DynamicToStaticShapeEltwiseSingleDSR, CompareFunctions) {
 }
 
-INSTANTIATE_TEST_CASE_P(EltwiseBroadcastSingleDSR, DynamicToStaticShapeEltwiseSingleDSR, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_EltwiseBroadcastSingleDSR, DynamicToStaticShapeEltwiseSingleDSR, testing::Combine(
     testing::Values(
         ngraph::element::f16,
         ngraph::element::f32,

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_broadcast.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_broadcast.cpp
@@ -118,7 +118,7 @@ protected:
 TEST_P(DynamicToStaticShapeBroadcastTests, compareFunctions) {
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicToStaticShapeBroadcastTests, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicToStaticShapeBroadcastTests, testing::Combine(
         testing::Values(
                 ngraph::element::f16,
                 ngraph::element::f32,

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_clamp.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_clamp.cpp
@@ -72,7 +72,7 @@ protected:
 TEST_P(DynamicToStaticShapeClamp, CompareFunctions) {
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicToStaticShapeClamp, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicToStaticShapeClamp, testing::Combine(
     testing::Values(
         ngraph::element::f16,
         ngraph::element::f32,

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_concat.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_concat.cpp
@@ -134,7 +134,7 @@ std::vector<ConcatParam> concatParams = {
         {DataShapes{DataShape{3, 64, 128}, DataShape{3, 64, 256}, DataShape{3, 64, 512}}, -1},
 };
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicToStaticShapeConcatTests, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicToStaticShapeConcatTests, testing::Combine(
         testing::ValuesIn(dataTypes),
         testing::ValuesIn(concatParams)));
 

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_convert.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_convert.cpp
@@ -72,7 +72,7 @@ protected:
 TEST_P(DynamicToStaticShapeConvert, CompareFunctions) {
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicToStaticShapeConvert, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicToStaticShapeConvert, testing::Combine(
     testing::Values(
         ngraph::element::f16,
         ngraph::element::f32,

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_gather.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_gather.cpp
@@ -133,7 +133,7 @@ protected:
 TEST_P(DynamicToStaticShapeGatherDataDSR, CompareFunctions) {
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicToStaticShapeGatherDataDSR, combinations);
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicToStaticShapeGatherDataDSR, combinations);
 
 class DynamicToStaticShapeGatherIdxDSR : public CommonTestUtils::TestsCommon,
         public testing::WithParamInterface<std::tuple<DataType, DataType, GatherTestCase>> {
@@ -223,7 +223,7 @@ protected:
 TEST_P(DynamicToStaticShapeGatherIdxDSR, CompareFunctions) {
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicToStaticShapeGatherIdxDSR, combinations);
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicToStaticShapeGatherIdxDSR, combinations);
 
 class DynamicToStaticShapeGather : public CommonTestUtils::TestsCommon,
         public testing::WithParamInterface<std::tuple<DataType, DataType, GatherTestCase>> {
@@ -315,6 +315,6 @@ protected:
 TEST_P(DynamicToStaticShapeGather, CompareFunctions) {
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicToStaticShapeGather, combinations);
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicToStaticShapeGather, combinations);
 
 }  // namespace

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_matmul.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_matmul.cpp
@@ -204,6 +204,6 @@ protected:
 
 TEST_P(DynamicToStaticShapeMatMul, CompareFunctions) {
 }
-INSTANTIATE_TEST_CASE_P(MatMul, DynamicToStaticShapeMatMul, combinations);
+INSTANTIATE_TEST_CASE_P(smoke_MatMul, DynamicToStaticShapeMatMul, combinations);
 
 }  // namespace

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_non_max_suppression.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_non_max_suppression.cpp
@@ -102,7 +102,7 @@ protected:
 TEST_P(DynamicToStaticShapeNonMaxSuppression, CompareFunctions) {
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicToStaticShapeNonMaxSuppression, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicToStaticShapeNonMaxSuppression, testing::Combine(
     testing::Values(
         ngraph::element::f16,
         ngraph::element::f32),

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_nonzero.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_nonzero.cpp
@@ -91,7 +91,7 @@ TEST_P(DynamicToStaticShapeNonZeroTests, CompareFunctions) {
     compareFunctions();
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicToStaticShapeNonZeroTests, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicToStaticShapeNonZeroTests, testing::Combine(
     testing::Values(
         ngraph::element::f16,
         ngraph::element::f32,

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_reduce.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_reduce.cpp
@@ -160,7 +160,7 @@ protected:
 TEST_P(DynamicToStaticShapeReduce, CompareFunctions) {
 }
 
-INSTANTIATE_TEST_CASE_P(Arithmetic, DynamicToStaticShapeReduce, arithmetic_combinations);
-INSTANTIATE_TEST_CASE_P(Logical, DynamicToStaticShapeReduce, logical_combinations);
+INSTANTIATE_TEST_CASE_P(smoke_Arithmetic, DynamicToStaticShapeReduce, arithmetic_combinations);
+INSTANTIATE_TEST_CASE_P(smoke_Logical, DynamicToStaticShapeReduce, logical_combinations);
 
 }  // namespace

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_reshape.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_reshape.cpp
@@ -114,7 +114,7 @@ std::shared_ptr<ngraph::op::Op> generateDynamicReshapePattern(std::shared_ptr<ng
         0);
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicToStaticShapeReshapeTests, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicToStaticShapeReshapeTests, testing::Combine(
     testing::Values(
         DataShape{4, 1000},
         DataShape{3, 128, 256},

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_roialign.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_roialign.cpp
@@ -101,7 +101,7 @@ protected:
 TEST_P(DynamicToStaticShapeROIAlignDataDSR, CompareFunctions) {
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicToStaticShapeROIAlignDataDSR, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicToStaticShapeROIAlignDataDSR, testing::Combine(
     testing::Values(
         ngraph::element::f16,
         ngraph::element::f32),
@@ -188,7 +188,7 @@ protected:
 TEST_P(DynamicToStaticShapeROIAlignROIDSR, CompareFunctions) {
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicToStaticShapeROIAlignROIDSR, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicToStaticShapeROIAlignROIDSR, testing::Combine(
         testing::Values(
                 ngraph::element::f16,
                 ngraph::element::f32),
@@ -281,7 +281,7 @@ protected:
 TEST_P(DynamicToStaticShapeROIAlign, CompareFunctions) {
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicToStaticShapeROIAlign, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicToStaticShapeROIAlign, testing::Combine(
         testing::Values(
                 ngraph::element::f16,
                 ngraph::element::f32),

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_scatter.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_scatter.cpp
@@ -91,7 +91,7 @@ protected:
 TEST_P(DynamicToStaticShapeScatter, CompareFunctions) {
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicToStaticShapeScatter, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicToStaticShapeScatter, testing::Combine(
     testing::Values(
         ngraph::element::f16,
         ngraph::element::f32,

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_squeeze.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_squeeze.cpp
@@ -98,7 +98,7 @@ protected:
 TEST_P(DynamicToStaticShapeSqueeze, CompareFunctions) {
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicToStaticShapeSqueeze, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicToStaticShapeSqueeze, testing::Combine(
     testing::Values(
         ngraph::element::f16,
         ngraph::element::f32,

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_topk.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_topk.cpp
@@ -155,7 +155,7 @@ protected:
 TEST_P(DynamicToStaticShapeTopKConst, CompareFunctions) {
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicToStaticShapeTopKConst, combinations);
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicToStaticShapeTopKConst, combinations);
 
 
 class DynamicToStaticShapeTopK : public CommonTestUtils::TestsCommon,
@@ -277,6 +277,6 @@ protected:
 TEST_P(DynamicToStaticShapeTopK, CompareFunctions) {
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicToStaticShapeTopK, combinations);
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicToStaticShapeTopK, combinations);
 
 }  // namespace

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_transpose.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_transpose.cpp
@@ -104,7 +104,7 @@ protected:
 TEST_P(DynamicToStaticShapeTranspose, CompareFunctions) {
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicToStaticShapeTranspose, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicToStaticShapeTranspose, testing::Combine(
     testing::Values(
         ngraph::element::f16,
         ngraph::element::f32,

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_unary_elementwise.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_unary_elementwise.cpp
@@ -75,7 +75,7 @@ protected:
 TEST_P(DynamicToStaticShapeUnaryElementwise, CompareFunctions) {
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicToStaticShapeUnaryElementwise, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicToStaticShapeUnaryElementwise, testing::Combine(
     testing::Values(
         ngraph::element::f16,
         ngraph::element::f32,

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_unsqueeze.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_unsqueeze.cpp
@@ -111,7 +111,7 @@ protected:
 TEST_P(DynamicToStaticShapeUnsqueeze, CompareFunctions) {
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicToStaticShapeUnsqueeze, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicToStaticShapeUnsqueeze, testing::Combine(
     testing::Values(
         ngraph::element::f16,
         ngraph::element::f32,

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_variadic_split.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_variadic_split.cpp
@@ -146,6 +146,6 @@ protected:
 TEST_P(DynamicToStaticShapeVeriadicSplit, CompareFunctions) {
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicToStaticShapeVeriadicSplit, combinations);
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicToStaticShapeVeriadicSplit, combinations);
 
 }  // namespace

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/eliminate_shapeof_after_dsr.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/eliminate_shapeof_after_dsr.cpp
@@ -66,7 +66,7 @@ protected:
 TEST_P(EliminateShapeOfAfterDSRTest, CompareFunctions) {
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, EliminateShapeOfAfterDSRTest, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, EliminateShapeOfAfterDSRTest, testing::Combine(
         testing::Values(
                 ngraph::element::f16,
                 ngraph::element::f32,
@@ -129,7 +129,7 @@ protected:
 TEST_P(EliminateShapeOfAfterDSRWithoutOutputDSR, CompareFunctions) {
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, EliminateShapeOfAfterDSRWithoutOutputDSR, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, EliminateShapeOfAfterDSRWithoutOutputDSR, testing::Combine(
         testing::Values(
                 ngraph::element::f16,
                 ngraph::element::f32,
@@ -196,7 +196,7 @@ protected:
 TEST_P(EliminateShapeOfAfterDSRKeepDSR, CompareFunctions) {
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, EliminateShapeOfAfterDSRKeepDSR, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, EliminateShapeOfAfterDSRKeepDSR, testing::Combine(
         testing::Values(
                 ngraph::element::f16,
                 ngraph::element::f32,

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/merge_subsequent_dsr_operations.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/merge_subsequent_dsr_operations.cpp
@@ -14,7 +14,7 @@
 
 namespace {
 
-TEST(MergeSubsequentDSROperations, SingleDSRFunction) {
+TEST(MergeSubsequentDSROperations, smoke_SingleDSRFunction) {
     // shape
     //      \
     //        dsr
@@ -39,7 +39,7 @@ TEST(MergeSubsequentDSROperations, SingleDSRFunction) {
     ASSERT_NO_THROW(ngraph::helpers::CompareFunctions(*reference, *actual));
 }
 
-TEST(MergeSubsequentDSROperations, DSR_ReLU_DSR_ReLU_DSR) {
+TEST(MergeSubsequentDSROperations, smoke_DSR_ReLU_DSR_ReLU_DSR) {
     //          one_1
     //               \
     //   one_0        sum_1 - - - - - - - - - - dsr_2
@@ -85,7 +85,7 @@ TEST(MergeSubsequentDSROperations, DSR_ReLU_DSR_ReLU_DSR) {
     ASSERT_NO_THROW(ngraph::helpers::CompareFunctions(*reference, *actual));
 }
 
-TEST(MergeSubsequentDSROperations, DSR_ReLU_DSR_DSR) {
+TEST(MergeSubsequentDSROperations, smoke_DSR_ReLU_DSR_DSR) {
     // Before:
     //          one_1
     //               \

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/behavior/stress_tests.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/behavior/stress_tests.cpp
@@ -9,7 +9,7 @@ using namespace LayerTestsDefinitions;
 const unsigned int g_BugAllocationLimit = 10000;
 
 namespace {
-    INSTANTIATE_TEST_CASE_P(BehaviorTests, MultipleAllocations,
+    INSTANTIATE_TEST_CASE_P(smoke_BehaviorTests, MultipleAllocations,
                             ::testing::Combine(
                                 ::testing::Values(CommonTestUtils::DEVICE_MYRIAD),
                                 ::testing::Values(g_BugAllocationLimit)),

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/activation.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/activation.cpp
@@ -40,6 +40,6 @@ const auto basicCases = ::testing::Combine(
 );
 
 
-INSTANTIATE_TEST_CASE_P(Activation_Basic, ActivationLayerTest, basicCases, ActivationLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_Activation_Basic, ActivationLayerTest, basicCases, ActivationLayerTest::getTestCaseName);
 
 }  // namespace

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/comparison.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/comparison.cpp
@@ -50,7 +50,7 @@ std::vector<ngraph::helpers::ComparisonTypes> comparisonOpTypesFpToInt = {
         ngraph::helpers::ComparisonTypes::LESS,
 };
 
-INSTANTIATE_TEST_CASE_P(ComparisonFp,
+INSTANTIATE_TEST_CASE_P(smoke_ComparisonFp,
                         ComparisonLayerTest,
                         ::testing::Combine(
                             ::testing::ValuesIn(CommonTestUtils::combineParams(inputShapes)),
@@ -63,7 +63,7 @@ INSTANTIATE_TEST_CASE_P(ComparisonFp,
                             ::testing::Values(Config{{InferenceEngine::MYRIAD_DETECT_NETWORK_BATCH, CONFIG_VALUE(NO)}})),
                         ComparisonLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(ComparisonInt,
+INSTANTIATE_TEST_CASE_P(smoke_ComparisonInt,
                         ComparisonLayerTest,
                         ::testing::Combine(
                                 ::testing::ValuesIn(CommonTestUtils::combineParams(inputShapes)),

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/concat.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/concat.cpp
@@ -20,7 +20,7 @@ std::vector<std::vector<std::vector<size_t>>> inShapes = {
 std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP16};
 
 
-INSTANTIATE_TEST_CASE_P(Concat_Basic, ConcatLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_Concat_Basic, ConcatLayerTest,
                         ::testing::Combine(
                                 ::testing::ValuesIn(axes),
                                 ::testing::ValuesIn(inShapes),

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/convolution.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/convolution.cpp
@@ -60,7 +60,7 @@ const auto conv2DParams_BigDimensionValid = ::testing::Combine(
         ::testing::Values(ngraph::op::PadType::VALID)
 );
 
-INSTANTIATE_TEST_CASE_P(Convolution2D_ExplicitPadding, ConvolutionLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_Convolution2D_ExplicitPadding, ConvolutionLayerTest,
                         ::testing::Combine(
                                 conv2DParams_ExplicitPadding,
                                 ::testing::ValuesIn(netPrecisions),
@@ -72,7 +72,7 @@ INSTANTIATE_TEST_CASE_P(Convolution2D_ExplicitPadding, ConvolutionLayerTest,
                                 ::testing::Values(CommonTestUtils::DEVICE_MYRIAD)),
                         ConvolutionLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(Convolution2D_AutoPadValid, ConvolutionLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_Convolution2D_AutoPadValid, ConvolutionLayerTest,
                         ::testing::Combine(
                                 conv2DParams_AutoPadValid,
                                 ::testing::ValuesIn(netPrecisions),
@@ -83,7 +83,7 @@ INSTANTIATE_TEST_CASE_P(Convolution2D_AutoPadValid, ConvolutionLayerTest,
                                 ::testing::Values(InferenceEngine::Layout::ANY),
                                 ::testing::Values(CommonTestUtils::DEVICE_MYRIAD)),
                         ConvolutionLayerTest::getTestCaseName);
-INSTANTIATE_TEST_CASE_P(Convolution2D_BigDimensionValid, ConvolutionLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_Convolution2D_BigDimensionValid, ConvolutionLayerTest,
                         ::testing::Combine(
                                 conv2DParams_BigDimensionValid,
                                 ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/eltwise.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/eltwise.cpp
@@ -55,7 +55,7 @@ std::vector<ngraph::helpers::EltwiseTypes> eltwiseMathTypesINT = {
         ngraph::helpers::EltwiseTypes::DIVIDE,
 };
 
-INSTANTIATE_TEST_CASE_P(EltwiseMathFP,
+INSTANTIATE_TEST_CASE_P(smoke_EltwiseMathFP,
                         EltwiseLayerTest,
                         ::testing::Combine(
                             ::testing::ValuesIn(inShapes),
@@ -67,7 +67,7 @@ INSTANTIATE_TEST_CASE_P(EltwiseMathFP,
                             ::testing::Values(Config{{InferenceEngine::MYRIAD_DETECT_NETWORK_BATCH, CONFIG_VALUE(NO)}})),
                         EltwiseLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(EltwiseMathInt,
+INSTANTIATE_TEST_CASE_P(smoke_EltwiseMathInt,
                         EltwiseLayerTest,
                         ::testing::Combine(
                                 ::testing::ValuesIn(inShapes),

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/equal.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/equal.cpp
@@ -19,7 +19,7 @@ std::vector<std::vector<InferenceEngine::SizeVector>> inShapes = {
         {{1}, {1, 256, 512}},
 };
 
-INSTANTIATE_TEST_CASE_P(equalS32, EqualLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_equalS32, EqualLayerTest,
         ::testing::Combine(
                 ::testing::ValuesIn(inShapes),
                 ::testing::Values(InferenceEngine::Precision::I32),

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/greater.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/greater.cpp
@@ -19,7 +19,7 @@ std::vector<std::vector<InferenceEngine::SizeVector>> inShapes = {
         {{1}, {1, 256, 512}},
 };
 
-INSTANTIATE_TEST_CASE_P(greaterS32, GreaterLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_greaterS32, GreaterLayerTest,
         ::testing::Combine(
                 ::testing::ValuesIn(inShapes),
                 ::testing::Values(InferenceEngine::Precision::FP16),

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/logical.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/logical.cpp
@@ -69,7 +69,7 @@ std::vector<ngraph::helpers::LogicalTypes> eltwiseLogicalTypesInt = {
         ngraph::helpers::LogicalTypes::LOGICAL_AND,
 };
 
-INSTANTIATE_TEST_CASE_P(EltwiseLogicalInt,
+INSTANTIATE_TEST_CASE_P(smoke_EltwiseLogicalInt,
                         LogicalLayerTestVPU,
                         ::testing::Combine(
                                 ::testing::ValuesIn(LogicalLayerTest::combineShapes(inputShapes)),
@@ -81,7 +81,7 @@ INSTANTIATE_TEST_CASE_P(EltwiseLogicalInt,
                                 ::testing::Values(Config{{InferenceEngine::MYRIAD_DETECT_NETWORK_BATCH, CONFIG_VALUE(NO)}})),
                         LogicalLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(EltwiseLogicalNotInt,
+INSTANTIATE_TEST_CASE_P(smoke_EltwiseLogicalNotInt,
                         LogicalLayerTestVPU,
                         ::testing::Combine(
                                 ::testing::ValuesIn(LogicalLayerTest::combineShapes(inputShapesNot)),

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/minimum_maximum.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/minimum_maximum.cpp
@@ -33,7 +33,7 @@ const std::vector<ngraph::helpers::InputLayerType> inputType = {
         ngraph::helpers::InputLayerType::PARAMETER,
 };
 
-INSTANTIATE_TEST_CASE_P(maximum, MaxMinLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_maximum, MaxMinLayerTest,
                         ::testing::Combine(
                                 ::testing::ValuesIn(inShapes),
                                 ::testing::ValuesIn(opType),

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/nonzero.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/nonzero.cpp
@@ -39,7 +39,7 @@ const std::vector<InferenceEngine::Precision> inputPrecisions = {
         InferenceEngine::Precision::U8,
 };
 
-INSTANTIATE_TEST_CASE_P(nonzero, NonZeroLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_nonzero, NonZeroLayerTest,
         ::testing::Combine(
                 ::testing::ValuesIn(inShapes),
                 ::testing::ValuesIn(inputPrecisions),

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/pooling.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/pooling.cpp
@@ -41,7 +41,7 @@ const auto maxPool_ExplicitPad_FloorRounding_Params = ::testing::Combine(
         ::testing::Values(false)  // placeholder value - exclude pad not applicable for max pooling
 );
 
-INSTANTIATE_TEST_CASE_P(MaxPool_ExplicitPad_FloorRpunding, PoolingLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_MaxPool_ExplicitPad_FloorRpunding, PoolingLayerTest,
                         ::testing::Combine(
                                 maxPool_ExplicitPad_FloorRounding_Params,
                                 ::testing::ValuesIn(netPrecisions),
@@ -64,7 +64,7 @@ const auto maxPool_ExplicitPad_CeilRounding_Params = ::testing::Combine(
         ::testing::Values(false)  // placeholder value - exclude pad not applicable for max pooling
 );
 
-INSTANTIATE_TEST_CASE_P(MaxPool_ExplicitPad_CeilRpunding, PoolingLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_MaxPool_ExplicitPad_CeilRpunding, PoolingLayerTest,
                         ::testing::Combine(
                                 maxPool_ExplicitPad_CeilRounding_Params,
                                 ::testing::ValuesIn(netPrecisions),
@@ -89,7 +89,7 @@ const auto avgPoolExplicitPadCeilRoundingParams = ::testing::Combine(
         ::testing::Values(true, false)
 );
 
-INSTANTIATE_TEST_CASE_P(AvgPool_ExplicitPad_CeilRounding, PoolingLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_AvgPool_ExplicitPad_CeilRounding, PoolingLayerTest,
                         ::testing::Combine(
                                 avgPoolExplicitPadCeilRoundingParams,
                                 ::testing::ValuesIn(netPrecisions),
@@ -111,7 +111,7 @@ const auto avgPoolExplicitPadFloorRoundingParams = ::testing::Combine(
 );
 
 
-INSTANTIATE_TEST_CASE_P(AvgPool_ExplicitPad_FloorRounding, PoolingLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_AvgPool_ExplicitPad_FloorRounding, PoolingLayerTest,
                         ::testing::Combine(
                                 avgPoolExplicitPadFloorRoundingParams,
                                 ::testing::ValuesIn(netPrecisions),
@@ -134,7 +134,7 @@ const auto allPools_ValidPad_Params = ::testing::Combine(
         ::testing::Values(false)  // placeholder value - exclude pad not applicable for max pooling
 );
 
-INSTANTIATE_TEST_CASE_P(MAX_and_AVGPool_ValidPad, PoolingLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_MAX_and_AVGPool_ValidPad, PoolingLayerTest,
                         ::testing::Combine(
                                 allPools_ValidPad_Params,
                                 ::testing::ValuesIn(netPrecisions),
@@ -156,7 +156,7 @@ const auto avgGlobalPoolParams = ::testing::Combine(
         ::testing::Values(false)
 );
 
-INSTANTIATE_TEST_CASE_P(GlobalAvgPool, GlobalPoolingLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_GlobalAvgPool, GlobalPoolingLayerTest,
                         ::testing::Combine(
                                 avgGlobalPoolParams,
                                 ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/proposal.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/proposal.cpp
@@ -40,7 +40,7 @@ const auto proposalParams = ::testing::Combine(
         ::testing::ValuesIn(framework_)
 );
 
-INSTANTIATE_TEST_CASE_P(Proposal_tests, ProposalLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_Proposal_tests, ProposalLayerTest,
                         ::testing::Combine(
                                 proposalParams,
                                 ::testing::Values(CommonTestUtils::DEVICE_MYRIAD)),

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/split.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/split.cpp
@@ -14,7 +14,7 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
         InferenceEngine::Precision::FP16
 };
 
-INSTANTIATE_TEST_CASE_P(NumSplitsCheck, SplitLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_NumSplitsCheck, SplitLayerTest,
                         ::testing::Combine(
                                 ::testing::Values(1),
                                 // TODO: 0-axis excluded

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/strided_slice.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/strided_slice.cpp
@@ -48,7 +48,7 @@ Config getConfig() {
     return config;
 }
 
-INSTANTIATE_TEST_CASE_P(StridedSlice_tests, StridedSliceLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_StridedSlice_tests, StridedSliceLayerTest,
                         ::testing::Combine(
                             ::testing::ValuesIn(testCases),
                             ::testing::ValuesIn(precisions),

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/subgraph_tests/split_conv_concat.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/subgraph_tests/split_conv_concat.cpp
@@ -15,7 +15,7 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
         InferenceEngine::Precision::FP16
 };
 
-INSTANTIATE_TEST_CASE_P(NoReshape, SplitConvConcat,
+INSTANTIATE_TEST_CASE_P(smoke_NoReshape, SplitConvConcat,
                         ::testing::Combine(
                                 ::testing::ValuesIn(netPrecisions),
                                 ::testing::Values(std::vector<size_t >({1, 6, 40, 40})),

--- a/inference-engine/tests/functional/plugin/myriad/single_layer_tests/out_shape_of_reshape.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/single_layer_tests/out_shape_of_reshape.cpp
@@ -111,7 +111,7 @@ std::vector<OutShapeOfReshapeParam> shapeParams = {
         std::make_tuple(InputShape{ 2, 5,   5,   0 }, ShapeDescriptor{ 0,  4          }, false),
 };
 
-INSTANTIATE_TEST_CASE_P(accuracy, OutShapeOfReshapeLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_accuracy, OutShapeOfReshapeLayerTest,
                         ::testing::Combine(
                                 ::testing::ValuesIn(shapeParams),
                                 ::testing::Values(CommonTestUtils::DEVICE_MYRIAD)),

--- a/inference-engine/tests/functional/plugin/myriad/single_layer_tests/static_shape_broadcast.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/single_layer_tests/static_shape_broadcast.cpp
@@ -110,7 +110,7 @@ std::vector<InferenceEngine::Precision> broadcastPrecisions = {
         InferenceEngine::Precision::I32,
 };
 
-INSTANTIATE_TEST_CASE_P(accuracy, StaticShapeBroadcastLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_accuracy, StaticShapeBroadcastLayerTest,
                         ::testing::Combine(
                                 ::testing::ValuesIn(broadcastParam),
                                 ::testing::ValuesIn(broadcastPrecisions),

--- a/inference-engine/tests/functional/plugin/myriad/single_layer_tests/static_shape_nonzero.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/single_layer_tests/static_shape_nonzero.cpp
@@ -110,7 +110,7 @@ std::vector<InferenceEngine::Precision> inputPrecisions = {
         InferenceEngine::Precision::I32,
 };
 
-INSTANTIATE_TEST_CASE_P(accuracy, StaticShapeNonZeroLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_accuracy, StaticShapeNonZeroLayerTest,
                         ::testing::Combine(
                                 ::testing::ValuesIn(inputDims),
                                 ::testing::ValuesIn(inputPrecisions),

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_binary_elementwise.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_binary_elementwise.cpp
@@ -96,7 +96,7 @@ std::vector<BinaryEltwiseShapes> dataShapesWithUpperBound = {
         },
 };
 
-INSTANTIATE_TEST_CASE_P(DynamicBinaryElementwise, DSR_BinaryElementwiseBothDSR,
+INSTANTIATE_TEST_CASE_P(smoke_DynamicBinaryElementwise, DSR_BinaryElementwiseBothDSR,
     ::testing::Combine(
         ::testing::Values(ngraph::element::f16, ngraph::element::f32, ngraph::element::i32),
         ::testing::ValuesIn(dataShapesWithUpperBound),
@@ -121,7 +121,7 @@ std::vector<BinaryEltwiseShapes> dataShapesWithUpperBoundSingleDSR = {
         },
 };
 
-INSTANTIATE_TEST_CASE_P(DynamicBinaryElementwiseSingleDSR, DSR_BinaryElementwiseSingleDSR,
+INSTANTIATE_TEST_CASE_P(smoke_DynamicBinaryElementwiseSingleDSR, DSR_BinaryElementwiseSingleDSR,
     ::testing::Combine(
         ::testing::Values(ngraph::element::f16, ngraph::element::f32, ngraph::element::i32),
         ::testing::ValuesIn(dataShapesWithUpperBoundSingleDSR),

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_clamp.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_clamp.cpp
@@ -38,7 +38,7 @@ TEST_P(DSR_Clamp, CompareWithReference) {
     Run();
 }
 
-INSTANTIATE_TEST_CASE_P(DynamicClamp, DSR_Clamp,
+INSTANTIATE_TEST_CASE_P(smoke_DynamicClamp, DSR_Clamp,
     ::testing::Combine(
         ::testing::Values(ngraph::element::f16, ngraph::element::f32),
         ::testing::Values(DataShapeWithUpperBound{DataShape{1, 800}, DataShape{2, 1000}}),

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_concat.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_concat.cpp
@@ -98,7 +98,7 @@ std::vector<ConcatParam> concatParams = {
         },
 };
 
-INSTANTIATE_TEST_CASE_P(DynamicConcat, DSR_Concat, ::testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_DynamicConcat, DSR_Concat, ::testing::Combine(
         ::testing::ValuesIn(dataTypes),
         ::testing::ValuesIn(concatParams),
         ::testing::Values(CommonTestUtils::DEVICE_MYRIAD)));

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_convert.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_convert.cpp
@@ -49,7 +49,7 @@ std::vector<DataTypeConversionPair> dataTypeConversionPairVector {
     {ngraph::element::f16, ngraph::element::i32},
 };
 
-INSTANTIATE_TEST_CASE_P(DynamicConvert, DSR_Convert,
+INSTANTIATE_TEST_CASE_P(smoke_DynamicConvert, DSR_Convert,
     ::testing::Combine(
         ::testing::ValuesIn(dataTypeConversionPairVector),
         ::testing::Values(DataShapeWithUpperBound{ngraph::Shape{1, 800}, ngraph::Shape{2, 1000}},

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_gather.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_gather.cpp
@@ -82,7 +82,7 @@ TEST_P(DSR_GatherDynamicDataStaticIdx, CompareWithReference) {
     Run();
 }
 
-INSTANTIATE_TEST_CASE_P(DynamicGatherData, DSR_GatherDynamicDataStaticIdx, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_DynamicGatherData, DSR_GatherDynamicDataStaticIdx, testing::Combine(
         testing::ValuesIn(dataTypeVector),
         testing::ValuesIn(idxTypeVector),
         testing::Values(
@@ -118,7 +118,7 @@ TEST_P(DSR_GatherStaticDataDynamicIdx, CompareWithReference) {
     Run();
 }
 
-INSTANTIATE_TEST_CASE_P(DynamicGatherIdx, DSR_GatherStaticDataDynamicIdx, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_DynamicGatherIdx, DSR_GatherStaticDataDynamicIdx, testing::Combine(
         testing::ValuesIn(dataTypeVector),
         testing::ValuesIn(idxTypeVector),
         testing::Values(
@@ -153,7 +153,7 @@ TEST_P(DSR_GatherDynamicDataDynamicIdx, CompareWithReference) {
     Run();
 }
 
-INSTANTIATE_TEST_CASE_P(DynamicGather, DSR_GatherDynamicDataDynamicIdx, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_DynamicGather, DSR_GatherDynamicDataDynamicIdx, testing::Combine(
         testing::ValuesIn(dataTypeVector),
         testing::ValuesIn(idxTypeVector),
         testing::Values(

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_matmul.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_matmul.cpp
@@ -99,5 +99,5 @@ TEST_P(DSR_MatMul, CompareWithReference) {
     Run();
 }
 
-INSTANTIATE_TEST_CASE_P(DynamicMatMul, DSR_MatMul, combinations);
+INSTANTIATE_TEST_CASE_P(smoke_DynamicMatMul, DSR_MatMul, combinations);
 }  // namespace

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_non_max_suppression.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_non_max_suppression.cpp
@@ -63,7 +63,7 @@ TEST_P(DSR_NonMaxSuppression, CompareWithReference) {
 }
 
 // #-30919
-INSTANTIATE_TEST_CASE_P(DISABLED_DynamicNonMaxSupression, DSR_NonMaxSuppression,
+INSTANTIATE_TEST_CASE_P(DISABLED_smoke_DynamicNonMaxSupression, DSR_NonMaxSuppression,
     ::testing::Combine(
          ::testing::Values(
                     ngraph::element::f16,

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_reduce.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_reduce.cpp
@@ -101,7 +101,7 @@ TEST_P(DSR_Reduce, CompareWithReference) {
     Run();
 }
 
-INSTANTIATE_TEST_CASE_P(DynamicArithmeticReduce, DSR_Reduce, arithmeticCombinations);
-INSTANTIATE_TEST_CASE_P(DynamicLogicalReduce, DSR_Reduce, logicalCombinations);
+INSTANTIATE_TEST_CASE_P(smoke_DynamicArithmeticReduce, DSR_Reduce, arithmeticCombinations);
+INSTANTIATE_TEST_CASE_P(smoke_DynamicLogicalReduce, DSR_Reduce, logicalCombinations);
 
 }  // namespace

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_reshape.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_reshape.cpp
@@ -52,7 +52,7 @@ std::vector<ReshapeTestParams> reshapeTestParams = {
         std::make_tuple(DataShapeWithUpperBound{{750}, {1000}}, true, ShapeDescriptor{1, 1, -1}),
 };
 
-INSTANTIATE_TEST_CASE_P(DynamicReshape, DSR_Reshape,
+INSTANTIATE_TEST_CASE_P(smoke_DynamicReshape, DSR_Reshape,
     ::testing::Combine(
         ::testing::Values(ngraph::element::f16,
                           ngraph::element::f32,

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_roialign.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_roialign.cpp
@@ -99,7 +99,7 @@ TEST_P(DSR_ROIAlignROIDSR, CompareWithReference) {
     Run();
 }
 
-INSTANTIATE_TEST_CASE_P(DISABLED_DynamicROIAlign, DSR_ROIAlignROIDSR,
+INSTANTIATE_TEST_CASE_P(DISABLED_smoke_DynamicROIAlign, DSR_ROIAlignROIDSR,
     ::testing::Combine(
         ::testing::Values(
                     ngraph::element::f16,
@@ -148,7 +148,7 @@ TEST_P(DSR_ROIAlign, CompareWithReference) {
 }
 
 // #-30909
-INSTANTIATE_TEST_CASE_P(DISABLED_DynamicROIAlign, DSR_ROIAlign,
+INSTANTIATE_TEST_CASE_P(DISABLED_smoke_DynamicROIAlign, DSR_ROIAlign,
     ::testing::Combine(
         ::testing::Values(
                     ngraph::element::f16,

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_scatter.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_scatter.cpp
@@ -44,7 +44,7 @@ TEST_P(DSR_Scatter, CompareWithReference) {
     Run();
 }
 
-INSTANTIATE_TEST_CASE_P(DynamicScatter, DSR_Scatter,
+INSTANTIATE_TEST_CASE_P(smoke_DynamicScatter, DSR_Scatter,
     ::testing::Combine(
             testing::Values(
                     ngraph::element::f16),

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_squeeze.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_squeeze.cpp
@@ -49,7 +49,7 @@ TEST_P(DSR_Squeeze, CompareWithReference) {
     Run();
 }
 
-INSTANTIATE_TEST_CASE_P(DynamicSqueeze, DSR_Squeeze,
+INSTANTIATE_TEST_CASE_P(smoke_DynamicSqueeze, DSR_Squeeze,
     ::testing::Combine(
         ::testing::Values(ngraph::element::f16, ngraph::element::i32),
         ::testing::Values(

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_strided_slice.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_strided_slice.cpp
@@ -65,7 +65,7 @@ std::vector<DataType> precisions = {
         ngraph::element::i32
 };
 
-INSTANTIATE_TEST_CASE_P(StridedSlice, DSR_StridedSlice,
+INSTANTIATE_TEST_CASE_P(smoke_StridedSlice, DSR_StridedSlice,
                         ::testing::Combine(
                             ::testing::ValuesIn(testCases),
                             ::testing::ValuesIn(precisions),

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_topk.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_topk.cpp
@@ -52,7 +52,7 @@ TEST_P(DSR_TopK_Const, CompareWithReference) {
     Run();
 }
 
-INSTANTIATE_TEST_CASE_P(DynamicTopKConst, DSR_TopK_Const, combinations);
+INSTANTIATE_TEST_CASE_P(smoke_DynamicTopKConst, DSR_TopK_Const, combinations);
 
 class DSR_TopK : public testing::WithParamInterface<Parameters>, public DSR_TestsCommon {
 protected:
@@ -82,6 +82,6 @@ TEST_P(DSR_TopK, CompareWithReference) {
     Run();
 }
 
-INSTANTIATE_TEST_CASE_P(DynamicTopKConst, DSR_TopK, combinations);
+INSTANTIATE_TEST_CASE_P(smoke_DynamicTopKConst, DSR_TopK, combinations);
 
 }  // namespace

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_unary_elementwise.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_unary_elementwise.cpp
@@ -40,7 +40,7 @@ TEST_P(DSR_UnaryElementwise, CompareWithReference) {
     Run();
 }
 
-INSTANTIATE_TEST_CASE_P(DynamicUnaryElementwise, DSR_UnaryElementwise,
+INSTANTIATE_TEST_CASE_P(smoke_DynamicUnaryElementwise, DSR_UnaryElementwise,
     ::testing::Combine(
         ::testing::Values(ngraph::element::f16, ngraph::element::f32),
         ::testing::Values(DataShapeWithUpperBound{ngraph::Shape{8, 800}, ngraph::Shape{10, 1000}}),

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_unsqueeze.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_unsqueeze.cpp
@@ -44,7 +44,7 @@ TEST_P(DSR_Unsqueeze, CompareWithReference) {
     Run();
 }
 
-INSTANTIATE_TEST_CASE_P(DynamicUnsqueeze, DSR_Unsqueeze,
+INSTANTIATE_TEST_CASE_P(smoke_DynamicUnsqueeze, DSR_Unsqueeze,
     ::testing::Combine(
         ::testing::Values(ngraph::element::f16, ngraph::element::i32),
         ::testing::Values(

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_variadic_split.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_variadic_split.cpp
@@ -57,6 +57,6 @@ TEST_P(DSR_VariadicSplit, CompareWithReference) {
     Run();
 }
 
-INSTANTIATE_TEST_CASE_P(DynamicGatherData, DSR_VariadicSplit, combinations);
+INSTANTIATE_TEST_CASE_P(smoke_DynamicGatherData, DSR_VariadicSplit, combinations);
 
 }  // namespace

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/nonzero_broadcast.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/nonzero_broadcast.cpp
@@ -60,7 +60,7 @@ TEST_P(NonZero_Broadcast, CompareWithReference) {
     Run();
 }
 
-INSTANTIATE_TEST_CASE_P(DynamicBroadcast, NonZero_Broadcast, ::testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_DynamicBroadcast, NonZero_Broadcast, ::testing::Combine(
         ::testing::Values(ngraph::element::f16, ngraph::element::f32, ngraph::element::i32),
         ::testing::Values(
                 TensorShape{1000},

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/nonzero_transpose.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/nonzero_transpose.cpp
@@ -45,7 +45,7 @@ TEST_P(NonZero_Transpose, CompareWithReference) {
     Run();
 }
 
-INSTANTIATE_TEST_CASE_P(DynamicTranspose, NonZero_Transpose,
+INSTANTIATE_TEST_CASE_P(smoke_DynamicTranspose, NonZero_Transpose,
     ::testing::Combine(
         ::testing::Values(ngraph::element::f16, ngraph::element::f32, ngraph::element::i32),
         ::testing::Values(ngraph::Shape{1, 800}),

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/topk_k_propagation.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/topk_k_propagation.cpp
@@ -64,7 +64,7 @@ const std::vector<int64_t> kVec = {0, 10, 100, 200, 500};
 TEST_P(DynamicToStaticTopKPropagation, KPropagation) {
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicToStaticTopKPropagation, ::testing::ValuesIn(kVec));
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicToStaticTopKPropagation, ::testing::ValuesIn(kVec));
 
 class DynamicToStaticTopKPropagationReshape : public DynamicToStaticTopKPropagation {
 protected:
@@ -76,7 +76,7 @@ protected:
 TEST_P(DynamicToStaticTopKPropagationReshape, KPropagation) {
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicToStaticTopKPropagationReshape, ::testing::ValuesIn(kVec));
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicToStaticTopKPropagationReshape, ::testing::ValuesIn(kVec));
 
 class DynamicToStaticTopKPropagationSqueezeUnsqueeze : public DynamicToStaticTopKPropagation {
 protected:
@@ -89,7 +89,7 @@ protected:
 TEST_P(DynamicToStaticTopKPropagationSqueezeUnsqueeze, KPropagation) {
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicToStaticTopKPropagationSqueezeUnsqueeze, ::testing::ValuesIn(kVec));
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicToStaticTopKPropagationSqueezeUnsqueeze, ::testing::ValuesIn(kVec));
 
 class DynamicToStaticTopKPropagationConvert : public DynamicToStaticTopKPropagation {
 protected:
@@ -102,6 +102,6 @@ protected:
 TEST_P(DynamicToStaticTopKPropagationConvert, KPropagation) {
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, DynamicToStaticTopKPropagationConvert, ::testing::ValuesIn(kVec));
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, DynamicToStaticTopKPropagationConvert, ::testing::ValuesIn(kVec));
 
 }  // namespace


### PR DESCRIPTION
Separation functional tests to the pre-commit (`gtest_filter=*smoke*`) and nightly scope (`gtest_filter=*nightly *`).
Default value is `smoke`. But after this merge you could change it.
CC @azhogov @mikhail-treskin 