### PR TITLE
[MO] cli_parser fix when input contains substring with matching scale/mean values

### DIFF
--- a/model-optimizer/mo/utils/cli_parser.py
+++ b/model-optimizer/mo/utils/cli_parser.py
@@ -932,17 +932,19 @@ def parse_tuple_pairs(argv_values: str):
         name_start_idx = match.end(0) + 1
         tuple_value = np.fromstring(match.groups()[0], dtype=float, sep=',')
 
-        if idx != 0 and name_was_present ^ bool(input_name):
+        if idx != 0 and (name_was_present ^ bool(input_name)):
             # if node name firstly was specified and then subsequently not or vice versa
             # e.g. (255),input[127] or input(255),[127]
             raise Error(error_msg, argv_values)
 
-        name_was_present = True if input_name else False
+        name_was_present = True if input_name != "" else False
         if name_was_present:
             res[input_name] = tuple_value
         else:
             res[idx] = tuple_value
+
     if not name_was_present:
+        # return a list instead of a dictionary
         res = sorted(res.values(), key=lambda v: v[0])
     return res
 

--- a/model-optimizer/mo/utils/cli_parser.py
+++ b/model-optimizer/mo/utils/cli_parser.py
@@ -919,27 +919,31 @@ def parse_tuple_pairs(argv_values: str):
 
     matches = [m for m in re.finditer(r'[(\[]([0-9., -]+)[)\]]', argv_values, re.IGNORECASE)]
 
-    error_msg = "Mean/scale values should be in format: data(1,2,3),info(2,3,4)" \
-                " or just plain set of them without naming any inputs: (1,2,3),(2,3,4). " + \
-                refer_to_faq_msg(101)
+    error_msg = 'Mean/scale values should consist of name and values specified in round or square brackets' \
+                'separated by comma, e.g. data(1,2,3),info[2,3,4],egg[255] or data(1,2,3). Or just plain set of ' \
+                'values without names: (1,2,3),(2,3,4) or [1,2,3],[2,3,4].' + refer_to_faq_msg(101)
     if not matches:
         raise Error(error_msg, argv_values)
 
     name_start_idx = 0
-    for m in matches:
-        input_name = argv_values[name_start_idx:m.start(0)]
-        name_start_idx = m.end(0) + 1
-        tuple_value = m.groups()[0]
+    name_was_present = False
+    for idx, match in enumerate(matches):
+        input_name = argv_values[name_start_idx:match.start(0)]
+        name_start_idx = match.end(0) + 1
+        tuple_value = np.fromstring(match.groups()[0], dtype=float, sep=',')
 
-        if not input_name:
-            # check that other values are specified without names
-            if re.search(r'([a-zA-Z]+)', argv_values[m.start(0):]) is None:
-                return [np.fromstring(m.groups()[0], dtype=float, sep=',') for m in matches]
-            else:
-                raise Error(error_msg, argv_values)
+        if idx != 0 and name_was_present ^ bool(input_name):
+            # if node name firstly was specified and then subsequently not or vice versa
+            # e.g. (255),input[127] or input(255),[127]
+            raise Error(error_msg, argv_values)
 
-        res[input_name] = np.fromstring(tuple_value, dtype=float, sep=',')
-
+        name_was_present = True if input_name else False
+        if name_was_present:
+            res[input_name] = tuple_value
+        else:
+            res[idx] = tuple_value
+    if not name_was_present:
+        res = sorted(res.values(), key=lambda v: v[0])
     return res
 
 

--- a/model-optimizer/mo/utils/cli_parser_test.py
+++ b/model-optimizer/mo/utils/cli_parser_test.py
@@ -41,6 +41,16 @@ class TestingMeanScaleGetter(unittest.TestCase):
         for el in exp_res.keys():
             npt.assert_array_equal(result[el], exp_res[el])
 
+    def test_tuple_parser_name_digits_only(self):
+        tuple_values = "0448(1.1,22.22,333.333),0449[2.2,33.33,444.444]"
+        result = parse_tuple_pairs(tuple_values)
+        exp_res = {
+            '0448': np.array([1.1, 22.22, 333.333]),
+            '0449': np.array([2.2, 33.33, 444.444])
+        }
+        for el in exp_res.keys():
+            npt.assert_array_equal(result[el], exp_res[el])
+
     def test_tuple_parser_same_values(self):
         tuple_values = "data(1.1,22.22,333.333),info[1.1,22.22,333.333]"
         result = parse_tuple_pairs(tuple_values)
