### PR TITLE
Fix ApplyPermutations for the case when more then 1 input with permutes

### DIFF
--- a/model-optimizer/extensions/middle/ApplyPermutations.py
+++ b/model-optimizer/extensions/middle/ApplyPermutations.py
@@ -143,6 +143,9 @@ class ApplyPermutation(MiddleReplacementPattern):
                         not is_input_data_in_correct_layout(node, in_port) and \
                         len(port_to_check.data.get_shape()) >= 4:
                     permutation(node, port_info, in_port)
+            if node.has_and_set('need_shape_inference'):
+                node.infer(node)
+                node.need_shape_inference = False
 
     @staticmethod
     def shape_of_sub_graph_reinference(graph: Graph):

--- a/model-optimizer/mo/graph/perm_inputs.py
+++ b/model-optimizer/mo/graph/perm_inputs.py
@@ -151,7 +151,7 @@ def shape(op_node: Node, port_info: str, input_port: int):
 
     # need to run manually to override output shape value to resolve shape collision for nodes with
     # 'correct_data_layout' output port attrs
-    op_node.infer(op_node)
+    op_node['need_shape_inference'] = True
 
 
 def transpose(op_node: Node, port_info: str, input_port: int):


### PR DESCRIPTION
Description: Shape permute was doing shape inference on the end of permutation, but if the node has other input with permute shape inference will fail.
JIRA: #39674