### PR TITLE
[VPU][GT][Tests] Make gemmTranspose pass layout agnostic

### DIFF
--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/gemm_transpose.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/gemm_transpose.cpp
@@ -56,15 +56,28 @@ void PassImpl::run(const Model& model) {
 
         const auto inputDimsA = inputA->desc().dims();
 
-        const auto K = inputDimsA[Dim::H];
-        const auto M = inputDimsA[Dim::W];
-        const auto batch1 = inputDimsA[Dim::N];
-        const auto batch2 = inputDimsA[Dim::C];
+        VPU_THROW_UNLESS(inputDimsA.size() >= 2,
+            "Processing layer {} with type {} failed: first input ({} with usage {}) should have at least 2 dimensions, but it actually has {}",
+            stage->name(), stage->type(), inputA->name(), inputA->usage(), inputDimsA.size());
 
-        const auto inputATranspose = model->duplicateData(inputA, "@reshape", DataDesc{K, M, batch2, batch1});
+        const auto perm = DimsOrder::fromNumDims(inputDimsA.size()).toPermutation();
+
+        std::vector<int> batchDims;
+        DimValues_<Dim> permMap = { {perm[0], perm[1]}, {perm[1], perm[0]} };
+        for (std::size_t i = 2; i < inputDimsA.size(); i++) {
+            batchDims.push_back(inputDimsA[perm[i]]);
+            permMap.set(perm[i], perm[i]);
+        }
+
+        std::vector<int> transposedDims = {inputDimsA[perm[1]], inputDimsA[perm[0]]};
+        transposedDims.insert(transposedDims.end(), batchDims.begin(), batchDims.end());
+
+        const auto inputATranspose = model->duplicateData(inputA, "@reshape", DataDesc{transposedDims});
 
         stage->attrs().set<bool>("transposeA", false);
         model->replaceStageInput(stage->inputEdge(0), inputATranspose);
+
+
 
         _stageBuilder->addPermuteStage(
             model,
@@ -72,7 +85,7 @@ void PassImpl::run(const Model& model) {
             stage->origLayer(),
             inputA,
             inputATranspose,
-            DimValues_<Dim>{{Dim::W, Dim::H}, {Dim::H, Dim::W}, {Dim::D, Dim::D}, {Dim::C, Dim::C}, {Dim::N, Dim::N}});
+            permMap);
     }
 }
 

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/gemm_transpose.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/gemm_transpose.cpp
@@ -56,8 +56,8 @@ void PassImpl::run(const Model& model) {
 
         const auto inputDimsA = inputA->desc().dims();
 
-        VPU_THROW_UNLESS(inputDimsA.size() >= 2,
-            "Processing layer {} with type {} failed: first input ({} with usage {}) should have at least 2 dimensions, but it actually has {}",
+        VPU_THROW_UNLESS(inputDimsA.size() >= 2 && inputDimsA.size() <= 4,
+            "Processing layer {} with type {} failed: first inputs' ({} with usage {}) dimensions number should be in range [2, 4], but it actually has {}",
             stage->name(), stage->type(), inputA->name(), inputA->usage(), inputDimsA.size());
 
         const auto perm = DimsOrder::fromNumDims(inputDimsA.size()).toPermutation();

--- a/inference-engine/src/vpu/graph_transformer/src/stages/gemm.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/gemm.cpp
@@ -99,6 +99,19 @@ void FrontEnd::parseGEMM(const Model& model, const ie::CNNLayerPtr& _layer, cons
     IE_ASSERT(inputs.size() == 2 || inputs.size() == 3);
     IE_ASSERT(outputs.size() == 1);
 
+    const auto input1 = inputs[0];
+    const auto input2 = inputs[1];
+
+    VPU_THROW_UNLESS(input1->desc().numDims() >= 2 && input1->desc().numDims() <= 4,
+        "Processing layer {} with type {} failed: first inputs' ({} with usage {}) dimensions number should be in range [2, 4], but it actually has {}",
+        _layer->name, _layer->type, input1->name(), input1->usage(), input1->desc().numDims());
+    VPU_THROW_UNLESS(input2->desc().numDims() >= 2 && input2->desc().numDims() <= 4,
+        "Processing layer {} with type {} failed: second inputs' ({} with usage {}) dimensions number should be in range [2, 4], but it actually has {}",
+        _layer->name, _layer->type, input2->name(), input2->usage(), input2->desc().numDims());
+    VPU_THROW_UNLESS(inputs.size() == 3 && inputs[2]->desc().numDims() >= 2 && inputs[2]->desc().numDims() <= 4,
+        "Processing layer {} with type {} failed: third inputs' ({} with usage {}) dimensions number should be in range [2, 4], but it actually has {}",
+        _layer->name, _layer->type, inputs[2]->name(), inputs[2]->usage(), inputs[2]->desc().numDims());
+
     auto layer = std::dynamic_pointer_cast<ie::GemmLayer>(_layer);
     IE_ASSERT(layer != nullptr);
 

--- a/inference-engine/src/vpu/graph_transformer/src/stages/gemm.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/gemm.cpp
@@ -108,7 +108,7 @@ void FrontEnd::parseGEMM(const Model& model, const ie::CNNLayerPtr& _layer, cons
     VPU_THROW_UNLESS(input2->desc().numDims() >= 2 && input2->desc().numDims() <= 4,
         "Processing layer {} with type {} failed: second inputs' ({} with usage {}) dimensions number should be in range [2, 4], but it actually has {}",
         _layer->name, _layer->type, input2->name(), input2->usage(), input2->desc().numDims());
-    VPU_THROW_UNLESS(inputs.size() == 3 && inputs[2]->desc().numDims() >= 2 && inputs[2]->desc().numDims() <= 4,
+    VPU_THROW_UNLESS(inputs.size() < 3 || inputs[2]->desc().numDims() >= 2 && inputs[2]->desc().numDims() <= 4,
         "Processing layer {} with type {} failed: third inputs' ({} with usage {}) dimensions number should be in range [2, 4], but it actually has {}",
         _layer->name, _layer->type, inputs[2]->name(), inputs[2]->usage(), inputs[2]->desc().numDims());
 

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/mat_mul.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/mat_mul.cpp
@@ -14,12 +14,8 @@ const std::vector<InferenceEngine::Precision> inputPrecisions = {
         InferenceEngine::Precision::FP32
 };
 
-const std::vector<std::vector<size_t>> shapesA = {
-        {1, 4, 5, 6}
-};
-
-const std::vector<std::vector<size_t>> shapesB = {
-        {1, 4, 6, 4}
+const std::vector<ShapeRelatedParams> shapeRelatedParams = {
+        { {1, 4, 5, 6}, {1, 4, 6, 4}, false, false }
 };
 
 std::vector<ngraph::helpers::InputLayerType> secondaryInputTypes = {
@@ -27,18 +23,18 @@ std::vector<ngraph::helpers::InputLayerType> secondaryInputTypes = {
         ngraph::helpers::InputLayerType::PARAMETER,
 };
 
+std::map<std::string, std::string> additional_config = {};
+
 INSTANTIATE_TEST_CASE_P(smoke_MatMul, MatMulTest,
         ::testing::Combine(
+                ::testing::ValuesIn(shapeRelatedParams),
                 ::testing::ValuesIn(inputPrecisions),
                 ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
                 ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
                 ::testing::Values(InferenceEngine::Layout::ANY),
-                ::testing::ValuesIn(shapesA),
-                ::testing::ValuesIn(shapesB),
-                ::testing::Values(false),
-                ::testing::Values(false),
                 ::testing::ValuesIn(secondaryInputTypes),
-                ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                ::testing::Values(additional_config)),
         MatMulTest::getTestCaseName);
 
 } // namespace

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/mat_mul.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/mat_mul.cpp
@@ -15,7 +15,7 @@ const std::vector<InferenceEngine::Precision> inputPrecisions = {
 };
 
 const std::vector<ShapeRelatedParams> shapeRelatedParams = {
-        { {1, 4, 5, 6}, {1, 4, 6, 4}, false, false }
+        { { {1, 4, 5, 6}, false }, { {1, 4, 6, 4}, false } }
 };
 
 std::vector<ngraph::helpers::InputLayerType> secondaryInputTypes = {

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/mat_mul.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/mat_mul.cpp
@@ -16,15 +16,19 @@ const std::vector<InferenceEngine::Precision> inputPrecisions = {
 };
 
 const std::vector<ShapeRelatedParams> shapeRelatedParams = {
-        { {1, 2, 7, 5}, {1, 2, 7, 11}, true, false },
-        { {10, 1, 1, 16}, {10, 1, 16, 1024}, false, false },
-        { {1, 5, 3}, {1, 5, 6}, true, false },
-        { {12, 8, 17}, {12, 17, 32}, false, false },
-        { {6, 128, 128}, {6, 128, 128}, false, false },
-        { {128, 384}, {128, 384}, true, false },
-        { {384, 128}, {372, 128}, false, true },
-        { {1, 2, 128, 384}, {1, 2, 128, 372}, true, false },
-        { {4, 3}, {5, 4}, true, true },
+        { { {1, 2, 7, 5}, true }, { {1, 2, 7, 11}, false } },
+        { { {10, 1, 1, 16}, false }, { {10, 1, 16, 1024}, false } },
+        { { {1, 5, 3}, true }, { {1, 5, 6}, false } },
+        { { {12, 8, 17}, false }, { {12, 17, 32}, false } },
+        { { {6, 128, 128}, false }, { {6, 128, 128}, false } },
+        { { {128, 384}, true }, { {128, 384}, false } },
+        { { {384, 128}, false }, { {372, 128}, true } },
+        { { {1, 2, 128, 384}, true }, { {1, 2, 128, 372}, false } },
+        { { {4, 3}, true }, { {5, 4}, true } },
+};
+
+Config additionalConfig = {
+        {InferenceEngine::MYRIAD_DETECT_NETWORK_BATCH, CONFIG_VALUE(NO)}
 };
 
 INSTANTIATE_TEST_CASE_P(smoke_MatMul, MatMulTest,
@@ -36,7 +40,7 @@ INSTANTIATE_TEST_CASE_P(smoke_MatMul, MatMulTest,
             ::testing::Values(InferenceEngine::Layout::ANY),
             ::testing::Values(ngraph::helpers::InputLayerType::PARAMETER),
             ::testing::Values(CommonTestUtils::DEVICE_MYRIAD),
-            ::testing::Values(Config{{InferenceEngine::MYRIAD_DETECT_NETWORK_BATCH, CONFIG_VALUE(NO)}})),
+            ::testing::Values(additionalConfig)),
         MatMulTest::getTestCaseName);
 
 } // namespace

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/mat_mul.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/mat_mul.cpp
@@ -1,0 +1,42 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "single_layer_tests/mat_mul.hpp"
+#include <vpu/private_plugin_config.hpp>
+
+using namespace LayerTestsDefinitions;
+
+namespace {
+
+typedef std::map<std::string, std::string> Config;
+
+const std::vector<InferenceEngine::Precision> inputPrecisions = {
+        InferenceEngine::Precision::FP32
+};
+
+const std::vector<ShapeRelatedParams> shapeRelatedParams = {
+        { {1, 2, 7, 5}, {1, 2, 7, 11}, true, false },
+        { {10, 1, 1, 16}, {10, 1, 16, 1024}, false, false },
+        { {1, 5, 3}, {1, 5, 6}, true, false },
+        { {12, 8, 17}, {12, 17, 32}, false, false },
+        { {6, 128, 128}, {6, 128, 128}, false, false },
+        { {128, 384}, {128, 384}, true, false },
+        { {384, 128}, {372, 128}, false, true },
+        { {1, 2, 128, 384}, {1, 2, 128, 372}, true, false },
+        { {4, 3}, {5, 4}, true, true },
+};
+
+INSTANTIATE_TEST_CASE_P(smoke_MatMul, MatMulTest,
+        ::testing::Combine(
+            ::testing::ValuesIn(shapeRelatedParams),
+            ::testing::ValuesIn(inputPrecisions),
+            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+            ::testing::Values(InferenceEngine::Layout::ANY),
+            ::testing::Values(ngraph::helpers::InputLayerType::PARAMETER),
+            ::testing::Values(CommonTestUtils::DEVICE_MYRIAD),
+            ::testing::Values(Config{{InferenceEngine::MYRIAD_DETECT_NETWORK_BATCH, CONFIG_VALUE(NO)}})),
+        MatMulTest::getTestCaseName);
+
+} // namespace

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/mat_mul.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/mat_mul.hpp
@@ -31,6 +31,10 @@ namespace LayerTestsDefinitions {
 class MatMulTest : public testing::WithParamInterface<MatMulLayerTestParamsSet>, virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<MatMulLayerTestParamsSet> &obj);
+    static std::vector<ShapeRelatedParams> combineShapes(const std::vector<std::vector<size_t>>& firstInputShapes,
+                                                         const std::vector<std::vector<size_t>>& secondInputShapes,
+                                                         bool transposeA,
+                                                         bool transposeB);
 
 protected:
     void SetUp() override;

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/mat_mul.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/mat_mul.hpp
@@ -12,8 +12,7 @@
 #include "functional_test_utils/layer_test_utils.hpp"
 
 struct ShapeRelatedParams {
-    InferenceEngine::SizeVector firstInputShape, secondInputShape;
-    bool transposeA, transposeB;
+    std::pair<InferenceEngine::SizeVector, bool> input1, input2;
 };
 
 typedef std::tuple<

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/mat_mul.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/mat_mul.hpp
@@ -11,17 +11,20 @@
 
 #include "functional_test_utils/layer_test_utils.hpp"
 
+struct ShapeRelatedParams {
+    InferenceEngine::SizeVector firstInputShape, secondInputShape;
+    bool transposeA, transposeB;
+};
+
 typedef std::tuple<
-        InferenceEngine::Precision,
-        InferenceEngine::Precision,    // Input precision
-        InferenceEngine::Precision,    // Output precision
-        InferenceEngine::Layout,       // Input layout
-        InferenceEngine::SizeVector,
-        InferenceEngine::SizeVector,
-        bool,
-        bool,
-        ngraph::helpers::InputLayerType,
-        LayerTestsUtils::TargetDevice
+        ShapeRelatedParams,
+        InferenceEngine::Precision,        // Network precision
+        InferenceEngine::Precision,        // Input precision
+        InferenceEngine::Precision,        // Output precision
+        InferenceEngine::Layout,           // Input layout
+        ngraph::helpers::InputLayerType,   // Secondary input type
+        LayerTestsUtils::TargetDevice,     // Device name
+        std::map<std::string, std::string> // Additional network configuration
 > MatMulLayerTestParamsSet;
 
 namespace LayerTestsDefinitions {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/mat_mul.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/mat_mul.cpp
@@ -13,6 +13,19 @@
 
 namespace LayerTestsDefinitions {
 
+std::vector<ShapeRelatedParams> MatMulTest::combineShapes(const std::vector<std::vector<size_t>>& firstInputShapes,
+                                                          const std::vector<std::vector<size_t>>& secondInputShapes,
+                                                          bool transposeA,
+                                                          bool transposeB) {
+    std::vector<ShapeRelatedParams> resVec;
+    for (const auto& firstInputShape : firstInputShapes) {
+        for (const auto& secondInputShape : secondInputShapes) {
+            resVec.push_back(ShapeRelatedParams{ {firstInputShape, transposeA}, {secondInputShape, transposeB } });
+        }
+    }
+    return resVec;
+}
+
 std::string MatMulTest::getTestCaseName(const testing::TestParamInfo<MatMulLayerTestParamsSet> &obj) {
     InferenceEngine::Precision netPrecision;
     InferenceEngine::Precision inPrc, outPrc;


### PR DESCRIPTION
Ticket - #-39277
Description: permTranspose pass suggests that it has NCHW as input layout and treats N & C as batch dimensions and H & W as spatial dimensions. It is not true if the input has 2 dimensions (in IE it is treated by default as NC layout), so the pass try to get H & W dimensions as spatial, while the correct would be to get N & C. The following changes make this logic layout agnostic. According to https://github.com/openvinotoolkit/openvino/blob/master/docs/ops/matrix/MatMul_1.md we treat two last dimensions as spatial and all others that come first as batch dimensions. 