@@ -59,8 +69,20 @@ class TestingMeanScaleGetter(unittest.TestCase):
         for i in range(0, len(exp_res)):
             npt.assert_array_equal(result[i], exp_res[i])
 
-    def test_tuple_parser_error(self):
+    def test_tuple_parser_error_mixed_with_and_without_name(self):
         tuple_values = "(1.1,22.22,333.333),data[2.2,33.33,444.444]"
+        self.assertRaises(Error, parse_tuple_pairs, tuple_values)
+
+    def test_tuple_parser_error_mixed_with_and_without_name_1(self):
+        tuple_values = "data(1.1,22.22,333.333),[2.2,33.33,444.444]"
+        self.assertRaises(Error, parse_tuple_pairs, tuple_values)
+
+    def test_tuple_parser_error_mixed_with_and_without_name_digits(self):
+        tuple_values = "(0.1,22.22,333.333),0448[2.2,33.33,444.444]"
+        self.assertRaises(Error, parse_tuple_pairs, tuple_values)
+
+    def test_tuple_parser_error_mixed_with_and_without_name_digits_1(self):
+        tuple_values = "447(1.1,22.22,333.333),[2.2,33.33,444.444]"
         self.assertRaises(Error, parse_tuple_pairs, tuple_values)
 
     def test_mean_scale_no_input(self):
@@ -357,7 +379,7 @@ class TestingMeanScaleGetter(unittest.TestCase):
         self.assertRaises(Error, get_mean_scale_dictionary, mean_values, scale_values, "input1,input2")
 
     def test_values_match_input_name(self):
-        # before fix cli_parser was confused when input had a substring that matches scale/mean values
+        # to be sure that we correctly processes complex names
         res_values = parse_tuple_pairs("input255(255),input255.0(255.0),multi-dotted.input.3.(255,128,64)")
         exp_res = {'input255': np.array([255.0]),
                    'input255.0': np.array([255.0]),

--- a/model-optimizer/mo/utils/cli_parser_test.py
+++ b/model-optimizer/mo/utils/cli_parser_test.py
@@ -22,6 +22,7 @@ import unittest
 from unittest.mock import patch
 
 import numpy as np
+import numpy.testing as npt
 
 from mo.utils.cli_parser import get_placeholder_shapes, get_tuple_values, get_mean_scale_dictionary, get_model_name, \
     parse_tuple_pairs, check_positive, writable_dir, readable_dirs, \
@@ -38,7 +39,7 @@ class TestingMeanScaleGetter(unittest.TestCase):
             'info': np.array([2.2, 33.33, 444.444])
         }
         for el in exp_res.keys():
-            np.array_equal(result[el], exp_res[el])
+            npt.assert_array_equal(result[el], exp_res[el])
 
     def test_tuple_parser_same_values(self):
         tuple_values = "data(1.1,22.22,333.333),info[1.1,22.22,333.333]"
@@ -48,7 +49,7 @@ class TestingMeanScaleGetter(unittest.TestCase):
             'info': np.array([1.1, 22.22, 333.333])
         }
         for el in exp_res.keys():
-            np.array_equal(result[el], exp_res[el])
+            npt.assert_array_equal(result[el], exp_res[el])
 
     def test_tuple_parser_no_inputs(self):
         tuple_values = "(1.1,22.22,333.333),[2.2,33.33,444.444]"
@@ -56,7 +57,7 @@ class TestingMeanScaleGetter(unittest.TestCase):
         exp_res = [np.array([1.1, 22.22, 333.333]),
                    np.array([2.2, 33.33, 444.444])]
         for i in range(0, len(exp_res)):
-            np.array_equal(result[i], exp_res[i])
+            npt.assert_array_equal(result[i], exp_res[i])
 
     def test_tuple_parser_error(self):
         tuple_values = "(1.1,22.22,333.333),data[2.2,33.33,444.444]"
