### PR TITLE
[IE][nGraph][VPU]: Enables DTS for Loop

### DIFF
--- a/inference-engine/src/vpu/common/include/vpu/ngraph/operations/static_shape_loop.hpp
+++ b/inference-engine/src/vpu/common/include/vpu/ngraph/operations/static_shape_loop.hpp
@@ -1,0 +1,21 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <ngraph/opsets/opset6.hpp>
+
+namespace ngraph { namespace vpu { namespace op {
+
+class StaticShapeLoop : public ngraph::opset6::Loop {
+public:
+    NGRAPH_RTTI_DECLARATION;
+
+    explicit StaticShapeLoop(const Loop& loop);
+    void validate_and_infer_types() override;
+};
+
+}  // namespace op
+}  // namespace vpu
+}  // namespace ngraph

--- a/inference-engine/src/vpu/common/include/vpu/ngraph/transformations/dynamic_to_static_shape_loop.hpp
+++ b/inference-engine/src/vpu/common/include/vpu/ngraph/transformations/dynamic_to_static_shape_loop.hpp
@@ -1,0 +1,16 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "ngraph/node.hpp"
+
+#include <memory>
+
+namespace vpu {
+
+void validateLoop(const ngraph::Node& node);
+void dynamicToStaticShapeLoop(std::shared_ptr<ngraph::Node> node);
+
+}  // namespace vpu

