### PR TITLE
Allow multiple output shapes testing

### DIFF
--- a/inference-engine/tests/functional/shared_test_classes/src/single_layer/reshape.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/single_layer/reshape.cpp
@@ -16,6 +16,7 @@ namespace LayerTestsDefinitions {
     std::tie(specialZero, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShapes, outFormShapes, targetDevice, config) = obj.param;
     std::ostringstream result;
     result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "OS=" << CommonTestUtils::vec2str(outFormShapes) << "_";
     result << "specialZero=" << specialZero << "_";
     result << "netPRC=" << netPrecision.name() << "_";
     result << "inPRC=" << inPrc.name() << "_";


### PR DESCRIPTION
gtest does not allow same name for different tests