### PR TITLE
Add ccache support to OV build process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,14 @@
 
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
+if(USE_CCACHE)
+    find_program(CCACHE_BINARY ccache)
+
+    if(CCACHE_BINARY)
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_BINARY}")
+    endif()
+endif()
+
 project(OpenVINO)
 
 set(OpenVINO_MAIN_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
Inspired by https://crascit.com/2016/04/09/using-ccache-with-cmake/

This change does not affect the default compilation options. To build with ccache you need to explicitly request it by adding `-DUSE_CCACHE=TRUE` to your build. It shortens the compilation time significantly, especially if you're frequently building on a laptop or other machine with limited number of cores.

By default ccache stores its files in `$HOME/.ccache` and it can be easily purged with `$ ccache --clear`

It can be used in CI builds as well, perhaps with a daily cleanup of the cache on build agents. The current build time ranging from 15 to 36 minutes would definitely be reduced in each PR.

```
1. first build
$ git checkout master
$ cmake (...) -DUSE_CCACHE=TRUE
$ time make -j72

real    3m8.966s
user    131m50.604s
sys     11m29.992s

2. first rebuild
$ make clean
$ time make -j72

real    1m25.646s
user    10m48.944s
sys     1m31.160s

3. a different branch, complete wipe of the build directory and full build from scratch
$ git checkout onnx_reduction_ops
$ rm -rf *
$ cmake (...) -DUSE_CCACHE=TRUE
$ time make -j72

real    1m6.383s
user    10m56.792s
sys     1m34.100s
```

The same but with 16 compilation threads:
```
1. first build (after clearing $HOME/.ccache)
real    6m4.603s
user    79m9.856s
sys     6m54.740s

2. first rebuild
real    0m54.181s
user    4m4.936s
sys     0m29.364s

3. another branch + full clean build
real    1m18.301s
user    7m38.464s
sys     1m8.496s

4. make clean + make -j4
real    1m37.313s
user    4m33.692s
sys     0m33.160s
```