### PR TITLE
[LPT] Q/DQ support

### DIFF
--- a/inference-engine/src/cldnn_engine/cldnn_engine.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_engine.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -30,6 +30,7 @@
 #include <transformations/control_flow/unroll_tensor_iterator.hpp>
 
 #include <transformations/common_optimizations/common_optimizations.hpp>
+#include "transformations/common_optimizations/convert_quantize_dequantize.hpp"
 #include <transformations/op_conversions/convert_depth_to_space.hpp>
 #include <transformations/op_conversions/convert_space_to_depth.hpp>
 #include <transformations/op_conversions/convert_gelu.hpp>
@@ -47,6 +48,7 @@
 #include <transformations/op_conversions/hsigmoid_decomposition.hpp>
 #include <transformations/op_conversions/log_softmax_decomposition.hpp>
 #include <transformations/op_conversions/convert_sequences_to_tensor_iterator.hpp>
+#include <transformations/op_conversions/convert_subtract.hpp>
 #include <transformations/op_conversions/convert_ti_to_sequences.hpp>
 #include <transformations/op_conversions/gru_cell_decomposition.hpp>
 #include <transformations/op_conversions/lstm_cell_decomposition.hpp>
@@ -60,9 +62,11 @@
 #include <transformations/init_node_info.hpp>
 #include <transformations/rt_info/fused_names_attribute.hpp>
 
+#include <low_precision/disable_convert_constant_folding_on_const_path.hpp>
 #include <low_precision/transformer.hpp>
 #include <low_precision/mat_mul.hpp>
 #include <low_precision/strided_slice.hpp>
+#include <low_precision/network_helper.hpp>
 
 #include "cldnn_engine.h"
 #include "cldnn_executable_network.h"
@@ -135,8 +139,15 @@ InferenceEngine::CNNNetwork clDNNEngine::CloneAndTransformNetwork(const Inferenc
         // Disable shape inference (WA for generic operations)
         ngraph::op::GenericIE::DisableReshape noReshape(nGraphFunc);
 
+        bool enableInt8;
         {
             ngraph::pass::Manager manager;
+            enableInt8 = config.enableInt8 && ngraph::pass::low_precision::LowPrecisionTransformer::isFunctionQuantized(nGraphFunc);
+            if (enableInt8) {
+                manager.register_pass<ngraph::pass::DisableConvertConstantFoldingOnConstPath>(
+                    std::vector<ngraph::element::Type>{ ngraph::element::i8, ngraph::element::u8 });
+            }
+
             manager.register_pass<ngraph::pass::InitNodeInfo>();
             manager.register_pass<ngraph::pass::CommonOptimizations>();
             manager.register_pass<ngraph::pass::ConvertRNNSequenceToTensorIterator>();
@@ -271,10 +282,19 @@ InferenceEngine::CNNNetwork clDNNEngine::CloneAndTransformNetwork(const Inferenc
 
             pass_config->enable<ngraph::pass::ConvertInterpolate1ToInterpolate4>();
 
+            if (enableInt8) {
+                pass_config->set_callback<ngraph::pass::ConvertQuantizeDequantize>([](const_node_ptr &node) -> bool {
+                    return ngraph::pass::low_precision::NetworkHelper::areQuantizeAndDequantizeSupportedForMultiply(node);
+                });
+
+                pass_config->set_callback<ngraph::pass::ConvertSubtract>([](const_node_ptr &node) -> bool {
+                    return ngraph::pass::low_precision::NetworkHelper::areQuantizeAndDequantizeSupportedForSubtract(node);
+                });
+            }
+
             manager.run_passes(nGraphFunc);
         }
 
-        bool enableInt8 = config.enableInt8 && ngraph::pass::low_precision::LowPrecisionTransformer::isFunctionQuantized(nGraphFunc);
         if (enableInt8) {
             OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "clDNNEngine::TransformNetwork::LPT");
             using namespace ngraph::pass::low_precision;

--- a/inference-engine/src/low_precision_transformations/include/low_precision/common/fake_quantize_dequantization.hpp
+++ b/inference-engine/src/low_precision_transformations/include/low_precision/common/fake_quantize_dequantization.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -20,21 +20,39 @@ public:
     FakeQuantizeDequantization();
 
     FakeQuantizeDequantization(
-        Output<Node> data,
-        std::shared_ptr<ngraph::opset1::Convert> convert,
-        std::shared_ptr<ngraph::opset1::Subtract> subtract,
-        std::shared_ptr<ngraph::opset1::Multiply> multiply);
+        const Output<Node>& data,
+        const std::shared_ptr<ngraph::opset1::Convert>& convert,
+        const std::shared_ptr<ngraph::opset1::Subtract>& subtract,
+        const std::shared_ptr<ngraph::opset1::Convert>& subtractConvert,
+        const std::shared_ptr<ngraph::opset1::Constant>& subtractConstant,
+        const std::shared_ptr<ngraph::opset1::Multiply>& multiply,
+        const std::shared_ptr<ngraph::opset1::Constant>& multiplyConstant);
 
     bool empty() const;
     bool multiplyHasZero() const;
     bool isShared() const;
     bool isLowPrecision() const;
+
     static bool checkElementwise(const std::shared_ptr<ngraph::Node>& elementwise);
+
+    static bool checkShape(const std::shared_ptr<ngraph::Node>& elementwise) noexcept;
+
+    static int fillDequantizationParams(
+        const std::shared_ptr<ngraph::Node>& elementwise,
+        std::shared_ptr<ngraph::opset1::Convert>& convert,
+        std::shared_ptr<ngraph::opset1::Constant>& constant) noexcept;
+
+    static int fillDequantizationParams(
+        const std::shared_ptr<ngraph::Node>& elementwise,
+        std::shared_ptr<ngraph::opset1::Constant>& constant) noexcept;
 
     Output<Node> data;
     std::shared_ptr<opset1::Convert> convert;
     std::shared_ptr<opset1::Subtract> subtract;
+    std::shared_ptr<ngraph::opset1::Convert> subtractConvert;
+    std::shared_ptr<ngraph::opset1::Constant> subtractConstant;
     std::shared_ptr<opset1::Multiply> multiply;
+    std::shared_ptr<ngraph::opset1::Constant> multiplyConstant;
 };
 
 } // namespace low_precision

--- a/inference-engine/src/low_precision_transformations/include/low_precision/disable_convert_constant_folding_on_const_path.hpp
+++ b/inference-engine/src/low_precision_transformations/include/low_precision/disable_convert_constant_folding_on_const_path.hpp
@@ -1,0 +1,26 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include <transformations_visibility.hpp>
+#include <ngraph/pass/graph_rewrite.hpp>
+
+namespace ngraph {
+namespace pass {
+
+class TRANSFORMATIONS_API DisableConvertConstantFoldingOnConstPath;
+
+}  // namespace pass
+}  // namespace ngraph
+
+class ngraph::pass::DisableConvertConstantFoldingOnConstPath : public ngraph::pass::MatcherPass {
+public:
+    NGRAPH_RTTI_DECLARATION;
+    DisableConvertConstantFoldingOnConstPath(
+        const std::vector<ngraph::element::Type>& inputPrecisions = {});
+};

--- a/inference-engine/src/low_precision_transformations/include/low_precision/eltwise_base_transformation.hpp
+++ b/inference-engine/src/low_precision_transformations/include/low_precision/eltwise_base_transformation.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -21,6 +21,9 @@ public:
     static bool isBroadcasted(const Shape& shape) noexcept;
 protected:
     int getNotEmpty(const std::shared_ptr<Node>& eltwise) const;
+    // Return indexes:
+    // 1. first  - data branch index for eltwise
+    // 2. second - Constant branch index for data branch Multiply
     std::pair<int, int> getMultiplyConstBranch(const std::shared_ptr<Node>& eltwise) const;
 };
 

--- a/inference-engine/src/low_precision_transformations/include/low_precision/fake_quantize.hpp
+++ b/inference-engine/src/low_precision_transformations/include/low_precision/fake_quantize.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -16,16 +16,14 @@ namespace low_precision {
 class TRANSFORMATIONS_API FakeQuantizeTransformation : public LayerTransformation {
 public:
     FakeQuantizeTransformation(const Params& params) : LayerTransformation(params) {}
-    ~FakeQuantizeTransformation() override {};
     void registerMatcherIn(GraphRewrite& pass, TransformationContext& context) const override;
     bool transform(TransformationContext& context, ngraph::pattern::Matcher &m) const override;
     bool isPrecisionPreserved(std::shared_ptr<Node> layer) const noexcept override;
 
     static bool checkElementwise(const std::shared_ptr<Node>& eltwise);
+
 private:
-    std::shared_ptr<opset1::FakeQuantize> fuseElementwise(
-        TransformationContext& context,
-        const std::shared_ptr<opset1::FakeQuantize>& fakeQuantize) const;
+    std::shared_ptr<opset1::FakeQuantize> fuseElementwise(TransformationContext& context, const std::shared_ptr<opset1::FakeQuantize>& fakeQuantize) const;
 };
 
 } // namespace low_precision

--- a/inference-engine/src/low_precision_transformations/include/low_precision/fake_quantize_decomposition.hpp
+++ b/inference-engine/src/low_precision_transformations/include/low_precision/fake_quantize_decomposition.hpp
@@ -1,0 +1,26 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+#include <ngraph/ngraph.hpp>
+#include "layer_transformation.hpp"
+#include "low_precision/fuse_fake_quantize.hpp"
+
+namespace ngraph {
+namespace pass {
+namespace low_precision {
+
+class TRANSFORMATIONS_API FakeQuantizeDecompositionTransformation : public LayerTransformation {
+public:
+    FakeQuantizeDecompositionTransformation(const Params& params) : LayerTransformation(params) {}
+    void registerMatcherIn(GraphRewrite& pass, TransformationContext& context) const override;
+    bool transform(TransformationContext& context, ngraph::pattern::Matcher &m) const override;
+    bool isPrecisionPreserved(std::shared_ptr<Node> layer) const noexcept override;
+};
+
+} // namespace low_precision
+} // namespace pass
+} // namespace ngraph

--- a/inference-engine/src/low_precision_transformations/include/low_precision/fold_convert.hpp
+++ b/inference-engine/src/low_precision_transformations/include/low_precision/fold_convert.hpp
@@ -1,0 +1,27 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+#include <ngraph/ngraph.hpp>
+#include "low_precision/layer_transformation.hpp"
+
+namespace ngraph {
+namespace pass {
+namespace low_precision {
+
+class TRANSFORMATIONS_API FoldConvertTransformation : public LayerTransformation {
+public:
+    FoldConvertTransformation(const Params& params) : LayerTransformation(params) {}
+    ~FoldConvertTransformation() override {}
+    void registerMatcherIn(GraphRewrite& pass, TransformationContext& context) const override;
+    bool transform(TransformationContext& context, ngraph::pattern::Matcher &m) const override;
+    bool canBeTransformed(const TransformationContext& context, std::shared_ptr<Node> layer) const override;
+    bool isPrecisionPreserved(std::shared_ptr<Node> layer) const noexcept override;
+};
+
+} // namespace low_precision
+} // namespace pass
+} // namespace ngraph

--- a/inference-engine/src/low_precision_transformations/include/low_precision/layer_transformation.hpp
+++ b/inference-engine/src/low_precision_transformations/include/low_precision/layer_transformation.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -50,6 +50,10 @@ public:
             min(min),
             max(max),
             hasZeroPoint(hasZeroPoint) {}
+
+    static bool isSupported(const element::Type& precision) {
+        return (precision == element::u8) || (precision == element::i8);
+    }
 
     static float getMinValue(const element::Type precision, const size_t levels) {
         if (precision == element::i8) {
@@ -305,16 +309,12 @@ protected:
     ILayerTransformationsManager* layerTransformationsManager;
 
 protected:
-    std::shared_ptr<ngraph::Node> separateInStandaloneBranch(std::shared_ptr<ngraph::Node> node) const;
-
     std::shared_ptr<ngraph::Node> moveDequantizationAfter(
         TransformationContext &context,
         const std::shared_ptr<ngraph::Node>& operation,
         const FakeQuantizeDequantization& dequantization,
         const bool updatePrecision,
         const bool moveSubtract = true) const;
-
-    void fuseConvertIfPossible(const std::shared_ptr<ngraph::Node>& operation) const;
 
     void updateOutput(
         TransformationContext &context,

--- a/inference-engine/src/low_precision_transformations/include/low_precision/network_helper.hpp
+++ b/inference-engine/src/low_precision_transformations/include/low_precision/network_helper.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -83,6 +83,8 @@ public:
 
     static std::shared_ptr<opset1::Constant> round(std::shared_ptr<Node> node, element::Type target_type);
 
+    static std::shared_ptr<opset1::FakeQuantize> composeFakeQuantize(const std::shared_ptr<opset1::FakeQuantize>& fq);
+
     static std::tuple<std::shared_ptr<Node>, std::shared_ptr<Node>> decomposeFakeQuantize(
         std::shared_ptr<opset1::FakeQuantize> fq,
         const element::Type precision,
@@ -114,10 +116,21 @@ public:
         const bool hasZeroPoint,
         const bool updatePrecision);
 
-    static FakeQuantizeDequantization getDequantization(const std::shared_ptr<Node> node, const size_t parentIndex = 0ul, const bool inPlace = false);
+    static bool areQuantizeAndDequantizeSupportedForSubtract(const std::shared_ptr<const ngraph::Node>& node);
+
+    static bool areQuantizeAndDequantizeSupportedForMultiply(const std::shared_ptr<const ngraph::Node>& node);
+
+    static bool isQuantizeSupported(const std::shared_ptr<opset1::FakeQuantize>& fakeQuantize);
+
+    static FakeQuantizeDequantization getDequantization(const std::shared_ptr<Node>& node, const size_t parentIndex = 0ul, const bool inPlace = false);
+
+    static FakeQuantizeDequantization getDequantizationBelow(const std::shared_ptr<Node>& node);
 
     static FakeQuantizeDequantization normalizeDequantization(FakeQuantizeDequantization dequantization);
 
+    // 1. remove Convert if possible
+    // 2. optimize Constant if possible
+    // 3. remove Subtract if Constant on the second branch is zero
     static std::shared_ptr<Node> optimizeSubtract(std::shared_ptr<opset1::Subtract> add);
 
     class InsertDequantizationResult {
@@ -136,11 +149,6 @@ public:
         const bool updatePrecision,
         const bool moveSubtract);
 
-    // TODO: rename: fuseConvertIfPossible
-    static void removeConvertIfPossible(
-        const std::shared_ptr<ngraph::Node>& operation,
-        const FakeQuantizeDequantization& dequantization);
-
     static bool checkConstantValuePrecision(const element::Type expectedPrecision, const std::shared_ptr<Node>& constant);
 
     static size_t getChildInputIndex(const std::shared_ptr<ngraph::Node>& parent, const std::shared_ptr<ngraph::Node>& child);
@@ -158,9 +166,11 @@ public:
     static std::shared_ptr<Node> fold_fake_quantize(const std::shared_ptr<opset1::FakeQuantize>& fq);
     static std::shared_ptr<Node> fold_fake_quantize(const std::shared_ptr<opset1::FakeQuantize>& fq, const bool roundValues);
 
-    // multi-precision constant folding
-    // handles only specific case: Constant -> [dequantization operations] -> [node]
-    static void foldDequantization(std::shared_ptr<Node>& node, const size_t branchIndex, const bool inPlace = false);
+    static FakeQuantizeDequantization foldDequantization(const std::shared_ptr<Node>& node, const size_t branchIndex, const bool inPlace = false);
+
+    static std::shared_ptr<ngraph::Node> separateInStandaloneBranch(std::shared_ptr<ngraph::Node> node);
+
+    static std::shared_ptr<opset1::FakeQuantize> fuseConvert(const std::shared_ptr<opset1::FakeQuantize>& fakeQuantize);
 
 private:
     static std::shared_ptr<Node> foldFakeQuantize(const std::shared_ptr<opset1::FakeQuantize>& fq, const bool roundValues, const bool roundValuesWasSet);

--- a/inference-engine/src/low_precision_transformations/include/low_precision/quantization_details.hpp
+++ b/inference-engine/src/low_precision_transformations/include/low_precision/quantization_details.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -71,7 +71,6 @@ public:
     const size_t outputChannelsCount;
 
 private:
-    QuantizationDetails &operator=(const QuantizationDetails & /*target*/) { return *this; }
     static void validate(std::shared_ptr<Node> constantLayer);
     static std::vector<float> getBlobValue(std::shared_ptr<Node> constantLayer);
 };

--- a/inference-engine/src/low_precision_transformations/include/low_precision/transformer.hpp
+++ b/inference-engine/src/low_precision_transformations/include/low_precision/transformer.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -149,6 +149,22 @@ public:
     }
 
     /**
+    * Add decomposition transformation. Transformation type and operation type are required.
+    * Operation type is used to find transformation by operation during precision definition.
+    */
+    template <class Transformation, class Operation>
+    LowPrecisionTransformations& addDecomposition(const LayerTransformation::Params& params) {
+        const std::string typeName = getType<Operation>();
+        const auto it = decompositionTransformations.find(typeName);
+        if (it != decompositionTransformations.end()) {
+            decompositionTransformations.erase(it);
+        }
+
+        decompositionTransformations.emplace(typeName, std::make_shared<Transformation>(params));
+        return *this;
+    }
+
+    /**
      * Add transformation. Transformation type and operation type are required.
      * Operation type is used to find transformation by operation during precision definition.
      */
@@ -233,6 +249,7 @@ public:
     // Key is not a layer type, but just a name of transformation
     // Layer type (or a pattern) is defined by transformation itself as an ngraph matcher
     std::map<std::string, LayerTransformationPtr> branchSpecificTransformations;
+    std::map<std::string, LayerTransformationPtr> decompositionTransformations;
     std::map<std::string, LayerTransformationPtr> transformations;
     std::map<std::string, std::vector<std::pair<std::string, LayerTransformationPtr>>> cleanupTransformations;
     std::vector<StandaloneCleanup> standaloneCleanupTransformations;

--- a/inference-engine/src/low_precision_transformations/include/low_precision/weightable_layer_transformation.hpp
+++ b/inference-engine/src/low_precision_transformations/include/low_precision/weightable_layer_transformation.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -17,11 +17,11 @@ class TRANSFORMATIONS_API WeightableLayerTransformation : public LayerTransforma
 public:
     WeightableLayerTransformation(const Params& params);
     bool canBeTransformed(const TransformationContext& context, std::shared_ptr<Node> layer) const override;
-    bool isQuantized(std::shared_ptr<Node> layer, bool isReshape) const noexcept;
+    bool isQuantized(std::shared_ptr<Node> layer, bool reshapeIsRequired) const noexcept;
     bool isPrecisionPreserved(std::shared_ptr<Node> layer) const noexcept override;
 
 protected:
-    DataPrecision decomposeFakeQuantizeForWeightsPath(std::shared_ptr<Node> weightableLayer) const;
+    void decomposeFakeQuantizeForWeightsPath(std::shared_ptr<Node> weightableLayer) const;
     static bool isGroup(const std::shared_ptr<Node>& node);
     static bool isDepthwise(const std::shared_ptr<Node>& node);
 

--- a/inference-engine/src/low_precision_transformations/src/avg_pool.cpp
+++ b/inference-engine/src/low_precision_transformations/src/avg_pool.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2020 Intel Corporation
+﻿// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -29,7 +29,7 @@ bool AvgPoolTransformation::transform(TransformationContext& context, ngraph::pa
         return false;
     }
 
-    const std::shared_ptr<Node> pooling = separateInStandaloneBranch(m.get_match_root());
+    const std::shared_ptr<Node> pooling = NetworkHelper::separateInStandaloneBranch(m.get_match_root());
 
     const std::vector<std::shared_ptr<ngraph::Node>> children = getChildrenRecursivelyExceptPrecisionPreserved(pooling);
 

--- a/inference-engine/src/low_precision_transformations/src/concat.cpp
+++ b/inference-engine/src/low_precision_transformations/src/concat.cpp
@@ -52,23 +52,22 @@ bool ConcatTransformation::transform(TransformationContext& context, ngraph::pat
     }
 
     std::unordered_map<std::string, ngraph::pass::low_precision::FakeQuantizeDequantization> dequantizations;
