### PR TITLE
Add command line input option to configure VPU_THROUGHPUT_STREAMS

### DIFF
--- a/inference-engine/tools/compile_tool/main.cpp
+++ b/inference-engine/tools/compile_tool/main.cpp
@@ -77,6 +77,11 @@ static constexpr char tiling_cmx_limit_message[] =
                                              "Optional. Specifies CMX limit for data tiling.\n"
 "                                             Value should be equal or greater than -1.\n"
 "                                             Overwrites value from config.";
+static constexpr char number_of_vpu_througput_streams[] =
+                                             "Optional. Optimize vpu plugin execution to maximize throughput.\n"
+"                                             This option should be used with integer value which is the requested number of streams.\n"
+"                                             The only possible values are: 1, 2, 3\n"
+"                                             Overwrites value from config.";
 
 // FPGA-specific
 static constexpr char dla_arch_name[] =
@@ -96,31 +101,33 @@ DEFINE_string(iol, "", iol_message);
 DEFINE_string(VPU_NUMBER_OF_SHAVES, "", number_of_shaves_message);
 DEFINE_string(VPU_NUMBER_OF_CMX_SLICES, "", number_of_cmx_slices_message);
 DEFINE_string(VPU_TILING_CMX_LIMIT_KB, "", tiling_cmx_limit_message);
+DEFINE_string(VPU_THROUGHPUT_STREAMS, "", number_of_vpu_througput_streams);
 DEFINE_string(DLA_ARCH_NAME, "", dla_arch_name);
 
 static void showUsage() {
     std::cout << "compile_tool [OPTIONS]" << std::endl;
-    std::cout                                                                                      << std::endl;
-    std::cout << " Common options:                             "                                   << std::endl;
-    std::cout << "    -h                                       "   << help_message                 << std::endl;
-    std::cout << "    -m                           <value>     "   << model_message                << std::endl;
-    std::cout << "    -d                           <value>     "   << targetDeviceMessage          << std::endl;
-    std::cout << "    -o                           <value>     "   << output_message               << std::endl;
-    std::cout << "    -c                           <value>     "   << config_message               << std::endl;
-    std::cout << "    -ip                          <value>     "   << inputs_precision_message     << std::endl;
-    std::cout << "    -op                          <value>     "   << outputs_precision_message    << std::endl;
-    std::cout << "    -iop                        \"<value>\"    "   << iop_message                << std::endl;
-    std::cout << "    -il                          <value>     "   << inputs_layout_message        << std::endl;
-    std::cout << "    -ol                          <value>     "   << outputs_layout_message       << std::endl;
-    std::cout << "    -iol                        \"<value>\"    "   << iol_message                << std::endl;
-    std::cout                                                                                      << std::endl;
-    std::cout << " MYRIAD-specific options:                    "                                   << std::endl;
-    std::cout << "      -VPU_NUMBER_OF_SHAVES      <value>     "   << number_of_shaves_message     << std::endl;
-    std::cout << "      -VPU_NUMBER_OF_CMX_SLICES  <value>     "   << number_of_cmx_slices_message << std::endl;
-    std::cout << "      -VPU_TILING_CMX_LIMIT_KB   <value>     "   << tiling_cmx_limit_message     << std::endl;
-    std::cout                                                                                      << std::endl;
-    std::cout << " FPGA-specific options:                      "                                   << std::endl;
-    std::cout << "      -DLA_ARCH_NAME             <value>     "   << dla_arch_name                << std::endl;
+    std::cout                                                                                           << std::endl;
+    std::cout << " Common options:                             "                                        << std::endl;
+    std::cout << "    -h                                       "   << help_message                      << std::endl;
+    std::cout << "    -m                           <value>     "   << model_message                     << std::endl;
+    std::cout << "    -d                           <value>     "   << targetDeviceMessage               << std::endl;
+    std::cout << "    -o                           <value>     "   << output_message                    << std::endl;
+    std::cout << "    -c                           <value>     "   << config_message                    << std::endl;
+    std::cout << "    -ip                          <value>     "   << inputs_precision_message          << std::endl;
+    std::cout << "    -op                          <value>     "   << outputs_precision_message         << std::endl;
+    std::cout << "    -iop                        \"<value>\"    "   << iop_message                     << std::endl;
+    std::cout << "    -il                          <value>     "   << inputs_layout_message             << std::endl;
+    std::cout << "    -ol                          <value>     "   << outputs_layout_message            << std::endl;
+    std::cout << "    -iol                        \"<value>\"    "   << iol_message                     << std::endl;
+    std::cout                                                                                           << std::endl;
+    std::cout << " MYRIAD-specific options:                    "                                        << std::endl;
+    std::cout << "      -VPU_NUMBER_OF_SHAVES      <value>     "   << number_of_shaves_message          << std::endl;
+    std::cout << "      -VPU_NUMBER_OF_CMX_SLICES  <value>     "   << number_of_cmx_slices_message      << std::endl;
+    std::cout << "      -VPU_TILING_CMX_LIMIT_KB   <value>     "   << tiling_cmx_limit_message          << std::endl;
+    std::cout << "      -VPU_THROUGHPUT_STREAMS    <value>     "   << number_of_vpu_througput_streams   << std::endl;
+    std::cout                                                                                           << std::endl;
+    std::cout << " FPGA-specific options:                      "                                        << std::endl;
+    std::cout << "      -DLA_ARCH_NAME             <value>     "   << dla_arch_name                     << std::endl;
     std::cout << std::endl;
 }
 
