### PR TITLE
Deprecated IE::Parameter <-> ngraph::Variant

### DIFF
--- a/docs/IE_DG/API_Changes.md
+++ b/docs/IE_DG/API_Changes.md
@@ -2,6 +2,15 @@
 
 The sections below contain detailed list of changes made to the Inference Engine API in recent releases.
 
+## 2021.4
+
+### Deprecated API
+
+ * InferenceEngine::Parameter(const std::shared_ptr<ngraph::Variant>&)
+ * InferenceEngine::Parameter(std::shared_ptr<ngraph::Variant>& var)
+ * std::shared_ptr<ngraph::Variant> InferenceEngine::Parameter::asVariant() const
+ * InferenceEngine::Parameter::operator std::shared_ptr<ngraph::Variant>() const
+
 ## 2021.3
 
 ### New API

--- a/inference-engine/include/ie_parameter.hpp
+++ b/inference-engine/include/ie_parameter.hpp
@@ -51,19 +51,23 @@ public:
     }
 
     /**
+     * @deprecated Use ngraph::Variant directly
      * @brief Creates parameter from variant.
      * This method creates empty parameter if variant doesn't contain Parameter
      *
      * @param var ngraph variant
      */
+    INFERENCE_ENGINE_DEPRECATED("Use ngraph::Variant directly")
     Parameter(const std::shared_ptr<ngraph::Variant>& var);
 
     /**
+     * @deprecated Use ngraph::Variant directly
      * @brief Creates parameter from variant.
      * This method creates empty parameter if variant doesn't contain Parameter
      *
      * @param var ngraph variant
      */
+    INFERENCE_ENGINE_DEPRECATED("Use ngraph::Variant directly")
     Parameter(std::shared_ptr<ngraph::Variant>& var);
 
     /**
@@ -201,19 +205,25 @@ public:
     }
 
     /**
+     * @deprecated Use ngraph::Variant directly
      * @brief Converts parameter to shared pointer on ngraph::Variant
      *
      * @return shared pointer on ngraph::Variant
      */
+    INFERENCE_ENGINE_DEPRECATED("Use ngraph::Variant directly")
     std::shared_ptr<ngraph::Variant> asVariant() const;
 
     /**
+     * @deprecated Use ngraph::Variant directly
      * @brief Casts to shared pointer on ngraph::Variant
      *
      * @return shared pointer on ngraph::Variant
      */
+    INFERENCE_ENGINE_DEPRECATED("Use ngraph::Variant directly")
     operator std::shared_ptr<ngraph::Variant>() const {
+        IE_SUPPRESS_DEPRECATED_START
         return asVariant();
+        IE_SUPPRESS_DEPRECATED_END
     }
 
     /**


### PR DESCRIPTION
### Details:
 -It's not used.
