### PR TITLE
Call validate_and_infer_types in ONNX Loop

### DIFF
--- a/ngraph/frontend/onnx_import/src/op/loop.cpp
+++ b/ngraph/frontend/onnx_import/src/op/loop.cpp
@@ -201,6 +201,7 @@ namespace ngraph
                         scan_outputs.push_back(loop->get_concatenated_slices(
                             *body_outputs_it, 0, 1, 1, -1, concat_axis));
                     }
+                    loop->validate_and_infer_types();
 
                     OutputVector node_outputs;
                     for (const auto& v : final_values)

--- a/ngraph/python/tests/__init__.py
+++ b/ngraph/python/tests/__init__.py
@@ -135,10 +135,8 @@ xfail_issue_38714 = xfail_test(reason="RuntimeError: While validating ONNX node 
                                       "While validating node 'v1::<name> (sizes[0]:i64{4},"
                                       "Convert_29306[0]:f32{4}) -> (dynamic?)' with friendly_name '<name>':"
                                       "Argument element types are inconsistent.")
-xfail_issue_42297 = xfail_test(reason="RuntimeError: While validating ONNX node '<Node(Conv): Conv__7398>':"
-                                      "Check 'data.get_partial_shape().rank().is_static()'"
-                                      " failed at ngraph/frontend/onnx_import/src/op/conv.cpp:102:"
-                                      "The input data tensor's rank has to be known (static)")
+xfail_issue_43742 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations:"
+                                      "If")
 xfail_issue_43439 = xfail_test(reason="Check 'tensor_rank.is_static()' failed at "
                                       "ngraph/core/src/validation_util.cpp:884:"
                                       "map_1/while/select_bboxes/sort_bboxes_10/TopKV2 "

--- a/ngraph/python/tests/test_onnx/test_zoo_models.py
+++ b/ngraph/python/tests/test_onnx/test_zoo_models.py
@@ -25,7 +25,7 @@ from tests.test_onnx.utils.model_importer import ModelImportRunner
 
 from tests import (
     xfail_issue_38701,
-    xfail_issue_42297,
+    xfail_issue_43742,
     xfail_issue_43380,
     xfail_issue_43382,
     xfail_issue_43439,
@@ -133,11 +133,11 @@ if len(zoo_models) > 0:
         import_xfail_list = [
             # ONNX Model Zoo
             (xfail_issue_38701, "test_onnx_model_zoo_text_machine_comprehension_bidirectional_attention_flow_model_bidaf_9_bidaf_bidaf_cpu"),
-            (xfail_issue_42297, "test_onnx_model_zoo_vision_object_detection_segmentation_ssd_mobilenetv1_model_ssd_mobilenet_v1_10_ssd_mobilenet_v1_ssd_mobilenet_v1_cpu"),
+            (xfail_issue_43742, "test_onnx_model_zoo_vision_object_detection_segmentation_ssd_mobilenetv1_model_ssd_mobilenet_v1_10_ssd_mobilenet_v1_ssd_mobilenet_v1_cpu"),
             (xfail_issue_38726, "test_onnx_model_zoo_text_machine_comprehension_t5_model_t5_decoder_with_lm_head_12_t5_decoder_with_lm_head_cpu"),
 
             # Model MSFT
-            (xfail_issue_42297, "test_MSFT_opset10_mlperf_ssd_mobilenet_300_ssd_mobilenet_v1_coco_2018_01_28_cpu"),
+            (xfail_issue_43742, "test_MSFT_opset10_mlperf_ssd_mobilenet_300_ssd_mobilenet_v1_coco_2018_01_28_cpu"),
             (xfail_issue_43439, "test_MSFT_opset10_mlperf_ssd_resnet34_1200_ssd_resnet34_mAP_20.2_cpu"),
             (xfail_issue_37957, "test_MSFT_opset10_mask_rcnn_keras_mask_rcnn_keras_cpu"),
         ]


### PR DESCRIPTION
`validate_and_infer_types` is not called as part of Loop constructor (it should be called after set up body configuration).