### PR TITLE
Simplified cancel behavior

### DIFF
--- a/docs/template_plugin/src/template_infer_request.cpp
+++ b/docs/template_plugin/src/template_infer_request.cpp
@@ -131,13 +131,6 @@ void TemplateInferRequest::InferImpl() {
 }
 // ! [infer_request:infer_impl]
 
-// ! [infer_request:cancel]
-InferenceEngine::StatusCode TemplateInferRequest::Cancel() {
-    // TODO: add code to  handle cancellation request
-    return InferenceEngine::OK;
-}
-// ! [infer_request:cancel]
-
 template<typename SrcT, typename DstT>
 static void blobCopy(const Blob::Ptr& src, const Blob::Ptr& dst) {
     std::copy_n(InferenceEngine::as<InferenceEngine::MemoryBlob>(src)->rmap().as<const SrcT*>(),

--- a/docs/template_plugin/src/template_infer_request.hpp
+++ b/docs/template_plugin/src/template_infer_request.hpp
@@ -40,8 +40,6 @@ public:
     void InferImpl() override;
     std::map<std::string, InferenceEngine::InferenceEngineProfileInfo> GetPerformanceCounts() const override;
 
-    InferenceEngine::StatusCode Cancel() override;
-
     // pipeline methods-stages which are used in async infer request implementation and assigned to particular executor
     void inferPreprocess();
     void startPipeline();

--- a/inference-engine/include/cpp/ie_infer_request.hpp
+++ b/inference-engine/include/cpp/ie_infer_request.hpp
@@ -162,10 +162,13 @@ public:
         CALL_STATUS_FNC_NO_ARGS(Infer);
     }
 
-    StatusCode Cancel() {
-        ResponseDesc resp;
-        if (actual == nullptr) THROW_IE_EXCEPTION << "InferRequest was not initialized.";
-        return actual->Cancel(&resp);
+    /**
+     * @copybrief IInferRequest::Cancel
+     *
+     * Wraps IInferRequest::Cancel
+     */
+    void Cancel() {
+        CALL_STATUS_FNC_NO_ARGS(Cancel);
     }
 
     /**

--- a/inference-engine/include/details/ie_exception_conversion.hpp
+++ b/inference-engine/include/details/ie_exception_conversion.hpp
@@ -60,6 +60,8 @@ inline void extract_exception(StatusCode status, const char* msg) {
         throw InferNotStarted(msg);
     case NETWORK_NOT_READ:
         throw NetworkNotRead(msg);
+    case INFER_CANCELLED:
+        throw InferCancelled(msg);
     default:
         THROW_IE_EXCEPTION << msg << InferenceEngine::details::as_status << status;
     }

--- a/inference-engine/include/ie_common.h
+++ b/inference-engine/include/ie_common.h
@@ -334,6 +334,11 @@ class NetworkNotRead : public std::logic_error {
     using std::logic_error::logic_error;
 };
 
+/** @brief This class represents StatusCode::INFER_CANCELLED exception */
+class InferCancelled : public std::logic_error {
+    using std::logic_error::logic_error;
+};
+
 }  // namespace InferenceEngine
 
 #if defined(_WIN32)

--- a/inference-engine/src/gna_plugin/gna_infer_request.hpp
+++ b/inference-engine/src/gna_plugin/gna_infer_request.hpp
@@ -120,9 +120,5 @@ class GNAInferRequest : public InferenceEngine::AsyncInferRequestInternal {
         return plg->QueryState();
     }
     IE_SUPPRESS_DEPRECATED_END
-
-    InferenceEngine::StatusCode Cancel() override {
-        return InferenceEngine::NOT_IMPLEMENTED;
-    }
 };
 }  // namespace GNAPluginNS

