### PR TITLE
Fix serialization dynamic shapes

### DIFF
--- a/inference-engine/src/transformations/src/transformations/serialize.cpp
+++ b/inference-engine/src/transformations/src/transformations/serialize.cpp
@@ -301,15 +301,13 @@ bool is_exec_graph(const ngraph::Function& f) {
 }
 
 bool resolve_dynamic_shapes(const ngraph::Function& f) {
-    const auto & f_results = f.get_results();
-    if (std::all_of(f_results.begin(), f_results.end(),
+    const auto & f_ops = f.get_ordered_ops();
+    if (std::all_of(f_ops.begin(), f_ops.end(),
             [](std::shared_ptr<Node> results) { return !results->is_dynamic(); })) {
         return false;
     }
 
     auto f_clone = ngraph::clone_function(f);
-
-    const auto & f_ops = f.get_ordered_ops();
     const auto & f_clone_ops = f_clone->get_ordered_ops();
     NGRAPH_CHECK(f_ops.size() == f_clone_ops.size(), "Unexpected get_ordered_ops method behaviour");
 

--- a/ngraph/core/src/op/util/attr_types.cpp
+++ b/ngraph/core/src/op/util/attr_types.cpp
@@ -118,7 +118,7 @@ namespace ngraph
     NGRAPH_API EnumNames<op::EpsMode>& EnumNames<op::EpsMode>::get()
     {
         static auto enum_names = EnumNames<op::EpsMode>(
-            "op::EpsMode", {{"ADD", op::EpsMode::ADD}, {"MAX", op::EpsMode::MAX}});
+            "op::EpsMode", {{"add", op::EpsMode::ADD}, {"max", op::EpsMode::MAX}});
         return enum_names;
     }
 


### PR DESCRIPTION
Change dynamism resolver in serialization to be run on functions which contain at least one node with dynamic output.

Additionally aligned EpsMode attribute to spec as it was needed to pass tests on aspire_tdnn model (which is used in E2E validation).

Ticket: 44193.