### PR TITLE
[GNA] Remove HW version enforcement when exporting a model

### DIFF
--- a/inference-engine/src/gna_plugin/gna_model_serial.cpp
+++ b/inference-engine/src/gna_plugin/gna_model_serial.cpp
@@ -384,10 +384,17 @@ void GNAModelSerial::Export(void * basePointer, size_t gnaGraphSize, std::ostrea
         writeBits(layer.NumberOfOperands, os);
 
         for (uint32_t i = 0; i < layer.NumberOfOperands; i++) {
-            if (layer.Operands[i] == nullptr)
+            if (layer.Operands[i] == nullptr) {
                 writeBits(Gna2Tensor{}, os);
-            else
-                writeBits(getTensorWithProperOffset(*layer.Operands[i]), os);
+            } else {
+                Gna2Tensor tensor = getTensorWithProperOffset(*layer.Operands[i]);
+                // we need to remove legacy (up to & including GNA HW 2.0) CNN enforement during export
+                // to avoid issues when importing and running the model on newer GNA HW with libGNA 2.1.x.y
+                if (i == 1 && layer.Type == Gna2OperationTypeConvolution) {
+                    memset(tensor.Layout, 0, sizeof(tensor.Layout));
+                }
+                writeBits(tensor, os);
+            }
         }
 
         writeBits(layer.NumberOfParameters, os);

--- a/inference-engine/src/gna_plugin/gna_model_serial.cpp
+++ b/inference-engine/src/gna_plugin/gna_model_serial.cpp
@@ -390,7 +390,7 @@ void GNAModelSerial::Export(void * basePointer, size_t gnaGraphSize, std::ostrea
                 Gna2Tensor tensor = getTensorWithProperOffset(*layer.Operands[i]);
                 // we need to remove legacy (up to & including GNA HW 2.0) CNN enforement during export
                 // to avoid issues when importing and running the model on newer GNA HW with libGNA 2.1.x.y
-                if (i == 1 && layer.Type == Gna2OperationTypeConvolution) {
+                if (i == OutOpIdx && layer.Type == Gna2OperationTypeConvolution) {
                     memset(tensor.Layout, 0, sizeof(tensor.Layout));
                 }
                 writeBits(tensor, os);


### PR DESCRIPTION
### Details:
Remove legacy CCN enforcement tags during export on GNA HW <= 2.0 to avoid issues during import with libGNA 2.1 on newer HW.

### Tickets:
 - 49735