### PR TITLE
[IE TESTS][CPU] Fusing tests added to the CPU specific single layer tests.

### DIFF
--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/activation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/activation.cpp
@@ -65,7 +65,7 @@ TEST_P(ActivationLayerCPUTest, CompareWithRefs) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 
     Run();
-    CheckCPUImpl(executableNetwork, "Eltwise");
+    CheckPluginRelatedResults(executableNetwork, "Eltwise");
 }
 
 

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution.cpp
@@ -59,7 +59,7 @@ protected:
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
-        std::tie(postFunction, postNodes, fusedOps) = fusingParams;
+        std::tie(postOpMgrPtr, fusedOps) = fusingParams;
 
         convSpecificParams convParams;
         std::vector<size_t> inputShape;
@@ -112,7 +112,8 @@ const std::vector<fusingSpecificParams> fusingParamsSet{
         fusingReluScaleShift,
         fusingFakeQuantizePerTensorRelu,
         fusingFakeQuantizePerChannelRelu,
-        fusingSum,
+        fusingSumEluFQ,
+        fusingSum
 };
 
 const std::vector<fusingSpecificParams> fusingParamsSetBF16{
@@ -126,7 +127,7 @@ const std::vector<fusingSpecificParams> fusingParamsSetBF16{
         fusingSwish,
         // other patterns
         fusingReluScaleShift,
-        fusingSum,
+        fusingSum
 };
 
 const std::map<std::string, std::string> cpuEmptyPluginConfig;

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution.cpp
@@ -1,0 +1,402 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "test_utils/cpu_test_utils.hpp"
+#include "test_utils/fusing_test_utils.hpp"
+#include "shared_test_classes/base/layer_test_utils.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+#include "ngraph_functions/builders.hpp"
+#include <shared_test_classes/single_layer/convolution.hpp>
+
+using namespace InferenceEngine;
+using namespace CPUTestUtils;
+
+namespace CPULayerTestsDefinitions {
+using LayerTestsDefinitions::convSpecificParams;
+using LayerTestsDefinitions::convLayerTestParamsSet;
+
+typedef std::tuple<
+    convLayerTestParamsSet,
+    CPUSpecificParams,
+    fusingSpecificParams,
+    std::map<std::string, std::string> > convLayerCPUTestParamsSet;
+
+class ConvolutionLayerCPUTest : public testing::WithParamInterface<convLayerCPUTestParamsSet>,
+    virtual public LayerTestsUtils::LayerTestsCommon, public CpuTestWithFusing {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<convLayerCPUTestParamsSet> obj) {
+        convLayerTestParamsSet basicParamsSet;
+        CPUSpecificParams cpuParams;
+        fusingSpecificParams fusingParams;
+        std::map<std::string, std::string> additionalConfig;
+        std::tie(basicParamsSet, cpuParams, fusingParams, additionalConfig) = obj.param;
+
+        std::ostringstream result;
+        result << LayerTestsDefinitions::ConvolutionLayerTest::getTestCaseName(testing::TestParamInfo<convLayerTestParamsSet>(
+            basicParamsSet, 0));
+
+        result << CPUTestsBase::getTestCaseName(cpuParams);
+        result << CpuTestWithFusing::getTestCaseName(fusingParams);
+
+        if (!additionalConfig.empty()) {
+            result << "_PluginConf";
+            for (auto& item : additionalConfig) {
+                result << "_" << item.first << "=" << item.second;
+            }
+        }
+
+        return result.str();
+    }
+protected:
+    void SetUp() override {
+        convLayerTestParamsSet basicParamsSet;
+        CPUSpecificParams cpuParams;
+        fusingSpecificParams fusingParams;
+        std::map<std::string, std::string> additionalConfig;
+        std::tie(basicParamsSet, cpuParams, fusingParams, additionalConfig) = this->GetParam();
+
+        configuration.insert(additionalConfig.begin(), additionalConfig.end());
+
+        std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
+        std::tie(postFunction, postNodes, fusedOps) = fusingParams;
+
+        convSpecificParams convParams;
+        std::vector<size_t> inputShape;
+        auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
+        std::tie(convParams, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, targetDevice) = basicParamsSet;
+
+        if (inPrc == Precision::UNSPECIFIED) {
+            selectedType += std::string("_") + Precision(Precision::FP32).name();
+        } else {
+            selectedType += std::string("_") + inPrc.name();
+        }
+
+        ngraph::op::PadType padType;
+        InferenceEngine::SizeVector kernel, stride, dilation;
+        std::vector<ptrdiff_t> padBegin, padEnd;
+        size_t convOutChannels;
+        std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType) = convParams;
+        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+
+        auto inputParams = ngraph::builder::makeParams(ngraph::element::f32, { inputShape });
+        auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(inputParams));
+
+        auto convolutionNode = ngraph::builder::makeConvolution(paramOuts.front(), ngPrc, kernel, stride, padBegin,
+            padEnd, dilation, padType, convOutChannels);
+
+        function = makeNgraphFunction(ngPrc, inputParams, convolutionNode, "Convolution");
+    }
+};
+
+TEST_P(ConvolutionLayerCPUTest, CompareWithRefs) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    Run();
+    CheckPluginRelatedResults(executableNetwork, "Convolution");
+}
+
+namespace {
+
+/* COMMON PARAMS */
+const std::vector<fusingSpecificParams> fusingParamsSet{
+        emptyFusingSpec,
+        // activations
+        fusingRelu,
+        fusingElu,
+        fusingSigmoid,
+        fusingClamp,
+        fusingPRelu,
+        fusingSwish,
+        // other patterns
+        fusingReluScaleShift,
+        fusingFakeQuantizePerTensorRelu,
+        fusingFakeQuantizePerChannelRelu,
+        fusingSum,
+};
+
+const std::vector<fusingSpecificParams> fusingParamsSetBF16{
+        emptyFusingSpec,
+        // activations
+        fusingRelu,
+        fusingElu,
+        fusingSigmoid,
+        fusingClamp,
+        fusingPRelu,
+        fusingSwish,
+        // other patterns
+        fusingReluScaleShift,
+        fusingSum,
+};
+
+const std::map<std::string, std::string> cpuEmptyPluginConfig;
+const std::map<std::string, std::string> cpuBF16PluginConfig = { { PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES } };
+
+/* ============= Convolution params (planar layout) ============= */
+const SizeVector numOutChannels_Planar = { 6 };
+
+/* ============= Convolution params (blocked layout) ============= */
+const SizeVector numOutChannels_Blocked = { 64 };
+
+/* ============= Convolution params (2D) ============= */
+const std::vector<SizeVector> kernels2d = { {3, 3}, {1, 1} };
+const std::vector<SizeVector> strides2d = { {1, 1}, {2, 2} };
+const std::vector<std::vector<ptrdiff_t>> padBegins2d = { {0, 0}, {1, 1} };
+const std::vector<std::vector<ptrdiff_t>> padEnds2d = { {0, 0} };
+const std::vector<SizeVector> dilations2d = { {1, 1}, {2, 2} };
+
+/* ============= Convolution params (3D) ============= */
+const std::vector<SizeVector> kernels3d = { {3, 3, 3}, {1, 1, 1} };
+const std::vector<SizeVector> strides3d = { {1, 1, 1}, {2, 2, 2} };
+const std::vector<std::vector<ptrdiff_t>> padBegins3d = { {0, 0, 0}, {1, 1, 1} };
+const std::vector<std::vector<ptrdiff_t>> padEnds3d = { {0, 0, 0} };
+const std::vector<SizeVector> dilations3d = { {1, 1, 1}, {2, 2, 2} };
+/* ============= */
+
+/* INSTANCES */
+/* ============= Convolution (Planar 2D) ============= */
+const auto convParams_ExplicitPadding_Planar_2D = ::testing::Combine(
+    ::testing::ValuesIn(kernels2d),
+    ::testing::ValuesIn(strides2d),
+    ::testing::ValuesIn(padBegins2d),
+    ::testing::ValuesIn(padEnds2d),
+    ::testing::ValuesIn(dilations2d),
+    ::testing::ValuesIn(numOutChannels_Planar),
+    ::testing::Values(ngraph::op::PadType::EXPLICIT)
+);
+
+const std::vector<CPUSpecificParams> CPUParams_Planar_2D = {
+        conv_gemm_2D
+};
+
+INSTANTIATE_TEST_CASE_P(smoke_Conv_2D_Planar_FP32, ConvolutionLayerCPUTest,
+    ::testing::Combine(
+        ::testing::Combine(
+            convParams_ExplicitPadding_Planar_2D,
+            ::testing::Values(Precision::FP32),
+            ::testing::Values(Precision::UNSPECIFIED),
+            ::testing::Values(Precision::UNSPECIFIED),
+            ::testing::Values(Layout::ANY),
+            ::testing::Values(Layout::ANY),
+            ::testing::Values(std::vector<size_t >({ 2, 12, 7, 7 })),
+            ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+        ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Planar_2D)),
+        ::testing::ValuesIn(fusingParamsSet),
+        ::testing::Values(cpuEmptyPluginConfig)),
+    ConvolutionLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_Conv_2D_Planar_BF16, ConvolutionLayerCPUTest,
+    ::testing::Combine(
+        ::testing::Combine(
+            convParams_ExplicitPadding_Planar_2D,
+            ::testing::Values(Precision::FP32),
+            ::testing::Values(Precision::BF16),
+            ::testing::Values(Precision::BF16),
+            ::testing::Values(Layout::ANY),
+            ::testing::Values(Layout::ANY),
+            ::testing::Values(std::vector<size_t >({ 2, 12, 7, 7 })),
+            ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+        ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Planar_2D)),
+        ::testing::ValuesIn(fusingParamsSetBF16),
+        ::testing::Values(cpuBF16PluginConfig)),
+    ConvolutionLayerCPUTest::getTestCaseName);
+
+/* ============= GroupConvolution (Planar 3D) ============= */
+const auto convParams_ExplicitPadding_Planar_3D = ::testing::Combine(
+    ::testing::ValuesIn(kernels3d),
+    ::testing::ValuesIn(strides3d),
+    ::testing::ValuesIn(padBegins3d),
+    ::testing::ValuesIn(padEnds3d),
+    ::testing::ValuesIn(dilations3d),
+    ::testing::ValuesIn(numOutChannels_Planar),
+    ::testing::Values(ngraph::op::PadType::EXPLICIT)
+);
+
+const std::vector<CPUSpecificParams> CPUParams_Planar_3D = {
+        conv_gemm_3D
+};
+
+INSTANTIATE_TEST_CASE_P(smoke_Conv_3D_Planar_FP32, ConvolutionLayerCPUTest,
+    ::testing::Combine(
+        ::testing::Combine(
+            convParams_ExplicitPadding_Planar_3D,
+            ::testing::Values(Precision::FP32),
+            ::testing::Values(Precision::UNSPECIFIED),
+            ::testing::Values(Precision::UNSPECIFIED),
+            ::testing::Values(Layout::ANY),
+            ::testing::Values(Layout::ANY),
+            ::testing::Values(std::vector<size_t >({ 2, 12, 7, 7, 7 })),
+            ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+        ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Planar_3D)),
+        ::testing::ValuesIn(fusingParamsSet),
+        ::testing::Values(cpuEmptyPluginConfig)),
+    ConvolutionLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_Conv_3D_Planar_BF16, ConvolutionLayerCPUTest,
+    ::testing::Combine(
+        ::testing::Combine(
+            convParams_ExplicitPadding_Planar_3D,
+            ::testing::Values(Precision::FP32),
+            ::testing::Values(Precision::BF16),
+            ::testing::Values(Precision::BF16),
+            ::testing::Values(Layout::ANY),
+            ::testing::Values(Layout::ANY),
+            ::testing::Values(std::vector<size_t >({ 2, 12, 7, 7, 7 })),
+            ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+        ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Planar_3D)),
+        ::testing::ValuesIn(fusingParamsSetBF16),
+        ::testing::Values(cpuBF16PluginConfig)),
+    ConvolutionLayerCPUTest::getTestCaseName);
+
+/* ============= GroupConvolution (Blocked 2D) ============= */
+const auto convParams_ExplicitPadding_Blocked_2D = ::testing::Combine(
+    ::testing::ValuesIn(kernels2d),
+    ::testing::ValuesIn(strides2d),
+    ::testing::ValuesIn(padBegins2d),
+    ::testing::ValuesIn(padEnds2d),
+    ::testing::ValuesIn(dilations2d),
+    ::testing::ValuesIn(numOutChannels_Blocked),
+    ::testing::Values(ngraph::op::PadType::EXPLICIT)
+);
+
+const std::vector<CPUSpecificParams> CPUParams_Blocked_2D = {
+        conv_sse42_2D,
+        conv_avx2_2D,
+        conv_avx512_2D
+};
+
+INSTANTIATE_TEST_CASE_P(smoke_Conv_2D_Blocked_FP32, ConvolutionLayerCPUTest,
+    ::testing::Combine(
+        ::testing::Combine(
+            convParams_ExplicitPadding_Blocked_2D,
+            ::testing::Values(Precision::FP32),
+            ::testing::Values(Precision::UNSPECIFIED),
+            ::testing::Values(Precision::UNSPECIFIED),
+            ::testing::Values(Layout::ANY),
+            ::testing::Values(Layout::ANY),
+            ::testing::Values(std::vector<size_t >({ 2, 64, 7, 7 })),
+            ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+        ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Blocked_2D)),
+        ::testing::ValuesIn(fusingParamsSet),
+        ::testing::Values(cpuEmptyPluginConfig)),
+    ConvolutionLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_Conv_2D_Blocked_BF16, ConvolutionLayerCPUTest,
+    ::testing::Combine(
+        ::testing::Combine(
+            convParams_ExplicitPadding_Blocked_2D,
+            ::testing::Values(Precision::FP32),
+            ::testing::Values(Precision::BF16),
+            ::testing::Values(Precision::BF16),
+            ::testing::Values(Layout::ANY),
+            ::testing::Values(Layout::ANY),
+            ::testing::Values(std::vector<size_t >({ 2, 64, 7, 7 })),
+            ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D})),
+        ::testing::ValuesIn(fusingParamsSetBF16),
+        ::testing::Values(cpuBF16PluginConfig)),
+    ConvolutionLayerCPUTest::getTestCaseName);
+
+/* ============= GroupConvolution (Blocked 3D) ============= */
+const auto convParams_ExplicitPadding_Blocked_3D = ::testing::Combine(
+    ::testing::ValuesIn(kernels3d),
+    ::testing::ValuesIn(strides3d),
+    ::testing::ValuesIn(padBegins3d),
+    ::testing::ValuesIn(padEnds3d),
+    ::testing::ValuesIn(dilations3d),
+    ::testing::ValuesIn(numOutChannels_Blocked),
+    ::testing::Values(ngraph::op::PadType::EXPLICIT)
+);
+
+const std::vector<CPUSpecificParams> CPUParams_Blocked_3D = {
+            //conv_sse42_3D, // not supported jit_sse42 for 3d
+            conv_avx2_3D,
+            conv_avx512_3D
+};
+
+INSTANTIATE_TEST_CASE_P(smoke_Conv_3D_Blocked_FP32, ConvolutionLayerCPUTest,
+    ::testing::Combine(
+        ::testing::Combine(
+            convParams_ExplicitPadding_Blocked_3D,
+            ::testing::Values(Precision::FP32),
+            ::testing::Values(Precision::UNSPECIFIED),
+            ::testing::Values(Precision::UNSPECIFIED),
+            ::testing::Values(Layout::ANY),
+            ::testing::Values(Layout::ANY),
+            ::testing::Values(std::vector<size_t >({ 2, 64, 7, 7, 7 })),
+            ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+        ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Blocked_3D)),
+        ::testing::ValuesIn(fusingParamsSet),
+        ::testing::Values(cpuEmptyPluginConfig)),
+    ConvolutionLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_Conv_3D_Blocked_BF16, ConvolutionLayerCPUTest,
+    ::testing::Combine(
+        ::testing::Combine(
+            convParams_ExplicitPadding_Blocked_3D,
+            ::testing::Values(Precision::FP32),
+            ::testing::Values(Precision::BF16),
+            ::testing::Values(Precision::BF16),
+            ::testing::Values(Layout::ANY),
+            ::testing::Values(Layout::ANY),
+            ::testing::Values(std::vector<size_t >({ 2, 64, 7, 7, 7 })),
+            ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_3D})),
+        ::testing::ValuesIn(fusingParamsSetBF16),
+        ::testing::Values(cpuBF16PluginConfig)),
+    ConvolutionLayerCPUTest::getTestCaseName);
+
+/* ============= Kernel_1x1 (2D) ============= */
+
+const auto convParams_ExplicitPadding_1x1_2D = ::testing::Combine(
+        ::testing::Values(SizeVector({1, 1})),
+        ::testing::Values(SizeVector({1, 1})),
+        ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
+        ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
+        ::testing::Values(SizeVector({1, 1})),
+        ::testing::ValuesIn(numOutChannels_Blocked),
+        ::testing::Values(ngraph::op::PadType::EXPLICIT)
+);
+
+const std::vector<CPUSpecificParams> CPUParams_1x1_2D = {
+    conv_sse42_2D_1x1,
+    conv_avx2_2D_1x1,
+    conv_avx512_2D_1x1
+};
+
+INSTANTIATE_TEST_CASE_P(smoke_Conv_2D_1x1_FP32, ConvolutionLayerCPUTest,
+    ::testing::Combine(
+        ::testing::Combine(
+            convParams_ExplicitPadding_1x1_2D,
+            ::testing::Values(Precision::FP32),
+            ::testing::Values(Precision::UNSPECIFIED),
+            ::testing::Values(Precision::UNSPECIFIED),
+            ::testing::Values(Layout::ANY),
+            ::testing::Values(Layout::ANY),
+            ::testing::Values(std::vector<size_t >({ 2, 64, 7, 7 })),
+            ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+        ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_1x1_2D)),
+        ::testing::ValuesIn(fusingParamsSet),
+        ::testing::Values(cpuEmptyPluginConfig)),
+    ConvolutionLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_Conv_2D_1x1_BF16, ConvolutionLayerCPUTest,
+    ::testing::Combine(
+        ::testing::Combine(
+            convParams_ExplicitPadding_1x1_2D,
+            ::testing::Values(Precision::FP32),
+            ::testing::Values(Precision::BF16),
+            ::testing::Values(Precision::BF16),
+            ::testing::Values(Layout::ANY),
+            ::testing::Values(Layout::ANY),
+            ::testing::Values(std::vector<size_t >({ 2, 64, 7, 7 })),
+            ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D_1x1})),
+        ::testing::ValuesIn(fusingParamsSetBF16),
+        ::testing::Values(cpuBF16PluginConfig)),
+    ConvolutionLayerCPUTest::getTestCaseName);
+
+/* ========= */
+
+} // namespace
+} // namespace CPULayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/crop.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/crop.cpp
@@ -86,7 +86,7 @@ TEST_P(CropLayerCPUTest, CompareWithRefs) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 
     Run();
