### PR TITLE
Remove doubled Reshape operator tests and revise unittest.manifest

### DIFF
--- a/ngraph/test/backend/reshape.in.cpp
+++ b/ngraph/test/backend/reshape.in.cpp
@@ -44,7 +44,7 @@ static string s_manifest = "${MANIFEST}";
 
 using TestEngine = test::ENGINE_CLASS_NAME(${BACKEND_NAME});
 
-NGRAPH_TEST(${BACKEND_NAME}, reshape_t2v_012)
+NGRAPH_TEST(${BACKEND_NAME}, reshape_t2v)
 {
     Shape shape_a{2, 2, 3};
     auto A = make_shared<op::Parameter>(element::f32, shape_a);
@@ -67,29 +67,7 @@ NGRAPH_TEST(${BACKEND_NAME}, reshape_t2v_012)
                                   MIN_FLOAT_TOLERANCE_BITS));
 }
 
-NGRAPH_TEST(${BACKEND_NAME}, reshape_t2s_012)
-{
-    Shape shape_a{1, 1, 1};
-    auto A = make_shared<op::Parameter>(element::f32, shape_a);
-    Shape shape_r{};
-    auto r = make_shared<op::v1::Reshape>(
-        A, op::Constant::create(element::u64, {shape_r.size()}, shape_r), false);
-    auto f = make_shared<Function>(r, ParameterVector{A});
-
-    auto backend = runtime::Backend::create("${BACKEND_NAME}");
-
-    // Create some tensors for input/output
-    auto a = backend->create_tensor(element::f32, shape_a);
-    copy_data(a, vector<float>{6});
-    auto result = backend->create_tensor(element::f32, shape_r);
-
-    auto handle = backend->compile(f);
-    handle->call_with_validate({result}, {a});
-    EXPECT_TRUE(test::all_close_f(
-        (vector<float>{6}), read_vector<float>(result), MIN_FLOAT_TOLERANCE_BITS));
-}
-
-NGRAPH_TEST(${BACKEND_NAME}, reshape_t2s_120)
+NGRAPH_TEST(${BACKEND_NAME}, reshape_t2s)
 {
     Shape shape_a{1, 1, 1};
     auto A = make_shared<op::Parameter>(element::f32, shape_a);

--- a/ngraph/test/runtime/ie/unit_test.manifest
+++ b/ngraph/test/runtime/ie/unit_test.manifest
@@ -421,13 +421,14 @@ reduce_sum_large_1d_to_scalar
 # Doesn't throw expected exception type.
 unhandled_op
 
-# Cannot cast ngraph node Reshape_158305 to CNNLayer
-transpose
-slice_matrix_axis_0_in_place_with_reshape
-reshape_t2v_012
-reshape_t2s_012
-reshape_t2s_120
-reshape_s2t
+# Const layer Constant_6325 has incorrect dimensions in the output data 0
+reshape_t2s
+
+# Expected equality of these values:
+#  (vector<char>{42})
+#    Which is: { '*' (42, 0x2A) }
+#  read_vector<char>(result)
+#    Which is: { '\0' }
 reshape_s2t1
 reshape_v2m_col
 reshape_v2m_row
@@ -924,7 +925,9 @@ broadcast_algo_matrix_stride_2
 broadcast_algo_matrix_stride_3
 
 # Cannot find blob with name: Parameter_1
+dyn_group_convolution_backprop_data
 dynamic_transpose
+transpose
 
 # Failing from new reason after unblocking more Blob types
 gather_2d_negative_and_positive_indices_axis_0_2d_input


### PR DESCRIPTION
Some of the Reshape tests have already been revised by:
https://github.com/openvinotoolkit/openvino/pull/3542

This PR removes doubled tests and cleans the manifest.

Ticket: 43374