### PR TITLE
Use Serialization as a default engine in MO

### DIFF
--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/CMakeLists.txt
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/CMakeLists.txt
@@ -49,7 +49,7 @@ endfunction()
 
 python_disable_deprecated_warnings()
 
-target_include_directories(${TARGET_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+target_include_directories(${TARGET_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}" ${IE_MAIN_SOURCE_DIR}/src/inference_engine)
 target_link_libraries(${TARGET_NAME} PRIVATE ${InferenceEngine_LIBRARIES})
 
 # Compatibility with python 2.7 which has deprecated "register" specifier

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pyx
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pyx
@@ -60,6 +60,19 @@ cdef c_map_to_dict(map[string, string] c_map):
 def get_version():
     return C.get_version().decode()
 
+
+def read_network(path_to_xml : str, path_to_bin : str, vector[string] extensions):
+    cdef IENetwork net = IENetwork()
+    net.impl = C.read_network(path_to_xml.encode(), path_to_bin.encode(), extensions)
+    return net
+
+
+def read_network_without_extensions(path_to_xml : str, path_to_bin : str):
+    cdef IENetwork net = IENetwork()
+    net.impl = C.read_network_without_extensions(path_to_xml.encode(), path_to_bin.encode())
+    return net
+
+
 ## This class defines Tensor description
 cdef class TensorDesc:
     def __eq__(self, other : TensorDesc):

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.cpp
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.cpp
@@ -5,6 +5,7 @@
 #include "ie_api_impl.hpp"
 #include "hetero/hetero_plugin_config.hpp"
 #include "ie_iinfer_request.hpp"
+#include "ie_network_reader.hpp"
 
 const std::string EXPORTED_NETWORK_NAME = "undefined";
 std::map <std::string, InferenceEngine::Precision> precision_map = {{"FP32", InferenceEngine::Precision::FP32},
@@ -470,6 +471,20 @@ std::string InferenceEnginePython::get_version() {
     return version_str;
 }
 
+InferenceEnginePython::IENetwork InferenceEnginePython::read_network(const std::string & path_to_xml,
+                                                                     const std::string & path_to_bin,
+                                                                     const std::vector<std::string> & extensions) {
+    std::vector<InferenceEngine::IExtensionPtr> ext;
+    // TODO: create vector of extensions
+    auto net = InferenceEngine::details::ReadNetwork(path_to_xml, path_to_bin, {});
+    return InferenceEnginePython::IENetwork(std::make_shared<InferenceEngine::CNNNetwork>(net));
+}
+
+InferenceEnginePython::IENetwork InferenceEnginePython::read_network_without_extensions(const std::string & path_to_xml,
+                                                                                        const std::string & path_to_bin) {
+    auto net = InferenceEngine::details::ReadNetworkWithoutExtensions(path_to_xml, path_to_bin);
+    return InferenceEnginePython::IENetwork(std::make_shared<InferenceEngine::CNNNetwork>(net));
+}
 
 InferenceEnginePython::IECore::IECore(const std::string &xmlConfigFile) {
     actual = InferenceEngine::Core(xmlConfigFile);

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.cpp
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.cpp
@@ -475,8 +475,11 @@ InferenceEnginePython::IENetwork InferenceEnginePython::read_network(const std::
                                                                      const std::string & path_to_bin,
                                                                      const std::vector<std::string> & extensions) {
     std::vector<InferenceEngine::IExtensionPtr> ext;
-    // TODO: create vector of extensions
-    auto net = InferenceEngine::details::ReadNetwork(path_to_xml, path_to_bin, {});
+    for (const auto & path : extensions) {
+        ext.push_back(std::make_shared<InferenceEngine::Extension>(path));
+    }
+
+    auto net = InferenceEngine::details::ReadNetwork(path_to_xml, path_to_bin, ext);
     return InferenceEnginePython::IENetwork(std::make_shared<InferenceEngine::CNNNetwork>(net));
 }
 

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.hpp
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.hpp
@@ -189,4 +189,9 @@ std::unique_ptr<T> make_unique(Args &&... args) {
 }
 
 std::string get_version();
+
+InferenceEnginePython::IENetwork read_network(const std::string & path_to_xml, const std::string & path_to_bin, const std::vector<std::string> & extensions);
+
+InferenceEnginePython::IENetwork read_network_without_extensions(const std::string & path_to_xml, const std::string & path_to_bin);
+
 };  // namespace InferenceEnginePython

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl_defs.pxd
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl_defs.pxd
@@ -220,3 +220,8 @@ cdef extern from "ie_api_impl.hpp" namespace "InferenceEnginePython":
     cdef T*get_buffer[T](CBlob &)
 
     cdef string get_version()
+
+    cdef IENetwork read_network_without_extensions(const string & path_to_xml, const string & path_to_bin)
+
+    cdef IENetwork read_network(const string & path_to_xml, const string & path_to_bin, const vector[string] & extensions)
+

--- a/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api.pyx
+++ b/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api.pyx
@@ -5,6 +5,7 @@ from .cimport offline_transformations_api_impl_defs as C
 from ..inference_engine.ie_api cimport IENetwork
 
 from libcpp cimport bool
+from libcpp.string cimport string
 
 def ApplyMOCTransformations(IENetwork network, bool cf):
     C.ApplyMOCTransformations(network.impl, cf)
@@ -14,6 +15,9 @@ def ApplyLowLatencyTransformation(IENetwork network):
 
 def ApplyPruningTransformation(IENetwork network):
     C.ApplyPruningTransformation(network.impl)
+
+def GenerateMappingFile(IENetwork network, string path):
+    C.GenerateMappingFile(network.impl, path)
 
 def CheckAPI():
     C.CheckAPI()

--- a/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api_impl.cpp
+++ b/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api_impl.cpp
@@ -4,6 +4,7 @@
 
 #include "offline_transformations_api_impl.hpp"
 
+#include <generate_mapping_file.hpp>
 #include <moc_transformations.hpp>
 #include <pruning.hpp>
 
@@ -39,6 +40,11 @@ void InferenceEnginePython::ApplyPruningTransformation(InferenceEnginePython::IE
     manager.run_passes(network.actual->getFunction());
 }
 
+void InferenceEnginePython::GenerateMappingFile(InferenceEnginePython::IENetwork network, std::string path) {
+    ngraph::pass::Manager manager;
+    manager.register_pass<ngraph::pass::GenerateMappingFile>(path);
+    manager.run_passes(network.actual->getFunction());
+}
 
 void InferenceEnginePython::CheckAPI() {
     std::shared_ptr<ngraph::Function> f;

--- a/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api_impl.hpp
+++ b/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api_impl.hpp
@@ -15,6 +15,8 @@ void ApplyLowLatencyTransformation(InferenceEnginePython::IENetwork network);
 
 void ApplyPruningTransformation(InferenceEnginePython::IENetwork network);
 
+void GenerateMappingFile(InferenceEnginePython::IENetwork network, std::string path);
+
 void CheckAPI();
 
 };  // namespace InferenceEnginePython

--- a/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api_impl_defs.pxd
+++ b/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api_impl_defs.pxd
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from libcpp cimport bool
+from libcpp.string cimport string
+
 from ..inference_engine.ie_api_impl_defs cimport IENetwork
 
 cdef extern from "offline_transformations_api_impl.hpp" namespace "InferenceEnginePython":
@@ -10,5 +12,7 @@ cdef extern from "offline_transformations_api_impl.hpp" namespace "InferenceEngi
     cdef void ApplyLowLatencyTransformation(IENetwork network)
 
     cdef void ApplyPruningTransformation(IENetwork network)
+
+    cdef void GenerateMappingFile(IENetwork network, string path)
 
     cdef void CheckAPI()

--- a/inference-engine/src/inference_engine/cnn_network_ngraph_impl.cpp
+++ b/inference-engine/src/inference_engine/cnn_network_ngraph_impl.cpp
@@ -260,6 +260,10 @@ size_t CNNNetworkNGraphImpl::getBatchSize() const noexcept {
     // This is not correct in general. We can follow the same semantics, but order of inputs should be
     // guaranteed to be the same.
     auto params = _ngraph_function->get_parameters();
+    sort(params.begin(), params.end(), [](std::shared_ptr<ngraph::Node> lhs, std::shared_ptr<ngraph::Node> rhs) {
+        return lhs->get_friendly_name() < rhs->get_friendly_name();
+    });
+
     for (const auto& param : params) {
         if (param->get_partial_shape().rank().is_dynamic())
             continue;

--- a/inference-engine/src/inference_engine/ie_network_reader.cpp
+++ b/inference-engine/src/inference_engine/ie_network_reader.cpp
@@ -168,8 +168,7 @@ void ReadModel(const std::string & modelPath, std::ifstream & modelStream) {
     modelStream.open(model_path, std::ios::binary);
     // save path in extensible array of stream
     // notice: lifetime of path pointed by pword(0) is limited by current scope
-    const std::string path_to_save_in_stream = modelPath;
-    modelStream.pword(0) = const_cast<char*>(path_to_save_in_stream.c_str());
+    modelStream.pword(0) = const_cast<char*>(modelPath.c_str());
     if (!modelStream.is_open())
         IE_THROW() << "Model file " << modelPath << " cannot be opened!";
 

--- a/inference-engine/src/inference_engine/ie_network_reader.cpp
+++ b/inference-engine/src/inference_engine/ie_network_reader.cpp
@@ -8,6 +8,7 @@
 #include <details/ie_so_pointer.hpp>
 #include <file_utils.h>
 #include <ie_reader.hpp>
+#include <ie_ir_parser.hpp>
 #include <ie_ir_version.hpp>
 
 #include <fstream>
@@ -29,6 +30,18 @@ public:
      * @brief A name of the fabric for creating IReader object in DLL
      */
     static constexpr auto name = "CreateReader";
+};
+
+/**
+ * @brief This class defines the name of the fabric for creating an IRReader object in DLL
+ */
+template <>
+class SOCreatorTrait<V10Parser> {
+public:
+    /**
+     * @brief A name of the fabric for creating V10Parser object in DLL
+     */
+    static constexpr auto name = "CreateV10Parser";
 };
 
 }  // namespace details
@@ -227,6 +240,75 @@ CNNNetwork details::ReadNetwork(const std::string& modelPath, const std::string&
     }
     IE_THROW() << "Unknown model format! Cannot find reader for model format: " << fileExt << " and read the model: " << modelPath <<
         ". Please check that reader library exists in your PATH.";
+}
+
+CNNNetwork details::ReadNetworkWithoutExtensions(const std::string& modelPath, const std::string& binPath) {
+    const auto ir_reader_path = std::string("inference_engine_ir_reader") + std::string(IE_BUILD_POSTFIX);
+
+    FileUtils::FilePath libraryName = FileUtils::toFilePath(ir_reader_path);
+    FileUtils::FilePath readersLibraryPath = FileUtils::makePluginLibraryName(getInferenceEngineLibraryPath(), libraryName);
+
+    if (!FileUtils::fileExist(readersLibraryPath)) {
+        IE_THROW() << "Please, make sure that Inference Engine IR reader library "
+                   << FileUtils::fromFilePath(::FileUtils::makePluginLibraryName({}, libraryName)) << " is in "
+                   << getIELibraryPath();
+    }
+    auto ptr = InferenceEngine::details::SOPointer<V10Parser>(readersLibraryPath);
+
+    // Try to open model file
+    std::ifstream modelStream(modelPath, std::ios::binary);
+    // save path in extensible array of stream
+    // notice: lifetime of path pointed by pword(0) is limited by current scope
+    const std::string path_to_save_in_stream = modelPath;
+    modelStream.pword(0) = const_cast<char*>(path_to_save_in_stream.c_str());
+    if (!modelStream.is_open())
+        IE_THROW() << "Model file " << modelPath << " cannot be opened!";
+
+    std::string bPath = binPath;
+    if (bPath.empty()) {
+        auto pathWoExt = modelPath;
+        auto pos = modelPath.rfind('.');
+        if (pos != std::string::npos) pathWoExt = modelPath.substr(0, pos);
+        bPath = pathWoExt + ".bin";
+        if (!FileUtils::fileExist(bPath)) {
+            bPath.clear();
+        }
+    }
+
+    Blob::Ptr weights = nullptr;
+
+    if (!bPath.empty()) {
+        // Open weights file
+#if defined(ENABLE_UNICODE_PATH_SUPPORT) && defined(_WIN32)
+        std::wstring weights_path = FileUtils::multiByteCharToWString(bPath.c_str());
+#else
+        std::string weights_path = bPath;
+#endif
+        std::ifstream binStream;
+        binStream.open(weights_path, std::ios::binary);
+        if (!binStream.is_open())
+            IE_THROW() << "Weights file " << bPath << " cannot be opened!";
+
+        binStream.seekg(0, std::ios::end);
+        size_t fileSize = binStream.tellg();
+        binStream.seekg(0, std::ios::beg);
+
+        weights = make_shared_blob<uint8_t>({Precision::U8, { fileSize }, C });
+        weights->allocate();
+
+        binStream.read(weights->buffer(), fileSize);
+        binStream.close();
+    }
+
+    pugi::xml_document xmlDoc;
+    pugi::xml_parse_result res = xmlDoc.load(modelStream);
+    if (res.status != pugi::status_ok) {
+        IE_THROW() << res.description() << "at offset " << res.offset;
+    }
+
+    pugi::xml_node root = xmlDoc.document_element();
+
+    return CNNNetwork(ptr->parse_without_extensions(root, weights));
 }
 
 CNNNetwork details::ReadNetwork(const std::string& model, const Blob::CPtr& weights, const std::vector<IExtensionPtr>& exts) {

--- a/inference-engine/src/inference_engine/ie_network_reader.hpp
+++ b/inference-engine/src/inference_engine/ie_network_reader.hpp
@@ -20,7 +20,7 @@ namespace details {
  * @param exts vector with extensions
  * @return CNNNetwork
  */
-CNNNetwork ReadNetwork(const std::string& modelPath, const std::string& binPath, const std::vector<IExtensionPtr>& exts);
+CNNNetwork INFERENCE_ENGINE_API_CPP(ReadNetwork) (const std::string& modelPath, const std::string& binPath, const std::vector<IExtensionPtr>& exts);
 
 CNNNetwork INFERENCE_ENGINE_API_CPP(ReadNetworkWithoutExtensions) (const std::string& modelPath, const std::string& binPath = "");
 

--- a/inference-engine/src/inference_engine/ie_network_reader.hpp
+++ b/inference-engine/src/inference_engine/ie_network_reader.hpp
@@ -20,9 +20,9 @@ namespace details {
  * @param exts vector with extensions
  * @return CNNNetwork
  */
-CNNNetwork INFERENCE_ENGINE_API_CPP(ReadNetwork) (const std::string& modelPath, const std::string& binPath, const std::vector<IExtensionPtr>& exts);
+INFERENCE_ENGINE_API_CPP(CNNNetwork) ReadNetwork(const std::string& modelPath, const std::string& binPath, const std::vector<IExtensionPtr>& exts);
 
-CNNNetwork INFERENCE_ENGINE_API_CPP(ReadNetworkWithoutExtensions) (const std::string& modelPath, const std::string& binPath = "");
+INFERENCE_ENGINE_API_CPP(CNNNetwork) ReadNetworkWithoutExtensions(const std::string& modelPath, const std::string& binPath = "");
 
 /**
  * @brief Reads IR xml and bin (with the same name) files

--- a/inference-engine/src/inference_engine/ie_network_reader.hpp
+++ b/inference-engine/src/inference_engine/ie_network_reader.hpp
@@ -21,6 +21,9 @@ namespace details {
  * @return CNNNetwork
  */
 CNNNetwork ReadNetwork(const std::string& modelPath, const std::string& binPath, const std::vector<IExtensionPtr>& exts);
+
+CNNNetwork INFERENCE_ENGINE_API_CPP(ReadNetworkWithoutExtensions) (const std::string& modelPath, const std::string& binPath = "");
+
 /**
  * @brief Reads IR xml and bin (with the same name) files
  * @param model string with IR

--- a/inference-engine/src/inference_engine/ie_network_reader.hpp
+++ b/inference-engine/src/inference_engine/ie_network_reader.hpp
@@ -22,6 +22,13 @@ namespace details {
  */
 INFERENCE_ENGINE_API_CPP(CNNNetwork) ReadNetwork(const std::string& modelPath, const std::string& binPath, const std::vector<IExtensionPtr>& exts);
 
+/**
+ * @brief Reads IR xml and bin files
+ * @param modelPath path to IR file
+ * @param binPath path to bin file, if path is empty, will try to read bin file with the same name as xml and
+ * if bin file with the same name was not found, will load IR without weights.
+ * @return CNNNetwork
+ */
 INFERENCE_ENGINE_API_CPP(CNNNetwork) ReadNetworkWithoutExtensions(const std::string& modelPath, const std::string& binPath = "");
 
 /**

--- a/inference-engine/src/offline_transformations/CMakeLists.txt
+++ b/inference-engine/src/offline_transformations/CMakeLists.txt
@@ -20,7 +20,7 @@ source_group("include" FILES ${PUBLIC_HEADERS})
 add_library(${TARGET_NAME} STATIC ${LIBRARY_SRC} ${PUBLIC_HEADERS})
 
 target_link_libraries(${TARGET_NAME} PUBLIC ${NGRAPH_LIBRARIES} inference_engine_transformations ngraph::reference
-                                     PRIVATE openvino::itt)
+                                     PRIVATE openvino::itt pugixml)
 
 target_include_directories(${TARGET_NAME} PUBLIC ${PUBLIC_HEADERS_DIR}
                                           PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src")

--- a/inference-engine/src/offline_transformations/include/generate_mapping_file.hpp
+++ b/inference-engine/src/offline_transformations/include/generate_mapping_file.hpp
@@ -1,0 +1,30 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+
+#include <ngraph/pass/graph_rewrite.hpp>
+
+namespace ngraph {
+namespace pass {
+
+class GenerateMappingFile;
+
+}  // namespace pass
+}  // namespace ngraph
+
+/**
+ * @brief Generate mapping file based on output tensor names.
+ */
+
+class ngraph::pass::GenerateMappingFile: public ngraph::pass::FunctionPass {
+    std::string m_path_to_file;
+public:
+    NGRAPH_RTTI_DECLARATION;
+    explicit GenerateMappingFile(const std::string & path) : m_path_to_file(path) {}
+
+    bool run_on_function(std::shared_ptr<ngraph::Function>) override;
+};

--- a/inference-engine/src/offline_transformations/include/generate_mapping_file.hpp
+++ b/inference-engine/src/offline_transformations/include/generate_mapping_file.hpp
@@ -22,9 +22,11 @@ class GenerateMappingFile;
 
 class ngraph::pass::GenerateMappingFile: public ngraph::pass::FunctionPass {
     std::string m_path_to_file;
+    bool m_extract_name;
 public:
     NGRAPH_RTTI_DECLARATION;
-    explicit GenerateMappingFile(const std::string & path) : m_path_to_file(path) {}
+    explicit GenerateMappingFile(const std::string & path, bool extract_name = true)
+        : m_path_to_file(path), m_extract_name(extract_name) {}
 
     bool run_on_function(std::shared_ptr<ngraph::Function>) override;
 };

--- a/inference-engine/src/offline_transformations/src/generate_mapping_file.cpp
+++ b/inference-engine/src/offline_transformations/src/generate_mapping_file.cpp
@@ -1,0 +1,43 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <memory>
+#include <ostream>
+#include <fstream>
+
+#include "generate_mapping_file.hpp"
+
+#include "pugixml.hpp"
+
+NGRAPH_RTTI_DEFINITION(ngraph::pass::GenerateMappingFile, "GenerateMappingFile", 0);
+
+bool ngraph::pass::GenerateMappingFile::run_on_function(std::shared_ptr<ngraph::Function> f) {
+    pugi::xml_document xml_doc;
+    pugi::xml_node root_node = xml_doc.append_child("mapping");
+
+    for (auto && node : f->get_ordered_ops()) {
+        uint64_t port_index{node->inputs().size()};
+        for (auto && output : node->outputs()) {
+            const auto & t = output.get_tensor_ptr();
+            for (const auto & port_name : t->get_names()) {
+                auto map_node = root_node.append_child("map");
+                auto framework_node = map_node.append_child("framework");
+                auto ir_node = map_node.append_child("IR");
+
+                framework_node.append_attribute("name").set_value(node->get_friendly_name().c_str());
+                framework_node.append_attribute("output_port_id").set_value(port_name.c_str());
+
+                ir_node.append_attribute("name").set_value(node->get_friendly_name().c_str());
+                ir_node.append_attribute("output_port_id").set_value(port_index);
+            }
+            ++port_index;
+        }
+    }
+
+    // save mapping file
+    std::ofstream mapping_file(m_path_to_file, std::ios::out);
+    xml_doc.save(mapping_file);
+    mapping_file.flush();
+    return false;
+}

--- a/inference-engine/src/offline_transformations/src/generate_mapping_file.cpp
+++ b/inference-engine/src/offline_transformations/src/generate_mapping_file.cpp
@@ -16,20 +16,41 @@ bool ngraph::pass::GenerateMappingFile::run_on_function(std::shared_ptr<ngraph::
     pugi::xml_document xml_doc;
     pugi::xml_node root_node = xml_doc.append_child("mapping");
 
+    auto add_mapping = [&](const std::string & fw_name, const std::string & fw_port_name,
+                           const std::string & ir_name, const std::string & ir_port_name) {
+        auto map_node = root_node.append_child("map");
+        auto framework_node = map_node.append_child("framework");
+        auto ir_node = map_node.append_child("IR");
+
+        framework_node.append_attribute("name").set_value(fw_name.c_str());
+        framework_node.append_attribute("output_port_id").set_value(fw_port_name.c_str());
+
+        ir_node.append_attribute("name").set_value(ir_name.c_str());
+        ir_node.append_attribute("output_port_id").set_value(ir_port_name.c_str());
+    };
+
+    auto extract_name = [](const std::string & port_name) -> std::string {
+        std::string res;
+        for (auto ch : port_name) {
+            if (ch == ':') break;
+            res += ch;
+        }
+        return res;
+    };
+
     for (auto && node : f->get_ordered_ops()) {
         uint64_t port_index{node->inputs().size()};
         for (auto && output : node->outputs()) {
             const auto & t = output.get_tensor_ptr();
             for (const auto & port_name : t->get_names()) {
-                auto map_node = root_node.append_child("map");
-                auto framework_node = map_node.append_child("framework");
-                auto ir_node = map_node.append_child("IR");
+                const auto & node_name = node->get_friendly_name();
+                add_mapping(node_name, port_name, node_name, std::to_string(port_index));
 
-                framework_node.append_attribute("name").set_value(node->get_friendly_name().c_str());
-                framework_node.append_attribute("output_port_id").set_value(port_name.c_str());
-
-                ir_node.append_attribute("name").set_value(node->get_friendly_name().c_str());
-                ir_node.append_attribute("output_port_id").set_value(port_index);
+                if (m_extract_name) {
+                    for (auto &name : t->get_names()) {
+                        add_mapping(extract_name(name), port_name, node_name, std::to_string(port_index));
+                    }
+                }
             }
             ++port_index;
         }

--- a/inference-engine/src/offline_transformations/src/generate_mapping_file.cpp
+++ b/inference-engine/src/offline_transformations/src/generate_mapping_file.cpp
@@ -39,20 +39,24 @@ bool ngraph::pass::GenerateMappingFile::run_on_function(std::shared_ptr<ngraph::
     };
 
     for (auto && node : f->get_ordered_ops()) {
-        uint64_t port_index{node->inputs().size()};
+        uint64_t ie_port_index{node->inputs().size()};
+        uint64_t ng_port_index{0};
         for (auto && output : node->outputs()) {
+            const auto & node_name = node->get_friendly_name();
+            add_mapping(node_name, node_name + ":" + std::to_string(ng_port_index), node_name, std::to_string(ie_port_index));
+
             const auto & t = output.get_tensor_ptr();
             for (const auto & port_name : t->get_names()) {
-                const auto & node_name = node->get_friendly_name();
-                add_mapping(node_name, port_name, node_name, std::to_string(port_index));
+                add_mapping(node_name, port_name, node_name, std::to_string(ie_port_index));
 
                 if (m_extract_name) {
                     for (auto &name : t->get_names()) {
-                        add_mapping(extract_name(name), port_name, node_name, std::to_string(port_index));
+                        add_mapping(extract_name(name), port_name, node_name, std::to_string(ie_port_index));
                     }
                 }
             }
-            ++port_index;
+            ++ie_port_index;
+            ++ng_port_index;
         }
     }
 

--- a/inference-engine/src/readers/ir_reader/ie_ir_parser.cpp
+++ b/inference-engine/src/readers/ir_reader/ie_ir_parser.cpp
@@ -53,6 +53,10 @@ std::shared_ptr<ICNNNetwork> IRParser::parse(
     return parser->parse(root, weights);
 }
 
+std::shared_ptr<ICNNNetwork> IRParser::parse_without_extensions(const pugi::xml_node &root, const Blob::CPtr &weights) {
+    return parser->parse_without_extensions(root, weights);
+}
+
 namespace {
 
 bool getStrAttribute(const pugi::xml_node& node, const std::string& name, std::string& value) {

--- a/inference-engine/src/readers/ir_reader/ie_ir_parser.cpp
+++ b/inference-engine/src/readers/ir_reader/ie_ir_parser.cpp
@@ -537,9 +537,9 @@ void XmlDeserializer::on_adapter(const std::string& name, ngraph::ValueAccessor<
         pugi::xml_node dn = node.child("data");
 
         if (!dn.empty()) {
-            std::vector<std::pair<std::string, std::string>> attrs;
+            std::map<std::string, std::string> attrs;
             for (const auto & data_attr : dn.attributes()) {
-                attrs.emplace_back(std::make_pair(data_attr.name(), data_attr.as_string()));
+                attrs[data_attr.name()] = data_attr.as_string();
             }
             node_attrs.set_attrs(attrs);
         }

--- a/inference-engine/src/readers/ir_reader/ie_ir_parser.cpp
+++ b/inference-engine/src/readers/ir_reader/ie_ir_parser.cpp
@@ -948,10 +948,6 @@ std::shared_ptr<ICNNNetwork> V10Parser::parse_without_extensions(
     return net;
 }
 
-void CreateV10Parser(std::shared_ptr<V10Parser> &parser) {
-    parser = std::make_shared<V10Parser>();
-}
-
 void V10Parser::parsePreProcess(
     CNNNetwork& network, const pugi::xml_node& root, const Blob::CPtr& weights) {
     /*

--- a/inference-engine/src/readers/ir_reader/ie_ir_parser.cpp
+++ b/inference-engine/src/readers/ir_reader/ie_ir_parser.cpp
@@ -853,7 +853,6 @@ std::shared_ptr<ngraph::Node> XmlDeserializer::createNode(
     }
 
     if (!ngraphNode && m_use_framework_node) {
-        // TODO: pass output shapes
         ngraphNode = std::make_shared<ngraph::op::util::FrameworkNode>(inputs);
         XmlDeserializer visitor(node, weights, opsets, variables);
         ngraphNode->visit_attributes(visitor);

--- a/inference-engine/src/readers/ir_reader/ie_ir_parser.hpp
+++ b/inference-engine/src/readers/ir_reader/ie_ir_parser.hpp
@@ -4,12 +4,14 @@
 
 #pragma once
 
+#ifdef IR_READER_V10
 #include <ie_ngraph_utils.hpp>
 #include <ngraph/node.hpp>
 #include <ngraph/op/util/sub_graph_base.hpp>
 #include <ngraph/op/util/variable.hpp>
 #include <ngraph/opsets/opset.hpp>
 #include <ngraph/opsets/opset5.hpp>
+#endif  // IR_READER_V10
 
 #include <cpp/ie_cnn_network.h>
 #include <ie_blob.h>
@@ -59,7 +61,8 @@ public:
         const pugi::xml_node& root, const Blob::CPtr& weights) override;
 };
 
-class INFERENCE_ENGINE_API_CLASS(V10Parser) : public IParser {
+#ifdef IR_READER_V10
+class V10Parser : public IParser {
 public:
     explicit V10Parser(const std::vector<IExtensionPtr>& exts = {});
 
@@ -97,6 +100,6 @@ private:
     const std::vector<IExtensionPtr> _exts;
 };
 
-INFERENCE_PLUGIN_API(void) CreateV10Parser(std::shared_ptr<V10Parser>& parser);
+#endif  // IR_READER_V10
 
 }  // namespace InferenceEngine

--- a/inference-engine/src/readers/ir_reader/ie_ir_parser.hpp
+++ b/inference-engine/src/readers/ir_reader/ie_ir_parser.hpp
@@ -46,8 +46,8 @@ public:
     explicit IRParser(size_t version);
     IRParser(size_t version, const std::vector<InferenceEngine::IExtensionPtr>& exts);
     std::shared_ptr<ICNNNetwork> parse(const pugi::xml_node& root, const Blob::CPtr& weights);
+    std::shared_ptr<ICNNNetwork> parse_without_extensions(const pugi::xml_node& root, const Blob::CPtr& weights);
     virtual ~IRParser() = default;
-
 private:
     IParser::Ptr parser;
 };

--- a/inference-engine/src/readers/ir_reader/ie_ir_parser.hpp
+++ b/inference-engine/src/readers/ir_reader/ie_ir_parser.hpp
@@ -4,14 +4,12 @@
 
 #pragma once
 
-#ifdef IR_READER_V10
 #include <ie_ngraph_utils.hpp>
 #include <ngraph/node.hpp>
 #include <ngraph/op/util/sub_graph_base.hpp>
 #include <ngraph/op/util/variable.hpp>
 #include <ngraph/opsets/opset.hpp>
 #include <ngraph/opsets/opset5.hpp>
-#endif  // IR_READER_V10
 
 #include <cpp/ie_cnn_network.h>
 #include <ie_blob.h>
@@ -36,6 +34,11 @@ public:
     virtual ~IParser() = default;
     virtual std::shared_ptr<ICNNNetwork> parse(
         const pugi::xml_node& root, const Blob::CPtr& weights) = 0;
+
+    virtual std::shared_ptr<ICNNNetwork> parse_without_extensions(
+        const pugi::xml_node& root, const Blob::CPtr& weights) {
+        IE_THROW() << "Not implemented";
+    }
 };
 
 class IRParser {
@@ -56,13 +59,15 @@ public:
         const pugi::xml_node& root, const Blob::CPtr& weights) override;
 };
 
-#ifdef IR_READER_V10
-class V10Parser : public IParser {
+class INFERENCE_ENGINE_API_CLASS(V10Parser) : public IParser {
 public:
-    explicit V10Parser(const std::vector<IExtensionPtr>& exts);
+    explicit V10Parser(const std::vector<IExtensionPtr>& exts = {});
 
     std::shared_ptr<ICNNNetwork> parse(
         const pugi::xml_node& root, const Blob::CPtr& weights) override;
+
+    std::shared_ptr<ICNNNetwork> parse_without_extensions(
+            const pugi::xml_node& root, const Blob::CPtr& weights) override;
 
     struct GenericLayerParams {
         struct LayerPortData {
@@ -92,6 +97,6 @@ private:
     const std::vector<IExtensionPtr> _exts;
 };
 
-#endif  // IR_READER_V10
+INFERENCE_PLUGIN_API(void) CreateV10Parser(std::shared_ptr<V10Parser>& parser);
 
 }  // namespace InferenceEngine

--- a/inference-engine/src/readers/ir_reader/ie_ir_reader.cpp
+++ b/inference-engine/src/readers/ir_reader/ie_ir_reader.cpp
@@ -48,6 +48,25 @@ CNNNetwork IRReader::read(std::istream& model, const Blob::CPtr& weights, const 
     return CNNNetwork(parser.parse(root, weights));
 }
 
+CNNNetwork IRReader::read_without_extensions(std::istream &model, const Blob::CPtr &weights) const {
+    OV_ITT_SCOPED_TASK(itt::domains::V10Reader, "IRReader::read_without_extensions");
+
+    pugi::xml_document xmlDoc;
+    pugi::xml_parse_result res = xmlDoc.load(model);
+    if (res.status != pugi::status_ok) {
+        IE_THROW() << res.description() << "at offset " << res.offset;
+    }
+    pugi::xml_node root = xmlDoc.document_element();
+
+    auto version = details::GetIRVersion(root);
+    IRParser parser(version);
+    return CNNNetwork(parser.parse_without_extensions(root, weights));
+}
+
+CNNNetwork IRReader::read_without_extensions(std::istream &model) const {
+    return read_without_extensions(model, nullptr);
+}
+
 INFERENCE_PLUGIN_API(void) InferenceEngine::CreateReader(std::shared_ptr<IReader>& reader) {
     reader = std::make_shared<IRReader>();
 }

--- a/inference-engine/src/readers/ir_reader/ie_ir_reader.hpp
+++ b/inference-engine/src/readers/ir_reader/ie_ir_reader.hpp
@@ -56,6 +56,10 @@ public:
      */
     CNNNetwork read(std::istream& model, const Blob::CPtr& weights, const std::vector<IExtensionPtr>& exts) const override;
 
+    CNNNetwork read_without_extensions(std::istream& model, const Blob::CPtr& weights) const override;
+
+    CNNNetwork read_without_extensions(std::istream& model) const override;
+
     std::vector<std::string> getDataFileExtensions() const override {
         return {"bin"};
     }

--- a/inference-engine/src/readers/ir_reader_v7/ie_ir_parser.cpp
+++ b/inference-engine/src/readers/ir_reader_v7/ie_ir_parser.cpp
@@ -22,6 +22,10 @@ std::shared_ptr<ICNNNetwork> IRParser::parse(const pugi::xml_node& root, const B
     return parser->parse(root, weights);
 }
 
+std::shared_ptr<ICNNNetwork> IRParser::parse_without_extensions(const pugi::xml_node &root, const Blob::CPtr &weights) {
+    IE_THROW() << "Not supported!";
+}
+
 /**
  * Hold original blob in order to avoid situations when original blob is allocated on stack
  */

--- a/inference-engine/src/readers/onnx_reader/ie_onnx_reader.hpp
+++ b/inference-engine/src/readers/onnx_reader/ie_onnx_reader.hpp
@@ -36,6 +36,14 @@ public:
         IE_THROW() << "ONNX reader cannot read model with weights!";
     }
 
+    CNNNetwork read_without_extensions(std::istream &model, const Blob::CPtr &weights) const override {
+        IE_THROW() << "ONNX reader cannot read model with weights!";
+    }
+
+    CNNNetwork read_without_extensions(std::istream &model) const override {
+        IE_THROW() << "Not Implemented!";
+    }
+
     std::vector<std::string> getDataFileExtensions() const override {
         return {};
     }

--- a/inference-engine/src/readers/reader_api/ie_reader.hpp
+++ b/inference-engine/src/readers/reader_api/ie_reader.hpp
@@ -42,6 +42,10 @@ public:
      */
     virtual CNNNetwork read(std::istream& model, const Blob::CPtr& weights, const std::vector<IExtensionPtr>& exts) const = 0;
 
+    virtual CNNNetwork read_without_extensions(std::istream& model, const Blob::CPtr& weights) const = 0;
+
+    virtual CNNNetwork read_without_extensions(std::istream& model) const = 0;
+
     /**
      * @brief Returns all supported extensions for data files
      *

--- a/inference-engine/src/transformations/src/transformations/serialize.cpp
+++ b/inference-engine/src/transformations/src/transformations/serialize.cpp
@@ -512,6 +512,8 @@ std::string get_precision_name(const ngraph::element::Type & elem_type) {
         return "BF16";
     case ::ngraph::element::Type_t::f64:
         return "FP64";
+    case ::ngraph::element::Type_t::i4:
+        return "I4";
     case ::ngraph::element::Type_t::i8:
         return "I8";
     case ::ngraph::element::Type_t::i16:

--- a/inference-engine/src/transformations/src/transformations/serialize.cpp
+++ b/inference-engine/src/transformations/src/transformations/serialize.cpp
@@ -522,6 +522,8 @@ std::string get_precision_name(const ngraph::element::Type & elem_type) {
         return "I32";
     case ::ngraph::element::Type_t::i64:
         return "I64";
+    case ::ngraph::element::Type_t::u4:
+            return "U4";
     case ::ngraph::element::Type_t::u8:
         return "U8";
     case ::ngraph::element::Type_t::u16:

--- a/inference-engine/src/transformations/src/transformations/serialize.cpp
+++ b/inference-engine/src/transformations/src/transformations/serialize.cpp
@@ -7,12 +7,14 @@
 #include <cassert>
 #include <cstdint>
 #include <fstream>
+#include <iostream>
 #include <unordered_map>
 #include <unordered_set>
 
 #include <ngraph/variant.hpp>
 #include "ngraph/ops.hpp"
 #include "ngraph/opsets/opset.hpp"
+#include "ngraph/opsets/opset1.hpp"
 #include "ngraph/op/util/framework_node.hpp"
 #include "pugixml.hpp"
 #include "transformations/serialize.hpp"
@@ -498,8 +500,7 @@ std::string get_opset_name(
     return "experimental";
 }
 
-std::string get_output_precision_name(ngraph::Output<Node>& o) {
-    auto elem_type = o.get_element_type();
+std::string get_precision_name(const ngraph::element::Type & elem_type) {
     switch (elem_type) {
     case ::ngraph::element::Type_t::undefined:
         return "UNSPECIFIED";
@@ -532,8 +533,9 @@ std::string get_output_precision_name(ngraph::Output<Node>& o) {
     case ::ngraph::element::Type_t::boolean:
         return "BOOL";
     default:
-        NGRAPH_CHECK(false, "Unsupported precision in ", o);
-        return "";
+        std::stringstream msg;
+        msg << "Unsupported precision: " << elem_type;
+        throw ngraph_error(msg.str());
     }
 }
 
@@ -715,21 +717,20 @@ void ngfunction_2_irv10(pugi::xml_node& netXml,
         // <layers/input>
         if (node->get_input_size() > 0) {
             pugi::xml_node input = layer.append_child("input");
-            for (auto i : node->inputs()) {
+            for (const auto & i : node->inputs()) {
                 NGRAPH_CHECK(i.get_partial_shape().is_static(),
                              "Unsupported dynamic input shape in ", node);
 
                 // WA for LSTMCellv0, peephole input shall not be serialized
-                if (i.get_index() == 6) {
-                    auto type_info = node->get_type_info();
-                    if (!strcmp(type_info.name, "LSTMCell") && type_info.version == 0) {
-                        port_id++;
-                        continue;
-                    }
+                if (i.get_index() == 6 && dynamic_cast<opset1::LSTMCell *>(node)) {
+                    port_id++;
+                    continue;
                 }
 
                 pugi::xml_node port = input.append_child("port");
                 port.append_attribute("id").set_value(port_id++);
+                port.append_attribute("precision")
+                        .set_value(get_precision_name(i.get_element_type()).c_str());
                 for (auto d : i.get_shape()) {
                     pugi::xml_node dim = port.append_child("dim");
                     dim.append_child(pugi::xml_node_type::node_pcdata)
@@ -744,14 +745,14 @@ void ngfunction_2_irv10(pugi::xml_node& netXml,
         // <layers/output>
         if ((node->get_output_size() > 0) && !ngraph::op::is_output(node)) {
             pugi::xml_node output = layer.append_child("output");
-            for (auto o : node->outputs()) {
+            for (const auto & o : node->outputs()) {
                 NGRAPH_CHECK(o.get_partial_shape().is_static(),
                              "Unsupported dynamic output shape in ", node);
 
                 pugi::xml_node port = output.append_child("port");
                 port.append_attribute("id").set_value(port_id++);
                 port.append_attribute("precision")
-                    .set_value(get_output_precision_name(o).c_str());
+                    .set_value(get_precision_name(o.get_element_type()).c_str());
                 std::string names;
                 for (const auto& name : o.get_tensor().get_names()) {
                     if (!names.empty())

--- a/inference-engine/tests/functional/inference_engine/CMakeLists.txt
+++ b/inference-engine/tests/functional/inference_engine/CMakeLists.txt
@@ -17,6 +17,7 @@ set(LINK_LIBRARIES
     sharedTestClasses
     inference_engine_snippets
     offline_transformations
+    inference_engine
 )
 
 set(DEPENDENCIES

--- a/inference-engine/tests/ie_test_utils/common_test_utils/ngraph_test_utils.cpp
+++ b/inference-engine/tests/ie_test_utils/common_test_utils/ngraph_test_utils.cpp
@@ -73,7 +73,7 @@ bool compare_rt_keys(const Node &node1, const Node &node2) {
 bool less_by_name(
         const std::shared_ptr<ngraph::op::v0::Result> &l,
         const std::shared_ptr<ngraph::op::v0::Result> &r) {
-    return l->get_friendly_name() < r->get_friendly_name();
+    return l->get_input_node_shared_ptr(0)->get_friendly_name() < r->get_input_node_shared_ptr(0)->get_friendly_name();
 }
 
 

--- a/inference-engine/tests/ie_test_utils/common_test_utils/ngraph_test_utils.cpp
+++ b/inference-engine/tests/ie_test_utils/common_test_utils/ngraph_test_utils.cpp
@@ -73,10 +73,14 @@ bool compare_rt_keys(const Node &node1, const Node &node2) {
 bool less_by_name(
         const std::shared_ptr<ngraph::op::v0::Result> &l,
         const std::shared_ptr<ngraph::op::v0::Result> &r) {
-    return l->get_input_node_shared_ptr(0)->get_friendly_name() < r->get_input_node_shared_ptr(0)->get_friendly_name();
+    return l->get_friendly_name() < r->get_friendly_name();
 }
 
-
+bool less_by_parent_name(
+        const std::shared_ptr<ngraph::op::v0::Result> &l,
+        const std::shared_ptr<ngraph::op::v0::Result> &r) {
+    return l->get_input_node_shared_ptr(0)->get_friendly_name() < r->get_input_node_shared_ptr(0)->get_friendly_name();
+}
 
 std::string typeInfoToStr(const ngraph::Node::type_info_t &typeInfo) {
     return std::string(typeInfo.name) + "/" + to_str(typeInfo.version);
@@ -550,8 +554,21 @@ Comparator::Result Comparator::compare(
     auto f1_results = f1->get_results();
     auto f2_results = f2->get_results();
 
-    std::sort(f1_results.begin(), f1_results.end(), less_by_name);
-    std::sort(f2_results.begin(), f2_results.end(), less_by_name);
+    auto cmp = less_by_name;
+    // In case if Result source output has more than one name so the Result may have any of this names as a friendly name
+    // And in case of multiple names we sort Result operation using their parent node names
+    if (std::any_of(f1_results.begin(), f1_results.end(), [](const std::shared_ptr<ngraph::Node> & node) {
+        const auto & t = node->input_value(0).get_tensor_ptr();
+        return t->get_names().size() > 1;
+    }) || std::any_of(f2_results.begin(), f2_results.end(), [](const std::shared_ptr<ngraph::Node> & node) {
+        const auto & t = node->input_value(0).get_tensor_ptr();
+        return t->get_names().size() > 1;
+    })) {
+        cmp = less_by_parent_name;
+    }
+
+    std::sort(f1_results.begin(), f1_results.end(), cmp);
+    std::sort(f2_results.begin(), f2_results.end(), cmp);
 
     if (f1_results.size() != f2_results.size()) {
         return Result::error(

--- a/model-optimizer/mo/back/ie_ir_ver_2/emitter.py
+++ b/model-optimizer/mo/back/ie_ir_ver_2/emitter.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import hashlib
-from xml.etree.ElementTree import Element, SubElement, tostring
+from xml.etree.ElementTree import Element, SubElement, tostring, ElementTree
 
 from defusedxml.minidom import parseString
 
@@ -438,3 +438,28 @@ def port_renumber(graph: Graph):
         for v, d in node.get_sorted_outputs():
             d['out'] = base
             base += 1
+
+
+def append_ir_info(file: str, meta_info: dict = dict(), mean_data: [list, None] = None, input_names: list = None):
+    path_to_xml = file + ".xml"
+    path_to_bin = file + ".bin"
+
+    et = ElementTree()
+    et.parse(path_to_xml)
+    net = et.getroot()
+
+    if mean_data:
+        mean_offset, mean_size = serialize_mean_image(path_to_bin, mean_data=mean_data)
+        create_pre_process_block_for_image(net, input_names, mean_offset, mean_size)
+
+    add_meta_data(net, meta_info)
+
+    for elem in et.iter():
+        if elem.text:
+            elem.text = elem.text.strip()
+        if elem.tail:
+            elem.tail = elem.tail.strip()
+
+    pretty_xml_as_string = parseString(tostring(net)).toprettyxml()
+    with open(path_to_xml, 'wb') as file:
+        file.write(bytes(pretty_xml_as_string, "UTF-8"))

--- a/model-optimizer/mo/back/offline_transformations.py
+++ b/model-optimizer/mo/back/offline_transformations.py
@@ -1,18 +1,5 @@
-"""
- Copyright (C) 2021 Intel Corporation
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
+# Copyright (C) 2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
 
 import argparse
 

--- a/model-optimizer/mo/back/offline_transformations.py
+++ b/model-optimizer/mo/back/offline_transformations.py
@@ -26,7 +26,7 @@ if __name__ == "__main__":
 
     try:
         from openvino.inference_engine import IECore # pylint: disable=import-error
-        from openvino.offline_transformations import ApplyMOCTransformations, CheckAPI # pylint: disable=import-error
+        from openvino.offline_transformations import ApplyMOCTransformations, GenerateMappingFile, CheckAPI # pylint: disable=import-error
     except Exception as e:
         print("[ WARNING ] {}".format(e))
         exit(1)
@@ -36,3 +36,6 @@ if __name__ == "__main__":
     ie = IECore()
     net = ie.read_network(model=path_to_model + "_tmp.xml", weights=path_to_model + "_tmp.bin")
     net.serialize(path_to_model + ".xml", path_to_model + ".bin")
+    path_to_mapping = path_to_model + ".mapping"
+    GenerateMappingFile(net, path_to_mapping.encode('utf-8'))
+

--- a/model-optimizer/mo/back/offline_transformations.py
+++ b/model-optimizer/mo/back/offline_transformations.py
@@ -25,7 +25,7 @@ if __name__ == "__main__":
     path_to_model = args.path_to_model
 
     try:
-        from openvino.inference_engine import IECore # pylint: disable=import-error
+        from openvino.inference_engine import IECore, read_network, read_network_without_extensions # pylint: disable=import-error
         from openvino.offline_transformations import ApplyMOCTransformations, GenerateMappingFile, CheckAPI # pylint: disable=import-error
     except Exception as e:
         print("[ WARNING ] {}".format(e))
@@ -33,9 +33,11 @@ if __name__ == "__main__":
 
     CheckAPI()
 
-    ie = IECore()
-    net = ie.read_network(model=path_to_model + "_tmp.xml", weights=path_to_model + "_tmp.bin")
+    net = read_network_without_extensions(path_to_model + "_tmp.xml", path_to_model + "_tmp.bin")
+    print("ok1")
     net.serialize(path_to_model + ".xml", path_to_model + ".bin")
+    print("ok2")
     path_to_mapping = path_to_model + ".mapping"
     GenerateMappingFile(net, path_to_mapping.encode('utf-8'))
+    print("ok3")
 

--- a/model-optimizer/mo/back/offline_transformations.py
+++ b/model-optimizer/mo/back/offline_transformations.py
@@ -34,10 +34,7 @@ if __name__ == "__main__":
     CheckAPI()
 
     net = read_network_without_extensions(path_to_model + "_tmp.xml", path_to_model + "_tmp.bin")
-    print("ok1")
     net.serialize(path_to_model + ".xml", path_to_model + ".bin")
-    print("ok2")
     path_to_mapping = path_to_model + ".mapping"
     GenerateMappingFile(net, path_to_mapping.encode('utf-8'))
-    print("ok3")
 

--- a/model-optimizer/mo/back/offline_transformations.py
+++ b/model-optimizer/mo/back/offline_transformations.py
@@ -1,9 +1,29 @@
-#!/usr/bin/env python3
+"""
+ Copyright (C) 2021 Intel Corporation
 
-# Copyright (C) 2018-2021 Intel Corporation
-# SPDX-License-Identifier: Apache-2.0
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import argparse
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    # parser.add_argument("--apply_low_latency", action="store_true")
+    # parser.add_argument("--apply_pruning", action="store_true")
+    parser.add_argument("--path_to_model")
+    args = parser.parse_args()
+    path_to_model = args.path_to_model
+
     try:
         from openvino.inference_engine import IECore # pylint: disable=import-error
         from openvino.offline_transformations import ApplyMOCTransformations, CheckAPI # pylint: disable=import-error
@@ -12,3 +32,7 @@ if __name__ == "__main__":
         exit(1)
 
     CheckAPI()
+
+    ie = IECore()
+    net = ie.read_network(model=path_to_model + "_tmp.xml", weights=path_to_model + "_tmp.bin")
+    net.serialize(path_to_model + ".xml", path_to_model + ".bin")

--- a/model-optimizer/mo/main.py
+++ b/model-optimizer/mo/main.py
@@ -263,7 +263,7 @@ def emit_ir(graph: Graph, argv: argparse.Namespace):
         # This try-except is additional reinsurance that the IE
         # dependency search does not break the MO pipeline
         try:
-            if find_ie_version(silent=True):
+            if not argv.use_fallback and find_ie_version(silent=True):
                 path_to_offline_transformations = os.path.join(os.path.realpath(os.path.dirname(__file__)), 'back',
                                                                'offline_transformations.py')
                 status = subprocess.run([sys.executable, path_to_offline_transformations, "--path_to_model", orig_model_name], env=os.environ, timeout=10)

--- a/model-optimizer/mo/main.py
+++ b/model-optimizer/mo/main.py
@@ -256,7 +256,8 @@ def emit_ir(graph: Graph, argv: argparse.Namespace):
                     output_model_name=argv.model_name,
                     mean_data=mean_data,
                     input_names=input_names,
-                    meta_info=get_meta_info(argv))
+                    meta_info=get_meta_info(argv),
+                    use_temporary_path=True)
 
     graph.clear()
 

--- a/model-optimizer/mo/main.py
+++ b/model-optimizer/mo/main.py
@@ -259,6 +259,7 @@ def emit_ir(graph: Graph, argv: argparse.Namespace):
                     meta_info=get_meta_info(argv),
                     use_temporary_path=True)
 
+    # This graph cleanup is required to avoid double memory consumption
     graph.clear()
 
     if not (argv.framework == 'tf' and argv.tensorflow_custom_operations_config_update):

--- a/model-optimizer/mo/pipeline/common.py
+++ b/model-optimizer/mo/pipeline/common.py
@@ -206,7 +206,7 @@ def prepare_emit_ir(graph: Graph, data_type: str, output_dir: str, output_model_
 
     tensor_names.propagate_op_name_to_tensor(graph)
 
-    bin_file = os.path.join(output_dir, '{}.bin'.format(output_model_name))
+    bin_file = os.path.join(output_dir, '{}_tmp.bin'.format(output_model_name))
     serialize_constants(graph, bin_file)
 
     mean_offset = None
@@ -215,12 +215,12 @@ def prepare_emit_ir(graph: Graph, data_type: str, output_dir: str, output_model_
         mean_offset, mean_size = serialize_mean_image(bin_file, mean_data=mean_data)
 
     generate_ie_ir(graph=graph,
-                   file_name=os.path.join(output_dir, '{}.xml'.format(output_model_name)),
+                   file_name=os.path.join(output_dir, '{}_tmp.xml'.format(output_model_name)),
                    input_names=input_names,
                    mean_offset=mean_offset,
                    mean_size=mean_size,
                    meta_info=meta_info)
-    tensor_names.output_tensor_names_map(graph, os.path.join(output_dir, '{}.mapping'.format(output_model_name)))
+    tensor_names.output_tensor_names_map(graph, os.path.join(output_dir, '{}_tmp.mapping'.format(output_model_name)))
 
 
 def get_ir_version(argv: argparse.Namespace):

--- a/model-optimizer/mo/pipeline/common.py
+++ b/model-optimizer/mo/pipeline/common.py
@@ -172,7 +172,8 @@ def convert_inputs_of_specific_ops(graph: Graph):
 
 
 def prepare_emit_ir(graph: Graph, data_type: str, output_dir: str, output_model_name: str,
-                    mean_data: [list, None] = None, input_names: list = None, meta_info: dict = None):
+                    mean_data: [list, None] = None, input_names: list = None, meta_info: dict = None,
+                    use_temporary_path=False):
     if input_names is None:
         input_names = []
     if meta_info is None:
@@ -206,7 +207,9 @@ def prepare_emit_ir(graph: Graph, data_type: str, output_dir: str, output_model_
 
     tensor_names.propagate_op_name_to_tensor(graph)
 
-    bin_file = os.path.join(output_dir, '{}_tmp.bin'.format(output_model_name))
+    ir_path_suffix = "_tmp" if use_temporary_path else ""
+
+    bin_file = os.path.join(output_dir, '{}{}.bin'.format(output_model_name, ir_path_suffix))
     serialize_constants(graph, bin_file)
 
     mean_offset = None
@@ -215,12 +218,12 @@ def prepare_emit_ir(graph: Graph, data_type: str, output_dir: str, output_model_
         mean_offset, mean_size = serialize_mean_image(bin_file, mean_data=mean_data)
 
     generate_ie_ir(graph=graph,
-                   file_name=os.path.join(output_dir, '{}_tmp.xml'.format(output_model_name)),
+                   file_name=os.path.join(output_dir, '{}{}.xml'.format(output_model_name, ir_path_suffix)),
                    input_names=input_names,
                    mean_offset=mean_offset,
                    mean_size=mean_size,
                    meta_info=meta_info)
-    tensor_names.output_tensor_names_map(graph, os.path.join(output_dir, '{}_tmp.mapping'.format(output_model_name)))
+    tensor_names.output_tensor_names_map(graph, os.path.join(output_dir, '{}{}.mapping'.format(output_model_name, ir_path_suffix)))
 
 
 def get_ir_version(argv: argparse.Namespace):

--- a/model-optimizer/mo/utils/cli_parser.py
+++ b/model-optimizer/mo/utils/cli_parser.py
@@ -325,6 +325,9 @@ def get_common_cli_parser(parser: argparse.ArgumentParser = None):
     common_group.add_argument('--transformations_config',
                           help='Use the configuration file with transformations description.',
                           action=CanonicalizePathCheckExistenceAction)
+    common_group.add_argument('--use_fallback',
+                              help='Use old IR serialization engine',
+                              action='store_true', default=False)
     return parser
 
 

--- a/ngraph/core/include/ngraph/op/util/framework_node.hpp
+++ b/ngraph/core/include/ngraph/op/util/framework_node.hpp
@@ -1,0 +1,82 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <vector>
+
+#include "ngraph/op/op.hpp"
+#include "ngraph/partial_shape.hpp"
+
+namespace ngraph
+{
+    namespace op
+    {
+        namespace util
+        {
+            class NGRAPH_API FrameworkNodeAttrs
+            {
+            public:
+                void set_opset_name(const std::string& opset_name) { m_opset_name = opset_name; }
+
+                void set_type_name(const std::string& type_name) { m_type_name = type_name; }
+
+                const std::string& get_opset_name() const { return m_opset_name; }
+
+                const std::string& get_type_name() const { return m_type_name; }
+
+                const std::vector<std::pair<std::string, std::string>>& get_attrs() const
+                {
+                    return m_attrs;
+                }
+
+                void set_attrs(const std::vector<std::pair<std::string, std::string>>& attrs)
+                {
+                    m_attrs = attrs;
+                }
+
+            private:
+                std::string m_type_name;
+                std::string m_opset_name;
+
+                std::vector<std::pair<std::string, std::string>> m_attrs;
+            };
+
+            class NGRAPH_API FrameworkNode : public Op
+            {
+            public:
+                NGRAPH_RTTI_DECLARATION;
+
+                explicit FrameworkNode(const OutputVector& inputs);
+
+                void validate_and_infer_types() override;
+
+                bool visit_attributes(AttributeVisitor& visitor) override
+                {
+                    visitor.on_attribute("framework_node_attrs", m_attrs);
+                    return true;
+                }
+
+                std::shared_ptr<Node>
+                    clone_with_new_inputs(const OutputVector& new_args) const override;
+
+            private:
+                std::vector<std::tuple<ngraph::PartialShape, ngraph::element::Type>> m_inputs_desc;
+
+                FrameworkNodeAttrs m_attrs;
+            };
+        }
+    }
+
+    template <>
+    class NGRAPH_API AttributeAdapter<op::util::FrameworkNodeAttrs>
+        : public DirectValueAccessor<op::util::FrameworkNodeAttrs>
+    {
+    public:
+        AttributeAdapter(op::util::FrameworkNodeAttrs& value);
+
+        static constexpr DiscreteTypeInfo type_info{"AttributeAdapter<FrameworkNodeAttr>", 0};
+        const DiscreteTypeInfo& get_type_info() const override { return type_info; }
+    };
+}

--- a/ngraph/core/include/ngraph/op/util/framework_node.hpp
+++ b/ngraph/core/include/ngraph/op/util/framework_node.hpp
@@ -26,15 +26,9 @@ namespace ngraph
 
                 const std::string& get_type_name() const { return m_type_name; }
 
-                const std::map<std::string, std::string>& get_attrs() const
-                {
-                    return m_attrs;
-                }
+                const std::map<std::string, std::string>& get_attrs() const { return m_attrs; }
 
-                void set_attrs(const std::map<std::string, std::string>& attrs)
-                {
-                    m_attrs = attrs;
-                }
+                void set_attrs(const std::map<std::string, std::string>& attrs) { m_attrs = attrs; }
 
             private:
                 std::string m_type_name;

--- a/ngraph/core/include/ngraph/op/util/framework_node.hpp
+++ b/ngraph/core/include/ngraph/op/util/framework_node.hpp
@@ -26,12 +26,12 @@ namespace ngraph
 
                 const std::string& get_type_name() const { return m_type_name; }
 
-                const std::vector<std::pair<std::string, std::string>>& get_attrs() const
+                const std::map<std::string, std::string>& get_attrs() const
                 {
                     return m_attrs;
                 }
 
-                void set_attrs(const std::vector<std::pair<std::string, std::string>>& attrs)
+                void set_attrs(const std::map<std::string, std::string>& attrs)
                 {
                     m_attrs = attrs;
                 }
@@ -40,7 +40,7 @@ namespace ngraph
                 std::string m_type_name;
                 std::string m_opset_name;
 
-                std::vector<std::pair<std::string, std::string>> m_attrs;
+                std::map<std::string, std::string> m_attrs;
             };
 
             class NGRAPH_API FrameworkNode : public Op

--- a/ngraph/core/src/op/util/framework_node.cpp
+++ b/ngraph/core/src/op/util/framework_node.cpp
@@ -1,0 +1,65 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "ngraph/op/util/framework_node.hpp"
+#include "itt.hpp"
+
+using namespace std;
+using namespace ngraph;
+
+NGRAPH_RTTI_DEFINITION(op::util::FrameworkNode, "FrameworkNode", 0);
+
+op::util::FrameworkNode::FrameworkNode(const OutputVector& inputs)
+    : Op(inputs)
+{
+    constructor_validate_and_infer_types();
+}
+
+shared_ptr<Node> op::util::FrameworkNode::clone_with_new_inputs(const OutputVector& new_args) const
+{
+    NGRAPH_OP_SCOPE(FrameworkNode_clone_with_new_inputs);
+    check_new_args_count(this, new_args);
+    auto node = std::make_shared<op::util::FrameworkNode>(new_args);
+    for (size_t i = 0; i < get_output_size(); ++i)
+    {
+        node->set_output_type(i, get_output_element_type(i), get_output_partial_shape(i));
+    }
+    return node;
+}
+
+void op::util::FrameworkNode::validate_and_infer_types()
+{
+    NGRAPH_OP_SCOPE(util_FrameworkNode_validate_and_infer_types);
+    // Save initial inputs descriptors
+    for (uint64_t i = 0; i < get_input_size(); i++)
+    {
+        // TODO: store constant values
+        const auto& new_input_desc =
+            std::make_tuple(get_input_partial_shape(i), get_input_element_type(i));
+
+        if (m_inputs_desc.empty())
+        {
+            m_inputs_desc.push_back(new_input_desc);
+        }
+        else
+        {
+            NODE_VALIDATION_CHECK(this,
+                                  m_inputs_desc[i] == new_input_desc,
+                                  "Input descriptor for ",
+                                  get_friendly_name(),
+                                  "has been changed.");
+        }
+    }
+}
+
+namespace ngraph
+{
+    constexpr DiscreteTypeInfo AttributeAdapter<op::util::FrameworkNodeAttrs>::type_info;
+
+    AttributeAdapter<op::util::FrameworkNodeAttrs>::AttributeAdapter(
+        op::util::FrameworkNodeAttrs& value)
+        : DirectValueAccessor<op::util::FrameworkNodeAttrs>(value)
+    {
+    }
+}


### PR DESCRIPTION
### Description
In this PR I start using nGraph Serialization as a default IR generation engine inside Model Optimizer. So the Model Optimizer backend was extended with additional steps. But the Inference Engine Python API dependency still remains optional so the customer flow (environment) won't be changed.
![image](https://user-images.githubusercontent.com/18436845/115217156-e2ffe500-a10d-11eb-96c8-d576c270f92f.png)
In case if Inference Engine Python API wasn't found so the user will get the warning message and IR will be produced using original Model Optimizer IR generation engine.

_Note: at the current moment (21.4 release) as Inference Engine Python API dependency is not required so we should produce the same IR in both cases, so we can't apply any generic transformations even if Inference Engine Python API exists. So the Common Transformations box will be empty until 22.1 release._

To enable Serialization by default we had to extend internal readers API with additional method `read_without_extensions` to support cases with custom operations. Also `FrameworkNode` operation was added to represent custom nodes.

Also to have parity between original Model Optimizer Serialization and nGraph Serialization the mapping generation transformation was implemented which takes IR as input and generate mapping file.

### Details
**Custom Operations Support**
To read IR without extensions FrameworkNode was introduced and new mrthods were added to private Parser and Reader API. See diagram below (click for full resolution).
![image](https://user-images.githubusercontent.com/18436845/115230458-0e3e0080-a11d-11eb-8f27-84f2a450e790.png)
To read an IR with custom operations inside Model Optimizer Backend two new private methods were added: `read_network` and `read_network_without_extensions`.

**Other Changes**
* [IE] `getBatchSize` method was fixed to sort Parameter nodes by friendly name.
* [IE] `GenerateMappingFile` transformation were implemented inside offline transformations target. Python API was added.
* [NG] `Serialize` transformation was updated to add precisions into operation input ports.
* [NG] Added `u4` and `i4` precisions support in `Serialize` transformation.
* [MO] Implemented function to add meta information into generated IR.
* [MO] To avoid double memory consumption during IR generation additional `graph.clean()` method was used.

### Validation
As this change may affect many components plus we need to guaranty that original Model Optimizer IR generation engine and nGraph Serialization produces the same IR, multiple validation cycles were executed and checked:

- [ ] IR generation time (in progress)
- [x] POT validation
- [x] e2e validation (in progress)
- [ ] Memory Consumption (in progress)
- [x] INT8 validation
- [x] Myriad validation
- [x] DL Benchmark validation 
- [x] IR difference validation (DL Benchmark, e2e)
- [x] Custom layers validation
- [x] `setBatchSize` cycle comparing to master only (dl benchmark)

### TODO:
- [ ] Move read_network, read_network_without_extensions away from openvino.inference_engine module
- [ ] Deprecase --use_fallback option