### PR TITLE
Pad backend test for constant mode if const value not provided

### DIFF
--- a/ngraph/test/type_prop/pad.cpp
+++ b/ngraph/test/type_prop/pad.cpp
@@ -23,6 +23,15 @@ NGRAPH_SUPPRESS_DEPRECATED_START
 using namespace std;
 using namespace ngraph;
 
+TEST(type_prop, pad_v1_arg_pad_constant_with_default_padded_value)
+{
+    auto arg = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3});
+    auto pads_begin = make_shared<op::Parameter>(element::i64, Shape{1});
+    auto pads_end = make_shared<op::Parameter>(element::i64, Shape{1});
+
+    EXPECT_NO_THROW(make_shared<op::v1::Pad>(arg, pads_begin, pads_end, op::PadMode::CONSTANT));
+}
+
 TEST(type_prop, pad_v1_arg_pad_value_type_mismatch)
 {
     auto arg = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3});


### PR DESCRIPTION
Add Pad backend test : pad_zero_for_constant_mode_if_const_value_not_provided

### Tickets:
 - 37523


```
pad_value - scalar tensor of type matching type of elements in data tensor to be replicated in padded area. Used with the 
pad_mode = "constant" only. All new elements are populated with this value. Optional for pad_mode = "constant". If not 
provided, 0 of appropriate type is used. Shouldn't be set for other pad_mode values.
```