### PR TITLE
Exception from OV after model reshape with multiple OV streams

### DIFF
--- a/inference-engine/src/mkldnn_plugin/mkldnn_edge.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_edge.h
@@ -71,7 +71,7 @@ public:
     MKLDNNEdgePtr getSharedEdge(std::nothrow_t) const;
 
 private:
-    std::string name() const;
+    std::string name();
 
 private:
     std::weak_ptr<MKLDNNNode> parent;


### PR DESCRIPTION
### Details:
 - MKLDNN weights cache key calculation algorithm changed

### Tickets:
 - CVS-50660
