### PR TITLE
Enable CNN2D tests for GNA library 2.1

### DIFF
--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/convolution.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/convolution.cpp
@@ -6,10 +6,30 @@
 
 #include "single_layer_tests/convolution.hpp"
 #include "common_test_utils/test_constants.hpp"
+#include "../skip_tests_check.hpp"
 
 using namespace LayerTestsDefinitions;
 
 namespace {
+
+class GnaConvolutionLayerTest : public ConvolutionLayerTest, GnaLayerTestCheck {
+protected:
+    void Run() override {
+        GnaLayerTestCheck::SkipTestCheck();
+
+        if (!GnaLayerTestCheck::skipTest) {
+            ConvolutionLayerTest::Run();
+        }
+    }
+
+    void SetUp() {
+        ConvolutionLayerTest::SetUp();
+    }
+};
+
+TEST_P(GnaConvolutionLayerTest, CompareWithRefs) {
+    Run();
+}
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
         InferenceEngine::Precision::FP32,
@@ -187,8 +207,7 @@ INSTANTIATE_TEST_CASE_P(smoke_Convolution2D_AutoPadValid_MapTo1d, ConvolutionLay
                                 ::testing::Values(CommonTestUtils::DEVICE_GNA)),
                         ConvolutionLayerTest::getTestCaseName);
 
-// TODO: Enable for GNA 2.1 library
-INSTANTIATE_TEST_CASE_P(DISABLED_smoke_Convolution2D_Kernels2D, ConvolutionLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_Convolution2D_Kernels2D, GnaConvolutionLayerTest,
     ::testing::Combine(
         conv2DParams_Kernels2D,
         ::testing::ValuesIn(netPrecisions),
@@ -198,5 +217,5 @@ INSTANTIATE_TEST_CASE_P(DISABLED_smoke_Convolution2D_Kernels2D, ConvolutionLayer
         ::testing::Values(InferenceEngine::Layout::ANY),
         ::testing::Values(input2DNCHW),
         ::testing::Values(CommonTestUtils::DEVICE_GNA)),
-    ConvolutionLayerTest::getTestCaseName);
+    GnaConvolutionLayerTest::getTestCaseName);
 }  // namespace

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/skip_tests_check.hpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/skip_tests_check.hpp
@@ -18,8 +18,8 @@ protected:
 
                 if (gnaLibVer.rfind("2.1", 0) != 0) {
                     GTEST_SKIP() << "Disabled test due to GNA library version being < 2.1" << std::endl;
-                    skipTest = false;
                 }
+                skipTest = false;
             }
         }
     }

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/skip_tests_check.hpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/skip_tests_check.hpp
@@ -1,0 +1,26 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gna/gna_config.hpp>
+
+class GnaLayerTestCheck : virtual public LayerTestsUtils::LayerTestsCommon {
+protected:
+    bool skipTest = true;
+
+    void SkipTestCheck() {
+        InferenceEngine::Core ie_core;
+        std::vector<std::string> metrics = ie_core.GetMetric(targetDevice, METRIC_KEY(SUPPORTED_METRICS));
+
+        if (targetDevice == "GNA") {
+            if (std::find(metrics.begin(), metrics.end(), METRIC_KEY(GNA_LIBRARY_FULL_VERSION)) != metrics.end()) {
+                std::string gnaLibVer = ie_core.GetMetric(targetDevice, METRIC_KEY(GNA_LIBRARY_FULL_VERSION));
+
+                if (gnaLibVer.rfind("2.1", 0) != 0) {
+                    GTEST_SKIP() << "Disabled test due to GNA library version being < 2.1" << std::endl;
+                    skipTest = false;
+                }
+            }
+        }
+    }
+};

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/convolution_relu_sequence.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/convolution_relu_sequence.cpp
@@ -8,10 +8,31 @@
 
 #include "subgraph_tests/convolution_relu_sequence.hpp"
 #include "common_test_utils/test_constants.hpp"
+#include "../skip_tests_check.hpp"
 
 using namespace SubgraphTestsDefinitions;
 
 namespace {
+
+class GnaConvolutionReluSequenceTest : public ConvolutionReluSequenceTest, GnaLayerTestCheck {
+protected:
+    void Run() override {
+        GnaLayerTestCheck::SkipTestCheck();
+
+        if (!GnaLayerTestCheck::skipTest) {
+            ConvolutionReluSequenceTest::Run();
+        }
+    }
+
+    void SetUp() {
+        ConvolutionReluSequenceTest::SetUp();
+    }
+};
+
+TEST_P(GnaConvolutionReluSequenceTest, CompareWithRefs) {
+    Run();
+}
+
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
@@ -130,7 +151,7 @@ const std::vector<std::map<std::string, std::string> > configs = {
 };
 
 // Enable when using GNA 2.1 library
-INSTANTIATE_TEST_CASE_P(DISABLED_smoke_ConvolutionReluSequenceTest, ConvolutionReluSequenceTest,
+INSTANTIATE_TEST_CASE_P(smoke_ConvolutionReluSequenceTest, GnaConvolutionReluSequenceTest,
     ::testing::Combine(
         ::testing::ValuesIn(convReluSpecificParamsAllAll),
         ::testing::ValuesIn(netPrecisions),
@@ -138,6 +159,6 @@ INSTANTIATE_TEST_CASE_P(DISABLED_smoke_ConvolutionReluSequenceTest, ConvolutionR
         ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
         ::testing::Values(CommonTestUtils::DEVICE_GNA),
         ::testing::ValuesIn(configs)),
-    ConvolutionReluSequenceTest::getTestCaseName);
+    GnaConvolutionReluSequenceTest::getTestCaseName);
 
 } // namespace


### PR DESCRIPTION
This patch:
- allows automatic enabling/disabling of tests during runtime based on GNA library version detected
- requires some additional code in test implementation
- is useful for skipping tests which are HW/lib version dependent.