### PR TITLE
[CPU BF16] Fix for fusing depthwise operation into BF16 convolutions

### DIFF
--- a/inference-engine/src/mkldnn_plugin/bf16transformer.h
+++ b/inference-engine/src/mkldnn_plugin/bf16transformer.h
@@ -22,7 +22,7 @@ class BF16Transformer {
           "broadcast", "convert", "BatchToSpace", "DepthToSpace", "ExtractImagePatches", "concat", "power", "lrn",
           "permute", "ScatterUpdate", "ScatterElementsUpdate", "ScatterNDUpdate", "depthwise",
           "select", "ShuffleChannels", "SpaceToBatch", "SpaceToDepth", "squeeze", "StridedSlice", "unsqueeze", "eltwise",
-          "ReduceAnd", "ReduceOr", "ReduceMax", "ReduceMin" };
+          "ReduceAnd", "ReduceOr", "ReduceMax", "ReduceMin", "ScaleShift"};
 
     const InferenceEngine::details::caseless_set<std::string> _multiinput =
         { "concat", "eltwise" };


### PR DESCRIPTION
### Description

Fix for mklDNN (https://github.com/openvinotoolkit/oneDNN/pull/25) fusing  bf16 convolutions with depthwise operations. The main problem was that the wrong data sizes were used to calculate the memory offset in the weight and offset arrays.

### Bug fixes

This PR fixes issue #43567.