### PR TITLE
Enable bf16 RNN primitives

### DIFF
--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_rnn.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_rnn.cpp
@@ -464,10 +464,10 @@ void MKLDNNRNN::verifyWeights() {
         THROW_ERROR << "Missed weights blob.";
 
     const auto& weightsPrec = weightsIt->second->getTensorDesc().getPrecision();
-    const auto& layerPrec = layer->outData[0]->getPrecision();
-    if (!verifyWeightsPrecision(layerPrec, weightsPrec)) {
+
+    if (!verifyWeightsPrecision(runtimePrecision, weightsPrec)) {
         THROW_ERROR << "Weights precision " << weightsPrec <<
-            " does not match layer precision" << layerPrec;
+            " does not match runtime precision" << runtimePrecision;
     }
 }
 

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_rnn.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_rnn.cpp
@@ -160,20 +160,6 @@ void MKLDNNRNN::fillCellDesc() {
 
     auto runtimePrecision = outs[0]->getPrecision();
 
-    // set recurent input data type
-    if (ins.size() > 1)
-        ins[1].lock()->setPrecision(runtimePrecision);
-    if (outs.size() > 1)
-        outs[1]->setPrecision(runtimePrecision);
-
-    // set cell datatype
-    if (cell_type == mkldnn::algorithm::vanilla_lstm) {
-        if (ins.size() == 3)
-            ins[2].lock()->setPrecision(Precision::FP32);
-        if (outs.size() == 3)
-            outs[2]->setPrecision(Precision::FP32);
-    }
-
     auto dataType = MKLDNNExtensionUtils::IEPrecisionToDataType(runtimePrecision);
 
     in_states_d.resize(S);
@@ -293,22 +279,7 @@ void MKLDNNRNN::fillSeqDesc() {
     in_states_d.resize(S);
     out_states_d.resize(S);
 
-    // auto cnnLayer = getCnnLayer();
     auto runtimePrecision = outs[0]->getPrecision();
-
-    // set recurent input data type
-    if (ins.size() > 1)
-        ins[1].lock()->setPrecision(runtimePrecision);
-    if (outs.size() > 1)
-        outs[1]->setPrecision(runtimePrecision);
-
-    // set cell datatype
-    if (cell_type == mkldnn::algorithm::vanilla_lstm) {
-        if (ins.size() == 3)
-            ins[2].lock()->setPrecision(Precision::FP32);
-        if (outs.size() == 3)
-            outs[2]->setPrecision(Precision::FP32);
-    }
 
     auto dataType = MKLDNNExtensionUtils::IEPrecisionToDataType(runtimePrecision);
 

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_rnn.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_rnn.cpp
@@ -170,7 +170,7 @@ void MKLDNNRNN::fillCellDesc() {
     if (bias && bias->size() != Gb * SC)
         IE_THROW() << "RNN Layer. Biases size is not correct. Expected size:" << G * SC;
 
-    auto runtimePrecision = outs[0]->getPrecision();
+    auto runtimePrecision = ins[0].lock()->getPrecision();
 
     auto dataType = MKLDNNExtensionUtils::IEPrecisionToDataType(runtimePrecision);
 

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_rnn.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_rnn.cpp
@@ -483,17 +483,7 @@ void MKLDNNRNN::createPrimitive() {
     verifyWeights();
     verifyBiases();
 
-    {
-        /**
-         * IE format:
-         *   W - [gates, out_state_size, in_data_size + in_state_size]
-         *   B - [gates, out_state_size]
-         *
-         * MKLDNN format:
-         *   W - [1, 1, in_date_size,  gates, out_state_size]
-         *   R - [1, 1, in_state_size, gates, out_state_size]
-         *   B - [gates, out_state_size]
-         *
+    {   /*
          *   Gate order
          *   ====== LSTM ======
          *   Caffe - IFOC, ONNX   - IOFC
@@ -554,6 +544,14 @@ void MKLDNNRNN::createPrimitive() {
     prim.reset(new mkldnn::primitive(pd));
 }
 
+/*
+ * IE format:
+ *   B - [gates, out_state_size]
+ *
+ * MKLDNN format:
+ *   B - [gates, out_state_size]
+ *
+ */
 template <typename Prec>
 void MKLDNNRNN::fillBiases(const int *gate_map) {
     if (!w_bias_d)
@@ -572,6 +570,15 @@ void MKLDNNRNN::fillBiases(const int *gate_map) {
     }
 }
 
+/*
+ * IE format:
+ *   W - [gates, out_state_size, in_data_size + in_state_size]
+ *
+ * MKLDNN format:
+ *   W - [1, 1, in_date_size,  gates, out_state_size]
+ *   R - [1, 1, in_state_size, gates, out_state_size]
+ *
+ */
 template <typename Prec>
 void MKLDNNRNN::fillWeights(const int *gate_map) {
     // create weight blobs (data and state part)

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_rnn.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_rnn.cpp
@@ -75,6 +75,14 @@ bool haveCellState(algorithm alg) {
     return alg == algorithm::vanilla_lstm;
 }
 
+const std::map<InferenceEngine::Precision, InferenceEngine::Precision> MKLDNNRNN::weightsByLayerPrec {
+    // layer precision, weights precision
+    {InferenceEngine::Precision::FP32, InferenceEngine::Precision::FP32},
+    {InferenceEngine::Precision::BF16, InferenceEngine::Precision::BF16},
+    {InferenceEngine::Precision::FP16, InferenceEngine::Precision::FP16},
+    {InferenceEngine::Precision::U8,   InferenceEngine::Precision::I8},
+};
+
 MKLDNNRNN::MKLDNNRNN(const InferenceEngine::CNNLayerPtr& layer, const mkldnn::engine& eng, MKLDNNWeightsSharing::Ptr &cache) :
         MKLDNNNode(layer, eng, cache) {
     is_cell = one_of(layer->type, "LSTMCell", "GRUCell", "RNNCell");
@@ -476,7 +484,7 @@ void MKLDNNRNN::createPrimitive() {
     verifyBiases();
 
     {
-        /* Copy Weight data
+        /**
          * IE format:
          *   W - [gates, out_state_size, in_data_size + in_state_size]
          *   B - [gates, out_state_size]

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_rnn.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_rnn.h
@@ -66,11 +66,14 @@ private:
     const ptrdiff_t L = 1;   /**< What is it??. Constant for mkldnn impl */
     const ptrdiff_t D = 1;   /**< Num of direction. 1 or 2 */
 
-    MKLDNNMemoryDesc in_data_d;
-    MKLDNNMemoryDesc out_data_d;
+    std::vector<MKLDNNMemoryDesc> in_data_d;
+    std::vector<MKLDNNMemoryDesc> out_data_d;
 
-    std::vector<MKLDNNMemoryDesc> in_states_d;
-    std::vector<MKLDNNMemoryDesc> out_states_d;
+    enum RNNInOutKind {
+        Layer       = 0,
+        HiddenState = 1,
+        CellState   = 2
+    };
 
     MKLDNNMemoryDesc w_data_d;
     MKLDNNMemoryDesc w_state_d;
@@ -80,14 +83,14 @@ private:
     std::vector<mkldnn::reorder> exec_before;
     std::vector<mkldnn::reorder> exec_after;
 
-    std::map<InferenceEngine::Precision, InferenceEngine::Precision> weightsByLayerPrec {
-        // layer precision, weights precision
-        {InferenceEngine::Precision::FP32, InferenceEngine::Precision::FP32},
-        {InferenceEngine::Precision::BF16, InferenceEngine::Precision::BF16},
-        {InferenceEngine::Precision::FP16, InferenceEngine::Precision::FP16},
-        {InferenceEngine::Precision::U8,   InferenceEngine::Precision::I8},
-    };
+    static const std::map<InferenceEngine::Precision, InferenceEngine::Precision> weightsByLayerPrec;
+}; // class MKLDNNRNN
+
+const std::map<InferenceEngine::Precision, InferenceEngine::Precision> MKLDNNRNN::weightsByLayerPrec {
+    // layer precision, weights precision
+    {InferenceEngine::Precision::FP32, InferenceEngine::Precision::FP32},
+    {InferenceEngine::Precision::BF16, InferenceEngine::Precision::BF16},
+    {InferenceEngine::Precision::FP16, InferenceEngine::Precision::FP16},
+    {InferenceEngine::Precision::U8,   InferenceEngine::Precision::I8},
 };
-
 }  // namespace MKLDNNPlugin
-

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_rnn.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_rnn.h
@@ -28,6 +28,16 @@ public:
 private:
     void fillCellDesc();
     void fillSeqDesc();
+    bool verifyWeightsPrecision(const InferenceEngine::Precision& layerPrec,
+                                const InferenceEngine::Precision& weightsPrec);
+    void verifyWeights();
+    void verifyBiases();
+    void convertWeightsBlobPrecision(const InferenceEngine::Precision cur_precision,
+                                     const InferenceEngine::Precision new_precision);
+    template <typename Prec>
+    void fillWeights(const int* gate_map);
+    template <typename Prec>
+    void fillBiases(const int* gate_map);
 
 private:
     /** Specify mode Cell or Seq. true - Cell, false - Seq */
@@ -69,6 +79,14 @@ private:
     // List of in/out reorders if required
     std::vector<mkldnn::reorder> exec_before;
     std::vector<mkldnn::reorder> exec_after;
+
+    std::map<InferenceEngine::Precision, InferenceEngine::Precision> weightsByLayerPrec {
+        // layer precision, weights precision
+        {InferenceEngine::Precision::FP32, InferenceEngine::Precision::FP32},
+        {InferenceEngine::Precision::BF16, InferenceEngine::Precision::BF16},
+        {InferenceEngine::Precision::FP16, InferenceEngine::Precision::FP16},
+        {InferenceEngine::Precision::U8,   InferenceEngine::Precision::I8},
+    };
 };
 
 }  // namespace MKLDNNPlugin

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_rnn.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_rnn.h
@@ -85,12 +85,4 @@ private:
 
     static const std::map<InferenceEngine::Precision, InferenceEngine::Precision> weightsByLayerPrec;
 }; // class MKLDNNRNN
-
-const std::map<InferenceEngine::Precision, InferenceEngine::Precision> MKLDNNRNN::weightsByLayerPrec {
-    // layer precision, weights precision
-    {InferenceEngine::Precision::FP32, InferenceEngine::Precision::FP32},
-    {InferenceEngine::Precision::BF16, InferenceEngine::Precision::BF16},
-    {InferenceEngine::Precision::FP16, InferenceEngine::Precision::FP16},
-    {InferenceEngine::Precision::U8,   InferenceEngine::Precision::I8},
-};
 }  // namespace MKLDNNPlugin

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_rnn.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_rnn.h
@@ -32,14 +32,15 @@ private:
                                 const InferenceEngine::Precision& weightsPrec);
     void verifyWeights();
     void verifyBiases();
-    void convertWeightsBlobPrecision(const InferenceEngine::Precision cur_precision,
-                                     const InferenceEngine::Precision new_precision);
+    void convertWeightsBlobToBF16();
+
     template <typename Prec>
     void fillWeights(const int* gate_map);
     template <typename Prec>
     void fillBiases(const int* gate_map);
 
 private:
+    InferenceEngine::Precision runtimePrecision;
     /** Specify mode Cell or Seq. true - Cell, false - Seq */
     bool is_cell = false;
 

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/gru_cell.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/gru_cell.cpp
@@ -72,8 +72,7 @@ protected:
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
         if (additionalConfig[PluginConfigParams::KEY_ENFORCE_BF16] == PluginConfigParams::YES) {
-            inPrc  = netPrecision;
-            outPrc = Precision::BF16;
+            inPrc = outPrc = Precision::BF16;
         } else {
             inPrc = outPrc = netPrecision;
         }
@@ -81,7 +80,7 @@ protected:
         selectedType += "_";
         selectedType += outPrc.name();
 
-        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(Precision::FP32);
         auto params = ngraph::builder::makeParams(ngPrc, {inputShapes[0], inputShapes[1]});
         std::vector<ngraph::Shape> WRB = {inputShapes[2], inputShapes[3], inputShapes[4]};
         auto gru_cell = ngraph::builder::makeGRU(
@@ -105,7 +104,7 @@ std::vector<std::map<std::string, std::string>> additionalConfig
     = {{{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::NO}},
        {{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES}}};
 
-std::vector<CPUSpecificParams> cpuParams = {{{nc, nc}, {nc}, {"ref_any"}, "ref_any"}};
+CPUSpecificParams cpuParams{{nc, nc}, {nc}, {"ref_any"}, "ref_any"};
 
 std::vector<bool> should_decompose{false};
 std::vector<size_t> batch{1, 5};
@@ -129,7 +128,7 @@ INSTANTIATE_TEST_CASE_P(smoke_GRUCellCPU,
                                                               ::testing::ValuesIn(linear_before_reset),
                                                               ::testing::ValuesIn(netPrecisions),
                                                               ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                           ::testing::ValuesIn(cpuParams),
+                                           ::testing::Values(cpuParams),
                                            ::testing::ValuesIn(additionalConfig)),
                         GRUCellCPUTest::getTestCaseName);
 } // namespace

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/gru_cell.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/gru_cell.cpp
@@ -1,0 +1,129 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "ngraph/op/gru_cell.hpp"
+#include <shared_test_classes/single_layer/gru_cell.hpp>
+#include "test_utils/cpu_test_utils.hpp"
+#include "transformations/op_conversions/gru_cell_decomposition.hpp"
+
+using namespace InferenceEngine;
+using namespace CPUTestUtils;
+
+namespace CPULayerTestsDefinitions {
+
+using GRUCellCpuSpecificParams = typename std::tuple<LayerTestsDefinitions::GRUCellParams, CPUSpecificParams, std::map<std::string, std::string>>;
+
+class GRUCellCPUTest : public testing::WithParamInterface<GRUCellCpuSpecificParams>,
+                            virtual public LayerTestsUtils::LayerTestsCommon,
+                            public CPUTestsBase {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<GRUCellCpuSpecificParams> &obj) {
+        CPUSpecificParams cpuParams;
+        LayerTestsDefinitions::GRUCellParams basicParamsSet;
+        std::map<std::string, std::string> enforceBF16;
+
+        std::tie(basicParamsSet, cpuParams, enforceBF16) = obj.param;
+
+        std::ostringstream result;
+        result << LayerTestsDefinitions::GRUCellTest::getTestCaseName(
+            testing::TestParamInfo<LayerTestsDefinitions::GRUCellParams>(basicParamsSet, 0));
+        result << CPUTestsBase::getTestCaseName(cpuParams);
+
+        if (!enforceBF16.empty()) {
+            result << "_PluginConf";
+            for (auto &item : enforceBF16) {
+                if (item.second == PluginConfigParams::YES)
+                    result << "_" << item.first << "=" << item.second;
+            }
+        }
+        return result.str();
+    }
+
+protected:
+    void SetUp() {
+        CPUSpecificParams cpuParams;
+        LayerTestsDefinitions::GRUCellParams basicParamsSet;
+        std::map<std::string, std::string> enforceBF16;
+
+        bool should_decompose;
+        size_t batch;
+        size_t hidden_size;
+        size_t input_size;
+        std::vector<std::string> activations;
+        std::vector<float> activations_alpha;
+        std::vector<float> activations_beta;
+        float clip;
+        bool linear_before_reset;
+        InferenceEngine::Precision netPrecision;
+
+        std::tie(basicParamsSet, cpuParams, enforceBF16) = this->GetParam();
+        std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
+        std::tie(should_decompose, batch, hidden_size, input_size, activations, clip, linear_before_reset, netPrecision, targetDevice) = basicParamsSet;
+
+        std::vector<std::vector<size_t>> inputShapes = {
+            {{batch, input_size},
+             {batch, hidden_size},
+             {3 * hidden_size, input_size},
+             {3 * hidden_size, hidden_size},
+             {(linear_before_reset ? 4 : 3) * hidden_size}},
+        };
+
+        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+        auto params = ngraph::builder::makeParams(ngPrc, {inputShapes[0], inputShapes[1]});
+        std::vector<ngraph::Shape> WRB = {inputShapes[2], inputShapes[3], inputShapes[4]};
+        auto gru_cell = ngraph::builder::makeGRU(
+            ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes(params)), WRB, hidden_size, activations, {}, {}, clip, linear_before_reset);
+        ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(gru_cell->output(0))};
+        function = std::make_shared<ngraph::Function>(results, params, "gru_cell");
+        if (should_decompose) {
+            ngraph::pass::Manager m;
+            m.register_pass<ngraph::pass::GRUCellDecomposition>();
+            m.run_passes(function);
+        }
+    }
+};
+
+TEST_P(GRUCellCPUTest, CompareWithRefs) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    Run();
+    CheckPluginRelatedResults(executableNetwork, "RNNCell");
+}
+
+namespace {
+/* CPU PARAMS */
+std::vector<std::map<std::string, std::string>> bf16EnforceFlags
+    = {{{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::NO}}, {{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES}}};
+
+std::vector<CPUSpecificParams> filterCPUInfoForDevice() {
+    return {CPUSpecificParams{{nc, nc}, {nc}, {"ref_any"}, "ref_any_FP32"}};
+}
+
+std::vector<bool> should_decompose{false};
+std::vector<size_t> batch{1, 5};
+std::vector<size_t> hidden_size{1, 10};
+std::vector<size_t> input_size{1, 30};
+// oneDNN supports only sigmoid-tanh
+std::vector<std::vector<std::string>> activations = {{"sigmoid", "tanh"}};
+// oneDNN supports only zero clip
+std::vector<float> clip = {0.f};
+std::vector<bool> linear_before_reset = {true, false};
+std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP32, InferenceEngine::Precision::FP16};
+
+INSTANTIATE_TEST_CASE_P(smoke_GRUCellCPU,
+                        GRUCellCPUTest,
+                        ::testing::Combine(::testing::Combine(::testing::ValuesIn(should_decompose),
+                                                              ::testing::ValuesIn(batch),
+                                                              ::testing::ValuesIn(hidden_size),
+                                                              ::testing::ValuesIn(input_size),
+                                                              ::testing::ValuesIn(activations),
+                                                              ::testing::ValuesIn(clip),
+                                                              ::testing::ValuesIn(linear_before_reset),
+                                                              ::testing::ValuesIn(netPrecisions),
+                                                              ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                                           ::testing::ValuesIn(filterCPUInfoForDevice()),
+                                           ::testing::ValuesIn(bf16EnforceFlags)),
+                        GRUCellCPUTest::getTestCaseName);
+} // namespace
+} // namespace CPULayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/gru_cell.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/gru_cell.cpp
@@ -106,9 +106,7 @@ std::vector<std::map<std::string, std::string>> bf16EnforceFlags
        {{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES}}
 };
 
