### PR TITLE
[ONNX][Model tests] Remove LSTM_Seq_lens model xfail declaration

### DIFF
--- a/ngraph/python/tests/__init__.py
+++ b/ngraph/python/tests/__init__.py
@@ -195,8 +195,6 @@ xfail_issue_39685 = xfail_test(reason="RuntimeError: While validating node 'v1::
                                       "Input order must have shape [n], where n is the rank of arg.")
 
 # Model MSFT issues:
-xfail_issue_36465 = xfail_test(reason="LSTM_Seq_lens: RuntimeError: get_shape was called on a "
-                                      "descriptor::Tensor with dynamic shape")
 xfail_issue_37957 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations:"
                                       "com.microsoft.CropAndResize, com.microsoft.GatherND,"
                                       "com.microsoft.Pad, com.microsoft.Range")

--- a/ngraph/python/tests/test_onnx/test_zoo_models.py
+++ b/ngraph/python/tests/test_onnx/test_zoo_models.py
@@ -33,7 +33,6 @@ from tests import (
     xfail_issue_40957,
     xfail_issue_39685,
     xfail_issue_37957,
-    xfail_issue_36465,
     xfail_issue_38084,
     xfail_issue_39669,
     xfail_issue_38726,


### PR DESCRIPTION
Remove LSTM_Seq_lens model xfail declaration (xfail_issue_36465).
The issue was resolved, model is supported now.