### PR TITLE
[GNA] Fix FakeQuantize weights fusion when multiple operations were using the same const

### DIFF
--- a/inference-engine/src/gna_plugin/frontend/scale_factor_calc.hpp
+++ b/inference-engine/src/gna_plugin/frontend/scale_factor_calc.hpp
@@ -931,7 +931,7 @@ class ScaleFactorPerLayer<InferenceEngine::ConcatLayer*> {
                     gnalog() << "[UFS] from : " << concatLayer->name << " reached: " << layer->name;
                     // found that direct input to concat is a indirect parent of align filter - so no link required
                     auto info = LayerInfo(layer);
-                    if (!info.isWeightable() && !info.isActivation() && !info.isConst()) {
+                    if (!info.isWeightable() && !info.isActivation() && !info.isConst() && !info.isMemory()) {
                         gnalog() << "... skipped\n";
                         return;
                     }
@@ -983,7 +983,7 @@ class ScaleFactorPerLayer<InferenceEngine::ConcatLayer*> {
                 }
 
                 quantDataForConCatInput->_dst_quant.SetScale(newScaleFactor);
-            } else if (restarLayerInfo.isConst()) {
+            } else if (restarLayerInfo.isConst() || restarLayerInfo.isMemory()) {
                 gnalog() << "... warning const layer will be requantized\n";
                 quantDataForConCatInput->_src_quant.SetScale(sourceQuantParams->_dst_quant.GetScale());
                 quantDataForConCatInput->_dst_quant.SetScale(sourceQuantParams->_dst_quant.GetScale());

--- a/inference-engine/src/gna_plugin/frontend/scale_factor_calc.hpp
+++ b/inference-engine/src/gna_plugin/frontend/scale_factor_calc.hpp
@@ -353,7 +353,7 @@ class ScaleFactorPerLayer<InferenceEngine::CNNLayer *> {
             auto absMin = std::min(std::abs(minOutValue), std::abs(maxOutValue));
 
             result = (quantizedParams->_dst_quant.GetLevels() - 1) / (maxOutValue - minOutValue);
-            if (0 && fp32eq(absMin, 0.0f) && !fp32eq(absMax, 0.0f)) {
+            if (fp32eq(absMin, 0.0f) && !fp32eq(absMax, 0.0f)) {
                 result = (quantizedParams->_dst_quant.GetLevels() - 1) / (2 * absMax);
             }
             //

--- a/inference-engine/src/gna_plugin/gna_plugin.cpp
+++ b/inference-engine/src/gna_plugin/gna_plugin.cpp
@@ -56,6 +56,7 @@
 #include <transformations/common_optimizations/pull_transpose_through_fq.hpp>
 #include <transformations/common_optimizations/relu_fake_quantize_fusion.hpp>
 #include <transformations/common_optimizations/add_fake_quantize_fusion.hpp>
+#include <transformations/common_optimizations/mul_fake_quantize_fusion.hpp>
 
 #if GNA_LIB_VER == 2
 #include <gna2-model-api.h>
@@ -634,6 +635,7 @@ void GNAPlugin::LoadNetwork(CNNNetwork & _network) {
         pass_config->disable<ngraph::pass::FakeQuantizeReshapeFusion>();
         pass_config->disable<ngraph::pass::PullTransposeThroughFQUp>();
         pass_config->disable<ngraph::pass::ReluFakeQuantizeFusion>();
+        pass_config->disable<ngraph::pass::MulFakeQuantizeFusion>();
         // Consider to enable after per-channel quantization on FakeQuantize layer is supported in GNAPlugin, see issue 52034
         pass_config->disable<ngraph::pass::AddFakeQuantizeFusion>();
         manager.run_passes(graph);

--- a/inference-engine/src/gna_plugin/gna_plugin.cpp
+++ b/inference-engine/src/gna_plugin/gna_plugin.cpp
@@ -413,7 +413,6 @@ void GNAPlugin::UpdateInputScaleFromNetwork(InferenceEngine::CNNNetwork & networ
         auto data = input.second->getInputData();
         for (auto && nextToInputLayer : getInputTo(data)) {
             if (!LayerInfo(nextToInputLayer.second).isFakeQuantize()) {
-                inputIdx++;
                 continue;
             }
             // replacing scale factor from this fq layer
@@ -448,9 +447,8 @@ void GNAPlugin::UpdateInputScaleFromNetwork(InferenceEngine::CNNNetwork & networ
 
             config.inputScaleFactors[inputIdx] = scaleInput;
             inputsDesc->inputScaleFactors[inputIdx] = scaleInput;
-
-            inputIdx++;
         }
+        inputIdx++;
     }
 }
 

--- a/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.cpp
+++ b/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.cpp
@@ -1806,12 +1806,12 @@ void FuseFQIntoWeightsPass::run() {
             THROW_GNA_LAYER_EXCEPTION(layer) << " not a weightable layer";
         }
         weigtableLayer->_weights = weights;
-        weigtableLayer->_biases  = biases;
+        weigtableLayer->_biases = biases;
         weigtableLayer->blobs["weights"] = weights;
         weigtableLayer->blobs["biases"] = biases;
     };
 
-    for (auto &l : *pLayers) {
+    for (auto& l : *pLayers) {
         if (!LayerInfo(l).isFakeQuantize()) {
             continue;
         }
@@ -1821,112 +1821,112 @@ void FuseFQIntoWeightsPass::run() {
             continue;
         }
 
-        auto weightableLayer = CNNNetGetNextLayerSkipCertain(fqLayer, 0, 0, isNonFunctional).first;
-        if (!LayerInfo(weightableLayer).isWeightable()) {
-            continue;
-        }
-        if (weightableLayer->insData.size() != 3) {
-            continue;
-        }
-
-        // check whether this FQ represents weights - it need to be at index 1 of weightable layer
-        auto prevLayerAt1 = CNNNetPrevLayerSkipCertain(weightableLayer, 1, isNonFunctional);
-
-        if (prevLayerAt1 != fqLayer) {
-            continue;
-        }
-
-        // now this FQ layer represents weights - lets apply it and fuse to given weightable layer.
-        pass_trace() << "found " << LAYER_NAME(fqLayer) << " that will be converted to weights of "
-            << LAYER_NAME(weightableLayer) << "\n";
-
         GNAFakeQuantizeLayer gnaFakeQuantizeLayer(fqLayer);
-
-        auto biases = LayerUtils::getParamFromInputAsBlob(weightableLayer, 2);
-        auto quantizedWeights = gnaFakeQuantizeLayer.getConstInputData();
-
-        // 1. broke existing connections - by detaching fq subgraph from rest of graph
-        auto prevData = weightableLayer->insData[1].lock();
-        auto prevLayer = getCreatorLayer(prevData).lock();
-        auto weightDims = prevLayer->outData.front()->getDims();
-        prevLayer->outData.clear();
-        weightableLayer->insData.resize(1);
-
-        // 2. running FQ function for given layer
-        auto outputSize = details::product(weightDims.begin(), weightDims.end());
-
-        // depending on compute precision weights will be recreated
-        // for integer mode - weights might be simply copied - to avoid furter quantisations overhead
-        auto quantized = InferenceEngine::getInjectedData<QuantizedLayerParams>(weightableLayer);
-        if (quantized) {
-            // assign already quantized Weights
-            assignWeightsAndBiases(weightableLayer, quantizedWeights, biases);
-
-            // modify scale factors for quantized component
-            auto levels = gnaFakeQuantizeLayer.getLevels();
-            auto inputRange = gnaFakeQuantizeLayer.getInputRange();
-            auto outputRange = gnaFakeQuantizeLayer.getOutputRange();
-            if (outputRange.first.size() != outputRange.second.size()) {
-                THROW_GNA_LAYER_EXCEPTION(fqLayer) << " number of min and max data must be equal, min size: "
-                    << outputRange.first.size() << ", max size: " << outputRange.second.size();
+        size_t layers_connected_to_fq_count = getInputTo(fqLayer->outData[0]).size();
+        for (int index = 0; index < layers_connected_to_fq_count; index++) {
+            auto weightableLayer = CNNNetGetNextLayerSkipCertain(fqLayer, 0, index, isNonFunctional).first;
+            if (!LayerInfo(weightableLayer).isWeightable()) {
+                continue;
+            }
+            if (weightableLayer->insData.size() != 3) {
+                continue;
             }
 
-            if (inputRange.first.size() != outputRange.first.size() ||
-                inputRange.second.size() != outputRange.second.size()) {
-                THROW_GNA_LAYER_EXCEPTION(fqLayer) << " size of input and output range differs. "
-                    << "input min size: " << inputRange.first.size() << ", "
-                    << "output min size: " << outputRange.first.size() << ", "
-                    << "input max size: " << inputRange.second.size() << ", "
-                    << "output max size: " << outputRange.second.size();
+            // check whether this FQ represents weights - it need to be at index 1 of weightable layer
+            auto prevLayerAt1 = CNNNetPrevLayerSkipCertain(weightableLayer, 1, isNonFunctional);
+
+            if (prevLayerAt1 != fqLayer) {
+                continue;
+            }
+            // now this FQ layer represents weights - lets apply it and fuse to given weightable layer.
+            pass_trace() << "found " << LAYER_NAME(fqLayer) << " that will be converted to weights of "
+                << LAYER_NAME(weightableLayer) << "\n";
+
+            auto biases = LayerUtils::getParamFromInputAsBlob(weightableLayer, 2);
+            auto quantizedWeights = gnaFakeQuantizeLayer.getConstInputData();
+
+            // 1. broke existing connections - by detaching fq subgraph from rest of graph
+            auto prevData = weightableLayer->insData[1].lock();
+            auto prevLayer = getCreatorLayer(prevData).lock();
+            auto weightDims = prevLayer->outData.front()->getDims();
+            weightableLayer->insData.resize(1);
+
+            // 2. running FQ function for given layer
+            auto outputSize = details::product(weightDims.begin(), weightDims.end());
+
+            // depending on compute precision weights will be recreated
+            // for integer mode - weights might be simply copied - to avoid furter quantisations overhead
+            auto quantized = InferenceEngine::getInjectedData<QuantizedLayerParams>(weightableLayer);
+            if (quantized) {
+                // assign already quantized Weights
+                assignWeightsAndBiases(weightableLayer, quantizedWeights, biases);
+
+                // modify scale factors for quantized component
+                auto levels = gnaFakeQuantizeLayer.getLevels();
+                auto inputRange = gnaFakeQuantizeLayer.getInputRange();
+                auto outputRange = gnaFakeQuantizeLayer.getOutputRange();
+                if (outputRange.first.size() != outputRange.second.size()) {
+                    THROW_GNA_LAYER_EXCEPTION(fqLayer) << " number of min and max data must be equal, min size: "
+                        << outputRange.first.size() << ", max size: " << outputRange.second.size();
+                }
+
+                if (inputRange.first.size() != outputRange.first.size() ||
+                    inputRange.second.size() != outputRange.second.size()) {
+                    THROW_GNA_LAYER_EXCEPTION(fqLayer) << " size of input and output range differs. "
+                        << "input min size: " << inputRange.first.size() << ", "
+                        << "output min size: " << outputRange.first.size() << ", "
+                        << "input max size: " << inputRange.second.size() << ", "
+                        << "output max size: " << outputRange.second.size();
+                }
+
+                if (levels > std::numeric_limits<uint8_t>::max() && outputRange.first.size() > 1) {
+                    THROW_GNA_LAYER_EXCEPTION(fqLayer) << " unsupported per-channel quantization for int16 weights."
+                        << " Per-channel quantization ";
+                }
+
+                // check if
+                // - weights were float values and need to be quantized,
+                // - weights are integer values and quantization can be skipped
+                quantized->_weights_quant.SetMinValues(inputRange.first, true);
+                quantized->_weights_quant.SetMaxValues(inputRange.second, true);
+                quantized->_weights_quant.SetMinValues(outputRange.first, false);
+                quantized->_weights_quant.SetMaxValues(outputRange.second, false);
+                quantized->_weights_quant.SetLevels(levels);
+
+                // lets find out minimum scale factor among channels
+                if (!quantized->_weights_quant.IsStatsSet()) {
+                    THROW_GNA_LAYER_EXCEPTION(fqLayer) << " per channel/tensor weigths scales are missed";
+                }
+                continue;
             }
 
-            if (levels > std::numeric_limits<uint8_t>::max() && outputRange.first.size() > 1) {
-                THROW_GNA_LAYER_EXCEPTION(fqLayer) << " unsupported per-channel quantization for int16 weights."
-                    << " Per-channel quantization ";
+            size_t depth = 1;
+            intel_dnn_component_t component;
+            component.num_columns_in = weightDims[1];
+            component.num_rows_in = weightDims[0];
+
+            if (LayerInfo(weightableLayer).isConvolution()) {
+                depth = (weightDims.size() == 4) ? weightDims[3] : 1;
             }
 
-            // check if
-            // - weights were float values and need to be quantized,
-            // - weights are integer values and quantization can be skipped
-            quantized->_weights_quant.SetMinValues(inputRange.first, true);
-            quantized->_weights_quant.SetMaxValues(inputRange.second, true);
-            quantized->_weights_quant.SetMinValues(outputRange.first, false);
-            quantized->_weights_quant.SetMaxValues(outputRange.second, false);
-            quantized->_weights_quant.SetLevels(levels);
+            intel_piecewiselinear_t* transform = reinterpret_cast<intel_piecewiselinear_t*>(&component.op.pwl);
+            transform->func_id = gnaFakeQuantizeLayer.parseAsActivation();
 
-            // lets find out minimum scale factor among channels
-            if (!quantized->_weights_quant.IsStatsSet()) {
-                THROW_GNA_LAYER_EXCEPTION(fqLayer) << " per channel/tensor weigths scales are missed";
+            auto quantizedWeightsData = quantizedWeights->buffer();
+            auto dequantizedWeights = make_shared_blob<float>(TensorDesc(Precision::FP32, { outputSize }, Layout::C));
+            dequantizedWeights->allocate();
+
+            auto resultBuffer = dequantizedWeights->buffer();
+            for (size_t i = 0; i < depth; ++i) {
+                component.ptr_inputs = quantizedWeightsData.as<float*>() + i * component.num_columns_in * component.num_rows_in;
+                component.ptr_outputs = resultBuffer.as<float*>() + i * component.num_columns_in * component.num_rows_in;
+
+                PwlApply32(&component, 0, component.num_rows_in - 1, 0, component.num_columns_in - 1);
             }
-            continue;
+
+            // 3. assign dequantized const blob to weightable layer
+            assignWeightsAndBiases(weightableLayer, dequantizedWeights, biases);
         }
-
-        size_t depth = 1;
-        intel_dnn_component_t component;
-        component.num_columns_in = weightDims[1];
-        component.num_rows_in    = weightDims[0];
-
-        if (LayerInfo(weightableLayer).isConvolution()) {
-            depth = (weightDims.size() == 4)? weightDims[3]: 1;
-        }
-
-        intel_piecewiselinear_t *transform = reinterpret_cast<intel_piecewiselinear_t *>(&component.op.pwl);
-        transform->func_id = gnaFakeQuantizeLayer.parseAsActivation();
-
-        auto quantizedWeightsData = quantizedWeights->buffer();
-        auto dequantizedWeights = make_shared_blob<float>(TensorDesc(Precision::FP32, {outputSize}, Layout::C));
-        dequantizedWeights->allocate();
-
-        auto resultBuffer = dequantizedWeights->buffer();
-        for (size_t i = 0; i < depth; ++i) {
-            component.ptr_inputs = quantizedWeightsData.as<float*>() + i * component.num_columns_in * component.num_rows_in;
-            component.ptr_outputs = resultBuffer.as<float*>() + i * component.num_columns_in * component.num_rows_in;
-
-            PwlApply32(&component, 0, component.num_rows_in - 1, 0, component.num_columns_in - 1);
-        }
-
-        // 3. assign dequantized const blob to weightable layer
-        assignWeightsAndBiases(weightableLayer, dequantizedWeights, biases);
     }
 }
 

--- a/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.cpp
+++ b/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.cpp
@@ -826,6 +826,34 @@ void InsertIdentityLayerPass::run() {
             }
 
             CNNNetworkInsertLayer(prev, notAll ? true_layer : CNNLayerPtr(nullptr), activationLayerWithQuant);
+
+            bool restart = true;
+            // if we added identity - we should reconnect others
+            // we can't leave 16bit output & 32bit output active in parallel
+            // due to GNA HW limitations
+            while (restart) {
+                restart = false;
+                for (auto prev_layer_output : prev->outData) {
+                    // prev ---> identity -+-> layer XYZ
+                    //                     |
+                    //                     |  <= here we want to inject identity
+                    //                     |
+                    //                     +--> l layer
+                    // but we may just connect l layer with existing identity
+                    for (auto&& next_layer : getInputTo(prev_layer_output)) {
+                        auto child_of_prev_layer = next_layer.second;
+                        if (child_of_prev_layer.get() == activationLayerWithQuant.get()) {
+                            continue;
+                        }
+                        else {
+                            CNNNetworkReconnectLayer(prev, activationLayerWithQuant, child_of_prev_layer);
+                            // the iterator aquired by getInputTo is invalid, we need to restart
+                            restart = true;
+                            break;
+                        }
+                    }
+                }
+            }
         }
     }
 }
@@ -1880,8 +1908,32 @@ void FuseFQIntoWeightsPass::run() {
                 }
 
                 if (levels > std::numeric_limits<uint8_t>::max() && outputRange.first.size() > 1) {
-                    THROW_GNA_LAYER_EXCEPTION(fqLayer) << " unsupported per-channel quantization for int16 weights."
-                        << " Per-channel quantization ";
+                    // find min and max for input and output range
+                    bool first = true;
+                    float min_input = 0.0f;
+                    float max_input = 0.0f;
+                    float min_output = 0.0f;
+                    float max_output = 0.0f;
+                    for (auto ir : inputRange.first)
+                        min_input = first ? ir : (min_input < ir ? min_input : ir);
+
+                    first = true;
+                    for (auto ir : inputRange.second)
+                        max_input = first ? ir : (max_input > ir ? max_input : ir);
+
+                    first = true;
+                    for (auto ir : inputRange.first)
+                        min_output = first ? ir : (min_output < ir ? min_output : ir);
+
+                    first = true;
+                    for (auto ir : inputRange.second)
+                        max_output = first ? ir : (max_output > ir ? max_output : ir);
+                    inputRange.first = { min_input };
+                    inputRange.second = { max_input };
+                    outputRange.first = { min_output };
+                    outputRange.second = { max_output };
+                    //THROW_GNA_LAYER_EXCEPTION(fqLayer) << " unsupported per-channel quantization for int16 weights."
+                    //    << " Per-channel quantization ";
                 }
 
                 // check if
@@ -2044,7 +2096,33 @@ void MoveFakeQuantizeLayerIntoQuantParamsPass :: run() {
         auto outputRange = fqLayer.getOutputRange();
         if (inputRange.first.size() != 1 || inputRange.second.size() != 1 ||
             outputRange.first.size() != 1 || outputRange.second.size() != 1) {
-            THROW_GNA_LAYER_EXCEPTION(fqLayer) << " unsupported per-channel quantisation";
+
+            // find min and max for input and output range
+            bool first = true;
+            float min_input = 0.0f;
+            float max_input = 0.0f;
+            float min_output = 0.0f;
+            float max_output = 0.0f;
+            for (auto ir : inputRange.first)
+                min_input = first ? ir : (min_input < ir ? min_input : ir);
+
+            first = true;
+            for (auto ir : inputRange.second)
+                max_input = first ? ir : (max_input > ir ? max_input : ir);
+
+            first = true;
+            for (auto ir : inputRange.first)
+                min_output = first ? ir : (min_output < ir ? min_output : ir);
+
+            first = true;
+            for (auto ir : inputRange.second)
+                max_output = first ? ir : (max_output > ir ? max_output : ir);
+            inputRange.first = { min_input };
+            inputRange.second = { max_input };
+            outputRange.first = { min_output };
+            outputRange.second = { max_output };
+
+            //THROW_GNA_LAYER_EXCEPTION(fqLayer) << " unsupported per-channel quantisation";
         }
 
         if (!LayerInfo(prevLayer).isConst() &&


### PR DESCRIPTION
FakeQuantize weights fusion when multiple operations were using the same const.
Solution iterates over all connected to FQ layer operations and fuses weights where appropriate.