### PR TITLE
Removed getOVNameForOperation

### DIFF
--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pyx
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pyx
@@ -1447,10 +1447,6 @@ cdef class IENetwork:
         name = bytes(orig_name, 'utf-8')
         return self.impl.getOVNameForTensor(name).decode('utf-8')
 
-    def get_ov_name_for_operation(self, orig_name: str):
-        name = bytes(orig_name, 'utf-8')
-        return self.impl.getOVNameForOperation(name).decode('utf-8')
-
 cdef class BlobBuffer:
     """Copy-less accessor for Inference Engine Blob"""
 

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.cpp
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.cpp
@@ -264,10 +264,6 @@ std::string InferenceEnginePython::IENetwork::getOVNameForTensor(const std::stri
     return actual->getOVNameForTensor(orig_name);
 }
 
-std::string InferenceEnginePython::IENetwork::getOVNameForOperation(const std::string& orig_name) {
-    return actual->getOVNameForOperation(orig_name);
-}
-
 void
 InferenceEnginePython::IENetwork::addOutput(const std::string &out_layer, size_t port_id) {
     actual->addOutput(out_layer, port_id);

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.hpp
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.hpp
@@ -73,7 +73,6 @@ struct IENetwork {
     void convertToOldRepresentation();
 
     std::string getOVNameForTensor(const std::string& orig_name);
-    std::string getOVNameForOperation(const std::string& orig_name);
 };
 
 

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl_defs.pxd
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl_defs.pxd
@@ -176,7 +176,6 @@ cdef extern from "ie_api_impl.hpp" namespace "InferenceEnginePython":
         object getFunction() except +
         void convertToOldRepresentation() except +
         string getOVNameForTensor(const string &) except +
-        string getOVNameForOperation(const string &) except +
 
     cdef cppclass InferRequestWrap:
         double exec_time;

--- a/inference-engine/ie_bridges/python/tests/test_IENetwork.py
+++ b/inference-engine/ie_bridges/python/tests/test_IENetwork.py
@@ -304,4 +304,3 @@ def test_tensor_names():
     assert net.get_ov_name_for_tensor("relu_t") == "activation"
     assert net.get_ov_name_for_tensor("identity_t") == "activation"
     assert net.get_ov_name_for_tensor("input") == "in1"
-    assert net.get_ov_name_for_operation("output") == "activation"

--- a/inference-engine/include/cpp/ie_cnn_network.h
+++ b/inference-engine/include/cpp/ie_cnn_network.h
@@ -202,19 +202,6 @@ public:
         return ov_name;
     }
 
-    /**
-     * @brief Method maps framework operator name to OpenVINO name
-     *
-     * @param orig_name Framework operation name
-     *
-     * @return OpenVINO name
-     */
-    std::string getOVNameForOperation(const std::string& orig_name) const {
-        std::string ov_name;
-        CALL_STATUS_FNC(getOVNameForOperation, ov_name, orig_name);
-        return ov_name;
-    }
-
 protected:
     IE_SUPPRESS_DEPRECATED_START
     /**

--- a/inference-engine/include/ie_icnn_network.hpp
+++ b/inference-engine/include/ie_icnn_network.hpp
@@ -72,8 +72,8 @@ public:
      * This method need to be called to find out OpenVINO output names for using them later
      * when calling InferenceEngine::InferRequest::GetBlob or InferenceEngine::InferRequest::SetBlob
      *
-     * If you want to use framework names, you can use InferenceEngine::ICNNNetwork::getOVNameForTensor or
-     * InferenceEngine::ICNNNetwork::getOVNameForOperation methods to map framework names to OpenVINO names
+     * If you want to use framework names, you can use InferenceEngine::ICNNNetwork::getOVNameForTensor
+     * method to map framework names to OpenVINO names
      *
      * @param out Reference to the OutputsDataMap object
      */
@@ -87,8 +87,8 @@ public:
      * This method need to be called to find out OpenVINO input names for using them later
      * when calling InferenceEngine::InferRequest::SetBlob
      *
