### PR TITLE
[IE Tests] Added test filters for ieFuncTests target

### DIFF
--- a/inference-engine/tests/functional/inference_engine/async_infer_request_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/async_infer_request_test.cpp
@@ -13,73 +13,73 @@ using namespace InferenceEngine;
 using namespace InferenceEngine::details;
 
 
-TEST(InferRequestCPPTests, throwsOnInitWithNull) {
+TEST(TransformationTests, smoke_throwsOnInitWithNull) {
     IInferRequest::Ptr nlptr = nullptr;
     ASSERT_THROW(InferRequest req(nlptr), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST(InferRequestCPPTests, throwsOnUninitializedSetBlob) {
+TEST(TransformationTests, smoke_throwsOnUninitializedSetBlob) {
     InferRequest req;
     ASSERT_THROW(req.SetBlob({}, {}), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST(InferRequestCPPTests, throwsOnUninitializedGetBlob) {
+TEST(TransformationTests, smoke_throwsOnUninitializedGetBlob) {
     InferRequest req;
     ASSERT_THROW(req.GetBlob({}), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST(InferRequestCPPTests, throwsOnUninitializedSetBlobPreproc) {
+TEST(TransformationTests, smoke_throwsOnUninitializedSetBlobPreproc) {
     InferRequest req;
     ASSERT_THROW(req.SetBlob({}, {}, {}), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST(InferRequestCPPTests, throwsOnUninitializedGetPreProcess) {
+TEST(TransformationTests, smoke_throwsOnUninitializedGetPreProcess) {
     InferRequest req;
     ASSERT_THROW(req.GetPreProcess({}), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST(InferRequestCPPTests, throwsOnUninitializedInfer) {
+TEST(TransformationTests, smoke_throwsOnUninitializedInfer) {
     InferRequest req;
     ASSERT_THROW(req.Infer(), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST(InferRequestCPPTests, throwsOnUninitializedGetPerformanceCounts) {
+TEST(TransformationTests, smoke_throwsOnUninitializedGetPerformanceCounts) {
     InferRequest req;
     ASSERT_THROW(req.GetPerformanceCounts(), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST(InferRequestCPPTests, throwsOnUninitializedSetInput) {
+TEST(TransformationTests, smoke_throwsOnUninitializedSetInput) {
     InferRequest req;
     ASSERT_THROW(req.SetInput({{}}), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST(InferRequestCPPTests, throwsOnUninitializedSetOutput) {
+TEST(TransformationTests, smoke_throwsOnUninitializedSetOutput) {
     InferRequest req;
     ASSERT_THROW(req.SetOutput({{}}), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST(InferRequestCPPTests, throwsOnUninitializedSetBatch) {
+TEST(TransformationTests, smoke_throwsOnUninitializedSetBatch) {
     InferRequest req;
     ASSERT_THROW(req.SetBatch({}), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST(InferRequestCPPTests, throwsOnUninitializedStartAsync) {
+TEST(TransformationTests, smoke_throwsOnUninitializedStartAsync) {
     InferRequest req;
     ASSERT_THROW(req.StartAsync(), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST(InferRequestCPPTests, throwsOnUninitializedWait) {
+TEST(TransformationTests, smoke_throwsOnUninitializedWait) {
     InferRequest req;
     ASSERT_THROW(req.Wait({}), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST(InferRequestCPPTests, throwsOnUninitializedSetCompletionCallback) {
+TEST(TransformationTests, smoke_throwsOnUninitializedSetCompletionCallback) {
     InferRequest req;
     std::function<void(InferRequest, StatusCode)> f;
     ASSERT_THROW(req.SetCompletionCallback(f), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST(InferRequestCPPTests, throwsOnUninitializedCast) {
+TEST(TransformationTests, smoke_throwsOnUninitializedCast) {
     InferRequest req;
     ASSERT_THROW(auto &ireq = static_cast<IInferRequest::Ptr &>(req), InferenceEngine::details::InferenceEngineException);
 }

--- a/inference-engine/tests/functional/inference_engine/blob_copy_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/blob_copy_test.cpp
@@ -233,7 +233,7 @@ bool IsCorrectBlobCopy(Blob::Ptr& srcBlob, Blob::Ptr& dstBlob) {
 
 using BlobCopyTest = ::testing::TestWithParam <std::tuple<IsInterleaved, IsInterleaved, BatchNum, ChannelNum, Dims, PrecisionType >>;
 
-TEST_P(BlobCopyTest, BlobCopy) {
+TEST_P(BlobCopyTest, smoke_BlobCopy) {
     IsInterleaved srcIsInterleaved = get<0>(GetParam());
     IsInterleaved dstIsInterleaved = get<1>(GetParam());
     BatchNum batchNum = get<2>(GetParam());
@@ -309,7 +309,7 @@ std::vector<PrecisionType> BlobCopy_PrecisionParams = {
 
 }  // namespace
 
-INSTANTIATE_TEST_CASE_P(accuracy, BlobCopyTest,
+INSTANTIATE_TEST_CASE_P(smoke_accuracy, BlobCopyTest,
                         ::testing::Combine(::testing::ValuesIn(BlobCopy_srcLayoutParam),
                            ::testing::ValuesIn(BlobCopy_dstLayoutParam),
                            ::testing::ValuesIn(BlobCopy_BatchNum),
@@ -449,7 +449,7 @@ TEST_P(BlobCopySetLayoutTest, BlobCopyWithNCHW_To_NHWC_After_setLayout) {
     ASSERT_TRUE(IsEqualBlobCopy(ref, dst)) << "'blob_copy' after setLayout function is not correct";
 }
 
-INSTANTIATE_TEST_CASE_P(accuracy, BlobCopySetLayoutTest,
+INSTANTIATE_TEST_CASE_P(smoke_accuracy, BlobCopySetLayoutTest,
     ::testing::Combine(::testing::ValuesIn(BlobCopySetLayout_Dims),
                        ::testing::ValuesIn(BlobCopySetLayout_Precisions)));
 

--- a/inference-engine/tests/functional/inference_engine/caseless_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/caseless_tests.cpp
@@ -12,19 +12,19 @@ using namespace InferenceEngine::details;
 
 using CaselessTests = ::testing::Test;
 
-TEST_F(CaselessTests, emptyAreEqual) {
+TEST_F(CaselessTests, smoke_emptyAreEqual) {
     ASSERT_TRUE(InferenceEngine::details::equal("", ""));
 }
 
-TEST_F(CaselessTests, canIgnoreCase) {
+TEST_F(CaselessTests, smoke_canIgnoreCase) {
     ASSERT_TRUE(InferenceEngine::details::equal("abc", "ABC"));
 }
 
-TEST_F(CaselessTests, emptyIsNotEqualNotEmpty) {
+TEST_F(CaselessTests, smoke_emptyIsNotEqualNotEmpty) {
     ASSERT_FALSE(InferenceEngine::details::equal("", "abc"));
 }
 
-TEST_F(CaselessTests, canFindCaslessInMap) {
+TEST_F(CaselessTests, smoke_canFindCaslessInMap) {
     caseless_map<string, int> storage = {
         {"Abc", 1},
         {"bC", 2},
@@ -38,7 +38,7 @@ TEST_F(CaselessTests, canFindCaslessInMap) {
     ASSERT_EQ(storage.find(""), storage.end());
 }
 
-TEST_F(CaselessTests, canFindCaslessInUnordered) {
+TEST_F(CaselessTests, smoke_canFindCaslessInUnordered) {
     caseless_unordered_map <string, int> storage = {
         {"Abc", 1},
         {"bC", 2},

--- a/inference-engine/tests/functional/inference_engine/cnn_network/cnn_ngraph_impl_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/cnn_network/cnn_ngraph_impl_tests.cpp
@@ -5,17 +5,14 @@
 #include <gtest/gtest.h>
 
 #include <legacy/cnn_network_impl.hpp>
-#include <legacy/details/ie_cnn_network_iterator.hpp>
 #include <string>
-#include <sstream>
-#include <fstream>
 #include <memory>
-#include <map>
 
 #include <cpp/ie_cnn_network.h>
 #include <legacy/ie_util_internal.hpp>
 #include <ie_parameter.hpp>
 #include <ie_core.hpp>
+#include <cnn_network_ngraph_impl.hpp>
 #include <legacy/net_pass.h>
 #include <generic_ie.hpp>
 #include <legacy/convert_function_to_cnn_network.hpp>
@@ -32,19 +29,16 @@
 #include <ngraph/op/relu.hpp>
 #include <ngraph/op/prelu.hpp>
 #include <ngraph/op/result.hpp>
-#include <common_test_utils/ngraph_test_utils.hpp>
 
 #include "common_test_utils/file_utils.hpp"
 #include "common_test_utils/common_utils.hpp"
-#include "transformations/rt_info/primitives_priority_attribute.hpp"
-#include "cnn_network_ngraph_impl.hpp"
 
 using namespace testing;
 using namespace InferenceEngine;
 
 IE_SUPPRESS_DEPRECATED_START
 
-TEST(CNNNGraphImplTests, TestConvertWithRemoveLastLayerNetwork) {
+TEST(CNNNGraphImplTests, smoke_TestConvertWithRemoveLastLayerNetwork) {
     std::shared_ptr<ngraph::Function> ngraph;
     {
         ngraph::PartialShape shape({1, 3, 22, 22});
@@ -70,7 +64,7 @@ TEST(CNNNGraphImplTests, TestConvertWithRemoveLastLayerNetwork) {
     ASSERT_NO_THROW(cloneNet(*convertedNet));
 }
 
-TEST(CNNNGraphImplTests, TestResultWithNotEqualName) {
+TEST(CNNNGraphImplTests, smoke_TestResultWithNotEqualName) {
     std::shared_ptr<ngraph::Function> ngraph;
     {
         ngraph::PartialShape shape({1, 3, 22, 22});
@@ -91,7 +85,7 @@ TEST(CNNNGraphImplTests, TestResultWithNotEqualName) {
     ASSERT_NO_THROW(auto convertedNet = std::make_shared<details::CNNNetworkImpl>(cnnNet));
 }
 
-TEST(CNNNGraphImplTests, TestGetOutputAfterConvertNetwork) {
+TEST(CNNNGraphImplTests, smoke_TestGetOutputAfterConvertNetwork) {
     const std::string testLayerName = "testReLU";
     std::shared_ptr<ngraph::Function> ngraph;
     {
@@ -121,7 +115,7 @@ TEST(CNNNGraphImplTests, TestGetOutputAfterConvertNetwork) {
     ASSERT_EQ(2, convertedOuts.size());
 }
 
-TEST(CNNNGraphImplTests, TestSetCurrentBatch) {
+TEST(CNNNGraphImplTests, smoke_TestSetCurrentBatch) {
     std::shared_ptr<ngraph::Function> ngraph;
     {
         ngraph::PartialShape shape({1, 3, 22, 22});
@@ -143,7 +137,7 @@ TEST(CNNNGraphImplTests, TestSetCurrentBatch) {
     ASSERT_NE(nullptr, cnnNet.getFunction());
 }
 
-TEST(CNNNGraphImplTests, TestSetBatch) {
+TEST(CNNNGraphImplTests, smoke_TestSetBatch) {
     std::shared_ptr<ngraph::Function> ngraph;
     {
         ngraph::PartialShape shape({1, 3, 22, 22});
@@ -165,7 +159,7 @@ TEST(CNNNGraphImplTests, TestSetBatch) {
     ASSERT_EQ(nullptr, cnnNet.getFunction());
 }
 
-TEST(CNNNGraphImplTests, TestGetBatchScalar) {
+TEST(CNNNGraphImplTests, smoke_TestGetBatchScalar) {
     std::shared_ptr<ngraph::Function> ngraph;
     {
         ngraph::Shape shape({});
@@ -184,7 +178,7 @@ TEST(CNNNGraphImplTests, TestGetBatchScalar) {
     ASSERT_EQ(1, cnnNet.getBatchSize());
 }
 
-TEST(CNNNGraphImplTests, TestSetBatchScalar) {
+TEST(CNNNGraphImplTests, smoke_TestSetBatchScalar) {
     std::shared_ptr<ngraph::Function> ngraph;
     {
         ngraph::Shape shape({});
@@ -204,7 +198,7 @@ TEST(CNNNGraphImplTests, TestSetBatchScalar) {
     ASSERT_EQ(PARAMETER_MISMATCH, cnnNet.setBatchSize(2, nullptr));  // triggers conversion
 }
 
-TEST(CNNNGraphImplTests, TestSaveAffinity) {
+TEST(CNNNGraphImplTests, smoke_TestSaveAffinity) {
     const std::string testAffinity = "testAffinity";
     std::shared_ptr<ngraph::Function> ngraph;
     {
@@ -230,7 +224,7 @@ TEST(CNNNGraphImplTests, TestSaveAffinity) {
     ASSERT_EQ(cnnLayer->affinity, testAffinity);
 }
 
-TEST(CNNNGraphImplTests, TestAddOutput) {
+TEST(CNNNGraphImplTests, smoke_TestAddOutput) {
     const std::string testLayerName = "testReLU";
     std::shared_ptr<ngraph::Function> ngraph;
     {
@@ -262,7 +256,7 @@ TEST(CNNNGraphImplTests, TestAddOutput) {
     ASSERT_TRUE(outputs.find(testLayerName) != outputs.end());
 }
 
-TEST(CNNNGraphImplTests, TestAddOutputFromConvertedNetwork) {
+TEST(CNNNGraphImplTests, smoke_TestAddOutputFromConvertedNetwork) {
     const std::string testLayerName = "testReLU";
     std::shared_ptr<ngraph::Function> ngraph;
     {
@@ -296,7 +290,7 @@ TEST(CNNNGraphImplTests, TestAddOutputFromConvertedNetwork) {
     ASSERT_TRUE(outputs.find(testLayerName) != outputs.end());
 }
 
-TEST(CNNNGraphImplTests, ConstantAsInternalAndExternalLayer) {
+TEST(CNNNGraphImplTests, smoke_ConstantAsInternalAndExternalLayer) {
     std::shared_ptr<ngraph::Function> ngraph;
     {
         ngraph::PartialShape shape({1, 3, 22, 22});
@@ -318,7 +312,7 @@ TEST(CNNNGraphImplTests, ConstantAsInternalAndExternalLayer) {
     ASSERT_EQ(4, convertedNetwork->layerCount());
 }
 
-TEST(CNNNGraphImplTests, SaveInputInfoAfterConversion) {
+TEST(CNNNGraphImplTests, smoke_SaveInputInfoAfterConversion) {
     std::string name = "param";
     std::shared_ptr<ngraph::Function> ngraph;
     {
@@ -348,7 +342,7 @@ TEST(CNNNGraphImplTests, SaveInputInfoAfterConversion) {
     ASSERT_EQ(inputInfo->getPreProcess().getResizeAlgorithm(), ResizeAlgorithm::RESIZE_AREA);
 }
 
-TEST(CNNNGraphImplTests, SavePrimitivesPriority) {
+TEST(CNNNGraphImplTests, smoke_SavePrimitivesPriority) {
     std::string model = R"V0G0N(
 <net name="Activation" version="10">
     <layers>
@@ -410,7 +404,7 @@ TEST(CNNNGraphImplTests, SavePrimitivesPriority) {
     ASSERT_EQ("cpu:avx2", cnnLayer->params["PrimitivesPriority"]);
 }
 
-TEST(CNNNGraphImplTests, ReadFromCNNNetReader) {
+TEST(CNNNGraphImplTests, smoke_ReadFromCNNNetReader) {
     std::string model = R"V0G0N(
 <net name="Activation" version="10">
     <layers>
@@ -465,7 +459,7 @@ TEST(CNNNGraphImplTests, ReadFromCNNNetReader) {
     ASSERT_EQ(3, network.layerCount());
 }
 
-TEST(CNNNGraphImplTests, ReadMeanImageFromCNNNetReader) {
+TEST(CNNNGraphImplTests, smoke_ReadMeanImageFromCNNNetReader) {
     std::string model = R"V0G0N(
 <net name="Activation" version="10">
     <pre-process mean-precision="FP32" reference-layer-name="data">
@@ -559,7 +553,7 @@ TEST(CNNNGraphImplTests, ReadMeanImageFromCNNNetReader) {
     }
 }
 
-TEST(CNNNGraphImplTests, CanChangeInputPrecision) {
+TEST(CNNNGraphImplTests, smoke_CanChangeInputPrecision) {
     std::shared_ptr<ngraph::Function> ngraph;
     {
         ngraph::PartialShape shape({1, 3, 16, 16});
@@ -608,7 +602,7 @@ TEST(CNNNGraphImplTests, CanChangeInputPrecision) {
     }
 }
 
-TEST(CNNNGraphImplTests, CanChangeInputLayout) {
+TEST(CNNNGraphImplTests, smoke_CanChangeInputLayout) {
     std::shared_ptr<ngraph::Function> ngraph;
     {
         ngraph::PartialShape shape({1, 3, 16, 16});
@@ -657,7 +651,7 @@ TEST(CNNNGraphImplTests, CanChangeInputLayout) {
     }
 }
 
-TEST(CNNNGraphImplTests, CanChangeOutputPrecision) {
+TEST(CNNNGraphImplTests, smoke_CanChangeOutputPrecision) {
     std::shared_ptr<ngraph::Function> ngraph;
     {
         ngraph::PartialShape shape({1, 3, 16, 16});
@@ -706,7 +700,7 @@ TEST(CNNNGraphImplTests, CanChangeOutputPrecision) {
     }
 }
 
-TEST(CNNNGraphImplTests, CanChangeOutputLayout) {
+TEST(CNNNGraphImplTests, smoke_CanChangeOutputLayout) {
     std::shared_ptr<ngraph::Function> ngraph;
     {
         ngraph::PartialShape shape({1, 3, 16, 16});
@@ -755,7 +749,7 @@ TEST(CNNNGraphImplTests, CanChangeOutputLayout) {
     }
 }
 
-TEST(CNNNGraphImplTests, TestCheckStats) {
+TEST(CNNNGraphImplTests, smoke_TestCheckStats) {
     std::shared_ptr<ngraph::Function> ngraph;
     {
         ngraph::PartialShape shape({1, 3, 22, 22});
@@ -773,7 +767,7 @@ TEST(CNNNGraphImplTests, TestCheckStats) {
     InferenceEngine::details::CNNNetworkNGraphImpl cnnNet(ngraph);
 }
 
-TEST(CNNNGraphImplTests, CanSetBatchReadValue) {
+TEST(CNNNGraphImplTests, smoke_CanSetBatchReadValue) {
     std::shared_ptr<ngraph::Function> ngraph;
     {
         auto input = std::make_shared<ngraph::opset3::Parameter>(ngraph::element::f32, ngraph::Shape{1, 2});
@@ -796,7 +790,7 @@ TEST(CNNNGraphImplTests, CanSetBatchReadValue) {
     EXPECT_EQ(status, StatusCode::OK);
 }
 
-TEST(CNNNGraphImplTests, addSameOutput) {
+TEST(CNNNGraphImplTests, smoke_addSameOutput) {
     std::shared_ptr<ngraph::Function> ngraph;
     {
         ngraph::PartialShape shape({1, 3, 22, 22});
@@ -823,7 +817,7 @@ TEST(CNNNGraphImplTests, addSameOutput) {
     ASSERT_EQ(outputs["reshape"]->getLayout(), InferenceEngine::Layout::NCHW);
 }
 
-TEST(CNNNGraphImplTests, addOutput) {
+TEST(CNNNGraphImplTests, smoke_addOutput) {
     std::shared_ptr<ngraph::Function> ngraph;
     {
         ngraph::PartialShape shape({1, 3, 22, 22});
@@ -851,7 +845,7 @@ TEST(CNNNGraphImplTests, addOutput) {
     ASSERT_EQ(outputs["reshape"]->getLayout(), InferenceEngine::Layout::NCHW);
 }
 
-TEST(CNNNGraphImplTests, addOutputForParameter) {
+TEST(CNNNGraphImplTests, smoke_addOutputForParameter) {
     std::shared_ptr<ngraph::Function> ngraph;
     {
         ngraph::PartialShape shape({1, 3, 22, 22});
@@ -884,7 +878,7 @@ TEST(CNNNGraphImplTests, addOutputForParameter) {
     }
 }
 
-TEST(CNNNGraphImplTests, AddOutputToExperimentalOp) {
+TEST(CNNNGraphImplTests, smoke_AddOutputToExperimentalOp) {
     std::string model = R"V0G0N(
 <net name="Activation" version="10">
     <layers>
@@ -960,7 +954,7 @@ TEST(CNNNGraphImplTests, AddOutputToExperimentalOp) {
     ASSERT_NE(outputs.find("exp.0"), outputs.end());
 }
 
-TEST(CNNNGraphImplTests, SaveOriginalResultNameForMultiOutputOp) {
+TEST(CNNNGraphImplTests, smoke_SaveOriginalResultNameForMultiOutputOp) {
     std::string model = R"V0G0N(
 <net name="Activation" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/cnn_network/convert_ngraph_to_cnn_network_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/cnn_network/convert_ngraph_to_cnn_network_tests.cpp
@@ -24,7 +24,7 @@
 using namespace testing;
 using namespace InferenceEngine;
 
-TEST(ConvertFunctionToCNNNetworkTests, ConvertPReLUNetwork) {
+TEST(ConvertFunctionToCNNNetworkTests, smoke_ConvertPReLUNetwork) {
     std::shared_ptr<ngraph::Function> f;
     {
         auto param1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{2, 2});
@@ -49,7 +49,7 @@ TEST(ConvertFunctionToCNNNetworkTests, ConvertPReLUNetwork) {
     }
 }
 
-TEST(ConvertFunctionToCNNNetworkTests, ConvertConvolutionNetwork) {
+TEST(ConvertFunctionToCNNNetworkTests, smoke_ConvertConvolutionNetwork) {
     std::shared_ptr<ngraph::Function> f;
     {
         auto param1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 64, 64});
@@ -76,7 +76,7 @@ TEST(ConvertFunctionToCNNNetworkTests, ConvertConvolutionNetwork) {
     }
 }
 
-TEST(ConvertFunctionToCNNNetworkTests, OpsShouldBeConvertedToIERepresentation) {
+TEST(ConvertFunctionToCNNNetworkTests, smoke_OpsShouldBeConvertedToIERepresentation) {
     ngraph::NodeVector should_converted_to_ie = {
             std::make_shared<ngraph::opset4::Broadcast>(),
             std::make_shared<ngraph::opset4::Convolution>(),
@@ -151,7 +151,7 @@ TEST(ConvertFunctionToCNNNetworkTests, OpsShouldBeConvertedToIERepresentation) {
     }
 }
 
-TEST(ConvertFunctionToCNNNetworkTests, ConvertTopKWithOneInput) {
+TEST(ConvertFunctionToCNNNetworkTests, smoke_ConvertTopKWithOneInput) {
     std::shared_ptr<ngraph::Function> f;
     {
         auto param = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 22, 22});

--- a/inference-engine/tests/functional/inference_engine/cnn_network/smart_reshape_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/cnn_network/smart_reshape_tests.cpp
@@ -68,7 +68,7 @@ public:
 TEST_P(CNNNGraphImplSmartReshapeTests, ReshapeMatMul) {
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, CNNNGraphImplSmartReshapeTests, testing::Values(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, CNNNGraphImplSmartReshapeTests, testing::Values(
         ReshapeMatMulTestCase{true, {1, 20, 30}, {30, 40}, {20, -1}, false, false, {{"input_A", {2, 20, 30}}}},
         ReshapeMatMulTestCase{true, {1, 20, 30}, {40, 30}, {20, -1}, false, true, {{"input_A", {2, 20, 30}}}},
         ReshapeMatMulTestCase{true, {1, 30, 20}, {30, 20}, {-1, 20}, true, false, {{"input_A", {2, 30, 20}}}},

--- a/inference-engine/tests/functional/inference_engine/cnn_network_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/cnn_network_test.cpp
@@ -9,62 +9,62 @@ using namespace InferenceEngine;
 
 using CNNNetworkTests = ::testing::Test;
 
-TEST_F(CNNNetworkTests, throwsOnInitWithNull) {
+TEST_F(CNNNetworkTests, smoke_throwsOnInitWithNull) {
     std::shared_ptr<ICNNNetwork> nlptr = nullptr;
     ASSERT_THROW(CNNNetwork network(nlptr), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST_F(CNNNetworkTests, throwsOnInitWithNullNgraph) {
+TEST_F(CNNNetworkTests, smoke_throwsOnInitWithNullNgraph) {
     std::shared_ptr<ngraph::Function> nlptr = nullptr;
     ASSERT_THROW(CNNNetwork network(nlptr), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST_F(CNNNetworkTests, throwsOnUninitializedGetOutputsInfo) {
+TEST_F(CNNNetworkTests, smoke_throwsOnUninitializedGetOutputsInfo) {
     CNNNetwork network;
     ASSERT_THROW(network.getOutputsInfo(), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST_F(CNNNetworkTests, throwsOnUninitializedGetInputsInfo) {
+TEST_F(CNNNetworkTests, smoke_throwsOnUninitializedGetInputsInfo) {
     CNNNetwork network;
     ASSERT_THROW(network.getInputsInfo(), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST_F(CNNNetworkTests, throwsOnUninitializedLayerCount) {
+TEST_F(CNNNetworkTests, smoke_throwsOnUninitializedLayerCount) {
     CNNNetwork network;
     ASSERT_THROW(network.layerCount(), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST_F(CNNNetworkTests, throwsOnUninitializedGetName) {
+TEST_F(CNNNetworkTests, smoke_throwsOnUninitializedGetName) {
     CNNNetwork network;
     ASSERT_THROW(network.getName(), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST_F(CNNNetworkTests, throwsOnUninitializedCastToICNNNetwork) {
+TEST_F(CNNNetworkTests, smoke_throwsOnUninitializedCastToICNNNetwork) {
     CNNNetwork network;
     ASSERT_THROW(auto & net = static_cast<ICNNNetwork&>(network), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST_F(CNNNetworkTests, throwsOnConstUninitializedCastToICNNNetwork) {
+TEST_F(CNNNetworkTests, smoke_throwsOnConstUninitializedCastToICNNNetwork) {
     const CNNNetwork network;
     ASSERT_THROW(const auto & net = static_cast<const ICNNNetwork&>(network), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST_F(CNNNetworkTests, throwsOnUninitializedGetFunction) {
+TEST_F(CNNNetworkTests, smoke_throwsOnUninitializedGetFunction) {
     CNNNetwork network;
     ASSERT_THROW(network.getFunction(), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST_F(CNNNetworkTests, throwsOnConstUninitializedGetFunction) {
+TEST_F(CNNNetworkTests, smoke_throwsOnConstUninitializedGetFunction) {
     const CNNNetwork network;
     ASSERT_THROW(network.getFunction(), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST_F(CNNNetworkTests, throwsOnConstUninitializedBegin) {
+TEST_F(CNNNetworkTests, smoke_throwsOnConstUninitializedBegin) {
     CNNNetwork network;
     ASSERT_THROW(network.getFunction(), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST_F(CNNNetworkTests, throwsOnConstUninitializedGetInputShapes) {
+TEST_F(CNNNetworkTests, smoke_throwsOnConstUninitializedGetInputShapes) {
     CNNNetwork network;
     ASSERT_THROW(network.getInputShapes(), InferenceEngine::details::InferenceEngineException);
 }

--- a/inference-engine/tests/functional/inference_engine/core_threading_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/core_threading_tests.cpp
@@ -57,7 +57,7 @@ public:
 };
 
 // tested function: SetConfig
-TEST_F(CoreThreadingTests, SetConfigPluginDoesNotExist) {
+TEST_F(CoreThreadingTests, smoke_SetConfigPluginDoesNotExist) {
     InferenceEngine::Core ie;
     std::map<std::string, std::string> localConfig = {
         { CONFIG_KEY(PERF_COUNT), InferenceEngine::PluginConfigParams::YES }
@@ -69,7 +69,7 @@ TEST_F(CoreThreadingTests, SetConfigPluginDoesNotExist) {
 }
 
 // tested function: RegisterPlugin
-TEST_F(CoreThreadingTests, RegisterPlugin) {
+TEST_F(CoreThreadingTests, smoke_RegisterPlugin) {
     InferenceEngine::Core ie;
     std::atomic<int> index{0};
     runParallel([&] () {
@@ -81,7 +81,7 @@ TEST_F(CoreThreadingTests, RegisterPlugin) {
 }
 
 // tested function: RegisterPlugins
-TEST_F(CoreThreadingTests, RegisterPlugins) {
+TEST_F(CoreThreadingTests, smoke_RegisterPlugins) {
     InferenceEngine::Core ie;
     std::atomic<unsigned int> index{0};
 
@@ -118,7 +118,7 @@ TEST_F(CoreThreadingTests, RegisterPlugins) {
 
 // tested function: GetAvailableDevices, UnregisterPlugin
 // TODO: some plugins initialization (e.g. GNA) failed during such stress-test scenario
-TEST_F(CoreThreadingTests, DISABLED_GetAvailableDevices) {
+TEST_F(CoreThreadingTests, DISABLED_smoke_GetAvailableDevices) {
     InferenceEngine::Core ie;
     runParallel([&] () {
         std::vector<std::string> devices = ie.GetAvailableDevices();
@@ -137,7 +137,7 @@ TEST_F(CoreThreadingTests, DISABLED_GetAvailableDevices) {
 }
 
 // tested function: ReadNetwork, AddExtension
-TEST_F(CoreThreadingTests, ReadNetwork) {
+TEST_F(CoreThreadingTests, smoke_ReadNetwork) {
     InferenceEngine::Core ie;
     auto model = FuncTestUtils::TestModel::convReluNormPoolFcModelFP32;
     auto network = ie.ReadNetwork(model.model_xml_str, model.weights_blob);

--- a/inference-engine/tests/functional/inference_engine/data_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/data_test.cpp
@@ -31,69 +31,69 @@ protected:
     };
 };
 
-TEST_F(DataTests, canSetEmptyDimsForDataDefault) {
+TEST_F(DataTests, smoke_canSetEmptyDimsForDataDefault) {
     Data data(data_name, precision);
     ASSERT_NO_THROW(data.setDims(emptyDims));
     ASSERT_FALSE(data.isInitialized());
 }
 
-TEST_F(DataTests, canSetEmptyDimsForDataBlocked) {
+TEST_F(DataTests, smoke_canSetEmptyDimsForDataBlocked) {
     Data data(data_name, precision, BLOCKED);
     ASSERT_NO_THROW(data.setDims(emptyDims));
 }
 
-TEST_F(DataTests, canSetNotEmptyDimsForDataBlocked) {
+TEST_F(DataTests, smoke_canSetNotEmptyDimsForDataBlocked) {
     Data data(data_name, precision, BLOCKED);
     ASSERT_NO_THROW(data.setDims(notEmptyDims));
 }
 
-TEST_F(DataTests, canSetNotEmptyDimsForDataNCHW) {
+TEST_F(DataTests, smoke_canSetNotEmptyDimsForDataNCHW) {
     Data data(data_name, precision, NCHW);
     ASSERT_NO_THROW(data.setDims(notEmptyDims));
     ASSERT_TRUE(data.isInitialized());
 }
 
-TEST_F(DataTests, canSetEmptyDimsForTensorDescNCHW) {
+TEST_F(DataTests, smoke_canSetEmptyDimsForTensorDescNCHW) {
     TensorDesc desc(precision, emptyDims, NCHW);
     ASSERT_NO_THROW(desc.setDims(emptyDims));
 }
 
-TEST_F(DataTests, canSetEmptyDimsForTensorDescBlocked) {
+TEST_F(DataTests, smoke_canSetEmptyDimsForTensorDescBlocked) {
     TensorDesc desc(precision, emptyDims, BLOCKED);
     ASSERT_NO_THROW(desc.setDims(emptyDims));
 }
 
-TEST_F(DataTests, canSetNotEmptyDimsForTensorDescBlocked) {
+TEST_F(DataTests, smoke_canSetNotEmptyDimsForTensorDescBlocked) {
     TensorDesc desc(precision, notEmptyDims, BLOCKED);
     ASSERT_NO_THROW(desc.setDims(notEmptyDims));
 }
 
-TEST_F(DataTests, canSetEmptyDimsForBlockingDescOrder) {
+TEST_F(DataTests, smoke_canSetEmptyDimsForBlockingDescOrder) {
     ASSERT_NO_THROW(BlockingDesc(emptyDims, emptyDims));
 }
 
-TEST_F(DataTests, throwOnFillDescByEmptyDimsForBlockingDesc) {
+TEST_F(DataTests, smoke_throwOnFillDescByEmptyDimsForBlockingDesc) {
     BlockingDescTest desc(emptyDims, emptyDims);
     ASSERT_THROW(desc.fillDescTest(emptyDims, emptyDims), InferenceEngineException);
 }
 
-TEST_F(DataTests, throwOnSetEmptyDimsForBlockingDescBlocked) {
+TEST_F(DataTests, smoke_throwOnSetEmptyDimsForBlockingDescBlocked) {
     ASSERT_NO_THROW(BlockingDesc(emptyDims, BLOCKED));
 }
 
-TEST_F(DataTests, throwOnSetEmptyDimsForBlockingDescNCHW) {
+TEST_F(DataTests, smoke_throwOnSetEmptyDimsForBlockingDescNCHW) {
     ASSERT_NO_THROW(BlockingDesc(emptyDims, NCHW));
 }
 
-TEST_F(DataTests, canSetNotEmptyDimsForBlockingDescBlocked) {
+TEST_F(DataTests, smoke_canSetNotEmptyDimsForBlockingDescBlocked) {
     ASSERT_NO_THROW(BlockingDesc(notEmptyDims, BLOCKED));
 }
 
-TEST_F(DataTests, canSetNotEmptyDimsForBlockingDescNCHW) {
+TEST_F(DataTests, smoke_canSetNotEmptyDimsForBlockingDescNCHW) {
     ASSERT_NO_THROW(BlockingDesc(notEmptyDims, NCHW));
 }
 
-TEST_F(DataTests, setPrecision) {
+TEST_F(DataTests, smoke_setPrecision) {
     Data data(data_name, { Precision::FP32, emptyDims, Layout::NCHW });
 
     EXPECT_EQ(Precision::FP32, data.getPrecision());

--- a/inference-engine/tests/functional/inference_engine/debug_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/debug_tests.cpp
@@ -8,12 +8,12 @@
 
 using DebugTests = ::testing::Test;
 
-TEST_F(DebugTests, tolowerWorksWithEmptyString) {
+TEST_F(DebugTests, smoke_tolowerWorksWithEmptyString) {
     std::string str = "";
     ASSERT_STREQ("", InferenceEngine::details::tolower(str).c_str());
 }
 
-TEST_F(DebugTests, shouldConvertToLowerCase) {
+TEST_F(DebugTests, smoke_shouldConvertToLowerCase) {
     std::string str = "Hello, World!1";
     ASSERT_STREQ("hello, world!1", InferenceEngine::details::tolower(str).c_str());
 }

--- a/inference-engine/tests/functional/inference_engine/exception_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/exception_test.cpp
@@ -24,7 +24,7 @@ public:
 };
 
 // TO_STATUS macros tests
-TEST_F(ExceptionTests, canConvertToStatus) {
+TEST_F(ExceptionTests, smoke_canConvertToStatus) {
     ResponseDesc *resp = nullptr;
     ASSERT_EQ(WrapperClass<StatusCode::GENERAL_ERROR>::toStatusWrapper(resp), StatusCode::GENERAL_ERROR);
     ASSERT_EQ(WrapperClass<StatusCode::NOT_IMPLEMENTED>::toStatusWrapper(resp), StatusCode::NOT_IMPLEMENTED);
@@ -40,12 +40,12 @@ TEST_F(ExceptionTests, canConvertToStatus) {
 }
 
 // CALL_STATUS_FNC macros tests
-TEST_F(ExceptionTests, canConvertStatusToException) {
+TEST_F(ExceptionTests, smoke_canConvertStatusToException) {
     auto actual = std::make_shared<WrapperClass<StatusCode::INFER_NOT_STARTED>>();
     ASSERT_THROW(CALL_STATUS_FNC_NO_ARGS(toStatusWrapper), InferenceEngine::InferNotStarted);
 }
 
-TEST_F(ExceptionTests, canHandleNullPtr) {
+TEST_F(ExceptionTests, smoke_canHandleNullPtr) {
     class Mock {
     public:
         StatusCode func0(ResponseDesc*) {return StatusCode ::OK;}
@@ -58,7 +58,7 @@ TEST_F(ExceptionTests, canHandleNullPtr) {
     ASSERT_THROW(CALL_STATUS_FNC(func1, 0), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST_F(ExceptionTests, throwAfterConvertStatusToClassContainMessage) {
+TEST_F(ExceptionTests, smoke_throwAfterConvertStatusToClassContainMessage) {
     std::string refMessage = "Exception message!";
     auto actual = std::make_shared<WrapperClass<StatusCode::NOT_ALLOCATED>>();
     try {

--- a/inference-engine/tests/functional/inference_engine/executable_network.cpp
+++ b/inference-engine/tests/functional/inference_engine/executable_network.cpp
@@ -10,62 +10,62 @@ using namespace std;
 using namespace InferenceEngine;
 using namespace InferenceEngine::details;
 
-TEST(ExecutableNetworkTests, throwsOnInitWithNull) {
+TEST(ExecutableNetworkTests, smoke_throwsOnInitWithNull) {
     std::shared_ptr<IExecutableNetwork> nlptr = nullptr;
     ASSERT_THROW(ExecutableNetwork exec(nlptr), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST(ExecutableNetworkTests, throwsOnUninitializedGetOutputsInfo) {
+TEST(ExecutableNetworkTests, smoke_throwsOnUninitializedGetOutputsInfo) {
     ExecutableNetwork exec;
     ASSERT_THROW(exec.GetOutputsInfo(), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST(ExecutableNetworkTests, throwsOnUninitializedGetInputsInfo) {
+TEST(ExecutableNetworkTests, smoke_throwsOnUninitializedGetInputsInfo) {
     ExecutableNetwork exec;
     ASSERT_THROW(exec.GetInputsInfo(), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST(ExecutableNetworkTests, throwsOnUninitializedExport) {
+TEST(ExecutableNetworkTests, smoke_throwsOnUninitializedExport) {
     ExecutableNetwork exec;
     ASSERT_THROW(exec.Export(std::string()), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST(ExecutableNetworkTests, throwsOnUninitializedExportStream) {
+TEST(ExecutableNetworkTests, smoke_throwsOnUninitializedExportStream) {
     ExecutableNetwork exec;
     ASSERT_THROW(exec.Export(std::cout), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST(ExecutableNetworkTests, nothrowsOnUninitializedCast) {
+TEST(ExecutableNetworkTests, smoke_nothrowsOnUninitializedCast) {
     ExecutableNetwork exec;
     ASSERT_NO_THROW(auto &enet = static_cast<IExecutableNetwork::Ptr &>(exec));
 }
 
-TEST(ExecutableNetworkTests, throwsOnUninitializedGetExecGraphInfo) {
+TEST(ExecutableNetworkTests, smoke_throwsOnUninitializedGetExecGraphInfo) {
     ExecutableNetwork exec;
     ASSERT_THROW(exec.GetExecGraphInfo(), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST(ExecutableNetworkTests, throwsOnUninitializedQueryState) {
+TEST(ExecutableNetworkTests, smoke_throwsOnUninitializedQueryState) {
     ExecutableNetwork exec;
     ASSERT_THROW(exec.QueryState(), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST(ExecutableNetworkTests, throwsOnUninitializedSetConfig) {
+TEST(ExecutableNetworkTests, smoke_throwsOnUninitializedSetConfig) {
     ExecutableNetwork exec;
     ASSERT_THROW(exec.SetConfig({{}}), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST(ExecutableNetworkTests, throwsOnUninitializedGetConfig) {
+TEST(ExecutableNetworkTests, smoke_throwsOnUninitializedGetConfig) {
     ExecutableNetwork exec;
     ASSERT_THROW(exec.GetConfig({}), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST(ExecutableNetworkTests, throwsOnUninitializedGetMetric) {
+TEST(ExecutableNetworkTests, smoke_throwsOnUninitializedGetMetric) {
     ExecutableNetwork exec;
     ASSERT_THROW(exec.GetMetric({}), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST(ExecutableNetworkTests, throwsOnUninitializedGetContext) {
+TEST(ExecutableNetworkTests, smoke_throwsOnUninitializedGetContext) {
     ExecutableNetwork exec;
     ASSERT_THROW(exec.GetContext(), InferenceEngine::details::InferenceEngineException);
 }

--- a/inference-engine/tests/functional/inference_engine/ie_irelease_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/ie_irelease_test.cpp
@@ -15,7 +15,7 @@ using IReleaseTests = CommonTestUtils::TestsCommon;
  * @brief Testing that callback with Release() from  shared_from_irelease(...)
  * won't be applied for nullptr.
  */
-TEST_F(IReleaseTests, sharedFromIReleaseWithNull) {
+TEST_F(IReleaseTests, smoke_sharedFromIReleaseWithNull) {
     InferenceEngine::details::IRelease *irelease = nullptr;
     std::shared_ptr<InferenceEngine::details::IRelease> ptr = InferenceEngine::details::shared_from_irelease(irelease);
     ptr.reset();

--- a/inference-engine/tests/functional/inference_engine/ie_precision_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/ie_precision_test.cpp
@@ -12,7 +12,7 @@ using Precision = InferenceEngine::Precision;
 
 using PrecisionTests = ::testing::Test;
 
-TEST_F(PrecisionTests, ShowsCorrectPrecisionNames) {
+TEST_F(PrecisionTests, smoke_ShowsCorrectPrecisionNames) {
     ASSERT_STREQ(Precision(Precision::I64).name(), "I64");
     ASSERT_STREQ(Precision(Precision::U64).name(), "U64");
     ASSERT_STREQ(Precision(Precision::FP16).name(), "FP16");
@@ -30,7 +30,7 @@ TEST_F(PrecisionTests, ShowsCorrectPrecisionNames) {
     ASSERT_STREQ(Precision(1, "Custom Name").name(), "Custom Name");
 }
 
-TEST_F(PrecisionTests, sizeIsCorrect) {
+TEST_F(PrecisionTests, smoke_sizeIsCorrect) {
     ASSERT_EQ(Precision(Precision::I64).size(), 8);
     ASSERT_EQ(Precision(Precision::U64).size(), 8);
     ASSERT_EQ(Precision(Precision::FP16).size(), 2);
@@ -47,7 +47,7 @@ TEST_F(PrecisionTests, sizeIsCorrect) {
     ASSERT_ANY_THROW(Precision(Precision::UNSPECIFIED).size());
 }
 
-TEST_F(PrecisionTests, is_float) {
+TEST_F(PrecisionTests, smoke_is_float) {
     ASSERT_TRUE(Precision(Precision::FP16).is_float());
     ASSERT_TRUE(Precision(Precision::FP32).is_float());
     ASSERT_FALSE(Precision(Precision::I64).is_float());
@@ -65,7 +65,7 @@ TEST_F(PrecisionTests, is_float) {
     ASSERT_FALSE(Precision(Precision::UNSPECIFIED).is_float());
 }
 
-TEST_F(PrecisionTests, constructFromSTR) {
+TEST_F(PrecisionTests, smoke_constructFromSTR) {
     ASSERT_EQ(Precision(Precision::I64), Precision::FromStr("I64"));
     ASSERT_EQ(Precision(Precision::U64), Precision::FromStr("U64"));
     ASSERT_EQ(Precision(Precision::FP16), Precision::FromStr("FP16"));
@@ -82,7 +82,7 @@ TEST_F(PrecisionTests, constructFromSTR) {
     ASSERT_EQ(Precision(Precision::UNSPECIFIED), Precision::FromStr("UNSPECIFIED"));
 }
 
-TEST_F(PrecisionTests, canCompareCustomPrecisions) {
+TEST_F(PrecisionTests, smoke_canCompareCustomPrecisions) {
     Precision p(12);
     Precision p1(12, "XXX");
     ASSERT_FALSE(p == p1);
@@ -105,7 +105,7 @@ TEST_F(PrecisionTests, canCompareCustomPrecisions) {
 }
 
 
-TEST_F(PrecisionTests, canUseInIfs) {
+TEST_F(PrecisionTests, smoke_canUseInIfs) {
     Precision p;
     ASSERT_TRUE(!p);
     p = Precision::FP32;
@@ -115,7 +115,7 @@ TEST_F(PrecisionTests, canUseInIfs) {
     ASSERT_TRUE(!p);
 }
 
-TEST_F(PrecisionTests, canCreateFromStruct) {
+TEST_F(PrecisionTests, smoke_canCreateFromStruct) {
     struct X {
         int a;
         int b;
@@ -124,7 +124,7 @@ TEST_F(PrecisionTests, canCreateFromStruct) {
     ASSERT_EQ(precision.size(), sizeof(X));
 }
 
-TEST_F(PrecisionTests, canCreateMoreThan255bitsPrecisions) {
+TEST_F(PrecisionTests, smoke_canCreateMoreThan255bitsPrecisions) {
     struct Y {
         uint8_t a[257];
     };

--- a/inference-engine/tests/functional/inference_engine/keep_constant_inputs_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/keep_constant_inputs_tests.cpp
@@ -52,7 +52,7 @@ void transformNetwork(std::shared_ptr<InferenceEngine::ICNNNetwork> & clonedNetw
     }
 }
 
-TEST(KeepConstantInputsTests, ConvertConvolutionPoolReluNetworkWithTrue) {
+TEST(KeepConstantInputsTests, smoke_ConvertConvolutionPoolReluNetworkWithTrue) {
     std::shared_ptr <ngraph::Function> f_ptr;
     f_ptr = ngraph::builder::subgraph::makeConvPoolRelu();
     InferenceEngine::CNNNetwork network(f_ptr);
@@ -61,7 +61,7 @@ TEST(KeepConstantInputsTests, ConvertConvolutionPoolReluNetworkWithTrue) {
     ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "Convolution"), 2);
 }
 
-TEST(KeepConstantInputsTests, ConvertConvolutionPoolReluNetworkWithFalse) {
+TEST(KeepConstantInputsTests, smoke_ConvertConvolutionPoolReluNetworkWithFalse) {
     std::shared_ptr <ngraph::Function> f_ptr;
     f_ptr = ngraph::builder::subgraph::makeConvPoolRelu();
     InferenceEngine::CNNNetwork network(f_ptr);
@@ -70,7 +70,7 @@ TEST(KeepConstantInputsTests, ConvertConvolutionPoolReluNetworkWithFalse) {
     ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "Convolution"), 1);
 }
 
-TEST(KeepConstantInputsTests, ConvertConvolutionBiasNetworkWithTrue) {
+TEST(KeepConstantInputsTests, smoke_ConvertConvolutionBiasNetworkWithTrue) {
     std::shared_ptr <ngraph::Function> f_ptr;
     f_ptr = ngraph::builder::subgraph::makeConvBias();
     InferenceEngine::CNNNetwork network(f_ptr);
@@ -79,7 +79,7 @@ TEST(KeepConstantInputsTests, ConvertConvolutionBiasNetworkWithTrue) {
     ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "Convolution"), 3);
 }
 
-TEST(KeepConstantInputsTests, ConvertConvolutionBiasNetworkWithFalse) {
+TEST(KeepConstantInputsTests, smoke_ConvertConvolutionBiasNetworkWithFalse) {
     std::shared_ptr <ngraph::Function> f_ptr;
     f_ptr = ngraph::builder::subgraph::makeConvBias();
     InferenceEngine::CNNNetwork network(f_ptr);
@@ -88,7 +88,7 @@ TEST(KeepConstantInputsTests, ConvertConvolutionBiasNetworkWithFalse) {
     ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "Convolution"), 1);
 }
 
-TEST(KeepConstantInputsTests, ConvertFullyConnectedNetworkWithTrue) {
+TEST(KeepConstantInputsTests, smoke_ConvertFullyConnectedNetworkWithTrue) {
     std::shared_ptr <ngraph::Function> f_ptr;
     auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 128});
     auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{786, 128}, {1});
@@ -101,7 +101,7 @@ TEST(KeepConstantInputsTests, ConvertFullyConnectedNetworkWithTrue) {
     ASSERT_EQ(numberOfInputsForLayerInCNNNetwork(originalNetwork, "FullyConnected"), 3);
 }
 
-TEST(KeepConstantInputsTests, ConvertFullyConnectedNetworkWithFalse) {
+TEST(KeepConstantInputsTests, smoke_ConvertFullyConnectedNetworkWithFalse) {
     std::shared_ptr <ngraph::Function> f_ptr;
     auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 128});
     auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{786, 128}, {1});

--- a/inference-engine/tests/functional/inference_engine/local_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/local_test.cpp
@@ -242,34 +242,34 @@ protected:
     }
 };
 
-TEST_F(LocaleTests, WithRULocale) {
+TEST_F(LocaleTests, smoke_WithRULocale) {
     setlocale(LC_ALL, "ru_RU.UTF-8");
     testBody();
 }
 
-TEST_F(LocaleTests, WithUSLocale) {
+TEST_F(LocaleTests, smoke_WithUSLocale) {
     setlocale(LC_ALL, "en_US.UTF-8");
     testBody();
 }
 
-TEST_F(LocaleTests, WithRULocaleOnLSTM) {
+TEST_F(LocaleTests, smoke_WithRULocaleOnLSTM) {
     setlocale(LC_ALL, "ru_RU.UTF-8");
     testBody(true);
 }
 
-TEST_F(LocaleTests, WithUSLocaleOnLSTM) {
+TEST_F(LocaleTests, smoke_WithUSLocaleOnLSTM) {
     setlocale(LC_ALL, "en_US.UTF-8");
     testBody(true);
 }
 
-TEST_F(LocaleTests, DISABLED_WithRULocaleCPP) {
+TEST_F(LocaleTests, DISABLED_smoke_WithRULocaleCPP) {
     auto prev = std::locale();
     std::locale::global(std::locale("ru_RU.UTF-8"));
     testBody();
     std::locale::global(prev);
 }
 
-TEST_F(LocaleTests, DISABLED_WithUSLocaleCPP) {
+TEST_F(LocaleTests, DISABLED_smoke_WithUSLocaleCPP) {
     auto prev = std::locale();
     std::locale::global(std::locale("en_US.UTF-8"));
     testBody();

--- a/inference-engine/tests/functional/inference_engine/lpt_transformations/eltwise_transformation_is_broadcasted_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/lpt_transformations/eltwise_transformation_is_broadcasted_test.cpp
@@ -22,27 +22,27 @@ protected:
     const TensorDesc n1c32h144w144 = TensorDesc(Precision::FP32, { 1ul, 32ul, 144ul, 144ul }, Layout::NCHW);
 };
 
-TEST_F(EltwiseTransformationIsBroadcastedTests, c1) {
+TEST_F(EltwiseTransformationIsBroadcastedTests, smoke_c1) {
     ASSERT_TRUE(EltwiseTransformation::isBroadcasted(c1));
 }
 
-TEST_F(EltwiseTransformationIsBroadcastedTests, c1000) {
+TEST_F(EltwiseTransformationIsBroadcastedTests, smoke_c1000) {
     ASSERT_FALSE(EltwiseTransformation::isBroadcasted(c1000));
 }
 
-TEST_F(EltwiseTransformationIsBroadcastedTests, n1c1) {
+TEST_F(EltwiseTransformationIsBroadcastedTests, smoke_n1c1) {
     ASSERT_TRUE(EltwiseTransformation::isBroadcasted(n1c1));
 }
 
-TEST_F(EltwiseTransformationIsBroadcastedTests, n1c256) {
+TEST_F(EltwiseTransformationIsBroadcastedTests, smoke_n1c256) {
     ASSERT_FALSE(EltwiseTransformation::isBroadcasted(n1c256));
 }
 
-TEST_F(EltwiseTransformationIsBroadcastedTests, n1c1000h1w1) {
+TEST_F(EltwiseTransformationIsBroadcastedTests, smoke_n1c1000h1w1) {
     ASSERT_TRUE(EltwiseTransformation::isBroadcasted(n1c1000h1w1));
 }
 
-TEST_F(EltwiseTransformationIsBroadcastedTests, n1c32h144w144) {
+TEST_F(EltwiseTransformationIsBroadcastedTests, smoke_n1c32h144w144) {
     ASSERT_FALSE(EltwiseTransformation::isBroadcasted(n1c32h144w144));
 }
 

--- a/inference-engine/tests/functional/inference_engine/lpt_transformations/eltwise_transformation_is_supported_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/lpt_transformations/eltwise_transformation_is_supported_test.cpp
@@ -25,46 +25,46 @@ protected:
     const TensorDesc c2000 = TensorDesc(Precision::FP32, { 2000ul }, Layout::C);
 };
 
-TEST_F(EltwiseTransformationIsSupportedTests, n1c1000h1w1_and_n1c2000h1w1) {
+TEST_F(EltwiseTransformationIsSupportedTests, smoke_n1c1000h1w1_and_n1c2000h1w1) {
     ASSERT_TRUE(EltwiseTransformation::isSupported(n1c1000h1w1, n1c2000h1w1));
 }
 
-TEST_F(EltwiseTransformationIsSupportedTests, n1c1000h1w1_and_n1c1000h1w1) {
+TEST_F(EltwiseTransformationIsSupportedTests, smoke_n1c1000h1w1_and_n1c1000h1w1) {
     ASSERT_TRUE(EltwiseTransformation::isSupported(n1c1000h1w1, n1c1000h1w1));
 }
 
-TEST_F(EltwiseTransformationIsSupportedTests, n1c1000h1w1_and_n1c1000) {
+TEST_F(EltwiseTransformationIsSupportedTests, smoke_n1c1000h1w1_and_n1c1000) {
     ASSERT_TRUE(EltwiseTransformation::isSupported(n1c1000h1w1, n1c1000));
 }
 
-TEST_F(EltwiseTransformationIsSupportedTests, n1c1000h1w1_and_n1c2000) {
+TEST_F(EltwiseTransformationIsSupportedTests, smoke_n1c1000h1w1_and_n1c2000) {
     ASSERT_FALSE(EltwiseTransformation::isSupported(n1c1000h1w1, n1c2000));
 }
 
-TEST_F(EltwiseTransformationIsSupportedTests, n1c1000h1w1_and_c1) {
+TEST_F(EltwiseTransformationIsSupportedTests, smoke_n1c1000h1w1_and_c1) {
     ASSERT_TRUE(EltwiseTransformation::isSupported(n1c1000h1w1, c1));
 }
 
-TEST_F(EltwiseTransformationIsSupportedTests, n1c1000h1w1_and_c1000) {
+TEST_F(EltwiseTransformationIsSupportedTests, smoke_n1c1000h1w1_and_c1000) {
     ASSERT_TRUE(EltwiseTransformation::isSupported(n1c1000h1w1, c1000));
 }
 
-TEST_F(EltwiseTransformationIsSupportedTests, n1c1000h1w1_and_c2000) {
+TEST_F(EltwiseTransformationIsSupportedTests, smoke_n1c1000h1w1_and_c2000) {
     ASSERT_FALSE(EltwiseTransformation::isSupported(n1c1000h1w1, c2000));
 }
 
-TEST_F(EltwiseTransformationIsSupportedTests, n1c1000_and_n1c1000) {
+TEST_F(EltwiseTransformationIsSupportedTests, smoke_n1c1000_and_n1c1000) {
     ASSERT_TRUE(EltwiseTransformation::isSupported(n1c1000, n1c1000));
 }
 
-TEST_F(EltwiseTransformationIsSupportedTests, n1c1000_and_n1c2000) {
+TEST_F(EltwiseTransformationIsSupportedTests, smoke_n1c1000_and_n1c2000) {
     ASSERT_FALSE(EltwiseTransformation::isSupported(n1c1000, n1c2000));
 }
 
-TEST_F(EltwiseTransformationIsSupportedTests, n1c2000h1w1_and_n1c1000) {
+TEST_F(EltwiseTransformationIsSupportedTests, smoke_n1c2000h1w1_and_n1c1000) {
     ASSERT_TRUE(EltwiseTransformation::isSupported(n1c2000h1w1, n1c1000));
 }
 
-TEST_F(EltwiseTransformationIsSupportedTests, n1c1000_and_n1c1) {
+TEST_F(EltwiseTransformationIsSupportedTests, smoke_n1c1000_and_n1c1) {
     ASSERT_TRUE(EltwiseTransformation::isSupported(n1c1000, n1c1));
 }

--- a/inference-engine/tests/functional/inference_engine/lpt_transformations/layer_transformation_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/lpt_transformations/layer_transformation_test.cpp
@@ -23,7 +23,7 @@ protected:
     const QuantizationDetails u8levels256WithZeroPoint = QuantizationDetails(256ul, { 0.12f }, { 1.23f }, { 0.12f }, { 1.23f }, 1ul, 1ul, 1ul);
 };
 
-TEST_F(LayerTransformationTests, getPrecisionDetailsI8levels255WithoutZeroPoint) {
+TEST_F(LayerTransformationTests, smoke_getPrecisionDetailsI8levels255WithoutZeroPoint) {
     LayerTransformation::Params params = LayerTransformation::Params();
     FakeQuantizeTransformation fakeQuantizeTransformation(params);
     const LayerTransformation::PrecisionDetails precisionDetails = fakeQuantizeTransformation.getPrecisionDetails(i8levels255WithoutZeroPoint);
@@ -32,7 +32,7 @@ TEST_F(LayerTransformationTests, getPrecisionDetailsI8levels255WithoutZeroPoint)
     ASSERT_FALSE(precisionDetails.hasZeroPoint);
 }
 
-TEST_F(LayerTransformationTests, getPrecisionDetailsI8levels255WithZeroPoint) {
+TEST_F(LayerTransformationTests, smoke_getPrecisionDetailsI8levels255WithZeroPoint) {
     LayerTransformation::Params params = LayerTransformation::Params();
     FakeQuantizeTransformation fakeQuantizeTransformation(params);
     const LayerTransformation::PrecisionDetails precisionDetails = fakeQuantizeTransformation.getPrecisionDetails(i8levels255WithZeroPoint);
@@ -41,7 +41,7 @@ TEST_F(LayerTransformationTests, getPrecisionDetailsI8levels255WithZeroPoint) {
     ASSERT_TRUE(precisionDetails.hasZeroPoint);
 }
 
-TEST_F(LayerTransformationTests, getPrecisionDetailsI8levels256WithoutZeroPoint) {
+TEST_F(LayerTransformationTests, smoke_getPrecisionDetailsI8levels256WithoutZeroPoint) {
     LayerTransformation::Params params = LayerTransformation::Params();
     FakeQuantizeTransformation fakeQuantizeTransformation(params);
     const LayerTransformation::PrecisionDetails precisionDetails = fakeQuantizeTransformation.getPrecisionDetails(i8levels256WithoutZeroPoint);
@@ -50,7 +50,7 @@ TEST_F(LayerTransformationTests, getPrecisionDetailsI8levels256WithoutZeroPoint)
     ASSERT_FALSE(precisionDetails.hasZeroPoint);
 }
 
-TEST_F(LayerTransformationTests, getPrecisionDetailsU8levels256WithoutZeroPoint) {
+TEST_F(LayerTransformationTests, smoke_getPrecisionDetailsU8levels256WithoutZeroPoint) {
     LayerTransformation::Params params = LayerTransformation::Params();
     FakeQuantizeTransformation fakeQuantizeTransformation(params);
     const LayerTransformation::PrecisionDetails precisionDetails = fakeQuantizeTransformation.getPrecisionDetails(u8levels256WithoutZeroPoint);
@@ -59,7 +59,7 @@ TEST_F(LayerTransformationTests, getPrecisionDetailsU8levels256WithoutZeroPoint)
     ASSERT_FALSE(precisionDetails.hasZeroPoint);
 }
 
-TEST_F(LayerTransformationTests, getPrecisionDetailsU8levels256WithZeroPoint) {
+TEST_F(LayerTransformationTests, smoke_getPrecisionDetailsU8levels256WithZeroPoint) {
     LayerTransformation::Params params = LayerTransformation::Params();
     FakeQuantizeTransformation fakeQuantizeTransformation(params);
     const LayerTransformation::PrecisionDetails precisionDetails = fakeQuantizeTransformation.getPrecisionDetails(u8levels256WithZeroPoint);

--- a/inference-engine/tests/functional/inference_engine/lpt_transformations/low_precision_transformations_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/lpt_transformations/low_precision_transformations_test.cpp
@@ -11,7 +11,7 @@ using namespace InferenceEngine::details;
 
 class LowPrecisionTransformationsTests : public Test {};
 
-TEST_F(LowPrecisionTransformationsTests, remove) {
+TEST_F(LowPrecisionTransformationsTests, smoke_remove) {
     LowPrecisionTransformations transformations = LowPrecisionTransformer::getAllTransformations(LayerTransformation::Params());
     LayerTransformationPtr transformation = transformations.find("ScaleShift");
     ASSERT_NE(nullptr, transformation);
@@ -21,7 +21,7 @@ TEST_F(LowPrecisionTransformationsTests, remove) {
     ASSERT_EQ(nullptr, transformation);
 }
 
-TEST_F(LowPrecisionTransformationsTests, removeBranchSpecificTransformations) {
+TEST_F(LowPrecisionTransformationsTests, smoke_removeBranchSpecificTransformations) {
     LowPrecisionTransformations transformations = LowPrecisionTransformer::getAllTransformations(LayerTransformation::Params());
     LayerTransformationPtr transformation = transformations.find("Concat");
     ASSERT_NE(nullptr, transformation);
@@ -31,7 +31,7 @@ TEST_F(LowPrecisionTransformationsTests, removeBranchSpecificTransformations) {
     ASSERT_EQ(nullptr, transformation);
 }
 
-TEST_F(LowPrecisionTransformationsTests, removeTransformations) {
+TEST_F(LowPrecisionTransformationsTests, smoke_removeTransformations) {
     LowPrecisionTransformations transformations = LowPrecisionTransformer::getAllTransformations(LayerTransformation::Params());
     LayerTransformationPtr transformation = transformations.find("FullyConnected");
     ASSERT_NE(nullptr, transformation);
@@ -41,7 +41,7 @@ TEST_F(LowPrecisionTransformationsTests, removeTransformations) {
     ASSERT_EQ(nullptr, transformation);
 }
 
-TEST_F(LowPrecisionTransformationsTests, removeCleanupTransformations) {
+TEST_F(LowPrecisionTransformationsTests, smoke_removeCleanupTransformations) {
     LowPrecisionTransformations transformations = LowPrecisionTransformer::getAllTransformations(LayerTransformation::Params());
     LayerTransformationPtr transformation = transformations.find("ScaleShift");
     ASSERT_NE(nullptr, transformation);

--- a/inference-engine/tests/functional/inference_engine/net_reader_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/net_reader_test.cpp
@@ -29,7 +29,7 @@
 
 using NetReaderNoParamTest = CommonTestUtils::TestsCommon;
 
-TEST_F(NetReaderNoParamTest, IncorrectModel) {
+TEST_F(NetReaderNoParamTest, smoke_IncorrectModel) {
     InferenceEngine::Core ie;
     ASSERT_THROW(ie.ReadNetwork("incorrectFilePath"), InferenceEngine::details::InferenceEngineException);
 }
@@ -147,7 +147,7 @@ TEST_P(NetReaderTest, ReadCorrectModelWithWeightsUnicodePath) {
 
 #endif
 
-TEST(NetReaderTest, IRSupportModelDetection) {
+TEST(NetReaderTest, smoke_IRSupportModelDetection) {
     InferenceEngine::Core ie;
 
     static char const *model = R"V0G0N(<net name="Network" version="10" some_attribute="Test Attribute">
@@ -237,7 +237,7 @@ static const auto params = testing::Combine(
         testing::Values(InferenceEngine::Precision::FP32, InferenceEngine::Precision::FP16));
 
 INSTANTIATE_TEST_CASE_P(
-        NetReaderTest,
+        smoke_NetReaderTest,
         NetReaderTest,
         params,
         getTestCaseName);

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/abs_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/abs_tests.cpp
@@ -44,7 +44,7 @@ public:
     }
 };
 
-TEST_F(NGraphReaderTests, ReadAbsFromCustomOpsetNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadAbsFromCustomOpsetNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -110,7 +110,7 @@ TEST_F(NGraphReaderTests, ReadAbsFromCustomOpsetNetwork) {
     ASSERT_TRUE(genericNodeExists);
 }
 
-TEST_F(NGraphReaderTests, ReadAbsNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadAbsNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/acos_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/acos_tests.cpp
@@ -6,7 +6,7 @@
 
 #include "ngraph_reader_tests.hpp"
 
-TEST_F(NGraphReaderTests, ReadAcosNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadAcosNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/asin_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/asin_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadAsinNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadAsinNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/atan_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/atan_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadAtanNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadAtanNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/batch_norm_inference_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/batch_norm_inference_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadBatchNormInferenceNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadBatchNormInferenceNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/broadcast_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/broadcast_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ConvertBroadcastToTiles1) {
+TEST_F(NGraphReaderTests, smoke_ConvertBroadcastToTiles1) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -160,7 +160,7 @@ TEST_F(NGraphReaderTests, ConvertBroadcastToTiles1) {
             });
 }
 
-TEST_F(NGraphReaderTests, ConvertBroadcastToTiles2) {
+TEST_F(NGraphReaderTests, smoke_ConvertBroadcastToTiles2) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -335,7 +335,7 @@ TEST_F(NGraphReaderTests, ConvertBroadcastToTiles2) {
             });
 }
 
-TEST_F(NGraphReaderTests, ConvertBroadcastToTiles3) {
+TEST_F(NGraphReaderTests, smoke_ConvertBroadcastToTiles3) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -448,7 +448,7 @@ TEST_F(NGraphReaderTests, ConvertBroadcastToTiles3) {
             });
 }
 
-TEST_F(NGraphReaderTests, ConvertBroadcastToTiles4) {
+TEST_F(NGraphReaderTests, smoke_ConvertBroadcastToTiles4) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -599,7 +599,7 @@ TEST_F(NGraphReaderTests, ConvertBroadcastToTiles4) {
     });
 }
 
-TEST_F(NGraphReaderTests, DISABLED_ConvertBroadcastToTiles5) {
+TEST_F(NGraphReaderTests, DISABLED_smoke_ConvertBroadcastToTiles5) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/ceiling_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/ceiling_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadCeilingNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadCeilingNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/clamp_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/clamp_tests.cpp
@@ -5,7 +5,7 @@
 #include <string>
 #include "ngraph_reader_tests.hpp"
 
-TEST_F(NGraphReaderTests, ReadClampNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadClampNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/concat_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/concat_tests.cpp
@@ -5,7 +5,7 @@
 #include <string>
 #include "ngraph_reader_tests.hpp"
 
-TEST_F(NGraphReaderTests, ReadConcatNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadConcatNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/convolution_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/convolution_tests.cpp
@@ -5,7 +5,7 @@
 #include <string>
 #include "ngraph_reader_tests.hpp"
 
-TEST_F(NGraphReaderTests, ReadConvolutionNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadConvolutionNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/cos_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/cos_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadCosNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadCosNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/cosh_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/cosh_tests.cpp
@@ -5,7 +5,7 @@
 #include <string>
 
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadCoshNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadCoshNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/deconvolution_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/deconvolution_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, DISABLED_ReadDeconvolution3DNetwork) {
+TEST_F(NGraphReaderTests, DISABLED_smoke_ReadDeconvolution3DNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -124,7 +124,7 @@ TEST_F(NGraphReaderTests, DISABLED_ReadDeconvolution3DNetwork) {
     compareIRs(model, modelV5, 33554432);
 }
 
-TEST_F(NGraphReaderTests, DISABLED_ReadDeconvolution2DNetwork) {
+TEST_F(NGraphReaderTests, DISABLED_smoke_ReadDeconvolution2DNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/detection_output_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/detection_output_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, DISABLED_ReadDetectionOutputNetwork) {
+TEST_F(NGraphReaderTests, DISABLED_smoke_ReadDetectionOutputNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/divide_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/divide_tests.cpp
@@ -6,7 +6,7 @@
 #include "ngraph_reader_tests.hpp"
 #include "common_test_utils/data_utils.hpp"
 
-TEST_F(NGraphReaderTests, ReadDivideNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadDivideNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/elu_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/elu_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadELUNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadELUNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/erf_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/erf_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadErfNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadErfNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/exp_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/exp_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadExpNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadExpNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/fake_quantize_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/fake_quantize_tests.cpp
@@ -6,7 +6,7 @@
 #include "ngraph_reader_tests.hpp"
 #include "common_test_utils/data_utils.hpp"
 
-TEST_F(NGraphReaderTests, ReadFQNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadFQNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/floor_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/floor_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadFloorNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadFloorNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/fusion_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/fusion_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ConvBiasFusion) {
+TEST_F(NGraphReaderTests, smoke_ConvBiasFusion) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -158,7 +158,7 @@ TEST_F(NGraphReaderTests, ConvBiasFusion) {
             });
 }
 
-TEST_F(NGraphReaderTests, ConvBiasFusionFP16) {
+TEST_F(NGraphReaderTests, smoke_ConvBiasFusionFP16) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -312,7 +312,7 @@ TEST_F(NGraphReaderTests, ConvBiasFusionFP16) {
             });
 }
 
-TEST_F(NGraphReaderTests, MatMulBiasFusionNoBroadcast) {
+TEST_F(NGraphReaderTests, MatMulBiasFusionNoBroadcast_smoke) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -435,7 +435,7 @@ TEST_F(NGraphReaderTests, MatMulBiasFusionNoBroadcast) {
     compareIRs(model, modelV5, 8196024);
 }
 
-TEST_F(NGraphReaderTests, DISABLED_MatMulBiasFusion) {
+TEST_F(NGraphReaderTests, DISABLED_smoke_MatMulBiasFusion) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/gather_tree_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/gather_tree_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadGatherTreeNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadGatherTreeNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/gelu_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/gelu_tests.cpp
@@ -6,7 +6,7 @@
 #include "ngraph_reader_tests.hpp"
 #include "common_test_utils/xml_net_builder/ir_net.hpp"
 
-TEST_F(NGraphReaderTests, ReadGeluNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadGeluNetwork) {
     CommonTestUtils::IRBuilder_v10 ir_builder_v10("Network");
 
     auto input_layer = ir_builder_v10

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/greater_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/greater_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadGreaterNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadGreaterNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -133,7 +133,7 @@ TEST_F(NGraphReaderTests, ReadGreaterNetwork) {
     compareIRs(model, modelV5, 3211264);
 }
 
-TEST_F(NGraphReaderTests, ReadGreaterEqualNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadGreaterEqualNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/grn_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/grn_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadGRNNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadGRNNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/hard_sigmoid_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/hard_sigmoid_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadHardSigmoidNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadHardSigmoidNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/interpolate_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/interpolate_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadInterpolateNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadInterpolateNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -111,7 +111,7 @@ TEST_F(NGraphReaderTests, ReadInterpolateNetwork) {
                 data[1] = 60;
             });
 }
-TEST_F(NGraphReaderTests, ReadInterpolate2Network) {
+TEST_F(NGraphReaderTests, smoke_ReadInterpolate2Network) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -221,7 +221,7 @@ TEST_F(NGraphReaderTests, ReadInterpolate2Network) {
             });
 }
 
-TEST_F(NGraphReaderTests, ReadInterpolate4Network) {
+TEST_F(NGraphReaderTests, smoke_ReadInterpolate4Network) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/less_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/less_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadLessNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadLessNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -133,7 +133,7 @@ TEST_F(NGraphReaderTests, ReadLessNetwork) {
     compareIRs(model, modelV5, 3211264);
 }
 
-TEST_F(NGraphReaderTests, ReadLessEqualNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadLessEqualNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/linear_ops_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/linear_ops_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ConvertMulAddToScaleShift) {
+TEST_F(NGraphReaderTests, smoke_ConvertMulAddToScaleShift) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -148,7 +148,7 @@ TEST_F(NGraphReaderTests, ConvertMulAddToScaleShift) {
     compareIRs(model, modelV5, 6422528);
 }
 
-TEST_F(NGraphReaderTests, ConvertMulAddToPower) {
+TEST_F(NGraphReaderTests, smoke_ConvertMulAddToPower) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -302,7 +302,7 @@ TEST_F(NGraphReaderTests, ConvertMulAddToPower) {
             });
 }
 
-TEST_F(NGraphReaderTests, ConvertMulToPower) {
+TEST_F(NGraphReaderTests, smoke_ConvertMulToPower) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -416,7 +416,7 @@ TEST_F(NGraphReaderTests, ConvertMulToPower) {
             });
 }
 
-TEST_F(NGraphReaderTests, ConvertMulToPower2) {
+TEST_F(NGraphReaderTests, smoke_ConvertMulToPower2) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -527,7 +527,7 @@ TEST_F(NGraphReaderTests, ConvertMulToPower2) {
     });
 }
 
-TEST_F(NGraphReaderTests, ConvertAddToPower) {
+TEST_F(NGraphReaderTests, smoke_ConvertAddToPower) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -641,7 +641,7 @@ TEST_F(NGraphReaderTests, ConvertAddToPower) {
             });
 }
 
-TEST_F(NGraphReaderTests, ConvertMulToScaleShift) {
+TEST_F(NGraphReaderTests, smoke_ConvertMulToScaleShift) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -749,7 +749,7 @@ TEST_F(NGraphReaderTests, ConvertMulToScaleShift) {
     compareIRs(model, modelV5, 6422528);
 }
 
-TEST_F(NGraphReaderTests, ConvertAddToScaleShift) {
+TEST_F(NGraphReaderTests, smoke_ConvertAddToScaleShift) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -857,7 +857,7 @@ TEST_F(NGraphReaderTests, ConvertAddToScaleShift) {
     compareIRs(model, modelV5, 6422528);
 }
 
-TEST_F(NGraphReaderTests, ConvertMulToEltwise) {
+TEST_F(NGraphReaderTests, smoke_ConvertMulToEltwise) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -978,7 +978,7 @@ TEST_F(NGraphReaderTests, ConvertMulToEltwise) {
     compareIRs(model, modelV5, 6422528);
 }
 
-TEST_F(NGraphReaderTests, ConvertAddToEltwise) {
+TEST_F(NGraphReaderTests, smoke_ConvertAddToEltwise) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -1099,7 +1099,7 @@ TEST_F(NGraphReaderTests, ConvertAddToEltwise) {
     compareIRs(model, modelV5, 6422528);
 }
 
-TEST_F(NGraphReaderTests, ReadAddNoBroadcastNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadAddNoBroadcastNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -1228,7 +1228,7 @@ TEST_F(NGraphReaderTests, ReadAddNoBroadcastNetwork) {
     compareIRs(model, modelV5, 3211264);
 }
 
-TEST_F(NGraphReaderTests, ReadMultiplyNoBroadcastNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadMultiplyNoBroadcastNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -1357,7 +1357,7 @@ TEST_F(NGraphReaderTests, ReadMultiplyNoBroadcastNetwork) {
     compareIRs(model, modelV5, 3211264);
 }
 
-TEST_F(NGraphReaderTests, RemoveAdd) {
+TEST_F(NGraphReaderTests, smoke_RemoveAdd) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -1486,7 +1486,7 @@ TEST_F(NGraphReaderTests, RemoveAdd) {
     });
 }
 
-TEST_F(NGraphReaderTests, RemoveMulAdd) {
+TEST_F(NGraphReaderTests, smoke_RemoveMulAdd) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -1658,7 +1658,7 @@ TEST_F(NGraphReaderTests, RemoveMulAdd) {
     });
 }
 
-TEST_F(NGraphReaderTests, RemoveAdd2) {
+TEST_F(NGraphReaderTests, smoke_RemoveAdd2) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -1788,7 +1788,7 @@ TEST_F(NGraphReaderTests, RemoveAdd2) {
     });
 }
 
-TEST_F(NGraphReaderTests, RemoveAdd3) {
+TEST_F(NGraphReaderTests, smoke_RemoveAdd3) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -2004,7 +2004,7 @@ TEST_F(NGraphReaderTests, RemoveAdd3) {
     });
 }
 
-TEST_F(NGraphReaderTests, ConvertAddToEltwise2) {
+TEST_F(NGraphReaderTests, smoke_ConvertAddToEltwise2) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/log_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/log_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadLogNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadLogNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/logical_and_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/logical_and_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadLogicalAndNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadLogicalAndNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/logical_not_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/logical_not_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, DISABLED_ReadLogicalNotNetwork) {
+TEST_F(NGraphReaderTests, DISABLED_smoke_ReadLogicalNotNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/logical_or_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/logical_or_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadLogicalOrNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadLogicalOrNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/logical_xor_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/logical_xor_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadLogicalXorNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadLogicalXorNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/lrn_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/lrn_tests.cpp
@@ -6,7 +6,7 @@
 #include "ngraph_reader_tests.hpp"
 #include "common_test_utils/xml_net_builder/ir_net.hpp"
 
-TEST_F(NGraphReaderTests, ReadLrnNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadLrnNetwork) {
     CommonTestUtils::IRBuilder_v10 ir_builder_v10("LRN");
 
     auto input_layer = ir_builder_v10
@@ -66,7 +66,7 @@ TEST_F(NGraphReaderTests, ReadLrnNetwork) {
             });
 }
 
-TEST_F(NGraphReaderTests, ReadLrnNetwork2) {
+TEST_F(NGraphReaderTests, smoke_ReadLrnNetwork2) {
     CommonTestUtils::IRBuilder_v10 ir_builder_v10("Activation");
 
     auto input_layer = ir_builder_v10

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/matmul_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/matmul_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadMatMulNetwork1) {
+TEST_F(NGraphReaderTests, smoke_ReadMatMulNetwork1) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -98,7 +98,7 @@ TEST_F(NGraphReaderTests, ReadMatMulNetwork1) {
     compareIRs(model, modelV5, 8193000);
 }
 
-TEST_F(NGraphReaderTests, ReadMatMulNetwork2) {
+TEST_F(NGraphReaderTests, smoke_ReadMatMulNetwork2) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -193,7 +193,7 @@ TEST_F(NGraphReaderTests, ReadMatMulNetwork2) {
     compareIRs(model, modelV5, 8193000);
 }
 
-TEST_F(NGraphReaderTests, ReadMatMulNetwork3) {
+TEST_F(NGraphReaderTests, smoke_ReadMatMulNetwork3) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -304,7 +304,7 @@ TEST_F(NGraphReaderTests, ReadMatMulNetwork3) {
     compareIRs(model, modelV5, 8193000);
 }
 
-TEST_F(NGraphReaderTests, ReadMatMulNetwork4) {
+TEST_F(NGraphReaderTests, smoke_ReadMatMulNetwork4) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -409,7 +409,7 @@ TEST_F(NGraphReaderTests, ReadMatMulNetwork4) {
     compareIRs(model, modelV5, 8192000);
 }
 
-TEST_F(NGraphReaderTests, ReadMatMulNetwork5) {
+TEST_F(NGraphReaderTests, smoke_ReadMatMulNetwork5) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/maximum_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/maximum_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadMaximumNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadMaximumNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/mvn_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/mvn_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadMVNNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadMVNNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/neg_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/neg_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadNegativeNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadNegativeNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/negative_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/negative_tests.cpp
@@ -6,7 +6,7 @@
 #include "ngraph_reader_tests.hpp"
 #include "common_test_utils/data_utils.hpp"
 
-TEST_F(NGraphReaderTests, DISABLED_ReadIncorrectNetwork) {
+TEST_F(NGraphReaderTests, DISABLED_smoke_ReadIncorrectNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/one_hot_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/one_hot_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadOneHotFP32) {
+TEST_F(NGraphReaderTests, smoke_ReadOneHotFP32) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -124,7 +124,7 @@ TEST_F(NGraphReaderTests, ReadOneHotFP32) {
     });
 }
 
-TEST_F(NGraphReaderTests, ReadOneHotINT16) {
+TEST_F(NGraphReaderTests, smoke_ReadOneHotINT16) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/pad_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/pad_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadPadNoPadValue) {
+TEST_F(NGraphReaderTests, smoke_ReadPadNoPadValue) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -132,7 +132,7 @@ TEST_F(NGraphReaderTests, ReadPadNoPadValue) {
     });
 }
 
-TEST_F(NGraphReaderTests, ReadPadWithPadValue) {
+TEST_F(NGraphReaderTests, smoke_ReadPadWithPadValue) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/pooling_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/pooling_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadMaxPoolNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadMaxPoolNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -97,7 +97,7 @@ TEST_F(NGraphReaderTests, ReadMaxPoolNetwork) {
     compareIRs(model, modelV5, 0);
 }
 
-TEST_F(NGraphReaderTests, ReadAvgPoolNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadAvgPoolNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/pow_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/pow_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadPowNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadPowNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/prelu_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/prelu_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadPReLUNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadPReLUNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/prior_box_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/prior_box_tests.cpp
@@ -8,7 +8,7 @@
 // Todo (itikhono): delete ReadPriorBoxClusteredNetwork and ReadPriorBoxNetwork and replace them with disabled tests
 //  below after supporting constants as outputs in plugins.
 
-TEST_F(NGraphReaderTests, ReadPriorBoxClusteredNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadPriorBoxClusteredNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -269,7 +269,7 @@ TEST_F(NGraphReaderTests, ReadPriorBoxClusteredNetwork) {
             });
 }
 
-TEST_F(NGraphReaderTests, ReadPriorBoxNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadPriorBoxNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -529,7 +529,7 @@ TEST_F(NGraphReaderTests, ReadPriorBoxNetwork) {
             });
 }
 
-TEST_F(NGraphReaderTests, DISABLED_ReadPriorBoxClusteredNetwork) {
+TEST_F(NGraphReaderTests, DISABLED_smoke_ReadPriorBoxClusteredNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -868,7 +868,7 @@ TEST_F(NGraphReaderTests, DISABLED_ReadPriorBoxClusteredNetwork) {
     });
 }
 
-TEST_F(NGraphReaderTests, DISABLED_ReadPriorBoxNetwork) {
+TEST_F(NGraphReaderTests, DISABLED_smoke_ReadPriorBoxNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/proposal_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/proposal_tests.cpp
@@ -5,7 +5,7 @@
 #include <string>
 #include <generic_ie.hpp>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadProposalNetwork) {
+TEST_F(NGraphReaderTests, ReadProposalNetwork_smoke) {
     std::string model_v10 = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -156,7 +156,7 @@ TEST_F(NGraphReaderTests, ReadProposalNetwork) {
     compareIRs(model_v10, model_v6, 24);
 }
 
-TEST_F(NGraphReaderTests, ReadProposalNetwork_2) {
+TEST_F(NGraphReaderTests, ReadProposalNetwork_2_smoke) {
     std::string model_v10 = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -166,7 +166,7 @@ TEST_F(NGraphReaderTests, ReadProposalNetwork_2) {
                 <port id="0" precision="FP32">
                     <dim>1</dim>
                     <dim>12</dim>
-                    <dim>34</dim>
+                    <dim>34</dim>smoke_ParameterAsUInt
                     <dim>62</dim>
                 </port>
             </output>
@@ -307,7 +307,7 @@ TEST_F(NGraphReaderTests, ReadProposalNetwork_2) {
     compareIRs(model_v10, model_v6, 32);
 }
 
-TEST_F(NGraphReaderTests, ReadExtensionProposalNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadExtensionProposalNetwork) {
     std::string model_v10 = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/range_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/range_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadRangeNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadRangeNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/reduce_logical_and_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/reduce_logical_and_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadReduceLogicalAndNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadReduceLogicalAndNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/reduce_logical_or_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/reduce_logical_or_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadReduceLogicalOrNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadReduceLogicalOrNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/reduce_to_pooling_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/reduce_to_pooling_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReduceMeanToAvgPool) {
+TEST_F(NGraphReaderTests, smoke_ReduceMeanToAvgPool) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -113,7 +113,7 @@ TEST_F(NGraphReaderTests, ReduceMeanToAvgPool) {
     });
 }
 
-TEST_F(NGraphReaderTests, ReduceMeanToAvgPoolKeepDimsFalse) {
+TEST_F(NGraphReaderTests, smoke_ReduceMeanToAvgPoolKeepDimsFalse) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -252,7 +252,7 @@ TEST_F(NGraphReaderTests, ReduceMeanToAvgPoolKeepDimsFalse) {
     });
 }
 
-TEST_F(NGraphReaderTests, ReduceMeanToAvgPoolNonSpatial) {
+TEST_F(NGraphReaderTests, smoke_ReduceMeanToAvgPoolNonSpatial) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -428,7 +428,7 @@ TEST_F(NGraphReaderTests, ReduceMeanToAvgPoolNonSpatial) {
     });
 }
 
-TEST_F(NGraphReaderTests, ReduceMeanToAvgPoolNonSpatialHard) {
+TEST_F(NGraphReaderTests, smoke_ReduceMeanToAvgPoolNonSpatialHard) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -572,7 +572,7 @@ TEST_F(NGraphReaderTests, ReduceMeanToAvgPoolNonSpatialHard) {
     });
 }
 
-TEST_F(NGraphReaderTests, ReduceMeanToMaxPool) {
+TEST_F(NGraphReaderTests, smoke_ReduceMeanToMaxPool) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -682,7 +682,7 @@ TEST_F(NGraphReaderTests, ReduceMeanToMaxPool) {
     });
 }
 
-TEST_F(NGraphReaderTests, ReduceMeanToMaxPoolKeepDimsFalse) {
+TEST_F(NGraphReaderTests, smoke_ReduceMeanToMaxPoolKeepDimsFalse) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -821,7 +821,7 @@ TEST_F(NGraphReaderTests, ReduceMeanToMaxPoolKeepDimsFalse) {
     });
 }
 
-TEST_F(NGraphReaderTests, ReduceMeanToMaxPoolNonSpatial) {
+TEST_F(NGraphReaderTests, smoke_ReduceMeanToMaxPoolNonSpatial) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -997,7 +997,7 @@ TEST_F(NGraphReaderTests, ReduceMeanToMaxPoolNonSpatial) {
     });
 }
 
-TEST_F(NGraphReaderTests, ReduceSumToAvgPool) {
+TEST_F(NGraphReaderTests, smoke_ReduceSumToAvgPool) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/relu_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/relu_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadReLUNetworkWithoutTopologicalOrder) {
+TEST_F(NGraphReaderTests, smoke_ReadReLUNetworkWithoutTopologicalOrder) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -95,7 +95,7 @@ TEST_F(NGraphReaderTests, ReadReLUNetworkWithoutTopologicalOrder) {
     compareIRs(model, modelV5, 0);
 }
 
-TEST_F(NGraphReaderTests, ReadReLUNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadReLUNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -186,7 +186,7 @@ TEST_F(NGraphReaderTests, ReadReLUNetwork) {
     compareIRs(model, modelV5, 0);
 }
 
-TEST_F(NGraphReaderTests, ReadReLUScalarNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadReLUScalarNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/reshape_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/reshape_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadReshapeNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadReshapeNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/reverse_sequence_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/reverse_sequence_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadReverseSequenceNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadReverseSequenceNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/roi_pooling_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/roi_pooling_tests.cpp
@@ -5,7 +5,7 @@
 #include <string>
 #include "ngraph_reader_tests.hpp"
 
-TEST_F(NGraphReaderTests, ROIPoolingNetwork) {
+TEST_F(NGraphReaderTests, smoke_ROIPoolingNetwork) {
     std::string model_v10 = R"V0G0N(
     <net name="ROIPoolingNet" version="10">
         <layers>
@@ -126,7 +126,7 @@ TEST_F(NGraphReaderTests, ROIPoolingNetwork) {
     compareIRs(model_v10, model_v6, 48);
 }
 
-TEST_F(NGraphReaderTests, ROIPoolingNetwork_2) {
+TEST_F(NGraphReaderTests, smoke_ROIPoolingNetwork_2) {
     std::string model_v10 = R"V0G0N(
     <net name="ROIPoolingNet" version="10">
         <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/select_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/select_tests.cpp
@@ -5,7 +5,7 @@
 #include <string>
 #include "ngraph_reader_tests.hpp"
 
-TEST_F(NGraphReaderTests, ReadSelectFP32Network) {
+TEST_F(NGraphReaderTests, smoke_ReadSelectFP32Network) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -166,7 +166,7 @@ TEST_F(NGraphReaderTests, ReadSelectFP32Network) {
     compareIRs(model, modelV5, 0);
 }
 
-TEST_F(NGraphReaderTests, ReadSelectI32Network) {
+TEST_F(NGraphReaderTests, smoke_ReadSelectI32Network) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/selu_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/selu_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadSeluNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadSeluNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/shape_of_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/shape_of_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, DISABLED_ReadShapeOfNetwork) {
+TEST_F(NGraphReaderTests, DISABLED_smoke_ReadShapeOfNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/sigmoid_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/sigmoid_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadSigmoidNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadSigmoidNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/sign_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/sign_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadSignNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadSignNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/sin_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/sin_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadSinNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadSinNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/sinh_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/sinh_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadSinhNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadSinhNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/softmax_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/softmax_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadSoftMaxNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadSoftMaxNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/split_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/split_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadSplitNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadSplitNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -131,7 +131,7 @@ TEST_F(NGraphReaderTests, ReadSplitNetwork) {
     });
 }
 
-TEST_F(NGraphReaderTests, ReadSplitNetwork2) {
+TEST_F(NGraphReaderTests, smoke_ReadSplitNetwork2) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -365,7 +365,7 @@ TEST_F(NGraphReaderTests, ReadSplitNetwork2) {
     });
 }
 
-TEST_F(NGraphReaderTests, ReadVariadicSplitNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadVariadicSplitNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/sqrt_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/sqrt_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadSqrtNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadSqrtNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/squared_difference_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/squared_difference_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadSquaredDifferenceNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadSquaredDifferenceNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/squeeze_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/squeeze_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadSqueeze) {
+TEST_F(NGraphReaderTests, smoke_ReadSqueeze) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/strided_slice_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/strided_slice_tests.cpp
@@ -8,7 +8,7 @@
 // This test should pass after deleting
 // "input_shape.size() != 2 && input_shape.size() != 4 && input_shape.size() != 5" condition in
 // strided_slice_to_crop transformation
-TEST_F(NGraphReaderTests, ConvertStridedSliceToCrop) {
+TEST_F(NGraphReaderTests, smoke_ConvertStridedSliceToCrop) {
     std::string model_version10 = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -162,7 +162,7 @@ TEST_F(NGraphReaderTests, ConvertStridedSliceToCrop) {
 // This test should pass after deleting
 // "input_shape.size() != 2 && input_shape.size() != 4 && input_shape.size() != 5" condition in
 // strided_slice_to_crop transformation
-TEST_F(NGraphReaderTests, DISABLED_ConvertStridedSliceToCropMultipleMasks) {
+TEST_F(NGraphReaderTests, DISABLED_smoke_ConvertStridedSliceToCropMultipleMasks) {
     // c = np.zeros((9, 9, 9, 9, 9, 9, 9))
     // const_use_axis_mask = tf.constant(c)
     // strided_slice_with_mask = tf.strided_slice(const_use_axis_mask,
@@ -428,7 +428,7 @@ TEST_F(NGraphReaderTests, DISABLED_ConvertStridedSliceToCropMultipleMasks) {
 }
 
 // TODO delete this check in ngraph "Check 'static_cast<size_t>(data_rank) == mask_size'
-TEST_F(NGraphReaderTests, DISABLED_ConvertStridedSliceToCropMultipleMasks_2) {
+TEST_F(NGraphReaderTests, DISABLED_smoke_ConvertStridedSliceToCropMultipleMasks_2) {
     std::string model_version10 = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/tan_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/tan_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadTanNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadTanNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/tanh_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/tanh_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadTanhNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadTanhNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/ti.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/ti.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadTensorIteratorNetwork_opset1) {
+TEST_F(NGraphReaderTests, smoke_ReadTensorIteratorNetwork_opset1) {
     std::string model_v10 = R"V0G0N(
     <net name="Transpose" version="10">
         <layers>
@@ -457,7 +457,7 @@ TEST_F(NGraphReaderTests, ReadTensorIteratorNetwork_opset1) {
     });
 }
 
-TEST_F(NGraphReaderTests, ReadTensorIteratorNetwork_resnet_opset1) {
+TEST_F(NGraphReaderTests, smoke_ReadTensorIteratorNetwork_resnet_opset1) {
     std::string model_v10 = R"V0G0N(
     <net name="Resnet" version="10">
         <layers>
@@ -948,7 +948,7 @@ TEST_F(NGraphReaderTests, ReadTensorIteratorNetwork_resnet_opset1) {
     });
 }
 
-TEST_F(NGraphReaderTests, ReadTensorIteratorNetwork_negative_stride_opset1) {
+TEST_F(NGraphReaderTests, smoke_ReadTensorIteratorNetwork_negative_stride_opset1) {
     std::string model_v10 = R"V0G0N(
     <net name="Transpose" version="10">
         <layers>
@@ -1401,7 +1401,7 @@ TEST_F(NGraphReaderTests, ReadTensorIteratorNetwork_negative_stride_opset1) {
     });
 }
 
-TEST_F(NGraphReaderTests, ReadTensorIteratorNetwork_opset4) {
+TEST_F(NGraphReaderTests, smoke_ReadTensorIteratorNetwork_opset4) {
     std::string model_v10 = R"V0G0N(
     <net name="Transpose" version="10">
         <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/tile_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/tile_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadTileNetwork) {
+TEST_F(NGraphReaderTests, smoke_ReadTileNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -114,7 +114,7 @@ TEST_F(NGraphReaderTests, ReadTileNetwork) {
             });
 }
 
-TEST_F(NGraphReaderTests, ReadTileNetwork2) {
+TEST_F(NGraphReaderTests, smoke_ReadTileNetwork2) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/topK_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/topK_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, DISABLED_ReadTopKNetwork) {
+TEST_F(NGraphReaderTests, DISABLED_smoke_ReadTopKNetwork) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/unsqueeze_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/unsqueeze_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 #include "ngraph_reader_tests.hpp"
-TEST_F(NGraphReaderTests, ReadUnsqueeze) {
+TEST_F(NGraphReaderTests, smoke_ReadUnsqueeze) {
     std::string model_version10 = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/ngraph_reshape_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reshape_tests.cpp
@@ -40,7 +40,7 @@ using namespace CommonTestUtils;
 
 using NGraphReshapeTests = TestsCommon;
 
-TEST_F(NGraphReshapeTests, getBatchSize) {
+TEST_F(NGraphReshapeTests, smoke_getBatchSize) {
     std::shared_ptr<ngraph::Function> ngraph;
     {
         ngraph::PartialShape shape({1, 3, 22, 22});
@@ -59,7 +59,7 @@ TEST_F(NGraphReshapeTests, getBatchSize) {
     ASSERT_EQ(1, cnnNetwork.getBatchSize());
 }
 
-TEST_F(NGraphReshapeTests, ReshapedDynamicShapeLayout) {
+TEST_F(NGraphReshapeTests, smoke_ReshapedDynamicShapeLayout) {
     std::shared_ptr<ngraph::Function> ngraph;
     {
         ngraph::PartialShape shape({-1, 3, 22, 22});
@@ -83,7 +83,7 @@ TEST_F(NGraphReshapeTests, ReshapedDynamicShapeLayout) {
     ASSERT_EQ(Layout::NCHW, cnnNetwork.getInputsInfo()["A"]->getLayout());
 }
 
-TEST_F(NGraphReshapeTests, ReshapeBatchReLU) {
+TEST_F(NGraphReshapeTests, smoke_ReshapeBatchReLU) {
     std::shared_ptr<ngraph::Function> ngraph;
     {
         ngraph::PartialShape shape({1, 3, 22, 22});
@@ -114,7 +114,7 @@ TEST_F(NGraphReshapeTests, ReshapeBatchReLU) {
     ASSERT_EQ(ngraph->get_results()[0]->get_shape(), ngraph::Shape({2, 3, 22, 22}));
 }
 
-TEST_F(NGraphReshapeTests, ReshapeSpatialReLU) {
+TEST_F(NGraphReshapeTests, smoke_ReshapeSpatialReLU) {
     std::shared_ptr<ngraph::Function> ngraph;
     {
         ngraph::PartialShape shape({1, 3, 22, 22});
@@ -145,7 +145,7 @@ TEST_F(NGraphReshapeTests, ReshapeSpatialReLU) {
     ASSERT_EQ(ngraph->get_results()[0]->get_shape(), ngraph::Shape({1, 3, 25, 25}));
 }
 
-TEST_F(NGraphReshapeTests, CNNReshapeSpatialReLU) {
+TEST_F(NGraphReshapeTests, smoke_CNNReshapeSpatialReLU) {
     std::shared_ptr<const ngraph::Function> ngraph;
     {
         ngraph::PartialShape shape({1, 3, 22, 22});
@@ -178,7 +178,7 @@ TEST_F(NGraphReshapeTests, CNNReshapeSpatialReLU) {
     ASSERT_EQ(ngraph->get_results()[0]->get_shape(), ngraph::Shape({1, 3, 22, 22}));
 }
 
-TEST_F(NGraphReshapeTests, CNNReshapeSpatialReLUWithoutCloneFunction) {
+TEST_F(NGraphReshapeTests, smoke_CNNReshapeSpatialReLUWithoutCloneFunction) {
     std::shared_ptr<ngraph::Function> ngraph;
     {
         ngraph::PartialShape shape({1, 3, 22, 22});
@@ -275,7 +275,7 @@ public:
 private:
 };
 
-TEST_F(NGraphReshapeTests, ReshapeNewIRWithNewExtension1) {
+TEST_F(NGraphReshapeTests, smoke_ReshapeNewIRWithNewExtension1) {
     std::string model = R"V0G0N(
 <net name="Activation" version="10">
     <layers>
@@ -346,7 +346,7 @@ TEST_F(NGraphReshapeTests, ReshapeNewIRWithNewExtension1) {
     ASSERT_EQ("CustomTestLayer", layer->type);
 }
 
-TEST_F(NGraphReshapeTests, ReshapeNewIRWithNewExtension2) {
+TEST_F(NGraphReshapeTests, smoke_ReshapeNewIRWithNewExtension2) {
     std::string model = R"V0G0N(
 <net name="Activation" version="10">
     <layers>
@@ -440,12 +440,12 @@ public:
     }
 };
 
-TEST_F(NGraphReshapeTests, LoadBadNewExtension) {
+TEST_F(NGraphReshapeTests, smoke_LoadBadNewExtension) {
     InferenceEngine::Core ie;
     ASSERT_THROW(ie.AddExtension(std::make_shared<BadExtension>()), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST_F(NGraphReshapeTests, TestInterpParameters) {
+TEST_F(NGraphReshapeTests, smoke_TestInterpParameters) {
     auto inp = std::make_shared<ngraph::op::Parameter>(ngraph::element::f32, ngraph::Shape{2, 3, 4, 5});
     inp->set_friendly_name("test");
 
@@ -471,7 +471,7 @@ TEST_F(NGraphReshapeTests, TestInterpParameters) {
     cnn.reshape(inShape);
 }
 
-TEST_F(NGraphReshapeTests, ReshapeWithDefaultGenericOps) {
+TEST_F(NGraphReshapeTests, smoke_ReshapeWithDefaultGenericOps) {
     std::string model = R"V0G0N(
 <net name="Activation" version="10">
     <layers>
@@ -536,7 +536,7 @@ TEST_F(NGraphReshapeTests, ReshapeWithDefaultGenericOps) {
     ASSERT_NO_THROW(network.reshape(newShapes));
 }
 
-TEST_F(NGraphReshapeTests, ReshapeEDDetectionOutput) {
+TEST_F(NGraphReshapeTests, smoke_ReshapeEDDetectionOutput) {
     std::string model = R"V0G0N(
 <net name="ExperimentalDetectronDetectionOutput" version="10">
     <layers>
@@ -654,7 +654,7 @@ TEST_F(NGraphReshapeTests, ReshapeEDDetectionOutput) {
     ASSERT_NO_THROW(network.reshape(newShapes));
 }
 
-TEST_F(NGraphReshapeTests, ReshapeEDPriorGridGenerator) {
+TEST_F(NGraphReshapeTests, smoke_ReshapeEDPriorGridGenerator) {
     std::string model = R"V0G0N(
 <net name="PriorGridGenerator" version="10">
     <layers>
@@ -740,7 +740,7 @@ TEST_F(NGraphReshapeTests, ReshapeEDPriorGridGenerator) {
     ASSERT_NO_THROW(network.reshape(newShapes));
 }
 
-TEST_F(NGraphReshapeTests, ReshapeEDGenerateProposalsSingleImage) {
+TEST_F(NGraphReshapeTests, smoke_ReshapeEDGenerateProposalsSingleImage) {
     std::string model = R"V0G0N(
 <net name="GenerateProposalsSingleImage" version="10">
     <layers>
@@ -847,7 +847,7 @@ TEST_F(NGraphReshapeTests, ReshapeEDGenerateProposalsSingleImage) {
     ASSERT_NO_THROW(network.reshape(newShapes));
 }
 
-TEST_F(NGraphReshapeTests, ReshapeEDROIFeatureExtractor) {
+TEST_F(NGraphReshapeTests, smoke_ReshapeEDROIFeatureExtractor) {
     std::string model = R"V0G0N(
 <net name="ExperimentalDetectronROIFeatureExtractor" version="10">
     <layers>
@@ -921,7 +921,7 @@ TEST_F(NGraphReshapeTests, ReshapeEDROIFeatureExtractor) {
     ASSERT_NO_THROW(network.reshape(newShapes));
 }
 
-TEST_F(NGraphReshapeTests, ReshapeEDTopKROIs) {
+TEST_F(NGraphReshapeTests, smoke_ReshapeEDTopKROIs) {
     std::string model = R"V0G0N(
 <net name="ExperimentalDetectronTopKROIs" version="10">
     <layers>

--- a/inference-engine/tests/functional/inference_engine/onnx_reader/onnx_reader.cpp
+++ b/inference-engine/tests/functional/inference_engine/onnx_reader/onnx_reader.cpp
@@ -11,7 +11,7 @@
 #include <ie_core.hpp>
 #include <ngraph/ngraph.hpp>
 
-TEST(ONNX_Reader_Tests, ImportBasicModelToCore) {
+TEST(ONNX_Reader_Tests, smoke_ImportBasicModelToCore) {
     std::string model = R"V0G0N(
 ir_version: 3
 producer_name: "nGraph ONNX Importer"

--- a/inference-engine/tests/functional/inference_engine/parameter_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/parameter_tests.cpp
@@ -41,14 +41,14 @@ public:
     }
 };
 
-TEST_F(ParameterTests, ParameterAsInt) {
+TEST_F(ParameterTests, smoke_ParameterAsInt) {
     Parameter p = 4;
     ASSERT_TRUE(p.is<int>());
     int test = p;
     ASSERT_EQ(4, test);
 }
 
-TEST_F(ParameterTests, ParameterAsUInt) {
+TEST_F(ParameterTests, ParameterAsUInt_smoke) {
     Parameter p = 4u;
     ASSERT_TRUE(p.is<unsigned int>());
     ASSERT_FALSE(p.is<size_t>());
@@ -56,7 +56,7 @@ TEST_F(ParameterTests, ParameterAsUInt) {
     ASSERT_EQ(4, test);
 }
 
-TEST_F(ParameterTests, ParameterAsSize_t) {
+TEST_F(ParameterTests, smoke_ParameterAsSize_t) {
     size_t ref = 4;
     Parameter p = ref;
     ASSERT_TRUE(p.is<size_t>());
@@ -64,14 +64,14 @@ TEST_F(ParameterTests, ParameterAsSize_t) {
     ASSERT_EQ(ref, test);
 }
 
-TEST_F(ParameterTests, ParameterAsFloat) {
+TEST_F(ParameterTests, smoke_ParameterAsFloat) {
     Parameter p = 4.f;
     ASSERT_TRUE(p.is<float>());
     float test = p;
     ASSERT_EQ(4.f, test);
 }
 
-TEST_F(ParameterTests, ParameterAsString) {
+TEST_F(ParameterTests, smoke_ParameterAsString) {
     std::string ref = "test";
     Parameter p = ref;
     std::string test = p;
@@ -79,14 +79,14 @@ TEST_F(ParameterTests, ParameterAsString) {
     ASSERT_EQ(ref, test);
 }
 
-TEST_F(ParameterTests, ParameterAsStringInLine) {
+TEST_F(ParameterTests, smoke_ParameterAsStringInLine) {
     Parameter p = "test";
     std::string test = p;
     ASSERT_TRUE(p.is<std::string>());
     ASSERT_EQ("test", test);
 }
 
-TEST_F(ParameterTests, IntParameterAsString) {
+TEST_F(ParameterTests, smoke_IntParameterAsString) {
     Parameter p = 4;
     ASSERT_TRUE(p.is<int>());
     ASSERT_FALSE(p.is<std::string>());
@@ -94,7 +94,7 @@ TEST_F(ParameterTests, IntParameterAsString) {
     ASSERT_THROW(std::string test = p.as<std::string>(), std::bad_cast);
 }
 
-TEST_F(ParameterTests, StringParameterAsInt) {
+TEST_F(ParameterTests, smoke_StringParameterAsInt) {
     Parameter p = "4";
     ASSERT_FALSE(p.is<int>());
     ASSERT_TRUE(p.is<std::string>());
@@ -102,7 +102,7 @@ TEST_F(ParameterTests, StringParameterAsInt) {
     ASSERT_THROW(int test = p.as<int>(), std::bad_cast);
 }
 
-TEST_F(ParameterTests, ParameterAsTensorDesc) {
+TEST_F(ParameterTests, smoke_ParameterAsTensorDesc) {
     TensorDesc ref(Precision::FP32, {1, 3, 2, 2}, Layout::NCHW);
     Parameter p = ref;
     ASSERT_TRUE(p.is<TensorDesc>());
@@ -110,7 +110,7 @@ TEST_F(ParameterTests, ParameterAsTensorDesc) {
     ASSERT_EQ(ref, test);
 }
 
-TEST_F(ParameterTests, ParameterAsInts) {
+TEST_F(ParameterTests, smoke_ParameterAsInts) {
     std::vector<int> ref = {1, 2, 3, 4, 5};
     Parameter p = ref;
     ASSERT_TRUE(p.is<std::vector<int>>());
@@ -121,7 +121,7 @@ TEST_F(ParameterTests, ParameterAsInts) {
     }
 }
 
-TEST_F(ParameterTests, ParameterAsUInts) {
+TEST_F(ParameterTests, smoke_ParameterAsUInts) {
     std::vector<unsigned int> ref = {1, 2, 3, 4, 5};
     Parameter p = ref;
     ASSERT_TRUE(p.is<std::vector<unsigned int>>());
@@ -132,7 +132,7 @@ TEST_F(ParameterTests, ParameterAsUInts) {
     }
 }
 
-TEST_F(ParameterTests, ParameterAsSize_ts) {
+TEST_F(ParameterTests, smoke_ParameterAsSize_ts) {
     std::vector<size_t> ref = {1, 2, 3, 4, 5};
     Parameter p = ref;
     ASSERT_TRUE(p.is<std::vector<size_t>>());
@@ -143,7 +143,7 @@ TEST_F(ParameterTests, ParameterAsSize_ts) {
     }
 }
 
-TEST_F(ParameterTests, ParameterAsFloats) {
+TEST_F(ParameterTests, smoke_ParameterAsFloats) {
     std::vector<float> ref = {1, 2, 3, 4, 5};
     Parameter p = ref;
     ASSERT_TRUE(p.is<std::vector<float>>());
@@ -154,7 +154,7 @@ TEST_F(ParameterTests, ParameterAsFloats) {
     }
 }
 
-TEST_F(ParameterTests, ParameterAsStrings) {
+TEST_F(ParameterTests, smoke_ParameterAsStrings) {
     std::vector<std::string> ref = {"test1", "test2", "test3", "test4", "test1"};
     Parameter p = ref;
     ASSERT_TRUE(p.is<std::vector<std::string>>());
@@ -165,7 +165,7 @@ TEST_F(ParameterTests, ParameterAsStrings) {
     }
 }
 
-TEST_F(ParameterTests, ParameterAsMapOfParameters) {
+TEST_F(ParameterTests, smoke_ParameterAsMapOfParameters) {
     std::map<std::string, Parameter> refMap;
     refMap["testParamInt"] = 4;
     refMap["testParamString"] = "test";
@@ -184,45 +184,45 @@ TEST_F(ParameterTests, ParameterAsMapOfParameters) {
     ASSERT_EQ(refMap["testParamString"].as<std::string>(), testString);
 }
 
-TEST_F(ParameterTests, ParameterNotEmpty) {
+TEST_F(ParameterTests, smoke_ParameterNotEmpty) {
     Parameter p = 4;
     ASSERT_FALSE(p.empty());
 }
 
-TEST_F(ParameterTests, ParameterEmpty) {
+TEST_F(ParameterTests, smoke_ParameterEmpty) {
     Parameter p;
     ASSERT_TRUE(p.empty());
 }
 
-TEST_F(ParameterTests, ParameterClear) {
+TEST_F(ParameterTests, smoke_ParameterClear) {
     Parameter p = 4;
     ASSERT_FALSE(p.empty());
     p.clear();
     ASSERT_TRUE(p.empty());
 }
 
-TEST_F(ParameterTests, ParametersNotEqualByType) {
+TEST_F(ParameterTests, smoke_ParametersNotEqualByType) {
     Parameter p1 = 4;
     Parameter p2 = "string";
     ASSERT_TRUE(p1 != p2);
     ASSERT_FALSE(p1 == p2);
 }
 
-TEST_F(ParameterTests, ParametersNotEqualByValue) {
+TEST_F(ParameterTests, smoke_ParametersNotEqualByValue) {
     Parameter p1 = 4;
     Parameter p2 = 5;
     ASSERT_TRUE(p1 != p2);
     ASSERT_FALSE(p1 == p2);
 }
 
-TEST_F(ParameterTests, ParametersEqual) {
+TEST_F(ParameterTests, smoke_ParametersEqual) {
     Parameter p1 = 4;
     Parameter p2 = 4;
     ASSERT_TRUE(p1 == p2);
     ASSERT_FALSE(p1 != p2);
 }
 
-TEST_F(ParameterTests, ParametersStringEqual) {
+TEST_F(ParameterTests, smoke_ParametersStringEqual) {
     std::string s1 = "abc";
     std::string s2 = std::string("a") + "bc";
     Parameter p1 = s1;
@@ -232,7 +232,7 @@ TEST_F(ParameterTests, ParametersStringEqual) {
     ASSERT_FALSE(p1 != p2);
 }
 
-TEST_F(ParameterTests, ParametersCStringEqual) {
+TEST_F(ParameterTests, smoke_ParametersCStringEqual) {
     const char s1[] = "abc";
     const char s2[] = "abc";
     Parameter p1 = s1;
@@ -242,7 +242,7 @@ TEST_F(ParameterTests, ParametersCStringEqual) {
     ASSERT_FALSE(p1 != p2);
 }
 
-TEST_F(ParameterTests, CompareParametersWithoutEqualOperator) {
+TEST_F(ParameterTests, smoke_CompareParametersWithoutEqualOperator) {
     class TestClass {
     public:
         TestClass(int test, int* testPtr): test(test), testPtr(testPtr) {}
@@ -265,7 +265,7 @@ TEST_F(ParameterTests, CompareParametersWithoutEqualOperator) {
     ASSERT_THROW(bool equal = parA != parC, details::InferenceEngineException);
 }
 
-TEST_F(ParameterTests, ParameterRemovedRealObject) {
+TEST_F(ParameterTests, smoke_ParameterRemovedRealObject) {
     ASSERT_EQ(0, DestructorTest::constructorCount);
     ASSERT_EQ(0, DestructorTest::destructorCount);
     {
@@ -276,7 +276,7 @@ TEST_F(ParameterTests, ParameterRemovedRealObject) {
     ASSERT_EQ(2, DestructorTest::destructorCount);
 }
 
-TEST_F(ParameterTests, ParameterRemovedRealObjectWithDuplication) {
+TEST_F(ParameterTests, smoke_ParameterRemovedRealObjectWithDuplication) {
     ASSERT_EQ(0, DestructorTest::constructorCount);
     ASSERT_EQ(0, DestructorTest::destructorCount);
     {
@@ -290,7 +290,7 @@ TEST_F(ParameterTests, ParameterRemovedRealObjectWithDuplication) {
     ASSERT_EQ(4, DestructorTest::destructorCount);
 }
 
-TEST_F(ParameterTests, ParameterRemovedRealObjectPointerWithDuplication) {
+TEST_F(ParameterTests, smoke_ParameterRemovedRealObjectPointerWithDuplication) {
     ASSERT_EQ(0, DestructorTest::constructorCount);
     ASSERT_EQ(0, DestructorTest::destructorCount);
     {

--- a/inference-engine/tests/functional/inference_engine/pre_allocator_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/pre_allocator_test.cpp
@@ -27,7 +27,7 @@ class PreallocatorTests: public ::testing::Test {
     std::shared_ptr<IAllocator> allocator;
 };
 
-TEST_F(PreallocatorTests, canAccessPreAllocatedMemory) {
+TEST_F(PreallocatorTests, smoke_canAccessPreAllocatedMemory) {
     void * handle = allocator->alloc(3);
     float * ptr = reinterpret_cast<float*>(allocator->lock(handle));
 
@@ -39,13 +39,13 @@ TEST_F(PreallocatorTests, canAccessPreAllocatedMemory) {
     ASSERT_EQ(ptr[2], 3.3f);
 }
 
-TEST_F(PreallocatorTests, canNotAllocateMoreMemory) {
+TEST_F(PreallocatorTests, smoke_canNotAllocateMoreMemory) {
     //large block such as 10k will result in nullptr
     EXPECT_EQ(nullptr, allocator->lock(allocator->alloc(10* sizeof(float) + 1)));
     EXPECT_NE(nullptr, allocator->lock(allocator->alloc(10* sizeof(float))));
 }
 
-TEST_F(PreallocatorTests, canNotLockWrongHandle) {
+TEST_F(PreallocatorTests, smoke_canNotLockWrongHandle) {
     void * handle  = allocator->alloc(3);
     EXPECT_EQ(nullptr, allocator->lock(1 + reinterpret_cast<int*>(handle)));
 }

--- a/inference-engine/tests/functional/inference_engine/preprocess_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/preprocess_test.cpp
@@ -9,14 +9,14 @@ using namespace std;
 
 using PreProcessTests = ::testing::Test;
 
-TEST_F(PreProcessTests, throwsOnSettingNullMeanImage) {
+TEST_F(PreProcessTests, smoke_throwsOnSettingNullMeanImage) {
     InferenceEngine::PreProcessInfo info;
     info.init(1);
     ASSERT_THROW(info.setMeanImage(InferenceEngine::Blob::Ptr(nullptr)),
             InferenceEngine::details::InferenceEngineException);
 }
 
-TEST_F(PreProcessTests, throwsOnSetting2DMeanImage) {
+TEST_F(PreProcessTests, smoke_throwsOnSetting2DMeanImage) {
     InferenceEngine::PreProcessInfo info;
     info.init(1);
     InferenceEngine::Blob::Ptr blob(new InferenceEngine::TBlob<float>({ InferenceEngine::Precision::FP32,
@@ -24,7 +24,7 @@ TEST_F(PreProcessTests, throwsOnSetting2DMeanImage) {
     ASSERT_THROW(info.setMeanImage(blob), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST_F(PreProcessTests, throwsOnSettingWrongSizeMeanImage) {
+TEST_F(PreProcessTests, smoke_throwsOnSettingWrongSizeMeanImage) {
     InferenceEngine::PreProcessInfo info;
     info.init(1);
     InferenceEngine::TBlob<float>::Ptr blob(new InferenceEngine::TBlob<float>({ InferenceEngine::Precision::FP32,
@@ -33,7 +33,7 @@ TEST_F(PreProcessTests, throwsOnSettingWrongSizeMeanImage) {
     ASSERT_THROW(info.setMeanImage(blob), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST_F(PreProcessTests, noThrowWithCorrectSizeMeanImage) {
+TEST_F(PreProcessTests, smoke_noThrowWithCorrectSizeMeanImage) {
     InferenceEngine::PreProcessInfo info;
     info.init(2);
     InferenceEngine::TBlob<float>::Ptr blob(new InferenceEngine::TBlob<float>({ InferenceEngine::Precision::FP32,

--- a/inference-engine/tests/functional/inference_engine/response_buffer_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/response_buffer_test.cpp
@@ -10,20 +10,20 @@ using namespace InferenceEngine;
 
 using ResponseBufferTests = ::testing::Test;
 
-TEST_F(ResponseBufferTests, canCreateResponseMessage) {
+TEST_F(ResponseBufferTests, smoke_canCreateResponseMessage) {
     ResponseDesc desc;
     DescriptionBuffer(&desc) << "make error: " << 1;
     ASSERT_STREQ("make error: 1", desc.msg);
 }
 
-TEST_F(ResponseBufferTests, canReportError) {
+TEST_F(ResponseBufferTests, smoke_canReportError) {
     ResponseDesc desc;
     DescriptionBuffer d(NETWORK_NOT_LOADED, &desc);
     d << "make error: ";
     ASSERT_EQ(NETWORK_NOT_LOADED, (StatusCode)d);
 }
 
-TEST_F(ResponseBufferTests, savePreviosMessage) {
+TEST_F(ResponseBufferTests, smoke_savePreviosMessage) {
     ResponseDesc desc;
     desc.msg[0] = 'T';
     desc.msg[1] = 'e';
@@ -35,7 +35,7 @@ TEST_F(ResponseBufferTests, savePreviosMessage) {
     ASSERT_EQ(std::string("Test"), desc.msg);
 }
 
-TEST_F(ResponseBufferTests, canHandleBigMessage) {
+TEST_F(ResponseBufferTests, smoke_canHandleBigMessage) {
     ResponseDesc desc;
     int size = sizeof(desc.msg) / sizeof(desc.msg[0]);
     DescriptionBuffer buf(&desc);
@@ -47,7 +47,7 @@ TEST_F(ResponseBufferTests, canHandleBigMessage) {
     ASSERT_EQ(desc.msg[size - 1], 0);
 }
 
-TEST_F(ResponseBufferTests, canHandleNotNullTerminatedInput) {
+TEST_F(ResponseBufferTests, smoke_canHandleNotNullTerminatedInput) {
     ResponseDesc desc;
     int size = sizeof(desc.msg) / sizeof(desc.msg[0]);
 
@@ -62,7 +62,7 @@ TEST_F(ResponseBufferTests, canHandleNotNullTerminatedInput) {
     ASSERT_EQ(desc.msg[size - 1], 0);
 }
 
-TEST_F(ResponseBufferTests, canHandlePredefined) {
+TEST_F(ResponseBufferTests, smoke_canHandlePredefined) {
     ResponseDesc desc;
     int size = sizeof(desc.msg) / sizeof(desc.msg[0]);
 
@@ -79,7 +79,7 @@ TEST_F(ResponseBufferTests, canHandlePredefined) {
     ASSERT_EQ(desc.msg[size - 1], 0);
 }
 
-TEST_F(ResponseBufferTests, canHandleNotNullTerminatedPredefined) {
+TEST_F(ResponseBufferTests, smoke_canHandleNotNullTerminatedPredefined) {
     ResponseDesc desc;
     int size = sizeof(desc.msg) / sizeof(desc.msg[0]);
 

--- a/inference-engine/tests/functional/inference_engine/shared_object_loader_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/shared_object_loader_test.cpp
@@ -36,29 +36,29 @@ protected:
 typedef void*(*PluginEngineCreateFunc)(void);
 typedef void(*PluginEngineDestoryFunc)(void *);
 
-TEST_F(SharedObjectLoaderTests, canLoadExistedPlugin) {
+TEST_F(SharedObjectLoaderTests, smoke_canLoadExistedPlugin) {
     loadDll(get_mock_engine_name());
     EXPECT_NE(nullptr, sharedObjectLoader.get());
 }
 
-TEST_F(SharedObjectLoaderTests, loaderThrowsIfNoPlugin) {
+TEST_F(SharedObjectLoaderTests, smoke_loaderThrowsIfNoPlugin) {
     EXPECT_THROW(loadDll("wrong_name"), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST_F(SharedObjectLoaderTests, canFindExistedMethod) {
+TEST_F(SharedObjectLoaderTests, smoke_canFindExistedMethod) {
     loadDll(get_mock_engine_name());
 
     auto factory = make_std_function<StatusCode(IInferencePlugin*&, ResponseDesc*)>("CreatePluginEngine");
     EXPECT_NE(nullptr, factory);
 }
 
-TEST_F(SharedObjectLoaderTests, throwIfMethodNofFoundInLibrary) {
+TEST_F(SharedObjectLoaderTests, smoke_throwIfMethodNofFoundInLibrary) {
     loadDll(get_mock_engine_name());
 
     EXPECT_THROW(make_std_function<IInferencePlugin*()>("wrong_function"), InferenceEngine::details::InferenceEngineException);
 }
 
-TEST_F(SharedObjectLoaderTests, canCallExistedMethod) {
+TEST_F(SharedObjectLoaderTests, smoke_canCallExistedMethod) {
     loadDll(get_mock_engine_name());
 
     auto factory = make_std_function<StatusCode(IInferencePlugin*&, ResponseDesc*)>("CreatePluginEngine");

--- a/inference-engine/tests/functional/inference_engine/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/inference_engine/skip_tests_config.cpp
@@ -9,10 +9,10 @@
 
 std::vector<std::string> disabledTestPatterns() {
     return {
-        // TODO: FIX BUG 33375
+        // TODO: Issue: 33375
         // Disabled due to rare sporadic failures.
-        ".*TransformationTests\\.ConstFoldingPriorBoxClustered.*",
-        // TODO: task 32568, enable after supporting constants outputs in plugins
-        ".*TransformationTests\\.ConstFoldingPriorBox.*",
+        ".*TransformationTests.*ConstFoldingPriorBoxClustered.*",
+        // TODO: Issue: 32568, enable after supporting constants outputs in plugins
+        ".*TransformationTests.*ConstFoldingPriorBox.*",
     };
 }

--- a/inference-engine/tests/functional/inference_engine/so_pointer_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/so_pointer_tests.cpp
@@ -54,7 +54,7 @@ protected:
     PointedObjHelper *obj1 = nullptr, *obj2 = nullptr;
 };
 
-TEST_F(SoPointerTests, assignObjThenLoader) {
+TEST_F(SoPointerTests, smoke_assignObjThenLoader) {
     auto loaderPtr1 = std::make_shared<SharedObjectLoaderHelper>();
     auto objPtr1 = std::make_shared<PointedObjHelper>();
     auto loaderPtr2 = std::make_shared<SharedObjectLoaderHelper>();
@@ -91,11 +91,11 @@ public:
 
 }  // namespace InferenceEngine
 
-TEST_F(SoPointerTests, UnknownPlugin) {
+TEST_F(SoPointerTests, smoke_UnknownPlugin) {
     ASSERT_THROW(SOPointer<InferenceEngine::details::IRelease>("UnknownPlugin"), InferenceEngineException);
 }
 
-TEST_F(SoPointerTests, UnknownPluginExceptionStr) {
+TEST_F(SoPointerTests, smoke_UnknownPluginExceptionStr) {
     try {
         SOPointer<InferenceEngine::details::IRelease>("UnknownPlugin");
     }

--- a/inference-engine/tests/functional/inference_engine/task_executor_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/task_executor_tests.cpp
@@ -22,7 +22,7 @@ using Future = std::future<void>;
 
 class TaskExecutorTests : public ::testing::TestWithParam<std::function<ITaskExecutor::Ptr()>> {};
 
-TEST_P(TaskExecutorTests, canCreateTaskExecutor) {
+TEST_P(TaskExecutorTests, smoke_canCreateTaskExecutor) {
     auto makeExecutor = GetParam();
     EXPECT_NO_THROW(makeExecutor());
 }
@@ -35,7 +35,7 @@ static std::future<void> async(E& executor, F&& f) {
     return future;
 }
 
-TEST_P(TaskExecutorTests, canRunCustomFunction) {
+TEST_P(TaskExecutorTests, smoke_canRunCustomFunction) {
     auto taskExecutor = GetParam()();
     int i = 0;
     auto f = async(taskExecutor, [&i] { i++; });
@@ -43,7 +43,7 @@ TEST_P(TaskExecutorTests, canRunCustomFunction) {
     ASSERT_NO_THROW(f.get());
 }
 
-TEST_P(TaskExecutorTests, canRun2FunctionsOneByOne) {
+TEST_P(TaskExecutorTests, smoke_canRun2FunctionsOneByOne) {
     auto taskExecutor = GetParam()();
     std::mutex m;
     int i = 0;
@@ -57,7 +57,7 @@ TEST_P(TaskExecutorTests, canRun2FunctionsOneByOne) {
     ASSERT_EQ(i, 2);
 }
 
-TEST_P(TaskExecutorTests, canRun2FunctionsOneByOneWithoutWait) {
+TEST_P(TaskExecutorTests, smoke_canRun2FunctionsOneByOneWithoutWait) {
     auto taskExecutor = GetParam()();
     async(taskExecutor, [] {
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
@@ -67,7 +67,7 @@ TEST_P(TaskExecutorTests, canRun2FunctionsOneByOneWithoutWait) {
     });
 }
 
-TEST_P(TaskExecutorTests, canRunMultipleTasksWithExceptionInside) {
+TEST_P(TaskExecutorTests, smoke_canRunMultipleTasksWithExceptionInside) {
     auto taskExecutor = GetParam()();
     std::vector<std::future<void>> futures;
 
@@ -82,7 +82,7 @@ TEST_P(TaskExecutorTests, canRunMultipleTasksWithExceptionInside) {
 }
 
 // TODO: Issue-11695
-TEST_P(TaskExecutorTests, canRunMultipleTasksFromMultipleThreads) {
+TEST_P(TaskExecutorTests, smoke_canRunMultipleTasksFromMultipleThreads) {
     auto taskExecutor = GetParam()();
     std::atomic_int sharedVar = {0};
     int THREAD_NUMBER = MAX_NUMBER_OF_TASKS_IN_QUEUE;
@@ -105,7 +105,7 @@ TEST_P(TaskExecutorTests, canRunMultipleTasksFromMultipleThreads) {
     for (auto&& thread : threads) if (thread.joinable()) thread.join();
 }
 
-TEST_P(TaskExecutorTests, executorNotReleasedUntilTasksAreDone) {
+TEST_P(TaskExecutorTests, smoke_executorNotReleasedUntilTasksAreDone) {
     std::mutex mutex_block_emulation;
     std::condition_variable cv_block_emulation;
     std::vector<Future> futures;

--- a/inference-engine/tests/functional/inference_engine/tensor_desc_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/tensor_desc_test.cpp
@@ -16,11 +16,11 @@ using namespace InferenceEngine;
 
 using TensorDescTests = ::testing::Test;
 
-TEST_F(TensorDescTests, CreateBlobWithIncorrectLayout) {
+TEST_F(TensorDescTests, smoke_CreateBlobWithIncorrectLayout) {
     ASSERT_THROW(make_shared_blob<float>({ Precision::FP32, {1, 3, 32}, Layout::NC }), details::InferenceEngineException);
 }
 
-TEST_F(TensorDescTests, CreateBlockedBlobNCHW) {
+TEST_F(TensorDescTests, smoke_CreateBlockedBlobNCHW) {
     TensorDesc desc(Precision::FP32, {1, 4, 2, 1}, {{1, 2, 2, 1, 2}, {0, 1, 2, 3, 1}});
     float data[8] = {1, 2, 3, 4, 5, 6, 7, 8};
     Blob::Ptr blockedBlob = make_shared_blob<float>(desc, data);
@@ -32,7 +32,7 @@ TEST_F(TensorDescTests, CreateBlockedBlobNCHW) {
     ASSERT_EQ(Layout::BLOCKED, blockedBlob->getTensorDesc().getLayout());
 }
 
-TEST_F(TensorDescTests, CreateBlockedBlobNCDHW) {
+TEST_F(TensorDescTests, smoke_CreateBlockedBlobNCDHW) {
     TensorDesc desc(Precision::FP32, {1, 4, 2, 2, 1}, {{1, 2, 2, 2, 1, 2}, {0, 1, 2, 3, 4, 1}});
     float data[8] = {1, 2, 3, 4, 5, 6, 7, 8};
     Blob::Ptr blockedBlob = make_shared_blob<float>(desc, data);
@@ -44,7 +44,7 @@ TEST_F(TensorDescTests, CreateBlockedBlobNCDHW) {
     ASSERT_EQ(Layout::BLOCKED, blockedBlob->getTensorDesc().getLayout());
 }
 
-TEST_F(TensorDescTests, CompareNHWCandNCHWLayouts) {
+TEST_F(TensorDescTests, smoke_CompareNHWCandNCHWLayouts) {
     TensorDesc descNCHW(Precision::FP32, {1, 3, 4, 2}, Layout::NCHW);
     TensorDesc descNHWC(Precision::FP32, {1, 3, 4, 2}, Layout::NHWC);
     SizeVector nchw = {0, 1, 2, 3};
@@ -57,7 +57,7 @@ TEST_F(TensorDescTests, CompareNHWCandNCHWLayouts) {
     ASSERT_EQ(descNHWC.getBlockingDesc().getOrder(), nhwc);
 }
 
-TEST_F(TensorDescTests, CompareNDHWCandNCDHWLayouts) {
+TEST_F(TensorDescTests, smoke_CompareNDHWCandNCDHWLayouts) {
     TensorDesc descNCDHW(Precision::FP32, {1, 3, 4, 4, 2}, Layout::NCDHW);
     TensorDesc descNDHWC(Precision::FP32, {1, 3, 4, 4, 2}, Layout::NDHWC);
     SizeVector ncdhw = {0, 1, 2, 3, 4};
@@ -70,7 +70,7 @@ TEST_F(TensorDescTests, CompareNDHWCandNCDHWLayouts) {
     ASSERT_EQ(descNDHWC.getBlockingDesc().getOrder(), ndhwc);
 }
 
-TEST_F(TensorDescTests, SetLayout) {
+TEST_F(TensorDescTests, smoke_SetLayout) {
     TensorDesc descNCHW(Precision::FP32, {1, 2, 3, 4}, Layout::NCHW);
 
     TensorDesc decsNHWC = descNCHW;

--- a/inference-engine/tests/functional/inference_engine/transformations/algebraic_simplification.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/algebraic_simplification.cpp
@@ -24,7 +24,7 @@
 using namespace ngraph;
 using namespace std;
 
-TEST(algebraic_simplification, add_negative_tests) {
+TEST(algebraic_simplification, smoke_add_negative_tests) {
     Shape shape{};
     auto type = element::f32;
     pass::Manager pass_manager;
@@ -51,7 +51,7 @@ TEST(algebraic_simplification, add_negative_tests) {
     }
 }
 
-TEST(algebraic_simplification, multiply_negative_tests) {
+TEST(algebraic_simplification, smoke_multiply_negative_tests) {
     Shape shape{};
     auto type = element::f32;
     pass::Manager pass_manager;
@@ -78,7 +78,7 @@ TEST(algebraic_simplification, multiply_negative_tests) {
     }
 }
 
-TEST(algebraic_simplification, multiply_prod_negative) {
+TEST(algebraic_simplification, smoke_multiply_prod_negative) {
     auto fconst1 = ngraph::op::Constant::create(element::f64, Shape{2}, {1.0, 1.0});
     auto broadcast = std::make_shared<op::Broadcast>(fconst1, Shape{2, 5}, AxisSet{1});
     auto prod_fconst1 = std::make_shared<op::Product>(broadcast, AxisSet{0, 1});
@@ -92,7 +92,7 @@ TEST(algebraic_simplification, multiply_prod_negative) {
     ASSERT_EQ(f_prod, prod_fconst1);
 }
 
-TEST(algebraic_simplification, multiply_sum_negative) {
+TEST(algebraic_simplification, smoke_multiply_sum_negative) {
     auto fconst1 = ngraph::op::Constant::create(element::f64, Shape{2}, {1.0, 1.0});
     auto broadcast = std::make_shared<op::Broadcast>(fconst1, Shape{2, 5}, AxisSet{1});
     auto sum_fconst1 = std::make_shared<op::Sum>(broadcast, AxisSet{0, 1});
@@ -106,7 +106,7 @@ TEST(algebraic_simplification, multiply_sum_negative) {
     ASSERT_EQ(f_sum, sum_fconst1);
 }
 
-TEST(algebraic_simplification, concat_parameter_slices_reversed) {
+TEST(algebraic_simplification, smoke_concat_parameter_slices_reversed) {
     auto a = make_shared<op::Parameter>(element::f32, Shape{96, 100});
     auto slice1 = make_shared<op::Slice>(a, Coordinate{0, 0}, Coordinate{32, 100}, Strides{1, 1});
     auto slice2 = make_shared<op::Slice>(a, Coordinate{32, 0}, Coordinate{64, 100}, Strides{1, 1});
@@ -123,7 +123,7 @@ TEST(algebraic_simplification, concat_parameter_slices_reversed) {
     ASSERT_EQ(f->get_results().at(0)->input_value(0).get_node_shared_ptr(), concat);
 }
 
-TEST(algebraic_simplification, concat_parameter_slices_element_count) {
+TEST(algebraic_simplification, smoke_concat_parameter_slices_element_count) {
     auto a = make_shared<op::Parameter>(element::f32, Shape{96, 100});
     // slicing 30 elements out of 96; should trigger a check that some elements are missing
     auto slice1 = make_shared<op::Slice>(a, Coordinate{0, 0}, Coordinate{10, 100}, Strides{1, 1});
@@ -141,7 +141,7 @@ TEST(algebraic_simplification, concat_parameter_slices_element_count) {
     ASSERT_EQ(f->get_results().at(0)->input_value(0).get_node_shared_ptr(), concat);
 }
 
-TEST(algebraic_simplification, concat_parameter_non_uniform_slices) {
+TEST(algebraic_simplification, smoke_concat_parameter_non_uniform_slices) {
     auto a = make_shared<op::Parameter>(element::f32, Shape{96, 100});
     auto slice1 = make_shared<op::Slice>(a, Coordinate{0, 0}, Coordinate{38, 100}, Strides{1, 1});
     auto slice2 = make_shared<op::Slice>(a, Coordinate{38, 0}, Coordinate{64, 100}, Strides{1, 1});
@@ -158,7 +158,7 @@ TEST(algebraic_simplification, concat_parameter_non_uniform_slices) {
     ASSERT_EQ(f->get_results().at(0)->input_value(0).get_node_shared_ptr(), concat);
 }
 
-TEST(algebraic_simplification, concat_different_inputs) {
+TEST(algebraic_simplification, smoke_concat_different_inputs) {
     auto a = make_shared<op::Parameter>(element::f32, Shape{96, 100});
     auto goe1 = -a;
     auto goe2 = -a;
@@ -180,7 +180,7 @@ TEST(algebraic_simplification, concat_different_inputs) {
     ASSERT_EQ(f->get_results().at(0)->input_value(0).get_node_shared_ptr(), concat);
 }
 
-TEST(algebraic_simplification, log_no_exp) {
+TEST(algebraic_simplification, smoke_log_no_exp) {
     auto a = make_shared<op::Parameter>(element::f32, Shape{96, 100});
     auto b = make_shared<op::Parameter>(element::f32, Shape{96, 100});
     auto abs_a = make_shared<op::Abs>(a);
@@ -200,7 +200,7 @@ TEST(algebraic_simplification, log_no_exp) {
     ASSERT_EQ(neg_inner->input_value(0).get_node_shared_ptr(), log_div);
 }
 
-TEST(algebraic_simplification, log_no_divide) {
+TEST(algebraic_simplification, smoke_log_no_divide) {
     auto a = make_shared<op::Parameter>(element::f32, Shape{96, 100});
     auto b = make_shared<op::Parameter>(element::f32, Shape{96, 100});
     auto exp_a = make_shared<op::Exp>(a);
@@ -220,13 +220,13 @@ TEST(algebraic_simplification, log_no_divide) {
     ASSERT_EQ(neg_inner->input_value(0).get_node_shared_ptr(), log_mul);
 }
 
-TEST(algebraic_simplification, pass_property) {
+TEST(algebraic_simplification, smoke_pass_property) {
     auto pass = std::make_shared<ngraph::pass::AlgebraicSimplification>();
 
     ASSERT_FALSE(pass->get_property(pass::PassProperty::CHANGE_DYNAMIC_STATE));
 }
 
-TEST(algebraic_simplification, replace_transpose_with_reshape) {
+TEST(algebraic_simplification, smoke_replace_transpose_with_reshape) {
     auto check_usecase = [](const PartialShape& shape,
                             const std::vector<int64_t>& perm_val,
                             bool i32,
@@ -312,7 +312,7 @@ TEST(algebraic_simplification, replace_transpose_with_reshape) {
 // gather is Nop and will be removed during `simplify_gather`
 // algebraic_simplification pass
 
-TEST(algebraic_simplification, gather_3d_indices_constant_axis_1) {
+TEST(algebraic_simplification, smoke_gather_3d_indices_constant_axis_1) {
     auto check_usecase = [](const PartialShape& pshape,
                             bool i32,
                             bool multiout,
@@ -372,7 +372,7 @@ TEST(algebraic_simplification, gather_3d_indices_constant_axis_1) {
         }
 }
 
-TEST(algebraic_simplification, gather_shapeof) {
+TEST(algebraic_simplification, smoke_gather_shapeof) {
     auto check_usecase = [](const PartialShape& pshape,
                             bool is_scalar_index,
                             bool opset2,

--- a/inference-engine/tests/functional/inference_engine/transformations/batch_to_space_decomposition_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/batch_to_space_decomposition_test.cpp
@@ -24,7 +24,7 @@
 using namespace testing;
 using namespace ngraph;
 
-TEST(TransformationTests, BatchToSpaceDecompositionByElements) {
+TEST(TransformationTests, smoke_BatchToSpaceDecompositionByElements) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
 
     {
@@ -83,7 +83,7 @@ TEST(TransformationTests, BatchToSpaceDecompositionByElements) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, SpaceToBatchDecompositionByElements) {
+TEST(TransformationTests, smoke_SpaceToBatchDecompositionByElements) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
 
     {
@@ -147,7 +147,7 @@ TEST(TransformationTests, SpaceToBatchDecompositionByElements) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, SpaceToBatchDecomposition) {
+TEST(TransformationTests, smoke_SpaceToBatchDecomposition) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
 
     {
@@ -189,7 +189,7 @@ TEST(TransformationTests, SpaceToBatchDecomposition) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, BatchToSpaceDecomposition) {
+TEST(TransformationTests, smoke_BatchToSpaceDecomposition) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
 
     {

--- a/inference-engine/tests/functional/inference_engine/transformations/const_folding_prior_box.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/const_folding_prior_box.cpp
@@ -18,7 +18,7 @@
 
 using namespace testing;
 
-TEST(TransformationTests, ConstFoldingPriorBox) {
+TEST(TransformationTests, smoke_ConstFoldingPriorBox) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
 
@@ -63,7 +63,7 @@ TEST(TransformationTests, ConstFoldingPriorBox) {
     EXPECT_TRUE(fused->get_vector<float>() == ref->get_vector<float>());
 }
 
-TEST(TransformationTests, ConstFoldingPriorBoxClustered) {
+TEST(TransformationTests, smoke_ConstFoldingPriorBoxClustered) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
 
@@ -110,7 +110,7 @@ TEST(TransformationTests, ConstFoldingPriorBoxClustered) {
     EXPECT_TRUE(fused->get_vector<float>() == ref->get_vector<float>());
 }
 
-TEST(TransformationTests, ConstFoldingPriorBoxSubgraph) {
+TEST(TransformationTests, smoke_ConstFoldingPriorBoxSubgraph) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
 
@@ -165,7 +165,7 @@ TEST(TransformationTests, ConstFoldingPriorBoxSubgraph) {
     EXPECT_TRUE(fused->get_vector<float>() == ref->get_vector<float>());
 }
 
-TEST(TransformationTests, ConstFoldingPriorBoxClusteredSubgraph) {
+TEST(TransformationTests, smoke_ConstFoldingPriorBoxClusteredSubgraph) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {

--- a/inference-engine/tests/functional/inference_engine/transformations/conv_fusion_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/conv_fusion_test.cpp
@@ -122,7 +122,7 @@ TEST_P(ConvFusionTests, CompareFunctions) {
 using add = ngraph::opset1::Add;
 using mul = ngraph::opset1::Multiply;
 
-INSTANTIATE_TEST_CASE_P(ConvAddFusion, ConvFusionTests,
+INSTANTIATE_TEST_CASE_P(smoke_ConvAddFusion, ConvFusionTests,
         testing::Values(std::make_tuple(InputShape{DYN, DYN, DYN, DYN, DYN}, WeightsShape{8, 3, 1, 2, 3}, add::type_info, EltwiseShape{8, 1, 1, 1}, false),
                         std::make_tuple(InputShape{DYN, 3, 64, 64, 64}, WeightsShape{8, 3, 1, 2, 3}, add::type_info, EltwiseShape{8, 1, 1, 1}, false),
                         std::make_tuple(InputShape{2, DYN, 64, 64, 64}, WeightsShape{9, 3, 2, 3, 1}, add::type_info, EltwiseShape{9, 1, 1, 1}, false),
@@ -140,12 +140,12 @@ INSTANTIATE_TEST_CASE_P(ConvAddFusion, ConvFusionTests,
                         std::make_tuple(InputShape{2, DYN, 9},          WeightsShape{2, 3, 2},       add::type_info, EltwiseShape{2, 1}, false),
                         std::make_tuple(InputShape{3, 3, DYN},          WeightsShape{1, 3, 3},       add::type_info, EltwiseShape{1, 1}, false)));
 
-INSTANTIATE_TEST_CASE_P(DISABLED_ConvAddFusionNegative, ConvFusionTests,
+INSTANTIATE_TEST_CASE_P(DISABLED_smoke_ConvAddFusionNegative, ConvFusionTests,
         testing::Values(std::make_tuple(InputShape{DYN, DYN, DYN, DYN, DYN}, WeightsShape{8, 3, 1, 2, 3}, add::type_info, EltwiseShape{2, 1}, true),
                         std::make_tuple(InputShape{DYN, 3, 64, 64, 64}, WeightsShape{8, 3, 1, 2, 3}, add::type_info, EltwiseShape{8, 1, 1}, true),
                         std::make_tuple(InputShape{2, DYN, 64, 64, 64}, WeightsShape{9, 3, 2, 3, 1}, add::type_info, EltwiseShape{9, 1, 1, 1, 1}, true)));
 
-INSTANTIATE_TEST_CASE_P(ConvMulFusion, ConvFusionTests,
+INSTANTIATE_TEST_CASE_P(smoke_ConvMulFusion, ConvFusionTests,
         testing::Values(std::make_tuple(InputShape{DYN, DYN, DYN, DYN, DYN}, WeightsShape{8, 3, 1, 2, 3}, mul::type_info, EltwiseShape{8, 1, 1, 1}, false),
                         std::make_tuple(InputShape{DYN, 3, 64, 64, 64}, WeightsShape{8, 3, 1, 2, 3}, mul::type_info, EltwiseShape{8, 1, 1, 1}, false),
                         std::make_tuple(InputShape{2, DYN, 64, 64, 64}, WeightsShape{9, 3, 2, 3, 1}, mul::type_info, EltwiseShape{9, 1, 1, 1}, false),
@@ -163,7 +163,7 @@ INSTANTIATE_TEST_CASE_P(ConvMulFusion, ConvFusionTests,
                         std::make_tuple(InputShape{2, DYN, 9},          WeightsShape{2, 3, 2},       mul::type_info, EltwiseShape{2, 1}, false),
                         std::make_tuple(InputShape{3, 3, DYN},          WeightsShape{1, 3, 3},       mul::type_info, EltwiseShape{1, 1}, false)));
 
-INSTANTIATE_TEST_CASE_P(DISABLED_ConvMulFusionNegative, ConvFusionTests,
+INSTANTIATE_TEST_CASE_P(DISABLED_smoke_ConvMulFusionNegative, ConvFusionTests,
         testing::Values(std::make_tuple(InputShape{DYN, DYN, DYN, DYN, DYN}, WeightsShape{8, 3, 1, 2, 3}, mul::type_info, EltwiseShape{2, 1}, true),
                         std::make_tuple(InputShape{DYN, 3, 64, 64}, WeightsShape{8, 3, 1, 2, 3}, mul::type_info, EltwiseShape{8, 1, 1}, true),
                         std::make_tuple(InputShape{2, DYN, 64, 64}, WeightsShape{9, 3, 2, 3, 1}, mul::type_info, EltwiseShape{9, 1, 1, 1, 1}, true)));

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_broadcast3_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_broadcast3_test.cpp
@@ -20,7 +20,7 @@
 using namespace testing;
 
 // Broadcast-3 is converted directly to Broadcast-1 for modes NUMPY, NONE and PDPD
-TEST(TransformationTests, ConvertBroadcast3WithNumpyModeToBroadcast1) {
+TEST(TransformationTests, smoke_ConvertBroadcast3WithNumpyModeToBroadcast1) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{3, 1, 2});
@@ -53,7 +53,7 @@ TEST(TransformationTests, ConvertBroadcast3WithNumpyModeToBroadcast1) {
     ASSERT_TRUE(broadcast_node->get_friendly_name() == "broadcast") << "Transformation ConvertBroadcast3 should keep output names.\n";
 }
 
-TEST(TransformationTests, ConvertBroadcast3WithPDPDModeToBroadcast1) {
+TEST(TransformationTests, smoke_ConvertBroadcast3WithPDPDModeToBroadcast1) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{3, 1, 2});
@@ -86,7 +86,7 @@ TEST(TransformationTests, ConvertBroadcast3WithPDPDModeToBroadcast1) {
     ASSERT_TRUE(broadcast_node->get_friendly_name() == "broadcast") << "Transformation ConvertBroadcast3 should keep output names.\n";
 }
 
-TEST(TransformationTests, ConvertBroadcast3WithExplicitModeToBroadcast1) {
+TEST(TransformationTests, smoke_ConvertBroadcast3WithExplicitModeToBroadcast1) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{3, 5, 2});
@@ -121,7 +121,7 @@ TEST(TransformationTests, ConvertBroadcast3WithExplicitModeToBroadcast1) {
 }
 
 // Broadcast-3 with mode BIDIRECTIONAL is converted to Multiply with constant with 1s of the corresponding type
-TEST(TransformationTests, ConvertBroadcast3WithBidirectionalModeToBroadcast1) {
+TEST(TransformationTests, smoke_ConvertBroadcast3WithBidirectionalModeToBroadcast1) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 1, 2});

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_cells_to_cells_ie_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_cells_to_cells_ie_test.cpp
@@ -26,7 +26,7 @@
 
 using namespace testing;
 
-TEST(TransformationTests, GRUCellConversionTest) {
+TEST(TransformationTests, smoke_GRUCellConversionTest) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     std::shared_ptr<ngraph::opset3::GRUCell> cell;
 
@@ -81,7 +81,7 @@ TEST(TransformationTests, GRUCellConversionTest) {
     ASSERT_TRUE(cell_node->get_friendly_name() == "test_cell") << "Transformation ConvertGRUCellToGRUCellIE should keep output names.\n";
 }
 
-TEST(TransformationTests, RNNCellConversionTest) {
+TEST(TransformationTests, smoke_RNNCellConversionTest) {
     const size_t hidden_size = 3;
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     std::shared_ptr<ngraph::opset3::RNNCell> cell;
@@ -130,7 +130,7 @@ TEST(TransformationTests, RNNCellConversionTest) {
     ASSERT_TRUE(cell_node->get_friendly_name() == "test_cell") << "Transformation ConvertRNNCellToRNNCellIE should keep output names.\n";
 }
 
-TEST(TransformationTests, LSTMCellConversionTest_opset3) {
+TEST(TransformationTests, smoke_LSTMCellConversionTest_opset3) {
     const size_t batch_size = 2;
     const size_t input_size = 3;
     const size_t hidden_size = 3;
@@ -189,7 +189,7 @@ TEST(TransformationTests, LSTMCellConversionTest_opset3) {
     ASSERT_TRUE(cell_node->get_friendly_name() == "test_cell") << "Transformation ConvertLSTMCellToLSTMCellIE should keep output names.\n";
 }
 
-TEST(TransformationTests, LSTMCellConversionTest_opset4) {
+TEST(TransformationTests, smoke_LSTMCellConversionTest_opset4) {
     const size_t batch_size = 2;
     const size_t input_size = 3;
     const size_t hidden_size = 3;

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_convolution_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_convolution_test.cpp
@@ -75,7 +75,7 @@ TEST_P(ConvertConvolutionTest, CompareFunctions) {
     ASSERT_TRUE(orig_shape.same_scheme(f->get_output_partial_shape(0))) << "Shape " << orig_shape << " is not equal to " << f->get_output_partial_shape(0);
 }
 
-INSTANTIATE_TEST_CASE_P(ConvertConvolution, ConvertConvolutionTest,
+INSTANTIATE_TEST_CASE_P(smoke_ConvertConvolution, ConvertConvolutionTest,
         testing::Values(std::make_tuple(InputShape{DYN, DYN, DYN, DYN, DYN}, WeightsShape{8, 3, 1, 2, 3}),
                         std::make_tuple(InputShape{DYN, 3, 64, 64, 64}, WeightsShape{8, 3, 1, 2, 3}),
                         std::make_tuple(InputShape{2, DYN, 64, 64, 64}, WeightsShape{9, 3, 2, 3, 1}),

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_deconvolution_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_deconvolution_test.cpp
@@ -76,7 +76,7 @@ TEST_P(ConvertDeconvolutionTest, CompareFunctions) {
     ASSERT_TRUE(orig_shape.same_scheme(f->get_output_partial_shape(0))) << "Shape " << orig_shape << " is not equal to " << f->get_output_partial_shape(0);
 }
 
-INSTANTIATE_TEST_CASE_P(ConvertDeconvolution, ConvertDeconvolutionTest,
+INSTANTIATE_TEST_CASE_P(smoke_ConvertDeconvolution, ConvertDeconvolutionTest,
         testing::Values(std::make_tuple(InputShape{DYN, DYN, DYN, DYN, DYN}, WeightsShape{3, 8, 1, 2, 3}),
                         std::make_tuple(InputShape{DYN, 3, 64, 64, 64}, WeightsShape{3, 8, 1, 2, 3}),
                         std::make_tuple(InputShape{2, DYN, 64, 64, 64}, WeightsShape{3, 9, 2, 3, 1}),

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_divide.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_divide.cpp
@@ -19,7 +19,7 @@
 
 using namespace testing;
 
-TEST(TransformationTests, ConvertDivide) {
+TEST(TransformationTests, smoke_ConvertDivide) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{3, 1, 2});
@@ -49,7 +49,7 @@ TEST(TransformationTests, ConvertDivide) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertDivideNegative) {
+TEST(TransformationTests, smoke_ConvertDivideNegative) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::i32, ngraph::Shape{3, 1, 2});

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_extract_image_patches_to_reorg_yolo_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_extract_image_patches_to_reorg_yolo_test.cpp
@@ -19,7 +19,7 @@
 
 using namespace testing;
 
-TEST(TransformationTests, ConvertExtractImagePatchesToReorgYoloTests1) {
+TEST(TransformationTests, smoke_ConvertExtractImagePatchesToReorgYoloTests1) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 10, 10});
@@ -52,7 +52,7 @@ TEST(TransformationTests, ConvertExtractImagePatchesToReorgYoloTests1) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertExtractImagePatchesToReorgYoloTestsNegative1) {
+TEST(TransformationTests, smoke_ConvertExtractImagePatchesToReorgYoloTestsNegative1) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32,
@@ -91,7 +91,7 @@ TEST(TransformationTests, ConvertExtractImagePatchesToReorgYoloTestsNegative1) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertExtractImagePatchesToReorgYoloTestsNegative2) {
+TEST(TransformationTests, smoke_ConvertExtractImagePatchesToReorgYoloTestsNegative2) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 10, 10});
@@ -129,7 +129,7 @@ TEST(TransformationTests, ConvertExtractImagePatchesToReorgYoloTestsNegative2) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertExtractImagePatchesToReorgYoloTestsNegative3) {
+TEST(TransformationTests, smoke_ConvertExtractImagePatchesToReorgYoloTestsNegative3) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 10, 10});

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_gather_to_gather_ie.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_gather_to_gather_ie.cpp
@@ -21,7 +21,7 @@
 using namespace testing;
 using namespace ngraph;
 
-TEST(TransformationTests, ConvertGatherToGatherIEStatic1) {
+TEST(TransformationTests, smoke_ConvertGatherToGatherIEStatic1) {
     std::shared_ptr<Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<opset1::Parameter>(element::f32, Shape{6, 12, 10, 24});
@@ -51,7 +51,7 @@ TEST(TransformationTests, ConvertGatherToGatherIEStatic1) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertGatherToGatherIEStatic2) {
+TEST(TransformationTests, smoke_ConvertGatherToGatherIEStatic2) {
     std::shared_ptr<Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<opset1::Parameter>(element::f32, Shape{6, 12, 10, 24});
@@ -83,7 +83,7 @@ TEST(TransformationTests, ConvertGatherToGatherIEStatic2) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertGatherToGatherIEDynamic1) {
+TEST(TransformationTests, smoke_ConvertGatherToGatherIEDynamic1) {
     std::shared_ptr<Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<opset1::Parameter>(element::f32, PartialShape{DYN, DYN, DYN, DYN});
@@ -112,7 +112,7 @@ TEST(TransformationTests, ConvertGatherToGatherIEDynamic1) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertGatherToGatherIEDynamic2) {
+TEST(TransformationTests, smoke_ConvertGatherToGatherIEDynamic2) {
     std::shared_ptr<Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<opset1::Parameter>(element::f32, PartialShape{DYN, DYN});

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_matmul_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_matmul_test.cpp
@@ -27,7 +27,7 @@
 
 using namespace testing;
 
-TEST(TransformationTests, ConvertMatMulTest1) {
+TEST(TransformationTests, smoke_ConvertMatMulTest1) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{3, 1, 2});
@@ -59,7 +59,7 @@ TEST(TransformationTests, ConvertMatMulTest1) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertMatMulTest2) {
+TEST(TransformationTests, smoke_ConvertMatMulTest2) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{3, 1, 2});
@@ -91,7 +91,7 @@ TEST(TransformationTests, ConvertMatMulTest2) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertMatMulTest3) {
+TEST(TransformationTests, smoke_ConvertMatMulTest3) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{2});
@@ -122,7 +122,7 @@ TEST(TransformationTests, ConvertMatMulTest3) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertMatMulTest4) {
+TEST(TransformationTests, smoke_ConvertMatMulTest4) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{3, 1, 2});
@@ -150,7 +150,7 @@ TEST(TransformationTests, ConvertMatMulTest4) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertMatMulTest5) {
+TEST(TransformationTests, smoke_ConvertMatMulTest5) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{3, 2, 2});
@@ -179,7 +179,7 @@ TEST(TransformationTests, ConvertMatMulTest5) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertMatMulTest6) {
+TEST(TransformationTests, smoke_ConvertMatMulTest6) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{3, 2, 2});
@@ -211,7 +211,7 @@ TEST(TransformationTests, ConvertMatMulTest6) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertMatMulTest7) {
+TEST(TransformationTests, smoke_ConvertMatMulTest7) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{3, 2, 2});

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_nms3_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_nms3_test.cpp
@@ -21,7 +21,7 @@
 using namespace testing;
 using namespace ngraph;
 
-TEST(TransformationTests, ConvertNMS3I32Output) {
+TEST(TransformationTests, smoke_ConvertNMS3I32Output) {
     std::shared_ptr<Function> f(nullptr), f_ref(nullptr);
     {
         auto boxes = std::make_shared<opset3::Parameter>(element::f32, Shape{1, 1000, 4});

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_nms4_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_nms4_test.cpp
@@ -20,7 +20,7 @@
 using namespace testing;
 using namespace ngraph;
 
-TEST(TransformationTests, ConvertNMS4ToNMSIEStatic) {
+TEST(TransformationTests, smoke_ConvertNMS4ToNMSIEStatic) {
     std::shared_ptr<Function> f(nullptr), f_ref(nullptr);
     {
         auto boxes = std::make_shared<opset4::Parameter>(element::f32, Shape{1, 1000, 4});
@@ -64,7 +64,7 @@ TEST(TransformationTests, ConvertNMS4ToNMSIEStatic) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertNMS4ToNMSIEDynamic1) {
+TEST(TransformationTests, smoke_ConvertNMS4ToNMSIEDynamic1) {
     std::shared_ptr<Function> f(nullptr), f_ref(nullptr);
     {
         auto boxes = std::make_shared<opset4::Parameter>(element::f32, PartialShape::dynamic());
@@ -105,7 +105,7 @@ TEST(TransformationTests, ConvertNMS4ToNMSIEDynamic1) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertNMS4ToNMSIEDynamic2) {
+TEST(TransformationTests, smoke_ConvertNMS4ToNMSIEDynamic2) {
     std::shared_ptr<Function> f(nullptr), f_ref(nullptr);
     {
         auto boxes = std::make_shared<opset4::Parameter>(element::f32, PartialShape{DYN, 1000, 4});

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_nms_to_nms_ie_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_nms_to_nms_ie_test.cpp
@@ -23,7 +23,7 @@
 using namespace testing;
 using namespace ngraph;
 
-TEST(TransformationTests, ConvertNMSToNMSIEStatic) {
+TEST(TransformationTests, smoke_ConvertNMSToNMSIEStatic) {
     std::shared_ptr<Function> f(nullptr), f_ref(nullptr);
     {
         auto boxes = std::make_shared<opset1::Parameter>(element::f32, Shape{1, 1000, 4});
@@ -64,7 +64,7 @@ TEST(TransformationTests, ConvertNMSToNMSIEStatic) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertNMSToNMSIEDynamic1) {
+TEST(TransformationTests, smoke_ConvertNMSToNMSIEDynamic1) {
     std::shared_ptr<Function> f(nullptr), f_ref(nullptr);
     {
         auto boxes = std::make_shared<opset1::Parameter>(element::f32, PartialShape::dynamic());
@@ -103,7 +103,7 @@ TEST(TransformationTests, ConvertNMSToNMSIEDynamic1) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertNMSToNMSIEDynamic2) {
+TEST(TransformationTests, smoke_ConvertNMSToNMSIEDynamic2) {
     std::shared_ptr<Function> f(nullptr), f_ref(nullptr);
     {
         auto boxes = std::make_shared<opset1::Parameter>(element::f32, PartialShape{DYN, 1000, 4});

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_pad_to_group_conv.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_pad_to_group_conv.cpp
@@ -20,7 +20,7 @@
 using namespace testing;
 using namespace ngraph;
 
-TEST(TransformationTests, ConvertPadToConv) {
+TEST(TransformationTests, smoke_ConvertPadToConv) {
     std::shared_ptr<Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<opset4::Parameter>(element::f32, Shape{1, 3, 64, 64});
@@ -58,7 +58,7 @@ TEST(TransformationTests, ConvertPadToConv) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertPadToConvNeg1) {
+TEST(TransformationTests, smoke_ConvertPadToConvNeg1) {
     auto get_function = []() -> std::shared_ptr<Function> {
         auto input = std::make_shared<opset4::Parameter>(element::f32, Shape{1, 3, 64, 64});
         auto pad_begin = opset4::Constant::create(element::i64, Shape{4}, {1, 0, 1, 0}); // Batch dim padding
@@ -86,7 +86,7 @@ TEST(TransformationTests, ConvertPadToConvNeg1) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertPadToConvNeg2) {
+TEST(TransformationTests, smoke_ConvertPadToConvNeg2) {
     auto get_function = []() -> std::shared_ptr<Function> {
         auto input = std::make_shared<opset4::Parameter>(element::f32, Shape{1, 3, 64, 64});
         auto pad_begin = opset4::Constant::create(element::i64, Shape{4}, {0, 0, 1, 0});
@@ -114,7 +114,7 @@ TEST(TransformationTests, ConvertPadToConvNeg2) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertPadToConvNeg3) {
+TEST(TransformationTests, smoke_ConvertPadToConvNeg3) {
     auto get_function = []() -> std::shared_ptr<Function> {
         auto input = std::make_shared<opset4::Parameter>(element::f32, Shape{1, 3, 64, 64});
         auto pad_begin = opset4::Constant::create(element::i64, Shape{4}, {0, 0, 1, 0});
@@ -143,7 +143,7 @@ TEST(TransformationTests, ConvertPadToConvNeg3) {
 }
 
 
-TEST(TransformationTests, ConvertPadToConvNeg4) {
+TEST(TransformationTests, smoke_ConvertPadToConvNeg4) {
     auto get_function = []() -> std::shared_ptr<Function> {
         auto input = std::make_shared<opset4::Parameter>(element::f32, Shape{1, 3, 64, 64});
         auto pad_begin = opset4::Constant::create(element::i64, Shape{4}, {0, 0, 1, 0});

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_precision.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_precision.cpp
@@ -40,7 +40,7 @@ bool has_type(std::shared_ptr<ngraph::Function> f) {
     return false;
 }
 
-TEST(TransformationTests, ConvertPrecision_NMS3) {
+TEST(TransformationTests, smoke_ConvertPrecision_NMS3) {
     std::shared_ptr<Function> f(nullptr);
     {
         auto boxes = std::make_shared<opset3::Parameter>(element::f16, Shape{1, 1000, 4});
@@ -63,7 +63,7 @@ TEST(TransformationTests, ConvertPrecision_NMS3) {
     ASSERT_FALSE(has_type<ngraph::element::Type_t::f16>(f));
 }
 
-TEST(TransformationTests, ConvertPrecision_NMS4) {
+TEST(TransformationTests, smoke_ConvertPrecision_NMS4) {
     std::shared_ptr<Function> f(nullptr);
     {
         auto boxes = std::make_shared<opset4::Parameter>(element::f16, Shape{1, 1000, 4});
@@ -86,7 +86,7 @@ TEST(TransformationTests, ConvertPrecision_NMS4) {
     ASSERT_FALSE(has_type<ngraph::element::Type_t::f16>(f));
 }
 
-TEST(TransformationTests, ConvertPrecision_ShapeOf) {
+TEST(TransformationTests, smoke_ConvertPrecision_ShapeOf) {
     std::shared_ptr<Function> f(nullptr);
     {
         auto input = std::make_shared<opset4::Parameter>(element::f16, Shape{1, 1000, 4});
@@ -104,7 +104,7 @@ TEST(TransformationTests, ConvertPrecision_ShapeOf) {
     ASSERT_FALSE(has_type<ngraph::element::Type_t::f16>(f));
 }
 
-TEST(TransformationTests, ConvertPrecision_Convert) {
+TEST(TransformationTests, smoke_ConvertPrecision_Convert) {
     std::shared_ptr<Function> f(nullptr);
     {
         auto input = std::make_shared<opset4::Parameter>(element::f16, Shape{1, 1000, 4});
@@ -122,7 +122,7 @@ TEST(TransformationTests, ConvertPrecision_Convert) {
     ASSERT_FALSE(has_type<ngraph::element::Type_t::i64>(f));
 }
 
-TEST(TransformationTests, ConvertPrecision_ConvertElimination) {
+TEST(TransformationTests, smoke_ConvertPrecision_ConvertElimination) {
     std::shared_ptr<Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<opset4::Parameter>(element::f16, Shape{1, 1000, 4});
@@ -148,7 +148,7 @@ TEST(TransformationTests, ConvertPrecision_ConvertElimination) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertPrecision_TopK) {
+TEST(TransformationTests, smoke_ConvertPrecision_TopK) {
     std::shared_ptr<Function> f(nullptr);
     {
         auto input = std::make_shared<ngraph::opset3::Parameter>(ngraph::element::f16, ngraph::Shape{15, 20, 3});
@@ -167,7 +167,7 @@ TEST(TransformationTests, ConvertPrecision_TopK) {
     ASSERT_FALSE(has_type<ngraph::element::Type_t::i64>(f));
 }
 
-TEST(TransformationTests, ConvertPrecision_NonZero) {
+TEST(TransformationTests, smoke_ConvertPrecision_NonZero) {
     std::shared_ptr<Function> f(nullptr);
     {
         auto input = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f16, ngraph::Shape{15, 20, 3});
@@ -185,7 +185,7 @@ TEST(TransformationTests, ConvertPrecision_NonZero) {
     ASSERT_FALSE(has_type<ngraph::element::Type_t::i64>(f));
 }
 
-TEST(TransformationTests, ConvertPrecision_Bucketize) {
+TEST(TransformationTests, smoke_ConvertPrecision_Bucketize) {
     std::shared_ptr<Function> f(nullptr);
     {
         auto input = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f16, ngraph::Shape{20});
@@ -204,7 +204,7 @@ TEST(TransformationTests, ConvertPrecision_Bucketize) {
     ASSERT_FALSE(has_type<ngraph::element::Type_t::i64>(f));
 }
 
-TEST(TransformationTests, ConvertPrecision_Roundings) {
+TEST(TransformationTests, smoke_ConvertPrecision_Roundings) {
     std::shared_ptr<Function> f(nullptr);
     {
         auto max_int64 = std::numeric_limits<int64_t>::max();
@@ -237,7 +237,7 @@ TEST(TransformationTests, ConvertPrecision_Roundings) {
     ASSERT_FALSE(has_type<ngraph::element::Type_t::i64>(f));
 }
 
-TEST(TransformationTests, ConvertPrecision_TIBody) {
+TEST(TransformationTests, smoke_ConvertPrecision_TIBody) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto X = std::make_shared<opset4::Parameter>(element::f16, Shape{2, 1, 16});
@@ -290,7 +290,7 @@ TEST(TransformationTests, ConvertPrecision_TIBody) {
     }
 }
 
-TEST(TransformationTests, ConvertPrecision_Equal) {
+TEST(TransformationTests, smoke_ConvertPrecision_Equal) {
     std::shared_ptr<Function> f(nullptr);
     {
         auto input1 = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f16, ngraph::Shape{15, 20, 3});
@@ -310,7 +310,7 @@ TEST(TransformationTests, ConvertPrecision_Equal) {
     ASSERT_TRUE(has_type<ngraph::element::Type_t::u8>(f));
 }
 
-TEST(TransformationTests, ConvertPrecision_NotEqual) {
+TEST(TransformationTests, smoke_ConvertPrecision_NotEqual) {
     std::shared_ptr<Function> f(nullptr);
     {
         auto input1 = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f16, ngraph::Shape{15, 20, 3});
@@ -330,7 +330,7 @@ TEST(TransformationTests, ConvertPrecision_NotEqual) {
     ASSERT_TRUE(has_type<ngraph::element::Type_t::u8>(f));
 }
 
-TEST(TransformationTests, ConvertPrecision_Greater) {
+TEST(TransformationTests, smoke_ConvertPrecision_Greater) {
     std::shared_ptr<Function> f(nullptr);
     {
         auto input1 = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f16, ngraph::Shape{15, 20, 3});
@@ -350,7 +350,7 @@ TEST(TransformationTests, ConvertPrecision_Greater) {
     ASSERT_TRUE(has_type<ngraph::element::Type_t::u8>(f));
 }
 
-TEST(TransformationTests, ConvertPrecision_GreaterEqual) {
+TEST(TransformationTests, smoke_ConvertPrecision_GreaterEqual) {
     std::shared_ptr<Function> f(nullptr);
     {
         auto input1 = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f16, ngraph::Shape{15, 20, 3});
@@ -370,7 +370,7 @@ TEST(TransformationTests, ConvertPrecision_GreaterEqual) {
     ASSERT_TRUE(has_type<ngraph::element::Type_t::u8>(f));
 }
 
-TEST(TransformationTests, ConvertPrecision_Less) {
+TEST(TransformationTests, smoke_ConvertPrecision_Less) {
     std::shared_ptr<Function> f(nullptr);
     {
         auto input1 = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f16, ngraph::Shape{15, 20, 3});
@@ -390,7 +390,7 @@ TEST(TransformationTests, ConvertPrecision_Less) {
     ASSERT_TRUE(has_type<ngraph::element::Type_t::u8>(f));
 }
 
-TEST(TransformationTests, ConvertPrecision_LessEqual) {
+TEST(TransformationTests, smoke_ConvertPrecision_LessEqual) {
     std::shared_ptr<Function> f(nullptr);
     {
         auto input1 = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f16, ngraph::Shape{15, 20, 3});
@@ -410,7 +410,7 @@ TEST(TransformationTests, ConvertPrecision_LessEqual) {
     ASSERT_TRUE(has_type<ngraph::element::Type_t::u8>(f));
 }
 
-TEST(TransformationTests, ConvertPrecision_LogicalAnd) {
+TEST(TransformationTests, smoke_ConvertPrecision_LogicalAnd) {
     std::shared_ptr<Function> f(nullptr);
     {
         auto input1 = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::boolean, ngraph::Shape{15, 20, 3});
@@ -428,7 +428,7 @@ TEST(TransformationTests, ConvertPrecision_LogicalAnd) {
     ASSERT_TRUE(has_type<ngraph::element::Type_t::u8>(f));
 }
 
-TEST(TransformationTests, ConvertPrecision_LogicalOr) {
+TEST(TransformationTests, smoke_ConvertPrecision_LogicalOr) {
     std::shared_ptr<Function> f(nullptr);
     {
         auto input1 = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::boolean, ngraph::Shape{15, 20, 3});
@@ -446,7 +446,7 @@ TEST(TransformationTests, ConvertPrecision_LogicalOr) {
     ASSERT_TRUE(has_type<ngraph::element::Type_t::u8>(f));
 }
 
-TEST(TransformationTests, ConvertPrecision_LogicalXor) {
+TEST(TransformationTests, smoke_ConvertPrecision_LogicalXor) {
     std::shared_ptr<Function> f(nullptr);
     {
         auto input1 = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::boolean, ngraph::Shape{15, 20, 3});
@@ -464,7 +464,7 @@ TEST(TransformationTests, ConvertPrecision_LogicalXor) {
     ASSERT_TRUE(has_type<ngraph::element::Type_t::u8>(f));
 }
 
-TEST(TransformationTests, ConvertPrecision_LogicalNot) {
+TEST(TransformationTests, smoke_ConvertPrecision_LogicalNot) {
     std::shared_ptr<Function> f(nullptr);
     {
         auto input1 = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::boolean, ngraph::Shape{15, 20, 3});
@@ -481,7 +481,7 @@ TEST(TransformationTests, ConvertPrecision_LogicalNot) {
     ASSERT_TRUE(has_type<ngraph::element::Type_t::u8>(f));
 }
 
-TEST(TransformationTests, ConvertPrecision_Select) {
+TEST(TransformationTests, smoke_ConvertPrecision_Select) {
     std::shared_ptr<Function> f(nullptr);
     {
         auto input1 = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::boolean, ngraph::Shape{15, 20, 3});
@@ -499,7 +499,7 @@ TEST(TransformationTests, ConvertPrecision_Select) {
     ASSERT_TRUE(has_type<ngraph::element::Type_t::u8>(f));
 }
 
-TEST(TransformationTests, ConvertPrecision_TypeRelaxedWithSelect) {
+TEST(TransformationTests, smoke_ConvertPrecision_TypeRelaxedWithSelect) {
     std::shared_ptr<Function> f(nullptr);
     {
         auto input1 = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::boolean, ngraph::Shape{15, 20, 3});
@@ -519,7 +519,7 @@ TEST(TransformationTests, ConvertPrecision_TypeRelaxedWithSelect) {
     ASSERT_TRUE(has_type<ngraph::element::Type_t::i64>(f));
 }
 
-TEST(TransformationTests, ConvertPrecision_TypeRelaxed) {
+TEST(TransformationTests, smoke_ConvertPrecision_TypeRelaxed) {
     std::shared_ptr<Function> f(nullptr);
     {
         auto input1 = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::boolean, ngraph::Shape{15, 20, 3});
@@ -539,7 +539,7 @@ TEST(TransformationTests, ConvertPrecision_TypeRelaxed) {
     }
 }
 
-TEST(TransformationTests, ConvertPrecision_Variables) {
+TEST(TransformationTests, smoke_ConvertPrecision_Variables) {
     std::shared_ptr<ngraph::Function> f(nullptr);
     {
         Shape shape {1, 10, 2};
@@ -581,44 +581,44 @@ void constant_convert_test(element::Type_t type_from, element::Type_t type_to, F
     ASSERT_EQ(expected, actual);
 }
 
-TEST(TransformationTests, ConvertPrecision_ConstantConversion_I64MinToI32) {
+TEST(TransformationTests, smoke_ConvertPrecision_ConstantConversion_I64MinToI32) {
     constant_convert_test(element::Type_t::i64, element::Type_t::i32,
                         std::numeric_limits<int64_t>::min(),
                         std::numeric_limits<int32_t>::min());
 }
 
-TEST(TransformationTests, ConvertPrecision_ConstantConversion_I64MaxToI32) {
+TEST(TransformationTests, smoke_ConvertPrecision_ConstantConversion_I64MaxToI32) {
     constant_convert_test(element::Type_t::i64, element::Type_t::i32,
                         std::numeric_limits<int64_t>::max(),
                         std::numeric_limits<int32_t>::max());
 }
 
-TEST(TransformationTests, ConvertPrecision_ConstantConversion_U64MinToI32) {
+TEST(TransformationTests, smoke_ConvertPrecision_ConstantConversion_U64MinToI32) {
     constant_convert_test(element::Type_t::u64, element::Type_t::i32,
                         std::numeric_limits<uint64_t>::min(), 0);
 }
 
-TEST(TransformationTests, ConvertPrecision_ConstantConversion_U64MaxToI32) {
+TEST(TransformationTests, smoke_ConvertPrecision_ConstantConversion_U64MaxToI32) {
     constant_convert_test(element::Type_t::u64, element::Type_t::i32,
                         std::numeric_limits<uint64_t>::max(),
                         std::numeric_limits<int32_t>::max());
 }
 
-TEST(TransformationTests, ConvertPrecision_ConstantConversion_U64ToI32) {
+TEST(TransformationTests, smoke_ConvertPrecision_ConstantConversion_U64ToI32) {
     constant_convert_test(element::Type_t::u64, element::Type_t::i32, 42, 42);
 }
 
-TEST(TransformationTests, ConvertPrecision_ConstantConversion_U32MinToI32) {
+TEST(TransformationTests, smoke_ConvertPrecision_ConstantConversion_U32MinToI32) {
     constant_convert_test(element::Type_t::u32, element::Type_t::i32,
                         std::numeric_limits<uint32_t>::min(), 0);
 }
 
-TEST(TransformationTests, ConvertPrecision_ConstantConversion_U32MaxToI32) {
+TEST(TransformationTests, smoke_ConvertPrecision_ConstantConversion_U32MaxToI32) {
     constant_convert_test(element::Type_t::u32, element::Type_t::i32,
                         std::numeric_limits<uint32_t>::max(),
                         std::numeric_limits<int32_t>::max());
 }
 
-TEST(TransformationTests, ConvertPrecision_ConstantConversion_U32ToI32) {
+TEST(TransformationTests, smoke_ConvertPrecision_ConstantConversion_U32ToI32) {
     constant_convert_test(element::Type_t::u32, element::Type_t::i32, 42, 42);
 }

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_quantize_dequantize.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_quantize_dequantize.cpp
@@ -77,7 +77,7 @@ void positive_test(const Shape& data_shape, float in_low, float in_high, float o
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertQuantizeDequantizeINT8) {
+TEST(TransformationTests, smoke_ConvertQuantizeDequantizeINT8) {
     std::shared_ptr<Function> f(nullptr), f_ref(nullptr);
     Shape data_shape{3, 1, 2};
     float in_low = 0;
@@ -94,7 +94,7 @@ TEST(TransformationTests, ConvertQuantizeDequantizeINT8) {
                   zero_point_shape, zero_point_values, scale_shape, scale_values, levels);
 }
 
-TEST(TransformationTests, ConvertQuantizeDequantizeUINT8) {
+TEST(TransformationTests, smoke_ConvertQuantizeDequantizeUINT8) {
     std::shared_ptr<Function> f(nullptr), f_ref(nullptr);
     Shape data_shape{3, 1, 2};
     float in_low = 0;
@@ -135,7 +135,7 @@ void negative_test(const Shape& data_shape, float in_low, float in_high, float o
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertQuantizeDequantizeZeroPointNotBroadcastable) {
+TEST(TransformationTests, smoke_ConvertQuantizeDequantizeZeroPointNotBroadcastable) {
     std::shared_ptr<Function> f(nullptr), f_ref(nullptr);
     Shape data_shape{3, 1, 2};
     float in_low = 0;
@@ -152,7 +152,7 @@ TEST(TransformationTests, ConvertQuantizeDequantizeZeroPointNotBroadcastable) {
                   zero_point_shape, zero_point_values, scale_shape, scale_values, levels);
 }
 
-TEST(TransformationTests, ConvertQuantizeDequantizeScaleNotBroadcastable) {
+TEST(TransformationTests, smoke_ConvertQuantizeDequantizeScaleNotBroadcastable) {
     std::shared_ptr<Function> f(nullptr), f_ref(nullptr);
     Shape data_shape{3, 1, 2};
     float in_low = 0;
@@ -169,7 +169,7 @@ TEST(TransformationTests, ConvertQuantizeDequantizeScaleNotBroadcastable) {
                   zero_point_shape, zero_point_values, scale_shape, scale_values, levels);
 }
 
-TEST(TransformationTests, ConvertQuantizeDequantizeInvalidLevels) {
+TEST(TransformationTests, smoke_ConvertQuantizeDequantizeInvalidLevels) {
     std::shared_ptr<Function> f(nullptr), f_ref(nullptr);
     Shape data_shape{3, 1, 2};
     float in_low = 0;
@@ -186,7 +186,7 @@ TEST(TransformationTests, ConvertQuantizeDequantizeInvalidLevels) {
                   zero_point_shape, zero_point_values, scale_shape, scale_values, levels);
 }
 
-TEST(TransformationTests, ConvertQuantizeDequantizeInvalidOutLowOutHigh) {
+TEST(TransformationTests, smoke_ConvertQuantizeDequantizeInvalidOutLowOutHigh) {
     std::shared_ptr<Function> f(nullptr), f_ref(nullptr);
     Shape data_shape{3, 1, 2};
     float in_low = 0;

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_reduce_to_pooling_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_reduce_to_pooling_test.cpp
@@ -122,17 +122,17 @@ TEST_P(ConvertReduceToPoolingTests, CompareFunctions) {
 
 #define MAX std::make_shared<ngraph::opset1::ReduceMax>()
 
-INSTANTIATE_TEST_CASE_P(ReduceToMaxPooling, ConvertReduceToPoolingTests,
+INSTANTIATE_TEST_CASE_P(smoke_ReduceToMaxPooling, ConvertReduceToPoolingTests,
         testing::Values(std::make_tuple(MAX, InputShape{2, 3, 64, 64},  ReduceAxes{3},    KeepDims{true}, ReduceToPoolParams({}, {1, 64}, {})),
                         std::make_tuple(MAX, InputShape{2, 3, 64, 64},  ReduceAxes{3, 2}, KeepDims{true}, ReduceToPoolParams({}, {64, 64}, {}))));
 
-INSTANTIATE_TEST_CASE_P(ReduceToReshape, ConvertReduceToPoolingTests,
+INSTANTIATE_TEST_CASE_P(smoke_ReduceToReshape, ConvertReduceToPoolingTests,
         testing::Values(std::make_tuple(MAX, InputShape{2, 3, 64, 1}, ReduceAxes{3},       KeepDims{false}, ReduceToPoolParams({1, 3, 64}, {}, {})),
                         std::make_tuple(MAX, InputShape{2, 3},        ReduceAxes{-2},      KeepDims{false}, ReduceToPoolParams({3}, {}, {})),
                         std::make_tuple(MAX, InputShape{2, 3, 1},     ReduceAxes{2},       KeepDims{false}, ReduceToPoolParams({1, 3}, {}, {})),
                         std::make_tuple(MAX, InputShape{2, 3, 1, 1},  ReduceAxes{0, 3, 2}, KeepDims{false}, ReduceToPoolParams({3}, {}, {}))));
 
-INSTANTIATE_TEST_CASE_P(ReduceToReshapePoolReshape, ConvertReduceToPoolingTests,
+INSTANTIATE_TEST_CASE_P(smoke_ReduceToReshapePoolReshape, ConvertReduceToPoolingTests,
         testing::Values(std::make_tuple(MAX, InputShape{2, 3, 3},    ReduceAxes{1, 2},    KeepDims{false}, ReduceToPoolParams({1, 1, 9, 1}, {9, 1}, {1})),
                         std::make_tuple(MAX, InputShape{2, 9},       ReduceAxes{-1},      KeepDims{true},  ReduceToPoolParams({1, 1, 9, 1}, {9, 1}, {1, 1})),
                         std::make_tuple(MAX, InputShape{2, 3, 4, 1}, ReduceAxes{1, 3, 2}, KeepDims{false}, ReduceToPoolParams({1, 1, 12, 1}, {12, 1}, {1}))));

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_scatter_elements_to_scatter_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_scatter_elements_to_scatter_test.cpp
@@ -83,49 +83,49 @@ void test(std::shared_ptr<ngraph::Function> f) {
     test(f, f);
 }
 
-TEST(TransformationTests, ConvertScatterElementsToScatterTestAxis0) {
+TEST(TransformationTests, smoke_ConvertScatterElementsToScatterTestAxis0) {
     test(get_initial_function({1000, 256, 7, 7}, {1000, 1, 1, 1}, {1000, 256, 7, 7}, {1000, 256, 7, 7}, 0),
          get_reference_function({1000, 256, 7, 7}, {1000, 1, 1, 1}, {1000, 256, 7, 7}, 0, {1000}));
 }
 
-TEST(TransformationTests, ConvertScatterElementsToScatterTestAxis1) {
+TEST(TransformationTests, smoke_ConvertScatterElementsToScatterTestAxis1) {
     test(get_initial_function({1000, 256, 7, 7}, {256, 1, 1}, {1000, 256, 7, 7}, {1000, 256, 7, 7}, 1),
          get_reference_function({1000, 256, 7, 7}, {256, 1, 1}, {1000, 256, 7, 7}, 1, {256}));
 }
 
-TEST(TransformationTests, ConvertScatterElementsToScatterTestNoReshape) {
+TEST(TransformationTests, smoke_ConvertScatterElementsToScatterTestNoReshape) {
     test(get_initial_function({1000, 256, 7, 7}, {1}, {1000, 1, 7, 7}, {1000, 1, 7, 7}, 1),
          get_reference_function({1000, 256, 7, 7}, {1}, {1000, 1, 7, 7}, 1));
 }
 
-TEST(TransformationTests, ConvertScatterElementsToScatterTestNoReshapeNegAxis) {
+TEST(TransformationTests, smoke_ConvertScatterElementsToScatterTestNoReshapeNegAxis) {
     test(get_initial_function({1000, 256, 7, 7}, {1}, {1000, 1, 7, 7}, {1000, 1, 7, 7}, -3),
          get_reference_function({1000, 256, 7, 7}, {1}, {1000, 1, 7, 7}, -3));
 }
 
-TEST(TransformationTests, ConvertScatterElementsToScatterTestNegative) {
+TEST(TransformationTests, smoke_ConvertScatterElementsToScatterTestNegative) {
     test(get_initial_function({1000, 256, 7, 7}, {1000, 256, 1, 1}, {1000, 256, 7, 7}, {1000, 256, 7, 7}, 0));
 }
 
-TEST(TransformationTests, ConvertScatterElementsToScatterTestAxis0Dyn) {
+TEST(TransformationTests, smoke_ConvertScatterElementsToScatterTestAxis0Dyn) {
     test(get_initial_function({DYN, 256, 7, 7}, {DYN, 1, 1, 1}, {DYN, 256, 7, 7}, {DYN, 256, 7, 7}, 0),
          get_reference_function({DYN, 256, 7, 7}, {DYN, 1, 1, 1}, {DYN, 256, 7, 7}, 0, {}, {1, 2, 3}));
 }
 
-TEST(TransformationTests, ConvertScatterElementsToScatterTestAxis1Dyn) {
+TEST(TransformationTests, smoke_ConvertScatterElementsToScatterTestAxis1Dyn) {
     test(get_initial_function({1000, DYN, 7, 7}, {DYN, 1, 1}, {1000, DYN, 7, 7}, {1000, DYN, 7, 7}, 1),
          get_reference_function({1000, DYN, 7, 7}, {DYN, 1, 1}, {1000, DYN, 7, 7}, 1, {}, {1, 2}));
 }
 
-TEST(TransformationTests, ConvertScatterElementsToScatterTestAxis1NoSqueezeDyn) {
+TEST(TransformationTests, smoke_ConvertScatterElementsToScatterTestAxis1NoSqueezeDyn) {
     test(get_initial_function({1000, DYN, 7, 7}, {DYN}, {1000, 256, 7, 7}, {1000, DYN, 7, 7}, 1),
          get_reference_function({1000, DYN, 7, 7}, {DYN}, {1000, 256, 7, 7}, 1));
 }
 
-TEST(TransformationTests, ConvertScatterElementsToScatterTestAxis0Neg1Dyn) {
+TEST(TransformationTests, smoke_ConvertScatterElementsToScatterTestAxis0Neg1Dyn) {
     test(get_initial_function({DYN, 256, 7, 7}, {DYN, DYN, 1, 1}, {DYN, 256, 7, 7}, {DYN, 256, 7, 7}, 0));
 }
 
-TEST(TransformationTests, ConvertScatterElementsToScatterTestAxis0Neg2Dyn) {
+TEST(TransformationTests, smoke_ConvertScatterElementsToScatterTestAxis0Neg2Dyn) {
     test(get_initial_function({DYN, 256, 7, 7}, {DYN, 1, 2, 1}, {DYN, 256, 7, 7}, {DYN, 256, 7, 7}, 0));
 }

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_sequences_to_sequences_ie_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_sequences_to_sequences_ie_test.cpp
@@ -23,7 +23,7 @@
 
 using namespace testing;
 
-TEST(TransformationTests, GRUSequenceConversionTest) {
+TEST(TransformationTests, smoke_GRUSequenceConversionTest) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     std::shared_ptr<ngraph::opset5::GRUSequence> sequence;
 
@@ -107,7 +107,7 @@ TEST(TransformationTests, GRUSequenceConversionTest) {
             ->input_value(0).get_node_shared_ptr();
 }
 
-TEST(TransformationTests, RNNSequenceConversionTest) {
+TEST(TransformationTests, smoke_RNNSequenceConversionTest) {
     const size_t hidden_size = 3;
     const size_t num_directions = 1;
     const size_t batch_size = 2;
@@ -173,7 +173,7 @@ TEST(TransformationTests, RNNSequenceConversionTest) {
             ->input_value(0).get_node_shared_ptr();
 }
 
-TEST(TransformationTests, LSTMSequenceConversionTest) {
+TEST(TransformationTests, smoke_LSTMSequenceConversionTest) {
     const size_t batch_size = 2;
     const size_t input_size = 3;
     const size_t hidden_size = 3;

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_shapeof3.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_shapeof3.cpp
@@ -17,7 +17,7 @@
 
 using namespace testing;
 
-TEST(TransformationTests, ConvertShapeOf3WithI64) {
+TEST(TransformationTests, smoke_ConvertShapeOf3WithI64) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 2, 3});
@@ -47,7 +47,7 @@ TEST(TransformationTests, ConvertShapeOf3WithI64) {
     ASSERT_TRUE(output_node->get_friendly_name() == "shapeof") << "Transformation ConvertShapeOf3 should keep output names.\n";
 }
 
-TEST(TransformationTests, ConvertShapeOf3WithI32) {
+TEST(TransformationTests, smoke_ConvertShapeOf3WithI32) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 2, 3});

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_shuffle_channels3_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_shuffle_channels3_test.cpp
@@ -31,7 +31,7 @@ std::shared_ptr<ngraph::Function> buildInputGraph(int64_t axis, int64_t group, c
     return f;
 }
 
-TEST(TransformationTests, ConvertShuffleChannelsAxis0) {
+TEST(TransformationTests, smoke_ConvertShuffleChannelsAxis0) {
     int64_t group = 4;
     auto ps = ::PartialShape{12, Dimension::dynamic(), Dimension::dynamic(), Dimension::dynamic()};
     std::shared_ptr<ngraph::Function> f = buildInputGraph(0, group, ps), f_ref(nullptr);
@@ -68,7 +68,7 @@ TEST(TransformationTests, ConvertShuffleChannelsAxis0) {
     ASSERT_TRUE(output_node->get_friendly_name() == "shc") << "ConvertShuffleChannels3 should keep output names.\n";
 }
 
-TEST(TransformationTests, ConvertShuffleChannelsAxis1) {
+TEST(TransformationTests, smoke_ConvertShuffleChannelsAxis1) {
     int64_t group = 4;
     auto ps = ::PartialShape{Dimension::dynamic(), 12, Dimension::dynamic(), Dimension::dynamic()};
     std::shared_ptr<ngraph::Function> f = buildInputGraph(1, group, ps), f_ref(nullptr);
@@ -106,7 +106,7 @@ TEST(TransformationTests, ConvertShuffleChannelsAxis1) {
     ASSERT_TRUE(output_node->get_friendly_name() == "shc") << "ConvertShuffleChannels3 should keep output names.\n";
 }
 
-TEST(TransformationTests, ConvertShuffleChannelsAxis2) {
+TEST(TransformationTests, smoke_ConvertShuffleChannelsAxis2) {
     int64_t group = 4;
     auto ps = ::PartialShape{Dimension::dynamic(), Dimension::dynamic(), 12, Dimension::dynamic()};
     std::shared_ptr<ngraph::Function> f = buildInputGraph(2, group, ps), f_ref(nullptr);
@@ -144,7 +144,7 @@ TEST(TransformationTests, ConvertShuffleChannelsAxis2) {
     ASSERT_TRUE(output_node->get_friendly_name() == "shc") << "ConvertShuffleChannels3 should keep output names.\n";
 }
 
-TEST(TransformationTests, ConvertShuffleChannelsLastAxis) {
+TEST(TransformationTests, smoke_ConvertShuffleChannelsLastAxis) {
     int64_t group = 4;
     auto ps = ::PartialShape{Dimension::dynamic(), Dimension::dynamic(), Dimension::dynamic(), 12};
     std::shared_ptr<ngraph::Function> f = buildInputGraph(-1, group, ps), f_ref(nullptr);

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_strided_slice_to_crop_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_strided_slice_to_crop_test.cpp
@@ -29,7 +29,7 @@
 
 using namespace testing;
 
-TEST(TransformationTests, ConvertStridedSliceToCropTests1) {
+TEST(TransformationTests, smoke_ConvertStridedSliceToCropTests1) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input        = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 2, 384, 640});
@@ -83,7 +83,7 @@ TEST(TransformationTests, ConvertStridedSliceToCropTests1) {
     ASSERT_TRUE(names_are_correct) << "Transformation ConvertStridedSliceToCrop should keep output names.\n";
 }
 
-TEST(TransformationTests, ConvertStridedSliceToCropTests2) {
+TEST(TransformationTests, smoke_ConvertStridedSliceToCropTests2) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input        = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 2, 384, 640});
@@ -137,7 +137,7 @@ TEST(TransformationTests, ConvertStridedSliceToCropTests2) {
     ASSERT_TRUE(names_are_correct) << "Transformation ConvertStridedSliceToCrop should keep output names.\n";
 }
 
-TEST(TransformationTests, ConvertStridedSliceToCropNegative) {
+TEST(TransformationTests, smoke_ConvertStridedSliceToCropNegative) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input        = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(4));
@@ -189,7 +189,7 @@ TEST(TransformationTests, ConvertStridedSliceToCropNegative) {
 }
 
 // in this test the Crop will get 3D input which is not supported so the transformation will not be applied
-TEST(TransformationTests, ConvertStridedSliceToCropNegative2) {
+TEST(TransformationTests, smoke_ConvertStridedSliceToCropNegative2) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input        = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{128, 1});

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_ti_to_sequences_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_ti_to_sequences_test.cpp
@@ -22,7 +22,7 @@
 using namespace testing;
 using namespace ngraph;
 
-TEST(TransformationTests, ConvertTensorIteratorToLSTMSequence) {
+TEST(TransformationTests, smoke_ConvertTensorIteratorToLSTMSequence) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto X = std::make_shared<opset5::Parameter>(element::f32, Shape{1, 2, 16});
@@ -111,7 +111,7 @@ TEST(TransformationTests, ConvertTensorIteratorToLSTMSequence) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertTensorIteratorToRNNSequence) {
+TEST(TransformationTests, smoke_ConvertTensorIteratorToRNNSequence) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto X = std::make_shared<opset5::Parameter>(element::f32, Shape{1, 2, 16});
@@ -194,7 +194,7 @@ TEST(TransformationTests, ConvertTensorIteratorToRNNSequence) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertTensorIteratorToGRUSequence) {
+TEST(TransformationTests, smoke_ConvertTensorIteratorToGRUSequence) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto X = std::make_shared<opset5::Parameter>(element::f32, Shape{1, 2, 16});

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_topk3_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_topk3_test.cpp
@@ -21,7 +21,7 @@
 using namespace testing;
 
 // check that the first output from the TopK-3 with I32 output indices is equal to the TopK-1 first output
-TEST(TransformationTests, ConvertTopK3I32Output0) {
+TEST(TransformationTests, smoke_ConvertTopK3I32Output0) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset3::Parameter>(ngraph::element::f32, ngraph::Shape{15, 20, 3});
@@ -56,7 +56,7 @@ TEST(TransformationTests, ConvertTopK3I32Output0) {
 }
 
 // check that the second output from the TopK-3 with I32 output indices is equal to the TopK-1 second output
-TEST(TransformationTests, ConvertTopK3I32Output1) {
+TEST(TransformationTests, smoke_ConvertTopK3I32Output1) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset3::Parameter>(ngraph::element::f32, ngraph::Shape{15, 20, 3});
@@ -91,7 +91,7 @@ TEST(TransformationTests, ConvertTopK3I32Output1) {
 }
 
 // check that the first output from the TopK-3 with I64 output indices is equal to the TopK-1 first output
-TEST(TransformationTests, ConvertTopK3I64Output0) {
+TEST(TransformationTests, smoke_ConvertTopK3I64Output0) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset3::Parameter>(ngraph::element::f32, ngraph::Shape{15, 20, 3});
@@ -126,7 +126,7 @@ TEST(TransformationTests, ConvertTopK3I64Output0) {
 }
 
 // check that the second output from the TopK-3 with I64 output indices is equal to the TopK-1 second output converted to I64
-TEST(TransformationTests, ConvertTopK3I64Output1) {
+TEST(TransformationTests, smoke_ConvertTopK3I64Output1) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset3::Parameter>(ngraph::element::f32, ngraph::Shape{15, 20, 3});

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_topk_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_topk_test.cpp
@@ -21,7 +21,7 @@
 
 using namespace testing;
 
-TEST(TransformationTests, ConvertTopKToTopKIEStatic) {
+TEST(TransformationTests, smoke_ConvertTopKToTopKIEStatic) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{15, 20, 3});
@@ -55,7 +55,7 @@ TEST(TransformationTests, ConvertTopKToTopKIEStatic) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertTopKToTopKIEDynamic1) {
+TEST(TransformationTests, smoke_ConvertTopKToTopKIEDynamic1) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{DYN, 20, 3});
@@ -86,7 +86,7 @@ TEST(TransformationTests, ConvertTopKToTopKIEDynamic1) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertTopKToTopKIEDynamic2) {
+TEST(TransformationTests, smoke_ConvertTopKToTopKIEDynamic2) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{1, DYN, 3});
@@ -117,7 +117,7 @@ TEST(TransformationTests, ConvertTopKToTopKIEDynamic2) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertTopKToTopKIEDynamic3) {
+TEST(TransformationTests, smoke_ConvertTopKToTopKIEDynamic3) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{1, 20, DYN});
@@ -148,7 +148,7 @@ TEST(TransformationTests, ConvertTopKToTopKIEDynamic3) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, ConvertTopKToTopKIENegative) {
+TEST(TransformationTests, smoke_ConvertTopKToTopKIENegative) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{15, 20, 3});

--- a/inference-engine/tests/functional/inference_engine/transformations/depth_to_space_fusion_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/depth_to_space_fusion_test.cpp
@@ -24,7 +24,7 @@
 
 using namespace testing;
 
-TEST(TransformationTests, DepthToSpaceFusionDepthFirst) {
+TEST(TransformationTests, smoke_DepthToSpaceFusionDepthFirst) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input0 = std::make_shared<ngraph::opset3::Parameter>(ngraph::element::f32, ngraph::Shape{1, 128, 720, 480});
@@ -58,7 +58,7 @@ TEST(TransformationTests, DepthToSpaceFusionDepthFirst) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, DepthToSpaceFusionBlockFirst) {
+TEST(TransformationTests, smoke_DepthToSpaceFusionBlockFirst) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input0 = std::make_shared<ngraph::opset3::Parameter>(ngraph::element::f32, ngraph::Shape{1, 128, 720, 480});
@@ -92,7 +92,7 @@ TEST(TransformationTests, DepthToSpaceFusionBlockFirst) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, DepthToSpaceFusionDynamicShape) {
+TEST(TransformationTests, smoke_DepthToSpaceFusionDynamicShape) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input0 = std::make_shared<ngraph::opset3::Parameter>(ngraph::element::f32, ngraph::Shape{1, 128, 720, 480});
@@ -134,7 +134,7 @@ TEST(TransformationTests, DepthToSpaceFusionDynamicShape) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, DepthToSpaceFusionSeveralConsumers) {
+TEST(TransformationTests, smoke_DepthToSpaceFusionSeveralConsumers) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input0 = std::make_shared<ngraph::opset3::Parameter>(ngraph::element::f32, ngraph::Shape{1, 128, 720, 480});

--- a/inference-engine/tests/functional/inference_engine/transformations/fc_bias_fusion_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/fc_bias_fusion_test.cpp
@@ -24,7 +24,7 @@
 
 using namespace testing;
 
-TEST(TransformationTests, FullyConnectedBiasFusionTest3D) {
+TEST(TransformationTests, smoke_FullyConnectedBiasFusionTest3D) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 128, 3072});
@@ -60,7 +60,7 @@ TEST(TransformationTests, FullyConnectedBiasFusionTest3D) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, FullyConnectedBiasFusionTest2D) {
+TEST(TransformationTests, FullyConnectedBiasFusionTest2D_smoke) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 128});
@@ -72,6 +72,7 @@ TEST(TransformationTests, FullyConnectedBiasFusionTest2D) {
         auto add = std::make_shared<ngraph::opset1::Add>(fc, const_bias);
 
         f = std::make_shared<ngraph::Function>(ngraph::NodeVector{add}, ngraph::ParameterVector{input1});
+
         ngraph::pass::Manager manager;
         manager.register_pass<ngraph::pass::InitNodeInfo>();
         manager.register_pass<ngraph::pass::FullyConnectedBiasFusion>();

--- a/inference-engine/tests/functional/inference_engine/transformations/fq_mul_fusion_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/fq_mul_fusion_test.cpp
@@ -92,98 +92,98 @@ TEST_P(FQMulFusion, ExpectFusion) {
 };
 
 namespace {
-INSTANTIATE_TEST_CASE_P(ScalarFQParams_C6_4D_channel_0, FQMulFusion,
+INSTANTIATE_TEST_CASE_P(smoke_ScalarFQParams_C6_4D_channel_0, FQMulFusion,
                         ::testing::Combine(::testing::Values(ngraph::Shape{64, 3, 7, 7}),
                                            ::testing::Values(ngraph::Shape{}),
                                            ::testing::Values(ngraph::Shape{}),
                                            ::testing::Values(ngraph::Shape{64, 1, 1, 1}),
                                            ::testing::Values(ngraph::Shape{64, 1, 1, 1})));
 
-INSTANTIATE_TEST_CASE_P(ScalarFQParams_C6_4D_channel_1, FQMulFusion,
+INSTANTIATE_TEST_CASE_P(smoke_ScalarFQParams_C6_4D_channel_1, FQMulFusion,
                         ::testing::Combine(::testing::Values(ngraph::Shape{64, 3, 7, 7}),
                                            ::testing::Values(ngraph::Shape{}),
                                            ::testing::Values(ngraph::Shape{}),
                                            ::testing::Values(ngraph::Shape{1, 3, 1, 1}),
                                            ::testing::Values(ngraph::Shape{1, 3, 1, 1})));
 
-INSTANTIATE_TEST_CASE_P(ScalarFQParams_C6_scalar, FQMulFusion,
+INSTANTIATE_TEST_CASE_P(smoke_ScalarFQParams_C6_scalar, FQMulFusion,
                         ::testing::Combine(::testing::Values(ngraph::Shape{64, 3, 7, 7}),
                                            ::testing::Values(ngraph::Shape{}),
                                            ::testing::Values(ngraph::Shape{}),
                                            ::testing::Values(ngraph::Shape{}),
                                            ::testing::Values(ngraph::Shape{})));
 
-INSTANTIATE_TEST_CASE_P(FQOutputs1D_C6_scalar, FQMulFusion,
+INSTANTIATE_TEST_CASE_P(smoke_FQOutputs1D_C6_scalar, FQMulFusion,
                         ::testing::Combine(::testing::Values(ngraph::Shape{64, 3, 7, 7}),
                                            ::testing::Values(ngraph::Shape{}),
                                            ::testing::Values(ngraph::Shape{1}),
                                            ::testing::Values(ngraph::Shape{}),
                                            ::testing::Values(ngraph::Shape{1})));
 
-INSTANTIATE_TEST_CASE_P(FQOutputs_NHWC_C6_scalar, FQMulFusion,
+INSTANTIATE_TEST_CASE_P(smoke_FQOutputs_NHWC_C6_scalar, FQMulFusion,
                         ::testing::Combine(::testing::Values(ngraph::Shape{1, 7, 7, 3}),
                                            ::testing::Values(ngraph::Shape{}),
                                            ::testing::Values(ngraph::Shape{1, 1, 1, 3}),
                                            ::testing::Values(ngraph::Shape{}),
                                            ::testing::Values(ngraph::Shape{1, 1, 1, 3})));
 
-INSTANTIATE_TEST_CASE_P(FQOutputs_NCHW_C6_scalar, FQMulFusion,
+INSTANTIATE_TEST_CASE_P(smoke_FQOutputs_NCHW_C6_scalar, FQMulFusion,
                         ::testing::Combine(::testing::Values(ngraph::Shape{1, 3, 7, 7}),
                                            ::testing::Values(ngraph::Shape{}),
                                            ::testing::Values(ngraph::Shape{1, 3, 1, 1}),
                                            ::testing::Values(ngraph::Shape{}),
                                            ::testing::Values(ngraph::Shape{1, 3, 1, 1})));
 
-INSTANTIATE_TEST_CASE_P(FQInputs_4D_with_channel_dimension, FQMulFusion,
+INSTANTIATE_TEST_CASE_P(smoke_FQInputs_4D_with_channel_dimension, FQMulFusion,
                         ::testing::Combine(::testing::Values(ngraph::Shape{1, 64, 3, 3}),
                                            ::testing::Values(ngraph::Shape{1, 1, 1, 1}),
                                            ::testing::Values(ngraph::Shape{1, 64, 1, 1}),
                                            ::testing::Values(ngraph::Shape{1, 64, 1, 1}),
                                            ::testing::Values(ngraph::Shape{1, 64, 1, 1})));
 
-INSTANTIATE_TEST_CASE_P(FQInputs_4D_per__multiplier_with_channel, FQMulFusion,
+INSTANTIATE_TEST_CASE_P(smoke_FQInputs_4D_per__multiplier_with_channel, FQMulFusion,
                         ::testing::Combine(::testing::Values(ngraph::Shape{1, 64, 3, 3}),
                                            ::testing::Values(ngraph::Shape{1, 1, 1, 1}),
                                            ::testing::Values(ngraph::Shape{1, 1, 1, 1}),
                                            ::testing::Values(ngraph::Shape{1, 64, 1, 1}),
                                            ::testing::Values(ngraph::Shape{1, 64, 1, 1})));
 
-INSTANTIATE_TEST_CASE_P(FQInputs_4D_with_channel__multiplier_4D_per_tensor, FQMulFusion,
+INSTANTIATE_TEST_CASE_P(smoke_FQInputs_4D_with_channel__multiplier_4D_per_tensor, FQMulFusion,
                         ::testing::Combine(::testing::Values(ngraph::Shape{1, 64, 3, 3}),
                                            ::testing::Values(ngraph::Shape{1, 1, 1, 1}),
                                            ::testing::Values(ngraph::Shape{1, 64, 1, 1}),
                                            ::testing::Values(ngraph::Shape{1, 1, 1, 1}),
                                            ::testing::Values(ngraph::Shape{1, 64, 1, 1})));
 
-INSTANTIATE_TEST_CASE_P(FQInputs_4D__multiplier_channel_3rd_dim, FQMulFusion,
+INSTANTIATE_TEST_CASE_P(smoke_FQInputs_4D__multiplier_channel_3rd_dim, FQMulFusion,
                         ::testing::Combine(::testing::Values(ngraph::Shape{1, 64, 3, 3}),
                                            ::testing::Values(ngraph::Shape{1, 1, 1, 1}),
                                            ::testing::Values(ngraph::Shape{1, 64, 1, 1}),
                                            ::testing::Values(ngraph::Shape{1, 1, 3, 1}),
                                            ::testing::Values(ngraph::Shape{1, 64, 3, 1})));
 
-INSTANTIATE_TEST_CASE_P(FQOutputs_1D__multiplier_3D, FQMulFusion,
+INSTANTIATE_TEST_CASE_P(smoke_FQOutputs_1D__multiplier_3D, FQMulFusion,
                         ::testing::Combine(::testing::Values(ngraph::Shape{1, 64, 3, 3}),
                                            ::testing::Values(ngraph::Shape{1, 64, 1, 1}),
                                            ::testing::Values(ngraph::Shape{1}),
                                            ::testing::Values(ngraph::Shape{1, 3, 1}),
                                            ::testing::Values(ngraph::Shape{1, 3, 1})));
 
-INSTANTIATE_TEST_CASE_P(FQ_all_ones__multiplier_4D_with_channel, FQMulFusion,
+INSTANTIATE_TEST_CASE_P(smoke_FQ_all_ones__multiplier_4D_with_channel, FQMulFusion,
                         ::testing::Combine(::testing::Values(ngraph::Shape{1, 1, 1, 1}),
                                            ::testing::Values(ngraph::Shape{1, 1, 1, 1}),
                                            ::testing::Values(ngraph::Shape{1, 1, 1, 1}),
                                            ::testing::Values(ngraph::Shape{1, 64, 1, 1}),
                                            ::testing::Values(ngraph::Shape{1, 64, 1, 1})));
 
-INSTANTIATE_TEST_CASE_P(FQInOUt_ones__multiplier_4D_with_channel, FQMulFusion,
+INSTANTIATE_TEST_CASE_P(smoke_FQInOUt_ones__multiplier_4D_with_channel, FQMulFusion,
                         ::testing::Combine(::testing::Values(ngraph::Shape{1, 64, 3, 3}),
                                            ::testing::Values(ngraph::Shape{1, 1, 1, 1}),
                                            ::testing::Values(ngraph::Shape{1, 1, 1, 1}),
                                            ::testing::Values(ngraph::Shape{1, 64, 3, 3}),
                                            ::testing::Values(ngraph::Shape{1, 64, 3, 3})));
 
-TEST(FQMulFusion_NonConstInputs, AllInputsNonConst) {
+TEST(FQMulFusion_NonConstInputs, smoke_AllInputsNonConst) {
     const auto data = std::make_shared<ngraph::opset4::Parameter>(
         ngraph::element::Type_t::f32, ngraph::Shape{1, 3, 224, 224});
     const auto in_low =
@@ -225,7 +225,7 @@ TEST(FQMulFusion_NonConstInputs, AllInputsNonConst) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(FQMulFusion_NonConstInputs, FQ_out_high_const) {
+TEST(FQMulFusion_NonConstInputs, smoke_FQ_out_high_const) {
     const auto data = std::make_shared<ngraph::opset4::Parameter>(
         ngraph::element::Type_t::f32, ngraph::Shape{1, 3, 224, 224});
     const auto in_low =
@@ -269,7 +269,7 @@ TEST(FQMulFusion_NonConstInputs, FQ_out_high_const) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(FQMulFusion_FQ_Mul_inputs, FQ_out_to_mul_input_2) {
+TEST(FQMulFusion_FQ_Mul_inputs, smoke_FQ_out_to_mul_input_2) {
     const auto data = ngraph::opset4::Constant::create(
         ngraph::element::Type_t::f32, ngraph::Shape{1, 3, 224, 224}, {0.0f});
     const auto in_low = ngraph::opset4::Constant::create(
@@ -313,7 +313,7 @@ TEST(FQMulFusion_FQ_Mul_inputs, FQ_out_to_mul_input_2) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(FQMulFusion_FQ_Mul_inputs, FQ_out_to_mul_input_2_param) {
+TEST(FQMulFusion_FQ_Mul_inputs, smoke_FQ_out_to_mul_input_2_param) {
     const auto data = ngraph::opset4::Constant::create(
         ngraph::element::Type_t::f32, ngraph::Shape{1, 3, 224, 224}, {0.0f});
     const auto in_low = ngraph::opset4::Constant::create(

--- a/inference-engine/tests/functional/inference_engine/transformations/fq_reshape_fusion.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/fq_reshape_fusion.cpp
@@ -114,7 +114,7 @@ TEST_P(nGraphFQReshapeFusionTests, ReshapeMatMul) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-INSTANTIATE_TEST_CASE_P(NGraph, nGraphFQReshapeFusionTests, testing::Values(
+INSTANTIATE_TEST_CASE_P(smoke_NGraph, nGraphFQReshapeFusionTests, testing::Values(
     // positive
     FQReshapeFusionTestCase{{1, 2, 1, 3}, {2, 1, 1}, {1}, {1, 1}, {1, 2, 1, 1}, {2, 3}, {2, 1}, {1, 1}, DO_NOT_RESHAPE, {2, 1}, false},
     FQReshapeFusionTestCase{{1, 2, 1, 3}, {2, 1, 1}, {1}, {1, 1}, {1, 2, 1, 1}, {1, 2, 1, 3}, {1, 2, 1, 1}, {1, 1, 1, 1},  {1, 1, 1, 1}, DO_NOT_RESHAPE, false},

--- a/inference-engine/tests/functional/inference_engine/transformations/hswish_decomposition_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/hswish_decomposition_test.cpp
@@ -18,7 +18,7 @@
 
 using namespace testing;
 
-TEST(TransformationTests, HSwishDecompositionTest) {
+TEST(TransformationTests, smoke_HSwishDecompositionTest) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(1));

--- a/inference-engine/tests/functional/inference_engine/transformations/hswish_fusion_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/hswish_fusion_test.cpp
@@ -18,7 +18,7 @@
 
 using namespace testing;
 
-TEST(TransformationTests, HSwishFusionWithReluDivF16) {
+TEST(TransformationTests, smoke_HSwishFusionWithReluDivF16) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f16, ngraph::PartialShape::dynamic(1));
@@ -51,7 +51,7 @@ TEST(TransformationTests, HSwishFusionWithReluDivF16) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, HSwishFusionWithReluDivF32) {
+TEST(TransformationTests, smoke_HSwishFusionWithReluDivF32) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f32, ngraph::Shape{});
@@ -84,7 +84,7 @@ TEST(TransformationTests, HSwishFusionWithReluDivF32) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, HSwishFusionWithReluMul) {
+TEST(TransformationTests, smoke_HSwishFusionWithReluMul) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f16, ngraph::PartialShape::dynamic(1));
@@ -117,7 +117,7 @@ TEST(TransformationTests, HSwishFusionWithReluMul) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, HSwishFusionWithoutRelu) {
+TEST(TransformationTests, smoke_HSwishFusionWithoutRelu) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f16, ngraph::PartialShape::dynamic(1));
@@ -151,7 +151,7 @@ TEST(TransformationTests, HSwishFusionWithoutRelu) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, HSwishFusionWithClamp) {
+TEST(TransformationTests, smoke_HSwishFusionWithClamp) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f16, ngraph::PartialShape::dynamic(1));
@@ -182,7 +182,7 @@ TEST(TransformationTests, HSwishFusionWithClamp) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, HSwishFusionWithReluMulWrongConstValue) {
+TEST(TransformationTests, smoke_HSwishFusionWithReluMulWrongConstValue) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f16, ngraph::PartialShape::dynamic(1));
@@ -222,7 +222,7 @@ TEST(TransformationTests, HSwishFusionWithReluMulWrongConstValue) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, HSwishFusionWithReluDivWrongConstValue) {
+TEST(TransformationTests, smoke_HSwishFusionWithReluDivWrongConstValue) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f16, ngraph::Shape{});
@@ -262,7 +262,7 @@ TEST(TransformationTests, HSwishFusionWithReluDivWrongConstValue) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, HSwishFusionWithoutReluWrongConstValue) {
+TEST(TransformationTests, smoke_HSwishFusionWithoutReluWrongConstValue) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f16, ngraph::PartialShape::dynamic(1));
@@ -304,7 +304,7 @@ TEST(TransformationTests, HSwishFusionWithoutReluWrongConstValue) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, HSwishFusionWithClampWrongConstValue) {
+TEST(TransformationTests, smoke_HSwishFusionWithClampWrongConstValue) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f16, ngraph::PartialShape::dynamic(1));

--- a/inference-engine/tests/functional/inference_engine/transformations/lin_op_sequence_fusion_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/lin_op_sequence_fusion_test.cpp
@@ -25,7 +25,7 @@
 using namespace testing;
 using namespace ngraph;
 
-TEST(TransformationTests, MulAddMulAddFusion) {
+TEST(TransformationTests, smoke_MulAddMulAddFusion) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
 
     {
@@ -64,7 +64,7 @@ TEST(TransformationTests, MulAddMulAddFusion) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, MulMulMulFusion) {
+TEST(TransformationTests, smoke_MulMulMulFusion) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
 
     {
@@ -99,7 +99,7 @@ TEST(TransformationTests, MulMulMulFusion) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, AddAddAddFusion) {
+TEST(TransformationTests, smoke_AddAddAddFusion) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
 
     {
@@ -134,7 +134,7 @@ TEST(TransformationTests, AddAddAddFusion) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, MulAddAddMulFusion) {
+TEST(TransformationTests, smoke_MulAddAddMulFusion) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
 
     {

--- a/inference-engine/tests/functional/inference_engine/transformations/mish_fusion_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/mish_fusion_test.cpp
@@ -19,7 +19,7 @@
 
 using namespace testing;
 
-TEST(TransformationTests, MishFusing) {
+TEST(TransformationTests, smoke_MishFusing) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input0 = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f64, ngraph::Shape{3, 1, 2});
@@ -51,7 +51,7 @@ TEST(TransformationTests, MishFusing) {
 }
 
 
-TEST(TransformationTests, MishWithSoftPlusFusing) {
+TEST(TransformationTests, smoke_MishWithSoftPlusFusing) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input0 = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f64, ngraph::Shape{3, 1, 2});

--- a/inference-engine/tests/functional/inference_engine/transformations/mul_add_conversion_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/mul_add_conversion_test.cpp
@@ -159,7 +159,7 @@ TEST_P(MulOrAddConversionTests, CompareFunctions) {
 #define ELTWISE_SUM MulAddConversionTests::get_eltwise_add_reference
 #define ELTWISE_PROD MulAddConversionTests::get_eltwise_mul_reference
 
-INSTANTIATE_TEST_CASE_P(MulAddToScaleShift, MulAddConversionTests, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_MulAddToScaleShift, MulAddConversionTests, testing::Combine(
         testing::Values(std::make_tuple(InputShape{DYN, 3, 64, 64},
                                         CONST(ngraph::Shape({1, 3, 1, 1}), 0.5),
                                         CONST(ngraph::Shape({1, 3, 1, 1}), 0.5)),
@@ -171,7 +171,7 @@ INSTANTIATE_TEST_CASE_P(MulAddToScaleShift, MulAddConversionTests, testing::Comb
                                         CONST(ngraph::Shape({1, 3, 1, 1}), 0.5))),
         testing::Values(SCALESHIFT)));
 
-INSTANTIATE_TEST_CASE_P(MulToScaleShift, MulOrAddConversionTests, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_MulToScaleShift, MulOrAddConversionTests, testing::Combine(
         testing::Values(std::make_tuple(InputShape{DYN, 3, 64, 64},
                                         CONST(ngraph::Shape({1, 3, 1, 1}), 0.5),
                                         NONE),
@@ -183,7 +183,7 @@ INSTANTIATE_TEST_CASE_P(MulToScaleShift, MulOrAddConversionTests, testing::Combi
                                         NONE)),
         testing::Values(SCALESHIFT)));
 
-INSTANTIATE_TEST_CASE_P(AddToScaleShift, MulOrAddConversionTests, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_AddToScaleShift, MulOrAddConversionTests, testing::Combine(
         testing::Values(std::make_tuple(InputShape{DYN, 3, 64, 64},
                                         NONE,
                                         CONST(ngraph::Shape({1, 3, 1, 1}), 0.5)),
@@ -195,7 +195,7 @@ INSTANTIATE_TEST_CASE_P(AddToScaleShift, MulOrAddConversionTests, testing::Combi
                                         CONST(ngraph::Shape({1, 3, 1, 1}), 0.5))),
         testing::Values(SCALESHIFT)));
 
-INSTANTIATE_TEST_CASE_P(MulAddToPower, MulAddConversionTests, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_MulAddToPower, MulAddConversionTests, testing::Combine(
         testing::Values(std::make_tuple(InputShape{DYN, 3, 64, 64},
                                         CONST(ngraph::Shape({1}), 0.5),
                                         CONST(ngraph::Shape({1}), 0.5)),
@@ -207,7 +207,7 @@ INSTANTIATE_TEST_CASE_P(MulAddToPower, MulAddConversionTests, testing::Combine(
                                         CONST(ngraph::Shape({1}), 0.5))),
         testing::Values(POWER)));
 
-INSTANTIATE_TEST_CASE_P(MulToPower, MulOrAddConversionTests, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_MulToPower, MulOrAddConversionTests, testing::Combine(
         testing::Values(std::make_tuple(InputShape{DYN, 3, 64, 64},
                                         CONST(ngraph::Shape({1}), 0.5),
                                         NONE),
@@ -219,7 +219,7 @@ INSTANTIATE_TEST_CASE_P(MulToPower, MulOrAddConversionTests, testing::Combine(
                                         NONE)),
         testing::Values(POWER)));
 
-INSTANTIATE_TEST_CASE_P(AddToPower, MulOrAddConversionTests, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_AddToPower, MulOrAddConversionTests, testing::Combine(
         testing::Values(std::make_tuple(InputShape{DYN, 3, 64, 64},
                                         NONE,
                                         CONST(ngraph::Shape({1}), 0.5)),
@@ -232,7 +232,7 @@ INSTANTIATE_TEST_CASE_P(AddToPower, MulOrAddConversionTests, testing::Combine(
         testing::Values(POWER)));
 
 
-INSTANTIATE_TEST_CASE_P(MulAddNegative, MulAddConversionTests, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_MulAddNegative, MulAddConversionTests, testing::Combine(
         testing::Values(std::make_tuple(InputShape{DYN, 3, 64},
                                         CONST(ngraph::Shape({1, 3, 1}), 0.5),
                                         CONST(ngraph::Shape({1, 3, 1}), 0.5)/*ScaleShift must always be 4D*/),
@@ -256,7 +256,7 @@ INSTANTIATE_TEST_CASE_P(MulAddNegative, MulAddConversionTests, testing::Combine(
                                         CONST(ngraph::Shape({1, 3, 1, 1}), 0.5))),
         testing::Values(SAME)));
 
-INSTANTIATE_TEST_CASE_P(MulToEltwise, MulOrAddConversionTests, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_MulToEltwise, MulOrAddConversionTests, testing::Combine(
         testing::Values(std::make_tuple(InputShape{DYN, 3, 64},
                                         CONST(ngraph::Shape({1, 1, 64}), 0.5),
                                         NONE),
@@ -286,7 +286,7 @@ INSTANTIATE_TEST_CASE_P(MulToEltwise, MulOrAddConversionTests, testing::Combine(
                                         NONE)),
         testing::Values(ELTWISE_PROD)));
 
-INSTANTIATE_TEST_CASE_P(AddToEltwise, MulOrAddConversionTests, testing::Combine(
+INSTANTIATE_TEST_CASE_P(smoke_AddToEltwise, MulOrAddConversionTests, testing::Combine(
         testing::Values(std::make_tuple(InputShape{DYN, 3, 64},
                                         NONE,
                                         CONST(ngraph::Shape({1, 1, 64}), 0.5)),

--- a/inference-engine/tests/functional/inference_engine/transformations/ngraph_1d_ops_reshape_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/ngraph_1d_ops_reshape_test.cpp
@@ -23,7 +23,7 @@
 using namespace testing;
 using namespace ngraph;
 
-TEST(TransformationTests, ConvReshapeTest1) {
+TEST(TransformationTests, smoke_ConvReshapeTest1) {
     auto input = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{1, 3, 64}, {1});
     auto w = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{6, 3, 3/*OIW*/}, {1});
 
@@ -55,7 +55,7 @@ TEST(TransformationTests, ConvReshapeTest1) {
     }
 }
 
-TEST(TransformationTests, ConvBiasReshapeTest1) {
+TEST(TransformationTests, smoke_ConvBiasReshapeTest1) {
     auto input = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{1, 3, 64}, {1});
     auto w = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{6, 3, 3/*OIW*/}, {1});
     auto b = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{6}, {1});
@@ -88,7 +88,7 @@ TEST(TransformationTests, ConvBiasReshapeTest1) {
     }
 }
 
-TEST(TransformationTests, MaxPoolReshapeTest1) {
+TEST(TransformationTests, smoke_MaxPoolReshapeTest1) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 64});
@@ -121,7 +121,7 @@ TEST(TransformationTests, MaxPoolReshapeTest1) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, AvgPoolReshapeTest1) {
+TEST(TransformationTests, smoke_AvgPoolReshapeTest1) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 64});

--- a/inference-engine/tests/functional/inference_engine/transformations/ngraph_depth_to_space_transform_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/ngraph_depth_to_space_transform_test.cpp
@@ -22,7 +22,7 @@
 
 using namespace testing;
 
-TEST(TransformationTests, TestDepthToSpaceTransformBlockFirst) {
+TEST(TransformationTests, smoke_TestDepthToSpaceTransformBlockFirst) {
     auto input = std::make_shared<ngraph::op::Parameter>(ngraph::element::f32, ngraph::Shape{1, 12, 1080, 1616});
     std::shared_ptr<ngraph::Function> f(nullptr);
 
@@ -62,7 +62,7 @@ TEST(TransformationTests, TestDepthToSpaceTransformBlockFirst) {
     ASSERT_EQ(shape_end_value, shape_end_value_ref);
 }
 
-TEST(TransformationTests, TestDepthToSpaceTransformDepthFirst) {
+TEST(TransformationTests, smoke_TestDepthToSpaceTransformDepthFirst) {
     auto input = std::make_shared<ngraph::op::Parameter>(ngraph::element::f32, ngraph::Shape{1, 12, 1080, 1616});
     std::shared_ptr<ngraph::Function> f(nullptr);
 
@@ -102,7 +102,7 @@ TEST(TransformationTests, TestDepthToSpaceTransformDepthFirst) {
     ASSERT_EQ(shape_end_value, shape_end_value_ref);
 }
 
-TEST(TransformationTests, TestSpaceToDepthTransformBlockFirst) {
+TEST(TransformationTests, smoke_TestSpaceToDepthTransformBlockFirst) {
     auto input = std::make_shared<ngraph::op::Parameter>(ngraph::element::f32, ngraph::Shape{1, 12, 1080, 1616});
     std::shared_ptr<ngraph::Function> f(nullptr);
 
@@ -142,7 +142,7 @@ TEST(TransformationTests, TestSpaceToDepthTransformBlockFirst) {
     ASSERT_EQ(shape_end_value, shape_end_value_ref);
 }
 
-TEST(TransformationTests, TestSpaceToDepthTransformDepthFirst) {
+TEST(TransformationTests, smoke_TestSpaceToDepthTransformDepthFirst) {
     auto input = std::make_shared<ngraph::op::Parameter>(ngraph::element::f32, ngraph::Shape{1, 12, 1080, 1616});
     std::shared_ptr<ngraph::Function> f(nullptr);
 

--- a/inference-engine/tests/functional/inference_engine/transformations/ngraph_fq_transpose_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/ngraph_fq_transpose_test.cpp
@@ -23,7 +23,7 @@
 
 using namespace testing;
 
-TEST(TransformationTests, FQTransposeTest1) {
+TEST(TransformationTests, smoke_FQTransposeTest1) {
     auto data1 = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{1, 1, 3}, {1, 2, 3});
     auto data2 = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{3}, {1, 2, 3});
     auto data3 = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{1, 3}, {1, 2, 3});

--- a/inference-engine/tests/functional/inference_engine/transformations/ngraph_mode_decomposition_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/ngraph_mode_decomposition_test.cpp
@@ -22,7 +22,7 @@
 
 using namespace testing;
 
-TEST(TransformationTests, ModDecompositionTests) {
+TEST(TransformationTests, smoke_ModDecompositionTests) {
     auto data1 = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{1, 1, 3}, {1, 2, 3});
     auto data2 = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{3}, {1, 2, 3});
 

--- a/inference-engine/tests/functional/inference_engine/transformations/nop_elimination.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/nop_elimination.cpp
@@ -26,7 +26,7 @@ NGRAPH_SUPPRESS_DEPRECATED_START
 using namespace ngraph;
 using namespace std;
 
-TEST(nop_elimination, eliminate_sum) {
+TEST(nop_elimination, smoke_eliminate_sum) {
     Shape shape{2, 2};
     auto A = make_shared<op::Parameter>(element::f32, shape);
     auto s = make_shared<op::v0::Sum>(A, AxisSet{});
@@ -39,7 +39,7 @@ TEST(nop_elimination, eliminate_sum) {
     ASSERT_EQ(count_ops_of_type<op::v0::Sum>(f), 0);
 }
 
-TEST(nop_elimination, eliminate_convert) {
+TEST(nop_elimination, smoke_eliminate_convert) {
     Shape shape{};
     auto type = element::f32;
     auto A = make_shared<op::Parameter>(type, shape);
@@ -53,7 +53,7 @@ TEST(nop_elimination, eliminate_convert) {
     ASSERT_EQ(count_ops_of_type<op::v0::Convert>(f), 0);
 }
 
-TEST(nop_elimination, convert_type_agnostic) {
+TEST(nop_elimination, smoke_convert_type_agnostic) {
     Shape shape{};
     auto type = element::from<char>();
     auto A = make_shared<op::Parameter>(type, shape);
@@ -70,7 +70,7 @@ TEST(nop_elimination, convert_type_agnostic) {
     ASSERT_EQ(count_ops_of_type<op::v0::Convert>(f), 0);
 }
 
-TEST(nop_elimination, eliminate_slice) {
+TEST(nop_elimination, smoke_eliminate_slice) {
     Shape shape{2, 2};
     auto A = make_shared<op::Parameter>(element::f32, shape);
     auto s = make_shared<op::v0::Slice>(A, Coordinate{0, 0}, Coordinate{2, 2});
@@ -83,7 +83,7 @@ TEST(nop_elimination, eliminate_slice) {
     ASSERT_EQ(count_ops_of_type<op::v0::Slice>(f), 0);
 }
 
-TEST(nop_elimination, eliminate_broadcast) {
+TEST(nop_elimination, smoke_eliminate_broadcast) {
     Shape shape{};
     auto A = make_shared<op::Parameter>(element::f32, shape);
     auto b = make_shared<op::v0::Broadcast>(A, shape, AxisSet{});
@@ -96,7 +96,7 @@ TEST(nop_elimination, eliminate_broadcast) {
     ASSERT_EQ(count_ops_of_type<op::v0::Broadcast>(f), 0);
 }
 
-TEST(nop_elimination, eliminate_stop_gradient) {
+TEST(nop_elimination, smoke_eliminate_stop_gradient) {
     Shape shape{};
     auto A = make_shared<op::Parameter>(element::f32, shape);
     auto s = make_shared<op::v0::StopGradient>(A);
@@ -109,12 +109,12 @@ TEST(nop_elimination, eliminate_stop_gradient) {
     ASSERT_EQ(count_ops_of_type<op::v0::StopGradient>(f), 0);
 }
 
-TEST(nop_elimination, pass_property) {
+TEST(nop_elimination, smoke_pass_property) {
     auto pass = std::make_shared<ngraph::pass::NopElimination>();
     ASSERT_FALSE(pass->get_property(pass::PassProperty::CHANGE_DYNAMIC_STATE));
 }
 
-TEST(nop_elimination, reshape_elimination_v1) {
+TEST(nop_elimination, smoke_reshape_elimination_v1) {
     auto generate_func = [](bool zero) {
         auto arg = std::make_shared<op::Parameter>(element::i64, PartialShape{8, 16, 2, 3});
         auto pattern_org = op::Constant::create(element::i64, Shape{3}, vector<int64_t>{8, 16, 6});
@@ -140,7 +140,7 @@ TEST(nop_elimination, reshape_elimination_v1) {
     ASSERT_TRUE(count_ops_of_type<op::v1::Reshape>(func_zero) == 1);
 }
 
-TEST(nop_elimination, squeeze_reshape_elimination_check_info) {
+TEST(nop_elimination, smoke_squeeze_reshape_elimination_check_info) {
     std::shared_ptr<Function> f;
     {
         auto arg = std::make_shared<opset4::Parameter>(element::f32, PartialShape{8, 16, 1, 3});
@@ -179,7 +179,7 @@ TEST(nop_elimination, squeeze_reshape_elimination_check_info) {
     ASSERT_FALSE(reshape_is_missing);
 }
 
-TEST(nop_elimination, reshape_elimination_v1_dynamic) {
+TEST(nop_elimination, smoke_reshape_elimination_v1_dynamic) {
     auto arg = std::make_shared<op::Parameter>(element::i64, PartialShape::dynamic());
     auto pattern = make_shared<op::Parameter>(element::i64, PartialShape::dynamic(1));
     auto reshape_v1 = std::make_shared<op::v1::Reshape>(arg, pattern, false);
@@ -191,7 +191,7 @@ TEST(nop_elimination, reshape_elimination_v1_dynamic) {
     ASSERT_TRUE(count_ops_of_type<op::v1::Reshape>(f) == 1);
 }
 
-TEST(nop_elimination, concat_elimination_single_node) {
+TEST(nop_elimination, smoke_concat_elimination_single_node) {
     int64_t a = 0;
     auto A = make_shared<op::Parameter>(element::f32, Shape{2, 3});
     auto f =
@@ -205,7 +205,7 @@ TEST(nop_elimination, concat_elimination_single_node) {
     ASSERT_EQ(count_ops_of_type<op::v0::Concat>(f), 1);
 }
 
-TEST(nop_elimination, concat_elimination_single_input) {
+TEST(nop_elimination, smoke_concat_elimination_single_input) {
     int64_t a = 0;
     auto A = make_shared<op::Parameter>(element::f32, Shape{2, 3});
     auto B = make_shared<op::v0::Concat>(NodeVector{A}, a);
@@ -219,7 +219,7 @@ TEST(nop_elimination, concat_elimination_single_input) {
     ASSERT_EQ(count_ops_of_type<op::v0::Concat>(f), 0);
 }
 
-TEST(nop_elimination, concat_elimination_single_input_dynamic) {
+TEST(nop_elimination, smoke_concat_elimination_single_input_dynamic) {
     int64_t a = 0;
     auto A = make_shared<op::Parameter>(element::f32, PartialShape{Dimension::dynamic(), 3});
     auto B = make_shared<op::v0::Concat>(NodeVector{A}, a);
@@ -233,7 +233,7 @@ TEST(nop_elimination, concat_elimination_single_input_dynamic) {
     ASSERT_EQ(count_ops_of_type<op::v0::Concat>(f), 0);
 }
 
-TEST(nop_elimination, unsqueeze_elimination) {
+TEST(nop_elimination, smoke_unsqueeze_elimination) {
     const auto axis = op::Constant::create<int64_t>(element::i64, {}, {0});
     const auto A = make_shared<op::Parameter>(
         element::f32, PartialShape{3, Dimension::dynamic(), Dimension::dynamic()});
@@ -248,7 +248,7 @@ TEST(nop_elimination, unsqueeze_elimination) {
     ASSERT_EQ(count_ops_of_type<op::v0::Unsqueeze>(f), 1);
 }
 
-TEST(nop_elimination, squeeze_unsqueeze_overlap_elimination) {
+TEST(nop_elimination, smoke_squeeze_unsqueeze_overlap_elimination) {
     auto check_usecase = [](const PartialShape& shape,
                             const std::vector<int64_t>& sq_axes_val,
                             const std::vector<int64_t>& unsq_axes_val,
@@ -493,7 +493,7 @@ TEST(nop_elimination, squeeze_unsqueeze_overlap_elimination) {
                   0);
 }
 
-TEST(nop_elimination, squeeze_squeeze_overlap_elimination) {
+TEST(nop_elimination, smoke_squeeze_squeeze_overlap_elimination) {
     auto check_usecase = [](const PartialShape& shape,
                             const std::vector<int64_t>& sq_axes_val_1,
                             const std::vector<int64_t>& sq_axes_val_2,
@@ -532,7 +532,7 @@ TEST(nop_elimination, squeeze_squeeze_overlap_elimination) {
         PartialShape{1, Dimension::dynamic(), 1, Dimension::dynamic(), 1}, {0}, {1, 3}, 1);
 }
 
-TEST(nop_elimination, unsqueeze_unsqueeze_overlap_elimination) {
+TEST(nop_elimination, smoke_unsqueeze_unsqueeze_overlap_elimination) {
     auto check_usecase = [](const PartialShape& shape,
                             const std::vector<int64_t>& unsq_axes_val_1,
                             const std::vector<int64_t>& unsq_axes_val_2,
@@ -569,7 +569,7 @@ TEST(nop_elimination, unsqueeze_unsqueeze_overlap_elimination) {
     check_usecase(PartialShape{Dimension::dynamic(), 1, Dimension::dynamic(), 1}, {0}, {1, 3}, 1);
 }
 
-TEST(nop_elimination, unsqueeze_squeeze_elimination) {
+TEST(nop_elimination, smoke_unsqueeze_squeeze_elimination) {
     auto generate_func = [](const Shape& shape, const std::vector<int64_t>& axes_val) {
         auto axes = op::Constant::create<int64_t>(element::i64, Shape{axes_val.size()}, axes_val);
         auto A = make_shared<op::Parameter>(element::f32, shape);
@@ -596,7 +596,7 @@ TEST(nop_elimination, unsqueeze_squeeze_elimination) {
     check_usecase(Shape{3, 2}, std::vector<int64_t>{-1, -4});
 }
 
-TEST(nop_elimination, reshape_unsqueeze_elimination) {
+TEST(nop_elimination, smoke_reshape_unsqueeze_elimination) {
     auto check_usecase = [](const Shape& shape,
                             const std::vector<int64_t>& pat_val,
                             bool zero,
@@ -625,7 +625,7 @@ TEST(nop_elimination, reshape_unsqueeze_elimination) {
     check_usecase(Shape{2, 3, 2}, {2, -1, 2}, false, {2});
     check_usecase(Shape{2, 3, 2, 1}, {2, 3, 2}, false, {0});
 }
-TEST(nop_elimination, reshape_squeeze_elimination) {
+TEST(nop_elimination, smoke_reshape_squeeze_elimination) {
     auto check_usecase = [](const Shape& shape,
                             const std::vector<int64_t>& pat_val,
                             bool zero,
@@ -655,7 +655,7 @@ TEST(nop_elimination, reshape_squeeze_elimination) {
     check_usecase(Shape{2, 3, 2, 1}, {1, 2, 3, 2}, false, {0});
 }
 
-TEST(nop_elimination, reshape_reshape_elimination) {
+TEST(nop_elimination, smoke_reshape_reshape_elimination) {
     auto check_usecase = [](const Shape& shape, const std::vector<int64_t>& pat_val, bool zero) {
         auto pat = op::Constant::create<int64_t>(element::i64, Shape{pat_val.size()}, pat_val);
         auto A = make_shared<op::Parameter>(element::f32, shape);
@@ -680,7 +680,7 @@ TEST(nop_elimination, reshape_reshape_elimination) {
     check_usecase(Shape{2, 3, 2, 1}, ::vector<int64_t>{2, 3, 2}, false);
 }
 
-TEST(nop_elimination, squeeze_reshape_elimination) {
+TEST(nop_elimination, smoke_squeeze_reshape_elimination) {
     auto check_usecase = [](const Shape& shape, const std::vector<int64_t>& indices_val) {
         auto indices =
             op::Constant::create<int64_t>(element::i64, Shape{indices_val.size()}, indices_val);
@@ -706,7 +706,7 @@ TEST(nop_elimination, squeeze_reshape_elimination) {
     check_usecase(Shape{1, 6, 2, 1}, std::vector<int64_t>{3});
 }
 
-TEST(nop_elimination, unsqueeze_reshape_elimination) {
+TEST(nop_elimination, smoke_unsqueeze_reshape_elimination) {
     auto check_usecase = [](const Shape& shape, const std::vector<int64_t>& indices_val) {
         auto indices =
             op::Constant::create<int64_t>(element::i64, Shape{indices_val.size()}, indices_val);
@@ -732,7 +732,7 @@ TEST(nop_elimination, unsqueeze_reshape_elimination) {
     check_usecase(Shape{1, 6, 2}, std::vector<int64_t>{3});
 }
 
-TEST(nop_elimination, squeeze_unsqueeze_elimination_negative) {
+TEST(nop_elimination, smoke_squeeze_unsqueeze_elimination_negative) {
     auto check_usecase = [](const Shape& shape, const std::vector<int64_t>& indices_val) {
         auto indices = op::Constant::create(element::i64, Shape{indices_val.size()}, indices_val);
         auto input = make_shared<op::Parameter>(element::f32, shape);
@@ -748,7 +748,7 @@ TEST(nop_elimination, squeeze_unsqueeze_elimination_negative) {
     check_usecase(Shape{1, 1, 1}, std::vector<int64_t>{0, 1, 2});
 }
 
-TEST(nop_elimination, topk_convert_elimination) {
+TEST(nop_elimination, smoke_topk_convert_elimination) {
     auto check_usecase = []() {
         auto A = make_shared<op::Parameter>(element::f32, Shape{20, 3, 4});
         auto A1 = make_shared<op::v0::Abs>(A);

--- a/inference-engine/tests/functional/inference_engine/transformations/normalize_l2_fusion_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/normalize_l2_fusion_test.cpp
@@ -18,7 +18,7 @@
 
 using namespace testing;
 
-TEST(TransformationTests, NormalizeL2FusionWithMax) {
+TEST(TransformationTests, smoke_NormalizeL2FusionWithMax) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     const float eps_value = 0.000099f;
     {
@@ -53,7 +53,7 @@ TEST(TransformationTests, NormalizeL2FusionWithMax) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, NormalizeL2FusionWithMaxIncorrectExp) {
+TEST(TransformationTests, smoke_NormalizeL2FusionWithMaxIncorrectExp) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     const float eps_value = 0.0009f;
     {
@@ -93,7 +93,7 @@ TEST(TransformationTests, NormalizeL2FusionWithMaxIncorrectExp) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, NormalizeL2FusionWithMaxIncorrectEpsValueShape) {
+TEST(TransformationTests, smoke_NormalizeL2FusionWithMaxIncorrectEpsValueShape) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f16, ngraph::PartialShape::dynamic(2));
@@ -132,7 +132,7 @@ TEST(TransformationTests, NormalizeL2FusionWithMaxIncorrectEpsValueShape) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, NormalizeL2FusionWithAdd) {
+TEST(TransformationTests, smoke_NormalizeL2FusionWithAdd) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     const float eps_value = 0.000099f;
     {
@@ -167,7 +167,7 @@ TEST(TransformationTests, NormalizeL2FusionWithAdd) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, NormalizeL2FusionWithAddIncorrectExp) {
+TEST(TransformationTests, smoke_NormalizeL2FusionWithAddIncorrectExp) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     const float eps_value = 0.0009f;
     {
@@ -208,7 +208,7 @@ TEST(TransformationTests, NormalizeL2FusionWithAddIncorrectExp) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, NormalizeL2FusionWithAddIncorrectEpsValueShape) {
+TEST(TransformationTests, smoke_NormalizeL2FusionWithAddIncorrectEpsValueShape) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f16, ngraph::PartialShape::dynamic(4));

--- a/inference-engine/tests/functional/inference_engine/transformations/optimize_strided_slice_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/optimize_strided_slice_test.cpp
@@ -25,7 +25,7 @@
 
 using namespace testing;
 
-TEST(TransformationTests, OptimizeSS_UselessDeletion_Negative1) {
+TEST(TransformationTests, smoke_OptimizeSS_UselessDeletion_Negative1) {
     std::shared_ptr<ngraph::Function> f(nullptr);
     {
         auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{5, 5, 5, 5});
@@ -47,7 +47,7 @@ TEST(TransformationTests, OptimizeSS_UselessDeletion_Negative1) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, OptimizeSS_UselessDeletion_Negative2) {
+TEST(TransformationTests, smoke_OptimizeSS_UselessDeletion_Negative2) {
     std::shared_ptr<ngraph::Function> f(nullptr);
     {
         auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(4));
@@ -70,7 +70,7 @@ TEST(TransformationTests, OptimizeSS_UselessDeletion_Negative2) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, OptimizeSS_UselessDeletion) {
+TEST(TransformationTests, smoke_OptimizeSS_UselessDeletion) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{5, 5, 5, 5});
@@ -98,7 +98,7 @@ TEST(TransformationTests, OptimizeSS_UselessDeletion) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, OptimizeSS_SkipUselessDeletionRevertCase) {
+TEST(TransformationTests, smoke_OptimizeSS_SkipUselessDeletionRevertCase) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto data = std::make_shared<ngraph::opset3::Parameter>(ngraph::element::f32, ngraph::Shape{5, 5, 5, 5});
@@ -135,7 +135,7 @@ TEST(TransformationTests, OptimizeSS_SkipUselessDeletionRevertCase) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, OptimizeSS_Usefull_Test) {
+TEST(TransformationTests, smoke_OptimizeSS_Usefull_Test) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{5, 5, 5, 5});
@@ -170,7 +170,7 @@ TEST(TransformationTests, OptimizeSS_Usefull_Test) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, OptimizeSS_Shared_Test) {
+TEST(TransformationTests, smoke_OptimizeSS_Shared_Test) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto source = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{5, 5, 5, 5});
@@ -213,7 +213,7 @@ TEST(TransformationTests, OptimizeSS_Shared_Test) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, OptimizeSS_NotShared_Test) {
+TEST(TransformationTests, smoke_OptimizeSS_NotShared_Test) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto source = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{5, 6, 5, 5});
@@ -270,7 +270,7 @@ TEST(TransformationTests, OptimizeSS_NotShared_Test) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, OptimizeSS_Groupped_Test) {
+TEST(TransformationTests, smoke_OptimizeSS_Groupped_Test) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto source = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{5, 5, 5, 5});

--- a/inference-engine/tests/functional/inference_engine/transformations/primitives_priority_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/primitives_priority_test.cpp
@@ -24,7 +24,7 @@
 
 using namespace testing;
 
-TEST(TransformationTests, ConvBiasFusion) {
+TEST(TransformationTests, smoke_ConvBiasFusion) {
     std::shared_ptr<ngraph::Function> f(nullptr);
     {
         auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 64, 64});

--- a/inference-engine/tests/functional/inference_engine/transformations/reduce_l1_decomposition_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/reduce_l1_decomposition_test.cpp
@@ -18,7 +18,7 @@
 
 using namespace testing;
 
-TEST(TransformationTests, ReduceL1DecompositionTest) {
+TEST(TransformationTests, smoke_ReduceL1DecompositionTest) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto data = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(1));

--- a/inference-engine/tests/functional/inference_engine/transformations/reduce_l2_decomposition_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/reduce_l2_decomposition_test.cpp
@@ -18,7 +18,7 @@
 
 using namespace testing;
 
-TEST(TransformationTests, ReduceL2DecompositionTest) {
+TEST(TransformationTests, smoke_ReduceL2DecompositionTest) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto data = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(1));

--- a/inference-engine/tests/functional/inference_engine/transformations/reshape_fc_fusion_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/reshape_fc_fusion_test.cpp
@@ -22,7 +22,7 @@
 
 using namespace testing;
 
-TEST(TransformationTests, ReshapeFCFusiuonTest1) {
+TEST(TransformationTests, smoke_ReshapeFCFusiuonTest1) {
     std::shared_ptr<ngraph::Function> f(nullptr);
     {
         auto input = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{1, 3, 64, 64}, {1});
@@ -41,7 +41,7 @@ TEST(TransformationTests, ReshapeFCFusiuonTest1) {
     ASSERT_EQ(f->get_ops().size(), 5);
 }
 
-TEST(TransformationTests, ReshapeFCFusiuonTest2) {
+TEST(TransformationTests, smoke_ReshapeFCFusiuonTest2) {
     std::shared_ptr<ngraph::Function> f(nullptr);
     {
         auto input = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{1, 3, 64, 64}, {1});
@@ -60,7 +60,7 @@ TEST(TransformationTests, ReshapeFCFusiuonTest2) {
     ASSERT_EQ(f->get_ops().size(), 5);
 }
 
-TEST(TransformationTests, ReshapeFCFusiuonTest3) {
+TEST(TransformationTests, smoke_ReshapeFCFusiuonTest3) {
     std::shared_ptr<ngraph::Function> f(nullptr);
     {
         auto input = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{2, 3, 64, 64}, {1});

--- a/inference-engine/tests/functional/inference_engine/transformations/softplus_decomposition_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/softplus_decomposition_test.cpp
@@ -18,7 +18,7 @@
 
 using namespace testing;
 
-TEST(TransformationTests, SoftPlusDecompositionFP32) {
+TEST(TransformationTests, smoke_SoftPlusDecompositionFP32) {
     std::shared_ptr<ngraph::Function> f, f_ref;
     {
         auto data = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f32, ngraph::Shape{3, 1, 2});
@@ -47,7 +47,7 @@ TEST(TransformationTests, SoftPlusDecompositionFP32) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, SoftPlusDecompositionFP16) {
+TEST(TransformationTests, smoke_SoftPlusDecompositionFP16) {
     std::shared_ptr<ngraph::Function> f, f_ref;
     {
         auto data = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f16, ngraph::Shape{3, 1, 2});

--- a/inference-engine/tests/functional/inference_engine/transformations/softplus_fusion_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/softplus_fusion_test.cpp
@@ -18,7 +18,7 @@
 
 using namespace testing;
 
-TEST(TransformationTests, SoftPlusFusing) {
+TEST(TransformationTests, smoke_SoftPlusFusing) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input0 = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f32, ngraph::Shape{3, 1, 2});
@@ -47,7 +47,7 @@ TEST(TransformationTests, SoftPlusFusing) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, SoftPlusFusingDynamic) {
+TEST(TransformationTests, smoke_SoftPlusFusingDynamic) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input0 = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(1));
@@ -76,7 +76,7 @@ TEST(TransformationTests, SoftPlusFusingDynamic) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, SoftPlusFusingNegative) {
+TEST(TransformationTests, smoke_SoftPlusFusingNegative) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input0 = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(1));

--- a/inference-engine/tests/functional/inference_engine/transformations/swish_fusion_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/swish_fusion_test.cpp
@@ -18,7 +18,7 @@
 
 using namespace testing;
 
-TEST(TransformationTests, SwishFusionWithBeta) {
+TEST(TransformationTests, smoke_SwishFusionWithBeta) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(1));
@@ -51,7 +51,7 @@ TEST(TransformationTests, SwishFusionWithBeta) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, SwishFusionWithoutBeta) {
+TEST(TransformationTests, smoke_SwishFusionWithoutBeta) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f16, ngraph::PartialShape::dynamic(1));
@@ -81,7 +81,7 @@ TEST(TransformationTests, SwishFusionWithoutBeta) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, SwishFusionWithoutBetaNonOneAddConstant) {
+TEST(TransformationTests, smoke_SwishFusionWithoutBetaNonOneAddConstant) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f16, ngraph::PartialShape::dynamic(1));
@@ -117,7 +117,7 @@ TEST(TransformationTests, SwishFusionWithoutBetaNonOneAddConstant) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, SwishFusionWithSigmoid) {
+TEST(TransformationTests, smoke_SwishFusionWithSigmoid) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f16, ngraph::PartialShape::dynamic(1));
@@ -144,7 +144,7 @@ TEST(TransformationTests, SwishFusionWithSigmoid) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, SwishFusionWithSigmoidWithBeta) {
+TEST(TransformationTests, smoke_SwishFusionWithSigmoidWithBeta) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f16, ngraph::PartialShape::dynamic(1));
@@ -174,7 +174,7 @@ TEST(TransformationTests, SwishFusionWithSigmoidWithBeta) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, SwishFusionWithSigmoidWithBetaConstant) {
+TEST(TransformationTests, smoke_SwishFusionWithSigmoidWithBetaConstant) {
     // test where the beta constant has multiple but the same value
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {

--- a/inference-engine/tests/functional/inference_engine/transformations/transpose_to_reshape_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/transpose_to_reshape_test.cpp
@@ -108,7 +108,7 @@ TEST_P(TransposeToReshapeTests, CompareFunctions) {
 #define EMPTY_FUNCTION   ReferenceParams(false, true)
 #define SHAPE_OF_GATHER  ReferenceParams()
 
-INSTANTIATE_TEST_CASE_P(KeepTranspose, TransposeToReshapeTests,
+INSTANTIATE_TEST_CASE_P(smoke_KeepTranspose, TransposeToReshapeTests,
         testing::Values(std::make_tuple(InputShape{1, 3, 64, 64},  TransposeOrder{0, 1, 3, 2}, SAME_FUNCTION),
                         std::make_tuple(InputShape{1, 3, 1, 64},   TransposeOrder{2, 0, 3, 1}, SAME_FUNCTION),
                         std::make_tuple(InputShape{1, 3, 1, 3},    TransposeOrder{3, 0, 2, 1}, SAME_FUNCTION),
@@ -117,19 +117,19 @@ INSTANTIATE_TEST_CASE_P(KeepTranspose, TransposeToReshapeTests,
                         std::make_tuple(InputShape{DYN, DYN, 1},   TransposeOrder{2, 1, 0},    SAME_FUNCTION),
                         std::make_tuple(InputShape{DYN, DYN},      TransposeOrder{1, 0},       SAME_FUNCTION)));
 
-INSTANTIATE_TEST_CASE_P(EliminateTranspose, TransposeToReshapeTests,
+INSTANTIATE_TEST_CASE_P(smoke_EliminateTranspose, TransposeToReshapeTests,
         testing::Values(std::make_tuple(InputShape{1, 3, 64, 64}, TransposeOrder{0, 1, 2, 3}, EMPTY_FUNCTION),
                         std::make_tuple(InputShape{1, 1, 1},      TransposeOrder{2, 0, 1},    EMPTY_FUNCTION),
                         std::make_tuple(InputShape{DYN, DYN},     TransposeOrder{0, 1},       EMPTY_FUNCTION)));
 
-INSTANTIATE_TEST_CASE_P(ReshapeWithConstant, TransposeToReshapeTests,
+INSTANTIATE_TEST_CASE_P(smoke_ReshapeWithConstant, TransposeToReshapeTests,
         testing::Values(std::make_tuple(InputShape{1, 3, 64, 1},   TransposeOrder{0, 1, 3, 2}, ReferenceParams({1, 3, 1, 64})),
                         std::make_tuple(InputShape{1, 3, 1, 64},   TransposeOrder{1, 0, 3, 2}, ReferenceParams({3, 1, 64, 1})),
                         std::make_tuple(InputShape{DYN, DYN, 1},   TransposeOrder{0, 2, 1},    ReferenceParams({0, 1, -1})),
                         std::make_tuple(InputShape{1, 1, DYN},     TransposeOrder{2, 1, 0},    ReferenceParams({-1, 0, 1})),
                         std::make_tuple(InputShape{DYN, 1, 64, 1}, TransposeOrder{1, 0, 3, 2}, ReferenceParams({1, -1, 1, 64}))));
 
-INSTANTIATE_TEST_CASE_P(ReshapeWithGather, TransposeToReshapeTests,
+INSTANTIATE_TEST_CASE_P(smoke_ReshapeWithGather, TransposeToReshapeTests,
         testing::Values(std::make_tuple(InputShape{DYN, 1, DYN, 1},   TransposeOrder{1, 0, 3, 2}, SHAPE_OF_GATHER),
                         std::make_tuple(InputShape{1, DYN, DYN, DYN}, TransposeOrder{1, 2, 3, 0}, SHAPE_OF_GATHER)));
 

--- a/inference-engine/tests/functional/inference_engine/transformations/type_relaxed_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/type_relaxed_tests.cpp
@@ -14,7 +14,7 @@ using TypeVector = element::TypeVector;
 
 using TypeRelaxedTests = CommonTestUtils::TestsCommon;
 
-TEST_F(TypeRelaxedTests, noOverrideCopyCtor) {
+TEST_F(TypeRelaxedTests, smoke_noOverrideCopyCtor) {
     std::shared_ptr<ngraph::Function> ngraph;
     {
         ngraph::PartialShape shape({1, 3, 22, 22});
@@ -36,7 +36,7 @@ TEST_F(TypeRelaxedTests, noOverrideCopyCtor) {
     ASSERT_EQ(3, ngraph->get_ops().size());
 }
 
-TEST_F(TypeRelaxedTests, overrideOutputCopyCtor) {
+TEST_F(TypeRelaxedTests, smoke_overrideOutputCopyCtor) {
     auto input_type = element::f32;
     auto overriden_type = element::i32;
     std::shared_ptr<ngraph::Function> ngraph;
@@ -57,7 +57,7 @@ TEST_F(TypeRelaxedTests, overrideOutputCopyCtor) {
     ASSERT_EQ(3, ngraph->get_ops().size());
 }
 
-TEST_F(TypeRelaxedTests, overrideInputCopyCtor) {
+TEST_F(TypeRelaxedTests, smoke_overrideInputCopyCtor) {
     auto input_type = element::f32;
     auto overriden_type = element::i32;
     std::shared_ptr<ngraph::Function> ngraph;
@@ -78,7 +78,7 @@ TEST_F(TypeRelaxedTests, overrideInputCopyCtor) {
     ASSERT_EQ(3, ngraph->get_ops().size());
 }
 
-TEST_F(TypeRelaxedTests, mixedInputsAutoOutput) {
+TEST_F(TypeRelaxedTests, smoke_mixedInputsAutoOutput) {
     auto input_type1 = element::u8;
     auto input_type2 = element::i8;
     auto overriden_type = element::i16;
@@ -104,7 +104,7 @@ TEST_F(TypeRelaxedTests, mixedInputsAutoOutput) {
     ASSERT_EQ(4, ngraph->get_ops().size());
 }
 
-TEST_F(TypeRelaxedTests, mixedInputsAutoOutputForwardCtor) {
+TEST_F(TypeRelaxedTests, smoke_mixedInputsAutoOutputForwardCtor) {
     auto input_type1 = element::u8;
     auto input_type2 = element::i8;
     auto overriden_type = element::i16;
@@ -129,7 +129,7 @@ TEST_F(TypeRelaxedTests, mixedInputsAutoOutputForwardCtor) {
     ASSERT_EQ(4, ngraph->get_ops().size());
 }
 
-TEST_F(TypeRelaxedTests, notSupportedTypeOverride) {
+TEST_F(TypeRelaxedTests, smoke_notSupportedTypeOverride) {
     auto overriden_type = element::u8;
     auto orig_type = element::boolean;
     std::shared_ptr<ngraph::Function> ngraph;
@@ -154,7 +154,7 @@ TEST_F(TypeRelaxedTests, notSupportedTypeOverride) {
     ASSERT_EQ(4, ngraph->get_ops().size());
 }
 
-TEST_F(TypeRelaxedTests, notSupportedTypeOverridePartially) {
+TEST_F(TypeRelaxedTests, smoke_notSupportedTypeOverridePartially) {
     auto some_type = element::u8;
     auto overriden_type = element::f32;
     auto orig_type = element::i64;
@@ -181,7 +181,7 @@ TEST_F(TypeRelaxedTests, notSupportedTypeOverridePartially) {
     ASSERT_EQ(4, ngraph->get_ops().size());
 }
 
-TEST_F(TypeRelaxedTests, setGetTypes) {
+TEST_F(TypeRelaxedTests, smoke_setGetTypes) {
     std::shared_ptr<ngraph::Function> ngraph;
     {
         ngraph::PartialShape shape({1, 3, 22, 22});
@@ -272,7 +272,7 @@ TEST_F(TypeRelaxedTests, setGetTypes) {
     ASSERT_EQ(4, ngraph->get_ops().size());
 }
 
-TEST_F(TypeRelaxedTests, OneOutputMultipleInputPorts) {
+TEST_F(TypeRelaxedTests, smoke_OneOutputMultipleInputPorts) {
     std::shared_ptr<ngraph::Function> f;
     {
         auto param1 = make_shared<ngraph::opset1::Parameter>(element::boolean, ngraph::Shape{1, 3, 22, 22});

--- a/inference-engine/tests/functional/inference_engine/transformations/unroll_tensor_iterator_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/unroll_tensor_iterator_test.cpp
@@ -22,7 +22,7 @@
 using namespace testing;
 using namespace ngraph;
 
-TEST(TransformationTests, UnrollTensorIteratorGRUCell) {
+TEST(TransformationTests, smoke_UnrollTensorIteratorGRUCell) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto X = std::make_shared<opset4::Parameter>(element::f32, Shape{2, 1, 16});
@@ -104,7 +104,7 @@ TEST(TransformationTests, UnrollTensorIteratorGRUCell) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, UnrollTensorIteratorRNNCell) {
+TEST(TransformationTests, smoke_UnrollTensorIteratorRNNCell) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto X = std::make_shared<opset4::Parameter>(element::f32, Shape{2, 1, 16});
@@ -186,7 +186,7 @@ TEST(TransformationTests, UnrollTensorIteratorRNNCell) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, UnrollTensorIteratorLSTMCell) {
+TEST(TransformationTests, smoke_UnrollTensorIteratorLSTMCell) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto X = std::make_shared<opset4::Parameter>(element::f32, Shape{2, 1, 16});
@@ -272,7 +272,7 @@ TEST(TransformationTests, UnrollTensorIteratorLSTMCell) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, UnrollTensorIteratorGRUCellSingleIteration) {
+TEST(TransformationTests, smoke_UnrollTensorIteratorGRUCellSingleIteration) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto X = std::make_shared<opset4::Parameter>(element::f32, Shape{1, 1, 16});
@@ -348,7 +348,7 @@ TEST(TransformationTests, UnrollTensorIteratorGRUCellSingleIteration) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, UnrollTensorIteratorRNNCellSingleIteration) {
+TEST(TransformationTests, smoke_UnrollTensorIteratorRNNCellSingleIteration) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto X = std::make_shared<opset4::Parameter>(element::f32, Shape{1, 1, 16});
@@ -423,7 +423,7 @@ TEST(TransformationTests, UnrollTensorIteratorRNNCellSingleIteration) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, UnrollTensorIteratorLSTMCellSingleIterationSingleIteration) {
+TEST(TransformationTests, smoke_UnrollTensorIteratorLSTMCellSingleIterationSingleIteration) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto X = std::make_shared<opset4::Parameter>(element::f32, Shape{1, 1, 16});

--- a/inference-engine/tests/functional/inference_engine/transformations/utils_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/utils_test.cpp
@@ -10,7 +10,7 @@
 
 #include "transformations/utils/utils.hpp"
 
-TEST(TransformationTests, HasConstantValueHelper) {
+TEST(TransformationTests, smoke_HasConstantValueHelper) {
     auto float32_scalar = ngraph::opset4::Constant::create(ngraph::element::f32, ngraph::Shape{}, {1.234f});
     ASSERT_TRUE(ngraph::op::util::has_constant_value<float>(float32_scalar, 1.234f));
     ASSERT_TRUE(ngraph::op::util::has_constant_value<float>(float32_scalar, 1.23f, 0.005f));


### PR DESCRIPTION
Separation functional tests to the pre-commit (`gtest_filter=*smoke*`) and nightly scope (`gtest_filter=*nightly *`).
Default value is `smoke`. But after this merge you could change it.
CC @azhogov @mikhail-treskin 