@@ -79,7 +80,7 @@ class TestingMeanScaleGetter(unittest.TestCase):
         for input in exp_res.keys():
             for key in exp_res[input].keys():
                 if type(exp_res[input][key]) is np.ndarray:
-                    np.array_equal(exp_res[input][key], result[input][key])
+                    npt.assert_array_equal(exp_res[input][key], result[input][key])
                 else:
                     self.assertEqual(exp_res[input][key], result[input][key])
 
@@ -100,7 +101,7 @@ class TestingMeanScaleGetter(unittest.TestCase):
         for input in exp_res.keys():
             for key in exp_res[input].keys():
                 if type(exp_res[input][key]) is np.ndarray:
-                    np.array_equal(exp_res[input][key], result[input][key])
+                    npt.assert_array_equal(exp_res[input][key], result[input][key])
                 else:
                     self.assertEqual(exp_res[input][key], result[input][key])
 
@@ -116,7 +117,7 @@ class TestingMeanScaleGetter(unittest.TestCase):
         for input in exp_res.keys():
             for key in exp_res[input].keys():
                 if type(exp_res[input][key]) is np.ndarray:
-                    np.array_equal(exp_res[input][key], result[input][key])
+                    npt.assert_array_equal(exp_res[input][key], result[input][key])
                 else:
                     self.assertEqual(exp_res[input][key], result[input][key])
 
@@ -132,7 +133,7 @@ class TestingMeanScaleGetter(unittest.TestCase):
         for input in exp_res.keys():
             for key in exp_res[input].keys():
                 if type(exp_res[input][key]) is np.ndarray:
-                    np.array_equal(exp_res[input][key], result[input][key])
+                    npt.assert_array_equal(exp_res[input][key], result[input][key])
                 else:
                     self.assertEqual(exp_res[input][key], result[input][key])
 
@@ -151,7 +152,7 @@ class TestingMeanScaleGetter(unittest.TestCase):
         for i in range(len(exp_res)):
             for j in range(len(exp_res[i])):
                 if type(exp_res[i][j]) is np.ndarray:
-                    np.array_equal(exp_res[i][j], result[i][j])
+                    npt.assert_array_equal(exp_res[i][j], result[i][j])
                 else:
                     self.assertEqual(exp_res[i][j], result[i][j])
 
@@ -170,7 +171,7 @@ class TestingMeanScaleGetter(unittest.TestCase):
         for input in exp_res.keys():
             for key in exp_res[input].keys():
                 if type(exp_res[input][key]) is np.ndarray:
-                    np.array_equal(exp_res[input][key], result[input][key])
+                    npt.assert_array_equal(exp_res[input][key], result[input][key])
                 else:
                     self.assertEqual(exp_res[input][key], result[input][key])
 
@@ -193,7 +194,7 @@ class TestingMeanScaleGetter(unittest.TestCase):
         for input in exp_res.keys():
             for key in exp_res[input].keys():
                 if type(exp_res[input][key]) is np.ndarray:
-                    np.array_equal(exp_res[input][key], result[input][key])
+                    npt.assert_array_equal(exp_res[input][key], result[input][key])
                 else:
                     self.assertEqual(exp_res[input][key], result[input][key])
 
@@ -216,7 +217,7 @@ class TestingMeanScaleGetter(unittest.TestCase):
         for input in exp_res.keys():
             for key in exp_res[input].keys():
                 if type(exp_res[input][key]) is np.ndarray:
-                    np.array_equal(exp_res[input][key], result[input][key])
+                    npt.assert_array_equal(exp_res[input][key], result[input][key])
                 else:
                     self.assertEqual(exp_res[input][key], result[input][key])
 
@@ -235,7 +236,7 @@ class TestingMeanScaleGetter(unittest.TestCase):
         for input in exp_res.keys():
             for key in exp_res[input].keys():
                 if type(exp_res[input][key]) is np.ndarray:
-                    np.array_equal(exp_res[input][key], result[input][key])
+                    npt.assert_array_equal(exp_res[input][key], result[input][key])
                 else:
                     self.assertEqual(exp_res[input][key], result[input][key])
 
@@ -258,7 +259,7 @@ class TestingMeanScaleGetter(unittest.TestCase):
         for i in range(len(exp_res)):
             for j in range(len(exp_res[i])):
                 if type(exp_res[i][j]) is np.ndarray:
