### PR TITLE
WIP: [CLDNN] Enable scatter update op 

### DIFF
--- a/inference-engine/src/cldnn_engine/cldnn_primitives_list.hpp
+++ b/inference-engine/src/cldnn_engine/cldnn_primitives_list.hpp
@@ -167,7 +167,7 @@ REGISTER_FACTORY(v3, ExtractImagePatches);
 // REGISTER_FACTORY(v3, ROIAlign);
 // REGISTER_FACTORY(v3, ReadValue);
 // REGISTER_FACTORY(v3, ScatterElementsUpdate);
-// REGISTER_FACTORY(v3, ScatterUpdate);
+REGISTER_FACTORY(v3, ScatterUpdate);
 // REGISTER_FACTORY(v3, ScatterNDUpdate);
 // REGISTER_FACTORY(v3, ShapeOf);
 // REGISTER_FACTORY(v3, TopK);

--- a/inference-engine/src/cldnn_engine/cldnn_primitives_list.hpp
+++ b/inference-engine/src/cldnn_engine/cldnn_primitives_list.hpp
@@ -156,10 +156,10 @@ REGISTER_FACTORY(v3, EmbeddingBagOffsetsSum);
 REGISTER_FACTORY(v3, EmbeddingBagPackedSum);
 REGISTER_FACTORY(v3, EmbeddingSegmentsSum);
 REGISTER_FACTORY(v3, ExtractImagePatches);
+REGISTER_FACTORY(v3, ScatterUpdate);
 // REGISTER_FACTORY(v3, NonMaxSuppression); Supported via v3 -> v5 internal conversion
 
 // ----------------------------- Unsupported v3 ops ----------------------------- //
-// REGISTER_FACTORY(v3, ScatterUpdate); // There is the scatter_update primitive, but seems like it produces wrong results
 // REGISTER_FACTORY(v3, Assign);
 // REGISTER_FACTORY(v3, Bucketize);
 // REGISTER_FACTORY(v3, GRUCell);
@@ -167,7 +167,6 @@ REGISTER_FACTORY(v3, ExtractImagePatches);
 // REGISTER_FACTORY(v3, ROIAlign);
 // REGISTER_FACTORY(v3, ReadValue);
 // REGISTER_FACTORY(v3, ScatterElementsUpdate);
