### PR TITLE
[MO] Add fusing transformation for EmbeddingBag

### DIFF
--- a/model-optimizer/automation/package_BOM.txt
+++ b/model-optimizer/automation/package_BOM.txt
@@ -120,6 +120,7 @@ extensions/front/create_tensor_nodes.py
 extensions/front/disable_weights_quantize_value_propagation.py
 extensions/front/div.py
 extensions/front/eltwise_n.py
+extensions/front/EmbeddingBagFuse.py
 extensions/front/ExpandDimsToUnsqueeze.py
 extensions/front/FillToBroadcast.py
 extensions/front/flatten_to_reshape.py

--- a/model-optimizer/extensions/front/EmbeddingBagFuse.py
+++ b/model-optimizer/extensions/front/EmbeddingBagFuse.py
@@ -1,0 +1,91 @@
+"""
+ Copyright (C) 2020 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+from extensions.ops.embedding_bag import EmbeddingBagOffsetsSum
+from mo.front.common.replacement import FrontReplacementSubgraph
+from mo.graph.graph import Graph, rename_nodes
+
+
+class EmbeddingBagFuse(FrontReplacementSubgraph):
+    enabled = True
+
+    def run_after(self):
+        from extensions.front.ExpandDimsToUnsqueeze import ExpandDimsToUnsqueeze
+        from extensions.front.AttributedGatherNormalizer import AttributedGatherNormalizer
+        return [ExpandDimsToUnsqueeze, AttributedGatherNormalizer]
+
+    def pattern(self):
+        return dict(
+            nodes=[
+                ('weights', dict(op='Const')),
+                ('concat_before', dict(op='Concat')),
+                ('gather_before1_1', dict(op='Gather')),
+                ('unsqueeze_before1_1', dict(op='Unsqueeze')),
+                ('gather_before2_1', dict(op='Gather')),
+                ('unsqueeze_before2_1', dict(op='Unsqueeze')),
+                ('slice1', dict(op='Slice')),
+                ('gather_after1', dict(op='Gather')),
+                ('reduce1', dict(op='ReduceSum')),
+                ('unsqueeze_after1', dict(op='Unsqueeze')),
+                ('concat_after', dict(op='Concat')),
+            ],
+            edges=[
+                ('concat_before', 'gather_before1_1'),
+                ('concat_before', 'gather_before2_1'),
+                ('gather_before1_1', 'unsqueeze_before1_1'),
+                ('gather_before2_1', 'unsqueeze_before2_1'),
+                ('unsqueeze_before1_1', 'slice1', {'out': 0, 'in': 1}),
+                ('unsqueeze_before2_1', 'slice1', {'out': 0, 'in': 2}),
+                ('weights', 'gather_after1', {'out': 0, 'in': 0}),
+                ('slice1', 'gather_after1', {'out': 0, 'in': 1}),
+                ('gather_after1', 'reduce1'),
+                ('reduce1', 'unsqueeze_after1'),
+                ('unsqueeze_after1', 'concat_after'),
+            ])
+
+    def replace_sub_graph(self, graph: Graph, match: dict):
+        concat_before = match['concat_before']
+        gather_after1 = match['gather_after1']
+        slice1 = match['slice1']
+        concat_after = match['concat_after']
+        weights_node = gather_after1.in_port(0).get_source().node
+        gather_after_axis = gather_after1.in_port(2).get_source().node.soft_get('value')
+        for dst_port in weights_node.out_port(0).get_destinations():
+            node = dst_port.node
+            if node.op == 'Gather':
+                # validate that all Gathers have same axis
+                if node.in_port(2).get_source().node.soft_get('value') != gather_after_axis:
+                    return
+                dst_port.disconnect()
+        indices_node = slice1.in_port(0).get_source().node
+        slice_axis = slice1.in_port(3).get_source().node.soft_get('value')
+        for dst_port in indices_node.out_port(0).get_destinations():
+            node = dst_port.node
+            if node.op == 'Slice':
+                # validate that all Slices have same axis
+                if node.in_port(3).get_source().node.soft_get('value') != slice_axis:
+                    return
+                dst_port.disconnect()
+        emb_bag = EmbeddingBagOffsetsSum(graph, {}).create_node()
+        weights_node.out_port(0).connect(emb_bag.in_port(0))
+        indices_node.out_port(0).connect(emb_bag.in_port(1))
+        concat_before.in_port(0).get_connection().set_destination(emb_bag.in_port(2))
+        concat_after.out_port(0).get_connection().set_source(emb_bag.out_port(0))
+        concat_name = concat_after.soft_get('name', concat_after.id)
+        rename_nodes([(concat_after, concat_name + '/TBD'), (emb_bag, concat_name)])
+
+        # remove this sub-graph since a lot of matchings will be obsolete
+        graph.remove_nodes_from(graph.dfs(concat_before.id, set()))

--- a/model-optimizer/extensions/front/EmbeddingBagFuse_test.py
+++ b/model-optimizer/extensions/front/EmbeddingBagFuse_test.py
@@ -1,0 +1,115 @@
+"""
+ Copyright (C) 2020 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import unittest
+
+import numpy as np
+
+from extensions.front.EmbeddingBagFuse import EmbeddingBagFuse
+from mo.front.common.partial_infer.utils import int64_array
+from mo.utils.ir_engine.compare_graphs import compare_graphs
+from mo.utils.unittest.graph import build_graph, result, \
+    regular_op, const
+
+
+class EmbeddingBagFuseTest(unittest.TestCase):
+    def test(self):
+        nodes = {
+            **regular_op('indices_inp', {'type': 'Parameter'}),
+            **regular_op('offsets_inp', {'type': 'Parameter'}),
+            **const('weights', np.random.randn(100, 2)),
+
+            **regular_op('concat_before', dict(op='Concat')),
+            # 1st branch
+            **regular_op('1_gather_before1_1', dict(op='Gather')),
+            **regular_op('1_unsqueeze_before1_1', dict(op='Unsqueeze')),
+            **regular_op('1_gather_before2_1', dict(op='Gather')),
+            **regular_op('1_unsqueeze_before2_1', dict(op='Unsqueeze')),
+            **const('1_slice1_axes', int64_array([0])),
+            **regular_op('1_slice1', dict(op='Slice')),
+            **const('1_gather_after1_axis', int64_array(0)),
+            **regular_op('1_gather_after1', dict(op='Gather')),
+            **regular_op('1_reduce1', dict(op='ReduceSum')),
+            **regular_op('1_unsqueeze_after1', dict(op='Unsqueeze')),
+            # 2nd branch
+            **regular_op('2_gather_before1_1', dict(op='Gather')),
+            **regular_op('2_unsqueeze_before1_1', dict(op='Unsqueeze')),
+            **regular_op('2_gather_before2_1', dict(op='Gather')),
+            **regular_op('2_unsqueeze_before2_1', dict(op='Unsqueeze')),
+            **const('2_slice1_axes', int64_array([0])),
+            **regular_op('2_slice1', dict(op='Slice')),
+            **const('2_gather_after1_axis', int64_array(0)),
+            **regular_op('2_gather_after1', dict(op='Gather')),
+            **regular_op('2_reduce1', dict(op='ReduceSum')),
+            **regular_op('2_unsqueeze_after1', dict(op='Unsqueeze')),
+
+            **regular_op('concat_after', dict(op='Concat')),
+
+            **regular_op('emb_bag', {'type': 'EmbeddingBagOffsetsSum', 'kind': 'op', 'op': 'EmbeddingBagOffsetsSum'}),
+            **result('result'),
+        }
+        edges = [
+            ('offsets_inp', 'concat_before', {'out': 0, 'in': 0}),
+            # connect 1st branch
+            ('concat_before', '1_gather_before1_1'),
+            ('concat_before', '1_gather_before2_1'),
+            ('1_gather_before1_1', '1_unsqueeze_before1_1'),
+            ('1_gather_before2_1', '1_unsqueeze_before2_1'),
+            ('indices_inp', '1_slice1', {'out': 0, 'in': 0}),
+            ('1_unsqueeze_before1_1', '1_slice1', {'out': 0, 'in': 1}),
+            ('1_unsqueeze_before2_1', '1_slice1', {'out': 0, 'in': 2}),
+            ('1_slice1_axes', '1_slice1', {'out': 0, 'in': 3}),
+            ('weights', '1_gather_after1', {'out': 0, 'in': 0}),
+            ('1_slice1', '1_gather_after1', {'out': 0, 'in': 1}),
+            ('1_gather_after1_axis', '1_gather_after1', {'out': 0, 'in': 2}),
+            ('1_gather_after1', '1_reduce1'),
+            ('1_reduce1', '1_unsqueeze_after1'),
+            ('1_unsqueeze_after1', 'concat_after'),
+            # connect 2nd branch
+            ('concat_before', '2_gather_before1_1'),
+            ('concat_before', '2_gather_before2_1'),
+            ('2_gather_before1_1', '2_unsqueeze_before1_1'),
+            ('2_gather_before2_1', '2_unsqueeze_before2_1'),
+            ('indices_inp', '2_slice1', {'out': 0, 'in': 0}),
+            ('2_unsqueeze_before1_1', '2_slice1', {'out': 0, 'in': 1}),
+            ('2_unsqueeze_before2_1', '2_slice1', {'out': 0, 'in': 2}),
+            ('2_slice1_axes', '2_slice1', {'out': 0, 'in': 3}),
+            ('weights', '2_gather_after1', {'out': 0, 'in': 0}),
+            ('2_slice1', '2_gather_after1', {'out': 0, 'in': 1}),
+            ('2_gather_after1_axis', '2_gather_after1', {'out': 0, 'in': 2}),
+            ('2_gather_after1', '2_reduce1'),
+            ('2_reduce1', '2_unsqueeze_after1'),
+            ('2_unsqueeze_after1', 'concat_after'),
+
+            ('concat_after', 'result'),
+        ]
+        graph = build_graph(nodes, edges)
+
+        graph.graph['layout'] = 'NCHW'
+        graph.stage = 'front'
+
+        edges_ref = [('weights', 'emb_bag'),
+                     ('indices_inp', 'emb_bag'),
+                     ('offsets_inp', 'emb_bag'),
+                     ('emb_bag', 'result'),
+                     ]
+
+        graph_ref = build_graph(nodes, edges_ref)
+
+        EmbeddingBagFuse().find_and_replace_pattern(graph)
+
+        (flag, resp) = compare_graphs(graph, graph_ref, 'result')
+        self.assertTrue(flag, resp)


### PR DESCRIPTION
This is needed to support DLRM model exported with PyTorch version >= 1.7. For MO to be able to read such a model, this fusing transform should exist on MO side.

Ticket: #40350, #37086

Code:

* [x] Comments
* [x] Code style (PEP8)
* [x] Transformation generates reshape-able IR: yes
* [x] Transformation preserves node names: yes

Validation: 

* [x] Unit tests
* [x] Framework layer tests: N/A
* [x] Transformation tests
* [x] e2e model test: N/A
* [x] MO IR Reader tests

Documentation:

* [x] Supported frameworks layers list: N/A
* [x] Supported **public** models list: N/A
* [x] New operations specification: N/A
* [x] Guide on how to convert the **public** model: N/A
* [x] User guide update: N/A

Other:

* [x] Sample/Demo application to infer the model: N/A