### PR TITLE
[IE CLDNN] Add input padding directly to input tensor in convolution_random_smoke_test

### DIFF
--- a/inference-engine/thirdparty/clDNN/tests/test_cases/convolution_gpu_test.cpp
+++ b/inference-engine/thirdparty/clDNN/tests/test_cases/convolution_gpu_test.cpp
@@ -7661,7 +7661,7 @@ template <typename InputT, typename WeightsT, typename OutputT>
 class convolution_test_base {
 public:
     virtual topology build_topology(const cldnn::engine& engine) {
-        auto input_lay = layout(input_type(), format::bfyx, input_size());
+        auto input_lay = layout(input_type(), format::bfyx, input_size(), padding_size());
         auto wei_lay = layout(weights_type(), format::bfyx, weights_size());
 
         auto wei_mem = memory::allocate(engine, wei_lay);
@@ -7739,7 +7739,7 @@ public:
 
         auto net = network(prog, 0);
 
-        auto input_lay = layout(input_type(), format::bfyx, input_size());
+        auto input_lay = layout(input_type(), format::bfyx, input_size(), padding_size());
         auto input_mem = memory::allocate(engine, input_lay);
         std::vector<InputT> input_flat(input_lay.get_linear_size(), static_cast<InputT>(0));
         for (size_t bi = 0; bi < batch_num(); ++bi)
@@ -8026,7 +8026,7 @@ class convolution_random_test_fsv4_input : public convolution_random_test_base<I
 public:
     using parent = convolution_random_test_base<InputT, WeightsT, OutputT>;
     topology build_topology(const cldnn::engine& engine) override {
-        auto input_lay = layout(this->input_type(), format::b_fs_yx_fsv4, this->input_size());
+        auto input_lay = layout(this->input_type(), format::b_fs_yx_fsv4, this->input_size(), this->padding_size());
         auto wei_lay = layout(this->weights_type(), format::bfyx, this->weights_size());
 
         auto wei_mem = memory::allocate(engine, wei_lay);
@@ -8099,7 +8099,7 @@ public:
 
         auto net = network(prog, 0);
 
-        auto input_lay = layout(this->input_type(), format::b_fs_yx_fsv4,  this->input_size());
+        auto input_lay = layout(this->input_type(), format::b_fs_yx_fsv4,  this->input_size(), this->padding_size());
         auto input_mem = memory::allocate(engine, input_lay);
         std::vector<InputT> input_flat(input_lay.get_linear_size(), static_cast<InputT>(0));
         for (size_t bi = 0; bi < this->batch_num(); ++bi)


### PR DESCRIPTION
This patch is meant to add input padding directly to input tensor in convolution_random_smoke_test unit tests. Currently, it's added only to the output of following reorder, which may be later removed by 'remove_redundant_reorders' graph optimizer pass. It affects testing how kernels handle input padding, because final convolution input in such cases actually doesn't have any padding.

Anoter problem (not visible in currently enabled set of tests and convolution implementations) is that in some cases it may also lead to test fail due to lack of compatible kernel. For example, forcing ConvolutionKernel_imad as convolution implementation may lead to fail in a following test case, because this implementation's NeedPaddedInput() method returns true and as it supports fsv4 input & fsv16 output, input reorder is optimized out:
`basic/convolution_random_smoke_test.s8s8f32_fsv4_input/b_fs_yx_fsv16_i1x3x28x28_w32x3x7x7_s2x2_ofsm3xm3_d1x1_g1_bias_in_pad`

This PR should be merged after #3194 to avoid unit tests fails.