### PR TITLE
[VPU][NGraph][Tests] Merge Gather & GatherElements

### DIFF
--- a/inference-engine/src/vpu/common/include/vpu/ngraph/operations/exp_gather_elements.hpp
+++ b/inference-engine/src/vpu/common/include/vpu/ngraph/operations/exp_gather_elements.hpp
@@ -1,0 +1,37 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "ngraph/op/op.hpp"
+
+namespace ngraph { namespace vpu { namespace op {
+
+class ExpGatherElements : public ngraph::op::Op {
+public:
+    NGRAPH_RTTI_DECLARATION;
+
+    explicit ExpGatherElements(const Output<Node>& data,
+                               const Output<Node>& indices,
+                               const Output<Node>& lookupIndices,
+                               const int64_t axis,
+                               const int64_t lookupAxis);
+
+    void validate_and_infer_types() override;
+
+    bool visit_attributes(AttributeVisitor& visitor) override;
+
+    std::shared_ptr<Node>
+    clone_with_new_inputs(const OutputVector& new_args) const override;
+
+    int64_t get_axis() const { return m_axis; }
+    int64_t get_lookup_axis() const { return m_lookup_axis; }
+private:
+    int64_t m_axis;
+    int64_t m_lookup_axis;
+};
+
+}  // namespace op
+}  // namespace vpu
+}  // namespace ngraph

