### PR TITLE
[IE Tests] Added test filters for cpuFuncTests target

### DIFF
--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/bf16_network_restoring.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/bf16_network_restoring.cpp
@@ -199,7 +199,7 @@ TEST_P(BF16NetworkRestore1, CompareWithRefImpl) {
 };
 
 
-INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, BF16NetworkRestore1,
+INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, BF16NetworkRestore1,
                         ::testing::Combine(
                             ::testing::Values(Precision::FP32),
                             ::testing::Values(Precision::BF16),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/bfloat16_helpers.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/bfloat16_helpers.hpp
@@ -120,7 +120,7 @@ typedef std::tuple<
  *  TEST_P(ScaleshiftConv_x3_Eltwise, CompareWithRefImpl) {
     test();
 };
- *  3. INSTANTIATE_TEST_CASE_P(bfloat16_NoReshape, ScaleshiftConv_x3_Eltwise,
+ *  3. INSTANTIATE_TEST_CASE_P(smoke_bfloat16_NoReshape, ScaleshiftConv_x3_Eltwise,
                         ::testing::Combine(
                             ::testing::Values(Precision::FP32),
                             ::testing::Values(Precision::FP32),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/concat_in_place.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/concat_in_place.cpp
@@ -140,7 +140,7 @@ TEST_P(Concat_in_place, CompareWithRefImpl) {
     test();
 };
 
-INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, Concat_in_place,
+INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, Concat_in_place,
                         ::testing::Combine(
                                 ::testing::Values(Precision::FP32),
                                 ::testing::Values(Precision::FP32),
@@ -149,7 +149,7 @@ INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, Concat_in_place,
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         Concat_in_place::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, Concat_in_place,
+INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, Concat_in_place,
                         ::testing::Combine(
                                 ::testing::Values(Precision::FP32),
                                 ::testing::Values(Precision::BF16),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/conv_add.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/conv_add.cpp
@@ -123,7 +123,7 @@ TEST_P(ConvAdd, CompareWithRefImpl) {
 
 //    CPU plug-in failure in that case
 
-//INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, ConvAdd,
+//INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, ConvAdd,
 //                        ::testing::Combine(
 //                                ::testing::Values(Precision::FP32),
 //                                ::testing::Values(Precision::FP32),
@@ -132,7 +132,7 @@ TEST_P(ConvAdd, CompareWithRefImpl) {
 //                                ::testing::Values(CommonTestUtils::DEVICE_CPU)),
 //                        ConvAdd::getTestCaseName);
 //
-//INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, ConvAdd,
+//INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, ConvAdd,
 //                        ::testing::Combine(
 //                                ::testing::Values(Precision::FP32),
 //                                ::testing::Values(Precision::BF16),
@@ -141,7 +141,7 @@ TEST_P(ConvAdd, CompareWithRefImpl) {
 //                                ::testing::Values(CommonTestUtils::DEVICE_CPU)),
 //                        ConvAdd::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, ConvAdd,
+INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, ConvAdd,
                         ::testing::Combine(
                                 ::testing::Values(Precision::FP32),
                                 ::testing::Values(Precision::FP32),
@@ -150,7 +150,7 @@ INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, ConvAdd,
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         ConvAdd::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, ConvAdd,
+INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, ConvAdd,
                         ::testing::Combine(
                                 ::testing::Values(Precision::FP32),
                                 ::testing::Values(Precision::BF16),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/conv_conv.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/conv_conv.cpp
@@ -108,7 +108,7 @@ TEST_P(ConvConv, CompareWithRefImpl) {
     test();
 };
 
-INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, ConvConv,
+INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, ConvConv,
                         ::testing::Combine(
                         ::testing::Values(Precision::FP32),
                         ::testing::Values(Precision::FP32),
@@ -117,7 +117,7 @@ INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, ConvConv,
                         ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         ConvConv::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, ConvConv,
+INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, ConvConv,
                         ::testing::Combine(
                             ::testing::Values(Precision::FP32),
                             ::testing::Values(Precision::FP32),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/conv_dwconv_relu.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/conv_dwconv_relu.cpp
@@ -127,7 +127,7 @@ TEST_P(ConvDWConvReLU, CompareWithRefImpl) {
     test();
 };
 
-INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, ConvDWConvReLU,
+INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, ConvDWConvReLU,
                             ::testing::Combine(
                                     ::testing::Values(Precision::FP32),
                                     ::testing::Values(Precision::FP32),
@@ -136,7 +136,7 @@ INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, ConvDWConvReLU,
                                     ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         ConvDWConvReLU::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, ConvDWConvReLU,
+INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, ConvDWConvReLU,
                         ::testing::Combine(
                             ::testing::Values(Precision::FP32),
                             ::testing::Values(Precision::BF16),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/conv_eltwise_depthwise.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/conv_eltwise_depthwise.cpp
@@ -225,7 +225,7 @@ TEST_P(ConvEltwiseDepthwise, CompareWithRefImpl) {
     Run_test();
 };
 
-INSTANTIATE_TEST_CASE_P(FP32_bfloat16_1x1_depthwise_BF16, ConvEltwiseDepthwise,
+INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_1x1_depthwise_BF16, ConvEltwiseDepthwise,
     ::testing::Combine(
         ::testing::Values(Precision::FP32),
         ::testing::Values(SizeVector({ 1, 5, 1, 1 })),
@@ -235,7 +235,7 @@ INSTANTIATE_TEST_CASE_P(FP32_bfloat16_1x1_depthwise_BF16, ConvEltwiseDepthwise,
         ::testing::Values(string("jit_avx512_1x1_BF16"))),
     ConvEltwiseDepthwise::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(FP32_bfloat16_gemm_depthwise_BF16, ConvEltwiseDepthwise,
+INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_gemm_depthwise_BF16, ConvEltwiseDepthwise,
     ::testing::Combine(
         ::testing::Values(Precision::FP32),
         ::testing::Values(SizeVector({ 1, 3, 10, 10 })),
@@ -245,7 +245,7 @@ INSTANTIATE_TEST_CASE_P(FP32_bfloat16_gemm_depthwise_BF16, ConvEltwiseDepthwise,
         ::testing::Values(string("jit_gemm_BF16"))),
     ConvEltwiseDepthwise::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(FP32_bfloat16_conv_depthwise_BF16, ConvEltwiseDepthwise,
+INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_conv_depthwise_BF16, ConvEltwiseDepthwise,
     ::testing::Combine(
         ::testing::Values(Precision::FP32),
         ::testing::Values(SizeVector({ 1, 5, 10, 10 })),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/conv_relu_pool_conv_relu_pool.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/conv_relu_pool_conv_relu_pool.cpp
@@ -177,7 +177,7 @@ TEST_P(ConvReLUPoolConvReLUPool, CompareWithRefImpl) {
 };
 
 
-INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, ConvReLUPoolConvReLUPool,
+INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, ConvReLUPoolConvReLUPool,
                         ::testing::Combine(
                             ::testing::Values(Precision::FP32),
                             ::testing::Values(Precision::FP32),
@@ -186,7 +186,7 @@ INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, ConvReLUPoolConvReLUPool,
                             ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         ConvReLUPoolConvReLUPool::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, ConvReLUPoolConvReLUPool,
+INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, ConvReLUPoolConvReLUPool,
                         ::testing::Combine(
                             ::testing::Values(Precision::FP32),
                             ::testing::Values(Precision::BF16),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/elt_max.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/elt_max.cpp
@@ -131,7 +131,7 @@ TEST_P(Elt_max, CompareWithRefImpl) {
 };
 
 
-INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, Elt_max,
+INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, Elt_max,
                         ::testing::Combine(
                                 ::testing::Values(Precision::FP32),
                                 ::testing::Values(Precision::FP32),
@@ -140,7 +140,7 @@ INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, Elt_max,
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         Elt_max::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, Elt_max,
+INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, Elt_max,
                         ::testing::Combine(
                                 ::testing::Values(Precision::FP32),
                                 ::testing::Values(Precision::BF16),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/elt_x3.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/elt_x3.cpp
@@ -191,7 +191,7 @@ TEST_P(Elt_x3, CompareWithRefImpl) {
 
 //    CPU plug-in failure in that case
 
-//INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, Elt_x3,
+//INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, Elt_x3,
 //                        ::testing::Combine(
 //                                ::testing::Values(Precision::FP32),
 //                                ::testing::Values(Precision::FP32),
@@ -200,7 +200,7 @@ TEST_P(Elt_x3, CompareWithRefImpl) {
 //                                ::testing::Values(CommonTestUtils::DEVICE_CPU)),
 //                        Elt_x3::getTestCaseName);
 //
-//INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, Elt_x3,
+//INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, Elt_x3,
 //                        ::testing::Combine(
 //                                ::testing::Values(Precision::FP32),
 //                                ::testing::Values(Precision::BF16),
@@ -209,7 +209,7 @@ TEST_P(Elt_x3, CompareWithRefImpl) {
 //                                ::testing::Values(CommonTestUtils::DEVICE_CPU)),
 //                        Elt_x3::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, Elt_x3,
+INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, Elt_x3,
                         ::testing::Combine(
                                 ::testing::Values(Precision::FP32),
                                 ::testing::Values(Precision::FP32),
@@ -218,7 +218,7 @@ INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, Elt_x3,
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         Elt_x3::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, Elt_x3,
+INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, Elt_x3,
                         ::testing::Combine(
                                 ::testing::Values(Precision::FP32),
                                 ::testing::Values(Precision::BF16),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/faster_100_5_1_1_conv.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/faster_100_5_1_1_conv.cpp
@@ -115,7 +115,7 @@ TEST_P(Faster100_5_1_1_Conv, CompareWithRefImpl) {
 };
 
 
-INSTANTIATE_TEST_CASE_P(bfloat16_NoReshape, Faster100_5_1_1_Conv,
+INSTANTIATE_TEST_CASE_P(smoke_bfloat16_NoReshape, Faster100_5_1_1_Conv,
                         ::testing::Combine(
                             ::testing::Values(Precision::FP32),
                             ::testing::Values(Precision::FP32),
@@ -124,7 +124,7 @@ INSTANTIATE_TEST_CASE_P(bfloat16_NoReshape, Faster100_5_1_1_Conv,
                             ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                             Faster100_5_1_1_Conv::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, Faster100_5_1_1_Conv,
+INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, Faster100_5_1_1_Conv,
                         ::testing::Combine(
                             ::testing::Values(Precision::FP32),
                             ::testing::Values(Precision::BF16),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/gather_multiply.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/gather_multiply.cpp
@@ -109,7 +109,7 @@ TEST_P(Gather_multiply, CompareWithRefImpl) {
 };
 
 
-INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, Gather_multiply,
+INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, Gather_multiply,
                         ::testing::Combine(
                                 ::testing::Values(Precision::FP32),
                                 ::testing::Values(Precision::FP32),
@@ -119,7 +119,7 @@ INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, Gather_multiply,
                         Gather_multiply::getTestCaseName);
 //    CPU plug-in failure in that case
 
-//INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, Gather_multiply,
+//INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, Gather_multiply,
 //                        ::testing::Combine(
 //                                ::testing::Values(Precision::FP32),
 //                                ::testing::Values(Precision::BF16),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/gather_x2_add_mul_relu_concat_matmul.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/gather_x2_add_mul_relu_concat_matmul.cpp
@@ -135,7 +135,7 @@ TEST_P(Gather_x2_add_mul_relu_concat_matmul, CompareWithRefImpl) {
 };
 
 
-INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, Gather_x2_add_mul_relu_concat_matmul,
+INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, Gather_x2_add_mul_relu_concat_matmul,
                         ::testing::Combine(
                                 ::testing::Values(Precision::FP32),
                                 ::testing::Values(Precision::FP32),
@@ -144,7 +144,7 @@ INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, Gather_x2_add_mul_relu_concat_m
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         Gather_x2_add_mul_relu_concat_matmul::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, Gather_x2_add_mul_relu_concat_matmul,
+INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, Gather_x2_add_mul_relu_concat_matmul,
                         ::testing::Combine(
                                 ::testing::Values(Precision::FP32),
                                 ::testing::Values(Precision::BF16),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/interpolation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/interpolation.cpp
@@ -125,7 +125,7 @@ TEST_P(Interpolation, CompareWithRefImpl) {
 };
 
 
-INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, Interpolation,
+INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, Interpolation,
                         ::testing::Combine(
                                 ::testing::Values(Precision::FP32),
                                 ::testing::Values(Precision::FP32),
@@ -134,7 +134,7 @@ INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, Interpolation,
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         Interpolation::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, Interpolation,
+INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, Interpolation,
                         ::testing::Combine(
                                 ::testing::Values(Precision::FP32),
                                 ::testing::Values(Precision::BF16),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/memory_conv.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/memory_conv.cpp
@@ -102,7 +102,7 @@ TEST_P(MemoryConv, CheckTypeConversion) {
     ASSERT_EQ(ngraph::element::bf16, mem_w->input(0).get_element_type());
 }
 
-INSTANTIATE_TEST_CASE_P(CPU, MemoryConv,
+INSTANTIATE_TEST_CASE_P(smoke_CPU, MemoryConv,
                         ::testing::Combine(
                                 ::testing::Values<Precision>(Precision::BF16, Precision::FP32),
                                 ::testing::Values(SizeVector{1, 200}),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/mobilenet_ssd_with_branching.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/mobilenet_ssd_with_branching.cpp
@@ -164,7 +164,7 @@ TEST_P(MobileNet_ssd_with_branching, CompareWithRefImpl) {
     test();
 };
 
-INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, MobileNet_ssd_with_branching,
+INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, MobileNet_ssd_with_branching,
                         ::testing::Combine(
                                 ::testing::Values(Precision::FP32),
                                 ::testing::Values(Precision::FP32),
@@ -173,7 +173,7 @@ INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, MobileNet_ssd_with_branching,
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         MobileNet_ssd_with_branching::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, MobileNet_ssd_with_branching,
+INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, MobileNet_ssd_with_branching,
                         ::testing::Combine(
                             ::testing::Values(Precision::FP32),
                             ::testing::Values(Precision::BF16),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/resample.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/resample.cpp
@@ -125,7 +125,7 @@ TEST_P(Resample, CompareWithRefImpl) {
 };
 
 
-INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, Resample,
+INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, Resample,
                         ::testing::Combine(
                                 ::testing::Values(Precision::FP32),
                                 ::testing::Values(Precision::FP32),
@@ -134,7 +134,7 @@ INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, Resample,
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         Resample::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, Resample,
+INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, Resample,
                         ::testing::Combine(
                                 ::testing::Values(Precision::FP32),
                                 ::testing::Values(Precision::BF16),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/scaleshift_conv_eltwise_conv.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/scaleshift_conv_eltwise_conv.cpp
@@ -134,7 +134,7 @@ TEST_P(ScaleshiftConvEltwiseConv, CompareWithRefImpl) {
     test();
 };
 
-INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, ScaleshiftConvEltwiseConv,
+INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, ScaleshiftConvEltwiseConv,
                         ::testing::Combine(
                                 ::testing::Values(Precision::FP32),
                                 ::testing::Values(Precision::FP32),
@@ -143,7 +143,7 @@ INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, ScaleshiftConvEltwiseConv,
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         ScaleshiftConvEltwiseConv::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, ScaleshiftConvEltwiseConv,
+INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, ScaleshiftConvEltwiseConv,
                         ::testing::Combine(
                             ::testing::Values(Precision::FP32),
                             ::testing::Values(Precision::BF16),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/scaleshift_conv_eltwise_relu_conv.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/scaleshift_conv_eltwise_relu_conv.cpp
@@ -139,7 +139,7 @@ TEST_P(ScaleshiftConvEltwiseReluConv, CompareWithRefImpl) {
     test();
 };
 
-INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, ScaleshiftConvEltwiseReluConv,
+INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, ScaleshiftConvEltwiseReluConv,
                         ::testing::Combine(
                                 ::testing::Values(Precision::FP32),
                                 ::testing::Values(Precision::FP32),
@@ -148,7 +148,7 @@ INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, ScaleshiftConvEltwiseReluConv,
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         ScaleshiftConvEltwiseReluConv::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, ScaleshiftConvEltwiseReluConv,
+INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, ScaleshiftConvEltwiseReluConv,
                         ::testing::Combine(
                             ::testing::Values(Precision::FP32),
                             ::testing::Values(Precision::BF16),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/scaleshift_conv_eltwise_scaleshift.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/scaleshift_conv_eltwise_scaleshift.cpp
@@ -132,7 +132,7 @@ TEST_P(ScaleshiftConvEltwiseScaleshift, CompareWithRefImpl) {
     test();
 };
 
-INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, ScaleshiftConvEltwiseScaleshift,
+INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, ScaleshiftConvEltwiseScaleshift,
                         ::testing::Combine(
                                 ::testing::Values(Precision::FP32),
                                 ::testing::Values(Precision::FP32),
@@ -141,7 +141,7 @@ INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, ScaleshiftConvEltwiseScaleshift
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         ScaleshiftConvEltwiseScaleshift::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, ScaleshiftConvEltwiseScaleshift,
+INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, ScaleshiftConvEltwiseScaleshift,
                         ::testing::Combine(
                             ::testing::Values(Precision::FP32),
                             ::testing::Values(Precision::BF16),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/scaleshift_conv_elu_conv.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/scaleshift_conv_elu_conv.cpp
@@ -119,7 +119,7 @@ TEST_P(ScaleshiftConvEluConv, CompareWithRefImpl) {
     test();
 };
 
-INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, ScaleshiftConvEluConv,
+INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, ScaleshiftConvEluConv,
                         ::testing::Combine(
                                 ::testing::Values(Precision::FP32),
                                 ::testing::Values(Precision::FP32),
@@ -128,7 +128,7 @@ INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, ScaleshiftConvEluConv,
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         ScaleshiftConvEluConv::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, ScaleshiftConvEluConv,
+INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, ScaleshiftConvEluConv,
                         ::testing::Combine(
                             ::testing::Values(Precision::FP32),
                             ::testing::Values(Precision::BF16),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/scaleshift_conv_relu.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/scaleshift_conv_relu.cpp
@@ -107,7 +107,7 @@ TEST_P(ScaleshiftConvRelu, CompareWithRefImpl) {
     test();
 };
 
-INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, ScaleshiftConvRelu,
+INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, ScaleshiftConvRelu,
                         ::testing::Combine(
                                 ::testing::Values(Precision::FP32),
                                 ::testing::Values(Precision::FP32),
@@ -116,7 +116,7 @@ INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, ScaleshiftConvRelu,
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         ScaleshiftConvRelu::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, ScaleshiftConvRelu,
+INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, ScaleshiftConvRelu,
                         ::testing::Combine(
                             ::testing::Values(Precision::FP32),
                             ::testing::Values(Precision::BF16),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/scaleshift_conv_x2_concat_relu.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/scaleshift_conv_x2_concat_relu.cpp
@@ -126,7 +126,7 @@ TEST_P(ScaleshiftConv_x2_ConcatRelu, CompareWithRefImpl) {
     test();
 };
 
-INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, ScaleshiftConv_x2_ConcatRelu,
+INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, ScaleshiftConv_x2_ConcatRelu,
                         ::testing::Combine(
                                 ::testing::Values(Precision::FP32),
                                 ::testing::Values(Precision::FP32),
@@ -135,7 +135,7 @@ INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, ScaleshiftConv_x2_ConcatRelu,
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         ScaleshiftConv_x2_ConcatRelu::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, ScaleshiftConv_x2_ConcatRelu,
+INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, ScaleshiftConv_x2_ConcatRelu,
                         ::testing::Combine(
                             ::testing::Values(Precision::FP32),
                             ::testing::Values(Precision::BF16),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/scaleshift_conv_x2_eltwise.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/scaleshift_conv_x2_eltwise.cpp
@@ -117,7 +117,7 @@ TEST_P(ScaleshiftConv_x2_Eltwise, CompareWithRefImpl) {
     test();
 };
 
-INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, ScaleshiftConv_x2_Eltwise,
+INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, ScaleshiftConv_x2_Eltwise,
                         ::testing::Combine(
                                 ::testing::Values(Precision::FP32),
                                 ::testing::Values(Precision::FP32),
@@ -126,7 +126,7 @@ INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, ScaleshiftConv_x2_Eltwise,
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         ScaleshiftConv_x2_Eltwise::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, ScaleshiftConv_x2_Eltwise,
+INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, ScaleshiftConv_x2_Eltwise,
                         ::testing::Combine(
                             ::testing::Values(Precision::FP32),
                             ::testing::Values(Precision::BF16),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/scaleshift_conv_x2_mixed1_eltwise.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/scaleshift_conv_x2_mixed1_eltwise.cpp
@@ -117,7 +117,7 @@ TEST_P(ScaleshiftConv_x2_mixed1_Eltwise, CompareWithRefImpl) {
     test();
 };
 
-INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, ScaleshiftConv_x2_mixed1_Eltwise,
+INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, ScaleshiftConv_x2_mixed1_Eltwise,
                             ::testing::Combine(
                                     ::testing::Values(Precision::FP32),
                                     ::testing::Values(Precision::FP32),
@@ -126,7 +126,7 @@ INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, ScaleshiftConv_x2_mixed1_Eltwis
                                     ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         ScaleshiftConv_x2_mixed1_Eltwise::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, ScaleshiftConv_x2_mixed1_Eltwise,
+INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, ScaleshiftConv_x2_mixed1_Eltwise,
                         ::testing::Combine(
                             ::testing::Values(Precision::FP32),
                             ::testing::Values(Precision::BF16),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/scaleshift_conv_x2_mixed2_eltwise.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/scaleshift_conv_x2_mixed2_eltwise.cpp
@@ -120,7 +120,7 @@ TEST_P(ScaleshiftConv_x2_mixed2_Eltwise, CompareWithRefImpl) {
     test();
 };
 
-INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, ScaleshiftConv_x2_mixed2_Eltwise,
+INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, ScaleshiftConv_x2_mixed2_Eltwise,
                             ::testing::Combine(
                                     ::testing::Values(Precision::FP32),
                                     ::testing::Values(Precision::FP32),
@@ -129,7 +129,7 @@ INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, ScaleshiftConv_x2_mixed2_Eltwis
                                     ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         ScaleshiftConv_x2_mixed2_Eltwise::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, ScaleshiftConv_x2_mixed2_Eltwise,
+INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, ScaleshiftConv_x2_mixed2_Eltwise,
                         ::testing::Combine(
                             ::testing::Values(Precision::FP32),
                             ::testing::Values(Precision::BF16),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/scaleshift_conv_x3_eltwise.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/scaleshift_conv_x3_eltwise.cpp
@@ -153,7 +153,7 @@ TEST_P(ScaleshiftConv_x3_Eltwise, CompareWithRefImpl) {
     test();
 };
 
-INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, ScaleshiftConv_x3_Eltwise,
+INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, ScaleshiftConv_x3_Eltwise,
                         ::testing::Combine(
                             ::testing::Values(Precision::FP32),
                             ::testing::Values(Precision::FP32),
@@ -162,7 +162,7 @@ INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, ScaleshiftConv_x3_Eltwise,
                             ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         ScaleshiftConv_x3_Eltwise::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, ScaleshiftConv_x3_Eltwise,
+INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, ScaleshiftConv_x3_Eltwise,
                         ::testing::Combine(
                             ::testing::Values(Precision::FP32),
                             ::testing::Values(Precision::BF16),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/scaleshift_x2_conv_x2_eltwise.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/scaleshift_x2_conv_x2_eltwise.cpp
@@ -140,7 +140,7 @@ TEST_P(Scaleshift_x2_Conv_x2_Eltwise, CompareWithRefImpl) {
     test();
 };
 
-INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, Scaleshift_x2_Conv_x2_Eltwise,
+INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, Scaleshift_x2_Conv_x2_Eltwise,
                         ::testing::Combine(
                                 ::testing::Values(Precision::FP32),
                                 ::testing::Values(Precision::FP32),
@@ -149,7 +149,7 @@ INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, Scaleshift_x2_Conv_x2_Eltwise,
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         Scaleshift_x2_Conv_x2_Eltwise::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, Scaleshift_x2_Conv_x2_Eltwise,
+INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, Scaleshift_x2_Conv_x2_Eltwise,
                         ::testing::Combine(
                             ::testing::Values(Precision::FP32),
                             ::testing::Values(Precision::BF16),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/scaleshift_x3_conv_eltwise_relu.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/scaleshift_x3_conv_eltwise_relu.cpp
@@ -160,7 +160,7 @@ TEST_P(Scaleshift_x3_ConvEltwiseRelu, CompareWithRefImpl) {
     test();
 };
 
-INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, Scaleshift_x3_ConvEltwiseRelu,
+INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, Scaleshift_x3_ConvEltwiseRelu,
                         ::testing::Combine(
                                 ::testing::Values(Precision::FP32),
                                 ::testing::Values(Precision::FP32),
@@ -169,7 +169,7 @@ INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, Scaleshift_x3_ConvEltwiseRelu,
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         Scaleshift_x3_ConvEltwiseRelu::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, Scaleshift_x3_ConvEltwiseRelu,
+INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, Scaleshift_x3_ConvEltwiseRelu,
                         ::testing::Combine(
                             ::testing::Values(Precision::FP32),
                             ::testing::Values(Precision::BF16),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/tail_fp32_optimization.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/tail_fp32_optimization.cpp
@@ -123,7 +123,7 @@ TEST_P(PoolingAfterConv, CompareWithRefImpl) {
 };
 
 
-INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, PoolingAfterConv,
+INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, PoolingAfterConv,
                         ::testing::Combine(
                             ::testing::Values(Precision::FP32),
                             ::testing::Values(Precision::FP32),
@@ -132,7 +132,7 @@ INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, PoolingAfterConv,
                             ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                             PoolingAfterConv::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, PoolingAfterConv,
+INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, PoolingAfterConv,
                         ::testing::Combine(
                             ::testing::Values(Precision::FP32),
                             ::testing::Values(Precision::BF16),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/topk_inputs_i32.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/topk_inputs_i32.cpp
@@ -144,7 +144,7 @@ TEST_P(TopKInputsI32, CompareWithRefImpl) {
 };
 
 
-INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, TopKInputsI32,
+INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, TopKInputsI32,
                         ::testing::Combine(
                             ::testing::Values(Precision::FP32),
                             ::testing::Values(Precision::FP32),
@@ -153,7 +153,7 @@ INSTANTIATE_TEST_CASE_P(FP32_bfloat16_NoReshape, TopKInputsI32,
                             ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         TopKInputsI32::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(BF16_bfloat16_NoReshape, TopKInputsI32,
+INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, TopKInputsI32,
                         ::testing::Combine(
                             ::testing::Values(Precision::FP32),
                             ::testing::Values(Precision::BF16),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/behavior/add_output.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/behavior/add_output.cpp
@@ -18,6 +18,6 @@ std::vector<addOutputsParams> testCases = {
         addOutputsParams(getTargetNetwork(), {"Memory_1"}, CommonTestUtils::DEVICE_CPU)
 };
 
-INSTANTIATE_TEST_CASE_P(AddOutputBasic, AddOutputsTest,
+INSTANTIATE_TEST_CASE_P(smoke_AddOutputBasic, AddOutputsTest,
                         ::testing::ValuesIn(testCases),
                         AddOutputsTest::getTestCaseName);

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/configuration_tests/configuration_tests.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/configuration_tests/configuration_tests.cpp
@@ -14,7 +14,7 @@ auto defaultBindThreadParameter = InferenceEngine::Parameter{std::string{CONFIG_
 auto defaultBindThreadParameter = InferenceEngine::Parameter{std::string{CONFIG_VALUE(YES)}};
 #endif
 INSTANTIATE_TEST_CASE_P(
-    Basic,
+    smoke_Basic,
     DefaultConfigurationTest,
     ::testing::Combine(
         ::testing::Values("CPU"),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/execution_graph_tests/keep_assign.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/execution_graph_tests/keep_assign.cpp
@@ -9,7 +9,7 @@ using namespace LayerTestsDefinitions;
 
 namespace {
 
-INSTANTIATE_TEST_CASE_P(KeepAssign, ExecGraphKeepAssignNode,
+INSTANTIATE_TEST_CASE_P(smoke_KeepAssign, ExecGraphKeepAssignNode,
         ::testing::Values(CommonTestUtils::DEVICE_CPU),
         ExecGraphKeepAssignNode::getTestCaseName);
 

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/execution_graph_tests/num_inputs_fusing_bin_conv.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/execution_graph_tests/num_inputs_fusing_bin_conv.cpp
@@ -7,5 +7,5 @@
 
 using namespace LayerTestsDefinitions;
 
-INSTANTIATE_TEST_CASE_P(inputsNumFusingBinConv, ExecGraphInputsFusingBinConv, ::testing::Values(CommonTestUtils::DEVICE_CPU),
+INSTANTIATE_TEST_CASE_P(smoke_inputsNumFusingBinConv, ExecGraphInputsFusingBinConv, ::testing::Values(CommonTestUtils::DEVICE_CPU),
                         ExecGraphInputsFusingBinConv::getTestCaseName);

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/execution_graph_tests/unique_node_names.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/execution_graph_tests/unique_node_names.cpp
@@ -15,7 +15,7 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
         InferenceEngine::Precision::FP32
 };
 
-INSTANTIATE_TEST_CASE_P(NoReshape, ExecGraphUniqueNodeNames,
+INSTANTIATE_TEST_CASE_P(smoke_NoReshape, ExecGraphUniqueNodeNames,
                         ::testing::Combine(
                                 ::testing::ValuesIn(netPrecisions),
                                 ::testing::Values(InferenceEngine::SizeVector({1, 2, 5, 5})),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/concat_neighboring_graph_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/concat_neighboring_graph_transformation.cpp
@@ -23,7 +23,7 @@ const std::vector<LayerTransformation::Params> trasformationParamValues = {
     LayerTestsUtils::LayerTransformationParamsFactory::createParamsU8I8()
 };
 
-INSTANTIATE_TEST_CASE_P(LPT, ConcatNeighboringGraphTransformation,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, ConcatNeighboringGraphTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(InferenceEngine::SizeVector({ 1, 3, 16, 16 })),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/concat_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/concat_transformation.cpp
@@ -23,7 +23,7 @@ const std::vector<LayerTransformation::Params> trasformationParamValues = {
     LayerTestsUtils::LayerTransformationParamsFactory::createParamsU8I8()
 };
 
-INSTANTIATE_TEST_CASE_P(LPT, ConcatTransformation,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, ConcatTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(InferenceEngine::SizeVector({ 1, 3, 16, 16 })),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/concat_with_intermediate_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/concat_with_intermediate_transformation.cpp
@@ -26,7 +26,7 @@ const std::vector<LayerTransformation::Params> trasformationParamValues = {
 const std::vector<bool> transparentIntermediateValues = { true, false };
 const std::vector<bool> multiChannelValues = { /*true,*/ false };
 
-INSTANTIATE_TEST_CASE_P(LPT, ConcatWithIntermediateTransformation,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, ConcatWithIntermediateTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(InferenceEngine::SizeVector({ 1, 3, 16, 16 })),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/convolution_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/convolution_transformation.cpp
@@ -25,7 +25,7 @@ const std::vector<bool> fqOnActivationsValues = { true, false };
 
 const std::vector<bool> fqOnWeightsValues = { true, false };
 
-INSTANTIATE_TEST_CASE_P(LPT, ConvolutionTransformation,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, ConvolutionTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(InferenceEngine::SizeVector({ 1, 3, 16, 16 })),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/depth_to_space_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/depth_to_space_transformation.cpp
@@ -22,7 +22,7 @@ const std::vector<LayerTransformation::Params> trasformationParamValues = {
     LayerTestsUtils::LayerTransformationParamsFactory::createParamsU8I8()
 };
 
-INSTANTIATE_TEST_CASE_P(LPT, DepthToSpaceTransformation,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, DepthToSpaceTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(InferenceEngine::SizeVector({ 1, 32, 72, 48 })),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/fully_connected_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/fully_connected_transformation.cpp
@@ -26,7 +26,7 @@ const std::vector<LayerTransformation::Params> trasformationParamValues = {
     LayerTestsUtils::LayerTransformationParamsFactory::createParamsU8I8()
 };
 
-INSTANTIATE_TEST_CASE_P(LPT, FullyConnectedTransformation,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, FullyConnectedTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::ValuesIn(dimensions),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/fuse_fake_quantize_and_scale_shift_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/fuse_fake_quantize_and_scale_shift_transformation.cpp
@@ -32,7 +32,7 @@ const std::vector<ngraph::builder::subgraph::FakeQuantizeOnData> fakeQuantizeOnD
     },
 };
 
-INSTANTIATE_TEST_CASE_P(LPT, FuseFakeQuantizeAndScaleShiftTransformation,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, FuseFakeQuantizeAndScaleShiftTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(InferenceEngine::SizeVector({ 1, 3, 9, 9 })),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/gemm_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/gemm_transformation.cpp
@@ -27,7 +27,7 @@ const std::vector<LayerTransformation::Params> trasformationParamValues = {
     LayerTestsUtils::LayerTransformationParamsFactory::createParamsU8I8()
 };
 
-INSTANTIATE_TEST_CASE_P(LPT, GemmTransformation,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, GemmTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::ValuesIn(dimensions),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/mat_mul_with_optimized_constant_fake_quantize_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/mat_mul_with_optimized_constant_fake_quantize_transformation.cpp
@@ -26,7 +26,7 @@ const std::vector<std::pair<InferenceEngine::SizeVector, InferenceEngine::SizeVe
     std::pair<InferenceEngine::SizeVector, InferenceEngine::SizeVector>({ InferenceEngine::SizeVector({ 1, 16 }), InferenceEngine::SizeVector({ 16, 10 }) })
 };
 
-INSTANTIATE_TEST_CASE_P(LPT, MatMulWithOptimizedConstantFakeQuantizeTransformation,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, MatMulWithOptimizedConstantFakeQuantizeTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::ValuesIn(inputShapes),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/multiply_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/multiply_transformation.cpp
@@ -67,7 +67,7 @@ const std::vector<LayerTestsDefinitions::MultiplyTestValues> params = {
     { {}, {}, false }, { {}, {}, true },
 };
 
-INSTANTIATE_TEST_CASE_P(LPT, MultiplyTransformation,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, MultiplyTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(InferenceEngine::SizeVector({ 1, 3, 16, 16 })),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/multiply_with_one_parent_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/multiply_with_one_parent_transformation.cpp
@@ -21,7 +21,7 @@ const std::vector<MultiplyWithOneParentTransformationValues> values = {
     }
 };
 
-INSTANTIATE_TEST_CASE_P(LPT, MultiplyWithOneParentTransformation,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, MultiplyWithOneParentTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(InferenceEngine::SizeVector({ 1, 3, 16, 16 })),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/normalize_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/normalize_transformation.cpp
@@ -26,7 +26,7 @@ const std::vector<bool> fuseMultiplyValues = { true, false };
 
 const std::vector<bool> shiftValues = { true, false };
 
-INSTANTIATE_TEST_CASE_P(LPT, NormalizeTransformation,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, NormalizeTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(InferenceEngine::SizeVector({ 1, 16, 8, 8 })),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/output_layers_handling_in_transformations.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/output_layers_handling_in_transformations.cpp
@@ -22,7 +22,7 @@ const std::vector<LayerTransformation::Params> trasformationParamValues = {
     LayerTestsUtils::LayerTransformationParamsFactory::createParamsU8I8()
 };
 
-INSTANTIATE_TEST_CASE_P(LPT, OutputLayersHandlingInTransformations,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, OutputLayersHandlingInTransformations,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(InferenceEngine::SizeVector({ 1, 3, 16, 16 })),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/output_layers_handling_in_transformations_for_concat.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/output_layers_handling_in_transformations_for_concat.cpp
@@ -22,7 +22,7 @@ const std::vector<LayerTransformation::Params> trasformationParamValues = {
     LayerTestsUtils::LayerTransformationParamsFactory::createParamsU8I8()
 };
 
-INSTANTIATE_TEST_CASE_P(LPT, OutputLayersHandlingInTransformationsForConcat,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, OutputLayersHandlingInTransformationsForConcat,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(InferenceEngine::SizeVector({ 1, 3, 16, 16 })),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/output_layers_handling_in_transformations_for_concat_multi_channel.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/output_layers_handling_in_transformations_for_concat_multi_channel.cpp
@@ -22,7 +22,7 @@ const std::vector<LayerTransformation::Params> trasformationParamValues = {
     LayerTestsUtils::LayerTransformationParamsFactory::createParamsU8I8()
 };
 
-INSTANTIATE_TEST_CASE_P(LPT, OutputLayersHandlingInTransformationsForConcatMultiChannel,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, OutputLayersHandlingInTransformationsForConcatMultiChannel,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(InferenceEngine::SizeVector({ 1, 3, 16, 16 })),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/permute_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/permute_transformation.cpp
@@ -107,7 +107,7 @@ const std::vector<PermuteTransformationTestValues> testValues = {
     }
 };
 
-INSTANTIATE_TEST_CASE_P(LPT, PermuteTransformation,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, PermuteTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(CommonTestUtils::DEVICE_CPU),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/reshape_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/reshape_transformation.cpp
@@ -22,7 +22,7 @@ const std::vector<InferenceEngine::details::LayerTransformation::Params> trasfor
 };
 
 
-INSTANTIATE_TEST_CASE_P(LPT, ReshapeTransformation,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, ReshapeTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(InferenceEngine::SizeVector({ 1, 3, 16, 16 })),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/ngraph_conversion_tests/conv_bias_fusion.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/ngraph_conversion_tests/conv_bias_fusion.cpp
@@ -9,6 +9,6 @@ using namespace NGraphConversionTestsDefinitions;
 
 namespace {
 
-INSTANTIATE_TEST_CASE_P(Basic, ConvBiasFusion, ::testing::Values("CPU"), ConvBiasFusion::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_Basic, ConvBiasFusion, ::testing::Values("CPU"), ConvBiasFusion::getTestCaseName);
 
 }  // namespace

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/ngraph_conversion_tests/plugin_specific_ngraph_conversion.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/ngraph_conversion_tests/plugin_specific_ngraph_conversion.cpp
@@ -9,6 +9,6 @@ using namespace NGraphConversionTestsDefinitions;
 
 namespace {
 
-INSTANTIATE_TEST_CASE_P(Basic, PluginSpecificConversion, ::testing::Values("CPU"), PluginSpecificConversion::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_Basic, PluginSpecificConversion, ::testing::Values("CPU"), PluginSpecificConversion::getTestCaseName);
 
 }  // namespace

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/activation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/activation.cpp
@@ -82,9 +82,9 @@ const auto basicPreluCases = ::testing::Combine(
 );
 
 
-INSTANTIATE_TEST_CASE_P(Activation_Basic, ActivationLayerTest, basicCases, ActivationLayerTest::getTestCaseName);
-INSTANTIATE_TEST_CASE_P(Activation_Basic_Prelu, ActivationLayerTest, basicPreluCases, ActivationLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_Activation_Basic, ActivationLayerTest, basicCases, ActivationLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_Activation_Basic_Prelu, ActivationLayerTest, basicPreluCases, ActivationLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(Activation_Basic, ActivationParamLayerTest, basicPreluCases, ActivationLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_Activation_Basic, ActivationParamLayerTest, basicPreluCases, ActivationLayerTest::getTestCaseName);
 
 }  // namespace

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/batch_norm.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/batch_norm.cpp
@@ -36,7 +36,7 @@ const auto batchNormParams = testing::Combine(
 );
 
 INSTANTIATE_TEST_CASE_P(
-        BatchNorm,
+        smoke_BatchNorm,
         BatchNormLayerTest,
         batchNormParams,
         BatchNormLayerTest::getTestCaseName

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/comparison.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/comparison.cpp
@@ -50,6 +50,6 @@ const auto ComparisonTestParams = ::testing::Combine(
         ::testing::Values(CommonTestUtils::DEVICE_CPU),
         ::testing::Values(additional_config));
 
-INSTANTIATE_TEST_CASE_P(CompareWithRefs, ComparisonLayerTest, ComparisonTestParams, ComparisonLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_CompareWithRefs, ComparisonLayerTest, ComparisonTestParams, ComparisonLayerTest::getTestCaseName);
 
 }  // namespace

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/concat.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/concat.cpp
@@ -24,7 +24,7 @@ std::vector<std::vector<std::vector<size_t>>> inShapes = {
 std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP32,
                                                          InferenceEngine::Precision::FP16};
 
-INSTANTIATE_TEST_CASE_P(NoReshape, ConcatLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_NoReshape, ConcatLayerTest,
                         ::testing::Combine(
                                 ::testing::ValuesIn(axes),
                                 ::testing::ValuesIn(inShapes),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/convert.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/convert.cpp
@@ -19,7 +19,7 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
         InferenceEngine::Precision::I8,
 };
 
-INSTANTIATE_TEST_CASE_P(NoReshape, ConvertLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_NoReshape, ConvertLayerTest,
                         ::testing::Combine(
                                 ::testing::Values(inShape),
                                 ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/convert_like.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/convert_like.cpp
@@ -19,7 +19,7 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
         InferenceEngine::Precision::I8,
 };
 
-INSTANTIATE_TEST_CASE_P(NoReshape, ConvertLikeLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_NoReshape, ConvertLikeLayerTest,
                         ::testing::Combine(
                                 ::testing::Values(inShape),
                                 ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/convolution.cpp
@@ -52,7 +52,7 @@ const auto conv2DParams_AutoPadValid = ::testing::Combine(
         ::testing::Values(ngraph::op::PadType::VALID)
 );
 
-INSTANTIATE_TEST_CASE_P(Convolution2D_ExplicitPadding, ConvolutionLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_Convolution2D_ExplicitPadding, ConvolutionLayerTest,
                         ::testing::Combine(
                                 conv2DParams_ExplicitPadding,
                                 ::testing::ValuesIn(netPrecisions),
@@ -64,7 +64,7 @@ INSTANTIATE_TEST_CASE_P(Convolution2D_ExplicitPadding, ConvolutionLayerTest,
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         ConvolutionLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(Convolution2D_AutoPadValid, ConvolutionLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_Convolution2D_AutoPadValid, ConvolutionLayerTest,
                         ::testing::Combine(
                                 conv2DParams_AutoPadValid,
                                 ::testing::ValuesIn(netPrecisions),
@@ -105,7 +105,7 @@ const auto conv3DParams_AutoPadValid = ::testing::Combine(
         ::testing::Values(ngraph::op::PadType::VALID)
 );
 
-INSTANTIATE_TEST_CASE_P(Convolution3D_ExplicitPadding, ConvolutionLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_Convolution3D_ExplicitPadding, ConvolutionLayerTest,
                         ::testing::Combine(
                                 conv3DParams_ExplicitPadding,
                                 ::testing::ValuesIn(netPrecisions),
@@ -117,7 +117,7 @@ INSTANTIATE_TEST_CASE_P(Convolution3D_ExplicitPadding, ConvolutionLayerTest,
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         ConvolutionLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(Convolution3D_AutoPadValid, ConvolutionLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_Convolution3D_AutoPadValid, ConvolutionLayerTest,
                         ::testing::Combine(
                                 conv3DParams_AutoPadValid,
                                 ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/convolution_backprop_data.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/convolution_backprop_data.cpp
@@ -47,7 +47,7 @@ const auto conv2DParams_AutoPadValid = ::testing::Combine(
         ::testing::Values(ngraph::op::PadType::VALID)
 );
 
-INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData2D_ExplicitPadding, ConvolutionBackpropDataLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_ConvolutionBackpropData2D_ExplicitPadding, ConvolutionBackpropDataLayerTest,
                         ::testing::Combine(
                                 conv2DParams_ExplicitPadding,
                                 ::testing::ValuesIn(netPrecisions),
@@ -55,7 +55,7 @@ INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData2D_ExplicitPadding, ConvolutionBa
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         ConvolutionBackpropDataLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData2D_AutoPadValid, ConvolutionBackpropDataLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_ConvolutionBackpropData2D_AutoPadValid, ConvolutionBackpropDataLayerTest,
                         ::testing::Combine(
                                 conv2DParams_AutoPadValid,
                                 ::testing::ValuesIn(netPrecisions),
@@ -92,7 +92,7 @@ const auto conv3DParams_AutoPadValid = ::testing::Combine(
         ::testing::Values(ngraph::op::PadType::VALID)
 );
 
-INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData3D_ExplicitPadding, ConvolutionBackpropDataLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_ConvolutionBackpropData3D_ExplicitPadding, ConvolutionBackpropDataLayerTest,
                         ::testing::Combine(
                                 conv3DParams_ExplicitPadding,
                                 ::testing::ValuesIn(netPrecisions),
@@ -100,7 +100,7 @@ INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData3D_ExplicitPadding, ConvolutionBa
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         ConvolutionBackpropDataLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData3D_AutoPadValid, ConvolutionBackpropDataLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_ConvolutionBackpropData3D_AutoPadValid, ConvolutionBackpropDataLayerTest,
                         ::testing::Combine(
                                 conv3DParams_AutoPadValid,
                                 ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/ctc_loss.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/ctc_loss.cpp
@@ -35,7 +35,7 @@ const auto ctcLossArgsSubset1 = ::testing::Combine(
         ::testing::ValuesIn(unique)
 );
 
-INSTANTIATE_TEST_CASE_P(Set1, CTCLossLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_Set1, CTCLossLayerTest,
                         ::testing::Combine(
                             ctcLossArgsSubset1,
                             ::testing::ValuesIn(fPrecisions),
@@ -56,7 +56,7 @@ const auto ctcLossArgsSubset2 = ::testing::Combine(
         ::testing::ValuesIn(unique)
 );
 
-INSTANTIATE_TEST_CASE_P(Set2, CTCLossLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_Set2, CTCLossLayerTest,
                         ::testing::Combine(
                             ctcLossArgsSubset2,
                             ::testing::ValuesIn(fPrecisions),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/depth_to_space.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/depth_to_space.cpp
@@ -34,7 +34,7 @@ const auto DepthToSpaceBS2 = ::testing::Combine(
         ::testing::Values(CommonTestUtils::DEVICE_CPU)
 );
 
-INSTANTIATE_TEST_CASE_P(DepthToSpaceBS2, DepthToSpaceLayerTest, DepthToSpaceBS2, DepthToSpaceLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_DepthToSpaceBS2, DepthToSpaceLayerTest, DepthToSpaceBS2, DepthToSpaceLayerTest::getTestCaseName);
 
 const std::vector<std::vector<size_t >> inputShapesBS3 = {
         {1, 9, 1, 1}, {1, 9, 2, 2}, {1, 9, 3, 3}, {2, 36, 3, 3}, {2, 27, 5, 4},
@@ -48,6 +48,6 @@ const auto DepthToSpaceBS3 = ::testing::Combine(
         ::testing::Values(CommonTestUtils::DEVICE_CPU)
 );
 
-INSTANTIATE_TEST_CASE_P(DepthToSpaceBS3, DepthToSpaceLayerTest, DepthToSpaceBS3, DepthToSpaceLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_DepthToSpaceBS3, DepthToSpaceLayerTest, DepthToSpaceBS3, DepthToSpaceLayerTest::getTestCaseName);
 
 }  // namespace

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/eltwise.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/eltwise.cpp
@@ -55,5 +55,5 @@ const auto multiply_params = ::testing::Combine(
         ::testing::Values(CommonTestUtils::DEVICE_CPU),
         ::testing::Values(additional_config));
 
-INSTANTIATE_TEST_CASE_P(CompareWithRefs, EltwiseLayerTest, multiply_params, EltwiseLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_CompareWithRefs, EltwiseLayerTest, multiply_params, EltwiseLayerTest::getTestCaseName);
 }  // namespace

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/extract_image_patches.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/extract_image_patches.cpp
@@ -32,7 +32,7 @@ const auto extractImagePatchesParamsSet = ::testing::Combine(
         ::testing::ValuesIn(autoPads)
 );
 
-INSTANTIATE_TEST_CASE_P(layers_CPU, ExtractImagePatchesTest,
+INSTANTIATE_TEST_CASE_P(smoke_layers_CPU, ExtractImagePatchesTest,
         ::testing::Combine(
             ::testing::ValuesIn(inDataShape),
             ::testing::ValuesIn(kernels),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/fake_quantize.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/fake_quantize.cpp
@@ -32,7 +32,7 @@ const auto fqParams = ::testing::Combine(
         ::testing::Values(inputParams)
 );
 
-INSTANTIATE_TEST_CASE_P(FakeQuantize, FakeQuantizeLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_FakeQuantize, FakeQuantizeLayerTest,
                         ::testing::Combine(
                                 fqParams,
                                 ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/gather.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/gather.cpp
@@ -40,7 +40,7 @@ const auto params = testing::Combine(
 );
 
 INSTANTIATE_TEST_CASE_P(
-        Gather,
+        smoke_Gather,
         GatherLayerTest,
         params,
         GatherLayerTest::getTestCaseName

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/group_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/group_convolution.cpp
@@ -45,7 +45,7 @@ const auto groupConv2DParams_AutoPadValid = ::testing::Combine(
         ::testing::Values(ngraph::op::PadType::VALID)
 );
 
-INSTANTIATE_TEST_CASE_P(GroupConvolution2D_ExplicitPadding, GroupConvolutionLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConvolution2D_ExplicitPadding, GroupConvolutionLayerTest,
                         ::testing::Combine(
                                 groupConv2DParams_ExplicitPadding,
                                 ::testing::ValuesIn(netPrecisions),
@@ -53,7 +53,7 @@ INSTANTIATE_TEST_CASE_P(GroupConvolution2D_ExplicitPadding, GroupConvolutionLaye
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         GroupConvolutionLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(GroupConvolution2D_AutoPadValid, GroupConvolutionLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConvolution2D_AutoPadValid, GroupConvolutionLayerTest,
                         ::testing::Combine(
                                 groupConv2DParams_AutoPadValid,
                                 ::testing::ValuesIn(netPrecisions),
@@ -89,7 +89,7 @@ const auto groupConv3DParams_AutoPadValid = ::testing::Combine(
         ::testing::Values(ngraph::op::PadType::VALID)
 );
 
-INSTANTIATE_TEST_CASE_P(GroupConvolution3D_ExplicitPadding, GroupConvolutionLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConvolution3D_ExplicitPadding, GroupConvolutionLayerTest,
                         ::testing::Combine(
                                 groupConv3DParams_ExplicitPadding,
                                 ::testing::ValuesIn(netPrecisions),
@@ -97,7 +97,7 @@ INSTANTIATE_TEST_CASE_P(GroupConvolution3D_ExplicitPadding, GroupConvolutionLaye
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         GroupConvolutionLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(GroupConvolution3D_AutoPadValid, GroupConvolutionLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConvolution3D_AutoPadValid, GroupConvolutionLayerTest,
                         ::testing::Combine(
                                 groupConv3DParams_AutoPadValid,
                                 ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/group_convolution_backprop_data.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/group_convolution_backprop_data.cpp
@@ -48,7 +48,7 @@ const auto groupConvBackpropData2DParams_AutoPadValid = ::testing::Combine(
         ::testing::Values(ngraph::op::PadType::VALID)
 );
 
-INSTANTIATE_TEST_CASE_P(GroupConvBackpropData2D_ExplicitPadding, GroupConvBackpropDataLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConvBackpropData2D_ExplicitPadding, GroupConvBackpropDataLayerTest,
                         ::testing::Combine(
                                 groupConvBackpropData2DParams_ExplicitPadding,
                                 ::testing::ValuesIn(netPrecisions),
@@ -56,7 +56,7 @@ INSTANTIATE_TEST_CASE_P(GroupConvBackpropData2D_ExplicitPadding, GroupConvBackpr
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         GroupConvBackpropDataLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(GroupConvBackpropData2D_AutoPadValid, GroupConvBackpropDataLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConvBackpropData2D_AutoPadValid, GroupConvBackpropDataLayerTest,
                         ::testing::Combine(
                                 groupConvBackpropData2DParams_AutoPadValid,
                                 ::testing::ValuesIn(netPrecisions),
@@ -94,7 +94,7 @@ const auto groupConvBackpropData3DParams_AutoPadValid = ::testing::Combine(
         ::testing::Values(ngraph::op::PadType::VALID)
 );
 
-INSTANTIATE_TEST_CASE_P(GroupConvBackpropData3D_ExplicitPadding, GroupConvBackpropDataLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConvBackpropData3D_ExplicitPadding, GroupConvBackpropDataLayerTest,
                         ::testing::Combine(
                                 groupConvBackpropData3DParams_ExplicitPadding,
                                 ::testing::ValuesIn(netPrecisions),
@@ -102,7 +102,7 @@ INSTANTIATE_TEST_CASE_P(GroupConvBackpropData3D_ExplicitPadding, GroupConvBackpr
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         GroupConvBackpropDataLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(GroupConvBackpropData3D_AutoPadValid, GroupConvBackpropDataLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConvBackpropData3D_AutoPadValid, GroupConvBackpropDataLayerTest,
                         ::testing::Combine(
                                 groupConvBackpropData3DParams_AutoPadValid,
                                 ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/gru_cell.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/gru_cell.cpp
@@ -21,7 +21,7 @@ namespace {
     std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP32,
                                                              InferenceEngine::Precision::FP16};
 
-    INSTANTIATE_TEST_CASE_P(GRUCellCommon, GRUCellTest,
+    INSTANTIATE_TEST_CASE_P(smoke_GRUCellCommon, GRUCellTest,
             ::testing::Combine(
             ::testing::ValuesIn(should_decompose),
             ::testing::ValuesIn(batch),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/gru_sequence.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/gru_sequence.cpp
@@ -28,7 +28,7 @@ namespace {
     std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP32,
                                                              InferenceEngine::Precision::FP16};
 
-    INSTANTIATE_TEST_CASE_P(GRUSequenceCommonZeroClip, GRUSequenceTest,
+    INSTANTIATE_TEST_CASE_P(smoke_GRUSequenceCommonZeroClip, GRUSequenceTest,
                             ::testing::Combine(
                                     ::testing::ValuesIn(seq_lengths_zero_clip),
                                     ::testing::ValuesIn(batch),
@@ -42,7 +42,7 @@ namespace {
                                     ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                             GRUSequenceTest::getTestCaseName);
 
-    INSTANTIATE_TEST_CASE_P(GRUSequenceCommonClip, GRUSequenceTest,
+    INSTANTIATE_TEST_CASE_P(smoke_GRUSequenceCommonClip, GRUSequenceTest,
                             ::testing::Combine(
                                     ::testing::ValuesIn(seq_lengths_clip_non_zero),
                                     ::testing::ValuesIn(batch),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/interpolate.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/interpolate.cpp
@@ -106,7 +106,7 @@ const auto interpolateCases = ::testing::Combine(
         ::testing::ValuesIn(defaultAxes),
         ::testing::ValuesIn(defaultScales));
 
-INSTANTIATE_TEST_CASE_P(Interpolate_Basic, InterpolateLayerTest, ::testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_Interpolate_Basic, InterpolateLayerTest, ::testing::Combine(
         interpolateCasesWithoutNearest,
         ::testing::ValuesIn(prc),
         ::testing::ValuesIn(inShapes),
@@ -114,7 +114,7 @@ INSTANTIATE_TEST_CASE_P(Interpolate_Basic, InterpolateLayerTest, ::testing::Comb
         ::testing::Values(CommonTestUtils::DEVICE_CPU)),
     InterpolateLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(Interpolate_Nearest, InterpolateLayerTest, ::testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_Interpolate_Nearest, InterpolateLayerTest, ::testing::Combine(
         interpolateCases,
         ::testing::ValuesIn(prc),
         ::testing::ValuesIn(inShapes),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/logical.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/logical.cpp
@@ -68,8 +68,8 @@ const auto LogicalTestParamsNot = ::testing::Combine(
         ::testing::Values(CommonTestUtils::DEVICE_CPU),
         ::testing::Values(additional_config));
 
-INSTANTIATE_TEST_CASE_P(CompareWithRefs, LogicalLayerTest, LogicalTestParams, LogicalLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_CompareWithRefs, LogicalLayerTest, LogicalTestParams, LogicalLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(CompareWithRefsNot, LogicalLayerTest, LogicalTestParamsNot, LogicalLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_CompareWithRefsNot, LogicalLayerTest, LogicalTestParamsNot, LogicalLayerTest::getTestCaseName);
 
 }  // namespace

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/lrn.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/lrn.cpp
@@ -22,7 +22,7 @@ const double beta = 2;
 const double bias = 1.0;
 const size_t size = 5;
 
-INSTANTIATE_TEST_CASE_P(LrnCheck, LrnLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_LrnCheck, LrnLayerTest,
                         ::testing::Combine(::testing::Values(alpha),
                                            ::testing::Values(beta),
                                            ::testing::Values(bias),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/lstm_cell.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/lstm_cell.cpp
@@ -21,7 +21,7 @@ namespace {
     std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP32,
                                                              InferenceEngine::Precision::FP16};
 
-    INSTANTIATE_TEST_CASE_P(LSTMCellCommon, LSTMCellTest,
+    INSTANTIATE_TEST_CASE_P(smoke_LSTMCellCommon, LSTMCellTest,
                             ::testing::Combine(
                                     ::testing::ValuesIn(should_decompose),
                                     ::testing::ValuesIn(batch),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/lstm_sequence.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/lstm_sequence.cpp
@@ -28,7 +28,7 @@ namespace {
     std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP32,
                                                              InferenceEngine::Precision::FP16};
 
-    INSTANTIATE_TEST_CASE_P(LSTMSequenceCommonZeroClip, LSTMSequenceTest,
+    INSTANTIATE_TEST_CASE_P(smoke_LSTMSequenceCommonZeroClip, LSTMSequenceTest,
                             ::testing::Combine(
                                     ::testing::ValuesIn(seq_lengths_zero_clip),
                                     ::testing::ValuesIn(batch),
@@ -41,7 +41,7 @@ namespace {
                                     ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                             LSTMSequenceTest::getTestCaseName);
 
-    INSTANTIATE_TEST_CASE_P(LSTMSequenceCommonClip, LSTMSequenceTest,
+    INSTANTIATE_TEST_CASE_P(smoke_LSTMSequenceCommonClip, LSTMSequenceTest,
                             ::testing::Combine(
                                     ::testing::ValuesIn(seq_lengths_clip_non_zero),
                                     ::testing::ValuesIn(batch),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/mat_mul.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/mat_mul.cpp
@@ -27,7 +27,7 @@ std::vector<ngraph::helpers::InputLayerType> secondaryInputTypes = {
         ngraph::helpers::InputLayerType::PARAMETER,
 };
 
-INSTANTIATE_TEST_CASE_P(MatMul, MatMulTest,
+INSTANTIATE_TEST_CASE_P(smoke_MatMul, MatMulTest,
         ::testing::Combine(
                 ::testing::ValuesIn(inputPrecisions),
                 ::testing::ValuesIn(shapesA),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/minimum_maximum.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/minimum_maximum.cpp
@@ -35,7 +35,7 @@ const std::vector<ngraph::helpers::InputLayerType> inputType = {
         ngraph::helpers::InputLayerType::PARAMETER,
 };
 
-INSTANTIATE_TEST_CASE_P(maximum, MaxMinLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_maximum, MaxMinLayerTest,
                         ::testing::Combine(
                                 ::testing::ValuesIn(inShapes),
                                 ::testing::ValuesIn(opType),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/pad.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/pad.cpp
@@ -34,7 +34,7 @@ const auto pad2DConstparams = testing::Combine(
 );
 
 INSTANTIATE_TEST_CASE_P(
-        Pad2DConst,
+        smoke_Pad2DConst,
         PadLayerTest,
         pad2DConstparams,
         PadLayerTest::getTestCaseName
@@ -51,7 +51,7 @@ const auto pad2Dparams = testing::Combine(
 );
 
 INSTANTIATE_TEST_CASE_P(
-        Pad2D,
+        smoke_Pad2D,
         PadLayerTest,
         pad2Dparams,
         PadLayerTest::getTestCaseName
@@ -71,7 +71,7 @@ const auto pad4DConstparams = testing::Combine(
 );
 
 INSTANTIATE_TEST_CASE_P(
-        Pad4DConst,
+        smoke_Pad4DConst,
         PadLayerTest,
         pad4DConstparams,
         PadLayerTest::getTestCaseName
@@ -88,7 +88,7 @@ const auto pad4Dparams = testing::Combine(
 );
 
 INSTANTIATE_TEST_CASE_P(
-        Pad4D,
+        smoke_Pad4D,
         PadLayerTest,
         pad4Dparams,
         PadLayerTest::getTestCaseName

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/pooling.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/pooling.cpp
@@ -46,7 +46,7 @@ const auto maxPool_ExplicitPad_FloorRounding_Params = ::testing::Combine(
         ::testing::Values(false)  // placeholder value - exclude pad not applicable for max pooling
 );
 
-INSTANTIATE_TEST_CASE_P(MaxPool_ExplicitPad_FloorRpunding, PoolingLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_MaxPool_ExplicitPad_FloorRpunding, PoolingLayerTest,
                         ::testing::Combine(
                                 maxPool_ExplicitPad_FloorRounding_Params,
                                 ::testing::ValuesIn(netPrecisions),
@@ -66,7 +66,7 @@ const auto maxPool_ExplicitPad_CeilRounding_Params = ::testing::Combine(
         ::testing::Values(false)  // placeholder value - exclude pad not applicable for max pooling
 );
 
-INSTANTIATE_TEST_CASE_P(MaxPool_ExplicitPad_CeilRpunding, PoolingLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_MaxPool_ExplicitPad_CeilRpunding, PoolingLayerTest,
                         ::testing::Combine(
                                 maxPool_ExplicitPad_CeilRounding_Params,
                                 ::testing::ValuesIn(netPrecisions),
@@ -89,7 +89,7 @@ const auto avgPoolExplicitPadCeilRoundingParams = ::testing::Combine(
         ::testing::Values(true, false)
 );
 
-INSTANTIATE_TEST_CASE_P(AvgPool_ExplicitPad_CeilRounding, PoolingLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_AvgPool_ExplicitPad_CeilRounding, PoolingLayerTest,
                         ::testing::Combine(
                                 avgPoolExplicitPadCeilRoundingParams,
                                 ::testing::ValuesIn(netPrecisions),
@@ -102,7 +102,7 @@ std::vector<poolSpecificParams> psParams({poolSpecificParams(ngraph::helpers::Po
     poolSpecificParams(ngraph::helpers::PoolingTypes::AVG, {7, 7}, {1, 1}, {0, 0}, {1, 1},
                         ngraph::op::RoundingType::CEIL, ngraph::op::PadType::EXPLICIT, false)});
 
-INSTANTIATE_TEST_CASE_P(AvgPool_ExplicitPad_CeilRounding_corner, PoolingLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_AvgPool_ExplicitPad_CeilRounding_corner, PoolingLayerTest,
                         ::testing::Combine(
                                 ::testing::ValuesIn(psParams),
                                 ::testing::ValuesIn(netPrecisions),
@@ -123,7 +123,7 @@ const auto avgPoolExplicitPadFloorRoundingParams = ::testing::Combine(
 );
 
 
-INSTANTIATE_TEST_CASE_P(AvgPool_ExplicitPad_FloorRounding, PoolingLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_AvgPool_ExplicitPad_FloorRounding, PoolingLayerTest,
                         ::testing::Combine(
                                 avgPoolExplicitPadFloorRoundingParams,
                                 ::testing::ValuesIn(netPrecisions),
@@ -145,7 +145,7 @@ const auto allPools_ValidPad_Params = ::testing::Combine(
         ::testing::Values(false)  // placeholder value - exclude pad not applicable for max pooling
 );
 
-INSTANTIATE_TEST_CASE_P(MAX_and_AVGPool_ValidPad, PoolingLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_MAX_and_AVGPool_ValidPad, PoolingLayerTest,
                         ::testing::Combine(
                                 allPools_ValidPad_Params,
                                 ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/range.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/range.cpp
@@ -20,7 +20,7 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
         InferenceEngine::Precision::FP16
 };
 
-INSTANTIATE_TEST_CASE_P(Basic, RangeLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_Basic, RangeLayerTest,
                         ::testing::Combine(
                                 ::testing::ValuesIn(start),
                                 ::testing::ValuesIn(stop),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/reduce_ops.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/reduce_ops.cpp
@@ -119,42 +119,42 @@ const auto params_ReductionTypes = testing::Combine(
 );
 
 INSTANTIATE_TEST_CASE_P(
-        ReduceOneAxis,
+        smoke_ReduceOneAxis,
         ReduceOpsLayerTest,
         paramsOneAxis,
         ReduceOpsLayerTest::getTestCaseName
 );
 
 INSTANTIATE_TEST_CASE_P(
-        Reduce_Precisions,
+        smoke_Reduce_Precisions,
         ReduceOpsLayerTest,
         params_Precisions,
         ReduceOpsLayerTest::getTestCaseName
 );
 
 INSTANTIATE_TEST_CASE_P(
-        Reduce_InputShapes,
+        smoke_Reduce_InputShapes,
         ReduceOpsLayerTest,
         params_InputShapes,
         ReduceOpsLayerTest::getTestCaseName
 );
 
 INSTANTIATE_TEST_CASE_P(
-        Reduce_Axes,
+        smoke_Reduce_Axes,
         ReduceOpsLayerTest,
         params_Axes,
         ReduceOpsLayerTest::getTestCaseName
 );
 
 INSTANTIATE_TEST_CASE_P(
-        Reduce_ReductionTypes,
+        smoke_Reduce_ReductionTypes,
         ReduceOpsLayerTest,
         params_ReductionTypes,
         ReduceOpsLayerTest::getTestCaseName
 );
 
 INSTANTIATE_TEST_CASE_P(
-        Reduce,
+        smoke_Reduce,
         ReduceOpsLayerWithSpecificInputTest,
         testing::Combine(
                 testing::ValuesIn(decltype(axes) {{0}, {1}}),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/reshape.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/reshape.cpp
@@ -15,7 +15,7 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
         InferenceEngine::Precision::FP16
 };
 
-INSTANTIATE_TEST_CASE_P(ReshapeCheckDynBatch, ReshapeLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_ReshapeCheckDynBatch, ReshapeLayerTest,
         ::testing::Combine(
                 ::testing::Values(true),
                 ::testing::ValuesIn(netPrecisions),
@@ -25,7 +25,7 @@ INSTANTIATE_TEST_CASE_P(ReshapeCheckDynBatch, ReshapeLayerTest,
                 ::testing::Values(std::map<std::string, std::string>({{CONFIG_KEY(DYN_BATCH_ENABLED), CONFIG_VALUE(YES)}}))),
                 ReshapeLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(ReshapeCheck, ReshapeLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_ReshapeCheck, ReshapeLayerTest,
         ::testing::Combine(
                 ::testing::Values(true),
                 ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/rnn_cell.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/rnn_cell.cpp
@@ -19,7 +19,7 @@ namespace {
     std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP32,
                                                              InferenceEngine::Precision::FP16};
 
-    INSTANTIATE_TEST_CASE_P(RNNCellCommon, RNNCellTest,
+    INSTANTIATE_TEST_CASE_P(smoke_RNNCellCommon, RNNCellTest,
             ::testing::Combine(
             ::testing::ValuesIn(should_decompose),
             ::testing::ValuesIn(batch),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/rnn_sequence.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/rnn_sequence.cpp
@@ -26,7 +26,7 @@ namespace {
     std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP32,
                                                              InferenceEngine::Precision::FP16};
 
-    INSTANTIATE_TEST_CASE_P(RNNSequenceCommonZeroClip, RNNSequenceTest,
+    INSTANTIATE_TEST_CASE_P(smoke_RNNSequenceCommonZeroClip, RNNSequenceTest,
                             ::testing::Combine(
                                     ::testing::ValuesIn(seq_lengths_zero_clip),
                                     ::testing::ValuesIn(batch),
@@ -39,7 +39,7 @@ namespace {
                                     ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                             RNNSequenceTest::getTestCaseName);
 
-    INSTANTIATE_TEST_CASE_P(RNNSequenceCommonClip, RNNSequenceTest,
+    INSTANTIATE_TEST_CASE_P(smoke_RNNSequenceCommonClip, RNNSequenceTest,
                             ::testing::Combine(
                                     ::testing::ValuesIn(seq_lengths_clip_non_zero),
                                     ::testing::ValuesIn(batch),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/scatter_ND_update.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/scatter_ND_update.cpp
@@ -36,6 +36,6 @@ const auto ScatterNDUpdateCases = ::testing::Combine(
         ::testing::Values(CommonTestUtils::DEVICE_CPU)
 );
 
-INSTANTIATE_TEST_CASE_P(ScatterNDUpdate, ScatterNDUpdateLayerTest, ScatterNDUpdateCases, ScatterNDUpdateLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_ScatterNDUpdate, ScatterNDUpdateLayerTest, ScatterNDUpdateCases, ScatterNDUpdateLayerTest::getTestCaseName);
 
 }  // namespace

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/scatter_elements_update.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/scatter_elements_update.cpp
@@ -42,7 +42,7 @@ const auto ScatterEltUpdateCases = ::testing::Combine(
         ::testing::Values(CommonTestUtils::DEVICE_CPU)
 );
 
-INSTANTIATE_TEST_CASE_P(ScatterEltsUpdate, ScatterElementsUpdateLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_ScatterEltsUpdate, ScatterElementsUpdateLayerTest,
     ScatterEltUpdateCases, ScatterElementsUpdateLayerTest::getTestCaseName);
 
 }  // namespace

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/scatter_update.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/scatter_update.cpp
@@ -41,6 +41,6 @@ const auto ScatterUpdateCase = ::testing::Combine(
         ::testing::Values(CommonTestUtils::DEVICE_CPU)
 );
 
-INSTANTIATE_TEST_CASE_P(ScatterUpdate, ScatterUpdateLayerTest, ScatterUpdateCase, ScatterUpdateLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_ScatterUpdate, ScatterUpdateLayerTest, ScatterUpdateCase, ScatterUpdateLayerTest::getTestCaseName);
 
 }  // namespace

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/shape_of.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/shape_of.cpp
@@ -14,7 +14,7 @@ namespace {
             InferenceEngine::Precision::I32
     };
 
-    INSTANTIATE_TEST_CASE_P(Check, ShapeOfLayerTest,
+    INSTANTIATE_TEST_CASE_P(smoke_Check, ShapeOfLayerTest,
                             ::testing::Combine(
                                     ::testing::ValuesIn(netPrecisions),
                                     ::testing::Values(std::vector<size_t>({10, 10, 10})),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/shuffle_channels.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/shuffle_channels.cpp
@@ -32,7 +32,7 @@ const auto shuffleChannelsParamsNegativeAxis4D = ::testing::Combine(
         ::testing::ValuesIn(groups)
 );
 
-INSTANTIATE_TEST_CASE_P(ShuffleChannels4D, ShuffleChannelsLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_ShuffleChannels4D, ShuffleChannelsLayerTest,
         ::testing::Combine(
                 shuffleChannelsParams4D,
                 ::testing::ValuesIn(netPrecisions),
@@ -40,7 +40,7 @@ INSTANTIATE_TEST_CASE_P(ShuffleChannels4D, ShuffleChannelsLayerTest,
                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
         ShuffleChannelsLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(ShuffleChannelsNegativeAxis4D, ShuffleChannelsLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_ShuffleChannelsNegativeAxis4D, ShuffleChannelsLayerTest,
         ::testing::Combine(
                 shuffleChannelsParamsNegativeAxis4D,
                 ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/softmax.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/softmax.cpp
@@ -39,7 +39,7 @@ const auto params2D = testing::Combine(
 );
 
 INSTANTIATE_TEST_CASE_P(
-        SoftMax2D,
+        smoke_SoftMax2D,
         SoftMaxLayerTest,
         params2D,
         SoftMaxLayerTest::getTestCaseName
@@ -63,7 +63,7 @@ const auto params4D = testing::Combine(
 );
 
 INSTANTIATE_TEST_CASE_P(
-        SoftMax4D,
+        smoke_SoftMax4D,
         SoftMaxLayerTest,
         params4D,
         SoftMaxLayerTest::getTestCaseName

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/space_to_depth.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/space_to_depth.cpp
@@ -34,7 +34,7 @@ const auto SpaceToDepthBS2 = ::testing::Combine(
         ::testing::Values(CommonTestUtils::DEVICE_CPU)
 );
 
-INSTANTIATE_TEST_CASE_P(SpaceToDepthBS2, SpaceToDepthLayerTest, SpaceToDepthBS2, SpaceToDepthLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_SpaceToDepthBS2, SpaceToDepthLayerTest, SpaceToDepthBS2, SpaceToDepthLayerTest::getTestCaseName);
 
 const std::vector<std::vector<size_t >> inputShapesBS3 = {
         {1, 1, 3, 3}, {1, 1, 6, 6}, {1, 1, 9, 9}, {2, 4, 9, 9}, {2, 3, 15, 12},
@@ -48,6 +48,6 @@ const auto SpaceToDepthBS3 = ::testing::Combine(
         ::testing::Values(CommonTestUtils::DEVICE_CPU)
 );
 
-INSTANTIATE_TEST_CASE_P(SpaceToDepthBS3, SpaceToDepthLayerTest, SpaceToDepthBS3, SpaceToDepthLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_SpaceToDepthBS3, SpaceToDepthLayerTest, SpaceToDepthBS3, SpaceToDepthLayerTest::getTestCaseName);
 
 }  // namespace

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/split.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/split.cpp
@@ -16,7 +16,7 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
         InferenceEngine::Precision::FP16
 };
 
-INSTANTIATE_TEST_CASE_P(NumSplitsCheck, SplitLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_NumSplitsCheck, SplitLayerTest,
                         ::testing::Combine(
                                 ::testing::Values(1),
                                 ::testing::Values(0, 1, 2, 3),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/squeeze_unsqueeze.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/squeeze_unsqueeze.cpp
@@ -29,7 +29,7 @@ const std::vector<ngraph::helpers::SqueezeOpType> opTypes = {
         ngraph::helpers::SqueezeOpType::UNSQUEEZE
 };
 
-INSTANTIATE_TEST_CASE_P(Basic, SqueezeUnsqueezeLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_Basic, SqueezeUnsqueezeLayerTest,
                         ::testing::Combine(
                                 ::testing::ValuesIn(CommonTestUtils::combineParams(axesVectors)),
                                 ::testing::ValuesIn(opTypes),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/tile.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/tile.cpp
@@ -21,7 +21,7 @@ const std::vector<std::vector<size_t>> repeats = {
         {2, 2, 2},
 };
 
-INSTANTIATE_TEST_CASE_P(Tile, TileLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_Tile, TileLayerTest,
         ::testing::Combine(
                 ::testing::ValuesIn(repeats),
                 ::testing::ValuesIn(netPrecisions),
@@ -29,7 +29,7 @@ INSTANTIATE_TEST_CASE_P(Tile, TileLayerTest,
                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
         TileLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(Tile6d, TileLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_Tile6d, TileLayerTest,
         ::testing::Combine(
                 ::testing::Values(std::vector<size_t>({1, 1, 1, 2, 1, 2})),
                 ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/topk.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/topk.cpp
@@ -39,7 +39,7 @@ const std::vector<ngraph::opset4::TopK::SortType> sortTypes = {
 };
 
 
-INSTANTIATE_TEST_CASE_P(TopK, TopKLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_TopK, TopKLayerTest,
         ::testing::Combine(
                 ::testing::ValuesIn(k),
                 ::testing::ValuesIn(axes),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/transpose.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/transpose.cpp
@@ -32,7 +32,7 @@ const auto params = testing::Combine(
 );
 
 INSTANTIATE_TEST_CASE_P(
-        Transpose,
+        smoke_Transpose,
         TransposeLayerTest,
         params,
         TransposeLayerTest::getTestCaseName

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/variadic_split.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/variadic_split.cpp
@@ -25,7 +25,7 @@ namespace {
             {4, 11, 6, 9}
     };
 
-    INSTANTIATE_TEST_CASE_P(NumSplitsCheck, VariadicSplitLayerTest,
+    INSTANTIATE_TEST_CASE_P(smoke_NumSplitsCheck, VariadicSplitLayerTest,
             ::testing::Combine(
             ::testing::ValuesIn(numSplits),
             ::testing::Values(0, 1, 2, 3),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/conv_eltwise_fusion.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/conv_eltwise_fusion.cpp
@@ -16,7 +16,7 @@ namespace {
 #define ADD(X) std::tuple<ngraph::NodeTypeInfo, int64_t>(ngraph::opset4::Add::type_info, X)
 #define IN std::vector<std::tuple<ngraph::NodeTypeInfo, int64_t>>
 
-    INSTANTIATE_TEST_CASE_P(Convolution_1D, ConvEltwiseFusion,
+    INSTANTIATE_TEST_CASE_P(smoke_Convolution_1D, ConvEltwiseFusion,
                             ::testing::Combine(
                                     ::testing::Values(ngraph::opset4::Convolution::type_info),
                                     ::testing::ValuesIn(IN({MUL(4), ADD(5)})),
@@ -27,7 +27,7 @@ namespace {
                                     ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                             ConvEltwiseFusion::getTestCaseName);
 
-    INSTANTIATE_TEST_CASE_P(GroupConvolution_1D, ConvEltwiseFusion,
+    INSTANTIATE_TEST_CASE_P(smoke_GroupConvolution_1D, ConvEltwiseFusion,
                             ::testing::Combine(
                                     ::testing::Values(ngraph::opset4::GroupConvolution::type_info),
                                     ::testing::ValuesIn(IN({MUL(4), ADD(5)})),
@@ -38,7 +38,7 @@ namespace {
                                     ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                             ConvEltwiseFusion::getTestCaseName);
 
-    INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData_1D, ConvEltwiseFusion,
+    INSTANTIATE_TEST_CASE_P(smoke_ConvolutionBackpropData_1D, ConvEltwiseFusion,
                             ::testing::Combine(
                                     ::testing::Values(ngraph::opset4::ConvolutionBackpropData::type_info),
                                     ::testing::ValuesIn(IN({MUL(4), ADD(5)})),
@@ -49,7 +49,7 @@ namespace {
                                     ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                             ConvEltwiseFusion::getTestCaseName);
 
-    INSTANTIATE_TEST_CASE_P(GroupConvolutionBackpropData_1D, ConvEltwiseFusion,
+    INSTANTIATE_TEST_CASE_P(smoke_GroupConvolutionBackpropData_1D, ConvEltwiseFusion,
                             ::testing::Combine(
                                     ::testing::Values(ngraph::opset4::GroupConvolutionBackpropData::type_info),
                                     ::testing::ValuesIn(IN({MUL(4), ADD(5)})),
@@ -68,7 +68,7 @@ namespace {
         {1, 1, 1, 1}
     };
 
-    INSTANTIATE_TEST_CASE_P(Convolution_2D, ConvEltwiseFusion,
+    INSTANTIATE_TEST_CASE_P(smoke_Convolution_2D, ConvEltwiseFusion,
                             ::testing::Combine(
                                     ::testing::Values(ngraph::opset4::Convolution::type_info),
                                     ::testing::ValuesIn(IN({MUL(4), ADD(5)})),
@@ -79,7 +79,7 @@ namespace {
                                     ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                             ConvEltwiseFusion::getTestCaseName);
 
-    INSTANTIATE_TEST_CASE_P(GroupConvolution_2D, ConvEltwiseFusion,
+    INSTANTIATE_TEST_CASE_P(smoke_GroupConvolution_2D, ConvEltwiseFusion,
                             ::testing::Combine(
                                     ::testing::Values(ngraph::opset4::GroupConvolution::type_info),
                                     ::testing::ValuesIn(IN({MUL(4), ADD(5)})),
@@ -90,7 +90,7 @@ namespace {
                                     ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                             ConvEltwiseFusion::getTestCaseName);
 
-    INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData_2D, ConvEltwiseFusion,
+    INSTANTIATE_TEST_CASE_P(smoke_ConvolutionBackpropData_2D, ConvEltwiseFusion,
                             ::testing::Combine(
                                     ::testing::Values(ngraph::opset4::ConvolutionBackpropData::type_info),
                                     ::testing::ValuesIn(IN({MUL(4), ADD(5)})),
@@ -101,7 +101,7 @@ namespace {
                                     ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                             ConvEltwiseFusion::getTestCaseName);
 
-    INSTANTIATE_TEST_CASE_P(GroupConvolutionBackpropData_2D, ConvEltwiseFusion,
+    INSTANTIATE_TEST_CASE_P(smoke_GroupConvolutionBackpropData_2D, ConvEltwiseFusion,
                             ::testing::Combine(
                                     ::testing::Values(ngraph::opset4::GroupConvolutionBackpropData::type_info),
                                     ::testing::ValuesIn(IN({MUL(4), ADD(5)})),
@@ -117,7 +117,7 @@ namespace {
         {3}, {3, 1}, {3, 1, 1, 1}
     };
 
-    INSTANTIATE_TEST_CASE_P(Convolution_2D_Negative, ConvEltwiseFusion,
+    INSTANTIATE_TEST_CASE_P(smoke_Convolution_2D_Negative, ConvEltwiseFusion,
                             ::testing::Combine(
                                     ::testing::Values(ngraph::opset4::Convolution::type_info),
                                     ::testing::ValuesIn(IN({MUL(6), ADD(6)})),
@@ -128,7 +128,7 @@ namespace {
                                     ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                             ConvEltwiseFusion::getTestCaseName);
 
-    INSTANTIATE_TEST_CASE_P(GroupConvolution_2D_Negative, ConvEltwiseFusion,
+    INSTANTIATE_TEST_CASE_P(smoke_GroupConvolution_2D_Negative, ConvEltwiseFusion,
                             ::testing::Combine(
                                     ::testing::Values(ngraph::opset4::GroupConvolution::type_info),
                                     ::testing::ValuesIn(IN({MUL(6), ADD(6)})),
@@ -139,7 +139,7 @@ namespace {
                                     ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                             ConvEltwiseFusion::getTestCaseName);
 
-    INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData_2D_Negative, ConvEltwiseFusion,
+    INSTANTIATE_TEST_CASE_P(smoke_ConvolutionBackpropData_2D_Negative, ConvEltwiseFusion,
                             ::testing::Combine(
                                     ::testing::Values(ngraph::opset4::ConvolutionBackpropData::type_info),
                                     ::testing::ValuesIn(IN({MUL(6), ADD(6)})),
@@ -150,7 +150,7 @@ namespace {
                                     ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                             ConvEltwiseFusion::getTestCaseName);
 
-    INSTANTIATE_TEST_CASE_P(GroupConvolutionBackpropData_2D_Negative, ConvEltwiseFusion,
+    INSTANTIATE_TEST_CASE_P(smoke_GroupConvolutionBackpropData_2D_Negative, ConvEltwiseFusion,
                             ::testing::Combine(
                                     ::testing::Values(ngraph::opset4::GroupConvolutionBackpropData::type_info),
                                     ::testing::ValuesIn(IN({MUL(6), ADD(6)})),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/convert_pad_to_group_conv.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/convert_pad_to_group_conv.cpp
@@ -16,7 +16,7 @@ namespace {
 
     const std::vector<float> values{0., 1.};
 
-    INSTANTIATE_TEST_CASE_P(Pad_1D, ConvertPadToConvTests,
+    INSTANTIATE_TEST_CASE_P(smoke_Pad_1D, ConvertPadToConvTests,
                             ::testing::Combine(
                                     ::testing::Values(ngraph::Shape{1, 8, 64}),
                                     ::testing::ValuesIn(pads_1d),
@@ -31,7 +31,7 @@ namespace {
             {0, 0, 10, 10}, {0, 0, 0, 4}, {0, 0, 4, 0}
     };
 
-    INSTANTIATE_TEST_CASE_P(Pad_2D, ConvertPadToConvTests,
+    INSTANTIATE_TEST_CASE_P(smoke_Pad_2D, ConvertPadToConvTests,
                             ::testing::Combine(
                                     ::testing::Values(ngraph::Shape{1, 8, 64, 16}),
                                     ::testing::ValuesIn(pads_2d),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/matmul_squeeze_add.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/matmul_squeeze_add.cpp
@@ -36,7 +36,7 @@ std::vector<size_t> output_sizes = {
     8
 };
 
-INSTANTIATE_TEST_CASE_P(MatmulSqueezeAdd, MatmulSqueezeAddTest,
+INSTANTIATE_TEST_CASE_P(smoke_MatmulSqueezeAdd, MatmulSqueezeAddTest,
                         ::testing::Combine(
                             ::testing::ValuesIn(netPrecisions),
                             ::testing::Values(CommonTestUtils::DEVICE_CPU),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/multiply_add.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/multiply_add.cpp
@@ -22,7 +22,7 @@ const std::vector<std::vector<size_t>> inputShapes = {
         {1, 3, 2, 2, 2, 2, 2, 2, 4, 5},
 };
 
-INSTANTIATE_TEST_CASE_P(MultipleAdd_Nd, MultiplyAddLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_MultipleAdd_Nd, MultiplyAddLayerTest,
                         ::testing::Combine(
                                 ::testing::ValuesIn(inputShapes),
                                 ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/quantized_convolution_backprop_data.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/quantized_convolution_backprop_data.cpp
@@ -42,7 +42,7 @@ const auto quantConvBackpropData2DParams = ::testing::Combine(
         ::testing::ValuesIn(granularity)
 );
 
-INSTANTIATE_TEST_CASE_P(QuantConvBackpropData2D, QuantConvBackpropDataLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_QuantConvBackpropData2D, QuantConvBackpropDataLayerTest,
                         ::testing::Combine(
                                 quantConvBackpropData2DParams,
                                 ::testing::ValuesIn(netPrecisions),
@@ -70,7 +70,7 @@ const auto quantConvBackpropData3DParams = ::testing::Combine(
         ::testing::ValuesIn(granularity)
 );
 
-INSTANTIATE_TEST_CASE_P(QuantConvBackpropData3D, QuantConvBackpropDataLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_QuantConvBackpropData3D, QuantConvBackpropDataLayerTest,
                         ::testing::Combine(
                                 quantConvBackpropData3DParams,
                                 ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/quantized_group_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/quantized_group_convolution.cpp
@@ -46,7 +46,7 @@ const auto quantGroupConv2DParams = ::testing::Combine(
         ::testing::ValuesIn(quantizeWeights)
 );
 
-INSTANTIATE_TEST_CASE_P(QuantGroupConv2D, QuantGroupConvLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_QuantGroupConv2D, QuantGroupConvLayerTest,
                         ::testing::Combine(
                                 quantGroupConv2DParams,
                                 ::testing::ValuesIn(netPrecisions),
@@ -75,7 +75,7 @@ const auto quantGroupConv3DParams = ::testing::Combine(
         ::testing::ValuesIn(quantizeWeights)
 );
 
-INSTANTIATE_TEST_CASE_P(QuantGroupConv3D, QuantGroupConvLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_QuantGroupConv3D, QuantGroupConvLayerTest,
                         ::testing::Combine(
                                 quantGroupConv3DParams,
                                 ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/quantized_group_convolution_backprop_data.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/quantized_group_convolution_backprop_data.cpp
@@ -44,7 +44,7 @@ const auto quantGroupConvBackpropData2DParams = ::testing::Combine(
         ::testing::ValuesIn(granularity)
 );
 
-INSTANTIATE_TEST_CASE_P(QuantGroupConvBackpropData2D, QuantGroupConvBackpropDataLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_QuantGroupConvBackpropData2D, QuantGroupConvBackpropDataLayerTest,
                         ::testing::Combine(
                                 quantGroupConvBackpropData2DParams,
                                 ::testing::ValuesIn(netPrecisions),
@@ -73,7 +73,7 @@ const auto quantGroupConvBackpropData3DParams = ::testing::Combine(
         ::testing::ValuesIn(granularity)
 );
 
-INSTANTIATE_TEST_CASE_P(QuantGroupConvBackpropData3D, QuantGroupConvBackpropDataLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_QuantGroupConvBackpropData3D, QuantGroupConvBackpropDataLayerTest,
                         ::testing::Combine(
                                 quantGroupConvBackpropData3DParams,
                                 ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/quantized_mat_mul.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/quantized_mat_mul.cpp
@@ -38,7 +38,7 @@ const auto quantParams_u8i8 = ::testing::Combine(
         ::testing::Values(InferenceEngine::Precision::U8)
 );
 
-INSTANTIATE_TEST_CASE_P(QuantMatMul_i8i8, QuantMatMulTest,
+INSTANTIATE_TEST_CASE_P(smoke_QuantMatMul_i8i8, QuantMatMulTest,
                         ::testing::Combine(
                                 quantParams_i8i8,
                                 ::testing::ValuesIn(netPrecisions),
@@ -47,7 +47,7 @@ INSTANTIATE_TEST_CASE_P(QuantMatMul_i8i8, QuantMatMulTest,
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         QuantMatMulTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(QuantMatMul_u8i8, QuantMatMulTest,
+INSTANTIATE_TEST_CASE_P(smoke_QuantMatMul_u8i8, QuantMatMulTest,
                         ::testing::Combine(
                                 quantParams_u8i8,
                                 ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/range_add.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/range_add.cpp
@@ -24,7 +24,7 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
         InferenceEngine::Precision::FP16
 };
 
-INSTANTIATE_TEST_CASE_P(BasicPositive, RangeAddSubgraphTest,
+INSTANTIATE_TEST_CASE_P(smoke_BasicPositive, RangeAddSubgraphTest,
                         ::testing::Combine(
                                 ::testing::ValuesIn(positiveStart),
                                 ::testing::ValuesIn(positiveStop),
@@ -33,7 +33,7 @@ INSTANTIATE_TEST_CASE_P(BasicPositive, RangeAddSubgraphTest,
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         RangeAddSubgraphTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(BasicNegative, RangeAddSubgraphTest,
+INSTANTIATE_TEST_CASE_P(smoke_BasicNegative, RangeAddSubgraphTest,
                         ::testing::Combine(
                                 ::testing::ValuesIn(negativeStart),
                                 ::testing::ValuesIn(negativeStop),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/relu_shape_of.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/relu_shape_of.cpp
@@ -14,7 +14,7 @@ namespace {
             InferenceEngine::Precision::I32
     };
 
-    INSTANTIATE_TEST_CASE_P(Check, ReluShapeOfSubgraphTest,
+    INSTANTIATE_TEST_CASE_P(smoke_Check, ReluShapeOfSubgraphTest,
                             ::testing::Combine(
                                     ::testing::ValuesIn(netPrecisions),
                                     ::testing::Values(std::vector<size_t>({20, 10, 10, 10})),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/reshape_squeeze_reshape_relu.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/reshape_squeeze_reshape_relu.cpp
@@ -36,7 +36,7 @@ namespace {
             ngraph::helpers::SqueezeOpType::UNSQUEEZE
     };
 
-    INSTANTIATE_TEST_CASE_P(reshape_squeeze_reshape_relu, ReshapeSqueezeReshapeRelu,
+    INSTANTIATE_TEST_CASE_P(smoke_reshape_squeeze_reshape_relu, ReshapeSqueezeReshapeRelu,
                             ::testing::Combine(
                                     ::testing::ValuesIn(inputs),
                                     ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/split_concat_memory.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/split_concat_memory.cpp
@@ -26,7 +26,7 @@ const std::vector<InferenceEngine::SizeVector> shapes = {
     {3, 8},
 };
 
-INSTANTIATE_TEST_CASE_P(CPU, SplitConcatMemory,
+INSTANTIATE_TEST_CASE_P(smoke_CPU, SplitConcatMemory,
                         ::testing::Combine(
                                 ::testing::ValuesIn(shapes),
                                 ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/split_conv_concat.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/split_conv_concat.cpp
@@ -16,7 +16,7 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
         InferenceEngine::Precision::FP16
 };
 
-INSTANTIATE_TEST_CASE_P(NoReshape, SplitConvConcat,
+INSTANTIATE_TEST_CASE_P(smoke_NoReshape, SplitConvConcat,
                         ::testing::Combine(
                                 ::testing::ValuesIn(netPrecisions),
                                 ::testing::Values(InferenceEngine::SizeVector({1, 6, 40, 40})),

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
@@ -166,7 +166,7 @@ const std::vector<CPUSpecificParams> CPUParams_Planar_2D = {
         conv_gemm_2D
 };
 
-INSTANTIATE_TEST_CASE_P(GroupConv_2D_Planar_FP32, GroupConvolutionLayerCPUTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConv_2D_Planar_FP32, GroupConvolutionLayerCPUTest,
                         ::testing::Combine(
                                 ::testing::Combine(
                                         groupConvParams_ExplicitPadding_Planar_2D,
@@ -192,7 +192,7 @@ const std::vector<CPUSpecificParams> CPUParams_Planar_3D = {
         conv_gemm_3D
 };
 
-INSTANTIATE_TEST_CASE_P(GroupConv_3D_Planar_FP32, GroupConvolutionLayerCPUTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConv_3D_Planar_FP32, GroupConvolutionLayerCPUTest,
                         ::testing::Combine(
                                 ::testing::Combine(
                                         groupConvParams_ExplicitPadding_Planar_3D,
@@ -220,7 +220,7 @@ const std::vector<CPUSpecificParams> CPUParams_Blocked_2D = {
         conv_avx512_2D
 };
 
-INSTANTIATE_TEST_CASE_P(GroupConv_2D_Blocked_FP32, GroupConvolutionLayerCPUTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConv_2D_Blocked_FP32, GroupConvolutionLayerCPUTest,
                         ::testing::Combine(
                                 ::testing::Combine(
                                         groupConvParams_ExplicitPadding_Blocked_2D,
@@ -248,7 +248,7 @@ const std::vector<CPUSpecificParams> CPUParams_Blocked_3D = {
         conv_avx512_3D
 };
 
-INSTANTIATE_TEST_CASE_P(GroupConv_3D_Blocked_FP32, GroupConvolutionLayerCPUTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConv_3D_Blocked_FP32, GroupConvolutionLayerCPUTest,
                         ::testing::Combine(
                                 ::testing::Combine(
                                         groupConvParams_ExplicitPadding_Blocked_3D,
@@ -276,7 +276,7 @@ const std::vector<CPUSpecificParams> CPUParams_DW_2D = {
         conv_avx512_dw_2D
 };
 
-INSTANTIATE_TEST_CASE_P(GroupConv_2D_DW_FP32, GroupConvolutionLayerCPUTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConv_2D_DW_FP32, GroupConvolutionLayerCPUTest,
                         ::testing::Combine(
                                 ::testing::Combine(
                                         groupConvParams_ExplicitPadding_DW_2D,
@@ -304,7 +304,7 @@ const std::vector<CPUSpecificParams> CPUParams_DW_3D = {
         conv_avx512_dw_3D
 };
 
-INSTANTIATE_TEST_CASE_P(GroupConv_3D_DW_FP32, GroupConvolutionLayerCPUTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConv_3D_DW_FP32, GroupConvolutionLayerCPUTest,
                         ::testing::Combine(
                                 ::testing::Combine(
                                         groupConvParams_ExplicitPadding_DW_3D,
@@ -358,7 +358,7 @@ const std::vector<groupConvLayerCPUTestParamsSet> gemmGroupConvTestCases = {
                 2, 1, {10, 10, 10}, 3, 3, conv_gemm_3D),
 };
 
-INSTANTIATE_TEST_CASE_P(GEMM_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(gemmGroupConvTestCases)));
+INSTANTIATE_TEST_CASE_P(smoke_GEMM_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(gemmGroupConvTestCases)));
 
 /* ============= JIT SSE42 GroupConvolution ============= */
 const std::vector<groupConvLayerCPUTestParamsSet> JIT_SSE42_GroupConvTestCases = {
@@ -397,7 +397,7 @@ const std::vector<groupConvLayerCPUTestParamsSet> JIT_SSE42_GroupConvTestCases =
         //                              2, 1, {10, 10, 10}, 8, 8, cpuParams_sse42_3D),
 };
 
-INSTANTIATE_TEST_CASE_P(JIT_SSE42_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(JIT_SSE42_GroupConvTestCases)));
+INSTANTIATE_TEST_CASE_P(smoke_JIT_SSE42_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(JIT_SSE42_GroupConvTestCases)));
 
 /* ============= JIT AVX2 GroupConvolution ============= */
 const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX2_GroupConvTestCases = {
@@ -434,7 +434,7 @@ const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX2_GroupConvTestCases = 
                                     2, 1, {10, 10, 10}, 8, 8, conv_avx2_3D),
 };
 
-INSTANTIATE_TEST_CASE_P(JIT_AVX2_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(JIT_AVX2_GroupConvTestCases)));
+INSTANTIATE_TEST_CASE_P(smoke_JIT_AVX2_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(JIT_AVX2_GroupConvTestCases)));
 
 /* ============= JIT AVX512 GroupConvolution ============= */
 const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX512_GroupConvTestCases = {
@@ -458,7 +458,7 @@ const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX512_GroupConvTestCases 
                                     2, 1, {10, 10, 10}, 16, 16, conv_avx512_3D),
 };
 
-INSTANTIATE_TEST_CASE_P(JIT_AVX512_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(JIT_AVX512_GroupConvTestCases)));
+INSTANTIATE_TEST_CASE_P(smoke_JIT_AVX512_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(JIT_AVX512_GroupConvTestCases)));
 
 /* ============= JIT SSE42 DW GroupConvolution ============= */
 const std::vector<groupConvLayerCPUTestParamsSet> JIT_SSE42_DW_GroupConvTestCases = {
@@ -486,7 +486,8 @@ const std::vector<groupConvLayerCPUTestParamsSet> JIT_SSE42_DW_GroupConvTestCase
                                     8, 1, {10, 10, 10}, 1, 1, conv_sse42_dw_3D),
 };
 
-INSTANTIATE_TEST_CASE_P(JIT_SSE42_DW_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(JIT_SSE42_DW_GroupConvTestCases)));
+INSTANTIATE_TEST_CASE_P(smoke_JIT_SSE42_DW_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice
+(JIT_SSE42_DW_GroupConvTestCases)));
 
 /* ============= JIT AVX2 DW GroupConvolution ============= */
 const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX2_DW_GroupConvTestCases = {
@@ -514,7 +515,8 @@ const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX2_DW_GroupConvTestCases
                                     8, 1, {10, 10, 10}, 1, 1, conv_avx2_dw_3D),
 };
 
-INSTANTIATE_TEST_CASE_P(JIT_AVX2_DW_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(JIT_AVX2_DW_GroupConvTestCases)));
+INSTANTIATE_TEST_CASE_P(smoke_JIT_AVX2_DW_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice
+(JIT_AVX2_DW_GroupConvTestCases)));
 
 /* ============= JIT AVX512 DW GroupConvolution ============= */
 const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX512_DW_GroupConvTestCases = {
@@ -543,7 +545,8 @@ const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX512_DW_GroupConvTestCas
                                     16, 1, {10, 10, 10}, 1, 1, conv_avx512_dw_3D),
 };
 
-INSTANTIATE_TEST_CASE_P(JIT_AVX512_DW_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(JIT_AVX512_DW_GroupConvTestCases)));
+INSTANTIATE_TEST_CASE_P(smoke_JIT_AVX512_DW_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice
+(JIT_AVX512_DW_GroupConvTestCases)));
 
 /* ============= JIT SSE42 1x1 Convolution (not supported with groups) ============= */
 /* ============= JIT AVX2 1x1 Convolution (not supported with groups) ============= */

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/interpolate.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/interpolate.cpp
@@ -191,7 +191,7 @@ const auto interpolateCasesLinearOnnx = ::testing::Combine(
         ::testing::ValuesIn(defaultAxes),
         ::testing::ValuesIn(defaultScales));
 
-INSTANTIATE_TEST_CASE_P(InterpolateNN_Layout_Test, InterpolateLayerCPUTest,
+INSTANTIATE_TEST_CASE_P(smoke_InterpolateNN_Layout_Test, InterpolateLayerCPUTest,
         ::testing::Combine(
             ::testing::Combine(
                 interpolateCasesNN,
@@ -202,7 +202,7 @@ INSTANTIATE_TEST_CASE_P(InterpolateNN_Layout_Test, InterpolateLayerCPUTest,
             ::testing::ValuesIn(filterCPUInfoForDevice())),
     InterpolateLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(InterpolateLinearOnnx_Layout_Test, InterpolateLayerCPUTest,
+INSTANTIATE_TEST_CASE_P(smoke_InterpolateLinearOnnx_Layout_Test, InterpolateLayerCPUTest,
         ::testing::Combine(
             ::testing::Combine(
                 interpolateCasesLinearOnnx,

--- a/inference-engine/tests/functional/plugin/cpu/subgraph_tests/src/conv_concat.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/subgraph_tests/src/conv_concat.cpp
@@ -179,7 +179,7 @@ const auto params2DConv = ::testing::Combine(
     ::testing::Values(axis)
 );
 
-INSTANTIATE_TEST_CASE_P(Convolution2D1x1, ConvConcatSubgraphTest, params2DConv, ConvConcatSubgraphTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_Convolution2D1x1, ConvConcatSubgraphTest, params2DConv, ConvConcatSubgraphTest::getTestCaseName);
 
 const std::vector<CPUSpecificParams> CPUParams2DDeconv = {
     conv_avx2_2D_1x1,
@@ -194,7 +194,7 @@ const auto params2DDeconv = ::testing::Combine(
     ::testing::Values(axis)
 );
 
-INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData2D1x1, ConvConcatSubgraphTest, params2DDeconv, ConvConcatSubgraphTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_ConvolutionBackpropData2D1x1, ConvConcatSubgraphTest, params2DDeconv, ConvConcatSubgraphTest::getTestCaseName);
 
 }  // namespace Kernel_1x1
 
@@ -217,7 +217,7 @@ const auto params2D = ::testing::Combine(
     ::testing::Values(axis)
 );
 
-INSTANTIATE_TEST_CASE_P(DWGroupConvolutionBackpropData2D, ConvConcatSubgraphTest, params2D, ConvConcatSubgraphTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_DWGroupConvolutionBackpropData2D, ConvConcatSubgraphTest, params2D, ConvConcatSubgraphTest::getTestCaseName);
 
 }  // namespace GroupConvolutionBackpropDataDWConcat
 
@@ -240,7 +240,7 @@ const auto params2D = ::testing::Combine(
     ::testing::Values(axis)
 );
 
-INSTANTIATE_TEST_CASE_P(DWGroupConvolution2D, ConvConcatSubgraphTest, params2D, ConvConcatSubgraphTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_DWGroupConvolution2D, ConvConcatSubgraphTest, params2D, ConvConcatSubgraphTest::getTestCaseName);
 
 /* ============= GroupConvolution (DW 3D) ============= */
 commonConvParams dwConvParams3D = commonConvParams{kernelSize3D, strides3D, padBegin3D, padEnd3D, dilation3D, numOutChannels, paddingType, numOutChannels};
@@ -259,7 +259,7 @@ const auto params3D = ::testing::Combine(
     ::testing::Values(axis)
 );
 
-INSTANTIATE_TEST_CASE_P(DWGroupConvolution3D, ConvConcatSubgraphTest, params3D, ConvConcatSubgraphTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_DWGroupConvolution3D, ConvConcatSubgraphTest, params3D, ConvConcatSubgraphTest::getTestCaseName);
 
 }  // namespace GroupConvolutionDWConcat
 
@@ -280,7 +280,7 @@ const auto params2D = ::testing::Combine(
     ::testing::Values(axis)
 );
 
-INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData2D, ConvConcatSubgraphTest, params2D, ConvConcatSubgraphTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_ConvolutionBackpropData2D, ConvConcatSubgraphTest, params2D, ConvConcatSubgraphTest::getTestCaseName);
 
 /* ============= ConvolutionBackpropData (3D) ============= */
 const std::vector<CPUSpecificParams> CPUParams3D = {
@@ -297,7 +297,7 @@ const auto params3D = ::testing::Combine(
     ::testing::Values(axis)
 );
 
-INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData3D, ConvConcatSubgraphTest, params3D, ConvConcatSubgraphTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_ConvolutionBackpropData3D, ConvConcatSubgraphTest, params3D, ConvConcatSubgraphTest::getTestCaseName);
 
 }  // namespace ConvolutionBackpropDataConcat
 
@@ -320,7 +320,7 @@ const auto params2D = ::testing::Combine(
     ::testing::Values(axis)
 );
 
-INSTANTIATE_TEST_CASE_P(Convolution2D, ConvConcatSubgraphTest, params2D, ConvConcatSubgraphTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_Convolution2D, ConvConcatSubgraphTest, params2D, ConvConcatSubgraphTest::getTestCaseName);
 
 /* ============= Convolution (3D) ============= */
 const std::vector<CPUSpecificParams> CPUParams3D = {
@@ -338,7 +338,7 @@ const auto params3D = ::testing::Combine(
     ::testing::Values(axis)
 );
 
-INSTANTIATE_TEST_CASE_P(Convolution3D, ConvConcatSubgraphTest, params3D, ConvConcatSubgraphTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_Convolution3D, ConvConcatSubgraphTest, params3D, ConvConcatSubgraphTest::getTestCaseName);
 
 }  // namespace ConvolutionConact
 
@@ -361,7 +361,7 @@ const auto params2D = ::testing::Combine(
     ::testing::Values(axis)
 );
 
-INSTANTIATE_TEST_CASE_P(GroupConvolution2D, ConvConcatSubgraphTest, params2D, ConvConcatSubgraphTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_GroupConvolution2D, ConvConcatSubgraphTest, params2D, ConvConcatSubgraphTest::getTestCaseName);
 
 /* ============= GroupConvolution (3D) ============= */
 const std::vector<CPUSpecificParams> CPUParams3D = {
@@ -379,7 +379,7 @@ const auto params3D = ::testing::Combine(
     ::testing::Values(axis)
 );
 
-INSTANTIATE_TEST_CASE_P(GroupConvolution3D, ConvConcatSubgraphTest, params3D, ConvConcatSubgraphTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_GroupConvolution3D, ConvConcatSubgraphTest, params3D, ConvConcatSubgraphTest::getTestCaseName);
 
 }  // namespace GroupConvolutionConcat
 
@@ -401,7 +401,7 @@ const auto params2D = ::testing::Combine(
     ::testing::Values(axis)
 );
 
-INSTANTIATE_TEST_CASE_P(GroupConvolutionBackpropData2D, ConvConcatSubgraphTest, params2D, ConvConcatSubgraphTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_GroupConvolutionBackpropData2D, ConvConcatSubgraphTest, params2D, ConvConcatSubgraphTest::getTestCaseName);
 
 /* ============= GroupConvolutionBackpropData (3D) ============= */
 const std::vector<CPUSpecificParams> CPUParams3D = {
@@ -418,7 +418,7 @@ const auto params3D = ::testing::Combine(
     ::testing::Values(axis)
 );
 
-INSTANTIATE_TEST_CASE_P(GroupConvolutionBackpropData3D, ConvConcatSubgraphTest, params3D, ConvConcatSubgraphTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_GroupConvolutionBackpropData3D, ConvConcatSubgraphTest, params3D, ConvConcatSubgraphTest::getTestCaseName);
 
 }  // namespace GroupConvolutionBackpropDataConcat
 

--- a/inference-engine/tests/functional/plugin/cpu/subgraph_tests/src/reshape_permute_conv_permute_reshape_act.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/subgraph_tests/src/reshape_permute_conv_permute_reshape_act.cpp
@@ -30,7 +30,7 @@ std::vector<InferenceEngine::Precision> netPrecisions = {
 std::map<std::string, std::string> additional_config = { };
 
 namespace LayerTestsDefinitions {
-    INSTANTIATE_TEST_CASE_P(basic, ConvReshapeAct,
+    INSTANTIATE_TEST_CASE_P(smoke_basic, ConvReshapeAct,
         ::testing::Combine(
             ::testing::ValuesIn(netPrecisions),
             ::testing::Values(CommonTestUtils::DEVICE_CPU),


### PR DESCRIPTION
Separation functional tests to the pre-commit (`gtest_filter=*smoke*`) and nightly scope (`gtest_filter=*nightly *`).
Default value is `smoke`. But after this merge you could change it.
CC @azhogov @mikhail-treskin 