### PR TITLE
[MO] Fix EfficientDet conversion

### DIFF
--- a/model-optimizer/extensions/front/tf/AutomlEfficientDet.py
+++ b/model-optimizer/extensions/front/tf/AutomlEfficientDet.py
@@ -22,6 +22,7 @@ from mo.ops.result import Result
 
 class EfficientDet(FrontReplacementFromConfigFileGeneral):
     replacement_id = 'AutomlEfficientDet'
+    run_not_recursively = True
 
     def run_before(self):
         from extensions.front.ExpandDimsToUnsqueeze import ExpandDimsToUnsqueeze
@@ -57,10 +58,11 @@ class EfficientDet(FrontReplacementFromConfigFileGeneral):
         # which includes padding and resizing from the model
         preprocessing_input_node_id = replacement_descriptions['preprocessing_input_node']
         assert preprocessing_input_node_id in graph.nodes, 'The node with name "{}" is not found in the graph. This ' \
-                                                           'node should provide scaled image output and is specified' \
+                                                           'should be a last node before image normalization and is specified' \
                                                            ' in the json file.'.format(preprocessing_input_node_id)
         preprocessing_input_node = Node(graph, preprocessing_input_node_id)
-        preprocessing_input_node.in_port(0).get_connection().set_source(parameter_node.out_port(0))
+        consumer_node = preprocessing_input_node.out_port(0).get_connection().get_destination().node
+        consumer_node.in_port(0).get_connection().set_source(parameter_node.out_port(0))
 
         preprocessing_output_node_id = replacement_descriptions['preprocessing_output_node']
         assert preprocessing_output_node_id in graph.nodes, 'The node with name "{}" is not found in the graph. This ' \

--- a/model-optimizer/extensions/front/tf/automl_efficientdet.json
+++ b/model-optimizer/extensions/front/tf/automl_efficientdet.json
@@ -2,7 +2,7 @@
   {
     "id": "AutomlEfficientDet",
     "custom_attributes": {
-      "preprocessing_input_node": "convert_image",
+      "preprocessing_input_node": "strided_slice_1",
       "preprocessing_output_node": "truediv",
       "aspect_ratios": [1.0, 1.0, 1.4, 0.7, 0.7, 1.4],
       "variance": [1.0, 1.0, 1.0, 1.0],


### PR DESCRIPTION
### Details:

Old EfficientDet (there is `convert_image`):

<img src="https://user-images.githubusercontent.com/25801568/112949238-ac9ffd00-9141-11eb-8664-945e57eb59a9.png" height="256">

The latest EfficientDet (no `convert_image` anymore):

<img src="https://user-images.githubusercontent.com/25801568/112947705-cc362600-913f-11eb-897f-c1692dd6b283.png" height="256">

Proposed solution - identify preprocessing block not by it's first node but it's input node (which has stable name `strided_slice_1`) so MO will manage to convert both old and new versions. Accuracy validated with https://github.com/dkurt/openvino_efficientdet/pull/15

### Tickets:
 - resolves https://github.com/openvinotoolkit/openvino/issues/4997
