### PR TITLE
Fix NMS5 dynamism issues

### DIFF
--- a/inference-engine/src/cldnn_engine/cldnn_engine.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_engine.cpp
@@ -42,6 +42,7 @@
 
 #include <legacy/transformations/convert_opset1_to_legacy/convert_opset1_to_legacy.hpp>
 #include <legacy/transformations/convert_opset1_to_legacy/convert_prior_to_ie_prior.hpp>
+#include <legacy/transformations/convert_opset1_to_legacy/convert_nms_5_to_legacy.hpp>
 #include <legacy/convert_function_to_cnn_network.hpp>
 #include <legacy/ie_util_internal.hpp>
 #include <legacy/graph_transformer.h>
@@ -155,6 +156,7 @@ InferenceEngine::ICNNNetwork::Ptr clDNNEngine::CloneAndTransformNetwork(const In
             manager.register_pass<ngraph::pass::InitNodeInfo>();
             // WA: ConvertPriorBox must be executed before the 1st ConstantFolding pass
             manager.register_pass<ngraph::pass::ConvertPriorBox>();
+            manager.register_pass<ngraph::pass::ConvertNMS5ToLegacyMatcher>();
             manager.register_pass<ngraph::pass::CommonOptimizations>();
             manager.register_pass<ngraph::pass::ConvertRNNSequenceToTensorIterator>();
             manager.register_pass<ngraph::pass::ConvertGRUSequenceToTensorIterator>();

--- a/inference-engine/src/inference_engine/CMakeLists.txt
+++ b/inference-engine/src/inference_engine/CMakeLists.txt
@@ -14,6 +14,8 @@ file (GLOB LIBRARY_SRC
 set(LEGACY_SRC_ROOT "${IE_MAIN_SOURCE_DIR}/src/legacy_api/src/")
 set(LEGACY_LIBRARY_SHARED_SRCS
     "${LEGACY_SRC_ROOT}/transformations/convert_opset1_to_legacy/convert_one_hot_to_one_hot_ie.cpp"
+    "${LEGACY_SRC_ROOT}/transformations/convert_opset1_to_legacy/convert_nms_5_to_legacy.cpp"
+    "${LEGACY_SRC_ROOT}/ngraph_ops/nms_ie.cpp"
     "${LEGACY_SRC_ROOT}/ngraph_ops/onehot_ie.cpp")
 
 set(IE_STATIC_DEPENDENT_FILES ${CMAKE_CURRENT_SOURCE_DIR}/file_utils.cpp)

--- a/inference-engine/src/inference_engine/cnn_network_ngraph_impl.cpp
+++ b/inference-engine/src/inference_engine/cnn_network_ngraph_impl.cpp
@@ -27,6 +27,7 @@
 
 // TODO: remove this pass usage
 #include <legacy/transformations/convert_opset1_to_legacy/convert_one_hot_to_one_hot_ie.hpp>
+#include <legacy/transformations/convert_opset1_to_legacy/convert_nms_5_to_legacy.hpp>
 
 #include "ie_ngraph_utils.hpp"
 #include "exec_graph_info.hpp"
@@ -337,10 +338,12 @@ CNNNetworkNGraphImpl::reshape(const std::map<std::string, std::vector<size_t>>& 
         auto specialized_ngraph_function = cloneFunction(true);
         // Call this transformation because OneHot IE and nGraph have different output precisions
         {
-            OV_ITT_SCOPED_TASK(itt::domains::IE, "CNNNetworkNGraphImpl::ConvertOneHot");
+            OV_ITT_SCOPED_TASK(itt::domains::IE, "CNNNetworkNGraphImpl::ConvertToLegacy");
             ::ngraph::pass::Manager manager;
             manager.register_pass<::ngraph::pass::ConvertOneHotToOneHotIEMatcher>()->detect_output_type(
                     specialized_ngraph_function);
+            manager.register_pass<::ngraph::pass::ConvertNMS5ToLegacyMatcher>();
+            manager.register_pass<::ngraph::pass::ConstantFolding>();
             manager.run_passes(specialized_ngraph_function);
         }
         specialized_ngraph_function->validate_nodes_and_infer_types();

--- a/inference-engine/src/legacy_api/src/ngraph_ops/nms_ie.cpp
+++ b/inference-engine/src/legacy_api/src/ngraph_ops/nms_ie.cpp
@@ -132,10 +132,16 @@ op::NonMaxSuppressionIE3::NonMaxSuppressionIE3(const Output<Node>& boxes,
 }
 
 std::shared_ptr<Node> op::NonMaxSuppressionIE3::clone_with_new_inputs(const ngraph::OutputVector &new_args) const {
-    check_new_args_count(this, new_args);
-    return make_shared<NonMaxSuppressionIE3>(new_args.at(0), new_args.at(1), new_args.at(2), new_args.at(3),
+    if (new_args.size() == 6) {
+        return make_shared<NonMaxSuppressionIE3>(new_args.at(0), new_args.at(1), new_args.at(2), new_args.at(3),
                                              new_args.at(4), new_args.at(5), m_center_point_box, m_sort_result_descending,
                                              m_output_type);
+    } else if (new_args.size() == 5) {
+        return make_shared<NonMaxSuppressionIE3>(new_args.at(0), new_args.at(1), new_args.at(2), new_args.at(3),
+                                             new_args.at(4), m_center_point_box, m_sort_result_descending,
+                                             m_output_type);
+    }
+    throw ngraph::ngraph_error("Unsupported number of inputs: " + std::to_string(new_args.size()));
 }
 
 bool op::NonMaxSuppressionIE3::visit_attributes(AttributeVisitor& visitor) {

--- a/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/convert_nms_5_to_legacy.cpp
+++ b/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/convert_nms_5_to_legacy.cpp
@@ -85,7 +85,7 @@ ngraph::pass::ConvertNMS5ToLegacyMatcher::ConvertNMS5ToLegacyMatcher() {
                     center_point_box,
                     nms_5->get_sort_result_descending(),
                     element::i32);
-            new_ops.emplace_back(nms_legacy);
+            new_ops.push_back(nms_legacy);
         } else {
             nms_legacy = std::make_shared<op::NonMaxSuppressionIE3>(
                     new_args.at(0),
@@ -96,15 +96,24 @@ ngraph::pass::ConvertNMS5ToLegacyMatcher::ConvertNMS5ToLegacyMatcher() {
                     center_point_box,
                     nms_5->get_sort_result_descending(),
                     element::i32);
-            new_ops.emplace_back(nms_legacy);
+            new_ops.push_back(nms_legacy);
         }
 
-        Output<Node> convert_1 = std::make_shared<opset1::Convert>(nms_legacy->output(0), nms_5->get_output_type());
-        Output<Node> convert_2 = std::make_shared<opset1::Convert>(nms_legacy->output(2), nms_5->get_output_type());
+        Output<Node> output_0 = nms_legacy->output(0);
+        if (nms_5->output(0).get_element_type() != output_0.get_element_type()) {
+            output_0 = std::make_shared<opset1::Convert>(output_0, nms_5->output(0).get_element_type());
+            new_ops.emplace_back(output_0.get_node_shared_ptr());
+        }
+
+        Output<Node> output_2 = nms_legacy->output(2);
+        if (nms_5->output(2).get_element_type() != output_2.get_element_type()) {
+            output_2 = std::make_shared<opset1::Convert>(output_2, nms_5->output(2).get_element_type());
+            new_ops.emplace_back(output_2.get_node_shared_ptr());
+        }
 
         nms_legacy->set_friendly_name(nms_5->get_friendly_name());
         ngraph::copy_runtime_info(nms_5, new_ops);
-        ngraph::replace_node(nms_5, {convert_1, nms_legacy->output(1), convert_2});
+        ngraph::replace_node(nms_5, {output_0, nms_legacy->output(1), output_2});
         return true;
     };
 

--- a/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/convert_nms_5_to_legacy.cpp
+++ b/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/convert_nms_5_to_legacy.cpp
@@ -84,7 +84,7 @@ ngraph::pass::ConvertNMS5ToLegacyMatcher::ConvertNMS5ToLegacyMatcher() {
                     new_soft_nms_sigma,
                     center_point_box,
                     nms_5->get_sort_result_descending(),
-                    nms_5->get_output_type());
+                    element::i32);
             new_ops.emplace_back(nms_legacy);
         } else {
             nms_legacy = std::make_shared<op::NonMaxSuppressionIE3>(
@@ -95,13 +95,16 @@ ngraph::pass::ConvertNMS5ToLegacyMatcher::ConvertNMS5ToLegacyMatcher() {
                     new_score_threshold,
                     center_point_box,
                     nms_5->get_sort_result_descending(),
-                    nms_5->get_output_type());
+                    element::i32);
             new_ops.emplace_back(nms_legacy);
         }
 
+        Output<Node> convert_1 = std::make_shared<opset1::Convert>(nms_legacy->output(0), nms_5->get_output_type());
+        Output<Node> convert_2 = std::make_shared<opset1::Convert>(nms_legacy->output(2), nms_5->get_output_type());
+
         nms_legacy->set_friendly_name(nms_5->get_friendly_name());
         ngraph::copy_runtime_info(nms_5, new_ops);
-        ngraph::replace_node(nms_5, nms_legacy);
+        ngraph::replace_node(nms_5, {convert_1, nms_legacy->output(1), convert_2});
         return true;
     };
 

--- a/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/convert_nms_5_to_legacy.cpp
+++ b/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/convert_nms_5_to_legacy.cpp
@@ -102,12 +102,14 @@ ngraph::pass::ConvertNMS5ToLegacyMatcher::ConvertNMS5ToLegacyMatcher() {
         Output<Node> output_0 = nms_legacy->output(0);
         if (nms_5->output(0).get_element_type() != output_0.get_element_type()) {
             output_0 = std::make_shared<opset1::Convert>(output_0, nms_5->output(0).get_element_type());
+            output_0.get_node_shared_ptr()->set_friendly_name(nms_5->get_friendly_name() + "/convert.0");
             new_ops.emplace_back(output_0.get_node_shared_ptr());
         }
 
         Output<Node> output_2 = nms_legacy->output(2);
         if (nms_5->output(2).get_element_type() != output_2.get_element_type()) {
             output_2 = std::make_shared<opset1::Convert>(output_2, nms_5->output(2).get_element_type());
+            output_2.get_node_shared_ptr()->set_friendly_name(nms_5->get_friendly_name() + "/convert.2");
             new_ops.emplace_back(output_2.get_node_shared_ptr());
         }
 

--- a/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/convert_opset1_to_legacy.cpp
+++ b/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/convert_opset1_to_legacy.cpp
@@ -130,7 +130,6 @@ bool ngraph::pass::ConvertOpSet1ToLegacy::run_on_function(std::shared_ptr<ngraph
     anchor->add_matcher<ngraph::pass::ConvertGatherTreeToGatherTreeIEMatcher>();
     anchor->add_matcher<ngraph::pass::ConvertTopKToTopKIEMatcher>();
     anchor->add_matcher<ngraph::pass::ConvertNMSToNMSIEMatcher>();
-    anchor->add_matcher<ngraph::pass::ConvertNMS5ToLegacyMatcher>();
     anchor->add_matcher<ngraph::pass::ConvertGRUSequenceMatcher>();
     anchor->add_matcher<ngraph::pass::ConvertRNNSequenceMatcher>();
     anchor->add_matcher<ngraph::pass::ConvertLSTMSequenceMatcher>();

--- a/inference-engine/src/mkldnn_plugin/mkldnn_plugin.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_plugin.cpp
@@ -25,6 +25,7 @@
 #include <legacy/transformations/convert_opset1_to_legacy/convert_opset1_to_legacy.hpp>
 #include <legacy/transformations/convert_opset1_to_legacy/convert_prior_to_ie_prior.hpp>
 #include <legacy/transformations/convert_opset1_to_legacy/reshape_fully_connected.hpp>
+#include <legacy/transformations/convert_opset1_to_legacy/convert_nms_5_to_legacy.hpp>
 #include <legacy/ngraph_ops/fully_connected.hpp>
 
 #include <transformations/opset_conversions/convert_opset3_to_opset2.hpp>
@@ -100,6 +101,7 @@ static void Transformation(ICNNNetwork::Ptr& clonedNetwork, const Config& conf) 
     manager.register_pass<ngraph::pass::InitNodeInfo>();
     // WA: ConvertPriorBox must be executed before the 1st ConstantFolding pass
     manager.register_pass<ngraph::pass::ConvertPriorBox>();
+    manager.register_pass<ngraph::pass::ConvertNMS5ToLegacyMatcher>();
     manager.register_pass<ngraph::pass::CommonOptimizations>();
     manager.register_pass<ngraph::pass::ConvertRNNSequenceToTensorIterator>();
     manager.register_pass<ngraph::pass::ConvertGRUSequenceToTensorIterator>();

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/ngraph_reader_tests.hpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/ngraph_reader_tests.hpp
@@ -12,6 +12,8 @@
 
 #include <ie_core.hpp>
 #include <legacy/details/ie_cnn_network_iterator.hpp>
+#include <legacy/transformations/convert_opset1_to_legacy/convert_nms_5_to_legacy.hpp>
+#include <ngraph/pass/manager.hpp>
 
 #include "common_test_utils/test_common.hpp"
 #include "common_test_utils/file_utils.hpp"
@@ -39,6 +41,12 @@ protected:
         }
 
         auto network = ie.ReadNetwork(modelV10, weights);
+        auto f = network.getFunction();
+        // WA: we have to resolve dynamysm manually to compare resulting function with v7 IR
+        ngraph::pass::Manager manager;
+        manager.register_pass<ngraph::pass::ConvertNMS5ToLegacyMatcher>();
+        manager.run_passes(f);
+        network = CNNNetwork(f);
         auto cnnNetwork = ie.ReadNetwork(oldModel, weights);
 
         IE_SUPPRESS_DEPRECATED_START

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/non_max_suppression_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/non_max_suppression_tests.cpp
@@ -72,7 +72,7 @@ TEST_F(NGraphReaderTests, ReadNonMaxSuppression5) {
             </output>
         </layer>
         <layer id="6" name="nms" type="NonMaxSuppression" version="opset5">
-            <data box_encoding="corner" sort_result_descending="0"/>
+            <data box_encoding="corner" sort_result_descending="0" output_type="i32"/>
             <input>
                 <port id="0" precision="FP32">
                     <dim>1</dim>
@@ -248,8 +248,8 @@ TEST_F(NGraphReaderTests, ReadNonMaxSuppression5) {
                 <custom offset="12" precision="FP32" size="4"/>
             </blobs>
         </layer>
-        <layer id="5" name="nms" type="NonMaxSuppression" precision="I64">
-            <data center_point_box="false" output_type="I64" sort_result_descending="false"/>
+        <layer id="5" name="nms" type="NonMaxSuppression" precision="I32">
+            <data center_point_box="false" output_type="I32" sort_result_descending="false"/>
             <input>
                 <port id="0">
                     <dim>1</dim>
@@ -272,7 +272,7 @@ TEST_F(NGraphReaderTests, ReadNonMaxSuppression5) {
                 </port>
             </input>
             <output>
-                <port id="5" precision="I64">
+                <port id="5" precision="I32">
                     <dim>16000</dim>
                     <dim>3</dim>
                 </port>
@@ -280,12 +280,12 @@ TEST_F(NGraphReaderTests, ReadNonMaxSuppression5) {
                     <dim>16000</dim>
                     <dim>3</dim>
                 </port>
-                <port id="7" precision="I64">
+                <port id="7" precision="I32">
                     <dim>1</dim>
                 </port>
             </output>
         </layer>
-        <layer id="6" name="mul" type="Eltwise" precision="I64">
+        <layer id="6" name="mul" type="Eltwise" precision="I32">
             <data operation="prod"/>
             <input>
                 <port id="0">
@@ -298,13 +298,13 @@ TEST_F(NGraphReaderTests, ReadNonMaxSuppression5) {
                 </port>
             </input>
             <output>
-                <port id="2" precision="I64">
+                <port id="2" precision="I32">
                     <dim>16000</dim>
                     <dim>3</dim>
                 </port>
             </output>
         </layer>
-        <layer id="7" name="mul2" type="Eltwise" precision="I64">
+        <layer id="7" name="mul2" type="Eltwise" precision="I32">
             <data operation="prod"/>
             <input>
                 <port id="0">
@@ -315,7 +315,7 @@ TEST_F(NGraphReaderTests, ReadNonMaxSuppression5) {
                 </port>
             </input>
             <output>
-                <port id="2" precision="I64">
+                <port id="2" precision="I32">
                     <dim>1</dim>
                 </port>
             </output>

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_nms5_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_nms5_test.cpp
@@ -30,7 +30,7 @@ TEST(TransformationTests, ConvertNMS5ToNMSIEStaticSixInputs) {
         auto score_threshold = opset5::Constant::create(element::f32, Shape{}, {0.7});
         auto soft_nms_sigma = ngraph::opset5::Constant::create(element::f32, Shape{}, {0.25});
         auto nms = std::make_shared<opset5::NonMaxSuppression>(boxes, scores, max_output_boxes_per_class, iou_threshold, score_threshold,
-                                                               soft_nms_sigma, opset5::NonMaxSuppression::BoxEncodingType::CORNER, true);
+                                                               soft_nms_sigma, opset5::NonMaxSuppression::BoxEncodingType::CORNER, true, element::i32);
 
         f = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
 
@@ -64,7 +64,7 @@ TEST(TransformationTests, ConvertNMS5ToNMSIEStaticSixInputs) {
                                                                     opset5::Constant::create(ngraph::element::i64, one_dim_shape,
                                                                                              one_dim_shape), true);
         auto nms = std::make_shared<op::NonMaxSuppressionIE3>(boxes, scores, new_max_per_class, new_iou_threshold, new_score_threshold,
-                                                              new_soft_nms_sigma, 0, true);
+                                                              new_soft_nms_sigma, 0, true, element::i32);
         nms->set_friendly_name("nms");
 
         f_ref = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
@@ -84,7 +84,7 @@ TEST(TransformationTests, ConvertNMS5ToNMSIEStaticFiveInputs) {
         auto iou_threshold = opset5::Constant::create(element::f32, Shape{}, {0.75});
         auto score_threshold = opset5::Constant::create(element::f32, Shape{}, {0.7});
         auto nms = std::make_shared<opset5::NonMaxSuppression>(boxes, scores, max_output_boxes_per_class, iou_threshold, score_threshold,
-                                                               opset5::NonMaxSuppression::BoxEncodingType::CORNER, true);
+                                                               opset5::NonMaxSuppression::BoxEncodingType::CORNER, true, element::i32);
 
         f = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
 
@@ -114,7 +114,7 @@ TEST(TransformationTests, ConvertNMS5ToNMSIEStaticFiveInputs) {
                                                                      opset5::Constant::create(ngraph::element::i64, one_dim_shape,
                                                                                               one_dim_shape), true);
         auto nms = std::make_shared<op::NonMaxSuppressionIE3>(boxes, scores, new_max_per_class, new_iou_threshold, new_score_threshold,
-                                                              0, true);
+                                                              0, true, element::i32);
         nms->set_friendly_name("nms");
 
         f_ref = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
@@ -133,7 +133,7 @@ TEST(TransformationTests, ConvertNMS5ToNMSIEStaticFourInputs) {
         auto max_output_boxes_per_class = opset5::Constant::create(element::i64, Shape{}, {10});
         auto iou_threshold = opset5::Constant::create(element::f32, Shape{}, {0.75});
         auto nms = std::make_shared<opset5::NonMaxSuppression>(boxes, scores, max_output_boxes_per_class, iou_threshold,
-                                                               opset5::NonMaxSuppression::BoxEncodingType::CORNER, true);
+                                                               opset5::NonMaxSuppression::BoxEncodingType::CORNER, true, element::i32);
 
         f = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
 
@@ -163,7 +163,7 @@ TEST(TransformationTests, ConvertNMS5ToNMSIEStaticFourInputs) {
                                                                      opset5::Constant::create(ngraph::element::i64, one_dim_shape,
                                                                                               one_dim_shape), true);
         auto nms = std::make_shared<op::NonMaxSuppressionIE3>(boxes, scores, new_max_per_class, new_iou_threshold, new_score_threshold,
-                                                              0, true);
+                                                              0, true, element::i32);
         nms->set_friendly_name("nms");
 
         f_ref = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
@@ -181,7 +181,7 @@ TEST(TransformationTests, ConvertNMS5ToNMSIEStaticThreeInputs) {
         auto scores = std::make_shared<opset5::Parameter>(element::f32, Shape{1, 1, 1000});
         auto max_output_boxes_per_class = opset5::Constant::create(element::i64, Shape{}, {10});
         auto nms = std::make_shared<opset5::NonMaxSuppression>(boxes, scores, max_output_boxes_per_class,
-                                                               opset5::NonMaxSuppression::BoxEncodingType::CORNER, true);
+                                                               opset5::NonMaxSuppression::BoxEncodingType::CORNER, true, element::i32);
 
         f = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
 
@@ -211,7 +211,7 @@ TEST(TransformationTests, ConvertNMS5ToNMSIEStaticThreeInputs) {
                                                                      opset5::Constant::create(ngraph::element::i64, one_dim_shape,
                                                                                               one_dim_shape), true);
         auto nms = std::make_shared<op::NonMaxSuppressionIE3>(boxes, scores, new_max_per_class, new_iou_threshold, new_score_threshold,
-                                                              0, true);
+                                                              0, true, element::i32);
         nms->set_friendly_name("nms");
 
         f_ref = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
@@ -228,7 +228,7 @@ TEST(TransformationTests, ConvertNMS5ToNMSIEStaticTwoInputs) {
         auto boxes = std::make_shared<opset5::Parameter>(element::f32, Shape{1, 1000, 4});
         auto scores = std::make_shared<opset5::Parameter>(element::f32, Shape{1, 1, 1000});
         auto nms = std::make_shared<opset5::NonMaxSuppression>(boxes, scores,
-                                                               opset5::NonMaxSuppression::BoxEncodingType::CORNER, true);
+                                                               opset5::NonMaxSuppression::BoxEncodingType::CORNER, true, element::i32);
 
         f = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
 
@@ -258,7 +258,7 @@ TEST(TransformationTests, ConvertNMS5ToNMSIEStaticTwoInputs) {
                                                                      opset5::Constant::create(ngraph::element::i64, one_dim_shape,
                                                                                               one_dim_shape), true);
         auto nms = std::make_shared<op::NonMaxSuppressionIE3>(boxes, scores, new_max_per_class, new_iou_threshold, new_score_threshold,
-                                                              0, true);
+                                                              0, true, element::i32);
         nms->set_friendly_name("nms");
 
         f_ref = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
@@ -279,7 +279,7 @@ TEST(TransformationTests, ConvertNMS5ToNMSIEDynamic1SixInputs) {
         auto score_threshold = opset5::Constant::create(element::f32, Shape{}, {0.7});
         auto soft_nms_sigma = ngraph::opset5::Constant::create(element::f32, Shape{}, {0.25});
         auto nms = std::make_shared<opset5::NonMaxSuppression>(boxes, scores, max_output_boxes_per_class, iou_threshold, score_threshold,
-                                                               soft_nms_sigma, opset5::NonMaxSuppression::BoxEncodingType::CORNER, true);
+                                                               soft_nms_sigma, opset5::NonMaxSuppression::BoxEncodingType::CORNER, true, element::i32);
 
         f = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
 
@@ -314,7 +314,7 @@ TEST(TransformationTests, ConvertNMS5ToNMSIEDynamic1SixInputs) {
                                                                     opset5::Constant::create(ngraph::element::i64, one_dim_shape,
                                                                                              one_dim_shape), true);
         auto nms = std::make_shared<op::NonMaxSuppressionIE3>(boxes, scores, new_max_per_class, new_iou_threshold, new_score_threshold,
-                                                              new_soft_nms_sigma, 0, true);
+                                                              new_soft_nms_sigma, 0, true, element::i32);
         nms->set_friendly_name("nms");
 
         f_ref = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
@@ -333,7 +333,7 @@ TEST(TransformationTests, ConvertNMS5ToNMSIEDynamic1FiveInputs) {
         auto iou_threshold = opset5::Constant::create(element::f32, Shape{}, {0.75});
         auto score_threshold = opset5::Constant::create(element::f32, Shape{}, {0.7});
         auto nms = std::make_shared<opset5::NonMaxSuppression>(boxes, scores, max_output_boxes_per_class, iou_threshold, score_threshold,
-                                                               opset5::NonMaxSuppression::BoxEncodingType::CORNER, true);
+                                                               opset5::NonMaxSuppression::BoxEncodingType::CORNER, true, element::i32);
 
         f = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
 
@@ -364,7 +364,7 @@ TEST(TransformationTests, ConvertNMS5ToNMSIEDynamic1FiveInputs) {
                                                                      opset5::Constant::create(ngraph::element::i64, one_dim_shape,
                                                                                               one_dim_shape), true);
         auto nms = std::make_shared<op::NonMaxSuppressionIE3>(boxes, scores, new_max_per_class, new_iou_threshold, new_score_threshold,
-                                                              0, true);
+                                                              0, true, element::i32);
         nms->set_friendly_name("nms");
 
         f_ref = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
@@ -382,7 +382,7 @@ TEST(TransformationTests, ConvertNMS5ToNMSIEDynamic1FourInputs) {
         auto max_output_boxes_per_class = opset5::Constant::create(element::i64, Shape{}, {10});
         auto iou_threshold = opset5::Constant::create(element::f32, Shape{}, {0.75});
         auto nms = std::make_shared<opset5::NonMaxSuppression>(boxes, scores, max_output_boxes_per_class, iou_threshold,
-                                                               opset5::NonMaxSuppression::BoxEncodingType::CORNER, true);
+                                                               opset5::NonMaxSuppression::BoxEncodingType::CORNER, true, element::i32);
 
         f = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
 
@@ -413,7 +413,7 @@ TEST(TransformationTests, ConvertNMS5ToNMSIEDynamic1FourInputs) {
                                                                      opset5::Constant::create(ngraph::element::i64, one_dim_shape,
                                                                                               one_dim_shape), true);
         auto nms = std::make_shared<op::NonMaxSuppressionIE3>(boxes, scores, new_max_per_class, new_iou_threshold, new_score_threshold,
-                                                              0, true);
+                                                              0, true, element::i32);
         nms->set_friendly_name("nms");
 
         f_ref = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
