### PR TITLE
[IE CLDNN] Fix permute reorder fusing error

### DIFF
--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/permute/permute_kernel_ref.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/permute/permute_kernel_ref.cpp
@@ -50,7 +50,19 @@ CommonDispatchData PermuteKernelRef::SetDefault(const permute_params& params) co
 
     return dispatchData;
 }
+bool PermuteKernelRef::Validate(const Params& p, const optional_params& o) const {
+    if (!Parent::Validate(p, o)) return false;
 
+    const permute_params& params = static_cast<const permute_params&>(p);
+
+    // currently reorder fusing is supported only for format change, not the layout change
+    if (DataTensor::ChannelsCount(params.inputs[0].GetLayout())
+        != DataTensor::ChannelsCount(params.output.GetLayout())) {
+        return false;
+    }
+
+    return true;
+}
 JitConstants PermuteKernelRef::GetJitConstants(const permute_params& params, const CommonDispatchData& dispatchData) const {
     auto jit = Parent::GetJitConstants(params, dispatchData);
     std::vector<std::string> in_idx;

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/permute/permute_kernel_ref.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/permute/permute_kernel_ref.h
@@ -29,6 +29,7 @@ public:
     PermuteKernelRef() : PermuteKernelBase("permute_ref") {}
     virtual ~PermuteKernelRef() {}
 
+    bool Validate(const Params& p, const optional_params& o) const override;
     KernelsPriority GetKernelsPriority(const Params& params, const optional_params& options) const;
     ParamsKey GetSupportedKey() const override;
 

--- a/inference-engine/thirdparty/clDNN/src/layout_optimizer.cpp
+++ b/inference-engine/thirdparty/clDNN/src/layout_optimizer.cpp
@@ -248,19 +248,9 @@ bool layout_optimizer::can_fuse_reorder_to_prev(program_node& prev, program_node
          fmt_next == format::b_fs_yx_fsv16 || fmt_next == format::b_fs_zyx_fsv16 || fmt_next == format::bs_fs_yx_bsv16_fsv16))
         return true;
 
-    if (prev.is_type<permute>() &&
-        ((fmt_prev == format::bfzyx && fmt_next == format::b_fs_zyx_fsv32) ||
-        (fmt_prev == format::bfzyx && fmt_next == format::b_fs_zyx_fsv16) ||
-        (fmt_prev == format::bfyx && fmt_next == format::b_fs_yx_fsv32) ||
-        (fmt_prev == format::bfyx && fmt_next == format::b_fs_yx_fsv16) ||
-        (fmt_prev == format::bfyx && fmt_next == format::b_fs_yx_fsv4) ||
-        (fmt_prev == format::b_fs_zyx_fsv32 && fmt_next == format::bfzyx) ||
-        (fmt_prev == format::b_fs_zyx_fsv16 && fmt_next == format::bfzyx) ||
-        (fmt_prev == format::b_fs_yx_fsv32 && fmt_next  == format::bfyx) ||
-        (fmt_prev == format::b_fs_yx_fsv16 && fmt_next  == format::bfyx) ||
-        (fmt_prev == format::b_fs_yx_fsv4 && fmt_next   == format::bfyx)))
-            return true;
-
+    if (prev.is_type<permute>() && fmt_prev.dimension() == fmt_next.dimension()) {
+        return true;
+    }
     return false;
 }
 

--- a/inference-engine/thirdparty/clDNN/src/layout_optimizer.cpp
+++ b/inference-engine/thirdparty/clDNN/src/layout_optimizer.cpp
@@ -248,8 +248,18 @@ bool layout_optimizer::can_fuse_reorder_to_prev(program_node& prev, program_node
          fmt_next == format::b_fs_yx_fsv16 || fmt_next == format::b_fs_zyx_fsv16 || fmt_next == format::bs_fs_yx_bsv16_fsv16))
         return true;
 
-    if (prev.is_type<permute>())
-        return true;
+    if (prev.is_type<permute>() &&
+        ((fmt_prev == format::bfzyx && fmt_next == format::b_fs_zyx_fsv32) ||
+        (fmt_prev == format::bfzyx && fmt_next == format::b_fs_zyx_fsv16) ||
+        (fmt_prev == format::bfyx && fmt_next == format::b_fs_yx_fsv32) ||
+        (fmt_prev == format::bfyx && fmt_next == format::b_fs_yx_fsv16) ||
+        (fmt_prev == format::bfyx && fmt_next == format::b_fs_yx_fsv4) ||
+        (fmt_prev == format::b_fs_zyx_fsv32 && fmt_next == format::bfzyx) ||
+        (fmt_prev == format::b_fs_zyx_fsv16 && fmt_next == format::bfzyx) ||
+        (fmt_prev == format::b_fs_yx_fsv32 && fmt_next  == format::bfyx) ||
+        (fmt_prev == format::b_fs_yx_fsv16 && fmt_next  == format::bfyx) ||
+        (fmt_prev == format::b_fs_yx_fsv4 && fmt_next   == format::bfyx)))
+            return true;
 
     return false;
 }


### PR DESCRIPTION
### Details:
- Current impl of permute_ref is not supporting reshaped output. 
- Need to implement such support for fusing general reorder. 
- So, enabled reorder fusing for limited cases (reorder to/from blocked format and normal format. Dims of permute output and reorder output should be same) 
### Tickets:
 - *ticket-id*