--- a/inference-engine/src/vpu/common/include/vpu/ngraph/operations/exp_gather_elements.hpp
+++ b/inference-engine/src/vpu/common/include/vpu/ngraph/operations/exp_gather_elements.hpp
@@ -8,6 +8,15 @@
 
 namespace ngraph { namespace vpu { namespace op {
 
+//
+// ExpGatherElements is an extended version of GatherElements-6.
+// Besides data, indices and axis, it has an additional input - lookupIndices and an additional attribute - lookupAxis
+// which are working in the same way as in Gather-1, so the output data is calculating by the following formula:
+// output[:, ..., i, j, k, ..., m, ...] = input[:, ..., lookupIndices[i, j, k], ..., indices[:, ..., i, j, k, ..., m, ...], ...]
+// where m is axis and i is lookupAxis.
+// Output shape is the same as indices shape
+//
+
 class ExpGatherElements : public ngraph::op::Op {
 public:
     NGRAPH_RTTI_DECLARATION;

--- a/inference-engine/src/vpu/common/include/vpu/ngraph/transformations/merge_gather_gather_elements.hpp
+++ b/inference-engine/src/vpu/common/include/vpu/ngraph/transformations/merge_gather_gather_elements.hpp
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "ngraph/pass/pass.hpp"
+
+namespace vpu {
+
+class MergeGatherGatherElements : public ngraph::pass::FunctionPass {
+public:
+    NGRAPH_RTTI_DECLARATION;
+    bool run_on_function(std::shared_ptr<ngraph::Function> f) override;
+};
+
+}  // namespace vpu

--- a/inference-engine/src/vpu/common/include/vpu/ngraph/utilities.hpp
+++ b/inference-engine/src/vpu/common/include/vpu/ngraph/utilities.hpp
@@ -20,7 +20,7 @@ std::shared_ptr<ngraph::Node> shapeToConstant(const ngraph::element::Type& type,
 
 std::shared_ptr<ngraph::Node> gatherShapeElements(const ngraph::Output<ngraph::Node>&, int startIndex, size_t elemCount);
 
-std::shared_ptr<ngraph::Node> gatherShapeElements(const ngraph::Output<ngraph::Node>& shape, std::vector<int64_t> indicesToGather);
+std::shared_ptr<ngraph::Node> gatherShapeElements(const ngraph::Output<ngraph::Node>& shape, const std::vector<int64_t>& indicesToGather);
 
 template<>
 inline void printTo(std::ostream& stream, const ngraph::NodeTypeInfo& object) {

--- a/inference-engine/src/vpu/common/include/vpu/ngraph/utilities.hpp
+++ b/inference-engine/src/vpu/common/include/vpu/ngraph/utilities.hpp
@@ -20,6 +20,8 @@ std::shared_ptr<ngraph::Node> shapeToConstant(const ngraph::element::Type& type,
 
 std::shared_ptr<ngraph::Node> gatherShapeElements(const ngraph::Output<ngraph::Node>&, int startIndex, size_t elemCount);
 
+std::shared_ptr<ngraph::Node> gatherShapeElements(const ngraph::Output<ngraph::Node>& shape, std::vector<int64_t> indicesToGather);
+
 template<>
 inline void printTo(std::ostream& stream, const ngraph::NodeTypeInfo& object) {
     stream << object.name << " ver. " << object.version;

--- a/inference-engine/src/vpu/common/src/ngraph/operations/exp_gather_elements.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/operations/exp_gather_elements.cpp
@@ -1,0 +1,68 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "vpu/ngraph/operations/exp_gather_elements.hpp"
+
+#include <ngraph/validation_util.hpp>
+
+namespace ngraph { namespace vpu { namespace op {
+
+NGRAPH_RTTI_DEFINITION(ExpGatherElements, "ExpGatherElements", 0);
+
+ExpGatherElements::ExpGatherElements(const Output<Node>& data,
+                                     const Output<Node>& indices,
+                                     const Output<Node>& lookupIndices,
+                                     const int64_t axis,
+                                     const int64_t lookupAxis)
+    : ngraph::op::Op({data, indices, lookupIndices})
+    , m_axis(axis)
+    , m_lookup_axis(lookupAxis) {
+    constructor_validate_and_infer_types();
+}
+
+void ExpGatherElements::validate_and_infer_types() {
+    const auto& dataType = get_input_element_type(0);
+    const auto& indicesType = get_input_element_type(1);
+    const auto& lookupIndicesType = get_input_element_type(2);
+
+    NODE_VALIDATION_CHECK(this, indicesType == element::Type_t::i32 || indicesType == element::Type_t::i64,
+                          "indices must be of int32 or int64 type. But instead got: ", indicesType);
+    NODE_VALIDATION_CHECK(this, lookupIndicesType == element::Type_t::i32 || lookupIndicesType == element::Type_t::i64,
+                          "lookupIndices must be of int32 or int64 type. But instead got: ", lookupIndicesType);
+
+    const auto& dataPShape = get_input_partial_shape(0);
+    const auto& indicesPShape = get_input_partial_shape(1);
+    const auto& lookupIndicesPShape = get_input_partial_shape(2);
+    const auto& dataRank = dataPShape.rank();
+    const auto& indicesRank = indicesPShape.rank();
+    const auto& lookupIndicesRank = lookupIndicesPShape.rank();
+
+    NODE_VALIDATION_CHECK(this, dataRank.is_static() && indicesRank.is_static() && lookupIndicesRank.is_static(),
+                          "Dynamic rank is not supported for any input");
+
+    const auto axis = ngraph::normalize_axis(description(), m_axis, indicesRank);
+    const auto lookupAxis = ngraph::normalize_axis(description(), m_lookup_axis, dataRank);
+
+    NODE_VALIDATION_CHECK(this, axis < indicesRank.get_length(),
+                          "axis must be within interval (-indices.rank,  indices.rank - 1). But instead Got", m_axis);
+    NODE_VALIDATION_CHECK(this, lookupAxis < dataRank.get_length(),
+                          "lookupAxis must be within interval (-data.rank,  data.rank - 1). But instead Got", m_lookup_axis);
+
+    set_output_type(0, dataType, indicesPShape);
+}
+
+bool ExpGatherElements::visit_attributes(AttributeVisitor& visitor) {
+    visitor.on_attribute("axis", m_axis);
+    visitor.on_attribute("lookup_axis", m_lookup_axis);
+    return true;
+}
+
+std::shared_ptr<Node> ExpGatherElements::clone_with_new_inputs(const OutputVector& new_args) const {
+    check_new_args_count(this, new_args);
+    return std::make_shared<ExpGatherElements>(new_args.at(0), new_args.at(1), new_args.at(2), get_axis(), m_lookup_axis);
+}
+
+}  // namespace op
+}  // namespace vpu
+}  // namespace ngraph

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape.cpp
@@ -26,6 +26,8 @@
 #include "vpu/ngraph/transformations/dynamic_to_static_shape_variadic_split.hpp"
 #include "vpu/ngraph/transformations/dynamic_to_static_shape_loop.hpp"
 
+#include "vpu/ngraph/operations/exp_gather_elements.hpp"
+
 #include "vpu/ngraph/utilities.hpp"
 #include "vpu/utils/error.hpp"
 
@@ -137,6 +139,7 @@ const Transformations& getDefaultTransformations() {
         {ngraph::opset5::Split::type_info,                 dynamicToStaticShapeSplit},
         {ngraph::opset5::GatherND::type_info,              dynamicToStaticShapeGatherND},
         {ngraph::opset6::GatherElements::type_info,        dynamicToStaticShapeGatherElements},
+        {ngraph::vpu::op::ExpGatherElements::type_info,    dynamicToStaticShapeGatherElements},
 
         // reduction
         {ngraph::opset3::ReduceLogicalAnd::type_info, dynamicToStaticShapeReduce},

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/merge_gather_gather_elements.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/merge_gather_gather_elements.cpp
@@ -1,0 +1,145 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "vpu/ngraph/transformations/merge_gather_gather_elements.hpp"
+
+#include <vpu/ngraph/operations/exp_gather_elements.hpp>
+#include <vpu/ngraph/utilities.hpp>
+
+#include <ngraph/pattern/op/wrap_type.hpp>
+#include <ngraph/opsets/opset6.hpp>
+#include <ngraph/pattern/matcher.hpp>
+#include <ngraph/pattern/op/label.hpp>
+#include <ngraph/validation_util.hpp>
+#include <ngraph/log.hpp>
+
+#include <numeric>
+
+NGRAPH_RTTI_DEFINITION(vpu::MergeGatherGatherElements, "MergeGatherGatherElements", 0);
+
+namespace vpu {
+
+bool MergeGatherGatherElements::run_on_function(std::shared_ptr<ngraph::Function> f) {
+    bool wasGraphChanged = false;
+
+    const auto gatherData = ngraph::pattern::any_input();
+    const auto gatherIndices = ngraph::pattern::any_input();
+    const auto gather = ngraph::pattern::wrap_type<ngraph::opset6::Gather>(
+        {gatherData, gatherIndices, ngraph::pattern::any_input()},
+        ngraph::pattern::consumers_count(1));
+
+    const auto squeezeAxes = ngraph::pattern::any_input(
+        ngraph::pattern::op::as_value_predicate(ngraph::pattern::has_class<ngraph::opset6::Constant>()));
+    const auto squeeze = ngraph::pattern::wrap_type<ngraph::opset6::Squeeze>({gather, squeezeAxes}, ngraph::pattern::consumers_count(1));
+
+    const auto transposePerm = ngraph::pattern::any_input(
+        ngraph::pattern::op::as_value_predicate(ngraph::pattern::has_class<ngraph::opset6::Constant>()));
+    const auto transpose = ngraph::pattern::wrap_type<ngraph::opset6::Transpose>({squeeze, transposePerm});
+
+    const auto m = std::make_shared<ngraph::pattern::Matcher>(transpose, "GatherSqueezeTransposeMatcher");
+    for (const auto& node : f->get_ordered_ops()) {
+        if (m->match(node)) {
+            auto& patternMap = m->get_pattern_value_map();
+
+            std::vector<ngraph::Node*> shapeOfs;
+            std::vector<ngraph::Node*> gatherElements;
+
+            const auto& m_transpose = patternMap.at(transpose);
+            const auto& transposeConsumers = m_transpose.get_target_inputs();
+            for (const auto& transposeConsumer : transposeConsumers) {
+                if (transposeConsumer.get_node()->get_type_info() == ngraph::opset6::ShapeOf::type_info) {
+                    shapeOfs.push_back(transposeConsumer.get_node());
+                } else if (transposeConsumer.get_node()->get_type_info() == ngraph::opset6::GatherElements::type_info) {
+                    gatherElements.push_back(transposeConsumer.get_node());
+                }
+            }
+            if (gatherElements.empty() || shapeOfs.size() + gatherElements.size() != transposeConsumers.size()) {
+                continue;
+            }
+
+            const auto& m_transposePerm = patternMap.at(transposePerm);
+            const auto& m_squeezeAxes = patternMap.at(squeezeAxes);
+            const auto& m_squeeze = patternMap.at(squeeze);
+            const auto& m_gatherData = patternMap.at(gatherData);
+            const auto& m_gatherIndices = patternMap.at(gatherIndices);
+            const auto& m_gather = patternMap.at(gather);
+
+            for (const auto& gatherElement : gatherElements) {
+                const auto transposeIndices = std::make_shared<ngraph::opset6::Transpose>(gatherElement->input_value(1), m_transposePerm);
+                const auto unsqueezeIndices = std::make_shared<ngraph::opset6::Unsqueeze>(
+                    transposeIndices,
+                    m_squeezeAxes);
+                const auto expGatherElements = std::make_shared<ngraph::vpu::op::ExpGatherElements>(
+                    m_gatherData,
+                    unsqueezeIndices,
+                    m_gatherIndices,
+                    ngraph::as_type<ngraph::opset6::GatherElements>(gatherElement)->get_axis(),
+                    ngraph::as_type<ngraph::opset6::Gather>(m_gather.get_node())->get_axis());
+                const auto squeezeData = m_squeeze.get_node()->clone_with_new_inputs({expGatherElements, m_squeezeAxes});
+                const auto transposeData = m_transpose.get_node()->clone_with_new_inputs({squeezeData, m_transposePerm});
+                transposeData->set_friendly_name(gatherElement->get_friendly_name());
+                gatherElement->get_default_output().replace(transposeData);
+                wasGraphChanged = true;
+            }
+
+            for (const auto& shapeOf : shapeOfs) {
+                const auto gatherDataShape = std::make_shared<ngraph::opset6::ShapeOf>(
+                    m_gatherData,
+                    ngraph::as_type<ngraph::opset6::ShapeOf>(shapeOf)->get_output_type());
+                const auto gatherIndicesShape = std::make_shared<ngraph::opset6::ShapeOf>(
+                    m_gatherIndices,
+                    ngraph::as_type<ngraph::opset6::ShapeOf>(shapeOf)->get_output_type());
+                const auto axis = ngraph::as_type<ngraph::opset6::Gather>(m_gather.get_node())->get_axis();
+
+                const auto gatherIndicesRank = m_gatherIndices.get_partial_shape().rank().get_length();
+                const auto gatherDataRank = m_gatherData.get_partial_shape().rank().get_length();
+                const auto gatherOutRank = gatherDataRank + gatherIndicesRank - 1;
+
+                std::vector<int64_t> squeezeOutIndices(gatherOutRank);
+                std::iota(squeezeOutIndices.begin(), squeezeOutIndices.end(), 0);
+
+                auto squeezeAxes = ngraph::as_type<ngraph::opset6::Constant>(m_squeezeAxes.get_node())->cast_vector<int64_t>();
+                ngraph::normalize_axes(m_squeezeAxes.get_node()->description(), squeezeAxes, gatherOutRank);
+                std::sort(squeezeAxes.begin(), squeezeAxes.end(), [](int64_t a, int64_t b) { return a > b; });
+                for (const auto& squeezeAxis : squeezeAxes) {
+                    squeezeOutIndices.erase(squeezeOutIndices.begin() + squeezeAxis);
+                }
+
+                std::vector<int64_t> transposeOutIndices(squeezeOutIndices.size());
+                auto transposePerm = ngraph::as_type<ngraph::opset6::Constant>(m_transposePerm.get_node())->cast_vector<int64_t>();
+                for (size_t i = 0; i < transposeOutIndices.size(); i++) {
+                    transposeOutIndices[i] = squeezeOutIndices[transposePerm[i]];
+                }
+
+                ngraph::OutputVector gatherOutDims;
+                if (axis) {
+                    gatherOutDims.push_back(gatherShapeElements(gatherDataShape, 0, axis));
+                }
+                if (m_gatherIndices.get_partial_shape().rank().get_length()) {
+                    gatherOutDims.push_back(gatherIndicesShape);
+                }
+                if (axis + 1 < gatherDataRank) {
+                    gatherOutDims.push_back(gatherShapeElements(gatherDataShape, axis + 1, gatherDataRank - axis - 1));
+                }
+
+                const auto gatherOutShape = std::make_shared<ngraph::opset6::Concat>(gatherOutDims, 0);
+
+                const auto transposeOutShape = std::make_shared<ngraph::opset6::Gather>(
+                    gatherOutShape,
+                    ngraph::opset6::Constant::create(ngraph::element::i64, ngraph::Shape{transposeOutIndices.size()}, transposeOutIndices),
+                    ngraph::opset6::Constant::create(ngraph::element::i64, ngraph::Shape{1}, {0}));
+
+                transposeOutShape->set_friendly_name(shapeOf->get_friendly_name());
+                shapeOf->get_default_output().replace(transposeOutShape);
+                wasGraphChanged = true;
+            }
+
+            m->clear_state();
+        }
+    }
+
+    return wasGraphChanged;
+}
+
+}  // namespace vpu

--- a/inference-engine/src/vpu/common/src/ngraph/utilities.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/utilities.cpp
@@ -86,7 +86,7 @@ std::shared_ptr<ngraph::Node> gatherShapeElements(const ngraph::Output<ngraph::N
         ngraph::opset5::Constant::create(ngraph::element::i64, {}, {0}));
 }
 
-std::shared_ptr<ngraph::Node> gatherShapeElements(const ngraph::Output<ngraph::Node>& shape, std::vector<int64_t> indicesToGather) {
+std::shared_ptr<ngraph::Node> gatherShapeElements(const ngraph::Output<ngraph::Node>& shape, const std::vector<int64_t>& indicesToGather) {
     return std::make_shared<ngraph::opset5::Gather>(
             shape,
             ngraph::opset5::Constant::create(ngraph::element::i64, {indicesToGather.size()}, indicesToGather),

--- a/inference-engine/src/vpu/common/src/ngraph/utilities.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/utilities.cpp
@@ -86,4 +86,11 @@ std::shared_ptr<ngraph::Node> gatherShapeElements(const ngraph::Output<ngraph::N
         ngraph::opset5::Constant::create(ngraph::element::i64, {}, {0}));
 }
 
+std::shared_ptr<ngraph::Node> gatherShapeElements(const ngraph::Output<ngraph::Node>& shape, std::vector<int64_t> indicesToGather) {
+    return std::make_shared<ngraph::opset5::Gather>(
+            shape,
+            ngraph::opset5::Constant::create(ngraph::element::i64, {indicesToGather.size()}, indicesToGather),
+            ngraph::opset5::Constant::create(ngraph::element::i64, {}, {0}));
+}
+
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/frontend/frontend.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/frontend/frontend.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -46,6 +46,7 @@
 #include <legacy/transformations/convert_opset1_to_legacy/convert_matmul_to_fc_or_gemm.hpp>
 #include <legacy/transformations/convert_opset1_to_legacy/convert_strided_slice_to_crop.hpp>
 #include <vpu/ngraph/transformations/extract_dynamic_batch/extract_dynamic_batch.hpp>
+#include <vpu/ngraph/transformations/merge_gather_gather_elements.hpp>
 
 namespace vpu {
 
@@ -171,6 +172,7 @@ ie::CNNNetwork FrontEnd::convertNetwork(ie::CNNNetwork& network) {
     manager.register_pass<ngraph::pass::ConvertNMS1ToNMS5>();
     manager.register_pass<ngraph::pass::ConvertNMS3ToNMS5>();
     manager.register_pass<ngraph::pass::ConvertNMS4ToNMS5>();
+    manager.register_pass<vpu::MergeGatherGatherElements>();
     manager.register_pass<ngraph::pass::CommonOptimizations>();
 
     manager.register_pass<vpu::ExtractBatch>(std::unordered_set<ngraph::Node::type_info_t>{

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/allocator/allocator.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/allocator/allocator.cpp
@@ -100,8 +100,9 @@ int getInUse(const Data& data) {
     }
     for (const auto& childEdge : data->childDataToShapeEdges()) {
         auto const& child = childEdge->child();
-        if (child->usage() == DataUsage::Output) {
-            VPU_THROW_UNLESS(child->parentData() == nullptr, "Output data object must not have parent");
+        if (child->usage() == DataUsage::Input || child->usage() == DataUsage::Output) {
+            VPU_THROW_UNLESS(child->parentData() == nullptr,
+                             "Data object {} with usage {} must not have parent", child->name(), child->usage());
             inUse++;
         } else if (child->getTopParentData() == child) {
             inUse += getInUse(child);

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/merge_gather_gather_elements.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/merge_gather_gather_elements.cpp
@@ -1,0 +1,299 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vpu/ngraph/transformations/merge_gather_gather_elements.hpp>
+
+#include <vpu/ngraph/operations/exp_gather_elements.hpp>
+#include <common_test_utils/test_common.hpp>
+#include <ngraph_functions/utils/ngraph_helpers.hpp>
+
+#include <ngraph/opsets/opset6.hpp>
+#include <ngraph/pass/manager.hpp>
+
+namespace {
+
+using DataType = ngraph::element::Type_t;
+using DataDims = ngraph::Shape;
+
+class MergeGatherGatherElements : public CommonTestUtils::TestsCommon {
+public:
+    void SetUp() override {
+        ngraph::helpers::CompareFunctions(*transform(), *reference());
+    }
+
+protected:
+std::shared_ptr<const ngraph::Function> transform() const {
+    const auto imageParam = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 800, 1216});
+    const auto imageGatherIndices = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::i32, ngraph::Shape{300, 64});
+    const auto imageGather = std::make_shared<ngraph::opset6::Gather>(
+        imageParam,
+        imageGatherIndices,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {2}));
+    const auto squeeze = std::make_shared<ngraph::opset6::Squeeze>(
+        imageGather,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+    const auto transpose = std::make_shared<ngraph::opset6::Transpose>(
+        squeeze,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {1, 0, 2, 3}));
+
+    const auto shapeOf1 = std::make_shared<ngraph::opset6::ShapeOf>(transpose, ngraph::element::i32);
+    const auto shapeOf2 = std::make_shared<ngraph::opset6::ShapeOf>(transpose, ngraph::element::i32);
+    const auto shapeOf3 = std::make_shared<ngraph::opset6::ShapeOf>(transpose, ngraph::element::i32);
+    const auto shapeOf4 = std::make_shared<ngraph::opset6::ShapeOf>(transpose, ngraph::element::i32);
+    const auto shapeOf5 = std::make_shared<ngraph::opset6::ShapeOf>(transpose, ngraph::element::i32);
+    const auto shapeOf6 = std::make_shared<ngraph::opset6::ShapeOf>(transpose, ngraph::element::i32);
+
+    const auto gatherShape1 = std::make_shared<ngraph::opset6::Gather>(
+        shapeOf1,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}),
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+    const auto gatherShape2 = std::make_shared<ngraph::opset6::Gather>(
+        shapeOf2,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {1}),
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+    const auto gatherShape3 = std::make_shared<ngraph::opset6::Gather>(
+        shapeOf3,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {2}),
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+    const auto gatherShape4 = std::make_shared<ngraph::opset6::Gather>(
+        shapeOf4,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}),
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+    const auto gatherShape5 = std::make_shared<ngraph::opset6::Gather>(
+        shapeOf5,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {1}),
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+    const auto gatherShape6 = std::make_shared<ngraph::opset6::Gather>(
+        shapeOf6,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {2}),
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+
+    const auto unsqueeze1 = std::make_shared<ngraph::opset6::Unsqueeze>(
+        gatherShape1,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+    const auto unsqueeze2 = std::make_shared<ngraph::opset6::Unsqueeze>(
+        gatherShape2,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+    const auto unsqueeze3 = std::make_shared<ngraph::opset6::Unsqueeze>(
+        gatherShape3,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+    const auto unsqueeze4 = std::make_shared<ngraph::opset6::Unsqueeze>(
+        gatherShape4,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+    const auto unsqueeze5 = std::make_shared<ngraph::opset6::Unsqueeze>(
+        gatherShape5,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+    const auto unsqueeze6 = std::make_shared<ngraph::opset6::Unsqueeze>(
+        gatherShape6,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+
+    const auto concat1 = std::make_shared<ngraph::opset6::Concat>(
+        ngraph::NodeVector{unsqueeze1, unsqueeze2, unsqueeze3, ngraph::opset6::Constant::create(unsqueeze1->get_element_type(), ngraph::Shape{1}, {64})},
+        0);
+    const auto concat2 = std::make_shared<ngraph::opset6::Concat>(
+        ngraph::NodeVector{unsqueeze4, unsqueeze5, unsqueeze6, ngraph::opset6::Constant::create(unsqueeze1->get_element_type(), ngraph::Shape{1}, {64})},
+        0);
+
+    const auto reshape1 = std::make_shared<ngraph::opset6::Reshape>(
+        concat1,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {-1}),
+        false);
+    const auto reshape2 = std::make_shared<ngraph::opset6::Reshape>(
+        concat2,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {-1}),
+        false);
+
+    const auto equal1 = std::make_shared<ngraph::opset6::Equal>(
+        reshape1,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {-1, -1, -1, -1}));
+    const auto equal2 = std::make_shared<ngraph::opset6::Equal>(
+        reshape2,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {-1, -1, -1, -1}));
+
+    const auto select1 = std::make_shared<ngraph::opset6::Select>(
+        equal1,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {1, 1, 1, 1}),
+        reshape1);
+    const auto select2 = std::make_shared<ngraph::opset6::Select>(
+        equal2,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {1, 1, 1, 1}),
+        reshape2);
+
+    const auto broadcastParam1 = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::i32, ngraph::Shape{300, 1, 1, 64});
+    const auto broadcast1 = std::make_shared<ngraph::opset6::Broadcast>(broadcastParam1, select1);
+
+    const auto broadcastParam2 = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::i32, ngraph::Shape{300, 1, 1, 64});
+    const auto broadcast2 = std::make_shared<ngraph::opset6::Broadcast>(broadcastParam2, select2);
+
+    const auto gatherElements1 = std::make_shared<ngraph::opset6::GatherElements>(transpose, broadcast1, 3);
+    const auto gatherElements2 = std::make_shared<ngraph::opset6::GatherElements>(transpose, broadcast2, 3);
+
+    const auto function = std::make_shared<ngraph::Function>(
+        ngraph::OutputVector{gatherElements1->output(0), gatherElements2->output(0)},
+        ngraph::ParameterVector{imageParam, imageGatherIndices, broadcastParam1, broadcastParam2},
+        "GatherGatherElements");
+
+    ngraph::pass::Manager manager;
+    manager.register_pass<vpu::MergeGatherGatherElements>();
+    manager.run_passes(function);
+
+    return function;
+}
+
+std::shared_ptr<const ngraph::Function> reference() const {
+    const auto imageParam = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 800, 1216});
+    const auto imageGatherIndices = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::i32, ngraph::Shape{300, 64});
+
+    std::vector<std::shared_ptr<ngraph::Node>> shapes;
+    for (int i = 0; i < 6; i++) {
+        const auto gatherDataShape = std::make_shared<ngraph::opset6::ShapeOf>(imageParam, ngraph::element::i32);
+        const auto gatherIndicesShape = std::make_shared<ngraph::opset6::ShapeOf>(imageGatherIndices, ngraph::element::i32);
+
+        const auto gatherOutShape = std::make_shared<ngraph::opset6::Concat>(
+            ngraph::NodeVector{
+                std::make_shared<ngraph::opset6::Gather>(
+                    gatherDataShape,
+                    ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{2}, {0, 1}),
+                    ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0})),
+                gatherIndicesShape,
+                std::make_shared<ngraph::opset6::Gather>(
+                    gatherDataShape,
+                    ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {3}),
+                    ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}))},
+            0);
+
+        shapes.push_back(
+            std::make_shared<ngraph::opset6::Gather>(
+                gatherOutShape,
+                ngraph::opset6::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {2, 1, 3, 4}),
+                ngraph::opset6::Constant::create(ngraph::element::i64, ngraph::Shape{1}, {0})));
+    }
+
+    const auto gatherShape1 = std::make_shared<ngraph::opset6::Gather>(
+        shapes[0],
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}),
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+    const auto gatherShape2 = std::make_shared<ngraph::opset6::Gather>(
+        shapes[1],
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {1}),
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+    const auto gatherShape3 = std::make_shared<ngraph::opset6::Gather>(
+        shapes[2],
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {2}),
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+    const auto gatherShape4 = std::make_shared<ngraph::opset6::Gather>(
+        shapes[3],
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}),
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+    const auto gatherShape5 = std::make_shared<ngraph::opset6::Gather>(
+        shapes[4],
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {1}),
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+    const auto gatherShape6 = std::make_shared<ngraph::opset6::Gather>(
+        shapes[5],
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {2}),
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+
+    const auto unsqueeze1 = std::make_shared<ngraph::opset6::Unsqueeze>(
+        gatherShape1,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+    const auto unsqueeze2 = std::make_shared<ngraph::opset6::Unsqueeze>(
+        gatherShape2,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+    const auto unsqueeze3 = std::make_shared<ngraph::opset6::Unsqueeze>(
+        gatherShape3,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+    const auto unsqueeze4 = std::make_shared<ngraph::opset6::Unsqueeze>(
+        gatherShape4,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+    const auto unsqueeze5 = std::make_shared<ngraph::opset6::Unsqueeze>(
+        gatherShape5,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+    const auto unsqueeze6 = std::make_shared<ngraph::opset6::Unsqueeze>(
+        gatherShape6,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+
+    const auto concat1 = std::make_shared<ngraph::opset6::Concat>(
+        ngraph::NodeVector{unsqueeze1, unsqueeze2, unsqueeze3, ngraph::opset6::Constant::create(unsqueeze1->get_element_type(), ngraph::Shape{1}, {64})},
+        0);
+    const auto concat2 = std::make_shared<ngraph::opset6::Concat>(
+        ngraph::NodeVector{unsqueeze4, unsqueeze5, unsqueeze6, ngraph::opset6::Constant::create(unsqueeze1->get_element_type(), ngraph::Shape{1}, {64})},
+        0);
+
+    const auto reshape1 = std::make_shared<ngraph::opset6::Reshape>(
+        concat1,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {-1}),
+        false);
+    const auto reshape2 = std::make_shared<ngraph::opset6::Reshape>(
+        concat2,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {-1}),
+        false);
+
+    const auto equal1 = std::make_shared<ngraph::opset6::Equal>(
+        reshape1,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {-1, -1, -1, -1}));
+    const auto equal2 = std::make_shared<ngraph::opset6::Equal>(
+        reshape2,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {-1, -1, -1, -1}));
+
+    const auto select1 = std::make_shared<ngraph::opset6::Select>(
+        equal1,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {1, 1, 1, 1}),
+        reshape1);
+    const auto select2 = std::make_shared<ngraph::opset6::Select>(
+        equal2,
+        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {1, 1, 1, 1}),
+        reshape2);
+
+    const auto broadcastParam1 = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::i32, ngraph::Shape{300, 1, 1, 64});
+    const auto broadcast1 = std::make_shared<ngraph::opset6::Broadcast>(broadcastParam1, select1);
+
+    const auto squeezeAxis = ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0});
+    const auto transposePerm = ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {1, 0, 2, 3});
+
+    const auto transposeIndices1 = std::make_shared<ngraph::opset6::Transpose>(
+        broadcast1,
+        transposePerm);
+    const auto unsqueezeIndices1 = std::make_shared<ngraph::opset6::Unsqueeze>(
+        transposeIndices1,
+        squeezeAxis);
+
+    const auto broadcastParam2 = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::i32, ngraph::Shape{300, 1, 1, 64});
+    const auto broadcast2 = std::make_shared<ngraph::opset6::Broadcast>(broadcastParam2, select2);
+
+    const auto transposeIndices2 = std::make_shared<ngraph::opset6::Transpose>(
+        broadcast2,
+        transposePerm);
+    const auto unsqueezeIndices2 = std::make_shared<ngraph::opset6::Unsqueeze>(
+        transposeIndices2,
+        squeezeAxis);
+
+    const auto expGatherElements1 = std::make_shared<ngraph::vpu::op::ExpGatherElements>(imageParam, unsqueezeIndices1, imageGatherIndices, 3, 2);
+    const auto expGatherElements2 = std::make_shared<ngraph::vpu::op::ExpGatherElements>(imageParam, unsqueezeIndices2, imageGatherIndices, 3, 2);
+
+    const auto squeezeData1 = std::make_shared<ngraph::opset6::Squeeze>(
+        expGatherElements1,
+        squeezeAxis);
+    const auto transposeData1 = std::make_shared<ngraph::opset6::Transpose>(
+        squeezeData1,
+        transposePerm);
+
+    const auto squeezeData2 = std::make_shared<ngraph::opset6::Squeeze>(
+        expGatherElements2,
+        squeezeAxis);
+    const auto transposeData2 = std::make_shared<ngraph::opset6::Transpose>(
+        squeezeData2,
+        transposePerm);
+
+    return std::make_shared<ngraph::Function>(
+        ngraph::OutputVector{transposeData1->output(0), transposeData2->output(0)},
+        ngraph::ParameterVector{imageParam, imageGatherIndices, broadcastParam1, broadcastParam2},
+        "GatherGatherElements");
+}
+};
+
+TEST_F(MergeGatherGatherElements, CompareFunctions) {
+}
+
+} // namespace

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/merge_gather_gather_elements.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/merge_gather_gather_elements.cpp
@@ -23,274 +23,274 @@ public:
     }
 
 protected:
