### PR TITLE
[LPT] FakeQuantizeTransformation: fuse eltwise to fq fix

### DIFF
--- a/inference-engine/src/low_precision_transformations/src/fake_quantize.cpp
+++ b/inference-engine/src/low_precision_transformations/src/fake_quantize.cpp
@@ -72,6 +72,17 @@ static std::shared_ptr<opset1::Constant> getConstant(const std::shared_ptr<Node>
 }  // namespace fq
 
 bool FakeQuantizeTransformation::checkElementwise(const std::shared_ptr<Node>& eltwise) {
+    const auto eltwiseInputShape = eltwise->get_input_shape(0);
+    const auto eltwiseOutputShape = eltwise->get_output_shape(0);
+    if (eltwiseInputShape.size() != eltwiseOutputShape.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < eltwiseOutputShape.size(); ++i) {
+        if (eltwiseInputShape[i] != eltwiseOutputShape[i]) {
+            return false;
+        }
+    }
+
     std::shared_ptr<opset1::Constant> constant = fq::getConstant(eltwise);
     if (constant == nullptr) {
         return false;
@@ -79,12 +90,11 @@ bool FakeQuantizeTransformation::checkElementwise(const std::shared_ptr<Node>& e
 
     Shape shape = constant->get_output_shape(0);
     if ((!shape.empty()) && (shape_size(shape) != 1ul)) {
-        const Shape eltwiseShape = eltwise->get_output_shape(0);
-        if ((eltwiseShape.size() - shape.size()) > 1) {
+        if ((eltwiseOutputShape.size() - shape.size()) > 1) {
             return false;
         }
 
-        if ((eltwiseShape.size() - shape.size()) == 1ul) {
+        if ((eltwiseOutputShape.size() - shape.size()) == 1ul) {
             shape.insert(shape.begin(), 1ul);
         }
 

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/fuse_fake_quantize_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/fuse_fake_quantize_transformation.cpp
@@ -142,6 +142,28 @@ const std::vector<FuseFakeQuantizeTransformationTestValues> testValues = {
             { 256ul, {}, { 0.f }, { 255.f }, { 0.f }, { 2.55f } }
         }
     },
+    // 1) Multiply with different input and output shape
+    {
+        Shape{128, 1},
+        LayerTransformation::createParamsU8I8(),
+        {
+            element::f32,
+            {},
+            element::f32,
+            { {}, {}, { {0.01f, 0.1f, 1.f}, ngraph::element::f32, {1, 3} } },
+            element::f32,
+            { 256ul, {}, { 0.f }, { 2.55f }, { 0.f }, { 2.55f } }
+        },
+        {
+            element::f32,
+            {},
+            element::f32,
+            { {}, {}, { {0.01f, 0.1f, 1.f}, ngraph::element::f32, {1, 3} } },
+            element::f32,
+            element::f32,
+            { 256ul, {}, { 0.f }, { 2.55f }, { 0.f }, { 2.55f } }
+        }
+    },
     // 1) Multiply + 2) Add
     {
         Shape{1, 3, 16, 16},

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/fuse_fake_quantize_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/fuse_fake_quantize_transformation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -21,6 +21,19 @@ const std::vector<FuseFakeQuantizeTransformationTestValues> testValues = {
             { },
             ngraph::element::f32,
             { {}, {}, { 0.01f } },
+            ngraph::element::f32,
+            { 256ul, {}, { 0.f }, { 2.55f }, { 0.f }, { 2.55f } }
+        }
+    },
+    // 1) Multiply with different input and output shape
+    {
+        ngraph::Shape{128, 1},
+        LayerTestsUtils::LayerTransformationParamsNGraphFactory::createParamsU8I8(),
+        {
+            ngraph::element::f32,
+            { },
+            ngraph::element::f32,
+            { {}, {}, { {0.01f, 0.1f, 1.f}, ngraph::element::f32, {1, 3} } },
             ngraph::element::f32,
             { 256ul, {}, { 0.f }, { 2.55f }, { 0.f }, { 2.55f } }
         }

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/fuse_fake_quantize_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/fuse_fake_quantize_transformation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -20,6 +20,19 @@ const std::vector<FuseFakeQuantizeTransformationTestValues> testValues = {
             { },
             ngraph::element::f32,
             { {}, {}, { 0.01f } },
+            ngraph::element::f32,
+            { 256ul, {}, { 0.f }, { 2.55f }, { 0.f }, { 2.55f } }
+        }
+    },
+    // 1) Multiply with different input and output shape
+    {
+        ngraph::Shape{128, 1},
+        LayerTestsUtils::LayerTransformationParamsNGraphFactory::createParamsU8I8(),
+        {
+            ngraph::element::f32,
+            { },
+            ngraph::element::f32,
+            { {}, {}, { {0.01f, 0.1f, 1.f}, ngraph::element::f32, {1, 3} } },
             ngraph::element::f32,
             { 256ul, {}, { 0.f }, { 2.55f }, { 0.f }, { 2.55f } }
         }


### PR DESCRIPTION
Issue #48203

Validation:
accuracy: developer-services/job/accuracy/1293/ (reference: developer-services/job/accuracy/1295/)

Validation:
accuracy: developer-services/job/accuracy/1303/ (reference: developer-services/job/accuracy/1299/)
performance: developer-services/job/performance/680/