### PR TITLE
[IE VPU] Performance fix for efficientnet-b0

### DIFF
--- a/inference-engine/src/vpu/graph_transformer/src/stages/swish.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/swish.cpp
@@ -23,10 +23,6 @@ private:
 
         serializer.append(static_cast<float>(beta));
     }
-
-    StageSHAVEsRequirements getSHAVEsRequirementsImpl() const override {
-        return StageSHAVEsRequirements::NeedMax;
-    }
 };
 
 }  // namespace


### PR DESCRIPTION
#-43670
Change `StageSHAVEsRequirements::NeedMax` to `StageSHAVEsRequirements::TwoOrOne` for Swish layer.
It recover performance.