### PR TITLE
[Template]: Metrics IMPORT_EXPORT_SUPPORT and DEVICE_ARCHITECTURE

### DIFF
--- a/docs/template_plugin/src/template_plugin.cpp
+++ b/docs/template_plugin/src/template_plugin.cpp
@@ -239,6 +239,8 @@ InferenceEngine::Parameter Plugin::GetMetric(const std::string& name, const std:
             METRIC_KEY(SUPPORTED_METRICS),
             METRIC_KEY(SUPPORTED_CONFIG_KEYS),
             METRIC_KEY(FULL_DEVICE_NAME),
+            METRIC_KEY(IMPORT_EXPORT_SUPPORT),
+            METRIC_KEY(DEVICE_ARCHITECTURE),
             METRIC_KEY(OPTIMIZATION_CAPABILITIES),
             METRIC_KEY(RANGE_FOR_ASYNC_INFER_REQUESTS) };
         IE_SET_METRIC_RETURN(SUPPORTED_METRICS, supportedMetrics);
@@ -261,6 +263,12 @@ InferenceEngine::Parameter Plugin::GetMetric(const std::string& name, const std:
     } else if (METRIC_KEY(FULL_DEVICE_NAME) == name) {
         std::string name = "Template Device Full Name";
         IE_SET_METRIC_RETURN(FULL_DEVICE_NAME, name);
+    } else if (METRIC_KEY(IMPORT_EXPORT_SUPPORT) == name) {
+        IE_SET_METRIC_RETURN(IMPORT_EXPORT_SUPPORT, true);
+    } else if (METRIC_KEY(DEVICE_ARCHITECTURE) == name) {
+        // TODO: return device architecture for device specified by DEVICE_ID config
+        std::string arch = "TEMPLATE";
+        IE_SET_METRIC_RETURN(DEVICE_ARCHITECTURE, arch);
     } else if (METRIC_KEY(OPTIMIZATION_CAPABILITIES) == name) {
         // TODO: fill actual list of supported capabilities: e.g. Template device supports only FP32
         std::vector<std::string> capabilities = { METRIC_VALUE(FP32) /*, TEMPLATE_METRIC_VALUE(HARDWARE_CONVOLUTION)*/ };


### PR DESCRIPTION
### Details:
Test:
Use benchmark_app from this PR #4814

Run ./benchmark_app -h
Verify that template plugin is listed in supported caching devices

Run ./benchmark_app -m <model.onnx> -d TEMPLATE -i <file> -cache tmpCache
Verify that tmpCache is created and network is exported to blob
Verify that if model is ONNX (e.g. ResNet50) - that loading of network is performed faster when cache is available

Run several times: ./benchmark_app -m <model.onnx> -d TEMPLATE -i <file> -cache tmpCache -single_load
Verify that if model is ONNX (e.g. ResNet50) - that loading of network is performed faster when cache is available
Verify that in this mode loading of network is faster than without "-single_load" option

### Tickets:
 - 50793
