### PR TITLE
Extend and fix input/output precisions support in functional tests

### DIFF
--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/utils/ngraph_helpers.hpp
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/utils/ngraph_helpers.hpp
@@ -239,7 +239,7 @@ inline ngraph::NodeVector castOps2Nodes(const std::vector<std::shared_ptr<opType
 
 std::vector<std::vector<std::uint8_t>> interpreterFunction(const std::shared_ptr<Function> &function,
                                                            const std::vector<std::vector<std::uint8_t>> &inputs,
-                                                           element::Type_t inType = element::Type_t::undefined,
+                                                           const std::vector<ngraph::element::Type> &inputTypes = {},
                                                            const std::vector<ngraph::element::Type_t> convertType = {});
 
 //
@@ -253,7 +253,7 @@ void CompareFunctions(const Function &actual, const Function &expected);
 
 std::shared_ptr<Function> foldFunction(const std::shared_ptr<Function> &function,
                                        const std::vector<std::vector<std::uint8_t>> &inputs,
-                                       element::Type_t inpType = element::Type_t::undefined);
+                                       const std::vector<ngraph::element::Type> &inputTypes = {});
 
 std::vector<std::vector<std::uint8_t>> getConstData(const std::shared_ptr<Function> &function,
                                                     std::vector<ngraph::element::Type_t> convertType = {});


### PR DESCRIPTION
* Use actual blobs type to get nGraph element type, when generating inputs and calculating reference results.
  It will allow to run tests with `undefined` preset and use real type, returned from the device to generate and process input.
  It also fixes the case with several inputs with different type.
* Extend `convertOutputPrecision` function to fully support conversions from/to fp16/bf16 types.
  The device might return blobs in that formats, so they need to be supported by the testing framework.