### PR TITLE
Improve GNA MT sychronization

### DIFF
--- a/inference-engine/src/gna_plugin/gna_device.hpp
+++ b/inference-engine/src/gna_plugin/gna_device.hpp
@@ -38,13 +38,13 @@ enum GnaWaitStatus : int {
  * holds gna - style handle in RAII way
  */
 class GNADeviceHelper {
+    static std::mutex acrossPluginsSync;
 #if GNA_LIB_VER == 1
     intel_gna_status_t nGNAStatus = GNA_NOERROR;
     intel_gna_handle_t nGNAHandle = 0;
     intel_gna_perf_t nGNAPerfResults;
     intel_gna_perf_t nGNAPerfResultsTotal;
 #else
-    static std::mutex acrossPluginsSync;
     uint32_t nGnaDeviceIndex = 0;
     Gna2DeviceVersion gna2HwConsistency = Gna2DeviceVersionSoftwareEmulation;
     Gna2DeviceVersion detectedGnaDevVersion = Gna2DeviceVersionSoftwareEmulation;

--- a/inference-engine/src/gna_plugin/gna_device.hpp
+++ b/inference-engine/src/gna_plugin/gna_device.hpp
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <map>
 #include <vector>
@@ -43,6 +44,7 @@ class GNADeviceHelper {
     intel_gna_perf_t nGNAPerfResults;
     intel_gna_perf_t nGNAPerfResultsTotal;
 #else
+    static std::mutex acrossPluginsSync;
     uint32_t nGnaDeviceIndex = 0;
     Gna2DeviceVersion gna2HwConsistency = Gna2DeviceVersionSoftwareEmulation;
     Gna2DeviceVersion detectedGnaDevVersion = Gna2DeviceVersionSoftwareEmulation;
@@ -172,6 +174,7 @@ public:
         nGNAPerfResults = {{0, 0, 0, 0, 0, 0, 0}, {0, 0}, {0, 0, 0}, {0, 0}};
         nGNAPerfResultsTotal = {{0, 0, 0, 0, 0, 0, 0}, {0, 0}, {0, 0, 0}, {0, 0}};
 #else
+        std::unique_lock<std::mutex> lockGnaCalls{ acrossPluginsSync };
         const auto status = Gna2InstrumentationConfigCreate(TotalGna2InstrumentationPoints,
             gna2InstrumentationPoints,
             instrumentationResults,

--- a/inference-engine/src/gna_plugin/gna_device.hpp
+++ b/inference-engine/src/gna_plugin/gna_device.hpp
@@ -170,11 +170,11 @@ public:
     void setOMPThreads(uint8_t const n_threads);
 
     void initGnaPerfCounters() {
+        std::unique_lock<std::mutex> lockGnaCalls{ acrossPluginsSync };
 #if GNA_LIB_VER == 1
         nGNAPerfResults = {{0, 0, 0, 0, 0, 0, 0}, {0, 0}, {0, 0, 0}, {0, 0}};
         nGNAPerfResultsTotal = {{0, 0, 0, 0, 0, 0, 0}, {0, 0}, {0, 0, 0}, {0, 0}};
 #else
-        std::unique_lock<std::mutex> lockGnaCalls{ acrossPluginsSync };
         const auto status = Gna2InstrumentationConfigCreate(TotalGna2InstrumentationPoints,
             gna2InstrumentationPoints,
             instrumentationResults,

--- a/inference-engine/tests/functional/inference_engine/core_threading_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/core_threading_tests.cpp
@@ -117,7 +117,6 @@ TEST_F(CoreThreadingTests, RegisterPlugins) {
 }
 
 // tested function: GetAvailableDevices, UnregisterPlugin
-// TODO: some plugins initialization (e.g. GNA) failed during such stress-test scenario
 TEST_F(CoreThreadingTests, GetAvailableDevices) {
     InferenceEngine::Core ie;
     runParallel([&] () {

--- a/inference-engine/tests/functional/inference_engine/core_threading_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/core_threading_tests.cpp
@@ -117,7 +117,8 @@ TEST_F(CoreThreadingTests, RegisterPlugins) {
 }
 
 // tested function: GetAvailableDevices, UnregisterPlugin
-TEST_F(CoreThreadingTests, GetAvailableDevices) {
+// TODO: some initialization (e.g. thread/dlopen) sporadically fails during such stress-test scenario
+TEST_F(CoreThreadingTests, DISABLED_GetAvailableDevices) {
     InferenceEngine::Core ie;
     runParallel([&] () {
         std::vector<std::string> devices = ie.GetAvailableDevices();

--- a/inference-engine/tests/functional/inference_engine/core_threading_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/core_threading_tests.cpp
@@ -118,7 +118,7 @@ TEST_F(CoreThreadingTests, RegisterPlugins) {
 
 // tested function: GetAvailableDevices, UnregisterPlugin
 // TODO: some plugins initialization (e.g. GNA) failed during such stress-test scenario
-TEST_F(CoreThreadingTests, DISABLED_GetAvailableDevices) {
+TEST_F(CoreThreadingTests, GetAvailableDevices) {
     InferenceEngine::Core ie;
     runParallel([&] () {
         std::vector<std::string> devices = ie.GetAvailableDevices();

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/behavior/core_threading_tests.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/behavior/core_threading_tests.cpp
@@ -1,0 +1,23 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <behavior/core_threading_tests.hpp>
+
+namespace {
+
+Params params[] = {
+    std::tuple<Device, Config>{ CommonTestUtils::DEVICE_GNA, {{ CONFIG_KEY(PERF_COUNT), CONFIG_VALUE(YES) }}},
+    std::tuple<Device, Config>{ CommonTestUtils::DEVICE_HETERO, {{ "TARGET_FALLBACK", CommonTestUtils::DEVICE_GNA }}},
+    std::tuple<Device, Config>{ CommonTestUtils::DEVICE_MULTI, {{ MULTI_CONFIG_KEY(DEVICE_PRIORITIES), CommonTestUtils::DEVICE_GNA }}},
+};
+
+}  // namespace
+
+INSTANTIATE_TEST_CASE_P(GNA, CoreThreadingTests, testing::ValuesIn(params), CoreThreadingTests::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(DISABLED_GNA, CoreThreadingTestsWithIterations,
+    testing::Combine(testing::ValuesIn(params),
+                     testing::Values(2),
+                     testing::Values(2)),
+    CoreThreadingTestsWithIterations::getTestCaseName);


### PR DESCRIPTION
Partially resolves issues 31708, 31709.
Similar to previous PR 2435, only the **problematic test is kept disabled** as still fails sporadically. 
No direct evidence (at this point) that it is only GNA related issue.