### PR TITLE
[LPT] Functional tests: used kernel verification

### DIFF
--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/convolution_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/convolution_transformation.cpp
@@ -26,26 +26,34 @@ const std::vector<LayerTestsDefinitions::ConvolutionTransformationParam> params 
         { 256ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 255.f }, { 0.f }, { 25.5f } },
         false,
         {},
-        false
+        false,
+        "output",
+        "FP32"
     },
     {
         {},
         false,
         { 255ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 254.f }, { -12.7f }, { 12.7f } },
-        false
+        false,
+        "output",
+        "FP32"
     },
     {
         { 256ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 255.f }, { 0.f }, { 25.5f } },
         false,
         { 255ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 254.f }, { -12.7f }, { 12.7f } },
-        false
+        false,
+        "output_original",
+        "I8"
     },
     {
-        { 256ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 255.f }, { -12.75f }, { 6.375f } },
+        { 256ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 255.f }, { -12.7f }, { 12.8f } },
         true,
         { 255ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 254.f }, { -12.7f }, { 12.7f } },
-        false
-    }
+        false,
+        "output_original",
+        "I8"
+    },
 };
 
 const std::vector<ngraph::Shape> shapes = {

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/mat_mul_with_constant_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/mat_mul_with_constant_transformation.cpp
@@ -18,7 +18,9 @@ std::vector<MatMulWithConstantTransformationTestValues> testValues = {
         { 256ul, ngraph::Shape({}), {0.f}, {25.5f}, {0.f}, {25.5f} },
         { 32, 10 },
         std::vector<float>(32 * 10, 1.f),
-        { 256ul, ngraph::Shape({}), {-12.8f}, {12.7f}, {-12.8f}, {12.7f} }
+        { 256ul, ngraph::Shape({}), {-12.8f}, {12.7f}, {-12.8f}, {12.7f} },
+        "matMul/1",
+        "I8"
     }
 };
 

--- a/inference-engine/tests/functional/plugin/shared/include/low_precision_transformations/convolution_transformation.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/low_precision_transformations/convolution_transformation.hpp
@@ -19,6 +19,8 @@ public:
     bool asymmetricQuantizationOnData;
     ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
     bool asymmetricQuantizationOnWeights;
+    std::string layerName;
+    std::string expectedKernelType;
 };
 
 typedef std::tuple<
@@ -37,6 +39,8 @@ public:
 
 protected:
     void SetUp() override;
+
+    void Run() override;
 
 private:
     void validateNGraph();

--- a/inference-engine/tests/functional/plugin/shared/include/low_precision_transformations/mat_mul_with_constant_transformation.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/low_precision_transformations/mat_mul_with_constant_transformation.hpp
@@ -21,6 +21,8 @@ public:
     ngraph::Shape weightsConstShape;
     std::vector<float> weightsConstValues;
     ngraph::builder::subgraph::FakeQuantizeOnWeights fqOnWeights;
+    std::string layerName;
+    std::string expectedKernelType;
 };
 
 typedef std::tuple<
@@ -37,6 +39,8 @@ public:
 
 protected:
     void SetUp() override;
+
+    void Run() override;
 };
 
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/convolution_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/convolution_transformation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+﻿// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -52,6 +52,14 @@ void ConvolutionTransformation::SetUp() {
         param.fakeQuantizeOnWeights);
 
     validateNGraph();
+}
+
+void ConvolutionTransformation::Run() {
+    LayerTestsCommon::Run();
+
+    const auto params = std::get<4>(GetParam());
+    const auto actualType = getRuntimePrecision(params.layerName);
+    EXPECT_EQ(actualType, params.expectedKernelType);
 }
 
 void ConvolutionTransformation::validateNGraph() {

--- a/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/mat_mul_with_constant_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/mat_mul_with_constant_transformation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+﻿// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -69,6 +69,15 @@ void MatMulWithConstantTransformation::SetUp() {
         testValues.fqOnWeights);
 
     ngraph::pass::InitNodeInfo().run_on_function(function);
+}
+
+void MatMulWithConstantTransformation::Run() {
+    LayerTestsCommon::Run();
+
+    const auto params = std::get<2>(GetParam());
+    const auto actualType = getRuntimePrecision(params.layerName);
+
+    EXPECT_EQ(actualType, params.expectedKernelType);
 }
 
 TEST_P(MatMulWithConstantTransformation, CompareWithRefImpl) {

--- a/inference-engine/tests/ie_test_utils/functional_test_utils/layer_test_utils.hpp
+++ b/inference-engine/tests/ie_test_utils/functional_test_utils/layer_test_utils.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2020 Intel Corporation
+﻿// Copyright (C) 2019-2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -148,6 +148,8 @@ public:
     std::shared_ptr<ngraph::Function> GetFunction();
 
     std::map<std::string, std::string>& GetConfiguration();
+
+    std::string getRuntimePrecision(const std::string& layerName);
 
 protected:
     LayerTestsCommon();


### PR DESCRIPTION
Note: workaround is still used in `LayerTestsCommon::getKernelType` to get executed kernel precision from `primitiveType`. `runtimePrecision` will be used after execution graph extending.