### PR TITLE
[IE CLDNN] Updated ocl build error message

### DIFF
--- a/inference-engine/thirdparty/clDNN/src/gpu/kernels_cache.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/kernels_cache.cpp
@@ -412,9 +412,7 @@ kernels_cache::kernels_map kernels_cache::build_program(const program_code& prog
         }
 
         if (!err_log.empty()) {
-            static const size_t max_msg_length = 128;
-            std::string short_err_log(err_log, 0, std::min(err_log.length(), max_msg_length));
-            throw std::runtime_error("Program build failed:\n" + std::move(short_err_log));
+            throw std::runtime_error("Program build failed. You may enable OCL source dump to see the error log.\n");
         }
 
         return kmap;


### PR DESCRIPTION
Get max error length from env variable so that developers can check
full error message without re-building.
