### PR TITLE
Fix TI deserialization

### DIFF
--- a/inference-engine/src/readers/ir_reader/ie_ir_parser.cpp
+++ b/inference-engine/src/readers/ir_reader/ie_ir_parser.cpp
@@ -47,33 +47,38 @@ IRParser::IRParser(size_t version, const std::vector<InferenceEngine::IExtension
     }
 }
 
-std::map<uint64_t, uint64_t> V10Parser::XmlDeserializer::map_type_in_function(const pugi::xml_node& node,
-    const std::string map_type) {
-    std::map<uint64_t, uint64_t> type_id_in_function;
-    uint64_t map_type_number = 0;
+thread_local V10Parser::XmlDeserializer::NodeIdToIoIndexStack V10Parser::XmlDeserializer::io_map_stack;
+
+
+V10Parser::XmlDeserializer::IoMap V10Parser::XmlDeserializer::updated_io_map(const pugi::xml_node& node) {
     auto body_node = node.child("body");
 
     if (body_node.empty()) {
         THROW_IE_EXCEPTION << "Missing body part.";
     }
-
     // Fill map: parameter/result id to parameter/result number in Function
+
+    auto io_map = V10Parser::XmlDeserializer::io_map_stack.top();
+
+    using io = V10Parser::XmlDeserializer::io;
     FOREACH_CHILD(layer, body_node.child("layers"), "layer") {
         auto type = XMLParseUtils::GetStrAttr(layer, "type");
 
-        if (type == map_type) {
+        if (type == "Parameter") {
             auto id = XMLParseUtils::GetUIntAttr(layer, "id");
-            type_id_in_function.emplace(id, map_type_number);
-            map_type_number++;
+            io_map[io::INPUTS].insert({id, -1});
+        } else if (type == "Result") {
+            auto id = XMLParseUtils::GetUIntAttr(layer, "id");
+            io_map[io::INPUTS].insert({id, -1});
         }
     }
-    return type_id_in_function;
+    return io_map;
 }
+
 
 std::vector<std::shared_ptr<ngraph::op::util::SubGraphOp::InputDescription>> V10Parser::XmlDeserializer::parseInputDescription(const pugi::xml_node& node) {
     std::vector<std::shared_ptr<ngraph::op::util::SubGraphOp::InputDescription>> inputs;
-    std::map<uint64_t, uint64_t> param_id_in_function = map_type_in_function(node, "Parameter");
-    std::map<uint64_t, uint64_t> result_id_in_function = map_type_in_function(node, "Result");
+    const auto io_map = updated_io_map(node);
 
     // Parse PortMap: external_port_id for inputs does not always appear in consecutive order
     std::map<uint64_t, pugi::xml_node> input_map;
@@ -96,9 +101,11 @@ std::vector<std::shared_ptr<ngraph::op::util::SubGraphOp::InputDescription>> V10
             int64_t end = XMLParseUtils::GetInt64Attr(xml_input, "end", -1);
             int64_t part_size = XMLParseUtils::GetInt64Attr(xml_input, "part_size", 1);
 
+            const auto input_index = io_map.at(io::INPUTS).at(body_parameter_index);
+
             inputs.push_back(std::make_shared<ngraph::op::util::SubGraphOp::SliceInputDescription>
                     (ti_input_index,
-                    param_id_in_function[body_parameter_index],
+                    input_index,
                     start,
                     stride,
                     part_size,
@@ -112,10 +119,14 @@ std::vector<std::shared_ptr<ngraph::op::util::SubGraphOp::InputDescription>> V10
 
                 if (to_layer == body_parameter_index) {
                     size_t from_layer = XMLParseUtils::GetUIntAttr(xml_edge, "from-layer");
+
+                    const auto input_index = io_map.at(io::INPUTS).at(body_parameter_index);
+                    const auto output_index = io_map.at(io::OUTPUTS).at(from_layer);
+
                     inputs.push_back(std::make_shared<ngraph::op::util::SubGraphOp::MergedInputDescription>
                         (ti_input_index,
-                        param_id_in_function[body_parameter_index],
-                        result_id_in_function[from_layer]));
+                        input_index,
+                        output_index));
 
                     is_back_edge_exist = true;
                     break;
@@ -125,9 +136,11 @@ std::vector<std::shared_ptr<ngraph::op::util::SubGraphOp::InputDescription>> V10
             // ti_input_index = -1 means that Parameter of the body is not connected to inputs of TensorIterator
             // and is used only for internal needs.
             if (!is_back_edge_exist && ti_input_index >= 0) {
+                const auto input_index = io_map.at(io::INPUTS).at(body_parameter_index);
+
                 inputs.push_back(std::make_shared<ngraph::op::util::SubGraphOp::InvariantInputDescription>
                     (ti_input_index,
-                    param_id_in_function[body_parameter_index]));
+                    input_index));
             }
         }
     }
