### PR TITLE
[LPT] Apple clang version 12.0.0 (clang-1200.0.32.2) compilation support

### DIFF
--- a/inference-engine/src/transformations/include/transformations/low_precision/fake_quantize.hpp
+++ b/inference-engine/src/transformations/include/transformations/low_precision/fake_quantize.hpp
@@ -26,6 +26,10 @@ private:
     std::shared_ptr<opset1::FakeQuantize> fuseElementwise(
         TransformationContext& context,
         const std::shared_ptr<opset1::FakeQuantize>& fakeQuantize) const;
+
+    static std::shared_ptr<Node> updateShape(std::shared_ptr<Node> op, const Shape& targetShape);
+    static std::shared_ptr<Node> getData(const std::shared_ptr<Node>& eltwise);
+    static std::shared_ptr<opset1::Constant> getConstant(const std::shared_ptr<Node>& eltwise);
 };
 
 } // namespace low_precision

--- a/inference-engine/src/transformations/include/transformations/low_precision/fuse_fake_quantize.hpp
+++ b/inference-engine/src/transformations/include/transformations/low_precision/fuse_fake_quantize.hpp
@@ -24,6 +24,11 @@ private:
     std::shared_ptr<opset1::FakeQuantize> handle(
         TransformationContext& context,
         const std::shared_ptr<opset1::FakeQuantize>& fakeQuantize) const;
+
+    static std::shared_ptr<Node> updateShape(std::shared_ptr<Node> op, const Shape& targetShape);
+    static std::shared_ptr<Node> getData(const std::shared_ptr<Node>& eltwise);
+    static std::shared_ptr<opset1::Constant> getConstant(const std::shared_ptr<Node>& eltwise);
+    static bool eltwiseWithConstant(const std::shared_ptr<Node>& eltwise);
 };
 
 } // namespace low_precision

--- a/inference-engine/src/transformations/include/transformations/low_precision/network_helper.hpp
+++ b/inference-engine/src/transformations/include/transformations/low_precision/network_helper.hpp
@@ -160,6 +160,19 @@ public:
     // handles only specific case: Constant -> [dequantization operations] -> [node]
     static void foldDequantization(std::shared_ptr<Node>& node, const size_t branchIndex, const bool inPlace = false);
 
+    template<typename T>
+    static std::shared_ptr<ngraph::op::Constant> createSignConstant(const ngraph::op::Constant& originalConst) {
+        std::vector<T> source = originalConst.cast_vector<T>();
+
+        std::vector<T> newData(source.size());
+        for (size_t i = 0; i < source.size(); ++i) {
+            newData[i] = source[i] < 0 ? -1 : 1;
+        }
+
+        const ngraph::element::Type type = originalConst.get_output_element_type(0);
+        return ngraph::op::Constant::create(type, originalConst.get_shape(), newData);
+    }
+
 private:
     static std::shared_ptr<Node> foldFakeQuantize(const std::shared_ptr<opset1::FakeQuantize>& fq, const bool roundValues, const bool roundValuesWasSet);
 

--- a/inference-engine/src/transformations/src/transformations/low_precision/fake_quantize.cpp
+++ b/inference-engine/src/transformations/src/transformations/low_precision/fake_quantize.cpp
@@ -119,7 +119,7 @@ bool FakeQuantizeTransformation::transform(TransformationContext& context, ngrap
     return true;
 }
 
