### PR TITLE
Partial revert of changes in the Pad transformations caused POT regression

### DIFF
--- a/model-optimizer/extensions/front/AttributedPadToPad.py
+++ b/model-optimizer/extensions/front/AttributedPadToPad.py
@@ -14,9 +14,7 @@
  limitations under the License.
 """
 
-from extensions.ops.ConvertLike import ConvertLike
 from mo.front.common.replacement import FrontReplacementPattern
-from mo.front.tf.graph_utils import create_op_with_const_inputs
 from mo.graph.graph import Graph, rename_nodes
 from mo.ops.const import Const
 from mo.ops.pad import Pad
@@ -41,11 +39,7 @@ class AttributedPadToPad(FrontReplacementPattern):
             new_pad.in_port(1).connect(Const(graph, {'value': attr_pad.pads[:, 0]}).create_node().out_port(0))
             new_pad.in_port(2).connect(Const(graph, {'value': attr_pad.pads[:, 1]}).create_node().out_port(0))
             if attr_pad.soft_get('mode') == 'constant':
-                # create Constant node of proper data type (equal to the data type of the Pad first input)
-                convert_pad_value = create_op_with_const_inputs(graph, ConvertLike, {0: attr_pad.fill_value},
-                                                                {'name': original_name + '/pad_value_convert'})
-                convert_pad_value.in_port(1).connect(new_pad.in_port(0).get_source())
-                new_pad.in_port(3).connect(convert_pad_value.out_port(0))
+                new_pad.in_port(3).connect(Const(graph, {'value': attr_pad.fill_value}).create_node().out_port(0))
 
             attr_pad.out_port(0).get_connection().set_source(new_pad.out_port(0))
             graph.remove_node(attr_pad.id)

--- a/model-optimizer/extensions/front/AttributedPadToPad_test.py
+++ b/model-optimizer/extensions/front/AttributedPadToPad_test.py
@@ -31,7 +31,6 @@ nodes_attributes = {
 
     # new Pad layer and inputs
     'pad': {'type': 'Pad', 'kind': 'op', 'op': 'Pad', 'mode': 'constant'},
-    'convert_like': {'type': 'ConvertLike', 'kind': 'op', 'op': 'ConvertLike'},
     **const('pad_begin', int64_array([1, 3, 5])),
     **const('pad_end', int64_array([2, 4, 6])),
     **const('pad_fill', np.array(0.75)),
@@ -50,9 +49,7 @@ class AttributedPadToPadTest(unittest.TestCase):
                                 [('placeholder', 'pad', {'in': 0, 'out': 0}),
                                  ('pad_begin', 'pad', {'in': 1, 'out': 0}),
                                  ('pad_end', 'pad', {'in': 2, 'out': 0}),
-                                 ('pad_fill', 'convert_like', {'in': 0, 'out': 0}),
-                                 ('placeholder', 'convert_like', {'in': 1, 'out': 0}),
-                                 ('convert_like', 'pad', {'in': 3, 'out': 0}),
+                                 ('pad_fill', 'pad', {'in': 3, 'out': 0}),
                                  ('pad', 'result')
                                  ],
                                 {}, nodes_with_edges_only=True)

--- a/model-optimizer/extensions/front/tf/pad_tf_to_pad.py
+++ b/model-optimizer/extensions/front/tf/pad_tf_to_pad.py
@@ -13,13 +13,13 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-from extensions.ops.ConvertLike import ConvertLike
 from extensions.ops.split import Split
 from extensions.ops.transpose import Transpose
 from mo.front.common.partial_infer.utils import int64_array
 from mo.front.common.replacement import FrontReplacementPattern
 from mo.front.tf.graph_utils import create_op_with_const_inputs
 from mo.graph.graph import Graph, rename_node
+from mo.ops.const import Const
 from mo.ops.pad import Pad
 from mo.ops.squeeze import Squeeze
 
@@ -47,11 +47,8 @@ class PadTFToPad(FrontReplacementPattern):
                 if not tfpad.in_port(2).disconnected():
                     tfpad.in_port(2).get_connection().set_destination(new_pad.in_port(3))
                 else:
-                    # create Constant node of proper data type (equal to the data type of the Pad first input)
-                    convert_pad_value = create_op_with_const_inputs(graph, ConvertLike, {0: 0.0},
-                                                                    {'name': original_name + '/pad_value_convert'})
-                    convert_pad_value.in_port(1).connect(new_pad.in_port(0).get_source())
-                    new_pad.in_port(3).connect(convert_pad_value.out_port(0))
+                    new_pad.in_port(3).connect(Const(graph, {'value': 0.0, 'name': new_pad.name + '/value'}
+                                                     ).create_node().out_port(0))
 
             # convert TF representation of the pads as [N, 2] to MO representation: [N] and [N]
             transposed_pads = create_op_with_const_inputs(graph, Transpose, {1: int64_array([1, 0])})

--- a/model-optimizer/extensions/front/tf/pad_tf_to_pad_test.py
+++ b/model-optimizer/extensions/front/tf/pad_tf_to_pad_test.py
@@ -40,7 +40,6 @@ nodes_attributes = {
     **const('squeeze_1_axis', int64_array([0])),
     'squeeze_2': {'type': 'Squeeze', 'kind': 'op', 'op': 'Squeeze'},
     **const('squeeze_2_axis', int64_array([0])),
-    'convert_like': {'type': 'ConvertLike', 'kind': 'op', 'op': 'ConvertLike'},
 
     **const('pad_fill', np.array(0.0)),
 }
@@ -87,9 +86,7 @@ class PadTFToPadTest(unittest.TestCase):
                             {}, nodes_with_edges_only=True)
         graph.get_op_nodes(op='TFPad')[0].add_input_port(2)
 
-        graph_ref = build_graph(nodes_attributes, common_edges + [('pad_fill', 'convert_like', {'in': 0, 'out': 0}),
-                                                                  ('placeholder', 'convert_like', {'in': 1, 'out': 0}),
-                                                                  ('convert_like', 'pad', {'in': 3, 'out': 0})],
+        graph_ref = build_graph(nodes_attributes, common_edges + [('pad_fill', 'pad', {'in': 3, 'out': 0})],
                                 {}, nodes_with_edges_only=True)
         self._run_test(graph, graph_ref)
 


### PR DESCRIPTION
Description: Partial revert of a change in https://github.com/openvinotoolkit/openvino/pull/4438 where MO start to insert ConverLike operation. This change caused degradation with the POT because POT does not handle `ConvertLike` operation properly and FakeQuantize operations are not properly optimized.

Ticket: 50202

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests: N/A no new operation enabled
* [x]  Transformation tests
* [x]  Model Optimizer IR Reader check: Done manually

Documentation:
* [x]  Supported frameworks operations list: N/A no new operation enabled
* [x]  Guide on how to convert the **public** model: N/A no new model enabled
* [x]  User guide update: N/A no user visible changes