@@ -136,7 +149,7 @@ std::vector<std::shared_ptr<ngraph::op::util::SubGraphOp::InputDescription>> V10
 
 std::vector<std::shared_ptr<ngraph::op::util::SubGraphOp::OutputDescription>> V10Parser::XmlDeserializer::parseOutputDescription(const pugi::xml_node& node) {
     std::vector<std::shared_ptr<ngraph::op::util::SubGraphOp::OutputDescription>> outputs;
-    std::map<uint64_t, uint64_t> result_id_in_function = map_type_in_function(node, "Result");
+    const auto io_map = updated_io_map(node);
 
     // Parse PortMap: outputs
     std::map<int64_t, pugi::xml_node> output_map;
@@ -162,8 +175,10 @@ std::vector<std::shared_ptr<ngraph::op::util::SubGraphOp::OutputDescription>> V1
                 int64_t end = XMLParseUtils::GetInt64Attr(xml_output, "end", -1);
                 int64_t part_size = XMLParseUtils::GetInt64Attr(xml_output, "part_size", 1);
 
+                const auto output_index = io_map.at(io::OUTPUTS).at(body_result_index);
+
                 outputs.push_back(std::make_shared<ngraph::op::util::SubGraphOp::ConcatOutputDescription>
-                        (result_id_in_function[body_result_index],
+                        (output_index,
                         output_number,
                         start,
                         stride,
@@ -172,8 +187,10 @@ std::vector<std::shared_ptr<ngraph::op::util::SubGraphOp::OutputDescription>> V1
                         axis));
             } else {
                 // otherwise create ngraph::TensorIterator::BodyOutput. -1 means last iteration.
+                const auto output_index = io_map.at(io::OUTPUTS).at(body_result_index);
+
                 outputs.push_back(std::make_shared<ngraph::op::util::SubGraphOp::BodyOutputDescription>
-                        (result_id_in_function[body_result_index],
+                        (output_index,
                         output_number,
                         -1));
             }
@@ -185,10 +202,10 @@ std::vector<std::shared_ptr<ngraph::op::util::SubGraphOp::OutputDescription>> V1
 
 ngraph::op::v5::Loop::SpecialBodyPorts V10Parser::XmlDeserializer::parsePurposeAttribute(const pugi::xml_node& node) {
     ngraph::op::v5::Loop::SpecialBodyPorts result = {-1, -1};
-    std::map<uint64_t, uint64_t> params = map_type_in_function(node, "Parameter");
-    std::map<uint64_t, uint64_t> results = map_type_in_function(node, "Result");
+    const auto io_map = updated_io_map(node);
 
-    NGRAPH_CHECK(!params.empty() || !results.empty(), "No parameters or results found in body Function.");
+    NGRAPH_CHECK(!io_map.at(io::INPUTS).empty() || !io_map.at(io::OUTPUTS).empty(),
+                 "No parameters or results found in body Function.");
 
     // Parse PortMap: external_port_id for inputs/outputs does not always appear in consecutive order
     std::map<uint64_t, pugi::xml_node> input_map;
@@ -207,7 +224,7 @@ ngraph::op::v5::Loop::SpecialBodyPorts V10Parser::XmlDeserializer::parsePurposeA
         auto purpose = XMLParseUtils::GetStrAttr(xml_input, "purpose", "");
         size_t body_parameter_index = XMLParseUtils::GetUIntAttr(xml_input, "internal_layer_id");
         if (purpose == "current_iteration") {
-            result.current_iteration_input_idx = params[body_parameter_index];
+            result.current_iteration_input_idx = io_map.at(io::INPUTS).at(body_parameter_index);
         }
     }
 
@@ -216,7 +233,7 @@ ngraph::op::v5::Loop::SpecialBodyPorts V10Parser::XmlDeserializer::parsePurposeA
         auto purpose = XMLParseUtils::GetStrAttr(xml_output, "purpose", "");
         size_t body_parameter_index = XMLParseUtils::GetUIntAttr(xml_output, "internal_layer_id");
         if (purpose == "execution_condition") {
-            result.body_condition_output_idx = results[body_parameter_index];
+            result.body_condition_output_idx = io_map.at(io::OUTPUTS).at(body_parameter_index);
         }
     }
 
@@ -316,13 +333,18 @@ void V10Parser::XmlDeserializer::on_adapter(const std::string& name, ngraph::Val
     adapter.set(ngraph_function);
 }
 
+
 std::shared_ptr<ngraph::Function> V10Parser::XmlDeserializer::parse_function(const pugi::xml_node& root, const Blob::CPtr& weights) {
     OV_ITT_TASK_CHAIN(taskChain, itt::domains::V10Reader_RT, "V10Parser", "Parse");
 
-    using node_params = struct {
+    struct edge {
+        size_t fromLayerId, fromPortId, toPortId;
+    };
+    struct node_params {
         pugi::xml_node xml;
         GenericLayerParams params;
     };
+
     std::map<size_t, node_params> params;
 
     std::vector<size_t> outputs;
@@ -340,7 +362,6 @@ std::shared_ptr<ngraph::Function> V10Parser::XmlDeserializer::parse_function(con
         }
     }
 
-    using edge = struct { size_t fromLayerId, fromPortId, toPortId; };
     std::map<size_t, std::vector<edge>> edges;
     std::map<size_t, std::shared_ptr<ngraph::Node>> id_to_node;
 
@@ -408,10 +429,12 @@ std::shared_ptr<ngraph::Function> V10Parser::XmlDeserializer::parse_function(con
         //        }
 
         if (const auto& parameter_node = std::dynamic_pointer_cast<ngraph::op::Parameter>(node)) {
+            io_map_stack.top()[io::INPUTS].insert({layer_id, parameter_nodes.size()});
             parameter_nodes.emplace_back(parameter_node);
         }
 
         if (const auto& result_node = std::dynamic_pointer_cast<ngraph::op::Result>(node)) {
+            io_map_stack.top()[io::OUTPUTS].insert({layer_id, result_nodes.size()});
             result_nodes.emplace_back(result_node);
         }
 
@@ -477,6 +500,7 @@ V10Parser::V10Parser(const std::vector<IExtensionPtr>& exts) : _exts(exts) {
 
 std::shared_ptr<ICNNNetwork> V10Parser::parse(const pugi::xml_node& root, const Blob::CPtr& weights) {
     std::shared_ptr<ngraph::Function> function;
+    const XmlDeserializer::NextLevelOfIoMap l{};
     XmlDeserializer visitor(root, weights, opsets, variables);
     visitor.on_attribute("net", function);
 
@@ -739,6 +763,7 @@ std::shared_ptr<ngraph::Node> V10Parser::XmlDeserializer::createNode(
             THROW_IE_EXCEPTION << "Opset " << params.version << " doesn't contain the operation with type: " << type;
         }
         ngraphNode->set_arguments(inputs);
+        const XmlDeserializer::NextLevelOfIoMap l{};
         XmlDeserializer visitor(node, weights, opsets, variables);
         if (ngraphNode->visit_attributes(visitor)) {
             ngraphNode->constructor_validate_and_infer_types();

--- a/inference-engine/src/readers/ir_reader/ie_ir_parser.cpp
+++ b/inference-engine/src/readers/ir_reader/ie_ir_parser.cpp
@@ -65,7 +65,7 @@ V10Parser::XmlDeserializer::IoMap V10Parser::XmlDeserializer::updated_io_map(con
             extend_io_map[io::INPUTS].insert({id, -1});
         } else if (type == "Result") {
             auto id = XMLParseUtils::GetUIntAttr(layer, "id");
-            extend_io_map[io::INPUTS].insert({id, -1});
+            extend_io_map[io::OUTPUTS].insert({id, -1});
         }
     }
     return extend_io_map;

--- a/inference-engine/src/readers/ir_reader/ie_ir_parser.hpp
+++ b/inference-engine/src/readers/ir_reader/ie_ir_parser.hpp
@@ -187,7 +187,7 @@ private:
         enum class io { INPUTS, OUTPUTS };
 
         using NodeIdToIoIndex = std::unordered_map<size_t /*xml node id*/, uint64_t /*body io index*/>;
-        using IoMap = std::unordered_map<io, NodeIdToIoIndex>;
+        using IoMap = std::map<io, NodeIdToIoIndex>;
 
         explicit XmlDeserializer(
             const pugi::xml_node& node,

--- a/inference-engine/src/readers/ir_reader/ie_ir_parser.hpp
+++ b/inference-engine/src/readers/ir_reader/ie_ir_parser.hpp
@@ -184,11 +184,6 @@ private:
     class XmlDeserializer : public ngraph::AttributeVisitor {
     public:
         /// TODO: move whole class to src file
-        enum class io { INPUTS, OUTPUTS };
-
-        using NodeIdToIoIndex = std::unordered_map<size_t /*xml node id*/, uint64_t /*body io index*/>;
-        using IoMap = std::map<io, NodeIdToIoIndex>;
-
         explicit XmlDeserializer(
             const pugi::xml_node& node,
             const Blob::CPtr& weights,
@@ -299,6 +294,12 @@ private:
 
 
     private:
+        struct IoMap {
+            using NodeIdToIoIndex = std::unordered_map<size_t /*xml node id*/, uint64_t /*body io index*/>;
+            NodeIdToIoIndex inputs;
+            NodeIdToIoIndex outputs;
+        };
+
         //TODO move data to the bottom (or top)
         const pugi::xml_node node;
         const Blob::CPtr& weights;

--- a/inference-engine/tests/functional/inference_engine/ir_serialization/models/ti_resnet.xml
+++ b/inference-engine/tests/functional/inference_engine/ir_serialization/models/ti_resnet.xml
@@ -74,16 +74,11 @@
             </back_edges>
             <body>
                 <layers>
-                    <layer id="0" name="20" type="Parameter" version="opset1">
-                        <data element_type="f32" shape="1,1,512"/>
-                        <output>
-                            <port id="0" precision="FP32">
-                                <dim>1</dim>
-                                <dim>1</dim>
-                                <dim>512</dim>
-                            </port>
-                        </output>
-                    </layer>
+                <!--
+                ***************************************************************************************
+                * nodes are place unordered to check if XmlDeserializer is not depend on layers order *
+                ***************************************************************************************
+                -->
                     <layer id="1" name="7_const" type="Const" version="opset1">
                         <data element_type="i64" offset="0" shape="2" size="16"/>
                         <output>
@@ -193,6 +188,15 @@
                             </port>
                         </output>
                     </layer>
+                    <layer id="13" name="18/sink_port_0" type="Result" version="opset1">
+                        <input>
+                            <port id="0">
+                                <dim>1</dim>
+                                <dim>1</dim>
+                                <dim>512</dim>
+                            </port>
+                        </input>
+                    </layer>
                     <layer id="9" name="471/outport/0/sink_port_0" type="Result" version="opset1">
                         <input>
                             <port id="0">
@@ -236,14 +240,15 @@
                             </port>
                         </output>
                     </layer>
-                    <layer id="13" name="18/sink_port_0" type="Result" version="opset1">
-                        <input>
-                            <port id="0">
+                    <layer id="0" name="20" type="Parameter" version="opset1">
+                        <data element_type="f32" shape="1,1,512"/>
+                        <output>
+                            <port id="0" precision="FP32">
                                 <dim>1</dim>
                                 <dim>1</dim>
                                 <dim>512</dim>
                             </port>
-                        </input>
+                        </output>
                     </layer>
                 </layers>
                 <edges>


### PR DESCRIPTION
This change is required because we can't depend on xml node sorting/ordering algorithm. Sorting algo start building nodes ids order based on Results nodes which might be serialize in different order than it was read from xml (xml order won't be preserve).

We have to have some mechanism for renumerate input (index/order) and store indexes in In/Out Description.

Ticket 44194. 