### PR TITLE
[CPU] Fixed CPU specific Interpolate test for BF16 precision

### DIFF
--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/interpolate.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/interpolate.cpp
@@ -101,12 +101,7 @@ protected:
             selectedType = getPrimitiveType();
         }
         selectedType.push_back('_');
-        if (configuration.find(PluginConfigParams::KEY_ENFORCE_BF16) != configuration.end() &&
-            configuration[PluginConfigParams::KEY_ENFORCE_BF16] == PluginConfigParams::YES) {
-            selectedType += "BF16";
-        } else {
-            selectedType += "FP32";
-        }
+        selectedType += "FP32";
     }
 };
 


### PR DESCRIPTION
### Details:
 - Fixed CPU specific Interpolate test for BF16 precision on master (the issue is caused by two intersect PRs: https://github.com/openvinotoolkit/openvino/pull/4236 and https://github.com/openvinotoolkit/openvino/pull/4395 merged at the same time).

