### PR TITLE
Added dynamic check for convertFunctionToCNNNetwork functoin

### DIFF
--- a/inference-engine/src/legacy_api/src/convert_function_to_cnn_network.cpp
+++ b/inference-engine/src/legacy_api/src/convert_function_to_cnn_network.cpp
@@ -907,6 +907,28 @@ void convertFunctionToICNNNetwork(const std::shared_ptr<const ::ngraph::Function
         network->setInputInfo(info);
     };
 
+    // Check if some of function nodes has dynamic input or output shape
+    // we collect this nodes and then throw an exception with the list
+    // of dynamic nodes.
+    std::vector<ngraph::Node*> dynamic_nodes;
+    for (const auto & node : graph->get_ordered_ops()) {
+        for (const auto & input : node->inputs()) {
+            if (input.get_partial_shape().is_dynamic()) {
+                dynamic_nodes.push_back(node.get());
+                break;
+            }
+        }
+        for (const auto & output : node->outputs()) {
+            if (output.get_partial_shape().is_dynamic()) {
+                dynamic_nodes.push_back(node.get());
+                break;
+            }
+        }
+    }
+    if (!dynamic_nodes.empty()) {
+        THROW_IE_EXCEPTION << dynamic_nodes;
+    }
+
     const CNNNetworkNGraphImpl* nGraphImpl = dynamic_cast<const CNNNetworkNGraphImpl*>(&network);
 
     InputsDataMap thisInputDataMap;

--- a/inference-engine/src/legacy_api/src/convert_function_to_cnn_network.cpp
+++ b/inference-engine/src/legacy_api/src/convert_function_to_cnn_network.cpp
@@ -910,23 +910,25 @@ void convertFunctionToICNNNetwork(const std::shared_ptr<const ::ngraph::Function
     // Check if some of function nodes has dynamic input or output shape
     // we collect this nodes and then throw an exception with the list
     // of dynamic nodes.
-    std::vector<ngraph::Node*> dynamic_nodes;
+    std::stringstream err_log;
     for (const auto & node : graph->get_ordered_ops()) {
+        bool is_dynamic = false;
         for (const auto & input : node->inputs()) {
             if (input.get_partial_shape().is_dynamic()) {
-                dynamic_nodes.push_back(node.get());
+                is_dynamic = true;
                 break;
             }
         }
         for (const auto & output : node->outputs()) {
             if (output.get_partial_shape().is_dynamic()) {
-                dynamic_nodes.push_back(node.get());
+                is_dynamic = true;
                 break;
             }
         }
+        if (is_dynamic) err_log << node << std::endl;
     }
-    if (!dynamic_nodes.empty()) {
-        THROW_IE_EXCEPTION << dynamic_nodes;
+    if (!err_log.str().empty()) {
+        THROW_IE_EXCEPTION << "\nUnsupported dynamic ops: \n" << err_log.str();
     }
 
     const CNNNetworkNGraphImpl* nGraphImpl = dynamic_cast<const CNNNetworkNGraphImpl*>(&network);

--- a/inference-engine/tests/functional/inference_engine/cnn_network/convert_ngraph_to_cnn_network_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/cnn_network/convert_ngraph_to_cnn_network_tests.cpp
@@ -219,6 +219,7 @@ TEST(ConvertFunctionToCNNNetworkTests, UnsupportedDynamicOps) {
         auto non_zero = std::make_shared<ngraph::opset4::NonZero>(relu);
         non_zero->set_friendly_name("non_zero");
         auto result = std::make_shared<ngraph::op::Result>(non_zero->output(0));
+        result->set_friendly_name("result");
 
         f = std::make_shared<ngraph::Function>(ngraph::ResultVector{result},
                                                ngraph::ParameterVector{param});
@@ -233,6 +234,6 @@ TEST(ConvertFunctionToCNNNetworkTests, UnsupportedDynamicOps) {
                                                              "v0::Parameter param () -> (f32?)\n"
                                                              "v0::Relu relu (param[0]:f32?) -> (f32?)\n"
                                                              "v3::NonZero non_zero (relu[0]:f32?) -> (i64{?,?})\n"
-                                                             "v0::Result Result_12 (non_zero[0]:i64{?,?}) -> (i64{?,?})")));
+                                                             "v0::Result result (non_zero[0]:i64{?,?}) -> (i64{?,?})")));
     }
 }

