### PR TITLE
[IE TESTS][CPU] I8 and U8 precisions was enabled in the reverse sequence single layer test.

### DIFF
--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/reverse_sequence.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/reverse_sequence.cpp
@@ -14,8 +14,8 @@ namespace {
 const std::vector<InferenceEngine::Precision> netPrecisions = {
         InferenceEngine::Precision::FP32,
         InferenceEngine::Precision::FP16,
-        InferenceEngine::Precision::U8, //doesn't match the reference values
-        InferenceEngine::Precision::I8, //doesn't match the reference values
+        InferenceEngine::Precision::U8,
+        InferenceEngine::Precision::I8,
         InferenceEngine::Precision::U16,
         InferenceEngine::Precision::I32
 };

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
@@ -51,8 +51,6 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*ActivationLayerTest.*Ceiling.*)",
         // TODO: Issue: 32032
         R"(.*ActivationParamLayerTest.*)",
-        // TODO: Issue: 37862
-        R"(.*ReverseSequenceLayerTest.*netPRC=(I8|U8).*)",
         // TODO: Issue: 38841
         R"(.*TopKLayerTest.*k=5.*sort=none.*)",
         // TODO: Issue: 43314


### PR DESCRIPTION
The I8 and U8 precisions for the reverse sequence test configuration was removed from the skip list  as these tests work after some fix.