### PR TITLE
Add missing header for std::tolower

### DIFF
--- a/ngraph/core/src/op/util/attr_types.cpp
+++ b/ngraph/core/src/op/util/attr_types.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //*****************************************************************************
 #include <map>
+#include <cctype>
 
 #include "ngraph/attribute_visitor.hpp"
 #include "ngraph/check.hpp"

--- a/ngraph/core/src/op/util/attr_types.cpp
+++ b/ngraph/core/src/op/util/attr_types.cpp
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //*****************************************************************************
-#include <map>
 #include <cctype>
+#include <map>
 
 #include "ngraph/attribute_visitor.hpp"
 #include "ngraph/check.hpp"


### PR DESCRIPTION
Missing header causes syntax error when compiling for Windows using Visual studio 2017. Closes #4155