### PR TITLE
[Time tests] Add options to enable model caching and loading from file

### DIFF
--- a/tests/time_tests/src/timetests_helper/cli.h
+++ b/tests/time_tests/src/timetests_helper/cli.h
@@ -30,6 +30,14 @@ static const char target_device_message[] =
 static const char statistics_path_message[] =
     "Required. Path to a file to write statistics.";
 
+/// @brief message for cache_dir argument
+static const char cache_dir_message[] =
+        "Optional. Enables caching of loaded models to specified directory.";
+
+/// @brief message for load_from_file argument
+static const char load_from_file_message[] =
+        "Optional. Loads model from file directly without ReadNetwork.";
+
 /// @brief Define flag for showing help message <br>
 DEFINE_bool(h, false, help_message);
 
@@ -48,6 +56,14 @@ DEFINE_string(d, "", target_device_message);
 /// It is a required parameter
 DEFINE_string(s, "", statistics_path_message);
 
+/// @brief Define parameter for set path to model caching folder <br>
+/// It is an optional parameter
+DEFINE_string(cache_dir, "", cache_dir_message);
+
+/// @brief Define flag to load network from file name without explicit call of ReadNetwork <br>
+/// It is an optional parameter
+DEFINE_bool(load_from_file, false, load_from_file_message);
+
 /**
  * @brief This function show a help message
  */
@@ -61,5 +77,9 @@ static void showUsage() {
   std::cout << "    -d \"<device>\"             " << target_device_message
             << std::endl;
   std::cout << "    -s \"<path>\"               " << statistics_path_message
+            << std::endl;
+  std::cout << "    --cache_dir \"<dir>\"       " << cache_dir_message
+            << std::endl;
+  std::cout << "    --load_from_file            " << load_from_file_message
             << std::endl;
 }

--- a/tests/time_tests/src/timetests_helper/main.cpp
+++ b/tests/time_tests/src/timetests_helper/main.cpp
@@ -8,7 +8,8 @@
 
 #include <iostream>
 
-int runPipeline(const std::string &model, const std::string &device);
+int runPipeline(const std::string &model, const std::string &device,
+                const std::string &cacheDir, bool loadFromFile);
 
 /**
  * @brief Parses command line and check required arguments
@@ -40,7 +41,7 @@ bool parseAndCheckCommandLine(int argc, char **argv) {
  */
 int _runPipeline() {
   SCOPED_TIMER(full_run);
-  return runPipeline(FLAGS_m, FLAGS_d);
+  return runPipeline(FLAGS_m, FLAGS_d, FLAGS_cache_dir, FLAGS_load_from_file);
 }
 
 /**


### PR DESCRIPTION
### Details:
C++:
--cache_dir [DIR] - enables model caching to specified directory
--load_from_file - enables LoadNetwork without explicit ReadNetwork

Python:
--enable_cache - creates temporary cache folder and enables cache in C++ app
--enable_load_from_file - turns on '--load_from_file' option in C++ app

How to test:
- Pull changes for enabling cache in GNA: https://github.com/openvinotoolkit/openvino/pull/4889
```
cd tests/time_tests
python3 ./scripts/run_timetest.py ../../bin/intel64/Release/timetest_infer -m ~/models/cnn4a/cnn4a.xml -d GNA --enable_cache --enable_load_from_file
```
- Observe first inference time to be much faster than without new options. Also with '--enable_load_from_file + --enable_cache' is faster than just '--enable_cache' only

### Tickets:
 - 51654
