### PR TITLE
[MYRIAD] Config key to disable weights analysis pass

### DIFF
--- a/inference-engine/src/vpu/graph_transformer/include/vpu/graph_transformer.hpp
+++ b/inference-engine/src/vpu/graph_transformer/include/vpu/graph_transformer.hpp
@@ -110,6 +110,7 @@ struct CompilationConfig final {
     bool enableTensorIteratorUnrolling = false;
     bool forcePureTensorIterator = false;
     bool enableMemoryTypesAnnotation = false;
+    bool disableWeightsAnalysis = false;
 
     //
     // Deprecated options

--- a/inference-engine/src/vpu/graph_transformer/include/vpu/graph_transformer.hpp
+++ b/inference-engine/src/vpu/graph_transformer/include/vpu/graph_transformer.hpp
@@ -110,7 +110,7 @@ struct CompilationConfig final {
     bool enableTensorIteratorUnrolling = false;
     bool forcePureTensorIterator = false;
     bool enableMemoryTypesAnnotation = false;
-    bool disableWeightsAnalysis = false;
+    bool enableWeightsAnalysis = true;
 
     //
     // Deprecated options

--- a/inference-engine/src/vpu/graph_transformer/include/vpu/private_plugin_config.hpp
+++ b/inference-engine/src/vpu/graph_transformer/include/vpu/private_plugin_config.hpp
@@ -39,9 +39,9 @@ DECLARE_VPU_CONFIG(MYRIAD_ENABLE_MEMORY_TYPES_ANNOTATION);
 
 /**
  * @brief Used to disable analyzeWeightableLayers pass in cases where
- * weights scaling leads to poor accuracy. Default = "NO"
+ * weights scaling leads to poor accuracy. Default = "YES"
  */
-DECLARE_VPU_CONFIG(MYRIAD_DISABLE_WEIGHTS_ANALYSIS);
+DECLARE_VPU_CONFIG(MYRIAD_ENABLE_WEIGHTS_ANALYSIS);
 
 //
 // Debug options

--- a/inference-engine/src/vpu/graph_transformer/include/vpu/private_plugin_config.hpp
+++ b/inference-engine/src/vpu/graph_transformer/include/vpu/private_plugin_config.hpp
@@ -36,6 +36,13 @@ DECLARE_VPU_CONFIG(MYRIAD_PER_LAYER);
 DECLARE_VPU_CONFIG(MYRIAD_PER_STAGE);
 
 DECLARE_VPU_CONFIG(MYRIAD_ENABLE_MEMORY_TYPES_ANNOTATION);
+
+/**
+ * @brief Used to disable analyzeWeightableLayers pass in cases where
+ * weights scaling leads to poor accuracy. Default = "NO"
+ */
+DECLARE_VPU_CONFIG(MYRIAD_DISABLE_WEIGHTS_ANALYSIS);
+
 //
 // Debug options
 //

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/pass_manager.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/pass_manager.cpp
@@ -131,7 +131,7 @@ PassSet::Ptr PassManager::buildMiddleEnd() {
     // To overcome fp16 limitations
     //
 
-    if (env.config.hwOptimization && !env.config.disableWeightsAnalysis) {
+    if (env.config.hwOptimization && env.config.enableWeightsAnalysis) {
         ADD_PASS(analyzeWeightableLayers);
         ADD_DUMP_PASS("analyzeWeightableLayers");
     }

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/pass_manager.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/pass_manager.cpp
@@ -131,7 +131,7 @@ PassSet::Ptr PassManager::buildMiddleEnd() {
     // To overcome fp16 limitations
     //
 
-    if (env.config.hwOptimization) {
+    if (env.config.hwOptimization && !env.config.disableWeightsAnalysis) {
         ADD_PASS(analyzeWeightableLayers);
         ADD_DUMP_PASS("analyzeWeightableLayers");
     }

--- a/inference-engine/src/vpu/graph_transformer/src/parsed_config.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/parsed_config.cpp
@@ -67,6 +67,7 @@ IE_SUPPRESS_DEPRECATED_START
         ie::MYRIAD_ENABLE_TENSOR_ITERATOR_UNROLLING,
         ie::MYRIAD_FORCE_PURE_TENSOR_ITERATOR,
         ie::MYRIAD_DISABLE_CONVERT_STAGES,
+        ie::MYRIAD_DISABLE_WEIGHTS_ANALYSIS,
 
         //
         // Debug options
@@ -182,6 +183,7 @@ void ParsedConfig::parse(const std::map<std::string, std::string>& config) {
     setOption(_compileConfig.enableTensorIteratorUnrolling,  switches, config, ie::MYRIAD_ENABLE_TENSOR_ITERATOR_UNROLLING);
     setOption(_compileConfig.forcePureTensorIterator,        switches, config, ie::MYRIAD_FORCE_PURE_TENSOR_ITERATOR);
     setOption(_compileConfig.disableConvertStages,           switches, config, ie::MYRIAD_DISABLE_CONVERT_STAGES);
+    setOption(_compileConfig.disableWeightsAnalysis,         switches, config, ie::MYRIAD_DISABLE_WEIGHTS_ANALYSIS);
 
     setOption(_compileConfig.irWithVpuScalesDir,                       config, ie::MYRIAD_IR_WITH_SCALES_DIRECTORY);
     setOption(_compileConfig.noneLayers,                               config, ie::MYRIAD_NONE_LAYERS, parseStringSet);

--- a/inference-engine/src/vpu/graph_transformer/src/parsed_config.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/parsed_config.cpp
@@ -67,7 +67,7 @@ IE_SUPPRESS_DEPRECATED_START
         ie::MYRIAD_ENABLE_TENSOR_ITERATOR_UNROLLING,
         ie::MYRIAD_FORCE_PURE_TENSOR_ITERATOR,
         ie::MYRIAD_DISABLE_CONVERT_STAGES,
-        ie::MYRIAD_DISABLE_WEIGHTS_ANALYSIS,
+        ie::MYRIAD_ENABLE_WEIGHTS_ANALYSIS,
 
         //
         // Debug options
@@ -183,7 +183,7 @@ void ParsedConfig::parse(const std::map<std::string, std::string>& config) {
     setOption(_compileConfig.enableTensorIteratorUnrolling,  switches, config, ie::MYRIAD_ENABLE_TENSOR_ITERATOR_UNROLLING);
     setOption(_compileConfig.forcePureTensorIterator,        switches, config, ie::MYRIAD_FORCE_PURE_TENSOR_ITERATOR);
     setOption(_compileConfig.disableConvertStages,           switches, config, ie::MYRIAD_DISABLE_CONVERT_STAGES);
-    setOption(_compileConfig.disableWeightsAnalysis,         switches, config, ie::MYRIAD_DISABLE_WEIGHTS_ANALYSIS);
+    setOption(_compileConfig.enableWeightsAnalysis,         switches, config, ie::MYRIAD_ENABLE_WEIGHTS_ANALYSIS);
 
     setOption(_compileConfig.irWithVpuScalesDir,                       config, ie::MYRIAD_IR_WITH_SCALES_DIRECTORY);
     setOption(_compileConfig.noneLayers,                               config, ie::MYRIAD_NONE_LAYERS, parseStringSet);

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/behavior/config.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/behavior/config.cpp
@@ -40,8 +40,8 @@ namespace {
             {{InferenceEngine::MYRIAD_THROUGHPUT_STREAMS, "2"}},
             {{InferenceEngine::MYRIAD_THROUGHPUT_STREAMS, "3"}},
 
-            {{InferenceEngine::MYRIAD_DISABLE_WEIGHTS_ANALYSIS, CONFIG_VALUE(YES)}},
-            {{InferenceEngine::MYRIAD_DISABLE_WEIGHTS_ANALYSIS, CONFIG_VALUE(NO)}},
+            {{InferenceEngine::MYRIAD_ENABLE_WEIGHTS_ANALYSIS, CONFIG_VALUE(YES)}},
+            {{InferenceEngine::MYRIAD_ENABLE_WEIGHTS_ANALYSIS, CONFIG_VALUE(NO)}},
 
             // Deprecated
             {{VPU_MYRIAD_CONFIG_KEY(FORCE_RESET), CONFIG_VALUE(YES)}},
@@ -105,8 +105,8 @@ namespace {
             {{InferenceEngine::MYRIAD_THROUGHPUT_STREAMS, "Two"}},
             {{InferenceEngine::MYRIAD_THROUGHPUT_STREAMS, "SINGLE"}},
 
-            {{InferenceEngine::MYRIAD_DISABLE_WEIGHTS_ANALYSIS, "ON"}},
-            {{InferenceEngine::MYRIAD_DISABLE_WEIGHTS_ANALYSIS, "OFF"}},
+            {{InferenceEngine::MYRIAD_ENABLE_WEIGHTS_ANALYSIS, "ON"}},
+            {{InferenceEngine::MYRIAD_ENABLE_WEIGHTS_ANALYSIS, "OFF"}},
 
             // Deprecated
             {{VPU_MYRIAD_CONFIG_KEY(PROTOCOL), "BLUETOOTH"}},

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/behavior/config.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/behavior/config.cpp
@@ -40,6 +40,9 @@ namespace {
             {{InferenceEngine::MYRIAD_THROUGHPUT_STREAMS, "2"}},
             {{InferenceEngine::MYRIAD_THROUGHPUT_STREAMS, "3"}},
 
+            {{InferenceEngine::MYRIAD_DISABLE_WEIGHTS_ANALYSIS, CONFIG_VALUE(YES)}},
+            {{InferenceEngine::MYRIAD_DISABLE_WEIGHTS_ANALYSIS, CONFIG_VALUE(NO)}},
+
             // Deprecated
             {{VPU_MYRIAD_CONFIG_KEY(FORCE_RESET), CONFIG_VALUE(YES)}},
             {{VPU_MYRIAD_CONFIG_KEY(FORCE_RESET), CONFIG_VALUE(NO)}},
@@ -101,6 +104,9 @@ namespace {
 
             {{InferenceEngine::MYRIAD_THROUGHPUT_STREAMS, "Two"}},
             {{InferenceEngine::MYRIAD_THROUGHPUT_STREAMS, "SINGLE"}},
+
+            {{InferenceEngine::MYRIAD_DISABLE_WEIGHTS_ANALYSIS, "ON"}},
+            {{InferenceEngine::MYRIAD_DISABLE_WEIGHTS_ANALYSIS, "OFF"}},
 
             // Deprecated
             {{VPU_MYRIAD_CONFIG_KEY(PROTOCOL), "BLUETOOTH"}},

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/behavior/infer_request_config.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/behavior/infer_request_config.cpp
@@ -47,8 +47,8 @@ namespace {
             {{InferenceEngine::MYRIAD_THROUGHPUT_STREAMS, "2"}},
             {{InferenceEngine::MYRIAD_THROUGHPUT_STREAMS, "3"}},
 
-            {{InferenceEngine::MYRIAD_DISABLE_WEIGHTS_ANALYSIS, CONFIG_VALUE(YES)}},
-            {{InferenceEngine::MYRIAD_DISABLE_WEIGHTS_ANALYSIS, CONFIG_VALUE(NO)}},
+            {{InferenceEngine::MYRIAD_ENABLE_WEIGHTS_ANALYSIS, CONFIG_VALUE(YES)}},
+            {{InferenceEngine::MYRIAD_ENABLE_WEIGHTS_ANALYSIS, CONFIG_VALUE(NO)}},
 
             // Deprecated
             {{VPU_MYRIAD_CONFIG_KEY(FORCE_RESET), CONFIG_VALUE(YES)}},

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/behavior/infer_request_config.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/behavior/infer_request_config.cpp
@@ -47,6 +47,8 @@ namespace {
             {{InferenceEngine::MYRIAD_THROUGHPUT_STREAMS, "2"}},
             {{InferenceEngine::MYRIAD_THROUGHPUT_STREAMS, "3"}},
 
+            {{InferenceEngine::MYRIAD_DISABLE_WEIGHTS_ANALYSIS, CONFIG_VALUE(YES)}},
+            {{InferenceEngine::MYRIAD_DISABLE_WEIGHTS_ANALYSIS, CONFIG_VALUE(NO)}},
 
             // Deprecated
             {{VPU_MYRIAD_CONFIG_KEY(FORCE_RESET), CONFIG_VALUE(YES)}},


### PR DESCRIPTION
`AnalyzeWeightableLayers` pass in Myriad graph transformer adjusts weights of Conv, FC and Deconv layers to obtain better accuracy. However, since the algorithm that computes the new scale is obtained solely from the weights with no knowledge of activation values, this may, in certain cases, lead to poorer accuracy. This PR introduces a config key that can be used to disable this pass from the application side.