### PR TITLE
Remove __clang__ macros from headers

### DIFF
--- a/inference-engine/include/ie_blob.h
+++ b/inference-engine/include/ie_blob.h
@@ -576,14 +576,7 @@ public:
     /**
      *@brief Virtual destructor.
      */
-
-#if defined(__ANDROID__)
     virtual ~TBlob();
-#else
-    virtual ~TBlob() {
-        free();
-    }
-#endif  // __ANDROID__
 
     /**
      * @brief Gets the size of the given type.
@@ -806,7 +799,6 @@ protected:
     }
 };
 
-#if defined(__ANDROID__)
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<float>);
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<double>);
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<int8_t>);
@@ -819,7 +811,8 @@ extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<long>);
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<long long>);
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<unsigned long>);
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<unsigned long long>);
-#endif  // __ANDROID__
+extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<bool>);
+extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<char>);
 
 /**
  * @brief Creates a blob with the given tensor descriptor.

--- a/inference-engine/include/ie_blob.h
+++ b/inference-engine/include/ie_blob.h
@@ -577,13 +577,13 @@ public:
      *@brief Virtual destructor.
      */
 
-#if defined(__clang__) && !defined(__SYCL_COMPILER_VERSION)
+#if defined(__ANDROID__)
     virtual ~TBlob();
 #else
     virtual ~TBlob() {
         free();
     }
