### PR TITLE
fix calculation of memoryoffset shape 

### DIFF
--- a/model-optimizer/extensions/front/kaldi/split_recurrent_memoryoffset.py
+++ b/model-optimizer/extensions/front/kaldi/split_recurrent_memoryoffset.py
@@ -57,11 +57,11 @@ class SplitRecurrentMemoryOffset(FrontReplacementSubgraph):
                 # MemoryOffset node is not in a recurrent block -- no splitting is needed
                 return
 
-            # check that node have information for future partial infer
-            # element_size set in loader based on dimensions of previous layer that were read from Kaldi model
+            # check that node has information for future partial infer
+            # element_size is set in loader based on dimensions of previous layer from original Kaldi model
             if not offset_node.has_valid('element_size'):
-                # node have not set element_size but previous node can have information about its shape in out-size
-                # out-size set in extractor of some nodes like affinecomponent based on weights size
+                # check if previous layer contains information about its shape in out-size
+                # out-size is set in extractor of some nodes like affinecomponent based on weight's size
                 if offset_node.in_port(0).get_source().node.has_valid('out-size'):
                     offset_node['element_size'] = offset_node.in_port(0).get_source().node['out-size']
                 else:

--- a/model-optimizer/mo/front/kaldi/loader/loader.py
+++ b/model-optimizer/mo/front/kaldi/loader/loader.py
@@ -234,15 +234,18 @@ def load_components(file_descr, graph, component_layer_map=None):
         # it is separated in 2 parts to remove cycle from graph
         file_descr.seek(start_index)
         dim = 0
-        try:
-            collect_until_token(file_descr, b'<Dim>', size_search_zone=end_index - start_index)
-            cur_index = file_descr.tell()
-            if start_index < cur_index < end_index:
-                dim = read_binary_integer32_token(file_descr)
-            else:
+        dim_words = {b'<Dim>', b'<InputDim>'}
+        for dim_word in dim_words:
+            try:
+                collect_until_token(file_descr, dim_word, size_search_zone=end_index - start_index)
+                cur_index = file_descr.tell()
+                if start_index < cur_index < end_index:
+                    dim = read_binary_integer32_token(file_descr)
+                    break
+                else:
+                    file_descr.seek(start_index)
+            except Error:
                 file_descr.seek(start_index)
-        except Error:
-            file_descr.seek(start_index)
 
         if is_nnet3:
             if name in component_layer_map:


### PR DESCRIPTION
### Details:
 Fixed MemoryOffset partial infer for 2 cases:
- after normalization layer - shape can be read from model with InputDim tag - fixed loader
- after affinecomponent - shape calculated in extractor and saved in out-size attribute - read it in split transformation and move to element_size for future use in partial infer

### Tickets:
 29401

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR **Not applicable**
* [x]  Transformation preserves original framework node names **Not applicable**


Validation:
* [x]  Unit tests **Not applicable**
* [x]  Framework operation tests **Not applicable**
* [x]  Transformation tests **Not applicable**
* [x]  Model Optimizer IR Reader check **Not applicable**

Documentation:
* [x]  Supported frameworks operations list **Not applicable**
* [x]  Guide on how to convert the **public** model **Not applicable**
* [x]  User guide update **Not applicable**
