### PR TITLE
[CPU BF16] OneHot layer extended with bf16 support.

### DIFF
--- a/inference-engine/src/mkldnn_plugin/bf16transformer.h
+++ b/inference-engine/src/mkldnn_plugin/bf16transformer.h
@@ -23,7 +23,7 @@ class BF16Transformer {
           "broadcast", "convert", "BatchToSpace", "DepthToSpace", "ExtractImagePatches", "concat", "power", "lrn",
           "permute", "ScatterUpdate", "ScatterElementsUpdate", "ScatterNDUpdate", "depthwise",
           "select", "ShuffleChannels", "SpaceToBatch", "SpaceToDepth", "squeeze", "StridedSlice", "unsqueeze", "eltwise",
-          "ReduceAnd", "ReduceOr", "ReduceMax", "ReduceMin", "ScaleShift", "SoftMax"};
+          "ReduceAnd", "ReduceOr", "ReduceMax", "ReduceMin", "ScaleShift", "SoftMax", "OneHot"};
 
     const InferenceEngine::details::caseless_set<std::string> _multiinput =
         { "concat", "eltwise" };

--- a/inference-engine/src/mkldnn_plugin/nodes/one_hot.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/one_hot.cpp
@@ -11,8 +11,6 @@
 
 #include <vector>
 
