### PR TITLE
Add dynamic shape checks for legacy transformations

### DIFF
--- a/inference-engine/src/legacy_api/src/ngraph_ops/tile_ie.cpp
+++ b/inference-engine/src/legacy_api/src/ngraph_ops/tile_ie.cpp
@@ -21,18 +21,23 @@ op::TileIE::TileIE(const Output<ngraph::Node>& data1, const int64_t axis, const 
 }
 
 std::shared_ptr<Node> op::TileIE::clone_with_new_inputs(const OutputVector& new_args) const {
-    if (new_args.size() != 1) {
-        throw ngraph_error("Incorrect number of new arguments");
-    }
-
+    check_new_args_count(this, new_args);
     return make_shared<TileIE>(new_args.at(0), axis, tiles);
 }
 
 void op::TileIE::validate_and_infer_types() {
-    auto input_shape = get_input_partial_shape(0).to_shape();
+    const auto & input_pshape = get_input_partial_shape(0);
+    auto output_pshape = PartialShape::dynamic();
+    if (input_pshape.rank().is_static()) {
+        const auto & rank = input_pshape.rank().get_length();
+        NODE_VALIDATION_CHECK(this,
+                              axis >= 0 && axis < rank,
+                              "Axis: ", axis, " must be >= 0 and less than ", rank, "(input rank)");
+        output_pshape = input_pshape;
+        if (output_pshape[axis].is_static()) {
+            output_pshape[axis] *= tiles;
+        }
+    }
 
-    ngraph::Shape output_shape(input_shape);
-    output_shape[axis] *= tiles;
-
-    set_output_type(0, get_input_element_type(0), PartialShape(output_shape));
+    set_output_type(0, get_input_element_type(0), output_pshape);
 }

--- a/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/convert_interpolate_to_interp_or_resample.cpp
+++ b/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/convert_interpolate_to_interp_or_resample.cpp
@@ -12,15 +12,15 @@
 
 #include <ngraph/opsets/opset1.hpp>
 #include <ngraph/rt_info.hpp>