-std::shared_ptr<const ngraph::Function> transform() const {
-    const auto imageParam = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 800, 1216});
-    const auto imageGatherIndices = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::i32, ngraph::Shape{300, 64});
-    const auto imageGather = std::make_shared<ngraph::opset6::Gather>(
-        imageParam,
-        imageGatherIndices,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {2}));
-    const auto squeeze = std::make_shared<ngraph::opset6::Squeeze>(
-        imageGather,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
-    const auto transpose = std::make_shared<ngraph::opset6::Transpose>(
-        squeeze,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {1, 0, 2, 3}));
+    std::shared_ptr<const ngraph::Function> transform() const {
+        const auto imageParam = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 800, 1216});
+        const auto imageGatherIndices = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::i32, ngraph::Shape{300, 64});
+        const auto imageGather = std::make_shared<ngraph::opset6::Gather>(
+            imageParam,
+            imageGatherIndices,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {2}));
+        const auto squeeze = std::make_shared<ngraph::opset6::Squeeze>(
+            imageGather,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+        const auto transpose = std::make_shared<ngraph::opset6::Transpose>(
+            squeeze,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {1, 0, 2, 3}));
 
-    const auto shapeOf1 = std::make_shared<ngraph::opset6::ShapeOf>(transpose, ngraph::element::i32);
-    const auto shapeOf2 = std::make_shared<ngraph::opset6::ShapeOf>(transpose, ngraph::element::i32);
-    const auto shapeOf3 = std::make_shared<ngraph::opset6::ShapeOf>(transpose, ngraph::element::i32);
-    const auto shapeOf4 = std::make_shared<ngraph::opset6::ShapeOf>(transpose, ngraph::element::i32);
-    const auto shapeOf5 = std::make_shared<ngraph::opset6::ShapeOf>(transpose, ngraph::element::i32);
-    const auto shapeOf6 = std::make_shared<ngraph::opset6::ShapeOf>(transpose, ngraph::element::i32);
+        const auto shapeOf1 = std::make_shared<ngraph::opset6::ShapeOf>(transpose, ngraph::element::i32);
+        const auto shapeOf2 = std::make_shared<ngraph::opset6::ShapeOf>(transpose, ngraph::element::i32);
+        const auto shapeOf3 = std::make_shared<ngraph::opset6::ShapeOf>(transpose, ngraph::element::i32);
+        const auto shapeOf4 = std::make_shared<ngraph::opset6::ShapeOf>(transpose, ngraph::element::i32);
+        const auto shapeOf5 = std::make_shared<ngraph::opset6::ShapeOf>(transpose, ngraph::element::i32);
+        const auto shapeOf6 = std::make_shared<ngraph::opset6::ShapeOf>(transpose, ngraph::element::i32);
 
