### PR TITLE
[CPU] Double registration of MVN6 decomposition.

### DIFF
--- a/inference-engine/src/mkldnn_plugin/mkldnn_plugin.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_plugin.cpp
@@ -120,7 +120,6 @@ static void Transformation(CNNNetwork& clonedNetwork, const Config& conf) {
 
     // WA: ConvertPriorBox must be executed before the 1st ConstantFolding pass
     manager.register_pass<ngraph::pass::ConvertPriorBox>();
-    manager.register_pass<ngraph::pass::MVN6Decomposition>();
     manager.register_pass<ngraph::pass::ConvertNMS5ToLegacyMatcher>();
     manager.register_pass<ngraph::pass::CommonOptimizations>();
     manager.register_pass<ngraph::pass::ConvertRNNSequenceToTensorIterator>();

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/mvn.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/mvn.cpp
@@ -130,18 +130,6 @@ INSTANTIATE_TEST_CASE_P(smoke_MVN_1D, Mvn6LayerTest,
                             ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         Mvn6LayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(smoke_Decomposition_1D, Mvn6LayerTest,
-                        ::testing::Combine(
-                            ::testing::ValuesIn(std::vector<std::vector<size_t>>{{3}, {9}, {55}}),
-                            ::testing::ValuesIn(dataPrecisions),
-                            ::testing::ValuesIn(idxPrecisions),
-                            ::testing::ValuesIn(std::vector<std::vector<int>>{{}}),
-                            ::testing::ValuesIn(normalizeVariance),
-                            ::testing::ValuesIn(epsilonF),
-                            ::testing::ValuesIn(epsMode),
-                            ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                        Mvn6LayerTest::getTestCaseName);
-
 INSTANTIATE_TEST_CASE_P(smoke_Decomposition_3D, Mvn6LayerTest,
                         ::testing::Combine(
                             ::testing::ValuesIn(std::vector<std::vector<size_t>>{{1, 32, 17}, {1, 37, 9}}),


### PR DESCRIPTION
### Details:
 - *MVN6 decomposition is enabled by default now. So, registration in plugin must be removed.*

### Tickets:
 - *48879*
