### PR TITLE
Investigate failing ExperimentalDetectron test

### DIFF
--- a/ngraph/test/runtime/ie/unit_test.manifest
+++ b/ngraph/test/runtime/ie/unit_test.manifest
@@ -1594,7 +1594,7 @@ evaluate_mvn_6_across_batch
 IE_CPU.onnx_mvn_v6
 
 # The test randomly fails in CI (MSVC2019 Debug)
-onnx_model_experimental_detectron_generate_proposals_single_image
+# onnx_model_experimental_detectron_generate_proposals_single_image
 
 # Issue 49621: Incorrect blob sizes for node BinaryConvolution_X
 bin_convolution_2D_1batch_1channel


### PR DESCRIPTION
### Details:
 - The problem has been observed only in CI runs, never locally.
 - Failing unit test IE_CPU.onnx_model_experimental_detectron_generate_proposals_single_image.  
 - This draft PR is to check whether the problem has been resolved by #4627.

### Tickets:
 - 50224
