### PR TITLE
[IE TESTS] Improved validation in TopK func tests for cases where sort=none

### DIFF
--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/topk.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/topk.hpp
@@ -28,6 +28,7 @@ class TopKLayerTest : public testing::WithParamInterface<TopKParams>,
                       virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<TopKParams> obj);
+    void Validate() override;
 
 protected:
     void SetUp() override;

--- a/inference-engine/tests/functional/shared_test_classes/src/single_layer/topk.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/single_layer/topk.cpp
@@ -29,6 +29,166 @@ namespace LayerTestsDefinitions {
     return result.str();
 }
 
+template <typename T, typename U>
+void sortOutputs(T* expectedValues, U* expectedIndices, T* actualValues, U* actualIndices, size_t size,
+                 InferenceEngine::SizeVector& inputShape, int64_t k, int64_t axis) {
+    size_t numSorts =
+        std::accumulate(inputShape.begin(), inputShape.end(), size_t{1}, std::multiplies<size_t>()) / inputShape[axis];
+    size_t kStride =
+        std::accumulate(inputShape.begin() + axis + 1, inputShape.end(), size_t{1}, std::multiplies<size_t>());
+
+    std::vector<std::pair<T, U>> expected(k);
+    std::vector<std::pair<T, U>> actual(k);
+    for (size_t i = 0; i < numSorts; ++i) {
+        size_t chunkId = i / kStride;
+        size_t chunkOffset = chunkId * k * kStride;
+        size_t startOffset = chunkOffset + i % kStride;
+        for (int j = 0; j < k; ++j) {
+            expected[j] =
+                std::make_pair(expectedValues[startOffset + j * kStride], expectedIndices[startOffset + j * kStride]);
+            actual[j] =
+                std::make_pair(actualValues[startOffset + j * kStride], actualIndices[startOffset + j * kStride]);
+        }
+
+        auto compPairs = [](std::pair<T, U> const& lhs, std::pair<T, U> const& rhs) {
+            if (lhs.first == rhs.first) {
+                return lhs.second < rhs.second;
+            }
+            return lhs.first < rhs.first;
+        };
+        std::sort(expected.begin(), expected.end(), compPairs);
+        std::sort(actual.begin(), actual.end(), compPairs);
+
+        for (int j = 0; j < k; ++j) {
+            expectedValues[startOffset + j * kStride] = expected[j].first;
+            expectedIndices[startOffset + j * kStride] = expected[j].second;
+            actualValues[startOffset + j * kStride] = actual[j].first;
+            actualIndices[startOffset + j * kStride] = actual[j].second;
+        }
+    }
+}
+
+template <typename T>
+void sortOutputs(T* expectedValues, uint8_t* expectedIndices, T* actualValues, uint8_t* actualIndices, size_t size,
+                 InferenceEngine::SizeVector& inputShape, int64_t k, int64_t axis,
+                 const InferenceEngine::Precision& indicesPrecision) {
+    switch (indicesPrecision) {
+    case InferenceEngine::Precision::I32:
+        return sortOutputs(expectedValues, reinterpret_cast<int32_t*>(expectedIndices), actualValues,
+                           reinterpret_cast<int32_t*>(actualIndices), size, inputShape, k, axis);
+    case InferenceEngine::Precision::I64:
+        return sortOutputs(expectedValues, reinterpret_cast<int64_t*>(expectedIndices), actualValues,
+                           reinterpret_cast<int64_t*>(actualIndices), size, inputShape, k, axis);
+    default:
+        FAIL() << indicesPrecision << " precision isn't supported for topK index tensor.";
+    }
+}
+
+void TopKLayerTest::Validate() {
+    auto expectedOutputs = LayerTestsCommon::CalculateRefs();
+    const auto& actualOutputs = LayerTestsCommon::GetOutputs();
+
+    if (expectedOutputs.empty()) {
+        return;
+    }
+
+    IE_ASSERT(actualOutputs.size() == expectedOutputs.size())
+        << "nGraph interpreter has " << expectedOutputs.size() << " outputs, while IE " << actualOutputs.size();
+
+    auto params = this->GetParam();
+    auto k = std::get<0>(params);
+    auto sort = std::get<3>(params);
+
+    // If SortType is NONE, the order of top k elements is undefined and may be implementation-dependent.
+    // This section sorts expected and actual values in a way that retains correctness of the results and ensures
+    // that the test won't fail because of different ordering of elements in the actual and reference implementation.
+    if (sort == ngraph::opset4::TopK::SortType::NONE && k > 1) {
+        ASSERT_EQ(expectedOutputs.size(), 2);
+        auto& expectedValues = expectedOutputs[0];
+        auto& expectedIndices = expectedOutputs[1];
+        auto& actualValues = actualOutputs[0];
+        auto& actualIndices = actualOutputs[1];
+
+        ASSERT_EQ(expectedValues.size(), actualValues->byteSize());
+        ASSERT_EQ(expectedIndices.size(), actualIndices->byteSize());
+        auto expectedValuesBuffer = expectedValues.data();
+        auto expectedIndicesBuffer = expectedIndices.data();
+
+        auto actualValuesMemory = InferenceEngine::as<InferenceEngine::MemoryBlob>(actualValues);
+        auto actualIndicesMemory = InferenceEngine::as<InferenceEngine::MemoryBlob>(actualIndices);
+        IE_ASSERT(actualValuesMemory);
+        IE_ASSERT(actualIndicesMemory);
+        auto lockedValuesMemory = actualValuesMemory->wmap();
+        auto lockedIndicesMemory = actualIndicesMemory->wmap();
+        auto actualValuesBuffer = lockedValuesMemory.as<std::uint8_t*>();
+        auto actualIndicesBuffer = lockedIndicesMemory.as<std::uint8_t*>();
+
+        const auto& valuesPrecision = actualValues->getTensorDesc().getPrecision();
+        const auto& indicesPrecision = actualIndices->getTensorDesc().getPrecision();
+        const auto& size = actualValues->size();
+        auto axis = std::get<1>(params);
+        auto inputShape = std::get<8>(params);
+
+        switch (valuesPrecision) {
+        case InferenceEngine::Precision::FP32:
+            sortOutputs(reinterpret_cast<float*>(expectedValuesBuffer), expectedIndicesBuffer,
+                        reinterpret_cast<float*>(actualValuesBuffer), actualIndicesBuffer, size, inputShape, k, axis,
+                        indicesPrecision);
+            break;
+        case InferenceEngine::Precision::I32:
+            sortOutputs(reinterpret_cast<int32_t*>(expectedValuesBuffer), expectedIndicesBuffer,
+                        reinterpret_cast<int32_t*>(actualValuesBuffer), actualIndicesBuffer, size, inputShape, k, axis,
+                        indicesPrecision);
+            break;
+        case InferenceEngine::Precision::I64:
+            sortOutputs(reinterpret_cast<int64_t*>(expectedValuesBuffer), expectedIndicesBuffer,
+                        reinterpret_cast<int64_t*>(actualValuesBuffer), actualIndicesBuffer, size, inputShape, k, axis,
+                        indicesPrecision);
+            break;
+        case InferenceEngine::Precision::I8:
+            sortOutputs(reinterpret_cast<int8_t*>(expectedValuesBuffer), expectedIndicesBuffer,
+                        reinterpret_cast<int8_t*>(actualValuesBuffer), actualIndicesBuffer, size, inputShape, k, axis,
+                        indicesPrecision);
+            break;
+        case InferenceEngine::Precision::U16:
+            sortOutputs(reinterpret_cast<uint16_t*>(expectedValuesBuffer), expectedIndicesBuffer,
+                        reinterpret_cast<uint16_t*>(actualValuesBuffer), actualIndicesBuffer, size, inputShape, k, axis,
+                        indicesPrecision);
+            break;
+        case InferenceEngine::Precision::I16:
+            sortOutputs(reinterpret_cast<int16_t*>(expectedValuesBuffer), expectedIndicesBuffer,
+                        reinterpret_cast<int16_t*>(actualValuesBuffer), actualIndicesBuffer, size, inputShape, k, axis,
+                        indicesPrecision);
+            break;
+        case InferenceEngine::Precision::BOOL:
+        case InferenceEngine::Precision::U8:
+            sortOutputs(reinterpret_cast<uint8_t*>(expectedValuesBuffer), expectedIndicesBuffer,
+                        reinterpret_cast<uint8_t*>(actualValuesBuffer), actualIndicesBuffer, size, inputShape, k, axis,
+                        indicesPrecision);
+            break;
+        case InferenceEngine::Precision::U64:
+            sortOutputs(reinterpret_cast<uint64_t*>(expectedValuesBuffer), expectedIndicesBuffer,
+                        reinterpret_cast<uint64_t*>(actualValuesBuffer), actualIndicesBuffer, size, inputShape, k, axis,
+                        indicesPrecision);
+            break;
+        case InferenceEngine::Precision::BF16:
+            sortOutputs(reinterpret_cast<ngraph::bfloat16*>(expectedValuesBuffer), expectedIndicesBuffer,
+                        reinterpret_cast<ngraph::bfloat16*>(actualValuesBuffer), actualIndicesBuffer, size, inputShape,
+                        k, axis, indicesPrecision);
+            break;
+        case InferenceEngine::Precision::FP16:
+            sortOutputs(reinterpret_cast<ngraph::float16*>(expectedValuesBuffer), expectedIndicesBuffer,
+                        reinterpret_cast<ngraph::float16*>(actualValuesBuffer), actualIndicesBuffer, size, inputShape,
+                        k, axis, indicesPrecision);
+            break;
+        default:
+            FAIL() << indicesPrecision << " precision isn't supported for topK values tensor.";
+        }
+    }
+
+    LayerTestsCommon::Compare(expectedOutputs, actualOutputs);
+}
+
 void TopKLayerTest::SetUp() {
     InferenceEngine::SizeVector inputShape;
     InferenceEngine::Precision netPrecision;


### PR DESCRIPTION
https://docs.openvinotoolkit.org/latest/openvino_docs_ops_sort_TopK_3.html

If SortType is NONE, the order of top k elements is undefined and may be implementation-dependent.
In this MR I added sorting of expected and actual values in a way that retains correctness of the results and ensures
that the test won't fail because of different ordering of elements in the actual and reference implementations.