### PR TITLE
Pyngraph independent locations for lib files

### DIFF
--- a/ngraph/python/CMakeLists.txt
+++ b/ngraph/python/CMakeLists.txt
@@ -18,6 +18,8 @@ cmake_minimum_required (VERSION 3.13)
 
 project (pyngraph)
 
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/${PYTHON_VERSION})
+
 if(NOT DEFINED OpenVINO_MAIN_SOURCE_DIR)
     find_package(InferenceEngineDeveloperPackage QUIET)
     find_package(ngraph REQUIRED)

--- a/ngraph/python/CMakeLists.txt
+++ b/ngraph/python/CMakeLists.txt
@@ -18,8 +18,6 @@ cmake_minimum_required (VERSION 3.13)
 
 project (pyngraph)
 
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/${PYTHON_VERSION})
-
 if(NOT DEFINED OpenVINO_MAIN_SOURCE_DIR)
     find_package(InferenceEngineDeveloperPackage QUIET)
     find_package(ngraph REQUIRED)
@@ -51,6 +49,8 @@ if(PYTHON_FOUND)
 else()
     message(FATAL_ERROR "Python was not found!")
 endif()
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/${PYTHON_VERSION})
 
 # compile options
 


### PR DESCRIPTION
### Details:
During parallel build of pyngraph module, collision in _pyngraph.exp file happens
This patch sets unique locations for each python versions