### PR TITLE
Fix NMS5 outputs naming

### DIFF
--- a/inference-engine/src/inference_engine/cnn_network_ngraph_impl.cpp
+++ b/inference-engine/src/inference_engine/cnn_network_ngraph_impl.cpp
@@ -340,7 +340,7 @@ CNNNetworkNGraphImpl::reshape(const std::map<std::string, std::vector<size_t>>& 
             OV_ITT_SCOPED_TASK(itt::domains::IE, "CNNNetworkNGraphImpl::ConvertToLegacy");
             ::ngraph::pass::Manager manager;
             // resolves dynamism by replacing dynamic operation with static version
-            manager.register_pass<::ngraph::pass::ConvertNMS5ToLegacyMatcher>();
+            manager.register_pass<::ngraph::pass::ConvertNMS5ToLegacyMatcher>(false);
             manager.register_pass<::ngraph::pass::ConstantFolding>();
             // OneHotToLegacy changes output precision
             manager.register_pass<::ngraph::pass::ConvertOneHotToOneHotIEMatcher>()->detect_output_type(

--- a/inference-engine/src/legacy_api/include/legacy/transformations/convert_opset1_to_legacy/convert_nms_5_to_legacy.hpp
+++ b/inference-engine/src/legacy_api/include/legacy/transformations/convert_opset1_to_legacy/convert_nms_5_to_legacy.hpp
@@ -28,6 +28,6 @@ class INFERENCE_ENGINE_API_CLASS(ConvertNMS5ToLegacyMatcher);
 class ngraph::pass::ConvertNMS5ToLegacyMatcher: public ngraph::pass::MatcherPass {
 public:
     NGRAPH_RTTI_DECLARATION;
-    ConvertNMS5ToLegacyMatcher();
+    ConvertNMS5ToLegacyMatcher(bool force_i32_output_type = true);
 };
 


### PR DESCRIPTION
Parametrize NMS5ToLegacy conversion to avoid Convert operations insertion that breaks outputs naming