### PR TITLE
CVS-44193: fix serialization dynamizm.

### DIFF
--- a/inference-engine/src/transformations/src/transformations/serialize.cpp
+++ b/inference-engine/src/transformations/src/transformations/serialize.cpp
@@ -304,11 +304,6 @@ bool is_exec_graph(const ngraph::Function& f) {
 
 bool resolve_dynamic_shapes(const ngraph::Function& f) {
     const auto & f_ops = f.get_ordered_ops();
-    if (std::all_of(f_ops.begin(), f_ops.end(),
-            [](std::shared_ptr<Node> results) { return !results->is_dynamic(); })) {
-        return false;
-    }
-
     auto f_clone = ngraph::clone_function(f);
     const auto & f_clone_ops = f_clone->get_ordered_ops();
     NGRAPH_CHECK(f_ops.size() == f_clone_ops.size(), "Unexpected get_ordered_ops method behaviour");


### PR DESCRIPTION
Remove early exit optimization which wasn't working in all of the cases.