### PR TITLE
[nGraph] Fix calculation of output size in DetectionOutput reference …

### DIFF
--- a/ngraph/core/reference/include/ngraph/runtime/reference/detection_output.hpp
+++ b/ngraph/core/reference/include/ngraph/runtime/reference/detection_output.hpp
@@ -551,7 +551,7 @@ namespace ngraph
                     priorsBatchSize = priorsShape[0];
                     numLocClasses =
                         _attrs.share_location ? 1 : static_cast<size_t>(_attrs.num_classes);
-                    numResults = outShape[2];
+                    numResults = numImages * outShape[2];
                     outTotalSize = shape_size(outShape);
                 }
 


### PR DESCRIPTION
Current version may not save the tuple signaling the end of output if the batch size is larger than 1.