### PR TITLE
-no-unused-variable option added for selective build mode

### DIFF
--- a/openvino/conditional_compilation/CMakeLists.txt
+++ b/openvino/conditional_compilation/CMakeLists.txt
@@ -51,6 +51,15 @@ elseif(SELECTIVE_BUILD STREQUAL "ON")
 
     target_compile_definitions(${TARGET_NAME} INTERFACE SELECTIVE_BUILD)
 
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+        OR CMAKE_CXX_COMPILER_ID MATCHES "^(Apple)?Clang$")
+        # After disabling a block of code, some variables might be unused.
+        target_compile_options(${TARGET_NAME} INTERFACE
+                                -Wno-unused-function
+                                -Wno-unused-parameter
+                                -Wunused-local-typedefs)
+    endif()
+
     set(GENERATED_HEADER ${CMAKE_CURRENT_BINARY_DIR}/conditional_compilation_gen.h)
     set(GENERATOR ${CMAKE_CURRENT_SOURCE_DIR}/scripts/ccheader.py)
 


### PR DESCRIPTION
After the cut out of unused code compiler throw error for all unused variables. This fix disables these errors.