--- a/inference-engine/tests/functional/inference_engine/cnn_network/convert_ngraph_to_cnn_network_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/cnn_network/convert_ngraph_to_cnn_network_tests.cpp
@@ -207,3 +207,59 @@ TEST(ConvertFunctionToCNNNetworkTests, ConvertTopKWithOneInput) {
         ASSERT_TRUE(resp_msg.find(ref_msg) != std::string::npos) << resp_msg;
     }
 }
+
+TEST(ConvertFunctionToCNNNetworkTests, ConvertTopKWithOneInput) {
+    std::shared_ptr<ngraph::Function> f;
+    {
+        auto param = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 22, 22});
+        ngraph::Shape const_shape = {};
+        std::vector<int64_t> val = {5};
+        auto k = std::make_shared<ngraph::opset4::Constant>(ngraph::element::i64, const_shape, val);
+        auto topK = std::make_shared<ngraph::opset4::TopK>(param, k, 2, ngraph::opset4::TopK::Mode::MAX, ngraph::opset4::TopK::SortType::SORT_VALUES);
+        topK->set_friendly_name("topK");
+        auto result = std::make_shared<ngraph::op::Result>(topK->output(1));
+
+        f = std::make_shared<ngraph::Function>(ngraph::ResultVector{result},
+                                               ngraph::ParameterVector{param});
+        ngraph::pass::InitNodeInfo().run_on_function(f);
+    }
+
+    ngraph::pass::Manager manager;
+    manager.register_pass<ngraph::pass::InitNodeInfo>();
+    // WA: ConvertPriorBox must be executed before the 1st ConstantFolding pass
+    manager.register_pass<ngraph::pass::ConvertPriorBox>();
+    manager.register_pass<ngraph::pass::CommonOptimizations>();
+    manager.register_pass<ngraph::pass::ConvertOpSet3ToOpSet2>();
+    manager.register_pass<ngraph::pass::ConvertOpSet2ToOpSet1>();
+
+    std::vector<std::pair<ngraph::element::Type, ngraph::element::Type>> convert_precision_list {
+            {ngraph::element::i64, ngraph::element::i32},
+            {ngraph::element::u64, ngraph::element::i32},
+            {ngraph::element::u16, ngraph::element::i32},
+            {ngraph::element::u32, ngraph::element::i32},
+            {ngraph::element::f16, ngraph::element::f32},
+            {ngraph::element::boolean, ngraph::element::u8},
+    };
+
+    for (auto & precision : convert_precision_list) {
+        manager.register_pass<ngraph::pass::ConvertPrecision>(precision.first, precision.second);
+    }
+
+    manager.register_pass<ngraph::pass::ConvertOpSet1ToLegacy>();
+    manager.register_pass<ngraph::pass::ConvertPrecision>(ngraph::element::i64, ngraph::element::i32);
+
+    manager.run_passes(f);
+
+    InferenceEngine::CNNNetwork nGraphImpl(f);
+    nGraphImpl = CNNNetwork(InferenceEngine::details::convertFunctionToICNNNetwork(f, nGraphImpl));
+
+    try {
+        OutputsDataMap outputs = nGraphImpl.getOutputsInfo();
+        ASSERT_EQ(outputs.size(), 1);
+        ASSERT_EQ(outputs.begin()->first, "topK.1");
+    } catch (InferenceEngine::details::InferenceEngineException &err) {
+        const std::string ref_msg = "Error of validate layer: prelu with type: PReLU. Number of inputs (2) is not equal to expected ones: 1";
+        const std::string resp_msg = err.what();
+        ASSERT_TRUE(resp_msg.find(ref_msg) != std::string::npos) << resp_msg;
+    }
+}

--- a/inference-engine/tests/functional/inference_engine/cnn_network/convert_ngraph_to_cnn_network_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/cnn_network/convert_ngraph_to_cnn_network_tests.cpp
@@ -3,6 +3,7 @@
 //
 
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include <cpp/ie_cnn_network.h>
 #include <legacy/cnn_network_impl.hpp>  // deprecated API
@@ -208,58 +209,30 @@ TEST(ConvertFunctionToCNNNetworkTests, ConvertTopKWithOneInput) {
     }
 }
 
