### PR TITLE
[GNA] Fake quantisation layer support for int-8 mode for GNA plugin

### DIFF
--- a/inference-engine/src/gna_plugin/backend/dnn_types.h
+++ b/inference-engine/src/gna_plugin/backend/dnn_types.h
@@ -45,14 +45,15 @@ struct DnnActivation {
         } pow;
         struct {
             int32_t levels;
-            float input_low;
-            float input_high;
-            float output_low;
-            float output_high;
+            // if input is perchannel quantisation - input pointers contains per-channer ranges
+            int8_t  inputPerChannel;
+            float  *input_low;
+            float  *input_high;
+            // if output is perchannel quantisation - output pointers contains per-channer ranges
+            int8_t  outputPerChannel;
+            float  *output_low;
+            float  *output_high;
         } fakeQuantize;
-        struct {
-            float reserved[5];
-        };
     } args;
     operator DnnActivationType () const noexcept {
         return type;

--- a/inference-engine/src/gna_plugin/backend/dnn_types.h
+++ b/inference-engine/src/gna_plugin/backend/dnn_types.h
@@ -45,11 +45,11 @@ struct DnnActivation {
         } pow;
         struct {
             int32_t levels;
-            // if input is perchannel quantisation - input pointers contains per-channer ranges
+            // if input is per-channel quantization - input pointers contains per-channel ranges
             int8_t  inputPerChannel;
             float  *input_low;
             float  *input_high;
-            // if output is perchannel quantisation - output pointers contains per-channer ranges
+            // if output is per-channel quantization - output pointers contains per-channel ranges
             int8_t  outputPerChannel;
             float  *output_low;
             float  *output_high;

--- a/inference-engine/src/gna_plugin/descriptions/gna_flags.hpp
+++ b/inference-engine/src/gna_plugin/descriptions/gna_flags.hpp
@@ -15,6 +15,7 @@ struct GNAFlags {
     bool uniformPwlDesign = false;
     bool gna_openmp_multithreading = false;
     bool sw_fp32 = false;
+    bool fake_quantized = false;
     bool performance_counting = false;
 };
 }  // namespace GNAPluginNS

--- a/inference-engine/src/gna_plugin/frontend/quantization.h
+++ b/inference-engine/src/gna_plugin/frontend/quantization.h
@@ -16,25 +16,34 @@
 #define MAX_VAL_2B_WEIGHT 16384
 #define MAX_VAL_2B_FEAT 16384
 #define MAX_VAL_4B_BIAS 1073741824
-#ifdef DEBUG
-#define QUANTWARNING(...) (fprintf(stderr, __VA_ARGS__))
-#else
-#define QUANTWARNING(...)
-#endif
 
-void QuantizeAffine16(float *ptr_float_weights,
-                      float *ptr_float_biases,
-                      int16_t *ptr_int_weights,
-                      int32_t *ptr_int_biases,
-                      float input_scale_factor,
-                      float *ptr_weight_scale_factor,
-                      float *ptr_output_scale_factor,
-                      uint32_t num_rows,
-                      uint32_t num_columns,
-                      uint32_t num_rows_padded,
-                      uint32_t num_columns_padded);
+template <class WeightsType,  class BiasType>
+struct QuantizationCallback {
+    float *ptr_float_weights;
+    float *ptr_float_biases;
+    WeightsType* ptr_int_weights;
+    BiasType* ptr_int_biases;
+    float input_scale_factor;
+    float *ptr_weight_scale_factor;
+    float *ptr_output_scale_factor;
+    uint32_t num_rows;
+    uint32_t num_columns;
+    uint32_t num_rows_padded;
+    uint32_t num_columns_padded;
+
+    // TODO: copied from fake quantize activation
+    int32_t fq_levels;
+    float  *fq_ptr_input_low;
+    float  *fq_ptr_input_high;
+    float  *fq_ptr_output_low;
+    float  *fq_ptr_output_high;
+
+    void runQuantize() const;
+    void runFakeQuantize() const;
+};
+
+template class QuantizationCallback<int16_t, int32_t>;
+template class QuantizationCallback<int8_t, gna_compound_bias_t>;
+
 float ScaleFactorForQuantization(void *ptr_float_memory, float target_max, size_t num_elements);
 void QuantizeVector16(float *ptr_float_memory, int16_t *ptr_int_memory, uint32_t num_elements, float scale_factor);
-void QuantizeAffine8(float *ptr_float_weights, float *ptr_float_biases, int8_t *ptr_int_weights, gna_compound_bias_t *ptr_int_biases,
-                     float input_scale_factor, float *ptr_weight_scale_factor, float *ptr_output_scale_factor,
-                     uint32_t num_rows, uint32_t num_columns, uint32_t num_rows_padded, uint32_t num_columns_padded);

--- a/inference-engine/src/gna_plugin/frontend/quantized_layer_params.hpp
+++ b/inference-engine/src/gna_plugin/frontend/quantized_layer_params.hpp
@@ -15,6 +15,9 @@ struct Quantization {
 struct QuantizedLayerParams {
     Quantization _src_quant;
     Quantization _dst_quant;
+    // per channel weights quant data
+    std::vector<Quantization> _weights_quants;
+    // deprecate this
     Quantization _weights_quant;
     Quantization _bias_quant;
     float _o_shift = 0.0f;

--- a/inference-engine/src/gna_plugin/frontend/quantized_layer_params.hpp
+++ b/inference-engine/src/gna_plugin/frontend/quantized_layer_params.hpp
@@ -15,8 +15,12 @@ struct Quantization {
 struct QuantizedLayerParams {
     Quantization _src_quant;
     Quantization _dst_quant;
+
     // per channel weights quant data
-    std::vector<Quantization> _weights_quants;
+    int32_t levels;
+    std::vector<float> _weights_quants_min;
+    std::vector<float> _weights_quants_max;
+
     // deprecate this
     Quantization _weights_quant;
     Quantization _bias_quant;

--- a/inference-engine/src/gna_plugin/gna_plugin.cpp
+++ b/inference-engine/src/gna_plugin/gna_plugin.cpp
@@ -372,6 +372,8 @@ void GNAPlugin::UpdateGnaQuantModeFromNetwork(InferenceEngine::ICNNNetwork & net
         if (fqLayer.getLevels() == int8Levels) {
             config.gnaPrecision = InferenceEngine::Precision::I8;
         }
+        gnaFlags->fake_quantized = true;
+        config.gnaFlags.fake_quantized = true;
     }
 }
 
@@ -405,6 +407,7 @@ void GNAPlugin::UpdateInputScaleFromNetwork(InferenceEngine::ICNNNetwork & netwo
 
             // TODO: proper mapping into scale factors
             config.inputScaleFactors[inputIdx] = 1 / scaleInput;
+            inputsDesc->inputScaleFactors[inputIdx] = 1 / scaleInput;
 
             inputIdx++;
         }
@@ -482,6 +485,19 @@ void GNAPlugin::LoadNetwork(ICNNNetwork & _network) {
         // to run all passes need to have two calls to pass manager
         run_passes(newNet, true);
         run_passes(newNet, false);
+    } else if (gnaFlags->fake_quantized) {
+        switch (config.gnaPrecision) {
+            case Precision::I16:
+                ModelQuantizer<FakeQuantI16> q16;
+                newNet = q16.quantize(network, run_passes, inputsDesc->inputScaleFactors);
+                break;
+            case Precision::I8:
+                ModelQuantizer<FakeQuantI8> q8;
+                newNet = q8.quantize(network, run_passes, inputsDesc->inputScaleFactors);
+                break;
+            default:
+                THROW_GNA_EXCEPTION << "unsupported GNA precision for quantisation: " << config.gnaPrecision;
+        }
     } else {
         switch (config.gnaPrecision) {
             case Precision::I16:
@@ -493,8 +509,7 @@ void GNAPlugin::LoadNetwork(ICNNNetwork & _network) {
                 newNet = q8.quantize(network, run_passes, inputsDesc->inputScaleFactors);
                 break;
             default:
-                THROW_GNA_EXCEPTION << "no mans land for GNA precision";
-                break;
+                THROW_GNA_EXCEPTION << "unsupported GNA precision for quantisation: " << config.gnaPrecision;
         }
     }
 
@@ -1044,7 +1059,7 @@ uint32_t GNAPlugin::QueueInference(const InferenceEngine::BlobMap &inputs, Infer
 #ifdef PLOT
     dnn->BeginNewWrite(dnn_dump_write_index);
     if (dnn->num_components() != 0) {
-        dnn->WriteDnnText("Net_.txt", kDnnFloat);
+        dnn->WriteDnnText("Net_.txt", kDnnInt);
     }
     dnn_dump_write_index++;
 #endif

--- a/inference-engine/src/gna_plugin/gna_plugin.cpp
+++ b/inference-engine/src/gna_plugin/gna_plugin.cpp
@@ -367,6 +367,9 @@ void GNAPlugin::LoadNetwork(ICNNNetwork & _network) {
         passes->registerPass<UnrollLSTMCellPass>();
         passes->registerPass<RemoveSingleInputConcatPass>();
 
+        // fake quantisation aware passes
+        passes->registerPass<FuseFQIntoWeightsPass>();
+
         passes->registerPass<SubstitutePReluPass>();
         passes->registerPass<SubstituteSoftSignPass>();
 

--- a/inference-engine/src/gna_plugin/gna_plugin.hpp
+++ b/inference-engine/src/gna_plugin/gna_plugin.hpp
@@ -221,6 +221,8 @@ class GNAPlugin : public InferenceEngine::IInferencePlugin {
                     int idx = 0);
 
     void UpdateFieldsFromConfig();
+    void UpdateGnaQuantModeFromNetwork(InferenceEngine::ICNNNetwork &);
+    void UpdateInputScaleFromNetwork(InferenceEngine::ICNNNetwork &);
 };
 
 }  // namespace GNAPluginNS

--- a/inference-engine/src/gna_plugin/gna_plugin_log.hpp
+++ b/inference-engine/src/gna_plugin/gna_plugin_log.hpp
@@ -72,5 +72,5 @@ if (!(expr)) { \
 }
 #define THROW_GNA_EXCEPTION THROW_IE_EXCEPTION << "[GNAPlugin] in function " << __PRETTY_FUNCTION__<< ": "
 #define THROW_GNA_LAYER_EXCEPTION(layer) THROW_GNA_EXCEPTION << LAYER_NAME(layer)
-#define LAYER_NAME(layer) layer->type << " layer : \"" << layer->name << "\" "
+#define LAYER_NAME(layer) (layer)->type << " layer : \"" << (layer)->name << "\" "
 

--- a/inference-engine/src/gna_plugin/layers/gna_fake_quantize_layer.hpp
+++ b/inference-engine/src/gna_plugin/layers/gna_fake_quantize_layer.hpp
@@ -1,0 +1,81 @@
+// Copyright (C) 2018-2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+#pragma once
+
+#include "gna_layer_info.hpp"
+#include "gna_plugin_log.hpp"
+#include "gna_layer_helpers.hpp"
+
+#include <ie_algorithm.hpp>
+
+namespace GNAPluginNS {
+class GNAFakeQuantizeLayer {
+    InferenceEngine::CNNLayerPtr fqLayer;
+ public :
+    GNAFakeQuantizeLayer(InferenceEngine::CNNLayerPtr fqLayer)
+        : fqLayer(fqLayer) {}
+
+    /**
+     * @brief convert FQ layer directly to gna-pwl activation layer
+     */
+    DnnActivation parseAsActivation() const {
+        DnnActivation fqActivation;
+        if (!LayerInfo(fqLayer).isFakeQuantize()) {
+            THROW_GNA_LAYER_EXCEPTION(fqLayer) << "cannot parse as fake quantize";
+        }
+        fqActivation.args.fakeQuantize.levels      = fqLayer->GetParamAsInt("levels");
+        auto inputShape  = getShapeForRange(fqLayer, 1);
+        auto outputShape = getShapeForRange(fqLayer, 3);
+
+        // TODO: check shapes broadcasting to shape of input at 0
+        auto inputRangeSize = InferenceEngine::details::product(inputShape.begin(), inputShape.end());
+        auto outputRangeSize = InferenceEngine::details::product(outputShape.begin(), outputShape.end());
+
+        fqActivation.args.fakeQuantize.inputPerChannel = inputRangeSize != 1;
+        fqActivation.args.fakeQuantize.input_low   = getParamFromInputAsFloats(fqLayer, 1);
+        fqActivation.args.fakeQuantize.input_high  = getParamFromInputAsFloats(fqLayer, 2);
+
+        fqActivation.args.fakeQuantize.outputPerChannel = outputRangeSize != 1;
+        fqActivation.args.fakeQuantize.output_low  = getParamFromInputAsFloats(fqLayer, 3);
+        fqActivation.args.fakeQuantize.output_high = getParamFromInputAsFloats(fqLayer, 4);
+        fqActivation.type = kActFakeQuantize;
+
+        return fqActivation;
+     }
+     /**
+      * retrieves input blob for FQ layer that connected to const layer
+      */
+     InferenceEngine::Blob::Ptr getConstInputData() const {
+         return LayerUtils::getParamFromInputAsBlob(fqLayer, 0);
+     }
+
+ protected :
+
+    static float*  getParamFromInputAsFloats(InferenceEngine::CNNLayerPtr input, size_t idx) {
+        auto data = LayerUtils::getParamFromInputAsBlob(input, idx);
+        return data->buffer().as<float*>();
+    }
+
+    static InferenceEngine::SizeVector  getShapeFromInput(InferenceEngine::CNNLayerPtr input, size_t idx) {
+        auto data = LayerUtils::getParamFromInputAsBlob(input, idx);
+        return data->getTensorDesc().getDims();
+    }
+
+    static InferenceEngine::SizeVector getShapeForRange(InferenceEngine::CNNLayerPtr input, size_t idx) {
+        auto lowShape  = getShapeFromInput(input, idx);
+        auto highShape = getShapeFromInput(input, idx + 1);
+        if (lowShape.size() != highShape.size()) {
+            THROW_GNA_LAYER_EXCEPTION(input) << "shapes mismatch for " << idx << " and " << idx + 1 << " inputs";
+        }
+        for (size_t i = 0; i != lowShape.size(); i++) {
+            if (lowShape[i] != highShape[i]) {
+                THROW_GNA_LAYER_EXCEPTION(input) << "shapes mismatch for " << idx << " and " << idx + 1 << " inputs";
+            }
+        }
+        return lowShape;
+     }
+};
+}  // namespace GNAPluginNS

--- a/inference-engine/src/gna_plugin/layers/gna_layer_helpers.hpp
+++ b/inference-engine/src/gna_plugin/layers/gna_layer_helpers.hpp
@@ -1,0 +1,48 @@
+// Copyright (C) 2018-2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+#pragma once
+
+#include "gna_layer_info.hpp"
+#include "gna_plugin_log.hpp"
+
+namespace GNAPluginNS {
+namespace LayerUtils {
+/**
+ * @brief retrievs blob from const layer connected to certain layer
+ * @param input
+ * @param idx
+ */
+inline InferenceEngine::Blob::Ptr getParamFromInputAsBlob(InferenceEngine::CNNLayerPtr input, size_t idx) {
+    if (input->insData.size() <= idx) {
+        THROW_GNA_LAYER_EXCEPTION(input) << "cannot get data from " << idx << "input";
+    }
+    auto iLayerData = input->insData[idx].lock();
+    if (!iLayerData) {
+        THROW_GNA_LAYER_EXCEPTION(input) << "cannot get data from " << idx
+                                         << ", input: cannot dereference data weak-pointer";
+    }
+    auto iLayer = getCreatorLayer(iLayerData).lock();
+    if (!iLayer) {
+        THROW_GNA_LAYER_EXCEPTION(input) << "cannot get data from " << idx
+                                         << ", input: cannot dereference creator layer weak-pointer";
+    }
+    if (!LayerInfo(iLayer).isConst()) {
+        THROW_GNA_LAYER_EXCEPTION(input) << "cannot get data from " << idx
+                                         << ", input: expected to be of type const, but was: " << iLayer->type;
+    }
+
+    if (!iLayer->blobs.count("custom")) {
+        THROW_GNA_LAYER_EXCEPTION(iLayer) << "cannot get custom blob";
+    }
+    auto data = iLayer->blobs["custom"];
+    if (data->getTensorDesc().getPrecision() != InferenceEngine::Precision::FP32) {
+        THROW_GNA_LAYER_EXCEPTION(iLayer) << "cannot cast custom blob to type FP32, since it is of type: "
+                                          << data->getTensorDesc().getPrecision();
+    }
+    return data;
+}
+}  // namespace LayerUtils
+}  // namespace GNAPluginNS

--- a/inference-engine/src/gna_plugin/layers/gna_layer_info.hpp
+++ b/inference-engine/src/gna_plugin/layers/gna_layer_info.hpp
@@ -205,8 +205,8 @@ class LayerInfo {
     bool isConcat() const noexcept {
         return isOfType("concat");
     }
-    bool isFakeQnatize() const noexcept {
-        return isOfType("FakeQnatize");
+    bool isFakeQuantize() const noexcept {
+        return isOfType("FakeQuantize");
     }
     bool isNonFunctional() const noexcept {
         return isOfType("reshape") || isOfType("squeeze") || isOfType("unsqueeze") || isTrivialPermute();

--- a/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.hpp
+++ b/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.hpp
@@ -185,6 +185,11 @@ DECL_PASS(BroadcastConst);
 */
 DECL_PASS(FuseFQIntoWeights);
 
+/**
+* @brief remove all fake quantize layers while moving it's settings into QuantParams for certain layer
+*/
+DECL_PASS(MoveFakeQuantizeLayerIntoQuantParams);
+
 
 struct PassManagerSettings {
     Policy policy;

--- a/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.hpp
+++ b/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.hpp
@@ -180,6 +180,12 @@ DECL_PASS(FuseMultipleIdentities);
 */
 DECL_PASS(BroadcastConst);
 
+/**
+* @brief runs static quantisation on given floating weights and replaces fakeQuantize with constblobs
+*/
+DECL_PASS(FuseFQIntoWeights);
+
+
 struct PassManagerSettings {
     Policy policy;
     /// @brief whether to run passes before copy

--- a/inference-engine/src/gna_plugin/runtime/pwl.cpp
+++ b/inference-engine/src/gna_plugin/runtime/pwl.cpp
@@ -1047,25 +1047,32 @@ void PwlApply32(intel_dnn_component_t *component,
             }
             break;
         case kActFakeQuantize: {
-            auto input_low   = transform->func_id.args.fakeQuantize.input_low;
-            auto input_high  = transform->func_id.args.fakeQuantize.input_high;
-            auto output_low  = transform->func_id.args.fakeQuantize.output_low;
-            auto output_high = transform->func_id.args.fakeQuantize.output_high;
             auto levels  = transform->func_id.args.fakeQuantize.levels;
-            // TODO: this special modification for spedup-compute give different result with straight FQ forulae
-            // but this used in referencen graph FakeQuantize implementations so we need to honor it for a while
-            float scaleInput = (input_high - input_low) / (levels-1);
-            float scaleOutputs = (output_high - output_low) / (levels-1);
 
             for (uint32_t i = num_row_start; i <= num_row_end; i++) {
+                auto inputChannel  = transform->func_id.args.fakeQuantize.inputPerChannel ? i : 0;
+                auto outputChannel = transform->func_id.args.fakeQuantize.outputPerChannel ? i : 0;
+
+                auto input_low   = transform->func_id.args.fakeQuantize.input_low[inputChannel];
+                auto input_high  = transform->func_id.args.fakeQuantize.input_high[inputChannel];
+                auto output_low  = transform->func_id.args.fakeQuantize.output_low[outputChannel];
+                auto output_high = transform->func_id.args.fakeQuantize.output_high[outputChannel];
+
+                // TODO: this special modification for spedup-compute give different result with straight FQ formulae
+                // but this used in reference graph FakeQuantize implementations so we need to honor it for a while
+                float scaleInput = (input_high - input_low) / (levels-1);
+                float scaleOutputs = (output_high - output_low) / (levels-1);
+
                 for (uint32_t j = num_col_start; j <= num_col_end; j++) {
-                    auto x = ptr_in[i * num_columns + j];
+                    auto offset = i * num_columns + j;
+                    auto x = ptr_in[offset];
+
                     if (x < std::min(input_low, input_high)) {
-                        ptr_out[i * num_columns + j] = output_low;
+                        ptr_out[offset] = output_low;
                     } else if (x > std::max(input_low, input_high)) {
-                        ptr_out[i * num_columns + j] = output_high;
+                        ptr_out[offset] = output_high;
                     } else {
-                        ptr_out[i * num_columns + j] = nearbyint((x - input_low) / scaleInput) * scaleOutputs + output_low;
+                        ptr_out[offset] = nearbyint((x - input_low) / scaleInput) * scaleOutputs + output_low;
                     }
                 }
             }


### PR DESCRIPTION
Currently i verified that mostly solution is working:
right now it is only 4-5x worse than in house quantization checked on WSJ topology

### current FQ based
         max error: 2.49037
         avg error: 0.175346
     avg rms error: 0.221937
       stdev error: 0.144078

### gna-plugin gold  
	 max error: 0.777118
         avg error: 0.0527347
     avg rms error: 0.0670969
       stdev error: 0.043879

remained issue is probably proper scale factor calculation for activations