### PR TITLE
Fix accuracy problem for YoloV3 (incorrect StridedSlice nop elimination)

### DIFF
--- a/inference-engine/src/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/inference-engine/src/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -330,7 +330,6 @@ bool pass::NopElimination::run_on_function(std::shared_ptr<Function> function) {
     static const std::unordered_map<NodeTypeInfo, std::function<bool(const std::shared_ptr<Node>&)>>
         dispatcher{{TI(opset3::Pad), &eliminate_nop},
                    {TI(opset3::Convert), &eliminate_convert},
-                   {TI(op::v1::StridedSlice), &eliminate_nop},
                    {TI(opset3::Reshape), &eliminate_reshape_v1},
                    {TI(opset3::Concat), &eliminate_concat},
                    {TI(opset3::Squeeze), &eliminate_squeeze},

--- a/inference-engine/tests/functional/inference_engine/transformations/nop_elimination.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/nop_elimination.cpp
@@ -57,22 +57,6 @@ TEST(nop_elimination, convert_type_agnostic) {
     ASSERT_EQ(count_ops_of_type<op::v0::Convert>(f), 0);
 }
 
-TEST(nop_elimination, eliminate_strided_slice) {
-    Shape shape{2, 2};
-    auto A = make_shared<op::Parameter>(element::f32, shape);
-    auto begin_node = op::Constant::create(element::i64, {2}, {0, 0});
-    auto end_node = op::Constant::create(element::i64, {2}, {2, 2});
-    std::vector<int64_t> mask(2, 0);
-    auto s = make_shared<op::v1::StridedSlice>(A, begin_node, end_node, mask, mask);
-    auto f = make_shared<Function>(make_shared<op::v0::Abs>(s), ParameterVector{A});
-
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::NopElimination>();
-    pass_manager.run_passes(f);
-
-    ASSERT_EQ(count_ops_of_type<op::v1::StridedSlice>(f), 0);
-}
-
 TEST(nop_elimination, eliminate_broadcast) {
     Shape shape{1};
     auto A = make_shared<op::Parameter>(element::f32, shape);

--- a/ngraph/python/tests/__init__.py
+++ b/ngraph/python/tests/__init__.py
@@ -232,6 +232,6 @@ xfail_issue_39661 = xfail_test(reason="RuntimeError: NonMaxSuppression operation
 xfail_issue_39662 = xfail_test(reason="RuntimeError: 'ScatterElementsUpdate' layer with name 'y' have "
                                       "indices value that points to non-existing output tensor element")
 xfail_issue_39663 = xfail_test(reason="RuntimeError: Unsupported primitive of type: ROIAlign name: Y")
-xfail_issue_41815 = xfail_test(reason="RuntimeError: Unsupported dynamic ops: v5::NonMaxSuppression casted "
-                                      "(yolo_evaluation_layer_1/concat_6:0_btc[0]:f32{1,2535,4},")
+xfail_issue_43380 = xfail_test(reason="RuntimeError: Sorting not possible, due to existed loop")
+xfail_issue_43382 = xfail_test(reason="Testing models which have upper bound output shape is not supported")
 xfail_issue_41894 = xfail_test(reason="CPU plugin elementwise computation missmatch")

--- a/ngraph/python/tests/test_onnx/test_zoo_models.py
+++ b/ngraph/python/tests/test_onnx/test_zoo_models.py
@@ -26,7 +26,8 @@ from tests.test_onnx.utils.model_importer import ModelImportRunner
 from tests import (
     xfail_issue_38701,
     xfail_issue_42297,
-    xfail_issue_41815,
+    xfail_issue_43380,
+    xfail_issue_43382,
     xfail_issue_41814,
     xfail_issue_36533,
     xfail_issue_39684,
@@ -98,6 +99,7 @@ tolerance_map = {
     "test_tiny_yolov2": {"atol": 1e-05, "rtol": 0.001},
     "test_resnet152v2": {"atol": 1e-04, "rtol": 0.001},
     "test_mobilenetv2-1": {"atol": 1e-04, "rtol": 0.001},
+    "yolov3": {"atol": 0.001, "rtol": 0.001}
 }
 
 zoo_models = []
@@ -159,8 +161,8 @@ if len(zoo_models) > 0:
             (xfail_issue_38084, "test_onnx_model_zoo_vision_object_detection_segmentation_mask_rcnn_model_MaskRCNN_10_mask_rcnn_R_50_FPN_1x_cpu"),
             (xfail_issue_42779, "test_onnx_model_zoo_vision_object_detection_segmentation_ssd_model_ssd_10_model_cpu"),
             (xfail_issue_38084, "test_onnx_model_zoo_vision_object_detection_segmentation_faster_rcnn_model_FasterRCNN_10_faster_rcnn_R_50_FPN_1x_cpu"),
-            (xfail_issue_41815, "test_onnx_model_zoo_vision_object_detection_segmentation_yolov3_model_yolov3_10_yolov3_yolov3_cpu"),
-            (xfail_issue_41815, "test_onnx_model_zoo_vision_object_detection_segmentation_tiny_yolov3_model_tiny_yolov3_11_yolov3_tiny_cpu"),
+            (xfail_issue_43382, "test_onnx_model_zoo_vision_object_detection_segmentation_yolov3_model_yolov3_10_yolov3_yolov3_cpu"),
+            (xfail_issue_43380, "test_onnx_model_zoo_vision_object_detection_segmentation_tiny_yolov3_model_tiny_yolov3_11_yolov3_tiny_cpu"),
 
             # Model MSFT
             (xfail_issue_36533, "test_MSFT_opset7_tf_inception_v2_model_cpu"),
@@ -178,8 +180,8 @@ if len(zoo_models) > 0:
             (xfail_issue_39669, "test_MSFT_opset9_cgan_cgan_cpu"),
             (xfail_issue_40957, "test_MSFT_opset10_BERT_Squad_bertsquad10_cpu"),
 
-            (xfail_issue_41815, "test_MSFT_opset11_tinyyolov3_yolov3_tiny_cpu"),
-            (xfail_issue_41815, "test_MSFT_opset10_yolov3_yolov3_cpu"),
+            (xfail_issue_43380, "test_MSFT_opset11_tinyyolov3_yolov3_tiny_cpu"),
+            (xfail_issue_43382, "test_MSFT_opset10_yolov3_yolov3_cpu"),
 
         ]
         for test_case in import_xfail_list + execution_xfail_list:

--- a/ngraph/test/models/onnx/dynamic_shapes/slice_2d_the_same_out_shape.prototxt
+++ b/ngraph/test/models/onnx/dynamic_shapes/slice_2d_the_same_out_shape.prototxt
@@ -1,0 +1,87 @@
+ir_version: 10
+producer_name: "nGraph ONNX Importer"
+graph {
+  name: "test_slice"
+  node {
+    input: "A"
+    input: "B"
+    output: "div_out"
+    op_type: "Div"
+  }
+  node {
+    input: "div_out"
+    input: "starts"
+    input: "ends"
+    input: "axes"
+    input: "steps"
+    output: "sliced"
+    name: "Slice"
+    op_type: "Slice"
+  }
+  initializer {
+    data_type: 7
+    dims: 1
+    int64_data: -1
+    name: "starts"
+  }
+  initializer {
+    data_type: 7
+    dims: 1
+    int64_data: -9223372036854775807
+    name: "ends"
+  }
+  initializer {
+    data_type: 7
+    dims: 2
+    int64_data: 1
+    name: "axes"
+  }
+  initializer {
+    data_type: 7
+    dims: 1
+    int64_data: -1
+    name: "steps"
+  }
+  input {
+    name: "A"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value:3
+          }
+          dim {
+            dim_value:2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "B"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value:2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "sliced"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 10
+}

--- a/ngraph/test/onnx/onnx_import_dyn_shapes.in.cpp
+++ b/ngraph/test/onnx/onnx_import_dyn_shapes.in.cpp
@@ -1059,6 +1059,18 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_10_default_axes)
     test_case.add_expected_output<float>(Shape{1, 1, 1}, {9});
 }
 
+NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_10_the_same_output_same)
+{
+    auto function = onnx_import::import_onnx_model(file_util::path_join(
+        SERIALIZED_ZOO, "onnx/dynamic_shapes/slice_2d_the_same_out_shape.prototxt"));
+
+    auto test_case = test::TestCase<TestEngine, TestCaseType::DYNAMIC>(function);
+    test_case.add_input<float>(std::vector<float>{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f});
+    test_case.add_input<float>(std::vector<float>{1.0f, 1.0f});
+    test_case.add_expected_output<float>(Shape{3, 2}, {2.0f, 1.0f, 4.0f, 3.0f, 6.0f, 5.0f});
+    test_case.run();
+}
+
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_model_hardmax)
 {
     auto function = onnx_import::import_onnx_model(


### PR DESCRIPTION
The problematic case was `StridedSlice` with the same output and input shape, but `steps = -1` which was removed from a graph.

For example when we have:
```
import numpy as np
a = np.array([1,2,3,4,5,6]).reshape(2, 3)
print(a[:, -1:-999999999:-1])
```
Output shape was not changed but data reorganized.

The transformation can be removed from `NopElimination`, because the same thing (but in a proper way) is done during `StridedSliceOptimization` optimization (https://github.com/openvinotoolkit/openvino/blob/master/inference-engine/src/transformations/src/transformations/common_optimizations/optimize_strided_slice.cpp#L17).
 