### PR TITLE
[LPT] GPU Support 3D tensor on activations - tests

### DIFF
--- a/inference-engine/tests/functional/inference_engine/lp_transformations/mat_mul_with_constant_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/mat_mul_with_constant_transformation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -79,7 +79,10 @@ inline std::ostream& operator << (std::ostream& out, const MatMullTransformation
 }
 
 inline std::ostream& operator << (std::ostream& out, const MatMullTransformationTestValues& values) {
-    return out << "_" << values.actual << "_" << values.expected;
+    return out << "_" <<
+        values.params.support3DTensorOnActivations << "_" <<
+        values.actual << "_" <<
+        values.expected;
 }
 
 typedef std::tuple<
@@ -197,6 +200,28 @@ std::vector<MatMullTransformationTestValues> testValues = {
             ngraph::element::u8,
             { {}, {}, { 0.02f * 0.1f } },
             {},
+            {}
+        }
+    },
+
+    // support3DTensorOnActivations = false for 3D tensor
+    {
+        LayerTransformation::createParamsU8I8().setSupport3DTensorOnActivations(false),
+        {
+            { 1, 384, 1024 },
+            ngraph::element::u8,
+            { ngraph::element::f32, {}, { 0.02f } },
+            { std::vector<float>(1024 * 1024, 1.f), ngraph::element::f32, { 1024, 1024 } },
+            { 255, { 1, 1 },  {0.f}, {254.f}, {-12.7f}, {12.7} }
+        },
+        {
+            { 1, 384, 1024 },
+            ngraph::element::u8,
+            { ngraph::element::f32, {}, { 0.02f } },
+            { std::vector<float>(1024 * 1024, 1.f), ngraph::element::f32, { 1024, 1024 } },
+            ngraph::element::i8,
+            {},
+            { 255, { 1, 1 },  {0.f}, {254.f}, {-12.7f}, {12.7} },
             {}
         }
     },
@@ -429,6 +454,28 @@ std::vector<MatMullTransformationTestValues> testValues = {
         }
     },
 
