### PR TITLE
[DRAFT] [IE CLDNN] gpu tensor iterator

### DIFF
--- a/inference-engine/src/cldnn_engine/cldnn_engine.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_engine.cpp
@@ -244,7 +244,8 @@ InferenceEngine::ICNNNetwork::Ptr clDNNEngine::CloneAndTransformNetwork(const In
         {
             ngraph::pass::Manager manager = ngraph::pass::Manager();
             manager.register_pass<ngraph::pass::ConvertOpSet1ToLegacy>();
-            manager.register_pass<ngraph::pass::UnrollTensorIterator>();
+            //TODO: implement switch mechanism
+            //manager.register_pass<ngraph::pass::UnrollTensorIterator>();
             manager.set_callback(transformations_callback);
             manager.run_passes(nGraphFunc);
         }

--- a/inference-engine/src/cldnn_engine/cldnn_program.h
+++ b/inference-engine/src/cldnn_engine/cldnn_program.h
@@ -31,6 +31,7 @@
 #include <api/eltwise.hpp>
 #include <api/concatenation.hpp>
 #include <api/detection_output.hpp>
+#include <api/tensor_iterator.hpp>
 
 namespace CLDNNPlugin {
 template<typename LayerTypePtr>
@@ -85,7 +86,7 @@ public:
 
 class Program {
 public:
-    Program(InferenceEngine::ICNNNetwork &network, std::shared_ptr<const cldnn::engine> engine, const Config& config);
+    Program(InferenceEngine::ICNNNetwork &network, std::shared_ptr<const cldnn::engine> engine, const Config& config, bool build_program = true);
     std::shared_ptr<cldnn::program> getCompiledProgram(int program_id = 0);
 
     std::map<std::string, cldnn::primitive_id> primitiveIDs;
@@ -230,6 +231,7 @@ public:
         EmbeddingBagOffsetsSum,
         EmbeddingSegmentsSum,
         ExtractImagePatches,
+        TensorIterator,
         NO_TYPE
     };
     using GenericBlobMap = std::map<cldnn::primitive_id, cldnn::primitive_id>;
@@ -242,6 +244,8 @@ private:
     Config m_config;
 
     std::shared_ptr<cldnn::program> BuildProgram(InferenceEngine::ICNNNetwork &network);
+    cldnn::topology BuildTopology(InferenceEngine::ICNNNetwork &network);
+    void processOutputs(InferenceEngine::ICNNNetwork & network, cldnn::topology& topology);
 
     void InitProfileInfo(const std::string& layerName,
                          const std::string& layerType,
@@ -395,6 +399,7 @@ private:
     void CreateEmbeddingBagOffsetsSumPrimitive(cldnn::topology& topology, InferenceEngine::CNNLayerPtr& layer);
     void CreateEmbeddingSegmentsSumPrimitive(cldnn::topology& topology, InferenceEngine::CNNLayerPtr& layer);
     void CreateExtractImagePatchesPrimitive(cldnn::topology& topology, InferenceEngine::CNNLayerPtr &layer);
+    void CreateTensorIteratorPrimitive(cldnn::topology& topology, InferenceEngine::CNNLayerPtr &layer);
 };
 
 }  // namespace CLDNNPlugin

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/tensor_iterator.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/tensor_iterator.cpp
@@ -1,0 +1,28 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+#include <ngraph/op/util/attr_types.hpp>
+#include "single_layer_tests/tensor_iterator.hpp"
+#include "common_test_utils/test_constants.hpp"
+
+using namespace LayerTestsDefinitions;
+
+namespace {
+    INSTANTIATE_TEST_CASE_P(smoke_TensorIteratorCommon, TensorIteratorTest,
+        ::testing::Combine(
+            ::testing::ValuesIn({ false }), // should decompose
+            ::testing::ValuesIn(std::vector<size_t>{2}), // seq lengths zero clip
+            ::testing::ValuesIn(std::vector<size_t> {20}), // seq lengths clip non zero
+            ::testing::ValuesIn(std::vector<size_t> {1, 10}), // hidden size
+            ::testing::ValuesIn(std::vector<size_t> {0, 1}), // seq axis
+            ::testing::ValuesIn(std::vector<float> {0.f}), // clip
+            ::testing::ValuesIn(std::vector<ngraph::helpers::TensorIteratorBody> {ngraph::helpers::TensorIteratorBody::SingleEltwise }), // body type
+            ::testing::ValuesIn(std::vector<ngraph::op::RecurrentSequenceDirection>{ngraph::op::RecurrentSequenceDirection::FORWARD,
+                                                                                    ngraph::op::RecurrentSequenceDirection::REVERSE }), // direction
+            ::testing::ValuesIn(std::vector<InferenceEngine::Precision> {InferenceEngine::Precision::FP32,
+                                                                         InferenceEngine::Precision::FP16 }), // precision
+            ::testing::Values(CommonTestUtils::DEVICE_GPU)),
+        TensorIteratorTest::getTestCaseName);
+}  // namespace

--- a/inference-engine/tests/ngraph_functions/include/ngraph_functions/utils/ngraph_helpers.hpp
+++ b/inference-engine/tests/ngraph_functions/include/ngraph_functions/utils/ngraph_helpers.hpp
@@ -187,6 +187,7 @@ enum class TensorIteratorBody {
     RNN,
     GRU,
     LSTM,
+    SingleEltwise
     // CNN todo: implement
 };
 

--- a/inference-engine/tests/ngraph_functions/src/utils/ngraph_helpers.cpp
+++ b/inference-engine/tests/ngraph_functions/src/utils/ngraph_helpers.cpp
@@ -758,6 +758,9 @@ std::ostream& operator<<(std::ostream & os, TensorIteratorBody type) {
         case TensorIteratorBody::GRU:
             os << "GRU";
             break;
+        case TensorIteratorBody::SingleEltwise:
+            os << "SingleEltwise";
+            break;
         default:
             throw std::runtime_error("NOT_SUPPORTED_OP_TYPE");
     }

--- a/inference-engine/thirdparty/clDNN/api/tensor_iterator.hpp
+++ b/inference-engine/thirdparty/clDNN/api/tensor_iterator.hpp
@@ -67,10 +67,8 @@ struct tensor_iterator : public primitive_base<tensor_iterator> {
         std::vector<backedge_mapping> backedge_mapping = {},
         const padding& output_padding = padding())
             : primitive_base(id, inputs, output_padding),
-               body(body),
-        ports_desc(input_mapping, outputs, backedge_mapping) {
-        /*output_data_type = data_types::f16;*/
-    };
+              body(body),
+              ports_desc(input_mapping, outputs, backedge_mapping) {};
 
     topology body;
 

--- a/inference-engine/thirdparty/clDNN/api/tensor_iterator.hpp
+++ b/inference-engine/thirdparty/clDNN/api/tensor_iterator.hpp
@@ -1,0 +1,79 @@
+/*
+// Copyright (c) 2020 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+#pragma once
+#include "primitive.hpp"
+#include "topology.hpp"
+#include <vector>
+#include <map>
+
+namespace cldnn {
+
+struct tensor_iterator : public primitive_base<tensor_iterator> {
+    CLDNN_DECLARE_PRIMITIVE(tensor_iterator)
+
+    struct input_mapping {
+        input_mapping(int from, primitive_id to, int axis = -1)
+            : from(from), to(to), axis(axis) {}
+        int from;
+        primitive_id to;
+        int axis;
+    };
+
+    struct backedge_mapping {
+        backedge_mapping(primitive_id from, int to)
+            : from(from), to(to) {}
+        primitive_id from;
+        int to;
+    };
+
+    struct port_map_collection {
+        port_map_collection(std::vector<input_mapping> input_ports, std::vector<primitive_id> output_ports, std::vector<backedge_mapping> back_edges)
+            : input_ports(input_ports),
+                output_ports(output_ports),
+                back_edges(back_edges) {};
+        std::vector<input_mapping> input_ports;
+        std::vector<primitive_id> output_ports;
+        std::vector<backedge_mapping> back_edges;
+        int find_input_port_with_selected_axis() const {
+            for (int i = 0; i < input_ports.size(); i++) {
+                if (input_ports[i].axis >= 0) {
+                    return i;
+                }
+            }
+            return -1;
+        }
+    } ports_desc;
+
+    tensor_iterator(const primitive_id& id,
+        const std::vector<primitive_id> inputs,
+        const topology& body,
+        std::vector<input_mapping> input_mapping,
+        std::vector<primitive_id> outputs,
+        std::vector<backedge_mapping> backedge_mapping = {},
+        const padding& output_padding = padding())
+            : primitive_base(id, inputs, output_padding),
+               body(body),
+        ports_desc(input_mapping, outputs, backedge_mapping) {
+        /*output_data_type = data_types::f16;*/
+    };
+
+    topology body;
+
+    
+};
+}  // namespace cldnn

