### PR TITLE
Improve axes input specification for MVN-6

### DIFF
--- a/docs/ops/normalization/MVN_6.md
+++ b/docs/ops/normalization/MVN_6.md
@@ -58,7 +58,7 @@ o_{i}=\frac{o_{i}}{\sqrt {\sum {o_{k}^2}}+\epsilon}
 
 * **1**: `data` - Input tensor to be normalized. Type *T*. Required.
 
-* **2**: `axes` - 1D tensor which specifies indices of dimensions in `data` that define normalization slices. Allowed range of axes is `[-r; r-1]`, the order can be not sorted. Type *T_IND*. Required.
+* **2**: `axes` - 1D tensor which specifies indices of dimensions in `data` that define normalization slices. Allowed range of axes is `[-r; r-1]` where `r = rank(data)`, the order can be not sorted. Negative value means counting dimensions from the back. Type *T_IND*. Required.
 
 **Outputs**
 

--- a/docs/ops/normalization/MVN_6.md
+++ b/docs/ops/normalization/MVN_6.md
@@ -58,7 +58,7 @@ o_{i}=\frac{o_{i}}{\sqrt {\sum {o_{k}^2}}+\epsilon}
 
 * **1**: `data` - Input tensor to be normalized. Type *T*. Required.
 
-* **2**: `axes` - 1D tensor which specifies indices of dimensions in `data` that define normalization slices. Type *T_IND*. Required.
+* **2**: `axes` - 1D tensor which specifies indices of dimensions in `data` that define normalization slices. Allowed range of axes is `[-r; r-1]`, the order can be not sorted. Type *T_IND*. Required.
 
 **Outputs**
 


### PR DESCRIPTION
### Details:
 - *Specify negative axes for MVN-6. Before it was unspecified if negative axes are supported.*
 - *Specify that axes can be in random order.*

### Tickets:
 - *48599*