-    const auto gatherShape1 = std::make_shared<ngraph::opset6::Gather>(
-        shapeOf1,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}),
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
-    const auto gatherShape2 = std::make_shared<ngraph::opset6::Gather>(
-        shapeOf2,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {1}),
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
-    const auto gatherShape3 = std::make_shared<ngraph::opset6::Gather>(
-        shapeOf3,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {2}),
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
-    const auto gatherShape4 = std::make_shared<ngraph::opset6::Gather>(
-        shapeOf4,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}),
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
-    const auto gatherShape5 = std::make_shared<ngraph::opset6::Gather>(
-        shapeOf5,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {1}),
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
-    const auto gatherShape6 = std::make_shared<ngraph::opset6::Gather>(
-        shapeOf6,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {2}),
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+        const auto gatherShape1 = std::make_shared<ngraph::opset6::Gather>(
+            shapeOf1,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}),
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+        const auto gatherShape2 = std::make_shared<ngraph::opset6::Gather>(
+            shapeOf2,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {1}),
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+        const auto gatherShape3 = std::make_shared<ngraph::opset6::Gather>(
+            shapeOf3,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {2}),
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+        const auto gatherShape4 = std::make_shared<ngraph::opset6::Gather>(
+            shapeOf4,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}),
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+        const auto gatherShape5 = std::make_shared<ngraph::opset6::Gather>(
+            shapeOf5,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {1}),
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+        const auto gatherShape6 = std::make_shared<ngraph::opset6::Gather>(
+            shapeOf6,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {2}),
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
 
