### PR TITLE
Remove `--collect_results_only`

### DIFF
--- a/tests/stress_tests/README.md
+++ b/tests/stress_tests/README.md
@@ -72,15 +72,6 @@ gtest-parallel ./MemCheckTests
 ``` bash
 gtest-parallel ./StressMemLeaksTests
 ```
-There are the next available command-line keys:
-1. --test_conf < path > - path to config with description of arguments 
-   used to parametrize tests
-2. --test_conf < path > - path to config with definition of environment values 
-   (path to models etc.) 
-3. --refs_conf < path > (available for MemCheckTests only) - path to config with references used to 
-   compare with results of a run
-4. --collect_results_only < bool > (available for MemCheckTests only) - boolean value that disable comparison and 
-   provide memory consumption results only 
 
 MemCheckTests logs can be used to gather reference values based on current
 memory consumption:

--- a/tests/stress_tests/common/tests_utils.cpp
+++ b/tests/stress_tests/common/tests_utils.cpp
@@ -18,14 +18,6 @@ void Environment::setTestConfig(const pugi::xml_document &test_config) {
     _test_config.reset(test_config);
 }
 
-const bool & Environment::getCollectResultsOnly() {
-    return _collect_results_only;
-}
-
-void Environment::setCollectResultsOnly(const bool &collect_results_only) {
-    _collect_results_only = collect_results_only;
-}
-
 std::vector<TestCase> generateTestsParams(std::initializer_list<std::string> fields) {
     std::vector<TestCase> tests_cases;
     const pugi::xml_document & test_config = Environment::Instance().getTestConfig();

--- a/tests/stress_tests/common/tests_utils.h
+++ b/tests/stress_tests/common/tests_utils.h
@@ -68,8 +68,6 @@ public:
 
     const pugi::xml_document & getTestConfig();
     void setTestConfig(const pugi::xml_document &test_config);
-    const bool & getCollectResultsOnly();
-    void setCollectResultsOnly(const bool &collect_results_only);
 };
 
 std::vector<TestCase> generateTestsParams(std::initializer_list<std::string> items);

--- a/tests/stress_tests/memcheck_tests/flags.h
+++ b/tests/stress_tests/memcheck_tests/flags.h
@@ -30,10 +30,3 @@ static const char refs_conf_message[] = "Optional. Path to a references config w
 /// @brief Define parameter for set references' configuration <br>
 /// refs_conf is an optional parameter
 DEFINE_string(refs_conf, OS_PATH_JOIN({"stress_tests_configs", "memcheck_tests", "references_config.xml"}), refs_conf_message);
-
-/// @brief message for collect_results_only argument
-static const char collect_results_only_message[] = "Optional. Path to a references config with values of memory consumption per test.";
-
-/// @brief Define parameter for mode with collecting results only <br>
-/// collect_results_only is an optional parameter
-DEFINE_bool(collect_results_only, false, collect_results_only_message);

--- a/tests/stress_tests/memcheck_tests/main.cpp
+++ b/tests/stress_tests/memcheck_tests/main.cpp
@@ -52,7 +52,6 @@ int main(int argc, char **argv) {
         return 0;   // TODO return correct status
     }
 
-    Environment::Instance().setCollectResultsOnly(FLAGS_collect_results_only);
     pugi::xml_document config;
     config.load_file(FLAGS_test_conf.c_str());
     Environment::Instance().setTestConfig(config);

--- a/tests/stress_tests/memcheck_tests/tests.cpp
+++ b/tests/stress_tests/memcheck_tests/tests.cpp
@@ -30,16 +30,14 @@ public:
         device = test_params.device;
 
         test_refs.collect_vm_values_for_test(test_name, test_params);
-        if (!Environment::Instance().getCollectResultsOnly()) {
-            ASSERT_GT(test_refs.references[VMSIZE], 0) << "Reference value of VmSize is less than 0. Value: "
-                                               << test_refs.references[VMSIZE];
-            ASSERT_GT(test_refs.references[VMPEAK], 0) << "Reference value of VmPeak is less than 0. Value: "
-                                               << test_refs.references[VMPEAK];
-            ASSERT_GT(test_refs.references[VMRSS], 0) << "Reference value of VmRSS is less than 0. Value: "
-                                              << test_refs.references[VMRSS];
-            ASSERT_GT(test_refs.references[VMHWM], 0) << "Reference value of VmHWM is less than 0. Value: "
-                                              << test_refs.references[VMHWM];
-        }
+        EXPECT_GT(test_refs.references[VMSIZE], 0) << "Reference value of VmSize is less than 0. Value: "
+                                           << test_refs.references[VMSIZE];
+        EXPECT_GT(test_refs.references[VMPEAK], 0) << "Reference value of VmPeak is less than 0. Value: "
+                                           << test_refs.references[VMPEAK];
+        EXPECT_GT(test_refs.references[VMRSS], 0) << "Reference value of VmRSS is less than 0. Value: "
+                                          << test_refs.references[VMRSS];
+        EXPECT_GT(test_refs.references[VMHWM], 0) << "Reference value of VmHWM is less than 0. Value: "
+                                          << test_refs.references[VMHWM];
     }
 };
 

--- a/tests/stress_tests/memcheck_tests/tests_pipelines/tests_pipelines.cpp
+++ b/tests/stress_tests/memcheck_tests/tests_pipelines/tests_pipelines.cpp
@@ -68,13 +68,13 @@ TestResult common_test_pipeline(const std::function<std::array<long, MeasureValu
 
     std::array<long, MeasureValueMax> measures = test_pipeline();
 
-    if ((!Environment::Instance().getCollectResultsOnly()) && (measures[VMRSS] > references[VMRSS]))
+    if (measures[VMRSS] > references[VMRSS])
         return TestResult(TestStatus::TEST_FAILED,
                           "Test failed: RSS virtual memory consumption became greater than reference.\n"
                           "Reference RSS memory consumption: " + std::to_string(references[VMRSS]) + " KB.\n" +
                           "Current RSS memory consumption: " + std::to_string(measures[VMRSS]) + " KB.\n");
 
-    if ((!Environment::Instance().getCollectResultsOnly()) && (measures[VMHWM] > references[VMHWM]))
+    if (measures[VMHWM] > references[VMHWM])
         return TestResult(TestStatus::TEST_FAILED,
                           "Test failed: HWM (peak of RSS) virtual memory consumption is greater than reference.\n"
                           "Reference HWM of memory consumption: " + std::to_string(references[VMHWM]) + " KB.\n" +


### PR DESCRIPTION
1. Remove unnecessary `--collect_results_only` which was added to unblock data submitting to database
2. Replace `ASSERT` with `EXPECT` to prevent test finish if reference wasn't set