### PR TITLE
[PP] Altered preprocessing tests to use existin posprocessing as well

### DIFF
--- a/docs/template_plugin/src/template_plugin.cpp
+++ b/docs/template_plugin/src/template_plugin.cpp
@@ -92,7 +92,8 @@ InferenceEngine::ExecutableNetworkInternal::Ptr Plugin::LoadExeNetworkImpl(const
         auto output_precision = networkOutput.second->getPrecision();
 
         if (output_precision != InferenceEngine::Precision::FP32 &&
-            output_precision != InferenceEngine::Precision::FP16) {
+            output_precision != InferenceEngine::Precision::FP16 &&
+            output_precision != InferenceEngine::Precision::U8) {
             THROW_IE_EXCEPTION << "Template device supports only FP16 and FP32 output precision.";
         }
     }

--- a/inference-engine/tests/functional/plugin/shared/include/behavior/preprocessing.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/behavior/preprocessing.hpp
@@ -93,6 +93,7 @@ public:
         SetRefMode(LayerTestsUtils::RefMode::INTERPRETER);
 
         std::tie(inPrc, channels, use_set_input, targetDevice, configuration) = this->GetParam();
+        outPrc = inPrc;
 
         bool specialZero = true;
 


### PR DESCRIPTION
This patch is intended to cover existing functionality of post processing in the plugins.

The patch:
 
changed PreprocessingPrecisionConvertTest:
 - to force output precision to be same as input (and not FP32 always)

changed TEMPLATE plugin to allow U8 outputs