-#endif  // __clang__ && !__SYCL_COMPILER_VERSION
+#endif  // __ANDROID__
 
     /**
      * @brief Gets the size of the given type.
@@ -806,7 +806,7 @@ protected:
     }
 };
 
-#if defined(__clang__) && !defined(__SYCL_COMPILER_VERSION)
+#if defined(__ANDROID__)
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<float>);
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<double>);
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<int8_t>);
@@ -819,7 +819,7 @@ extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<long>);
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<long long>);
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<unsigned long>);
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<unsigned long long>);
-#endif  // __clang__ && !__SYCL_COMPILER_VERSION
+#endif  // __ANDROID__
 
 /**
  * @brief Creates a blob with the given tensor descriptor.

--- a/inference-engine/include/ie_parameter.hpp
+++ b/inference-engine/include/ie_parameter.hpp
@@ -274,11 +274,11 @@ private:
     struct HasOperatorEqual : CheckOperatorEqual<T, EqualTo>::type {};
 
     struct Any {
-#if defined(__clang__) && !defined(__SYCL_COMPILER_VERSION)
+#if defined(__ANDROID__)
         virtual ~Any();
 #else
         virtual ~Any() = default;
-#endif  // __clang__ && !__SYCL_COMPILER_VERSION
+#endif  // __ANDROID__
         virtual bool is(const std::type_info&) const = 0;
         virtual Any* copy() const = 0;
         virtual bool operator==(const Any& rhs) const = 0;
@@ -335,7 +335,7 @@ private:
     Any* ptr = nullptr;
 };
 
-#if defined(__clang__) && !defined(__SYCL_COMPILER_VERSION)
+#if defined(__ANDROID__)
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<InferenceEngine::Blob::Ptr>);
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<int>);
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<bool>);
@@ -350,6 +350,6 @@ extern template struct INFERENCE_ENGINE_API_CLASS(
     InferenceEngine::Parameter::RealData<std::tuple<unsigned int, unsigned int>>);
 extern template struct INFERENCE_ENGINE_API_CLASS(
     InferenceEngine::Parameter::RealData<std::tuple<unsigned int, unsigned int, unsigned int>>);
-#endif  // __clang__ && !__SYCL_COMPILER_VERSION
+#endif  // __ANDROID__
 
 }  // namespace InferenceEngine

--- a/inference-engine/include/ie_parameter.hpp
+++ b/inference-engine/include/ie_parameter.hpp
@@ -273,7 +273,7 @@ private:
     template <class T, class EqualTo = T>
     struct HasOperatorEqual : CheckOperatorEqual<T, EqualTo>::type {};
 
-    struct Any {
+    struct INFERENCE_ENGINE_API_CLASS(Any) {
         virtual ~Any();
         virtual bool is(const std::type_info&) const = 0;
         virtual Any* copy() const = 0;
@@ -331,7 +331,6 @@ private:
     Any* ptr = nullptr;
 };
 
-#if defined(__ANDROID__)
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<InferenceEngine::Blob::Ptr>);
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<int>);
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<bool>);
@@ -346,6 +345,5 @@ extern template struct INFERENCE_ENGINE_API_CLASS(
     InferenceEngine::Parameter::RealData<std::tuple<unsigned int, unsigned int>>);
 extern template struct INFERENCE_ENGINE_API_CLASS(
     InferenceEngine::Parameter::RealData<std::tuple<unsigned int, unsigned int, unsigned int>>);
-#endif  // __ANDROID__
 
 }  // namespace InferenceEngine

--- a/inference-engine/include/ie_parameter.hpp
+++ b/inference-engine/include/ie_parameter.hpp
@@ -273,8 +273,12 @@ private:
     template <class T, class EqualTo = T>
     struct HasOperatorEqual : CheckOperatorEqual<T, EqualTo>::type {};
 
-    struct INFERENCE_ENGINE_API_CLASS(Any) {
+    struct Any {
+#ifdef __ANDROID__
         virtual ~Any();
+#else
+        virtual ~Any() = default;
+#endif
         virtual bool is(const std::type_info&) const = 0;
         virtual Any* copy() const = 0;
         virtual bool operator==(const Any& rhs) const = 0;
@@ -287,12 +291,13 @@ private:
         bool is(const std::type_info& id) const override {
             return id == typeid(T);
         }
-
         Any* copy() const override {
             return new RealData {get()};
         }
 
-        T& get() &;
+        T& get() & {
+            return std::get<0>(*static_cast<std::tuple<T>*>(this));
+        }
 
         const T& get() const& {
             return std::get<0>(*static_cast<const std::tuple<T>*>(this));
@@ -330,24 +335,21 @@ private:
     Any* ptr = nullptr;
 };
 
+#ifdef __ANDROID__
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<InferenceEngine::Blob::Ptr>);
-extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<InferenceEngine::TensorDesc>);
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<int>);
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<bool>);
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<float>);
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<uint32_t>);
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<std::string>);
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<unsigned long>);
-extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<long long>);
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<std::vector<int>>);
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<std::vector<std::string>>);
-extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<std::vector<float>>);
-extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<std::vector<uint32_t>>);
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<std::vector<unsigned long>>);
 extern template struct INFERENCE_ENGINE_API_CLASS(
     InferenceEngine::Parameter::RealData<std::tuple<unsigned int, unsigned int>>);
 extern template struct INFERENCE_ENGINE_API_CLASS(
     InferenceEngine::Parameter::RealData<std::tuple<unsigned int, unsigned int, unsigned int>>);
-extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<std::map<std::string, Parameter>>);
+#endif
 
 }  // namespace InferenceEngine

--- a/inference-engine/include/ie_parameter.hpp
+++ b/inference-engine/include/ie_parameter.hpp
@@ -274,11 +274,7 @@ private:
     struct HasOperatorEqual : CheckOperatorEqual<T, EqualTo>::type {};
 
     struct Any {
-#if defined(__ANDROID__)
         virtual ~Any();
-#else
-        virtual ~Any() = default;
-#endif  // __ANDROID__
         virtual bool is(const std::type_info&) const = 0;
         virtual Any* copy() const = 0;
         virtual bool operator==(const Any& rhs) const = 0;

--- a/inference-engine/include/ie_parameter.hpp
+++ b/inference-engine/include/ie_parameter.hpp
@@ -287,13 +287,12 @@ private:
         bool is(const std::type_info& id) const override {
             return id == typeid(T);
         }
+
         Any* copy() const override {
             return new RealData {get()};
         }
 
-        T& get() & {
-            return std::get<0>(*static_cast<std::tuple<T>*>(this));
-        }
+        T& get() &;
 
         const T& get() const& {
             return std::get<0>(*static_cast<const std::tuple<T>*>(this));
@@ -332,18 +331,23 @@ private:
 };
 
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<InferenceEngine::Blob::Ptr>);
+extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<InferenceEngine::TensorDesc>);
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<int>);
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<bool>);
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<float>);
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<uint32_t>);
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<std::string>);
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<unsigned long>);
+extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<long long>);
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<std::vector<int>>);
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<std::vector<std::string>>);
+extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<std::vector<float>>);
+extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<std::vector<uint32_t>>);
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<std::vector<unsigned long>>);
 extern template struct INFERENCE_ENGINE_API_CLASS(
     InferenceEngine::Parameter::RealData<std::tuple<unsigned int, unsigned int>>);
 extern template struct INFERENCE_ENGINE_API_CLASS(
     InferenceEngine::Parameter::RealData<std::tuple<unsigned int, unsigned int, unsigned int>>);
+extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<std::map<std::string, Parameter>>);
 
 }  // namespace InferenceEngine

--- a/inference-engine/src/gna_plugin/gna_plugin.cpp
+++ b/inference-engine/src/gna_plugin/gna_plugin.cpp
@@ -85,12 +85,10 @@ using namespace std;
 using namespace GNAPluginNS;
 using namespace InferenceEngine::details;
 
-#ifdef __ANDROID__
 namespace InferenceEngine {
     template<>
-    InferenceEngine::TBlob<intel_compound_bias_t, std::enable_if<true, void> >::~TBlob() { free(); }
+    InferenceEngine::TBlob<gna_compound_bias_t, std::enable_if<true, void> >::~TBlob() { free(); }
 }
-#endif  // __ANDROID__
 
 template <typename T, typename U>
 void GNAPlugin::copyInputData(T *dst,

--- a/inference-engine/src/gna_plugin/gna_plugin.cpp
+++ b/inference-engine/src/gna_plugin/gna_plugin.cpp
@@ -85,12 +85,12 @@ using namespace std;
 using namespace GNAPluginNS;
 using namespace InferenceEngine::details;
 
-#ifdef __clang__
+#ifdef __ANDROID__
 namespace InferenceEngine {
     template<>
     InferenceEngine::TBlob<intel_compound_bias_t, std::enable_if<true, void> >::~TBlob() { free(); }
 }
-#endif  // __clang__
+#endif  // __ANDROID__
 
 template <typename T, typename U>
 void GNAPlugin::copyInputData(T *dst,

--- a/inference-engine/src/inference_engine/ie_common.cpp
+++ b/inference-engine/src/inference_engine/ie_common.cpp
@@ -102,9 +102,9 @@ Parameter::~Parameter() {
     clear();
 }
 
-#if defined(__ANDROID__)
 Parameter::Any::~Any() {}
 
+#if defined(__ANDROID__)
 template struct Parameter::RealData<int>;
 template struct Parameter::RealData<bool>;
 template struct Parameter::RealData<float>;

--- a/inference-engine/src/inference_engine/ie_common.cpp
+++ b/inference-engine/src/inference_engine/ie_common.cpp
@@ -104,7 +104,6 @@ Parameter::~Parameter() {
 
 Parameter::Any::~Any() {}
 
-#if defined(__ANDROID__)
 template struct Parameter::RealData<int>;
 template struct Parameter::RealData<bool>;
 template struct Parameter::RealData<float>;
@@ -140,6 +139,7 @@ template class TBlob<long>;
 template class TBlob<long long>;
 template class TBlob<unsigned long>;
 template class TBlob<unsigned long long>;
-#endif  // defined(__ANDROID__)
+template class TBlob<bool>;
+template class TBlob<char>;
 
 }  // namespace InferenceEngine

--- a/inference-engine/src/inference_engine/ie_common.cpp
+++ b/inference-engine/src/inference_engine/ie_common.cpp
@@ -102,7 +102,7 @@ Parameter::~Parameter() {
     clear();
 }
 
-#if defined(__clang__) && !defined(__SYCL_COMPILER_VERSION)
+#if defined(__ANDROID__)
 Parameter::Any::~Any() {}
 
 template struct Parameter::RealData<int>;
@@ -140,6 +140,6 @@ template class TBlob<long>;
 template class TBlob<long long>;
 template class TBlob<unsigned long>;
 template class TBlob<unsigned long long>;
-#endif  // defined(__clang__) && !defined(__SYCL_COMPILER_VERSION)
+#endif  // defined(__ANDROID__)
 
 }  // namespace InferenceEngine

--- a/inference-engine/src/inference_engine/ie_common.cpp
+++ b/inference-engine/src/inference_engine/ie_common.cpp
@@ -104,6 +104,11 @@ Parameter::~Parameter() {
 
 Parameter::Any::~Any() {}
 
+template <typename T>
+T& Parameter::RealData<T>::get() & {
+    return std::get<0>(*static_cast<std::tuple<T>*>(this));
+}
+
 template struct Parameter::RealData<int>;
 template struct Parameter::RealData<bool>;
 template struct Parameter::RealData<float>;
@@ -111,12 +116,17 @@ template struct Parameter::RealData<double>;
 template struct Parameter::RealData<uint32_t>;
 template struct Parameter::RealData<std::string>;
 template struct Parameter::RealData<unsigned long>;
+template struct Parameter::RealData<long long>;
 template struct Parameter::RealData<std::vector<int>>;
 template struct Parameter::RealData<std::vector<std::string>>;
+template struct Parameter::RealData<std::vector<float>>;
+template struct Parameter::RealData<std::vector<uint32_t>>;
 template struct Parameter::RealData<std::vector<unsigned long>>;
 template struct Parameter::RealData<std::tuple<unsigned int, unsigned int>>;
 template struct Parameter::RealData<std::tuple<unsigned int, unsigned int, unsigned int>>;
 template struct Parameter::RealData<Blob::Ptr>;
+template struct Parameter::RealData<TensorDesc>;
+template struct Parameter::RealData<std::map<std::string, Parameter>>;
 
 //
 // ie_blob.h

--- a/inference-engine/src/inference_engine/ie_common.cpp
+++ b/inference-engine/src/inference_engine/ie_common.cpp
@@ -102,12 +102,8 @@ Parameter::~Parameter() {
     clear();
 }
 
+#ifdef __ANDROID__
 Parameter::Any::~Any() {}
-
-template <typename T>
-T& Parameter::RealData<T>::get() & {
-    return std::get<0>(*static_cast<std::tuple<T>*>(this));
-}
 
 template struct Parameter::RealData<int>;
 template struct Parameter::RealData<bool>;
@@ -116,17 +112,13 @@ template struct Parameter::RealData<double>;
 template struct Parameter::RealData<uint32_t>;
 template struct Parameter::RealData<std::string>;
 template struct Parameter::RealData<unsigned long>;
-template struct Parameter::RealData<long long>;
 template struct Parameter::RealData<std::vector<int>>;
 template struct Parameter::RealData<std::vector<std::string>>;
-template struct Parameter::RealData<std::vector<float>>;
-template struct Parameter::RealData<std::vector<uint32_t>>;
 template struct Parameter::RealData<std::vector<unsigned long>>;
 template struct Parameter::RealData<std::tuple<unsigned int, unsigned int>>;
 template struct Parameter::RealData<std::tuple<unsigned int, unsigned int, unsigned int>>;
 template struct Parameter::RealData<Blob::Ptr>;
-template struct Parameter::RealData<TensorDesc>;
-template struct Parameter::RealData<std::map<std::string, Parameter>>;
+#endif
 
 //
 // ie_blob.h

--- a/inference-engine/tests/functional/inference_engine/parameter_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/parameter_tests.cpp
@@ -33,6 +33,13 @@ public:
 size_t DestructorTest::destructorCount = 0;
 size_t DestructorTest::constructorCount = 0;
 
+// These lines are requred to solve linkage issue
+template<>
+DestructorTest*& Parameter::RealData<DestructorTest*>::get() & {
+    return std::get<0>(*static_cast<std::tuple<DestructorTest*>*>(this));
+}
+template struct Parameter::RealData<DestructorTest*>;
+
 class ParameterTests : public ::testing::Test {
 public:
     void SetUp() override {

--- a/inference-engine/tests/functional/inference_engine/parameter_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/parameter_tests.cpp
@@ -33,13 +33,6 @@ public:
 size_t DestructorTest::destructorCount = 0;
 size_t DestructorTest::constructorCount = 0;
 
-// These lines are requred to solve linkage issue
-template<>
-DestructorTest*& Parameter::RealData<DestructorTest*>::get() & {
-    return std::get<0>(*static_cast<std::tuple<DestructorTest*>*>(this));
-}
-template struct Parameter::RealData<DestructorTest*>;
-
 class ParameterTests : public ::testing::Test {
 public:
     void SetUp() override {

--- a/ngraph/test/util/engine/ie_engines.cpp
+++ b/ngraph/test/util/engine/ie_engines.cpp
@@ -315,10 +315,10 @@ void test::IE_Engine::reset()
 
 namespace InferenceEngine
 {
-// those definitions and template specializations are required for clang (both Linux and Mac)
+// those definitions and template specializations are required for Android
 // Without this section the linker is not able to find destructors for missing TBlob specializations
 // which are instantiated in the unit tests that use TestCase and this engine
-#ifdef __clang__
+#ifdef __ANDROID__
     template <typename T, typename U>
     TBlob<T, U>::~TBlob()
     {

--- a/ngraph/test/util/engine/ie_engines.cpp
+++ b/ngraph/test/util/engine/ie_engines.cpp
@@ -315,20 +315,14 @@ void test::IE_Engine::reset()
 
 namespace InferenceEngine
 {
-// those definitions and template specializations are required for Android
 // Without this section the linker is not able to find destructors for missing TBlob specializations
 // which are instantiated in the unit tests that use TestCase and this engine
-#ifdef __ANDROID__
     template <typename T, typename U>
     TBlob<T, U>::~TBlob()
     {
         free();
     }
 
-    template class TBlob<unsigned int>;
-    template class TBlob<bool>;
     template class TBlob<ngraph::bfloat16>;
     template class TBlob<ngraph::float16>;
-    template class TBlob<char>;
-#endif
 } // namespace InferenceEngine


### PR DESCRIPTION
### Details:
 - Remove `#ifdef(__clang__)` which were introduced in headers for Android compilation (problem with Clang compilation of applications with gcc compiled OpenVINO)
 - Replace `__clang__` to `__ANDROID__` only for `Parameter::Any` + `Parameter::RealData` (otherwise is not compiled for Windows)
 - Cannot replace every `__clang__` to `__ANDROID__` because Mac uses Apple Clang for compilation and tests crashed without some of the definitions 🤦 

### Tickets:
 - 41513
