### PR TITLE
Workaround for Cython issue on Python 3.8

### DIFF
--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/CMakeLists.txt
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/CMakeLists.txt
@@ -32,7 +32,7 @@ endforeach()
 
 function(python_disable_deprecated_warnings)
     disable_deprecated_warnings()
-    set(pyx_file "${CMAKE_CURRENT_BINARY_DIR}/ie_api.cxx", "${CMAKE_CURRENT_BINARY_DIR}/constants.cxx")
+    set(pyx_file "${CMAKE_CURRENT_BINARY_DIR}/ie_api.cxx" "${CMAKE_CURRENT_BINARY_DIR}/constants.cxx")
     set_source_files_properties(${pyx_file} PROPERTIES COMPILE_FLAGS ${ie_c_cxx_deprecated})
 endfunction()
 

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/CMakeLists.txt
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/CMakeLists.txt
@@ -3,6 +3,8 @@
 
 set(TARGET_NAME "ie_api")
 
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=deprecated-declarations")
+
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PYTHON_BRIDGE_OUTPUT_DIRECTORY}/inference_engine)
 
 file(GLOB SOURCE

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/CMakeLists.txt
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/CMakeLists.txt
@@ -3,8 +3,6 @@
 
 set(TARGET_NAME "ie_api")
 
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=deprecated-declarations")
-
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PYTHON_BRIDGE_OUTPUT_DIRECTORY}/inference_engine)
 
 file(GLOB SOURCE
@@ -34,7 +32,7 @@ endforeach()
 
 function(python_disable_deprecated_warnings)
     disable_deprecated_warnings()
-    set(pyx_file "${CMAKE_CURRENT_BINARY_DIR}/ie_api.cxx")
+    set(pyx_file "${CMAKE_CURRENT_BINARY_DIR}/ie_api.cxx", "${CMAKE_CURRENT_BINARY_DIR}/constants.cxx")
     set_source_files_properties(${pyx_file} PROPERTIES COMPILE_FLAGS ${ie_c_cxx_deprecated})
 endfunction()
 


### PR DESCRIPTION
This is a proposed workaround for an issue we're seeing with Cython when using Python 3.8 to build the IE Python API.

```
openvino/build-test/inference-engine/ie_bridges/python/src/openvino/inference_engine/constants.cxx:3409:3: error: 'tp_print' is deprecated [-Werror,-Wdeprecated-declarations]
  0, /*tp_print*/
  ^
/usr/local/Frameworks/Python.framework/Versions/3.8/include/python3.8/cpython/object.h:260:5: note: 'tp_print' has been explicitly marked deprecated here
    Py_DEPRECATED(3.8) int (*tp_print)(PyObject *, FILE *, int);
    ^
/usr/local/Frameworks/Python.framework/Versions/3.8/include/python3.8/pyport.h:515:54: note: expanded from macro 'Py_DEPRECATED'
#define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
...
...
2 errors generated.
```

Related to: https://github.com/cython/cython/issues/3474