### PR TITLE
Add opset6 to serialization.

### DIFF
--- a/inference-engine/src/transformations/src/transformations/serialize.cpp
+++ b/inference-engine/src/transformations/src/transformations/serialize.cpp
@@ -407,9 +407,9 @@ const std::vector<Edge> create_edge_mapping(
 std::string get_opset_name(
     const ngraph::Node* n,
     const std::map<std::string, ngraph::OpSet>& custom_opsets) {
-    auto opsets = std::array<std::reference_wrapper<const ngraph::OpSet>, 5>{
+    auto opsets = std::array<std::reference_wrapper<const ngraph::OpSet>, 6>{
         ngraph::get_opset1(), ngraph::get_opset2(), ngraph::get_opset3(),
-        ngraph::get_opset4(), ngraph::get_opset5()};
+        ngraph::get_opset4(), ngraph::get_opset5(), ngraph::get_opset6()};
 
     auto special_opset = get_special_opset_for_op(n->get_type_info());
     if (!special_opset.empty()) {

--- a/inference-engine/tests/functional/inference_engine/serialization/single_layer/mvn.cpp
+++ b/inference-engine/tests/functional/inference_engine/serialization/single_layer/mvn.cpp
@@ -1,0 +1,62 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "shared_test_classes/single_layer/mvn.hpp"
+
+using namespace LayerTestsDefinitions;
+
+std::vector<InferenceEngine::Precision> dataPrecisions = {
+    InferenceEngine::Precision::FP32, InferenceEngine::Precision::FP16};
+
+const std::vector<bool> normalizeVariance = {true, false};
+
+// ------------------- MVN-1 -------------------------------------------------
+const std::vector<std::vector<size_t>> inputShapes = {{1, 10, 5, 7, 8},
+                                                      {1, 3, 8, 9, 49}};
+
+const std::vector<bool> acrossChannels = {true, false};
+
+const std::vector<double> epsilon = {0.000000001};
+
+const auto MvnCases = ::testing::Combine(
+    ::testing::ValuesIn(inputShapes), ::testing::ValuesIn(dataPrecisions),
+    ::testing::ValuesIn(acrossChannels), ::testing::ValuesIn(normalizeVariance),
+    ::testing::ValuesIn(epsilon),
+    ::testing::Values(CommonTestUtils::DEVICE_CPU));
+
+TEST_P(MvnLayerTest, Serialize) {
+    Serialize();
+}
+
+INSTANTIATE_TEST_CASE_P(smoke_MKLDNN_TestsMVN, MvnLayerTest, MvnCases,
+                        MvnLayerTest::getTestCaseName);
+
+// ------------------- MVN-6 -------------------------------------------------
+
+std::vector<InferenceEngine::Precision> idxPrecisions = {
+    InferenceEngine::Precision::I32, InferenceEngine::Precision::I64};
+
+const std::vector<std::string> epsMode = {"inside_sqrt", "outside_sqrt"};
+
+const std::vector<float> epsilonF = {0.0001};
+
+TEST_P(Mvn6LayerTest, Serialize) {
+    Serialize();
+}
+
+INSTANTIATE_TEST_CASE_P(
+    smoke_MVN_5D, Mvn6LayerTest,
+    ::testing::Combine(::testing::ValuesIn(std::vector<std::vector<size_t>>{
+                           {1, 10, 5, 7, 8}, {1, 3, 8, 9, 49}}),
+                       ::testing::ValuesIn(dataPrecisions),
+                       ::testing::ValuesIn(idxPrecisions),
+                       ::testing::ValuesIn(std::vector<std::vector<int>>{
+                           {1, 2, 3, 4}, {2, 3, 4}}),
+                       ::testing::ValuesIn(normalizeVariance),
+                       ::testing::ValuesIn(epsilonF),
+                       ::testing::ValuesIn(epsMode),
+                       ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+    Mvn6LayerTest::getTestCaseName);


### PR DESCRIPTION
Fixes "MVN/6 != GenericIE/1" serialization issue. MVN-6 Serialization SLT reproduced the issue locally. Adding opset6 handling to serialization code resolved it .

Ticket: 48248.