### PR TITLE
[CPU] CoreThreadingTestsWithIterations test enabling on WIN platform

### DIFF
--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
@@ -27,10 +27,6 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*RangeLayerTest.*)",
         R"(.*(RangeAddSubgraphTest).*Start=1.2.*Stop=(5.2|-5.2).*Step=(0.1|-0.1).*netPRC=FP16.*)",
         R"(.*(RangeNumpyAddSubgraphTest).*netPRC=FP16.*)",
-        // TODO: Issue: 34083
-#if (defined(_WIN32) || defined(_WIN64))
-        R"(.*(CoreThreadingTestsWithIterations).*(smoke_LoadNetworkAccuracy).*)",
-#endif
         // TODO: Issue: 43793
         R"(.*(PreprocessTest).*(SetScalePreProcessSetBlob).*)",
         R"(.*(PreprocessTest).*(SetScalePreProcessGetBlob).*)",


### PR DESCRIPTION
### Details:
It seems that CoreThreadingTestsWithIterations.smoke_LoadNetworkAccuracy functional test does not fail anymore. It should be enabled.

### Tickets:
 - 42538
 - 34092