-                    np.array_equal(exp_res[i][j], result[i][j])
+                    npt.assert_array_equal(exp_res[i][j], result[i][j])
                 else:
                     self.assertEqual(exp_res[i][j], result[i][j])
 
@@ -279,7 +280,7 @@ class TestingMeanScaleGetter(unittest.TestCase):
         for input in exp_res.keys():
             for key in exp_res[input].keys():
                 if type(exp_res[input][key]) is np.ndarray:
-                    np.array_equal(exp_res[input][key], result[input][key])
+                    npt.assert_array_equal(exp_res[input][key], result[input][key])
                 else:
                     self.assertEqual(exp_res[input][key], result[input][key])
 
@@ -301,7 +302,7 @@ class TestingMeanScaleGetter(unittest.TestCase):
         for input in exp_res.keys():
             for key in exp_res[input].keys():
                 if type(exp_res[input][key]) is np.ndarray:
-                    np.array_equal(exp_res[input][key], result[input][key])
+                    npt.assert_array_equal(exp_res[input][key], result[input][key])
                 else:
                     self.assertEqual(exp_res[input][key], result[input][key])
 
@@ -323,7 +324,7 @@ class TestingMeanScaleGetter(unittest.TestCase):
         for input in exp_res.keys():
             for key in exp_res[input].keys():
                 if type(exp_res[input][key]) is np.ndarray:
-                    np.array_equal(exp_res[input][key], result[input][key])
+                    npt.assert_array_equal(exp_res[input][key], result[input][key])
                 else:
                     self.assertEqual(exp_res[input][key], result[input][key])
 
@@ -343,7 +344,7 @@ class TestingMeanScaleGetter(unittest.TestCase):
         ]
         for i in range(0, len(exp_res)):
             for j in range(0, len(exp_res[i])):
-                np.array_equal(exp_res[i][j], result[i][j])
+                npt.assert_array_equal(exp_res[i][j], result[i][j])
 
     def test_scale_do_not_match_input(self):
         scale_values = parse_tuple_pairs("input_not_present(255),input2(255)")
@@ -358,13 +359,13 @@ class TestingMeanScaleGetter(unittest.TestCase):
     def test_values_match_input_name(self):
         # before fix cli_parser was confused when input had a substring that matches scale/mean values
         res_values = parse_tuple_pairs("input255(255),input255.0(255.0),multi-dotted.input.3.(255,128,64)")
-        exp_res = {'input255': np.array([255.0, 254.]),
+        exp_res = {'input255': np.array([255.0]),
                    'input255.0': np.array([255.0]),
-                   'multi-dotted.input.3.': np.array([255., 128., 128.])}
+                   'multi-dotted.input.3.': np.array([255., 128., 64.])}
         self.assertEqual(len(exp_res), len(res_values))
         for i, j in zip(exp_res, res_values):
             self.assertEqual(i, j)
-            np.array_equal(exp_res[i], res_values[j])
+            npt.assert_array_equal(exp_res[i], res_values[j])
 
     def test_input_without_values(self):
         self.assertRaises(Error, parse_tuple_pairs, "input1,input2")
@@ -439,7 +440,7 @@ class TestShapesParsing(unittest.TestCase):
         exp_res = {'inp1': np.array([1, 22, 333, 123]), 'inp2': np.array([-1, 45, 7, 1])}
         self.assertEqual(list(exp_res.keys()), list(result.keys()))
         for i in exp_res.keys():
-            np.testing.assert_array_equal(result[i], exp_res[i])
+            npt.assert_array_equal(result[i], exp_res[i])
 
     def test_get_shapes_several_inputs_several_shapes2(self):
         # shapes specified using --input command line parameter and no values
@@ -448,13 +449,13 @@ class TestShapesParsing(unittest.TestCase):
         exp_res = {'inp1': np.array([1, 22, 333, 123]), 'inp2': np.array([-1, 45, 7, 1])}
         self.assertEqual(list(exp_res.keys()), list(result.keys()))
         for i in exp_res.keys():
