### PR TITLE
[IE][VPU]: Use unified pcie firmware

### DIFF
--- a/inference-engine/cmake/vpu_dependencies.cmake
+++ b/inference-engine/cmake/vpu_dependencies.cmake
@@ -13,16 +13,16 @@ endif()
 
 include(dependency_solver)
 
-set(VPU_SUPPORTED_FIRMWARES usb-ma2x8x pcie-ma248x)
+set(VPU_SUPPORTED_FIRMWARES usb-ma2x8x pcie-ma2x8x)
 set(VPU_SUPPORTED_FIRMWARES_HASH
-    "67f91ad33170ac6304772f8f7bbb9ea92bf41a86c080980644a12f66a5ef956c"
-    "bfb1b2e465e4b3c7d003a54f2d910c872a042c5b09e77a0fb12913fe253d53ae")
+    "becaeea32805cc59a59fced0ed08235255a43a3c8535a36fa376351607b24ad6"
+    "fa0303c0c073c68076190cb71ce8bf1cc04ade74ca9a7b5a538ceb99d24d3289")
 
 #
 # Default packages
 #
 
-set(FIRMWARE_PACKAGE_VERSION 1508)
+set(FIRMWARE_PACKAGE_VERSION 1521)
 set(VPU_CLC_MA2X8X_VERSION "movi-cltools-20.09.2")
 
 #
@@ -37,7 +37,7 @@ foreach(idx RANGE 0 ${num_firmwares})
 
     set(firmware_name_full ${firmware_name}.mvcmd)
     # Handle PCIe elf firmware for Windows
-    if (WIN32 AND "${firmware_name}" STREQUAL "pcie-ma248x")
+    if (WIN32 AND "${firmware_name}" STREQUAL "pcie-ma2x8x")
         set(firmware_name_full ${firmware_name}.elf)
     endif ()
 
@@ -76,7 +76,7 @@ foreach(firmware_name IN LISTS VPU_SUPPORTED_FIRMWARES)
     set(firmware_out_file "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/${firmware_name}.mvcmd")
 
     # Handle PCIe elf firmware for Windows
-    if (WIN32 AND "${firmware_name}" STREQUAL "pcie-ma248x")
+    if (WIN32 AND "${firmware_name}" STREQUAL "pcie-ma2x8x")
         set(firmware_out_file "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/${firmware_name}.elf")
     endif ()
 

--- a/inference-engine/thirdparty/movidius/mvnc/src/mvnc_api.c
+++ b/inference-engine/thirdparty/movidius/mvnc/src/mvnc_api.c
@@ -424,7 +424,7 @@ static ncStatus_t getDeviceFwProtocolPrefix(const deviceDesc_t deviceDesc,
 
 static char* getDevicePlatform(deviceDesc_t deviceDesc, int useUniversalFirmware) {
     if (deviceDesc.platform == X_LINK_MYRIAD_X) {
-        if (useUniversalFirmware && deviceDesc.protocol != X_LINK_PCIE) {
+        if (useUniversalFirmware) {
             return "ma2x8x";
         } else {
             return "ma248x";

--- a/inference-engine/thirdparty/movidius/mvnc/tests/cases/mvnc_common_test_cases.cpp
+++ b/inference-engine/thirdparty/movidius/mvnc/tests/cases/mvnc_common_test_cases.cpp
@@ -100,7 +100,7 @@ std::string MvncTestsCommon::getMyriadFirmwarePath(const deviceDesc_t& in_device
 #else
         const std::string extension = "mvcmd";
 #endif
-        return firmwareDir + std::string("pcie-ma248x.") + extension;
+        return firmwareDir + std::string("pcie-ma2x8x.") + extension;
     }
 
     return getMyriadUSBFirmwarePath(in_deviceDesc.name);

--- a/inference-engine/thirdparty/movidius/tests/XLink/helpers/XLink_tests_helpers.cpp
+++ b/inference-engine/thirdparty/movidius/tests/XLink/helpers/XLink_tests_helpers.cpp
@@ -88,7 +88,7 @@ std::string XLinkTestsHelper::getMyriadFirmwarePath(const deviceDesc_t& in_devic
 #else
         const std::string extension = "mvcmd";
 #endif
-        return FIRMWARE_SUBFOLDER + std::string("pcie-ma248x.") + extension;
+        return FIRMWARE_SUBFOLDER + std::string("pcie-ma2x8x.") + extension;
     }
 
     return getMyriadUSBFirmwarePath(in_deviceDesc.name);


### PR DESCRIPTION
### Description
* Unified firmware named pcie-ma2x8x is needed to use both ma2480 and ma2085 with pcie connection.
* Update firmware built from develop branch

### Task
#-43615

### CI
* [x] - 2066