### PR TITLE
Deprecated IVariableState interface

### DIFF
--- a/inference-engine/include/cpp/ie_executable_network.hpp
+++ b/inference-engine/include/cpp/ie_executable_network.hpp
@@ -177,14 +177,15 @@ public:
      */
     INFERENCE_ENGINE_DEPRECATED("Use InferRequest::QueryState instead")
     std::vector<VariableState> QueryState() {
-        IE_SUPPRESS_DEPRECATED_START
         if (actual == nullptr) THROW_IE_EXCEPTION << "ExecutableNetwork was not initialized.";
         IVariableState::Ptr pState = nullptr;
         auto res = OK;
         std::vector<VariableState> controller;
         for (size_t idx = 0; res == OK; ++idx) {
             ResponseDesc resp;
+            IE_SUPPRESS_DEPRECATED_START
             res = actual->QueryState(pState, idx, &resp);
+            IE_SUPPRESS_DEPRECATED_END
             if (res != OK && res != OUT_OF_BOUNDS) {
                 THROW_IE_EXCEPTION << resp.msg;
             }
@@ -193,7 +194,6 @@ public:
             }
         }
 
-        IE_SUPPRESS_DEPRECATED_END
         return controller;
     }
 

--- a/inference-engine/include/cpp/ie_infer_request.hpp
+++ b/inference-engine/include/cpp/ie_infer_request.hpp
@@ -267,6 +267,7 @@ public:
      * @return A vector of Memory State objects
      */
     std::vector<VariableState> QueryState() {
+        IE_SUPPRESS_DEPRECATED_START
         if (actual == nullptr) THROW_IE_EXCEPTION << "ExecutableNetwork was not initialized.";
         IVariableState::Ptr pState = nullptr;
         auto res = OK;
@@ -281,6 +282,7 @@ public:
                 controller.push_back(VariableState(pState, plg));
             }
         }
+        IE_SUPPRESS_DEPRECATED_END
 
         return controller;
     }

--- a/inference-engine/include/cpp/ie_memory_state.hpp
+++ b/inference-engine/include/cpp/ie_memory_state.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -12,39 +12,41 @@
 
 #include <string>
 
