### PR TITLE
[VPU] Use nGraph value propagation in VPU private ops

### DIFF
--- a/inference-engine/src/vpu/common/include/vpu/ngraph/operations/static_shape_broadcast.hpp
+++ b/inference-engine/src/vpu/common/include/vpu/ngraph/operations/static_shape_broadcast.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/inference-engine/src/vpu/common/include/vpu/ngraph/operations/static_shape_broadcast.hpp
+++ b/inference-engine/src/vpu/common/include/vpu/ngraph/operations/static_shape_broadcast.hpp
@@ -36,13 +36,7 @@ public:
 
     bool visit_attributes(ngraph::AttributeVisitor& visitor) override;
 
-    PartialShape getEvaluatedShape() const { return m_evaluatedOutputShape; }
-    void setEvaluatedShape(const PartialShape& shape) { m_evaluatedOutputShape = shape; }
-
     bool evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const override;
-
-private:
-    PartialShape m_evaluatedOutputShape;
 };
 
 }  // namespace op

--- a/inference-engine/src/vpu/common/include/vpu/ngraph/operations/static_shape_topk.hpp
+++ b/inference-engine/src/vpu/common/include/vpu/ngraph/operations/static_shape_topk.hpp
@@ -58,7 +58,7 @@ public:
 
 protected:
     int64_t m_axis;
-    int64_t m_maximumK;
+    ngraph::Dimension m_maximumK;
     uint64_t m_normalized_axis;
     Mode m_mode;
     SortType m_sort;

