### PR TITLE
allow building without opencv

### DIFF
--- a/inference-engine/CMakeLists.txt
+++ b/inference-engine/CMakeLists.txt
@@ -70,7 +70,9 @@ if(ENABLE_TESTS)
     add_subdirectory(tests)
 endif()
 
-add_subdirectory(tools)
+if(ENABLE_TOOLS)
+    add_subdirectory(tools)
+endif()
 
 function(ie_build_samples)
     # samples should be build with the same flags as from OpenVINO package,

--- a/inference-engine/CMakeLists.txt
+++ b/inference-engine/CMakeLists.txt
@@ -182,7 +182,9 @@ endif()
 # Developer package
 #
 
-ie_developer_export_targets(format_reader)
+if(ENABLE_SAMPLES OR ENABLE_TOOLS)
+    ie_developer_export_targets(format_reader)
+endif()
 ie_developer_export_targets(${NGRAPH_LIBRARIES})
 
 # for Template plugin

--- a/inference-engine/cmake/features_ie.cmake
+++ b/inference-engine/cmake/features_ie.cmake
@@ -84,6 +84,8 @@ ie_dependent_option (ENABLE_SAMPLES "console samples are part of inference engin
 
 ie_dependent_option (ENABLE_SPEECH_DEMO "enable speech demo integration" ON "NOT APPLE;NOT ANDROID;X86 OR X86_64" OFF)
 
+ie_option (ENABLE_TOOLS "compile_tool and benchmark/performance tools" ON)
+
 ie_option (ENABLE_FUZZING "instrument build for fuzzing" OFF)
 
 ie_option (VERBOSE_BUILD "shows extra information about build" OFF)

--- a/inference-engine/samples/CMakeLists.txt
+++ b/inference-engine/samples/CMakeLists.txt
@@ -141,6 +141,11 @@ else()
     find_package(InferenceEngine 2.1 REQUIRED)
 endif()
 
+# format_reader build can be switched off when both samples and tools are skipped
+if (IE_MAIN_SOURCE_DIR AND NOT ENABLE_SAMPLES AND NOT ENABLE_TOOLS)
+    return()
+endif()
+
 # format reader must be added after find_package(InferenceEngine) to get
 # exactly the same OpenCV_DIR path which was used for the InferenceEngine build
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/common/format_reader")


### PR DESCRIPTION
It would be nice to be able to build the core of OpenVINO entirely without OpenCV. While OpenCV makes a lot of things easier, it is a significant dependency in terms of size. The inference engine is built in a way that it doesn't actually require OpenCV.

The one remaining piece that requires OpenCV and cannot easily be disabled is the `format_reader`. It is a library required by both tools and samples. The samples are already optional via `ENABLE_SAMPLES`. Consequently, this PR introduces a matching `ENABLE_TOOLS`. Once both are disabled, the build of `format_reader` is skipped. At that point, the inference engine can be built and used without having any kind of OpenCV.