### PR TITLE
Pin astroid to 2.4.2 (workaround to make pylint passing)

### DIFF
--- a/model-optimizer/requirements_dev.txt
+++ b/model-optimizer/requirements_dev.txt
@@ -1,4 +1,5 @@
 coverage==4.4.2
+astroid==2.4.2
 pylint==2.5.0
 pyenchant==1.6.11
 test-generator==0.1.1


### PR DESCRIPTION
Astroid 2.5 released yesterday caused pylint checks (as github actions) to fail. Workaround is to stick to older version, however the proper way is to fix file that became guilty now