### PR TITLE
Removed constant DDR_MAX_SIZE = 512.

### DIFF
--- a/inference-engine/src/vpu/graph_transformer/include/vpu/middleend/allocator/allocator.hpp
+++ b/inference-engine/src/vpu/graph_transformer/include/vpu/middleend/allocator/allocator.hpp
@@ -109,7 +109,6 @@ private:
 
     void extractDatas(MemoryType memType, const DataSet& from, DataVector& out) const;
 
-    std::size_t freeDDRMemoryAmount() const;
     void updateChildDataAllocation(const Data& data);
 
 private:

--- a/inference-engine/src/vpu/graph_transformer/include/vpu/middleend/allocator/allocator.hpp
+++ b/inference-engine/src/vpu/graph_transformer/include/vpu/middleend/allocator/allocator.hpp
@@ -96,6 +96,8 @@ public:
     DataSet& getCandidatesForCMX() { return _candidatesForCMX; }
     bool removeCMXCandidates(const Data& data);
 
+    std::size_t freeCMXMemoryAmount() const;
+
     AllocatorForShaves& getAllocatorOfShaves() { return _allocatorOfShaves; }
 
 private:
@@ -108,7 +110,7 @@ private:
     void extractDatas(MemoryType memType, const DataSet& from, DataVector& out) const;
 
     std::size_t freeDDRMemoryAmount() const;
-    std::size_t freeCMXMemoryAmount() const;
+    void updateChildDataAllocation(const Data& data);
 
 private:
     int _modelBatchSize = 1;

