### PR TITLE
Specify MVN-6 operation

### DIFF
--- a/docs/doxygen/ie_docs.xml
+++ b/docs/doxygen/ie_docs.xml
@@ -145,6 +145,7 @@
                 <tab type="user" title="LogSoftmax-5" url="@ref openvino_docs_ops_activation_LogSoftmax_5"/>
                 <tab type="user" title="Loop-5" url="@ref openvino_docs_ops_infrastructure_Loop_5"/>
                 <tab type="user" title="MVN-1" url="@ref openvino_docs_ops_normalization_MVN_1"/>
+                <tab type="user" title="MVN-6" url="@ref openvino_docs_ops_normalization_MVN_6"/>
                 <tab type="user" title="MatMul-1" url="@ref openvino_docs_ops_matrix_MatMul_1"/>
                 <tab type="user" title="MaxPool-1" url="@ref openvino_docs_ops_pooling_MaxPool_1"/>
                 <tab type="user" title="Maximum-1" url="@ref openvino_docs_ops_arithmetic_Maximum_1"/>

--- a/docs/ops/normalization/MVN_6.md
+++ b/docs/ops/normalization/MVN_6.md
@@ -65,7 +65,7 @@ o_{i}=\frac{o_{i}}{\sum \sqrt {o_{k}^2}+\epsilon}
 
 * *T*: any floating point type.
 
-* *T_IND*: int64 or int32+.
+* *T_IND*: int64 or int32.
 
 **Example**
 

--- a/docs/ops/normalization/MVN_6.md
+++ b/docs/ops/normalization/MVN_6.md
@@ -1,0 +1,91 @@
+## MVN <a name="MVN"></a> {#openvino_docs_ops_normalization_MVN_6}
+
+**Versioned name**: *MVN-6*
+
+**Category**: *Normalization*
+
+**Short description**: Calculates mean-variance normalization of the input tensor.
+
+**Detailed description**
+
+*MVN* subtracts mean value from the input blob:
+\f[
+o_{i} = i_{i} - \frac{\sum{i_{k}}}{C * H * W}
+\f]
+If *normalize_variance* is set to 1, the output blob is divided by variance:
+\f[
+o_{i}=\frac{o_{i}}{\sum \sqrt {o_{k}^2+\epsilon}+\epsilon}
+\f]
+
+**Attributes**
+
+* *normalize_variance*
+
+  * **Description**: *normalize_variance* is a flag that specifies whether to perform variance normalization.
+  * **Range of values**:
+    * `false` -- do not normalize variance
+    * `true` -- normalize variance
+  * **Type**: `boolean`
+  * **Default value**: `false`
+  * **Required**: *no*
+
+* *eps*
+
+  * **Description**: *eps* is the number to be added to the variance inside sqrt to avoid division by zero when normalizing the value. For example, *epsilon* equal to 0.001 means that 0.001 is added to the variance.
+  * **Range of values**: a positive floating-point number
+  * **Type**: `float`
+  * **Default value**: None
+  * **Required**: *yes*
+
+* *how_eps_applied*
+
+  * **Description**: Choose where to add epsilon.
+  * **Range of values**:
+    * `in_sqrt` -- add epsilon inside sqrt
+    * `outside_sqrt` -- add epsilon outside of sqrt
+  * **Type**: `string`
+  * **Default value**: None
+  * **Required**: *yes*
+
+**Inputs**
+
+* **1**: `data` - input tensor to be normalized. Type *T*. Required.
+
+* **2**: `axes` - 1D tensor which specifies indices of dimensions in `data` that define normalization slices. Type *T_IND*. Required.
+
+**Outputs**
+
+* **1**: Output tensor of the same shape and type as the `data` input tensor.
+
+**Types**
+
+* *T*: any floating point type.
+
+* *T_IND*: any integer type.
+
+**Example**
+
+```xml
+<layer ... type="MVN">
+    <data eps="1e-9" how_eps_applied="in_sqrt" normalize_variance="true"/>
+    <input>
+        <port id="0">
+            <dim>6</dim>
+            <dim>12</dim>
+            <dim>10</dim>
+            <dim>24</dim>
+        </port>
+        <port id="1">
+            <dim>3</dim>         <!-- value of [0,2,3] means independent normalization per channels -->
+        </port>
+    </input>
+    <output>
+        <port id="2">
+            <dim>6</dim>
+            <dim>12</dim>
+            <dim>10</dim>
+            <dim>24</dim>
+        </port>
+    </output>
+</layer>
+```

--- a/docs/ops/normalization/MVN_6.md
+++ b/docs/ops/normalization/MVN_6.md
@@ -10,11 +10,15 @@
 
 *MVN* subtracts mean value from the input blob:
 \f[
-o_{i} = i_{i} - \frac{\sum{i_{k}}}{C * H * W}
+o_{i} = i_{i} - ReduceMean(i_{k}, axes)
 \f]