@@ -430,7 +430,7 @@ TEST(TransformationTests, ConvertNMS5ToNMSIEDynamic1ThreeInputs) {
         auto scores = std::make_shared<opset5::Parameter>(element::f32, PartialShape::dynamic());
         auto max_output_boxes_per_class = opset5::Constant::create(element::i64, Shape{}, {10});
         auto nms = std::make_shared<opset5::NonMaxSuppression>(boxes, scores, max_output_boxes_per_class,
-                                                               opset5::NonMaxSuppression::BoxEncodingType::CORNER, true);
+                                                               opset5::NonMaxSuppression::BoxEncodingType::CORNER, true, element::i32);
 
         f = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
 
@@ -461,7 +461,7 @@ TEST(TransformationTests, ConvertNMS5ToNMSIEDynamic1ThreeInputs) {
                                                                      opset5::Constant::create(ngraph::element::i64, one_dim_shape,
                                                                                               one_dim_shape), true);
         auto nms = std::make_shared<op::NonMaxSuppressionIE3>(boxes, scores, new_max_per_class, new_iou_threshold, new_score_threshold,
-                                                              0, true);
+                                                              0, true, element::i32);
         nms->set_friendly_name("nms");
 
         f_ref = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
@@ -477,7 +477,7 @@ TEST(TransformationTests, ConvertNMS5ToNMSIEDynamic1TwoInputs) {
         auto boxes = std::make_shared<opset5::Parameter>(element::f32, PartialShape::dynamic());
         auto scores = std::make_shared<opset5::Parameter>(element::f32, PartialShape::dynamic());
         auto nms = std::make_shared<opset5::NonMaxSuppression>(boxes, scores,
-                                                               opset5::NonMaxSuppression::BoxEncodingType::CORNER, true);
+                                                               opset5::NonMaxSuppression::BoxEncodingType::CORNER, true, element::i32);
 
         f = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
 
