### PR TITLE
[IE][VPU]: Check memory capacity after finding the corresponding device

### DIFF
--- a/inference-engine/thirdparty/movidius/mvnc/src/mvnc_api.c
+++ b/inference-engine/thirdparty/movidius/mvnc/src/mvnc_api.c
@@ -1986,11 +1986,6 @@ ncStatus_t ncGraphAllocate(struct ncDeviceHandle_t * deviceHandle,
     struct _graphPrivate_t *g = graphHandle->private_data;
 
     struct _devicePrivate_t *d = devices;
-    if (graphBufferLength > d->dev_attr.max_memory) {
-        mvLog(MVLOG_ERROR, "The graph file is bigger than the device memory");
-        return NC_OUT_OF_MEMORY;
-    }
-
     GLOBAL_LOCK();
     while (d) {
         if (d == deviceHandle->private_data)
@@ -2005,6 +2000,11 @@ ncStatus_t ncGraphAllocate(struct ncDeviceHandle_t * deviceHandle,
         return NC_INVALID_PARAMETERS;
     }
     GLOBAL_UNLOCK();
+
+    if (graphBufferLength > d->dev_attr.max_memory) {
+        mvLog(MVLOG_ERROR, "The graph file is bigger than the device memory");
+        return NC_OUT_OF_MEMORY;
+    }
 
     lockAllInferences();
     g->id = graphIdCount++;


### PR DESCRIPTION
### Description
This issue relates to multi-device mode. 
While we are trying to allocate a graph on one of the devices we should check memory capacity only for the corresponding device, not for the last opened as far devices may have different memory capacity or the latest opened device may have still not sent its attributes (including memory capacity)

### CI
* [ ] - RunTests-MYRIAD/2213/
* [ ] - Ubuntu18_MultiStickTest/8/

### Task
#-46293