### PR TITLE
Python 3.8 support

### DIFF
--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/__init__.py
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/__init__.py
@@ -19,20 +19,18 @@ import os
 import sys
 
 if sys.platform == "win32":
-    # Installer, yum, pip installs openvino dlls to the different directory
-    # and this path needs to be visible to the openvino modules
+    # Installer, yum, pip installs openvino dlls to the different directories
+    # and those paths need to be visible to the openvino modules
     #
     # If you're using a custom installation of openvino,
     # add the location of openvino dlls to your system PATH.
-    openvino_libs = [
-            '../../../../deployment_tools/inference_engine/bin/intel64/Release',
-            '../../../../deployment_tools/inference_engine/bin/intel64/Debug',
-            '../../../../deployment_tools/inference_engine/external/hddl/bin',
-            '../../../../deployment_tools/inference_engine/external/gna/lib',
-            '../../../../deployment_tools/inference_engine/external/tbb/bin',
-            '../../../../deployment_tools/ngraph/lib',
-            '../../openvino/libs',  # pip specific directory
-        ]
+    #
+    # looking for the libs in the pip installation path by default.
+    openvino_libs = [os.path.join(os.path.dirname(__file__), '..', '..', 'openvino', 'libs')]
+    # setupvars.bat script set all libs paths to OPENVINO_LIB_PATHS environment variable.
+    openvino_libs_installer = os.getenv('OPENVINO_LIB_PATHS')
+    if openvino_libs_installer:
+        openvino_libs.extend(openvino_libs_installer.split(';'))
     for lib in openvino_libs:
         lib_path = os.path.join(os.path.dirname(__file__), lib)
         if os.path.isdir(lib_path):

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/__init__.py
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/__init__.py
@@ -19,17 +19,28 @@ import os
 import sys
 
 if sys.platform == "win32":
-    # PIP installs openvino dlls 3 directories above in openvino.libs by default
+    # Installer, yum, pip installs openvino dlls to the different directory
     # and this path needs to be visible to the openvino modules
     #
     # If you're using a custom installation of openvino,
     # add the location of openvino dlls to your system PATH.
-    openvino_dlls = os.path.join(os.path.dirname(__file__), "..", "..", "openvino", "libs")
-    if (3, 8) <= sys.version_info:
-        # On Windows, with Python >= 3.8, DLLs are no longer imported from the PATH.
-        os.add_dll_directory(os.path.abspath(openvino_dlls))
-    else:
-        os.environ["PATH"] = os.path.abspath(openvino_dlls) + ";" + os.environ["PATH"]
+    openvino_libs = [
+            '../../../../deployment_tools/inference_engine/bin/intel64/Release',
+            '../../../../deployment_tools/inference_engine/bin/intel64/Debug',
+            '../../../../deployment_tools/inference_engine/external/hddl/bin',
+            '../../../../deployment_tools/inference_engine/external/gna/lib',
+            '../../../../deployment_tools/inference_engine/external/tbb/bin',
+            '../../../../deployment_tools/ngraph/lib',
+            '../../openvino/libs',  # pip specific directory
+        ]
+    for lib in openvino_libs:
+        lib_path = os.path.join(os.path.dirname(__file__), lib)
+        if os.path.isdir(lib_path):
+            # On Windows, with Python >= 3.8, DLLs are no longer imported from the PATH.
+            if (3, 8) <= sys.version_info:
+                os.add_dll_directory(os.path.abspath(lib_path))
+            else:
+                os.environ["PATH"] = os.path.abspath(lib_path) + ";" + os.environ["PATH"]
 
 from .ie_api import *
 __all__ = ['IENetwork', "TensorDesc", "IECore", "Blob", "PreProcessInfo", "get_version"]

--- a/inference-engine/ie_bridges/python/src/openvino/offline_transformations/__init__.py
+++ b/inference-engine/ie_bridges/python/src/openvino/offline_transformations/__init__.py
@@ -4,17 +4,28 @@ import os
 import sys
 
 if sys.platform == "win32":
-    # PIP installs openvino dlls 3 directories above in openvino.libs by default
+    # Installer, yum, pip installs openvino dlls to the different directory
     # and this path needs to be visible to the openvino modules
     #
     # If you're using a custom installation of openvino,
     # add the location of openvino dlls to your system PATH.
