### PR TITLE
Document TensorFlow 2* Update: Layers Support and Remove Beta Status

### DIFF
--- a/docs/MO_DG/prepare_model/Supported_Frameworks_Layers.md
+++ b/docs/MO_DG/prepare_model/Supported_Frameworks_Layers.md
@@ -255,6 +255,89 @@ Standard TensorFlow\* operations:
 | ZerosLike | No |
 
 
+## TensorFlow 2 Keras\* Supported Operations
+
+Standard TensorFlow 2 Keras\* operations:
+
+| Operation Name in TensorFlow 2 Keras\* | Limitations|
+| :----------| :----------|
+| ActivityRegularization | No |
+| Add | No |
+| AdditiveAttention | No |
+| AlphaDropout | No |
+| Attention | No |
+| Average | No |
+| AveragePooling1D | No |
+| AveragePooling2D | No |
+| AveragePooling3D | No |
+| BatchNormalization | No |
+| Bidirectional | No |
+| Concatenate | No |
+| Conv1D | No |
+| Conv1DTranspose | Not supported if dilation is not equal to 1 |
+| Conv2D | No |
+| Conv2DTranspose | No |
+| Conv3D | No |
+| Conv3DTranspose | No |
+| Cropping1D | No |
+| Cropping2D | No |
+| Cropping3D | No |
+| Dense | No |
+| DenseFeatures | Not supported for categorical and crossed features |
+| DepthwiseConv2D | No |
+| Dot | No |
+| Dropout | No |
+| ELU | No |
+| Embedding | No |
+| Flatten | No |
+| GRU | No |
+| GRUCell | No |
+| GaussianDropout | No |
+| GaussianNoise | No |
+| GlobalAveragePooling1D | No |
+| GlobalAveragePooling2D | No |
+| GlobalAveragePooling3D | No |
+| GlobalMaxPool1D | No |
+| GlobalMaxPool2D | No |
+| GlobalMaxPool3D | No |
+| LSTM | No |
+| LSTMCell | No |
+| Lambda | No |
+| LayerNormalization | No |
+| LeakyReLU | No |
+| LocallyConnected1D | No |
+| LocallyConnected2D | No |
+| MaxPool1D | No |
+| MaxPool2D | No |
+| MaxPool3D | No |
+| Maximum | No |
+| Minimum | No |
+| Multiply | No |
+| PReLU | No |
+| Permute | No |
+| RNN | Not supported for some custom cells |
+| ReLU | No |
+| RepeatVector | No |
+| Reshape | No |
+| SeparableConv1D | No |
+| SeparableConv2D | No |
+| SimpleRNN | No |
+| SimpleRNNCell | No |
+| Softmax | No |
+| SpatialDropout1D | No |
+| SpatialDropout2D | No |
+| SpatialDropout3D | No |
+| StackedRNNCells | No |
+| Subtract | No |
+| ThresholdedReLU | No |
+| TimeDistributed | No |
+| UpSampling1D | No |
+| UpSampling2D | No |
+| UpSampling3D | No |
+| ZeroPadding1D | No |
+| ZeroPadding2D | No |
+| ZeroPadding3D | No |
+
 ## Kaldi\* Supported Layers
 
 Standard Kaldi\* Layers:

--- a/docs/MO_DG/prepare_model/convert_model/Convert_Model_From_TensorFlow.md
+++ b/docs/MO_DG/prepare_model/convert_model/Convert_Model_From_TensorFlow.md
@@ -342,11 +342,9 @@ model = tf.keras.models.load_model('model.h5', custom_objects={'CustomLayer': Cu
 tf.saved_model.save(model,'model')
 ```
 
-Then follow the above instructions for the SavedModel format. 
+Then follow the above instructions for the SavedModel format.
 
-> **NOTE:** Do not use other hacks to resave TensorFlow* 2 models into TensorFlow* 1 formats.    
-
-> **NOTE**: Currently, OpenVINO™ support for TensorFlow* 2 models is in preview (aka Beta), which means limited and not of production quality yet. OpenVINO™ does not support models with Keras RNN and Embedding layers.
+> **NOTE:** Do not use other hacks to resave TensorFlow* 2 models into TensorFlow* 1 formats.
 
 
 ## Custom Layer Definition
@@ -360,7 +358,7 @@ See [Custom Layers in the Model Optimizer](../customize_model_optimizer/Customiz
 * Custom layer implementation details
 
 
-## Supported TensorFlow\* Layers
+## Supported TensorFlow\* and TensorFlow 2 Keras\* Layers
 Refer to [Supported Framework Layers ](../Supported_Frameworks_Layers.md) for the list of supported standard layers.
 
 


### PR DESCRIPTION
### Details:
 - List of Status Support for TensorFlow 2 Keras Layers
 - Remove Beta Status for TensorFlow 2 Support

### Ticket:
 - 43661
