### PR TITLE
async OCL programs build in clDNN- speeds up the GPU device Load time by 1.2-1.5x

### DIFF
--- a/inference-engine/thirdparty/clDNN/src/gpu/kernels_cache.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/kernels_cache.cpp
@@ -205,7 +205,10 @@ size_t kernels_cache::get_max_kernels_per_batch() const {
 
 kernels_cache::sorted_code kernels_cache::get_program_source(const kernels_code& kernels_source_code) const {
     sorted_code scode;
-
+    // min number of OCL programs (needed to leverage the parallel compilation)
+    // using more than 2 doesn't help much as overall the task is rather I/O bottle-necked (to load/save binaries, protected with mutex)
+    const size_t num_programs = 2;
+    size_t kernels_counter = 0;
     for (const auto& code : kernels_source_code) {
         std::string full_code = code.kernel_strings->jit + code.kernel_strings->str;
         full_code += get_undef_jit({full_code});
@@ -236,7 +239,7 @@ kernels_cache::sorted_code kernels_cache::get_program_source(const kernels_code&
             key += " __ONE_TIME__";
         }
 
-        auto& current_bucket = scode[key];
+        auto& current_bucket = scode[key + "_" + std::to_string(kernels_counter++%num_programs)];
         current_bucket.dump_custom_program = dump_custom_program;
         current_bucket.one_time = one_time_kernel;
 
@@ -444,10 +447,10 @@ void kernels_cache::build_all() {
         builds.push_back(std::async(std::launch::async,[&]() {
             auto kernels = build_program(program.second);
 
+            std::lock_guard<std::mutex> lock(_context.get_cache_mutex());
             for (auto &k : kernels) {
                 const auto &entry_point = k.first;
                 const auto &k_id = program.second.entry_point_to_id[entry_point];
-                std::lock_guard<std::mutex> lock(_context.get_cache_mutex());
                 if (program.second.one_time) {
                     _one_time_kernels[k_id] = k.second;
                 } else {

--- a/inference-engine/thirdparty/clDNN/src/gpu/kernels_cache.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/kernels_cache.cpp
@@ -25,6 +25,8 @@
 #include <string>
 #include <memory>
 #include <utility>
+#include <future>
+
 
 #include "kernel_selector_helper.h"
 
@@ -430,25 +432,33 @@ void kernels_cache::build_all() {
     if (!_pending_compilation)
         return;
 
-    std::lock_guard<std::mutex> lock(_context.get_cache_mutex());
-
-    auto sorted_program_code = get_program_source(_kernels_code);
-
-    _one_time_kernels.clear();
-    for (auto& program : sorted_program_code) {
-        auto kernels = build_program(program.second);
-
-        for (auto& k : kernels) {
-            const auto& entry_point = k.first;
-            const auto& k_id = program.second.entry_point_to_id[entry_point];
-            if (program.second.one_time) {
-                _one_time_kernels[k_id] = k.second;
-            } else {
-                _kernels[k_id] = k.second;
-            }
-        }
+    kernels_cache::sorted_code sorted_program_code;
+    {
+        std::lock_guard<std::mutex> lock(_context.get_cache_mutex());
+        sorted_program_code = get_program_source(_kernels_code);
+        _one_time_kernels.clear();
     }
 
+    std::vector<std::future<void>> builds;
+    for (auto& program : sorted_program_code) {
+        builds.push_back(std::async(std::launch::async,[&]() {
+            auto kernels = build_program(program.second);
+
+            for (auto &k : kernels) {
+                const auto &entry_point = k.first;
+                const auto &k_id = program.second.entry_point_to_id[entry_point];
+                std::lock_guard<std::mutex> lock(_context.get_cache_mutex());
+                if (program.second.one_time) {
+                    _one_time_kernels[k_id] = k.second;
+                } else {
+                    _kernels[k_id] = k.second;
+                }
+            }
+        }));
+    }
+    std::for_each(builds.begin(), builds.end(), [&] (std::future<void>& f){ f.wait();});
+
+    std::lock_guard<std::mutex> lock(_context.get_cache_mutex());
     _kernels_code.clear();
     _pending_compilation = false;
 }

--- a/inference-engine/thirdparty/clDNN/src/gpu/kernels_cache.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/kernels_cache.cpp
@@ -454,6 +454,7 @@ void kernels_cache::build_all() {
             for (auto &k : kernels) {
                 const auto &entry_point = k.first;
                 const auto &k_id = program.second.entry_point_to_id[entry_point];
+                std::cout << "  k_id " << k_id << std::endl;
                 if (program.second.one_time) {
                     _one_time_kernels[k_id] = k.second;
                 } else {

--- a/inference-engine/thirdparty/clDNN/src/gpu/kernels_cache.h
+++ b/inference-engine/thirdparty/clDNN/src/gpu/kernels_cache.h
@@ -105,7 +105,7 @@ public:
     kernel_id set_kernel_source(const std::shared_ptr<kernel_selector::kernel_string>& kernel_string,
                                 bool dump_custom_program,
                                 bool one_time_kernel);
-    kernel_type get_kernel(kernel_id id, bool one_time_kernel);
+    kernel_type get_kernel(kernel_id id, bool one_time_kernel) const;
     gpu_toolkit& get_context() { return _context; }
     // forces compilation of all pending kernels/programs
     void build_all();


### PR DESCRIPTION
async OCL program build in clDNN- speeds up the GPU device Load time by 1.2-1.5x
Also, avoiding single global lock enables multiple GPUs to be initialized concurrently.
E.g. MULTI:GPU.0,GPU.1 will be  accelerated accordingly as well (once the corresponding PR for the MULTI, that also does devices load in parallel will be merged - https://github.com/openvinotoolkit/openvino/pull/3599). Today, the lock does serializes the GPUs on the clDNN side... 