### PR TITLE
Used internal executable network implementation

### DIFF
--- a/docs/template_plugin/src/template_plugin.cpp
+++ b/docs/template_plugin/src/template_plugin.cpp
@@ -118,14 +118,13 @@ InferenceEngine::ExecutableNetworkInternal::Ptr Plugin::LoadExeNetworkImpl(const
 // ! [plugin:load_exe_network_impl]
 
 // ! [plugin:import_network_impl]
-InferenceEngine::ExecutableNetwork Plugin::ImportNetworkImpl(std::istream& model, const std::map<std::string, std::string>& config) {
+InferenceEngine::ExecutableNetworkInternal::Ptr
+Plugin::ImportNetworkImpl(std::istream& model, const std::map<std::string, std::string>& config) {
     OV_ITT_SCOPED_TASK(itt::domains::TemplatePlugin, "Plugin::ImportNetworkImpl");
 
     Configuration cfg(config);
-    auto exec_network_impl = std::make_shared<ExecutableNetwork>(model, cfg,
+    return std::make_shared<ExecutableNetwork>(model, cfg,
         std::static_pointer_cast<Plugin>(shared_from_this()));
-
-    return make_executable_network(exec_network_impl);
 }
 // ! [plugin:import_network_impl]
 

--- a/docs/template_plugin/src/template_plugin.hpp
+++ b/docs/template_plugin/src/template_plugin.hpp
@@ -30,7 +30,7 @@ public:
     void AddExtension(InferenceEngine::IExtensionPtr extension) override;
     InferenceEngine::Parameter GetConfig(const std::string& name, const std::map<std::string, InferenceEngine::Parameter> & options) const override;
     InferenceEngine::Parameter GetMetric(const std::string& name, const std::map<std::string, InferenceEngine::Parameter> & options) const override;
-    InferenceEngine::ExecutableNetwork ImportNetworkImpl(std::istream& model, const std::map<std::string, std::string>& config) override;
+    InferenceEngine::ExecutableNetworkInternal::Ptr ImportNetworkImpl(std::istream& model, const std::map<std::string, std::string>& config) override;
 
 private:
     friend class ExecutableNetwork;

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.hpp
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.hpp
@@ -23,6 +23,7 @@
 
 #include <ie_extension.h>
 #include <ie_core.hpp>
+#include <ie_iexecutable_network.hpp>
 
 typedef std::chrono::high_resolution_clock Time;
 typedef std::chrono::nanoseconds ns;

--- a/inference-engine/include/details/ie_so_pointer.hpp
+++ b/inference-engine/include/details/ie_so_pointer.hpp
@@ -123,7 +123,7 @@ public:
     }
 
     explicit operator bool() const noexcept {
-        return (nullptr != _so_loader) && (nullptr != _pointedObj);
+        return (nullptr != _pointedObj);
     }
 
     friend bool operator==(std::nullptr_t, const SOPointer& ptr) noexcept {
@@ -145,7 +145,7 @@ public:
         return *this;
     }
 
-    operator std::shared_ptr<Loader>() const noexcept {
+    operator const std::shared_ptr<Loader>&() const noexcept {
         return _so_loader;
     }
 

--- a/inference-engine/include/ie_common.h
+++ b/inference-engine/include/ie_common.h
@@ -281,6 +281,11 @@ struct QueryNetworkResult {
     ResponseDesc resp;
 };
 
+/**
+ * @brief A collection that contains string as key, and const Data smart pointer as value
+ */
+using ConstOutputsDataMap = std::map<std::string, CDataPtr>;
+
 namespace details {
 struct INFERENCE_ENGINE_DEPRECATED("Use InferRequest::Exception")
 INFERENCE_ENGINE_API_CLASS(InferenceEngineException) : public std::runtime_error {

--- a/inference-engine/include/ie_iexecutable_network.hpp
+++ b/inference-engine/include/ie_iexecutable_network.hpp
@@ -23,16 +23,11 @@
 #include "ie_remote_context.hpp"
 
 namespace InferenceEngine {
-
-/**
- * @brief A collection that contains string as key, and const Data smart pointer as value
- */
-using ConstOutputsDataMap = std::map<std::string, CDataPtr>;
-
 /**
  * @brief This is an interface of an executable network
  */
-class IExecutableNetwork : public std::enable_shared_from_this<IExecutableNetwork> {
+class INFERENCE_ENGINE_DEPRECATED("Use InferenceEngine::ExecutableNetwork instead") IExecutableNetwork
+    : public std::enable_shared_from_this<IExecutableNetwork> {
 public:
     /**
      * @brief A smart pointer to the current IExecutableNetwork object

--- a/inference-engine/src/gna_plugin/gna_plugin.cpp
+++ b/inference-engine/src/gna_plugin/gna_plugin.cpp
@@ -1476,7 +1476,7 @@ void GNAPlugin::SetName(const std::string & pluginName) noexcept {
     _pluginName = pluginName;
 }
 
-InferenceEngine::ExecutableNetwork GNAPlugin::ImportNetwork(std::istream& networkModel) {
+InferenceEngine::IExecutableNetworkInternal::Ptr GNAPlugin::ImportNetwork(std::istream& networkModel) {
     auto header = GNAModelSerial::ReadHeader(networkModel);
 
     InitGNADevice();

--- a/inference-engine/src/gna_plugin/gna_plugin.hpp
+++ b/inference-engine/src/gna_plugin/gna_plugin.hpp
@@ -13,6 +13,7 @@
 #include <vector>
 #include <tuple>
 #include <cpp_interfaces/interface/ie_iplugin_internal.hpp>
+#include <cpp_interfaces/interface/ie_iexecutable_network_internal.hpp>
 #include "cpp_interfaces/impl/ie_variable_state_internal.hpp"
 #include "descriptions/gna_flags.hpp"
 #include "descriptions/gna_input_desc.hpp"
@@ -104,9 +105,9 @@ class GNAPlugin : public InferenceEngine::IInferencePlugin {
     void AddExtension(InferenceEngine::IExtensionPtr extension) override;
 
     void SetConfig(const std::map<std::string, std::string> &config) override;
-    InferenceEngine::ExecutableNetwork LoadNetwork(const InferenceEngine::CNNNetwork &network,
+    InferenceEngine::IExecutableNetworkInternal::Ptr LoadNetwork(const InferenceEngine::CNNNetwork &network,
         const std::map<std::string, std::string> &config_map) override { THROW_GNA_EXCEPTION << "Not implemented"; }
-    InferenceEngine::ExecutableNetwork LoadNetwork(const InferenceEngine::CNNNetwork &network,
+    InferenceEngine::IExecutableNetworkInternal::Ptr LoadNetwork(const InferenceEngine::CNNNetwork &network,
                                   const std::map<std::string, std::string> &config_map,
                                   InferenceEngine::RemoteContext::Ptr context) override { THROW_GNA_EXCEPTION << "Not implemented"; }
     bool Infer(const InferenceEngine::Blob &input, InferenceEngine::Blob &result);
@@ -130,22 +131,22 @@ class GNAPlugin : public InferenceEngine::IInferencePlugin {
 
     void Export(const std::string &fileName);
     void Export(std::ostream &networkModel);
-    InferenceEngine::ExecutableNetwork ImportNetwork(const std::string &modelFileName,
+    InferenceEngine::IExecutableNetworkInternal::Ptr ImportNetwork(const std::string &modelFileName,
                                                      const std::map<std::string, std::string> &config) override {
         THROW_GNA_EXCEPTION << "Not implemented";
     }
-    InferenceEngine::ExecutableNetwork ImportNetwork(std::istream& networkModel,
+    InferenceEngine::IExecutableNetworkInternal::Ptr ImportNetwork(std::istream& networkModel,
                                                      const InferenceEngine::RemoteContext::Ptr& context,
                                                      const std::map<std::string, std::string> &config) override {
         THROW_GNA_EXCEPTION << "Not implemented";
     }
 
-    InferenceEngine::ExecutableNetwork ImportNetwork(std::istream& networkModel,
+    InferenceEngine::IExecutableNetworkInternal::Ptr ImportNetwork(std::istream& networkModel,
                                                      const std::map<std::string, std::string>& config) override {
         THROW_GNA_EXCEPTION << "Not implemented";
     }
 
-    InferenceEngine::ExecutableNetwork ImportNetwork(std::istream& networkModel);
+    InferenceEngine::IExecutableNetworkInternal::Ptr ImportNetwork(std::istream& networkModel);
 
     /**
      * utility to provide input and output blobs externally to be used by InferenceEngine request API clients

--- a/inference-engine/src/gna_plugin/gna_plugin_internal.hpp
+++ b/inference-engine/src/gna_plugin/gna_plugin_internal.hpp
@@ -46,7 +46,7 @@ public:
         defaultConfig.UpdateFromMap(config);
     }
 
-    InferenceEngine::ExecutableNetwork ImportNetwork(
+    InferenceEngine::IExecutableNetworkInternal::Ptr ImportNetwork(
                                                 const std::string &modelFileName,
                                                 const std::map<std::string, std::string> &config) override {
         Config updated_config(defaultConfig);
@@ -54,19 +54,17 @@ public:
         auto plg = std::make_shared<GNAPlugin>(updated_config.keyConfigMap);
         plgPtr = plg;
 
-        return make_executable_network(std::make_shared<GNAExecutableNetwork>(modelFileName, plg));
+        return std::make_shared<GNAExecutableNetwork>(modelFileName, plg);
     }
 
-    InferenceEngine::ExecutableNetwork ImportNetwork(std::istream& networkModel,
+    InferenceEngine::IExecutableNetworkInternal::Ptr ImportNetwork(std::istream& networkModel,
                                                      const std::map<std::string, std::string>& config) override {
         Config updated_config(defaultConfig);
         updated_config.UpdateFromMap(config);
         auto plg = std::make_shared<GNAPlugin>(updated_config.keyConfigMap);
         plgPtr = plg;
-        return make_executable_network(std::make_shared<GNAExecutableNetwork>(networkModel, plg));
+        return std::make_shared<GNAExecutableNetwork>(networkModel, plg);
     }
-
-    using InferenceEngine::InferencePluginInternal::ImportNetwork;
 
     std::string GetName() const noexcept override {
         return GetCurrentPlugin()->GetName();

--- a/inference-engine/src/hetero_plugin/hetero_plugin.cpp
+++ b/inference-engine/src/hetero_plugin/hetero_plugin.cpp
@@ -58,13 +58,13 @@ InferenceEngine::ExecutableNetworkInternal::Ptr Engine::LoadExeNetworkImpl(const
     return std::make_shared<HeteroExecutableNetwork>(network, mergeConfigs(_config, config), this);
 }
 
-InferenceEngine::ExecutableNetwork Engine::ImportNetworkImpl(std::istream& heteroModel, const Configs& config) {
+InferenceEngine::ExecutableNetworkInternal::Ptr Engine::ImportNetworkImpl(std::istream& heteroModel, const Configs& config) {
     if (GetCore() == nullptr) {
         IE_THROW() << "Please, work with HETERO device via InferencEngine::Core object";
     }
 
-    return make_executable_network(std::make_shared<HeteroExecutableNetwork>(heteroModel,
-        mergeConfigs(_config, config), this));
+    return std::make_shared<HeteroExecutableNetwork>(heteroModel,
+        mergeConfigs(_config, config), this);
 }
 
 Engine::Configs Engine::GetSupportedConfig(const Engine::Configs& config, const std::string & deviceName) const {

--- a/inference-engine/src/hetero_plugin/hetero_plugin.hpp
+++ b/inference-engine/src/hetero_plugin/hetero_plugin.hpp
@@ -37,7 +37,7 @@ public:
     InferenceEngine::Parameter GetConfig(const std::string& name, const std::map<std::string,
                                          InferenceEngine::Parameter> & options) const override;
 
-    InferenceEngine::ExecutableNetwork ImportNetworkImpl(std::istream& heteroModel, const Configs& config) override;
+    InferenceEngine::ExecutableNetworkInternal::Ptr ImportNetworkImpl(std::istream& heteroModel, const Configs& config) override;
 
     DeviceMetaInformationMap GetDevicePlugins(const std::string& targetFallback,
         const Configs & localConfig) const;

--- a/inference-engine/src/inference_engine/cpp/ie_executable_network.cpp
+++ b/inference-engine/src/inference_engine/cpp/ie_executable_network.cpp
@@ -4,117 +4,109 @@
 
 #include "cpp/ie_executable_network.hpp"
 #include "ie_common.h"
+#include "cpp_interfaces/interface/ie_iexecutable_network_internal.hpp"
+#include "cpp_interfaces/exception2status.hpp"
+#include "ie_iexecutable_network.hpp"
+#include "cpp_interfaces/base/ie_executable_network_base.hpp"
 
 namespace InferenceEngine {
 
-ExecutableNetwork::ExecutableNetwork(IExecutableNetwork::Ptr actual_, details::SharedObjectLoader::Ptr plg)
-    : actual(actual_), plg(plg) {
-    //  plg can be null, but not the actual
-    if (actual == nullptr) {
-        IE_THROW() << "ExecutableNetwork wrapper was not initialized.";
+#define CALL_STATEMENT(...)                                                                        \
+    if (_impl == nullptr) IE_THROW() << "ExecutableNetwork was not initialized.";                  \
+    try {                                                                                          \
+        __VA_ARGS__;                                                                               \
+    } CATCH_IE_EXCEPTIONS catch (const std::exception& ex) {                                       \
+        IE_THROW() << ex.what();                                                                   \
+    } catch (...) {                                                                                \
+        IE_THROW(Unexpected);                                                                      \
     }
+
+ExecutableNetwork::ExecutableNetwork(const IExecutableNetworkInternal::Ptr& impl,
+                                     const std::shared_ptr<details::SharedObjectLoader>& so)
+    : _impl(impl), _so(so) {
+    IE_ASSERT(_impl != nullptr);
 }
 
 ExecutableNetwork::~ExecutableNetwork() {
-    actual = {};
+    _impl = {};
 }
 
 ConstOutputsDataMap ExecutableNetwork::GetOutputsInfo() const {
-    ConstOutputsDataMap data;
-    CALL_STATUS_FNC(GetOutputsInfo, data);
-    return data;
+    CALL_STATEMENT(return _impl->GetOutputsInfo());
 }
 
 ConstInputsDataMap ExecutableNetwork::GetInputsInfo() const {
-    ConstInputsDataMap info;
-    CALL_STATUS_FNC(GetInputsInfo, info);
-    return info;
+    CALL_STATEMENT(return _impl->GetInputsInfo());
 }
 
 void ExecutableNetwork::reset(IExecutableNetwork::Ptr newActual) {
-    if (actual == nullptr) {
-        IE_THROW() << "ExecutableNetwork wrapper was not initialized.";
-    }
-    if (newActual == nullptr) {
-        IE_THROW() << "ExecutableNetwork wrapper used for reset was not initialized.";
-    }
-    this->actual.swap(newActual);
+    if (_impl == nullptr) IE_THROW() << "ExecutableNetwork was not initialized.";
+    if (newActual == nullptr) IE_THROW() << "ExecutableNetwork wrapper used for reset was not initialized.";
+    auto newBase = std::dynamic_pointer_cast<ExecutableNetworkBase>(newActual);
+    IE_ASSERT(newBase != nullptr);
+    auto newImpl = newBase->GetImpl();
+    IE_ASSERT(newImpl != nullptr);
+    this->_impl.swap(newImpl);
 }
 
 InferRequest ExecutableNetwork::CreateInferRequest() {
-    IInferRequest::Ptr req;
-    CALL_STATUS_FNC(CreateInferRequest, req);
-    if (req.get() == nullptr) IE_THROW() << "Internal error: pointer to infer request is null";
-    return InferRequest(req, plg);
+    CALL_STATEMENT(return InferRequest{_impl->CreateInferRequest(), _so});
 }
 
 InferRequest::Ptr ExecutableNetwork::CreateInferRequestPtr() {
-    IInferRequest::Ptr req;
-    CALL_STATUS_FNC(CreateInferRequest, req);
-    return std::make_shared<InferRequest>(req, plg);
+    CALL_STATEMENT(return std::make_shared<InferRequest>(_impl->CreateInferRequest(), _so));
 }
 
 void ExecutableNetwork::Export(const std::string& modelFileName) {
-    CALL_STATUS_FNC(Export, modelFileName);
+    CALL_STATEMENT(return _impl->Export(modelFileName));
 }
 
 void ExecutableNetwork::Export(std::ostream& networkModel) {
-    CALL_STATUS_FNC(Export, networkModel);
+    CALL_STATEMENT(return _impl->Export(networkModel));
 }
 
-ExecutableNetwork::operator IExecutableNetwork::Ptr&() {
-    return actual;
+ExecutableNetwork::operator IExecutableNetwork::Ptr() {
+    return std::make_shared<ExecutableNetworkBase>(_impl);
 }
 
 CNNNetwork ExecutableNetwork::GetExecGraphInfo() {
     IE_SUPPRESS_DEPRECATED_START
-    ICNNNetwork::Ptr ptr = nullptr;
-    CALL_STATUS_FNC(GetExecGraphInfo, ptr);
-    return CNNNetwork(ptr);
-    IE_SUPPRESS_DEPRECATED_END
+    CALL_STATEMENT(return _impl->GetExecGraphInfo());
 }
 
-
+IE_SUPPRESS_DEPRECATED_START
 std::vector<VariableState> ExecutableNetwork::QueryState() {
-    if (actual == nullptr) IE_THROW() << "ExecutableNetwork was not initialized.";
-    IVariableState::Ptr pState = nullptr;
-    auto res = OK;
     std::vector<VariableState> controller;
-    for (size_t idx = 0; res == OK; ++idx) {
-        ResponseDesc resp;
-        IE_SUPPRESS_DEPRECATED_START
-        res = actual->QueryState(pState, idx, &resp);
-        IE_SUPPRESS_DEPRECATED_END
-        if (res != OK && res != OUT_OF_BOUNDS) {
-            IE_THROW() << resp.msg;
-        }
-        if (res != OUT_OF_BOUNDS) {
-            controller.push_back(VariableState(pState, plg));
-        }
-    }
-
+    CALL_STATEMENT(
+        for (auto&& state : _impl->QueryState()) {
+            controller.emplace_back(std::make_shared<VariableStateBase>(state), _so);
+        });
     return controller;
 }
+IE_SUPPRESS_DEPRECATED_END
 
 void ExecutableNetwork::SetConfig(const std::map<std::string, Parameter>& config) {
-    CALL_STATUS_FNC(SetConfig, config);
+    CALL_STATEMENT(_impl->SetConfig(config));
 }
 
 Parameter ExecutableNetwork::GetConfig(const std::string& name) const {
-    Parameter configValue;
-    CALL_STATUS_FNC(GetConfig, name, configValue);
-    return configValue;
+    CALL_STATEMENT(return _impl->GetConfig(name));
 }
 
 Parameter ExecutableNetwork::GetMetric(const std::string& name) const {
-    Parameter metricValue;
-    CALL_STATUS_FNC(GetMetric, name, metricValue);
-    return metricValue;
+    CALL_STATEMENT(return _impl->GetMetric(name));
 }
 
 RemoteContext::Ptr ExecutableNetwork::GetContext() const {
-    RemoteContext::Ptr pContext;
-    CALL_STATUS_FNC(GetContext, pContext);
-    return pContext;
+    CALL_STATEMENT(return _impl->GetContext());
 }
+
+bool ExecutableNetwork::operator!() const noexcept {
+    return !_impl;
+}
+
+ExecutableNetwork::operator bool() const noexcept {
+    return !!_impl;
+}
+
 }  // namespace InferenceEngine

--- a/inference-engine/src/inference_engine/ie_plugin_cpp.hpp
+++ b/inference-engine/src/inference_engine/ie_plugin_cpp.hpp
@@ -24,23 +24,6 @@
 # pragma GCC diagnostic ignored "-Wreturn-type"
 #endif
 
-#define CATCH_IE_EXCEPTION(ExceptionType) catch (const InferenceEngine::ExceptionType& e) {throw e;}
-
-#define CATCH_IE_EXCEPTIONS                     \
-        CATCH_IE_EXCEPTION(GeneralError)        \
-        CATCH_IE_EXCEPTION(NotImplemented)      \
-        CATCH_IE_EXCEPTION(NetworkNotLoaded)    \
-        CATCH_IE_EXCEPTION(ParameterMismatch)   \
-        CATCH_IE_EXCEPTION(NotFound)            \
-        CATCH_IE_EXCEPTION(OutOfBounds)         \
-        CATCH_IE_EXCEPTION(Unexpected)          \
-        CATCH_IE_EXCEPTION(RequestBusy)         \
-        CATCH_IE_EXCEPTION(ResultNotReady)      \
-        CATCH_IE_EXCEPTION(NotAllocated)        \
-        CATCH_IE_EXCEPTION(InferNotStarted)     \
-        CATCH_IE_EXCEPTION(NetworkNotRead)      \
-        CATCH_IE_EXCEPTION(InferCancelled)
-
 #define CALL_STATEMENT(...)                                                                        \
     if (!actual) IE_THROW() << "Wrapper used in the CALL_STATEMENT was not initialized.";  \
     try {                                                                                          \

--- a/inference-engine/src/plugin_api/cpp_interfaces/base/ie_executable_network_base.hpp
+++ b/inference-engine/src/plugin_api/cpp_interfaces/base/ie_executable_network_base.hpp
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <ie_iexecutable_network.hpp>
 #include <cpp/ie_executable_network.hpp>
 #include <cpp_interfaces/base/ie_variable_state_base.hpp>
 #include <cpp_interfaces/interface/ie_ivariable_state_internal.hpp>
@@ -103,23 +104,11 @@ public:
     StatusCode GetContext(RemoteContext::Ptr& pContext, ResponseDesc* resp) const noexcept override {
         TO_STATUS(pContext = _impl->GetContext());
     }
+
+    std::shared_ptr<IExecutableNetworkInternal> GetImpl() const {
+        return _impl;
+    }
 };
 IE_SUPPRESS_DEPRECATED_END_WIN
-
-/**
- * @brief Create an execuable network public C++ object wrapper based on internal inplementation
- * @ingroup ie_dev_api_exec_network_api
- * @param impl An internal implementation for executable network
- * @tparam T A type of internal implementation
- * @return C++ wrapper for executable network
- */
-template <class T>
-inline typename InferenceEngine::ExecutableNetwork make_executable_network(std::shared_ptr<T> impl) {
-    // to suppress warning about deprecated QueryState
-    IE_SUPPRESS_DEPRECATED_START
-    typename ExecutableNetworkBase::Ptr net(new ExecutableNetworkBase(impl));
-    IE_SUPPRESS_DEPRECATED_END
-    return InferenceEngine::ExecutableNetwork(net);
-}
 
 }  // namespace InferenceEngine

--- a/inference-engine/src/plugin_api/cpp_interfaces/exception2status.hpp
+++ b/inference-engine/src/plugin_api/cpp_interfaces/exception2status.hpp
@@ -66,4 +66,21 @@ INFERENCE_ENGINE_API_CPP(StatusCode) ExceptionToStatus(const Exception& exceptio
         return InferenceEngine::DescriptionBuffer(UNEXPECTED);                                                  \
     }
 
+#define CATCH_IE_EXCEPTION(ExceptionType) catch (const InferenceEngine::ExceptionType& e) {throw e;}
+
+#define CATCH_IE_EXCEPTIONS                     \
+        CATCH_IE_EXCEPTION(GeneralError)        \
+        CATCH_IE_EXCEPTION(NotImplemented)      \
+        CATCH_IE_EXCEPTION(NetworkNotLoaded)    \
+        CATCH_IE_EXCEPTION(ParameterMismatch)   \
+        CATCH_IE_EXCEPTION(NotFound)            \
+        CATCH_IE_EXCEPTION(OutOfBounds)         \
+        CATCH_IE_EXCEPTION(Unexpected)          \
+        CATCH_IE_EXCEPTION(RequestBusy)         \
+        CATCH_IE_EXCEPTION(ResultNotReady)      \
+        CATCH_IE_EXCEPTION(NotAllocated)        \
+        CATCH_IE_EXCEPTION(InferNotStarted)     \
+        CATCH_IE_EXCEPTION(NetworkNotRead)      \
+        CATCH_IE_EXCEPTION(InferCancelled)
+
 }  // namespace InferenceEngine

--- a/inference-engine/src/plugin_api/cpp_interfaces/impl/ie_executable_network_thread_safe_async_only.hpp
+++ b/inference-engine/src/plugin_api/cpp_interfaces/impl/ie_executable_network_thread_safe_async_only.hpp
@@ -22,8 +22,7 @@ namespace InferenceEngine {
  * @brief      This class describes an executable network thread safe asynchronous only implementation.
  * @ingroup    ie_dev_api_exec_network_api
  */
-class ExecutableNetworkThreadSafeAsyncOnly : public ExecutableNetworkInternal,
-                                             public std::enable_shared_from_this<ExecutableNetworkThreadSafeAsyncOnly> {
+class ExecutableNetworkThreadSafeAsyncOnly : public ExecutableNetworkInternal {
 public:
     /**
      * @brief A shared pointer to a ExecutableNetworkThreadSafeAsyncOnly object

--- a/inference-engine/src/plugin_api/cpp_interfaces/impl/ie_executable_network_thread_safe_default.hpp
+++ b/inference-engine/src/plugin_api/cpp_interfaces/impl/ie_executable_network_thread_safe_default.hpp
@@ -22,8 +22,7 @@ namespace InferenceEngine {
  * The class is recommended to be used as a base class for Executable Network impleentation during plugin development.
  * @ingroup ie_dev_api_exec_network_api
  */
-class ExecutableNetworkThreadSafeDefault : public ExecutableNetworkInternal,
-                                           public std::enable_shared_from_this<ExecutableNetworkThreadSafeDefault> {
+class ExecutableNetworkThreadSafeDefault : public ExecutableNetworkInternal {
 public:
     /**
      * @brief A shared pointer to a ExecutableNetworkThreadSafeDefault object

--- a/inference-engine/src/plugin_api/cpp_interfaces/impl/ie_infer_request_internal.hpp
+++ b/inference-engine/src/plugin_api/cpp_interfaces/impl/ie_infer_request_internal.hpp
@@ -22,7 +22,7 @@
 
 namespace InferenceEngine {
 
-class ExecutableNetworkInternal;
+class IExecutableNetworkInternal;
 
 /**
  * @brief An optimal implementation of IInferRequestInternal interface to avoid duplication in all plugins
@@ -223,7 +223,7 @@ public:
      * @note       Needed to correctly handle ownership between objects.
      * @param[in]  exeNetwork  The executable network
      */
-    void setPointerToExecutableNetworkInternal(std::shared_ptr<ExecutableNetworkInternal> exeNetwork) {
+    void setPointerToExecutableNetworkInternal(std::shared_ptr<IExecutableNetworkInternal> exeNetwork) {
         _exeNetwork = exeNetwork;
     }
 
@@ -258,7 +258,7 @@ protected:
      * @brief A shared pointer to ExecutableNetworkInternal interface
      * @note Needed to correctly handle ownership between objects.
      */
-    std::shared_ptr<ExecutableNetworkInternal> _exeNetwork;
+    std::shared_ptr<IExecutableNetworkInternal> _exeNetwork;
     /**
      * @brief Checks and executes input data pre-processing if needed.
      * @param inputs Inputs blobs to perform preprocessing on

--- a/inference-engine/src/plugin_api/cpp_interfaces/impl/ie_plugin_internal.hpp
+++ b/inference-engine/src/plugin_api/cpp_interfaces/impl/ie_plugin_internal.hpp
@@ -48,13 +48,13 @@ static inline void parsePluginName(std::istream& networkModel) {
  */
 class InferencePluginInternal : public IInferencePlugin {
 public:
-    ExecutableNetwork LoadNetwork(const CNNNetwork& network,
+    IExecutableNetworkInternal::Ptr LoadNetwork(const CNNNetwork& network,
                                   const std::map<std::string, std::string>& config) override {
         return LoadNetwork(network, config, nullptr);
     }
 
-    ExecutableNetwork LoadNetwork(const CNNNetwork& network, const std::map<std::string, std::string>& config,
-                                  RemoteContext::Ptr context) override {
+    IExecutableNetworkInternal::Ptr LoadNetwork(const CNNNetwork& network, const std::map<std::string, std::string>& config,
+                                                RemoteContext::Ptr context) override {
         InputsDataMap networkInputs = network.getInputsInfo(), networkInputsCloned;
         OutputsDataMap networkOutputs = network.getOutputsInfo(), networkOutputsCloned;
         copyInputOutputInfo(networkInputs, networkOutputs, networkInputsCloned, networkOutputsCloned);
@@ -70,26 +70,25 @@ public:
         impl->setNetworkOutputs(networkOutputsCloned);
         impl->SetPointerToPlugin(shared_from_this());
 
-        auto executableNetwork = make_executable_network(impl);
-        return ExecutableNetwork(executableNetwork);
+        return impl;
     }
 
-    ExecutableNetwork ImportNetwork(const std::string& modelFileName,
-                                    const std::map<std::string, std::string>& config) override {
+    IExecutableNetworkInternal::Ptr ImportNetwork(const std::string& modelFileName,
+                                                  const std::map<std::string, std::string>& config) override {
         (void)modelFileName;
         (void)config;
         IE_THROW(NotImplemented);
     }
 
-    ExecutableNetwork ImportNetwork(std::istream& networkModel,
-                                    const std::map<std::string, std::string>& config) override {
+    IExecutableNetworkInternal::Ptr ImportNetwork(std::istream& networkModel,
+                                                  const std::map<std::string, std::string>& config) override {
         parsePluginName(networkModel);
         return ImportNetworkImpl(networkModel, config);
     }
 
-    ExecutableNetwork ImportNetwork(std::istream& networkModel,
-                                    const RemoteContext::Ptr& context,
-                                    const std::map<std::string, std::string>& config) override {
+    IExecutableNetworkInternal::Ptr ImportNetwork(std::istream& networkModel,
+                                                  const RemoteContext::Ptr& context,
+                                                  const std::map<std::string, std::string>& config) override {
         parsePluginName(networkModel);
         return ImportNetworkImpl(networkModel, context, config);
     }
@@ -184,8 +183,8 @@ protected:
      * @param config A string -> string map of parameters
      * @return An Executable network
      */
-    virtual ExecutableNetwork ImportNetworkImpl(std::istream& networkModel,
-                                                const std::map<std::string, std::string>& config) {
+    virtual ExecutableNetworkInternal::Ptr ImportNetworkImpl(std::istream& networkModel,
+                                                             const std::map<std::string, std::string>& config) {
         (void)networkModel;
         (void)config;
         IE_THROW(NotImplemented);
@@ -199,9 +198,9 @@ protected:
      * @param config A string -> string map of parameters
      * @return An Executable network
      */
-    virtual ExecutableNetwork ImportNetworkImpl(std::istream& networkModel,
-                                                const RemoteContext::Ptr& context,
-                                                const std::map<std::string, std::string>& config) {
+    virtual ExecutableNetworkInternal::Ptr ImportNetworkImpl(std::istream& networkModel,
+                                                             const RemoteContext::Ptr& context,
+                                                             const std::map<std::string, std::string>& config) {
         (void)networkModel;
         (void)context;
         (void)config;

--- a/inference-engine/src/plugin_api/cpp_interfaces/interface/ie_iexecutable_network_internal.hpp
+++ b/inference-engine/src/plugin_api/cpp_interfaces/interface/ie_iexecutable_network_internal.hpp
@@ -17,10 +17,9 @@ namespace InferenceEngine {
 /**
  * @interface IExecutableNetworkInternal
  * @brief An internal API of executable network to be implemented by plugin,
- * which is used in ExecutableNetworkBase forwarding mechanism.
  * @ingroup ie_dev_api_exec_network_api
  */
-class IExecutableNetworkInternal {
+class IExecutableNetworkInternal : public std::enable_shared_from_this<IExecutableNetworkInternal> {
 public:
     /**
      * @brief A shared pointer to IExecutableNetworkInternal interface

--- a/inference-engine/src/plugin_api/cpp_interfaces/interface/ie_iplugin_internal.hpp
+++ b/inference-engine/src/plugin_api/cpp_interfaces/interface/ie_iplugin_internal.hpp
@@ -26,6 +26,8 @@
 
 namespace InferenceEngine {
 
+class IExecutableNetworkInternal;
+
 /**
  * @brief      Copies preprocess info
  *
@@ -152,8 +154,8 @@ public:
      * @param config A string-string map of config parameters relevant only for this load operation
      * @return Created Executable Network object
      */
-    virtual ExecutableNetwork LoadNetwork(const CNNNetwork& network,
-                                          const std::map<std::string, std::string>& config) = 0;
+    virtual std::shared_ptr<IExecutableNetworkInternal> LoadNetwork(const CNNNetwork& network,
+                                                                    const std::map<std::string, std::string>& config) = 0;
 
     /**
      * @brief Creates an executable network from network object, on specified remote context
@@ -163,9 +165,9 @@ public:
      *        execute the network
      * @return Created Executable Network object
      */
-    virtual ExecutableNetwork LoadNetwork(const CNNNetwork& network,
-                                          const std::map<std::string, std::string>& config,
-                                          RemoteContext::Ptr context) = 0;
+    virtual std::shared_ptr<IExecutableNetworkInternal> LoadNetwork(const CNNNetwork& network,
+                                                                    const std::map<std::string, std::string>& config,
+                                                                    RemoteContext::Ptr context) = 0;
     /**
      * @brief Registers extension within plugin
      * @param extension - pointer to already loaded extension
@@ -215,8 +217,8 @@ public:
      * @param config A string -> string map of parameters
      * @return An Executable network
      */
-    virtual ExecutableNetwork ImportNetwork(const std::string& modelFileName,
-                                            const std::map<std::string, std::string>& config) = 0;
+    virtual std::shared_ptr<IExecutableNetworkInternal> ImportNetwork(const std::string& modelFileName,
+                                                                      const std::map<std::string, std::string>& config) = 0;
 
     /**
      * @brief Creates an executable network from an previously exported network using plugin implementation
@@ -225,8 +227,8 @@ public:
      * @param config A string -> string map of parameters
      * @return An Executable network
      */
-    virtual ExecutableNetwork ImportNetwork(std::istream& networkModel,
-                                            const std::map<std::string, std::string>& config) = 0;
+    virtual std::shared_ptr<IExecutableNetworkInternal> ImportNetwork(std::istream& networkModel,
+                                                                      const std::map<std::string, std::string>& config) = 0;
 
     /**
      * @brief Creates an executable network from an previously exported network using plugin implementation
@@ -237,9 +239,9 @@ public:
      * @param config A string -> string map of parameters
      * @return An Executable network
      */
-    virtual ExecutableNetwork ImportNetwork(std::istream& networkModel,
-                                            const RemoteContext::Ptr& context,
-                                            const std::map<std::string, std::string>& config) = 0;
+    virtual std::shared_ptr<IExecutableNetworkInternal> ImportNetwork(std::istream& networkModel,
+                                                                      const RemoteContext::Ptr& context,
+                                                                      const std::map<std::string, std::string>& config) = 0;
 
     /**
      * @brief Sets pointer to ICore interface

--- a/inference-engine/src/vpu/myriad_plugin/myriad_plugin.cpp
+++ b/inference-engine/src/vpu/myriad_plugin/myriad_plugin.cpp
@@ -135,7 +135,7 @@ IE_SUPPRESS_DEPRECATED_START
 IE_SUPPRESS_DEPRECATED_END
 }
 
-InferenceEngine::ExecutableNetwork Engine::ImportNetwork(
+InferenceEngine::IExecutableNetworkInternal::Ptr Engine::ImportNetwork(
         std::istream& model,
         const std::map<std::string, std::string>& config) {
     VPU_PROFILE(ImportNetwork);
@@ -148,10 +148,10 @@ InferenceEngine::ExecutableNetwork Engine::ImportNetwork(
                 model, _mvnc, _devicePool, parsedConfigCopy, GetCore());
     executableNetwork->SetPointerToPlugin(shared_from_this());
 
-    return make_executable_network(executableNetwork);
+    return executableNetwork;
 }
 
-InferenceEngine::ExecutableNetwork Engine::ImportNetwork(
+InferenceEngine::IExecutableNetworkInternal::Ptr Engine::ImportNetwork(
         const std::string& modelFileName,
         const std::map<std::string, std::string>& config) {
     VPU_PROFILE(ImportNetwork);

--- a/inference-engine/src/vpu/myriad_plugin/myriad_plugin.h
+++ b/inference-engine/src/vpu/myriad_plugin/myriad_plugin.h
@@ -37,11 +37,11 @@ public:
 
     using ie::InferencePluginInternal::ImportNetwork;
 
-    ie::ExecutableNetwork ImportNetwork(
+    ie::IExecutableNetworkInternal::Ptr ImportNetwork(
             const std::string& modelFileName,
             const std::map<std::string, std::string>& config) override;
 
-    ie::ExecutableNetwork ImportNetwork(
+    ie::IExecutableNetworkInternal::Ptr ImportNetwork(
             std::istream& model,
             const std::map<std::string, std::string>& config) override;
 

--- a/inference-engine/tests/functional/inference_engine/executable_network.cpp
+++ b/inference-engine/tests/functional/inference_engine/executable_network.cpp
@@ -4,16 +4,12 @@
 
 #include <gtest/gtest.h>
 #include <cpp/ie_executable_network.hpp>
+#include <ie_iexecutable_network.hpp>
 
 using namespace ::testing;
 using namespace std;
 using namespace InferenceEngine;
 using namespace InferenceEngine::details;
-
-TEST(ExecutableNetworkTests, throwsOnInitWithNull) {
-    std::shared_ptr<IExecutableNetwork> nlptr = nullptr;
-    ASSERT_THROW(ExecutableNetwork exec(nlptr), InferenceEngine::Exception);
-}
 
 TEST(ExecutableNetworkTests, throwsOnUninitializedGetOutputsInfo) {
     ExecutableNetwork exec;
@@ -33,11 +29,6 @@ TEST(ExecutableNetworkTests, throwsOnUninitializedExport) {
 TEST(ExecutableNetworkTests, throwsOnUninitializedExportStream) {
     ExecutableNetwork exec;
     ASSERT_THROW(exec.Export(std::cout), InferenceEngine::Exception);
-}
-
-TEST(ExecutableNetworkTests, nothrowsOnUninitializedCast) {
-    ExecutableNetwork exec;
-    ASSERT_NO_THROW((void)static_cast<IExecutableNetwork::Ptr &>(exec));
 }
 
 TEST(ExecutableNetworkTests, throwsOnUninitializedGetExecGraphInfo) {

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/behavior/core_integration.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/behavior/core_integration.cpp
@@ -50,7 +50,7 @@ TEST_P(IEClassNetworkTestP_VPU, smoke_ImportNetworkNoThrowIfNoDeviceName) {
     if (!strm.str().empty() && deviceName.find(CommonTestUtils::DEVICE_FPGA) != std::string::npos) {
         SKIP_IF_NOT_IMPLEMENTED(executableNetwork = ie.ImportNetwork(strm));
     }
-    if (nullptr != static_cast<IExecutableNetwork::Ptr &>(executableNetwork)) {
+    if (executableNetwork) {
         ASSERT_NO_THROW(executableNetwork.CreateInferRequest());
     }
 }

--- a/inference-engine/tests/functional/plugin/shared/include/behavior/core_integration.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/behavior/core_integration.hpp
@@ -485,7 +485,7 @@ TEST_P(IEClassImportExportTestP, smoke_ImportNetworkNoThrowIfNoDeviceName) {
     if (!strm.str().empty()) {
         SKIP_IF_NOT_IMPLEMENTED(executableNetwork = ie.ImportNetwork(strm));
     }
-    if (nullptr != static_cast<IExecutableNetwork::Ptr &>(executableNetwork)) {
+    if (executableNetwork) {
         ASSERT_NO_THROW(executableNetwork.CreateInferRequest());
     }
 }
@@ -498,7 +498,7 @@ TEST_P(IEClassImportExportTestP, smoke_ImportNetworkNoThrowWithDeviceName) {
     ASSERT_NO_THROW(executableNetwork = ie.LoadNetwork(actualNetwork, deviceName));
     SKIP_IF_NOT_IMPLEMENTED(executableNetwork.Export(strm));
     SKIP_IF_NOT_IMPLEMENTED(executableNetwork = ie.ImportNetwork(strm, deviceName));
-    if (nullptr != static_cast<IExecutableNetwork::Ptr &>(executableNetwork)) {
+    if (executableNetwork) {
         ASSERT_NO_THROW(executableNetwork.CreateInferRequest());
     }
 }
@@ -519,7 +519,7 @@ TEST_P(IEClassImportExportTestP, smoke_ExportUsingFileNameImportFromStreamNoThro
         }
         ASSERT_EQ(0, remove(fileName.c_str()));
     }
-    if (nullptr != static_cast<IExecutableNetwork::Ptr &>(executableNetwork)) {
+    if (executableNetwork) {
         ASSERT_NO_THROW(executableNetwork.CreateInferRequest());
     }
 }

--- a/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/cpp_interfaces/impl/mock_inference_plugin_internal.hpp
+++ b/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/cpp_interfaces/impl/mock_inference_plugin_internal.hpp
@@ -20,7 +20,7 @@ class MockInferencePluginInternal2 : public InferenceEngine::InferencePluginInte
 public:
     MOCK_METHOD2(LoadExeNetworkImpl, std::shared_ptr<InferenceEngine::ExecutableNetworkInternal>(
             const InferenceEngine::CNNNetwork &, const std::map<std::string, std::string> &));
-    MOCK_METHOD2(LoadNetwork, ExecutableNetwork(
+    MOCK_METHOD2(LoadNetwork, std::shared_ptr<InferenceEngine::IExecutableNetworkInternal>(
             const InferenceEngine::CNNNetwork &,
             const std::map<std::string, std::string> &));
     MOCK_METHOD1(AddExtension, void(InferenceEngine::IExtensionPtr ext_ptr));
@@ -36,7 +36,7 @@ public:
 
     using InferenceEngine::InferencePluginInternal::ImportNetwork;
 
-    ExecutableNetwork ImportNetworkImpl(std::istream& stream, const std::map <std::string, std::string>&) {
+    ExecutableNetworkInternal::Ptr ImportNetworkImpl(std::istream& stream, const std::map <std::string, std::string>&) {
         std::getline(stream, importedString);
         return {};
     }

--- a/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/cpp_interfaces/interface/mock_iinference_plugin.hpp
+++ b/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/cpp_interfaces/interface/mock_iinference_plugin.hpp
@@ -13,9 +13,9 @@
 class MockIInferencePlugin : public InferenceEngine::IInferencePlugin {
 public:
     MOCK_METHOD1(AddExtension, void(InferenceEngine::IExtensionPtr));
-    MOCK_METHOD2(LoadNetwork, InferenceEngine::ExecutableNetwork(
+    MOCK_METHOD2(LoadNetwork, std::shared_ptr<InferenceEngine::IExecutableNetworkInternal>(
                 const CNNNetwork&, const std::map<std::string, std::string>&));
-    MOCK_METHOD2(ImportNetwork, InferenceEngine::ExecutableNetwork(
+    MOCK_METHOD2(ImportNetwork, std::shared_ptr<InferenceEngine::IExecutableNetworkInternal>(
                 const std::string&, const std::map<std::string, std::string>&));
     MOCK_METHOD1(SetConfig, void(const std::map<std::string, std::string> &));
 
@@ -30,12 +30,12 @@ public:
     MOCK_METHOD1(CreateContext,
                 InferenceEngine::RemoteContext::Ptr(const InferenceEngine::ParamMap&));
     MOCK_METHOD1(GetDefaultContext, InferenceEngine::RemoteContext::Ptr(const InferenceEngine::ParamMap&));
-    MOCK_METHOD3(LoadNetwork, InferenceEngine::ExecutableNetwork(
+    MOCK_METHOD3(LoadNetwork, std::shared_ptr<InferenceEngine::IExecutableNetworkInternal>(
                 const InferenceEngine::CNNNetwork&, const std::map<std::string, std::string>&,
                 InferenceEngine::RemoteContext::Ptr));
-    MOCK_METHOD2(ImportNetwork, InferenceEngine::ExecutableNetwork(
+    MOCK_METHOD2(ImportNetwork, std::shared_ptr<InferenceEngine::IExecutableNetworkInternal>(
                 std::istream&, const std::map<std::string, std::string>&));
-    MOCK_METHOD3(ImportNetwork, InferenceEngine::ExecutableNetwork(
+    MOCK_METHOD3(ImportNetwork, std::shared_ptr<InferenceEngine::IExecutableNetworkInternal>(
                 std::istream&, const InferenceEngine::RemoteContext::Ptr&,
                 const std::map<std::string, std::string>&));
 };

--- a/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/mock_engine/mock_plugin.cpp
+++ b/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/mock_engine/mock_plugin.cpp
@@ -30,7 +30,7 @@ Parameter MockPlugin::GetMetric(const std::string& name, const std::map<std::str
     }
 }
 
-ExecutableNetwork
+std::shared_ptr<InferenceEngine::IExecutableNetworkInternal>
 MockPlugin::LoadNetwork(const CNNNetwork &network,
                         const std::map<std::string, std::string> &config) {
     if (_target) {
@@ -40,7 +40,7 @@ MockPlugin::LoadNetwork(const CNNNetwork &network,
     }
 }
 
-ExecutableNetwork
+std::shared_ptr<InferenceEngine::IExecutableNetworkInternal>
 MockPlugin::LoadNetwork(const CNNNetwork& network, const std::map<std::string, std::string>& config,
                         RemoteContext::Ptr context) {
     if (_target) {
@@ -56,22 +56,22 @@ MockPlugin::LoadExeNetworkImpl(const CNNNetwork& network,
     return {};
 }
 
-InferenceEngine::ExecutableNetwork
+InferenceEngine::ExecutableNetworkInternal::Ptr
 MockPlugin::ImportNetworkImpl(std::istream& networkModel,
                               const std::map<std::string, std::string>& config) {
     if (_target) {
-        return _target->ImportNetwork(networkModel, config);
+        return std::static_pointer_cast<ExecutableNetworkInternal>(_target->ImportNetwork(networkModel, config));
     } else {
         IE_THROW(NotImplemented);
     }
 }
 
-InferenceEngine::ExecutableNetwork
+InferenceEngine::ExecutableNetworkInternal::Ptr
 MockPlugin::ImportNetworkImpl(std::istream& networkModel,
                               const InferenceEngine::RemoteContext::Ptr& context,
                               const std::map<std::string, std::string>& config) {
     if (_target) {
-        return _target->ImportNetwork(networkModel, context, config);
+        return std::static_pointer_cast<ExecutableNetworkInternal>(_target->ImportNetwork(networkModel, context, config));
     } else {
         IE_THROW(NotImplemented);
     }

--- a/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/mock_engine/mock_plugin.hpp
+++ b/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/mock_engine/mock_plugin.hpp
@@ -18,23 +18,25 @@ public:
 
     void SetConfig(const std::map<std::string, std::string>& config) override;
 
-    InferenceEngine::ExecutableNetwork
+    std::shared_ptr<InferenceEngine::IExecutableNetworkInternal>
     LoadNetwork(const InferenceEngine::CNNNetwork &network,
                 const std::map<std::string, std::string> &config) override;
 
-    InferenceEngine::ExecutableNetwork
+    std::shared_ptr<InferenceEngine::IExecutableNetworkInternal>
     LoadNetwork(const InferenceEngine::CNNNetwork& network,
                 const std::map<std::string, std::string>& config,
                 InferenceEngine::RemoteContext::Ptr context) override;
 
-    InferenceEngine::ExecutableNetworkInternal::Ptr
+    std::shared_ptr<InferenceEngine::ExecutableNetworkInternal>
     LoadExeNetworkImpl(const InferenceEngine::CNNNetwork& network,
                        const std::map<std::string, std::string>& config) override;
 
-    InferenceEngine::ExecutableNetwork ImportNetworkImpl(std::istream& networkModel,
+    std::shared_ptr<InferenceEngine::ExecutableNetworkInternal>
+    ImportNetworkImpl(std::istream& networkModel,
         const std::map<std::string, std::string>& config) override;
 
-    InferenceEngine::ExecutableNetwork ImportNetworkImpl(std::istream& networkModel,
+    std::shared_ptr<InferenceEngine::ExecutableNetworkInternal>
+    ImportNetworkImpl(std::istream& networkModel,
         const InferenceEngine::RemoteContext::Ptr& context,
         const std::map<std::string, std::string>& config) override;
 

--- a/inference-engine/tests/unit/inference_engine/cpp_interfaces/ie_plugin_test.cpp
+++ b/inference-engine/tests/unit/inference_engine/cpp_interfaces/ie_plugin_test.cpp
@@ -8,6 +8,9 @@
 #include <ie_version.hpp>
 #include <ie_plugin_cpp.hpp>
 
+#include <cpp_interfaces/base/ie_infer_async_request_base.hpp>
+#include <cpp_interfaces/interface/ie_iexecutable_network_internal.hpp>
+
 #include "unit_test_utils/mocks/mock_not_empty_icnn_network.hpp"
 #include "unit_test_utils/mocks/cpp_interfaces/impl/mock_inference_plugin_internal.hpp"
 #include "unit_test_utils/mocks/cpp_interfaces/impl/mock_executable_thread_safe_default.hpp"
@@ -48,7 +51,7 @@ protected:
     }
 
     void getInferRequestWithMockImplInside(IInferRequest::Ptr &request) {
-        ExecutableNetwork exeNetwork;
+        IExecutableNetworkInternal::Ptr exeNetwork;
         InputsDataMap inputsInfo;
         mockNotEmptyNet->getInputsInfo(inputsInfo);
         OutputsDataMap outputsInfo;
@@ -58,7 +61,7 @@ protected:
         EXPECT_CALL(*mock_plugin_impl.get(), LoadExeNetworkImpl(_, _)).WillOnce(Return(mockExeNetworkTS));
         EXPECT_CALL(*mockExeNetworkTS.get(), CreateInferRequestImpl(_, _)).WillOnce(Return(mockInferRequestInternal));
         ASSERT_NO_THROW(exeNetwork = plugin->LoadNetwork(InferenceEngine::CNNNetwork(mockNotEmptyNet), {}));
-        ASSERT_NO_THROW(request = exeNetwork.CreateInferRequest());
+        ASSERT_NO_THROW(request = exeNetwork->CreateInferRequest());
     }
 };
 

--- a/inference-engine/tests/unit/inference_engine/ie_executable_network_test.cpp
+++ b/inference-engine/tests/unit/inference_engine/ie_executable_network_test.cpp
@@ -8,12 +8,16 @@
 #include <vector>
 
 #include "cpp/ie_executable_network.hpp"
+#include "ie_iexecutable_network.hpp"
+#include "ie_plugin_cpp.hpp"
 
 #include "unit_test_utils/mocks/mock_iexecutable_network.hpp"
 #include "unit_test_utils/mocks/mock_iinfer_request.hpp"
 #include "unit_test_utils/mocks/mock_ie_ivariable_state.hpp"
 #include "unit_test_utils/mocks/cpp_interfaces/impl/mock_inference_plugin_internal.hpp"
 #include "unit_test_utils/mocks/cpp_interfaces/interface/mock_iexecutable_network_internal.hpp"
+#include "unit_test_utils/mocks/cpp_interfaces/interface/mock_ivariable_state_internal.hpp"
+#include "unit_test_utils/mocks/cpp_interfaces/interface/mock_iinference_plugin.hpp"
 
 using testing::_;
 using testing::Throw;
@@ -31,128 +35,91 @@ using testing::SetArgReferee;
 //  8. RemoteContext::Ptr GetContext()
 
 
-TEST(ExecutableNetworkConstructorTests, ThrowsIfConstructFromNullptr) {
-    // TODO issue: 26390; ExecutableNetwork's constructor shouldn't be available
-    EXPECT_NO_THROW(InferenceEngine::ExecutableNetwork exeNet{});
-
-    EXPECT_THROW(InferenceEngine::ExecutableNetwork exeNet{nullptr}, InferenceEngine::Exception);
-}
-
-TEST(ExecutableNetworkConstructorTests, CanConstruct) {
-    std::shared_ptr<MockIExecutableNetwork> mockIExeNet_p = std::make_shared<MockIExecutableNetwork>();
-    InferenceEngine::ExecutableNetwork exeNet{mockIExeNet_p};
-}
-
-TEST(ExecutableNetworkDestructorTests, Destruct) {
-    std::shared_ptr<MockIExecutableNetwork> mockIExeNet_p = std::make_shared<MockIExecutableNetwork>();
-    {
-        InferenceEngine::ExecutableNetwork exeNet{mockIExeNet_p};
-    }
-    // Call of destructor should decrease counter of shared_ptr
-    ASSERT_EQ(mockIExeNet_p.use_count(), 1);
-}
-
 class ExecutableNetworkTests : public ::testing::Test {
 protected:
-    std::shared_ptr<MockIExecutableNetwork> mockIExeNet_p;
-    std::unique_ptr<InferenceEngine::ExecutableNetwork> exeNetwork;
+    std::shared_ptr<MockIExecutableNetworkInternal> mockIExeNet;
+    InferenceEngine::ExecutableNetwork exeNetwork;
+
+    struct TestPluginInternal : public MockIInferencePlugin {
+        TestPluginInternal(const std::shared_ptr<MockIExecutableNetworkInternal>& mockIExeNet_) : mockIExeNet{mockIExeNet_} {}
+        std::shared_ptr<IExecutableNetworkInternal> LoadNetwork(const CNNNetwork&, const std::map<std::string, std::string>&) override {
+            return mockIExeNet;
+        }
+        QueryNetworkResult QueryNetwork(const CNNNetwork&, const std::map<std::string, std::string>&) const override {
+            IE_THROW(NotImplemented);
+        }
+        std::shared_ptr<MockIExecutableNetworkInternal> mockIExeNet;
+    };
+    struct TestPlugin : public InferenceEngine::InferencePlugin {
+        TestPlugin(std::shared_ptr<MockIExecutableNetworkInternal> mockIExeNet) :
+            InferenceEngine::InferencePlugin{InferenceEngine::details::SOPointer<TestPluginInternal>{
+                new TestPluginInternal{mockIExeNet}}} {}
+    };
 
     virtual void TearDown() {
-        mockIExeNet_p.reset();
-        exeNetwork.reset();
+        mockIExeNet.reset();
+        exeNetwork = {};
     }
 
     virtual void SetUp() {
-        mockIExeNet_p = std::make_shared<MockIExecutableNetwork>();
-        ASSERT_EQ(exeNetwork, nullptr);
-        exeNetwork = std::unique_ptr<InferenceEngine::ExecutableNetwork>(
-                new InferenceEngine::ExecutableNetwork(mockIExeNet_p));
-        ASSERT_NE(exeNetwork, nullptr);
+        mockIExeNet = std::make_shared<MockIExecutableNetworkInternal>();
+        exeNetwork = TestPlugin{mockIExeNet}.LoadNetwork({}, {});
     }
 };
 
 TEST_F(ExecutableNetworkTests, GetOutputsInfoThrowsIfReturnErr) {
-    EXPECT_CALL(*mockIExeNet_p.get(), GetOutputsInfo(_, _))
+    EXPECT_CALL(*mockIExeNet.get(), GetOutputsInfo())
             .Times(1)
-            .WillOnce(Return(InferenceEngine::GENERAL_ERROR));
+            .WillOnce(Throw(InferenceEngine::GeneralError{""}));
 
-    ASSERT_THROW(exeNetwork->GetOutputsInfo(), InferenceEngine::Exception);
+    ASSERT_THROW(exeNetwork.GetOutputsInfo(), InferenceEngine::Exception);
 }
 
 TEST_F(ExecutableNetworkTests, GetOutputsInfo) {
-    EXPECT_CALL(*mockIExeNet_p.get(), GetOutputsInfo(_, _))
-            .Times(1)
-            .WillOnce(Return(InferenceEngine::OK));
-
     InferenceEngine::ConstOutputsDataMap data;
-    ASSERT_NO_THROW(data = exeNetwork->GetOutputsInfo());
+    EXPECT_CALL(*mockIExeNet.get(), GetOutputsInfo()).Times(1).WillRepeatedly(Return(InferenceEngine::ConstOutputsDataMap{}));
+
+    ASSERT_NO_THROW(data = exeNetwork.GetOutputsInfo());
     ASSERT_EQ(data, InferenceEngine::ConstOutputsDataMap{});
 }
 
 TEST_F(ExecutableNetworkTests, GetInputsInfoThrowsIfReturnErr) {
-    EXPECT_CALL(*mockIExeNet_p.get(), GetInputsInfo(_, _))
+    EXPECT_CALL(*mockIExeNet.get(), GetInputsInfo())
             .Times(1)
-            .WillOnce(Return(InferenceEngine::GENERAL_ERROR));
+            .WillOnce(Throw(InferenceEngine::GeneralError{""}));
 
-    ASSERT_THROW(exeNetwork->GetInputsInfo(), InferenceEngine::Exception);
+    ASSERT_THROW(exeNetwork.GetInputsInfo(), InferenceEngine::Exception);
 }
 
 TEST_F(ExecutableNetworkTests, GetInputsInfo) {
-    EXPECT_CALL(*mockIExeNet_p.get(), GetInputsInfo(_, _))
-            .Times(1)
-            .WillOnce(Return(InferenceEngine::OK));
+    EXPECT_CALL(*mockIExeNet.get(), GetInputsInfo()).Times(1).WillRepeatedly(Return(InferenceEngine::ConstInputsDataMap{}));
 
     InferenceEngine::ConstInputsDataMap info;
-    ASSERT_NO_THROW(info = exeNetwork->GetInputsInfo());
+    ASSERT_NO_THROW(info = exeNetwork.GetInputsInfo());
     ASSERT_EQ(info, InferenceEngine::ConstInputsDataMap{});
 }
 
 
 TEST_F(ExecutableNetworkTests, resetThrowsIfResetToNullptr) {
-    InferenceEngine::IExecutableNetwork::Ptr mockIExeNet_p_2{};
-    ASSERT_THROW(exeNetwork->reset(mockIExeNet_p_2), InferenceEngine::Exception);
-}
-
-TEST_F(ExecutableNetworkTests, reset) {
-    InferenceEngine::IExecutableNetwork::Ptr mockIExeNet_p_2 = std::make_shared<MockIExecutableNetwork>();
-
-    exeNetwork->reset(mockIExeNet_p_2);
-
-    InferenceEngine::IExecutableNetwork::Ptr exeNet_p = *exeNetwork;   // use of IExecutableNetwork::Ptr&
-    EXPECT_NE(exeNet_p, mockIExeNet_p);
-    EXPECT_EQ(exeNet_p, mockIExeNet_p_2);
-}
-
-TEST_F(ExecutableNetworkTests, OperatorAmpersand) {
-    InferenceEngine::IExecutableNetwork::Ptr exeNet_p = *exeNetwork;   // use of IExecutableNetwork::Ptr&
-    ASSERT_EQ(exeNet_p, mockIExeNet_p);
+    InferenceEngine::IExecutableNetwork::Ptr mockIExeNet_2{};
+    ASSERT_THROW(exeNetwork.reset(mockIExeNet_2), InferenceEngine::Exception);
 }
 
 IE_SUPPRESS_DEPRECATED_START
 TEST_F(ExecutableNetworkTests, QueryStateThrowsIfReturnErr) {
-    EXPECT_CALL(*mockIExeNet_p.get(), QueryState(_, _, _))
+    EXPECT_CALL(*mockIExeNet.get(), QueryState())
             .Times(1)
-            .WillOnce(Return(InferenceEngine::GENERAL_ERROR));
-    EXPECT_THROW(exeNetwork->QueryState(), InferenceEngine::Exception);
-}
-
-TEST_F(ExecutableNetworkTests, QueryStateIfReturnOutOfBounds) {
-    EXPECT_CALL(*mockIExeNet_p.get(), QueryState(_, _, _))
-            .Times(1)
-            .WillOnce(Return(InferenceEngine::OUT_OF_BOUNDS));
-    std::vector<InferenceEngine::VariableState> MemState_;
-    EXPECT_NO_THROW(MemState_ = exeNetwork->QueryState());
-    EXPECT_EQ(MemState_.size(), 0);
+            .WillOnce(Throw(InferenceEngine::GeneralError{""}));
+    EXPECT_THROW(exeNetwork.QueryState(), InferenceEngine::Exception);
 }
 
 TEST_F(ExecutableNetworkTests, QueryState) {
-    std::shared_ptr<MockIVariableState> mockIMemState_p = std::make_shared<MockIVariableState>();
-    EXPECT_CALL(*mockIExeNet_p.get(), QueryState(_, _, _))
-            .Times(2)
-            .WillOnce(DoAll(SetArgReferee<0>(mockIMemState_p), Return(InferenceEngine::OK)))
-            .WillOnce(Return(InferenceEngine::OUT_OF_BOUNDS));
+    auto mockIMemState_p = std::make_shared<MockIVariableStateInternal>();
+    EXPECT_CALL(*mockIExeNet.get(), QueryState())
+            .Times(1)
+            .WillOnce(Return(std::vector<std::shared_ptr<InferenceEngine::IVariableStateInternal>>(1, mockIMemState_p)));
     std::vector<InferenceEngine::VariableState> MemState_v;
-    EXPECT_NO_THROW(MemState_v = exeNetwork->QueryState());
+    EXPECT_NO_THROW(MemState_v = exeNetwork.QueryState());
     EXPECT_EQ(MemState_v.size(), 1);
 }
 IE_SUPPRESS_DEPRECATED_END
@@ -173,42 +140,39 @@ protected:
 };
 
 TEST_F(ExecutableNetworkWithIInferReqTests, CanCreateInferRequest) {
-    EXPECT_CALL(*mockIExeNet_p.get(), CreateInferRequest(_, _))
-            .WillOnce(DoAll(SetArgReferee<0>(mockIInferReq_p), Return(InferenceEngine::OK)));
+    EXPECT_CALL(*mockIExeNet.get(), CreateInferRequest()).WillOnce(Return(mockIInferReq_p));
     InferRequest actualInferReq;
-    ASSERT_NO_THROW(actualInferReq = exeNetwork->CreateInferRequest());
+    ASSERT_NO_THROW(actualInferReq = exeNetwork.CreateInferRequest());
     ASSERT_EQ(mockIInferReq_p, static_cast<IInferRequest::Ptr &>(actualInferReq));
 }
 
 TEST_F(ExecutableNetworkWithIInferReqTests, CreateInferRequestThrowsIfReturnNotOK) {
-    EXPECT_CALL(*mockIExeNet_p.get(), CreateInferRequest(_, _)).WillOnce(Return(InferenceEngine::GENERAL_ERROR));
-    ASSERT_THROW(exeNetwork->CreateInferRequest(), InferenceEngine::Exception);
+    EXPECT_CALL(*mockIExeNet.get(), CreateInferRequest()).WillOnce(Throw(InferenceEngine::GeneralError{""}));
+    ASSERT_THROW(exeNetwork.CreateInferRequest(), InferenceEngine::Exception);
 }
 
 TEST_F(ExecutableNetworkWithIInferReqTests, CreateInferRequestThrowsIfSetRequestToNullptr) {
-    EXPECT_CALL(*mockIExeNet_p.get(), CreateInferRequest(_, _))
-            .WillOnce(DoAll(SetArgReferee<0>(nullptr), Return(InferenceEngine::OK)));
-    ASSERT_THROW(exeNetwork->CreateInferRequest(), InferenceEngine::Exception);
+    EXPECT_CALL(*mockIExeNet.get(), CreateInferRequest())
+            .WillOnce(Return(std::shared_ptr<MockIInferRequest>{}));
+    ASSERT_THROW(exeNetwork.CreateInferRequest(), InferenceEngine::Exception);
 }
 
 // CreateInferRequestPtr
 TEST_F(ExecutableNetworkWithIInferReqTests, CanCreateInferRequestPtr) {
-    EXPECT_CALL(*mockIExeNet_p.get(), CreateInferRequest(_, _))
-            .WillOnce(DoAll(SetArgReferee<0>(mockIInferReq_p), Return(InferenceEngine::OK)));
+    EXPECT_CALL(*mockIExeNet.get(), CreateInferRequest()).WillOnce(Return(mockIInferReq_p));
     InferRequest::Ptr actualInferReq;
-    ASSERT_NO_THROW(actualInferReq = exeNetwork->CreateInferRequestPtr());
+    ASSERT_NO_THROW(actualInferReq = exeNetwork.CreateInferRequestPtr());
     ASSERT_EQ(mockIInferReq_p, static_cast<IInferRequest::Ptr &>(*actualInferReq.get()));
 }
 
 TEST_F(ExecutableNetworkWithIInferReqTests, CreateInferRequestPtrThrowsIfReturnNotOK) {
-    EXPECT_CALL(*mockIExeNet_p.get(), CreateInferRequest(_, _)).WillOnce(Return(InferenceEngine::GENERAL_ERROR));
-    ASSERT_THROW(exeNetwork->CreateInferRequestPtr(), InferenceEngine::Exception);
+    EXPECT_CALL(*mockIExeNet.get(), CreateInferRequest()).WillOnce(Throw(InferenceEngine::GeneralError{""}));
+    ASSERT_THROW(exeNetwork.CreateInferRequestPtr(), InferenceEngine::Exception);
 }
 
 TEST_F(ExecutableNetworkWithIInferReqTests, CreateInferRequestPtrThrowsIfSetRequestToNullptr) {
-    EXPECT_CALL(*mockIExeNet_p.get(), CreateInferRequest(_, _))
-            .WillOnce(DoAll(SetArgReferee<0>(nullptr), Return(InferenceEngine::OK)));
-    ASSERT_THROW(exeNetwork->CreateInferRequestPtr(), InferenceEngine::Exception);
+    EXPECT_CALL(*mockIExeNet.get(), CreateInferRequest()).WillOnce(Return(std::shared_ptr<MockIInferRequest>{}));
+    ASSERT_THROW(exeNetwork.CreateInferRequestPtr(), InferenceEngine::Exception);
 }
 
 IE_SUPPRESS_DEPRECATED_START

--- a/inference-engine/tests_deprecated/behavior/vpu/myriad_tests/helpers/myriad_load_network_case.hpp
+++ b/inference-engine/tests_deprecated/behavior/vpu/myriad_tests/helpers/myriad_load_network_case.hpp
@@ -11,7 +11,7 @@
 #include <mvnc.h>
 
 using namespace InferenceEngine;
-using ExeNetworkPtr = InferenceEngine::IExecutableNetwork::Ptr;
+using ExeNetwork = InferenceEngine::ExecutableNetwork;
 
 //------------------------------------------------------------------------------
 // class MyriadLoadNetworkTestCase

--- a/inference-engine/tests_deprecated/behavior/vpu/myriad_tests/vpu_load_network_tests.cpp
+++ b/inference-engine/tests_deprecated/behavior/vpu/myriad_tests/vpu_load_network_tests.cpp
@@ -22,7 +22,7 @@ TEST_F(MyriadLoadNetworkTestCase, smoke_SimpleLoading) {
         {KEY_DEVICE_ID, device_to_load},
     };
 
-    ASSERT_NO_THROW(ExeNetworkPtr exe_network =
+    ASSERT_NO_THROW(ExeNetwork exe_network =
                         ie->LoadNetwork(cnnNetwork, "MYRIAD", config));
 
     ASSERT_TRUE(!IsDeviceAvailable(device_to_load));
@@ -37,12 +37,12 @@ TEST_F(MyriadLoadNetworkTestCase, smoke_LoadingAtTheSameDevice) {
         {KEY_DEVICE_ID, device_to_load},
     };
 
-    ASSERT_NO_THROW(ExeNetworkPtr exe_network =
+    ASSERT_NO_THROW(ExeNetwork exe_network =
                         ie->LoadNetwork(cnnNetwork, "MYRIAD", config));
 
     ASSERT_TRUE(!IsDeviceAvailable(device_to_load));
 
-    ASSERT_NO_THROW(ExeNetworkPtr exe_network =
+    ASSERT_NO_THROW(ExeNetwork exe_network =
                         ie->LoadNetwork(cnnNetwork, "MYRIAD", config));
 }
 
@@ -52,7 +52,7 @@ TEST_F(MyriadLoadNetworkTestCase, smoke_ThrowsExeptionWhenNameIsInvalid) {
         {KEY_DEVICE_ID, device_to_load},
     };
 
-    ASSERT_ANY_THROW(ExeNetworkPtr exe_network =
+    ASSERT_ANY_THROW(ExeNetwork exe_network =
         ie->LoadNetwork(cnnNetwork, "MYRIAD", config));
 }
 
@@ -76,6 +76,6 @@ TEST_F(MyriadLoadNetworkTestCase, smoke_ThrowsExeptionWhenPlatformConflictWithPr
         {KEY_VPU_MYRIAD_PLATFORM, wrong_platform},
     };
 
-    ASSERT_ANY_THROW(ExeNetworkPtr exe_network =
+    ASSERT_ANY_THROW(ExeNetwork exe_network =
         ie->LoadNetwork(cnnNetwork, "MYRIAD", config));
 }

--- a/inference-engine/tests_deprecated/functional/ie_tests/src/custom_matcher.cpp
+++ b/inference-engine/tests_deprecated/functional/ie_tests/src/custom_matcher.cpp
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 #include <ie_plugin_config.hpp>
 #include "custom_matcher.hpp"
+#include "ie_iexecutable_network.hpp"
 
 using namespace InferenceEngine;
 
@@ -103,7 +104,7 @@ void Regression::Matchers::CustomMatcher::matchCustom() {
             ASSERT_NO_FATAL_FAILURE(executableApi = createExecutableNetworkFromIR());
         }
 
-        if (executableApi.operator IExecutableNetwork::Ptr &() != nullptr) {
+        if (executableApi) {
             for (int i=0; i != config._nrequests; i++ ) {
                 inferRequests.push_back(executableApi.CreateInferRequest());
             }
@@ -116,7 +117,7 @@ void Regression::Matchers::CustomMatcher::matchCustom() {
         }
 
         auto make_unified_endpoints = [&] () {
-            if (executableApi.operator IExecutableNetwork::Ptr &() != nullptr) {
+            if (executableApi) {
                 return std::make_pair(executableApi.GetInputsInfo(), executableApi.GetOutputsInfo());
             }
             auto inputs2 = network.getInputsInfo();

--- a/inference-engine/tests_deprecated/unit/engines/mkldnn/graph/layers/internal/graph_leaks_test.cpp
+++ b/inference-engine/tests_deprecated/unit/engines/mkldnn/graph/layers/internal/graph_leaks_test.cpp
@@ -24,10 +24,8 @@ struct TestExecutableNetworkBase : public InferenceEngine::ExecutableNetworkBase
     using InferenceEngine::ExecutableNetworkBase::_impl;
 };
 
-static MKLDNNPlugin::MKLDNNGraph& getGraph(InferenceEngine::IExecutableNetwork::Ptr execNetwork) {
-    return reinterpret_cast<MKLDNNTestExecNetwork*>(
-        reinterpret_cast<TestExecutableNetworkBase*>(
-            execNetwork.get())->_impl.get())->getGraph();
+static MKLDNNPlugin::MKLDNNGraph& getGraph(InferenceEngine::IExecutableNetworkInternal::Ptr execNetwork) {
+    return static_cast<MKLDNNTestExecNetwork*>(execNetwork.get())->getGraph();
 }
 
 class MKLDNNGraphLeaksTests: public ::testing::Test {
@@ -253,7 +251,7 @@ TEST_F(MKLDNNGraphLeaksTests, MKLDNN_not_release_outputs_fp32) {
         ASSERT_NE(1, network.getOutputsInfo().size());
 
         std::shared_ptr<MKLDNNPlugin::Engine> score_engine(new MKLDNNPlugin::Engine());
-        InferenceEngine::ExecutableNetwork exeNetwork1;
+        InferenceEngine::IExecutableNetworkInternal::Ptr exeNetwork1;
         ASSERT_NO_THROW(exeNetwork1 = score_engine->LoadNetwork(network, {}));
 
         size_t modified_outputs_size = getGraph(exeNetwork1).GetOutputNodes().size();
@@ -262,7 +260,7 @@ TEST_F(MKLDNNGraphLeaksTests, MKLDNN_not_release_outputs_fp32) {
         ASSERT_NO_THROW(network2 = core.ReadNetwork(model, weights_ptr));
         ASSERT_EQ(1, network2.getOutputsInfo().size());
 
-        InferenceEngine::ExecutableNetwork exeNetwork2;
+        InferenceEngine::IExecutableNetworkInternal::Ptr exeNetwork2;
         ASSERT_NO_THROW(exeNetwork2 = score_engine->LoadNetwork(network2, {}));
 
         size_t original_outputs_size = getGraph(exeNetwork2).GetOutputNodes().size();

--- a/inference-engine/tools/vpu/vpu_perfcheck/main.cpp
+++ b/inference-engine/tools/vpu/vpu_perfcheck/main.cpp
@@ -381,7 +381,7 @@ int process(const std::string& modelFileName, const std::string& inputsDir,
         }
     }
 
-    std::vector<InferenceEngine::IExecutableNetwork::Ptr> exeNetwork(num_networks);
+    std::vector<InferenceEngine::ExecutableNetwork> exeNetwork(num_networks);
     std::map<std::string, std::string> networkConfig;
     setConfig(networkConfig, file_config_cl);
 
@@ -403,7 +403,7 @@ int process(const std::string& modelFileName, const std::string& inputsDir,
 
     for (int r = 0, idxPic = 0; r < num_requests; ++r) {
         int n = r % num_networks;
-        IECALL(exeNetwork[n]->CreateInferRequest(request[r], &resp));
+        request[r] = exeNetwork[n].CreateInferRequest();
 
         for (auto &input : networkInputs) {
             InferenceEngine::Blob::Ptr inputBlob;


### PR DESCRIPTION
* `nothrow` wrapper is replaced by direct usage of internal implementation
* Network creation functions do not use public API
