### PR TITLE
Fixed convertFunctionToCNNNetwork to support non unique names

### DIFF
--- a/inference-engine/tests/functional/inference_engine/cnn_network/convert_ngraph_to_cnn_network_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/cnn_network/convert_ngraph_to_cnn_network_tests.cpp
@@ -237,3 +237,160 @@ TEST(ConvertFunctionToCNNNetworkTests, UnsupportedDynamicOps) {
                                                              "v0::Result result (non_zero[0]:i64{?,?}) -> (i64{?,?})")));
     }
 }
+
+TEST(ConvertFunctionToCNNNetworkTests, NonUniqueNamesAllInternal) {
+    std::shared_ptr<ngraph::Function> f(nullptr);
+    {
+        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3});
+        auto begin = ngraph::opset1::Constant::create(ngraph::element::i64, {2}, {0, 0});
+        auto end = ngraph::opset1::Constant::create(ngraph::element::i64, {2}, {0, 0});
+        end->set_friendly_name(begin->get_name());
+        auto stride = ngraph::opset1::Constant::create(ngraph::element::i64, {2}, {1, 1});
+        auto ss = std::make_shared<ngraph::opset1::StridedSlice>(
+                input,
+                begin,
+                end,
+                stride,
+                std::vector<int64_t>{1, 1}, std::vector<int64_t>{1, 1});
+
+        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{ss}, ngraph::ParameterVector{input});
+    }
+
+    InferenceEngine::CNNNetwork nGraphImpl(f);
+    nGraphImpl = CNNNetwork(InferenceEngine::details::convertFunctionToICNNNetwork(f, nGraphImpl));
+    ASSERT_EQ(nGraphImpl.layerCount(), 5);
+}
+
+TEST(ConvertFunctionToCNNNetworkTests, NonUniqueNamesHasResult1) {
+    std::shared_ptr<ngraph::Function> f(nullptr);
+    {
+        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3});
+        auto begin = ngraph::opset1::Constant::create(ngraph::element::i64, {2}, {0, 0});
+        auto end = ngraph::opset1::Constant::create(ngraph::element::i64, {2}, {0, 0});
+        end->set_friendly_name(begin->get_name());
+        auto stride = ngraph::opset1::Constant::create(ngraph::element::i64, {2}, {1, 1});
+        auto ss = std::make_shared<ngraph::opset1::StridedSlice>(
+                input,
+                begin,
+                end,
+                stride,
+                std::vector<int64_t>{1, 1}, std::vector<int64_t>{1, 1});
+
+        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{ss, begin}, ngraph::ParameterVector{input});
+    }
+
+    InferenceEngine::CNNNetwork nGraphImpl(f);
+    nGraphImpl = CNNNetwork(InferenceEngine::details::convertFunctionToICNNNetwork(f, nGraphImpl));
+    ASSERT_EQ(nGraphImpl.layerCount(), 5);
+}
+
+TEST(ConvertFunctionToCNNNetworkTests, NonUniqueNamesHasResult2) {
+    std::shared_ptr<ngraph::Function> f(nullptr);
+    {
+        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3});
+        auto begin = ngraph::opset1::Constant::create(ngraph::element::i64, {2}, {0, 0});
+        begin->set_friendly_name("const");
+        auto end = ngraph::opset1::Constant::create(ngraph::element::i64, {2}, {0, 0});
+        end->set_friendly_name("const");
+        auto stride = ngraph::opset1::Constant::create(ngraph::element::i64, {2}, {1, 1});
+        stride->set_friendly_name("const");
+        auto ss = std::make_shared<ngraph::opset1::StridedSlice>(
+                input,
+                begin,
+                end,
+                stride,
+                std::vector<int64_t>{1, 1}, std::vector<int64_t>{1, 1});
+
+        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{ss, begin}, ngraph::ParameterVector{input});
+    }
+
+    InferenceEngine::CNNNetwork nGraphImpl(f);
+    nGraphImpl = CNNNetwork(InferenceEngine::details::convertFunctionToICNNNetwork(f, nGraphImpl));
+    ASSERT_EQ(nGraphImpl.layerCount(), 5);
+}
+
+TEST(ConvertFunctionToCNNNetworkTests, NonUniqueNamesHasResult3) {
+    std::shared_ptr<ngraph::Function> f(nullptr);
+    {
+        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3});
+        auto begin = ngraph::opset1::Constant::create(ngraph::element::i64, {2}, {0, 0});
+        begin->set_friendly_name("const");
+        auto end = ngraph::opset1::Constant::create(ngraph::element::i64, {2}, {0, 0});
+        end->set_friendly_name("const");
+        auto stride = ngraph::opset1::Constant::create(ngraph::element::i64, {2}, {1, 1});
+        stride->set_friendly_name("const");
+        auto ss = std::make_shared<ngraph::opset1::StridedSlice>(
+                input,
+                begin,
+                end,
+                stride,
+                std::vector<int64_t>{1, 1}, std::vector<int64_t>{1, 1});
+        ss->set_friendly_name("node");
+        auto squeeze = std::make_shared<ngraph::opset1::Squeeze>(ss, ngraph::opset1::Constant::create(ngraph::element::i64, {1}, {0}));
+        squeeze->set_friendly_name("node");
+        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{squeeze, begin}, ngraph::ParameterVector{input});
+    }
+
+    InferenceEngine::CNNNetwork nGraphImpl(f);
+    nGraphImpl = CNNNetwork(InferenceEngine::details::convertFunctionToICNNNetwork(f, nGraphImpl));
+    ASSERT_EQ(nGraphImpl.layerCount(), 7);
+    auto outputs_info = nGraphImpl.getOutputsInfo();
+    ASSERT_TRUE(outputs_info.count("node"));
+    ASSERT_TRUE(outputs_info.count("const"));
+}
+
+TEST(ConvertFunctionToCNNNetworkTests, NonUniqueNamesNegative) {
+    std::shared_ptr<ngraph::Function> f(nullptr);
+    {
+        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3});
+        auto begin = ngraph::opset1::Constant::create(ngraph::element::i64, {2}, {0, 0});
+        begin->set_friendly_name("const");
+        auto end = ngraph::opset1::Constant::create(ngraph::element::i64, {2}, {0, 0});
+        end->set_friendly_name("const");
+        auto stride = ngraph::opset1::Constant::create(ngraph::element::i64, {2}, {1, 1});
+        auto ss = std::make_shared<ngraph::opset1::StridedSlice>(
+                input,
+                begin,
+                end,
+                stride,
+                std::vector<int64_t>{1, 1}, std::vector<int64_t>{1, 1});
+
+        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{ss, begin, end}, ngraph::ParameterVector{input});
+    }
+
+    InferenceEngine::CNNNetwork nGraphImpl(f);
+    try {
+        InferenceEngine::details::convertFunctionToICNNNetwork(f, nGraphImpl);
+        FAIL() << "InferenceEngineException must be thrown";
+    } catch(InferenceEngine::details::InferenceEngineException & e) {
+        EXPECT_THAT(e.what(), testing::HasSubstr(std::string("Detected two external operations with the same name:")));
+    }
+}
+
+TEST(ConvertFunctionToCNNNetworkTests, NonUniqueNamesParametersNegative) {
+    std::shared_ptr<ngraph::Function> f(nullptr);
+    auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3});
+    input->set_friendly_name("param");
+    auto begin = ngraph::opset1::Constant::create(ngraph::element::i64, {2}, {0, 0});
+    auto end = ngraph::opset1::Constant::create(ngraph::element::i64, {2}, {0, 0});
+    auto stride = ngraph::opset1::Constant::create(ngraph::element::i64, {2}, {1, 1});
+    auto ss = std::make_shared<ngraph::opset1::StridedSlice>(
+            input,
+            begin,
+            end,
+            stride,
+            std::vector<int64_t>{1, 1}, std::vector<int64_t>{1, 1});
+    auto input2 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3});
+    auto concat = std::make_shared<ngraph::opset1::Concat>(ngraph::NodeVector{ss, input2}, 0);
+
+    f = std::make_shared<ngraph::Function>(ngraph::NodeVector{concat}, ngraph::ParameterVector{input, input2});
+
+    InferenceEngine::CNNNetwork nGraphImpl(f);
+    try {
+        input2->set_friendly_name("param");
+        InferenceEngine::details::convertFunctionToICNNNetwork(f, nGraphImpl);
+        FAIL() << "InferenceEngineException must be thrown";
+    } catch(InferenceEngine::details::InferenceEngineException & e) {
+        EXPECT_THAT(e.what(), testing::HasSubstr(std::string("Detected two external operations with the same name:")));
+    }
+}