-using namespace dnnl::impl::utils;
-
 namespace InferenceEngine {
 namespace Extensions {
 namespace Cpu {

--- a/inference-engine/src/mkldnn_plugin/nodes/one_hot.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/one_hot.cpp
@@ -90,13 +90,14 @@ private:
         std::fill(dst_data, dst_data + dst_size, static_cast<out_type>(off_value));
 
         // set on_value at needed locations
+        auto on_val = static_cast<out_type>(on_value);
         parallel_for(prefix_size, [&](std::size_t prefix_idx) {
-            for (std::size_t suffix_idx = 0; suffix_idx < suffix_size; ++suffix_idx) {
-                auto src_index = prefix_idx * suffix_size + suffix_idx;
-                auto v = static_cast<std::size_t>(src_data[src_index]);
+            const in_type* src_dataPtr = &src_data[prefix_idx * suffix_size];
+            out_type* dst_dataPtr = &dst_data[prefix_idx * depth * suffix_size];
+            for (std::size_t suffix_idx = 0; suffix_idx < suffix_size; ++suffix_idx, ++src_dataPtr, ++dst_dataPtr) {
+                auto v = static_cast<std::size_t>(*src_dataPtr);
                 if (v < depth) {
-                    std::size_t dst_offset = prefix_idx * depth * suffix_size + v * suffix_size + suffix_idx;
-                    dst_data[dst_offset] = on_value;
+                    dst_dataPtr[v * suffix_size] = on_val;
                 }
             }
         });

--- a/inference-engine/src/mkldnn_plugin/nodes/one_hot.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/one_hot.cpp
@@ -4,8 +4,13 @@
 
 #include "base.hpp"
 #include "ie_parallel.hpp"
+#include "common/utils.hpp"
+#include "utils/bfloat16.hpp"
+#include <mkldnn_selective_build.h>
 
 #include <vector>
+
+using namespace dnnl::impl::utils;
 
 namespace InferenceEngine {
 namespace Extensions {
@@ -36,38 +41,41 @@ public:
 
             // check a precision of the input tensor
             input_precision = layer->insData[0].lock()->getTensorDesc().getPrecision();
-            if (input_precision == Precision::BF16)
-                input_precision = Precision::FP32;
-            if (input_precision != Precision::I32 && input_precision != Precision::FP32) {
-                THROW_IE_EXCEPTION << layer->name << " Incorrect input precision for the input. Only I32 and FP32 are supported!";
+            if (!one_of(input_precision, Precision::I32, Precision::FP32, Precision::BF16)) {
+                THROW_IE_EXCEPTION << layer->name << " Incorrect input precision for the input. Only I32, FP32 and BF16 are supported!";
+            }
+            output_precision = layer->outData[0]->getTensorDesc().getPrecision();
+            if (!one_of(output_precision, Precision::FP32, Precision::BF16)) {
+                THROW_IE_EXCEPTION << layer->name << " Incorrect precision for the output. Only FP32 and BF16 are supported!";
             }
 
-            addConfig(layer, { DataConfigurator(ConfLayout::PLN) }, { DataConfigurator(ConfLayout::PLN) });
+            addConfig(layer, { DataConfigurator(ConfLayout::PLN, input_precision) }, { DataConfigurator(ConfLayout::PLN, output_precision) });
         } catch (InferenceEngine::details::InferenceEngineException &ex) {
             errorMsg = ex.what();
         }
     }
 
     StatusCode execute(std::vector<Blob::Ptr>& inputs, std::vector<Blob::Ptr>& outputs, ResponseDesc *resp) noexcept override {
-        switch (input_precision) {
-            case Precision::FP32:
-                one_hot<float>(inputs[0], outputs[0]);
-                break;
-            case Precision::I32:
-                one_hot<int>(inputs[0], outputs[0]);
-                break;
-            default:
-                return GENERAL_ERROR;
-        }
+        OneHotContext ctx = {this, inputs[0], outputs[0], false};
+        OV_SWITCH(MKLDNNPlugin, OneHotExecute, ctx, std::tie(input_precision, output_precision),
+                  OV_CASE2(Precision::FP32, Precision::FP32, float, float),
+                  OV_CASE2(Precision::I32, Precision::FP32, int, float),
+                  OV_CASE2(Precision::BF16, Precision::FP32, MKLDNNPlugin::bfloat16_t, float),
+                  OV_CASE2(Precision::FP32, Precision::BF16, float, MKLDNNPlugin::bfloat16_t),
+                  OV_CASE2(Precision::I32, Precision::BF16, int, MKLDNNPlugin::bfloat16_t),
+                  OV_CASE2(Precision::BF16, Precision::BF16, MKLDNNPlugin::bfloat16_t, MKLDNNPlugin::bfloat16_t))
 
+        if (!ctx.executed) {
+            return GENERAL_ERROR;
+        }
         return OK;
     }
 
 private:
-    template <typename in_type>
+    template <typename in_type, typename out_type>
     void one_hot(Blob::Ptr input, Blob::Ptr output) {
         const auto *src_data = input->cbuffer().as<const in_type *>();
-        auto *dst_data = output->buffer().as<float *>();
+        auto *dst_data = output->buffer().as<out_type *>();
         std::size_t prefix_size = 1;
         auto input_dims = input->getTensorDesc().getDims();
 
@@ -85,7 +93,7 @@ private:
         parallel_for(prefix_size, [&](std::size_t prefix_idx) {
             for (std::size_t suffix_idx = 0; suffix_idx < suffix_size; ++suffix_idx) {
                 auto src_index = prefix_idx * suffix_size + suffix_idx;
-                std::size_t v = static_cast<std::size_t>(src_data[src_index]);
+                auto v = static_cast<std::size_t>(src_data[src_index]);
                 if (v < depth) {
                     std::size_t dst_offset = prefix_idx * depth * suffix_size + v * suffix_size + suffix_idx;
                     dst_data[dst_offset] = on_value;
@@ -93,6 +101,24 @@ private:
             }
         });
     }
+
+    struct OneHotContext {
+        OneHotImpl* nodePtr;
+        Blob::Ptr input;
+        Blob::Ptr output;
+        bool executed;
+    };
+
+    template<typename T>
+    struct OneHotExecute {
+        using src_t = typename std::tuple_element<0, T>::type;
+        using dst_t = typename std::tuple_element<1, T>::type;
+
+        void operator()(OneHotContext & ctx) {
+            ctx.nodePtr->one_hot<src_t, dst_t>(ctx.input, ctx.output);
+            ctx.executed = true;
+        }
+    };
 
     uint32_t depth;
     float on_value = 1.f;
@@ -102,6 +128,7 @@ private:
     SizeVector dst_dims;
 
     Precision input_precision;
+    Precision output_precision;
 };
 
 REG_FACTORY_FOR(OneHotImpl, OneHot);

--- a/inference-engine/src/mkldnn_plugin/nodes/one_hot.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/one_hot.cpp
@@ -87,7 +87,7 @@ private:
 
         // fill the output with off_value
         std::size_t dst_size = prefix_size * depth * suffix_size;
-        std::fill(dst_data, dst_data + dst_size, off_value);
+        std::fill(dst_data, dst_data + dst_size, static_cast<out_type>(off_value));
 
         // set on_value at needed locations
         parallel_for(prefix_size, [&](std::size_t prefix_idx) {

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/one_hot.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/one_hot.cpp
@@ -1,0 +1,166 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <ngraph_functions/builders.hpp>
+#include "test_utils/cpu_test_utils.hpp"
+
+using namespace InferenceEngine;
+using namespace CPUTestUtils;
+
+namespace CPULayerTestsDefinitions {
+
+typedef std::tuple<
+        std::vector<size_t>,       // Input shape
+        int,                       // axis to extend
+        size_t,                    // depth
+        float,                     // on_value
+        float,                     // off_value
+        InferenceEngine::Precision,// Net precision
+        InferenceEngine::Precision,// Input precision
+        InferenceEngine::Precision,// Output precision
+        std::string,               // Target device name
+        CPUSpecificParams
+> oneHotCPUTestParams;
+
+class OneHotLayerCPUTest : public testing::WithParamInterface<oneHotCPUTestParams>,
+                           virtual public LayerTestsUtils::LayerTestsCommon, public CPUTestsBase {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<oneHotCPUTestParams>& obj) {
+        InferenceEngine::SizeVector inputShape;
+        int axis;
+        size_t depth;
+        float onValue, offValue;
+        InferenceEngine::Precision netPrecision;
+        InferenceEngine::Precision inPrc, outPrc;
+        std::string targetDevice;
+        CPUSpecificParams cpuParams;
+        std::tie(inputShape, axis, depth, onValue, offValue, netPrecision, inPrc, outPrc, targetDevice, cpuParams) = obj.param;
+
+        std::ostringstream result;
+        result << "IS=" << CommonTestUtils::vec2str(inputShape) << "_";
+        result << "axis=" << axis << "_";
+        result << "depth=" << depth << "_";
+        result << "OnVal=" << onValue << "_";
+        result << "OffVal=" << offValue << "_";
+        result << "netPRC=" << netPrecision.name() << "_";
+        result << "inPRC=" << inPrc.name() << "_";
+        result << "outPRC=" << outPrc.name() << "_";
+        result << "trgDev=" << targetDevice;
+        result << CPUTestsBase::getTestCaseName(cpuParams);
+        return result.str();
+    }
+protected:
+    void SetUp() override {
+        ngraph::Shape inputShape;
+        int axis;
+        size_t depth;
+        float onValue, offValue;
+        InferenceEngine::Precision netPrecision;
+        CPUSpecificParams cpuParams;
+
+        std::tie(inputShape, axis, depth, onValue, offValue, netPrecision, inPrc, outPrc, targetDevice, cpuParams) = this->GetParam();
+        std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
+        selectedType = std::string("unknown_") + inPrc.name();
+
+        auto depthConst = ngraph::builder::makeConstant<size_t>(ngraph::element::i32, {}, {depth});
+        auto onConst = ngraph::builder::makeConstant<float>(ngraph::element::f32, {}, {onValue});
+        auto offConst = ngraph::builder::makeConstant<float>(ngraph::element::f32, {}, {offValue});
+
+        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+        auto inputParams = ngraph::builder::makeParams(ngPrc, { inputShape });
+
+        auto oneHot = std::make_shared<ngraph::opset5::OneHot>(inputParams.front(), depthConst, onConst, offConst, axis);
+        function = makeNgraphFunction(ngPrc, inputParams, oneHot, "OneHot");
+    }
+};
+
+TEST_P(OneHotLayerCPUTest, CompareWithRefs) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    Run();
+    CheckPluginRelatedResults(executableNetwork, "OneHot");
+}
+
+namespace {
+const std::vector<Precision> inPrc = {Precision::FP32, Precision::I32, Precision::BF16};
+const std::vector<Precision> outPrc = {Precision::FP32, Precision::BF16};
+
+// 0d -> 1d, depth
+const auto testCase_1d = ::testing::Combine(
+        ::testing::Values(std::vector<size_t>{}),
+        ::testing::Values(-1, 0),
+        ::testing::Values(3, 4),
+        ::testing::Values(1.f),
+        ::testing::Values(0.f),
+        ::testing::Values(Precision::I32),
+        ::testing::ValuesIn(inPrc),
+        ::testing::ValuesIn(outPrc),
+        ::testing::Values(CommonTestUtils::DEVICE_CPU),
+        ::testing::Values(emptyCPUSpec)
+);
+INSTANTIATE_TEST_CASE_P(smoke_OneHotCPU_1D, OneHotLayerCPUTest, testCase_1d, OneHotLayerCPUTest::getTestCaseName);
+
+
+// 1d -> 2d, axis default
+const auto testCase_2d = ::testing::Combine(
+        ::testing::Values(std::vector<size_t>{3}),
+        ::testing::Values(-1, 0, 1),
+        ::testing::Values(6),
+        ::testing::Values(1.f),
+        ::testing::Values(0.f),
+        ::testing::Values(Precision::I32),
+        ::testing::ValuesIn(inPrc),
+        ::testing::ValuesIn(outPrc),
+        ::testing::Values(CommonTestUtils::DEVICE_CPU),
+        ::testing::Values(emptyCPUSpec)
+);
+INSTANTIATE_TEST_CASE_P(smoke_OneHotCPU_2D, OneHotLayerCPUTest, testCase_2d, OneHotLayerCPUTest::getTestCaseName);
+
+// 2d -> 3d, on_value, off_value
+const auto testCase_3d = ::testing::Combine(
+        ::testing::Values(std::vector<size_t>{3, 2}),
+        ::testing::Values(-1, 0, 1),
+        ::testing::Values(4),
+        ::testing::Values(2.f),
+        ::testing::Values(-1.f),
+        ::testing::Values(Precision::I32),
+        ::testing::ValuesIn(inPrc),
+        ::testing::ValuesIn(outPrc),
+        ::testing::Values(CommonTestUtils::DEVICE_CPU),
+        ::testing::Values(emptyCPUSpec)
+);
+INSTANTIATE_TEST_CASE_P(smoke_OneHotCPU_3D, OneHotLayerCPUTest, testCase_3d, OneHotLayerCPUTest::getTestCaseName);
+
+// 3d -> 4d
+const auto testCase_4d = ::testing::Combine(
+        ::testing::Values(std::vector<size_t>{1, 3, 2}),
+        ::testing::Values(-1, 0, 1, 2),
+        ::testing::Values(4),
+        ::testing::Values(1.f),
+        ::testing::Values(0.f),
+        ::testing::Values(Precision::I32),
+        ::testing::ValuesIn(inPrc),
+        ::testing::ValuesIn(outPrc),
+        ::testing::Values(CommonTestUtils::DEVICE_CPU),
+        ::testing::Values(emptyCPUSpec)
+);
+INSTANTIATE_TEST_CASE_P(smoke_OneHotCPU_4D, OneHotLayerCPUTest, testCase_4d, OneHotLayerCPUTest::getTestCaseName);
+
+// 4d -> 5d
+const auto testCase_5d = ::testing::Combine(
+        ::testing::Values(std::vector<size_t>{1, 3, 2, 3}),
+        ::testing::Values(-1, 0, 1, 2, 3),
+        ::testing::Values(4),
+        ::testing::Values(1.f),
+        ::testing::Values(0.f),
+        ::testing::Values(Precision::I32),
+        ::testing::ValuesIn(inPrc),
+        ::testing::ValuesIn(outPrc),
+        ::testing::Values(CommonTestUtils::DEVICE_CPU),
+        ::testing::Values(emptyCPUSpec)
+);
+INSTANTIATE_TEST_CASE_P(smoke_OneHotCPU_5D, OneHotLayerCPUTest, testCase_5d, OneHotLayerCPUTest::getTestCaseName);
+
+} // namespace
+} // namespace CPULayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/one_hot.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/one_hot.cpp
@@ -83,8 +83,8 @@ TEST_P(OneHotLayerCPUTest, CompareWithRefs) {
 }
 
 namespace {
-const std::vector<Precision> inPrc = {Precision::FP32, Precision::I32, Precision::BF16};
-const std::vector<Precision> outPrc = {Precision::FP32, Precision::BF16};
+const std::vector<Precision> inPrc = {Precision::I32};
+const std::vector<Precision> outPrc = {Precision::FP32, Precision::BF16, Precision::I8, Precision::U8};
 
 // 0d -> 1d, depth
 const auto testCase_1d = ::testing::Combine(

--- a/inference-engine/tests_deprecated/unit/engines/mkldnn/graph/layers/extensions/onehot_tests.cpp
+++ b/inference-engine/tests_deprecated/unit/engines/mkldnn/graph/layers/extensions/onehot_tests.cpp
@@ -32,9 +32,9 @@ class OneHotOnly1dTest: public TestsCommon,
                        public WithParamInterface<one_hot_test_params> {
 
     std::string model_t = R"V0G0N(
-<net name="OneHot_Only" version="2" precision="FP32" batch="1">
+<net name="OneHot_Only" version="2" precision="I32" batch="1">
     <layers>
-        <layer id="1" name="input" precision="FP32" type="Input">
+        <layer id="1" name="input" precision="I32" type="Input">
             <output>
                 <port id="0">
                     <dim>1</dim>
@@ -160,9 +160,9 @@ class OneHotOnly2dTest: public TestsCommon,
                        public WithParamInterface<one_hot_test_params> {
 
     std::string model_t = R"V0G0N(
-<net name="OneHot_Only" version="2" precision="FP32" batch="1">
+<net name="OneHot_Only" version="2" precision="I32" batch="1">
     <layers>
-        <layer id="1" name="input" precision="FP32" type="Input">
+        <layer id="1" name="input" precision="I32" type="Input">
             <output>
                 <port id="0">
                     <dim>_IW_</dim>
@@ -303,9 +303,9 @@ class OneHotOnly3dTest: public TestsCommon,
                        public WithParamInterface<one_hot_test_params> {
 
     std::string model_t = R"V0G0N(
-<net name="OneHot_Only" version="2" precision="FP32" batch="1">
+<net name="OneHot_Only" version="2" precision="I32" batch="1">
     <layers>
-        <layer id="1" name="input" precision="FP32" type="Input">
+        <layer id="1" name="input" precision="I32" type="Input">
             <output>
                 <port id="0">
                     <dim>_IH_</dim>
@@ -454,9 +454,9 @@ class OneHotOnly4dTest: public TestsCommon,
                        public WithParamInterface<one_hot_test_params> {
 
     std::string model_t = R"V0G0N(
-<net name="OneHot_Only" version="2" precision="FP32" batch="1">
+<net name="OneHot_Only" version="2" precision="I32" batch="1">
     <layers>
-        <layer id="1" name="input" precision="FP32" type="Input">
+        <layer id="1" name="input" precision="I32" type="Input">
             <output>
                 <port id="0">
                     <dim>_IC_</dim>
@@ -615,9 +615,9 @@ class OneHotOnly5dTest: public TestsCommon,
                        public WithParamInterface<one_hot_test_params> {
 
     std::string model_t = R"V0G0N(
-<net name="OneHot_Only" version="2" precision="FP32" batch="1">
+<net name="OneHot_Only" version="2" precision="I32" batch="1">
     <layers>
-        <layer id="1" name="input" precision="FP32" type="Input">
+        <layer id="1" name="input" precision="I32" type="Input">
             <output>
                 <port id="0">
                     <dim>_IN_</dim>


### PR DESCRIPTION
The OneHot layer has been extended with bf16 support mainly to fix some functional issues of enabling greedy mode.