+#include <ngraph/pattern/op/wrap_type.hpp>
 
 #include <legacy/ngraph_ops/interp.hpp>
 
 NGRAPH_RTTI_DEFINITION(ngraph::pass::ConvertInterpolateToInterpOrResampleMatcher, "ConvertInterpolateToInterpOrResampleMatcher", 0);
 
 ngraph::pass::ConvertInterpolateToInterpOrResampleMatcher::ConvertInterpolateToInterpOrResampleMatcher() {
-    auto data = std::make_shared<pattern::op::Label>(element::f32, Shape{1, 1, 1, 1});
-    auto shp = std::make_shared<pattern::op::Label>(element::i64, Shape{2});
-    auto interpolate = std::make_shared<ngraph::opset1::Interpolate>(data, shp, ngraph::op::v0::InterpolateAttrs());
+    auto interpolate = pattern::wrap_type<opset1::Interpolate>({pattern::any_input(pattern::has_static_shape()),
+                                                                pattern::wrap_type<opset1::Constant>()});
 
     ngraph::matcher_pass_callback callback = [](pattern::Matcher& m) {
         auto interpolate = std::dynamic_pointer_cast<ngraph::opset1::Interpolate> (m.get_match_root());

--- a/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/convert_matmul_to_fc_or_gemm.cpp
+++ b/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/convert_matmul_to_fc_or_gemm.cpp
@@ -13,6 +13,7 @@
 
 #include <ngraph/opsets/opset1.hpp>
 #include <ngraph/rt_info.hpp>
+#include <ngraph/pattern/op/wrap_type.hpp>
 
 #include <legacy/ngraph_ops/fully_connected.hpp>
 #include <transformations/utils/utils.hpp>
@@ -20,9 +21,9 @@
 NGRAPH_RTTI_DEFINITION(ngraph::pass::ConvertMatMulToFC, "ConvertMatMulToFC", 0);
 
 ngraph::pass::ConvertMatMulToFC::ConvertMatMulToFC() {
-    auto input_0 = std::make_shared<pattern::op::Label>(element::f32, Shape {1, 1});
-    auto input_1 = std::make_shared<pattern::op::Label>(element::f32, Shape {1, 1});
-    auto matmul = std::make_shared<ngraph::opset1::MatMul>(input_0, input_1);
+    auto matmul = pattern::wrap_type<opset1::MatMul>({pattern::any_input(pattern::has_static_shape()),
+                                                      pattern::any_input(pattern::has_static_shape())},
+                                                      pattern::has_static_shape());
 
     ngraph::matcher_pass_callback callback = [this](pattern::Matcher& m) {
         auto matmul = std::dynamic_pointer_cast<ngraph::opset1::MatMul>(m.get_match_root());
@@ -163,9 +164,9 @@ ngraph::pass::ConvertMatMulToFC::ConvertMatMulToFC() {
 NGRAPH_RTTI_DEFINITION(ngraph::pass::ConvertMatMulToGemm, "ConvertMatMulToGemm", 0);
 
 ngraph::pass::ConvertMatMulToGemm::ConvertMatMulToGemm() {
-    auto input_0 = std::make_shared<pattern::op::Label>(element::f32, Shape {1, 1});
-    auto input_1 = std::make_shared<pattern::op::Label>(element::f32, Shape {1, 1});
-    auto matmul = std::make_shared<ngraph::opset1::MatMul>(input_0, input_1);
+    auto matmul = pattern::wrap_type<opset1::MatMul>({pattern::any_input(pattern::has_static_shape()),
+                                                      pattern::any_input(pattern::has_static_shape())},
+                                                      pattern::has_static_shape());
 
     ngraph::matcher_pass_callback callback = [this](pattern::Matcher& m) {
         auto matmul = std::dynamic_pointer_cast<ngraph::opset1::MatMul>(m.get_match_root());

--- a/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/convert_pad_to_pad_ie.cpp
+++ b/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/convert_pad_to_pad_ie.cpp
@@ -14,7 +14,7 @@
 NGRAPH_RTTI_DEFINITION(ngraph::pass::ConvertPadToLegacyMatcher, "ConvertPadToLegacyMatcher", 0);
 
 ngraph::pass::ConvertPadToLegacyMatcher::ConvertPadToLegacyMatcher() {
-    auto m_pad = ngraph::pattern::wrap_type<ngraph::opset1::Pad>();
+    auto m_pad = ngraph::pattern::wrap_type<ngraph::opset1::Pad>(pattern::has_static_shape());
 
     ngraph::matcher_pass_callback callback = [](pattern::Matcher& m) {
         auto pad = std::dynamic_pointer_cast<ngraph::opset1::Pad> (m.get_match_root());

--- a/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/fc_bias_fusion.cpp
+++ b/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/fc_bias_fusion.cpp
@@ -15,38 +15,33 @@
 NGRAPH_RTTI_DEFINITION(ngraph::pass::FullyConnectedBiasFusion, "FullyConnectedBiasFusion", 0);
 
 ngraph::pass::FullyConnectedBiasFusion::FullyConnectedBiasFusion() {
-    auto fc = ngraph::pattern::wrap_type<op::FullyConnected>();
-    auto add = ngraph::pattern::wrap_type<opset1::Add>({fc, std::make_shared<pattern::op::Label>()});
+    auto m_fc = ngraph::pattern::wrap_type<op::FullyConnected>([](Output<Node> output) {
+        return pattern::consumers_count(1)(output) &&
+               pattern::has_static_shape()(output);
+    });
+    auto m_bias = pattern::any_input();
+    auto m_add = ngraph::pattern::wrap_type<opset1::Add>({m_fc, m_bias});
 
-    ngraph::graph_rewrite_callback callback = [](pattern::Matcher &m) {
-        auto add = m.get_match_root();
-        auto add_input_0 = add->input(0).get_source_output().get_node_shared_ptr();
-        auto add_input_1 = add->input(1).get_source_output().get_node_shared_ptr();
+    ngraph::matcher_pass_callback callback = [=](pattern::Matcher &m) {
+        auto & pattern_to_output = m.get_pattern_value_map();
 
-        auto m_fc = std::dynamic_pointer_cast<op::FullyConnected>(add_input_0);
-        auto m_bias = add_input_1;
-
-        if (m_fc == nullptr) {
-            m_fc = std::dynamic_pointer_cast<op::FullyConnected>(add_input_1);
-            if (m_fc == nullptr)
-                return false;
-            m_bias = add_input_0;
-        }
-
-        if (auto bcast_m = std::dynamic_pointer_cast<opset1::Broadcast>(m_bias)) {
-            m_bias = bcast_m->input(0).get_source_output().get_node_shared_ptr();
-        }
-
-        if (!std::dynamic_pointer_cast<opset1::Constant>(m_bias)) {
-            return false;
-        }
-        Shape bias_shape(m_bias->get_shape());
-
-        if (m_fc->output(0).get_target_inputs().size() != 1) {
+        auto add = pattern_to_output[m_add].get_node_shared_ptr();
+        auto bias = pattern_to_output[m_bias].get_node_shared_ptr();
+        auto fc = std::dynamic_pointer_cast<op::FullyConnected>(pattern_to_output[m_fc].get_node_shared_ptr());
+        if (!fc) {
             return false;
         }
 
-        Shape output_shape(m_fc->get_shape());
+        if (auto bcast = std::dynamic_pointer_cast<opset1::Broadcast>(bias)) {
+            bias = bcast->input_value(0).get_node_shared_ptr();
+        }
+
+        if (!std::dynamic_pointer_cast<opset1::Constant>(bias)) {
+            return false;
+        }
+
+        Shape bias_shape(bias->get_shape());
+        Shape output_shape(fc->get_shape());
         size_t bias_size = std::accumulate(bias_shape.begin(), bias_shape.end(), size_t{1}, std::multiplies<int64_t>());
         if (bias_shape.empty() || bias_shape.back() != output_shape.back() || bias_shape.back() != bias_size) {
             return false;
@@ -54,7 +49,7 @@ ngraph::pass::FullyConnectedBiasFusion::FullyConnectedBiasFusion() {
 
         NodeVector new_ops;
 
-        auto new_bias = std::make_shared<opset1::Add>(m_fc->input(2).get_source_output(), m_bias);
+        auto new_bias = std::make_shared<opset1::Add>(fc->input(2).get_source_output(), bias);
         new_ops.push_back(new_bias);
         std::shared_ptr<Node> final_bias = new_bias;
         if (new_bias->get_shape().size() >= 2) {
@@ -62,19 +57,19 @@ ngraph::pass::FullyConnectedBiasFusion::FullyConnectedBiasFusion() {
             new_ops.push_back(final_bias);
         }
 
-        auto new_fc = std::make_shared<op::FullyConnected>(m_fc->input(0).get_source_output(),
-                                                           m_fc->input(1).get_source_output(),
+        auto new_fc = std::make_shared<op::FullyConnected>(fc->input(0).get_source_output(),
+                                                           fc->input(1).get_source_output(),
                                                            final_bias,
-                                                           m_fc->get_shape(),
-                                                           m_fc->get_output_type());
+                                                           fc->get_shape(),
+                                                           fc->get_output_type());
         new_ops.push_back(new_fc);
 
         new_fc->set_friendly_name(add->get_friendly_name());
-        ngraph::copy_runtime_info({m_fc, add}, new_ops);
+        ngraph::copy_runtime_info({fc, add}, new_ops);
         ngraph::replace_node(add, new_fc);
         return true;
     };
 
-    auto m = std::make_shared<ngraph::pattern::Matcher>(add, "FullyConnectedBiasFusion");
+    auto m = std::make_shared<ngraph::pattern::Matcher>(m_add, "FullyConnectedBiasFusion");
     this->register_matcher(m, callback);
 }

--- a/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/reshape_1d_ops.cpp
+++ b/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/reshape_1d_ops.cpp
@@ -109,7 +109,7 @@ std::shared_ptr<Node> convert(const Output<Node> & data, std::shared_ptr<opset1:
 matcher_pass_callback get_callback() {
     return [](pattern::Matcher& m) {
         auto node = m.get_match_root();
-        if (!node || node->input(0).get_partial_shape().rank().get_length() != 3) {
+        if (node->input(0).get_partial_shape().rank().get_length() != 3) {
             return false;
         }
 
@@ -154,7 +154,9 @@ NGRAPH_RTTI_DEFINITION(ngraph::pass::Reshape1DOps, "Reshape1DOps", 0);
 NGRAPH_RTTI_DEFINITION(ngraph::pass::Reshape1DConvolution, "Reshape1DConvolution", 0);
 
 ngraph::pass::Reshape1DConvolution::Reshape1DConvolution() {
-    auto conv = ngraph::pattern::wrap_type<op::ConvolutionIE>();
+    auto conv = ngraph::pattern::wrap_type<op::ConvolutionIE>({pattern::any_input(pattern::has_static_shape()),
+                                                               pattern::any_input()},
+                                                               pattern::has_static_shape());
     auto m = std::make_shared<ngraph::pattern::Matcher>(conv, "Reshape1DConvolution");
     this->register_matcher(m, get_callback());
 }
@@ -162,7 +164,7 @@ ngraph::pass::Reshape1DConvolution::Reshape1DConvolution() {
 NGRAPH_RTTI_DEFINITION(ngraph::pass::Reshape1DAvgPool, "Reshape1DAvgPool", 0);
 
 ngraph::pass::Reshape1DAvgPool::Reshape1DAvgPool() {
-    auto pool = ngraph::pattern::wrap_type<opset1::AvgPool>();
+    auto pool = ngraph::pattern::wrap_type<opset1::AvgPool>(pattern::has_static_shape());
     auto m = std::make_shared<ngraph::pattern::Matcher>(pool, "Reshape1DAvgPool");
     this->register_matcher(m, get_callback());
 }
@@ -170,7 +172,7 @@ ngraph::pass::Reshape1DAvgPool::Reshape1DAvgPool() {
 NGRAPH_RTTI_DEFINITION(ngraph::pass::Reshape1DMaxPool, "Reshape1DMaxPool", 0);
 
 ngraph::pass::Reshape1DMaxPool::Reshape1DMaxPool() {
-    auto pool = ngraph::pattern::wrap_type<opset1::MaxPool>();
+    auto pool = ngraph::pattern::wrap_type<opset1::MaxPool>(pattern::has_static_shape());
     auto m = std::make_shared<ngraph::pattern::Matcher>(pool, "Reshape1DMaxPool");
     this->register_matcher(m, get_callback());
 }

--- a/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/reshape_1d_ops.cpp
+++ b/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/reshape_1d_ops.cpp
@@ -154,9 +154,7 @@ NGRAPH_RTTI_DEFINITION(ngraph::pass::Reshape1DOps, "Reshape1DOps", 0);
 NGRAPH_RTTI_DEFINITION(ngraph::pass::Reshape1DConvolution, "Reshape1DConvolution", 0);
 
 ngraph::pass::Reshape1DConvolution::Reshape1DConvolution() {
-    auto conv = ngraph::pattern::wrap_type<op::ConvolutionIE>({pattern::any_input(pattern::has_static_shape()),
-                                                               pattern::any_input()},
-                                                               pattern::has_static_shape());
+    auto conv = ngraph::pattern::wrap_type<op::ConvolutionIE>(pattern::has_static_shape());
     auto m = std::make_shared<ngraph::pattern::Matcher>(conv, "Reshape1DConvolution");
     this->register_matcher(m, get_callback());
 }

--- a/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/reshape_fully_connected.cpp
+++ b/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/reshape_fully_connected.cpp
@@ -9,6 +9,7 @@
 
 #include <ngraph/opsets/opset1.hpp>
 #include <ngraph/rt_info.hpp>
+#include <ngraph/pattern/op/wrap_type.hpp>
 
 #include "legacy/ngraph_ops/fully_connected.hpp"
 #include "transformations/utils/utils.hpp"
@@ -16,10 +17,10 @@
 NGRAPH_RTTI_DEFINITION(ngraph::pass::ReshapeFullyConnected, "ReshapeFullyConnected", 0);
 
 ngraph::pass::ReshapeFullyConnected::ReshapeFullyConnected() {
-    auto input0 = std::make_shared<pattern::op::Label>(element::i64, Shape{1, 1});
-    auto input1 = std::make_shared<pattern::op::Label>(element::i64, Shape{1, 1});
-    auto input2 = std::make_shared<pattern::op::Label>(element::i64, Shape{1});
-    auto fc = std::make_shared<ngraph::op::FullyConnected>(input0, input1, input2, Shape{1, 1});
+    auto fc = pattern::wrap_type<op::FullyConnected>({pattern::any_input(pattern::has_static_shape()),
+                                                      pattern::any_input(),
+                                                      pattern::any_input()},
+                                                      pattern::has_static_shape());
 
     ngraph::graph_rewrite_callback callback = [this](pattern::Matcher& m) {
         auto fc = std::dynamic_pointer_cast<ngraph::op::FullyConnected> (m.get_match_root());

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_interpolate_to_legacy.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_interpolate_to_legacy.cpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <memory>
+#include <queue>
+
+#include <ngraph/function.hpp>
+#include <ngraph/opsets/opset1.hpp>
+#include <legacy/transformations/convert_opset1_to_legacy/convert_interpolate_to_interp_or_resample.hpp>
+#include <transformations/utils/utils.hpp>
+#include <ngraph/pass/manager.hpp>
+
+#include "common_test_utils/ngraph_test_utils.hpp"
+
+using namespace testing;
+
+TEST(TransformationTests, ConvertInterpolateDynamic) {
+    auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic());
+    auto shape = ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {30, 60});
+    auto interp = std::make_shared<ngraph::opset1::Interpolate>(data, shape, ngraph::op::v0::InterpolateAttrs());
+
+    auto f = std::make_shared<ngraph::Function>(ngraph::NodeVector{interp}, ngraph::ParameterVector{data});
+
+    ngraph::pass::Manager m;
+    m.register_pass<ngraph::pass::ConvertInterpolateToInterpOrResampleMatcher>();
+    ASSERT_NO_THROW(m.run_passes(f));
+}

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_lrn_to_legacy.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_lrn_to_legacy.cpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <memory>
+#include <queue>
+
+#include <ngraph/function.hpp>
+#include <ngraph/opsets/opset1.hpp>
+#include <legacy/transformations/convert_opset1_to_legacy/convert_lrn_to_lrn_ie.hpp>
+#include <transformations/utils/utils.hpp>
+#include <ngraph/pass/manager.hpp>
+
+#include "common_test_utils/ngraph_test_utils.hpp"
+
+using namespace testing;
+
+TEST(TransformationTests, ConvertLRNToLegacyDynamic) {
+    auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic());
+    auto axis = ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{1}, {0});
+    auto lrn = std::make_shared<ngraph::opset1::LRN>(data, axis, 1, 2, 3, 4);
+
+    auto f = std::make_shared<ngraph::Function>(ngraph::NodeVector{lrn}, ngraph::ParameterVector{data});
+
+    ngraph::pass::Manager m;
+    m.register_pass<ngraph::pass::ConvertLRNToLegacyMatcher>();
+    ASSERT_NO_THROW(m.run_passes(f));
+}

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_pad_to_legacy.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_pad_to_legacy.cpp
@@ -1,0 +1,32 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <memory>
+#include <queue>
+
+#include <ngraph/function.hpp>
+#include <ngraph/opsets/opset1.hpp>
+#include <legacy/transformations/convert_opset1_to_legacy/convert_pad_to_pad_ie.hpp>
+#include <transformations/utils/utils.hpp>
+#include <ngraph/pass/manager.hpp>
+
+#include "common_test_utils/ngraph_test_utils.hpp"
+
+using namespace testing;
+
+TEST(TransformationTests, ConvertPadToLegacyDynamic) {
+    auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic());
+    auto pad_begin = ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {1, 0});
+    auto pad_end = ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {0, 1});
+    auto pad = std::make_shared<ngraph::opset1::Pad>(data, pad_begin, pad_end, ngraph::op::PadMode::SYMMETRIC);
+
+    auto f = std::make_shared<ngraph::Function>(ngraph::NodeVector{pad}, ngraph::ParameterVector{data});
+
+    ngraph::pass::Manager m;
+    m.register_pass<ngraph::pass::ConvertPadToLegacyMatcher>();
+    ASSERT_NO_THROW(m.run_passes(f));
+}

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_tile_to_legacy.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_tile_to_legacy.cpp
@@ -1,0 +1,48 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <memory>
+#include <queue>
+
+#include <ngraph/function.hpp>
+#include <ngraph/opsets/opset1.hpp>
+#include <legacy/transformations/convert_opset1_to_legacy/convert_tile_to_ie_tile.hpp>
+#include <transformations/init_node_info.hpp>
+#include <transformations/utils/utils.hpp>
+#include <ngraph/pass/manager.hpp>
+#include <legacy/ngraph_ops/tile_ie.hpp>
+
+#include "common_test_utils/ngraph_test_utils.hpp"
+
+using namespace testing;
+using namespace ngraph;
+
+TEST(TransformationTests, ConvertTileToLegacyDynamic1) {
+    auto data = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, Dimension::dynamic()});
+    auto axes = opset1::Constant::create(element::i64, Shape{1}, {0});
+    auto tile = std::make_shared<opset1::Tile>(data, axes);
+
+    auto f = std::make_shared<Function>(NodeVector{tile}, ParameterVector{data});
+    pass::Manager manager;
+    manager.register_pass<pass::InitNodeInfo>();
+    manager.register_pass<pass::ConvertTileToLegacyMatcher>();
+    ASSERT_NO_THROW(manager.run_passes(f));
+    ASSERT_NO_THROW(check_rt_info(f));
+}
+
+TEST(TransformationTests, ConvertTileToLegacyDynamic2) {
+    auto data = std::make_shared<opset1::Parameter>(element::f32, PartialShape::dynamic());
+    auto axes = opset1::Constant::create(element::i64, Shape{1}, {0});
+    auto tile = std::make_shared<opset1::Tile>(data, axes);
+
+    auto f = std::make_shared<Function>(NodeVector{tile}, ParameterVector{data});
+    pass::Manager manager;
+    manager.register_pass<pass::InitNodeInfo>();
+    manager.register_pass<pass::ConvertTileToLegacyMatcher>();
+    ASSERT_NO_THROW(manager.run_passes(f));
+    ASSERT_NO_THROW(check_rt_info(f));
+}


### PR DESCRIPTION
In this PR I added checks for dynamic shapes into legacy transformations.
List of this transformations:
* ConvertInterpolateToInterpOrResample
* ConvertLRNToLRNIE
* ConvertMatMulToFCorGemm
* ConvertPadToPadIE
* ConvertTileToIETile
* FullyConnectedBiasFusion
* Reshape1DConvolutions
* Reshape1DAvgPool
* Reshape1DMaxPool
* ReshapeFullyConnectedFusion
* ReshapeFullyConnected

