### PR TITLE
Fix TFSliceToSlice for Windows

### DIFF
--- a/model-optimizer/extensions/front/tf/TFSliceToSlice.py
+++ b/model-optimizer/extensions/front/tf/TFSliceToSlice.py
@@ -44,7 +44,7 @@ class TFSliceToSliceReplacer(FrontReplacementOp):
 
         eq_node = Equal(graph, {'name': slice_name + '/equal'}).create_node()
         minus_one_node = Const(graph, {'name': slice_name + '/minus_one', 'value': np.array(-1)}).create_node()
-        int32_max_node = Const(graph, {'name': slice_name + '/int32_max', 'value': np.iinfo(np.int32).max}).create_node()
+        int32_max_node = Const(graph, {'name': slice_name + '/int32_max', 'value': np.int64(np.iinfo(np.int32).max)}).create_node()
         select_node = Select(graph, {'name': slice_name + '/select'}).create_node()
 
         # node to convert sizes to ends

--- a/model-optimizer/extensions/front/tf/TFSliceToSlice.py
+++ b/model-optimizer/extensions/front/tf/TFSliceToSlice.py
@@ -45,6 +45,7 @@ class TFSliceToSliceReplacer(FrontReplacementOp):
         eq_node = Equal(graph, {'name': slice_name + '/equal'}).create_node()
         minus_one_node = Const(graph, {'name': slice_name + '/minus_one', 'value': np.array(-1)}).create_node()
         int32_max_node = Const(graph, {'name': slice_name + '/int32_max', 'value': np.int64(np.iinfo(np.int32).max)}).create_node()
+        
         select_node = Select(graph, {'name': slice_name + '/select'}).create_node()
 
         # node to convert sizes to ends

--- a/model-optimizer/extensions/front/tf/TFSliceToSlice.py
+++ b/model-optimizer/extensions/front/tf/TFSliceToSlice.py
@@ -47,8 +47,7 @@ class TFSliceToSliceReplacer(FrontReplacementOp):
         minus_one_node = Const(graph, {'name': slice_name + '/minus_one', 'value': int64_array(-1)}).create_node()     
         
         #Select requires equal dtypes on ports 1 and 2.
-        #Dtype of [2] port is int64(summ_node -> cast to int64),
-        #so dtype of [1] (int32_max_node)  must be the same
+        #Dtype of [2] port is int64(summ_node -> cast to int64), so dtype of [1] (int32_max_node)  must be the same
         int32_max_node = Const(graph, {'name': slice_name + '/int32_max', 
                         'value': int64_array(np.iinfo(np.int32).max)}).create_node()
         select_node = Select(graph, {'name': slice_name + '/select'}).create_node()


### PR DESCRIPTION
Model Optimizer does not convert TF models with TFSlice layers on Windows

Ticket: #45388


Code:
* [x]  Comments - N/A 
* [x]  Code style (PEP8) - N/A
* [x]  Transformation generates reshape-able IR - N/A
* [x]  Transformation preserves original framework node names - N/A


Validation:
* [x]  Unit tests - N/A
* [x]  Framework operation tests - N/A
* [x]  Transformation tests - N/A
* [x]  e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py - N/A
* [x]  Model Optimizer IR Reader check - N/A

Documentation:
* [x]  Supported frameworks operations list - N/A
* [x]  Supported **public** models list - N/A
* [x]  New operations specification - N/A
* [x]  Guide on how to convert the **public** model - N/A
* [x]  User guide update - N/A