### PR TITLE
[CPU] Improved Split layer

### DIFF
--- a/inference-engine/src/mkldnn_plugin/bf16transformer.cpp
+++ b/inference-engine/src/mkldnn_plugin/bf16transformer.cpp
@@ -210,7 +210,7 @@ void BF16Transformer::optimizeToFloat(InferenceEngine::CNNNetwork &network) {
                     }
                     bool marked = tryToMarkFP32(inputTo.second->outData[o], immutable);
                     if (marked) {
-                        toAnalyzeTensors.insert(layer->outData[o]);
+                        toAnalyzeTensors.insert(inputTo.second->outData[o]);
                     }
                 }
             }

--- a/inference-engine/src/mkldnn_plugin/bf16transformer.h
+++ b/inference-engine/src/mkldnn_plugin/bf16transformer.h
@@ -28,7 +28,7 @@ class BF16Transformer {
         { "concat", "eltwise" };
     //  prevent fallback to fp32 without considering both input and output nodes
     const InferenceEngine::details::caseless_set<std::string> _skipmarking =
-        { "memory" };
+        { "memory", "Split" };
 
     /**
     * Tries to mark tensor as FP32 by analyzing of local consumers of the tensor. Do not mark if

--- a/inference-engine/src/mkldnn_plugin/mkldnn_edge.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_edge.cpp
@@ -93,7 +93,7 @@ bool MKLDNNEdge::needReorder() {
     };
 
     const auto portChildEdges = getParent()->getChildEdgesAtPort(inNumber);
-    if (in_place && detectInPlaceChildsNum(portChildEdges) > 1 && childCanChangeMem)
+    if (in_place && childCanChangeMem && portChildEdges.size() > 1 && detectInPlaceChildsNum(portChildEdges) > 1)
         canBeInPlaceConflicts = true;
     if (!canBeInPlaceConflicts && in_place && !getParent()->getChildEdges().empty()) {
         for (auto &p_edge_peer : portChildEdges) {

--- a/inference-engine/src/mkldnn_plugin/mkldnn_memory.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_memory.cpp
@@ -595,6 +595,7 @@ MKLDNNMemoryDesc::operator InferenceEngine::TensorDesc() const {
             blkDims = dims;
             break;
         case memory::tnc:
+        case memory::ncw:
             layout = Layout::CHW;
             order = {0, 1, 2};
             blkDims = dims;
@@ -605,6 +606,13 @@ MKLDNNMemoryDesc::operator InferenceEngine::TensorDesc() const {
             blkDims = {static_cast<size_t>(dims[1]),
                        static_cast<size_t>(dims[0]),
                        static_cast<size_t>(dims[2])};
+            break;
+        case memory::nwc:
+            layout = Layout::CHW;
+            order = {0, 2, 1};
+            blkDims = {static_cast<size_t>(dims[0]),
+                       static_cast<size_t>(dims[2]),
+                       static_cast<size_t>(dims[1])};
             break;
         case memory::oihw:
         case memory::nchw:

--- a/inference-engine/src/mkldnn_plugin/mkldnn_memory.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_memory.cpp
@@ -303,24 +303,6 @@ memory::format MKLDNNMemory::GetPlainFormat(memory::dims dims) {
     }
 }
 
-memory::format MKLDNNMemory::GetPerChannelFormat(memory::dims dims) {
-    switch (dims.size()) {
-        case 0:
-        case 1:
-            return memory::x;
-        case 2:
-            return memory::nc;
-        case 3:
-            return memory::nwc;
-        case 4:
-            return memory::nhwc;
-        case 5:
-            return memory::ndhwc;
-        default:
-            return memory::blocked;
-    }
-}
-
 InferenceEngine::Layout MKLDNNMemory::GetPlainLayout(memory::dims dims) {
     switch (dims.size()) {
         case 0: return Layout::SCALAR;

--- a/inference-engine/src/mkldnn_plugin/mkldnn_memory.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_memory.cpp
@@ -288,7 +288,6 @@ bool MKLDNNMemory::IsGroupedFormat(memory::format format) {
 memory::format MKLDNNMemory::GetPlainFormat(memory::dims dims) {
     switch (dims.size()) {
         case 0:
-            return memory::x;
         case 1:
             return memory::x;
         case 2:
@@ -307,7 +306,6 @@ memory::format MKLDNNMemory::GetPlainFormat(memory::dims dims) {
 memory::format MKLDNNMemory::GetPerChannelFormat(memory::dims dims) {
     switch (dims.size()) {
         case 0:
-            return memory::x;
         case 1:
             return memory::x;
         case 2:

--- a/inference-engine/src/mkldnn_plugin/mkldnn_memory.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_memory.cpp
@@ -304,6 +304,25 @@ memory::format MKLDNNMemory::GetPlainFormat(memory::dims dims) {
     }
 }
 
+memory::format MKLDNNMemory::GetPerChannelFormat(memory::dims dims) {
+    switch (dims.size()) {
+        case 0:
+            return memory::x;
+        case 1:
+            return memory::x;
+        case 2:
+            return memory::nc;
+        case 3:
+            return memory::nwc;
+        case 4:
+            return memory::nhwc;
+        case 5:
+            return memory::ndhwc;
+        default:
+            return memory::blocked;
+    }
+}
+
 InferenceEngine::Layout MKLDNNMemory::GetPlainLayout(memory::dims dims) {
     switch (dims.size()) {
         case 0: return Layout::SCALAR;

--- a/inference-engine/src/mkldnn_plugin/mkldnn_memory.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_memory.h
@@ -112,7 +112,6 @@ public:
     static bool IsPlainFormat(mkldnn::memory::format format);
     static bool IsGroupedFormat(mkldnn::memory::format format);
     static mkldnn::memory::format GetPlainFormat(mkldnn::memory::dims dims);
-    static mkldnn::memory::format GetPerChannelFormat(mkldnn::memory::dims dims);
     static InferenceEngine::Layout GetPlainLayout(mkldnn::memory::dims dims);
     static bool isConsistant(mkldnn::memory::dims dims, mkldnn::memory::format format);
     static mkldnn::memory::format Convert(const InferenceEngine::Layout layout);

--- a/inference-engine/src/mkldnn_plugin/mkldnn_memory.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_memory.h
@@ -112,6 +112,7 @@ public:
     static bool IsPlainFormat(mkldnn::memory::format format);
     static bool IsGroupedFormat(mkldnn::memory::format format);
     static mkldnn::memory::format GetPlainFormat(mkldnn::memory::dims dims);
+    static mkldnn::memory::format GetPerChannelFormat(mkldnn::memory::dims dims);
     static InferenceEngine::Layout GetPlainLayout(mkldnn::memory::dims dims);
     static bool isConsistant(mkldnn::memory::dims dims, mkldnn::memory::format format);
     static mkldnn::memory::format Convert(const InferenceEngine::Layout layout);

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.cpp
@@ -35,10 +35,22 @@ void MKLDNNSplitNode::getSupportedDescriptors() {
 }
 
 void MKLDNNSplitNode::initSupportedPrimitiveDescriptors() {
+    constexpr size_t expectedPdVectorSize = 5ul;
     if (!supportedPrimitiveDescriptors.empty())
         return;
 
-    InferenceEngine::Precision inpPrecision = getCnnLayer()->insData[0].lock()->getPrecision();
+    if (getCnnLayer()->insData.empty()) {
+        THROW_IE_EXCEPTION << "Split node '" << getName() << "' has an empty input in the CNN layer";
+    }
+
+    auto inpData = getCnnLayer()->insData[0].lock();
+    if (!inpData) {
+        THROW_IE_EXCEPTION << "Split node '" << getName() << "' input data is empty";
+    }
+
+    supportedPrimitiveDescriptors.reserve(expectedPdVectorSize);
+
+    InferenceEngine::Precision inpPrecision = inpData->getPrecision();
     auto outPrecision = inpPrecision; // the split layer doesn't convert precisions
     auto inputDataType = MKLDNNExtensionUtils::IEPrecisionToDataType(inpPrecision);
     auto outputDataType = MKLDNNExtensionUtils::IEPrecisionToDataType(outPrecision);

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.cpp
@@ -5,9 +5,7 @@
 #include "mkldnn_split_node.h"
 #include "common/cpu_memcpy.h"
 #include <legacy/ie_layers.h>
-#include <string>
 #include <vector>
-#include <map>
 #include <mkldnn_types.h>
 #include <mkldnn_extension_utils.h>
 #include <limits>
@@ -40,15 +38,12 @@ void MKLDNNSplitNode::initSupportedPrimitiveDescriptors() {
     if (!supportedPrimitiveDescriptors.empty())
         return;
 
-    InferenceEngine::Precision precision = getCnnLayer()->insData[0].lock()->getPrecision();
-    if (precision != InferenceEngine::Precision::FP32)
-        precision = InferenceEngine::Precision::FP32;
-    auto inputDataType = MKLDNNExtensionUtils::IEPrecisionToDataType(precision);
-    precision = getCnnLayer()->outData[0]->getPrecision();
-    if (precision != InferenceEngine::Precision::FP32)
-        precision = InferenceEngine::Precision::FP32;
-    auto outputDataType = MKLDNNExtensionUtils::IEPrecisionToDataType(precision);
+    InferenceEngine::Precision inpPrecision = getCnnLayer()->insData[0].lock()->getPrecision();
+    auto outPrecision = inpPrecision; // the split layer doesn't convert precisions
+    auto inputDataType = MKLDNNExtensionUtils::IEPrecisionToDataType(inpPrecision);
+    auto outputDataType = MKLDNNExtensionUtils::IEPrecisionToDataType(outPrecision);
 
+    //Set plain format
     auto srcDims = getParentEdgeAt(0)->getDims();
     auto memoryFormat = MKLDNNMemory::GetPlainFormat(srcDims);
 
@@ -88,9 +83,57 @@ void MKLDNNSplitNode::initSupportedPrimitiveDescriptors() {
         THROW_IE_EXCEPTION << "The sizes of input blob and sum of output blobs are not equal.";
     supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::ref, outFormats);
 
+    //Support per channel format
+    outFormats.clear();
+    auto perChannelFormat = MKLDNNMemory::GetPerChannelFormat(srcDims);
+    config.inConfs[0].desc = MKLDNNMemoryDesc(srcDims, inputDataType, perChannelFormat);
+    for (size_t i = 0; i < outDims.size(); ++i) {
+        auto o_Dims = outDims[i];
+        config.outConfs[i].desc = MKLDNNMemoryDesc(o_Dims, outputDataType, perChannelFormat);
+        outFormats.push_back(perChannelFormat);
+    }
+    supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::ref, outFormats);
+
+    //Support channel blocked format
+    SizeVector order(srcDims.ndims());
+    std::iota(order.begin(), order.end(), 0);
+    order.push_back(1);
+    std::vector<unsigned> blockedPdIndexes;
+
+    for (size_t sizeS : {8lu, 16lu}) {
+        SizeVector blkDims = srcDims.ToSizeVector();
+        if (blkDims[1] % sizeS)
+            continue;
+        blkDims[1] = blkDims[1] / sizeS;
+        blkDims.push_back(sizeS);
+
+        config.inConfs[0].desc = TensorDesc(inpPrecision, srcDims.ToSizeVector(), {blkDims, order});
+
+        outFormats.clear();
+        bool blocked = true;
+        for (size_t i = 0; i < outDims.size(); i++) {
+            auto dims = outDims[i].ToSizeVector();
+            blkDims = dims;
+
+            if (blkDims[1] % sizeS) {
+                blocked = false;
+                break;
+            }
+            blkDims[1] = blkDims[1] / sizeS;
+            blkDims.push_back(sizeS);
+            config.outConfs[i].desc = TensorDesc(outPrecision, dims, {blkDims, order});
+            outFormats.emplace_back(MKLDNNMemoryDesc(config.outConfs[i].desc).getFormat());
+        }
+        if (blocked) {
+            supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::ref, outFormats);
+            blockedPdIndexes.push_back(supportedPrimitiveDescriptors.size() - 1);
+        }
+    }
+
+    // Optimized inplace case
     auto numOfDim = static_cast<size_t>(srcDims.ndims());
 
-    SizeVector order;
+    order.clear();
     SizeVector offsets(numOfDim, 0lu);
     size_t offset = (std::numeric_limits<size_t>::max)();
     for (size_t i = 0; i < numOfDim; i++) {
@@ -107,31 +150,27 @@ void MKLDNNSplitNode::initSupportedPrimitiveDescriptors() {
         }
     }
 
-    config.inConfs[0].desc = TensorDesc(Precision::FP32, srcDims.ToSizeVector(), {srcDims.ToSizeVector(), order, offset, offsets, strides});
+    config.inConfs[0].desc = TensorDesc(inpPrecision, srcDims.ToSizeVector(), {srcDims.ToSizeVector(), order, offset, offsets, strides});
     outFormats.clear();
     for (size_t i = 0; i < outDims.size(); i++) {
         auto dims = outDims[i].ToSizeVector();
         config.outConfs[i].inPlace = 0;
-        config.outConfs[i].desc = TensorDesc(Precision::FP32, dims,
+        config.outConfs[i].desc = TensorDesc(outPrecision, dims,
                                             {dims, order, offset, offsets, strides});
         outFormats.push_back(MKLDNNMemory::Convert(config.outConfs[i].desc.getLayout()));
     }
     supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::unknown, outFormats);
 
-    if ((numOfDim != 4 && numOfDim != 5) || axis != 1)
-        return;
+    if (axis > 1) return;
 
-    order.push_back(1);
-    numOfDim = order.size();
-    offsets = SizeVector(numOfDim, 0lu);
+    // Optimized inplace case for blocked layout
+    for (auto index : blockedPdIndexes) {
+        const auto& refConfig = supportedPrimitiveDescriptors[index].getConfig();
 
-    // nChw8c and nChw16c
-    for (size_t sizeS : {8lu, 16lu}) {
-        SizeVector blkDims = srcDims.ToSizeVector();
-        if (blkDims[1] % sizeS)
-            continue;
-        blkDims[1] = blkDims[1] / sizeS + (blkDims[1] % sizeS ? 1lu : 0lu);
-        blkDims.push_back(sizeS);
+        order = refConfig.inConfs[0].desc.getBlockingDesc().getOrder();
+        SizeVector blkDims = refConfig.inConfs[0].desc.getBlockingDesc().getBlockDims();
+        numOfDim = blkDims.size();
+        offsets = SizeVector(numOfDim, 0lu);
 
         strides.resize(numOfDim);
         strides[numOfDim - 1] = 1lu;
@@ -142,26 +181,17 @@ void MKLDNNSplitNode::initSupportedPrimitiveDescriptors() {
                 strides[numOfDim - i] = strides[numOfDim - i + 1] * blkDims[numOfDim - i + 1];
             }
         }
-        config.inConfs[0].desc = TensorDesc(Precision::FP32, srcDims.ToSizeVector(), {blkDims, order, offset, offsets, strides});
+        config.inConfs[0].desc = TensorDesc(inpPrecision, srcDims.ToSizeVector(), {blkDims, order, offset, offsets, strides});
 
         outFormats.clear();
-        bool canInplace = true;
         for (size_t i = 0; i < outDims.size(); i++) {
-            auto dims = outDims[i].ToSizeVector();
-            blkDims = dims;
+            blkDims = refConfig.outConfs[i].desc.getBlockingDesc().getBlockDims();
+            auto dims = refConfig.outConfs[i].desc.getDims();
 
-            if (blkDims[1] % sizeS) {
-                canInplace = false;
-                break;
-            }
-            blkDims[1] = blkDims[1] / sizeS + (blkDims[1] % sizeS ? 1lu : 0lu);
-            blkDims.push_back(sizeS);
-            config.outConfs[i].desc = TensorDesc(Precision::FP32, dims, {blkDims, order, offset, offsets, strides});
-
-            outFormats.emplace_back(MKLDNNMemory::Convert(config.outConfs[i].desc.getLayout()));
+            config.outConfs[i].desc = TensorDesc(outPrecision, dims, {blkDims, order, offset, offsets, strides});
+            outFormats.emplace_back(MKLDNNMemoryDesc(config.outConfs[i].desc).getFormat());
         }
-        if (canInplace)
-            supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::unknown, outFormats);
+        supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::unknown, outFormats);
     }
 }
 
@@ -194,203 +224,14 @@ void MKLDNNSplitNode::execute(mkldnn::stream strm) {
     parallel_for2d(this->getChildEdges().size(), optimizedParams.countStrides, [&](size_t i, size_t j) {
         uint8_t* dstData = getDataPtr(this->getChildEdgeAt(i)->getMemory());
 
-        cpu_memcpy(&dstData[j * optimizedParams.sizeData[i]],
-                   &srcData[optimizedParams.srcShifts[i] + j * optimizedParams.srcStride],
-                   optimizedParams.sizeData[i]);
+        cpu_memcpy(&dstData[j * optimizedParams.dataSize[i]],
+                   &srcData[optimizedParams.srcDataOffsets[i] + j * optimizedParams.srcDataStride],
+                   optimizedParams.dataSize[i]);
     });
 }
 
 bool MKLDNNSplitNode::created() const {
     return getType() == Split;
-}
-
-void MKLDNNSplitNode::selectOptimalPrimitiveDescriptor() {
-    if (implPriorities.size() > 0 && implPriorities[0] == impl_desc_type::ref) {
-        selectPrimitiveDescriptorByIndex(0);
-        return;
-    }
-    InferenceEngine::Precision precision = getCnnLayer()->insData[0].lock()->getPrecision();
-    if (precision != InferenceEngine::Precision::FP32)
-        precision = InferenceEngine::Precision::FP32;
-    auto inputDataType = MKLDNNExtensionUtils::IEPrecisionToDataType(precision);
-    precision = getCnnLayer()->outData[0]->getPrecision();
-    if (precision != InferenceEngine::Precision::FP32)
-        precision = InferenceEngine::Precision::FP32;
-    auto outputDataType = MKLDNNExtensionUtils::IEPrecisionToDataType(precision);
-
-    bool hasUnknown = false;
-    std::vector<size_t> canSelectPrimitive;
-    for (size_t i = 0; i < supportedPrimitiveDescriptors.size(); i++) {
-        bool hasAny = true;
-        auto &primDescInfo = supportedPrimitiveDescriptors[i];
-        if (primDescInfo.getImplementationType() != impl_desc_type::unknown ||
-            primDescInfo.getConfig().outConfs[0].inPlace < 0)
-            continue;
-        hasUnknown = true;
-        for (auto iInfo : primDescInfo.getConfig().inConfs) {
-            if (iInfo.desc.getLayout() != InferenceEngine::Layout::ANY) {
-                hasAny = false;
-                break;
-            }
-        }
-
-        if (hasAny) {
-            for (auto oInfo : primDescInfo.getConfig().outConfs) {
-                if (oInfo.desc.getLayout() != InferenceEngine::Layout::ANY) {
-                    hasAny = false;
-                    break;
-                }
-            }
-        }
-
-        if (!hasAny) {
-            canSelectPrimitive.push_back(i);
-        }
-    }
-
-    bool canOptimize = false;
-    if (hasUnknown) {
-        canOptimize = true;
-
-        if (canSelectPrimitive.size() == 1) {
-            selectPrimitiveDescriptorByIndex(static_cast<int>(canSelectPrimitive[0]));
-            return;
-        }
-    }
-
-    std::map<mkldnn::memory::format, size_t> formatFrequency;
-    for (size_t i = 0; i < getParentEdges().size(); i++) {
-        auto parentEdge = getParentEdgeAt(i);
-        auto parent = parentEdge->getParent();
-
-        if (parent->getSelectedPrimitiveDescriptor() == nullptr)
-            continue;
-
-        int outputIndex = parentEdge->getOutputNum();
-        if (outputIndex < 0)
-            THROW_IE_EXCEPTION << "Cannot find index of output node";
-        if (outputIndex >= parent->getSelectedPrimitiveDescriptor()->getConfig().outConfs.size())
-            outputIndex = 0;
-        auto outDesc = MKLDNNMemoryDesc(parent->getSelectedPrimitiveDescriptor()->getConfig().outConfs[outputIndex].desc);
-        if (!outDesc)
-            continue;
-        if (formatFrequency.find(outDesc.getFormat()) != formatFrequency.end())
-            formatFrequency[outDesc.getFormat()] += 1;
-        else
-            formatFrequency[outDesc.getFormat()] = 1;
-    }
-    for (size_t i = 0; i < getChildEdges().size(); i++) {
-        auto childEdge = getChildEdgeAt(i);
-        auto child = childEdge->getChild();
-        if (child->getSelectedPrimitiveDescriptor() == nullptr)
-            continue;
-        int inputIndex = childEdge->getOutputNum();
-        if (inputIndex < 0)
-            THROW_IE_EXCEPTION << "Cannot find index of output node";
-        if (inputIndex >= child->getSelectedPrimitiveDescriptor()->getConfig().inConfs.size())
-            inputIndex = 0;
-        auto outDesc = MKLDNNMemoryDesc(child->getSelectedPrimitiveDescriptor()->getConfig().inConfs[inputIndex].desc);
-        if (!outDesc)
-            continue;
-        if (formatFrequency.find(outDesc.getFormat()) != formatFrequency.end())
-            formatFrequency[outDesc.getFormat()] += 1;
-        else
-            formatFrequency[outDesc.getFormat()] = 1;
-    }
-
-    size_t maxCount = 0;
-    mkldnn::memory::format convertTo = MKLDNNMemory::GetPlainFormat(getParentEdgeAt(0)->getDims());
-    for (auto &it : formatFrequency) {
-        if (it.second > maxCount && !MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, it.first).blocksExtended()) {
-            maxCount = it.second;
-            convertTo = it.first;
-        }
-    }
-
-    // This logic is needed to cover cases when Split node cannot be optimized out for particular block size
-    // In general it is significantly better to have additional reorders in graph than to use reference Split implementation
-    if (convertTo == memory::nChw16c || convertTo == memory::nCdhw16c ||
-        convertTo == memory::nChw8c || convertTo == memory::nCdhw8c) {
-        int blockSize = convertTo == memory::nChw16c || convertTo == memory::nCdhw16c ? 16 : 8;
-        bool shouldDecreaseBlockSize = false;
-        for (auto& parentEdge : getParentEdges()) {
-            if (parentEdge.lock()->getDims()[1] % blockSize != 0)
-                shouldDecreaseBlockSize = true;
-        }
-
-        for (auto& childEdge : getChildEdges()) {
-            if (childEdge.lock()->getDims()[1] % blockSize != 0)
-                shouldDecreaseBlockSize = true;
-        }
-
-        if (shouldDecreaseBlockSize) {
-            int decreasedBlockSize = 8;
-            bool canDecreaseBlockSize = true;
-            for (auto &parentEdge : getParentEdges()) {
-                if (parentEdge.lock()->getDims()[1] % decreasedBlockSize != 0)
-                    canDecreaseBlockSize = false;
-            }
-
-            for (auto &childEdge : getChildEdges()) {
-                if (childEdge.lock()->getDims()[1] % decreasedBlockSize != 0)
-                    canDecreaseBlockSize = false;
-            }
-
-            if (canDecreaseBlockSize)
-                convertTo = getParentEdgeAt(0)->getDims().ndims() == 5 ? memory::nCdhw8c : memory::nChw8c;
-            else
-                convertTo = MKLDNNMemory::GetPlainFormat(getParentEdgeAt(0)->getDims());
-        }
-    }
-
-    if (canOptimize && MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, convertTo).blocksExtended())
-        canOptimize = false;
-    for (size_t i = 0; canOptimize && i < getChildEdges().size(); i++) {
-        if (MKLDNNMemoryDesc(getChildEdgeAt(i)->getDims(), outputDataType, convertTo).blocksExtended())
-            canOptimize = false;
-    }
-
-    if (canOptimize) {
-        for (auto supportedPdIndex : canSelectPrimitive) {
-            if (MKLDNNMemoryDesc(supportedPrimitiveDescriptors[supportedPdIndex].getConfig().inConfs[0].desc).getFormat() == convertTo) {
-                selectPrimitiveDescriptorByIndex(static_cast<int>(supportedPdIndex));
-                return;
-            }
-        }
-    }
-
-    for (size_t i = 0; i < supportedPrimitiveDescriptors.size(); i++) {
-        auto &primDescInfo = supportedPrimitiveDescriptors[i];
-        if (primDescInfo.getImplementationType() == impl_desc_type::unknown)
-            continue;
-        if (convertTo == MKLDNNMemoryDesc(supportedPrimitiveDescriptors[i].getConfig().outConfs[0].desc).getFormat()) {
-            size_t num = 0;
-            for (num = 0; num < getParentEdges().size(); num++) {
-                if (MKLDNNMemoryDesc(getParentEdgeAt(num)->getDims(), inputDataType, convertTo).blocksExtended())
-                    break;
-            }
-            if (num == getParentEdges().size()) {
-                selectPrimitiveDescriptorByIndex(i);
-                return;
-            }
-        }
-    }
-
-    bool convertToIsBlocked = (convertTo == mkldnn::memory::nChw8c) || (convertTo == mkldnn::memory::nCdhw8c);
-    if (canOptimize && !convertToIsBlocked) {
-        for (auto supportedPdIndex : canSelectPrimitive) {
-            auto memoryDesc = MKLDNNMemoryDesc(supportedPrimitiveDescriptors[supportedPdIndex].getConfig().inConfs[0].desc);
-            bool memoryDescFormatIsBlocked = (memoryDesc.getFormat() == mkldnn::memory::nChw8c) ||
-                    (memoryDesc.getFormat() == mkldnn::memory::nCdhw8c);
-
-            if (!memoryDescFormatIsBlocked) {
-                selectPrimitiveDescriptorByIndex(static_cast<int>(supportedPdIndex));
-                return;
-            }
-        }
-    }
-
-    selectPrimitiveDescriptorByIndex(0);
 }
 
 bool MKLDNNSplitNode::isOptimized() {
@@ -443,7 +284,6 @@ void MKLDNNSplitNode::initOptimalPrimitiveDescriptor() {
         THROW_IE_EXCEPTION << "Invalid config for Split layer " << getName();
     size_t offset = 0;
     for (size_t i = 0; i < cnnLayer->outData.size(); i++) {
-        size_t confNum = i;
         config.outConfs[i].desc = InferenceEngine::TensorDesc(config.outConfs[i].desc.getPrecision(),
                                                               config.outConfs[i].desc.getDims(), {
                                                                       config.outConfs[i].desc.getBlockingDesc().getBlockDims(),
@@ -453,8 +293,8 @@ void MKLDNNSplitNode::initOptimalPrimitiveDescriptor() {
                                                                       config.inConfs[0].desc.getBlockingDesc().getStrides()
                                                               });
         size_t axisSize = 1;
-        for (size_t j = axis; j < config.outConfs[confNum].desc.getBlockingDesc().getBlockDims().size(); j++) {
-            axisSize *= config.outConfs[confNum].desc.getBlockingDesc().getBlockDims()[j];
+        for (size_t j = axis; j < config.outConfs[i].desc.getBlockingDesc().getBlockDims().size(); j++) {
+            axisSize *= config.outConfs[i].desc.getBlockingDesc().getBlockDims()[j];
         }
         offset += axisSize;
     }
@@ -477,29 +317,44 @@ inline uint8_t* MKLDNNSplitNode::getDataPtr(const MKLDNNMemory& memoryPtr) {
 }
 
 void MKLDNNSplitNode::prepareOptimizedParams() {
-    auto srcDims = this->getParentEdgeAt(0)->getDims();
-    int nDims = srcDims.ndims();
-    uint8_t srcSizeData = this->getSelectedPrimitiveDescriptor()->getConfig().inConfs[0].desc.getPrecision().size();
+    auto inpTensorDesc = this->getSelectedPrimitiveDescriptor()->getConfig().inConfs[0].desc;
 
-    optimizedParams.countStrides = 1;
-    for (int i = 0; i < axis; i++)
-            optimizedParams.countStrides *= srcDims[i];
-
-    optimizedParams.srcStride = 0;
-    optimizedParams.sizeData.resize(this->getChildEdges().size());
-    for (int i = 0; i < this->getChildEdges().size(); i++) {
-        optimizedParams.sizeData[i] = srcSizeData;
-
-        for (int j = axis; j < nDims; j++)
-            optimizedParams.sizeData[i] *= this->getChildEdgeAt(i)->getDims()[j];
-
-        optimizedParams.srcStride += optimizedParams.sizeData[i];
+    //find axis order position
+    auto order = inpTensorDesc.getBlockingDesc().getOrder();
+    unsigned axisOrderPos = UINT_MAX;
+    for (size_t i = 0; i < order.size(); ++i) {
+        if (order[i] == axis) {
+            axisOrderPos = i;
+            break;
+        }
+    }
+    if (UINT_MAX == axisOrderPos) {
+        THROW_IE_EXCEPTION << "Can't find the axis in the input tensor order list";
     }
 
-    optimizedParams.srcShifts.resize(this->getChildEdges().size());
-    optimizedParams.srcShifts[0] = 0;
+    uint8_t srcDataSize = inpTensorDesc.getPrecision().size();
+    auto srcDims = inpTensorDesc.getBlockingDesc().getBlockDims();
+    int nDims = srcDims.size();
+
+    optimizedParams.countStrides = 1;
+    for (int i = 0; i < axisOrderPos; i++)
+            optimizedParams.countStrides *= srcDims[i];
+
+    optimizedParams.srcDataStride = 0;
+    optimizedParams.dataSize.resize(this->getChildEdges().size());
+    for (int i = 0; i < this->getChildEdges().size(); i++) {
+        optimizedParams.dataSize[i] = srcDataSize;
+
+        for (int j = axisOrderPos; j < nDims; j++)
+            optimizedParams.dataSize[i] *= this->getChildEdgeAt(i)->getDesc().getBlockingDesc().getBlockDims()[j];
+
+        optimizedParams.srcDataStride += optimizedParams.dataSize[i];
+    }
+
+    optimizedParams.srcDataOffsets.resize(this->getChildEdges().size());
+    optimizedParams.srcDataOffsets[0] = 0;
     for (int i = 1; i < this->getChildEdges().size(); i++) {
-        optimizedParams.srcShifts[i] = optimizedParams.srcShifts[i - 1] + optimizedParams.sizeData[i - 1];
+        optimizedParams.srcDataOffsets[i] = optimizedParams.srcDataOffsets[i - 1] + optimizedParams.dataSize[i - 1];
     }
 }
 REG_MKLDNN_PRIM_FOR(MKLDNNSplitNode, Split);

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.h
@@ -28,10 +28,17 @@ public:
     void setDynamicBatchLim(int lim) override;
 
 private:
-    void optimizedImpl(size_t MB);
+    inline uint8_t* getDataPtr(const MKLDNNMemory& memoryPtr);
+    void prepareOptimizedParams();
 
-    bool canUseOptimizedImpl = true;
     size_t axis = 1;
+
+    struct {
+        std::vector<size_t> sizeData;
+        std::vector<size_t> srcShifts;
+        size_t srcStride;
+        size_t countStrides;
+    } optimizedParams;
 };
 
 }  // namespace MKLDNNPlugin

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.h
@@ -17,6 +17,7 @@ public:
 
     void getSupportedDescriptors() override;
     void initSupportedPrimitiveDescriptors() override;
+    void selectOptimalPrimitiveDescriptor() override;
     void createPrimitive() override;
     void execute(mkldnn::stream strm) override;
     bool created() const override;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.h
@@ -17,7 +17,6 @@ public:
 
     void getSupportedDescriptors() override;
     void initSupportedPrimitiveDescriptors() override;
-    void selectOptimalPrimitiveDescriptor() override;
     void createPrimitive() override;
     void execute(mkldnn::stream strm) override;
     bool created() const override;
@@ -34,9 +33,9 @@ private:
     size_t axis = 1;
 
     struct {
-        std::vector<size_t> sizeData;
-        std::vector<size_t> srcShifts;
-        size_t srcStride;
+        std::vector<size_t> dataSize;
+        std::vector<size_t> srcDataOffsets;
+        size_t srcDataStride;
         size_t countStrides;
     } optimizedParams;
 };

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.h
@@ -27,7 +27,6 @@ public:
     void setDynamicBatchLim(int lim) override;
 
 private:
-    inline uint8_t* getDataPtr(const MKLDNNMemory& memoryPtr);
     void prepareOptimizedParams();
 
     size_t axis = 1;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.h
@@ -34,6 +34,7 @@ private:
     struct {
         std::vector<size_t> dataSize;
         std::vector<size_t> srcDataOffsets;
+        std::vector<uint8_t *> dstMemPtrs;
         size_t srcDataStride;
         size_t countStrides;
     } optimizedParams;

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/region_yolo.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/region_yolo.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include <shared_test_classes/single_layer/region_yolo.hpp>
 #include "ngraph_functions/builders.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/split.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/split.cpp
@@ -91,8 +91,8 @@ const auto planar_5D_ref = CPUSpecificParams{{ncdhw}, {ncdhw}, {"ref"}, "ref"};
 const auto planar_4D = CPUSpecificParams{{nchw}, {nchw}, {}, "unknown"};
 const auto planar_5D = CPUSpecificParams{{ncdhw}, {ncdhw}, {}, "unknown"};
 
-const auto planarChannels_4D = CPUSpecificParams{{nhwc}, {nhwc}, {}, "ref"};
-const auto planarChannels_5D = CPUSpecificParams{{ndhwc}, {ndhwc}, {}, "ref"};
+const auto planarChannels_4D = CPUSpecificParams{{nhwc}, {nhwc}, {}, "unknown"};
+const auto planarChannels_5D = CPUSpecificParams{{ndhwc}, {ndhwc}, {}, "unknown"};
 
 const auto blocked8_4D = CPUSpecificParams{{nChw8c}, {nChw8c}, {}, "unknown"};
 const auto blocked8_5D = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {}, "unknown"};

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/split.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/split.cpp
@@ -1,0 +1,217 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "ngraph_functions/builders.hpp"
+#include "test_utils/cpu_test_utils.hpp"
+
+using namespace InferenceEngine;
+using namespace CPUTestUtils;
+
+namespace CPULayerTestsDefinitions {
+
+typedef std::tuple<
+        size_t,                         // Num splits
+        int64_t,                        // Axis
+        InferenceEngine::Precision,     // Net precision
+        std::vector<size_t>,            // Input shapes
+        std::vector<size_t>,            // Used outputs indices
+        std::string,                    // Target device name
+        CPUSpecificParams
+> splitCPUTestParams;
+
+class SplitLayerCPUTest : public testing::WithParamInterface<splitCPUTestParams>,
+                          virtual public LayerTestsUtils::LayerTestsCommon, public CPUTestsBase {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<splitCPUTestParams> obj) {
+        size_t numSplits;
+        int64_t axis;
+        InferenceEngine::Precision netPrecision;
+        InferenceEngine::SizeVector inputShape, outIndices;
+        std::string targetDevice;
+        CPUSpecificParams cpuParams;
+        std::tie(numSplits, axis, netPrecision, inputShape, outIndices, targetDevice, cpuParams) = obj.param;
+
+        std::ostringstream result;
+        result << "IS=" << CommonTestUtils::vec2str(inputShape) << "_";
+        result << "numSplits=" << numSplits << "_";
+        result << "axis=" << axis << "_";
+        if (!outIndices.empty()) {
+            result << "outIndices" << CommonTestUtils::vec2str(outIndices) << "_";
+        }
+        result << "netPRC=" << netPrecision.name() << "_";
+        result << "trgDev=" << targetDevice;
+        result << CPUTestsBase::getTestCaseName(cpuParams);
+        return result.str();
+    }
+protected:
+    void SetUp() override {
+        SetRefMode(LayerTestsUtils::RefMode::CONSTANT_FOLDING);
+        size_t axis, numSplits;
+        std::vector<size_t> inputShape, outIndices;
+        InferenceEngine::Precision netPrecision;
+        CPUSpecificParams cpuParams;
+        std::tie(numSplits, axis, netPrecision, inputShape, outIndices, targetDevice, cpuParams) = this->GetParam();
+        inPrc = outPrc = netPrecision;
+        if (outIndices.empty()) {
+            for (int i = 0; i < numSplits; ++i) {
+                outIndices.push_back(i);
+            }
+        }
+
+        std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
+        selectedType += std::string("_") + inPrc.name();
+
+        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+        auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
+        auto paramOuts = ngraph::helpers::convert2OutputVector(
+                ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
+        auto split = std::dynamic_pointer_cast<ngraph::opset5::Split>(ngraph::builder::makeSplit(paramOuts[0],
+                                                                                                 ngPrc, numSplits, axis));
+        ngraph::ResultVector results;
+        for (int i = 0; i < outIndices.size(); i++) {
+            results.push_back(std::make_shared<ngraph::opset5::Result>(split->output(outIndices[i])));
+        }
+        split->get_rt_info() = getCPUInfo();
+        function = std::make_shared<ngraph::Function>(results, params, "split");
+    }
+};
+
+TEST_P(SplitLayerCPUTest, CompareWithRefs) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    Run();
+    CheckCPUImpl(executableNetwork, "Split");
+}
+
+namespace {
+const auto planar_4D_ref = CPUSpecificParams{{nchw}, {nchw}, {"ref"}, "ref"};
+const auto planar_5D_ref = CPUSpecificParams{{ncdhw}, {ncdhw}, {"ref"}, "ref"};
+
+const auto planar_4D = CPUSpecificParams{{nchw}, {nchw}, {}, "unknown"};
+const auto planar_5D = CPUSpecificParams{{ncdhw}, {ncdhw}, {}, "unknown"};
+
+const auto planarChannels_4D = CPUSpecificParams{{nhwc}, {nhwc}, {}, "ref"};
+const auto planarChannels_5D = CPUSpecificParams{{ndhwc}, {ndhwc}, {}, "ref"};
+
+const auto blocked8_4D = CPUSpecificParams{{nChw8c}, {nChw8c}, {}, "unknown"};
+const auto blocked8_5D = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {}, "unknown"};
+
+const auto blocked8_4D_ref = CPUSpecificParams{{nChw8c}, {nChw8c}, {}, "ref"};
+const auto blocked8_5D_ref = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {}, "ref"};
+
+const auto blocked16_4D = CPUSpecificParams{{nChw16c}, {nChw16c}, {}, "unknown"};
+const auto blocked16_5D = CPUSpecificParams{{nCdhw16c}, {nCdhw16c}, {}, "unknown"};
+
+const auto blocked16_4D_ref = CPUSpecificParams{{nChw16c}, {nChw16c}, {}, "ref"};
+const auto blocked16_5D_ref = CPUSpecificParams{{nCdhw16c}, {nCdhw16c}, {}, "ref"};
+
+// List of precisions natively supported by mkldnn.
+const std::vector<Precision> netPrecisions = {
+        Precision::I8,
+        Precision::I16,
+        Precision::I32,
+        Precision::FP32,
+        Precision::BF16
+};
+
+INSTANTIATE_TEST_CASE_P(smoke_Split4D_CPU_Block8inPlace, SplitLayerCPUTest,
+                    ::testing::Combine(
+                            ::testing::Values(3),
+                            ::testing::Values(0, 1),
+                            ::testing::ValuesIn(netPrecisions),
+                            ::testing::Values(std::vector<size_t>({3, 24, 24, 9})),
+                            ::testing::Values(std::vector<size_t>({})),
+                            ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                            ::testing::Values(planar_4D, planar_4D_ref, planarChannels_4D, blocked8_4D)),
+                    SplitLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_Split4D_CPU_Block8, SplitLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Values(3),
+                                ::testing::Values(2, 3),
+                                ::testing::ValuesIn(netPrecisions),
+                                ::testing::Values(std::vector<size_t>({3, 24, 24, 9})),
+                                ::testing::Values(std::vector<size_t>({})),
+                                ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                                ::testing::Values(planar_4D, planar_4D_ref, planarChannels_4D, blocked8_4D_ref)),
+                        SplitLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_Split4D_CPU_Block16inPlace, SplitLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Values(4),
+                                ::testing::Values(0, 1),
+                                ::testing::ValuesIn(netPrecisions),
+                                ::testing::Values(std::vector<size_t>({4, 64, 32, 12})),
+                                ::testing::Values(std::vector<size_t>({})),
+                                ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                                ::testing::Values(blocked16_4D)),
+                        SplitLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_Split4D_CPU_Block16, SplitLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Values(4),
+                                ::testing::Values(2, 3),
+                                ::testing::ValuesIn(netPrecisions),
+                                ::testing::Values(std::vector<size_t>({4, 64, 32, 12})),
+                                ::testing::Values(std::vector<size_t>({})),
+                                ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                                ::testing::Values(blocked16_4D_ref)),
+                        SplitLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_Split5D_CPU_Block8inPlace, SplitLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Values(3),
+                                ::testing::Values(0, 1),
+                                ::testing::ValuesIn(netPrecisions),
+                                ::testing::Values(std::vector<size_t>({3, 24, 24, 9, 15})),
+                                ::testing::Values(std::vector<size_t>({})),
+                                ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                                ::testing::Values(planar_5D, planar_5D_ref, planarChannels_5D, blocked8_5D)),
+                        SplitLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_Split5D_CPU_Block8, SplitLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Values(3),
+                                ::testing::Values(2, 3, 4),
+                                ::testing::ValuesIn(netPrecisions),
+                                ::testing::Values(std::vector<size_t>({3, 24, 24, 9, 15})),
+                                ::testing::Values(std::vector<size_t>({})),
+                                ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                                ::testing::Values(planar_5D, planar_5D_ref, planarChannels_5D, blocked8_5D_ref)),
+                        SplitLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_Split5D_CPU_Block16inPlace, SplitLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Values(4),
+                                ::testing::Values(0, 1),
+                                ::testing::ValuesIn(netPrecisions),
+                                ::testing::Values(std::vector<size_t>({4, 64, 32, 12, 20})),
+                                ::testing::Values(std::vector<size_t>({})),
+                                ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                                ::testing::Values(blocked16_5D)),
+                        SplitLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_Split5D_CPU_Block16, SplitLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Values(4),
+                                ::testing::Values(2, 3, 4),
+                                ::testing::ValuesIn(netPrecisions),
+                                ::testing::Values(std::vector<size_t>({4, 64, 32, 12, 20})),
+                                ::testing::Values(std::vector<size_t>({})),
+                                ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                                ::testing::Values(blocked16_5D_ref)),
+                        SplitLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_Split3D, SplitLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Values(7),
+                                ::testing::Values(0, 1, 2),
+                                ::testing::ValuesIn(netPrecisions),
+                                ::testing::Values(std::vector<size_t>({14, 42, 21})),
+                                ::testing::Values(std::vector<size_t>({})),
+                                ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "unknown"}, CPUSpecificParams{{}, {}, {"ref"}, "ref"})),
+                                SplitLayerCPUTest::getTestCaseName);
+} // namespace
+} // namespace CPULayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/split.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/split.cpp
@@ -213,5 +213,27 @@ INSTANTIATE_TEST_CASE_P(smoke_Split3D, SplitLayerCPUTest,
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU),
                                 ::testing::Values(CPUSpecificParams{{}, {}, {}, "unknown"}, CPUSpecificParams{{}, {}, {"ref"}, "ref"})),
                                 SplitLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_Split2D, SplitLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Values(2),
+                                ::testing::Values(0, 1),
+                                ::testing::ValuesIn(netPrecisions),
+                                ::testing::Values(std::vector<size_t>({6, 12})),
+                                ::testing::Values(std::vector<size_t>({})),
+                                ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "unknown"}, CPUSpecificParams{{}, {}, {"ref"}, "ref"})),
+                        SplitLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_Split1D, SplitLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Values(5),
+                                ::testing::Values(0),
+                                ::testing::ValuesIn(netPrecisions),
+                                ::testing::Values(std::vector<size_t>({10})),
+                                ::testing::Values(std::vector<size_t>({})),
+                                ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "unknown"}, CPUSpecificParams{{}, {}, {"ref"}, "ref"})),
+                            SplitLayerCPUTest::getTestCaseName);
 } // namespace
 } // namespace CPULayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/split.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/split.cpp
@@ -91,8 +91,8 @@ const auto planar_5D_ref = CPUSpecificParams{{ncdhw}, {ncdhw}, {"ref"}, "ref"};
 const auto planar_4D = CPUSpecificParams{{nchw}, {nchw}, {}, "unknown"};
 const auto planar_5D = CPUSpecificParams{{ncdhw}, {ncdhw}, {}, "unknown"};
 
-const auto planarChannels_4D = CPUSpecificParams{{nhwc}, {nhwc}, {}, "unknown"};
-const auto planarChannels_5D = CPUSpecificParams{{ndhwc}, {ndhwc}, {}, "unknown"};
+const auto planarChannels_4D = CPUSpecificParams{{nhwc}, {nhwc}, {}, "ref"};
+const auto planarChannels_5D = CPUSpecificParams{{ndhwc}, {ndhwc}, {}, "ref"};
 
 const auto blocked8_4D = CPUSpecificParams{{nChw8c}, {nChw8c}, {}, "unknown"};
 const auto blocked8_5D = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {}, "unknown"};

--- a/inference-engine/tests_deprecated/unit/engines/mkldnn/graph/layers/internal/graph_split_test.cpp
+++ b/inference-engine/tests_deprecated/unit/engines/mkldnn/graph/layers/internal/graph_split_test.cpp
@@ -227,102 +227,102 @@ TEST_P(MKLDNNGraphSplitTests, TestsSplit) {}
 INSTANTIATE_TEST_CASE_P(
         TestsSplit, MKLDNNGraphSplitTests,
         ::testing::Values(
-                split_test_params {
-                        {1, 24, 2, 5},
-                        {{1, 16, 2, 5}, {1, 8, 2, 5}},
-                        1, 3, MKLDNNPlugin::impl_desc_type::unknown, {}, {
-                                [](MKLDNNPlugin::PrimitiveDescInfo impl) {
-                                    ASSERT_EQ(MKLDNNPlugin::impl_desc_type::ref, impl.getImplementationType());
-                                    ASSERT_EQ(1, impl.getConfig().inConfs.size());
-                                    ASSERT_EQ(2, impl.getConfig().outConfs.size());
-                                    ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().inConfs.at(0).desc.getLayout());
-                                    ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(0).desc.getLayout());
-                                    ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(1).desc.getLayout());
-                                },
-                                [](MKLDNNPlugin::PrimitiveDescInfo impl) {
-                                    ASSERT_EQ(MKLDNNPlugin::impl_desc_type::unknown, impl.getImplementationType());
-                                    ASSERT_EQ(1, impl.getConfig().inConfs.size());
-                                    ASSERT_EQ(2, impl.getConfig().outConfs.size());
-                                    ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().inConfs.at(0).desc.getLayout());
-                                    ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(0).desc.getLayout());
-                                    ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(1).desc.getLayout());
-                                },
-                                [](MKLDNNPlugin::PrimitiveDescInfo impl) {
-                                    ASSERT_EQ(MKLDNNPlugin::impl_desc_type::unknown, impl.getImplementationType());
-                                    ASSERT_EQ(1, impl.getConfig().inConfs.size());
-                                    ASSERT_EQ(2, impl.getConfig().outConfs.size());
-                                    ASSERT_EQ(InferenceEngine::Layout::BLOCKED, impl.getConfig().inConfs.at(0).desc.getLayout());
-                                    ASSERT_EQ(InferenceEngine::Layout::BLOCKED, impl.getConfig().outConfs.at(0).desc.getLayout());
-                                    ASSERT_EQ(InferenceEngine::Layout::BLOCKED, impl.getConfig().outConfs.at(1).desc.getLayout());
-                                }
-                        }
-                },
-                split_test_params {
-                        {1, 20, 2, 5},
-                        {{1, 13, 2, 5}, {1, 7, 2, 5}},
-                        1, 2, MKLDNNPlugin::impl_desc_type::unknown, {}, {
-                                [](MKLDNNPlugin::PrimitiveDescInfo impl) {
-                                    ASSERT_EQ(MKLDNNPlugin::impl_desc_type::ref, impl.getImplementationType());
-                                    ASSERT_EQ(1, impl.getConfig().inConfs.size());
-                                    ASSERT_EQ(2, impl.getConfig().outConfs.size());
-                                    ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().inConfs.at(0).desc.getLayout());
-                                    ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(0).desc.getLayout());
-                                    ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(1).desc.getLayout());
-                                },
-                                [](MKLDNNPlugin::PrimitiveDescInfo impl) {
-                                    ASSERT_EQ(MKLDNNPlugin::impl_desc_type::unknown, impl.getImplementationType());
-                                    ASSERT_EQ(1, impl.getConfig().inConfs.size());
-                                    ASSERT_EQ(2, impl.getConfig().outConfs.size());
-                                    ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().inConfs.at(0).desc.getLayout());
-                                    ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(0).desc.getLayout());
-                                    ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(1).desc.getLayout());
-                                }
-                        }
-                },
-                split_test_params {
-                        {1, 20, 2, 5},
-                        {{1, 10, 2, 5}, {1, 10, 2, 5}},
-                        1, 2, MKLDNNPlugin::impl_desc_type::unknown, {}, {
-                                [](MKLDNNPlugin::PrimitiveDescInfo impl) {
-                                    ASSERT_EQ(MKLDNNPlugin::impl_desc_type::ref, impl.getImplementationType());
-                                    ASSERT_EQ(1, impl.getConfig().inConfs.size());
-                                    ASSERT_EQ(2, impl.getConfig().outConfs.size());
-                                    ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().inConfs.at(0).desc.getLayout());
-                                    ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(0).desc.getLayout());
-                                    ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(1).desc.getLayout());
-                                },
-                                [](MKLDNNPlugin::PrimitiveDescInfo impl) {
-                                    ASSERT_EQ(MKLDNNPlugin::impl_desc_type::unknown, impl.getImplementationType());
-                                    ASSERT_EQ(1, impl.getConfig().inConfs.size());
-                                    ASSERT_EQ(2, impl.getConfig().outConfs.size());
-                                    ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().inConfs.at(0).desc.getLayout());
-                                    ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(0).desc.getLayout());
-                                    ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(1).desc.getLayout());
-                                }
-                        }
-                },
-                split_test_params {
-                        {2, 20, 2, 5},
-                        {{2, 10, 2, 5}, {2, 10, 2, 5}},
-                        1, 2, MKLDNNPlugin::impl_desc_type::unknown, {}, {
-                                [](MKLDNNPlugin::PrimitiveDescInfo impl) {
-                                    ASSERT_EQ(MKLDNNPlugin::impl_desc_type::ref, impl.getImplementationType());
-                                    ASSERT_EQ(1, impl.getConfig().inConfs.size());
-                                    ASSERT_EQ(2, impl.getConfig().outConfs.size());
-                                    ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().inConfs.at(0).desc.getLayout());
-                                    ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(0).desc.getLayout());
-                                    ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(1).desc.getLayout());
-                                },
-                                [](MKLDNNPlugin::PrimitiveDescInfo impl) {
-                                    ASSERT_EQ(MKLDNNPlugin::impl_desc_type::unknown, impl.getImplementationType());
-                                    ASSERT_EQ(1, impl.getConfig().inConfs.size());
-                                    ASSERT_EQ(2, impl.getConfig().outConfs.size());
-                                    ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().inConfs.at(0).desc.getLayout());
-                                    ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(0).desc.getLayout());
-                                    ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(1).desc.getLayout());
-                                }
-                        }
-                },
+                // split_test_params {
+                //         {1, 24, 2, 5},
+                //         {{1, 16, 2, 5}, {1, 8, 2, 5}},
+                //         1, 3, MKLDNNPlugin::impl_desc_type::unknown, {}, {
+                //                 [](MKLDNNPlugin::PrimitiveDescInfo impl) {
+                //                     ASSERT_EQ(MKLDNNPlugin::impl_desc_type::ref, impl.getImplementationType());
+                //                     ASSERT_EQ(1, impl.getConfig().inConfs.size());
+                //                     ASSERT_EQ(2, impl.getConfig().outConfs.size());
+                //                     ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().inConfs.at(0).desc.getLayout());
+                //                     ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(0).desc.getLayout());
+                //                     ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(1).desc.getLayout());
+                //                 },
+                //                 [](MKLDNNPlugin::PrimitiveDescInfo impl) {
+                //                     ASSERT_EQ(MKLDNNPlugin::impl_desc_type::unknown, impl.getImplementationType());
+                //                     ASSERT_EQ(1, impl.getConfig().inConfs.size());
+                //                     ASSERT_EQ(2, impl.getConfig().outConfs.size());
+                //                     ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().inConfs.at(0).desc.getLayout());
+                //                    ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(0).desc.getLayout());
+                //                     ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(1).desc.getLayout());
+                //                 },
+                //                 [](MKLDNNPlugin::PrimitiveDescInfo impl) {
+                //                     ASSERT_EQ(MKLDNNPlugin::impl_desc_type::unknown, impl.getImplementationType());
+                //                     ASSERT_EQ(1, impl.getConfig().inConfs.size());
+                //                     ASSERT_EQ(2, impl.getConfig().outConfs.size());
+                //                     ASSERT_EQ(InferenceEngine::Layout::BLOCKED, impl.getConfig().inConfs.at(0).desc.getLayout());
+                //                    ASSERT_EQ(InferenceEngine::Layout::BLOCKED, impl.getConfig().outConfs.at(0).desc.getLayout());
+                //                    ASSERT_EQ(InferenceEngine::Layout::BLOCKED, impl.getConfig().outConfs.at(1).desc.getLayout());
+                //                }
+                //        }
+                // },
+                // split_test_params {
+                //         {1, 20, 2, 5},
+                //         {{1, 13, 2, 5}, {1, 7, 2, 5}},
+                //         1, 2, MKLDNNPlugin::impl_desc_type::unknown, {}, {
+                //                 [](MKLDNNPlugin::PrimitiveDescInfo impl) {
+                //                     ASSERT_EQ(MKLDNNPlugin::impl_desc_type::ref, impl.getImplementationType());
+                //                     ASSERT_EQ(1, impl.getConfig().inConfs.size());
+                //                     ASSERT_EQ(2, impl.getConfig().outConfs.size());
+                //                     ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().inConfs.at(0).desc.getLayout());
+                //                     ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(0).desc.getLayout());
+                //                     ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(1).desc.getLayout());
+                //                 },
+                //                 [](MKLDNNPlugin::PrimitiveDescInfo impl) {
+                //                     ASSERT_EQ(MKLDNNPlugin::impl_desc_type::unknown, impl.getImplementationType());
+                //                     ASSERT_EQ(1, impl.getConfig().inConfs.size());
+                //                     ASSERT_EQ(2, impl.getConfig().outConfs.size());
+                //                     ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().inConfs.at(0).desc.getLayout());
+                //                     ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(0).desc.getLayout());
+                //                     ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(1).desc.getLayout());
+                //                 }
+                //         }
+                // },
+                // split_test_params {
+                //         {1, 20, 2, 5},
+                //         {{1, 10, 2, 5}, {1, 10, 2, 5}},
+                //         1, 2, MKLDNNPlugin::impl_desc_type::unknown, {}, {
+                //                 [](MKLDNNPlugin::PrimitiveDescInfo impl) {
+                //                     ASSERT_EQ(MKLDNNPlugin::impl_desc_type::ref, impl.getImplementationType());
+                //                     ASSERT_EQ(1, impl.getConfig().inConfs.size());
+                //                     ASSERT_EQ(2, impl.getConfig().outConfs.size());
+                //                     ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().inConfs.at(0).desc.getLayout());
+                //                     ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(0).desc.getLayout());
+                //                     ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(1).desc.getLayout());
+                //                 },
+                //                 [](MKLDNNPlugin::PrimitiveDescInfo impl) {
+                //                     ASSERT_EQ(MKLDNNPlugin::impl_desc_type::unknown, impl.getImplementationType());
+                //                     ASSERT_EQ(1, impl.getConfig().inConfs.size());
+                //                     ASSERT_EQ(2, impl.getConfig().outConfs.size());
+                //                     ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().inConfs.at(0).desc.getLayout());
+                //                     ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(0).desc.getLayout());
+                //                     ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(1).desc.getLayout());
+                //                 }
+                //         }
+                // },
+                // split_test_params {
+                //         {2, 20, 2, 5},
+                //         {{2, 10, 2, 5}, {2, 10, 2, 5}},
+                //         1, 2, MKLDNNPlugin::impl_desc_type::unknown, {}, {
+                //                 [](MKLDNNPlugin::PrimitiveDescInfo impl) {
+                //                     ASSERT_EQ(MKLDNNPlugin::impl_desc_type::ref, impl.getImplementationType());
+                //                     ASSERT_EQ(1, impl.getConfig().inConfs.size());
+                //                     ASSERT_EQ(2, impl.getConfig().outConfs.size());
+                //                     ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().inConfs.at(0).desc.getLayout());
+                //                    ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(0).desc.getLayout());
+                //                     ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(1).desc.getLayout());
+                //                 },
+                //                 [](MKLDNNPlugin::PrimitiveDescInfo impl) {
+                //                     ASSERT_EQ(MKLDNNPlugin::impl_desc_type::unknown, impl.getImplementationType());
+                //                     ASSERT_EQ(1, impl.getConfig().inConfs.size());
+                //                     ASSERT_EQ(2, impl.getConfig().outConfs.size());
+                //                     ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().inConfs.at(0).desc.getLayout());
+                //                     ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(0).desc.getLayout());
+                //                     ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(1).desc.getLayout());
+                //                 }
+                //         }
+                //  },
                 split_test_params {
                         {1, 24, 2, 5},
                         {{1, 16, 2, 5}, {1, 8, 2, 5}},
@@ -544,28 +544,28 @@ INSTANTIATE_TEST_CASE_P(
                 //                 }
                 //         }
                 // },
-                split_test_params {
-                        {2, 20, 2, 5},
-                        {{2, 10, 2, 5}, {2, 10, 2, 5}},
-                        1, 2, MKLDNNPlugin::impl_desc_type::unknown, {}, {
-                                [](MKLDNNPlugin::PrimitiveDescInfo impl) {
-                                    ASSERT_EQ(MKLDNNPlugin::impl_desc_type::ref, impl.getImplementationType());
-                                    ASSERT_EQ(1, impl.getConfig().inConfs.size());
-                                    ASSERT_EQ(2, impl.getConfig().outConfs.size());
-                                    ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().inConfs.at(0).desc.getLayout());
-                                    ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(0).desc.getLayout());
-                                    ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(1).desc.getLayout());
-                                },
-                                [](MKLDNNPlugin::PrimitiveDescInfo impl) {
-                                    ASSERT_EQ(MKLDNNPlugin::impl_desc_type::unknown, impl.getImplementationType());
-                                    ASSERT_EQ(1, impl.getConfig().inConfs.size());
-                                    ASSERT_EQ(2, impl.getConfig().outConfs.size());
-                                    ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().inConfs.at(0).desc.getLayout());
-                                    ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(0).desc.getLayout());
-                                    ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(1).desc.getLayout());
-                                }
-                        }
-                },
+                // split_test_params {
+                //         {2, 20, 2, 5},
+                //         {{2, 10, 2, 5}, {2, 10, 2, 5}},
+                //         1, 2, MKLDNNPlugin::impl_desc_type::unknown, {}, {
+                //                 [](MKLDNNPlugin::PrimitiveDescInfo impl) {
+                //                     ASSERT_EQ(MKLDNNPlugin::impl_desc_type::ref, impl.getImplementationType());
+                //                     ASSERT_EQ(1, impl.getConfig().inConfs.size());
+                //                     ASSERT_EQ(2, impl.getConfig().outConfs.size());
+                //                     ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().inConfs.at(0).desc.getLayout());
+                //                     ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(0).desc.getLayout());
+                //                     ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(1).desc.getLayout());
+                //                 },
+                //                 [](MKLDNNPlugin::PrimitiveDescInfo impl) {
+                //                     ASSERT_EQ(MKLDNNPlugin::impl_desc_type::unknown, impl.getImplementationType());
+                //                     ASSERT_EQ(1, impl.getConfig().inConfs.size());
+                //                     ASSERT_EQ(2, impl.getConfig().outConfs.size());
+                //                     ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().inConfs.at(0).desc.getLayout());
+                //                      ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(0).desc.getLayout());
+                //                     ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(1).desc.getLayout());
+                //                 }
+                //         }
+                // },
                 split_test_params {
                         {2, 24, 2, 5},
                         {{2, 16, 2, 5}, {2, 8, 2, 5}},

--- a/inference-engine/tests_deprecated/unit/engines/mkldnn/graph/layers/internal/graph_split_test.cpp
+++ b/inference-engine/tests_deprecated/unit/engines/mkldnn/graph/layers/internal/graph_split_test.cpp
@@ -227,174 +227,78 @@ TEST_P(MKLDNNGraphSplitTests, TestsSplit) {}
 INSTANTIATE_TEST_CASE_P(
         TestsSplit, MKLDNNGraphSplitTests,
         ::testing::Values(
-                // split_test_params {
-                //         {1, 24, 2, 5},
-                //         {{1, 16, 2, 5}, {1, 8, 2, 5}},
-                //         1, 3, MKLDNNPlugin::impl_desc_type::unknown, {}, {
-                //                 [](MKLDNNPlugin::PrimitiveDescInfo impl) {
-                //                     ASSERT_EQ(MKLDNNPlugin::impl_desc_type::ref, impl.getImplementationType());
-                //                     ASSERT_EQ(1, impl.getConfig().inConfs.size());
-                //                     ASSERT_EQ(2, impl.getConfig().outConfs.size());
-                //                     ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().inConfs.at(0).desc.getLayout());
-                //                     ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(0).desc.getLayout());
-                //                     ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(1).desc.getLayout());
-                //                 },
-                //                 [](MKLDNNPlugin::PrimitiveDescInfo impl) {
-                //                     ASSERT_EQ(MKLDNNPlugin::impl_desc_type::unknown, impl.getImplementationType());
-                //                     ASSERT_EQ(1, impl.getConfig().inConfs.size());
-                //                     ASSERT_EQ(2, impl.getConfig().outConfs.size());
-                //                     ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().inConfs.at(0).desc.getLayout());
-                //                    ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(0).desc.getLayout());
-                //                     ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(1).desc.getLayout());
-                //                 },
-                //                 [](MKLDNNPlugin::PrimitiveDescInfo impl) {
-                //                     ASSERT_EQ(MKLDNNPlugin::impl_desc_type::unknown, impl.getImplementationType());
-                //                     ASSERT_EQ(1, impl.getConfig().inConfs.size());
-                //                     ASSERT_EQ(2, impl.getConfig().outConfs.size());
-                //                     ASSERT_EQ(InferenceEngine::Layout::BLOCKED, impl.getConfig().inConfs.at(0).desc.getLayout());
-                //                    ASSERT_EQ(InferenceEngine::Layout::BLOCKED, impl.getConfig().outConfs.at(0).desc.getLayout());
-                //                    ASSERT_EQ(InferenceEngine::Layout::BLOCKED, impl.getConfig().outConfs.at(1).desc.getLayout());
-                //                }
-                //        }
-                // },
-                // split_test_params {
-                //         {1, 20, 2, 5},
-                //         {{1, 13, 2, 5}, {1, 7, 2, 5}},
-                //         1, 2, MKLDNNPlugin::impl_desc_type::unknown, {}, {
-                //                 [](MKLDNNPlugin::PrimitiveDescInfo impl) {
-                //                     ASSERT_EQ(MKLDNNPlugin::impl_desc_type::ref, impl.getImplementationType());
-                //                     ASSERT_EQ(1, impl.getConfig().inConfs.size());
-                //                     ASSERT_EQ(2, impl.getConfig().outConfs.size());
-                //                     ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().inConfs.at(0).desc.getLayout());
-                //                     ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(0).desc.getLayout());
-                //                     ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(1).desc.getLayout());
-                //                 },
-                //                 [](MKLDNNPlugin::PrimitiveDescInfo impl) {
-                //                     ASSERT_EQ(MKLDNNPlugin::impl_desc_type::unknown, impl.getImplementationType());
-                //                     ASSERT_EQ(1, impl.getConfig().inConfs.size());
-                //                     ASSERT_EQ(2, impl.getConfig().outConfs.size());
-                //                     ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().inConfs.at(0).desc.getLayout());
-                //                     ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(0).desc.getLayout());
-                //                     ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(1).desc.getLayout());
-                //                 }
-                //         }
-                // },
-                // split_test_params {
-                //         {1, 20, 2, 5},
-                //         {{1, 10, 2, 5}, {1, 10, 2, 5}},
-                //         1, 2, MKLDNNPlugin::impl_desc_type::unknown, {}, {
-                //                 [](MKLDNNPlugin::PrimitiveDescInfo impl) {
-                //                     ASSERT_EQ(MKLDNNPlugin::impl_desc_type::ref, impl.getImplementationType());
-                //                     ASSERT_EQ(1, impl.getConfig().inConfs.size());
-                //                     ASSERT_EQ(2, impl.getConfig().outConfs.size());
-                //                     ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().inConfs.at(0).desc.getLayout());
-                //                     ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(0).desc.getLayout());
-                //                     ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(1).desc.getLayout());
-                //                 },
-                //                 [](MKLDNNPlugin::PrimitiveDescInfo impl) {
-                //                     ASSERT_EQ(MKLDNNPlugin::impl_desc_type::unknown, impl.getImplementationType());
-                //                     ASSERT_EQ(1, impl.getConfig().inConfs.size());
-                //                     ASSERT_EQ(2, impl.getConfig().outConfs.size());
-                //                     ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().inConfs.at(0).desc.getLayout());
-                //                     ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(0).desc.getLayout());
-                //                     ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(1).desc.getLayout());
-                //                 }
-                //         }
-                // },
-                // split_test_params {
-                //         {2, 20, 2, 5},
-                //         {{2, 10, 2, 5}, {2, 10, 2, 5}},
-                //         1, 2, MKLDNNPlugin::impl_desc_type::unknown, {}, {
-                //                 [](MKLDNNPlugin::PrimitiveDescInfo impl) {
-                //                     ASSERT_EQ(MKLDNNPlugin::impl_desc_type::ref, impl.getImplementationType());
-                //                     ASSERT_EQ(1, impl.getConfig().inConfs.size());
-                //                     ASSERT_EQ(2, impl.getConfig().outConfs.size());
-                //                     ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().inConfs.at(0).desc.getLayout());
-                //                    ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(0).desc.getLayout());
-                //                     ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(1).desc.getLayout());
-                //                 },
-                //                 [](MKLDNNPlugin::PrimitiveDescInfo impl) {
-                //                     ASSERT_EQ(MKLDNNPlugin::impl_desc_type::unknown, impl.getImplementationType());
-                //                     ASSERT_EQ(1, impl.getConfig().inConfs.size());
-                //                     ASSERT_EQ(2, impl.getConfig().outConfs.size());
-                //                     ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().inConfs.at(0).desc.getLayout());
-                //                     ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(0).desc.getLayout());
-                //                     ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(1).desc.getLayout());
-                //                 }
-                //         }
-                //  },
                 split_test_params {
                         {1, 24, 2, 5},
                         {{1, 16, 2, 5}, {1, 8, 2, 5}},
-                        1, 3, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
+                        1, 5, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
                 },
                 split_test_params {
                         {1, 20, 2, 5},
                         {{1, 13, 2, 5}, {1, 7, 2, 5}},
-                        1, 2, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
+                        1, 3, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
                 },
                 split_test_params {
                         {1, 20, 2, 5},
                         {{1, 10, 2, 5}, {1, 10, 2, 5}},
-                        1, 2, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
+                        1, 3, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
                 },
                 split_test_params {
                         {2, 20, 2, 5},
                         {{2, 10, 2, 5}, {2, 10, 2, 5}},
-                        1, 2, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
+                        1, 3, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
                 },
                 split_test_params {
                         {2, 20, 2, 5},
                         {{2, 15, 2, 5}, {2,  5, 2, 5}},
-                        1, 2, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
+                        1, 3, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
                 },
                 split_test_params {
                         {9, 11, 7, 5},
                         {{3, 11, 7, 5}, {6, 11, 7, 5}},
-                        0, 2, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
+                        0, 3, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
                 },
                 split_test_params {
                         {3, 11, 7, 5},
                         {{3, 11, 4, 5}, {3, 11, 3, 5}},
-                        2, 2, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
+                        2, 3, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
                 },
                 split_test_params {
                         {3, 11, 7, 5},
                         {{3, 11, 7, 1}, {3, 11, 7, 4}},
-                        3, 2, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
+                        3, 3, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
                 },
                 split_test_params {
                         {5, 6, 7, 15},
                         {{1, 6, 7, 15}, {2, 6, 7, 15}, {1, 6, 7, 15}, {1, 6, 7, 15}},
-                        0, 2, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
+                        0, 3, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
                 },
                 split_test_params {
                         {5, 6, 7, 15},
                         {{5, 1, 7, 15}, {5, 2, 7, 15}, {5, 1, 7, 15}, {5, 2, 7, 15}},
-                        1, 2, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
+                        1, 3, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
                 },
                 split_test_params {
                         {5, 6, 7, 15},
                         {{5, 6, 3, 15}, {5, 6, 1, 15}, {5, 6, 2, 15}, {5, 6, 1, 15}},
-                        2, 2, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
+                        2, 3, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
                 },
                 split_test_params {
                         {5, 6, 7, 15},
                         {{5, 6, 7, 5}, {5, 6, 7, 3}, {5, 6, 7, 4}, {5, 6, 7, 3}},
-                        3, 2, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
+                        3, 3, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
                 },
                 split_test_params {
                         {5, 6, 7, 15},
                         {{5, 6, 7, 15}},
-                        1, 2, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}},
-                split_test_params {
-                        {1, 32, 16, 16, 16},
-                        {{1, 8, 16, 16, 16}, {1, 8, 16, 16, 16}, {1, 8, 16, 16, 16}, {1, 8, 16, 16, 16}},
                         1, 3, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}},
                 split_test_params {
                         {1, 32, 16, 16, 16},
                         {{1, 8, 16, 16, 16}, {1, 8, 16, 16, 16}, {1, 8, 16, 16, 16}, {1, 8, 16, 16, 16}},
-                        1, 3, MKLDNNPlugin::impl_desc_type::unknown, {}}));
+                        1, 5, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}},
+                split_test_params {
+                        {1, 32, 16, 16, 16},
+                        {{1, 8, 16, 16, 16}, {1, 8, 16, 16, 16}, {1, 8, 16, 16, 16}, {1, 8, 16, 16, 16}},
+                        1, 5, MKLDNNPlugin::impl_desc_type::unknown, {}}));
 
 class MKLDNNGraphDynBatchSplitTests: public MKLDNNGraphSplitTests {
 protected:
@@ -544,32 +448,10 @@ INSTANTIATE_TEST_CASE_P(
                 //                 }
                 //         }
                 // },
-                // split_test_params {
-                //         {2, 20, 2, 5},
-                //         {{2, 10, 2, 5}, {2, 10, 2, 5}},
-                //         1, 2, MKLDNNPlugin::impl_desc_type::unknown, {}, {
-                //                 [](MKLDNNPlugin::PrimitiveDescInfo impl) {
-                //                     ASSERT_EQ(MKLDNNPlugin::impl_desc_type::ref, impl.getImplementationType());
-                //                     ASSERT_EQ(1, impl.getConfig().inConfs.size());
-                //                     ASSERT_EQ(2, impl.getConfig().outConfs.size());
-                //                     ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().inConfs.at(0).desc.getLayout());
-                //                     ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(0).desc.getLayout());
-                //                     ASSERT_EQ(InferenceEngine::Layout::ANY, impl.getConfig().outConfs.at(1).desc.getLayout());
-                //                 },
-                //                 [](MKLDNNPlugin::PrimitiveDescInfo impl) {
-                //                     ASSERT_EQ(MKLDNNPlugin::impl_desc_type::unknown, impl.getImplementationType());
-                //                     ASSERT_EQ(1, impl.getConfig().inConfs.size());
-                //                     ASSERT_EQ(2, impl.getConfig().outConfs.size());
-                //                     ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().inConfs.at(0).desc.getLayout());
-                //                      ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(0).desc.getLayout());
-                //                     ASSERT_EQ(InferenceEngine::Layout::NCHW, impl.getConfig().outConfs.at(1).desc.getLayout());
-                //                 }
-                //         }
-                // },
                 split_test_params {
                         {2, 24, 2, 5},
                         {{2, 16, 2, 5}, {2, 8, 2, 5}},
-                        1, 3, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
+                        1, 5, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
                 },
                 // TODO: rewrite to ngraph to have reshape functionality
                 // split_test_params {
@@ -586,34 +468,34 @@ INSTANTIATE_TEST_CASE_P(
                 split_test_params {
                         {2, 20, 2, 5},
                         {{2, 10, 2, 5}, {2, 10, 2, 5}},
-                        1, 2, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
+                        1, 3, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
                 },
                 split_test_params {
                         {2, 20, 2, 5},
                         {{2, 15, 2, 5}, {2,  5, 2, 5}},
-                        1, 2, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
+                        1, 3, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
                 },
                 split_test_params {
                         {3, 11, 7, 5},
                         {{3, 11, 4, 5}, {3, 11, 3, 5}},
-                        2, 2, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
+                        2, 3, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
                 },
                 split_test_params {
                         {3, 11, 7, 5},
                         {{3, 11, 7, 1}, {3, 11, 7, 4}},
-                        3, 2, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
+                        3, 3, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
                 },
                 split_test_params {
                         {5, 6, 7, 15},
                         {{5, 1, 7, 15}, {5, 2, 7, 15}, {5, 1, 7, 15}, {5, 2, 7, 15}},
-                        1, 2, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
+                        1, 3, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
                 },
                 split_test_params {
                         {5, 6, 7, 15},
                         {{5, 6, 3, 15}, {5, 6, 1, 15}, {5, 6, 2, 15}, {5, 6, 1, 15}},
-                        2, 2, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
+                        2, 3, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
                 },
                 split_test_params {
                         {5, 6, 7, 15},
                         {{5, 6, 7, 5}, {5, 6, 7, 3}, {5, 6, 7, 4}, {5, 6, 7, 3}},
-                        3, 2, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}}));
+                        3, 3, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}}));


### PR DESCRIPTION
This PR is based on the PR https://github.com/openvinotoolkit/openvino/pull/2269. All technical requirements are listed in ticket  #34237. The main difference from the current implementation is as follows:
1. Only the same input and output data layouts and precisions are supported.
2. Performance of the main algorithm was improved.
3. Support for per channel layouts (e.g. nhwc, ndhwc etc.) was added.
4. The layer implemented as data agnostic. 