### PR TITLE
Inconsistent inference results for hello_classification sample between Windows and Linux (44369)

### DIFF
--- a/inference-engine/samples/hello_classification/main.cpp
+++ b/inference-engine/samples/hello_classification/main.cpp
@@ -5,11 +5,13 @@
 #include <vector>
 #include <memory>
 #include <string>
+#include <iterator>
 #include <samples/common.hpp>
 
 #include <inference_engine.hpp>
 #include <samples/ocv_common.hpp>
 #include <samples/classification_results.h>
+
 
 using namespace InferenceEngine;
 
@@ -34,12 +36,13 @@ cv::Mat imreadW(std::wstring input_image_path) {
         std::iostream::binary | std::ios_base::ate | std::ios_base::in);
     if (input_image_stream.is_open()) {
         if (input_image_stream.good()) {
+            input_image_stream.seekg(0, std::ios::end);
             std::size_t file_size = input_image_stream.tellg();
             input_image_stream.seekg(0, std::ios::beg);
             std::vector<char> buffer(0);
             std::copy(
-                std::istream_iterator<char>(input_image_stream),
-                std::istream_iterator<char>(),
+                std::istreambuf_iterator<char>(input_image_stream),
+                std::istreambuf_iterator<char>(),
                 std::back_inserter(buffer));
             image = cv::imdecode(cv::Mat(1, file_size, CV_8UC1, &buffer[0]), cv::IMREAD_COLOR);
         } else {

--- a/inference-engine/samples/hello_classification/main.cpp
+++ b/inference-engine/samples/hello_classification/main.cpp
@@ -12,7 +12,6 @@
 #include <samples/ocv_common.hpp>
 #include <samples/classification_results.h>
 
-
 using namespace InferenceEngine;
 
 #if defined(ENABLE_UNICODE_PATH_SUPPORT) && defined(_WIN32)


### PR DESCRIPTION
Fixed image load issue: std::ios::skipws flag is unset for istream_iterator by default, instead use istreambuf_iterator to read raw data.