### PR TITLE
Fixed warnings generation for ngraph API

### DIFF
--- a/inference-engine/ie_bridges/c/tests/test_model_repo.hpp
+++ b/inference-engine/ie_bridges/c/tests/test_model_repo.hpp
@@ -44,7 +44,7 @@ std::string generate_model_path(std::string dir, std::string filename) {
 }
 
 std::string generate_image_path(std::string dir, std::string filename) {
-    return get_data_path() + kPathSeparator +"validation_set" + kPathSeparator + dir + kPathSeparator + filename;
+    return get_data_path() + kPathSeparator + "validation_set" + kPathSeparator + dir + kPathSeparator + filename;
 }
 
 std::string generate_ieclass_xml_path(std::string filename) {

--- a/inference-engine/src/legacy_api/include/legacy/transformations/convert_opset1_to_legacy/convert_mul_or_add_finally.hpp
+++ b/inference-engine/src/legacy_api/include/legacy/transformations/convert_opset1_to_legacy/convert_mul_or_add_finally.hpp
@@ -299,5 +299,7 @@ void ngraph::pass::ConvertMulOrAddFinally::convert_mul_or_add_finally() {
     auto lin_op = std::make_shared<T>(data_batch_1, data_batch_2);
 
     auto m = std::make_shared<ngraph::pattern::Matcher>(lin_op);
+    NGRAPH_SUPPRESS_DEPRECATED_START
     this->add_matcher(m, get_callback<T>(), PassProperty::CHANGE_DYNAMIC_STATE);
+    NGRAPH_SUPPRESS_DEPRECATED_END
 }

--- a/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/convert_mul_add_to_scaleshift_or_power.cpp
+++ b/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/convert_mul_add_to_scaleshift_or_power.cpp
@@ -210,5 +210,7 @@ void ngraph::pass::ConvertMulAddToScaleShiftOrPower::convert_mul_add_to_scaleshi
     };
 
     auto m = std::make_shared<ngraph::pattern::Matcher>(add, "CPUFusion.MulAddToScaleShiftOrPower");
+    NGRAPH_SUPPRESS_DEPRECATED_START
     this->add_matcher(m, callback, PassProperty::CHANGE_DYNAMIC_STATE);
+    NGRAPH_SUPPRESS_DEPRECATED_END
 }

--- a/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/convert_prior_to_ie_prior.cpp
+++ b/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/convert_prior_to_ie_prior.cpp
@@ -154,7 +154,9 @@ void ngraph::pass::ConvertPriorBox::convert_prior_box() {
     };
 
     auto m = std::make_shared<ngraph::pattern::Matcher>(unsqueeze, "CPUFusion.ConvertPriorBoxToPriorBoxIE");
+    NGRAPH_SUPPRESS_DEPRECATED_START
     this->add_matcher(m, callback, PassProperty::CHANGE_DYNAMIC_STATE);
+    NGRAPH_SUPPRESS_DEPRECATED_END
 }
 
 void ngraph::pass::ConvertPriorBox::convert_prior_box_clustered() {
@@ -292,5 +294,7 @@ void ngraph::pass::ConvertPriorBox::convert_prior_box_clustered() {
     };
 
     auto m = std::make_shared<ngraph::pattern::Matcher>(unsqueeze, "CPUFusion.ConvertPriorBoxClusteredToPriorBoxClusteredIE");
+    NGRAPH_SUPPRESS_DEPRECATED_START
     this->add_matcher(m, callback, PassProperty::CHANGE_DYNAMIC_STATE);
+    NGRAPH_SUPPRESS_DEPRECATED_END
 }

--- a/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/reshape_fc_fusion.cpp
+++ b/inference-engine/src/legacy_api/src/transformations/convert_opset1_to_legacy/reshape_fc_fusion.cpp
@@ -52,5 +52,7 @@ void ngraph::pass::ReshapeFullyConnectedFusion::construct_reshape_fc() {
     };
 
     auto m = std::make_shared<ngraph::pattern::Matcher>(m_fc, "ReshapeFullyConnectedFusion");