@@ -508,7 +508,7 @@ TEST(TransformationTests, ConvertNMS5ToNMSIEDynamic1TwoInputs) {
                                                                      opset5::Constant::create(ngraph::element::i64, one_dim_shape,
                                                                                               one_dim_shape), true);
         auto nms = std::make_shared<op::NonMaxSuppressionIE3>(boxes, scores, new_max_per_class, new_iou_threshold, new_score_threshold,
-                                                              0, true);
+                                                              0, true, element::i32);
         nms->set_friendly_name("nms");
 
         f_ref = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
@@ -528,7 +528,7 @@ TEST(TransformationTests, ConvertNMS5ToNMSIEDynamic2SixInputs) {
         auto score_threshold = opset5::Constant::create(element::f32, Shape{}, {0.7});
         auto soft_nms_sigma = ngraph::opset5::Constant::create(element::f32, Shape{}, {0.25});
         auto nms = std::make_shared<opset5::NonMaxSuppression>(boxes, scores, max_output_boxes_per_class, iou_threshold, score_threshold,
-                                                               soft_nms_sigma, opset5::NonMaxSuppression::BoxEncodingType::CORNER, true);
+                                                               soft_nms_sigma, opset5::NonMaxSuppression::BoxEncodingType::CORNER, true, element::i32);
 
         f = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
 
