### PR TITLE
Support Pad-2 in opset-11 ONNX model

### DIFF
--- a/model-optimizer/extensions/front/onnx/pad_ext.py
+++ b/model-optimizer/extensions/front/onnx/pad_ext.py
@@ -16,6 +16,7 @@
 
 import numpy as np
 
+from mo.front.common.partial_infer.utils import int64_array
 from mo.front.extractor import FrontExtractorOp
 from mo.front.onnx.extractors.utils import onnx_attr, get_onnx_opset_version
 from mo.ops.pad import AttributedPad, ONNXPad
@@ -29,12 +30,12 @@ class PadFrontExtractor(FrontExtractorOp):
     def extract(cls, node):
         mode = onnx_attr(node, 'mode', 's', default='constant', dst_type=lambda x: x.decode())
         # Pytorch 1.3 while converting to opset 11, creates Pad from older opset.
-        # To be able to convert such models we have to check if pads attribute exist
-        pads = onnx_attr(node, 'pads', 'ints', dst_type=lambda x: np.array(x, dtype=np.int64))
+        # To be able to convert such models we have to check if pads attribute exists.
+        pads = onnx_attr(node, 'pads', 'ints', dst_type=int64_array)
         if get_onnx_opset_version(node) < 11 or pads is not None:
             value = onnx_attr(node, 'value', 'f', default=0.)
 
-            assert pads is not None
+            assert pads is not None, 'pads is required attribute for Pad operation'
 
             # MO Pad op and ONNX Pad op have different format for pads values
             # MO Pad has Dx2 where D is the total number of dimensions

--- a/model-optimizer/extensions/front/onnx/pad_ext.py
+++ b/model-optimizer/extensions/front/onnx/pad_ext.py
@@ -28,8 +28,10 @@ class PadFrontExtractor(FrontExtractorOp):
     @classmethod
     def extract(cls, node):
         mode = onnx_attr(node, 'mode', 's', default='constant', dst_type=lambda x: x.decode())
-        if get_onnx_opset_version(node) < 11:
-            pads = onnx_attr(node, 'pads', 'ints', dst_type=lambda x: np.array(x, dtype=np.int64))
+        # Pytorch 1.3 while converting to opset 11, creates Pad from older opset.
+        # To be able to convert such models we have to check if pads attribute exist
+        pads = onnx_attr(node, 'pads', 'ints', dst_type=lambda x: np.array(x, dtype=np.int64))
+        if get_onnx_opset_version(node) < 11 or pads is not None:
             value = onnx_attr(node, 'value', 'f', default=0.)
 
             assert pads is not None

--- a/model-optimizer/extensions/front/onnx/pad_ext_test.py
+++ b/model-optimizer/extensions/front/onnx/pad_ext_test.py
@@ -57,6 +57,20 @@ class TestPad(BaseExtractorsTestingClass):
 
         self.compare()
 
+    def test_older_pad_opset_11(self):
+        node = self._create_node()
+        node.graph.graph['fw_opset_version'] = 11
+        PadFrontExtractor.extract(node)
+        self.res = node
+
+        self.expected = {
+            'pads': [[1, 3], [2, 4]],
+            'mode': 'constant',
+            'fill_value': 0
+        }
+
+        self.compare()
+
     def test_reflect(self):
         node = self._create_node(mode='reflect')
         PadFrontExtractor.extract(node)


### PR DESCRIPTION
Root cause analysis:
Pytorch 1.3 creates an older version of Pad operation even when converting to opset-11.

Solution: 
In order to support such an operation, we have to check if pads exist in attributes.

Ticket: 51378


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR: N/A no transformation changed
* [x]  Transformation preserves original framework node names: N/A no transformation changed


Validation:
* [x]  Unit tests
* [x]  Framework operation tests: N/A no new operation enabled
* [x]  Transformation tests: N/A no transformation changed
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list: N/A no new operation enabled
* [x]  Guide on how to convert the **public** model: N/A no new public model enabled
* [x]  User guide update: N/A no new public model enabled