### PR TITLE
Usability: conditional compilation

### DIFF
--- a/thirdparty/itt_collector/CMakeLists.txt
+++ b/thirdparty/itt_collector/CMakeLists.txt
@@ -14,6 +14,4 @@
 # limitations under the License.
 # ******************************************************************************
 
-if(ENABLE_PROFILING_ITT AND SELECTIVE_BUILD STREQUAL "COLLECT")
-    add_subdirectory(sea_itt_lib)
-endif()
+add_subdirectory(sea_itt_lib)

--- a/thirdparty/ittapi/CMakeLists.txt
+++ b/thirdparty/ittapi/CMakeLists.txt
@@ -42,5 +42,6 @@ if(ENABLE_PROFILING_ITT)
         endif()
 
         openvino_developer_export_targets(COMPONENT openvino_common TARGETS ittnotify)
+        add_dependencies(ittnotify sea_itt_lib)
     endif()
 endif()


### PR DESCRIPTION
I may forget to build `sea_itt_lib` and script will fail with:
```
user@user-pc:~/Documents/Programming/git_repo/dldt$ python thirdparty/itt_collector/runtool/sea_runtool.py --bindir bin/intel64/Release/lib/ -o resnet5 0 ! ./benchmark_app -niter 1 -nireq 1 -m /home/sandye51/Documents/resnet-50.xml
Warning: Failed to load /home/sandye51/Documents/Programming/git_repo/dldt/bin/intel64/Release/lib/libIntelSEAPI.so ...

 WARNING: didn't find any files for: /home/sandye51/Documents/Programming/git_repo/dldt/bin/intel64/Release/lib/*IntelSEAPI.so
        File "thirdparty/itt_collector/runtool/sea_runtool.py", line 259, in launch
For execution details see: resnet50/sea_2021_02_10__17_38_46.log

 WARNING: didn't find any files for: /home/sandye51/Documents/Programming/git_repo/dldt/bin/intel64/Release/lib/*IntelSEAPI.so
        File "thirdparty/itt_collector/runtool/sea_runtool.py", line 259, in launch
Error: didn't find any *IntelSEAPI.so files. Please check that you run from bin directory, or use --bindir.
```