### PR TITLE
Updated MO requirements for numpy

### DIFF
--- a/model-optimizer/requirements.txt
+++ b/model-optimizer/requirements.txt
@@ -2,7 +2,7 @@ tensorflow>=1.15.2,<2.0; python_version < "3.8"
 tensorflow>=2.0; python_version >= "3.8"
 mxnet>=1.0.0,<=1.5.1
 networkx>=1.11
-numpy>=1.13.0,<1.19.0
+numpy>=1.14.0,<1.19.0
 protobuf>=3.6.1
 onnx>=1.1.2
 test-generator==0.1.1

--- a/model-optimizer/requirements_caffe.txt
+++ b/model-optimizer/requirements_caffe.txt
@@ -1,5 +1,5 @@
 networkx>=1.11
-numpy>=1.13.0
+numpy>=1.14.0
 protobuf>=3.6.1
 test-generator==0.1.1
 defusedxml>=0.5.0

--- a/model-optimizer/requirements_kaldi.txt
+++ b/model-optimizer/requirements_kaldi.txt
@@ -1,4 +1,4 @@
 networkx>=1.11
-numpy>=1.13.0
+numpy>=1.14.0
 test-generator==0.1.1
 defusedxml>=0.5.0

--- a/model-optimizer/requirements_mxnet.txt
+++ b/model-optimizer/requirements_mxnet.txt
@@ -1,5 +1,5 @@
 mxnet>=1.0.0,<=1.5.1
 networkx>=1.11
-numpy>=1.13.0
+numpy>=1.14.0
 test-generator==0.1.1
 defusedxml>=0.5.0

--- a/model-optimizer/requirements_onnx.txt
+++ b/model-optimizer/requirements_onnx.txt
@@ -1,5 +1,5 @@
 onnx>=1.1.2
 networkx>=1.11
-numpy>=1.13.0
+numpy>=1.14.0
 test-generator==0.1.1
 defusedxml>=0.5.0

--- a/model-optimizer/requirements_tf.txt
+++ b/model-optimizer/requirements_tf.txt
@@ -1,6 +1,6 @@
 tensorflow>=1.15.2,<2.0; python_version < "3.8"
 tensorflow>=2.0; python_version >= "3.8"
 networkx>=1.11
-numpy>=1.13.0,<1.19.0
+numpy>=1.14.0,<1.19.0
 test-generator==0.1.1
 defusedxml>=0.5.0

--- a/model-optimizer/requirements_tf2.txt
+++ b/model-optimizer/requirements_tf2.txt
@@ -1,5 +1,5 @@
 tensorflow>=2.0
 networkx>=1.11
-numpy>=1.13.0
+numpy>=1.14.0
 test-generator==0.1.1
 defusedxml>=0.5.0


### PR DESCRIPTION
Updated MO requirements for numpy since there is a bug with the `numpy==1.13.x` which occurs because of the line 94 in the file mo/middle/passes/convert_data_type.py:
```
converted_blob = blob.astype(dtype=dst_type, casting="unsafe")
```
Upgrading to `numpy>=1.14.0` resolves this issue.
The issue has been found during experiments with bug 41900.