### PR TITLE
[CPU] Split supported PD initialization refactoring plus tests for multiply port connections.

### DIFF
--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.cpp
@@ -4,6 +4,7 @@
 
 #include "mkldnn_split_node.h"
 #include "common/cpu_memcpy.h"
+#include "common/tensor_desc_creator.h"
 #include <legacy/ie_layers.h>
 #include <vector>
 #include <mkldnn_types.h>

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.cpp
@@ -16,47 +16,6 @@ using namespace mkldnn;
 using namespace MKLDNNPlugin;
 using namespace InferenceEngine;
 
-static TensorDesc makePlainTensorDesc(const Precision& precision, const SizeVector& srcDims) {
-    SizeVector order(srcDims.size());
-    std::iota(order.begin(), order.end(), 0);
-    return TensorDesc(precision, srcDims, {srcDims, order});
-}
-
-static TensorDesc makePerChannelTensorDesc(const Precision& precision, const SizeVector& srcDims) {
-    constexpr size_t channelsPos = 1lu;
-    SizeVector order(srcDims.size());
-    std::iota(order.begin(), order.end(), 0);
-    SizeVector blkDims = srcDims;
-    if (srcDims.size() > 2) {
-        auto moveElementBack = [](SizeVector& vector, size_t indx) {
-            auto itr = vector.begin() + indx;
-            std::rotate(itr, itr + 1, vector.end());
-        };
-
-        moveElementBack(order, channelsPos);
-        moveElementBack(blkDims, channelsPos);
-    }
-
-    return TensorDesc(precision, srcDims, {blkDims, order});
-}
-
-static TensorDesc makeChannelBlockedTensorDesc(const Precision& precision, const SizeVector& srcDims, size_t blockSize) {
-    if (srcDims.size() < 2) {
-        IE_THROW() << "Can't create blocked tensor descriptor!";
-    }
-
-    constexpr size_t channelsPos = 1lu;
-    SizeVector order(srcDims.size());
-    std::iota(order.begin(), order.end(), 0);
-    order.push_back(channelsPos);
-
-    SizeVector blkDims = srcDims;
-    blkDims[1] = blkDims[1] / blockSize + (blkDims[1] % blockSize ? 1 : 0);
-    blkDims.push_back(blockSize);
-
-    return TensorDesc(precision, srcDims, {blkDims, order});
-}
-
 MKLDNNSplitNode::MKLDNNSplitNode(const InferenceEngine::CNNLayerPtr& layer, const mkldnn::engine& eng, MKLDNNWeightsSharing::Ptr &cache) :
         MKLDNNNode(layer, eng, cache) {}
 
