### PR TITLE
[IE CLDNN] Fix to handle reshape on graph optimization stage

### DIFF
--- a/inference-engine/thirdparty/clDNN/src/graph_optimizer/handle_reshape.cpp
+++ b/inference-engine/thirdparty/clDNN/src/graph_optimizer/handle_reshape.cpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2019 Intel Corporation
+// Copyright (c) 2019-2021 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,13 +40,19 @@ void handle_reshape::run(program_impl& p) {
     while (node_itr != p.get_processing_order().end()) {
         auto node = (*node_itr++);
         program_helpers::do_for_types<reshape>(*node, [&p](reshape_node& node) {
-            auto input_lay = node.input().get_output_layout();
+            auto& input_node = node.input();
+            auto input_lay = input_node.get_output_layout();
             auto output_lay = node.get_output_layout();
 
             if (!node.is_in_place())
                 return;
 
-            if (program_helpers::are_layouts_identical(input_lay, output_lay).first) {
+            auto are_layouts_identical = program_helpers::are_layouts_identical(input_lay, output_lay);
+            if (are_layouts_identical.first) {
+                p.add_optimized_primitive_info(node.id());
+                p.extract_and_remove(node);
+            } else if (are_layouts_identical.second && input_node.is_type<data>()) {
+                input_node.set_output_layout(output_lay, false);
                 p.add_optimized_primitive_info(node.id());
                 p.extract_and_remove(node);
             }

--- a/inference-engine/thirdparty/clDNN/src/program.cpp
+++ b/inference-engine/thirdparty/clDNN/src/program.cpp
@@ -26,6 +26,7 @@
 #include "program_dump_graph.h"
 #include "program_impl.h"
 #include "sliding_window_utils.h"
+#include "program_helpers.h"
 
 #include "roi_pooling_inst.h"
 #include "reorg_yolo_inst.h"
@@ -375,7 +376,9 @@ void program_impl::build_program(bool is_internal) {
     if (!is_internal)
         prim_info = get_current_stage_info();
 
-    if (!is_internal)  transfer_memory_to_device();
+    if (!is_internal)
+        transfer_memory_to_device();
+
     cleanup();
 }
 
@@ -531,12 +534,19 @@ void program_impl::transfer_memory_to_device() {
     for (auto& node : processing_order) {
         if (node->is_type<data>() && !node->need_lockable_memory()) {
             auto& data_node = node->as<data>();
+            auto data_node_layout = data_node.get_output_layout();
             auto& mem = data_node.get_attached_memory();
+            auto mem_layout = mem.get_layout();
             auto alloc_type = mem.get_allocation_type();
+
+            if (!program_helpers::are_layouts_identical(mem_layout, data_node_layout).second) {
+                std::string err_str("Node and memory layouts are incompatible, error occurred for " + node->id() + " node");
+                throw std::invalid_argument(err_str);
+            }
 
             if (alloc_type == allocation_type::usm_host || alloc_type == allocation_type::usm_shared) {
                 // Allocate and transfer memory
-                auto device_mem = mem.get_engine()->allocate_memory(mem.get_layout(),
+                auto device_mem = mem.get_engine()->allocate_memory(data_node_layout,
                                                                     allocation_type::usm_device,
                                                                     mem.get_net_id(),
                                                                     false);


### PR DESCRIPTION
This patch fixes reshapes processing, that were inserted in clDNN Plugin in `CreateElementwiseOp` (and some other) function. For now these additional reshapes processed by constant propagator, which cause an increase in compilation time.
The changes in transfer_memory stage are needed to use node's layout instead of memory's.