### PR TITLE
Add caching and LoadNetworkByName support

### DIFF
--- a/inference-engine/samples/benchmark_app/README.md
+++ b/inference-engine/samples/benchmark_app/README.md
@@ -93,6 +93,9 @@ Options:
     -progress                 Optional. Show progress bar (can affect performance measurement). Default values is "false".
     -shape                    Optional. Set shape for input. For example, "input1[1,3,224,224],input2[1,4]" or "[1,3,224,224]" in case of one input size.
     -layout                   Optional. Prompts how network layouts should be treated by application. For example, "input1[NCHW],input2[NC]" or "[NCHW]" in case of one input size.
+    -cache "<path>"           Optional. Enables caching of loaded models to specified directory.
+    -single_load              Optional. Calls LoadNetwork by name (without need of ReadNetwork).
+                              All CNNNetwork options (like re-shape) will be ignored.
 
   CPU-specific performance options:
     -nstreams "<integer>"     Optional. Number of streams to use for inference on the CPU, GPU or MYRIAD devices

--- a/inference-engine/samples/benchmark_app/benchmark_app.hpp
+++ b/inference-engine/samples/benchmark_app/benchmark_app.hpp
@@ -105,6 +105,14 @@ static const char shape_message[] = "Optional. Set shape for input. For example,
 static const char layout_message[] = "Optional. Prompts how network layouts should be treated by application. "
                                      "For example, \"input1[NCHW],input2[NC]\" or \"[NCHW]\" in case of one input size.";
 
+// @brief message for enabling caching
+static const char cache_dir_message[] = "Optional. Enables caching of loaded models to specified directory. "
+                                        "List of devices which support caching is shown at the end of this message.";
+
+// @brief message for single load network
+static const char single_load_message[] = "Optional. Calls LoadNetwork by name (without need of ReadNetwork). "
+                                          "All CNNNetwork options (like re-shape) will be ignored";
+
 // @brief message for quantization bits
 static const char gna_qb_message[] = "Optional. Weight bits for quantization:  8 or 16 (default)";
 
@@ -198,6 +206,12 @@ DEFINE_string(layout, "", layout_message);
 /// @brief Define flag for quantization bits (default 16)
 DEFINE_int32(qb, 16, gna_qb_message);
 
+/// @brief Define parameter for cache model dir <br>
+DEFINE_string(cache, "", cache_dir_message);
+
+/// @brief Define flag for load network by model file name without ReadNetwork <br>
+DEFINE_bool(single_load, false, single_load_message);
+
 /**
 * @brief This function show a help message
 */
@@ -222,6 +236,8 @@ static void showUsage() {
     std::cout << "    -progress                 " << progress_message << std::endl;
     std::cout << "    -shape                    " << shape_message << std::endl;
     std::cout << "    -layout                   " << layout_message << std::endl;
+    std::cout << "    -cache \"<path>\"           " << cache_dir_message << std::endl;
+    std::cout << "    -single_load              " << single_load_message << std::endl;
     std::cout << std::endl << "  device-specific performance options:" << std::endl;
     std::cout << "    -nstreams \"<integer>\"     " << infer_num_streams_message << std::endl;
     std::cout << "    -nthreads \"<integer>\"     " << infer_num_threads_message << std::endl;


### PR DESCRIPTION
### Details:
2 new options are introduced
- cache <dir> - enables models caching
- single_load - use new perform "LoadNetwork" by model name

Using both parameters will achieve maximum performance of read/load network on startup

Tests:
1) Run "benchmark_app -h". Help will display 2 new options. After available devices there will be list of devices with cache support
2) ./benchmark_app -d CPU -i <model.xml> -single_load
Verify that some test steps are skipped (related to ReadNetwork, re-shaping etc)
3) Pre-requisite: support of caching shall be enabled for Template plugin
./benchmark_app -d TEMPLATE -i <model.onnx> -single_load -cache someDir
Verify that "someDir" is created and generated blob is available
Run again, verify that loading works as well (should be faster as it will not load onnx model)
4) Run same test as (3), but without -single_load option. Verify that cache is properly created
For some devices loadNetwork time shall be improved when cache is available

### Tickets:
 - 50092