--- a/inference-engine/thirdparty/clDNN/src/gpu/register_gpu.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/register_gpu.cpp
@@ -88,6 +88,7 @@ void register_implementations_gpu() {
     REGISTER_GPU(cum_sum);
     REGISTER_GPU(embedding_bag);
     REGISTER_GPU(extract_image_patches);
+    REGISTER_GPU(tensor_iterator);
 }
 
 }  // namespace gpu

--- a/inference-engine/thirdparty/clDNN/src/gpu/register_gpu.hpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/register_gpu.hpp
@@ -76,6 +76,7 @@
 #include "api/non_max_suppression.hpp"
 #include "api/grn.hpp"
 #include "api/ctc_greedy_decoder.hpp"
+#include "api/tensor_iterator.hpp"
 
 
 namespace cldnn { namespace gpu {
@@ -155,6 +156,7 @@ REGISTER_GPU(ctc_greedy_decoder);
 REGISTER_GPU(cum_sum);
 REGISTER_GPU(embedding_bag);
 REGISTER_GPU(extract_image_patches);
+REGISTER_GPU(tensor_iterator);
 
 #undef REGISTER_GPU
 

--- a/inference-engine/thirdparty/clDNN/src/gpu/tensor_iterator_gpu.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/tensor_iterator_gpu.cpp
@@ -1,0 +1,246 @@
+/*
+// Copyright (c) 2020 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+#include "tensor_iterator_inst.h"
+#include "network_impl.h"
+#include "implementation_map.h"
+#include "math_utils.h"
+#include "register_gpu.hpp"
+#include "mutable_data_inst.h"
+#include "input_layout_inst.h"
+#include <vector>
+
+namespace cldnn {
+namespace gpu {
+struct tensor_iterator_gpu : typed_primitive_impl<tensor_iterator> {
+    const tensor_iterator_node& outer;
+    using port_map_collection = tensor_iterator::port_map_collection;
+
+    explicit tensor_iterator_gpu(const tensor_iterator_node& outer) : outer(outer) {}
+
+    struct backedge_memory_binding {
+        memory_impl* from_mem;
+        memory_impl* to_mem;
+        memory_impl::ptr backup;
+        primitive_id from_id;
+        primitive_id to_id;
+        bool is_optimized;
+    };
+
+    struct input_memory_binding {
+        memory_impl* from_mem;
+        memory_impl* to_mem;
+        int iteration_elements = 0;
+        int offset = 0;
+    };
+
+    // helpers
+    static size_t get_datatype_size(const memory_impl* mem) {
+        if (mem->get_layout().data_type == data_types::f16)
+            return 2;
+        return 4;
+    }
+
+    static memory_impl* get_output_memory(network_impl::ptr body_network, primitive_id prim_id) {
+        return &body_network->get_primitive(prim_id).get()->output_memory();
+    }
+
+    static bool check_if_can_be_optimized(backedge_memory_binding backedge, const tensor_iterator_inst& instance) {
+        if (instance.get_body_network()->get_primitive(backedge.from_id)->dependencies().size() == 1)
+            return false;
+        auto node_feeding_backedge = instance.get_body_network()->get_primitive(backedge.from_id)->dependencies()[0];
+        for (auto node_dep : node_feeding_backedge->dependencies()) {
+            void* ptr1 = node_dep->output_memory().lock();
+            void* ptr2 = backedge.to_mem->lock();
+            if (ptr1 == ptr2) {
+                return false;
+            }
+            node_dep->output_memory().unlock();
+            backedge.to_mem->unlock();
+        }
+        return true;
+    }
+
+    static void copy_memory(primitive_id instance_id, memory_impl* from, memory_impl* to, size_t elements_to_copy, size_t source_offset = 0, size_t destination_offset = 0) {
+        if (from->get_layout().data_type != to->get_layout().data_type)
+            CLDNN_ERROR_MESSAGE(instance_id,"incompatible datatypes");
+        size_t bytes_per_element = get_datatype_size(from);
+        mem_lock<uint8_t> from_lock{ *from };
+        mem_lock<uint8_t> to_lock{ *to };
+        std::copy(from_lock.begin() + (source_offset * bytes_per_element),
+                  from_lock.begin() + (source_offset * bytes_per_element) + (elements_to_copy * bytes_per_element),
+                  to_lock.begin() + (destination_offset * bytes_per_element));
+    }
+
+    static void copy_entire_buffer(primitive_id instance_id, memory_impl* from, memory_impl* to, size_t destination_offset = 0) {
+        copy_memory(instance_id, from, to, from->size() / get_datatype_size(from), 0, destination_offset);
+    }
+
+    // memory pools
+    std::set<memory_impl::ptr> croped_mem_pool;
+    std::map<primitive_id, memory_impl::ptr> croped_input_mem_pool;
+
+    void process_internal_memory(tensor_iterator_inst& instance,
+                                 std::vector<backedge_memory_binding>& backedge_mem,
+                                 std::vector<input_memory_binding>& iteration_mem) {
+        auto body_network = instance.get_body_network();
+        const auto& ports_desc = instance.get_port_desc();
+        
+        for (int memory_num = 0; memory_num < instance.inputs_memory_count(); memory_num++) {
+            memory_impl& memory = instance.input_memory(memory_num);
+            auto input_desc = tensor_iterator_node::find_input_port_description(memory_num, ports_desc);
+            if (input_desc == nullptr)
+                CLDNN_ERROR_MESSAGE(instance.id(), "tensor iterator routing info incomplete");
+
+            // handle memory
+            if (input_desc->axis >= 0) { // checks if it's a memory to iterate through
+                layout croped_layout
+                    = instance.get_body_network()->get_primitive(input_desc->to)->output_memory().get_layout();
+                memory_impl::ptr croped_mem = instance.get_network().get_engine().allocate_memory(croped_layout, 0);
+                croped_input_mem_pool[input_desc->to] = croped_mem;
+                int lin_size = static_cast<int>(croped_layout.get_linear_size());
+                input_memory_binding memory_binding;
+                memory_binding.from_mem = &memory;
+                memory_binding.to_mem = croped_mem.get();
+                memory_binding.iteration_elements = lin_size;
+                iteration_mem.push_back(memory_binding);
+                body_network->set_input_data(input_desc->to, *croped_mem.get());
+            }
+            else { // "normal" mem
+                if (memory.get_layout().data_type != body_network->get_primitive(input_desc->to)->output_memory().get_layout().data_type)
+                    CLDNN_ERROR_MESSAGE(instance.id(), "incompatible datatypes");
+
+                body_network->set_input_data(input_desc->to, memory);
+            }
+
+            // checking if memory is a destination of a backedge
+            for (auto back_edge_desc : ports_desc.back_edges) { //todo: what if node is both input & output?
+                if (memory_num == back_edge_desc.to) {
+                    //find corresponding input of the backedge
+                    for (auto output : body_network->get_outputs()) {
+                        if (output->id() == back_edge_desc.from + instance.node.backedge_suffix) {
+                            backedge_memory_binding mem_bind;
+                            mem_bind.from_mem = get_output_memory(body_network, output->id());
+                            mem_bind.to_mem = get_output_memory(body_network, input_desc->to);
+                            mem_bind.from_id = output->id();
+                            mem_bind.to_id = input_desc->to;
+                            mem_bind.is_optimized = false;
+                            mem_bind.backup = instance.get_network().get_engine().allocate_memory(mem_bind.to_mem->get_layout(), 0);
+
+                            if (mem_bind.to_mem->get_layout().data_type != mem_bind.to_mem->get_layout().data_type)
+                                CLDNN_ERROR_MESSAGE(instance.id(), "incompatible datatypes");
+                            copy_entire_buffer(instance.id(), mem_bind.to_mem, mem_bind.from_mem);
+                            copy_entire_buffer(instance.id(), mem_bind.to_mem, mem_bind.backup.get());
+                            backedge_mem.push_back(mem_bind);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    event_impl::ptr execute_impl(const std::vector<event_impl::ptr>& events, tensor_iterator_inst& instance) override {
+        auto ev = instance.get_network().get_engine().create_user_event(instance.get_network().get_stream_id(), false);
+        for (auto& e : events)
+            e->wait();
+
+        //shortcut refs
+        auto body_network = instance.get_body_network();
+        const auto& ports_desc = instance.get_port_desc();
+
+        //manage internal memory
+        std::vector<backedge_memory_binding> backedge_mem;
+        std::vector<input_memory_binding> iteration_mem;
+        process_internal_memory(instance, backedge_mem, iteration_mem);
+
+        //find an output memory
+        std::string main_internal_output_id = ports_desc.output_ports.at(0);
+        if (instance.node.is_output_working_as_backedge())
+            main_internal_output_id += instance.node.backedge_suffix;
+
+        auto body_output_mem_result = std::find_if(body_network->get_outputs().begin(),
+                                                   body_network->get_outputs().end(),
+                                                   [&](auto output) {return output->id() == main_internal_output_id;});
+
+        if (body_output_mem_result == body_network->get_outputs().end())
+            CLDNN_ERROR_MESSAGE(instance.id(), "incompatible datatypes");
+
+        memory_impl* body_output_mem = &(*body_output_mem_result)->output_memory();
+        size_t output_mem_offset = 0;
+        size_t ti_output_mem_iter_size = body_output_mem->get_layout().get_linear_size();
+
+        // memory read-write optimization
+        // it makes output nodes write directly to input memory
+        const bool enable_memory_rw_opt = true;
+        if (enable_memory_rw_opt) {
+            for (auto& backedge : backedge_mem) {
+                if (check_if_can_be_optimized(backedge, instance)) {
+                    body_network->set_input_data(backedge.to_id, *backedge.from_mem);
+                    backedge.is_optimized = true;
+                }
+            }
+        }
+
+        // execute internal topology
+        for (int i = 0; i < instance.node.iterations; i++) {
+           // copy input mem
+            for (auto& iter_mem : iteration_mem) {
+                copy_memory(instance.id(), iter_mem.from_mem, iter_mem.to_mem, iter_mem.iteration_elements, iter_mem.offset);
+                iter_mem.offset += iter_mem.iteration_elements;
+            }
+            body_network->execute(events);
+            //copy output
+            copy_entire_buffer(instance.id(), body_output_mem, &instance.output_memory(), output_mem_offset);
+            output_mem_offset += ti_output_mem_iter_size;
+
+            // copy back_edges
+            for (auto edge_mem_bind : backedge_mem) {
+                if (!edge_mem_bind.is_optimized) {
+                    copy_entire_buffer(instance.id(), edge_mem_bind.from_mem, edge_mem_bind.to_mem);
+                }
+            }
+        }
+        
+        //restore previous inputs' state
+        for (auto edge_mem_bind : backedge_mem) {
+            if (edge_mem_bind.is_optimized) {
+                body_network->set_input_data(edge_mem_bind.to_id, *edge_mem_bind.to_mem);
+            }
+            else {
+                copy_entire_buffer(instance.id(), edge_mem_bind.backup.get(), edge_mem_bind.to_mem);
+            }
+        }
+        dynamic_cast<cldnn::user_event*>(ev.get())->set();
+        return ev;
+    }
+
+    static primitive_impl* create(const tensor_iterator_node& arg) { return new tensor_iterator_gpu(arg); }
+};
+
+namespace detail {
+attach_tensor_iterator_gpu::attach_tensor_iterator_gpu() {
+    implementation_map<tensor_iterator>::add(
+                                std::make_tuple(engine_types::ocl, data_types::f32, format::bfyx),
+                                tensor_iterator_gpu::create);
+    implementation_map<tensor_iterator>::add(
+                                std::make_tuple(engine_types::ocl, data_types::f16, format::bfyx),
+                                tensor_iterator_gpu::create);
+}
+}  // namespace detail
+
+}  // namespace gpu
+}  // namespace cldnn

--- a/inference-engine/thirdparty/clDNN/src/include/tensor_iterator_inst.h
+++ b/inference-engine/thirdparty/clDNN/src/include/tensor_iterator_inst.h
@@ -1,0 +1,169 @@
+/*
+// Copyright (c) 2020 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+#pragma once
+
+#include <api/tensor_iterator.hpp>
+#include <api/mutable_data.hpp>
+#include <api/input_layout.hpp>
+#include <api/memory.hpp>
+
+#include "network_impl.h"
+#include "primitive_inst.h"
+#include <string>
+#include <memory>
+#include <vector>
+
+namespace cldnn {
+namespace details {}
+
+template<>
+struct typed_program_node<tensor_iterator> : public typed_program_node_base<tensor_iterator> {
+private:
+    using parent = typed_program_node_base<tensor_iterator>;
+    topology_impl& body;
+
+    mutable program_impl::ptr body_program;
+    mutable std::map<primitive_id, memory_impl::ptr> backedge_mem_impls;
+    mutable std::map<primitive_id, std::shared_ptr<mutable_data>> backedge_layers;
+    mutable std::map<primitive_id, std::shared_ptr<memory>> backedge_mem;  
+    
+    mutable bool output_is_backedge;
+
+    void setup_internal_mutabledata_node(primitive_id md_id, layout md_layout, std::vector<primitive_id> md_inputs_id = {}) const {
+        if (body.get_primitives().count(md_id) == 0) {
+            backedge_mem_impls[md_id] = get_program().get_engine().allocate_memory(md_layout, 0);
+            backedge_mem[md_id] = std::make_shared<memory>(backedge_mem_impls[md_id].get());
+            backedge_layers[md_id] = std::make_shared<mutable_data>(md_id, md_inputs_id, *backedge_mem[md_id]);       
+            body.add(backedge_layers[md_id]);
+        }
+    }
+
+public:
+    typed_program_node(std::shared_ptr<primitive> prim, program_impl& prog)
+        : parent(prim, prog),
+          body(*this->get_primitive()->body.get()),
+          ports_desc(get_primitive()->ports_desc){}
+
+    mutable int iterations;
+    mutable int iteration_axis;
+
+    program_impl::ptr get_body_program() const {
+        return body_program;
+    };
+
+    bool is_output_working_as_backedge() const {
+        return output_is_backedge;
+    }
+    const std::string backedge_suffix = ":backedge";
+
+    static const tensor_iterator::input_mapping* find_input_port_description(int prim_num, const tensor_iterator::port_map_collection& ports_desc) {
+        auto input_desc = std::find_if(ports_desc.input_ports.begin(),
+                                       ports_desc.input_ports.end(),
+                                       [&](const tensor_iterator::input_mapping& im) { return im.from == prim_num; });
+        if (input_desc == std::end(ports_desc.input_ports))
+            return nullptr;
+        return &(*input_desc);
+     }
+
+    layout calculate_layout_for_input(int input_num) const {
+        auto* inputDesc = find_input_port_description(input_num, ports_desc);
+        assert(inputDesc != nullptr);
+        layout calculated_layout = get_dependency(input_num).get_output_layout();
+        if (inputDesc->axis >= 0)
+            calculated_layout.size.raw[iteration_axis] = 1;
+        return calculated_layout;
+    }
+
+    void build_body_program() const {
+        auto deps = get_dependencies();
+
+        // setup internal inputs
+        for (int i = 0; i < deps.size(); i++) {
+            const tensor_iterator::input_mapping* input_rule = find_input_port_description(i, ports_desc);
+            assert(desc != nullptr);
+            layout calculated_layout = calculate_layout_for_input(i);
+            if (body.get_primitives().count(input_rule->to) == 0)
+                body.add(std::make_shared<input_layout>(input_rule->to, calculated_layout));
+            else
+                body.change_input_layout(input_rule->to, calculated_layout);
+        }
+        // setup internal output
+        std::set<primitive_id> output_names;
+
+        output_is_backedge = false;
+        for (auto out : ports_desc.back_edges) {
+            if (out.from == ports_desc.output_ports.at(0)) {
+                output_is_backedge = true;
+                break;
+            }
+        }
+
+        if (!output_is_backedge)
+            output_names.insert(ports_desc.output_ports.at(0));
+
+        // setup outputs for backedges
+        for (auto backedge : ports_desc.back_edges) {
+            primitive_id from_with_suffix = backedge.from + backedge_suffix;
+
+            for (auto prim : body.get_primitives()) {
+                for (auto &prims_dep : prim.second->dependencies()) {
+                    if (prims_dep.get() == backedge.from && prim.first != from_with_suffix) {
+                        prims_dep.get() = from_with_suffix;
+                        break;
+                    }
+                }
+            }
+            setup_internal_mutabledata_node(backedge.from + backedge_suffix, calculate_layout_for_input(backedge.to), { backedge.from });
+            output_names.insert(backedge.from + backedge_suffix);
+        }
+
+        auto opts = get_program().get_options();
+        std::vector<primitive_id> output_names_vec;
+        for (auto name : output_names)
+            output_names_vec.push_back(name);
+        opts.set_option(build_option::outputs(output_names_vec));
+        body_program = get_program().get_engine().build_program(body, opts, true);
+    }
+
+    std::vector<primitive_id> body_inputs() const {
+        std::vector<primitive_id> ids;
+        for (auto& dep_id : get_dependencies_ids()) {
+            ids.push_back(id() + ":" + dep_id);
+        }
+        return ids;
+    }
+    const tensor_iterator::port_map_collection &ports_desc;
+};
+
+using tensor_iterator_node = typed_program_node<tensor_iterator>;
+
+template <>
+class typed_primitive_inst<tensor_iterator> : public typed_primitive_inst_base<tensor_iterator> {
+    using parent = typed_primitive_inst_base<tensor_iterator>;
+
+public:
+    static layout calc_output_layout(tensor_iterator_node const& node);
+    static std::string to_string(tensor_iterator_node const& node);
+    typed_primitive_inst(network_impl& network, tensor_iterator_node const& node);
+    network_impl::ptr get_body_network() const { return body_network; };
+    std::vector<primitive_id> body_inputs() const { return node.body_inputs(); }
+    const tensor_iterator::port_map_collection get_port_desc() const { return node.ports_desc; };
+private:
+    network_impl::ptr body_network;
+};
+
+using tensor_iterator_inst = typed_primitive_inst<tensor_iterator>;
+}  // namespace cldnn

--- a/inference-engine/thirdparty/clDNN/src/tensor_iterator.cpp
+++ b/inference-engine/thirdparty/clDNN/src/tensor_iterator.cpp
@@ -1,0 +1,131 @@
+/*
+// Copyright (c) 2020 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+#include "tensor_iterator_inst.h"
+
+#include "error_handler.h"
+#include "json_object.h"
+#include "primitive_type_base.h"
+#include <string>
+#include <exception>
+#include <algorithm>
+
+namespace cldnn {
+primitive_type_id tensor_iterator::type_id() {
+    static primitive_type_base<tensor_iterator> instance;
+    return &instance;
+}
+
+bool check_if_axis_is_set_properly(tensor_iterator_node const & node) {
+    // helper
+    auto translate_between_bfyx_and_raw_axis = [](int axis) {
+        if (axis == 2)
+            return 3;
+        if (axis == 3)
+            return 2;
+        return axis;
+    };
+
+    std::vector<tensor_iterator::input_mapping> inputs_with_selected_axis;
+    for (const auto& input : node.ports_desc.input_ports) {
+        if (input.axis >= 0)
+            inputs_with_selected_axis.push_back(input);
+    }
+
+    // check if all iteration are performed on the same axis
+    int common_axis = -1;
+    for (const auto& input : inputs_with_selected_axis) {
+        if (common_axis == -1)
+            common_axis = input.axis;
+        else if (common_axis != input.axis)
+            return false;
+    }
+
+    // check if size of iteration axis is 1
+    for (const auto& input : inputs_with_selected_axis) {
+        tensor size = node.get_dependency(input.from).get_output_layout().size;
+        for (int i = translate_between_bfyx_and_raw_axis(input.axis) - 1; i >= 0; i--) {
+            if (size.raw[translate_between_bfyx_and_raw_axis(i)] != 1)
+                return false;
+        }
+    }
+    return true;
+}
+
+layout tensor_iterator_inst::calc_output_layout(tensor_iterator_node const & node) {
+    if (!check_if_axis_is_set_properly(node))
+        CLDNN_ERROR_MESSAGE(node.id(), "axis is not set properly");
+    // getting number of interations
+    int port_to_iterate_throgh = node.ports_desc.find_input_port_with_selected_axis();
+    node.iteration_axis = -1;
+    if (port_to_iterate_throgh == -1) {
+        node.iterations = 1;
+    }
+    else {
+        node.iteration_axis = node.ports_desc.input_ports[port_to_iterate_throgh].axis;
+        node.iterations = node.get_dependency(port_to_iterate_throgh).get_output_layout().size.raw[node.iteration_axis];
+    }
+
+    //TODO: check inputs
+    node.build_body_program();
+    auto outputs = node.get_body_program()->get_outputs();
+    for (auto output : outputs) {
+        layout l = output->get_output_layout();
+        output->set_output_layout(l);
+    }
+    
+    assert(node.ports_desc.output_ports.size() == 1);
+    primitive_id main_output_id = node.ports_desc.output_ports[0];
+    if (node.is_output_working_as_backedge())
+        main_output_id += node.backedge_suffix;
+
+    // finds internal output
+    auto target = std::find_if(outputs.begin(), outputs.end(), [&](const auto output) {
+        return output->id() == main_output_id;
+    });
+
+    if (target == outputs.end())
+        CLDNN_ERROR_MESSAGE(node.id(), "output not found");
+
+    layout ti_output_layout = (*target)->get_output_layout();
+    if (port_to_iterate_throgh != -1)
+         ti_output_layout.size.raw[node.iteration_axis] = node.iterations;
+    return ti_output_layout;
+}
+
+std::string tensor_iterator_inst::to_string(tensor_iterator_node const & node) {
+    auto desc = node.get_primitive();
+    auto node_info = node.desc_to_json();
+
+    json_composite ti_info;
+    ti_info.add("body", desc->body.get_primitive_ids());
+
+    std::stringstream primitive_description;
+    node_info->add("tensor iterator pooling info", ti_info);
+    node_info->dump(primitive_description);
+    return primitive_description.str();
+    
+}
+tensor_iterator_inst::typed_primitive_inst(network_impl & network, tensor_iterator_node const & node)
+    : parent(network, node),
+      body_network(node.get_program().get_engine().allocate_network(
+                                                     *node.get_body_program(),
+                                                     network.get_stream_id(),
+                                                     true)) {
+    if (!check_if_axis_is_set_properly(node))
+        CLDNN_ERROR_MESSAGE(node.id(), "axis is not set properly");
+}
+}


### PR DESCRIPTION
Initial implantation of a dynamic tensor iterator for gpu. 

Supports only TI nodes with one (external) output and stride = 1. 

An appropriate mechanism for choosing whether use static unrolling or use this dynamic TI implementation, has to be implemented.