### PR TITLE
Avoid excess tensor copy for Reshape/Squeeze/Unsqueeze folding

### DIFF
--- a/ngraph/core/include/ngraph/op/constant.hpp
+++ b/ngraph/core/include/ngraph/op/constant.hpp
@@ -285,6 +285,11 @@ namespace ngraph
                 ///        Repeated values are allowed.
                 AxisSet get_axis_set_val() const;
 
+                /// \brief Update Constant shape. New shape size must equal to the data elements count
+                ///
+                /// \param shape The shape of the tensor constant.
+                void set_data_shape(const Shape & shape);
+
                 /// \brief Wrapper around constructing a shared_ptr of a Constant
                 ///
                 /// \param type The element type of the tensor constant.

--- a/ngraph/core/include/ngraph/op/constant.hpp
+++ b/ngraph/core/include/ngraph/op/constant.hpp
@@ -285,10 +285,11 @@ namespace ngraph
                 ///        Repeated values are allowed.
                 AxisSet get_axis_set_val() const;
 
-                /// \brief Update Constant shape. New shape size must equal to the data elements count
+                /// \brief Update Constant shape. New shape size must equal to the data elements
+                /// count
                 ///
                 /// \param shape The shape of the tensor constant.
-                void set_data_shape(const Shape & shape);
+                void set_data_shape(const Shape& shape);
 
                 /// \brief Wrapper around constructing a shared_ptr of a Constant
                 ///

--- a/ngraph/core/include/ngraph/op/reshape.hpp
+++ b/ngraph/core/include/ngraph/op/reshape.hpp
@@ -153,6 +153,8 @@ namespace ngraph
                 void set_special_zero(bool special_zero) { m_special_zero = special_zero; }
                 bool evaluate(const HostTensorVector& outputs,
                               const HostTensorVector& inputs) const override;
+                bool constant_fold(OutputVector& output_values,
+                                   const OutputVector& inputs_values) override;
 
             protected:
                 bool m_special_zero;

--- a/ngraph/core/include/ngraph/op/squeeze.hpp
+++ b/ngraph/core/include/ngraph/op/squeeze.hpp
@@ -44,6 +44,8 @@ namespace ngraph
                 virtual void pre_validate_and_infer_types() override;
                 bool evaluate(const HostTensorVector& outputs,
                               const HostTensorVector& inputs) const override;
+                bool constant_fold(OutputVector& output_values,
+                                   const OutputVector& inputs_values) override;
 
                 virtual std::shared_ptr<Node>
                     clone_with_new_inputs(const OutputVector& new_args) const override;

--- a/ngraph/core/include/ngraph/op/unsqueeze.hpp
+++ b/ngraph/core/include/ngraph/op/unsqueeze.hpp
@@ -45,6 +45,8 @@ namespace ngraph
                 bool visit_attributes(AttributeVisitor& visitor) override;
                 bool evaluate(const HostTensorVector& outputs,
                               const HostTensorVector& inputs) const override;
+                bool constant_fold(OutputVector& output_values,
+                                   const OutputVector& inputs_values) override;
 
                 virtual std::shared_ptr<Node>
                     clone_with_new_inputs(const OutputVector& new_args) const override;

--- a/ngraph/core/src/op/constant.cpp
+++ b/ngraph/core/src/op/constant.cpp
@@ -540,6 +540,12 @@ AxisSet op::Constant::get_axis_set_val() const
     return output_axis_set;
 }
 
+void op::Constant::set_data_shape(const Shape & shape)
+{
+    NGRAPH_CHECK(shape_size(shape) == shape_size(m_shape));
+    m_shape = shape;
+}
+
 shared_ptr<Node> op::Constant::clone_with_new_inputs(const OutputVector& new_args) const
 {
     check_new_args_count(this, new_args);

--- a/ngraph/core/src/op/constant.cpp
+++ b/ngraph/core/src/op/constant.cpp
@@ -540,7 +540,7 @@ AxisSet op::Constant::get_axis_set_val() const
     return output_axis_set;
 }
 
-void op::Constant::set_data_shape(const Shape & shape)
+void op::Constant::set_data_shape(const Shape& shape)
 {
     NGRAPH_CHECK(shape_size(shape) == shape_size(m_shape));
     m_shape = shape;

--- a/ngraph/core/src/op/reshape.cpp
+++ b/ngraph/core/src/op/reshape.cpp
@@ -453,3 +453,31 @@ bool op::v1::Reshape::evaluate(const HostTensorVector& outputs,
     const AxisVector order = get_default_order(inputs[0]->get_shape());
     return evaluate_reshape(inputs[0], outputs[0], order);
 }
+
+bool op::v1::Reshape::constant_fold(OutputVector& output_values, const OutputVector& inputs_values)
+{
+    if (get_output_partial_shape(0).is_dynamic())
+    {
+        return false;
+    }
+
+    const auto& shape = get_output_shape(0);
+
+    if (auto data_const =
+            std::dynamic_pointer_cast<op::Constant>(inputs_values[0].get_node_shared_ptr()))
+    {
+        // In case if data constant has single consumer we can change it shape without making a copy
+        // Otherwise we create Constant copy with shape from reshape node
+        if (data_const->output(0).get_target_inputs().size() == 1)
+        {
+            data_const->set_data_shape(shape);
+            output_values[0] = data_const;
+        }
+        else
+        {
+            output_values[0] = std::make_shared<op::Constant>(
+                data_const->get_element_type(), shape, data_const->get_data_ptr());
+        }
+    }
+    return true;
+}

--- a/ngraph/core/src/op/reshape.cpp
+++ b/ngraph/core/src/op/reshape.cpp
@@ -471,6 +471,7 @@ bool op::v1::Reshape::constant_fold(OutputVector& output_values, const OutputVec
         if (data_const->output(0).get_target_inputs().size() == 1)
         {
             data_const->set_data_shape(shape);
+            data_const->validate_and_infer_types();
             output_values[0] = data_const;
         }
         else
@@ -478,6 +479,7 @@ bool op::v1::Reshape::constant_fold(OutputVector& output_values, const OutputVec
             output_values[0] = std::make_shared<op::Constant>(
                 data_const->get_element_type(), shape, data_const->get_data_ptr());
         }
+        return true;
     }
-    return true;
+    return false;
 }