-    CheckCPUImpl(executableNetwork, "Crop");
+    CheckPluginRelatedResults(executableNetwork, "Crop");
 }
 
 namespace {

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/eltwise.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/eltwise.cpp
@@ -90,8 +90,8 @@ protected:
         }
 
         auto eltwise = ngraph::builder::makeEltwise(input[0], secondaryInput, eltwiseType);
-        eltwise->get_rt_info() = getCPUInfo();
-        function = std::make_shared<ngraph::Function>(eltwise, input, "Eltwise");
+
+        function = makeNgraphFunction(ngPrc, input, eltwise, "Eltwise");
     }
 };
 

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/eltwise.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/eltwise.cpp
@@ -99,7 +99,7 @@ TEST_P(EltwiseLayerCPUTest, CompareWithRefs) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 
     Run();
-    CheckCPUImpl(executableNetwork, "Eltwise");
+    CheckPluginRelatedResults(executableNetwork, "Eltwise");
 }
 
 namespace {

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
@@ -60,9 +60,7 @@ protected:
         auto groupConv = std::dynamic_pointer_cast<ngraph::opset1::GroupConvolution>(
                 ngraph::builder::makeGroupConvolution(paramOuts[0], ngPrc, kernel, stride, padBegin,
                                                       padEnd, dilation, padType, convOutChannels, numGroups));
-        groupConv->get_rt_info() = getCPUInfo();
-        ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(groupConv)};
-        function = std::make_shared<ngraph::Function>(results, params, "groupConvolution");
+        function = makeNgraphFunction(ngPrc, params, groupConv, "groupConvolution");
     }
 };
 

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
@@ -46,7 +46,7 @@ protected:
         std::tie(basicParamsSet, cpuParams, fusingParams) = this->GetParam();
 
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
-        std::tie(postFunction, postNodes, fusedOps) = fusingParams;
+        std::tie(postOpMgrPtr, fusedOps) = fusingParams;
 
         groupConvSpecificParams groupConvParams;
         std::vector<size_t> inputShape;
