### PR TITLE
Removed redundant memcpy calls. Share weights from original blob

### DIFF
--- a/inference-engine/src/readers/ir_reader/ie_ir_parser.cpp
+++ b/inference-engine/src/readers/ir_reader/ie_ir_parser.cpp
@@ -781,6 +781,10 @@ std::shared_ptr<ngraph::Node> V10Parser::XmlDeserializer::createNode(
         if (!ngraphNode) {
             THROW_IE_EXCEPTION << "Opset " << params.version << " doesn't contain the operation with type: " << type;
         }
+        // Share Weights form constant blob
+        if (auto constant = std::dynamic_pointer_cast<ngraph::opset6::Constant>(ngraphNode)) {
+            constant->alloc_buffer_on_visit_attributes(false);
+        }
         ngraphNode->set_arguments(inputs);
         XmlDeserializer visitor(node, weights, opsets, variables);
         if (ngraphNode->visit_attributes(visitor)) {

--- a/inference-engine/src/readers/ir_reader/ie_ir_parser.cpp
+++ b/inference-engine/src/readers/ir_reader/ie_ir_parser.cpp
@@ -224,6 +224,11 @@ ngraph::op::v5::Loop::SpecialBodyPorts V10Parser::XmlDeserializer::parsePurposeA
 }
 
 void V10Parser::XmlDeserializer::on_adapter(const std::string& name, ngraph::ValueAccessor<void>& adapter) {
+    static const std::unordered_set<std::string> skip_names = {
+        "input_descriptions",
+        "output_descriptions",
+        "special_body_ports"
+    };
     std::string val;
 
     // for TensorIterator look for 'port_map' as 'data' does not exist
@@ -239,7 +244,7 @@ void V10Parser::XmlDeserializer::on_adapter(const std::string& name, ngraph::Val
         }
     }
 
-    if (!getStrAttribute(node.child("data"), name, val)) return;
+    if (skip_names.count(name) && !getStrAttribute(node.child("data"), name, val)) return;
     if (auto a = ngraph::as_type<ngraph::AttributeAdapter<ngraph::element::Type>>(&adapter)) {
         static_cast<ngraph::element::Type&>(*a) = details::convertPrecision(val);
     } else if (auto a = ngraph::as_type<ngraph::AttributeAdapter<ngraph::PartialShape>>(&adapter)) {
@@ -292,6 +297,44 @@ void V10Parser::XmlDeserializer::on_adapter(const std::string& name, ngraph::Val
                                           ngraph::element::dynamic, variable_id});
         }
         a->set(variables[variable_id]);
