### PR TITLE
Remove results ambiguity from DetectionOutput functional tests and ngraph ref impl

### DIFF
--- a/docs/ops/detection/DetectionOutput_1.md
+++ b/docs/ops/detection/DetectionOutput_1.md
@@ -10,6 +10,10 @@
 
 At each feature map cell, *DetectionOutput* predicts the offsets relative to the default box shapes in the cell, as well as the per-class scores that indicate the presence of a class instance in each of those boxes. Specifically, for each box out of k at a given location, *DetectionOutput* computes class scores and the four offsets relative to the original default box shape. This results in a total of \f$(c + 4)k\f$ filters that are applied around each location in the feature map, yielding \f$(c + 4)kmn\f$ outputs for a *m \* n* feature map.
 
+If multiple boxes have equal confidence scores while choosing `top_k` and `keep_top_k` boxes, following rules are applied:
+* if `decrease_label_id` is false: prioritize boxes with smaller input index in respect to `num_prior_boxes` order.
+* if `decrease_label_id` is true: prioritize boxes with smaller `class_id`. If the boxes have equal `class_id` values, prioritize input index in respect to `num_prior_boxes` order.
+
 **Attributes**:
 
 * *num_classes*
@@ -139,7 +143,6 @@ At each feature map cell, *DetectionOutput* predicts the offsets relative to the
 * **1**: 2D input tensor with box logits with shape `[N, num_prior_boxes * num_loc_classes * 4]` and type *T*. `num_loc_classes` is equal to `num_classes` when `share_location` is 0 or it's equal to 1 otherwise. Required.
 * **2**: 2D input tensor with class predictions with shape `[N, num_prior_boxes * num_classes]` and type *T*. Required.
 * **3**: 3D input tensor with proposals with shape `[priors_batch_size, 1, num_prior_boxes * prior_box_size]` or `[priors_batch_size, 2, num_prior_boxes * prior_box_size]`. `priors_batch_size` is either 1 or `N`. Size of the second dimension depends on `variance_encoded_in_target`. If `variance_encoded_in_target` is equal to 0, the second dimension equals to 2 and variance values are provided for each boxes coordinates. If `variance_encoded_in_target` is equal to 1, the second dimension equals to 1 and this tensor contains proposals boxes only. `prior_box_size` is equal to 4 when `normalized` is set to 1 or it's equal to 5 otherwise. Required.
- Required.
 * **4**: 2D input tensor with additional class predictions information described in the [article](https://arxiv.org/pdf/1711.06897.pdf). Its shape must be equal to `[N, num_prior_boxes * 2]`. Optional.
 * **5**: 2D input tensor with additional box predictions information described in the [article](https://arxiv.org/pdf/1711.06897.pdf). Its shape must be equal to first input tensor shape. Optional.
 

--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/detection_output.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/detection_output.hpp
@@ -63,7 +63,7 @@ class DetectionOutputLayerTest : public testing::WithParamInterface<DetectionOut
     ngraph::op::DetectionOutputAttrs attrs;
     std::vector<InferenceEngine::SizeVector> inShapes;
     void GenerateInputs() override;
-    void Compare(const std::vector<std::uint8_t> &expected, const InferenceEngine::Blob::Ptr &actual) override;
+    void Compare(const std::vector<std::vector<std::uint8_t>> &expected, const std::vector<InferenceEngine::Blob::Ptr> &actual) override;
   protected:
     void SetUp() override;
 };

--- a/inference-engine/tests/functional/shared_test_classes/src/single_layer/detection_output.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/single_layer/detection_output.cpp
@@ -90,7 +90,13 @@ void DetectionOutputLayerTest::GenerateInputs() {
     }
 }
 
-void DetectionOutputLayerTest::Compare(const std::vector<std::uint8_t> &expected, const InferenceEngine::Blob::Ptr &actual) {
+void DetectionOutputLayerTest::Compare(const std::vector<std::vector<std::uint8_t>> &expectedOutputs,
+                                       const std::vector<InferenceEngine::Blob::Ptr> &actualOutputs) {
+    ASSERT_EQ(expectedOutputs.size(), 1);
+    ASSERT_EQ(actualOutputs.size(), 1);
+
+    const auto& expected = expectedOutputs[0];
+    const auto& actual = actualOutputs[0];
     ASSERT_EQ(expected.size(), actual->byteSize());
 
     size_t expSize = 0;

--- a/ngraph/core/reference/include/ngraph/runtime/reference/detection_output.hpp
+++ b/ngraph/core/reference/include/ngraph/runtime/reference/detection_output.hpp
@@ -382,7 +382,8 @@ namespace ngraph
                 static bool SortScorePairDescend(const std::pair<dataType, T>& pair1,
                                                  const std::pair<dataType, T>& pair2)
                 {
-                    if (pair1.first != pair2.first) {
+                    if (pair1.first != pair2.first)
+                    {
                         return pair1.first > pair2.first;
                     }
                     return pair1.second < pair2.second;

--- a/ngraph/core/reference/include/ngraph/runtime/reference/detection_output.hpp
+++ b/ngraph/core/reference/include/ngraph/runtime/reference/detection_output.hpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "ngraph/op/detection_output.hpp"
@@ -381,7 +382,10 @@ namespace ngraph
                 static bool SortScorePairDescend(const std::pair<dataType, T>& pair1,
                                                  const std::pair<dataType, T>& pair2)
                 {
-                    return pair1.first > pair2.first;
+                    if (pair1.first != pair2.first) {
+                        return pair1.first > pair2.first;
+                    }
+                    return pair1.second < pair2.second;
                 }
 
                 void GetMaxScoreIndex(const std::vector<dataType>& scores,
@@ -397,7 +401,7 @@ namespace ngraph
                         }
                     }
 
-                    std::stable_sort(
+                    std::sort(
                         scoreIndexVec.begin(), scoreIndexVec.end(), SortScorePairDescend<int>);
 
                     if (topK > -1 && topK < scoreIndexVec.size())

--- a/ngraph/core/reference/include/ngraph/runtime/reference/detection_output.hpp
+++ b/ngraph/core/reference/include/ngraph/runtime/reference/detection_output.hpp
@@ -402,7 +402,7 @@ namespace ngraph
                         }
                     }
 
-                    std::sort(
+                    std::stable_sort(
                         scoreIndexVec.begin(), scoreIndexVec.end(), SortScorePairDescend<int>);
 
                     if (topK > -1 && topK < scoreIndexVec.size())


### PR DESCRIPTION
Changes introduced:

- in the func test another `Compare` function is overriden - after the change it's the one that Validate() function calls directly.
- ngraph reference implementation tweaked so that the sorting results are always the same. Previously it was possible to have 2 or more elements that the sorting algorithm deemed equal (same confidence score) but had different coordinates. Because of that and the fact that the ngraph ref uses unstable algorithms, there was no guarantee that the plugin and ref results would be the same even if both implementations are correct - equal elements could be outputted in different order. It could also happen that during the keepTopK stage different elements would be discarded from the results. This change eliminates these issues - however, plugins are required to use the same rule for sorting in order to guarantee passing functional tests.