### PR TITLE
Corrected PyYAML dependency (#4598)

### DIFF
--- a/inference-engine/ie_bridges/python/wheel/meta/openvino-dev.requirements.txt
+++ b/inference-engine/ie_bridges/python/wheel/meta/openvino-dev.requirements.txt
@@ -9,7 +9,7 @@ networkx==2.2
 tqdm==4.31.1
 texttable==1.6.3
 py-cpuinfo!=5.0,!=6.0
-PyYAML>=5.4.2
+PyYAML>=5.4.1
 pillow>=8.1.0
 scikit-image
 scikit-learn


### PR DESCRIPTION
### Details:
5.4.2 is absent on PyPI changed to the 5.4.1

### Tickets:
50491