-REGISTER_FACTORY(v3, ScatterUpdate);
 // REGISTER_FACTORY(v3, ScatterNDUpdate);
 // REGISTER_FACTORY(v3, ShapeOf);
 // REGISTER_FACTORY(v3, TopK);

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/scatter_update.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/scatter_update.cpp
@@ -25,8 +25,9 @@ const std::vector<InferenceEngine::Precision> idxPrecisions = {
 
 // map<inputShape, map<indicesShape, axis>>
 std::map<std::vector<size_t>, std::map<std::vector<size_t>, std::vector<int>>> axesShapeInShape {
-    {{10, 16, 12, 15}, {{{2, 4}, {0, 1, 2, 3}}, {{8}, {-1, -2, -3, -4}}}},
-    {{10, 9, 10, 9, 10}, {{{8}, {-3, -1, 0, 2, 4}}, {{4, 2}, {-2, 2}}}},
+    {{10, 16, 12, 15}, {{{2, 2, 2}, {0, 1, 2, 3}}, {{2, 4}, {0, 1, 2, 3}}, {{8}, {0, 1, 2, 3}}}},
+    {{10, 9, 10, 9, 10}, {{{8}, {0, 1, 2, 3, 4}}, {{4, 2}, {0, 1, 2, 3, 4}}}},
+    {{10, 9, 10, 9, 10, 12}, {{{8}, {0, 1, 2, 3, 4, 5}}}},
 };
 //indices should not be random value
 const std::vector<std::vector<int64_t>> idxValue = {

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/skip_tests_config.cpp
@@ -48,7 +48,6 @@ std::vector<std::string> disabledTestPatterns() {
             R"(.*(LSTMSequence).*mode=CONVERT_TO_TI_RAND_SEQ_LEN.*)",
             R"(.*(smoke_DetectionOutput3In).*)",
             R"(.*(smoke_DetectionOutput5In).*)",
-            R"(.*(ScatterUpdateLayerTest).*)",
 
             // INT8 StridedSlice not supported
             R"(.*(LPT/StridedSliceTransformation).*)",

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/scatter_update/scatter_update_kernel_ref.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/scatter_update/scatter_update_kernel_ref.cpp
@@ -141,12 +141,6 @@ static std::string GetOutputIndexOnAxis(const scatter_update_params& params, siz
     return default_order[axis];
 }
 
-static std::vector<std::string> GetVectorSecondOutputIndexOrder(const scatter_update_params& params, size_t axis) {
-    std::vector<std::string> default_order = GetDefaultOrder(params.output.GetDims().size());
-    default_order[axis] = "convert_int(indices[OUTPUT_INDEX_ON_AXIS])";
-    return default_order;
-}
-
 static std::vector<std::string> GetIndicesOrder(const scatter_update_params& params, size_t axis) {
     std::vector<std::string> indices_order {"0", "0", "0", "0"};
     auto updates_dim = params.inputs[2].GetDims().size();
@@ -162,7 +156,7 @@ static std::vector<std::string> GetIndicesOrder(const scatter_update_params& par
     return indices_order;
 }
 
-static std::string GetSecondIterOutputIndexOrder(const scatter_update_params& params, size_t axis) {
+static std::vector<std::string> GetVectorSecondOutputIndexOrder(const scatter_update_params& params, size_t axis) {
     auto output_order  = GetDefaultOrder(params.output.GetDims().size());
     auto update_order  = GetDefaultOrder(params.inputs[2].GetDims().size());
     auto indices_order = GetIndicesOrder(params, axis);
@@ -182,7 +176,14 @@ static std::string GetSecondIterOutputIndexOrder(const scatter_update_params& pa
     }
     output_order[axis] = "convert_int(indices[(INPUT1_GET_INDEX(" + GetOrderString(indices_order) + "))])";
 
+    return output_order;
+}
+
+
+static std::string GetSecondIterOutputIndexOrder(const scatter_update_params& params, size_t axis) {
+    auto output_order = GetVectorSecondOutputIndexOrder(params, axis);
     return GetOrderString(output_order);
+
 }
 
 JitConstants ScatterUpdateKernelRef::GetJitConstants(const scatter_update_params& params) const {

--- a/inference-engine/thirdparty/clDNN/src/graph_optimizer/reorder_inputs.cpp
+++ b/inference-engine/thirdparty/clDNN/src/graph_optimizer/reorder_inputs.cpp
@@ -17,6 +17,7 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "api/binary_convolution.hpp"
+#include "api/scatter_update.hpp"
 #include "pass_manager.h"
 #include "program_node.h"
 #include "layout_optimizer.h"
@@ -351,6 +352,9 @@ void insert_reorders_in_dir(program_impl& p, const std::map<program_node*, forma
             continue;
 
         if (fmt_map.count(next) > 0 && fmt_map.at(next) == fmt)
+            continue;
+
+        if (node->is_type<scatter_update>())
             continue;
 
         auto next_layout = next->get_output_layout();

--- a/inference-engine/thirdparty/clDNN/src/program.cpp
+++ b/inference-engine/thirdparty/clDNN/src/program.cpp
@@ -421,12 +421,10 @@ void program_impl::pre_optimize_graph(bool is_internal) {
         apply_opt_pass<pre_replace_deconv>(lo);
 
         apply_opt_pass<prepare_primitive_fusing>(lo);
-#if 0
         apply_opt_pass<reorder_inputs>(lo, rf);
         // Ideally this should be done before fusing to simplify logic and make the pass more powerful,
         // but after format selection to select correct alignment.
         // Unfortunately those passes currently happen in reverse order.
-#endif
         apply_opt_pass<concat_input_order>();
 
         // TODO this code should be moved to post compilation after kernel selector will support handling reorder bias

--- a/inference-engine/thirdparty/clDNN/src/program.cpp
+++ b/inference-engine/thirdparty/clDNN/src/program.cpp
@@ -421,11 +421,12 @@ void program_impl::pre_optimize_graph(bool is_internal) {
         apply_opt_pass<pre_replace_deconv>(lo);
 
         apply_opt_pass<prepare_primitive_fusing>(lo);
-
+#if 0
         apply_opt_pass<reorder_inputs>(lo, rf);
         // Ideally this should be done before fusing to simplify logic and make the pass more powerful,
         // but after format selection to select correct alignment.
         // Unfortunately those passes currently happen in reverse order.
+#endif
         apply_opt_pass<concat_input_order>();
 
         // TODO this code should be moved to post compilation after kernel selector will support handling reorder bias

--- a/inference-engine/thirdparty/clDNN/tests/test_cases/fusings_gpu_test.cpp
+++ b/inference-engine/thirdparty/clDNN/tests/test_cases/fusings_gpu_test.cpp
@@ -5601,7 +5601,7 @@ struct scatter_update_test_params {
 #define CASE_SCATTER_UPDATE_5D_FP32_4 {2, 3, 1, 4, 4}, {2, 1, 1, 1}, {2, 3, 1, 4, 2}, cldnn::scatter_update::scatter_update_axis::along_z, data_types::f32, format::bfzyx, format::bfzyx, data_types::f32, format::bfzyx
 #define CASE_SCATTER_UPDATE_5D_FP32_5 {3, 1, 5, 2, 1}, {2, 1, 1, 1}, {3, 1, 2, 2, 1}, cldnn::scatter_update::scatter_update_axis::along_x, data_types::f32, format::bfzyx, format::bfzyx, data_types::f32, format::bfzyx
 
-#define CASE_SCATTER_UPDATE_5D_FP16_1 {3, 2, 1, 2, 1}, {2, 1, 1, 1}, {2, 2, 2, 2, 1}, cldnn::scatter_update::scatter_update_axis::along_b, data_types::f16, format::bfzyx, format::bfzyx,  data_types::f16, format::bfzyx
+#define CASE_SCATTER_UPDATE_5D_FP16_1 {3, 2, 1, 2, 1}, {1, 2, 1, 1}, {2, 2, 1, 2, 1}, cldnn::scatter_update::scatter_update_axis::along_b, data_types::f16, format::bfzyx, format::bfzyx,  data_types::f16, format::bfzyx
 #define CASE_SCATTER_UPDATE_5D_FP16_2 {1, 3, 1, 2, 1}, {2, 1, 1, 1}, {1, 2, 1, 2, 1}, cldnn::scatter_update::scatter_update_axis::along_f, data_types::f16, format::bfzyx, format::bfzyx, data_types::f16, format::bfzyx
 #define CASE_SCATTER_UPDATE_5D_FP16_3 {2, 3, 1, 3, 3}, {1, 2, 1, 1}, {2, 3, 1, 1, 2, 3}, cldnn::scatter_update::scatter_update_axis::along_y, data_types::f16, format::bfzyx, format::bfwzyx, data_types::f16, format::bfzyx
 #define CASE_SCATTER_UPDATE_5D_FP16_4 {3, 2, 2, 2, 2}, {2, 1, 1, 1}, {3, 2, 2, 2, 2}, cldnn::scatter_update::scatter_update_axis::along_z, data_types::f16, format::bfzyx, format::bfzyx, data_types::f16, format::bfzyx

--- a/inference-engine/thirdparty/clDNN/tests/test_cases/fusings_gpu_test.cpp
+++ b/inference-engine/thirdparty/clDNN/tests/test_cases/fusings_gpu_test.cpp
@@ -5576,35 +5576,36 @@ struct scatter_update_test_params {
     cldnn::scatter_update::scatter_update_axis axis;
     data_types data_type;
     format input_format;
+    format updates_format;
     data_types default_type;
     format default_format;
     size_t expected_fused_primitives;
     size_t expected_not_fused_primitives;
 };
 
-#define CASE_SCATTER_UPDATE_FP32_1 {2, 4, 1, 1}, {2, 1, 1, 1}, {2, 4, 1, 1}, cldnn::scatter_update::scatter_update_axis::along_b, data_types::f32, format::bfyx, data_types::f32, format::bfyx
-#define CASE_SCATTER_UPDATE_FP32_2 {8, 1, 1, 1}, {4, 1, 1, 1}, {4, 1, 1, 1}, cldnn::scatter_update::scatter_update_axis::along_b, data_types::f32, format::bfyx, data_types::f32, format::bfyx
-#define CASE_SCATTER_UPDATE_FP32_3 {4, 3, 1, 1}, {2, 2, 1, 1}, {2, 2, 1, 3}, cldnn::scatter_update::scatter_update_axis::along_b, data_types::f32, format::bfyx, data_types::f32, format::bfyx
-#define CASE_SCATTER_UPDATE_FP32_4 {2, 5, 1, 2}, {2, 2, 1, 1}, {2, 2, 2, 2}, cldnn::scatter_update::scatter_update_axis::along_f, data_types::f32, format::bfyx, data_types::f32, format::bfyx
-#define CASE_SCATTER_UPDATE_FP32_5 {2, 2, 1, 4}, {2, 2, 1, 1}, {2, 2, 2, 2}, cldnn::scatter_update::scatter_update_axis::along_y, data_types::f32, format::bfyx, data_types::f32, format::bfyx
+#define CASE_SCATTER_UPDATE_FP32_1 {2, 4, 1, 1}, {2, 1, 1, 1}, {2, 4, 1, 1}, cldnn::scatter_update::scatter_update_axis::along_b, data_types::f32,    format::bfyx, format::bfyx, data_types::f32, format::bfyx
+#define CASE_SCATTER_UPDATE_FP32_2 {8, 1, 1, 1}, {4, 1, 1, 1}, {4, 1, 1, 1}, cldnn::scatter_update::scatter_update_axis::along_b, data_types::f32,    format::bfyx, format::bfyx, data_types::f32, format::bfyx
+#define CASE_SCATTER_UPDATE_FP32_3 {4, 3, 1, 1}, {2, 2, 1, 1}, {2, 2, 1, 1, 3}, cldnn::scatter_update::scatter_update_axis::along_b, data_types::f32, format::bfyx, format::bfzyx, data_types::f32, format::bfyx
+#define CASE_SCATTER_UPDATE_FP32_4 {2, 5, 1, 2}, {2, 2, 1, 1}, {2, 2, 2, 1, 2}, cldnn::scatter_update::scatter_update_axis::along_f, data_types::f32, format::bfyx, format::bfzyx, data_types::f32, format::bfyx
+#define CASE_SCATTER_UPDATE_FP32_5 {2, 2, 1, 4}, {2, 2, 1, 1}, {2, 2, 4, 2, 2}, cldnn::scatter_update::scatter_update_axis::along_y, data_types::f32, format::bfyx, format::bfzyx, data_types::f32, format::bfyx
 
-#define CASE_SCATTER_UPDATE_FP16_1 {2, 4, 1, 1}, {1, 1, 1, 2}, {2, 1, 2, 1}, cldnn::scatter_update::scatter_update_axis::along_f, data_types::f16, format::bfyx, data_types::f16, format::bfyx
-#define CASE_SCATTER_UPDATE_FP16_2 {8, 2, 1, 20}, {2, 3, 1, 1}, {2, 3, 20, 2}, cldnn::scatter_update::scatter_update_axis::along_b, data_types::f16, format::bfyx, data_types::f16, format::bfyx
-#define CASE_SCATTER_UPDATE_FP16_3 {2, 2, 4, 1}, {3, 1, 1, 1}, {2, 2, 3, 1}, cldnn::scatter_update::scatter_update_axis::along_x, data_types::f16, format::bfyx, data_types::f16, format::bfyx
-#define CASE_SCATTER_UPDATE_FP16_4 {6, 2, 1, 1}, {1, 2, 1, 2}, {1, 2, 2, 2}, cldnn::scatter_update::scatter_update_axis::along_b, data_types::f16, format::bfyx, data_types::f16, format::bfyx
-#define CASE_SCATTER_UPDATE_FP16_5 {3, 1, 1, 5}, {2, 2, 1, 1}, {3, 1, 2, 2}, cldnn::scatter_update::scatter_update_axis::along_y, data_types::f16, format::bfyx, data_types::f16, format::bfyx
+#define CASE_SCATTER_UPDATE_FP16_1 {2, 4, 1, 1}, {1, 1, 1, 2}, {2, 1, 1, 1, 1, 2}, cldnn::scatter_update::scatter_update_axis::along_f, data_types::f16, format::bfyx, format::bfwzyx, data_types::f16, format::bfyx
+#define CASE_SCATTER_UPDATE_FP16_2 {8, 2, 1, 20}, {2, 3, 1, 1}, {2, 3, 1, 20, 2}, cldnn::scatter_update::scatter_update_axis::along_b, data_types::f16, format::bfyx, format::bfzyx, data_types::f16, format::bfyx
+#define CASE_SCATTER_UPDATE_FP16_3 {2, 2, 4, 1}, {3, 1, 1, 1}, {2, 2, 3, 1}, cldnn::scatter_update::scatter_update_axis::along_x, data_types::f16, format::bfyx, format::bfyx, data_types::f16, format::bfyx
+#define CASE_SCATTER_UPDATE_FP16_4 {6, 2, 1, 1}, {1, 2, 1, 2}, {1, 2, 1, 1, 2, 2}, cldnn::scatter_update::scatter_update_axis::along_b, data_types::f16, format::bfyx, format::bfwzyx, data_types::f16, format::bfyx
+#define CASE_SCATTER_UPDATE_FP16_5 {3, 1, 1, 5}, {2, 2, 1, 1}, {3, 1, 1, 2, 2}, cldnn::scatter_update::scatter_update_axis::along_y, data_types::f16, format::bfyx, format::bfzyx, data_types::f16, format::bfyx
 
-#define CASE_SCATTER_UPDATE_5D_FP32_1 {4, 3, 1, 4, 1}, {4, 1, 1, 1}, {4, 3, 1, 4, 1}, cldnn::scatter_update::scatter_update_axis::along_b, data_types::f32, format::bfzyx, data_types::f32, format::bfzyx
-#define CASE_SCATTER_UPDATE_5D_FP32_2 {2, 3, 2, 2, 2}, {2, 1, 1, 1}, {2, 2, 2, 2, 2}, cldnn::scatter_update::scatter_update_axis::along_f, data_types::f32, format::bfzyx, data_types::f32, format::bfzyx
-#define CASE_SCATTER_UPDATE_5D_FP32_3 {5, 3, 2, 4, 2}, {3, 1, 1, 1}, {5, 3, 2, 3, 2}, cldnn::scatter_update::scatter_update_axis::along_y, data_types::f32, format::bfzyx, data_types::f32, format::bfzyx
-#define CASE_SCATTER_UPDATE_5D_FP32_4 {2, 3, 1, 4, 4}, {2, 1, 1, 1}, {2, 3, 1, 4, 2}, cldnn::scatter_update::scatter_update_axis::along_z, data_types::f32, format::bfzyx, data_types::f32, format::bfzyx
-#define CASE_SCATTER_UPDATE_5D_FP32_5 {3, 1, 5, 2, 1}, {2, 1, 1, 1}, {3, 1, 2, 2, 1}, cldnn::scatter_update::scatter_update_axis::along_x, data_types::f32, format::bfzyx, data_types::f32, format::bfzyx
+#define CASE_SCATTER_UPDATE_5D_FP32_1 {4, 3, 1, 4, 1}, {4, 1, 1, 1}, {4, 3, 1, 4, 1}, cldnn::scatter_update::scatter_update_axis::along_b, data_types::f32, format::bfzyx, format::bfzyx, data_types::f32, format::bfzyx
+#define CASE_SCATTER_UPDATE_5D_FP32_2 {2, 3, 2, 2, 2}, {2, 1, 1, 1}, {2, 2, 2, 2, 2}, cldnn::scatter_update::scatter_update_axis::along_f, data_types::f32, format::bfzyx, format::bfzyx, data_types::f32, format::bfzyx
+#define CASE_SCATTER_UPDATE_5D_FP32_3 {5, 3, 2, 4, 2}, {3, 1, 1, 1}, {5, 3, 2, 3, 2}, cldnn::scatter_update::scatter_update_axis::along_y, data_types::f32, format::bfzyx, format::bfzyx, data_types::f32, format::bfzyx
+#define CASE_SCATTER_UPDATE_5D_FP32_4 {2, 3, 1, 4, 4}, {2, 1, 1, 1}, {2, 3, 1, 4, 2}, cldnn::scatter_update::scatter_update_axis::along_z, data_types::f32, format::bfzyx, format::bfzyx, data_types::f32, format::bfzyx
+#define CASE_SCATTER_UPDATE_5D_FP32_5 {3, 1, 5, 2, 1}, {2, 1, 1, 1}, {3, 1, 2, 2, 1}, cldnn::scatter_update::scatter_update_axis::along_x, data_types::f32, format::bfzyx, format::bfzyx, data_types::f32, format::bfzyx
 
-#define CASE_SCATTER_UPDATE_5D_FP16_1 {3, 2, 1, 2, 1}, {2, 1, 1, 1}, {2, 2, 2, 2, 1}, cldnn::scatter_update::scatter_update_axis::along_b, data_types::f16, format::bfzyx, data_types::f16, format::bfzyx
-#define CASE_SCATTER_UPDATE_5D_FP16_2 {1, 3, 1, 2, 1}, {2, 1, 1, 1}, {1, 2, 1, 2, 1}, cldnn::scatter_update::scatter_update_axis::along_f, data_types::f16, format::bfzyx, data_types::f16, format::bfzyx
-#define CASE_SCATTER_UPDATE_5D_FP16_3 {2, 3, 1, 3, 3}, {1, 2, 1, 1}, {2, 3, 1, 2, 3}, cldnn::scatter_update::scatter_update_axis::along_y, data_types::f16, format::bfzyx, data_types::f16, format::bfzyx
-#define CASE_SCATTER_UPDATE_5D_FP16_4 {3, 2, 2, 2, 2}, {2, 1, 1, 1}, {3, 2, 2, 2, 2}, cldnn::scatter_update::scatter_update_axis::along_z, data_types::f16, format::bfzyx, data_types::f16, format::bfzyx
-#define CASE_SCATTER_UPDATE_5D_FP16_5 {1, 1, 4, 1, 1}, {3, 1, 1, 1}, {1, 1, 3, 1, 1}, cldnn::scatter_update::scatter_update_axis::along_x, data_types::f16, format::bfzyx, data_types::f16, format::bfzyx
+#define CASE_SCATTER_UPDATE_5D_FP16_1 {3, 2, 1, 2, 1}, {2, 1, 1, 1}, {2, 2, 2, 2, 1}, cldnn::scatter_update::scatter_update_axis::along_b, data_types::f16, format::bfzyx, format::bfzyx,  data_types::f16, format::bfzyx
+#define CASE_SCATTER_UPDATE_5D_FP16_2 {1, 3, 1, 2, 1}, {2, 1, 1, 1}, {1, 2, 1, 2, 1}, cldnn::scatter_update::scatter_update_axis::along_f, data_types::f16, format::bfzyx, format::bfzyx, data_types::f16, format::bfzyx
+#define CASE_SCATTER_UPDATE_5D_FP16_3 {2, 3, 1, 3, 3}, {1, 2, 1, 1}, {2, 3, 1, 1, 2, 3}, cldnn::scatter_update::scatter_update_axis::along_y, data_types::f16, format::bfzyx, format::bfwzyx, data_types::f16, format::bfzyx
+#define CASE_SCATTER_UPDATE_5D_FP16_4 {3, 2, 2, 2, 2}, {2, 1, 1, 1}, {3, 2, 2, 2, 2}, cldnn::scatter_update::scatter_update_axis::along_z, data_types::f16, format::bfzyx, format::bfzyx, data_types::f16, format::bfzyx
+#define CASE_SCATTER_UPDATE_5D_FP16_5 {1, 1, 4, 1, 1}, {3, 1, 1, 1}, {1, 1, 3, 1, 1}, cldnn::scatter_update::scatter_update_axis::along_x, data_types::f16, format::bfzyx, format::bfzyx, data_types::f16, format::bfzyx
 
 class ScatterUpdatePrimitiveFusingTest : public ::BaseFusingTest<scatter_update_test_params> {
 public:
@@ -5626,7 +5627,7 @@ public:
     }
 
     layout get_updates_layout(scatter_update_test_params& p) {
-        return layout{ p.data_type, p.input_format, p.updates_shape };
+        return layout{ p.data_type, p.updates_format, p.updates_shape };
     }
 
     size_t get_axis_dim(scatter_update_test_params& p) {
@@ -5742,7 +5743,6 @@ INSTANTIATE_TEST_CASE_P(fusings_gpu, scatter_update_scale_activation,
                         scatter_update_test_params{ CASE_SCATTER_UPDATE_5D_FP16_4, 2, 4 },
                         scatter_update_test_params{ CASE_SCATTER_UPDATE_5D_FP16_5, 2, 4 },
 }), );
-
 /* ------------------------------------------------------------------------------------------------------------ */
 /* ---------------------------------------- PERMUTE FUSE cases -------------------------------------------------- */
 /* ------------------------------------------------------------------------------------------------------------ */

--- a/inference-engine/thirdparty/clDNN/tests/test_cases/scatter_update_gpu_test.cpp
+++ b/inference-engine/thirdparty/clDNN/tests/test_cases/scatter_update_gpu_test.cpp
@@ -261,7 +261,7 @@ TEST(scatter_update_gpu_fp16, d4311_axisB) {
     } 
 }
 
-TEST(scatter_update_gpu_fp16, d2521_axisF) {
+TEST(scatter_update_gpu_fp16, d2521_axisF_taylor3) {
     //  Dictionary : 2x5x2x1
     //  Indexes : 2x2x1x1
     //  Updates : 2x2x2x2
@@ -316,7 +316,7 @@ TEST(scatter_update_gpu_fp16, d2521_axisF) {
 
     auto input1 = memory::allocate(engine, { data_types::f16, format::bfyx, { 2, 5, 1, 2 } }); // Dictionary
     auto input2 = memory::allocate(engine, { data_types::f32, format::bfyx, { 2, 2, 1, 1 } }); // Indexes
-    auto input3 = memory::allocate(engine, { data_types::f16, format::bfyx, { 2, 2, 2, 2 } }); // Updates
+    auto input3 = memory::allocate(engine, { data_types::f16, format::bfzyx, { 2, 2, 1, 2, 2 } }); // Updates
     auto axis = cldnn::scatter_update::scatter_update_axis::along_f;
 
     set_values(input1, {
@@ -488,10 +488,10 @@ TEST(scatter_update_gpu_fp16, d2241_axisY) {
     }
 }
 
-TEST(scatter_update_gpu_fp16, d8x2x20x1_axisB) {
+TEST(scatter_update_gpu_fp16, d8x2x20x1_axisB_taylor2) {
     //  Dictionary : 8x2x20x1
     //  Indexes : 2x3x1x1
-    //  Updates : 2x3x2x20
+    //  Updates : 2x3x2x20x1
     //  Axis : 0
     //  Output : 8x2x20x1
     //  Input values in fp16
@@ -500,7 +500,7 @@ TEST(scatter_update_gpu_fp16, d8x2x20x1_axisB) {
 
     auto input1 = memory::allocate(engine, { data_types::f16, format::bfyx, { 8, 2, 1, 20 } }); // Dictionary
     auto input2 = memory::allocate(engine, { data_types::f32, format::bfyx, { 2, 3, 1, 1 } });  // Indexes
-    auto input3 = memory::allocate(engine, { data_types::f16, format::bfyx, { 2, 3, 20, 2 } }); // Updates
+    auto input3 = memory::allocate(engine, { data_types::f16, format::bfzyx, { 2, 3, 1, 20, 2 } }); // Updates
     auto axis = cldnn::scatter_update::scatter_update_axis::along_b;
 
     set_values(input1, {
@@ -693,10 +693,10 @@ TEST(scatter_update_gpu_fp32, d2214_axisX) {
     }
 }
 
-TEST(scatter_update_gpu_int32, d6211_axisB) {
-    //  Dictionary : 6x2x1x1
-    //  Indexes : 1x2x2x1
-    //  Updates : 1x2x2x2
+TEST(scatter_update_gpu_int32, d6211_axisB_taylor4) {
+    //  Dictionary : (6)x2x1x1
+    //  Indexes : (1x2x2)x1
+    //  Updates : (1x2x2)x2x1x1
     //  Axis : 0
     //  Output : 6x2x1x1
     //  Input values in int32
@@ -732,7 +732,8 @@ TEST(scatter_update_gpu_int32, d6211_axisB) {
 
     auto input1 = memory::allocate(engine, { data_types::i32, format::bfyx, { 6, 2, 1, 1 } }); // Dictionary
     auto input2 = memory::allocate(engine, { data_types::i32, format::bfyx, { 1, 2, 1, 2 } }); // Indexes
-    auto input3 = memory::allocate(engine, { data_types::i32, format::bfyx, { 1, 2, 2, 2 } }); // Updates
+//    auto input3 = memory::allocate(engine, { data_types::i32, format::bfwzyx, { 1, 2, 1, 1, 2, 2 } }); // Updates bfxyzw
+    auto input3 = memory::allocate(engine, { data_types::i32, format::bfyx, { 1, 2, 2, 2 } }); // Updates bfxyzw
     auto axis = cldnn::scatter_update::scatter_update_axis::along_b;
 
     set_values(input1, {
@@ -789,10 +790,10 @@ TEST(scatter_update_gpu_int32, d6211_axisB) {
     }
 }
 
-TEST(scatter_update_gpu_int32, d3151_axisY) {
+TEST(scatter_update_gpu_int32, d3151_axisY_taylor1) {
     //  Dictionary : 3x1x5x1
     //  Indexes : 2x2x1x1
-    //  Updates : 3x1x2x2
+    //  Updates : 3x1x2x2x1
     //  Axis : 2
     //  Output : 3x1x5x1
     //  Input values in int32
@@ -823,15 +824,15 @@ TEST(scatter_update_gpu_int32, d3151_axisY) {
 
     engine engine;
 
-    auto input1 = memory::allocate(engine, { data_types::i32, format::bfyx, { 3, 1, 1, 5 } }); // Dictionary
+    auto input1 = memory::allocate(engine, { data_types::i32, format::bfyx, { 3, 1, 1/*x*/, 5/*y*/ } }); // Dictionary
     auto input2 = memory::allocate(engine, { data_types::i32, format::bfyx, { 2, 2, 1, 1 } }); // Indexes
-    auto input3 = memory::allocate(engine, { data_types::i32, format::bfyx, { 3, 1, 2, 2 } }); // Updates
+    auto input3 = memory::allocate(engine, { data_types::i32, format::bfzyx, { 3, 1, 1/*x*/, 2/*y*/, 2/*z*/ } }); // Updates
     auto axis = cldnn::scatter_update::scatter_update_axis::along_y;
 
     set_values(input1, {
-        0, 1, 2, 3, 4,
-        5, 6, 7, 8, 9,
-        10, 11, 12, 13, 14
+        1, 2, 3, 4, 5,
+        6, 7, 8, 9, 10,
+        11, 12, 13, 14,
     });
 
     set_values(input2, {
@@ -855,31 +856,31 @@ TEST(scatter_update_gpu_int32, d3151_axisY) {
     topology.add(
         scatter_update("scatter_update", "InputDictionary", "InputText", "InputUpdates", axis)
     );
-    
-    network network(engine, topology); 
-    
+
+    network network(engine, topology);
+
     network.set_input_data("InputDictionary", input1);
     network.set_input_data("InputText", input2);
     network.set_input_data("InputUpdates", input3);
-    
+
     auto outputs = network.execute();
 
     auto output = outputs.at("scatter_update").get_memory();
     auto output_ptr = output.pointer<int>();
 
     std::vector<int> expected_results = {
-        30, 1, 20, 200, 40,
-        70, 6, 60, 50, 80,
-        110, 11, 100, 90, 120
+        30, 2, 20, 200, 40,
+        70, 7, 60, 50, 80,
+        110, 12, 100, 90, 120
     };
-    
+
     for (size_t i = 0; i < expected_results.size(); ++i) {
         EXPECT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
 TEST(scatter_update_gpu_fp32, d24111_axisF_bfzyx) {
-    //  Dictionary : 2x4x1x1
+    //  Dictionary : 2x'4'x1x1
     //  Indexes : 1x1x1x2
     //  Updates : 2x1x1x1x2
     //  Axis : 1
@@ -951,7 +952,7 @@ TEST(scatter_update_gpu_fp32, d24111_axisF_bfzyx) {
     }
 }
 
-TEST(scatter_update_gpu_int32, d121251_bfwzyx_axisB) {
+TEST(scatter_update_gpu_int32, d121251_bfwzyx_axisB_taylor6) {
     //  Dictionary : 1x2x1x2x5x1
     //  Indexes : 1x2x2x1
     //  Updates : 1x2x1x2x2x2

--- a/inference-engine/thirdparty/clDNN/tests/test_cases/scatter_update_gpu_test.cpp
+++ b/inference-engine/thirdparty/clDNN/tests/test_cases/scatter_update_gpu_test.cpp
@@ -175,7 +175,7 @@ TEST(scatter_update_gpu_fp32, d8111_axisB) {
 TEST(scatter_update_gpu_fp16, d4311_axisB) {
     //  Dictionary : 4x3x1x1
     //  Indexes : 2x2x1x1
-    //  Updates : 2x2x3x1
+    //  Updates : 2x2x3x1x1
     //  Axis : 0
     //  Output : 4x3x1x1
     //  Input values in fp16
@@ -207,7 +207,7 @@ TEST(scatter_update_gpu_fp16, d4311_axisB) {
 
     auto input1 = memory::allocate(engine, { data_types::f16, format::bfyx, { 4, 3, 1, 1 } }); // Dictionary
     auto input2 = memory::allocate(engine, { data_types::f32, format::bfyx, { 2, 2, 1, 1 } }); // Indexes
-    auto input3 = memory::allocate(engine, { data_types::f16, format::bfyx, { 2, 2, 1, 3 } }); // Updates
+    auto input3 = memory::allocate(engine, { data_types::f16, format::bfzyx, { 2, 2, 1, 1, 3 } }); // Updates
     auto axis = cldnn::scatter_update::scatter_update_axis::along_b;
 
     set_values(input1, {
@@ -261,10 +261,10 @@ TEST(scatter_update_gpu_fp16, d4311_axisB) {
     } 
 }
 
-TEST(scatter_update_gpu_fp16, d2521_axisF_taylor3) {
+TEST(scatter_update_gpu_fp16, d2521_axisF) {
     //  Dictionary : 2x5x2x1
     //  Indexes : 2x2x1x1
-    //  Updates : 2x2x2x2
+    //  Updates : 2x2x2x2x1
     //  Axis : 1
     //  Output : 2x5x2x1
     //  Input values in fp16
@@ -391,7 +391,7 @@ TEST(scatter_update_gpu_fp16, d2521_axisF_taylor3) {
 TEST(scatter_update_gpu_fp16, d2241_axisY) {
     //  Dictionary : 2x2x4x1
     //  Indexes : 2x2x1x1
-    //  Updates : 2x2x2x2
+    //  Updates : 2x2x2x2x1
     //  Axis : 2
     //  Output : 2x2x4x1
     //  Input values in fp16
@@ -429,7 +429,7 @@ TEST(scatter_update_gpu_fp16, d2241_axisY) {
 
     auto input1 = memory::allocate(engine, { data_types::f16, format::bfyx, { 2, 2, 1, 4 } }); // Dictionary
     auto input2 = memory::allocate(engine, { data_types::f32, format::bfyx, { 2, 2, 1, 1 } }); // Indexes
-    auto input3 = memory::allocate(engine, { data_types::f16, format::bfyx, { 2, 2, 2, 2 } }); // Updates
+    auto input3 = memory::allocate(engine, { data_types::f16, format::bfzyx, { 2, 2, 1, 2, 2 } }); // Updates
     auto axis = cldnn::scatter_update::scatter_update_axis::along_y;
 
     set_values(input1, {
@@ -488,7 +488,7 @@ TEST(scatter_update_gpu_fp16, d2241_axisY) {
     }
 }
 
-TEST(scatter_update_gpu_fp16, d8x2x20x1_axisB_taylor2) {
+TEST(scatter_update_gpu_fp16, d8x2x20x1_axisB) {
     //  Dictionary : 8x2x20x1
     //  Indexes : 2x3x1x1
     //  Updates : 2x3x2x20x1
@@ -693,10 +693,10 @@ TEST(scatter_update_gpu_fp32, d2214_axisX) {
     }
 }
 
-TEST(scatter_update_gpu_int32, d6211_axisB_taylor4) {
-    //  Dictionary : (6)x2x1x1
-    //  Indexes : (1x2x2)x1
-    //  Updates : (1x2x2)x2x1x1
+TEST(scatter_update_gpu_int32, d6211_axisB) {
+    //  Dictionary : 6x2x1x1
+    //  Indexes : 1x2x2x1
+    //  Updates : 1x2x2x2x1x1
     //  Axis : 0
     //  Output : 6x2x1x1
     //  Input values in int32
@@ -732,8 +732,7 @@ TEST(scatter_update_gpu_int32, d6211_axisB_taylor4) {
 
     auto input1 = memory::allocate(engine, { data_types::i32, format::bfyx, { 6, 2, 1, 1 } }); // Dictionary
     auto input2 = memory::allocate(engine, { data_types::i32, format::bfyx, { 1, 2, 1, 2 } }); // Indexes
-//    auto input3 = memory::allocate(engine, { data_types::i32, format::bfwzyx, { 1, 2, 1, 1, 2, 2 } }); // Updates bfxyzw
-    auto input3 = memory::allocate(engine, { data_types::i32, format::bfyx, { 1, 2, 2, 2 } }); // Updates bfxyzw
+    auto input3 = memory::allocate(engine, { data_types::i32, format::bfwzyx, { 1, 2, 1, 1, 2, 2 } }); // Updates
     auto axis = cldnn::scatter_update::scatter_update_axis::along_b;
 
     set_values(input1, {
@@ -790,7 +789,7 @@ TEST(scatter_update_gpu_int32, d6211_axisB_taylor4) {
     }
 }
 
-TEST(scatter_update_gpu_int32, d3151_axisY_taylor1) {
+TEST(scatter_update_gpu_int32, d3151_axisY) {
     //  Dictionary : 3x1x5x1
     //  Indexes : 2x2x1x1
     //  Updates : 3x1x2x2x1
@@ -824,15 +823,15 @@ TEST(scatter_update_gpu_int32, d3151_axisY_taylor1) {
 
     engine engine;
 
-    auto input1 = memory::allocate(engine, { data_types::i32, format::bfyx, { 3, 1, 1/*x*/, 5/*y*/ } }); // Dictionary
+    auto input1 = memory::allocate(engine, { data_types::i32, format::bfyx, { 3, 1, 1, 5 } }); // Dictionary
     auto input2 = memory::allocate(engine, { data_types::i32, format::bfyx, { 2, 2, 1, 1 } }); // Indexes
-    auto input3 = memory::allocate(engine, { data_types::i32, format::bfzyx, { 3, 1, 1/*x*/, 2/*y*/, 2/*z*/ } }); // Updates
+    auto input3 = memory::allocate(engine, { data_types::i32, format::bfzyx, { 3, 1, 1, 2, 2} }); // Updates
     auto axis = cldnn::scatter_update::scatter_update_axis::along_y;
 
     set_values(input1, {
-        1, 2, 3, 4, 5,
-        6, 7, 8, 9, 10,
-        11, 12, 13, 14,
+        0, 1, 2, 3, 4,
+        5, 6, 7, 8, 9,
+        10, 11, 12, 13, 14
     });
 
     set_values(input2, {
@@ -856,33 +855,33 @@ TEST(scatter_update_gpu_int32, d3151_axisY_taylor1) {
     topology.add(
         scatter_update("scatter_update", "InputDictionary", "InputText", "InputUpdates", axis)
     );
-
-    network network(engine, topology);
-
+    
+    network network(engine, topology); 
+    
     network.set_input_data("InputDictionary", input1);
     network.set_input_data("InputText", input2);
     network.set_input_data("InputUpdates", input3);
-
+    
     auto outputs = network.execute();
 
     auto output = outputs.at("scatter_update").get_memory();
     auto output_ptr = output.pointer<int>();
 
     std::vector<int> expected_results = {
-        30, 2, 20, 200, 40,
-        70, 7, 60, 50, 80,
-        110, 12, 100, 90, 120
+        30, 1, 20, 200, 40,
+        70, 6, 60, 50, 80,
+        110, 11, 100, 90, 120
     };
-
+    
     for (size_t i = 0; i < expected_results.size(); ++i) {
         EXPECT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
 TEST(scatter_update_gpu_fp32, d24111_axisF_bfzyx) {
-    //  Dictionary : 2x'4'x1x1
-    //  Indexes : 1x1x1x2
-    //  Updates : 2x1x1x1x2
+    //  Dictionary : 2x4x1x1
+    //  Indexes : 1x1x2x1
+    //  Updates : 2x1x1x2x1x1
     //  Axis : 1
     //  Output : 2x4x1x1x1
     //  Input values in fp32
@@ -905,8 +904,8 @@ TEST(scatter_update_gpu_fp32, d24111_axisF_bfzyx) {
     engine engine;
 
     auto input1 = memory::allocate(engine, { data_types::f32, format::bfyx, { 2, 4, 1, 1 } });      // Dictionary
-    auto input2 = memory::allocate(engine, { data_types::f32, format::bfyx, { 1, 1, 2, 1 } });      // Indexes
-    auto input3 = memory::allocate(engine, { data_types::f32, format::bfzyx, { 2, 1, 1, 2, 1 } });  // Updates
+    auto input2 = memory::allocate(engine, { data_types::f32, format::bfyx, { 1, 1, 1, 2 } });      // Indexes
+    auto input3 = memory::allocate(engine, { data_types::f32, format::bfwzyx, { 2, 1, 1, 1, 2 } });  // Updates
     auto axis = cldnn::scatter_update::scatter_update_axis::along_f;
 
     set_values(input1, {
@@ -952,12 +951,12 @@ TEST(scatter_update_gpu_fp32, d24111_axisF_bfzyx) {
     }
 }
 
-TEST(scatter_update_gpu_int32, d121251_bfwzyx_axisB_taylor6) {
-    //  Dictionary : 1x2x1x2x5x1
-    //  Indexes : 1x2x2x1
+TEST(scatter_update_gpu_int32, d121251_bfwzyx_axisB) {
+    //  Dictionary : 1x2x1x2x5
+    //  Indexes : 2x2
     //  Updates : 1x2x1x2x2x2
     //  Axis : 4
-    //  Output : 1x2x1x2x5x1
+    //  Output : 1x2x1x2x5
     //  Input values in int32
 
     //  Indexes:
@@ -991,10 +990,10 @@ TEST(scatter_update_gpu_int32, d121251_bfwzyx_axisB_taylor6) {
 
     engine engine;
 
-    auto input1 = memory::allocate(engine, { data_types::i32, format::bfwzyx, tensor{ batch(1), feature(2), spatial(1, 5, 2, 1) }}); // Dictionary
+    auto input1 = memory::allocate(engine, { data_types::i32, format::bfzyx, tensor{ batch(1), feature(2), spatial(5, 2, 1, 1) }}); // Dictionary
     auto input2 = memory::allocate(engine, { data_types::i32, format::bfyx, { 2, 2, 1, 1 } });                                       // Indexes
     auto input3 = memory::allocate(engine, { data_types::i32, format::bfwzyx, tensor{ batch(1), feature(2), spatial(2, 2, 2, 1) }}); // Updates
-    auto axis = cldnn::scatter_update::scatter_update_axis::along_y;
+    auto axis = cldnn::scatter_update::scatter_update_axis::along_x;
 
     set_values(input1, {
         0, 1, 2, 3, 4,
@@ -1050,10 +1049,10 @@ TEST(scatter_update_gpu_int32, d121251_bfwzyx_axisB_taylor6) {
     }
 }
 
-TEST(scatter_update_gpu_fp32, d21511_bfzyx_axisX) {
-    //  Dictionary : 2x1x5x1x1
+TEST(scatter_update_gpu_fp32, d2151_bfzyx_axisX) {
+    //  Dictionary : 2x1x5x1
     //  Indexes : 2x1x2x1
-    //  Updates : 2x1x2x1x2
+    //  Updates : 2x1x2x1x2x1
     //  Axis : 2
     //  Output : 2x1x5x1x1
     //  Input values in fp32
@@ -1079,10 +1078,10 @@ TEST(scatter_update_gpu_fp32, d21511_bfzyx_axisX) {
 
     engine engine;
 
-    auto input1 = memory::allocate(engine, { data_types::f32, format::bfzyx, { 2, 1, 1, 1, 5 } }); // Dictionary
-    auto input2 = memory::allocate(engine, { data_types::f32, format::bfyx, { 2, 2, 1, 1 } });     // Indices
-    auto input3 = memory::allocate(engine, { data_types::f32, format::bfzyx, { 2, 1, 1, 2, 2 } }); // Updates
-    auto axis = cldnn::scatter_update::scatter_update_axis::along_z;
+    auto input1 = memory::allocate(engine, { data_types::f32, format::bfyx, { 2, 1, 1, 5 } }); // Dictionary
+    auto input2 = memory::allocate(engine, { data_types::f32, format::bfyx, { 2, 1, 1, 2 } });     // Indices
+    auto input3 = memory::allocate(engine, { data_types::f32, format::bfwzyx, { 2, 1, 1, 2, 1, 2 } }); // Updates
+    auto axis = cldnn::scatter_update::scatter_update_axis::along_y;
 
     set_values(input1, {
         0.f, 1.f, 2.f, 3.f, 4.f,


### PR DESCRIPTION
Previously scatter update op was failing due to the mis-aligned implementation b/w the kernel data generation and kernel implementation. Also, the reorder_input pass was reordering the update tensor for scatter operation in an unexpected way.

In this PR:
- Added hot-fix on reorder-input pass not to reorder scatter operation 
- Re-implemented scatter update's kernel
- Fixed cldnn unit test according to the original definition. 
- Register ScatterUpdate op to primitive list 
- Enable functional test for ScatterUpdate slayer 

