### PR TITLE
nGraph 'shell' implementation for GatherElements-6 and MO 'shell' implementation

### DIFF
--- a/docs/MO_DG/prepare_model/Supported_Frameworks_Layers.md
+++ b/docs/MO_DG/prepare_model/Supported_Frameworks_Layers.md
@@ -338,6 +338,7 @@ Standard ONNX\* operators:
 | Floor | No |
 | GRU | No |
 | Gather | No |
+| GatherElements | only with positive indices |
 | GatherND | No |
 | GatherTree | No |
 | Gemm | No |

--- a/docs/MO_DG/prepare_model/Supported_Frameworks_Layers.md
+++ b/docs/MO_DG/prepare_model/Supported_Frameworks_Layers.md
@@ -338,7 +338,7 @@ Standard ONNX\* operators:
 | Floor | No |
 | GRU | No |
 | Gather | No |
-| GatherElements | only with positive indices |
+| GatherElements | Doesn't work with negative indices |
 | GatherND | No |
 | GatherTree | No |
 | Gemm | No |

--- a/docs/ops/movement/GatherElements_6.md
+++ b/docs/ops/movement/GatherElements_6.md
@@ -20,53 +20,53 @@ For instance, in the 3D case (`r = 3`), the output is determined by the followin
 ```
 Example 1 with concrete values:
 ```
