### PR TITLE
Base cancelation implementation

### DIFF
--- a/inference-engine/include/cpp/ie_infer_request.hpp
+++ b/inference-engine/include/cpp/ie_infer_request.hpp
@@ -241,7 +241,7 @@ public:
         auto res = actual->Wait(millis_timeout, &resp);
         if (res != OK && res != RESULT_NOT_READY &&
             res != INFER_NOT_STARTED && res != INFER_CANCELLED) {
-            InferenceEngine::details::extract_exception(res, resp.msg);
+            THROW_IE_EXCEPTION << InferenceEngine::details::as_status << res << resp.msg;
         }
         return res;
     }

--- a/inference-engine/src/mkldnn_plugin/mkldnn_async_infer_request.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_async_infer_request.cpp
@@ -8,7 +8,9 @@
 MKLDNNPlugin::MKLDNNAsyncInferRequest::MKLDNNAsyncInferRequest(const InferenceEngine::InferRequestInternal::Ptr& inferRequest,
                                                                const InferenceEngine::ITaskExecutor::Ptr& taskExecutor,
                                                                const InferenceEngine::ITaskExecutor::Ptr& callbackExecutor)
-        : InferenceEngine::AsyncInferRequestThreadSafeDefault(inferRequest, taskExecutor, callbackExecutor) {}
+        : InferenceEngine::AsyncInferRequestThreadSafeDefault(inferRequest, taskExecutor, callbackExecutor) {
+    static_cast<MKLDNNInferRequest*>(inferRequest.get())->SetAsyncRequest(this);
+}
 
 void MKLDNNPlugin::MKLDNNAsyncInferRequest::Infer_ThreadUnsafe() {
     InferUsingAsync();

--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph.cpp
@@ -20,6 +20,7 @@
 #include "mkldnn_extension_mngr.h"
 #include "mkldnn_memory_solver.hpp"
 #include "mkldnn_itt.h"
+#include "mkldnn_infer_request.h"
 #include <nodes/mkldnn_input_node.h>
 #include <nodes/mkldnn_reorder_node.h>
 
@@ -755,7 +756,7 @@ void MKLDNNGraph::PullOutputData(BlobMap &out) {
     }
 }
 
