### PR TITLE
Extend information to submit to a DB in time_tests

### DIFF
--- a/tests/time_tests/test_runner/conftest.py
+++ b/tests/time_tests/test_runner/conftest.py
@@ -175,31 +175,32 @@ def validate_test_case(request, test_info):
     """Fixture for validating test case on correctness.
 
     Fixture checks current test case contains all fields required for
-    a correct work. To submit results to a database test case have
-    contain several additional properties.
+    a correct work.
     """
-    schema = {
+    schema = """
+    {
         "type": "object",
         "properties": {
             "device": {
                 "type": "object",
                 "properties": {
                     "name": {"type": "string"}
-                }},
+                },
+                "required": ["name"]
+            },
             "model": {
                 "type": "object",
                 "properties": {
                     "path": {"type": "string"}
-                }},
+                },
+                "required": ["path"]
+            }
         },
+        "required": ["device", "model"],
+        "additionalProperties": false
     }
-    if request.config.getoption("db_submit"):
-        # For submission data to a database some additional fields are required
-        schema["properties"]["model"]["properties"].update({
-            "name": {"type": "string"},
-            "precision": {"type": "string"},
-            "framework": {"type": "string"}
-        })
+    """
+    schema = json.loads(schema)
 
     try:
         validate(instance=request.node.funcargs["instance"], schema=schema)

--- a/tests/time_tests/test_runner/conftest.py
+++ b/tests/time_tests/test_runner/conftest.py
@@ -15,21 +15,22 @@ This plugin adds the following command-line options:
 * `--niter` - Number of times to run executable.
 """
 
+import hashlib
+import logging
 # pylint:disable=import-error
 import os
-import sys
-import pytest
-from pathlib import Path
-import yaml
-import hashlib
 import shutil
-import logging
+import sys
 import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
 from jsonschema import validate, ValidationError
 
+from scripts.run_timetest import check_positive_int
 from test_runner.utils import upload_timetest_data, \
     DATABASE, DB_COLLECTIONS
-from scripts.run_timetest import check_positive_int
 
 
 # -------------------- CLI options --------------------
@@ -105,6 +106,7 @@ def executable(request):
 def niter(request):
     """Fixture function for command-line option."""
     return request.config.getoption('niter')
+
 
 # -------------------- CLI options --------------------
 

--- a/tests/time_tests/test_runner/conftest.py
+++ b/tests/time_tests/test_runner/conftest.py
@@ -30,7 +30,7 @@ import yaml
 from jsonschema import validate, ValidationError
 
 from scripts.run_timetest import check_positive_int
-from test_runner.utils import upload_timetest_data, metadata_from_manifest, \
+from test_runner.utils import upload_timetest_data, metadata_from_manifest, get_os_name, get_os_version, \
     DATABASE, DB_COLLECTIONS
 
 
@@ -236,7 +236,8 @@ def prepare_db_info(request, test_info, executable, niter, manifest_metadata):
         "device": request.node.funcargs["instance"]["device"],
         "niter": niter,
         "test_name": request.node.name,
-        "results": test_info["results"]
+        "results": test_info["results"],
+        "os": "_".join([str(item) for item in [get_os_name(), *get_os_version()]])
     }
     info['_id'] = hashlib.sha256(
         ''.join([str(info[key]) for key in FIELDS_FOR_ID]).encode()).hexdigest()
@@ -272,9 +273,10 @@ def prepare_db_info(request, test_info, executable, niter, manifest_metadata):
             "niter": {"type": "integer"},
             "test_name": {"type": "string"},
             "results": {"type": "object"},
+            "os": {"type": "string"},
             "_id": {"type": "string"}
         },
-        "required": ["device", "model", "run_id", "timetest", "niter", "test_name", "results", "_id"],
+        "required": ["device", "model", "run_id", "timetest", "niter", "test_name", "results", "os", "_id"],
         "additionalProperties": true
     }
     """

--- a/tests/time_tests/test_runner/requirements.txt
+++ b/tests/time_tests/test_runner/requirements.txt
@@ -2,3 +2,4 @@ pytest==4.0.1
 attrs==19.1.0   # required for pytest==4.0.1 to resolve compatibility issues
 PyYAML==5.3.1
 jsonschema==3.2.0
+distro==1.5.0

--- a/tests/time_tests/test_runner/test_timetest.py
+++ b/tests/time_tests/test_runner/test_timetest.py
@@ -25,7 +25,8 @@ from test_runner.utils import expand_env_vars
 REFS_FACTOR = 1.2      # 120%
 
 
-def test_timetest(instance, executable, niter, cl_cache_dir, test_info, temp_dir, validate_test_case):
+def test_timetest(instance, executable, niter, cl_cache_dir, test_info, temp_dir, validate_test_case,
+                  prepare_db_info):
     """Parameterized test.
 
     :param instance: test instance. Should not be changed during test run
@@ -35,6 +36,7 @@ def test_timetest(instance, executable, niter, cl_cache_dir, test_info, temp_dir
     :param test_info: custom `test_info` field of built-in `request` pytest fixture
     :param temp_dir: path to a temporary directory. Will be cleaned up after test run
     :param validate_test_case: custom pytest fixture. Should be declared as test argument to be enabled
+    :param prepare_db_info: custom pytest fixture. Should be declared as test argument to be enabled
     """
     # Prepare model to get model_path
     model_path = instance["model"].get("path")

--- a/tests/time_tests/test_runner/utils.py
+++ b/tests/time_tests/test_runner/utils.py
@@ -4,11 +4,14 @@
 """Utility module."""
 
 import os
+from pathlib import Path
+import yaml
 from pymongo import MongoClient
 
 # constants
 DATABASE = 'timetests'   # database name for timetests results
 DB_COLLECTIONS = ["commit", "nightly", "weekly"]
+PRODUCT_NAME = 'dldt'   # product name from build manifest
 
 
 def expand_env_vars(obj):
@@ -31,3 +34,20 @@ def upload_timetest_data(data, db_url, db_collection):
     client = MongoClient(db_url)
     collection = client[DATABASE][db_collection]
     collection.replace_one({'_id': data['_id']}, data, upsert=True)
+
+
+def metadata_from_manifest(manifest: Path):
+    """ Extract commit metadata from manifest
+    """
+    with open(manifest, 'r') as manifest_file:
+        manifest = yaml.safe_load(manifest_file)
+    repo_trigger = next(
+        repo for repo in manifest['components'][PRODUCT_NAME]['repository'] if repo['trigger'])
+    return {
+        'product_type': manifest['components'][PRODUCT_NAME]['product_type'],
+        'commit_sha': repo_trigger['revision'],
+        'commit_date': repo_trigger['commit_time'],
+        'repo_url': repo_trigger['url'],
+        'target_branch': repo_trigger['target_branch'],
+        'version': manifest['components'][PRODUCT_NAME]['version']
+    }

--- a/tests/time_tests/test_runner/utils.py
+++ b/tests/time_tests/test_runner/utils.py
@@ -4,7 +4,12 @@
 """Utility module."""
 
 import os
+import platform
+import sys
+from enum import Enum
 from pathlib import Path
+
+import distro
 import yaml
 from pymongo import MongoClient
 
@@ -51,3 +56,80 @@ def metadata_from_manifest(manifest: Path):
         'target_branch': repo_trigger['target_branch'],
         'version': manifest['components'][PRODUCT_NAME]['version']
     }