@@ -562,7 +562,7 @@ TEST(TransformationTests, ConvertNMS5ToNMSIEDynamic2SixInputs) {
                                                                     opset5::Constant::create(ngraph::element::i64, one_dim_shape,
                                                                                              one_dim_shape), true);
         auto nms = std::make_shared<op::NonMaxSuppressionIE3>(boxes, scores, new_max_per_class, new_iou_threshold, new_score_threshold,
-                                                              new_soft_nms_sigma, 0, true);
+                                                              new_soft_nms_sigma, 0, true, element::i32);
         nms->set_friendly_name("nms");
 
         f_ref = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
@@ -581,7 +581,7 @@ TEST(TransformationTests, ConvertNMS5ToNMSIEDynamic2FiveInputs) {
         auto iou_threshold = opset5::Constant::create(element::f32, Shape{}, {0.75});
         auto score_threshold = opset5::Constant::create(element::f32, Shape{}, {0.7});
         auto nms = std::make_shared<opset5::NonMaxSuppression>(boxes, scores, max_output_boxes_per_class, iou_threshold, score_threshold,
-                                                               opset5::NonMaxSuppression::BoxEncodingType::CORNER, true);
+                                                               opset5::NonMaxSuppression::BoxEncodingType::CORNER, true, element::i32);
 
         f = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
 
