### PR TITLE
DPC++ link error workaround.

### DIFF
--- a/inference-engine/include/ie_blob.h
+++ b/inference-engine/include/ie_blob.h
@@ -577,13 +577,14 @@ public:
     /**
      *@brief Virtual destructor.
      */
-//#ifdef __clang__
-//    virtual ~TBlob();
-//#else
+#ifdef __clang__
+    virtual ~TBlob() {};
+#else
     virtual ~TBlob() {
         free();
     }
-//#endif  // __clang__
+#endif  // __clang__
+
 
     /**
      * @brief Gets the size of the given type.
@@ -805,22 +806,7 @@ protected:
         _handle = origBlob._handle;
     }
 };
-/*
-#ifdef __clang__
-extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<float>);
-extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<double>);
-extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<int8_t>);
-extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<uint8_t>);
-extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<int16_t>);
-extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<uint16_t>);
-extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<int32_t>);
-extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<uint32_t>);
-extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<long>);
-extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<long long>);
-extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<unsigned long>);
-extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<unsigned long long>);
-#endif  // __clang__
-*/
+
 /**
  * @brief Creates a blob with the given tensor descriptor.
  *

--- a/inference-engine/include/ie_blob.h
+++ b/inference-engine/include/ie_blob.h
@@ -577,14 +577,19 @@ public:
     /**
      *@brief Virtual destructor.
      */
-#ifdef __clang__
-    virtual ~TBlob() {};
-#else
+#ifdef __SYCL_COMPILER_VERSION
     virtual ~TBlob() {
         free();
     }
-#endif  // __clang__
-
+#else
+#  ifdef __clang__
+    virtual ~TBlob();
+#  else
+    virtual ~TBlob() {
+        free();
+    }
+#  endif  // __clang__
+#endif  // __SYCL_COMPILER_VERSION
 
     /**
      * @brief Gets the size of the given type.
@@ -806,6 +811,23 @@ protected:
         _handle = origBlob._handle;
     }
 };
+
+#ifndef __SYCL_COMPILER_VERSION
+#ifdef __clang__
+extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<float>);
+extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<double>);
+extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<int8_t>);
+extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<uint8_t>);
+extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<int16_t>);
+extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<uint16_t>);
+extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<int32_t>);
+extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<uint32_t>);
+extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<long>);
+extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<long long>);
+extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<unsigned long>);
+extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<unsigned long long>);
+#endif  // __clang__
+#endif  // __SYCL_COMPILER_VERSION
 
 /**
  * @brief Creates a blob with the given tensor descriptor.

--- a/inference-engine/include/ie_blob.h
+++ b/inference-engine/include/ie_blob.h
@@ -577,19 +577,14 @@ public:
     /**
      *@brief Virtual destructor.
      */
-#ifdef __SYCL_COMPILER_VERSION
-    virtual ~TBlob() {
-        free();
-    }
-#else
-#  ifdef __clang__
+
+#if defined(__clang__) && !defined(__SYCL_COMPILER_VERSION)
     virtual ~TBlob();
-#  else
+#else
     virtual ~TBlob() {
         free();
     }
-#  endif  // __clang__
-#endif  // __SYCL_COMPILER_VERSION
+#endif  // __clang__ && !__SYCL_COMPILER_VERSION
 
     /**
      * @brief Gets the size of the given type.
@@ -812,8 +807,7 @@ protected:
     }
 };
 
-#ifndef __SYCL_COMPILER_VERSION
-#ifdef __clang__
+#if defined(__clang__) && !defined(__SYCL_COMPILER_VERSION)
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<float>);
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<double>);
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<int8_t>);
@@ -826,8 +820,7 @@ extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<long>);
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<long long>);
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<unsigned long>);
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<unsigned long long>);
-#endif  // __clang__
-#endif  // __SYCL_COMPILER_VERSION
+#endif  // __clang__ && !__SYCL_COMPILER_VERSION
 
 /**
  * @brief Creates a blob with the given tensor descriptor.

--- a/inference-engine/include/ie_blob.h
+++ b/inference-engine/include/ie_blob.h
@@ -577,13 +577,13 @@ public:
     /**
      *@brief Virtual destructor.
      */
