### PR TITLE
Fix reading FP16 scalars from TensorFlow

### DIFF
--- a/model-optimizer/mo/front/tf/common.py
+++ b/model-optimizer/mo/front/tf/common.py
@@ -17,6 +17,8 @@
 import numpy as np
 from tensorflow.core.framework import types_pb2 as tf_types  # pylint: disable=no-name-in-module,import-error
 
+# Suppress false positive pylint warning about function with too many arguments
+# pylint: disable=E1121
 # mapping between TF data type and numpy data type and function to extract data from TF tensor
 _tf_np_mapping = [('DT_BOOL', np.bool, lambda pb: pb.bool_val, lambda x: bool_cast(x)),
                   ('DT_INT8', np.int8, lambda pb: pb.int_val, lambda x: np.int8(x)),
@@ -27,16 +29,16 @@ _tf_np_mapping = [('DT_BOOL', np.bool, lambda pb: pb.bool_val, lambda x: bool_ca
                   ('DT_UINT16', np.uint16, lambda pb: pb.int_val, lambda x: np.uint16(x)),
                   ('DT_UINT32', np.uint32, lambda pb: pb.uint32_val, lambda x: np.uint32(x)),
                   ('DT_UINT64', np.uint64, lambda pb: pb.uint64_val, lambda x: np.uint64(x)),
-                  ('DT_HALF', np.float16, lambda pb: pb.half_val, lambda x: np.float16(x)),
+                  ('DT_HALF', np.float16, lambda pb: np.uint16(pb.half_val).view(np.float16), lambda x: np.float16(x)),
                   ('DT_FLOAT', np.float32, lambda pb: pb.float_val, lambda x: np.float32(x)),
                   ('DT_DOUBLE', np.double, lambda pb: pb.double_val, lambda x: np.double(x)),
                   ('DT_STRING', np.str, lambda pb: pb.string_val, lambda x: np.str(x)),
                   ]
 
-tf_data_type_decode = {getattr(tf_types, tf_dt): (np_type, func) for tf_dt, np_type, func, cast in _tf_np_mapping if
+tf_data_type_decode = {getattr(tf_types, tf_dt): (np_type, func) for tf_dt, np_type, func, _ in _tf_np_mapping if
                        hasattr(tf_types, tf_dt)}
 
-tf_data_type_cast = {np_type: cast for tf_dt, np_type, func, cast in _tf_np_mapping if hasattr(tf_types, tf_dt)}
+tf_data_type_cast = {np_type: cast for tf_dt, np_type, _, cast in _tf_np_mapping if hasattr(tf_types, tf_dt)}
 
 
 def bool_cast(x):


### PR DESCRIPTION
Root cause analysis:
Tensorflow stores FP16 scalars as uint16 in protobuf. It is similar to ONNX.

Solution: 
Read FP16 scalars as uint16 and reinterpret as FP16.

Ticket: 51731


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR: N/A no transformation changed
* [x]  Transformation preserves original framework node names: N/A no transformation changed


Validation:
* [x]  Unit tests: N/A
* [x]  Framework operation tests: N/A no new operation enabled
* [x]  Transformation tests: N/A no transformation changed
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list: N/A no new operation enabled
* [x]  Guide on how to convert the **public** model: N/A no new public model enabled
* [x]  User guide update: N/A no new public model enabled