### PR TITLE
Fix wrong attributes for Pad

### DIFF
--- a/model-optimizer/mo/middle/passes/conv.py
+++ b/model-optimizer/mo/middle/passes/conv.py
@@ -35,9 +35,11 @@ def pad_op_transform(graph: Graph, match: dict):
         log.info('The pad node "{}" with pad mode "{}" cannot be fused.'.format(pad_op.soft_get('name'), pad_op.mode))
         return
 
-    if pad_op.mode == 'constant' and pad_op.fill_value != 0.0:
-        log.info('The pad node "{}" with non-zero fill value cannot be fused.'.format(pad_op.soft_get('name')))
-        return
+    if pad_op.mode == 'constant':
+        fill_value = pad_op.in_port(3).data.get_value()
+        if fill_value is None or fill_value != 0.0:
+            log.info('The pad node "{}" with non-zero fill value cannot be fused.'.format(pad_op.soft_get('name')))
+            return
 
     input_tensor_dims = len(match['pad_output'].shape)
     for in_port in [1, 2]:

--- a/model-optimizer/mo/ops/pad.py
+++ b/model-optimizer/mo/ops/pad.py
@@ -42,7 +42,6 @@ class Pad(Op):
             'infer': self.infer,
 
             'mode': 'constant',
-            'fill_value': float(0),
 
             'force_precision_in_ports': {
                 1: 'int64',
@@ -54,11 +53,7 @@ class Pad(Op):
         }, attrs)
 
     def backend_attrs(self):
-        return [('pad_mode', 'mode'),
-                ('pad_value', 'fill_value'),
-                ('pads_begin', lambda node: ','.join(map(str, node.pads[:, 0])) if node.has_valid('pads') else None),
-                ('pads_end', lambda node: ','.join(map(str, node.pads[:, 1])) if node.has_valid('pads') else None),
-                ]
+        return [('pad_mode', 'mode')]
 
     @staticmethod
     def infer(node):


### PR DESCRIPTION
Description: Allign attributes of Pad operation acording to spec. This fixes invalid merge of Pad with Convolution in cases when non-zero pad is used.

JIRA: 47942


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names


Validation:
* [x]  Unit tests: N/A
* [x]  Framework operation tests: N/A
* [x]  Transformation tests: N/A
* [x]  e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py - N/A no new models added
* [ ]  Model Optimizer IR Reader check: check fails, but not because of changes in this PR. The issue is under investigation.

Documentation:
* [x]  Supported frameworks operations list - N/A
* [x]  Supported **public** models list - N/A
* [x]  New operations specification - N/A
* [x]  Guide on how to convert the **public** model - N/A
* [x]  User guide update - N/A