-#include "ie_imemory_state.hpp"
+#include "ie_blob.h"
 #include "details/ie_exception_conversion.hpp"
 #include "details/ie_so_loader.h"
 
 namespace InferenceEngine {
 
+IE_SUPPRESS_DEPRECATED_START
+class IVariableState;
+IE_SUPPRESS_DEPRECATED_END
+
 /**
  * @brief C++ exception based error reporting wrapper of API class IVariableState
  */
-class VariableState {
-    IVariableState::Ptr actual = nullptr;
-    details::SharedObjectLoader::Ptr plugin = {};
+class INFERENCE_ENGINE_API_CLASS(VariableState) {
+    IE_SUPPRESS_DEPRECATED_START
+    std::shared_ptr<IVariableState> actual = nullptr;
+    IE_SUPPRESS_DEPRECATED_END
+    details::SharedObjectLoader::Ptr plugin = nullptr;
 
 public:
+    IE_SUPPRESS_DEPRECATED_START
     /**
-     * @brief constructs VariableState from the initialized shared_pointer
+     * @brief constructs VariableState from the initialized std::shared_ptr
      * @param pState Initialized shared pointer
      * @param plg Optional: Plugin to use. This is required to ensure that VariableState can work properly even if plugin object is destroyed.
      */
-    explicit VariableState(IVariableState::Ptr pState, details::SharedObjectLoader::Ptr plg = {}) : actual(pState), plugin(plg) {
-        if (actual == nullptr) {
-            THROW_IE_EXCEPTION << "VariableState wrapper was not initialized.";
-        }
-    }
+    explicit VariableState(std::shared_ptr<IVariableState> pState, details::SharedObjectLoader::Ptr plg = {});
+    IE_SUPPRESS_DEPRECATED_END
 
     /**
      * @copybrief IVariableState::Reset
      *
      * Wraps IVariableState::Reset
      */
-    void Reset() {
-        CALL_STATUS_FNC_NO_ARGS(Reset);
-    }
+    void Reset();
 
     /**
      * @copybrief IVariableState::GetName
@@ -52,11 +54,7 @@ public:
      * Wraps IVariableState::GetName
      * @return A string representing a state name
      */
-    std::string GetName() const {
-        char name[256];
-        CALL_STATUS_FNC(GetName, name, sizeof(name));
-        return name;
-    }
+    std::string GetName() const;
 
     /**
      * @copybrief IVariableState::GetState
@@ -64,11 +62,7 @@ public:
      * Wraps IVariableState::GetState
      * @return A blob representing a state 
      */
-    Blob::CPtr GetState() const {
-        Blob::CPtr stateBlob;
-        CALL_STATUS_FNC(GetState, stateBlob);
-        return stateBlob;
-    }
+    Blob::CPtr GetState() const;
 
     /**
      * @copybrief IVariableState::GetLastState
@@ -78,9 +72,7 @@ public:
      * @return A blob representing a last state 
      */
     INFERENCE_ENGINE_DEPRECATED("Use VariableState::GetState function instead")
-    Blob::CPtr GetLastState() const {
-        return GetState();
-    }
+    Blob::CPtr GetLastState() const;
 
     /**
      * @copybrief IVariableState::SetState
@@ -88,9 +80,7 @@ public:
      * Wraps IVariableState::SetState
      * @param state The current state to set
      */
-    void SetState(Blob::Ptr state) {
-        CALL_STATUS_FNC(SetState, state);
-    }
+    void SetState(Blob::Ptr state);
 };
 
 /**

--- a/inference-engine/include/ie_iexecutable_network.hpp
+++ b/inference-engine/include/ie_iexecutable_network.hpp
@@ -107,7 +107,9 @@ public:
      */
     virtual StatusCode GetExecGraphInfo(ICNNNetwork::Ptr& graphPtr, ResponseDesc* resp) noexcept = 0;
 
+    IE_SUPPRESS_DEPRECATED_START
     /**
+     * @deprecated Use InferRequest::QueryState instead
      * @brief Gets state control interface for given executable network.
      *
      * State control essential for recurrent networks
@@ -118,7 +120,9 @@ public:
      * @return Status code of the operation: InferenceEngine::OK (0) for success, OUT_OF_BOUNDS (-6) no memory state for
      * given index
      */
+    INFERENCE_ENGINE_DEPRECATED("Use InferRequest::QueryState instead")
     virtual StatusCode QueryState(IVariableState::Ptr& pState, size_t idx, ResponseDesc* resp) noexcept = 0;
+    IE_SUPPRESS_DEPRECATED_END
 
     /**
      * @brief Sets configuration for current executable network

--- a/inference-engine/include/ie_iinfer_request.hpp
+++ b/inference-engine/include/ie_iinfer_request.hpp
@@ -185,17 +185,20 @@ public:
      */
     virtual InferenceEngine::StatusCode SetBatch(int batch_size, ResponseDesc* resp) noexcept = 0;
 
+    IE_SUPPRESS_DEPRECATED_START
     /**
-    * @brief Gets state control interface for given infer request.
-    *
-    * State control essential for recurrent networks
-    *
-    * @param pState reference to a pointer that receives internal states
-    * @param idx requested index for receiving memory state
-    * @param resp Optional: pointer to an already allocated object to contain information in case of failure
-    * @return Status code of the operation: InferenceEngine::OK (0) for success, OUT_OF_BOUNDS (-6) no memory state for
-    * given index
-    */
+     * @brief Gets state control interface for given infer request.
+     *
+     * State control essential for recurrent networks
+     *
+     * @param pState reference to a pointer that receives internal states
+     * @param idx requested index for receiving memory state
+     * @param resp Optional: pointer to an already allocated object to contain information in case of failure
+     * @return Status code of the operation: InferenceEngine::OK (0) for success, OUT_OF_BOUNDS (-6) no memory state for
+     * given index
+     */
     virtual StatusCode QueryState(IVariableState::Ptr& pState, size_t idx, ResponseDesc* resp) noexcept = 0;
+    IE_SUPPRESS_DEPRECATED_END
 };
+
 }  // namespace InferenceEngine

