### PR TITLE
Backport of PR #3092 - TopK sorting fix

### DIFF
--- a/docs/ops/sort/TopK_1.md
+++ b/docs/ops/sort/TopK_1.md
@@ -10,7 +10,7 @@
 
 * *axis*
 
-  * **Description**: Specifies the axis along which 
+  * **Description**: Specifies the axis along which the values are retrieved.
   * **Range of values**: An integer. Negative value means counting dimension from the end.
   * **Type**: `int`
   * **Default value**: None
@@ -50,7 +50,15 @@ Output tensor is populated by values computes in the following way:
 
     output[i1, ..., i(axis-1), j, i(axis+1) ..., iN] = top_k(input[i1, ...., i(axis-1), :, i(axis+1), ..., iN]), k, sort, mode)
 
-So for each slice `input[i1, ...., i(axis-1), :, i(axis+1), ..., iN]` which represents 1D array, top_k value is computed individually. Sorting and minimum/maximum are controlled by `sort` and `mode` attributes.
+So for each slice `input[i1, ...., i(axis-1), :, i(axis+1), ..., iN]` which represents 1D array, top_k value is computed individually.
+
+Sorting and minimum/maximum are controlled by `sort` and `mode` attributes:
+  * *mode*=`max`, *sort*=`value` - descending by value
+  * *mode*=`max`, *sort*=`index` - ascending by index
+  * *mode*=`max`, *sort*=`none`  - undefined
+  * *mode*=`min`, *sort*=`value` - ascending by value
+  * *mode*=`min`, *sort*=`index` - ascending by index
+  * *mode*=`min`, *sort*=`none`  - undefined
 
 **Example**
 

--- a/docs/ops/sort/TopK_3.md
+++ b/docs/ops/sort/TopK_3.md
@@ -10,7 +10,7 @@
 
 * *axis*
 
-  * **Description**: Specifies the axis along which 
+  * **Description**: Specifies the axis along which the values are retrieved.
   * **Range of values**: An integer. Negative value means counting dimension from the end.
   * **Type**: `int`
   * **Default value**: None
@@ -31,7 +31,7 @@
   * **Type**: `string`
   * **Default value**: None
   * **Required**: *yes*
-  
+
 * *index_element_type*
 
   * **Description**: the type of output tensor with indices
@@ -65,7 +65,15 @@ Output tensor is populated by values computes in the following way:
 
     output[i1, ..., i(axis-1), j, i(axis+1) ..., iN] = top_k(input[i1, ...., i(axis-1), :, i(axis+1), ..., iN]), k, sort, mode)
 
-So for each slice `input[i1, ...., i(axis-1), :, i(axis+1), ..., iN]` which represents 1D array, *TopK* value is computed individually. Sorting and minimum/maximum are controlled by `sort` and `mode` attributes.
+So for each slice `input[i1, ...., i(axis-1), :, i(axis+1), ..., iN]` which represents 1D array, *TopK* value is computed individually.
+
+Sorting and minimum/maximum are controlled by `sort` and `mode` attributes:
+  * *mode*=`max`, *sort*=`value` - descending by value
+  * *mode*=`max`, *sort*=`index` - ascending by index
+  * *mode*=`max`, *sort*=`none`  - undefined
+  * *mode*=`min`, *sort*=`value` - ascending by value
+  * *mode*=`min`, *sort*=`index` - ascending by index
+  * *mode*=`min`, *sort*=`none`  - undefined
 
 **Example**
 

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
@@ -51,8 +51,7 @@ std::vector<std::string> disabledTestPatterns() {
         // TODO: Issue: 37862
         R"(.*ReverseSequenceLayerTest.*netPRC=(I8|U8).*)",
         // TODO: Issue: 38841
-        R"(.*TopKLayerTest.*k=10.*mode=min.*sort=index.*)",
-        R"(.*TopKLayerTest.*k=5.*sort=(none|index).*)",
+        R"(.*TopKLayerTest.*k=5.*sort=none.*)",
         // TODO: Issue: 43314
         R"(.*Broadcast.*mode=BIDIRECTIONAL.*inNPrec=BOOL.*)",
         // TODO: Issue 43417 sporadic issue, looks like an issue in test, reproducible only on Windows platform

--- a/ngraph/core/reference/include/ngraph/runtime/reference/topk.hpp
+++ b/ngraph/core/reference/include/ngraph/runtime/reference/topk.hpp
@@ -59,16 +59,9 @@ namespace ngraph
             }
 
             template <typename T, typename U>
-            inline bool sort_indices_descending(const std::tuple<T, U>& a,
-                                                const std::tuple<T, U>& b)
-            {
-                return std::get<1>(a) < std::get<1>(b);
-            }
-
-            template <typename T, typename U>
             inline bool sort_indices_ascending(const std::tuple<T, U>& a, const std::tuple<T, U>& b)
             {
-                return std::get<1>(a) > std::get<1>(b);
+                return std::get<1>(a) < std::get<1>(b);
             }
 
             template <typename T, typename U>
@@ -133,35 +126,18 @@ namespace ngraph
                                     compare_min<T, U>);
                     }
                     // Write temp vector to output
-                    if (compute_max)
+                    switch (sort)
                     {
-                        switch (sort)
-                        {
-                        case op::v1::TopK::SortType::NONE: break;
-                        case op::v1::TopK::SortType::SORT_INDICES:
-                            std::sort(workspace.begin(),
-                                      workspace.begin() + k,
-                                      sort_indices_descending<T, U>);
-                            break;
-                        case op::v1::TopK::SortType::SORT_VALUES:
+                    case op::v1::TopK::SortType::NONE: break;
+                    case op::v1::TopK::SortType::SORT_INDICES:
+                        std::sort(
+                            workspace.begin(), workspace.begin() + k, sort_indices_ascending<T, U>);
+                        break;
+                    case op::v1::TopK::SortType::SORT_VALUES:
+                        if (compute_max)
                             std::sort(workspace.begin(), workspace.begin() + k, compare_max<T, U>);
-                            break;
-                        }
-                    }
-                    else
-                    {
-                        switch (sort)
-                        {
-                        case op::v1::TopK::SortType::NONE: break;
-                        case op::v1::TopK::SortType::SORT_INDICES:
-                            std::sort(workspace.begin(),
-                                      workspace.begin() + k,
-                                      sort_indices_ascending<T, U>);
-                            break;
-                        case op::v1::TopK::SortType::SORT_VALUES:
+                        else
                             std::sort(workspace.begin(), workspace.begin() + k, compare_min<T, U>);
-                            break;
-                        }
                     }
                     for (size_t j = 0; j < k; j++)
                     {


### PR DESCRIPTION
[PR #3092](https://github.com/openvinotoolkit/openvino/pull/3092)
Main resolved problem is inconsistency of sorting TopK output elements for attributes `mode=min` and `sort=index`. This inconsistency led to validations issues.
 - Was: from lowest to biggest (VPU/CPU), from biggest to lowest (NGraph),
 - should be:  from lowest to biggest for all.

It also:
 - enables skipped Single Layer Functional Tests for TopK with attribute `sort=index`,
 - corrects axis attribute description in TopK nGraph doc.

Ticket: 40743