### PR TITLE
[IE TESTS] Fix issue with assert in `Compare` function (Failed tests are reported as Passed)

### DIFF
--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
@@ -180,10 +180,11 @@ public:
 
             const auto max = std::max(CommonTestUtils::ie_abs(res), CommonTestUtils::ie_abs(ref));
             float diff = static_cast<float>(absoluteDifference) / static_cast<float>(max);
-            ASSERT_TRUE(max != 0 && (diff <= static_cast<float>(threshold)))
-                                        << "Relative comparison of values expected: " << ref << " and actual: " << res
-                                        << " at index " << i << " with threshold " << threshold
-                                        << " failed";
+            if (max == 0 || (diff > static_cast<float>(threshold))) {
+                THROW_IE_EXCEPTION << "Relative comparison of values expected: " << ref << " and actual: " << res
+                                   << " at index " << i << " with threshold " << threshold
+                                   << " failed";
+            }
         }
     }
 


### PR DESCRIPTION
### Details:
 - Fix issue with assert in `Compare` function (Failed tests are reported as Passed)

