### PR TITLE
Reset Variable to dynamic state in revalidate_and_infer function of ReadValue op

### DIFF
--- a/ngraph/core/include/ngraph/node.hpp
+++ b/ngraph/core/include/ngraph/node.hpp
@@ -237,7 +237,7 @@ namespace ngraph
         void set_output_size(size_t output_size);
 
         void invalidate_values();
-        void revalidate_and_infer_types()
+        virtual void revalidate_and_infer_types()
         {
             invalidate_values();
             validate_and_infer_types();

--- a/ngraph/core/include/ngraph/op/read_value.hpp
+++ b/ngraph/core/include/ngraph/op/read_value.hpp
@@ -112,6 +112,8 @@ namespace ngraph
 
                 void validate_and_infer_types() override;
 
+                void revalidate_and_infer_types() override;
+
                 std::shared_ptr<Node>
                     clone_with_new_inputs(const OutputVector& new_args) const override;
 

--- a/ngraph/core/src/op/read_value.cpp
+++ b/ngraph/core/src/op/read_value.cpp
@@ -98,3 +98,11 @@ bool op::v6::ReadValue::visit_attributes(AttributeVisitor& visitor)
     visitor.on_attribute("variable_id", m_variable);
     return true;
 }
+
+void op::v6::ReadValue::revalidate_and_infer_types()
+{
+    VariableInfo var_info{
+        PartialShape::dynamic(), element::dynamic, m_variable->get_info().variable_id};
+    m_variable->update(var_info);
+    Node::revalidate_and_infer_types();
+}


### PR DESCRIPTION
### Details:
 - * Reset Variable to dynamic state in revalidate_and_infer function of ReadValue op. We need to store the state (shape and type) of Variables between inferences (or between evaluate calls), but in some scenarios such as calling the reshape() of CNN Network, we need to drop shape and type and set them to dynamic. *

### Tickets:
 - *49217*
