### PR TITLE
Enabled SSE42 on ia32 by default

### DIFF
--- a/cmake/toolchains/ia32.linux.toolchain.cmake
+++ b/cmake/toolchains/ia32.linux.toolchain.cmake
@@ -20,8 +20,5 @@ endmacro()
 # need libusb 32-bits version
 _set_if_not_defined(ENABLE_VPU OFF)
 
-# _mm_loadl_epi64 is not defined
-_set_if_not_defined(ENABLE_SSE42 OFF)
-
 # fix conversion from uint64_t / int64_t to size_t
 _set_if_not_defined(NGRAPH_ONNX_IMPORT_ENABLE OFF)


### PR DESCRIPTION
### Details:
 - After this fix https://github.com/openvinotoolkit/openvino/pull/4433 we can enable SSE42 by default.

### Tickets:
 - CVS-48065
