### PR TITLE
CPU executor may crash when Core is destructing(Resend to master)

### DIFF
--- a/inference-engine/src/mkldnn_plugin/mkldnn_plugin.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_plugin.cpp
@@ -103,6 +103,7 @@ Engine::Engine() {
 }
 
 Engine::~Engine() {
+    ExecutorManager::getInstance()->clear("CPU");
     ExecutorManager::getInstance()->clear("CPUStreamsExecutor");
     ExecutorManager::getInstance()->clear("CPUCallbackExecutor");
 }


### PR DESCRIPTION
CPU executor should be waited or there may crash when running HETERO_CPU_run_smoke/LSTM_IR_Test.canParseLSTM/0 test case. It's same as #4778.