### PR TITLE
[IE][VPU][GT]: Fixes Eltwise+ReLU merge for dynamic networks

### DIFF
--- a/inference-engine/src/vpu/graph_transformer/include/vpu/middleend/pass_manager.hpp
+++ b/inference-engine/src/vpu/graph_transformer/include/vpu/middleend/pass_manager.hpp
@@ -148,7 +148,8 @@ public:
     //
 
     Pass::Ptr mergeReLUAndBias();
-    Pass::Ptr mergeEltwiseAndReLU();
+    Pass::Ptr mergeEltwiseAndReLUDynamic();
+    Pass::Ptr mergeEltwiseAndReLUStatic();
     Pass::Ptr replaceWithSCReLU();
     Pass::Ptr replaceWithReduceMean();
 

--- a/inference-engine/src/vpu/graph_transformer/include/vpu/model/model.hpp
+++ b/inference-engine/src/vpu/graph_transformer/include/vpu/model/model.hpp
@@ -322,6 +322,9 @@ public:
         return _orderedStageList | asRange();
     }
 
+    bool isDynamic() const;
+    bool isStatic() const;
+
     //
     // Allocator
     //

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/pass_manager.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/pass_manager.cpp
@@ -255,6 +255,9 @@ PassSet::Ptr PassManager::buildMiddleEnd() {
     ADD_PASS(mergeReLUAndBias);
     ADD_DUMP_PASS("mergeReLUAndBias");
 
+    ADD_PASS(mergeEltwiseAndReLUDynamic);
+    ADD_DUMP_PASS("mergeEltwiseAndReLUDynamic");
+
     //
     // Data layout adjustment
     //
@@ -277,8 +280,8 @@ PassSet::Ptr PassManager::buildMiddleEnd() {
     // Model SW-specific optimizations after data layout adjustment
     //
 
-    ADD_PASS(mergeEltwiseAndReLU);
-    ADD_DUMP_PASS("mergeEltwiseAndReLU");
+    ADD_PASS(mergeEltwiseAndReLUStatic);
+    ADD_DUMP_PASS("mergeEltwiseAndReLUStatic");
 
     //
     // Model special stages processing

--- a/inference-engine/src/vpu/graph_transformer/src/model/model.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/model/model.cpp
@@ -2166,4 +2166,14 @@ void ModelObj::removeUnusedData(const Data& data) {
     _dataPtrList.erase(data->_ptrPosInModel);
 }
 
+bool ModelObj::isDynamic() const {
+    const auto& dataObjects = datas();
+    return std::any_of(dataObjects.begin(), dataObjects.end(),
+        [](const Data& data) { return data->parentDataToShapeEdge() || !data->childDataToShapeEdges().empty(); });
+}
+
+bool ModelObj::isStatic() const {
+    return !isDynamic();
+}
+
 }  // namespace vpu


### PR DESCRIPTION
# Task

#-38326

# Description

Eltwise + ReLU merge is expected to be performed unconditionally in all cases and since it does not require strides to be defined
could be performed before `adjustDataLayout` pass.

Unfortunately, there are cases with unexpected degradation after such a change is introduced. In specific case it seems to be caused by degradation in HW operation (convolution). It was not investigated completely and reason is still unknown (convolution itself remains unchanged in network, but for some reason works slower).

It has been decided to introduce change only in case of dynamic models to have performance benefit for some cases and avoid degradations in others.

Moving `mergeEltwiseAndReLU` pass before `adjustDataLayout` for dynamic cases allows to get additional performance gain due to lack of extra copy stages introduced in `adjustDataLayout`.