### PR TITLE
[IE CLDNN] Changed weights layout used in the plugin

### DIFF
--- a/inference-engine/src/cldnn_engine/cldnn_program.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_program.cpp
@@ -327,7 +327,7 @@ void Program::InitProfileInfo(const std::string& layerName,
 bool IsNodeOnConstPath(const std::shared_ptr<ngraph::Node>& node) {
     std::list<std::shared_ptr<ngraph::Node>> nodes_to_process = { node };
     while (!nodes_to_process.empty()) {
-        auto& current_node = nodes_to_process.front();
+        auto current_node = nodes_to_process.front();
         nodes_to_process.pop_front();
 
         for (size_t i = 0; i < current_node->get_input_size(); i++) {

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/skip_tests_config.cpp
@@ -34,6 +34,8 @@ std::vector<std::string> disabledTestPatterns() {
             R"(.*EltwiseLayerTest.*IS=\(1.4.3.2.1.3\).*)",
             R"(.*EltwiseLayerTest.*IS=\(2\).*OpType=Mod.*opType=VECTOR.*)",
             R"(.*EltwiseLayerTest.*OpType=FloorMod.*netPRC=I64.*)",
+            // TODO: Issue: 46841
+            R"(.*(QuantGroupConvBackpropData3D).*)",
 
             // These tests might fail due to accuracy loss a bit bigger than threshold
             R"(.*(GRUCellTest).*)",

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/subgraph_tests/quantized_convolution_backprop_data.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/subgraph_tests/quantized_convolution_backprop_data.cpp
@@ -1,0 +1,80 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "subgraph_tests/quantized_convolution_backprop_data.hpp"
+#include "common_test_utils/test_constants.hpp"
+
+using namespace SubgraphTestsDefinitions;
+using namespace ngraph::helpers;
+
+namespace {
+
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32
+};
+
+const std::vector<size_t> numOutChannels = {16, 32};
+
+const std::vector<size_t > levels = {256};
+const std::vector<QuantizationGranularity > granularity = {Pertensor, Perchannel};
+
+/* ============= 2D GroupConvolutionBackpropData ============= */
+const std::vector<std::vector<size_t >> inputShapes2D = {{1, 16, 10, 10}, {1, 32, 10, 10}};
+const std::vector<std::vector<size_t >> kernels2D = {{1, 1}, {3, 3}};
+const std::vector<std::vector<size_t >> strides2D = {{1, 1}};
+const std::vector<std::vector<ptrdiff_t>> padBegins2D = {{0, 0}};
+const std::vector<std::vector<ptrdiff_t>> padEnds2D = {{0, 0}};
+const std::vector<std::vector<size_t >> dilations2D = {{1, 1}};
+
+const auto quantConvBackpropData2DParams = ::testing::Combine(
+        ::testing::ValuesIn(kernels2D),
+        ::testing::ValuesIn(strides2D),
+        ::testing::ValuesIn(padBegins2D),
+        ::testing::ValuesIn(padEnds2D),
+        ::testing::ValuesIn(dilations2D),
+        ::testing::ValuesIn(numOutChannels),
+        ::testing::Values(ngraph::op::PadType::AUTO),
+        ::testing::ValuesIn(levels),
+        ::testing::ValuesIn(granularity)
+);
+
+INSTANTIATE_TEST_CASE_P(smoke_QuantConvBackpropData2D, QuantConvBackpropDataLayerTest,
+                        ::testing::Combine(
+                                quantConvBackpropData2DParams,
+                                ::testing::ValuesIn(netPrecisions),
+                                ::testing::ValuesIn(inputShapes2D),
+                                ::testing::Values(CommonTestUtils::DEVICE_GPU)),
+                        QuantConvBackpropDataLayerTest::getTestCaseName);
+
+/* ============= 3D ConvolutionBackpropData ============= */
+const std::vector<std::vector<size_t >> inputShapes3D = {{1, 16, 5, 5, 5}, {1, 32, 5, 5, 5}};
+const std::vector<std::vector<size_t >> kernels3D = {{1, 1, 1}, {3, 3, 3}};
+const std::vector<std::vector<size_t >> strides3D = {{1, 1, 1}};
+const std::vector<std::vector<ptrdiff_t>> padBegins3D = {{0, 0, 0}};
+const std::vector<std::vector<ptrdiff_t>> padEnds3D = {{0, 0, 0}};
+const std::vector<std::vector<size_t >> dilations3D = {{1, 1, 1}};
+
+const auto quantConvBackpropData3DParams = ::testing::Combine(
+        ::testing::ValuesIn(kernels3D),
+        ::testing::ValuesIn(strides3D),
+        ::testing::ValuesIn(padBegins3D),
+        ::testing::ValuesIn(padEnds3D),
+        ::testing::ValuesIn(dilations3D),
+        ::testing::ValuesIn(numOutChannels),
+        ::testing::Values(ngraph::op::PadType::AUTO),
+        ::testing::ValuesIn(levels),
+        ::testing::ValuesIn(granularity)
+);
+
+INSTANTIATE_TEST_CASE_P(smoke_QuantConvBackpropData3D, QuantConvBackpropDataLayerTest,
+                        ::testing::Combine(
+                                quantConvBackpropData3DParams,
+                                ::testing::ValuesIn(netPrecisions),
+                                ::testing::ValuesIn(inputShapes3D),
+                                ::testing::Values(CommonTestUtils::DEVICE_GPU)),
+                        QuantConvBackpropDataLayerTest::getTestCaseName);
+
+}  // namespace

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/subgraph_tests/quantized_group_convolution_backprop_data.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/subgraph_tests/quantized_group_convolution_backprop_data.cpp
@@ -1,0 +1,83 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "subgraph_tests/quantized_group_convolution_backprop_data.hpp"
+#include "common_test_utils/test_constants.hpp"
+
+using namespace SubgraphTestsDefinitions;
+using namespace ngraph::helpers;
+
+namespace {
+
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32
+};
+
+const std::vector<size_t> numOutChannels = {16, 32};
+const std::vector<size_t> numGroups = {2, 8, 16};
+
+const std::vector<size_t > levels = {256};
+const std::vector<QuantizationGranularity > granularity = {Pertensor, Perchannel};
+
+/* ============= 2D GroupConvolutionBackpropData ============= */
+const std::vector<std::vector<size_t >> inputShapes2D = {{1, 16, 10, 10}, {1, 32, 10, 10}};
+const std::vector<std::vector<size_t >> kernels2D = {{1, 1}, {3, 3}};
+const std::vector<std::vector<size_t >> strides2D = {{1, 1}};
+const std::vector<std::vector<ptrdiff_t>> padBegins2D = {{0, 0}};
+const std::vector<std::vector<ptrdiff_t>> padEnds2D = {{0, 0}};
+const std::vector<std::vector<size_t >> dilations2D = {{1, 1}};
+
+const auto quantGroupConvBackpropData2DParams = ::testing::Combine(
+        ::testing::ValuesIn(kernels2D),
+        ::testing::ValuesIn(strides2D),
+        ::testing::ValuesIn(padBegins2D),
+        ::testing::ValuesIn(padEnds2D),
+        ::testing::ValuesIn(dilations2D),
+        ::testing::ValuesIn(numOutChannels),
+        ::testing::ValuesIn(numGroups),
+        ::testing::Values(ngraph::op::PadType::AUTO),
+        ::testing::ValuesIn(levels),
+        ::testing::ValuesIn(granularity)
+);
+
+INSTANTIATE_TEST_CASE_P(smoke_QuantGroupConvBackpropData2D, QuantGroupConvBackpropDataLayerTest,
+                        ::testing::Combine(
+                                quantGroupConvBackpropData2DParams,
+                                ::testing::ValuesIn(netPrecisions),
+                                ::testing::ValuesIn(inputShapes2D),
+                                ::testing::Values(CommonTestUtils::DEVICE_GPU)),
+                        QuantGroupConvBackpropDataLayerTest::getTestCaseName);
+
+/* ============= 3D GroupConvolutionBackpropData ============= */
+const std::vector<std::vector<size_t >> inputShapes3D = {{1, 16, 5, 5, 5}, {1, 32, 5, 5, 5}};
+const std::vector<std::vector<size_t >> kernels3D = {{3, 3, 3}};
+const std::vector<std::vector<size_t >> strides3D = {{1, 1, 1}};
+const std::vector<std::vector<ptrdiff_t>> padBegins3D = {{0, 0, 0}};
+const std::vector<std::vector<ptrdiff_t>> padEnds3D = {{0, 0, 0}};
+const std::vector<std::vector<size_t >> dilations3D = {{1, 1, 1}};
+
+const auto quantGroupConvBackpropData3DParams = ::testing::Combine(
+        ::testing::ValuesIn(kernels3D),
+        ::testing::ValuesIn(strides3D),
+        ::testing::ValuesIn(padBegins3D),
+        ::testing::ValuesIn(padEnds3D),
+        ::testing::ValuesIn(dilations3D),
+        ::testing::ValuesIn(numOutChannels),
+        ::testing::ValuesIn(numGroups),
+        ::testing::Values(ngraph::op::PadType::AUTO),
+        ::testing::ValuesIn(levels),
+        ::testing::ValuesIn(granularity)
+);
+
+INSTANTIATE_TEST_CASE_P(smoke_QuantGroupConvBackpropData3D, QuantGroupConvBackpropDataLayerTest,
+                        ::testing::Combine(
+                                quantGroupConvBackpropData3DParams,
+                                ::testing::ValuesIn(netPrecisions),
+                                ::testing::ValuesIn(inputShapes3D),
+                                ::testing::Values(CommonTestUtils::DEVICE_GPU)),
+                        QuantGroupConvBackpropDataLayerTest::getTestCaseName);
+
+}  // namespace

--- a/inference-engine/thirdparty/clDNN/api/convolution.hpp
+++ b/inference-engine/thirdparty/clDNN/api/convolution.hpp
@@ -48,6 +48,12 @@ struct convolution : public primitive_base<convolution> {
     /// @param with_activation Enable Relu activation.
     /// @param activation_slp Relu activation slope.
     /// @param output_size User-defined output data size of the primitive (w/o padding).
+    /// @param output_type User-defined output data type of the primitive.
+    /// @param grouped_weights_shape Defines if weights tensor has explicit group dimension.
+    /// This parameter affects how bfzyx and bfwzyx format on weights is converted:
+    /// bfzyx -> oizyx (grouped_weights_shape=false) or goiyx (grouped_weights_shape=true)
+    /// bfwzyx -> error (grouped_weights_shape=false) or goizyx (grouped_weights_shape=true)
+    /// If weights already have (g)oi(z)yx format, then this flag has no effect
     convolution(const primitive_id& id,
                 const primitive_id& input,
                 const std::vector<primitive_id>& weights,
@@ -58,6 +64,7 @@ struct convolution : public primitive_base<convolution> {
                 tensor dilation,
                 tensor output_size,
                 data_types output_type,
+                bool grouped_weights_shape,
                 const padding& output_padding = padding())
             : primitive_base(id, {input}, output_padding, optional_data_type{output_type}),
               input_offset(input_offset),
@@ -70,6 +77,7 @@ struct convolution : public primitive_base<convolution> {
               padding_above(tensor(0)),
               padding_below(tensor(0)),
               deformable_mode(false),
+              grouped_weights_shape(grouped_weights_shape),
               weights(weights),
               bias(bias),
               weights_zero_points(std::vector<primitive_id>(0)),
@@ -107,6 +115,7 @@ struct convolution : public primitive_base<convolution> {
                 tensor input_offset,
                 tensor dilation,
                 tensor output_size,
+                bool grouped_weights_shape,
                 const padding& output_padding = padding())
             : primitive_base(id, {input}, output_padding, optional_data_type{output_data_type}),
               input_offset(input_offset),
@@ -119,6 +128,7 @@ struct convolution : public primitive_base<convolution> {
               padding_above(tensor(0)),
               padding_below(tensor(0)),
               deformable_mode(false),
+              grouped_weights_shape(grouped_weights_shape),
               weights(weights),
               bias(bias),
               weights_zero_points(w_zero_point),
@@ -163,6 +173,7 @@ struct convolution : public primitive_base<convolution> {
                 tensor input_offset,
                 tensor dilation,
                 tensor output_size,
+                bool grouped_weights_shape,
                 const padding& output_padding = padding())
             : primitive_base(id, {input}, output_padding, optional_data_type{output_data_type}),
               input_offset(input_offset),
@@ -175,6 +186,7 @@ struct convolution : public primitive_base<convolution> {
               padding_above(tensor(0)),
               padding_below(tensor(0)),
               deformable_mode(false),
+              grouped_weights_shape(grouped_weights_shape),
               weights(weights),
               bias(bias),
               weights_zero_points(w_zero_point),
@@ -220,6 +232,7 @@ struct convolution : public primitive_base<convolution> {
           padding_above(tensor(0)),
           padding_below(tensor(0)),
           deformable_mode(false),
+          grouped_weights_shape(false),
           weights(weights),
           bias(bias),
           weights_zero_points(std::vector<primitive_id>(0)),
@@ -264,6 +277,7 @@ struct convolution : public primitive_base<convolution> {
           padding_above(padding_above),
           padding_below(padding_below),
           deformable_mode(false),
+          grouped_weights_shape(false),
           weights(weights),
           bias(bias),
           weights_zero_points(std::vector<primitive_id>(0)),
@@ -310,6 +324,7 @@ struct convolution : public primitive_base<convolution> {
           padding_above(padding_above),
           padding_below(padding_below),
           deformable_mode(false),
+          grouped_weights_shape(false),
           weights(weights),
           bias(bias),
           weights_zero_points(std::vector<primitive_id>(0)),
@@ -343,6 +358,7 @@ struct convolution : public primitive_base<convolution> {
                 tensor stride = {1, 1, 1, 1},
                 tensor input_offset = tensor(0),
                 tensor dilation = {1, 1, 1, 1},
+                bool grouped_weights_shape = false,
                 const padding& output_padding = padding())
         : primitive_base(id, {input}, output_padding),
           input_offset(input_offset),
@@ -354,6 +370,7 @@ struct convolution : public primitive_base<convolution> {
           padding_above(tensor(0)),
           padding_below(tensor(0)),
           deformable_mode(false),
+          grouped_weights_shape(grouped_weights_shape),
           weights(weights),
           bias(bias),
           weights_zero_points(std::vector<primitive_id>(0)),
@@ -385,6 +402,7 @@ struct convolution : public primitive_base<convolution> {
                 tensor stride = {1, 1, 1, 1},
                 tensor input_offset = tensor(0),
                 tensor dilation = {1, 1, 1, 1},
+                bool grouped_weights_shape = false,
                 const padding& output_padding = padding())
         : primitive_base(id, {input}, output_padding),
           input_offset(input_offset),
@@ -396,6 +414,7 @@ struct convolution : public primitive_base<convolution> {
           padding_above(tensor(0)),
           padding_below(tensor(0)),
           deformable_mode(false),
+          grouped_weights_shape(grouped_weights_shape),
           weights(weights),
           bias(std::vector<primitive_id>(0)),
           weights_zero_points(std::vector<primitive_id>(0)),
@@ -437,6 +456,7 @@ struct convolution : public primitive_base<convolution> {
           padding_above(padding_above),
           padding_below(padding_below),
           deformable_mode(false),
+          grouped_weights_shape(false),
           weights(weights),
           bias(std::vector<primitive_id>(0)),
           weights_zero_points(std::vector<primitive_id>(0)),
@@ -480,6 +500,7 @@ struct convolution : public primitive_base<convolution> {
           padding_above(padding_above),
           padding_below(padding_below),
           deformable_mode(false),
+          grouped_weights_shape(false),
           weights(weights),
           bias(std::vector<primitive_id>(0)),
           weights_zero_points(std::vector<primitive_id>(0)),
@@ -508,6 +529,7 @@ struct convolution : public primitive_base<convolution> {
                 tensor stride = {1, 1, 1, 1},
                 tensor input_offset = tensor(0),
                 tensor dilation = {1, 1, 1, 1},
+                bool grouped_weights_shape = false,
                 const padding& output_padding = padding())
         : primitive_base(id, {input}, output_padding),
           input_offset(input_offset),
@@ -519,6 +541,7 @@ struct convolution : public primitive_base<convolution> {
           padding_above(tensor(0)),
           padding_below(tensor(0)),
           deformable_mode(false),
+          grouped_weights_shape(grouped_weights_shape),
           weights(weights),
           bias(std::vector<primitive_id>(0)),
           weights_zero_points(std::vector<primitive_id>(0)),
@@ -561,6 +584,7 @@ struct convolution : public primitive_base<convolution> {
           padding_above(tensor(0)),
           padding_below(tensor(0)),
           deformable_mode(false),
+          grouped_weights_shape(false),
           weights(weights),
           bias(bias),
           weights_zero_points(std::vector<primitive_id>(0)),
@@ -604,6 +628,7 @@ struct convolution : public primitive_base<convolution> {
           padding_above(tensor(0)),
           padding_below(tensor(0)),
           deformable_mode(false),
+          grouped_weights_shape(false),
           weights(weights),
           bias(std::vector<primitive_id>(0)),
           weights_zero_points(std::vector<primitive_id>(0)),
@@ -651,6 +676,7 @@ struct convolution : public primitive_base<convolution> {
           padding_above(tensor(0)),
           padding_below(tensor(0)),
           deformable_mode(true),
+          grouped_weights_shape(false),
           weights(weights),
           bias(bias),
           weights_zero_points(std::vector<primitive_id>(0)),
@@ -756,6 +782,8 @@ struct convolution : public primitive_base<convolution> {
     tensor padding_below;
     /// @param deformable_mode.
     bool deformable_mode;
+    /// @param grouped_weights_shape Defines if weights tensor has explicit group dimension.
+    bool grouped_weights_shape;
     /// @brief List of primitive ids containing weights data.
     const primitive_id_arr weights;
     /// @brief List of primitive ids containing bias data.

--- a/inference-engine/thirdparty/clDNN/api/deconvolution.hpp
+++ b/inference-engine/thirdparty/clDNN/api/deconvolution.hpp
@@ -55,6 +55,7 @@ struct deconvolution : public primitive_base<deconvolution> {
           stride(stride),
           with_output_size(false),
           groups(1),
+          grouped_weights_shape(false),
           weights(weights),
           bias(bias) {}
     /// @brief Constructs deconvolution primitive.
@@ -81,6 +82,7 @@ struct deconvolution : public primitive_base<deconvolution> {
           stride(stride),
           with_output_size(false),
           groups(groups),
+          grouped_weights_shape(false),
           weights(weights),
           bias(bias) {}
 
@@ -104,6 +106,7 @@ struct deconvolution : public primitive_base<deconvolution> {
           stride(stride),
           with_output_size(false),
           groups(1),
+          grouped_weights_shape(false),
           weights(weights),
           bias(std::vector<primitive_id>(0)) {}
 
@@ -129,6 +132,7 @@ struct deconvolution : public primitive_base<deconvolution> {
           stride(stride),
           with_output_size(false),
           groups(groups),
+          grouped_weights_shape(false),
           weights(weights),
           bias(std::vector<primitive_id>(0)) {}
 
@@ -157,6 +161,7 @@ struct deconvolution : public primitive_base<deconvolution> {
           with_output_size(true),
           output_size(output_size),
           groups(1),
+          grouped_weights_shape(false),
           weights(weights),
           bias(bias) {}
 
@@ -180,6 +185,7 @@ struct deconvolution : public primitive_base<deconvolution> {
                   tensor stride,
                   tensor input_offset,
                   tensor output_size,
+                  bool grouped_weights_shape,
                   const padding& output_padding = padding())
         : primitive_base(id, {input}, output_padding),
           input_offset(input_offset),
@@ -187,6 +193,7 @@ struct deconvolution : public primitive_base<deconvolution> {
           with_output_size(true),
           output_size(output_size),
           groups(groups),
+          grouped_weights_shape(grouped_weights_shape),
           weights(weights),
           bias(bias) {}
 
@@ -213,6 +220,7 @@ struct deconvolution : public primitive_base<deconvolution> {
           with_output_size(true),
           output_size(output_size),
           groups(1),
+          grouped_weights_shape(false),
           weights(weights),
           bias(std::vector<primitive_id>(0)) {}
 
@@ -283,6 +291,8 @@ struct deconvolution : public primitive_base<deconvolution> {
     tensor output_size;
     /// @brief Number of feature groups (grouped convolution). If more than 1 then weights/bias count needs to be 1.
     uint32_t groups;
+    /// @param grouped_weights_shape Defines if weights tensor has explicit group dimension.
+    bool grouped_weights_shape;
     /// @brief List of primitive ids containing weights data.
     const primitive_id_arr weights;
     /// @brief List of primitive ids containing bias data.

--- a/inference-engine/thirdparty/clDNN/api/tensor.hpp
+++ b/inference-engine/thirdparty/clDNN/api/tensor.hpp
@@ -615,13 +615,13 @@ public:
      *
      * @endcode
      */
-    tensor(value_type batch_num, value_type feature_num, value_type width, value_type height)
+    tensor(value_type batch_num, value_type feature_num, value_type x, value_type y)
         : tensor(1) {
         _sizes[0] = batch_num;
         _sizes[tensor_batch_dim_max] = feature_num;
-        _sizes[tensor_batch_dim_max + tensor_feature_dim_max] = width;
-        _sizes[tensor_batch_dim_max + tensor_feature_dim_max + 1] = height;
-        if (batch_num == 0 && feature_num == 0 && width == 0 && height == 0)
+        _sizes[tensor_batch_dim_max + tensor_feature_dim_max] = x;
+        _sizes[tensor_batch_dim_max + tensor_feature_dim_max + 1] = y;
+        if (batch_num == 0 && feature_num == 0 && x == 0 && y == 0)
             _sizes[tensor_batch_dim_max + tensor_feature_dim_max + 2] = 0;
     }
 
@@ -629,7 +629,7 @@ public:
     /// @details Example:
     /*! @code
     *
-    tensor my_tensor( 2, 3, 4, 5, 6 );   // b=2, f=3, x=4, y=5, z =6
+    tensor my_tensor( 2, 3, 4, 5, 6 );   // b=2, f=3, x=4, y=5, z=6
     cout << my_tensor.batch[0] << endl;           // 2
     cout << my_tensor.feature[0] << endl;         // 3
     cout << "x=" << my_tensor.spatial[0] << endl; // x=4
@@ -638,38 +638,37 @@ public:
     *
     * @endcode
     */
-    tensor(value_type batch_num, value_type feature_num, value_type width, value_type height, value_type depth)
+    tensor(value_type batch_num, value_type feature_num, value_type x, value_type y, value_type z)
         : tensor(1) {
         _sizes[0] = batch_num;
         _sizes[tensor_batch_dim_max] = feature_num;
-        _sizes[tensor_batch_dim_max + tensor_feature_dim_max] = width;
-        _sizes[tensor_batch_dim_max + tensor_feature_dim_max + 1] = height;
-        _sizes[tensor_batch_dim_max + tensor_feature_dim_max + 2] = depth;
+        _sizes[tensor_batch_dim_max + tensor_feature_dim_max] = x;
+        _sizes[tensor_batch_dim_max + tensor_feature_dim_max + 1] = y;
+        _sizes[tensor_batch_dim_max + tensor_feature_dim_max + 2] = z;
     }
 
     /// @brief Constructs @p tensor.
     /// @details Example:
     /*! @code
     *
-    tensor my_tensor( 2, 3, 4, 5, 6, 7 );   // b=2, f=3, x=4, y=5, lx= 6, ly =7
+    tensor my_tensor( 2, 3, 4, 5, 6, 7 );   // b=2, f=3, x=4, y=5, z=6, w=7
     cout << my_tensor.batch[0] << endl;           // 2
     cout << my_tensor.feature[0] << endl;         // 3
     cout << "x=" << my_tensor.spatial[0] << endl; // x=4
     cout << "y=" << my_tensor.spatial[1] << endl; // y=5
-    cout << "local x=" << my_tensor.local[0] << endl; // local x=6
-    cout << "loxal y=" << my_tensor.local[1] << endl; // local y=7
+    cout << "z=" << my_tensor.spatial[2] << endl; // z=6
+    cout << "w=" << my_tensor.spatial[3] << endl; // w=7
     *
     * @endcode
     */
-    tensor(value_type batch_num, value_type feature_num, value_type width,
-           value_type height, value_type local_x, value_type local_y)
+    tensor(value_type batch_num, value_type feature_num, value_type x, value_type y, value_type z, value_type w)
         : tensor(1) {
         _sizes[0] = batch_num;
         _sizes[tensor_batch_dim_max] = feature_num;
-        _sizes[tensor_batch_dim_max + tensor_feature_dim_max] = width;
-        _sizes[tensor_batch_dim_max + tensor_feature_dim_max + 1] = height;
-        _sizes[tensor_batch_dim_max + tensor_feature_dim_max + tensor_spatial_dim_max] = local_x;
-        _sizes[tensor_batch_dim_max + tensor_feature_dim_max + tensor_spatial_dim_max + 1] = local_y;
+        _sizes[tensor_batch_dim_max + tensor_feature_dim_max] = x;
+        _sizes[tensor_batch_dim_max + tensor_feature_dim_max + 1] = y;
+        _sizes[tensor_batch_dim_max + tensor_feature_dim_max + 2] = z;
+        _sizes[tensor_batch_dim_max + tensor_feature_dim_max + 3] = w;
     }
 
     /// @brief Constructs @p tensor using vector of sizes.

--- a/inference-engine/thirdparty/clDNN/kernel_selector/common/tensor_type.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/common/tensor_type.cpp
@@ -810,6 +810,11 @@ WeightsTensor WeightsTensor::TransformIgnorePadding(WeightsLayout l, WeightsType
         vec[Channelndex(l, WeightsChannelName::Z)] = 1;
         vec[Channelndex(l, WeightsChannelName::IFM)] = IFM().v;
         vec[Channelndex(l, WeightsChannelName::OFM)] = OFM().v;
+    } else if (g > 1 && src_channels == 5 && dst_channels == 4) {
+        vec[Channelndex(l, WeightsChannelName::X)] = X().v;
+        vec[Channelndex(l, WeightsChannelName::Y)] = Y().v;
+        vec[Channelndex(l, WeightsChannelName::IFM)] = Z().v;
+        vec[Channelndex(l, WeightsChannelName::OFM)] = OFM().v * IFM().v;
     } else {
         assert(0);
     }

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/quantize/quantize_kernel_ref.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/quantize/quantize_kernel_ref.cpp
@@ -54,7 +54,7 @@ CommonDispatchData QuantizeKernelRef::SetDefault(const quantize_params& params, 
     } else {
         dispatchData.gws[0] = output.Batch().v;
         dispatchData.gws[1] = params.packed_binary_output ? CeilDiv(output.Feature().v, 32) : output.Feature().v;
-        dispatchData.gws[2] = Align(output.X().v * output.Y().v * output.Z().v, 16);
+        dispatchData.gws[2] = Align(output.X().v * output.Y().v * output.Z().v * output.W().v, 16);
 
         dispatchData.lws[0] = 1;
         dispatchData.lws[1] = 1;

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/quantize/quantize_kernel_scale_shift_opt.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/quantize/quantize_kernel_scale_shift_opt.cpp
@@ -35,6 +35,7 @@ ParamsKey QuantizeKernelScaleShift::GetSupportedKey() const {
     k.EnableInputLayout(DataLayout::yxfb);
     k.EnableInputLayout(DataLayout::byxf);
     k.EnableInputLayout(DataLayout::bfzyx);
+    k.EnableInputLayout(DataLayout::bfwzyx);
     k.EnableInputLayout(DataLayout::b_fs_yx_fsv16);
     k.EnableInputLayout(DataLayout::b_fs_zyx_fsv16);
     k.EnableInputLayout(DataLayout::b_fs_yx_fsv4);
@@ -45,6 +46,7 @@ ParamsKey QuantizeKernelScaleShift::GetSupportedKey() const {
     k.EnableOutputLayout(DataLayout::bfyx);
     k.EnableOutputLayout(DataLayout::yxfb);
     k.EnableOutputLayout(DataLayout::bfzyx);
+    k.EnableOutputLayout(DataLayout::bfwzyx);
     k.EnableOutputLayout(DataLayout::b_fs_yx_fsv16);
     k.EnableOutputLayout(DataLayout::b_fs_zyx_fsv16);
     k.EnableOutputLayout(DataLayout::b_fs_yx_fsv4);

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/quantize_gpu_ref.cl
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/quantize_gpu_ref.cl
@@ -39,6 +39,12 @@ KERNEL(quantize_ref)(const __global INPUT0_TYPE* input,
     const int x = zyx % OUTPUT_SIZE_X;
     const int y = (zyx / OUTPUT_SIZE_X) % OUTPUT_SIZE_Y;
     const int z = (zyx / OUTPUT_SIZE_X) / OUTPUT_SIZE_Y;
+#elif OUTPUT_DIMS == 6
+    const int wzyx = get_global_id(2);
+    const int x = wzyx % OUTPUT_SIZE_X;
+    const int y = (wzyx / OUTPUT_SIZE_X) % OUTPUT_SIZE_Y;
+    const int z = ((wzyx / OUTPUT_SIZE_X) / OUTPUT_SIZE_Y) % OUTPUT_SIZE_Z;
+    const int w = ((wzyx / OUTPUT_SIZE_X) / OUTPUT_SIZE_Y) / OUTPUT_SIZE_Z;
 #endif
 
 #if PACKED_BINARY_OUTPUT
@@ -77,37 +83,49 @@ KERNEL(quantize_ref)(const __global INPUT0_TYPE* input,
 
 #else
 
-#if INPUT0_DIMS == 5
+#if INPUT0_DIMS == 6
+    const int input_offset = INPUT0_GET_INDEX(b, of, w, z, y, x);
+#elif INPUT0_DIMS == 5
     const int input_offset = INPUT0_GET_INDEX(b, of, z, y, x);
 #elif INPUT0_DIMS <= 4
     const int input_offset = INPUT0_GET_INDEX(b, of, y, x);
 #endif
 
-#if OUTPUT_DIMS == 5
+#if OUTPUT_DIMS == 6
+    const int output_offset = OUTPUT_GET_INDEX(b, of, w, z, y, x);
+#elif OUTPUT_DIMS == 5
     const int output_offset = OUTPUT_GET_INDEX(b, of, z, y, x);
 #elif OUTPUT_DIMS <= 4
     const int output_offset = OUTPUT_GET_INDEX(b, of, y, x);
 #endif
 
-#if INPUT1_DIMS == 5
+#if INPUT1_DIMS == 6
+    const int input_low_offset = INPUT1_GET_INDEX_SAFE(b, of, w, z, y, x);
+#elif INPUT1_DIMS == 5
     const int input_low_offset = INPUT1_GET_INDEX_SAFE(b, of, z, y, x);
 #elif INPUT1_DIMS <= 4
     const int input_low_offset = INPUT1_GET_INDEX_SAFE(b, of, y, x);
 #endif
 
-#if INPUT2_DIMS == 5
+#if INPUT2_DIMS == 6
+    const int input_high_offset = INPUT2_GET_INDEX_SAFE(b, of, w, z, y, x);
+#elif INPUT2_DIMS == 5
     const int input_high_offset = INPUT2_GET_INDEX_SAFE(b, of, z, y, x);
 #elif INPUT2_DIMS <= 4
     const int input_high_offset = INPUT2_GET_INDEX_SAFE(b, of, y, x);
 #endif
 
-#if INPUT3_DIMS == 5
+#if INPUT3_DIMS == 6
+    const int output_low_offset = INPUT3_GET_INDEX_SAFE(b, of, w, z, y, x);
+#elif INPUT3_DIMS == 5
     const int output_low_offset = INPUT3_GET_INDEX_SAFE(b, of, z, y, x);
 #elif INPUT3_DIMS <= 4
     const int output_low_offset = INPUT3_GET_INDEX_SAFE(b, of, y, x);
 #endif
 
-#if INPUT4_DIMS == 5
+#if INPUT4_DIMS == 6
+    const int output_high_offset = INPUT4_GET_INDEX_SAFE(b, of, w, z, y, x);
+#elif INPUT4_DIMS == 5
     const int output_high_offset = INPUT4_GET_INDEX_SAFE(b, of, z, y, x);
 #elif INPUT4_DIMS <= 4
     const int output_high_offset = INPUT4_GET_INDEX_SAFE(b, of, y, x);

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/quantize_gpu_scale_shift_opt.cl
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/quantize_gpu_scale_shift_opt.cl
@@ -43,14 +43,25 @@ KERNEL(quantize_gpu_scale_shift_opt)(const __global INPUT0_TYPE* input,
     const int x = zyx % OUTPUT_SIZE_X;
     const int y = (zyx / OUTPUT_SIZE_X) % OUTPUT_SIZE_Y;
     const int z = (zyx / OUTPUT_SIZE_X) / OUTPUT_SIZE_Y;
+#elif OUTPUT_DIMS == 6
+    const int wzyx = get_global_id(GWS_YX);
+    const int x = wzyx % OUTPUT_SIZE_X;
+    const int y = (wzyx / OUTPUT_SIZE_X) % OUTPUT_SIZE_Y;
+    const int z = ((wzyx / OUTPUT_SIZE_X) / OUTPUT_SIZE_Y) % OUTPUT_SIZE_Z;
+    const int w = ((wzyx / OUTPUT_SIZE_X) / OUTPUT_SIZE_Y) / OUTPUT_SIZE_Z;
 #endif
 
-#if INPUT0_DIMS == 5
+#if INPUT0_DIMS == 6
+    const int input_offset = INPUT0_GET_INDEX(b, of, w, z, y, x);
+#elif INPUT0_DIMS == 5
     const int input_offset = INPUT0_GET_INDEX(b, of, z, y, x);
 #elif INPUT0_DIMS <= 4
     const int input_offset = INPUT0_GET_INDEX(b, of, y, x);
 #endif
-#if OUTPUT_DIMS == 5
+
+#if OUTPUT_DIMS == 6
+    const int output_offset = OUTPUT_GET_INDEX(b, of, w, z, y, x);
+#elif OUTPUT_DIMS == 5
     const int output_offset = OUTPUT_GET_INDEX(b, of, z, y, x);
 #elif OUTPUT_DIMS <= 4
     const int output_offset = OUTPUT_GET_INDEX(b, of, y, x);
@@ -61,6 +72,8 @@ KERNEL(quantize_gpu_scale_shift_opt)(const __global INPUT0_TYPE* input,
     const int in_range_offset = INPUT1_GET_INDEX_SAFE(b, of, y, x);
 #elif INPUT1_DIMS == 5
     const int in_range_offset = INPUT1_GET_INDEX_SAFE(b, of, z, y, x);
+#elif INPUT1_DIMS == 6
+    const int in_range_offset = INPUT1_GET_INDEX_SAFE(b, of, w, z, y, x);
 #endif
 #endif
 
@@ -68,6 +81,8 @@ KERNEL(quantize_gpu_scale_shift_opt)(const __global INPUT0_TYPE* input,
     const int scales_offset = INPUT7_GET_INDEX_SAFE(b, of, y, x);
 #elif INPUT7_DIMS == 5
     const int scales_offset = INPUT7_GET_INDEX_SAFE(b, of, z, y, x);
+#elif INPUT7_DIMS == 6
+    const int scales_offset = INPUT7_GET_INDEX_SAFE(b, of, w, z, y, x);
 #endif
 
 #if PER_TENSOR_INPUT_SCALE

--- a/inference-engine/thirdparty/clDNN/src/gpu/convolution_gpu.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/convolution_gpu.cpp
@@ -88,10 +88,8 @@ public:
         const auto& deformable_groups = primitive->deformable_groups;
         const auto transposed = arg.get_transposed();
 
-        assert(arg.get_output_layout().size.feature[0] == weights_layout.size.batch[0] * weights_layout.size.group[0]);
-
         auto conv_params = get_weight_bias_zero_point_default_params<kernel_selector::convolution_params>(
-            arg, split, 1);
+            arg, split, 1, primitive->grouped_weights_shape);
         auto conv_optional_params =
             get_default_weights_bias_optional_params<kernel_selector::convolution_optional_params>(arg.get_program());
 

--- a/inference-engine/thirdparty/clDNN/src/gpu/deconvolution_gpu.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/deconvolution_gpu.cpp
@@ -81,7 +81,8 @@ public:
         auto deconv_params = get_weights_bias_default_params<kernel_selector::deconvolution_params>(
             arg,
             (groups > 1) ? 1 : actual_split,
-            1);
+            1,
+            primitive->grouped_weights_shape);
         auto deconv_optional_params =
             get_default_weights_bias_optional_params<kernel_selector::deconvolution_optional_params>(arg.get_program());
 

--- a/inference-engine/thirdparty/clDNN/src/gpu/quantize_gpu.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/quantize_gpu.cpp
@@ -164,6 +164,12 @@ attach_quantize_gpu::attach_quantize_gpu() {
     implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::u8, format::bfzyx), val_fw);
     implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::i8, format::bfzyx), val_fw);
 
+    implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::f32, format::bfwzyx), val_fw);
+    implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::f16, format::bfwzyx), val_fw);
+    implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::i32, format::bfwzyx), val_fw);
+    implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::u8, format::bfwzyx), val_fw);
+    implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::i8, format::bfwzyx), val_fw);
+
     implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::f32, format::b_fs_zyx_fsv16), val_fw);
     implementation_map<quantize>::add(std::make_tuple(engine_types::ocl, data_types::f16, format::b_fs_zyx_fsv16), val_fw);
 

--- a/inference-engine/thirdparty/clDNN/src/graph_optimizer/pre_replace_deconv.cpp
+++ b/inference-engine/thirdparty/clDNN/src/graph_optimizer/pre_replace_deconv.cpp
@@ -90,6 +90,7 @@ void pre_replace_deconv::run(program_impl& p) {
                     bias_vec.push_back(bias_id);
                 auto input_offset = deconv_prim->input_offset;
                 auto output_padding = deconv_prim->output_padding;
+                auto grouped_weights_shape = deconv_prim->grouped_weights_shape;
 
                 // remove deconvolution node and its connections to weights and biases, rename it and move to the optimized
                 // list
@@ -136,6 +137,7 @@ void pre_replace_deconv::run(program_impl& p) {
                                                                    stride,
                                                                    input_offset,
                                                                    tensor{ 1, 1, 1, 1 },
+                                                                   grouped_weights_shape,
                                                                    output_padding);
                     p.get_or_create(conv_prim);
                 } else {
@@ -146,6 +148,7 @@ void pre_replace_deconv::run(program_impl& p) {
                                                                    stride,
                                                                    input_offset,
                                                                    tensor{ 1, 1, 1, 1 },
+                                                                   grouped_weights_shape,
                                                                    output_padding);
                     p.get_or_create(conv_prim);
                 }
@@ -231,6 +234,7 @@ void pre_replace_deconv::run(program_impl& p) {
                 tensor stride = { 1, 1, 1, 1 };
                 tensor input_offset = { 0, 0, -scale_factor, -scale_factor };
                 auto output_padding = deconv_prim->output_padding;
+                auto grouped_weights_shape = deconv_prim->grouped_weights_shape;
 
                 // remove deconvolution node and its connections to weights and biases,
                 // rename it and move to the optimized list
@@ -309,6 +313,7 @@ void pre_replace_deconv::run(program_impl& p) {
                     stride,
                     input_offset,
                     tensor{ 1, 1, 1, 1 },
+                    grouped_weights_shape,
                     output_padding);
                 p.get_or_create(conv_prim);
 

--- a/inference-engine/thirdparty/clDNN/src/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/inference-engine/thirdparty/clDNN/src/graph_optimizer/prepare_primitive_fusing.cpp
@@ -312,7 +312,8 @@ void prepare_primitive_fusing::fuse_bias(program_impl &p) {
                                                                      desc->input_offset,
                                                                      desc->dilation,
                                                                      conv.get_output_layout().size,
-                                                                     conv.get_output_layout().data_type);
+                                                                     conv.get_output_layout().data_type,
+                                                                     desc->grouped_weights_shape);
 
             conv_with_bias_prim->activations_zero_points = desc->activations_zero_points;
             conv_with_bias_prim->weights_zero_points = desc->weights_zero_points;
@@ -334,7 +335,8 @@ void prepare_primitive_fusing::fuse_bias(program_impl &p) {
                                                                          desc->groups,
                                                                          desc->stride,
                                                                          desc->input_offset,
-                                                                         deconv.get_output_layout().size);
+                                                                         deconv.get_output_layout().size,
+                                                                         desc->grouped_weights_shape);
 
             auto& new_deconv_node = p.get_or_create(deconv_with_bias_prim);
             fuse_bias_f(deconv, new_deconv_node, bias_node, eltw_node);

--- a/inference-engine/thirdparty/clDNN/src/graph_optimizer/prepare_quantization.cpp
+++ b/inference-engine/thirdparty/clDNN/src/graph_optimizer/prepare_quantization.cpp
@@ -658,6 +658,7 @@ void prepare_quantization::prepare_asymmetric_quantization(program_impl &p) {
                         old_conv_prim->input_offset,
                         old_conv_prim->dilation,
                         output_size,
+                        old_conv_prim->grouped_weights_shape,
                         old_conv_prim->output_padding);
 
             auto& new_conv_node = p.get_or_create(new_conv_prim);

--- a/inference-engine/thirdparty/clDNN/src/include/kernel_selector_helper.h
+++ b/inference-engine/thirdparty/clDNN/src/include/kernel_selector_helper.h
@@ -106,11 +106,11 @@ kernel_selector::weights_type to_weights_type(data_types dt);
 data_types from_weights_type(kernel_selector::weights_type dt);
 kernel_selector::data_layout to_data_layout(format f);
 cldnn::format from_data_layout(kernel_selector::data_layout l);
-kernel_selector::weights_layout to_weights_layout(format f);
+kernel_selector::weights_layout to_weights_layout(format f, bool is_grouped);
 cldnn::format::type from_weights_layout(kernel_selector::weights_layout l);
 kernel_selector::tuning_mode to_tuning_mode(cldnn::tuning_mode mode);
 kernel_selector::data_tensor convert_data_tensor(const layout& l, uint32_t split = 1, const tensor view_offset = tensor {});
-kernel_selector::weights_tensor convert_weights_tensor(const layout& l);
+kernel_selector::weights_tensor convert_weights_tensor(const layout& l, bool is_grouped = false);
 layout from_weights_tensor(const kernel_selector::weights_tensor& t);
 kernel_selector::activation_function get_kernel_selector_activation_param(activation_func activation_func);
 
@@ -192,10 +192,10 @@ inline params_t get_default_params(const arg_t& arg, uint32_t split = 1) {
 }
 
 template <typename params_t, typename arg_t>
-inline params_t get_weights_bias_default_params(const arg_t& arg, uint32_t split = 1, uint32_t groups = 1) {
+inline params_t get_weights_bias_default_params(const arg_t& arg, uint32_t split = 1, uint32_t groups = 1, bool has_group_dimension = false) {
     params_t params = get_default_params<params_t>(arg, split);
     const auto& weights_layout = arg.weights().get_output_layout();
-    params.weights = convert_weights_tensor(weights_layout);
+    params.weights = convert_weights_tensor(weights_layout, has_group_dimension);
 
     if (arg.bias_term()) {
         auto bias_layout = arg.bias().get_output_layout();
@@ -210,8 +210,8 @@ inline params_t get_weights_bias_default_params(const arg_t& arg, uint32_t split
 }
 
 template <typename params_t, typename arg_t>
-params_t get_weight_bias_zero_point_default_params(const arg_t& arg, uint32_t split = 1, uint32_t groups = 1) {
-    params_t params = get_weights_bias_default_params<params_t>(arg, split, groups);
+params_t get_weight_bias_zero_point_default_params(const arg_t& arg, uint32_t split = 1, uint32_t groups = 1, bool has_group_dimension = false) {
+    params_t params = get_weights_bias_default_params<params_t>(arg, split, groups, has_group_dimension);
 
     if (arg.weights_zero_points_term()) {
         params.weights_zero_points.push_back(

--- a/inference-engine/thirdparty/clDNN/tests/test_cases/convolution_gpu_test.cpp
+++ b/inference-engine/thirdparty/clDNN/tests/test_cases/convolution_gpu_test.cpp
@@ -1132,7 +1132,7 @@ TEST(convolution_f32_fw_gpu, basic_convolution3D_split2) {
         input_layout("input", input.get_layout()),
         data("weights_1", weights_1),
         data("biases_1", biases_1),
-        convolution("conv", "input", { "weights_1" }, { "biases_1" }, 2, tensor(1), tensor(0), tensor(1), tensor{1, 2, 3, 3, 3}, data_types::f32));
+        convolution("conv", "input", { "weights_1" }, { "biases_1" }, 2, tensor(1), tensor(0), tensor(1), tensor{1, 2, 3, 3, 3}, data_types::f32, true));
 
     network network(engine, topology);
     network.set_input_data("input", input);
@@ -4295,7 +4295,7 @@ TEST(convolution_int8_fw_gpu, quantized_convolution_u8s8f32_asymmetric_weight_an
         data("a_zp", a_zp),
         data("w_zp", w_zp),
         convolution("conv", "input", { "weights" }, { "biases" }, { "w_zp" }, { "a_zp" }, 1, data_types::f32,
-                    tensor{ 0, 0, 2, 2 }, tensor(0), tensor{1, 1, 1, 1}, tensor{1, 2, 3, 2}),
+                    tensor{ 0, 0, 2, 2 }, tensor(0), tensor{1, 1, 1, 1}, tensor{1, 2, 3, 2}, false),
         reorder("out", "conv", format::bfyx, data_types::f32));
 
     build_options opts;
@@ -4366,7 +4366,7 @@ TEST(convolution_int8_fw_gpu, quantized_convolution_u8s8f32_asymmetric_activatio
         data("biases", biases),
         data("a_zp", a_zp),
         convolution("conv", "input", { "weights" }, { "biases" }, { }, { "a_zp" }, 1, data_types::f32,
-                    tensor{ 0, 0, 2, 2 }, tensor(0), tensor{1, 1, 1, 1}, tensor{1, 2, 3, 2}),
+                    tensor{ 0, 0, 2, 2 }, tensor(0), tensor{1, 1, 1, 1}, tensor{1, 2, 3, 2}, false),
         reorder("out", "conv", format::bfyx, data_types::f32));
 
     build_options opts;
@@ -4451,7 +4451,7 @@ TEST(convolution_int8_fw_gpu, quantized_convolution_u8s8f32_asymmetric_activatio
         data("biases", biases),
         data("a_zp", a_zp),
         convolution("conv", "input", { "weights" }, { "biases" }, { }, { "a_zp" }, 1, data_types::f32,
-                    tensor{ 0, 0, 2, 2 }, tensor(0), tensor{1, 1, 1, 1}, tensor{1, 2, 3, 2}),
+                    tensor{ 0, 0, 2, 2 }, tensor(0), tensor{1, 1, 1, 1}, tensor{1, 2, 3, 2}, false),
         reorder("out", "conv", format::bfyx, data_types::f32));
 
     build_options opts;
@@ -4552,7 +4552,7 @@ TEST(convolution_int8_fw_gpu, quantized_convolution_u8s8f32_asymmetric_activatio
         activation("activation", "input", activation_func::relu),  // needed just to add padding
         eltwise("in", {"activation", "a_zp"}, eltwise_mode::sub, data_types::f32),
         convolution("conv", "in", { "weights" }, { "biases" }, 1,
-                    tensor{ 0, 0, 2, 2 }, tensor(0), tensor{1, 1, 1, 1}, tensor{1, 2, 3, 2}, data_types::f32),
+                    tensor{ 0, 0, 2, 2 }, tensor(0), tensor{1, 1, 1, 1}, tensor{1, 2, 3, 2}, data_types::f32, false),
         reorder("out", "conv", format::bfyx, data_types::f32));
 
     build_options opts;
@@ -4623,7 +4623,7 @@ TEST(convolution_int8_fw_gpu, quantized_convolution_u8s8f32_asymmetric_weights_p
         data("biases", biases),
         data("w_zp", w_zp),
         convolution("conv", "input", { "weights" }, { "biases" }, { "w_zp" }, { }, 1, data_types::f32,
-                    tensor{ 0, 0, 2, 2 }, tensor(0), tensor{1, 1, 1, 1}, tensor{1, 2, 3, 2}),
+                    tensor{ 0, 0, 2, 2 }, tensor(0), tensor{1, 1, 1, 1}, tensor{1, 2, 3, 2}, false),
         reorder("out", "conv", format::bfyx, data_types::f32));
 
     build_options opts;
@@ -7018,7 +7018,7 @@ TEST(convolution_depthwise_gpu_fsv16, depthwise_conv_b_fs_yx_fsv16_in_feature_pa
         reorder("input_reordered", "input", reordered_input_layout),
         data("weights", weights),
         data("bias", bias),
-        convolution("conv", "input_reordered", { "weights" }, { "bias" }, num_groups, stride, input_offset, dilation, output_size, data_types::f32),
+        convolution("conv", "input_reordered", { "weights" }, { "bias" }, num_groups, stride, input_offset, dilation, output_size, data_types::f32, true),
         reorder("out", "conv", format::bfyx, data_types::f32));
 
     build_options options;
@@ -7440,7 +7440,8 @@ TEST_P(convolution_grouped_gpu, base) {
                                   stride_tensor,
                                   tensor(batch(0), feature(0), spatial(-input_offset_x, -input_offset_y, -input_offset_z, 0)),
                                   tensor(batch(1), feature(1), spatial(1, 1, 1, 1)),
-                                  ref_conv_out_size),
+                                  ref_conv_out_size,
+                                  true),
                       reorder("out", "conv", {data_types::f32, format::bfzyx, ref_conv_out_size}));
 
     if (has_input_zp)

--- a/inference-engine/thirdparty/clDNN/tests/test_cases/fusings_gpu_test.cpp
+++ b/inference-engine/thirdparty/clDNN/tests/test_cases/fusings_gpu_test.cpp
@@ -512,9 +512,9 @@ public:
 #define CASE_CONV_FP32_8 {1, 32, 4, 5, 4}, {1, 16, 2, 3, 2}, {1, 1, 3, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 2, data_types::f32, format::b_fs_zyx_fsv16, data_types::f32, format::g_os_is_zyx_isv16_osv16, data_types::f32, format::bfzyx
 #define CASE_CONV_FP32_9 {1, 32, 4, 5, 4}, {1, 32, 2, 3, 2}, {1, 1, 3, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 2, data_types::f32, format::b_fs_zyx_fsv16, data_types::f32, format::g_os_is_zyx_isv16_osv16, data_types::f32, format::bfzyx
 #define CASE_CONV_FP32_10 {32, 16, 4, 5, 4}, {32, 32, 4, 5, 4}, {1, 1, 1, 1, 1}, tensor{1}, tensor{0}, tensor{1}, 1, data_types::f32, format::bs_fs_zyx_bsv16_fsv16, data_types::f32, format::bfzyx, data_types::f32, format::bfzyx
-#define CASE_CONV_FP32_11 {1, 32, 4, 5, 4}, {1, 16, 2, 3, 2}, {1, 1, 3, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 2, data_types::f32, format::b_fs_zyx_fsv16, data_types::f32, format::os_is_zyx_isv16_osv16, data_types::f32, format::bfzyx
-#define CASE_CONV_FP32_12 {1, 16, 4, 5, 4}, {1, 16, 2, 3, 2}, {1, 1, 3, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 2, data_types::f32, format::b_fs_zyx_fsv16, data_types::f32, format::os_is_zyx_isv16_osv16, data_types::f32, format::bfzyx
-#define CASE_CONV_FP32_13 {1, 16, 18, 5, 4}, {1, 16, 16, 3, 2}, {1, 1, 3, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 2, data_types::f32, format::b_fs_zyx_fsv16, data_types::f32, format::os_is_zyx_isv16_osv16, data_types::f32, format::bfzyx
+#define CASE_CONV_FP32_11 {1, 32, 4, 5, 4}, {1, 16, 2, 3, 2}, {1, 1, 3, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 2, data_types::f32, format::b_fs_zyx_fsv16, data_types::f32, format::g_os_is_zyx_isv16_osv16, data_types::f32, format::bfzyx
+#define CASE_CONV_FP32_12 {1, 16, 4, 5, 4}, {1, 16, 2, 3, 2}, {1, 1, 3, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 2, data_types::f32, format::b_fs_zyx_fsv16, data_types::f32, format::g_os_is_zyx_isv16_osv16, data_types::f32, format::bfzyx
+#define CASE_CONV_FP32_13 {1, 16, 18, 5, 4}, {1, 16, 16, 3, 2}, {1, 1, 3, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 2, data_types::f32, format::b_fs_zyx_fsv16, data_types::f32, format::g_os_is_zyx_isv16_osv16, data_types::f32, format::bfzyx
 #define CASE_CONV_FP32_14 {1, 3, 4, 5}, {1, 30, 2, 3}, {1, 1, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 1, data_types::f32, format::bfyx, data_types::f32, format::bfyx, data_types::f32, format::bfyx
 
 #define CASE_CONV_FP16_1 {1, 15, 4, 5}, {1, 30, 2, 3}, {1, 1, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 1, data_types::f16, format::bfyx, data_types::f16, format::bfyx, data_types::f16, format::bfyx
@@ -527,8 +527,8 @@ public:
 #define CASE_CONV_FP16_8 {1, 32, 4, 5, 4}, {1, 16, 2, 3, 2}, {1, 1, 3, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 2, data_types::f16, format::b_fs_zyx_fsv16, data_types::f16, format::g_os_is_zyx_isv16_osv16, data_types::f16, format::bfzyx
 #define CASE_CONV_FP16_9 {1, 32, 4, 5, 4}, {1, 32, 2, 3, 2}, {1, 1, 3, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 2, data_types::f16, format::b_fs_zyx_fsv16, data_types::f16, format::g_os_is_zyx_isv16_osv16, data_types::f16, format::bfzyx
 #define CASE_CONV_FP16_10 {32, 16, 4, 5, 4}, {32, 32, 2, 3, 2}, {1, 1, 3, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 1, data_types::f16, format::bs_fs_zyx_bsv16_fsv16, data_types::f16, format::bfzyx, data_types::f16, format::bfzyx
-#define CASE_CONV_FP16_11 {1, 32, 4, 5, 4}, {1, 16, 2, 3, 2}, {1, 1, 3, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 2, data_types::f16, format::b_fs_zyx_fsv16, data_types::f16, format::os_is_zyx_isv16_osv16, data_types::f16, format::bfzyx
-#define CASE_CONV_FP16_12 {1, 16, 4, 5, 4}, {1, 16, 2, 3, 2}, {1, 1, 3, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 2, data_types::f16, format::b_fs_zyx_fsv16, data_types::f16, format::os_is_zyx_isv16_osv16, data_types::f16, format::bfzyx
+#define CASE_CONV_FP16_11 {1, 32, 4, 5, 4}, {1, 16, 2, 3, 2}, {1, 1, 3, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 2, data_types::f16, format::b_fs_zyx_fsv16, data_types::f16, format::g_os_is_zyx_isv16_osv16, data_types::f16, format::bfzyx
+#define CASE_CONV_FP16_12 {1, 16, 4, 5, 4}, {1, 16, 2, 3, 2}, {1, 1, 3, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 2, data_types::f16, format::b_fs_zyx_fsv16, data_types::f16, format::g_os_is_zyx_isv16_osv16, data_types::f16, format::bfzyx
 #define CASE_CONV_FP16_13 {16, 32, 4, 5}, {16, 64, 2, 3}, {1, 1, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 1, data_types::f16, format::fs_b_yx_fsv32, data_types::f16, format::bfyx, data_types::f16, format::bfyx
 
 #define CASE_CONV_U8S8_1 {1, 15, 4, 5}, {1, 30, 2, 3}, {1, 1, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 1, data_types::u8, format::bfyx, data_types::i8, format::bfyx, data_types::f32, format::bfyx
@@ -571,10 +571,10 @@ public:
 #define CASE_CONV_ELTW_FP32_2 {1, 16, 4, 5}, {1, 32, 2, 3}, {1, 1, 1, 1}, {1, 1, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 1, data_types::f32, format::b_fs_yx_fsv16, data_types::f32, format::os_is_yx_isv16_osv16, data_types::f32, format::bfyx
 #define CASE_CONV_ELTW_FP32_3 {1, 16, 4, 5}, {1, 32, 4, 5}, {1, 32, 4, 5}, {1, 1, 1, 1}, tensor{1}, tensor{0}, tensor{1}, 1, data_types::f32, format::b_fs_yx_fsv16, data_types::f32, format::os_is_yx_isv16_osv16, data_types::f32, format::bfyx
 #define CASE_CONV_ELTW_FP32_4 {1, 32, 4, 5}, {1, 32, 4, 5}, {1, 32, 1, 1}, {1, 1, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 32, data_types::f32, format::b_fs_yx_fsv16, data_types::f32,  format::gs_oiyx_gsv16, data_types::f32, format::bfyx
-#define CASE_CONV_ELTW_FP32_5 {1, 32, 4, 5, 4}, {1, 32, 2, 3, 2}, {1, 32, 2, 1, 1}, {1, 1, 3, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 2, data_types::f32, format::b_fs_zyx_fsv16, data_types::f32, format::os_is_zyx_isv16_osv16, data_types::f32, format::bfzyx
-#define CASE_CONV_ELTW_FP32_6 {1, 32, 4, 5, 4}, {1, 16, 2, 3, 2}, {1, 16, 2, 1, 1}, {1, 1, 3, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 2, data_types::f32, format::b_fs_zyx_fsv16, data_types::f32, format::os_is_zyx_isv16_osv16, data_types::f32, format::bfzyx
+#define CASE_CONV_ELTW_FP32_5 {1, 32, 4, 5, 4}, {1, 32, 2, 3, 2}, {1, 32, 2, 1, 1}, {1, 1, 3, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 2, data_types::f32, format::b_fs_zyx_fsv16, data_types::f32, format::g_os_is_zyx_isv16_osv16, data_types::f32, format::bfzyx
+#define CASE_CONV_ELTW_FP32_6 {1, 32, 4, 5, 4}, {1, 16, 2, 3, 2}, {1, 16, 2, 1, 1}, {1, 1, 3, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 2, data_types::f32, format::b_fs_zyx_fsv16, data_types::f32, format::g_os_is_zyx_isv16_osv16, data_types::f32, format::bfzyx
 #define CASE_CONV_ELTW_FP32_7 {1, 16, 3, 5}, {1, 32, 1, 3}, {1, 32, 3, 1}, {1, 1, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 1, data_types::f32, format::b_fs_yx_fsv16, data_types::f32, format::os_is_yx_isv16_osv16, data_types::f32, format::bfyx
-#define CASE_CONV_ELTW_FP32_8 {1, 32, 3, 5, 4}, {1, 16, 1, 3, 2}, {1, 1, 2, 1, 1}, {1, 1, 3, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 2, data_types::f32, format::b_fs_zyx_fsv16, data_types::f32, format::os_is_zyx_isv16_osv16, data_types::f32, format::bfzyx
+#define CASE_CONV_ELTW_FP32_8 {1, 32, 3, 5, 4}, {1, 16, 1, 3, 2}, {1, 1, 2, 1, 1}, {1, 1, 3, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 2, data_types::f32, format::b_fs_zyx_fsv16, data_types::f32, format::g_os_is_zyx_isv16_osv16, data_types::f32, format::bfzyx
 
 #define CASE_CONV_ELTW_i8_1 {1, 16, 3, 5}, {1, 32, 1, 3}, {1, 32, 3, 1}, {1, 1, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 1, data_types::i8, format::b_fs_yx_fsv16, data_types::i8, format::os_is_yx_osv16_isv16, data_types::f32, format::bfyx
 #define CASE_CONV_ELTW_i8_2 {1, 16, 3, 5, 3}, {1, 32, 2, 4, 2}, {1, 1, 2, 4, 2}, {1, 1, 2, 2, 2}, tensor{1}, tensor{0}, tensor{1}, 1, data_types::i8, format::bfzyx, data_types::i8, format::oiyx, data_types::f32, format::bfzyx
@@ -2214,7 +2214,7 @@ TEST_P(conv_int8_asymmetric_weights, basic) {
                  data("bias", get_mem(get_bias_layout(p))),
                  data("w_zp", get_mem(get_weights_zp_layout(p), 1, 127)),
                  eltwise("w_sub", {"weights", "w_zp"}, eltwise_mode::sub, data_types::f32),
-                 convolution("conv_prim", "input", {"w_sub"}, {"bias"}, p.groups, p.stride, p.pad, p.dilation, p.out_shape, data_types::f32),
+                 convolution("conv_prim", "input", {"w_sub"}, {"bias"}, p.groups, p.stride, p.pad, p.dilation, p.out_shape, data_types::f32, false),
                  reorder("reorder_bfyx", "conv_prim", p.default_format, data_types::f32)
     );
     tolerance = 1.f;
@@ -2281,7 +2281,7 @@ TEST_P(conv_int8_asymmetric_data, basic) {
                  data("bias", get_mem(get_bias_layout(p))),
                  data("a_zp", get_mem(get_activations_zp_layout(p), 1, 127)),
                  eltwise("a_sub", {"input", "a_zp"}, eltwise_mode::sub, data_types::f32),
-                 convolution("conv_prim", "a_sub", {"weights"}, {"bias"}, p.groups, p.stride, p.pad, p.dilation, p.out_shape, data_types::f32),
+                 convolution("conv_prim", "a_sub", {"weights"}, {"bias"}, p.groups, p.stride, p.pad, p.dilation, p.out_shape, data_types::f32, false),
                  reorder("reorder_bfyx", "conv_prim", p.default_format, data_types::f32)
     );
     tolerance = 1.f;
@@ -2352,7 +2352,7 @@ TEST_P(conv_int8_asymmetric_data_and_weights, basic) {
                  data("w_zp", get_mem(get_weights_zp_layout(p), 1, 127)),
                  eltwise("a_sub", {"input", "a_zp"}, eltwise_mode::sub, data_types::f32),
                  eltwise("w_sub", {"weights", "w_zp"}, eltwise_mode::sub, data_types::f32),
-                 convolution("conv_prim", "a_sub", {"w_sub"}, {"bias"}, p.groups, p.stride, p.pad, p.dilation, p.out_shape, data_types::f32),
+                 convolution("conv_prim", "a_sub", {"w_sub"}, {"bias"}, p.groups, p.stride, p.pad, p.dilation, p.out_shape, data_types::f32, false),
                  reorder("reorder_bfyx", "conv_prim", p.default_format, data_types::f32)
     );
     tolerance = 1.f;
@@ -3980,7 +3980,7 @@ using deconv_test_params = bc_test_params;
 #define CASE_DECONV_S8S8_1 {1, 15, 4, 5}, {1, 30, 6, 7}, {1, 1, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 1, data_types::i8, format::bfyx, data_types::i8, format::oiyx, data_types::f32, format::bfyx
 #define CASE_DECONV_S8S8_2 {1, 16, 4, 5}, {1, 32, 6, 7}, {1, 1, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 1, data_types::i8, format::b_fs_yx_fsv16, data_types::i8, format::oiyx, data_types::f32, format::bfyx
 #define CASE_DECONV_S8S8_3 {1, 16, 4, 5}, {1, 32, 4, 5}, {1, 1, 1, 1}, tensor{1}, tensor{0}, tensor{1}, 1, data_types::i8, format::b_fs_yx_fsv16, data_types::i8, format::oiyx, data_types::f32, format::bfyx
-#define CASE_DECONV_S8S8_4 {1, 32, 4, 5}, {1, 32, 4, 5}, {1, 1, 3, 3}, tensor{1}, tensor{0, 0, -1, -1, 0, 0}, tensor{1}, 32, data_types::i8, format::b_fs_yx_fsv16, data_types::i8,  format::goiyx, data_types::f32, format::bfyx
+#define CASE_DECONV_S8S8_4 {1, 32, 4, 5}, {1, 32, 4, 5}, {1, 1, 3, 3}, tensor{1}, tensor{0, 0, -1, -1}, tensor{1}, 32, data_types::i8, format::b_fs_yx_fsv16, data_types::i8,  format::goiyx, data_types::f32, format::bfyx
 #define CASE_DECONV_S8S8_5 {1, 15, 4, 5}, {1, 30, 9, 11}, {1, 1, 3, 3}, tensor{1, 1, 2, 2}, tensor{0}, tensor{1}, 1, data_types::i8, format::bfyx, data_types::i8, format::oiyx, data_types::f32, format::bfyx
 #define CASE_DECONV_S8S8_6 {1, 16, 4, 5}, {1, 32, 9, 11}, {1, 1, 3, 3}, tensor{1, 1, 2, 2}, tensor{0}, tensor{1}, 1, data_types::i8, format::b_fs_yx_fsv16, data_types::i8, format::oiyx, data_types::f32, format::bfyx
 #define CASE_DECONV_S8S8_7 {1, 16, 4, 5}, {1, 32, 7, 9}, {1, 1, 1, 1}, tensor{1, 1, 2, 2}, tensor{0}, tensor{1}, 1, data_types::i8, format::b_fs_yx_fsv16, data_types::i8, format::oiyx, data_types::f32, format::bfyx
@@ -3989,7 +3989,7 @@ using deconv_test_params = bc_test_params;
 #define CASE_DECONV_U8S8_1 {1, 15, 4, 5}, {1, 30, 6, 7}, {1, 1, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 1, data_types::u8, format::bfyx, data_types::i8, format::oiyx, data_types::f32, format::bfyx
 #define CASE_DECONV_U8S8_2 {1, 16, 4, 5}, {1, 32, 6, 7}, {1, 1, 3, 3}, tensor{1}, tensor{0}, tensor{1}, 1, data_types::u8, format::b_fs_yx_fsv16, data_types::i8, format::oiyx, data_types::f32, format::bfyx
 #define CASE_DECONV_U8S8_3 {1, 16, 4, 5}, {1, 32, 4, 5}, {1, 1, 1, 1}, tensor{1}, tensor{0}, tensor{1}, 1, data_types::u8, format::b_fs_yx_fsv16, data_types::i8, format::oiyx, data_types::f32, format::bfyx
-#define CASE_DECONV_U8S8_4 {1, 32, 4, 5}, {1, 32, 4, 5}, {1, 1, 3, 3}, tensor{1}, tensor{0, 0, -1, -1, 0, 0}, tensor{1}, 32, data_types::u8, format::b_fs_yx_fsv16, data_types::i8,  format::goiyx, data_types::f32, format::bfyx
+#define CASE_DECONV_U8S8_4 {1, 32, 4, 5}, {1, 32, 4, 5}, {1, 1, 3, 3}, tensor{1}, tensor{0, 0, -1, -1}, tensor{1}, 32, data_types::u8, format::b_fs_yx_fsv16, data_types::i8,  format::goiyx, data_types::f32, format::bfyx
 #define CASE_DECONV_U8S8_5 {1, 15, 4, 5}, {1, 30, 9, 11}, {1, 1, 3, 3}, tensor{1, 1, 2, 2}, tensor{0}, tensor{1}, 1, data_types::u8, format::bfyx, data_types::i8, format::oiyx, data_types::f32, format::bfyx
 #define CASE_DECONV_U8S8_6 {1, 16, 4, 5}, {1, 32, 9, 11}, {1, 1, 3, 3}, tensor{1, 1, 2, 2}, tensor{0}, tensor{1}, 1, data_types::u8, format::b_fs_yx_fsv16, data_types::i8, format::oiyx, data_types::f32, format::bfyx
 #define CASE_DECONV_U8S8_7 {1, 16, 4, 5}, {1, 32, 7, 9}, {1, 1, 1, 1}, tensor{1, 1, 2, 2}, tensor{0}, tensor{1}, 1, data_types::u8, format::b_fs_yx_fsv16, data_types::i8, format::oiyx, data_types::f32, format::bfyx


### PR DESCRIPTION
Before this patch constant with weights could be not detected if it wasn't directly connected to Conv/Deconv layer.
Now weights always uses common data format (bfzyx) in the plugin which is converted into weights format later (goiyx, oiyx, etc), so weights sub-graph can now contain anything
Also fixed weights transpose for deconv and added 6d quantize support to handle FQ on weights with bfwzyx == goizyx layout