-std::vector<CPUSpecificParams> filterCPUInfoForDevice() {
-    return {CPUSpecificParams{{nc, nc}, {nc}, {"ref_any"}, "ref_any"}};
-}
+std::vector<CPUSpecificParams> cpuParams = {{{nc, nc}, {nc}, {"ref_any"}, "ref_any"}};
 
 std::vector<bool> should_decompose{false};
 std::vector<size_t> batch{1, 5};
@@ -132,7 +130,7 @@ INSTANTIATE_TEST_CASE_P(smoke_GRUCellCPU,
                                                               ::testing::ValuesIn(linear_before_reset),
                                                               ::testing::ValuesIn(netPrecisions),
                                                               ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                           ::testing::ValuesIn(filterCPUInfoForDevice()),
+                                           ::testing::ValuesIn(cpuParams),
                                            ::testing::ValuesIn(bf16EnforceFlags)),
                         GRUCellCPUTest::getTestCaseName);
 } // namespace

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/gru_sequence.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/gru_sequence.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/gru_sequence.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/gru_sequence.cpp
@@ -75,8 +75,7 @@ protected:
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
         if (additionalConfig[PluginConfigParams::KEY_ENFORCE_BF16] == PluginConfigParams::YES) {
-            inPrc  = netPrecision;
-            outPrc = Precision::BF16;
+            inPrc = outPrc = Precision::BF16;
         } else {
             inPrc = outPrc = netPrecision;
         }
@@ -85,7 +84,7 @@ protected:
         selectedType += outPrc.name();
 
         m_max_seq_len = seq_lenghts;
-        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(Precision::FP32);
         auto params = ngraph::builder::makeParams(ngPrc, {inputShapes[0], inputShapes[1]});
         if (m_mode == ngraph::helpers::SequenceTestsMode::CONVERT_TO_TI_MAX_SEQ_LEN_PARAM
             || m_mode == ngraph::helpers::SequenceTestsMode::CONVERT_TO_TI_RAND_SEQ_LEN_PARAM) {
@@ -152,8 +151,8 @@ namespace {
 std::vector<std::map<std::string, std::string>> additionalConfig
     = {{{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::NO}}, {{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES}}};
 
-std::vector<CPUSpecificParams> cpuParams = {{{ntc, nc}, {ntc, nc}, {"ref_any"}, "ref_any"}};
-std::vector<CPUSpecificParams> cpuParamsBatchSizeOne = {{{tnc, nc}, {tnc, nc}, {"ref_any"}, "ref_any"}};
+CPUSpecificParams cpuParams{{ntc, nc}, {ntc, nc}, {"ref_any"}, "ref_any"};
+CPUSpecificParams cpuParamsBatchSizeOne{{tnc, nc}, {tnc, nc}, {"ref_any"}, "ref_any"};;
 
 std::vector<ngraph::helpers::SequenceTestsMode> mode{ngraph::helpers::SequenceTestsMode::PURE_SEQ};
 // output values increase rapidly without clip, so use only seq_lenghts = 2
@@ -180,7 +179,7 @@ INSTANTIATE_TEST_CASE_P(smoke_GRUSequenceCPU,
                                                               ::testing::ValuesIn(direction),
                                                               ::testing::ValuesIn(netPrecisions),
                                                               ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                           ::testing::ValuesIn(cpuParams),
+                                           ::testing::Values(cpuParams),
                                            ::testing::ValuesIn(additionalConfig)),
                         GRUSequenceCPUTest::getTestCaseName);
 
@@ -196,7 +195,7 @@ INSTANTIATE_TEST_CASE_P(smoke_GRUSequenceCPUBatchSizeOne,
                                                               ::testing::ValuesIn(direction),
                                                               ::testing::ValuesIn(netPrecisions),
                                                               ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                           ::testing::ValuesIn(cpuParamsBatchSizeOne),
+                                           ::testing::Values(cpuParamsBatchSizeOne),
                                            ::testing::ValuesIn(additionalConfig)),
                         GRUSequenceCPUTest::getTestCaseName);
 } // namespace

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/gru_sequence.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/gru_sequence.cpp
@@ -71,6 +71,19 @@ protected:
              {num_directions, 3 * hidden_size, hidden_size},
              {num_directions, (linear_before_reset ? 4 : 3) * hidden_size}},
         };
+
+        configuration.insert(enforceBF16.begin(), enforceBF16.end());
+
+        if (enforceBF16[PluginConfigParams::KEY_ENFORCE_BF16] == PluginConfigParams::YES) {
+            inPrc  = netPrecision;
+            outPrc = Precision::BF16;
+        } else {
+            inPrc = outPrc = netPrecision;
+        }
+
+        selectedType += "_";
+        selectedType += outPrc.name();
+
         m_max_seq_len = seq_lenghts;
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         auto params = ngraph::builder::makeParams(ngPrc, {inputShapes[0], inputShapes[1]});
@@ -94,7 +107,9 @@ protected:
                                                      m_mode);
         ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(gru_sequence->output(0)),
                                      std::make_shared<ngraph::opset1::Result>(gru_sequence->output(1))};
