### PR TITLE
Fix mode attribute values in DepthToSpace ONNX operation extractor

### DIFF
--- a/model-optimizer/extensions/front/onnx/depth_to_space_ext.py
+++ b/model-optimizer/extensions/front/onnx/depth_to_space_ext.py
@@ -34,9 +34,9 @@ class DepthToSpaceFrontExtractor(FrontExtractorOp):
         onnx_mode = onnx_attr(node, 'mode', 's', default=b'DCR').decode()
         assert onnx_mode in ['DCR', 'CRD'], 'Unrecognized mode provided for DepthToSpace node {}'.format(node_name)
         if onnx_mode == 'DCR':
-            mode = 'depth_first'
-        else:
             mode = 'blocks_first'
+        else:
+            mode = 'depth_first'
 
         DepthToSpaceOp.update_node_stat(node, {'block_size': block_size, 'mode': mode})
         return cls.enabled


### PR DESCRIPTION
Description: Fixed wrong values in operation extractor.

JIRA: 43601, 43638

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names

Validation:
* [x]  Unit tests: N/A - No new implemented functions;
* [x]  Framework operation tests: 44486;
* [x]  Transformation tests: N/A - No new implemented transformations;
* [x]  e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py: N/A - this changes fix already existed e2e test;
* [x]  Model Optimizer IR Reader check: N/A - No affected changes.

Documentation:
* [x]  Supported frameworks operations list: N/A - No new supported operations;
* [x]  Supported **public** models list: N/A - Nothing to add;
* [x]  New operations specification: N/A - No new supported operations;
* [x]  Guide on how to convert the **public** model: N/A - Nothing to add;
* [x]  User guide update: N/A - Nothing to update.