### PR TITLE
[GNA] Move weights transposition from NCHW to NHWC to GNA pass after FQ passes

### DIFF
--- a/inference-engine/src/gna_plugin/gna_plugin.cpp
+++ b/inference-engine/src/gna_plugin/gna_plugin.cpp
@@ -38,6 +38,7 @@
 #include "runtime/gna_float_runtime.hpp"
 #include <layers/gna_fake_quantize_layer.hpp>
 #include "gna_graph_patterns.hpp"
+#include "gna_tensor_tools.hpp"
 
 #include <ngraph/pass/manager.hpp>
 #include <legacy/convert_function_to_cnn_network.hpp>
@@ -497,59 +498,7 @@ bool GNAPlugin::TryToInitOutput(int portId, InferenceEngine::CNNLayerPtr layer) 
     return false;
 }
 
-static void TransposeTensorFromNCHWToNHWC(size_t precision, size_t rows, size_t columns, uint8_t* buffer, bool transpose_rows,
-                                          const std::vector<TranspositionInfo> &transpositionInfo) {
-    size_t weightsTotalSize = rows * columns * precision;
-    std::vector<uint8_t> transposedWeights(weightsTotalSize);
-    size_t weightsPartOffset = 0;
-    bool transposed = false;
-    for (const auto &transpositionInfoPart : transpositionInfo) {
-        auto partSize = transpositionInfoPart.num_transpose_rows * transpositionInfoPart.num_transpose_columns;
-        size_t weightsPartSize = partSize * precision * (transpose_rows ? rows : columns);
-        if (transpositionInfoPart.transpose &&
-            transpositionInfoPart.num_transpose_rows != 1 &&
-            transpositionInfoPart.num_transpose_columns != 1) {
-            if (transpose_rows) {
-                for (int weightsRowIx = 0; weightsRowIx < rows; ++weightsRowIx) {
-                    auto weightsRowsOffset = weightsRowIx * partSize * precision;
-                    auto cbuffer = buffer + weightsPartOffset + weightsRowsOffset;
-                    auto weights_ptr = transposedWeights.data() + weightsPartOffset + weightsRowsOffset;
-                    for (int colsIx = 0; colsIx < transpositionInfoPart.num_transpose_columns; ++colsIx) {
-                        for (int rowIx = 0; rowIx < transpositionInfoPart.num_transpose_rows; ++rowIx) {
-                            auto offsetWrite = (colsIx * transpositionInfoPart.num_transpose_rows + rowIx) * precision;
-                            auto offsetRead = (transpositionInfoPart.num_transpose_columns * rowIx + colsIx) * precision;
-                            ie_memcpy(weights_ptr + offsetWrite, weightsPartSize - weightsRowsOffset - offsetWrite,
-                                cbuffer + offsetRead, precision);
-                        }
-                    }
-                }
-            } else {
-                auto cbuffer = buffer + weightsPartOffset;
-                auto weights_ptr = transposedWeights.data() + weightsPartOffset;
-                for (int colsIx = 0; colsIx < transpositionInfoPart.num_transpose_columns; ++colsIx) {
-                    for (int rowIx = 0; rowIx < transpositionInfoPart.num_transpose_rows; ++rowIx) {
-                        auto offsetWrite = (colsIx * transpositionInfoPart.num_transpose_rows + rowIx) * columns * precision;
-                        auto offsetRead = (transpositionInfoPart.num_transpose_columns * rowIx + colsIx) * columns * precision;
-                        ie_memcpy(weights_ptr + offsetWrite, weightsPartSize - offsetWrite, cbuffer + offsetRead, columns * precision);
-                    }
-                }
-            }
-            transposed = true;
-        } else {
-            // Just copy data which should not be transposed
-            ie_memcpy(transposedWeights.data() + weightsPartOffset,
-                      weightsPartSize,
-                      buffer + weightsPartOffset,
-                      weightsPartSize);
-        }
-        weightsPartOffset += weightsPartSize;
-    }
-    if (transposed) {
-        ie_memcpy(buffer, weightsTotalSize, transposedWeights.data(), weightsTotalSize);
-    }
-}
-
-void GNAPlugin::ConvertModelLayoutFromNCHWToNHWC(const std::vector<CNNLayerPtr> &layers) {
+void GNAPlugin::FillInputsAndOutputsTranspositionInfo(const InferenceEngine::CNNNetwork& net) {
     auto printTranspositionInfo = [](const std::vector<TranspositionInfo> &transpositionInfo) {
         for (const auto &transpositionInfoPart : transpositionInfo) {
             gnalog() << "transpose=" << transpositionInfoPart.transpose << " rows_num=" << transpositionInfoPart.num_transpose_rows
@@ -557,134 +506,35 @@ void GNAPlugin::ConvertModelLayoutFromNCHWToNHWC(const std::vector<CNNLayerPtr> 
         }
     };
 
-    auto foundPartToTranspose = [](const std::vector<TranspositionInfo> &transpositionInfo) {
-        auto partToTranspose = std::find_if(std::begin(transpositionInfo), std::end(transpositionInfo),
-            [](const TranspositionInfo &infoPart) { return infoPart.transpose; });
-        return partToTranspose != std::end(transpositionInfo);
-    };
-
-    for (auto& l : layers) {
+    auto inputLayers = CNNNetGetAllInputLayers(net);
+    for (const auto& inputLayer : inputLayers) {
         // Collect information for inputs transposition
-        if (LayerInfo(l).isInput()) {
-            auto transpositionInfo = FindTranspositionInfoFromNextLayers(l);
-            if (!transpositionInfo.empty()) {
-                transpose_inputs_info.insert({l->name, transpositionInfo});
-                gnalog() << "Input " << l->name << " transposition info: \n";
-                printTranspositionInfo(transpositionInfo);
-            }
-        }
+        if (!LayerInfo(inputLayer).isInput()) continue;
+        auto transpositionInfo = FindTranspositionInfoFromNextLayers(inputLayer);
+        if (transpositionInfo.empty()) continue;
 
+        transpose_inputs_info.insert({inputLayer->name, transpositionInfo});
+        gnalog() << "Input " << inputLayer->name << " transposition info: \n";
+        printTranspositionInfo(transpositionInfo);
+    }
+
+    auto outputsMap = net.getOutputsInfo();
+    for (const auto& outPort : outputsMap) {
+        auto outLayer = getCreatorLayer(outPort.second).lock();
         // Collect information for outputs transposition
-        if (LayerInfo(l).isOutput()) {
-            auto transpositionInfo = FindTranspositionInfoFromPrevLayers(l);
-            if (!transpositionInfo.empty()) {
-                // Swap transposition info rows and columns since we need to transpose output back from NHWC to NCHW
-                for (auto && transpositionInfoPart : transpositionInfo) {
-                    if (transpositionInfoPart.transpose) {
-                        std::swap(transpositionInfoPart.num_transpose_rows, transpositionInfoPart.num_transpose_columns);
-                    }
-                }
-                transpose_outputs_info.insert({l->name, transpositionInfo});
-                gnalog() << "Output " << l->name << " transposition info: \n";
-                printTranspositionInfo(transpositionInfo);
-            }
-        }
+        if (!LayerInfo(outLayer).isOutput()) continue;
+        auto transpositionInfo = FindTranspositionInfoFromPrevLayers(outLayer);
+        if (transpositionInfo.empty()) continue;
 
-        // Transpose weights
-        if (LayerInfo(l).isScaleShift()) {
-            std::vector<TranspositionInfo> transpositionInfo;
-            // Try to find a convolution in previous layers
-            if (InferenceEngine::CNNNetHasPrevLayer(l.get())) {
-                transpositionInfo = FindTranspositionInfoFromPrevLayers(InferenceEngine::CNNNetPrevLayer(l));
-                // If no convolutions are found try to find them in next layers
-                if (!foundPartToTranspose(transpositionInfo) && !l->outData.empty() && !getInputTo(l->outData[0]).empty()) {
-                    transpositionInfo = FindTranspositionInfoFromNextLayers(getInputTo(l->outData[0]).begin()->second);
-                }
-            }
-            if (!transpositionInfo.empty()) {
-                auto weightable = dynamic_cast<WeightableLayer*>(l.get());
-                IE_ASSERT(weightable != nullptr);
-                TransposeTensorFromNCHWToNHWC(weightable->precision.size(), 1, weightable->_weights->size(),
-                    weightable->_weights->cbuffer().as<uint8_t*>(), true, transpositionInfo);
-                if (weightable->_biases) {
-                    TransposeTensorFromNCHWToNHWC(weightable->precision.size(), 1, weightable->_biases->size(),
-                        weightable->_biases->cbuffer().as<uint8_t*>(), true, transpositionInfo);
-                }
-                gnalog() << l->name << " weights and biases rows transposition info:\n";
-                printTranspositionInfo(transpositionInfo);
+        // Swap transposition info rows and columns since we need to transpose output back from NHWC to NCHW
+        for (auto && transpositionInfoPart : transpositionInfo) {
+            if (transpositionInfoPart.transpose) {
+                std::swap(transpositionInfoPart.num_transpose_rows, transpositionInfoPart.num_transpose_columns);
             }
         }
-
-        if (LayerInfo(l).isFullyConnected()) {
-            auto weightable = dynamic_cast<WeightableLayer*>(l.get());
-            IE_ASSERT(weightable != nullptr);
-            auto precision = weightable->precision.size();
-            auto out_dims = l->outData[0]->getDims();
-            auto in_dims = l->input()->getDims();
-            auto weightsRows = InferenceEngine::details::product(std::begin(out_dims) + 1, std::end(out_dims));
-            auto weightsColumns = InferenceEngine::details::product(std::begin(in_dims) + 1, std::end(in_dims));
-            // Find a convolution in previous layers to rotate weights rows
-            if (InferenceEngine::CNNNetHasPrevLayer(l.get())) {
-                auto transpositionInfo = FindTranspositionInfoFromPrevLayers(InferenceEngine::CNNNetPrevLayer(l));
-                if (!transpositionInfo.empty()) {
-                    size_t totalColumns = 0;
-                    for (auto && transpositionInfoPart : transpositionInfo) {
-                        totalColumns += transpositionInfoPart.num_transpose_rows * transpositionInfoPart.num_transpose_columns;
-                    }
-                    if (weightsColumns != totalColumns) {
-                        THROW_GNA_EXCEPTION << l->name << " weights columns from transposition info (" << totalColumns
-                                            << ") don't match input dimensions (" << weightsColumns << ")";
-                    }
-                    TransposeTensorFromNCHWToNHWC(precision, weightsRows, weightsColumns, weightable->_weights->cbuffer().as<uint8_t*>(),
-                                                  true, transpositionInfo);
-                    gnalog() << l->name << " weights rows transposition info:\n";
-                    printTranspositionInfo(transpositionInfo);
-                }
-            }
-            // Find a convolution in next layers to rotate weights columns
-            if (!l->outData.empty() && !getInputTo(l->outData[0]).empty()) {
-                auto transpositionInfo = FindTranspositionInfoFromNextLayers(getInputTo(l->outData[0]).begin()->second);
-                if (!transpositionInfo.empty()) {
-                    size_t totalRows = 0;
-                    for (const auto& transpositionInfoPart : transpositionInfo) {
-                        totalRows += transpositionInfoPart.num_transpose_rows * transpositionInfoPart.num_transpose_columns;
-                    }
-                    if (weightsRows != totalRows) {
-                        THROW_GNA_EXCEPTION << l->name << "weights rows from transposition info (" << totalRows
-                                            << ") don't match output dimensions (" << weightsRows << ")";
-                    }
-                    TransposeTensorFromNCHWToNHWC(precision, weightsRows, weightsColumns, weightable->_weights->cbuffer().as<uint8_t*>(),
-                                                  false, transpositionInfo);
-                    gnalog() << l->name << " weights columns transposition info:\n";
-                    printTranspositionInfo(transpositionInfo);
-                }
-            }
-        }
-
-        if (LayerInfo(l).isEltwise()) {
-            // We need to transpose a constant which is an eltwise input
-            auto firstInput = InferenceEngine::CNNNetPrevLayer(l, 0);
-            auto secondInput = InferenceEngine::CNNNetPrevLayer(l, 1);
-            if (!LayerInfo(firstInput).isConst() && !LayerInfo(secondInput).isConst()) {
-                continue;
-            }
-            // Let a constant to be the second input
-            if (LayerInfo(firstInput).isConst()) {
-                std::swap(firstInput, secondInput);
-            }
-            // Find a convolution in previous or next layers
-            auto transpositionInfo = FindTranspositionInfoFromPrevLayers(firstInput);
-            if (!foundPartToTranspose(transpositionInfo) && !l->outData.empty() && !getInputTo(l->outData[0]).empty()) {
-                transpositionInfo = FindTranspositionInfoFromNextLayers(getInputTo(l->outData[0]).begin()->second);
-            }
-            if (!transpositionInfo.empty()) {
-                auto blob = secondInput->blobs["custom"];
-                TransposeTensorFromNCHWToNHWC(blob->getTensorDesc().getPrecision().size(), 1, blob->size(),
-                                              blob->buffer().as<uint8_t*>(), true, transpositionInfo);
-                gnalog() << l->name << " data transposition info:\n";
-                printTranspositionInfo(transpositionInfo);
-            }
-        }
+        transpose_outputs_info.insert({outLayer->name, transpositionInfo});
+        gnalog() << "Output " << outLayer->name << " transposition info: \n";
+        printTranspositionInfo(transpositionInfo);
     }
 }
 
@@ -795,9 +645,8 @@ void GNAPlugin::LoadNetwork(CNNNetwork & _network) {
     UpdateGnaQuantModeFromNetwork(network);
     UpdateInputScaleFromNetwork(network);
 
-    auto layers = details::CNNNetSortTopologically(network);
-    if (MustBeConvertedFromNCHWToNHWC(layers)) {
-        ConvertModelLayoutFromNCHWToNHWC(layers);
+    if (MustBeConvertedFromNCHWToNHWC(details::CNNNetSortTopologically(network))) {
+        FillInputsAndOutputsTranspositionInfo(network);
     }
 
     // network optimisation phases
@@ -814,6 +663,8 @@ void GNAPlugin::LoadNetwork(CNNNetwork & _network) {
         // fake quantisation aware passes
         passes->registerPass<FuseFQIntoWeightsPass>();
         passes->registerPass<MoveFakeQuantizeLayerIntoQuantParamsPass>();
+
+        passes->registerPass<TransposeWeightsFromNCHWToNHWCPass>();
 
         passes->registerPass<SubstitutePReluPass>();
         passes->registerPass<SubstituteSoftSignPass>();
@@ -1338,7 +1189,7 @@ uint32_t GNAPlugin::QueueInference(const InferenceEngine::BlobMap &inputs, Infer
                                     << ") do not match input buffer length of " << elementsPerBatch;
             }
             auto input_ptr = reinterpret_cast<uint8_t *>(inputsDesc->getPtrInputsGlobal(input.first)[idx]);
-            TransposeTensorFromNCHWToNHWC(gnadevice ? 2 : 4, batchSize, elementsPerBatch, input_ptr, true, transpose_info->second);
+            ConvertTensorFromNCHWToNHWC(gnadevice ? 2 : 4, batchSize, elementsPerBatch, input_ptr, true, transpose_info->second);
         }
         ++inputNum;
     }
@@ -1440,12 +1291,12 @@ GnaWaitStatus GNAPlugin::WaitFor(uint32_t request_idx, int64_t millisTimeout) {
                 THROW_GNA_EXCEPTION << "Transposed data size (" << transposed_data_size
                                     << ") do not match output buffer length of " << elementsPerBatch;
             }
-            TransposeTensorFromNCHWToNHWC(outputDesc.num_bytes_per_element,
-                                            batchSize,
-                                            elementsPerBatch,
-                                            reinterpret_cast<uint8_t*>(outputDesc.ptrs[request_idx]),
-                                            true,
-                                            transpose_output_info->second);
+            ConvertTensorFromNCHWToNHWC(outputDesc.num_bytes_per_element,
+                                        batchSize,
+                                        elementsPerBatch,
+                                        reinterpret_cast<uint8_t*>(outputDesc.ptrs[request_idx]),
+                                        true,
+                                        transpose_output_info->second);
         }
 
         ExportScores(outputBlob->buffer(),

--- a/inference-engine/src/gna_plugin/gna_plugin.hpp
+++ b/inference-engine/src/gna_plugin/gna_plugin.hpp
@@ -232,12 +232,11 @@ class GNAPlugin : public InferenceEngine::IInferencePlugin {
     bool TryToInitOutput(int portId, InferenceEngine::CNNLayerPtr layer);
 
     /**
-     * @brief Converts a model from NCHW to NHWC. It fills inputs and outputs transposition info and
-     *        changes weights order for affine, eltwise and scaleshift layers. Information for transposition
-     *        is found from convolution/pooling input or output dimensions.
+     * @brief Fills inputs and outputs transposition info for model convertion from NCHW to NHWC.
+     *        Information for transposition is found from convolution/pooling input or output dimensions.
      * @param layers model sorted layers
      */
-    void ConvertModelLayoutFromNCHWToNHWC(const std::vector<InferenceEngine::CNNLayerPtr> &layers);
+    void FillInputsAndOutputsTranspositionInfo(const InferenceEngine::CNNNetwork& net);
 #ifdef PLOT
     void AddDebugProperties(const InferenceEngine::CNNLayerPtr layer,
         InferenceEngine::ordered_properties& printed_properties,

--- a/inference-engine/src/gna_plugin/gna_tensor_tools.hpp
+++ b/inference-engine/src/gna_plugin/gna_tensor_tools.hpp
@@ -1,0 +1,82 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <ie_memcpy.h>
+#include "gna_data_types.hpp"
+
+namespace GNAPluginNS {
+
+/**
+ * @brief convert a tensor or its parts from NCHW to NHWC order on the base of transposition information.
+ * The tensor to be converted from NCHW to NHWC may be 2D. But we may need to change data order inside one of its dimensions since
+ * its data is reshaped to/from 4D data used by convolution. TranspositionInfo contains number of rows (corresponds to C dimension)
+ * and columns (corresponds to HW dimensions) of every part of the tensor which should or shouldn't be transposed (for example if output
+ * of some convolution layer is concatenated with output of another convolution layer and there is a fully connected layer after that,
+ * we need to transpose its weights parts corresponding to different convolutions outputs separately).
+ * If the tensor is input, output data, scaleshift weights or a constant input of eltwise, it's rows number is equal to 1 and its columns number
+ * is equal to the product of input dimensions (N * C * H * W). The row (or its separate parts) should be transposed.
+ * If the tensor is fully connected layer weights, it's rows number is equal to the product of input dimensions and it's columns number is
+ * equal to the product of output dimensions. Every row of this tensor (or its separate parts) should be transposed if there are convolution
+ * layers before this layer. Every column (or its separate parts) should be transposed if there are convolution layers after this layer.
+ * @param precision data precision
+ * @param rows number of rows in the whole tensor
+ * @param columns number of columns in the whole tensor
+ * @param buffer pointer to a tensor buffer
+ * @param transpose_rows flag indicated if tensor rows or tensor columns must be transposed
+ * @param transpositionInfo vector of structures with information about transposition: every element contains information about tensor
+ * part which should be transposed separately or shouldn't be transposed
+ */
+inline void ConvertTensorFromNCHWToNHWC(size_t precision, size_t rows, size_t columns, uint8_t* buffer, bool transpose_rows,
+                                        const std::vector<TranspositionInfo> &transpositionInfo) {
+    size_t weightsTotalSize = rows * columns * precision;
+    std::vector<uint8_t> transposedWeights(weightsTotalSize);
+    size_t weightsPartOffset = 0;
+    bool transposed = false;
+    for (const auto &transpositionInfoPart : transpositionInfo) {
+        auto partSize = transpositionInfoPart.num_transpose_rows * transpositionInfoPart.num_transpose_columns;
+        size_t weightsPartSize = partSize * precision * (transpose_rows ? rows : columns);
+        if (transpositionInfoPart.transpose &&
+            transpositionInfoPart.num_transpose_rows != 1 &&
+            transpositionInfoPart.num_transpose_columns != 1) {
+            if (transpose_rows) {
+                for (int weightsRowIx = 0; weightsRowIx < rows; ++weightsRowIx) {
+                    auto weightsRowsOffset = weightsRowIx * partSize * precision;
+                    auto cbuffer = buffer + weightsPartOffset + weightsRowsOffset;
+                    auto weights_ptr = transposedWeights.data() + weightsPartOffset + weightsRowsOffset;
+                    for (int colsIx = 0; colsIx < transpositionInfoPart.num_transpose_columns; ++colsIx) {
+                        for (int rowIx = 0; rowIx < transpositionInfoPart.num_transpose_rows; ++rowIx) {
+                            auto offsetWrite = (colsIx * transpositionInfoPart.num_transpose_rows + rowIx) * precision;
+                            auto offsetRead = (transpositionInfoPart.num_transpose_columns * rowIx + colsIx) * precision;
+                            ie_memcpy(weights_ptr + offsetWrite, weightsPartSize - weightsRowsOffset - offsetWrite,
+                                cbuffer + offsetRead, precision);
+                        }
+                    }
+                }
+            } else {
+                auto cbuffer = buffer + weightsPartOffset;
+                auto weights_ptr = transposedWeights.data() + weightsPartOffset;
+                for (int colsIx = 0; colsIx < transpositionInfoPart.num_transpose_columns; ++colsIx) {
+                    for (int rowIx = 0; rowIx < transpositionInfoPart.num_transpose_rows; ++rowIx) {
+                        auto offsetWrite = (colsIx * transpositionInfoPart.num_transpose_rows + rowIx) * columns * precision;
+                        auto offsetRead = (transpositionInfoPart.num_transpose_columns * rowIx + colsIx) * columns * precision;
+                        ie_memcpy(weights_ptr + offsetWrite, weightsPartSize - offsetWrite, cbuffer + offsetRead, columns * precision);
+                    }
+                }
+            }
+            transposed = true;
+        } else {
+            // Just copy data which should not be transposed
+            ie_memcpy(transposedWeights.data() + weightsPartOffset,
+                      weightsPartSize,
+                      buffer + weightsPartOffset,
+                      weightsPartSize);
+        }
+        weightsPartOffset += weightsPartSize;
+    }
+    if (transposed) {
+        ie_memcpy(buffer, weightsTotalSize, transposedWeights.data(), weightsTotalSize);
+    }
+}
+
+} // namespace GNAPluginNS

--- a/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.hpp
+++ b/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.hpp
@@ -209,6 +209,13 @@ DECL_PASS(FuseFQIntoWeights);
 */
 DECL_PASS(MoveFakeQuantizeLayerIntoQuantParams);
 
+/**
+* @brief convert FullyConnected, ScaleShift and Eltwise layers weights order from NCHW to NHWC.
+* Information for transposition is found from convolution/pooling input or output dimensions.
+* Convolution weights are transposed in finalizeConvolution1DPrimitive() method (gna_graph_compiler.cpp).
+* They are transposed for the both, NCHW and NHWC models since MO always stores them in NCHW layout.
+*/
+DECL_PASS(TransposeWeightsFromNCHWToNHWC);
 
 struct PassManagerSettings {
     Policy policy;

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/fq_conv_fq_affine.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/fq_conv_fq_affine.cpp
@@ -1,0 +1,59 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+#include <gna/gna_config.hpp>
+
+#include "subgraph_tests/fq_conv_fq_affine.hpp"
+#include "common_test_utils/test_constants.hpp"
+
+using namespace SubgraphTestsDefinitions;
+
+namespace {
+
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+        InferenceEngine::Precision::FP32, InferenceEngine::Precision::FP16,
+};
+
+const std::vector<std::map<std::string, std::string>> configs = {
+        {{"GNA_DEVICE_MODE", "GNA_SW_FP32"}},
+        {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}}
+};
+
+const std::vector<std::vector<size_t>> inputShapes = {
+        {1, 1024}
+};
+
+const std::vector<size_t> levels = {65535, 65535};
+
+const std::vector<std::vector<float>> inputParams = {{-0.2, 0.2, 0.01}};
+
+const auto fqParams = ::testing::Combine(
+        ::testing::Values(levels),
+        ::testing::ValuesIn(inputParams)
+);
+
+const std::vector<std::vector<size_t>> kernels = {{1, 3}};
+const std::vector<std::vector<size_t>> strides = {{1, 1}};
+const std::vector<size_t> inputChannels = {8};
+const std::vector<size_t> outputChannels {4};
+
+const auto convParams = ::testing::Combine(
+        ::testing::ValuesIn(kernels),
+        ::testing::ValuesIn(strides),
+        ::testing::ValuesIn(inputChannels),
+        ::testing::ValuesIn(outputChannels)
+);
+
+INSTANTIATE_TEST_CASE_P(smoke_FqConvFqAffineTest, FqConvFqAffineTest,
+                        ::testing::Combine(
+                                fqParams,
+                                convParams,
+                                ::testing::ValuesIn(netPrecisions),
+                                ::testing::ValuesIn(inputShapes),
+                                ::testing::Values(CommonTestUtils::DEVICE_GNA),
+                                ::testing::ValuesIn(configs)),
+                        FqConvFqAffineTest::getTestCaseName);
+
+}  // namespace

--- a/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/fq_conv_fq_affine.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/fq_conv_fq_affine.hpp
@@ -1,0 +1,15 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "shared_test_classes/subgraph/fq_conv_fq_affine.hpp"
+
+namespace SubgraphTestsDefinitions {
+
+TEST_P(FqConvFqAffineTest, CompareWithRefs) {
+    Run();
+}
+
+}  // namespace SubgraphTestsDefinitions

--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/fq_conv_fq_affine.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/fq_conv_fq_affine.hpp
@@ -1,0 +1,55 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <vector>
+#include <string>
+#include <memory>
+
+#include "shared_test_classes/base/layer_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+namespace SubgraphTestsDefinitions {
+
+typedef std::tuple<
+        std::vector<size_t>,              // levels
+        std::vector<float>                // input generator data: low, high, resolution
+> FqSpecificParams;
+
+typedef std::tuple<
+        std::vector<size_t>,                 // Kernel Shape
+        std::vector<size_t>,                 // Strides
+        size_t,                              // Input channels
+        size_t                               // Output channels
+> ConvParams;
+
+typedef std::tuple<
+        FqSpecificParams,
+        ConvParams,
+        InferenceEngine::Precision,        // Net precision
+        InferenceEngine::SizeVector,       // Input shapes
+        LayerTestsUtils::TargetDevice,     // Device name
+        std::map<std::string, std::string> // Additional backend configuration and alis name to it
+> FqConvFqAffineTestParamsSet;
+
+class FqConvFqAffineTest : public testing::WithParamInterface<FqConvFqAffineTestParamsSet>,
+                           virtual public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<FqConvFqAffineTestParamsSet> obj);
+
+protected:
+    void SetUp() override;
+    InferenceEngine::Blob::Ptr GenerateInput(const InferenceEngine::InputInfo &info) const override;
+
+protected:
+    float inputDataMin        = 0.0;
+    float inputDataMax        = 10.0;
+    float inputDataResolution = 1.0;
+    int32_t  seed = 1;
+};
+
+}  // namespace SubgraphTestsDefinitions

--- a/inference-engine/tests/functional/shared_test_classes/src/subgraph/fq_conv_fq_affine.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/subgraph/fq_conv_fq_affine.cpp
@@ -1,0 +1,122 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/subgraph/fq_conv_fq_affine.hpp"
+
+namespace SubgraphTestsDefinitions {
+
+std::string FqConvFqAffineTest::getTestCaseName(testing::TestParamInfo<FqConvFqAffineTestParamsSet> obj) {
+    FqSpecificParams fqParams;
+    ConvParams convParams;
+    InferenceEngine::Precision netPrecision;
+    InferenceEngine::SizeVector inputShapes;
+    std::string targetDevice;
+    std::map<std::string, std::string> config;
+    std::tie(fqParams, convParams, netPrecision, inputShapes, targetDevice, config) = obj.param;
+
+    std::vector<size_t> levels;
+    std::vector<float> inputArg;
+    std::tie(levels, inputArg) = fqParams;
+
+    std::vector<size_t> kernelShape;
+    std::vector<size_t> strides;
+    size_t inputChannels;
+    size_t outputChannels;
+    std::tie(kernelShape, strides, inputChannels, outputChannels) = convParams;
+
+    std::ostringstream result;
+    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "LEVELS=" << CommonTestUtils::vec2str(levels) << "_";
+    result << "netPRC=" << netPrecision.name() << "_";
+    result << "trgDev=" << targetDevice;
+    for (auto const& configItem : config) {
+        result << "_configItem=" << configItem.first << "_" << configItem.second;
+    }
+     if (inputArg.size() == 3) {
+        result << "_inputArg=" << inputArg[0] << "_" << inputArg[1] << "_" << inputArg[2];
+    }
+    result << "_KERNEL=" << CommonTestUtils::vec2str(kernelShape) << "_";
+    result << "STRIDES=" << CommonTestUtils::vec2str(strides) << "_";
+    result << "IC=" << inputChannels << "_";
+    result << "OC=" << outputChannels;
+    return result.str();
+}
+
+void FqConvFqAffineTest::SetUp() {
+    FqSpecificParams fqParams;
+    ConvParams convParams;
+    std::vector<size_t> inputShape;
+    std::map<std::string, std::string> config;
+    auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
+    std::tie(fqParams, convParams, netPrecision, inputShape, targetDevice, config) = this->GetParam();
+    configuration.insert(config.begin(), config.end());
+
+    std::vector<size_t> levels;
+    std::vector<float> inputArg;
+    std::tie(levels, inputArg) = fqParams;
+    if (inputArg.size() == 3) {
+        inputDataMin = inputArg[0];
+        inputDataMax = inputArg[1];
+        inputDataResolution = inputArg[2];
+    }
+
+    std::vector<size_t> kernelShape;
+    std::vector<size_t> strides;
+    size_t inputChannels;
+    size_t outputChannels;
+    std::tie(kernelShape, strides, inputChannels, outputChannels) = convParams;
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+
+    auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
+
+    const int seed = 0;
+    std::mt19937 gen(static_cast<float>(seed));
+
+    auto inputFQNode = ngraph::builder::makeFakeQuantize(params[0], ngraph::element::f32, levels[0], std::vector<size_t>{},
+        { inputDataMin }, { inputDataMax }, { inputDataMin }, { inputDataMax });
+    auto inputFQ = std::dynamic_pointer_cast<ngraph::opset1::FakeQuantize>(inputFQNode);
+
+    std::vector<size_t> convInputShape = {1, inputChannels, 1, inputShape[0] * inputShape[1] / inputChannels};
+    auto reshapePattern1 = std::make_shared<ngraph::opset1::Constant>(ngraph::element::Type_t::i64, ngraph::Shape{ 4 }, convInputShape);
+    auto reshape1 = std::make_shared<ngraph::opset1::Reshape>(inputFQ, reshapePattern1, false);
+
+    auto filterWeightsNode = ngraph::builder::makeConstant<float>(ngPrc, {outputChannels, inputChannels, kernelShape[0], kernelShape[1]},
+                                                                  { 1.0f });
+
+    auto convLowNode = ngraph::builder::makeConstant(ngraph::element::f32, std::vector<size_t>{ 1 }, std::vector<float>{inputDataMin});
+    auto convHighNode = ngraph::builder::makeConstant(ngraph::element::f32, std::vector<size_t>{ 1 }, std::vector<float>{inputDataMax});
+    auto convWeightsFQNode = std::make_shared<ngraph::opset1::FakeQuantize>(filterWeightsNode,
+        convLowNode, convHighNode, convLowNode, convHighNode, levels[1]);
+    auto convWeightsFQ = std::dynamic_pointer_cast<ngraph::opset1::FakeQuantize>(convWeightsFQNode);
+
+    auto conv = std::make_shared<ngraph::opset1::Convolution>(reshape1, convWeightsFQ, strides, std::vector<ptrdiff_t>{ 0, 0 },
+                                                              std::vector<ptrdiff_t>{ 0, 0 }, std::vector<size_t>{ 1, 1 },
+                                                              ngraph::op::PadType::VALID);
+    auto biasesWeightsNode = ngraph::builder::makeConstant(ngPrc, {}, std::vector<float>{ 0.0f });
+    auto add = std::make_shared<ngraph::opset1::Add>(conv, biasesWeightsNode);
+
+    auto widthAfterConv = (convInputShape[3] - kernelShape[1]) / strides[1] + 1;
+    auto heightAfterConv = (convInputShape[2] - kernelShape[0]) / strides[0] + 1;
+    std::vector<size_t> outFormShapes = {1,  outputChannels * widthAfterConv * heightAfterConv };
+
+    auto reshapePattern2 = std::make_shared<ngraph::opset1::Constant>(ngraph::element::Type_t::i64, ngraph::Shape{ 2 }, outFormShapes);
+    auto reshape2 = std::make_shared<ngraph::opset1::Reshape>(add, reshapePattern2, false);
+
+    auto matMulWeightsNode = ngraph::builder::makeConstant<float>(ngPrc, {outFormShapes[1], outFormShapes[1]}, { 1.0f });
+    auto matMulLowNode = ngraph::builder::makeConstant(ngraph::element::f32, std::vector<size_t>{ 1 }, std::vector<float>{inputDataMin});
+    auto matMulHighNode = ngraph::builder::makeConstant(ngraph::element::f32, std::vector<size_t>{ 1 }, std::vector<float>{inputDataMax});
+    auto matMulWeightsFQNode = std::make_shared<ngraph::opset1::FakeQuantize>(matMulWeightsNode,
+        matMulLowNode, matMulHighNode, matMulLowNode, matMulHighNode, levels[1]);
+    auto matMulWeightsFQ = std::dynamic_pointer_cast<ngraph::opset1::FakeQuantize>(matMulWeightsFQNode);
+
+    auto matmul = std::make_shared<ngraph::opset1::MatMul>(reshape2, matMulWeightsFQ, false, true);
+
+    function = std::make_shared<ngraph::Function>(matmul, params, "fqConvfqAffine");
+}
+
+InferenceEngine::Blob::Ptr FqConvFqAffineTest::GenerateInput(const InferenceEngine::InputInfo &info) const {
+    return FuncTestUtils::createAndFillBlob(info.getTensorDesc(), inputDataMax - inputDataMin, inputDataMin, 1 / inputDataResolution,
+                                            seed);
+}
+}  // namespace SubgraphTestsDefinitions


### PR DESCRIPTION
### Details:
 - Currently weights transposition is performed before GNA passes, if the model contains fake quantizes for weighted layers their weights will be kept in additional constants but not in CNN layer data structure. This transformation should be done after the pass which fuses quantized weights with their layer structure.

### Tickets:
- 49993