-If *normalize_variance* is set to 1, the output blob is divided by variance:
+If *normalize_variance* is set to `true`, the output blob is divided by variance. In the case of `eps_mode` equal to `inside_sqrt`:
 \f[
-o_{i}=\frac{o_{i}}{\sum \sqrt {o_{k}^2+\epsilon}+\epsilon}
+o_{i}=\frac{o_{i}}{\sum \sqrt {o_{k}^2}}
+\f]
+And in the case of `eps_mode` equal to `outside_sqrt`:
+\f[
+o_{i}=\frac{o_{i}}{\sum \sqrt {o_{k}^2}+\epsilon}
 \f]
 
 **Attributes**
@@ -31,17 +35,17 @@ o_{i}=\frac{o_{i}}{\sum \sqrt {o_{k}^2+\epsilon}+\epsilon}
 
 * *eps*
 
-  * **Description**: *eps* is the number to be added to the variance inside sqrt to avoid division by zero when normalizing the value. For example, *epsilon* equal to 0.001 means that 0.001 is added to the variance.
+  * **Description**: *eps* is the number to be added to the variance to avoid division by zero when normalizing the value.
   * **Range of values**: a positive floating-point number
   * **Type**: `float`
   * **Default value**: None
   * **Required**: *yes*
 
-* *how_eps_applied*
+* *eps_mode*
 
   * **Description**: Choose where to add epsilon.
   * **Range of values**:
-    * `in_sqrt` -- add epsilon inside sqrt
+    * `inside_sqrt` -- add epsilon inside sqrt
     * `outside_sqrt` -- add epsilon outside of sqrt
   * **Type**: `string`
   * **Default value**: None
@@ -61,7 +65,7 @@ o_{i}=\frac{o_{i}}{\sum \sqrt {o_{k}^2+\epsilon}+\epsilon}
 
 * *T*: any floating point type.
 
-* *T_IND*: any integer type.
+* *T_IND*: int64 or int32+.
 
 **Example**
 

--- a/docs/ops/normalization/MVN_6.md
+++ b/docs/ops/normalization/MVN_6.md
@@ -13,13 +13,13 @@
 o_{i} = i_{i} - ReduceMean(i_{k}, axes)
 \f]
 
-If *normalize_variance* is set to `true`, the output blob is divided by variance.
+If *normalize_variance* is set to `true`, the output blob is divided by variance. When normalizing the value, the number `eps` is added to the variance to avoid division by zero. According to the `eps_mode` flag's value, `eps` is added inside or outside sqrt:
 
-If `eps_mode` is equal to `inside_sqrt`:
+* If `eps_mode` is `inside_sqrt`:
 \f[
 o_{i}=\frac{o_{i}}{\sum \sqrt {o_{k}^2+\epsilon}}
 \f]
-If `eps_mode` equal to `outside_sqrt`:
+* If `eps_mode` is `outside_sqrt`:
 \f[
 o_{i}=\frac{o_{i}}{\sum \sqrt {o_{k}^2}+\epsilon}
 \f]

--- a/docs/ops/normalization/MVN_6.md
+++ b/docs/ops/normalization/MVN_6.md
@@ -12,11 +12,14 @@
 \f[
 o_{i} = i_{i} - ReduceMean(i_{k}, axes)
 \f]
-If *normalize_variance* is set to `true`, the output blob is divided by variance. In the case of `eps_mode` equal to `inside_sqrt`:
+
+If *normalize_variance* is set to `true`, the output blob is divided by variance.
+
+If `eps_mode` is equal to `inside_sqrt`:
 \f[
 o_{i}=\frac{o_{i}}{\sum \sqrt {o_{k}^2+\epsilon}}
 \f]
-And in the case of `eps_mode` equal to `outside_sqrt`:
+If `eps_mode` equal to `outside_sqrt`:
 \f[
 o_{i}=\frac{o_{i}}{\sum \sqrt {o_{k}^2}+\epsilon}
 \f]
@@ -27,8 +30,8 @@ o_{i}=\frac{o_{i}}{\sum \sqrt {o_{k}^2}+\epsilon}
 
   * **Description**: *normalize_variance* is a flag that specifies whether to perform variance normalization.
   * **Range of values**:
-    * `false` -- do not normalize variance
-    * `true` -- normalize variance
+    * `false` -- Do not normalize variance
+    * `true` -- Normalize variance
   * **Type**: `boolean`
   * **Default value**: `false`
   * **Required**: *no*
@@ -45,15 +48,15 @@ o_{i}=\frac{o_{i}}{\sum \sqrt {o_{k}^2}+\epsilon}
 
   * **Description**: Choose where to add epsilon.
   * **Range of values**:
-    * `inside_sqrt` -- add epsilon inside sqrt
-    * `outside_sqrt` -- add epsilon outside of sqrt
+    * `inside_sqrt` -- Add epsilon inside sqrt
+    * `outside_sqrt` -- Add epsilon outside of sqrt
   * **Type**: `string`
   * **Default value**: None
   * **Required**: *yes*
 
 **Inputs**
 
-* **1**: `data` - input tensor to be normalized. Type *T*. Required.
+* **1**: `data` - Input tensor to be normalized. Type *T*. Required.
 
 * **2**: `axes` - 1D tensor which specifies indices of dimensions in `data` that define normalization slices. Type *T_IND*. Required.
 

--- a/docs/ops/normalization/MVN_6.md
+++ b/docs/ops/normalization/MVN_6.md
@@ -17,11 +17,11 @@ If *normalize_variance* is set to `true`, the output blob is divided by variance
 
 * If `eps_mode` is `inside_sqrt`:
 \f[
-o_{i}=\frac{o_{i}}{\sum \sqrt {o_{k}^2+\epsilon}}
+o_{i}=\frac{o_{i}}{\sqrt {\sum {o_{k}^2}+\epsilon}}
 \f]
 * If `eps_mode` is `outside_sqrt`:
 \f[
-o_{i}=\frac{o_{i}}{\sum \sqrt {o_{k}^2}+\epsilon}
+o_{i}=\frac{o_{i}}{\sqrt {\sum {o_{k}^2}}+\epsilon}
 \f]
 
 **Attributes**

--- a/docs/ops/normalization/MVN_6.md
+++ b/docs/ops/normalization/MVN_6.md
@@ -14,7 +14,7 @@ o_{i} = i_{i} - ReduceMean(i_{k}, axes)
 \f]
 If *normalize_variance* is set to `true`, the output blob is divided by variance. In the case of `eps_mode` equal to `inside_sqrt`:
 \f[
-o_{i}=\frac{o_{i}}{\sum \sqrt {o_{k}^2}}
+o_{i}=\frac{o_{i}}{\sum \sqrt {o_{k}^2+\epsilon}}
 \f]
 And in the case of `eps_mode` equal to `outside_sqrt`:
 \f[
@@ -65,7 +65,7 @@ o_{i}=\frac{o_{i}}{\sum \sqrt {o_{k}^2}+\epsilon}
 
 * *T*: any floating point type.
 
-* *T_IND*: int64 or int32.
+* *T_IND*: `int64` or `int32`.
 
 **Example**
 

--- a/docs/ops/normalization/MVN_6.md
+++ b/docs/ops/normalization/MVN_6.md
@@ -33,8 +33,8 @@ o_{i}=\frac{o_{i}}{\sum \sqrt {o_{k}^2}+\epsilon}
     * `false` -- Do not normalize variance
     * `true` -- Normalize variance
   * **Type**: `boolean`
-  * **Default value**: `false`
-  * **Required**: *no*
+  * **Default value**: None
+  * **Required**: *yes*
 
 * *eps*
 

--- a/docs/ops/normalization/MVN_6.md
+++ b/docs/ops/normalization/MVN_6.md
@@ -13,7 +13,7 @@
 o_{i} = i_{i} - ReduceMean(i_{k}, axes)
 \f]
 
-If *normalize_variance* is set to `true`, the output blob is divided by variance. When normalizing the value, the number `eps` is added to the variance to avoid division by zero. According to the `eps_mode` flag's value, `eps` is added inside or outside sqrt:
+If *normalize_variance* is set to `true`, the output blob is divided by variance. When normalizing the value, the number `eps` is added to the variance to avoid division by zero. According to the `eps_mode` flag's value, `eps` is added inside or outside the sqrt:
 
 * If `eps_mode` is `inside_sqrt`:
 \f[

--- a/docs/ops/normalization/MVN_6.md
+++ b/docs/ops/normalization/MVN_6.md
@@ -74,7 +74,7 @@ o_{i}=\frac{o_{i}}{\sum \sqrt {o_{k}^2}+\epsilon}
 
 ```xml
 <layer ... type="MVN">
-    <data eps="1e-9" how_eps_applied="in_sqrt" normalize_variance="true"/>
+    <data eps="1e-9" eps_mode="inside_sqrt" normalize_variance="true"/>
     <input>
         <port id="0">
             <dim>6</dim>


### PR DESCRIPTION
MVN-6 is generalized for any input shape and provides a feature to switch how epsilon is applied: inside sqrt or outside sqrt.

Jira: #30068

List of ngraph transformations to add:

- MVN-6 decomposition
- MVN-1 to MVN-6 transformation