### PR TITLE
Optimizations for precision conversion operations in nGraph reference implementations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,7 @@
 	path = inference-engine/samples/thirdparty/gflags
 	url = https://github.com/gflags/gflags.git
 	ignore = dirty
+[submodule "thirdparty/xbyak"]
+	path = thirdparty/xbyak
+	url = https://github.com/herumi/xbyak.git
+	ignore = dirty

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,7 @@ function(openvino_developer_export_targets)
         "A list of OpenVINO exported components" FORCE)
 endfunction()
 
+add_subdirectory(thirdparty)
 add_subdirectory(openvino)
 add_subdirectory(thirdparty)
 build_ngraph()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,7 @@ add_subdirectory(docs)
 ie_shellcheck_process(DIRECTORY "${OpenVINO_MAIN_SOURCE_DIR}"
                       SKIP "${OpenVINO_MAIN_SOURCE_DIR}/bin"
                            "${OpenVINO_MAIN_SOURCE_DIR}/build"
+                           "${OpenVINO_MAIN_SOURCE_DIR}/thirdparty"
                            "${IE_MAIN_SOURCE_DIR}/tests/ie_test_utils/common_test_utils/gtest"
                            "${IE_MAIN_SOURCE_DIR}/samples/thirdparty"
                            "${IE_MAIN_SOURCE_DIR}/thirdparty"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ function(build_ngraph)
     set(NGRAPH_COMPONENT_PREFIX "deployment_tools/ngraph/")
     add_subdirectory(ngraph)
     set(NGRAPH_LIBRARIES ngraph PARENT_SCOPE)
+    set(NGRAPH_REF_LIBRARIES ngraph_reference PARENT_SCOPE)
 endfunction()
 
 function(openvino_developer_export_targets)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,6 @@ endfunction()
 
 add_subdirectory(thirdparty)
 add_subdirectory(openvino)
-add_subdirectory(thirdparty)
 build_ngraph()
 add_subdirectory(inference-engine)
 add_subdirectory(model-optimizer)

--- a/inference-engine/src/inference_engine/CMakeLists.txt
+++ b/inference-engine/src/inference_engine/CMakeLists.txt
@@ -110,7 +110,7 @@ target_compile_definitions(${TARGET_NAME}_obj PRIVATE IMPLEMENT_INFERENCE_ENGINE
 
 target_include_directories(${TARGET_NAME}_obj SYSTEM PRIVATE $<TARGET_PROPERTY:ngraph::ngraph,INTERFACE_INCLUDE_DIRECTORIES>
                                                              $<TARGET_PROPERTY:pugixml,INTERFACE_INCLUDE_DIRECTORIES>
-                                                             $<TARGET_PROPERTY:xbyak::xbyak,INTERFACE_INCLUDE_DIRECTORIES>)
+                                                             $<TARGET_PROPERTY:xbyak,INTERFACE_INCLUDE_DIRECTORIES>)
 
 target_include_directories(${TARGET_NAME}_obj PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}"
                                                       "${IE_MAIN_SOURCE_DIR}/src/readers/ir_reader" # for ie_ir_version.hpp

--- a/inference-engine/src/inference_engine/CMakeLists.txt
+++ b/inference-engine/src/inference_engine/CMakeLists.txt
@@ -109,7 +109,8 @@ target_compile_definitions(${TARGET_NAME}_obj PRIVATE IMPLEMENT_INFERENCE_ENGINE
                                                       $<TARGET_PROPERTY:ngraph::ngraph,INTERFACE_COMPILE_DEFINITIONS>)
 
 target_include_directories(${TARGET_NAME}_obj SYSTEM PRIVATE $<TARGET_PROPERTY:ngraph::ngraph,INTERFACE_INCLUDE_DIRECTORIES>
-                                                             $<TARGET_PROPERTY:pugixml,INTERFACE_INCLUDE_DIRECTORIES>)
+                                                             $<TARGET_PROPERTY:pugixml,INTERFACE_INCLUDE_DIRECTORIES>
+                                                             $<TARGET_PROPERTY:xbyak::xbyak,INTERFACE_INCLUDE_DIRECTORIES>)
 
 target_include_directories(${TARGET_NAME}_obj PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}"
                                                       "${IE_MAIN_SOURCE_DIR}/src/readers/ir_reader" # for ie_ir_version.hpp
@@ -118,10 +119,6 @@ target_include_directories(${TARGET_NAME}_obj PRIVATE "${CMAKE_CURRENT_SOURCE_DI
                                                       $<TARGET_PROPERTY:${TARGET_NAME}_plugin_api,INTERFACE_INCLUDE_DIRECTORIES>)
 
 target_link_libraries(${TARGET_NAME}_obj PRIVATE ${TARGET_NAME}_reader_api)
-
-if(ENABLE_MKL_DNN)
-    target_include_directories(${TARGET_NAME}_obj SYSTEM PRIVATE "${IE_MAIN_SOURCE_DIR}/thirdparty/mkl-dnn/src/cpu/x64/xbyak")
-endif()
 
 set_ie_threading_interface_for(${TARGET_NAME}_obj)
 
