### PR TITLE
Refactor install_openvino_dependencies script: extra options and cleanup

### DIFF
--- a/scripts/install_dependencies/install_openvino_dependencies.sh
+++ b/scripts/install_dependencies/install_openvino_dependencies.sh
@@ -298,7 +298,7 @@ elif [ "$os" == "centos7" ] ; then
     fi
 
 else
-    echo "Internal script error: invalid OS after check" >&2
+    echo "Internal script error: invalid OS after check (package selection)" >&2
     exit 3
 fi
 
@@ -355,7 +355,7 @@ elif [ "$os" == "centos7" ] ; then
     yum install $iopt ${pkgs[@]}
 
 else
-    echo "Internal script error: invalid OS after check" >&2
+    echo "Internal script error: invalid OS after check (package installation)" >&2
     exit 3
 fi
 

--- a/scripts/install_dependencies/install_openvino_dependencies.sh
+++ b/scripts/install_dependencies/install_openvino_dependencies.sh
@@ -297,6 +297,9 @@ elif [ "$os" == "centos7" ] ; then
         )
     fi
 
+else
+    echo "Internal script error: invalid OS after check" >&2
+    exit 3
 fi
 
 #===================================================================================================
@@ -351,6 +354,9 @@ elif [ "$os" == "centos7" ] ; then
 
     yum install $iopt ${pkgs[@]}
 
+else
+    echo "Internal script error: invalid OS after check" >&2
+    exit 3
 fi
 
 exit 0

--- a/scripts/install_dependencies/install_openvino_dependencies.sh
+++ b/scripts/install_dependencies/install_openvino_dependencies.sh
@@ -107,7 +107,7 @@ extra_repos=()
 if [ "$os" == "ubuntu18.04" ] ; then
 
     pkgs_opencv_req=(libgtk-3-0)
-    pkgs_python=(python3 python3-dev python3-venv python3-setuptools)
+    pkgs_python=(python3 python3-dev python3-venv python3-setuptools python3-pip)
     pkgs_dev=(cmake g++ gcc libc6-dev make curl)
     pkgs_myriad=(libusb-1.0-0)
     pkgs_installer=(cpio)
@@ -146,7 +146,7 @@ if [ "$os" == "ubuntu18.04" ] ; then
 elif [ "$os" == "ubuntu20.04" ] ; then
 
     pkgs_opencv_req=(libgtk-3-0)
-    pkgs_python=(python3 python3-dev python3-venv python3-setuptools)
+    pkgs_python=(python3 python3-dev python3-venv python3-setuptools python3-pip)
     pkgs_dev=(cmake g++ gcc libc6-dev make curl)
     pkgs_myriad=(libusb-1.0-0)
     pkgs_installer=(cpio)
@@ -192,7 +192,7 @@ elif [ "$os" == "centos7" ] ; then
     # find -name *.so -exec objdump -p {} \; | grep NEEDED | sort -u | cut -c 23- | xargs -t -n1 yum -q whatprovides
 
     pkgs_opencv_req=(gtk2)
-    pkgs_python=(python3 python3-pip)
+    pkgs_python=(python3 python3-devel python3-setuptools python3-pip)
     pkgs_dev=(gcc gcc-c++ make glibc libstdc++ libgcc cmake curl)
     pkgs_myriad=(libusbx)
     pkgs_installer=()

--- a/scripts/install_dependencies/install_openvino_dependencies.sh
+++ b/scripts/install_dependencies/install_openvino_dependencies.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2018 - 2020 Intel Corporation
+# Copyright (c) 2018 - 2021 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,260 +16,341 @@
 
 set -e
 
