### PR TITLE
[ONNX] Update warning message for ONNX Constant node

### DIFF
--- a/ngraph/frontend/onnx_import/src/op/constant.cpp
+++ b/ngraph/frontend/onnx_import/src/op/constant.cpp
@@ -43,10 +43,11 @@ namespace ngraph
                         catch (const ngraph::ngraph_error& exc)
                         {
                             NGRAPH_WARN
-                                << "\nCould not create an nGraph Constant for an ONNX Constant node. "
+                                << "\nCould not create an nGraph Constant for an ONNX Constant "
+                                   "node. "
                                 << "Constant with a 0 value was created instead.\n"
                                 << "Verify if the ONNX Constant node contains a correct number of "
-                                "elements matching the node's shape. \n"
+                                   "elements matching the node's shape. \n"
                                 << "Detailed error:\n"
                                 << exc.what();
                             constant = std::make_shared<default_opset::Constant>(type, Shape{}, 0);

--- a/ngraph/frontend/onnx_import/src/op/constant.cpp
+++ b/ngraph/frontend/onnx_import/src/op/constant.cpp
@@ -42,9 +42,13 @@ namespace ngraph
                         }
                         catch (const ngraph::ngraph_error& exc)
                         {
-                            NGRAPH_WARN << "Could not create an nGraph Constant for an ONNX "
-                                           "Constant node. Detailed error:\n"
-                                        << exc.what();
+                            NGRAPH_WARN
+                                << "\nCould not create an nGraph Constant for an ONNX Constant node. "
+                                << "Constant with a 0 value was created instead.\n"
+                                << "Verify if the ONNX Constant node contains a correct number of "
+                                "elements matching the node's shape. \n"
+                                << "Detailed error:\n"
+                                << exc.what();
                             constant = std::make_shared<default_opset::Constant>(type, Shape{}, 0);
                         }
 


### PR DESCRIPTION
### Details:
 - More meaningful warning message when nGraph Constant for ONNX Constant node couldn't be created (usually because of empty tensor data)
- Similar it was changed for initializer with this PR https://github.com/openvinotoolkit/openvino/pull/3443 

### Tickets:
 - 48334