--- a/inference-engine/include/ie_imemory_state.hpp
+++ b/inference-engine/include/ie_imemory_state.hpp
@@ -19,15 +19,18 @@
 namespace InferenceEngine {
 
 /**
+ * @deprecated Use VariableState C++ wrapper instead
  * @interface IVariableState
  * @brief Manages data for reset operations
  */
 class IVariableState : public details::no_copy {
 public:
+    IE_SUPPRESS_DEPRECATED_START
     /**
      * @brief A shared pointer to the IVariableState interface
      */
     using Ptr = std::shared_ptr<IVariableState>;
+    IE_SUPPRESS_DEPRECATED_END
 
     /**
      * @brief Gets name of current variable state, if length of array is not enough name is truncated by len, null
@@ -81,9 +84,13 @@ public:
     virtual StatusCode GetState(Blob::CPtr& state, ResponseDesc* resp) const noexcept = 0;
 };
 
+IE_SUPPRESS_DEPRECATED_START
+
 /**
  * @brief For compatibility reasons.
  */
 using IMemoryState = IVariableState;
+
+IE_SUPPRESS_DEPRECATED_END
 
 }  // namespace InferenceEngine

--- a/inference-engine/src/inference_engine/CMakeLists.txt
+++ b/inference-engine/src/inference_engine/CMakeLists.txt
@@ -6,6 +6,7 @@ set (TARGET_NAME "inference_engine")
 
 file (GLOB LIBRARY_SRC
         ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/cpp/*.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/threading/*.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/shape_infer/ie_built_in_holder.cpp
       )

--- a/inference-engine/src/inference_engine/cpp/ie_variable_state.cpp
+++ b/inference-engine/src/inference_engine/cpp/ie_variable_state.cpp
@@ -1,0 +1,45 @@
+// Copyright (C) 2018-2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+#include "ie_imemory_state.hpp"
+#include "cpp/ie_memory_state.hpp"
+
+namespace InferenceEngine {
+
+IE_SUPPRESS_DEPRECATED_START
+
+VariableState::VariableState(IVariableState::Ptr pState, details::SharedObjectLoader::Ptr plg) : actual(pState), plugin(plg) {
+    if (actual == nullptr) {
+        THROW_IE_EXCEPTION << "VariableState wrapper was not initialized.";
+    }
+}
+
+Blob::CPtr VariableState::GetLastState() const {
+    return GetState();
+}
+
+IE_SUPPRESS_DEPRECATED_END
+
+void VariableState::Reset() {
+    CALL_STATUS_FNC_NO_ARGS(Reset);
+}
+
+std::string VariableState::GetName() const {
+    char name[256];
+    CALL_STATUS_FNC(GetName, name, sizeof(name));
+    return name;
+}
+
+Blob::CPtr VariableState::GetState() const {
+    Blob::CPtr stateBlob;
+    CALL_STATUS_FNC(GetState, stateBlob);
+    return stateBlob;
+}
+
+void VariableState::SetState(Blob::Ptr state) {
+    CALL_STATUS_FNC(SetState, state);
+}
+
+}  // namespace InferenceEngine

--- a/inference-engine/src/plugin_api/cpp_interfaces/base/ie_executable_network_base.hpp
+++ b/inference-engine/src/plugin_api/cpp_interfaces/base/ie_executable_network_base.hpp
@@ -66,9 +66,9 @@ public:
         TO_STATUS(graphPtr = _impl->GetExecGraphInfo());
     }
 
+    IE_SUPPRESS_DEPRECATED_START
     INFERENCE_ENGINE_DEPRECATED("Use InferRequest::QueryState instead")
     StatusCode QueryState(IVariableState::Ptr& pState, size_t idx, ResponseDesc* resp) noexcept override {
-        IE_SUPPRESS_DEPRECATED_START
         try {
             auto v = _impl->QueryState();
             if (idx >= v.size()) {
@@ -81,8 +81,8 @@ public:
         } catch (...) {
             return InferenceEngine::DescriptionBuffer(UNEXPECTED);
         }
-        IE_SUPPRESS_DEPRECATED_END
     }
+    IE_SUPPRESS_DEPRECATED_END
 
     void Release() noexcept override {
         delete this;
@@ -122,9 +122,12 @@ private:
  */
 template <class T>
 inline typename InferenceEngine::ExecutableNetwork make_executable_network(std::shared_ptr<T> impl) {
+    // to suppress warning about deprecated QueryState
+    IE_SUPPRESS_DEPRECATED_START
     typename ExecutableNetworkBase<T>::Ptr net(new ExecutableNetworkBase<T>(impl), [](IExecutableNetwork* p) {
         p->Release();
     });
+    IE_SUPPRESS_DEPRECATED_END
     return InferenceEngine::ExecutableNetwork(net);
 }
 

--- a/inference-engine/src/plugin_api/cpp_interfaces/base/ie_infer_async_request_base.hpp
+++ b/inference-engine/src/plugin_api/cpp_interfaces/base/ie_infer_async_request_base.hpp
@@ -94,6 +94,7 @@ public:
         TO_STATUS(_impl->SetBatch(batch_size));
     }
 
+    IE_SUPPRESS_DEPRECATED_START
     StatusCode QueryState(IVariableState::Ptr& pState, size_t idx, ResponseDesc* resp) noexcept override {
         try {
             auto v = _impl->QueryState();
@@ -108,6 +109,7 @@ public:
             return InferenceEngine::DescriptionBuffer(UNEXPECTED);
         }
     }
+    IE_SUPPRESS_DEPRECATED_END
 
 private:
     ~InferRequestBase() = default;

--- a/inference-engine/src/plugin_api/cpp_interfaces/base/ie_variable_state_base.hpp
+++ b/inference-engine/src/plugin_api/cpp_interfaces/base/ie_variable_state_base.hpp
@@ -12,6 +12,8 @@
 
 namespace InferenceEngine {
 
+IE_SUPPRESS_DEPRECATED_START
+
 /**
  * @brief Default implementation for IVariableState
  * @tparam T Minimal CPP implementation of IVariableStateInternal (e.g. VariableStateInternal)
@@ -53,5 +55,7 @@ public:
         TO_STATUS(state = impl->GetState());
     }
 };
+
+IE_SUPPRESS_DEPRECATED_END
 
 }  // namespace InferenceEngine

--- a/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/mock_ie_ivariable_state.hpp
+++ b/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/mock_ie_ivariable_state.hpp
@@ -12,6 +12,8 @@
 
 using namespace InferenceEngine;
 
+IE_SUPPRESS_DEPRECATED_START
+
 class MockIVariableState : public InferenceEngine::IVariableState {
 public:
     MOCK_QUALIFIED_METHOD3(GetName, const noexcept, StatusCode(char * , size_t, ResponseDesc *));
@@ -19,3 +21,5 @@ public:
     MOCK_QUALIFIED_METHOD2(SetState, noexcept, StatusCode(Blob::Ptr, ResponseDesc *));
     MOCK_QUALIFIED_METHOD2(GetState, const noexcept, StatusCode(Blob::CPtr &, ResponseDesc *));
 };
+
+IE_SUPPRESS_DEPRECATED_END

--- a/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/mock_iexecutable_network.hpp
+++ b/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/mock_iexecutable_network.hpp
@@ -18,6 +18,8 @@
 
 using namespace InferenceEngine;
 
+IE_SUPPRESS_DEPRECATED_START
+
 class MockIExecutableNetwork : public IExecutableNetwork {
 public:
     MOCK_QUALIFIED_METHOD2(GetOutputsInfo, const noexcept, StatusCode(ConstOutputsDataMap  &, ResponseDesc *));
@@ -33,3 +35,5 @@ public:
     MOCK_QUALIFIED_METHOD3(QueryState, noexcept, StatusCode(IVariableState::Ptr &, size_t, ResponseDesc *));
     MOCK_QUALIFIED_METHOD0(Release, noexcept, void());
 };
+
+IE_SUPPRESS_DEPRECATED_END

--- a/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/mock_iinfer_request.hpp
+++ b/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/mock_iinfer_request.hpp
@@ -18,6 +18,8 @@
 
 using namespace InferenceEngine;
 
+IE_SUPPRESS_DEPRECATED_START
+
 class MockIInferRequest : public IInferRequest {
 public:
     MOCK_QUALIFIED_METHOD1(StartAsync, noexcept, StatusCode(ResponseDesc*));
@@ -37,3 +39,5 @@ public:
     MOCK_QUALIFIED_METHOD3(QueryState, noexcept, StatusCode(IVariableState::Ptr &, size_t, ResponseDesc *));
     MOCK_QUALIFIED_METHOD1(Cancel, noexcept, InferenceEngine::StatusCode(ResponseDesc*));
 };
+
+IE_SUPPRESS_DEPRECATED_END

--- a/inference-engine/tests/unit/inference_engine/cpp_interfaces/ie_executable_network_base_test.cpp
+++ b/inference-engine/tests/unit/inference_engine/cpp_interfaces/ie_executable_network_base_test.cpp
@@ -16,6 +16,8 @@ using namespace std;
 using namespace InferenceEngine;
 using namespace InferenceEngine::details;
 
+IE_SUPPRESS_DEPRECATED_START
+
 class ExecutableNetworkThreadSafeAsyncOnlyTests : public ::testing::Test {
 protected:
     shared_ptr<MockExecutableNetworkThreadSafeAsyncOnly> mockExeNetwork;

--- a/inference-engine/tests/unit/inference_engine/cpp_interfaces/ie_memory_state_internal_test.cpp
+++ b/inference-engine/tests/unit/inference_engine/cpp_interfaces/ie_memory_state_internal_test.cpp
@@ -331,6 +331,7 @@ auto req = make_infer_request(mockInferRequestInternal);
 }
 
 TEST_F(VariableStateTests, InfReqVariableStatePropagatesGetNameWithZeroLen) {
+    IE_SUPPRESS_DEPRECATED_START
     auto req = make_infer_request(mockInferRequestInternal);
     std::vector<IVariableStateInternal::Ptr> toReturn;
     toReturn.push_back(mockVariableStateInternal);
@@ -343,9 +344,11 @@ TEST_F(VariableStateTests, InfReqVariableStatePropagatesGetNameWithZeroLen) {
     static_cast<IInferRequest::Ptr>(req)->QueryState(pState, 0, nullptr);
     char *name = reinterpret_cast<char *>(1);
     EXPECT_NO_THROW(pState->GetName(name, 0, nullptr));
+    IE_SUPPRESS_DEPRECATED_END
 }
 
 TEST_F(VariableStateTests, InfReqVariableStatePropagatesGetNameWithLenOfOne) {
+    IE_SUPPRESS_DEPRECATED_START
     auto req = make_infer_request(mockInferRequestInternal);
     std::vector<IVariableStateInternal::Ptr> toReturn;
     toReturn.push_back(mockVariableStateInternal);
@@ -359,9 +362,11 @@ TEST_F(VariableStateTests, InfReqVariableStatePropagatesGetNameWithLenOfOne) {
     char name[1];
     EXPECT_NO_THROW(pState->GetName(name, 1, nullptr));
     EXPECT_STREQ(name, "");
+    IE_SUPPRESS_DEPRECATED_END
 }
 
 TEST_F(VariableStateTests, InfReqVariableStatePropagatesGetNameWithLenOfTwo) {
+    IE_SUPPRESS_DEPRECATED_START
     auto req = make_infer_request(mockInferRequestInternal);
     std::vector<IVariableStateInternal::Ptr> toReturn;
     toReturn.push_back(mockVariableStateInternal);
@@ -375,6 +380,7 @@ TEST_F(VariableStateTests, InfReqVariableStatePropagatesGetNameWithLenOfTwo) {
     char name[2];
     EXPECT_NO_THROW(pState->GetName(name, 2, nullptr));
     EXPECT_STREQ(name, "s");
+    IE_SUPPRESS_DEPRECATED_END
 }
 
 TEST_F(VariableStateTests, InfReqVariableStateCanPropagateSetState) {

--- a/inference-engine/tests/unit/inference_engine/ie_executable_network_test.cpp
+++ b/inference-engine/tests/unit/inference_engine/ie_executable_network_test.cpp
@@ -210,6 +210,8 @@ TEST_F(ExecutableNetworkWithIInferReqTests, CreateInferRequestPtrThrowsIfSetRequ
     ASSERT_THROW(exeNetwork->CreateInferRequestPtr(), InferenceEngine::details::InferenceEngineException);
 }
 
+IE_SUPPRESS_DEPRECATED_START
+
 class ExecutableNetworkBaseTests : public ::testing::Test {
 protected:
     std::shared_ptr<MockIExecutableNetworkInternal> mock_impl;


### PR DESCRIPTION
@apankratovantonp 

Using the following scheme other interfaces can be deprecated:

1. forward declaration in c++ wrapper and move wrapper implementation to src folder
2. don't touch other public API where deprecated interface is used (for BW compatibility). Just deprecated such API (e.g. `QueryState` with `IVariableState` interface)
3. suppress / remove old usages in libraries and remove usages in tests
4. once we can remove deprecated interface:
 a. move header with deprecated interface to `cpp_interfaces/interface` and merge with interla interface in `cpp_interfaces/interface`. Now main interface is not `IVariableStateInternal`, but `IVariableState`
 b. In all usages in public API just use forward declaration (but keep `QueryState` with old interface for compatibility)
 c. Remove `cpp_interfaces/base` class and refactor `cpp_interfaces/interface` instance to better fit C++ wrapper