### PR TITLE
[IE CLDNN] Fix handling of fsv4 input padding in mmad bfyx to fsv32 convolution kernel

### DIFF
--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/convolution_gpu_mmad_bfyx_to_b_fs_yx_fsv32.cl
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/convolution_gpu_mmad_bfyx_to_b_fs_yx_fsv32.cl
@@ -185,7 +185,9 @@ KERNEL(convolution_mmad_bfyx_to_b_fs_yx_fsv32)(
                         }
                         slm_block[c + lid] = AS_PACKED_IN_TYPE(src);
                     #elif INPUT0_LAYOUT_B_FS_YX_FSV4
-                        const __global uint* ptr = input + input_offset + kh * DILATION_SIZE_Y * input_y_pitch + (x_chunk + lid) * input_x_pitch;
+                        const __global uint* ptr = input + input_offset
+                                                   + (kh * DILATION_SIZE_Y + INPUT0_PAD_BEFORE_SIZE_Y) * input_y_pitch
+                                                   + (x_chunk + lid + INPUT0_PAD_BEFORE_SIZE_X) * input_x_pitch;
                         PACKED_IN_TYPE src = AS_PACKED_IN_TYPE(ptr[0]);
                         slm_block[c + lid] = src;
                     #endif
@@ -214,7 +216,9 @@ KERNEL(convolution_mmad_bfyx_to_b_fs_yx_fsv32)(
                         }
                         slm_block_tail[lid] = AS_PACKED_IN_TYPE(src);
                     #elif INPUT0_LAYOUT_B_FS_YX_FSV4
-                        const __global uint* ptr = input + input_offset + kh * DILATION_SIZE_Y * input_y_pitch + (x_chunk + lid) * input_x_pitch;
+                        const __global uint* ptr = input + input_offset
+                                                   + (kh * DILATION_SIZE_Y + INPUT0_PAD_BEFORE_SIZE_Y) * input_y_pitch
+                                                   + (x_chunk + lid + INPUT0_PAD_BEFORE_SIZE_X) * input_x_pitch;
                         PACKED_IN_TYPE src = AS_PACKED_IN_TYPE(ptr[0]);
                         slm_block_tail[lid] = src;
                     #endif


### PR DESCRIPTION
Current tests didn't catch it because of the issue explained in #3014.