--- a/inference-engine/src/vpu/graph_transformer/include/vpu/middleend/allocator/structs.hpp
+++ b/inference-engine/src/vpu/graph_transformer/include/vpu/middleend/allocator/structs.hpp
@@ -18,7 +18,6 @@ namespace vpu {
 // Common allocation constants
 //
 
-const int DDR_MAX_SIZE = 512 * 1024 * 1024;
 const int CMX_SLICE_SIZE = 128 * 1024;
 const int DATA_ALIGNMENT = 64;
 const int CMX_SHAVE_BUFFER_SIZE = 100 * 1024;

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/allocator/allocator.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/allocator/allocator.cpp
@@ -60,7 +60,7 @@ Allocator::Allocator(): _allocatorOfShaves(_cmxMemoryPool) {
 
 namespace {
 
-void updateChildDataAllocation(const Data& data, int offsetLimitation) {
+void updateChildDataAllocation(const Data& data) {
     for (const auto& edge : data->childDataToDataEdges()) {
         auto parent = edge->parent();
         auto child = edge->child();
@@ -77,8 +77,6 @@ void updateChildDataAllocation(const Data& data, int offsetLimitation) {
             }
 
             memoryOffset += byteOffset;
-
-            IE_ASSERT(memoryOffset + child->lastElemOffset() <= offsetLimitation);
         } else if (edge->mode() == SharedDataMode::Reshape) {
             IE_ASSERT(parent->checkStrides(StridesRequirement::compact()));
             IE_ASSERT(child->checkStrides(StridesRequirement::compact()));
@@ -88,7 +86,7 @@ void updateChildDataAllocation(const Data& data, int offsetLimitation) {
 
         child->setDataAllocationInfo({parent->dataLocation().location, memoryOffset});
 
-        updateChildDataAllocation(child, offsetLimitation);
+        updateChildDataAllocation(child);
     }
 }
 
@@ -131,7 +129,7 @@ bool Allocator::allocateData(const Data& data) {
         if (_allocatedData.count(data) == 0) {
             IE_ASSERT(data->parentDataToDataEdge() == nullptr);
 
-            updateChildDataAllocation(data, 0);
+            updateChildDataAllocation(data);
 
             _allocatedData.emplace(data);
         }
@@ -156,7 +154,7 @@ bool Allocator::allocateData(const Data& data) {
             data->setIOInfo(Location::Input, alignVal(_inputMemOffset, DATA_ALIGNMENT));
             _inputMemOffset = alignVal(_inputMemOffset, DATA_ALIGNMENT) + finalByteSize;
 
-            updateChildDataAllocation(data, DDR_MAX_SIZE);
+            updateChildDataAllocation(data);
 
             _allocatedData.emplace(data);
         }
@@ -181,7 +179,7 @@ bool Allocator::allocateData(const Data& data) {
             data->setIOInfo(Location::Output, alignVal(_outputMemOffset, DATA_ALIGNMENT));
             _outputMemOffset = alignVal(_outputMemOffset, DATA_ALIGNMENT) + finalByteSize;
 
-            updateChildDataAllocation(data, DDR_MAX_SIZE);
+            updateChildDataAllocation(data);
 
             _allocatedData.emplace(data);
         }
@@ -204,7 +202,7 @@ bool Allocator::allocateData(const Data& data) {
             data->setDataAllocationInfo({Location::Blob, _blobMemOffset});
             _blobMemOffset += finalByteSize;
 
-            updateChildDataAllocation(data, DDR_MAX_SIZE);
+            updateChildDataAllocation(data);
 
             _allocatedData.emplace(data);
         }
@@ -290,8 +288,7 @@ bool Allocator::allocateData(const Data& data) {
 
     data->setDataAllocationInfo({chunk->memType == MemoryType::CMX ? Location::CMX : Location::BSS, chunk->pointer});
 
-    auto offsetLimitation = (data->dataLocation().location == Location::CMX) ? _maxCmxSize : DDR_MAX_SIZE;
-    updateChildDataAllocation(data, offsetLimitation);
+    updateChildDataAllocation(data);
 
     _memChunksPerData.emplace(data, chunk);
     _allocatedIntermData.emplace(data);
@@ -432,7 +429,7 @@ void Allocator::freeData(const Data& data, DeallocationMode mode) {
             _memChunksPerData[data] = ddrChunk;
 
             data->setDataAllocationInfo({Location::BSS, ddrChunk->pointer});
-            updateChildDataAllocation(data, DDR_MAX_SIZE);
+            updateChildDataAllocation(data);
 
             break;
         }
@@ -465,14 +462,6 @@ UsedMemory Allocator::usedMemoryAmount() const {
     return stats;
 }
 
-std::size_t Allocator::freeDDRMemoryAmount() const {
-    const auto& pool = _memPools.at(MemoryType::DDR);
-    const auto offset = pool->curMemOffset;
-    VPU_THROW_UNLESS(offset <= DDR_MAX_SIZE, "Out of bound offset for next free data in DDR: size = {}, while offset = {}", DDR_MAX_SIZE, offset);
-
-    return DDR_MAX_SIZE - offset;
-}
-
 std::size_t Allocator::freeCMXMemoryAmount() const {
     const auto& pool = _memPools.at(MemoryType::CMX);
     const auto shavesCMX = _allocatorOfShaves.getLockedSHAVEs() * CMX_SLICE_SIZE;
@@ -480,10 +469,6 @@ std::size_t Allocator::freeCMXMemoryAmount() const {
     VPU_THROW_UNLESS(offset <= _maxCmxSize, "Out of bound offset for next free data in CMX: size = {}, while offset = {}", _maxCmxSize, offset);
 
     return _maxCmxSize - offset;
-}
-
-std::size_t Allocator::freeMemoryAmount(const MemoryType& type) const {
-    return type == MemoryType::CMX ? freeCMXMemoryAmount() : freeDDRMemoryAmount();
 }
 
 void Allocator::extractDatas(MemoryType memType, const DataSet& from, DataVector& out) const {
@@ -534,15 +519,6 @@ allocator::MemChunk* Allocator::allocateMem(MemoryType memType, int size, int in
     if (auto chunk = checkMemPool(*memPool, memType, size, inUse)) {
         memPool->memUsed = std::max(memPool->memUsed, chunk->offset + chunk->size);
         return chunk;
-    }
-
-    //
-    // Check free space
-    //
-
-    const auto freeSpace = freeMemoryAmount(memType);
-    if (static_cast<std::size_t>(size) > freeSpace) {
-        return nullptr;
     }
 
     //

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/allocator/allocator.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/allocator/allocator.cpp
@@ -57,6 +57,7 @@ Allocator::Allocator(): _allocatorOfShaves(_cmxMemoryPool) {
     _memPools.emplace(MemoryType::DDR, &_ddrMemoryPool);
     _memPools.emplace(MemoryType::CMX, &_cmxMemoryPool);
 }
+
 void Allocator::updateChildDataAllocation(const Data& data) {
     for (const auto& edge : data->childDataToDataEdges()) {
         auto parent = edge->parent();
@@ -525,8 +526,7 @@ allocator::MemChunk* Allocator::allocateMem(MemoryType memType, int size, int in
     // Check free space
     //
 
-    const auto freeSpace = (memType == MemoryType::CMX ? freeCMXMemoryAmount() : -1);
-    if (static_cast<std::size_t>(size) > freeSpace) {
+    if (memType == MemoryType::CMX && static_cast<std::size_t>(size) > freeCMXMemoryAmount()) {
         return nullptr;
     }
 

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/adjust_data_location.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/adjust_data_location.cpp
@@ -232,9 +232,8 @@ void PassImpl::adjustModelForMemReqs(const Model& model) {
 
         const auto failedData = allocRes.failedData;
         VPU_THROW_UNLESS(!failedData || failedData->memReqs() == MemoryType::CMX,
-            R"(Stage "{}" of type "{}" requested {} bytes in {} for output "{}", while there is only {} bytes is free)",
-            failedStage->name(), failedStage->type(), calcAllocationSize(failedData), failedData->memReqs(), failedData->name(),
-                        failedData->memReqs() == MemoryType::CMX ? allocator.freeCMXMemoryAmount() : -1);
+            R"(Request {} bytes in {} for output "{}" failed for stage "{}" of type "{}")",
+            calcAllocationSize(failedData), failedData->memReqs(), failedData->name(), failedStage->name(), failedStage->type());
 
         auto allCmxDatas = allocator.getAllocatedDatas(MemoryType::CMX);
         env.log->trace("Got %d datas in CMX : %v", allCmxDatas.size(), allCmxDatas);

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/adjust_data_location.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/adjust_data_location.cpp
@@ -234,7 +234,7 @@ void PassImpl::adjustModelForMemReqs(const Model& model) {
         VPU_THROW_UNLESS(!failedData || failedData->memReqs() == MemoryType::CMX,
             R"(Stage "{}" of type "{}" requested {} bytes in {} for output "{}", while there is only {} bytes is free)",
             failedStage->name(), failedStage->type(), calcAllocationSize(failedData), failedData->memReqs(), failedData->name(),
-                         allocator.freeMemoryAmount(failedData->memReqs()));
+                        failedData->memReqs() == MemoryType::CMX ? allocator.freeCMXMemoryAmount() : -1);
 
         auto allCmxDatas = allocator.getAllocatedDatas(MemoryType::CMX);
         env.log->trace("Got %d datas in CMX : %v", allCmxDatas.size(), allCmxDatas);


### PR DESCRIPTION
Removed the DDR_MAX_SIZE constant as it could potentially lead to incorrect behavior of devices with a different DDR size (Prism Creek can be up to 2 GB in size). Removed the use of this constant in methods.