+    NGRAPH_SUPPRESS_DEPRECATED_START
     this->add_matcher(m, callback, PassProperty::CHANGE_DYNAMIC_STATE);
+    NGRAPH_SUPPRESS_DEPRECATED_END
 }

--- a/inference-engine/src/low_precision_transformations/src/layer_transformation.cpp
+++ b/inference-engine/src/low_precision_transformations/src/layer_transformation.cpp
@@ -491,7 +491,9 @@ void LayerTransformation::addPattern(ngraph::pass::GraphRewrite& pass, Transform
     };
     // TODO: better name for matcher? required?
     auto m = std::make_shared<ngraph::pattern::Matcher>(patternRoot, "SingleNodeMatcher");
+    NGRAPH_SUPPRESS_DEPRECATED_START
     pass.add_matcher(m, internal_callback, ngraph::pass::PassProperty::CHANGE_DYNAMIC_STATE);
+    NGRAPH_SUPPRESS_DEPRECATED_END
 }
 
 }  // namespace low_precision

--- a/inference-engine/src/low_precision_transformations/src/transformer.cpp
+++ b/inference-engine/src/low_precision_transformations/src/transformer.cpp
@@ -302,7 +302,9 @@ void make_matcher_type_relaxed(ngraph::pass::GraphRewrite* transformation) {
     };
 
     auto m = std::make_shared<ngraph::pattern::Matcher>(p_node, "TypeRelaxedReplacer");
+    NGRAPH_SUPPRESS_DEPRECATED_START
     transformation->add_matcher(m, callback, ngraph::pass::PassProperty::CHANGE_DYNAMIC_STATE);
+    NGRAPH_SUPPRESS_DEPRECATED_END
 }
 
 TypeRelaxedReplacer::TypeRelaxedReplacer() {

--- a/inference-engine/src/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/inference-engine/src/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -25,8 +25,6 @@
 #include <ngraph/log.hpp>
 #include <transformations/common_optimizations/nop_elimination.hpp>
 
-NGRAPH_SUPPRESS_DEPRECATED_START
-
 using namespace std;
 using namespace ngraph;
 

--- a/inference-engine/src/transformations/src/transformations/common_optimizations/remove_filtering_boxes_by_size.cpp
+++ b/inference-engine/src/transformations/src/transformations/common_optimizations/remove_filtering_boxes_by_size.cpp
@@ -104,5 +104,7 @@ void ngraph::pass::RemoveFilteringBoxesBySize::remove_filtering_boxes_by_size() 
     };
 
     auto m = std::make_shared<ngraph::pattern::Matcher>(cast, "RemoveFilteringBoxesBySize");
+    NGRAPH_SUPPRESS_DEPRECATED_START
     this->add_matcher(m, callback, PassProperty::CHANGE_DYNAMIC_STATE);
+    NGRAPH_SUPPRESS_DEPRECATED_END
 }