--- a/inference-engine/tests/functional/inference_engine/cnn_network/convert_ngraph_to_cnn_network_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/cnn_network/convert_ngraph_to_cnn_network_tests.cpp
@@ -363,7 +363,7 @@ TEST(ConvertFunctionToCNNNetworkTests, NonUniqueNamesNegative) {
         InferenceEngine::details::convertFunctionToICNNNetwork(f, nGraphImpl);
         FAIL() << "InferenceEngineException must be thrown";
     } catch(InferenceEngine::details::InferenceEngineException & e) {
-        EXPECT_THAT(e.what(), testing::HasSubstr(std::string("Detected two external operations with the same name:")));
+        EXPECT_THAT(e.what(), testing::HasSubstr(std::string("Detected two output operations with the same name:")));
     }
 }
 
@@ -391,6 +391,6 @@ TEST(ConvertFunctionToCNNNetworkTests, NonUniqueNamesParametersNegative) {
         InferenceEngine::details::convertFunctionToICNNNetwork(f, nGraphImpl);
         FAIL() << "InferenceEngineException must be thrown";
     } catch(InferenceEngine::details::InferenceEngineException & e) {
-        EXPECT_THAT(e.what(), testing::HasSubstr(std::string("Detected two external operations with the same name:")));
+        EXPECT_THAT(e.what(), testing::HasSubstr(std::string("Detected two output operations with the same name:")));
     }
 }


### PR DESCRIPTION
**Description:**
Sometimes during nGraph transformations we insert operations which auto-generated names may conflict with already existing names in graph that came from original model and that leads to unexpected accuracy or functional failures. For example if model has node with name 'Constant_1680' and during transformation we add new Constant operation which auto-generated name is 'Constant_1680' then during conversion to CNNNetwork we will get unexpected behavior because of friendly_name to 
 CNNLayer map inside CNNNetwork.

To resolve this problem with non-unique names I propose next solution:
* We can changes friendly_name for a node if its type is not Parameter or Result and this node has no Result as consumers.
* nGraph has no engine to track unique names and I think it shouldn't. And function may have multiple non-unique names.
* We require from user/original model unique names only for Parameter and Result operations (otherwise we throw an exception).
* During nGraph to CNNNetwork conversion we normalize operations names to be unique but we don't change names for nodes described in the first bullet.
* During nGraph transformations we have to preserve and propagate friendly_name for replacement node (that is already done in every transformation, so we won't have cases when output node has auto-generated name).

Following all statements above we can easily support non-unique node names without changing current nGraph functionality and without updating plugins to support non-unique names.
