### PR TITLE
Bump minimal numpy version required for Model Optimizer

### DIFF
--- a/model-optimizer/requirements.txt
+++ b/model-optimizer/requirements.txt
@@ -2,7 +2,7 @@ tensorflow>=1.15.2,<2.0; python_version < "3.8"
 tensorflow>=2.0; python_version >= "3.8"
 mxnet>=1.0.0,<=1.5.1
 networkx>=1.11
-numpy>=1.14.0,<1.19.0
+numpy>=1.18.5,<1.19.0
 protobuf>=3.6.1
 onnx>=1.1.2
 test-generator==0.1.1

--- a/model-optimizer/requirements_kaldi.txt
+++ b/model-optimizer/requirements_kaldi.txt
@@ -1,4 +1,4 @@
 networkx>=1.11
-numpy>=1.14.0
+numpy>=1.18.5
 test-generator==0.1.1
 defusedxml>=0.5.0

--- a/model-optimizer/requirements_onnx.txt
+++ b/model-optimizer/requirements_onnx.txt
@@ -1,5 +1,5 @@
 onnx>=1.1.2
 networkx>=1.11
-numpy>=1.14.0
+numpy>=1.18.5
 test-generator==0.1.1
 defusedxml>=0.5.0

--- a/model-optimizer/requirements_tf.txt
+++ b/model-optimizer/requirements_tf.txt
@@ -1,6 +1,6 @@
 tensorflow>=1.15.2,<2.0; python_version < "3.8"
 tensorflow>=2.0; python_version >= "3.8"
 networkx>=1.11
-numpy>=1.14.0,<1.19.0
+numpy>=1.18.5,<1.19.0
 test-generator==0.1.1
 defusedxml>=0.5.0


### PR DESCRIPTION
Unit tests fail with the following log when ran on numpy==1.17.0:
```
mo_ut INFO: ======================================================================
mo_ut INFO: ERROR [0.002s]: test_broadcast[([1], [1, 2], [0], 'explicit', [[1, 1]])] (mo.ops.broadcast_test.BroadcastTest)
mo_ut INFO: ----------------------------------------------------------------------
mo_ut INFO: Traceback (most recent call last):
mo_ut INFO:   File "/home/user/test_venv/lib/python3.6/site-packages/generator/__init__.py", line 19, in wrapper_func
mo_ut INFO:     return func(test_case, *arg)
mo_ut INFO:   File "/home/jenkins/agent/workspace/mo-unit-tests/b/dldt/deployment_tools/model-optimizer/mo/ops/broadcast_test.py", line 87, in test_broadcast
mo_ut INFO:     Broadcast.infer(broadcast_node)
mo_ut INFO:   File "/home/jenkins/agent/workspace/mo-unit-tests/b/dldt/deployment_tools/model-optimizer/mo/ops/broadcast.py", line 78, in infer
mo_ut INFO:     node.out_port(0).data.set_value(explicit_broadcasting(input_value, target_shape, axes_mapping))
mo_ut INFO:   File "/home/jenkins/agent/workspace/mo-unit-tests/b/dldt/deployment_tools/model-optimizer/mo/utils/broadcasting.py", line 139, in explicit_broadcasting
mo_ut INFO:     input_expanded = np.expand_dims(input_value.copy(), axis=list(expand_dim_axis))
mo_ut INFO:   File "<__array_function__ internals>", line 6, in expand_dims
mo_ut INFO:   File "/home/user/test_venv/lib/python3.6/site-packages/numpy/lib/shape_base.py", line 577, in expand_dims
mo_ut INFO:     if axis > a.ndim or axis < -a.ndim - 1:
mo_ut INFO: TypeError: '>' not supported between instances of 'list' and 'int'
```

But they pass on numpy==1.18.5