### PR TITLE
Enable calculation of reference data without prior run of infer request

### DIFF
--- a/inference-engine/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
@@ -375,13 +375,14 @@ std::vector<std::vector<std::uint8_t>> LayerTestsCommon::CalculateRefs() {
     }
 
     auto ieOutPrc = outPrc;
-    const auto &actualOutputs = GetOutputs();
-    std::vector<ngraph::element::Type_t> convertType(actualOutputs.size(),
+    const auto &&outputsInfo = executableNetwork.GetOutputsInfo();
+    std::vector<ngraph::element::Type_t> convertType(outputsInfo.size(),
                                                      FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(ieOutPrc));
     if (ieOutPrc == InferenceEngine::Precision::UNSPECIFIED) {
-        for (size_t i = 0; i < convertType.size(); i++) {
-            convertType[i] = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(
-                    actualOutputs[i]->getTensorDesc().getPrecision());
+        size_t i = 0;
+        for (const auto &output : outputsInfo) {
+                convertType[i++] = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(
+                    output.second->getTensorDesc().getPrecision());
         }
     }
 


### PR DESCRIPTION
vpux plugin has the test case scenario when reference values are calculated without having infer run first.
This change allows the framework to run reference calculations without infer request object.

#CVS-46799