--- a/inference-engine/src/vpu/common/include/vpu/ngraph/transformations/dynamic_to_static_shape_split.hpp
+++ b/inference-engine/src/vpu/common/include/vpu/ngraph/transformations/dynamic_to_static_shape_split.hpp
@@ -8,6 +8,7 @@
 
 namespace vpu {
 
+void validateSplit(const ngraph::Node& node);
 void dynamicToStaticShapeSplit(std::shared_ptr<ngraph::Node> target);
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/common/src/ngraph/operations/static_shape_loop.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/operations/static_shape_loop.cpp
@@ -1,0 +1,49 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <ngraph/validation_util.hpp>
+#include "vpu/ngraph/operations/static_shape_loop.hpp"
+
+namespace ngraph { namespace vpu { namespace op {
+
+NGRAPH_RTTI_DEFINITION(ngraph::vpu::op::StaticShapeLoop, "StaticShapeLoop", 0);
+
+StaticShapeLoop::StaticShapeLoop(const Loop& loop) : Loop(loop) {}
+
+void StaticShapeLoop::validate_and_infer_types() {
+    const auto isLoopStatic = [this]() {
+        const auto& outs = outputs();
+        return !outs.empty() && std::all_of(outs.cbegin(), outs.cend(), [](const Output<Node>& output) { return output.get_partial_shape().is_static(); });
+    };
+
+    if (isLoopStatic()) {
+        return;
+    }
+
+    Loop::validate_and_infer_types();
+
+    const auto maxIterationsCountEstimation = ngraph::maximum_value(input_value(0).get_node_shared_ptr());
+    NODE_VALIDATION_CHECK(this, maxIterationsCountEstimation.first,
+        "Encountered a loop for which upper-bound estimation for iterations count ", input_value(0), " failed");
+    const auto& maxIterationsCount = maxIterationsCountEstimation.second;
+    NODE_VALIDATION_CHECK(this, maxIterationsCount > 0, "Encountered a loop with non-positive upper-bound estimation for iterations count ",
+        maxIterationsCountEstimation.second);
+
+    const auto& body = get_function();
+    for (const auto& outputDescription : get_output_descriptions()) {
+        if (const auto& concatOutputDescription = ngraph::as_type_ptr<ngraph::op::util::SubGraphOp::ConcatOutputDescription>(outputDescription)) {
+            const auto& bodyOutput = body->output(concatOutputDescription->m_body_value_index);
+            const auto& axis = concatOutputDescription->m_axis;
+            auto partialShape = bodyOutput.get_partial_shape();
+            partialShape[axis] *= maxIterationsCount;
+
+            const auto& concatOutput = output(concatOutputDescription->m_output_index);
+            set_output_type(concatOutputDescription->m_output_index, concatOutput.get_element_type(), partialShape);
+        }
+    }
+}
+
+}  // namespace op
+}  // namespace vpu
+}  // namespace ngraph

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape.cpp
@@ -24,6 +24,7 @@
 #include "vpu/ngraph/transformations/dynamic_to_static_shape_unary_elementwise.hpp"
 #include "vpu/ngraph/transformations/dynamic_to_static_shape_unsqueeze.hpp"
 #include "vpu/ngraph/transformations/dynamic_to_static_shape_variadic_split.hpp"
+#include "vpu/ngraph/transformations/dynamic_to_static_shape_loop.hpp"
 
 #include "vpu/ngraph/utilities.hpp"
 #include "vpu/utils/error.hpp"
@@ -77,6 +78,7 @@ const Validators& getValidators() {
     static const Validators validators = {
         {ngraph::opset5::Split::type_info,         validateSplit},
         {ngraph::opset5::VariadicSplit::type_info, validateSplit},
+        {ngraph::opset6::Loop::type_info,          validateLoop},
     };
     return validators;
 }
@@ -144,6 +146,8 @@ const Transformations& getDefaultTransformations() {
         {ngraph::opset3::ReduceMin::type_info,        dynamicToStaticShapeReduce},
         {ngraph::opset3::ReduceProd::type_info,       dynamicToStaticShapeReduce},
         {ngraph::opset3::ReduceSum::type_info,        dynamicToStaticShapeReduce},
+
+        {ngraph::opset6::Loop::type_info, dynamicToStaticShapeLoop},
     };
     return transformations;
 }

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_loop.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape_loop.cpp
@@ -1,0 +1,112 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "ngraph/opsets/opset6.hpp"
+#include "vpu/ngraph/transformations/dynamic_to_static_shape_loop.hpp"
+#include <vpu/utils/error.hpp>
+#include <vpu/ngraph/operations/dynamic_shape_resolver.hpp>
+#include <ngraph/ngraph.hpp>
+#include <vpu/ngraph/operations/static_shape_loop.hpp>
+
+template<class DataObject>
+bool hasDynamic(const std::vector<DataObject>& dataObjects) {
+    return std::any_of(dataObjects.cbegin(), dataObjects.cend(), [](const DataObject& data) { return data.get_partial_shape().is_dynamic(); });
+}
+
+namespace vpu {
+
+void validateLoop(const ngraph::Node& node) {
+    const auto& loop = dynamic_cast<const ngraph::opset6::Loop&>(node);
+    VPU_THROW_UNLESS(loop.get_input_size() >= 3, "Encountered operation {} with {} inputs, expected at least {} inputs", loop, loop.get_input_size(), 3);
+
+    const auto& executionCondition = ngraph::as_type_ptr<ngraph::opset6::Constant>(loop.input_value(1).get_node_shared_ptr());
+    VPU_THROW_UNLESS(executionCondition != nullptr, "Execution condition of a loop {} is expected to be constant true, got {}", loop, executionCondition);
+    const auto& executionConditionValue = executionCondition->get_vector<bool>();
+    VPU_THROW_UNLESS(executionConditionValue == std::vector<bool>{true},
+        "Execution condition of a loop {} is expected to be constant true, got {}", loop, executionCondition);
+
+    for (const auto& inputDescription : loop.get_input_descriptions()) {
+        if (const auto& sliceInputDescription = ngraph::as_type_ptr<ngraph::op::util::SubGraphOp::SliceInputDescription>(inputDescription)) {
+            const auto& sliceInput = loop.input_value(sliceInputDescription->m_input_index);
+            const auto& partialShape = sliceInput.get_partial_shape();
+
+            VPU_THROW_UNLESS(partialShape.rank().is_static(), "Slice input {} of a loop {} is expected to have static rank, got dynamic", sliceInput, loop);
+            const auto& rank = partialShape.rank().get_length();
+            for (std::size_t dimension = 1; dimension < rank; ++dimension) {
+                VPU_THROW_UNLESS(partialShape[dimension].is_static(),
+                    "Slice input {} of a loop {} is expected to have only batch as dynamic dimension, got {}", sliceInput, loop, partialShape);
+            }
+        } else if (const auto& invariantInputDescription = ngraph::as_type_ptr<ngraph::op::util::SubGraphOp::InvariantInputDescription>(inputDescription)) {
+            const auto& invariantInput = loop.input_value(invariantInputDescription->m_input_index);
+            const auto& partialShape = invariantInput.get_partial_shape();
+            VPU_THROW_UNLESS(partialShape.is_static(),
+                "Invariant input {} of a loop {} is expected to have static shape, got {}", invariantInput, loop, partialShape);
+        } else {
+            VPU_THROW_FORMAT("Encountered unknown input type of a loop {} at index {}", loop, inputDescription->m_input_index);
+        }
+    }
+
+    const auto& body = loop.get_function();
+    for (const auto& operation : body->get_ordered_ops()) {
+        VPU_THROW_UNLESS(!hasDynamic(operation->inputs()) && !hasDynamic(operation->outputs()),
+            "Encountered a loop {} with dynamic operation {} in the body, but only static body loops are supported", loop, operation);
+    }
+
+    for (const auto& outputDescription : loop.get_output_descriptions()) {
+        if (const auto& concatOutputDescription = ngraph::as_type_ptr<ngraph::op::util::SubGraphOp::ConcatOutputDescription>(outputDescription)) {
+            const auto& concatOutput = loop.output(concatOutputDescription->m_output_index);
+            const auto& partialShape = concatOutput.get_partial_shape();
+
+            VPU_THROW_UNLESS(partialShape.rank().is_static(), "Concat output {} of a loop {} is expected to have static rank, got dynamic", concatOutput, loop);
+            const auto& rank = partialShape.rank().get_length();
+            for (std::size_t dimension = 1; dimension < rank; ++dimension) {
+                VPU_THROW_UNLESS(partialShape[dimension].is_static(),
+                                 "Concat output {} of a loop {} is expected to have only batch as dynamic dimension, got {}", concatOutput, loop, partialShape);
+            }
+        } else if (const auto& bodyOutputDescription = ngraph::as_type_ptr<ngraph::op::util::SubGraphOp::BodyOutputDescription>(outputDescription)) {
+            const auto& bodyOutput = loop.output(bodyOutputDescription->m_output_index);
+            const auto& partialShape = bodyOutput.get_partial_shape();
+            VPU_THROW_UNLESS(partialShape.is_static(),
+                             "Body output {} of a loop {} is expected to have static shape, got {}", bodyOutput, loop, partialShape);
+        } else {
+            VPU_THROW_FORMAT("Encountered unknown output type of a loop {} at index {}", loop, outputDescription->m_output_index);
+        }
+    }
+}
+
+void dynamicToStaticShapeLoop(std::shared_ptr<ngraph::Node> node) {
+    const auto& loop = ngraph::as_type_ptr<ngraph::opset6::Loop>(node);
+    VPU_THROW_UNLESS(loop != nullptr, "Encountered node {}, but expected loop", node);
+
+    const auto copied = ngraph::as_type_ptr<ngraph::opset6::Loop>(loop->clone_with_new_inputs(loop->input_values()));
+    const auto& staticShapeLoop = std::make_shared<ngraph::vpu::op::StaticShapeLoop>(*copied);
+    staticShapeLoop->validate_and_infer_types();
+    const auto& iterationsCount = staticShapeLoop->input_value(0);
+    const auto& body = staticShapeLoop->get_function();
+    for (const auto& outputDescription : loop->get_output_descriptions()) {
+        const auto& index = outputDescription->m_output_index;
+        auto replacement = staticShapeLoop->output(index).get_node_shared_ptr();
+        if (const auto& concatOutputDescription = ngraph::as_type_ptr<ngraph::op::util::SubGraphOp::ConcatOutputDescription>(outputDescription)) {
+            const auto& bodyOutput = body->get_results().at(concatOutputDescription->m_body_value_index)->input_value(0);
+
+            VPU_THROW_UNLESS(bodyOutput.get_partial_shape().is_static(),
+                             "Encountered loop {} with dynamic body output {}, but only static body is supported", loop, bodyOutput);
+            auto shape = bodyOutput.get_shape();
+            const auto& axis = concatOutputDescription->m_axis;
+
+            const auto outputShape = std::make_shared<ngraph::opset6::ScatterElementsUpdate>(
+                std::make_shared<ngraph::opset6::Constant>(ngraph::element::i64, ngraph::Shape{shape.size()}, shape),
+                std::make_shared<ngraph::opset6::Constant>(ngraph::element::i64, ngraph::Shape{1}, axis),
+                iterationsCount,
+                std::make_shared<ngraph::opset6::Constant>(ngraph::element::i64, ngraph::Shape{}, 0));
+
+            replacement = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(replacement, outputShape);
+        }
+
+        replacement->set_friendly_name(loop->get_friendly_name() + "." + std::to_string(index));
+        loop->output(index).replace(replacement);
+    }
+}
+
+}  // namespace vpu