-    const auto unsqueeze1 = std::make_shared<ngraph::opset6::Unsqueeze>(
-        gatherShape1,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
-    const auto unsqueeze2 = std::make_shared<ngraph::opset6::Unsqueeze>(
-        gatherShape2,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
-    const auto unsqueeze3 = std::make_shared<ngraph::opset6::Unsqueeze>(
-        gatherShape3,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
-    const auto unsqueeze4 = std::make_shared<ngraph::opset6::Unsqueeze>(
-        gatherShape4,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
-    const auto unsqueeze5 = std::make_shared<ngraph::opset6::Unsqueeze>(
-        gatherShape5,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
-    const auto unsqueeze6 = std::make_shared<ngraph::opset6::Unsqueeze>(
-        gatherShape6,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+        const auto unsqueeze1 = std::make_shared<ngraph::opset6::Unsqueeze>(
+            gatherShape1,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+        const auto unsqueeze2 = std::make_shared<ngraph::opset6::Unsqueeze>(
+            gatherShape2,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+        const auto unsqueeze3 = std::make_shared<ngraph::opset6::Unsqueeze>(
+            gatherShape3,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+        const auto unsqueeze4 = std::make_shared<ngraph::opset6::Unsqueeze>(
+            gatherShape4,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+        const auto unsqueeze5 = std::make_shared<ngraph::opset6::Unsqueeze>(
+            gatherShape5,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+        const auto unsqueeze6 = std::make_shared<ngraph::opset6::Unsqueeze>(
+            gatherShape6,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
 
-    const auto concat1 = std::make_shared<ngraph::opset6::Concat>(
-        ngraph::NodeVector{unsqueeze1, unsqueeze2, unsqueeze3, ngraph::opset6::Constant::create(unsqueeze1->get_element_type(), ngraph::Shape{1}, {64})},
-        0);
-    const auto concat2 = std::make_shared<ngraph::opset6::Concat>(
-        ngraph::NodeVector{unsqueeze4, unsqueeze5, unsqueeze6, ngraph::opset6::Constant::create(unsqueeze1->get_element_type(), ngraph::Shape{1}, {64})},
-        0);
-
-    const auto reshape1 = std::make_shared<ngraph::opset6::Reshape>(
-        concat1,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {-1}),
-        false);
-    const auto reshape2 = std::make_shared<ngraph::opset6::Reshape>(
-        concat2,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {-1}),
-        false);
-
-    const auto equal1 = std::make_shared<ngraph::opset6::Equal>(
-        reshape1,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {-1, -1, -1, -1}));
-    const auto equal2 = std::make_shared<ngraph::opset6::Equal>(
-        reshape2,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {-1, -1, -1, -1}));
-
-    const auto select1 = std::make_shared<ngraph::opset6::Select>(
-        equal1,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {1, 1, 1, 1}),
-        reshape1);
-    const auto select2 = std::make_shared<ngraph::opset6::Select>(
-        equal2,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {1, 1, 1, 1}),
-        reshape2);
-
-    const auto broadcastParam1 = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::i32, ngraph::Shape{300, 1, 1, 64});
-    const auto broadcast1 = std::make_shared<ngraph::opset6::Broadcast>(broadcastParam1, select1);
-
-    const auto broadcastParam2 = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::i32, ngraph::Shape{300, 1, 1, 64});
-    const auto broadcast2 = std::make_shared<ngraph::opset6::Broadcast>(broadcastParam2, select2);
-
-    const auto gatherElements1 = std::make_shared<ngraph::opset6::GatherElements>(transpose, broadcast1, 3);
-    const auto gatherElements2 = std::make_shared<ngraph::opset6::GatherElements>(transpose, broadcast2, 3);
-
-    const auto function = std::make_shared<ngraph::Function>(
-        ngraph::OutputVector{gatherElements1->output(0), gatherElements2->output(0)},
-        ngraph::ParameterVector{imageParam, imageGatherIndices, broadcastParam1, broadcastParam2},
-        "GatherGatherElements");
-
-    ngraph::pass::Manager manager;
-    manager.register_pass<vpu::MergeGatherGatherElements>();
-    manager.run_passes(function);
-
-    return function;
-}
-
-std::shared_ptr<const ngraph::Function> reference() const {
-    const auto imageParam = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 800, 1216});
-    const auto imageGatherIndices = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::i32, ngraph::Shape{300, 64});
-
-    std::vector<std::shared_ptr<ngraph::Node>> shapes;
-    for (int i = 0; i < 6; i++) {
-        const auto gatherDataShape = std::make_shared<ngraph::opset6::ShapeOf>(imageParam, ngraph::element::i32);
-        const auto gatherIndicesShape = std::make_shared<ngraph::opset6::ShapeOf>(imageGatherIndices, ngraph::element::i32);
-
-        const auto gatherOutShape = std::make_shared<ngraph::opset6::Concat>(
-            ngraph::NodeVector{
-                std::make_shared<ngraph::opset6::Gather>(
-                    gatherDataShape,
-                    ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{2}, {0, 1}),
-                    ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0})),
-                gatherIndicesShape,
-                std::make_shared<ngraph::opset6::Gather>(
-                    gatherDataShape,
-                    ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {3}),
-                    ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}))},
+        const auto concat1 = std::make_shared<ngraph::opset6::Concat>(
+            ngraph::NodeVector{unsqueeze1, unsqueeze2, unsqueeze3, ngraph::opset6::Constant::create(unsqueeze1->get_element_type(), ngraph::Shape{1}, {64})},
+            0);
+        const auto concat2 = std::make_shared<ngraph::opset6::Concat>(
+            ngraph::NodeVector{unsqueeze4, unsqueeze5, unsqueeze6, ngraph::opset6::Constant::create(unsqueeze1->get_element_type(), ngraph::Shape{1}, {64})},
             0);
 
-        shapes.push_back(
-            std::make_shared<ngraph::opset6::Gather>(
-                gatherOutShape,
-                ngraph::opset6::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {2, 1, 3, 4}),
-                ngraph::opset6::Constant::create(ngraph::element::i64, ngraph::Shape{1}, {0})));
+        const auto reshape1 = std::make_shared<ngraph::opset6::Reshape>(
+            concat1,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {-1}),
+            false);
+        const auto reshape2 = std::make_shared<ngraph::opset6::Reshape>(
+            concat2,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {-1}),
+            false);
+
+        const auto equal1 = std::make_shared<ngraph::opset6::Equal>(
+            reshape1,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {-1, -1, -1, -1}));
+        const auto equal2 = std::make_shared<ngraph::opset6::Equal>(
+            reshape2,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {-1, -1, -1, -1}));
+
+        const auto select1 = std::make_shared<ngraph::opset6::Select>(
+            equal1,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {1, 1, 1, 1}),
+            reshape1);
+        const auto select2 = std::make_shared<ngraph::opset6::Select>(
+            equal2,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {1, 1, 1, 1}),
+            reshape2);
+
+        const auto broadcastParam1 = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::i32, ngraph::Shape{300, 1, 1, 64});
+        const auto broadcast1 = std::make_shared<ngraph::opset6::Broadcast>(broadcastParam1, select1);
+
+        const auto broadcastParam2 = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::i32, ngraph::Shape{300, 1, 1, 64});
+        const auto broadcast2 = std::make_shared<ngraph::opset6::Broadcast>(broadcastParam2, select2);
+
+        const auto gatherElements1 = std::make_shared<ngraph::opset6::GatherElements>(transpose, broadcast1, 3);
+        const auto gatherElements2 = std::make_shared<ngraph::opset6::GatherElements>(transpose, broadcast2, 3);
+
+        const auto function = std::make_shared<ngraph::Function>(
+            ngraph::OutputVector{gatherElements1->output(0), gatherElements2->output(0)},
+            ngraph::ParameterVector{imageParam, imageGatherIndices, broadcastParam1, broadcastParam2},
+            "GatherGatherElements");
+
+        ngraph::pass::Manager manager;
+        manager.register_pass<vpu::MergeGatherGatherElements>();
+        manager.run_passes(function);
+
+        return function;
     }
 
-    const auto gatherShape1 = std::make_shared<ngraph::opset6::Gather>(
-        shapes[0],
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}),
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
-    const auto gatherShape2 = std::make_shared<ngraph::opset6::Gather>(
-        shapes[1],
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {1}),
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
-    const auto gatherShape3 = std::make_shared<ngraph::opset6::Gather>(
-        shapes[2],
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {2}),
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
-    const auto gatherShape4 = std::make_shared<ngraph::opset6::Gather>(
-        shapes[3],
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}),
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
-    const auto gatherShape5 = std::make_shared<ngraph::opset6::Gather>(
-        shapes[4],
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {1}),
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
-    const auto gatherShape6 = std::make_shared<ngraph::opset6::Gather>(
-        shapes[5],
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {2}),
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+    std::shared_ptr<const ngraph::Function> reference() const {
+        const auto imageParam = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 800, 1216});
+        const auto imageGatherIndices = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::i32, ngraph::Shape{300, 64});
 