+    } else if (auto a = ngraph::as_type<ngraph::AttributeAdapter<std::shared_ptr<ngraph::runtime::AlignedBuffer>>>(&adapter)) {
+        std::string value;
+        pugi::xml_node dn = node.child("data");
+        auto type = XMLParseUtils::GetStrAttr(node, "type");
+
+        if (dn.empty())
+            THROW_IE_EXCEPTION << "No attrtibutes defined for " << type << " op!";
+
+        if (getStrAttribute(dn, name, value)) {
+            auto buffer = std::make_shared<ngraph::runtime::AlignedBuffer>(value.size());
+            auto data = static_cast<char*>(buffer->get_ptr());
+            value.copy(data, value.size());
+            a->set(buffer);
+        } else if (name == "value" && type == "Const") {
+            std::vector<int64_t> shape;
+            std::string el_type_str;
+
+            size_t offset = XMLParseUtils::GetUInt64Attr(dn, "offset");
+            size_t size = XMLParseUtils::GetUInt64Attr(dn, "size");
+            if (!getStrAttribute(dn, "element_type", el_type_str)) return;
+            if (!getParameters<int64_t>(dn, "shape", shape)) return;
+
+            ngraph::element::Type el_type = details::convertPrecision(el_type_str);
+
+            size_t length = weights->byteSize();
+            if (!length)
+                THROW_IE_EXCEPTION << "Empty weights data in bin file or bin file cannot be found!";
+            if (length < offset + size)
+                THROW_IE_EXCEPTION << "Incorrect weights in bin file!";
+            if (size < std::ceil(ngraph::shape_size(shape) * el_type.bitwidth() / 8.f))
+                THROW_IE_EXCEPTION << "Attribute and shape size are inconsistent for " << type << " op!";
+
+            char* data = weights->cbuffer().as<char*>() + offset;
+
+            using SharedBuffer = ngraph::runtime::SharedBuffer<const Blob::CPtr>;
+            auto buffer = std::make_shared<SharedBuffer>(data, size, weights);
+            a->set(buffer);
+        }
     } else {
         THROW_IE_EXCEPTION << "Error IR reading. Attribute adapter can not be found for " << name
                             << " parameter";

--- a/inference-engine/src/transformations/src/transformations/serialize.cpp
+++ b/inference-engine/src/transformations/src/transformations/serialize.cpp
@@ -247,22 +247,15 @@ public:
             }
         } else if (const auto& a = ngraph::as_type<ngraph::AttributeAdapter<std::shared_ptr<ngraph::Variable>>>(&adapter)) {
                 m_xml_node.append_attribute(name.c_str()).set_value(a->get()->get_info().variable_id.c_str());
-        }
-    }
-
-    void on_adapter(const std::string& name,
-                    ngraph::ValueAccessor<void*>& adapter) override {
-        if (name == "value" &&  translate_type_name(m_node_type_name) == "Const") {
-            using AlignedBufferAdapter =
-                ngraph::AttributeAdapter<std::shared_ptr<runtime::AlignedBuffer>>;
-            if (auto a = ngraph::as_type<AlignedBufferAdapter>(&adapter)) {
-                const int64_t size = a->size();
+        } else if (const auto& a = ngraph::as_type<ngraph::AttributeAdapter<std::shared_ptr<ngraph::runtime::AlignedBuffer>>>(&adapter)) {
+            if (name == "value" &&  translate_type_name(m_node_type_name) == "Const") {
+                const int64_t size = a->get()->size();
                 const int64_t offset = m_bin_data.tellp();
 
                 m_xml_node.append_attribute("offset").set_value(offset);
                 m_xml_node.append_attribute("size").set_value(size);
 
-                auto data = static_cast<const char*>(a->get_ptr());
+                auto data = static_cast<const char*>(a->get()->get_ptr());
                 m_bin_data.write(data, size);
             }
         }

--- a/inference-engine/tests/ie_test_utils/common_test_utils/ngraph_test_utils.cpp
+++ b/inference-engine/tests/ie_test_utils/common_test_utils/ngraph_test_utils.cpp
@@ -240,27 +240,21 @@ public:
 class ReadAndStoreAttributes : public ngraph::AttributeVisitor, protected storage::Storage {
 public:
     void on_adapter(const std::string& name, ngraph::ValueAccessor<void>& adapter) override {
-        if (auto inputs =
-                ngraph::as_type<ngraph::AttributeAdapter<SubGraphOpInputDescription>>(&adapter)) {
+        if (auto inputs = ngraph::as_type<ngraph::AttributeAdapter<SubGraphOpInputDescription>>(&adapter)) {
             insert(name, inputs->get());
-        } else if (
-            auto outputs =
-                ngraph::as_type<ngraph::AttributeAdapter<SubGraphOpOutputDescription>>(&adapter)) {
+        } else if (auto outputs = ngraph::as_type<ngraph::AttributeAdapter<SubGraphOpOutputDescription>>(&adapter)) {
             insert(name, outputs->get());
-        } else if (
-            auto ports = ngraph::as_type<ngraph::AttributeAdapter<SpecialBodyPorts>>(&adapter)) {
+        } else if (auto ports = ngraph::as_type<ngraph::AttributeAdapter<SpecialBodyPorts>>(&adapter)) {
             insert(name, ports->get());
+        } else if (auto a = ngraph::as_type<ngraph::AttributeAdapter<std::shared_ptr<ngraph::runtime::AlignedBuffer>>>(&adapter)) {
+            const auto beg = static_cast<unsigned char*>(a->get()->get_ptr());
+            const auto end = beg + a->get()->size();
+            insert(name, storage::MemoryChunk{storage::MemoryChunk::Data(beg, end)});
         } else {
             m_read_result += "store   attr [ ERR ]: " + name +
                              " [drop `void` comparison which is '" + adapter.get_type_info().name +
                              "']";
         }
-    }
-
-    void on_adapter(const std::string& name, ngraph::ValueAccessor<void*>& adapter) override {
-        const auto beg = static_cast<unsigned char*>(adapter.get_ptr());
-        const auto end = beg + adapter.size();
-        insert(name, storage::MemoryChunk{storage::MemoryChunk::Data(beg, end)});
     }
 
 #define ON_ADAPTER(TYPE)                                                                      \
@@ -506,38 +500,29 @@ public:
             return;
         }
         m_visited_attributes.insert(name);
-        if (auto inputs =
-                ngraph::as_type<ngraph::AttributeAdapter<SubGraphOpInputDescription>>(&adapter)) {
+        if (auto inputs = ngraph::as_type<ngraph::AttributeAdapter<SubGraphOpInputDescription>>(&adapter)) {
             verify(name, inputs->get());
-        } else if (
-            auto outputs =
-                ngraph::as_type<ngraph::AttributeAdapter<SubGraphOpOutputDescription>>(&adapter)) {
+        } else if (auto outputs = ngraph::as_type<ngraph::AttributeAdapter<SubGraphOpOutputDescription>>(&adapter)) {
             verify(name, outputs->get());
-        } else if (
-            auto ports = ngraph::as_type<ngraph::AttributeAdapter<SpecialBodyPorts>>(&adapter)) {
+        } else if (auto ports = ngraph::as_type<ngraph::AttributeAdapter<SpecialBodyPorts>>(&adapter)) {
             verify(name, ports->get());
+        } else if (auto a = ngraph::as_type<ngraph::AttributeAdapter<std::shared_ptr<ngraph::runtime::AlignedBuffer>>>(&adapter)) {
+            m_visited_attributes.insert(name);
+            const auto ref_value = m_attr_ref.get<storage::MemoryChunk>(name);
+            if (!ref_value) {
+                m_cmp_result += "missing attribute name: '" + name + "'";
+                return;
+            }
+
+            if (a->get()->size() != ref_value->size() ||
+                std::memcmp(ref_value->data(), a->get()->get_ptr(), ref_value->size()) != 0) {
+                m_cmp_result += "mismatch in value: '" + name + "' : look in to the mem buffer";
+                return;
+            }
         } else {
             m_cmp_result += "compare attr [ ERR ]: " + name +
                             " [drop `void` comparison which is '" + adapter.get_type_info().name +
                             "']";
-        }
-    }
-
-    void on_adapter(const std::string& name, ngraph::ValueAccessor<void*>& adapter) override {
-        if (should_return()) {
-            return;
-        }
-        m_visited_attributes.insert(name);
-        const auto ref_value = m_attr_ref.get<storage::MemoryChunk>(name);
-        if (!ref_value) {
-            m_cmp_result += "missing attribute name: '" + name + "'";
-            return;
-        }
-
-        if (adapter.size() != ref_value->size() ||
-            std::memcmp(ref_value->data(), adapter.get_ptr(), ref_value->size()) != 0) {
-            m_cmp_result += "mismatch in value: '" + name + "' : look in to the mem buffer";
-            return;
         }
     }
 

--- a/ngraph/core/include/ngraph/op/constant.hpp
+++ b/ngraph/core/include/ngraph/op/constant.hpp
@@ -470,6 +470,14 @@ namespace ngraph
                 }
                 std::string convert_value_to_string(size_t index) const;
 
+                /**
+                 * \brief Allows to avoid buffer allocation on the visit_attributes call
+                 */
+                void alloc_buffer_on_visit_attributes(bool val)
+                {
+                    m_alloc_buffer_on_visit_attributes = val;
+                }
+
             protected:
                 template <typename IN_T, typename OUT_T>
                 void cast_vector(std::vector<OUT_T>& output_vector) const
@@ -591,6 +599,7 @@ namespace ngraph
                 std::shared_ptr<runtime::AlignedBuffer> m_data;
                 bool m_all_elements_bitwise_identical;
                 bool are_all_data_elements_bitwise_identical() const;
+                bool m_alloc_buffer_on_visit_attributes = true;
             };
         }
         using v0::Constant;

