### PR TITLE
[IE CLDNN] Improve network outputs detection in quantized FP16+INT8 IR to avoid converting them to FP16 precision

### DIFF
--- a/inference-engine/src/cldnn_engine/cldnn_program.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_program.cpp
@@ -405,8 +405,7 @@ Program::Program(InferenceEngine::CNNNetwork& network, std::shared_ptr<const cld
         }
     }
 
-    OutputsDataMap outputsMap;
-    network.getOutputsInfo(outputsMap);
+    OutputsDataMap outputsMap = network.getOutputsInfo(outputsMap);
 
     // [WA part2] Try to find non-quantized layers and convert them back to FP16
     if (config.enableInt8) {

--- a/inference-engine/src/cldnn_engine/cldnn_program.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_program.cpp
@@ -426,8 +426,11 @@ Program::Program(InferenceEngine::CNNNetwork& network, std::shared_ptr<const cld
                     if (GetNextLayers(l).empty())
                         is_output = true;
 
-                    // Condition above is not enough, as network output
+                    // Condition above is not enough, as network output layer
                     // can still be used in other parts of the graph
+                    // (e.g. 1st output form TopK primitive may become network output
+                    // while 2nd output from the same primitive may still be used
+                    // in the graph).
                     if (!is_output) {
                         for (auto layerOutput : l->outData) {
                             for (auto networkOutput : networkOutputs) {

--- a/inference-engine/src/cldnn_engine/cldnn_program.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_program.cpp
@@ -454,6 +454,7 @@ Program::Program(InferenceEngine::CNNNetwork& network, std::shared_ptr<const cld
                         return false;
 
                     auto type = LayerTypeFromStr(l->type);
+                    auto next = GetNextLayers(l);
 
                     if (type == LayerType::ScaleShift) {
                         // ScaleShift is supposed to return Dequantized values, so in most of the cases we can convert it's output to FP16

--- a/inference-engine/src/cldnn_engine/cldnn_program.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_program.cpp
@@ -405,7 +405,7 @@ Program::Program(InferenceEngine::CNNNetwork& network, std::shared_ptr<const cld
         }
     }
 
-    OutputsDataMap outputsMap = network.getOutputsInfo(outputsMap);
+    OutputsDataMap outputsMap = network.getOutputsInfo();
 
     // [WA part2] Try to find non-quantized layers and convert them back to FP16
     if (config.enableInt8) {

--- a/inference-engine/src/cldnn_engine/cldnn_program.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_program.cpp
@@ -405,6 +405,9 @@ Program::Program(InferenceEngine::CNNNetwork& network, std::shared_ptr<const cld
         }
     }
 
+    OutputsDataMap outputsMap;
+    network.getOutputsInfo(outputsMap);
+
     // [WA part2] Try to find non-quantized layers and convert them back to FP16
     if (config.enableInt8) {
         if (fqFound && baselineIsFP16 && config.enable_fp16_for_quantized_models) {
@@ -417,13 +420,37 @@ Program::Program(InferenceEngine::CNNNetwork& network, std::shared_ptr<const cld
                 if (layer->outData.empty() || layer->insData.empty())
                     continue;
 
-                auto canReduceOutputPrecision = [](const CNNLayerPtr& l) -> bool {
-                    auto type = LayerTypeFromStr(l->type);
-                    // Don't do conversion for outputs
-                    auto next = GetNextLayers(l);
-                    if (next.empty()) {
-                        return false;
+                auto isOutputLayer = [](const CNNLayerPtr& l, const OutputsDataMap& networkOutputs) -> bool {
+                    bool is_output = false;
+
+                    if (GetNextLayers(l).empty())
+                        is_output = true;
+
+                    // Condition above is not enough, as network output
+                    // can still be used in other parts of the graph
+                    if (!is_output) {
+                        for (auto layerOutput : l->outData) {
+                            for (auto networkOutput : networkOutputs) {
+                               if (layerOutput->getName() == networkOutput.second->getName()) {
+                                   is_output = true;
+                                   break;
+                               }
+                            }
+
+                            if (is_output)
+                                break;
+                        }
                     }
+
+                    return is_output;
+                };
+
+                auto canReduceOutputPrecision = [](const CNNLayerPtr& l, const bool isNetworkOutput) -> bool {
+                    // Don't do the conversion for network outputs
+                    if (isNetworkOutput)
+                        return false;
+
+                    auto type = LayerTypeFromStr(l->type);
 
                     if (type == LayerType::ScaleShift) {
                         // ScaleShift is supposed to return Dequantized values, so in most of the cases we can convert it's output to FP16
@@ -462,9 +489,11 @@ Program::Program(InferenceEngine::CNNNetwork& network, std::shared_ptr<const cld
                     return result;
                 };
 
+                bool is_network_output = isOutputLayer(layer, outputsMap);
+
                 if (canReducePrecision(layer)) {
-                    convertLayerPrecision<Precision::FP32, Precision::FP16>(layer, GetNextLayers(layer).empty());
-                } else if (canReduceOutputPrecision(layer)) {
+                    convertLayerPrecision<Precision::FP32, Precision::FP16>(layer, is_network_output);
+                } else if (canReduceOutputPrecision(layer, is_network_output)) {
                     for (auto &out_data : layer->outData) {
                         if (out_data->getPrecision() == Precision::FP32)
                             out_data->setPrecision(Precision::FP16);


### PR DESCRIPTION
Fallback to FP16 for non-quantized layers in quantized FP16+INT8 IR introduced in #941 shouldn't happen for network outputs. However, mechanism used to detect them was only checking if given layer has no next layers - it does not take into account the fact that even network output layers can still be used in other parts of the graph (e.g. 1st output form TopK primitive may become network output, while 2nd output from the same primitive may still be used in the graph). As a result, such FP32 outputs will be converted to FP16 precision inside clDNN, and since they were forced to have FP32 precision during model read, we end up with memory data type misalignment error.

This patch is meant to improve mechanism used to detection of network outputs for such cases to avoid converting them to FP16 precision.

Alternatively, we can keep current IE network output detection mechanism and make sure that the precision chosen for clDNN output primitives will be the same as forced during model read, something along the lines of #3405.

JIRA: CVS-43902