### PR TITLE
[CPU] Splitting order was fixed in the Split layer.

### DIFF
--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.cpp
@@ -6,10 +6,8 @@
 #include "common/cpu_memcpy.h"
 #include <legacy/ie_layers.h>
 #include <vector>
-#include <queue>
 #include <mkldnn_types.h>
 #include <mkldnn_extension_utils.h>
-#include <climits>
 #include <ie_parallel.hpp>
 
 #define THROW_ERROR THROW_IE_EXCEPTION << "Split layer with name '" << getName() <<"' "
@@ -551,28 +549,14 @@ void MKLDNNSplitNode::optimizedNspc2Ncsp(size_t MB) {
 void MKLDNNSplitNode::initializeDstMemPtrs() {
     dstMemPtrs.clear();
 
-    //Here we have to place the output data pointers in the order that reflects the output edges order.
-    //It's important in case when several edges are connected to one port.
-    //This is a naive implementation, an indexed priority queue or modified treap would be a more elegant solution.
-    std::unordered_map<uint8_t*, size_t> mapDstPtrs;
-    for (size_t i = 0; i < getChildEdges().size(); ++i) {
-        auto outputEdge = this->getChildEdgeAt(i);
-        if (uint8_t* dstData = reinterpret_cast<uint8_t*>(outputEdge->getMemoryPtr()->GetPtr())) {
-            mapDstPtrs[dstData] = i;
+    for (size_t i = 0; i < outDims.size(); ++i) {
+        auto outputEdges = this->getChildEdgesAtPort(i);
+        if (uint8_t* dstData = reinterpret_cast<uint8_t*>(outputEdges.front()->getMemoryPtr()->GetPtr())) {
+            dstMemPtrs.push_back(dstData);
         } else {
             THROW_ERROR << "can't get child edge indx " << i << "data.";
         }
     }
-
-    std::vector<uint8_t*> vecCountingSort(getChildEdges().size(), nullptr);
-    for (auto& item : mapDstPtrs) {
-        vecCountingSort[item.second] = item.first;
-    }
-
-    dstMemPtrs.reserve(vecCountingSort.size());
-    auto backInserter = std::back_inserter(dstMemPtrs);
-    std::copy_if(vecCountingSort.begin(), vecCountingSort.end(), backInserter, [](const uint8_t* x) {return x;});
-    dstMemPtrs.shrink_to_fit();
 }
 
 REG_MKLDNN_PRIM_FOR(MKLDNNSplitNode, Split);


### PR DESCRIPTION
### Details:
The splitting order in the Split layer implementation now reflects the order of the output ports. This behavior is now aligned with the inPlace implementation.

### Tickets:
 - 47383