--- a/inference-engine/src/vpu/graph_transformer/src/frontend/frontend.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/frontend/frontend.cpp
@@ -197,7 +197,9 @@ ie::ICNNNetwork::Ptr FrontEnd::convertNetwork(ie::ICNNNetwork& network) {
     manager.register_pass<ngraph::pass::ConvertOpSet1ToLegacy>();
     manager.get_pass_config()->disable<ngraph::pass::ConvertGatherToGatherIEMatcher>();
 
+    NGRAPH_SUPPRESS_DEPRECATED_START
     manager.set_callback(transformationsPredicate);
+    NGRAPH_SUPPRESS_DEPRECATED_END
     manager.run_passes(nGraphFunc);
 
     vpu::MergeSubsequentDSROperations().run_on_function(nGraphFunc);

--- a/ngraph/core/include/ngraph/op/lstm_cell.hpp
+++ b/ngraph/core/include/ngraph/op/lstm_cell.hpp
@@ -26,8 +26,6 @@
 #include "ngraph/op/util/fused_op.hpp"
 #include "ngraph/op/util/rnn_cell_base.hpp"
 
-NGRAPH_SUPPRESS_DEPRECATED_START
-
 namespace ngraph
 {
     namespace op

--- a/ngraph/core/include/ngraph/pass/pass_config.hpp
+++ b/ngraph/core/include/ngraph/pass/pass_config.hpp
@@ -77,7 +77,9 @@ namespace ngraph
             template <typename T>
             void disable()
             {
+                NGRAPH_SUPPRESS_DEPRECATED_START
                 disable(T::type_info);
+                NGRAPH_SUPPRESS_DEPRECATED_END
             }
 
             /// \brief Enable transformation by its type_info
@@ -87,7 +89,9 @@ namespace ngraph
             template <typename T>
             void enable()
             {
+                NGRAPH_SUPPRESS_DEPRECATED_START
                 enable(T::type_info);
+                NGRAPH_SUPPRESS_DEPRECATED_END
             }
 
             /// \brief Set callback for all kind of transformations
@@ -142,7 +146,9 @@ namespace ngraph
             template <typename T>
             param_callback get_callback() const
             {
+                NGRAPH_SUPPRESS_DEPRECATED_START
                 return get_callback(T::type_info);
+                NGRAPH_SUPPRESS_DEPRECATED_END
             }
 
             /// \brief Check either transformation type is disabled or not
@@ -158,7 +164,9 @@ namespace ngraph
             template <typename T>
             bool is_disabled() const
             {
+                NGRAPH_SUPPRESS_DEPRECATED_START
                 return is_disabled(T::type_info);
+                NGRAPH_SUPPRESS_DEPRECATED_END
             }
 
             /// \brief Check either transformation type is force enabled or not

--- a/ngraph/core/src/op/lstm_sequence.cpp
+++ b/ngraph/core/src/op/lstm_sequence.cpp
@@ -30,6 +30,8 @@
 using namespace ngraph;
 using namespace std;
 
+NGRAPH_SUPPRESS_DEPRECATED_START
+
 NGRAPH_RTTI_DEFINITION(op::v0::LSTMSequence, "LSTMSequence", 0);
 NGRAPH_RTTI_DEFINITION(op::v5::LSTMSequence, "LSTMSequence", 5);
 

--- a/ngraph/test/graph_rewrite.cpp
+++ b/ngraph/test/graph_rewrite.cpp
@@ -8,6 +8,8 @@
 #include <ngraph/pass/manager.hpp>
 #include <util/test_tools.hpp>
 
+NGRAPH_SUPPRESS_DEPRECATED_START
+
 using namespace ::testing;
 using namespace std;
 using namespace ngraph;

--- a/ngraph/test/runtime/pass/fused_op_decomposition.hpp
+++ b/ngraph/test/runtime/pass/fused_op_decomposition.hpp
@@ -19,8 +19,9 @@
 #include <memory>
 
 #include "backend_visibility.hpp"
-#include "ngraph/op/util/fused_op.hpp"
 #include "ngraph/pass/pass.hpp"
+
+NGRAPH_SUPPRESS_DEPRECATED_START
 
 namespace ngraph
 {
@@ -74,3 +75,5 @@ namespace ngraph
         };
     }
 }
+
+NGRAPH_SUPPRESS_DEPRECATED_END

--- a/ngraph/test/runtime/pass/implicit_broadcast_elimination.hpp
+++ b/ngraph/test/runtime/pass/implicit_broadcast_elimination.hpp
@@ -21,6 +21,7 @@
 #include "ngraph/pass/pass.hpp"
 
 NGRAPH_SUPPRESS_DEPRECATED_START
+
 namespace ngraph
 {
     namespace pass
@@ -35,4 +36,5 @@ class BACKEND_API ngraph::pass::ImplicitBroadcastElimination : public ngraph::pa
 public:
     bool run_on_node(std::shared_ptr<ngraph::Node> node) override;
 };
+
 NGRAPH_SUPPRESS_DEPRECATED_END


### PR DESCRIPTION
Now, warnings from ngraph deprecated API are generated properly.