### PR TITLE
Stick requirement version of astroid to be 2.4.2

### DIFF
--- a/model-optimizer/extensions/middle/RNNSequenceNormalizeToIE.py
+++ b/model-optimizer/extensions/middle/RNNSequenceNormalizeToIE.py
@@ -34,7 +34,7 @@ class RNNSequenceNormalize(MiddleReplacementPattern):
     This class normalize RNNSequence layers to IE-compatible from of weights, inputs and outputs.
 
     In this pass next will be done:
-        1. Weights repack (squeeze all useless shapes in all blobls and concatenate W and R together, also add
+        1. Weights repack (squeeze all useless shapes in all blobs and concatenate W and R together, also add
                             bin param and all similar staff )
         1. UNSqueeze num directions (in states and )
         2. Initial states squeeze
@@ -104,7 +104,7 @@ class RNNSequenceNormalize(MiddleReplacementPattern):
             B_tmp[:, :, :, 3, :] = B[:, :, 1, 2, :][:, :, np.newaxis, :]
             B = B_tmp
         else:
-            B = np.add.reduce(B, axis=2, keepdims=True)
+            B = np.sum(B, axis=2, keepdims=True)
 
         # Concatenate W, R to IE-compatible format
         assert len(W.shape) == 5

--- a/model-optimizer/requirements_dev.txt
+++ b/model-optimizer/requirements_dev.txt
@@ -1,4 +1,5 @@
 coverage==4.4.2
+astroid==2.4.2
 pylint==2.5.0
 pyenchant==1.6.11
 test-generator==0.1.1


### PR DESCRIPTION
astroid==2.5 released yesterday caused pylint checks (as github actions) to fail. Workaround is to stick to older version + fixed the line causing the failure.

Ticket: 49148