--- a/ngraph/core/include/ngraph/op/loop.hpp
+++ b/ngraph/core/include/ngraph/op/loop.hpp
@@ -86,7 +86,12 @@ namespace ngraph
                 bool evaluate(const HostTensorVector& outputs,
                               const HostTensorVector& inputs) const override;
 
+            protected:
+                Loop(const Loop&);
+
             private:
+                void clone_to(Loop& dst, const OutputVector& new_args) const;
+
                 SpecialBodyPorts m_special_body_ports;
                 int64_t m_num_iterations = -1; // -1 means infinity
             };

--- a/ngraph/core/include/ngraph/op/util/sub_graph_base.hpp
+++ b/ngraph/core/include/ngraph/op/util/sub_graph_base.hpp
@@ -320,6 +320,12 @@ namespace ngraph
                                                              int64_t end,
                                                              int64_t axis);
 
+                SubGraphOp(const SubGraphOp&) = delete;
+                SubGraphOp(SubGraphOp&&) = default;
+
+                SubGraphOp& operator=(const SubGraphOp&) = delete;
+                SubGraphOp& operator=(SubGraphOp&&) = default;
+
             protected:
                 // Find an input corresponding to value, adding one if necessary.
                 Input<Node> input_for_value(const Output<Node>& value);

--- a/ngraph/core/include/ngraph/op/util/sub_graph_base.hpp
+++ b/ngraph/core/include/ngraph/op/util/sub_graph_base.hpp
@@ -218,6 +218,7 @@ namespace ngraph
                 };
 
                 virtual std::shared_ptr<Function> get_function() { return m_body; };