--- a/inference-engine/src/plugin_api/cpp_interfaces/base/ie_infer_async_request_base.hpp
+++ b/inference-engine/src/plugin_api/cpp_interfaces/base/ie_infer_async_request_base.hpp
@@ -38,7 +38,7 @@ public:
 
     StatusCode Cancel(ResponseDesc* resp) noexcept override {
         OV_ITT_SCOPED_TASK(itt::domains::Plugin, "Cancel");
-        NO_EXCEPT_CALL_RETURN_STATUS(_impl->Cancel());
+        TO_STATUS(_impl->Cancel());
     }
 
     StatusCode GetPerformanceCounts(std::map<std::string, InferenceEngineProfileInfo>& perfMap,

--- a/inference-engine/src/plugin_api/cpp_interfaces/impl/ie_infer_async_request_thread_safe_default.hpp
+++ b/inference-engine/src/plugin_api/cpp_interfaces/impl/ie_infer_async_request_thread_safe_default.hpp
@@ -281,13 +281,10 @@ public:
         }
     }
 
-    StatusCode Cancel() override {
+    void Cancel() override {
         std::lock_guard<std::mutex> lock{_mutex};
-        if (_state == InferState::Idle) {
-            return StatusCode::INFER_NOT_STARTED;
-        } else {
+        if (_state == InferState::Busy) {
             _state = InferState::Canceled;
-            return InferenceEngine::OK;
         }
     }
 

--- a/inference-engine/src/plugin_api/cpp_interfaces/impl/ie_infer_request_internal.hpp
+++ b/inference-engine/src/plugin_api/cpp_interfaces/impl/ie_infer_request_internal.hpp
@@ -66,8 +66,8 @@ public:
     /**
      * @brief Default common implementation for all plugins
      */
-    StatusCode Cancel() override {
-        return InferenceEngine::NOT_IMPLEMENTED;
+    void Cancel() override {
+        THROW_IE_EXCEPTION_WITH_STATUS(NOT_IMPLEMENTED);
     }
 
     /**

--- a/inference-engine/src/plugin_api/cpp_interfaces/interface/ie_iinfer_request_internal.hpp
+++ b/inference-engine/src/plugin_api/cpp_interfaces/interface/ie_iinfer_request_internal.hpp
@@ -42,7 +42,7 @@ public:
     /**
      * @brief Cancel current inference request execution
      */
-    virtual StatusCode Cancel() = 0;
+    virtual void Cancel() = 0;
 
     /**
      * @brief Queries performance measures per layer to get feedback of what is the most time consuming layer.

--- a/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/cpp_interfaces/impl/mock_async_infer_request_internal.hpp
+++ b/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/cpp_interfaces/impl/mock_async_infer_request_internal.hpp
@@ -32,6 +32,6 @@ public:
     MOCK_METHOD1(setNetworkOutputs, void(OutputsDataMap));
     MOCK_METHOD1(GetBlob, Blob::Ptr(const std::string&));
     MOCK_METHOD1(SetCompletionCallback, void(IInferRequest::CompletionCallback));
-    MOCK_METHOD0(Cancel, InferenceEngine::StatusCode());
-    MOCK_METHOD0(Cancel_ThreadUnsafe, InferenceEngine::StatusCode());
+    MOCK_METHOD0(Cancel, void());
+    MOCK_METHOD0(Cancel_ThreadUnsafe, void());
 };

--- a/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/cpp_interfaces/impl/mock_infer_request_internal.hpp
+++ b/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/cpp_interfaces/impl/mock_infer_request_internal.hpp
@@ -23,5 +23,5 @@ public:
     MOCK_METHOD0(InferImpl, void());
     MOCK_CONST_METHOD0(GetPerformanceCounts, std::map<std::string, InferenceEngineProfileInfo>());
     MOCK_METHOD0(checkBlobs, void());
-    MOCK_METHOD0(Cancel, InferenceEngine::StatusCode());
+    MOCK_METHOD0(Cancel, void());
 };

--- a/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/cpp_interfaces/interface/mock_iasync_infer_request_internal.hpp
+++ b/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/cpp_interfaces/interface/mock_iasync_infer_request_internal.hpp
@@ -28,5 +28,5 @@ public:
     MOCK_METHOD1(SetCompletionCallback, void(InferenceEngine::IInferRequest::CompletionCallback));
     MOCK_METHOD1(SetBatch, void(int));
     MOCK_METHOD0(QueryState, std::vector<IVariableStateInternal::Ptr>());
-    MOCK_METHOD0(Cancel, InferenceEngine::StatusCode());
+    MOCK_METHOD0(Cancel, void());
 };


### PR DESCRIPTION
There is no sense in `INFER_NOT_STARTED` error  from `InferRequest::Cancel()`.