### PR TITLE
Reverse input channels fusion

### DIFF
--- a/model-optimizer/extensions/front/DropoutWithRandomUniformReplacer.py
+++ b/model-optimizer/extensions/front/DropoutWithRandomUniformReplacer.py
@@ -20,6 +20,7 @@ import numpy as np
 from mo.front.common.replacement import FrontReplacementSubgraph
 from mo.front.tf.graph_utils import create_op_with_const_inputs
 from mo.graph.graph import Graph, Node, rename_nodes
+from mo.middle.pattern_match import check_value
 from mo.ops.broadcast import Broadcast
 
 
@@ -51,7 +52,7 @@ class DropoutWithRandomUniformReplacer(FrontReplacementSubgraph):
                 ('shape', dict(op='ShapeOf')),
                 ('random_uniform', dict(op='RandomUniform')),
                 ('mul', dict(op='Mul')),
-                ('add_const', dict(op='Const', value=lambda v: v is not None and np.allclose(v, 0.0, atol=0))),
+                ('add_const', dict(op='Const', value=lambda v: check_value(v, lambda x: np.allclose(x, 0.0, atol=0)))),
                 ('add', dict(op='Add')),
                 ('add2', dict(op='Add')),
                 ('floor', dict(op='Floor')),

--- a/model-optimizer/extensions/front/HSigmoid_fusion.py
+++ b/model-optimizer/extensions/front/HSigmoid_fusion.py
@@ -20,6 +20,7 @@ from extensions.ops.activation_ops import HSigmoid
 from mo.front.common.replacement import FrontReplacementSubgraph
 from mo.front.subgraph_matcher import SubgraphMatch
 from mo.graph.graph import Graph, rename_nodes
+from mo.middle.pattern_match import check_value
 from mo.utils.graph import Node
 
 
@@ -50,10 +51,11 @@ class HSigmoidWithClamp(FrontReplacementSubgraph):
             nodes=[
                 ('input', dict()),
                 ('add', dict(op='Add')),
-                ('const_0', dict(op='Const', value=lambda v: v is not None and np.allclose(v, 0.0, atol=1e-6))),
-                ('const_3', dict(op='Const', value=lambda v: v is not None and np.allclose(v, 3.0, atol=1e-6))),
-                ('const_6', dict(op='Const', value=lambda v: v is not None and np.allclose(v, 6.0, atol=1e-6))),
-                ('const_1_6', dict(op='Const', value=lambda v: v is not None and np.allclose(v, 1.0 / 6.0, atol=1e-6))),
+                ('const_0', dict(op='Const', value=lambda v: check_value(v, lambda x: np.allclose(x, 0.0, atol=1e-6)))),
+                ('const_3', dict(op='Const', value=lambda v: check_value(v, lambda x: np.allclose(x, 3.0, atol=1e-6)))),
+                ('const_6', dict(op='Const', value=lambda v: check_value(v, lambda x: np.allclose(x, 6.0, atol=1e-6)))),
+                ('const_1_6',
+                 dict(op='Const', value=lambda v: check_value(v, lambda x: np.allclose(x, 1.0 / 6.0, atol=1e-6)))),
                 ('clamp', dict(op='Clamp')),
                 ('mul_2', dict(op='Mul')),
             ],
@@ -86,10 +88,11 @@ class HSigmoidWithMinMax(FrontReplacementSubgraph):
             nodes=[
                 ('input', dict()),
                 ('add', dict(op='Add')),
-                ('const_0', dict(op='Const', value=lambda v: v is not None and np.allclose(v, 0.0, atol=1e-6))),
-                ('const_3', dict(op='Const', value=lambda v: v is not None and np.allclose(v, 3.0, atol=1e-6))),
-                ('const_6', dict(op='Const', value=lambda v: v is not None and np.allclose(v, 6.0, atol=1e-6))),
-                ('const_1_6', dict(op='Const', value=lambda v: v is not None and np.allclose(v, 1.0 / 6.0, atol=1e-6))),
+                ('const_0', dict(op='Const', value=lambda v: check_value(v, lambda x: np.allclose(x, 0.0, atol=1e-6)))),
+                ('const_3', dict(op='Const', value=lambda v: check_value(v, lambda x: np.allclose(x, 3.0, atol=1e-6)))),
+                ('const_6', dict(op='Const', value=lambda v: check_value(v, lambda x: np.allclose(x, 6.0, atol=1e-6)))),
+                ('const_1_6',
+                 dict(op='Const', value=lambda v: check_value(v, lambda x: np.allclose(x, 1.0 / 6.0, atol=1e-6)))),
                 ('max', dict(op='Maximum')),
                 ('min', dict(op='Minimum')),
                 ('mul_2', dict(op='Mul')),
@@ -123,12 +126,15 @@ class HSigmoidWithReluDiv(FrontReplacementSubgraph):
         return dict(
             nodes=[
                 ('input', dict()),
-                ('add_const', dict(op='Const', value=lambda v: v is not None and np.allclose(v, 3.0, atol=1e-6))),
+                ('add_const',
+                 dict(op='Const', value=lambda v: check_value(v, lambda x: np.allclose(x, 3.0, atol=1e-6)))),
                 ('add', dict(op='Add')),
                 ('relu', dict(op='ReLU')),
-                ('min_const', dict(op='Const', value=lambda v: v is not None and np.allclose(v, 6.0, atol=1e-6))),
+                ('min_const',
+                 dict(op='Const', value=lambda v: check_value(v, lambda x: np.allclose(x, 6.0, atol=1e-6)))),
                 ('min', dict(op='Minimum')),
-                ('div_const', dict(op='Const', value=lambda v: v is not None and np.allclose(v, 6.0, atol=1e-6))),
+                ('div_const',
+                 dict(op='Const', value=lambda v: check_value(v, lambda x: np.allclose(x, 6.0, atol=1e-6)))),
                 ('div', dict(op='Div')),
             ],
             edges=[
@@ -159,12 +165,15 @@ class HSigmoidWithReluMul(FrontReplacementSubgraph):
         return dict(
             nodes=[
                 ('input', dict()),
-                ('add_const', dict(op='Const', value=lambda v: v is not None and np.allclose(v, 3.0, atol=1e-6))),
+                ('add_const',
+                 dict(op='Const', value=lambda v: check_value(v, lambda x: np.allclose(x, 3.0, atol=1e-6)))),
                 ('add', dict(op='Add')),
                 ('relu', dict(op='ReLU')),
-                ('min_const', dict(op='Const', value=lambda v: v is not None and np.allclose(v, 6.0, atol=1e-6))),
+                ('min_const',
+                 dict(op='Const', value=lambda v: check_value(v, lambda x: np.allclose(x, 6.0, atol=1e-6)))),
                 ('min', dict(op='Minimum')),
-                ('mul_const', dict(op='Const', value=lambda v: v is not None and np.allclose(v, 1.0/6.0, atol=1e-6))),
+                ('mul_const',
+                 dict(op='Const', value=lambda v: check_value(v, lambda x: np.allclose(x, 1.0 / 6.0, atol=1e-6)))),
                 ('mul', dict(op='Mul')),
             ],
             edges=[

--- a/model-optimizer/extensions/front/HSwish_fusion.py
+++ b/model-optimizer/extensions/front/HSwish_fusion.py
@@ -20,6 +20,7 @@ from extensions.ops.activation_ops import HSwish
 from mo.front.common.replacement import FrontReplacementSubgraph
 from mo.front.subgraph_matcher import SubgraphMatch
 from mo.graph.graph import Graph, rename_nodes
+from mo.middle.pattern_match import check_value
 
 
 def replace_with_hswish(graph: Graph, match: [dict, SubgraphMatch]):
@@ -58,10 +59,11 @@ class HSwishWithClamp(FrontReplacementSubgraph):
             nodes=[
                 ('input', dict()),
                 ('add', dict(op='Add')),
-                ('const_0', dict(op='Const', value=lambda v: v is not None and np.allclose(v, 0.0, atol=1e-6))),
-                ('const_3', dict(op='Const', value=lambda v: v is not None and np.allclose(v, 3.0, atol=1e-6))),
-                ('const_6', dict(op='Const', value=lambda v: v is not None and np.allclose(v, 6.0, atol=1e-6))),
-                ('const_1_6', dict(op='Const', value=lambda v: v is not None and np.allclose(v, 1 / 6.0, atol=1e-6))),
+                ('const_0', dict(op='Const', value=lambda v: check_value(v, lambda x: np.allclose(x, 0.0, atol=1e-6)))),
+                ('const_3', dict(op='Const', value=lambda v: check_value(v, lambda x: np.allclose(x, 3.0, atol=1e-6)))),
+                ('const_6', dict(op='Const', value=lambda v: check_value(v, lambda x: np.allclose(x, 6.0, atol=1e-6)))),
+                ('const_1_6',
+                 dict(op='Const', value=lambda v: check_value(v, lambda x: np.allclose(x, 1.0 / 6.0, atol=1e-6)))),
                 ('clamp', dict(op='Clamp')),
                 ('mul', dict(op='Mul')),
                 ('mul_2', dict(op='Mul')),
@@ -97,10 +99,11 @@ class HSwishWithMinMax(FrontReplacementSubgraph):
             nodes=[
                 ('input', dict()),
                 ('add', dict(op='Add')),
-                ('const_0', dict(op='Const', value=lambda v: v is not None and np.allclose(v, 0.0, atol=1e-6))),
-                ('const_3', dict(op='Const', value=lambda v: v is not None and np.allclose(v, 3.0, atol=1e-6))),
-                ('const_6', dict(op='Const', value=lambda v: v is not None and np.allclose(v, 6.0, atol=1e-6))),
-                ('const_1_6', dict(op='Const', value=lambda v: v is not None and np.allclose(v, 1 / 6.0, atol=1e-6))),
+                ('const_0', dict(op='Const', value=lambda v: check_value(v, lambda x: np.allclose(x, 0.0, atol=1e-6)))),
+                ('const_3', dict(op='Const', value=lambda v: check_value(v, lambda x: np.allclose(x, 3.0, atol=1e-6)))),
+                ('const_6', dict(op='Const', value=lambda v: check_value(v, lambda x: np.allclose(x, 6.0, atol=1e-6)))),
+                ('const_1_6',
+                 dict(op='Const', value=lambda v: check_value(v, lambda x: np.allclose(x, 1.0 / 6.0, atol=1e-6)))),
                 ('max', dict(op='Maximum')),
                 ('min', dict(op='Minimum')),
                 ('mul', dict(op='Mul')),

--- a/model-optimizer/extensions/front/Softplus_fusion.py
+++ b/model-optimizer/extensions/front/Softplus_fusion.py
@@ -19,6 +19,7 @@ from extensions.ops.activation_ops import SoftPlus
 from mo.front.common.replacement import FrontReplacementSubgraph
 from mo.front.subgraph_matcher import SubgraphMatch
 from mo.graph.graph import Graph, rename_nodes
+from mo.middle.pattern_match import check_value
 
 
 class SoftplusFusion(FrontReplacementSubgraph):
@@ -32,7 +33,7 @@ class SoftplusFusion(FrontReplacementSubgraph):
             nodes=[
                 ('exp', dict(op='Exp')),
                 ('add', dict(op='Add')),
-                ('const_1', dict(op='Const', value=lambda v: v is not None and np.allclose(v, 1.0, atol=1e-6))),
+                ('const_1', dict(op='Const', value=lambda v: check_value(v, lambda x: np.allclose(x, 1.0, atol=1e-6)))),
                 ('ln', dict(op='Log')),
             ],
             edges=[

--- a/model-optimizer/mo/middle/pattern_match.py
+++ b/model-optimizer/mo/middle/pattern_match.py
@@ -16,6 +16,7 @@
 
 import logging as log
 
+import numpy as np
 from networkx.algorithms import isomorphism as ism
 
 from mo.graph.graph import Node, dict_includes, Graph
@@ -163,3 +164,7 @@ def find_isomorphisms(graph: Graph, nodes: list, edges: list):
         match = {k: Node(graph, match[k]) for k in match.keys()}
         result.append(match)
     return result
+
+
+def check_value(v: np.ndarray, check: callable):
+    return v is not None and np.all(np.isreal(v)) and check(v)


### PR DESCRIPTION
**Description:** Relax channel reversing restrictions for elementwise operations

**Ticket:** 45096

**Code:**
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names


**Validation:**
* [x]  Unit tests: N/A
* [x]  Framework operation tests: N/A
* [x]  Transformation tests: N/A Transformation works in complex with other ones. So testing the whole solution is available only in e2e scenario
* [x]  e2e model test with an update of ./tests/e2e_oss/utils/reshape_utils.py: N/A
* [x]  Model Optimizer IR Reader check: N/A


**Documentation:**
* [x]  Supported frameworks operations list: N/A
* [x]  Supported **public** models list: N/A
* [x]  New operations specification: N/A
* [x]  Guide on how to convert the **public** model: N/A
* [x]  User guide update: N/A