@@ -125,6 +125,7 @@ std::vector<fusingSpecificParams> fusingParamsSet {
         fusingReluScaleShift,
         fusingFakeQuantizePerTensorRelu,
         fusingFakeQuantizePerChannelRelu,
+        fusingSumEluFQ,
         fusingSum,
 };
 

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
@@ -139,6 +139,7 @@ std::vector<fusingSpecificParams> fusingParamsSet {
         fusingSwish,
         // other patterns
         fusingReluScaleShift,
+        fusingFakeQuantizePerTensorRelu,
         fusingFakeQuantizePerChannelRelu,
         fusingSum,
 };

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
@@ -53,6 +53,12 @@ protected:
         auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
         std::tie(groupConvParams, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, targetDevice) = basicParamsSet;
 
+        if (inPrc == Precision::UNSPECIFIED) {
+            selectedType += std::string("_") + Precision(Precision::FP32).name();
+        } else {
+            selectedType += std::string("_") + inPrc.name();
+        }
+
         ngraph::op::PadType padType;
         InferenceEngine::SizeVector kernel, stride, dilation;
         std::vector<ptrdiff_t> padBegin, padEnd;
@@ -80,28 +86,6 @@ TEST_P(GroupConvolutionLayerCPUTest, CompareWithRefs) {
 namespace {
 
 /* GROUP CONV TEST UTILS */
-std::vector<CPUSpecificParams> filterCPUInfoForDevice(std::vector<CPUSpecificParams> CPUParams) {
-    std::vector<CPUSpecificParams> resCPUParams;
-    const int selectedTypeIndex = 3;
-
-    for (auto param : CPUParams) {
-        auto selectedTypeStr = std::get<selectedTypeIndex>(param);
-
-        if (selectedTypeStr.find("jit") != std::string::npos && !with_cpu_x86_sse42())
-            continue;
-        if (selectedTypeStr.find("sse42") != std::string::npos && !with_cpu_x86_sse42())
-            continue;
-        if (selectedTypeStr.find("avx2") != std::string::npos && !with_cpu_x86_avx2())
-            continue;
-        if (selectedTypeStr.find("avx512") != std::string::npos && !with_cpu_x86_avx512f())
-            continue;
-
-        resCPUParams.push_back(param);
-    }
-
-    return resCPUParams;
-}
-
 std::vector<groupConvLayerCPUTestParamsSet> filterParamsSetForDevice(std::vector<groupConvLayerCPUTestParamsSet> paramsSet) {
     std::vector<groupConvLayerCPUTestParamsSet> resParamsSet;
     const int cpuParamsIndex = 1;

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/interpolate.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/interpolate.cpp
@@ -85,9 +85,7 @@ protected:
                                                                          scalesInput,
                                                                          axesInput,
                                                                          interpolateAttributes);
-        interpolate->get_rt_info() = getCPUInfo();
-        const ngraph::ResultVector results{std::make_shared<ngraph::opset3::Result>(interpolate)};
-        function = std::make_shared<ngraph::Function>(results, params, "interpolate");
+        function = makeNgraphFunction(ngPrc, params, interpolate, "interpolate");
         selectedType = getPrimitiveType() + "_" + inPrc.name();
     }
 };

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/interpolate.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/interpolate.cpp
@@ -94,7 +94,7 @@ TEST_P(InterpolateLayerCPUTest, CompareWithRefs) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 
     Run();
