### PR TITLE
[GNA] Enable convolution in height dimension for NHWC native models

### DIFF
--- a/inference-engine/src/gna_plugin/frontend/layer_quantizer.hpp
+++ b/inference-engine/src/gna_plugin/frontend/layer_quantizer.hpp
@@ -393,13 +393,12 @@ inline void quantizeWeightsBiasesConv(const QuantDesc & quantDesc,
             << "cannot copy weights for layer :"<< conv->name << " of size" << intWeights->byteSize();
     }
 
-    auto getBiasSizeForLayer = [](InferenceEngine::WeightableLayer *wl) {
+    auto getBiasSizeForLayer = [](InferenceEngine::WeightableLayer *wl) -> size_t {
         if (wl->_biases) {
             return wl->_biases->size();
         }
-        // calculating biases len using outdata dims
-        auto & dims = wl->outData.front()->getDims();
-        return dims[1];
+        // calculating biases len using outdata dims: biases number should be equal to output channels number
+        return InferenceEngine::GetDataDimSize(wl->outData.front(), InferenceEngine::DataDimName::C);
     };
 
     using BiasesPrecision = typename QuantDesc::BiasesPrecision;

--- a/inference-engine/src/gna_plugin/frontend/scale_factor_calc.hpp
+++ b/inference-engine/src/gna_plugin/frontend/scale_factor_calc.hpp
@@ -17,6 +17,7 @@
 #include "gna_plugin_log.hpp"
 #include "gna_slope_scale.h"
 #include "runtime/pwl.h"
+#include "gna_data_types.hpp"
 
 namespace GNAPluginNS {
 namespace frontend {
@@ -1080,9 +1081,8 @@ class ScaleFactorPerLayer<InferenceEngine::WeightableLayer*> {
             double weights_reducer = 1.0;
             auto conv = dynamic_cast<InferenceEngine::ConvolutionLayer *>(wl);
             if (conv) {
-                auto dims = conv->insData.front().lock()->getDims();
-
-                weights_reducer = MAX_VAL_2B_FEAT * scaleRange * dims[1] / std::numeric_limits<int32_t>::max();
+                auto channels_num = GetDataDimSize(conv->insData.front().lock(), InferenceEngine::DataDimName::C);
+                weights_reducer = MAX_VAL_2B_FEAT * scaleRange * channels_num / std::numeric_limits<int32_t>::max();
                 weights_reducer = std::max(1.0, weights_reducer);
             }
             quant->_weights_quant.SetScale(quant->_weights_quant.GetScale() / weights_reducer);

--- a/inference-engine/src/gna_plugin/gna_data_types.hpp
+++ b/inference-engine/src/gna_plugin/gna_data_types.hpp
@@ -17,9 +17,6 @@
 #include "memory/polymorph_allocator.hpp"
 #include "memory/gna_memory.hpp"
 
-#define FROM_IR_DIM(mem, idx)\
-((mem->getTensorDesc().getDims().size() > (idx) - 1) ? mem->getTensorDesc().getDims()[mem->getTensorDesc().getDims().size() - (idx)] : 1)
-
 struct TranspositionInfo {
     bool transpose;
     size_t num_transpose_rows;

--- a/inference-engine/src/gna_plugin/gna_graph_compiler.hpp
+++ b/inference-engine/src/gna_plugin/gna_graph_compiler.hpp
@@ -50,7 +50,6 @@ private:
     static void printPoolingLayer(const InferenceEngine::PoolingLayer& layer);
     static void assertConvolutionLayoutProper(const InferenceEngine::DataPtr&);
     std::vector<uint8_t> static transposeMatrix(uint8_t* ptr_matrix, size_t element_size, uint32_t num_rows, uint32_t num_cols);
-    std::vector<std::size_t> static getFromIRDimsOrderNCHW(InferenceEngine::Layout layout);
 
 public:
     GNAPluginNS::backend::DnnComponents dnnComponents;
@@ -127,8 +126,8 @@ public:
     void CopyPrimitive(InferenceEngine::CNNLayerPtr);
 
     void finalizeConvolution1DPrimitive(InferenceEngine::CNNLayerPtr,
-        uint32_t in_batch, uint32_t in_channels, uint32_t in_height, uint32_t in_width,
-        uint32_t out_batch, uint32_t out_channels, uint32_t out_height, uint32_t out_width);
+        uint32_t in_batch, uint32_t in_channels, uint32_t in_width,
+        uint32_t out_batch, uint32_t out_channels, uint32_t out_width);
 #if GNA_LIB_VER == 2
     void finalizeConvolution2DPrimitive(InferenceEngine::CNNLayerPtr,
         uint32_t in_batch, uint32_t in_channels, uint32_t in_height, uint32_t in_width,

--- a/inference-engine/src/gna_plugin/gna_graph_patterns.hpp
+++ b/inference-engine/src/gna_plugin/gna_graph_patterns.hpp
@@ -141,8 +141,9 @@ inline std::vector<TranspositionInfo> FindTranspositionInfoFromPrevLayers(Infere
     std::function<std::vector<TranspositionInfo>(InferenceEngine::CNNLayerPtr)> findTranspositionInfoRecursive =
         [&findTranspositionInfoRecursive](InferenceEngine::CNNLayerPtr layer) -> std::vector<TranspositionInfo> {
         auto getTransposeInfoFromData = [](InferenceEngine::DataPtr data, bool transpose = true) {
-            auto rows = FROM_IR_DIM(data, 3);
-            auto columns = FROM_IR_DIM(data, 1) * FROM_IR_DIM(data, 2);
+            auto rows = InferenceEngine::GetDataDimSize(data, InferenceEngine::DataDimName::C);
+            auto columns = InferenceEngine::GetDataDimSize(data, InferenceEngine::DataDimName::H) *
+                           InferenceEngine::GetDataDimSize(data, InferenceEngine::DataDimName::W);
             return std::vector<TranspositionInfo>{{transpose, rows, columns}};
         };
         if (LayerInfo(layer).isConvolution() || LayerInfo(layer).isPooling()) {
@@ -236,8 +237,9 @@ inline std::vector<TranspositionInfo> FindTranspositionInfoFromNextLayers(Infere
     std::function<std::vector<TranspositionInfo>(InferenceEngine::CNNLayerPtr)> findTranspositionInfoRecursive =
         [&findTranspositionInfoRecursive](InferenceEngine::CNNLayerPtr layer) -> std::vector<TranspositionInfo> {
         if (LayerInfo(layer).isConvolution()) {
-            auto rows = FROM_IR_DIM(layer->input(), 3);
-            auto columns = FROM_IR_DIM(layer->input(), 1) * FROM_IR_DIM(layer->input(), 2);
+            auto rows = InferenceEngine::GetDataDimSize(layer->input(), InferenceEngine::DataDimName::C);
+            auto columns = InferenceEngine::GetDataDimSize(layer->input(), InferenceEngine::DataDimName::H) *
+                           InferenceEngine::GetDataDimSize(layer->input(), InferenceEngine::DataDimName::W);
             return {{true, rows, columns}};
         }
 

--- a/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.cpp
+++ b/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.cpp
@@ -677,16 +677,6 @@ void RemovePermutationsNHWCToNCHWPass::run() {
         }
 
         nhwc_layout_patterns.push_back({prev, next});
-
-        auto* convolution = dynamic_cast<ConvolutionLayer*>(l.get());
-        if (!convolution) {
-            THROW_GNA_EXCEPTION << "Invalid type of convolution layer";
-        }
-        if (convolution->_kernel_y != 1) {
-            THROW_GNA_LAYER_EXCEPTION(l) << "this case is not implemented yet";
-        }
-        auto in_channels = convolution->input()->getDims()[1];
-        convolution->_kernel_y = in_channels;
     }
 
     for (const auto& layers : nhwc_layout_patterns) {
@@ -2286,8 +2276,8 @@ void TransposeWeightsFromNCHWToNHWCPass::run() {
 
             // Transpose all constant inputs
             for (auto && input : constInputs) {
-                auto rows = FROM_IR_DIM(input->outData[0], 3);
-                auto columns = FROM_IR_DIM(input->outData[0], 1) * FROM_IR_DIM(input->outData[0], 2);
+                auto rows = GetDataDimSize(input->outData[0], DataDimName::C);
+                auto columns = GetDataDimSize(input->outData[0], DataDimName::H) * GetDataDimSize(input->outData[0], DataDimName::W);
                 auto blob = input->blobs["custom"];
                 // A constant should have the same number of channels since concatenation will be in height/weight dimension
                 TranspositionInfo concatTranspositionInfo{true, rows, columns};

--- a/inference-engine/tests/functional/plugin/gna/pass_tests/remove_permutations_NHWC_to_NCHW_pass.cpp
+++ b/inference-engine/tests/functional/plugin/gna/pass_tests/remove_permutations_NHWC_to_NCHW_pass.cpp
@@ -74,15 +74,17 @@ class RemovePermutationsNHWCToNCHWPassTest : public testing::WithParamInterface<
                 ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{ 4 }, { 0, 3, 1, 2 }));
 
             size_t num_out_channels = 12;
-            size_t kernal_size = 8;
-            auto conv1 = ngraph::builder::makeConvolution(permute1, ngPrc, { 1, kernal_size }, { 1, 1 }, { 0, 0 }, { 0, 0 }, { 1, 1 },
-                ngraph::op::PadType::VALID, num_out_channels);
+            size_t kernel_size = 8;
+            std::vector<size_t> kernal_shape = (inputShape[1] == 1 ? std::vector<size_t>{1, kernel_size} : std::vector<size_t>{kernel_size, 1});
+            auto conv1 = ngraph::builder::makeConvolution(permute1, ngPrc, kernal_shape, { 1, 1 }, { 0, 0 }, { 0, 0 }, { 1, 1 },
+                                                          ngraph::op::PadType::VALID, num_out_channels);
 
             auto permute2 = std::make_shared<ngraph::opset1::Transpose>(conv1,
                 ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{ 4 }, { 0, 2, 3, 1 }));
 
-            size_t out_width = (inputShape[2] - kernal_size) + 1;
-            std::vector<size_t> outFormShapes = { 1, out_width * num_out_channels };
+            size_t out_width = (inputShape[2] - kernal_shape[1]) + 1;
+            size_t out_height = (inputShape[1] - kernal_shape[0]) + 1;
+            std::vector<size_t> outFormShapes = { 1, out_width * out_height * num_out_channels };
             auto pattern2 = std::make_shared<ngraph::opset1::Constant>(ngraph::element::Type_t::i64, ngraph::Shape{ 2 }, outFormShapes);
             auto reshape2 = std::make_shared<ngraph::opset1::Reshape>(permute2, pattern2, false);
 
@@ -122,7 +124,9 @@ protected:
         auto permute1 = std::make_shared<ngraph::opset1::Transpose>(params[0],
                              ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{ 4 }, { 0, 3, 1, 2 }));
 
-        auto conv1 = ngraph::builder::makeConvolution(permute1, ngPrc, { 1, 8 }, { 1, 1 }, { 0, 0 }, { 0, 0 }, { 1, 1 }, ngraph::op::PadType::VALID, 12);
+        size_t kernal_size = 8;
+        std::vector<size_t> kernal_shape = (inputShape[1] == 1 ? std::vector<size_t>{1, kernal_size} : std::vector<size_t>{kernal_size, 1});
+        auto conv1 = ngraph::builder::makeConvolution(permute1, ngPrc, kernal_shape, { 1, 1 }, { 0, 0 }, { 0, 0 }, { 1, 1 }, ngraph::op::PadType::VALID, 12);
 
         auto permute2 = std::make_shared<ngraph::opset1::Transpose>(conv1,
                              ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{ 4 }, { 0, 2, 3, 1 }));
@@ -200,20 +204,23 @@ class RemovePermutationsWithPoolAndActTest : public testing::WithParamInterface<
 
             size_t num_out_channels = 12;
             size_t kernal_size = 8;
+            auto kernal_shape = (inputShape[1] == 1 ? std::vector<size_t>{1, kernal_size} : std::vector<size_t>{kernal_size, 1});
             std::vector<float> filter_weights = CommonTestUtils::generate_float_numbers(num_out_channels * inputShape[3] * kernal_size,
                                                                                         -0.2f, 0.2f);
-            auto conv1 = ngraph::builder::makeConvolution(relu1, ngPrc, { 1, kernal_size }, { 1, 1 }, { 0, 0 }, { 0, 0 }, { 1, 1 },
+            auto conv1 = ngraph::builder::makeConvolution(relu1, ngPrc, kernal_shape, { 1, 1 }, { 0, 0 }, { 0, 0 }, { 1, 1 },
                 ngraph::op::PadType::VALID, num_out_channels, false, filter_weights);
-            auto pool = ngraph::builder::makePooling(conv1, {1, 2}, {0, 0}, {0, 0}, {1, 2}, ngraph::op::RoundingType::FLOOR,
+            auto pool_kernal_shape = (inputShape[1] == 1 ? std::vector<size_t>{1, 2} : std::vector<size_t>{2, 1});
+            auto pool = ngraph::builder::makePooling(conv1, pool_kernal_shape, {0, 0}, {0, 0}, pool_kernal_shape, ngraph::op::RoundingType::FLOOR,
                                                      ngraph::op::PadType::VALID, false, ngraph::helpers::PoolingTypes::MAX);
 
-            size_t out_width = ((inputShape[2] - kernal_size) + 1) / 2;
+            size_t out_width = ((inputShape[2] - kernal_shape[1]) + 1) / pool_kernal_shape[1];
+            size_t out_height = ((inputShape[1] - kernal_shape[0]) + 1) / pool_kernal_shape[0];
             auto relu2 = std::make_shared<ngraph::opset3::Relu>(pool);
 
             auto permute2 = std::make_shared<ngraph::opset1::Transpose>(relu2,
                 ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{ 4 }, { 0, 2, 3, 1 }));
 
-            std::vector<size_t> outFormShapes = { 1, out_width * num_out_channels };
+            std::vector<size_t> outFormShapes = { 1, out_width * out_height * num_out_channels };
             auto pattern2 = std::make_shared<ngraph::opset1::Constant>(ngraph::element::Type_t::i64, ngraph::Shape{ 2 }, outFormShapes);
             auto reshape2 = std::make_shared<ngraph::opset1::Reshape>(permute2, pattern2, false);
 
@@ -283,22 +290,25 @@ class RemovePermutationsWithTwoConvTest : public testing::WithParamInterface<rem
 
             size_t num_out_channels = 12;
             size_t kernal_size = 8;
+            std::vector<size_t> kernal_shape = (inputShape[1] == 1 ? std::vector<size_t>{1, kernal_size} : std::vector<size_t>{kernal_size, 1});
             std::vector<float> filter_weights_1 = CommonTestUtils::generate_float_numbers(num_out_channels * inputShape[3] * kernal_size,
                                                                                           0.0f, 0.5f);
-            auto conv1 = ngraph::builder::makeConvolution(permute1, ngPrc, { 1, kernal_size }, { 1, 1 }, { 0, 0 }, { 0, 0 }, { 1, 1 },
+            auto conv1 = ngraph::builder::makeConvolution(permute1, ngPrc, kernal_shape, { 1, 1 }, { 0, 0 }, { 0, 0 }, { 1, 1 },
                 ngraph::op::PadType::VALID, num_out_channels, false, filter_weights_1);
-            size_t out_width = ((inputShape[2] - kernal_size) + 1);
+            size_t out_width = ((inputShape[2] - kernal_shape[1]) + 1);
+            size_t out_height = ((inputShape[1] - kernal_shape[0]) + 1);
 
             std::vector<float> filter_weights_2 = CommonTestUtils::generate_float_numbers(num_out_channels * num_out_channels * kernal_size,
                                                                                           -0.2f, 0.2f);
-            auto conv2 = ngraph::builder::makeConvolution(conv1, ngPrc, { 1, kernal_size }, { 1, 1 }, { 0, 0 }, { 0, 0 }, { 1, 1 },
+            auto conv2 = ngraph::builder::makeConvolution(conv1, ngPrc, kernal_shape, { 1, 1 }, { 0, 0 }, { 0, 0 }, { 1, 1 },
                 ngraph::op::PadType::VALID, num_out_channels, false, filter_weights_2);
-            out_width = ((out_width - kernal_size) + 1);
+            out_width = ((out_width - kernal_shape[1]) + 1);
+            out_height = ((out_height - kernal_shape[0]) + 1);
 
             auto permute2 = std::make_shared<ngraph::opset1::Transpose>(conv2,
                 ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{ 4 }, { 0, 2, 3, 1 }));
 
-            std::vector<size_t> outFormShapes = { 1, out_width * num_out_channels };
+            std::vector<size_t> outFormShapes = { 1, out_width * out_height * num_out_channels };
             auto pattern2 = std::make_shared<ngraph::opset1::Constant>(ngraph::element::Type_t::i64, ngraph::Shape{ 2 }, outFormShapes);
             auto reshape2 = std::make_shared<ngraph::opset1::Reshape>(permute2, pattern2, false);
 
@@ -363,6 +373,7 @@ class RemovePermutationsWithEltwiseTest : public testing::WithParamInterface<rem
             auto params = ngraph::builder::makeParams(ngPrc, { {1, 2 * in_total_dims_size} });
             auto split = ngraph::builder::makeSplit(params[0], ngPrc, 2, 1);
             auto in_width = inputShape[2];
+            auto in_height = inputShape[1];
             auto in_channels = inputShape[3];
 
             auto pattern1 = std::make_shared<ngraph::opset1::Constant>(ngraph::element::Type_t::i64, ngraph::Shape{ 4 }, inputShape);
@@ -372,9 +383,10 @@ class RemovePermutationsWithEltwiseTest : public testing::WithParamInterface<rem
 
             size_t num_out_channels = 12;
             size_t kernal_size = 8;
+            std::vector<size_t> kernal_shape = (inputShape[1] == 1 ? std::vector<size_t>{1, kernal_size} : std::vector<size_t>{kernal_size, 1});
             std::vector<float> filter_weights_1 = CommonTestUtils::generate_float_numbers(num_out_channels * in_channels * kernal_size,
                                                                                           -0.2f, 0.2f);
-            auto conv1 = ngraph::builder::makeConvolution(permute1, ngPrc, { 1, kernal_size }, { 1, 1 }, { 0, 0 }, { 0, 0 }, { 1, 1 },
+            auto conv1 = ngraph::builder::makeConvolution(permute1, ngPrc, kernal_shape, { 1, 1 }, { 0, 0 }, { 0, 0 }, { 1, 1 },
                 ngraph::op::PadType::VALID, num_out_channels, false, filter_weights_1);
 
             auto pattern2 = std::make_shared<ngraph::opset1::Constant>(ngraph::element::Type_t::i64, ngraph::Shape{ 4 }, inputShape);
@@ -384,7 +396,7 @@ class RemovePermutationsWithEltwiseTest : public testing::WithParamInterface<rem
 
             std::vector<float> filter_weights_2 = CommonTestUtils::generate_float_numbers(num_out_channels * in_channels * kernal_size,
                                                                                           -0.2f, 0.2f);
-            auto conv2 = ngraph::builder::makeConvolution(permute2, ngPrc, { 1, kernal_size }, { 1, 1 }, { 0, 0 }, { 0, 0 }, { 1, 1 },
+            auto conv2 = ngraph::builder::makeConvolution(permute2, ngPrc, kernal_shape, { 1, 1 }, { 0, 0 }, { 0, 0 }, { 1, 1 },
                 ngraph::op::PadType::VALID, num_out_channels, false, filter_weights_2);
 
             auto add = std::make_shared<ngraph::opset1::Add>(conv1, conv2);
@@ -392,8 +404,9 @@ class RemovePermutationsWithEltwiseTest : public testing::WithParamInterface<rem
             auto permute3 = std::make_shared<ngraph::opset1::Transpose>(add,
                 ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{ 4 }, { 0, 2, 3, 1 }));
 
-            size_t out_width = ((in_width - kernal_size) + 1);
-            std::vector<size_t> outFormShapes = { 1, out_width * num_out_channels };
+            size_t out_width = ((in_width - kernal_shape[1]) + 1);
+            size_t out_height = ((in_height - kernal_shape[0]) + 1);
+            std::vector<size_t> outFormShapes = { 1, out_width * out_height * num_out_channels };
             auto pattern3 = std::make_shared<ngraph::opset1::Constant>(ngraph::element::Type_t::i64, ngraph::Shape{ 2 }, outFormShapes);
             auto reshape3 = std::make_shared<ngraph::opset1::Reshape>(permute3, pattern3, false);
 
@@ -440,7 +453,13 @@ class RemovePermutationsWithEltwiseTest : public testing::WithParamInterface<rem
         {1, 1, 168, 8},
         {1, 1, 32, 1},
         {1, 1, 32, 2},
-        {1, 1, 32, 8}
+        {1, 1, 32, 8},
+        {1, 168, 1, 1},
+        {1, 168, 1, 2},
+        {1, 168, 1, 8},
+        {1, 32, 1, 1},
+        {1, 32, 1, 2},
+        {1, 32, 1, 8}
     };
 
     INSTANTIATE_TEST_CASE_P(smoke_PermutationPass, RemovePermutationsNHWCToNCHWPassTest,


### PR DESCRIPTION
### Details:
 - Allow graph patterns with permutations around convolution with height dimension > 1
 - Some fixes for convolution quantization
 - Removed setting of kernel_y to be equal to input channels number since it doesn't seem to be used by GNA compiler

### Tickets:
