### PR TITLE
Supported threading command line options for other devices

### DIFF
--- a/inference-engine/samples/benchmark_app/main.cpp
+++ b/inference-engine/samples/benchmark_app/main.cpp
@@ -295,7 +295,7 @@ int main(int argc, char *argv[]) {
                 if (supported(CONFIG_KEY(CPU_THROUGHPUT_STREAMS)) && isFlagSetInCommandLine("nstreams")) {
                     device_config[CONFIG_KEY(CPU_THROUGHPUT_STREAMS)] = FLAGS_nstreams;
                 }
-                if (supported(CONFIG_KEY(CPU_THROUGHPUT_STREAMS)) && isFlagSetInCommandLine("pin")) {
+                if (supported(CONFIG_KEY(CPU_BIND_THREAD)) && isFlagSetInCommandLine("pin")) {
                     device_config[CONFIG_KEY(CPU_BIND_THREAD)] = FLAGS_pin;
                 }
             }

--- a/inference-engine/samples/benchmark_app/main.cpp
+++ b/inference-engine/samples/benchmark_app/main.cpp
@@ -283,6 +283,21 @@ int main(int argc, char *argv[]) {
 
                 if (isFlagSetInCommandLine("nthreads"))
                     device_config[GNA_CONFIG_KEY(LIB_N_THREADS)] = std::to_string(FLAGS_nthreads);
+            } else {
+                std::vector<std::string> supported_config_keys = ie.GetMetric(device, METRIC_KEY(SUPPORTED_CONFIG_KEYS));
+                auto supported = [&] (const std::string& key) {
+                    return std::find(std::begin(supported_config_keys), std::end(supported_config_keys), key)
+                        != std::end(supported_config_keys);
+                };
+                if (supported(CONFIG_KEY(CPU_THREADS_NUM)) && isFlagSetInCommandLine("nthreads")) {
+                    device_config[CONFIG_KEY(CPU_THREADS_NUM)] = std::to_string(FLAGS_nthreads);
+                }
+                if (supported(CONFIG_KEY(CPU_THROUGHPUT_STREAMS)) && isFlagSetInCommandLine("nstreams")) {
+                    device_config[CONFIG_KEY(CPU_THROUGHPUT_STREAMS)] = FLAGS_nstreams;
+                }
+                if (supported(CONFIG_KEY(CPU_THROUGHPUT_STREAMS)) && isFlagSetInCommandLine("pin")) {
+                    device_config[CONFIG_KEY(CPU_BIND_THREAD)] = FLAGS_pin;
+                }
             }
         }
 

--- a/tools/benchmark/main.py
+++ b/tools/benchmark/main.py
@@ -162,6 +162,14 @@ def run(args):
                         config[device]['GNA_PRECISION'] = 'I16'
                 if args.number_threads and is_flag_set_in_command_line("nthreads"):
                     config[device]['GNA_LIB_N_THREADS'] = str(args.number_threads)
+            else:
+                supported_config_keys = benchmark.ie.get_metric(device, 'SUPPORTED_CONFIG_KEYS')
+                if 'CPU_THREADS_NUM' in supported_config_keys and args.number_threads and is_flag_set_in_command_line("nthreads"):
+                    config[device]['CPU_THREADS_NUM'] = str(args.number_threads)
+                if 'CPU_THROUGHPUT_STREAMS' in supported_config_keys and args.number_streams and is_flag_set_in_command_line("streams"):
+                    config[device]['CPU_THROUGHPUT_STREAMS'] = args.number_streams
+                if 'CPU_BIND_THREAD' in supported_config_keys and args.infer_threads_pinning and is_flag_set_in_command_line("pin"):
+                    config[device]['CPU_BIND_THREAD'] = args.infer_threads_pinning
         perf_counts = perf_counts
 
         benchmark.set_config(config)


### PR DESCRIPTION
Benchmark application will pass threading command line options to device if it is presented in supported configuration keys list for device