-        function = std::make_shared<ngraph::Function>(results, params, "gru_sequence");
+
+        function = makeNgraphFunction(ngPrc, params, gru_sequence, "gru_sequence");
+
         if (m_mode != ngraph::helpers::SequenceTestsMode::PURE_SEQ) {
             ngraph::pass::Manager manager;
             if (direction == ngraph::op::RecurrentSequenceDirection::BIDIRECTIONAL)
@@ -138,10 +153,10 @@ std::vector<std::map<std::string, std::string>> bf16EnforceFlags
     = {{{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::NO}}, {{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES}}};
 
 std::vector<CPUSpecificParams> filterCPUInfoForDevice() {
-    return {CPUSpecificParams{{ntc, nc}, {ntc, nc}, {"ref_any"}, "ref_any_FP32"}};
+    return {CPUSpecificParams{{ntc, nc}, {ntc, nc}, {"ref_any"}, "ref_any"}};
 }
 std::vector<CPUSpecificParams> filterCPUInfoForDeviceBatchSizeOne() {
-    return {CPUSpecificParams{{tnc, nc}, {tnc, nc}, {"ref_any"}, "ref_any_FP32"}};
+    return {CPUSpecificParams{{tnc, nc}, {tnc, nc}, {"ref_any"}, "ref_any"}};
 }
 
 std::vector<ngraph::helpers::SequenceTestsMode> mode{ngraph::helpers::SequenceTestsMode::PURE_SEQ};
@@ -155,7 +170,7 @@ std::vector<bool> linear_before_reset = {true, false};
 std::vector<float> clip{0.f};
 std::vector<ngraph::op::RecurrentSequenceDirection> direction = {ngraph::op::RecurrentSequenceDirection::FORWARD};
 
-std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP32, InferenceEngine::Precision::FP16};
+std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP32};
 
 INSTANTIATE_TEST_CASE_P(smoke_GRUSequenceCPU,
                         GRUSequenceCPUTest,

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/gru_sequence.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/gru_sequence.cpp
@@ -1,0 +1,192 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/single_layer/gru_sequence.hpp"
+#include "ngraph/pass/visualize_tree.hpp"
+#include "test_utils/cpu_test_utils.hpp"
+#include "transformations/op_conversions/bidirectional_sequences_decomposition.hpp"
+#include "transformations/op_conversions/convert_sequences_to_tensor_iterator.hpp"
+
+using namespace InferenceEngine;
+using namespace CPUTestUtils;
+
+namespace CPULayerTestsDefinitions {
+
+using GRUSequenceCpuSpecificParams = typename std::tuple<LayerTestsDefinitions::GRUSequenceParams, CPUSpecificParams, std::map<std::string, std::string>>;
+
+class GRUSequenceCPUTest : public testing::WithParamInterface<GRUSequenceCpuSpecificParams>,
+                           virtual public LayerTestsUtils::LayerTestsCommon,
+                           public CPUTestsBase {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<GRUSequenceCpuSpecificParams> &obj) {
+        CPUSpecificParams cpuParams;
+        LayerTestsDefinitions::GRUSequenceParams basicParamsSet;
+        std::map<std::string, std::string> enforceBF16;
+
+        std::tie(basicParamsSet, cpuParams, enforceBF16) = obj.param;
+        std::ostringstream result;
+
+        result << LayerTestsDefinitions::GRUSequenceTest::getTestCaseName(testing::TestParamInfo<LayerTestsDefinitions::GRUSequenceParams>(basicParamsSet, 0));
+        result << CPUTestsBase::getTestCaseName(cpuParams);
+
+        if (!enforceBF16.empty()) {
+            result << "_PluginConf";
+            for (auto &item : enforceBF16) {
+                if (item.second == PluginConfigParams::YES)
+                    result << "_" << item.first << "=" << item.second;
+            }
+        }
+        return result.str();
+    }
+
+protected:
+    void SetUp() {
+        LayerTestsDefinitions::GRUSequenceParams basicParamsSet;
+        CPUSpecificParams cpuParams;
+        std::map<std::string, std::string> enforceBF16;
+
+        size_t seq_lenghts;
+        size_t batch;
+        size_t hidden_size;
+        size_t input_size = 10;
+        std::vector<std::string> activations;
+        std::vector<float> activations_alpha;
+        std::vector<float> activations_beta;
+        float clip;
+        bool linear_before_reset;
+        ngraph::op::RecurrentSequenceDirection direction;
+        InferenceEngine::Precision netPrecision;
+
+        std::tie(basicParamsSet, cpuParams, enforceBF16) = this->GetParam();
+        std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
+        std::tie(m_mode, seq_lenghts, batch, hidden_size, activations, clip, linear_before_reset, direction, netPrecision, targetDevice) = basicParamsSet;
+
+        size_t num_directions = direction == ngraph::op::RecurrentSequenceDirection::BIDIRECTIONAL ? 2 : 1;
+        std::vector<std::vector<size_t>> inputShapes = {
+            {{batch, seq_lenghts, input_size},
+             {batch, num_directions, hidden_size},
+             {batch},
+             {num_directions, 3 * hidden_size, input_size},
+             {num_directions, 3 * hidden_size, hidden_size},
+             {num_directions, (linear_before_reset ? 4 : 3) * hidden_size}},
+        };
+        m_max_seq_len = seq_lenghts;
+        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+        auto params = ngraph::builder::makeParams(ngPrc, {inputShapes[0], inputShapes[1]});
+        if (m_mode == ngraph::helpers::SequenceTestsMode::CONVERT_TO_TI_MAX_SEQ_LEN_PARAM
+            || m_mode == ngraph::helpers::SequenceTestsMode::CONVERT_TO_TI_RAND_SEQ_LEN_PARAM) {
+            auto seq_lengths = ngraph::builder::makeParams(ngraph::element::i64, {inputShapes[2]}).at(0);
+            seq_lengths->set_friendly_name("seq_lengths");
+            params.push_back(seq_lengths);
+        }
+        std::vector<ngraph::Shape> WRB = {inputShapes[3], inputShapes[4], inputShapes[5], inputShapes[2]};
+        auto gru_sequence = ngraph::builder::makeGRU(ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes(params)),
+                                                     WRB,
+                                                     hidden_size,
+                                                     activations,
+                                                     {},
+                                                     {},
+                                                     clip,
+                                                     linear_before_reset,
+                                                     true,
+                                                     direction,
+                                                     m_mode);
+        ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(gru_sequence->output(0)),
+                                     std::make_shared<ngraph::opset1::Result>(gru_sequence->output(1))};
+        function = std::make_shared<ngraph::Function>(results, params, "gru_sequence");
+        if (m_mode != ngraph::helpers::SequenceTestsMode::PURE_SEQ) {
+            ngraph::pass::Manager manager;
+            if (direction == ngraph::op::RecurrentSequenceDirection::BIDIRECTIONAL)
+                manager.register_pass<ngraph::pass::BidirectionalGRUSequenceDecomposition>();
+            manager.register_pass<ngraph::pass::ConvertGRUSequenceToTensorIterator>();
+            manager.run_passes(function);
+            bool ti_found = ngraph::helpers::is_tensor_iterator_exist(function);
+            EXPECT_EQ(ti_found, true);
+        } else {
+            bool ti_found = ngraph::helpers::is_tensor_iterator_exist(function);
+            EXPECT_EQ(ti_found, false);
+        }
+    }
+
+    void GenerateInputs() {
+        for (const auto &input : executableNetwork.GetInputsInfo()) {
+            const auto &info = input.second;
+            auto blob = GenerateInput(*info);
+            if (input.first == "seq_lengths") {
+                blob = FuncTestUtils::createAndFillBlob(info->getTensorDesc(), m_max_seq_len, 0);
+            }
+            inputs.push_back(blob);
+        }
+    }
+
+private:
+    ngraph::helpers::SequenceTestsMode m_mode;
+    int64_t m_max_seq_len = 0;
+};
+
+TEST_P(GRUSequenceCPUTest, CompareWithRefs) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    Run();
+    CheckPluginRelatedResults(executableNetwork, "RNNSeq");
+}
+
+namespace {
+/* CPU PARAMS */
+std::vector<std::map<std::string, std::string>> bf16EnforceFlags
+    = {{{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::NO}}, {{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES}}};
+
+std::vector<CPUSpecificParams> filterCPUInfoForDevice() {
+    return {CPUSpecificParams{{ntc, nc}, {ntc, nc}, {"ref_any"}, "ref_any_FP32"}};
+}
+std::vector<CPUSpecificParams> filterCPUInfoForDeviceBatchSizeOne() {
+    return {CPUSpecificParams{{tnc, nc}, {tnc, nc}, {"ref_any"}, "ref_any_FP32"}};
+}
+
+std::vector<ngraph::helpers::SequenceTestsMode> mode{ngraph::helpers::SequenceTestsMode::PURE_SEQ};
+// output values increase rapidly without clip, so use only seq_lenghts = 2
+std::vector<size_t> seq_lengths_zero_clip{2};
+std::vector<size_t> batch{10};
+std::vector<size_t> batch_size_one{1};
+std::vector<size_t> hidden_size{1, 10};
+std::vector<std::vector<std::string>> activations = {{"sigmoid", "tanh"}};
+std::vector<bool> linear_before_reset = {true, false};
+std::vector<float> clip{0.f};
+std::vector<ngraph::op::RecurrentSequenceDirection> direction = {ngraph::op::RecurrentSequenceDirection::FORWARD};
+
+std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP32, InferenceEngine::Precision::FP16};
+
+INSTANTIATE_TEST_CASE_P(smoke_GRUSequenceCPU,
+                        GRUSequenceCPUTest,
+                        ::testing::Combine(::testing::Combine(::testing::ValuesIn(mode),
+                                                              ::testing::ValuesIn(seq_lengths_zero_clip),
+                                                              ::testing::ValuesIn(batch),
+                                                              ::testing::ValuesIn(hidden_size),
+                                                              ::testing::ValuesIn(activations),
+                                                              ::testing::ValuesIn(clip),
+                                                              ::testing::ValuesIn(linear_before_reset),
+                                                              ::testing::ValuesIn(direction),
+                                                              ::testing::ValuesIn(netPrecisions),
+                                                              ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                                           ::testing::ValuesIn(filterCPUInfoForDevice()),
+                                           ::testing::ValuesIn(bf16EnforceFlags)),
+                        GRUSequenceCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_GRUSequenceCPUBatchSizeOne,
+                        GRUSequenceCPUTest,
+                        ::testing::Combine(::testing::Combine(::testing::ValuesIn(mode),
+                                                              ::testing::ValuesIn(seq_lengths_zero_clip),
+                                                              ::testing::ValuesIn(batch_size_one),
+                                                              ::testing::ValuesIn(hidden_size),
+                                                              ::testing::ValuesIn(activations),
+                                                              ::testing::ValuesIn(clip),
+                                                              ::testing::ValuesIn(linear_before_reset),
+                                                              ::testing::ValuesIn(direction),
+                                                              ::testing::ValuesIn(netPrecisions),
+                                                              ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                                           ::testing::ValuesIn(filterCPUInfoForDeviceBatchSizeOne()),
+                                           ::testing::ValuesIn(bf16EnforceFlags)),
+                        GRUSequenceCPUTest::getTestCaseName);
+} // namespace
+} // namespace CPULayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/gru_sequence.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/gru_sequence.cpp
@@ -22,17 +22,17 @@ public:
     static std::string getTestCaseName(const testing::TestParamInfo<GRUSequenceCpuSpecificParams> &obj) {
         CPUSpecificParams cpuParams;
         LayerTestsDefinitions::GRUSequenceParams basicParamsSet;
-        std::map<std::string, std::string> enforceBF16;
+        std::map<std::string, std::string> additionalConfig;
 
-        std::tie(basicParamsSet, cpuParams, enforceBF16) = obj.param;
+        std::tie(basicParamsSet, cpuParams, additionalConfig) = obj.param;
         std::ostringstream result;
 
         result << LayerTestsDefinitions::GRUSequenceTest::getTestCaseName(testing::TestParamInfo<LayerTestsDefinitions::GRUSequenceParams>(basicParamsSet, 0));
         result << CPUTestsBase::getTestCaseName(cpuParams);
 
-        if (!enforceBF16.empty()) {
+        if (!additionalConfig.empty()) {
             result << "_PluginConf";
-            for (auto &item : enforceBF16) {
+            for (auto &item : additionalConfig) {
                 if (item.second == PluginConfigParams::YES)
                     result << "_" << item.first << "=" << item.second;
             }
@@ -44,7 +44,7 @@ protected:
     void SetUp() {
         LayerTestsDefinitions::GRUSequenceParams basicParamsSet;
         CPUSpecificParams cpuParams;
-        std::map<std::string, std::string> enforceBF16;
+        std::map<std::string, std::string> additionalConfig;
 
         size_t seq_lenghts;
         size_t batch;
@@ -58,7 +58,7 @@ protected:
         ngraph::op::RecurrentSequenceDirection direction;
         InferenceEngine::Precision netPrecision;
 
-        std::tie(basicParamsSet, cpuParams, enforceBF16) = this->GetParam();
+        std::tie(basicParamsSet, cpuParams, additionalConfig) = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         std::tie(m_mode, seq_lenghts, batch, hidden_size, activations, clip, linear_before_reset, direction, netPrecision, targetDevice) = basicParamsSet;
 
@@ -72,9 +72,9 @@ protected:
              {num_directions, (linear_before_reset ? 4 : 3) * hidden_size}},
         };
 
-        configuration.insert(enforceBF16.begin(), enforceBF16.end());
+        configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
-        if (enforceBF16[PluginConfigParams::KEY_ENFORCE_BF16] == PluginConfigParams::YES) {
+        if (additionalConfig[PluginConfigParams::KEY_ENFORCE_BF16] == PluginConfigParams::YES) {
             inPrc  = netPrecision;
             outPrc = Precision::BF16;
         } else {
@@ -149,15 +149,11 @@ TEST_P(GRUSequenceCPUTest, CompareWithRefs) {
 
 namespace {
 /* CPU PARAMS */
-std::vector<std::map<std::string, std::string>> bf16EnforceFlags
+std::vector<std::map<std::string, std::string>> additionalConfig
     = {{{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::NO}}, {{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES}}};
 
-std::vector<CPUSpecificParams> filterCPUInfoForDevice() {
-    return {CPUSpecificParams{{ntc, nc}, {ntc, nc}, {"ref_any"}, "ref_any"}};
-}
-std::vector<CPUSpecificParams> filterCPUInfoForDeviceBatchSizeOne() {
-    return {CPUSpecificParams{{tnc, nc}, {tnc, nc}, {"ref_any"}, "ref_any"}};
-}
+std::vector<CPUSpecificParams> cpuParams = {{{ntc, nc}, {ntc, nc}, {"ref_any"}, "ref_any"}};
+std::vector<CPUSpecificParams> cpuParamsBatchSizeOne = {{{tnc, nc}, {tnc, nc}, {"ref_any"}, "ref_any"}};
 
 std::vector<ngraph::helpers::SequenceTestsMode> mode{ngraph::helpers::SequenceTestsMode::PURE_SEQ};
 // output values increase rapidly without clip, so use only seq_lenghts = 2
@@ -184,8 +180,8 @@ INSTANTIATE_TEST_CASE_P(smoke_GRUSequenceCPU,
                                                               ::testing::ValuesIn(direction),
                                                               ::testing::ValuesIn(netPrecisions),
                                                               ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                           ::testing::ValuesIn(filterCPUInfoForDevice()),
-                                           ::testing::ValuesIn(bf16EnforceFlags)),
+                                           ::testing::ValuesIn(cpuParams),
+                                           ::testing::ValuesIn(additionalConfig)),
                         GRUSequenceCPUTest::getTestCaseName);
 
 INSTANTIATE_TEST_CASE_P(smoke_GRUSequenceCPUBatchSizeOne,
@@ -200,8 +196,8 @@ INSTANTIATE_TEST_CASE_P(smoke_GRUSequenceCPUBatchSizeOne,
                                                               ::testing::ValuesIn(direction),
                                                               ::testing::ValuesIn(netPrecisions),
                                                               ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                           ::testing::ValuesIn(filterCPUInfoForDeviceBatchSizeOne()),
-                                           ::testing::ValuesIn(bf16EnforceFlags)),
+                                           ::testing::ValuesIn(cpuParamsBatchSizeOne),
+                                           ::testing::ValuesIn(additionalConfig)),
                         GRUSequenceCPUTest::getTestCaseName);
 } // namespace
 } // namespace CPULayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/lstm_cell.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/lstm_cell.cpp
@@ -1,0 +1,129 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "ngraph/op/lstm_cell.hpp"
+#include <shared_test_classes/single_layer/lstm_cell.hpp>
+#include "test_utils/cpu_test_utils.hpp"
+#include "transformations/op_conversions/lstm_cell_decomposition.hpp"
+
+using namespace InferenceEngine;
+using namespace CPUTestUtils;
+
+namespace CPULayerTestsDefinitions {
+
+using LSTMCellCpuSpecificParams = typename std::tuple<LayerTestsDefinitions::LSTMCellParams, CPUSpecificParams, std::map<std::string, std::string>>;
+
+class LSTMCellLayerCPUTest : public testing::WithParamInterface<LSTMCellCpuSpecificParams>,
+                             virtual public LayerTestsUtils::LayerTestsCommon,
+                             public CPUTestsBase {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<LSTMCellCpuSpecificParams>& obj) {
+        CPUSpecificParams cpuParams;
+        LayerTestsDefinitions::LSTMCellParams basicParamsSet;
+        std::map<std::string, std::string> enforceBF16;
+
+        std::tie(basicParamsSet, cpuParams, enforceBF16) = obj.param;
+        std::ostringstream result;
+
+        result << LayerTestsDefinitions::LSTMCellTest::getTestCaseName(testing::TestParamInfo<LayerTestsDefinitions::LSTMCellParams>(
+                basicParamsSet, 0));
+        result << CPUTestsBase::getTestCaseName(cpuParams);
+
+        if (!enforceBF16.empty()) {
+            result << "_PluginConf";
+            for (auto& item : enforceBF16) {
+                if (item.second == PluginConfigParams::YES)
+                    result << "_" << item.first << "=" << item.second;
+            }
+        }
+        return result.str();
+    }
+
+protected:
+    void SetUp() {
+        LayerTestsDefinitions::LSTMCellParams basicParamsSet;
+        CPUSpecificParams cpuParams;
+        std::map<std::string, std::string> enforceBF16;
+
+        bool should_decompose;
+        size_t batch;
+        size_t hidden_size;
+        size_t input_size;
+        std::vector<std::string> activations;
+        std::vector<float> activations_alpha;
+        std::vector<float> activations_beta;
+        float clip;
+        InferenceEngine::Precision netPrecision;
+        threshold = 0.05;
+
+        std::tie(basicParamsSet, cpuParams, enforceBF16) = this->GetParam();
+        std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
+        std::tie(should_decompose, batch, hidden_size, input_size, activations, clip, netPrecision, targetDevice) = basicParamsSet;
+
+        configuration.insert(enforceBF16.begin(), enforceBF16.end());
+
+        std::vector<std::vector<size_t>> inputShapes = {
+            {{batch, input_size}, {batch, hidden_size}, {batch, hidden_size}, {4 * hidden_size, input_size}, {4 * hidden_size, hidden_size}, {4 * hidden_size}},
+        };
+        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+        auto params = ngraph::builder::makeParams(ngPrc, {inputShapes[0], inputShapes[1], inputShapes[2]});
+        std::vector<ngraph::Shape> WRB = {inputShapes[3], inputShapes[4], inputShapes[5]};
+        auto lstm_cell = ngraph::builder::makeLSTM(
+            ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes(params)), WRB, hidden_size, activations, {}, {}, clip);
+        ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(lstm_cell->output(0)),
+                                     std::make_shared<ngraph::opset1::Result>(lstm_cell->output(1))};
+        function = std::make_shared<ngraph::Function>(results, params, "lstm_cell");
+        if (should_decompose) {
+            ngraph::pass::Manager m;
+            m.register_pass<ngraph::pass::LSTMCellDecomposition>();
+            m.run_passes(function);
+        }
+
+        if (selectedType.empty()) {
+            selectedType = getPrimitiveType();
+        }
+    }
+};
+
+TEST_P(LSTMCellLayerCPUTest, CompareWithRefs) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    Run();
+    CheckPluginRelatedResults(executableNetwork, "RNNCell");
+}
+
+namespace {
+/* CPU PARAMS */
+std::vector<std::map<std::string, std::string>> bf16EnforceFlags
+    = {{{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::NO}}, {{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES}}};
+
+std::vector<CPUSpecificParams> filterCPUInfoForDevice() {
+    return {CPUSpecificParams{{nc, nc, nc}, {nc}, {"ref_any"}, "ref_any_FP32"}};
+}
+
+std::vector<bool> should_decompose{false};
+std::vector<size_t> batch{5};
+std::vector<size_t> hidden_size{1, 10};
+std::vector<size_t> input_size{1, 30};
+// oneDNN supports only sigmoid-tanh-tanh
+std::vector<std::vector<std::string>> activations = {{"sigmoid", "tanh", "tanh"}};
+// oneDNN supports only zero clip
+std::vector<float> clip{0.f};
+std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP32};
+
+INSTANTIATE_TEST_CASE_P(smoke_LSTMCellCPU,
+                        LSTMCellLayerCPUTest,
+                        ::testing::Combine(::testing::Combine(::testing::ValuesIn(should_decompose),
+                                                              ::testing::ValuesIn(batch),
+                                                              ::testing::ValuesIn(hidden_size),
+                                                              ::testing::ValuesIn(input_size),
+                                                              ::testing::ValuesIn(activations),
+                                                              ::testing::ValuesIn(clip),
+                                                              ::testing::ValuesIn(netPrecisions),
+                                                              ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                                           ::testing::ValuesIn(filterCPUInfoForDevice()),
+                                           ::testing::ValuesIn(bf16EnforceFlags)),
+                        LSTMCellLayerCPUTest::getTestCaseName);
+} // namespace
+} // namespace CPULayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/lstm_cell.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/lstm_cell.cpp
@@ -68,8 +68,7 @@ protected:
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
         if (additionalConfig[PluginConfigParams::KEY_ENFORCE_BF16] == PluginConfigParams::YES) {
-            inPrc  = Precision::BF16;
-            outPrc = Precision::BF16;
+            inPrc = outPrc = Precision::BF16;
         } else {
             inPrc = outPrc = netPrecision;
         }
