### PR TITLE
[ICV][VPU] ExpGenerateProposals: added temporary buffer allocation

### DIFF
--- a/inference-engine/cmake/vpu_dependencies.cmake
+++ b/inference-engine/cmake/vpu_dependencies.cmake
@@ -19,7 +19,7 @@ set(VPU_SUPPORTED_FIRMWARES usb-ma2x8x pcie-ma248x)
 # Default packages
 #
 
-set(FIRMWARE_PACKAGE_VERSION 1476)
+set(FIRMWARE_PACKAGE_VERSION 1479)
 set(VPU_CLC_MA2X8X_VERSION "movi-cltools-20.09.2")
 
 #

--- a/inference-engine/cmake/vpu_dependencies.cmake
+++ b/inference-engine/cmake/vpu_dependencies.cmake
@@ -19,7 +19,7 @@ set(VPU_SUPPORTED_FIRMWARES usb-ma2x8x pcie-ma248x)
 # Default packages
 #
 
-set(FIRMWARE_PACKAGE_VERSION 1479)
+set(FIRMWARE_PACKAGE_VERSION 1492)
 set(VPU_CLC_MA2X8X_VERSION "movi-cltools-20.09.2")
 
 #

--- a/inference-engine/cmake/vpu_dependencies.cmake
+++ b/inference-engine/cmake/vpu_dependencies.cmake
@@ -19,7 +19,7 @@ set(VPU_SUPPORTED_FIRMWARES usb-ma2x8x pcie-ma248x)
 # Default packages
 #
 
-set(FIRMWARE_PACKAGE_VERSION 1474)
+set(FIRMWARE_PACKAGE_VERSION 1476)
 set(VPU_CLC_MA2X8X_VERSION "movi-cltools-20.09.2")
 
 #

--- a/inference-engine/src/vpu/graph_transformer/src/stages/exp_generateproposals.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/exp_generateproposals.cpp
@@ -132,7 +132,8 @@ void FrontEnd::parseExpGenerateProposals(
 
     stage->attrs().set("params", params);
 
-    //This structure is required for sizeof to work
+    //This structure is needed to compute sizeProposalBuf.
+    //Since its outside the scope of the file, we write structure here
     typedef struct {
         int32_t idx;
         fp16_t x0;
@@ -142,16 +143,15 @@ void FrontEnd::parseExpGenerateProposals(
         fp16_t score;
     } t_ExpGenerateProposalsProposal;
 
-    //Counting memory for tmpBuffer
     const int ALIGN_VALUE = 64;
-    const int numProposals = sizeof(t_ExpGenerateProposalsProposal) *
+    const int sizeProposalsBuf = sizeof(t_ExpGenerateProposalsProposal) *
                              inputScores->desc().dim(Dim::H) *
                              inputScores->desc().dim(Dim::W) *
                              inputScores->desc().dim(Dim::C) + ALIGN_VALUE;
-    const int sizeAuxBuff = sizeof(int8_t) * params.pre_nms_topn + ALIGN_VALUE;
+    const int sizeAuxBuf = sizeof(int8_t) * params.pre_nms_topn + ALIGN_VALUE;
     const int sizeRoiIndicesBuf = sizeof(int32_t) * params.post_nms_topn + ALIGN_VALUE;
 
-    int buffer_size = 2 * numProposals + sizeAuxBuff + sizeRoiIndicesBuf;
+    int buffer_size = 2 * sizeProposalsBuf + sizeAuxBuf + sizeRoiIndicesBuf;
 
     model->addTempBuffer(stage, buffer_size);
 }

--- a/inference-engine/src/vpu/graph_transformer/src/stages/exp_generateproposals.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/exp_generateproposals.cpp
@@ -60,6 +60,8 @@ private:
         for (auto& outputEdge : outputEdges()) {
             outputEdge->output()->serializeBuffer(serializer);
         }
+
+        tempBuffer(0)->serializeBuffer(serializer);
     }
 };
 
@@ -129,6 +131,13 @@ void FrontEnd::parseExpGenerateProposals(
         outputs);
 
     stage->attrs().set("params", params);
+
+    const int numProposals = sizeof(uint8_t) * 2 * inputScores->desc().dim(Dim::H) * inputScores->desc().dim(Dim::W) * inputScores->desc().dim(Dim::C);
+    const int sizeAuxBuff = sizeof(uint8_t) * params.pre_nms_topn;
+    const int sizeRoiIndicesBuf = sizeof(int32_t) * params.post_nms_topn;
+    int buffer_size = numProposals + sizeAuxBuff + sizeRoiIndicesBuf;
+
+    model->addTempBuffer(stage, buffer_size);
 }
 
 }  // namespace vpu


### PR DESCRIPTION
ExpGenerateProposals: temporary buffer allocation moved from firmware to blob

Blob changed! Must be merged together with corresponding MDK PR #14788

Previous (inclomplete) OpenVINO PR #2605