### PR TITLE
[CPU] Split layer nspc -> ncsp special case put back.

### DIFF
--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.cpp
@@ -59,11 +59,6 @@ static TensorDesc makeChannelBlockedTensorDesc(const Precision& precision, const
     return TensorDesc(precision, srcDims, {blkDims, order});
 }
 
-static inline uint8_t* getDataPtr(const MKLDNNMemory& memoryPtr) {
-    return reinterpret_cast<uint8_t*>(memoryPtr.GetData()) + memoryPtr.GetDescriptor().data.layout_desc.blocking.offset_padding *
-        MKLDNNExtensionUtils::sizeOfDataType(mkldnn::memory::data_type(memoryPtr.GetDescriptor().data.data_type));
-}
-
 MKLDNNSplitNode::MKLDNNSplitNode(const InferenceEngine::CNNLayerPtr& layer, const mkldnn::engine& eng, MKLDNNWeightsSharing::Ptr &cache) :
         MKLDNNNode(layer, eng, cache) {}
 
@@ -140,7 +135,7 @@ void MKLDNNSplitNode::initSupportedPrimitiveDescriptors() {
         config.inConfs[0].desc = getTensorDesc(precision, srcDims.ToSizeVector());
         config.outConfs.resize(outDims.size());
 
-        std::vector<memory::format> outFormats;
+        std::vector<memory::format_tag> outFormats;
 
         for (size_t i = 0; i < outDims.size(); i++) {
             auto o_Dims = outDims[i];
@@ -198,7 +193,7 @@ void MKLDNNSplitNode::initSupportedPrimitiveDescriptors() {
         const auto& blkDims = refConfig.inConfs[0].desc.getBlockingDesc().getBlockDims();
         auto numOfDim = blkDims.size();
 
-        std::vector<memory::format> outFormats;
+        std::vector<memory::format_tag> outFormats;
         SizeVector offsets(numOfDim, 0lu);
         SizeVector strides(numOfDim);
         strides.back() = 1lu;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.h
@@ -29,16 +29,17 @@ public:
 
 private:
     void prepareOptimizedParams();
+    void initializeDstMemPtrs();
     void optimizedNspc2Ncsp(size_t MB);
 
     bool canUseOptimizedNspc2Ncsp;
 
     size_t axis = 1;
+    std::vector<uint8_t*> dstMemPtrs;
 
     struct {
         std::vector<size_t> dataSize;
         std::vector<size_t> srcDataOffsets;
-        std::vector<uint8_t *> dstMemPtrs;
         size_t srcDataStride;
         size_t countStrides;
     } optimizedParams;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.h
@@ -29,6 +29,9 @@ public:
 
 private:
     void prepareOptimizedParams();
+    void optimizedNspc2Ncsp(size_t MB);
+
+    bool canUseOptimizedNspc2Ncsp;
 
     size_t axis = 1;
 

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/split.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/split.cpp
@@ -91,8 +91,11 @@ const auto planar_5D_ref = CPUSpecificParams{{ncdhw}, {ncdhw}, {"ref"}, "ref"};
 const auto planar_4D = CPUSpecificParams{{nchw}, {nchw}, {}, "unknown"};
 const auto planar_5D = CPUSpecificParams{{ncdhw}, {ncdhw}, {}, "unknown"};
 
-const auto planarChannels_4D = CPUSpecificParams{{nhwc}, {nhwc}, {}, "ref"};
-const auto planarChannels_5D = CPUSpecificParams{{ndhwc}, {ndhwc}, {}, "ref"};
+const auto perChannels_4D = CPUSpecificParams{{nhwc}, {nhwc}, {}, "ref"};
+const auto perChannels_5D = CPUSpecificParams{{ndhwc}, {ndhwc}, {}, "ref"};
+
+const auto planarChannels_4D = CPUSpecificParams{{nhwc}, {nchw}, {}, "ref"};
+const auto planarChannels_5D = CPUSpecificParams{{ndhwc}, {ncdhw}, {}, "ref"};
 
 const auto blocked8_4D = CPUSpecificParams{{nChw8c}, {nChw8c}, {}, "unknown"};
 const auto blocked8_5D = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {}, "unknown"};
@@ -114,6 +117,28 @@ const std::vector<Precision> netPrecisions = {
         Precision::BF16
 };
 
+INSTANTIATE_TEST_CASE_P(smoke_Split4D_CPU_Nspc2NcspSpetial, SplitLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Values(4),
+                                ::testing::Values(1),
+                                ::testing::ValuesIn(netPrecisions),
+                                ::testing::Values(std::vector<size_t>({3, 28, 24, 9})),
+                                ::testing::Values(std::vector<size_t>({})),
+                                ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                                ::testing::Values(planarChannels_4D)),
+                        SplitLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_Split5D_CPU_Nspc2NcspSpetial, SplitLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Values(3),
+                                ::testing::Values(1),
+                                ::testing::ValuesIn(netPrecisions),
+                                ::testing::Values(std::vector<size_t>({3, 21, 24, 9, 15})),
+                                ::testing::Values(std::vector<size_t>({})),
+                                ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                                ::testing::Values(planarChannels_5D)),
+                        SplitLayerCPUTest::getTestCaseName);
+
 INSTANTIATE_TEST_CASE_P(smoke_Split4D_CPU_Block8inPlace, SplitLayerCPUTest,
                     ::testing::Combine(
                             ::testing::Values(3),
@@ -122,7 +147,7 @@ INSTANTIATE_TEST_CASE_P(smoke_Split4D_CPU_Block8inPlace, SplitLayerCPUTest,
                             ::testing::Values(std::vector<size_t>({3, 24, 24, 9})),
                             ::testing::Values(std::vector<size_t>({})),
                             ::testing::Values(CommonTestUtils::DEVICE_CPU),
-                            ::testing::Values(planar_4D, planar_4D_ref, planarChannels_4D, blocked8_4D)),
+                            ::testing::Values(planar_4D, planar_4D_ref, perChannels_4D, blocked8_4D)),
                     SplitLayerCPUTest::getTestCaseName);
 
 INSTANTIATE_TEST_CASE_P(smoke_Split4D_CPU_Block8, SplitLayerCPUTest,
@@ -133,7 +158,7 @@ INSTANTIATE_TEST_CASE_P(smoke_Split4D_CPU_Block8, SplitLayerCPUTest,
                                 ::testing::Values(std::vector<size_t>({3, 24, 24, 9})),
                                 ::testing::Values(std::vector<size_t>({})),
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU),
-                                ::testing::Values(planar_4D, planar_4D_ref, planarChannels_4D, blocked8_4D_ref)),
+                                ::testing::Values(planar_4D, planar_4D_ref, perChannels_4D, blocked8_4D_ref)),
                         SplitLayerCPUTest::getTestCaseName);
 
 INSTANTIATE_TEST_CASE_P(smoke_Split4D_CPU_Block16inPlace, SplitLayerCPUTest,
@@ -166,7 +191,7 @@ INSTANTIATE_TEST_CASE_P(smoke_Split5D_CPU_Block8inPlace, SplitLayerCPUTest,
                                 ::testing::Values(std::vector<size_t>({3, 24, 24, 9, 15})),
                                 ::testing::Values(std::vector<size_t>({})),
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU),
-                                ::testing::Values(planar_5D, planar_5D_ref, planarChannels_5D, blocked8_5D)),
+                                ::testing::Values(planar_5D, planar_5D_ref, perChannels_5D, blocked8_5D)),
                         SplitLayerCPUTest::getTestCaseName);
 
 INSTANTIATE_TEST_CASE_P(smoke_Split5D_CPU_Block8, SplitLayerCPUTest,
@@ -177,7 +202,7 @@ INSTANTIATE_TEST_CASE_P(smoke_Split5D_CPU_Block8, SplitLayerCPUTest,
                                 ::testing::Values(std::vector<size_t>({3, 24, 24, 9, 15})),
                                 ::testing::Values(std::vector<size_t>({})),
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU),
-                                ::testing::Values(planar_5D, planar_5D_ref, planarChannels_5D, blocked8_5D_ref)),
+                                ::testing::Values(planar_5D, planar_5D_ref, perChannels_5D, blocked8_5D_ref)),
                         SplitLayerCPUTest::getTestCaseName);
 
 INSTANTIATE_TEST_CASE_P(smoke_Split5D_CPU_Block16inPlace, SplitLayerCPUTest,

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/split.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/split.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -94,8 +94,8 @@ const auto planar_5D = CPUSpecificParams{{ncdhw}, {ncdhw}, {}, "unknown"};
 const auto perChannels_4D = CPUSpecificParams{{nhwc}, {nhwc}, {}, "ref"};
 const auto perChannels_5D = CPUSpecificParams{{ndhwc}, {ndhwc}, {}, "ref"};
 
-const auto planarChannels_4D = CPUSpecificParams{{nhwc}, {nchw}, {}, "ref"};
-const auto planarChannels_5D = CPUSpecificParams{{ndhwc}, {ncdhw}, {}, "ref"};
+const auto perChannelsToPlanar_4D = CPUSpecificParams{{nhwc}, {nchw}, {}, "ref"};
+const auto perChannelsToPlanar_5D = CPUSpecificParams{{ndhwc}, {ncdhw}, {}, "ref"};
 
 const auto blocked8_4D = CPUSpecificParams{{nChw8c}, {nChw8c}, {}, "unknown"};
 const auto blocked8_5D = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {}, "unknown"};