@@ -611,7 +611,7 @@ TEST(TransformationTests, ConvertNMS5ToNMSIEDynamic2FiveInputs) {
                                                                      opset5::Constant::create(ngraph::element::i64, one_dim_shape,
                                                                                               one_dim_shape), true);
         auto nms = std::make_shared<op::NonMaxSuppressionIE3>(boxes, scores, new_max_per_class, new_iou_threshold, new_score_threshold,
-                                                              0, true);
+                                                              0, true, element::i32);
         nms->set_friendly_name("nms");
 
         f_ref = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
@@ -629,7 +629,7 @@ TEST(TransformationTests, ConvertNMS5ToNMSIEDynamic2FourInputs) {
         auto max_output_boxes_per_class = opset5::Constant::create(element::i64, Shape{}, {10});
         auto iou_threshold = opset5::Constant::create(element::f32, Shape{}, {0.75});
         auto nms = std::make_shared<opset5::NonMaxSuppression>(boxes, scores, max_output_boxes_per_class, iou_threshold,
-                                                               opset5::NonMaxSuppression::BoxEncodingType::CORNER, true);
+                                                               opset5::NonMaxSuppression::BoxEncodingType::CORNER, true, element::i32);
 
         f = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
 
@@ -659,7 +659,7 @@ TEST(TransformationTests, ConvertNMS5ToNMSIEDynamic2FourInputs) {
                                                                      opset5::Constant::create(ngraph::element::i64, one_dim_shape,
                                                                                               one_dim_shape), true);
         auto nms = std::make_shared<op::NonMaxSuppressionIE3>(boxes, scores, new_max_per_class, new_iou_threshold, new_score_threshold,
-                                                              0, true);
+                                                              0, true, element::i32);
         nms->set_friendly_name("nms");
 
         f_ref = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
