### PR TITLE
add build option USE_SYSTEM_PUGIXML

### DIFF
--- a/inference-engine/cmake/features_ie.cmake
+++ b/inference-engine/cmake/features_ie.cmake
@@ -109,3 +109,5 @@ ie_option(ENABLE_CLANG_FORMAT "Enable clang-format checks during the build" ON)
 set(IE_EXTRA_PLUGINS "" CACHE STRING "Extra paths for plugins to include into DLDT build tree")
 
 ie_dependent_option(ENABLE_TBB_RELEASE_ONLY "Only Release TBB libraries are linked to the Inference Engine binaries" ON "THREADING MATCHES TBB;LINUX" OFF)
+
+ie_option (USE_SYSTEM_PUGIXML "use the system copy of pugixml" OFF)

--- a/inference-engine/thirdparty/CMakeLists.txt
+++ b/inference-engine/thirdparty/CMakeLists.txt
@@ -55,22 +55,31 @@ function(build_with_lto)
         set(BUILD_TESTS ${BUILD_TESTS_current} CACHE BOOL "Build tests" FORCE)
     endfunction()
 
-    ie_build_pugixml()
+    if (USE_SYSTEM_PUGIXML)
+        find_package(PugiXML REQUIRED)
+        set_property(TARGET pugixml PROPERTY IMPORTED_GLOBAL TRUE)
+    else()
+        ie_build_pugixml()
+        target_include_directories(pugixml INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/pugixml/src>")
+    endif()
     add_subdirectory(stb_lib)
     add_subdirectory(ade)
     add_subdirectory(fluid/modules/gapi)
 
-    target_include_directories(pugixml INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/pugixml/src>")
-
-    set_target_properties(pugixml ade fluid stb_image
+    set_target_properties(ade fluid stb_image
                           PROPERTIES FOLDER thirdparty)
 
     # developer package
 
-    ie_developer_export_targets(ade fluid pugixml)
-    if(TARGET pugixml_mt)
-        ie_developer_export_targets(pugixml_mt)
-        set_target_properties(pugixml_mt PROPERTIES FOLDER thirdparty)
+    ie_developer_export_targets(ade fluid)
+
+    if (NOT USE_SYSTEM_PUGIXML)
+        set_target_properties(pugixml PROPERTIES FOLDER thirdparty)
+        ie_developer_export_targets(pugixml)
+        if(TARGET pugixml_mt)
+            ie_developer_export_targets(pugixml_mt)
+            set_target_properties(pugixml_mt PROPERTIES FOLDER thirdparty)
+        endif()
     endif()
 
     if(ENABLE_MKL_DNN)


### PR DESCRIPTION
It allows skipping inference-engine/thirdparty/pugixml and using the system copy instead.

This is similar to `NGRAPH_USE_SYSTEM_PROTOBUF`, which allows building with the system copy of protobuf instead of downloading the bundled version during build.

Since 2e6c95f38, a current pugixml can be used without a build failure due to deprecation warnings.