-    openvino_dlls = os.path.join(os.path.dirname(__file__), "..", "..", "openvino", "libs")
-    if (3, 8) <= sys.version_info:
-        # On Windows, with Python >= 3.8, DLLs are no longer imported from the PATH.
-        os.add_dll_directory(os.path.abspath(openvino_dlls))
-    else:
-        os.environ["PATH"] = os.path.abspath(openvino_dlls) + ";" + os.environ["PATH"]
+    openvino_libs = [
+            '../../../../deployment_tools/inference_engine/bin/intel64/Release',
+            '../../../../deployment_tools/inference_engine/bin/intel64/Debug',
+            '../../../../deployment_tools/inference_engine/external/hddl/bin',
+            '../../../../deployment_tools/inference_engine/external/gna/lib',
+            '../../../../deployment_tools/inference_engine/external/tbb/bin',
+            '../../../../deployment_tools/ngraph/lib',
+            '../../openvino/libs',  # pip specific directory
+        ]
+    for lib in openvino_libs:
+        lib_path = os.path.join(os.path.dirname(__file__), lib)
+        if os.path.isdir(lib_path):
+            # On Windows, with Python >= 3.8, DLLs are no longer imported from the PATH.
+            if (3, 8) <= sys.version_info:
+                os.add_dll_directory(os.path.abspath(lib_path))
+            else:
+                os.environ["PATH"] = os.path.abspath(lib_path) + ";" + os.environ["PATH"]
 
 from .offline_transformations_api import *
 __all__ = ['ApplyMOCTransformations']

--- a/inference-engine/ie_bridges/python/src/openvino/offline_transformations/__init__.py
+++ b/inference-engine/ie_bridges/python/src/openvino/offline_transformations/__init__.py
@@ -4,20 +4,18 @@ import os
 import sys
 
 if sys.platform == "win32":
-    # Installer, yum, pip installs openvino dlls to the different directory
-    # and this path needs to be visible to the openvino modules
+    # Installer, yum, pip installs openvino dlls to the different directories
+    # and those paths need to be visible to the openvino modules
     #
     # If you're using a custom installation of openvino,
     # add the location of openvino dlls to your system PATH.
-    openvino_libs = [
-            '../../../../deployment_tools/inference_engine/bin/intel64/Release',
-            '../../../../deployment_tools/inference_engine/bin/intel64/Debug',
-            '../../../../deployment_tools/inference_engine/external/hddl/bin',
-            '../../../../deployment_tools/inference_engine/external/gna/lib',
-            '../../../../deployment_tools/inference_engine/external/tbb/bin',
-            '../../../../deployment_tools/ngraph/lib',
-            '../../openvino/libs',  # pip specific directory
-        ]
+    #
+    # looking for the libs in the pip installation path by default.
+    openvino_libs = [os.path.join(os.path.dirname(__file__), '..', '..', 'openvino', 'libs')]
+    # setupvars.bat script set all libs paths to OPENVINO_LIB_PATHS environment variable.
+    openvino_libs_installer = os.getenv('OPENVINO_LIB_PATHS')
+    if openvino_libs_installer:
+        openvino_libs.extend(openvino_libs_installer.split(';'))
     for lib in openvino_libs:
         lib_path = os.path.join(os.path.dirname(__file__), lib)
         if os.path.isdir(lib_path):

--- a/ngraph/python/src/ngraph/impl/__init__.py
+++ b/ngraph/python/src/ngraph/impl/__init__.py
@@ -24,23 +24,24 @@ import os
 import sys
 
 if sys.platform == "win32":
-    # ngraph.dll is installed 3 directories above by default
-    # and this path needs to be visible to the _pyngraph module
+    # Installer, yum, pip installs openvino dlls to the different directory
+    # and this path needs to be visible to the openvino modules
     #
-    ngraph_dll = os.path.join(os.path.dirname(__file__), "..", "..", "..")
-
-    # PIP installs openvino and ngraph dlls 2 directories above in openvino.libs by default
-    # and this path needs to be visible to the _pyngraph modules
-    #
-    openvino_dlls = os.path.join(os.path.dirname(__file__), "..", "..", "openvino", "libs")
     # If you're using a custom installation of openvino,
     # add the location of openvino dlls to your system PATH.
-    if (3, 8) <= sys.version_info:
-        # On Windows, with Python >= 3.8, DLLs are no longer imported from the PATH.
-        os.add_dll_directory(os.path.abspath(ngraph_dll))
-        os.add_dll_directory(os.path.abspath(openvino_dlls))
-    else:
-        os.environ["PATH"] = os.path.abspath(openvino_dlls) + ";" + os.path.abspath(ngraph_dll) + ";" + os.environ["PATH"]
+    openvino_libs = [
+            '../../..',
+            '../../../../deployment_tools/ngraph/lib',  # installer, yum specific directory
+            '../../openvino/libs',  # pip specific directory
+        ]
+    for lib in openvino_libs:
+        lib_path = os.path.join(os.path.dirname(__file__), lib)
+        if os.path.isdir(lib_path):
+            # On Windows, with Python >= 3.8, DLLs are no longer imported from the PATH.
+            if (3, 8) <= sys.version_info:
+                os.add_dll_directory(os.path.abspath(lib_path))
+            else:
+                os.environ["PATH"] = os.path.abspath(lib_path) + ";" + os.environ["PATH"]
 
 from _pyngraph import Dimension
 from _pyngraph import Function