@@ -104,7 +103,7 @@ std::vector<std::map<std::string, std::string>> additionalConfig
     = {{{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES}},
        {{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::NO}}};
 
-std::vector<CPUSpecificParams> cpuParams = {{{nc, nc, nc}, {nc}, {"ref_any"}, "ref_any"}};
+CPUSpecificParams cpuParams{{nc, nc, nc}, {nc}, {"ref_any"}, "ref_any"};
 
 std::vector<bool> should_decompose{false};
 std::vector<size_t> batch{5};
@@ -126,7 +125,7 @@ INSTANTIATE_TEST_CASE_P(smoke_LSTMCellCPU,
                                                               ::testing::ValuesIn(clip),
                                                               ::testing::ValuesIn(netPrecisions),
                                                               ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                           ::testing::ValuesIn(cpuParams),
+                                           ::testing::Values(cpuParams),
                                            ::testing::ValuesIn(additionalConfig)),
                         LSTMCellLayerCPUTest::getTestCaseName);
 } // namespace

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/lstm_cell.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/lstm_cell.cpp
@@ -68,7 +68,7 @@ protected:
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
         if (additionalConfig[PluginConfigParams::KEY_ENFORCE_BF16] == PluginConfigParams::YES) {
-            inPrc  = netPrecision;
+            inPrc  = Precision::BF16;
             outPrc = Precision::BF16;
         } else {
             inPrc = outPrc = netPrecision;
@@ -77,11 +77,13 @@ protected:
         selectedType += "_";
         selectedType += outPrc.name();
 
-        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(Precision::FP32);
         auto params = ngraph::builder::makeParams(ngPrc, {inputShapes[0], inputShapes[1], inputShapes[2]});
         std::vector<ngraph::Shape> WRB = {inputShapes[3], inputShapes[4], inputShapes[5]};
+
         auto lstm_cell = ngraph::builder::makeLSTM(
             ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes(params)), WRB, hidden_size, activations, {}, {}, clip);