--- a/ngraph/core/include/ngraph/runtime/aligned_buffer.hpp
+++ b/ngraph/core/include/ngraph/runtime/aligned_buffer.hpp
@@ -75,17 +75,13 @@ namespace ngraph
     }
     template <>
     class NGRAPH_API AttributeAdapter<std::shared_ptr<runtime::AlignedBuffer>>
-        : public ValueAccessor<void*>
+        : public DirectValueAccessor<std::shared_ptr<runtime::AlignedBuffer>>
     {
     public:
         AttributeAdapter(std::shared_ptr<runtime::AlignedBuffer>& value);
-        void* get_ptr() override;
-        size_t size() override;
 
         static constexpr DiscreteTypeInfo type_info{
             "AttributeAdapter<std::shared_ptr<runtime::AlignedBuffer>>", 0};
         const DiscreteTypeInfo& get_type_info() const override { return type_info; }
-    protected:
-        std::shared_ptr<runtime::AlignedBuffer>& m_ref;
     };
 }

--- a/ngraph/core/src/op/constant.cpp
+++ b/ngraph/core/src/op/constant.cpp
@@ -628,8 +628,17 @@ bool op::Constant::are_all_data_elements_bitwise_identical() const
 bool op::v0::Constant::visit_attributes(AttributeVisitor& visitor)
 {
     NGRAPH_OP_SCOPE(v0_Constant_visit_attributes);
+    Shape prev_shape = m_shape;
+    element::Type prev_type = m_element_type;
     visitor.on_attribute("element_type", m_element_type);
     visitor.on_attribute("shape", m_shape);
+
+    bool need_to_reallocate = (m_shape != prev_shape || prev_type != m_element_type);
+    if (m_alloc_buffer_on_visit_attributes && need_to_reallocate)
+    {
+        // Filling in a fresh constant
+        allocate_buffer();
+    }
     visitor.on_attribute("value", m_data);
     return true;
 }