-    CheckCPUImpl(executableNetwork, "Interpolate");
+    CheckPluginRelatedResults(executableNetwork, "Interpolate");
 }
 
 namespace {

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/logical.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/logical.cpp
@@ -79,7 +79,7 @@ TEST_P(LogicalLayerCPUTest, CompareWithRefs) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 
     Run();
-    CheckCPUImpl(executableNetwork, "Eltwise");
+    CheckPluginRelatedResults(executableNetwork, "Eltwise");
 }
 
 namespace {

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/mvn.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/mvn.cpp
@@ -71,7 +71,7 @@ TEST_P(MvnLayerCPUTest, CompareWithRefs) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 
     Run();
-    CheckCPUImpl(executableNetwork, "MVN");
+    CheckPluginRelatedResults(executableNetwork, "MVN");
 }
 
 namespace {

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/normalize.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/normalize.cpp
@@ -73,7 +73,7 @@ TEST_P(NormalizeL2LayerCPUTest, CompareWithRefs) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 
     Run();
-    CheckCPUImpl(executableNetwork, "Normalize");
+    CheckPluginRelatedResults(executableNetwork, "Normalize");
 }
 
 namespace {

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/pad.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/pad.cpp
@@ -65,7 +65,7 @@ TEST_P(PadLayerCPUTest, CompareWithRefs) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 
     Run();
-    CheckCPUImpl(executableNetwork, "Pad");
+    CheckPluginRelatedResults(executableNetwork, "Pad");
 }
 
 namespace {

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/permute.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/permute.cpp
@@ -76,7 +76,7 @@ TEST_P(PermuteLayerCPUTest, CompareWithRefs) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 
     Run();
-    CheckCPUImpl(executableNetwork, "Permute");
+    CheckPluginRelatedResults(executableNetwork, "Permute");
 }
 
 namespace {

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/reduce_ops.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/reduce_ops.cpp
@@ -114,7 +114,7 @@ TEST_P(ReduceCPULayerTest, CompareWithRefs) {
     }
 
     Run();
-    CheckCPUImpl(executableNetwork, name);
+    CheckPluginRelatedResults(executableNetwork, name);
 }
 namespace {
 std::vector<Precision> inpOutPrc = {Precision::BF16, Precision::FP32};

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/region_yolo.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/region_yolo.cpp
@@ -81,7 +81,7 @@ TEST_P(RegionYoloCPULayerTest, CompareWithRefs) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 
     Run();
-    CheckCPUImpl(executableNetwork, "RegionYolo");
+    CheckPluginRelatedResults(executableNetwork, "RegionYolo");
 }
 
 namespace {

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/roialign.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/roialign.cpp
@@ -104,7 +104,7 @@ protected:
 TEST_P(ROIAlignLayerCPUTest, CompareWithRefs) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
     Run();
-    CheckCPUImpl(executableNetwork, "ROIAlign");
+    CheckPluginRelatedResults(executableNetwork, "ROIAlign");
 }
 
 namespace {

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/split.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/split.cpp
@@ -81,7 +81,7 @@ TEST_P(SplitLayerCPUTest, CompareWithRefs) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 
     Run();
-    CheckCPUImpl(executableNetwork, "Split");
+    CheckPluginRelatedResults(executableNetwork, "Split");
 }
 
 namespace {

--- a/inference-engine/tests/functional/plugin/cpu/subgraph_tests/src/conv_concat.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/subgraph_tests/src/conv_concat.cpp
@@ -61,6 +61,8 @@ void ConvConcatSubgraphTest::SetUp() {
     std::tie(kernelSize, strides, padBegin, padEnd, dilation, numOutChannels, paddingType, numOfGroups) = convParams;
     std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
 
+    selectedType += "_FP32";
+
     auto inputParams = ngraph::builder::makeParams(ngraph::element::f32, {inputShapes, inputShapes});
     auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(inputParams));
 
@@ -137,28 +139,6 @@ const std::vector<ptrdiff_t> padEnd3D{1, 1, 1};
 const SizeVector dilation3D{1, 1, 1};
 commonConvParams convParams3D = commonConvParams{kernelSize3D, strides3D, padBegin3D, padEnd3D, dilation3D, numOutChannels, paddingType, 1};
 commonConvParams groupConvParams3D = commonConvParams{kernelSize3D, strides3D, padBegin3D, padEnd3D, dilation3D, numOutChannels, paddingType, 2};
-
-std::vector<CPUSpecificParams> filterCPUInfoForDevice(std::vector<CPUSpecificParams> CPUParams) {
-    std::vector<CPUSpecificParams> resCPUParams;
-    const int selectedTypeIndex = 3;
-
-    for (auto param : CPUParams) {
-        auto selectedTypeStr = std::get<selectedTypeIndex>(param);
-
-        if (selectedTypeStr.find("jit") != std::string::npos && !with_cpu_x86_sse42())
-            continue;
-        if (selectedTypeStr.find("sse42") != std::string::npos && !with_cpu_x86_sse42())
-            continue;
-        if (selectedTypeStr.find("avx2") != std::string::npos && !with_cpu_x86_avx2())
-            continue;
-        if (selectedTypeStr.find("avx512") != std::string::npos && !with_cpu_x86_avx512f())
-            continue;
-
-        resCPUParams.push_back(param);
-    }
-
-    return resCPUParams;
-}
 
 namespace Kernel_1x1 {
 

--- a/inference-engine/tests/functional/plugin/cpu/subgraph_tests/src/conv_concat.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/subgraph_tests/src/conv_concat.cpp
@@ -112,7 +112,7 @@ TEST_P(ConvConcatSubgraphTest, CompareWithRefs) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 
     Run();
-    CheckCPUImpl(executableNetwork, pluginTypeNode);
+    CheckPluginRelatedResults(executableNetwork, pluginTypeNode);
 };
 
 /* ============= Common Convolution Params ============= */

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.cpp
@@ -65,7 +65,7 @@ std::string CPUTestsBase::impls2str(const std::vector<std::string> &priority) {
     return str;
 }
 
-void CPUTestsBase::CheckCPUImpl(InferenceEngine::ExecutableNetwork &execNet, std::string nodeType) const {
+void CPUTestsBase::CheckPluginRelatedResults(InferenceEngine::ExecutableNetwork &execNet, std::string nodeType) const {
     IE_SUPPRESS_DEPRECATED_START
     ASSERT_TRUE(!selectedType.empty()) << "Node type is not defined.";
     bool isNodeFound = false;

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.cpp
@@ -205,4 +205,25 @@ auto adjustBlockedFormatByIsa = [](std::vector<cpu_memory_format_t>& formats) {
     return paramsVector;
 }
 
+std::vector<CPUSpecificParams> filterCPUInfoForDevice(std::vector<CPUSpecificParams> CPUParams) {
+    std::vector<CPUSpecificParams> resCPUParams;
+    const int selectedTypeIndex = 3;
+
+    for (auto param : CPUParams) {
+        auto selectedTypeStr = std::get<selectedTypeIndex>(param);
+
+        if (selectedTypeStr.find("jit") != std::string::npos && !InferenceEngine::with_cpu_x86_sse42())
+            continue;
+        if (selectedTypeStr.find("sse42") != std::string::npos && !InferenceEngine::with_cpu_x86_sse42())
+            continue;
+        if (selectedTypeStr.find("avx2") != std::string::npos && !InferenceEngine::with_cpu_x86_avx2())
+            continue;
+        if (selectedTypeStr.find("avx512") != std::string::npos && !InferenceEngine::with_cpu_x86_avx512f())
+            continue;
+
+        resCPUParams.push_back(param);
+    }
+
+    return resCPUParams;
+}
 } // namespace CPUTestUtils

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.cpp
@@ -170,8 +170,23 @@ CPUTestsBase::makeCPUInfo(std::vector<cpu_memory_format_t> inFmts, std::vector<c
     return cpuInfo;
 }
 
+std::shared_ptr<ngraph::Function>
+CPUTestsBase::makeNgraphFunction(const ngraph::element::Type &ngPrc, ngraph::ParameterVector &params,
+                                 const std::shared_ptr<ngraph::Node> &lastNode, std::string name) const {
+   auto newLastNode = modifyGraph(ngPrc, params, lastNode);
+
+   ngraph::ResultVector results = {std::make_shared<ngraph::opset1::Result>(newLastNode)};
+   return std::make_shared<ngraph::Function>(results, params, name);
+}
+
+std::shared_ptr<ngraph::Node>
+CPUTestsBase::modifyGraph(const ngraph::element::Type &ngPrc, ngraph::ParameterVector &params, const std::shared_ptr<ngraph::Node> &lastNode) const {
+    lastNode->get_rt_info() = getCPUInfo();
+    return lastNode;
+}
+
 std::vector<CPUSpecificParams> filterCPUSpecificParams(std::vector<CPUSpecificParams> &paramsVector) {
-    auto adjustBlockedFormatByIsa = [](std::vector<cpu_memory_format_t>& formats) {
+auto adjustBlockedFormatByIsa = [](std::vector<cpu_memory_format_t>& formats) {
         for (int i = 0; i < formats.size(); i++) {
             if (formats[i] == nChw16c)
                 formats[i] = nChw8c;

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
@@ -68,32 +68,32 @@ protected:
 
 const auto emptyCPUSpec = CPUSpecificParams{{}, {}, {}, {}};
 
-const auto conv_ref_2D = CPUSpecificParams{{nchw}, {nchw}, {"ref_any"}, "ref_any_FP32"};
-const auto conv_ref_3D = CPUSpecificParams{{ncdhw}, {ncdhw}, {"ref_any"}, "ref_any_FP32"};
+const auto conv_ref_2D = CPUSpecificParams{{nchw}, {nchw}, {"ref_any"}, "ref_any"};
+const auto conv_ref_3D = CPUSpecificParams{{ncdhw}, {ncdhw}, {"ref_any"}, "ref_any"};
 
-const auto conv_gemm_2D = CPUSpecificParams{{nchw}, {nchw}, {"gemm_any"}, "jit_gemm_FP32"};
-const auto conv_gemm_3D = CPUSpecificParams{{ncdhw}, {ncdhw}, {"gemm_any"}, "jit_gemm_FP32"};
+const auto conv_gemm_2D = CPUSpecificParams{{nchw}, {nchw}, {"gemm_any"}, "jit_gemm"};
+const auto conv_gemm_3D = CPUSpecificParams{{ncdhw}, {ncdhw}, {"gemm_any"}, "jit_gemm"};
 
-const auto conv_sse42_2D = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_sse42"}, "jit_sse42_FP32"};
-const auto conv_sse42_3D = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {"jit_sse42"}, "jit_sse42_FP32"};
-const auto conv_sse42_dw_2D = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_sse42_dw"}, "jit_sse42_dw_FP32"};
-const auto conv_sse42_dw_3D = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {"jit_sse42_dw"}, "jit_sse42_dw_FP32"};
+const auto conv_sse42_2D = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_sse42"}, "jit_sse42"};
+const auto conv_sse42_3D = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {"jit_sse42"}, "jit_sse42"};
+const auto conv_sse42_dw_2D = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_sse42_dw"}, "jit_sse42_dw"};
+const auto conv_sse42_dw_3D = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {"jit_sse42_dw"}, "jit_sse42_dw"};
 
-const auto conv_avx2_2D = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_avx2"}, "jit_avx2_FP32"};
-const auto conv_avx2_3D = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {"jit_avx2"}, "jit_avx2_FP32"};
-const auto conv_avx2_dw_2D = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_avx2_dw"}, "jit_avx2_dw_FP32"};
-const auto conv_avx2_dw_3D = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {"jit_avx2_dw"}, "jit_avx2_dw_FP32"};
+const auto conv_avx2_2D = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_avx2"}, "jit_avx2"};
+const auto conv_avx2_3D = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {"jit_avx2"}, "jit_avx2"};
+const auto conv_avx2_dw_2D = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_avx2_dw"}, "jit_avx2_dw"};
+const auto conv_avx2_dw_3D = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {"jit_avx2_dw"}, "jit_avx2_dw"};
 
