### PR TITLE
[IE][VPU]: Added DSR_Reshape tests with dynamic output shape descriptor

### DIFF
--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_reshape.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_reshape.cpp
@@ -16,8 +16,7 @@ using Parameters = std::tuple<
         ReshapeTestParams,
         LayerTestsUtils::TargetDevice>;
 
-
-class DSR_Reshape : public testing::WithParamInterface<Parameters>, public DSR_TestsCommon {
+class DSR_ReshapeWithStaticDescriptor : public testing::WithParamInterface<Parameters>, public DSR_TestsCommon {
 protected:
     std::shared_ptr<ngraph::Node> createTestedOp() override {
         const auto& parameters = GetParam();
@@ -33,14 +32,43 @@ protected:
 
         const auto outShapeDescriptorConstNode = std::make_shared<ngraph::opset3::Constant>(
                 ngraph::element::i64, ngraph::Shape{outShapeDescriptor.size()}, outShapeDescriptor);
-        const auto reshape = std::make_shared<ngraph::opset3::Reshape>(
-                inputSubgraph, outShapeDescriptorConstNode, specialZero);
 
-        return reshape;
+        return std::make_shared<ngraph::opset3::Reshape>(
+                inputSubgraph, outShapeDescriptorConstNode, specialZero);
     }
 };
 
-TEST_P(DSR_Reshape, CompareWithReference) {
+TEST_P(DSR_ReshapeWithStaticDescriptor, CompareWithReference) {
+    Run();
+}
+
+class DSR_ReshapeWithDynamicDescriptor : public testing::WithParamInterface<Parameters>, public DSR_TestsCommon {
+protected:
+    std::shared_ptr<ngraph::Node> createTestedOp() override {
+        const auto& parameters = GetParam();
+        const auto& inDataType = std::get<0>(GetParam());
+        const auto& inDataShapes = std::get<0>(std::get<1>(GetParam()));
+        targetDevice = std::get<2>(GetParam());
+
+        const auto inputSubgraph = createInputSubgraphWithDSR(inDataType, inDataShapes);
+
+        const auto shapeDataType = inputSubgraph->get_input_element_type(1);
+        const auto shapeOf = std::make_shared<ngraph::opset3::ShapeOf>(inputSubgraph, shapeDataType);
+        const auto axis    = ngraph::opset3::Constant::create(shapeDataType, {1}, {0});
+        const auto indices = ngraph::opset3::Constant::create(shapeDataType, {1}, {inDataShapes.shape.size() - 1});
+        const auto outShapeDescriptorDynamicNode = std::make_shared<ngraph::opset3::Concat>(
+                ngraph::OutputVector{
+                        ngraph::opset3::Constant::create(shapeDataType, {1}, {1}),
+                        ngraph::opset3::Constant::create(shapeDataType, {1}, {-1}),
+                        std::make_shared<ngraph::opset3::Gather>(shapeOf, indices, axis)},
+                0);
+
+        return std::make_shared<ngraph::opset3::Reshape>(
+                inputSubgraph, outShapeDescriptorDynamicNode, true);
+    }
+};
+
+TEST_P(DSR_ReshapeWithDynamicDescriptor, CompareWithReference) {
     Run();
 }
 
@@ -50,9 +78,19 @@ std::vector<ReshapeTestParams> reshapeTestParams = {
         std::make_tuple(DataShapeWithUpperBound{{750, 1}, {750, 1}}, true, ShapeDescriptor{-1, 1, 1, 1}),
         std::make_tuple(DataShapeWithUpperBound{{750, 4}, {1000, 4}}, true, ShapeDescriptor{1, -1, 4}),
         std::make_tuple(DataShapeWithUpperBound{{750}, {1000}}, true, ShapeDescriptor{1, 1, -1}),
+        std::make_tuple(DataShapeWithUpperBound{{800, 81, 4}, {1000, 81, 4}}, true, ShapeDescriptor{0, -1}),
+        std::make_tuple(DataShapeWithUpperBound{{800, 256, 7, 7}, {1000, 256, 7, 7}}, true, ShapeDescriptor{0, -1}),
 };
 
-INSTANTIATE_TEST_CASE_P(smoke_DynamicReshape, DSR_Reshape,
+INSTANTIATE_TEST_CASE_P(smoke_DynamicReshape, DSR_ReshapeWithStaticDescriptor,
+    ::testing::Combine(
+        ::testing::Values(ngraph::element::f16,
+                          ngraph::element::f32,
+                          ngraph::element::i32),
+        ::testing::ValuesIn(reshapeTestParams),
+        ::testing::Values(CommonTestUtils::DEVICE_MYRIAD)));
+
+INSTANTIATE_TEST_CASE_P(smoke_DynamicReshape, DSR_ReshapeWithDynamicDescriptor,
     ::testing::Combine(
         ::testing::Values(ngraph::element::f16,
                           ngraph::element::f32,

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_reshape.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_reshape.cpp
@@ -72,7 +72,7 @@ TEST_P(DSR_ReshapeWithDynamicDescriptor, CompareWithReference) {
     Run();
 }
 
-std::vector<ReshapeTestParams> reshapeTestParams = {
+const std::vector<ReshapeTestParams> reshapeTestParams = {
         std::make_tuple(DataShapeWithUpperBound{{1, 750}, {1, 1000}}, true, ShapeDescriptor{-1, 1}),
         std::make_tuple(DataShapeWithUpperBound{{750, 1}, {1000, 1}}, true, ShapeDescriptor{-1}),
         std::make_tuple(DataShapeWithUpperBound{{750, 1}, {750, 1}}, true, ShapeDescriptor{-1, 1, 1, 1}),
@@ -82,19 +82,21 @@ std::vector<ReshapeTestParams> reshapeTestParams = {
         std::make_tuple(DataShapeWithUpperBound{{800, 256, 7, 7}, {1000, 256, 7, 7}}, true, ShapeDescriptor{0, -1}),
 };
 
+const std::vector<ngraph::element::Type> dataTypesVector = {
+        ngraph::element::f16,
+        ngraph::element::f32,
+        ngraph::element::i32,
+};
+
 INSTANTIATE_TEST_CASE_P(smoke_DynamicReshape, DSR_ReshapeWithStaticDescriptor,
     ::testing::Combine(
-        ::testing::Values(ngraph::element::f16,
-                          ngraph::element::f32,
-                          ngraph::element::i32),
+        ::testing::ValuesIn(dataTypesVector),
         ::testing::ValuesIn(reshapeTestParams),
         ::testing::Values(CommonTestUtils::DEVICE_MYRIAD)));
 
 INSTANTIATE_TEST_CASE_P(smoke_DynamicReshape, DSR_ReshapeWithDynamicDescriptor,
     ::testing::Combine(
-        ::testing::Values(ngraph::element::f16,
-                          ngraph::element::f32,
-                          ngraph::element::i32),
+        ::testing::ValuesIn(dataTypesVector),
         ::testing::ValuesIn(reshapeTestParams),
         ::testing::Values(CommonTestUtils::DEVICE_MYRIAD)));
 


### PR DESCRIPTION
### Description
This commit added some DSR_Reshape test cases where dynamic Reshape operation get subgraph as the second input aka output shape descriptor

### Task
#-35111

### CI
* [ ] 1849