### PR TITLE
[GNA] 4D StridedSlice, Clamp, InsertIdentityLayerPass, SubstituteScaleShiftBroadCastPass fixes

### DIFF
--- a/inference-engine/src/gna_plugin/backend/dnn_types.h
+++ b/inference-engine/src/gna_plugin/backend/dnn_types.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -46,6 +46,10 @@ struct DnnActivation {
             float scale;
             float offset;
         } pow;
+        struct {
+            float low;
+            float high;
+        } clamp;
         struct {
             int32_t levels;
             // if input is per-channel quantization - input pointers contains per-channel ranges

--- a/inference-engine/src/gna_plugin/backend/dnn_types.h
+++ b/inference-engine/src/gna_plugin/backend/dnn_types.h
@@ -49,7 +49,7 @@ struct DnnActivation {
         struct {
             float low;
             float high;
-        } clamp;
+        } clamp; // structure to store cut-off values
         struct {
             int32_t levels;
             // if input is per-channel quantization - input pointers contains per-channel ranges

--- a/inference-engine/src/gna_plugin/backend/dnn_types.h
+++ b/inference-engine/src/gna_plugin/backend/dnn_types.h
@@ -49,7 +49,7 @@ struct DnnActivation {
         struct {
             float low;
             float high;
-        } clamp; // structure to store cut-off values
+        } clamp;
         struct {
             int32_t levels;
             // if input is per-channel quantization - input pointers contains per-channel ranges

--- a/inference-engine/src/gna_plugin/gna_graph_compiler.cpp
+++ b/inference-engine/src/gna_plugin/gna_graph_compiler.cpp
@@ -1785,9 +1785,21 @@ void GNAGraphCompiler::PWLPrimitive(InferenceEngine::CNNLayerPtr layer) {
     }
 
     if (it->second == kActKaldiLstmClipping) {
-        auto& clamp_layer = dynamic_cast<ClampLayer&>(*layer.get());
-        activation_type.args.clamp.low = clamp_layer.min_value;
-        activation_type.args.clamp.high = clamp_layer.max_value;
+        auto clamp_layer = dynamic_cast<ClampLayer*>(layer.get());
+        if (clamp_layer) {
+            if (clamp_layer->min_value == 0 && clamp_layer->max_value == 0) {
+                // Clamp layer may be not initialized due to backward compatibility
+                // use in such case old default values
+                activation_type.args.clamp.low = KALDI_LSTM_CLIP_LOWER;
+                activation_type.args.clamp.high = KALDI_LSTM_CLIP_UPPER;
+            } else {
+                activation_type.args.clamp.low = clamp_layer->min_value;
+                activation_type.args.clamp.high = clamp_layer->max_value;
+            }
+        } else {
+            activation_type.args.clamp.low = KALDI_LSTM_CLIP_LOWER;
+            activation_type.args.clamp.high = KALDI_LSTM_CLIP_UPPER;
+        }
     }
     string actName = "unknown";
 

--- a/inference-engine/src/gna_plugin/gna_graph_compiler.cpp
+++ b/inference-engine/src/gna_plugin/gna_graph_compiler.cpp
@@ -1042,8 +1042,7 @@ void GNAGraphCompiler::CropPrimitive(InferenceEngine::CNNLayerPtr layer) {
     size_t cropOffset = offset.front() * cropLayer->precision.size();
     size_t cropOutputSize = dim.front() * cropLayer->precision.size();
     // fix for crop on tensor dim > 2D
-    for (int n = axis[0]+1; n < cropLayer->dim.size(); n++)
-    {
+    for (int n = axis[0]+1; n < cropLayer->dim.size(); n++) {
         cropOffset *= cropLayer->dim[n];
         cropOutputSize *= cropLayer->dim[n];
     }

--- a/inference-engine/src/gna_plugin/gna_graph_compiler.cpp
+++ b/inference-engine/src/gna_plugin/gna_graph_compiler.cpp
@@ -2357,7 +2357,6 @@ GNAPluginNS::ConnectionDetails GNAGraphCompiler::connectInput(CNNLayerPtr layer,
         return connectInput(prevLayer, ptr, num_data_bytes_in, offset, 0);
     }
 
-
     THROW_GNA_EXCEPTION << "Cannot connect input for: " << layer->name;
 }
 

--- a/inference-engine/src/gna_plugin/gna_graph_tools.hpp
+++ b/inference-engine/src/gna_plugin/gna_graph_tools.hpp
@@ -743,6 +743,9 @@ inline void CNNNetworkReconnectLayer(CNNLayerPtr old_prev_layer, CNNLayerPtr new
         THROW_IE_EXCEPTION << "Cannot reconnect layer : " << old_prev_layer->name << " must have exactly 1 outgoing port";
     }
 
+    if (new_prev_layer->outData.size() != 1) {
+        THROW_IE_EXCEPTION << "Cannot reconnect layer : " << new_prev_layer->name << " must have exactly 1 outgoing port";
+    }
     // layer has ports
     // each port has several layers connected to port
     // we are assuming that old & new prev has only one outgoing port

--- a/inference-engine/src/gna_plugin/gna_graph_tools.hpp
+++ b/inference-engine/src/gna_plugin/gna_graph_tools.hpp
@@ -756,6 +756,7 @@ inline void CNNNetworkReconnectLayer(CNNLayerPtr old_prev_layer, CNNLayerPtr new
     for (auto layer_input_port : CNNLayerFindInsDataIdxes(old_prev_layer_out_port_0, layer)) {
         layer->insData[layer_input_port] = new_prev_layer_out_port_0;
     }
+
     // remove old_prev->layer connection
     for (auto i = getInputTo(old_prev_layer_out_port_0).begin(); i != getInputTo(old_prev_layer_out_port_0).end(); i++) {
         if (i->second.get() == layer.get()) {

--- a/inference-engine/src/gna_plugin/gna_graph_tools.hpp
+++ b/inference-engine/src/gna_plugin/gna_graph_tools.hpp
@@ -765,6 +765,7 @@ inline void CNNNetworkReconnectLayer(CNNLayerPtr old_prev_layer, CNNLayerPtr new
     // remove old_prev->layer connection
     for (auto i = getInputTo(old_prev_layer_out_port_0).begin(); i != getInputTo(old_prev_layer_out_port_0).end(); i++) {
         if (i->second.get() == layer.get()) {
+            getInputTo(new_prev_layer_out_port_0).insert({ layer->name, layer });
             getInputTo(old_prev_layer_out_port_0).erase(i);
             break;
         }

--- a/inference-engine/src/gna_plugin/gna_graph_tools.hpp
+++ b/inference-engine/src/gna_plugin/gna_graph_tools.hpp
@@ -722,7 +722,8 @@ inline void CNNNetworkRemoveLayer(CNNLayerPtr layer, bool checkDims = true) {
  *    - new & old prev layer must have exactly one outgoing port
  */
 inline void CNNNetworkReconnectLayer(CNNLayerPtr old_prev_layer, CNNLayerPtr new_prev_layer, CNNLayerPtr layer, bool checkDims = true) {
-    gnalog() << "Reconnecting " << old_prev_layer->name << " --> " << layer->name << " layer to " << new_prev_layer->name << " -- > " << layer->name << "layer\n";
+    gnalog() << "Reconnecting " << old_prev_layer->name << " --> " << layer->name << " layer to "
+        << new_prev_layer->name << " -- > " << layer->name << "layer\n";
     if (!layer) {
         THROW_IE_EXCEPTION << "Cannot reconnect layer pointed to NULL";
     }
@@ -734,7 +735,8 @@ inline void CNNNetworkReconnectLayer(CNNLayerPtr old_prev_layer, CNNLayerPtr new
     }
 
     if (layer->insData.size() < 1) {
-        THROW_IE_EXCEPTION << "Cannot reconnect layer : " << layer->name << " operation supports only layers with at least 1 incomming port";
+        THROW_IE_EXCEPTION << "Cannot reconnect layer : " << layer->name
+            << " operation supports only layers with at least 1 incomming port";
     }
 
     if (old_prev_layer->outData.size() != 1) {

--- a/inference-engine/src/gna_plugin/gna_graph_tools.hpp
+++ b/inference-engine/src/gna_plugin/gna_graph_tools.hpp
@@ -712,4 +712,57 @@ inline void CNNNetworkRemoveLayer(CNNLayerPtr layer, bool checkDims = true) {
     // removing layer->osp, and layer->isp connection not necessary - layer will delete it by itself
 }
 
+/**
+ * @brief reconnects given layer to different parent
+ * before:
+ *   old_prev_layer --> layer
+ * after:
+ *   new_prev_layer --> layer
+ * limitations:
+ *    - new & old prev layer must have exactly one outgoing port
+ */
+inline void CNNNetworkReconnectLayer(CNNLayerPtr old_prev_layer, CNNLayerPtr new_prev_layer, CNNLayerPtr layer, bool checkDims = true) {
+    gnalog() << "Reconnecting " << old_prev_layer->name << " --> " << layer->name << " layer to " << new_prev_layer->name << " -- > " << layer->name << "layer\n";
+    if (!layer) {
+        THROW_IE_EXCEPTION << "Cannot reconnect layer pointed to NULL";
+    }
+    if (!old_prev_layer) {
+        THROW_IE_EXCEPTION << "Cannot reconnect layer old parent is NULL";
+    }
+    if (!new_prev_layer) {
+        THROW_IE_EXCEPTION << "Cannot reconnect layer new parent is NULL";
+    }
+
+    if (layer->insData.size() < 1) {
+        THROW_IE_EXCEPTION << "Cannot reconnect layer : " << layer->name << " operation supports only layers with at least 1 incomming port";
+    }
+
+    if (old_prev_layer->outData.size() != 1) {
+        THROW_IE_EXCEPTION << "Cannot reconnect layer : " << old_prev_layer->name << " must have exactly 1 outgoing port";
+    }
+
+    // layer has ports
+    // each port has several layers connected to port
+    // we are assuming that old & new prev has only one outgoing port
+    auto old_prev_layer_out_port_0 = old_prev_layer->outData.front();
+    auto new_prev_layer_out_port_0 = new_prev_layer->outData.front();
+
+    if (checkDims && old_prev_layer_out_port_0->getDims() != new_prev_layer_out_port_0->getDims()) {
+        THROW_IE_EXCEPTION << "Cannot reconnect layer : " << old_prev_layer->name << " as its output have different dims than"
+            << new_prev_layer->name;
+    }
+
+    // find connection between old_prev & layer connection in layer input collection
+    for (auto layer_input_port : CNNLayerFindInsDataIdxes(old_prev_layer_out_port_0, layer)) {
+        layer->insData[layer_input_port] = new_prev_layer_out_port_0;
+    }
+    // remove old_prev->layer connection
+    for (auto i = getInputTo(old_prev_layer_out_port_0).begin(); i != getInputTo(old_prev_layer_out_port_0).end(); i++) {
+        if (i->second.get() == layer.get()) {
+            getInputTo(old_prev_layer_out_port_0).erase(i);
+            break;
+        }
+    }
+}
+
 }  // namespace InferenceEngine

--- a/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.cpp
+++ b/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.cpp
@@ -733,8 +733,7 @@ void InsertIdentityLayerPass::run() {
             // check if prev layer have id layer already connected to output
             // if so reuse it instead of create new one
             bool reconnected = false;
-            for (auto prev_layer_output : prev->outData)
-            {
+            for (auto prev_layer_output : prev->outData) {
                 // prev ---------+--> identity --> layer XYZ
                 //               |
                 //               |  <= here we want to inject identity

--- a/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.cpp
+++ b/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.cpp
@@ -730,6 +730,31 @@ void InsertIdentityLayerPass::run() {
                     break;
                 }
             }
+            // check if prev layer have id layer already connected to output
+            // if so reuse it instead of create new one
+            bool reconnected = false;
+            for (auto prev_layer_output : prev->outData)
+            {
+                // prev ---------+--> identity --> layer XYZ
+                //               |
+                //               |  <= here we want to inject identity
+                //               |
+                //               +--> l layer
+                // but we may just connect l layer with existing identity
+                for (auto&& next_layer : getInputTo(prev_layer_output)) {
+                    auto child_of_prev_layer = next_layer.second;
+                    if (child_of_prev_layer.get() == true_layer.get()) {
+                        continue;
+                    } else if (LayerInfo(child_of_prev_layer).isIdentity()) {
+                        CNNNetworkReconnectLayer(prev, child_of_prev_layer, true_layer);
+                        reconnected = true;
+                        break;
+                    }
+                }
+            }
+            if (reconnected)
+                continue;
+
             int numOfIdentityLayers = this->getPassManager()->getIntVar(identityLayersCounterName)++;
             // actual insertion
             auto activationName = std::string("identity_") + std::to_string(numOfIdentityLayers);
@@ -760,7 +785,7 @@ void InsertIdentityLayerPass::run() {
                                             activationLayer;
             getCreatorLayer(dataPtr) = activationLayerWithQuant;
             activationLayerWithQuant->outData.push_back(dataPtr);
-            // wether 1 identity or all outputs TODO possible grouping here, need to implement special groupped inserter
+            // wether 1 identity or all outputs TODO possible grouping here, need to implement special grouped inserter
             bool notAll = false;
             for (auto && nextData  : prev->outData) {
                 for (auto && nextLayer : getInputTo(nextData)) {
@@ -1399,6 +1424,8 @@ void EltwiseSplitOverChannelsPass::run() {
 
 void SubstituteScaleShiftBroadCastPass::run() {
     std::map<std::string, InferenceEngine::SizeVector> reshaped_data;
+    auto quantized = InferenceEngine::getInjectedData<QuantizedLayerParams>(pLayers->front());
+
     for (auto & l : *pLayers) {
         LayerInfo layerInfo(l);
 
@@ -1461,12 +1488,14 @@ void SubstituteScaleShiftBroadCastPass::run() {
                 scaleShift->_biases = tileBlob(scaleShift->_biases, nElements);
             }
 
-            // currently data type no providing reshape method of tensor desc
-            scaleShift->outData.front()->reshape({batchSize, nElements}, Layout::NC);
-            if (!was_reshaped) {
-                reshaped_data[insData->getName()] = insData->getDims();
-                insData->reshape({batchSize, nElements}, Layout::NC);
-            }
+            auto tensor = InferenceEngine::TensorDesc(insData->getTensorDesc());
+            tensor.reshape(SizeVector{ batchSize, nElements }, Layout::NC);
+            auto reshapeName = scaleShift->name + "_input_" + std::to_string(0) + "_reshape";
+            auto reshape = CNNNetworkCreateReshape(tensor, reshapeName, quantized);
+            auto layer_before_scale_shift = getCreatorLayer(insData);
+
+            CNNNetworkInsertLayer(layer_before_scale_shift.lock(), l, reshape);
+            gnalog() << "\tInserted " << reshapeName << " between " << layer_before_scale_shift.lock()->name << " and " << l->name << std::endl;
         } else {
             THROW_GNA_EXCEPTION << "Not implemented substitution of scaleshift broadcast policy of "
                                 << getPassManager()->getPolicy().ScaleShiftPolicy <<  "using layers tiling, layer: " << l->name;
@@ -1968,13 +1997,15 @@ void MoveFakeQuantizeLayerIntoQuantParamsPass :: run() {
 }
 
 int PassManager::run(int index) {
-#ifdef PLOT
+#if defined PLOT || defined ENABLE_V7_SERIALIZE
     auto dumpNetworkAfterPass = [&index, this] (std::shared_ptr<Pass> pass) {
         std::string name = std::string("gna_passes_") + (index < 10 ? "0" : "") + std::to_string(index) + "_" + pass->getName();
+#ifdef PLOT
         std::ofstream out(name + ".dot");
         saveGraphToDot(network, out, [](const CNNLayerPtr layer,
                                         ordered_properties &printed_properties,
                                         ordered_properties &node_properties) {});
+#endif
         network.serialize(name + ".xml", name + ".bin");
     };
 #else

--- a/inference-engine/src/gna_plugin/runtime/gna_float_runtime.cpp
+++ b/inference-engine/src/gna_plugin/runtime/gna_float_runtime.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/inference-engine/src/gna_plugin/runtime/pwl.cpp
+++ b/inference-engine/src/gna_plugin/runtime/pwl.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 //  pwl_design.cpp : simple activation function designer

--- a/inference-engine/src/gna_plugin/runtime/pwl.cpp
+++ b/inference-engine/src/gna_plugin/runtime/pwl.cpp
@@ -978,8 +978,7 @@ void PwlApply32(intel_dnn_component_t *component,
                 }
             }
             break;
-        case kActKaldiLstmClipping:
-        {
+        case kActKaldiLstmClipping: {
             float upper_limit = component->op.pwl.func_id.args.clamp.high;
             float lowwer_limit = component->op.pwl.func_id.args.clamp.low;
             for (uint32_t i = num_row_start; i <= num_row_end; i++) {
@@ -988,11 +987,9 @@ void PwlApply32(intel_dnn_component_t *component,
 
                     if (val > upper_limit) {
                         ptr_out[i * num_columns + j] = upper_limit;
-                    }
-                    else if (val < lowwer_limit) {
+                    } else if (val < lowwer_limit) {
                         ptr_out[i * num_columns + j] = lowwer_limit;
-                    }
-                    else {
+                    } else {
                         ptr_out[i * num_columns + j] = val;
                     }
                 }

--- a/inference-engine/src/gna_plugin/runtime/pwl.cpp
+++ b/inference-engine/src/gna_plugin/runtime/pwl.cpp
@@ -369,13 +369,13 @@ std::vector<pwl_t> pwl_search(const DnnActivation& activation_type,
             pwl.resize(4);
             pwl[0].alpha = pwl[0].t = pwl[0].beta = -std::numeric_limits<float>::infinity();
             pwl[0].m = 0.0;
-            pwl[0].b = pwl[0].beta = KALDI_LSTM_CLIP_LOWER;
-            pwl[1].alpha = pwl[0].t = pwl[1].beta = KALDI_LSTM_CLIP_LOWER;
+            pwl[0].b = pwl[0].beta = l_bound;
+            pwl[1].alpha = pwl[0].t = pwl[1].beta = l_bound;
             pwl[1].m = 1.0;
             pwl[1].b = 0.0;
-            pwl[2].alpha = pwl[0].t = pwl[1].beta = KALDI_LSTM_CLIP_UPPER;
+            pwl[2].alpha = pwl[0].t = pwl[1].beta = u_bound;
             pwl[2].m = 0.0;
-            pwl[2].b = KALDI_LSTM_CLIP_UPPER;
+            pwl[2].b = u_bound;
             pwl[3].alpha = pwl[3].beta = std::numeric_limits<float>::infinity();
 
         } else if (activation_type == kActSign) {
@@ -525,7 +525,7 @@ void PwlDesignOpt16(const DnnActivation activation_type,
             make_gna_pwl(activation_type, pwl, -1.0, 1.0, scale_in, scale_out, ptr_segment);
             break;
         case kActKaldiLstmClipping:
-            make_gna_pwl(activation_type, pwl, KALDI_LSTM_CLIP_LOWER, KALDI_LSTM_CLIP_UPPER, scale_in, scale_out, ptr_segment);
+            make_gna_pwl(activation_type, pwl, activation_type.args.clamp.low, activation_type.args.clamp.high, scale_in, scale_out, ptr_segment);
             break;
         case kActLog: {
             double x_min = (1 + ~XBASEMASK) / scale_in;
@@ -979,19 +979,26 @@ void PwlApply32(intel_dnn_component_t *component,
             }
             break;
         case kActKaldiLstmClipping:
+        {
+            float upper_limit = component->op.pwl.func_id.args.clamp.high;
+            float lowwer_limit = component->op.pwl.func_id.args.clamp.low;
             for (uint32_t i = num_row_start; i <= num_row_end; i++) {
                 for (uint32_t j = num_col_start; j <= num_col_end; j++) {
                     float val = ptr_in[i * num_columns + j];
-                    if (val > KALDI_LSTM_CLIP_UPPER) {
-                        ptr_out[i * num_columns + j] = KALDI_LSTM_CLIP_UPPER;
-                    } else if (val < KALDI_LSTM_CLIP_LOWER) {
-                        ptr_out[i * num_columns + j] = KALDI_LSTM_CLIP_LOWER;
-                    } else {
+
+                    if (val > upper_limit) {
+                        ptr_out[i * num_columns + j] = upper_limit;
+                    }
+                    else if (val < lowwer_limit) {
+                        ptr_out[i * num_columns + j] = lowwer_limit;
+                    }
+                    else {
                         ptr_out[i * num_columns + j] = val;
                     }
                 }
             }
             break;
+        }
         case kActExp:
             for (uint32_t i = num_row_start; i <= num_row_end; i++) {
                 for (uint32_t j = num_col_start; j <= num_col_end; j++) {

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/crop4d.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/crop4d.cpp
@@ -1,0 +1,46 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "subgraph_tests/crop4d.hpp"
+#include "common_test_utils/test_constants.hpp"
+
+using namespace SubgraphTestsDefinitions;
+
+namespace {
+
+std::vector<StridedSliceSpecificParams> ss_only_test_cases = {
+        StridedSliceSpecificParams{ { 1, 2, 100, 100 },
+                                    { 0, 0, 0, 0 },
+                                    { 1, 1, 1, 1 }, { 1, 1, 1, 1 },
+                                    { 1, 1, 1, 1 }, { 1, 0, 1, 1 },  { 0, 0, 0, 0 },  { 1, 0, 0, 0 },  { 0, 0, 0, 0 } },
+};
+
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+        InferenceEngine::Precision::FP32,
+        InferenceEngine::Precision::FP16,
+};
+
+const std::vector<std::map<std::string, std::string>> configs = {
+        {
+                {"GNA_DEVICE_MODE", "GNA_SW_EXACT"},
+                {"GNA_COMPACT_MODE", "NO"}
+        }
+};
+
+INSTANTIATE_TEST_CASE_P(
+        smoke_crop4d_gna, Crop4dTest,
+        ::testing::Combine(
+        ::testing::ValuesIn(ss_only_test_cases),
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(CommonTestUtils::DEVICE_GNA),
+        ::testing::ValuesIn(configs)),
+        Crop4dTest::getTestCaseName);
+
+}  // namespace

--- a/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/crop4d.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/crop4d.hpp
@@ -1,0 +1,13 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#include "shared_test_classes/subgraph/crop4d.hpp"
+
+namespace SubgraphTestsDefinitions {
+
+TEST_P(Crop4dTest, CompareWithRefs){
+    Run();
+};
+}  // namespace SubgraphTestsDefinitions

--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/crop4d.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/crop4d.hpp
@@ -1,0 +1,47 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "shared_test_classes/base/layer_test_utils.hpp"
+
+namespace SubgraphTestsDefinitions {
+
+struct StridedSliceSpecificParams {
+    InferenceEngine::SizeVector inputShape;
+    std::vector<int64_t> begin;
+    std::vector<int64_t> end;
+    std::vector<int64_t> strides;
+    std::vector<int64_t> beginMask;
+    std::vector<int64_t> endMask;
+    std::vector<int64_t> newAxisMask;
+    std::vector<int64_t> shrinkAxisMask;
+    std::vector<int64_t> ellipsisAxisMask;
+};
+
+using Crop4dParams = std::tuple<
+        StridedSliceSpecificParams,
+        InferenceEngine::Precision,        // Net precision
+        InferenceEngine::Precision,        // Input precision
+        InferenceEngine::Precision,        // Output precision
+        InferenceEngine::Layout,           // Input layout
+        InferenceEngine::Layout,           // Output layout
+        std::string,                       // Device name
+        std::map<std::string, std::string> // Additional network configuration
+>;
+
+class Crop4dTest : public testing::WithParamInterface<Crop4dParams>,
+                              virtual public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<Crop4dParams> &obj);
+
+protected:
+    void SetUp() override;
+};
+}  // namespace SubgraphTestsDefinitions

--- a/inference-engine/tests/functional/shared_test_classes/src/subgraph/crop4d.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/subgraph/crop4d.cpp
@@ -1,0 +1,56 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "ngraph_functions/builders.hpp"
+
+#include "shared_test_classes/subgraph/crop4d.hpp"
+
+namespace SubgraphTestsDefinitions {
+
+std::string Crop4dTest::getTestCaseName(const testing::TestParamInfo<Crop4dParams> &obj) {
+    StridedSliceSpecificParams params;
+    InferenceEngine::Precision netPrc;
+    InferenceEngine::Precision inPrc, outPrc;
+    InferenceEngine::Layout inLayout, outLayout;
+    std::string targetName;
+    std::map<std::string, std::string> additionalConfig;
+    std::tie(params, netPrc, inPrc, outPrc, inLayout, outLayout, targetName, additionalConfig) = obj.param;
+    std::ostringstream result;
+    result << "inShape=" << CommonTestUtils::vec2str(params.inputShape) << "_";
+    result << "netPRC=" << netPrc.name() << "_";
+    result << "inPRC=" << inPrc.name() << "_";
+    result << "outPRC=" << outPrc.name() << "_";
+    result << "inL=" << inLayout << "_";
+    result << "outL=" << outLayout << "_";
+    result << "begin=" << CommonTestUtils::vec2str(params.begin) << "_";
+    result << "end=" << CommonTestUtils::vec2str(params.end) << "_";
+    result << "stride=" << CommonTestUtils::vec2str(params.strides) << "_";
+    result << "begin_m=" << CommonTestUtils::vec2str(params.beginMask) << "_";
+    result << "end_m=" << CommonTestUtils::vec2str(params.endMask) << "_";
+    result << "new_axis_m=" << (params.newAxisMask.empty() ? "def" : CommonTestUtils::vec2str(params.newAxisMask)) << "_";
+    result << "shrink_m=" << (params.shrinkAxisMask.empty() ? "def" : CommonTestUtils::vec2str(params.shrinkAxisMask)) << "_";
+    result << "ellipsis_m=" << (params.ellipsisAxisMask.empty() ? "def" : CommonTestUtils::vec2str(params.ellipsisAxisMask)) << "_";
+    result << "trgDev=" << targetName;
+    return result.str();
+}
+
+void Crop4dTest::SetUp() {
+    StridedSliceSpecificParams ssParams;
+    InferenceEngine::Precision netPrecision;
+    std::map<std::string, std::string> additionalConfig;
+    std::tie(ssParams, netPrecision, inPrc, outPrc, inLayout, outLayout, targetDevice, additionalConfig) = this->GetParam();
+    configuration.insert(additionalConfig.begin(), additionalConfig.end());
+
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+    auto params = ngraph::builder::makeParams(ngPrc, {ssParams.inputShape});
+    auto paramOuts = ngraph::helpers::convert2OutputVector(
+            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
+    auto relu = std::make_shared<ngraph::opset1::Relu>(paramOuts[0]);
+    auto ss = ngraph::builder::makeStridedSlice(relu, ssParams.begin, ssParams.end, ssParams.strides, ngPrc, ssParams.beginMask,
+                                                ssParams.endMask, ssParams.newAxisMask, ssParams.shrinkAxisMask, ssParams.ellipsisAxisMask);
+    ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(ss)};
+    function = std::make_shared<ngraph::Function>(results, params, "crop4d");
+}
+
+}  // namespace SubgraphTestsDefinitions

--- a/inference-engine/tests_deprecated/unit/engines/gna/test_irs.cpp
+++ b/inference-engine/tests_deprecated/unit/engines/gna/test_irs.cpp
@@ -1822,7 +1822,7 @@ std::string ClampActivationModel() {
             </output>
         </layer>
         <layer name="Clamp_Activation" id="2" type="Activation" precision="FP32">
-            <data type="clamp" min="-5" max="5" />
+            <data type="clamp" min="-50" max="50" />
             <input>
                 <port id="0">
                     <dim>1</dim>


### PR DESCRIPTION
fixed: StrideSlice/Crop was broken when crop axis != dim.size() - 1 &… added support for tensor dim > 2
fixed: clamp had hard coded upper & lower boundary to -50/50
fixed: InsertIdentityLayerPass was adding not necessary identities that was leading to exception when 2 identities was added to convolution output
fixed: SubstituteScaleShiftBroadCastPass caused invalid input tensor dimension overwrite - instead of overwrite currently reshape is injected