### PR TITLE
Fix unexpected keyword argument error in 'overall_accuracy_check' function

### DIFF
--- a/inference-engine/tools/cross_check_tool/cross_check_tool.py
+++ b/inference-engine/tools/cross_check_tool/cross_check_tool.py
@@ -207,8 +207,8 @@ def two_ir_mode(args):
     global_accuracy = []
     global_times, ref_global_times = overall_accuracy_check(model=args.model, ref_model=args.reference_model,
                                                             out_layers=out_layers, ref_out_layers=ref_out_layers,
-                                                            inputs=inputs, ref_inputs=ref_inputs, plugin=core,
-                                                            ref_plugin=ref_core, layers=args.layers,
+                                                            inputs=inputs, ref_inputs=ref_inputs, core=core,device=args.device,
+                                                            ref_core=ref_core, ref_device=args.reference_device,layers=args.layers,
                                                             num_of_iterations=args.num_of_iterations)
     for out_layer in layers_map:
         ref_out_layer = layers_map[out_layer]


### PR DESCRIPTION
When using two_ir_mode function, it will throw unexpected key error.
The overall_accuracy_check call from two_ir_mode function is not consistent with the fuction definition