--- a/ngraph/core/src/op/constant.cpp
+++ b/ngraph/core/src/op/constant.cpp
@@ -630,11 +630,6 @@ bool op::v0::Constant::visit_attributes(AttributeVisitor& visitor)
     NGRAPH_OP_SCOPE(v0_Constant_visit_attributes);
     visitor.on_attribute("element_type", m_element_type);
     visitor.on_attribute("shape", m_shape);
-    if (m_data == nullptr)
-    {
-        // Filling in a fresh constant
-        allocate_buffer();
-    }
     visitor.on_attribute("value", m_data);
     return true;
 }

--- a/ngraph/core/src/runtime/aligned_buffer.cpp
+++ b/ngraph/core/src/runtime/aligned_buffer.cpp
@@ -87,13 +87,7 @@ namespace ngraph
 
     AttributeAdapter<shared_ptr<runtime::AlignedBuffer>>::AttributeAdapter(
         shared_ptr<runtime::AlignedBuffer>& value)
-        : m_ref(value)
+        : DirectValueAccessor<shared_ptr<runtime::AlignedBuffer>>(value)
     {
     }
-
-    void* AttributeAdapter<shared_ptr<runtime::AlignedBuffer>>::get_ptr()
-    {
-        return m_ref->get_ptr();
-    }
-    size_t AttributeAdapter<shared_ptr<runtime::AlignedBuffer>>::size() { return m_ref->size(); }
 }


### PR DESCRIPTION
task: 47768

In order to remove memcpy usage, I changed the type of AttributeAdapter for AlignedBuffer and it helped me to use SharedBuffer instead of copy.