-    const auto unsqueeze1 = std::make_shared<ngraph::opset6::Unsqueeze>(
-        gatherShape1,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
-    const auto unsqueeze2 = std::make_shared<ngraph::opset6::Unsqueeze>(
-        gatherShape2,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
-    const auto unsqueeze3 = std::make_shared<ngraph::opset6::Unsqueeze>(
-        gatherShape3,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
-    const auto unsqueeze4 = std::make_shared<ngraph::opset6::Unsqueeze>(
-        gatherShape4,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
-    const auto unsqueeze5 = std::make_shared<ngraph::opset6::Unsqueeze>(
-        gatherShape5,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
-    const auto unsqueeze6 = std::make_shared<ngraph::opset6::Unsqueeze>(
-        gatherShape6,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+        std::vector<std::shared_ptr<ngraph::Node>> shapes;
+        for (int i = 0; i < 6; i++) {
+            const auto gatherDataShape = std::make_shared<ngraph::opset6::ShapeOf>(imageParam, ngraph::element::i32);
+            const auto gatherIndicesShape = std::make_shared<ngraph::opset6::ShapeOf>(imageGatherIndices, ngraph::element::i32);
 
-    const auto concat1 = std::make_shared<ngraph::opset6::Concat>(
-        ngraph::NodeVector{unsqueeze1, unsqueeze2, unsqueeze3, ngraph::opset6::Constant::create(unsqueeze1->get_element_type(), ngraph::Shape{1}, {64})},
-        0);
-    const auto concat2 = std::make_shared<ngraph::opset6::Concat>(
-        ngraph::NodeVector{unsqueeze4, unsqueeze5, unsqueeze6, ngraph::opset6::Constant::create(unsqueeze1->get_element_type(), ngraph::Shape{1}, {64})},
-        0);
+            const auto gatherOutShape = std::make_shared<ngraph::opset6::Concat>(
+                ngraph::NodeVector{
+                    std::make_shared<ngraph::opset6::Gather>(
+                        gatherDataShape,
+                        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{2}, {0, 1}),
+                        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0})),
+                    gatherIndicesShape,
+                    std::make_shared<ngraph::opset6::Gather>(
+                        gatherDataShape,
+                        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {3}),
+                        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}))},
+                0);
 
-    const auto reshape1 = std::make_shared<ngraph::opset6::Reshape>(
-        concat1,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {-1}),
-        false);
-    const auto reshape2 = std::make_shared<ngraph::opset6::Reshape>(
-        concat2,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {-1}),
-        false);
+            shapes.push_back(
+                std::make_shared<ngraph::opset6::Gather>(
+                    gatherOutShape,
+                    ngraph::opset6::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {2, 1, 3, 4}),
+                    ngraph::opset6::Constant::create(ngraph::element::i64, ngraph::Shape{1}, {0})));
+        }
 
-    const auto equal1 = std::make_shared<ngraph::opset6::Equal>(
-        reshape1,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {-1, -1, -1, -1}));
-    const auto equal2 = std::make_shared<ngraph::opset6::Equal>(
-        reshape2,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {-1, -1, -1, -1}));
+        const auto gatherShape1 = std::make_shared<ngraph::opset6::Gather>(
+            shapes[0],
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}),
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+        const auto gatherShape2 = std::make_shared<ngraph::opset6::Gather>(
+            shapes[1],
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {1}),
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+        const auto gatherShape3 = std::make_shared<ngraph::opset6::Gather>(
+            shapes[2],
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {2}),
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+        const auto gatherShape4 = std::make_shared<ngraph::opset6::Gather>(
+            shapes[3],
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}),
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+        const auto gatherShape5 = std::make_shared<ngraph::opset6::Gather>(
+            shapes[4],
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {1}),
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+        const auto gatherShape6 = std::make_shared<ngraph::opset6::Gather>(
+            shapes[5],
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {2}),
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
 
-    const auto select1 = std::make_shared<ngraph::opset6::Select>(
-        equal1,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {1, 1, 1, 1}),
-        reshape1);
-    const auto select2 = std::make_shared<ngraph::opset6::Select>(
-        equal2,
-        ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {1, 1, 1, 1}),
-        reshape2);
+        const auto unsqueeze1 = std::make_shared<ngraph::opset6::Unsqueeze>(
+            gatherShape1,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+        const auto unsqueeze2 = std::make_shared<ngraph::opset6::Unsqueeze>(
+            gatherShape2,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+        const auto unsqueeze3 = std::make_shared<ngraph::opset6::Unsqueeze>(
+            gatherShape3,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+        const auto unsqueeze4 = std::make_shared<ngraph::opset6::Unsqueeze>(
+            gatherShape4,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+        const auto unsqueeze5 = std::make_shared<ngraph::opset6::Unsqueeze>(
+            gatherShape5,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+        const auto unsqueeze6 = std::make_shared<ngraph::opset6::Unsqueeze>(
+            gatherShape6,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
 
-    const auto broadcastParam1 = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::i32, ngraph::Shape{300, 1, 1, 64});
-    const auto broadcast1 = std::make_shared<ngraph::opset6::Broadcast>(broadcastParam1, select1);
+        const auto concat1 = std::make_shared<ngraph::opset6::Concat>(
+            ngraph::NodeVector{unsqueeze1, unsqueeze2, unsqueeze3, ngraph::opset6::Constant::create(unsqueeze1->get_element_type(), ngraph::Shape{1}, {64})},
+            0);
+        const auto concat2 = std::make_shared<ngraph::opset6::Concat>(
+            ngraph::NodeVector{unsqueeze4, unsqueeze5, unsqueeze6, ngraph::opset6::Constant::create(unsqueeze1->get_element_type(), ngraph::Shape{1}, {64})},
+            0);
 
-    const auto squeezeAxis = ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0});
-    const auto transposePerm = ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {1, 0, 2, 3});
+        const auto reshape1 = std::make_shared<ngraph::opset6::Reshape>(
+            concat1,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {-1}),
+            false);
+        const auto reshape2 = std::make_shared<ngraph::opset6::Reshape>(
+            concat2,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {-1}),
+            false);
 
-    const auto transposeIndices1 = std::make_shared<ngraph::opset6::Transpose>(
-        broadcast1,
-        transposePerm);
-    const auto unsqueezeIndices1 = std::make_shared<ngraph::opset6::Unsqueeze>(
-        transposeIndices1,
-        squeezeAxis);
+        const auto equal1 = std::make_shared<ngraph::opset6::Equal>(
+            reshape1,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {-1, -1, -1, -1}));
+        const auto equal2 = std::make_shared<ngraph::opset6::Equal>(
+            reshape2,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {-1, -1, -1, -1}));
 
-    const auto broadcastParam2 = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::i32, ngraph::Shape{300, 1, 1, 64});
-    const auto broadcast2 = std::make_shared<ngraph::opset6::Broadcast>(broadcastParam2, select2);
+        const auto select1 = std::make_shared<ngraph::opset6::Select>(
+            equal1,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {1, 1, 1, 1}),
+            reshape1);
+        const auto select2 = std::make_shared<ngraph::opset6::Select>(
+            equal2,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {1, 1, 1, 1}),
+            reshape2);
 
-    const auto transposeIndices2 = std::make_shared<ngraph::opset6::Transpose>(
-        broadcast2,
-        transposePerm);
-    const auto unsqueezeIndices2 = std::make_shared<ngraph::opset6::Unsqueeze>(
-        transposeIndices2,
-        squeezeAxis);
+        const auto broadcastParam1 = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::i32, ngraph::Shape{300, 1, 1, 64});
+        const auto broadcast1 = std::make_shared<ngraph::opset6::Broadcast>(broadcastParam1, select1);
 
-    const auto expGatherElements1 = std::make_shared<ngraph::vpu::op::ExpGatherElements>(imageParam, unsqueezeIndices1, imageGatherIndices, 3, 2);
-    const auto expGatherElements2 = std::make_shared<ngraph::vpu::op::ExpGatherElements>(imageParam, unsqueezeIndices2, imageGatherIndices, 3, 2);
+        const auto squeezeAxis = ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0});
+        const auto transposePerm = ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {1, 0, 2, 3});
 
-    const auto squeezeData1 = std::make_shared<ngraph::opset6::Squeeze>(
-        expGatherElements1,
-        squeezeAxis);
-    const auto transposeData1 = std::make_shared<ngraph::opset6::Transpose>(
-        squeezeData1,
-        transposePerm);
+        const auto transposeIndices1 = std::make_shared<ngraph::opset6::Transpose>(
+            broadcast1,
+            transposePerm);
+        const auto unsqueezeIndices1 = std::make_shared<ngraph::opset6::Unsqueeze>(
+            transposeIndices1,
+            squeezeAxis);
 
-    const auto squeezeData2 = std::make_shared<ngraph::opset6::Squeeze>(
-        expGatherElements2,
-        squeezeAxis);
-    const auto transposeData2 = std::make_shared<ngraph::opset6::Transpose>(
-        squeezeData2,
-        transposePerm);
+        const auto broadcastParam2 = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::i32, ngraph::Shape{300, 1, 1, 64});
+        const auto broadcast2 = std::make_shared<ngraph::opset6::Broadcast>(broadcastParam2, select2);
 
