### PR TITLE
Remove a duplicate XFAIL marker for ONNX Dropout tests

### DIFF
--- a/ngraph/python/tests/__init__.py
+++ b/ngraph/python/tests/__init__.py
@@ -159,8 +159,6 @@ xfail_issue_47330 = xfail_test(reason="RuntimeError: Eltwise node with name `[na
                                       "FP64 precision.")
 xfail_issue_47337 = xfail_test(reason="RuntimeError: Unsupported dynamic ops: v1::OneHot")
 xfail_issue_33593 = xfail_test(reason="Current implementation of MaxPool doesn't support indices output")
-xfail_issue_48098 = xfail_test(reason="ngraph.exceptions.UserInputError: ('Expected %s parameters, "
-                                      "received %s.', <value1>, <value2>)")
 xfail_issue_48100 = xfail_test(reason="RuntimeError: cpu_convert can't convert from: "
                                       "FP64 precision to: FP32")
 

--- a/ngraph/python/tests/test_onnx/test_backend.py
+++ b/ngraph/python/tests/test_onnx/test_backend.py
@@ -75,7 +75,6 @@ from tests import (BACKEND_NAME,
                    xfail_issue_47330,
                    xfail_issue_47337,
                    xfail_issue_48052,
-                   xfail_issue_48098,
                    xfail_issue_48100,
                    xfail_issue_49207,
                    xfail_issue_49750,
@@ -431,10 +430,6 @@ tests_expected_to_fail = [
     (xfail_issue_33593,
      "OnnxBackendNodeModelTest.test_maxpool_with_argmax_2d_precomputed_strides_cpu",
      "OnnxBackendNodeModelTest.test_maxpool_with_argmax_2d_precomputed_pads_cpu",),
-    (xfail_issue_48098,
-     "OnnxBackendNodeModelTest.test_training_dropout_cpu",
-     "OnnxBackendNodeModelTest.test_training_dropout_default_cpu",
-     "OnnxBackendNodeModelTest.test_training_dropout_zero_ratio_cpu",),
     (xfail_issue_48100,
      "OnnxBackendNodeModelTest.test_eyelike_with_dtype_cpu",)
 ]


### PR DESCRIPTION
### Details:
Removes a duplicate marker for ONNX Dropout op tests which are already xfailed with `xfail_issue_48052`

### Tickets:
 - *48098*
