### PR TITLE
Fix windows build for gflags for time_tests

### DIFF
--- a/tests/time_tests/CMakeLists.txt
+++ b/tests/time_tests/CMakeLists.txt
@@ -4,11 +4,17 @@
 
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
-if (CMAKE_BUILD_TYPE STREQUAL "")
-    message(STATUS "CMAKE_BUILD_TYPE not defined, 'Release' will be used")
-    set(CMAKE_BUILD_TYPE "Release")
-endif()
+set (CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the build type")
 
-find_package(InferenceEngineDeveloperPackage REQUIRED)
+project(time_tests)
+
+
+find_package(InferenceEngine)
+if (NOT InferenceEngine_FOUND)
+    set (HAVE_SYS_STAT_H 1)
+    set (HAVE_INTTYPES_H 1)
+    set (INTTYPES_FORMAT C99)
+    find_package(InferenceEngineDeveloperPackage REQUIRED)
+endif()
 
 add_subdirectory(src)

--- a/tests/time_tests/src/timetests_helper/CMakeLists.txt
+++ b/tests/time_tests/src/timetests_helper/CMakeLists.txt
@@ -10,4 +10,16 @@ file (GLOB SRC *.cpp)
 add_library(${TARGET_NAME} STATIC ${SRC})
 target_include_directories(${TARGET_NAME} PUBLIC "${CMAKE_SOURCE_DIR}/include")
 
+include(FetchContent)
+FetchContent_Declare(
+    gflags
+    GIT_REPOSITORY "https://github.com/gflags/gflags.git"
+    GIT_TAG "v2.2.2"
+)
+FetchContent_GetProperties(gflags)
+if(NOT gflags_POPULATED)
+    FetchContent_Populate(gflags)
+    add_subdirectory(${gflags_SOURCE_DIR} ${gflags_BINARY_DIR})
+endif()
+
 target_link_libraries(${TARGET_NAME} gflags)


### PR DESCRIPTION
GFlags builds multiple targets, require aligning build
options on windows builds.

FetchModule offloads project configuration to cmake. This also allows
to align build configurations and targets across projects:
https://crascit.com/2015/07/25/cmake-gtest/