-    std::vector<QuantizationDetails> quantizationLayersDetails;
-
     for (size_t i = 0; i < subgraph.quantizationLayers.size(); ++i) {
-        const std::shared_ptr<ngraph::Node> fakeQuantizeLayer = subgraph.quantizationLayers[i];
-
-        const ngraph::Shape shape = fakeQuantizeLayer->get_output_shape(0);
-        if (shape.size() < 4ul) {
-            return false;
-        }
-
-        const std::shared_ptr<ngraph::opset1::FakeQuantize> fq = ngraph::as_type_ptr<ngraph::opset1::FakeQuantize>(fakeQuantizeLayer->shared_from_this());
+        const std::shared_ptr<ngraph::opset1::FakeQuantize> fq = ngraph::as_type_ptr<ngraph::opset1::FakeQuantize>(subgraph.quantizationLayers[i]);
         if (fq == nullptr) {
             return false;
         }
 
+        if (!NetworkHelper::isQuantizeSupported(fq)) {
+            return false;
+        }
+
         const QuantizationDetails& quantizationDetails = QuantizationDetails::getDetails(fq);
-        quantizationLayersDetails.push_back(quantizationDetails);
+
+        // per tensor scale is supported only
+        if (quantizationDetails.inputHighValues.size() != 1ul) {
+            return false;
+        }
 
         const DataPrecision dataPrecision2 = getDataPrecision(subgraph.quantizationLayers[i]->shared_from_this(), quantizationDetails, false);
         if (dataPrecision2.precision == ngraph::element::undefined) {
@@ -86,9 +85,27 @@ bool ConcatTransformation::transform(TransformationContext& context, ngraph::pat
         return false;
     }
 
-    // per tensor scale is supported only
-    if (quantizationLayersDetails.empty() || (quantizationLayersDetails[0].inputHighValues.size() != 1ul)) {
-        return false;
+    std::vector<QuantizationDetails> quantizationLayersDetails;
+    for (size_t i = 0; i < subgraph.quantizationLayers.size(); ++i) {
+        std::shared_ptr<opset1::FakeQuantize> fakeQuantize = as_type_ptr<opset1::FakeQuantize>(subgraph.quantizationLayers[i]);
+        auto newFakeQuantize = NetworkHelper::fuseConvert(fakeQuantize);
+        if (newFakeQuantize == nullptr) {
+            subgraph.quantizationLayers[i] = fakeQuantize;
+            quantizationLayersDetails.push_back(QuantizationDetails::getDetails(fakeQuantize));
+            continue;
+        }
+
+        fakeQuantize = newFakeQuantize;
+        newFakeQuantize = NetworkHelper::composeFakeQuantize(fakeQuantize);
+        if (newFakeQuantize == nullptr) {
+            subgraph.quantizationLayers[i] = fakeQuantize;
+            quantizationLayersDetails.push_back(QuantizationDetails::getDetails(fakeQuantize));
+            continue;
+        }
+
+        fakeQuantize = newFakeQuantize;
+        subgraph.quantizationLayers[i] = fakeQuantize;
+        quantizationLayersDetails.push_back(QuantizationDetails::getDetails(fakeQuantize));
     }
 
     FakeQuantizeDequantization dequantization;

--- a/inference-engine/src/low_precision_transformations/src/convolution.cpp
+++ b/inference-engine/src/low_precision_transformations/src/convolution.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2020 Intel Corporation
+﻿// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -24,7 +24,12 @@ void ConvolutionTransformation::registerMatcherIn(GraphRewrite &pass, Transforma
     addPattern(
         pass,
         context,
-        make_op_pattern<opset1::Convolution>({ make_op_label<opset1::Multiply>(), make_op_label<opset1::FakeQuantize>()}));
+        make_op_pattern<opset1::Convolution>({ make_op_label<opset1::Multiply>(), make_op_label<opset1::Multiply>() }));
+
+    addPattern(
+        pass,
+        context,
+        make_op_pattern<opset1::Convolution>({ make_op_label<opset1::Multiply>(), make_op_label<opset1::FakeQuantize>() }));
 }
 
 bool ConvolutionTransformation::isQuantized(std::shared_ptr<Node> layer) const noexcept {
@@ -51,7 +56,7 @@ bool ConvolutionTransformation::transform(TransformationContext &context, ngraph
         return false;
     }
 
-    convolution = separateInStandaloneBranch(convolution);
+    convolution = NetworkHelper::separateInStandaloneBranch(convolution);
     dequantization = NetworkHelper::getDequantization(convolution);
 
     {
@@ -156,6 +161,18 @@ bool ConvolutionTransformation::transform(TransformationContext &context, ngraph
         decomposeFakeQuantizeForWeightsPath(convolution);
 
         std::shared_ptr<opset1::Reshape> reshapeFromWeights = as_type_ptr<opset1::Reshape>(convolution->input_value(1).get_node_shared_ptr());
+
+        const auto dequantization = reshapeFromWeights == nullptr ?
+            NetworkHelper::getDequantization(convolution, 1ul) :
+            NetworkHelper::getDequantization(reshapeFromWeights);
+        assert(!dequantization.empty());
+        if (is_type<opset1::FakeQuantize>(dequantization.data.get_node())) {
+            const std::shared_ptr<opset1::FakeQuantize> fq = as_type_ptr<opset1::FakeQuantize>(dequantization.data.get_node_shared_ptr());
+            std::shared_ptr<ngraph::Node> newFQ = NetworkHelper::fold_fake_quantize(fq, true);
+            NetworkHelper::copyInfo(fq, newFQ);
+            replace_node(fq, newFQ);
+        }
+
         std::shared_ptr<opset1::Multiply> multiplyFromWeights = as_type_ptr<opset1::Multiply>(
             reshapeFromWeights == nullptr ?
             convolution->input_value(1).get_node_shared_ptr() :
@@ -164,8 +181,10 @@ bool ConvolutionTransformation::transform(TransformationContext &context, ngraph
 
         {
             Shape newScaleShape = multiplyFromWeights->get_input_shape(1);
-            // that's all we need: [C, 1, 1, 1] => [C, 1, 1]
-            newScaleShape.pop_back();
+            if (!newScaleShape.empty()) {
+                // that's all we need: [C, 1, 1, 1] => [C, 1, 1]
+                newScaleShape.pop_back();
+            }
 
             if (reshapeFromWeights != nullptr) {
                 reshapeFromWeights = as_type_ptr<opset1::Reshape>(reshapeFromWeights->copy_with_new_inputs({
@@ -189,9 +208,13 @@ bool ConvolutionTransformation::transform(TransformationContext &context, ngraph
         }
 
         if (subtractFromWeights != nullptr) {
+            // optimize zero point on weights
             auto optimizedSubtract = NetworkHelper::optimizeSubtract(subtractFromWeights);
+
             // TODO: handle optimizedSubtract == nullptr;
-            if (optimizedSubtract != nullptr) {
+            if (optimizedSubtract == nullptr) {
+                subtractFromWeights = nullptr;
+            } else {
                 subtractFromWeights = as_type_ptr<opset1::Subtract>(optimizedSubtract);
 
                 const Shape weightsShape = subtractFromWeights->input(0).get_shape();
@@ -208,8 +231,8 @@ bool ConvolutionTransformation::transform(TransformationContext &context, ngraph
         std::shared_ptr<opset1::Convert> convertFromWeights = as_type_ptr<opset1::Convert>(subtractFromWeights == nullptr ?
             multiplyFromWeights->get_input_node_shared_ptr(0) :
             subtractFromWeights->get_input_node_shared_ptr(0));
-
         if (convertFromWeights != nullptr) {
+            // remove Convert on weights
             std::shared_ptr<Node> childNode = reshapeFromWeights == nullptr ? convolution : reshapeFromWeights;
 
             auto newConvolution = convolution->clone_with_new_inputs({
@@ -223,6 +246,7 @@ bool ConvolutionTransformation::transform(TransformationContext &context, ngraph
 
         reshapeFromWeights = as_type_ptr<opset1::Reshape>(convolution->get_input_node_shared_ptr(1));
         if (reshapeFromWeights != nullptr) {
+            // remove Reshape on weights
             const std::shared_ptr<Node> newWeights = fold_reshape<opset1::Reshape>(
                 reshapeFromWeights->input_value(0),
                 reshapeFromWeights->input_value(1),

--- a/inference-engine/src/low_precision_transformations/src/disable_convert_constant_folding_on_const_path.cpp
+++ b/inference-engine/src/low_precision_transformations/src/disable_convert_constant_folding_on_const_path.cpp
@@ -1,0 +1,63 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "low_precision/disable_convert_constant_folding_on_const_path.hpp"
+
+#include <memory>
+#include <queue>
+#include <vector>
+
+#include <ngraph/opsets/opset1.hpp>
+#include <ngraph/opsets/opset3.hpp>
+#include <ngraph/rt_info.hpp>
+#include <ngraph/pattern/op/wrap_type.hpp>
+#include <ngraph/variant.hpp>
+#include "transformations/rt_info/dequantization_attribute.hpp"
+
+using namespace ngraph;
+
+NGRAPH_RTTI_DEFINITION(ngraph::pass::DisableConvertConstantFoldingOnConstPath, "DisableConvertConstantFoldingOnConstPath", 0);
+
+ngraph::pass::DisableConvertConstantFoldingOnConstPath::DisableConvertConstantFoldingOnConstPath(
+    const std::vector<ngraph::element::Type>& inputPrecisions) {
+    auto matcherData = ngraph::pattern::any_input();
+    auto matcherConvert = ngraph::pattern::wrap_type<opset3::Convert>({ matcherData }, pattern::consumers_count(1));
+
+    ngraph::matcher_pass_callback callback = [=](ngraph::pattern::Matcher & m) -> bool {
+        const auto& opsMap = m.get_pattern_value_map();
+        const auto convert = opsMap.find(matcherConvert)->second.get_node()->shared_from_this();
+
+        // validation by Convert operation input precisions
+        if (!inputPrecisions.empty()) {
+            const ngraph::element::Type inputPrecision = convert->input(0).get_element_type();
+            if (std::find(inputPrecisions.begin(), inputPrecisions.end(), inputPrecision) == inputPrecisions.end()) {
+                return false;
+            }
+        }
+
+        // Constant subgraph has not be folded if Convert is part of dequantization operations:
+        //
+        //   Constant                             Constant
+        //      |                                    |
+        //   Convert  Constant           OR       Convert  Constant
+        //       \     /                             \      /
+        //       Subtract   Constant                 Multiply
+        //           \      /
+        //           Multiply
+        //
+        auto parent = convert->get_input_node_ptr(0);
+        auto child = convert->output(0).get_target_inputs().begin()->get_node();
+        if (is_type<ngraph::opset1::Constant>(parent) &&
+            (is_type<ngraph::opset1::Subtract>(child) || is_type<ngraph::opset1::Multiply>(child))) {
+            auto& rtInfo = convert->get_rt_info();
+            rtInfo["DISABLED_CONSTANT_FOLDING"] = std::make_shared<VariantWrapper<std::string>>("");
+            return true;
+        }
+
+        return false;
+    };
+
+    auto m = std::make_shared<ngraph::pattern::Matcher>(matcherConvert, "DisableConvertConstantFoldingOnConstPath");
+    this->register_matcher(m, callback);
+}

--- a/inference-engine/src/low_precision_transformations/src/fake_quantize.cpp
+++ b/inference-engine/src/low_precision_transformations/src/fake_quantize.cpp
@@ -1,21 +1,12 @@
-﻿// Copyright (C) 2020 Intel Corporation
+﻿// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
 #include "low_precision/fake_quantize.hpp"
 
-#include <algorithm>
-#include <cmath>
-#include <limits>
-#include <map>
 #include <memory>
-#include <string>
-#include <utility>
-#include <vector>
-
 #include <ngraph/opsets/opset1.hpp>
 
-#include "low_precision/common/ie_lpt_exception.hpp"
 #include "low_precision/network_helper.hpp"
 
 namespace ngraph {
@@ -28,104 +19,15 @@ void FakeQuantizeTransformation::registerMatcherIn(GraphRewrite& pass, Transform
 
 bool FakeQuantizeTransformation::transform(TransformationContext& context, ngraph::pattern::Matcher &m) const {
     std::shared_ptr<opset1::FakeQuantize> layer = std::dynamic_pointer_cast<opset1::FakeQuantize>(m.get_match_root());
+    if (!NetworkHelper::isQuantizeSupported(layer)) {
+        return false;
+    }
 
     std::shared_ptr<opset1::FakeQuantize> fakeQuantize = layer;
-
     do {
         layer = fakeQuantize;
         fakeQuantize = fuseElementwise(context, fakeQuantize);
     } while (fakeQuantize != nullptr);
-
-    const ngraph::element::Type precision = layer->get_output_element_type(0);
-    if ((precision == ngraph::element::i8) || (precision == ngraph::element::u8)) {
-        return false;
-    }
-
-    // FakeQuantize on weights are used without dequantization ScaleShifts
-    if (NetworkHelper::isConstantPath(layer)) {
-        // fold fq if constant just before fq and child layers aren't supported in LPT
-        if (as_type<opset1::Constant>(layer->get_input_node_ptr(0))) {
-            bool nextOpearionsWillBeNotHandled = true;
-            for (auto output : layer->outputs()) {
-                for (auto input : output.get_target_inputs()) {
-                    const auto node = input.get_node();
-
-                    if (as_type<ngraph::opset1::Reshape>(node)) {
-                        for (const auto& child : NetworkHelper::consumers(node->shared_from_this())) {
-                            if ((as_type_ptr<ngraph::opset1::GroupConvolution>(child)) &&
-                                (paramsManager->getPrecisionsOnActivations(*child).size() != 0ul)) {
-                                nextOpearionsWillBeNotHandled = false;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (paramsManager->getPrecisionsOnActivations(*input.get_node()).size() != 0ul) {
-                        nextOpearionsWillBeNotHandled = false;
-                        break;
-                    }
-                }
-
-                if (!nextOpearionsWillBeNotHandled) {
-                    break;
-                }
-            }
-
-            if (nextOpearionsWillBeNotHandled) {
-                const std::shared_ptr<ngraph::Node> resultConstant = NetworkHelper::fold_fake_quantize(layer);
-                if (as_type_ptr<opset1::Constant>(resultConstant)) {
-                    replace_node(layer, resultConstant);
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    if (!QuantizationDetails::outputLayoutIsSupported(layer)) {
-        return false;
-    }
-
-    if (!QuantizationDetails::isSupportedLevel(layer->get_levels())) {
-        return false;
-    }
-
-    const QuantizationDetails quantizationDetails = QuantizationDetails::getDetails(layer);
-    const DataPrecision dataPrecision = getDataPrecision(layer, quantizationDetails, false);
-    if (dataPrecision.precision == element::undefined) {
-        return false;
-    }
-
-    // Split FakeQuantize to two parts: Quantize and Dequantize
-    auto QDQ = NetworkHelper::decomposeFakeQuantize(
-        as_type_ptr<opset1::FakeQuantize>(layer),
-        dataPrecision.precision,
-        dataPrecision.min,
-        dataPrecision.max,
-        dataPrecision.hasZeroPoint,
-        updatePrecisions);
-
-#ifdef LPT_PRINT_DEQUANTIZATION_INFO
-    {
-        const std::shared_ptr<opset1::Multiply> multiply = as_type_ptr<opset1::Multiply>(std::get<1>(QDQ));
-        const std::shared_ptr<opset1::Constant> multiplyConst = as_type_ptr<opset1::Constant>(multiply->get_input_node_shared_ptr(1));
-        const std::vector<float> dequantizationScales = multiplyConst->cast_vector<float>();
-
-        const std::shared_ptr<opset1::Subtract> subtract = as_type_ptr<opset1::Subtract>(multiply->get_input_node_shared_ptr(0));
-        std::vector<float> dequantizationShifts;
-        if (subtract != nullptr) {
-            const std::shared_ptr<opset1::Constant> subtractConst = as_type_ptr<opset1::Constant>(subtract->get_input_node_shared_ptr(1));
-            dequantizationShifts = subtractConst->cast_vector<float>();
-        } else {
-            dequantizationShifts = std::vector<float>(dequantizationScales.size());
-        }
-
-        printDequantizationValues(dequantizationScales, dequantizationShifts);
-    }
-#endif
-
-    std::shared_ptr<ngraph::Node> dequantize = std::get<1>(QDQ);
-    updateOutput(context, dequantize, layer);
 
     return true;
 }

--- a/inference-engine/src/low_precision_transformations/src/fake_quantize_decomposition.cpp
+++ b/inference-engine/src/low_precision_transformations/src/fake_quantize_decomposition.cpp
@@ -1,0 +1,169 @@
+﻿// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "low_precision/fake_quantize_decomposition.hpp"
+
+#include <memory>
+#include <ngraph/opsets/opset1.hpp>
+
+#include "low_precision/common/ie_lpt_exception.hpp"
+#include "low_precision/network_helper.hpp"
+
+namespace ngraph {
+namespace pass {
+namespace low_precision {
+
+void FakeQuantizeDecompositionTransformation::registerMatcherIn(GraphRewrite& pass, TransformationContext& context) const {
+    addSingleNodePattern<opset1::FakeQuantize>(pass, context);
+}
+
+bool FakeQuantizeDecompositionTransformation::transform(TransformationContext& context, ngraph::pattern::Matcher &m) const {
+    std::shared_ptr<opset1::FakeQuantize> layer = std::dynamic_pointer_cast<opset1::FakeQuantize>(m.get_match_root());
+    if (!NetworkHelper::isQuantizeSupported(layer)) {
+        return false;
+    }
+
+    layer = NetworkHelper::fuseConvert(layer);
+    if (NetworkHelper::isConstantPath(layer)) {
+        // fold fq if constant just before fq and child layers aren't supported in LPT
+        if (as_type<opset1::Constant>(layer->get_input_node_ptr(0))) {
+            bool nextOpearionsWillBeNotHandled = true;
+            for (auto output : layer->outputs()) {
+                for (auto input : output.get_target_inputs()) {
+                    const auto node = input.get_node();
+
+                    if (as_type<ngraph::opset1::Reshape>(node)) {
+                        for (const auto& child : NetworkHelper::consumers(node->shared_from_this())) {
+                            if ((as_type_ptr<ngraph::opset1::GroupConvolution>(child)) &&
+                                (paramsManager->getPrecisionsOnActivations(*child).size() != 0ul)) {
+                                nextOpearionsWillBeNotHandled = false;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (paramsManager->getPrecisionsOnActivations(*input.get_node()).size() != 0ul) {
+                        nextOpearionsWillBeNotHandled = false;
+                        break;
+                    }
+                }
+
+                if (!nextOpearionsWillBeNotHandled) {
+                    break;
+                }
+            }
+
+            if (nextOpearionsWillBeNotHandled) {
+                const std::shared_ptr<ngraph::Node> resultConstant = NetworkHelper::fold_fake_quantize(layer);
+                if (as_type_ptr<opset1::Constant>(resultConstant)) {
+                    replace_node(layer, resultConstant);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    const ngraph::element::Type precision = layer->get_output_element_type(0);
+    if (DataPrecision::isSupported(precision)) {
+        const QuantizationDetails quantizationDetails = QuantizationDetails::getDetails(layer);
+        const FakeQuantizeDequantization dequantization = NetworkHelper::getDequantizationBelow(layer);
+        if (dequantization.empty()) {
+            return false;
+        }
+
+        const DataPrecision expectedDataPrecision = getDataPrecision(dequantization.multiply, quantizationDetails, false);
+        if (expectedDataPrecision.precision == element::undefined) {
+            return false;
+        }
+
+        if (expectedDataPrecision.precision == precision) {
+            return false;
+        }
+
+        layer = NetworkHelper::composeFakeQuantize(layer);
+        if (layer == nullptr) {
+            return false;
+        }
+    }
+
+    if (as_type<opset1::Constant>(layer->get_input_node_ptr(0))) {
+        bool nextOpearionsWillBeNotHandled = true;
+        for (auto output : layer->outputs()) {
+            for (auto input : output.get_target_inputs()) {
+                auto activations = paramsManager->getPrecisionsOnActivations(*input.get_node());
+                if (paramsManager->getPrecisionsOnActivations(*input.get_node()).size() != 0ul) {
+                    nextOpearionsWillBeNotHandled = false;
+                    break;
+                }
+            }
+
+            if (!nextOpearionsWillBeNotHandled) {
+                break;
+            }
+        }
+
+        if (nextOpearionsWillBeNotHandled) {
+            const std::shared_ptr<ngraph::Node> resultConstant = NetworkHelper::fold_fake_quantize(layer);
+            if (as_type_ptr<opset1::Constant>(resultConstant)) {
+                replace_node(layer, resultConstant);
+                return true;
+            }
+        }
+    }
+
+    if (!QuantizationDetails::outputLayoutIsSupported(layer)) {
+        return false;
+    }
+
+    if (!QuantizationDetails::isSupportedLevel(layer->get_levels())) {
+        return false;
+    }
+
+    const QuantizationDetails quantizationDetails = QuantizationDetails::getDetails(layer);
+    const DataPrecision dataPrecision = getDataPrecision(layer, quantizationDetails, false);
+    if (dataPrecision.precision == element::undefined) {
+        return false;
+    }
+
+    // Split FakeQuantize to two parts: Quantize and Dequantize
+    auto QDQ = NetworkHelper::decomposeFakeQuantize(
+        as_type_ptr<opset1::FakeQuantize>(layer),
+        dataPrecision.precision,
+        dataPrecision.min,
+        dataPrecision.max,
+        dataPrecision.hasZeroPoint,
+        updatePrecisions);
+
+#ifdef LPT_PRINT_DEQUANTIZATION_INFO
+    {
+        const std::shared_ptr<opset1::Multiply> multiply = as_type_ptr<opset1::Multiply>(std::get<1>(QDQ));
+        const std::shared_ptr<opset1::Constant> multiplyConst = as_type_ptr<opset1::Constant>(multiply->get_input_node_shared_ptr(1));
+        const std::vector<float> dequantizationScales = multiplyConst->cast_vector<float>();
+
+        const std::shared_ptr<opset1::Subtract> subtract = as_type_ptr<opset1::Subtract>(multiply->get_input_node_shared_ptr(0));
+        std::vector<float> dequantizationShifts;
+        if (subtract != nullptr) {
+            const std::shared_ptr<opset1::Constant> subtractConst = as_type_ptr<opset1::Constant>(subtract->get_input_node_shared_ptr(1));
+            dequantizationShifts = subtractConst->cast_vector<float>();
+        } else {
+            dequantizationShifts = std::vector<float>(dequantizationScales.size());
+        }
+
+        printDequantizationValues(dequantizationScales, dequantizationShifts);
+    }
+#endif
+
+    std::shared_ptr<ngraph::Node> dequantize = std::get<1>(QDQ);
+    updateOutput(context, dequantize, layer);
+
+    return true;
+}
+
+bool FakeQuantizeDecompositionTransformation::isPrecisionPreserved(std::shared_ptr<Node> layer) const noexcept {
+    return false;
+}
+} // namespace low_precision
+} // namespace pass
+} // namespace ngraph

--- a/inference-engine/src/low_precision_transformations/src/fold_convert.cpp
+++ b/inference-engine/src/low_precision_transformations/src/fold_convert.cpp
@@ -1,0 +1,45 @@
+﻿// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "low_precision/fold_convert.hpp"
+#include <memory>
+#include <ngraph/ngraph.hpp>
+#include "low_precision/fake_quantize.hpp"
+#include "low_precision/network_helper.hpp"
+
+namespace ngraph {
+namespace pass {
+namespace low_precision {
+
+void FoldConvertTransformation::registerMatcherIn(GraphRewrite &pass, TransformationContext &context) const {
+    addSingleNodePattern<opset1::Subtract>(pass, context);
+}
+
+bool FoldConvertTransformation::transform(TransformationContext& context, ngraph::pattern::Matcher &m) const {
+    const auto subtract = m.get_match_root();
+    if (!canBeTransformed(context, subtract)) {
+        return false;
+    }
+
+    const auto convert = subtract->get_input_node_shared_ptr(1);
+    const auto resultConstant = fold<opset1::Convert>(convert->get_input_node_shared_ptr(0), convert->output(0).get_element_type());
+
+    replace_node(convert, resultConstant);
+    updateOutput(context, resultConstant, convert);
+    return true;
+}
+
+bool FoldConvertTransformation::canBeTransformed(const TransformationContext& context, std::shared_ptr<Node> operation) const {
+    return
+        is_type<opset1::Convert>(operation->get_input_node_ptr(1)) &&
+        is_type<opset1::Constant>(operation->get_input_node_ptr(1)->get_input_node_ptr(0));
+}
+
+bool FoldConvertTransformation::isPrecisionPreserved(std::shared_ptr<Node> layer) const noexcept {
+    return false;
+}
+
+} // namespace low_precision
+} // namespace pass
+} // namespace ngraph

--- a/inference-engine/src/low_precision_transformations/src/interpolate.cpp
+++ b/inference-engine/src/low_precision_transformations/src/interpolate.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2020 Intel Corporation
+﻿// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -37,7 +37,7 @@ bool InterpolateTransformation::transform(TransformationContext &context, ngraph
     if (!canBeTransformed(context, m.get_match_root())) {
         return false;
     }
-    interpolate = separateInStandaloneBranch(interpolate);
+    interpolate = NetworkHelper::separateInStandaloneBranch(interpolate);
     moveDequantizationAfter(context, interpolate, NetworkHelper::getDequantization(interpolate), true);
     return true;
 }

--- a/inference-engine/src/low_precision_transformations/src/layer_transformation.cpp
+++ b/inference-engine/src/low_precision_transformations/src/layer_transformation.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2020 Intel Corporation
+﻿// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -152,7 +152,17 @@ bool LayerTransformation::canSubtractBeHandled(const std::shared_ptr<Node>& op, 
         return false;
     }
 
-    return true;
+    const auto parent = dequantization.subtract->input_value(1).get_node_shared_ptr();
+
+    if (is_type<opset1::Constant>(parent)) {
+        return true;
+    } else if (is_type<opset1::Convert>(parent) && is_type<opset1::Constant>(parent->get_input_node_shared_ptr(0))) {
+        const auto constant = parent->get_input_node_shared_ptr(0);
+        const auto constantType = constant->output(0).get_element_type();
+        return operationType == constantType;
+    } else {
+        return false;
+    }
 }
 
 #ifdef LPT_PRINT_DEQUANTIZATION_INFO
@@ -170,7 +180,7 @@ std::stringstream toStream(const std::vector<float>& dequantizationValues) {
 void LayerTransformation::printDequantizationInfo(const std::shared_ptr<Node>& layer) {
     const QuantizationDetails quantizationDetails = QuantizationDetails::getDetails(as_type_ptr<opset1::FakeQuantize>(layer));
     std::cout <<
-        layer->get_type_name() << (NetworkHelper::onWeights(layer) ? " on weights " : " on activations ") <<
+        layer->get_type_name() << (NetworkHelper::isConstantPath(layer) ? " on weights " : " on activations ") <<
         layer->get_friendly_name() << ":" << std::endl <<
         "   details  : " << quantizationDetails << std::endl;
 }
@@ -392,44 +402,6 @@ std::vector<std::shared_ptr<Node>> LayerTransformation::getChildrenRecursivelyEx
     return resultChildren;
 }
 
-
-std::shared_ptr<ngraph::Node> LayerTransformation::separateInStandaloneBranch(std::shared_ptr<ngraph::Node> node) const {
-    FakeQuantizeDequantization dequantization = NetworkHelper::getDequantization(node);
-    if (dequantization.isShared()) {
-        Output<Node> parent = dequantization.data;
-        if (dequantization.convert != nullptr) {
-            parent = dequantization.convert->clone_with_new_inputs({ parent });
-            parent.get_node_shared_ptr()->set_friendly_name(parent.get_node_shared_ptr()->get_name() + "_new");
-        }
-
-        if (dequantization.subtract != nullptr) {
-            parent = dequantization.subtract->clone_with_new_inputs({
-                parent,
-                dequantization.subtract->get_input_node_shared_ptr(1)->clone_with_new_inputs({}) });
-            parent.get_node_shared_ptr()->set_friendly_name(parent.get_node_shared_ptr()->get_name() + "_new");
-        }
-
-        if (dequantization.multiply != nullptr) {
-            parent = dequantization.multiply->clone_with_new_inputs({
-                parent,
-                dequantization.multiply->get_input_node_shared_ptr(1)->clone_with_new_inputs({}) });
-            parent.get_node_shared_ptr()->set_friendly_name(parent.get_node_shared_ptr()->get_name() + "_new");
-        }
-
-        std::vector<Output<Node>> inputs = NetworkHelper::getInputs(node);
-        const size_t inputIndex = NetworkHelper::getChildInputIndex(dequantization.multiply, node);
-        inputs[inputIndex] = parent;
-        const std::shared_ptr<Node> newNode = node->clone_with_new_inputs(inputs);
-
-        replace_node(node, newNode);
-        newNode->set_friendly_name(node->get_friendly_name());
-
-        return newNode;
-    }
-
-    return node;
-}
-
 std::shared_ptr<ngraph::Node> LayerTransformation::moveDequantizationAfter(
     TransformationContext &context,
     const std::shared_ptr<ngraph::Node>& operation,
@@ -439,21 +411,6 @@ std::shared_ptr<ngraph::Node> LayerTransformation::moveDequantizationAfter(
     const auto result = ngraph::pass::low_precision::NetworkHelper::moveDequantizationAfter(operation, dequantization, updatePrecision, moveSubtract);
     updateOutput(context, result.lastDequantization, result.newOperation);
     return result.newOperation;
-}
-
-void LayerTransformation::fuseConvertIfPossible(const std::shared_ptr<ngraph::Node>& operation) const {
-    FakeQuantizeDequantization dequantization = NetworkHelper::getDequantization(operation, 0);
-    if ((dequantization.subtract != nullptr) &&
-        NetworkHelper::checkConstantValuePrecision(
-            dequantization.convert->get_output_element_type(0),
-            dequantization.subtract->get_input_node_shared_ptr(1))) {
-        auto newOperation = separateInStandaloneBranch(operation);
-        dequantization = NetworkHelper::getDequantization(operation, 0);
-        // TODO: It is correct to use optimizeSubtract here: uncomment following rows and fix it
-        //auto newSubtract = NetworkHelper::optimizeSubtract(dequantization.subtract);
-        //replace_node(dequantization.subtract, newSubtract);
-        NetworkHelper::removeConvertIfPossible(operation, dequantization);
-    }
 }
 
 void LayerTransformation::updateOutput(

--- a/inference-engine/src/low_precision_transformations/src/max_pool.cpp
+++ b/inference-engine/src/low_precision_transformations/src/max_pool.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2020 Intel Corporation
+﻿// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -47,7 +47,7 @@ bool MaxPoolTransformation::transform(TransformationContext& context, ngraph::pa
         return false;
     }
 
-    const std::shared_ptr<Node> pooling = separateInStandaloneBranch(m.get_match_root());
+    const std::shared_ptr<Node> pooling = NetworkHelper::separateInStandaloneBranch(m.get_match_root());
     moveDequantizationAfter(context, pooling, NetworkHelper::getDequantization(pooling), false);
     return true;
 }

--- a/inference-engine/src/low_precision_transformations/src/multiply.cpp
+++ b/inference-engine/src/low_precision_transformations/src/multiply.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2018-2020 Intel Corporation
+﻿// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -33,7 +33,7 @@ bool MultiplyTransformation::transform(TransformationContext& context, ngraph::p
     NetworkHelper::normalizeDequantization(NetworkHelper::getDequantization(multiply, 0));
     NetworkHelper::normalizeDequantization(NetworkHelper::getDequantization(multiply, 1));
 
-    multiply = separateInStandaloneBranch(multiply);
+    multiply = NetworkHelper::separateInStandaloneBranch(multiply);
     auto newMultiply = multiply;
 
     auto fold_fake_quantizes = [](std::shared_ptr<Node>& multiply, const size_t index) {
@@ -52,8 +52,12 @@ bool MultiplyTransformation::transform(TransformationContext& context, ngraph::p
     const int fullPathIndex = getNotEmpty(multiply);
     if (fullPathIndex == -1) {
         const auto multiplyBranch = getMultiplyConstBranch(multiply);
+        if (multiplyBranch.first != -1) {
+            NetworkHelper::foldDequantization(multiply, multiplyBranch.first == 0 ? 1 : 0);
+        }
 
         if (multiplyBranch.first == -1 || multiplyBranch.second == -1) {
+            // constant folding on dequantization ops (for example: Convert on Subtract)
             NetworkHelper::foldDequantization(multiply, 0);
             NetworkHelper::foldDequantization(multiply, 1);
             return false;
@@ -90,6 +94,7 @@ bool MultiplyTransformation::transform(TransformationContext& context, ngraph::p
             return false;
         }
 
+        dequantizationEmptyPath = NetworkHelper::foldDequantization(multiply, emptyPathIndex);
         std::shared_ptr<Node> subtractValuesEmptyPath;
         std::shared_ptr<Node> multiplyValuesEmptyPath;
         std::tie(subtractValuesEmptyPath, multiplyValuesEmptyPath) = NetworkHelper::createEmptyValues(dequantizationEmptyPath);
@@ -99,6 +104,7 @@ bool MultiplyTransformation::transform(TransformationContext& context, ngraph::p
             return false;
         }
 
+        dequantizationFullPath = NetworkHelper::foldDequantization(multiply, fullPathIndex);
         std::shared_ptr<Node> subtractValuesFullPath;
         std::shared_ptr<Node> multiplyValuesFullPath;
         std::tie(subtractValuesFullPath, multiplyValuesFullPath) = NetworkHelper::createEmptyValues(dequantizationFullPath);

--- a/inference-engine/src/low_precision_transformations/src/multiply_to_group_convolution.cpp
+++ b/inference-engine/src/low_precision_transformations/src/multiply_to_group_convolution.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2020 Intel Corporation
+﻿// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -31,6 +31,9 @@ bool MultiplyToGroupConvolutionTransformation::transform(TransformationContext& 
     }
 
     auto dequantization = NetworkHelper::getDequantization(multiply, inputIndex);
+    if (dequantization.subtractConvert != nullptr) {
+        dequantization = NetworkHelper::foldDequantization(multiply, inputIndex);
+    }
 
     const element::Type weightsPrecision = updatePrecisions ? precisionsOnWeights[0] : dequantization.data.get_element_type();
 
@@ -88,8 +91,8 @@ bool MultiplyToGroupConvolutionTransformation::transform(TransformationContext& 
     if (dequantization.subtract != nullptr) {
         lastNode = std::make_shared<opset1::Add>(
             convolution,
-            fold<opset1::Negative>(fold<opset1::Convert>(dequantization.subtract->get_input_node_shared_ptr(1), element::f32)));
-        lastNode->set_friendly_name(dequantization.subtract->get_friendly_name());
+            fold<opset1::Negative>(fold<opset1::Convert>(dequantization.subtractConstant, element::f32)));
+        lastNode->set_friendly_name(convolution->get_friendly_name() + "/Add");
     }
 
     lastNode = multiply->copy_with_new_inputs({ lastNode, constant });

--- a/inference-engine/src/low_precision_transformations/src/mvn.cpp
+++ b/inference-engine/src/low_precision_transformations/src/mvn.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -79,7 +79,7 @@ bool MVNTransformation::transform(TransformationContext &context, ngraph::patter
         return false;
     }
 
-    auto mvn = as_type_ptr<op::MVN>(separateInStandaloneBranch(operation));
+    auto mvn = as_type_ptr<op::MVN>(NetworkHelper::separateInStandaloneBranch(operation));
 
     FakeQuantizeDequantization dequantization = NetworkHelper::getDequantization(mvn);
     auto scalesConst = as_type_ptr<opset1::Constant>(dequantization.multiply->get_input_node_shared_ptr(1));

--- a/inference-engine/src/low_precision_transformations/src/normalize_l2.cpp
+++ b/inference-engine/src/low_precision_transformations/src/normalize_l2.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -94,7 +94,7 @@ bool NormalizeL2Transformation::transform(TransformationContext &context, ngraph
         return false;
     }
 
-    auto normalize = as_type_ptr<opset1::NormalizeL2>(separateInStandaloneBranch(operation));
+    auto normalize = as_type_ptr<opset1::NormalizeL2>(NetworkHelper::separateInStandaloneBranch(operation));
 
     const auto axes = as_type_ptr<opset1::Constant>(normalize->get_input_node_shared_ptr(1));
     FakeQuantizeDequantization dequantization = NetworkHelper::getDequantization(normalize);

--- a/inference-engine/src/low_precision_transformations/src/prelu.cpp
+++ b/inference-engine/src/low_precision_transformations/src/prelu.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2018-2020 Intel Corporation
+﻿// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -28,7 +28,7 @@ bool PReluTransformation::transform(TransformationContext& context, ngraph::patt
         return false;
     }
 
-    prelu = separateInStandaloneBranch(prelu);
+    prelu = NetworkHelper::separateInStandaloneBranch(prelu);
     const FakeQuantizeDequantization dequantization = NetworkHelper::getDequantization(prelu, 0);
     moveDequantizationAfter(context, prelu, dequantization, false, false);
     return true;

--- a/inference-engine/src/low_precision_transformations/src/quantization_details.cpp
+++ b/inference-engine/src/low_precision_transformations/src/quantization_details.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2018-2020 Intel Corporation
+﻿// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -21,56 +21,6 @@
 namespace ngraph {
 namespace pass {
 namespace low_precision {
-
-#if 0 // TODO LPT-TO-NGRAPH
-
-class ConstTensorDesc {
-public:
-    static void validate(const Layout layout, const std::vector<size_t>& dims) {
-        switch (layout) {
-        case Layout::SCALAR: {
-            if (dims.size() != 0) {
-                THROW_TRANSFORMATION_EXCEPTION << "unexpected dimensions size " << dims.size() << " for layout " << layout;
-            }
-            break;
-        }
-        case Layout::C: {
-            if (dims.size() != 1) {
-                THROW_TRANSFORMATION_EXCEPTION << "unexpected dimensions size " << dims.size() << " for layout " << layout;
-            }
-            break;
-        }
-        case Layout::NCHW: {
-            if (dims.size() != 4) {
-                THROW_TRANSFORMATION_EXCEPTION << "unexpected dimensions size " << dims.size() << " for layout " << layout;
-            }
-            break;
-        }
-        default: {
-            THROW_TRANSFORMATION_EXCEPTION << "unexpected layout " << layout;
-        }
-        }
-    }
-
-    static size_t getChannelsCount(const Layout layout, const std::vector<size_t>& dims) {
-        switch (layout) {
-        case Layout::SCALAR: {
-            return 1;
-        }
-        case Layout::C: {
-            return dims[0];
-        }
-        case Layout::NCHW: {
-            return dims[1];
-        }
-        default: {
-            THROW_TRANSFORMATION_EXCEPTION << "unexpected layout " << layout;
-        }
-        }
-    }
-};
-
-#endif
 
 QuantizationDetails::QuantizationDetails()
     : levels(),

--- a/inference-engine/src/low_precision_transformations/src/relu.cpp
+++ b/inference-engine/src/low_precision_transformations/src/relu.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2018-2020 Intel Corporation
+﻿// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -32,7 +32,7 @@ bool ReluTransformation::transform(TransformationContext& context, ngraph::patte
         return false;
     }
 
-    relu = separateInStandaloneBranch(relu);
+    relu = NetworkHelper::separateInStandaloneBranch(relu);
     const FakeQuantizeDequantization dequantization = NetworkHelper::getDequantization(relu, 0);
     moveDequantizationAfter(context, relu, dequantization, false, false);
     return true;

--- a/inference-engine/src/low_precision_transformations/src/reshape.cpp
+++ b/inference-engine/src/low_precision_transformations/src/reshape.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2020 Intel Corporation
+﻿// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -147,11 +147,15 @@ void reshapeDequantizationConstant(const std::shared_ptr<opset1::Reshape>& resha
 
 bool ReshapeTransformation::transform(TransformationContext& context, ngraph::pattern::Matcher &m) const {
     std::shared_ptr<opset1::Reshape> reshape = as_type_ptr<opset1::Reshape>(m.get_match_root());
-    if ((reshape == nullptr) || (!canBeTransformed(context, reshape))) {
+    if (NetworkHelper::isConstantPath(reshape)) {
         return false;
     }
 
-    reshape = as_type_ptr<opset1::Reshape>(separateInStandaloneBranch(reshape));
+    if (!canBeTransformed(context, reshape)) {
+        return false;
+    }
+
+    reshape = as_type_ptr<opset1::Reshape>(NetworkHelper::separateInStandaloneBranch(reshape));
     reshapeDequantizationConstant(reshape);
     moveDequantizationAfter(context, reshape, NetworkHelper::getDequantization(reshape, 0), false);
     return true;

--- a/inference-engine/src/low_precision_transformations/src/split.cpp
+++ b/inference-engine/src/low_precision_transformations/src/split.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -22,7 +22,7 @@ bool SplitTransformation::transform(TransformationContext& context, ngraph::patt
         return false;
     }
 
-    const std::shared_ptr<Node> split = separateInStandaloneBranch(m.get_match_root());
+    const std::shared_ptr<Node> split = NetworkHelper::separateInStandaloneBranch(m.get_match_root());
     auto dequantization = NetworkHelper::getDequantization(split);
 
     OutputVector inputs(split->get_input_size());

--- a/inference-engine/src/low_precision_transformations/src/squeeze.cpp
+++ b/inference-engine/src/low_precision_transformations/src/squeeze.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2020 Intel Corporation
+﻿// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -39,7 +39,7 @@ bool SqueezeTransformation::transform(TransformationContext& context, ngraph::pa
         return dequantizationOpConstant;
     };
 
-    const std::shared_ptr<Node> squeeze = separateInStandaloneBranch(m.get_match_root());
+    const std::shared_ptr<Node> squeeze = NetworkHelper::separateInStandaloneBranch(m.get_match_root());
     FakeQuantizeDequantization dequantization = NetworkHelper::getDequantization(squeeze);
 
     if (dequantization.multiply != nullptr) {

--- a/inference-engine/src/low_precision_transformations/src/strided_slice.cpp
+++ b/inference-engine/src/low_precision_transformations/src/strided_slice.cpp
@@ -68,7 +68,7 @@ bool StridedSliceTransformation::transform(TransformationContext& context, ngrap
         return false;
     }
 
-    const auto stridedSlice = separateInStandaloneBranch(m.get_match_root());
+    const auto stridedSlice = NetworkHelper::separateInStandaloneBranch(m.get_match_root());
     const auto dequantization = NetworkHelper::getDequantization(stridedSlice);
 
     if (dequantization.subtract) {
@@ -85,7 +85,7 @@ bool StridedSliceTransformation::transform(TransformationContext& context, ngrap
     const auto newMulConst = stridedSliceDeqConstant(stridedSlice, mulConst);
     dequantization.multiply->set_argument(mulConstIdx, newMulConst);
 
-    moveDequantizationAfter(context, stridedSlice, dequantization, false);
+    moveDequantizationAfter(context, stridedSlice, NetworkHelper::getDequantization(stridedSlice), false);
     return true;
 }
 

--- a/inference-engine/src/low_precision_transformations/src/unsqueeze.cpp
+++ b/inference-engine/src/low_precision_transformations/src/unsqueeze.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2020 Intel Corporation
+﻿// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -39,7 +39,7 @@ bool UnsqueezeTransformation::transform(TransformationContext& context, ngraph::
         return dequantizationOpConstant;
     };
 
-    const std::shared_ptr<Node> unsqueeze = separateInStandaloneBranch(m.get_match_root());
+    const std::shared_ptr<Node> unsqueeze = NetworkHelper::separateInStandaloneBranch(m.get_match_root());
     FakeQuantizeDequantization dequantization = NetworkHelper::getDequantization(unsqueeze);
 
     if (dequantization.multiply != nullptr) {

--- a/inference-engine/src/low_precision_transformations/src/weightable_layer_transformation.cpp
+++ b/inference-engine/src/low_precision_transformations/src/weightable_layer_transformation.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2020 Intel Corporation
+﻿// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -88,55 +88,125 @@ bool WeightableLayerTransformation::canBeTransformed(const TransformationContext
 
     // TODO Implement similar checks in other weightable operaitons
 
-    std::shared_ptr<opset1::Reshape> reshapeFromWeights = as_type_ptr<opset1::Reshape>(layer->input_value(1).get_node_shared_ptr());
-    std::shared_ptr<opset1::FakeQuantize> fqFromWeights = as_type_ptr<opset1::FakeQuantize>(
-        reshapeFromWeights == nullptr ?
-        layer->input_value(1).get_node_shared_ptr() :
-        layer->get_input_node_ptr(1)->get_input_node_shared_ptr(0));
+    const std::shared_ptr<opset1::Reshape> reshapeFromWeights = as_type_ptr<opset1::Reshape>(layer->input_value(1).get_node_shared_ptr());
 
-    if ((fqFromWeights == nullptr) || (fqFromWeights->get_input_size() != 5ul)) {
-        return false;
+    std::shared_ptr<opset1::FakeQuantize> fqFromWeights;
+    if (reshapeFromWeights == nullptr) {
+        fqFromWeights = as_type_ptr<opset1::FakeQuantize>(layer->input_value(1).get_node_shared_ptr());
+        if (fqFromWeights == nullptr) {
+            const FakeQuantizeDequantization dequantization = NetworkHelper::getDequantization(layer, 1ul);
+            fqFromWeights = as_type_ptr<opset1::FakeQuantize>(dequantization.data.get_node_shared_ptr());
+        }
+    } else {
+        fqFromWeights = as_type_ptr<opset1::FakeQuantize>(reshapeFromWeights->get_input_node_shared_ptr(0));
+        if (fqFromWeights == nullptr) {
+            const FakeQuantizeDequantization dequantization = NetworkHelper::getDequantization(reshapeFromWeights, 0ul);
+            fqFromWeights = as_type_ptr<opset1::FakeQuantize>(dequantization.data.get_node_shared_ptr());
+        }
     }
 
-    const Shape constOutputShape = fqFromWeights->get_input_node_ptr(3)->get_output_shape(0);
-    if (fqFromWeights->get_input_node_ptr(4)->get_output_shape(0) != constOutputShape) {
-        return false;
-    }
+    if (fqFromWeights != nullptr) {
+        if ((!NetworkHelper::isQuantizeSupported(fqFromWeights)) || (fqFromWeights->get_input_size() != 5ul)) {
+            return false;
+        }
 
-    // Check if all dimensions of scale except the first one (which is O-Output channels dimension) are all ones
-    if ((shape_size(constOutputShape) != constOutputShape[0]) ||
-        ((constOutputShape[0] != 1ul) && (fqFromWeights->get_output_shape(0)[0] != constOutputShape[0]))) {
-        return false;
+        const Shape constOutputShape = fqFromWeights->get_input_node_ptr(3)->get_output_shape(0);
+        if (fqFromWeights->get_input_node_ptr(4)->get_output_shape(0) != constOutputShape) {
+            return false;
+        }
+
+        if ( // Check if all dimensions of scale except the first one (which is O-Output channels dimension) are all ones
+            (shape_size(constOutputShape) != constOutputShape[0]) ||
+            ((constOutputShape[0] != 1ul) && (fqFromWeights->get_output_shape(0)[0] != constOutputShape[0]))) {
+            return false;
+        }
+    } else {
+        // TODO: LPT: is it possible to share with isQuantized?
+        const FakeQuantizeDequantization dequantizationOnWeights = reshapeFromWeights == nullptr ?
+            NetworkHelper::getDequantization(layer, 1ul) :
+            NetworkHelper::getDequantization(reshapeFromWeights, 0ul);
+        if (dequantizationOnWeights.empty()) {
+            return false;
+        }
+
+        const opset1::Constant* weightsData = as_type<opset1::Constant>(dequantizationOnWeights.data.get_node());
+        if (weightsData == nullptr) {
+            return false;
+        }
+
+        const ngraph::element::Type weightsDataPrecision = weightsData->output(0).get_element_type();
+        if (!DataPrecision::isSupported(weightsDataPrecision)) {
+            return false;
+        }
+
+        if ((dequantizationOnWeights.subtract != nullptr) && (dequantizationOnWeights.subtractConvert != nullptr)) {
+            const auto subtractConstantType = dequantizationOnWeights.subtractConstant->output(0).get_element_type();
+            if (subtractConstantType != weightsDataPrecision) {
+                return false;
+            }
+        }
     }
 
     return true;
 }
 
-bool WeightableLayerTransformation::isQuantized(std::shared_ptr<Node> layer, bool isReshape) const noexcept {
-    auto isFakeQuantize = [](std::shared_ptr<Node> layer) {
-        std::string opName = layer->get_type_name();
-        return opName == "FakeQuantize";
-    };
-
-    auto parentOnWeights = layer->get_input_node_shared_ptr(1);
-    std::string operationName = parentOnWeights->get_type_name();
-    if (isReshape) {
-        if (operationName != "Reshape") {
+bool WeightableLayerTransformation::isQuantized(std::shared_ptr<Node> layer, bool reshapeIsRequired) const noexcept {
+    FakeQuantizeDequantization dequantizationOnWeights;
+    if (reshapeIsRequired) {
+        const auto reshape = layer->get_input_node_shared_ptr(1);
+        if (!is_type<opset1::Reshape>(reshape)) {
             return false;
         }
-        parentOnWeights = parentOnWeights->get_input_node_shared_ptr(0);
-        return isFakeQuantize(parentOnWeights);
+
+        if (is_type<opset1::FakeQuantize>(reshape->get_input_node_shared_ptr(0))) {
+            const std::shared_ptr<opset1::FakeQuantize> fq = as_type_ptr<opset1::FakeQuantize>(reshape->get_input_node_shared_ptr(0));
+            return NetworkHelper::isQuantizeSupported(fq);
+        }
+
+        dequantizationOnWeights = NetworkHelper::getDequantization(reshape, 0);
+    } else if (is_type<opset1::FakeQuantize>(layer->get_input_node_shared_ptr(1))) {
+        const std::shared_ptr<opset1::FakeQuantize> fq = as_type_ptr<opset1::FakeQuantize>(layer->get_input_node_shared_ptr(1));
+        return NetworkHelper::isQuantizeSupported(fq);
     } else {
-        return isFakeQuantize(parentOnWeights);
+        dequantizationOnWeights = NetworkHelper::getDequantization(layer, 1);
     }
+
+    if (dequantizationOnWeights.empty()) {
+        return false;
+    }
+
+    // TODO: LPT: is it possible to share with canBeTransformed?
+    if (is_type<opset1::Constant>(dequantizationOnWeights.data.get_node())) {
+        const ngraph::element::Type weightsDataPrecision = dequantizationOnWeights.data.get_element_type();
+        if (!DataPrecision::isSupported(weightsDataPrecision)) {
+            return false;
+        }
+
+        if ((dequantizationOnWeights.subtract != nullptr) && (dequantizationOnWeights.subtractConvert != nullptr)) {
+            const auto subtractConstantType = dequantizationOnWeights.subtractConstant->output(0).get_element_type();
+            if (subtractConstantType != weightsDataPrecision) {
+                return false;
+            }
+        }
+
+        return true;
+    } else if (is_type<opset1::FakeQuantize>(dequantizationOnWeights.data.get_node())) {
+        return true;
+    }
+
+    return false;
 }
 
 bool WeightableLayerTransformation::isPrecisionPreserved(std::shared_ptr<Node> layer) const noexcept {
     return false;
 }
 
-DataPrecision WeightableLayerTransformation::decomposeFakeQuantizeForWeightsPath(std::shared_ptr<Node> node) const {
+void WeightableLayerTransformation::decomposeFakeQuantizeForWeightsPath(std::shared_ptr<Node> node) const {
     const auto fq = getFakeQuantizeOnWeights(node);
+    if (fq == nullptr) {
+        return;
+    }
+
     const QuantizationDetails quantizationDetails = QuantizationDetails::getDetails(fq);
     const DataPrecision dataPrecision = getDataPrecision(fq, quantizationDetails, true);
     auto tuple = NetworkHelper::decomposeFakeQuantize(
@@ -151,8 +221,6 @@ DataPrecision WeightableLayerTransformation::decomposeFakeQuantizeForWeightsPath
     if (as_type_ptr<ngraph::opset1::Constant>(fqOnWeights) == nullptr) {
         THROW_IE_LPT_EXCEPTION(*fqOnWeights) << "FakeQuantize on weights was not folded to constant";
     }
-
-    return dataPrecision;
 }
 
 bool WeightableLayerTransformation::isGroup(const std::shared_ptr<Node>& layer) {

--- a/inference-engine/src/mkldnn_plugin/mkldnn_plugin.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_plugin.cpp
@@ -33,6 +33,7 @@
 #include <transformations/opset_conversions/convert_opset2_to_opset1.hpp>
 
 #include <transformations/common_optimizations/common_optimizations.hpp>
+#include "transformations/common_optimizations/convert_quantize_dequantize.hpp"
 #include <transformations/common_optimizations/depth_to_space_fusion.hpp>
 #include <transformations/op_conversions/convert_depth_to_space.hpp>
 #include <transformations/op_conversions/convert_space_to_depth.hpp>
@@ -46,6 +47,7 @@
 #include <transformations/op_conversions/convert_space_to_batch.hpp>
 #include <transformations/op_conversions/convert_batch_to_space.hpp>
 #include <transformations/op_conversions/convert_sequences_to_tensor_iterator.hpp>
+#include <transformations/op_conversions/convert_subtract.hpp>
 #include <transformations/control_flow/unroll_tensor_iterator.hpp>
 #include <transformations/op_conversions/convert_mod.hpp>
 #include <transformations/op_conversions/convert_ti_to_sequences.hpp>
@@ -68,10 +70,12 @@
 
 #include <transformations/common_optimizations/lin_op_sequence_fusion.hpp>
 
-# include <low_precision/transformer.hpp>
-# include <low_precision/convolution.hpp>
-# include <low_precision/group_convolution.hpp>
-# include <low_precision/multiply_to_group_convolution.hpp>
+#include <low_precision/disable_convert_constant_folding_on_const_path.hpp>
+#include <low_precision/transformer.hpp>
+#include <low_precision/convolution.hpp>
+#include <low_precision/group_convolution.hpp>
+#include <low_precision/multiply_to_group_convolution.hpp>
+#include <low_precision/network_helper.hpp>
 
 #include "nodes/mkldnn_quantize_node.h"
 
@@ -104,6 +108,15 @@ static void Transformation(CNNNetwork& clonedNetwork, const Config& conf) {
 
     ngraph::pass::Manager manager;
     manager.register_pass<ngraph::pass::InitNodeInfo>();
+
+    const bool useLpt =
+        (conf.lpTransformsMode == Config::LPTransformsMode::On) &&
+        ngraph::pass::low_precision::LowPrecisionTransformer::isFunctionQuantized(nGraphFunc);
+    if (useLpt) {
+        manager.register_pass<ngraph::pass::DisableConvertConstantFoldingOnConstPath>(
+            std::vector<ngraph::element::Type>{ ngraph::element::i8, ngraph::element::u8 });
+    }
+
     // WA: ConvertPriorBox must be executed before the 1st ConstantFolding pass
     manager.register_pass<ngraph::pass::ConvertPriorBox>();
     manager.register_pass<ngraph::pass::ConvertNMS5ToLegacyMatcher>();
@@ -210,10 +223,21 @@ static void Transformation(CNNNetwork& clonedNetwork, const Config& conf) {
 
     pass_config->enable<ngraph::pass::ConvertInterpolate1ToInterpolate4>();
 
+    if (useLpt) {
+        pass_config->set_callback<ngraph::pass::ConvertQuantizeDequantize>([](const_node_ptr &node) -> bool {
+            return ngraph::pass::low_precision::NetworkHelper::areQuantizeAndDequantizeSupportedForMultiply(node);
+        });
+
+        pass_config->set_callback<ngraph::pass::ConvertSubtract>([](const_node_ptr &node) -> bool {
+            return ngraph::pass::low_precision::NetworkHelper::areQuantizeAndDequantizeSupportedForSubtract(node);
+        });
+    }
+
     manager.run_passes(nGraphFunc);
 
     using namespace ngraph::pass::low_precision;
-    if (conf.lpTransformsMode == Config::LPTransformsMode::On) {
+    if (useLpt) {
+        OV_ITT_SCOPED_TASK(MKLDNNPlugin::itt::domains::MKLDNN_LT, "LowPrecisionTransformations");
         auto params = LayerTransformation::Params(
             true,  // updatePrecisions
             LayerTransformation::QuantizedTensorAlignment::UpdateLevel,  // quantizedTensorAlignmentOnActivations

--- a/inference-engine/src/transformations/src/transformations/common_optimizations/convert_quantize_dequantize.cpp
+++ b/inference-engine/src/transformations/src/transformations/common_optimizations/convert_quantize_dequantize.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -76,6 +76,11 @@ ngraph::pass::ConvertQuantizeDequantize::ConvertQuantizeDequantize() {
 
     ngraph::matcher_pass_callback callback = [=](pattern::Matcher& m) {
         auto pattern_map = m.get_pattern_value_map();
+
+        if (transformation_callback(m.get_match_root())) {
+            return false;
+        }
+
         auto data = pattern_map[data_pattern];
         auto input_low = pattern_map[input_low_pattern];
         auto input_high = pattern_map[input_high_pattern];

--- a/inference-engine/src/transformations/src/transformations/op_conversions/convert_subtract.cpp
+++ b/inference-engine/src/transformations/src/transformations/op_conversions/convert_subtract.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -18,8 +18,12 @@ ngraph::pass::ConvertSubtract::ConvertSubtract() {
     MATCHER_SCOPE(ConvertSubtract);
     auto sub = ngraph::pattern::wrap_type<ngraph::opset1::Subtract>();
 
-    ngraph::matcher_pass_callback callback = [](pattern::Matcher& m) {
-        auto sub = std::dynamic_pointer_cast<ngraph::opset1::Subtract> (m.get_match_root());
+    ngraph::matcher_pass_callback callback = [=](pattern::Matcher& m) {
+        if (transformation_callback(m.get_match_root())) {
+            return false;
+        }
+
+        auto sub = std::dynamic_pointer_cast<ngraph::opset1::Subtract>(m.get_match_root());
         if (!sub) {
             return false;
         }

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/add_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/add_transformation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -195,7 +195,37 @@ const std::vector<AddTransformationTestValues> addTransformationTestValues = {
         },
         ""
     },
-    // U8
+
+    // Actual:
+    //
+    // Parameter           Parameter
+    //   |U8                 |U8
+    //   |                   |
+    // Convert Constant    Convert  Constant
+    //  \FP32  /FP32        \FP32   /FP32
+    //   \    /              \     /
+    //  Subtract  Constant  Subtract  Constant
+    //     \FP32   /FP32       \FP32  /FP32
+    //      \     /             \    /
+    //      Multiply           Multiply
+    //             \FP32      /FP32
+    //              \        /
+    //                 Add
+    // Transformed:
+    //
+    // Parameter
+    //   |U8
+    //   |
+    // Convert  Constant
+    //   \FP32   /FP32
+    //    \     /
+    //   Subtract    Constant
+    //      \FP32    /FP32
+    //       \      /
+    //      Multiply   Parameter
+    //          \FP32  /U8
+    //           \    /
+    //            Add
     {
         ngraph::element::f32,
         ngraph::Shape{1, 4, 16, 16},
@@ -207,6 +237,68 @@ const std::vector<AddTransformationTestValues> addTransformationTestValues = {
             { {ngraph::element::f32},  { 7.f }, { 10.f }},
             ngraph::element::u8,
             { {ngraph::element::f32},  { 3.f }, { 5.f } },
+            {}
+        },
+        {
+            ngraph::element::u8,
+            { {ngraph::element::f32},  { 8.5f }, { 2.f }},
+            ngraph::element::u8,
+            { {},  {}, {} },
+            { {},  {}, {5.f} },
+            {}
+        },
+        ""
+    },
+
+    // Actual:
+    //
+    // Parameter Constant Parameter Constant
+    //  |U8      |U8        |U8      |U8
+    //  |        |          |        |
+    // Convert Convert    Convert  Convert
+    //  \FP32  /FP32        \FP32   /FP32
+    //   \    /              \     /
+    //  Subtract  Constant  Subtract  Constant
+    //     \FP32   /FP32       \FP32  /FP32
+    //      \     /             \    /
+    //      Multiply           Multiply
+    //             \FP32      /FP32
+    //              \        /
+    //                 Add
+    // Transformed:
+    //
+    // Parameter
+    //   |U8
+    //   |
+    // Convert  Constant
+    //   \FP32   /FP32
+    //    \     /
+    //   Subtract    Constant
+    //      \FP32    /FP32
+    //       \      /
+    //      Multiply   Parameter
+    //          \FP32  /U8
+    //           \    /
+    //            Add
+    {
+        ngraph::element::f32,
+        ngraph::Shape{1, 4, 16, 16},
+        false,
+        -1,
+        LayerTransformation::createParamsU8I8(),
+        {
+            ngraph::element::u8,
+            {
+                {ngraph::element::f32},
+                { {7.f}, ngraph::element::f32, {}, false, 1, ngraph::element::u8, true },
+                { 10.f }
+            },
+            ngraph::element::u8,
+            {
+                {ngraph::element::f32},
+                { {3.f}, ngraph::element::f32, {}, false, 1, ngraph::element::u8, true },
+                { 5.f }
+            },
             {}
         },
         {
@@ -553,6 +645,126 @@ const std::vector<AddTransformationTestValues> addTransformationTestValues = {
             {}
         },
         "group_convolution"
+    },
+
+    // Actual:
+    //
+    // Parameter          Parameter Constant
+    //  |U8                 |U8      |U8
+    //  |                   |        |
+    // Convert Constant    Convert  Convert
+    //  \FP32  /FP32        \FP32   /FP32
+    //   \    /              \     /
+    //  Subtract  Constant  Subtract  Constant
+    //     \FP32   /FP32       \FP32  /FP32
+    //      \     /             \    /
+    //      Multiply           Multiply
+    //             \FP32      /FP32
+    //              \        /
+    //                 Add
+    // Transformed:
+    //
+    // Parameter
+    //   |U8
+    //   |
+    // Convert  Constant
+    //   \FP32   /FP32
+    //    \     /
+    //   Subtract    Constant
+    //      \FP32    /FP32
+    //       \      /
+    //      Multiply
+    {
+        ngraph::element::f32,
+        ngraph::Shape{1, 4, 16, 16},
+        false,
+        1,
+        LayerTransformation::createParamsU8I8(),
+        {
+            ngraph::element::u8,
+            {
+                {ngraph::element::f32},
+                {7.f},
+                { 10.f }
+            },
+            ngraph::element::u8,
+            {
+                {ngraph::element::f32},
+                { {3.f}, ngraph::element::f32, {}, false, 1, ngraph::element::u8, true },
+                { 5.f }
+            },
+            {10.f}
+        },
+        {
+            ngraph::element::u8,
+            { {ngraph::element::f32}, {}, {}},
+            ngraph::element::u8,
+            { },
+            { {},  {}, {10.f} },
+            {3.5f},
+            "Subtract"
+        },
+        ""
+    },
+
+    // Actual:
+    //
+    // Constant Constant   Parameter
+    //  |U8      |U8        |U8
+    //  |        |          |
+    // Convert Convert    Convert  Constant
+    //  \FP32  /FP32        \FP32   /FP32
+    //   \    /              \     /
+    //  Subtract  Constant  Subtract  Constant
+    //     \FP32   /FP32       \FP32  /FP32
+    //      \     /             \    /
+    //      Multiply           Multiply
+    //             \FP32      /FP32
+    //              \        /
+    //                 Add
+    // Transformed:
+    //
+    // Parameter
+    //   |U8
+    //   |
+    // Convert  Constant
+    //   \FP32   /FP32
+    //    \     /
+    //   Subtract    Constant
+    //      \FP32    /FP32
+    //       \      /
+    //      Multiply
+    {
+        ngraph::element::f32,
+        ngraph::Shape{1, 4, 16, 16},
+        false,
+        0,
+        LayerTransformation::createParamsU8I8(),
+        {
+            ngraph::element::u8,
+            {
+                {ngraph::element::f32},
+                { {7.f}, ngraph::element::f32, {}, false, 1, ngraph::element::u8, true },
+                { 10.f }
+            },
+            ngraph::element::u8,
+            {
+                {ngraph::element::f32},
+                { 3.f },
+                { 5.f }
+            },
+            { 10.f }
+        },
+        {
+            ngraph::element::u8,
+            { {ngraph::element::f32}, {}, {}},
+            ngraph::element::u8,
+            { },
+            { {},  {}, { 5.f } },
+            { -3.f },
+            "Subtract"
+        },
+        ""
     },
 };
 

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/clamp_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/clamp_transformation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -79,9 +79,7 @@ public:
 };
 
 TEST_P(ClampTransformation, CompareFunctions) {
-    InitNodeInfo().run_on_function(actualFunction);
     actualFunction->validate_nodes_and_infer_types();
-
     auto res = compare_functions(referenceFunction, actualFunction, true, true);
     ASSERT_TRUE(res.first) << res.second;
 }
@@ -102,6 +100,31 @@ const std::vector<ClampTransformationTestValues> testValues = {
             {{}, {}, {}},
             ngraph::element::f32,
             {{}, {128.f}, {3.f}}
+        }
+    },
+    // U8 per tensor quantization
+    {
+        ngraph::Shape({ 1, 3, 224, 224 }),
+        LayerTransformation::createParamsU8I8(),
+        // ActualValues
+        {
+            ngraph::element::u8,
+            {
+                {ngraph::element::f32},
+                {{128.f}, ngraph::element::f32, {}, false, 1, ngraph::element::u8, true},
+                {3.f}
+            }
+        },
+        // ExpectedValues
+        {
+            ngraph::element::u8,
+            {{}, {}, {}},
+            ngraph::element::f32,
+            {
+                {},
+                {{128.f}, ngraph::element::f32, {}, false, 1, ngraph::element::u8, true},
+                {3.f}
+            }
         }
     },
     // I8 per tensor quantization

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/compose_fake_quantize_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/compose_fake_quantize_transformation.cpp
@@ -1,0 +1,149 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "layer_transformation.hpp"
+
+#include <string>
+#include <sstream>
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include <utility>
+#include <transformations/utils/utils.hpp>
+#include <low_precision/network_helper.hpp>
+
+#include "common_test_utils/ngraph_test_utils.hpp"
+#include "lpt_ngraph_functions/compose_fake_quantize_function.hpp"
+#include "lpt_ngraph_functions/common/dequantization_operations.hpp"
+#include "lpt_ngraph_functions/common/fake_quantize_on_data.hpp"
+
+using namespace testing;
+using namespace ngraph::pass;
+using namespace ngraph::builder::subgraph;
+
+class ComposeFakeQuantizeTransformationParams {
+public:
+    class Values {
+    public:
+        ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize;
+        ngraph::builder::subgraph::DequantizationOperations dequantization1;
+        ngraph::builder::subgraph::DequantizationOperations dequantization2;
+    };
+
+    ngraph::element::Type originalPrecision;
+    Values actual;
+    Values expected;
+};
+
+typedef std::tuple<
+    ngraph::Shape,
+    ComposeFakeQuantizeTransformationParams> ComposeFakeQuantizeTransformationValues;
+
+class ComposeFakeQuantizeTransformation :
+    public LayerTransformation,
+    public testing::WithParamInterface<ComposeFakeQuantizeTransformationValues> {
+public:
+    void SetUp() override {
+        const auto inputShape = std::get<0>(GetParam());
+        const auto testValues = std::get<1>(GetParam());
+        actualFunction = ngraph::builder::subgraph::ComposeFakeQuantizeFunction::get(
+            testValues.originalPrecision,
+            inputShape,
+            testValues.actual.fakeQuantize,
+            testValues.actual.dequantization1,
+            testValues.actual.dequantization2);
+
+        const auto input = actualFunction->get_parameters()[0];
+        const auto fakeQuantizes = input->output(0).get_target_inputs();
+        const auto it = fakeQuantizes.begin();
+        const auto fakeQuantize = ngraph::as_type_ptr<ngraph::opset1::FakeQuantize>(it->get_node()->shared_from_this());
+        low_precision::NetworkHelper::composeFakeQuantize(fakeQuantize);
+
+        referenceFunction = ngraph::builder::subgraph::ComposeFakeQuantizeFunction::get(
+            testValues.originalPrecision,
+            inputShape,
+            testValues.expected.fakeQuantize,
+            testValues.expected.dequantization1,
+            testValues.expected.dequantization2);
+    }
+
+    static std::string getTestCaseName(testing::TestParamInfo<ComposeFakeQuantizeTransformationValues> obj) {
+        const auto inputShape = std::get<0>(obj.param);
+        const auto testValues = std::get<1>(obj.param);
+
+        std::ostringstream result;
+        result <<
+            testValues.originalPrecision << "_" <<
+            inputShape << "_" <<
+            testValues.actual.fakeQuantize << "_" <<
+            testValues.actual.dequantization1 << "_" <<
+            testValues.actual.dequantization2 << "_" <<
+            testValues.expected.fakeQuantize << "_" <<
+            testValues.expected.dequantization1 << "_" <<
+            testValues.expected.dequantization2;
+        return result.str();
+    }
+};
+
+TEST_P(ComposeFakeQuantizeTransformation, CompareFunctions) {
+    actualFunction->validate_nodes_and_infer_types();
+    auto res = compare_functions(referenceFunction, actualFunction, true, false, true);
+    ASSERT_TRUE(res.first) << res.second;
+}
+
+const std::vector<ngraph::Shape> inputShapes = {
+    { 1, 3, 16, 16 },
+    { 4, 3, 16, 16 }
+};
+
+const std::vector<ComposeFakeQuantizeTransformationParams> testValues = {
+    {
+        ngraph::element::f32,
+        {
+            { 256ul, {}, { 0.f }, { 2.55f }, { 0.f }, { 255.f } },
+            { {ngraph::element::f32},  {}, { 0.01f } },
+            {}
+        },
+        {
+            { 256ul, {}, { 0.f }, { 2.55f }, { 0.f }, { 2.55f } },
+            {},
+            {}
+        },
+    },
+    {
+        ngraph::element::f32,
+        {
+            { 256ul, {}, { 0.f }, { 2.55f }, { -128.f }, { 127.f } },
+            { {ngraph::element::f32},  {-128}, { 0.01f } },
+            {}
+        },
+        {
+            { 256ul, {}, { 0.f }, { 2.55f }, { 0.f }, { 2.55f } },
+            {},
+            {}
+        },
+    },
+    {
+        ngraph::element::f32,
+        {
+            { 256ul, {}, { 0.f }, { 2.55f }, { -128.f }, { 127.f } },
+            { {ngraph::element::f32},  {-128}, { 0.01f } },
+            { {ngraph::element::f32},  {-128}, { 0.01f } }
+        },
+        {
+            { 256ul, {}, { 0.f }, { 2.55f }, { -128.f }, { 127.f } },
+            { {ngraph::element::f32},  {-128}, { 0.01f } },
+            { {ngraph::element::f32},  {-128}, { 0.01f } }
+        },
+    }
+};
+
+INSTANTIATE_TEST_CASE_P(
+    smoke_LPT,
+    ComposeFakeQuantizeTransformation,
+    ::testing::Combine(
+        ::testing::ValuesIn(inputShapes),
+        ::testing::ValuesIn(testValues)),
+    ComposeFakeQuantizeTransformation::getTestCaseName);

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/convolution_qdq_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/convolution_qdq_transformation.cpp
@@ -1,0 +1,415 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "layer_transformation.hpp"
+
+#include <string>
+#include <sstream>
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include <transformations/utils/utils.hpp>
+#include <transformations/init_node_info.hpp>
+#include <low_precision/convolution.hpp>
+
+#include "common_test_utils/ngraph_test_utils.hpp"
+#include "simple_low_precision_transformer.hpp"
+#include "lpt_ngraph_functions/fake_quantize_and_convolution_function.hpp"
+
+using namespace testing;
+using namespace ngraph;
+using namespace ngraph::pass;
+
+class ConvolutionQDqTransformationTestValues {
+public:
+    class Values {
+    public:
+        ngraph::element::Type precisionBeforeDequantization;
+        ngraph::builder::subgraph::DequantizationOperations dequantizationOnActivations;
+        ngraph::builder::subgraph::DequantizationOperations dequantizationOnWeights;
+        ngraph::builder::subgraph::Constant weights;
+        builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
+        ngraph::element::Type precisionAfterOperation;
+        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+    };
+
+    ngraph::pass::low_precision::LayerTransformation::Params params;
+    Values actual;
+    Values expected;
+};
+
+typedef std::tuple<
+    ngraph::Shape,
+    ConvolutionQDqTransformationTestValues> ConvolutionQDqTransformationParams;
+
+class ConvolutionQDqTransformation : public LayerTransformation, public testing::WithParamInterface<ConvolutionQDqTransformationParams> {
+public:
+    void SetUp() override {
+        const auto inputShape = std::get<0>(GetParam());
+        const auto testValues = std::get<1>(GetParam());
+
+        actualFunction = ngraph::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
+            testValues.actual.precisionBeforeDequantization,
+            inputShape,
+            {},
+            {},
+            testValues.actual.dequantizationOnActivations,
+            testValues.actual.weights,
+            testValues.actual.fakeQuantizeOnWeights,
+            {},
+            testValues.actual.dequantizationOnWeights,
+            testValues.actual.dequantizationAfter);
+
+        SimpleLowPrecisionTransformer transform;
+        transform.add<ngraph::pass::low_precision::ConvolutionTransformation, ngraph::opset1::Convolution>(testValues.params);
+        transform.transform(actualFunction);
+
+        referenceFunction = ngraph::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
+            testValues.actual.precisionBeforeDequantization,
+            inputShape,
+            {},
+            {},
+            testValues.expected.dequantizationOnActivations,
+            testValues.expected.weights,
+            testValues.expected.fakeQuantizeOnWeights,
+            {},
+            testValues.expected.dequantizationOnWeights,
+            testValues.expected.dequantizationAfter);
+    }
+
+    static std::string getTestCaseName(testing::TestParamInfo<ConvolutionQDqTransformationParams> obj) {
+        auto inputShape = std::get<0>(obj.param);
+        ConvolutionQDqTransformationTestValues testValues = std::get<1>(obj.param);
+
+        std::ostringstream result;
+        result << toString(testValues.params) << "_" <<
+            inputShape << "_" <<
+            testValues.actual.precisionBeforeDequantization << "_" <<
+            testValues.actual.dequantizationOnActivations << "_" << "_weights_" <<
+            testValues.actual.weights.outPrecision << "_" << "{ " <<
+            testValues.actual.weights.values[0] << " }_" <<
+            testValues.actual.fakeQuantizeOnWeights << "_" <<
+            testValues.actual.dequantizationOnWeights;
+        return result.str();
+    }
+};
+
+TEST_P(ConvolutionQDqTransformation, CompareFunctions) {
+    actualFunction->validate_nodes_and_infer_types();
+    auto res = compare_functions(referenceFunction, actualFunction, true, true, true);
+    ASSERT_TRUE(res.first) << res.second;
+}
+
+const std::vector<ngraph::Shape> shapes = {
+    ngraph::Shape({ 1, 3, 72, 48 }),
+    ngraph::Shape({ 4, 3, 72, 48 })
+};
+
+const std::vector<ConvolutionQDqTransformationTestValues> testValues = {
+    // Actual:
+    //                        Constant
+    //                         |FP32  Constant Constant Constant Constant
+    //                         |      /FP32    /FP32    /FP32    /FP32
+    // Parameter   Constant   FakeQuantize  Constant
+    //  |U8         |U8        |I8          /I8
+    //  |           |          |           /
+    // Convert    Convert     Convert  Convert
+    //   \FP32    /FP32        |FP32   /FP32
+    //    \      /             |      /
+    //    Subtract  Constant  Subtract  Constant
+    //      \FP32   /FP32      |FP32   /FP32
+    //       \     /           |      /
+    //       Multiply         Multiply
+    //         \FP32         /FP32
+    //          \           /
+    //           Convolution
+    //
+    // Transformed:
+    //
+    // Parameter  Constant
+    //   \U8      /U8
+    //    \      /
+    //    Subtract   Constant
+    //      \FP32    /I8
+    //       \      /
+    //       Convolution  Constant
+    //         \FP32      /FP32
+    //          \        /
+    //           Multiply
+    {
+        LayerTransformation::createParamsU8I8().setSupportAsymmetricQuantization(true),
+        // ActualValues
+        {
+            ngraph::element::u8,
+            {
+                {ngraph::element::f32},
+                { {127.f}, element::f32, {}, false, 1ul, element::u8, true },
+                { {0.02f}, element::f32, {}, false }
+            },
+            {
+                { ngraph::element::f32, false },
+                { {127.f}, element::f32, {}, false, 1ul, element::i8, true },
+                { {0.03f}, element::f32, {}, false }
+            },
+            { std::vector<float>{ 1.f }, ngraph::element::f32},
+            { 255ul, Shape({ 1, 1, 1, 1 }), { -1.28f }, { 1.27f }, { -128.f }, { 127.f }, element::i8 },
+            ngraph::element::f32,
+            {}
+        },
+        // ExpectedValues
+        {
+            ngraph::element::u8,
+            {
+                {},
+                { { 127.f }, ngraph::element::f32, { 1, 3, 1, 1 }, false },
+                {}
+            },
+            {
+                {},
+                { { 127.f }, ngraph::element::f32, { 6, 1, 1, 1 }, false, 1ul, element::i8, false, { "DISABLED_CONSTANT_FOLDING" } },
+                {}
+            },
+            { std::vector<float>{ 100.f }, ngraph::element::i8},
+            {},
+            ngraph::element::f32,
+            {{}, {}, {{ 0.0006f }, ngraph::element::f32, {1}}}
+        }
+    },
+
+    // Actual:
+    //
+    // Parameter   Constant
+    //  |U8         |U8
+    //  |           |
+    // Convert    Convert
+    //   \FP32    /FP32
+    //    \      /
+    //    Subtract  Constant  Constant
+    //      \FP32   /FP32      |FP32  Constant Constant Constant Constant
+    //       \     /           |      /FP32    /FP32    /FP32    /FP32
+    //       Multiply      FakeQuantize
+    //         \FP32       /FP32
+    //          \         /
+    //          Convolution
+    //
+    // Transformed:
+    //
+    // Parameter  Constant
+    //   \U8      /U8
+    //    \      /
+    //    Subtract   Constant
+    //      \FP32    /I8
+    //       \      /
+    //       Convolution  Constant
+    //         \FP32      /FP32
+    //          \        /
+    //           Multiply
+    {
+        LayerTransformation::createParamsU8I8().setSupportAsymmetricQuantization(true),
+        // ActualValues
+        {
+            ngraph::element::u8,
+            {{ngraph::element::f32}, { {127.f}, element::f32, {}, false, 1ul, element::u8, true }, { 0.02f }},
+            {},
+            { std::vector<float>{ 2.f }, ngraph::element::f32},
+            { 255ul, Shape({ 1, 1, 1, 1 }), { 0.f }, { 254.f }, { -1.27f }, { 1.27f } },
+            ngraph::element::f32,
+            {}
+        },
+        // ExpectedValues
+        {
+            ngraph::element::u8,
+            {{}, { { 127.f }, ngraph::element::f32, { 1, 3, 1, 1 }, false }, {}},
+            {},
+            { std::vector<float>{ -125.f }, ngraph::element::i8},
+            {},
+            ngraph::element::f32,
+            {{}, {}, {{ 0.0002f }, ngraph::element::f32, { 1, 1, 1 }}}
+        }
+    },
+
+    // Actual & Transformed:
+    //
+    // Parameter   Constant   Constant Constant
+    //  |U8         |U8        |FP32    |I8
+    //  |           |          |        |
+    // Convert    Convert     Convert  Convert
+    //   \FP32    /FP32        |FP32   /FP32
+    //    \      /             |      /
+    //    Subtract  Constant  Subtract  Constant
+    //      \FP32   /FP32      |FP32   /FP32
+    //       \     /           |      /
+    //       Multiply         Multiply
+    //         \FP32         /FP32
+    //          \           /
+    //           Convolution
+    {
+        LayerTransformation::createParamsU8I8().setSupportAsymmetricQuantization(true),
+        // ActualValues
+        {
+            ngraph::element::u8,
+            {{ngraph::element::f32}, { {127.f}, element::f32, {}, false, 1ul, element::u8, true }, { 0.02f }},
+            {{ngraph::element::f32}, { {127.f}, element::f32, {}, false, 1ul, element::i8, true }, { 0.03f }},
+            { std::vector<float>{ 2.f }, ngraph::element::f32},
+            {},
+            ngraph::element::f32,
+            {}
+        },
+        // ExpectedValues
+        {
+            ngraph::element::u8,
+            {{ngraph::element::f32}, { {127.f}, element::f32, {}, false, 1ul, element::u8, true }, { 0.02f }},
+            {{ngraph::element::f32}, { {127.f}, element::f32, {}, false, 1ul, element::i8, true }, { 0.03f }},
+            { std::vector<float>{ 2.f }, ngraph::element::f32},
+            {},
+            ngraph::element::f32,
+            {}
+        }
+    },
+
+    // Actual:
+    //
+    // Parameter   Constant   Constant Constant
+    //  |U8         |U8        |I8      |I8
+    //  |           |          |        |
+    // Convert    Convert     Convert  Convert
+    //   \FP32    /FP32        |FP32   /FP32
+    //    \      /             |      /
+    //    Subtract  Constant  Subtract  Constant
+    //      \FP32   /FP32      |FP32   /FP32
+    //       \     /           |      /
+    //       Multiply         Multiply
+    //         \FP32         /FP32
+    //          \           /
+    //           Convolution
+    //
+    // Transformed:
+    //
+    // Parameter  Constant  Constant  Constant
+    //   \U8      /U8       |I8      /I8
+    //    \      /          |       /
+    //    Subtract         Subtract
+    //      \FP32         /FP32
+    //       \           /
+    //        Convolution  Constant
+    //         \FP32      /FP32
+    //          \        /
+    //           Multiply
+    {
+        LayerTransformation::createParamsU8I8().setSupportAsymmetricQuantization(true),
+        // ActualValues
+        {
+            ngraph::element::u8,
+            {
+                { ngraph::element::f32, false },
+                { {127.f}, element::f32, {}, false, 1ul, element::u8, true },
+                { {0.02f}, element::f32, {}, false }
+            },
+            {
+                { ngraph::element::f32, false },
+                { {127.f}, element::f32, {}, false, 1ul, element::i8, true },
+                { {0.03f}, element::f32, {}, false }
+            },
+            { std::vector<float>{ 2.f }, ngraph::element::i8},
+            {},
+            ngraph::element::f32,
+            {}
+        },
+        // ExpectedValues
+        {
+            ngraph::element::u8,
+            {
+                {},
+                { { 127.f }, ngraph::element::f32, { 1, 3, 1, 1 }, false },
+                {}
+            },
+            {
+                {},
+                { { 127.f }, ngraph::element::f32, { 6, 1, 1, 1 }, false, 1ul, element::i8, false, { "DISABLED_CONSTANT_FOLDING" } },
+                {}
+            },
+            { std::vector<float>{ 2.f }, ngraph::element::i8},
+            {},
+            ngraph::element::f32,
+            {{}, {}, {{ 0.0006f }, ngraph::element::f32, { 1 }}}
+        }
+    },
+
+    // Actual:
+    //
+    // Parameter   Constant   Constant
+    //  |U8         |U8        |I8
+    //  |           |          |
+    // Convert    Convert     Convert  Constant
+    //   \FP32    /FP32        |FP32   /FP32
+    //    \      /             |      /
+    //    Subtract  Constant  Subtract  Constant
+    //      \FP32   /FP32      |FP32   /FP32
+    //       \     /           |      /
+    //       Multiply         Multiply
+    //         \FP32         /FP32
+    //          \           /
+    //           Convolution
+    //
+    // Transformed:
+    //
+    // Parameter  Constant  Constant  Constant
+    //   \U8      /U8       |I8      /I8
+    //    \      /          |       /
+    //    Subtract         Subtract
+    //      \FP32         /FP32
+    //       \           /
+    //        Convolution  Constant
+    //         \FP32      /FP32
+    //          \        /
+    //           Multiply
+    {
+        LayerTransformation::createParamsU8I8().setSupportAsymmetricQuantization(true),
+        // ActualValues
+        {
+            ngraph::element::u8,
+            {
+                { ngraph::element::f32, false },
+                { {127.f}, element::f32, {}, false, 1ul, element::u8, true },
+                { {0.02f}, element::f32, {}, false }
+            },
+            {
+                { ngraph::element::f32, false },
+                { {127.f}, element::f32, {}, false },
+                { {0.03f}, element::f32, {}, false }
+            },
+            { std::vector<float>{ 2.f }, ngraph::element::i8},
+            {},
+            ngraph::element::f32,
+            {}
+        },
+        // ExpectedValues
+        {
+            ngraph::element::u8,
+            {
+                {},
+                { { 127.f }, ngraph::element::f32, { 1, 3, 1, 1 }, false },
+                {}
+            },
+            {
+                {},
+                { { 127.f }, ngraph::element::f32, { 6, 1, 1, 1 }, false, 1ul, element::i8, false, { "DISABLED_CONSTANT_FOLDING" } },
+                {}
+            },
+            { std::vector<float>{ 2.f }, ngraph::element::i8},
+            {},
+            ngraph::element::f32,
+            {{}, {}, {{ 0.0006f }, ngraph::element::f32, { 1 }}}
+        }
+    }
+};
+
+INSTANTIATE_TEST_CASE_P(
+    smoke_LPT,
+    ConvolutionQDqTransformation,
+    ::testing::Combine(
+        ::testing::ValuesIn(shapes),
+        ::testing::ValuesIn(testValues)),
+    ConvolutionQDqTransformation::getTestCaseName);

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/convolution_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/convolution_transformation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -27,7 +27,7 @@ public:
     class Actual {
     public:
         ngraph::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ngraph::builder::subgraph::DequantizationOperations dequantizationOnActivations;
         std::shared_ptr<ngraph::opset1::Constant> weights;
         builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
     };
@@ -61,7 +61,7 @@ public:
         actualFunction = ngraph::builder::subgraph::ConvolutionFunction::getOriginal(
             testValues.actual.precisionBeforeDequantization,
             inputShape,
-            testValues.actual.dequantization,
+            testValues.actual.dequantizationOnActivations,
             testValues.actual.weights,
             testValues.actual.fakeQuantizeOnWeights);
 
@@ -70,14 +70,14 @@ public:
         transform.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::ConvolutionFunction::getReference(
-                testValues.expected.precisionBeforeDequantization,
-                inputShape,
-                testValues.expected.dequantizationBefore,
-                testValues.expected.weights,
-                testValues.expected.fakeQuantizeOnWeights,
-                testValues.expected.precisionAfterOperation,
-                testValues.expected.dequantizationAfter,
-                testValues.expected.precisionAfterDequantization);
+            testValues.expected.precisionBeforeDequantization,
+            inputShape,
+            testValues.expected.dequantizationBefore,
+            testValues.expected.weights,
+            testValues.expected.fakeQuantizeOnWeights,
+            testValues.expected.precisionAfterOperation,
+            testValues.expected.dequantizationAfter,
+            testValues.expected.precisionAfterDequantization);
     }
 
     static std::string getTestCaseName(testing::TestParamInfo<ConvolutionTransformationParams> obj) {
@@ -88,7 +88,7 @@ public:
         result << toString(testValues.params) << "_" <<
             inputShape << "_" <<
             testValues.actual.precisionBeforeDequantization << "_" <<
-            testValues.actual.dequantization << "_" << "_weights_" <<
+            testValues.actual.dequantizationOnActivations << "_" << "_weights_" <<
             testValues.actual.weights->get_element_type() << "_" << "{ " <<
             testValues.actual.weights->cast_vector<float>()[0] << " }_" <<
             testValues.actual.fakeQuantizeOnWeights << "_";

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/convolution_with_incorrect_weights.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/convolution_with_incorrect_weights.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -10,7 +10,7 @@
 
 #include <transformations/init_node_info.hpp>
 #include <low_precision/convolution.hpp>
-#include <low_precision/fake_quantize.hpp>
+#include <low_precision/fake_quantize_decomposition.hpp>
 
 #include "common_test_utils/ngraph_test_utils.hpp"
 #include "lpt_ngraph_functions/common/dequantization_operations.hpp"
@@ -62,7 +62,7 @@ public:
 
         SimpleLowPrecisionTransformer transform;
         transform.add<ngraph::pass::low_precision::ConvolutionTransformation, ngraph::opset1::Convolution>(testValues.params);
-        transform.add<ngraph::pass::low_precision::FakeQuantizeTransformation, ngraph::opset1::FakeQuantize>(testValues.params);
+        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ngraph::opset1::FakeQuantize>(testValues.params);
         transform.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::ConvolutionFunction::getReferenceWithIncorrectWeights(

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/depth_to_space_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/depth_to_space_transformation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -114,6 +114,31 @@ const std::vector<DepthToSpaceTransformationTestValues> testValues = {
             {{}, {}, {}},
             ngraph::element::u8,
             {{ngraph::element::f32}, {0.32f}, {0.45f}}
+        }
+    },
+    // blockSize = 2
+    {
+        ngraph::Shape{ 1, 4, 3, 3 },
+        DepthToSpace::DepthToSpaceMode::BLOCKS_FIRST,
+        2,
+        LayerTransformation::createParamsU8I8(),
+        {
+            ngraph::element::u8,
+            {
+                {ngraph::element::f32},
+                {{0.32f}, ngraph::element::f32, {}, false, 1, ngraph::element::u8, true},
+                {0.45f}
+            }
+        },
+        {
+            ngraph::element::u8,
+            {{}, {}, {}},
+            ngraph::element::u8,
+            {
+                {ngraph::element::f32},
+                {{0.32f}, ngraph::element::f32, {}, false, 1, ngraph::element::u8, true},
+                {0.45f}
+            }
         }
     },
     // blockSize = 3

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/disable_convert_on_const_path_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/disable_convert_on_const_path_transformation.cpp
@@ -1,0 +1,171 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "layer_transformation.hpp"
+
+#include <string>
+#include <sstream>
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include <low_precision/disable_convert_constant_folding_on_const_path.hpp>
+
+#include <transformations/utils/utils.hpp>
+#include <transformations/init_node_info.hpp>
+#include <low_precision/convolution.hpp>
+
+#include "common_test_utils/ngraph_test_utils.hpp"
+#include "simple_low_precision_transformer.hpp"
+#include "lpt_ngraph_functions/fake_quantize_and_convolution_function.hpp"
+
+using namespace testing;
+using namespace ngraph;
+using namespace ngraph::pass;
+
+class DisableConvertOnConstPathTransformationValues {
+public:
+    class Values {
+    public:
+        ngraph::element::Type precisionBeforeDequantization;
+        ngraph::builder::subgraph::DequantizationOperations dequantizationOnActivations;
+        ngraph::builder::subgraph::DequantizationOperations dequantizationOnWeights;
+        ngraph::builder::subgraph::Constant weights;
+        builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
+        ngraph::element::Type precisionAfterOperation;
+        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+    };
+
+    Values actual;
+    Values expected;
+};
+
+typedef std::tuple<
+    ngraph::Shape,
+    DisableConvertOnConstPathTransformationValues> DisableConvertOnConstPathTransformationParams;
+
+class DisableConvertOnConstPathTransformation : public LayerTransformation, public testing::WithParamInterface<DisableConvertOnConstPathTransformationParams> {
+public:
+    void SetUp() override {
+        const auto inputShape = std::get<0>(GetParam());
+        const auto testValues = std::get<1>(GetParam());
+
+        actualFunction = ngraph::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
+            testValues.actual.precisionBeforeDequantization,
+            inputShape,
+            {},
+            {},
+            testValues.actual.dequantizationOnActivations,
+            testValues.actual.weights,
+            testValues.actual.fakeQuantizeOnWeights,
+            {},
+            testValues.actual.dequantizationOnWeights,
+            testValues.actual.dequantizationAfter);
+
+        ngraph::pass::Manager manager;
+        manager.register_pass<ngraph::pass::DisableConvertConstantFoldingOnConstPath>();
+        manager.run_passes(actualFunction);
+
+        referenceFunction = ngraph::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
+            testValues.actual.precisionBeforeDequantization,
+            inputShape,
+            {},
+            {},
+            testValues.expected.dequantizationOnActivations,
+            testValues.expected.weights,
+            testValues.expected.fakeQuantizeOnWeights,
+            {},
+            testValues.expected.dequantizationOnWeights,
+            testValues.expected.dequantizationAfter);
+    }
+
+    static std::string getTestCaseName(testing::TestParamInfo<DisableConvertOnConstPathTransformationParams> obj) {
+        auto inputShape = std::get<0>(obj.param);
+        DisableConvertOnConstPathTransformationValues testValues = std::get<1>(obj.param);
+
+        std::ostringstream result;
+        result <<
+            inputShape << "_" <<
+            testValues.actual.precisionBeforeDequantization << "_" <<
+            testValues.actual.dequantizationOnActivations << "_" << "_weights_" <<
+            testValues.actual.weights.outPrecision << "_" << "{ " <<
+            testValues.actual.weights.values[0] << " }_" <<
+            testValues.actual.fakeQuantizeOnWeights << "_";
+        return result.str();
+    }
+};
+
+TEST_P(DisableConvertOnConstPathTransformation, CompareFunctions) {
+    actualFunction->validate_nodes_and_infer_types();
+    auto res = compare_functions(referenceFunction, actualFunction, true, true, true);
+    ASSERT_TRUE(res.first) << res.second;
+}
+
+const std::vector<ngraph::Shape> shapes = { ngraph::Shape({ 1, 3, 72, 48 }) };
+
+const std::vector<DisableConvertOnConstPathTransformationValues> testValues = {
+    // Actual & Transformed:
+    //                          Constant
+    //                           |FP32  Constant Constant Constant Constant
+    //                           |      /FP32    /FP32    /FP32    /FP32
+    // Parameter   Constant     FakeQuantize
+    //  |U8         |U8          |I8
+    //  |           |            |
+    // Convert    Convert       Convert  Constant
+    //   \FP32    /FP32          |FP32   /I8
+    //    \      /               |      /
+    //    Subtract  Constant    Subtract  Constant
+    //      \FP32   /FP32        |FP32   /FP32
+    //       \     /             |      /
+    //       Multiply           Multiply
+    //         \FP32           /FP32
+    //          \             /
+    //            Convolution
+    {
+        // ActualValues
+        {
+            ngraph::element::u8,
+            {
+                {ngraph::element::f32},
+                { {128.f}, element::f32, {}, false, 1ul, element::u8, true },
+                { {0.02f}, element::f32, {}, false }
+            },
+            {
+                { ngraph::element::f32, false },
+                { {128.f}, element::f32, {}, false, 1ul, element::i8, true },
+                { {0.03f}, element::f32, {}, false }
+            },
+            { std::vector<float>{ 1.f }, ngraph::element::f32},
+            { 255ul, Shape({ 1, 1, 1, 1 }), { -1.28f }, { 1.27f }, { -128.f }, { 127.f }, element::i8 },
+            ngraph::element::f32,
+            {}
+        },
+        // ExpectedValues
+        {
+            ngraph::element::u8,
+            {
+                {ngraph::element::f32},
+                { {128.f}, element::f32, {}, false, 1ul, element::u8, true, {}, { "DISABLED_CONSTANT_FOLDING" } },
+                { {0.02f}, element::f32, {}, false }
+            },
+            {
+                { ngraph::element::f32, false },
+                { {128.f}, element::f32, {}, false, 1ul, element::i8, true, {}, { "DISABLED_CONSTANT_FOLDING" } },
+                { {0.03f}, element::f32, {}, false }
+            },
+            { std::vector<float>{ 1.f }, ngraph::element::f32},
+            { 255ul, Shape({ 1, 1, 1, 1 }), { -1.28f }, { 1.27f }, { -128.f }, { 127.f }, element::i8 },
+            ngraph::element::f32,
+            {}
+        }
+    }
+};
+
+INSTANTIATE_TEST_CASE_P(
+    smoke_LPT,
+    DisableConvertOnConstPathTransformation,
+    ::testing::Combine(
+        ::testing::ValuesIn(shapes),
+        ::testing::ValuesIn(testValues)),
+    DisableConvertOnConstPathTransformation::getTestCaseName);

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/fake_quantize_and_two_output_branches_with_convolution.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/fake_quantize_and_two_output_branches_with_convolution.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -12,7 +12,7 @@
 #include <gtest/gtest.h>
 
 #include <low_precision/convolution.hpp>
-#include <low_precision/fake_quantize.hpp>
+#include <low_precision/fake_quantize_decomposition.hpp>
 
 #include "common_test_utils/ngraph_test_utils.hpp"
 
@@ -75,7 +75,7 @@ public:
             testValues.actual.fqOnWeights2);
 
         SimpleLowPrecisionTransformer transform;
-        transform.add<ngraph::pass::low_precision::FakeQuantizeTransformation, ngraph::opset1::FakeQuantize>(testValues.params);
+        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ngraph::opset1::FakeQuantize>(testValues.params);
         transform.add<ngraph::pass::low_precision::ConvolutionTransformation, ngraph::opset1::Convolution>(testValues.params);
         transform.transform(actualFunction);
 

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/fake_quantize_on_weights_with_unsupported_child.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/fake_quantize_on_weights_with_unsupported_child.cpp
@@ -11,7 +11,7 @@
 #include <gtest/gtest.h>
 
 #include <transformations/utils/utils.hpp>
-#include <low_precision/fake_quantize.hpp>
+#include <low_precision/fake_quantize_decomposition.hpp>
 
 #include "common_test_utils/ngraph_test_utils.hpp"
 #include "simple_low_precision_transformer.hpp"
@@ -60,7 +60,7 @@ public:
             testValues.actual.fakeQuantizeOnWeights);
 
         SimpleLowPrecisionTransformer transform;
-        transform.add<ngraph::pass::low_precision::FakeQuantizeTransformation, ngraph::opset1::FakeQuantize>(testValues.params);
+        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ngraph::opset1::FakeQuantize>(testValues.params);
         transform.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::FakeQuantizeOnWeightsAndUnsupportedChildFunction::get(

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/fake_quantize_precision_selection_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/fake_quantize_precision_selection_transformation.cpp
@@ -1,20 +1,18 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
 #include "layer_transformation.hpp"
 
-#include <map>
-#include <memory>
-#include <sstream>
+#include <ostream>
 #include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 
-#include <ngraph/pass/visualize_tree.hpp>
 #include <low_precision/prelu.hpp>
 #include <low_precision/convolution.hpp>
-#include <low_precision/fake_quantize.hpp>
+#include <low_precision/fake_quantize_decomposition.hpp>
 #include <low_precision/max_pool.hpp>
 
 #include "common_test_utils/ngraph_test_utils.hpp"
@@ -93,7 +91,7 @@ public:
         SimpleLowPrecisionTransformer transform;
         transform.add<ngraph::pass::low_precision::PReluTransformation, ngraph::opset1::AvgPool>(params);
         transform.add<ngraph::pass::low_precision::ConvolutionTransformation, ngraph::opset1::Convolution>(precisionLimitedOperationParams);
-        transform.add<ngraph::pass::low_precision::FakeQuantizeTransformation, ngraph::opset1::FakeQuantize>(params);
+        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ngraph::opset1::FakeQuantize>(params);
         transform.add<ngraph::pass::low_precision::MaxPoolTransformation, ngraph::opset1::MaxPool>(params);
         transform.transform(actualFunction);
 

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/fake_quantize_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/fake_quantize_transformation.cpp
@@ -1,18 +1,17 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
 #include "layer_transformation.hpp"
 
-#include <map>
 #include <memory>
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 
-#include <ngraph/pass/visualize_tree.hpp>
-#include <low_precision/fake_quantize.hpp>
+#include <low_precision/fake_quantize_decomposition.hpp>
 
 #include "common_test_utils/ngraph_test_utils.hpp"
 
@@ -75,7 +74,7 @@ public:
             fakeQuantizeOnData.actual);
 
         SimpleLowPrecisionTransformer transform;
-        transform.add<ngraph::pass::low_precision::FakeQuantizeTransformation, ngraph::opset1::FakeQuantize>(params);
+        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ngraph::opset1::FakeQuantize>(params);
         transform.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::FakeQuantizeFunction::getReference(

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/fake_quantize_with_dq_not_optimal_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/fake_quantize_with_dq_not_optimal_transformation.cpp
@@ -1,0 +1,216 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "layer_transformation.hpp"
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <low_precision/convolution.hpp>
+#include <low_precision/fake_quantize_decomposition.hpp>
+
+#include "common_test_utils/ngraph_test_utils.hpp"
+#include "simple_low_precision_transformer.hpp"
+
+#include "lpt_ngraph_functions/fake_quantize_and_convolution_function.hpp"
+#include "lpt_ngraph_functions/common/dequantization_operations.hpp"
+#include "lpt_ngraph_functions/common/constant.hpp"
+#include "lpt_ngraph_functions/common/fake_quantize_on_data.hpp"
+#include "lpt_ngraph_functions/common/fake_quantize_on_weights.hpp"
+
+using namespace testing;
+using namespace ngraph;
+using namespace ngraph::pass;
+
+class FakeQuantizeWithNotOptimalTransformationTestValues {
+public:
+    class Values {
+    public:
+        builder::subgraph::FakeQuantizeOnDataWithConstant fqOnData;
+        builder::subgraph::DequantizationOperations::Convert convertOnData;
+        builder::subgraph::DequantizationOperations dequantizationOnData;
+        builder::subgraph::Constant constantOnWeights;
+        builder::subgraph::FakeQuantizeOnWeights fqOnWeights;
+        builder::subgraph::DequantizationOperations dequantizationOnWeights;
+        builder::subgraph::DequantizationOperations dequantizationAfter;
+    };
+    low_precision::LayerTransformation::Params params;
+    Values actual;
+    Values expected;
+};
+
+inline std::ostream& operator<<(std::ostream& out, const FakeQuantizeWithNotOptimalTransformationTestValues& testValue) {
+    return out << "_" <<
+        testValue.actual.fqOnData << "_" << testValue.actual.fqOnWeights <<
+        testValue.expected.fqOnData << "_" << testValue.expected.fqOnWeights;
+}
+
+typedef std::tuple<
+    ngraph::element::Type,
+    ngraph::Shape,
+    bool,
+    FakeQuantizeWithNotOptimalTransformationTestValues> FakeQuantizeWithNotOptimalTransformationParams;
+
+class FakeQuantizeWithNotOptimalTransformation :
+    public LayerTransformation,
+    public testing::WithParamInterface<FakeQuantizeWithNotOptimalTransformationParams> {
+public:
+    void SetUp() override {
+        const ngraph::element::Type precision = std::get<0>(GetParam());
+        const ngraph::Shape shape = std::get<1>(GetParam());
+        const bool updatePrecision = std::get<2>(GetParam());
+        const FakeQuantizeWithNotOptimalTransformationTestValues testValues = std::get<3>(GetParam());
+
+        const low_precision::LayerTransformation::Params params = low_precision::LayerTransformation::Params(testValues.params).
+            setUpdatePrecisions(updatePrecision);
+
+        actualFunction = ngraph::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
+            precision,
+            shape,
+            testValues.actual.fqOnData,
+            testValues.actual.convertOnData,
+            testValues.actual.dequantizationOnData,
+            testValues.actual.constantOnWeights,
+            testValues.actual.fqOnWeights,
+            {},
+            testValues.actual.dequantizationOnWeights,
+            testValues.actual.dequantizationAfter);
+
+        SimpleLowPrecisionTransformer transformer;
+        transformer.add<ngraph::pass::low_precision::ConvolutionTransformation, ngraph::opset1::Convolution>(
+            low_precision::LayerTransformation::Params(params).setPrecisionsOnActivations({ element::u8 }));
+        transformer.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ngraph::opset1::FakeQuantize>(params);
+        transformer.transform(actualFunction);
+
+        referenceFunction = ngraph::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
+            precision,
+            shape,
+            testValues.expected.fqOnData,
+            {},
+            testValues.expected.dequantizationOnData,
+            testValues.expected.constantOnWeights,
+            testValues.expected.fqOnWeights,
+            {},
+            testValues.expected.dequantizationOnWeights,
+            testValues.expected.dequantizationAfter);
+    }
+
+    static std::string getTestCaseName(testing::TestParamInfo<FakeQuantizeWithNotOptimalTransformationParams> obj) {
+        ngraph::element::Type precision;
+        ngraph::Shape shape;
+        bool updatePrecision;
+        FakeQuantizeWithNotOptimalTransformationTestValues fakeQuantizeOnData;
+        std::tie(precision, shape, updatePrecision, fakeQuantizeOnData) = obj.param;
+
+        std::ostringstream result;
+        result << LayerTransformation::getTestCaseNameByParams(precision, shape, fakeQuantizeOnData.params) <<
+            (updatePrecision ? "" : "_notUpdatePrecision_") <<
+            fakeQuantizeOnData;
+        return result.str();
+    }
+};
+
+TEST_P(FakeQuantizeWithNotOptimalTransformation, CompareFunctions) {
+    actualFunction->validate_nodes_and_infer_types();
+    auto res = compare_functions(referenceFunction, actualFunction, true, true, true);
+    ASSERT_TRUE(res.first) << res.second;
+}
+
+const std::vector<ngraph::element::Type> precisions = {
+    ngraph::element::f32,
+    //ngraph::element::i32,
+    //ngraph::element::f16
+};
+
+const std::vector<bool> updatePrecisions = { true/*, false*/ };
+
+const std::vector<FakeQuantizeWithNotOptimalTransformationTestValues> fakeQuantizeTransformationTestValues = {
+    // Actual:
+    //
+    // FakeQuantize
+    //  |FP32
+    //  |
+    // Convert   Constant
+    //  |I8         |I8
+    //  |           |
+    // Convert    Convert
+    //   \FP32    /FP32
+    //    \      /
+    //    Subtract  Constant  Constant
+    //      \FP32   /FP32      |FP32   Constant Constant Constant Constant
+    //       \     /           |       /FP32    /FP32    /FP32    /FP32
+    //       Multiply         FakeQuantize
+    //         \FP32         /FP32
+    //          \           /
+    //           Convolution
+    //
+    // Transformed:
+    //
+    // FakeQuantize  Constant
+    //   \U8        /U8
+    //    \        /
+    //     Subtract   Constant
+    //      \FP32    /I8
+    //       \      /
+    //       Convolution  Constant
+    //         \FP32      /FP32
+    //          \        /
+    //           Multiply
+    {
+        LayerTransformation::createParamsU8I8AndI8(),
+        {
+            { 256ul, {{ 1, 1, 1, 1 }}, { 0.f }, { 2.55f }, { -128.f }, { 127.f }, ngraph::element::i8 },
+            { ngraph::element::i8, false },
+            {
+                { ngraph::element::f32, false },
+                { {-128.f}, ngraph::element::f32, {}, false, 1ul, ngraph::element::i8, true },
+                { {0.01f}, ngraph::element::f32, {}, false }
+            },
+            {{5.f}, ngraph::element::i8},
+            {},
+            {
+                { ngraph::element::f32, false },
+                { {127.f}, ngraph::element::f32, {}, false, 1ul, ngraph::element::i8, true },
+                { {0.03f}, ngraph::element::f32, {}, false }
+            },
+            {}
+        },
+        {
+            { 256ul, {{ 1, 1, 1, 1 }, { 1, 1, 1, 1 }, {}, {}}, { 0.f }, { 2.55f }, { 0.f }, { 255.f }, ngraph::element::u8 },
+            { ngraph::element::u8, false },
+            {},
+            {{5.f}, ngraph::element::i8},
+            {},
+            {
+                {},
+                { std::vector<float>(64, 127.f), ngraph::element::f32, {64, 1, 1, 1}, false, 1ul, ngraph::element::i8, false, {"DISABLED_CONSTANT_FOLDING"}},
+                {}
+            },
+            {
+                { },
+                { },
+                { {0.0003f}, ngraph::element::f32, {1}}
+            }
+        },
+    }
+};
+
+const std::vector<ngraph::Shape> shapes = {
+    { 1, 32, 72, 48 },
+    // TODO: 3D tensor
+};
+
+INSTANTIATE_TEST_CASE_P(
+    smoke_LPT,
+    FakeQuantizeWithNotOptimalTransformation,
+    ::testing::Combine(
+        ::testing::ValuesIn(precisions),
+        ::testing::ValuesIn(shapes),
+        ::testing::ValuesIn(updatePrecisions),
+        ::testing::ValuesIn(fakeQuantizeTransformationTestValues)),
+    FakeQuantizeWithNotOptimalTransformation::getTestCaseName);

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/fake_quantize_with_dynamic_intervals_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/fake_quantize_with_dynamic_intervals_transformation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -6,12 +6,10 @@
 
 #include <map>
 #include <memory>
-#include <sstream>
 #include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
-
-#include <ngraph/pass/visualize_tree.hpp>
 #include <low_precision/fake_quantize.hpp>
 
 #include "common_test_utils/ngraph_test_utils.hpp"

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/fold_convert_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/fold_convert_transformation.cpp
@@ -1,0 +1,131 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "layer_transformation.hpp"
+
+#include <string>
+#include <sstream>
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include <utility>
+#include <transformations/utils/utils.hpp>
+#include <transformations/init_node_info.hpp>
+
+#include "common_test_utils/ngraph_test_utils.hpp"
+#include "simple_low_precision_transformer.hpp"
+
+#include <low_precision/fold_convert.hpp>
+#include "lpt_ngraph_functions/common/builders.hpp"
+#include "lpt_ngraph_functions/common/dequantization_operations.hpp"
+
+using namespace testing;
+using namespace ngraph::pass;
+using namespace ngraph::builder::subgraph;
+
+class FoldConvertTransformationTestValues {
+public:
+    ngraph::pass::low_precision::LayerTransformation::Params params;
+    ngraph::element::Type precision;
+    ngraph::Shape inputShape;
+    ngraph::builder::subgraph::DequantizationOperations dequantizationActual;
+    ngraph::builder::subgraph::DequantizationOperations dequantizationExpected;
+};
+
+class FoldConvertTransformation : public LayerTransformation, public testing::WithParamInterface<FoldConvertTransformationTestValues> {
+public:
+    void SetUp() override {
+        const FoldConvertTransformationTestValues testValues = GetParam();
+
+        const auto createFunction = [](
+            const ngraph::element::Type precision,
+            const ngraph::Shape& inputShape,
+            const ngraph::builder::subgraph::DequantizationOperations& dequantization) -> std::shared_ptr<ngraph::Function> {
+            auto input = std::make_shared<ngraph::opset1::Parameter>(precision, inputShape);
+            std::shared_ptr<ngraph::Node> output = makeDequantization(input, dequantization);
+            output->set_friendly_name("output");
+
+            return std::make_shared<ngraph::Function>(
+                ngraph::ResultVector{ std::make_shared<ngraph::opset1::Result>(output) },
+                ngraph::ParameterVector{ input },
+                "FoldConvertTransformation");
+        };
+        actualFunction = createFunction(testValues.precision, testValues.inputShape, testValues.dequantizationActual);
+
+        SimpleLowPrecisionTransformer transform;
+        transform.add<ngraph::pass::low_precision::FoldConvertTransformation, ngraph::opset1::Add>(
+            low_precision::LayerTransformation::Params(testValues.params));
+        transform.transform(actualFunction);
+
+        referenceFunction = createFunction(testValues.precision, testValues.inputShape, testValues.dequantizationExpected);
+    }
+
+    static std::string getTestCaseName(testing::TestParamInfo<FoldConvertTransformationTestValues> obj) {
+        const FoldConvertTransformationTestValues testValues = obj.param;
+
+        std::ostringstream result;
+        result <<
+            testValues.precision << "_" <<
+            testValues.inputShape << "_" <<
+            testValues.dequantizationActual << "_" <<
+            testValues.dequantizationExpected;
+        return result.str();
+    }
+};
+
+TEST_P(FoldConvertTransformation, CompareFunctions) {
+    actualFunction->validate_nodes_and_infer_types();
+    auto res = compare_functions(referenceFunction, actualFunction, true, true, true);
+    ASSERT_TRUE(res.first) << res.second;
+}
+
+const std::vector<FoldConvertTransformationTestValues> testValues = {
+    // Actual:
+    //
+    // Parameter Constant
+    //  |U8      |U8
+    //  |        |
+    // Convert  Convert
+    //  \FP32   /FP32
+    //   \     /
+    //  Subtract   Constant
+    //     \FP32    /FP32
+    //      \      /
+    //      Multiply
+    //
+    // Transformed:
+    //
+    // Parameter
+    //   |U8
+    //   |
+    // Convert   Constant
+    //   \FP32   /FP32
+    //    \     /
+    //   Subtract    Constant
+    //      \FP32    /FP32
+    //       \      /
+    //       Multiply
+    {
+        LayerTransformation::createParamsU8I8(),
+        ngraph::element::f32,
+        ngraph::Shape{1, 4, 16, 16},
+        {
+            {ngraph::element::f32},
+            { {7.f}, ngraph::element::f32, {}, false, 1, ngraph::element::u8, true },
+            { 10.f }
+        },
+        {
+            {ngraph::element::f32},
+            { {7.f}, ngraph::element::f32, {}, false, 1 },
+            { 10.f }
+        }
+    }
+};
+
+INSTANTIATE_TEST_CASE_P(
+    smoke_LPT,
+    FoldConvertTransformation,
+    ::testing::ValuesIn(testValues),
+    FoldConvertTransformation::getTestCaseName);

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/fold_fake_quantize_in_transformations.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/fold_fake_quantize_in_transformations.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -6,12 +6,10 @@
 
 #include <map>
 #include <memory>
-#include <sstream>
 #include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
-
-#include <ngraph/pass/visualize_tree.hpp>
 #include <low_precision/fake_quantize.hpp>
 
 #include "common_test_utils/ngraph_test_utils.hpp"

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/fuse_fake_quantize_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/fuse_fake_quantize_transformation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -14,6 +14,7 @@
 #include <transformations/init_node_info.hpp>
 #include <low_precision/transformer.hpp>
 #include <low_precision/fake_quantize.hpp>
+#include <low_precision/fake_quantize_decomposition.hpp>
 #include "lpt_ngraph_functions/common/add.hpp"
 #include "lpt_ngraph_functions/common/fake_quantize_on_data.hpp"
 #include "lpt_ngraph_functions/common/dequantization_operations.hpp"
@@ -74,6 +75,9 @@ public:
             testValues.actual.fakeQuantizeOnData);
 
         SimpleLowPrecisionTransformer transformer;
+        transformer.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ngraph::opset1::FakeQuantize>(testValues.params);
+        transformer.transform(actualFunction);
+
         transformer.add<ngraph::pass::low_precision::FakeQuantizeTransformation, ngraph::opset1::FakeQuantize>(testValues.params);
         transformer.transform(actualFunction);
 

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/get_dequantization_below_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/get_dequantization_below_transformation.cpp
@@ -1,0 +1,134 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "layer_transformation.hpp"
+
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <low_precision/fake_quantize_decomposition.hpp>
+
+#include "common_test_utils/ngraph_test_utils.hpp"
+#include "lpt_ngraph_functions/get_dequantization_function.hpp"
+#include <low_precision/common/fake_quantize_dequantization.hpp>
+#include "low_precision/network_helper.hpp"
+
+using namespace testing;
+using namespace ngraph;
+using namespace ngraph::pass;
+
+class GetDequantizationBelowTestValues {
+public:
+    builder::subgraph::FakeQuantizeOnData fakeQuantize;
+    builder::subgraph::DequantizationOperations dequantization;
+};
+
+inline std::ostream& operator<<(std::ostream& os, const std::vector<float>& values) {
+    os << "{ ";
+    for (size_t i = 0; i < values.size(); ++i) {
+        os << values[i];
+        if (i != (values.size() - 1ul)) {
+            os << ", ";
+        }
+    }
+    os << " }";
+    return os;
+}
+
+inline std::ostream& operator<<(std::ostream& out, const GetDequantizationBelowTestValues& testValue) {
+    return out << "_" << testValue.fakeQuantize << "_" << testValue.dequantization;
+}
+
+typedef std::tuple<
+    ngraph::element::Type,
+    ngraph::Shape,
+    GetDequantizationBelowTestValues> GetDequantizationBelowParams;
+
+class GetDequantizationBelowTransformation : public LayerTransformation, public testing::WithParamInterface<GetDequantizationBelowParams> {
+public:
+    void SetUp() override {
+        const ngraph::element::Type precision = std::get<0>(GetParam());
+        const ngraph::Shape shape = std::get<1>(GetParam());
+        const GetDequantizationBelowTestValues testValues = std::get<2>(GetParam());
+
+        auto const function = ngraph::builder::subgraph::GetDequantizationFunction::get(
+            precision,
+            shape,
+            testValues.fakeQuantize,
+            testValues.dequantization);
+
+        auto const fakeQuantize = function->get_parameters()[0]->output(0).get_target_inputs().begin()->get_node()->shared_from_this();
+        auto dequantization = ngraph::pass::low_precision::NetworkHelper::getDequantizationBelow(fakeQuantize);
+
+        actualFunction = ngraph::builder::subgraph::GetDequantizationFunction::get(
+            precision,
+            shape,
+            testValues.fakeQuantize,
+            dequantization);
+
+        referenceFunction = ngraph::builder::subgraph::GetDequantizationFunction::get(
+            precision,
+            shape,
+            testValues.fakeQuantize,
+            testValues.dequantization);
+    }
+
+    static std::string getTestCaseName(testing::TestParamInfo<GetDequantizationBelowParams> obj) {
+        ngraph::element::Type precision;
+        ngraph::Shape shape;
+        GetDequantizationBelowTestValues testValues;
+        std::tie(precision, shape, testValues) = obj.param;
+
+        std::ostringstream result;
+        result << precision << "_" << shape << "_" << testValues;
+        return result.str();
+    }
+};
+
+TEST_P(GetDequantizationBelowTransformation, CompareFunctions) {
+    actualFunction->validate_nodes_and_infer_types();
+    auto res = compare_functions(referenceFunction, actualFunction, true, true, true);
+    ASSERT_TRUE(res.first) << res.second;
+}
+
+const std::vector<ngraph::element::Type> precisions = {
+    ngraph::element::f32,
+};
+
+const std::vector<GetDequantizationBelowTestValues> testValues = {
+    {
+        { 256ul, {}, { 0.f }, { 2.55f }, { 0.f }, { 2.55f }, ngraph::element::u8 },
+        { ngraph::element::f32, {}, { 0.01f } }
+    },
+    {
+        { 256ul, {}, { 0.f }, { 2.55f }, { 0.f }, { 2.55f }, ngraph::element::u8 },
+        { ngraph::element::f32, { 127.f }, { 0.01f } }
+    },
+    {
+        { 256ul, {}, { 0.f }, { 2.55f }, { 0.f }, { 2.55f }, ngraph::element::u8 },
+        {
+            ngraph::element::f32,
+            {{ 127.f }, ngraph::element::f32, {}, false, 1, ngraph::element::u8, true},
+            { 0.01f }
+        }
+    }
+};
+
+const std::vector<ngraph::Shape> shapes = {
+    { 1, 32, 72, 48 },
+    // TODO: 3D tensor
+};
+
+INSTANTIATE_TEST_CASE_P(
+    smoke_LPT,
+    GetDequantizationBelowTransformation,
+    ::testing::Combine(
+        ::testing::ValuesIn(precisions),
+        ::testing::ValuesIn(shapes),
+        ::testing::ValuesIn(testValues)),
+    GetDequantizationBelowTransformation::getTestCaseName);

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/get_dequantization_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/get_dequantization_test.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -28,7 +28,7 @@ typedef std::tuple<
     // mulDataInput
     size_t> GetDequantizationTestValues;
 
-class GetDequantizationTransformation : public LayerTransformation, public testing::WithParamInterface<GetDequantizationTestValues> {
+class GetDequantizationTestTransformation : public LayerTransformation, public testing::WithParamInterface<GetDequantizationTestValues> {
 public:
     void SetUp() override {
         bool isConvert;
@@ -70,7 +70,7 @@ std::vector<size_t> subDataInput = { 0ul, 1ul };
 std::vector<size_t> mulDataInput = { 0ul, 1ul };
 
 
-TEST_P(GetDequantizationTransformation, CompareFunctions) {
+TEST_P(GetDequantizationTestTransformation, CompareFunctions) {
     InitNodeInfo().run_on_function(actualFunction);
     actualFunction->validate_nodes_and_infer_types();
 
@@ -78,11 +78,11 @@ TEST_P(GetDequantizationTransformation, CompareFunctions) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-INSTANTIATE_TEST_CASE_P(smoke_LPT, GetDequantizationTransformation,
+INSTANTIATE_TEST_CASE_P(smoke_LPT, GetDequantizationTestTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(isConvert),
         ::testing::ValuesIn(isSubtract),
         ::testing::ValuesIn(subDataInput),
         ::testing::ValuesIn(mulDataInput)),
-    GetDequantizationTransformation::getTestCaseName);
+    GetDequantizationTestTransformation::getTestCaseName);
 } // namespace

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/get_dequantization_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/get_dequantization_transformation.cpp
@@ -1,0 +1,165 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "layer_transformation.hpp"
+
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <low_precision/fake_quantize_decomposition.hpp>
+
+#include "common_test_utils/ngraph_test_utils.hpp"
+#include "lpt_ngraph_functions/get_dequantization_function.hpp"
+#include <low_precision/common/fake_quantize_dequantization.hpp>
+#include "low_precision/network_helper.hpp"
+
+using namespace testing;
+using namespace ngraph;
+using namespace ngraph::pass;
+
+class GetDequantizationTestValues {
+public:
+    builder::subgraph::FakeQuantizeOnData fakeQuantize;
+    // actual dequantization to create nGraph function to run NetworkHelper::getDequantization
+    builder::subgraph::DequantizationOperations actualDequantization;
+    builder::subgraph::DequantizationOperations expectedDequantization;
+};
+
+inline std::ostream& operator<<(std::ostream& os, const std::vector<float>& values) {
+    os << "{ ";
+    for (size_t i = 0; i < values.size(); ++i) {
+        os << values[i];
+        if (i != (values.size() - 1ul)) {
+            os << ", ";
+        }
+    }
+    os << " }";
+    return os;
+}
+
+inline std::ostream& operator<<(std::ostream& out, const GetDequantizationTestValues& testValue) {
+    return out << "_" << testValue.fakeQuantize << "_" << testValue.actualDequantization;
+}
+
+typedef std::tuple<
+    ngraph::element::Type,
+    ngraph::Shape,
+    GetDequantizationTestValues> GetDequantizationParams;
+
+class GetDequantizationTransformation : public LayerTransformation, public testing::WithParamInterface<GetDequantizationParams> {
+public:
+    void SetUp() override {
+        const ngraph::element::Type precision = std::get<0>(GetParam());
+        const ngraph::Shape shape = std::get<1>(GetParam());
+        const GetDequantizationTestValues testValues = std::get<2>(GetParam());
+
+        actualFunction = ngraph::builder::subgraph::GetDequantizationFunction::get(
+            precision,
+            shape,
+            testValues.fakeQuantize,
+            testValues.actualDequantization);
+
+        const auto output = actualFunction->get_output_op(0);
+        auto dequantization = ngraph::pass::low_precision::NetworkHelper::getDequantization(output);
+    }
+
+    static std::string getTestCaseName(testing::TestParamInfo<GetDequantizationParams> obj) {
+        ngraph::element::Type precision;
+        ngraph::Shape shape;
+        GetDequantizationTestValues testValues;
+        std::tie(precision, shape, testValues) = obj.param;
+
+        std::ostringstream result;
+        result << precision << "_" << shape << "_" << testValues;
+        return result.str();
+    }
+};
+
+TEST_P(GetDequantizationTransformation, CompareFunctions) {
+    const GetDequantizationTestValues testValues = std::get<2>(GetParam());
+
+    const auto output = actualFunction->get_output_op(0);
+    const ngraph::pass::low_precision::FakeQuantizeDequantization dequantization = ngraph::pass::low_precision::NetworkHelper::getDequantization(output);
+    ngraph::builder::subgraph::DequantizationOperations actualDequantization = toDequantizationOperations(dequantization);
+    actualDequantization.subtract.constantShapeIsDefined = testValues.expectedDequantization.subtract.constantShapeIsDefined;
+    actualDequantization.subtract.outPrecision = testValues.expectedDequantization.subtract.outPrecision;
+    actualDequantization.multiply.constantShapeIsDefined = testValues.expectedDequantization.multiply.constantShapeIsDefined;
+    actualDequantization.multiply.outPrecision = testValues.expectedDequantization.multiply.outPrecision;
+    ASSERT_TRUE(actualDequantization == testValues.expectedDequantization);
+}
+
+const std::vector<ngraph::element::Type> precisions = {
+    ngraph::element::f32,
+};
+
+const std::vector<GetDequantizationTestValues> testValues = {
+    {
+        { 256ul, {}, { 0.f }, { 2.55f }, { 0.f }, { 2.55f }, ngraph::element::u8 },
+        { ngraph::element::f32, {}, { 0.01f } },
+        { ngraph::element::f32, {}, { 0.01f } }
+    },
+    {
+        { 256ul, {}, { 0.f }, { 2.55f }, { 0.f }, { 2.55f }, ngraph::element::u8 },
+        { ngraph::element::f32, { 127.f }, { 0.01f } },
+        { ngraph::element::f32, { 127.f }, { 0.01f } }
+    },
+    {
+        { 256ul, {}, { 0.f }, { 2.55f }, { 0.f }, { 2.55f }, ngraph::element::u8 },
+        {
+            ngraph::element::f32,
+            {{ 127.f }, ngraph::element::f32, {}, false, 1, ngraph::element::u8, true},
+            {{ 0.1f }, ngraph::element::f32, {}, false, 1},
+        },
+        {
+            ngraph::element::f32,
+            {{ 127.f }, ngraph::element::f32, {}, false, 1, ngraph::element::u8, true},
+            {{ 0.1f }, ngraph::element::f32, {}, false, 1},
+        }
+    },
+    {
+        // unexpected Subtract shape
+        { 256ul, {}, { 0.f }, { 2.55f }, { 0.f }, { 2.55f }, ngraph::element::u8 },
+        {
+            ngraph::element::f32,
+            {std::vector<float>(12ul, 127.0), ngraph::element::f32, {1, 3, 2, 2}, false, 0, ngraph::element::u8, true},
+            {{ 0.1f }, ngraph::element::f32, {}, false, 1},
+        },
+        {
+            {},
+            {},
+            {{ 0.1f }, ngraph::element::f32, {}, false, 1},
+        }
+    },
+    {
+        { 256ul, {}, { 0.f }, { 2.55f }, { 0.f }, { 2.55f }, ngraph::element::u8 },
+        {
+            ngraph::element::f32,
+            {{ 127.f }, ngraph::element::f32, {}, false, 0, ngraph::element::u8, true},
+            {{ 0.1f }, ngraph::element::f32, {}, false, 0},
+        },
+        {
+            ngraph::element::f32,
+            {{ 127.f }, ngraph::element::f32, {}, false, 0, ngraph::element::u8, true},
+            {{ 0.1f }, ngraph::element::f32, {}, false, 0},
+        }
+    }
+};
+
+const std::vector<ngraph::Shape> shapes = {
+    { 1, 1, 2, 2 },
+    // TODO: 3D tensor
+};
+
+INSTANTIATE_TEST_CASE_P(
+    smoke_LPT,
+    GetDequantizationTransformation,
+    ::testing::Combine(
+        ::testing::ValuesIn(precisions),
+        ::testing::ValuesIn(shapes),
+        ::testing::ValuesIn(testValues)),
+    GetDequantizationTransformation::getTestCaseName);

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/is_function_quantized_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/is_function_quantized_transformation.cpp
@@ -1,0 +1,116 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "layer_transformation.hpp"
+
+#include <string>
+#include <sstream>
+#include <memory>
+
+#include <gtest/gtest.h>
+#include "lpt_ngraph_functions/common/builders.hpp"
+
+using namespace testing;
+using namespace ngraph;
+using namespace ngraph::pass;
+
+class IsFunctionQuantizedTransformationValues {
+public:
+    ngraph::Shape shape;
+    ngraph::element::Type precision;
+    builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize;
+    bool constantSubgraphOnParameters;
+    bool inputOnParameters;
+
+    bool isQuantized;
+};
+
+class IsFunctionQuantizedTransformation : public LayerTransformation, public testing::WithParamInterface<IsFunctionQuantizedTransformationValues> {
+public:
+    void SetUp() override {
+        const auto testValues = GetParam();
+
+        const auto input = std::make_shared<ngraph::opset1::Parameter>(testValues.precision, ngraph::Shape(testValues.shape));
+        const auto fakeQuantize = ngraph::builder::subgraph::makeFakeQuantize(
+            input,
+            testValues.precision,
+            testValues.fakeQuantize,
+            testValues.constantSubgraphOnParameters);
+
+        if (testValues.inputOnParameters) {
+            replace_node(fakeQuantize->get_input_node_shared_ptr(3), input);
+        }
+
+        ngraph::ResultVector results{ std::make_shared<ngraph::opset1::Result>(fakeQuantize) };
+        function = std::make_shared<ngraph::Function>(results, ngraph::ParameterVector{ input }, "IsFunctionQuantizedFunction");
+        function->validate_nodes_and_infer_types();
+    }
+
+    static std::string getTestCaseName(testing::TestParamInfo<IsFunctionQuantizedTransformationValues> obj) {
+        IsFunctionQuantizedTransformationValues testValues = obj.param;
+
+        std::ostringstream result;
+        result <<
+            testValues.shape << "_" <<
+            testValues.precision << "_" <<
+            testValues.fakeQuantize <<
+            testValues.constantSubgraphOnParameters << "_" <<
+            testValues.inputOnParameters << "_" <<
+            testValues.isQuantized;
+        return result.str();
+    }
+
+protected:
+    std::shared_ptr<ngraph::Function> function;
+};
+
+TEST_P(IsFunctionQuantizedTransformation, Run) {
+    const bool isQuantized = ngraph::pass::low_precision::LowPrecisionTransformer::isFunctionQuantized(function);
+
+    const auto testValues = GetParam();
+    ASSERT_EQ(testValues.isQuantized, isQuantized);
+}
+
+const std::vector<ngraph::Shape> shapes = { ngraph::Shape({ 1, 3, 72, 48 }) };
+
+const std::vector<IsFunctionQuantizedTransformationValues> testValues = {
+    {
+        ngraph::Shape{1, 3, 9, 9},
+        ngraph::element::f32,
+        { 255ul, {{ 1, 1, 1, 1 }}, { -1.28f }, { 1.27f }, { -128.f }, { 127.f }, element::i8 },
+        false,
+        false,
+        true
+    },
+    {
+        ngraph::Shape{1, 3, 9, 9},
+        ngraph::element::f32,
+        { 255ul, {{ 1, 1, 1, 1 }}, { -1.28f }, { 1.27f }, { -128.f }, { 127.f }, element::i8 },
+        true,
+        false,
+        false
+    },
+    {
+        ngraph::Shape{1, 3, 9, 9},
+        ngraph::element::f32,
+        { 255ul, {{ 1, 1, 1, 1 }}, { -1.28f }, { 1.27f }, { -128.f }, { 127.f }, element::i8 },
+        false,
+        true,
+        false
+    },
+    {
+        ngraph::Shape{1, 3, 9, 9},
+        ngraph::element::f32,
+        { 255ul, {{ 1, 1, 1, 1 }}, { -1.28f }, { 1.27f }, { -128.f }, { 127.f }, element::i8 },
+        true,
+        true,
+        false
+    }
+};
+
+INSTANTIATE_TEST_CASE_P(
+    smoke_LPT,
+    IsFunctionQuantizedTransformation,
+    ::testing::ValuesIn(testValues),
+    IsFunctionQuantizedTransformation::getTestCaseName);

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/layer_transformation.hpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/layer_transformation.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -8,6 +8,7 @@
 #include "low_precision/layer_transformation.hpp"
 #include "low_precision/transformation_context.hpp"
 #include "low_precision/transformer.hpp"
+#include "lpt_ngraph_functions/common/dequantization_operations.hpp"
 
 typedef std::tuple<
     ngraph::element::Type,
@@ -27,6 +28,9 @@ public:
         const ngraph::element::Type& type,
         const ngraph::Shape& shape,
         const ngraph::pass::low_precision::LayerTransformation::Params& params);
+
+    static ngraph::builder::subgraph::DequantizationOperations toDequantizationOperations(
+        const ngraph::pass::low_precision::FakeQuantizeDequantization& dequantization);
 
 protected:
     void transform(std::shared_ptr<ngraph::Function> function);

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/mat_mul_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/mat_mul_transformation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -171,7 +171,7 @@ std::vector<MatMullTransformationTestValues> testValues = {
     // },
     // U8 + I8
     {
-        LayerTransformation::createParamsU8U8().setSupportAsymmetricQuantization(true),
+        LayerTransformation::createParamsU8U8().setSupportAsymmetricQuantization(false),
         {
             ngraph::element::u8,
             { ngraph::element::f32, { 127.f }, { 0.02f } },
@@ -190,7 +190,7 @@ std::vector<MatMullTransformationTestValues> testValues = {
     },
     // I8 + I8
     {
-        LayerTransformation::createParamsU8U8().setSupportAsymmetricQuantization(true),
+        LayerTransformation::createParamsU8U8().setSupportAsymmetricQuantization(false),
         {
             ngraph::element::i8,
             { ngraph::element::f32, { 127.f }, { 0.02f } },
@@ -209,7 +209,7 @@ std::vector<MatMullTransformationTestValues> testValues = {
     },
     // U8 + I8, Subtract with not int
     {
-        LayerTransformation::createParamsU8U8().setSupportAsymmetricQuantization(true),
+        LayerTransformation::createParamsU8U8().setSupportAsymmetricQuantization(false),
         {
             ngraph::element::u8,
             { ngraph::element::f32, { 127.5f }, { 0.02f } },
@@ -228,7 +228,7 @@ std::vector<MatMullTransformationTestValues> testValues = {
     },
     // U8 + FP32
     {
-        LayerTransformation::createParamsU8U8().setSupportAsymmetricQuantization(true),
+        LayerTransformation::createParamsU8U8().setSupportAsymmetricQuantization(false),
         {
             ngraph::element::u8,
             { ngraph::element::f32, { 127.f }, { 0.02f } },
@@ -247,34 +247,16 @@ std::vector<MatMullTransformationTestValues> testValues = {
     },
     // FP32 + I8
     {
-        LayerTransformation::createParamsU8U8().setSupportAsymmetricQuantization(true),
-        {
-            ngraph::element::f32,
-            { {}, { 127.f }, { 0.02f } },
-            ngraph::element::i8,
-            { ngraph::element::f32, {}, { 0.03f } },
-        },
-        {
-            ngraph::element::f32,
-            { {}, { 127.f }, { 0.02f } },
-            ngraph::element::i8,
-            { ngraph::element::f32, {}, { 0.03f } },
-            ngraph::element::f32,
-            ngraph::element::f32,
-            { },
-        }
-    },
-    {
         LayerTransformation::createParamsU8U8().setSupportAsymmetricQuantization(false),
         {
-            ngraph::element::u8,
-            { ngraph::element::f32, { 127.f }, { 0.02f } },
+            ngraph::element::f32,
+            { {}, { 127.f }, { 0.02f } },
             ngraph::element::i8,
             { ngraph::element::f32, {}, { 0.03f } },
         },
         {
-            ngraph::element::u8,
-            { ngraph::element::f32, { 127.f }, { 0.02f } },
+            ngraph::element::f32,
+            { {}, { 127.f }, { 0.02f } },
             ngraph::element::i8,
             { ngraph::element::f32, {}, { 0.03f } },
             ngraph::element::f32,

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/multiply_to_group_convolution_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/multiply_to_group_convolution_transformation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -150,6 +150,31 @@ const std::vector<MultiplyToGroupConvolutionTransformationTestValues> testValues
             ngraph::element::u8,
             std::make_shared<ngraph::opset1::Constant>(ngraph::element::i8, ngraph::Shape{4, 1, 1, 1, 1}, std::vector<float>{1.f, 1.f, 1.f, 1.f}),
             std::make_shared<ngraph::opset1::Constant>(ngraph::element::f32, ngraph::Shape{1, 4, 1, 1}, std::vector<float>{0.77f, -0.8f, -0.1f, -1.5f}),
+            {
+                {},
+                {},
+                {{0.45f, 0.82f, 0.71f, 0.37f}}
+            }
+        }
+    },
+    // subtract + multiply
+    {
+        ngraph::Shape{ 1, 4, 1, 1 },
+        LayerTransformation::createParamsU8I8(),
+        true,
+        false,
+        {
+            ngraph::element::u8,
+            {
+                {ngraph::element::f32},
+                {{1.f, 2.f, 3.f, 4.f}, ngraph::element::f32, {1, 4, 1, 1}, true, 1, ngraph::element::u8, true},
+                {{0.45f, 0.82f, 0.71f, 0.37f}}
+            }
+        },
+        {
+            ngraph::element::u8,
+            std::make_shared<ngraph::opset1::Constant>(ngraph::element::i8, ngraph::Shape{4, 1, 1, 1, 1}, std::vector<float>{1.f, 1.f, 1.f, 1.f}),
+            std::make_shared<ngraph::opset1::Constant>(ngraph::element::f32, ngraph::Shape{1, 4, 1, 1}, std::vector<float>{-1.f, -2.f, -3.f, -4.f}),
             {
                 {},
                 {},

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/multiply_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/multiply_transformation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -273,6 +273,36 @@ const std::vector<MultiplyTransformationTestValues> multiplyTransformationTestVa
         }
     },
 
+    // Actual:
+    //
+    // Parameter
+    //  |I8
+    //  |
+    // Convert Constant    Parameter
+    //  \FP32  /FP32          |I8
+    //   \    /               |
+    //  Subtract  Constant  Convert  Constant
+    //     \FP32   /FP32      \FP32  /FP32
+    //      \     /            \    /
+    //      Multiply          Multiply
+    //             \FP32      /FP32
+    //              \        /
+    //               Multiply
+    // Transformed:
+    //
+    // Parameter
+    //   |I8
+    //   |
+    // Convert  Constant
+    //   \FP32   /FP32
+    //    \     /
+    //   Subtract    Constant
+    //      \FP32    /FP32
+    //       \      /
+    //      Multiply   Parameter
+    //          \FP32  /I8
+    //           \    /
+    //          Multiply
     {
         LayerTransformation::createParamsI8I8(),
         {
@@ -281,6 +311,74 @@ const std::vector<MultiplyTransformationTestValues> multiplyTransformationTestVa
                 {},
                 ngraph::element::i8,
                 {ngraph::element::f32, { 2.f }, { 10.f }}
+            },
+            {
+                { 1, 3, 8, 16 },
+                {},
+                ngraph::element::i8,
+                {ngraph::element::f32, { }, { 7.f }}
+            },
+            false
+        },
+        {
+            {
+                { 1, 3, 8, 16 },
+                {},
+                ngraph::element::i8,
+                {ngraph::element::f32, { 2.f }, { 70.f }},
+            },
+            {
+                { 1, 3, 8, 16 },
+                {},
+                ngraph::element::i8,
+                {}
+            },
+            false
+        }
+    },
+
+    // Actual:
+    //
+    // Parameter Constant
+    //  |I8      |I8
+    //  |        |
+    // Convert Convert      Parameter
+    //  \FP32  /FP32         |I8
+    //   \    /              |
+    //  Subtract  Constant  Convert  Constant
+    //     \FP32   /FP32      \FP32  /FP32
+    //      \     /            \    /
+    //      Multiply          Multiply
+    //             \FP32      /FP32
+    //              \        /
+    //               Multiply
+    // Transformed:
+    //
+    // Parameter
+    //   |I8
+    //   |
+    // Convert  Constant
+    //   \FP32   /FP32
+    //    \     /
+    //   Subtract    Constant
+    //      \FP32    /FP32
+    //       \      /
+    //      Multiply   Parameter
+    //          \FP32  /I8
+    //           \    /
+    //          Multiply
+    {
+        LayerTransformation::createParamsI8I8(),
+        {
+            {
+                { 1, 3, 8, 16 },
+                {},
+                ngraph::element::i8,
+                {
+                    ngraph::element::f32,
+                    { {2.f}, ngraph::element::f32, {}, true, 1ul, ngraph::element::i8, true },
+                    { 10.f }
+                }
             },
             {
                 { 1, 3, 8, 16 },
@@ -442,7 +540,190 @@ const std::vector<MultiplyTransformationTestValues> multiplyTransformationTestVa
             },
             true
         }
-    }
+    },
+
+    // Constant as input
+    {
+        LayerTransformation::createParamsU8I8(),
+        {
+            {
+                { 1, 3, 8, 16 },
+                {},
+                ngraph::element::i8,
+                {ngraph::element::f32, { }, { 0.2f }},
+            },
+            {
+                {},
+                {{ 7.f }, ngraph::element::i8}, // Constant as input
+                ngraph::element::i8,
+                {ngraph::element::f32, { }, { 0.5f }},
+            },
+            false
+        },
+        {
+            {
+                { 1, 3, 8, 16 },
+                {},
+                ngraph::element::i8,
+                {ngraph::element::f32, {}, {}},
+            },
+            {
+                {},
+                {{ 0.7f }, ngraph::element::f32},
+                ngraph::element::f32,
+                {}
+            },
+            true
+        }
+    },
+
+    // Actual:
+    //
+    // Parameter Constant   Constant  Constant
+    //  |I8      |I8         |I8       |I8
+    //  |        |           |         |
+    // Convert Convert      Convert  Convert
+    //  \FP32  /FP32         |I8    /FP32
+    //   \    /              |     /
+    //  Subtract  Constant  Subtract  Constant
+    //     \FP32   /FP32      \FP32  /FP32
+    //      \     /            \    /
+    //      Multiply          Multiply
+    //            \FP32      /FP32
+    //             \        /
+    //              Multiply
+    // Transformed:
+    //
+    // Parameter Constant
+    //   |I8      |I8
+    //   |        |
+    // Convert   Convert
+    //   \FP32   /FP32
+    //    \     /
+    //   Subtract    Constant
+    //      \FP32    /FP32
+    //       \      /
+    //      Multiply
+    //
+    {
+        LayerTransformation::createParamsU8I8(),
+        {
+            {
+                { 1, 3, 8, 16 },
+                {},
+                ngraph::element::i8,
+                {
+                    ngraph::element::f32,
+                    { {127.f}, ngraph::element::f32, {}, false, 1, ngraph::element::i8, true },
+                    { 0.2f }
+                },
+            },
+            {
+                {},
+                {{ 7.f }, ngraph::element::i8}, // Constant as input
+                ngraph::element::i8,
+                {
+                    ngraph::element::f32,
+                    { {127.f}, ngraph::element::f32, {}, false, 1, ngraph::element::i8, true },
+                    { 0.5f }
+                },
+            },
+            false
+        },
+        {
+            {
+                { 1, 3, 8, 16 },
+                {},
+                ngraph::element::i8,
+                {
+                    ngraph::element::f32,
+                    { {127.f}, ngraph::element::f32, {}, false, 1, ngraph::element::i8, true },
+                    {}
+                },
+            },
+            {
+                {},
+                {{ -12.f }, ngraph::element::f32},
+                ngraph::element::f32,
+                {}
+            },
+            true
+        }
+    },
+
+    // Actual:
+    //
+    // Constant Constant   Parameter  Constant
+    //  |I8      |I8         |I8       |I8
+    //  |        |           |         |
+    // Convert Convert      Convert  Convert
+    //  \FP32  /FP32         |I8    /FP32
+    //   \    /              |     /
+    //  Subtract  Constant  Subtract  Constant
+    //     \FP32   /FP32      \FP32  /FP32
+    //      \     /            \    /
+    //      Multiply          Multiply
+    //            \FP32      /FP32
+    //             \        /
+    //              Multiply
+    // Transformed:
+    //
+    // Parameter Constant
+    //   |I8      |I8
+    //   |        |
+    // Convert   Convert
+    //   \FP32   /FP32
+    //    \     /
+    //   Subtract    Constant
+    //      \FP32    /FP32
+    //       \      /
+    //      Multiply
+    //
+    {
+        LayerTransformation::createParamsU8I8(),
+        {
+            {
+                {},
+                {{ 7.f }, ngraph::element::i8}, // Constant as input
+                ngraph::element::i8,
+                {
+                    ngraph::element::f32,
+                    { {127.f}, ngraph::element::f32, {}, false, 1, ngraph::element::i8, true },
+                    { 0.5f }
+                },
+            },
+            {
+                { 1, 3, 8, 16 },
+                {},
+                ngraph::element::i8,
+                {
+                    ngraph::element::f32,
+                    { {127.f}, ngraph::element::f32, {}, false, 1, ngraph::element::i8, true },
+                    { 0.2f }
+                },
+            },
+            false
+        },
+        {
+            {
+                { 1, 3, 8, 16 },
+                {},
+                ngraph::element::i8,
+                {
+                    ngraph::element::f32,
+                    { {127.f}, ngraph::element::f32, {}, false, 1, ngraph::element::i8, true },
+                    {}
+                },
+            },
+            {
+                {},
+                {{ -12.f }, ngraph::element::f32},
+                ngraph::element::f32,
+                {}
+            },
+            true
+        }
+    },
 };
 
 INSTANTIATE_TEST_CASE_P(

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/separate_in_standalone_branch_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/separate_in_standalone_branch_transformation.cpp
@@ -1,0 +1,165 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "layer_transformation.hpp"
+
+#include <string>
+#include <sstream>
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include <transformations/utils/utils.hpp>
+#include <transformations/init_node_info.hpp>
+#include <low_precision/transformer.hpp>
+#include <low_precision/mat_mul.hpp>
+
+#include "common_test_utils/ngraph_test_utils.hpp"
+#include "lpt_ngraph_functions/common/builders.hpp"
+#include "lpt_ngraph_functions/mat_mul_function.hpp"
+#include "lpt_ngraph_functions/common/dequantization_operations.hpp"
+
+#include "ngraph_functions/subgraph_builders.hpp"
+#include "simple_low_precision_transformer.hpp"
+#include "lpt_ngraph_functions/common/dequantization_operations.hpp"
+
+namespace {
+
+using namespace testing;
+using namespace ngraph::pass;
+
+class SeparateInStandaloneBranchTransformationTestValues {
+public:
+    ngraph::pass::low_precision::LayerTransformation::Params params;
+    ngraph::element::Type precisionBefore;
+    ngraph::builder::subgraph::DequantizationOperations dequantization;
+};
+
+inline std::ostream& operator << (std::ostream& out, const SeparateInStandaloneBranchTransformationTestValues& testValues) {
+    return out << "_" << testValues.dequantization;
+}
+
+typedef std::tuple<
+    ngraph::Shape,
+    SeparateInStandaloneBranchTransformationTestValues> SeparateInStandaloneBranchTransformationParams;
+
+class SeparateInStandaloneBranchTransformation :
+    public LayerTransformation,
+    public testing::WithParamInterface<SeparateInStandaloneBranchTransformationParams> {
+public:
+    void SetUp() override {
+        const ngraph::Shape shape = std::get<0>(GetParam());
+        const SeparateInStandaloneBranchTransformationTestValues testValues = std::get<1>(GetParam());
+
+        const auto createActualFunction = [](
+            const ngraph::element::Type precision,
+            const ngraph::Shape& inputShape,
+            const ngraph::builder::subgraph::DequantizationOperations& dequantizations) -> std::shared_ptr<ngraph::Function> {
+            const std::shared_ptr<ngraph::opset1::Parameter> input = std::make_shared<ngraph::opset1::Parameter>(precision, inputShape);
+            const auto relu = std::make_shared<ngraph::opset1::Relu>(input);
+            const auto dequantizationsNode = ngraph::builder::subgraph::makeDequantization(relu, dequantizations);
+
+            const std::shared_ptr<ngraph::Node> reshape1 = std::make_shared<ngraph::opset1::Reshape>(
+                dequantizationsNode,
+                std::make_shared<ngraph::opset1::Constant>(ngraph::element::i32, ngraph::Shape{ 2 }, std::vector<double>({0, -1})),
+                true);
+            reshape1->set_friendly_name("reshape1");
+
+            const std::shared_ptr<ngraph::Node> reshape2 = std::make_shared<ngraph::opset1::Reshape>(
+                dequantizationsNode,
+                std::make_shared<ngraph::opset1::Constant>(ngraph::element::i32, ngraph::Shape{ 2 }, std::vector<double>({0, -1})),
+                true);
+            reshape2->set_friendly_name("reshape2");
+
+            return std::make_shared<ngraph::Function>(
+                ngraph::ResultVector{
+                    std::make_shared<ngraph::opset1::Result>(reshape1),
+                    std::make_shared<ngraph::opset1::Result>(reshape2)
+                },
+                std::vector<std::shared_ptr<ngraph::op::Parameter>> { input },
+                "SeparateInStandaloneBranchTransformation");
+        };
+        actualFunction = createActualFunction(testValues.precisionBefore, shape, testValues.dequantization);
+
+        const auto result = actualFunction->get_results()[0];
+        ngraph::pass::low_precision::NetworkHelper::separateInStandaloneBranch(result->get_input_node_shared_ptr(0));
+
+        const auto createReferenceFunction = [](
+            const ngraph::element::Type precision,
+            const ngraph::Shape& inputShape,
+            const ngraph::builder::subgraph::DequantizationOperations& dequantization) -> std::shared_ptr<ngraph::Function> {
+            const std::shared_ptr<ngraph::opset1::Parameter> input = std::make_shared<ngraph::opset1::Parameter>(precision, inputShape);
+            const auto relu = std::make_shared<ngraph::opset1::Relu>(input);
+
+            const std::shared_ptr<ngraph::Node> reshape1 = std::make_shared<ngraph::opset1::Reshape>(
+                ngraph::builder::subgraph::makeDequantization(relu, dequantization),
+                std::make_shared<ngraph::opset1::Constant>(ngraph::element::i32, ngraph::Shape{ 2 }, std::vector<double>({0, -1})),
+                true);
+            reshape1->set_friendly_name("reshape1");
+
+            const std::shared_ptr<ngraph::Node> reshape2 = std::make_shared<ngraph::opset1::Reshape>(
+                ngraph::builder::subgraph::makeDequantization(relu, dequantization),
+                std::make_shared<ngraph::opset1::Constant>(ngraph::element::i32, ngraph::Shape{ 2 }, std::vector<double>({0, -1})),
+                true);
+            reshape2->set_friendly_name("reshape2");
+
+            return std::make_shared<ngraph::Function>(
+                ngraph::ResultVector{
+                    std::make_shared<ngraph::opset1::Result>(reshape1),
+                    std::make_shared<ngraph::opset1::Result>(reshape2)
+                },
+                std::vector<std::shared_ptr<ngraph::op::Parameter>> { input },
+                "SeparateInStandaloneBranchTransformation");
+        };
+        referenceFunction = createReferenceFunction(testValues.precisionBefore, shape, testValues.dequantization);
+    }
+
+    static std::string getTestCaseName(testing::TestParamInfo<SeparateInStandaloneBranchTransformationParams> obj) {
+        ngraph::Shape shapes;
+        SeparateInStandaloneBranchTransformationTestValues testValues;
+        std::tie(shapes, testValues) = obj.param;
+
+        std::stringstream ss;
+        ss << shapes << "_" << "_" << testValues;
+        return ss.str();
+    }
+};
+
+TEST_P(SeparateInStandaloneBranchTransformation, CompareFunctions) {
+    actualFunction->validate_nodes_and_infer_types();
+    auto res = compare_functions(referenceFunction, actualFunction, true, true, true);
+    ASSERT_TRUE(res.first) << res.second;
+}
+
+const std::vector<ngraph::Shape> shapes = {
+    { 1, 3, 9, 9 },
+    { 4, 3, 9, 9 }
+};
+
+std::vector<SeparateInStandaloneBranchTransformationTestValues> testValues = {
+    {
+        LayerTransformation::createParamsU8U8().setSupportAsymmetricQuantization(true),
+        ngraph::element::u8,
+        { ngraph::element::f32, { 127.f }, { 0.02f } }
+    },
+    {
+        LayerTransformation::createParamsU8U8().setSupportAsymmetricQuantization(true),
+        ngraph::element::u8,
+        {
+            ngraph::element::f32,
+            { {127.f}, ngraph::element::f32, {}, true, 1ul, ngraph::element::u8, true},
+            { 0.02f }
+        }
+    }
+};
+
+INSTANTIATE_TEST_CASE_P(
+    smoke_LPT,
+    SeparateInStandaloneBranchTransformation,
+    ::testing::Combine(
+        ::testing::ValuesIn(shapes),
+        ::testing::ValuesIn(testValues)),
+    SeparateInStandaloneBranchTransformation::getTestCaseName);
+
+} // namespace

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/transformer_is_function_quantized.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/transformer_is_function_quantized.cpp
@@ -6,12 +6,10 @@
 
 #include <map>
 #include <memory>
-#include <sstream>
 #include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
-
-#include <ngraph/pass/visualize_tree.hpp>
 #include <low_precision/fake_quantize.hpp>
 #include <low_precision/transformer.hpp>
 

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/transpose_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/transpose_transformation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -98,6 +98,30 @@ public:
 };
 
 const std::vector<TransposeTransformationTestValues> testValues = {
+    // U8: per-tensor quantization
+    {
+        ngraph::Shape({ 1, 1000, 1, 1}),
+        { 0, 1, 3, 2},
+        LayerTransformation::createParamsU8I8(),
+        {
+            ngraph::element::u8,
+            {
+                {ngraph::element::f32},
+                { {128}, ngraph::element::f32, {}, true, 1, ngraph::element::u8, true },
+                {0.1f}
+            }
+        },
+        {
+            ngraph::element::u8,
+            {{}, {}, {}},
+            ngraph::element::u8,
+            {
+                {ngraph::element::f32},
+                { {128}, ngraph::element::f32, {}, true, 1, ngraph::element::u8, true },
+                {0.1f}
+            }
+        }
+    },
     // U8: per-tensor quantization
     {
         ngraph::Shape({ 1, 1000, 1, 1}),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/convolution_qdq_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/convolution_qdq_transformation.cpp
@@ -1,0 +1,249 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "low_precision_transformations/convolution_qdq_transformation.hpp"
+#include "low_precision_transformations/convolution_with_incorrect_weights.hpp"
+#include "common_test_utils/test_constants.hpp"
+
+using namespace LayerTestsDefinitions;
+
+namespace {
+const std::vector<ngraph::element::Type> netPrecisions = {
+    ngraph::element::f32,
+    // ngraph::element::f16
+};
+
+const std::vector<ngraph::pass::low_precision::LayerTransformation::Params> trasformationParamValues = {
+    LayerTestsUtils::LayerTransformationParamsNGraphFactory::createParams().setUpdatePrecisions(true),
+    LayerTestsUtils::LayerTransformationParamsNGraphFactory::createParams().setUpdatePrecisions(false),
+};
+
+const std::vector<LayerTestsDefinitions::ConvolutionQDqTransformationParam> params = {
+    // Actual:
+    //
+    //                        Constant
+    //                         |      Constant Constant Constant Constant
+    //                         |      /FP32    /FP32    /FP32    /FP32
+    // FakeQuantize           FakeQuantize
+    //  |FP32                  |FP32
+    //  |                      |
+    // Convert    Constant    Convert
+    //  |U8         |U8        |I8
+    //  |           |          |
+    // Convert    Convert     Convert  Constant
+    //   \FP32    /FP32        |FP32   /I8
+    //    \      /             |      /
+    //    Subtract  Constant  Subtract  Constant
+    //      \FP32   /FP32      |FP32   /FP32
+    //       \     /           |      /
+    //       Multiply         Multiply
+    //         \FP32         /FP32
+    //          \           /
+    //           Convolution
+    //
+    // Transformed:
+    //
+    // Parameter  Constant  Constant
+    //   \U8      /U8      /I8
+    //    \      /        /
+    //    Subtract   Subtract
+    //      \FP32    /FP32
+    //       \      /
+    //       Convolution  Constant
+    //         \FP32      /FP32
+    //          \        /
+    //           Multiply
+    {
+        { 256ul, {{ 1, 1, 1, 1 }}, { -12.8f }, { 12.7f }, { 0.f }, { 255.f }, ngraph::element::f32 },
+        { ngraph::element::u8, false },
+        {
+            {ngraph::element::f32},
+            { {128.f}, ngraph::element::f32, {}, false, 1ul, ngraph::element::u8, true },
+            { {0.1f}, ngraph::element::f32, {}, false }
+        },
+        { std::vector<float>{ 15.f }, ngraph::element::f32},
+        { 255ul, ngraph::Shape({ 1, 1, 1, 1 }), { 0.f }, { 25.5f }, { -128.f }, { 127.f }, ngraph::element::f32 },
+        { ngraph::element::i8, false },
+        {
+            { ngraph::element::f32, false },
+            { {-128.f}, ngraph::element::f32, {}, false, 1ul, ngraph::element::i8, true },
+            { {0.2f}, ngraph::element::f32, {}, false }
+        },
+        "output_original",
+        "FP32"
+    },
+
+    // Actual:
+    //
+    //                        Constant
+    //                         |      Constant Constant Constant Constant
+    //                         |      /FP32    /FP32    /FP32    /FP32
+    // FakeQuantize           FakeQuantize
+    //  |FP32                  |FP32
+    //  |                      |
+    // Convert    Constant    Convert
+    //  |U8         |U8        |I8
+    //  |           |          |
+    // Convert    Convert     Convert
+    //   \FP32    /FP32        |FP32
+    //    \      /             |
+    //    Subtract  Constant   |      Constant
+    //      \FP32   /FP32      |       /FP32
+    //       \     /           |      /
+    //       Multiply         Multiply
+    //         \FP32         /FP32
+    //          \           /
+    //           Convolution
+    //
+    // Transformed:
+    //
+    // Parameter  Constant
+    //   \U8      /U8
+    //    \      /
+    //    Subtract   Constant
+    //      \FP32    /I8
+    //       \      /
+    //       Convolution  Constant
+    //         \FP32      /FP32
+    //          \        /
+    //           Multiply
+    {
+        { 256ul, {{ 1, 1, 1, 1 }}, { -12.8f }, { 12.7f }, { 0.f }, { 255.f }, ngraph::element::f32 },
+        { ngraph::element::u8, false },
+        {
+            {ngraph::element::f32},
+            {},
+            { {0.1f}, ngraph::element::f32, {}, false }
+        },
+        { std::vector<float>{ 15.f }, ngraph::element::f32},
+        { 255ul, ngraph::Shape({ 1, 1, 1, 1 }), { 0.f }, { 25.5f }, { -128.f }, { 127.f }, ngraph::element::f32 },
+        { ngraph::element::i8, false },
+        {
+            { ngraph::element::f32, false },
+            {},
+            { {0.2f}, ngraph::element::f32, {}, false }
+        },
+        "output_original",
+        "U8"
+    },
+
+    // Actual:
+    //
+    // FQ
+    //  |FP32
+    //  |
+    // Convert    Convert   Constant  Constant
+    //  |U8        |U8       |U8       |U8
+    //  |          |         |         |
+    // Convert    Convert   Convert   Convert
+    //   \FP32    /FP32      \FP32    /FP32
+    //    \      /            \      /
+    //    Subtract  Constant  Subtract  Constant
+    //      \FP32   /FP32       \FP32   /FP32
+    //       \     /             \     /
+    //       Multiply           Multiply
+    //         \FP32           /FP32
+    //          \             /
+    //            Convolution
+    //
+    // Transformed:
+    //
+    //  FQ        Constant Constant
+    //   \U8      /U8      / I8
+    //    \      /        /
+    //    Subtract   Subtract
+    //      \FP32    /FP32
+    //       \      /
+    //       Convolution  Constant
+    //         \FP32      /FP32
+    //          \        /
+    //           Multiply
+    {
+        { 256ul, {{ 1, 1, 1, 1 }}, { -12.8f }, { 12.7f }, { 0.f }, { 255.f }, ngraph::element::f32 },
+        { ngraph::element::u8, false },
+        {
+            { ngraph::element::f32, false },
+            { {128.f}, ngraph::element::f32, {}, false, 1ul, ngraph::element::u8, true },
+            { {0.1f}, ngraph::element::f32, {}, false }
+        },
+        {{0.5f}, ngraph::element::i8},
+        {},
+        {},
+        {
+            { ngraph::element::f32, false },
+            { {128.f}, ngraph::element::f32, {}, false, 1ul, ngraph::element::i8, true },
+            { {0.2f}, ngraph::element::f32, {}, false }
+        },
+        "output_original",
+        "FP32"
+    },
+
+    // Actual:
+    //
+    // FQ
+    //  |FP32
+    //  |
+    // Convert    Convert
+    //  |U8        |U8
+    //  |          |
+    // Convert    Convert   Constant
+    //   \FP32    /FP32      \U8
+    //    \      /            \
+    //    Subtract  Constant  Convert   Constant
+    //      \FP32   /FP32       \FP32   /FP32
+    //       \     /             \     /
+    //       Multiply           Multiply
+    //         \FP32           /FP32
+    //          \             /
+    //            Convolution
+    //
+    // Transformed:
+    //
+    //  FQ        Constant Constant
+    //   \U8      /U8      / I8
+    //    \      /        /
+    //    Subtract   Subtract
+    //      \FP32    /FP32
+    //       \      /
+    //       Convolution  Constant
+    //         \FP32      /FP32
+    //          \        /
+    //           Multiply
+    {
+        { 256ul, {{ 1, 1, 1, 1 }}, { -12.8f }, { 12.7f }, { 0.f }, { 255.f }, ngraph::element::f32 },
+        { ngraph::element::u8, false },
+        {
+            { ngraph::element::f32, false },
+            { {128.f}, ngraph::element::f32, {}, false, 1ul, ngraph::element::u8, true },
+            { {0.1f}, ngraph::element::f32, {}, false }
+        },
+        {{0.5f}, ngraph::element::i8},
+        {},
+        {},
+        {
+            { ngraph::element::f32, false },
+            {},
+            { {0.2f}, ngraph::element::f32, {}, false }
+        },
+        "output_original",
+        "U8"
+    },
+};
+
+const std::vector<ngraph::Shape> shapes = {
+    { 1, 3, 4, 4 },
+    { 4, 3, 4, 4 }
+};
+
+INSTANTIATE_TEST_CASE_P(smoke_LPT, ConvolutionQDqTransformation,
+    ::testing::Combine(
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::ValuesIn(shapes),
+        ::testing::Values(CommonTestUtils::DEVICE_CPU),
+        ::testing::ValuesIn(trasformationParamValues),
+        ::testing::ValuesIn(params)),
+    ConvolutionQDqTransformation::getTestCaseName);
+}  // namespace

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/convolution_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/convolution_transformation.cpp
@@ -47,6 +47,30 @@ const std::vector<LayerTestsDefinitions::ConvolutionTransformationParam> params 
         "U8"
     },
     {
+        { 16ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 255.f }, { 0.f }, { 25.5f } },
+        false,
+        { 16ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 254.f }, { -12.7f }, { 12.7f } },
+        false,
+        "output",
+        "FP32"
+    },
+    {
+        { 16ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 25.5f }, { 0.f }, { 25.5f } },
+        false,
+        { 255ul, ngraph::Shape { 1, 1, 1, 1 }, { -12.7f }, { 12.7f }, { -12.7f }, { 12.7f } },
+        false,
+        "output",
+        "FP32"
+    },
+    {
+        { 256ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 255.f }, { 0.f }, { 25.5f } },
+        false,
+        { 16ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 254.f }, { -12.7f }, { 12.7f } },
+        false,
+        "output",
+        "FP32"
+    },
+    {
         { 256ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 255.f }, { -12.7f }, { 12.8f } },
         true,
         { 255ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 254.f }, { -12.7f }, { 12.7f } },

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/fake_quantize_and_two_output_branches_with_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/fake_quantize_and_two_output_branches_with_convolution.cpp
@@ -28,7 +28,6 @@ const std::vector<FakeQuantizeAndTwoOutputBranchesWithConvolution> testValues = 
     }
 };
 
-// TODO: add something to avoid cleanup and enable
 INSTANTIATE_TEST_CASE_P(smoke_LPT, FakeQuantizeAndTwoOutputBranchesWithConvolutionTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/fake_quantize_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/fake_quantize_transformation.cpp
@@ -34,7 +34,6 @@ const std::vector<ngraph::builder::subgraph::FakeQuantizeOnData> fakeQuantizeOnD
     // { 256ul, { 1ul }, { -1.28f} , { 1.27f } }
 };
 
-// TODO: add something to avoid cleanup and enable
 INSTANTIATE_TEST_CASE_P(smoke_LPT, FakeQuantizeTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/fake_quantize_with_dq_not_optimal_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/fake_quantize_with_dq_not_optimal_transformation.cpp
@@ -1,0 +1,111 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "low_precision_transformations/fake_quantize_with_dq_not_optimal_transformation.hpp"
+#include "common_test_utils/test_constants.hpp"
+#include "lpt_ngraph_functions/fake_quantize_function.hpp"
+
+using namespace LayerTestsDefinitions;
+using namespace ngraph::pass::low_precision;
+
+namespace {
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32
+};
+
+const std::vector<LayerTransformation::Params> trasformationParamValues = {
+    LayerTestsUtils::LayerTransformationParamsFactory::createParamsU8I8AndI8().setUpdatePrecisions(true),
+    LayerTestsUtils::LayerTransformationParamsFactory::createParamsU8I8AndI8().setUpdatePrecisions(false)
+};
+
+const std::vector<FakeQuantizeWithNotOptimalTransformationTestValues> fakeQuantizeOnDataValues = {
+    {
+        { 256ul, {{ 1, 1, 1, 1 }}, { 0.f }, { 25.5f }, { -128.f }, { 127.f }, ngraph::element::f32 },
+        { ngraph::element::i8, false },
+        {
+            { ngraph::element::f32, false },
+            { {-128.f}, ngraph::element::f32, {}, false, 1ul, ngraph::element::i8, true },
+            { {0.1f}, ngraph::element::f32, {}, false }
+        },
+        {{5.f}, ngraph::element::i8},
+        {},
+        {},
+        {
+            { ngraph::element::f32, false },
+            { {127.f}, ngraph::element::f32, {}, false, 1ul, ngraph::element::i8, true },
+            { {0.3f}, ngraph::element::f32, {}, false }
+        },
+        {},
+        "FP32"
+    },
+    {
+        { 256ul, {{ 1, 1, 1, 1 }}, { 0.f }, { 25.5f }, { -128.f }, { 127.f }, ngraph::element::f32 },
+        { ngraph::element::i8, false },
+        {
+            { ngraph::element::f32, false },
+            {},
+            { {0.1f}, ngraph::element::f32, {}, false }
+        },
+        {{5.f}, ngraph::element::i8},
+        {},
+        {},
+        {
+            { ngraph::element::f32, false },
+            {},
+            { {0.3f}, ngraph::element::f32, {}, false }
+        },
+        {},
+        "U8"
+    },
+    {
+        { 256ul, {{ 1, 1, 1, 1 }}, { 0.f }, { 25.5f }, { -128.f }, { 127.f }, ngraph::element::f32 },
+        { ngraph::element::i8, false },
+        {
+            { ngraph::element::f32, false },
+            { },
+            { {0.1f}, ngraph::element::f32, {}, false }
+        },
+        {{5.f}, ngraph::element::i8},
+        {},
+        {},
+        {
+            { ngraph::element::f32, false },
+            { {127.f}, ngraph::element::f32, {}, false, 1ul, ngraph::element::i8, true },
+            { {0.3f}, ngraph::element::f32, {}, false }
+        },
+        {},
+        "FP32"
+    },
+    {
+        { 256ul, {{ 1, 1, 1, 1 }}, { 0.f }, { 25.5f }, { -128.f }, { 127.f }, ngraph::element::f32 },
+        { ngraph::element::i8, false },
+        {
+            { ngraph::element::f32, false },
+            { {-128.f}, ngraph::element::f32, {}, false, 1ul, ngraph::element::i8, true },
+            { {0.1f}, ngraph::element::f32, {}, false }
+        },
+        {{5.f}, ngraph::element::i8},
+        {},
+        {},
+        {
+            { ngraph::element::f32, false },
+            { },
+            { {0.3f}, ngraph::element::f32, {}, false }
+        },
+        {},
+        "U8"
+    }
+};
+
+INSTANTIATE_TEST_CASE_P(smoke_LPT, FakeQuantizeWithNotOptimalTransformation,
+    ::testing::Combine(
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(InferenceEngine::SizeVector({ 1, 3, 16, 16 })),
+        ::testing::Values(CommonTestUtils::DEVICE_CPU),
+        ::testing::ValuesIn(trasformationParamValues),
+        ::testing::ValuesIn(fakeQuantizeOnDataValues)),
+    FakeQuantizeWithNotOptimalTransformation::getTestCaseName);
+}  // namespace

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/convolution_qdq_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/convolution_qdq_transformation.cpp
@@ -1,0 +1,249 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "low_precision_transformations/convolution_qdq_transformation.hpp"
+#include "low_precision_transformations/convolution_with_incorrect_weights.hpp"
+#include "common_test_utils/test_constants.hpp"
+
+using namespace LayerTestsDefinitions;
+
+namespace {
+const std::vector<ngraph::element::Type> netPrecisions = {
+    ngraph::element::f32,
+    // ngraph::element::f16
+};
+
+const std::vector<ngraph::pass::low_precision::LayerTransformation::Params> trasformationParamValues = {
+    LayerTestsUtils::LayerTransformationParamsNGraphFactory::createParams().setUpdatePrecisions(true),
+    // LayerTestsUtils::LayerTransformationParamsNGraphFactory::createParams().setUpdatePrecisions(false),
+};
+
+const std::vector<LayerTestsDefinitions::ConvolutionQDqTransformationParam> params = {
+    // Actual:
+    //
+    //                        Constant
+    //                         |      Constant Constant Constant Constant
+    //                         |      /FP32    /FP32    /FP32    /FP32
+    // FakeQuantize           FakeQuantize
+    //  |FP32                  |FP32
+    //  |                      |
+    // Convert    Constant    Convert
+    //  |U8         |U8        |I8
+    //  |           |          |
+    // Convert    Convert     Convert  Constant
+    //   \FP32    /FP32        |FP32   /I8
+    //    \      /             |      /
+    //    Subtract  Constant  Subtract  Constant
+    //      \FP32   /FP32      |FP32   /FP32
+    //       \     /           |      /
+    //       Multiply         Multiply
+    //         \FP32         /FP32
+    //          \           /
+    //           Convolution
+    //
+    // Transformed:
+    //
+    // Parameter  Constant  Constant
+    //   \U8      /U8      /I8
+    //    \      /        /
+    //    Subtract   Subtract
+    //      \FP32    /FP32
+    //       \      /
+    //       Convolution  Constant
+    //         \FP32      /FP32
+    //          \        /
+    //           Multiply
+    {
+        { 256ul, {{ 1, 1, 1, 1 }}, { -12.8f }, { 12.7f }, { 0.f }, { 255.f }, ngraph::element::f32 },
+        { ngraph::element::u8, false },
+        {
+            {ngraph::element::f32},
+            { {128.f}, ngraph::element::f32, {}, false, 1ul, ngraph::element::u8, true },
+            { {0.1f}, ngraph::element::f32, {}, false }
+        },
+        { std::vector<float>{ 15.f }, ngraph::element::f32},
+        { 255ul, ngraph::Shape({ 1, 1, 1, 1 }), { 0.f }, { 25.5f }, { -128.f }, { 127.f }, ngraph::element::f32 },
+        { ngraph::element::i8, false },
+        {
+            { ngraph::element::f32, false },
+            { {-128.f}, ngraph::element::f32, {}, false, 1ul, ngraph::element::i8, true },
+            { {0.2f}, ngraph::element::f32, {}, false }
+        },
+        "output_original",
+        "U8"
+    },
+
+    // Actual:
+    //
+    //                        Constant
+    //                         |      Constant Constant Constant Constant
+    //                         |      /FP32    /FP32    /FP32    /FP32
+    // FakeQuantize           FakeQuantize
+    //  |FP32                  |FP32
+    //  |                      |
+    // Convert    Constant    Convert
+    //  |U8         |U8        |I8
+    //  |           |          |
+    // Convert    Convert     Convert
+    //   \FP32    /FP32        |FP32
+    //    \      /             |
+    //    Subtract  Constant   |      Constant
+    //      \FP32   /FP32      |       /FP32
+    //       \     /           |      /
+    //       Multiply         Multiply
+    //         \FP32         /FP32
+    //          \           /
+    //           Convolution
+    //
+    // Transformed:
+    //
+    // Parameter  Constant
+    //   \U8      /U8
+    //    \      /
+    //    Subtract   Constant
+    //      \FP32    /I8
+    //       \      /
+    //       Convolution  Constant
+    //         \FP32      /FP32
+    //          \        /
+    //           Multiply
+    {
+        { 256ul, {{ 1, 1, 1, 1 }}, { -12.8f }, { 12.7f }, { 0.f }, { 255.f }, ngraph::element::f32 },
+        { ngraph::element::u8, false },
+        {
+            {ngraph::element::f32},
+            {},
+            { {0.1f}, ngraph::element::f32, {}, false }
+        },
+        { std::vector<float>{ 15.f }, ngraph::element::f32},
+        { 255ul, ngraph::Shape({ 1, 1, 1, 1 }), { 0.f }, { 25.5f }, { -128.f }, { 127.f }, ngraph::element::f32 },
+        { ngraph::element::i8, false },
+        {
+            { ngraph::element::f32, false },
+            {},
+            { {0.2f}, ngraph::element::f32, {}, false }
+        },
+        "output_original",
+        "U8"
+    },
+
+    // Actual:
+    //
+    // FQ
+    //  |FP32
+    //  |
+    // Convert    Convert   Constant  Constant
+    //  |U8        |U8       |U8       |U8
+    //  |          |         |         |
+    // Convert    Convert   Convert   Convert
+    //   \FP32    /FP32      \FP32    /FP32
+    //    \      /            \      /
+    //    Subtract  Constant  Subtract  Constant
+    //      \FP32   /FP32       \FP32   /FP32
+    //       \     /             \     /
+    //       Multiply           Multiply
+    //         \FP32           /FP32
+    //          \             /
+    //            Convolution
+    //
+    // Transformed:
+    //
+    //  FQ        Constant Constant
+    //   \U8      /U8      / I8
+    //    \      /        /
+    //    Subtract   Subtract
+    //      \FP32    /FP32
+    //       \      /
+    //       Convolution  Constant
+    //         \FP32      /FP32
+    //          \        /
+    //           Multiply
+    {
+        { 256ul, {{ 1, 1, 1, 1 }}, { -12.8f }, { 12.7f }, { 0.f }, { 255.f }, ngraph::element::f32 },
+        { ngraph::element::u8, false },
+        {
+            { ngraph::element::f32, false },
+            { {128.f}, ngraph::element::f32, {}, false, 1ul, ngraph::element::u8, true },
+            { {0.1f}, ngraph::element::f32, {}, false }
+        },
+        {{0.5f}, ngraph::element::i8},
+        {},
+        {},
+        {
+            { ngraph::element::f32, false },
+            { {128.f}, ngraph::element::f32, {}, false, 1ul, ngraph::element::i8, true },
+            { {0.2f}, ngraph::element::f32, {}, false }
+        },
+        "output_original",
+        "U8"
+    },
+
+    // Actual:
+    //
+    // FQ
+    //  |FP32
+    //  |
+    // Convert    Convert
+    //  |U8        |U8
+    //  |          |
+    // Convert    Convert   Constant
+    //   \FP32    /FP32      \U8
+    //    \      /            \
+    //    Subtract  Constant  Convert   Constant
+    //      \FP32   /FP32       \FP32   /FP32
+    //       \     /             \     /
+    //       Multiply           Multiply
+    //         \FP32           /FP32
+    //          \             /
+    //            Convolution
+    //
+    // Transformed:
+    //
+    //  FQ        Constant Constant
+    //   \U8      /U8      / I8
+    //    \      /        /
+    //    Subtract   Subtract
+    //      \FP32    /FP32
+    //       \      /
+    //       Convolution  Constant
+    //         \FP32      /FP32
+    //          \        /
+    //           Multiply
+    {
+        { 256ul, {{ 1, 1, 1, 1 }}, { -12.8f }, { 12.7f }, { 0.f }, { 255.f }, ngraph::element::f32 },
+        { ngraph::element::u8, false },
+        {
+            { ngraph::element::f32, false },
+            { {128.f}, ngraph::element::f32, {}, false, 1ul, ngraph::element::u8, true },
+            { {0.1f}, ngraph::element::f32, {}, false }
+        },
+        {{0.5f}, ngraph::element::i8},
+        {},
+        {},
+        {
+            { ngraph::element::f32, false },
+            {},
+            { {0.2f}, ngraph::element::f32, {}, false }
+        },
+        "output_original",
+        "U8"
+    },
+};
+
+const std::vector<ngraph::Shape> shapes = {
+    { 1, 3, 4, 4 },
+    { 4, 3, 4, 4 }
+};
+
+INSTANTIATE_TEST_CASE_P(smoke_LPT, ConvolutionQDqTransformation,
+    ::testing::Combine(
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::ValuesIn(shapes),
+        ::testing::Values(CommonTestUtils::DEVICE_GPU),
+        ::testing::ValuesIn(trasformationParamValues),
+        ::testing::ValuesIn(params)),
+    ConvolutionQDqTransformation::getTestCaseName);
+}  // namespace

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/convolution_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/convolution_transformation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Intel Corporation
+// Copyright (C) 2019-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -18,7 +18,7 @@ const std::vector<ngraph::element::Type> netPrecisions = {
 
 const std::vector<ngraph::pass::low_precision::LayerTransformation::Params> trasformationParamValues = {
     LayerTestsUtils::LayerTransformationParamsNGraphFactory::createParams().setUpdatePrecisions(true),
-    LayerTestsUtils::LayerTransformationParamsNGraphFactory::createParams().setUpdatePrecisions(false),
+    // LayerTestsUtils::LayerTransformationParamsNGraphFactory::createParams().setUpdatePrecisions(false),
 };
 
 const std::vector<LayerTestsDefinitions::ConvolutionTransformationParam> params = {
@@ -26,19 +26,25 @@ const std::vector<LayerTestsDefinitions::ConvolutionTransformationParam> params 
         { 256ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 255.f }, { 0.f }, { 25.5f } },
         false,
         {},
-        false
+        false,
+        "output",
+        ""
     },
     {
         {},
         false,
         { 255ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 254.f }, { -12.7f }, { 12.7f } },
-        false
+        false,
+        "output",
+        ""
     },
     {
         { 256ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 255.f }, { 0.f }, { 25.5f } },
         false,
         { 255ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 254.f }, { -12.7f }, { 12.7f } },
-        false
+        false,
+        "output_original",
+        "U8"
     },
     {
         { 256ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 255.f }, { -12.75f }, { 6.375f } },

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/fake_quantize_and_two_output_branches_with_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/fake_quantize_and_two_output_branches_with_convolution.cpp
@@ -28,7 +28,6 @@ const std::vector<FakeQuantizeAndTwoOutputBranchesWithConvolution> testValues = 
     }
 };
 
-// TODO: add something to avoid cleanup and enable
 INSTANTIATE_TEST_CASE_P(smoke_LPT, FakeQuantizeAndTwoOutputBranchesWithConvolutionTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/fake_quantize_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/fake_quantize_transformation.cpp
@@ -33,7 +33,6 @@ const std::vector<ngraph::builder::subgraph::FakeQuantizeOnData> fakeQuantizeOnD
     // { 256ul, { 1ul }, { -1.28f} , { 1.27f } }
 };
 
-// TODO: add something to avoid cleanup and enable
 INSTANTIATE_TEST_CASE_P(smoke_LPT, FakeQuantizeTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/fake_quantize_with_dq_not_optimal_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/fake_quantize_with_dq_not_optimal_transformation.cpp
@@ -1,0 +1,111 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "low_precision_transformations/fake_quantize_with_dq_not_optimal_transformation.hpp"
+#include "common_test_utils/test_constants.hpp"
+#include "lpt_ngraph_functions/fake_quantize_function.hpp"
+
+using namespace LayerTestsDefinitions;
+using namespace ngraph::pass::low_precision;
+
+namespace {
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32
+};
+
+const std::vector<LayerTransformation::Params> trasformationParamValues = {
+    LayerTestsUtils::LayerTransformationParamsFactory::createParamsU8I8AndI8().setUpdatePrecisions(true),
+    // LayerTestsUtils::LayerTransformationParamsFactory::createParamsU8I8AndI8().setUpdatePrecisions(false),
+};
+
+const std::vector<FakeQuantizeWithNotOptimalTransformationTestValues> fakeQuantizeOnDataValues = {
+    {
+        { 256ul, {{ 1, 1, 1, 1 }}, { 0.f }, { 25.5f }, { -128.f }, { 127.f }, ngraph::element::f32 },
+        { ngraph::element::i8, false },
+        {
+            { ngraph::element::f32, false },
+            { {-128.f}, ngraph::element::f32, {}, false, 1ul, ngraph::element::i8, true },
+            { {0.1f}, ngraph::element::f32, {}, false }
+        },
+        {{5.f}, ngraph::element::i8},
+        {},
+        {},
+        {
+            { ngraph::element::f32, false },
+            { {127.f}, ngraph::element::f32, {}, false, 1ul, ngraph::element::i8, true },
+            { {0.3f}, ngraph::element::f32, {}, false }
+        },
+        {},
+        "I8"
+    },
+    {
+        { 256ul, {{ 1, 1, 1, 1 }}, { 0.f }, { 25.5f }, { -128.f }, { 127.f }, ngraph::element::f32 },
+        { ngraph::element::i8, false },
+        {
+            { ngraph::element::f32, false },
+            {},
+            { {0.1f}, ngraph::element::f32, {}, false }
+        },
+        {{5.f}, ngraph::element::i8},
+        {},
+        {},
+        {
+            { ngraph::element::f32, false },
+            {},
+            { {0.3f}, ngraph::element::f32, {}, false }
+        },
+        {},
+        "I8"
+    },
+    {
+        { 256ul, {{ 1, 1, 1, 1 }}, { 0.f }, { 25.5f }, { -128.f }, { 127.f }, ngraph::element::f32 },
+        { ngraph::element::i8, false },
+        {
+            { ngraph::element::f32, false },
+            { },
+            { {0.1f}, ngraph::element::f32, {}, false }
+        },
+        {{5.f}, ngraph::element::i8},
+        {},
+        {},
+        {
+            { ngraph::element::f32, false },
+            { {127.f}, ngraph::element::f32, {}, false, 1ul, ngraph::element::i8, true },
+            { {0.3f}, ngraph::element::f32, {}, false }
+        },
+        {},
+        "I8"
+    },
+    {
+        { 256ul, {{ 1, 1, 1, 1 }}, { 0.f }, { 25.5f }, { -128.f }, { 127.f }, ngraph::element::f32 },
+        { ngraph::element::i8, false },
+        {
+            { ngraph::element::f32, false },
+            { {-128.f}, ngraph::element::f32, {}, false, 1ul, ngraph::element::i8, true },
+            { {0.1f}, ngraph::element::f32, {}, false }
+        },
+        {{5.f}, ngraph::element::i8},
+        {},
+        {},
+        {
+            { ngraph::element::f32, false },
+            { },
+            { {0.3f}, ngraph::element::f32, {}, false }
+        },
+        {},
+        "I8"
+    }
+};
+
+INSTANTIATE_TEST_CASE_P(smoke_LPT, FakeQuantizeWithNotOptimalTransformation,
+    ::testing::Combine(
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(InferenceEngine::SizeVector({ 1, 3, 16, 16 })),
+        ::testing::Values(CommonTestUtils::DEVICE_GPU),
+        ::testing::ValuesIn(trasformationParamValues),
+        ::testing::ValuesIn(fakeQuantizeOnDataValues)),
+    FakeQuantizeWithNotOptimalTransformation::getTestCaseName);
+}  // namespace

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/prelu_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/prelu_transformation.cpp
@@ -23,7 +23,8 @@ std::vector<PReluTestValues> testValues = {
     { { 256ul, ngraph::Shape({}), {-12.8f / 2.f}, {12.7f}, {-12.8f / 2.f}, {12.7f} }, true }
 };
 
-INSTANTIATE_TEST_CASE_P(LPT, PReluTransformation,
+// PRelu in low precision is not supported in GPU
+INSTANTIATE_TEST_CASE_P(DISABLED_LPT, PReluTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(precisions),
         ::testing::Values(ngraph::Shape({ 1, 3, 16, 16 })),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/transpose_after_matmul_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/transpose_after_matmul_transformation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/inference-engine/tests/functional/plugin/shared/include/low_precision_transformations/convolution_qdq_transformation.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/low_precision_transformations/convolution_qdq_transformation.hpp
@@ -1,0 +1,68 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <string>
+#include <memory>
+
+#include "shared_test_classes/base/low_precision_transformations/layer_transformation.hpp"
+#include "lpt_ngraph_functions/common/constant.hpp"
+#include "lpt_ngraph_functions/common/dequantization_operations.hpp"
+#include "lpt_ngraph_functions/common/fake_quantize_on_data.hpp"
+#include "lpt_ngraph_functions/common/fake_quantize_on_weights.hpp"
+
+namespace LayerTestsDefinitions {
+
+class ConvolutionQDqTransformationParam {
+public:
+    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantizeOnData;
+    ngraph::builder::subgraph::DequantizationOperations::Convert convertOnData;
+    ngraph::builder::subgraph::DequantizationOperations dequantizationOnData;
+
+    ngraph::builder::subgraph::Constant constantOnWeights;
+    ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
+    ngraph::builder::subgraph::DequantizationOperations::Convert convertOnWeights;
+    ngraph::builder::subgraph::DequantizationOperations dequantizationOnWeights;
+
+    std::string layerName;
+    std::string expectedKernelType;
+};
+
+inline std::ostream& operator<<(std::ostream& out, const ConvolutionQDqTransformationParam& data) {
+    return out <<  "_" <<
+        data.fakeQuantizeOnData << "_" <<
+        data.convertOnData << "_" <<
+        data.dequantizationOnData << "_" <<
+
+        data.constantOnWeights << "_" <<
+        data.fakeQuantizeOnWeights << "_" <<
+        data.convertOnWeights << "_" <<
+        data.dequantizationOnWeights <<
+
+        data.layerName << "_" <<
+        data.expectedKernelType;
+}
+
+typedef std::tuple<
+    ngraph::element::Type,
+    ngraph::Shape,
+    std::string,
+    ngraph::pass::low_precision::LayerTransformation::Params,
+    ConvolutionQDqTransformationParam
+> ConvolutionQDqTransformationParams;
+
+class ConvolutionQDqTransformation :
+    public testing::WithParamInterface<ConvolutionQDqTransformationParams>,
+    public LayerTestsUtils::LayerTransformation {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<ConvolutionQDqTransformationParams> obj);
+
+protected:
+    void SetUp() override;
+
+    void Run() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/low_precision_transformations/fake_quantize_with_dq_not_optimal_transformation.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/low_precision_transformations/fake_quantize_with_dq_not_optimal_transformation.hpp
@@ -1,0 +1,69 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <string>
+#include <memory>
+#include "lpt_ngraph_functions/fake_quantize_function.hpp"
+#include "shared_test_classes/base/low_precision_transformations/layer_transformation.hpp"
+
+#include "lpt_ngraph_functions/fake_quantize_and_convolution_function.hpp"
+#include "lpt_ngraph_functions/common/dequantization_operations.hpp"
+#include "lpt_ngraph_functions/common/constant.hpp"
+#include "lpt_ngraph_functions/common/fake_quantize_on_data.hpp"
+#include "lpt_ngraph_functions/common/fake_quantize_on_weights.hpp"
+
+namespace LayerTestsDefinitions {
+
+class FakeQuantizeWithNotOptimalTransformationTestValues {
+public:
+    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fqOnData;
+    ngraph::builder::subgraph::DequantizationOperations::Convert convertOnData;
+    ngraph::builder::subgraph::DequantizationOperations dequantizationOnData;
+
+    ngraph::builder::subgraph::Constant constantOnWeights;
+    ngraph::builder::subgraph::FakeQuantizeOnWeights fqOnWeights;
+    ngraph::builder::subgraph::DequantizationOperations::Convert convertOnWeights;
+    ngraph::builder::subgraph::DequantizationOperations dequantizationOnWeights;
+
+    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+    std::string expectedPrecision;
+};
+
+inline std::ostream& operator<<(std::ostream& out, const FakeQuantizeWithNotOptimalTransformationTestValues& data) {
+    return out <<  "_" <<
+        data.fqOnData << "_" <<
+        data.convertOnData << "_" <<
+        data.dequantizationOnData << "_" <<
+
+        data.constantOnWeights << "_" <<
+        data.fqOnWeights << "_" <<
+        data.convertOnWeights << "_" <<
+        data.dequantizationOnWeights <<
+
+        data.dequantizationAfter << "_" <<
+        data.expectedPrecision;
+}
+
+// ngraph::builder::subgraph::FakeQuantizeOnData
+typedef std::tuple<
+    InferenceEngine::Precision,
+    InferenceEngine::SizeVector,
+    std::string,
+    ngraph::pass::low_precision::LayerTransformation::Params,
+    FakeQuantizeWithNotOptimalTransformationTestValues> FakeQuantizeTransformationParams;
+
+class FakeQuantizeWithNotOptimalTransformation :
+    public testing::WithParamInterface<FakeQuantizeTransformationParams>,
+    public LayerTestsUtils::LayerTransformation {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<FakeQuantizeTransformationParams> obj);
+
+protected:
+    void SetUp() override;
+    void Run() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/convolution_qdq_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/convolution_qdq_transformation.cpp
@@ -1,0 +1,70 @@
+﻿// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "low_precision_transformations/convolution_qdq_transformation.hpp"
+
+#include <memory>
+#include <tuple>
+#include <vector>
+#include <string>
+
+#include <ie_core.hpp>
+
+#include "common_test_utils/common_utils.hpp"
+#include "functional_test_utils/plugin_cache.hpp"
+#include "shared_test_classes/base/layer_test_utils.hpp"
+#include "functional_test_utils/blob_utils.hpp"
+#include "ngraph_functions/pass/convert_prc.hpp"
+#include "lpt_ngraph_functions/fake_quantize_and_convolution_function.hpp"
+
+namespace LayerTestsDefinitions {
+
+std::string ConvolutionQDqTransformation::getTestCaseName(testing::TestParamInfo<ConvolutionQDqTransformationParams> obj) {
+    ngraph::element::Type netPrecision;
+    ngraph::Shape inputShape;
+    std::string targetDevice;
+    ngraph::pass::low_precision::LayerTransformation::Params params;
+    ConvolutionQDqTransformationParam param;
+    std::tie(netPrecision, inputShape, targetDevice, params, param) = obj.param;
+
+    std::ostringstream result;
+    result << getTestCaseNameByParams(netPrecision, inputShape, targetDevice, params) << param;
+    return result.str();
+}
+
+void ConvolutionQDqTransformation::SetUp() {
+    // threshold = 0.1f;
+
+    ngraph::element::Type netPrecision;
+    ngraph::Shape inputShape;
+    ngraph::pass::low_precision::LayerTransformation::Params params;
+    ConvolutionQDqTransformationParam param;
+    std::tie(netPrecision, inputShape, targetDevice, params, param) = this->GetParam();
+
+    function = ngraph::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
+        netPrecision,
+        inputShape,
+        param.fakeQuantizeOnData,
+        param.convertOnData,
+        param.dequantizationOnData,
+        param.constantOnWeights,
+        param.fakeQuantizeOnWeights,
+        param.convertOnWeights,
+        param.dequantizationOnWeights,
+        {});
+}
+
+void ConvolutionQDqTransformation::Run() {
+    LayerTestsCommon::Run();
+
+    const auto params = std::get<4>(GetParam());
+    const auto actualType = getRuntimePrecision(params.layerName);
+    EXPECT_EQ(actualType, params.expectedKernelType);
+}
+
+TEST_P(ConvolutionQDqTransformation, CompareWithRefImpl) {
+    Run();
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/fake_quantize_with_dq_not_optimal_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/fake_quantize_with_dq_not_optimal_transformation.cpp
@@ -1,0 +1,63 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "low_precision_transformations/fake_quantize_with_dq_not_optimal_transformation.hpp"
+
+#include <memory>
+#include <tuple>
+#include <vector>
+#include <string>
+#include <ie_core.hpp>
+
+#include <transformations/init_node_info.hpp>
+#include "lpt_ngraph_functions/fake_quantize_and_convolution_function.hpp"
+
+namespace LayerTestsDefinitions {
+
+std::string FakeQuantizeWithNotOptimalTransformation::getTestCaseName(testing::TestParamInfo<FakeQuantizeTransformationParams> obj) {
+    InferenceEngine::Precision netPrecision;
+    InferenceEngine::SizeVector inputShapes;
+    std::string targetDevice;
+    ngraph::pass::low_precision::LayerTransformation::Params params;
+    FakeQuantizeWithNotOptimalTransformationTestValues testValues;
+    std::tie(netPrecision, inputShapes, targetDevice, params, testValues) = obj.param;
+
+    std::ostringstream result;
+    result << getTestCaseNameByParams(netPrecision, inputShapes, targetDevice, params) << "_" << testValues;
+    return result.str();
+}
+
+void FakeQuantizeWithNotOptimalTransformation::SetUp() {
+    InferenceEngine::SizeVector inputShape;
+    InferenceEngine::Precision netPrecision;
+    ngraph::pass::low_precision::LayerTransformation::Params params;
+    FakeQuantizeWithNotOptimalTransformationTestValues testValues;
+    std::tie(netPrecision, inputShape, targetDevice, params, testValues) = this->GetParam();
+
+    function = ngraph::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
+        FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision),
+        inputShape,
+        testValues.fqOnData,
+        testValues.convertOnData,
+        testValues.dequantizationOnData,
+        testValues.constantOnWeights,
+        testValues.fqOnWeights,
+        testValues.convertOnWeights,
+        testValues.dequantizationOnWeights,
+        testValues.dequantizationAfter);
+}
+
+void FakeQuantizeWithNotOptimalTransformation::Run() {
+    LayerTestsCommon::Run();
+
+    const auto params = std::get<4>(GetParam());
+    const auto actualType = getRuntimePrecision("output_original");
+    EXPECT_EQ(actualType, params.expectedPrecision);
+}
+
+TEST_P(FakeQuantizeWithNotOptimalTransformation, CompareWithRefImpl) {
+    Run();
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/fuse_convert_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/fuse_convert_transformation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -18,8 +18,6 @@
 
 #include "ngraph_functions/pass/convert_prc.hpp"
 #include "lpt_ngraph_functions/fuse_convert_function.hpp"
-
-#include <ngraph/pass/visualize_tree.hpp>
 
 namespace LayerTestsDefinitions {
 

--- a/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/multiply_to_group_convolution_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/multiply_to_group_convolution_transformation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -18,8 +18,6 @@
 
 #include "ngraph_functions/pass/convert_prc.hpp"
 #include "lpt_ngraph_functions/multiply_to_group_convolution_function.hpp"
-
-#include <ngraph/pass/visualize_tree.hpp>
 
 namespace LayerTestsDefinitions {
 

--- a/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/mvn_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/mvn_transformation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -18,8 +18,6 @@
 
 #include "ngraph_functions/pass/convert_prc.hpp"
 #include "lpt_ngraph_functions/mvn_function.hpp"
-
-#include <ngraph/pass/visualize_tree.hpp>
 
 namespace LayerTestsDefinitions {
 

--- a/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/squeeze_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/squeeze_transformation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -14,8 +14,6 @@
 #include "low_precision_transformations/squeeze_transformation.hpp"
 #include "ngraph_functions/subgraph_builders.hpp"
 #include "lpt_ngraph_functions/squeeze_function.hpp"
-
-#include <ngraph/pass/visualize_tree.hpp>
 
 namespace LayerTestsDefinitions {
 

--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/base/low_precision_transformations/layer_transformation.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/base/low_precision_transformations/layer_transformation.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -17,6 +17,7 @@ namespace LayerTestsUtils {
 
 class LayerTransformationParamsNGraphFactory {
 public:
+    static ngraph::pass::low_precision::LayerTransformation::Params createParamsU8I8AndI8();
     static ngraph::pass::low_precision::LayerTransformation::Params createParamsU8I8();
     static ngraph::pass::low_precision::LayerTransformation::Params createParamsI8I8();
     static ngraph::pass::low_precision::LayerTransformation::Params createParams();

--- a/inference-engine/tests/functional/shared_test_classes/src/base/low_precision_transformations/layer_transformation.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/base/low_precision_transformations/layer_transformation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -8,6 +8,7 @@
 #include <string>
 
 #include <ie_core.hpp>
+#include "cpp_interfaces/interface/ie_internal_plugin_config.hpp"
 #include "functional_test_utils/blob_utils.hpp"
 
 #include "ngraph_functions/pass/convert_prc.hpp"
@@ -18,6 +19,16 @@ using namespace InferenceEngine;
 using namespace ngraph;
 
 namespace LayerTestsUtils {
+
+ngraph::pass::low_precision::LayerTransformation::Params LayerTransformationParamsNGraphFactory::createParamsU8I8AndI8() {
+    return ngraph::pass::low_precision::LayerTransformation::Params(
+        true,
+        ngraph::pass::low_precision::LayerTransformation::QuantizedTensorAlignment::None,
+        ngraph::pass::low_precision::LayerTransformation::QuantizedTensorAlignment::None,
+        true,
+        { ngraph::element::u8, ngraph::element::i8 },
+        { ngraph::element::i8 });
+}
 
 ngraph::pass::low_precision::LayerTransformation::Params LayerTransformationParamsNGraphFactory::createParamsU8I8() {
     return ngraph::pass::low_precision::LayerTransformation::Params(
@@ -41,6 +52,8 @@ ngraph::pass::low_precision::LayerTransformation::Params LayerTransformationPara
 
 LayerTransformation::LayerTransformation() {
     threshold = 0.05;
+    auto& configuration = GetConfiguration();
+    configuration[PluginConfigInternalParams::KEY_LP_TRANSFORMS_MODE] = PluginConfigParams::YES;
 }
 
 InferenceEngine::Blob::Ptr LayerTransformation::GenerateInput(

--- a/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/common/builders.hpp
+++ b/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/common/builders.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -77,7 +77,8 @@ std::shared_ptr<ngraph::opset1::FakeQuantize> makeFakeQuantizeTypeRelaxed(
 std::shared_ptr<ngraph::opset1::FakeQuantize> makeFakeQuantize(
     const Output<Node>& input,
     const ngraph::element::Type precision,
-    const FakeQuantizeOnDataWithConstant& fqOnData);
+    const FakeQuantizeOnDataWithConstant& fqOnData,
+    const bool subgraphOnConstantPath = false);
 
 std::shared_ptr<ngraph::opset1::FakeQuantize> makeFakeQuantizeTypeRelaxed(
     const std::shared_ptr<ngraph::Node>& input,

--- a/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/common/constant.hpp
+++ b/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/common/constant.hpp
@@ -4,6 +4,10 @@
 
 #pragma once
 
+#include <ostream>
+#include <string>
+#include <vector>
+
 #include <ngraph/ngraph.hpp>
 
 namespace ngraph {
@@ -28,7 +32,22 @@ private:
 };
 
 inline std::ostream& operator<<(std::ostream& out, const Constant& constant) {
-    return out << "_" << constant.values << "_" << constant.outPrecision << "_" << constant.shape;
+    auto toStream = [](const std::vector<float>& values) -> std::string {
+        std::stringstream os;
+        os << "{";
+        for (size_t i = 0; i < values.size(); ++i) {
+            const float& value = values[i];
+            if (i > 0) {
+                os << value;
+            } else {
+                os << ", " << value;
+            }
+        }
+        os << "}";
+        return os.str();
+    };
+
+    return out << "_" << toStream(constant.values) << "_" << constant.outPrecision << "_" << constant.shape;
 }
 
 }  // namespace subgraph

--- a/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/common/fake_quantize_on_data.hpp
+++ b/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/common/fake_quantize_on_data.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -59,6 +59,21 @@ inline std::ostream& operator<<(std::ostream& out, const FakeQuantizeOnData& dat
 
 class FakeQuantizeOnDataWithConstant {
 public:
+    FakeQuantizeOnDataWithConstant();
+
+    FakeQuantizeOnDataWithConstant(
+        const size_t quantizationLevel,
+        const std::vector<ngraph::Shape>& constantShapes,
+        const std::vector<float>& inputLowValues,
+        const std::vector<float>& inputHighValues,
+        const std::vector<float>& outputLowValues,
+        const std::vector<float>& outputHighValues,
+        const ngraph::element::Type outputPrecision = ngraph::element::undefined);
+
+    virtual ~FakeQuantizeOnDataWithConstant();
+
+    virtual bool empty() const;
+
     size_t quantizationLevel;
     std::vector<ngraph::Shape> constantShapes;
     std::vector<float> inputLowValues;

--- a/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/common/fake_quantize_on_weights.hpp
+++ b/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/common/fake_quantize_on_weights.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -32,7 +32,7 @@ public:
 };
 
 inline std::ostream& operator<<(std::ostream& out, const FakeQuantizeOnWeights& data) {
-    return out << "_" << data.constantShape << "_" << data.outputLowValues << "_" << data.outputHighValues;
+    return out << "_" << data.quantizationLevel << "_" << data.constantShape << "_" << data.outputLowValues << "_" << data.outputHighValues;
 }
 
 }  // namespace subgraph

--- a/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/compose_fake_quantize_function.hpp
+++ b/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/compose_fake_quantize_function.hpp
@@ -1,0 +1,29 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+#include <ngraph/ngraph.hpp>
+
+#include "lpt_ngraph_functions/common/dequantization_operations.hpp"
+#include "ngraph_functions/subgraph_builders.hpp"
+
+namespace ngraph {
+namespace builder {
+namespace subgraph {
+
+class ComposeFakeQuantizeFunction {
+public:
+    static std::shared_ptr<ngraph::Function> get(
+        const ngraph::element::Type precision,
+        const ngraph::Shape& inputShape,
+        const ngraph::builder::subgraph::FakeQuantizeOnData& fakeQuantizeOnData,
+        const ngraph::builder::subgraph::DequantizationOperations& dequantization1,
+        const ngraph::builder::subgraph::DequantizationOperations& dequantization2);
+};
+
+}  // namespace subgraph
+}  // namespace builder
+}  // namespace ngraph

--- a/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/concat_function.hpp
+++ b/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/concat_function.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -89,13 +89,15 @@ public:
         const FakeQuantizeOnData& fakeQuantize2,
         const DequantizationOperations& dequantizationOperations);
 
-    static std::shared_ptr<ngraph::Function> getReference(
+    static std::shared_ptr<ngraph::Function> get(
         const ngraph::element::Type inputPrecision,
         const ngraph::Shape& inputShape,
         const FakeQuantizeOnDataWithConstant& fakeQuantize1,
+        const DequantizationOperations::Convert& convert1,
+        const DequantizationOperations& dequantization1,
         const FakeQuantizeOnDataWithConstant& fakeQuantize2,
-        const ngraph::element::Type precisionBeforeOp,
-        const DequantizationOperations& dequantizationBefore,
+        const DequantizationOperations::Convert& convert2,
+        const DequantizationOperations& dequantization2,
         const ngraph::element::Type precisionAfterOperation,
         const DequantizationOperations& dequantizationAfter);
 

--- a/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/fake_quantize_and_convolution_function.hpp
+++ b/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/fake_quantize_and_convolution_function.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -6,8 +6,12 @@
 
 #include <memory>
 #include <ngraph/ngraph.hpp>
+#include <string>
+
+#include "lpt_ngraph_functions/common/constant.hpp"
 #include "lpt_ngraph_functions/common/fake_quantize_on_data.hpp"
 #include "lpt_ngraph_functions/common/fake_quantize_on_weights.hpp"
+#include "lpt_ngraph_functions/common/dequantization_operations.hpp"
 
 namespace ngraph {
 namespace builder {
@@ -16,11 +20,24 @@ namespace subgraph {
 class FakeQuantizeAndConvolutionFunction {
 public:
     // TODO: move to ConvolutionFunction
-    static std::shared_ptr<ngraph::Function> getOriginal(
+    static std::shared_ptr<ngraph::Function> get(
         const ngraph::element::Type precision,
         const ngraph::Shape& inputShape,
         const FakeQuantizeOnData& fakeQuantizeOnData,
         const FakeQuantizeOnWeights& fakeQuantizeOnWeights);
+
+    static std::shared_ptr<ngraph::Function> get(
+        const ngraph::element::Type precision,
+        const ngraph::Shape& inputShape,
+        const FakeQuantizeOnDataWithConstant& fakeQuantizeOnData,
+        const DequantizationOperations::Convert& convertOnData,
+        const DequantizationOperations& dequantizationOnData,
+        const Constant& constantOnWeights,
+        const FakeQuantizeOnWeights& fakeQuantizeOnWeights,
+        const DequantizationOperations::Convert& convertOnWeights,
+        const DequantizationOperations& dequantizationOnWeights,
+        const DequantizationOperations& dequantizationAfter,
+        const std::string operation = "Convolution");
 };
 
 }  // namespace subgraph

--- a/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/get_dequantization_function.hpp
+++ b/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/get_dequantization_function.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -8,6 +8,8 @@
 #include <vector>
 #include <ngraph/ngraph.hpp>
 #include <low_precision/common/fake_quantize_dequantization.hpp>
+#include "lpt_ngraph_functions/common/dequantization_operations.hpp"
+#include "lpt_ngraph_functions/common/fake_quantize_on_data.hpp"
 
 namespace ngraph {
 namespace builder {
@@ -15,6 +17,18 @@ namespace subgraph {
 
 class GetDequantizationFunction {
 public:
+    static std::shared_ptr<ngraph::Function> get(
+        const ngraph::element::Type& precision,
+        const Shape& shape,
+        const FakeQuantizeOnData& fakeQuantize,
+        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore);
+
+    static std::shared_ptr<ngraph::Function> get(
+        const ngraph::element::Type& precision,
+        const Shape& shape,
+        const FakeQuantizeOnData& fakeQuantize,
+        const ngraph::pass::low_precision::FakeQuantizeDequantization& dequantization);
+
     static std::shared_ptr<ngraph::Function> getOriginal(
         bool isConvert, bool isSubtract, size_t subDataInput, size_t mulDataInput);
 

--- a/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/group_convolution_function.hpp
+++ b/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/group_convolution_function.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -34,14 +34,15 @@ public:
         const FakeQuantizeOnData& fakeQuantizeOnData,
         const FakeQuantizeOnWeights& fakeQuantizeOnWeights);
 
-    static std::shared_ptr<ngraph::Function> getReference(
+    static std::shared_ptr<ngraph::Function> get(
         const ngraph::element::Type precision,
         const ngraph::Shape& inputShape,
         const ngraph::Shape& outputShape,
         const size_t groupCount,
         const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
         std::shared_ptr<ngraph::opset1::Constant> weightsConst,
-        const ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights,
+        const ngraph::builder::subgraph::FakeQuantizeOnWeights& fakeQuantizeOnWeights,
+        const ngraph::builder::subgraph::DequantizationOperations& dequantizationOnWeights,
         const ngraph::element::Type precisionAfterOperation,
         const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter,
         const ngraph::element::Type precisionAfterDequantization);

--- a/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/src/common/builders.cpp
+++ b/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/src/common/builders.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -22,9 +22,9 @@ std::shared_ptr<Node> makeDequantization(
     Output<Node> parent = data;
 
     if (!dequantizationOperations.convert.empty()) {
-        std::shared_ptr<ngraph::opset1::Convert> convert = std::make_shared<ngraph::pass::low_precision::DequantizationConvert>(
-            data,
-            dequantizationOperations.convert.outPrecision);
+        std::shared_ptr<ngraph::opset1::Convert> convert = dequantizationOperations.convert.addDequantizationAttribute ?
+            std::make_shared<ngraph::pass::low_precision::DequantizationConvert>(data, dequantizationOperations.convert.outPrecision) :
+            std::make_shared<ngraph::opset1::Convert>(data, dequantizationOperations.convert.outPrecision);
         ngraph::copy_runtime_info({ data.get_node_shared_ptr(), convert }, convert);
         parent = convert;
     }
@@ -33,8 +33,12 @@ std::shared_ptr<Node> makeDequantization(
         std::shared_ptr<ngraph::opset1::Subtract> subtract;
 
         std::vector<size_t> shape;
+        auto values = dequantizationOperations.subtract.values;
         if (dequantizationOperations.subtract.constantShapeIsDefined) {
             shape = dequantizationOperations.subtract.constantShape;
+            if (values.size() == 1ul) {
+                values = std::vector<float>(shape_size(shape), values[0]);
+            }
         } else {
             if (dequantizationOperations.subtract.values.size() == 1ul) {
                 shape = std::vector<size_t>({});
@@ -44,12 +48,25 @@ std::shared_ptr<Node> makeDequantization(
             }
         }
 
-        const auto subtractConst = std::make_shared<ngraph::opset1::Constant>(
+        std::shared_ptr<Node> subtractConst = std::make_shared<ngraph::opset1::Constant>(
             dequantizationOperations.subtract.constantPrecision != element::undefined ?
                 dequantizationOperations.subtract.constantPrecision :
                 parent.get_element_type(),
             shape,
-            dequantizationOperations.subtract.values);
+            values);
+
+        if (dequantizationOperations.subtract.addConvert) {
+            std::shared_ptr<Node> subtractConstConvert = std::make_shared<ngraph::opset1::Convert>(
+                subtractConst,
+                dequantizationOperations.subtract.outPrecision);
+
+            auto& rt = subtractConstConvert->get_rt_info();
+            for (const std::string& attribute : dequantizationOperations.subtract.convertAttributes) {
+                rt[attribute] = std::make_shared<ngraph::VariantWrapper<std::string>>("");
+            }
+
+            subtractConst = subtractConstConvert;
+        }
 
         Output<Node> leftBranchParent = dequantizationOperations.subtract.constantIndex == 1 ? parent : subtractConst;
         Output<Node> rightBranchParent = dequantizationOperations.subtract.constantIndex == 1 ? subtractConst : parent;
@@ -58,32 +75,72 @@ std::shared_ptr<Node> makeDequantization(
             (dequantizationOperations.subtract.outPrecision == parent.get_element_type())) &&
             ((dequantizationOperations.subtract.constantPrecision == element::undefined) ||
             (dequantizationOperations.subtract.constantPrecision == parent.get_element_type()))) {
-            subtract = std::make_shared<ngraph::pass::low_precision::DequantizationSubtract>(leftBranchParent, rightBranchParent);
+            subtract = dequantizationOperations.subtract.addDequantizationAttribute ?
+                std::make_shared<ngraph::pass::low_precision::DequantizationSubtract>(parent, subtractConst) :
+                std::make_shared<ngraph::opset1::Subtract>(parent, subtractConst);
         } else {
-            subtract = std::make_shared<op::TypeRelaxed<ngraph::pass::low_precision::DequantizationSubtract>>(
-                    std::vector<element::Type>{element::f32, element::f32},
-                    std::vector<element::Type>{ element::f32 },
-                    ngraph::op::TemporaryReplaceOutputType(leftBranchParent, element::f32).get(),
-                    ngraph::op::TemporaryReplaceOutputType(rightBranchParent, element::f32).get());
+            // TODO: use templates
+            if (dequantizationOperations.subtract.addDequantizationAttribute) {
+                if (dequantizationOperations.subtract.constantIndex == 1ul) {
+                    subtract = std::make_shared<op::TypeRelaxed<ngraph::pass::low_precision::DequantizationSubtract>>(
+                        std::vector<element::Type>{element::f32, element::f32},
+                        std::vector<element::Type>{ element::f32 },
+                        ngraph::op::TemporaryReplaceOutputType(parent, element::f32).get(),
+                        ngraph::op::TemporaryReplaceOutputType(subtractConst, element::f32).get());
+                } else {
+                    subtract = std::make_shared<op::TypeRelaxed<ngraph::pass::low_precision::DequantizationSubtract>>(
+                        std::vector<element::Type>{element::f32, element::f32},
+                        std::vector<element::Type>{ element::f32 },
+                        ngraph::op::TemporaryReplaceOutputType(subtractConst, element::f32).get(),
+                        ngraph::op::TemporaryReplaceOutputType(parent, element::f32).get());
+                }
+            } else {
+                if (dequantizationOperations.subtract.constantIndex == 1ul) {
+                    subtract = std::make_shared<op::TypeRelaxed<ngraph::opset1::Subtract>>(
+                        std::vector<element::Type>{element::f32, element::f32},
+                        std::vector<element::Type>{ element::f32 },
+                        ngraph::op::TemporaryReplaceOutputType(parent, element::f32).get(),
+                        ngraph::op::TemporaryReplaceOutputType(subtractConst, element::f32).get());
+                } else {
+                    subtract = std::make_shared<op::TypeRelaxed<ngraph::opset1::Subtract>>(
+                        std::vector<element::Type>{element::f32, element::f32},
+                        std::vector<element::Type>{ element::f32 },
+                        ngraph::op::TemporaryReplaceOutputType(subtractConst, element::f32).get(),
+                        ngraph::op::TemporaryReplaceOutputType(parent, element::f32).get());
+                }
+            }
+
             ngraph::pass::low_precision::NetworkHelper::setOutDataPrecision(subtract, dequantizationOperations.subtract.outPrecision);
         }
         if (!dequantizationOperations.subtract.addDequantizationAttribute) {
             ngraph::pass::low_precision::NetworkHelper::cleanRunTimeInfo(subtract);
         }
         ngraph::copy_runtime_info({ data.get_node_shared_ptr(), subtract }, subtract);
+
+        if (!dequantizationOperations.subtract.attributes.empty()) {
+            auto& rt = subtract->get_rt_info();
+            for (const std::string& attribute : dequantizationOperations.subtract.attributes) {
+                rt[attribute] = std::make_shared<ngraph::VariantWrapper<std::string>>("");
+            }
+        }
+
         parent = subtract;
     }
 
     if (!dequantizationOperations.multiply.empty()) {
         std::vector<size_t> shape;
+        auto values = dequantizationOperations.multiply.values;
         if (dequantizationOperations.multiply.constantShapeIsDefined) {
             shape = dequantizationOperations.multiply.constantShape;
+            if (values.size() == 1ul) {
+                values = std::vector<float>(shape_size(shape), values[0]);
+            }
         } else {
-            if (dequantizationOperations.multiply.values.size() == 1ul) {
+            if (values.size() == 1ul) {
                 shape = std::vector<size_t>({});
             } else {
                 shape = std::vector<size_t>(parent.get_shape().size(), 1ul);
-                shape[shape.size() >= 2 ? 1ul : 0] = dequantizationOperations.multiply.values.size();
+                shape[shape.size() >= 2 ? 1ul : 0] = values.size();
             }
         }
 
@@ -97,30 +154,51 @@ std::shared_ptr<Node> makeDequantization(
                     dequantizationOperations.multiply.constantPrecision :
                     parent.get_element_type(),
                 shape,
-                dequantizationOperations.multiply.values);
+                values);
 
-            multiply = dequantizationOperations.multiply.constantIndex == 1ul ?
-                std::make_shared<ngraph::pass::low_precision::DequantizationMultiply>(parent, constant) :
-                std::make_shared<ngraph::pass::low_precision::DequantizationMultiply>(constant, parent);
+            if (dequantizationOperations.multiply.addDequantizationAttribute) {
+                multiply = dequantizationOperations.multiply.constantIndex == 1ul ?
+                    std::make_shared<ngraph::pass::low_precision::DequantizationMultiply>(parent, constant) :
+                    std::make_shared<ngraph::pass::low_precision::DequantizationMultiply>(constant, parent);
+            } else {
+                multiply = dequantizationOperations.multiply.constantIndex == 1ul ?
+                    std::make_shared<ngraph::opset1::Multiply>(parent, constant) :
+                    std::make_shared<ngraph::opset1::Multiply>(constant, parent);
+            }
         } else {
             const std::shared_ptr<ngraph::opset1::Constant> constant = std::make_shared<ngraph::opset1::Constant>(
                 dequantizationOperations.multiply.constantPrecision != element::undefined ?
                     dequantizationOperations.multiply.constantPrecision :
                     parent.get_element_type(),
                 shape,
-                dequantizationOperations.multiply.values);
+                values);
 
-            multiply = dequantizationOperations.multiply.constantIndex == 1ul ?
-                std::make_shared<op::TypeRelaxed<ngraph::pass::low_precision::DequantizationMultiply>>(
-                    std::vector<element::Type>{element::f32, element::f32},
-                    std::vector<element::Type>{ element::f32 },
-                    ngraph::op::TemporaryReplaceOutputType(parent, element::f32).get(),
-                    ngraph::op::TemporaryReplaceOutputType(constant, element::f32).get()) :
-                std::make_shared<op::TypeRelaxed<ngraph::pass::low_precision::DequantizationMultiply>>(
-                    std::vector<element::Type>{element::f32, element::f32},
-                    std::vector<element::Type>{ element::f32 },
-                    ngraph::op::TemporaryReplaceOutputType(constant, element::f32).get(),
-                    ngraph::op::TemporaryReplaceOutputType(parent, element::f32).get());
+            // TODO: use templates
+            if (dequantizationOperations.multiply.addDequantizationAttribute) {
+                multiply = dequantizationOperations.multiply.constantIndex == 1ul ?
+                    std::make_shared<op::TypeRelaxed<ngraph::pass::low_precision::DequantizationMultiply>>(
+                        std::vector<element::Type>{element::f32, element::f32},
+                        std::vector<element::Type>{ element::f32 },
+                        ngraph::op::TemporaryReplaceOutputType(parent, element::f32).get(),
+                        ngraph::op::TemporaryReplaceOutputType(constant, element::f32).get()) :
+                    std::make_shared<op::TypeRelaxed<ngraph::pass::low_precision::DequantizationMultiply>>(
+                        std::vector<element::Type>{element::f32, element::f32},
+                        std::vector<element::Type>{ element::f32 },
+                        ngraph::op::TemporaryReplaceOutputType(constant, element::f32).get(),
+                        ngraph::op::TemporaryReplaceOutputType(parent, element::f32).get());
+            } else {
+                multiply = dequantizationOperations.multiply.constantIndex == 1ul ?
+                    std::make_shared<op::TypeRelaxed<ngraph::opset1::Multiply>>(
+                        std::vector<element::Type>{element::f32, element::f32},
+                        std::vector<element::Type>{ element::f32 },
+                        ngraph::op::TemporaryReplaceOutputType(parent, element::f32).get(),
+                        ngraph::op::TemporaryReplaceOutputType(constant, element::f32).get()) :
+                    std::make_shared<op::TypeRelaxed<ngraph::opset1::Multiply>>(
+                        std::vector<element::Type>{element::f32, element::f32},
+                        std::vector<element::Type>{ element::f32 },
+                        ngraph::op::TemporaryReplaceOutputType(constant, element::f32).get(),
+                        ngraph::op::TemporaryReplaceOutputType(parent, element::f32).get());
+            }
         }
         ngraph::copy_runtime_info({ data.get_node_shared_ptr(), multiply }, multiply);
         parent = multiply;
@@ -155,28 +233,57 @@ std::shared_ptr<ngraph::opset1::FakeQuantize> makeFakeQuantizeTypeRelaxed(
 std::shared_ptr<ngraph::opset1::FakeQuantize> makeFakeQuantize(
     const Output<Node>& input,
     const ngraph::element::Type precision,
-    const FakeQuantizeOnDataWithConstant& fqOnData) {
-    const auto inputLowNode = ngraph::builder::makeConstant(
-        precision,
-        fqOnData.constantShapes.empty() ? ngraph::Shape{} : fqOnData.constantShapes[0],
-        fqOnData.inputLowValues,
-        fqOnData.inputLowValues.empty());
+    const FakeQuantizeOnDataWithConstant& fqOnData,
+    const bool subgraphOnConstantPath) {
+    std::shared_ptr<Node> inputLowNode;
+    std::shared_ptr<Node> inputHighNode;
 
-    const auto inputHighNode = ngraph::builder::makeConstant(
-        precision,
-        fqOnData.constantShapes.empty() ? ngraph::Shape{} : fqOnData.constantShapes[1],
-        fqOnData.inputHighValues,
-        fqOnData.inputHighValues.empty());
+    if (subgraphOnConstantPath) {
+        const auto topConstant = ngraph::builder::makeConstant(precision, ngraph::Shape{1}, std::vector<float>(1, 0.f), false);
+        const auto convert = std::make_shared<opset1::Convert>(topConstant, element::f32);
+
+        const auto subtractMin = std::make_shared<opset1::Subtract>(
+            std::make_shared<opset1::Constant>(precision, ngraph::Shape{ 1 }, std::vector<float>{fqOnData.outputLowValues[0]}),
+            convert);
+        const auto subtractMax = std::make_shared<opset1::Subtract>(
+            std::make_shared<opset1::Constant>(precision, ngraph::Shape{ 1 }, std::vector<float>{fqOnData.outputHighValues[0]}),
+            convert);
+
+        inputLowNode = std::make_shared<opset1::Multiply>(
+            std::make_shared<opset1::Constant>(precision, ngraph::Shape{ 1 }, std::vector<float>{fqOnData.inputLowValues[0] / fqOnData.outputLowValues[0]}),
+            subtractMin);
+        inputHighNode = std::make_shared<opset1::Multiply>(
+            std::make_shared<opset1::Constant>(precision, ngraph::Shape{ 1 }, std::vector<float>{fqOnData.inputHighValues[0] / fqOnData.outputHighValues[0]}),
+            subtractMax);
+    } else {
+        inputLowNode = ngraph::builder::makeConstant(
+            precision,
+            fqOnData.constantShapes.empty() ? ngraph::Shape{} : fqOnData.constantShapes[0],
+            fqOnData.inputLowValues,
+            fqOnData.inputLowValues.empty());
+
+        inputHighNode = ngraph::builder::makeConstant(
+            precision,
+            fqOnData.constantShapes.empty() ?
+                ngraph::Shape{} :
+                (fqOnData.constantShapes.size() == 1 ? fqOnData.constantShapes[0] : fqOnData.constantShapes[1]),
+            fqOnData.inputHighValues,
+            fqOnData.inputHighValues.empty());
+    }
 
     const auto outputLowNode = ngraph::builder::makeConstant(
         precision,
-        fqOnData.constantShapes.empty() ? ngraph::Shape{} : fqOnData.constantShapes[2],
+        fqOnData.constantShapes.empty() ?
+            ngraph::Shape{} :
+            (fqOnData.constantShapes.size() == 1 ? fqOnData.constantShapes[0] : fqOnData.constantShapes[2]),
         fqOnData.outputLowValues,
         fqOnData.outputLowValues.empty());
 
     const auto outputHighNode = ngraph::builder::makeConstant(
         precision,
-        fqOnData.constantShapes.empty() ? ngraph::Shape{} : fqOnData.constantShapes[3],
+        fqOnData.constantShapes.empty() ?
+            ngraph::Shape{} :
+            (fqOnData.constantShapes.size() == 1 ? fqOnData.constantShapes[0] : fqOnData.constantShapes[3]),
         fqOnData.outputHighValues,
         fqOnData.outputHighValues.empty());
 

--- a/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/src/common/fake_quantize_on_data.cpp
+++ b/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/src/common/fake_quantize_on_data.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -38,6 +38,38 @@ bool FakeQuantizeOnData::isSigned() const {
 bool FakeQuantizeOnData::empty() const {
     return (quantizationLevel == 0ul) &&
         constantShape.empty() &&
+        inputLowValues.empty() &&
+        inputHighValues.empty() &&
+        outputLowValues.empty() &&
+        outputHighValues.empty();
+}
+
+FakeQuantizeOnDataWithConstant::FakeQuantizeOnDataWithConstant() :
+    quantizationLevel(0),
+    outputPrecision(ngraph::element::undefined) {}
+
+FakeQuantizeOnDataWithConstant::FakeQuantizeOnDataWithConstant(
+    const size_t quantizationLevel,
+    const std::vector<ngraph::Shape>& constantShapes,
+    const std::vector<float>& inputLowValues,
+    const std::vector<float>& inputHighValues,
+    const std::vector<float>& outputLowValues,
+    const std::vector<float>& outputHighValues,
+    const ngraph::element::Type outputPrecision) :
+    quantizationLevel(quantizationLevel),
+    constantShapes(constantShapes),
+    inputLowValues(inputLowValues),
+    inputHighValues(inputHighValues),
+    outputLowValues(outputLowValues),
+    outputHighValues(outputHighValues),
+    outputPrecision(outputPrecision)
+{}
+
+FakeQuantizeOnDataWithConstant::~FakeQuantizeOnDataWithConstant() {}
+
+bool FakeQuantizeOnDataWithConstant::empty() const {
+    return (quantizationLevel == 0ul) &&
+        constantShapes.empty() &&
         inputLowValues.empty() &&
         inputHighValues.empty() &&
         outputLowValues.empty() &&

--- a/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/src/compose_fake_quantize_function.cpp
+++ b/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/src/compose_fake_quantize_function.cpp
@@ -1,0 +1,47 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "lpt_ngraph_functions/compose_fake_quantize_function.hpp"
+#include "low_precision/network_helper.hpp"
+
+#include <ngraph/opsets/opset1.hpp>
+#include "ngraph_functions/subgraph_builders.hpp"
+#include "lpt_ngraph_functions/common/builders.hpp"
+
+using namespace ngraph::pass::low_precision;
+
+namespace ngraph {
+namespace builder {
+namespace subgraph {
+
+    std::shared_ptr<ngraph::Function> ComposeFakeQuantizeFunction::get(
+        const ngraph::element::Type precision,
+        const ngraph::Shape& inputShape,
+        const ngraph::builder::subgraph::FakeQuantizeOnData& fqOnData,
+        const ngraph::builder::subgraph::DequantizationOperations& dequantization1,
+        const ngraph::builder::subgraph::DequantizationOperations& dequantization2) {
+        const auto input = std::make_shared<ngraph::op::v0::Parameter>(precision, inputShape);
+
+        auto fakeQuantize = makeFakeQuantize(input, precision, fqOnData);
+
+        auto results = ngraph::ResultVector{};
+        if (dequantization1.empty() && dequantization2.empty()) {
+            results.push_back(std::make_shared<ngraph::opset1::Result>(fakeQuantize));
+        } else {
+            if (!dequantization1.empty()) {
+                const auto deq = makeDequantization(fakeQuantize, dequantization1);
+                results.push_back(std::make_shared<ngraph::opset1::Result>(deq));
+            }
+            if (!dequantization2.empty()) {
+                const auto deq = makeDequantization(fakeQuantize, dequantization2);
+                results.push_back(std::make_shared<ngraph::opset1::Result>(deq));
+            }
+        }
+
+        return std::make_shared<ngraph::Function>(results, ngraph::ParameterVector{ input }, "ComposeFakeQuantizeFunction");
+    }
+
+}  // namespace subgraph
+}  // namespace builder
+}  // namespace ngraph

--- a/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/src/fake_quantize_and_convolution_function.cpp
+++ b/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/src/fake_quantize_and_convolution_function.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -6,12 +6,15 @@
 
 #include <ngraph/opsets/opset1.hpp>
 #include "ngraph_functions/subgraph_builders.hpp"
+#include "lpt_ngraph_functions/common/builders.hpp"
+#include "inference_engine.hpp"
 
 namespace ngraph {
 namespace builder {
 namespace subgraph {
 
-std::shared_ptr<ngraph::Function> FakeQuantizeAndConvolutionFunction::getOriginal(
+// TODO: remove, reuse mode extended method
+std::shared_ptr<ngraph::Function> FakeQuantizeAndConvolutionFunction::get(
     const ngraph::element::Type precision,
     const ngraph::Shape& inputShape,
     const FakeQuantizeOnData& fqOnData,
@@ -44,6 +47,103 @@ std::shared_ptr<ngraph::Function> FakeQuantizeAndConvolutionFunction::getOrigina
     convolution->set_friendly_name("output");
 
     ngraph::ResultVector results{ std::make_shared<ngraph::opset1::Result>(convolution) };
+    return std::make_shared<ngraph::Function>(results, ngraph::ParameterVector{ input }, "FakeQuantizeAndConvolutionFunction");
+}
+
+std::shared_ptr<ngraph::Function> FakeQuantizeAndConvolutionFunction::get(
+    const ngraph::element::Type precision,
+    const ngraph::Shape& inputShape,
+    const FakeQuantizeOnDataWithConstant& fqOnData,
+    const DequantizationOperations::Convert& convertOnData,
+    const DequantizationOperations& dequantizationOnData,
+    const Constant& constantOnWeights,
+    const FakeQuantizeOnWeights& fqOnWeights,
+    const DequantizationOperations::Convert& convertOnWeights,
+    const DequantizationOperations& dequantizationOnWeights,
+    const DequantizationOperations& dequantizationAfter,
+    const std::string operation) {
+    const auto input = std::make_shared<ngraph::opset1::Parameter>(precision, ngraph::Shape(inputShape));
+
+    std::shared_ptr<Node> parentOnActivation = input;
+    {
+        if (!fqOnData.empty()) {
+            parentOnActivation = fqOnData.outputPrecision == element::undefined ?
+                ngraph::builder::subgraph::makeFakeQuantize(input, precision, fqOnData) :
+                ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(input, precision, fqOnData);
+        }
+
+        if (!convertOnData.empty()) {
+            parentOnActivation = std::make_shared<opset1::Convert>(parentOnActivation, convertOnData.outPrecision);
+        }
+
+        if (!dequantizationOnData.empty()) {
+            parentOnActivation = makeDequantization(parentOnActivation, dequantizationOnData);
+        }
+    }
+
+    std::shared_ptr<Node> parentOnWeights;
+    {
+        const size_t inputChannelsCount = inputShape[1];
+        const size_t outputChannelsCount = 2 * inputShape[1];
+        const Shape shape = constantOnWeights.shapeIsDefined ? constantOnWeights.shape : ngraph::Shape{ outputChannelsCount, inputChannelsCount, 1, 1 };
+        parentOnWeights = ngraph::opset1::Constant::create(
+            constantOnWeights.outPrecision,
+            shape,
+            constantOnWeights.values.size() != ngraph::shape_size(shape) ?
+                std::vector<float>(outputChannelsCount * inputChannelsCount, constantOnWeights.values[0]) :
+                constantOnWeights.values);
+
+        if (!fqOnWeights.empty()) {
+            parentOnWeights = fqOnWeights.outputPrecision == element::undefined ?
+                ngraph::builder::subgraph::makeFakeQuantize(parentOnWeights, parentOnWeights->output(0).get_element_type(), fqOnWeights) :
+                ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(parentOnWeights, parentOnWeights->output(0).get_element_type(), fqOnWeights);
+        }
+
+        if (!convertOnWeights.empty()) {
+            parentOnWeights = std::make_shared<opset1::Convert>(parentOnWeights, convertOnWeights.outPrecision);
+        }
+
+        if (!dequantizationOnWeights.empty()) {
+            parentOnWeights = makeDequantization(parentOnWeights, dequantizationOnWeights);
+        }
+    }
+
+    std::shared_ptr<Node> lastOperation;
+    if (operation == "Convolution") {
+        lastOperation = std::make_shared<ngraph::op::TypeRelaxed<ngraph::opset1::Convolution>>(
+            ngraph::opset1::Convolution(
+                ngraph::op::TemporaryReplaceOutputType(parentOnActivation, element::f32).get(),
+                ngraph::op::TemporaryReplaceOutputType(parentOnWeights, element::f32).get(),
+                ngraph::Strides{ 1, 1 },
+                ngraph::CoordinateDiff{ 0, 0 },
+                ngraph::CoordinateDiff{ 0, 0 },
+                ngraph::Strides{ 1, 1 }),
+            std::vector<element::Type>{ element::f32, element::f32 },
+            std::vector<element::Type>{});
+    } else if (operation == "GroupConvolution") {
+        std::make_shared<ngraph::op::TypeRelaxed<ngraph::opset1::GroupConvolution>>(
+            ngraph::opset1::GroupConvolution(
+                ngraph::op::TemporaryReplaceOutputType(parentOnActivation, element::f32).get(),
+                ngraph::op::TemporaryReplaceOutputType(parentOnWeights, element::f32).get(),
+                ngraph::Strides{ 1, 1 },
+                ngraph::CoordinateDiff{ 0, 0 },
+                ngraph::CoordinateDiff{ 0, 0 },
+                ngraph::Strides{ 1, 1 }),
+            std::vector<element::Type>{ element::f32, element::f32 },
+            std::vector<element::Type>{});
+    } else {
+        THROW_IE_EXCEPTION << "unknown operation type " << operation;
+    }
+
+    if (!dequantizationAfter.empty()) {
+        lastOperation->set_friendly_name("output_original");
+        lastOperation = makeDequantization(lastOperation, dequantizationAfter);
+        lastOperation->set_friendly_name("output");
+    } else {
+        lastOperation->set_friendly_name("output");
+    }
+
+    ngraph::ResultVector results{ std::make_shared<ngraph::opset1::Result>(lastOperation) };
     return std::make_shared<ngraph::Function>(results, ngraph::ParameterVector{ input }, "FakeQuantizeAndConvolutionFunction");
 }
 

--- a/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/src/get_dequantization_function.cpp
+++ b/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/src/get_dequantization_function.cpp
@@ -1,21 +1,93 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
+
+#include "lpt_ngraph_functions/get_dequantization_function.hpp"
 
 #include <vector>
 #include <memory>
 #include <vector>
 #include <ngraph/ngraph.hpp>
 
-#include <ngraph/ngraph.hpp>
-#include "lpt_ngraph_functions/get_dequantization_function.hpp"
-#include "ngraph_functions/subgraph_builders.hpp"
 #include <low_precision/common/fake_quantize_dequantization.hpp>
+#include <low_precision/network_helper.hpp>
 
+#include "ngraph_functions/subgraph_builders.hpp"
+#include "lpt_ngraph_functions/common/builders.hpp"
 
 namespace ngraph {
 namespace builder {
 namespace subgraph {
+
+std::shared_ptr<ngraph::Function> GetDequantizationFunction::get(
+    const ngraph::element::Type& precision,
+    const Shape& shape,
+    const FakeQuantizeOnData& fakeQuantize,
+    const ngraph::builder::subgraph::DequantizationOperations& dequantization) {
+    const std::shared_ptr<ngraph::Node> input = std::make_shared<ngraph::opset1::Parameter>(
+        ngraph::element::f32,
+        shape);
+
+    std::shared_ptr<ngraph::Node> parent = input;
+    if (!fakeQuantize.empty()) {
+        parent = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(parent, precision, fakeQuantize);
+    }
+
+    if (!dequantization.empty()) {
+        parent = makeDequantization(parent, dequantization);
+        parent->set_friendly_name("output");
+    }
+
+    return std::make_shared<ngraph::Function>(
+        ngraph::ResultVector{ std::make_shared<ngraph::opset1::Result>(parent) },
+        ngraph::ParameterVector{ as_type_ptr<op::v0::Parameter>(input) },
+        "DequantizationFunction");
+}
+
+std::shared_ptr<ngraph::Function> GetDequantizationFunction::get(
+    const ngraph::element::Type& precision,
+    const Shape& shape,
+    const FakeQuantizeOnData& fakeQuantize,
+    const ngraph::pass::low_precision::FakeQuantizeDequantization& dequantization) {
+    const std::shared_ptr<ngraph::Node> input = std::make_shared<ngraph::opset1::Parameter>(
+        ngraph::element::f32,
+        shape);
+
+    std::shared_ptr<ngraph::Node> parent = input;
+    if (!fakeQuantize.empty()) {
+        parent = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(parent, precision, fakeQuantize);
+    }
+
+    if (dequantization.convert != nullptr) {
+        parent = dequantization.convert->clone_with_new_inputs({ parent });
+        parent->set_friendly_name(dequantization.convert->get_friendly_name());
+    }
+
+    if (dequantization.subtract != nullptr) {
+        const auto parent2 = dequantization.subtractConvert == nullptr ?
+            std::dynamic_pointer_cast<ngraph::Node>(dequantization.subtractConstant) :
+            dequantization.subtractConvert;
+        const auto index = ngraph::pass::low_precision::NetworkHelper::getChildInputIndex(parent2, dequantization.subtract);
+        parent = dequantization.subtract->clone_with_new_inputs(index == 1ul ?
+            OutputVector{ parent, parent2 } :
+            OutputVector{ parent2, parent });
+        parent->set_friendly_name(dequantization.subtract->get_friendly_name());
+    }
+
+    if (dequantization.multiply != nullptr) {
+        const auto index = ngraph::pass::low_precision::NetworkHelper::getChildInputIndex(dequantization.multiplyConstant, dequantization.multiply);
+        parent = dequantization.multiply->clone_with_new_inputs(index == 1ul ?
+            OutputVector{ parent, dequantization.multiplyConstant } :
+            OutputVector{ dequantization.multiplyConstant, parent });
+        parent->set_friendly_name(dequantization.multiply->get_friendly_name());
+    }
+
+    return std::make_shared<ngraph::Function>(
+        ngraph::ResultVector{ std::make_shared<ngraph::opset1::Result>(parent) },
+        ngraph::ParameterVector{ as_type_ptr<op::v0::Parameter>(input) },
+        "DequantizationFunction");
+}
+
 std::shared_ptr<ngraph::Function> GetDequantizationFunction::getOriginal(
     bool isConvert, bool isSubtract, size_t subDataInput, size_t mulDataInput) {
     const std::shared_ptr<ngraph::Node> input = std::make_shared<ngraph::opset1::Parameter>(


### PR DESCRIPTION
validation:
* developer-services/job/accuracy/1087/
* developer-services/job/performance/562/ (developer-services/job/performance/552/ - on previous models)

validation:
* developer-services/job/accuracy/1015/
* developer-services/job/performance/535/ (developer-services/job/performance/543/)

validation:
* developer-services/job/accuracy/969/ (AAQ, not limited by time)
* developer-services/job/accuracy/968/ (AAQ, aborted)
* developer-services/job/performance/509/

validation:
* developer-services/job/accuracy/961/ (default)
* developer-services/job/accuracy/960/ (AAQ)

validation:
* developer-services/job/accuracy/932/ (default) (reference: developer-services/job/accuracy/950/)
* developer-services/job/accuracy/934/ (AAQ) (reference: developer-services/job/accuracy/951/)
* developer-services/job/performance/499/

validation:
* developer-services/job/accuracy/921
* developer-services/job/performance/495 (reference: developer-services/job/performance/496/)

validation:
* AVX 512 VNNI: developer-services/job/accuracy/915/
* developer-services/job/performance/493/ (developer-services/job/performance/494/)

validation:
* AVX512: developer-services/job/accuracy/871/ (reference in FP32: developer-services/job/accuracy/872/), AVX512 VNNI: general pool: developer-services/job/accuracy/903, custom pool: developer-services/job/accuracy/906/ (reference in FP32: developer-services/job/accuracy/905/, custom pool: developer-services/job/accuracy/907/)
* developer-services/job/performance/482/ 

validation:
* accuracy: developer-services/job/accuracy/854/ (reference (previous models + INT8): developer-services/job/accuracy/855, reference (new models + FP32): developer-services/job/accuracy/856/). Master on previous models in FP32: default: developer-services/job/accuracy/863/ (AAQ: developer-services/job/accuracy/857/)
* performance: developer-services/job/performance/473/ (reference: developer-services/job/performance/475/)