### PR TITLE
[IE][VPU]: Use unified pcie firmware

### DIFF
--- a/inference-engine/cmake/vpu_dependencies.cmake
+++ b/inference-engine/cmake/vpu_dependencies.cmake
@@ -13,13 +13,13 @@ endif()
 
 include(dependency_solver)
 
-set(VPU_SUPPORTED_FIRMWARES usb-ma2x8x pcie-ma248x)
+set(VPU_SUPPORTED_FIRMWARES usb-ma2x8x pcie-ma2x8x)
 
 #
 # Default packages
 #
 
-set(FIRMWARE_PACKAGE_VERSION 1508)
+set(FIRMWARE_PACKAGE_VERSION 1522)
 set(VPU_CLC_MA2X8X_VERSION "movi-cltools-20.09.2")
 
 #
@@ -31,7 +31,7 @@ foreach(firmware_name IN LISTS VPU_SUPPORTED_FIRMWARES)
 
     set(firmware_name_full ${firmware_name}.mvcmd)
     # Handle PCIe elf firmware for Windows
-    if (WIN32 AND "${firmware_name}" STREQUAL "pcie-ma248x")
+    if (WIN32 AND "${firmware_name}" STREQUAL "pcie-ma2x8x")
         set(firmware_name_full ${firmware_name}.elf)
     endif ()
 
@@ -69,7 +69,7 @@ foreach(firmware_name IN LISTS VPU_SUPPORTED_FIRMWARES)
     set(firmware_out_file "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/${firmware_name}.mvcmd")
 
     # Handle PCIe elf firmware for Windows
-    if (WIN32 AND "${firmware_name}" STREQUAL "pcie-ma248x")
+    if (WIN32 AND "${firmware_name}" STREQUAL "pcie-ma2x8x")
         set(firmware_out_file "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/${firmware_name}.elf")
     endif ()
 

--- a/inference-engine/thirdparty/movidius/mvnc/src/mvnc_api.c
+++ b/inference-engine/thirdparty/movidius/mvnc/src/mvnc_api.c
@@ -424,7 +424,7 @@ static ncStatus_t getDeviceFwProtocolPrefix(const deviceDesc_t deviceDesc,
 
 static char* getDevicePlatform(deviceDesc_t deviceDesc, int useUniversalFirmware) {
     if (deviceDesc.platform == X_LINK_MYRIAD_X) {
-        if (useUniversalFirmware && deviceDesc.protocol != X_LINK_PCIE) {
+        if (useUniversalFirmware) {
             return "ma2x8x";
         } else {
             return "ma248x";

--- a/inference-engine/thirdparty/movidius/mvnc/tests/cases/mvnc_common_test_cases.cpp
+++ b/inference-engine/thirdparty/movidius/mvnc/tests/cases/mvnc_common_test_cases.cpp
@@ -100,7 +100,7 @@ std::string MvncTestsCommon::getMyriadFirmwarePath(const deviceDesc_t& in_device
 #else
         const std::string extension = "mvcmd";
 #endif
-        return firmwareDir + std::string("pcie-ma248x.") + extension;
+        return firmwareDir + std::string("pcie-ma2x8x.") + extension;
     }
 
     return getMyriadUSBFirmwarePath(in_deviceDesc.name);

--- a/inference-engine/thirdparty/movidius/tests/XLink/helpers/XLink_tests_helpers.cpp
+++ b/inference-engine/thirdparty/movidius/tests/XLink/helpers/XLink_tests_helpers.cpp
@@ -88,7 +88,7 @@ std::string XLinkTestsHelper::getMyriadFirmwarePath(const deviceDesc_t& in_devic
 #else
         const std::string extension = "mvcmd";
 #endif
-        return FIRMWARE_SUBFOLDER + std::string("pcie-ma248x.") + extension;
+        return FIRMWARE_SUBFOLDER + std::string("pcie-ma2x8x.") + extension;
     }
 
     return getMyriadUSBFirmwarePath(in_deviceDesc.name);


### PR DESCRIPTION
### Description
* Unified firmware named pcie-ma2x8x is needed to use both ma2480 and ma2085 with pcie connection.
* Update firmware built from R14 release branch

### Task
#-43615

### CI
* [x] - 2067

### Links
https://github.com/openvinotoolkit/openvino/pull/3382