### PR TITLE
Added gstreamer1.0-x pkg for dlstreamer

### DIFF
--- a/scripts/install_dependencies/install_openvino_dependencies.sh
+++ b/scripts/install_dependencies/install_openvino_dependencies.sh
@@ -181,7 +181,6 @@ elif [ "$os" == "ubuntu20.04" ] ; then
         gstreamer1.0-vaapi
         gstreamer1.0-tools
         gstreamer1.0-x
-        intel-media-va-driver-non-free
         libfaac0
         libfluidsynth2
         libgl-dev

--- a/scripts/install_dependencies/install_openvino_dependencies.sh
+++ b/scripts/install_dependencies/install_openvino_dependencies.sh
@@ -180,6 +180,7 @@ elif [ "$os" == "ubuntu20.04" ] ; then
         gstreamer1.0-plugins-ugly
         gstreamer1.0-vaapi
         gstreamer1.0-tools
+        gstreamer1.0-x
         libfaac0
         libfluidsynth2
         libgl-dev

--- a/scripts/install_dependencies/install_openvino_dependencies.sh
+++ b/scripts/install_dependencies/install_openvino_dependencies.sh
@@ -181,6 +181,7 @@ elif [ "$os" == "ubuntu20.04" ] ; then
         gstreamer1.0-vaapi
         gstreamer1.0-tools
         gstreamer1.0-x
+        intel-media-va-driver-non-free
         libfaac0
         libfluidsynth2
         libgl-dev


### PR DESCRIPTION
### Details:
 - Added `gstreamer1.0-x` as a dependency for DL Streamer for Ubuntu 20.
 - `gstreamer1.0-x` provides plugins for X11 video output which DL Streamer uses in its samples.

