### PR TITLE
[IE CLDNN] Fixed performance of grouped convolutions

### DIFF
--- a/inference-engine/thirdparty/clDNN/src/gpu/convolution_gpu.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/convolution_gpu.cpp
@@ -110,11 +110,12 @@ public:
         conv_params.local_convolution = weights_size.local[0] > 1 || weights_size.local[1] > 1;
         conv_params.split = split;
         conv_params.groups = groups;
-        conv_params.filterSize = {
-            (uint32_t)weights_size.spatial[0],
-            (uint32_t)weights_size.spatial[1],
-            (uint32_t)weights_size.spatial[2],
-        };
+
+        auto spatial_size = arg.get_output_layout().format.dimension() - 2;
+        uint32_t kx = weights_size.spatial[0];
+        uint32_t ky = weights_size.spatial[1];
+        uint32_t kz = spatial_size == 2 ? 1 : weights_size.spatial[2];
+        conv_params.filterSize = { kx, ky, kz };
 
         conv_params.padding = {(uint32_t)std::max(-input_offset.spatial[0], 0),
                                (uint32_t)std::max(-input_offset.spatial[1], 0),

--- a/inference-engine/thirdparty/clDNN/src/gpu/deconvolution_gpu.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/deconvolution_gpu.cpp
@@ -88,9 +88,12 @@ public:
 
         deconv_params.split = split;
         deconv_params.groups = groups;
-        deconv_params.filterSize = {(uint32_t)weights_size.spatial[0],
-                                    (uint32_t)weights_size.spatial[1],
-                                    (uint32_t)weights_size.spatial[2]};
+
+        auto spatial_size = arg.get_output_layout().format.dimension() - 2;
+        uint32_t kx = weights_size.spatial[0];
+        uint32_t ky = weights_size.spatial[1];
+        uint32_t kz = spatial_size == 2 ? 1 : weights_size.spatial[2];
+        deconv_params.filterSize = { kx, ky, kz };
 
         deconv_params.padding = {(uint32_t)std::max(-input_offset.spatial[0], 0),
                                  (uint32_t)std::max(-input_offset.spatial[1], 0),


### PR DESCRIPTION
Weights tensor for grouped (de)convolution has bfzyx layout which means goiyx. It means that "i" value is put into spatial[2], so we need to adjust filter size conversion logic to respect this case. 