### PR TITLE
[BUG] Serialize loses runtime info

### DIFF
--- a/inference-engine/src/transformations/src/transformations/serialize.cpp
+++ b/inference-engine/src/transformations/src/transformations/serialize.cpp
@@ -85,7 +85,9 @@ const std::vector<std::string> list_of_names {
 
 class XmlSerializer {
 public:
-    explicit XmlSerializer(pugi::xml_node &xml_node) : m_xml_node{xml_node} {}
+    explicit XmlSerializer(pugi::xml_node &xml_node)
+        : m_xml_node(xml_node) {
+    }
 
     void serialize(const ngraph::Node::RTMap& rt_info) {
         for (const auto& rt_info_name : list_of_names) {

--- a/inference-engine/src/transformations/src/transformations/serialize.cpp
+++ b/inference-engine/src/transformations/src/transformations/serialize.cpp
@@ -77,6 +77,40 @@ std::string get_special_opset_for_op(const ngraph::Node::type_info_t& type_info)
     return "";
 }
 
+namespace rt_info {
+const std::vector<std::string> list_of_names {
+    "PrimitivesPriority",
+    "alt_width",
+};
+
+class XmlSerializer {
+public:
+    explicit XmlSerializer(pugi::xml_node &xml_node) : m_xml_node{xml_node} {}
+
+    void serialize(const ngraph::Node::RTMap& rt_info) {
+        for (const auto& rt_info_name : list_of_names) {
+            const auto &found_rt_info = rt_info.find(rt_info_name);
+            if (found_rt_info != rt_info.end()) {
+                xml_node_append_attribute<std::string>(rt_info_name, found_rt_info->second);
+            }
+        }
+    }
+
+private:
+    template<typename VariantType>
+    void xml_node_append_attribute(const std::string& name,
+                                   const std::shared_ptr<ngraph::Variant>& variant) {
+        if ( auto v = std::dynamic_pointer_cast<ngraph::VariantImpl<VariantType>>(variant) ) {
+            const auto& value = v->get();
+            m_xml_node.append_attribute(name.c_str()).set_value(value.c_str());
+        }
+    }
+
+    pugi::xml_node& m_xml_node;
+};
+
+} // namespace rt_info
+
 class XmlSerializer : public ngraph::AttributeVisitor {
     pugi::xml_node& m_xml_node;
     std::ostream& m_bin_data;
@@ -551,6 +585,7 @@ void ngfunction_2_irv10(pugi::xml_node& netXml,
             XmlSerializer visitor(data, bin_file, node_type_name, custom_opsets);
             NGRAPH_CHECK(node->visit_attributes(visitor),
                          "Visitor API is not supported in ", node);
+            rt_info::XmlSerializer{data}.serialize(node->get_rt_info());
         }
         layer_type_attribute.set_value(
             translate_type_name(node_type_name).c_str());

--- a/inference-engine/tests/functional/inference_engine/ir_serialization/models/conv_with_rt_info.xml
+++ b/inference-engine/tests/functional/inference_engine/ir_serialization/models/conv_with_rt_info.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<net name="Function_0" version="10">
+	<layers>
+		<layer id="0" name="Parameter_69" type="Parameter" version="opset1">
+			<data shape="490, 608, 1, 1" element_type="f32" />
+			<output>
+				<port id="0" precision="FP32">
+					<dim>490</dim>
+					<dim>608</dim>
+					<dim>1</dim>
+					<dim>1</dim>
+				</port>
+			</output>
+		</layer>
+		<layer id="1" name="Parameter_68" type="Parameter" version="opset1">
+			<data shape="1, 608, 34, 60" element_type="f32" />
+			<output>
+				<port id="0" precision="FP32">
+					<dim>1</dim>
+					<dim>608</dim>
+					<dim>34</dim>
+					<dim>60</dim>
+				</port>
+			</output>
+		</layer>
+		<layer id="2" name="Convolution_72" type="Convolution" version="opset1">
+			<data strides="1, 1" dilations="1, 1" pads_begin="0, 0" pads_end="0, 0" auto_pad="explicit" PrimitivesPriority="_IMPLS_"/>
+			<input>
+				<port id="0">
+					<dim>1</dim>
+					<dim>608</dim>
+					<dim>34</dim>
+					<dim>60</dim>
+				</port>
+				<port id="1">
+					<dim>490</dim>
+					<dim>608</dim>
+					<dim>1</dim>
+					<dim>1</dim>
+				</port>
+			</input>
+			<output>
+				<port id="2" precision="FP32">
+					<dim>1</dim>
+					<dim>490</dim>
+					<dim>34</dim>
+					<dim>60</dim>
+				</port>
+			</output>
+		</layer>
+		<layer id="3" name="Result_73" type="Result" version="opset1">
+			<input>
+				<port id="0">
+					<dim>1</dim>
+					<dim>490</dim>
+					<dim>34</dim>
+					<dim>60</dim>
+				</port>
+			</input>
+		</layer>
+	</layers>
+	<edges>
+		<edge from-layer="0" from-port="0" to-layer="2" to-port="1" />
+		<edge from-layer="1" from-port="0" to-layer="2" to-port="0" />
+		<edge from-layer="2" from-port="2" to-layer="3" to-port="0" />
+	</edges>
+</net>

--- a/inference-engine/tests/functional/inference_engine/ir_serialization/serialize.cpp
+++ b/inference-engine/tests/functional/inference_engine/ir_serialization/serialize.cpp
@@ -53,7 +53,7 @@ TEST_P(SerializationTest, CompareFunctions) {
 
     bool success;
     std::string message;
-    std::tie(success, message) = compare_functions(result.getFunction(), expected.getFunction(), true);
+    std::tie(success, message) = compare_functions(result.getFunction(), expected.getFunction(), true, false, true);
     ASSERT_TRUE(success) << message;
 }
 
@@ -69,7 +69,8 @@ INSTANTIATE_TEST_CASE_P(IRSerialization, SerializationTest,
                         std::make_tuple("experimental_detectron_detection_output_opset6.xml", ""),
                         std::make_tuple("nms5.xml", "nms5.bin"),
                         std::make_tuple("shape_of.xml", ""),
-                        std::make_tuple("pad_with_shape_of.xml", "")));
+                        std::make_tuple("pad_with_shape_of.xml", ""),
+                        std::make_tuple("conv_with_rt_info.xml", "")));
 
 INSTANTIATE_TEST_CASE_P(ONNXSerialization, SerializationTest,
         testing::Values(std::make_tuple("add_abc.prototxt", ""),


### PR DESCRIPTION
Introduce `ngraph::Node - rt_info` serialization.

Ticket: 46177

----
`rt_info` names came from https://github.com/openvinotoolkit/openvino/blob/4d98d7ceeea65b373a53ae8e3616a44f1860cec6/inference-engine/src/readers/ir_reader/ie_ir_parser.cpp#L771