### PR TITLE
Enable Conditional Compilation for nGraph evaluate methods

### DIFF
--- a/ngraph/core/CMakeLists.txt
+++ b/ngraph/core/CMakeLists.txt
@@ -110,7 +110,6 @@ target_include_directories(ngraph PRIVATE ${NGRAPH_INCLUDE_DIR}
                                           ${NGRAPH_INCLUDE_DIR}/pattern/op
                                           ${NGRAPH_INCLUDE_DIR}/runtime
                                           ${CMAKE_CURRENT_SOURCE_DIR}/src
-                                          $<TARGET_PROPERTY:openvino::conditional_compilation,INTERFACE_INCLUDE_DIRECTORIES>
                                           )
 
 #Add an alias so that library can be used inside the build tree, e.g. when testing

--- a/ngraph/core/CMakeLists.txt
+++ b/ngraph/core/CMakeLists.txt
@@ -58,7 +58,7 @@ set_target_properties(ngraph PROPERTIES
                       C_VISIBILITY_PRESET hidden
                       VISIBILITY_INLINES_HIDDEN ON)
 
-target_link_libraries(ngraph PRIVATE openvino::itt ngraph::builder ngraph::reference)
+target_link_libraries(ngraph PRIVATE openvino::conditional_compilation openvino::itt ngraph::builder ngraph::reference)
 
 find_package(Graphviz QUIET)
 if (GRAPHVIZ_FOUND)
@@ -110,6 +110,7 @@ target_include_directories(ngraph PRIVATE ${NGRAPH_INCLUDE_DIR}
                                           ${NGRAPH_INCLUDE_DIR}/pattern/op
                                           ${NGRAPH_INCLUDE_DIR}/runtime
                                           ${CMAKE_CURRENT_SOURCE_DIR}/src
+                                          $<TARGET_PROPERTY:openvino::conditional_compilation,INTERFACE_INCLUDE_DIRECTORIES>
                                           )
 
 #Add an alias so that library can be used inside the build tree, e.g. when testing

--- a/ngraph/core/include/ngraph/op/broadcast.hpp
+++ b/ngraph/core/include/ngraph/op/broadcast.hpp
@@ -82,6 +82,10 @@ namespace ngraph
                 std::pair<bool, AxisSet> get_broadcast_axes() const override;
                 bool evaluate(const HostTensorVector& outputs,
                               const HostTensorVector& inputs) const override;
+
+            private:
+                bool broadcast_evaluate(const HostTensorVector& outputs,
+                                        const HostTensorVector& inputs) const;
             };
         } // namespace v3
 

--- a/ngraph/core/include/ngraph/op/depth_to_space.hpp
+++ b/ngraph/core/include/ngraph/op/depth_to_space.hpp
@@ -79,6 +79,10 @@ namespace ngraph
                 std::size_t m_blocksize;
                 DepthToSpaceMode m_mode;
                 DepthToSpaceMode mode_from_string(const std::string& mode) const;
+
+            private:
+                bool evaluate_depth_to_space(const HostTensorVector& outputs,
+                                             const HostTensorVector& inputs) const;
             };
         }
         using v0::DepthToSpace;

--- a/ngraph/core/include/ngraph/op/gather.hpp
+++ b/ngraph/core/include/ngraph/op/gather.hpp
@@ -57,6 +57,9 @@ namespace ngraph
                 static const int PARAMS;
                 static const int INDICES;
                 static const int AXIS;
+
+                bool evaluate_gather(const HostTensorVector& outputs,
+                                     const HostTensorVector& inputs) const;
             };
         } // namespace v1
     }     // namespace op

--- a/ngraph/core/include/ngraph/op/interpolate.hpp
+++ b/ngraph/core/include/ngraph/op/interpolate.hpp
@@ -234,6 +234,8 @@ namespace ngraph
                 std::vector<int64_t> get_axes() const;
 
             private:
+                bool evaluate_interpolate(const HostTensorVector& outputs,
+                                          const HostTensorVector& inputs) const;
                 InterpolateAttrs m_attrs;
 
                 /// \brief Corrects pads_begin and pads_end attributes.

--- a/ngraph/core/include/ngraph/op/max_pool.hpp
+++ b/ngraph/core/include/ngraph/op/max_pool.hpp
@@ -98,6 +98,8 @@ namespace ngraph
                 bool update_auto_padding(const PartialShape& in_shape,
                                          Shape& new_pads_end,
                                          Shape& new_pads_begin) const;
+                bool evaluate_maxpool(const HostTensorVector& outputs,
+                                      const HostTensorVector& inputs) const;
             };
         } // namespace v1
     }     // namespace op

--- a/ngraph/core/include/ngraph/op/pad.hpp
+++ b/ngraph/core/include/ngraph/op/pad.hpp
@@ -89,6 +89,8 @@ namespace ngraph
 
             private:
                 PadMode m_pad_mode;
+                bool evaluate_pad(const HostTensorVector& outputs,
+                                  const HostTensorVector& inputs) const;
             };
         }
     }

--- a/ngraph/core/include/ngraph/op/reshape.hpp
+++ b/ngraph/core/include/ngraph/op/reshape.hpp
@@ -71,6 +71,8 @@ namespace ngraph
 
             protected:
                 bool m_special_zero;
+                bool evaluate_reshape(const HostTensorVector& outputs,
+                                      const HostTensorVector& inputs) const;
             };
         }
     }

--- a/ngraph/core/include/ngraph/op/reverse.hpp
+++ b/ngraph/core/include/ngraph/op/reverse.hpp
@@ -73,6 +73,9 @@ namespace ngraph
                 /// Alternatively it can contain a boolean mask that indicates which axes should be
                 /// reversed.
                 Mode m_mode;
+            private:
+                bool evaluate_reverse(const HostTensorVector& outputs,
+                                      const HostTensorVector& inputs) const;
             };
         }
     }

--- a/ngraph/core/include/ngraph/op/reverse.hpp
+++ b/ngraph/core/include/ngraph/op/reverse.hpp
@@ -73,6 +73,7 @@ namespace ngraph
                 /// Alternatively it can contain a boolean mask that indicates which axes should be
                 /// reversed.
                 Mode m_mode;
+
             private:
                 bool evaluate_reverse(const HostTensorVector& outputs,
                                       const HostTensorVector& inputs) const;

--- a/ngraph/core/include/ngraph/op/scatter_elements_update.hpp
+++ b/ngraph/core/include/ngraph/op/scatter_elements_update.hpp
@@ -52,6 +52,10 @@ namespace ngraph
                     clone_with_new_inputs(const OutputVector& inputs) const override;
                 bool evaluate(const HostTensorVector& outputs,
                               const HostTensorVector& inputs) const override;
+
+            private:
+                bool evaluate_scatter_element_update(const HostTensorVector& outputs,
+                                                     const HostTensorVector& inputs) const;
             };
         }
         using v3::ScatterElementsUpdate;

--- a/ngraph/core/include/ngraph/op/scatter_update.hpp
+++ b/ngraph/core/include/ngraph/op/scatter_update.hpp
@@ -53,6 +53,10 @@ namespace ngraph
 
                 bool evaluate(const HostTensorVector& outputs,
                               const HostTensorVector& inputs) const override;
+
+            private:
+                bool evaluate_scatter_update(const HostTensorVector& outputs,
+                                             const HostTensorVector& inputs) const;
             };
         }
     }

--- a/ngraph/core/include/ngraph/op/shuffle_channels.hpp
+++ b/ngraph/core/include/ngraph/op/shuffle_channels.hpp
@@ -69,6 +69,8 @@ namespace ngraph
                 /// \param data_shape - Shape of the original input data tensor
                 /// \return A 4D tensor to be used to reshape the input data before shuffling it
                 Shape get_pre_shuffle_shape(const Shape& data_shape) const;
+                bool evaluate_shuffle_channels(const HostTensorVector& outputs,
+                                               const HostTensorVector& inputs) const;
 
                 int64_t m_axis;
                 int64_t m_group;

--- a/ngraph/core/include/ngraph/op/space_to_batch.hpp
+++ b/ngraph/core/include/ngraph/op/space_to_batch.hpp
@@ -63,6 +63,9 @@ namespace ngraph
 
                 bool evaluate(const HostTensorVector& outputs,
                               const HostTensorVector& inputs) const override;
+            private:
+                bool evaluate_space_to_batch(const HostTensorVector& outputs,
+                                             const HostTensorVector& inputs) const;
             };
         }
         using v1::SpaceToBatch;

--- a/ngraph/core/include/ngraph/op/space_to_batch.hpp
+++ b/ngraph/core/include/ngraph/op/space_to_batch.hpp
@@ -63,6 +63,7 @@ namespace ngraph
 
                 bool evaluate(const HostTensorVector& outputs,
                               const HostTensorVector& inputs) const override;
+
             private:
                 bool evaluate_space_to_batch(const HostTensorVector& outputs,
                                              const HostTensorVector& inputs) const;

--- a/ngraph/core/include/ngraph/op/space_to_depth.hpp
+++ b/ngraph/core/include/ngraph/op/space_to_depth.hpp
@@ -76,6 +76,10 @@ namespace ngraph
             protected:
                 std::size_t m_blocksize;
                 SpaceToDepthMode m_mode;
+
+            private:
+                bool evaluate_space_to_depth(const HostTensorVector& outputs,
+                                             const HostTensorVector& inputs) const;
             };
         }
         using v0::SpaceToDepth;

--- a/ngraph/core/include/ngraph/op/tile.hpp
+++ b/ngraph/core/include/ngraph/op/tile.hpp
@@ -47,6 +47,10 @@ namespace ngraph
 
                 bool evaluate(const HostTensorVector& outputs,
                               const HostTensorVector& inputs) const override;
+
+            private:
+                bool evaluate_tile(const HostTensorVector& outputs,
+                                   const HostTensorVector& inputs) const;
             };
         }
     }

--- a/ngraph/core/include/ngraph/op/topk.hpp
+++ b/ngraph/core/include/ngraph/op/topk.hpp
@@ -115,6 +115,7 @@ namespace ngraph
                                            const PartialShape input_partial_shape,
                                            const int64_t k) const;
                 void set_axis(const Rank input_rank, const int64_t axis);
+
             private:
                 bool evaluate_topk(const HostTensorVector& outputs,
                                    const HostTensorVector& inputs) const;

--- a/ngraph/core/include/ngraph/op/topk.hpp
+++ b/ngraph/core/include/ngraph/op/topk.hpp
@@ -115,6 +115,9 @@ namespace ngraph
                                            const PartialShape input_partial_shape,
                                            const int64_t k) const;
                 void set_axis(const Rank input_rank, const int64_t axis);
+            private:
+                bool evaluate_topk(const HostTensorVector& outputs,
+                                   const HostTensorVector& inputs) const;
             };
         } // namespace v1
 

--- a/ngraph/core/include/ngraph/op/variadic_split.hpp
+++ b/ngraph/core/include/ngraph/op/variadic_split.hpp
@@ -56,6 +56,7 @@ namespace ngraph
                 size_t get_default_output_index() const override { return no_default_index(); }
                 bool evaluate(const HostTensorVector& outputs,
                               const HostTensorVector& inputs) const override;
+
             private:
                 bool evaluate_variadic_split(const HostTensorVector& outputs,
                                              const HostTensorVector& inputs) const;

--- a/ngraph/core/include/ngraph/op/variadic_split.hpp
+++ b/ngraph/core/include/ngraph/op/variadic_split.hpp
@@ -56,6 +56,9 @@ namespace ngraph
                 size_t get_default_output_index() const override { return no_default_index(); }
                 bool evaluate(const HostTensorVector& outputs,
                               const HostTensorVector& inputs) const override;
+            private:
+                bool evaluate_variadic_split(const HostTensorVector& outputs,
+                                             const HostTensorVector& inputs) const;
             };
         } // namespace v1
 

--- a/ngraph/core/src/itt.hpp
+++ b/ngraph/core/src/itt.hpp
@@ -33,17 +33,17 @@ namespace ngraph
         {
             OV_ITT_DOMAIN(nGraph);
             OV_ITT_DOMAIN(nGraphPass_LT);
-            OV_ITT_DOMAIN(nGraphOp, "nGraph::Op");
+            OV_ITT_DOMAIN(ngraph_op, "nGraph::Op");
         }
     }
-    OV_CC_DOMAINS(nGraphOp);
+    OV_CC_DOMAINS(ngraph_op);
 }
 
 #if defined(SELECTIVE_BUILD) || defined(SELECTIVE_BUILD_ANALYZER)
-#define NGRAPH_OP_SCOPE(region, ...) OV_SCOPE(nGraphOp, region, __VA_ARGS__)
+#define NGRAPH_OP_SCOPE(region, ...) OV_SCOPE(ngraph_op, region, __VA_ARGS__)
 #else
 #define NGRAPH_OP_SCOPE(region, ...)                                                               \
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, region);                                            \
+    OV_ITT_SCOPED_TASK(itt::domains::ngraph_op, #region);                                          \
     __VA_ARGS__
 #endif
 
@@ -51,14 +51,14 @@ namespace ngraph
     case element::Type_t::a:                                                                       \
     {                                                                                              \
         OV_SCOPE(                                                                                  \
-            nGraphOp, OV_CC_CAT3(region, _, a), rc = evaluate<element::Type_t::a>(__VA_ARGS__));   \
+            ngraph_op, OV_CC_CAT3(region, _, a), rc = evaluate<element::Type_t::a>(__VA_ARGS__));  \
     }                                                                                              \
     break;
 
 #define NGRAPH_COPY_TENSOR(region, a, ...)                                                         \
     case element::Type_t::a:                                                                       \
     {                                                                                              \
-        OV_SCOPE(nGraphOp,                                                                         \
+        OV_SCOPE(ngraph_op,                                                                        \
                  OV_CC_CAT3(region, _, a),                                                         \
                  rc = copy_tensor<element::Type_t::a>(__VA_ARGS__));                               \
     }                                                                                              \

--- a/ngraph/core/src/op/abs.cpp
+++ b/ngraph/core/src/op/abs.cpp
@@ -57,22 +57,14 @@ namespace absop
 
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(boolean)(arg0, out, count);
-            break;
-            TYPE_CASE(i32)(arg0, out, count);
-            break;
-            TYPE_CASE(i64)(arg0, out, count);
-            break;
-            TYPE_CASE(u32)(arg0, out, count);
-            break;
-            TYPE_CASE(u64)(arg0, out, count);
-            break;
-            TYPE_CASE(f16)(arg0, out, count);
-            break;
-            TYPE_CASE(f32)(arg0, out, count);
-            break;
-            TYPE_CASE(bf16)(arg0, out, count);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_abs, boolean, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_abs, i32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_abs, i64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_abs, u32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_abs, u64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_abs, f16, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_abs, f32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_abs, bf16, arg0, out, count);
         default: rc = false; break;
         }
         return rc;
@@ -81,6 +73,9 @@ namespace absop
 
 bool op::Abs::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::Abs::evaluate");
-    return absop::evaluate_abs(inputs[0], outputs[0], shape_size(get_output_shape(0)));
+    bool rc = false;
+    NGRAPH_OP_SCOPE(
+        Abs_evaluate,
+        rc = absop::evaluate_abs(inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    return rc;
 }

--- a/ngraph/core/src/op/abs.cpp
+++ b/ngraph/core/src/op/abs.cpp
@@ -75,7 +75,7 @@ bool op::Abs::evaluate(const HostTensorVector& outputs, const HostTensorVector& 
 {
     bool rc = false;
     NGRAPH_OP_SCOPE(
-        Abs_evaluate,
+        v0_Abs_evaluate,
         rc = absop::evaluate_abs(inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return rc;
 }

--- a/ngraph/core/src/op/acos.cpp
+++ b/ngraph/core/src/op/acos.cpp
@@ -83,7 +83,7 @@ bool op::Acos::evaluate(const HostTensorVector& outputs, const HostTensorVector&
 {
     bool rc = false;
     NGRAPH_OP_SCOPE(
-        Acos_evaluate,
+        v0_Acos_evaluate,
         rc = acosop::evaluate_acos(inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return rc;
 }

--- a/ngraph/core/src/op/acos.cpp
+++ b/ngraph/core/src/op/acos.cpp
@@ -66,20 +66,13 @@ namespace acosop
 
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(boolean)(arg0, out, count);
-            break;
-            TYPE_CASE(i32)(arg0, out, count);
-            break;
-            TYPE_CASE(i64)(arg0, out, count);
-            break;
-            TYPE_CASE(u32)(arg0, out, count);
-            break;
-            TYPE_CASE(u64)(arg0, out, count);
-            break;
-            TYPE_CASE(f16)(arg0, out, count);
-            break;
-            TYPE_CASE(f32)(arg0, out, count);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_acos, boolean, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_acos, i32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_acos, i64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_acos, u32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_acos, u64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_acos, f16, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_acos, f32, arg0, out, count);
         default: rc = false; break;
         }
         return rc;
@@ -88,6 +81,9 @@ namespace acosop
 
 bool op::Acos::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::Acos::evaluate");
-    return acosop::evaluate_acos(inputs[0], outputs[0], shape_size(get_output_shape(0)));
+    bool rc = false;
+    NGRAPH_OP_SCOPE(
+        Acos_evaluate,
+        rc = acosop::evaluate_acos(inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    return rc;
 }

--- a/ngraph/core/src/op/acosh.cpp
+++ b/ngraph/core/src/op/acosh.cpp
@@ -56,18 +56,12 @@ namespace acoshop
         out->set_unary(arg0);
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(i32)(arg0, out);
-            break;
-            TYPE_CASE(i64)(arg0, out);
-            break;
-            TYPE_CASE(u32)(arg0, out);
-            break;
-            TYPE_CASE(u64)(arg0, out);
-            break;
-            TYPE_CASE(f16)(arg0, out);
-            break;
-            TYPE_CASE(f32)(arg0, out);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_acosh, i32, arg0, out);
+            NGRAPH_TYPE_CASE(evaluate_acosh, i64, arg0, out);
+            NGRAPH_TYPE_CASE(evaluate_acosh, u32, arg0, out);
+            NGRAPH_TYPE_CASE(evaluate_acosh, u64, arg0, out);
+            NGRAPH_TYPE_CASE(evaluate_acosh, f16, arg0, out);
+            NGRAPH_TYPE_CASE(evaluate_acosh, f32, arg0, out);
         default: rc = false; break;
         }
         return rc;
@@ -76,6 +70,7 @@ namespace acoshop
 
 bool op::v3::Acosh::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v3::Acosh::evaluate");
-    return acoshop::evaluate_acosh(inputs[0], outputs[0]);
+    bool rc = false;
+    NGRAPH_OP_SCOPE(v3_Acosh_evaluate, rc = acoshop::evaluate_acosh(inputs[0], outputs[0]));
+    return rc;
 }

--- a/ngraph/core/src/op/add.cpp
+++ b/ngraph/core/src/op/add.cpp
@@ -50,28 +50,17 @@ namespace add
         out->set_broadcast(broadcast_spec, arg0, arg1);
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(i8)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(i16)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(i32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(i64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u8)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u16)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(bf16)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_add, i8, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_add, i16, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_add, i32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_add, i64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_add, u8, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_add, u16, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_add, u32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_add, u64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_add, bf16, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_add, f16, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_add, f32, arg0, arg1, out, broadcast_spec);
         default: rc = false; break;
         }
         return rc;
@@ -104,6 +93,8 @@ shared_ptr<Node> op::v1::Add::clone_with_new_inputs(const OutputVector& new_args
 
 bool op::v1::Add::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::Add::evaluate");
-    return add::evaluate_add(inputs[0], inputs[1], outputs[0], get_autob());
+    bool rc = false;
+    NGRAPH_OP_SCOPE(v1_Add_evaluate,
+                    rc = add::evaluate_add(inputs[0], inputs[1], outputs[0], get_autob()));
+    return rc;
 }

--- a/ngraph/core/src/op/and.cpp
+++ b/ngraph/core/src/op/and.cpp
@@ -70,20 +70,13 @@ namespace logand
         out->set_broadcast(broadcast_spec, arg0, arg1);
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(boolean)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(i32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(i64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_logand, boolean, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_logand, i32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_logand, i64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_logand, u32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_logand, u64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_logand, f16, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_logand, f32, arg0, arg1, out, broadcast_spec);
         default: rc = false; break;
         }
         return rc;
@@ -93,6 +86,8 @@ namespace logand
 bool op::v1::LogicalAnd::evaluate(const HostTensorVector& outputs,
                                   const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::LogicalAnd::evaluate");
-    return logand::evaluate_logand(inputs[0], inputs[1], outputs[0], get_autob());
+    bool rc = false;
+    NGRAPH_OP_SCOPE(v1_LogicalAnd_evaluate,
+                    rc = logand::evaluate_logand(inputs[0], inputs[1], outputs[0], get_autob()););
+    return rc;
 }

--- a/ngraph/core/src/op/and.cpp
+++ b/ngraph/core/src/op/and.cpp
@@ -88,6 +88,6 @@ bool op::v1::LogicalAnd::evaluate(const HostTensorVector& outputs,
 {
     bool rc = false;
     NGRAPH_OP_SCOPE(v1_LogicalAnd_evaluate,
-                    rc = logand::evaluate_logand(inputs[0], inputs[1], outputs[0], get_autob()););
+                    rc = logand::evaluate_logand(inputs[0], inputs[1], outputs[0], get_autob()));
     return rc;
 }

--- a/ngraph/core/src/op/asin.cpp
+++ b/ngraph/core/src/op/asin.cpp
@@ -84,7 +84,7 @@ bool op::Asin::evaluate(const HostTensorVector& outputs, const HostTensorVector&
 {
     bool rc = false;
     NGRAPH_OP_SCOPE(
-        Asin_evaluate,
+        v0_Asin_evaluate,
         rc = asinop::evaluate_asin(inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return rc;
 }

--- a/ngraph/core/src/op/asin.cpp
+++ b/ngraph/core/src/op/asin.cpp
@@ -67,20 +67,13 @@ namespace asinop
 
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(boolean)(arg0, out, count);
-            break;
-            TYPE_CASE(i32)(arg0, out, count);
-            break;
-            TYPE_CASE(i64)(arg0, out, count);
-            break;
-            TYPE_CASE(u32)(arg0, out, count);
-            break;
-            TYPE_CASE(u64)(arg0, out, count);
-            break;
-            TYPE_CASE(f16)(arg0, out, count);
-            break;
-            TYPE_CASE(f32)(arg0, out, count);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_asin, boolean, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_asin, i32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_asin, i64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_asin, u32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_asin, u64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_asin, f16, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_asin, f32, arg0, out, count);
         default: rc = false; break;
         }
         return rc;
@@ -89,6 +82,9 @@ namespace asinop
 
 bool op::Asin::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::Asin::evaluate");
-    return asinop::evaluate_asin(inputs[0], outputs[0], shape_size(get_output_shape(0)));
+    bool rc = false;
+    NGRAPH_OP_SCOPE(
+        Asin_evaluate,
+        rc = asinop::evaluate_asin(inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    return rc;
 }

--- a/ngraph/core/src/op/asinh.cpp
+++ b/ngraph/core/src/op/asinh.cpp
@@ -56,18 +56,12 @@ namespace asinhop
         out->set_unary(arg0);
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(i32)(arg0, out);
-            break;
-            TYPE_CASE(i64)(arg0, out);
-            break;
-            TYPE_CASE(u32)(arg0, out);
-            break;
-            TYPE_CASE(u64)(arg0, out);
-            break;
-            TYPE_CASE(f16)(arg0, out);
-            break;
-            TYPE_CASE(f32)(arg0, out);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_asinh, i32, arg0, out);
+            NGRAPH_TYPE_CASE(evaluate_asinh, i64, arg0, out);
+            NGRAPH_TYPE_CASE(evaluate_asinh, u32, arg0, out);
+            NGRAPH_TYPE_CASE(evaluate_asinh, u64, arg0, out);
+            NGRAPH_TYPE_CASE(evaluate_asinh, f16, arg0, out);
+            NGRAPH_TYPE_CASE(evaluate_asinh, f32, arg0, out);
         default: rc = false; break;
         }
         return rc;
@@ -76,6 +70,7 @@ namespace asinhop
 
 bool op::v3::Asinh::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v3::Asinh::evaluate");
-    return asinhop::evaluate_asinh(inputs[0], outputs[0]);
+    bool rc = false;
+    NGRAPH_OP_SCOPE(v3_Asinh_evaluate, rc = asinhop::evaluate_asinh(inputs[0], outputs[0]));
+    return rc;
 }

--- a/ngraph/core/src/op/atan.cpp
+++ b/ngraph/core/src/op/atan.cpp
@@ -66,20 +66,13 @@ namespace atanop
 
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(boolean)(arg0, out, count);
-            break;
-            TYPE_CASE(i32)(arg0, out, count);
-            break;
-            TYPE_CASE(i64)(arg0, out, count);
-            break;
-            TYPE_CASE(u32)(arg0, out, count);
-            break;
-            TYPE_CASE(u64)(arg0, out, count);
-            break;
-            TYPE_CASE(f16)(arg0, out, count);
-            break;
-            TYPE_CASE(f32)(arg0, out, count);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_atan, boolean, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_atan, i32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_atan, i64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_atan, u32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_atan, u64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_atan, f16, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_atan, f32, arg0, out, count);
         default: rc = false; break;
         }
         return rc;
@@ -88,6 +81,9 @@ namespace atanop
 
 bool op::Atan::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::Atan::evaluate");
-    return atanop::evaluate_atan(inputs[0], outputs[0], shape_size(get_output_shape(0)));
+    bool rc = false;
+    NGRAPH_OP_SCOPE(
+        Atan_evaluate,
+        rc = atanop::evaluate_atan(inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    return rc;
 }

--- a/ngraph/core/src/op/atan.cpp
+++ b/ngraph/core/src/op/atan.cpp
@@ -83,7 +83,7 @@ bool op::Atan::evaluate(const HostTensorVector& outputs, const HostTensorVector&
 {
     bool rc = false;
     NGRAPH_OP_SCOPE(
-        Atan_evaluate,
+        v0_Atan_evaluate,
         rc = atanop::evaluate_atan(inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return rc;
 }

--- a/ngraph/core/src/op/atanh.cpp
+++ b/ngraph/core/src/op/atanh.cpp
@@ -56,18 +56,12 @@ namespace atanhop
         out->set_unary(arg0);
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(i32)(arg0, out);
-            break;
-            TYPE_CASE(i64)(arg0, out);
-            break;
-            TYPE_CASE(u32)(arg0, out);
-            break;
-            TYPE_CASE(u64)(arg0, out);
-            break;
-            TYPE_CASE(f16)(arg0, out);
-            break;
-            TYPE_CASE(f32)(arg0, out);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_atanh, i32, arg0, out);
+            NGRAPH_TYPE_CASE(evaluate_atanh, i64, arg0, out);
+            NGRAPH_TYPE_CASE(evaluate_atanh, u32, arg0, out);
+            NGRAPH_TYPE_CASE(evaluate_atanh, u64, arg0, out);
+            NGRAPH_TYPE_CASE(evaluate_atanh, f16, arg0, out);
+            NGRAPH_TYPE_CASE(evaluate_atanh, f32, arg0, out);
         default: rc = false; break;
         }
         return rc;
@@ -76,6 +70,7 @@ namespace atanhop
 
 bool op::v3::Atanh::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v3::Atanh::evaluate");
-    return atanhop::evaluate_atanh(inputs[0], outputs[0]);
+    bool rc = false;
+    NGRAPH_OP_SCOPE(v3_Atanh_evaluate, rc = atanhop::evaluate_atanh(inputs[0], outputs[0]));
+    return rc;
 }

--- a/ngraph/core/src/op/batch_to_space.cpp
+++ b/ngraph/core/src/op/batch_to_space.cpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <numeric>
 #include <ops.hpp>
+#include "itt.hpp"
 
 #include "ngraph/builder/make_constant.hpp"
 #include "ngraph/node.hpp"
@@ -144,111 +145,101 @@ bool ngraph::op::v1::BatchToSpace::visit_attributes(ngraph::AttributeVisitor& vi
 bool ngraph::op::v1::BatchToSpace::evaluate(const HostTensorVector& outputs,
                                             const HostTensorVector& inputs) const
 {
-    auto data = inputs[0];
-    size_t elem_size = data->get_element_type().size();
+    NGRAPH_OP_SCOPE(
+        v1_BatchToSpace, auto data = inputs[0]; size_t elem_size = data->get_element_type().size();
 
-    if (data->get_partial_shape().is_dynamic())
-    {
-        return false;
-    }
-    auto data_shape = data->get_shape();
+        if (data->get_partial_shape().is_dynamic()) { return false; } auto data_shape =
+            data->get_shape();
 
-    if (!(data->get_shape().size() == 4 || data->get_shape().size() == 5))
-    {
-        return false;
-    }
-    size_t block_values_size = shape_size(inputs[1]->get_shape());
-    const auto* block_values = inputs[1]->get_data_ptr<int64_t>();
-    const auto* crops_begin_values = inputs[2]->get_data_ptr<int64_t>();
-    const auto* crops_end_values = inputs[3]->get_data_ptr<int64_t>();
+        if (!(data->get_shape().size() == 4 || data->get_shape().size() == 5)) {
+            return false;
+        } size_t block_values_size = shape_size(inputs[1]->get_shape());
+        const auto* block_values = inputs[1]->get_data_ptr<int64_t>();
+        const auto* crops_begin_values = inputs[2]->get_data_ptr<int64_t>();
+        const auto* crops_end_values = inputs[3]->get_data_ptr<int64_t>();
 
-    Shape dispersed_shape(1);
-    dispersed_shape.insert(dispersed_shape.end(), data_shape.begin(), data_shape.end());
-    std::vector<size_t> axes_order(block_values_size + 1);
-    std::vector<size_t> plain_axes_order(block_values_size + 1);
-    std::iota(plain_axes_order.begin(), plain_axes_order.end(), 0);
-    Shape squeezed_shape(data_shape.begin(), data_shape.end());
-    if (squeezed_shape.size() > block_values_size)
-    {
-        return false;
-    }
+        Shape dispersed_shape(1);
+        dispersed_shape.insert(dispersed_shape.end(), data_shape.begin(), data_shape.end());
+        std::vector<size_t> axes_order(block_values_size + 1);
+        std::vector<size_t> plain_axes_order(block_values_size + 1);
+        std::iota(plain_axes_order.begin(), plain_axes_order.end(), 0);
+        Shape squeezed_shape(data_shape.begin(), data_shape.end());
+        if (squeezed_shape.size() > block_values_size) { return false; }
 
-    auto* flat_data = data->get_data_ptr<char>();
-    std::vector<char> dispersed_data(shape_size(data_shape) * elem_size);
+        auto* flat_data = data->get_data_ptr<char>();
+        std::vector<char> dispersed_data(shape_size(data_shape) * elem_size);
 
-    Shape post_transpose_shape(axes_order.size());
-    std::vector<char> post_transpose_data(shape_size(data_shape) * elem_size);
+        Shape post_transpose_shape(axes_order.size());
+        std::vector<char> post_transpose_data(shape_size(data_shape) * elem_size);
 
-    for (size_t block_idx = 1; block_idx < block_values_size; ++block_idx)
-    {
-        dispersed_shape[0] = block_values[block_idx];
-        dispersed_shape[1] /= block_values[block_idx];
-        runtime::opt_kernel::reshape(flat_data,
-                                     dispersed_data.data(),
-                                     data_shape,
-                                     plain_axes_order,
-                                     dispersed_shape,
-                                     elem_size);
+        for (size_t block_idx = 1; block_idx < block_values_size; ++block_idx) {
+            dispersed_shape[0] = block_values[block_idx];
+            dispersed_shape[1] /= block_values[block_idx];
+            runtime::opt_kernel::reshape(flat_data,
+                                         dispersed_data.data(),
+                                         data_shape,
+                                         plain_axes_order,
+                                         dispersed_shape,
+                                         elem_size);
 
-        size_t val = 1;
-        for (size_t axis_idx = 0; axis_idx <= block_values_size; ++axis_idx)
-        {
-            if ((block_idx + 1) == axis_idx)
+            size_t val = 1;
+            for (size_t axis_idx = 0; axis_idx <= block_values_size; ++axis_idx)
             {
-                axes_order[axis_idx] = 0;
+                if ((block_idx + 1) == axis_idx)
+                {
+                    axes_order[axis_idx] = 0;
+                }
+                else
+                {
+                    axes_order[axis_idx] = val;
+                    val++;
+                }
             }
-            else
+            for (size_t axis_idx = 0; axis_idx < axes_order.size(); ++axis_idx)
             {
-                axes_order[axis_idx] = val;
-                val++;
+                post_transpose_shape[axis_idx] = dispersed_shape[axes_order[axis_idx]];
             }
+
+            runtime::opt_kernel::reshape(dispersed_data.data(),
+                                         post_transpose_data.data(),
+                                         dispersed_shape,
+                                         axes_order,
+                                         post_transpose_shape,
+                                         elem_size);
+            squeezed_shape[0] = dispersed_shape[1];
+            squeezed_shape[block_idx] *= block_values[block_idx];
+            dispersed_shape[block_idx + 1] = squeezed_shape[block_idx];
+            runtime::opt_kernel::reshape(post_transpose_data.data(),
+                                         flat_data,
+                                         post_transpose_shape,
+                                         plain_axes_order,
+                                         squeezed_shape,
+                                         elem_size);
+            data_shape = squeezed_shape;
         }
-        for (size_t axis_idx = 0; axis_idx < axes_order.size(); ++axis_idx)
-        {
-            post_transpose_shape[axis_idx] = dispersed_shape[axes_order[axis_idx]];
-        }
 
-        runtime::opt_kernel::reshape(dispersed_data.data(),
-                                     post_transpose_data.data(),
-                                     dispersed_shape,
-                                     axes_order,
-                                     post_transpose_shape,
-                                     elem_size);
-        squeezed_shape[0] = dispersed_shape[1];
-        squeezed_shape[block_idx] *= block_values[block_idx];
-        dispersed_shape[block_idx + 1] = squeezed_shape[block_idx];
-        runtime::opt_kernel::reshape(post_transpose_data.data(),
-                                     flat_data,
-                                     post_transpose_shape,
-                                     plain_axes_order,
-                                     squeezed_shape,
-                                     elem_size);
-        data_shape = squeezed_shape;
-    }
+        std::vector<int64_t> upperbounds_values(data_shape.size());
+        for (size_t i = 0; i < data_shape.size();
+             ++i) { upperbounds_values[i] = data_shape[i] - crops_end_values[i]; }
 
-    std::vector<int64_t> upperbounds_values(data_shape.size());
-    for (size_t i = 0; i < data_shape.size(); ++i)
-    {
-        upperbounds_values[i] = data_shape[i] - crops_end_values[i];
-    }
+        std::vector<size_t> begin_mask(data_shape.size(), 0);
+        std::vector<size_t> end_mask(data_shape.size(), 0);
 
-    std::vector<size_t> begin_mask(data_shape.size(), 0);
-    std::vector<size_t> end_mask(data_shape.size(), 0);
+        std::vector<int64_t> begins(shape_size(inputs[2]->get_shape()));
+        begins.assign(crops_begin_values, crops_begin_values + shape_size(inputs[2]->get_shape()));
 
-    std::vector<int64_t> begins(shape_size(inputs[2]->get_shape()));
-    begins.assign(crops_begin_values, crops_begin_values + shape_size(inputs[2]->get_shape()));
-
-    std::vector<int64_t> default_strides(begins.size(), 1);
-    SlicePlan slice_plan = make_slice_plan(data_shape,
-                                           begins,
-                                           upperbounds_values,
-                                           default_strides,
-                                           begin_mask,
-                                           end_mask,
-                                           AxisSet(),
-                                           AxisSet(),
-                                           AxisSet());
-    runtime::reference::strided_slice(
-        flat_data, outputs[0]->get_data_ptr<char>(), data_shape, slice_plan, elem_size);
-    return true;
+        std::vector<int64_t> default_strides(begins.size(), 1);
+        SlicePlan slice_plan = make_slice_plan(data_shape,
+                                               begins,
+                                               upperbounds_values,
+                                               default_strides,
+                                               begin_mask,
+                                               end_mask,
+                                               AxisSet(),
+                                               AxisSet(),
+                                               AxisSet());
+        runtime::reference::strided_slice(
+            flat_data, outputs[0]->get_data_ptr<char>(), data_shape, slice_plan, elem_size);
+        return true);
+    return false;
 }

--- a/ngraph/core/src/op/broadcast.cpp
+++ b/ngraph/core/src/op/broadcast.cpp
@@ -318,7 +318,7 @@ bool op::v1::Broadcast::visit_attributes(AttributeVisitor& visitor)
 bool op::v1::Broadcast::evaluate(const HostTensorVector& outputs,
                                  const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(op_v1_Broadcast_evaluate,
+    NGRAPH_OP_SCOPE(v1_Broadcast_evaluate,
                     return op::util::BroadcastBase::evaluate(outputs, inputs));
     return false;
 }

--- a/ngraph/core/src/op/broadcast.cpp
+++ b/ngraph/core/src/op/broadcast.cpp
@@ -311,7 +311,7 @@ bool op::v1::Broadcast::visit_attributes(AttributeVisitor& visitor)
 bool op::v1::Broadcast::evaluate(const HostTensorVector& outputs,
                                  const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(
-        op_v1_Broadcast_evaluate return op::util::BroadcastBase::evaluate(outputs, inputs));
+    NGRAPH_OP_SCOPE(op_v1_Broadcast_evaluate,
+                    return op::util::BroadcastBase::evaluate(outputs, inputs));
     return false;
 }

--- a/ngraph/core/src/op/broadcast.cpp
+++ b/ngraph/core/src/op/broadcast.cpp
@@ -211,19 +211,18 @@ bool op::v3::Broadcast::visit_attributes(AttributeVisitor& visitor)
 bool op::v3::Broadcast::evaluate(const HostTensorVector& outputs,
                                  const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v3::Broadcast::evaluate");
-    if (get_broadcast_spec().m_type == op::BroadcastType::BIDIRECTIONAL)
-    {
-        auto arg_shape = inputs[0]->get_shape();
-        Shape target_shape = op::util::BroadcastBase::get_target_shape(inputs[1]);
-        PartialShape result_shape =
-            get_result_shape_bidirectional(this, PartialShape{arg_shape}, target_shape);
-        auto pair_broadcast_axes =
-            get_broadcast_axes_bidirectional(arg_shape, result_shape.to_shape());
-        return op::util::BroadcastBase::evaluate_broadcast(
-            inputs[0], outputs[0], pair_broadcast_axes, result_shape.to_shape());
-    }
-    return op::util::BroadcastBase::evaluate(outputs, inputs);
+    NGRAPH_OP_SCOPE(v3_Broadcast_evaluate,
+                    if (get_broadcast_spec().m_type == op::BroadcastType::BIDIRECTIONAL) {
+                        auto arg_shape = inputs[0]->get_shape();
+                        Shape target_shape = op::util::BroadcastBase::get_target_shape(inputs[1]);
+                        PartialShape result_shape = get_result_shape_bidirectional(
+                            this, PartialShape{arg_shape}, target_shape);
+                        auto pair_broadcast_axes =
+                            get_broadcast_axes_bidirectional(arg_shape, result_shape.to_shape());
+                        return op::util::BroadcastBase::evaluate_broadcast(
+                            inputs[0], outputs[0], pair_broadcast_axes, result_shape.to_shape());
+                    } return op::util::BroadcastBase::evaluate(outputs, inputs));
+    return false;
 }
 
 namespace
@@ -312,6 +311,7 @@ bool op::v1::Broadcast::visit_attributes(AttributeVisitor& visitor)
 bool op::v1::Broadcast::evaluate(const HostTensorVector& outputs,
                                  const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::Broadcast::evaluate");
-    return op::util::BroadcastBase::evaluate(outputs, inputs);
+    NGRAPH_OP_SCOPE(
+        op_v1_Broadcast_evaluate return op::util::BroadcastBase::evaluate(outputs, inputs));
+    return false;
 }

--- a/ngraph/core/src/op/broadcast.cpp
+++ b/ngraph/core/src/op/broadcast.cpp
@@ -142,6 +142,23 @@ namespace
     }
 }
 
+bool op::v3::Broadcast::broadcast_evaluate(const HostTensorVector& outputs,
+                                           const HostTensorVector& inputs) const
+{
+    if (get_broadcast_spec().m_type == op::BroadcastType::BIDIRECTIONAL)
+    {
+        auto arg_shape = inputs[0]->get_shape();
+        Shape target_shape = op::util::BroadcastBase::get_target_shape(inputs[1]);
+        PartialShape result_shape =
+            get_result_shape_bidirectional(this, PartialShape{arg_shape}, target_shape);
+        auto pair_broadcast_axes =
+            get_broadcast_axes_bidirectional(arg_shape, result_shape.to_shape());
+        return op::util::BroadcastBase::evaluate_broadcast(
+            inputs[0], outputs[0], pair_broadcast_axes, result_shape.to_shape());
+    }
+    return op::util::BroadcastBase::evaluate(outputs, inputs);
+}
+
 void op::v3::Broadcast::validate_and_infer_types()
 {
     if (m_mode.m_type == BroadcastType::NONE)
@@ -211,17 +228,7 @@ bool op::v3::Broadcast::visit_attributes(AttributeVisitor& visitor)
 bool op::v3::Broadcast::evaluate(const HostTensorVector& outputs,
                                  const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(v3_Broadcast_evaluate,
-                    if (get_broadcast_spec().m_type == op::BroadcastType::BIDIRECTIONAL) {
-                        auto arg_shape = inputs[0]->get_shape();
-                        Shape target_shape = op::util::BroadcastBase::get_target_shape(inputs[1]);
-                        PartialShape result_shape = get_result_shape_bidirectional(
-                            this, PartialShape{arg_shape}, target_shape);
-                        auto pair_broadcast_axes =
-                            get_broadcast_axes_bidirectional(arg_shape, result_shape.to_shape());
-                        return op::util::BroadcastBase::evaluate_broadcast(
-                            inputs[0], outputs[0], pair_broadcast_axes, result_shape.to_shape());
-                    } return op::util::BroadcastBase::evaluate(outputs, inputs));
+    NGRAPH_OP_SCOPE(v3_Broadcast_evaluate, return broadcast_evaluate(outputs, inputs));
     return false;
 }
 

--- a/ngraph/core/src/op/ceiling.cpp
+++ b/ngraph/core/src/op/ceiling.cpp
@@ -64,28 +64,17 @@ namespace ceiling
 
         switch (arg0->get_element_type())
         {
-            COPY_TENSOR(boolean)(arg0, out, count);
-            break;
-            COPY_TENSOR(i8)(arg0, out, count);
-            break;
-            COPY_TENSOR(i16)(arg0, out, count);
-            break;
-            COPY_TENSOR(i32)(arg0, out, count);
-            break;
-            COPY_TENSOR(i64)(arg0, out, count);
-            break;
-            COPY_TENSOR(u8)(arg0, out, count);
-            break;
-            COPY_TENSOR(u16)(arg0, out, count);
-            break;
-            COPY_TENSOR(u32)(arg0, out, count);
-            break;
-            COPY_TENSOR(u64)(arg0, out, count);
-            break;
-            TYPE_CASE(f16)(arg0, out, count);
-            break;
-            TYPE_CASE(f32)(arg0, out, count);
-            break;
+            NGRAPH_COPY_TENSOR(evaluate_ceiling, boolean, arg0, out, count);
+            NGRAPH_COPY_TENSOR(evaluate_ceiling, i8, arg0, out, count);
+            NGRAPH_COPY_TENSOR(evaluate_ceiling, i16, arg0, out, count);
+            NGRAPH_COPY_TENSOR(evaluate_ceiling, i32, arg0, out, count);
+            NGRAPH_COPY_TENSOR(evaluate_ceiling, i64, arg0, out, count);
+            NGRAPH_COPY_TENSOR(evaluate_ceiling, u8, arg0, out, count);
+            NGRAPH_COPY_TENSOR(evaluate_ceiling, u16, arg0, out, count);
+            NGRAPH_COPY_TENSOR(evaluate_ceiling, u32, arg0, out, count);
+            NGRAPH_COPY_TENSOR(evaluate_ceiling, u64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_ceiling, f16, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_ceiling, f32, arg0, out, count);
         default: rc = false; break;
         }
         return rc;
@@ -94,6 +83,7 @@ namespace ceiling
 
 bool op::Ceiling::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::Ceiling::evaluate");
-    return ceiling::evaluate_ceiling(inputs[0], outputs[0], shape_size(get_output_shape(0)));
+    NGRAPH_OP_SCOPE(Ceiling_evaluate return ceiling::evaluate_ceiling(
+        inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    return false;
 }

--- a/ngraph/core/src/op/ceiling.cpp
+++ b/ngraph/core/src/op/ceiling.cpp
@@ -84,7 +84,7 @@ namespace ceiling
 bool op::Ceiling::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
     NGRAPH_OP_SCOPE(
-        Ceiling_evaluate,
+        v0_Ceiling_evaluate,
         return ceiling::evaluate_ceiling(inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return false;
 }

--- a/ngraph/core/src/op/ceiling.cpp
+++ b/ngraph/core/src/op/ceiling.cpp
@@ -83,7 +83,8 @@ namespace ceiling
 
 bool op::Ceiling::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(Ceiling_evaluate return ceiling::evaluate_ceiling(
-        inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    NGRAPH_OP_SCOPE(
+        Ceiling_evaluate,
+        return ceiling::evaluate_ceiling(inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return false;
 }

--- a/ngraph/core/src/op/clamp.cpp
+++ b/ngraph/core/src/op/clamp.cpp
@@ -86,9 +86,9 @@ namespace clamp
 
 bool op::v0::Clamp::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v0::Clamp::evaluate");
-    return clamp::evaluate_clamp(
-        inputs[0], outputs[0], get_min(), get_max(), shape_size(get_input_shape(0)));
+    NGRAPH_OP_SCOPE(v0_Clamp_evaluate return clamp::evaluate_clamp(
+        inputs[0], outputs[0], get_min(), get_max(), shape_size(get_input_shape(0))));
+    return false;
 }
 
 NGRAPH_RTTI_DEFINITION(op::v0::Clamp, "Clamp", 0);

--- a/ngraph/core/src/op/clamp.cpp
+++ b/ngraph/core/src/op/clamp.cpp
@@ -86,8 +86,10 @@ namespace clamp
 
 bool op::v0::Clamp::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(v0_Clamp_evaluate return clamp::evaluate_clamp(
-        inputs[0], outputs[0], get_min(), get_max(), shape_size(get_input_shape(0))));
+    NGRAPH_OP_SCOPE(
+        v0_Clamp_evaluate,
+        return clamp::evaluate_clamp(
+            inputs[0], outputs[0], get_min(), get_max(), shape_size(get_input_shape(0))));
     return false;
 }
 

--- a/ngraph/core/src/op/concat.cpp
+++ b/ngraph/core/src/op/concat.cpp
@@ -144,7 +144,9 @@ namespace
 
 bool op::Concat::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::Concat::evaluate");
-    auto concat_axis = get_axis() < 0 ? get_axis() + inputs[0]->get_shape().size() : get_axis();
-    return evaluate_concat(inputs, outputs[0], concat_axis);
+    NGRAPH_OP_SCOPE(Concat_evaluate,
+                    auto concat_axis =
+                        get_axis() < 0 ? get_axis() + inputs[0]->get_shape().size() : get_axis();
+                    return evaluate_concat(inputs, outputs[0], concat_axis));
+    return false;
 }

--- a/ngraph/core/src/op/concat.cpp
+++ b/ngraph/core/src/op/concat.cpp
@@ -144,7 +144,7 @@ namespace
 
 bool op::Concat::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(Concat_evaluate,
+    NGRAPH_OP_SCOPE(v0_Concat_evaluate,
                     auto concat_axis =
                         get_axis() < 0 ? get_axis() + inputs[0]->get_shape().size() : get_axis();
                     return evaluate_concat(inputs, outputs[0], concat_axis));

--- a/ngraph/core/src/op/constant.cpp
+++ b/ngraph/core/src/op/constant.cpp
@@ -638,7 +638,7 @@ bool op::v0::Constant::visit_attributes(AttributeVisitor& visitor)
 bool op::v0::Constant::evaluate(const HostTensorVector& outputs,
                                 const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(v0_Constant_evaluate auto output = outputs[0];
+    NGRAPH_OP_SCOPE(v0_Constant_evaluate, auto output = outputs[0];
                     output->write(get_data_ptr(), output->get_size_in_bytes());
                     return true);
     return false;

--- a/ngraph/core/src/op/constant.cpp
+++ b/ngraph/core/src/op/constant.cpp
@@ -638,10 +638,10 @@ bool op::v0::Constant::visit_attributes(AttributeVisitor& visitor)
 bool op::v0::Constant::evaluate(const HostTensorVector& outputs,
                                 const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v0::Constant::evaluate");
-    auto output = outputs[0];
-    output->write(get_data_ptr(), output->get_size_in_bytes());
-    return true;
+    NGRAPH_OP_SCOPE(v0_Constant_evaluate auto output = outputs[0];
+                    output->write(get_data_ptr(), output->get_size_in_bytes());
+                    return true);
+    return false;
 }
 
 //

--- a/ngraph/core/src/op/convert.cpp
+++ b/ngraph/core/src/op/convert.cpp
@@ -63,8 +63,13 @@ namespace convert
                 true);
     }
 
-#define TYPE_OUT_CASE(a)                                                                           \
-    case element::Type_t::a: rc = evaluate<INPUT_ET, element::Type_t::a>
+#define TYPE_OUT_CASE(a, ...)                                                                      \
+    case element::Type_t::a:                                                                       \
+    {                                                                                              \
+        NGRAPH_OP_SCOPE(OV_CC_CAT3(evaluate_covert_out, _, a),                                     \
+                        rc = evaluate<INPUT_ET, element::Type_t::a>(__VA_ARGS__));                 \
+    }                                                                                              \
+    break
 
     template <element::Type_t INPUT_ET>
     bool evaluate(const HostTensorPtr& arg, const HostTensorPtr& out)
@@ -73,30 +78,18 @@ namespace convert
 
         switch (out->get_element_type())
         {
-            TYPE_OUT_CASE(i8)(arg, out);
-            break;
-            TYPE_OUT_CASE(i16)(arg, out);
-            break;
-            TYPE_OUT_CASE(i32)(arg, out);
-            break;
-            TYPE_OUT_CASE(i64)(arg, out);
-            break;
-            TYPE_OUT_CASE(u8)(arg, out);
-            break;
-            TYPE_OUT_CASE(u16)(arg, out);
-            break;
-            TYPE_OUT_CASE(u32)(arg, out);
-            break;
-            TYPE_OUT_CASE(u64)(arg, out);
-            break;
-            TYPE_OUT_CASE(bf16)(arg, out);
-            break;
-            TYPE_OUT_CASE(f16)(arg, out);
-            break;
-            TYPE_OUT_CASE(f32)(arg, out);
-            break;
-            TYPE_OUT_CASE(f64)(arg, out);
-            break;
+            TYPE_OUT_CASE(i8, arg, out);
+            TYPE_OUT_CASE(i16, arg, out);
+            TYPE_OUT_CASE(i32, arg, out);
+            TYPE_OUT_CASE(i64, arg, out);
+            TYPE_OUT_CASE(u8, arg, out);
+            TYPE_OUT_CASE(u16, arg, out);
+            TYPE_OUT_CASE(u32, arg, out);
+            TYPE_OUT_CASE(u64, arg, out);
+            TYPE_OUT_CASE(bf16, arg, out);
+            TYPE_OUT_CASE(f16, arg, out);
+            TYPE_OUT_CASE(f32, arg, out);
+            TYPE_OUT_CASE(f64, arg, out);
         default: rc = false; break;
         }
         return rc;
@@ -107,24 +100,15 @@ namespace convert
         bool rc = true;
         switch (arg->get_element_type())
         {
-            TYPE_CASE(u8)(arg, out);
-            break;
-            TYPE_CASE(i8)(arg, out);
-            break;
-            TYPE_CASE(i32)(arg, out);
-            break;
-            TYPE_CASE(i16)(arg, out);
-            break;
-            TYPE_CASE(i64)(arg, out);
-            break;
-            TYPE_CASE(u32)(arg, out);
-            break;
-            TYPE_CASE(u64)(arg, out);
-            break;
-            TYPE_CASE(f16)(arg, out);
-            break;
-            TYPE_CASE(f32)(arg, out);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_convert, u8, arg, out);
+            NGRAPH_TYPE_CASE(evaluate_convert, i8, arg, out);
+            NGRAPH_TYPE_CASE(evaluate_convert, i32, arg, out);
+            NGRAPH_TYPE_CASE(evaluate_convert, i16, arg, out);
+            NGRAPH_TYPE_CASE(evaluate_convert, i64, arg, out);
+            NGRAPH_TYPE_CASE(evaluate_convert, u32, arg, out);
+            NGRAPH_TYPE_CASE(evaluate_convert, u64, arg, out);
+            NGRAPH_TYPE_CASE(evaluate_convert, f16, arg, out);
+            NGRAPH_TYPE_CASE(evaluate_convert, f32, arg, out);
         default: rc = false; break;
         }
         return rc;
@@ -133,6 +117,7 @@ namespace convert
 bool op::v0::Convert::evaluate(const HostTensorVector& output_values,
                                const HostTensorVector& input_values) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v0::Convert::evaluate");
-    return convert::evaluate_convert(input_values[0], output_values[0]);
+    NGRAPH_OP_SCOPE(
+        v0_Convert_evaluate return convert::evaluate_convert(input_values[0], output_values[0]));
+    return false;
 }

--- a/ngraph/core/src/op/convert.cpp
+++ b/ngraph/core/src/op/convert.cpp
@@ -117,7 +117,7 @@ namespace convert
 bool op::v0::Convert::evaluate(const HostTensorVector& output_values,
                                const HostTensorVector& input_values) const
 {
-    NGRAPH_OP_SCOPE(
-        v0_Convert_evaluate return convert::evaluate_convert(input_values[0], output_values[0]));
+    NGRAPH_OP_SCOPE(v0_Convert_evaluate,
+                    return convert::evaluate_convert(input_values[0], output_values[0]));
     return false;
 }

--- a/ngraph/core/src/op/cos.cpp
+++ b/ngraph/core/src/op/cos.cpp
@@ -79,7 +79,7 @@ namespace cosop
 bool op::Cos::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
     NGRAPH_OP_SCOPE(
-        Cos_evaluate,
+        v0_Cos_evaluate,
         return cosop::evaluate_cos(inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return false;
 }

--- a/ngraph/core/src/op/cos.cpp
+++ b/ngraph/core/src/op/cos.cpp
@@ -63,20 +63,13 @@ namespace cosop
 
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(boolean)(arg0, out, count);
-            break;
-            TYPE_CASE(i32)(arg0, out, count);
-            break;
-            TYPE_CASE(i64)(arg0, out, count);
-            break;
-            TYPE_CASE(u32)(arg0, out, count);
-            break;
-            TYPE_CASE(u64)(arg0, out, count);
-            break;
-            TYPE_CASE(f16)(arg0, out, count);
-            break;
-            TYPE_CASE(f32)(arg0, out, count);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_cos, boolean, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_cos, i32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_cos, i64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_cos, u32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_cos, u64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_cos, f16, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_cos, f32, arg0, out, count);
         default: rc = false; break;
         }
         return rc;
@@ -85,6 +78,7 @@ namespace cosop
 
 bool op::Cos::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::Cos::evaluate");
-    return cosop::evaluate_cos(inputs[0], outputs[0], shape_size(get_output_shape(0)));
+    NGRAPH_OP_SCOPE(Cos_evaluate return cosop::evaluate_cos(
+        inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    return false;
 }

--- a/ngraph/core/src/op/cos.cpp
+++ b/ngraph/core/src/op/cos.cpp
@@ -78,7 +78,8 @@ namespace cosop
 
 bool op::Cos::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(Cos_evaluate return cosop::evaluate_cos(
-        inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    NGRAPH_OP_SCOPE(
+        Cos_evaluate,
+        return cosop::evaluate_cos(inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return false;
 }

--- a/ngraph/core/src/op/cosh.cpp
+++ b/ngraph/core/src/op/cosh.cpp
@@ -77,7 +77,8 @@ namespace coshop
 
 bool op::Cosh::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(Cosh_evaluate return coshop::evaluate_cosh(
-        inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    NGRAPH_OP_SCOPE(
+        Cosh_evaluate,
+        return coshop::evaluate_cosh(inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return false;
 }

--- a/ngraph/core/src/op/cosh.cpp
+++ b/ngraph/core/src/op/cosh.cpp
@@ -62,20 +62,13 @@ namespace coshop
 
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(boolean)(arg0, out, count);
-            break;
-            TYPE_CASE(i32)(arg0, out, count);
-            break;
-            TYPE_CASE(i64)(arg0, out, count);
-            break;
-            TYPE_CASE(u32)(arg0, out, count);
-            break;
-            TYPE_CASE(u64)(arg0, out, count);
-            break;
-            TYPE_CASE(f16)(arg0, out, count);
-            break;
-            TYPE_CASE(f32)(arg0, out, count);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_cosh, boolean, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_cosh, i32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_cosh, i64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_cosh, u32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_cosh, u64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_cosh, f16, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_cosh, f32, arg0, out, count);
         default: rc = false; break;
         }
         return rc;
@@ -84,6 +77,7 @@ namespace coshop
 
 bool op::Cosh::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::Cosh::evaluate");
-    return coshop::evaluate_cosh(inputs[0], outputs[0], shape_size(get_output_shape(0)));
+    NGRAPH_OP_SCOPE(Cosh_evaluate return coshop::evaluate_cosh(
+        inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    return false;
 }

--- a/ngraph/core/src/op/cosh.cpp
+++ b/ngraph/core/src/op/cosh.cpp
@@ -78,7 +78,7 @@ namespace coshop
 bool op::Cosh::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
     NGRAPH_OP_SCOPE(
-        Cosh_evaluate,
+        v0_Cosh_evaluate,
         return coshop::evaluate_cosh(inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return false;
 }

--- a/ngraph/core/src/op/depth_to_space.cpp
+++ b/ngraph/core/src/op/depth_to_space.cpp
@@ -113,115 +113,137 @@ void op::DepthToSpace::validate_and_infer_types()
     }
 }
 
+bool op::DepthToSpace::evaluate_depth_to_space(const HostTensorVector& outputs,
+                                               const HostTensorVector& inputs) const
+{
+    const auto& data = inputs[0];
+    const auto& out = outputs[0];
+    const auto& out_shape = out->get_shape();
+    size_t elem_size = data->get_element_type().size();
+
+    if (data->get_partial_shape().is_dynamic())
+    {
+        return false;
+    }
+    auto data_shape = data->get_shape();
+    const size_t n_dim = data_shape.at(0);
+    const size_t c_dim = data_shape.at(1);
+    const size_t spatial_dim_index = 2;
+    const size_t spatial_dims = data_shape.size() - spatial_dim_index;
+    const auto c_dim_divider = static_cast<int>(std::pow(m_blocksize, spatial_dims));
+
+    NODE_VALIDATION_CHECK(this,
+                          m_blocksize > 0 && c_dim % c_dim_divider == 0,
+                          "DepthToSpace: The input data's 'channels' axis size: ",
+                          c_dim,
+                          " must be a equivalent to ",
+                          "'block_size'^'spatial_dims': ",
+                          c_dim_divider);
+
+    auto bs = static_cast<size_t>(m_blocksize);
+    size_t c_flat = c_dim / c_dim_divider;
+
+    // First we have to disperse the data from depth channel, then rearrange them
+    // so as appropriate chunks of data where close to their destination place.
+    // Finally squeeze data from respective dimensions.
+    shared_ptr<Node> flat_node;
+    Shape dispersed_shape{n_dim};
+    for (int i = 0; i < spatial_dims; ++i)
+    {
+        dispersed_shape.push_back(bs);
+    }
+    for (int i = 0; i < spatial_dims; ++i)
+    {
+        dispersed_shape.push_back(data_shape.at(spatial_dim_index + i));
+    }
+    vector<size_t> axes_order{0};
+    switch (m_mode)
+    {
+    // x' = reshape(data, [N, C / (block_size ^ K), block_size, block_size, ..., block_size,
+    // D1, D2,
+    // ..., DK])
+    // x'' = transpose(x', [0,  1,  K + 2, 2, K + 3, 3, K + 4, 4, ..., K + (K + 1), K + 1])
+    // y = reshape(x'', [N, C / (block_size ^ K), D1 * block_size, D2 * block_size, D3 *
+    // block_size,
+    // ..., DK * block_size])
+    case DepthToSpaceMode::DEPTH_FIRST:
+    {
+        dispersed_shape.insert(dispersed_shape.begin() + 1, c_flat);
+        axes_order.push_back(1);
+        for (int i = spatial_dim_index; i < data_shape.size(); ++i)
+        {
+            axes_order.push_back(spatial_dims + i);
+            axes_order.push_back(i);
+        }
+
+        break;
+    }
+    // x' = reshape(data, [N, block_size, block_size, ..., block_size, C / (block_size ^ K),
+    // D1, D2,
+    // ..., DK])
+    // x'' = transpose(x', [0,  K + 1,  K + 2, 1, K + 3, 2, K + 4, 3, ..., K + (K + 1), K])
+    // y = reshape(x'', [N, C / (block_size ^ K), D1 * block_size, D2 * block_size, D3 *
+    // block_size,
+    // ..., DK * block_size])
+    case DepthToSpaceMode::BLOCKS_FIRST:
+    default:
+    {
+        dispersed_shape.insert(dispersed_shape.begin() + spatial_dims + 1, c_flat);
+        axes_order.push_back(spatial_dims + 1);
+        for (int i = 2; i < data_shape.size(); ++i)
+        {
+            axes_order.push_back(spatial_dims + i);
+            axes_order.push_back(i - 1);
+        }
+        break;
+    }
+    }
+    std::vector<size_t> plain_axes_order(data_shape.size());
+    std::iota(plain_axes_order.begin(), plain_axes_order.end(), 0);
+    std::vector<char> dispersed_data(shape_size(data_shape) * elem_size);
+    std::vector<char> transposed_data(shape_size(data_shape) * elem_size);
+
+    runtime::opt_kernel::reshape(data->get_data_ptr<char>(),
+                                 dispersed_data.data(),
+                                 data_shape,
+                                 plain_axes_order,
+                                 dispersed_shape,
+                                 elem_size);
+
+    Shape post_transpose_shape(axes_order.size());
+    for (size_t axis_idx = 0; axis_idx < axes_order.size(); ++axis_idx)
+    {
+        post_transpose_shape[axis_idx] = dispersed_shape[axes_order[axis_idx]];
+    }
+    runtime::opt_kernel::reshape(dispersed_data.data(),
+                                 transposed_data.data(),
+                                 dispersed_shape,
+                                 axes_order,
+                                 post_transpose_shape,
+                                 elem_size);
+
+    Shape squeezed_shape{n_dim, c_flat};
+    for (int i = spatial_dim_index; i < data_shape.size(); ++i)
+    {
+        squeezed_shape.push_back(data_shape.at(i) * bs);
+    }
+    for (size_t i = plain_axes_order.size() - 1; i < post_transpose_shape.size() - 1; ++i)
+    {
+        plain_axes_order.push_back(plain_axes_order[i] + 1);
+    }
+    runtime::opt_kernel::reshape(transposed_data.data(),
+                                 out->get_data_ptr<char>(),
+                                 post_transpose_shape,
+                                 plain_axes_order,
+                                 squeezed_shape,
+                                 elem_size);
+    return true;
+}
+
 bool op::DepthToSpace::evaluate(const HostTensorVector& outputs,
                                 const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(
-        DepthToSpace_evaluate, const auto& data = inputs[0]; const auto& out = outputs[0];
-        const auto& out_shape = out->get_shape();
-        size_t elem_size = data->get_element_type().size();
-
-        if (data->get_partial_shape().is_dynamic()) { return false; } auto data_shape =
-            data->get_shape();
-        const size_t n_dim = data_shape.at(0);
-        const size_t c_dim = data_shape.at(1);
-        const size_t spatial_dim_index = 2;
-        const size_t spatial_dims = data_shape.size() - spatial_dim_index;
-        const auto c_dim_divider = static_cast<int>(std::pow(m_blocksize, spatial_dims));
-
-        NODE_VALIDATION_CHECK(this,
-                              m_blocksize > 0 && c_dim % c_dim_divider == 0,
-                              "DepthToSpace: The input data's 'channels' axis size: ",
-                              c_dim,
-                              " must be a equivalent to ",
-                              "'block_size'^'spatial_dims': ",
-                              c_dim_divider);
-
-        auto bs = static_cast<size_t>(m_blocksize);
-        size_t c_flat = c_dim / c_dim_divider;
-
-        // First we have to disperse the data from depth channel, then rearrange them
-        // so as appropriate chunks of data where close to their destination place.
-        // Finally squeeze data from respective dimensions.
-        shared_ptr<Node> flat_node;
-        Shape dispersed_shape{n_dim};
-        for (int i = 0; i < spatial_dims;
-             ++i) { dispersed_shape.push_back(bs); } for (int i = 0; i < spatial_dims; ++i) {
-            dispersed_shape.push_back(data_shape.at(spatial_dim_index + i));
-        } vector<size_t> axes_order{0};
-        switch (m_mode) {
-            // x' = reshape(data, [N, C / (block_size ^ K), block_size, block_size, ..., block_size,
-            // D1, D2,
-            // ..., DK])
-            // x'' = transpose(x', [0,  1,  K + 2, 2, K + 3, 3, K + 4, 4, ..., K + (K + 1), K + 1])
-            // y = reshape(x'', [N, C / (block_size ^ K), D1 * block_size, D2 * block_size, D3 *
-            // block_size,
-            // ..., DK * block_size])
-            case DepthToSpaceMode::DEPTH_FIRST:
-            {
-                dispersed_shape.insert(dispersed_shape.begin() + 1, c_flat);
-                axes_order.push_back(1);
-                for (int i = spatial_dim_index; i < data_shape.size(); ++i)
-                {
-                    axes_order.push_back(spatial_dims + i);
-                    axes_order.push_back(i);
-                }
-
-                break;
-            }
-            // x' = reshape(data, [N, block_size, block_size, ..., block_size, C / (block_size ^ K),
-            // D1, D2,
-            // ..., DK])
-            // x'' = transpose(x', [0,  K + 1,  K + 2, 1, K + 3, 2, K + 4, 3, ..., K + (K + 1), K])
-            // y = reshape(x'', [N, C / (block_size ^ K), D1 * block_size, D2 * block_size, D3 *
-            // block_size,
-            // ..., DK * block_size])
-            case DepthToSpaceMode::BLOCKS_FIRST:
-            default:
-            {
-                dispersed_shape.insert(dispersed_shape.begin() + spatial_dims + 1, c_flat);
-                axes_order.push_back(spatial_dims + 1);
-                for (int i = 2; i < data_shape.size(); ++i)
-                {
-                    axes_order.push_back(spatial_dims + i);
-                    axes_order.push_back(i - 1);
-                }
-                break;
-            }
-        } std::vector<size_t> plain_axes_order(data_shape.size());
-        std::iota(plain_axes_order.begin(), plain_axes_order.end(), 0);
-        std::vector<char> dispersed_data(shape_size(data_shape) * elem_size);
-        std::vector<char> transposed_data(shape_size(data_shape) * elem_size);
-
-        runtime::opt_kernel::reshape(data->get_data_ptr<char>(),
-                                     dispersed_data.data(),
-                                     data_shape,
-                                     plain_axes_order,
-                                     dispersed_shape,
-                                     elem_size);
-
-        Shape post_transpose_shape(axes_order.size());
-        for (size_t axis_idx = 0; axis_idx < axes_order.size(); ++axis_idx) {
-            post_transpose_shape[axis_idx] = dispersed_shape[axes_order[axis_idx]];
-        } runtime::opt_kernel::reshape(dispersed_data.data(),
-                                       transposed_data.data(),
-                                       dispersed_shape,
-                                       axes_order,
-                                       post_transpose_shape,
-                                       elem_size);
-
-        Shape squeezed_shape{n_dim, c_flat};
-        for (int i = spatial_dim_index; i < data_shape.size(); ++i) {
-            squeezed_shape.push_back(data_shape.at(i) * bs);
-        } for (size_t i = plain_axes_order.size() - 1; i < post_transpose_shape.size() - 1; ++i) {
-            plain_axes_order.push_back(plain_axes_order[i] + 1);
-        } runtime::opt_kernel::reshape(transposed_data.data(),
-                                       out->get_data_ptr<char>(),
-                                       post_transpose_shape,
-                                       plain_axes_order,
-                                       squeezed_shape,
-                                       elem_size);
-        return true);
+    NGRAPH_OP_SCOPE(v0_DepthToSpace_evaluate, return evaluate_depth_to_space(outputs, inputs));
     return false;
 }
 namespace ngraph

--- a/ngraph/core/src/op/depth_to_space.cpp
+++ b/ngraph/core/src/op/depth_to_space.cpp
@@ -19,6 +19,7 @@
 #include <ngraph/op/constant.hpp>
 #include <ngraph/ops.hpp>
 #include <numeric>
+#include "itt.hpp"
 
 #include "depth_to_space.hpp"
 #include "ngraph/builder/reshape.hpp"
@@ -115,124 +116,113 @@ void op::DepthToSpace::validate_and_infer_types()
 bool op::DepthToSpace::evaluate(const HostTensorVector& outputs,
                                 const HostTensorVector& inputs) const
 {
-    const auto& data = inputs[0];
-    const auto& out = outputs[0];
-    const auto& out_shape = out->get_shape();
-    size_t elem_size = data->get_element_type().size();
+    NGRAPH_OP_SCOPE(
+        DepthToSpace_evaluate, const auto& data = inputs[0]; const auto& out = outputs[0];
+        const auto& out_shape = out->get_shape();
+        size_t elem_size = data->get_element_type().size();
 
-    if (data->get_partial_shape().is_dynamic())
-    {
-        return false;
-    }
-    auto data_shape = data->get_shape();
-    const size_t n_dim = data_shape.at(0);
-    const size_t c_dim = data_shape.at(1);
-    const size_t spatial_dim_index = 2;
-    const size_t spatial_dims = data_shape.size() - spatial_dim_index;
-    const auto c_dim_divider = static_cast<int>(std::pow(m_blocksize, spatial_dims));
+        if (data->get_partial_shape().is_dynamic()) { return false; } auto data_shape =
+            data->get_shape();
+        const size_t n_dim = data_shape.at(0);
+        const size_t c_dim = data_shape.at(1);
+        const size_t spatial_dim_index = 2;
+        const size_t spatial_dims = data_shape.size() - spatial_dim_index;
+        const auto c_dim_divider = static_cast<int>(std::pow(m_blocksize, spatial_dims));
 
-    NODE_VALIDATION_CHECK(this,
-                          m_blocksize > 0 && c_dim % c_dim_divider == 0,
-                          "DepthToSpace: The input data's 'channels' axis size: ",
-                          c_dim,
-                          " must be a equivalent to ",
-                          "'block_size'^'spatial_dims': ",
-                          c_dim_divider);
+        NODE_VALIDATION_CHECK(this,
+                              m_blocksize > 0 && c_dim % c_dim_divider == 0,
+                              "DepthToSpace: The input data's 'channels' axis size: ",
+                              c_dim,
+                              " must be a equivalent to ",
+                              "'block_size'^'spatial_dims': ",
+                              c_dim_divider);
 
-    auto bs = static_cast<size_t>(m_blocksize);
-    size_t c_flat = c_dim / c_dim_divider;
+        auto bs = static_cast<size_t>(m_blocksize);
+        size_t c_flat = c_dim / c_dim_divider;
 
-    // First we have to disperse the data from depth channel, then rearrange them
-    // so as appropriate chunks of data where close to their destination place.
-    // Finally squeeze data from respective dimensions.
-    shared_ptr<Node> flat_node;
-    Shape dispersed_shape{n_dim};
-    for (int i = 0; i < spatial_dims; ++i)
-    {
-        dispersed_shape.push_back(bs);
-    }
-    for (int i = 0; i < spatial_dims; ++i)
-    {
-        dispersed_shape.push_back(data_shape.at(spatial_dim_index + i));
-    }
-    vector<size_t> axes_order{0};
-    switch (m_mode)
-    {
-    // x' = reshape(data, [N, C / (block_size ^ K), block_size, block_size, ..., block_size, D1, D2,
-    // ..., DK])
-    // x'' = transpose(x', [0,  1,  K + 2, 2, K + 3, 3, K + 4, 4, ..., K + (K + 1), K + 1])
-    // y = reshape(x'', [N, C / (block_size ^ K), D1 * block_size, D2 * block_size, D3 * block_size,
-    // ..., DK * block_size])
-    case DepthToSpaceMode::DEPTH_FIRST:
-    {
-        dispersed_shape.insert(dispersed_shape.begin() + 1, c_flat);
-        axes_order.push_back(1);
-        for (int i = spatial_dim_index; i < data_shape.size(); ++i)
-        {
-            axes_order.push_back(spatial_dims + i);
-            axes_order.push_back(i);
-        }
+        // First we have to disperse the data from depth channel, then rearrange them
+        // so as appropriate chunks of data where close to their destination place.
+        // Finally squeeze data from respective dimensions.
+        shared_ptr<Node> flat_node;
+        Shape dispersed_shape{n_dim};
+        for (int i = 0; i < spatial_dims;
+             ++i) { dispersed_shape.push_back(bs); } for (int i = 0; i < spatial_dims; ++i) {
+            dispersed_shape.push_back(data_shape.at(spatial_dim_index + i));
+        } vector<size_t> axes_order{0};
+        switch (m_mode) {
+            // x' = reshape(data, [N, C / (block_size ^ K), block_size, block_size, ..., block_size,
+            // D1, D2,
+            // ..., DK])
+            // x'' = transpose(x', [0,  1,  K + 2, 2, K + 3, 3, K + 4, 4, ..., K + (K + 1), K + 1])
+            // y = reshape(x'', [N, C / (block_size ^ K), D1 * block_size, D2 * block_size, D3 *
+            // block_size,
+            // ..., DK * block_size])
+            case DepthToSpaceMode::DEPTH_FIRST:
+            {
+                dispersed_shape.insert(dispersed_shape.begin() + 1, c_flat);
+                axes_order.push_back(1);
+                for (int i = spatial_dim_index; i < data_shape.size(); ++i)
+                {
+                    axes_order.push_back(spatial_dims + i);
+                    axes_order.push_back(i);
+                }
 
-        break;
-    }
-    // x' = reshape(data, [N, block_size, block_size, ..., block_size, C / (block_size ^ K), D1, D2,
-    // ..., DK])
-    // x'' = transpose(x', [0,  K + 1,  K + 2, 1, K + 3, 2, K + 4, 3, ..., K + (K + 1), K])
-    // y = reshape(x'', [N, C / (block_size ^ K), D1 * block_size, D2 * block_size, D3 * block_size,
-    // ..., DK * block_size])
-    case DepthToSpaceMode::BLOCKS_FIRST:
-    default:
-    {
-        dispersed_shape.insert(dispersed_shape.begin() + spatial_dims + 1, c_flat);
-        axes_order.push_back(spatial_dims + 1);
-        for (int i = 2; i < data_shape.size(); ++i)
-        {
-            axes_order.push_back(spatial_dims + i);
-            axes_order.push_back(i - 1);
-        }
-        break;
-    }
-    }
-    std::vector<size_t> plain_axes_order(data_shape.size());
-    std::iota(plain_axes_order.begin(), plain_axes_order.end(), 0);
-    std::vector<char> dispersed_data(shape_size(data_shape) * elem_size);
-    std::vector<char> transposed_data(shape_size(data_shape) * elem_size);
+                break;
+            }
+            // x' = reshape(data, [N, block_size, block_size, ..., block_size, C / (block_size ^ K),
+            // D1, D2,
+            // ..., DK])
+            // x'' = transpose(x', [0,  K + 1,  K + 2, 1, K + 3, 2, K + 4, 3, ..., K + (K + 1), K])
+            // y = reshape(x'', [N, C / (block_size ^ K), D1 * block_size, D2 * block_size, D3 *
+            // block_size,
+            // ..., DK * block_size])
+            case DepthToSpaceMode::BLOCKS_FIRST:
+            default:
+            {
+                dispersed_shape.insert(dispersed_shape.begin() + spatial_dims + 1, c_flat);
+                axes_order.push_back(spatial_dims + 1);
+                for (int i = 2; i < data_shape.size(); ++i)
+                {
+                    axes_order.push_back(spatial_dims + i);
+                    axes_order.push_back(i - 1);
+                }
+                break;
+            }
+        } std::vector<size_t> plain_axes_order(data_shape.size());
+        std::iota(plain_axes_order.begin(), plain_axes_order.end(), 0);
+        std::vector<char> dispersed_data(shape_size(data_shape) * elem_size);
+        std::vector<char> transposed_data(shape_size(data_shape) * elem_size);
 
-    runtime::opt_kernel::reshape(data->get_data_ptr<char>(),
-                                 dispersed_data.data(),
-                                 data_shape,
-                                 plain_axes_order,
-                                 dispersed_shape,
-                                 elem_size);
+        runtime::opt_kernel::reshape(data->get_data_ptr<char>(),
+                                     dispersed_data.data(),
+                                     data_shape,
+                                     plain_axes_order,
+                                     dispersed_shape,
+                                     elem_size);
 
-    Shape post_transpose_shape(axes_order.size());
-    for (size_t axis_idx = 0; axis_idx < axes_order.size(); ++axis_idx)
-    {
-        post_transpose_shape[axis_idx] = dispersed_shape[axes_order[axis_idx]];
-    }
-    runtime::opt_kernel::reshape(dispersed_data.data(),
-                                 transposed_data.data(),
-                                 dispersed_shape,
-                                 axes_order,
-                                 post_transpose_shape,
-                                 elem_size);
+        Shape post_transpose_shape(axes_order.size());
+        for (size_t axis_idx = 0; axis_idx < axes_order.size(); ++axis_idx) {
+            post_transpose_shape[axis_idx] = dispersed_shape[axes_order[axis_idx]];
+        } runtime::opt_kernel::reshape(dispersed_data.data(),
+                                       transposed_data.data(),
+                                       dispersed_shape,
+                                       axes_order,
+                                       post_transpose_shape,
+                                       elem_size);
 
-    Shape squeezed_shape{n_dim, c_flat};
-    for (int i = spatial_dim_index; i < data_shape.size(); ++i)
-    {
-        squeezed_shape.push_back(data_shape.at(i) * bs);
-    }
-    for (size_t i = plain_axes_order.size() - 1; i < post_transpose_shape.size() - 1; ++i)
-    {
-        plain_axes_order.push_back(plain_axes_order[i] + 1);
-    }
-    runtime::opt_kernel::reshape(transposed_data.data(),
-                                 out->get_data_ptr<char>(),
-                                 post_transpose_shape,
-                                 plain_axes_order,
-                                 squeezed_shape,
-                                 elem_size);
-    return true;
+        Shape squeezed_shape{n_dim, c_flat};
+        for (int i = spatial_dim_index; i < data_shape.size(); ++i) {
+            squeezed_shape.push_back(data_shape.at(i) * bs);
+        } for (size_t i = plain_axes_order.size() - 1; i < post_transpose_shape.size() - 1; ++i) {
+            plain_axes_order.push_back(plain_axes_order[i] + 1);
+        } runtime::opt_kernel::reshape(transposed_data.data(),
+                                       out->get_data_ptr<char>(),
+                                       post_transpose_shape,
+                                       plain_axes_order,
+                                       squeezed_shape,
+                                       elem_size);
+        return true);
+    return false;
 }
 namespace ngraph
 {

--- a/ngraph/core/src/op/divide.cpp
+++ b/ngraph/core/src/op/divide.cpp
@@ -55,20 +55,13 @@ namespace divide
         out->set_broadcast(broadcast_spec, arg0, arg1);
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(i32)(arg0, arg1, out, broadcast_spec, pythondiv);
-            break;
-            TYPE_CASE(i64)(arg0, arg1, out, broadcast_spec, pythondiv);
-            break;
-            TYPE_CASE(u32)(arg0, arg1, out, broadcast_spec, pythondiv);
-            break;
-            TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec, pythondiv);
-            break;
-            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec, pythondiv);
-            break;
-            TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec, pythondiv);
-            break;
-            TYPE_CASE(bf16)(arg0, arg1, out, broadcast_spec, pythondiv);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_divide, i32, arg0, arg1, out, broadcast_spec, pythondiv);
+            NGRAPH_TYPE_CASE(evaluate_divide, i64, arg0, arg1, out, broadcast_spec, pythondiv);
+            NGRAPH_TYPE_CASE(evaluate_divide, u32, arg0, arg1, out, broadcast_spec, pythondiv);
+            NGRAPH_TYPE_CASE(evaluate_divide, u64, arg0, arg1, out, broadcast_spec, pythondiv);
+            NGRAPH_TYPE_CASE(evaluate_divide, f16, arg0, arg1, out, broadcast_spec, pythondiv);
+            NGRAPH_TYPE_CASE(evaluate_divide, f32, arg0, arg1, out, broadcast_spec, pythondiv);
+            NGRAPH_TYPE_CASE(evaluate_divide, bf16, arg0, arg1, out, broadcast_spec, pythondiv);
         default: rc = false; break;
         }
         return rc;
@@ -113,6 +106,7 @@ shared_ptr<Node> op::v1::Divide::clone_with_new_inputs(const OutputVector& new_a
 
 bool op::v1::Divide::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::Divide::evaluate");
-    return divide::evaluate_divide(inputs[0], inputs[1], outputs[0], get_autob(), is_pythondiv());
+    NGRAPH_OP_SCOPE(v1_Divide_evaluate return divide::evaluate_divide(
+        inputs[0], inputs[1], outputs[0], get_autob(), is_pythondiv()));
+    return false;
 }

--- a/ngraph/core/src/op/divide.cpp
+++ b/ngraph/core/src/op/divide.cpp
@@ -106,7 +106,8 @@ shared_ptr<Node> op::v1::Divide::clone_with_new_inputs(const OutputVector& new_a
 
 bool op::v1::Divide::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(v1_Divide_evaluate return divide::evaluate_divide(
-        inputs[0], inputs[1], outputs[0], get_autob(), is_pythondiv()));
+    NGRAPH_OP_SCOPE(v1_Divide_evaluate,
+                    return divide::evaluate_divide(
+                        inputs[0], inputs[1], outputs[0], get_autob(), is_pythondiv()));
     return false;
 }

--- a/ngraph/core/src/op/equal.cpp
+++ b/ngraph/core/src/op/equal.cpp
@@ -50,20 +50,13 @@ namespace equal
         out->set_broadcast(broadcast_spec, arg0, arg1, element::boolean);
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(boolean)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(i32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(i64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_equal, boolean, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_equal, i32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_equal, i64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_equal, u32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_equal, u64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_equal, f16, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_equal, f32, arg0, arg1, out, broadcast_spec);
         default: rc = false; break;
         }
         return rc;
@@ -90,6 +83,7 @@ shared_ptr<Node> op::v1::Equal::clone_with_new_inputs(const OutputVector& new_ar
 
 bool op::v1::Equal::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::Equal::evaluate");
-    return equal::evaluate_equal(inputs[0], inputs[1], outputs[0], get_autob());
+    NGRAPH_OP_SCOPE(v1_Equal_evaluate return equal::evaluate_equal(
+        inputs[0], inputs[1], outputs[0], get_autob()));
+    return false;
 }

--- a/ngraph/core/src/op/equal.cpp
+++ b/ngraph/core/src/op/equal.cpp
@@ -83,7 +83,7 @@ shared_ptr<Node> op::v1::Equal::clone_with_new_inputs(const OutputVector& new_ar
 
 bool op::v1::Equal::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(v1_Equal_evaluate return equal::evaluate_equal(
-        inputs[0], inputs[1], outputs[0], get_autob()));
+    NGRAPH_OP_SCOPE(v1_Equal_evaluate,
+                    return equal::evaluate_equal(inputs[0], inputs[1], outputs[0], get_autob()));
     return false;
 }

--- a/ngraph/core/src/op/erf.cpp
+++ b/ngraph/core/src/op/erf.cpp
@@ -61,20 +61,13 @@ namespace erfop
 
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(boolean)(arg0, out, count);
-            break;
-            TYPE_CASE(i32)(arg0, out, count);
-            break;
-            TYPE_CASE(i64)(arg0, out, count);
-            break;
-            TYPE_CASE(u32)(arg0, out, count);
-            break;
-            TYPE_CASE(u64)(arg0, out, count);
-            break;
-            TYPE_CASE(f16)(arg0, out, count);
-            break;
-            TYPE_CASE(f32)(arg0, out, count);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_erf, boolean, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_erf, i32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_erf, i64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_erf, u32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_erf, u64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_erf, f16, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_erf, f32, arg0, out, count);
         default: rc = false; break;
         }
         return rc;
@@ -83,6 +76,7 @@ namespace erfop
 
 bool op::Erf::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::Erf::evaluate");
-    return erfop::evaluate_erf(inputs[0], outputs[0], shape_size(get_output_shape(0)));
+    NGRAPH_OP_SCOPE(Erf_evaluate return erfop::evaluate_erf(
+        inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    return false;
 }

--- a/ngraph/core/src/op/erf.cpp
+++ b/ngraph/core/src/op/erf.cpp
@@ -76,7 +76,8 @@ namespace erfop
 
 bool op::Erf::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(Erf_evaluate return erfop::evaluate_erf(
-        inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    NGRAPH_OP_SCOPE(
+        Erf_evaluate,
+        return erfop::evaluate_erf(inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return false;
 }

--- a/ngraph/core/src/op/erf.cpp
+++ b/ngraph/core/src/op/erf.cpp
@@ -77,7 +77,7 @@ namespace erfop
 bool op::Erf::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
     NGRAPH_OP_SCOPE(
-        Erf_evaluate,
+        v0_Erf_evaluate,
         return erfop::evaluate_erf(inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return false;
 }

--- a/ngraph/core/src/op/exp.cpp
+++ b/ngraph/core/src/op/exp.cpp
@@ -76,7 +76,8 @@ namespace expop
 
 bool op::Exp::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(Exp_evaluate return expop::evaluate_exp(
-        inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    NGRAPH_OP_SCOPE(
+        Exp_evaluate,
+        return expop::evaluate_exp(inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return false;
 }

--- a/ngraph/core/src/op/exp.cpp
+++ b/ngraph/core/src/op/exp.cpp
@@ -61,20 +61,13 @@ namespace expop
 
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(boolean)(arg0, out, count);
-            break;
-            TYPE_CASE(i32)(arg0, out, count);
-            break;
-            TYPE_CASE(i64)(arg0, out, count);
-            break;
-            TYPE_CASE(u32)(arg0, out, count);
-            break;
-            TYPE_CASE(u64)(arg0, out, count);
-            break;
-            TYPE_CASE(f16)(arg0, out, count);
-            break;
-            TYPE_CASE(f32)(arg0, out, count);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_exp, boolean, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_exp, i32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_exp, i64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_exp, u32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_exp, u64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_exp, f16, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_exp, f32, arg0, out, count);
         default: rc = false; break;
         }
         return rc;
@@ -83,6 +76,7 @@ namespace expop
 
 bool op::Exp::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::Exp::evaluate");
-    return expop::evaluate_exp(inputs[0], outputs[0], shape_size(get_output_shape(0)));
+    NGRAPH_OP_SCOPE(Exp_evaluate return expop::evaluate_exp(
+        inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    return false;
 }

--- a/ngraph/core/src/op/exp.cpp
+++ b/ngraph/core/src/op/exp.cpp
@@ -77,7 +77,7 @@ namespace expop
 bool op::Exp::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
     NGRAPH_OP_SCOPE(
-        Exp_evaluate,
+        v0_Exp_evaluate,
         return expop::evaluate_exp(inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return false;
 }

--- a/ngraph/core/src/op/floor.cpp
+++ b/ngraph/core/src/op/floor.cpp
@@ -89,7 +89,7 @@ namespace floorop
 bool op::Floor::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
     NGRAPH_OP_SCOPE(
-        Floor_evaluate,
+        v0_Floor_evaluate,
         return floorop::evaluate_floor(inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return false;
 }

--- a/ngraph/core/src/op/floor.cpp
+++ b/ngraph/core/src/op/floor.cpp
@@ -69,28 +69,17 @@ namespace floorop
 
         switch (arg0->get_element_type())
         {
-            COPY_TENSOR(boolean)(arg0, out, count);
-            break;
-            COPY_TENSOR(i8)(arg0, out, count);
-            break;
-            COPY_TENSOR(i16)(arg0, out, count);
-            break;
-            COPY_TENSOR(i32)(arg0, out, count);
-            break;
-            COPY_TENSOR(i64)(arg0, out, count);
-            break;
-            COPY_TENSOR(u8)(arg0, out, count);
-            break;
-            COPY_TENSOR(u16)(arg0, out, count);
-            break;
-            COPY_TENSOR(u32)(arg0, out, count);
-            break;
-            COPY_TENSOR(u64)(arg0, out, count);
-            break;
-            TYPE_CASE(f16)(arg0, out, count);
-            break;
-            TYPE_CASE(f32)(arg0, out, count);
-            break;
+            NGRAPH_COPY_TENSOR(evaluate_floor, boolean, arg0, out, count);
+            NGRAPH_COPY_TENSOR(evaluate_floor, i8, arg0, out, count);
+            NGRAPH_COPY_TENSOR(evaluate_floor, i16, arg0, out, count);
+            NGRAPH_COPY_TENSOR(evaluate_floor, i32, arg0, out, count);
+            NGRAPH_COPY_TENSOR(evaluate_floor, i64, arg0, out, count);
+            NGRAPH_COPY_TENSOR(evaluate_floor, u8, arg0, out, count);
+            NGRAPH_COPY_TENSOR(evaluate_floor, u16, arg0, out, count);
+            NGRAPH_COPY_TENSOR(evaluate_floor, u32, arg0, out, count);
+            NGRAPH_COPY_TENSOR(evaluate_floor, u64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_floor, f16, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_floor, f32, arg0, out, count);
         default: rc = false; break;
         }
         return rc;
@@ -99,6 +88,7 @@ namespace floorop
 
 bool op::Floor::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::Floor::evaluate");
-    return floorop::evaluate_floor(inputs[0], outputs[0], shape_size(get_output_shape(0)));
+    NGRAPH_OP_SCOPE(Floor_evaluate return floorop::evaluate_floor(
+        inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    return false;
 }

--- a/ngraph/core/src/op/floor.cpp
+++ b/ngraph/core/src/op/floor.cpp
@@ -88,7 +88,8 @@ namespace floorop
 
 bool op::Floor::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(Floor_evaluate return floorop::evaluate_floor(
-        inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    NGRAPH_OP_SCOPE(
+        Floor_evaluate,
+        return floorop::evaluate_floor(inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return false;
 }

--- a/ngraph/core/src/op/floor_mod.cpp
+++ b/ngraph/core/src/op/floor_mod.cpp
@@ -82,8 +82,9 @@ namespace floor_mod
 bool op::v1::FloorMod::evaluate(const HostTensorVector& outputs,
                                 const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(v1_FloorMod_evaluate return floor_mod::evaluate_floor_mod(
-        inputs[0], inputs[1], outputs[0], get_autob()));
+    NGRAPH_OP_SCOPE(
+        v1_FloorMod_evaluate,
+        return floor_mod::evaluate_floor_mod(inputs[0], inputs[1], outputs[0], get_autob()));
     return false;
 }
 

--- a/ngraph/core/src/op/floor_mod.cpp
+++ b/ngraph/core/src/op/floor_mod.cpp
@@ -64,24 +64,15 @@ namespace floor_mod
         out->set_broadcast(broadcast_spec, arg0, arg1);
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(i8)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(i32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(i64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u8)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(bf16)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_floor_mod, i8, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_floor_mod, i32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_floor_mod, i64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_floor_mod, u8, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_floor_mod, u32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_floor_mod, u64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_floor_mod, bf16, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_floor_mod, f16, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_floor_mod, f32, arg0, arg1, out, broadcast_spec);
         default: rc = false; break;
         }
         return rc;
@@ -91,8 +82,9 @@ namespace floor_mod
 bool op::v1::FloorMod::evaluate(const HostTensorVector& outputs,
                                 const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::FloorMod::evaluate");
-    return floor_mod::evaluate_floor_mod(inputs[0], inputs[1], outputs[0], get_autob());
+    NGRAPH_OP_SCOPE(v1_FloorMod_evaluate return floor_mod::evaluate_floor_mod(
+        inputs[0], inputs[1], outputs[0], get_autob()));
+    return false;
 }
 
 bool op::v1::FloorMod::visit_attributes(AttributeVisitor& visitor)

--- a/ngraph/core/src/op/gather.cpp
+++ b/ngraph/core/src/op/gather.cpp
@@ -204,20 +204,13 @@ namespace gather
 
         switch (out->get_element_type())
         {
-            TYPE_CASE(i32)(arg0, arg1, out, axis);
-            break;
-            TYPE_CASE(i64)(arg0, arg1, out, axis);
-            break;
-            TYPE_CASE(u32)(arg0, arg1, out, axis);
-            break;
-            TYPE_CASE(u64)(arg0, arg1, out, axis);
-            break;
-            TYPE_CASE(f16)(arg0, arg1, out, axis);
-            break;
-            TYPE_CASE(f32)(arg0, arg1, out, axis);
-            break;
-            TYPE_CASE(boolean)(arg0, arg1, out, axis);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_gather, i32, arg0, arg1, out, axis);
+            NGRAPH_TYPE_CASE(evaluate_gather, i64, arg0, arg1, out, axis);
+            NGRAPH_TYPE_CASE(evaluate_gather, u32, arg0, arg1, out, axis);
+            NGRAPH_TYPE_CASE(evaluate_gather, u64, arg0, arg1, out, axis);
+            NGRAPH_TYPE_CASE(evaluate_gather, f16, arg0, arg1, out, axis);
+            NGRAPH_TYPE_CASE(evaluate_gather, f32, arg0, arg1, out, axis);
+            NGRAPH_TYPE_CASE(evaluate_gather, boolean, arg0, arg1, out, axis);
         default: rc = false; break;
         }
         return rc;
@@ -292,30 +285,26 @@ namespace gather
 
 bool op::v1::Gather::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::Gather::evaluate");
-    int64_t axis = 0;
-    switch (inputs[2]->get_element_type())
-    {
-    case element::Type_t::i8: axis = inputs[2]->get_data_ptr<element::Type_t::i8>()[0]; break;
-    case element::Type_t::i16: axis = inputs[2]->get_data_ptr<element::Type_t::i16>()[0]; break;
-    case element::Type_t::i32: axis = inputs[2]->get_data_ptr<element::Type_t::i32>()[0]; break;
-    case element::Type_t::i64: axis = inputs[2]->get_data_ptr<element::Type_t::i64>()[0]; break;
-    case element::Type_t::u8: axis = inputs[2]->get_data_ptr<element::Type_t::u8>()[0]; break;
-    case element::Type_t::u16: axis = inputs[2]->get_data_ptr<element::Type_t::u16>()[0]; break;
-    case element::Type_t::u32: axis = inputs[2]->get_data_ptr<element::Type_t::u32>()[0]; break;
-    case element::Type_t::u64: axis = inputs[2]->get_data_ptr<element::Type_t::u64>()[0]; break;
-    default: throw ngraph_error("axis element type is not integral data type");
+    NGRAPH_OP_SCOPE(v1_Gather_evaluate int64_t axis = 0; switch (inputs[2]->get_element_type()) {
+        case element::Type_t::i8: axis = inputs[2]->get_data_ptr<element::Type_t::i8>()[0]; break;
+        case element::Type_t::i16: axis = inputs[2]->get_data_ptr<element::Type_t::i16>()[0]; break;
+        case element::Type_t::i32: axis = inputs[2]->get_data_ptr<element::Type_t::i32>()[0]; break;
+        case element::Type_t::i64: axis = inputs[2]->get_data_ptr<element::Type_t::i64>()[0]; break;
+        case element::Type_t::u8: axis = inputs[2]->get_data_ptr<element::Type_t::u8>()[0]; break;
+        case element::Type_t::u16: axis = inputs[2]->get_data_ptr<element::Type_t::u16>()[0]; break;
+        case element::Type_t::u32: axis = inputs[2]->get_data_ptr<element::Type_t::u32>()[0]; break;
+        case element::Type_t::u64: axis = inputs[2]->get_data_ptr<element::Type_t::u64>()[0]; break;
+        default: throw ngraph_error("axis element type is not integral data type");
     }
 
-    if (axis < 0)
-    {
-        const auto& input_rank = get_input_partial_shape(PARAMS).rank();
-        if (input_rank.is_static())
-        {
-            axis += input_rank.get_length();
-        }
-    }
-    return gather::evaluate_gather(inputs[0], inputs[1], outputs[0], axis);
+                    if (axis < 0) {
+                        const auto& input_rank = get_input_partial_shape(PARAMS).rank();
+                        if (input_rank.is_static())
+                        {
+                            axis += input_rank.get_length();
+                        }
+                    } return gather::evaluate_gather(inputs[0], inputs[1], outputs[0], axis));
+    return false;
 }
 
 bool op::v1::Gather::constant_fold(OutputVector& output_values, const OutputVector& input_values)

--- a/ngraph/core/src/op/gather.cpp
+++ b/ngraph/core/src/op/gather.cpp
@@ -285,25 +285,42 @@ namespace gather
 
 bool op::v1::Gather::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(v1_Gather_evaluate int64_t axis = 0; switch (inputs[2]->get_element_type()) {
-        case element::Type_t::i8: axis = inputs[2]->get_data_ptr<element::Type_t::i8>()[0]; break;
-        case element::Type_t::i16: axis = inputs[2]->get_data_ptr<element::Type_t::i16>()[0]; break;
-        case element::Type_t::i32: axis = inputs[2]->get_data_ptr<element::Type_t::i32>()[0]; break;
-        case element::Type_t::i64: axis = inputs[2]->get_data_ptr<element::Type_t::i64>()[0]; break;
-        case element::Type_t::u8: axis = inputs[2]->get_data_ptr<element::Type_t::u8>()[0]; break;
-        case element::Type_t::u16: axis = inputs[2]->get_data_ptr<element::Type_t::u16>()[0]; break;
-        case element::Type_t::u32: axis = inputs[2]->get_data_ptr<element::Type_t::u32>()[0]; break;
-        case element::Type_t::u64: axis = inputs[2]->get_data_ptr<element::Type_t::u64>()[0]; break;
-        default: throw ngraph_error("axis element type is not integral data type");
-    }
+    NGRAPH_OP_SCOPE(
+        v1_Gather_evaluate, int64_t axis = 0; switch (inputs[2]->get_element_type()) {
+            case element::Type_t::i8:
+                axis = inputs[2]->get_data_ptr<element::Type_t::i8>()[0];
+                break;
+            case element::Type_t::i16:
+                axis = inputs[2]->get_data_ptr<element::Type_t::i16>()[0];
+                break;
+            case element::Type_t::i32:
+                axis = inputs[2]->get_data_ptr<element::Type_t::i32>()[0];
+                break;
+            case element::Type_t::i64:
+                axis = inputs[2]->get_data_ptr<element::Type_t::i64>()[0];
+                break;
+            case element::Type_t::u8:
+                axis = inputs[2]->get_data_ptr<element::Type_t::u8>()[0];
+                break;
+            case element::Type_t::u16:
+                axis = inputs[2]->get_data_ptr<element::Type_t::u16>()[0];
+                break;
+            case element::Type_t::u32:
+                axis = inputs[2]->get_data_ptr<element::Type_t::u32>()[0];
+                break;
+            case element::Type_t::u64:
+                axis = inputs[2]->get_data_ptr<element::Type_t::u64>()[0];
+                break;
+            default: throw ngraph_error("axis element type is not integral data type");
+        }
 
-                    if (axis < 0) {
-                        const auto& input_rank = get_input_partial_shape(PARAMS).rank();
-                        if (input_rank.is_static())
-                        {
-                            axis += input_rank.get_length();
-                        }
-                    } return gather::evaluate_gather(inputs[0], inputs[1], outputs[0], axis));
+        if (axis < 0) {
+            const auto& input_rank = get_input_partial_shape(PARAMS).rank();
+            if (input_rank.is_static())
+            {
+                axis += input_rank.get_length();
+            }
+        } return gather::evaluate_gather(inputs[0], inputs[1], outputs[0], axis));
     return false;
 }
 

--- a/ngraph/core/src/op/gather.cpp
+++ b/ngraph/core/src/op/gather.cpp
@@ -283,44 +283,37 @@ namespace gather
     }
 } // namespace gather
 
+bool op::v1::Gather::evaluate_gather(const HostTensorVector& outputs,
+                                     const HostTensorVector& inputs) const
+{
+    int64_t axis = 0;
+    switch (inputs[2]->get_element_type())
+    {
+    case element::Type_t::i8: axis = inputs[2]->get_data_ptr<element::Type_t::i8>()[0]; break;
+    case element::Type_t::i16: axis = inputs[2]->get_data_ptr<element::Type_t::i16>()[0]; break;
+    case element::Type_t::i32: axis = inputs[2]->get_data_ptr<element::Type_t::i32>()[0]; break;
+    case element::Type_t::i64: axis = inputs[2]->get_data_ptr<element::Type_t::i64>()[0]; break;
+    case element::Type_t::u8: axis = inputs[2]->get_data_ptr<element::Type_t::u8>()[0]; break;
+    case element::Type_t::u16: axis = inputs[2]->get_data_ptr<element::Type_t::u16>()[0]; break;
+    case element::Type_t::u32: axis = inputs[2]->get_data_ptr<element::Type_t::u32>()[0]; break;
+    case element::Type_t::u64: axis = inputs[2]->get_data_ptr<element::Type_t::u64>()[0]; break;
+    default: throw ngraph_error("axis element type is not integral data type");
+    }
+
+    if (axis < 0)
+    {
+        const auto& input_rank = get_input_partial_shape(PARAMS).rank();
+        if (input_rank.is_static())
+        {
+            axis += input_rank.get_length();
+        }
+    }
+    return gather::evaluate_gather(inputs[0], inputs[1], outputs[0], axis);
+}
+
 bool op::v1::Gather::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(
-        v1_Gather_evaluate, int64_t axis = 0; switch (inputs[2]->get_element_type()) {
-            case element::Type_t::i8:
-                axis = inputs[2]->get_data_ptr<element::Type_t::i8>()[0];
-                break;
-            case element::Type_t::i16:
-                axis = inputs[2]->get_data_ptr<element::Type_t::i16>()[0];
-                break;
-            case element::Type_t::i32:
-                axis = inputs[2]->get_data_ptr<element::Type_t::i32>()[0];
-                break;
-            case element::Type_t::i64:
-                axis = inputs[2]->get_data_ptr<element::Type_t::i64>()[0];
-                break;
-            case element::Type_t::u8:
-                axis = inputs[2]->get_data_ptr<element::Type_t::u8>()[0];
-                break;
-            case element::Type_t::u16:
-                axis = inputs[2]->get_data_ptr<element::Type_t::u16>()[0];
-                break;
-            case element::Type_t::u32:
-                axis = inputs[2]->get_data_ptr<element::Type_t::u32>()[0];
-                break;
-            case element::Type_t::u64:
-                axis = inputs[2]->get_data_ptr<element::Type_t::u64>()[0];
-                break;
-            default: throw ngraph_error("axis element type is not integral data type");
-        }
-
-        if (axis < 0) {
-            const auto& input_rank = get_input_partial_shape(PARAMS).rank();
-            if (input_rank.is_static())
-            {
-                axis += input_rank.get_length();
-            }
-        } return gather::evaluate_gather(inputs[0], inputs[1], outputs[0], axis));
+    NGRAPH_OP_SCOPE(v1_Gather_evaluate, return evaluate_gather(outputs, inputs));
     return false;
 }
 

--- a/ngraph/core/src/op/greater.cpp
+++ b/ngraph/core/src/op/greater.cpp
@@ -50,20 +50,13 @@ namespace greaterop
         out->set_broadcast(broadcast_spec, arg0, arg1, element::boolean);
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(boolean)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(i32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(i64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_greater, boolean, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_greater, i32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_greater, i64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_greater, u32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_greater, u64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_greater, f16, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_greater, f32, arg0, arg1, out, broadcast_spec);
         default: rc = false; break;
         }
         return rc;
@@ -91,6 +84,7 @@ shared_ptr<Node> op::v1::Greater::clone_with_new_inputs(const OutputVector& new_
 bool op::v1::Greater::evaluate(const HostTensorVector& outputs,
                                const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::Greater::evaluate");
-    return greaterop::evaluate_greater(inputs[0], inputs[1], outputs[0], get_autob());
+    NGRAPH_OP_SCOPE(v1_Greater_evaluate return greaterop::evaluate_greater(
+        inputs[0], inputs[1], outputs[0], get_autob()));
+    return false;
 }

--- a/ngraph/core/src/op/greater.cpp
+++ b/ngraph/core/src/op/greater.cpp
@@ -84,7 +84,8 @@ shared_ptr<Node> op::v1::Greater::clone_with_new_inputs(const OutputVector& new_
 bool op::v1::Greater::evaluate(const HostTensorVector& outputs,
                                const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(v1_Greater_evaluate return greaterop::evaluate_greater(
-        inputs[0], inputs[1], outputs[0], get_autob()));
+    NGRAPH_OP_SCOPE(
+        v1_Greater_evaluate,
+        return greaterop::evaluate_greater(inputs[0], inputs[1], outputs[0], get_autob()));
     return false;
 }

--- a/ngraph/core/src/op/greater_eq.cpp
+++ b/ngraph/core/src/op/greater_eq.cpp
@@ -50,20 +50,13 @@ namespace greater_equalop
         out->set_broadcast(broadcast_spec, arg0, arg1, element::boolean);
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(boolean)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(i32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(i64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_greater_equal, boolean, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_greater_equal, i32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_greater_equal, i64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_greater_equal, u32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_greater_equal, u64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_greater_equal, f16, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_greater_equal, f32, arg0, arg1, out, broadcast_spec);
         default: rc = false; break;
         }
         return rc;
@@ -91,6 +84,7 @@ shared_ptr<Node> op::v1::GreaterEqual::clone_with_new_inputs(const OutputVector&
 bool op::v1::GreaterEqual::evaluate(const HostTensorVector& outputs,
                                     const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::GreaterEqual::evaluate");
-    return greater_equalop::evaluate_greater_equal(inputs[0], inputs[1], outputs[0], get_autob());
+    NGRAPH_OP_SCOPE(v1_GreaterEqual_evaluate return greater_equalop::evaluate_greater_equal(
+        inputs[0], inputs[1], outputs[0], get_autob()));
+    return false;
 }

--- a/ngraph/core/src/op/greater_eq.cpp
+++ b/ngraph/core/src/op/greater_eq.cpp
@@ -84,7 +84,8 @@ shared_ptr<Node> op::v1::GreaterEqual::clone_with_new_inputs(const OutputVector&
 bool op::v1::GreaterEqual::evaluate(const HostTensorVector& outputs,
                                     const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(v1_GreaterEqual_evaluate return greater_equalop::evaluate_greater_equal(
-        inputs[0], inputs[1], outputs[0], get_autob()));
+    NGRAPH_OP_SCOPE(v1_GreaterEqual_evaluate,
+                    return greater_equalop::evaluate_greater_equal(
+                        inputs[0], inputs[1], outputs[0], get_autob()));
     return false;
 }

--- a/ngraph/core/src/op/hsigmoid.cpp
+++ b/ngraph/core/src/op/hsigmoid.cpp
@@ -15,6 +15,7 @@
 //*****************************************************************************
 
 #include "ngraph/op/hsigmoid.hpp"
+#include "itt.hpp"
 #include "ngraph/attribute_visitor.hpp"
 #include "ngraph/op/constant.hpp"
 
@@ -60,12 +61,9 @@ namespace
 
         switch (arg->get_element_type())
         {
-            TYPE_CASE(bf16)(arg, out, count);
-            break;
-            TYPE_CASE(f16)(arg, out, count);
-            break;
-            TYPE_CASE(f32)(arg, out, count);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_hsigmoid, bf16, arg, out, count);
+            NGRAPH_TYPE_CASE(evaluate_hsigmoid, f16, arg, out, count);
+            NGRAPH_TYPE_CASE(evaluate_hsigmoid, f32, arg, out, count);
         default: rc = false; break;
         }
         return rc;
@@ -75,5 +73,8 @@ namespace
 bool op::v5::HSigmoid::evaluate(const HostTensorVector& outputs,
                                 const HostTensorVector& inputs) const
 {
-    return evaluate_hsigmoid(inputs[0], outputs[0], shape_size(get_output_shape(0)));
+    NGRAPH_OP_SCOPE(
+        v5_HSigmoid_evaluate,
+        return evaluate_hsigmoid(inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    return false;
 }

--- a/ngraph/core/src/op/hswish.cpp
+++ b/ngraph/core/src/op/hswish.cpp
@@ -15,6 +15,7 @@
 //*****************************************************************************
 
 #include "ngraph/op/hswish.hpp"
+#include "itt.hpp"
 #include "ngraph/attribute_visitor.hpp"
 #include "ngraph/op/constant.hpp"
 
@@ -60,12 +61,9 @@ namespace hswish
 
         switch (arg->get_element_type())
         {
-            TYPE_CASE(bf16)(arg, out, count);
-            break;
-            TYPE_CASE(f16)(arg, out, count);
-            break;
-            TYPE_CASE(f32)(arg, out, count);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_hswish, bf16, arg, out, count);
+            NGRAPH_TYPE_CASE(evaluate_hswish, f16, arg, out, count);
+            NGRAPH_TYPE_CASE(evaluate_hswish, f32, arg, out, count);
         default: rc = false; break;
         }
         return rc;
@@ -74,5 +72,8 @@ namespace hswish
 
 bool op::v4::HSwish::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    return hswish::evaluate_hswish(inputs[0], outputs[0], shape_size(get_output_shape(0)));
+    NGRAPH_OP_SCOPE(
+        v4_HSwish_evaluate,
+        return hswish::evaluate_hswish(inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    return false;
 }

--- a/ngraph/core/src/op/interpolate.cpp
+++ b/ngraph/core/src/op/interpolate.cpp
@@ -19,6 +19,7 @@
 #include <cmath>
 #include <cstring>
 #include <numeric>
+#include "itt.hpp"
 #include "ngraph/op/constant.hpp"
 #include "ngraph/runtime/reference/interpolate.hpp"
 
@@ -420,77 +421,80 @@ static void pad_input_data(const uint8_t* data_ptr,
 bool op::v4::Interpolate::evaluate(const HostTensorVector& outputs,
                                    const HostTensorVector& inputs) const
 {
-    element::Type input_et = get_input_element_type(0);
-    size_t type_size = input_et.size();
+    NGRAPH_OP_SCOPE(
+        v4_Interpolate_evaluate, element::Type input_et = get_input_element_type(0);
+        size_t type_size = input_et.size();
 
-    Shape input_shape{inputs[data_port]->get_shape()};
-    Shape padded_input_shape = get_padded_input_shape(input_shape).to_shape();
+        Shape input_shape{inputs[data_port]->get_shape()};
+        Shape padded_input_shape = get_padded_input_shape(input_shape).to_shape();
 
-    auto axes = get_axes_vector(inputs);
-    size_t num_of_axes = axes.size();
+        auto axes = get_axes_vector(inputs);
+        size_t num_of_axes = axes.size();
 
-    auto scales = get_scales_vector(inputs, padded_input_shape, m_attrs, axes);
+        auto scales = get_scales_vector(inputs, padded_input_shape, m_attrs, axes);
 
-    PartialShape output_shape{padded_input_shape};
+        PartialShape output_shape{padded_input_shape};
 
-    if (m_attrs.shape_calculation_mode == ShapeCalcMode::scales)
-    {
-        infer_using_scales(output_shape, axes, scales, padded_input_shape);
-    }
-    else
-    {
-        auto sizes = get_target_shape_vector(inputs, num_of_axes);
-        infer_using_shapes(output_shape, axes, sizes);
-    }
+        if (m_attrs.shape_calculation_mode == ShapeCalcMode::scales) {
+            infer_using_scales(output_shape, axes, scales, padded_input_shape);
+        } else {
+            auto sizes = get_target_shape_vector(inputs, num_of_axes);
+            infer_using_shapes(output_shape, axes, sizes);
+        }
 
-    Shape out_shape = output_shape.to_shape();
+        Shape out_shape = output_shape.to_shape();
 
-    outputs[0]->set_element_type(inputs[0]->get_element_type());
-    outputs[0]->set_shape(out_shape);
+        outputs[0]->set_element_type(inputs[0]->get_element_type());
+        outputs[0]->set_shape(out_shape);
 
-    size_t bytes_in_padded_input = shape_size(padded_input_shape) * type_size;
+        size_t bytes_in_padded_input = shape_size(padded_input_shape) * type_size;
 
-    std::vector<uint8_t> padded_input_data(bytes_in_padded_input, 0);
+        std::vector<uint8_t> padded_input_data(bytes_in_padded_input, 0);
 
-    const uint8_t* data_ptr = inputs[0]->get_data_ptr<uint8_t>();
-    uint8_t* padded_data_ptr = padded_input_data.data();
+        const uint8_t* data_ptr = inputs[0]->get_data_ptr<uint8_t>();
+        uint8_t* padded_data_ptr = padded_input_data.data();
 
-    pad_input_data(
-        data_ptr, padded_data_ptr, type_size, input_shape, padded_input_shape, m_attrs.pads_begin);
+        pad_input_data(data_ptr,
+                       padded_data_ptr,
+                       type_size,
+                       input_shape,
+                       padded_input_shape,
+                       m_attrs.pads_begin);
 
-    switch (input_et)
-    {
-    case element::Type_t::f32:
-        runtime::reference::interpolate<float>(reinterpret_cast<float*>(padded_data_ptr),
-                                               padded_input_shape,
-                                               scales,
-                                               axes,
-                                               outputs[0]->get_data_ptr<float>(),
-                                               out_shape,
-                                               m_attrs);
-        break;
-    case element::Type_t::f16:
-        runtime::reference::interpolate<float16>(reinterpret_cast<float16*>(padded_data_ptr),
-                                                 padded_input_shape,
-                                                 scales,
-                                                 axes,
-                                                 outputs[0]->get_data_ptr<float16>(),
-                                                 out_shape,
-                                                 m_attrs);
-        break;
-    case element::Type_t::i8:
-        runtime::reference::interpolate<int8_t>(reinterpret_cast<int8_t*>(padded_data_ptr),
-                                                padded_input_shape,
-                                                scales,
-                                                axes,
-                                                outputs[0]->get_data_ptr<int8_t>(),
-                                                out_shape,
-                                                m_attrs);
-        break;
-    default:;
-    }
+        switch (input_et) {
+            case element::Type_t::f32:
+                runtime::reference::interpolate<float>(reinterpret_cast<float*>(padded_data_ptr),
+                                                       padded_input_shape,
+                                                       scales,
+                                                       axes,
+                                                       outputs[0]->get_data_ptr<float>(),
+                                                       out_shape,
+                                                       m_attrs);
+                break;
+            case element::Type_t::f16:
+                runtime::reference::interpolate<float16>(
+                    reinterpret_cast<float16*>(padded_data_ptr),
+                    padded_input_shape,
+                    scales,
+                    axes,
+                    outputs[0]->get_data_ptr<float16>(),
+                    out_shape,
+                    m_attrs);
+                break;
+            case element::Type_t::i8:
+                runtime::reference::interpolate<int8_t>(reinterpret_cast<int8_t*>(padded_data_ptr),
+                                                        padded_input_shape,
+                                                        scales,
+                                                        axes,
+                                                        outputs[0]->get_data_ptr<int8_t>(),
+                                                        out_shape,
+                                                        m_attrs);
+                break;
+            default:;
+        }
 
-    return true;
+        return true);
+    return false;
 }
 
 namespace ngraph

--- a/ngraph/core/src/op/less.cpp
+++ b/ngraph/core/src/op/less.cpp
@@ -50,20 +50,13 @@ namespace lessop
         out->set_broadcast(broadcast_spec, arg0, arg1, element::boolean);
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(boolean)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(i32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(i64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_less, boolean, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_less, i32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_less, i64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_less, u32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_less, u64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_less, f16, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_less, f32, arg0, arg1, out, broadcast_spec);
         default: rc = false; break;
         }
         return rc;
@@ -90,6 +83,7 @@ shared_ptr<Node> op::v1::Less::clone_with_new_inputs(const OutputVector& new_arg
 
 bool op::v1::Less::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::Less::evaluate");
-    return lessop::evaluate_less(inputs[0], inputs[1], outputs[0], get_autob());
+    NGRAPH_OP_SCOPE(v1_Less_evaluate return lessop::evaluate_less(
+        inputs[0], inputs[1], outputs[0], get_autob()));
+    return false;
 }

--- a/ngraph/core/src/op/less.cpp
+++ b/ngraph/core/src/op/less.cpp
@@ -83,7 +83,7 @@ shared_ptr<Node> op::v1::Less::clone_with_new_inputs(const OutputVector& new_arg
 
 bool op::v1::Less::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(v1_Less_evaluate return lessop::evaluate_less(
-        inputs[0], inputs[1], outputs[0], get_autob()));
+    NGRAPH_OP_SCOPE(v1_Less_evaluate,
+                    return lessop::evaluate_less(inputs[0], inputs[1], outputs[0], get_autob()));
     return false;
 }

--- a/ngraph/core/src/op/less_eq.cpp
+++ b/ngraph/core/src/op/less_eq.cpp
@@ -68,20 +68,13 @@ namespace less_equalop
         out->set_broadcast(broadcast_spec, arg0, arg1, element::boolean);
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(boolean)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(i32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(i64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_less_equal, boolean, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_less_equal, i32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_less_equal, i64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_less_equal, u32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_less_equal, u64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_less_equal, f16, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_less_equal, f32, arg0, arg1, out, broadcast_spec);
         default: rc = false; break;
         }
         return rc;
@@ -91,6 +84,7 @@ namespace less_equalop
 bool op::v1::LessEqual::evaluate(const HostTensorVector& outputs,
                                  const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::LessEqual::evaluate");
-    return less_equalop::evaluate_less_equal(inputs[0], inputs[1], outputs[0], get_autob());
+    NGRAPH_OP_SCOPE(v1_LessEqual_evaluate return less_equalop::evaluate_less_equal(
+        inputs[0], inputs[1], outputs[0], get_autob()));
+    return false;
 }

--- a/ngraph/core/src/op/less_eq.cpp
+++ b/ngraph/core/src/op/less_eq.cpp
@@ -84,7 +84,8 @@ namespace less_equalop
 bool op::v1::LessEqual::evaluate(const HostTensorVector& outputs,
                                  const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(v1_LessEqual_evaluate return less_equalop::evaluate_less_equal(
-        inputs[0], inputs[1], outputs[0], get_autob()));
+    NGRAPH_OP_SCOPE(
+        v1_LessEqual_evaluate,
+        return less_equalop::evaluate_less_equal(inputs[0], inputs[1], outputs[0], get_autob()));
     return false;
 }

--- a/ngraph/core/src/op/log.cpp
+++ b/ngraph/core/src/op/log.cpp
@@ -61,20 +61,13 @@ namespace logop
 
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(boolean)(arg0, out, count);
-            break;
-            TYPE_CASE(i32)(arg0, out, count);
-            break;
-            TYPE_CASE(i64)(arg0, out, count);
-            break;
-            TYPE_CASE(u32)(arg0, out, count);
-            break;
-            TYPE_CASE(u64)(arg0, out, count);
-            break;
-            TYPE_CASE(f16)(arg0, out, count);
-            break;
-            TYPE_CASE(f32)(arg0, out, count);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_log, boolean, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_log, i32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_log, i64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_log, u32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_log, u64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_log, f16, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_log, f32, arg0, out, count);
         default: rc = false; break;
         }
         return rc;
@@ -83,6 +76,7 @@ namespace logop
 
 bool op::Log::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::Log::evaluate");
-    return logop::evaluate_log(inputs[0], outputs[0], shape_size(get_output_shape(0)));
+    NGRAPH_OP_SCOPE(Log_evaluate return logop::evaluate_log(
+        inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    return false;
 }

--- a/ngraph/core/src/op/log.cpp
+++ b/ngraph/core/src/op/log.cpp
@@ -77,7 +77,7 @@ namespace logop
 bool op::Log::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
     NGRAPH_OP_SCOPE(
-        Log_evaluate,
+        v0_Log_evaluate,
         return logop::evaluate_log(inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return false;
 }

--- a/ngraph/core/src/op/log.cpp
+++ b/ngraph/core/src/op/log.cpp
@@ -76,7 +76,8 @@ namespace logop
 
 bool op::Log::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(Log_evaluate return logop::evaluate_log(
-        inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    NGRAPH_OP_SCOPE(
+        Log_evaluate,
+        return logop::evaluate_log(inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return false;
 }

--- a/ngraph/core/src/op/loop.cpp
+++ b/ngraph/core/src/op/loop.cpp
@@ -397,8 +397,12 @@ Output<Node> op::v5::Loop::get_concatenated_slices(const Output<Node>& value,
 
 bool op::v5::Loop::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v5::Loop::evaluate");
-    runtime::reference::loop(
-        m_body, m_output_descriptions, m_input_descriptions, m_special_body_ports, outputs, inputs);
-    return true;
+    NGRAPH_OP_SCOPE(v5_Loop_evaluate runtime::reference::loop(m_body,
+                                                              m_output_descriptions,
+                                                              m_input_descriptions,
+                                                              m_special_body_ports,
+                                                              outputs,
+                                                              inputs);
+                    return true);
+    return false;
 }

--- a/ngraph/core/src/op/loop.cpp
+++ b/ngraph/core/src/op/loop.cpp
@@ -397,12 +397,13 @@ Output<Node> op::v5::Loop::get_concatenated_slices(const Output<Node>& value,
 
 bool op::v5::Loop::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(v5_Loop_evaluate runtime::reference::loop(m_body,
-                                                              m_output_descriptions,
-                                                              m_input_descriptions,
-                                                              m_special_body_ports,
-                                                              outputs,
-                                                              inputs);
+    NGRAPH_OP_SCOPE(v5_Loop_evaluate,
+                    runtime::reference::loop(m_body,
+                                             m_output_descriptions,
+                                             m_input_descriptions,
+                                             m_special_body_ports,
+                                             outputs,
+                                             inputs);
                     return true);
     return false;
 }

--- a/ngraph/core/src/op/matmul.cpp
+++ b/ngraph/core/src/op/matmul.cpp
@@ -259,8 +259,9 @@ namespace matmul
 
 bool op::MatMul::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(MatMul_evaluate return matmul::evaluate_matmul(
-        inputs[0], inputs[1], outputs[0], get_transpose_a(), get_transpose_b()));
+    NGRAPH_OP_SCOPE(MatMul_evaluate,
+                    return matmul::evaluate_matmul(
+                        inputs[0], inputs[1], outputs[0], get_transpose_a(), get_transpose_b()));
     return false;
 }
 

--- a/ngraph/core/src/op/matmul.cpp
+++ b/ngraph/core/src/op/matmul.cpp
@@ -245,18 +245,12 @@ namespace matmul
 
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(i32)(arg0, arg1, output, transpose_a, transpose_b);
-            break;
-            TYPE_CASE(i64)(arg0, arg1, output, transpose_a, transpose_b);
-            break;
-            TYPE_CASE(u32)(arg0, arg1, output, transpose_a, transpose_b);
-            break;
-            TYPE_CASE(u64)(arg0, arg1, output, transpose_a, transpose_b);
-            break;
-            TYPE_CASE(f16)(arg0, arg1, output, transpose_a, transpose_b);
-            break;
-            TYPE_CASE(f32)(arg0, arg1, output, transpose_a, transpose_b);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_matmul, i32, arg0, arg1, output, transpose_a, transpose_b);
+            NGRAPH_TYPE_CASE(evaluate_matmul, i64, arg0, arg1, output, transpose_a, transpose_b);
+            NGRAPH_TYPE_CASE(evaluate_matmul, u32, arg0, arg1, output, transpose_a, transpose_b);
+            NGRAPH_TYPE_CASE(evaluate_matmul, u64, arg0, arg1, output, transpose_a, transpose_b);
+            NGRAPH_TYPE_CASE(evaluate_matmul, f16, arg0, arg1, output, transpose_a, transpose_b);
+            NGRAPH_TYPE_CASE(evaluate_matmul, f32, arg0, arg1, output, transpose_a, transpose_b);
         default: rc = false; break;
         }
         return rc;
@@ -265,9 +259,9 @@ namespace matmul
 
 bool op::MatMul::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::MatMul::evaluate");
-    return matmul::evaluate_matmul(
-        inputs[0], inputs[1], outputs[0], get_transpose_a(), get_transpose_b());
+    NGRAPH_OP_SCOPE(MatMul_evaluate return matmul::evaluate_matmul(
+        inputs[0], inputs[1], outputs[0], get_transpose_a(), get_transpose_b()));
+    return false;
 }
 
 void ngraph::op::v0::MatMul::validate_and_infer_types()

--- a/ngraph/core/src/op/matmul.cpp
+++ b/ngraph/core/src/op/matmul.cpp
@@ -259,7 +259,7 @@ namespace matmul
 
 bool op::MatMul::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(MatMul_evaluate,
+    NGRAPH_OP_SCOPE(v0_MatMul_evaluate,
                     return matmul::evaluate_matmul(
                         inputs[0], inputs[1], outputs[0], get_transpose_a(), get_transpose_b()));
     return false;

--- a/ngraph/core/src/op/max.cpp
+++ b/ngraph/core/src/op/max.cpp
@@ -46,18 +46,12 @@ namespace maxop
         bool rc = true;
         switch (arg->get_element_type())
         {
-            TYPE_CASE(i32)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(i64)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(u32)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(u64)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(f16)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(f32)(arg, out, axes, keep_dims);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_max, i32, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_max, i64, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_max, u32, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_max, u64, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_max, f16, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_max, f32, arg, out, axes, keep_dims);
         default: rc = false; break;
         }
         return rc;
@@ -83,6 +77,7 @@ shared_ptr<Node> op::v1::ReduceMax::clone_with_new_inputs(const OutputVector& ne
 bool op::v1::ReduceMax::evaluate(const HostTensorVector& outputs,
                                  const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::ReduceMax::evaluate");
-    return maxop::evaluate_max(inputs[0], outputs[0], get_reduction_axes(), get_keep_dims());
+    NGRAPH_OP_SCOPE(v1_ReduceMax_evaluate return maxop::evaluate_max(
+        inputs[0], outputs[0], get_reduction_axes(), get_keep_dims()));
+    return false;
 }

--- a/ngraph/core/src/op/max.cpp
+++ b/ngraph/core/src/op/max.cpp
@@ -77,7 +77,8 @@ shared_ptr<Node> op::v1::ReduceMax::clone_with_new_inputs(const OutputVector& ne
 bool op::v1::ReduceMax::evaluate(const HostTensorVector& outputs,
                                  const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(v1_ReduceMax_evaluate return maxop::evaluate_max(
-        inputs[0], outputs[0], get_reduction_axes(), get_keep_dims()));
+    NGRAPH_OP_SCOPE(
+        v1_ReduceMax_evaluate,
+        return maxop::evaluate_max(inputs[0], outputs[0], get_reduction_axes(), get_keep_dims()));
     return false;
 }

--- a/ngraph/core/src/op/max_pool.cpp
+++ b/ngraph/core/src/op/max_pool.cpp
@@ -203,7 +203,7 @@ namespace maxpool
 bool op::v1::MaxPool::evaluate(const HostTensorVector& outputs,
                                const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(v1_MaxPool_evaluate auto arg_shape = inputs[0]->get_partial_shape();
+    NGRAPH_OP_SCOPE(v1_MaxPool_evaluate, auto arg_shape = inputs[0]->get_partial_shape();
                     auto pads_begin_s = get_pads_begin();
                     auto pads_end_s = get_pads_end();
                     update_auto_padding(arg_shape, pads_begin_s, pads_end_s);

--- a/ngraph/core/src/op/max_pool.cpp
+++ b/ngraph/core/src/op/max_pool.cpp
@@ -182,18 +182,18 @@ namespace maxpool
 
         switch (out->get_element_type())
         {
-            TYPE_CASE(i32)(arg, out, out_shape, kernel, strides, pad_begin, pad_end);
-            break;
-            TYPE_CASE(i64)(arg, out, out_shape, kernel, strides, pad_begin, pad_end);
-            break;
-            TYPE_CASE(u32)(arg, out, out_shape, kernel, strides, pad_begin, pad_end);
-            break;
-            TYPE_CASE(u64)(arg, out, out_shape, kernel, strides, pad_begin, pad_end);
-            break;
-            TYPE_CASE(f16)(arg, out, out_shape, kernel, strides, pad_begin, pad_end);
-            break;
-            TYPE_CASE(f32)(arg, out, out_shape, kernel, strides, pad_begin, pad_end);
-            break;
+            NGRAPH_TYPE_CASE(
+                evaluate_maxpool, i32, arg, out, out_shape, kernel, strides, pad_begin, pad_end);
+            NGRAPH_TYPE_CASE(
+                evaluate_maxpool, i64, arg, out, out_shape, kernel, strides, pad_begin, pad_end);
+            NGRAPH_TYPE_CASE(
+                evaluate_maxpool, u32, arg, out, out_shape, kernel, strides, pad_begin, pad_end);
+            NGRAPH_TYPE_CASE(
+                evaluate_maxpool, u64, arg, out, out_shape, kernel, strides, pad_begin, pad_end);
+            NGRAPH_TYPE_CASE(
+                evaluate_maxpool, f16, arg, out, out_shape, kernel, strides, pad_begin, pad_end);
+            NGRAPH_TYPE_CASE(
+                evaluate_maxpool, f32, arg, out, out_shape, kernel, strides, pad_begin, pad_end);
         default: rc = false; break;
         }
         return rc;
@@ -203,28 +203,28 @@ namespace maxpool
 bool op::v1::MaxPool::evaluate(const HostTensorVector& outputs,
                                const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::MaxPool::evaluate");
+    NGRAPH_OP_SCOPE(v1_MaxPool_evaluate auto arg_shape = inputs[0]->get_partial_shape();
+                    auto pads_begin_s = get_pads_begin();
+                    auto pads_end_s = get_pads_end();
+                    update_auto_padding(arg_shape, pads_begin_s, pads_end_s);
+                    CoordinateDiff pads_begin(pads_begin_s.begin(), pads_begin_s.end());
+                    CoordinateDiff pads_end(pads_end_s.begin(), pads_end_s.end());
+                    auto out_shape = infer_batched_pooling_forward(this,
+                                                                   arg_shape,
+                                                                   pads_begin,
+                                                                   pads_end,
+                                                                   get_kernel(),
+                                                                   get_strides(),
+                                                                   true,
+                                                                   get_rounding_type() ==
+                                                                       op::RoundingType::CEIL);
 
-    auto arg_shape = inputs[0]->get_partial_shape();
-    auto pads_begin_s = get_pads_begin();
-    auto pads_end_s = get_pads_end();
-    update_auto_padding(arg_shape, pads_begin_s, pads_end_s);
-    CoordinateDiff pads_begin(pads_begin_s.begin(), pads_begin_s.end());
-    CoordinateDiff pads_end(pads_end_s.begin(), pads_end_s.end());
-    auto out_shape = infer_batched_pooling_forward(this,
-                                                   arg_shape,
-                                                   pads_begin,
-                                                   pads_end,
-                                                   get_kernel(),
-                                                   get_strides(),
-                                                   true,
-                                                   get_rounding_type() == op::RoundingType::CEIL);
-
-    return maxpool::evaluate_maxpool(inputs[0],
-                                     outputs[0],
-                                     out_shape.get_shape(),
-                                     get_kernel(),
-                                     get_strides(),
-                                     get_pads_begin(),
-                                     get_pads_end());
+                    return maxpool::evaluate_maxpool(inputs[0],
+                                                     outputs[0],
+                                                     out_shape.get_shape(),
+                                                     get_kernel(),
+                                                     get_strides(),
+                                                     get_pads_begin(),
+                                                     get_pads_end()));
+    return false;
 }

--- a/ngraph/core/src/op/max_pool.cpp
+++ b/ngraph/core/src/op/max_pool.cpp
@@ -200,31 +200,35 @@ namespace maxpool
     }
 } // namespace
 
+bool op::v1::MaxPool::evaluate_maxpool(const HostTensorVector& outputs,
+                                       const HostTensorVector& inputs) const
+{
+    auto arg_shape = inputs[0]->get_partial_shape();
+    auto pads_begin_s = get_pads_begin();
+    auto pads_end_s = get_pads_end();
+    update_auto_padding(arg_shape, pads_begin_s, pads_end_s);
+    CoordinateDiff pads_begin(pads_begin_s.begin(), pads_begin_s.end());
+    CoordinateDiff pads_end(pads_end_s.begin(), pads_end_s.end());
+    auto out_shape = infer_batched_pooling_forward(this,
+                                                   arg_shape,
+                                                   pads_begin,
+                                                   pads_end,
+                                                   get_kernel(),
+                                                   get_strides(),
+                                                   true,
+                                                   get_rounding_type() == op::RoundingType::CEIL);
+
+    return maxpool::evaluate_maxpool(inputs[0],
+                                     outputs[0],
+                                     out_shape.get_shape(),
+                                     get_kernel(),
+                                     get_strides(),
+                                     get_pads_begin(),
+                                     get_pads_end());
+}
 bool op::v1::MaxPool::evaluate(const HostTensorVector& outputs,
                                const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(v1_MaxPool_evaluate, auto arg_shape = inputs[0]->get_partial_shape();
-                    auto pads_begin_s = get_pads_begin();
-                    auto pads_end_s = get_pads_end();
-                    update_auto_padding(arg_shape, pads_begin_s, pads_end_s);
-                    CoordinateDiff pads_begin(pads_begin_s.begin(), pads_begin_s.end());
-                    CoordinateDiff pads_end(pads_end_s.begin(), pads_end_s.end());
-                    auto out_shape = infer_batched_pooling_forward(this,
-                                                                   arg_shape,
-                                                                   pads_begin,
-                                                                   pads_end,
-                                                                   get_kernel(),
-                                                                   get_strides(),
-                                                                   true,
-                                                                   get_rounding_type() ==
-                                                                       op::RoundingType::CEIL);
-
-                    return maxpool::evaluate_maxpool(inputs[0],
-                                                     outputs[0],
-                                                     out_shape.get_shape(),
-                                                     get_kernel(),
-                                                     get_strides(),
-                                                     get_pads_begin(),
-                                                     get_pads_end()));
+    NGRAPH_OP_SCOPE(v1_MaxPool_evaluate, return evaluate_maxpool(outputs, inputs));
     return false;
 }

--- a/ngraph/core/src/op/maximum.cpp
+++ b/ngraph/core/src/op/maximum.cpp
@@ -91,7 +91,8 @@ shared_ptr<Node> op::v1::Maximum::clone_with_new_inputs(const OutputVector& new_
 bool op::v1::Maximum::evaluate(const HostTensorVector& outputs,
                                const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(v1_Maximum_evaluate return maximumop::evaluate_maximum(
-        inputs[0], inputs[1], outputs[0], get_autob()));
+    NGRAPH_OP_SCOPE(
+        v1_Maximum_evaluate,
+        return maximumop::evaluate_maximum(inputs[0], inputs[1], outputs[0], get_autob()));
     return false;
 }

--- a/ngraph/core/src/op/maximum.cpp
+++ b/ngraph/core/src/op/maximum.cpp
@@ -58,18 +58,12 @@ namespace maximumop
         out->set_broadcast(broadcast_spec, arg0, arg1);
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(i32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(i64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_maximum, i32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_maximum, i64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_maximum, u32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_maximum, u64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_maximum, f16, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_maximum, f32, arg0, arg1, out, broadcast_spec);
         default: rc = false; break;
         }
         return rc;
@@ -97,6 +91,7 @@ shared_ptr<Node> op::v1::Maximum::clone_with_new_inputs(const OutputVector& new_
 bool op::v1::Maximum::evaluate(const HostTensorVector& outputs,
                                const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::Maximum::evaluate");
-    return maximumop::evaluate_maximum(inputs[0], inputs[1], outputs[0], get_autob());
+    NGRAPH_OP_SCOPE(v1_Maximum_evaluate return maximumop::evaluate_maximum(
+        inputs[0], inputs[1], outputs[0], get_autob()));
+    return false;
 }

--- a/ngraph/core/src/op/min.cpp
+++ b/ngraph/core/src/op/min.cpp
@@ -79,7 +79,8 @@ shared_ptr<Node> op::v1::ReduceMin::clone_with_new_inputs(const OutputVector& ne
 bool op::v1::ReduceMin::evaluate(const HostTensorVector& outputs,
                                  const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(v1_ReduceMin_evaluate return minop::evaluate_min(
-        inputs[0], outputs[0], get_reduction_axes(), get_keep_dims()));
+    NGRAPH_OP_SCOPE(
+        v1_ReduceMin_evaluate,
+        return minop::evaluate_min(inputs[0], outputs[0], get_reduction_axes(), get_keep_dims()));
     return false;
 }

--- a/ngraph/core/src/op/min.cpp
+++ b/ngraph/core/src/op/min.cpp
@@ -48,18 +48,12 @@ namespace minop
         bool rc = true;
         switch (arg->get_element_type())
         {
-            TYPE_CASE(i32)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(i64)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(u32)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(u64)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(f16)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(f32)(arg, out, axes, keep_dims);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_min, i32, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_min, i64, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_min, u32, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_min, u64, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_min, f16, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_min, f32, arg, out, axes, keep_dims);
         default: rc = false; break;
         }
         return rc;
@@ -85,6 +79,7 @@ shared_ptr<Node> op::v1::ReduceMin::clone_with_new_inputs(const OutputVector& ne
 bool op::v1::ReduceMin::evaluate(const HostTensorVector& outputs,
                                  const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::ReduceMin::evaluate");
-    return minop::evaluate_min(inputs[0], outputs[0], get_reduction_axes(), get_keep_dims());
+    NGRAPH_OP_SCOPE(v1_ReduceMin_evaluate return minop::evaluate_min(
+        inputs[0], outputs[0], get_reduction_axes(), get_keep_dims()));
+    return false;
 }

--- a/ngraph/core/src/op/minimum.cpp
+++ b/ngraph/core/src/op/minimum.cpp
@@ -89,7 +89,8 @@ shared_ptr<Node> op::v1::Minimum::clone_with_new_inputs(const OutputVector& new_
 bool op::v1::Minimum::evaluate(const HostTensorVector& outputs,
                                const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(v1_Minimum_evaluate return minimumop::evaluate_minimum(
-        inputs[0], inputs[1], outputs[0], get_autob()));
+    NGRAPH_OP_SCOPE(
+        v1_Minimum_evaluate,
+        return minimumop::evaluate_minimum(inputs[0], inputs[1], outputs[0], get_autob()));
     return false;
 }

--- a/ngraph/core/src/op/minimum.cpp
+++ b/ngraph/core/src/op/minimum.cpp
@@ -56,18 +56,12 @@ namespace minimumop
         out->set_broadcast(broadcast_spec, arg0, arg1);
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(i32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(i64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_minimum, i32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_minimum, i64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_minimum, u32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_minimum, u64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_minimum, f16, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_minimum, f32, arg0, arg1, out, broadcast_spec);
         default: rc = false; break;
         }
         return rc;
@@ -95,6 +89,7 @@ shared_ptr<Node> op::v1::Minimum::clone_with_new_inputs(const OutputVector& new_
 bool op::v1::Minimum::evaluate(const HostTensorVector& outputs,
                                const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::Minimum::evaluate");
-    return minimumop::evaluate_minimum(inputs[0], inputs[1], outputs[0], get_autob());
+    NGRAPH_OP_SCOPE(v1_Minimum_evaluate return minimumop::evaluate_minimum(
+        inputs[0], inputs[1], outputs[0], get_autob()));
+    return false;
 }

--- a/ngraph/core/src/op/mish.cpp
+++ b/ngraph/core/src/op/mish.cpp
@@ -77,7 +77,8 @@ namespace mish
 
 bool op::v4::Mish::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(v4_Mish_evaluate return mish::evaluate_mish(
-        inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    NGRAPH_OP_SCOPE(
+        v4_Mish_evaluate,
+        return mish::evaluate_mish(inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return false;
 }

--- a/ngraph/core/src/op/mish.cpp
+++ b/ngraph/core/src/op/mish.cpp
@@ -67,10 +67,8 @@ namespace mish
 
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(f16)(arg0, out, count);
-            break;
-            TYPE_CASE(f32)(arg0, out, count);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_mish, f16, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_mish, f32, arg0, out, count);
         default: rc = false; break;
         }
         return rc;
@@ -79,6 +77,7 @@ namespace mish
 
 bool op::v4::Mish::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v4::Mish::evaluate");
-    return mish::evaluate_mish(inputs[0], outputs[0], shape_size(get_output_shape(0)));
+    NGRAPH_OP_SCOPE(v4_Mish_evaluate return mish::evaluate_mish(
+        inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    return false;
 }

--- a/ngraph/core/src/op/multiply.cpp
+++ b/ngraph/core/src/op/multiply.cpp
@@ -85,7 +85,7 @@ bool op::v0::Multiply::evaluate(const HostTensorVector& outputs,
                                 const HostTensorVector& inputs) const
 {
     NGRAPH_OP_SCOPE(
-        Multiply_evaluate,
+        v0_Multiply_evaluate,
         return multiplyop::evaluate_multiply(inputs[0], inputs[1], outputs[0], get_autob()));
     return false;
 }

--- a/ngraph/core/src/op/multiply.cpp
+++ b/ngraph/core/src/op/multiply.cpp
@@ -85,7 +85,7 @@ bool op::v0::Multiply::evaluate(const HostTensorVector& outputs,
                                 const HostTensorVector& inputs) const
 {
     NGRAPH_OP_SCOPE(
-        op_v0_Multiply_evaluate,
+        Multiply_evaluate,
         return multiplyop::evaluate_multiply(inputs[0], inputs[1], outputs[0], get_autob()));
     return false;
 }

--- a/ngraph/core/src/op/multiply.cpp
+++ b/ngraph/core/src/op/multiply.cpp
@@ -50,20 +50,13 @@ namespace multiplyop
         out->set_broadcast(broadcast_spec, arg0, arg1);
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(i32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(i64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(bf16)(arg0, arg1, out, broadcast_spec);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_multiply, i32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_multiply, i64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_multiply, u32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_multiply, u64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_multiply, f16, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_multiply, f32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_multiply, bf16, arg0, arg1, out, broadcast_spec);
         default: rc = false; break;
         }
         return rc;
@@ -91,8 +84,9 @@ shared_ptr<Node> op::v0::Multiply::clone_with_new_inputs(const OutputVector& new
 bool op::v0::Multiply::evaluate(const HostTensorVector& outputs,
                                 const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v0::Multiply::evaluate");
-    return multiplyop::evaluate_multiply(inputs[0], inputs[1], outputs[0], get_autob());
+    NGRAPH_OP_SCOPE(op_v0_Multiply_evaluate return multiplyop::evaluate_multiply(
+        inputs[0], inputs[1], outputs[0], get_autob()));
+    return false;
 }
 
 // ------------------------------------ v1 -------------------------------------
@@ -116,6 +110,7 @@ shared_ptr<Node> op::v1::Multiply::clone_with_new_inputs(const OutputVector& new
 bool op::v1::Multiply::evaluate(const HostTensorVector& outputs,
                                 const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::Multiply::evaluate");
-    return multiplyop::evaluate_multiply(inputs[0], inputs[1], outputs[0], get_autob());
+    NGRAPH_OP_SCOPE(v1_Multiply_evaluate return multiplyop::evaluate_multiply(
+        inputs[0], inputs[1], outputs[0], get_autob()));
+    return false;
 }

--- a/ngraph/core/src/op/multiply.cpp
+++ b/ngraph/core/src/op/multiply.cpp
@@ -84,8 +84,9 @@ shared_ptr<Node> op::v0::Multiply::clone_with_new_inputs(const OutputVector& new
 bool op::v0::Multiply::evaluate(const HostTensorVector& outputs,
                                 const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(op_v0_Multiply_evaluate return multiplyop::evaluate_multiply(
-        inputs[0], inputs[1], outputs[0], get_autob()));
+    NGRAPH_OP_SCOPE(
+        op_v0_Multiply_evaluate,
+        return multiplyop::evaluate_multiply(inputs[0], inputs[1], outputs[0], get_autob()));
     return false;
 }
 
@@ -110,7 +111,8 @@ shared_ptr<Node> op::v1::Multiply::clone_with_new_inputs(const OutputVector& new
 bool op::v1::Multiply::evaluate(const HostTensorVector& outputs,
                                 const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(v1_Multiply_evaluate return multiplyop::evaluate_multiply(
-        inputs[0], inputs[1], outputs[0], get_autob()));
+    NGRAPH_OP_SCOPE(
+        v1_Multiply_evaluate,
+        return multiplyop::evaluate_multiply(inputs[0], inputs[1], outputs[0], get_autob()));
     return false;
 }

--- a/ngraph/core/src/op/negative.cpp
+++ b/ngraph/core/src/op/negative.cpp
@@ -73,7 +73,7 @@ namespace negativeop
 
 bool op::Negative::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(Negative_evaluate,
+    NGRAPH_OP_SCOPE(v0_Negative_evaluate,
                     return negativeop::evaluate_negative(
                         inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return false;

--- a/ngraph/core/src/op/negative.cpp
+++ b/ngraph/core/src/op/negative.cpp
@@ -73,8 +73,9 @@ namespace negativeop
 
 bool op::Negative::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(Negative_evaluate return negativeop::evaluate_negative(
-        inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    NGRAPH_OP_SCOPE(Negative_evaluate,
+                    return negativeop::evaluate_negative(
+                        inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return false;
 }
 

--- a/ngraph/core/src/op/negative.cpp
+++ b/ngraph/core/src/op/negative.cpp
@@ -58,20 +58,13 @@ namespace negativeop
 
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(boolean)(arg0, out, count);
-            break;
-            TYPE_CASE(i32)(arg0, out, count);
-            break;
-            TYPE_CASE(i64)(arg0, out, count);
-            break;
-            TYPE_CASE(u32)(arg0, out, count);
-            break;
-            TYPE_CASE(u64)(arg0, out, count);
-            break;
-            TYPE_CASE(f16)(arg0, out, count);
-            break;
-            TYPE_CASE(f32)(arg0, out, count);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_negative, boolean, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_negative, i32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_negative, i64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_negative, u32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_negative, u64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_negative, f16, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_negative, f32, arg0, out, count);
         default: rc = false; break;
         }
         return rc;
@@ -80,8 +73,9 @@ namespace negativeop
 
 bool op::Negative::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::Negative::evaluate");
-    return negativeop::evaluate_negative(inputs[0], outputs[0], shape_size(get_output_shape(0)));
+    NGRAPH_OP_SCOPE(Negative_evaluate return negativeop::evaluate_negative(
+        inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    return false;
 }
 
 shared_ptr<Node> ngraph::operator-(const Output<Node>& arg0)

--- a/ngraph/core/src/op/non_zero.cpp
+++ b/ngraph/core/src/op/non_zero.cpp
@@ -158,6 +158,6 @@ namespace nonzero
 bool op::v3::NonZero::evaluate(const HostTensorVector& outputs,
                                const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(v3_NonZero_evaluate return nonzero::evaluate_nonzero(inputs[0], outputs[0]));
+    NGRAPH_OP_SCOPE(v3_NonZero_evaluate, return nonzero::evaluate_nonzero(inputs[0], outputs[0]));
     return false;
 }

--- a/ngraph/core/src/op/non_zero.cpp
+++ b/ngraph/core/src/op/non_zero.cpp
@@ -115,18 +115,21 @@ namespace nonzero
         return true;
     }
 
+#define TYPE_OUT_CASE(a, ...)                                                                      \
+    case element::Type_t::a:                                                                       \
+    {                                                                                              \
+        NGRAPH_OP_SCOPE(OV_CC_CAT3(evaluate_nonzero_out, _, a),                                    \
+                        rc = evaluate_nonzero_execute<INPUT_ET, element::Type_t::a>(__VA_ARGS__)); \
+    }                                                                                              \
+    break;
     template <element::Type_t INPUT_ET>
     bool evaluate(const HostTensorPtr& input, const HostTensorPtr& output)
     {
         bool rc = true;
         switch (output->get_element_type())
         {
-        case element::Type_t::i64:
-            rc = evaluate_nonzero_execute<INPUT_ET, element::Type_t::i64>(input, output);
-            break;
-        case element::Type_t::i32:
-            rc = evaluate_nonzero_execute<INPUT_ET, element::Type_t::i32>(input, output);
-            break;
+            TYPE_OUT_CASE(i64, input, output);
+            TYPE_OUT_CASE(i32, input, output);
         default: rc = false; break;
         }
 
@@ -139,20 +142,13 @@ namespace nonzero
 
         switch (input->get_element_type())
         {
-            TYPE_CASE(i32)(input, output);
-            break;
-            TYPE_CASE(i64)(input, output);
-            break;
-            TYPE_CASE(u8)(input, output);
-            break;
-            TYPE_CASE(u32)(input, output);
-            break;
-            TYPE_CASE(u64)(input, output);
-            break;
-            TYPE_CASE(f16)(input, output);
-            break;
-            TYPE_CASE(f32)(input, output);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_nonzero, i32, input, output);
+            NGRAPH_TYPE_CASE(evaluate_nonzero, i64, input, output);
+            NGRAPH_TYPE_CASE(evaluate_nonzero, u8, input, output);
+            NGRAPH_TYPE_CASE(evaluate_nonzero, u32, input, output);
+            NGRAPH_TYPE_CASE(evaluate_nonzero, u64, input, output);
+            NGRAPH_TYPE_CASE(evaluate_nonzero, f16, input, output);
+            NGRAPH_TYPE_CASE(evaluate_nonzero, f32, input, output);
         default: rc = false; break;
         }
         return rc;
@@ -162,6 +158,6 @@ namespace nonzero
 bool op::v3::NonZero::evaluate(const HostTensorVector& outputs,
                                const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v3::NonZero::evaluate");
-    return nonzero::evaluate_nonzero(inputs[0], outputs[0]);
+    NGRAPH_OP_SCOPE(v3_NonZero_evaluate return nonzero::evaluate_nonzero(inputs[0], outputs[0]));
+    return false;
 }

--- a/ngraph/core/src/op/not.cpp
+++ b/ngraph/core/src/op/not.cpp
@@ -75,20 +75,13 @@ namespace notop
 
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(boolean)(arg0, out, count);
-            break;
-            TYPE_CASE(i32)(arg0, out, count);
-            break;
-            TYPE_CASE(i64)(arg0, out, count);
-            break;
-            TYPE_CASE(u32)(arg0, out, count);
-            break;
-            TYPE_CASE(u64)(arg0, out, count);
-            break;
-            TYPE_CASE(f16)(arg0, out, count);
-            break;
-            TYPE_CASE(f32)(arg0, out, count);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_not, boolean, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_not, i32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_not, i64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_not, u32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_not, u64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_not, f16, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_not, f32, arg0, out, count);
         default: rc = false; break;
         }
         return rc;
@@ -98,6 +91,7 @@ namespace notop
 bool op::v1::LogicalNot::evaluate(const HostTensorVector& outputs,
                                   const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::LogicalNot::evaluate");
-    return notop::evaluate_not(inputs[0], outputs[0], shape_size(get_output_shape(0)));
+    NGRAPH_OP_SCOPE(v1_LogicalNot_evaluate return notop::evaluate_not(
+        inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    return false;
 }

--- a/ngraph/core/src/op/not.cpp
+++ b/ngraph/core/src/op/not.cpp
@@ -91,7 +91,8 @@ namespace notop
 bool op::v1::LogicalNot::evaluate(const HostTensorVector& outputs,
                                   const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(v1_LogicalNot_evaluate return notop::evaluate_not(
-        inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    NGRAPH_OP_SCOPE(
+        v1_LogicalNot_evaluate,
+        return notop::evaluate_not(inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return false;
 }

--- a/ngraph/core/src/op/not_equal.cpp
+++ b/ngraph/core/src/op/not_equal.cpp
@@ -84,8 +84,9 @@ shared_ptr<Node> op::v1::NotEqual::clone_with_new_inputs(const OutputVector& new
 bool op::v1::NotEqual::evaluate(const HostTensorVector& outputs,
                                 const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(v1_NotEqual_evaluate return not_equalop::evaluate_not_equal(
-        inputs[0], inputs[1], outputs[0], get_autob()));
+    NGRAPH_OP_SCOPE(
+        v1_NotEqual_evaluate,
+        return not_equalop::evaluate_not_equal(inputs[0], inputs[1], outputs[0], get_autob()));
     return false;
 }
 

--- a/ngraph/core/src/op/not_equal.cpp
+++ b/ngraph/core/src/op/not_equal.cpp
@@ -50,20 +50,13 @@ namespace not_equalop
         out->set_broadcast(broadcast_spec, arg0, arg1, element::boolean);
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(boolean)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(i32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(i64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_not_equal, boolean, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_not_equal, i32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_not_equal, i64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_not_equal, u32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_not_equal, u64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_not_equal, f16, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_not_equal, f32, arg0, arg1, out, broadcast_spec);
         default: rc = false; break;
         }
         return rc;
@@ -91,8 +84,9 @@ shared_ptr<Node> op::v1::NotEqual::clone_with_new_inputs(const OutputVector& new
 bool op::v1::NotEqual::evaluate(const HostTensorVector& outputs,
                                 const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::NotEqual::evaluate");
-    return not_equalop::evaluate_not_equal(inputs[0], inputs[1], outputs[0], get_autob());
+    NGRAPH_OP_SCOPE(v1_NotEqual_evaluate return not_equalop::evaluate_not_equal(
+        inputs[0], inputs[1], outputs[0], get_autob()));
+    return false;
 }
 
 bool op::v1::NotEqual::visit_attributes(AttributeVisitor& visitor)

--- a/ngraph/core/src/op/or.cpp
+++ b/ngraph/core/src/op/or.cpp
@@ -83,6 +83,6 @@ bool op::v1::LogicalOr::evaluate(const HostTensorVector& outputs,
                                  const HostTensorVector& inputs) const
 {
     NGRAPH_OP_SCOPE(v1_LogicalOr_evaluate,
-                    return logor::evaluate_logor(inputs[0], inputs[1], outputs[0], get_autob()););
+                    return logor::evaluate_logor(inputs[0], inputs[1], outputs[0], get_autob()));
     return false;
 }

--- a/ngraph/core/src/op/or.cpp
+++ b/ngraph/core/src/op/or.cpp
@@ -66,20 +66,13 @@ namespace logor
         out->set_broadcast(broadcast_spec, arg0, arg1);
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(boolean)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(i32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(i64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_logor, boolean, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_logor, i32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_logor, i64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_logor, u32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_logor, u64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_logor, f16, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_logor, f32, arg0, arg1, out, broadcast_spec);
         default: rc = false; break;
         }
         return rc;
@@ -89,6 +82,7 @@ namespace logor
 bool op::v1::LogicalOr::evaluate(const HostTensorVector& outputs,
                                  const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::LogicalOr::evaluate");
-    return logor::evaluate_logor(inputs[0], inputs[1], outputs[0], get_autob());
+    NGRAPH_OP_SCOPE(v1_LogicalOr_evaluate,
+                    return logor::evaluate_logor(inputs[0], inputs[1], outputs[0], get_autob()););
+    return false;
 }

--- a/ngraph/core/src/op/pad.cpp
+++ b/ngraph/core/src/op/pad.cpp
@@ -15,6 +15,7 @@
 //*****************************************************************************
 
 #include "ngraph/op/pad.hpp"
+#include "itt.hpp"
 #include "ngraph/attribute_visitor.hpp"
 #include "ngraph/except.hpp"
 #include "ngraph/op/broadcast.hpp"
@@ -211,30 +212,26 @@ shared_ptr<Node> op::v1::Pad::clone_with_new_inputs(const OutputVector& new_args
 
 bool op::v1::Pad::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    const auto& data = inputs[0];
-    const auto elem_size = data->get_element_type().size();
+    NGRAPH_OP_SCOPE(
+        v1_Pad_evaluate, const auto& data = inputs[0];
+        const auto elem_size = data->get_element_type().size();
 
-    const char* pad_value = nullptr;
-    const std::vector<char> pad_zero_value(elem_size, 0);
-    if (get_input_size() == 4)
-    {
-        pad_value = inputs[3]->get_data_ptr<char>();
-    }
-    else
-    {
-        pad_value = pad_zero_value.data();
-    }
-    const auto& out = outputs[0];
+        const char* pad_value = nullptr;
+        const std::vector<char> pad_zero_value(elem_size, 0);
+        if (get_input_size() == 4) { pad_value = inputs[3]->get_data_ptr<char>(); } else {
+            pad_value = pad_zero_value.data();
+        } const auto& out = outputs[0];
 
-    ngraph::runtime::reference::pad(data->get_data_ptr<char>(),
-                                    pad_value,
-                                    out->get_data_ptr<char>(),
-                                    elem_size,
-                                    data->get_shape(),
-                                    out->get_shape(),
-                                    get_pads_begin(),
-                                    get_pads_end(),
-                                    get_pad_mode());
+        ngraph::runtime::reference::pad(data->get_data_ptr<char>(),
+                                        pad_value,
+                                        out->get_data_ptr<char>(),
+                                        elem_size,
+                                        data->get_shape(),
+                                        out->get_shape(),
+                                        get_pads_begin(),
+                                        get_pads_end(),
+                                        get_pad_mode());
 
-    return true;
+        return true);
+    return false;
 }

--- a/ngraph/core/src/op/pad.cpp
+++ b/ngraph/core/src/op/pad.cpp
@@ -210,15 +210,23 @@ shared_ptr<Node> op::v1::Pad::clone_with_new_inputs(const OutputVector& new_args
     }
 }
 
-bool op::v1::Pad::evaluate_pad(const HostTensorVector& outputs, const HostTensorVector& inputs) const {
+bool op::v1::Pad::evaluate_pad(const HostTensorVector& outputs,
+                               const HostTensorVector& inputs) const
+{
     const auto& data = inputs[0];
     const auto elem_size = data->get_element_type().size();
 
     const char* pad_value = nullptr;
     const std::vector<char> pad_zero_value(elem_size, 0);
-    if (get_input_size() == 4) { pad_value = inputs[3]->get_data_ptr<char>(); } else {
+    if (get_input_size() == 4)
+    {
+        pad_value = inputs[3]->get_data_ptr<char>();
+    }
+    else
+    {
         pad_value = pad_zero_value.data();
-    } const auto& out = outputs[0];
+    }
+    const auto& out = outputs[0];
 
     ngraph::runtime::reference::pad(data->get_data_ptr<char>(),
                                     pad_value,
@@ -235,7 +243,6 @@ bool op::v1::Pad::evaluate_pad(const HostTensorVector& outputs, const HostTensor
 
 bool op::v1::Pad::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(
-        v1_Pad_evaluate, return evaluate_pad(outputs, inputs));
+    NGRAPH_OP_SCOPE(v1_Pad_evaluate, return evaluate_pad(outputs, inputs));
     return false;
 }

--- a/ngraph/core/src/op/pad.cpp
+++ b/ngraph/core/src/op/pad.cpp
@@ -210,28 +210,32 @@ shared_ptr<Node> op::v1::Pad::clone_with_new_inputs(const OutputVector& new_args
     }
 }
 
+bool op::v1::Pad::evaluate_pad(const HostTensorVector& outputs, const HostTensorVector& inputs) const {
+    const auto& data = inputs[0];
+    const auto elem_size = data->get_element_type().size();
+
+    const char* pad_value = nullptr;
+    const std::vector<char> pad_zero_value(elem_size, 0);
+    if (get_input_size() == 4) { pad_value = inputs[3]->get_data_ptr<char>(); } else {
+        pad_value = pad_zero_value.data();
+    } const auto& out = outputs[0];
+
+    ngraph::runtime::reference::pad(data->get_data_ptr<char>(),
+                                    pad_value,
+                                    out->get_data_ptr<char>(),
+                                    elem_size,
+                                    data->get_shape(),
+                                    out->get_shape(),
+                                    get_pads_begin(),
+                                    get_pads_end(),
+                                    get_pad_mode());
+
+    return true;
+}
+
 bool op::v1::Pad::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
     NGRAPH_OP_SCOPE(
-        v1_Pad_evaluate, const auto& data = inputs[0];
-        const auto elem_size = data->get_element_type().size();
-
-        const char* pad_value = nullptr;
-        const std::vector<char> pad_zero_value(elem_size, 0);
-        if (get_input_size() == 4) { pad_value = inputs[3]->get_data_ptr<char>(); } else {
-            pad_value = pad_zero_value.data();
-        } const auto& out = outputs[0];
-
-        ngraph::runtime::reference::pad(data->get_data_ptr<char>(),
-                                        pad_value,
-                                        out->get_data_ptr<char>(),
-                                        elem_size,
-                                        data->get_shape(),
-                                        out->get_shape(),
-                                        get_pads_begin(),
-                                        get_pads_end(),
-                                        get_pad_mode());
-
-        return true);
+        v1_Pad_evaluate, return evaluate_pad(outputs, inputs));
     return false;
 }

--- a/ngraph/core/src/op/power.cpp
+++ b/ngraph/core/src/op/power.cpp
@@ -53,20 +53,13 @@ namespace power
         out->set_broadcast(broadcast_spec, arg0, arg1);
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(i32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(i64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(bf16)(arg0, arg1, out, broadcast_spec);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_power, i32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_power, i64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_power, u32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_power, u64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_power, f16, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_power, f32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_power, bf16, arg0, arg1, out, broadcast_spec);
         default: rc = false; break;
         }
         return rc;
@@ -93,6 +86,7 @@ shared_ptr<Node> op::v1::Power::clone_with_new_inputs(const OutputVector& new_ar
 
 bool op::v1::Power::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::Power::evaluate");
-    return power::evaluate_power(inputs[0], inputs[1], outputs[0], get_autob());
+    NGRAPH_OP_SCOPE(v1_Power_evaluate,
+                    return power::evaluate_power(inputs[0], inputs[1], outputs[0], get_autob()));
+    return false;
 }

--- a/ngraph/core/src/op/prelu.cpp
+++ b/ngraph/core/src/op/prelu.cpp
@@ -127,7 +127,7 @@ namespace prelu
 
 bool op::PRelu::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(PRelu_evaluate,
+    NGRAPH_OP_SCOPE(v0_PRelu_evaluate,
                     return prelu::evaluate_prelu(inputs[0], inputs[1], outputs[0]););
     return false;
 }

--- a/ngraph/core/src/op/prelu.cpp
+++ b/ngraph/core/src/op/prelu.cpp
@@ -115,14 +115,10 @@ namespace prelu
         bool rc = true;
         switch (arg->get_element_type())
         {
-            TYPE_CASE(i8)(arg, slope, out);
-            break;
-            TYPE_CASE(bf16)(arg, slope, out);
-            break;
-            TYPE_CASE(f16)(arg, slope, out);
-            break;
-            TYPE_CASE(f32)(arg, slope, out);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_prelu, i8, arg, slope, out);
+            NGRAPH_TYPE_CASE(evaluate_prelu, bf16, arg, slope, out);
+            NGRAPH_TYPE_CASE(evaluate_prelu, f16, arg, slope, out);
+            NGRAPH_TYPE_CASE(evaluate_prelu, f32, arg, slope, out);
         default: rc = false; break;
         }
         return rc;
@@ -131,6 +127,7 @@ namespace prelu
 
 bool op::PRelu::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::PRelu::evaluate");
-    return prelu::evaluate_prelu(inputs[0], inputs[1], outputs[0]);
+    NGRAPH_OP_SCOPE(PRelu_evaluate,
+                    return prelu::evaluate_prelu(inputs[0], inputs[1], outputs[0]););
+    return false;
 }

--- a/ngraph/core/src/op/prior_box.cpp
+++ b/ngraph/core/src/op/prior_box.cpp
@@ -175,22 +175,14 @@ namespace prior_box
         bool rc = true;
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(i8)(arg0, arg1, out, attrs);
-            break;
-            TYPE_CASE(i16)(arg0, arg1, out, attrs);
-            break;
-            TYPE_CASE(i32)(arg0, arg1, out, attrs);
-            break;
-            TYPE_CASE(i64)(arg0, arg1, out, attrs);
-            break;
-            TYPE_CASE(u8)(arg0, arg1, out, attrs);
-            break;
-            TYPE_CASE(u16)(arg0, arg1, out, attrs);
-            break;
-            TYPE_CASE(u32)(arg0, arg1, out, attrs);
-            break;
-            TYPE_CASE(u64)(arg0, arg1, out, attrs);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_prior_box, i8, arg0, arg1, out, attrs);
+            NGRAPH_TYPE_CASE(evaluate_prior_box, i16, arg0, arg1, out, attrs);
+            NGRAPH_TYPE_CASE(evaluate_prior_box, i32, arg0, arg1, out, attrs);
+            NGRAPH_TYPE_CASE(evaluate_prior_box, i64, arg0, arg1, out, attrs);
+            NGRAPH_TYPE_CASE(evaluate_prior_box, u8, arg0, arg1, out, attrs);
+            NGRAPH_TYPE_CASE(evaluate_prior_box, u16, arg0, arg1, out, attrs);
+            NGRAPH_TYPE_CASE(evaluate_prior_box, u32, arg0, arg1, out, attrs);
+            NGRAPH_TYPE_CASE(evaluate_prior_box, u64, arg0, arg1, out, attrs);
         default: rc = false; break;
         }
         return rc;
@@ -200,9 +192,11 @@ namespace prior_box
 bool op::v0::PriorBox::evaluate(const HostTensorVector& outputs,
                                 const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v0::PriorBox::evaluate");
+    NGRAPH_OP_SCOPE(v0_PriorBox_evaluate,
+                    // Todo (itikhono): enable the use of the reference implementation after
+                    // supporting constants as
+                    // outputs in plugins
+                    // return evaluate_prior_box(inputs[0], inputs[1], outputs[0], get_attrs());
+                    return false);
     return false;
-    // Todo (itikhono): enable the use of the reference implementation after supporting constants as
-    // outputs in plugins
-    // return evaluate_prior_box(inputs[0], inputs[1], outputs[0], get_attrs());
 }

--- a/ngraph/core/src/op/prior_box_clustered.cpp
+++ b/ngraph/core/src/op/prior_box_clustered.cpp
@@ -148,22 +148,14 @@ namespace prior_box_clustered
         bool rc = true;
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(i8)(arg0, arg1, out, attrs);
-            break;
-            TYPE_CASE(i16)(arg0, arg1, out, attrs);
-            break;
-            TYPE_CASE(i32)(arg0, arg1, out, attrs);
-            break;
-            TYPE_CASE(i64)(arg0, arg1, out, attrs);
-            break;
-            TYPE_CASE(u8)(arg0, arg1, out, attrs);
-            break;
-            TYPE_CASE(u16)(arg0, arg1, out, attrs);
-            break;
-            TYPE_CASE(u32)(arg0, arg1, out, attrs);
-            break;
-            TYPE_CASE(u64)(arg0, arg1, out, attrs);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_prior_box, i8, arg0, arg1, out, attrs);
+            NGRAPH_TYPE_CASE(evaluate_prior_box, i16, arg0, arg1, out, attrs);
+            NGRAPH_TYPE_CASE(evaluate_prior_box, i32, arg0, arg1, out, attrs);
+            NGRAPH_TYPE_CASE(evaluate_prior_box, i64, arg0, arg1, out, attrs);
+            NGRAPH_TYPE_CASE(evaluate_prior_box, u8, arg0, arg1, out, attrs);
+            NGRAPH_TYPE_CASE(evaluate_prior_box, u16, arg0, arg1, out, attrs);
+            NGRAPH_TYPE_CASE(evaluate_prior_box, u32, arg0, arg1, out, attrs);
+            NGRAPH_TYPE_CASE(evaluate_prior_box, u64, arg0, arg1, out, attrs);
         default: rc = false; break;
         }
         return rc;
@@ -173,9 +165,11 @@ namespace prior_box_clustered
 bool op::v0::PriorBoxClustered::evaluate(const HostTensorVector& outputs,
                                          const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v0::PriorBoxClustered::evaluate");
+    NGRAPH_OP_SCOPE(v0_PriorBoxClustered_evaluate,
+                    // Todo (itikhono): enable the use of the reference implementation after
+                    // supporting constants as
+                    // outputs in plugins
+                    // return evaluate_prior_box(inputs[0], inputs[1], outputs[0], get_attrs());
+                    return false);
     return false;
-    // Todo (itikhono): enable the use of the reference implementation after supporting constants as
-    // outputs in plugins
-    // return evaluate_prior_box(inputs[0], inputs[1], outputs[0], get_attrs());
 }

--- a/ngraph/core/src/op/reduce_l1.cpp
+++ b/ngraph/core/src/op/reduce_l1.cpp
@@ -67,11 +67,11 @@ namespace reduce_l1
         bool rc = true;
         switch (arg->get_element_type())
         {
-            NGRAPH_TYPE_CASE(evaluate_sum, i32, arg, out, axes, keep_dims);
-            NGRAPH_TYPE_CASE(evaluate_sum, i64, arg, out, axes, keep_dims);
-            NGRAPH_TYPE_CASE(evaluate_sum, bf16, arg, out, axes, keep_dims);
-            NGRAPH_TYPE_CASE(evaluate_sum, f16, arg, out, axes, keep_dims);
-            NGRAPH_TYPE_CASE(evaluate_sum, f32, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_reducel1_sum, i32, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_reducel1_sum, i64, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_reducel1_sum, bf16, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_reducel1_sum, f16, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_reducel1_sum, f32, arg, out, axes, keep_dims);
         default: rc = false; break;
         }
         return rc;

--- a/ngraph/core/src/op/reduce_l1.cpp
+++ b/ngraph/core/src/op/reduce_l1.cpp
@@ -67,16 +67,11 @@ namespace reduce_l1
         bool rc = true;
         switch (arg->get_element_type())
         {
-            TYPE_CASE(i32)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(i64)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(bf16)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(f16)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(f32)(arg, out, axes, keep_dims);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_sum, i32, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_sum, i64, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_sum, bf16, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_sum, f16, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_sum, f32, arg, out, axes, keep_dims);
         default: rc = false; break;
         }
         return rc;
@@ -86,6 +81,8 @@ namespace reduce_l1
 bool op::v4::ReduceL1::evaluate(const HostTensorVector& outputs,
                                 const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v4::ReduceL1::evaluate");
-    return reduce_l1::evaluate_sum(inputs[0], outputs[0], get_reduction_axes(), get_keep_dims());
+    NGRAPH_OP_SCOPE(v4_ReduceL1_evaluate,
+                    return reduce_l1::evaluate_sum(
+                        inputs[0], outputs[0], get_reduction_axes(), get_keep_dims()));
+    return false;
 }

--- a/ngraph/core/src/op/reduce_l2.cpp
+++ b/ngraph/core/src/op/reduce_l2.cpp
@@ -67,12 +67,9 @@ namespace reduce_l2
         bool rc = true;
         switch (arg->get_element_type())
         {
-            TYPE_CASE(bf16)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(f16)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(f32)(arg, out, axes, keep_dims);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_reduce_l2, bf16, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_reduce_l2, f16, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_reduce_l2, f32, arg, out, axes, keep_dims);
         default: rc = false; break;
         }
         return rc;
@@ -82,7 +79,8 @@ namespace reduce_l2
 bool op::v4::ReduceL2::evaluate(const HostTensorVector& outputs,
                                 const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v4::ReduceL2::evaluate");
-    return reduce_l2::evaluate_reduce_l2(
-        inputs[0], outputs[0], get_reduction_axes(), get_keep_dims());
+    NGRAPH_OP_SCOPE(v4_ReduceL2_evaluate,
+                    return reduce_l2::evaluate_reduce_l2(
+                        inputs[0], outputs[0], get_reduction_axes(), get_keep_dims()));
+    return false;
 }

--- a/ngraph/core/src/op/reduce_logical_and.cpp
+++ b/ngraph/core/src/op/reduce_logical_and.cpp
@@ -70,19 +70,13 @@ namespace
 bool op::v1::ReduceLogicalAnd::evaluate(const HostTensorVector& outputs,
                                         const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::ReduceLogicalAnd::evaluate");
+    NGRAPH_OP_SCOPE(v1_ReduceLogicalAnd_evaluate, const auto& data = inputs[0];
+                    const auto& axes = inputs[1];
+                    const auto& out = outputs[0];
 
-    const auto& data = inputs[0];
-    const auto& axes = inputs[1];
-    const auto& out = outputs[0];
-
-    if (data->get_element_type() != element::boolean ||
-        !axes->get_element_type().is_integral_number())
-    {
-        return false;
-    }
-    else
-    {
-        return evaluate_reduce_logical_and(data, axes, out, get_keep_dims());
-    }
+                    if (data->get_element_type() != element::boolean ||
+                        !axes->get_element_type().is_integral_number()) {
+                        return false;
+                    } return evaluate_reduce_logical_and(data, axes, out, get_keep_dims()));
+    return false;
 }

--- a/ngraph/core/src/op/reduce_logical_and.cpp
+++ b/ngraph/core/src/op/reduce_logical_and.cpp
@@ -48,7 +48,8 @@ namespace
                                      bool keep_dims)
     {
         if (data->get_element_type() != element::boolean ||
-            !axes->get_element_type().is_integral_number()) {
+            !axes->get_element_type().is_integral_number())
+        {
             return false;
         }
         try

--- a/ngraph/core/src/op/reduce_logical_and.cpp
+++ b/ngraph/core/src/op/reduce_logical_and.cpp
@@ -47,6 +47,10 @@ namespace
                                      const HostTensorPtr& out,
                                      bool keep_dims)
     {
+        if (data->get_element_type() != element::boolean ||
+            !axes->get_element_type().is_integral_number()) {
+            return false;
+        }
         try
         {
             const AxisSet reduction_axes = eval::extract_reduction_axes(axes, "ReduceLogicalAnd");
@@ -73,10 +77,6 @@ bool op::v1::ReduceLogicalAnd::evaluate(const HostTensorVector& outputs,
     NGRAPH_OP_SCOPE(v1_ReduceLogicalAnd_evaluate, const auto& data = inputs[0];
                     const auto& axes = inputs[1];
                     const auto& out = outputs[0];
-
-                    if (data->get_element_type() != element::boolean ||
-                        !axes->get_element_type().is_integral_number()) {
-                        return false;
-                    } return evaluate_reduce_logical_and(data, axes, out, get_keep_dims()));
+                    return evaluate_reduce_logical_and(data, axes, out, get_keep_dims()));
     return false;
 }

--- a/ngraph/core/src/op/reduce_logical_or.cpp
+++ b/ngraph/core/src/op/reduce_logical_or.cpp
@@ -70,19 +70,13 @@ namespace
 bool op::v1::ReduceLogicalOr::evaluate(const HostTensorVector& outputs,
                                        const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::ReduceLogicalOr::evaluate");
+    NGRAPH_OP_SCOPE(v1_ReduceLogicalOr_evaluate, const auto& data = inputs[0];
+                    const auto& axes = inputs[1];
+                    const auto& out = outputs[0];
 
-    const auto& data = inputs[0];
-    const auto& axes = inputs[1];
-    const auto& out = outputs[0];
-
-    if (data->get_element_type() != element::boolean ||
-        !axes->get_element_type().is_integral_number())
-    {
-        return false;
-    }
-    else
-    {
-        return evaluate_reduce_logical_or(data, axes, out, get_keep_dims());
-    }
+                    if (data->get_element_type() != element::boolean ||
+                        !axes->get_element_type().is_integral_number()) {
+                        return false;
+                    } return evaluate_reduce_logical_or(data, axes, out, get_keep_dims()));
+    return false;
 }

--- a/ngraph/core/src/op/reduce_logical_or.cpp
+++ b/ngraph/core/src/op/reduce_logical_or.cpp
@@ -47,6 +47,10 @@ namespace
                                     const HostTensorPtr& out,
                                     bool keep_dims)
     {
+        if (data->get_element_type() != element::boolean ||
+            !axes->get_element_type().is_integral_number()) {
+            return false;
+        }
         try
         {
             const AxisSet reduction_axes = eval::extract_reduction_axes(axes, "ReduceLogicalOr");
@@ -73,10 +77,6 @@ bool op::v1::ReduceLogicalOr::evaluate(const HostTensorVector& outputs,
     NGRAPH_OP_SCOPE(v1_ReduceLogicalOr_evaluate, const auto& data = inputs[0];
                     const auto& axes = inputs[1];
                     const auto& out = outputs[0];
-
-                    if (data->get_element_type() != element::boolean ||
-                        !axes->get_element_type().is_integral_number()) {
-                        return false;
-                    } return evaluate_reduce_logical_or(data, axes, out, get_keep_dims()));
+                    return evaluate_reduce_logical_or(data, axes, out, get_keep_dims()));
     return false;
 }

--- a/ngraph/core/src/op/reduce_logical_or.cpp
+++ b/ngraph/core/src/op/reduce_logical_or.cpp
@@ -48,7 +48,8 @@ namespace
                                     bool keep_dims)
     {
         if (data->get_element_type() != element::boolean ||
-            !axes->get_element_type().is_integral_number()) {
+            !axes->get_element_type().is_integral_number())
+        {
             return false;
         }
         try

--- a/ngraph/core/src/op/reduce_mean.cpp
+++ b/ngraph/core/src/op/reduce_mean.cpp
@@ -63,18 +63,12 @@ namespace mean
         bool rc = true;
         switch (arg->get_element_type())
         {
-            TYPE_CASE(i32)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(i64)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(u32)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(u64)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(f16)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(f32)(arg, out, axes, keep_dims);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_mean, i32, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_mean, i64, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_mean, u32, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_mean, u64, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_mean, f16, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_mean, f32, arg, out, axes, keep_dims);
         default: rc = false; break;
         }
         return rc;
@@ -84,6 +78,8 @@ namespace mean
 bool op::v1::ReduceMean::evaluate(const HostTensorVector& outputs,
                                   const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::ReduceMean::evaluate");
-    return mean::evaluate_mean(inputs[0], outputs[0], get_reduction_axes(), get_keep_dims());
+    NGRAPH_OP_SCOPE(
+        v1_ReduceMean_evaluate,
+        return mean::evaluate_mean(inputs[0], outputs[0], get_reduction_axes(), get_keep_dims()));
+    return false;
 }

--- a/ngraph/core/src/op/reduce_prod.cpp
+++ b/ngraph/core/src/op/reduce_prod.cpp
@@ -67,18 +67,12 @@ namespace reduce_prod
         bool rc = true;
         switch (arg->get_element_type())
         {
-            TYPE_CASE(i32)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(i64)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(u32)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(u64)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(f16)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(f32)(arg, out, axes, keep_dims);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_product, i32, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_product, i64, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_product, u32, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_product, u64, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_product, f16, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_product, f32, arg, out, axes, keep_dims);
         default: rc = false; break;
         }
         return rc;
@@ -88,7 +82,8 @@ namespace reduce_prod
 bool op::v1::ReduceProd::evaluate(const HostTensorVector& outputs,
                                   const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::ReduceProd::evaluate");
-    return reduce_prod::evaluate_product(
-        inputs[0], outputs[0], get_reduction_axes(), get_keep_dims());
+    NGRAPH_OP_SCOPE(v1_ReduceProd_evaluate,
+                    return reduce_prod::evaluate_product(
+                        inputs[0], outputs[0], get_reduction_axes(), get_keep_dims()));
+    return false;
 }

--- a/ngraph/core/src/op/reduce_sum.cpp
+++ b/ngraph/core/src/op/reduce_sum.cpp
@@ -68,18 +68,12 @@ namespace reduce_sum
         bool rc = true;
         switch (arg->get_element_type())
         {
-            TYPE_CASE(i32)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(i64)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(u32)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(u64)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(f16)(arg, out, axes, keep_dims);
-            break;
-            TYPE_CASE(f32)(arg, out, axes, keep_dims);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_sum, i32, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_sum, i64, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_sum, u32, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_sum, u64, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_sum, f16, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_sum, f32, arg, out, axes, keep_dims);
         default: rc = false; break;
         }
         return rc;
@@ -89,6 +83,8 @@ namespace reduce_sum
 bool op::v1::ReduceSum::evaluate(const HostTensorVector& outputs,
                                  const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::ReduceSum::evaluate");
-    return reduce_sum::evaluate_sum(inputs[0], outputs[0], get_reduction_axes(), get_keep_dims());
+    NGRAPH_OP_SCOPE(v1_ReduceSum_evaluate,
+                    return reduce_sum::evaluate_sum(
+                        inputs[0], outputs[0], get_reduction_axes(), get_keep_dims()));
+    return false;
 }

--- a/ngraph/core/src/op/reduce_sum.cpp
+++ b/ngraph/core/src/op/reduce_sum.cpp
@@ -68,12 +68,12 @@ namespace reduce_sum
         bool rc = true;
         switch (arg->get_element_type())
         {
-            NGRAPH_TYPE_CASE(evaluate_sum, i32, arg, out, axes, keep_dims);
-            NGRAPH_TYPE_CASE(evaluate_sum, i64, arg, out, axes, keep_dims);
-            NGRAPH_TYPE_CASE(evaluate_sum, u32, arg, out, axes, keep_dims);
-            NGRAPH_TYPE_CASE(evaluate_sum, u64, arg, out, axes, keep_dims);
-            NGRAPH_TYPE_CASE(evaluate_sum, f16, arg, out, axes, keep_dims);
-            NGRAPH_TYPE_CASE(evaluate_sum, f32, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_reduce_sum, i32, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_reduce_sum, i64, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_reduce_sum, u32, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_reduce_sum, u64, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_reduce_sum, f16, arg, out, axes, keep_dims);
+            NGRAPH_TYPE_CASE(evaluate_reduce_sum, f32, arg, out, axes, keep_dims);
         default: rc = false; break;
         }
         return rc;

--- a/ngraph/core/src/op/relu.cpp
+++ b/ngraph/core/src/op/relu.cpp
@@ -72,7 +72,7 @@ namespace relu
 bool op::Relu::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
     NGRAPH_OP_SCOPE(
-        Relu_evaluate,
+        v0_Relu_evaluate,
         return relu::evaluate_relu(inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return false;
 }

--- a/ngraph/core/src/op/relu.cpp
+++ b/ngraph/core/src/op/relu.cpp
@@ -56,20 +56,13 @@ namespace relu
 
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(boolean)(arg0, out, count);
-            break;
-            TYPE_CASE(i32)(arg0, out, count);
-            break;
-            TYPE_CASE(i64)(arg0, out, count);
-            break;
-            TYPE_CASE(u32)(arg0, out, count);
-            break;
-            TYPE_CASE(u64)(arg0, out, count);
-            break;
-            TYPE_CASE(f16)(arg0, out, count);
-            break;
-            TYPE_CASE(f32)(arg0, out, count);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_relu, boolean, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_relu, i32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_relu, i64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_relu, u32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_relu, u64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_relu, f16, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_relu, f32, arg0, out, count);
         default: rc = false; break;
         }
         return rc;
@@ -78,8 +71,10 @@ namespace relu
 
 bool op::Relu::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::Relu::evaluate");
-    return relu::evaluate_relu(inputs[0], outputs[0], shape_size(get_output_shape(0)));
+    NGRAPH_OP_SCOPE(
+        Relu_evaluate,
+        return relu::evaluate_relu(inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    return false;
 }
 
 bool op::Relu::visit_attributes(AttributeVisitor& visitor)

--- a/ngraph/core/src/op/reshape.cpp
+++ b/ngraph/core/src/op/reshape.cpp
@@ -27,7 +27,7 @@
 using namespace std;
 using namespace ngraph;
 
-namespace
+namespace reshapeop
 {
     bool evaluate_reshape(const HostTensorPtr& arg0,
                           const HostTensorPtr& out,
@@ -227,127 +227,120 @@ shared_ptr<Node> op::v1::Reshape::clone_with_new_inputs(const OutputVector& new_
     return make_shared<v1::Reshape>(new_args.at(0), new_args.at(1), m_special_zero);
 }
 
+#define COMPUTE_OUT_SHAPE_CASE(a, ...)                                                             \
+    case element::Type_t::a:                                                                       \
+    {                                                                                              \
+        NGRAPH_OP_SCOPE(OV_CC_CAT3(compute_reshape_out_shape, _, a),                               \
+                        reshapeop::compute_output_shape<element::Type_t::a>(__VA_ARGS__));         \
+    }                                                                                              \
+    break;
+
 bool op::v1::Reshape::evaluate(const HostTensorVector& outputs,
                                const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::Reshape::evaluate");
+    NGRAPH_OP_SCOPE(
+        v1_Reshape_evaluate,
+        // infer and set output shape if the output shape contain -1
+        // and zero value dimension
+        size_t output_rank = inputs[1]->get_shape()[0];
+        std::vector<int64_t> out_shape_val;
 
-    // infer and set output shape if the output shape contain -1
-    // and zero value dimension
-    size_t output_rank = inputs[1]->get_shape()[0];
-    std::vector<int64_t> out_shape_val;
-
-    switch (inputs[1]->get_element_type())
-    {
-    case element::Type_t::i8:
-        compute_output_shape<element::Type_t::i8>(inputs[1], out_shape_val);
-        break;
-    case element::Type_t::i16:
-        compute_output_shape<element::Type_t::i16>(inputs[1], out_shape_val);
-        break;
-    case element::Type_t::i32:
-        compute_output_shape<element::Type_t::i32>(inputs[1], out_shape_val);
-        break;
-    case element::Type_t::i64:
-        compute_output_shape<element::Type_t::i64>(inputs[1], out_shape_val);
-        break;
-    case element::Type_t::u8:
-        compute_output_shape<element::Type_t::u8>(inputs[1], out_shape_val);
-        break;
-    case element::Type_t::u16:
-        compute_output_shape<element::Type_t::u16>(inputs[1], out_shape_val);
-        break;
-    case element::Type_t::u32:
-        compute_output_shape<element::Type_t::u32>(inputs[1], out_shape_val);
-        break;
-    case element::Type_t::u64:
-        compute_output_shape<element::Type_t::u64>(inputs[1], out_shape_val);
-        break;
-    default: throw ngraph_error("shape_pattern element type is not integral data type");
-    }
-
-    NODE_VALIDATION_CHECK(
-        this,
-        std::none_of(out_shape_val.begin(), out_shape_val.end(), [](int64_t v) { return v < -1; }),
-        "Dim size cannot be less than -1 ");
-
-    int zero_dims =
-        std::count_if(out_shape_val.begin(), out_shape_val.end(), [](int64_t v) { return v == 0; });
-    int negative_dims = std::count_if(
-        out_shape_val.begin(), out_shape_val.end(), [](int64_t v) { return v == -1; });
-    NODE_VALIDATION_CHECK(
-        this, negative_dims <= 1, "More than one dimension has size of -1 (", negative_dims, ")");
-
-    Shape output_shape;
-    std::copy(out_shape_val.begin(), out_shape_val.end(), std::back_inserter(output_shape));
-    if (!(zero_dims && m_special_zero) && !negative_dims)
-    {
-        if (get_input_partial_shape(0).is_static())
-        {
-            NODE_VALIDATION_CHECK(this,
-                                  shape_size(inputs[0]->get_shape()) == shape_size(output_shape),
-                                  "Requested output shape ",
-                                  output_shape,
-                                  " is incompatible with input shape ",
-                                  get_input_shape(0));
-        }
-        outputs[0]->set_shape(output_shape);
-    }
-    else
-    {
-        size_t output_elements = 1;
-        int negative_dim = -1;
-
-        auto input_shape = inputs[0]->get_shape();
-        size_t input_elements = shape_size(input_shape);
-
-        // compute the output shape
-        for (size_t i = 0; i < output_rank; i++)
-        {
-            if (out_shape_val[i] == 0 && m_special_zero)
-            {
-                // Copy input_shape[i] for zero values
-                NODE_VALIDATION_CHECK(
-                    this, i < input_shape.size(), "'0' dimension is out of range");
-                output_shape[i] = input_shape[i];
-                output_elements *= input_shape[i];
-            }
-            else if (out_shape_val[i] == -1)
-            {
-                negative_dim = i;
-            }
-            else
-            {
-                output_elements *= out_shape_val[i];
-            }
+        switch (inputs[1]->get_element_type()) {
+            COMPUTE_OUT_SHAPE_CASE(i8, inputs[1], out_shape_val);
+            COMPUTE_OUT_SHAPE_CASE(i16, inputs[1], out_shape_val);
+            COMPUTE_OUT_SHAPE_CASE(i32, inputs[1], out_shape_val);
+            COMPUTE_OUT_SHAPE_CASE(i64, inputs[1], out_shape_val);
+            COMPUTE_OUT_SHAPE_CASE(u8, inputs[1], out_shape_val);
+            COMPUTE_OUT_SHAPE_CASE(u16, inputs[1], out_shape_val);
+            COMPUTE_OUT_SHAPE_CASE(u32, inputs[1], out_shape_val);
+            COMPUTE_OUT_SHAPE_CASE(u64, inputs[1], out_shape_val);
+        default: throw ngraph_error("shape_pattern element type is not integral data type");
         }
 
-        if (negative_dim != -1)
-        {
-            // Infer size such that number of output elements matches
-            // input elements
-            if (output_elements == 0)
+        NODE_VALIDATION_CHECK(this,
+                              std::none_of(out_shape_val.begin(),
+                                           out_shape_val.end(),
+                                           [](int64_t v) { return v < -1; }),
+                              "Dim size cannot be less than -1 ");
+
+        int zero_dims = std::count_if(
+            out_shape_val.begin(), out_shape_val.end(), [](int64_t v) { return v == 0; });
+        int negative_dims = std::count_if(
+            out_shape_val.begin(), out_shape_val.end(), [](int64_t v) { return v == -1; });
+        NODE_VALIDATION_CHECK(this,
+                              negative_dims <= 1,
+                              "More than one dimension has size of -1 (",
+                              negative_dims,
+                              ")");
+
+        Shape output_shape;
+        std::copy(out_shape_val.begin(), out_shape_val.end(), std::back_inserter(output_shape));
+        if (!(zero_dims && m_special_zero) && !negative_dims) {
+            if (get_input_partial_shape(0).is_static())
             {
                 NODE_VALIDATION_CHECK(this,
-                                      input_elements == 0,
-                                      "Cannot infer '-1' dimension with zero-size output "
-                                      "dimension unless at least one input dimension is "
-                                      "also zero-size");
-                output_shape[negative_dim] = 0;
+                                      shape_size(inputs[0]->get_shape()) ==
+                                          shape_size(output_shape),
+                                      "Requested output shape ",
+                                      output_shape,
+                                      " is incompatible with input shape ",
+                                      get_input_shape(0));
             }
-            else
+            outputs[0]->set_shape(output_shape);
+        } else {
+            size_t output_elements = 1;
+            int negative_dim = -1;
+
+            auto input_shape = inputs[0]->get_shape();
+            size_t input_elements = shape_size(input_shape);
+
+            // compute the output shape
+            for (size_t i = 0; i < output_rank; i++)
             {
-                NODE_VALIDATION_CHECK(
-                    this,
-                    input_elements % output_elements == 0,
-                    "Non-'-1' output dimensions do not evenly divide the input dimensions");
-                output_shape[negative_dim] = input_elements / output_elements;
+                if (out_shape_val[i] == 0 && m_special_zero)
+                {
+                    // Copy input_shape[i] for zero values
+                    NODE_VALIDATION_CHECK(
+                        this, i < input_shape.size(), "'0' dimension is out of range");
+                    output_shape[i] = input_shape[i];
+                    output_elements *= input_shape[i];
+                }
+                else if (out_shape_val[i] == -1)
+                {
+                    negative_dim = i;
+                }
+                else
+                {
+                    output_elements *= out_shape_val[i];
+                }
             }
-        }
-        outputs[0]->set_shape(output_shape);
-    }
-    const AxisVector order = get_default_order(inputs[0]->get_shape());
-    return evaluate_reshape(inputs[0], outputs[0], order);
+
+            if (negative_dim != -1)
+            {
+                // Infer size such that number of output elements matches
+                // input elements
+                if (output_elements == 0)
+                {
+                    NODE_VALIDATION_CHECK(this,
+                                          input_elements == 0,
+                                          "Cannot infer '-1' dimension with zero-size output "
+                                          "dimension unless at least one input dimension is "
+                                          "also zero-size");
+                    output_shape[negative_dim] = 0;
+                }
+                else
+                {
+                    NODE_VALIDATION_CHECK(
+                        this,
+                        input_elements % output_elements == 0,
+                        "Non-'-1' output dimensions do not evenly divide the input dimensions");
+                    output_shape[negative_dim] = input_elements / output_elements;
+                }
+            }
+            outputs[0]->set_shape(output_shape);
+        } const AxisVector order = get_default_order(inputs[0]->get_shape());
+        return reshapeop::evaluate_reshape(inputs[0], outputs[0], order));
+    return false;
 }
 
 bool op::v1::Reshape::constant_fold(OutputVector& output_values, const OutputVector& inputs_values)

--- a/ngraph/core/src/op/reshape.cpp
+++ b/ngraph/core/src/op/reshape.cpp
@@ -243,7 +243,8 @@ bool op::v1::Reshape::evaluate_reshape(const HostTensorVector& outputs,
     size_t output_rank = inputs[1]->get_shape()[0];
     std::vector<int64_t> out_shape_val;
 
-    switch (inputs[1]->get_element_type()) {
+    switch (inputs[1]->get_element_type())
+    {
         COMPUTE_OUT_SHAPE_CASE(i8, inputs[1], out_shape_val);
         COMPUTE_OUT_SHAPE_CASE(i16, inputs[1], out_shape_val);
         COMPUTE_OUT_SHAPE_CASE(i32, inputs[1], out_shape_val);
@@ -255,37 +256,35 @@ bool op::v1::Reshape::evaluate_reshape(const HostTensorVector& outputs,
     default: throw ngraph_error("shape_pattern element type is not integral data type");
     }
 
-    NODE_VALIDATION_CHECK(this,
-                          std::none_of(out_shape_val.begin(),
-                                       out_shape_val.end(),
-                                       [](int64_t v) { return v < -1; }),
-                          "Dim size cannot be less than -1 ");
+    NODE_VALIDATION_CHECK(
+        this,
+        std::none_of(out_shape_val.begin(), out_shape_val.end(), [](int64_t v) { return v < -1; }),
+        "Dim size cannot be less than -1 ");
 
-    int zero_dims = std::count_if(
-                                  out_shape_val.begin(), out_shape_val.end(), [](int64_t v) { return v == 0; });
+    int zero_dims =
+        std::count_if(out_shape_val.begin(), out_shape_val.end(), [](int64_t v) { return v == 0; });
     int negative_dims = std::count_if(
-                                      out_shape_val.begin(), out_shape_val.end(), [](int64_t v) { return v == -1; });
-    NODE_VALIDATION_CHECK(this,
-                          negative_dims <= 1,
-                          "More than one dimension has size of -1 (",
-                          negative_dims,
-                          ")");
+        out_shape_val.begin(), out_shape_val.end(), [](int64_t v) { return v == -1; });
+    NODE_VALIDATION_CHECK(
+        this, negative_dims <= 1, "More than one dimension has size of -1 (", negative_dims, ")");
 
     Shape output_shape;
     std::copy(out_shape_val.begin(), out_shape_val.end(), std::back_inserter(output_shape));
-    if (!(zero_dims && m_special_zero) && !negative_dims) {
+    if (!(zero_dims && m_special_zero) && !negative_dims)
+    {
         if (get_input_partial_shape(0).is_static())
         {
             NODE_VALIDATION_CHECK(this,
-                                  shape_size(inputs[0]->get_shape()) ==
-                                  shape_size(output_shape),
+                                  shape_size(inputs[0]->get_shape()) == shape_size(output_shape),
                                   "Requested output shape ",
                                   output_shape,
                                   " is incompatible with input shape ",
                                   get_input_shape(0));
         }
         outputs[0]->set_shape(output_shape);
-    } else {
+    }
+    else
+    {
         size_t output_elements = 1;
         int negative_dim = -1;
 
@@ -299,7 +298,7 @@ bool op::v1::Reshape::evaluate_reshape(const HostTensorVector& outputs,
             {
                 // Copy input_shape[i] for zero values
                 NODE_VALIDATION_CHECK(
-                                      this, i < input_shape.size(), "'0' dimension is out of range");
+                    this, i < input_shape.size(), "'0' dimension is out of range");
                 output_shape[i] = input_shape[i];
                 output_elements *= input_shape[i];
             }
@@ -329,23 +328,22 @@ bool op::v1::Reshape::evaluate_reshape(const HostTensorVector& outputs,
             else
             {
                 NODE_VALIDATION_CHECK(
-                                      this,
-                                      input_elements % output_elements == 0,
-                                      "Non-'-1' output dimensions do not evenly divide the input dimensions");
+                    this,
+                    input_elements % output_elements == 0,
+                    "Non-'-1' output dimensions do not evenly divide the input dimensions");
                 output_shape[negative_dim] = input_elements / output_elements;
             }
         }
         outputs[0]->set_shape(output_shape);
-    } const AxisVector order = get_default_order(inputs[0]->get_shape());
+    }
+    const AxisVector order = get_default_order(inputs[0]->get_shape());
     return reshapeop::evaluate_reshape(inputs[0], outputs[0], order);
 }
 
 bool op::v1::Reshape::evaluate(const HostTensorVector& outputs,
                                const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(
-        v1_Reshape_evaluate,
-        return evaluate_reshape(outputs, inputs));
+    NGRAPH_OP_SCOPE(v1_Reshape_evaluate, return evaluate_reshape(outputs, inputs));
     return false;
 }
 

--- a/ngraph/core/src/op/result.cpp
+++ b/ngraph/core/src/op/result.cpp
@@ -58,12 +58,12 @@ shared_ptr<Node> op::Result::clone_with_new_inputs(const OutputVector& new_args)
 
 bool op::Result::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::Result::evaluate");
-    outputs[0]->set_unary(inputs[0]);
-    void* output = outputs[0]->get_data_ptr();
-    void* input = inputs[0]->get_data_ptr();
-    memcpy(output, input, outputs[0]->get_size_in_bytes());
-    return true;
+    NGRAPH_OP_SCOPE(Result_evaluate, outputs[0]->set_unary(inputs[0]);
+                    void* output = outputs[0]->get_data_ptr();
+                    void* input = inputs[0]->get_data_ptr();
+                    memcpy(output, input, outputs[0]->get_size_in_bytes());
+                    return true);
+    return false;
 }
 
 bool op::Result::constant_fold(OutputVector& output_values, const OutputVector& inputs_values)

--- a/ngraph/core/src/op/reverse.cpp
+++ b/ngraph/core/src/op/reverse.cpp
@@ -171,8 +171,10 @@ namespace reverseop
 bool op::v1::Reverse::evaluate_reverse(const HostTensorVector& outputs,
                                        const HostTensorVector& inputs) const
 {
-    AxisSet axes{}; size_t axes_rank = inputs[1]->get_element_count();
-    if (get_mode() == op::v1::Reverse::Mode::INDEX) {
+    AxisSet axes{};
+    size_t axes_rank = inputs[1]->get_element_count();
+    if (get_mode() == op::v1::Reverse::Mode::INDEX)
+    {
         switch (inputs[1]->get_element_type())
         {
             GET_AXES(i8, axes, inputs[1]);
@@ -185,7 +187,8 @@ bool op::v1::Reverse::evaluate_reverse(const HostTensorVector& outputs,
             GET_AXES(u64, axes, inputs[1]);
         default: NGRAPH_CHECK(false, "Not supported axes type", inputs[1]->get_element_type());
         }
-    } else // Mode::MASK
+    }
+    else // Mode::MASK
     {
         auto axes_mask = inputs[1]->get_data_ptr<bool>();
         for (size_t i = 0; i < inputs[1]->get_element_count(); ++i)
@@ -195,21 +198,20 @@ bool op::v1::Reverse::evaluate_reverse(const HostTensorVector& outputs,
                 axes.emplace(i);
             }
         }
-    } runtime::reference::reverse(inputs[0]->get_data_ptr<const char>(),
-                                  outputs[0]->get_data_ptr<char>(),
-                                  inputs[0]->get_shape(),
-                                  outputs[0]->get_shape(),
-                                  axes,
-                                  inputs[0]->get_element_type().size());
+    }
+    runtime::reference::reverse(inputs[0]->get_data_ptr<const char>(),
+                                outputs[0]->get_data_ptr<char>(),
+                                inputs[0]->get_shape(),
+                                outputs[0]->get_shape(),
+                                axes,
+                                inputs[0]->get_element_type().size());
     return true;
 }
 
 bool op::v1::Reverse::evaluate(const HostTensorVector& outputs,
                                const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(
-        v1_Reverse_evaluate,
-        return evaluate_reverse(outputs, inputs));
+    NGRAPH_OP_SCOPE(v1_Reverse_evaluate, return evaluate_reverse(outputs, inputs));
     return false;
 }
 

--- a/ngraph/core/src/op/round.cpp
+++ b/ngraph/core/src/op/round.cpp
@@ -58,30 +58,18 @@ namespace roundop
 
         switch (arg0->get_element_type())
         {
-            COPY_TENSOR(boolean)(arg0, out, count);
-            break;
-            COPY_TENSOR(i8)(arg0, out, count);
-            break;
-            COPY_TENSOR(i16)(arg0, out, count);
-            break;
-            COPY_TENSOR(i32)(arg0, out, count);
-            break;
-            COPY_TENSOR(i64)(arg0, out, count);
-            break;
-            COPY_TENSOR(u8)(arg0, out, count);
-            break;
-            COPY_TENSOR(u16)(arg0, out, count);
-            break;
-            COPY_TENSOR(u32)(arg0, out, count);
-            break;
-            COPY_TENSOR(u64)(arg0, out, count);
-            break;
-            TYPE_CASE(f16)(arg0, out, count, mode);
-            break;
-            TYPE_CASE(f32)(arg0, out, count, mode);
-            break;
-            TYPE_CASE(bf16)(arg0, out, count, mode);
-            break;
+            NGRAPH_COPY_TENSOR(evaluate_round, boolean, arg0, out, count);
+            NGRAPH_COPY_TENSOR(evaluate_round, i8, arg0, out, count);
+            NGRAPH_COPY_TENSOR(evaluate_round, i16, arg0, out, count);
+            NGRAPH_COPY_TENSOR(evaluate_round, i32, arg0, out, count);
+            NGRAPH_COPY_TENSOR(evaluate_round, i64, arg0, out, count);
+            NGRAPH_COPY_TENSOR(evaluate_round, u8, arg0, out, count);
+            NGRAPH_COPY_TENSOR(evaluate_round, u16, arg0, out, count);
+            NGRAPH_COPY_TENSOR(evaluate_round, u32, arg0, out, count);
+            NGRAPH_COPY_TENSOR(evaluate_round, u64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_round, f16, arg0, out, count, mode);
+            NGRAPH_TYPE_CASE(evaluate_round, f32, arg0, out, count, mode);
+            NGRAPH_TYPE_CASE(evaluate_round, bf16, arg0, out, count, mode);
         default: rc = false; break;
         }
         return rc;
@@ -117,9 +105,9 @@ shared_ptr<Node> op::v5::Round::clone_with_new_inputs(const OutputVector& new_ar
 
 bool op::v5::Round::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v5::Round::evaluate");
-    return roundop::evaluate_round(
-        inputs[0], outputs[0], shape_size(get_output_shape(0)), get_mode());
+    NGRAPH_OP_SCOPE(v5_Round_evaluate return roundop::evaluate_round(
+        inputs[0], outputs[0], shape_size(get_output_shape(0)), get_mode()));
+    return false;
 }
 
 namespace ngraph

--- a/ngraph/core/src/op/round.cpp
+++ b/ngraph/core/src/op/round.cpp
@@ -105,8 +105,9 @@ shared_ptr<Node> op::v5::Round::clone_with_new_inputs(const OutputVector& new_ar
 
 bool op::v5::Round::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(v5_Round_evaluate return roundop::evaluate_round(
-        inputs[0], outputs[0], shape_size(get_output_shape(0)), get_mode()));
+    NGRAPH_OP_SCOPE(v5_Round_evaluate,
+                    return roundop::evaluate_round(
+                        inputs[0], outputs[0], shape_size(get_output_shape(0)), get_mode()));
     return false;
 }
 

--- a/ngraph/core/src/op/scatter_elements_update.cpp
+++ b/ngraph/core/src/op/scatter_elements_update.cpp
@@ -162,8 +162,13 @@ namespace scatter_element_update
         return true;
     }
 
-#define TYPE_AXS_CASE(a)                                                                           \
-    case element::Type_t::a: rc = evaluate<DT, IT, element::Type_t::a>
+#define TYPE_AXS_CASE(a, ...)                                                                      \
+    case element::Type_t::a:                                                                       \
+    {                                                                                              \
+        NGRAPH_OP_SCOPE(OV_CC_CAT3(scatter_element_update_axs, _, a),                              \
+                        rc = evaluate<DT, IT, element::Type_t::a>(__VA_ARGS__));                   \
+    }                                                                                              \
+    break;
 
     template <element::Type_t DT, element::Type_t IT>
     bool evaluate(const HostTensorPtr& arg0,
@@ -180,29 +185,26 @@ namespace scatter_element_update
 
         switch (axis_type)
         {
-            TYPE_AXS_CASE(i8)(arg0, arg1, arg2, arg3, out, normalized_axis);
-            break;
-            TYPE_AXS_CASE(i16)(arg0, arg1, arg2, arg3, out, normalized_axis);
-            break;
-            TYPE_AXS_CASE(i32)(arg0, arg1, arg2, arg3, out, normalized_axis);
-            break;
-            TYPE_AXS_CASE(i64)(arg0, arg1, arg2, arg3, out, normalized_axis);
-            break;
-            TYPE_AXS_CASE(u8)(arg0, arg1, arg2, arg3, out, normalized_axis);
-            break;
-            TYPE_AXS_CASE(u16)(arg0, arg1, arg2, arg3, out, normalized_axis);
-            break;
-            TYPE_AXS_CASE(u32)(arg0, arg1, arg2, arg3, out, normalized_axis);
-            break;
-            TYPE_AXS_CASE(u64)(arg0, arg1, arg2, arg3, out, normalized_axis);
-            break;
+            TYPE_AXS_CASE(i8, arg0, arg1, arg2, arg3, out, normalized_axis);
+            TYPE_AXS_CASE(i16, arg0, arg1, arg2, arg3, out, normalized_axis);
+            TYPE_AXS_CASE(i32, arg0, arg1, arg2, arg3, out, normalized_axis);
+            TYPE_AXS_CASE(i64, arg0, arg1, arg2, arg3, out, normalized_axis);
+            TYPE_AXS_CASE(u8, arg0, arg1, arg2, arg3, out, normalized_axis);
+            TYPE_AXS_CASE(u16, arg0, arg1, arg2, arg3, out, normalized_axis);
+            TYPE_AXS_CASE(u32, arg0, arg1, arg2, arg3, out, normalized_axis);
+            TYPE_AXS_CASE(u64, arg0, arg1, arg2, arg3, out, normalized_axis);
         default: rc = false; break;
         }
         return rc;
     }
 
-#define TYPE_IND_CASE(a)                                                                           \
-    case element::Type_t::a: rc = evaluate<DT, element::Type_t::a>
+#define TYPE_IND_CASE(a, ...)                                                                      \
+    case element::Type_t::a:                                                                       \
+    {                                                                                              \
+        NGRAPH_OP_SCOPE(OV_CC_CAT3(scatter_element_update_ind, _, a),                              \
+                        rc = evaluate<DT, element::Type_t::a>(__VA_ARGS__));                       \
+    }                                                                                              \
+    break;
 
     template <element::Type_t DT>
     bool evaluate(const HostTensorPtr& arg0,
@@ -219,22 +221,14 @@ namespace scatter_element_update
 
         switch (indices_type)
         {
-            TYPE_IND_CASE(i8)(arg0, arg1, arg2, arg3, out, normalized_axis);
-            break;
-            TYPE_IND_CASE(i16)(arg0, arg1, arg2, arg3, out, normalized_axis);
-            break;
-            TYPE_IND_CASE(i32)(arg0, arg1, arg2, arg3, out, normalized_axis);
-            break;
-            TYPE_IND_CASE(i64)(arg0, arg1, arg2, arg3, out, normalized_axis);
-            break;
-            TYPE_IND_CASE(u8)(arg0, arg1, arg2, arg3, out, normalized_axis);
-            break;
-            TYPE_IND_CASE(u16)(arg0, arg1, arg2, arg3, out, normalized_axis);
-            break;
-            TYPE_IND_CASE(u32)(arg0, arg1, arg2, arg3, out, normalized_axis);
-            break;
-            TYPE_IND_CASE(u64)(arg0, arg1, arg2, arg3, out, normalized_axis);
-            break;
+            TYPE_IND_CASE(i8, arg0, arg1, arg2, arg3, out, normalized_axis);
+            TYPE_IND_CASE(i16, arg0, arg1, arg2, arg3, out, normalized_axis);
+            TYPE_IND_CASE(i32, arg0, arg1, arg2, arg3, out, normalized_axis);
+            TYPE_IND_CASE(i64, arg0, arg1, arg2, arg3, out, normalized_axis);
+            TYPE_IND_CASE(u8, arg0, arg1, arg2, arg3, out, normalized_axis);
+            TYPE_IND_CASE(u16, arg0, arg1, arg2, arg3, out, normalized_axis);
+            TYPE_IND_CASE(u32, arg0, arg1, arg2, arg3, out, normalized_axis);
+            TYPE_IND_CASE(u64, arg0, arg1, arg2, arg3, out, normalized_axis);
         default: rc = false; break;
         }
         return rc;
@@ -251,20 +245,20 @@ namespace scatter_element_update
 
         switch (out->get_element_type())
         {
-            TYPE_CASE(i16)(arg0, arg1, arg2, arg3, out, normalized_axis);
-            break;
-            TYPE_CASE(i32)(arg0, arg1, arg2, arg3, out, normalized_axis);
-            break;
-            TYPE_CASE(i64)(arg0, arg1, arg2, arg3, out, normalized_axis);
-            break;
-            TYPE_CASE(u32)(arg0, arg1, arg2, arg3, out, normalized_axis);
-            break;
-            TYPE_CASE(u64)(arg0, arg1, arg2, arg3, out, normalized_axis);
-            break;
-            TYPE_CASE(f16)(arg0, arg1, arg2, arg3, out, normalized_axis);
-            break;
-            TYPE_CASE(f32)(arg0, arg1, arg2, arg3, out, normalized_axis);
-            break;
+            NGRAPH_TYPE_CASE(
+                evaluate_scatter_element_update, i16, arg0, arg1, arg2, arg3, out, normalized_axis);
+            NGRAPH_TYPE_CASE(
+                evaluate_scatter_element_update, i32, arg0, arg1, arg2, arg3, out, normalized_axis);
+            NGRAPH_TYPE_CASE(
+                evaluate_scatter_element_update, i64, arg0, arg1, arg2, arg3, out, normalized_axis);
+            NGRAPH_TYPE_CASE(
+                evaluate_scatter_element_update, u32, arg0, arg1, arg2, arg3, out, normalized_axis);
+            NGRAPH_TYPE_CASE(
+                evaluate_scatter_element_update, u64, arg0, arg1, arg2, arg3, out, normalized_axis);
+            NGRAPH_TYPE_CASE(
+                evaluate_scatter_element_update, f16, arg0, arg1, arg2, arg3, out, normalized_axis);
+            NGRAPH_TYPE_CASE(
+                evaluate_scatter_element_update, f32, arg0, arg1, arg2, arg3, out, normalized_axis);
         default: rc = false; break;
         }
         return rc;
@@ -274,28 +268,28 @@ namespace scatter_element_update
 bool op::v3::ScatterElementsUpdate::evaluate(const HostTensorVector& outputs,
                                              const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v3::ScatterElementsUpdate::evaluate");
+    NGRAPH_OP_SCOPE(
+        v3_ScatterElementsUpdate_evaluate,
+        NGRAPH_CHECK(inputs[3]->get_element_type().is_integral_number(),
+                     "axis element type is not integral data type");
 
-    NGRAPH_CHECK(inputs[3]->get_element_type().is_integral_number(),
-                 "axis element type is not integral data type");
+        int64_t axis = host_tensor_2_vector<int64_t>(inputs[3])[0];
+        const auto& input_rank = get_input_partial_shape(0).rank();
+        int64_t normalized_axis = axis;
 
-    int64_t axis = host_tensor_2_vector<int64_t>(inputs[3])[0];
-    const auto& input_rank = get_input_partial_shape(0).rank();
-    int64_t normalized_axis = axis;
-
-    if (normalized_axis < 0)
-    {
-        if (input_rank.is_static())
-        {
-            normalized_axis = ngraph::normalize_axis(this, axis, input_rank);
+        if (normalized_axis < 0) {
+            if (input_rank.is_static())
+            {
+                normalized_axis = ngraph::normalize_axis(this, axis, input_rank);
+            }
+            else
+            {
+                normalized_axis = ngraph::normalize_axis(
+                    this, axis, static_cast<int64_t>(inputs[0]->get_shape().size()));
+            }
         }
-        else
-        {
-            normalized_axis = ngraph::normalize_axis(
-                this, axis, static_cast<int64_t>(inputs[0]->get_shape().size()));
-        }
-    }
 
-    return scatter_element_update::evaluate_scatter_element_update(
-        inputs[0], inputs[1], inputs[2], inputs[3], outputs[0], normalized_axis);
+        return scatter_element_update::evaluate_scatter_element_update(
+            inputs[0], inputs[1], inputs[2], inputs[3], outputs[0], normalized_axis));
+    return false;
 }

--- a/ngraph/core/src/op/scatter_elements_update.cpp
+++ b/ngraph/core/src/op/scatter_elements_update.cpp
@@ -265,8 +265,8 @@ namespace scatter_element_update
     }
 }
 
-bool op::v3::ScatterElementsUpdate::evaluate_scatter_element_update(const HostTensorVector& outputs,
-                                                                    const HostTensorVector& inputs) const
+bool op::v3::ScatterElementsUpdate::evaluate_scatter_element_update(
+    const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
     NGRAPH_CHECK(inputs[3]->get_element_type().is_integral_number(),
                  "axis element type is not integral data type");
@@ -275,7 +275,8 @@ bool op::v3::ScatterElementsUpdate::evaluate_scatter_element_update(const HostTe
     const auto& input_rank = get_input_partial_shape(0).rank();
     int64_t normalized_axis = axis;
 
-    if (normalized_axis < 0) {
+    if (normalized_axis < 0)
+    {
         if (input_rank.is_static())
         {
             normalized_axis = ngraph::normalize_axis(this, axis, input_rank);
@@ -283,18 +284,18 @@ bool op::v3::ScatterElementsUpdate::evaluate_scatter_element_update(const HostTe
         else
         {
             normalized_axis = ngraph::normalize_axis(
-                                                     this, axis, static_cast<int64_t>(inputs[0]->get_shape().size()));
+                this, axis, static_cast<int64_t>(inputs[0]->get_shape().size()));
         }
     }
 
-    return scatter_element_update::evaluate_scatter_element_update(inputs[0], inputs[1], inputs[2], inputs[3], outputs[0], normalized_axis);
+    return scatter_element_update::evaluate_scatter_element_update(
+        inputs[0], inputs[1], inputs[2], inputs[3], outputs[0], normalized_axis);
 }
 
 bool op::v3::ScatterElementsUpdate::evaluate(const HostTensorVector& outputs,
                                              const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(
-        v3_ScatterElementsUpdate_evaluate,
-        return evaluate_scatter_element_update( outputs, inputs));
+    NGRAPH_OP_SCOPE(v3_ScatterElementsUpdate_evaluate,
+                    return evaluate_scatter_element_update(outputs, inputs));
     return false;
 }

--- a/ngraph/core/src/op/scatter_update.cpp
+++ b/ngraph/core/src/op/scatter_update.cpp
@@ -64,7 +64,8 @@ namespace scatter_update
 bool op::v3::ScatterUpdate::evaluate_scatter_update(const HostTensorVector& outputs,
                                                     const HostTensorVector& inputs) const
 {
-    const auto& data = inputs[0]; const auto& indices = inputs[1];
+    const auto& data = inputs[0];
+    const auto& indices = inputs[1];
     const auto& updates = inputs[2];
     const auto& axis = inputs[3];
     const auto& out = outputs[0];
@@ -76,13 +77,15 @@ bool op::v3::ScatterUpdate::evaluate_scatter_update(const HostTensorVector& outp
                  "axis element type is not integral data type");
 
     int64_t axis_val = host_tensor_2_vector<int64_t>(axis)[0];
-    if (axis_val < 0) {
-        axis_val = ngraph::normalize_axis(
-                                          this, axis_val, static_cast<int64_t>(data->get_shape().size()));
+    if (axis_val < 0)
+    {
+        axis_val =
+            ngraph::normalize_axis(this, axis_val, static_cast<int64_t>(data->get_shape().size()));
     }
 
     std::vector<int64_t> indices_casted_vector;
-    switch (indices->get_element_type()) {
+    switch (indices->get_element_type())
+    {
         GET_INDICES(i8, indices);
         GET_INDICES(i16, indices);
         GET_INDICES(i32, indices);
@@ -110,7 +113,6 @@ bool op::v3::ScatterUpdate::evaluate_scatter_update(const HostTensorVector& outp
 bool op::v3::ScatterUpdate::evaluate(const HostTensorVector& outputs,
                                      const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(
-        v3_ScatterUpdate_evaluate, return evaluate_scatter_update(outputs, inputs));
+    NGRAPH_OP_SCOPE(v3_ScatterUpdate_evaluate, return evaluate_scatter_update(outputs, inputs));
     return false;
 }

--- a/ngraph/core/src/op/scatter_update.cpp
+++ b/ngraph/core/src/op/scatter_update.cpp
@@ -15,6 +15,7 @@
 //*****************************************************************************
 
 #include "ngraph/op/scatter_update.hpp"
+#include "itt.hpp"
 #include "ngraph/runtime/reference/scatter_update.hpp"
 #include "ngraph/shape.hpp"
 #include "ngraph/type/element_type.hpp"
@@ -41,99 +42,68 @@ shared_ptr<Node> op::v3::ScatterUpdate::clone_with_new_inputs(const OutputVector
         new_args.at(0), new_args.at(1), new_args.at(2), new_args.at(3));
 }
 
+namespace scatter_update
+{
+    template <element::Type_t ET>
+    std::vector<int64_t> get_indices(const HostTensorPtr& in)
+    {
+        auto data_ptr = in->get_data_ptr<ET>();
+        return std::vector<int64_t>(data_ptr, data_ptr + in->get_element_count());
+    }
+}
+
+#define GET_INDICES(a, ...)                                                                        \
+    case element::Type_t::a:                                                                       \
+    {                                                                                              \
+        NGRAPH_OP_SCOPE(OV_CC_CAT3(get_scatter_update_indices, _, a),                              \
+                        scatter_update::get_indices<element::Type_t::a>(__VA_ARGS__));             \
+    }                                                                                              \
+    break;
+
 bool op::v3::ScatterUpdate::evaluate(const HostTensorVector& outputs,
                                      const HostTensorVector& inputs) const
 {
-    const auto& data = inputs[0];
-    const auto& indices = inputs[1];
-    const auto& updates = inputs[2];
-    const auto& axis = inputs[3];
-    const auto& out = outputs[0];
+    NGRAPH_OP_SCOPE(
+        v3_ScatterUpdate_evaluate, const auto& data = inputs[0]; const auto& indices = inputs[1];
+        const auto& updates = inputs[2];
+        const auto& axis = inputs[3];
+        const auto& out = outputs[0];
 
-    const auto elem_size = data->get_element_type().size();
-    out->set_shape(data->get_shape());
+        const auto elem_size = data->get_element_type().size();
+        out->set_shape(data->get_shape());
 
-    NGRAPH_CHECK(axis->get_element_type().is_integral_number(),
-                 "axis element type is not integral data type");
+        NGRAPH_CHECK(axis->get_element_type().is_integral_number(),
+                     "axis element type is not integral data type");
 
-    int64_t axis_val = host_tensor_2_vector<int64_t>(axis)[0];
-    if (axis_val < 0)
-    {
-        axis_val =
-            ngraph::normalize_axis(this, axis_val, static_cast<int64_t>(data->get_shape().size()));
-    }
+        int64_t axis_val = host_tensor_2_vector<int64_t>(axis)[0];
+        if (axis_val < 0) {
+            axis_val = ngraph::normalize_axis(
+                this, axis_val, static_cast<int64_t>(data->get_shape().size()));
+        }
 
-    std::vector<int64_t> indices_casted_vector;
-    switch (indices->get_element_type())
-    {
-    case element::Type_t::i8:
-    {
-        auto indices_ptr = indices->get_data_ptr<element::Type_t::i8>();
-        indices_casted_vector =
-            std::vector<int64_t>(indices_ptr, indices_ptr + indices->get_element_count());
-        break;
-    }
-    case element::Type_t::i16:
-    {
-        auto indices_ptr = indices->get_data_ptr<element::Type_t::i16>();
-        indices_casted_vector =
-            std::vector<int64_t>(indices_ptr, indices_ptr + indices->get_element_count());
-        break;
-    }
-    case element::Type_t::i32:
-    {
-        auto indices_ptr = indices->get_data_ptr<element::Type_t::i32>();
-        indices_casted_vector =
-            std::vector<int64_t>(indices_ptr, indices_ptr + indices->get_element_count());
-        break;
-    }
-    case element::Type_t::i64:
-    {
-        auto indices_ptr = indices->get_data_ptr<element::Type_t::i64>();
-        indices_casted_vector =
-            std::vector<int64_t>(indices_ptr, indices_ptr + indices->get_element_count());
-        break;
-    }
-    case element::Type_t::u8:
-    {
-        auto indices_ptr = indices->get_data_ptr<element::Type_t::u8>();
-        indices_casted_vector =
-            std::vector<int64_t>(indices_ptr, indices_ptr + indices->get_element_count());
-        break;
-    }
-    case element::Type_t::u16:
-    {
-        auto indices_ptr = indices->get_data_ptr<element::Type_t::u16>();
-        indices_casted_vector =
-            std::vector<int64_t>(indices_ptr, indices_ptr + indices->get_element_count());
-        break;
-    }
-    case element::Type_t::u32:
-    {
-        auto indices_ptr = indices->get_data_ptr<element::Type_t::u32>();
-        indices_casted_vector =
-            std::vector<int64_t>(indices_ptr, indices_ptr + indices->get_element_count());
-        break;
-    }
-    case element::Type_t::u64:
-    {
-        auto indices_ptr = indices->get_data_ptr<element::Type_t::u64>();
-        indices_casted_vector =
-            std::vector<int64_t>(indices_ptr, indices_ptr + indices->get_element_count());
-        break;
-    }
-    default: throw ngraph_error("indices element type is not integral data type");
-    }
+        std::vector<int64_t> indices_casted_vector;
+        switch (indices->get_element_type()) {
+            GET_INDICES(i8, indices);
+            GET_INDICES(i16, indices);
+            GET_INDICES(i32, indices);
+            GET_INDICES(i64, indices);
+            GET_INDICES(u8, indices);
+            GET_INDICES(u16, indices);
+            GET_INDICES(u32, indices);
+            GET_INDICES(u64, indices);
+        default: return false;
+        }
 
-    runtime::reference::scatter_update(data->get_data_ptr<char>(),
-                                       indices_casted_vector.data(),
-                                       updates->get_data_ptr<char>(),
-                                       axis_val,
-                                       out->get_data_ptr<char>(),
-                                       elem_size,
-                                       data->get_shape(),
-                                       indices->get_shape(),
-                                       updates->get_shape());
+        runtime::reference::scatter_update(data->get_data_ptr<char>(),
+                                           indices_casted_vector.data(),
+                                           updates->get_data_ptr<char>(),
+                                           axis_val,
+                                           out->get_data_ptr<char>(),
+                                           elem_size,
+                                           data->get_shape(),
+                                           indices->get_shape(),
+                                           updates->get_shape());
 
-    return true;
+        return true);
+    return false;
 }

--- a/ngraph/core/src/op/scatter_update.cpp
+++ b/ngraph/core/src/op/scatter_update.cpp
@@ -56,7 +56,8 @@ namespace scatter_update
     case element::Type_t::a:                                                                       \
     {                                                                                              \
         NGRAPH_OP_SCOPE(OV_CC_CAT3(get_scatter_update_indices, _, a),                              \
-                        scatter_update::get_indices<element::Type_t::a>(__VA_ARGS__));             \
+                        indices_casted_vector =                                                    \
+                            scatter_update::get_indices<element::Type_t::a>(__VA_ARGS__));         \
     }                                                                                              \
     break;
 

--- a/ngraph/core/src/op/select.cpp
+++ b/ngraph/core/src/op/select.cpp
@@ -16,6 +16,7 @@
 
 #include <memory>
 
+#include "itt.hpp"
 #include "ngraph/attribute_visitor.hpp"
 #include "ngraph/log.hpp"
 #include "ngraph/op/convert.hpp"
@@ -133,30 +134,18 @@ namespace detail
 
         switch (et)
         {
-            TYPE_CASE(i8)(output_values, input_values, autob);
-            break;
-            TYPE_CASE(i16)(output_values, input_values, autob);
-            break;
-            TYPE_CASE(i32)(output_values, input_values, autob);
-            break;
-            TYPE_CASE(i64)(output_values, input_values, autob);
-            break;
-            TYPE_CASE(u8)(output_values, input_values, autob);
-            break;
-            TYPE_CASE(u16)(output_values, input_values, autob);
-            break;
-            TYPE_CASE(u32)(output_values, input_values, autob);
-            break;
-            TYPE_CASE(u64)(output_values, input_values, autob);
-            break;
-            TYPE_CASE(bf16)(output_values, input_values, autob);
-            break;
-            TYPE_CASE(f32)(output_values, input_values, autob);
-            break;
-            TYPE_CASE(f64)(output_values, input_values, autob);
-            break;
-            TYPE_CASE(boolean)(output_values, input_values, autob);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_select, i8, output_values, input_values, autob);
+            NGRAPH_TYPE_CASE(evaluate_select, i16, output_values, input_values, autob);
+            NGRAPH_TYPE_CASE(evaluate_select, i32, output_values, input_values, autob);
+            NGRAPH_TYPE_CASE(evaluate_select, i64, output_values, input_values, autob);
+            NGRAPH_TYPE_CASE(evaluate_select, u8, output_values, input_values, autob);
+            NGRAPH_TYPE_CASE(evaluate_select, u16, output_values, input_values, autob);
+            NGRAPH_TYPE_CASE(evaluate_select, u32, output_values, input_values, autob);
+            NGRAPH_TYPE_CASE(evaluate_select, u64, output_values, input_values, autob);
+            NGRAPH_TYPE_CASE(evaluate_select, bf16, output_values, input_values, autob);
+            NGRAPH_TYPE_CASE(evaluate_select, f32, output_values, input_values, autob);
+            NGRAPH_TYPE_CASE(evaluate_select, f64, output_values, input_values, autob);
+            NGRAPH_TYPE_CASE(evaluate_select, boolean, output_values, input_values, autob);
         default: rc = false; break;
         }
 
@@ -167,7 +156,9 @@ namespace detail
 bool op::v1::Select::evaluate(const HostTensorVector& output_values,
                               const HostTensorVector& input_values) const
 {
-    const auto autob = get_auto_broadcast();
+    NGRAPH_OP_SCOPE(v1_Select_evaluate, const auto autob = get_auto_broadcast();
 
-    return detail::evaluate_select(output_values, input_values, autob, get_output_element_type(0));
+                    return detail::evaluate_select(
+                        output_values, input_values, autob, get_output_element_type(0)));
+    return false;
 }

--- a/ngraph/core/src/op/shape_of.cpp
+++ b/ngraph/core/src/op/shape_of.cpp
@@ -78,14 +78,10 @@ namespace shape_of
         output_value->set_shape(Shape{shape.size()});
         switch (output_value->get_element_type())
         {
-            TYPE_CASE(i32)(shape, output_value);
-            break;
-            TYPE_CASE(i64)(shape, output_value);
-            break;
-            TYPE_CASE(u32)(shape, output_value);
-            break;
-            TYPE_CASE(u64)(shape, output_value);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_shape_of, i32, shape, output_value);
+            NGRAPH_TYPE_CASE(evaluate_shape_of, i64, shape, output_value);
+            NGRAPH_TYPE_CASE(evaluate_shape_of, u32, shape, output_value);
+            NGRAPH_TYPE_CASE(evaluate_shape_of, u64, shape, output_value);
         default: rc = false; break;
         }
         return rc;
@@ -158,8 +154,9 @@ namespace shape_of
 bool op::v3::ShapeOf::evaluate(const HostTensorVector& output_values,
                                const HostTensorVector& input_values) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v3::ShapeOf::evaluate");
-    return shape_of::evaluate_shape_of(output_values[0], input_values[0]);
+    NGRAPH_OP_SCOPE(v3_ShapeOf_evaluate,
+                    return shape_of::evaluate_shape_of(output_values[0], input_values[0]););
+    return false;
 }
 
 bool op::v3::ShapeOf::constant_fold(OutputVector& output_values, const OutputVector& input_values)
@@ -207,8 +204,9 @@ shared_ptr<Node> op::v0::ShapeOf::clone_with_new_inputs(const OutputVector& new_
 bool op::v0::ShapeOf::evaluate(const HostTensorVector& output_values,
                                const HostTensorVector& input_values) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v0::ShapeOf::evaluate");
-    return shape_of::evaluate_shape_of(output_values[0], input_values[0]);
+    NGRAPH_OP_SCOPE(v0_ShapeOf_evaluate,
+                    return shape_of::evaluate_shape_of(output_values[0], input_values[0]));
+    return false;
 }
 
 bool op::v0::ShapeOf::constant_fold(OutputVector& output_values, const OutputVector& input_values)

--- a/ngraph/core/src/op/shuffle_channels.cpp
+++ b/ngraph/core/src/op/shuffle_channels.cpp
@@ -151,14 +151,19 @@ bool op::ShuffleChannels::evaluate_shuffle_channels(const HostTensorVector& outp
 
     Shape reshaped_out_shape(4, 1);
     size_t axis_zb = m_axis >= 0 ? m_axis : m_axis + data_shape.size();
-    for (size_t i = 0; i < axis_zb; ++i) { reshaped_out_shape[0] *= ds[i]; }
+    for (size_t i = 0; i < axis_zb; ++i)
+    {
+        reshaped_out_shape[0] *= ds[i];
+    }
 
     reshaped_out_shape[1] = m_group;
     reshaped_out_shape[2] = ds[axis_zb] / m_group;
 
-    for (size_t i = axis_zb + 1; i < ds.size(); ++i) {
+    for (size_t i = axis_zb + 1; i < ds.size(); ++i)
+    {
         reshaped_out_shape[3] *= ds[i];
-    } size_t data_size = shape_size(data_shape) * elem_size;
+    }
+    size_t data_size = shape_size(data_shape) * elem_size;
 
     // first reshape from data_shape to reshaped_out_shape is skipped since it doesn't affect
     // out
@@ -167,11 +172,13 @@ bool op::ShuffleChannels::evaluate_shuffle_channels(const HostTensorVector& outp
     Shape transpose_axes_order = {0, 2, 1, 3};
     Shape transposed_shape(transpose_axes_order.size());
 
-    for (size_t i = 0; i < transpose_axes_order.size(); ++i) {
+    for (size_t i = 0; i < transpose_axes_order.size(); ++i)
+    {
         transposed_shape[i] = data_shape.at(transpose_axes_order.at(i));
-    } auto axis_vector = AxisVector{begin(transpose_axes_order), end(transpose_axes_order)};
+    }
+    auto axis_vector = AxisVector{begin(transpose_axes_order), end(transpose_axes_order)};
     runtime::opt_kernel::reshape(
-                                 arg, out, reshaped_out_shape, axis_vector, transposed_shape, elem_size);
+        arg, out, reshaped_out_shape, axis_vector, transposed_shape, elem_size);
 
     // last reshape from transposed_shape to data_shape is skipped since it doesn't affect out
     // data
@@ -180,7 +187,6 @@ bool op::ShuffleChannels::evaluate_shuffle_channels(const HostTensorVector& outp
 bool op::ShuffleChannels::evaluate(const HostTensorVector& outputs,
                                    const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(
-        ShuffleChannels_evaluate, return evaluate_shuffle_channels(outputs, inputs));
+    NGRAPH_OP_SCOPE(ShuffleChannels_evaluate, return evaluate_shuffle_channels(outputs, inputs));
     return false;
 }

--- a/ngraph/core/src/op/shuffle_channels.cpp
+++ b/ngraph/core/src/op/shuffle_channels.cpp
@@ -15,6 +15,7 @@
 //*****************************************************************************
 #include <numeric>
 
+#include "itt.hpp"
 #include "ngraph/attribute_visitor.hpp"
 #include "ngraph/builder/reshape.hpp"
 #include "ngraph/op/shuffle_channels.hpp"
@@ -142,42 +143,39 @@ Shape op::ShuffleChannels::get_pre_shuffle_shape(const Shape& data_shape) const
 bool op::ShuffleChannels::evaluate(const HostTensorVector& outputs,
                                    const HostTensorVector& inputs) const
 {
-    const auto arg = inputs[0]->get_data_ptr<const char>();
-    auto out = outputs[0]->get_data_ptr<char>();
-    Shape data_shape = inputs[0]->get_shape();
-    const Shape& ds = data_shape;
-    size_t elem_size = inputs[0]->get_element_type().size();
+    NGRAPH_OP_SCOPE(
+        ShuffleChannels_evaluate, const auto arg = inputs[0]->get_data_ptr<const char>();
+        auto out = outputs[0]->get_data_ptr<char>();
+        Shape data_shape = inputs[0]->get_shape();
+        const Shape& ds = data_shape;
+        size_t elem_size = inputs[0]->get_element_type().size();
 
-    Shape reshaped_out_shape(4, 1);
-    size_t axis_zb = m_axis >= 0 ? m_axis : m_axis + data_shape.size();
-    for (size_t i = 0; i < axis_zb; ++i)
-    {
-        reshaped_out_shape[0] *= ds[i];
-    }
+        Shape reshaped_out_shape(4, 1);
+        size_t axis_zb = m_axis >= 0 ? m_axis : m_axis + data_shape.size();
+        for (size_t i = 0; i < axis_zb; ++i) { reshaped_out_shape[0] *= ds[i]; }
 
-    reshaped_out_shape[1] = m_group;
-    reshaped_out_shape[2] = ds[axis_zb] / m_group;
+        reshaped_out_shape[1] = m_group;
+        reshaped_out_shape[2] = ds[axis_zb] / m_group;
 
-    for (size_t i = axis_zb + 1; i < ds.size(); ++i)
-    {
-        reshaped_out_shape[3] *= ds[i];
-    }
-    size_t data_size = shape_size(data_shape) * elem_size;
+        for (size_t i = axis_zb + 1; i < ds.size(); ++i) {
+            reshaped_out_shape[3] *= ds[i];
+        } size_t data_size = shape_size(data_shape) * elem_size;
 
-    // first reshape from data_shape to reshaped_out_shape is skipped since it doesn't affect out
-    // data
+        // first reshape from data_shape to reshaped_out_shape is skipped since it doesn't affect
+        // out
+        // data
 
-    Shape transpose_axes_order = {0, 2, 1, 3};
-    Shape transposed_shape(transpose_axes_order.size());
+        Shape transpose_axes_order = {0, 2, 1, 3};
+        Shape transposed_shape(transpose_axes_order.size());
 
-    for (size_t i = 0; i < transpose_axes_order.size(); ++i)
-    {
-        transposed_shape[i] = data_shape.at(transpose_axes_order.at(i));
-    }
-    auto axis_vector = AxisVector{begin(transpose_axes_order), end(transpose_axes_order)};
-    runtime::opt_kernel::reshape(
-        arg, out, reshaped_out_shape, axis_vector, transposed_shape, elem_size);
+        for (size_t i = 0; i < transpose_axes_order.size(); ++i) {
+            transposed_shape[i] = data_shape.at(transpose_axes_order.at(i));
+        } auto axis_vector = AxisVector{begin(transpose_axes_order), end(transpose_axes_order)};
+        runtime::opt_kernel::reshape(
+            arg, out, reshaped_out_shape, axis_vector, transposed_shape, elem_size);
 
-    // last reshape from transposed_shape to data_shape is skipped since it doesn't affect out data
-    return true;
+        // last reshape from transposed_shape to data_shape is skipped since it doesn't affect out
+        // data
+        return true);
+    return false;
 }

--- a/ngraph/core/src/op/shuffle_channels.cpp
+++ b/ngraph/core/src/op/shuffle_channels.cpp
@@ -140,42 +140,47 @@ Shape op::ShuffleChannels::get_pre_shuffle_shape(const Shape& data_shape) const
     return res;
 }
 
+bool op::ShuffleChannels::evaluate_shuffle_channels(const HostTensorVector& outputs,
+                                                    const HostTensorVector& inputs) const
+{
+    const auto arg = inputs[0]->get_data_ptr<const char>();
+    auto out = outputs[0]->get_data_ptr<char>();
+    Shape data_shape = inputs[0]->get_shape();
+    const Shape& ds = data_shape;
+    size_t elem_size = inputs[0]->get_element_type().size();
+
+    Shape reshaped_out_shape(4, 1);
+    size_t axis_zb = m_axis >= 0 ? m_axis : m_axis + data_shape.size();
+    for (size_t i = 0; i < axis_zb; ++i) { reshaped_out_shape[0] *= ds[i]; }
+
+    reshaped_out_shape[1] = m_group;
+    reshaped_out_shape[2] = ds[axis_zb] / m_group;
+
+    for (size_t i = axis_zb + 1; i < ds.size(); ++i) {
+        reshaped_out_shape[3] *= ds[i];
+    } size_t data_size = shape_size(data_shape) * elem_size;
+
+    // first reshape from data_shape to reshaped_out_shape is skipped since it doesn't affect
+    // out
+    // data
+
+    Shape transpose_axes_order = {0, 2, 1, 3};
+    Shape transposed_shape(transpose_axes_order.size());
+
+    for (size_t i = 0; i < transpose_axes_order.size(); ++i) {
+        transposed_shape[i] = data_shape.at(transpose_axes_order.at(i));
+    } auto axis_vector = AxisVector{begin(transpose_axes_order), end(transpose_axes_order)};
+    runtime::opt_kernel::reshape(
+                                 arg, out, reshaped_out_shape, axis_vector, transposed_shape, elem_size);
+
+    // last reshape from transposed_shape to data_shape is skipped since it doesn't affect out
+    // data
+    return true;
+}
 bool op::ShuffleChannels::evaluate(const HostTensorVector& outputs,
                                    const HostTensorVector& inputs) const
 {
     NGRAPH_OP_SCOPE(
-        ShuffleChannels_evaluate, const auto arg = inputs[0]->get_data_ptr<const char>();
-        auto out = outputs[0]->get_data_ptr<char>();
-        Shape data_shape = inputs[0]->get_shape();
-        const Shape& ds = data_shape;
-        size_t elem_size = inputs[0]->get_element_type().size();
-
-        Shape reshaped_out_shape(4, 1);
-        size_t axis_zb = m_axis >= 0 ? m_axis : m_axis + data_shape.size();
-        for (size_t i = 0; i < axis_zb; ++i) { reshaped_out_shape[0] *= ds[i]; }
-
-        reshaped_out_shape[1] = m_group;
-        reshaped_out_shape[2] = ds[axis_zb] / m_group;
-
-        for (size_t i = axis_zb + 1; i < ds.size(); ++i) {
-            reshaped_out_shape[3] *= ds[i];
-        } size_t data_size = shape_size(data_shape) * elem_size;
-
-        // first reshape from data_shape to reshaped_out_shape is skipped since it doesn't affect
-        // out
-        // data
-
-        Shape transpose_axes_order = {0, 2, 1, 3};
-        Shape transposed_shape(transpose_axes_order.size());
-
-        for (size_t i = 0; i < transpose_axes_order.size(); ++i) {
-            transposed_shape[i] = data_shape.at(transpose_axes_order.at(i));
-        } auto axis_vector = AxisVector{begin(transpose_axes_order), end(transpose_axes_order)};
-        runtime::opt_kernel::reshape(
-            arg, out, reshaped_out_shape, axis_vector, transposed_shape, elem_size);
-
-        // last reshape from transposed_shape to data_shape is skipped since it doesn't affect out
-        // data
-        return true);
+        ShuffleChannels_evaluate, return evaluate_shuffle_channels(outputs, inputs));
     return false;
 }

--- a/ngraph/core/src/op/sigmoid.cpp
+++ b/ngraph/core/src/op/sigmoid.cpp
@@ -57,20 +57,13 @@ namespace sigmoid
 
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(boolean)(arg0, out, count);
-            break;
-            TYPE_CASE(i32)(arg0, out, count);
-            break;
-            TYPE_CASE(i64)(arg0, out, count);
-            break;
-            TYPE_CASE(u32)(arg0, out, count);
-            break;
-            TYPE_CASE(u64)(arg0, out, count);
-            break;
-            TYPE_CASE(f16)(arg0, out, count);
-            break;
-            TYPE_CASE(f32)(arg0, out, count);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_sigmoid, boolean, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_sigmoid, i32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_sigmoid, i64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_sigmoid, u32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_sigmoid, u64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_sigmoid, f16, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_sigmoid, f32, arg0, out, count);
         default: rc = false; break;
         }
         return rc;
@@ -79,6 +72,8 @@ namespace sigmoid
 
 bool op::Sigmoid::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::Sigmoid::evaluate");
-    return sigmoid::evaluate_sigmoid(inputs[0], outputs[0], shape_size(get_output_shape(0)));
+    NGRAPH_OP_SCOPE(
+        Sigmoid_evaluate,
+        return sigmoid::evaluate_sigmoid(inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    return false;
 }

--- a/ngraph/core/src/op/sigmoid.cpp
+++ b/ngraph/core/src/op/sigmoid.cpp
@@ -73,7 +73,7 @@ namespace sigmoid
 bool op::Sigmoid::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
     NGRAPH_OP_SCOPE(
-        Sigmoid_evaluate,
+        v0_Sigmoid_evaluate,
         return sigmoid::evaluate_sigmoid(inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return false;
 }

--- a/ngraph/core/src/op/sign.cpp
+++ b/ngraph/core/src/op/sign.cpp
@@ -76,7 +76,7 @@ namespace signop
 bool op::Sign::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
     NGRAPH_OP_SCOPE(
-        Sign_evaluate,
+        v0_Sign_evaluate,
         return signop::evaluate_sign(inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return false;
 }

--- a/ngraph/core/src/op/sign.cpp
+++ b/ngraph/core/src/op/sign.cpp
@@ -60,20 +60,13 @@ namespace signop
 
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(boolean)(arg0, out, count);
-            break;
-            TYPE_CASE(i32)(arg0, out, count);
-            break;
-            TYPE_CASE(i64)(arg0, out, count);
-            break;
-            TYPE_CASE(u32)(arg0, out, count);
-            break;
-            TYPE_CASE(u64)(arg0, out, count);
-            break;
-            TYPE_CASE(f16)(arg0, out, count);
-            break;
-            TYPE_CASE(f32)(arg0, out, count);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_sign, boolean, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_sign, i32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_sign, i64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_sign, u32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_sign, u64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_sign, f16, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_sign, f32, arg0, out, count);
         default: rc = false; break;
         }
         return rc;
@@ -82,6 +75,8 @@ namespace signop
 
 bool op::Sign::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::Sign::evaluate");
-    return signop::evaluate_sign(inputs[0], outputs[0], shape_size(get_output_shape(0)));
+    NGRAPH_OP_SCOPE(
+        Sign_evaluate,
+        return signop::evaluate_sign(inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    return false;
 }

--- a/ngraph/core/src/op/sin.cpp
+++ b/ngraph/core/src/op/sin.cpp
@@ -62,20 +62,13 @@ namespace sinop
 
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(boolean)(arg0, out, count);
-            break;
-            TYPE_CASE(i32)(arg0, out, count);
-            break;
-            TYPE_CASE(i64)(arg0, out, count);
-            break;
-            TYPE_CASE(u32)(arg0, out, count);
-            break;
-            TYPE_CASE(u64)(arg0, out, count);
-            break;
-            TYPE_CASE(f16)(arg0, out, count);
-            break;
-            TYPE_CASE(f32)(arg0, out, count);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_sin, boolean, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_sin, i32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_sin, i64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_sin, u32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_sin, u64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_sin, f16, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_sin, f32, arg0, out, count);
         default: rc = false; break;
         }
         return rc;
@@ -84,6 +77,8 @@ namespace sinop
 
 bool op::Sin::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::Sin::evaluate");
-    return sinop::evaluate_sin(inputs[0], outputs[0], shape_size(get_output_shape(0)));
+    NGRAPH_OP_SCOPE(
+        Sin_evaluate,
+        return sinop::evaluate_sin(inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    return false;
 }

--- a/ngraph/core/src/op/sin.cpp
+++ b/ngraph/core/src/op/sin.cpp
@@ -78,7 +78,7 @@ namespace sinop
 bool op::Sin::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
     NGRAPH_OP_SCOPE(
-        Sin_evaluate,
+        v0_Sin_evaluate,
         return sinop::evaluate_sin(inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return false;
 }

--- a/ngraph/core/src/op/sinh.cpp
+++ b/ngraph/core/src/op/sinh.cpp
@@ -78,7 +78,7 @@ namespace sinhop
 bool op::Sinh::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
     NGRAPH_OP_SCOPE(
-        Sinh_evaluate,
+        v0_Sinh_evaluate,
         return sinhop::evaluate_sinh(inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return false;
 }

--- a/ngraph/core/src/op/sinh.cpp
+++ b/ngraph/core/src/op/sinh.cpp
@@ -62,20 +62,13 @@ namespace sinhop
 
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(boolean)(arg0, out, count);
-            break;
-            TYPE_CASE(i32)(arg0, out, count);
-            break;
-            TYPE_CASE(i64)(arg0, out, count);
-            break;
-            TYPE_CASE(u32)(arg0, out, count);
-            break;
-            TYPE_CASE(u64)(arg0, out, count);
-            break;
-            TYPE_CASE(f16)(arg0, out, count);
-            break;
-            TYPE_CASE(f32)(arg0, out, count);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_sinh, boolean, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_sinh, i32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_sinh, i64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_sinh, u32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_sinh, u64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_sinh, f16, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_sinh, f32, arg0, out, count);
         default: rc = false; break;
         }
         return rc;
@@ -84,6 +77,8 @@ namespace sinhop
 
 bool op::Sinh::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::Sinh::evaluate");
-    return sinhop::evaluate_sinh(inputs[0], outputs[0], shape_size(get_output_shape(0)));
+    NGRAPH_OP_SCOPE(
+        Sinh_evaluate,
+        return sinhop::evaluate_sinh(inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    return false;
 }

--- a/ngraph/core/src/op/softmax.cpp
+++ b/ngraph/core/src/op/softmax.cpp
@@ -54,6 +54,7 @@ namespace
             NGRAPH_TYPE_CASE(evaluate_softmax, bf16, arg, out, shape, axes);
             NGRAPH_TYPE_CASE(evaluate_softmax, f16, arg, out, shape, axes);
             NGRAPH_TYPE_CASE(evaluate_softmax, f32, arg, out, shape, axes);
+            NGRAPH_TYPE_CASE(evaluate_softmax, f64, arg, out, shape, axes);
         default: rc = false; break;
         }
         return rc;

--- a/ngraph/core/src/op/softmax.cpp
+++ b/ngraph/core/src/op/softmax.cpp
@@ -35,23 +35,28 @@ using namespace ngraph;
 namespace
 {
     template <element::Type_t ET>
-    inline bool try_evaluate_softmax(const HostTensorPtr& arg,
-                                     const HostTensorPtr& out,
-                                     const Shape& shape,
-                                     const AxisSet& axes)
+    inline bool evaluate(const HostTensorPtr& arg,
+                         const HostTensorPtr& out,
+                         const Shape& shape,
+                         const AxisSet& axes)
     {
-        return (ET == arg->get_element_type()) &&
-               (runtime::reference::softmax(
-                    arg->get_data_ptr<ET>(), out->get_data_ptr<ET>(), shape, axes),
-                true);
+        runtime::reference::softmax(arg->get_data_ptr<ET>(), out->get_data_ptr<ET>(), shape, axes);
+        return true;
     }
 
     bool evaluate_softmax(const HostTensorPtr& arg, const HostTensorPtr& out, const AxisSet& axes)
     {
         auto shape = out->get_shape();
-        return try_evaluate_softmax<element::Type_t::f16>(arg, out, shape, axes) ||
-               try_evaluate_softmax<element::Type_t::f32>(arg, out, shape, axes) ||
-               try_evaluate_softmax<element::Type_t::f64>(arg, out, shape, axes);
+        bool rc = true;
+
+        switch (arg->get_element_type())
+        {
+            NGRAPH_TYPE_CASE(evaluate_softmax, bf16, arg, out, shape, axes);
+            NGRAPH_TYPE_CASE(evaluate_softmax, f16, arg, out, shape, axes);
+            NGRAPH_TYPE_CASE(evaluate_softmax, f32, arg, out, shape, axes);
+        default: rc = false; break;
+        }
+        return rc;
     }
 }
 
@@ -95,7 +100,7 @@ shared_ptr<Node> op::v1::Softmax::clone_with_new_inputs(const OutputVector& new_
 bool op::v1::Softmax::evaluate(const HostTensorVector& outputs,
                                const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::Softmax::evaluate");
-    outputs[0]->set_unary(inputs[0]);
-    return evaluate_softmax(inputs[0], outputs[0], AxisSet{m_axis});
+    NGRAPH_OP_SCOPE(v1_Softmax_evaluate, outputs[0]->set_unary(inputs[0]);
+                    return evaluate_softmax(inputs[0], outputs[0], AxisSet{m_axis}));
+    return false;
 }

--- a/ngraph/core/src/op/softplus.cpp
+++ b/ngraph/core/src/op/softplus.cpp
@@ -78,7 +78,7 @@ bool op::v4::SoftPlus::evaluate(const HostTensorVector& outputs,
                                 const HostTensorVector& inputs) const
 {
     NGRAPH_OP_SCOPE(
-        SoftPlus_evaluate,
+        v4_SoftPlus_evaluate,
         return softplus::evaluate_softplus(inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return false;
 }

--- a/ngraph/core/src/op/softplus.cpp
+++ b/ngraph/core/src/op/softplus.cpp
@@ -65,12 +65,9 @@ namespace softplus
 
         switch (arg->get_element_type())
         {
-            TYPE_CASE(bf16)(arg, out, count);
-            break;
-            TYPE_CASE(f16)(arg, out, count);
-            break;
-            TYPE_CASE(f32)(arg, out, count);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_softplus, bf16, arg, out, count);
+            NGRAPH_TYPE_CASE(evaluate_softplus, f16, arg, out, count);
+            NGRAPH_TYPE_CASE(evaluate_softplus, f32, arg, out, count);
         default: rc = false; break;
         }
         return rc;
@@ -80,6 +77,8 @@ namespace softplus
 bool op::v4::SoftPlus::evaluate(const HostTensorVector& outputs,
                                 const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::SoftPlus::evaluate");
-    return softplus::evaluate_softplus(inputs[0], outputs[0], shape_size(get_output_shape(0)));
+    NGRAPH_OP_SCOPE(
+        SoftPlus_evaluate,
+        return softplus::evaluate_softplus(inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    return false;
 }

--- a/ngraph/core/src/op/space_to_batch.cpp
+++ b/ngraph/core/src/op/space_to_batch.cpp
@@ -17,6 +17,7 @@
 #include <cstddef>
 #include <memory>
 #include <numeric>
+#include "itt.hpp"
 
 #include "ngraph/builder/make_constant.hpp"
 #include "ngraph/node.hpp"
@@ -143,128 +144,115 @@ bool ngraph::op::v1::SpaceToBatch::visit_attributes(ngraph::AttributeVisitor& vi
 bool ngraph::op::v1::SpaceToBatch::evaluate(const HostTensorVector& outputs,
                                             const HostTensorVector& inputs) const
 {
-    const auto& data = inputs[0];
-    const auto& out = outputs[0];
-    const auto& out_shape = out->get_shape();
-    size_t elem_size = data->get_element_type().size();
+    NGRAPH_OP_SCOPE(
+        v1_SpaceToBatch, const auto& data = inputs[0]; const auto& out = outputs[0];
+        const auto& out_shape = out->get_shape();
+        size_t elem_size = data->get_element_type().size();
 
-    if (data->get_partial_shape().is_dynamic())
-    {
-        return false;
-    }
-    auto data_shape = data->get_shape();
+        if (data->get_partial_shape().is_dynamic()) { return false; } auto data_shape =
+            data->get_shape();
 
-    if (!(data->get_shape().size() == 4 || data->get_shape().size() == 5))
-    {
-        return false;
-    }
+        if (!(data->get_shape().size() == 4 || data->get_shape().size() == 5)) { return false; }
 
-    size_t block_values_size = shape_size(inputs[1]->get_shape());
-    const auto* block_values = inputs[1]->get_data_ptr<int64_t>();
-    const auto* pads_begin = inputs[2]->get_data_ptr<int64_t>();
-    const auto* pads_end = inputs[3]->get_data_ptr<int64_t>();
+        size_t block_values_size = shape_size(inputs[1]->get_shape());
+        const auto* block_values = inputs[1]->get_data_ptr<int64_t>();
+        const auto* pads_begin = inputs[2]->get_data_ptr<int64_t>();
+        const auto* pads_end = inputs[3]->get_data_ptr<int64_t>();
 
-    const char* pad_value = nullptr;
-    const std::vector<char> pad_zero_value(elem_size, 0);
-    if (inputs.size() == 4)
-    {
-        pad_value = inputs[3]->get_data_ptr<char>();
-    }
-    else
-    {
-        pad_value = pad_zero_value.data();
-    }
-    CoordinateDiff pads_begin_vec(shape_size(inputs[2]->get_shape()));
-    pads_begin_vec.assign(pads_begin, pads_begin + shape_size(inputs[2]->get_shape()));
-    CoordinateDiff pads_end_vec(shape_size(inputs[2]->get_shape()));
-    pads_end_vec.assign(pads_end, pads_end + shape_size(inputs[2]->get_shape()));
+        const char* pad_value = nullptr;
+        const std::vector<char> pad_zero_value(elem_size, 0);
+        if (inputs.size() == 4) { pad_value = inputs[3]->get_data_ptr<char>(); } else {
+            pad_value = pad_zero_value.data();
+        } CoordinateDiff pads_begin_vec(shape_size(inputs[2]->get_shape()));
+        pads_begin_vec.assign(pads_begin, pads_begin + shape_size(inputs[2]->get_shape()));
+        CoordinateDiff pads_end_vec(shape_size(inputs[2]->get_shape()));
+        pads_end_vec.assign(pads_end, pads_end + shape_size(inputs[2]->get_shape()));
 
-    Shape padded_shape(data_shape.size());
-    for (size_t i = 0; i < data_shape.size(); ++i)
-    {
-        padded_shape[i] = data_shape[i] + pads_begin_vec[i] + pads_end_vec[i];
-    }
+        Shape padded_shape(data_shape.size());
+        for (size_t i = 0; i < data_shape.size();
+             ++i) { padded_shape[i] = data_shape[i] + pads_begin_vec[i] + pads_end_vec[i]; }
 
-    std::vector<char> padded_data(shape_size(padded_shape) * elem_size);
-    ngraph::runtime::reference::pad(data->get_data_ptr<char>(),
-                                    pad_value,
-                                    padded_data.data(),
-                                    elem_size,
-                                    data_shape,
-                                    padded_shape,
-                                    pads_begin_vec,
-                                    pads_end_vec,
-                                    ngraph::op::PadMode::CONSTANT);
-    data_shape = padded_shape;
+        std::vector<char> padded_data(shape_size(padded_shape) * elem_size);
+        ngraph::runtime::reference::pad(data->get_data_ptr<char>(),
+                                        pad_value,
+                                        padded_data.data(),
+                                        elem_size,
+                                        data_shape,
+                                        padded_shape,
+                                        pads_begin_vec,
+                                        pads_end_vec,
+                                        ngraph::op::PadMode::CONSTANT);
+        data_shape = padded_shape;
 
-    Shape dispersed_shape(block_values_size + 1);
-    std::vector<size_t> axes_order(block_values_size + 1);
-    Shape squeezed_shape(data_shape.begin(), data_shape.end());
-    std::vector<size_t> plain_axes_order(block_values_size + 1);
-    std::iota(plain_axes_order.begin(), plain_axes_order.end(), 0);
+        Shape dispersed_shape(block_values_size + 1);
+        std::vector<size_t> axes_order(block_values_size + 1);
+        Shape squeezed_shape(data_shape.begin(), data_shape.end());
+        std::vector<size_t> plain_axes_order(block_values_size + 1);
+        std::iota(plain_axes_order.begin(), plain_axes_order.end(), 0);
 
-    std::vector<char> flat_data(padded_data.begin(), padded_data.end());
-    std::vector<char> dispersed_data(shape_size(data_shape) * elem_size);
-    std::vector<char> post_transpose_data(shape_size(data_shape) * elem_size);
+        std::vector<char> flat_data(padded_data.begin(), padded_data.end());
+        std::vector<char> dispersed_data(shape_size(data_shape) * elem_size);
+        std::vector<char> post_transpose_data(shape_size(data_shape) * elem_size);
 
-    for (int64_t block_idx = block_values_size - 1; block_idx >= 0; --block_idx)
-    {
-        int64_t sq_shape_idx = block_values_size - 1;
-        int64_t axis_idx = axes_order.size() - 1;
-        for (int64_t shape_idx = dispersed_shape.size() - 1; shape_idx >= 0; --shape_idx)
-        {
-            if (shape_idx == (block_idx + 1))
+        for (int64_t block_idx = block_values_size - 1; block_idx >= 0; --block_idx) {
+            int64_t sq_shape_idx = block_values_size - 1;
+            int64_t axis_idx = axes_order.size() - 1;
+            for (int64_t shape_idx = dispersed_shape.size() - 1; shape_idx >= 0; --shape_idx)
             {
-                dispersed_shape[shape_idx] = block_values[block_idx];
-                axes_order[0] = shape_idx;
+                if (shape_idx == (block_idx + 1))
+                {
+                    dispersed_shape[shape_idx] = block_values[block_idx];
+                    axes_order[0] = shape_idx;
+                }
+                else if (shape_idx == block_idx)
+                {
+                    dispersed_shape[shape_idx] =
+                        squeezed_shape[sq_shape_idx] / block_values[block_idx];
+                    axes_order[axis_idx] = shape_idx;
+                    axis_idx--;
+                    sq_shape_idx--;
+                }
+                else
+                {
+                    dispersed_shape[shape_idx] = squeezed_shape[sq_shape_idx];
+                    axes_order[axis_idx] = shape_idx;
+                    axis_idx--;
+                    sq_shape_idx--;
+                }
             }
-            else if (shape_idx == block_idx)
+
+            runtime::opt_kernel::reshape(flat_data.data(),
+                                         dispersed_data.data(),
+                                         data_shape,
+                                         plain_axes_order,
+                                         dispersed_shape,
+                                         elem_size);
+            Shape post_transpose_shape(axes_order.size());
+            for (size_t i = 0; i < axes_order.size(); ++i)
             {
-                dispersed_shape[shape_idx] = squeezed_shape[sq_shape_idx] / block_values[block_idx];
-                axes_order[axis_idx] = shape_idx;
-                axis_idx--;
-                sq_shape_idx--;
+                post_transpose_shape[i] = dispersed_shape[axes_order[i]];
             }
-            else
-            {
-                dispersed_shape[shape_idx] = squeezed_shape[sq_shape_idx];
-                axes_order[axis_idx] = shape_idx;
-                axis_idx--;
-                sq_shape_idx--;
-            }
+
+            runtime::opt_kernel::reshape(dispersed_data.data(),
+                                         post_transpose_data.data(),
+                                         dispersed_shape,
+                                         axes_order,
+                                         post_transpose_shape,
+                                         elem_size);
+            squeezed_shape[0] *= block_values[block_idx];
+            squeezed_shape[block_idx] /= block_values[block_idx];
+
+            runtime::opt_kernel::reshape(post_transpose_data.data(),
+                                         flat_data.data(),
+                                         post_transpose_shape,
+                                         plain_axes_order,
+                                         squeezed_shape,
+                                         elem_size);
+            data_shape = squeezed_shape;
         }
 
-        runtime::opt_kernel::reshape(flat_data.data(),
-                                     dispersed_data.data(),
-                                     data_shape,
-                                     plain_axes_order,
-                                     dispersed_shape,
-                                     elem_size);
-        Shape post_transpose_shape(axes_order.size());
-        for (size_t i = 0; i < axes_order.size(); ++i)
-        {
-            post_transpose_shape[i] = dispersed_shape[axes_order[i]];
-        }
+        out->write(flat_data.data(), elem_size * shape_size(out->get_shape()));
 
-        runtime::opt_kernel::reshape(dispersed_data.data(),
-                                     post_transpose_data.data(),
-                                     dispersed_shape,
-                                     axes_order,
-                                     post_transpose_shape,
-                                     elem_size);
-        squeezed_shape[0] *= block_values[block_idx];
-        squeezed_shape[block_idx] /= block_values[block_idx];
-
-        runtime::opt_kernel::reshape(post_transpose_data.data(),
-                                     flat_data.data(),
-                                     post_transpose_shape,
-                                     plain_axes_order,
-                                     squeezed_shape,
-                                     elem_size);
-        data_shape = squeezed_shape;
-    }
-
-    out->write(flat_data.data(), elem_size * shape_size(out->get_shape()));
-
-    return true;
+        return true);
+    return false;
 }

--- a/ngraph/core/src/op/space_to_batch.cpp
+++ b/ngraph/core/src/op/space_to_batch.cpp
@@ -144,14 +144,21 @@ bool ngraph::op::v1::SpaceToBatch::visit_attributes(ngraph::AttributeVisitor& vi
 bool ngraph::op::v1::SpaceToBatch::evaluate_space_to_batch(const HostTensorVector& outputs,
                                                            const HostTensorVector& inputs) const
 {
-    const auto& data = inputs[0]; const auto& out = outputs[0];
+    const auto& data = inputs[0];
+    const auto& out = outputs[0];
     const auto& out_shape = out->get_shape();
     size_t elem_size = data->get_element_type().size();
 
-    if (data->get_partial_shape().is_dynamic()) { return false; } auto data_shape =
-        data->get_shape();
+    if (data->get_partial_shape().is_dynamic())
+    {
+        return false;
+    }
+    auto data_shape = data->get_shape();
 
-    if (!(data->get_shape().size() == 4 || data->get_shape().size() == 5)) { return false; }
+    if (!(data->get_shape().size() == 4 || data->get_shape().size() == 5))
+    {
+        return false;
+    }
 
     size_t block_values_size = shape_size(inputs[1]->get_shape());
     const auto* block_values = inputs[1]->get_data_ptr<int64_t>();
@@ -160,16 +167,24 @@ bool ngraph::op::v1::SpaceToBatch::evaluate_space_to_batch(const HostTensorVecto
 
     const char* pad_value = nullptr;
     const std::vector<char> pad_zero_value(elem_size, 0);
-    if (inputs.size() == 4) { pad_value = inputs[3]->get_data_ptr<char>(); } else {
+    if (inputs.size() == 4)
+    {
+        pad_value = inputs[3]->get_data_ptr<char>();
+    }
+    else
+    {
         pad_value = pad_zero_value.data();
-    } CoordinateDiff pads_begin_vec(shape_size(inputs[2]->get_shape()));
+    }
+    CoordinateDiff pads_begin_vec(shape_size(inputs[2]->get_shape()));
     pads_begin_vec.assign(pads_begin, pads_begin + shape_size(inputs[2]->get_shape()));
     CoordinateDiff pads_end_vec(shape_size(inputs[2]->get_shape()));
     pads_end_vec.assign(pads_end, pads_end + shape_size(inputs[2]->get_shape()));
 
     Shape padded_shape(data_shape.size());
-    for (size_t i = 0; i < data_shape.size();
-         ++i) { padded_shape[i] = data_shape[i] + pads_begin_vec[i] + pads_end_vec[i]; }
+    for (size_t i = 0; i < data_shape.size(); ++i)
+    {
+        padded_shape[i] = data_shape[i] + pads_begin_vec[i] + pads_end_vec[i];
+    }
 
     std::vector<char> padded_data(shape_size(padded_shape) * elem_size);
     ngraph::runtime::reference::pad(data->get_data_ptr<char>(),
@@ -193,7 +208,8 @@ bool ngraph::op::v1::SpaceToBatch::evaluate_space_to_batch(const HostTensorVecto
     std::vector<char> dispersed_data(shape_size(data_shape) * elem_size);
     std::vector<char> post_transpose_data(shape_size(data_shape) * elem_size);
 
-    for (int64_t block_idx = block_values_size - 1; block_idx >= 0; --block_idx) {
+    for (int64_t block_idx = block_values_size - 1; block_idx >= 0; --block_idx)
+    {
         int64_t sq_shape_idx = block_values_size - 1;
         int64_t axis_idx = axes_order.size() - 1;
         for (int64_t shape_idx = dispersed_shape.size() - 1; shape_idx >= 0; --shape_idx)
@@ -205,8 +221,7 @@ bool ngraph::op::v1::SpaceToBatch::evaluate_space_to_batch(const HostTensorVecto
             }
             else if (shape_idx == block_idx)
             {
-                dispersed_shape[shape_idx] =
-                    squeezed_shape[sq_shape_idx] / block_values[block_idx];
+                dispersed_shape[shape_idx] = squeezed_shape[sq_shape_idx] / block_values[block_idx];
                 axes_order[axis_idx] = shape_idx;
                 axis_idx--;
                 sq_shape_idx--;
@@ -258,7 +273,6 @@ bool ngraph::op::v1::SpaceToBatch::evaluate_space_to_batch(const HostTensorVecto
 bool ngraph::op::v1::SpaceToBatch::evaluate(const HostTensorVector& outputs,
                                             const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(
-        v1_SpaceToBatch, return evaluate_space_to_batch(outputs, inputs));
+    NGRAPH_OP_SCOPE(v1_SpaceToBatch, return evaluate_space_to_batch(outputs, inputs));
     return false;
 }

--- a/ngraph/core/src/op/space_to_batch.cpp
+++ b/ngraph/core/src/op/space_to_batch.cpp
@@ -141,118 +141,124 @@ bool ngraph::op::v1::SpaceToBatch::visit_attributes(ngraph::AttributeVisitor& vi
     return true;
 }
 
+bool ngraph::op::v1::SpaceToBatch::evaluate_space_to_batch(const HostTensorVector& outputs,
+                                                           const HostTensorVector& inputs) const
+{
+    const auto& data = inputs[0]; const auto& out = outputs[0];
+    const auto& out_shape = out->get_shape();
+    size_t elem_size = data->get_element_type().size();
+
+    if (data->get_partial_shape().is_dynamic()) { return false; } auto data_shape =
+        data->get_shape();
+
+    if (!(data->get_shape().size() == 4 || data->get_shape().size() == 5)) { return false; }
+
+    size_t block_values_size = shape_size(inputs[1]->get_shape());
+    const auto* block_values = inputs[1]->get_data_ptr<int64_t>();
+    const auto* pads_begin = inputs[2]->get_data_ptr<int64_t>();
+    const auto* pads_end = inputs[3]->get_data_ptr<int64_t>();
+
+    const char* pad_value = nullptr;
+    const std::vector<char> pad_zero_value(elem_size, 0);
+    if (inputs.size() == 4) { pad_value = inputs[3]->get_data_ptr<char>(); } else {
+        pad_value = pad_zero_value.data();
+    } CoordinateDiff pads_begin_vec(shape_size(inputs[2]->get_shape()));
+    pads_begin_vec.assign(pads_begin, pads_begin + shape_size(inputs[2]->get_shape()));
+    CoordinateDiff pads_end_vec(shape_size(inputs[2]->get_shape()));
+    pads_end_vec.assign(pads_end, pads_end + shape_size(inputs[2]->get_shape()));
+
+    Shape padded_shape(data_shape.size());
+    for (size_t i = 0; i < data_shape.size();
+         ++i) { padded_shape[i] = data_shape[i] + pads_begin_vec[i] + pads_end_vec[i]; }
+
+    std::vector<char> padded_data(shape_size(padded_shape) * elem_size);
+    ngraph::runtime::reference::pad(data->get_data_ptr<char>(),
+                                    pad_value,
+                                    padded_data.data(),
+                                    elem_size,
+                                    data_shape,
+                                    padded_shape,
+                                    pads_begin_vec,
+                                    pads_end_vec,
+                                    ngraph::op::PadMode::CONSTANT);
+    data_shape = padded_shape;
+
+    Shape dispersed_shape(block_values_size + 1);
+    std::vector<size_t> axes_order(block_values_size + 1);
+    Shape squeezed_shape(data_shape.begin(), data_shape.end());
+    std::vector<size_t> plain_axes_order(block_values_size + 1);
+    std::iota(plain_axes_order.begin(), plain_axes_order.end(), 0);
+
+    std::vector<char> flat_data(padded_data.begin(), padded_data.end());
+    std::vector<char> dispersed_data(shape_size(data_shape) * elem_size);
+    std::vector<char> post_transpose_data(shape_size(data_shape) * elem_size);
+
+    for (int64_t block_idx = block_values_size - 1; block_idx >= 0; --block_idx) {
+        int64_t sq_shape_idx = block_values_size - 1;
+        int64_t axis_idx = axes_order.size() - 1;
+        for (int64_t shape_idx = dispersed_shape.size() - 1; shape_idx >= 0; --shape_idx)
+        {
+            if (shape_idx == (block_idx + 1))
+            {
+                dispersed_shape[shape_idx] = block_values[block_idx];
+                axes_order[0] = shape_idx;
+            }
+            else if (shape_idx == block_idx)
+            {
+                dispersed_shape[shape_idx] =
+                    squeezed_shape[sq_shape_idx] / block_values[block_idx];
+                axes_order[axis_idx] = shape_idx;
+                axis_idx--;
+                sq_shape_idx--;
+            }
+            else
+            {
+                dispersed_shape[shape_idx] = squeezed_shape[sq_shape_idx];
+                axes_order[axis_idx] = shape_idx;
+                axis_idx--;
+                sq_shape_idx--;
+            }
+        }
+
+        runtime::opt_kernel::reshape(flat_data.data(),
+                                     dispersed_data.data(),
+                                     data_shape,
+                                     plain_axes_order,
+                                     dispersed_shape,
+                                     elem_size);
+        Shape post_transpose_shape(axes_order.size());
+        for (size_t i = 0; i < axes_order.size(); ++i)
+        {
+            post_transpose_shape[i] = dispersed_shape[axes_order[i]];
+        }
+
+        runtime::opt_kernel::reshape(dispersed_data.data(),
+                                     post_transpose_data.data(),
+                                     dispersed_shape,
+                                     axes_order,
+                                     post_transpose_shape,
+                                     elem_size);
+        squeezed_shape[0] *= block_values[block_idx];
+        squeezed_shape[block_idx] /= block_values[block_idx];
+
+        runtime::opt_kernel::reshape(post_transpose_data.data(),
+                                     flat_data.data(),
+                                     post_transpose_shape,
+                                     plain_axes_order,
+                                     squeezed_shape,
+                                     elem_size);
+        data_shape = squeezed_shape;
+    }
+
+    out->write(flat_data.data(), elem_size * shape_size(out->get_shape()));
+
+    return true;
+}
+
 bool ngraph::op::v1::SpaceToBatch::evaluate(const HostTensorVector& outputs,
                                             const HostTensorVector& inputs) const
 {
     NGRAPH_OP_SCOPE(
-        v1_SpaceToBatch, const auto& data = inputs[0]; const auto& out = outputs[0];
-        const auto& out_shape = out->get_shape();
-        size_t elem_size = data->get_element_type().size();
-
-        if (data->get_partial_shape().is_dynamic()) { return false; } auto data_shape =
-            data->get_shape();
-
-        if (!(data->get_shape().size() == 4 || data->get_shape().size() == 5)) { return false; }
-
-        size_t block_values_size = shape_size(inputs[1]->get_shape());
-        const auto* block_values = inputs[1]->get_data_ptr<int64_t>();
-        const auto* pads_begin = inputs[2]->get_data_ptr<int64_t>();
-        const auto* pads_end = inputs[3]->get_data_ptr<int64_t>();
-
-        const char* pad_value = nullptr;
-        const std::vector<char> pad_zero_value(elem_size, 0);
-        if (inputs.size() == 4) { pad_value = inputs[3]->get_data_ptr<char>(); } else {
-            pad_value = pad_zero_value.data();
-        } CoordinateDiff pads_begin_vec(shape_size(inputs[2]->get_shape()));
-        pads_begin_vec.assign(pads_begin, pads_begin + shape_size(inputs[2]->get_shape()));
-        CoordinateDiff pads_end_vec(shape_size(inputs[2]->get_shape()));
-        pads_end_vec.assign(pads_end, pads_end + shape_size(inputs[2]->get_shape()));
-
-        Shape padded_shape(data_shape.size());
-        for (size_t i = 0; i < data_shape.size();
-             ++i) { padded_shape[i] = data_shape[i] + pads_begin_vec[i] + pads_end_vec[i]; }
-
-        std::vector<char> padded_data(shape_size(padded_shape) * elem_size);
-        ngraph::runtime::reference::pad(data->get_data_ptr<char>(),
-                                        pad_value,
-                                        padded_data.data(),
-                                        elem_size,
-                                        data_shape,
-                                        padded_shape,
-                                        pads_begin_vec,
-                                        pads_end_vec,
-                                        ngraph::op::PadMode::CONSTANT);
-        data_shape = padded_shape;
-
-        Shape dispersed_shape(block_values_size + 1);
-        std::vector<size_t> axes_order(block_values_size + 1);
-        Shape squeezed_shape(data_shape.begin(), data_shape.end());
-        std::vector<size_t> plain_axes_order(block_values_size + 1);
-        std::iota(plain_axes_order.begin(), plain_axes_order.end(), 0);
-
-        std::vector<char> flat_data(padded_data.begin(), padded_data.end());
-        std::vector<char> dispersed_data(shape_size(data_shape) * elem_size);
-        std::vector<char> post_transpose_data(shape_size(data_shape) * elem_size);
-
-        for (int64_t block_idx = block_values_size - 1; block_idx >= 0; --block_idx) {
-            int64_t sq_shape_idx = block_values_size - 1;
-            int64_t axis_idx = axes_order.size() - 1;
-            for (int64_t shape_idx = dispersed_shape.size() - 1; shape_idx >= 0; --shape_idx)
-            {
-                if (shape_idx == (block_idx + 1))
-                {
-                    dispersed_shape[shape_idx] = block_values[block_idx];
-                    axes_order[0] = shape_idx;
-                }
-                else if (shape_idx == block_idx)
-                {
-                    dispersed_shape[shape_idx] =
-                        squeezed_shape[sq_shape_idx] / block_values[block_idx];
-                    axes_order[axis_idx] = shape_idx;
-                    axis_idx--;
-                    sq_shape_idx--;
-                }
-                else
-                {
-                    dispersed_shape[shape_idx] = squeezed_shape[sq_shape_idx];
-                    axes_order[axis_idx] = shape_idx;
-                    axis_idx--;
-                    sq_shape_idx--;
-                }
-            }
-
-            runtime::opt_kernel::reshape(flat_data.data(),
-                                         dispersed_data.data(),
-                                         data_shape,
-                                         plain_axes_order,
-                                         dispersed_shape,
-                                         elem_size);
-            Shape post_transpose_shape(axes_order.size());
-            for (size_t i = 0; i < axes_order.size(); ++i)
-            {
-                post_transpose_shape[i] = dispersed_shape[axes_order[i]];
-            }
-
-            runtime::opt_kernel::reshape(dispersed_data.data(),
-                                         post_transpose_data.data(),
-                                         dispersed_shape,
-                                         axes_order,
-                                         post_transpose_shape,
-                                         elem_size);
-            squeezed_shape[0] *= block_values[block_idx];
-            squeezed_shape[block_idx] /= block_values[block_idx];
-
-            runtime::opt_kernel::reshape(post_transpose_data.data(),
-                                         flat_data.data(),
-                                         post_transpose_shape,
-                                         plain_axes_order,
-                                         squeezed_shape,
-                                         elem_size);
-            data_shape = squeezed_shape;
-        }
-
-        out->write(flat_data.data(), elem_size * shape_size(out->get_shape()));
-
-        return true);
+        v1_SpaceToBatch, return evaluate_space_to_batch(outputs, inputs));
     return false;
 }

--- a/ngraph/core/src/op/space_to_depth.cpp
+++ b/ngraph/core/src/op/space_to_depth.cpp
@@ -110,102 +110,107 @@ void ngraph::op::v0::SpaceToDepth::validate_and_infer_types()
     }
 }
 
+bool ngraph::op::v0::SpaceToDepth::evaluate_space_to_depth(const HostTensorVector& outputs,
+                                                           const HostTensorVector& inputs) const
+{
+    const auto& data = inputs[0]; const auto& out = outputs[0];
+    const auto& out_shape = out->get_shape();
+    size_t elem_size = data->get_element_type().size();
+
+    if (data->get_partial_shape().is_dynamic()) { return false; } auto data_shape =
+        data->get_shape();
+    const size_t n_dim = data_shape.at(0);
+    const size_t c_dim = data_shape.at(1);
+    const size_t spatial_dim_index = 2;
+    const size_t spatial_dims = data_shape.size() - spatial_dim_index;
+
+    for (int i = spatial_dim_index; i < data_shape.size(); ++i) {
+        NODE_VALIDATION_CHECK(this,
+                              m_blocksize > 0 && data_shape.at(i) % m_blocksize == 0,
+                              "The dimension on position: ",
+                              i,
+                              " equal to: ",
+                              data_shape.at(i),
+                              " must be a multiple of m_blocksize: ",
+                              m_blocksize);
+    }
+
+    // First we have to disperse the data from spatial dimensions, then
+    // rearrange them so as appropriate chunks of data where close to their
+    // destination place. Finally squeeze data from respective dimensions.
+    Shape dispersed_shape{n_dim, c_dim};
+    for (int i = 0; i < spatial_dims; ++i) {
+        dispersed_shape.push_back(data_shape.at(i + spatial_dim_index) / m_blocksize);
+        dispersed_shape.push_back(m_blocksize);
+    } std::vector<size_t> plain_axes_order(data_shape.size());
+    std::iota(plain_axes_order.begin(), plain_axes_order.end(), 0);
+    std::vector<char> dispersed_data(shape_size(data_shape) * elem_size);
+    runtime::opt_kernel::reshape(data->get_data_ptr<char>(),
+                                 dispersed_data.data(),
+                                 data_shape,
+                                 plain_axes_order,
+                                 dispersed_shape,
+                                 elem_size);
+    // calculate axes to transpose
+    // [0, 3, 5, ..., spatial_dims + (spatial_dims + 1), 2, 4, ..., K + K])
+    vector<size_t> axes_order{0};
+    for (size_t i = 0, j = 3; i < spatial_dims; ++i, j += 2) {
+        axes_order.push_back(j);
+    } for (size_t i = 0, j = 2; i < spatial_dims; ++i, j += 2) { axes_order.push_back(j); }
+
+    switch (m_mode) {
+        // x' = reshape(data, [N, C, D1/block_size, block_size, D2/block_size, block_size, ...,
+        // DK/block_size, block_size])
+        // x'' = transpose(x', [0,  1, 3, 5, ..., K + (K + 1),  2, 4, ..., K + K])
+        // y = reshape(x'', [N, C * (block_size ^ K), D1 / block_size, D2 / block_size, ..., DK
+        // /
+        // block_size])
+    case SpaceToDepthMode::DEPTH_FIRST:
+        {
+            axes_order.insert(axes_order.begin() + 1, 1);
+            break;
+        }
+        // x' = reshape(data, [N, C, D1/block_size, block_size, D2/block_size, block_size, ... ,
+        // DK/block_size, block_size])
+        // x'' = transpose(x',  [0,  3, 5, ..., K + (K + 1), 1,  2, 4, ..., K + K])
+        // y = reshape(x'', [N, C * (block_size ^ K), D1 / block_size, D2 / block_size, ..., DK
+        // /
+        // block_size])
+    case SpaceToDepthMode::BLOCKS_FIRST:
+    default: { axes_order.insert(axes_order.begin() + spatial_dims + 1, 1);
+    }
+    } std::vector<char> transposed_data(shape_size(data_shape) * elem_size);
+    Shape post_transpose_shape(axes_order.size());
+    for (size_t axis_idx = 0; axis_idx < axes_order.size();
+         ++axis_idx) { post_transpose_shape[axis_idx] = dispersed_shape[axes_order[axis_idx]]; }
+
+    runtime::opt_kernel::reshape(dispersed_data.data(),
+                                 transposed_data.data(),
+                                 dispersed_shape,
+                                 axes_order,
+                                 post_transpose_shape,
+                                 elem_size);
+
+    Shape squeezed_shape{n_dim};
+    for (int i = 0; i < spatial_dims; ++i) {
+        squeezed_shape.push_back(data_shape.at(spatial_dim_index + i) / m_blocksize);
+    } squeezed_shape.insert(squeezed_shape.begin() + 1,
+                            c_dim * std::pow(m_blocksize, spatial_dims));
+    for (size_t i = plain_axes_order.size() - 1; i < post_transpose_shape.size() - 1; ++i) {
+        plain_axes_order.push_back(plain_axes_order[i] + 1);
+    } runtime::opt_kernel::reshape(transposed_data.data(),
+                                   out->get_data_ptr<char>(),
+                                   post_transpose_shape,
+                                   plain_axes_order,
+                                   squeezed_shape,
+                                   elem_size);
+    return true;
+}
 bool ngraph::op::v0::SpaceToDepth::evaluate(const HostTensorVector& outputs,
                                             const HostTensorVector& inputs) const
 {
     NGRAPH_OP_SCOPE(
-        v0_SpaceToDepth_evaluate, const auto& data = inputs[0]; const auto& out = outputs[0];
-        const auto& out_shape = out->get_shape();
-        size_t elem_size = data->get_element_type().size();
-
-        if (data->get_partial_shape().is_dynamic()) { return false; } auto data_shape =
-            data->get_shape();
-        const size_t n_dim = data_shape.at(0);
-        const size_t c_dim = data_shape.at(1);
-        const size_t spatial_dim_index = 2;
-        const size_t spatial_dims = data_shape.size() - spatial_dim_index;
-
-        for (int i = spatial_dim_index; i < data_shape.size(); ++i) {
-            NODE_VALIDATION_CHECK(this,
-                                  m_blocksize > 0 && data_shape.at(i) % m_blocksize == 0,
-                                  "The dimension on position: ",
-                                  i,
-                                  " equal to: ",
-                                  data_shape.at(i),
-                                  " must be a multiple of m_blocksize: ",
-                                  m_blocksize);
-        }
-
-        // First we have to disperse the data from spatial dimensions, then
-        // rearrange them so as appropriate chunks of data where close to their
-        // destination place. Finally squeeze data from respective dimensions.
-        Shape dispersed_shape{n_dim, c_dim};
-        for (int i = 0; i < spatial_dims; ++i) {
-            dispersed_shape.push_back(data_shape.at(i + spatial_dim_index) / m_blocksize);
-            dispersed_shape.push_back(m_blocksize);
-        } std::vector<size_t> plain_axes_order(data_shape.size());
-        std::iota(plain_axes_order.begin(), plain_axes_order.end(), 0);
-        std::vector<char> dispersed_data(shape_size(data_shape) * elem_size);
-        runtime::opt_kernel::reshape(data->get_data_ptr<char>(),
-                                     dispersed_data.data(),
-                                     data_shape,
-                                     plain_axes_order,
-                                     dispersed_shape,
-                                     elem_size);
-        // calculate axes to transpose
-        // [0, 3, 5, ..., spatial_dims + (spatial_dims + 1), 2, 4, ..., K + K])
-        vector<size_t> axes_order{0};
-        for (size_t i = 0, j = 3; i < spatial_dims; ++i, j += 2) {
-            axes_order.push_back(j);
-        } for (size_t i = 0, j = 2; i < spatial_dims; ++i, j += 2) { axes_order.push_back(j); }
-
-        switch (m_mode) {
-            // x' = reshape(data, [N, C, D1/block_size, block_size, D2/block_size, block_size, ...,
-            // DK/block_size, block_size])
-            // x'' = transpose(x', [0,  1, 3, 5, ..., K + (K + 1),  2, 4, ..., K + K])
-            // y = reshape(x'', [N, C * (block_size ^ K), D1 / block_size, D2 / block_size, ..., DK
-            // /
-            // block_size])
-            case SpaceToDepthMode::DEPTH_FIRST:
-            {
-                axes_order.insert(axes_order.begin() + 1, 1);
-                break;
-            }
-            // x' = reshape(data, [N, C, D1/block_size, block_size, D2/block_size, block_size, ... ,
-            // DK/block_size, block_size])
-            // x'' = transpose(x',  [0,  3, 5, ..., K + (K + 1), 1,  2, 4, ..., K + K])
-            // y = reshape(x'', [N, C * (block_size ^ K), D1 / block_size, D2 / block_size, ..., DK
-            // /
-            // block_size])
-            case SpaceToDepthMode::BLOCKS_FIRST:
-            default: { axes_order.insert(axes_order.begin() + spatial_dims + 1, 1);
-            }
-        } std::vector<char> transposed_data(shape_size(data_shape) * elem_size);
-        Shape post_transpose_shape(axes_order.size());
-        for (size_t axis_idx = 0; axis_idx < axes_order.size();
-             ++axis_idx) { post_transpose_shape[axis_idx] = dispersed_shape[axes_order[axis_idx]]; }
-
-        runtime::opt_kernel::reshape(dispersed_data.data(),
-                                     transposed_data.data(),
-                                     dispersed_shape,
-                                     axes_order,
-                                     post_transpose_shape,
-                                     elem_size);
-
-        Shape squeezed_shape{n_dim};
-        for (int i = 0; i < spatial_dims; ++i) {
-            squeezed_shape.push_back(data_shape.at(spatial_dim_index + i) / m_blocksize);
-        } squeezed_shape.insert(squeezed_shape.begin() + 1,
-                                c_dim * std::pow(m_blocksize, spatial_dims));
-        for (size_t i = plain_axes_order.size() - 1; i < post_transpose_shape.size() - 1; ++i) {
-            plain_axes_order.push_back(plain_axes_order[i] + 1);
-        } runtime::opt_kernel::reshape(transposed_data.data(),
-                                       out->get_data_ptr<char>(),
-                                       post_transpose_shape,
-                                       plain_axes_order,
-                                       squeezed_shape,
-                                       elem_size);
-        return true);
+        v0_SpaceToDepth_evaluate, return evaluate_space_to_depth(outputs, inputs));
     return false;
 }
 

--- a/ngraph/core/src/op/space_to_depth.cpp
+++ b/ngraph/core/src/op/space_to_depth.cpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <numeric>
 
+#include "itt.hpp"
 #include "ngraph/attribute_visitor.hpp"
 #include "ngraph/builder/reshape.hpp"
 #include "ngraph/op/space_to_depth.hpp"
@@ -112,115 +113,100 @@ void ngraph::op::v0::SpaceToDepth::validate_and_infer_types()
 bool ngraph::op::v0::SpaceToDepth::evaluate(const HostTensorVector& outputs,
                                             const HostTensorVector& inputs) const
 {
-    const auto& data = inputs[0];
-    const auto& out = outputs[0];
-    const auto& out_shape = out->get_shape();
-    size_t elem_size = data->get_element_type().size();
+    NGRAPH_OP_SCOPE(
+        v0_SpaceToDepth_evaluate, const auto& data = inputs[0]; const auto& out = outputs[0];
+        const auto& out_shape = out->get_shape();
+        size_t elem_size = data->get_element_type().size();
 
-    if (data->get_partial_shape().is_dynamic())
-    {
-        return false;
-    }
-    auto data_shape = data->get_shape();
-    const size_t n_dim = data_shape.at(0);
-    const size_t c_dim = data_shape.at(1);
-    const size_t spatial_dim_index = 2;
-    const size_t spatial_dims = data_shape.size() - spatial_dim_index;
+        if (data->get_partial_shape().is_dynamic()) { return false; } auto data_shape =
+            data->get_shape();
+        const size_t n_dim = data_shape.at(0);
+        const size_t c_dim = data_shape.at(1);
+        const size_t spatial_dim_index = 2;
+        const size_t spatial_dims = data_shape.size() - spatial_dim_index;
 
-    for (int i = spatial_dim_index; i < data_shape.size(); ++i)
-    {
-        NODE_VALIDATION_CHECK(this,
-                              m_blocksize > 0 && data_shape.at(i) % m_blocksize == 0,
-                              "The dimension on position: ",
-                              i,
-                              " equal to: ",
-                              data_shape.at(i),
-                              " must be a multiple of m_blocksize: ",
-                              m_blocksize);
-    }
+        for (int i = spatial_dim_index; i < data_shape.size(); ++i) {
+            NODE_VALIDATION_CHECK(this,
+                                  m_blocksize > 0 && data_shape.at(i) % m_blocksize == 0,
+                                  "The dimension on position: ",
+                                  i,
+                                  " equal to: ",
+                                  data_shape.at(i),
+                                  " must be a multiple of m_blocksize: ",
+                                  m_blocksize);
+        }
 
-    // First we have to disperse the data from spatial dimensions, then
-    // rearrange them so as appropriate chunks of data where close to their
-    // destination place. Finally squeeze data from respective dimensions.
-    Shape dispersed_shape{n_dim, c_dim};
-    for (int i = 0; i < spatial_dims; ++i)
-    {
-        dispersed_shape.push_back(data_shape.at(i + spatial_dim_index) / m_blocksize);
-        dispersed_shape.push_back(m_blocksize);
-    }
-    std::vector<size_t> plain_axes_order(data_shape.size());
-    std::iota(plain_axes_order.begin(), plain_axes_order.end(), 0);
-    std::vector<char> dispersed_data(shape_size(data_shape) * elem_size);
-    runtime::opt_kernel::reshape(data->get_data_ptr<char>(),
-                                 dispersed_data.data(),
-                                 data_shape,
-                                 plain_axes_order,
-                                 dispersed_shape,
-                                 elem_size);
-    // calculate axes to transpose
-    // [0, 3, 5, ..., spatial_dims + (spatial_dims + 1), 2, 4, ..., K + K])
-    vector<size_t> axes_order{0};
-    for (size_t i = 0, j = 3; i < spatial_dims; ++i, j += 2)
-    {
-        axes_order.push_back(j);
-    }
-    for (size_t i = 0, j = 2; i < spatial_dims; ++i, j += 2)
-    {
-        axes_order.push_back(j);
-    }
+        // First we have to disperse the data from spatial dimensions, then
+        // rearrange them so as appropriate chunks of data where close to their
+        // destination place. Finally squeeze data from respective dimensions.
+        Shape dispersed_shape{n_dim, c_dim};
+        for (int i = 0; i < spatial_dims; ++i) {
+            dispersed_shape.push_back(data_shape.at(i + spatial_dim_index) / m_blocksize);
+            dispersed_shape.push_back(m_blocksize);
+        } std::vector<size_t> plain_axes_order(data_shape.size());
+        std::iota(plain_axes_order.begin(), plain_axes_order.end(), 0);
+        std::vector<char> dispersed_data(shape_size(data_shape) * elem_size);
+        runtime::opt_kernel::reshape(data->get_data_ptr<char>(),
+                                     dispersed_data.data(),
+                                     data_shape,
+                                     plain_axes_order,
+                                     dispersed_shape,
+                                     elem_size);
+        // calculate axes to transpose
+        // [0, 3, 5, ..., spatial_dims + (spatial_dims + 1), 2, 4, ..., K + K])
+        vector<size_t> axes_order{0};
+        for (size_t i = 0, j = 3; i < spatial_dims; ++i, j += 2) {
+            axes_order.push_back(j);
+        } for (size_t i = 0, j = 2; i < spatial_dims; ++i, j += 2) { axes_order.push_back(j); }
 
-    switch (m_mode)
-    {
-    // x' = reshape(data, [N, C, D1/block_size, block_size, D2/block_size, block_size, ...,
-    // DK/block_size, block_size])
-    // x'' = transpose(x', [0,  1, 3, 5, ..., K + (K + 1),  2, 4, ..., K + K])
-    // y = reshape(x'', [N, C * (block_size ^ K), D1 / block_size, D2 / block_size, ..., DK /
-    // block_size])
-    case SpaceToDepthMode::DEPTH_FIRST:
-    {
-        axes_order.insert(axes_order.begin() + 1, 1);
-        break;
-    }
-    // x' = reshape(data, [N, C, D1/block_size, block_size, D2/block_size, block_size, ... ,
-    // DK/block_size, block_size])
-    // x'' = transpose(x',  [0,  3, 5, ..., K + (K + 1), 1,  2, 4, ..., K + K])
-    // y = reshape(x'', [N, C * (block_size ^ K), D1 / block_size, D2 / block_size, ..., DK /
-    // block_size])
-    case SpaceToDepthMode::BLOCKS_FIRST:
-    default: { axes_order.insert(axes_order.begin() + spatial_dims + 1, 1);
-    }
-    }
-    std::vector<char> transposed_data(shape_size(data_shape) * elem_size);
-    Shape post_transpose_shape(axes_order.size());
-    for (size_t axis_idx = 0; axis_idx < axes_order.size(); ++axis_idx)
-    {
-        post_transpose_shape[axis_idx] = dispersed_shape[axes_order[axis_idx]];
-    }
+        switch (m_mode) {
+            // x' = reshape(data, [N, C, D1/block_size, block_size, D2/block_size, block_size, ...,
+            // DK/block_size, block_size])
+            // x'' = transpose(x', [0,  1, 3, 5, ..., K + (K + 1),  2, 4, ..., K + K])
+            // y = reshape(x'', [N, C * (block_size ^ K), D1 / block_size, D2 / block_size, ..., DK
+            // /
+            // block_size])
+            case SpaceToDepthMode::DEPTH_FIRST:
+            {
+                axes_order.insert(axes_order.begin() + 1, 1);
+                break;
+            }
+            // x' = reshape(data, [N, C, D1/block_size, block_size, D2/block_size, block_size, ... ,
+            // DK/block_size, block_size])
+            // x'' = transpose(x',  [0,  3, 5, ..., K + (K + 1), 1,  2, 4, ..., K + K])
+            // y = reshape(x'', [N, C * (block_size ^ K), D1 / block_size, D2 / block_size, ..., DK
+            // /
+            // block_size])
+            case SpaceToDepthMode::BLOCKS_FIRST:
+            default: { axes_order.insert(axes_order.begin() + spatial_dims + 1, 1);
+            }
+        } std::vector<char> transposed_data(shape_size(data_shape) * elem_size);
+        Shape post_transpose_shape(axes_order.size());
+        for (size_t axis_idx = 0; axis_idx < axes_order.size();
+             ++axis_idx) { post_transpose_shape[axis_idx] = dispersed_shape[axes_order[axis_idx]]; }
 
-    runtime::opt_kernel::reshape(dispersed_data.data(),
-                                 transposed_data.data(),
-                                 dispersed_shape,
-                                 axes_order,
-                                 post_transpose_shape,
-                                 elem_size);
+        runtime::opt_kernel::reshape(dispersed_data.data(),
+                                     transposed_data.data(),
+                                     dispersed_shape,
+                                     axes_order,
+                                     post_transpose_shape,
+                                     elem_size);
 
-    Shape squeezed_shape{n_dim};
-    for (int i = 0; i < spatial_dims; ++i)
-    {
-        squeezed_shape.push_back(data_shape.at(spatial_dim_index + i) / m_blocksize);
-    }
-    squeezed_shape.insert(squeezed_shape.begin() + 1, c_dim * std::pow(m_blocksize, spatial_dims));
-    for (size_t i = plain_axes_order.size() - 1; i < post_transpose_shape.size() - 1; ++i)
-    {
-        plain_axes_order.push_back(plain_axes_order[i] + 1);
-    }
-    runtime::opt_kernel::reshape(transposed_data.data(),
-                                 out->get_data_ptr<char>(),
-                                 post_transpose_shape,
-                                 plain_axes_order,
-                                 squeezed_shape,
-                                 elem_size);
-    return true;
+        Shape squeezed_shape{n_dim};
+        for (int i = 0; i < spatial_dims; ++i) {
+            squeezed_shape.push_back(data_shape.at(spatial_dim_index + i) / m_blocksize);
+        } squeezed_shape.insert(squeezed_shape.begin() + 1,
+                                c_dim * std::pow(m_blocksize, spatial_dims));
+        for (size_t i = plain_axes_order.size() - 1; i < post_transpose_shape.size() - 1; ++i) {
+            plain_axes_order.push_back(plain_axes_order[i] + 1);
+        } runtime::opt_kernel::reshape(transposed_data.data(),
+                                       out->get_data_ptr<char>(),
+                                       post_transpose_shape,
+                                       plain_axes_order,
+                                       squeezed_shape,
+                                       elem_size);
+        return true);
+    return false;
 }
 
 namespace ngraph

--- a/ngraph/core/src/op/space_to_depth.cpp
+++ b/ngraph/core/src/op/space_to_depth.cpp
@@ -113,18 +113,23 @@ void ngraph::op::v0::SpaceToDepth::validate_and_infer_types()
 bool ngraph::op::v0::SpaceToDepth::evaluate_space_to_depth(const HostTensorVector& outputs,
                                                            const HostTensorVector& inputs) const
 {
-    const auto& data = inputs[0]; const auto& out = outputs[0];
+    const auto& data = inputs[0];
+    const auto& out = outputs[0];
     const auto& out_shape = out->get_shape();
     size_t elem_size = data->get_element_type().size();
 
-    if (data->get_partial_shape().is_dynamic()) { return false; } auto data_shape =
-        data->get_shape();
+    if (data->get_partial_shape().is_dynamic())
+    {
+        return false;
+    }
+    auto data_shape = data->get_shape();
     const size_t n_dim = data_shape.at(0);
     const size_t c_dim = data_shape.at(1);
     const size_t spatial_dim_index = 2;
     const size_t spatial_dims = data_shape.size() - spatial_dim_index;
 
-    for (int i = spatial_dim_index; i < data_shape.size(); ++i) {
+    for (int i = spatial_dim_index; i < data_shape.size(); ++i)
+    {
         NODE_VALIDATION_CHECK(this,
                               m_blocksize > 0 && data_shape.at(i) % m_blocksize == 0,
                               "The dimension on position: ",
@@ -139,10 +144,12 @@ bool ngraph::op::v0::SpaceToDepth::evaluate_space_to_depth(const HostTensorVecto
     // rearrange them so as appropriate chunks of data where close to their
     // destination place. Finally squeeze data from respective dimensions.
     Shape dispersed_shape{n_dim, c_dim};
-    for (int i = 0; i < spatial_dims; ++i) {
+    for (int i = 0; i < spatial_dims; ++i)
+    {
         dispersed_shape.push_back(data_shape.at(i + spatial_dim_index) / m_blocksize);
         dispersed_shape.push_back(m_blocksize);
-    } std::vector<size_t> plain_axes_order(data_shape.size());
+    }
+    std::vector<size_t> plain_axes_order(data_shape.size());
     std::iota(plain_axes_order.begin(), plain_axes_order.end(), 0);
     std::vector<char> dispersed_data(shape_size(data_shape) * elem_size);
     runtime::opt_kernel::reshape(data->get_data_ptr<char>(),
@@ -154,35 +161,44 @@ bool ngraph::op::v0::SpaceToDepth::evaluate_space_to_depth(const HostTensorVecto
     // calculate axes to transpose
     // [0, 3, 5, ..., spatial_dims + (spatial_dims + 1), 2, 4, ..., K + K])
     vector<size_t> axes_order{0};
-    for (size_t i = 0, j = 3; i < spatial_dims; ++i, j += 2) {
+    for (size_t i = 0, j = 3; i < spatial_dims; ++i, j += 2)
+    {
         axes_order.push_back(j);
-    } for (size_t i = 0, j = 2; i < spatial_dims; ++i, j += 2) { axes_order.push_back(j); }
+    }
+    for (size_t i = 0, j = 2; i < spatial_dims; ++i, j += 2)
+    {
+        axes_order.push_back(j);
+    }
 
-    switch (m_mode) {
-        // x' = reshape(data, [N, C, D1/block_size, block_size, D2/block_size, block_size, ...,
-        // DK/block_size, block_size])
-        // x'' = transpose(x', [0,  1, 3, 5, ..., K + (K + 1),  2, 4, ..., K + K])
-        // y = reshape(x'', [N, C * (block_size ^ K), D1 / block_size, D2 / block_size, ..., DK
-        // /
-        // block_size])
+    switch (m_mode)
+    {
+    // x' = reshape(data, [N, C, D1/block_size, block_size, D2/block_size, block_size, ...,
+    // DK/block_size, block_size])
+    // x'' = transpose(x', [0,  1, 3, 5, ..., K + (K + 1),  2, 4, ..., K + K])
+    // y = reshape(x'', [N, C * (block_size ^ K), D1 / block_size, D2 / block_size, ..., DK
+    // /
+    // block_size])
     case SpaceToDepthMode::DEPTH_FIRST:
-        {
-            axes_order.insert(axes_order.begin() + 1, 1);
-            break;
-        }
-        // x' = reshape(data, [N, C, D1/block_size, block_size, D2/block_size, block_size, ... ,
-        // DK/block_size, block_size])
-        // x'' = transpose(x',  [0,  3, 5, ..., K + (K + 1), 1,  2, 4, ..., K + K])
-        // y = reshape(x'', [N, C * (block_size ^ K), D1 / block_size, D2 / block_size, ..., DK
-        // /
-        // block_size])
+    {
+        axes_order.insert(axes_order.begin() + 1, 1);
+        break;
+    }
+    // x' = reshape(data, [N, C, D1/block_size, block_size, D2/block_size, block_size, ... ,
+    // DK/block_size, block_size])
+    // x'' = transpose(x',  [0,  3, 5, ..., K + (K + 1), 1,  2, 4, ..., K + K])
+    // y = reshape(x'', [N, C * (block_size ^ K), D1 / block_size, D2 / block_size, ..., DK
+    // /
+    // block_size])
     case SpaceToDepthMode::BLOCKS_FIRST:
     default: { axes_order.insert(axes_order.begin() + spatial_dims + 1, 1);
     }
-    } std::vector<char> transposed_data(shape_size(data_shape) * elem_size);
+    }
+    std::vector<char> transposed_data(shape_size(data_shape) * elem_size);
     Shape post_transpose_shape(axes_order.size());
-    for (size_t axis_idx = 0; axis_idx < axes_order.size();
-         ++axis_idx) { post_transpose_shape[axis_idx] = dispersed_shape[axes_order[axis_idx]]; }
+    for (size_t axis_idx = 0; axis_idx < axes_order.size(); ++axis_idx)
+    {
+        post_transpose_shape[axis_idx] = dispersed_shape[axes_order[axis_idx]];
+    }
 
     runtime::opt_kernel::reshape(dispersed_data.data(),
                                  transposed_data.data(),
@@ -192,25 +208,27 @@ bool ngraph::op::v0::SpaceToDepth::evaluate_space_to_depth(const HostTensorVecto
                                  elem_size);
 
     Shape squeezed_shape{n_dim};
-    for (int i = 0; i < spatial_dims; ++i) {
+    for (int i = 0; i < spatial_dims; ++i)
+    {
         squeezed_shape.push_back(data_shape.at(spatial_dim_index + i) / m_blocksize);
-    } squeezed_shape.insert(squeezed_shape.begin() + 1,
-                            c_dim * std::pow(m_blocksize, spatial_dims));
-    for (size_t i = plain_axes_order.size() - 1; i < post_transpose_shape.size() - 1; ++i) {
+    }
+    squeezed_shape.insert(squeezed_shape.begin() + 1, c_dim * std::pow(m_blocksize, spatial_dims));
+    for (size_t i = plain_axes_order.size() - 1; i < post_transpose_shape.size() - 1; ++i)
+    {
         plain_axes_order.push_back(plain_axes_order[i] + 1);
-    } runtime::opt_kernel::reshape(transposed_data.data(),
-                                   out->get_data_ptr<char>(),
-                                   post_transpose_shape,
-                                   plain_axes_order,
-                                   squeezed_shape,
-                                   elem_size);
+    }
+    runtime::opt_kernel::reshape(transposed_data.data(),
+                                 out->get_data_ptr<char>(),
+                                 post_transpose_shape,
+                                 plain_axes_order,
+                                 squeezed_shape,
+                                 elem_size);
     return true;
 }
 bool ngraph::op::v0::SpaceToDepth::evaluate(const HostTensorVector& outputs,
                                             const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(
-        v0_SpaceToDepth_evaluate, return evaluate_space_to_depth(outputs, inputs));
+    NGRAPH_OP_SCOPE(v0_SpaceToDepth_evaluate, return evaluate_space_to_depth(outputs, inputs));
     return false;
 }
 

--- a/ngraph/core/src/op/split.cpp
+++ b/ngraph/core/src/op/split.cpp
@@ -15,6 +15,7 @@
 //*****************************************************************************
 #include "ngraph/runtime/reference/split.hpp"
 #include <numeric>
+#include "itt.hpp"
 #include "ngraph/attribute_visitor.hpp"
 #include "ngraph/builder/split.hpp"
 #include "ngraph/op/constant.hpp"
@@ -148,8 +149,8 @@ namespace split
 
 bool op::v1::Split::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    const auto& data = inputs[0];
-    const auto& axis = inputs[1];
+    NGRAPH_OP_SCOPE(v1_Split_evaluate, const auto& data = inputs[0]; const auto& axis = inputs[1];
 
-    return split::evaluate_split(data, axis, outputs, m_num_splits, this);
+                    return split::evaluate_split(data, axis, outputs, m_num_splits, this));
+    return false;
 }

--- a/ngraph/core/src/op/split.cpp
+++ b/ngraph/core/src/op/split.cpp
@@ -150,7 +150,6 @@ namespace split
 bool op::v1::Split::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
     NGRAPH_OP_SCOPE(v1_Split_evaluate, const auto& data = inputs[0]; const auto& axis = inputs[1];
-
                     return split::evaluate_split(data, axis, outputs, m_num_splits, this));
     return false;
 }

--- a/ngraph/core/src/op/sqrt.cpp
+++ b/ngraph/core/src/op/sqrt.cpp
@@ -76,7 +76,7 @@ namespace sqrtop
 bool op::Sqrt::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
     NGRAPH_OP_SCOPE(
-        Sqrt_evaluate,
+        v0_Sqrt_evaluate,
         return sqrtop::evaluate_sqrt(inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return false;
 }

--- a/ngraph/core/src/op/sqrt.cpp
+++ b/ngraph/core/src/op/sqrt.cpp
@@ -61,18 +61,12 @@ namespace sqrtop
         out->set_unary(arg0);
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(i32)(arg0, out, count);
-            break;
-            TYPE_CASE(i64)(arg0, out, count);
-            break;
-            TYPE_CASE(u32)(arg0, out, count);
-            break;
-            TYPE_CASE(u64)(arg0, out, count);
-            break;
-            TYPE_CASE(f16)(arg0, out, count);
-            break;
-            TYPE_CASE(f32)(arg0, out, count);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_sqrt, i32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_sqrt, i64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_sqrt, u32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_sqrt, u64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_sqrt, f16, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_sqrt, f32, arg0, out, count);
         default: rc = false; break;
         }
         return rc;
@@ -81,6 +75,8 @@ namespace sqrtop
 
 bool op::Sqrt::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::Sqrt::evaluate");
-    return sqrtop::evaluate_sqrt(inputs[0], outputs[0], shape_size(get_output_shape(0)));
+    NGRAPH_OP_SCOPE(
+        Sqrt_evaluate,
+        return sqrtop::evaluate_sqrt(inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    return false;
 }

--- a/ngraph/core/src/op/squeeze.cpp
+++ b/ngraph/core/src/op/squeeze.cpp
@@ -158,18 +158,12 @@ namespace squeeze
         bool rc = true;
         switch (element_type)
         {
-            TYPE_CASE(i32)(arg0, out);
-            break;
-            TYPE_CASE(i64)(arg0, out);
-            break;
-            TYPE_CASE(u32)(arg0, out);
-            break;
-            TYPE_CASE(u64)(arg0, out);
-            break;
-            TYPE_CASE(f16)(arg0, out);
-            break;
-            TYPE_CASE(f32)(arg0, out);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_squeeze, i32, arg0, out);
+            NGRAPH_TYPE_CASE(evaluate_squeeze, i64, arg0, out);
+            NGRAPH_TYPE_CASE(evaluate_squeeze, u32, arg0, out);
+            NGRAPH_TYPE_CASE(evaluate_squeeze, u64, arg0, out);
+            NGRAPH_TYPE_CASE(evaluate_squeeze, f16, arg0, out);
+            NGRAPH_TYPE_CASE(evaluate_squeeze, f32, arg0, out);
         default: rc = false; break;
         }
         return rc;
@@ -179,8 +173,9 @@ namespace squeeze
 bool op::v0::Squeeze::evaluate(const HostTensorVector& outputs,
                                const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v0::Squeeze::evaluate");
-    return squeeze::evaluate_squeeze(inputs[0], inputs[1], outputs[0]);
+    NGRAPH_OP_SCOPE(v0_Squeeze_evaluate,
+                    return squeeze::evaluate_squeeze(inputs[0], inputs[1], outputs[0]));
+    return false;
 }
 
 bool op::v0::Squeeze::constant_fold(OutputVector& output_values, const OutputVector& inputs_values)

--- a/ngraph/core/src/op/strided_slice.cpp
+++ b/ngraph/core/src/op/strided_slice.cpp
@@ -281,15 +281,17 @@ namespace strided_slice
 bool op::v1::StridedSlice::evaluate(const HostTensorVector& output_values,
                                     const HostTensorVector& input_values) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::StridedSlice::evaluate");
-    return strided_slice::evaluate_strided_slice(input_values[0],
-                                                 input_values[1],
-                                                 input_values[2],
-                                                 input_values[3],
-                                                 convert_mask_to_axis_set(get_begin_mask()),
-                                                 convert_mask_to_axis_set(get_end_mask()),
-                                                 convert_mask_to_axis_set(get_new_axis_mask()),
-                                                 convert_mask_to_axis_set(get_shrink_axis_mask()),
-                                                 convert_mask_to_axis_set(get_ellipsis_mask()),
-                                                 output_values[0]);
+    NGRAPH_OP_SCOPE(v1_StridedSlice_evaluate,
+                    return strided_slice::evaluate_strided_slice(
+                        input_values[0],
+                        input_values[1],
+                        input_values[2],
+                        input_values[3],
+                        convert_mask_to_axis_set(get_begin_mask()),
+                        convert_mask_to_axis_set(get_end_mask()),
+                        convert_mask_to_axis_set(get_new_axis_mask()),
+                        convert_mask_to_axis_set(get_shrink_axis_mask()),
+                        convert_mask_to_axis_set(get_ellipsis_mask()),
+                        output_values[0]));
+    return false;
 }

--- a/ngraph/core/src/op/subtract.cpp
+++ b/ngraph/core/src/op/subtract.cpp
@@ -49,20 +49,13 @@ namespace subtract
         out->set_broadcast(broadcast_spec, arg0, arg1);
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(i32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(i64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(bf16)(arg0, arg1, out, broadcast_spec);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_subtract, i32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_subtract, i64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_subtract, u32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_subtract, u64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_subtract, f16, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_subtract, f32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_subtract, bf16, arg0, arg1, out, broadcast_spec);
         default: rc = false; break;
         }
         return rc;
@@ -90,6 +83,8 @@ shared_ptr<Node> op::v1::Subtract::clone_with_new_inputs(const OutputVector& new
 bool op::v1::Subtract::evaluate(const HostTensorVector& outputs,
                                 const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::Subtract::evaluate");
-    return subtract::evaluate_subtract(inputs[0], inputs[1], outputs[0], get_autob());
+    NGRAPH_OP_SCOPE(
+        v1_Subtract_evaluate,
+        return subtract::evaluate_subtract(inputs[0], inputs[1], outputs[0], get_autob()));
+    return false;
 }

--- a/ngraph/core/src/op/swish.cpp
+++ b/ngraph/core/src/op/swish.cpp
@@ -130,6 +130,6 @@ bool op::v4::Swish::evaluate(const HostTensorVector& outputs, const HostTensorVe
 {
     NGRAPH_OP_SCOPE(
         v4_Swish_evaluate,
-        return swish::evaluate_swish(inputs[0], in1, outputs[0], shape_size(get_output_shape(0))););
+        return swish::evaluate_swish(inputs, outputs[0], shape_size(get_output_shape(0))););
     return false;
 }

--- a/ngraph/core/src/op/swish.cpp
+++ b/ngraph/core/src/op/swish.cpp
@@ -108,9 +108,8 @@ namespace swish
         return true;
     }
 
-    bool evaluate_swish(const HostTensorVector& inputs,
-                        const HostTensorPtr& out,
-                        const size_t count)
+    bool
+        evaluate_swish(const HostTensorVector& inputs, const HostTensorPtr& out, const size_t count)
     {
         bool rc = true;
         const HostTensorPtr arg0 = inputs[0];
@@ -129,7 +128,8 @@ namespace swish
 
 bool op::v4::Swish::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(v4_Swish_evaluate,
-    return swish::evaluate_swish(inputs[0], in1, outputs[0], shape_size(get_output_shape(0))););
+    NGRAPH_OP_SCOPE(
+        v4_Swish_evaluate,
+        return swish::evaluate_swish(inputs[0], in1, outputs[0], shape_size(get_output_shape(0))););
     return false;
 }

--- a/ngraph/core/src/op/swish.cpp
+++ b/ngraph/core/src/op/swish.cpp
@@ -15,6 +15,7 @@
 //*****************************************************************************
 
 #include "ngraph/op/swish.hpp"
+#include "itt.hpp"
 #include "ngraph/attribute_visitor.hpp"
 #include "ngraph/op/constant.hpp"
 
@@ -117,10 +118,8 @@ namespace swish
 
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(f16)(arg0, arg1, out, count);
-            break;
-            TYPE_CASE(f32)(arg0, arg1, out, count);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_swish, f16, arg0, arg1, out, count);
+            NGRAPH_TYPE_CASE(evaluate_swish, f32, arg0, arg1, out, count);
         default: rc = false; break;
         }
         return rc;
@@ -129,14 +128,8 @@ namespace swish
 
 bool op::v4::Swish::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    if (inputs.size() == 2)
-    {
-        return swish::evaluate_swish(
-            inputs[0], inputs[1], outputs[0], shape_size(get_output_shape(0)));
-    }
-    else
-    {
-        return swish::evaluate_swish(
-            inputs[0], nullptr, outputs[0], shape_size(get_output_shape(0)));
-    }
+    NGRAPH_OP_SCOPE(v4_Swish_evaluate, HostTensorPtr in1 = nullptr; if (inputs.size() == 2) {
+        in1 = inputs[1];
+    } return swish::evaluate_swish(inputs[0], in1, outputs[0], shape_size(get_output_shape(0))););
+    return false;
 }

--- a/ngraph/core/src/op/swish.cpp
+++ b/ngraph/core/src/op/swish.cpp
@@ -108,12 +108,13 @@ namespace swish
         return true;
     }
 
-    bool evaluate_swish(const HostTensorPtr& arg0,
-                        const HostTensorPtr& arg1,
+    bool evaluate_swish(const HostTensorVector& inputs,
                         const HostTensorPtr& out,
                         const size_t count)
     {
         bool rc = true;
+        const HostTensorPtr arg0 = inputs[0];
+        const HostTensorPtr arg1 = inputs.size() == 2 ? inputs[1] : nullptr;
         out->set_unary(arg0);
 
         switch (arg0->get_element_type())
@@ -128,8 +129,7 @@ namespace swish
 
 bool op::v4::Swish::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(v4_Swish_evaluate, HostTensorPtr in1 = nullptr; if (inputs.size() == 2) {
-        in1 = inputs[1];
-    } return swish::evaluate_swish(inputs[0], in1, outputs[0], shape_size(get_output_shape(0))););
+    NGRAPH_OP_SCOPE(v4_Swish_evaluate,
+    return swish::evaluate_swish(inputs[0], in1, outputs[0], shape_size(get_output_shape(0))););
     return false;
 }

--- a/ngraph/core/src/op/tan.cpp
+++ b/ngraph/core/src/op/tan.cpp
@@ -79,7 +79,7 @@ namespace tanop
 bool op::Tan::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
     NGRAPH_OP_SCOPE(
-        Tan_evaluate,
+        v0_Tan_evaluate,
         return tanop::evaluate_tan(inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return false;
 }

--- a/ngraph/core/src/op/tan.cpp
+++ b/ngraph/core/src/op/tan.cpp
@@ -63,20 +63,13 @@ namespace tanop
 
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(boolean)(arg0, out, count);
-            break;
-            TYPE_CASE(i32)(arg0, out, count);
-            break;
-            TYPE_CASE(i64)(arg0, out, count);
-            break;
-            TYPE_CASE(u32)(arg0, out, count);
-            break;
-            TYPE_CASE(u64)(arg0, out, count);
-            break;
-            TYPE_CASE(f16)(arg0, out, count);
-            break;
-            TYPE_CASE(f32)(arg0, out, count);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_tan, boolean, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_tan, i32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_tan, i64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_tan, u32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_tan, u64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_tan, f16, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_tan, f32, arg0, out, count);
         default: rc = false; break;
         }
         return rc;
@@ -85,6 +78,8 @@ namespace tanop
 
 bool op::Tan::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::Tan::evaluate");
-    return tanop::evaluate_tan(inputs[0], outputs[0], shape_size(get_output_shape(0)));
+    NGRAPH_OP_SCOPE(
+        Tan_evaluate,
+        return tanop::evaluate_tan(inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    return false;
 }

--- a/ngraph/core/src/op/tanh.cpp
+++ b/ngraph/core/src/op/tanh.cpp
@@ -62,18 +62,12 @@ namespace tanhop
 
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(i32)(arg0, out, count);
-            break;
-            TYPE_CASE(i64)(arg0, out, count);
-            break;
-            TYPE_CASE(u32)(arg0, out, count);
-            break;
-            TYPE_CASE(u64)(arg0, out, count);
-            break;
-            TYPE_CASE(f16)(arg0, out, count);
-            break;
-            TYPE_CASE(f32)(arg0, out, count);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_tanh, i32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_tanh, i64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_tanh, u32, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_tanh, u64, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_tanh, f16, arg0, out, count);
+            NGRAPH_TYPE_CASE(evaluate_tanh, f32, arg0, out, count);
         default: rc = false; break;
         }
         return rc;
@@ -82,6 +76,8 @@ namespace tanhop
 
 bool op::Tanh::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::Tanh::evaluate");
-    return tanhop::evaluate_tanh(inputs[0], outputs[0], shape_size(get_output_shape(0)));
+    NGRAPH_OP_SCOPE(
+        Tanh_evaluate,
+        return tanhop::evaluate_tanh(inputs[0], outputs[0], shape_size(get_output_shape(0))));
+    return false;
 }

--- a/ngraph/core/src/op/tanh.cpp
+++ b/ngraph/core/src/op/tanh.cpp
@@ -77,7 +77,7 @@ namespace tanhop
 bool op::Tanh::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
     NGRAPH_OP_SCOPE(
-        Tanh_evaluate,
+        v0_Tanh_evaluate,
         return tanhop::evaluate_tanh(inputs[0], outputs[0], shape_size(get_output_shape(0))));
     return false;
 }

--- a/ngraph/core/src/op/tile.cpp
+++ b/ngraph/core/src/op/tile.cpp
@@ -96,9 +96,11 @@ shared_ptr<Node> op::v0::Tile::clone_with_new_inputs(const OutputVector& new_arg
     return make_shared<Tile>(new_args.at(0), new_args.at(1));
 }
 
-bool op::v0::Tile::evaluate_tile(const HostTensorVector& outputs, const HostTensorVector& inputs) const
+bool op::v0::Tile::evaluate_tile(const HostTensorVector& outputs,
+                                 const HostTensorVector& inputs) const
 {
-    const auto& data = inputs[0]; const auto& axis = inputs[1];
+    const auto& data = inputs[0];
+    const auto& axis = inputs[1];
     auto& output = outputs[0];
     auto repeats_val = read_vector<int64_t>(axis);
     auto repeats_rank = repeats_val.size();
@@ -111,10 +113,15 @@ bool op::v0::Tile::evaluate_tile(const HostTensorVector& outputs, const HostTens
     repeats_val.insert(repeats_val.begin(), output_rank - repeats_rank, 1);
 
     Shape output_shape(output_rank);
-    for (size_t i = 0; i < output_rank;
-         i++) { output_shape[i] = data_shape[i] * repeats_val[i]; }
+    for (size_t i = 0; i < output_rank; i++)
+    {
+        output_shape[i] = data_shape[i] * repeats_val[i];
+    }
 
-    if (!output->get_is_allocated()) { output->set_shape(output_shape); }
+    if (!output->get_is_allocated())
+    {
+        output->set_shape(output_shape);
+    }
 
     runtime::reference::tile(data->get_data_ptr<const char>(),
                              output->get_data_ptr<char>(),

--- a/ngraph/core/src/op/tile.cpp
+++ b/ngraph/core/src/op/tile.cpp
@@ -96,33 +96,38 @@ shared_ptr<Node> op::v0::Tile::clone_with_new_inputs(const OutputVector& new_arg
     return make_shared<Tile>(new_args.at(0), new_args.at(1));
 }
 
+bool op::v0::Tile::evaluate_tile(const HostTensorVector& outputs, const HostTensorVector& inputs) const
+{
+    const auto& data = inputs[0]; const auto& axis = inputs[1];
+    auto& output = outputs[0];
+    auto repeats_val = read_vector<int64_t>(axis);
+    auto repeats_rank = repeats_val.size();
+    Shape data_shape = data->get_shape();
+    auto data_rank = data_shape.size();
+    auto output_rank = std::max(data_rank, repeats_rank);
+
+    // expand data shape and repeats to output rank
+    data_shape.insert(data_shape.begin(), output_rank - data_rank, 1);
+    repeats_val.insert(repeats_val.begin(), output_rank - repeats_rank, 1);
+
+    Shape output_shape(output_rank);
+    for (size_t i = 0; i < output_rank;
+         i++) { output_shape[i] = data_shape[i] * repeats_val[i]; }
+
+    if (!output->get_is_allocated()) { output->set_shape(output_shape); }
+
+    runtime::reference::tile(data->get_data_ptr<const char>(),
+                             output->get_data_ptr<char>(),
+                             data->get_shape(),
+                             output_shape,
+                             data->get_element_type().size(),
+                             repeats_val);
+
+    return true;
+}
+
 bool op::v0::Tile::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(v0_Tile_evaluate, const auto& data = inputs[0]; const auto& axis = inputs[1];
-                    auto& output = outputs[0];
-                    auto repeats_val = read_vector<int64_t>(axis);
-                    auto repeats_rank = repeats_val.size();
-                    Shape data_shape = data->get_shape();
-                    auto data_rank = data_shape.size();
-                    auto output_rank = std::max(data_rank, repeats_rank);
-
-                    // expand data shape and repeats to output rank
-                    data_shape.insert(data_shape.begin(), output_rank - data_rank, 1);
-                    repeats_val.insert(repeats_val.begin(), output_rank - repeats_rank, 1);
-
-                    Shape output_shape(output_rank);
-                    for (size_t i = 0; i < output_rank;
-                         i++) { output_shape[i] = data_shape[i] * repeats_val[i]; }
-
-                    if (!output->get_is_allocated()) { output->set_shape(output_shape); }
-
-                    runtime::reference::tile(data->get_data_ptr<const char>(),
-                                             output->get_data_ptr<char>(),
-                                             data->get_shape(),
-                                             output_shape,
-                                             data->get_element_type().size(),
-                                             repeats_val);
-
-                    return true);
+    NGRAPH_OP_SCOPE(v0_Tile_evaluate, return evaluate_tile(outputs, inputs));
     return false;
 }

--- a/ngraph/core/src/op/topk.cpp
+++ b/ngraph/core/src/op/topk.cpp
@@ -449,7 +449,8 @@ void op::v1::TopK::set_k(size_t k)
         op::Constant::create(element::i64, Shape{}, {k})->output(0));
 }
 
-bool op::v1::TopK::evaluatetopk(const HostTensorVector& outputs, const HostTensorVector& inputs) const
+bool op::v1::TopK::evaluatetopk(const HostTensorVector& outputs,
+                                const HostTensorVector& inputs) const
 {
     Shape arg_shape = inputs[0]->get_shape();
     // 1. get axis, mode ( max/min), sort_type
@@ -459,17 +460,23 @@ bool op::v1::TopK::evaluatetopk(const HostTensorVector& outputs, const HostTenso
 
     // 2. get value of k - from constant node or from HT
     size_t k = 0;
-    if (op::is_constant(input_value(1).get_node())) {
+    if (op::is_constant(input_value(1).get_node()))
+    {
         k = read_k_from_constant_node(input_value(1).get_node_shared_ptr(),
                                       get_input_element_type(1));
         NGRAPH_CHECK(k <= arg_shape[axis], "'K' exceeds the dimension of top_k_axis");
-    } else { k = topk::read_k_from_host_tensor(inputs[1]); }
+    }
+    else
+    {
+        k = topk::read_k_from_host_tensor(inputs[1]);
+    }
 
     // 3. Compute output_shape
     auto output_shape = compute_output_shape(this->description(), inputs[0]->get_shape(), k);
 
     // do this after compute_output_shape
-    if (k == 0) {
+    if (k == 0)
+    {
         // the kernel can't handle k = 0, but output_shape[axis] = arg_shape[axis]
         k = arg_shape[axis];
     }
@@ -487,8 +494,7 @@ bool op::v1::TopK::evaluatetopk(const HostTensorVector& outputs, const HostTenso
 
 bool op::v1::TopK::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(
-        v1_TopK_evaluate, return evaluate_topk(outputs, inputs));
+    NGRAPH_OP_SCOPE(v1_TopK_evaluate, return evaluate_topk(outputs, inputs));
     return false;
 }
 

--- a/ngraph/core/src/op/topk.cpp
+++ b/ngraph/core/src/op/topk.cpp
@@ -449,41 +449,46 @@ void op::v1::TopK::set_k(size_t k)
         op::Constant::create(element::i64, Shape{}, {k})->output(0));
 }
 
+bool op::v1::TopK::evaluatetopk(const HostTensorVector& outputs, const HostTensorVector& inputs) const
+{
+    Shape arg_shape = inputs[0]->get_shape();
+    // 1. get axis, mode ( max/min), sort_type
+    size_t axis = ngraph::normalize_axis(this, m_axis, arg_shape.size());
+    bool compute_max = get_mode() == TopKMode::MAX ? true : false;
+    SortType sort_type = get_sort_type();
+
+    // 2. get value of k - from constant node or from HT
+    size_t k = 0;
+    if (op::is_constant(input_value(1).get_node())) {
+        k = read_k_from_constant_node(input_value(1).get_node_shared_ptr(),
+                                      get_input_element_type(1));
+        NGRAPH_CHECK(k <= arg_shape[axis], "'K' exceeds the dimension of top_k_axis");
+    } else { k = topk::read_k_from_host_tensor(inputs[1]); }
+
+    // 3. Compute output_shape
+    auto output_shape = compute_output_shape(this->description(), inputs[0]->get_shape(), k);
+
+    // do this after compute_output_shape
+    if (k == 0) {
+        // the kernel can't handle k = 0, but output_shape[axis] = arg_shape[axis]
+        k = arg_shape[axis];
+    }
+
+    return topk::evaluate_topk(inputs[0],
+                               outputs[1],
+                               outputs[0],
+                               output_shape,
+                               axis,
+                               k,
+                               compute_max,
+                               sort_type,
+                               get_index_element_type());
+}
+
 bool op::v1::TopK::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
     NGRAPH_OP_SCOPE(
-        v1_TopK_evaluate, Shape arg_shape = inputs[0]->get_shape();
-        // 1. get axis, mode ( max/min), sort_type
-        size_t axis = ngraph::normalize_axis(this, m_axis, arg_shape.size());
-        bool compute_max = get_mode() == TopKMode::MAX ? true : false;
-        SortType sort_type = get_sort_type();
-
-        // 2. get value of k - from constant node or from HT
-        size_t k = 0;
-        if (op::is_constant(input_value(1).get_node())) {
-            k = read_k_from_constant_node(input_value(1).get_node_shared_ptr(),
-                                          get_input_element_type(1));
-            NGRAPH_CHECK(k <= arg_shape[axis], "'K' exceeds the dimension of top_k_axis");
-        } else { k = topk::read_k_from_host_tensor(inputs[1]); }
-
-        // 3. Compute output_shape
-        auto output_shape = compute_output_shape(this->description(), inputs[0]->get_shape(), k);
-
-        // do this after compute_output_shape
-        if (k == 0) {
-            // the kernel can't handle k = 0, but output_shape[axis] = arg_shape[axis]
-            k = arg_shape[axis];
-        }
-
-        return topk::evaluate_topk(inputs[0],
-                                   outputs[1],
-                                   outputs[0],
-                                   output_shape,
-                                   axis,
-                                   k,
-                                   compute_max,
-                                   sort_type,
-                                   get_index_element_type()));
+        v1_TopK_evaluate, return evaluate_topk(outputs, inputs));
     return false;
 }
 

--- a/ngraph/core/src/op/topk.cpp
+++ b/ngraph/core/src/op/topk.cpp
@@ -449,8 +449,8 @@ void op::v1::TopK::set_k(size_t k)
         op::Constant::create(element::i64, Shape{}, {k})->output(0));
 }
 
-bool op::v1::TopK::evaluatetopk(const HostTensorVector& outputs,
-                                const HostTensorVector& inputs) const
+bool op::v1::TopK::evaluate_topk(const HostTensorVector& outputs,
+                                 const HostTensorVector& inputs) const
 {
     Shape arg_shape = inputs[0]->get_shape();
     // 1. get axis, mode ( max/min), sort_type

--- a/ngraph/core/src/op/topk.cpp
+++ b/ngraph/core/src/op/topk.cpp
@@ -64,6 +64,14 @@ namespace topk
         return true;
     }
 
+#define EXECUTE_EVALUATE_TOPK(a, ...)                                                              \
+    case element::Type_t::a:                                                                       \
+    {                                                                                              \
+        NGRAPH_OP_SCOPE(OV_CC_CAT3(exec_topk_eval, _, a),                                          \
+                        rc = evaluate_execute<INPUT_ET, element::Type_t::a>(__VA_ARGS__));         \
+    }                                                                                              \
+    break
+
     template <element::Type_t INPUT_ET>
     bool evaluate(const HostTensorPtr& arg,
                   const HostTensorPtr& out_indices,
@@ -78,14 +86,8 @@ namespace topk
         bool rc = true;
         switch (index_et)
         {
-        case element::Type_t::i64:
-            evaluate_execute<INPUT_ET, element::Type_t::i64>(
-                arg, out_indices, out_values, out_shape, axis, k, max, sort);
-            break;
-        case element::Type_t::i32:
-            evaluate_execute<INPUT_ET, element::Type_t::i32>(
-                arg, out_indices, out_values, out_shape, axis, k, max, sort);
-            break;
+            EXECUTE_EVALUATE_TOPK(i32, arg, out_indices, out_values, out_shape, axis, k, max, sort);
+            EXECUTE_EVALUATE_TOPK(i64, arg, out_indices, out_values, out_shape, axis, k, max, sort);
         default: rc = false; break;
         }
         return rc;
@@ -104,18 +106,72 @@ namespace topk
         bool rc = true;
         switch (arg->get_element_type())
         {
-            TYPE_CASE(i32)(arg, out_indices, out_values, out_shape, axis, k, max, sort, index_et);
-            break;
-            TYPE_CASE(i64)(arg, out_indices, out_values, out_shape, axis, k, max, sort, index_et);
-            break;
-            TYPE_CASE(u32)(arg, out_indices, out_values, out_shape, axis, k, max, sort, index_et);
-            break;
-            TYPE_CASE(u64)(arg, out_indices, out_values, out_shape, axis, k, max, sort, index_et);
-            break;
-            TYPE_CASE(f16)(arg, out_indices, out_values, out_shape, axis, k, max, sort, index_et);
-            break;
-            TYPE_CASE(f32)(arg, out_indices, out_values, out_shape, axis, k, max, sort, index_et);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_topk,
+                             i32,
+                             arg,
+                             out_indices,
+                             out_values,
+                             out_shape,
+                             axis,
+                             k,
+                             max,
+                             sort,
+                             index_et);
+            NGRAPH_TYPE_CASE(evaluate_topk,
+                             i64,
+                             arg,
+                             out_indices,
+                             out_values,
+                             out_shape,
+                             axis,
+                             k,
+                             max,
+                             sort,
+                             index_et);
+            NGRAPH_TYPE_CASE(evaluate_topk,
+                             u32,
+                             arg,
+                             out_indices,
+                             out_values,
+                             out_shape,
+                             axis,
+                             k,
+                             max,
+                             sort,
+                             index_et);
+            NGRAPH_TYPE_CASE(evaluate_topk,
+                             u64,
+                             arg,
+                             out_indices,
+                             out_values,
+                             out_shape,
+                             axis,
+                             k,
+                             max,
+                             sort,
+                             index_et);
+            NGRAPH_TYPE_CASE(evaluate_topk,
+                             f16,
+                             arg,
+                             out_indices,
+                             out_values,
+                             out_shape,
+                             axis,
+                             k,
+                             max,
+                             sort,
+                             index_et);
+            NGRAPH_TYPE_CASE(evaluate_topk,
+                             f32,
+                             arg,
+                             out_indices,
+                             out_values,
+                             out_shape,
+                             axis,
+                             k,
+                             max,
+                             sort,
+                             index_et);
         default: rc = false; break;
         }
         return rc;
@@ -130,30 +186,23 @@ namespace topk
         return k;
     }
 
-#define CASE_GET_K(a)                                                                              \
-    case element::Type_t::a: k = get_k_from_hosttensor<element::Type_t::a>
+#define CASE_GET_K(a, ...)                                                                         \
+    case element::Type_t::a:                                                                       \
+    {                                                                                              \
+        NGRAPH_OP_SCOPE(OV_CC_CAT3(topk_get_k, _, a),                                              \
+                        k = get_k_from_hosttensor<element::Type_t::a>(__VA_ARGS__));               \
+    }                                                                                              \
+    break
 
     size_t read_k_from_host_tensor(const HostTensorPtr& arg_k)
     {
         size_t k = 0;
         switch (arg_k->get_element_type())
         {
-            CASE_GET_K(i8)(arg_k);
-            break;
-            CASE_GET_K(i16)(arg_k);
-            break;
-            CASE_GET_K(i32)(arg_k);
-            break;
-            CASE_GET_K(i64)(arg_k);
-            break;
-            CASE_GET_K(u8)(arg_k);
-            break;
-            CASE_GET_K(u16)(arg_k);
-            break;
-            CASE_GET_K(u32)(arg_k);
-            break;
-            CASE_GET_K(u64)(arg_k);
-            break;
+            CASE_GET_K(i8, arg_k);
+            CASE_GET_K(i32, arg_k);
+            CASE_GET_K(u8, arg_k);
+            CASE_GET_K(u32, arg_k);
         default:
             // other types are not supported and would have thrown in ctor
             ngraph_error("read_k_from_host_tensor: type is not integral\n");
@@ -330,10 +379,6 @@ size_t op::v1::TopK::read_k_from_constant_node(const shared_ptr<Node>& node,
 
     size_t k = 0;
 
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wswitch-enum"
-#endif
     switch (static_cast<element::Type_t>(k_element_type))
     {
     case element::Type_t::i8: k = validate_and_get_k<int8_t>(k_constant); break;
@@ -341,9 +386,6 @@ size_t op::v1::TopK::read_k_from_constant_node(const shared_ptr<Node>& node,
     case element::Type_t::i64: k = validate_and_get_k<int64_t>(k_constant); break;
     default: break;
     }
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
 
     return k;
 }
@@ -405,46 +447,40 @@ void op::v1::TopK::set_k(size_t k)
 
 bool op::v1::TopK::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::TopK::evaluate");
+    NGRAPH_OP_SCOPE(
+        v1_TopK_evaluate, Shape arg_shape = inputs[0]->get_shape();
+        // 1. get axis, mode ( max/min), sort_type
+        size_t axis = ngraph::normalize_axis(this, m_axis, arg_shape.size());
+        bool compute_max = get_mode() == TopKMode::MAX ? true : false;
+        SortType sort_type = get_sort_type();
 
-    Shape arg_shape = inputs[0]->get_shape();
-    // 1. get axis, mode ( max/min), sort_type
-    size_t axis = ngraph::normalize_axis(this, m_axis, arg_shape.size());
-    bool compute_max = get_mode() == TopKMode::MAX ? true : false;
-    SortType sort_type = get_sort_type();
+        // 2. get value of k - from constant node or from HT
+        size_t k = 0;
+        if (op::is_constant(input_value(1).get_node())) {
+            k = read_k_from_constant_node(input_value(1).get_node_shared_ptr(),
+                                          get_input_element_type(1));
+            NGRAPH_CHECK(k <= arg_shape[axis], "'K' exceeds the dimension of top_k_axis");
+        } else { k = topk::read_k_from_host_tensor(inputs[1]); }
 
-    // 2. get value of k - from constant node or from HT
-    size_t k = 0;
-    if (op::is_constant(input_value(1).get_node()))
-    {
-        k = read_k_from_constant_node(input_value(1).get_node_shared_ptr(),
-                                      get_input_element_type(1));
-        NGRAPH_CHECK(k <= arg_shape[axis], "'K' exceeds the dimension of top_k_axis");
-    }
-    else
-    {
-        k = topk::read_k_from_host_tensor(inputs[1]);
-    }
+        // 3. Compute output_shape
+        auto output_shape = compute_output_shape(this->description(), inputs[0]->get_shape(), k);
 
-    // 3. Compute output_shape
-    auto output_shape = compute_output_shape(this->description(), inputs[0]->get_shape(), k);
+        // do this after compute_output_shape
+        if (k == 0) {
+            // the kernel can't handle k = 0, but output_shape[axis] = arg_shape[axis]
+            k = arg_shape[axis];
+        }
 
-    // do this after compute_output_shape
-    if (k == 0)
-    {
-        // the kernel can't handle k = 0, but output_shape[axis] = arg_shape[axis]
-        k = arg_shape[axis];
-    }
-
-    return topk::evaluate_topk(inputs[0],
-                               outputs[1],
-                               outputs[0],
-                               output_shape,
-                               axis,
-                               k,
-                               compute_max,
-                               sort_type,
-                               get_index_element_type());
+        return topk::evaluate_topk(inputs[0],
+                                   outputs[1],
+                                   outputs[0],
+                                   output_shape,
+                                   axis,
+                                   k,
+                                   compute_max,
+                                   sort_type,
+                                   get_index_element_type()));
+    return false;
 }
 
 // v3 version starts
@@ -497,10 +533,6 @@ size_t op::v3::TopK::read_k_from_constant_node(const shared_ptr<Node>& node,
 
     size_t k = 0;
 
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wswitch-enum"
-#endif
     switch (static_cast<element::Type_t>(k_element_type))
     {
     case element::Type_t::i8: k = validate_and_get_k<int8_t>(k_constant); break;
@@ -513,9 +545,6 @@ size_t op::v3::TopK::read_k_from_constant_node(const shared_ptr<Node>& node,
     case element::Type_t::u64: k = validate_and_get_k<uint64_t>(k_constant); break;
     default: break;
     }
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
 
     return k;
 }
@@ -533,6 +562,6 @@ shared_ptr<Node> op::v3::TopK::clone_with_new_inputs(const OutputVector& new_arg
 
 bool op::v3::TopK::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v3::TopK::evaluate");
-    return op::v1::TopK::evaluate(outputs, inputs);
+    NGRAPH_OP_SCOPE(v3_TopK_evaluate, return op::v1::TopK::evaluate(outputs, inputs));
+    return false;
 }

--- a/ngraph/core/src/op/topk.cpp
+++ b/ngraph/core/src/op/topk.cpp
@@ -200,9 +200,13 @@ namespace topk
         switch (arg_k->get_element_type())
         {
             CASE_GET_K(i8, arg_k);
+            CASE_GET_K(i16, arg_k);
             CASE_GET_K(i32, arg_k);
+            CASE_GET_K(i64, arg_k);
             CASE_GET_K(u8, arg_k);
+            CASE_GET_K(u16, arg_k);
             CASE_GET_K(u32, arg_k);
+            CASE_GET_K(u64, arg_k);
         default:
             // other types are not supported and would have thrown in ctor
             ngraph_error("read_k_from_host_tensor: type is not integral\n");

--- a/ngraph/core/src/op/transpose.cpp
+++ b/ngraph/core/src/op/transpose.cpp
@@ -144,6 +144,8 @@ namespace transpose
 bool op::v1::Transpose::evaluate(const HostTensorVector& output_values,
                                  const HostTensorVector& input_values) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::Transpose::evaluate");
-    return transpose::evaluate_transpose(input_values[0], input_values[1], output_values[0]);
+    NGRAPH_OP_SCOPE(
+        v1_Transpose_evaluate,
+        return transpose::evaluate_transpose(input_values[0], input_values[1], output_values[0]));
+    return false;
 }

--- a/ngraph/core/src/op/unsqueeze.cpp
+++ b/ngraph/core/src/op/unsqueeze.cpp
@@ -135,18 +135,12 @@ namespace unsqueeze
         bool rc = true;
         switch (element_type)
         {
-            TYPE_CASE(i32)(arg0, out);
-            break;
-            TYPE_CASE(i64)(arg0, out);
-            break;
-            TYPE_CASE(u32)(arg0, out);
-            break;
-            TYPE_CASE(u64)(arg0, out);
-            break;
-            TYPE_CASE(f16)(arg0, out);
-            break;
-            TYPE_CASE(f32)(arg0, out);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_unsqueeze, i32, arg0, out);
+            NGRAPH_TYPE_CASE(evaluate_unsqueeze, i64, arg0, out);
+            NGRAPH_TYPE_CASE(evaluate_unsqueeze, u32, arg0, out);
+            NGRAPH_TYPE_CASE(evaluate_unsqueeze, u64, arg0, out);
+            NGRAPH_TYPE_CASE(evaluate_unsqueeze, f16, arg0, out);
+            NGRAPH_TYPE_CASE(evaluate_unsqueeze, f32, arg0, out);
         default: rc = false; break;
         }
         return rc;
@@ -156,8 +150,9 @@ namespace unsqueeze
 bool op::v0::Unsqueeze::evaluate(const HostTensorVector& outputs,
                                  const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v0::Unsqueeze::evaluate");
-    return unsqueeze::evaluate_unsqueeze(inputs[0], inputs[1], outputs[0]);
+    NGRAPH_OP_SCOPE(v0_Unsqueeze_evaluate,
+                    return unsqueeze::evaluate_unsqueeze(inputs[0], inputs[1], outputs[0]));
+    return false;
 }
 
 bool op::v0::Unsqueeze::constant_fold(OutputVector& output_values,

--- a/ngraph/core/src/op/util/broadcast_base.cpp
+++ b/ngraph/core/src/op/util/broadcast_base.cpp
@@ -361,14 +361,15 @@ bool op::util::BroadcastBase::evaluate(const HostTensorPtr& arg0,
                                        const HostTensorPtr& out,
                                        const AxisSet& broadcast_axes) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::util::BroadcastBase::evaluate<ET>");
-    runtime::reference::broadcast(arg0->get_data_ptr<const char>(),
-                                  out->get_data_ptr<char>(),
-                                  arg0->get_shape(),
-                                  out->get_shape(),
-                                  broadcast_axes,
-                                  arg0->get_element_type().size());
-    return true;
+    NGRAPH_OP_SCOPE(op_util_BroadcastBase_evaluate,
+                    runtime::reference::broadcast(arg0->get_data_ptr<const char>(),
+                                                  out->get_data_ptr<char>(),
+                                                  arg0->get_shape(),
+                                                  out->get_shape(),
+                                                  broadcast_axes,
+                                                  arg0->get_element_type().size());
+                    return true);
+    return false;
 }
 
 namespace
@@ -499,49 +500,41 @@ Shape op::util::BroadcastBase::get_target_shape(const HostTensorPtr& input1) con
 bool op::util::BroadcastBase::evaluate(const HostTensorVector& outputs,
                                        const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::util::BroadcastBase::evaluate");
+    NGRAPH_OP_SCOPE(
+        op_util_BroadcastBase_evaluate, Shape target_shape = get_target_shape(inputs[1]);
 
-    Shape target_shape = get_target_shape(inputs[1]);
+        PartialShape result_shape;
+        std::pair<bool, AxisSet> pair_broadcast_axes;
+        auto arg_shape = inputs[0]->get_shape();
 
-    PartialShape result_shape;
-    std::pair<bool, AxisSet> pair_broadcast_axes;
-    auto arg_shape = inputs[0]->get_shape();
+        if (m_mode.m_type == BroadcastType::NONE) {
+            AxisVector axes_mapping_val;
+            const auto axes_mapping_constant =
+                as_type_ptr<op::v0::Constant>(input_value(2).get_node_shared_ptr());
+            if (axes_mapping_constant)
+            {
+                axes_mapping_val = axes_mapping_constant->get_axis_vector_val();
+            }
+            else
+            {
+                // read from HT and save as AxisVector
+                get_axis_vector_from_ht(inputs[2], axes_mapping_val, arg_shape);
+            }
+            pair_broadcast_axes = get_broadcast_axes_none(axes_mapping_val, target_shape.size());
+            validate_target_shape_none(inputs[0]->get_shape(), axes_mapping_val, target_shape);
+            result_shape = target_shape;
+        } else if (m_mode.m_type == BroadcastType::PDPD) {
+            result_shape = get_result_shape_pdpd(arg_shape, target_shape, m_mode);
+            pair_broadcast_axes =
+                get_broadcast_axes_numpy_pdpd(arg_shape, result_shape.to_shape(), m_mode);
+        } else if (m_mode.m_type == BroadcastType::NUMPY) {
+            result_shape = target_shape;
+            validate_target_shape_numpy(arg_shape, target_shape);
+            pair_broadcast_axes =
+                get_broadcast_axes_numpy_pdpd(arg_shape, result_shape.to_shape(), m_mode);
+        } else { ngraph_error("Unsupported BroadcastType "); }
 
-    if (m_mode.m_type == BroadcastType::NONE)
-    {
-        AxisVector axes_mapping_val;
-        const auto axes_mapping_constant =
-            as_type_ptr<op::v0::Constant>(input_value(2).get_node_shared_ptr());
-        if (axes_mapping_constant)
-        {
-            axes_mapping_val = axes_mapping_constant->get_axis_vector_val();
-        }
-        else
-        {
-            // read from HT and save as AxisVector
-            get_axis_vector_from_ht(inputs[2], axes_mapping_val, arg_shape);
-        }
-        pair_broadcast_axes = get_broadcast_axes_none(axes_mapping_val, target_shape.size());
-        validate_target_shape_none(inputs[0]->get_shape(), axes_mapping_val, target_shape);
-        result_shape = target_shape;
-    }
-    else if (m_mode.m_type == BroadcastType::PDPD)
-    {
-        result_shape = get_result_shape_pdpd(arg_shape, target_shape, m_mode);
-        pair_broadcast_axes =
-            get_broadcast_axes_numpy_pdpd(arg_shape, result_shape.to_shape(), m_mode);
-    }
-    else if (m_mode.m_type == BroadcastType::NUMPY)
-    {
-        result_shape = target_shape;
-        validate_target_shape_numpy(arg_shape, target_shape);
-        pair_broadcast_axes =
-            get_broadcast_axes_numpy_pdpd(arg_shape, result_shape.to_shape(), m_mode);
-    }
-    else
-    {
-        ngraph_error("Unsupported BroadcastType ");
-    }
-
-    return evaluate_broadcast(inputs[0], outputs[0], pair_broadcast_axes, result_shape.to_shape());
+        return evaluate_broadcast(
+            inputs[0], outputs[0], pair_broadcast_axes, result_shape.to_shape()));
+    return false;
 }

--- a/ngraph/core/src/op/util/broadcast_base.cpp
+++ b/ngraph/core/src/op/util/broadcast_base.cpp
@@ -361,7 +361,7 @@ bool op::util::BroadcastBase::evaluate(const HostTensorPtr& arg0,
                                        const HostTensorPtr& out,
                                        const AxisSet& broadcast_axes) const
 {
-    NGRAPH_OP_SCOPE(op_util_BroadcastBase_evaluate,
+    NGRAPH_OP_SCOPE(util_BroadcastBase_evaluate_axes,
                     runtime::reference::broadcast(arg0->get_data_ptr<const char>(),
                                                   out->get_data_ptr<char>(),
                                                   arg0->get_shape(),
@@ -501,7 +501,7 @@ bool op::util::BroadcastBase::evaluate(const HostTensorVector& outputs,
                                        const HostTensorVector& inputs) const
 {
     NGRAPH_OP_SCOPE(
-        op_util_BroadcastBase_evaluate, Shape target_shape = get_target_shape(inputs[1]);
+        util_BroadcastBase_evaluate, Shape target_shape = get_target_shape(inputs[1]);
 
         PartialShape result_shape;
         std::pair<bool, AxisSet> pair_broadcast_axes;

--- a/ngraph/core/src/op/variadic_split.cpp
+++ b/ngraph/core/src/op/variadic_split.cpp
@@ -165,12 +165,13 @@ namespace variadic_split
 
         return true;
     }
-
 }
 
 bool op::v1::VariadicSplit::evaluate_variadic_split(const HostTensorVector& inputs,
-                                                    const HostTensorVector& outputs) const 
-{ const auto& data_tensor = inputs[0]; const auto& axis_tensor = inputs[1];
+                                                    const HostTensorVector& outputs) const
+{
+    const auto& data_tensor = inputs[0];
+    const auto& axis_tensor = inputs[1];
     const auto& split_lengths_tensor = inputs[2];
     NGRAPH_CHECK(axis_tensor->get_element_type().is_integral_number(),
                  "axis element type is not integral data type");
@@ -215,8 +216,6 @@ bool op::v1::VariadicSplit::evaluate_variadic_split(const HostTensorVector& inpu
 bool op::v1::VariadicSplit::evaluate(const HostTensorVector& outputs,
                                      const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(
-        v1_VariadicSplit_evaluate,
-        return evaluate_variadic_split(inputs, outputs));
+    NGRAPH_OP_SCOPE(v1_VariadicSplit_evaluate, return evaluate_variadic_split(inputs, outputs));
     return false;
 }

--- a/ngraph/core/src/op/variadic_split.cpp
+++ b/ngraph/core/src/op/variadic_split.cpp
@@ -16,6 +16,7 @@
 
 #include <numeric>
 
+#include "itt.hpp"
 #include "ngraph/op/constant.hpp"
 #include "ngraph/op/util/op_types.hpp"
 #include "ngraph/op/variadic_split.hpp"
@@ -216,9 +217,10 @@ namespace variadic_split
 bool op::v1::VariadicSplit::evaluate(const HostTensorVector& outputs,
                                      const HostTensorVector& inputs) const
 {
-    const auto& data = inputs[0];
-    const auto& axis = inputs[1];
-    const auto& split_lengths = inputs[2];
+    NGRAPH_OP_SCOPE(
+        v1_VariadicSplit_evaluate, const auto& data = inputs[0]; const auto& axis = inputs[1];
+        const auto& split_lengths = inputs[2];
 
-    return variadic_split::evaluate_variadic_split(data, axis, split_lengths, outputs, this);
+        return variadic_split::evaluate_variadic_split(data, axis, split_lengths, outputs, this));
+    return false;
 }

--- a/ngraph/core/src/op/variadic_split.cpp
+++ b/ngraph/core/src/op/variadic_split.cpp
@@ -166,61 +166,57 @@ namespace variadic_split
         return true;
     }
 
-    bool evaluate_variadic_split(const HostTensorPtr& data_tensor,
-                                 const HostTensorPtr& axis_tensor,
-                                 const HostTensorPtr& split_lengths_tensor,
-                                 const HostTensorVector& outputs,
-                                 const Node* split_node)
-    {
-        NGRAPH_CHECK(axis_tensor->get_element_type().is_integral_number(),
-                     "axis element type is not integral data type");
-
-        int64_t axis = host_tensor_2_vector<int64_t>(axis_tensor)[0];
-
-        axis = ngraph::normalize_axis(split_node, axis, data_tensor->get_partial_shape().rank());
-
-        NGRAPH_CHECK(split_lengths_tensor->get_element_type().is_integral_number(),
-                     "axis element type is not integral data type");
-
-        std::vector<int64_t> split_lengths = host_tensor_2_vector<int64_t>(split_lengths_tensor);
-
-        const auto data_shape = data_tensor->get_shape();
-        const auto neg_one = std::find(std::begin(split_lengths), std::end(split_lengths), -1);
-        if (neg_one != std::end(split_lengths)) // negative length set
-        {
-            const auto sum_of_known_splits =
-                std::accumulate(std::begin(split_lengths), std::end(split_lengths), 0) + 1;
-            split_lengths[std::distance(std::begin(split_lengths), neg_one)] =
-                data_shape[axis] - sum_of_known_splits;
-        }
-
-        Shape output_shape = data_shape;
-        std::vector<size_t> lower_bounds(data_shape.size(), 0);
-        std::vector<size_t> upper_bounds = data_shape;
-        upper_bounds.at(axis) = split_lengths[0];
-
-        int64_t split_pos = 0;
-        for (const auto& output : outputs)
-        {
-            output_shape.at(axis) = split_lengths[split_pos++];
-            output->set_shape(output_shape);
-            evaluate(data_tensor, output, lower_bounds, upper_bounds);
-            lower_bounds.at(axis) = upper_bounds.at(axis);
-            if (split_pos < split_lengths.size())
-                upper_bounds.at(axis) += split_lengths[split_pos];
-        }
-
-        return true;
-    }
 }
 
+bool op::v1::VariadicSplit::evaluate_variadic_split(const HostTensorVector& inputs,
+                                                    const HostTensorVector& outputs) const 
+{ const auto& data_tensor = inputs[0]; const auto& axis_tensor = inputs[1];
+    const auto& split_lengths_tensor = inputs[2];
+    NGRAPH_CHECK(axis_tensor->get_element_type().is_integral_number(),
+                 "axis element type is not integral data type");
+
+    int64_t axis = host_tensor_2_vector<int64_t>(axis_tensor)[0];
+
+    axis = ngraph::normalize_axis(this, axis, data_tensor->get_partial_shape().rank());
+
+    NGRAPH_CHECK(split_lengths_tensor->get_element_type().is_integral_number(),
+                 "axis element type is not integral data type");
+
+    std::vector<int64_t> split_lengths = host_tensor_2_vector<int64_t>(split_lengths_tensor);
+
+    const auto data_shape = data_tensor->get_shape();
+    const auto neg_one = std::find(std::begin(split_lengths), std::end(split_lengths), -1);
+    if (neg_one != std::end(split_lengths)) // negative length set
+    {
+        const auto sum_of_known_splits =
+            std::accumulate(std::begin(split_lengths), std::end(split_lengths), 0) + 1;
+        split_lengths[std::distance(std::begin(split_lengths), neg_one)] =
+            data_shape[axis] - sum_of_known_splits;
+    }
+
+    Shape output_shape = data_shape;
+    std::vector<size_t> lower_bounds(data_shape.size(), 0);
+    std::vector<size_t> upper_bounds = data_shape;
+    upper_bounds.at(axis) = split_lengths[0];
+
+    int64_t split_pos = 0;
+    for (const auto& output : outputs)
+    {
+        output_shape.at(axis) = split_lengths[split_pos++];
+        output->set_shape(output_shape);
+        variadic_split::evaluate(data_tensor, output, lower_bounds, upper_bounds);
+        lower_bounds.at(axis) = upper_bounds.at(axis);
+        if (split_pos < split_lengths.size())
+            upper_bounds.at(axis) += split_lengths[split_pos];
+    }
+
+    return true;
+}
 bool op::v1::VariadicSplit::evaluate(const HostTensorVector& outputs,
                                      const HostTensorVector& inputs) const
 {
     NGRAPH_OP_SCOPE(
-        v1_VariadicSplit_evaluate, const auto& data = inputs[0]; const auto& axis = inputs[1];
-        const auto& split_lengths = inputs[2];
-
-        return variadic_split::evaluate_variadic_split(data, axis, split_lengths, outputs, this));
+        v1_VariadicSplit_evaluate,
+        return evaluate_variadic_split(inputs, outputs));
     return false;
 }

--- a/ngraph/core/src/op/xor.cpp
+++ b/ngraph/core/src/op/xor.cpp
@@ -86,7 +86,7 @@ namespace logxor
 bool op::v1::LogicalXor::evaluate(const HostTensorVector& outputs,
                                   const HostTensorVector& inputs) const
 {
-    NGRAPH_OP_SCOPE(op_v1_LogicalXor_evaluate,
+    NGRAPH_OP_SCOPE(v1_LogicalXor_evaluate,
                     return logxor::evaluate_logxor(inputs[0], inputs[1], outputs[0], get_autob()));
     return false;
 }

--- a/ngraph/core/src/op/xor.cpp
+++ b/ngraph/core/src/op/xor.cpp
@@ -70,20 +70,13 @@ namespace logxor
         out->set_broadcast(broadcast_spec, arg0, arg1);
         switch (arg0->get_element_type())
         {
-            TYPE_CASE(boolean)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(i32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(i64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u32)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(u64)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f16)(arg0, arg1, out, broadcast_spec);
-            break;
-            TYPE_CASE(f32)(arg0, arg1, out, broadcast_spec);
-            break;
+            NGRAPH_TYPE_CASE(evaluate_logxor, boolean, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_logxor, i32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_logxor, i64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_logxor, u32, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_logxor, u64, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_logxor, f16, arg0, arg1, out, broadcast_spec);
+            NGRAPH_TYPE_CASE(evaluate_logxor, f32, arg0, arg1, out, broadcast_spec);
         default: rc = false; break;
         }
         return rc;
@@ -93,8 +86,9 @@ namespace logxor
 bool op::v1::LogicalXor::evaluate(const HostTensorVector& outputs,
                                   const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v1::LogicalXor::evaluate");
-    return logxor::evaluate_logxor(inputs[0], inputs[1], outputs[0], get_autob());
+    NGRAPH_OP_SCOPE(op_v1_LogicalXor_evaluate,
+                    return logxor::evaluate_logxor(inputs[0], inputs[1], outputs[0], get_autob()));
+    return false;
 }
 
 constexpr NodeTypeInfo op::v0::Xor::type_info;
@@ -115,6 +109,7 @@ shared_ptr<Node> op::v0::Xor::clone_with_new_inputs(const OutputVector& new_args
 
 bool op::v0::Xor::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraphOp, "op::v0::Xor::evaluate");
-    return logxor::evaluate_logxor(inputs[0], inputs[1], outputs[0], get_autob());
+    NGRAPH_OP_SCOPE(v0_Xor_evaluate,
+                    return logxor::evaluate_logxor(inputs[0], inputs[1], outputs[0], get_autob()));
+    return false;
 }


### PR DESCRIPTION
In this PR I have added the new macros  to enable conditional compilation for nGraph.

And also I changed implementations of all existed evaluate methods to these macros.