@@ -215,10 +212,6 @@ configure_file("${IE_MAIN_SOURCE_DIR}/cmake/templates/InferenceEngineConfig-vers
 
 # Export for developer package
 
-add_library(xbyak INTERFACE)
-target_include_directories(xbyak INTERFACE ${IE_MAIN_SOURCE_DIR}/thirdparty/mkl-dnn/src/cpu/xbyak)
-
-openvino_developer_export_targets(COMPONENT openvino_common TARGETS xbyak)
 ie_developer_export_targets(${TARGET_NAME} ${TARGET_NAME}_plugin_api)
 
 # install TBB

--- a/inference-engine/src/inference_engine/ie_system_conf.cpp
+++ b/inference-engine/src/inference_engine/ie_system_conf.cpp
@@ -9,89 +9,41 @@
 #include <iostream>
 #include <vector>
 
-#ifdef ENABLE_MKL_DNN
 # define XBYAK_NO_OP_NAMES
 # define XBYAK_UNDEF_JNL
-# include <xbyak_util.h>
-#endif
+# include <xbyak/xbyak_util.h>
 
 namespace InferenceEngine {
 
-#ifdef ENABLE_MKL_DNN
 static Xbyak::util::Cpu& get_cpu_info() {
     static Xbyak::util::Cpu cpu;
     return cpu;
 }
-#endif
 
 bool with_cpu_x86_sse42() {
-#ifdef ENABLE_MKL_DNN
     return get_cpu_info().has(Xbyak::util::Cpu::tSSE42);
-#else
-#if defined(HAVE_SSE)
-    return true;
-#else
-    return false;
-#endif
-#endif
 }
 
 bool with_cpu_x86_avx() {
-#ifdef ENABLE_MKL_DNN
     return get_cpu_info().has(Xbyak::util::Cpu::tAVX);
-#else
-#if defined(HAVE_AVX)
-    return true;
-#else
-    return false;
-#endif
-#endif
 }
 
 bool with_cpu_x86_avx2() {
-#ifdef ENABLE_MKL_DNN
     return get_cpu_info().has(Xbyak::util::Cpu::tAVX2);
-#else
-#if defined(HAVE_AVX2)
-    return true;
-#else
-    return false;
-#endif
-#endif
 }
 
 bool with_cpu_x86_avx512f() {
-#ifdef ENABLE_MKL_DNN
     return get_cpu_info().has(Xbyak::util::Cpu::tAVX512F);
-#else
-#if defined(HAVE_AVX512)
-    return true;
-#else
-    return false;
-#endif
-#endif
 }
 
 bool with_cpu_x86_avx512_core() {
-#ifdef ENABLE_MKL_DNN
        return get_cpu_info().has(Xbyak::util::Cpu::tAVX512F |
                                  Xbyak::util::Cpu::tAVX512DQ |
                                  Xbyak::util::Cpu::tAVX512BW);
-#else
-#if defined(HAVE_AVX512)
-    return true;
-#else
-    return false;
-#endif
-#endif
 }
 
 bool with_cpu_x86_bfloat16() {
-#ifdef ENABLE_MKL_DNN
     return get_cpu_info().has(Xbyak::util::Cpu::tAVX512_BF16);
-#else
-    return false;
-#endif
 }
 
 bool checkOpenMpEnvVars(bool includeOMPNumThreads) {

--- a/inference-engine/src/transformations/CMakeLists.txt
+++ b/inference-engine/src/transformations/CMakeLists.txt
@@ -19,8 +19,6 @@ source_group("include" FILES ${PUBLIC_HEADERS})
 
 add_library(${TARGET_NAME} SHARED ${LIBRARY_SRC} ${PUBLIC_HEADERS})
 
-target_compile_options(${TARGET_NAME} PRIVATE -march=native)
-
 ie_faster_build(${TARGET_NAME}
     UNITY
     PCH PRIVATE "src/precomp.hpp"
@@ -30,7 +28,7 @@ ie_add_vs_version_file(NAME ${TARGET_NAME}
                        FILEDESCRIPTION "Inference Engine Transformations library")
 
 target_link_libraries(${TARGET_NAME} PUBLIC ${NGRAPH_LIBRARIES}
-                                     PRIVATE openvino::conditional_compilation openvino::itt ngraph::builder pugixml)
+                                     PRIVATE ${NGRAPH_REF_LIBRARIES} openvino::conditional_compilation openvino::itt ngraph::builder pugixml)
 
 target_include_directories(${TARGET_NAME} PUBLIC ${PUBLIC_HEADERS_DIR}
                                           PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src")

--- a/inference-engine/src/transformations/CMakeLists.txt
+++ b/inference-engine/src/transformations/CMakeLists.txt
@@ -19,6 +19,8 @@ source_group("include" FILES ${PUBLIC_HEADERS})
 
 add_library(${TARGET_NAME} SHARED ${LIBRARY_SRC} ${PUBLIC_HEADERS})
 
+target_compile_options(${TARGET_NAME} PRIVATE -march=native)
+
 ie_faster_build(${TARGET_NAME}
     UNITY
     PCH PRIVATE "src/precomp.hpp"

--- a/inference-engine/src/transformations/src/transformations/convert_precision.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_precision.cpp
@@ -14,6 +14,8 @@
 #include <ngraph/opsets/opset1.hpp>
 #include <ngraph_ops/type_relaxed.hpp>
 
+#include <immintrin.h>
+
 using namespace ngraph;
 
 bool fuse_type_to_constant(std::shared_ptr<ngraph::Node> & node, ngraph::element::Type to, const std::vector<ngraph::Input<ngraph::Node>> & consumers);
@@ -341,25 +343,61 @@ inline int32_t convert_value<uint32_t, int32_t>(uint32_t val) {
     return static_cast<int32_t>(val);
 }
 
-template <element::Type_t PREC_FROM, element::Type_t PREC_TO>
-static std::shared_ptr<Node> change_constant_precision(std::shared_ptr<opset4::Constant>& constant) {
-    using src_type = typename element_type_traits<PREC_FROM>::value_type;
-    using dst_type = typename element_type_traits<PREC_TO>::value_type;
+namespace {
+    template <element::Type_t PREC_FROM, element::Type_t PREC_TO>
+    std::shared_ptr<Node> change_constant_precision(std::shared_ptr<opset4::Constant>& constant) {
+        using src_type = typename element_type_traits<PREC_FROM>::value_type;
+        using dst_type = typename element_type_traits<PREC_TO>::value_type;
 
-    const auto * src_data = constant->get_data_ptr<src_type>();
-    const auto size = shape_size(constant->get_shape());
+        const auto * src_data = constant->get_data_ptr<src_type>();
+        const auto size = shape_size(constant->get_shape());
 
-    auto new_constant = std::make_shared<ngraph::opset4::Constant>(PREC_TO, constant->get_shape());
-    auto * dst_data = const_cast<dst_type *>(reinterpret_cast<const dst_type *>(new_constant->get_data_ptr()));
-    if (dst_data == nullptr)
-        throw ngraph_error("Can't get destination data pointer");
+        auto new_constant = std::make_shared<ngraph::opset4::Constant>(PREC_TO, constant->get_shape());
+        auto * dst_data = const_cast<dst_type *>(reinterpret_cast<const dst_type *>(new_constant->get_data_ptr()));
+        if (dst_data == nullptr)
+            throw ngraph_error("Can't get destination data pointer");
 
-    std::vector<dst_type> final_data;
-    for (size_t i = 0; i < size; ++i) {
-        dst_data[i] = convert_value<src_type, dst_type>(src_data[i]);
+        for (size_t i = 0; i < size; ++i) {
+            dst_data[i] = convert_value<src_type, dst_type>(src_data[i]);
+        }
+        return new_constant;
     }
-    return new_constant;
-}
+
+    template <>
+    std::shared_ptr<Node> change_constant_precision<element::Type_t::f16, element::Type_t::f32>(std::shared_ptr<opset4::Constant>& constant) {
+        using src_type = typename element_type_traits<element::Type_t::f16>::value_type;
+        using dst_type = typename element_type_traits<element::Type_t::f32>::value_type;
+
+        const auto * src_data = constant->get_data_ptr<src_type>();
+        const auto size = shape_size(constant->get_shape());
+
+        auto new_constant = std::make_shared<ngraph::opset4::Constant>(element::Type_t::f32, constant->get_shape());
+        auto * dst_data = const_cast<dst_type *>(reinterpret_cast<const dst_type *>(new_constant->get_data_ptr()));
+        if (dst_data == nullptr)
+            throw ngraph_error("Can't get destination data pointer");
+
+        size_t i = 0;
+
+        // if SSE2/FP16C and AVX supported
+
+        size_t const step = 8;
+        size_t const n = size / step;
+
+        for (; i < n * step; i += 8) {
+            __m128i f16vec = _mm_loadu_si128((const __m128i*)&src_data[i]);     // SSE2
+            __m256 f32vec = _mm256_cvtph_ps(f16vec);                            // FP16C
+            _mm256_storeu_ps(&dst_data[i], f32vec);                             // AVX
+        }
+
+        // else
+
+        for (; i < size; ++i) {
+            dst_data[i] = convert_value<src_type, dst_type>(src_data[i]);
+        }
+
+        return new_constant;
+    }
+}   // namespace
 
 bool fuse_type_to_constant(std::shared_ptr<Node> & node, element::Type to, const std::vector<Input<Node>> & consumers) {
     if (auto constant = as_type_ptr<opset4::Constant>(node)) {

--- a/ngraph/core/reference/CMakeLists.txt
+++ b/ngraph/core/reference/CMakeLists.txt
@@ -44,10 +44,6 @@ source_group("include" FILES ${PUBLIC_HEADERS})
 # Create shared library
 add_library(${TARGET_NAME} STATIC ${LIBRARY_SRC} ${PUBLIC_HEADERS})
 
-target_compile_definitions(${TARGET_NAME} PRIVATE XBYAK_NO_OP_NAMES XBYAK64)
-
-target_include_directories(${TARGET_NAME} PRIVATE ${xbyak_SOURCE_DIR})
-
 if(COMMAND ie_faster_build)
     ie_faster_build(${TARGET_NAME}
         UNITY
@@ -55,8 +51,11 @@ if(COMMAND ie_faster_build)
     )
 endif()
 
+target_compile_definitions(${TARGET_NAME} PRIVATE XBYAK_NO_OP_NAMES XBYAK64)
+
 # Defines macro in C++ to load backend plugin
-target_include_directories(${TARGET_NAME} PUBLIC ${REF_IMPL_INCLUDE_DIR} ${NGRAPH_INCLUDE_PATH})
+target_include_directories(${TARGET_NAME} PUBLIC ${REF_IMPL_INCLUDE_DIR} ${NGRAPH_INCLUDE_PATH}
+                                          PRIVATE ${xbyak_SOURCE_DIR})
 
 # Add an alias so that library can be used inside the build tree, e.g. when testing
 add_library(ngraph::reference ALIAS ${TARGET_NAME})

--- a/ngraph/core/reference/CMakeLists.txt
+++ b/ngraph/core/reference/CMakeLists.txt
@@ -30,6 +30,8 @@ source_group("include" FILES ${PUBLIC_HEADERS})
 # Create shared library
 add_library(${TARGET_NAME} STATIC ${LIBRARY_SRC} ${PUBLIC_HEADERS})
 
+target_compile_options(${TARGET_NAME} PRIVATE -march=native)
+
 if(COMMAND ie_faster_build)
     ie_faster_build(${TARGET_NAME}
         UNITY

--- a/ngraph/core/reference/CMakeLists.txt
+++ b/ngraph/core/reference/CMakeLists.txt
@@ -42,7 +42,7 @@ target_compile_definitions(${TARGET_NAME} PRIVATE XBYAK_NO_OP_NAMES XBYAK64)
 # Defines macro in C++ to load backend plugin
 target_include_directories(${TARGET_NAME} PUBLIC ${REF_IMPL_INCLUDE_DIR} ${NGRAPH_INCLUDE_PATH})
 
-target_link_libraries(${TARGET_NAME} PRIVATE xbyak::xbyak)
+target_link_libraries(${TARGET_NAME} PRIVATE xbyak)
 
 # Add an alias so that library can be used inside the build tree, e.g. when testing
 add_library(ngraph::reference ALIAS ${TARGET_NAME})

--- a/ngraph/core/reference/CMakeLists.txt
+++ b/ngraph/core/reference/CMakeLists.txt
@@ -21,6 +21,20 @@ file(GLOB_RECURSE PUBLIC_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp)
 
 set(REF_IMPL_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
+include(FetchContent)
+
+FetchContent_Declare(
+    xbyak
+    GIT_REPOSITORY https://github.com/herumi/xbyak.git
+    GIT_TAG v5.991
+)
+
+FetchContent_GetProperties(xbyak)
+if(NOT xbyak_POPULATED)
+    FetchContent_Populate(xbyak)
+    add_subdirectory(${xbyak_SOURCE_DIR} ${xbyak_BINARY_DIR})
+endif()
+
 # Create named folders for the sources within the .vcproj
 # Empty name lists them directly under the .vcproj
 
@@ -30,7 +44,9 @@ source_group("include" FILES ${PUBLIC_HEADERS})
 # Create shared library
 add_library(${TARGET_NAME} STATIC ${LIBRARY_SRC} ${PUBLIC_HEADERS})
 
-target_compile_options(${TARGET_NAME} PRIVATE -march=native)
+target_compile_definitions(${TARGET_NAME} PRIVATE XBYAK_NO_OP_NAMES XBYAK64)
+
+target_include_directories(${TARGET_NAME} PRIVATE ${xbyak_SOURCE_DIR})
 
 if(COMMAND ie_faster_build)
     ie_faster_build(${TARGET_NAME}

--- a/ngraph/core/reference/CMakeLists.txt
+++ b/ngraph/core/reference/CMakeLists.txt
@@ -21,20 +21,6 @@ file(GLOB_RECURSE PUBLIC_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp)
 
 set(REF_IMPL_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
-include(FetchContent)
-
-FetchContent_Declare(
-    xbyak
-    GIT_REPOSITORY https://github.com/herumi/xbyak.git
-    GIT_TAG v5.991
-)
-
-FetchContent_GetProperties(xbyak)
-if(NOT xbyak_POPULATED)
-    FetchContent_Populate(xbyak)
-    add_subdirectory(${xbyak_SOURCE_DIR} ${xbyak_BINARY_DIR})
-endif()
-
 # Create named folders for the sources within the .vcproj
 # Empty name lists them directly under the .vcproj
 
@@ -54,8 +40,9 @@ endif()
 target_compile_definitions(${TARGET_NAME} PRIVATE XBYAK_NO_OP_NAMES XBYAK64)
 
 # Defines macro in C++ to load backend plugin
-target_include_directories(${TARGET_NAME} PUBLIC ${REF_IMPL_INCLUDE_DIR} ${NGRAPH_INCLUDE_PATH}
-                                          PRIVATE ${xbyak_SOURCE_DIR})
+target_include_directories(${TARGET_NAME} PUBLIC ${REF_IMPL_INCLUDE_DIR} ${NGRAPH_INCLUDE_PATH})
+
+target_link_libraries(${TARGET_NAME} PRIVATE xbyak::xbyak)
 
 # Add an alias so that library can be used inside the build tree, e.g. when testing
 add_library(ngraph::reference ALIAS ${TARGET_NAME})

--- a/ngraph/core/reference/include/ngraph/runtime/reference/convert.hpp
+++ b/ngraph/core/reference/include/ngraph/runtime/reference/convert.hpp
@@ -18,6 +18,8 @@
 
 #include <cstddef>
 
+#include "ngraph/type/float16.hpp"
+
 namespace ngraph
 {
     namespace runtime
@@ -33,6 +35,9 @@ namespace ngraph
                     out[i] = static_cast<TO>(arg[i]);
                 }
             }
+
+            template <>
+            void convert<uint8_t, float16>(const uint8_t* arg, float16* out, size_t count);
 
             template <typename TI, typename TO>
             typename std::enable_if<std::is_same<TO, char>::value>::type

--- a/ngraph/core/reference/include/ngraph/runtime/reference/convert.hpp
+++ b/ngraph/core/reference/include/ngraph/runtime/reference/convert.hpp
@@ -38,6 +38,8 @@ namespace ngraph
 
             template <>
             void convert<uint8_t, float16>(const uint8_t* arg, float16* out, size_t count);
+            template <>
+            void convert<float16, float>(const float16* arg, float* out, size_t count);
 
             template <typename TI, typename TO>
             typename std::enable_if<std::is_same<TO, char>::value>::type

--- a/ngraph/core/reference/src/runtime/reference/convert.cpp
+++ b/ngraph/core/reference/src/runtime/reference/convert.cpp
@@ -35,11 +35,13 @@ namespace ngraph
 
                 for (; i < n * step; i += 8)
                 {
-                    __m128i u8vec = _mm_loadl_epi64((__m128i const*)&arg[i]);   // SSE2: Load(u8[8])
-                    __m256i i32vec = _mm256_cvtepu8_epi32(u8vec);               // AVX2: Convert u8[8] -> i32[8]
-                    __m256 fvec = _mm256_cvtepi32_ps(i32vec);                   // AVX: Convert i32[8] -> float[8]
-                    __m128i f16vec = _mm256_cvtps_ph(fvec, 0);                  // FP16C: Convert float[8] -> float16[8]
-                    _mm_storeu_si128((__m128i*)&out[i], f16vec);                // SSE2: Store (Works only in LE architecture!)
+                    __m128i u8vec = _mm_loadl_epi64((__m128i const*)&arg[i]); // SSE2: Load(u8[8])
+                    __m256i i32vec = _mm256_cvtepu8_epi32(u8vec); // AVX2: Convert u8[8] -> i32[8]
+                    __m256 fvec = _mm256_cvtepi32_ps(i32vec);     // AVX: Convert i32[8] -> float[8]
+                    __m128i f16vec =
+                        _mm256_cvtps_ph(fvec, 0); // FP16C: Convert float[8] -> float16[8]
+                    _mm_storeu_si128((__m128i*)&out[i],
+                                     f16vec); // SSE2: Store (Works only in LE architecture!)
                 }
 
                 for (; i < count; ++i)

--- a/ngraph/core/reference/src/runtime/reference/convert.cpp
+++ b/ngraph/core/reference/src/runtime/reference/convert.cpp
@@ -122,7 +122,7 @@ namespace ngraph
 
                     static fn_t get()
                     {
-                        if (mayiuse(avx) && mayiuse(avx2) && mayiuse(fp16))
+                        if (is_x64() && mayiuse(avx) && mayiuse(avx2) && mayiuse(fp16))
                         {
                             static jit_convert_u8_to_f16 generator;
                             return (fn_t)generator.getCode();
@@ -221,7 +221,7 @@ namespace ngraph
 
                     static fn_t get()
                     {
-                        if (mayiuse(avx) && mayiuse(fp16))
+                        if (is_x64() && mayiuse(avx) && mayiuse(fp16))
                         {
                             static jit_convert_f16_to_f32 generator;
                             return (fn_t)generator.getCode();

--- a/ngraph/core/reference/src/runtime/reference/convert.cpp
+++ b/ngraph/core/reference/src/runtime/reference/convert.cpp
@@ -1,5 +1,5 @@
 //*****************************************************************************
-// Copyright 2017-2020 Intel Corporation
+// Copyright 2021 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,85 +25,105 @@ namespace ngraph
         {
             namespace
             {
-                class jit_convert_u8_to_f16 : public jit::Generator
+                template <typename src_t, typename dst_t>
+                void jit_convert_vec(jit::Generator&, const Xbyak::RegExp&, const Xbyak::RegExp&);
+
+                template <>
+                void jit_convert_vec<uint8_t, float16>(jit::Generator& gen,
+                                                       const Xbyak::RegExp& src,
+                                                       const Xbyak::RegExp& dst)
                 {
-                    jit_convert_u8_to_f16()
+                    auto u8vec = gen.xmm1;
+                    auto i32vec = gen.ymm2;
+                    auto f16vec = gen.xmm3;
+                    auto fvec = gen.ymm4;
+
+                    gen.movq(u8vec, gen.qword[src]);
+                    gen.vpmovzxbd(i32vec, u8vec);
+                    gen.vcvtdq2ps(fvec, i32vec);
+                    gen.vcvtps2ph(f16vec, fvec, 0);
+                    gen.movdqu(gen.xword[dst], f16vec);
+                }
+
+                template <>
+                void jit_convert_vec<float16, float>(jit::Generator& gen,
+                                                     const Xbyak::RegExp& src,
+                                                     const Xbyak::RegExp& dst)
+                {
+                    auto f16vec = gen.xmm3;
+                    auto f32vec = gen.ymm4;
+
+                    gen.movdqu(f16vec, gen.xword[src]);
+                    gen.vcvtph2ps(f32vec, f16vec);
+                    gen.vmovups(gen.yword[dst], f32vec);
+                }
+
+                class jit_convert_array : public jit::Generator
+                {
+                    typedef struct context
+                    {
+                        struct
+                        {
+                            size_t type_size;
+                            void (jit::Generator::*copy)(const Xbyak::Reg64& dst,
+                                                         const Xbyak::Reg64& src,
+                                                         const Xbyak::Reg64& size);
+                        } src, dst;
+                        void (*convert_vec)(jit::Generator&,
+                                            const Xbyak::RegExp&,
+                                            const Xbyak::RegExp&);
+                    } context_t;
+
+                    jit_convert_array(const context_t& ctx)
                     {
                         using namespace Xbyak;
 
-                        auto u8vec = xmm1;
-                        auto i32vec = ymm2;
-                        auto f16vec = xmm3;
-                        auto fvec = ymm4;
+                        const uint32_t vlen = 8u;
 
                         auto reg_src = rax;
                         auto reg_dst = rbx;
                         auto reg_sz = rdx;
 
-                        Label loop, tail, tail_loop, copy_loop, exit;
+                        Label tail, exit;
 
                         preamble();
 
-                        mov(reg_src, ptr[param + offsetof(args_t, arg)]);
+                        mov(reg_src, ptr[param + offsetof(args_t, src)]);
                         mov(reg_dst, ptr[param + offsetof(args_t, out)]);
                         mov(reg_sz, ptr[param + offsetof(args_t, count)]);
 
-                        L(loop);
+                        xor_(rsi, rsi);
+                        mov(r8, reg_sz);
+                        shr(r8, 3);
 
-                        cmp(reg_sz, 8);
-                        jl(tail);
-
-                        movq(u8vec, qword[reg_src]);
-                        vpmovzxbd(i32vec, u8vec);
-                        vcvtdq2ps(fvec, i32vec);
-                        vcvtps2ph(f16vec, fvec, 0);
-                        movdqu(xword[reg_dst], f16vec);
-
-                        lea(reg_src, ptr[reg_src + sizeof(uint8_t) * 8]);
-                        lea(reg_dst, ptr[reg_dst + sizeof(float16) * 8]);
-
-                        sub(reg_sz, 8);
-                        jmp(loop);
+                        foreach (rsi, 1, r8, [&, this](const Xbyak::Reg64& idx) {
+                            ctx.convert_vec(*this, reg_src, reg_dst);
+                            add(reg_src, ctx.src.type_size * vlen);
+                            add(reg_dst, ctx.dst.type_size * vlen);
+                        })
+                            ;
 
                         L(tail);
 
+                        shl(rsi, 3);
+                        sub(reg_sz, rsi);
                         test(reg_sz, reg_sz);
                         jz(exit);
 
-                        sub(rsp, 8 * sizeof(float)); // allocate array for 8 floats on stack
-                        xor_(rsi, rsi);
+                        // allocate array for 8 floats on stack
+                        sub(rsp, vlen * sizeof(float));
+                        mov(r8, rsp);
 
-                        mov(qword[rsp], rsi);
-                        mov(qword[rsp + 8], rsi);
-                        mov(qword[rsp + 16], rsi);
-                        mov(qword[rsp + 24], rsi);
+                        vpxor(ymm4, ymm4, ymm4);
+                        vmovups(yword[r8], ymm4);
 
                         // Tail conversion
-                        L(tail_loop);
-                        movzx(edi, byte[reg_src]);                     // read u8
-                        cvtsi2ss(xmm0, edi);                           // convert u8 to float
-                        movss(dword[rsp + rsi * sizeof(float)], xmm0); // save float on stack
-                        lea(reg_src, ptr[reg_src + sizeof(uint8_t)]);  // reg_src++
-                        inc(rsi);
-                        cmp(rsi, reg_sz);
-                        jl(tail_loop);
+                        (this->*ctx.src.copy)(r8, reg_src, reg_sz);
+                        ctx.convert_vec(*this, r8, r8);
+                        (this->*ctx.dst.copy)(reg_dst, r8, reg_sz);
 
-                        vmovups(fvec, yword[rsp]);
-                        vcvtps2ph(f16vec, fvec, 0);
-                        movdqu(xword[rsp], f16vec);
-
-                        xor_(rsi, rsi);
-
-                        // Tail copying
-                        L(copy_loop);
-                        mov(di, word[rsp + rsi * sizeof(float16)]);
-                        mov(word[reg_dst], di);
-                        lea(reg_dst, ptr[reg_dst + sizeof(float16)]);
-                        inc(rsi);
-                        cmp(rsi, reg_sz);
-                        jl(copy_loop);
-
-                        add(rsp, 8 * sizeof(float)); // Free the array on stack
+                        // Free the array on stack
+                        add(rsp, vlen * sizeof(float));
 
                         L(exit);
 
@@ -113,117 +133,25 @@ namespace ngraph
                 public:
                     typedef struct
                     {
-                        const uint8_t* arg;
-                        float16* out;
+                        const void* src;
+                        void* out;
                         const size_t count;
                     } args_t;
 
                     typedef void (*fn_t)(const args_t*);
 
+                    template <typename src_t, typename dst_t>
                     static fn_t get()
                     {
                         if (is_x64() && mayiuse(avx) && mayiuse(avx2) && mayiuse(fp16))
                         {
-                            static jit_convert_u8_to_f16 generator;
-                            return (fn_t)generator.getCode();
-                        }
-                        return nullptr;
-                    }
-                };
+                            static const jit_convert_array::context_t context{
+                                {sizeof(src_t), &jit::Generator::copy<src_t>},
+                                {sizeof(dst_t), &jit::Generator::copy<dst_t>},
+                                jit_convert_vec<src_t, dst_t>};
 
-                class jit_convert_f16_to_f32 : public jit::Generator
-                {
-                    jit_convert_f16_to_f32()
-                    {
-                        using namespace Xbyak;
+                            static jit_convert_array generator(context);
 
-                        auto f16vec = xmm1;
-                        auto f32vec = ymm2;
-
-                        auto reg_src = rax;
-                        auto reg_dst = rbx;
-                        auto reg_sz = rdx;
-
-                        Label loop, tail, tail_loop, copy_loop, exit;
-
-                        preamble();
-
-                        mov(reg_src, ptr[param + offsetof(args_t, arg)]);
-                        mov(reg_dst, ptr[param + offsetof(args_t, out)]);
-                        mov(reg_sz, ptr[param + offsetof(args_t, count)]);
-
-                        L(loop);
-
-                        cmp(reg_sz, 8);
-                        jl(tail);
-
-                        movdqu(f16vec, xword[reg_src]);
-                        vcvtph2ps(f32vec, f16vec);
-                        vmovups(yword[reg_dst], f32vec);
-
-                        lea(reg_src, ptr[reg_src + sizeof(float16) * 8]);
-                        lea(reg_dst, ptr[reg_dst + sizeof(float) * 8]);
-
-                        sub(reg_sz, 8);
-                        jmp(loop);
-
-                        L(tail);
-
-                        test(reg_sz, reg_sz);
-                        jz(exit);
-
-                        sub(rsp, 8 * sizeof(float)); // allocate array for 8 floats on stack
-                        xor_(rsi, rsi);
-
-                        mov(qword[rsp], rsi);
-                        mov(qword[rsp + 8], rsi);
-                        mov(qword[rsp + 16], rsi);
-                        mov(qword[rsp + 24], rsi);
-
-                        // Tail conversion
-                        L(tail_loop);
-                        mov(di, word[reg_src + rsi * sizeof(float16)]); // read f16
-                        mov(word[rsp + rsi * sizeof(float16)], di);     // copy to stack
-                        inc(rsi);                                       // read next
-                        cmp(rsi, reg_sz);
-                        jl(tail_loop);
-
-                        movdqu(f16vec, xword[rsp]);
-                        vcvtph2ps(f32vec, f16vec);
-                        vmovups(yword[rsp], f32vec);
-
-                        xor_(rsi, rsi);
-
-                        // Tail copying
-                        L(copy_loop);
-                        mov(edi, dword[rsp + rsi * sizeof(float)]);
-                        mov(dword[reg_dst + rsi * sizeof(float)], edi);
-                        inc(rsi);
-                        cmp(rsi, reg_sz);
-                        jl(copy_loop);
-
-                        add(rsp, 8 * sizeof(float)); // Free the array on stack
-
-                        L(exit);
-
-                        postamble();
-                    }
-
-                public:
-                    typedef struct
-                    {
-                        const float16* arg;
-                        float* out;
-                        const size_t count;
-                    } args_t;
-
-                    typedef void (*fn_t)(const args_t*);
-
-                    static fn_t get()
-                    {
-                        if (is_x64() && mayiuse(avx) && mayiuse(fp16))
-                        {
-                            static jit_convert_f16_to_f32 generator;
                             return (fn_t)generator.getCode();
                         }
                         return nullptr;
@@ -234,11 +162,11 @@ namespace ngraph
             template <>
             void convert<uint8_t, float16>(const uint8_t* arg, float16* out, size_t count)
             {
-                auto converter = jit_convert_u8_to_f16::get();
+                auto converter = jit_convert_array::get<uint8_t, float16>();
 
                 if (converter)
                 {
-                    jit_convert_u8_to_f16::args_t args = {arg, out, count};
+                    jit_convert_array::args_t args = {arg, out, count};
                     converter(&args);
                 }
                 else
@@ -253,11 +181,11 @@ namespace ngraph
             template <>
             void convert<float16, float>(const float16* arg, float* out, size_t count)
             {
-                auto converter = jit_convert_f16_to_f32::get();
+                auto converter = jit_convert_array::get<float16, float>();
 
                 if (converter)
                 {
-                    jit_convert_f16_to_f32::args_t args = {arg, out, count};
+                    jit_convert_array::args_t args = {arg, out, count};
                     converter(&args);
                 }
                 else

--- a/ngraph/core/reference/src/runtime/reference/convert.cpp
+++ b/ngraph/core/reference/src/runtime/reference/convert.cpp
@@ -70,7 +70,7 @@ namespace ngraph
                         test(reg_sz, reg_sz);
                         jz(exit);
 
-                        sub(rsp, 8 * sizeof(float));                    // allocate array for 8 floats on stack
+                        sub(rsp, 8 * sizeof(float)); // allocate array for 8 floats on stack
                         xor_(rsi, rsi);
 
                         mov(qword[rsp], rsi);
@@ -80,10 +80,10 @@ namespace ngraph
 
                         // Tail conversion
                         L(tail_loop);
-                        movzx(edi, byte[reg_src]);                      // read u8
-                        cvtsi2ss(xmm0, edi);                            // convert u8 to float
-                        movss(dword[rsp + rsi * sizeof(float)], xmm0);  // save float on stack
-                        lea(reg_src, ptr[reg_src + sizeof(uint8_t)]);   // reg_src++
+                        movzx(edi, byte[reg_src]);                     // read u8
+                        cvtsi2ss(xmm0, edi);                           // convert u8 to float
+                        movss(dword[rsp + rsi * sizeof(float)], xmm0); // save float on stack
+                        lea(reg_src, ptr[reg_src + sizeof(uint8_t)]);  // reg_src++
                         inc(rsi);
                         cmp(rsi, reg_sz);
                         jl(tail_loop);
@@ -103,7 +103,7 @@ namespace ngraph
                         cmp(rsi, reg_sz);
                         jl(copy_loop);
 
-                        add(rsp, 8 * sizeof(float));                    // Free the array on stack
+                        add(rsp, 8 * sizeof(float)); // Free the array on stack
 
                         L(exit);
 
@@ -172,7 +172,7 @@ namespace ngraph
                         test(reg_sz, reg_sz);
                         jz(exit);
 
-                        sub(rsp, 8 * sizeof(float));                    // allocate array for 8 floats on stack
+                        sub(rsp, 8 * sizeof(float)); // allocate array for 8 floats on stack
                         xor_(rsi, rsi);
 
                         mov(qword[rsp], rsi);
@@ -202,7 +202,7 @@ namespace ngraph
                         cmp(rsi, reg_sz);
                         jl(copy_loop);
 
-                        add(rsp, 8 * sizeof(float));                    // Free the array on stack
+                        add(rsp, 8 * sizeof(float)); // Free the array on stack
 
                         L(exit);
 

--- a/ngraph/core/reference/src/runtime/reference/convert.cpp
+++ b/ngraph/core/reference/src/runtime/reference/convert.cpp
@@ -1,0 +1,52 @@
+//*****************************************************************************
+// Copyright 2017-2020 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+
+#include <cstring>
+
+#include "ngraph/runtime/reference/convert.hpp"
+
+#include <immintrin.h>
+
+namespace ngraph
+{
+    namespace runtime
+    {
+        namespace reference
+        {
+            template <>
+            void convert<uint8_t, float16>(const uint8_t* arg, float16* out, size_t count)
+            {
+                size_t i = 0;
+                const size_t step = 8;
+                const size_t n = count / step;
+
+                for (; i < n * step; i += 8)
+                {
+                    __m128i u8vec = _mm_loadl_epi64((__m128i const*)&arg[i]);   // SSE2: Load(u8[8])
+                    __m256i i32vec = _mm256_cvtepu8_epi32(u8vec);               // AVX2: Convert u8[8] -> i32[8]
+                    __m256 fvec = _mm256_cvtepi32_ps(i32vec);                   // AVX: Convert i32[8] -> float[8]
+                    __m128i f16vec = _mm256_cvtps_ph(fvec, 0);                  // FP16C: Convert float[8] -> float16[8]
+                    _mm_storeu_si128((__m128i*)&out[i], f16vec);                // SSE2: Store (Works only in LE architecture!)
+                }
+
+                for (; i < count; ++i)
+                {
+                    out[i] = static_cast<float16>(arg[i]);
+                }
+            }
+        }
+    }
+}

--- a/ngraph/core/reference/src/runtime/reference/jit_generator.cpp
+++ b/ngraph/core/reference/src/runtime/reference/jit_generator.cpp
@@ -1,0 +1,131 @@
+//*****************************************************************************
+// Copyright 2017-2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+#include "jit_generator.hpp"
+
+#include <xbyak/xbyak_util.h>
+
+namespace ngraph
+{
+    namespace runtime
+    {
+        namespace jit
+        {
+#ifdef XBYAK64
+            static const Xbyak::Operand::Code abi_save_gpr_regs[] = {
+                Xbyak::Operand::RBX,
+                Xbyak::Operand::RBP,
+                Xbyak::Operand::R12,
+                Xbyak::Operand::R13,
+                Xbyak::Operand::R14,
+                Xbyak::Operand::R15,
+#ifdef _WIN32
+                Xbyak::Operand::RDI,
+                Xbyak::Operand::RSI,
+#endif
+            };
+
+#ifdef _WIN32
+            static const Xbyak::Reg64 abi_param1(Xbyak::Operand::RCX),
+                abi_param2(Xbyak::Operand::RDX), abi_param3(Xbyak::Operand::R8),
+                abi_param4(Xbyak::Operand::R9), abi_not_param1(Xbyak::Operand::RDI);
+#else
+            static const Xbyak::Reg64 abi_param1(Xbyak::Operand::RDI),
+                abi_param2(Xbyak::Operand::RSI), abi_param3(Xbyak::Operand::RDX),
+                abi_param4(Xbyak::Operand::RCX), abi_param5(Xbyak::Operand::R8),
+                abi_param6(Xbyak::Operand::R9), abi_not_param1(Xbyak::Operand::RCX);
+#endif
+#endif
+
+            const size_t Generator::num_abi_save_gpr_regs =
+                sizeof(abi_save_gpr_regs) / sizeof(abi_save_gpr_regs[0]);
+
+            const Xbyak::Reg64 Generator::param = abi_param1;
+
+            bool Generator::mayiuse(const cpu_isa_t cpu_isa)
+            {
+                static Xbyak::util::Cpu cpu;
+
+                using namespace Xbyak::util;
+
+                switch (cpu_isa)
+                {
+                case sse42: return cpu.has(Cpu::tSSE42);
+                case avx: return cpu.has(Cpu::tAVX);
+                case avx2: return cpu.has(Cpu::tAVX2);
+                case avx512_common: return cpu.has(Cpu::tAVX512F);
+                case avx512_core:
+                    return cpu.has(Cpu::tAVX512F) && cpu.has(Cpu::tAVX512BW) &&
+                           cpu.has(Cpu::tAVX512VL) && cpu.has(Cpu::tAVX512DQ);
+                case avx512_core_vnni:
+                    return cpu.has(Cpu::tAVX512F) && cpu.has(Cpu::tAVX512BW) &&
+                           cpu.has(Cpu::tAVX512VL) && cpu.has(Cpu::tAVX512DQ) &&
+                           cpu.has(Cpu::tAVX512_VNNI);
+                case avx512_mic:
+                    return cpu.has(Cpu::tAVX512F) && cpu.has(Cpu::tAVX512CD) &&
+                           cpu.has(Cpu::tAVX512ER) && cpu.has(Cpu::tAVX512PF);
+                case avx512_mic_4ops:
+                    return mayiuse(avx512_mic) && cpu.has(Cpu::tAVX512_4FMAPS) &&
+                           cpu.has(Cpu::tAVX512_4VNNIW);
+                case avx512_core_bf16:
+                    return mayiuse(avx512_core_vnni) && cpu.has(Cpu::tAVX512_BF16);
+                case avx512_vpopcnt: return true && cpu.has(Cpu::tAVX512_VPOPCNTDQ);
+                case fp16: return cpu.has(Cpu::tF16C);
+                case isa_any: return true;
+                }
+                return false;
+            }
+
+            Generator::Generator(void* code_ptr, size_t code_size)
+                : Xbyak::CodeGenerator(code_size, code_ptr)
+                , size_of_abi_save_regs(num_abi_save_gpr_regs * rax.getBit() / 8 +
+                                        xmm_to_preserve * xmm_len)
+                , reg_EVEX_max_8b_offt(rbp)
+            {
+            }
+
+            void Generator::preamble()
+            {
+                if (xmm_to_preserve)
+                {
+                    sub(rsp, xmm_to_preserve * xmm_len);
+                    for (size_t i = 0; i < xmm_to_preserve; ++i)
+                        movdqu(ptr[rsp + i * xmm_len], Xbyak::Xmm(xmm_to_preserve_start + i));
+                }
+                for (size_t i = 0; i < num_abi_save_gpr_regs; ++i)
+                    push(Xbyak::Reg64(abi_save_gpr_regs[i]));
+                if (mayiuse(avx512_common))
+                {
+                    mov(reg_EVEX_max_8b_offt, 2 * EVEX_max_8b_offt);
+                }
+            }
+
+            void Generator::postamble()
+            {
+                for (size_t i = 0; i < num_abi_save_gpr_regs; ++i)
+                    pop(Xbyak::Reg64(abi_save_gpr_regs[num_abi_save_gpr_regs - 1 - i]));
+                if (xmm_to_preserve)
+                {
+                    for (size_t i = 0; i < xmm_to_preserve; ++i)
+                        movdqu(Xbyak::Xmm(xmm_to_preserve_start + i), ptr[rsp + i * xmm_len]);
+                    add(rsp, xmm_to_preserve * xmm_len);
+                }
+                if (mayiuse(avx) && !mayiuse(avx512_mic))
+                    vzeroupper();
+                ret();
+            }
+        }
+    }
+}

--- a/ngraph/core/reference/src/runtime/reference/jit_generator.cpp
+++ b/ngraph/core/reference/src/runtime/reference/jit_generator.cpp
@@ -88,6 +88,7 @@ namespace ngraph
                 return false;
             }
 
+            bool Generator::is_x64() { return sizeof(void*) == 8; }
             Generator::Generator(void* code_ptr, size_t code_size)
                 : Xbyak::CodeGenerator(code_size, code_ptr)
                 , size_of_abi_save_regs(num_abi_save_gpr_regs * rax.getBit() / 8 +

--- a/ngraph/core/reference/src/runtime/reference/jit_generator.hpp
+++ b/ngraph/core/reference/src/runtime/reference/jit_generator.hpp
@@ -15,6 +15,7 @@
 //*****************************************************************************
 #pragma once
 
+#include <functional>
 #include <xbyak/xbyak.h>
 
 namespace ngraph
@@ -65,6 +66,16 @@ namespace ngraph
                 Generator(void* code_ptr = nullptr, size_t code_size = 16 * 1024);
                 void preamble();
                 void postamble();
+
+                void foreach (const Xbyak::Reg64& idx,
+                              size_t step,
+                              const Xbyak::Reg64& end,
+                              std::function<void(const Xbyak::Reg64&)> && fn);
+
+                template <typename T>
+                void copy(const Xbyak::Reg64& dst,
+                          const Xbyak::Reg64& src,
+                          const Xbyak::Reg64& size);
             };
         }
     }

--- a/ngraph/core/reference/src/runtime/reference/jit_generator.hpp
+++ b/ngraph/core/reference/src/runtime/reference/jit_generator.hpp
@@ -1,0 +1,70 @@
+//*****************************************************************************
+// Copyright 2017-2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+#pragma once
+
+#include <xbyak/xbyak.h>
+
+namespace ngraph
+{
+    namespace runtime
+    {
+        namespace jit
+        {
+            class Generator : public Xbyak::CodeGenerator
+            {
+                static constexpr size_t xmm_len = 16;
+
+#ifdef _WIN32
+                static constexpr size_t xmm_to_preserve_start = 6;
+                static constexpr size_t xmm_to_preserve = 10;
+#else
+                static constexpr size_t xmm_to_preserve_start = 0;
+                static constexpr size_t xmm_to_preserve = 0;
+#endif
+
+                static const size_t num_abi_save_gpr_regs;
+                const size_t size_of_abi_save_regs;
+
+                const Xbyak::Reg64 reg_EVEX_max_8b_offt;
+                static constexpr int EVEX_max_8b_offt = 0x200;
+
+            public:
+                static const Xbyak::Reg64 param;
+
+                typedef enum {
+                    isa_any,
+                    sse42,
+                    avx,
+                    avx2,
+                    avx512_common,
+                    avx512_core,
+                    avx512_core_vnni,
+                    avx512_mic,
+                    avx512_mic_4ops,
+                    avx512_core_bf16,
+                    avx512_vpopcnt,
+                    fp16
+                } cpu_isa_t;
+
+                static bool mayiuse(const cpu_isa_t cpu_isa);
+
+                Generator(void* code_ptr = nullptr, size_t code_size = 16 * 1024);
+                void preamble();
+                void postamble();
+            };
+        }
+    }
+}

--- a/ngraph/core/reference/src/runtime/reference/jit_generator.hpp
+++ b/ngraph/core/reference/src/runtime/reference/jit_generator.hpp
@@ -60,6 +60,7 @@ namespace ngraph
                 } cpu_isa_t;
 
                 static bool mayiuse(const cpu_isa_t cpu_isa);
+                static bool is_x64();
 
                 Generator(void* code_ptr = nullptr, size_t code_size = 16 * 1024);
                 void preamble();

--- a/ngraph/core/reference/src/runtime/reference/non_max_suppression.cpp
+++ b/ngraph/core/reference/src/runtime/reference/non_max_suppression.cpp
@@ -25,115 +25,118 @@
 using namespace ngraph;
 using namespace ngraph::runtime::reference;
 
-struct Rectangle
-{
-    Rectangle(float y_left, float x_left, float y_right, float x_right)
-        : y1{y_left}
-        , x1{x_left}
-        , y2{y_right}
-        , x2{x_right}
-    {
-    }
-
-    Rectangle() = default;
-
-    float y1 = 0.0f;
-    float x1 = 0.0f;
-    float y2 = 0.f;
-    float x2 = 0.0f;
-};
-
-static float intersectionOverUnion(const Rectangle& boxI, const Rectangle& boxJ)
-{
-    float areaI = (boxI.y2 - boxI.y1) * (boxI.x2 - boxI.x1);
-    float areaJ = (boxJ.y2 - boxJ.y1) * (boxJ.x2 - boxJ.x1);
-
-    if (areaI <= 0.0f || areaJ <= 0.0f)
-    {
-        return 0.0f;
-    }
-
-    float intersection_ymin = std::max(boxI.y1, boxJ.y1);
-    float intersection_xmin = std::max(boxI.x1, boxJ.x1);
-    float intersection_ymax = std::min(boxI.y2, boxJ.y2);
-    float intersection_xmax = std::min(boxI.x2, boxJ.x2);
-
-    float intersection_area = std::max(intersection_ymax - intersection_ymin, 0.0f) *
-                              std::max(intersection_xmax - intersection_xmin, 0.0f);
-
-    return intersection_area / (areaI + areaJ - intersection_area);
-}
-
-struct SelectedIndex
-{
-    SelectedIndex(int64_t batch_idx, int64_t class_idx, int64_t box_idx)
-        : batch_index(batch_idx)
-        , class_index(class_idx)
-        , box_index(box_idx)
-    {
-    }
-
-    SelectedIndex() = default;
-
-    int64_t batch_index = 0;
-    int64_t class_index = 0;
-    int64_t box_index = 0;
-};
-
-struct SelectedScore
-{
-    SelectedScore(float batch_idx, float class_idx, float score)
-        : batch_index{batch_idx}
-        , class_index{class_idx}
-        , box_score{score}
-    {
-    }
-
-    SelectedScore() = default;
-
-    float batch_index = 0.0f;
-    float class_index = 0.0f;
-    float box_score = 0.0f;
-};
-
-struct BoxInfo
-{
-    BoxInfo(const Rectangle& r,
-            int64_t idx,
-            float sc,
-            int64_t suppress_idx,
-            int64_t batch_idx,
-            int64_t class_idx)
-        : box{r}
-        , index{idx}
-        , suppress_begin_index{suppress_idx}
-        , batch_index{batch_idx}
-        , class_index{class_idx}
-        , score{sc}
-    {
-    }
-
-    BoxInfo() = default;
-
-    inline bool operator<(const BoxInfo& rhs) const
-    {
-        return score < rhs.score || (score == rhs.score && index > rhs.index);
-    }
-
-    Rectangle box;
-    int64_t index = 0;
-    int64_t suppress_begin_index = 0;
-    int64_t batch_index = 0;
-    int64_t class_index = 0;
-    float score = 0.0f;
-};
-
 namespace ngraph
 {
     namespace runtime
     {
         namespace reference
         {
+            namespace
+            {
+                struct Rectangle
+                {
+                    Rectangle(float y_left, float x_left, float y_right, float x_right)
+                        : y1{y_left}
+                        , x1{x_left}
+                        , y2{y_right}
+                        , x2{x_right}
+                    {
+                    }
+
+                    Rectangle() = default;
+
+                    float y1 = 0.0f;
+                    float x1 = 0.0f;
+                    float y2 = 0.f;
+                    float x2 = 0.0f;
+                };
+
+                static float intersectionOverUnion(const Rectangle& boxI, const Rectangle& boxJ)
+                {
+                    float areaI = (boxI.y2 - boxI.y1) * (boxI.x2 - boxI.x1);
+                    float areaJ = (boxJ.y2 - boxJ.y1) * (boxJ.x2 - boxJ.x1);
+
+                    if (areaI <= 0.0f || areaJ <= 0.0f)
+                    {
+                        return 0.0f;
+                    }
+
+                    float intersection_ymin = std::max(boxI.y1, boxJ.y1);
+                    float intersection_xmin = std::max(boxI.x1, boxJ.x1);
+                    float intersection_ymax = std::min(boxI.y2, boxJ.y2);
+                    float intersection_xmax = std::min(boxI.x2, boxJ.x2);
+
+                    float intersection_area =
+                        std::max(intersection_ymax - intersection_ymin, 0.0f) *
+                        std::max(intersection_xmax - intersection_xmin, 0.0f);
+
+                    return intersection_area / (areaI + areaJ - intersection_area);
+                }
+
+                struct SelectedIndex
+                {
+                    SelectedIndex(int64_t batch_idx, int64_t class_idx, int64_t box_idx)
+                        : batch_index(batch_idx)
+                        , class_index(class_idx)
+                        , box_index(box_idx)
+                    {
+                    }
+
+                    SelectedIndex() = default;
+
+                    int64_t batch_index = 0;
+                    int64_t class_index = 0;
+                    int64_t box_index = 0;
+                };
+
+                struct SelectedScore
+                {
+                    SelectedScore(float batch_idx, float class_idx, float score)
+                        : batch_index{batch_idx}
+                        , class_index{class_idx}
+                        , box_score{score}
+                    {
+                    }
+
+                    SelectedScore() = default;
+
+                    float batch_index = 0.0f;
+                    float class_index = 0.0f;
+                    float box_score = 0.0f;
+                };
+
+                struct BoxInfo
+                {
+                    BoxInfo(const Rectangle& r,
+                            int64_t idx,
+                            float sc,
+                            int64_t suppress_idx,
+                            int64_t batch_idx,
+                            int64_t class_idx)
+                        : box{r}
+                        , index{idx}
+                        , suppress_begin_index{suppress_idx}
+                        , batch_index{batch_idx}
+                        , class_index{class_idx}
+                        , score{sc}
+                    {
+                    }
+
+                    BoxInfo() = default;
+
+                    inline bool operator<(const BoxInfo& rhs) const
+                    {
+                        return score < rhs.score || (score == rhs.score && index > rhs.index);
+                    }
+
+                    Rectangle box;
+                    int64_t index = 0;
+                    int64_t suppress_begin_index = 0;
+                    int64_t batch_index = 0;
+                    int64_t class_index = 0;
+                    float score = 0.0f;
+                };
+            }
             void non_max_suppression(const float* boxes_data,
                                      const Shape& boxes_data_shape,
                                      const float* scores_data,

--- a/ngraph/test/backend/convert.in.cpp
+++ b/ngraph/test/backend/convert.in.cpp
@@ -16,6 +16,7 @@
 
 #include "gtest/gtest.h"
 #include "ngraph/ngraph.hpp"
+#include "ngraph/runtime/reference/convert.hpp"
 #include "ngraph/runtime/tensor.hpp"
 #include "runtime/backend.hpp"
 #include "util/all_close.hpp"
@@ -170,4 +171,22 @@ NGRAPH_TEST(${BACKEND_NAME}, convert_bf16_float32)
                              0.5f,
                              1.5f}),
               read_vector<float>(result));
+}
+
+NGRAPH_TEST(${BACKEND_NAME}, convert_fp16_float32)
+{
+    std::vector<float> f32vec = {-20.5, -15, -10.5, -0.5, 0, 0.5, 10.5, 15, 20.5};
+    std::vector<float16> f16vec(std::begin(f32vec), std::end(f32vec));
+    std::vector<float> result(f32vec.size());
+    runtime::reference::convert(f16vec.data(), result.data(), f32vec.size());
+    EXPECT_EQ(result, f32vec);
+}
+
+NGRAPH_TEST(${BACKEND_NAME}, convert_uint8_fp16)
+{
+    std::vector<uint8_t> u8vec = {0, 10, 15, 20, 43, 56, 78, 99, 102, 130, 142};
+    std::vector<float16> f16vec(std::begin(u8vec), std::end(u8vec));
+    std::vector<float16> result(u8vec.size());
+    runtime::reference::convert(u8vec.data(), result.data(), u8vec.size());
+    EXPECT_EQ(result, f16vec);
 }

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -16,3 +16,5 @@
 
 add_subdirectory(itt_collector)
 add_subdirectory(xbyak)
+
+openvino_developer_export_targets(COMPONENT openvino_common TARGETS xbyak)

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -15,3 +15,4 @@
 # ******************************************************************************
 
 add_subdirectory(itt_collector)
+add_subdirectory(xbyak)


### PR DESCRIPTION
Data precision conversion operations take up a significant part of the load time. On average ConvertPrecision transformation pass takes 34% of load time for FP16 models. This fix significantly reduce time of int8->fp16 and fp16->fp32 conversions.