### PR TITLE
Fix shape inference for Transpose nodes inserted by ApplyPermutes

### DIFF
--- a/model-optimizer/mo/graph/perm_inputs.py
+++ b/model-optimizer/mo/graph/perm_inputs.py
@@ -169,6 +169,7 @@ def transpose(op_node: Node, port_info: str, input_port: int):
     transpose = create_op_with_const_inputs(
         graph, Transpose, {1: permutation.perm}, {'name': transpose_name, 'override_output_shape': True})
     op_node.in_port(input_port).get_connection().insert_node(transpose)
+    transpose.infer(transpose)
 
 
 def transpose_nchw_to_nhwc(op_node: Node, port_info: str, input_port: int):
@@ -186,6 +187,7 @@ def transpose_nchw_to_nhwc(op_node: Node, port_info: str, input_port: int):
     transpose = create_op_with_const_inputs(
         graph, Transpose, {1: perm}, {'name': transpose_name, 'override_output_shape': True})
     op_node.in_port(input_port).get_connection().insert_node(transpose)
+    transpose.infer(transpose)
 
 
 class PermuteInputs:


### PR DESCRIPTION
Ticket: #43859

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names

Validation:
* [x]  Unit tests: N/A
* [x]  Framework operation tests: N/A - no new operations
* [x]  Transformation tests: N/A - this is a fix for transformation without tests
* [x]  e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py: N/A - no new models
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list: N/A - no new operations added
* [x]  Supported **public** models list:  N/A - no new models supported
* [x]  New operations specification:  N/A - no new operations added
* [x]  Guide on how to convert the **public** model:  N/A - no new model supported
* [x]  User guide update: N/A - not needed