### PR TITLE
[MO] Implement support of TensorFlow 2 Keras Embedding operation in MO

### DIFF
--- a/model-optimizer/requirements.txt
+++ b/model-optimizer/requirements.txt
@@ -1,5 +1,5 @@
 tensorflow>=1.15.2,<2.0; python_version < "3.8"
-tensorflow>=2.0; python_version >= "3.8"
+tensorflow>=2.2; python_version >= "3.8"
 mxnet>=1.0.0,<=1.5.1
 networkx>=1.11
 numpy>=1.14.0,<1.19.0

--- a/model-optimizer/requirements_tf.txt
+++ b/model-optimizer/requirements_tf.txt
@@ -1,5 +1,5 @@
 tensorflow>=1.15.2,<2.0; python_version < "3.8"
-tensorflow>=2.0; python_version >= "3.8"
+tensorflow>=2.2; python_version >= "3.8"
 networkx>=1.11
 numpy>=1.14.0,<1.19.0
 test-generator==0.1.1

--- a/model-optimizer/requirements_tf2.txt
+++ b/model-optimizer/requirements_tf2.txt
@@ -1,4 +1,4 @@
-tensorflow>=2.0
+tensorflow>=2.2
 networkx>=1.11
 numpy>=1.14.0
 test-generator==0.1.1


### PR DESCRIPTION
Description: Implement support of TensorFlow 2 Keras Embedding operation in the MO tool

JIRA: 32185


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names


Validation:
* [x]  Unit tests - N/A
* [x]  Framework operation tests - N/A
* [x]  Transformation tests - N/A
* [x]  e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list - the documentation will be updated in the scope of separate activity
* [x]  Supported **public** models list - N/A
* [x]  New operations specification - N/A
* [x]  Guide on how to convert the **public** model - N/A
* [x]  User guide update - N/A

Signed-off-by: Roman Kazantsev <roman.kazantsev@intel.com>