### PR TITLE
Fix shape propagation with broadcast to second input

### DIFF
--- a/ngraph/core/src/validation_util.cpp
+++ b/ngraph/core/src/validation_util.cpp
@@ -1452,11 +1452,11 @@ HostTensorPtr equality_mask(const HostTensorPtr& tensor, const shared_ptr<op::Co
 
 HostTensorPtr or_tensor(const HostTensorPtr& lhs, const HostTensorPtr& rhs)
 {
-    auto result = std::make_shared<HostTensor>(element::boolean, lhs->get_shape());
-    op::v1::LogicalOr(std::make_shared<op::Parameter>(lhs->get_element_type(), lhs->get_shape()),
+    auto log_or = op::v1::LogicalOr(std::make_shared<op::Parameter>(lhs->get_element_type(), lhs->get_shape()),
                       std::make_shared<op::Parameter>(rhs->get_element_type(), rhs->get_shape()),
-                      ngraph::op::AutoBroadcastSpec::NUMPY)
-        .evaluate({result}, {lhs, rhs});
+                      ngraph::op::AutoBroadcastSpec::NUMPY);
+    auto result = std::make_shared<HostTensor>(element::boolean, log_or.get_shape());
+    log_or.evaluate({result}, {lhs, rhs});
     return result;
 }
 

--- a/ngraph/core/src/validation_util.cpp
+++ b/ngraph/core/src/validation_util.cpp
@@ -1452,11 +1452,11 @@ HostTensorPtr equality_mask(const HostTensorPtr& tensor, const shared_ptr<op::Co
 
 HostTensorPtr or_tensor(const HostTensorPtr& lhs, const HostTensorPtr& rhs)
 {
-    auto log_or = op::v1::LogicalOr(std::make_shared<op::Parameter>(lhs->get_element_type(), lhs->get_shape()),
+    auto result = std::make_shared<HostTensor>();
+    op::v1::LogicalOr(std::make_shared<op::Parameter>(lhs->get_element_type(), lhs->get_shape()),
                       std::make_shared<op::Parameter>(rhs->get_element_type(), rhs->get_shape()),
-                      ngraph::op::AutoBroadcastSpec::NUMPY);
-    auto result = std::make_shared<HostTensor>(element::boolean, log_or.get_shape());
-    log_or.evaluate({result}, {lhs, rhs});
+                      ngraph::op::AutoBroadcastSpec::NUMPY)
+        .evaluate({result}, {lhs, rhs});
     return result;
 }
 

--- a/ngraph/test/type_prop/binary_elementwise.cpp
+++ b/ngraph/test/type_prop/binary_elementwise.cpp
@@ -215,9 +215,13 @@ void test_binary_eltwise_numpy(const element::Type& et, const op::AutoBroadcastS
     auto param2 = make_shared<op::Parameter>(et, Shape{3, 1});
     auto param3 = make_shared<op::Parameter>(et, Shape{2, 3, 6});
     auto param4 = make_shared<op::Parameter>(et, Shape{6});
+    auto param5 = make_shared<op::Parameter>(et, Shape{});
+
     EXPECT_EQ(make_shared<T>(param1, param2, autob)->get_shape(), (Shape{1, 3, 6}));
     EXPECT_EQ(make_shared<T>(param1, param3, autob)->get_shape(), (Shape{2, 3, 6}));
     EXPECT_EQ(make_shared<T>(param4, param3, autob)->get_shape(), (Shape{2, 3, 6}));
+    EXPECT_EQ(make_shared<T>(param5, param3, autob)->get_shape(), (Shape{2, 3, 6}));
+    EXPECT_EQ(make_shared<T>(param3, param5, autob)->get_shape(), (Shape{2, 3, 6}));
 
     auto pp1 = make_shared<op::Parameter>(et, PartialShape{1, Dimension::dynamic(), 6});
     auto pp2 = make_shared<op::Parameter>(et, PartialShape{3, 1});

--- a/ngraph/test/type_prop/reshape.cpp
+++ b/ngraph/test/type_prop/reshape.cpp
@@ -177,6 +177,38 @@ TEST(type_prop, interval_value_propagation_mul_div_rhs_scalar)
     ASSERT_EQ(r->get_output_partial_shape(0), PartialShape({Dimension(2, 8), Dimension(8, 32), 4}));
 }
 
+TEST(type_prop, interval_value_propagation_mul_div_lhs_1D)
+{
+    auto param = make_shared<op::Parameter>(element::f32,
+                                            PartialShape{Dimension(2, 8), Dimension(4, 16), 6});
+    auto shape_of = make_shared<op::v3::ShapeOf>(param);
+    auto cast_fp = make_shared<op::Convert>(shape_of, element::f32);
+    auto mul = make_shared<op::v1::Multiply>(op::Constant::create(element::f32, {1}, {2}), cast_fp);
+    auto div = make_shared<op::v1::Divide>(mul, op::Constant::create(element::f32, {3}, {2, 1, 3}));
+    auto cast_int = make_shared<op::Convert>(div, element::i32);
+
+    auto r = make_shared<op::v1::Reshape>(param, cast_int, false);
+
+    ASSERT_EQ(r->get_element_type(), element::f32);
+    ASSERT_EQ(r->get_output_partial_shape(0), PartialShape({Dimension(2, 8), Dimension(8, 32), 4}));
+}
+
+TEST(type_prop, interval_value_propagation_mul_div_rhs_1D)
+{
+    auto param = make_shared<op::Parameter>(element::f32,
+                                            PartialShape{Dimension(2, 8), Dimension(4, 16), 6});
+    auto shape_of = make_shared<op::v3::ShapeOf>(param);
+    auto cast_fp = make_shared<op::Convert>(shape_of, element::f32);
+    auto mul = make_shared<op::v1::Multiply>(cast_fp, op::Constant::create(element::f32, {1}, {2}));
+    auto div = make_shared<op::v1::Divide>(mul, op::Constant::create(element::f32, {3}, {2, 1, 3}));
+    auto cast_int = make_shared<op::Convert>(div, element::i32);
+
+    auto r = make_shared<op::v1::Reshape>(param, cast_int, false);
+
+    ASSERT_EQ(r->get_element_type(), element::f32);
+    ASSERT_EQ(r->get_output_partial_shape(0), PartialShape({Dimension(2, 8), Dimension(8, 32), 4}));
+}
+
 TEST(type_prop, interval_value_propagation_reduce)
 {
     auto param = make_shared<op::Parameter>(element::f32, PartialShape{Dimension(1, 8), 2, 3});

--- a/ngraph/test/type_prop/reshape.cpp
+++ b/ngraph/test/type_prop/reshape.cpp
@@ -145,6 +145,38 @@ TEST(type_prop, interval_value_propagation_mul_div)
     ASSERT_EQ(r->get_output_partial_shape(0), PartialShape({Dimension(2, 8), Dimension(4, 16), 2}));
 }
 
+TEST(type_prop, interval_value_propagation_mul_div_lhs_scalar)
+{
+    auto param = make_shared<op::Parameter>(element::f32,
+                                            PartialShape{Dimension(2, 8), Dimension(4, 16), 6});
+    auto shape_of = make_shared<op::v3::ShapeOf>(param);
+    auto cast_fp = make_shared<op::Convert>(shape_of, element::f32);
+    auto mul = make_shared<op::v1::Multiply>(op::Constant::create(element::f32, {}, {2}), cast_fp);
+    auto div = make_shared<op::v1::Divide>(mul, op::Constant::create(element::f32, {3}, {2, 1, 3}));
+    auto cast_int = make_shared<op::Convert>(div, element::i32);
+
+    auto r = make_shared<op::v1::Reshape>(param, cast_int, false);
+
+    ASSERT_EQ(r->get_element_type(), element::f32);
+    ASSERT_EQ(r->get_output_partial_shape(0), PartialShape({Dimension(2, 8), Dimension(8, 32), 4}));
+}
+
+TEST(type_prop, interval_value_propagation_mul_div_rhs_scalar)
+{
+    auto param = make_shared<op::Parameter>(element::f32,
+                                            PartialShape{Dimension(2, 8), Dimension(4, 16), 6});
+    auto shape_of = make_shared<op::v3::ShapeOf>(param);
+    auto cast_fp = make_shared<op::Convert>(shape_of, element::f32);
+    auto mul = make_shared<op::v1::Multiply>(cast_fp, op::Constant::create(element::f32, {}, {2}));
+    auto div = make_shared<op::v1::Divide>(mul, op::Constant::create(element::f32, {3}, {2, 1, 3}));
+    auto cast_int = make_shared<op::Convert>(div, element::i32);
+
+    auto r = make_shared<op::v1::Reshape>(param, cast_int, false);
+
+    ASSERT_EQ(r->get_element_type(), element::f32);
+    ASSERT_EQ(r->get_output_partial_shape(0), PartialShape({Dimension(2, 8), Dimension(8, 32), 4}));
+}
+
 TEST(type_prop, interval_value_propagation_reduce)
 {
     auto param = make_shared<op::Parameter>(element::f32, PartialShape{Dimension(1, 8), 2, 3});


### PR DESCRIPTION
### Details:
 -  `or_tensor` function previously set HostTensor result shape same as `lhs` (first input) shape, what caused error like:
 `Allocation shape Shape{3} must be compatible with the partial shape: {}` ([log](https://dev.azure.com/openvinoci/dldt/_build/results?buildId=57667&view=logs&j=0609cd82-f9f7-5e70-371c-89fca78031ab&t=d7ecf6fe-a4b9-53ec-d3c3-e8ce906215b2&l=7197))
 when the `lhs` input was smaller and broadcast to `rhs` (second input) was applied.
 
 (The `or_tensor` function was introduced with PR https://github.com/openvinotoolkit/openvino/pull/3368)
 
 
 
### Tickets:
 - 49699
