### PR TITLE
Added PythonAPI For LowLatency Transformation

### DIFF
--- a/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api.pyx
+++ b/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api.pyx
@@ -20,3 +20,6 @@ from libcpp cimport bool
 
 def ApplyMOCTransformations(IENetwork network, bool cf):
     C.ApplyMOCTransformations(network.impl, cf)
+
+def ApplyLowLatencyTransformation(IENetwork network):
+    C.ApplyLowLatencyTransformation(network.impl)

--- a/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api_impl.cpp
+++ b/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api_impl.cpp
@@ -5,10 +5,26 @@
 #include "offline_transformations_api_impl.hpp"
 
 #include <moc_transformations.hpp>
+
+#include <transformations/control_flow/unroll_tensor_iterator.hpp>
+
+#include <ngraph/pass/low_latency.hpp>
 #include <ngraph/pass/manager.hpp>
 
 void InferenceEnginePython::ApplyMOCTransformations(InferenceEnginePython::IENetwork network, bool cf) {
     ngraph::pass::Manager manager;
     manager.register_pass<ngraph::pass::MOCTransformations>(cf);
+    manager.run_passes(network.actual->getFunction());
+}
+
+void InferenceEnginePython::ApplyLowLatencyTransformation(InferenceEnginePython::IENetwork network) {
+    ngraph::pass::Manager manager;
+    manager.register_pass<ngraph::pass::LowLatency>();
+    manager.register_pass<ngraph::pass::UnrollTensorIterator>();
+
+    auto pass_config = manager.get_pass_config();
+    pass_config->set_callback<ngraph::pass::UnrollTensorIterator>([](const std::shared_ptr<const ngraph::Node> &node) -> bool {
+        return node->get_rt_info().count("UNROLL_TI") == 0;
+    });
     manager.run_passes(network.actual->getFunction());
 }

--- a/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api_impl.hpp
+++ b/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api_impl.hpp
@@ -11,4 +11,6 @@ namespace InferenceEnginePython {
 
 void ApplyMOCTransformations(InferenceEnginePython::IENetwork network, bool cf);
 
+void ApplyLowLatencyTransformation(InferenceEnginePython::IENetwork network);
+
 };  // namespace InferenceEnginePython

--- a/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api_impl_defs.pxd
+++ b/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api_impl_defs.pxd
@@ -3,3 +3,5 @@ from ..inference_engine.ie_api_impl_defs cimport IENetwork
 
 cdef extern from "offline_transformations_api_impl.hpp" namespace "InferenceEnginePython":
     cdef void ApplyMOCTransformations(IENetwork network, bool cf)
+
+    cdef void ApplyLowLatencyTransformation(IENetwork network)


### PR DESCRIPTION
**Description:**
Added Python API for LowLatency transformation into `offline_transformations_api` target. The purpose of this transformation in offline is to have an ability to see how model has been changed after applying LowLatency transformation.

**Details:**
As LowLatency currently has two steps (LowLatency + UnrollTensorIterator) we have to combine them into single `pass::Manager` and set callback for `UnrollTensorIterator` to enable it as we do in MKLDNNPlugin.

**Usage:**

```py
from openvino.inference_engine import IECore
from openvino.offline_transformations import ApplyLowLatencyTransformation
ie = IECore()
net = ie.read_network(model="path_to_xml", weights="path_to_bin")
ApplyLowLatencyTransformation(net)
net.serialize("path_to_xml", "path_to_bin")
```