-#ifdef __clang__
-    virtual ~TBlob();
-#else
+//#ifdef __clang__
+//    virtual ~TBlob();
+//#else
     virtual ~TBlob() {
         free();
     }
-#endif  // __clang__
+//#endif  // __clang__
 
     /**
      * @brief Gets the size of the given type.
@@ -805,7 +805,7 @@ protected:
         _handle = origBlob._handle;
     }
 };
-
+/*
 #ifdef __clang__
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<float>);
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<double>);
@@ -820,7 +820,7 @@ extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<long lon
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<unsigned long>);
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<unsigned long long>);
 #endif  // __clang__
-
+*/
 /**
  * @brief Creates a blob with the given tensor descriptor.
  *

--- a/inference-engine/include/ie_parameter.hpp
+++ b/inference-engine/include/ie_parameter.hpp
@@ -265,11 +265,11 @@ private:
     struct HasOperatorEqual : CheckOperatorEqual<T, EqualTo>::type {};
 
     struct Any {
-#ifdef __clang__
+#if defined(__clang__) && !defined(__SYCL_COMPILER_VERSION)
         virtual ~Any();
 #else
         virtual ~Any() = default;
-#endif
+#endif  // __clang__ && !__SYCL_COMPILER_VERSION
         virtual bool is(const std::type_info&) const = 0;
         virtual Any* copy() const = 0;
         virtual bool operator==(const Any& rhs) const = 0;
@@ -326,7 +326,7 @@ private:
     Any* ptr = nullptr;
 };
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__SYCL_COMPILER_VERSION)
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<InferenceEngine::Blob::Ptr>);
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<int>);
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<bool>);
@@ -341,6 +341,6 @@ extern template struct INFERENCE_ENGINE_API_CLASS(
     InferenceEngine::Parameter::RealData<std::tuple<unsigned int, unsigned int>>);
 extern template struct INFERENCE_ENGINE_API_CLASS(
     InferenceEngine::Parameter::RealData<std::tuple<unsigned int, unsigned int, unsigned int>>);
-#endif  // __clang__
+#endif  // __clang__ && !__SYCL_COMPILER_VERSION
 
 }  // namespace InferenceEngine

--- a/inference-engine/src/inference_engine/ie_rtti.cpp
+++ b/inference-engine/src/inference_engine/ie_rtti.cpp
@@ -81,7 +81,7 @@ Parameter::~Parameter() {
     clear();
 }
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__SYCL_COMPILER_VERSION)
 Parameter::Any::~Any() {}
 
 template struct InferenceEngine::Parameter::RealData<int>;
@@ -97,12 +97,12 @@ template struct InferenceEngine::Parameter::RealData<std::vector<unsigned long>>
 template struct InferenceEngine::Parameter::RealData<std::tuple<unsigned int, unsigned int>>;
 template struct InferenceEngine::Parameter::RealData<std::tuple<unsigned int, unsigned int, unsigned int>>;
 template struct InferenceEngine::Parameter::RealData<InferenceEngine::Blob::Ptr>;
-#endif  // __clang__
+#endif  // __clang__ && !__SYCL_COMPILER_VERSION
 //
 // ie_blob.h
 //
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__SYCL_COMPILER_VERSION)
 template <typename T, typename U>
 TBlob<T, U>::~TBlob() {
     free();
@@ -120,4 +120,4 @@ template class InferenceEngine::TBlob<long>;
 template class InferenceEngine::TBlob<long long>;
 template class InferenceEngine::TBlob<unsigned long>;
 template class InferenceEngine::TBlob<unsigned long long>;
-#endif  // __clang__
+#endif  // __clang__ && !__SYCL_COMPILER_VERSION


### PR DESCRIPTION
OpenVINO C++ program failed to link when DPC++ compiler is used.
'make_shared_blob' causes 'unresolved external symbol' error on linking.
Commented out some __clang__ specific directives to workaround the issue in "ie_blob.h".