### PR TITLE
Fixed transformations looking for FusedBatchNorm operation to look for FBNV2 and FBNV3 also

### DIFF
--- a/model-optimizer/extensions/front/tf/mvn.py
+++ b/model-optimizer/extensions/front/tf/mvn.py
@@ -35,7 +35,7 @@ class MVNReplacer(FrontReplacementSubgraph):
                 ('variance', dict(op='ReduceMean')),
                 ('squeeze_mean', dict(op='Squeeze')),
                 ('squeeze_variance', dict(op='Squeeze')),
-                ('fbn', dict(op='FusedBatchNorm')),
+                ('fbn', dict(op=lambda op: op in ['FusedBatchNorm', 'FusedBatchNormV2', 'FusedBatchNormV3'])),
             ],
             edges=[
                 ('mean', 'stop_grad', {'in': 0}),

--- a/model-optimizer/extensions/middle/FusedBatchNormNonConstant.py
+++ b/model-optimizer/extensions/middle/FusedBatchNormNonConstant.py
@@ -40,7 +40,8 @@ class FusedBatchNormNonConstant(MiddleReplacementPattern):
     def pattern(self):
         return dict(
             nodes=[
-                ('op', dict(kind='op', op='FusedBatchNorm'))],
+                ('op', dict(kind='op', op=lambda op: op in ['FusedBatchNorm', 'FusedBatchNormV2',
+                                                            'FusedBatchNormV3']))],
             edges=[]
         )
 

--- a/model-optimizer/extensions/middle/FusedBatchNormTraining.py
+++ b/model-optimizer/extensions/middle/FusedBatchNormTraining.py
@@ -44,7 +44,8 @@ class FusedBatchNormTraining(MiddleReplacementPattern):
     def pattern(self):
         return dict(
             nodes=[
-                ('op', dict(kind='op', op='FusedBatchNorm', is_training=True))],
+                ('op', dict(kind='op', op=lambda op: op in ['FusedBatchNorm', 'FusedBatchNormV2', 'FusedBatchNormV3'],
+                 is_training=True))],
             edges=[]
         )
 

--- a/model-optimizer/extensions/middle/FusedBatchNormTraining_test.py
+++ b/model-optimizer/extensions/middle/FusedBatchNormTraining_test.py
@@ -130,6 +130,8 @@ class FusedBatchNormTrainingTest(unittest.TestCase):
         FusedBatchNormTraining().find_and_replace_pattern(graph)
         shape_inference(graph)
 
+        graph_ref.nodes['batchnorm']['op'] = op
+
         (flag, resp) = compare_graphs(graph, graph_ref, 'result', check_op_attrs=True)
         self.assertTrue(flag, resp)
 

--- a/model-optimizer/extensions/middle/FusedBatchNormTraining_test.py
+++ b/model-optimizer/extensions/middle/FusedBatchNormTraining_test.py
@@ -17,6 +17,7 @@
 import unittest
 
 import numpy as np
+from generator import generator, generate
 
 from extensions.middle.FusedBatchNormTraining import FusedBatchNormTraining
 from mo.front.common.partial_infer.utils import int64_array
@@ -74,8 +75,12 @@ nodes_attributes = {
 }
 
 
+@generator
 class FusedBatchNormTrainingTest(unittest.TestCase):
-    def test_transformation(self):
+    @generate(*[
+        'FusedBatchNorm', 'FusedBatchNormV2', 'FusedBatchNormV3',
+    ])
+    def test_transformation(self, op: str):
         graph = build_graph(nodes_attributes,
                             [('placeholder', 'placeholder_data', {}),
                              ('scale', 'scale_data'),
@@ -91,7 +96,7 @@ class FusedBatchNormTrainingTest(unittest.TestCase):
                              ('batchnorm_data', 'result'),
                              ],
                             {}, nodes_with_edges_only=True)
-
+        graph.nodes['batchnorm']['op'] = op
         graph_ref = build_graph(nodes_attributes,
                                 [('placeholder', 'placeholder_data', {}),
                                  ('scale', 'scale_data'),


### PR DESCRIPTION
Description: Fixed transformations using FBN to use FBNv2 and FBNv3 also. The correct fix actually should be done as described in the 32688, but it is too big and risky.

JIRA: 42996


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR: N/A
* [x]  Transformation preserves original framework node names: N/A


Validation:
* [x]  Unit tests: updated existing unit tests
* [x]  Framework operation tests: N/A no new op enabled
* [x]  Transformation tests: updated existing unit tests
* [x]  e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py: N/A no new model enabled
* [x]  Model Optimizer IR Reader check: N/A not applicable

Documentation:
* [x]  Supported frameworks operations list: N/A no new op enabled
* [x]  Supported **public** models list: N/A no new model enabled
* [x]  New operations specification: N/A no new op enabled
* [x]  Guide on how to convert the **public** model: N/A no new op enabled
* [x]  User guide update: N/A