### PR TITLE
[LPT] Handle empty dequantization in MultiplyToGroupConvolution

### DIFF
--- a/inference-engine/src/low_precision_transformations/src/multiply_to_group_convolution.cpp
+++ b/inference-engine/src/low_precision_transformations/src/multiply_to_group_convolution.cpp
@@ -123,6 +123,12 @@ bool MultiplyToGroupConvolutionTransformation::canBeTransformed(const Transforma
         return false;
     }
 
+    const auto dequantization = NetworkHelper::getDequantization(operation, inputIndex);
+
+    if (dequantization.empty()) {
+        return false;
+    }
+
     const Shape outShape = operation->get_output_shape(0);
     if (outShape[1] % groupSize != 0) {
         return false;
@@ -135,14 +141,11 @@ bool MultiplyToGroupConvolutionTransformation::canBeTransformed(const Transforma
     }
 
     if (updatePrecisions) {
-        auto dequantization = NetworkHelper::getDequantization(operation, inputIndex);
         const element::Type parentPrecision = dequantization.data.get_element_type();
         if (std::find(precisionsOnActivations.begin(), precisionsOnActivations.end(), parentPrecision) == precisionsOnActivations.end()) {
             return false;
         }
     }
-
-
 
     return true;
 }

--- a/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/multiply_to_group_convolution_function.hpp
+++ b/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/multiply_to_group_convolution_function.hpp
@@ -20,7 +20,8 @@ public:
     static std::shared_ptr<ngraph::Function> getOriginal(
         const ngraph::Shape& inputShape,
         const ngraph::element::Type& precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization);
+        const ngraph::builder::subgraph::DequantizationOperations& dequantization,
+        const bool haveMultiplyWithNoConstBeforeDequantization);
 
     static std::shared_ptr<ngraph::Function> getOriginal(
         const ngraph::element::Type precision,


### PR DESCRIPTION
validation:
* accuracy: developer-services/job/accuracy/1041/
* performance: developer-services/job/performance/544/

issue: #44943