### PR TITLE
Disable drop excess convert+reorder optimization

### DIFF
--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph_optimizer.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph_optimizer.cpp
@@ -139,8 +139,12 @@ void MKLDNNGraphOptimizer::ApplyImplSpecificGraphOptimizations(MKLDNNGraph &grap
     DropDoubleReorders(graph);
     graph.RemoveDroppedNodes();
 
+#if 0
+    /* disable, since there is no use case for it at the moment
+     * should be enabled after ngraph migration */
     DropConvertReorder(graph);
     graph.RemoveDroppedNodes();
+#endif
 
     MergePermuteAndReorder(graph);
     graph.RemoveDroppedNodes();
@@ -1765,6 +1769,11 @@ void MKLDNNGraphOptimizer::DropConvertReorder(MKLDNNGraph& graph) {
                         if (inTD.getPrecision() == rnOutput.getPrecision() &&
                             inTD.getLayout() == rnOutput.getLayout() &&
                             inTD.getDims() == rnOutput.getDims()) {
+                            /**
+                             * TODO: just drop extra nodes instead of moving edges
+                             * graph.DropNode(convert);
+                             * graph.DropNode(reorder);
+                             */
                             auto avterReorder = reorder->getChildEdgeAt(0)->getChild();
                             auto oldEdgeNum = reorder->getChildEdgeAt(0)->getOutputNum();
                             reorder->getChildEdgeAt(0)->drop();


### PR DESCRIPTION
### Details:

- The optimization does not have a use case at the moment
since in scope of greedy mode we removed insertion of
convert/reorder after input layer.
This logic will be re-implemented after ngraph migration
and then we can bring back the optimization together with
some tests.

### Tickets:
 - CVS-48232