### PR TITLE
[IE][VPU]: Implement HSwish layer with tests

### DIFF
--- a/inference-engine/cmake/vpu_dependencies.cmake
+++ b/inference-engine/cmake/vpu_dependencies.cmake
@@ -19,7 +19,7 @@ set(VPU_SUPPORTED_FIRMWARES usb-ma2450 usb-ma2x8x pcie-ma248x)
 # Default packages
 #
 
-set(FIRMWARE_PACKAGE_VERSION 1430)
+set(FIRMWARE_PACKAGE_VERSION 1440)
 set(VPU_CLC_MA2X8X_VERSION "movi-cltools-20.09.1")
 
 #

--- a/inference-engine/src/vpu/graph_transformer/include/vpu/frontend/frontend.hpp
+++ b/inference-engine/src/vpu/graph_transformer/include/vpu/frontend/frontend.hpp
@@ -156,6 +156,7 @@ public:
     void parseSwish(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
     void parseActivation(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
     void parseLogicalNot(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
+    void parseHSwish(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
 
     //
     // Special layers

--- a/inference-engine/src/vpu/graph_transformer/include/vpu/model/stage.hpp
+++ b/inference-engine/src/vpu/graph_transformer/include/vpu/model/stage.hpp
@@ -171,6 +171,7 @@ VPU_DECLARE_ENUM(StageType,
     StridedSlice = 133,
     SoftPlus = 134,
     Swish = 135,
+    HSwish = 137,
 )
 
 //

--- a/inference-engine/src/vpu/graph_transformer/src/frontend/frontend.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/frontend/frontend.cpp
@@ -30,7 +30,6 @@
 #include <legacy/transformations/convert_opset1_to_legacy/convert_opset1_to_legacy.hpp>
 #include <legacy/transformations/convert_opset1_to_legacy/convert_prior_to_ie_prior.hpp>
 #include <transformations/common_optimizations/common_optimizations.hpp>
-#include <transformations/op_conversions/hswish_decomposition.hpp>
 #include <transformations/init_node_info.hpp>
 #include <vpu/ngraph/transformations/merge_subsequent_dsr_operations.hpp>
 #include "vpu/ngraph/transformations/dynamic_to_static_shape.hpp"
@@ -155,7 +154,8 @@ ie::ICNNNetwork::Ptr FrontEnd::convertNetwork(ie::ICNNNetwork& network) {
         const bool casesWithDynamicOrStaticUsage =
             std::dynamic_pointer_cast<const ngraph::opset3::Gelu>(node) ||
             std::dynamic_pointer_cast<const ngraph::opset4::SoftPlus>(node) ||
-            std::dynamic_pointer_cast<const ngraph::opset5::Minimum>(node);
+            std::dynamic_pointer_cast<const ngraph::opset5::Minimum>(node) ||
+            std::dynamic_pointer_cast<const ngraph::opset5::HSwish>(node);
 
         const bool casesWithOnlyDynamicUsage =
             (std::dynamic_pointer_cast<const ngraph::opset3::MatMul>(node) ||
@@ -179,8 +179,6 @@ ie::ICNNNetwork::Ptr FrontEnd::convertNetwork(ie::ICNNNetwork& network) {
     manager.register_pass<ngraph::pass::ConvertOpSet3ToOpSet2>();
     manager.register_pass<ngraph::pass::ConvertOpSet2ToOpSet1>();
     manager.register_pass<ngraph::pass::ConvertOpSet1ToLegacy>();
-
-    manager.get_pass_config()->disable<ngraph::pass::HSwishDecomposition>();
 
     manager.set_callback(transformationsPredicate);
     manager.run_passes(nGraphFunc);

--- a/inference-engine/src/vpu/graph_transformer/src/frontend/frontend.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/frontend/frontend.cpp
@@ -30,6 +30,7 @@
 #include <legacy/transformations/convert_opset1_to_legacy/convert_opset1_to_legacy.hpp>
 #include <legacy/transformations/convert_opset1_to_legacy/convert_prior_to_ie_prior.hpp>
 #include <transformations/common_optimizations/common_optimizations.hpp>
+#include <transformations/op_conversions/hswish_decomposition.hpp>
 #include <transformations/init_node_info.hpp>
 #include <vpu/ngraph/transformations/merge_subsequent_dsr_operations.hpp>
 #include "vpu/ngraph/transformations/dynamic_to_static_shape.hpp"
@@ -128,6 +129,7 @@ FrontEnd::FrontEnd(StageBuilder::Ptr stageBuilder, const ie::ICore* core)
         {"SoftPlus",                                           LAYER_PARSER(parseSoftPlus)},
         {"Swish",                                              LAYER_PARSER(parseSwish)},
         {"Activation",                                         LAYER_PARSER(parseActivation)},
+        {"HSwish",                                             LAYER_PARSER(parseHSwish)},
     }} {
         VPU_THROW_UNLESS(_core != nullptr, "Argument core is null");
     }
@@ -177,6 +179,9 @@ ie::ICNNNetwork::Ptr FrontEnd::convertNetwork(ie::ICNNNetwork& network) {
     manager.register_pass<ngraph::pass::ConvertOpSet3ToOpSet2>();
     manager.register_pass<ngraph::pass::ConvertOpSet2ToOpSet1>();
     manager.register_pass<ngraph::pass::ConvertOpSet1ToLegacy>();
+
+    manager.get_pass_config()->disable<ngraph::pass::HSwishDecomposition>();
+
     manager.set_callback(transformationsPredicate);
     manager.run_passes(nGraphFunc);
 

--- a/inference-engine/src/vpu/graph_transformer/src/stages/hswish.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/hswish.cpp
@@ -1,0 +1,38 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vpu/frontend/frontend.hpp>
+#include <vpu/stages/post_op_stage.hpp>
+
+namespace vpu {
+
+namespace {
+
+class HSwishStage final : public PostOpStage {
+public:
+    using PostOpStage::PostOpStage;
+
+private:
+    StagePtr cloneImpl() const override {
+        return std::make_shared<HSwishStage >(*this);
+    }
+
+    void serializeParamsImpl(BlobSerializer&) const override {
+    }
+};
+
+}  // namespace
+
+void FrontEnd::parseHSwish(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+    VPU_THROW_UNLESS((inputs.size() == 1),
+                     "HSwish stage with name {} must have only 1 input, "
+                     "actually provided {}", layer->name, inputs.size());
+    VPU_THROW_UNLESS(outputs.size() == 1,
+                     "HSwish stage with name {} must have only 1 output, "
+                     "actually provided {}", layer->name, outputs.size());
+
+    model->addNewStage<HSwishStage>(layer->name, StageType::HSwish, layer, inputs, outputs);
+}
+
+}  // namespace vpu

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/activation.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/activation.cpp
@@ -24,7 +24,8 @@ const std::map<ActivationTypes, std::vector<std::vector<float>>> activationTypes
         {Gelu,     {}},
         {Mish,     {}},
         {SoftPlus, {}},
-        {Swish,    {{0.05f}, {0.8f}, {1.0f}, {15.0f}}}
+        {Swish,    {{0.05f}, {0.8f}, {1.0f}, {15.0f}}},
+        {HSwish,   {}},
 };
 
 std::map<std::vector<size_t>, std::vector<std::vector<size_t>>> basic = {


### PR DESCRIPTION
### Description
This PR introduces a new PostOps kernel named HSwish. `out(i) = in(i) * ReLU6(in(i) + 3) / 6`.
Disabling decomposition of HSwish layer and infer HSwish as is allows us to speed up mobilenet-v3-small performance up to ~50%

### Task
#-41495

### CI
* [x] IE-MDK #-1924
* [x] DL_benchmark #-496 100.77558 FPS (old) vs 143.1965 FPS (new)



