### PR TITLE
Fixes in the spec of Interpolate-4.

### DIFF
--- a/docs/ops/image/Interpolate_4.md
+++ b/docs/ops/image/Interpolate_4.md
@@ -15,6 +15,7 @@
   * **Type**: string
   * **Default value**: none
   * **Required**: *yes*
+  * **Note**: Only 2D and 4D tensors with `axes = {0, 1}` and `axes = {2, 3}` respectively are supported for `"mode" == "linear_onnx"`.
 
 * *shape_calculation_mode*
 
@@ -56,10 +57,10 @@
 
   * **Description**: *antialias* is a flag that specifies whether to perform anti-aliasing.
   * **Range of values**:
-    * False - do not perform anti-aliasing
-    * True - perform anti-aliasing
+    * false - do not perform anti-aliasing
+    * true - perform anti-aliasing
   * **Type**: boolean
-  * **Default value**: False
+  * **Default value**: false
   * **Required**: *no*
 
 * *pads_begin*


### PR DESCRIPTION
State in the operation description that mode `linear_onnx` supports only 2D or 4D tensors and mode `linear_onnx` supports only case when `axes = {2, 3}` or `axes = {0, 1}`.

Ticket: #44906