@@ -117,7 +117,7 @@ const std::vector<Precision> netPrecisions = {
         Precision::BF16
 };
 
-INSTANTIATE_TEST_CASE_P(smoke_Split4D_CPU_Nspc2NcspSpetial, SplitLayerCPUTest,
+INSTANTIATE_TEST_CASE_P(smoke_Split4D_CPU_Nspc2NcspSpecial, SplitLayerCPUTest,
                         ::testing::Combine(
                                 ::testing::Values(4),
                                 ::testing::Values(1),
@@ -125,10 +125,10 @@ INSTANTIATE_TEST_CASE_P(smoke_Split4D_CPU_Nspc2NcspSpetial, SplitLayerCPUTest,
                                 ::testing::Values(std::vector<size_t>({3, 28, 24, 9})),
                                 ::testing::Values(std::vector<size_t>({})),
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU),
-                                ::testing::Values(planarChannels_4D)),
+                                ::testing::Values(perChannelsToPlanar_4D)),
                         SplitLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(smoke_Split5D_CPU_Nspc2NcspSpetial, SplitLayerCPUTest,
+INSTANTIATE_TEST_CASE_P(smoke_Split5D_CPU_Nspc2NcspSpecial, SplitLayerCPUTest,
                         ::testing::Combine(
                                 ::testing::Values(3),
                                 ::testing::Values(1),
@@ -136,7 +136,7 @@ INSTANTIATE_TEST_CASE_P(smoke_Split5D_CPU_Nspc2NcspSpetial, SplitLayerCPUTest,
                                 ::testing::Values(std::vector<size_t>({3, 21, 24, 9, 15})),
                                 ::testing::Values(std::vector<size_t>({})),
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU),
-                                ::testing::Values(planarChannels_5D)),
+                                ::testing::Values(perChannelsToPlanar_5D)),
                         SplitLayerCPUTest::getTestCaseName);
 
 INSTANTIATE_TEST_CASE_P(smoke_Split4D_CPU_Block8inPlace, SplitLayerCPUTest,

--- a/inference-engine/tests_deprecated/unit/engines/mkldnn/graph/layers/internal/graph_split_test.cpp
+++ b/inference-engine/tests_deprecated/unit/engines/mkldnn/graph/layers/internal/graph_split_test.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -230,27 +230,27 @@ INSTANTIATE_TEST_CASE_P(
                 split_test_params {
                         {1, 24, 2, 5},
                         {{1, 16, 2, 5}, {1, 8, 2, 5}},
-                        1, 5, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
+                        1, 6, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
                 },
                 split_test_params {
                         {1, 20, 2, 5},
                         {{1, 13, 2, 5}, {1, 7, 2, 5}},
-                        1, 3, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
+                        1, 4, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
                 },
                 split_test_params {
                         {1, 20, 2, 5},
                         {{1, 10, 2, 5}, {1, 10, 2, 5}},
-                        1, 3, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
+                        1, 4, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
                 },
                 split_test_params {
                         {2, 20, 2, 5},
                         {{2, 10, 2, 5}, {2, 10, 2, 5}},
-                        1, 3, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
+                        1, 4, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
                 },
                 split_test_params {
                         {2, 20, 2, 5},
                         {{2, 15, 2, 5}, {2,  5, 2, 5}},
-                        1, 3, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
+                        1, 4, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
                 },
                 split_test_params {
                         {9, 11, 7, 5},
@@ -275,7 +275,7 @@ INSTANTIATE_TEST_CASE_P(
                 split_test_params {
                         {5, 6, 7, 15},
                         {{5, 1, 7, 15}, {5, 2, 7, 15}, {5, 1, 7, 15}, {5, 2, 7, 15}},
-                        1, 3, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
+                        1, 4, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}
                 },
                 split_test_params {
                         {5, 6, 7, 15},
@@ -290,15 +290,15 @@ INSTANTIATE_TEST_CASE_P(
                 split_test_params {
                         {5, 6, 7, 15},
                         {{5, 6, 7, 15}},
-                        1, 3, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}},
+                        1, 4, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}},
                 split_test_params {
                         {1, 32, 16, 16, 16},
                         {{1, 8, 16, 16, 16}, {1, 8, 16, 16, 16}, {1, 8, 16, 16, 16}, {1, 8, 16, 16, 16}},
-                        1, 5, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}},
+                        1, 6, MKLDNNPlugin::impl_desc_type::ref, {MKLDNNPlugin::impl_desc_type::ref}},
                 split_test_params {
                         {1, 32, 16, 16, 16},
                         {{1, 8, 16, 16, 16}, {1, 8, 16, 16, 16}, {1, 8, 16, 16, 16}, {1, 8, 16, 16, 16}},
-                        1, 5, MKLDNNPlugin::impl_desc_type::unknown, {}}));
+                        1, 6, MKLDNNPlugin::impl_desc_type::unknown, {}}));
 
 class MKLDNNGraphDynBatchSplitTests: public MKLDNNGraphSplitTests {
 protected:


### PR DESCRIPTION
Special case for split layer (n(d)hwc -> nc(d)hw) put back to fix the performance degradation (see ticket 46414 for details).
Also this PR contains fix for bug 47383.