-static std::shared_ptr<Node> updateShape(std::shared_ptr<Node> op, const Shape& targetShape) {
+std::shared_ptr<Node> FakeQuantizeTransformation::updateShape(std::shared_ptr<Node> op, const Shape& targetShape) {
     const Shape shape = op->get_output_shape(0);
     if ((shape.size() < targetShape.size()) && (shape.size() > 1ul)) {
         op = fold<opset1::Unsqueeze>(
@@ -129,7 +129,7 @@ static std::shared_ptr<Node> updateShape(std::shared_ptr<Node> op, const Shape& 
     return op;
 }
 
-static std::shared_ptr<Node> getData(const std::shared_ptr<Node>& eltwise) {
+std::shared_ptr<Node> FakeQuantizeTransformation::getData(const std::shared_ptr<Node>& eltwise) {
     if (!is_type<opset1::Constant>(eltwise->get_input_node_shared_ptr(0))) {
         return eltwise->get_input_node_shared_ptr(0);
     }
@@ -141,7 +141,7 @@ static std::shared_ptr<Node> getData(const std::shared_ptr<Node>& eltwise) {
     return nullptr;
 }
 
-static std::shared_ptr<opset1::Constant> getConstant(const std::shared_ptr<Node>& eltwise) {
+std::shared_ptr<opset1::Constant> FakeQuantizeTransformation::getConstant(const std::shared_ptr<Node>& eltwise) {
     if (eltwise->get_input_size() != 2) {
         return nullptr;
     }

--- a/inference-engine/src/transformations/src/transformations/low_precision/fuse_fake_quantize.cpp
+++ b/inference-engine/src/transformations/src/transformations/low_precision/fuse_fake_quantize.cpp
@@ -24,7 +24,7 @@ bool FuseFakeQuantizeTransformation::transform(TransformationContext& context, n
     return true;
 }
 
-std::shared_ptr<Node> updateShape(std::shared_ptr<Node> op, const Shape& targetShape) {
+std::shared_ptr<Node> FuseFakeQuantizeTransformation::updateShape(std::shared_ptr<Node> op, const Shape& targetShape) {
     const Shape shape = op->get_output_shape(0);
     if ((shape.size() < targetShape.size()) && (shape.size() > 1ul)) {
         op = fold<opset1::Unsqueeze>(
@@ -34,7 +34,7 @@ std::shared_ptr<Node> updateShape(std::shared_ptr<Node> op, const Shape& targetS
     return op;
 }
 
-std::shared_ptr<Node> getData(const std::shared_ptr<Node>& eltwise) {
+std::shared_ptr<Node> FuseFakeQuantizeTransformation::getData(const std::shared_ptr<Node>& eltwise) {
     if (!is_type<opset1::Constant>(eltwise->get_input_node_shared_ptr(0))) {
         return eltwise->get_input_node_shared_ptr(0);
     }
@@ -46,7 +46,7 @@ std::shared_ptr<Node> getData(const std::shared_ptr<Node>& eltwise) {
     return nullptr;
 }
 
-std::shared_ptr<opset1::Constant> getConstant(const std::shared_ptr<Node>& eltwise) {
+std::shared_ptr<opset1::Constant> FuseFakeQuantizeTransformation::getConstant(const std::shared_ptr<Node>& eltwise) {
     if (eltwise->get_input_size() != 2) {
         return nullptr;
     }
@@ -59,7 +59,7 @@ std::shared_ptr<opset1::Constant> getConstant(const std::shared_ptr<Node>& eltwi
     return as_type_ptr<opset1::Constant>(eltwise->get_input_node_shared_ptr(0));
 }
 
-bool eltwiseWithConstant(const std::shared_ptr<Node>& eltwise) {
+bool FuseFakeQuantizeTransformation::eltwiseWithConstant(const std::shared_ptr<Node>& eltwise) {
     std::shared_ptr<opset1::Constant> constant = getConstant(eltwise);
     if (constant == nullptr) {
         return false;

--- a/inference-engine/src/transformations/src/transformations/low_precision/mvn.cpp
+++ b/inference-engine/src/transformations/src/transformations/low_precision/mvn.cpp
@@ -18,23 +18,6 @@ using namespace ngraph;
 using namespace ngraph::pass;
 using namespace ngraph::pass::low_precision;
 
-namespace {
-
-template<typename T>
-std::shared_ptr<ngraph::op::Constant> createNewScalesConst(const ngraph::op::Constant& originalConst) {
-    std::vector<T> source = originalConst.cast_vector<T>();
-
-    std::vector<T> newData(source.size());
-    for (size_t i = 0; i < source.size(); ++i) {
-        newData[i] = source[i] < 0 ? -1 : 1;
-    }
-
-    const ngraph::element::Type type = originalConst.get_output_element_type(0);
-    return ngraph::op::Constant::create(type, originalConst.get_shape(), newData);
-}
-
-} // namespace
-
 bool MVNTransformation::canBeTransformed(const TransformationContext& context, std::shared_ptr<Node> operation) const {
     if (!LayerTransformation::canBeTransformed(context, operation)) {
         return false;
@@ -93,11 +76,11 @@ bool MVNTransformation::transform(TransformationContext &context, ngraph::patter
     if (normalizeVariance) {
         switch (type) {
             case ngraph::element::Type_t::f16: {
-                newScalesConst = createNewScalesConst<ngraph::element_type_traits<ngraph::element::Type_t::f16>::value_type>(*scalesConst);
+                newScalesConst = NetworkHelper::createSignConstant<ngraph::element_type_traits<ngraph::element::Type_t::f16>::value_type>(*scalesConst);
                 break;
             }
             case ngraph::element::Type_t::f32: {
-                newScalesConst = createNewScalesConst<ngraph::element_type_traits<ngraph::element::Type_t::f32>::value_type>(*scalesConst);
+                newScalesConst = NetworkHelper::createSignConstant<ngraph::element_type_traits<ngraph::element::Type_t::f32>::value_type>(*scalesConst);
                 break;
             }
             default: {

--- a/inference-engine/src/transformations/src/transformations/low_precision/normalize_l2.cpp
+++ b/inference-engine/src/transformations/src/transformations/low_precision/normalize_l2.cpp
@@ -17,23 +17,6 @@ using namespace ngraph;
 using namespace ngraph::pass;
 using namespace ngraph::pass::low_precision;
 
-namespace {
-
-template<typename T>
-std::shared_ptr<ngraph::op::Constant> createNewScalesConst(const ngraph::op::Constant& originalConst) {
-    std::vector<T> source = originalConst.cast_vector<T>();
-
-    std::vector<T> newData(source.size());
-    for (size_t i = 0; i < source.size(); ++i) {
-        newData[i] = source[i] < 0 ? -1 : 1;
-    }
-
-    const ngraph::element::Type type = originalConst.get_output_element_type(0);
-    return ngraph::op::Constant::create(type, originalConst.get_shape(), newData);
-}
-
-} // namespace
-
 bool NormalizeL2Transformation::canBeTransformed(const TransformationContext& context, std::shared_ptr<Node> operation) const {
     if (!LayerTransformation::canBeTransformed(context, operation)) {
         return false;
@@ -106,11 +89,11 @@ bool NormalizeL2Transformation::transform(TransformationContext &context, ngraph
     const auto type = scalesConst->get_output_element_type(0);
     switch (type) {
         case ngraph::element::Type_t::f16: {
-            newScalesConst = createNewScalesConst<ngraph::element_type_traits<ngraph::element::Type_t::f16>::value_type>(*scalesConst);
+            newScalesConst = NetworkHelper::createSignConstant<ngraph::element_type_traits<ngraph::element::Type_t::f16>::value_type>(*scalesConst);
             break;
         }
         case ngraph::element::Type_t::f32: {
-            newScalesConst = createNewScalesConst<ngraph::element_type_traits<ngraph::element::Type_t::f32>::value_type>(*scalesConst);
+            newScalesConst = NetworkHelper::createSignConstant<ngraph::element_type_traits<ngraph::element::Type_t::f32>::value_type>(*scalesConst);
             break;
         }
         default: {


### PR DESCRIPTION
Redefinition of functions (`createNewScalesConst`) from unnamed namespaces issues fix. 
Specific environment:
* Apple clang version 12.0.0 (clang-1200.0.32.2)  
* Target: x86_64-apple-darwin19.6.0  
