### PR TITLE
[LPT] ConvolutionTransformation: shape normalize of dequantization constant after convolution

### DIFF
--- a/inference-engine/src/low_precision_transformations/include/low_precision/network_helper.hpp
+++ b/inference-engine/src/low_precision_transformations/include/low_precision/network_helper.hpp
@@ -136,6 +136,8 @@ public:
 
     static FakeQuantizeDequantization normalizeDequantization(FakeQuantizeDequantization dequantization);
 
+    static std::shared_ptr<opset1::Constant> normalizeDequantizationShape(const std::shared_ptr<Node>& eltwise);
+
     // 1. remove Convert if possible
     // 2. optimize Constant if possible
     // 3. remove Subtract if Constant on the second branch is zero

--- a/inference-engine/src/low_precision_transformations/src/convolution.cpp
+++ b/inference-engine/src/low_precision_transformations/src/convolution.cpp
@@ -278,6 +278,9 @@ bool ConvolutionTransformation::transform(TransformationContext &context, ngraph
     ngraph::copy_runtime_info({ convolution, finalDequantization }, finalDequantization);
     updateOutput(context, finalDequantization, convolution);
 
+    // [C, 1, 1] -> [1, C, 1, 1]
+    NetworkHelper::normalizeDequantizationShape(finalDequantization);
+
     auto onWeights = convolution->get_input_node_shared_ptr(1);
     if (is_type<opset1::Reshape>(onWeights)) {
         onWeights = onWeights->get_input_node_shared_ptr(0);

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/convolution_qdq_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/convolution_qdq_transformation.cpp
@@ -79,6 +79,7 @@ public:
             testValues.expected.dequantizationAfter);
     }
 
+
     static std::string getTestCaseName(testing::TestParamInfo<ConvolutionQDqTransformationParams> obj) {
         auto inputShape = std::get<0>(obj.param);
         ConvolutionQDqTransformationTestValues testValues = std::get<1>(obj.param);
@@ -174,7 +175,7 @@ const std::vector<ConvolutionQDqTransformationTestValues> testValues = {
             { std::vector<float>{ 100.f }, ngraph::element::i8},
             {},
             ngraph::element::f32,
-            {{}, {}, {{ 0.0006f }, ngraph::element::f32, {1}}}
+            {{}, {}, {{ 0.0006f }, ngraph::element::f32, {1, 1, 1, 1}}}
         }
     },
 
@@ -226,7 +227,7 @@ const std::vector<ConvolutionQDqTransformationTestValues> testValues = {
             { std::vector<float>{ -125.f }, ngraph::element::i8},
             {},
             ngraph::element::f32,
-            {{}, {}, {{ 0.0002f }, ngraph::element::f32, { 1, 1, 1 }}}
+            {{}, {}, {{ 0.0002f }, ngraph::element::f32, { 1, 1, 1, 1 }}}
         }
     },
 
@@ -333,7 +334,7 @@ const std::vector<ConvolutionQDqTransformationTestValues> testValues = {
             { std::vector<float>{ 2.f }, ngraph::element::i8},
             {},
             ngraph::element::f32,
-            {{}, {}, {{ 0.0006f }, ngraph::element::f32, { 1 }}}
+            {{}, {}, {{ 0.0006f }, ngraph::element::f32, { 1, 1, 1, 1 }}}
         }
     },
 
@@ -401,7 +402,7 @@ const std::vector<ConvolutionQDqTransformationTestValues> testValues = {
             { std::vector<float>{ 2.f }, ngraph::element::i8},
             {},
             ngraph::element::f32,
-            {{}, {}, {{ 0.0006f }, ngraph::element::f32, { 1 }}}
+            {{}, {}, {{ 0.0006f }, ngraph::element::f32, { 1, 1, 1, 1 }}}
         }
     }
 };

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/convolution_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/convolution_transformation.cpp
@@ -143,7 +143,7 @@ const std::vector<ConvolutionTransformationTestValues> testValues = {
             op::Constant::create(ngraph::element::i8, ngraph::Shape{}, std::vector<float>{ -125.f }),
             {},
             ngraph::element::f32,
-            {{}, {}, {{ 0.0002f }, ngraph::element::f32, { 1, 1, 1 }}}
+            {{}, {}, {{ 0.0002f }, ngraph::element::f32, { 1, 1, 1, 1 }}}
         }
     },
     // with zero point
