### PR TITLE
[GNA] [speech_sample] Fix accuracy problem when nthreads == 2

### DIFF
--- a/inference-engine/samples/speech_sample/main.cpp
+++ b/inference-engine/samples/speech_sample/main.cpp
@@ -1029,6 +1029,11 @@ int main(int argc, char *argv[]) {
                             continue;
                         }
 
+                        ptrInputBlobs.clear();
+                        for (auto& input : cInputInfo) {
+                            ptrInputBlobs.push_back(inferRequest.inferRequest.GetBlob(input.first));
+                        }
+
                         if (FLAGS_iname.empty()) {
                             size_t num_files = FLAGS_iname.empty() ? numInputArkFiles : ptrInputBlobs.size();
                             for (size_t i = 0; i < num_files; ++i) {


### PR DESCRIPTION
### Details:
Fix accuracy problem when nthreads == 2
  - breaking commit:
     https://github.com/openvinotoolkit/openvino/commit/aff7a6608286129cb7eb9019854959c0c155718e

### Tickets:
 - CVS-49036
