### PR TITLE
[PP] Support for FP16 in Reorder cases

### DIFF
--- a/inference-engine/src/preprocessing/ie_preprocess_gapi.cpp
+++ b/inference-engine/src/preprocessing/ie_preprocess_gapi.cpp
@@ -81,7 +81,8 @@ inline int get_cv_depth(const TensorDesc &ie_desc) {
     case Precision::U8:   return CV_8U;
     case Precision::FP32: return CV_32F;
     case Precision::U16:  return CV_16U;
-    case Precision::FP16: return CV_16U;
+    case Precision::I16:  return CV_16S;
+    case Precision::FP16: return CV_16F;
 
     default: IE_THROW() << "Unsupported data type";
     }

--- a/inference-engine/src/preprocessing/ie_preprocess_gapi_kernels.cpp
+++ b/inference-engine/src/preprocessing/ie_preprocess_gapi_kernels.cpp
@@ -434,6 +434,11 @@ void splitRow(const uint8_t* in, std::array<uint8_t*, chs>& outs, int length) {
 
 namespace {
 
+struct fp_16_t {
+    int16_t v;
+};
+
+
 template<typename type>
 struct cv_type_to_depth;
 
@@ -443,6 +448,7 @@ template<> struct cv_type_to_depth<std::uint16_t>   { enum { depth = CV_16U }; }
 template<> struct cv_type_to_depth<std::int16_t>    { enum { depth = CV_16S }; };
 template<> struct cv_type_to_depth<std::int32_t>    { enum { depth = CV_32S }; };
 template<> struct cv_type_to_depth<float>           { enum { depth = CV_32F }; };
+template<> struct cv_type_to_depth<fp_16_t>         { enum { depth = CV_16F }; };
 
 template<typename ... types>
 struct typelist {};
@@ -500,7 +506,7 @@ bool is_cv_type_in_list(const int type_id) {
 
 namespace {
 
-using merge_supported_types = typelist<uint8_t, int8_t, uint16_t, int16_t, int32_t, float>;
+using merge_supported_types = typelist<uint8_t, int8_t, uint16_t, int16_t, int32_t, float, fp_16_t>;
 
 template<int chs>
 struct typed_merge_row {
@@ -508,6 +514,12 @@ struct typed_merge_row {
 
     template <typename type>
     p_f operator()(type_to_type<type> ) { return mergeRow<type, chs>; }
+
+    p_f operator()(type_to_type<fp_16_t> ) {
+        static_assert(sizeof(fp_16_t) == sizeof(fp_16_t::v),
+                "fp_16_t should be a plain wrap over FP16 implementation type");
+        return mergeRow<decltype(fp_16_t::v), chs>;
+    }
 };
 
 }  // namespace
@@ -562,8 +574,7 @@ GAPI_FLUID_KERNEL(FMerge4, Merge4, false) {
 
 
 namespace {
-
-using split_supported_types = typelist<uint8_t, int8_t, uint16_t, int16_t, int32_t, float>;
+using split_supported_types = typelist<uint8_t, int8_t, uint16_t, int16_t, int32_t, float, fp_16_t>;
 
 template<int chs>
 struct typed_split_row {
@@ -571,6 +582,12 @@ struct typed_split_row {
 
     template <typename type>
     p_f operator()(type_to_type<type> ) { return splitRow<type, chs>; }
+
+    p_f operator()(type_to_type<fp_16_t> ) {
+        static_assert(sizeof(fp_16_t) == sizeof(fp_16_t::v),
+                "fp_16_t should be a plain wrap over FP16 implementation type");
+        return splitRow<decltype(fp_16_t::v), chs>;
+    }
 };
 
 }  // namespace

--- a/inference-engine/tests_deprecated/fluid_preproc/cpu/fluid_tests_cpu.cpp
+++ b/inference-engine/tests_deprecated/fluid_preproc/cpu/fluid_tests_cpu.cpp
@@ -132,7 +132,7 @@ INSTANTIATE_TEST_CASE_P(ResizeTestFluid_F32, ResizeTestGAPI,
 
 INSTANTIATE_TEST_CASE_P(SplitTestFluid, SplitTestGAPI,
                         Combine(Values(2, 3, 4),
-                                Values(CV_8U, CV_8S, CV_16U, CV_16S, CV_32F, CV_32S),
+                                Values(CV_8U, CV_8S, CV_16U, CV_16S, CV_16F, CV_32F, CV_32S),
                                 Values(TEST_SIZES),
                                 Values(0)));
 
@@ -144,7 +144,7 @@ INSTANTIATE_TEST_CASE_P(ChanToPlaneTestFluid, ChanToPlaneTestGAPI,
 
 INSTANTIATE_TEST_CASE_P(MergeTestFluid, MergeTestGAPI,
                         Combine(Values(2, 3, 4),
-                                Values(CV_8U, CV_8S, CV_16U, CV_16S, CV_32F, CV_32S),
+                                Values(CV_8U, CV_8S, CV_16U, CV_16S, CV_16F, CV_32F, CV_32S),
                                 Values(TEST_SIZES),
                                 Values(0)));
 
@@ -269,7 +269,7 @@ INSTANTIATE_TEST_CASE_P(ColorConvertYUV420Fluid, ColorConvertYUV420TestIE,
                                 Values(0)));
 
 INSTANTIATE_TEST_CASE_P(Reorder_HWC2CHW, ColorConvertTestIE,
-                        Combine(Values(CV_8U, CV_32F),
+                        Combine(Values(CV_8U, CV_32F, CV_16S, CV_16F),
                                 Values(InferenceEngine::ColorFormat::BGR),
                                 Values(InferenceEngine::NHWC),
                                 Values(InferenceEngine::NCHW),
@@ -277,7 +277,7 @@ INSTANTIATE_TEST_CASE_P(Reorder_HWC2CHW, ColorConvertTestIE,
                                 Values(0)));
 
 INSTANTIATE_TEST_CASE_P(Reorder_CHW2HWC, ColorConvertTestIE,
-                        Combine(Values(CV_8U, CV_32F),
+                        Combine(Values(CV_8U, CV_32F, CV_16S, CV_16F),
                                 Values(InferenceEngine::ColorFormat::BGR),
                                 Values(InferenceEngine::NCHW),
                                 Values(InferenceEngine::NHWC),

--- a/inference-engine/thirdparty/fluid/modules/gapi/include/opencv2/gapi/own/cvdefs.hpp
+++ b/inference-engine/thirdparty/fluid/modules/gapi/include/opencv2/gapi/own/cvdefs.hpp
@@ -32,7 +32,8 @@ typedef unsigned short ushort;
 #define CV_32S  4
 #define CV_32F  5
 #define CV_64F  6
-#define CV_USRTYPE1 7
+#define CV_16F  7
+#define CV_USRTYPE1 8
 
 #define CV_MAT_DEPTH_MASK       (CV_DEPTH_MAX - 1)
 #define CV_MAT_DEPTH(flags)     ((flags) & CV_MAT_DEPTH_MASK)
@@ -69,6 +70,13 @@ typedef unsigned short ushort;
 #define CV_32SC3 CV_MAKETYPE(CV_32S,3)
 #define CV_32SC4 CV_MAKETYPE(CV_32S,4)
 #define CV_32SC(n) CV_MAKETYPE(CV_32S,(n))
+
+
+#define CV_16FC1 CV_MAKETYPE(CV_16F,1)
+#define CV_16FC2 CV_MAKETYPE(CV_16F,2)
+#define CV_16FC3 CV_MAKETYPE(CV_16F,3)
+#define CV_16FC4 CV_MAKETYPE(CV_16F,4)
+#define CV_16FC(n) CV_MAKETYPE(CV_16F,(n))
 
 #define CV_32FC1 CV_MAKETYPE(CV_32F,1)
 #define CV_32FC2 CV_MAKETYPE(CV_32F,2)


### PR DESCRIPTION
This tiny PR fixes up FP16 support introduced in #4141 

### Details:
 - added basic support for FP16 (plain wrapper over uint16_t)
 - extended Split/Merge operations to support it
 - tests

@nikita-kud , FYI
