### PR TITLE
[CPU BF16] BF16 support was added to the SoftMax primitive.

### DIFF
--- a/inference-engine/src/mkldnn_plugin/bf16transformer.h
+++ b/inference-engine/src/mkldnn_plugin/bf16transformer.h
@@ -23,7 +23,7 @@ class BF16Transformer {
           "broadcast", "convert", "BatchToSpace", "DepthToSpace", "ExtractImagePatches", "concat", "power", "lrn",
           "permute", "ScatterUpdate", "ScatterElementsUpdate", "ScatterNDUpdate", "depthwise",
           "select", "ShuffleChannels", "SpaceToBatch", "SpaceToDepth", "squeeze", "StridedSlice", "unsqueeze", "eltwise",
-          "ReduceAnd", "ReduceOr", "ReduceMax", "ReduceMin", "ScaleShift"};
+          "ReduceAnd", "ReduceOr", "ReduceMax", "ReduceMin", "ScaleShift", "SoftMax"};
 
     const InferenceEngine::details::caseless_set<std::string> _multiinput =
         { "concat", "eltwise" };

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_softmax_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_softmax_node.cpp
@@ -21,7 +21,7 @@ void MKLDNNSoftMaxNode::getSupportedDescriptors() {
         return;
 
     InferenceEngine::Precision precision = getCnnLayer()->insData[0].lock()->getPrecision();
-    if (precision != InferenceEngine::Precision::FP32)
+    if (precision != InferenceEngine::Precision::FP32 && precision != InferenceEngine::Precision::BF16)
         precision = InferenceEngine::Precision::FP32;
     auto inputDataType = MKLDNNExtensionUtils::IEPrecisionToDataType(precision);
 

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/softmax.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/softmax.cpp
@@ -1,0 +1,171 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <ngraph_functions/builders.hpp>
+#include "test_utils/cpu_test_utils.hpp"
+
+using namespace InferenceEngine;
+using namespace CPUTestUtils;
+
+namespace CPULayerTestsDefinitions {
+struct SoftMaxConfig {
+    InferenceEngine::SizeVector  inputShape;
+    size_t axis;
+};
+
+typedef std::tuple<
+    InferenceEngine::Precision,         // netPrecision
+    SoftMaxConfig,                      // softmaxTestConfig
+    std::string,                        // targetDevice
+    CPUSpecificParams
+> softmaxCPUTestParams;
+
+class SoftMaxLayerCPUTest : public testing::WithParamInterface<softmaxCPUTestParams>,
+                            virtual public LayerTestsUtils::LayerTestsCommon, public CPUTestsBase {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<softmaxCPUTestParams>& obj) {
+        CPUSpecificParams cpuParams;
+        InferenceEngine::Precision netPrecision;
+        SoftMaxConfig config;
+        std::string targetDevice;
+        std::tie(netPrecision, config, targetDevice, cpuParams) = obj.param;
+
+        std::ostringstream result;
+        result << "netPRC=" << netPrecision.name() << "_";
+        result << "IS=" << CommonTestUtils::vec2str(config.inputShape) << "_";
+        result << "axis=" << config.axis << "_";
+        result << "trgDev=" << targetDevice;
+        result << CPUTestsBase::getTestCaseName(cpuParams);
+
+        return result.str();
+    }
+
+protected:
+    void SetUp() override {
+        InferenceEngine::Precision netPrecision;
+        SoftMaxConfig config;
+        CPUSpecificParams cpuParams;
+        std::tie(netPrecision, config, targetDevice, cpuParams) = this->GetParam();
+
+        inPrc = outPrc = netPrecision;
+
+        std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
+        if (selectedType.empty()) {
+            selectedType = getPrimitiveType();
+        }
+        selectedType.push_back('_');
+        selectedType += inPrc.name();
+
+        const auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+
+        auto params = ngraph::builder::makeParams(ngPrc, {config.inputShape});
+
+        const auto paramOuts =
+                ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
+
+        const auto softMax = std::make_shared<ngraph::opset1::Softmax>(paramOuts.at(0), config.axis);
+
+        function = makeNgraphFunction(ngPrc, params, softMax, "SoftMax");
+    }
+};
+
+TEST_P(SoftMaxLayerCPUTest, CompareWithRefs) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    Run();
+    CheckPluginRelatedResults(executableNetwork, "SoftMax");
+}
+
+namespace {
+//not optimized cpu spec
+const auto notOptimizedCPUSpec = CPUSpecificParams{{}, {}, {}, "ref_any"};
+
+const std::vector<SoftMaxConfig> optimizedConfigsFP32 {
+        {InferenceEngine::SizeVector{1, 100}, 1},
+        {InferenceEngine::SizeVector{10, 10}, 1},
+        {InferenceEngine::SizeVector{100, 1}, 0},
+        {InferenceEngine::SizeVector{100, 1}, 1},
+        {InferenceEngine::SizeVector{5, 5, 1}, 1},
+        {InferenceEngine::SizeVector{5, 5, 5}, 2},
+        {InferenceEngine::SizeVector{5, 5, 5, 5}, 0},
+        {InferenceEngine::SizeVector{5, 5, 5, 5}, 1},
+        {InferenceEngine::SizeVector{5, 5, 5, 5}, 2},
+        {InferenceEngine::SizeVector{5, 5, 5, 5, 5}, 0},
+        {InferenceEngine::SizeVector{5, 5, 5, 5, 5}, 1},
+        {InferenceEngine::SizeVector{5, 5, 5, 5, 5}, 2},
+        {InferenceEngine::SizeVector{5, 5, 5, 5, 5}, 3},
+        {InferenceEngine::SizeVector{5, 5, 5, 5, 5}, 4}
+};
+
+const std::vector<SoftMaxConfig> notOptimizedConfigsFP32 {
+        {InferenceEngine::SizeVector{1, 100}, 0},
+        {InferenceEngine::SizeVector{10, 10}, 0},
+        {InferenceEngine::SizeVector{10, 10, 10}, 0},
+        {InferenceEngine::SizeVector{10, 10, 10}, 1},
+};
+
+const auto OptimizedParams = testing::Combine(
+            testing::Values(Precision::FP32),
+            testing::ValuesIn(optimizedConfigsFP32),
+            testing::Values(CommonTestUtils::DEVICE_CPU),
+            testing::Values(emptyCPUSpec));
+
+INSTANTIATE_TEST_CASE_P(smoke_SoftMax_Optimized_CPU_FP32, SoftMaxLayerCPUTest, OptimizedParams, SoftMaxLayerCPUTest::getTestCaseName);
+
+const auto NotOptimizedParams = testing::Combine(
+        testing::Values(Precision::FP32),
+        testing::ValuesIn(notOptimizedConfigsFP32),
+        testing::Values(CommonTestUtils::DEVICE_CPU),
+        testing::Values(notOptimizedCPUSpec));
+
+INSTANTIATE_TEST_CASE_P(smoke_SoftMax_CPU_FP32, SoftMaxLayerCPUTest, NotOptimizedParams, SoftMaxLayerCPUTest::getTestCaseName);
+
+const std::vector<SoftMaxConfig> optimizedConfigsBF16 {
+        {InferenceEngine::SizeVector{1, 100}, 1},
+        {InferenceEngine::SizeVector{10, 10}, 1},
+        {InferenceEngine::SizeVector{100, 1}, 0},
+        {InferenceEngine::SizeVector{100, 1}, 1},
+        {InferenceEngine::SizeVector{5, 5, 1}, 1},
+        {InferenceEngine::SizeVector{5, 5, 5}, 2},
+        {InferenceEngine::SizeVector{5, 5, 1, 1}, 1},
+        {InferenceEngine::SizeVector{5, 5, 5, 1}, 2},
+        {InferenceEngine::SizeVector{5, 5, 5, 5}, 3},
+        {InferenceEngine::SizeVector{5, 5, 1, 1, 1}, 1},
+        {InferenceEngine::SizeVector{5, 5, 5, 1, 1}, 2},
+        {InferenceEngine::SizeVector{5, 5, 5, 1, 1}, 3},
+        {InferenceEngine::SizeVector{5, 5, 5, 5, 5}, 4}
+};
+
+const std::vector<SoftMaxConfig> notOptimizedConfigsBF16 {
+        {InferenceEngine::SizeVector{1, 100}, 0},
+        {InferenceEngine::SizeVector{10, 10}, 0},
+        {InferenceEngine::SizeVector{10, 10, 10}, 0},
+        {InferenceEngine::SizeVector{10, 10, 10}, 1},
+        {InferenceEngine::SizeVector{5, 5, 5, 5}, 0},
+        {InferenceEngine::SizeVector{5, 5, 5, 5}, 1},
+        {InferenceEngine::SizeVector{5, 5, 5, 5}, 2},
+        {InferenceEngine::SizeVector{5, 5, 5, 5, 5}, 0},
+        {InferenceEngine::SizeVector{5, 5, 5, 5, 5}, 1},
+        {InferenceEngine::SizeVector{5, 5, 5, 5, 5}, 2},
+        {InferenceEngine::SizeVector{5, 5, 5, 5, 5}, 3}
+};
+
+const auto OptimizedParamsBF16 = testing::Combine(
+        testing::Values(Precision::BF16),
+        testing::ValuesIn(optimizedConfigsBF16),
+        testing::Values(CommonTestUtils::DEVICE_CPU),
+        testing::Values(emptyCPUSpec));
+
+INSTANTIATE_TEST_CASE_P(smoke_SoftMax_Optimized_CPU_BF16, SoftMaxLayerCPUTest, OptimizedParamsBF16, SoftMaxLayerCPUTest::getTestCaseName);
+
+const auto NotOptimizedParamsBF16 = testing::Combine(
+        testing::Values(Precision::BF16),
+        testing::ValuesIn(notOptimizedConfigsBF16),
+        testing::Values(CommonTestUtils::DEVICE_CPU),
+        testing::Values(notOptimizedCPUSpec));
+
+INSTANTIATE_TEST_CASE_P(smoke_SoftMax_CPU_BF16, SoftMaxLayerCPUTest, NotOptimizedParamsBF16, SoftMaxLayerCPUTest::getTestCaseName);
+
+} // namespace
+} // namespace CPULayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/softmax.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/softmax.cpp
@@ -89,13 +89,20 @@ const std::vector<SoftMaxConfig> optimizedConfigsFP32 {
         {InferenceEngine::SizeVector{5, 5, 1}, 1},
         {InferenceEngine::SizeVector{5, 5, 5}, 2},
         {InferenceEngine::SizeVector{5, 5, 5, 5}, 0},
+        {InferenceEngine::SizeVector{5, 5, 1, 1}, 1},
         {InferenceEngine::SizeVector{5, 5, 5, 5}, 1},
+        {InferenceEngine::SizeVector{5, 5, 5, 1}, 2},
         {InferenceEngine::SizeVector{5, 5, 5, 5}, 2},
+        {InferenceEngine::SizeVector{5, 5, 5, 5}, 3},
         {InferenceEngine::SizeVector{5, 5, 5, 5, 5}, 0},
+        {InferenceEngine::SizeVector{5, 5, 1, 1, 1}, 1},
         {InferenceEngine::SizeVector{5, 5, 5, 5, 5}, 1},
+        {InferenceEngine::SizeVector{5, 5, 5, 1, 1}, 2},
         {InferenceEngine::SizeVector{5, 5, 5, 5, 5}, 2},
+        {InferenceEngine::SizeVector{5, 5, 5, 1, 1}, 3},
         {InferenceEngine::SizeVector{5, 5, 5, 5, 5}, 3},
-        {InferenceEngine::SizeVector{5, 5, 5, 5, 5}, 4}
+        {InferenceEngine::SizeVector{5, 5, 5, 5, 1}, 4},
+        {InferenceEngine::SizeVector{5, 5, 5, 5, 5}, 4},
 };
 
 const std::vector<SoftMaxConfig> notOptimizedConfigsFP32 {
@@ -106,66 +113,20 @@ const std::vector<SoftMaxConfig> notOptimizedConfigsFP32 {
 };
 
 const auto OptimizedParams = testing::Combine(
-            testing::Values(Precision::FP32),
-            testing::ValuesIn(optimizedConfigsFP32),
-            testing::Values(CommonTestUtils::DEVICE_CPU),
-            testing::Values(emptyCPUSpec));
+        testing::Values(Precision::FP32, Precision::BF16),
+        testing::ValuesIn(optimizedConfigsFP32),
+        testing::Values(CommonTestUtils::DEVICE_CPU),
+        testing::Values(emptyCPUSpec));
 