@@ -676,7 +676,7 @@ TEST(TransformationTests, ConvertNMS5ToNMSIEDynamic2ThreeInputs) {
         auto scores = std::make_shared<opset5::Parameter>(element::f32, PartialShape{DYN, 1, 1000});
         auto max_output_boxes_per_class = opset5::Constant::create(element::i64, Shape{}, {10});
         auto nms = std::make_shared<opset5::NonMaxSuppression>(boxes, scores, max_output_boxes_per_class,
-                                                               opset5::NonMaxSuppression::BoxEncodingType::CORNER, true);
+                                                               opset5::NonMaxSuppression::BoxEncodingType::CORNER, true, element::i32);
 
         f = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
 
@@ -706,7 +706,7 @@ TEST(TransformationTests, ConvertNMS5ToNMSIEDynamic2ThreeInputs) {
                                                                      opset5::Constant::create(ngraph::element::i64, one_dim_shape,
                                                                                               one_dim_shape), true);
         auto nms = std::make_shared<op::NonMaxSuppressionIE3>(boxes, scores, new_max_per_class, new_iou_threshold, new_score_threshold,
-                                                              0, true);
+                                                              0, true, element::i32);
         nms->set_friendly_name("nms");
 
         f_ref = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
@@ -752,10 +752,12 @@ TEST(TransformationTests, ConvertNMS5ToNMSIEDynamic2TwoInputs) {
                                                                      opset5::Constant::create(ngraph::element::i64, one_dim_shape,
                                                                                               one_dim_shape), true);
         auto nms = std::make_shared<op::NonMaxSuppressionIE3>(boxes, scores, new_max_per_class, new_iou_threshold, new_score_threshold,
-                                                              0, true);
+                                                              0, true, element::i32);
         nms->set_friendly_name("nms");
 
