### PR TITLE
Fix m_auto_broadcast default value for SquaredDifference operation

### DIFF
--- a/ngraph/core/src/op/squared_difference.cpp
+++ b/ngraph/core/src/op/squared_difference.cpp
@@ -31,7 +31,7 @@ constexpr NodeTypeInfo op::SquaredDifference::type_info;
 
 op::SquaredDifference::SquaredDifference()
     : FusedOp()
-    , m_autobroadcast()
+    , m_autobroadcast(AutoBroadcastType::NUMPY)
 {
 }
 

--- a/ngraph/test/type_prop/squared_difference.cpp
+++ b/ngraph/test/type_prop/squared_difference.cpp
@@ -37,7 +37,11 @@ TEST(type_prop, squared_difference)
         EXPECT_HAS_SUBSTRING(error.what(), std::string("Argument shapes are inconsistent"));
     }
 
-    const auto clamp = make_shared<op::SquaredDifference>(x1, x3);
-    EXPECT_EQ(clamp->get_element_type(), element::f64);
-    EXPECT_EQ(clamp->get_shape(), (Shape{2, 2}));
+    const auto squared_diff = make_shared<op::SquaredDifference>(x1, x3);
+    EXPECT_EQ(squared_diff->get_element_type(), element::f64);
+    EXPECT_EQ(squared_diff->get_shape(), (Shape{2, 2}));
+    EXPECT_EQ(squared_diff->get_autob(), op::AutoBroadcastType::NUMPY);
+
+    const auto squared_diff_no_args = make_shared<op::SquaredDifference>();
+    EXPECT_EQ(squared_diff_no_args->get_autob(), op::AutoBroadcastType::NUMPY);
 }


### PR DESCRIPTION
### Description
Fix auto-broadcast default value for SquearedDifference operation to NUMPY which is correct according to the spec: https://github.com/openvinotoolkit/openvino/blob/master/docs/ops/arithmetic/SquaredDifference_1.md
Undefined value (AutoBroadcastType::NONE) for auto-broadcast in default SquaredDifference c-tor leads to issues when we create operation using visitor API.

### Tickets
49673