-            np.testing.assert_array_equal(result[i], exp_res[i])
+            npt.assert_array_equal(result[i], exp_res[i])
         placeholder_values_res, input_node_names_res = get_freeze_placeholder_values(argv_input, None)
         placeholder_values_ref = {}
         input_node_names_ref = "inp1,inp2"
         self.assertEqual(list(placeholder_values_res.keys()), list(placeholder_values_ref.keys()))
         for i in placeholder_values_ref.keys():
-            np.testing.assert_array_equal(placeholder_values_res[i], placeholder_values_ref[i])
+            npt.assert_array_equal(placeholder_values_res[i], placeholder_values_ref[i])
 
     def test_get_shapes_several_inputs_several_shapes3(self):
         # shapes and value for freezing specified using --input command line parameter
@@ -463,13 +464,13 @@ class TestShapesParsing(unittest.TestCase):
         exp_res = {'inp1': np.array([3, 1]), 'inp2': np.array([3, 2, 3]), 'inp3': np.array([5])}
         self.assertEqual(list(exp_res.keys()), list(result.keys()))
         for i in exp_res.keys():
-            np.testing.assert_array_equal(result[i], exp_res[i])
+            npt.assert_array_equal(result[i], exp_res[i])
         placeholder_values_res, input_node_names_res = get_freeze_placeholder_values(argv_input, None)
         placeholder_values_ref = {'inp1': np.array(['1.0', '2.0', '3.0']), 'inp3': np.array(['1.0', '1.0', '2.0', '3.0', '5.0'])}
         input_node_names_ref = "inp1,inp2,inp3"
         self.assertEqual(list(placeholder_values_res.keys()), list(placeholder_values_ref.keys()))
         for i in placeholder_values_ref.keys():
-            np.testing.assert_array_equal(placeholder_values_res[i], placeholder_values_ref[i])
+            npt.assert_array_equal(placeholder_values_res[i], placeholder_values_ref[i])
 
     def test_get_shapes_several_inputs_several_shapes4(self):
         # shapes specified using --input_shape and values for freezing using --input command line parameter
@@ -479,13 +480,13 @@ class TestShapesParsing(unittest.TestCase):
         exp_res = {'inp1': np.array([3, 1]), 'inp2': np.array([3, 2, 3]), 'inp3': np.array([5])}
         self.assertEqual(list(exp_res.keys()), list(result.keys()))
         for i in exp_res.keys():
-            np.testing.assert_array_equal(result[i], exp_res[i])
+            npt.assert_array_equal(result[i], exp_res[i])
         placeholder_values_res, input_node_names_res = get_freeze_placeholder_values(argv_input, None)
         placeholder_values_ref = {'inp1': np.array(['1.0', '2.0', '3.0']), 'inp3': np.array(['1.0', '1.0', '2.0', '3.0', '5.0'])}
         input_node_names_ref = "inp1,inp2,inp3"
         self.assertEqual(list(placeholder_values_res.keys()), list(placeholder_values_ref.keys()))
         for i in placeholder_values_ref.keys():
-            np.testing.assert_array_equal(placeholder_values_res[i], placeholder_values_ref[i])
+            npt.assert_array_equal(placeholder_values_res[i], placeholder_values_ref[i])
         self.assertEqual(input_node_names_ref, input_node_names_res)
 
     def test_get_shapes_several_inputs_several_shapes5(self):
@@ -498,14 +499,14 @@ class TestShapesParsing(unittest.TestCase):
         exp_res = {'inp1': np.array([3, 1]), 'inp2': np.array([3, 2, 3]), 'inp3': np.array([5])}
         self.assertEqual(list(exp_res.keys()), list(result.keys()))
         for i in exp_res.keys():
-            np.testing.assert_array_equal(result[i], exp_res[i])
+            npt.assert_array_equal(result[i], exp_res[i])
         placeholder_values_res, input_node_names_res = get_freeze_placeholder_values(argv_input, argv_freeze_placeholder_with_value)
         placeholder_values_ref = {'inp1': np.array(['1.0', '2.0', '3.0']), 'inp3': np.array(['1.0', '1.0', '2.0', '3.0', '5.0'],),
                                   'inp2': np.array(['5.0', '7.0', '3.0']), 'inp4': np.array(['100.0', '200.0'])}
         input_node_names_ref = "inp1,inp2,inp3"
         self.assertEqual(sorted(list(placeholder_values_res.keys())), sorted(list(placeholder_values_ref.keys())))
         for i in placeholder_values_ref.keys():