-    return std::make_shared<ngraph::Function>(
-        ngraph::OutputVector{transposeData1->output(0), transposeData2->output(0)},
-        ngraph::ParameterVector{imageParam, imageGatherIndices, broadcastParam1, broadcastParam2},
-        "GatherGatherElements");
-}
+        const auto transposeIndices2 = std::make_shared<ngraph::opset6::Transpose>(
+            broadcast2,
+            transposePerm);
+        const auto unsqueezeIndices2 = std::make_shared<ngraph::opset6::Unsqueeze>(
+            transposeIndices2,
+            squeezeAxis);
+
+        const auto expGatherElements1 = std::make_shared<ngraph::vpu::op::ExpGatherElements>(imageParam, unsqueezeIndices1, imageGatherIndices, 3, 2);
+        const auto expGatherElements2 = std::make_shared<ngraph::vpu::op::ExpGatherElements>(imageParam, unsqueezeIndices2, imageGatherIndices, 3, 2);
+
+        const auto squeezeData1 = std::make_shared<ngraph::opset6::Squeeze>(
+            expGatherElements1,
+            squeezeAxis);
+        const auto transposeData1 = std::make_shared<ngraph::opset6::Transpose>(
+            squeezeData1,
+            transposePerm);
+
+        const auto squeezeData2 = std::make_shared<ngraph::opset6::Squeeze>(
+            expGatherElements2,
+            squeezeAxis);
+        const auto transposeData2 = std::make_shared<ngraph::opset6::Transpose>(
+            squeezeData2,
+            transposePerm);
+
+        return std::make_shared<ngraph::Function>(
+            ngraph::OutputVector{transposeData1->output(0), transposeData2->output(0)},
+            ngraph::ParameterVector{imageParam, imageGatherIndices, broadcastParam1, broadcastParam2},
+            "GatherGatherElements");
+    }
 };
 
 TEST_F(MergeGatherGatherElements, CompareFunctions) {

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/skip_tests_config.cpp
@@ -34,6 +34,8 @@ std::vector<std::string> disabledTestPatterns() {
         // TODO: Issue 47315
         ".*ProposalLayerTest.*",
         // TODO: Issue 46755
-        ".*DSR_GatherElements.*"
+        ".*DSR_GatherElements.*",
+        // TODO: Issue 46756
+        ".*smoke_Gather_GatherElements.*"
     };
 }

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/gather_gather_elements.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/gather_gather_elements.cpp
@@ -1,0 +1,136 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "dsr_tests_common.hpp"
+
+#include <ngraph/opsets/opset6.hpp>
+
+namespace {
+
+using namespace LayerTestsUtils::vpu;
+
+class Gather_GatherElements : public testing::WithParamInterface<std::string>,
+                              public DSR_TestsCommon {
+    std::shared_ptr<ngraph::Node> createTestedOp() override {
+        SetRefMode(LayerTestsUtils::RefMode::INTERPRETER);
+
+        targetDevice = GetParam();
+
+        const auto imageParam = createParameter(ngraph::element::f32, ngraph::Shape{1, 3, 800, 1216});
+        const auto imageGatherIndices = createInputSubgraphWithDSR(ngraph::element::i32, DataShapeWithUpperBound{{300, 64}, {300, 64}});
+        const auto imageGather = std::make_shared<ngraph::opset6::Gather>(
+            imageParam,
+            imageGatherIndices,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {2}));
+        const auto squeeze = std::make_shared<ngraph::opset6::Squeeze>(
+            imageGather,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+        const auto transpose = std::make_shared<ngraph::opset6::Transpose>(
+                squeeze,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {1, 0, 2, 3}));
+
+        const auto shapeOf1 = std::make_shared<ngraph::opset6::ShapeOf>(transpose, ngraph::element::i32);
+        const auto shapeOf2 = std::make_shared<ngraph::opset6::ShapeOf>(transpose, ngraph::element::i32);
+        const auto shapeOf3 = std::make_shared<ngraph::opset6::ShapeOf>(transpose, ngraph::element::i32);
+        const auto shapeOf4 = std::make_shared<ngraph::opset6::ShapeOf>(transpose, ngraph::element::i32);
+        const auto shapeOf5 = std::make_shared<ngraph::opset6::ShapeOf>(transpose, ngraph::element::i32);
+        const auto shapeOf6 = std::make_shared<ngraph::opset6::ShapeOf>(transpose, ngraph::element::i32);
+
+        const auto gatherShape1 = std::make_shared<ngraph::opset6::Gather>(
+            shapeOf1,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}),
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+        const auto gatherShape2 = std::make_shared<ngraph::opset6::Gather>(
+            shapeOf2,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {1}),
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+        const auto gatherShape3 = std::make_shared<ngraph::opset6::Gather>(
+            shapeOf3,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {2}),
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+        const auto gatherShape4 = std::make_shared<ngraph::opset6::Gather>(
+            shapeOf4,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}),
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+        const auto gatherShape5 = std::make_shared<ngraph::opset6::Gather>(
+            shapeOf5,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {1}),
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+        const auto gatherShape6 = std::make_shared<ngraph::opset6::Gather>(
+            shapeOf6,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {2}),
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{}, {0}));
+
+        const auto unsqueeze1 = std::make_shared<ngraph::opset6::Unsqueeze>(
+            gatherShape1,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+        const auto unsqueeze2 = std::make_shared<ngraph::opset6::Unsqueeze>(
+            gatherShape2,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+        const auto unsqueeze3 = std::make_shared<ngraph::opset6::Unsqueeze>(
+            gatherShape3,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+        const auto unsqueeze4 = std::make_shared<ngraph::opset6::Unsqueeze>(
+            gatherShape4,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+        const auto unsqueeze5 = std::make_shared<ngraph::opset6::Unsqueeze>(
+            gatherShape5,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+        const auto unsqueeze6 = std::make_shared<ngraph::opset6::Unsqueeze>(
+            gatherShape6,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {0}));
+
+        const auto concat1 = std::make_shared<ngraph::opset6::Concat>(
+            ngraph::NodeVector{unsqueeze1, unsqueeze2, unsqueeze3, ngraph::opset6::Constant::create(unsqueeze1->get_element_type(), ngraph::Shape{1}, {64})},
+            0);
+        const auto concat2 = std::make_shared<ngraph::opset6::Concat>(
+            ngraph::NodeVector{unsqueeze4, unsqueeze5, unsqueeze6, ngraph::opset6::Constant::create(unsqueeze1->get_element_type(), ngraph::Shape{1}, {64})},
+            0);
+
+        const auto reshape1 = std::make_shared<ngraph::opset6::Reshape>(
+            concat1,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {-1}),
+            false);
+        const auto reshape2 = std::make_shared<ngraph::opset6::Reshape>(
+            concat2,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {-1}),
+            false);
+
+        const auto equal1 = std::make_shared<ngraph::opset6::Equal>(
+            reshape1,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {-1, -1, -1, -1}));
+        const auto equal2 = std::make_shared<ngraph::opset6::Equal>(
+            reshape2,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {-1, -1, -1, -1}));
+
+        const auto select1 = std::make_shared<ngraph::opset6::Select>(
+            equal1,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {1, 1, 1, 1}),
+            reshape1);
+        const auto select2 = std::make_shared<ngraph::opset6::Select>(
+            equal2,
+            ngraph::opset6::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {1, 1, 1, 1}),
+            reshape2);
+
+        const auto broadcastParam1 = createInputSubgraphWithDSR(ngraph::element::i32, DataShapeWithUpperBound{{300, 1, 1, 64}, {300, 1, 1, 64}});
+        const auto broadcast1 = std::make_shared<ngraph::opset6::Broadcast>(broadcastParam1, select1);
+
+        const auto broadcastParam2 = createInputSubgraphWithDSR(ngraph::element::i32, DataShapeWithUpperBound{{300, 1, 1, 64}, {300, 1, 1, 64}});
+        const auto broadcast2 = std::make_shared<ngraph::opset6::Broadcast>(broadcastParam2, select2);
+
+        const auto gatherElements1 = std::make_shared<ngraph::opset6::GatherElements>(transpose, broadcast1, 3);
+        const auto gatherElements2 = std::make_shared<ngraph::opset6::GatherElements>(transpose, broadcast2, 3);
+
+        m_additionalResults.push_back(std::make_shared<ngraph::opset6::Result>(gatherElements1));
+        return gatherElements2;
+    }
+};
+
+TEST_P(Gather_GatherElements, CompareWithReference) {
+    Run();
+}
+
+INSTANTIATE_TEST_CASE_P(smoke_Gather_GatherElements, Gather_GatherElements, testing::Values(CommonTestUtils::DEVICE_MYRIAD));
+
+} // namespace