--- a/ngraph/core/src/op/squeeze.cpp
+++ b/ngraph/core/src/op/squeeze.cpp
@@ -212,3 +212,31 @@ bool op::v0::Squeeze::evaluate(const HostTensorVector& outputs,
     OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v0::Squeeze::evaluate");
     return squeeze::evaluate_squeeze(inputs[0], inputs[1], outputs[0]);
 }
+
+bool op::v0::Squeeze::constant_fold(OutputVector& output_values, const OutputVector& inputs_values)
+{
+    if (get_output_partial_shape(0).is_dynamic())
+    {
+        return false;
+    }
+
+    const auto& shape = get_output_shape(0);
+
+    if (auto data_const =
+            std::dynamic_pointer_cast<op::Constant>(inputs_values[0].get_node_shared_ptr()))
+    {
+        // In case if data constant has single consumer we can change it shape without making a copy
+        // Otherwise we create Constant copy with shape from squeeze node
+        if (data_const->output(0).get_target_inputs().size() == 1)
+        {
+            data_const->set_data_shape(shape);
+            output_values[0] = data_const;
+        }
+        else
+        {
+            output_values[0] = std::make_shared<op::Constant>(
+                data_const->get_element_type(), shape, data_const->get_data_ptr());
+        }
+    }
+    return true;
+}

--- a/ngraph/core/src/op/squeeze.cpp
+++ b/ngraph/core/src/op/squeeze.cpp
@@ -230,6 +230,7 @@ bool op::v0::Squeeze::constant_fold(OutputVector& output_values, const OutputVec
         if (data_const->output(0).get_target_inputs().size() == 1)
         {
             data_const->set_data_shape(shape);
+            data_const->validate_and_infer_types();
             output_values[0] = data_const;
         }
         else
@@ -237,6 +238,7 @@ bool op::v0::Squeeze::constant_fold(OutputVector& output_values, const OutputVec
             output_values[0] = std::make_shared<op::Constant>(
                 data_const->get_element_type(), shape, data_const->get_data_ptr());
         }
+        return true;
     }
-    return true;
+    return false;
 }

--- a/ngraph/core/src/op/unsqueeze.cpp
+++ b/ngraph/core/src/op/unsqueeze.cpp
@@ -173,3 +173,32 @@ bool op::v0::Unsqueeze::evaluate(const HostTensorVector& outputs,
     OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v0::Unsqueeze::evaluate");
     return unsqueeze::evaluate_unsqueeze(inputs[0], inputs[1], outputs[0]);
 }
+
+bool op::v0::Unsqueeze::constant_fold(OutputVector& output_values,
+                                      const OutputVector& inputs_values)
+{
+    if (get_output_partial_shape(0).is_dynamic())
+    {
+        return false;
+    }
+
+    const auto& shape = get_output_shape(0);
+
+    if (auto data_const =
+            std::dynamic_pointer_cast<op::Constant>(inputs_values[0].get_node_shared_ptr()))
+    {
+        // In case if data constant has single consumer we can change it shape without making a copy
+        // Otherwise we create Constant copy with shape from unsqueeze node
+        if (data_const->output(0).get_target_inputs().size() == 1)
+        {
+            data_const->set_data_shape(shape);
+            output_values[0] = data_const;
+        }
+        else
+        {
+            output_values[0] = std::make_shared<op::Constant>(
+                data_const->get_element_type(), shape, data_const->get_data_ptr());
+        }
+    }
+    return true;
+}

--- a/ngraph/core/src/op/unsqueeze.cpp
+++ b/ngraph/core/src/op/unsqueeze.cpp
@@ -192,6 +192,7 @@ bool op::v0::Unsqueeze::constant_fold(OutputVector& output_values,
         if (data_const->output(0).get_target_inputs().size() == 1)
         {
             data_const->set_data_shape(shape);
+            data_const->validate_and_infer_types();
             output_values[0] = data_const;
         }
         else
@@ -199,6 +200,7 @@ bool op::v0::Unsqueeze::constant_fold(OutputVector& output_values,
             output_values[0] = std::make_shared<op::Constant>(
                 data_const->get_element_type(), shape, data_const->get_data_ptr());
         }
+        return true;
     }
-    return true;
+    return false;
 }


### PR DESCRIPTION
In this PR I overrided constant_folding methods for Reshape/Squeeze/Unsqeeze operations to avoid excess host tensor copies during ConstantFolding pass. Previously we did 3 extra tensor copy but with this changes the number of copies reduced to 1 in worst case and 0 in best case.

Also this changes are highly required by TensorIterator to Sequence transformations. Manual testing shows that this transformations doesn't affect load time.

This PR doesn't includes test because actual number of unit tests already covers Reshape/Squeeze/Unsqueeze operations constant folding.