### PR TITLE
Fix building protobuf-lite on macos

### DIFF
--- a/ngraph/cmake/external_protobuf.cmake
+++ b/ngraph/cmake/external_protobuf.cmake
@@ -106,11 +106,11 @@ else()
             list(APPEND _proto_libs libprotoc)
         endif()
         set_target_properties(${_proto_libs} PROPERTIES
-                                COMPILE_FLAGS "-Wno-unused-variable -Wno-inconsistent-missing-override")
-        set_target_properties(${_proto_libs} PROPERTIES
             CXX_VISIBILITY_PRESET default
             C_VISIBILITY_PRESET default
             VISIBILITY_INLINES_HIDDEN OFF)
+        set_target_properties(libprotobuf libprotobuf-lite PROPERTIES
+            COMPILE_FLAGS "-Wno-unused-variable -Wno-inconsistent-missing-override")
     endif()
     if(NGRAPH_USE_PROTOBUF_LITE)
         # if only libprotobuf-lite is used, both libprotobuf and libprotobuf-lite are built


### PR DESCRIPTION
During build `protobuf-lite` on macos, warning properties should be applied both to `libprotobuf` and `libprotobuf-lite` (both of them are built always, but we use only the one - `libprotbuf` is used by `libprotoc` even in protobuf-lite scenario),
