### PR TITLE
[VPU] Support dynamic data in Broadcast DTS

### DIFF
--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_tests_common.hpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_tests_common.hpp
@@ -29,6 +29,7 @@ class DSR_TestsCommon : virtual public LayerTestsUtils::LayerTestsCommon {
 protected:
     std::unordered_map<std::string, DataShape> m_shapes;
     ngraph::ParameterVector m_parameterVector;
+    ngraph::ResultVector m_additionalResults;
 
     std::shared_ptr<ngraph::opset3::Parameter> createParameter(
             const ngraph::element::Type& element_type,
@@ -69,6 +70,7 @@ protected:
         for (const auto& output : testedOp->outputs()) {
             results.emplace_back(std::make_shared<ngraph::opset3::Result>(output));
         }
+        results.insert(results.end(), m_additionalResults.begin(), m_additionalResults.end());
 
         function = std::make_shared<ngraph::Function>(
                 results,


### PR DESCRIPTION
Ticket - #-44546
Changes:
- Support dynamic data as broadcast input in Broadcast DTS
- Update DTS tests to support both dynamic and static inputs
- Update inference tests:
    a) Refactor tests to have only one testing class - `NonZero_Broadcast`
    b) Make `DSR_TestsCommon` base class to reuse `createInputSubgraphWithDSR` and inputs generating utils.
    c) Add possibility to add additional results in `DSR_TestsCommon`, because `NonZero` doesn't support cases when both its outputs are unused, so we need to add at least one of them to function results.
