### PR TITLE
ConvND: fix errmsg if groups > 1

### DIFF
--- a/inference-engine/src/vpu/graph_transformer/src/stages/convolution.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/convolution.cpp
@@ -377,7 +377,7 @@ void parseConvND(const Model      & model,
     VPU_THROW_UNLESS(output_channels > 0, "invalid number of output channels: %d", output_channels);
 
     int groups = convLayer->_group;
-    VPU_THROW_UNLESS(groups > 0, "number of groups=%d, but grouped 3D convolution is not supported", groups);
+    VPU_THROW_UNLESS(groups == 1, "number of groups=%d, but grouped 3D convolution is not supported", groups);
 
     int inputNDims = input->desc().numDims();
     int outputNDims = output->desc().numDims();


### PR DESCRIPTION
**Description**

Fix error message if attempting grouped 3D convolution (groups > 1 is not supported for 3D conv)

**Tickets**

* OpenVINO #4073: Grouped Convolution on VPU
* Internal #-48267: [Myriad] incorrect error message on unsupported groups > 1 at 3D convolution

**Testing**

See internal ticket