### PR TITLE
[IE][VPU][GT]: Introduce Split by dynamic dimension check

### DIFF
--- a/ngraph/core/include/ngraph/validation_util.hpp
+++ b/ngraph/core/include/ngraph/validation_util.hpp
@@ -144,6 +144,7 @@ namespace ngraph
     /// \return    Checking if axis is in range [-tensor_rank, tensor_rank-1], otherwise
     ///            returns error. If negative axis, it counts from the last to the first axis,
     ///            by adding tensor_rank to axis.
+    NGRAPH_API
     int64_t normalize_axis(const Node* node, std::int64_t axis, const Rank& tensor_rank);
 
     /// \brief      Handle out of range axes in vector.


### PR DESCRIPTION
# Task

#-41568

# Description

At the moment, myriad plugin does not support split operation by dynamic axis. To be sure there is no issue with optimized-out
split operation which should have been replaced with copy stage - assertion before DTS transformation is introduced.

Check should be performed before loop with DTS transformations because it requires dynamic context (dynamic dimension should be visible as dynamic), otherwise dynamic dimension would be replaced with upper-bound estimation and check will always pass.