### PR TITLE
[IE][VPU]: Enables WA for Loop creation

### DIFF
--- a/inference-engine/src/vpu/common/src/ngraph/transformations/extract_dynamic_batch/extract_dynamic_batch.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/extract_dynamic_batch/extract_dynamic_batch.cpp
@@ -342,6 +342,7 @@ std::shared_ptr<ngraph::opset5::Loop> makeLoop(ngraph::Node* root, ngraph::Node*
     results.emplace_back(std::make_shared<ngraph::opset5::Result>(iterationCondition));
     auto body = std::make_shared<ngraph::Function>(results, parameters, "body");
     loop->set_function(body);
+    loop->set_special_body_ports({-1, static_cast<std::int64_t>(results.size()) - 1});
     for (const auto& entry : slicedInputs) {
         loop->set_sliced_input(entry.first, entry.second, 0, 1, 1, -1, 0);
     }
@@ -358,7 +359,6 @@ std::shared_ptr<ngraph::opset5::Loop> makeLoop(ngraph::Node* root, ngraph::Node*
         loop->get_concatenated_slices(entry, 0, 1, 1, -1, 0);
     }
 
-    loop->set_special_body_ports({-1, static_cast<std::int64_t>(results.size()) - 1});
     loop->validate_and_infer_types();
     return loop;
 }


### PR DESCRIPTION
# Description

`Loop` operation constructor call is not sufficient to create Loop operation, such methods as `set_special_body_ports`, `set_sliced_input` and other may need to be called as well. `set_special_body_ports` must always be called since it specifies required attribute `body_condition_output_idx`. If it has not been done before `validate_and_infer_types` call - exception will be thrown that this required attribute is not set.

Recently, `validate_and_infer_types` call has been added to `set_sliced_input` implementation. As a result, if `Loop` has sliced
inputs, they must be specified not earlier `set_special_body_ports`, otherwise program will fail.

# Task

#-48092