### PR TITLE
Add `jsonschema` to validate test configs in test_timetest.py

### DIFF
--- a/tests/time_tests/test_runner/.automation/tgl_test_config.yml
+++ b/tests/time_tests/test_runner/.automation/tgl_test_config.yml
@@ -2,47 +2,55 @@
     name: CPU
   model:
     path: ${VPUX_MODELS_PKG}/resnet-50-pytorch/caffe2/FP16/resnet-50-pytorch.xml
+    name: resnet-50-pytorch
     precision: FP16
     framework: caffe2
 - device:
     name: GPU
   model:
     path: ${VPUX_MODELS_PKG}/resnet-50-pytorch/caffe2/FP16/resnet-50-pytorch.xml
+    name: resnet-50-pytorch
     precision: FP16
     framework: caffe2
 - device:
     name: CPU
   model:
     path: ${VPUX_MODELS_PKG}/resnet-50-pytorch/caffe2/FP16-INT8/resnet-50-pytorch.xml
+    name: resnet-50-pytorch
     precision: FP16-INT8
     framework: caffe2
 - device:
     name: GPU
   model:
     path: ${VPUX_MODELS_PKG}/resnet-50-pytorch/caffe2/FP16-INT8/resnet-50-pytorch.xml
+    name: resnet-50-pytorch
     precision: FP16-INT8
     framework: caffe2
 - device:
     name: CPU
   model:
     path: ${VPUX_MODELS_PKG}/mobilenet-v2/caffe2/FP16/mobilenet-v2.xml
+    name: mobilenet-v2
     precision: FP16
     framework: caffe2
 - device:
     name: GPU
   model:
     path: ${VPUX_MODELS_PKG}/mobilenet-v2/caffe2/FP16/mobilenet-v2.xml
+    name: mobilenet-v2
     precision: FP16
     framework: caffe2
 - device:
     name: CPU
   model:
     path: ${VPUX_MODELS_PKG}/mobilenet-v2/caffe2/FP16-INT8/mobilenet-v2.xml
+    name: mobilenet-v2
     precision: FP16-INT8
     framework: caffe2
 - device:
     name: GPU
   model:
     path: ${VPUX_MODELS_PKG}/mobilenet-v2/caffe2/FP16-INT8/mobilenet-v2.xml
+    name: mobilenet-v2
     precision: FP16-INT8
     framework: caffe2

--- a/tests/time_tests/test_runner/requirements.txt
+++ b/tests/time_tests/test_runner/requirements.txt
@@ -1,3 +1,4 @@
 pytest==4.0.1
 attrs==19.1.0   # required for pytest==4.0.1 to resolve compatibility issues
 PyYAML==5.3.1
+jsonschema==3.2.0

--- a/tests/time_tests/test_runner/test_config.yml
+++ b/tests/time_tests/test_runner/test_config.yml
@@ -2,7 +2,13 @@
     name: CPU
   model:
     path: ${SHARE}/stress_tests/master_04d6f112132f92cab563ae7655747e0359687dc9/caffe/FP32/alexnet/alexnet.xml # TODO: add link to `test_data` repo model
+    name: alexnet
+    precision: FP32
+    framework: caffe
 - device:
     name: GPU
   model:
     path: ${SHARE}/stress_tests/master_04d6f112132f92cab563ae7655747e0359687dc9/caffe/FP32/alexnet/alexnet.xml
+    name: alexnet
+    precision: FP32
+    framework: caffe

--- a/tests/time_tests/test_runner/test_timetest.py
+++ b/tests/time_tests/test_runner/test_timetest.py
@@ -25,7 +25,7 @@ from test_runner.utils import expand_env_vars
 REFS_FACTOR = 1.2      # 120%
 
 
-def test_timetest(instance, executable, niter, cl_cache_dir, test_info, temp_dir):
+def test_timetest(instance, executable, niter, cl_cache_dir, test_info, temp_dir, validate_test_case):
     """Parameterized test.
 
     :param instance: test instance. Should not be changed during test run
@@ -34,6 +34,7 @@ def test_timetest(instance, executable, niter, cl_cache_dir, test_info, temp_dir
     :param cl_cache_dir: directory to store OpenCL cache
     :param test_info: custom `test_info` field of built-in `request` pytest fixture
     :param temp_dir: path to a temporary directory. Will be cleaned up after test run
+    :param validate_test_case: custom pytest fixture. Should be declared as test argument to be enabled
     """
     # Prepare model to get model_path
     model_path = instance["model"].get("path")


### PR DESCRIPTION
1. Add checks of fields for `model` record required for correct work of web tool via `jsonschema`. If validation using schema failed, test is aborted, and data won't be submitted to a database
2. If `--db_submit` specified, several additional properties become required.