### PR TITLE
Revise ADD operation reference implementation

### DIFF
--- a/inference-engine/tests/functional/inference_engine/serialization/single_layer/elementwise.cpp
+++ b/inference-engine/tests/functional/inference_engine/serialization/single_layer/elementwise.cpp
@@ -1,0 +1,63 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "shared_test_classes/single_layer/eltwise.hpp"
+
+using namespace LayerTestsDefinitions;
+
+namespace {
+TEST_P(EltwiseLayerTest, Serialize) { Serialize(); }
+const std::vector<InferenceEngine::Precision> inputPrecisions = {
+        InferenceEngine::Precision::FP32,
+        InferenceEngine::Precision::FP16,
+        InferenceEngine::Precision::I32,
+        };
+
+std::vector<std::vector<std::vector<size_t>>> inputShapes = {
+        {{2}},
+        {{1, 5, 50}},
+        {{2, 10, 1, 4}, {2, 10, 1, 1}}
+};
+
+std::vector<ngraph::helpers::InputLayerType> secondaryInputTypes = {
+        ngraph::helpers::InputLayerType::CONSTANT,
+        ngraph::helpers::InputLayerType::PARAMETER,
+};
+
+std::vector<CommonTestUtils::OpType> opTypes = {
+        CommonTestUtils::OpType::SCALAR,
+        CommonTestUtils::OpType::VECTOR,
+};
+
+std::vector<ngraph::helpers::EltwiseTypes> eltwiseOpTypes = {
+        ngraph::helpers::EltwiseTypes::ADD,
+        ngraph::helpers::EltwiseTypes::MULTIPLY,
+        ngraph::helpers::EltwiseTypes::SUBTRACT,
+        ngraph::helpers::EltwiseTypes::DIVIDE,
+        ngraph::helpers::EltwiseTypes::FLOOR_MOD,
+        ngraph::helpers::EltwiseTypes::SQUARED_DIFF,
+        ngraph::helpers::EltwiseTypes::POWER,
+        ngraph::helpers::EltwiseTypes::MOD
+};
+
+std::map<std::string, std::string> additionalConfig = {};
+
+const auto elementiwiseParams = ::testing::Combine(
+        ::testing::ValuesIn(inputShapes),
+        ::testing::ValuesIn(eltwiseOpTypes),
+        ::testing::ValuesIn(secondaryInputTypes),
+        ::testing::ValuesIn(opTypes),
+        ::testing::ValuesIn(inputPrecisions),
+        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(CommonTestUtils::DEVICE_CPU),
+        ::testing::Values(additionalConfig));
+
+INSTANTIATE_TEST_CASE_P(smoke_ElementwiseSerialization, EltwiseLayerTest,
+                        elementiwiseParams,
+                        EltwiseLayerTest::getTestCaseName);
+} // namespace

--- a/ngraph/test/backend/add.in.cpp
+++ b/ngraph/test/backend/add.in.cpp
@@ -95,3 +95,53 @@ NGRAPH_TEST(${BACKEND_NAME}, add_in_place)
     test_case.add_expected_output<float>(shape, {48, 64, 80, 96});
     test_case.run();
 }
+
+NGRAPH_TEST(${BACKEND_NAME}, add_broadcast)
+{
+    Shape shape_a{1, 2};
+    Shape shape_b{3, 2, 2};
+    auto A = make_shared<op::Parameter>(element::f32, shape_a);
+    auto B = make_shared<op::Parameter>(element::f32, shape_b);
+    auto f = make_shared<Function>(make_shared<op::v1::Add>(A, B), ParameterVector{A, B});
+
+    vector<float> a{1, 2};
+    vector<float> b{5, 6, 7, 8, 2, 3, 1, 5, 6, 7, 1, 3};
+
+    auto test_case = test::TestCase<TestEngine>(f);
+    test_case.add_multiple_inputs<float>({a, b});
+    test_case.add_expected_output<float>(shape_b, {6, 8, 8, 10, 3, 5, 2, 7, 7, 9, 2, 5});
+    test_case.run();
+}
+
+NGRAPH_TEST(${BACKEND_NAME}, add_scalars)
+{
+    Shape shape{};
+    auto A = make_shared<op::Parameter>(element::f32, shape);
+    auto B = make_shared<op::Parameter>(element::f32, shape);
+    auto f = make_shared<Function>(make_shared<op::v1::Add>(A, B), ParameterVector{A, B});
+
+    vector<float> a{2};
+    vector<float> b{8};
+
+    auto test_case = test::TestCase<TestEngine>(f);
+    test_case.add_multiple_inputs<float>({a, b});
+    test_case.add_expected_output<float>(shape, {10});
+    test_case.run();
+}
+
+NGRAPH_TEST(${BACKEND_NAME}, add_vector_and_scalar)
+{
+    Shape shape_a{2, 2};
+    Shape shape_b{};
+    auto A = make_shared<op::Parameter>(element::f32, shape_a);
+    auto B = make_shared<op::Parameter>(element::f32, shape_b);
+    auto f = make_shared<Function>(make_shared<op::v1::Add>(A, B), ParameterVector{A, B});
+
+    vector<float> a{2, 4, 7, 8};
+    vector<float> b{8};
+
+    auto test_case = test::TestCase<TestEngine>(f);
+    test_case.add_multiple_inputs<float>({a, b});
+    test_case.add_expected_output<float>(shape_a, {10, 12, 15, 16});
+    test_case.run();
+}

--- a/ngraph/test/type_prop/binary_elementwise.cpp
+++ b/ngraph/test/type_prop/binary_elementwise.cpp
@@ -274,6 +274,26 @@ TEST(type_prop, binary_arithmetic_bad_argument_element_types)
     }
 }
 
+TEST(type_prop, binary_arithmetic_bad_argument_shape_with_none_autobroadcast_attribute)
+{
+    auto input1 = make_shared<op::Parameter>(element::f32, Shape{2, 4});
+    auto input2 = make_shared<op::Parameter>(element::f32, Shape{1, 2, 4});
+    try
+    {
+        auto bc = make_shared<op::v1::Add>(input1, input2, op::AutoBroadcastType::NONE);
+        // Should have thrown, so fail if it didn't
+        FAIL() << "Did not detect incorrect element types for arithmetic operator";
+    }
+    catch (const NodeValidationFailure& error)
+    {
+        EXPECT_HAS_SUBSTRING(error.what(), std::string("Argument shapes are inconsistent"));
+    }
+    catch (...)
+    {
+        FAIL() << "Deduced type check failed for unexpected reason";
+    }
+}
+
 TEST(type_prop, binary_elementwise_arithmetic_both_dynamic)
 {
     auto a = make_shared<op::Parameter>(element::f32, PartialShape::dynamic());


### PR DESCRIPTION
### Details:
 - add type prop test for autobroadcast attribute set to None
 - add backend tests with scalar inputs
 - add serialization single layer tests for all elementwise ops (including Add)

### Tickets:
 - 37413
