### PR TITLE
Allow enabling cpplint on Windows, fix Windows style after check

### DIFF
--- a/cmake/developer_package/features.cmake
+++ b/cmake/developer_package/features.cmake
@@ -42,9 +42,13 @@ ie_option (BUILD_SHARED_LIBS "Build as a shared library" ON)
 
 ie_dependent_option (ENABLE_FASTER_BUILD "Enable build features (PCH, UNITY) to speed up build time" OFF "CMAKE_VERSION VERSION_GREATER_EQUAL 3.16" OFF)
 
-ie_dependent_option (ENABLE_CPPLINT "Enable cpplint checks during the build" ON "UNIX;NOT ANDROID" OFF)
+if(NOT DEFINED ENABLE_CPPLINT)
+	ie_dependent_option (ENABLE_CPPLINT "Enable cpplint checks during the build" ON "UNIX;NOT ANDROID" OFF)
+endif()
 
-ie_dependent_option (ENABLE_CPPLINT_REPORT "Build cpplint report instead of failing the build" OFF "ENABLE_CPPLINT" OFF)
+if(NOT DEFINED ENABLE_CPPLINT_REPORT)
+	ie_dependent_option (ENABLE_CPPLINT_REPORT "Build cpplint report instead of failing the build" OFF "ENABLE_CPPLINT" OFF)
+endif()
 
 ie_option (ENABLE_CLANG_FORMAT "Enable clang-format checks during the build" ON)
 

--- a/inference-engine/src/inference_engine/os/win/win_shared_object_loader.cpp
+++ b/inference-engine/src/inference_engine/os/win/win_shared_object_loader.cpp
@@ -1,7 +1,7 @@
 // Copyright (C) 2018-2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
- 
+
 #include "details/ie_exception.hpp"
 #include "details/ie_so_loader.h"
 #include "file_utils.h"
@@ -204,7 +204,7 @@ class SharedObjectLoader::Impl {
         ExcludeCurrentDirectoryW();
         LoadPluginFromDirectoryW(pluginName);
 
-        if(!shared_object) {
+        if (!shared_object) {
             shared_object = LoadLibraryW(pluginName);
         }
 


### PR DESCRIPTION
### Details:
 - this PR allows user to override cpplint related build options by adding command line option ENABLE_CPPLINT=ON/OFF or ENABLE_CPPLINT_REPORT=ON/OFF; without this change cpplint will remain disabled on Windows even with ENABLE_CPPLINT=ON option
 - the default behavior is as before (i.e. the check is enabled on Unix, disabled on Windows) when no option is given on command line
 - introduced are minor style fixes after cpplint run on Windows
 - NOTE: python3 is required in system path.