-            np.testing.assert_array_equal(placeholder_values_res[i], placeholder_values_ref[i])
+            npt.assert_array_equal(placeholder_values_res[i], placeholder_values_ref[i])
         self.assertEqual(input_node_names_ref, input_node_names_res)
 
     def test_get_shapes_several_inputs_several_shapes6(self):
@@ -515,12 +516,12 @@ class TestShapesParsing(unittest.TestCase):
         exp_res = {'inp1': np.array([3, 1]), 'inp2': np.array([3, 2, 3]), 'inp3': np.array(False).shape}
         self.assertEqual(list(exp_res.keys()), list(result.keys()))
         for i in exp_res.keys():
-            np.testing.assert_array_equal(result[i], exp_res[i])
+            npt.assert_array_equal(result[i], exp_res[i])
         placeholder_values_res, input_node_names_res = get_freeze_placeholder_values(argv_input, None)
         placeholder_values_ref = {'inp1': np.array(['1.0', '2.0', '3.0']), 'inp3': False}
         self.assertEqual(list(placeholder_values_res.keys()), list(placeholder_values_ref.keys()))
         for i in placeholder_values_ref.keys():
-            np.testing.assert_array_equal(placeholder_values_res[i], placeholder_values_ref[i])
+            npt.assert_array_equal(placeholder_values_res[i], placeholder_values_ref[i])
 
     def test_get_shapes_several_inputs_several_shapes7(self):
         # 0D shape and value for freezing specified using --input command line parameter
@@ -529,12 +530,12 @@ class TestShapesParsing(unittest.TestCase):
         exp_res = {'inp1': np.array([3, 1]), 'inp2': np.array([3, 2, 3]), 'inp3': np.array(False).shape}
         self.assertEqual(list(exp_res.keys()), list(result.keys()))
         for i in exp_res.keys():
-            np.testing.assert_array_equal(result[i], exp_res[i])
+            npt.assert_array_equal(result[i], exp_res[i])
         placeholder_values_res, input_node_names_res = get_freeze_placeholder_values(argv_input, None)
         placeholder_values_ref = {'inp1': np.array(['1.0', '2.0', '3.0']), 'inp3': True}
         self.assertEqual(list(placeholder_values_res.keys()), list(placeholder_values_ref.keys()))
         for i in placeholder_values_ref.keys():
-            np.testing.assert_array_equal(placeholder_values_res[i], placeholder_values_ref[i])
+            npt.assert_array_equal(placeholder_values_res[i], placeholder_values_ref[i])
 
     def test_get_shapes_and_data_types1(self):
         argv_input = "inp1[3 1]->[1.0 2.0 3.0],inp2[3 2 3]{i32},inp3[5]{f32}->[1.0 1.0 2.0 3.0 5.0]"
@@ -543,7 +544,7 @@ class TestShapesParsing(unittest.TestCase):
         ref_result_data_types = {'inp2': np.int32, 'inp3': np.float32}
         self.assertEqual(list(ref_result_shapes.keys()), list(result_shapes.keys()))
         for i in ref_result_shapes.keys():
-            np.testing.assert_array_equal(result_shapes[i], ref_result_shapes[i])
+            npt.assert_array_equal(result_shapes[i], ref_result_shapes[i])
         self.assertEqual(list(ref_result_data_types.keys()), list(result_data_types.keys()))
         for i in ref_result_data_types.keys():
             np.testing.assert_equal(result_data_types[i], ref_result_data_types[i])
@@ -555,7 +556,7 @@ class TestShapesParsing(unittest.TestCase):
         ref_result_data_types = {'inp2': np.int32, '0:inp3': np.float32}
         self.assertEqual(list(ref_result_shapes.keys()), list(result_shapes.keys()))
         for i in ref_result_shapes.keys():
-            np.testing.assert_array_equal(result_shapes[i], ref_result_shapes[i])
+            npt.assert_array_equal(result_shapes[i], ref_result_shapes[i])
         self.assertEqual(list(ref_result_data_types.keys()), list(result_data_types.keys()))
         for i in ref_result_data_types.keys():
             np.testing.assert_equal(result_data_types[i], ref_result_data_types[i])