-  data = [
-      [1, 2],
-      [3, 4],
-  ]
-  indices = [
-      [0, 1],
-      [0, 0],
-  ]
-  axis = 0
-  output = [
-        [1, 4],
-        [1, 2],
-  ]
+data = [
+    [1, 2],
+    [3, 4],
+]
+indices = [
+    [0, 1],
+    [0, 0],
+]
+axis = 0
+output = [
+    [1, 4],
+    [1, 2],
+]
 ```
 Example 2 with `axis` = 1 and `indices` having greater (than `data`) shape:
 ```
 data = [
-      [1, 7],
-      [4, 3],
-  ]
-  indices = [
-      [1, 1, 0],
-      [1, 0, 1],
-  ]
-  axis = 1
-  output = [
-        [7, 7, 1],
-        [3, 4, 3],
-  ]
+    [1, 7],
+    [4, 3],
+]
+indices = [
+    [1, 1, 0],
+    [1, 0, 1],
+]
+axis = 1
+output = [
+    [7, 7, 1],
+    [3, 4, 3],
+]
 ```
 
 Example 3 `indices` has lesser (than `data`) shape:
 ```
 data = [
-      [1, 2, 3],
-      [4, 5, 6],
-      [7, 8, 9],
-  ]
-  indices = [
-      [1, 0, 1],
-      [1, 2, 0],
-  ]
-  axis = 0
-  output = [
-        [4, 2, 6],
-        [4, 8, 3],
-  ]
+    [1, 2, 3],
+    [4, 5, 6],
+    [7, 8, 9],
+]
+indices = [
+    [1, 0, 1],
+    [1, 2, 0],
+]
+axis = 0
+output = [
+    [4, 2, 6],
+    [4, 8, 3],
+]
 ```
 
 **Attributes**:

--- a/model-optimizer/automation/package_BOM.txt
+++ b/model-optimizer/automation/package_BOM.txt
@@ -263,6 +263,7 @@ extensions/front/onnx/flatten_ext.py
 extensions/front/onnx/flattenONNX_to_reshape.py
 extensions/front/onnx/fused_bn_ext.py
 extensions/front/onnx/gather_ext.py
+extensions/front/onnx/gatherelements_ext.py
 extensions/front/onnx/gathernd_ext.py
 extensions/front/onnx/gemm_ext.py
 extensions/front/onnx/group_norm_ext.py

--- a/model-optimizer/automation/package_BOM.txt
+++ b/model-optimizer/automation/package_BOM.txt
@@ -631,6 +631,7 @@ extensions/ops/ExtractImagePatches.py
 extensions/ops/fake_output.py
 extensions/ops/fakequantize.py
 extensions/ops/gather.py
+extensions/ops/gatherelements.py
 extensions/ops/gathernd.py
 extensions/ops/GatherTree.py
 extensions/ops/gelu.py

--- a/model-optimizer/extensions/front/onnx/gatherelements_ext.py
+++ b/model-optimizer/extensions/front/onnx/gatherelements_ext.py
@@ -1,0 +1,32 @@
+"""
+ Copyright (C) 2020 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+from extensions.ops.gatherelements import GatherElements
+from mo.front.extractor import FrontExtractorOp
+from mo.front.onnx.extractors.utils import onnx_attr
+
+
+class GatherElementsFrontExtractor(FrontExtractorOp):
+    op = 'GatherElements'
+    enabled = False
+
+    @classmethod
+    def extract(cls, node):
+        attrs = {
+            'axis': onnx_attr(node, 'axis', 'i', default=0)
+        }
+        GatherElements.update_node_stat(node, attrs)
+        return cls.enabled

--- a/model-optimizer/extensions/front/onnx/gatherelements_ext.py
+++ b/model-optimizer/extensions/front/onnx/gatherelements_ext.py
@@ -1,5 +1,5 @@
 """
- Copyright (C) 2020 Intel Corporation
+ Copyright (C) 2017-2020 Intel Corporation
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/model-optimizer/extensions/front/onnx/gatherelements_ext.py
+++ b/model-optimizer/extensions/front/onnx/gatherelements_ext.py
@@ -21,7 +21,7 @@ from mo.front.onnx.extractors.utils import onnx_attr
 
 class GatherElementsFrontExtractor(FrontExtractorOp):
     op = 'GatherElements'
-    enabled = False
+    enabled = True
 
     @classmethod
     def extract(cls, node):

--- a/model-optimizer/extensions/ops/gatherelements.py
+++ b/model-optimizer/extensions/ops/gatherelements.py
@@ -35,7 +35,6 @@ class GatherElements(Op):
             'out_ports_count': 1,
         }, attrs)
 
-
     def backend_attrs(self):
         return ['axis']
 

--- a/model-optimizer/extensions/ops/gatherelements.py
+++ b/model-optimizer/extensions/ops/gatherelements.py
@@ -1,0 +1,45 @@
+"""
+ Copyright (C) 2017-2020 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import numpy as np
+
+from mo.front.common.partial_infer.utils import int64_array
+from mo.graph.graph import Node, Graph
+from mo.ops.op import Op, PermuteAttrs
+
+
+class GatherElements(Op):
+    op = 'GatherElements'
+    enabled = True
+
+    def __init__(self, graph: Graph, attrs: dict):
+        super().__init__(graph, {
+            'op': self.op,
+            'type': self.op,
+            'version': 'opset6',
+            'infer': self.infer,
+            'in_ports_count': 2,
+            'out_ports_count': 1,
+        }, attrs)
+
+
+    def backend_attrs(self):
+        return ['axis']
+
+    @staticmethod
+    def infer(node: Node):
+        indices_shape = node.in_port(1).data.get_shape()
+        node.out_port(0).data.set_shape(indices_shape)

--- a/model-optimizer/extensions/ops/gatherelements.py
+++ b/model-optimizer/extensions/ops/gatherelements.py
@@ -44,6 +44,7 @@ class GatherElements(Op):
         axis = node.axis
         data_rank = len(data_shape)
 
+        assert data_rank >= 1, 'data_rank must be >= 1'
         assert data_rank == len(indices_shape), 'data and indices inputs for node {} must be of the ' \
                                                 'same rank. Instead got {} and {}'.\
                                                 format(node.name, data_rank, len(indices_shape))

--- a/model-optimizer/extensions/ops/gatherelements.py
+++ b/model-optimizer/extensions/ops/gatherelements.py
@@ -14,11 +14,8 @@
  limitations under the License.
 """
 
-import numpy as np
-
-from mo.front.common.partial_infer.utils import int64_array
 from mo.graph.graph import Node, Graph
-from mo.ops.op import Op, PermuteAttrs
+from mo.ops.op import Op
 
 
 class GatherElements(Op):
@@ -40,5 +37,6 @@ class GatherElements(Op):
 
     @staticmethod
     def infer(node: Node):
-        indices_shape = node.in_port(1).data.get_shape()
-        node.out_port(0).data.set_shape(indices_shape)
+        node.in_port(1).data.get_shape()
+
+        # todo: add value_inference

--- a/model-optimizer/extensions/ops/gatherelements.py
+++ b/model-optimizer/extensions/ops/gatherelements.py
@@ -20,7 +20,6 @@ from mo.ops.op import Op
 
 class GatherElements(Op):
     op = 'GatherElements'
-    enabled = True
 
     def __init__(self, graph: Graph, attrs: dict):
         super().__init__(graph, {
@@ -30,6 +29,7 @@ class GatherElements(Op):
             'infer': self.infer,
             'in_ports_count': 2,
             'out_ports_count': 1,
+            'axis': 0,
         }, attrs)
 
     def backend_attrs(self):
@@ -37,6 +37,7 @@ class GatherElements(Op):
 
     @staticmethod
     def infer(node: Node):
-        node.in_port(1).data.get_shape()
+        indices_shape = node.in_port(1).data.get_shape()
+        node.out_port(0).data.set_shape(indices_shape)
 
         # todo: add value_inference

--- a/model-optimizer/extensions/ops/gatherelements_test.py
+++ b/model-optimizer/extensions/ops/gatherelements_test.py
@@ -1,0 +1,115 @@
+"""
+ Copyright (C) 2017-2020 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import unittest
+
+import numpy as np
+from generator import generator, generate
+
+from extensions.ops.gatherelements import GatherElements
+from mo.front.common.partial_infer.utils import int64_array
+from mo.graph.graph import Node
+from mo.utils.unittest.graph import build_graph, regular_op_with_empty_data, result, connect, \
+    valued_const_with_data
+
+
+@generator
+class GatherElementsInferTest(unittest.TestCase):
+    @generate(*[
+        ([[1, 2],
+          [3, 4]],
+         [[0, 1],
+          [0, 0]],
+         0,  # axis
+         [[1, 4],  # ref_res
+          [1, 2]]),
+
+        ([[1, 2],
+          [3, 4]],
+         [[0, 1],
+          [0, 0]],
+         1,  # axis
+         [[1, 2],  # ref_res
+          [3, 3]]),
+
+        ([[1, 2, 3],
+          [4, 5, 6],
+          [7, 8, 9]],
+         [[1, 2, 0],
+          [2, 0, 0]],
+         0,  # axis
+         [[4, 8, 3],  # ref_res
+          [7, 2, 3]]),
+
+        ([[1, 2],
+          [3, 4]],
+         [[0, 1],
+          [0, 0]],
+         -1,  # axis
+         [[1, 2],  # ref_res
+          [3, 3]]),
+
+        ([  # 3D case
+          [[1, 2],
+           [3, 4]],
+          [[5, 6],
+           [7, 8]],
+          [[9, 10],
+           [11, 12]]
+        ],
+         [
+          [[1, 0],
+           [0, 1]],
+          [[1, 1],
+           [1, 0]],
+          [[0, 0],
+           [1, 1]]
+         ],
+         -1,  # axis
+         [
+          [[2, 1],
+           [3, 4]],
+          [[6, 6],
+           [8, 7]],
+          [[9, 9],
+           [12, 12]]
+         ]),
+    ])
+
+    def test_gatherelements_value_infer(self, data, indices, axis, ref_res):
+        nodes = {
+            **valued_const_with_data('data', int64_array(data)),
+            **valued_const_with_data('indices', int64_array(indices)),
+            **regular_op_with_empty_data('gather_elements', {'op': 'GatherElements', 'axis': axis}),
+            **result()
+        }
+
+        graph = build_graph(nodes_attrs=nodes, edges=[
+            *connect('data', '0:gather_elements'),
+            *connect('indices', '1:gather_elements'),
+            *connect('gather_elements', 'output')
+        ], nodes_with_edges_only=True)
+        graph.stage = 'middle'
+
+        gather_el_node = Node(graph, 'gather_elements')
+        GatherElements.infer(gather_el_node)
+
+        res_output_shape = gather_el_node.out_node().shape
+        self.assertTrue(np.array_equal(int64_array(ref_res).shape, res_output_shape))
+
+        res_output_value = gather_el_node.out_node().value
+        if res_output_value is not None:
+            self.assertTrue(np.array_equal(int64_array(ref_res), res_output_value))

--- a/ngraph/core/include/ngraph/op/gather_elements.hpp
+++ b/ngraph/core/include/ngraph/op/gather_elements.hpp
@@ -38,8 +38,8 @@ namespace ngraph
                 /// \param indices Node producing indices by which the operation gathers elements
                 /// \param axis specifies axis along which indices are specified
                 GatherElements(const Output<Node>& data,
-                         const Output<Node>& indices,
-                         const size_t axis);
+                               const Output<Node>& indices,
+                               const size_t axis);
 
                 void validate_and_infer_types() override;
                 bool visit_attributes(AttributeVisitor& visitor) override;

--- a/ngraph/core/include/ngraph/op/gather_elements.hpp
+++ b/ngraph/core/include/ngraph/op/gather_elements.hpp
@@ -1,0 +1,55 @@
+//*****************************************************************************
+// Copyright 2017-2020 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+
+#pragma once
+
+#include "ngraph/op/op.hpp"
+
+namespace ngraph
+{
+    namespace op
+    {
+        namespace v6
+        {
+            /// \brief GatherElements operation
+            ///
+            class NGRAPH_API GatherElements : public Op
+            {
+            public:
+                NGRAPH_RTTI_DECLARATION;
+                GatherElements() = default;
+
+                /// \brief Constructs a GatherElements operation.
+                ///
+                /// \param data Node producing data that are gathered
+                /// \param indices Node producing indices by which the operation gathers elements
+                /// \param axis specifies axis along which indices are specified
+                GatherElements(const Output<Node>& data,
+                         const Output<Node>& indices,
+                         const size_t axis);
+
+                void validate_and_infer_types() override;
+                bool visit_attributes(AttributeVisitor& visitor) override;
+                virtual std::shared_ptr<Node>
+                    clone_with_new_inputs(const OutputVector& new_args) const override;
+
+                size_t get_axis() const { return m_axis; }
+            private:
+                size_t m_axis;
+            };
+        }
+    }
+}

--- a/ngraph/core/include/ngraph/op/gather_elements.hpp
+++ b/ngraph/core/include/ngraph/op/gather_elements.hpp
@@ -43,7 +43,7 @@ namespace ngraph
 
                 void validate_and_infer_types() override;
                 bool visit_attributes(AttributeVisitor& visitor) override;
-                virtual std::shared_ptr<Node>
+                std::shared_ptr<Node>
                     clone_with_new_inputs(const OutputVector& new_args) const override;
 
                 int64_t get_axis() const { return m_axis; }

--- a/ngraph/core/include/ngraph/op/gather_elements.hpp
+++ b/ngraph/core/include/ngraph/op/gather_elements.hpp
@@ -39,7 +39,7 @@ namespace ngraph
                 /// \param axis specifies axis along which indices are specified
                 GatherElements(const Output<Node>& data,
                                const Output<Node>& indices,
-                               const size_t axis);
+                               const int axis);
 
                 void validate_and_infer_types() override;
                 bool visit_attributes(AttributeVisitor& visitor) override;
@@ -48,7 +48,7 @@ namespace ngraph
 
                 size_t get_axis() const { return m_axis; }
             private:
-                size_t m_axis;
+                int m_axis;
             };
         }
     }

--- a/ngraph/core/include/ngraph/op/gather_elements.hpp
+++ b/ngraph/core/include/ngraph/op/gather_elements.hpp
@@ -39,7 +39,7 @@ namespace ngraph
                 /// \param axis specifies axis along which indices are specified
                 GatherElements(const Output<Node>& data,
                                const Output<Node>& indices,
-                               const int axis);
+                               const int64_t axis);
 
                 void validate_and_infer_types() override;
                 bool visit_attributes(AttributeVisitor& visitor) override;
@@ -48,7 +48,7 @@ namespace ngraph
 
                 size_t get_axis() const { return m_axis; }
             private:
-                int m_axis;
+                int64_t m_axis;
             };
         }
     }

--- a/ngraph/core/include/ngraph/op/gather_elements.hpp
+++ b/ngraph/core/include/ngraph/op/gather_elements.hpp
@@ -46,7 +46,7 @@ namespace ngraph
                 virtual std::shared_ptr<Node>
                     clone_with_new_inputs(const OutputVector& new_args) const override;
 
-                size_t get_axis() const { return m_axis; }
+                int64_t get_axis() const { return m_axis; }
             private:
                 int64_t m_axis;
             };

--- a/ngraph/core/include/ngraph/ops.hpp
+++ b/ngraph/core/include/ngraph/ops.hpp
@@ -63,6 +63,7 @@
 #include "ngraph/op/floor.hpp"
 #include "ngraph/op/floor_mod.hpp"
 #include "ngraph/op/gather.hpp"
+#include "ngraph/op/gather_elements.hpp"
 #include "ngraph/op/gather_nd.hpp"
 #include "ngraph/op/gather_tree.hpp"
 #include "ngraph/op/gelu.hpp"

--- a/ngraph/core/include/ngraph/opsets/opset6.hpp
+++ b/ngraph/core/include/ngraph/opsets/opset6.hpp
@@ -27,4 +27,3 @@ namespace ngraph
 #undef NGRAPH_OP
     } // namespace opset6
 } // namespace ngraph
-

--- a/ngraph/core/include/ngraph/opsets/opset6.hpp
+++ b/ngraph/core/include/ngraph/opsets/opset6.hpp
@@ -27,3 +27,4 @@ namespace ngraph
 #undef NGRAPH_OP
     } // namespace opset6
 } // namespace ngraph
+

--- a/ngraph/core/include/ngraph/opsets/opset6_tbl.hpp
+++ b/ngraph/core/include/ngraph/opsets/opset6_tbl.hpp
@@ -77,6 +77,10 @@ NGRAPH_OP(Maximum, ngraph::op::v1)
 NGRAPH_OP(Minimum, ngraph::op::v1)
 NGRAPH_OP(Mod, ngraph::op::v1)
 NGRAPH_OP(Multiply, ngraph::op::v1)
+<<<<<<< HEAD
+=======
+NGRAPH_OP(MVN, ngraph::op::v0)
+>>>>>>> de2edcf1c (Initial support of GatherElements in MO and nGraph)
 NGRAPH_OP(Negative, ngraph::op::v0)
 NGRAPH_OP(NormalizeL2, ngraph::op::v0)
 NGRAPH_OP(NotEqual, ngraph::op::v1)
@@ -174,3 +178,5 @@ NGRAPH_OP(Round, ngraph::op::v5)
 
 // New operations added in opset6
 NGRAPH_OP(MVN, ngraph::op::v6)
+NGRAPH_OP(GatherElements, ngraph::op::v6)
+

--- a/ngraph/core/include/ngraph/opsets/opset6_tbl.hpp
+++ b/ngraph/core/include/ngraph/opsets/opset6_tbl.hpp
@@ -77,10 +77,6 @@ NGRAPH_OP(Maximum, ngraph::op::v1)
 NGRAPH_OP(Minimum, ngraph::op::v1)
 NGRAPH_OP(Mod, ngraph::op::v1)
 NGRAPH_OP(Multiply, ngraph::op::v1)
-<<<<<<< HEAD
-=======
-NGRAPH_OP(MVN, ngraph::op::v0)
->>>>>>> de2edcf1c (Initial support of GatherElements in MO and nGraph)
 NGRAPH_OP(Negative, ngraph::op::v0)
 NGRAPH_OP(NormalizeL2, ngraph::op::v0)
 NGRAPH_OP(NotEqual, ngraph::op::v1)
@@ -179,4 +175,3 @@ NGRAPH_OP(Round, ngraph::op::v5)
 // New operations added in opset6
 NGRAPH_OP(MVN, ngraph::op::v6)
 NGRAPH_OP(GatherElements, ngraph::op::v6)
-

--- a/ngraph/core/src/op/gather_elements.cpp
+++ b/ngraph/core/src/op/gather_elements.cpp
@@ -25,8 +25,8 @@ using namespace ngraph;
 NGRAPH_RTTI_DEFINITION(op::v6::GatherElements, "GatherElements", 6);
 
 op::v6::GatherElements::GatherElements(const Output<Node>& data,
-                           const Output<Node>& indices,
-                           const size_t axis)
+                                       const Output<Node>& indices,
+                                       const size_t axis)
     : Op({data, indices})
     , m_axis(axis)
 {
@@ -52,12 +52,14 @@ void op::v6::GatherElements::validate_and_infer_types()
     {
         auto data_rank = data_pshape.rank().get_length();
 
-        NODE_VALIDATION_CHECK(
-            this, data_rank > 1, "Data rank must be greater than 1.");
+        NODE_VALIDATION_CHECK(this, data_rank > 1, "Data rank must be greater than 1.");
 
-        if (m_axis < 0) {
-            NODE_VALIDATION_CHECK(this, -data_rank < m_axis < data_rank - 1,
-                                  "axis must be within interval (-data.rank,  data.rank - 1. Got: ", m_axis);
+        if (m_axis < 0)
+        {
+            NODE_VALIDATION_CHECK(this,
+                                  -data_rank < m_axis < data_rank - 1,
+                                  "axis must be within interval (-data.rank,  data.rank - 1. Got: ",
+                                  m_axis);
             m_axis = data_rank + m_axis;
         }
     }
@@ -68,9 +70,12 @@ void op::v6::GatherElements::validate_and_infer_types()
             this, indices_pshape.rank().get_length() > 1, "Indices rank must be greater that 1.");
     }
 
-    if (data_pshape.is_static() && indices_pshape.is_static()){
+    if (data_pshape.is_static() && indices_pshape.is_static())
+    {
         set_output_type(0, data_type, indices_pshape);
-    } else {
+    }
+    else
+    {
         set_output_type(0, data_type, PartialShape::dynamic());
     }
 }

--- a/ngraph/core/src/op/gather_elements.cpp
+++ b/ngraph/core/src/op/gather_elements.cpp
@@ -40,7 +40,7 @@ void op::v6::GatherElements::validate_and_infer_types()
     const auto& indices_type = get_input_element_type(1);
 
     NODE_VALIDATION_CHECK(this,
-                          indices_type == element::i32 || indices_type == element::i64,
+                          indices_type == element::Type_t::i32 || indices_type == element::Type_t::i64,
                           "indices mush be of int32 or int64 type. But instead got: ",
                           indices_type);
 

--- a/ngraph/core/src/op/gather_elements.cpp
+++ b/ngraph/core/src/op/gather_elements.cpp
@@ -40,7 +40,8 @@ void op::v6::GatherElements::validate_and_infer_types()
     const auto& indices_type = get_input_element_type(1);
 
     NODE_VALIDATION_CHECK(this,
-                          indices_type == element::Type_t::i32 || indices_type == element::Type_t::i64,
+                          indices_type == element::Type_t::i32 ||
+                              indices_type == element::Type_t::i64,
                           "indices mush be of int32 or int64 type. But instead got: ",
                           indices_type);
 
@@ -97,7 +98,7 @@ void op::v6::GatherElements::validate_and_infer_types()
                         indices_pshape[i],
                         " on axis ",
                         i,
-                        " do not match. data and indices mush have equal shapes except for axis ",
+                        " do not match. data and indices must have equal shapes except for axis ",
                         m_axis);
             }
         }

--- a/ngraph/core/src/op/gather_elements.cpp
+++ b/ngraph/core/src/op/gather_elements.cpp
@@ -26,7 +26,7 @@ NGRAPH_RTTI_DEFINITION(op::v6::GatherElements, "GatherElements", 6);
 
 op::v6::GatherElements::GatherElements(const Output<Node>& data,
                                        const Output<Node>& indices,
-                                       const size_t axis)
+                                       const int axis)
     : Op({data, indices})
     , m_axis(axis)
 {
@@ -53,16 +53,16 @@ void op::v6::GatherElements::validate_and_infer_types()
 
     if (data_rank.is_static())
     {
-        auto data_rank_size = data_rank.get_length();
+        int data_rank_size = data_rank.get_length();
 
-        NODE_VALIDATION_CHECK(this, data_rank_size > 1, "Data rank must be greater than 1.");
+        NODE_VALIDATION_CHECK(this, data_rank_size > 1, "data rank must be greater than 1.");
 
         if (m_axis < 0)
         {
             NODE_VALIDATION_CHECK(
                 this,
-                -data_rank_size < m_axis < data_rank_size - 1,
-                "axis must be within interval (-data.rank,  data.rank - 1. But instead Got: ",
+                (-data_rank_size < m_axis) && (m_axis < data_rank_size - 1),
+                "axis must be within interval (-data.rank,  data.rank - 1). But instead Got: ",
                 m_axis);
             m_axis = data_rank_size + m_axis;
         }
@@ -71,7 +71,7 @@ void op::v6::GatherElements::validate_and_infer_types()
     if (indices_rank.is_static())
     {
         NODE_VALIDATION_CHECK(
-            this, indices_rank.get_length() > 1, "Indices rank must be greater that 1.");
+            this, indices_rank.get_length() > 1, "indices rank must be greater than 1.");
     }
 
     if (data_rank.is_static() && indices_rank.is_static())

--- a/ngraph/core/src/op/gather_elements.cpp
+++ b/ngraph/core/src/op/gather_elements.cpp
@@ -56,10 +56,7 @@ void op::v6::GatherElements::validate_and_infer_types()
     set_output_type(0, data_type, indices_pshape);
 
     NODE_VALIDATION_CHECK(
-        this,
-        data_rank.is_dynamic() ||
-                data_rank.get_length() >= 1,
-        "data rank must be >= 1.");
+        this, data_rank.is_dynamic() || data_rank.get_length() >= 1, "data rank must be >= 1.");
 
     NODE_VALIDATION_CHECK(
         this,
@@ -68,20 +65,20 @@ void op::v6::GatherElements::validate_and_infer_types()
         "axis must be within interval (-data.rank,  data.rank - 1). But instead Got: ",
         m_axis);
 
-    NODE_VALIDATION_CHECK(
-        this,
-        indices_rank.is_dynamic() ||
-            indices_rank.get_length() >= 1,
-        "indices rank must be >= 1.");
+    NODE_VALIDATION_CHECK(this,
+                          indices_rank.is_dynamic() || indices_rank.get_length() >= 1,
+                          "indices rank must be >= 1.");
 
-    if (data_rank.is_static() && indices_rank.is_dynamic()){
+    if (data_rank.is_static() && indices_rank.is_dynamic())
+    {
         PartialShape out_shape_info(data_pshape);
         out_shape_info[axis] = Dimension::dynamic();
         set_output_type(0, data_type, out_shape_info);
         return;
     }
 
-    if (data_rank.is_dynamic()){
+    if (data_rank.is_dynamic())
+    {
         if (indices_rank.is_dynamic())
             set_output_type(0, data_type, PartialShape::dynamic());
         return;
@@ -105,16 +102,15 @@ void op::v6::GatherElements::validate_and_infer_types()
             // (and if intervals intersect) then output_pshape will be {1, 4, 5}
             Dimension curr_dim = data_pshape[i] & indices_pshape[i];
 
-            NODE_VALIDATION_CHECK(
-                this,
-                !curr_dim.get_interval().empty(),
-                "Shapes ",
-                data_pshape,
-                " and ",
-                indices_pshape,
-                " are not consistent. data and indices must have equal or "
-                "intersecting sizes, except for axis ",
-                m_axis);
+            NODE_VALIDATION_CHECK(this,
+                                  !curr_dim.get_interval().empty(),
+                                  "Shapes ",
+                                  data_pshape,
+                                  " and ",
+                                  indices_pshape,
+                                  " are not consistent. data and indices must have equal or "
+                                  "intersecting sizes, except for axis ",
+                                  m_axis);
 
             output_pshape[i] = curr_dim;
         }

--- a/ngraph/core/src/op/gather_elements.cpp
+++ b/ngraph/core/src/op/gather_elements.cpp
@@ -50,7 +50,7 @@ void op::v6::GatherElements::validate_and_infer_types()
     auto indices_rank = indices_pshape.rank();
 
     int64_t axis = m_axis;
-    if (m_axis < 0)
+    if (m_axis < 0 && data_rank.is_static())
         axis += data_rank.get_length();
 
     set_output_type(0, data_type, indices_pshape);

--- a/ngraph/core/src/op/gather_elements.cpp
+++ b/ngraph/core/src/op/gather_elements.cpp
@@ -111,7 +111,7 @@ void op::v6::GatherElements::validate_and_infer_types()
         // if at least one input has static rank propagate PartialShape of that input
         // in the optimistic scenario at least we will have static rank
         // in the worse scenario propagating any of PartialShapes is equivalent
-        set_output_type(0, data_type, indices_pshape.is_static() ? indices_pshape : data_pshape);
+        set_output_type(0, data_type, indices_rank.is_static() ? indices_pshape : data_pshape);
     }
 }
 

--- a/ngraph/test/CMakeLists.txt
+++ b/ngraph/test/CMakeLists.txt
@@ -128,6 +128,7 @@ set(SRC
     type_prop/embedding_segments_sum.cpp
     type_prop/fake_quantize.cpp
     type_prop/gather.cpp
+    type_prop/gather_elements.cpp
     type_prop/gather_nd.cpp
     type_prop/gather_tree.cpp
     type_prop/grn.cpp

--- a/ngraph/test/type_prop/gather_elements.cpp
+++ b/ngraph/test/type_prop/gather_elements.cpp
@@ -1,0 +1,115 @@
+//*****************************************************************************
+// Copyright 2017-2020 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+
+#include "gtest/gtest.h"
+#include "ngraph/ngraph.hpp"
+#include "util/type_prop.hpp"
+
+using namespace std;
+using namespace ngraph;
+
+// ------------------------------ V6 ------------------------------
+
+TEST(type_prop, gather_elements_2d_axis_0)
+{
+    Shape data_shape{3, 3};
+    Shape indices_shape{2, 3};
+    int axis = 0;
+    auto D = make_shared<op::Parameter>(element::Type_t::f32, data_shape);
+    auto I = make_shared<op::Parameter>(element::Type_t::i32, indices_shape);
+    auto GE = make_shared<op::v6::GatherElements>(D, I, axis);
+    ASSERT_EQ(GE->get_element_type(), element::Type_t::f32);
+    ASSERT_EQ(GE->get_shape(), indices_shape);
+}
+
+TEST(type_prop, gather_elements_2d_axis_1)
+{
+    Shape data_shape{3, 3};
+    Shape indices_shape{3, 1};
+    int axis = 1;
+    auto D = make_shared<op::Parameter>(element::Type_t::f32, data_shape);
+    auto I = make_shared<op::Parameter>(element::Type_t::i32, indices_shape);
+    auto GE = make_shared<op::v6::GatherElements>(D, I, axis);
+    ASSERT_EQ(GE->get_element_type(), element::Type_t::f32);
+    ASSERT_EQ(GE->get_shape(), indices_shape);
+}
+
+TEST(type_prop, gather_elements_3d_axis_0)
+{
+    Shape data_shape{3, 3, 10000};
+    Shape indices_shape{300, 3, 10000};
+    int axis = 0;
+    auto D = make_shared<op::Parameter>(element::Type_t::f32, data_shape);
+    auto I = make_shared<op::Parameter>(element::Type_t::i32, indices_shape);
+    auto GE = make_shared<op::v6::GatherElements>(D, I, axis);
+    ASSERT_EQ(GE->get_element_type(), element::Type_t::f32);
+    ASSERT_EQ(GE->get_shape(), indices_shape);
+}
+
+// --------------------- Negative tests ------------------------------
+TEST(type_prop, gather_elements_shapes_inconsistency)
+{
+    Shape data_shape{3, 3};
+    Shape indices_shape{2, 1};
+    int axis = 1;
+    auto D = make_shared<op::Parameter>(element::Type_t::f32, data_shape);
+    auto I = make_shared<op::Parameter>(element::Type_t::i32, indices_shape);
+
+    try
+    {
+        auto GE = make_shared<op::v6::GatherElements>(D, I, axis);
+        // Should have thrown, so fail if it didn't
+        FAIL() << "Shape inconsistency check failed";
+    }
+    catch (const NodeValidationFailure& error)
+    {
+        EXPECT_HAS_SUBSTRING(
+            error.what(), std::string("data and indices must have equal shapes except for axis "));
+    }
+    catch (...)
+    {
+        FAIL() << "Deduced shape check failed for unexpected reason";
+    }
+}
+
+TEST(type_prop, gather_elements_type_inconsistency)
+{
+    Shape data_shape{3, 3};
+    Shape indices_shape{2, 1};
+    int axis = 1;
+    auto D = make_shared<op::Parameter>(element::Type_t::f32, data_shape);
+    auto I = make_shared<op::Parameter>(element::Type_t::u32, indices_shape);
+
+    try
+    {
+        auto GE = make_shared<op::v6::GatherElements>(D, I, axis);
+        // Should have thrown, so fail if it didn't
+        FAIL() << "the indices tensor type check failed";
+    }
+    catch (const NodeValidationFailure& error)
+    {
+        EXPECT_HAS_SUBSTRING(
+            error.what(), std::string("indices mush be of int32 or int64 type. But instead got"));
+    }
+    catch (...)
+    {
+        FAIL() << "Deduced type check failed for unexpected reason";
+    }
+}
+
+// negative tests
+// axis out of bounds
+// rank check

--- a/ngraph/test/type_prop/gather_elements.cpp
+++ b/ngraph/test/type_prop/gather_elements.cpp
@@ -51,7 +51,7 @@ TEST(type_prop, gather_elements_3D_axis_0)
 {
     Shape data_shape{3, 3, 10000};
     Shape indices_shape{300, 3, 10000};
-    int axis = 0;
+    int64_t axis = 0;
     auto D = make_shared<op::Parameter>(element::Type_t::f32, data_shape);
     auto I = make_shared<op::Parameter>(element::Type_t::i32, indices_shape);
     auto GE = make_shared<op::v6::GatherElements>(D, I, axis);
@@ -63,7 +63,7 @@ TEST(type_prop, gather_elements_3D_axis_2)
 {
     Shape data_shape{300, 3, 10};
     Shape indices_shape{300, 3, 10000};
-    int axis = 2;
+    int64_t axis = 2;
     auto D = make_shared<op::Parameter>(element::Type_t::f32, data_shape);
     auto I = make_shared<op::Parameter>(element::Type_t::i32, indices_shape);
     auto GE = make_shared<op::v6::GatherElements>(D, I, axis);
@@ -75,12 +75,48 @@ TEST(type_prop, gather_elements_4D_axis_minus_1)
 {
     Shape data_shape{300, 3, 10, 1};
     Shape indices_shape{300, 3, 10, 33333};
-    int axis = -1;
+    int64_t axis = -1;
     auto D = make_shared<op::Parameter>(element::Type_t::f32, data_shape);
     auto I = make_shared<op::Parameter>(element::Type_t::i32, indices_shape);
     auto GE = make_shared<op::v6::GatherElements>(D, I, axis);
     ASSERT_EQ(GE->get_element_type(), element::Type_t::f32);
     ASSERT_EQ(GE->get_shape(), indices_shape);
+}
+
+TEST(type_prop, gather_elements_nonfloat_data_type_int64_indices)
+{
+    Shape data_shape{300, 3, 10, 1};
+    Shape indices_shape{300, 3, 10, 33333};
+    int64_t axis = -1;
+    auto D = make_shared<op::Parameter>(element::Type_t::i8, data_shape);
+    auto I = make_shared<op::Parameter>(element::Type_t::i64, indices_shape);
+    auto GE = make_shared<op::v6::GatherElements>(D, I, axis);
+    ASSERT_EQ(GE->get_element_type(), element::Type_t::i8);
+    ASSERT_EQ(GE->get_shape(), indices_shape);
+}
+
+TEST(type_prop, gather_elements_dynamic_consistent_shapes)
+{
+    PartialShape data_shape{4, 4, Dimension::dynamic()};
+    PartialShape indices_shape{1, Dimension::dynamic(), 5};
+    int64_t axis = 0;
+    auto D = make_shared<op::Parameter>(element::Type_t::i8, data_shape);
+    auto I = make_shared<op::Parameter>(element::Type_t::i64, indices_shape);
+    auto GE = make_shared<op::v6::GatherElements>(D, I, axis);
+    ASSERT_EQ(GE->get_element_type(), element::Type_t::i8);
+    ASSERT_EQ(GE->get_shape(), Shape({1, 4, 5}));
+}
+
+TEST(type_prop, gather_elements_dynamic_out_shape)
+{
+    PartialShape data_shape{4, 4, Dimension::dynamic()};
+    PartialShape indices_shape{1, Dimension::dynamic(), Dimension::dynamic()};
+    int64_t axis = 0;
+    auto D = make_shared<op::Parameter>(element::Type_t::i8, data_shape);
+    auto I = make_shared<op::Parameter>(element::Type_t::i64, indices_shape);
+    auto GE = make_shared<op::v6::GatherElements>(D, I, axis);
+    ASSERT_EQ(GE->get_element_type(), element::Type_t::i8);
+    ASSERT_EQ(GE->get_output_partial_shape(0), PartialShape({1, 4, Dimension::dynamic()}));
 }
 
 // --------------------- Negative tests ------------------------------
@@ -89,7 +125,7 @@ TEST(type_prop, gather_elements_type_inconsistency)
 {
     Shape data_shape{3, 3};
     Shape indices_shape{2, 1};
-    int axis = 1;
+    int64_t axis = 1;
     auto D = make_shared<op::Parameter>(element::Type_t::f32, data_shape);
     auto I = make_shared<op::Parameter>(element::Type_t::u32, indices_shape);
 
@@ -114,7 +150,7 @@ TEST(type_prop, gather_elements_data_rank_check)
 {
     Shape data_shape{3};
     Shape indices_shape{2, 333};
-    int axis = 0;
+    int64_t axis = 0;
     auto D = make_shared<op::Parameter>(element::Type_t::f32, data_shape);
     auto I = make_shared<op::Parameter>(element::Type_t::i32, indices_shape);
 
@@ -138,7 +174,7 @@ TEST(type_prop, gather_elements_out_of_bounds_axis)
 {
     Shape data_shape{3, 3};
     Shape indices_shape{2, 1};
-    int axis = -33;
+    int64_t axis = -33;
     auto D = make_shared<op::Parameter>(element::Type_t::f32, data_shape);
     auto I = make_shared<op::Parameter>(element::Type_t::i32, indices_shape);
 
@@ -162,7 +198,7 @@ TEST(type_prop, gather_elements_indices_rank_check)
 {
     Shape data_shape{3, 3};
     Shape indices_shape{333};
-    int axis = 0;
+    int64_t axis = 0;
     auto D = make_shared<op::Parameter>(element::Type_t::f32, data_shape);
     auto I = make_shared<op::Parameter>(element::Type_t::i32, indices_shape);
 
@@ -186,7 +222,7 @@ TEST(type_prop, gather_elements_rank_consistency_check)
 {
     Shape data_shape{3, 3};
     Shape indices_shape{2, 3, 3333};
-    int axis = 0;
+    int64_t axis = 0;
     auto D = make_shared<op::Parameter>(element::Type_t::f32, data_shape);
     auto I = make_shared<op::Parameter>(element::Type_t::i32, indices_shape);
 
@@ -210,7 +246,7 @@ TEST(type_prop, gather_elements_shapes_inconsistency)
 {
     Shape data_shape{3, 3};
     Shape indices_shape{2, 1};
-    int axis = 1;
+    int64_t axis = 1;
     auto D = make_shared<op::Parameter>(element::Type_t::f32, data_shape);
     auto I = make_shared<op::Parameter>(element::Type_t::i32, indices_shape);
 
@@ -227,6 +263,31 @@ TEST(type_prop, gather_elements_shapes_inconsistency)
     }
     catch (...)
     {
-        FAIL() << "Deduced shape check failed for unexpected reason";
+        FAIL() << "Shape inconsistency check failed for unexpected reason";
+    }
+}
+
+TEST(type_prop, gather_elements_dynamic_inconsistent_shapes)
+{
+    PartialShape data_shape{4, 2, 4, Dimension::dynamic()};
+    PartialShape indices_shape{1, 3, Dimension::dynamic(), 5};
+    int64_t axis = 0;
+    auto D = make_shared<op::Parameter>(element::Type_t::i8, data_shape);
+    auto I = make_shared<op::Parameter>(element::Type_t::i64, indices_shape);
+
+    try
+    {
+        auto GE = make_shared<op::v6::GatherElements>(D, I, axis);
+        // Should have thrown, so fail if it didn't
+        FAIL() << "Shape inconsistency check for dynamic PartialShape failed";
+    }
+    catch (const NodeValidationFailure& error)
+    {
+        EXPECT_HAS_SUBSTRING(
+            error.what(), std::string("data and indices must have equal shapes except for axis "));
+    }
+    catch (...)
+    {
+        FAIL() << "Shape inconsistency check for dynamic PartialShape failed for unexpected reason";
     }
 }

--- a/ngraph/test/type_prop/gather_elements.cpp
+++ b/ngraph/test/type_prop/gather_elements.cpp
@@ -152,7 +152,8 @@ TEST(type_prop, gather_elements_data_rank_static_indices_rank_dynamic)
     auto I = make_shared<op::Parameter>(element::Type_t::i64, indices_shape);
     auto GE = make_shared<op::v6::GatherElements>(D, I, axis);
     ASSERT_EQ(GE->get_element_type(), element::Type_t::i8);
-    ASSERT_EQ(GE->get_output_partial_shape(0), PartialShape({Dimension::dynamic(), Dimension(1, 7), 5}));
+    ASSERT_EQ(GE->get_output_partial_shape(0),
+              PartialShape({Dimension::dynamic(), Dimension(1, 7), 5}));
 }
 
 TEST(type_prop, gather_elements_data_pshape_static_indices_rank_dynamic)

--- a/ngraph/test/type_prop/gather_elements.cpp
+++ b/ngraph/test/type_prop/gather_elements.cpp
@@ -130,6 +130,42 @@ TEST(type_prop, gather_elements_interval_shapes)
     ASSERT_EQ(GE->get_element_type(), element::Type_t::i8);
     ASSERT_EQ(GE->get_output_partial_shape(0), PartialShape({1, Dimension(5, 7), 5}));
 }
+
+TEST(type_prop, gather_elements_data_rank_dynamic_indices_rank_static)
+{
+    PartialShape data_shape = PartialShape::dynamic();
+    PartialShape indices_shape{4, 7, 5};
+    int64_t axis = 0;
+    auto D = make_shared<op::Parameter>(element::Type_t::i8, data_shape);
+    auto I = make_shared<op::Parameter>(element::Type_t::i64, indices_shape);
+    auto GE = make_shared<op::v6::GatherElements>(D, I, axis);
+    ASSERT_EQ(GE->get_element_type(), element::Type_t::i8);
+    ASSERT_EQ(GE->get_output_partial_shape(0), PartialShape({4, 7, 5}));
+}
+
+TEST(type_prop, gather_elements_data_rank_static_indices_rank_dynamic)
+{
+    PartialShape data_shape{4, Dimension(1, 7), 5};
+    PartialShape indices_shape = PartialShape::dynamic();
+    int64_t axis = 0;
+    auto D = make_shared<op::Parameter>(element::Type_t::i8, data_shape);
+    auto I = make_shared<op::Parameter>(element::Type_t::i64, indices_shape);
+    auto GE = make_shared<op::v6::GatherElements>(D, I, axis);
+    ASSERT_EQ(GE->get_element_type(), element::Type_t::i8);
+    ASSERT_EQ(GE->get_output_partial_shape(0), PartialShape({Dimension::dynamic(), Dimension(1, 7), 5}));
+}
+
+TEST(type_prop, gather_elements_data_pshape_static_indices_rank_dynamic)
+{
+    PartialShape data_shape{4, 7, 5};
+    PartialShape indices_shape = PartialShape::dynamic();
+    int64_t axis = 0;
+    auto D = make_shared<op::Parameter>(element::Type_t::i8, data_shape);
+    auto I = make_shared<op::Parameter>(element::Type_t::i64, indices_shape);
+    auto GE = make_shared<op::v6::GatherElements>(D, I, axis);
+    ASSERT_EQ(GE->get_element_type(), element::Type_t::i8);
+    ASSERT_EQ(GE->get_output_partial_shape(0), PartialShape({Dimension::dynamic(), 7, 5}));
+}
 // --------------------- Negative tests ------------------------------
 
 TEST(type_prop, gather_elements_type_inconsistency)
@@ -205,7 +241,7 @@ TEST(type_prop, gather_elements_rank_consistency_check)
     }
 }
 
-TEST(type_prop, gather_elements_shapes_inconsistency)
+TEST(type_prop, gather_elements_shape_inconsistency)
 {
     Shape data_shape{3, 3};
     Shape indices_shape{2, 1};

--- a/ngraph/test/type_prop/gather_elements.cpp
+++ b/ngraph/test/type_prop/gather_elements.cpp
@@ -225,8 +225,7 @@ TEST(type_prop, gather_elements_shapes_inconsistency)
     {
         EXPECT_HAS_SUBSTRING(
             error.what(),
-            std::string(
-                "data and indices must have equal or intersecting sizes, except for axis"));
+            std::string("data and indices must have equal or intersecting sizes, except for axis"));
     }
     catch (...)
     {
@@ -252,8 +251,7 @@ TEST(type_prop, gather_elements_dynamic_inconsistent_shapes)
     {
         EXPECT_HAS_SUBSTRING(
             error.what(),
-            std::string(
-                "data and indices must have equal or intersecting sizes, except for axis"));
+            std::string("data and indices must have equal or intersecting sizes, except for axis"));
     }
     catch (...)
     {
@@ -278,8 +276,7 @@ TEST(type_prop, gather_elements_incosistent_interval_shapes)
     {
         EXPECT_HAS_SUBSTRING(
             error.what(),
-            std::string(
-                "data and indices must have equal or intersecting sizes, except for axis"));
+            std::string("data and indices must have equal or intersecting sizes, except for axis"));
     }
     catch (...)
     {

--- a/ngraph/test/type_prop/gather_elements.cpp
+++ b/ngraph/test/type_prop/gather_elements.cpp
@@ -121,8 +121,6 @@ TEST(type_prop, gather_elements_dynamic_out_shape)
 
 TEST(type_prop, gather_elements_interval_shapes)
 {
-    //    PartialShape data_shape{4, 4, Dimension(0, 100)};
-    //    PartialShape indices_shape{1, Dimension(0, 5), Dimension(0, 100)};
     PartialShape data_shape{4, Dimension(1, 7), 5};
     PartialShape indices_shape{1, Dimension(5, 10), 5};
     int64_t axis = 0;

--- a/ngraph/test/type_prop/gather_elements.cpp
+++ b/ngraph/test/type_prop/gather_elements.cpp
@@ -151,7 +151,7 @@ TEST(type_prop, gather_elements_type_inconsistency)
     catch (const NodeValidationFailure& error)
     {
         EXPECT_HAS_SUBSTRING(
-            error.what(), std::string("indices mush be of int32 or int64 type. But instead got"));
+            error.what(), std::string("indices must be of int32 or int64 type. But instead got"));
     }
     catch (...)
     {
@@ -226,7 +226,7 @@ TEST(type_prop, gather_elements_shapes_inconsistency)
         EXPECT_HAS_SUBSTRING(
             error.what(),
             std::string(
-                "data and indices must have equal or intersecting shapes except for axis "));
+                "data and indices must have equal or intersecting sizes, except for axis"));
     }
     catch (...)
     {
@@ -253,7 +253,7 @@ TEST(type_prop, gather_elements_dynamic_inconsistent_shapes)
         EXPECT_HAS_SUBSTRING(
             error.what(),
             std::string(
-                "data and indices must have equal or intersecting shapes except for axis "));
+                "data and indices must have equal or intersecting sizes, except for axis"));
     }
     catch (...)
     {
@@ -279,7 +279,7 @@ TEST(type_prop, gather_elements_incosistent_interval_shapes)
         EXPECT_HAS_SUBSTRING(
             error.what(),
             std::string(
-                "data and indices must have equal or intersecting shapes except for axis "));
+                "data and indices must have equal or intersecting sizes, except for axis"));
     }
     catch (...)
     {


### PR DESCRIPTION
Description: Added 'shell' implementation of GatherElement-6 operation to nGraph and MO. By MO 'shell' implementation I mean that value_inference in MO is not implemented yet.

tickets: #42630, #42628 

The following tasks are applicable only for MO part of PR. If you are not reviewing MO part you can ignore them.

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR: N/A -- no new transformations were added
* [x]  Transformation preserves original framework node names: N/A -- no new transformation were added

Validation:
* [x]  Unit tests:
* [x]  Framework operation tests: layer test are not implemented yet but checks have done manually with different inputs and attributes and results matched to FW
* [x]  Transformation tests: N/A -- no new transformations were added
* [x]  e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py: N/A
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list
* [x]  Supported **public** models list: N/A
* [x]  New operations specification: https://github.com/openvinotoolkit/openvino/pull/3304
* [x]  Guide on how to convert the **public** model: N/A
* [x]  User guide update: N/A