+                virtual std::shared_ptr<const Function> get_function() const { return m_body; };
                 virtual void set_function(const std::shared_ptr<Function>& func) { m_body = func; };
                 /// \return a reference to the input descriptions.
                 const std::vector<std::shared_ptr<InputDescription>>& get_input_descriptions() const

--- a/ngraph/core/src/op/loop.cpp
+++ b/ngraph/core/src/op/loop.cpp
@@ -237,9 +237,6 @@ void op::v5::Loop::validate_and_infer_types()
 
             auto body_param_partial_shape = body_parameter->get_partial_shape();
             auto input_partial_shape = input(index).get_partial_shape();
-            NODE_VALIDATION_CHECK(this,
-                                  input_partial_shape.compatible(body_param_partial_shape),
-                                  "Iterator initial value is not compatible with body param");
 
             body_parameter->set_partial_shape(input_partial_shape);
         }
@@ -317,95 +314,16 @@ void op::v5::Loop::validate_and_infer_types()
 
 std::shared_ptr<Node> op::v5::Loop::clone_with_new_inputs(const OutputVector& new_args) const
 {
-    NGRAPH_OP_SCOPE(v5_Loop_clone_with_new_inputs);
-    // WA: input description with index 0 or 1 means that Loop consructor will duplicate it in
-    // the inputs.
-    // When using visit_attributes() no duplication occurs, input_offset shall be decremented.
-    size_t input_offset = 2;
-    for (const auto& in_desc : m_input_descriptions)
-    {
-        if (in_desc->m_input_index == 0 || in_desc->m_input_index == 1)
-        {
-            input_offset--;
-        }
-    }
-    // input_offset < 0 means that there are several duplications of external_port_id
-    // (the same ext_port_id is connected to several Parameters in the port map) in input_desc,
-    // this can lead to wrong or undefined behavior, so throw exception here. Ticket: 47302
-    NODE_VALIDATION_CHECK(this, input_offset >= 0, "External port id 0 or 1 is duplicated.");
-    // 0 - trip_count, 1 - execution condition, these inputs are not connected to the body
-    // params
-    OutputVector body_params_args(new_args.begin() + input_offset, new_args.end());
-    auto op = make_shared<op::v5::Loop>(new_args[0], new_args[1]);
-    for (int idx = 2; idx < new_args.size(); ++idx)
-    {
-        op->set_argument(idx, new_args[idx]);
-    }
+    NGRAPH_OP_SCOPE(v5_Loop_clone_with_new_inputs)
+    check_new_args_count(this, new_args);
+    auto op = make_shared<op::v5::Loop>();
     NGRAPH_CHECK(op.get(),
                  op != nullptr,
                  "Cannot clone ",
                  description(),
                  " operation with name ",
                  get_friendly_name());
-    op->set_output_size(m_output_descriptions.size());
-
-    std::vector<::ngraph::element::Type> types(m_body->get_parameters().size());
-    std::vector<::ngraph::PartialShape> new_shapes(m_body->get_parameters().size());
-
-    for (size_t input_index = 0; input_index < new_args.size(); ++input_index)
-    {
-        for (auto& input_description : m_input_descriptions)
-        {
-            if (input_description->m_input_index == input_index)
-            {
-                types[input_description->m_body_parameter_index] =
-                    new_args[input_index].get_element_type();
-                new_shapes[input_description->m_body_parameter_index] =
-                    new_args[input_index].get_partial_shape();
-
-                if (new_shapes[input_description->m_body_parameter_index].is_static())
-                {
-                    if (auto slice_in = ::ngraph::as_type_ptr<
-                            ngraph::op::v0::TensorIterator::SliceInputDescription>(
-                            input_description))
-                    {
-                        new_shapes[slice_in->m_body_parameter_index][slice_in->m_axis] =
-                            slice_in->m_part_size;
-                    }
-                }
-            }
-        }
-    }
-
-    if (m_special_body_ports.current_iteration_input_idx >= 0)
-    {
-        const auto& cur_iterations_param =
-            m_body->get_parameters().at(m_special_body_ports.current_iteration_input_idx);
-        body_params_args.insert(body_params_args.begin() +
-                                    m_special_body_ports.current_iteration_input_idx,
-                                cur_iterations_param);
-        new_shapes.at(m_special_body_ports.current_iteration_input_idx) =
-            cur_iterations_param->get_partial_shape();
-        types.at(m_special_body_ports.current_iteration_input_idx) =
-            cur_iterations_param->get_element_type();
-    }
-    op->m_num_iterations = m_num_iterations;
-    op->m_special_body_ports = m_special_body_ports;
-    auto func = std::make_shared<Function>(
-        m_body->get_results(), m_body->get_sinks(), m_body->get_parameters());
-    auto spec_func = specialize_function(
-        func, types, new_shapes, std::vector<void*>(body_params_args.size(), nullptr));
-    op->m_body = std::make_shared<Function>(
-        spec_func->get_results(), spec_func->get_sinks(), spec_func->get_parameters());
-
-    for (auto& input_description : m_input_descriptions)
-    {
-        op->m_input_descriptions.push_back(input_description->copy());
-    }
-    for (auto& output_description : m_output_descriptions)
-    {
-        op->m_output_descriptions.push_back(output_description->copy());
-    }
+    clone_to(*op, new_args);
     return op;
 }
 
