### PR TITLE
Fixed conversion of the TF OD API 2.0 SSD models

### DIFF
--- a/model-optimizer/extensions/front/tf/ObjectDetectionAPI.py
+++ b/model-optimizer/extensions/front/tf/ObjectDetectionAPI.py
@@ -1172,6 +1172,12 @@ class ObjectDetectionAPISSDPostprocessorReplacement(FrontReplacementFromConfigFi
             node.in_node(2).shape = int64_array(prior_boxes.shape)
             node.in_node(2).value = prior_boxes
 
+            # create Const node with an updated prior boxes values. Cannot use Port/Connection API here because we are
+            # in the middle of the partial inference phase and graph is in the intermediate step
+            graph.remove_edge(node.in_node(2).in_node(0).id, node.in_node(2).id)
+            const = Const(graph, {'name': 'prior_boxes', 'executable': True, 'value': prior_boxes}).create_node()
+            graph.create_edge(const, node.in_node(2))
+
         node.old_infer(node)
 
         conv_nodes = backward_bfs_for_operation(node.in_node(0), ['Conv2D'])


### PR DESCRIPTION
Description: Fixed conversion of TF OD API 2.X SSD models. The problem appeared after https://github.com/openvinotoolkit/openvino/pull/4367 where the StridedSlice operation transformation was changed and ShapeOf operations appeared in the sub-graph being added. The TF OD API models conversion relies on the fact that the part of sub-graph with prior boxes must be const folded and the data node with value of prior boxes is modified in the transformation to align from the TF semantic to OpenVINO semantic. Because of the change in https://github.com/openvinotoolkit/openvino/pull/4367 the sub-graph is not const folded and the change of the data node of prior boxes is ignored. The fix is to create a Const node explicitly so the const sub-graph is removed. 

Ticket: 50020

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [ ]  Transformation preserves original framework node names

Validation:
* [x]  Unit tests: N/A for such a change
* [x]  Framework operation tests: N/A no new operation added
* [x]  Transformation tests: N/A for such a change. Will be tested by the e2e tests
* [x]  Model Optimizer IR Reader check: Done

Documentation:
* [x]  Supported frameworks operations list: N/A no new operation enabled
* [x]  Guide on how to convert the **public** model: N/A no user visible changes
* [x]  User guide update: N/A no user visible changes