@@ -567,7 +568,7 @@ class TestShapesParsing(unittest.TestCase):
         ref_result_data_types = {'inp2': np.int32, 'inp3:4': np.float32}
         self.assertEqual(list(ref_result_shapes.keys()), list(result_shapes.keys()))
         for i in ref_result_shapes.keys():
-            np.testing.assert_array_equal(result_shapes[i], ref_result_shapes[i])
+            npt.assert_array_equal(result_shapes[i], ref_result_shapes[i])
         self.assertEqual(list(ref_result_data_types.keys()), list(result_data_types.keys()))
         for i in ref_result_data_types.keys():
             np.testing.assert_equal(result_data_types[i], ref_result_data_types[i])
@@ -580,7 +581,7 @@ class TestShapesParsing(unittest.TestCase):
         ref_result_data_types = {}
         self.assertEqual(list(ref_result_shapes.keys()), list(result_shapes.keys()))
         for i in ref_result_shapes.keys():
-            np.testing.assert_array_equal(result_shapes[i], ref_result_shapes[i])
+            npt.assert_array_equal(result_shapes[i], ref_result_shapes[i])
         self.assertEqual(list(ref_result_data_types.keys()), list(result_data_types.keys()))
         for i in ref_result_data_types.keys():
             np.testing.assert_equal(result_data_types[i], ref_result_data_types[i])
@@ -593,7 +594,7 @@ class TestShapesParsing(unittest.TestCase):
         ref_result_data_types = {}
         self.assertEqual(list(ref_result_shapes.keys()), list(result_shapes.keys()))
         for i in ref_result_shapes.keys():
-            np.testing.assert_array_equal(result_shapes[i], ref_result_shapes[i])
+            npt.assert_array_equal(result_shapes[i], ref_result_shapes[i])
         self.assertEqual(list(ref_result_data_types.keys()), list(result_data_types.keys()))
         for i in ref_result_data_types.keys():
             np.testing.assert_equal(result_data_types[i], ref_result_data_types[i])
@@ -606,7 +607,7 @@ class TestShapesParsing(unittest.TestCase):
         ref_result_data_types = {'placeholder1': np.int32, 'placeholder3': np.int32}
         self.assertEqual(list(ref_result_shapes.keys()), list(result_shapes.keys()))
         for i in ref_result_shapes.keys():
-            np.testing.assert_array_equal(result_shapes[i], ref_result_shapes[i])
+            npt.assert_array_equal(result_shapes[i], ref_result_shapes[i])
         self.assertEqual(list(ref_result_data_types.keys()), list(result_data_types.keys()))
         for i in ref_result_data_types.keys():
             np.testing.assert_equal(result_data_types[i], ref_result_data_types[i])
@@ -655,28 +656,28 @@ class TestShapesParsing(unittest.TestCase):
         exp_res = {'inp1': np.array([1, 22, 333, 123])}
         self.assertEqual(list(exp_res.keys()), list(result.keys()))
         for i in exp_res.keys():
-            np.testing.assert_array_equal(result[i], exp_res[i])
+            npt.assert_array_equal(result[i], exp_res[i])
 
     def test_get_shapes_no_input_no_shape(self):
         argv_input = ""
         input_shapes = ""
         result, _ = get_placeholder_shapes(argv_input, input_shapes)
         exp_res = np.array([None])
-        np.testing.assert_array_equal(result, exp_res)
+        npt.assert_array_equal(result, exp_res)
 
     def test_get_shapes_no_input_one_shape(self):
         argv_input = ""
         input_shapes = "(12,4,1)"
         result, _ = get_placeholder_shapes(argv_input, input_shapes)
         exp_res = np.array([12, 4, 1])
-        np.testing.assert_array_equal(result, exp_res)
+        npt.assert_array_equal(result, exp_res)
 
     def test_get_shapes_no_input_one_shape2(self):
         argv_input = ""
         input_shapes = "[12,4,1]"
         result, _ = get_placeholder_shapes(argv_input, input_shapes)
         exp_res = np.array([12, 4, 1])
