### PR TITLE
Updated PIP install instructions

### DIFF
--- a/docs/install_guides/pypi-openvino-dev.md
+++ b/docs/install_guides/pypi-openvino-dev.md
@@ -51,7 +51,11 @@ python -m pip install --user virtualenv
 python -m venv openvino_env --system-site-packages
 ```
 
-Activate virtual environment:<br>
+> **NOTE**: On Linux and macOS, you may need to type `python3` instead of
+`python`. You may also need to [install pip](https://pip.pypa.io/en/stable/installing/).
+
+### Step 2. Activate Virtual Environment
+
 On Linux and macOS:
 ```sh
 source openvino_env/bin/activate
@@ -61,14 +65,14 @@ On Windows:
 openvino_env\Scripts\activate
 ```
 
-### Step 2. Set Up and Update pip to the Highest Version
+### Step 3. Set Up and Update pip to the Highest Version
 
 Run the command below:
 ```sh
 python -m pip install --upgrade pip
 ```
 
-### Step 3. Install the Package
+### Step 4. Install the Package
 
 Run the command below: <br>
 
@@ -76,18 +80,17 @@ Run the command below: <br>
    pip install openvino-dev
    ```
 
-### Step 4. Verify that the Package is Installed
+### Step 5. Verify that the Package is Installed
 
-Run the command below:
+Run the command below (this may take a few seconds):
 ```sh
-python -c "pot -h"
+pot -h
 ```
-   
+
 You will see the help message for Post-Training Optimization Tool if installation finished successfully.
 
 ## Additional Resources
 
 - Intel® Distribution of OpenVINO™ toolkit home page: [https://software.intel.com/en-us/openvino-toolkit](https://software.intel.com/en-us/openvino-toolkit)
 - OpenVINO™ toolkit online documentation: [https://docs.openvinotoolkit.org](https://docs.openvinotoolkit.org)
-
 

--- a/docs/install_guides/pypi-openvino-rt.md
+++ b/docs/install_guides/pypi-openvino-rt.md
@@ -48,7 +48,11 @@ python -m pip install --user virtualenv
 python -m venv openvino_env --system-site-packages
 ```
 
-Activate virtual environment:<br>
+> **NOTE**: On Linux and macOS, you may need to type `python3` instead of
+`python`. You may also need to [install pip](https://pip.pypa.io/en/stable/installing/).
+
+### Step 2. Activate Virtual Environment
+
 On Linux and macOS:
 ```sh
 source openvino_env/bin/activate
@@ -58,14 +62,14 @@ On Windows:
 openvino_env\Scripts\activate
 ```
 
-### Step 2. Set Up and Update pip to the Highest Version
+### Step 3. Set Up and Update pip to the Highest Version
 
 Run the command below:
 ```sh
 python -m pip install --upgrade pip
 ```
 
-### Step 3. Install the Package
+### Step 4. Install the Package
 
 Run the command below: <br>
 
@@ -73,7 +77,7 @@ Run the command below: <br>
    pip install openvino
    ```
 
-### Step 4. Verify that the Package is Installed
+### Step 5. Verify that the Package is Installed
 
 Run the command below:
 ```sh


### PR DESCRIPTION
See this PR for the master branch: https://github.com/openvinotoolkit/openvino/pull/4791

* Change command to verify openvino-dev installation from python -c "pot -h" to pot -h
* Add note that Mac/Linux users may need to type python3 instead of python (this is not always the case - it depends on how they configured Python).
* Made "Activate Virtual Environment" a separate step, so that there is 1 step per step, and you don't accidentally miss a sub-step.