### PR TITLE
Always build sea_itt_lib

### DIFF
--- a/thirdparty/itt_collector/CMakeLists.txt
+++ b/thirdparty/itt_collector/CMakeLists.txt
@@ -14,6 +14,4 @@
 # limitations under the License.
 # ******************************************************************************
 
-if(ENABLE_PROFILING_ITT AND SELECTIVE_BUILD STREQUAL "COLLECT")
-    add_subdirectory(sea_itt_lib)
-endif()
+add_subdirectory(sea_itt_lib)


### PR DESCRIPTION
sea_itt_lib is an ITT collector. Building it by default to ensure
build is validation across different platfroms and code is under stataic
analysis