### PR TITLE
Rename dunder methods

### DIFF
--- a/ngraph/frontend/onnx_import/src/op/max_pool.cpp
+++ b/ngraph/frontend/onnx_import/src/op/max_pool.cpp
@@ -18,7 +18,6 @@
 
 #include "core/null_node.hpp"
 #include "ngraph/log.hpp"
-#include "ngraph/op/max_pool.hpp"
 #include "op/max_pool.hpp"
 #include "utils/pooling_factory.hpp"
 
@@ -35,7 +34,7 @@ namespace ngraph
                     if (node.get_outputs_size() > 1)
                     {
                         NGRAPH_WARN
-                            << "Indices output is not supported for MaxPooling and was ignored";
+                            << "MaxPool: Indices output is not supported and was ignored";
                     }
                     auto max_pool = pooling::PoolingFactory(node).make_max_pool();
                     max_pool.emplace_back(std::make_shared<NullNode>()); // Indices (optional)

--- a/ngraph/frontend/onnx_import/src/op/max_pool.cpp
+++ b/ngraph/frontend/onnx_import/src/op/max_pool.cpp
@@ -33,8 +33,7 @@ namespace ngraph
                 {
                     if (node.get_outputs_size() > 1)
                     {
-                        NGRAPH_WARN
-                            << "MaxPool: Indices output is not supported and was ignored";
+                        NGRAPH_WARN << "MaxPool: Indices output is not supported and was ignored";
                     }
                     auto max_pool = pooling::PoolingFactory(node).make_max_pool();
                     max_pool.emplace_back(std::make_shared<NullNode>()); // Indices (optional)

--- a/ngraph/python/tests/runtime.py
+++ b/ngraph/python/tests/runtime.py
@@ -115,7 +115,7 @@ class Computation(object):
         params_string = ", ".join([param.name for param in self.parameters])
         return "<Computation: {}({})>".format(self.function.get_name(), params_string)
 
-    def __get_ie_output_blob_name(self, outputs: Dict, ng_result: result) -> str:
+    def _get_ie_output_blob_name(self, outputs: Dict, ng_result: result) -> str:
         if len(self.results) == 1:
             return next(iter(outputs.keys()))
         else:
@@ -125,8 +125,8 @@ class Computation(object):
                 out_name += "." + str(prev_layer.get_index())
             return out_name
 
-    def __get_ie_output_blob_buffer(self, output_blobs: Dict[str, Blob], ng_result: result) -> np.ndarray:
-        out_name = self.__get_ie_output_blob_name(output_blobs, ng_result)
+    def _get_ie_output_blob_buffer(self, output_blobs: Dict[str, Blob], ng_result: result) -> np.ndarray:
+        out_name = self._get_ie_output_blob_name(output_blobs, ng_result)
         return output_blobs[out_name].buffer
 
     def __call__(self, *input_values: NumericData) -> List[NumericData]:
@@ -157,7 +157,7 @@ class Computation(object):
 
         # set output blobs precission based on nG results
         for ng_result in self.results:
-            ie_out_name = self.__get_ie_output_blob_name(cnn_network.outputs, ng_result)
+            ie_out_name = self._get_ie_output_blob_name(cnn_network.outputs, ng_result)
             apply_ng_type(cnn_network.outputs[ie_out_name], ng_result.get_output_element_type(0))
 
         executable_network = self.runtime.backend.load_network(cnn_network, self.runtime.backend_name)
@@ -176,7 +176,7 @@ class Computation(object):
         request.infer(dict(zip(param_names, input_values)))
 
         # Set order of output blobs compatible with nG Function
-        result_buffers = [self.__get_ie_output_blob_buffer(request.output_blobs, result)
+        result_buffers = [self._get_ie_output_blob_buffer(request.output_blobs, result)
                           for result in self.results]
 
         # Since OV overwrite result data type we have to convert results to the original one.


### PR DESCRIPTION
Method names starting with double underscore (`__`) should be reserved for Python system and magic methods.