### PR TITLE
Fix NonZero output shape inference for static inputs.

### DIFF
--- a/inference-engine/tests/functional/inference_engine/serialization/single_layer/nonzero.cpp
+++ b/inference-engine/tests/functional/inference_engine/serialization/single_layer/nonzero.cpp
@@ -1,0 +1,35 @@
+
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "shared_test_classes/single_layer/nonzero.hpp"
+
+using namespace ngraph;
+using namespace LayerTestsDefinitions;
+
+namespace {
+TEST_P(NonZeroLayerTest, Serialize) {
+    Serialize();
+}
+
+std::vector<InferenceEngine::SizeVector> inputDims = {
+    {7},       {1000},         {3, 5},       {65, 33},       {33, 65},
+    {1, 1000}, {223, 217, 21}, {3, 4, 5, 1}, {3, 4, 1, 5, 1}};
+
+std::vector<InferenceEngine::Precision> inputPrecisions = {
+    InferenceEngine::Precision::U8, InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::I32,
+};
+
+ConfigMap config;
+
+INSTANTIATE_TEST_CASE_P(
+    smoke_NonZeroLayerTest, NonZeroLayerTest,
+    ::testing::Combine(::testing::ValuesIn(inputDims),
+                       ::testing::ValuesIn(inputPrecisions),
+                       ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                       ::testing::Values(config)));
+}  // namespace

--- a/ngraph/core/src/op/non_zero.cpp
+++ b/ngraph/core/src/op/non_zero.cpp
@@ -13,10 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //*****************************************************************************
+#include <numeric>
 
-#include "ngraph/op/non_zero.hpp"
 #include <ngraph/validation_util.hpp>
 #include "itt.hpp"
+#include "ngraph/op/non_zero.hpp"
 #include "ngraph/op/op.hpp"
 #include "ngraph/runtime/host_tensor.hpp"
 #include "ngraph/runtime/reference/non_zero.hpp"
@@ -75,8 +76,8 @@ void op::v3::NonZero::validate_and_infer_types()
     }
     else
     {
-        const Dimension dim =
-            input_shape.is_static() ? shape_size(input_shape.get_shape()) : Dimension::dynamic();
+        const Dimension dim = std::accumulate(
+            begin(input_shape), end(input_shape), Dimension(), std::multiplies<Dimension>());
         set_output_type(0, m_output_type, PartialShape{input_shape.rank(), dim});
     }
 

--- a/ngraph/core/src/op/non_zero.cpp
+++ b/ngraph/core/src/op/non_zero.cpp
@@ -77,7 +77,7 @@ void op::v3::NonZero::validate_and_infer_types()
     else
     {
         const Dimension dim = std::accumulate(
-            begin(input_shape), end(input_shape), Dimension(), std::multiplies<Dimension>());
+            begin(input_shape), end(input_shape), Dimension(1), std::multiplies<Dimension>());
         set_output_type(0, m_output_type, PartialShape{input_shape.rank(), dim});
     }
 

--- a/ngraph/core/src/op/non_zero.cpp
+++ b/ngraph/core/src/op/non_zero.cpp
@@ -75,7 +75,9 @@ void op::v3::NonZero::validate_and_infer_types()
     }
     else
     {
-        set_output_type(0, m_output_type, PartialShape{input_shape.rank(), Dimension::dynamic()});
+        const Dimension dim =
+            input_shape.is_static() ? shape_size(input_shape.get_shape()) : Dimension::dynamic();
+        set_output_type(0, m_output_type, PartialShape{input_shape.rank(), dim});
     }
 
     set_input_is_relevant_to_shape(0);

--- a/ngraph/core/src/op/non_zero.cpp
+++ b/ngraph/core/src/op/non_zero.cpp
@@ -76,8 +76,12 @@ void op::v3::NonZero::validate_and_infer_types()
     }
     else
     {
-        const Dimension dim = std::accumulate(
-            begin(input_shape), end(input_shape), Dimension(1), std::multiplies<Dimension>());
+        const Dimension dim = input_shape.is_static()
+                                  ? std::accumulate(begin(input_shape),
+                                                    end(input_shape),
+                                                    Dimension(0, 1),
+                                                    std::multiplies<Dimension>())
+                                  : Dimension();
         set_output_type(0, m_output_type, PartialShape{input_shape.rank(), dim});
     }
 


### PR DESCRIPTION
Ticket. 29898. Serialization fails for NonZero op because it contain dynamic dimension which cannot be resolved (no upper bound). Improved error message for this case.