-INSTANTIATE_TEST_CASE_P(smoke_SoftMax_Optimized_CPU_FP32, SoftMaxLayerCPUTest, OptimizedParams, SoftMaxLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_SoftMax_Optimized_CPU, SoftMaxLayerCPUTest, OptimizedParams, SoftMaxLayerCPUTest::getTestCaseName);
 
 const auto NotOptimizedParams = testing::Combine(
-        testing::Values(Precision::FP32),
+        testing::Values(Precision::FP32, Precision::BF16),
         testing::ValuesIn(notOptimizedConfigsFP32),
         testing::Values(CommonTestUtils::DEVICE_CPU),
         testing::Values(notOptimizedCPUSpec));
 
-INSTANTIATE_TEST_CASE_P(smoke_SoftMax_CPU_FP32, SoftMaxLayerCPUTest, NotOptimizedParams, SoftMaxLayerCPUTest::getTestCaseName);
-
-const std::vector<SoftMaxConfig> optimizedConfigsBF16 {
-        {InferenceEngine::SizeVector{1, 100}, 1},
-        {InferenceEngine::SizeVector{10, 10}, 1},
-        {InferenceEngine::SizeVector{100, 1}, 0},
-        {InferenceEngine::SizeVector{100, 1}, 1},
-        {InferenceEngine::SizeVector{5, 5, 1}, 1},
-        {InferenceEngine::SizeVector{5, 5, 5}, 2},
-        {InferenceEngine::SizeVector{5, 5, 1, 1}, 1},
-        {InferenceEngine::SizeVector{5, 5, 5, 1}, 2},
-        {InferenceEngine::SizeVector{5, 5, 5, 5}, 3},
-        {InferenceEngine::SizeVector{5, 5, 1, 1, 1}, 1},
-        {InferenceEngine::SizeVector{5, 5, 5, 1, 1}, 2},
-        {InferenceEngine::SizeVector{5, 5, 5, 1, 1}, 3},
-        {InferenceEngine::SizeVector{5, 5, 5, 5, 5}, 4}
-};
-
-const std::vector<SoftMaxConfig> notOptimizedConfigsBF16 {
-        {InferenceEngine::SizeVector{1, 100}, 0},
-        {InferenceEngine::SizeVector{10, 10}, 0},
-        {InferenceEngine::SizeVector{10, 10, 10}, 0},
-        {InferenceEngine::SizeVector{10, 10, 10}, 1},
-        {InferenceEngine::SizeVector{5, 5, 5, 5}, 0},
-        {InferenceEngine::SizeVector{5, 5, 5, 5}, 1},
-        {InferenceEngine::SizeVector{5, 5, 5, 5}, 2},
-        {InferenceEngine::SizeVector{5, 5, 5, 5, 5}, 0},
-        {InferenceEngine::SizeVector{5, 5, 5, 5, 5}, 1},
-        {InferenceEngine::SizeVector{5, 5, 5, 5, 5}, 2},
-        {InferenceEngine::SizeVector{5, 5, 5, 5, 5}, 3}
-};
-
-const auto OptimizedParamsBF16 = testing::Combine(
-        testing::Values(Precision::BF16),
-        testing::ValuesIn(optimizedConfigsBF16),
-        testing::Values(CommonTestUtils::DEVICE_CPU),
-        testing::Values(emptyCPUSpec));
-
-INSTANTIATE_TEST_CASE_P(smoke_SoftMax_Optimized_CPU_BF16, SoftMaxLayerCPUTest, OptimizedParamsBF16, SoftMaxLayerCPUTest::getTestCaseName);
-
-const auto NotOptimizedParamsBF16 = testing::Combine(
-        testing::Values(Precision::BF16),
-        testing::ValuesIn(notOptimizedConfigsBF16),
-        testing::Values(CommonTestUtils::DEVICE_CPU),
-        testing::Values(notOptimizedCPUSpec));
-
-INSTANTIATE_TEST_CASE_P(smoke_SoftMax_CPU_BF16, SoftMaxLayerCPUTest, NotOptimizedParamsBF16, SoftMaxLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_SoftMax_CPU, SoftMaxLayerCPUTest, NotOptimizedParams, SoftMaxLayerCPUTest::getTestCaseName);
 
 } // namespace
 } // namespace CPULayerTestsDefinitions


### PR DESCRIPTION
OneDNN  fork SoftMax primitive was extended with the bfloat16 support. See ticket 32817.
Corresponding oneDNN PR https://github.com/openvinotoolkit/oneDNN/pull/34.