### PR TITLE
[PyPI] remove rpath for dylib

### DIFF
--- a/inference-engine/ie_bridges/python/wheel/setup.py
+++ b/inference-engine/ie_bridges/python/wheel/setup.py
@@ -223,7 +223,7 @@ def remove_rpath(file_path):
                '|', 'cut', '-d', '" "', '-f2',
                '|', 'xargs', '-I{{}}',
                'install_name_tool', '-delete_rpath', '{{}}', f'{file_path}']
-        ret_info = subprocess.run(list(cmd.split(" ")), check=True)
+        ret_info = subprocess.run(cmd, check=True)
         if ret_info.returncode != 0:
             sys.exit(f"Could not remove rpath for {file_path}")
     else:

--- a/inference-engine/ie_bridges/python/wheel/setup.py
+++ b/inference-engine/ie_bridges/python/wheel/setup.py
@@ -217,10 +217,13 @@ def remove_rpath(file_path):
         :type file_path: pathlib.Path
     """
     if sys.platform == "darwin":
-        cmd = f'otool -l {file_path} ' \
-              f'| grep LC_RPATH -A 3 | grep -o "path.*" | cut -d \" \" -f2 ' \
-              f'| xargs -I{{}} install_name_tool -delete_rpath {{}} {file_path}'
-        ret_info = subprocess.run(cmd, shell=True, check=True)
+        cmd = ['otool', '-l', f'{file_path}',
+               '|', 'grep', 'LC_RPATH', '-A3',
+               '|', 'grep', '-o', '"path.*"',
+               '|', 'cut', '-d', '" "', '-f2',
+               '|', 'xargs', '-I{{}}',
+               'install_name_tool', '-delete_rpath', '{{}}', f'{file_path}']
+        ret_info = subprocess.run(list(cmd.split(" ")), check=True)
         if ret_info.returncode != 0:
             sys.exit(f"Could not remove rpath for {file_path}")
     else:

--- a/inference-engine/ie_bridges/python/wheel/setup.py
+++ b/inference-engine/ie_bridges/python/wheel/setup.py
@@ -217,7 +217,7 @@ def remove_rpath(file_path):
         :type file_path: pathlib.Path
     """
     if sys.platform == "darwin":
-        сmd = f'otool -l {file_path} ' \
+        cmd = f'otool -l {file_path} ' \
               f'| grep LC_RPATH -A3 ' \
               f'| grep -o "path.*" ' \
               f'| cut -d " " -f2 ' \

--- a/inference-engine/ie_bridges/python/wheel/setup.py
+++ b/inference-engine/ie_bridges/python/wheel/setup.py
@@ -217,10 +217,10 @@ def remove_rpath(file_path):
         :type file_path: pathlib.Path
     """
     if sys.platform == "darwin":
-        cmd = [f'otool -l {file_path}',
-               f'| grep LC_RPATH -A 3 | grep -o "path.*" | cut -d \" \" -f2',
-               f'| xargs -I{{}} install_name_tool -delete_rpath {{}} {file_path}']
-        ret_info = subprocess.run(cmd, check=True)
+        cmd = f'otool -l {file_path} ' \
+              f'| grep LC_RPATH -A 3 | grep -o "path.*" | cut -d \" \" -f2 ' \
+              f'| xargs -I{{}} install_name_tool -delete_rpath {{}} {file_path}'
+        ret_info = subprocess.run(cmd, shell=True, check=True)
         if ret_info.returncode != 0:
             sys.exit(f"Could not remove rpath for {file_path}")
     else:

--- a/inference-engine/ie_bridges/python/wheel/setup.py
+++ b/inference-engine/ie_bridges/python/wheel/setup.py
@@ -210,6 +210,23 @@ def is_tool(name):
     return True
 
 
+def remove_rpath(file_path):
+    """
+        Remove rpath from binaries
+        :param file_path: binary path
+        :type file_path: pathlib.Path
+    """
+    if sys.platform == "darwin":
+        cmd = [f'otool -l {file_path}',
+               f'| grep LC_RPATH -A 3 | grep -o "path.*" | cut -d \" \" -f2',
+               f'| xargs -I{{}} install_name_tool -delete_rpath {{}} {file_path}']
+        ret_info = subprocess.run(cmd, check=True)
+        if ret_info.returncode != 0:
+            sys.exit(f"Could not remove rpath for {file_path}")
+    else:
+        sys.exit(f"Unsupported platform: {sys.platform}")
+
+
 def set_rpath(rpath, executable):
     """Setting rpath for linux and macOS libraries"""
     print(f"Setting rpath {rpath} for {executable}")
@@ -225,6 +242,8 @@ def set_rpath(rpath, executable):
         sys.exit(f"Unsupported platform: {sys.platform}")
 
     if is_tool(rpath_tool):
+        if sys.platform == "darwin":
+            remove_rpath(executable)
         ret_info = subprocess.run(cmd, check=True)
         if ret_info.returncode != 0:
             sys.exit(f"Could not set rpath: {rpath} for {executable}")

--- a/inference-engine/ie_bridges/python/wheel/setup.py
+++ b/inference-engine/ie_bridges/python/wheel/setup.py
@@ -217,14 +217,12 @@ def remove_rpath(file_path):
         :type file_path: pathlib.Path
     """
     if sys.platform == "darwin":
-        cmd = ['otool', '-l', f'{file_path}',
-               '|', 'grep', 'LC_RPATH', '-A3',
-               '|', 'grep', '-o', '"path.*"',
-               '|', 'cut', '-d', '" "', '-f2',
-               '|', 'xargs', '-I{{}}',
-               'install_name_tool', '-delete_rpath', '{{}}', f'{file_path}']
-        ret_info = subprocess.run(cmd, check=True)
-        if ret_info.returncode != 0:
+        сmd = f'otool -l {file_path} ' \
+              f'| grep LC_RPATH -A3 ' \
+              f'| grep -o "path.*" ' \
+              f'| cut -d " " -f2 ' \
+              f'| xargs -I{{}} install_name_tool -delete_rpath {{}} {file_path}'
+        if os.WEXITSTATUS(os.system(cmd)) != 0:
             sys.exit(f"Could not remove rpath for {file_path}")
     else:
         sys.exit(f"Unsupported platform: {sys.platform}")


### PR DESCRIPTION
### Details:
install_name_tool -add_rpath throws an error if the same rpath already has been set, we need to remove it
