### PR TITLE
Add FP32 <-> BF16 conversion

### DIFF
--- a/inference-engine/src/inference_engine/precision_utils.cpp
+++ b/inference-engine/src/inference_engine/precision_utils.cpp
@@ -24,6 +24,18 @@ void f32tof16Arrays(short* dst, const float* src, size_t nelem, float scale, flo
     }
 }
 
+void bf16tof32Arrays(float* dst, const short* src, size_t nelem, float scale, float bias) {
+    const ie_fp16* _src = reinterpret_cast<const ie_fp16*>(src);
+    for (size_t i = 0; i < nelem; i++) {
+        dst[i] = PrecisionUtils::bf16tof32(_src[i]);
+    }
+}
+
+void f32tobf16Arrays(short* dst, const float* src, size_t nelem, float scale, float bias) {
+    for (size_t i = 0; i < nelem; i++) {
+        dst[i] = PrecisionUtils::f32tobf16(src[i] * scale + bias);
+    }
+}
 // Function to convert F32 into F16
 // F32: exp_bias:127 SEEEEEEE EMMMMMMM MMMMMMMM MMMMMMMM.
 // F16: exp_bias:15  SEEEEEMM MMMMMMMM
@@ -96,6 +108,27 @@ float f16tof32(ie_fp16 x) {
 
     // finaly represent result as float and return
     return asfloat(u);
+}
+
+ie_bf16 f32tobf16(float x) {
+    union
+    {
+        uint32_t i;
+        float f;
+    };
+    f = x;
+    ie_bf16 res = i >>16;
+    return res;
+}
+
+float bf16tof32(ie_bf16 x) {
+    union
+    {
+        uint32_t i;
+        float f;
+    };
+    i = x << 16;
+    return f;
 }
 
 // This function convert f32 to f16 with rounding to nearest value to minimize error

--- a/inference-engine/src/inference_engine/precision_utils.cpp
+++ b/inference-engine/src/inference_engine/precision_utils.cpp
@@ -111,8 +111,7 @@ float f16tof32(ie_fp16 x) {
 }
 
 ie_bf16 f32tobf16(float x) {
-    union
-    {
+    union {
         uint32_t i;
         float f;
     };
@@ -122,8 +121,7 @@ ie_bf16 f32tobf16(float x) {
 }
 
 float bf16tof32(ie_bf16 x) {
-    union
-    {
+    union {
         uint32_t i;
         float f;
     };

--- a/inference-engine/src/plugin_api/precision_utils.h
+++ b/inference-engine/src/plugin_api/precision_utils.h
@@ -76,12 +76,31 @@ namespace InferenceEngine {
  * @ingroup ie_dev_api_precision
  */
 using ie_fp16 = short;
+using ie_bf16 = short;
 
 /**
  * @brief Namespace for precision utilities
  * @ingroup ie_dev_api_precision
  */
 namespace PrecisionUtils {
+
+/**
+ * @brief      Converts a single-precision floating point value to a truncated single percision floating point value
+ * @ingroup    ie_dev_api_precision
+ *
+ * @param[in]  x     A single-precision floating point value
+ * @return     A truncated single floating point value
+ */
+INFERENCE_ENGINE_API_CPP(ie_bf16) f32tobf16(float x);
+
+/**
+ * @brief      Convers a truncated single percision floating point value to a single-precision floating point value
+ * @ingroup    ie_dev_api_precision
+ *
+ * @param[in]  x   truncated single percision floating point
+ * @return     A single-precision floating point value
+ */
+INFERENCE_ENGINE_API_CPP(float) bf16tof32(ie_bf16 x);
 
 /**
  * @brief      Converts a single-precision floating point value to a half-precision floating poit value
@@ -128,6 +147,35 @@ f16tof32Arrays(float* dst, const ie_fp16* src, size_t nelem, float scale = 1.f, 
  */
 INFERENCE_ENGINE_API_CPP(void)
 f32tof16Arrays(ie_fp16* dst, const float* src, size_t nelem, float scale = 1.f, float bias = 0.f);
+
+
+/**
+ * @brief      Converts a truncated single percision floating point array to single-precision floating point array
+ * 	           and applies `scale` and `bias` is needed
+ * @ingroup    ie_dev_api_precision
+ *
+ * @param      dst    A destination array of single-precision floating point values
+ * @param[in]  src    A source array of truncated single percision floating point values
+ * @param[in]  nelem  A number of elements in arrays
+ * @param[in]  scale  An optional scale parameter
+ * @param[in]  bias   An optional bias parameter
+ */
+INFERENCE_ENGINE_API_CPP(void)
+bf16tof32Arrays(float* dst, const ie_bf16* src, size_t nelem, float scale = 1.f, float bias = 0.f);
+
+/**
+ * @brief      Converts a single-precision floating point array to a truncated single percision floating point array
+ *             and applies `scale` and `bias` if needed
+ * @ingroup    ie_dev_api_precision
+ *
+ * @param      dst    A destination array of truncated single percision floating point values
+ * @param[in]  src    A sources array of single-precision floating point values
+ * @param[in]  nelem  A number of elements in arrays
+ * @param[in]  scale  An optional scale parameter
+ * @param[in]  bias   An optional bias parameter
+ */
+INFERENCE_ENGINE_API_CPP(void)
+f32tobf16Arrays(ie_bf16* dst, const float* src, size_t nelem, float scale = 1.f, float bias = 0.f);
 
 #if defined(_MSC_VER)
 #pragma warning(push)


### PR DESCRIPTION
For supporting BFloat16 DType, conversion from/to FP32 is needed, the MR adds this support