@@ -183,7 +183,7 @@ const std::vector<ConvolutionTransformationTestValues> testValues = {
             op::Constant::create(ngraph::element::f32, ngraph::Shape{}, std::vector<float>{ -125.f }),
             {},
             ngraph::element::f32,
-            {{}, {}, {{ 0.0002f }, ngraph::element::f32, { 1, 1, 1 }}}
+            {{}, {}, {{ 0.0002f }, ngraph::element::f32, { 1, 1, 1, 1 }}}
         }
     },
     // without zero point
@@ -203,7 +203,7 @@ const std::vector<ConvolutionTransformationTestValues> testValues = {
             op::Constant::create(ngraph::element::i8, ngraph::Shape{}, std::vector<float>{ -125.f }),
             {},
             ngraph::element::f32,
-            {{}, {}, {{ 0.0002f }, ngraph::element::f32, { 1, 1, 1 }}}
+            {{}, {}, {{ 0.0002f }, ngraph::element::f32, { 1, 1, 1, 1 }}}
         }
     },
     // without zero point
@@ -223,7 +223,7 @@ const std::vector<ConvolutionTransformationTestValues> testValues = {
             op::Constant::create(ngraph::element::i8, ngraph::Shape{}, std::vector<float>{ -125.f }),
             {},
             ngraph::element::f32,
-            {{}, {}, {{ 0.0002f }, ngraph::element::f32, { 1, 1, 1 }}}
+            {{}, {}, {{ 0.0002f }, ngraph::element::f32, { 1, 1, 1, 1 }}}
         }
     },
     // without zero point, not update precisions
@@ -243,7 +243,7 @@ const std::vector<ConvolutionTransformationTestValues> testValues = {
             op::Constant::create(ngraph::element::f32, ngraph::Shape{}, std::vector<float>{ -125.f }),
             {},
             ngraph::element::f32,
-            {{}, {}, {{ 0.0002f }, ngraph::element::f32, { 1, 1, 1 }}}
+            {{}, {}, {{ 0.0002f }, ngraph::element::f32, { 1, 1, 1, 1 }}}
         }
     },
     // with zero point, per-channel quantization with the same values
@@ -263,7 +263,7 @@ const std::vector<ConvolutionTransformationTestValues> testValues = {
             op::Constant::create(ngraph::element::i8, ngraph::Shape{}, std::vector<float>{ -125.f }),
             {},
             ngraph::element::f32,
-            {{}, {}, {{ 0.0002f }, ngraph::element::f32, { 1, 1, 1 }}}
+            {{}, {}, {{ 0.0002f }, ngraph::element::f32, { 1, 1, 1, 1 }}}
         }
     },
     // with zero point, per-channel quantization with different values
@@ -379,7 +379,7 @@ const std::vector<ConvolutionTransformationTestValues> testValues = {
             op::Constant::create(ngraph::element::i8, ngraph::Shape{}, std::vector<float>{ -125.f }),
             {},
             ngraph::element::f32,
-            {{}, {}, {{ 0.0002f }, ngraph::element::f32, { 1, 1, 1 }}}
+            {{}, {}, {{ 0.0002f }, ngraph::element::f32, { 1, 1, 1, 1 }}}
         }
     },
 };

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/convolution_with_incorrect_weights.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/convolution_with_incorrect_weights.cpp
@@ -125,7 +125,7 @@ const std::vector<ConvolutionWIthIncorrectWeightsTestValues> testValues = {
             {},
             ngraph::element::i8,
             {-126.f},
-            {{}, {}, {{ 0.1f }, ngraph::element::f32, { 1, 1, 1 }}},
+            {{}, {}, {{ 0.1f }, ngraph::element::f32, { 1, 1, 1, 1 }}},
         },
     },
 };

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/fake_quantize_and_two_output_branches_with_convolution.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/fake_quantize_and_two_output_branches_with_convolution.cpp
@@ -130,9 +130,9 @@ const std::vector<FakeQuantizeAndTwoOutputBranchesWithConvolutionTestValues> fak
             {{}, {}, {}},
             ngraph::element::f32,
             { 255ul, {1, 1, 1, 1}, { 0.f }, { 254.f }, { -127.f }, { 127.f } },