-        f_ref = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
+        auto convert_0 = std::make_shared<opset1::Convert>(nms->output(0), element::i64);
+
+        f_ref = std::make_shared<Function>(NodeVector{convert_0}, ParameterVector{boxes, scores});
     }
 
     auto res = compare_functions(f, f_ref);

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_non_max_suppression.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_non_max_suppression.cpp
@@ -77,9 +77,12 @@ protected:
             SetRefMode(LayerTestsUtils::RefMode::INTERPRETER);
             configuration[InferenceEngine::MYRIAD_DETECT_NETWORK_BATCH] = CONFIG_VALUE(NO);
             const auto testedOp = createTestedOp();
-
+            const auto identity_0 = std::make_shared<ngraph::opset5::Multiply>(testedOp->output(0),
+                ngraph::opset5::Constant::create(testedOp->output(0).get_element_type(), ngraph::Shape{1}, {1}));
+            const auto identity_2 = std::make_shared<ngraph::opset5::Multiply>(testedOp->output(2),
+                ngraph::opset5::Constant::create(testedOp->output(2).get_element_type(), ngraph::Shape{1}, {1}));
             function = std::make_shared<ngraph::Function>(
-                ngraph::OutputVector{testedOp->output(0), testedOp->output(2)},
+                ngraph::OutputVector{identity_0, identity_2},
                 m_parameterVector);
     }
 };

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/non_max_suppression.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/non_max_suppression.hpp
@@ -34,7 +34,6 @@ using NmsParams = std::tuple<InputShapeParams,                                  
 class NmsLayerTest : public testing::WithParamInterface<NmsParams>, virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<NmsParams> obj);
-    void ConfigureNetwork() override;
     void Infer() override;
     void Compare(const std::vector<std::vector<std::uint8_t>> &expectedOutputs, const std::vector<InferenceEngine::Blob::Ptr> &actualOutputs) override;
 

