### PR TITLE
Resolve Klocwork issues

### DIFF
--- a/ngraph/frontend/onnx_import/src/op/loop.cpp
+++ b/ngraph/frontend/onnx_import/src/op/loop.cpp
@@ -203,7 +203,8 @@ namespace ngraph
                     // Set-up parameters from parent graph which are not changed during Loop's
                     // iterations
                     for (auto out_from_parent_it = outputs_from_parent.begin();
-                         body_inputs_it != body_inputs.end();
+                         body_inputs_it != body_inputs.end() &&
+                         out_from_parent_it != outputs_from_parent.end();
                          ++body_inputs_it, ++out_from_parent_it)
                     {
                         loop->set_invariant_input(*body_inputs_it, *out_from_parent_it);

--- a/ngraph/frontend/onnx_import/src/utils/tensor_external_data.hpp
+++ b/ngraph/frontend/onnx_import/src/utils/tensor_external_data.hpp
@@ -45,7 +45,7 @@ namespace ngraph
                 std::string to_string() const;
 
             private:
-                std::string m_data_location;
+                std::string m_data_location{};
                 int m_offset = 0;
                 int m_data_lenght = 0;
                 int m_sha1_digest = 0;


### PR DESCRIPTION
After static code analysis two problems have been resolved:
- `m_data_location` was not initialized in constructor
- `out_from_parent_it` iterator range was not checked directly