### PR TITLE
Added support for the MxNet op "take"

### DIFF
--- a/docs/MO_DG/prepare_model/Supported_Frameworks_Layers.md
+++ b/docs/MO_DG/prepare_model/Supported_Frameworks_Layers.md
@@ -108,6 +108,7 @@ Standard MXNet\* symbols:
 | SoftmaxActivation | No |
 | SoftmaxOutput | No |
 | SoftSign | No |
+| Take | The attribute 'mode' is not supported |
 | Tile | No |
 | UpSampling | No |
 | Where | No |

--- a/model-optimizer/automation/package_BOM.txt
+++ b/model-optimizer/automation/package_BOM.txt
@@ -224,6 +224,7 @@ extensions/front/mxnet/ssd_pattern_remove_transpose.py
 extensions/front/mxnet/ssd_reorder_detection_out_inputs.py
 extensions/front/mxnet/stack_ext.py
 extensions/front/mxnet/swapaxis_ext.py
+extensions/front/mxnet/take_ext.py
 extensions/front/mxnet/tile_ext.py
 extensions/front/mxnet/tile_replacer.py
 extensions/front/mxnet/transpose_ext.py

--- a/model-optimizer/extensions/front/mxnet/take_ext.py
+++ b/model-optimizer/extensions/front/mxnet/take_ext.py
@@ -1,0 +1,33 @@
+"""
+ Copyright (C) 2017-2021 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+from extensions.ops.gather import AttributedGather
+from mo.front.extractor import FrontExtractorOp
+from mo.front.mxnet.extractors.utils import get_mxnet_layer_attrs
+from mo.graph.graph import Node
+
+
+class TakeExtractor(FrontExtractorOp):
+    op = 'take'
+    enabled = True
+
+    @classmethod
+    def extract(cls, node: Node):
+        attrs = get_mxnet_layer_attrs(node.symbol_dict)
+        AttributedGather.update_node_stat(node, {
+            'axis': attrs.int('axis', 0),
+        })
+        return cls.enabled


### PR DESCRIPTION
Description: Enable operation "take" from MxNet

Ticket: 45746

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR: N/A no new transformations
* [x]  Transformation preserves original framework node names: N/A no new transformations


Validation:
* [x]  Unit tests: N/A we do not implement tests for extractor
* [x]  Framework operation tests: 47794
* [x]  Transformation tests: N/A no new transformations
* [x]  e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py: not a public model, but verified locally that the inference results match between MxNet and IE
* [x]  Model Optimizer IR Reader check: verified locally

Documentation:
* [x]  Supported frameworks operations list
* [x]  Supported **public** models list: N/A no new public model
* [x]  New operations specification: N/A no new operation specification
* [x]  Guide on how to convert the **public** model: N/A no new public model
* [x]  User guide update: N/A no new customer visible changes