### PR TITLE
Fix virtual inheritance for class PadLayerTest

### DIFF
--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/pad.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/pad.hpp
@@ -27,7 +27,7 @@ typedef std::tuple<
 > padLayerTestParamsSet;
 
 class PadLayerTest : public testing::WithParamInterface<padLayerTestParamsSet>,
-                     public LayerTestsUtils::LayerTestsCommon {
+                     virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<padLayerTestParamsSet> obj);
 


### PR DESCRIPTION
Fix virtual inheritance for class PadLayerTest
#CVS-43952