### PR TITLE
Remove enforcement for legacy CNN as not needed for 1047

### DIFF
--- a/inference-engine/src/gna_plugin/backend/am_intel_dnn.cpp
+++ b/inference-engine/src/gna_plugin/backend/am_intel_dnn.cpp
@@ -1453,12 +1453,6 @@ void GNAPluginNS::backend::AMIntelDNN::InitGNAStruct(intel_nnet_type_t *ptr_nnet
                                 comp.op.conv1D.num_feature_maps * comp.op.conv1D.num_feature_map_columns),
                         nullptr);
 
-                // TODO: GNA2: We have to explicitly enforce to use Legacy CNN
-                snprintf(
-                        const_cast<char*>(gnaOperation->Operands[1]->Layout),
-                        sizeof(gnaOperation->Operands[1]->Layout) / sizeof(char),
-                        "GNA1");
-
                 AdvanceCnnOperationIfAllApplied(component, i, gnaOperation);
 #else
                 pLayer->nInputRows = component[i].num_rows_in;


### PR DESCRIPTION
Enforcement not needed in the 1047 version.
To not conflict with future types of CNNs.