+#===================================================================================================
+# Option parsing
+
+all_comp=(opencv_req opencv_opt python dev myriad dlstreamer installer pot)
+os=${os:-auto}
+
+# public options
+interactive=yes
+dry=
+extra=
+print=
+comp=()
+
+# private options
+keepcache=
+selftest=
+
+while :; do
+    case $1 in
+        -h|-\?|--help)
+            echo "Options:"
+            echo "  -y          non-interactive run (off)"
+            echo "  -n          dry-run, assume no (off)"
+            echo "  -c=<name>   install component <name>, can be repeated (${all_comp[*]})"
+            echo "  -e          add extra repositories (CentOS 7) (off)"
+            echo "  -p          print package list and exit (off)"
+            exit
+            ;;
+        -y) interactive= ;;
+        -n) dry=yes ;;
+        -c=?*) comp+=("${1#*=}") ;;
+        -e) extra=yes ;;
+        -p) print=yes ;;
+        --selftest) selftest=yes ;;
+        --keepcache) keepcache=yes ;;
+        *) break ;;
+    esac
+    shift
+done
+
+# No components selected - install all
+if [ ${#comp[@]} -eq 0 ]; then
+    comp=(${all_comp[@]})
+fi
+
+#===================================================================================================
+#  Selftest
+
+if [ -n "$selftest" ] ; then
+    for image in centos:7 ubuntu:18.04 ubuntu:20.04 ; do
+        for opt in  "-h" "-p" "-e -p" "-n" "-n -e" "-y" "-y -e" ; do
+            echo "||"
+            echo "|| Test $image / '$opt'"
+            echo "||"
+            SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+            docker run -it --rm \
+                --volume ${SCRIPT_DIR}:/scripts:ro,Z  \
+                --volume yum-cache:/var/cache/yum \
+                --volume apt-cache:/var/cache/apt/archives \
+                -e DEBIAN_FRONTEND=noninteractive \
+                $image \
+                bash /scripts/${0##*/} $opt --keepcache
+            echo "||"
+            echo "|| Completed: $image / '$opt'"
+            echo "||"
+        done
+    done
+    echo "Self test finished, to remove temporary docker volumes run:
+        'docker volume rm yum-cache apt-cache'"
+    exit 0
+fi
+
+#===================================================================================================
+# OS detection
+
+if [ "$os" == "auto" ] ; then
+    os=$( . /etc/os-release ; echo "${ID}${VERSION_ID}" )
+    case $os in
+        centos7|ubuntu18.04|ubuntu20.04) [ -z "$print" ] && echo "Detected OS: ${os}" ;;
+        *) echo "Unsupported OS: ${os:-detection failed}" >&2 ; exit 1 ;;
+    esac
+fi
+
+#===================================================================================================
+# Collect packages
+
+extra_repos=()
+
+if [ "$os" == "ubuntu18.04" ] ; then
+
+    pkgs_opencv_req=(libgtk-3-0)
+    pkgs_python=(python3 python3-dev python3-venv python3-setuptools)
+    pkgs_dev=(cmake g++ gcc libc6-dev make curl)
+    pkgs_myriad=(libusb-1.0-0)
+    pkgs_installer=(cpio)
+    pkgs_pot=()
+    pkgs_opencv_opt=(
+        gstreamer1.0-plugins-bad
+        gstreamer1.0-plugins-base
+        gstreamer1.0-plugins-good
+        gstreamer1.0-plugins-ugly
+        libavcodec57
+        libavformat57
+        libavresample3
+        libavutil55
+        libgstreamer1.0-0
+        libswscale4
+    )
+    pkgs_dlstreamer=(
+        ffmpeg
+        flex
+        gstreamer1.0-alsa
+        gstreamer1.0-plugins-bad
+        gstreamer1.0-plugins-base
+        gstreamer1.0-plugins-good
+        gstreamer1.0-plugins-ugly
+        gstreamer1.0-vaapi
+        libfaac0
+        libfluidsynth1
+        libgl-dev
+        libglib2.0
+        libgstreamer1.0-0
+        libnettle6
+        libtag-extras1
+        python3-gi
+    )
+
+elif [ "$os" == "ubuntu20.04" ] ; then
+
+    pkgs_opencv_req=(libgtk-3-0)
+    pkgs_python=(python3 python3-dev python3-venv python3-setuptools)
+    pkgs_dev=(cmake g++ gcc libc6-dev make curl)
+    pkgs_myriad=(libusb-1.0-0)
+    pkgs_installer=(cpio)
+    pkgs_pot=(libblas-dev liblapack-dev gfortran)
+    pkgs_opencv_opt=(
+        gstreamer1.0-plugins-bad
+        gstreamer1.0-plugins-base
+        gstreamer1.0-plugins-good
+        gstreamer1.0-plugins-ugly
+        libavcodec58
+        libavformat58
+        libavresample4
+        libavutil56
+        libgstreamer1.0-0
+        libswscale5
+    )
+    pkgs_dlstreamer=(
+        ffmpeg
+        flex
+        gstreamer1.0-alsa
+        gstreamer1.0-libav
+        gstreamer1.0-plugins-bad
+        gstreamer1.0-plugins-base
+        gstreamer1.0-plugins-good
+        gstreamer1.0-plugins-ugly
+        gstreamer1.0-vaapi
+        libfaac0
+        libfluidsynth2
+        libgl-dev
+        libglib2.0-0
+        libgstreamer-plugins-base1.0-dev
+        libgstreamer1.0-0
+        libgstrtspserver-1.0-dev
+        libnettle7
+        libopenexr24
+        libtag-extras1
+        python3-gi
+        python3-gst-1.0
+    )
+
+elif [ "$os" == "centos7" ] ; then
+
+    # find -name *.so -exec objdump -p {} \; | grep NEEDED | sort -u | cut -c 23- | xargs -t -n1 yum -q whatprovides
+
+    pkgs_opencv_req=(gtk2)
+    pkgs_python=(python3 python3-pip)
+    pkgs_dev=(gcc gcc-c++ make glibc libstdc++ libgcc cmake curl)
+    pkgs_myriad=(libusbx)
+    pkgs_installer=()
+    pkgs_pot=()
+    pkgs_opencv_opt=(
+        gstreamer1
+        gstreamer1-plugins-bad-free
+        gstreamer1-plugins-good
+        gstreamer1-plugins-ugly-free
+    )
+    pkgs_dlstreamer=(
+        OpenEXR-libs
+        alsa-lib
+        boost-regex
+        bzip2-libs
+        cairo
+        cdparanoia-libs
+        flac-libs
+        flite
+        gdk-pixbuf2
+        glib2
+        glibc
+        gmp
+        gsm
+        gstreamer1
+        gstreamer1-plugins-bad-free
+        gstreamer1-plugins-base
+        ilmbase
+        libX11
+        libXdamage
+        libXext
+        libXfixes
+        libXrandr
+        libXrender
+        libXv
+        libdrm
+        libdv
+        libgcc
+        libglvnd-glx
+        libjpeg-turbo
+        libogg
+        libpng
+        librdkafka
+        librsvg2
+        libsndfile
+        libsoup
+        libstdc++
+        libtheora
+        libuuid
+        libv4l
+        libvisual
+        libvorbis
+        libxml2
+        mpg123-libs
+        neon
+        nettle
+        openjpeg2
+        openssl-libs
+        opus
+        orc
+        pango
+        pulseaudio-libs
+        sbc
+        soundtouch
+        speex
+        wavpack
+        xz-libs
+        zlib
+    )
+
+    if [ -n "$extra" ] ; then
+        # 1 RPMFusion
+        extra_repos+=(https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-7.noarch.rpm)
+        pkgs_opencv_opt+=(ffmpeg-libs)
+        pkgs_dlstreamer+=(
+            libde265
+            libmms
+            librtmp
+            opencore-amr
+            vo-amrwbenc
+        )
+        # 2 EPEL
+        extra_repos+=(https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm)
+        pkgs_dlstreamer+=(
+            fluidsynth-libs
+            game-music-emu
+            libass
+            libbs2b
+            libchromaprint
+            libmodplug
+            openal-soft
+            paho-c
+            spandsp
+            zbar
+            zvbi
+        )
+        # 3 ForensicsTools
+        extra_repos+=(https://forensics.cert.org/cert-forensics-tools-release-el7.rpm)
+        pkgs_dlstreamer+=(
+            faac
+            fdk-aac
+        )
+    fi
+
+fi
+
+#===================================================================================================
+# Gather packages and print list
+
+pkgs=()
+for comp in ${comp[@]} ; do
+    var=pkgs_${comp}[@]
+    pkgs+=(${!var})
+done
+
+if [ ${#pkgs[@]} -eq 0 ]; then
+    if  [ -n "$print" ] ; then
+        echo "No packages to install" >&2
+        exit 1
+    else
+        echo "No packages to install"
+        exit 0
+    fi
+fi
+
+if  [ -n "$print" ] ; then
+    echo "${pkgs[*]}"
+    exit 0
+fi
+
+#===================================================================================================
+# Actual installation
+
 if [ $EUID -ne 0 ]; then
     echo "ERROR: this script must be run as root to install 3rd party packages." >&2
     echo "Please try again with \"sudo -E $0\", or as root." >&2
     exit 1
 fi
 
-params=$@
+iopt=
 
-yes_or_no_ffmpeg() {
-    if [ "$params" == "-y" ]; then
-        return 0
-    fi
+if [ "$os" == "ubuntu18.04" ] || [ "$os" == "ubuntu20.04" ] ; then
 
-    while true; do
-        read -p "Add third-party RPM Fusion repository and install FFmpeg package (y/n): " yn
-        case $yn in
-            [Yy]*) return 0  ;;
-            [Nn]*) return  1 ;;
-        esac
-    done
-}
+    [ -z "$interactive" ] && iopt="-y"
+    [ -n "$dry" ] && iopt="--dry-run"
+    [ -n "$keepcache" ] && rm -f /etc/apt/apt.conf.d/docker-clean
 
-yes_or_no_gst_bad_ugly() {
-    if [ "$params" == "-y" ]; then
-        return 0
-    fi
+    apt-get update && apt-get install --no-install-recommends $iopt ${pkgs[@]}
 
-    while true; do
-        read -p "Add third-party RPM Epel, Nux, Fusion, Forensics repositories and install dependencies for GStreamer Bad & Ugly Plugins (y/n): " yn
-        case $yn in
-            [Yy]*) return 0  ;;
-            [Nn]*) return  1 ;;
-        esac
-    done
-}
+elif [ "$os" == "centos7" ] ; then
 