+
         ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(lstm_cell->output(0)),
                                      std::make_shared<ngraph::opset1::Result>(lstm_cell->output(1))};
 
@@ -112,7 +114,7 @@ std::vector<size_t> input_size{1, 30};
 std::vector<std::vector<std::string>> activations = {{"sigmoid", "tanh", "tanh"}};
 // oneDNN supports only zero clip
 std::vector<float> clip{0.f};
-std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP32};
+std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP32, InferenceEngine::Precision::BF16};
 
 INSTANTIATE_TEST_CASE_P(smoke_LSTMCellCPU,
                         LSTMCellLayerCPUTest,

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/lstm_sequence.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/lstm_sequence.cpp
@@ -1,0 +1,195 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/single_layer/lstm_sequence.hpp"
+#include "ngraph/pass/visualize_tree.hpp"
+#include "test_utils/cpu_test_utils.hpp"
+#include "transformations/op_conversions/bidirectional_sequences_decomposition.hpp"
+#include "transformations/op_conversions/convert_sequences_to_tensor_iterator.hpp"
+
+using namespace InferenceEngine;
+using namespace CPUTestUtils;
+
+namespace CPULayerTestsDefinitions {
+
+using LSTMSequenceCpuSpecificParams = typename std::tuple<LayerTestsDefinitions::LSTMSequenceParams, CPUSpecificParams, std::map<std::string, std::string>>;
+
+class LSTMSequenceCPUTest : public testing::WithParamInterface<LSTMSequenceCpuSpecificParams>,
+                            virtual public LayerTestsUtils::LayerTestsCommon,
+                            public CPUTestsBase {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<LSTMSequenceCpuSpecificParams> &obj) {
+        CPUSpecificParams cpuParams;
+        LayerTestsDefinitions::LSTMSequenceParams basicParamsSet;
+        std::map<std::string, std::string> enforceBF16;
+
+        std::tie(basicParamsSet, cpuParams, enforceBF16) = obj.param;
+        std::ostringstream result;
+
+        result << LayerTestsDefinitions::LSTMSequenceTest::getTestCaseName(
+            testing::TestParamInfo<LayerTestsDefinitions::LSTMSequenceParams>(basicParamsSet, 0));
+        result << CPUTestsBase::getTestCaseName(cpuParams);
+
+        if (!enforceBF16.empty()) {
+            result << "_PluginConf";
+            for (auto &item : enforceBF16) {
+                if (item.second == PluginConfigParams::YES)
+                    result << "_" << item.first << "=" << item.second;
+            }
+        }
+        return result.str();
+    }
+
+protected:
+    void SetUp() {
+        LayerTestsDefinitions::LSTMSequenceParams basicParamsSet;
+        CPUSpecificParams cpuParams;
+        std::map<std::string, std::string> enforceBF16;
+
+        size_t seq_lenghts;
+        size_t batch;
+        size_t hidden_size;
+        size_t input_size;
+        std::vector<std::string> activations;
+        std::vector<float> activations_alpha;
+        std::vector<float> activations_beta;
+        float clip;
+        ngraph::op::RecurrentSequenceDirection direction;
+        InferenceEngine::Precision netPrecision;
+
+        std::tie(basicParamsSet, cpuParams, enforceBF16) = this->GetParam();
+        std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
+        std::tie(m_mode, seq_lenghts, batch, hidden_size, input_size, activations, clip, direction, netPrecision, targetDevice) = basicParamsSet;
+
+        size_t num_directions = direction == ngraph::op::RecurrentSequenceDirection::BIDIRECTIONAL ? 2 : 1;
+        m_max_seq_len = seq_lenghts;
+        std::vector<std::vector<size_t>> inputShapes = {
+            {{batch, seq_lenghts, input_size},
+             {batch, num_directions, hidden_size},
+             {batch, num_directions, hidden_size},
+             {batch},
+             {num_directions, 4 * hidden_size, input_size},
+             {num_directions, 4 * hidden_size, hidden_size},
+             {num_directions, 4 * hidden_size}},
+        };
+        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+        auto params = ngraph::builder::makeParams(ngPrc, {inputShapes[0], inputShapes[1], inputShapes[2]});
+        if (m_mode == ngraph::helpers::SequenceTestsMode::CONVERT_TO_TI_MAX_SEQ_LEN_PARAM
+            || m_mode == ngraph::helpers::SequenceTestsMode::CONVERT_TO_TI_RAND_SEQ_LEN_PARAM) {
+            auto seq_lengths = ngraph::builder::makeParams(ngraph::element::i64, {inputShapes[3]}).at(0);
+            seq_lengths->set_friendly_name("seq_lengths");
+            params.push_back(seq_lengths);
+        }
+        std::vector<ngraph::Shape> WRB = {inputShapes[4], inputShapes[5], inputShapes[6], inputShapes[3]};
+        auto lstm_sequence = ngraph::builder::makeLSTM(ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes(params)),
+                                                       WRB,
+                                                       hidden_size,
+                                                       activations,
+                                                       {},
+                                                       {},
+                                                       clip,
+                                                       true,
+                                                       direction,
+                                                       m_mode);
+        ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(lstm_sequence->output(0)),
+                                     std::make_shared<ngraph::opset1::Result>(lstm_sequence->output(1)),
+                                     std::make_shared<ngraph::opset1::Result>(lstm_sequence->output(2))};
+        function = std::make_shared<ngraph::Function>(results, params, "lstm_sequence");
+        if (m_mode != ngraph::helpers::SequenceTestsMode::PURE_SEQ) {
+            ngraph::pass::Manager manager;
+            if (direction == ngraph::op::RecurrentSequenceDirection::BIDIRECTIONAL)
+                manager.register_pass<ngraph::pass::BidirectionalLSTMSequenceDecomposition>();
+            manager.register_pass<ngraph::pass::ConvertLSTMSequenceToTensorIterator>();
+            manager.run_passes(function);
+            bool ti_found = ngraph::helpers::is_tensor_iterator_exist(function);
+            EXPECT_EQ(ti_found, true);
+        } else {
+            bool ti_found = ngraph::helpers::is_tensor_iterator_exist(function);
+            EXPECT_EQ(ti_found, false);
+        }
+    }
+
+    void GenerateInputs() {
+        for (const auto &input : executableNetwork.GetInputsInfo()) {
+            const auto &info = input.second;
+            auto blob = GenerateInput(*info);
+            if (input.first == "seq_lengths") {
+                blob = FuncTestUtils::createAndFillBlob(info->getTensorDesc(), m_max_seq_len, 0);
+            }
+
+            inputs.push_back(blob);
+        }
+    }
+
+private:
+    ngraph::helpers::SequenceTestsMode m_mode;
+    int64_t m_max_seq_len = 0;
+};
+
+TEST_P(LSTMSequenceCPUTest, CompareWithRefs) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    Run();
+    CheckPluginRelatedResults(executableNetwork, "RNNSeq");
+}
+
+namespace {
+/* CPU PARAMS */
+std::vector<std::map<std::string, std::string>> bf16EnforceFlags
+    = {{{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::NO}}, {{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES}}};
+
+std::vector<CPUSpecificParams> filterCPUInfoForDevice() {
+    return {CPUSpecificParams{{ntc, nc, nc}, {ntc, nc, nc}, {"ref_any"}, "ref_any_FP32"}};
+}
+
+std::vector<CPUSpecificParams> filterCPUInfoForDeviceBatchSizeOne() {
+    return {CPUSpecificParams{{tnc, nc, nc}, {tnc, nc, nc}, {"ref_any"}, "ref_any_FP32"}};
+}
+
+std::vector<ngraph::helpers::SequenceTestsMode> mode{ngraph::helpers::SequenceTestsMode::PURE_SEQ};
+std::vector<size_t> seq_lengths_zero_clip{2};
+std::vector<size_t> batch_size_one{1};
+std::vector<size_t> batch{10};
+std::vector<size_t> hidden_size{1, 10};
+std::vector<size_t> input_size{10};
+// oneDNN supports only sigmoid-tanh-tanh
+std::vector<std::vector<std::string>> activations = {{"sigmoid", "tanh", "tanh"}};
+// oneDNN supports only zero clip
+std::vector<float> clip{0.f};
+std::vector<ngraph::op::RecurrentSequenceDirection> direction = {ngraph::op::RecurrentSequenceDirection::FORWARD};
+std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP32, InferenceEngine::Precision::FP16};
+
+INSTANTIATE_TEST_CASE_P(smoke_LSTMSequenceCPU,
+                        LSTMSequenceCPUTest,
+                        ::testing::Combine(::testing::Combine(::testing::ValuesIn(mode),
+                                                              ::testing::ValuesIn(seq_lengths_zero_clip),
+                                                              ::testing::ValuesIn(batch),
+                                                              ::testing::ValuesIn(hidden_size),
+                                                              ::testing::ValuesIn(input_size),
+                                                              ::testing::ValuesIn(activations),
+                                                              ::testing::ValuesIn(clip),
+                                                              ::testing::ValuesIn(direction),
+                                                              ::testing::ValuesIn(netPrecisions),
+                                                              ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                                           ::testing::ValuesIn(filterCPUInfoForDevice()),
+                                           ::testing::ValuesIn(bf16EnforceFlags)),
+                        LSTMSequenceCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_LSTMSequenceCPUbatchSizeOne,
+                        LSTMSequenceCPUTest,
+                        ::testing::Combine(::testing::Combine(::testing::ValuesIn(mode),
+                                                              ::testing::ValuesIn(seq_lengths_zero_clip),
+                                                              ::testing::ValuesIn(batch_size_one),
+                                                              ::testing::ValuesIn(hidden_size),
+                                                              ::testing::ValuesIn(input_size),
+                                                              ::testing::ValuesIn(activations),
+                                                              ::testing::ValuesIn(clip),
+                                                              ::testing::ValuesIn(direction),
+                                                              ::testing::ValuesIn(netPrecisions),
+                                                              ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                                           ::testing::ValuesIn(filterCPUInfoForDeviceBatchSizeOne()),
+                                           ::testing::ValuesIn(bf16EnforceFlags)),
+                        LSTMSequenceCPUTest::getTestCaseName);
+} // namespace
+} // namespace CPULayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/lstm_sequence.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/lstm_sequence.cpp
@@ -77,8 +77,7 @@ protected:
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
         if (additionalConfig[PluginConfigParams::KEY_ENFORCE_BF16] == PluginConfigParams::YES) {
-            inPrc  = netPrecision;
-            outPrc = Precision::BF16;
+            inPrc = outPrc = Precision::BF16;
         } else {
             inPrc = outPrc = netPrecision;
         }
@@ -86,7 +85,7 @@ protected:
         selectedType += "_";
         selectedType += outPrc.name();
 
