### PR TITLE
Move ClampFusion before HSwishFusion and HSigmoidFusion

### DIFF
--- a/inference-engine/src/transformations/src/transformations/common_optimizations/common_optimizations.cpp
+++ b/inference-engine/src/transformations/src/transformations/common_optimizations/common_optimizations.cpp
@@ -76,11 +76,11 @@ bool ngraph::pass::CommonOptimizations::run_on_function(std::shared_ptr<ngraph::
     manager.register_pass<ngraph::pass::SoftPlusFusion>();
     manager.register_pass<ngraph::pass::SoftPlusToMishFusion>();
     manager.register_pass<ngraph::pass::SwishFusion>();
+    manager.register_pass<ngraph::pass::ClampFusion>();
     manager.register_pass<ngraph::pass::HSwishFusion>();
     manager.register_pass<ngraph::pass::HSigmoidFusion>();
     manager.register_pass<ngraph::pass::ConvertPadToGroupConvolution, false>();
     manager.register_pass<ngraph::pass::NormalizeL2Fusion>();
-    manager.register_pass<ngraph::pass::ClampFusion>();
     manager.register_pass<ngraph::pass::PadFusion>();
 
     auto decomp = manager.register_pass<ngraph::pass::GraphRewrite>();


### PR DESCRIPTION
HSwishFusion and HSigmoidFusion use Clamp in their patterns so that change allows for even more fusions.