--- a/ngraph/python/tests/__init__.py
+++ b/ngraph/python/tests/__init__.py
@@ -174,30 +174,6 @@ xfail_issue_38735 = xfail_test(reason="RuntimeError: nGraph does not support the
 xfail_issue_38736 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations:"
                                       "NegativeLogLikelihoodLoss")
 
-xfail_issue_42779 = xfail_test(reason="Unsupported dynamic ops:"
-                                      "v1::TopKIE TopK_6774 (Gather_706[0]:f32{16000}, Unsqueeze_7522[0]:"
-                                      "i32{1}) -> (f32{?}, i32{?})"
-                                      "v0::Convert TopK_718.1 (TopK_6774[1]:i32{?}) -> (i32{?})"
-                                      "v0::GatherIE Gather_733 (Gather_706[0]:f32{16000}, TopK_718.1[0]:"
-                                      "i32{?}) -> (f32{?})"
-                                      "v1::Reshape scores (Gather_733[0]:f32{?}, Constant_6852[0]:i32{2})"
-                                      " -> (f32{1,?})"
-                                      "v0::Result scores (scores[0]:f32{1,?}) -> (f32{1,?})"
-                                      "v0::GatherIE Gather_729 (Gather_690[0]:i32{16000}, TopK_718.1[0]:"
-                                      "i32{?}) -> (i32{?})"
-                                      "v1::Reshape Unsqueeze_730 (Gather_729[0]:i32{?}, Constant_6854[0]:"
-                                      "i32{2}) -> (i32{1,?})"
-                                      "v1::Eltwise labels (Unsqueeze_730[0]:i32{1,?}, Constant_6855[0]:"
-                                      "i32{}) -> (i32{1,?})"
-                                      "v0::Result labels (labels[0]:i32{1,?}) -> (i32{1,?})"
-                                      "v0::GatherIE Gather_720 (Gather_697[0]:i32{16000}, TopK_718.1[0]:"
-                                      "i32{?}) -> (i32{?})"
-                                      "v0::GatherIE Gather_727 (Squeeze_719[0]:f32{15130,4}, Gather_720[0]:"
-                                      "i32{?}) -> (f32{?,4})"
-                                      "v1::Reshape bboxes (Gather_727[0]:f32{?,4}, Constant_6859[0]:i32{3})"
-                                      " -> (f32{1,?,4})"
-                                      "v0::Result bboxes (bboxes[0]:f32{1,?,4}) -> (f32{1,?,4}))")
-
 # Model ONNX Zoo issues:
 xfail_issue_36533 = xfail_test(reason="AssertionError: zoo models results mismatch")
 xfail_issue_39684 = xfail_test(reason="ngraph.exceptions.UserInputError:"

--- a/ngraph/python/tests/test_onnx/test_zoo_models.py
+++ b/ngraph/python/tests/test_onnx/test_zoo_models.py
@@ -37,8 +37,7 @@ from tests import (
     xfail_issue_38084,
     xfail_issue_39669,
     xfail_issue_38726,
-    xfail_issue_40686,
-    xfail_issue_42779)
+    xfail_issue_40686)
 
 MODELS_ROOT_DIR = tests.MODEL_ZOO_DIR
 
@@ -157,7 +156,6 @@ if len(zoo_models) > 0:
             (xfail_issue_39685, "test_onnx_model_zoo_text_machine_comprehension_roberta_model_roberta_sequence_classification_9_roberta_sequence_classification_9_roberta_sequence_classification_9_cpu"),
             (xfail_issue_39669, "test_onnx_model_zoo_text_machine_comprehension_t5_model_t5_encoder_12_t5_encoder_cpu"),
             (xfail_issue_38084, "test_onnx_model_zoo_vision_object_detection_segmentation_mask_rcnn_model_MaskRCNN_10_mask_rcnn_R_50_FPN_1x_cpu"),
-            (xfail_issue_42779, "test_onnx_model_zoo_vision_object_detection_segmentation_ssd_model_ssd_10_model_cpu"),
             (xfail_issue_38084, "test_onnx_model_zoo_vision_object_detection_segmentation_faster_rcnn_model_FasterRCNN_10_faster_rcnn_R_50_FPN_1x_cpu"),
             (xfail_issue_41815, "test_onnx_model_zoo_vision_object_detection_segmentation_yolov3_model_yolov3_10_yolov3_yolov3_cpu"),
             (xfail_issue_41815, "test_onnx_model_zoo_vision_object_detection_segmentation_tiny_yolov3_model_tiny_yolov3_11_yolov3_tiny_cpu"),


### PR DESCRIPTION
Change list:
* Added NMS5ToLegacy transformation for CPU and GPU plugins before CommonOptimizations pass. This is necessary as NMS5 produces dynamic shape and we have to get rid of this shapes as soon as possible. Otherwise some transformations won't apply so we can get performance or functional issues (in a worst case).
* Updated NMS5ToLegacy transformation to produce i32 output type for NMS. That helps to avoid legacy dependency in ConvertPrecision transformation that works only with opset operations.
* Added NMS5ToLegacy transformation into CNNNetworkNGraphImpl::reshape method to be able to get static output shapes. Otherwise we will get some default output shape that in final will cause an "inference results shape mistmatch" exception in InferRequest.
* Fixed a bug in NMS3IE copy function.
* Updated NMS5ToLegacy tests.

As a result this changes fix all NMS5 related issues including issues with "unsupported dynamic ops".