@@ -77,7 +36,6 @@ void MKLDNNSplitNode::getSupportedDescriptors() {
 }
 
 void MKLDNNSplitNode::initSupportedPrimitiveDescriptors() {
-    using TensorDescFactory = std::function<TensorDesc(const Precision&, const SizeVector&)>;
     constexpr size_t channelsPos = 1lu;
 
     if (!supportedPrimitiveDescriptors.empty())
@@ -122,15 +80,42 @@ void MKLDNNSplitNode::initSupportedPrimitiveDescriptors() {
     if (axis < 1) {
         dynBatchSupport = false;
     }
-    auto makePdInfo = [dynBatchSupport](TensorDescFactory getTensorDesc, const Precision& precision,  const MKLDNNDims& srcDims,
-                                        const std::vector<MKLDNNDims>& outDims, impl_desc_type type) -> PrimitiveDescInfo {
+
+    //Set plain and taiC formats
+    std::vector<TensorDescCreatorTypes> tdCreatorTypes{ TensorDescCreatorTypes::ncsp, TensorDescCreatorTypes::nspc };
+
+    //Support channel blocked format
+    if (srcDims.ndims() > channelsPos) {
+        for (auto item : { std::make_pair(8lu, TensorDescCreatorTypes::nCsp8c), std::make_pair(16lu, TensorDescCreatorTypes::nCsp16c) }) {
+            SizeVector blkDims = srcDims.ToSizeVector();
+            if (blkDims[channelsPos] % item.first)
+                continue;
+
+            bool blocked = true;
+            for (size_t i = 0; i < outDims.size(); i++) {
+                if (outDims[i].ToSizeVector()[channelsPos] % item.first) {
+                    blocked = false;
+                    break;
+                }
+            }
+            if (blocked) {
+                tdCreatorTypes.push_back(item.second);
+            }
+        }
+    }
+
+    std::vector<size_t> pdIndexesToReuse;
+
+    auto& creatorsMap = TensorDescCreator::getCommonCreators();
+    auto itrRange = TensorDescCreator::makeFilteredRange(creatorsMap, static_cast<unsigned>(srcDims.ndims()), tdCreatorTypes);
+    for (auto itr = itrRange.first; itr != itrRange.second; ++itr) {
         InferenceEngine::LayerConfig config;
 
         config.dynBatchSupport = dynBatchSupport;
         config.inConfs.resize(1);
         config.inConfs[0].inPlace = -1;
         config.inConfs[0].constant = false;
-        config.inConfs[0].desc = getTensorDesc(precision, srcDims.ToSizeVector());
+        config.inConfs[0].desc = itr->second->createDesc(inpPrecision, srcDims.ToSizeVector());
         config.outConfs.resize(outDims.size());
 
         std::vector<memory::format_tag> outFormats;
@@ -140,49 +125,22 @@ void MKLDNNSplitNode::initSupportedPrimitiveDescriptors() {
 
             config.outConfs[i].inPlace = -1;
             config.outConfs[i].constant = false;
-            config.outConfs[i].desc = getTensorDesc(precision, o_Dims.ToSizeVector());
+            config.outConfs[i].desc = itr->second->createDesc(inpPrecision, o_Dims.ToSizeVector());
             outFormats.push_back(MKLDNNMemoryDesc(config.outConfs[i].desc).getFormat());
         }
-        return {config, type, outFormats};
-    };
+        supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::ref, outFormats);
 
-    //Set plain format
-    supportedPrimitiveDescriptors.push_back(makePdInfo(&makePlainTensorDesc, inpPrecision, srcDims, outDims, impl_desc_type::ref));
-
-    //Set per channel format.
-    supportedPrimitiveDescriptors.push_back(makePdInfo(&makePerChannelTensorDesc, inpPrecision, srcDims, outDims, impl_desc_type::ref));
-
-    //Support channel blocked format
-    std::vector<size_t> blockedPdIndexes;
-    if (srcDims.ndims() > channelsPos) {
-        for (size_t sizeS : {8lu, 16lu}) {
-            SizeVector blkDims = srcDims.ToSizeVector();
-            if (blkDims[channelsPos] % sizeS)
-                continue;
-
-            bool blocked = true;
-            for (size_t i = 0; i < outDims.size(); i++) {
-                if (outDims[i].ToSizeVector()[channelsPos] % sizeS) {
-                    blocked = false;
-                    break;
-                }
-            }
-            if (blocked) {
-                using std::placeholders::_1;
-                using std::placeholders::_2;
-                supportedPrimitiveDescriptors.push_back(makePdInfo(std::bind(&makeChannelBlockedTensorDesc, _1, _2, sizeS),
-                                                                   inpPrecision, srcDims, outDims, impl_desc_type::ref));
-                blockedPdIndexes.push_back(supportedPrimitiveDescriptors.size() - 1);
+        if (itr->first == TensorDescCreatorTypes::ncsp) {
+            // at least the plain layout can be optimized inplace.
+            pdIndexesToReuse.emplace_back(supportedPrimitiveDescriptors.size() - 1);
+        } else if (itr->first == TensorDescCreatorTypes::nCsp8c || itr->first == TensorDescCreatorTypes::nCsp16c) {
+            if (axis < 2) {
+                pdIndexesToReuse.emplace_back(supportedPrimitiveDescriptors.size() - 1);
             }
         }
     }
 
     // Optimized inplace case
-    std::vector<size_t> pdIndexesToReuse(1, 0); // at least the first plain layout can be optimized inplace.
-    if (axis < 2) {
-        pdIndexesToReuse.insert(pdIndexesToReuse.end(), blockedPdIndexes.begin(), blockedPdIndexes.end());
-    }
-
     for (auto refPdIndex : pdIndexesToReuse) {
         const auto& refConfig = supportedPrimitiveDescriptors[refPdIndex].getConfig();
         auto config = refConfig;
@@ -220,12 +178,26 @@ void MKLDNNSplitNode::initSupportedPrimitiveDescriptors() {
 
     // Special nspc -> ncsp case when splitting channels
     if (axis == 1 && (dstFirstDims.ndims() == 4 || dstFirstDims.ndims() == 5)) {
-        auto plain = makePdInfo(&makePlainTensorDesc, inpPrecision, srcDims, outDims, impl_desc_type::ref);
-        auto perChannel = makePdInfo(&makePerChannelTensorDesc, inpPrecision, srcDims, outDims, impl_desc_type::ref);
+        InferenceEngine::LayerConfig config;
 
-        plain.getConfig().inConfs[0].desc = perChannel.getConfig().inConfs[0].desc;
+        config.dynBatchSupport = dynBatchSupport;
+        config.inConfs.resize(1);
+        config.inConfs[0].inPlace = -1;
+        config.inConfs[0].constant = false;
+        config.inConfs[0].desc = creatorsMap.at(TensorDescCreatorTypes::nspc)->createDesc(inpPrecision, srcDims.ToSizeVector());
+        config.outConfs.resize(outDims.size());
 
-        supportedPrimitiveDescriptors.push_back(plain);
+        std::vector<memory::format_tag> outFormats;
+
+        for (size_t i = 0; i < outDims.size(); i++) {
+            auto o_Dims = outDims[i];
+
+            config.outConfs[i].inPlace = -1;
+            config.outConfs[i].constant = false;
+            config.outConfs[i].desc = creatorsMap.at(TensorDescCreatorTypes::ncsp)->createDesc(inpPrecision, o_Dims.ToSizeVector());
+            outFormats.push_back(MKLDNNMemoryDesc(config.outConfs[i].desc).getFormat());
+        }
+        supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::ref, outFormats);
     }
 }
 


### PR DESCRIPTION
### Details:
Supported primitive descriptors initialization has been rewritten using TensorDescCreators to make this procedure aligned with the other layers. Also necessary tests that check the case when multiple edges connected to the same port was added.

### Tickets:
 - 49925
