### PR TITLE
Added specific for Python3.8 way how to find libs

### DIFF
--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/__init__.py
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/__init__.py
@@ -25,7 +25,11 @@ if sys.platform == "win32":
     # If you're using a custom installation of openvino,
     # add the location of openvino dlls to your system PATH.
     openvino_dlls = os.path.join(os.path.dirname(__file__), "..", "..", "openvino", "libs")
-    os.environ["PATH"] = os.path.abspath(openvino_dlls) + ";" + os.environ["PATH"]
+    if (3, 8) <= sys.version_info:
+        # On Windows, with Python >= 3.8, DLLs are no longer imported from the PATH.
+        os.add_dll_directory(os.path.abspath(openvino_dlls))
+    else:
+        os.environ["PATH"] = os.path.abspath(openvino_dlls) + ";" + os.environ["PATH"]
 
 from .ie_api import *
 __all__ = ['IENetwork', "TensorDesc", "IECore", "Blob", "PreProcessInfo", "get_version"]

--- a/inference-engine/ie_bridges/python/src/openvino/offline_transformations/__init__.py
+++ b/inference-engine/ie_bridges/python/src/openvino/offline_transformations/__init__.py
@@ -10,7 +10,11 @@ if sys.platform == "win32":
     # If you're using a custom installation of openvino,
     # add the location of openvino dlls to your system PATH.
     openvino_dlls = os.path.join(os.path.dirname(__file__), "..", "..", "openvino", "libs")
-    os.environ["PATH"] = os.path.abspath(openvino_dlls) + ";" + os.environ["PATH"]
+    if (3, 8) <= sys.version_info:
+        # On Windows, with Python >= 3.8, DLLs are no longer imported from the PATH.
+        os.add_dll_directory(os.path.abspath(openvino_dlls))
+    else:
+        os.environ["PATH"] = os.path.abspath(openvino_dlls) + ";" + os.environ["PATH"]
 
 from .offline_transformations_api import *
 __all__ = ['ApplyMOCTransformations']

--- a/ngraph/python/src/ngraph/impl/__init__.py
+++ b/ngraph/python/src/ngraph/impl/__init__.py
@@ -35,7 +35,12 @@ if sys.platform == "win32":
     openvino_dlls = os.path.join(os.path.dirname(__file__), "..", "..", "openvino", "libs")
     # If you're using a custom installation of openvino,
     # add the location of openvino dlls to your system PATH.
-    os.environ["PATH"] = os.path.abspath(openvino_dlls) + ";" + os.path.abspath(ngraph_dll) + ";" + os.environ["PATH"]
+    if (3, 8) <= sys.version_info:
+        # On Windows, with Python >= 3.8, DLLs are no longer imported from the PATH.
+        os.add_dll_directory(os.path.abspath(ngraph_dll))
+        os.add_dll_directory(os.path.abspath(openvino_dlls))
+    else:
+        os.environ["PATH"] = os.path.abspath(openvino_dlls) + ";" + os.path.abspath(ngraph_dll) + ";" + os.environ["PATH"]
 
 from _pyngraph import Dimension
 from _pyngraph import Function


### PR DESCRIPTION
On Windows, with Python >= 3.8, DLLs are no longer imported from the PATH.
os.add_dll_directory() can be used

### Tickets:
 - 49635
 - 48177
