### PR TITLE
Fixed pyngraph compilation with python 3.9.2

### DIFF
--- a/ngraph/python/CMakeLists.txt
+++ b/ngraph/python/CMakeLists.txt
@@ -78,6 +78,11 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_compile_options(-Wno-error=attributes)
 endif()
 
+if(CMAKE_COMPILER_IS_GNUCXX AND Python_VERSION VERSION_GREATER_EQUAL "3.9")
+    # for proper fix need to update pybind to version which does not use PyEval_InitThreads()
+    add_compile_options(-Wno-deprecated-declarations)
+endif()
+
 # create target
 
 file(GLOB_RECURSE SOURCES src/pyngraph/*.cpp)


### PR DESCRIPTION
Such errors are deprecated as from 3rd party project
```
/home/sandye51/Documents/Programming/builds/dldt-release-gcc9/_deps/pybind11-src/include/pybind11/detail/internals.h:276:28: error: ‘void PyEval_InitThreads()’ is deprecated [-Werror=deprecated-declarations]
  276 |         PyEval_InitThreads();
      |                            ^
In file included from /usr/include/python3.9/Python.h:145,
                 from /home/sandye51/Documents/Programming/builds/dldt-release-gcc9/_deps/pybind11-src/include/pybind11/detail/common.h:112,
                 from /home/sandye51/Documents/Programming/builds/dldt-release-gcc9/_deps/pybind11-src/include/pybind11/buffer_info.h:12,
                 from /home/sandye51/Documents/Programming/git_repo/dldt/ngraph/python/src/pyngraph/ops/constant.cpp:17:
/usr/include/python3.9/ceval.h:130:79: note: declared here
  130 | Py_DEPRECATED(3.9) PyAPI_FUNC(void) PyEval_InitThreads(void);
```
