### PR TITLE
Fixed undeclared identifier SWITCH_MKLDNNPlugin

### DIFF
--- a/inference-engine/src/mkldnn_plugin/nodes/one_hot.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/one_hot.cpp
@@ -11,6 +11,8 @@
 
 #include <vector>
 
+using namespace MKLDNNPlugin;
+
 namespace InferenceEngine {
 namespace Extensions {
 namespace Cpu {


### PR DESCRIPTION
### Details:
 - Fixed build for CC
 - error: ‘SWITCH_MKLDNNPlugin’ was not declared in this scope
 - In the line `OV_SWITCH(MKLDNNPlugin, OneHotExecute, ctx, output_precision.size(),` (`inference-engine/src/mkldnn_plugin/nodes/one_hot.cpp:93`) I got the next suggestion: `use of undeclared identifier 'SWITCH_MKLDNNPlugin'; did you mean 'MKLDNNPlugin::SWITCH_MKLDNNPlugin'?`
