### PR TITLE
Delete unnecessary check in validate_and_infer function of TensorIterator

### DIFF
--- a/ngraph/core/src/op/tensor_iterator.cpp
+++ b/ngraph/core/src/op/tensor_iterator.cpp
@@ -168,9 +168,6 @@ void op::v0::TensorIterator::validate_and_infer_types()
 
             auto body_param_partial_shape = body_parameter->get_partial_shape();
             auto input_partial_shape = inputs().at(index).get_source_output().get_partial_shape();
-            NODE_VALIDATION_CHECK(this,
-                                  input_partial_shape.compatible(body_param_partial_shape),
-                                  "Iterator initial value is not compatible with body param");
             body_parameter->set_partial_shape(input_partial_shape);
         }
     }


### PR DESCRIPTION
### Details:
 - This check in validate_and_infer_type function of TI is unnecessary and brokes reshape() of networks

### Tickets:
 - *49223*