-TEST(ConvertFunctionToCNNNetworkTests, ConvertTopKWithOneInput) {
+TEST(ConvertFunctionToCNNNetworkTests, UnsupportedDynamicOps) {
     std::shared_ptr<ngraph::Function> f;
     {
-        auto param = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 22, 22});
-        ngraph::Shape const_shape = {};
-        std::vector<int64_t> val = {5};
-        auto k = std::make_shared<ngraph::opset4::Constant>(ngraph::element::i64, const_shape, val);
-        auto topK = std::make_shared<ngraph::opset4::TopK>(param, k, 2, ngraph::opset4::TopK::Mode::MAX, ngraph::opset4::TopK::SortType::SORT_VALUES);
-        topK->set_friendly_name("topK");
-        auto result = std::make_shared<ngraph::op::Result>(topK->output(1));
+        auto param = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic());
+        param->set_friendly_name("param");
+        auto relu = std::make_shared<ngraph::opset4::Relu>(param);
+        relu->set_friendly_name("relu");
+        auto non_zero = std::make_shared<ngraph::opset4::NonZero>(relu);
+        non_zero->set_friendly_name("non_zero");
+        auto result = std::make_shared<ngraph::op::Result>(non_zero->output(0));
 
         f = std::make_shared<ngraph::Function>(ngraph::ResultVector{result},
                                                ngraph::ParameterVector{param});
-        ngraph::pass::InitNodeInfo().run_on_function(f);
     }
-
-    ngraph::pass::Manager manager;
-    manager.register_pass<ngraph::pass::InitNodeInfo>();
-    // WA: ConvertPriorBox must be executed before the 1st ConstantFolding pass
-    manager.register_pass<ngraph::pass::ConvertPriorBox>();
-    manager.register_pass<ngraph::pass::CommonOptimizations>();
-    manager.register_pass<ngraph::pass::ConvertOpSet3ToOpSet2>();
-    manager.register_pass<ngraph::pass::ConvertOpSet2ToOpSet1>();
-
-    std::vector<std::pair<ngraph::element::Type, ngraph::element::Type>> convert_precision_list {
-            {ngraph::element::i64, ngraph::element::i32},
-            {ngraph::element::u64, ngraph::element::i32},
-            {ngraph::element::u16, ngraph::element::i32},
-            {ngraph::element::u32, ngraph::element::i32},
-            {ngraph::element::f16, ngraph::element::f32},
-            {ngraph::element::boolean, ngraph::element::u8},
-    };
-
-    for (auto & precision : convert_precision_list) {
-        manager.register_pass<ngraph::pass::ConvertPrecision>(precision.first, precision.second);
-    }
-
-    manager.register_pass<ngraph::pass::ConvertOpSet1ToLegacy>();
-    manager.register_pass<ngraph::pass::ConvertPrecision>(ngraph::element::i64, ngraph::element::i32);
-
-    manager.run_passes(f);
 
     InferenceEngine::CNNNetwork nGraphImpl(f);
-    nGraphImpl = CNNNetwork(InferenceEngine::details::convertFunctionToICNNNetwork(f, nGraphImpl));
-
     try {
-        OutputsDataMap outputs = nGraphImpl.getOutputsInfo();
-        ASSERT_EQ(outputs.size(), 1);
-        ASSERT_EQ(outputs.begin()->first, "topK.1");
-    } catch (InferenceEngine::details::InferenceEngineException &err) {
-        const std::string ref_msg = "Error of validate layer: prelu with type: PReLU. Number of inputs (2) is not equal to expected ones: 1";
-        const std::string resp_msg = err.what();
-        ASSERT_TRUE(resp_msg.find(ref_msg) != std::string::npos) << resp_msg;
+        InferenceEngine::details::convertFunctionToICNNNetwork(f, nGraphImpl);
+        FAIL() << "InferenceEngineException must be thrown";
+    } catch(InferenceEngine::details::InferenceEngineException & e) {
+        EXPECT_THAT(e.what(), testing::HasSubstr(std::string("Unsupported dynamic ops: \n"
+                                                             "v0::Parameter param () -> (f32?)\n"
+                                                             "v0::Relu relu (param[0]:f32?) -> (f32?)\n"
+                                                             "v3::NonZero non_zero (relu[0]:f32?) -> (i64{?,?})\n"
+                                                             "v0::Result Result_12 (non_zero[0]:i64{?,?}) -> (i64{?,?})")));
     }
 }


### PR DESCRIPTION
In this PR I updated `convertFunctionToCNNNetwork` to check that if function contains dynamic operations it will throw a detailed exception with the list of dynamic operations.