### PR TITLE
Add workaround for control edges to support TF 2.4 Keras RNN layers

### DIFF
--- a/model-optimizer/extensions/front/tf/while_ext.py
+++ b/model-optimizer/extensions/front/tf/while_ext.py
@@ -51,6 +51,12 @@ def update_body_graph(body_graph: Graph, subgraph_proto: dict,
         # add incoming edges based on data_nodes_map
         for dst_port, inp in enumerate(pb_node.input):
             orig_src_id = inp.split(":")[0]
+
+            # TODO: avoid this temporal workaround for TF 2.4 or higher RNN layers:
+            #  skip control flow dependency
+            if orig_src_id[0] == '^':
+                continue
+
             src_id = map_original_name[orig_src_id]
             src_port = 0 if len(inp.split(":")) == 1 else int(inp.split(":")[-1])
             assert (body_graph.has_node(src_id))


### PR DESCRIPTION
Description: Since TF 2.4 body graph of the while loop starts to contain control edges inside that we can not support properly by the MO tool, so we have to add this workaround to skip control edges inside the body graph. Now tests for TF2 Keras RNN layers generated using TF 2.4 or higher pass.

Ticket: 50500


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR - N/A
* [x]  Transformation preserves original framework node names - N/A


Validation:
* [x]  Unit tests - TF2.4 Keras RNN layer tests pass
* [x]  Framework operation tests - TF2.4 Keras RNN layer tests pass
* [x]  Transformation tests - N/A
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list
* [x]  Guide on how to convert the **public** model - N/A
* [x]  User guide update
