### PR TITLE
Handle scalar inputs for MYRIAD plugin

### DIFF
--- a/inference-engine/src/plugin_api/cpp_interfaces/impl/ie_infer_request_internal.hpp
+++ b/inference-engine/src/plugin_api/cpp_interfaces/impl/ie_infer_request_internal.hpp
@@ -109,7 +109,9 @@ public:
             if (preProcRequired) {
                 addInputPreProcessingFor(name, userBlob, devBlob ? devBlob : _inputs[name]);
             } else {
-                size_t inputSize = details::product(foundInput->getTensorDesc().getDims());
+                size_t inputSize = foundInput->getTensorDesc().getLayout() != InferenceEngine::Layout::SCALAR
+                ? InferenceEngine::details::product(foundInput->getTensorDesc().getDims())
+                : 1;
                 if (dataSize != inputSize) {
                     THROW_IE_EXCEPTION << "Input blob size is not equal network input size (" << dataSize
                                        << "!=" << inputSize << ").";


### PR DESCRIPTION
This change fixes the error
```
Input blob size is not equal network input size (1!=0)
```
seen when passing a scalar input to a model in the case of VPU plugins. While not strictly specific to the MYRIAD plugin, the input size is adjusted to be 1 in case of scalar inputs in much the same way as the CPU and GPU plugins do.