-if [ -f /etc/lsb-release ]; then
-    # Ubuntu
-    echo
-    echo "This script installs the following OpenVINO 3rd-party dependencies:"
-    echo "  1. GTK+, FFmpeg and GStreamer libraries used by OpenCV"
-    echo "  2. libusb library required for Myriad plugin for Inference Engine"
-    echo "  3. build dependencies for OpenVINO samples"
-    echo "  4. build dependencies for GStreamer Plugins"
-    echo
-    PKGS=(
-        cpio
-        build-essential
-        cmake
-        libusb-1.0-0-dev
-        libdrm-dev
-        libgstreamer1.0-0
-        gstreamer1.0-plugins-base
-        gstreamer1.0-plugins-good
-        gstreamer1.0-plugins-bad
-        gstreamer1.0-vaapi
-        ffmpeg
-    )
-    system_ver=$(cat /etc/lsb-release | grep -i "DISTRIB_RELEASE" | cut -d "=" -f2)
-    if [ "$system_ver" = "16.04" ]; then
-        PKGS+=( libgtk2.0-0 )
-    else
-        if [ "$system_ver" = "20.04" ]; then
-            PKGS+=( gstreamer1.0-plugins-ugly
-                    gstreamer1.0-libav
-                    libgstreamer-plugins-base1.0-dev
-                    gstreamer1.0-alsa
-                    libgstrtspserver-1.0-dev
-                    python3-gst-1.0
-                    libfluidsynth2
-                    libnettle7
-                    libopenexr24
-                    python3.8
-                    libpython3.8
-                    libglib2.0-0
-                )
-        elif [ "$system_ver" = "18.04" ]; then
-            PKGS+=( libfluidsynth1
-                    libnettle6
-                    libopenexr22
-                    gstreamer1.0-plugins-ugly
-                    gstreamer1.0-alsa
-                    libglib2.0
-                )
-        fi
-        PKGS+=( flex
-                libgl-dev
-                libtag-extras1
-                libusb-1.0-0-dev
-                libfaac0
-                python3-gi
-                libgtk-3-0
-        )
-    fi
-    apt update
-    # shellcheck disable=SC2068
-    apt install -y ${PKGS[@]}
-else
-    # CentOS
-    echo
-    echo "This script installs the following OpenVINO 3rd-party dependencies:"
-    echo "  1. GTK+ and GStreamer libraries used by OpenCV"
-    echo "  2. libusb library required for Myriad plugin for Inference Engine"
-    echo "  3. Python 3.6 for Model Optimizer"
-    echo "  4. gcc 4.8.5 and other build dependencies for OpenVINO samples"
-    echo "  5. build dependencies for GStreamer Plugins"
-    echo
-    PKGS=(
-        libusbx-devel
-        gtk2
-        gstreamer1
-        gstreamer1-plugins-good
-        gstreamer1-plugins-bad-free
-        gcc
-        gcc-c++
-        make
-        glibc-static
-        glibc
-        libstdc++-static
-        libstdc++
-        libstdc++
-        libgcc
-        cmake
-        python36
-        python36-pip
-        glib2-devel
-        flex
-        gmp
-        gsl
-        libcap
-        libcap
-        gettext
-        libXrandr
-        libX11
-        iso-codes
-        mesa-libEGL
-        mesa-libGLES
-        mesa-libGL
-        libgudev1
-        libtheora
-        cdparanoia
-        pango
-        mesa-libgbm
-        alsa-lib
-        libjpeg-turbo
-        libvisual
-        libXv
-        opus
-        libvorbis
-        patch
-        bzip2
-        libv4l
-        flac
-        gdk-pixbuf2
-        libdv
-        mpg123
-        libraw1394
-        libavc1394
-        libiec61883
-        pulseaudio-libs
-        libsoup
-        speex
-        wavpack
-        boost-regex-1.53.0
-    )
-    yum install -y ${PKGS[@]}
+    [ -z "$interactive" ] && iopt="--assumeyes"
+    [ -n "$dry" ] && iopt="--downloadonly"
+    [ -n "$keepcache" ] && iopt="$iopt --setopt=keepcache=1"
+    [ ${#extra_repos[@]} -ne 0 ] && yum localinstall $iopt --nogpgcheck ${extra_repos[@]}
 
-    # Thirdparty repositories for installing GStreamer Bad & Ugly Plugins dependencies.
-    if yes_or_no_gst_bad_ugly; then
-        GST_BAD_UGLY_PKGS=(
-            bluez-libs
-            libusb
-            libass
-            libbs2b
-            libchromaprint
-            lcms2
-            libssh2
-            libdc1394
-            libXext
-            libssh
-            libdca
-            faac
-            fdk-aac
-            flite
-            fluidsynth
-            game-music-emu
-            gsm
-            nettle
-            kate
-            liblrdf
-            libde265
-            mjpegtools
-            libmms
-            libmodplug
-            libmpcdec
-            neon
-            openal-soft
-            OpenEXR
-            openjpeg2
-            openni
-            libdvdnav
-            librtmp
-            librsvg2
-            sbc
-            libsndfile
-            soundtouch
-            spandsp
-            libsrtp
-            zvbi
-            vo-amrwbenc
-            webrtc-audio-processing
-            wildmidi
-            zbar
-            libnice
-            libxkbcommon
-            opencore-amr
-            libva
-            python36-gobject
-            python3-devel
-        )
-        yum install -y epel-release
-        rpm -Uvh https://download1.rpmfusion.org/free/el/rpmfusion-free-release-7.noarch.rpm
-        RPMFUSION_IS_INSTALLED=1
-        yum install -y https://forensics.cert.org/cert-forensics-tools-release-el7.rpm
-        yum install -y ${GST_BAD_UGLY_PKGS[@]}
-    else
-        echo "Dependencies for GStreamer Ugly & Bad plugins installation skipped."
-        echo
-    fi
+    yum install $iopt ${pkgs[@]}
 
-    echo
-    echo "Intel(R) Distribution of OpenVINO(TM) toolkit can use FFmpeg for processing video streams with OpenCV. Please select your preferred method for installing FFmpeg:"
-    echo
-    echo "Option 1: Allow installer script to add a third party repository, RPM Fusion (https://rpmfusion.org/), which contains FFmpeg. FFmpeg rpm package will be installed from this repository. "
-    echo "WARNING: This repository is NOT PROVIDED OR SUPPORTED by Intel or CentOS. Neither Intel nor CentOS has control over this repository. Terms governing your use of FFmpeg can be found here: https://www.ffmpeg.org/legal.html "
-    echo "Once added, this repository will be enabled on your operating system and can thus receive updates to all packages installed from it. "
-    echo
-    echo "Consider the following ways to prevent unintended 'updates' from this third party repository from over-writing some core part of CentOS:"
-    echo "a) Only enable these archives from time to time, and generally leave them disabled. See: man yum"
-    echo "b) Use the exclude= and includepkgs= options on a per sub-archive basis, in the matching .conf file found in /etc/yum.repos.d/ See: man yum.conf"
-    echo "c) The yum Priorities plug-in can prevent a 3rd party repository from replacing base packages, or prevent base/updates from replacing a 3rd party package."
-    echo
-    echo "Option 2: Skip FFmpeg installation."
-    echo
-
-    if yes_or_no_ffmpeg; then
-        if [[ -z $RPMFUSION_IS_INSTALLED ]]; then
-            yum install -y epel-release
-            rpm -Uvh https://download1.rpmfusion.org/free/el/rpmfusion-free-release-7.noarch.rpm
-        fi
-        yum install -y ffmpeg
-    else
-        echo "FFmpeg installation skipped. You may build FFmpeg from sources as described here: https://trac.ffmpeg.org/wiki/CompilationGuide/Centos"
-        echo
-    fi
-    exit
 fi
+
+exit 0


### PR DESCRIPTION
Major changes:
* OS detection changed to use `/etc/os-release file`, can be overriden
* Packages split by components and OSes
* New options: 
    * `-y` - answer "yes" everywhere
    * `-n` - dry-run (do not install anything)
    * `-e` - add extra repositories for CentOS
    * `-p` - print packages list and exit
    * `-c=<name>` - install only packages for component <name>
* Hidden options:
    * `--selfcheck` - run script in ad-hoc Docker containers with various options
    * `--keepcache` - for faster selfcheck

📄 **Note:** Old option `-y` should be replaced with new options `-y -e`, old default mode - `-e`

@artanokhov @generalova-kate , please take a look.