-void MKLDNNGraph::Infer(int batch) {
+void MKLDNNGraph::Infer(MKLDNNInferRequest* request, int batch) {
     if (!IsReady()) {
         THROW_IE_EXCEPTION << "Wrong state. Topology is not ready.";
     }
@@ -763,9 +764,8 @@ void MKLDNNGraph::Infer(int batch) {
     mkldnn::stream stream(eng);
 
     for (int i = 0; i < graphNodes.size(); i++) {
-        if (IsCancellationRequested()) {
-            ResetCancellationRequest();
-            THROW_IE_EXCEPTION << InferenceEngine::details::as_status << InferenceEngine::INFER_CANCELLED;
+        if (request != nullptr) {
+            request->ThrowIfCanceled();
         }
 
         PERF(graphNodes[i]);

--- a/inference-engine/src/mkldnn_plugin/mkldnn_infer_request.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_infer_request.h
@@ -13,6 +13,7 @@
 namespace MKLDNNPlugin {
 
 class MKLDNNExecNetwork;
+class MKLDNNAsyncInferRequest;
 
 class MKLDNNInferRequest : public InferenceEngine::InferRequestInternal {
 public:
@@ -25,8 +26,6 @@ public:
 
     void InferImpl() override;
 
-    InferenceEngine::StatusCode Cancel() override;
-
     std::map<std::string, InferenceEngine::InferenceEngineProfileInfo> GetPerformanceCounts() const override;
 
     void SetBlob(const std::string& name, const InferenceEngine::Blob::Ptr &data) override;
@@ -36,6 +35,17 @@ public:
     void SetBatch(int batch = -1) override;
 
     std::vector<InferenceEngine::IVariableStateInternal::Ptr> QueryState() override;
+
+    /**
+     * @brief      Sets the pointer to asynchronous inference request that holds this request
+     * @param[in]  asyncRequest Pointer to asynchronous inference request
+     */
+    void SetAsyncRequest(MKLDNNAsyncInferRequest* asyncRequest);
+
+    /**
+     * @brief If `_asyncRequest` is initialized throw exception with `InferenceEngine::INFER_CANCELLED` status if inference request is canceled
+     */
+    void ThrowIfCanceled() const;
 
 private:
     void PushInputData();
@@ -50,5 +60,6 @@ private:
     std::map<std::string, void*>        externalPtr;
     openvino::itt::handle_t             profilingTask;
     std::vector<InferenceEngine::IVariableStateInternal::Ptr> memoryStates;
+    MKLDNNAsyncInferRequest*            _asyncRequest = nullptr;
 };
 }  // namespace MKLDNNPlugin

--- a/inference-engine/src/multi_device/multi_device_async_infer_request.cpp
+++ b/inference-engine/src/multi_device/multi_device_async_infer_request.cpp
@@ -87,8 +87,8 @@ void MultiDeviceAsyncInferRequest::Infer_ThreadUnsafe() {
 }
 
 std::map<std::string, InferenceEngineProfileInfo> MultiDeviceAsyncInferRequest::GetPerformanceCounts() const {
-    CheckBusy();
-    return _perfMap;
+    CheckState();
+    return std::move(_perfMap);
 }
 
 MultiDeviceAsyncInferRequest::~MultiDeviceAsyncInferRequest() {

--- a/inference-engine/src/plugin_api/cpp_interfaces/exception2status.hpp
+++ b/inference-engine/src/plugin_api/cpp_interfaces/exception2status.hpp
@@ -142,6 +142,12 @@ namespace InferenceEngine {
 #define NOT_ALLOCATED_str std::string("[NOT_ALLOCATED] ")
 
 /**
+ * @def INFER_CANCELLED_str
+ * @brief Defines the `infer cancelled` message
+ */
+#define INFER_CANCELLED_str std::string("[INFER_CANCELLED] ")
+
+/**
  * @}
  */
 

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
@@ -59,10 +59,8 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*Broadcast.*mode=BIDIRECTIONAL.*inNPrec=BOOL.*)",
         // TODO: Issue 43417 sporadic issue, looks like an issue in test, reproducible only on Windows platform
         R"(.*decomposition1_batch=5_hidden_size=10_input_size=30_.*tanh.relu.*_clip=0_linear_before_reset=1.*_targetDevice=CPU_.*)",
-        // TODO: Sporadic Issue: 45163
-        R"(.*Behavior.*CancellationTests.*canResetAfterCancelAsyncRequest.*)",
         // TODO: Issue 47556. [NGraph] CTCGreedyDecoderSeqLen. Invalid type transformation i64 to i32.
-        R"(.*(CTCGreedyDecoderSeqLenLayerTest).*(idxPRC=I64).*)"
+        R"(.*(CTCGreedyDecoderSeqLenLayerTest).*(idxPRC=I64).*)",
     };
 
     if (!InferenceEngine::with_cpu_x86_avx512_core()) {

--- a/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/cpp_interfaces/impl/mock_async_infer_request_default.hpp
+++ b/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/cpp_interfaces/impl/mock_async_infer_request_default.hpp
@@ -23,5 +23,5 @@ public:
                                  const ITaskExecutor::Ptr &callbackExecutor)
             : AsyncInferRequestThreadSafeDefault(request, taskExecutor, callbackExecutor) {}
 
-    MOCK_METHOD0(StartAsync_ThreadUnsafe, void());
+    MOCK_METHOD0(CheckBlob, void());
 };

--- a/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/cpp_interfaces/impl/mock_infer_request_internal.hpp
+++ b/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/cpp_interfaces/impl/mock_infer_request_internal.hpp
@@ -22,5 +22,6 @@ public:
     using InferRequestInternal::GetBlob;
     MOCK_METHOD0(InferImpl, void());
     MOCK_CONST_METHOD0(GetPerformanceCounts, std::map<std::string, InferenceEngineProfileInfo>());
+    MOCK_METHOD0(checkBlobs, void());
     MOCK_METHOD0(Cancel, InferenceEngine::StatusCode());
 };

--- a/inference-engine/tests/unit/inference_engine/cpp_interfaces/ie_executable_network_base_test.cpp
+++ b/inference-engine/tests/unit/inference_engine/cpp_interfaces/ie_executable_network_base_test.cpp
@@ -128,7 +128,7 @@ TEST_F(ExecutableNetworkThreadSafeTests, returnErrorIfInferThrowsException) {
     IInferRequest::Ptr req;
     EXPECT_CALL(*mockExeNetwork.get(), CreateInferRequestImpl(_, _)).WillOnce(Return(mockInferRequestInternal));
     EXPECT_NO_THROW(exeNetwork->CreateInferRequest(req, &dsc));
-    EXPECT_CALL(*mockInferRequestInternal.get(), InferImpl()).WillOnce(Throw(std::runtime_error("")));
+    EXPECT_CALL(*mockInferRequestInternal.get(), checkBlobs()).WillOnce(Throw(std::runtime_error("")));
     EXPECT_NO_THROW(sts = req->Infer(&dsc));
     ASSERT_EQ(StatusCode::GENERAL_ERROR, sts) << dsc.msg;
 }

--- a/inference-engine/tests_deprecated/unit/engines/mkldnn/graph/test_graph.hpp
+++ b/inference-engine/tests_deprecated/unit/engines/mkldnn/graph/test_graph.hpp
@@ -210,7 +210,7 @@ public:
 
                 PushInputData(input.first, input.second, batch);
             }
-            MKLDNNPlugin::MKLDNNGraph::Infer(batch);
+            MKLDNNPlugin::MKLDNNGraph::Infer(nullptr, batch);
         } catch (const std::exception &e) {
             FAIL() << e.what();
         }


### PR DESCRIPTION
* Cancelation state is now part of base synchronization implementation
* Added new API for plugin developer. It is used to throw exception if inference request is canceled:
```c++
AsyncInferRequestThreadSafeInternal::CheckCanceled();
```
* Added usage example into MKLDNN Plugin
 