### PR TITLE
Fixes for CMakeLists for Java bindings

### DIFF
--- a/inference-engine/ie_bridges/java/samples/CMakeLists.txt
+++ b/inference-engine/ie_bridges/java/samples/CMakeLists.txt
@@ -1,64 +1,64 @@
-# Copyright (C) 2020 Intel Corporation
+# # Copyright (C) 2020 Intel Corporation
 
-# Find OpenCV components if exist
+# # Find OpenCV components if exist
 
-find_package(OpenCV QUIET)
+# find_package(OpenCV QUIET)
 
-if(EXISTS "${OpenCV_INSTALL_PATH}/share/java")
-    file(GLOB_RECURSE JAVA_OPENCV_SRC ${OpenCV_INSTALL_PATH}/share/java/*.jar)
-elseif(EXISTS "${OpenCV_INSTALL_PATH}/bin")
-    file(GLOB JAVA_OPENCV_SRC ${OpenCV_INSTALL_PATH}/bin/*.jar)
-endif()
+# if(EXISTS "${OpenCV_INSTALL_PATH}/share/java")
+#     file(GLOB_RECURSE JAVA_OPENCV_SRC ${OpenCV_INSTALL_PATH}/share/java/*.jar)
+# elseif(EXISTS "${OpenCV_INSTALL_PATH}/bin")
+#     file(GLOB JAVA_OPENCV_SRC ${OpenCV_INSTALL_PATH}/bin/*.jar)
+# endif()
 
-#
-# ie_add_java_sample(NAME <target name>
-#               SOURCES <source files>
-#               [DEPENDENCIES <dependencies>]
-#               [OPENCV_DEPENDENCIES]
-#
-macro(ie_add_java_sample)
-    set(options OPENCV_DEPENDENCIES)
-    set(oneValueArgs NAME)
-    cmake_parse_arguments(IE_SAMPLE "${options}" "${oneValueArgs}"
-                          "" ${ARGN} )
+# #
+# # ie_add_java_sample(NAME <target name>
+# #               SOURCES <source files>
+# #               [DEPENDENCIES <dependencies>]
+# #               [OPENCV_DEPENDENCIES]
+# #
+# macro(ie_add_java_sample)
+#     set(options OPENCV_DEPENDENCIES)
+#     set(oneValueArgs NAME)
+#     cmake_parse_arguments(IE_SAMPLE "${options}" "${oneValueArgs}"
+#                           "" ${ARGN} )
 
-    # Collect sample sources
+#     # Collect sample sources
 
-    file(GLOB_RECURSE SAMPLE_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.java)
-    list(APPEND SAMPLE_SOURCES ${PROJECT_SOURCE_DIR}/samples/ArgumentParser.java)
+#     file(GLOB_RECURSE SAMPLE_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.java)
+#     list(APPEND SAMPLE_SOURCES ${PROJECT_SOURCE_DIR}/samples/ArgumentParser.java)
 
-    # Set InferenceEngine component
+#     # Set InferenceEngine component
 
-    set(IE_JAVA_SRC ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/inference_engine_java_api.jar)
+#     set(IE_JAVA_SRC ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/inference_engine_java_api.jar)
 
-    # Add OpenCV components if required
+#     # Add OpenCV components if required
 
-    if(IE_SAMPLE_OPENCV_DEPENDENCIES) 
-        if(EXISTS "${JAVA_OPENCV_SRC}")
-            list(APPEND IE_JAVA_SRC ${JAVA_OPENCV_SRC})
-        else()
-            message(WARNING "OPENCV .jar file is disabled or not found, " ${IE_SAMPLE_NAME} " skipped")
-            return()
-        endif()
-    endif()
+#     if(IE_SAMPLE_OPENCV_DEPENDENCIES) 
+#         if(EXISTS "${JAVA_OPENCV_SRC}")
+#             list(APPEND IE_JAVA_SRC ${JAVA_OPENCV_SRC})
+#         else()
+#             message(WARNING "OPENCV .jar file is disabled or not found, " ${IE_SAMPLE_NAME} " skipped")
+#             return()
+#         endif()
+#     endif()
 
-    # Create .jar file from sources
+#     # Create .jar file from sources
     
-    add_jar("${IE_SAMPLE_NAME}_jar"
-                    SOURCES ${SAMPLE_SOURCES}
-                    OUTPUT_NAME ${IE_SAMPLE_NAME}  
-                    OUTPUT_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} 
-                    INCLUDE_JARS ${IE_JAVA_SRC})          
-    add_dependencies(${IE_SAMPLE_NAME}_jar inference_engine_jar)
-endmacro()
+#     add_jar("${IE_SAMPLE_NAME}_jar"
+#                     SOURCES ${SAMPLE_SOURCES}
+#                     OUTPUT_NAME ${IE_SAMPLE_NAME}  
+#                     OUTPUT_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} 
+#                     INCLUDE_JARS ${IE_JAVA_SRC})          
+#     add_dependencies(${IE_SAMPLE_NAME}_jar inference_engine_jar)
+# endmacro()
 
-# Collect all samples subdirectories
+# # Collect all samples subdirectories
 
-file(GLOB samples_dirs RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *)
+# file(GLOB samples_dirs RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *)
 
-foreach(dir ${samples_dirs})
-    if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${dir})
-            # Include subdirectory to the project.
-            add_subdirectory(${dir})
-    endif() 
-endforeach()
+# foreach(dir ${samples_dirs})
+#     if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${dir})
+#             # Include subdirectory to the project.
+#             add_subdirectory(${dir})
+#     endif() 
+# endforeach()

--- a/inference-engine/ie_bridges/java/samples/CMakeLists.txt
+++ b/inference-engine/ie_bridges/java/samples/CMakeLists.txt
@@ -1,29 +1,64 @@
 # Copyright (C) 2020 Intel Corporation
 
-find_package(OpenCV) 
-if(NOT OpenCV_FOUND)
-    message(WARNING ".jar file wasn't found for OpenCV. Java samples won't be build.")
-    return()
-endif()
+# Find OpenCV components if exist
+
+find_package(OpenCV QUIET)
 
 if(EXISTS "${OpenCV_INSTALL_PATH}/share/java")
-    file(GLOB_RECURSE java_opencv_src ${OpenCV_INSTALL_PATH}/share/java/*.jar)
+    file(GLOB_RECURSE JAVA_OPENCV_SRC ${OpenCV_INSTALL_PATH}/share/java/*.jar)
 elseif(EXISTS "${OpenCV_INSTALL_PATH}/bin")
-    file(GLOB java_opencv_src ${OpenCV_INSTALL_PATH}/bin/*.jar)
+    file(GLOB JAVA_OPENCV_SRC ${OpenCV_INSTALL_PATH}/bin/*.jar)
 endif()
 
-if(EXISTS "${java_opencv_src}")
-    file(GLOB java_samples ${CMAKE_CURRENT_SOURCE_DIR}/samples/*)
-    foreach(sample IN LISTS java_samples)
-        if(IS_DIRECTORY "${sample}")
-            get_filename_component(sample_name "${sample}" NAME)
-            file(GLOB_RECURSE sample_src ${sample}/*.java)
-            add_jar("${sample_name}_jar"
-                    SOURCES ${sample_src}
-                            ${PROJECT_SOURCE_DIR}/samples/ArgumentParser.java
-                    OUTPUT_NAME ${sample_name} 
-                    OUTPUT_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} 
-                    INCLUDE_JARS ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/* ${java_opencv_src})
+#
+# ie_add_java_sample(NAME <target name>
+#               SOURCES <source files>
+#               [DEPENDENCIES <dependencies>]
+#               [OPENCV_DEPENDENCIES]
+#
+macro(ie_add_java_sample)
+    set(options OPENCV_DEPENDENCIES)
+    set(oneValueArgs NAME)
+    cmake_parse_arguments(IE_SAMPLE "${options}" "${oneValueArgs}"
+                          "" ${ARGN} )
+
+    # Collect sample sources
+
+    file(GLOB_RECURSE SAMPLE_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.java)
+    list(APPEND SAMPLE_SOURCES ${PROJECT_SOURCE_DIR}/samples/ArgumentParser.java)
+
+    # Set InferenceEngine component
+
+    set(IE_JAVA_SRC ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/inference_engine_java_api.jar)
+
+    # Add OpenCV components if required
+
+    if(IE_SAMPLE_OPENCV_DEPENDENCIES) 
+        if(EXISTS "${JAVA_OPENCV_SRC}")
+            list(APPEND IE_JAVA_SRC ${JAVA_OPENCV_SRC})
+        else()
+            message(WARNING "OPENCV .jar file is disabled or not found, " ${IE_SAMPLE_NAME} " skipped")
+            return()
         endif()
-    endforeach()
-endif()
+    endif()
+
+    # Create .jar file from sources
+    
+    add_jar("${IE_SAMPLE_NAME}_jar"
+                    SOURCES ${SAMPLE_SOURCES}
+                    OUTPUT_NAME ${IE_SAMPLE_NAME}  
+                    OUTPUT_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} 
+                    INCLUDE_JARS ${IE_JAVA_SRC})          
+    add_dependencies(${IE_SAMPLE_NAME}_jar inference_engine_jar)
+endmacro()
+
+# Collect all samples subdirectories
+
+file(GLOB samples_dirs RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *)
+
+foreach(dir ${samples_dirs})
+    if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${dir})
+            # Include subdirectory to the project.
+            add_subdirectory(${dir})
+    endif() 
+endforeach()

--- a/inference-engine/ie_bridges/java/samples/CMakeLists.txt
+++ b/inference-engine/ie_bridges/java/samples/CMakeLists.txt
@@ -1,64 +1,64 @@
-# # Copyright (C) 2020 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 
-# # Find OpenCV components if exist
+# Find OpenCV components if exist
 
-# find_package(OpenCV QUIET)
+find_package(OpenCV QUIET)
 
-# if(EXISTS "${OpenCV_INSTALL_PATH}/share/java")
-#     file(GLOB_RECURSE JAVA_OPENCV_SRC ${OpenCV_INSTALL_PATH}/share/java/*.jar)
-# elseif(EXISTS "${OpenCV_INSTALL_PATH}/bin")
-#     file(GLOB JAVA_OPENCV_SRC ${OpenCV_INSTALL_PATH}/bin/*.jar)
-# endif()
+if(EXISTS "${OpenCV_INSTALL_PATH}/share/java")
+    file(GLOB_RECURSE JAVA_OPENCV_SRC ${OpenCV_INSTALL_PATH}/share/java/*.jar)
+elseif(EXISTS "${OpenCV_INSTALL_PATH}/bin")
+    file(GLOB JAVA_OPENCV_SRC ${OpenCV_INSTALL_PATH}/bin/*.jar)
+endif()
 
-# #
-# # ie_add_java_sample(NAME <target name>
-# #               SOURCES <source files>
-# #               [DEPENDENCIES <dependencies>]
-# #               [OPENCV_DEPENDENCIES]
-# #
-# macro(ie_add_java_sample)
-#     set(options OPENCV_DEPENDENCIES)
-#     set(oneValueArgs NAME)
-#     cmake_parse_arguments(IE_SAMPLE "${options}" "${oneValueArgs}"
-#                           "" ${ARGN} )
+#
+# ie_add_java_sample(NAME <target name>
+#               SOURCES <source files>
+#               [DEPENDENCIES <dependencies>]
+#               [OPENCV_DEPENDENCIES]
+#
+macro(ie_add_java_sample)
+    set(options OPENCV_DEPENDENCIES)
+    set(oneValueArgs NAME)
+    cmake_parse_arguments(IE_SAMPLE "${options}" "${oneValueArgs}"
+                          "" ${ARGN} )
 
-#     # Collect sample sources
+    # Collect sample sources
 
-#     file(GLOB_RECURSE SAMPLE_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.java)
-#     list(APPEND SAMPLE_SOURCES ${PROJECT_SOURCE_DIR}/samples/ArgumentParser.java)
+    file(GLOB_RECURSE SAMPLE_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.java)
+    list(APPEND SAMPLE_SOURCES ${PROJECT_SOURCE_DIR}/samples/ArgumentParser.java)
 
-#     # Set InferenceEngine component
+    # Set InferenceEngine component
 
-#     set(IE_JAVA_SRC ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/inference_engine_java_api.jar)
+    set(IE_JAVA_SRC ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/inference_engine_java_api.jar)
 
-#     # Add OpenCV components if required
+    # Add OpenCV components if required
 
-#     if(IE_SAMPLE_OPENCV_DEPENDENCIES) 
-#         if(EXISTS "${JAVA_OPENCV_SRC}")
-#             list(APPEND IE_JAVA_SRC ${JAVA_OPENCV_SRC})
-#         else()
-#             message(WARNING "OPENCV .jar file is disabled or not found, " ${IE_SAMPLE_NAME} " skipped")
-#             return()
-#         endif()
-#     endif()
+    if(IE_SAMPLE_OPENCV_DEPENDENCIES) 
+        if(EXISTS "${JAVA_OPENCV_SRC}")
+            list(APPEND IE_JAVA_SRC ${JAVA_OPENCV_SRC})
+        else()
+            message(WARNING "OPENCV .jar file is disabled or not found, " ${IE_SAMPLE_NAME} " skipped")
+            return()
+        endif()
+    endif()
 
-#     # Create .jar file from sources
+    # Create .jar file from sources
     
-#     add_jar("${IE_SAMPLE_NAME}_jar"
-#                     SOURCES ${SAMPLE_SOURCES}
-#                     OUTPUT_NAME ${IE_SAMPLE_NAME}  
-#                     OUTPUT_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} 
-#                     INCLUDE_JARS ${IE_JAVA_SRC})          
-#     add_dependencies(${IE_SAMPLE_NAME}_jar inference_engine_jar)
-# endmacro()
+    add_jar("${IE_SAMPLE_NAME}_jar"
+                    SOURCES ${SAMPLE_SOURCES}
+                    OUTPUT_NAME ${IE_SAMPLE_NAME}  
+                    OUTPUT_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} 
+                    INCLUDE_JARS ${IE_JAVA_SRC})          
+    add_dependencies(${IE_SAMPLE_NAME}_jar inference_engine_jar)
+endmacro()
 
-# # Collect all samples subdirectories
+# Collect all samples subdirectories
 
-# file(GLOB samples_dirs RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *)
+file(GLOB samples_dirs RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *)
 
-# foreach(dir ${samples_dirs})
-#     if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${dir})
-#             # Include subdirectory to the project.
-#             add_subdirectory(${dir})
-#     endif() 
-# endforeach()
+foreach(dir ${samples_dirs})
+    if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${dir})
+            # Include subdirectory to the project.
+            add_subdirectory(${dir})
+    endif() 
+endforeach()

--- a/inference-engine/ie_bridges/java/samples/benchmark_app/CMakeLists.txt
+++ b/inference-engine/ie_bridges/java/samples/benchmark_app/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (C) 2020 Intel Corporation
+
+get_filename_component(sample_name "${CMAKE_CURRENT_SOURCE_DIR}" NAME)
+
+ie_add_java_sample(NAME ${sample_name})

--- a/inference-engine/ie_bridges/java/samples/face_detection_java_sample/CMakeLists.txt
+++ b/inference-engine/ie_bridges/java/samples/face_detection_java_sample/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright (C) 2020 Intel Corporation
+
+get_filename_component(sample_name "${CMAKE_CURRENT_SOURCE_DIR}" NAME)
+
+ie_add_java_sample(NAME ${sample_name} OPENCV_DEPENDENCIES)
+              

--- a/inference-engine/ie_bridges/java/samples/face_detection_sample_async/CMakeLists.txt
+++ b/inference-engine/ie_bridges/java/samples/face_detection_sample_async/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright (C) 2020 Intel Corporation
+
+get_filename_component(sample_name "${CMAKE_CURRENT_SOURCE_DIR}" NAME)
+
+ie_add_java_sample(NAME ${sample_name} OPENCV_DEPENDENCIES)
+              


### PR DESCRIPTION
Fixed: 
1. After CMakeLists split, Java samples can't be built.
2. Java Benchmark Application can't be build without OpenCV.