### PR TITLE
Changed ngraph header to fix client build with VS2015

### DIFF
--- a/ngraph/core/include/ngraph/pass/graph_rewrite.hpp
+++ b/ngraph/core/include/ngraph/pass/graph_rewrite.hpp
@@ -156,11 +156,11 @@ namespace ngraph
             ///     anchor->add_matcher<MatcherPassB, false>();
             ///
             /// \return shared_ptr to the transformation instance
-            template <
-                typename T,
-                bool Enabled = true,
-                class... Args,
-                typename std::enable_if<std::is_base_of<pass::MatcherPass, T>{}, bool>::type = true>
+            template <typename T,
+                      bool Enabled = true,
+                      class... Args,
+                      typename std::enable_if<std::is_base_of<pass::MatcherPass, T>::value,
+                                              bool>::type = true>
             std::shared_ptr<T> add_matcher(Args&&... args)
             {
                 static_assert(std::is_base_of<pass::MatcherPass, T>::value,
@@ -200,7 +200,7 @@ namespace ngraph
             /// registered matchers.
             template <typename T,
                       class... Args,
-                      typename std::enable_if<std::is_base_of<pass::GraphRewrite, T>{},
+                      typename std::enable_if<std::is_base_of<pass::GraphRewrite, T>::value,
                                               bool>::type = true>
             void add_matcher(Args&&... args)
             {


### PR DESCRIPTION
We observed build errors when building **our** code with ngraph in VS2015:
```
C:\deployment_tools\ngraph\include\ngraph/pass/graph_rewrite.hpp(163): error C2512: 'std::is_base_of<ngraph::pass::MatcherPass,T>': no appropriate default constructor available (compiling source file C:\opencv\modules\dnn\src\dnn.cpp) [C:\build_release\modules\dnn\opencv_dnn.vcxproj]
  C:\deployment_tools\ngraph\include\ngraph/pass/graph_rewrite.hpp(163): note: The target type has no constructors (compiling source file C:\opencv\modules\dnn\src\dnn.cpp)
```

Other possible fix is to remove _graph_rewrite.hpp_ inclusion from root _ngraph.hpp_.

**cc** @alalek 