### PR TITLE
Speed up determined_sort which speeds up emitting the IR

### DIFF
--- a/model-optimizer/mo/pipeline/common.py
+++ b/model-optimizer/mo/pipeline/common.py
@@ -40,12 +40,11 @@ def determined_sort(outputs: list):
     stack = list(outputs)
     visited = set()
     while len(stack) != 0:
-        node = stack[0]
+        node = stack.pop(0)
         node_id = node.id
-        stack.pop(0)
         visited.add(node_id)
         has_child = False
-        in_names = [n.id if isinstance(node.in_nodes(), list) else node.in_node(n).id for n in node.in_nodes()]
+        in_names = [n for n, d in node.get_inputs()]
         for in_node_name in in_names:
             if in_node_name not in visited:
                 stack.insert(0, node)


### PR DESCRIPTION
Root cause analysis:
`determined_sort()` uses the `in_nodes()` method multiple times when it needs only ids of input nodes. For some models, which have nodes with a big number of inputs this leads to a huge slowdown during emitting IR.

Solution: 
Use `get_inputs()` method instead. This fixes time on one specific model from tens of minutes to seconds.

Ticket: 51796


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR: N/A no transformation changed
* [x]  Transformation preserves original framework node names: N/A no transformation changed


Validation:
* [x]  Unit tests: N/A
* [x]  Framework operation tests: N/A no new operation enabled
* [x]  Transformation tests: N/A no transformation changed
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list: N/A no new operation enabled
* [x]  Guide on how to convert the **public** model: N/A no new public model enabled
* [x]  User guide update: N/A no new public model enabled