### PR TITLE
[BF16] Instantiation params for bf16-tests fitted to original task

### DIFF
--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/conv_add.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/conv_add.cpp
@@ -119,26 +119,6 @@ TEST_P(ConvAdd, CompareWithRefImpl) {
     test();
 };
 
-//    CPU plug-in failure in that case
-
-//INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, ConvAdd,
-//                        ::testing::Combine(
-//                                ::testing::Values(Precision::FP32),
-//                                ::testing::Values(Precision::FP32),
-//                                ::testing::Values(SizeVector({1, 256, 38, 38})),
-//                                ::testing::Values(SizeVector()),
-//                                ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-//                        ConvAdd::getTestCaseName);
-//
-//INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, ConvAdd,
-//                        ::testing::Combine(
-//                                ::testing::Values(Precision::FP32),
-//                                ::testing::Values(Precision::BF16),
-//                                ::testing::Values(SizeVector({1, 256, 38, 38})),
-//                                ::testing::Values(SizeVector()),
-//                                ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-//                        ConvAdd::getTestCaseName);
-
 INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, ConvAdd,
                         ::testing::Combine(
                                 ::testing::Values(Precision::FP32),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/elt_x3.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/elt_x3.cpp
@@ -187,26 +187,6 @@ TEST_P(Elt_x3, CompareWithRefImpl) {
     test();
 };
 
-//    CPU plug-in failure in that case
-
-//INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, Elt_x3,
-//                        ::testing::Combine(
-//                                ::testing::Values(Precision::FP32),
-//                                ::testing::Values(Precision::FP32),
-//                                ::testing::Values(SizeVector({1, 256, 38, 38})),
-//                                ::testing::Values(SizeVector()),
-//                                ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-//                        Elt_x3::getTestCaseName);
-//
-//INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, Elt_x3,
-//                        ::testing::Combine(
-//                                ::testing::Values(Precision::FP32),
-//                                ::testing::Values(Precision::BF16),
-//                                ::testing::Values(SizeVector({1, 256, 38, 38})),
-//                                ::testing::Values(SizeVector()),
-//                                ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-//                        Elt_x3::getTestCaseName);
-
 INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, Elt_x3,
                         ::testing::Combine(
                                 ::testing::Values(Precision::FP32),

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/gather_multiply.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/gather_multiply.cpp
@@ -93,7 +93,7 @@ protected:
         fnPtr = createGraph(netPrecision);
 
         // STAGE2: set up safe threshold <= 5% from maximum value of output tensor
-        threshold = 0.1f;  // Max in fp32 network by output:  21.7285
+        threshold = 0.4f;  // Max in fp32 network by output:  9.20144
 
         // STAGE3:
         // filling of expected precision of layer execution defined by precisoin of input tensor to the primitive and reflected in
@@ -108,24 +108,21 @@ TEST_P(Gather_multiply, CompareWithRefImpl) {
     test();
 };
 
+INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, Gather_multiply,
+                        ::testing::Combine(
+                                ::testing::Values(Precision::FP32),
+                                ::testing::Values(Precision::BF16),
+                                ::testing::Values(SizeVector({2048, 64})),
+                                ::testing::Values(SizeVector()),
+                                ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                        Gather_multiply::getTestCaseName);
 
 INSTANTIATE_TEST_CASE_P(smoke_FP32_bfloat16_NoReshape, Gather_multiply,
                         ::testing::Combine(
                                 ::testing::Values(Precision::FP32),
                                 ::testing::Values(Precision::FP32),
-                                ::testing::Values(SizeVector({1, 4})),
+                                ::testing::Values(SizeVector({2048, 64})),
                                 ::testing::Values(SizeVector()),
                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                         Gather_multiply::getTestCaseName);
-//    CPU plug-in failure in that case
-
-//INSTANTIATE_TEST_CASE_P(smoke_BF16_bfloat16_NoReshape, Gather_multiply,
-//                        ::testing::Combine(
-//                                ::testing::Values(Precision::FP32),
-//                                ::testing::Values(Precision::BF16),
-//                                ::testing::Values(SizeVector({1, 4})),
-//                                ::testing::Values(SizeVector()),
-//                                ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-//                        Gather_multiply::getTestCaseName);
-
 }  // namespace LayerTestsDefinitions


### PR DESCRIPTION
### Details:
 - We've found significant divergence in some subgraph tests for 'big' channels number. It was found, that only sparse tensors are used in real models. Instead of imitation of sparse input in the test infrastructure, it was decided to remove corresponding instantiations from tests.

### Tickets:
 - 31314
