### PR TITLE
[IE][VPU]: Mish decomposition

### DIFF
--- a/inference-engine/src/vpu/common/include/vpu/ngraph/transformations/mish_decomposition.hpp
+++ b/inference-engine/src/vpu/common/include/vpu/ngraph/transformations/mish_decomposition.hpp
@@ -8,10 +8,11 @@
 
 namespace vpu {
 
-class ConvertExtractImagePatchesToReorgYolo : public ngraph::pass::MatcherPass {
+class MishDecomposition : public ngraph::pass::MatcherPass {
 public:
     NGRAPH_RTTI_DECLARATION;
-    ConvertExtractImagePatchesToReorgYolo();
+    MishDecomposition();
 };
 
 }  // namespace vpu
+

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/convert_extract_image_patches_to_reorg_yolo.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/convert_extract_image_patches_to_reorg_yolo.cpp
@@ -10,6 +10,8 @@
 #include <memory>
 #include <vector>
 
+NGRAPH_RTTI_DEFINITION(vpu::ConvertExtractImagePatchesToReorgYolo, "ConvertExtractImagePatchesToReorgYolo", 0);
+
 namespace vpu {
 
 ConvertExtractImagePatchesToReorgYolo::ConvertExtractImagePatchesToReorgYolo() {

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/mish_decomposition.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/mish_decomposition.cpp
@@ -1,0 +1,49 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "vpu/ngraph/transformations/mish_decomposition.hpp"
+
+#include <ngraph/opsets/opset5.hpp>
+#include <ngraph/rt_info.hpp>
+#include <ngraph/pattern/op/wrap_type.hpp>
+
+#include <memory>
+#include <vector>
+
+NGRAPH_RTTI_DEFINITION(vpu::MishDecomposition, "MishDecomposition", 0);
+
+namespace vpu {
+
+MishDecomposition::MishDecomposition() {
+    const auto mishPattern = ngraph::pattern::wrap_type<ngraph::opset5::Mish>();
+
+    ngraph::matcher_pass_callback callback = [this](ngraph::pattern::Matcher &matcher) {
+        const auto& mish = ngraph::as_type_ptr<ngraph::opset5::Mish>(matcher.get_match_root());
+
+        if (!mish || m_transformation_callback(mish)) {
+            return false;
+        }
+
+        const auto inputType = mish->input_value(0).get_element_type();
+        const auto addConst = ngraph::opset5::Constant::create(inputType, ngraph::Shape{}, {1.0f});
+
+        const auto exp = std::make_shared<ngraph::opset5::Exp>(mish->input_value(0));
+        const auto add = std::make_shared<ngraph::opset5::Add>(exp, addConst);
+        const auto log = std::make_shared<ngraph::opset5::Log>(add);
+        const auto tanh = std::make_shared<ngraph::opset5::Tanh>(log);
+        const auto mul = std::make_shared<ngraph::opset5::Multiply>(mish->input_value(0), tanh);
+
+        mul->set_friendly_name(mish->get_friendly_name());
+        ngraph::copy_runtime_info(mish, {addConst, exp, add, log, tanh, mul});
+        ngraph::replace_node(mish, mul);
+
+        return true;
+    };
+
+    const auto matcher = std::make_shared<ngraph::pattern::Matcher>(mishPattern, "MishDecomposition");
+    register_matcher(matcher, callback);
+}
+
+}  // namespace vpu
+

--- a/inference-engine/src/vpu/graph_transformer/src/frontend/frontend.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/frontend/frontend.cpp
@@ -32,6 +32,7 @@
 #include <transformations/common_optimizations/common_optimizations.hpp>
 #include <transformations/init_node_info.hpp>
 #include <vpu/ngraph/transformations/convert_extract_image_patches_to_reorg_yolo.hpp>
+#include <vpu/ngraph/transformations/mish_decomposition.hpp>
 #include <vpu/ngraph/transformations/merge_subsequent_dsr_operations.hpp>
 #include "vpu/ngraph/transformations/dynamic_to_static_shape.hpp"
 #include "vpu/ngraph/transformations/eliminate_shapeof_after_dsr.hpp"
@@ -181,6 +182,8 @@ ie::ICNNNetwork::Ptr FrontEnd::convertNetwork(ie::ICNNNetwork& network) {
     manager.register_pass<vpu::DynamicToStaticShape>();
     manager.register_pass<vpu::EliminateShapeOfAfterDSR>();
     manager.register_pass<vpu::ConvertExtractImagePatchesToReorgYolo>();
+    // WA: Mish is not accurate enough. Remove this decomposition when mish is improved
+    manager.register_pass<vpu::MishDecomposition>();
     manager.register_pass<ngraph::pass::ConvertOpSet3ToOpSet2>();
     manager.register_pass<ngraph::pass::ConvertOpSet2ToOpSet1>();
     manager.register_pass<ngraph::pass::ConvertOpSet1ToLegacy>();


### PR DESCRIPTION
### Description
Introduce vpu ngraph transformation that decomposes Mish layer with the following formula: `mish(x) = x * tanh(ln(exp(x) + 1))`. It is needed to fix the accuracy drop of Yolo-v4 public model that happened due to Mish implementation in the myriad plugin is not accurate enough. It is just a workaround and will be removed when Mish layer will be improved.
_map: 70.97% (ref: 70.96%)
coco_precision: 73.50% (ref 73.49%)_


### Task
#-40294

### CI
not needed to trigger internal VPU CI because Mish functional tests are run in github pre-commit

### Links
It is a cherry-pick of https://github.com/openvinotoolkit/openvino/pull/3411