### PR TITLE
V10Parser node factory improvements

### DIFF
--- a/inference-engine/src/readers/ir_reader/ie_ir_parser.cpp
+++ b/inference-engine/src/readers/ir_reader/ie_ir_parser.cpp
@@ -689,6 +689,10 @@ std::shared_ptr<ngraph::Node> V10Parser::XmlDeserializer::createNode(
             // MVN and ROIPooling were missing in opset1
             if (type == "MVN" || type == "ROIPooling") {
                 opsetIt = opsets.find("opset2");
+                if (opsetIt == opsets.end()) {
+                    THROW_IE_EXCEPTION << "Cannot create " << params.type << " layer " << params.name << " id:" << params.layerId
+                        << " from unsupported opset: " << params.version;
+                }
             }
         }
 

--- a/inference-engine/src/readers/ir_reader/ie_ir_parser.cpp
+++ b/inference-engine/src/readers/ir_reader/ie_ir_parser.cpp
@@ -642,12 +642,12 @@ std::shared_ptr<ngraph::Node> V10Parser::XmlDeserializer::createNode(
 
     // Check that operation in default opsets
     auto isDefaultOpSet = [](const std::string& version) -> bool {
-        for (size_t i = 1; i <= 6; i++) {
-            std::string opset_name = "opset" + std::to_string(i);
-            if (version == opset_name)
-                return true;
-        }
-        return false;
+        static char const * prefix = "opset";
+        static size_t const prefixLen = strlen(prefix);
+        return version.length() == prefixLen + 1
+                && version.compare(0, prefixLen, prefix) == 0
+                && version[prefixLen] >= '1'
+                && version[prefixLen] <= '6';
     };
 
     for (size_t i = 0; i < inputs.size(); i++) {

--- a/inference-engine/src/readers/ir_reader/ie_ir_parser.hpp
+++ b/inference-engine/src/readers/ir_reader/ie_ir_parser.hpp
@@ -181,7 +181,7 @@ private:
     class XmlDeserializer : public ngraph::AttributeVisitor {
     public:
         explicit XmlDeserializer(const pugi::xml_node& node, const Blob::CPtr& weights,
-        const std::map<std::string, ngraph::OpSet>& opsets) : node(node), weights(weights), opsets(opsets) {}
+        const std::unordered_map<std::string, ngraph::OpSet>& opsets) : node(node), weights(weights), opsets(opsets) {}
         void on_adapter(const std::string& name, ngraph::ValueAccessor<std::string>& value) override {
             std::string val;
             if (!getStrAttribute(node.child("data"), name, val)) return;
@@ -286,7 +286,7 @@ private:
     private:
         const pugi::xml_node node;
         const Blob::CPtr& weights;
-        const std::map<std::string, ngraph::OpSet>& opsets;
+        const std::unordered_map<std::string, ngraph::OpSet>& opsets;
         /// \brief Traverses port_map in order to create vector of InputDescription shared_ptrs.
         /// Shall be used only for ops which have port_map attribute.
         /// \param node xml op representation

--- a/inference-engine/src/readers/ir_reader/ie_ir_parser.hpp
+++ b/inference-engine/src/readers/ir_reader/ie_ir_parser.hpp
@@ -7,6 +7,7 @@
 #ifdef IR_READER_V10
 # include <ngraph/node.hpp>
 # include <ngraph/op/util/sub_graph_base.hpp>
+# include <ngraph/opsets/opset.hpp>
 # include <ie_ngraph_utils.hpp>
 # include <ngraph/opsets/opset.hpp>
 #endif  // IR_READER_V10
@@ -19,6 +20,7 @@
 #include <cctype>
 #include <algorithm>
 #include <map>
+#include <unordered_map>
 #include <memory>
 #include <set>
 #include <sstream>
@@ -58,7 +60,7 @@ public:
     std::shared_ptr<ICNNNetwork> parse(const pugi::xml_node& root, const Blob::CPtr& weights) override;
 
 private:
-    std::map<std::string, ngraph::OpSet> opsets;
+    std::unordered_map<std::string, ngraph::OpSet> opsets;
     const std::vector<IExtensionPtr> _exts;
 
     struct GenericLayerParams {

--- a/inference-engine/src/readers/ir_reader/ie_ir_parser.hpp
+++ b/inference-engine/src/readers/ir_reader/ie_ir_parser.hpp
@@ -77,7 +77,7 @@ private:
         std::vector<LayerPortData> inputPorts;
         std::vector<LayerPortData> outputPorts;
 
-        size_t getRealInputPortId(size_t id) {
+        size_t getRealInputPortId(size_t id) const {
             size_t real_id = 0;
             for (auto& it : inputPorts) {
                 if (it.portId == id) {
@@ -88,7 +88,7 @@ private:
             THROW_IE_EXCEPTION << "Can not find input port with id " << id << " in layer " << name;
         }
 
-        size_t getRealOutputPortId(size_t id) {
+        size_t getRealOutputPortId(size_t id) const {
             size_t real_id = 0;
             for (auto& it : outputPorts) {
                 if (it.portId == id) {


### PR DESCRIPTION
After the analysis some issues were found in V10Parser::createNode function:
1. Opset is cloned when nGraph node is created
2. Default opsets operation checking complexity can be reduced from O(N) to O(1)
3. Supported opsets checking also slightly can be optimized by replacing versions strings comparison inside loop by single condition.