### PR TITLE
Set friendly name in order to operate with it on visit attributes and validate stages

### DIFF
--- a/inference-engine/src/readers/ir_reader/ie_ir_parser.cpp
+++ b/inference-engine/src/readers/ir_reader/ie_ir_parser.cpp
@@ -499,6 +499,7 @@ std::shared_ptr<ngraph::Node> V10Parser::createNode(const std::vector<ngraph::Ou
         }
 
         ngraphNode = std::shared_ptr<ngraph::Node>(opset.create(params.type));
+        ngraphNode->set_friendly_name(params.name);
         ngraphNode->set_arguments(inputs);
         XmlDeserializer visitor(node);
         if (ngraphNode->visit_attributes(visitor))


### PR DESCRIPTION
Use friendly names instead of auto generated names.
Before:
```
While validating node 'v1::Multiply Multiply_62 ...
```
After
```
While validating node 'v1::Multiply 201/factor_mul_ ...
```