--- a/ngraph/python/src/ngraph/impl/__init__.py
+++ b/ngraph/python/src/ngraph/impl/__init__.py
@@ -24,16 +24,19 @@ import os
 import sys
 
 if sys.platform == "win32":
-    # Installer, yum, pip installs openvino dlls to the different directory
-    # and this path needs to be visible to the openvino modules
+    # Installer, yum, pip installs openvino dlls to the different directories
+    # and those paths need to be visible to the openvino modules
     #
     # If you're using a custom installation of openvino,
     # add the location of openvino dlls to your system PATH.
-    openvino_libs = [
-            '../../..',
-            '../../../../deployment_tools/ngraph/lib',  # installer, yum specific directory
-            '../../openvino/libs',  # pip specific directory
-        ]
+    #
+    # looking for the libs in the pip installation path by default.
+    openvino_libs = [os.path.join(os.path.dirname(__file__), '..', '..', '..'),
+                     os.path.join(os.path.dirname(__file__), '..', '..', 'openvino', 'libs')]
+    # setupvars.bat script set all libs paths to OPENVINO_LIB_PATHS environment variable.
+    openvino_libs_installer = os.getenv('OPENVINO_LIB_PATHS')
+    if openvino_libs_installer:
+        openvino_libs.extend(openvino_libs_installer.split(';'))
     for lib in openvino_libs:
         lib_path = os.path.join(os.path.dirname(__file__), lib)
         if os.path.isdir(lib_path):

--- a/scripts/setupvars/setupvars.bat
+++ b/scripts/setupvars/setupvars.bat
@@ -55,7 +55,7 @@ set "HDDL_INSTALL_DIR=%INTEL_OPENVINO_DIR%\deployment_tools\inference_engine\ext
 set "OPENMP_DIR=%INTEL_OPENVINO_DIR%\deployment_tools\inference_engine\external\omp\lib"
 set "GNA_DIR=%INTEL_OPENVINO_DIR%\deployment_tools\inference_engine\external\gna\lib"
 
-set "PATH=%INTEL_OPENVINO_DIR%\deployment_tools\inference_engine\bin\intel64\Release;%INTEL_OPENVINO_DIR%\deployment_tools\inference_engine\bin\intel64\Debug;%HDDL_INSTALL_DIR%\bin;%OPENMP_DIR%;%GNA_DIR%;%PATH%"
+set "OPENVINO_LIB_PATHS=%INTEL_OPENVINO_DIR%\deployment_tools\inference_engine\bin\intel64\Release;%INTEL_OPENVINO_DIR%\deployment_tools\inference_engine\bin\intel64\Debug;%HDDL_INSTALL_DIR%\bin;%OPENMP_DIR%;%GNA_DIR%;%OPENVINO_LIB_PATHS%"
 if exist %INTEL_OPENVINO_DIR%\deployment_tools\inference_engine\bin\intel64\arch_descriptions (
 set ARCH_ROOT_DIR=%INTEL_OPENVINO_DIR%\deployment_tools\inference_engine\bin\intel64\arch_descriptions
 )
@@ -65,15 +65,18 @@ set ARCH_ROOT_DIR=%INTEL_OPENVINO_DIR%\deployment_tools\inference_engine\bin\int
 
 :: TBB
 if exist %INTEL_OPENVINO_DIR%\deployment_tools\inference_engine\external\tbb (
-set "PATH=%INTEL_OPENVINO_DIR%\deployment_tools\inference_engine\external\tbb\bin;%PATH%"
+set "OPENVINO_LIB_PATHS=%INTEL_OPENVINO_DIR%\deployment_tools\inference_engine\external\tbb\bin;%OPENVINO_LIB_PATHS%"
 set "TBB_DIR=%INTEL_OPENVINO_DIR%\deployment_tools\inference_engine\external\tbb\cmake"
 )
 
 :: nGraph
 if exist %INTEL_OPENVINO_DIR%\deployment_tools\ngraph (
-set "PATH=%INTEL_OPENVINO_DIR%\deployment_tools\ngraph\lib;%PATH%"
+set "OPENVINO_LIB_PATHS=%INTEL_OPENVINO_DIR%\deployment_tools\ngraph\lib;%OPENVINO_LIB_PATHS%"
 set "ngraph_DIR=%INTEL_OPENVINO_DIR%\deployment_tools\ngraph\cmake"
 )
+
+:: Add libs dirs to the PATH
+set "PATH=%OPENVINO_LIB_PATHS%;%PATH%"
 
 :: Check if Python is installed
 python --version 2>NUL


### PR DESCRIPTION
### Details:
On Windows, with Python >= 3.8, DLLs are no longer imported from the PATH.

Potential conflicts:
1. Installed the version from PyPI and version from installer:
    - run setupvars.bat: modules and libs from the installer should be used (pip version will be ignored)
    - doesn't run setupvars.bat: modules and libs from the pip should be used (installer's version will be ignored)

### Tickets:
48177
OpenCV will be fixed separately (51531)