--- a/inference-engine/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
@@ -339,8 +339,12 @@ void LayerTestsCommon::Infer() {
     inferRequest = executableNetwork.CreateInferRequest();
     inputs.clear();
 
-    for (const auto &input : executableNetwork.GetInputsInfo()) {
-        const auto &info = input.second;
+    const auto& inputsInfo = executableNetwork.GetInputsInfo();
+    for (const auto& param : function->get_parameters()) {
+        const auto infoIt = inputsInfo.find(param->get_friendly_name());
+        IE_ASSERT(infoIt != inputsInfo.cend());
+
+        const auto& info = infoIt->second;
         auto blob = GenerateInput(*info);
         inferRequest.SetBlob(info->name(), blob);
         inputs.push_back(blob);

--- a/inference-engine/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
@@ -342,7 +342,7 @@ void LayerTestsCommon::Infer() {
     const auto& inputsInfo = executableNetwork.GetInputsInfo();
     for (const auto& param : function->get_parameters()) {
         const auto infoIt = inputsInfo.find(param->get_friendly_name());
-        IE_ASSERT(infoIt != inputsInfo.cend());
+        GTEST_ASSERT_NE(infoIt, inputsInfo.cend());
 
         const auto& info = infoIt->second;
         auto blob = GenerateInput(*info);

--- a/inference-engine/tests/functional/shared_test_classes/src/single_layer/squeeze_unsqueeze.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/single_layer/squeeze_unsqueeze.cpp
@@ -39,7 +39,7 @@ void SqueezeUnsqueezeLayerTest::SetUp() {
     std::tie(inputShapes, axesVector) = shapeItem;
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShapes});
-    auto squeeze = ngraph::builder::makeSqueezeUnsqueeze(params.front(), ngPrc, axesVector, opType);
+    auto squeeze = ngraph::builder::makeSqueezeUnsqueeze(params.front(), ngraph::element::i64, axesVector, opType);
     const ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(squeeze)};
     function = std::make_shared<ngraph::Function>(results, params, "Squeeze");
 }

--- a/inference-engine/tests/functional/shared_test_classes/src/subgraph/cascade_concat.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/subgraph/cascade_concat.cpp
@@ -39,8 +39,8 @@ void CascadeConcat::SetUp() {
     auto concat = std::make_shared<ngraph::opset1::Concat>(ngraph::OutputVector{relu1->output(0),
                                                                                 relu2->output(0)},
                                                                                 1);
-    auto reshape = ngraph::builder::makeSqueezeUnsqueeze(concat, ngPrc, {0}, ngraph::helpers::SqueezeOpType::UNSQUEEZE);
-    auto reshape2 = ngraph::builder::makeSqueezeUnsqueeze(reshape, ngPrc, {0}, ngraph::helpers::SqueezeOpType::SQUEEZE);
+    auto reshape = ngraph::builder::makeSqueezeUnsqueeze(concat, ngraph::element::i64, {0}, ngraph::helpers::SqueezeOpType::UNSQUEEZE);
+    auto reshape2 = ngraph::builder::makeSqueezeUnsqueeze(reshape, ngraph::element::i64, {0}, ngraph::helpers::SqueezeOpType::SQUEEZE);
     auto concat2 = std::make_shared<ngraph::opset1::Concat>(ngraph::OutputVector{reshape2->output(0),
                                                                                  relu3->output(0)},
                                                                                  1);

--- a/inference-engine/tests/functional/shared_test_classes/src/subgraph/multioutput_eltwise_squeeze_eltwise.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/subgraph/multioutput_eltwise_squeeze_eltwise.cpp
@@ -31,8 +31,8 @@ namespace SubgraphTestsDefinitions {
                                                     ngraph::Shape{input[0]->get_shape()},
                                                      std::vector<float>{-1.0f});
         auto eltwise = std::make_shared<ngraph::opset1::Multiply>(input[0], eltwise_const);
-        auto squeeze = ngraph::builder::makeSqueezeUnsqueeze(eltwise, ngPrc, {0}, ngraph::helpers::SqueezeOpType::UNSQUEEZE);
-        auto unsqueeze = ngraph::builder::makeSqueezeUnsqueeze(squeeze, ngPrc, {0}, ngraph::helpers::SqueezeOpType::SQUEEZE);
+        auto squeeze = ngraph::builder::makeSqueezeUnsqueeze(eltwise, ngraph::element::i64, {0}, ngraph::helpers::SqueezeOpType::UNSQUEEZE);
+        auto unsqueeze = ngraph::builder::makeSqueezeUnsqueeze(squeeze, ngraph::element::i64, {0}, ngraph::helpers::SqueezeOpType::SQUEEZE);
         auto eltwise_const2 = ngraph::builder::makeConstant(ngPrc, ngraph::Shape{1}, std::vector<float>{1.01f});
         auto eltwise_const3 = ngraph::builder::makeConstant(ngPrc, ngraph::Shape{1}, std::vector<float>{1.01f});
         auto eltwise2 = std::make_shared<ngraph::opset1::Multiply>(eltwise, eltwise_const2);

--- a/inference-engine/tests/functional/shared_test_classes/src/subgraph/reshape_squeeze_reshape_relu.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/subgraph/reshape_squeeze_reshape_relu.cpp
@@ -34,7 +34,7 @@ namespace SubgraphTestsDefinitions {
                                                                        ngraph::Shape{squeezeShape.first.size()},
                                                                        squeezeShape.first);
         auto reshape1 = std::make_shared<ngraph::op::v1::Reshape>(input[0], reshape1_pattern, false);
-        auto squeeze = ngraph::builder::makeSqueezeUnsqueeze(reshape1, ngPrc, squeezeShape.second, opType);
+        auto squeeze = ngraph::builder::makeSqueezeUnsqueeze(reshape1, ngraph::element::i64, squeezeShape.second, opType);
         auto reshape2_pattern = std::make_shared<ngraph::op::Constant>(ngraph::element::i64,
                                                                        ngraph::Shape{2},
                                                                        std::vector<size_t>{1, input_dim});

--- a/ngraph/core/src/op/squeeze.cpp
+++ b/ngraph/core/src/op/squeeze.cpp
@@ -153,15 +153,19 @@ namespace squeeze
     {
         const auto data_rank = arg0->get_partial_shape().rank().get_length();
         const auto axes_num = shape_size(arg1->get_shape());
-        auto axes = normalize_axes(
+        auto norm_axes = normalize_axes(
             "",
             std::vector<int64_t>(arg1->get_data_ptr<ET>(), arg1->get_data_ptr<ET>() + axes_num),
             data_rank);
-        std::sort(axes.begin(), axes.end(), [](int64_t a, int64_t b) { return a > b; });
+        set<size_t, greater<size_t>> ordered_axes(norm_axes.begin(), norm_axes.end());
 
         auto out_shape = arg0->get_shape();
-        for (const auto& axis : axes)
+        for (const auto& axis : ordered_axes)
         {
+            if (out_shape[axis] != 1)
+            {
+                throw ngraph_error("Squeeze dimension is not equal to 1");
+            }
             out_shape.erase(out_shape.begin() + axis);
         }
         out->set_shape(out_shape);

--- a/ngraph/core/src/op/squeeze.cpp
+++ b/ngraph/core/src/op/squeeze.cpp
@@ -149,10 +149,26 @@ shared_ptr<Node> op::Squeeze::clone_with_new_inputs(const OutputVector& new_args
 namespace squeeze
 {
     template <element::Type_t ET>
-    bool evaluate(const HostTensorPtr& arg0, const HostTensorPtr& out)
+    bool evaluate(const HostTensorPtr& arg0, const HostTensorPtr& arg1, const HostTensorPtr& out)
     {
-        runtime::reference::copy(
-            arg0->get_data_ptr<ET>(), out->get_data_ptr<ET>(), shape_size(out->get_shape()));
+        const auto data_rank = arg0->get_partial_shape().rank().get_length();
+        const auto axes_num = shape_size(arg1->get_shape());
+        auto axes = normalize_axes(
+            "",
+            std::vector<int64_t>(arg1->get_data_ptr<ET>(), arg1->get_data_ptr<ET>() + axes_num),
+            data_rank);
+        std::sort(axes.begin(), axes.end(), [](int64_t a, int64_t b) { return a > b; });
+
+        auto out_shape = arg0->get_shape();
+        for (const auto& axis : axes)
+        {
+            out_shape.erase(out_shape.begin() + axis);
+        }
+        out->set_shape(out_shape);
+
+        runtime::reference::copy(arg0->get_data_ptr<char>(),
+                                 out->get_data_ptr<char>(),
+                                 shape_size(out_shape) * out->get_element_type().size());
         return true;
     }
 
@@ -160,17 +176,13 @@ namespace squeeze
                           const HostTensorPtr& arg1,
                           const HostTensorPtr& out)
     {
-        auto element_type = arg0->get_element_type();
+        auto element_type = arg1->get_element_type();
 
         bool rc = true;
         switch (element_type)
         {
-            NGRAPH_TYPE_CASE(evaluate_squeeze, i32, arg0, out);
-            NGRAPH_TYPE_CASE(evaluate_squeeze, i64, arg0, out);
-            NGRAPH_TYPE_CASE(evaluate_squeeze, u32, arg0, out);
-            NGRAPH_TYPE_CASE(evaluate_squeeze, u64, arg0, out);
-            NGRAPH_TYPE_CASE(evaluate_squeeze, f16, arg0, out);
-            NGRAPH_TYPE_CASE(evaluate_squeeze, f32, arg0, out);
+            NGRAPH_TYPE_CASE(evaluate_squeeze, i32, arg0, arg1, out);
+            NGRAPH_TYPE_CASE(evaluate_squeeze, i64, arg0, arg1, out);
         default: rc = false; break;
         }
         return rc;


### PR DESCRIPTION
Ticket - #-47166
Changes:
- Introduce transformation to merge `Gather->Squeeze->Transpose->GatherElements` in order to hide the intermediate tensor between `Gather` and `GatherElements` which may have very big size (e.g. ~`140mb`).
- Introduce `ExpGatherElements` operation to express merged `Gather` and `GatherElements` and DTS for it.
- Fix allocator for dynamic inputs that have more than one consumers (in this case we do deallocation only once at the end of the allocation process, while `inUse` for it is more than 1).
- Correct the order of generating inputs in test suite. For some networks with big number of parameters, the order of inputs in `function->get_parameters` and `executableNetwork.GetInputsInfo()` may vary. We generate inputs according `executableNetwork.GetInputsInfo()`, while we are comparing the inputs according to `function->get_parameters which may lead to inputs mismatch.
- Calculate output shape in `Squeeze::evaluate()` function according to the inputs' shapes from inputs' `HostTensor`'s. It's needed to enable testing when `Squeeze` has dynamic output shape.