-const auto conv_avx512_2D = CPUSpecificParams{{nChw16c}, {nChw16c}, {"jit_avx512"}, "jit_avx512_FP32"};
-const auto conv_avx512_3D = CPUSpecificParams{{nCdhw16c}, {nCdhw16c}, {"jit_avx512"}, "jit_avx512_FP32"};
-const auto conv_avx512_dw_2D = CPUSpecificParams{{nChw16c}, {nChw16c}, {"jit_avx512_dw"}, "jit_avx512_dw_FP32"};
-const auto conv_avx512_dw_3D = CPUSpecificParams{{nCdhw16c}, {nCdhw16c}, {"jit_avx512_dw"}, "jit_avx512_dw_FP32"};
+const auto conv_avx512_2D = CPUSpecificParams{{nChw16c}, {nChw16c}, {"jit_avx512"}, "jit_avx512"};
+const auto conv_avx512_3D = CPUSpecificParams{{nCdhw16c}, {nCdhw16c}, {"jit_avx512"}, "jit_avx512"};
+const auto conv_avx512_dw_2D = CPUSpecificParams{{nChw16c}, {nChw16c}, {"jit_avx512_dw"}, "jit_avx512_dw"};
+const auto conv_avx512_dw_3D = CPUSpecificParams{{nCdhw16c}, {nCdhw16c}, {"jit_avx512_dw"}, "jit_avx512_dw"};
 
-const auto conv_sse42_2D_1x1 = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_sse42_1x1"}, "jit_sse42_1x1_FP32"};
-const auto conv_avx2_2D_1x1 = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_avx2_1x1"}, "jit_avx2_1x1_FP32"};
-const auto conv_avx512_2D_1x1 = CPUSpecificParams{{nChw16c}, {nChw16c}, {"jit_avx512_1x1"}, "jit_avx512_1x1_FP32"};
+const auto conv_sse42_2D_1x1 = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_sse42_1x1"}, "jit_sse42_1x1"};
+const auto conv_avx2_2D_1x1 = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_avx2_1x1"}, "jit_avx2_1x1"};
+const auto conv_avx512_2D_1x1 = CPUSpecificParams{{nChw16c}, {nChw16c}, {"jit_avx512_1x1"}, "jit_avx512_1x1"};
 
 // utility functions
 std::vector<CPUSpecificParams> filterCPUSpecificParams(std::vector<CPUSpecificParams>& paramsVector);
-
+std::vector<CPUSpecificParams> filterCPUInfoForDevice(std::vector<CPUSpecificParams> CPUParams);
 } // namespace CPUTestUtils

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
@@ -56,6 +56,7 @@ public:
                                                          std::string name) const;
 
 protected:
+    virtual void CheckPluginRelatedResults(InferenceEngine::ExecutableNetwork &execNet, std::string nodeType) const;
     virtual std::shared_ptr<ngraph::Node> modifyGraph(const ngraph::element::Type &ngPrc,
                                                       ngraph::ParameterVector &params,
                                                       const std::shared_ptr<ngraph::Node> &lastNode) const;

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
@@ -48,8 +48,6 @@ public:
                                std::vector<std::string> priority);
 
     CPUInfo getCPUInfo() const;
