### PR TITLE
Added EXCLUDE_FROM_ALL for static versions of plugins

### DIFF
--- a/inference-engine/src/gna_plugin/CMakeLists.txt
+++ b/inference-engine/src/gna_plugin/CMakeLists.txt
@@ -64,7 +64,8 @@ target_include_directories(${TARGET_NAME}_test_static PUBLIC ${CMAKE_CURRENT_SOU
 set_target_properties(${TARGET_NAME}_test_static PROPERTIES COMPILE_PDB_NAME ${TARGET_NAME}_test_static)
 
 set_target_properties(${TARGET_NAME} ${TARGET_NAME}_test_static
-                      PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE ${ENABLE_LTO})
+                      PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE ${ENABLE_LTO}
+                                 EXCLUDE_FROM_ALL ON)
 
 # install
 

--- a/inference-engine/src/inference_engine/CMakeLists.txt
+++ b/inference-engine/src/inference_engine/CMakeLists.txt
@@ -176,6 +176,8 @@ target_link_libraries(${TARGET_NAME}_s PRIVATE openvino::itt ${CMAKE_DL_LIBS} ${
 
 target_compile_definitions(${TARGET_NAME}_s PUBLIC USE_STATIC_IE)
 
+set_target_properties(${TARGET_NAME}_s PROPERTIES EXCLUDE_FROM_ALL ON)
+
 # LTO
 
 set_target_properties(${TARGET_NAME} ${TARGET_NAME}_obj ${TARGET_NAME}_s

--- a/inference-engine/src/mkldnn_plugin/CMakeLists.txt
+++ b/inference-engine/src/mkldnn_plugin/CMakeLists.txt
@@ -207,6 +207,8 @@ set_ie_threading_interface_for(${TARGET_NAME}_obj)
 target_compile_definitions(${TARGET_NAME}_obj PUBLIC -DMKLDNN_THR=${MKLDNN_THR}
                                               PRIVATE USE_STATIC_IE IMPLEMENT_INFERENCE_ENGINE_PLUGIN)
 
+set_target_properties(${TARGET_NAME}_obj PROPERTIES EXCLUDE_FROM_ALL ON)
+
 # LTO
 
 set_target_properties(${TARGET_NAME} ${TARGET_NAME}_obj

--- a/inference-engine/src/preprocessing/CMakeLists.txt
+++ b/inference-engine/src/preprocessing/CMakeLists.txt
@@ -169,6 +169,8 @@ target_link_libraries(${TARGET_NAME}_s PRIVATE fluid openvino::itt
 
 target_compile_definitions(${TARGET_NAME}_s INTERFACE USE_STATIC_IE)
 
+set_target_properties(${TARGET_NAME}_s PROPERTIES EXCLUDE_FROM_ALL ON)
+
 # LTO
 
 set_target_properties(${TARGET_NAME} ${TARGET_NAME}_obj ${TARGET_NAME}_s

--- a/inference-engine/src/vpu/common/CMakeLists.txt
+++ b/inference-engine/src/vpu/common/CMakeLists.txt
@@ -26,6 +26,7 @@ function(add_common_target TARGET_NAME STATIC_IE)
         target_compile_definitions(${TARGET_NAME}
             PUBLIC
                 USE_STATIC_IE)
+        set_target_properties(${TARGET_NAME} PROPERTIES EXCLUDE_FROM_ALL ON)
     endif()
     target_compile_definitions(${TARGET_NAME} PRIVATE IMPLEMENT_INFERENCE_ENGINE_PLUGIN)
 

--- a/inference-engine/src/vpu/graph_transformer/CMakeLists.txt
+++ b/inference-engine/src/vpu/graph_transformer/CMakeLists.txt
@@ -22,6 +22,7 @@ function(add_graph_transformer_target TARGET_NAME STATIC_IE)
         target_compile_definitions(${TARGET_NAME}
             PUBLIC
                 USE_STATIC_IE)
+        set_target_properties(${TARGET_NAME} PROPERTIES EXCLUDE_FROM_ALL ON)
     endif()
     target_compile_definitions(${TARGET_NAME} PRIVATE IMPLEMENT_INFERENCE_ENGINE_PLUGIN)
 

--- a/ngraph/test/runtime/CMakeLists.txt
+++ b/ngraph/test/runtime/CMakeLists.txt
@@ -73,7 +73,7 @@ target_link_libraries(ngraph_backend PUBLIC ngraph
                                             ngraph::builder
                                             ngraph::reference)
 if (NOT WIN32)
-    target_link_libraries(ngraph_backend PRIVATE dl)
+    target_link_libraries(ngraph_backend PRIVATE ${CMAKE_DL_LIBS})
 endif()
 target_compile_definitions(ngraph_backend PRIVATE BACKEND_DLL_EXPORTS)
 target_include_directories(ngraph_backend PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
This is needed to minimize a number of targets to build when we build with `-DENABLE_TESTS=OFF`. In opposite case static versions of plugins are built, but not used.

This mode is used when we build OpenVINO contrib