### PR TITLE
Fix for MKLDNN constant layers execution

### DIFF
--- a/inference-engine/src/mkldnn_plugin/mkldnn_edge.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_edge.cpp
@@ -169,9 +169,9 @@ void MKLDNNEdge::allocate(const void* mem_ptr) {
 }
 
 std::string MKLDNNEdge::name() const {
-    auto childPtr = getChild();
     auto parentPtr = getParent();
-    return childPtr->getName() + "<->" + parentPtr->getName();
+    auto childPtr = getChild();
+    return parentPtr->getName() + std::to_string(parent_port) + "<->" + childPtr->getName() + std::to_string(child_port);
 }
 
 void MKLDNNEdge::externalAllocate(MKLDNNWeightsSharing::Ptr weightsCache) {

--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph.cpp
@@ -67,6 +67,8 @@ using namespace InferenceEngine::details;
 typedef std::unordered_set<MKLDNNEdgePtr> edge_cluster_t;
 typedef std::vector<edge_cluster_t> edge_clusters_t;
 
+mkldnn::engine MKLDNNGraph::eng(mkldnn::engine::kind::cpu, 0);
+
 template<typename NET>
 void MKLDNNGraph::ApplyUnrollPasses(NET &net) {
     OV_ITT_SCOPED_TASK(itt::domains::MKLDNNPlugin, "MKLDNNGraph::ApplyUnrollPasses");

--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph.h
@@ -30,7 +30,7 @@ public:
         Ready = 1,
     };
 
-    MKLDNNGraph(mkldnn::engine eng = mkldnn::engine(mkldnn::engine::kind::cpu, 0)) : status(NotReady), eng(eng) {}
+    MKLDNNGraph() = default;
 
     Status GetStatus() {
         return status;
@@ -172,7 +172,7 @@ protected:
         graphEdges.clear();
         _meanImages.clear();
     }
-    Status status;
+    Status status { NotReady };
     Config config;
 
     // For dumping purposes. -1 - no counting, all other positive
@@ -191,7 +191,7 @@ protected:
     std::map<std::string, MeanImage> _meanImages;
     std::string _name;
 
-    mkldnn::engine eng;
+    static mkldnn::engine eng;
 
     void Replicate(const InferenceEngine::CNNNetwork &network, const MKLDNNExtensionManager::Ptr& extMgr);
     void Replicate(const InferenceEngine::TensorIterator::Body &subgraph, const MKLDNNExtensionManager::Ptr& extMgr);

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_tensoriterator_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_tensoriterator_node.cpp
@@ -187,8 +187,7 @@ private:
 }  // namespace MKLDNNPlugin
 
 MKLDNNTensorIteratorNode::MKLDNNTensorIteratorNode(InferenceEngine::CNNLayerPtr layer, const mkldnn::engine& eng, MKLDNNWeightsSharing::Ptr &cache) :
-        MKLDNNNode(layer, eng, cache),
-        sub_graph(eng) {}
+        MKLDNNNode(layer, eng, cache) {}
 
 void MKLDNNTensorIteratorNode::getSupportedDescriptors() {
     auto *ti = dynamic_cast<class InferenceEngine::TensorIterator*>(getCnnLayer().get());


### PR DESCRIPTION
### Details:
 - Single mkldnn::engine is used for all MKLDNN graphs
 - Fix for MKLDNN constant layers execution

### Tickets:
 - CVS-50538
