### PR TITLE
Proper cleanup of cache_dir on start/end tests

### DIFF
--- a/inference-engine/tests/functional/plugin/shared/src/behavior/caching_tests.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/behavior/caching_tests.cpp
@@ -146,14 +146,17 @@ void LoadNetworkCacheTestBase::SetUp() {
     auto hash = std::hash<std::string>()(GetTestName());
     ss << "testCache_" << std::to_string(hash) << "_" << std::this_thread::get_id() << "_" << GetTimestamp();
     m_cacheFolderName = ss.str();
+    core->SetConfig({{CONFIG_KEY(CACHE_DIR), {}}});
 }
 
 void LoadNetworkCacheTestBase::TearDown() {
     CommonTestUtils::removeFilesWithExt(m_cacheFolderName, "blob");
     std::remove(m_cacheFolderName.c_str());
+    core->SetConfig({{CONFIG_KEY(CACHE_DIR), {}}});
 }
 
 void LoadNetworkCacheTestBase::Run() {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     auto compareOutputs = [&](const std::vector<InferenceEngine::Blob::Ptr>& expected,
                               const std::vector<InferenceEngine::Blob::Ptr>& actual) {
         ASSERT_EQ(expected.size(), actual.size());


### PR DESCRIPTION
### Details:
 - In case of 'core' object is reused in Plugins cache, it's CACHE_DIR shall be cleaned up after each test
 - Also add ability to skip the test depending on plugins 'skip_test_config'

### Tickets:
 - 51262
