### PR TITLE
async network loading in the MULTI

### DIFF
--- a/inference-engine/src/multi_device/multi_device_plugin.cpp
+++ b/inference-engine/src/multi_device/multi_device_plugin.cpp
@@ -13,6 +13,7 @@
 
 #include <ie_metric_helpers.hpp>
 #include <multi-device/multi_device_config.hpp>
+#include <threading/ie_executor_manager.hpp>
 #include "multi_device_plugin.hpp"
 
 // ------------------------------MultiDeviceInferencePlugin----------------------------
@@ -170,14 +171,24 @@ ExecutableNetworkInternal::Ptr MultiDeviceInferencePlugin::LoadExeNetworkImpl(co
     multiNetworkConfig.insert(*priorities);
 
     DeviceMap<ExecutableNetwork> executableNetworkPerDevice;
+    std::mutex load_mutex;
+    std::vector<Task> loads;
     for (auto& p : metaDevices) {
-        auto & deviceName = p.deviceName;
-        auto & deviceConfig = p.config;
-        executableNetworkPerDevice.insert({ deviceName, GetCore()->LoadNetwork(network, deviceName, deviceConfig) });
-        multiNetworkConfig.insert(deviceConfig.begin(), deviceConfig.end());
+        loads.push_back([&]() {
+            const auto &deviceName = p.deviceName;
+            const auto &deviceConfig = p.config;
+            auto exec_net = GetCore()->LoadNetwork(network, deviceName, deviceConfig);
+            std::unique_lock<std::mutex> lock{load_mutex};
+            executableNetworkPerDevice.insert({deviceName, exec_net});
+            multiNetworkConfig.insert(deviceConfig.begin(), deviceConfig.end());
+        });
     }
+    auto executor = InferenceEngine::ExecutorManager::getInstance()->getIdleCPUStreamsExecutor(
+            IStreamsExecutor::Config{"MultiDeviceAsyncLoad", static_cast<int>(metaDevices.size()),
+                                     1, IStreamsExecutor::ThreadBindingType::NONE});
+    executor->runAndWait(loads);
     if (executableNetworkPerDevice.empty())
-        THROW_IE_EXCEPTION << NOT_FOUND_str << "Failed to load Executable network to any device "
+        THROW_IE_EXCEPTION << NOT_FOUND_str << "Failed to load network to any device "
                                             <<  "that the MULTI device is initialized to work with";
 
     auto perfConfig = fullConfig.find(PluginConfigParams::KEY_PERF_COUNT);


### PR DESCRIPTION
makes the overall load time as MAX of the individual devices loading timings, as opposite to the current SUM.
NB: the multiple GPUs load is currently serialized on the clDNN side : https://github.com/openvinotoolkit/openvino/pull/3598