### PR TITLE
[IE Tests] Added test filters for gpuFuncTests target

### DIFF
--- a/inference-engine/tests/functional/plugin/gpu/remote_blob_tests/cldnn_remote_blob_tests.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/remote_blob_tests/cldnn_remote_blob_tests.cpp
@@ -30,7 +30,7 @@ protected:
     }
 };
 
-TEST_F(RemoteBlob_Test, canInputUserBlob) {
+TEST_F(RemoteBlob_Test, smoke_canInputUserBlob) {
 #if defined(_WIN32) || defined(ANDROID)
     GTEST_SKIP();
 #endif
@@ -85,7 +85,7 @@ TEST_F(RemoteBlob_Test, canInputUserBlob) {
     }
 }
 
-TEST_F(RemoteBlob_Test, canInferOnUserContext) {
+TEST_F(RemoteBlob_Test, smoke_canInferOnUserContext) {
 #if defined _WIN32
     GTEST_SKIP();
 #endif
@@ -213,4 +213,4 @@ TEST_P(TwoNets_Test, canInferTwoExecNets) {
 
 const std::vector<size_t> num_strems{1, 2};
 
-INSTANTIATE_TEST_CASE_P(RemoteBlob, TwoNets_Test, ::testing::ValuesIn(num_strems), TwoNets_Test::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_RemoteBlob, TwoNets_Test, ::testing::ValuesIn(num_strems), TwoNets_Test::getTestCaseName);

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/behavior/core_threading_tests.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/behavior/core_threading_tests.cpp
@@ -46,9 +46,9 @@ TEST_P(CoreThreadingTestsWithIterations, smoke_LoadNetwork_RemoteContext) {
     }, numIterations, numThreads);
 }
 
-INSTANTIATE_TEST_CASE_P(GPU, CoreThreadingTests, testing::ValuesIn(params), CoreThreadingTests::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_GPU, CoreThreadingTests, testing::ValuesIn(params), CoreThreadingTests::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(GPU, CoreThreadingTestsWithIterations,
+INSTANTIATE_TEST_CASE_P(smoke_GPU, CoreThreadingTestsWithIterations,
     testing::Combine(testing::ValuesIn(params),
                      testing::Values(4),
                      testing::Values(20)),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/execution_graph_tests/unique_node_names.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/execution_graph_tests/unique_node_names.cpp
@@ -15,7 +15,7 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
         InferenceEngine::Precision::FP32
 };
 
-INSTANTIATE_TEST_CASE_P(NoReshape, ExecGraphUniqueNodeNames,
+INSTANTIATE_TEST_CASE_P(smoke_NoReshape, ExecGraphUniqueNodeNames,
                         ::testing::Combine(
                                 ::testing::ValuesIn(netPrecisions),
                                 ::testing::Values(InferenceEngine::SizeVector({1, 2, 5, 5})),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/concat_neighboring_graph_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/concat_neighboring_graph_transformation.cpp
@@ -19,7 +19,7 @@ const std::vector<LayerTransformation::Params> trasformationParamValues = {
     LayerTestsUtils::LayerTransformationParamsFactory::createParams()
 };
 
-INSTANTIATE_TEST_CASE_P(LPT, ConcatNeighboringGraphTransformation,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, ConcatNeighboringGraphTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(InferenceEngine::SizeVector({ 1, 3, 16, 16 })),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/concat_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/concat_transformation.cpp
@@ -19,7 +19,7 @@ const std::vector<LayerTransformation::Params> trasformationParamValues = {
     LayerTestsUtils::LayerTransformationParamsFactory::createParams()
 };
 
-INSTANTIATE_TEST_CASE_P(LPT, ConcatTransformation,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, ConcatTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(InferenceEngine::SizeVector({ 1, 3, 16, 16 })),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/concat_with_intermediate_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/concat_with_intermediate_transformation.cpp
@@ -22,7 +22,7 @@ const std::vector<LayerTransformation::Params> trasformationParamValues = {
 const std::vector<bool> transparentIntermediates = { true, false };
 const std::vector<bool> multiChannelValues = { true, false };
 
-INSTANTIATE_TEST_CASE_P(LPT, ConcatWithIntermediateTransformation,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, ConcatWithIntermediateTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(InferenceEngine::SizeVector({ 1, 3, 16, 16 })),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/convolution_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/convolution_transformation.cpp
@@ -22,7 +22,7 @@ const std::vector<bool> fqOnActivationsValues = { true, false };
 
 const std::vector<bool> fqOnWeightsValues = { true, false };
 
-INSTANTIATE_TEST_CASE_P(LPT, ConvolutionTransformation,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, ConvolutionTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(InferenceEngine::SizeVector({ 1, 3, 16, 16 })),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/depth_to_space_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/depth_to_space_transformation.cpp
@@ -20,7 +20,7 @@ const std::vector<LayerTransformation::Params> trasformationParamValues = {
 };
 
 // disabled while GPU is not supported DepthToSpace
-INSTANTIATE_TEST_CASE_P(DISABLED_LPT, DepthToSpaceTransformation,
+INSTANTIATE_TEST_CASE_P(DISABLED_smoke_LPT, DepthToSpaceTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(InferenceEngine::SizeVector({ 1, 32, 72, 48 })),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/fully_connected_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/fully_connected_transformation.cpp
@@ -23,7 +23,7 @@ const std::vector<LayerTransformation::Params> trasformationParamValues = {
     LayerTestsUtils::LayerTransformationParamsFactory::createParams()
 };
 
-INSTANTIATE_TEST_CASE_P(LPT, FullyConnectedTransformation,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, FullyConnectedTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::ValuesIn(dimensions),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/fuse_fake_quantize_and_scale_shift_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/fuse_fake_quantize_and_scale_shift_transformation.cpp
@@ -32,7 +32,7 @@ const std::vector<ngraph::builder::subgraph::FakeQuantizeOnData> fakeQuantizeOnD
     },
 };
 
-INSTANTIATE_TEST_CASE_P(LPT, FuseFakeQuantizeAndScaleShiftTransformation,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, FuseFakeQuantizeAndScaleShiftTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(InferenceEngine::SizeVector({ 1, 3, 9, 9 })),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/gemm_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/gemm_transformation.cpp
@@ -23,7 +23,7 @@ const std::vector<LayerTransformation::Params> trasformationParamValues = {
     LayerTestsUtils::LayerTransformationParamsFactory::createParamsI8I8()
 };
 
-INSTANTIATE_TEST_CASE_P(LPT, GemmTransformation,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, GemmTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::ValuesIn(dimensions),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/mat_mul_with_optimized_constant_fake_quantize_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/mat_mul_with_optimized_constant_fake_quantize_transformation.cpp
@@ -26,7 +26,7 @@ const std::vector<std::pair<InferenceEngine::SizeVector, InferenceEngine::SizeVe
     std::pair<InferenceEngine::SizeVector, InferenceEngine::SizeVector>({ InferenceEngine::SizeVector({ 1, 16 }), InferenceEngine::SizeVector({ 16, 10 }) })
 };
 
-INSTANTIATE_TEST_CASE_P(LPT, MatMulWithOptimizedConstantFakeQuantizeTransformation,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, MatMulWithOptimizedConstantFakeQuantizeTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::ValuesIn(inputShapes),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/multiply_with_one_parent_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/multiply_with_one_parent_transformation.cpp
@@ -21,7 +21,7 @@ const std::vector<MultiplyWithOneParentTransformationValues> values = {
     }
 };
 
-INSTANTIATE_TEST_CASE_P(LPT, MultiplyWithOneParentTransformation,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, MultiplyWithOneParentTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(InferenceEngine::SizeVector({ 1, 3, 16, 16 })),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/normalize_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/normalize_transformation.cpp
@@ -23,7 +23,7 @@ const std::vector<bool> fuseMultiplyValues = { true, false };
 
 const std::vector<bool> shiftValues = { true, false };
 
-INSTANTIATE_TEST_CASE_P(LPT, NormalizeTransformation,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, NormalizeTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(InferenceEngine::SizeVector({ 1, 16, 8, 8 })),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/output_layers_handling_in_transformations.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/output_layers_handling_in_transformations.cpp
@@ -19,7 +19,7 @@ const std::vector<LayerTransformation::Params> trasformationParamValues = {
     LayerTestsUtils::LayerTransformationParamsFactory::createParams()
 };
 
-INSTANTIATE_TEST_CASE_P(LPT, OutputLayersHandlingInTransformations,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, OutputLayersHandlingInTransformations,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(InferenceEngine::SizeVector({ 1, 3, 16, 16 })),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/output_layers_handling_in_transformations_for_concat.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/output_layers_handling_in_transformations_for_concat.cpp
@@ -19,7 +19,7 @@ const std::vector<LayerTransformation::Params> trasformationParamValues = {
     LayerTestsUtils::LayerTransformationParamsFactory::createParams()
 };
 
-INSTANTIATE_TEST_CASE_P(LPT, OutputLayersHandlingInTransformations,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, OutputLayersHandlingInTransformations,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(InferenceEngine::SizeVector({ 1, 3, 16, 16 })),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/output_layers_handling_in_transformations_for_concat_multi_channel.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/output_layers_handling_in_transformations_for_concat_multi_channel.cpp
@@ -19,7 +19,7 @@ const std::vector<LayerTransformation::Params> trasformationParamValues = {
     LayerTestsUtils::LayerTransformationParamsFactory::createParams()
 };
 
-INSTANTIATE_TEST_CASE_P(LPT, OutputLayersHandlingInTransformations,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, OutputLayersHandlingInTransformations,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(InferenceEngine::SizeVector({ 1, 3, 16, 16 })),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/permute_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/permute_transformation.cpp
@@ -107,7 +107,7 @@ const std::vector<PermuteTransformationTestValues> testValues = {
     }
 };
 
-INSTANTIATE_TEST_CASE_P(LPT, PermuteTransformation,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, PermuteTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(CommonTestUtils::DEVICE_GPU),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/reshape_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/reshape_transformation.cpp
@@ -19,7 +19,7 @@ const std::vector<InferenceEngine::details::LayerTransformation::Params> trasfor
 };
 
 
-INSTANTIATE_TEST_CASE_P(LPT, ReshapeTransformation,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, ReshapeTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(InferenceEngine::SizeVector({ 1, 3, 16, 16 })),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/ngraph_conversion_tests/conv_bias_fusion.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/ngraph_conversion_tests/conv_bias_fusion.cpp
@@ -9,6 +9,6 @@ using namespace NGraphConversionTestsDefinitions;
 
 namespace {
 
-INSTANTIATE_TEST_CASE_P(Basic, ConvBiasFusion, ::testing::Values(CommonTestUtils::DEVICE_GPU), ConvBiasFusion::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_Basic, ConvBiasFusion, ::testing::Values(CommonTestUtils::DEVICE_GPU), ConvBiasFusion::getTestCaseName);
 
 }  // namespace

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/ngraph_conversion_tests/plugin_specific_ngraph_conversion.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/ngraph_conversion_tests/plugin_specific_ngraph_conversion.cpp
@@ -9,6 +9,6 @@ using namespace NGraphConversionTestsDefinitions;
 
 namespace {
 
-INSTANTIATE_TEST_CASE_P(Basic, PluginSpecificConversion, ::testing::Values("GPU"), PluginSpecificConversion::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_Basic, PluginSpecificConversion, ::testing::Values("GPU"), PluginSpecificConversion::getTestCaseName);
 
 }  // namespace

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/activation.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/activation.cpp
@@ -59,6 +59,6 @@ const auto basicCases = ::testing::Combine(
         ::testing::Values(CommonTestUtils::DEVICE_GPU)
 );
 
-INSTANTIATE_TEST_CASE_P(Activation_Basic, ActivationLayerTest, basicCases, ActivationLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_Activation_Basic, ActivationLayerTest, basicCases, ActivationLayerTest::getTestCaseName);
 
 }  // namespace

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/comparison.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/comparison.cpp
@@ -50,6 +50,6 @@ const auto ComparisonTestParams = ::testing::Combine(
         ::testing::Values(CommonTestUtils::DEVICE_GPU),
         ::testing::Values(additional_config));
 
-INSTANTIATE_TEST_CASE_P(CompareWithRefs, ComparisonLayerTest, ComparisonTestParams, ComparisonLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_CompareWithRefs, ComparisonLayerTest, ComparisonTestParams, ComparisonLayerTest::getTestCaseName);
 
 }  // namespace

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/concat.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/concat.cpp
@@ -24,7 +24,7 @@ std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precis
                                                          InferenceEngine::Precision::I64};
 
 
-INSTANTIATE_TEST_CASE_P(NoReshape, ConcatLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_NoReshape, ConcatLayerTest,
                         ::testing::Combine(
                                 ::testing::ValuesIn(axes),
                                 ::testing::ValuesIn(inShapes),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/convolution.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/convolution.cpp
@@ -50,7 +50,7 @@ const auto conv2DParams_AutoPadValid = ::testing::Combine(
         ::testing::Values(ngraph::op::PadType::VALID)
 );
 
-INSTANTIATE_TEST_CASE_P(Convolution2D_ExplicitPadding, ConvolutionLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_Convolution2D_ExplicitPadding, ConvolutionLayerTest,
                         ::testing::Combine(
                                 conv2DParams_ExplicitPadding,
                                 ::testing::ValuesIn(netPrecisions),
@@ -62,7 +62,7 @@ INSTANTIATE_TEST_CASE_P(Convolution2D_ExplicitPadding, ConvolutionLayerTest,
                                 ::testing::Values(CommonTestUtils::DEVICE_GPU)),
                         ConvolutionLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(Convolution2D_AutoPadValid, ConvolutionLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_Convolution2D_AutoPadValid, ConvolutionLayerTest,
                         ::testing::Combine(
                                 conv2DParams_AutoPadValid,
                                 ::testing::ValuesIn(netPrecisions),
@@ -97,7 +97,7 @@ const auto conv3DParams = ::testing::Combine(
         ::testing::Values(ngraph::op::PadType::EXPLICIT)
 );
 
-INSTANTIATE_TEST_CASE_P(Convolution3D_Basic1, ConvolutionLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_Convolution3D_Basic1, ConvolutionLayerTest,
                         ::testing::Combine(
                                 conv3DParams,
                                 ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/convolution_backprop_data.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/convolution_backprop_data.cpp
@@ -52,7 +52,7 @@ const auto conv2DParams_AutoPadValid = ::testing::Combine(
         ::testing::Values(ngraph::op::PadType::VALID)
 );
 
-INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData2D_ExplicitPadding, ConvolutionBackpropDataLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_ConvolutionBackpropData2D_ExplicitPadding, ConvolutionBackpropDataLayerTest,
                         ::testing::Combine(
                                 conv2DParams_ExplicitPadding,
                                 ::testing::ValuesIn(netPrecisions2D),
@@ -60,7 +60,7 @@ INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData2D_ExplicitPadding, ConvolutionBa
                                 ::testing::Values(CommonTestUtils::DEVICE_GPU)),
                         ConvolutionBackpropDataLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData2D_AutoPadValid, ConvolutionBackpropDataLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_ConvolutionBackpropData2D_AutoPadValid, ConvolutionBackpropDataLayerTest,
                         ::testing::Combine(
                                 conv2DParams_AutoPadValid,
                                 ::testing::ValuesIn(netPrecisions2D),
@@ -100,7 +100,7 @@ const auto conv3DParams_AutoPadValid = ::testing::Combine(
         ::testing::Values(ngraph::op::PadType::VALID)
 );
 
-INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData3D_ExplicitPadding, ConvolutionBackpropDataLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_ConvolutionBackpropData3D_ExplicitPadding, ConvolutionBackpropDataLayerTest,
                         ::testing::Combine(
                                 conv3DParams_ExplicitPadding,
                                 ::testing::ValuesIn(netPrecisions3D),
@@ -108,7 +108,7 @@ INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData3D_ExplicitPadding, ConvolutionBa
                                 ::testing::Values(CommonTestUtils::DEVICE_GPU)),
                         ConvolutionBackpropDataLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(ConvolutionBackpropData3D_AutoPadValid, ConvolutionBackpropDataLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_ConvolutionBackpropData3D_AutoPadValid, ConvolutionBackpropDataLayerTest,
                         ::testing::Combine(
                                 conv3DParams_AutoPadValid,
                                 ::testing::ValuesIn(netPrecisions3D),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/ctc_greedy_decoder.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/ctc_greedy_decoder.cpp
@@ -23,7 +23,7 @@ namespace {
         ::testing::Values(true, false),
         ::testing::Values(CommonTestUtils::DEVICE_GPU));
 
-    INSTANTIATE_TEST_CASE_P(CTC_Greedy_decoder_Basic, CTCGreedyDecoderLayerTest,
+    INSTANTIATE_TEST_CASE_P(smoke_CTC_Greedy_decoder_Basic, CTCGreedyDecoderLayerTest,
                             basicCases,
                             CTCGreedyDecoderLayerTest::getTestCaseName);
 }  // namespace

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/cum_sum.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/cum_sum.cpp
@@ -26,7 +26,7 @@ std::vector<InferenceEngine::Precision> precisions = {InferenceEngine::Precision
 
 std::vector<std::vector<size_t>> shape1d = {{10}};
 std::vector<int64_t> axis1d = {0};
-INSTANTIATE_TEST_CASE_P(CumSum1D, CumSumLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_CumSum1D, CumSumLayerTest,
                         ::testing::Combine(
                                 ::testing::ValuesIn(shape1d),
                                 ::testing::ValuesIn(precisions),
@@ -36,7 +36,7 @@ INSTANTIATE_TEST_CASE_P(CumSum1D, CumSumLayerTest,
                                 ::testing::Values(CommonTestUtils::DEVICE_GPU)),
                         CumSumLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(CumSum, CumSumLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_CumSum, CumSumLayerTest,
                         ::testing::Combine(
                                 ::testing::ValuesIn(inShapes),
                                 ::testing::ValuesIn(precisions),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/depth_to_space.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/depth_to_space.cpp
@@ -34,7 +34,7 @@ const auto DepthToSpaceBS2 = ::testing::Combine(
         ::testing::Values(CommonTestUtils::DEVICE_GPU)
 );
 
-INSTANTIATE_TEST_CASE_P(DepthToSpaceBS2, DepthToSpaceLayerTest, DepthToSpaceBS2, DepthToSpaceLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_DepthToSpaceBS2, DepthToSpaceLayerTest, DepthToSpaceBS2, DepthToSpaceLayerTest::getTestCaseName);
 
 const std::vector<std::vector<size_t >> inputShapesBS3 = {
         {1, 9, 1, 1}, {1, 9, 2, 2}, {1, 9, 3, 3}, {2, 36, 3, 3}, {2, 27, 5, 4},
@@ -48,6 +48,6 @@ const auto DepthToSpaceBS3 = ::testing::Combine(
         ::testing::Values(CommonTestUtils::DEVICE_GPU)
 );
 
-INSTANTIATE_TEST_CASE_P(DepthToSpaceBS3, DepthToSpaceLayerTest, DepthToSpaceBS3, DepthToSpaceLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_DepthToSpaceBS3, DepthToSpaceLayerTest, DepthToSpaceBS3, DepthToSpaceLayerTest::getTestCaseName);
 
 }  // namespace

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/eltwise.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/eltwise.cpp
@@ -56,5 +56,5 @@ const auto multiply_params = ::testing::Combine(
         ::testing::Values(CommonTestUtils::DEVICE_GPU),
         ::testing::Values(additional_config));
 
-INSTANTIATE_TEST_CASE_P(CompareWithRefs, EltwiseLayerTest, multiply_params, EltwiseLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_CompareWithRefs, EltwiseLayerTest, multiply_params, EltwiseLayerTest::getTestCaseName);
 }  // namespace

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/extract_image_patches.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/extract_image_patches.cpp
@@ -56,7 +56,7 @@ const auto extractImagePatchesParamsSet = ::testing::Combine(
         ::testing::ValuesIn(autoPads)
 );
 
-INSTANTIATE_TEST_CASE_P(layers_GPU, ExtractImagePatchesTest,
+INSTANTIATE_TEST_CASE_P(smoke_layers_GPU, ExtractImagePatchesTest,
         ::testing::Combine(
             ::testing::ValuesIn(inDataShape),
             ::testing::ValuesIn(kernels),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/gather.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/gather.cpp
@@ -94,7 +94,7 @@ const auto GatherAxes4 = testing::Combine(
 );
 
 INSTANTIATE_TEST_CASE_P(
-        GatherAxes4,
+        smoke_GatherAxes4,
         GatherLayerTest,
         GatherAxes4,
         GatherLayerTest::getTestCaseName
@@ -110,7 +110,7 @@ const auto Gather6dAxes4 = testing::Combine(
 );
 
 INSTANTIATE_TEST_CASE_P(
-        Gather6dAxes4,
+        smoke_Gather6dAxes4,
         GatherLayerTest,
         Gather6dAxes4,
         GatherLayerTest::getTestCaseName
@@ -154,7 +154,7 @@ const auto GatherAxes3 = testing::Combine(
 );
 
 INSTANTIATE_TEST_CASE_P(
-        GatherAxes3,
+        smoke_GatherAxes3,
         GatherLayerTest,
         GatherAxes3,
         GatherLayerTest::getTestCaseName
@@ -170,7 +170,7 @@ const auto Gather6dAxes3 = testing::Combine(
 );
 
 INSTANTIATE_TEST_CASE_P(
-        Gather6dAxes3,
+        smoke_Gather6dAxes3,
         GatherLayerTest,
         Gather6dAxes3,
         GatherLayerTest::getTestCaseName
@@ -214,7 +214,7 @@ const auto GatherAxes2 = testing::Combine(
 );
 
 INSTANTIATE_TEST_CASE_P(
-        GatherAxes2,
+        smoke_GatherAxes2,
         GatherLayerTest,
         GatherAxes2,
         GatherLayerTest::getTestCaseName
@@ -230,7 +230,7 @@ const auto Gather6dAxes2 = testing::Combine(
 );
 
 INSTANTIATE_TEST_CASE_P(
-        Gather6dAxes2,
+        smoke_Gather6dAxes2,
         GatherLayerTest,
         Gather6dAxes2,
         GatherLayerTest::getTestCaseName
@@ -274,7 +274,7 @@ const auto GatherAxes1 = testing::Combine(
 );
 
 INSTANTIATE_TEST_CASE_P(
-        GatherAxes1,
+        smoke_GatherAxes1,
         GatherLayerTest,
         GatherAxes1,
         GatherLayerTest::getTestCaseName
@@ -290,7 +290,7 @@ const auto Gather6dAxes1 = testing::Combine(
 );
 
 INSTANTIATE_TEST_CASE_P(
-        Gather6dAxes1,
+        smoke_Gather6dAxes1,
         GatherLayerTest,
         Gather6dAxes1,
         GatherLayerTest::getTestCaseName
@@ -334,7 +334,7 @@ const auto GatherAxes0 = testing::Combine(
 );
 
 INSTANTIATE_TEST_CASE_P(
-        GatherAxes0,
+        smoke_GatherAxes0,
         GatherLayerTest,
         GatherAxes0,
         GatherLayerTest::getTestCaseName
@@ -350,7 +350,7 @@ const auto Gather6dAxes0 = testing::Combine(
 );
 
 INSTANTIATE_TEST_CASE_P(
-        Gather6dAxes0,
+        smoke_Gather6dAxes0,
         GatherLayerTest,
         Gather6dAxes0,
         GatherLayerTest::getTestCaseName

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/grn.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/grn.cpp
@@ -23,7 +23,7 @@ namespace {
         ::testing::Values(0.33f, 1.1f),
         ::testing::Values(CommonTestUtils::DEVICE_GPU));
 
-    INSTANTIATE_TEST_CASE_P(Grn_Basic, GrnLayerTest,
+    INSTANTIATE_TEST_CASE_P(smoke_Grn_Basic, GrnLayerTest,
                             basicCases,
                             GrnLayerTest::getTestCaseName);
 

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/group_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/group_convolution.cpp
@@ -45,7 +45,7 @@ const auto groupConv2DParams_AutoPadValid = ::testing::Combine(
         ::testing::Values(ngraph::op::PadType::VALID)
 );
 
-INSTANTIATE_TEST_CASE_P(GroupConvolution2D_ExplicitPadding, GroupConvolutionLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConvolution2D_ExplicitPadding, GroupConvolutionLayerTest,
                         ::testing::Combine(
                                 groupConv2DParams_ExplicitPadding,
                                 ::testing::ValuesIn(netPrecisions),
@@ -53,7 +53,7 @@ INSTANTIATE_TEST_CASE_P(GroupConvolution2D_ExplicitPadding, GroupConvolutionLaye
                                 ::testing::Values(CommonTestUtils::DEVICE_GPU)),
                         GroupConvolutionLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(GroupConvolution2D_AutoPadValid, GroupConvolutionLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConvolution2D_AutoPadValid, GroupConvolutionLayerTest,
                         ::testing::Combine(
                                 groupConv2DParams_AutoPadValid,
                                 ::testing::ValuesIn(netPrecisions),
@@ -89,7 +89,7 @@ const auto groupConv3DParams_AutoPadValid = ::testing::Combine(
         ::testing::Values(ngraph::op::PadType::VALID)
 );
 
-INSTANTIATE_TEST_CASE_P(GroupConvolution3D_ExplicitPadding, GroupConvolutionLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConvolution3D_ExplicitPadding, GroupConvolutionLayerTest,
                         ::testing::Combine(
                                 groupConv3DParams_ExplicitPadding,
                                 ::testing::ValuesIn(netPrecisions),
@@ -97,7 +97,7 @@ INSTANTIATE_TEST_CASE_P(GroupConvolution3D_ExplicitPadding, GroupConvolutionLaye
                                 ::testing::Values(CommonTestUtils::DEVICE_GPU)),
                         GroupConvolutionLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(GroupConvolution3D_AutoPadValid, GroupConvolutionLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConvolution3D_AutoPadValid, GroupConvolutionLayerTest,
                         ::testing::Combine(
                                 groupConv3DParams_AutoPadValid,
                                 ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/interpolate.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/interpolate.cpp
@@ -106,7 +106,7 @@ const auto interpolateCasesNearesMode = ::testing::Combine(
         ::testing::ValuesIn(defaultAxes),
         ::testing::ValuesIn(defaultScales));
 
-INSTANTIATE_TEST_CASE_P(Interpolate_Basic, InterpolateLayerTest, ::testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_Interpolate_Basic, InterpolateLayerTest, ::testing::Combine(
         interpolateCasesWithoutNearest,
         ::testing::ValuesIn(prc),
         ::testing::ValuesIn(inShapes),
@@ -114,7 +114,7 @@ INSTANTIATE_TEST_CASE_P(Interpolate_Basic, InterpolateLayerTest, ::testing::Comb
         ::testing::Values(CommonTestUtils::DEVICE_GPU)),
     InterpolateLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(Interpolate_Nearest, InterpolateLayerTest, ::testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_Interpolate_Nearest, InterpolateLayerTest, ::testing::Combine(
         interpolateCasesNearesMode,
         ::testing::ValuesIn(prc),
         ::testing::ValuesIn(inShapes),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/logical.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/logical.cpp
@@ -68,8 +68,8 @@ const auto LogicalTestParamsNot = ::testing::Combine(
         ::testing::Values(CommonTestUtils::DEVICE_CPU),
         ::testing::Values(additional_config));
 
-INSTANTIATE_TEST_CASE_P(CompareWithRefs, LogicalLayerTest, LogicalTestParams, LogicalLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_CompareWithRefs, LogicalLayerTest, LogicalTestParams, LogicalLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(CompareWithRefsNot, LogicalLayerTest, LogicalTestParamsNot, LogicalLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_CompareWithRefsNot, LogicalLayerTest, LogicalTestParamsNot, LogicalLayerTest::getTestCaseName);
 
 }  // namespace

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/lrn.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/lrn.cpp
@@ -20,7 +20,7 @@ const double beta = 2;
 const double bias = 1.0;
 const size_t size = 5;
 
-INSTANTIATE_TEST_CASE_P(LrnCheck, LrnLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_LrnCheck, LrnLayerTest,
                         ::testing::Combine(::testing::Values(alpha),
                                            ::testing::Values(beta),
                                            ::testing::Values(bias),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/pooling.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/pooling.cpp
@@ -41,7 +41,7 @@ const auto maxPool_ExplicitPad_FloorRounding_Params = ::testing::Combine(
         ::testing::Values(false)  // placeholder value - exclude pad not applicable for max pooling
 );
 
-INSTANTIATE_TEST_CASE_P(MaxPool_ExplicitPad_FloorRpunding, PoolingLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_MaxPool_ExplicitPad_FloorRpunding, PoolingLayerTest,
                         ::testing::Combine(
                                 maxPool_ExplicitPad_FloorRounding_Params,
                                 ::testing::ValuesIn(netPrecisions),
@@ -62,7 +62,7 @@ const auto maxPool_ExplicitPad_CeilRounding_Params = ::testing::Combine(
         ::testing::Values(false)  // placeholder value - exclude pad not applicable for max pooling
 );
 
-INSTANTIATE_TEST_CASE_P(MaxPool_ExplicitPad_CeilRpunding, PoolingLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_MaxPool_ExplicitPad_CeilRpunding, PoolingLayerTest,
                         ::testing::Combine(
                                 maxPool_ExplicitPad_CeilRounding_Params,
                                 ::testing::ValuesIn(netPrecisions),
@@ -85,7 +85,7 @@ const auto avgPoolExplicitPadCeilRoundingParams = ::testing::Combine(
         ::testing::Values(true, false)
 );
 
-INSTANTIATE_TEST_CASE_P(AvgPool_ExplicitPad_CeilRounding, PoolingLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_AvgPool_ExplicitPad_CeilRounding, PoolingLayerTest,
                         ::testing::Combine(
                                 avgPoolExplicitPadCeilRoundingParams,
                                 ::testing::ValuesIn(netPrecisions),
@@ -106,7 +106,7 @@ const auto avgPoolExplicitPadFloorRoundingParams = ::testing::Combine(
 );
 
 
-INSTANTIATE_TEST_CASE_P(AvgPool_ExplicitPad_FloorRounding, PoolingLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_AvgPool_ExplicitPad_FloorRounding, PoolingLayerTest,
                         ::testing::Combine(
                                 avgPoolExplicitPadFloorRoundingParams,
                                 ::testing::ValuesIn(netPrecisions),
@@ -128,7 +128,7 @@ const auto allPools_ValidPad_Params = ::testing::Combine(
         ::testing::Values(false)  // placeholder value - exclude pad not applicable for max pooling
 );
 
-INSTANTIATE_TEST_CASE_P(MAX_and_AVGPool_ValidPad, PoolingLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_MAX_and_AVGPool_ValidPad, PoolingLayerTest,
                         ::testing::Combine(
                                 allPools_ValidPad_Params,
                                 ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/prior_box_clustered.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/prior_box_clustered.cpp
@@ -56,7 +56,7 @@ const auto layerSpeficParams = ::testing::Combine(
     ::testing::ValuesIn(variances)
 );
 
-INSTANTIATE_TEST_CASE_P(PriorBoxClustered_Basic, PriorBoxClusteredLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_PriorBoxClustered_Basic, PriorBoxClusteredLayerTest,
                         ::testing::Combine(
                             layerSpeficParams,
                             ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/proposal.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/proposal.cpp
@@ -39,7 +39,7 @@ const auto proposalParams = ::testing::Combine(
         ::testing::ValuesIn(framework_)
 );
 
-INSTANTIATE_TEST_CASE_P(Proposal_tests, ProposalLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_Proposal_tests, ProposalLayerTest,
                         ::testing::Combine(
                                 proposalParams,
                                 ::testing::Values(CommonTestUtils::DEVICE_GPU)),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/reduce_ops.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/reduce_ops.cpp
@@ -47,7 +47,7 @@ namespace {
         testing::Values(CommonTestUtils::DEVICE_GPU));
 
     INSTANTIATE_TEST_CASE_P(
-        ReduceOneAxis,
+        smoke_ReduceOneAxis,
         ReduceOpsLayerTest,
         paramsOneAxis,
         ReduceOpsLayerTest::getTestCaseName);
@@ -62,7 +62,7 @@ namespace {
         testing::Values(CommonTestUtils::DEVICE_GPU));
 
     INSTANTIATE_TEST_CASE_P(
-        Reduce,
+        smoke_Reduce,
         ReduceOpsLayerTest,
         params,
         ReduceOpsLayerTest::getTestCaseName);

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/reshape.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/reshape.cpp
@@ -16,7 +16,7 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
 };
 
 //TODO: Issue : - 28981
-INSTANTIATE_TEST_CASE_P(DISABLE_ReshapeCheckDynBatch, ReshapeLayerTest,
+INSTANTIATE_TEST_CASE_P(DISABLE_smoke_ReshapeCheckDynBatch, ReshapeLayerTest,
         ::testing::Combine(
                 ::testing::Values(true),
                 ::testing::ValuesIn(netPrecisions),
@@ -26,7 +26,7 @@ INSTANTIATE_TEST_CASE_P(DISABLE_ReshapeCheckDynBatch, ReshapeLayerTest,
                 ::testing::Values(std::map<std::string, std::string>({{CONFIG_KEY(DYN_BATCH_ENABLED), CONFIG_VALUE(YES)}}))),
                 ReshapeLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(ReshapeCheck, ReshapeLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_ReshapeCheck, ReshapeLayerTest,
         ::testing::Combine(
                 ::testing::Values(true),
                 ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/split.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/split.cpp
@@ -17,7 +17,7 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
         InferenceEngine::Precision::I64
 };
 
-INSTANTIATE_TEST_CASE_P(NumSplitsCheck, SplitLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_NumSplitsCheck, SplitLayerTest,
                         ::testing::Combine(
                                 ::testing::Values(1),
                                 ::testing::Values(0, 1, 2, 3),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/subgraph_tests/reshape_permute_conv_permute_reshape_act.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/subgraph_tests/reshape_permute_conv_permute_reshape_act.cpp
@@ -30,7 +30,7 @@ std::vector<InferenceEngine::Precision> netPrecisions = {
 std::map<std::string, std::string> additional_config = {};
 
 namespace LayerTestsDefinitions {
-    INSTANTIATE_TEST_CASE_P(basic, ConvReshapeAct,
+    INSTANTIATE_TEST_CASE_P(smoke_basic, ConvReshapeAct,
         ::testing::Combine(
             ::testing::ValuesIn(netPrecisions),
             ::testing::Values(CommonTestUtils::DEVICE_GPU),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/subgraph_tests/reshape_squeeze_reshape_relu.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/subgraph_tests/reshape_squeeze_reshape_relu.cpp
@@ -37,7 +37,7 @@ namespace {
             ngraph::helpers::SqueezeOpType::UNSQUEEZE
     };
 
-    INSTANTIATE_TEST_CASE_P(reshape_squeeze_reshape_relu, ReshapeSqueezeReshapeRelu,
+    INSTANTIATE_TEST_CASE_P(smoke_reshape_squeeze_reshape_relu, ReshapeSqueezeReshapeRelu,
                             ::testing::Combine(
                                     ::testing::ValuesIn(inputs_squeeze),
                                     ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/subgraph_tests/scale_shift.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/subgraph_tests/scale_shift.cpp
@@ -47,7 +47,7 @@ std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precis
 
 }  // namespace
 
-INSTANTIATE_TEST_CASE_P(ScaleShift, ScaleShiftLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_ScaleShift, ScaleShiftLayerTest,
                         ::testing::Combine(
                                 ::testing::ValuesIn(inShapes),
                                 ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/subgraph_tests/split_conv_concat.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/subgraph_tests/split_conv_concat.cpp
@@ -15,7 +15,7 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
         InferenceEngine::Precision::FP16
 };
 
-INSTANTIATE_TEST_CASE_P(NoReshape, SplitConvConcat,
+INSTANTIATE_TEST_CASE_P(smoke_NoReshape, SplitConvConcat,
                         ::testing::Combine(
                                 ::testing::ValuesIn(netPrecisions),
                                 ::testing::Values(std::vector<size_t >({1, 6, 40, 40})),


### PR DESCRIPTION
Separation functional tests to the pre-commit (`gtest_filter=*smoke*`) and nightly scope (`gtest_filter=*nightly *`).
Default value is `smoke`. But after this merge you could change it.
CC @azhogov @mikhail-treskin 