+
+
+class UnsupportedOsError(Exception):
+    """
+    Exception for unsupported OS type
+    """
+
+    def __init__(self, *args, **kwargs):
+        error_message = f'OS type "{get_os_type()}" is not currently supported'
+        if args or kwargs:
+            super().__init__(*args, **kwargs)
+        else:
+            super().__init__(error_message)
+
+
+class OsType(Enum):
+    """
+    Container for supported os types
+    """
+    WINDOWS = 'Windows'
+    LINUX = 'Linux'
+    DARWIN = 'Darwin'
+
+
+def get_os_type():
+    """
+    Get OS type
+
+    :return: OS type
+    :rtype: String | Exception if it is not supported
+    """
+    return platform.system()
+
+
+def os_type_is_windows():
+    """Returns True if OS type is Windows. Otherwise returns False"""
+    return get_os_type() == OsType.WINDOWS.value
+
+
+def os_type_is_linux():
+    """Returns True if OS type is Linux. Otherwise returns False"""
+    return get_os_type() == OsType.LINUX.value
+
+
+def os_type_is_darwin():
+    """Returns True if OS type is Darwin. Otherwise returns False"""
+    return get_os_type() == OsType.DARWIN.value
+
+
+def get_os_name():
+    """
+    Check OS type and return OS name
+
+    :return: OS name
+    :rtype: String | Exception if it is not supported
+    """
+    if os_type_is_linux():
+        return distro.id().lower()
+    if os_type_is_windows() or os_type_is_darwin():
+        return get_os_type().lower()
+    raise UnsupportedOsError()
+
+
+def get_os_version():
+    """
+    Check OS version and return it
+
+    :return: OS version
+    :rtype: tuple | Exception if it is not supported
+    """
+    if os_type_is_linux():
+        return distro.major_version(), distro.minor_version()
+    if os_type_is_windows():
+        return sys.getwindowsversion().major, sys.getwindowsversion().minor
+    if os_type_is_darwin():
+        return tuple(platform.mac_ver()[0].split(".")[:2])
+    raise UnsupportedOsError()


### PR DESCRIPTION
1. Added `--manifest` and `--db_metadata` CLI keys
2. Add `prepare_db_info` and `manifest_metadata` fixtures

Function `metadata_from_manifest` is copied from MemCheckTests, but with some number of changes