-            {{}, {}, {{ 1.f }, ngraph::element::f32, { 1, 1, 1 }}},
+            {{}, {}, {{ 1.f }, ngraph::element::f32, { 1, 1, 1, 1 }}},
             { 255ul, {1, 1, 1, 1}, { 0.f }, { 254.f }, { -127.f }, { 127.f } },
-            {{}, {}, {{ 1.f }, ngraph::element::f32, { 1, 1, 1 }}},
+            {{}, {}, {{ 1.f }, ngraph::element::f32, { 1, 1, 1, 1 }}},
         }
     },
     // not update precisions
@@ -149,9 +149,9 @@ const std::vector<FakeQuantizeAndTwoOutputBranchesWithConvolutionTestValues> fak
             {{}, {}, {}},
             ngraph::element::f32,
             { 255ul, {1, 1, 1, 1}, { 0.f }, { 254.f }, { -127.f }, { 127.f } },
-            {{}, {}, {{ 1.f }, ngraph::element::f32, { 1, 1, 1 }}},
+            {{}, {}, {{ 1.f }, ngraph::element::f32, { 1, 1, 1, 1 }}},
             { 255ul, {1, 1, 1, 1}, { 0.f }, { 254.f }, { -127.f }, { 127.f } },
-            {{}, {}, {{ 1.f }, ngraph::element::f32, { 1, 1, 1 }}},
+            {{}, {}, {{ 1.f }, ngraph::element::f32, { 1, 1, 1, 1 }}},
         }
     }
 };

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/fake_quantize_with_dq_not_optimal_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/fake_quantize_with_dq_not_optimal_transformation.cpp
@@ -194,7 +194,7 @@ const std::vector<FakeQuantizeWithNotOptimalTransformationTestValues> fakeQuanti
             {
                 { },
                 { },
-                { {0.0003f}, ngraph::element::f32, {1}}
+                { {0.0003f}, ngraph::element::f32, {1, 1, 1, 1}}
             }
         },
     }

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/group_convolution_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/group_convolution_transformation.cpp
@@ -139,7 +139,7 @@ const std::vector<GroupConvolutionTestValues> testValues = {
             {},
             {},
             ngraph::element::f32,
-            {{}, {}, {{ 0.0002f }, ngraph::element::f32, { 24, 1, 1 }}} // 0.0002 = 0.02 (on data) * 0.01 (on weights)
+            {{}, {}, {{ 0.0002f }, ngraph::element::f32, { 1, 24, 1, 1 }}} // 0.0002 = 0.02 (on data) * 0.01 (on weights)
         }
     },
     // group convolution, tensor quantization, with zero point
@@ -189,7 +189,7 @@ const std::vector<GroupConvolutionTestValues> testValues = {
             {},
             {},
             ngraph::element::f32,
-            {{}, {}, {{ 0.0002f }, ngraph::element::f32, { 24, 1, 1 }}} // 0.0002 = 0.02 (on data) * 0.01 (on weights)
+            {{}, {}, {{ 0.0002f }, ngraph::element::f32, { 1, 24, 1, 1 }}} // 0.0002 = 0.02 (on data) * 0.01 (on weights)
         }
     },
     // group convolution, per-channel quantization with different values, without zero point
@@ -230,7 +230,7 @@ const std::vector<GroupConvolutionTestValues> testValues = {
                         // 0.0008 = 0.08 (on data) * 0.01 (on weights)
                         0.0008f, 0.0008f, 0.0008f, 0.0008f, 0.0008f, 0.0008f, 0.0008f, 0.0008f
                     },
-                    ngraph::element::f32, {24, 1, 1}
+                    ngraph::element::f32, {1, 24, 1, 1}
                 }
             },
         }
@@ -264,7 +264,7 @@ const std::vector<GroupConvolutionTestValues> testValues = {
             {
                 {},
                 {},
-                {{ 0.0002f }, ngraph::element::f32, {24, 1, 1}}
+                {{ 0.0002f }, ngraph::element::f32, {1, 24, 1, 1}}
             },
         }
     },
@@ -315,7 +315,7 @@ const std::vector<GroupConvolutionTestValues> testValues = {
             {},
             {},
             ngraph::element::f32,
-            {{}, {}, {{ 0.0002f }, ngraph::element::f32, { 24, 1, 1 }}}
+            {{}, {}, {{ 0.0002f }, ngraph::element::f32, { 1, 24, 1, 1 }}}
         }
     },
     // depth-wise convolution, per-tensor quantization, with zero point
