### PR TITLE
[IE]: Enables WA for NMS output name issue

### DIFF
--- a/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/convert_nms_5_to_legacy.cpp
+++ b/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/convert_nms_5_to_legacy.cpp
@@ -102,18 +102,21 @@ ngraph::pass::ConvertNMS5ToLegacyMatcher::ConvertNMS5ToLegacyMatcher() {
         Output<Node> output_0 = nms_legacy->output(0);
         if (nms_5->output(0).get_element_type() != output_0.get_element_type()) {
             output_0 = std::make_shared<opset1::Convert>(output_0, nms_5->output(0).get_element_type());
-            output_0.get_node_shared_ptr()->set_friendly_name(nms_5->get_friendly_name() + "/convert.0");
+            output_0.get_node_shared_ptr()->set_friendly_name(nms_5->get_friendly_name() + ".0");
             new_ops.emplace_back(output_0.get_node_shared_ptr());
+        } else {
+            nms_legacy->set_friendly_name(nms_5->get_friendly_name());
         }
 
         Output<Node> output_2 = nms_legacy->output(2);
         if (nms_5->output(2).get_element_type() != output_2.get_element_type()) {
             output_2 = std::make_shared<opset1::Convert>(output_2, nms_5->output(2).get_element_type());
-            output_2.get_node_shared_ptr()->set_friendly_name(nms_5->get_friendly_name() + "/convert.2");
+            output_2.get_node_shared_ptr()->set_friendly_name(nms_5->get_friendly_name() + ".2");
             new_ops.emplace_back(output_2.get_node_shared_ptr());
+        } else {
+            nms_legacy->set_friendly_name(nms_5->get_friendly_name());
         }
 
-        nms_legacy->set_friendly_name(nms_5->get_friendly_name());
         ngraph::copy_runtime_info(nms_5, new_ops);
         ngraph::replace_node(nms_5, {output_0, nms_legacy->output(1), output_2});
         return true;


### PR DESCRIPTION
# Description

Inside ReadNetwork ConvertNMS5ToLegacyMatcher transformation is called which may add Convert operation after NMS outputs. Name of Convert operation here is not the as NMS. In case if NMS was an output operation of model this insertion
will change output names in function (ex. NMS.0 -> NMS/convert.0). Further, ExecutableNetwork object will keep these values as output names.

At the same time, if plugin supports dynamic NMS with replace it with another operation, the same transformation is not going to be triggered and Converts will not be inserted, so output names will remain as in original outputs.

Mismatch between output names in ExecutableNetwork and compiler lead to error. To fix that, names of Convert operations are kept the same as NMS outputs

# Task

#-39275
#-44282