### PR TITLE
[GNA] Fixed issue with multiple connections between pair of nodes (Split=>Concat)

### DIFF
--- a/inference-engine/src/gna_plugin/gna_graph_tools.hpp
+++ b/inference-engine/src/gna_plugin/gna_graph_tools.hpp
@@ -573,7 +573,7 @@ inline void CNNNetworkInsertLayer(CNNLayerPtr after,
 
         // separately checking case of possible single unconnected output of given layer
         if (!bLocated && !before && !hasOutputIndex) {
-            if (nUnconnectedOData != 1) {
+            if (nUnconnectedOData != 1 && number_of_connections_between_after_n_before <= 1) {
                 THROW_GNA_EXCEPTION << "Cannot insert layer: " << LAYER_NAME(layerToInsert) <<" after: " << LAYER_NAME(after);
             }
 

--- a/inference-engine/src/gna_plugin/gna_graph_tools.hpp
+++ b/inference-engine/src/gna_plugin/gna_graph_tools.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2021 Intel Corporation
+// Copyright (C) 2018-2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -532,6 +532,7 @@ inline void CNNNetworkInsertLayer(CNNLayerPtr after,
                 auto input = inputIt->second;
                 if (before != nullptr && input.get() != before.get())
                     continue;
+
                 // located data
                 for (auto input_port_idx : CNNLayerFindInsDataIdxes(data, input)) {
                     if (((size_t)inDataIndex != invalid_data_idx && (size_t)inDataIndex == input_port_idx) || (size_t)inDataIndex == invalid_data_idx)
@@ -543,11 +544,10 @@ inline void CNNNetworkInsertLayer(CNNLayerPtr after,
 
                 bLocated = true;
 
+                // erasing only one particular connection
                 // we must check if there is only one connection between after <=> before
-                if (number_of_connections_between_after_n_before == 1) {
-                    // erasing only one particular connection
+                if (number_of_connections_between_after_n_before == 1)
                     getInputTo(data).erase(inputIt->first);
-                }
 
                 if (before != nullptr) {
                     break;

--- a/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.cpp
+++ b/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.cpp
@@ -852,7 +852,10 @@ void InsertCopyLayerPass::run() {
                         if ((LayerInfo(l).isConcat() || LayerInfo(l).isCrop() || LayerInfo(l).isSplit()) && LayerInfo(current_layer).isMemory()) {
                             // Concat|Split|Crop -> Memory case
                             delayed_copy_insertion_tuples.push_back(std::make_tuple(original_parent, original_child, input_idx));
-                        } else if ((LayerInfo(l).isSplit() || LayerInfo(l).isMemory() || LayerInfo(l).isCrop()) && LayerInfo(current_layer).isConcat()) {
+                        } else if (LayerInfo(l).isMemory() && LayerInfo(current_layer).isConcat()) {
+                            // Memory -> Concat case
+                            delayed_copy_insertion_tuples.push_back(std::make_tuple(original_parent, original_child, input_idx));
+                        } else if ((LayerInfo(l).isSplit() || LayerInfo(l).isCrop()) && LayerInfo(current_layer).isConcat()) {
                             // Split|Crop|Memory -> Concat case
                             // concat may be connected to previous layer with multiple connections
                             copy_insertion_tuples.push_back(std::make_tuple(original_parent, original_child, input_idx));

--- a/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.cpp
+++ b/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.cpp
@@ -848,6 +848,7 @@ void InsertCopyLayerPass::run() {
                             current_layer = next_layer;
                         }
 
+
                         if ((LayerInfo(l).isConcat() || LayerInfo(l).isCrop() || LayerInfo(l).isSplit()) && LayerInfo(current_layer).isMemory()) {
                             // Concat|Split|Crop -> Memory case
                             delayed_copy_insertion_tuples.push_back(std::make_tuple(original_parent, original_child, input_idx));

--- a/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.cpp
+++ b/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.cpp
@@ -826,7 +826,6 @@ void InsertCopyLayerPass::run() {
         if ((LayerInfo(l).isCrop() && !LayerInfo(l).isCropAffined()) || LayerInfo(l).isConcat() || LayerInfo(l).isSplit() || LayerInfo(l).isMemory()) {
             std::vector<std::tuple<CNNLayerPtr, CNNLayerPtr, size_t>> copy_insertion_tuples;
             std::vector<std::tuple<CNNLayerPtr, CNNLayerPtr, size_t>> delayed_copy_insertion_tuples;
-
             for (auto output : l->outData) {
                 auto& inputTo = getInputTo(output);
                 for (auto& childLayer : inputTo) {
@@ -854,6 +853,7 @@ void InsertCopyLayerPass::run() {
                             delayed_copy_insertion_tuples.push_back(std::make_tuple(original_parent, original_child, input_idx));
                         } else if ((LayerInfo(l).isSplit() || LayerInfo(l).isMemory() || LayerInfo(l).isCrop()) && LayerInfo(current_layer).isConcat()) {
                             // Split|Crop|Memory -> Concat case
+                            // concat may be connected to previous layer with multiple connections
                             copy_insertion_tuples.push_back(std::make_tuple(original_parent, original_child, input_idx));
                         }
                     }
@@ -2003,7 +2003,7 @@ void MoveFakeQuantizeLayerIntoQuantParamsPass :: run() {
 }
 
 int PassManager::run(int index) {
-#ifdef PLOT || defined ENABLE_V7_SERIALIZE
+#if defined PLOT || defined ENABLE_V7_SERIALIZE
     auto dumpNetworkAfterPass = [&index, this] (std::shared_ptr<Pass> pass) {
         std::string name = std::string("gna_passes_") + (index < 10 ? "0" : "") + std::to_string(index) + "_" + pass->getName();
 #ifdef PLOT

--- a/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.cpp
+++ b/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.cpp
@@ -856,15 +856,15 @@ void InsertCopyLayerPass::run() {
                             // Memory -> Concat case
                             // If concat is connected to input - we delay copy, for other cases we treat it normally
                             bool concat_has_input = false;
-                            for (auto input_to_concat : current_layer->insData)
-                            {
+                            for (auto input_to_concat : current_layer->insData) {
                                 auto input_layer_to_concat = getCreatorLayer(input_to_concat.lock()).lock();
                                 concat_has_input |= LayerInfo(input_layer_to_concat).isMemory();
                             }
-                            if (concat_has_input)
+                            if (concat_has_input) {
                                 delayed_copy_insertion_tuples.push_back(std::make_tuple(original_parent, original_child, input_idx));
-                            else
+                            } else {
                                 copy_insertion_tuples.push_back(std::make_tuple(original_parent, original_child, input_idx));
+                            }
                         } else if ((LayerInfo(l).isSplit() || LayerInfo(l).isCrop()) && LayerInfo(current_layer).isConcat()) {
                             // Split|Crop|Memory -> Concat case
                             // concat may be connected to previous layer with multiple connections

--- a/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.cpp
+++ b/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.cpp
@@ -2019,7 +2019,7 @@ int PassManager::run(int index) {
     auto dumpNetworkAfterPass = [] (std::shared_ptr<Pass> ) {};
 #endif
 
-    for (auto & pass : passes) {
+    for (auto && pass : passes) {
         if (settings.runBeforeCopy != pass->runBeforeCopyPass()) {
             continue;
         }

--- a/inference-engine/src/legacy_api/src/network_serializer_v7.cpp
+++ b/inference-engine/src/legacy_api/src/network_serializer_v7.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -11,6 +11,7 @@
 #include <unordered_set>
 #include <sstream>
 
+#include "cpp/ie_cnn_network.h"
 #include "caseless.hpp"
 #include "legacy/ie_layers.h"
 #include "xml_parse_utils.h"
@@ -255,7 +256,7 @@ void UpdateStdLayerParams(const CNNLayer::Ptr& layer) {
     }
 }
 
-std::size_t FillXmlDoc(const InferenceEngine::ICNNNetwork& network, pugi::xml_document& doc,
+std::size_t FillXmlDoc(const InferenceEngine::CNNNetwork& network, pugi::xml_document& doc,
                        const bool execGraphInfoSerialization, const bool dumpWeights) {
     const std::vector<CNNLayerPtr> ordered = InferenceEngine::details::CNNNetSortTopologically(network);
     pugi::xml_node netXml = doc.append_child("net");
@@ -378,7 +379,7 @@ std::size_t FillXmlDoc(const InferenceEngine::ICNNNetwork& network, pugi::xml_do
     return dataOffset;
 }
 
-void SerializeBlobs(std::ostream& stream, const InferenceEngine::ICNNNetwork& network) {
+void SerializeBlobs(std::ostream& stream, const InferenceEngine::CNNNetwork& network) {
     const std::vector<CNNLayerPtr> ordered = InferenceEngine::details::CNNNetSortTopologically(network);
     for (auto&& node : ordered) {
         if (!node->blobs.empty()) {
@@ -394,9 +395,7 @@ void SerializeBlobs(std::ostream& stream, const InferenceEngine::ICNNNetwork& ne
         }
     }
 
-    InputsDataMap inputInfo;
-    network.getInputsInfo(inputInfo);
-
+    InputsDataMap inputInfo = network.getInputsInfo();
     for (auto ii : inputInfo) {
         const PreProcessInfo& pp = ii.second->getPreProcess();
         size_t nInChannels = pp.getNumberOfChannels();
@@ -419,7 +418,7 @@ void SerializeBlobs(std::ostream& stream, const InferenceEngine::ICNNNetwork& ne
 }  // namespace
 
 void Serialize(const std::string& xmlPath, const std::string& binPath,
-               const InferenceEngine::ICNNNetwork& network) {
+               const InferenceEngine::CNNNetwork& network) {
     // A flag for serializing executable graph information (not complete IR)
     bool execGraphInfoSerialization = false;
     pugi::xml_document doc;

--- a/inference-engine/src/legacy_api/src/network_serializer_v7.cpp
+++ b/inference-engine/src/legacy_api/src/network_serializer_v7.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2021 Intel Corporation
+// Copyright (C) 2018-2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -11,7 +11,6 @@
 #include <unordered_set>
 #include <sstream>
 
-#include "cpp/ie_cnn_network.h"
 #include "caseless.hpp"
 #include "legacy/ie_layers.h"
 #include "xml_parse_utils.h"
@@ -256,7 +255,7 @@ void UpdateStdLayerParams(const CNNLayer::Ptr& layer) {
     }
 }
 
-std::size_t FillXmlDoc(const InferenceEngine::CNNNetwork& network, pugi::xml_document& doc,
+std::size_t FillXmlDoc(const InferenceEngine::ICNNNetwork& network, pugi::xml_document& doc,
                        const bool execGraphInfoSerialization, const bool dumpWeights) {
     const std::vector<CNNLayerPtr> ordered = InferenceEngine::details::CNNNetSortTopologically(network);
     pugi::xml_node netXml = doc.append_child("net");
@@ -379,7 +378,7 @@ std::size_t FillXmlDoc(const InferenceEngine::CNNNetwork& network, pugi::xml_doc
     return dataOffset;
 }
 
-void SerializeBlobs(std::ostream& stream, const InferenceEngine::CNNNetwork& network) {
+void SerializeBlobs(std::ostream& stream, const InferenceEngine::ICNNNetwork& network) {
     const std::vector<CNNLayerPtr> ordered = InferenceEngine::details::CNNNetSortTopologically(network);
     for (auto&& node : ordered) {
         if (!node->blobs.empty()) {
@@ -395,7 +394,9 @@ void SerializeBlobs(std::ostream& stream, const InferenceEngine::CNNNetwork& net
         }
     }
 
-    InputsDataMap inputInfo = network.getInputsInfo();
+    InputsDataMap inputInfo;
+    network.getInputsInfo(inputInfo);
+
     for (auto ii : inputInfo) {
         const PreProcessInfo& pp = ii.second->getPreProcess();
         size_t nInChannels = pp.getNumberOfChannels();
@@ -418,7 +419,7 @@ void SerializeBlobs(std::ostream& stream, const InferenceEngine::CNNNetwork& net
 }  // namespace
 
 void Serialize(const std::string& xmlPath, const std::string& binPath,
-               const InferenceEngine::CNNNetwork& network) {
+               const InferenceEngine::ICNNNetwork& network) {
     // A flag for serializing executable graph information (not complete IR)
     bool execGraphInfoSerialization = false;
     pugi::xml_document doc;

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/connect_split_concat.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/connect_split_concat.cpp
@@ -1,0 +1,32 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "subgraph_tests/multiple_connect_split_concat.hpp"
+#include "subgraph_tests/connect_split_concat_concat.hpp"
+
+using namespace SubgraphTestsDefinitions;
+
+namespace {
+
+std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP32,
+                                                         InferenceEngine::Precision::FP16
+};
+
+std::map<std::string, std::string> additional_config = {
+        {"GNA_COMPACT_MODE", "NO"}
+};
+
+INSTANTIATE_TEST_CASE_P(multiple_connect_split_concat, MultipleConnectSplitConcatTest,
+        ::testing::Combine(
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(CommonTestUtils::DEVICE_GNA),
+        ::testing::Values(additional_config)),
+        MultipleConnectSplitConcatTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(connect_split_concat_concat, SplitConcatConcatTest,
+        ::testing::Combine(
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(CommonTestUtils::DEVICE_GNA),
+        ::testing::Values(additional_config)),
+        MultipleConnectSplitConcatTest::getTestCaseName);
+}  // namespace

--- a/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/connect_split_concat_concat.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/connect_split_concat_concat.hpp
@@ -1,0 +1,14 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#include "shared_test_classes/subgraph/connect_split_concat_concat.hpp"
+
+namespace SubgraphTestsDefinitions {
+
+TEST_P(SplitConcatConcatTest, CompareWithRefs) {
+    Run();
+};
+
+}  // namespace SubgraphTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/multiple_connect_split_concat.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/multiple_connect_split_concat.hpp
@@ -1,0 +1,14 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#include "shared_test_classes/subgraph/multiple_connect_split_concat.hpp"
+
+namespace SubgraphTestsDefinitions {
+
+TEST_P(MultipleConnectSplitConcatTest, CompareWithRefs) {
+    Run();
+};
+
+}  // namespace SubgraphTestsDefinitions

--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/connect_split_concat_concat.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/connect_split_concat_concat.hpp
@@ -1,0 +1,32 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+#include "shared_test_classes/base/layer_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+#include "common_test_utils/test_constants.hpp"
+
+namespace SubgraphTestsDefinitions {
+
+typedef std::tuple<
+        InferenceEngine::Precision,         // Network Precision
+        std::string,                        // Target Device
+        std::map<std::string, std::string>  //Configuration
+> SplitConcatConcatParams;
+
+class SplitConcatConcatTest:
+        public testing::WithParamInterface<SplitConcatConcatParams>,
+        public LayerTestsUtils::LayerTestsCommon{
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<SplitConcatConcatParams> &obj);
+protected:
+    void SetUp() override;
+};
+
+}  // namespace SubgraphTestsDefinitions

--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/multiple_connect_split_concat.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/multiple_connect_split_concat.hpp
@@ -1,0 +1,32 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+#include "shared_test_classes/base/layer_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+#include "common_test_utils/test_constants.hpp"
+
+namespace SubgraphTestsDefinitions {
+
+typedef std::tuple<
+        InferenceEngine::Precision,         // Network Precision
+        std::string,                        // Target Device
+        std::map<std::string, std::string>  //Configuration
+> MultipleConnectSplitConcatParams;
+
+class MultipleConnectSplitConcatTest:
+        public testing::WithParamInterface<MultipleConnectSplitConcatParams>,
+        public LayerTestsUtils::LayerTestsCommon{
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<MultipleConnectSplitConcatParams> &obj);
+protected:
+    void SetUp() override;
+};
+
+}  // namespace SubgraphTestsDefinitions

--- a/inference-engine/tests/functional/shared_test_classes/src/subgraph/connect_split_concat_concat.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/subgraph/connect_split_concat_concat.cpp
@@ -1,0 +1,42 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/subgraph/connect_split_concat_concat.hpp"
+
+namespace SubgraphTestsDefinitions {
+std::string SplitConcatConcatTest::getTestCaseName(const testing::TestParamInfo<SplitConcatConcatParams> &obj) {
+    InferenceEngine::Precision netPrecision;
+    std::string targetDevice;
+    std::map<std::string, std::string> configuration;
+    std::tie(netPrecision, targetDevice, configuration) = obj.param;
+
+    std::ostringstream result;
+    result << "netPRC=" << netPrecision.name() << "_";
+    result << "targetDevice=" << targetDevice << "_";
+    for (auto const &configItem : configuration) {
+        result << "_configItem=" << configItem.first << "_" << configItem.second;
+    }
+    return result.str();
+}
+
+void SplitConcatConcatTest::SetUp() {
+    InferenceEngine::Precision netPrecision;
+    std::tie(netPrecision, targetDevice, configuration) = this->GetParam();
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+
+    auto params = ngraph::builder::makeParams(ngPrc, {{1, 256}});
+    auto relu_start = std::make_shared<ngraph::opset1::Relu>(params[0]);
+    auto split = ngraph::builder::makeSplit(relu_start, ngPrc, 2, 1);
+    auto const_concat = ngraph::builder::makeConstant(ngPrc, {1, 96}, std::vector<float>{0});
+    auto const_concat_2 = ngraph::builder::makeConstant(ngPrc, {1, 96}, std::vector<float>{0});
+    auto concat = std::make_shared<ngraph::opset1::Concat>(ngraph::OutputVector{split->output(0), const_concat}, 1);
+    auto concat_2 = std::make_shared<ngraph::opset1::Concat>(ngraph::OutputVector{concat, const_concat_2},
+                                                             1);
+    auto relu = std::make_shared<ngraph::opset1::Relu>(concat_2);
+    ngraph::ResultVector resultVector{
+            std::make_shared<ngraph::opset1::Result>(relu)
+    };
+    function = std::make_shared<ngraph::Function>(resultVector, params, "Multiple_connection_split_concat");
+}
+} // namespace SubgraphTestsDefinitions

--- a/inference-engine/tests/functional/shared_test_classes/src/subgraph/multiple_connect_split_concat.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/subgraph/multiple_connect_split_concat.cpp
@@ -1,0 +1,42 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/subgraph/multiple_connect_split_concat.hpp"
+
+namespace SubgraphTestsDefinitions {
+std::string MultipleConnectSplitConcatTest::getTestCaseName(const testing::TestParamInfo<MultipleConnectSplitConcatParams> &obj) {
+    InferenceEngine::Precision netPrecision;
+    std::string targetDevice;
+    std::map<std::string, std::string> configuration;
+    std::tie(netPrecision, targetDevice, configuration) = obj.param;
+
+    std::ostringstream result;
+    result << "netPRC=" << netPrecision.name() << "_";
+    result << "targetDevice=" << targetDevice << "_";
+    for (auto const &configItem : configuration) {
+        result << "_configItem=" << configItem.first << "_" << configItem.second;
+    }
+    return result.str();
+}
+
+void MultipleConnectSplitConcatTest::SetUp() {
+    InferenceEngine::Precision netPrecision;
+    std::tie(netPrecision, targetDevice, configuration) = this->GetParam();
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+
+    auto params = ngraph::builder::makeParams(ngPrc, {{1, 256}});
+    auto relu_start = std::make_shared<ngraph::opset1::Relu>(params[0]);
+    auto split = ngraph::builder::makeSplit(relu_start, ngPrc, 1, 1);
+    auto concat = std::make_shared<ngraph::opset1::Concat>(ngraph::OutputVector{split->output(0), split->output(0)}, 1);
+    auto concat_2 = std::make_shared<ngraph::opset1::Concat>(ngraph::OutputVector{split->output(0), split->output(0)},
+                                                             1);
+    auto relu = std::make_shared<ngraph::opset1::Relu>(concat);
+    auto relu_2 = std::make_shared<ngraph::opset1::Relu>(concat_2);
+    ngraph::ResultVector resultVector{
+            std::make_shared<ngraph::opset1::Result>(relu),
+            std::make_shared<ngraph::opset1::Result>(relu_2)
+    };
+    function = std::make_shared<ngraph::Function>(resultVector, params, "Multiple_connection_split_concat");
+}
+} // namespace SubgraphTestsDefinitions

--- a/inference-engine/tests_deprecated/unit/engines/gna/fp32_non_quantized_tests.cpp
+++ b/inference-engine/tests_deprecated/unit/engines/gna/fp32_non_quantized_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/inference-engine/tests_deprecated/unit/engines/gna/fp32_non_quantized_tests.cpp
+++ b/inference-engine/tests_deprecated/unit/engines/gna/fp32_non_quantized_tests.cpp
@@ -343,7 +343,7 @@ TEST_F(FP32NonQuantizedTest, InputSplitConcatReshapeUnalignedPropagateForward) {
 
 TEST_F(FP32NonQuantizedTest, LSTMCellPropagateForward) {
     std::vector<float> input_data(96, 0.10f);
-    std::vector<float> expected_result(32, 0.27119124f);
+    std::vector<float> expected_result(32, 0.14366889f);
 
     assert_that().onInferModel(LSTMCellOnlyModel()).withWeigthsPattern({0.1f})
             .inNotCompactMode().gna().propagate_forward().onCPU()


### PR DESCRIPTION
Fixed cases where GNA plugin did not correctly handled following patterns:
- multiple connections between same pair split => concat 
- split => concat => concat 
- memory => concat

Fix an issue of serializing IRv7 concat => memory pattern
