### PR TITLE
[VPU] Extend StaticShapeBroadcast target shape evaluator

### DIFF
--- a/inference-engine/src/vpu/common/src/ngraph/utilities.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/utilities.cpp
@@ -49,13 +49,16 @@ ngraph::HostTensorVector evaluateOp(ngraph::Node* node, const ngraph::HostTensor
 
 std::vector<std::int64_t> evaluateTargetShape(const ngraph::Output<ngraph::Node>& value) {
     static ngraph::Evaluator<ngraph::HostTensorPtr>::op_handler_map handlers = {
-        {ngraph::opset3::ShapeOf::type_info,  evaluateShapeOf},
-        {ngraph::opset3::Constant::type_info, evaluateConstant},
-        {ngraph::opset3::Gather::type_info,   evaluateOp},
-        {ngraph::opset3::Concat::type_info,   evaluateOp},
-        {ngraph::opset3::Reshape::type_info,  evaluateOp},
-        {ngraph::opset3::Multiply::type_info, evaluateOp},
-        {ngraph::opset3::Squeeze::type_info,  evaluateOp},
+        {ngraph::opset3::ShapeOf::type_info,   evaluateShapeOf},
+        {ngraph::opset3::Constant::type_info,  evaluateConstant},
+        {ngraph::opset3::Gather::type_info,    evaluateOp},
+        {ngraph::opset3::Concat::type_info,    evaluateOp},
+        {ngraph::opset3::Reshape::type_info,   evaluateOp},
+        {ngraph::opset3::Multiply::type_info,  evaluateOp},
+        {ngraph::opset3::Squeeze::type_info,   evaluateOp},
+        {ngraph::opset5::Unsqueeze::type_info, evaluateOp},
+        {ngraph::opset5::Equal::type_info,     evaluateOp},
+        {ngraph::opset5::Select::type_info,    evaluateOp},
     };
     ngraph::Evaluator<ngraph::HostTensorPtr>::value_map value_map;
     ngraph::Evaluator<ngraph::HostTensorPtr> evaluator(handlers, value_map);


### PR DESCRIPTION
Ticket - #-42237
Add `Unsqueeze`, `Equal` and `Select` operations to the StaticShapeBroadcast target shape evaluator, because they are presented in the target shape subgraph evaluator in one of the network, we are currently enabling.