### PR TITLE
[IE TESTS] Fixes to the Reduce operation single layer test.

### DIFF
--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/reduce_ops.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/reduce_ops.cpp
@@ -63,9 +63,13 @@ const std::vector<ngraph::helpers::ReductionType> reductionTypes = {
         ngraph::helpers::ReductionType::Max,
         ngraph::helpers::ReductionType::Sum,
         ngraph::helpers::ReductionType::Prod,
+        ngraph::helpers::ReductionType::L1,
+        ngraph::helpers::ReductionType::L2,
+};
+
+const std::vector<ngraph::helpers::ReductionType> reductionLogicalTypes = {
         ngraph::helpers::ReductionType::LogicalOr,
-        ngraph::helpers::ReductionType::LogicalXor,
-        ngraph::helpers::ReductionType::LogicalAnd,
+        ngraph::helpers::ReductionType::LogicalAnd
 };
 
 const auto paramsOneAxis = testing::Combine(
@@ -78,6 +82,19 @@ const auto paramsOneAxis = testing::Combine(
         testing::Values(InferenceEngine::Precision::UNSPECIFIED),
         testing::Values(InferenceEngine::Layout::ANY),
         testing::ValuesIn(inputShapesOneAxis),
+        testing::Values(CommonTestUtils::DEVICE_CPU)
+);
+
+const auto paramsOneAxisLogical = testing::Combine(
+        testing::Values(std::vector<int>{0}),
+        testing::ValuesIn(opTypes),
+        testing::Values(true, false),
+        testing::ValuesIn(reductionLogicalTypes),
+        testing::Values(InferenceEngine::Precision::BOOL),
+        testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        testing::Values(InferenceEngine::Layout::ANY),
+        testing::ValuesIn(inputShapes),
         testing::Values(CommonTestUtils::DEVICE_CPU)
 );
 
@@ -139,10 +156,30 @@ const auto params_ReductionTypes = testing::Combine(
         testing::Values(CommonTestUtils::DEVICE_CPU)
 );
 
+const auto params_ReductionTypesLogical = testing::Combine(
+        testing::Values(std::vector<int>{0, 1, 3}),
+        testing::Values(opTypes[1]),
+        testing::ValuesIn(keepDims),
+        testing::ValuesIn(reductionLogicalTypes),
+        testing::Values(InferenceEngine::Precision::BOOL),
+        testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        testing::Values(InferenceEngine::Layout::ANY),
+        testing::Values(std::vector<size_t>{2, 9, 2, 9}),
+        testing::Values(CommonTestUtils::DEVICE_CPU)
+);
+
 INSTANTIATE_TEST_CASE_P(
         smoke_ReduceOneAxis,
         ReduceOpsLayerTest,
         paramsOneAxis,
+        ReduceOpsLayerTest::getTestCaseName
+);
+
+INSTANTIATE_TEST_CASE_P(
+        smoke_ReduceLogicalOneAxis,
+        ReduceOpsLayerTest,
+        paramsOneAxisLogical,
         ReduceOpsLayerTest::getTestCaseName
 );
 
@@ -171,6 +208,13 @@ INSTANTIATE_TEST_CASE_P(
         smoke_Reduce_ReductionTypes,
         ReduceOpsLayerTest,
         params_ReductionTypes,
+        ReduceOpsLayerTest::getTestCaseName
+);
+
+INSTANTIATE_TEST_CASE_P(
+        smoke_ReduceLogical_ReductionTypes,
+        ReduceOpsLayerTest,
+        params_ReductionTypesLogical,
         ReduceOpsLayerTest::getTestCaseName
 );
 

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
@@ -25,9 +25,7 @@ std::vector<std::string> disabledTestPatterns() {
         // TODO: failed to downgrade to opset v0 in interpreter backend
         R"(.*Gather.*axis=-1.*)",
         // TODO: Issue 33151
-        R"(.*Reduce.*type=Logical.*)",
         R"(.*Reduce.*axes=\(1\.-1\).*)",
-        R"(.*Reduce.*axes=\(0\.3\)_type=Prod.*)",
         // TODO: Issue: 34518
         R"(.*RangeLayerTest.*)",
         R"(.*(RangeAddSubgraphTest).*Start=1.2.*Stop=(5.2|-5.2).*Step=(0.1|-0.1).*netPRC=FP16.*)",

--- a/inference-engine/tests/ngraph_functions/include/ngraph_functions/utils/ngraph_helpers.hpp
+++ b/inference-engine/tests/ngraph_functions/include/ngraph_functions/utils/ngraph_helpers.hpp
@@ -167,7 +167,8 @@ enum ReductionType {
     Sum,
     LogicalOr,
     LogicalAnd,
-    LogicalXor
+    L1,
+    L2
 };
 
 enum class InputLayerType {

--- a/inference-engine/tests/ngraph_functions/src/reduce.cpp
+++ b/inference-engine/tests/ngraph_functions/src/reduce.cpp
@@ -15,21 +15,23 @@ std::shared_ptr<ngraph::Node> makeReduce(const ngraph::Output<Node>& data,
                                          ngraph::helpers::ReductionType reductionType) {
     switch (reductionType) {
         case helpers::Mean:
-            return std::make_shared<ngraph::opset3::ReduceMean>(data, axes, keepDims);
+            return std::make_shared<ngraph::opset4::ReduceMean>(data, axes, keepDims);
         case helpers::Max:
-            return std::make_shared<ngraph::opset3::ReduceMax>(data, axes, keepDims);
+            return std::make_shared<ngraph::opset4::ReduceMax>(data, axes, keepDims);
         case helpers::Min:
-            return std::make_shared<ngraph::opset3::ReduceMin>(data, axes, keepDims);
+            return std::make_shared<ngraph::opset4::ReduceMin>(data, axes, keepDims);
         case helpers::Prod:
-            return std::make_shared<ngraph::opset3::ReduceProd>(data, axes, keepDims);
+            return std::make_shared<ngraph::opset4::ReduceProd>(data, axes, keepDims);
         case helpers::Sum:
-            return std::make_shared<ngraph::opset3::ReduceSum>(data, axes, keepDims);
+            return std::make_shared<ngraph::opset4::ReduceSum>(data, axes, keepDims);
         case helpers::LogicalOr:
-            return std::make_shared<ngraph::opset3::LogicalOr>(data, axes);
+            return std::make_shared<ngraph::opset4::ReduceLogicalOr>(data, axes, keepDims);
         case helpers::LogicalAnd:
-            return std::make_shared<ngraph::opset3::LogicalAnd>(data, axes);
-        case helpers::LogicalXor:
-            return std::make_shared<ngraph::opset3::LogicalXor>(data, axes);
+            return std::make_shared<ngraph::opset4::ReduceLogicalAnd>(data, axes, keepDims);
+        case helpers::L1:
+            return std::make_shared<ngraph::opset4::ReduceL1>(data, axes, keepDims);
+        case helpers::L2:
+            return std::make_shared<ngraph::opset4::ReduceL2>(data, axes, keepDims);
         default:
             throw std::runtime_error("Can't create layer for this reduction type");
     }

--- a/inference-engine/tests/ngraph_functions/src/utils/ngraph_helpers.cpp
+++ b/inference-engine/tests/ngraph_functions/src/utils/ngraph_helpers.cpp
@@ -41,8 +41,11 @@ std::ostream &operator<<(std::ostream &os, const ReductionType &m) {
         case LogicalAnd:
             os << "LogicalAnd";
             break;
-        case LogicalXor:
-            os << "LogicalXor";
+        case L1:
+            os << "ReduceL1";
+            break;
+        case L2:
+            os << "ReduceL2";
             break;
     }
     return os;


### PR DESCRIPTION
Previously, the reduce builder routine used wrong operations  instances for logical reduce tests. This PR fixes this issue.