### PR TITLE
[Transformations] Hswish fusion to be called before Hsigmoid fusion

### DIFF
--- a/inference-engine/src/transformations/src/transformations/common_optimizations/common_optimizations.cpp
+++ b/inference-engine/src/transformations/src/transformations/common_optimizations/common_optimizations.cpp
@@ -70,8 +70,8 @@ bool ngraph::pass::CommonOptimizations::run_on_function(std::shared_ptr<ngraph::
     manager.register_pass<ngraph::pass::SoftPlusFusion>();
     manager.register_pass<ngraph::pass::SoftPlusToMishFusion>();
     manager.register_pass<ngraph::pass::SwishFusion>();
-    manager.register_pass<ngraph::pass::HSigmoidFusion>();
     manager.register_pass<ngraph::pass::HSwishFusion>();
+    manager.register_pass<ngraph::pass::HSigmoidFusion>();
     manager.register_pass<ngraph::pass::ConvertPadToGroupConvolution, false>();
     manager.register_pass<ngraph::pass::NormalizeL2Fusion>();
     manager.register_pass<ngraph::pass::BidirectionalLSTMSequenceDecomposition>();
@@ -81,8 +81,8 @@ bool ngraph::pass::CommonOptimizations::run_on_function(std::shared_ptr<ngraph::
     auto decomp = manager.register_pass<ngraph::pass::GraphRewrite>();
     decomp->add_matcher<ngraph::pass::ReduceL1Decomposition>();
     decomp->add_matcher<ngraph::pass::ReduceL2Decomposition>();
-    decomp->add_matcher<ngraph::pass::HSigmoidDecomposition>();
     decomp->add_matcher<ngraph::pass::HSwishDecomposition>();
+    decomp->add_matcher<ngraph::pass::HSigmoidDecomposition>();
     decomp->add_matcher<ngraph::pass::LogSoftmaxDecomposition>();
     decomp->add_matcher<ngraph::pass::ConvertReduceMeanToPooling>();
     decomp->add_matcher<ngraph::pass::ConvertReduceMaxToPooling>();


### PR DESCRIPTION
@iimironov Please review

We have several models that contains Hswish pattern (and Hswish fusion transformation correctly fused it into single op). You added Hsigmoid fusion before Hswish that led to the fact that now in plug-ins we have pattern: x * Hsigmoid(x), which works slower than single Hswish(x). As a results several models shows performance degradation comparing to previous release.
My proposal is to change the order of these fusions.