-        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(Precision::FP32);
         auto params = ngraph::builder::makeParams(ngPrc, {inputShapes[0], inputShapes[1], inputShapes[2]});
         if (m_mode == ngraph::helpers::SequenceTestsMode::CONVERT_TO_TI_MAX_SEQ_LEN_PARAM
             || m_mode == ngraph::helpers::SequenceTestsMode::CONVERT_TO_TI_RAND_SEQ_LEN_PARAM) {
@@ -155,8 +154,8 @@ std::vector<std::map<std::string, std::string>> additionalConfig
     = {{{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::NO}},
        {{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES}}};
 
-std::vector<CPUSpecificParams> cpuParams = {{{ntc, nc, nc}, {ntc, nc, nc}, {"ref_any"}, "ref_any"}};
-std::vector<CPUSpecificParams> cpuParamsBatchSizeOne = {{{{tnc, nc, nc}, {tnc, nc, nc}, {"ref_any"}, "ref_any"}}};
+CPUSpecificParams cpuParams{{ntc, nc, nc}, {ntc, nc, nc}, {"ref_any"}, "ref_any"};
+CPUSpecificParams cpuParamsBatchSizeOne{{tnc, nc, nc}, {tnc, nc, nc}, {"ref_any"}, "ref_any"};
 
 std::vector<ngraph::helpers::SequenceTestsMode> mode{ngraph::helpers::SequenceTestsMode::PURE_SEQ};
 std::vector<size_t> seq_lengths_zero_clip{2};
@@ -183,7 +182,7 @@ INSTANTIATE_TEST_CASE_P(smoke_LSTMSequenceCPU,
                                                               ::testing::ValuesIn(direction),
                                                               ::testing::ValuesIn(netPrecisions),
                                                               ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                           ::testing::ValuesIn(cpuParams),
+                                           ::testing::Values(cpuParams),
                                            ::testing::ValuesIn(additionalConfig)),
                         LSTMSequenceCPUTest::getTestCaseName);
 
@@ -199,7 +198,7 @@ INSTANTIATE_TEST_CASE_P(smoke_LSTMSequenceCPUbatchSizeOne,
                                                               ::testing::ValuesIn(direction),
                                                               ::testing::ValuesIn(netPrecisions),
                                                               ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                           ::testing::ValuesIn(cpuParamsBatchSizeOne),
+                                           ::testing::Values(cpuParamsBatchSizeOne),
                                            ::testing::ValuesIn(additionalConfig)),
                         LSTMSequenceCPUTest::getTestCaseName);
 } // namespace

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/rnn_cell.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/rnn_cell.cpp
@@ -66,8 +66,7 @@ protected:
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
         if (additionalConfig[PluginConfigParams::KEY_ENFORCE_BF16] == PluginConfigParams::YES) {
-            inPrc  = netPrecision;
-            outPrc = Precision::BF16;
+            inPrc = outPrc = Precision::BF16;
         } else {
             inPrc = outPrc = netPrecision;
         }
@@ -75,7 +74,7 @@ protected:
         selectedType += "_";
         selectedType += outPrc.name();
 
