### PR TITLE
Add missing types in convertIE2nGraphPrc() test util function.

### DIFF
--- a/inference-engine/tests/ie_test_utils/functional_test_utils/include/functional_test_utils/precision_utils.hpp
+++ b/inference-engine/tests/ie_test_utils/functional_test_utils/include/functional_test_utils/precision_utils.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Intel Corporation
+// Copyright (C) 2019-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -19,6 +19,8 @@ inline ::ngraph::element::Type convertIE2nGraphPrc(const InferenceEngine::Precis
     switch (pType) {
         case InferenceEngine::Precision::UNSPECIFIED:
             return ::ngraph::element::Type(::ngraph::element::Type_t::undefined);
+        case InferenceEngine::Precision::FP64:
+            return ::ngraph::element::Type(::ngraph::element::Type_t::f64);
         case InferenceEngine::Precision::FP32:
             return ::ngraph::element::Type(::ngraph::element::Type_t::f32);
         case InferenceEngine::Precision::FP16:
@@ -33,6 +35,8 @@ inline ::ngraph::element::Type convertIE2nGraphPrc(const InferenceEngine::Precis
             return ::ngraph::element::Type(::ngraph::element::Type_t::u16);
         case InferenceEngine::Precision::I16:
             return ::ngraph::element::Type(::ngraph::element::Type_t::i16);
+        case InferenceEngine::Precision::U32:
+            return ::ngraph::element::Type(::ngraph::element::Type_t::u32);
         case InferenceEngine::Precision::I32:
             return ::ngraph::element::Type(::ngraph::element::Type_t::i32);
         case InferenceEngine::Precision::I64:


### PR DESCRIPTION
During work on Serialization SLT for GroupConvolution I've noticed that FP64 & U32 are not supported in convertIE2nGraphPrc(). Because of this my SSLT tests were failing - so here is the fix.

If for some reason not supporting these types are by design, please explain and reject this PR - for me it looks like a bug.