### PR TITLE
Adds fix required to run tests for other plugins

### DIFF
--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/eltwise_conv_eltwise.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/eltwise_conv_eltwise.hpp
@@ -31,7 +31,7 @@ typedef std::tuple<
 > EltwiseConvEltwiseParams;
 
 class EltwiseAfterConvTest : public testing::WithParamInterface<EltwiseConvEltwiseParams>,
-                             public LayerTestsUtils::LayerTestsCommon {
+                             virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<EltwiseConvEltwiseParams> obj);
     InferenceEngine::Blob::Ptr GenerateInput(const InferenceEngine::InputInfo& info) const override;
@@ -41,7 +41,7 @@ protected:
 };
 
 class EltwiseBeforeConvTest : public testing::WithParamInterface<EltwiseConvEltwiseParams>,
-                              public LayerTestsUtils::LayerTestsCommon {
+                              virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<EltwiseConvEltwiseParams> obj);
     InferenceEngine::Blob::Ptr GenerateInput(const InferenceEngine::InputInfo& info) const override;
@@ -51,7 +51,7 @@ protected:
 };
 
 class EltwiseWithTwoConvsAsInputsTest : public testing::WithParamInterface<EltwiseConvEltwiseParams>,
-                                        public LayerTestsUtils::LayerTestsCommon {
+                                        virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<EltwiseConvEltwiseParams> obj);
     InferenceEngine::Blob::Ptr GenerateInput(const InferenceEngine::InputInfo& info) const override;


### PR DESCRIPTION
### Details:
 - This adds the virtual keyword to the _LayerTestsCommon_ class to allow instances of this Eltwise test class to be created for other plugins

### Tickets:

