### PR TITLE
ONNX ExperimentalDetectronGenerateProposalsSingleImage - unsafe inputs retrieval fix

### DIFF
--- a/ngraph/frontend/onnx_import/src/op/org.openvinotoolkit/experimental_detectron/generate_proposals_single_image.cpp
+++ b/ngraph/frontend/onnx_import/src/op/org.openvinotoolkit/experimental_detectron/generate_proposals_single_image.cpp
@@ -31,7 +31,12 @@ namespace ngraph
                     using GenerateProposalsSingleImage =
                         ngraph::op::v6::ExperimentalDetectronGenerateProposalsSingleImage;
 
-                    auto inputs = node.get_ng_inputs();
+                    const auto inputs = node.get_ng_inputs();
+                    NGRAPH_CHECK(inputs.size() == 4,
+                                 "ExperimentalDetectronGenerateProposalsSingleImage expects 4 "
+                                 "inputs, received: ",
+                                 inputs.size());
+
                     auto im_info = inputs[0];
                     auto anchors = inputs[1];
                     auto deltas = inputs[2];


### PR DESCRIPTION
### Details:
- Possible fix for the randomly failing onnx_model_experimental_detectron_generate_proposals_single_image causes tests (MSVC19/Debug)
- The changes will guard the code from segfaulting if an incorrect number of inputs from a previous node is passed-in

### Tickets:
 - 49234