@@ -429,6 +347,31 @@ bool op::v5::Loop::evaluate(const HostTensorVector& outputs, const HostTensorVec
     runtime::reference::loop(
         m_body, m_output_descriptions, m_input_descriptions, m_special_body_ports, outputs, inputs);
     return true;
+}
+
+void op::v5::Loop::clone_to(op::v5::Loop& dst, const OutputVector& new_args) const
+{
+    dst.set_arguments(new_args);
+    dst.set_output_size(m_output_descriptions.size());
+
+    dst.m_num_iterations = m_num_iterations;
+    dst.m_special_body_ports = m_special_body_ports;
+
+    dst.m_body = clone_function(*get_function());
+
+    for (auto& input_description : m_input_descriptions)
+    {
+        dst.m_input_descriptions.push_back(input_description->copy());
+    }
+    for (auto& output_description : m_output_descriptions)
+    {
+        dst.m_output_descriptions.push_back(output_description->copy());
+    }
+}
+
+op::v5::Loop::Loop(const op::v5::Loop& other)
+{
+    other.clone_to(*this, other.input_values());
 }
 
 namespace ngraph


### PR DESCRIPTION
# Description

* Enables const overload for `SubGraphOp::get_function`
* Deletes `SubGraphOp` copy constructor
  `SubGraphOp` has `clone_with_new_inputs` function for deep coping, while default copy constructor does some kind of shallow one. In order to avoid confusion, copy constructor is deleted since it's unused anyway.
* Enables protected `Loop` copy constructor
  Additional clone method is introduced in order to reuse `Loop::clone_with_new_inputs` implementation. `Loop::clone_with_new_inputs` implementation at the same time is refactored, since there were extra job that does not needed to be done there.
* Introduces `StaticShapeLoop`
  `StaticShapeLoop` is a class derived from Loop to override `validate_and_infer_types` method in order to propagate upper-bounds through the function instead of dynamic tensors.

  It uses `maximum_value` estimation to get upper-bound for iterations count in case if it is dynamic.
* Refactors function validators in DTS
  The same approach (nGraph operation to functor map) as for DTS shape functors is used since validation is operation type specific.
* Enables DTS for `Loop`
  Only loops with inputs dynamic in batch (iterations count) and static body are supported.

# Task

#-45341