@@ -192,6 +199,10 @@ IE_SUPPRESS_DEPRECATED_END
 
         if (!FLAGS_VPU_TILING_CMX_LIMIT_KB.empty()) {
             config[InferenceEngine::MYRIAD_TILING_CMX_LIMIT_KB] = FLAGS_VPU_TILING_CMX_LIMIT_KB;
+        }
+
+        if (!FLAGS_VPU_THROUGHPUT_STREAMS.empty()) {
+            config[InferenceEngine::MYRIAD_THROUGHPUT_STREAMS] = FLAGS_VPU_THROUGHPUT_STREAMS;
         }
     }
 

--- a/inference-engine/tools/vpu/vpu_compile/main.cpp
+++ b/inference-engine/tools/vpu/vpu_compile/main.cpp
@@ -73,7 +73,7 @@ static void showUsage() {
     std::cout << "    -c                           <value>     "   << config_message                    << std::endl;
     std::cout << "    -ip                          <value>     "   << inputs_precision_message          << std::endl;
     std::cout << "    -op                          <value>     "   << outputs_precision_message         << std::endl;
-    std::cout << "    -iop                        \"<value>\"  "   << iop_message                       << std::endl;
+    std::cout << "    -iop                        \"<value>\"    " << iop_message                       << std::endl;
     std::cout << "    -VPU_NUMBER_OF_SHAVES        <value>     "   << number_of_shaves_message          << std::endl;
     std::cout << "    -VPU_NUMBER_OF_CMX_SLICES    <value>     "   << number_of_cmx_slices_message      << std::endl;
     std::cout << "    -VPU_TILING_CMX_LIMIT_KB     <value>     "   << tiling_cmx_limit_message          << std::endl;

--- a/inference-engine/tools/vpu/vpu_compile/main.cpp
+++ b/inference-engine/tools/vpu/vpu_compile/main.cpp
@@ -34,6 +34,10 @@ static constexpr char number_of_cmx_slices_message[] = "Optional. Specifies numb
 static constexpr char tiling_cmx_limit_message[] = "Optional. Specifies CMX limit for data tiling."
                                                    " Value should be equal or greater than -1."
                                                    " Overwrites value from config.";
+static constexpr char number_of_vpu_througput_streams[] = "Optional. Optimize vpu plugin execution to maximize throughput."
+                                                          " This option should be used with integer value which is the requested number of streams."
+                                                          " The only possible values are: 1, 2, 3"
+                                                          " Overwrites value from config.";
 static constexpr char inputs_precision_message[] = "Optional. Specifies precision for all input layers of network."
                                                    " Supported values: FP32, FP16, U8. Default value: FP16.";
 static constexpr char outputs_precision_message[] = "Optional. Specifies precision for all output layers of network."
@@ -56,22 +60,24 @@ DEFINE_string(iop, "", iop_message);
 DEFINE_string(VPU_NUMBER_OF_SHAVES, "", number_of_shaves_message);
 DEFINE_string(VPU_NUMBER_OF_CMX_SLICES, "", number_of_cmx_slices_message);
 DEFINE_string(VPU_TILING_CMX_LIMIT_KB, "", tiling_cmx_limit_message);
+DEFINE_string(VPU_THROUGHPUT_STREAMS, "", number_of_vpu_througput_streams);
 
 static void showUsage() {
     std::cout << std::endl;
     std::cout << "myriad_compile [OPTIONS]" << std::endl;
     std::cout << "[OPTIONS]:" << std::endl;
-    std::cout << "    -h                                       "   << help_message                 << std::endl;
-    std::cout << "    -m                           <value>     "   << model_message                << std::endl;
-    std::cout << "    -pp                          <value>     "   << plugin_path_message          << std::endl;
-    std::cout << "    -o                           <value>     "   << output_message               << std::endl;
-    std::cout << "    -c                           <value>     "   << config_message               << std::endl;
-    std::cout << "    -ip                          <value>     "   << inputs_precision_message     << std::endl;
-    std::cout << "    -op                          <value>     "   << outputs_precision_message    << std::endl;
-    std::cout << "    -iop                        \"<value>\"    " << iop_message                  << std::endl;
-    std::cout << "    -VPU_NUMBER_OF_SHAVES        <value>     "   << number_of_shaves_message     << std::endl;
-    std::cout << "    -VPU_NUMBER_OF_CMX_SLICES    <value>     "   << number_of_cmx_slices_message << std::endl;
-    std::cout << "    -VPU_TILING_CMX_LIMIT_KB     <value>     "   << tiling_cmx_limit_message     << std::endl;
+    std::cout << "    -h                                       "   << help_message                      << std::endl;
+    std::cout << "    -m                           <value>     "   << model_message                     << std::endl;
+    std::cout << "    -pp                          <value>     "   << plugin_path_message               << std::endl;
+    std::cout << "    -o                           <value>     "   << output_message                    << std::endl;
+    std::cout << "    -c                           <value>     "   << config_message                    << std::endl;
+    std::cout << "    -ip                          <value>     "   << inputs_precision_message          << std::endl;
+    std::cout << "    -op                          <value>     "   << outputs_precision_message         << std::endl;
+    std::cout << "    -iop                        \"<value>\"  "   << iop_message                       << std::endl;
+    std::cout << "    -VPU_NUMBER_OF_SHAVES        <value>     "   << number_of_shaves_message          << std::endl;
+    std::cout << "    -VPU_NUMBER_OF_CMX_SLICES    <value>     "   << number_of_cmx_slices_message      << std::endl;
+    std::cout << "    -VPU_TILING_CMX_LIMIT_KB     <value>     "   << tiling_cmx_limit_message          << std::endl;
+    std::cout << "    -VPU_THROUGHPUT_STREAMS      <value>     "   << number_of_vpu_througput_streams   << std::endl;
     std::cout << std::endl;
 }
 
@@ -119,6 +125,10 @@ static std::map<std::string, std::string> configure(const std::string &configFil
 
     if (!FLAGS_VPU_TILING_CMX_LIMIT_KB.empty()) {
         config[InferenceEngine::MYRIAD_TILING_CMX_LIMIT_KB] = FLAGS_VPU_TILING_CMX_LIMIT_KB;
+    }
+
+    if (!FLAGS_VPU_THROUGHPUT_STREAMS.empty()) {
+        config[InferenceEngine::MYRIAD_THROUGHPUT_STREAMS] = FLAGS_VPU_THROUGHPUT_STREAMS;
     }
 
     return config;


### PR DESCRIPTION
This PR adds CLI option too, which is easier/faster than using a config file and more transparent. 

Starting with `openvino 2020.2` `VPU_THROUGHPUT_STREAMS` was defaulted to `2`, meaning that when user requests compilation for X shaves, the model will be compiled for X*2 shaves, which is not what was requested. For example if model is compiled for 14 shaves, the following error happens: `Cannot allocate "28" shaves: only 16 is available`
Luckily `VPU_THROUGHPUT_STREAMS` still can be configured through `config` file (although I had a hard time finding the documentation for it so I just read the source code):
For example, contents of config file (w/ openvino 2021.1):
```
MYRIAD_NUMBER_OF_SHAVES 14
MYRIAD_NUMBER_OF_CMX_SLICES 14
MYRIAD_THROUGHPUT_STREAMS 1
```

It might be useful for the user to print that the model will be compiled for double the shaves by default. (because inferences running on different threads, and using "half" the shaves each w/ 1 NCE gives better performance)

IMO it would be better defaulting to `1` in `myriad_compile/compile_tool`, since it can be misleading otherwise when model is manually compiled, but I didn't want to change the default behavior in this PR. 