### PR TITLE
Fix FakeQuantizeMulFusion for cases with NUMPY broadcasting

### DIFF
--- a/inference-engine/tests/functional/inference_engine/transformations/fq_mul_fusion_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/fq_mul_fusion_test.cpp
@@ -169,13 +169,6 @@ INSTANTIATE_TEST_CASE_P(FQOutputs_1D__multiplier_3D, FQMulFusion,
                                            ::testing::Values(ngraph::Shape{1, 3, 1}),
                                            ::testing::Values(ngraph::Shape{1, 3, 1})));
 
-INSTANTIATE_TEST_CASE_P(FQ_all_ones__multiplier_4D_with_channel, FQMulFusion,
-                        ::testing::Combine(::testing::Values(ngraph::Shape{1, 1, 1, 1}),
-                                           ::testing::Values(ngraph::Shape{1, 1, 1, 1}),
-                                           ::testing::Values(ngraph::Shape{1, 1, 1, 1}),
-                                           ::testing::Values(ngraph::Shape{1, 64, 1, 1}),
-                                           ::testing::Values(ngraph::Shape{1, 64, 1, 1})));
-
 INSTANTIATE_TEST_CASE_P(FQInOUt_ones__multiplier_4D_with_channel, FQMulFusion,
                         ::testing::Combine(::testing::Values(ngraph::Shape{1, 64, 3, 3}),
                                            ::testing::Values(ngraph::Shape{1, 1, 1, 1}),


### PR DESCRIPTION
### Description
At the current moment FQ shape infer function doesn't work correctly and use zero input shape for an output shape. This leads to issues with shape inconsistency when one of 2-4 FQ inputs broadcast 1 input. In this PR I added a check which disable replacement if new FQ shape is not equal to Multiply output shape.

### Tickets:
50195
