### PR TITLE
Use  ittnotify built from sources

### DIFF
--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -44,7 +44,7 @@ ie_dependent_option (ENABLE_AVX2 "Enable AVX2 optimizations" ON "X86_64 OR X86" 
 
 ie_dependent_option (ENABLE_AVX512F "Enable AVX512 optimizations" ON "X86_64 OR X86" OFF)
 
-ie_dependent_option (ENABLE_PROFILING_ITT "ITT tracing of IE and plugins internals" ON "NOT CMAKE_CROSSCOMPILING" OFF)
+ie_option (ENABLE_PROFILING_ITT "Build with ITT tracing. Optionally configure pre-built ittnotify library though INTEL_VTUNE_DIR variable." OFF)
 
 # Documentation build
 ie_option (ENABLE_DOCS "build docs using Doxygen" OFF)

--- a/openvino/itt/CMakeLists.txt
+++ b/openvino/itt/CMakeLists.txt
@@ -29,9 +29,11 @@ if(ENABLE_PROFILING_ITT)
     else()
         include(ExternalProject)
         set(ITTAPI_BINARY_DIR  ${CMAKE_CURRENT_BINARY_DIR}/ittapi/build)
+        set(ITTAPI_SOURCE_DIR  ${CMAKE_CURRENT_BINARY_DIR}/ittapi/source)
         set(ITTNOTIFY_LIBRARY  ${ITTAPI_BINARY_DIR}/bin/${CMAKE_STATIC_LIBRARY_PREFIX}ittnotify${CMAKE_STATIC_LIBRARY_SUFFIX})
         ExternalProject_Add(
-            ittapi_external
+            ext_ittapi
+            PREFIX ittapi
             GIT_REPOSITORY https://github.com/intel/ittapi.git
             GIT_TAG v3.18.6
             LOG_DOWNLOAD ON
@@ -43,11 +45,13 @@ if(ENABLE_PROFILING_ITT)
             CMAKE_GENERATOR_PLATFORM ${CMAKE_GENERATOR_PLATFORM}
             CMAKE_GENERATOR_TOOLSET ${CMAKE_GENERATOR_TOOLSET}
             BINARY_DIR ${ITTAPI_BINARY_DIR}
+            SOURCE_DIR ${ITTAPI_SOURCE_DIR}
             EXCLUDE_FROM_ALL TRUE
             BUILD_BYPRODUCTS ${ITTNOTIFY_LIBRARY})
         add_library(ittnotify INTERFACE)
         add_dependencies(ittnotify ittapi_external)
         target_link_libraries(ittnotify INTERFACE ${ITTNOTIFY_LIBRARY})
+        target_include_directories(ittnotify INTERFACE ${ITTAPI_SOURCE_DIR}/include)
         openvino_developer_export_targets(ittnotify)
     endif()
 endif()

--- a/openvino/itt/CMakeLists.txt
+++ b/openvino/itt/CMakeLists.txt
@@ -29,7 +29,7 @@ if(ENABLE_PROFILING_ITT)
     else()
         include(ExternalProject)
         set(ITTAPI_BINARY_DIR  ${CMAKE_CURRENT_BINARY_DIR}/ittapi/build)
-        set(ITTNOTIFY_LIBRARY  ${ITTAPI_BINARY_DIR}/bin/${CMAKE_FIND_LIBRARY_PREFIXES}ittnotify${CMAKE_STATIC_LIBRARY_SUFFIX})
+        set(ITTNOTIFY_LIBRARY  ${ITTAPI_BINARY_DIR}/bin/${CMAKE_STATIC_LIBRARY_PREFIX}ittnotify${CMAKE_STATIC_LIBRARY_SUFFIX})
         ExternalProject_Add(
             ittapi_external
             GIT_REPOSITORY https://github.com/intel/ittapi.git

--- a/openvino/itt/CMakeLists.txt
+++ b/openvino/itt/CMakeLists.txt
@@ -21,9 +21,34 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 file(GLOB_RECURSE SOURCES "src/*.cpp")
 
 if(ENABLE_PROFILING_ITT)
-    find_package(ITT)
-    if(NOT ITT_FOUND)
-        message(WARNING "Profiling option enabled, but no ITT library was found")
+    if(DEFINED INTEL_VTUNE_DIR OR DEFINED ENV{INTEL_VTUNE_DIR})
+        find_package(ITT)
+        if(NOT ITT_FOUND)
+            message(WARNING "Profiling option enabled, but no ITT library was found under INTEL_VTUNE_DIR")
+        endif()
+    else()
+        include(ExternalProject)
+        set(ITTAPI_BINARY_DIR  ${CMAKE_CURRENT_BINARY_DIR}/ittapi/build)
+        set(ITTNOTIFY_LIBRARY  ${ITTAPI_BINARY_DIR}/bin/${CMAKE_FIND_LIBRARY_PREFIXES}ittnotify${CMAKE_STATIC_LIBRARY_SUFFIX})
+        ExternalProject_Add(
+            ittapi_external
+            GIT_REPOSITORY https://github.com/intel/ittapi.git
+            GIT_TAG v3.18.6
+            LOG_DOWNLOAD ON
+            LOG_CONFIGURE ON
+            LOG_BUILD ON
+            INSTALL_COMMAND ""
+            UPDATE_COMMAND ""
+            CMAKE_GENERATOR ${CMAKE_GENERATOR}
+            CMAKE_GENERATOR_PLATFORM ${CMAKE_GENERATOR_PLATFORM}
+            CMAKE_GENERATOR_TOOLSET ${CMAKE_GENERATOR_TOOLSET}
+            BINARY_DIR ${ITTAPI_BINARY_DIR}
+            EXCLUDE_FROM_ALL TRUE
+            BUILD_BYPRODUCTS ${ITTNOTIFY_LIBRARY})
+        add_library(ittnotify INTERFACE)
+        add_dependencies(ittnotify ittapi_external)
+        target_link_libraries(ittnotify INTERFACE ${ITTNOTIFY_LIBRARY})
+        openvino_developer_export_targets(ittnotify)
     endif()
 endif()
 


### PR DESCRIPTION
ITT tracing was only possible on the platfroms supported by VTune.
Building ittnotify from sources removes VTune dependency.

ITT traces was found significantly slowdown tests execution time.
Disabling ENABLE_PROFILING_ITT by default. This is also
a current behavior of Intel Distribution of OpenVINO.