--- a/inference-engine/src/vpu/common/include/vpu/ngraph/operations/static_shape_topk.hpp
+++ b/inference-engine/src/vpu/common/include/vpu/ngraph/operations/static_shape_topk.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -13,14 +13,9 @@
 
 namespace ngraph { namespace vpu { namespace op {
 
-class StaticShapeTopK : public ngraph::op::Op {
+class StaticShapeTopK : public ngraph::op::v3::TopK {
 public:
-    static constexpr NodeTypeInfo type_info{"StaticShapeTopK", 0};
-
-    const NodeTypeInfo& get_type_info() const override { return type_info; }
-
-    using SortType = ngraph::op::TopKSortType;
-    using Mode = ngraph::op::TopKMode;
+    NGRAPH_RTTI_DECLARATION;
 
     StaticShapeTopK(const Output<Node>& data,
                     const Output<Node>& k,
@@ -36,33 +31,7 @@ public:
                     const SortType sort,
                     const element::Type& index_element_type = element::i32);
 
-    bool visit_attributes(AttributeVisitor& visitor) override;
     void validate_and_infer_types() override;
-
-    std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
-
-    size_t get_version() const override { return 1; }
-
-    uint64_t get_axis() const;
-    int64_t get_provided_axis() const { return m_axis; }
-    void set_axis(const int64_t axis);
-    Mode get_mode() const { return m_mode; }
-    void set_mode(const Mode mode) { m_mode = mode; }
-    SortType get_sort_type() const { return m_sort; }
-    void set_sort_type(const SortType sort) { m_sort = sort; }
-    element::Type get_index_element_type() const { return m_index_element_type; }
-    void set_index_element_type(const element::Type& index_element_type) {
-        m_index_element_type = index_element_type;
-    }
-    size_t get_default_output_index() const override { return no_default_index(); }
-
-protected:
-    int64_t m_axis;
-    ngraph::Dimension m_maximumK;
-    uint64_t m_normalized_axis;
-    Mode m_mode;
-    SortType m_sort;
-    element::Type m_index_element_type{element::i32};
 };
 
 }  // namespace op

--- a/inference-engine/src/vpu/common/include/vpu/ngraph/utilities.hpp
+++ b/inference-engine/src/vpu/common/include/vpu/ngraph/utilities.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/inference-engine/src/vpu/common/include/vpu/ngraph/utilities.hpp
+++ b/inference-engine/src/vpu/common/include/vpu/ngraph/utilities.hpp
@@ -14,8 +14,6 @@
 
 namespace vpu {
 
-std::vector<std::int64_t> evaluateTargetShape(const ngraph::Output<ngraph::Node>& value);
-
 std::shared_ptr<ngraph::Node> shapeToConstant(const ngraph::element::Type& type, const ngraph::Shape& shape);
 
 std::shared_ptr<ngraph::Node> gatherShapeElements(const ngraph::Output<ngraph::Node>&, int startIndex, size_t elemCount);

--- a/inference-engine/src/vpu/common/src/ngraph/operations/static_shape_broadcast.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/operations/static_shape_broadcast.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -31,51 +31,22 @@ StaticShapeBroadcast::StaticShapeBroadcast(const Output<Node>& arg,
 }
 
 void StaticShapeBroadcast::validate_and_infer_types() {
-    if (m_mode.m_type == ngraph::op::BroadcastType::EXPLICIT) {
-        NODE_VALIDATION_CHECK(this, get_input_size() == 3,
-                              "StaticShapeBroadcast (", get_friendly_name(), ") ",
-                              "with explicit mode must have 3 inputs, provided: ",
-                              get_input_size());
-    } else if (m_mode.m_type == ngraph::op::BroadcastType::NUMPY || m_mode.m_type == ngraph::op::BroadcastType::BIDIRECTIONAL) {
-        NODE_VALIDATION_CHECK(this, get_input_size() == 2,
-                              "StaticShapeBroadcast (", get_friendly_name(), ") ",
-                              "with ", m_mode.m_type, " mode must have 2 inputs, provided: ",
-                              get_input_size());
-    } else {
-        NODE_VALIDATION_CHECK(this, false,
-                              "StaticShapeBroadcast (", get_friendly_name(), ") ",
-                              "doesn't support ", m_mode.m_type, " mode");
-    }
-
     if (get_output_partial_shape(0).is_static()) {
         return;
     }
 
     ::ngraph::op::v3::Broadcast::validate_and_infer_types();
-    // Try to evaluate output shape. After some transformations further, we may not be able
-    // to evaluate the target shape again, then we will leave the evaluated shape unchanged.
-    // For example, EliminateShapeOfAfterDSR remove ShapeOf and pass the second input of DSR.
-    ngraph::PartialShape evaluatedTargetShape;
-    NODE_VALIDATION_CHECK(this, ngraph::evaluate_as_partial_shape(input_value(1), evaluatedTargetShape) && evaluatedTargetShape.is_static(),
+
+    auto outputShape = get_output_partial_shape(0);
+    NODE_VALIDATION_CHECK(this, outputShape.rank().is_static(), "StaticShapeBroadcast (", get_friendly_name(), ") ",
+                          "output is expected to be of static rank");
+    for (size_t i = 0; i < outputShape.rank().get_length(); i++) {
+        outputShape[i] = outputShape[i].get_max_length();
+    }
+    NODE_VALIDATION_CHECK(this, outputShape.is_static(),
                           "StaticShapeBroadcast (", get_friendly_name(), ") can't evaluate output shape");
 
-    auto targetShape = evaluatedTargetShape.get_shape();
-
-    if (m_mode.m_type == ngraph::op::BroadcastType::BIDIRECTIONAL) {
-        auto inputShape = get_input_partial_shape(0).get_shape();
-
-        auto& lowRankShape = targetShape.size() < inputShape.size() ? targetShape : inputShape;
-        auto& highRankShape = lowRankShape == targetShape ? inputShape : targetShape;
-
-        while (lowRankShape.size() < highRankShape.size()) {
-            lowRankShape.insert(lowRankShape.begin(), 1);
-        }
-
-        for (size_t i = 0; i < targetShape.size(); i++) {
-            targetShape[i] = std::max(targetShape[i], inputShape[i]);
-        }
-    }
-    set_output_type(0, get_input_element_type(0), targetShape);
+    set_output_type(0, get_input_element_type(0), outputShape);
 }
 
 std::shared_ptr<Node> StaticShapeBroadcast::clone_with_new_inputs(const OutputVector& newInputs) const {

--- a/inference-engine/src/vpu/common/src/ngraph/operations/static_shape_broadcast.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/operations/static_shape_broadcast.cpp
@@ -9,6 +9,7 @@
 
 #include "ngraph/opsets/opset3.hpp"
 #include "ngraph/evaluator.hpp"
+#include <ngraph/validation_util.hpp>
 
 namespace ngraph { namespace vpu { namespace op {
 
@@ -18,16 +19,14 @@ StaticShapeBroadcast::StaticShapeBroadcast(const Output<Node>& arg,
                                            const Output<Node>& targetShape,
                                            const Output<Node>& axesMapping,
                                            const ngraph::op::BroadcastModeSpec& broadcastSpec)
-        : ::ngraph::op::v3::Broadcast{arg, targetShape, axesMapping, broadcastSpec},
-          m_evaluatedOutputShape{PartialShape::dynamic()} {
+        : ::ngraph::op::v3::Broadcast{arg, targetShape, axesMapping, broadcastSpec} {
     constructor_validate_and_infer_types();
 }
 
 StaticShapeBroadcast::StaticShapeBroadcast(const Output<Node>& arg,
                                            const Output<Node>& targetShape,
                                            const ngraph::op::BroadcastModeSpec& broadcastSpec)
-        : ::ngraph::op::v3::Broadcast{arg, targetShape, broadcastSpec},
-          m_evaluatedOutputShape{PartialShape::dynamic()} {
+        : ::ngraph::op::v3::Broadcast{arg, targetShape, broadcastSpec} {
     constructor_validate_and_infer_types();
 }
 
@@ -48,44 +47,38 @@ void StaticShapeBroadcast::validate_and_infer_types() {
                               "doesn't support ", m_mode.m_type, " mode");
     }
 
-    if (get_output_partial_shape(0).is_dynamic()) {
-        ::ngraph::op::v3::Broadcast::validate_and_infer_types();
-        // Try to evaluate output shape. After some transformations further, we may not be able
-        // to evaluate the target shape again, then we will leave the evaluated shape unchanged.
-        // For example, EliminateShapeOfAfterDSR remove ShapeOf and pass the second input of DSR.
-        const auto evaluatedDimensionValues = ::vpu::evaluateTargetShape(input_value(1));
-        NODE_VALIDATION_CHECK(this, !evaluatedDimensionValues.empty(), "StaticShapeBroadcast (", get_friendly_name(), ") can't evaluate output shape");
-
-        const auto evaluatedTargetShape = ngraph::PartialShape(evaluatedDimensionValues);
-        if (evaluatedTargetShape.is_static()) {
-            if (m_mode.m_type == ngraph::op::BroadcastType::BIDIRECTIONAL) {
-                auto targetShape = evaluatedTargetShape.get_shape();
-                auto inputShape = get_input_partial_shape(0).get_shape();
-
-                auto& lowRankShape = targetShape.size() < inputShape.size() ? targetShape : inputShape;
-                auto& highRankShape = lowRankShape == targetShape ? inputShape : targetShape;
-
-                while (lowRankShape.size() < highRankShape.size()) {
-                    lowRankShape.insert(lowRankShape.begin(), 1);
-                }
-
-                for (size_t i = 0; i < targetShape.size(); i++) {
-                    targetShape[i] = std::max(targetShape[i], inputShape[i]);
-                }
-
-                m_evaluatedOutputShape = targetShape;
-            } else {
-                m_evaluatedOutputShape = evaluatedTargetShape;
-            }
-        }
-        NODE_VALIDATION_CHECK(this, m_evaluatedOutputShape.is_static(),
-                              "StaticShapeBroadcast (", get_friendly_name(), ") ",
-                              "can't evaluate output shape, got: ", m_evaluatedOutputShape);
-        NODE_VALIDATION_CHECK(this, m_evaluatedOutputShape.all_non_negative(),
-                              "StaticShapeBroadcast (", get_friendly_name(), ") ",
-                              "expects non-negative shape, got: ", m_evaluatedOutputShape);
-        set_output_type(0, get_input_element_type(0), m_evaluatedOutputShape);
+    if (get_output_partial_shape(0).is_static()) {
+        return;
     }
+
+    ::ngraph::op::v3::Broadcast::validate_and_infer_types();
+    // Try to evaluate output shape. After some transformations further, we may not be able
+    // to evaluate the target shape again, then we will leave the evaluated shape unchanged.
+    // For example, EliminateShapeOfAfterDSR remove ShapeOf and pass the second input of DSR.
+    ngraph::PartialShape evaluatedTargetShape;
+    if (!ngraph::evaluate_as_partial_shape(input_value(1), evaluatedTargetShape) ||
+        evaluatedTargetShape.is_dynamic()) {
+        NODE_VALIDATION_CHECK(this, false,
+                              "StaticShapeBroadcast (", get_friendly_name(), ") can't evaluate output shape");
+    }
+
+    auto targetShape = evaluatedTargetShape.get_shape();
+
+    if (m_mode.m_type == ngraph::op::BroadcastType::BIDIRECTIONAL) {
+        auto inputShape = get_input_partial_shape(0).get_shape();
+
+        auto& lowRankShape = targetShape.size() < inputShape.size() ? targetShape : inputShape;
+        auto& highRankShape = lowRankShape == targetShape ? inputShape : targetShape;
+
+        while (lowRankShape.size() < highRankShape.size()) {
+            lowRankShape.insert(lowRankShape.begin(), 1);
+        }
+
+        for (size_t i = 0; i < targetShape.size(); i++) {
+            targetShape[i] = std::max(targetShape[i], inputShape[i]);
+        }
+    }
+    set_output_type(0, get_input_element_type(0), targetShape);
 }
 
 std::shared_ptr<Node> StaticShapeBroadcast::clone_with_new_inputs(const OutputVector& newInputs) const {

--- a/inference-engine/src/vpu/common/src/ngraph/operations/static_shape_broadcast.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/operations/static_shape_broadcast.cpp
@@ -56,11 +56,8 @@ void StaticShapeBroadcast::validate_and_infer_types() {
     // to evaluate the target shape again, then we will leave the evaluated shape unchanged.
     // For example, EliminateShapeOfAfterDSR remove ShapeOf and pass the second input of DSR.
     ngraph::PartialShape evaluatedTargetShape;
-    if (!ngraph::evaluate_as_partial_shape(input_value(1), evaluatedTargetShape) ||
-        evaluatedTargetShape.is_dynamic()) {
-        NODE_VALIDATION_CHECK(this, false,
-                              "StaticShapeBroadcast (", get_friendly_name(), ") can't evaluate output shape");
-    }
+    NODE_VALIDATION_CHECK(this, ngraph::evaluate_as_partial_shape(input_value(1), evaluatedTargetShape) && evaluatedTargetShape.is_static(),
+                          "StaticShapeBroadcast (", get_friendly_name(), ") can't evaluate output shape");
 
     auto targetShape = evaluatedTargetShape.get_shape();
 

--- a/inference-engine/src/vpu/common/src/ngraph/operations/static_shape_loop.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/operations/static_shape_loop.cpp
@@ -23,14 +23,11 @@ void StaticShapeLoop::validate_and_infer_types() {
 
     Loop::validate_and_infer_types();
 
-    ngraph::PartialShape numIterAsShape;
-    if (!ngraph::evaluate_as_partial_shape(input_value(0), numIterAsShape)) {
-        NODE_VALIDATION_CHECK(this, false,
-                              "Encountered a loop for which upper-bound estimation for iterations count ",
-                              input_value(0), " failed");
-    }
+    ngraph::PartialShape iterationsCount;
+    NODE_VALIDATION_CHECK(this, ngraph::evaluate_as_partial_shape(input_value(0), iterationsCount),
+                          "Encountered a loop for which upper-bound estimation for iterations count ", input_value(0), " failed");
 
-    const auto &maxIterationsCount = numIterAsShape[0].get_max_length();
+    const auto& maxIterationsCount = iterationsCount[0].get_max_length();
     NODE_VALIDATION_CHECK(this, maxIterationsCount > 0,
                           "Encountered a loop with non-positive upper-bound estimation for iterations count ",
                           maxIterationsCount);

--- a/inference-engine/src/vpu/common/src/ngraph/operations/static_shape_loop.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/operations/static_shape_loop.cpp
@@ -23,12 +23,17 @@ void StaticShapeLoop::validate_and_infer_types() {
 
     Loop::validate_and_infer_types();
 
-    const auto maxIterationsCountEstimation = ngraph::maximum_value(input_value(0).get_node_shared_ptr());
-    NODE_VALIDATION_CHECK(this, maxIterationsCountEstimation.first,
-        "Encountered a loop for which upper-bound estimation for iterations count ", input_value(0), " failed");
-    const auto& maxIterationsCount = maxIterationsCountEstimation.second;
-    NODE_VALIDATION_CHECK(this, maxIterationsCount > 0, "Encountered a loop with non-positive upper-bound estimation for iterations count ",
-        maxIterationsCountEstimation.second);
+    ngraph::PartialShape numIterAsShape;
+    if (!ngraph::evaluate_as_partial_shape(input_value(0), numIterAsShape)) {
+        NODE_VALIDATION_CHECK(this, false,
+                              "Encountered a loop for which upper-bound estimation for iterations count ",
+                              input_value(0), " failed");
+    }
+
+    const auto &maxIterationsCount = numIterAsShape[0].get_max_length();
+    NODE_VALIDATION_CHECK(this, maxIterationsCount > 0,
+                          "Encountered a loop with non-positive upper-bound estimation for iterations count ",
+                          maxIterationsCount);
 
     const auto& body = get_function();
     for (const auto& outputDescription : get_output_descriptions()) {

--- a/inference-engine/src/vpu/common/src/ngraph/operations/static_shape_reshape.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/operations/static_shape_reshape.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -21,69 +21,25 @@ StaticShapeReshape::StaticShapeReshape(const std::shared_ptr<ngraph::opset3::Res
 }
 
 void StaticShapeReshape::validate_and_infer_types() {
-    const auto& targetShape = input_value(1);
-    if (as_type_ptr<opset3::Constant>(targetShape.get_node_shared_ptr())) {
-        opset3::Reshape::validate_and_infer_types();
-        return;
-    }
-
-    NODE_VALIDATION_CHECK(this, get_input_element_type(1).is_integral_number(), "Pattern must be an integral number.");
-    NODE_VALIDATION_CHECK(this, get_input_partial_shape(1).rank().compatible(1), "Pattern must have rank 1, got ", get_input_partial_shape(1).rank(), ".");
-
-    set_input_is_relevant_to_shape(1);
-
-    NODE_VALIDATION_CHECK(this, get_input_partial_shape(0).is_static(), "StaticShapeReshape (", get_friendly_name(), ") ",
-                          "input#0 is expected to be of static shape, got: ", get_input_partial_shape(0));
-
     if (get_output_partial_shape(0).is_static()) {
         return;
     }
 
-    const auto& inputShape = get_input_shape(0);
+    opset3::Reshape::validate_and_infer_types();
 
-    ngraph::PartialShape targetPShape;
-    NODE_VALIDATION_CHECK(this, ngraph::evaluate_as_partial_shape(targetShape, targetPShape) && targetPShape.is_static(),
+    set_input_is_relevant_to_shape(1);
+    NODE_VALIDATION_CHECK(this, get_input_partial_shape(0).is_static(), "StaticShapeReshape (", get_friendly_name(), ") ",
+                          "input#0 is expected to be of static shape, got: ", get_input_partial_shape(0));
+
+    auto outputShape = get_output_partial_shape(0);
+    NODE_VALIDATION_CHECK(this, outputShape.rank().is_static(), "StaticShapeReshape (", get_friendly_name(), ") ",
+                          "output is expected to be of static rank");
+    for (size_t i = 0; i < outputShape.rank().get_length(); i++) {
+        outputShape[i] = outputShape[i].get_max_length();
+    }
+
+    NODE_VALIDATION_CHECK(this, outputShape.is_static(),
                           "StaticShapeReshape (", get_friendly_name(), ") can't evaluate output shape");
-
-    auto outputDimensionsValues = targetPShape.to_shape();
-
-    for (std::size_t i = 0; i < outputDimensionsValues.size(); ++i) {
-        if (outputDimensionsValues[i] == 0 && m_special_zero) {
-            NODE_VALIDATION_CHECK(this, inputShape[i] <= static_cast<std::size_t>(std::numeric_limits<std::int64_t>::max()),
-                                  "StaticShapeReshape (", get_friendly_name(), ") out of range input shape dimension value: ", inputShape[i]);
-            outputDimensionsValues[i] = static_cast<std::int64_t>(inputShape[i]);
-        }
-    }
-
-    NODE_VALIDATION_CHECK(this, std::none_of(outputDimensionsValues.cbegin(), outputDimensionsValues.cend(),
-        [](std::int64_t dimension) { return dimension < -1; }), "Dim size cannot be less than -1, got ", ngraph::PartialShape(outputDimensionsValues));
-    const auto negativeDimsCount = std::count_if(outputDimensionsValues.cbegin(), outputDimensionsValues.cend(),
-        [](std::int64_t dimension) { return dimension == -1; });
-    NODE_VALIDATION_CHECK(this, negativeDimsCount <= 1, "More than one dimension has size of -1 (", negativeDimsCount, ")");
-
-    const auto& inputShapeVolume = shape_size(inputShape);
-    if (negativeDimsCount == 1) {
-        const auto& outputShapeVolume = std::abs(std::accumulate(
-            outputDimensionsValues.cbegin(),
-            outputDimensionsValues.cend(),
-            static_cast<std::int64_t>(1),
-            std::multiplies<std::int64_t>())); //shape_size(outputDimensionsValues);
-        NODE_VALIDATION_CHECK(this, inputShapeVolume % outputShapeVolume == 0, "StaticShapeReshape (", get_friendly_name(), ") ",
-                              "output shape volume does not evenly divide the input shape volume: input shape volume = ", inputShapeVolume, " output shape ",
-                              "volume = ", outputShapeVolume);
-        NODE_VALIDATION_CHECK(this, outputShapeVolume != 0, "StaticShapeReshape (", get_friendly_name(), ") ",
-                              "output shape volume is equal to 0");
-
-        const auto actualValue = inputShapeVolume / outputShapeVolume;
-        NODE_VALIDATION_CHECK(this, actualValue <= static_cast<std::size_t>(std::numeric_limits<std::int64_t>::max()),
-                              "StaticShapeReshape (", get_friendly_name(), ") out of range output shape dimension value: ", actualValue);
-        std::replace(outputDimensionsValues.begin(), outputDimensionsValues.end(),
-            static_cast<std::int64_t>(-1), static_cast<std::int64_t>(actualValue));
-    }
-
-    const auto& outputShape = ngraph::PartialShape(outputDimensionsValues);
-    NODE_VALIDATION_CHECK(this, inputShapeVolume == shape_size(outputDimensionsValues), "Requested output shape (upper-bound) ", outputShape,
-                          " is incompatible with input shape ", get_input_shape(0), " (upper-bound)");
 
     set_output_type(0, get_input_element_type(0), outputShape);
 }

--- a/inference-engine/src/vpu/common/src/ngraph/operations/static_shape_reshape.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/operations/static_shape_reshape.cpp
@@ -42,10 +42,8 @@ void StaticShapeReshape::validate_and_infer_types() {
     const auto& inputShape = get_input_shape(0);
 
     ngraph::PartialShape targetPShape;
-    if (!ngraph::evaluate_as_partial_shape(targetShape, targetPShape) ||
-        targetPShape.is_dynamic()) {
-        NODE_VALIDATION_CHECK(this, false, "StaticShapeReshape (", get_friendly_name(), ") can't evaluate output shape");
-    }
+    NODE_VALIDATION_CHECK(this, ngraph::evaluate_as_partial_shape(targetShape, targetPShape) && targetPShape.is_static(),
+                          "StaticShapeReshape (", get_friendly_name(), ") can't evaluate output shape");
 
     auto outputDimensionsValues = targetPShape.to_shape();
 

--- a/inference-engine/src/vpu/common/src/ngraph/operations/static_shape_topk.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/operations/static_shape_topk.cpp
@@ -1,13 +1,11 @@
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
 #include <vpu/ngraph/operations/static_shape_topk.hpp>
 #include <ngraph/validation_util.hpp>
 
-constexpr ngraph::NodeTypeInfo ngraph::vpu::op::StaticShapeTopK::type_info;
-
-static const std::uint64_t UNKNOWN_NORMALIZED_AXIS = std::numeric_limits<uint64_t>::max();
+NGRAPH_RTTI_DEFINITION(ngraph::vpu::op::StaticShapeTopK, "StaticShapeTopK", 0);
 
 ngraph::vpu::op::StaticShapeTopK::StaticShapeTopK(
         const Output<Node>& data,
@@ -16,13 +14,7 @@ ngraph::vpu::op::StaticShapeTopK::StaticShapeTopK(
         const std::string& mode,
         const std::string& sort,
         const element::Type& index_element_type)
-        : Op{{data, k}}
-        , m_axis{axis}
-        , m_maximumK{ngraph::Dimension::dynamic()}
-        , m_normalized_axis{0}
-        , m_mode{as_enum<Mode>(mode)}
-        , m_sort{as_enum<SortType>(sort)}
-        , m_index_element_type{index_element_type} {
+        : ngraph::op::v3::TopK{data, k, axis, mode, sort, index_element_type} {
     constructor_validate_and_infer_types();
 }
 
@@ -33,103 +25,25 @@ ngraph::vpu::op::StaticShapeTopK::StaticShapeTopK(
         const ngraph::vpu::op::StaticShapeTopK::Mode mode,
         const ngraph::vpu::op::StaticShapeTopK::SortType sort,
         const ngraph::element::Type &index_element_type)
-        : Op{{data, k}}
-        , m_axis{axis}
-        , m_maximumK{ngraph::Dimension::dynamic()}
-        , m_normalized_axis{0}
-        , m_mode{mode}
-        , m_sort{sort}
-        , m_index_element_type{index_element_type} {
+        : ngraph::op::v3::TopK{data, k, axis, mode, sort, index_element_type} {
     constructor_validate_and_infer_types();
 }
 
-std::shared_ptr<ngraph::Node> ngraph::vpu::op::StaticShapeTopK::clone_with_new_inputs(const OutputVector& new_args) const {
-    check_new_args_count(this, new_args);
-    auto new_v1_topk = std::make_shared<ngraph::vpu::op::StaticShapeTopK>(
-            new_args.at(0), new_args.at(1), m_axis, m_mode, m_sort);
-
-    new_v1_topk->set_index_element_type(m_index_element_type);
-
-    return std::move(new_v1_topk);
-}
-
 void ngraph::vpu::op::StaticShapeTopK::validate_and_infer_types() {
-    NODE_VALIDATION_CHECK(this,
-                          get_input_element_type(1).is_integral_number(),
-                          "K input has to be an integer type, which does match the provided one:",
-                          get_input_element_type(1));
-    const auto& input_partial_shape = get_input_partial_shape(0);
-    const auto input_rank = input_partial_shape.rank();
-
-    NODE_VALIDATION_CHECK(this,
-                          input_rank.is_static() && input_rank.get_length() > 0,
-                          "Input rank must be greater than 0.");
-
-    const auto& k_partial_shape = get_input_partial_shape(1);
-    NODE_VALIDATION_CHECK(
-            this, k_partial_shape.rank().compatible(0), "The 'K' input must be a scalar.");
-
-    size_t k = 0;
-    if (auto constant = ngraph::as_type_ptr<ngraph::opset3::Constant>(input_value(1).get_node_shared_ptr())) {
-        const auto value = constant->cast_vector<int64_t>();
-        NODE_VALIDATION_CHECK(this,
-                              value.size() == 1,
-                              "Only one value (scalar) should be provided as the 'K' input to TopK",
-                              " (got ",
-                              value.size(),
-                              " elements).");
-
-        NODE_VALIDATION_CHECK(this,
-                              value[0] > 0,
-                              "The value of 'K' must be a positive number.",
-                              " (got ",
-                              value[0],
-                              ").");
-        k = static_cast<size_t>(value[0]);
+    if (get_output_partial_shape(0).is_static() && get_output_partial_shape(1).is_static()) {
+        return;
     }
 
-    PartialShape output_shape{input_partial_shape};
-    m_normalized_axis = ngraph::normalize_axis(this->description(), m_axis, output_shape.rank());
-    if (k != 0) {
-        output_shape[m_normalized_axis] = k;
-    } else if (m_maximumK.is_dynamic()) {
-        PartialShape kAsShape;
-        if (ngraph::evaluate_as_partial_shape(input_value(1), kAsShape)) {
-            m_maximumK = kAsShape[0].get_max_length();
-        }
+    ngraph::op::v3::TopK::validate_and_infer_types();
+    auto outputShape = get_output_partial_shape(0);
+    NODE_VALIDATION_CHECK(this, outputShape.rank().is_static(), "StaticShapeTopK (", get_friendly_name(), ") ",
+                          "output is expected to be of static rank");
+    for (size_t i = 0; i < outputShape.rank().get_length(); i++) {
+        outputShape[i] = outputShape[i].get_max_length();
     }
+    NODE_VALIDATION_CHECK(this, outputShape.is_static(),
+                          "StaticShapeTopK (", get_friendly_name(), ") can't evaluate output shape");
 
-    output_shape[m_normalized_axis] = m_maximumK;
-
-    NODE_VALIDATION_CHECK(this, output_shape.is_static(),
-            "StaticShapeTopK output shape is not fully defined: ", output_shape);
-
-    set_output_size(2);
-    set_output_type(0, get_input_element_type(0), output_shape);
-    set_output_type(1, m_index_element_type, output_shape);
-}
-
-void ngraph::vpu::op::StaticShapeTopK::set_axis(const int64_t axis) {
-    const auto input_rank = get_input_partial_shape(0).rank();
-    if (input_rank.is_static()) {
-        m_normalized_axis = ngraph::normalize_axis(this->description(), axis, input_rank);
-    } else {
-        m_normalized_axis = UNKNOWN_NORMALIZED_AXIS;
-    }
-    m_axis = axis;
-}
-
-uint64_t ngraph::vpu::op::StaticShapeTopK::get_axis() const {
-    NODE_VALIDATION_CHECK(
-            this, m_normalized_axis != UNKNOWN_NORMALIZED_AXIS, "Normalized axis of TopK is unknown");
-
-    return m_normalized_axis;
-}
-
-bool ngraph::vpu::op::StaticShapeTopK::visit_attributes(AttributeVisitor& visitor) {
-    visitor.on_attribute("axis", m_axis);
-    visitor.on_attribute("mode", m_mode);
-    visitor.on_attribute("sort", m_sort);
-    visitor.on_attribute("index_element_type", m_index_element_type);
-    return true;
+    set_output_type(0, get_input_element_type(0), outputShape);
+    set_output_type(1, m_index_element_type, outputShape);
 }

--- a/inference-engine/src/vpu/common/src/ngraph/operations/static_shape_topk.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/operations/static_shape_topk.cpp
@@ -92,7 +92,7 @@ void ngraph::vpu::op::StaticShapeTopK::validate_and_infer_types() {
     m_normalized_axis = ngraph::normalize_axis(this->description(), m_axis, output_shape.rank());
     if (k != 0) {
         output_shape[m_normalized_axis] = k;
-    } else if (m_maximumK == ngraph::Dimension::dynamic()) {
+    } else if (m_maximumK.is_dynamic()) {
         PartialShape kAsShape;
         if (ngraph::evaluate_as_partial_shape(input_value(1), kAsShape)) {
             m_maximumK = kAsShape[0].get_max_length();

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape.cpp
@@ -182,6 +182,11 @@ bool DynamicToStaticShape::run_on_function(std::shared_ptr<ngraph::Function> fun
     // Operation-specific testing that needs to be performed in dynamic context before DSRs are introduced
     validateDynamicFunction(*function);
 
+    // Make sure all values are invalidated, we need it to correctly evaluate upper-bound
+    for (auto& node : function->get_ordered_ops()) {
+        node->invalidate_values();
+    }
+
     for (const auto& operation : function->get_ordered_ops()) {
         if (!isDynamic(*operation)) {
             continue;

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/dynamic_to_static_shape.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -183,7 +183,7 @@ bool DynamicToStaticShape::run_on_function(std::shared_ptr<ngraph::Function> fun
     validateDynamicFunction(*function);
 
     // Make sure all values are invalidated, we need it to correctly evaluate upper-bound
-    for (auto& node : function->get_ordered_ops()) {
+    for (auto& node : function->get_ops()) {
         node->invalidate_values();
     }
 

--- a/inference-engine/src/vpu/common/src/ngraph/utilities.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/utilities.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/inference-engine/src/vpu/common/src/ngraph/utilities.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/utilities.cpp
@@ -11,66 +11,6 @@
 #include <numeric>
 
 namespace vpu {
-namespace {
-
-ngraph::HostTensorVector evaluateShapeOf(ngraph::Node* node, const ngraph::HostTensorVector&) {
-    auto shapeOf = ngraph::as_type<ngraph::opset3::ShapeOf>(node);
-    const auto inputValue = shapeOf->input_value(0);
-    const auto outputValue = shapeOf->output(0);
-    const auto inputTensors =
-        ngraph::HostTensorVector{std::make_shared<ngraph::runtime::HostTensor>(inputValue)};
-    const auto outputTensors =
-        ngraph::HostTensorVector{std::make_shared<ngraph::runtime::HostTensor>(outputValue)};
-
-    shapeOf->evaluate(outputTensors, inputTensors);
-    return outputTensors;
-}
-
-ngraph::HostTensorVector evaluateConstant(ngraph::Node* node, const ngraph::HostTensorVector&) {
-    const auto constantNode = ngraph::as_type<ngraph::opset3::Constant>(node);
-    const auto constant = std::make_shared<ngraph::opset3::Constant>(*constantNode);
-
-    const auto outputTensor = std::make_shared<ngraph::runtime::HostTensor>(constant);
-
-    return {outputTensor};
-}
-
-ngraph::HostTensorVector evaluateOp(ngraph::Node* node, const ngraph::HostTensorVector& inputTensors) {
-    ngraph::HostTensorVector outputTensors;
-    for (const auto& output : node->outputs()) {
-        outputTensors.push_back(std::make_shared<ngraph::HostTensor>(output));
-    }
-
-    node->evaluate(outputTensors, inputTensors);
-    return outputTensors;
-}
-
-} // namespace
-
-std::vector<std::int64_t> evaluateTargetShape(const ngraph::Output<ngraph::Node>& value) {
-    static ngraph::Evaluator<ngraph::HostTensorPtr>::op_handler_map handlers = {
-        {ngraph::opset3::ShapeOf::type_info,   evaluateShapeOf},
-        {ngraph::opset3::Constant::type_info,  evaluateConstant},
-        {ngraph::opset3::Gather::type_info,    evaluateOp},
-        {ngraph::opset3::Concat::type_info,    evaluateOp},
-        {ngraph::opset3::Reshape::type_info,   evaluateOp},
-        {ngraph::opset3::Multiply::type_info,  evaluateOp},
-        {ngraph::opset3::Squeeze::type_info,   evaluateOp},
-        {ngraph::opset5::Unsqueeze::type_info, evaluateOp},
-        {ngraph::opset5::Equal::type_info,     evaluateOp},
-        {ngraph::opset5::Select::type_info,    evaluateOp},
-    };
-    ngraph::Evaluator<ngraph::HostTensorPtr>::value_map value_map;
-    ngraph::Evaluator<ngraph::HostTensorPtr> evaluator(handlers, value_map);
-
-    const auto shapeTensor = evaluator.evaluate(value);
-    if (!shapeTensor || !shapeTensor->get_is_allocated()) {
-        return {};
-    }
-
-    const auto shapeConstNode = std::make_shared<ngraph::opset3::Constant>(shapeTensor);
-    return {shapeConstNode->cast_vector<std::int64_t>()};
-}
 
 std::shared_ptr<ngraph::Node> shapeToConstant(const ngraph::element::Type& type, const ngraph::Shape& shape) {
     return ngraph::opset5::Constant::create(type, {shape.size()}, shape);

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_topk.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_topk.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_topk.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_topk.cpp
@@ -159,7 +159,8 @@ protected:
         const auto data = std::make_shared<ngraph::opset3::Parameter>(data_type, topk_setup.data_shape);
         const auto dims = std::make_shared<ngraph::opset3::Parameter>(ngraph::element::i64, ngraph::Shape{topk_setup.data_shape.size()});
 
-        const auto gather = std::make_shared<ngraph::opset3::Gather>(dims,
+        const auto shapeOf = std::make_shared<ngraph::opset3::ShapeOf>(data);
+        const auto gather = std::make_shared<ngraph::opset3::Gather>(shapeOf,
                                                                      ngraph::opset3::Constant::create(ngraph::element::i32, {1}, {topk_setup.axis}),
                                                                      ngraph::opset3::Constant::create(ngraph::element::i32, {1}, {0}));
         const auto upper_bound = ngraph::opset3::Constant::create(dims->get_element_type(), {1}, {100});
@@ -188,7 +189,8 @@ protected:
         const auto data = std::make_shared<ngraph::opset3::Parameter>(data_type, topk_setup.data_shape);
         const auto dims = std::make_shared<ngraph::opset3::Parameter>(ngraph::element::i64, ngraph::Shape{topk_setup.data_shape.size()});
 
-        const auto gather = std::make_shared<ngraph::opset3::Gather>(dims,
+        const auto shapeOf = std::make_shared<ngraph::opset3::ShapeOf>(data);
+        const auto gather = std::make_shared<ngraph::opset3::Gather>(shapeOf,
                                                                      ngraph::opset3::Constant::create(ngraph::element::i32, {1}, {topk_setup.axis}),
                                                                      ngraph::opset3::Constant::create(ngraph::element::i32, {1}, {0}));
         const auto upper_bound = ngraph::opset3::Constant::create(dims->get_element_type(), {1}, {100});

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_topk.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_topk.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_topk.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/subgraph_tests/dsr_topk.cpp
@@ -64,8 +64,9 @@ protected:
 
         const auto inputSubgraph = createInputSubgraphWithDSR(dataType, topkSetup.dataShapes);
 
+        const auto shapeOf = std::make_shared<ngraph::opset3::ShapeOf>(inputSubgraph->input_value(0), ngraph::element::i32);
         const auto gather = std::make_shared<ngraph::opset3::Gather>(
-                inputSubgraph->input_value(1),
+                shapeOf,
                 ngraph::opset3::Constant::create(ngraph::element::i32, {1}, {topkSetup.axis}),
                 ngraph::opset3::Constant::create(ngraph::element::i32, {1}, {0}));
         const auto upper_bound = ngraph::opset3::Constant::create(inputSubgraph->get_input_element_type(1), {1}, {topkSetup.k});


### PR DESCRIPTION
Ticket - #48507
Changes:
- Change VPU private ops to use `evaluate_as_partial_shape` generic method.
- Get rid of `evaluateTargetShape`
- nGraph has a caching mechanism for evaluated values, so to be sure that we will not received incorrect cached values (which were calculated when the model was fully dynamic), manual invalidation was added.