### PR TITLE
Fix ROIPooling test

### DIFF
--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/roi_pooling.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/roi_pooling.cpp
@@ -12,7 +12,7 @@ using namespace LayerTestsDefinitions;
 namespace {
 
 const std::vector<std::vector<size_t>> inShapes = {
-    {3, 4, 50, 50}
+    {1, 4, 50, 50}
 };
 
 const std::vector<std::vector<size_t>> pooledShapes_max = {

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/skip_tests_config.cpp
@@ -32,8 +32,6 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*DSR_NonMaxSuppression.*NBoxes=(5|20|200).*)",
         // TODO: Issue: 42721
         R"(.*(DSR_GatherND).*)",
-        // TODO: Issue 43781
-        ".*ROIPoolingLayerTest.*",
         // TODO: Issue 26090
         ".*DSR_GatherStaticDataDynamicIdx.*f32.*1.3.200.304.*"
     };

--- a/inference-engine/tests/functional/shared_test_classes/src/single_layer/roi_pooling.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/single_layer/roi_pooling.cpp
@@ -41,8 +41,11 @@ namespace LayerTestsDefinitions {
         inputs.clear();
 
         auto feat_map_shape = cnnNetwork.getInputShapes().begin()->second;
-        const int height = pool_method == ngraph::helpers::ROIPoolingTypes::ROI_MAX ? feat_map_shape[2] / spatial_scale : 1;
-        const int width = pool_method == ngraph::helpers::ROIPoolingTypes::ROI_MAX ? feat_map_shape[3] / spatial_scale : 1;
+
+        const auto is_roi_max_mode = (pool_method == ngraph::helpers::ROIPoolingTypes::ROI_MAX);
+
+        const int height = is_roi_max_mode ? feat_map_shape[2] / spatial_scale : 1;
+        const int width  = is_roi_max_mode ? feat_map_shape[3] / spatial_scale : 1;
 
         size_t it = 0;
         for (const auto &input : cnnNetwork.getInputsInfo()) {
@@ -53,7 +56,7 @@ namespace LayerTestsDefinitions {
                 blob = make_blob_with_precision(info->getTensorDesc());
                 blob->allocate();
                 CommonTestUtils::fill_data_roi(blob->buffer(), blob->size(), feat_map_shape[0] - 1,
-                                               height, width, 1.0f);
+                                               height, width, 1.0f, is_roi_max_mode);
             } else {
                 blob = GenerateInput(*info);
             }
@@ -69,7 +72,8 @@ namespace LayerTestsDefinitions {
         InferenceEngine::SizeVector coordsShape;
         InferenceEngine::SizeVector poolShape;
         InferenceEngine::Precision netPrecision;
-        float spatial_scale;
+
+        threshold = 0.08f;
 
         std::tie(inputShape, coordsShape, poolShape, spatial_scale, pool_method, netPrecision, targetDevice) = this->GetParam();
 

--- a/inference-engine/tests/ie_test_utils/common_test_utils/data_utils.hpp
+++ b/inference-engine/tests/ie_test_utils/common_test_utils/data_utils.hpp
@@ -123,32 +123,42 @@ static void fill_data_bbox(float *data, size_t size, int height, int width, floa
     }
 }
 
-static void fill_data_roi(float *data, size_t size, const uint32_t range, const int height, const int width, const float omega, const int seed = 1) {
+static void fill_data_roi(float *data, size_t size, const uint32_t range, const int height, const int width, const float omega,
+                          const bool is_roi_max_mode, const int seed = 1) {
     std::default_random_engine random(seed);
     std::uniform_int_distribution<int32_t> distribution(0, range);
-    float center_h = (height - 1.0f) / 2;
-    float center_w = (width - 1.0f) / 2;
+
+    const int max_y = (is_roi_max_mode) ? (height - 1) : 1;
+    const int max_x = (is_roi_max_mode) ? (width - 1)  : 1;
+
+    float center_h = (max_y) / 2.0f;
+    float center_w = (max_x) / 2.0f;
+
     for (size_t i = 0; i < size; i += 5) {
         data[i] = static_cast<float>(distribution(random));
-        data[i + 1] = std::floor(center_w + width * 0.6f * sin(static_cast<float>(i+1) * omega));
-        data[i + 3] = std::floor(center_w + width * 0.6f * sin(static_cast<float>(i+3) * omega));
+        const float x0 = (center_w + width * 0.3f * sin(static_cast<float>(i + 1) * omega));
+        const float x1 = (center_w + width * 0.3f * sin(static_cast<float>(i + 3) * omega));
+        data[i + 1] = is_roi_max_mode ? std::floor(x0) : x0;
+        data[i + 3] = is_roi_max_mode ? std::floor(x1) : x1;
         if (data[i + 3] < data[i + 1]) {
             std::swap(data[i + 1], data[i + 3]);
         }
         if (data[i + 1] < 0)
             data[i + 1] = 0;
-        if (data[i + 3] > width - 1)
-            data[i + 3] = static_cast<float>(width - 1);
+        if (data[i + 3] > max_x)
+            data[i + 3] = static_cast<float>(max_x);
 
-        data[i + 2] = std::floor(center_h + height * 0.6f * sin(static_cast<float>(i+2) * omega));
-        data[i + 4] = std::floor(center_h + height * 0.6f * sin(static_cast<float>(i+4) * omega));
+        const float y0 = (center_h + height * 0.3f * sin(static_cast<float>(i + 2) * omega));
+        const float y1 = (center_h + height * 0.3f * sin(static_cast<float>(i + 4) * omega));
+        data[i + 2] = is_roi_max_mode ? std::floor(y0) : y0;
+        data[i + 4] = is_roi_max_mode ? std::floor(y1) : y1;
         if (data[i + 4] < data[i + 2]) {
             std::swap(data[i + 2], data[i + 4]);
         }
         if (data[i + 2] < 0)
             data[i + 2] = 0;
-        if (data[i + 4] > height - 1)
-            data[i + 4] = static_cast<float>(height - 1);
+        if (data[i + 4] > max_y)
+            data[i + 4] = static_cast<float>(max_y);
     }
 }
 


### PR DESCRIPTION
task: -43781
- fix initialization bug of `spatial_scale` in tests (affected input generating)
- fix input generating for bilinear ROI Pooling
- correct parameters for myriad tests:
    - myriad plugin does not support batch for this layer;
    - decrease threshold since myriad uses fp16 calculations