### PR TITLE
[VPU TESTS] Fix for myriad stress test

### DIFF
--- a/inference-engine/tests/functional/plugin/shared/src/behavior/stress_tests.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/behavior/stress_tests.cpp
@@ -42,8 +42,9 @@ TEST_P(MultipleAllocations, InferWorksCorrectAfterAllocations) {
         LoadNetwork();
 
         std::cout << "Infer(): " << j << std::flush;
-
-        GenerateInputs();
+        if (j == 0) {
+            GenerateInputs();
+        }
         Infer();
         Validate();
     }


### PR DESCRIPTION
### Details:
 - Reused inputs for cycling infer requests in `MultipleAllocations` test.

### Tickets:
 - *51592*
