### PR TITLE
[VPU] Limit dlclose() WA to be used for Ubuntu only

### DIFF
--- a/inference-engine/src/vpu/myriad_plugin/CMakeLists.txt
+++ b/inference-engine/src/vpu/myriad_plugin/CMakeLists.txt
@@ -42,7 +42,7 @@ target_link_libraries(${TARGET_NAME}
         mvnc inference_engine inference_engine_legacy vpu_graph_transformer)
 
 # MyriadPlugin is not safe to unload it at runtime
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+if(LINUX AND LINUX_OS_NAME MATCHES "Ubuntu")
     set_target_properties(${TARGET_NAME} PROPERTIES LINK_OPTIONS "-Wl,-z,nodelete")
 endif()
 


### PR DESCRIPTION
Ticket - #-51137
Recently we have merged the WA for MyriadPlugin to be not unloaded at runtime for Linux systems.
It has been found that there are some problems with the usage of this linker option on CentOS, which led to Segmentation Fault on it, on the second call of dlopen() on myriadPlugin.
I tried to update glibc version on CentOS (to 2.28) and the problem disappeared.
Both Ubuntu 18 and 20 works fine and as it was requested as the used platform for the initial problem, I've decided to limit the solution for Ubuntu OS only.