### PR TITLE
Deformable convolution specification review

### DIFF
--- a/docs/ops/convolution/DeformableConvolution_1.md
+++ b/docs/ops/convolution/DeformableConvolution_1.md
@@ -4,22 +4,24 @@
 
 **Category**: Convolution
 
-**Detailed description**: [Reference](https://arxiv.org/abs/1703.06211)
+**Short description**: Computes 1D, 2D or 3D deformable convolution of input and kernel tensors.
 
-**Attributes**
+**Detailed description**: *Deformable Convolution* is similar to regular *Convolution* but its receptive field is deformed because of additional spatial offsets used during input sampling. More thorough explanation can be found in [Deformable Convolutions Demystified](https://towardsdatascience.com/deformable-convolutions-demystified-2a77498699e8) and [Deformable Convolutional Networks](https://arxiv.org/abs/1703.06211).
+
+**Attributes**:
 
 * *strides*
 
-  * **Description**: *strides* is a distance (in pixels) to slide the filter on the feature map over the (z, y, x) axes for 3D convolutions and (y, x) axes for 2D convolutions. For example, *strides* equal *4,2,1* means sliding the filter 4 pixel at a time over depth dimension, 2 over height dimension and 1 over width dimension.
-  * **Range of values**: integer values starting from 0
+  * **Description**: *strides* is a distance (in pixels) to slide the filter on the feature map over the `(z, y, x)` axes for 3D convolutions and `(y, x)` axes for 2D convolutions. For example, *strides* equal `4,2,1` means sliding the filter 4 pixel at a time over depth dimension, 2 over height dimension and 1 over width dimension.
+  * **Range of values**: integer values starting from `0`
   * **Type**: int[]
   * **Default value**: None
   * **Required**: *yes*
 
 * *pads_begin*
 
-  * **Description**: *pads_begin* is a number of pixels to add to the beginning along each axis. For example, *pads_begin* equal *1,2* means adding 1 pixel to the top of the input and 2 to the left of the input.
-  * **Range of values**: integer values starting from 0
+  * **Description**: *pads_begin* is a number of pixels to add to the beginning along each axis. For example, *pads_begin* equal `1,2` means adding 1 pixel to the top of the input and 2 to the left of the input.
+  * **Range of values**: integer values starting from `0`
   * **Type**: int[]
   * **Default value**: None
   * **Required**: *yes*
@@ -27,8 +29,8 @@
 
 * *pads_end*
 
-  * **Description**: *pads_end* is a number of pixels to add to the ending along each axis. For example, *pads_end* equal *1,2* means adding 1 pixel to the bottom of the input and 2 to the right of the input.
-  * **Range of values**: integer values starting from 0
+  * **Description**: *pads_end* is a number of pixels to add to the ending along each axis. For example, *pads_end* equal `1,2` means adding 1 pixel to the bottom of the input and 2 to the right of the input.
+  * **Range of values**: integer values starting from `0`
   * **Type**: int[]
   * **Default value**: None
   * **Required**: *yes*
@@ -36,8 +38,8 @@
 
 * *dilations*
 
-  * **Description**: *dilations* denotes the distance in width and height between elements (weights) in the filter. For example, *dilation* equal *1,1* means that all the elements in the filter are neighbors, so it is the same as for the usual convolution. *dilation* equal *2,2* means that all the elements in the filter are matched not to adjacent elements in the input matrix, but to those that are adjacent with distance 1.
-  * **Range of values**: integer value starting from 0
+  * **Description**: *dilations* denotes the distance in width and height between elements (weights) in the filter. For example, *dilation* equal `1,1` means that all the elements in the filter are neighbors, so it is the same as for the usual convolution. *dilation* equal `2,2` means that all the elements in the filter are matched not to adjacent elements in the input matrix, but to those that are adjacent with distance 1.
+  * **Range of values**: integer value starting from `0`
   * **Type**: int[]
   * **Default value**: None
   * **Required**: *yes*
@@ -45,44 +47,137 @@
 * *auto_pad*
 
   * **Description**: *auto_pad* how the padding is calculated. Possible values:
-    * *explicit*: use explicit padding values from `pads_begin` and `pads_end`.
-    * *same_upper (same_lower)* the input is padded to match the output size. In case of odd padding value an extra padding is added at the end (at the beginning).
+    * *explicit* - use explicit padding values from *pads_begin* and *pads_end*.
+    * *same_upper* - the input is padded to match the output size. In case of odd padding value an extra padding is added at the end.
+    * *same_lower* - the input is padded to match the output size. In case of odd padding value an extra padding is added at the beginning.
     * *valid* - do not use padding.
   * **Type**: string
-  * **Default value**: None
+  * **Default value**: explicit
   * **Required**: *no*
   * **Note**: *pads_begin* and *pads_end* attributes are ignored when *auto_pad* is specified.
+
 
 * *group*
 
   * **Description**: *group* is the number of groups which *output* and *input* should be split into. For example, *group* equal to 1 means that all filters are applied to the whole input (usual convolution), *group* equal to 2 means that both *input* and *output* channels are separated into two groups and the *i-th output* group is connected to the *i-th input* group channel. *group* equal to a number of output feature maps implies depth-wise separable convolution.
-  * **Range of values**: integer value starting from 1
+  * **Range of values**: integer value starting from `1`
   * **Type**: int
-  * **Default value**: 1
+  * **Default value**: `1`
   * **Required**: *no*
 
 * *deformable_group*
 
   * **Description**: *deformable_group* is the number of groups which deformable values and *output* should be split into along the channel axis. Apply the deformable convolution using the i-th part of the offset part on the i-th out.
-  * **Range of values**: integer value starting from 1
+  * **Range of values**: integer value starting from `1`
   * **Type**: int
-  * **Default value**: 1
+  * **Default value**: `1`
   * **Required**: *no*
 
 **Inputs**:
 
-*   **1**: Input tensor of rank 3 or greater. Required.
+*   **1**: Input tensor of type *T* and rank 3, 4 or 5. Layout is NCZYX (number of batches, number of channels, spatial axes Z, Y, X). Required.
 
-*   **2**: Deformable values tensor of rank 3 or higher. Required.
+*   **2**: Deformable values tensor of type *T* and rank 3, 4 or 5. Layout is *TBD*. Required.
 
-*   **3**: Convolution kernel tensor. Weights layout is OIYX (OIZYX for 3D convolution), which means that *X* is changing the fastest, then *Y*, then *Input* then *Output*. The size of kernel is derived from the shape of this input and not specified by any attribute. Required.
+*   **3**: Kernel tensor of type *T* and rank 3, 4 or 5. Layout is OIZYX (number of output channels, number of input channels, spatial axes Z, Y, X). Required.
+*   **Note**: Type of the convolution (1D, 2D or 3D) is derived from the rank of the input tensors and not specified by any attribute:
+      * 1D convolution (input tensors rank 3) means that there is only one spatial axis X
+      * 2D convolution (input tensors rank 4) means that there are two spatial axes Y, X
+      * 3D convolution (input tensors rank 5) means that there are three spatial axes Z, Y, X
 
+
+**Outputs**:
+
+*   **1**: Output tensor of type *T* and rank 3, 4 or 5. Layout is NOZYX (number of batches, number of kernel output channels, spatial axes Z, Y, X).
+
+**Types**:
+
+* *T*: Any floating point type.
+ 
 **Example**
 
+1D Convolution
 ```xml
-<layer ... type="DeformableConvolution" ... >
-        <data dilations="1,1" pads_begin="2,2" pads_end="3,3" strides="2,2"/>
-        <input> ... </input>
-        <output> ... </output>
+<layer type="DeformableConvolution" ...>
+    <data dilations="1" pads_begin="0" pads_end="0" strides="2" auto_pad="valid" group="1" deformable_group="1"/>
+    <input>
+        <port id="0">
+            <dim>1</dim>
+            <dim>5</dim>
+            <dim>128</dim>
+        </port>
+        <port id="1">
+            <dim>16</dim>
+            <dim>5</dim>
+            <dim>4</dim>
+        </port>
+    </input>
+    <output>
+        <port id="2" precision="FP32">
+            <dim>1</dim>
+            <dim>16</dim>
+            <dim>63</dim>
+        </port>
+    </output>
+</layer>
+```
+2D Convolution
+```xml
+<layer type="DeformableConvolution" ...>
+    <data dilations="1,1" pads_begin="2,2" pads_end="2,2" strides="1,1" auto_pad="explicit"  group="1" deformable_group="1"/>
+    <input>
+        <port id="0">
+            <dim>1</dim>
+            <dim>3</dim>
+            <dim>224</dim>
+            <dim>224</dim>
+        </port>
+        <port id="1">
+            <dim>64</dim>
+            <dim>3</dim>
+            <dim>5</dim>
+            <dim>5</dim>
+        </port>
+    </input>
+    <output>
+        <port id="2" precision="FP32">
+            <dim>1</dim>
+            <dim>64</dim>
+            <dim>224</dim>
+            <dim>224</dim>
+        </port>
+    </output>
+</layer>
+```
+
+3D Convolution
+```xml
+<layer type="DeformableConvolution" ...>
+    <data dilations="2,2,2" pads_begin="0,0,0" pads_end="0,0,0" strides="3,3,3" auto_pad="explicit" group="1" deformable_group="1"/>
+    <input>
+        <port id="0">
+            <dim>1</dim>
+            <dim>7</dim>
+            <dim>320</dim>
+            <dim>320</dim>
+            <dim>320</dim>
+        </port>
+        <port id="1">
+            <dim>32</dim>
+            <dim>7</dim>
+            <dim>3</dim>
+            <dim>3</dim>
+            <dim>3</dim>
+        </port>
+    </input>
+    <output>
+        <port id="2" precision="FP32">
+            <dim>1</dim>
+            <dim>32</dim>
+            <dim>106</dim>
+            <dim>106</dim>
+            <dim>106</dim>
+        </port>
+    </output>
 </layer>
 ```

--- a/ngraph/test/CMakeLists.txt
+++ b/ngraph/test/CMakeLists.txt
@@ -276,6 +276,7 @@ set(MULTI_TEST_SRC
     backend/cum_sum.in.cpp
     backend/detection_output.in.cpp
     backend/divide.in.cpp
+    backend/deformable_convolution.in.cpp
     backend/dyn_reshape.in.cpp
     backend/strided_slice.in.cpp
     backend/dynamic.in.cpp

--- a/ngraph/test/backend/deformable_convolution.in.cpp
+++ b/ngraph/test/backend/deformable_convolution.in.cpp
@@ -1,0 +1,120 @@
+//*****************************************************************************
+// Copyright 2017-2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+
+#include "gtest/gtest.h"
+#include "ngraph/ngraph.hpp"
+#include "ngraph/runtime/tensor.hpp"
+#include "runtime/backend.hpp"
+#include "util/all_close.hpp"
+#include "util/all_close_f.hpp"
+#include "util/engine/test_engines.hpp"
+#include "util/known_element_types.hpp"
+#include "util/ndarray.hpp"
+#include "util/test_case.hpp"
+#include "util/test_control.hpp"
+#include "util/test_tools.hpp"
+
+using namespace std;
+using namespace ngraph;
+
+static string s_manifest = "${MANIFEST}";
+using TestEngine = test::ENGINE_CLASS_NAME(${BACKEND_NAME});
+
+static void DeformableConvolutionTest(const std::vector<float>& inputs,
+                            const Shape inputs_shape,
+                            const std::vector<float>& deformable_values,
+                            const Shape deformable_values_shape,
+                            const std::vector<float>& filters,
+                            const Shape filter_shape,
+                            const std::vector<float>& outputs,
+                            const Shape outputs_shape,
+                            const Strides& strides,
+                            const CoordinateDiff& padding,
+                            const Strides& dilations)
+{
+    const CoordinateDiff pads_begin{padding};
+    const CoordinateDiff pads_end{padding};
+    const op::PadType auto_pad{op::PadType::EXPLICIT};
+
+    auto inputs_param = make_shared<op::Parameter>(element::f32, inputs_shape);
+    auto deformable_values_param = make_shared<op::Parameter>(element::i32, deformable_values_shape);
+    auto filters_param = make_shared<op::Parameter>(element::f32, filter_shape);
+    auto conv = make_shared<op::v1::DeformableConvolution>(
+        inputs_param, deformable_values_param, filters_param, strides, pads_begin, pads_end, dilations, auto_pad);
+    auto f = make_shared<Function>(conv, ParameterVector{inputs_param, deformable_values_param, filters_param});
+
+    auto test_case = test::TestCase<TestEngine>(f);
+    test_case.add_input<float>(inputs);
+    test_case.add_input<float>(deformable_values);
+    test_case.add_input<float>(filters);
+    test_case.add_expected_output<float>(outputs_shape, outputs);
+    test_case.run();
+}
+/*
+NGRAPH_TEST(${BACKEND_NAME}, deformable_convolution_1D_1batch_1channel)
+{
+    const Strides strides{1};
+    const CoordinateDiff padding{0};
+    const Strides dilations{1};
+
+    const Shape inputs_shape{1, 1, 6};
+    const std::vector<float> inputs{1.0f, 3.0f, 3.0f, 0.0f, 1.0f, 2.0f};
+
+    const Shape deformable_values_shape{1, 1, 6};
+    const std::vector<float> deformable_values{1.0f, 3.0f, 3.0f, 0.0f, 1.0f, 2.0f};
+
+    const Shape filter_shape{1, 1, 3};
+    const std::vector<float> filters{2.0f, 0.0f, 1.0f};
+
+    const Shape outputs_shape{1, 1, 4};
+    const std::vector<float> outputs{5.0f, 6.0f, 7.0f, 2.0f};
+
+    DeformableConvolutionTest(inputs, inputs_shape, deformable_values, deformable_values_shape, filters, filter_shape, outputs, outputs_shape,
+                    strides, padding, dilations);
+}
+*/
+
+NGRAPH_TEST(${BACKEND_NAME}, deformable_convolution_2D_1batch_1channel_padding)
+{
+    const Strides strides{1, 1};
+    const CoordinateDiff padding{1, 1};
+    const Strides dilations{1, 1};
+
+    const Shape inputs_shape{1, 1, 4, 4};
+    const std::vector<float> inputs{1.0f, 3.0f, 5.0f, 7.0f,
+                                    7.0f, 5.0f, 3.0f, 1.0f,
+                                    2.0f, 4.0f, 6.0f, 8.0f,
+                                    8.0f, 6.0f, 4.0f, 2.0f};
+
+    const Shape filter_shape{1, 1, 3, 3};
+    const std::vector<float> filters{1.0f, 2.0f, 3.0f,
+                                     0.0f, 1.0f, 0.0f,
+                                     2.0f, 1.0f, 2.0f};
+    
+    const Shape deformable_values_shape{1, 1, 3, 3};
+    const std::vector<float> deformable_values{0.1f, 0.3f, 0.2f,
+                                               0.6f, 0.5f, 0.1f,
+                                               0.3f, 0.1f, 0.6f};
+
+    const Shape outputs_shape{1, 1, 4, 4};
+    const std::vector<float> outputs{18.0f, 28.0f, 20.0f, 14.0f,
+                                     28.0f, 40.0f, 64.0f, 35.0f,
+                                     51.0f, 53.0f, 35.0f, 23.0f,
+                                     24.0f, 32.0f, 44.0f, 24.0f};
+
+    DeformableConvolutionTest(inputs, inputs_shape, deformable_values, deformable_values_shape, filters, filter_shape, outputs, outputs_shape,
+                    strides, padding, dilations);
+}


### PR DESCRIPTION
DeformableConvolution specification refactored and aligned to what was suggested in #3922.

Changes:
- Changed input & output tensor types to 'any floating point'
- Added detailed description
- Added detailed description
- Added examples
- Added description of input & output rank and layout