### PR TITLE
[IE COMMON] Fix FP32 to FP16 positive infinity conversion

### DIFF
--- a/inference-engine/src/inference_engine/precision_utils.cpp
+++ b/inference-engine/src/inference_engine/precision_utils.cpp
@@ -129,7 +129,7 @@ ie_fp16 f32tof16(float x) {
         if (v.u & 0x007FFFFF) {
             return s | (v.u >> (23 - 10)) | 0x0200;  // return NAN f16
         } else {
-            return s | (v.u >> (23 - 10));  // return INF f16
+            return s | EXP_MASK_F16;  // return INF f16
         }
     }
 

--- a/inference-engine/tests/unit/inference_engine/precision_utils_test.cpp
+++ b/inference-engine/tests/unit/inference_engine/precision_utils_test.cpp
@@ -1,0 +1,48 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "precision_utils.h"
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+using namespace InferenceEngine;
+
+using PrecisionUtilsTests = ::testing::Test;
+
+static constexpr ie_fp16 positiveInf = 0x7C00;
+static constexpr ie_fp16 negativeInf = 0xFC00;
+static constexpr ie_fp16 largestNumber = 0x7BFF;
+static constexpr ie_fp16 lowestNumber = 0xFBFF;
+
+TEST_F(PrecisionUtilsTests, FP32ToFP16PositiveInfinity) {
+    const auto fp16ConvertedInf = InferenceEngine::PrecisionUtils::f32tof16(std::numeric_limits<float>::infinity());
+    ASSERT_EQ(fp16ConvertedInf, positiveInf);
+}
+
+TEST_F(PrecisionUtilsTests, FP32ToFP16NegativeInfinity) {
+    const auto fp16ConvertedInf = InferenceEngine::PrecisionUtils::f32tof16(-1 * std::numeric_limits<float>::infinity());
+    ASSERT_EQ(fp16ConvertedInf, negativeInf);
+}
+
+TEST_F(PrecisionUtilsTests, FP16ToFP32PositiveInfinity) {
+    const auto fp32ConvertedInf = InferenceEngine::PrecisionUtils::f16tof32(positiveInf);
+    ASSERT_EQ(fp32ConvertedInf, std::numeric_limits<float>::infinity());
+}
+
+TEST_F(PrecisionUtilsTests, FP16ToFP32NegativeInfinity) {
+    const auto fp32ConvertedInf = InferenceEngine::PrecisionUtils::f16tof32(negativeInf);
+    ASSERT_EQ(fp32ConvertedInf, -1 * std::numeric_limits<float>::infinity());
+}
+
+TEST_F(PrecisionUtilsTests, FP32ToFP16MaximumValue) {
+    const auto fp16ConvertedMaxValue = InferenceEngine::PrecisionUtils::f32tof16(std::numeric_limits<float>::max());
+    ASSERT_EQ(fp16ConvertedMaxValue, largestNumber);
+}
+
+TEST_F(PrecisionUtilsTests, FP32ToFP16LowestValue) {
+    const auto fp16ConvertedLowestValue = InferenceEngine::PrecisionUtils::f32tof16(std::numeric_limits<float>::lowest());
+    ASSERT_EQ(fp16ConvertedLowestValue, lowestNumber);
+}

--- a/inference-engine/tools/vpu/vpu_perfcheck/CMakeLists.txt
+++ b/inference-engine/tools/vpu/vpu_perfcheck/CMakeLists.txt
@@ -33,6 +33,7 @@ function(add_perfcheck_target TARGET_NAME PLUGIN_NAME)
     target_include_directories(${TARGET_NAME}
         SYSTEM PRIVATE
             "${IE_MAIN_SOURCE_DIR}/src/vpu/graph_transformer/include"
+            "${IE_MAIN_SOURCE_DIR}/src/plugin_api"
             "${IE_MAIN_SOURCE_DIR}/samples/common/samples"
             "${IE_MAIN_SOURCE_DIR}/samples/common/format_reader")
 


### PR DESCRIPTION
Ticket - #-44532
Description: in case if input value is `std::numeric_limits<float>::infinity()`, `(v.u >> (23 - 10))` already has `1` sign bit, so we always get negative infinity.