### PR TITLE
Removed thread_local from memory node

### DIFF
--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph.cpp
@@ -248,6 +248,7 @@ void MKLDNNGraph::Replicate(const CNNNetwork &network, const MKLDNNExtensionMana
         const MKLDNNNodePtr node(MKLDNNNode::factory().create(_layer, getEngine(), extMgr, weightsCache));
         graphNodes.push_back(node);
         layer2node[layer] = node;
+        node->graph = this;
 
         if (layer->params.count("originalLayersNames")) {
             node->originalLayers = layer->params["originalLayersNames"];
@@ -290,6 +291,8 @@ void MKLDNNGraph::Replicate(const CNNNetwork &network, const MKLDNNExtensionMana
         graphNodes.push_back(node);
         outputNodes.push_back(node);
 
+        node->graph = this;
+
         unused_data.erase(data);
     }
 
@@ -307,6 +310,7 @@ void MKLDNNGraph::Replicate(const CNNNetwork &network, const MKLDNNExtensionMana
         node->addEdge(edge);
         graphEdges.push_back(edge);
         graphNodes.push_back(node);
+        node->graph = this;
     }
 
     // Replicate input nodes

--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph.h
@@ -20,6 +20,7 @@
 
 namespace MKLDNNPlugin {
 class MKLDNNInferRequest;
+class MKLDNNMemoryNode;
 class MKLDNNGraph {
 public:
     typedef std::shared_ptr<MKLDNNGraph> Ptr;
@@ -181,6 +182,10 @@ protected:
 
     bool reuse_io_tensors = true;
 
+    friend class MKLDNNMemoryOutputNode;
+    friend class MKLDNNMemoryInputNode;
+    std::map<std::string, MKLDNNMemoryNode*> virtualEdge;
+
     MKLDNNMemoryPtr memWorkspace;
 
     std::map<std::string, MKLDNNNodePtr> inputNodes;
@@ -209,6 +214,7 @@ protected:
     void do_before(const std::string &dir, const MKLDNNNodePtr &node);
     void do_after(const std::string &dir, const MKLDNNNodePtr &node);
 
+    friend class MKLDNNMemoryNode;
     friend class MKLDNNInferRequest;
     friend class MKLDNNGraphlessInferRequest;
     friend InferenceEngine::CNNNetwork dump_graph_as_ie_net(const MKLDNNGraph &graph);

--- a/inference-engine/src/mkldnn_plugin/mkldnn_node.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_node.h
@@ -260,6 +260,7 @@ private:
     std::vector<mkldnn::memory::format_tag> outputLayouts;
 };
 
+class MKLDNNGraph;
 class MKLDNNNode : public InferenceEngine::details::no_copy {
 public:
     template<typename T, int N>
@@ -610,6 +611,8 @@ protected:
      */
     virtual std::vector<InferenceEngine::Precision> getOutputPrecisions() const;
 
+    MKLDNNGraph* graph = nullptr;
+
 private:
     std::vector<MKLDNNEdgeWeakPtr> parentEdges;
     std::vector<MKLDNNEdgeWeakPtr> childEdges;
@@ -671,7 +674,6 @@ struct MKLDNNNodeImpl : public MKLDNNNodeType {
 
 #define REG_MKLDNN_CONCAT3_(X, Y, Z) X ## Y ## Z
 #define REG_MKLDNN_CONCAT3(X, Y, Z) REG_MKLDNN_CONCAT3_(X, Y, Z)
-
 #define REG_MKLDNN_PRIM_FOR(__prim, __type)                                                 \
 static struct REG_MKLDNN_CONCAT3(Registrar4, __prim, __LINE__) {                            \
     REG_MKLDNN_CONCAT3(Registrar4, __prim, __LINE__)() {                                    \


### PR DESCRIPTION
Graph specific information was stored in thread local storage. As each graph instance was binded to some thread there was no problems. But if we want to use other executors (for example tbb based) it is better that graph should be thread independent. 