-    void CheckCPUImpl(InferenceEngine::ExecutableNetwork &execNet, std::string nodeType) const;
-
     std::shared_ptr<ngraph::Function> makeNgraphFunction(const ngraph::element::Type &ngPrc,
                                                          ngraph::ParameterVector &params,
                                                          const std::shared_ptr<ngraph::Node> &lastNode,
@@ -60,6 +58,7 @@ protected:
     virtual std::shared_ptr<ngraph::Node> modifyGraph(const ngraph::element::Type &ngPrc,
                                                       ngraph::ParameterVector &params,
                                                       const std::shared_ptr<ngraph::Node> &lastNode) const;
+
 protected:
     std::string getPrimitiveType() const;
     std::vector<cpu_memory_format_t> inFmts, outFmts;

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
@@ -55,6 +55,13 @@ public:
 
 protected:
     virtual void CheckPluginRelatedResults(InferenceEngine::ExecutableNetwork &execNet, std::string nodeType) const;
+    /**
+     * @brief This function modifies the initial single layer test graph to add any necessary modifications that are specific to the cpu test scope.
+     * @param ngPrc Graph precision.
+     * @param params Graph parameters vector.
+     * @param lastNode The last node of the initial graph.
+     * @return The last node of the modified graph.
+     */
     virtual std::shared_ptr<ngraph::Node> modifyGraph(const ngraph::element::Type &ngPrc,
                                                       ngraph::ParameterVector &params,
                                                       const std::shared_ptr<ngraph::Node> &lastNode) const;

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation7
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
@@ -50,6 +50,15 @@ public:
     CPUInfo getCPUInfo() const;
     void CheckCPUImpl(InferenceEngine::ExecutableNetwork &execNet, std::string nodeType) const;
 
+    std::shared_ptr<ngraph::Function> makeNgraphFunction(const ngraph::element::Type &ngPrc,
+                                                         ngraph::ParameterVector &params,
+                                                         const std::shared_ptr<ngraph::Node> &lastNode,
+                                                         std::string name) const;
+
+protected:
+    virtual std::shared_ptr<ngraph::Node> modifyGraph(const ngraph::element::Type &ngPrc,
+                                                      ngraph::ParameterVector &params,
+                                                      const std::shared_ptr<ngraph::Node> &lastNode) const;
 protected:
     std::string getPrimitiveType() const;
     std::vector<cpu_memory_format_t> inFmts, outFmts;

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/fusing_test_utils.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/fusing_test_utils.cpp
@@ -1,0 +1,91 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "fusing_test_utils.hpp"
+
+using namespace LayerTestsDefinitions;
+
+namespace CPUTestUtils {
+
+
+std::string CpuTestWithFusing::getTestCaseName(fusingSpecificParams params) {
+    std::ostringstream result;
+    std::shared_ptr<ngraph::Function> postFunction;
+    std::vector<postNode> postNodes;
+    std::vector<std::string> fusedOps;
+    std::tie(postFunction, postNodes, fusedOps) = params;
+
+    if (postFunction) {
+        result << "_Fused=" << postFunction->get_friendly_name();
+    } else if (!postNodes.empty()) {
+        result << "_Fused=";
+        const char* separator = "";
+        for (const auto& item : postNodes) {
+            result << separator << item.name;
+            separator = ",";
+        }
+    }
+
+    return result.str();
+}
+
+std::shared_ptr<ngraph::Node>
+CpuTestWithFusing::modifyGraph(const ngraph::element::Type &ngPrc, ngraph::ParameterVector &params, const std::shared_ptr<ngraph::Node> &lastNode) const {
+    CPUTestsBase::modifyGraph(ngPrc, params, lastNode);
+    std::shared_ptr<ngraph::Node> retNode = lastNode;
+    if (postFunction) {
+        retNode = addPostFunction(lastNode);
+    } else if (!postNodes.empty()) {
+        retNode = addPostNodes(ngPrc, params, lastNode);
+    }
+    return retNode;
+}
+
+std::shared_ptr<ngraph::Node> CpuTestWithFusing::addPostFunction(const std::shared_ptr<ngraph::Node> &lastNode) const {
+    auto clonedPostFunction = clone_function(*postFunction);
+    clonedPostFunction->set_friendly_name(postFunction->get_friendly_name());
+    clonedPostFunction->replace_node(clonedPostFunction->get_parameters()[0], lastNode);
+    return clonedPostFunction->get_result()->get_input_node_shared_ptr(0);
+}
+
+std::shared_ptr<ngraph::Node>
+CpuTestWithFusing::addPostNodes(const ngraph::element::Type &ngPrc, ngraph::ParameterVector &params, const std::shared_ptr<ngraph::Node> &lastNode) const {
+    std::shared_ptr<ngraph::Node> tmpNode = lastNode;
+
+    for (auto postNode : postNodes) {
+        tmpNode = postNode.makeNode(tmpNode, ngPrc, params);
+    }
+    return tmpNode;
+}
+
+void CpuTestWithFusing::CheckPluginRelatedResults(InferenceEngine::ExecutableNetwork &execNet, std::string nodeType) const {
+    CPUTestsBase::CheckPluginRelatedResults(execNet, nodeType);
+    InferenceEngine::CNNNetwork execGraphInfo = execNet.GetExecGraphInfo();
+    auto function = execGraphInfo.getFunction();
+    ASSERT_NE(nullptr, function);
+    for (const auto & op : function->get_ops()) {
+        const auto &rtInfo = op->get_rt_info();
+
+        auto getExecValue = [](const std::string &paramName, const ngraph::Node::RTMap& rtInfo) -> std::string {
+            auto it = rtInfo.find(paramName);
+            IE_ASSERT(rtInfo.end() != it);
+            auto value = std::dynamic_pointer_cast<ngraph::VariantImpl<std::string>>(it->second);
+            IE_ASSERT(nullptr != value);
+
+            return value->get();
+        };
+
+        auto layerType = getExecValue("layerType", rtInfo);
+        if (layerType == nodeType) {
+            auto originalLayersNames = getExecValue("originalLayersNames", rtInfo);
+            auto pos = originalLayersNames.find(nodeType);
+            ASSERT_TRUE(pos != std::string::npos) << "Node type " << nodeType << " has not been found!";
+            for (auto fusedOp : fusedOps) {
+                pos = originalLayersNames.find(fusedOp, pos);
+                ASSERT_TRUE(pos != std::string::npos) << "Fused op " << fusedOp << " has not been found!";
+            }
+        }
+    }
+}
+} // namespace CPUTestUtils

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/fusing_test_utils.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/fusing_test_utils.hpp
@@ -1,0 +1,126 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "cpu_test_utils.hpp"
+#include "single_layer_tests/activation.hpp"
+
+namespace CPUTestUtils {
+
+struct postNode {
+    std::function<std::shared_ptr<ngraph::Node>(std::shared_ptr<ngraph::Node>, const ngraph::element::Type&, ngraph::ParameterVector&)> makeNode;
+    std::string name;
+};
+
+typedef std::tuple<
+        std::shared_ptr<ngraph::Function>,
+        std::vector<postNode>,
+        std::vector<std::string>> fusingSpecificParams;
+
+class CpuTestWithFusing : public CPUTestsBase {
+public:
+    static std::string getTestCaseName(fusingSpecificParams params);
+
+protected:
+    std::shared_ptr<ngraph::Node> modifyGraph(const ngraph::element::Type &ngPrc,
+                                                      ngraph::ParameterVector &params,
+                                                      const std::shared_ptr<ngraph::Node> &lastNode) const override;
+
+    void CheckPluginRelatedResults(InferenceEngine::ExecutableNetwork &execNet, std::string nodeType) const override;
+
+private:
+    std::shared_ptr<ngraph::Node> addPostFunction(const std::shared_ptr<ngraph::Node> &lastNode) const;
+    std::shared_ptr<ngraph::Node> addPostNodes(const ngraph::element::Type &ngPrc,
+                                               ngraph::ParameterVector &params,
+                                               const std::shared_ptr<ngraph::Node> &lastNode) const;
+protected:
+    std::shared_ptr<ngraph::Function> postFunction;
+    std::vector<postNode> postNodes;
+    std::vector<std::string> fusedOps;
+};
+
+/* FUSING PATTERNS */
+const auto emptyFusingSpec = fusingSpecificParams{nullptr, {}, {}};
+const auto fusingRelu = fusingSpecificParams{nullptr, {
+            {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params){
+                return ngraph::builder::makeActivation(inpNode, ngPrc, ngraph::helpers::Relu);
+            }, "Relu"}}, {"Relu"}};
+const auto fusingElu = fusingSpecificParams{nullptr, {
+            {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params){
+                return ngraph::builder::makeActivation(inpNode, ngPrc, ngraph::helpers::Elu, {}, {2.0f});
+            }, "Elu"}}, {"Elu"}};
+const auto fusingSigmoid = fusingSpecificParams{nullptr, {
+            {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params){
+                return ngraph::builder::makeActivation(inpNode, ngPrc, ngraph::helpers::Sigmoid);
+            }, "Sigmoid"}}, {"Sigmoid"}};
+const auto fusingClamp = fusingSpecificParams{nullptr, {
+            {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params){
+                return ngraph::builder::makeActivation(inpNode, ngPrc, ngraph::helpers::Clamp, {}, {3.0f, 6.0f});
+            }, "Clamp"}}, {"Clamp"}};
+const auto fusingPRelu = fusingSpecificParams{nullptr, {
+            {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params){
+                auto shape = inpNode->get_shape();
+                if (shape.size() == 1)
+                    THROW_IE_EXCEPTION << "If shape.size() == 1 then Granularity can be PerTensor only";
+                ngraph::Shape newShape(shape.size(), 1);
+                newShape[1] = shape[1];
+                auto data = NGraphFunctions::Utils::generateVector<ngraph::element::Type_t::f32>(ngraph::shape_size(newShape));
+                return ngraph::builder::makeActivation(inpNode, ngPrc, ngraph::helpers::LeakyRelu, newShape, data);
+            }, "PRelu(PerChannel)"}}, {"PRelu"}};
+const auto fusingSwish = fusingSpecificParams{nullptr, {
+            {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params){
+                return ngraph::builder::makeActivation(inpNode, ngPrc, ngraph::helpers::Swish, {}, {1.0f});
+            }, "Swish"}}, {"Swish"}};
+
+const auto fusingReluScaleShift = fusingSpecificParams{nullptr, {
+            {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params){
+                return ngraph::builder::makeActivation(inpNode, ngPrc, ngraph::helpers::Relu);
+            }, "Relu"},
+            {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params){
+                 auto shape = inpNode->get_shape();
+                 if (shape.size() == 1)
+                     THROW_IE_EXCEPTION << "If shape.size() == 1 then Granularity can be PerTensor only";
+                 ngraph::Shape newShape(shape.size(), 1);
+                 newShape[1] = shape[1];
+                 auto constNode = ngraph::builder::makeConstant<float>(ngPrc, newShape, {}, true);
+                 return std::make_shared<ngraph::opset1::Multiply>(inpNode, constNode);
+            }, "Multiply(PerChannel)"},
+            {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params){
+                auto shape = inpNode->get_shape();
+                if (shape.size() == 1)
+                 THROW_IE_EXCEPTION << "If shape.size() == 1 then Granularity can be PerTensor only";
+                ngraph::Shape newShape(shape.size(), 1);
+                newShape[1] = shape[1];
+                auto constNode = ngraph::builder::makeConstant<float>(ngPrc, newShape, {}, true);
+                return std::make_shared<ngraph::opset1::Add>(inpNode, constNode);
+            }, "Add(PerChannel)"}}, {"Relu", "Add"}};
+const auto fusingFakeQuantizePerChannelRelu = fusingSpecificParams{nullptr, {
+            {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params){
+                auto shape = inpNode->get_shape();
+                if (shape.size() == 1)
+                 THROW_IE_EXCEPTION << "If shape.size() == 1 then Granularity can be PerTensor only";
+                ngraph::Shape newShape(shape.size(), 1);
+                newShape[1] = shape[1];
+                return ngraph::builder::makeFakeQuantize(inpNode, ngPrc, 256, newShape);
+            }, "FakeQuantize(PerChannel)"},
+            {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params){
+                return ngraph::builder::makeActivation(inpNode, ngPrc, ngraph::helpers::Relu);
+            }, "Relu"}}, {"FakeQuantize", "Relu"}};
+// TODO: failed test
+// const auto fusingFakeQuantizePerTensorRelu = fusingSpecificParams{nullptr,
+//         {{ngraph::builder::makeFakeQuantize(fakeConstNode, ngraph::element::f32, 256, fakeShape), {{"Granularity", "PerTensor"}}},
+//          {ngraph::builder::makeActivation(fakeConstNode, ngraph::element::f32, ngraph::helpers::Relu)}}, {"FakeQuantize", "Relu"}};
+const auto fusingSum = fusingSpecificParams{nullptr, {
+            {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params){
+                auto shape = inpNode->get_shape();
+                ngraph::ParameterVector newParams = ngraph::builder::makeParams(ngPrc, {shape});
+                params.insert(params.end(), newParams.begin(), newParams.end());
+                auto newParamOuts = ngraph::helpers::convert2OutputVector(
+                     ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(newParams));
+                return std::make_shared<ngraph::opset1::Add>(inpNode, newParamOuts[0]);
+            }, "Add(Parameters)"}}, {"Add"}};
+// todo: DWConvolution (not supported for GroupConvolution)
+
+} // namespace CPUTestUtils

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/fusing_test_utils.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/fusing_test_utils.hpp
@@ -57,9 +57,12 @@ public:
     static std::string getTestCaseName(fusingSpecificParams params);
 
 protected:
+    /**
+     * @brief This function adds post operations.
+     */
     std::shared_ptr<ngraph::Node> modifyGraph(const ngraph::element::Type &ngPrc,
-                                                      ngraph::ParameterVector &params,
-                                                      const std::shared_ptr<ngraph::Node> &lastNode) const override;
+                                              ngraph::ParameterVector &params,
+                                              const std::shared_ptr<ngraph::Node> &lastNode) const override;
 
     void CheckPluginRelatedResults(InferenceEngine::ExecutableNetwork &execNet, std::string nodeType) const override;
 

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/fusing_test_utils.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/fusing_test_utils.hpp
@@ -108,10 +108,14 @@ const auto fusingFakeQuantizePerChannelRelu = fusingSpecificParams{nullptr, {
             {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params){
                 return ngraph::builder::makeActivation(inpNode, ngPrc, ngraph::helpers::Relu);
             }, "Relu"}}, {"FakeQuantize", "Relu"}};
-// TODO: failed test
-// const auto fusingFakeQuantizePerTensorRelu = fusingSpecificParams{nullptr,
-//         {{ngraph::builder::makeFakeQuantize(fakeConstNode, ngraph::element::f32, 256, fakeShape), {{"Granularity", "PerTensor"}}},
-//          {ngraph::builder::makeActivation(fakeConstNode, ngraph::element::f32, ngraph::helpers::Relu)}}, {"FakeQuantize", "Relu"}};
+const auto fusingFakeQuantizePerTensorRelu = fusingSpecificParams{nullptr, {
+            {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params) {
+                auto newShape = ngraph::Shape(inpNode->get_shape().size(), 1);
+                return ngraph::builder::makeFakeQuantize(inpNode, ngPrc, 256, newShape);
+            }, "FakeQuantize(PerTensor)"},
+            {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params){
+                return ngraph::builder::makeActivation(inpNode, ngPrc, ngraph::helpers::Relu);
+            }, "Relu"}}, {"FakeQuantize", "Relu"}};
 const auto fusingSum = fusingSpecificParams{nullptr, {
             {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params){
                 auto shape = inpNode->get_shape();

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/fusing_test_utils.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/fusing_test_utils.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "cpu_test_utils.hpp"
-#include "single_layer_tests/activation.hpp"
+#include <shared_test_classes/single_layer/activation.hpp>
 
 namespace CPUTestUtils {
 

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/fusing_test_utils.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/fusing_test_utils.hpp
@@ -9,15 +9,48 @@
 
 namespace CPUTestUtils {
 
-struct postNode {
+struct postNodeBuilder {
     std::function<std::shared_ptr<ngraph::Node>(std::shared_ptr<ngraph::Node>, const ngraph::element::Type&, ngraph::ParameterVector&)> makeNode;
     std::string name;
 };
 
+class postOpMgr {
+public:
+    virtual std::shared_ptr<ngraph::Node> addPostOps(const ngraph::element::Type &ngPrc,
+                                                     ngraph::ParameterVector &params,
+                                                     const std::shared_ptr<ngraph::Node> &lastNode) const = 0;
+    virtual std::string getFusedOpsNames() const = 0;
+    virtual ~postOpMgr() = default;
+};
+
+class postFunctionMgr : public postOpMgr {
+public:
+    postFunctionMgr(std::shared_ptr<ngraph::Function> function) : _pFunction(function) {}
+    std::shared_ptr<ngraph::Node> addPostOps(const ngraph::element::Type &ngPrc,
+                                             ngraph::ParameterVector &params,
+                                             const std::shared_ptr<ngraph::Node> &lastNode) const override;
+    std::string getFusedOpsNames() const override;
+
+private:
+    std::shared_ptr<ngraph::Function> _pFunction;
+};
+
+class postNodesMgr : public postOpMgr {
+public:
+    postNodesMgr(std::vector<postNodeBuilder> postNodes);
+    std::shared_ptr<ngraph::Node> addPostOps(const ngraph::element::Type &ngPrc,
+                                             ngraph::ParameterVector &params,
+                                             const std::shared_ptr<ngraph::Node> &lastNode) const override;
+    std::string getFusedOpsNames() const override;
+
+private:
+    std::vector<postNodeBuilder> _postNodes;
+};
+
 typedef std::tuple<
-        std::shared_ptr<ngraph::Function>,
-        std::vector<postNode>,
-        std::vector<std::string>> fusingSpecificParams;
+        std::shared_ptr<postOpMgr>, // post operation manager (add post operations to the graph)
+        std::vector<std::string> // list of node types that are to be fused
+        > fusingSpecificParams;
 
 class CpuTestWithFusing : public CPUTestsBase {
 public:
@@ -30,36 +63,30 @@ protected:
 
     void CheckPluginRelatedResults(InferenceEngine::ExecutableNetwork &execNet, std::string nodeType) const override;
 
-private:
-    std::shared_ptr<ngraph::Node> addPostFunction(const std::shared_ptr<ngraph::Node> &lastNode) const;
-    std::shared_ptr<ngraph::Node> addPostNodes(const ngraph::element::Type &ngPrc,
-                                               ngraph::ParameterVector &params,
-                                               const std::shared_ptr<ngraph::Node> &lastNode) const;
 protected:
-    std::shared_ptr<ngraph::Function> postFunction;
-    std::vector<postNode> postNodes;
+    std::shared_ptr<postOpMgr> postOpMgrPtr;
     std::vector<std::string> fusedOps;
 };
 
 /* FUSING PATTERNS */
-const auto emptyFusingSpec = fusingSpecificParams{nullptr, {}, {}};
-const auto fusingRelu = fusingSpecificParams{nullptr, {
+const auto emptyFusingSpec = fusingSpecificParams{nullptr, {}};
+const auto fusingRelu = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params){
                 return ngraph::builder::makeActivation(inpNode, ngPrc, ngraph::helpers::Relu);
-            }, "Relu"}}, {"Relu"}};
-const auto fusingElu = fusingSpecificParams{nullptr, {
+            }, "Relu"}}), {"Relu"}};
+const auto fusingElu = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params){
                 return ngraph::builder::makeActivation(inpNode, ngPrc, ngraph::helpers::Elu, {}, {2.0f});
-            }, "Elu"}}, {"Elu"}};
-const auto fusingSigmoid = fusingSpecificParams{nullptr, {
+            }, "Elu"}}), {"Elu"}};
+const auto fusingSigmoid = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params){
                 return ngraph::builder::makeActivation(inpNode, ngPrc, ngraph::helpers::Sigmoid);
-            }, "Sigmoid"}}, {"Sigmoid"}};
-const auto fusingClamp = fusingSpecificParams{nullptr, {
+            }, "Sigmoid"}}), {"Sigmoid"}};
+const auto fusingClamp = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params){
                 return ngraph::builder::makeActivation(inpNode, ngPrc, ngraph::helpers::Clamp, {}, {3.0f, 6.0f});
-            }, "Clamp"}}, {"Clamp"}};
-const auto fusingPRelu = fusingSpecificParams{nullptr, {
+            }, "Clamp"}}), {"Clamp"}};
+const auto fusingPRelu = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params){
                 auto shape = inpNode->get_shape();
                 if (shape.size() == 1)
@@ -68,13 +95,13 @@ const auto fusingPRelu = fusingSpecificParams{nullptr, {
                 newShape[1] = shape[1];
                 auto data = NGraphFunctions::Utils::generateVector<ngraph::element::Type_t::f32>(ngraph::shape_size(newShape));
                 return ngraph::builder::makeActivation(inpNode, ngPrc, ngraph::helpers::LeakyRelu, newShape, data);
-            }, "PRelu(PerChannel)"}}, {"PRelu"}};
-const auto fusingSwish = fusingSpecificParams{nullptr, {
+            }, "PRelu(PerChannel)"}}), {"PRelu"}};
+const auto fusingSwish = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params){
                 return ngraph::builder::makeActivation(inpNode, ngPrc, ngraph::helpers::Swish, {}, {1.0f});
-            }, "Swish"}}, {"Swish"}};
+            }, "Swish"}}), {"Swish"}};
 
