### PR TITLE
add getting nms_threshold / iou_threshold from RetinaNet

### DIFF
--- a/model-optimizer/extensions/front/tf/RetinaNetFilteredDetectionsReplacement.py
+++ b/model-optimizer/extensions/front/tf/RetinaNetFilteredDetectionsReplacement.py
@@ -246,12 +246,13 @@ class RetinaNetFilteredDetectionsReplacement(FrontReplacementFromConfigFileSubGr
                                                                    applied_width_height_regressions_node)
 
         detection_output_op = DetectionOutput(graph, match.custom_replacement_desc.custom_attributes)
-        # get nms from original network
+        # get nms from the original network
+        iou_threshold = None
         for node_name in match.matched_nodes_names():
             if Node(graph, node_name)['op'] == 'NonMaxSuppression':
                 iou_threshold = Node(graph, node_name).in_node(3).value
                 break
-        if not iou_threshold:
+        if iou_threshold is not None:
             raise Error('During {} `iou_threshold` was not retrieved from RetinaNet subgraph'.format(self.replacement_id))
 
         detection_output_node = detection_output_op.create_node(

--- a/model-optimizer/extensions/front/tf/RetinaNetFilteredDetectionsReplacement.py
+++ b/model-optimizer/extensions/front/tf/RetinaNetFilteredDetectionsReplacement.py
@@ -79,11 +79,10 @@ class RetinaNetFilteredDetectionsReplacement(FrontReplacementFromConfigFileSubGr
         end.out_port(0).connect(shape_part_for_tiling.in_port(2))
         stride.out_port(0).connect(shape_part_for_tiling.in_port(3))
 
-        concat_value = Const(graph, {'value': int64_array([4])}).create_node()
-        shape_concat = Concat(graph, {'name': name + '/shape_for_tiling', 'in_ports_count': 2,
-                                      'axis': np.array(0)}).create_node()
-        shape_part_for_tiling.out_port(0).connect(shape_concat.in_port(0))
-        concat_value.out_port(0).connect(shape_concat.in_port(1))
+        shape_concat = create_op_node_with_second_input(graph, Concat, int64_array([4]),
+                                                        {'name': name + '/shape_for_tiling', 'in_ports_count': 2,
+                                                         'axis': int64_array(0)},
+                                                        shape_part_for_tiling)
 
         variance = Const(graph, {'name': name + '/variance', 'value': np.array(variance)}).create_node()
         tile = Broadcast(graph, {'name': name + '/variance_tile'}).create_node()
@@ -248,12 +247,13 @@ class RetinaNetFilteredDetectionsReplacement(FrontReplacementFromConfigFileSubGr
         detection_output_op = DetectionOutput(graph, match.custom_replacement_desc.custom_attributes)
         # get nms from the original network
         iou_threshold = None
-        for node_name in match.matched_nodes_names():
-            if Node(graph, node_name)['op'] == 'NonMaxSuppression':
-                iou_threshold = Node(graph, node_name).in_node(3).value
-                break
-        if iou_threshold is not None:
-            raise Error('During {} `iou_threshold` was not retrieved from RetinaNet subgraph'.format(self.replacement_id))
+        nms_nodes = graph.get_op_nodes(op='NonMaxSuppression')
+        if len(nms_nodes) > 0:
+            # it is highly unlikely that for different classes NMS has different
+            # moreover DetectionOutput accepts only scalar values for iou_threshold (nms_threshold)
+            iou_threshold = nms_nodes[0].in_node(3).value
+        if iou_threshold is None:
+            raise Error('During {} `iou_threshold` was not retrieved from RetinaNet graph'.format(self.replacement_id))
 
         detection_output_node = detection_output_op.create_node(
             [reshape_regression_node, reshape_classes_node, priors],

--- a/model-optimizer/extensions/front/tf/non_max_suppression_ext.py
+++ b/model-optimizer/extensions/front/tf/non_max_suppression_ext.py
@@ -21,6 +21,17 @@ from extensions.ops.non_max_suppression import NonMaxSuppression
 from mo.front.extractor import FrontExtractorOp
 
 
+class NonMaxSuppressionV2Extractor(FrontExtractorOp):
+    op = 'NonMaxSuppressionV2'
+    enabled = True
+
+    @classmethod
+    def extract(cls, node):
+        attrs = {'sort_result_descending': 1, 'center_point_box': 0, 'output_type': np.int32}
+        NonMaxSuppression.update_node_stat(node, attrs)
+        return cls.enabled
+
+
 class NonMaxSuppressionV3Extractor(FrontExtractorOp):
     op = 'NonMaxSuppressionV3'
     enabled = True

--- a/model-optimizer/extensions/front/tf/non_max_suppression_ext.py
+++ b/model-optimizer/extensions/front/tf/non_max_suppression_ext.py
@@ -27,7 +27,7 @@ class NonMaxSuppressionV2Extractor(FrontExtractorOp):
 
     @classmethod
     def extract(cls, node):
-        attrs = {'sort_result_descending': 1, 'center_point_box': 0, 'output_type': np.int32}
+        attrs = {'sort_result_descending': 1, 'box_encoding': 'corner', 'output_type': np.int32}
         NonMaxSuppression.update_node_stat(node, attrs)
         return cls.enabled
 
@@ -38,7 +38,7 @@ class NonMaxSuppressionV3Extractor(FrontExtractorOp):
 
     @classmethod
     def extract(cls, node):
-        attrs = {'sort_result_descending': 1, 'center_point_box': 0, 'output_type': np.int32}
+        attrs = {'sort_result_descending': 1, 'box_encoding': 'corner', 'output_type': np.int32}
         NonMaxSuppression.update_node_stat(node, attrs)
         return cls.enabled
 

--- a/model-optimizer/extensions/front/tf/retinanet.json
+++ b/model-optimizer/extensions/front/tf/retinanet.json
@@ -7,7 +7,6 @@
             "confidence_threshold": 0.05,
             "top_k": 6000,
             "keep_top_k": 300,
-            "nms_threshold": 0.5,
             "variance": [0.2, 0.2, 0.2, 0.2]
         },
         "include_inputs_to_sub_graph": true,

--- a/model-optimizer/extensions/ops/non_max_suppression.py
+++ b/model-optimizer/extensions/ops/non_max_suppression.py
@@ -34,7 +34,6 @@ class NonMaxSuppression(Op):
             'version': 'opset5',
             'infer': self.infer,
             'output_type': np.int64,
-            'center_point_box': 0,
             'box_encoding': 'corner',
             'in_ports_count': 5,
             'sort_result_descending': 1,


### PR DESCRIPTION
Added getting nms_threshold / iou_threshold from original RetinaNet model
#34761

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR: N/A -- no new transformations were added
* [x]  Transformation preserves original framework node names: N/A -- because no transformation were added

Validation:
* [x]  Unit tests: N/A
* [x]  Framework operation tests: N/A -- no new operations were added
* [x]  Transformation tests: N/A -- no new transformations were added
* [x]  e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py: N/A
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list: N/A
* [x]  Supported **public** models list: N/A
* [x]  New operations specification: N/A
* [x]  Guide on how to convert the **public** model: N/A
* [x]  User guide update: N/A