### PR TITLE
[IE CLDNN] Added missing pointer type cast for blocked read

### DIFF
--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/fused_conv_eltwise_gpu_imad.cl
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/fused_conv_eltwise_gpu_imad.cl
@@ -249,7 +249,7 @@ KERNEL (fused_convolution_eltwise_gpu_imad)(
                  #endif
             #else
                 #ifdef BLOCK_LOAD_INPUTS
-                    in[reg] = AS_PACKED_TYPE(intel_sub_group_block_read(&conv_input[in_addr]));
+                    in[reg] = AS_PACKED_TYPE(intel_sub_group_block_read((const __global uint*) &conv_input[in_addr]));
                     #ifdef SHOULD_USE_DATA_ZP
                         if (input_on_padding)
                             in[reg] = data_zp_val;


### PR DESCRIPTION
If `PACKED_TYPE == int`, then some compiler versions complain that this call is ambiguous