### PR TITLE
[IE CLDNN] Reflect output precision conversion from model reader

### DIFF
--- a/inference-engine/src/cldnn_engine/cldnn_program.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_program.cpp
@@ -5822,12 +5822,11 @@ void Program::AddOutputPrimitive(cldnn::topology& topology, std::string outputNa
 
     auto outputReorderID = "reorder:" + outputName + m_postProcessTag;
     Precision precision = outputPrecision == Precision::UNSPECIFIED ? outputData->getPrecision() : outputPrecision;
-    
+
     // Reflect output precision conversion forced during model reading
     if (precision == Precision::I64)
         precision = Precision::I32;
-    else if (precision != Precision::FP32 &&
-             precision != Precision::I32) {
+    else if (precision != Precision::FP32 && precision != Precision::I32) {
         precision = Precision::FP32;
     }
 

--- a/inference-engine/src/cldnn_engine/cldnn_program.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_program.cpp
@@ -5822,6 +5822,14 @@ void Program::AddOutputPrimitive(cldnn::topology& topology, std::string outputNa
 
     auto outputReorderID = "reorder:" + outputName + m_postProcessTag;
     Precision precision = outputPrecision == Precision::UNSPECIFIED ? outputData->getPrecision() : outputPrecision;
+    
+    // Reflect output precision conversion forced during model reading
+    if (precision == Precision::I64)
+        precision = Precision::I32;
+    else if (precision != Precision::FP32 &&
+             precision != Precision::I32) {
+        precision = Precision::FP32;
+    }
 
     // Find correct output ID. Start with name stored in IR.
     std::string outputID = outLayerName;

--- a/inference-engine/src/cldnn_engine/cldnn_program.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_program.cpp
@@ -5824,9 +5824,9 @@ void Program::AddOutputPrimitive(cldnn::topology& topology, std::string outputNa
     Precision precision = outputPrecision == Precision::UNSPECIFIED ? outputData->getPrecision() : outputPrecision;
 
     // Reflect output precision conversion forced during model reading
-    if (precision == Precision::I64)
+    if (precision == Precision::I64) {
         precision = Precision::I32;
-    else if (precision != Precision::FP32 && precision != Precision::I32) {
+    } else if (precision != Precision::FP32 && precision != Precision::I32) {
         precision = Precision::FP32;
     }
 


### PR DESCRIPTION
This patch is meant to align precision of clDNN output primitives with precision forced in model reader. Without this change it's possible that clDNN will try to create e.g. FP16 output, but due to forcing it to FP32 during model reading, we will end up with memory data type misalignment error.

JIRA: CVS-43902