### PR TITLE
gna_plugin: include cmath library to avoid call of overloaded ‘abs(float)’ is ambiguous error

### DIFF
--- a/inference-engine/src/gna_plugin/gna_plugin_config.cpp
+++ b/inference-engine/src/gna_plugin/gna_plugin_config.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <cmath>
 #include <gna/gna_config.hpp>
 #include "gna_plugin.hpp"
 #include "gna_plugin_config.hpp"


### PR DESCRIPTION
I got following error on build with gcc 6.3.0.

```
/home/junya/src/github.com/openvinotoolkit/openvino/inference-engine/src/gna_plugin/gna_plugin_config.cpp:57:37: error: call of overloaded ‘abs(float)’ is ambiguous
...
/home/junya/src/github.com/openvinotoolkit/openvino/inference-engine/src/gna_plugin/gna_plugin_config.cpp:57:73: error: call of overloaded ‘abs(float&)’ is ambiguous
```

I included `<cmath>` header to avoid this.

references:
- [stackoverflow: error: call of overloaded 'abs(double)' is ambiguous](https://stackoverflow.com/a/55314916)
- [cppreference.com std::abs](https://en.cppreference.com/w/cpp/numeric/math/fabs)