### PR TITLE
Change is to == to avoid warning

### DIFF
--- a/model-optimizer/mo/main.py
+++ b/model-optimizer/mo/main.py
@@ -86,7 +86,7 @@ def print_argv(argv: argparse.Namespace, is_caffe: bool, is_tf: bool, is_mxnet: 
             if isinstance(desc, list):
                 lines.append('\t{}: \t{}'.format(desc[0], desc[1](getattr(argv, op, 'NONE'))))
             else:
-                if op is 'k':
+                if op == 'k':
                     default_path = os.path.join(os.path.dirname(sys.argv[0]),
                                                 'extensions/front/caffe/CustomLayersMapping.xml')
                     if getattr(argv, op, 'NONE') == default_path:


### PR DESCRIPTION
### Details:
Use of `is` to compare a literal and a variable at https://github.com/openvinotoolkit/openvino/blob/7f8d3aa63899a3e3362c95eb7d1b04a5899660bd/model-optimizer/mo/main.py#L89 leads to the following warning:
```
C:\Program Files (x86)\Intel\openvino_2021\deployment_tools\model_optimizer\mo\main.py:85: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if op is 'k':
```
As the operator overloads to `==` in this case, this fix should simply remove the warning without changing any behavior.

### Tickets:
 - https://github.com/openvinotoolkit/openvino/issues/4673