-        np.testing.assert_array_equal(result, exp_res)
+        npt.assert_array_equal(result, exp_res)
 
     def test_get_shapes_no_input_two_shapes(self):
         argv_input = ""
@@ -690,7 +691,7 @@ class TestShapesParsing(unittest.TestCase):
         exp_res = {'inp1': np.array([None])}
         self.assertEqual(list(exp_res.keys()), list(result.keys()))
         for i in exp_res.keys():
-            np.testing.assert_array_equal(result[i], exp_res[i])
+            npt.assert_array_equal(result[i], exp_res[i])
 
     def test_get_shapes_one_input_wrong_shape8(self):
         argv_input = "inp1"
@@ -749,7 +750,7 @@ class TestShapesParsing(unittest.TestCase):
         exp_res = {'inp1': np.array([-1, 4, 1]), 'inp2': np.array([4, 6, 8])}
         self.assertEqual(list(exp_res.keys()), list(result.keys()))
         for i in exp_res.keys():
-            np.testing.assert_array_equal(result[i], exp_res[i])
+            npt.assert_array_equal(result[i], exp_res[i])
 
     def test_get_shapes_one_input_first_neg_shape_not_one(self):
         argv_input = "inp1"

--- a/model-optimizer/mo/utils/cli_parser_test.py
+++ b/model-optimizer/mo/utils/cli_parser_test.py
@@ -357,9 +357,14 @@ class TestingMeanScaleGetter(unittest.TestCase):
 
     def test_values_match_input_name(self):
         # before fix cli_parser was confused when input had a substring that matches scale/mean values
-        values = parse_tuple_pairs("input255(255),input255.0(255.0)")
-        exp_res = {'input255': 255.0, 'input255.0': 255.0}
-        self.assertEqual(exp_res, values)
+        res_values = parse_tuple_pairs("input255(255),input255.0(255.0),multi-dotted.input.3.(255,128,64)")
+        exp_res = {'input255': np.array([255.0, 254.]),
+                   'input255.0': np.array([255.0]),
+                   'multi-dotted.input.3.': np.array([255., 128., 128.])}
+        self.assertEqual(len(exp_res), len(res_values))
+        for i, j in zip(exp_res, res_values):
+            self.assertEqual(i, j)
+            np.array_equal(exp_res[i], res_values[j])
 
     def test_input_without_values(self):
         self.assertRaises(Error, parse_tuple_pairs, "input1,input2")

--- a/model-optimizer/mo/utils/cli_parser_test.py
+++ b/model-optimizer/mo/utils/cli_parser_test.py
@@ -355,6 +355,15 @@ class TestingMeanScaleGetter(unittest.TestCase):
         mean_values = parse_tuple_pairs("input_not_present(255),input2(255)")
         self.assertRaises(Error, get_mean_scale_dictionary, mean_values, scale_values, "input1,input2")
 
+    def test_values_match_input_name(self):
+        # before fix cli_parser was confused when input had a substring that matches scale/mean values
+        values = parse_tuple_pairs("input255(255),input255.0(255.0)")
+        exp_res = {'input255': 255.0, 'input255.0': 255.0}
+        self.assertEqual(exp_res, values)
+
+    def test_input_without_values(self):
+        self.assertRaises(Error, parse_tuple_pairs, "input1,input2")
+
 class TestSingleTupleParsing(unittest.TestCase):
     def test_get_values_ideal(self):
         values = "(1.11, 22.22, 333.333)"


### PR DESCRIPTION
Description:  When input contained substring that matches scale/mean values e.g. 

> --scale_values data.70[127.5],data.**1**[**1**],

cli_parses incorrectly handles that case. This PR fixes this issue.

ticket #42774

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR: N/A -- no new transformations were added
* [x]  Transformation preserves original framework node names: N/A -- because no transformation were added

Validation:
* [x]  Unit tests:
* [x]  Framework operation tests: N/A -- no new operations were added
* [x]  Transformation tests: N/A -- no new transformations were added
* [x]  e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py: N/A
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list: N/A
* [x]  Supported **public** models list: N/A
* [x]  New operations specification: N/A
* [x]  Guide on how to convert the **public** model: N/A
* [x]  User guide update: N/A