### PR TITLE
[IE][VPU]: Enables check on split by dynamic dimension for VariadicSplit

### DIFF
--- a/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape.cpp
@@ -72,7 +72,7 @@ bool propagateUpperBoundFromExistingDSR(std::shared_ptr<ngraph::Function>& funct
 
 void validateDynamicFunction(const ngraph::Function& function) {
     for (auto const& split : function.get_ordered_ops()) {
-        if (split->get_type_info() != ngraph::opset5::Split::type_info) {
+        if (split->get_type_info() != ngraph::opset5::Split::type_info && split->get_type_info() != ngraph::opset5::VariadicSplit::type_info) {
             continue;
         }
 


### PR DESCRIPTION
# Description

Previously, if there were a Variadic Split by dynamic dimension we just silently tried to process that, while we don't support it. There are probably options to implement that without much effort as I see, but now, we have accuracy issues for some networks instead of clear error message at load time. I propose to enable check and then implement split by dynamic dimension if needed.

# Task

#-45022