### PR TITLE
Update call signature with the fw from R14 develop branch

### DIFF
--- a/inference-engine/cmake/vpu_dependencies.cmake
+++ b/inference-engine/cmake/vpu_dependencies.cmake
@@ -19,7 +19,7 @@ set(VPU_SUPPORTED_FIRMWARES usb-ma2x8x pcie-ma248x)
 # Default packages
 #
 
-set(FIRMWARE_PACKAGE_VERSION 1492)
+set(FIRMWARE_PACKAGE_VERSION 1508)
 set(VPU_CLC_MA2X8X_VERSION "movi-cltools-20.09.2")
 
 #

--- a/inference-engine/thirdparty/movidius/mvnc/src/mvnc_data.c
+++ b/inference-engine/thirdparty/movidius/mvnc/src/mvnc_data.c
@@ -212,7 +212,7 @@ static ncStatus_t patchSetWdSwitchCommand(char **firmware, size_t *length, const
 // 0x98 the write command for 8bit
 // {0x00, 0x0c, 0x20, 0x70} == 0x70200c00 the address of memory type for ddrInit application
 const char g_setMemTypeCommandMX[] = {0x98, 0x00, 0x0c, 0x20, 0x70};
-const char g_callCommand[] = {0xba, 0x24, 0xe7, 0x21, 0x70};
+const char g_callCommand[] = {0xba, 0x78, 0xe9, 0x00, 0x70};
 
 static ncStatus_t patchSetMemTypeCommand(char **firmware, size_t *length, const char memType) {
     CHECK_HANDLE_CORRECT(firmware);


### PR DESCRIPTION
Update the VPU call with continue signature with the latest from MDK R14. This is needed for patching the DDR type for MA2085 PCIE and USB builds.