-        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(Precision::FP32);
         auto params = ngraph::builder::makeParams(ngPrc, {inputShapes[0], inputShapes[1]});
         std::vector<ngraph::Shape> WRB = {inputShapes[2], inputShapes[3], inputShapes[4]};
         auto rnn_cell = ngraph::builder::makeRNN(
@@ -98,7 +97,7 @@ namespace {
 std::vector<std::map<std::string, std::string>> additionalConfig
     = {{{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::NO}}, {{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES}}};
 
-std::vector<CPUSpecificParams> cpuParams = {{{nc, nc}, {nc}, {"ref_any"}, "ref_any"}};
+CPUSpecificParams cpuParams{{nc, nc}, {nc}, {"ref_any"}, "ref_any"};
 std::vector<bool> should_decompose{false};
 std::vector<size_t> batch{1, 5};
 std::vector<size_t> hidden_size{1, 10};
@@ -118,7 +117,7 @@ INSTANTIATE_TEST_CASE_P(smoke_RNNCellCPU,
                                                               ::testing::ValuesIn(clip),
                                                               ::testing::ValuesIn(netPrecisions),
                                                               ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                           ::testing::ValuesIn(cpuParams),
+                                           ::testing::Values(cpuParams),
                                            ::testing::ValuesIn(additionalConfig)),
                         RNNCellCPUTest::getTestCaseName);
 } // namespace

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/rnn_cell.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/rnn_cell.cpp
@@ -1,0 +1,114 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "ngraph/op/rnn_cell.hpp"
+#include <shared_test_classes/single_layer/rnn_cell.hpp>
+#include "test_utils/cpu_test_utils.hpp"
+
+using namespace InferenceEngine;
+using namespace CPUTestUtils;
+
+namespace CPULayerTestsDefinitions {
+
+using RNNCellCpuSpecificParams = typename std::tuple<LayerTestsDefinitions::RNNCellParams, CPUSpecificParams, std::map<std::string, std::string>>;
+
+class RNNCellCPUTest : public testing::WithParamInterface<RNNCellCpuSpecificParams>,
+                            virtual public LayerTestsUtils::LayerTestsCommon,
+                            public CPUTestsBase {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<RNNCellCpuSpecificParams> &obj) {
+        CPUSpecificParams cpuParams;
+        LayerTestsDefinitions::RNNCellParams basicParamsSet;
+        std::map<std::string, std::string> enforceBF16;
+
+        std::tie(basicParamsSet, cpuParams, enforceBF16) = obj.param;
+
+        std::ostringstream result;
+        result << LayerTestsDefinitions::RNNCellTest::getTestCaseName(
+            testing::TestParamInfo<LayerTestsDefinitions::RNNCellParams>(basicParamsSet, 0));
+        result << CPUTestsBase::getTestCaseName(cpuParams);
+
+        if (!enforceBF16.empty()) {
+            result << "_PluginConf";
+            for (auto &item : enforceBF16) {
+                if (item.second == PluginConfigParams::YES)
+                    result << "_" << item.first << "=" << item.second;
+            }
+        }
+        return result.str();
+    }
+
+protected:
+    void SetUp() {
+        CPUSpecificParams cpuParams;
+        LayerTestsDefinitions::RNNCellParams basicParamsSet;
+        std::map<std::string, std::string> enforceBF16;
+
+        bool should_decompose;
+        size_t batch;
+        size_t hidden_size;
+        size_t input_size;
+        std::vector<std::string> activations;
+        std::vector<float> activations_alpha;
+        std::vector<float> activations_beta;
+        float clip;
+        InferenceEngine::Precision netPrecision;
+
+        std::tie(basicParamsSet, cpuParams, enforceBF16) = this->GetParam();
+        std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
+        std::tie(should_decompose, batch, hidden_size, input_size, activations, clip, netPrecision, targetDevice) = basicParamsSet;
+
+        std::vector<std::vector<size_t>> inputShapes = {{batch, input_size}, {batch, hidden_size},
+                                                        {hidden_size, input_size}, {hidden_size, hidden_size}, {hidden_size}};
+        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+        auto params = ngraph::builder::makeParams(ngPrc, {inputShapes[0], inputShapes[1]});
+        std::vector<ngraph::Shape> WRB = {inputShapes[2], inputShapes[3], inputShapes[4]};
+        auto rnn_cell = ngraph::builder::makeRNN(
+            ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes(params)),
+            WRB, hidden_size, activations, {}, {}, clip);
+        ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(rnn_cell)};
+        function = std::make_shared<ngraph::Function>(results, params, "rnn_cell");
+    }
+};
+
+TEST_P(RNNCellCPUTest, CompareWithRefs) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    Run();
+    CheckPluginRelatedResults(executableNetwork, "RNNCell");
+}
+
+namespace {
+/* CPU PARAMS */
+std::vector<std::map<std::string, std::string>> bf16EnforceFlags
+    = {{{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::NO}}, {{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES}}};
+
+std::vector<CPUSpecificParams> filterCPUInfoForDevice() {
+    return {CPUSpecificParams{{nc, nc}, {nc}, {"ref_any"}, "ref_any_FP32"}};
+}
+
+std::vector<bool> should_decompose{false};
+std::vector<size_t> batch{1, 5};
+std::vector<size_t> hidden_size{1, 10};
+std::vector<size_t> input_size{1, 30};
+std::vector<std::vector<std::string>> activations = {{"relu"}, {"sigmoid"}, {"tanh"}};
+// oneDNN supports only zero clip
+std::vector<float> clip = {0.f};
+std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP32, InferenceEngine::Precision::FP16};
+
+INSTANTIATE_TEST_CASE_P(smoke_RNNCellCPU,
+                        RNNCellCPUTest,
+                        ::testing::Combine(::testing::Combine(::testing::ValuesIn(should_decompose),
+                                                              ::testing::ValuesIn(batch),
+                                                              ::testing::ValuesIn(hidden_size),
+                                                              ::testing::ValuesIn(input_size),
+                                                              ::testing::ValuesIn(activations),
+                                                              ::testing::ValuesIn(clip),
+                                                              ::testing::ValuesIn(netPrecisions),
+                                                              ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                                           ::testing::ValuesIn(filterCPUInfoForDevice()),
+                                           ::testing::ValuesIn(bf16EnforceFlags)),
+                        RNNCellCPUTest::getTestCaseName);
+} // namespace
+} // namespace CPULayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/rnn_cell.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/rnn_cell.cpp
@@ -20,18 +20,18 @@ public:
     static std::string getTestCaseName(const testing::TestParamInfo<RNNCellCpuSpecificParams> &obj) {
         CPUSpecificParams cpuParams;
         LayerTestsDefinitions::RNNCellParams basicParamsSet;
-        std::map<std::string, std::string> enforceBF16;
+        std::map<std::string, std::string> additionalConfig;
 
-        std::tie(basicParamsSet, cpuParams, enforceBF16) = obj.param;
+        std::tie(basicParamsSet, cpuParams, additionalConfig) = obj.param;
 
         std::ostringstream result;
         result << LayerTestsDefinitions::RNNCellTest::getTestCaseName(
             testing::TestParamInfo<LayerTestsDefinitions::RNNCellParams>(basicParamsSet, 0));
         result << CPUTestsBase::getTestCaseName(cpuParams);
 
-        if (!enforceBF16.empty()) {
+        if (!additionalConfig.empty()) {
             result << "_PluginConf";
-            for (auto &item : enforceBF16) {
+            for (auto &item : additionalConfig) {
                 if (item.second == PluginConfigParams::YES)
                     result << "_" << item.first << "=" << item.second;
             }
@@ -44,7 +44,7 @@ protected:
     void SetUp() {
         CPUSpecificParams cpuParams;
         LayerTestsDefinitions::RNNCellParams basicParamsSet;
-        std::map<std::string, std::string> enforceBF16;
+        std::map<std::string, std::string> additionalConfig;
 
         bool should_decompose;
         size_t batch;
@@ -56,16 +56,16 @@ protected:
         float clip;
         InferenceEngine::Precision netPrecision;
 
-        std::tie(basicParamsSet, cpuParams, enforceBF16) = this->GetParam();
+        std::tie(basicParamsSet, cpuParams, additionalConfig) = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         std::tie(should_decompose, batch, hidden_size, input_size, activations, clip, netPrecision, targetDevice) = basicParamsSet;
 
         std::vector<std::vector<size_t>> inputShapes = {{batch, input_size}, {batch, hidden_size},
                                                         {hidden_size, input_size}, {hidden_size, hidden_size}, {hidden_size}};
 
-        configuration.insert(enforceBF16.begin(), enforceBF16.end());
+        configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
-        if (enforceBF16[PluginConfigParams::KEY_ENFORCE_BF16] == PluginConfigParams::YES) {
+        if (additionalConfig[PluginConfigParams::KEY_ENFORCE_BF16] == PluginConfigParams::YES) {
             inPrc  = netPrecision;
             outPrc = Precision::BF16;
         } else {
@@ -95,13 +95,10 @@ TEST_P(RNNCellCPUTest, CompareWithRefs) {
 
 namespace {
 /* CPU PARAMS */
-std::vector<std::map<std::string, std::string>> bf16EnforceFlags
+std::vector<std::map<std::string, std::string>> additionalConfig
     = {{{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::NO}}, {{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES}}};
 
-std::vector<CPUSpecificParams> filterCPUInfoForDevice() {
-    return {CPUSpecificParams{{nc, nc}, {nc}, {"ref_any"}, "ref_any"}};
-}
-
+std::vector<CPUSpecificParams> cpuParams = {{{nc, nc}, {nc}, {"ref_any"}, "ref_any"}};
 std::vector<bool> should_decompose{false};
 std::vector<size_t> batch{1, 5};
 std::vector<size_t> hidden_size{1, 10};
@@ -121,8 +118,8 @@ INSTANTIATE_TEST_CASE_P(smoke_RNNCellCPU,
                                                               ::testing::ValuesIn(clip),
                                                               ::testing::ValuesIn(netPrecisions),
                                                               ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                           ::testing::ValuesIn(filterCPUInfoForDevice()),
-                                           ::testing::ValuesIn(bf16EnforceFlags)),
+                                           ::testing::ValuesIn(cpuParams),
+                                           ::testing::ValuesIn(additionalConfig)),
                         RNNCellCPUTest::getTestCaseName);
 } // namespace
 } // namespace CPULayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/rnn_sequence.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/rnn_sequence.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/rnn_sequence.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/rnn_sequence.cpp
@@ -1,0 +1,194 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/single_layer/rnn_sequence.hpp"
+#include "ngraph/pass/visualize_tree.hpp"
+#include "test_utils/cpu_test_utils.hpp"
+#include "transformations/op_conversions/bidirectional_sequences_decomposition.hpp"
+#include "transformations/op_conversions/convert_sequences_to_tensor_iterator.hpp"
+
+using namespace InferenceEngine;
+using namespace CPUTestUtils;
+
+namespace CPULayerTestsDefinitions {
+
+using RNNSequenceCpuSpecificParams = typename std::tuple<LayerTestsDefinitions::RNNSequenceParams, CPUSpecificParams, std::map<std::string, std::string>>;
+
+class RNNSequenceCPUTest : public testing::WithParamInterface<RNNSequenceCpuSpecificParams>,
+                           virtual public LayerTestsUtils::LayerTestsCommon,
+                           public CPUTestsBase {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<RNNSequenceCpuSpecificParams> &obj) {
+        CPUSpecificParams cpuParams;
+        LayerTestsDefinitions::RNNSequenceParams basicParamsSet;
+        std::map<std::string, std::string> enforceBF16;
+
+        std::tie(basicParamsSet, cpuParams, enforceBF16) = obj.param;
+        std::ostringstream result;
+
+        result << LayerTestsDefinitions::RNNSequenceTest::getTestCaseName(testing::TestParamInfo<LayerTestsDefinitions::RNNSequenceParams>(basicParamsSet, 0));
+        result << CPUTestsBase::getTestCaseName(cpuParams);
+
+        if (!enforceBF16.empty()) {
+            result << "_PluginConf";
+            for (auto &item : enforceBF16) {
+                if (item.second == PluginConfigParams::YES)
+                    result << "_" << item.first << "=" << item.second;
+            }
+        }
+        return result.str();
+    }
+
+protected:
+    void SetUp() {
+        LayerTestsDefinitions::RNNSequenceParams basicParamsSet;
+        CPUSpecificParams cpuParams;
+        std::map<std::string, std::string> enforceBF16;
+
+        size_t seq_lenghts;
+        size_t batch;
+        size_t hidden_size;
+        size_t input_size;
+        std::vector<std::string> activations;
+        std::vector<float> activations_alpha;
+        std::vector<float> activations_beta;
+        float clip;
+        ngraph::op::RecurrentSequenceDirection direction;
+        InferenceEngine::Precision netPrecision;
+
+        std::tie(basicParamsSet, cpuParams, enforceBF16) = this->GetParam();
+        std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
+        std::tie(m_mode, seq_lenghts, batch, hidden_size, input_size, activations, clip, direction, netPrecision, targetDevice) = basicParamsSet;
+
+        size_t num_directions = direction == ngraph::op::RecurrentSequenceDirection::BIDIRECTIONAL ? 2 : 1;
+        std::vector<std::vector<size_t>> inputShapes = {
+            {{batch, seq_lenghts, input_size},
+             {batch, num_directions, hidden_size},
+             {batch},
+             {num_directions, hidden_size, input_size},
+             {num_directions, hidden_size, hidden_size},
+             {num_directions, hidden_size}},
+        };
+        m_max_seq_len = seq_lenghts;
+        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+        auto params = ngraph::builder::makeParams(ngPrc, {inputShapes[0], inputShapes[1]});
+        if (m_mode == ngraph::helpers::SequenceTestsMode::CONVERT_TO_TI_MAX_SEQ_LEN_PARAM
+            || m_mode == ngraph::helpers::SequenceTestsMode::CONVERT_TO_TI_RAND_SEQ_LEN_PARAM) {
+            auto seq_lengths = ngraph::builder::makeParams(ngraph::element::i64, {inputShapes[2]}).at(0);
+            seq_lengths->set_friendly_name("seq_lengths");
+            params.push_back(seq_lengths);
+        }
+        std::vector<ngraph::Shape> WRB = {inputShapes[3], inputShapes[4], inputShapes[5], inputShapes[2]};
+        auto rnn_sequence = ngraph::builder::makeRNN(ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes(params)),
+                                                     WRB,
+                                                     hidden_size,
+                                                     activations,
+                                                     {},
+                                                     {},
+                                                     clip,
+                                                     true,
+                                                     direction,
+                                                     m_mode);
+        ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(rnn_sequence->output(0)),
+                                     std::make_shared<ngraph::opset1::Result>(rnn_sequence->output(1))};
+        function = std::make_shared<ngraph::Function>(results, params, "rnn_sequence");
+        if (m_mode != ngraph::helpers::SequenceTestsMode::PURE_SEQ) {
+            ngraph::pass::Manager manager;
+            if (direction == ngraph::op::RecurrentSequenceDirection::BIDIRECTIONAL)
+                manager.register_pass<ngraph::pass::BidirectionalRNNSequenceDecomposition>();
+            manager.register_pass<ngraph::pass::ConvertRNNSequenceToTensorIterator>();
+            manager.run_passes(function);
+            bool ti_found = ngraph::helpers::is_tensor_iterator_exist(function);
+            EXPECT_EQ(ti_found, true);
+        } else {
+            bool ti_found = ngraph::helpers::is_tensor_iterator_exist(function);
+            EXPECT_EQ(ti_found, false);
+        }
+    }
+
+    void GenerateInputs() {
+        for (const auto &input : executableNetwork.GetInputsInfo()) {
+            const auto &info = input.second;
+            auto blob = GenerateInput(*info);
+            if (input.first == "seq_lengths") {
+                blob = FuncTestUtils::createAndFillBlob(info->getTensorDesc(), m_max_seq_len, 0);
+            }
+
+            inputs.push_back(blob);
+        }
+    }
+
+private:
+    ngraph::helpers::SequenceTestsMode m_mode;
+    int64_t m_max_seq_len = 0;
+};
+
+TEST_P(RNNSequenceCPUTest, CompareWithRefs) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    Run();
+    CheckPluginRelatedResults(executableNetwork, "RNNSeq");
+}
+
+namespace {
+/* CPU PARAMS */
+std::vector<std::map<std::string, std::string>> bf16EnforceFlags
+    = {{{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::NO}}, {{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES}}};
+
+std::vector<CPUSpecificParams> filterCPUInfoForDevice() {
+    return {CPUSpecificParams{{ntc, nc}, {ntc, nc}, {"ref_any"}, "ref_any_FP32"}};
+}
+
+std::vector<CPUSpecificParams> filterCPUInfoForDeviceBatchSizeOne() {
+    return {CPUSpecificParams{{tnc, nc}, {tnc, nc}, {"ref_any"}, "ref_any_FP32"}};
+}
+
+std::vector<ngraph::helpers::SequenceTestsMode> mode{ngraph::helpers::SequenceTestsMode::PURE_SEQ};
+// output values increase rapidly without clip, so use only seq_lenghts = 2
+std::vector<size_t> seq_lengths_zero_clip{2};
+std::vector<size_t> batch{10};
+std::vector<size_t> batch_size_one{1};
+std::vector<size_t> hidden_size{1, 10};
+std::vector<size_t> input_size{10};
+std::vector<std::vector<std::string>> activations = {{"relu"}, {"sigmoid"}, {"tanh"}};
+// oneDNN supports only zero clip
+std::vector<float> clip{0.f};
+
+std::vector<ngraph::op::RecurrentSequenceDirection> direction{ngraph::op::RecurrentSequenceDirection::FORWARD};
+
+std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP32, InferenceEngine::Precision::FP16};
+
+INSTANTIATE_TEST_CASE_P(smoke_RNNSequenceCPU,
+                        RNNSequenceCPUTest,
+                        ::testing::Combine(::testing::Combine(::testing::ValuesIn(mode),
+                                                              ::testing::ValuesIn(seq_lengths_zero_clip),
+                                                              ::testing::ValuesIn(batch),
+                                                              ::testing::ValuesIn(hidden_size),
+                                                              ::testing::ValuesIn(input_size),
+                                                              ::testing::ValuesIn(activations),
+                                                              ::testing::ValuesIn(clip),
+                                                              ::testing::ValuesIn(direction),
+                                                              ::testing::ValuesIn(netPrecisions),
+                                                              ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                                           ::testing::ValuesIn(filterCPUInfoForDevice()),
+                                           ::testing::ValuesIn(bf16EnforceFlags)),
+                        RNNSequenceCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_RNNSequenceCPUBatchSizeOne,
+                        RNNSequenceCPUTest,
+                        ::testing::Combine(::testing::Combine(::testing::ValuesIn(mode),
+                                                              ::testing::ValuesIn(seq_lengths_zero_clip),
+                                                              ::testing::ValuesIn(batch_size_one),
+                                                              ::testing::ValuesIn(hidden_size),
+                                                              ::testing::ValuesIn(input_size),
+                                                              ::testing::ValuesIn(activations),
+                                                              ::testing::ValuesIn(clip),
+                                                              ::testing::ValuesIn(direction),
+                                                              ::testing::ValuesIn(netPrecisions),
+                                                              ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                                           ::testing::ValuesIn(filterCPUInfoForDeviceBatchSizeOne()),
+                                           ::testing::ValuesIn(bf16EnforceFlags)),
+                        RNNSequenceCPUTest::getTestCaseName);
+} // namespace
+} // namespace CPULayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/rnn_sequence.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/rnn_sequence.cpp
@@ -74,8 +74,7 @@ protected:
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
         if (additionalConfig[PluginConfigParams::KEY_ENFORCE_BF16] == PluginConfigParams::YES) {
-            inPrc  = netPrecision;
-            outPrc = Precision::BF16;
+            inPrc = outPrc = Precision::BF16;
         } else {
             inPrc = outPrc = netPrecision;
         }
@@ -84,7 +83,7 @@ protected:
         selectedType += outPrc.name();
 
         m_max_seq_len = seq_lenghts;
-        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(Precision::FP32);
         auto params = ngraph::builder::makeParams(ngPrc, {inputShapes[0], inputShapes[1]});
         if (m_mode == ngraph::helpers::SequenceTestsMode::CONVERT_TO_TI_MAX_SEQ_LEN_PARAM
             || m_mode == ngraph::helpers::SequenceTestsMode::CONVERT_TO_TI_RAND_SEQ_LEN_PARAM) {
@@ -149,8 +148,8 @@ namespace {
 std::vector<std::map<std::string, std::string>> additionalConfig
     = {{{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::NO}}, {{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES}}};
 
-std::vector<CPUSpecificParams> cpuParams = {{{ntc, nc}, {ntc, nc}, {"ref_any"}, "ref_any"}};
-std::vector<CPUSpecificParams> cpuParamsBatchSizeOne = {{{tnc, nc}, {tnc, nc}, {"ref_any"}, "ref_any"}};
+CPUSpecificParams cpuParams{{ntc, nc}, {ntc, nc}, {"ref_any"}, "ref_any"};
+CPUSpecificParams cpuParamsBatchSizeOne{{tnc, nc}, {tnc, nc}, {"ref_any"}, "ref_any"};
 
 std::vector<ngraph::helpers::SequenceTestsMode> mode{ngraph::helpers::SequenceTestsMode::PURE_SEQ};
 // output values increase rapidly without clip, so use only seq_lenghts = 2
@@ -180,7 +179,7 @@ INSTANTIATE_TEST_CASE_P(smoke_RNNSequenceCPU,
                                                               ::testing::ValuesIn(direction),
                                                               ::testing::ValuesIn(netPrecisions),
                                                               ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                           ::testing::ValuesIn(cpuParams),
+                                           ::testing::Values(cpuParams),
                                            ::testing::ValuesIn(additionalConfig)),
                         RNNSequenceCPUTest::getTestCaseName);
 
@@ -196,7 +195,7 @@ INSTANTIATE_TEST_CASE_P(smoke_RNNSequenceCPUBatchSizeOne,
                                                               ::testing::ValuesIn(direction),
                                                               ::testing::ValuesIn(netPrecisions),
                                                               ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                           ::testing::ValuesIn(cpuParamsBatchSizeOne),
+                                           ::testing::Values(cpuParamsBatchSizeOne),
                                            ::testing::ValuesIn(additionalConfig)),
                         RNNSequenceCPUTest::getTestCaseName);
 } // namespace

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.cpp
@@ -80,24 +80,32 @@ cpu_memory_format_t CPUTestsBase::cpu_str2fmt(const char *str) {
 }
 
 std::string CPUTestsBase::fmts2str(const std::vector<cpu_memory_format_t> &fmts) {
+    if (fmts.empty())
+        return {};
+
     std::string str;
+
     for (auto &fmt : fmts) {
-        ((str += "cpu:") += cpu_fmt2str(fmt)) += ",";
+        (str += cpu_fmt2str(fmt)) += ",";
     }
-    if (!str.empty()) {
-        str.pop_back();
-    }
+    str.pop_back();
+    str += "(cpu)";
+
     return str;
 }
 
 std::string CPUTestsBase::impls2str(const std::vector<std::string> &priority) {
+    if (priority.empty())
+        return {};
+
     std::string str;
+
     for (auto &impl : priority) {
-        ((str += "cpu:") += impl) += ",";
+        (str += impl) += ",";
     }
-    if (!str.empty()) {
-        str.pop_back();
-    }
+    str.pop_back();
+    str += "(cpu)";
+
     return str;
 }
 
@@ -242,8 +250,11 @@ std::shared_ptr<ngraph::Function>
 CPUTestsBase::makeNgraphFunction(const ngraph::element::Type &ngPrc, ngraph::ParameterVector &params,
                                  const std::shared_ptr<ngraph::Node> &lastNode, std::string name) const {
    auto newLastNode = modifyGraph(ngPrc, params, lastNode);
+   ngraph::ResultVector results;
 
-   ngraph::ResultVector results = {std::make_shared<ngraph::opset1::Result>(newLastNode)};
+   for (int i = 0; i < newLastNode->get_output_size(); i++)
+        results.push_back(std::make_shared<ngraph::opset1::Result>(newLastNode->output(i)));
+
    return std::make_shared<ngraph::Function>(results, params, name);
 }
 

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.cpp
@@ -8,16 +8,32 @@
 namespace CPUTestUtils {
 
 const char *CPUTestsBase::cpu_fmt2str(cpu_memory_format_t v) {
-    if (v == nchw) return "nchw";
-    if (v == nChw8c) return "nChw8c";
-    if (v == nChw16c) return "nChw16c";
-    if (v == nhwc) return "nhwc";
-    if (v == ncdhw) return "ncdhw";
-    if (v == nCdhw8c) return "nCdhw8c";
-    if (v == nCdhw16c) return "nCdhw16c";
-    if (v == ndhwc) return "ndhwc";
-    if (v == nc) return "nc";
-    if (v == x) return "x";
+#define FMT_2_STR(_fmt) do { \
+    if (v == _fmt) return #_fmt; \
+} while (0)
+    FMT_2_STR(nchw);
+    FMT_2_STR(nChw8c);
+    FMT_2_STR(nChw16c);
+    FMT_2_STR(nhwc);
+    FMT_2_STR(ncdhw);
+    FMT_2_STR(nCdhw8c);
+    FMT_2_STR(nCdhw16c);
+    FMT_2_STR(ndhwc);
+    FMT_2_STR(nc);
+    FMT_2_STR(x);
+    FMT_2_STR(abc);
+    FMT_2_STR(bac);
+    FMT_2_STR(abdc);
+    FMT_2_STR(abdec);
+    FMT_2_STR(tnc);
+    FMT_2_STR(ntc);
+    FMT_2_STR(ldnc);
+    FMT_2_STR(ldigo);
+    FMT_2_STR(ldgoi);
+    FMT_2_STR(ldio);
+    FMT_2_STR(ldoi);
+    FMT_2_STR(ldgo);
+#undef FMT_2_STR
     assert(!"unknown fmt");
     return "undef";
 }
@@ -39,6 +55,10 @@ cpu_memory_format_t CPUTestsBase::cpu_str2fmt(const char *str) {
     CASE(acdeb);
     CASE(aBcde8b);
     CASE(aBcde16b);
+    CASE(abc);
+    CASE(bac);
+    CASE(abdc);
+    CASE(abdec);
     CASE(nchw);
     CASE(nChw8c);
     CASE(nChw16c);
@@ -49,6 +69,14 @@ cpu_memory_format_t CPUTestsBase::cpu_str2fmt(const char *str) {
     CASE(ndhwc);
     CASE(nc);
     CASE(x);
+    CASE(tnc);
+    CASE(ntc);
+    CASE(ldnc);
+    CASE(ldigo);
+    CASE(ldgoi);
+    CASE(ldio);
+    CASE(ldoi);
+    CASE(ldgo);
 #undef CASE
     assert(!"unknown memory format");
     return undef;
@@ -108,6 +136,8 @@ void CPUTestsBase::CheckPluginRelatedResults(InferenceEngine::ExecutableNetwork 
             return skip_unsquized_1D || permule_of_1;
         };
 
+        std::cout << "Current Layer type: " << getExecValue(ExecGraphInfoSerialization::LAYER_TYPE) << '\n';
+
         if (getExecValue(ExecGraphInfoSerialization::LAYER_TYPE) == nodeType) {
             isNodeFound = true;
             ASSERT_LE(inFmts.size(), node->get_input_size());
@@ -120,18 +150,21 @@ void CPUTestsBase::CheckPluginRelatedResults(InferenceEngine::ExecutableNetwork 
                     auto shape = parentNode->get_output_tensor(0).get_shape();
                     auto actualInputMemoryFormat = getExecValueOutputsLayout(parentNode);
 
-                    if (!should_be_skipped(shape, inFmts[i]))
+                    if (!should_be_skipped(shape, inFmts[i])) {
                         ASSERT_EQ(inFmts[i], cpu_str2fmt(actualInputMemoryFormat.c_str()));
+                    }
                 }
             }
             for (int i = 0; i < outFmts.size(); i++) {
                 const auto actualOutputMemoryFormat = getExecValue(ExecGraphInfoSerialization::OUTPUT_LAYOUTS);
                 const auto shape = node->get_output_shape(i);
 
-                if (!should_be_skipped(shape, outFmts[i]))
+                if (!should_be_skipped(shape, outFmts[i])) {
                     ASSERT_EQ(outFmts[i], cpu_str2fmt(actualOutputMemoryFormat.c_str()));
+                }
             }
             auto primType = getExecValue(ExecGraphInfoSerialization::IMPL_TYPE);
+
             ASSERT_EQ(selectedType, primType);
         }
     }

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.cpp
@@ -80,32 +80,24 @@ cpu_memory_format_t CPUTestsBase::cpu_str2fmt(const char *str) {
 }
 
 std::string CPUTestsBase::fmts2str(const std::vector<cpu_memory_format_t> &fmts) {
-    if (fmts.empty())
-        return {};
-
     std::string str;
-
     for (auto &fmt : fmts) {
-        (str += cpu_fmt2str(fmt)) += ",";
+        ((str += "cpu:") += cpu_fmt2str(fmt)) += ",";
     }
-    str.pop_back();
-    str += "(cpu)";
-
+    if (!str.empty()) {
+        str.pop_back();
+    }
     return str;
 }
 
 std::string CPUTestsBase::impls2str(const std::vector<std::string> &priority) {
-    if (priority.empty())
-        return {};
-
     std::string str;
-
     for (auto &impl : priority) {
-        (str += impl) += ",";
+        ((str += "cpu:") += impl) += ",";
     }
-    str.pop_back();
-    str += "(cpu)";
-
+    if (!str.empty()) {
+        str.pop_back();
+    }
     return str;
 }
 

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
@@ -24,6 +24,11 @@ namespace CPUTestUtils {
         acdeb,
         aBcde8b,
         aBcde16b,
+        // RNN layouts
+        abc,
+        bac,
+        abdc,
+        abdec,
 
         x = a,
         nc = ab,
@@ -34,7 +39,41 @@ namespace CPUTestUtils {
         ncdhw = abcde,
         nCdhw8c = aBcde8b,
         nCdhw16c = aBcde16b,
-        ndhwc = acdeb
+        ndhwc = acdeb,
+        // RNN layouts
+        tnc = abc,
+        /// 3D RNN data tensor in the format (batch, seq_length, input channels).
+        ntc = bac,
+        /// 4D RNN states tensor in the format (num_layers, num_directions,
+        /// batch, state channels).
+        ldnc = abcd,
+        /// 5D RNN weights tensor in the format (num_layers, num_directions,
+        ///  input_channels, num_gates, output_channels).
+        ///
+        ///  - For LSTM cells, the gates order is input, forget, candidate
+        ///    and output gate.
+        ///  - For GRU cells, the gates order is update, reset and output gate.
+        ldigo = abcde,
+        /// 5D RNN weights tensor in the format (num_layers, num_directions,
+        /// num_gates, output_channels, input_channels).
+        ///
+        ///  - For LSTM cells, the gates order is input, forget, candidate
+        ///    and output gate.
+        ///  - For GRU cells, the gates order is update, reset and output gate.
+        ldgoi = abdec,
+        /// 4D LSTM projection tensor in the format (num_layers, num_directions,
+        /// num_channels_in_hidden_state, num_channels_in_recurrent_projection).
+        ldio = abcd,
+        /// 4D LSTM projection tensor in the format (num_layers, num_directions,
+        /// num_channels_in_recurrent_projection, num_channels_in_hidden_state).
+        ldoi = abdc,
+        /// 4D RNN bias tensor in the format (num_layers, num_directions,
+        /// num_gates, output_channels).
+        ///
+        ///  - For LSTM cells, the gates order is input, forget, candidate
+        ///    and output gate.
+        ///  - For GRU cells, the gates order is update, reset and output gate.
+        ldgo = abcd,
     } cpu_memory_format_t;
 
     using CPUSpecificParams =  std::tuple<

--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/lstm_cell.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/lstm_cell.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <gtest/gtest.h>
 #include <tuple>
 #include <string>
 #include <vector>
@@ -26,7 +27,7 @@ using LSTMCellParams = typename std::tuple<
         std::string>;                      // Device name
 
 class LSTMCellTest : public testing::WithParamInterface<LSTMCellParams >,
-                    virtual public LayerTestsUtils::LayerTestsCommon {
+                     virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<LSTMCellParams> &obj);
 


### PR DESCRIPTION
### Details:
 - Enable bf16 RNN primitives. At the moment even if BF16 is forced LSTM is executed in FP32
 - Related oneDNN PR: [41](https://github.com/openvinotoolkit/oneDNN/pull/41)
### Tickets:
 - 32830