+    // support3DTensorOnActivations = false, but 2D tensor is used
+    {
+        LayerTransformation::createParamsU8I8().setSupport3DTensorOnActivations(false),
+        {
+            { 1, 2048 },
+            ngraph::element::u8,
+            { ngraph::element::f32, {}, { 0.02f } },
+            { std::vector<float>(2048 * 1000, 1.f), ngraph::element::f32, { 2048, 1000 }},
+            { 255, { 1, 1 },  {0.f}, {254.f}, {-12.7f}, {12.7} },
+            {}
+        },
+        {
+            { 1, 2048 },
+            ngraph::element::u8,
+            {},
+            { std::vector<float>(2048 * 1000, -126), ngraph::element::i8, { 2048, 1000 }},
+            ngraph::element::i8,
+            { {}, {}, { 0.02f * 0.1f } },
+            {}
+        }
+    },
+
     // 2D: I8 & I8
     {
         LayerTransformation::createParamsI8I8(),
@@ -542,7 +589,7 @@ std::vector<MatMullTransformationTestValues> testValues = {
             {},
             {}
         }
-    },
+    }
 };
 
 INSTANTIATE_TEST_CASE_P(

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/mat_mul_with_constant_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/mat_mul_with_constant_transformation.cpp
@@ -20,6 +20,8 @@ std::vector<MatMulWithConstantTransformationTestValues> testValues = {
         { std::vector<float>(4 * 2, 2.f), ngraph::element::f32, ngraph::Shape{ 2, 4 } },
         { 256ul, {{1}, {1}, {2, 1}, {2, 1}}, {-128.f}, {127.f}, {-128.f, -12.8f}, {127.f, 12.7f} },
         { {}, {}, {} },
+        "result_result",
+        "FP32"
     },
     {
         { 2, 3, 4 },
@@ -27,6 +29,8 @@ std::vector<MatMulWithConstantTransformationTestValues> testValues = {
         { std::vector<float>(4 * 2, 2.f), ngraph::element::i8, ngraph::Shape{ 2, 4 } },
         {},
         { ngraph::element::f32, {}, {0.1f} },
+        "result_result",
+        "FP32"
     },
     {
         { 1, 3, 4 },
@@ -34,6 +38,8 @@ std::vector<MatMulWithConstantTransformationTestValues> testValues = {
         { std::vector<float>(4 * 2, 2.f), ngraph::element::f32, ngraph::Shape{ 2, 4 } },
         { 256ul, {{1}, {1}, {2, 1}, {2, 1}}, {-128.f}, {127.f}, {-128.f, -12.8f}, {127.f, 12.7f} },
         { {}, {}, {} },
+        "result_result",
+        "FP32"
     },
     {
         { 1, 1, 3, 4 },
@@ -41,6 +47,8 @@ std::vector<MatMulWithConstantTransformationTestValues> testValues = {
         { std::vector<float>(4 * 2, 2.f), ngraph::element::f32, ngraph::Shape{ 2, 4 } },
         { 256ul, {{1}, {1}, {2, 1}, {2, 1}}, {-128.f}, {127.f}, {-128.f, -12.8f}, {127.f, 12.7f} },
         { {}, {}, {} },
+        "matMul",
+        "U8"
     },
     {
         { 1, 1, 3, 4 },
@@ -48,6 +56,8 @@ std::vector<MatMulWithConstantTransformationTestValues> testValues = {
         { std::vector<float>(4 * 2, 2.f), ngraph::element::i8, ngraph::Shape{ 2, 4 } },
         {},
         { ngraph::element::f32, {}, {{0.1f, 0.01}, ngraph::element::f32, ngraph::Shape{ 2, 1 }} },
+        "matMul",
+        "U8"
     },
     {
         { 1, 3, 4 },
@@ -55,6 +65,8 @@ std::vector<MatMulWithConstantTransformationTestValues> testValues = {
         { std::vector<float>(4 * 4, 2.f), ngraph::element::f32, ngraph::Shape{ 4, 4 } },
         { 256ul, {{1}, {1}, {1}, {1}}, {-128.f}, {127.f}, {-128.f}, {127.f} },
         { {}, {}, {} },
+        "result_result",
+        "FP32"
     },
     {
         { 2, 3 },
@@ -62,6 +74,8 @@ std::vector<MatMulWithConstantTransformationTestValues> testValues = {
         { std::vector<float>{1, 2, 3, 4, 5, 6}, ngraph::element::f32, ngraph::Shape{ 2, 3 } },
         { 256ul, {{1}, {1}, {1}, {1}}, {-128.f}, {127.f}, {-12.8f}, {12.7f} },
         { {}, {}, {} },
+        "matMul",
+        "U8"
     },
     {
         { 2, 3 },

--- a/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/src/mat_mul_function.cpp
+++ b/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/src/mat_mul_function.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -327,7 +327,9 @@ std::shared_ptr<ngraph::Function> MatMulFunction::getOriginal(
         true);
     matMul->set_friendly_name("matMul");
 
-    const auto result = std::make_shared<ngraph::opset1::Result>(matMul);
+    const std::shared_ptr<ngraph::opset1::Result> result = std::make_shared<ngraph::opset1::Result>(matMul);
+    result->set_friendly_name("result");
+
     std::shared_ptr<ngraph::Function> function = std::make_shared<ngraph::Function>(
         ngraph::ResultVector{ result },
         std::vector<std::shared_ptr<ngraph::op::Parameter>> { input },


### PR DESCRIPTION
### Details:
 - LPT transformation API extending: 3D tensor support disabling

### Tickets:
 - [will be updated]

### Validation:
- accuracy:
   - TGLU: developer-services/job/accuracy/1381/ (developer-services/job/accuracy/1386/)
   - CPU: developer-services/job/accuracy/1383/
- performance:
   - TGLU: developer-services/job/performance/712/ (reference: developer-services/job/performance/715/)
   - CPU: developer-services/job/performance/713/

