### PR TITLE
add string constants '0'/'1' to bool normalizer

### DIFF
--- a/model-optimizer/mo/front/extractor.py
+++ b/model-optimizer/mo/front/extractor.py
@@ -138,8 +138,10 @@ def bool_to_str(node: Node, attr: str):
         return None
     if isinstance(attribute_name, bool):
         return str(attribute_name).lower()
-    elif attribute_name in [0, 1, '0', '1']:
+    elif attribute_name in [0, 1]:
         return str(bool(attribute_name)).lower()
+    elif attribute_name in ['0', '1']:
+        return str(bool(int(attribute_name))).lower()
     else:
         raise Error('Wrong value {} for boolean attribute {} in node {}'.format(
             attribute_name, attr, node.soft_get('name')))

--- a/model-optimizer/mo/front/extractor.py
+++ b/model-optimizer/mo/front/extractor.py
@@ -132,13 +132,13 @@ def attr_getter(node: Node, name: str):
 
 
 def bool_to_str(node: Node, attr: str):
-    # Function converts 0/1 or bool False/True values to str 'false'/'true' which need to appear in IR
+    # Function converts 0/1 or bool False/True or '0'/'1' values to str 'false'/'true' which need to appear in IR
     attribute_name = node.soft_get(attr, None)
     if attribute_name is None:
         return None
     if isinstance(attribute_name, bool):
         return str(attribute_name).lower()
-    elif attribute_name in [0, 1]:
+    elif attribute_name in [0, 1, '0', '1']:
         return str(bool(attribute_name)).lower()
     else:
         raise Error('Wrong value {} for boolean attribute {} in node {}'.format(


### PR DESCRIPTION
### Details:
MO for Caffe models save bool attributes as string with int. Fix bool normalizer to get standard value in IR because change in extractor is more risky.

### Tickets:
 - 48105