-const auto fusingReluScaleShift = fusingSpecificParams{nullptr, {
+const auto fusingReluScaleShift = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params){
                 return ngraph::builder::makeActivation(inpNode, ngPrc, ngraph::helpers::Relu);
             }, "Relu"},
@@ -95,13 +122,10 @@ const auto fusingReluScaleShift = fusingSpecificParams{nullptr, {
                 newShape[1] = shape[1];
                 auto constNode = ngraph::builder::makeConstant<float>(ngraph::element::f32, newShape, {}, true);
                 return std::make_shared<ngraph::opset1::Add>(inpNode, constNode);
-            }, "Add(PerChannel)"}}, {"Relu", "Add"}};
-const auto fusingFakeQuantizePerChannelRelu = fusingSpecificParams{nullptr, {
+            }, "Add(PerChannel)"}}), {"Relu", "Add"}};
+const auto fusingFakeQuantizePerChannelRelu = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params){
-                auto localPrc = ngPrc;
-                if (ngraph::element::bf16 == localPrc) {
-                    localPrc = ngraph::element::f32;
-                }
+                auto localPrc = inpNode->get_element_type();
                 auto shape = inpNode->get_shape();
                 if (shape.size() == 1)
                  THROW_IE_EXCEPTION << "If shape.size() == 1 then Granularity can be PerTensor only";
@@ -111,20 +135,17 @@ const auto fusingFakeQuantizePerChannelRelu = fusingSpecificParams{nullptr, {
             }, "FakeQuantize(PerChannel)"},
             {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params){
                 return ngraph::builder::makeActivation(inpNode, ngPrc, ngraph::helpers::Relu);
-            }, "Relu"}}, {"FakeQuantize", "Relu"}};
-const auto fusingFakeQuantizePerTensorRelu = fusingSpecificParams{nullptr, {
+            }, "Relu"}}), {"FakeQuantize", "Relu"}};
+const auto fusingFakeQuantizePerTensorRelu = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params) {
-                auto localPrc = ngPrc;
-                if (ngraph::element::bf16 == localPrc) {
-                    localPrc = ngraph::element::f32;
-                }
+                auto localPrc = inpNode->get_element_type();
                 auto newShape = ngraph::Shape(inpNode->get_shape().size(), 1);
                 return ngraph::builder::makeFakeQuantize(inpNode, localPrc, 256, newShape);
             }, "FakeQuantize(PerTensor)"},
             {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params){
                 return ngraph::builder::makeActivation(inpNode, ngPrc, ngraph::helpers::Relu);
-            }, "Relu"}}, {"FakeQuantize", "Relu"}};
-const auto fusingSum = fusingSpecificParams{nullptr, {
+            }, "Relu"}}), {"FakeQuantize", "Relu"}};
+const auto fusingSum = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params){
                 auto shape = inpNode->get_shape();
                 ngraph::ParameterVector newParams = ngraph::builder::makeParams(ngPrc, {shape});
@@ -132,7 +153,22 @@ const auto fusingSum = fusingSpecificParams{nullptr, {
                 auto newParamOuts = ngraph::helpers::convert2OutputVector(
                      ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(newParams));
                 return std::make_shared<ngraph::opset1::Add>(inpNode, newParamOuts[0]);
-            }, "Add(Parameters)"}}, {"Add"}};
-// todo: DWConvolution (not supported for GroupConvolution)
-
+            }, "Add(Parameters)"}}), {"Add"}};
+const auto fusingSumEluFQ = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
+        {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params){
+            auto shape = inpNode->get_shape();
+            ngraph::ParameterVector newParams = ngraph::builder::makeParams(ngPrc, {shape});
+            params.insert(params.end(), newParams.begin(), newParams.end());
+            auto newParamOuts = ngraph::helpers::convert2OutputVector(
+                    ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(newParams));
+            return std::make_shared<ngraph::opset1::Add>(inpNode, newParamOuts[0]);
+        }, "Add(Parameters)"},
+        {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params){
+            return ngraph::builder::makeActivation(inpNode, ngPrc, ngraph::helpers::Elu, {}, {2.0f});
+        }, "Elu"},
+        {[](std::shared_ptr<ngraph::Node> inpNode, const ngraph::element::Type& ngPrc, ngraph::ParameterVector& params) {
+            auto localPrc = inpNode->get_element_type();
+            auto newShape = ngraph::Shape(inpNode->get_shape().size(), 1);
+            return ngraph::builder::makeFakeQuantize(inpNode, localPrc, 256, newShape);
+        }, "FakeQuantize(PerTensor)"}}), {"Add", "Elu", "FakeQuantize"}};
 } // namespace CPUTestUtils

--- a/inference-engine/tests/ie_test_utils/common_test_utils/data_utils.hpp
+++ b/inference-engine/tests/ie_test_utils/common_test_utils/data_utils.hpp
@@ -297,7 +297,7 @@ static ie_abs(const T &val) {
 }
 
 static ngraph::bfloat16 ie_abs(const ngraph::bfloat16& val) {
-    return ngraph::bfloat16::from_bits(val.to_bits() ^ 0x8000);
+    return ngraph::bfloat16::from_bits(val.to_bits() & 0x7FFF);
 }
 
 static ngraph::float16 ie_abs(const ngraph::float16& val) {


### PR DESCRIPTION
This PR contains some refactoring of the existing CPU single layer tests structure. Also it proposes an approach of testing fusing in single layer tests. The latter is mainly based on PR https://github.com/openvinotoolkit/openvino/pull/1145. But the main difference is that in this PR, fusing tests can be included in the CPU-specific single layer tests. Group convolution CPU-specific single layer test is used as an example of this functionality.