### PR TITLE
Catch std::except in fuzz tests

### DIFF
--- a/tests/fuzz/src/read_network-fuzzer.cc
+++ b/tests/fuzz/src/read_network-fuzzer.cc
@@ -38,7 +38,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     try {
         InferenceEngine::Core ie;
         InferenceEngine::CNNNetwork network = ie.ReadNetwork(net, weights_blob);
-    } catch (const InferenceEngine::details::InferenceEngineException& error) {
+    } catch (const std::exception&) {
         return 0;  // fail gracefully on expected exceptions
     }
 


### PR DESCRIPTION
Fuzz tests must catch all expected exceptions from IE. IE is using the std
library which may raise standard exceptions which IE passes through.