### PR TITLE
[CPU] Added custom nspc <-> ncsp reorder implementations

### DIFF
--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reorder_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reorder_node.cpp
@@ -9,9 +9,12 @@
 #include <mkldnn_types.h>
 #include <mkldnn_extension_utils.h>
 #include "ie_parallel.hpp"
+#include "utils/general_utils.h"
+#include <cpu/x64/cpu_isa_traits.hpp>
 
 using namespace mkldnn;
 using namespace MKLDNNPlugin;
+using namespace InferenceEngine;
 
 MKLDNNReorderNode::MKLDNNReorderNode(const InferenceEngine::CNNLayerPtr& layer, const mkldnn::engine& eng, MKLDNNWeightsSharing::Ptr &w_cache) :
         MKLDNNNode(layer, eng, w_cache) {
@@ -75,9 +78,30 @@ void MKLDNNReorderNode::createPrimitive() {
     if (getSelectedPrimitiveDescriptor() == nullptr)
         THROW_IE_EXCEPTION << "Preferable primitive descriptor is not set.";
 
-    if (!isOptimized)
-    createReorderPrimitive(srcMemPtr->GetDescriptor(), srcMemPtr->GetPrimitive().get_data_handle(),
-            dstMemPtr->GetDescriptor(), dstMemPtr->GetPrimitive().get_data_handle());
+    if (!isOptimized) {
+        if (MKLDNNPlugin::one_of(getParentEdgeAt(0)->getDims().ndims(), 4, 5) &&
+                getParentEdgeAt(0)->getDims()[1] <= 64 &&
+                getParentEdgeAt(0)->getDims()[1] >= 16 &&
+                (getParentEdgeAt(0)->getMemory().GetElementsCount() / getParentEdgeAt(0)->getDims()[1]) >= 128 &&
+                getParentEdgeAt(0)->getMemory().GetDesc().isTailCFormat() &&
+                getChildEdgeAt(0)->getMemory().GetDesc().isPlainFormat() &&
+                getParentEdgeAt(0)->getMemory().GetDesc().getDataType() == memory::data_type::f32 &&
+                getChildEdgeAt(0)->getMemory().GetDesc().getDataType() == memory::data_type::f32) {
+            // oneDNN JIT reorder shows bad perf for nspc to ncsp reorder case so we fallback on simple c++ implementation
+            canUseOptimizedNspc2Ncsp = true;
+        } else if (!impl::cpu::x64::mayiuse(impl::cpu::x64::avx2) &&
+                   MKLDNNPlugin::one_of(getParentEdgeAt(0)->getDims().ndims(), 4, 5) &&
+                   getParentEdgeAt(0)->getMemory().GetDesc().isPlainFormat() &&
+                   getChildEdgeAt(0)->getMemory().GetDesc().isTailCFormat() &&
+                   getParentEdgeAt(0)->getMemory().GetDataType() == getChildEdgeAt(0)->getMemory().GetDataType() &&
+                   MKLDNNExtensionUtils::sizeOfDataType(getParentEdgeAt(0)->getMemory().GetDataType()) == 1) {
+            // oneDNN doesn't provide JIT reorder impl for non-avx2 targets so we fallback on simple c++ implementation which shows better perf
+            canUseOptimizedNcsp2Nspc = true;
+        } else {
+            createReorderPrimitive(srcMemPtr->GetDescriptor(), srcMemPtr->GetPrimitive().get_data_handle(),
+                                   dstMemPtr->GetDescriptor(), dstMemPtr->GetPrimitive().get_data_handle());
+        }
+    }
 }
 
 void MKLDNNReorderNode::createReorderPrimitive(const mkldnn::memory::desc &srcDesc, void* srcPtr, const mkldnn::memory::desc &dstDesc, void* dstPtr) {
@@ -161,14 +185,75 @@ bool MKLDNNReorderNode::created() const {
     return getType() == Reorder;
 }
 
+void MKLDNNReorderNode::optimizedNcsp2Nspc() {
+    auto parentEdge = getParentEdgeAt(0);
+    auto childEdge = getChildEdgeAt(0);
+    const int ndims = parentEdge->getDims().ndims();
+    const size_t DIM0 = parentEdge->getDims()[0];
+    const size_t DIM1 = parentEdge->getDims()[1];
+    const size_t DIM2 = ndims == 5 ? parentEdge->getDims()[ndims - 3] : 1;
+    const size_t DIM3 = parentEdge->getDims()[ndims - 2];
+    const size_t DIM4 = parentEdge->getDims()[ndims - 1];
+
+    auto src_data = reinterpret_cast<const uint8_t *>(parentEdge->getMemoryPtr()->GetPtr());
+    auto dst_data = reinterpret_cast<uint8_t *>(childEdge->getMemoryPtr()->GetPtr());
+
+    const size_t stride0 = DIM1 * DIM2 * DIM3 * DIM4;
+    const size_t stride1 = DIM2 * DIM3 * DIM4;
+    const size_t stride2 = DIM2 * DIM3;
+
+    parallel_for3d(DIM0, DIM1, stride2, [&](size_t dim0, size_t dim1, size_t j) {
+        size_t src_off = dim0 * stride0 + j * DIM4 + dim1 * stride1;
+        size_t dst_off = dim0 * stride0 + j * DIM4 * DIM1 + dim1;
+
+        for (size_t dim4 = 0; dim4 < DIM4; ++dim4) {
+            dst_data[dst_off] = src_data[src_off];
+            src_off++;
+            dst_off += DIM1;
+        }
+    });
+}
+
+void MKLDNNReorderNode::optimizedNspc2Ncsp() {
+    auto parentEdge = getParentEdgeAt(0);
+    auto childEdge = getChildEdgeAt(0);
+    const int ndims = parentEdge->getDims().ndims();
+    const size_t DIM0 = parentEdge->getDims()[0];
+    const size_t DIM1 = parentEdge->getDims()[1];
+    const size_t DIM2 = ndims == 5 ? parentEdge->getDims()[ndims - 3] : 1;
+    const size_t DIM3 = parentEdge->getDims()[ndims - 2];
+    const size_t DIM4 = parentEdge->getDims()[ndims - 1];
+
+    auto src_data = reinterpret_cast<const float *>(parentEdge->getMemoryPtr()->GetPtr());
+    auto dst_data = reinterpret_cast<float *>(childEdge->getMemoryPtr()->GetPtr());
+
+    const size_t stride1 = DIM2 * DIM3 * DIM4;
+    const size_t stride0 = stride1 * DIM1;
+    parallel_for2d(DIM0, stride1, [&](size_t b, size_t j) {
+        auto src_off = b*stride0 + j*DIM1;
+        auto dst_off = b*stride0 + j;
+        for (size_t dim1 = 0; dim1 < DIM1; ++dim1) {
+            dst_data[dst_off] = src_data[src_off];
+            src_off++;
+            dst_off += stride1;
+        }
+    });
+}
+
 void MKLDNNReorderNode::execute(mkldnn::stream strm) {
     if (isOptimized)
         return;
 
-    src_blocked->GetPrimitivePtr()->set_data_handle(getParentEdgeAt(0)->getMemory().GetPrimitive().get_data_handle());
-    dst_blocked->GetPrimitivePtr()->set_data_handle(getChildEdgeAt(0)->getMemory().GetPrimitive().get_data_handle());
+    if (canUseOptimizedNspc2Ncsp) {
+        optimizedNspc2Ncsp();
+    } else if (canUseOptimizedNcsp2Nspc) {
+        optimizedNcsp2Nspc();
+    } else {
+        src_blocked->GetPrimitivePtr()->set_data_handle(getParentEdgeAt(0)->getMemory().GetPrimitive().get_data_handle());
+        dst_blocked->GetPrimitivePtr()->set_data_handle(getChildEdgeAt(0)->getMemory().GetPrimitive().get_data_handle());
 
-    MKLDNNNode::execute(strm);
+        MKLDNNNode::execute(strm);
+    }
 }
 
 void MKLDNNReorderNode::setDynamicBatchLim(int lim) {

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reorder_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reorder_node.h
@@ -55,7 +55,11 @@ private:
     MKLDNNMemoryPtr src_blocked;
 
     bool isOptimized = false;
+    bool canUseOptimizedNspc2Ncsp = false;
+    bool canUseOptimizedNcsp2Nspc = false;
 
+    void optimizedNspc2Ncsp();
+    void optimizedNcsp2Nspc();
     void createReorderPrimitive(const mkldnn::memory::desc &srcDesc, void* srcPtr, const mkldnn::memory::desc &dstDesc, void* dstPtr);
 };
 


### PR DESCRIPTION
### Details:
 - OneDNN JIT reorder implementation provides bad performance for NSPC -> NCSP case. As WA this PR introduces custom c++ implementation which perform significantly better.
 - OneDNN doesn't provide JIT reorder implementation for non-avx2 targets. As WA this PR introduces custom c++ implementation which perform significantly better.

### Tickets:
 - 46413
 - 49075
