### PR TITLE
Added support for attribute 'pad_to_max_dimension' for TF OD API models

### DIFF
--- a/model-optimizer/extensions/front/tf/ObjectDetectionAPI.py
+++ b/model-optimizer/extensions/front/tf/ObjectDetectionAPI.py
@@ -363,7 +363,8 @@ def skip_nodes_by_condition(current_node: Node, condition: callable):
     return current_node
 
 
-def calculate_shape_keeping_aspect_ratio(height: int, width: int, min_size: int, max_size: int):
+def calculate_shape_keeping_aspect_ratio(height: int, width: int, min_size: int, max_size: int,
+                                         pad_to_max_dimension: bool = False):
     """
     The function scales spatial sizes of the image keeping aspect ratio to satisfy provided requirements.
     The behavior of this function is equivalent to the output shape calculation of the Preprocessor block of TensorFlow
@@ -372,8 +373,11 @@ def calculate_shape_keeping_aspect_ratio(height: int, width: int, min_size: int,
     :param width: input width.
     :param min_size: size limit.
     :param max_size: size limit.
+    :param pad_to_max_dimension: scale the input image size to the maximum value specified
     :return: the tuple with scaled image height, width.
     """
+    if pad_to_max_dimension:
+        return max_size, max_size
     ratio_min = min_size / min(height, width)
     ratio_max = max_size / max(height, width)
     ratio = min(ratio_min, ratio_max)
@@ -441,6 +445,7 @@ def calculate_placeholder_spatial_shape(graph: Graph, match: SubgraphMatch, pipe
 
     # if the model is created with an input image resizer keeping aspect ratio
     if resizer_min_dimension and resizer_max_dimension:
+        pad_to_max_dimension = pipeline_config.get_param('pad_to_max_dimension')
         print('[ WARNING ] Model Optimizer removes pre-processing block of the model which resizes image keeping '
               'aspect ratio. The Inference Engine does not support dynamic image size so the Intermediate '
               'Representation file is generated with the input image size of a fixed size.')
@@ -448,7 +453,8 @@ def calculate_placeholder_spatial_shape(graph: Graph, match: SubgraphMatch, pipe
             scaled_height, scaled_width = calculate_shape_keeping_aspect_ratio(user_defined_height,
                                                                                user_defined_width,
                                                                                resizer_min_dimension,
-                                                                               resizer_max_dimension)
+                                                                               resizer_max_dimension,
+                                                                               pad_to_max_dimension)
             if scaled_height != user_defined_height or scaled_width != user_defined_width:
                 log.error('The model resizes the input image keeping aspect ratio with min dimension {}, max '
                           'dimension {}. The provided input height {}, width {} is transformed to height {}, width '
@@ -457,7 +463,10 @@ def calculate_placeholder_spatial_shape(graph: Graph, match: SubgraphMatch, pipe
             height = scaled_height
             width = scaled_width
         else:
-            height = width = resizer_min_dimension
+            if pad_to_max_dimension:
+                height = width = resizer_max_dimension
+            else:
+                height = width = resizer_min_dimension
             print('Specify the "--input_shape" command line parameter to override the default shape which is equal to '
                   '({}, {}).'.format(height, width))
 

--- a/model-optimizer/mo/utils/pipeline_config.py
+++ b/model-optimizer/mo/utils/pipeline_config.py
@@ -31,6 +31,7 @@ mapping_rules = [
     ('resizer_image_height', 'image_resizer/fixed_shape_resizer/height'),
     ('resizer_image_width', 'image_resizer/fixed_shape_resizer/width'),
     ('resizer_min_dimension', 'image_resizer/keep_aspect_ratio_resizer/min_dimension'),
+    ('resizer_max_dimension', 'image_resizer/keep_aspect_ratio_resizer/max_dimension'),
     ('pad_to_max_dimension', 'image_resizer/keep_aspect_ratio_resizer/pad_to_max_dimension', False),
     # anchor generator attributes
     ('anchor_generator_height', 'first_stage_anchor_generator/grid_anchor_generator/height$', 256),

--- a/model-optimizer/mo/utils/pipeline_config.py
+++ b/model-optimizer/mo/utils/pipeline_config.py
@@ -31,7 +31,7 @@ mapping_rules = [
     ('resizer_image_height', 'image_resizer/fixed_shape_resizer/height'),
     ('resizer_image_width', 'image_resizer/fixed_shape_resizer/width'),
     ('resizer_min_dimension', 'image_resizer/keep_aspect_ratio_resizer/min_dimension'),
-    ('resizer_max_dimension', 'image_resizer/keep_aspect_ratio_resizer/max_dimension'),
+    ('pad_to_max_dimension', 'image_resizer/keep_aspect_ratio_resizer/pad_to_max_dimension', False),
     # anchor generator attributes
     ('anchor_generator_height', 'first_stage_anchor_generator/grid_anchor_generator/height$', 256),
     ('anchor_generator_width', 'first_stage_anchor_generator/grid_anchor_generator/width$', 256),

--- a/model-optimizer/mo/utils/pipeline_config_test.py
+++ b/model-optimizer/mo/utils/pipeline_config_test.py
@@ -151,6 +151,7 @@ class TestingSimpleProtoParser(unittest.TestCase):
                            'use_matmul_crop_and_resize': False,
                            'add_background_class': True,
                            'share_box_across_classes': False,
+                           'pad_to_max_dimension': False,
                            }
         os.unlink(file_name)
         self.assertDictEqual(pipeline_config._model_params, expected_result)


### PR DESCRIPTION
Description: There is an attribute "pad_to_max_dimension" of the "preprocessor" block in the TF OD API models. This attribute was introduced recently and makes the pre-processor block of the model to reshape the input image spatial dimensions to `(max_size, max_size)` specified in the configuration file. The attribute was not taken into account in the MO so the model input shape was calculated incorrectly (the model input shape was rounded to the min_size instead which was the default behaviour).

Ticket: 50860

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR: N/A
* [x]  Transformation preserves original framework node names: N/A

Validation:
* [x]  Unit tests
* [x]  Framework operation tests: N/A no new model enabled
* [x]  Transformation tests: done
* [x]  Model Optimizer IR Reader check: Done for several TF OD API models

Documentation:
* [x]  Supported frameworks operations list: N/A
* [x]  Guide on how to convert the **public** model: done
* [x]  User guide update: done