### PR TITLE
Use find_package instead of include(Find*) in CMake scripts

### DIFF
--- a/cmake/developer_package/download/download_and_check.cmake
+++ b/cmake/developer_package/download/download_and_check.cmake
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-include (FindWget)
+find_package(Wget QUIET)
 
 function (DownloadAndCheck from to fatal result sha256)
   set(status_res "ON")
@@ -23,10 +23,10 @@ function (DownloadAndCheck from to fatal result sha256)
           list(GET output 0 status_code)
         else()
           foreach(index RANGE 5)
-            message(STATUS "${WGET_EXECUTABLE} --no-cache --no-check-certificate 
+            message(STATUS "${WGET_EXECUTABLE} --no-cache --no-check-certificate
               --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 --tries=5 ${from}")
-            execute_process(COMMAND ${WGET_EXECUTABLE} "--no-cache" "--no-check-certificate" 
-              "--retry-connrefused" "--waitretry=1" "--read-timeout=20" "--timeout=15" "--tries=5" 
+            execute_process(COMMAND ${WGET_EXECUTABLE} "--no-cache" "--no-check-certificate"
+              "--retry-connrefused" "--waitretry=1" "--read-timeout=20" "--timeout=15" "--tries=5"
               "${from}" "-O" "${to}"
               TIMEOUT 2000
               RESULT_VARIABLE status_code)

--- a/inference-engine/tests_deprecated/functional/cldnn/CMakeLists.txt
+++ b/inference-engine/tests_deprecated/functional/cldnn/CMakeLists.txt
@@ -15,8 +15,10 @@ list(APPEND CLDNN_LIBS
         ${CLDNN__IOCL_ICD_LIBPATH})
 
 # try to find VA libraries
-include(FindPkgConfig)
-pkg_search_module(LIBVA QUIET libva)
+find_package(PkgConfig QUIET)
+if(PkgConfig_FOUND)
+    pkg_search_module(LIBVA QUIET libva)
+endif()
 
 # TODO: pkg_search_module finds libva not in sysroot
 if(ANDROID)


### PR DESCRIPTION
Otherwise CMake produces the following warning:

```
CMake Warning (dev) at /usr/local/share/cmake-3.19/Modules/FindPackageHandleStandardArgs.cmake:426 (message):
  The package name passed to `find_package_handle_standard_args` (Wget) does
  not match the name of the calling package (IEDevScripts).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  /usr/local/share/cmake-3.19/Modules/FindWget.cmake:26 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  cmake/developer_package/download/download_and_check.cmake:5 (include)
  cmake/developer_package/download/download_and_extract.cmake:6 (include)
  cmake/developer_package/download/download.cmake:25 (include)
  cmake/developer_package/download/dependency_solver.cmake:5 (include)
  cmake/developer_package/IEDevScriptsConfig.cmake:208 (include)
  CMakeLists.txt:12 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```