@@ -340,7 +340,7 @@ const std::vector<GroupConvolutionTestValues> testValues = {
             {},
             {},
             ngraph::element::f32,
-            {{}, {}, {{ 0.0002f }, ngraph::element::f32, { 6, 1, 1 }}}
+            {{}, {}, {{ 0.0002f }, ngraph::element::f32, { 1, 6, 1, 1 }}}
         }
     },
     // depth-wise convolution, tensor quantization, with zero point
@@ -365,7 +365,7 @@ const std::vector<GroupConvolutionTestValues> testValues = {
             {},
             {},
             ngraph::element::f32,
-            {{}, {}, {{ 0.0002f }, ngraph::element::f32, { 6, 1, 1 }}}
+            {{}, {}, {{ 0.0002f }, ngraph::element::f32, { 1, 6, 1, 1 }}}
         }
     },
     // depth-wise convolution, per-channel quantization with different values, without zero point
@@ -403,7 +403,7 @@ const std::vector<GroupConvolutionTestValues> testValues = {
                         0.0004f, 0.0004f,  // 0.0004 = 0.04 (on data) * 0.01 (on weights)
                         0.0008f, 0.0008f   // 0.0008 = 0.08 (on data) * 0.01 (on weights)
                     },
-                    ngraph::element::f32, {6, 1, 1}
+                    ngraph::element::f32, {1, 6, 1, 1}
                 }
             },
         }
@@ -437,7 +437,7 @@ const std::vector<GroupConvolutionTestValues> testValues = {
             {
                 {},
                 {},
-                {{ 0.0002f }, ngraph::element::f32, {6, 1, 1}}
+                {{ 0.0002f }, ngraph::element::f32, {1, 6, 1, 1}}
             },
         }
     },
@@ -488,7 +488,7 @@ const std::vector<GroupConvolutionTestValues> testValues = {
             {},
             {},
             ngraph::element::f32,
-            {{}, {}, {{ 0.0002f }, ngraph::element::f32, { 6, 1, 1 }}}
+            {{}, {}, {{ 0.0002f }, ngraph::element::f32, { 1, 6, 1, 1 }}}
         }
     },
     // without dequantization operations
@@ -555,7 +555,7 @@ const std::vector<GroupConvolutionTestValues> testValues = {
                         // 0.0008 = 0.08 (on data) * 0.01 (on weights)
                         0.0008f, 0.0008f, 0.0008f, 0.0008f, 0.0008f, 0.0008f, 0.0008f, 0.0008f
                     },
-                    ngraph::element::f32, {24, 1, 1}
+                    ngraph::element::f32, {1, 24, 1, 1}
                 }
             },
         }
@@ -611,7 +611,7 @@ const std::vector<GroupConvolutionTestValues> testValues = {
                         // 0.0008 = 0.08 (on data) * 0.01 (on weights)
                         0.0008f, 0.0008f, 0.0008f, 0.0008f, 0.0008f, 0.0008f, 0.0008f, 0.0008f
                     },
-                    ngraph::element::f32, {24, 1, 1}
+                    ngraph::element::f32, {1, 24, 1, 1}
                 }
             },
         }

--- a/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/src/fake_quantize_precision_selection_function.cpp
+++ b/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/src/fake_quantize_precision_selection_function.cpp
@@ -149,7 +149,7 @@ std::shared_ptr<ngraph::Function> FakeQuantizePrecisionSelectionFunction::getRef
 
     std::shared_ptr<ngraph::opset1::Multiply> branch1Multiply = std::make_shared<ngraph::opset1::Multiply>(
         convolution,
-        std::make_shared<ngraph::opset1::Constant>(precision, Shape({1, 1, 1}), std::vector<float>({ 0.0001f })));
+        std::make_shared<ngraph::opset1::Constant>(precision, Shape({1, 1, 1, 1}), std::vector<float>({ 0.0001f })));
 
 
     // just another branch


### PR DESCRIPTION
Issue #50721

Validation:
• Accuracy: developer-services/job/accuracy/1456/ (reference: developer-services/job/accuracy/1455/)
• Performance: developer-services/job/performance/746/ (reference: developer-services/job/performance/745/)