### PR TITLE
fix unintended shape change

### DIFF
--- a/model-optimizer/extensions/ops/loop.py
+++ b/model-optimizer/extensions/ops/loop.py
@@ -119,7 +119,7 @@ class Loop(TensorIterator):
             loop_port_idx = record['external_port_id']
             if loop_port_idx != -1:  # the id = -1 for execution condition output which is not connected anywhere
                 output_value = body_node.in_port(0).data.get_value()
-                output_shape = body_node.in_port(0).data.get_shape()
+                output_shape = body_node.in_port(0).data.get_shape().copy()
                 concat_axis = record['axis']
                 if concat_axis is not None:
                     assert output_shape[concat_axis] == 1, 'Dimension for concatenation is not equal to 1 for scan ' \


### PR DESCRIPTION
### Details:
IRreader can't read IR with constant with inconsistent value and shape. The reason was in wrong shape change. Shape taken from get_shape() was changed, so shape in node was changed too.

### Tickets:
 - 49603
 
Code:
* [ ]  Comments **Not applicable**
* [x]  Code style (PEP8)
* [ ]  Transformation generates reshape-able IR **Not applicable**
* [ ]  Transformation preserves original framework node names **Not applicable**


Validation:
* [x]  Unit tests
* [ ]  Framework operation tests **Not applicable**
* [ ]  Transformation tests **Not applicable**
* [x]  Model Optimizer IR Reader check 

Documentation:
* [ ]  Supported frameworks operations list **Not applicable**
* [ ]  Guide on how to convert the **public** model **Not applicable**
* [ ]  User guide update **Not applicable**