-     * If you want to use framework names, you can use InferenceEngine::ICNNNetwork::getOVNameForTensor or
-     * InferenceEngine::ICNNNetwork::getOVNameForOperation methods to map framework names to OpenVINO names
+     * If you want to use framework names, you can use InferenceEngine::ICNNNetwork::getOVNameForTensor
+     * method to map framework names to OpenVINO names
      *
      * @param inputs Reference to InputsDataMap object.
      */
@@ -194,22 +194,6 @@ public:
      * @return Status code of the operation
      */
     virtual StatusCode getOVNameForTensor(std::string& ov_name, const std::string& orig_name, ResponseDesc* resp) const noexcept {
-        (void) ov_name;
-        (void) orig_name;
-        (void) resp;
-        return NOT_IMPLEMENTED;
-    }
-
-    /**
-     * @brief Methods maps framework operation name to OpenVINO name
-     *
-     * @param ov_name OpenVINO name
-     * @param orig_name Framework operation name
-     * @param resp Pointer to the response message that holds a description of an error if any occurred
-     *
-     * @return Status code of the operation
-     */
-    virtual StatusCode getOVNameForOperation(std::string& ov_name, const std::string& orig_name, ResponseDesc* resp) const noexcept {
         (void) ov_name;
         (void) orig_name;
         (void) resp;

--- a/inference-engine/src/inference_engine/cnn_network_ngraph_impl.cpp
+++ b/inference-engine/src/inference_engine/cnn_network_ngraph_impl.cpp
@@ -119,7 +119,6 @@ CNNNetworkNGraphImpl::CNNNetworkNGraphImpl(
         IE_ASSERT(layer->get_output_size() == 1);  // Parameter as only singly output port
 
         // map original names to OpenVINO name
-        _opNames[outName] = outName;
         for (const auto& name : layer->get_output_tensor(0).get_names()) {
             _tensorNames[name] = outName;
         }
@@ -152,7 +151,6 @@ CNNNetworkNGraphImpl::CNNNetworkNGraphImpl(const CNNNetwork& network) {
     InputsDataMap inputs = network.getInputsInfo();
     OutputsDataMap outputs = network.getOutputsInfo();
 
-    _opNames = net->_opNames;
     _tensorNames = net->_tensorNames;
 
     for (const auto& outputInfo : outputs) {
@@ -253,12 +251,6 @@ void CNNNetworkNGraphImpl::addOutput(const ::ngraph::Output<::ngraph::Node> & ou
     // Save original framework names
     for (const auto& name : output.get_tensor().get_names()) {
         _tensorNames[name] = dataName;
-    }
-    for (const auto consumerInput : output.get_target_inputs()) {
-        const auto &consumerLayer = consumerInput.get_node()->shared_from_this();
-        if (std::dynamic_pointer_cast<ngraph::op::Result>(consumerLayer)) {
-            _opNames[consumerLayer->get_friendly_name()] = dataName;
-        }
     }
 }
 
@@ -449,13 +441,6 @@ StatusCode CNNNetworkNGraphImpl::getOVNameForTensor(std::string& ov_name, const 
     if (_tensorNames.find(orig_name) == _tensorNames.end())
         return DescriptionBuffer(NOT_FOUND, resp) << "Framework tensor with name \"" << orig_name << "\" was not mapped to OpenVINO data!";
     ov_name = _tensorNames.at(orig_name);
-    return OK;
-}
-
-StatusCode CNNNetworkNGraphImpl::getOVNameForOperation(std::string& ov_name, const std::string& orig_name, ResponseDesc* resp) const noexcept {
-    if (_opNames.find(orig_name) == _opNames.end())
-        return DescriptionBuffer(NOT_FOUND, resp) << "Framework operation with name \"" << orig_name << "\" was not mapped to OpenVINO data!";
-    ov_name = _opNames.at(orig_name);
     return OK;
 }
 

--- a/inference-engine/src/inference_engine/cnn_network_ngraph_impl.hpp
+++ b/inference-engine/src/inference_engine/cnn_network_ngraph_impl.hpp
@@ -84,8 +84,6 @@ public:
 
     StatusCode getOVNameForTensor(std::string& ov_name, const std::string& orig_name, ResponseDesc* resp) const noexcept override;
 
-    StatusCode getOVNameForOperation(std::string& ov_name, const std::string& orig_name, ResponseDesc* resp) const noexcept override;
-
     // used by convertFunctionToICNNNetwork from legacy library
     std::map<std::string, DataPtr> _data;
 protected:
@@ -96,7 +94,6 @@ private:
     InferenceEngine::InputsDataMap _inputData;
     std::map<std::string, DataPtr> _outputData;
     const std::vector<IExtensionPtr> _ie_extensions;
-    std::unordered_map<std::string, std::string> _opNames;
     std::unordered_map<std::string, std::string> _tensorNames;
 
     /**

--- a/inference-engine/tests/functional/inference_engine/ngraph_reader/tensor_names.cpp
+++ b/inference-engine/tests/functional/inference_engine/ngraph_reader/tensor_names.cpp
@@ -74,14 +74,12 @@ TEST_F(NGraphReaderTests, ReadNetworkWithTensorNames) {
     ASSERT_EQ(1, function->get_results().size());
 
     for (const auto& param : function->get_parameters()) {
-        ASSERT_TRUE(inNames.count(network.getOVNameForOperation(param->get_friendly_name())));
         ASSERT_TRUE(!param->get_output_tensor(0).get_names().empty());
         for (const auto& name : param->get_output_tensor(0).get_names())
             ASSERT_TRUE(inNames.count(network.getOVNameForTensor(name)));
     }
 
     for (const auto& result : function->get_results()) {
-        ASSERT_TRUE(outNames.count(network.getOVNameForOperation(result->get_friendly_name())));
         ASSERT_TRUE(!result->get_input_tensor(0).get_names().empty());
         for (const auto& name : result->get_input_tensor(0).get_names())
             ASSERT_TRUE(outNames.count(network.getOVNameForTensor(name)));

--- a/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/tensor_names.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/tensor_names.hpp
@@ -23,13 +23,11 @@ TEST_P(TensorNamesTest, CheckTensorNames) {
         outNames.emplace(out.first);
 
     for (const auto& param : function->get_parameters()) {
-        ASSERT_TRUE(inNames.count(cnnNetwork.getOVNameForOperation(param->get_friendly_name())));
         for (const auto& name : param->get_output_tensor(0).get_names())
             ASSERT_TRUE(inNames.count(cnnNetwork.getOVNameForTensor(name)));
     }
 
     for (const auto& result : function->get_results()) {
-        ASSERT_TRUE(outNames.count(cnnNetwork.getOVNameForOperation(result->get_friendly_name())));
         for (const auto& name : result->input_value(0).get_tensor().get_names())
             ASSERT_TRUE(outNames.count(cnnNetwork.getOVNameForTensor(name)));
     }
@@ -38,13 +36,11 @@ TEST_P(TensorNamesTest, CheckTensorNames) {
     inferRequest = executableNetwork.CreateInferRequest();
 
     for (const auto& param : function->get_parameters()) {
-        ASSERT_NO_THROW(inferRequest.GetBlob(cnnNetwork.getOVNameForOperation(param->get_friendly_name())));
         for (const auto& name : param->get_output_tensor(0).get_names())
             ASSERT_NO_THROW(inferRequest.GetBlob(cnnNetwork.getOVNameForTensor(name)));
     }
 
     for (const auto& result : function->get_results()) {
-        ASSERT_NO_THROW(inferRequest.GetBlob(cnnNetwork.getOVNameForOperation(result->get_friendly_name())));
         for (const auto& name : result->get_input_tensor(0).get_names()) {
             ASSERT_NO_THROW(inferRequest.GetBlob(cnnNetwork.getOVNameForTensor(name)));
         }
@@ -66,14 +62,11 @@ TEST_P(TensorNamesTest, CheckTensorNamesAfterClone) {
         outNames.emplace(out.first);
 
     for (const auto& param : function->get_parameters()) {
-        ASSERT_TRUE(inNames.count(clonedNet.getOVNameForOperation(param->get_friendly_name())));
         for (const auto& name : param->get_output_tensor(0).get_names())
             ASSERT_TRUE(inNames.count(clonedNet.getOVNameForTensor(name)));
     }
 
     for (const auto& result : function->get_results()) {
-        ASSERT_TRUE(outNames.count(clonedNet.getOVNameForOperation(result->get_friendly_name())));
-
         for (const auto& name : result->get_input_tensor(0).get_names()) {
             ASSERT_TRUE(outNames.count(clonedNet.getOVNameForTensor(name)));
         }
@@ -83,13 +76,11 @@ TEST_P(TensorNamesTest, CheckTensorNamesAfterClone) {
     inferRequest = executableNetwork.CreateInferRequest();
 
     for (const auto& param : function->get_parameters()) {
-        ASSERT_NO_THROW(inferRequest.GetBlob(clonedNet.getOVNameForOperation(param->get_friendly_name())));
         for (const auto& name : param->get_output_tensor(0).get_names())
             ASSERT_NO_THROW(inferRequest.GetBlob(clonedNet.getOVNameForTensor(name)));
     }
 
     for (const auto& result : function->get_results()) {
-        ASSERT_NO_THROW(inferRequest.GetBlob(clonedNet.getOVNameForOperation(result->get_friendly_name())));
         for (const auto& name : result->input_value(0).get_tensor().get_names())
             ASSERT_NO_THROW(inferRequest.GetBlob(clonedNet.getOVNameForTensor(name)));
     }
@@ -114,9 +105,8 @@ TEST_P(TensorNamesTest, CheckAddOutput) {
     ASSERT_EQ(1, function->get_results().size());
 
     // Check that relu_prev doesn't exist in output and input maps
-    ASSERT_THROW(cnnNetwork.getOVNameForOperation("relu_prev"), InferenceEngine::NotFound);
     for (const std::string& tensor_name : {"relu,prev_t", "identity_prev_t"}) {
-        ASSERT_THROW(cnnNetwork.getOVNameForOperation(tensor_name), InferenceEngine::NotFound);
+        ASSERT_THROW(cnnNetwork.getOVNameForTensor(tensor_name), InferenceEngine::NotFound);
     }
 
     // Add relu_prev as output
@@ -136,11 +126,9 @@ TEST_P(TensorNamesTest, CheckAddOutput) {
     ASSERT_EQ(2, function->get_results().size());
 
     // Check that relu_prev exists in output map
-    ASSERT_FALSE(inNames.count(cnnNetwork.getOVNameForOperation("relu_prev")));
     for (const std::string& tensor_name : {"relu,prev_t", "identity_prev_t"}) {
         ASSERT_FALSE(inNames.count(cnnNetwork.getOVNameForTensor(tensor_name)));
     }
-    ASSERT_TRUE(outNames.count(cnnNetwork.getOVNameForOperation("relu_prev")));
     for (const std::string& tensor_name : {"relu,prev_t", "identity_prev_t"}) {
         ASSERT_TRUE(outNames.count(cnnNetwork.getOVNameForTensor(tensor_name)));
     }
@@ -149,13 +137,11 @@ TEST_P(TensorNamesTest, CheckAddOutput) {
     inferRequest = executableNetwork.CreateInferRequest();
 
     for (const auto& param : cnnNetwork.getFunction()->get_parameters()) {
-        ASSERT_NO_THROW(inferRequest.GetBlob(cnnNetwork.getOVNameForOperation(param->get_friendly_name())));
         for (const auto& name : param->get_output_tensor(0).get_names())
             ASSERT_NO_THROW(inferRequest.GetBlob(cnnNetwork.getOVNameForTensor(name)));
     }
 
     for (const auto& result : cnnNetwork.getFunction()->get_results()) {
-        ASSERT_NO_THROW(inferRequest.GetBlob(cnnNetwork.getOVNameForOperation(result->get_friendly_name())));
         for (const auto& name : result->get_input_tensor(0).get_names()) {
             ASSERT_NO_THROW(inferRequest.GetBlob(cnnNetwork.getOVNameForTensor(name)));
         }


### PR DESCRIPTION
### Details:
 - After the discussions about IR forward compatibility issues we decided to revert several fixes for the MO and remove getOVNameForOperation() method because it can work incorrectly

### Tickets:
 - NA
