### PR TITLE
Incorrect ITT counter names fixed

### DIFF
--- a/ngraph/core/src/itt.hpp
+++ b/ngraph/core/src/itt.hpp
@@ -41,7 +41,7 @@ OV_ITT_DOMAIN(SIMPLE_ngraph_pass);
                                " is disabled!")
 #define NGRAPH_PASS_CALLBACK(matcher)
 #else
-#define NGRAPH_OP_SCOPE(region) OV_ITT_SCOPED_TASK(ngraph::itt::domains::ngraph_op, #region)
+#define NGRAPH_OP_SCOPE(region) OV_ITT_SCOPED_TASK(ngraph::itt::domains::ngraph_op, OV_PP_TOSTRING(region))
 #define NGRAPH_PASS_CALLBACK(matcher)
 #endif
 

--- a/ngraph/core/src/itt.hpp
+++ b/ngraph/core/src/itt.hpp
@@ -41,7 +41,8 @@ OV_ITT_DOMAIN(SIMPLE_ngraph_pass);
                                " is disabled!")
 #define NGRAPH_PASS_CALLBACK(matcher)
 #else
-#define NGRAPH_OP_SCOPE(region) OV_ITT_SCOPED_TASK(ngraph::itt::domains::ngraph_op, OV_PP_TOSTRING(region))
+#define NGRAPH_OP_SCOPE(region)                                                                    \
+    OV_ITT_SCOPED_TASK(ngraph::itt::domains::ngraph_op, OV_PP_TOSTRING(region))
 #define NGRAPH_PASS_CALLBACK(matcher)
 #endif
 

--- a/ngraph/core/src/pass/graph_rewrite.cpp
+++ b/ngraph/core/src/pass/graph_rewrite.cpp
@@ -67,9 +67,9 @@ namespace ngraph
                 static PerfCounters counters;
                 return counters;
             }
-        }
-    }
-}
+        } // namespace
+    }     // namespace pass
+} // namespace ngraph
 
 bool pass::GraphRewrite::run_on_function(shared_ptr<Function> f)
 {
@@ -410,8 +410,7 @@ void ngraph::pass::MatcherPass::register_matcher(const std::shared_ptr<ngraph::p
 
 bool ngraph::pass::MatcherPass::apply(std::shared_ptr<ngraph::Node> node)
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraph,
-                    pass::perf_counters()[get_type_info()]);
+    OV_ITT_SCOPED_TASK(itt::domains::nGraph, pass::perf_counters()[get_type_info()]);
     m_new_nodes.clear();
     if (m_handler)
         return m_handler(node);

--- a/ngraph/core/src/pass/graph_rewrite.cpp
+++ b/ngraph/core/src/pass/graph_rewrite.cpp
@@ -15,6 +15,7 @@
 #include "ngraph/log.hpp"
 #include "ngraph/op/util/sub_graph_base.hpp"
 #include "ngraph/pass/graph_rewrite.hpp"
+#include "perf_counters.hpp"
 
 using namespace std;
 using namespace ngraph;
@@ -54,6 +55,21 @@ using namespace ngraph;
 NGRAPH_RTTI_DEFINITION(ngraph::pass::GraphRewrite, "ngraph::pass::GraphRewrite", 0);
 
 NGRAPH_RTTI_DEFINITION(ngraph::pass::MatcherPass, "ngraph::pass::MatcherPass", 0);
+
+namespace ngraph
+{
+    namespace pass
+    {
+        namespace
+        {
+            PerfCounters& perf_counters()
+            {
+                static PerfCounters counters;
+                return counters;
+            }
+        }
+    }
+}
 
 bool pass::GraphRewrite::run_on_function(shared_ptr<Function> f)
 {
@@ -394,7 +410,8 @@ void ngraph::pass::MatcherPass::register_matcher(const std::shared_ptr<ngraph::p
 
 bool ngraph::pass::MatcherPass::apply(std::shared_ptr<ngraph::Node> node)
 {
-    OV_ITT_SCOPED_TASK(itt::domains::nGraph, "ngraph::pass::MatcherPass::apply");
+    OV_ITT_SCOPED_TASK(itt::domains::nGraph,
+                    pass::perf_counters()[get_type_info()]);
     m_new_nodes.clear();
     if (m_handler)
         return m_handler(node);

--- a/ngraph/core/src/pass/manager.cpp
+++ b/ngraph/core/src/pass/manager.cpp
@@ -20,6 +20,7 @@
 #include "ngraph/pass/pass.hpp"
 #include "ngraph/pass/visualize_tree.hpp"
 #include "ngraph/util.hpp"
+#include "perf_counters.hpp"
 
 using namespace std;
 using namespace ngraph;
@@ -30,32 +31,6 @@ namespace ngraph
     {
         namespace
         {
-            class PerfCounters
-            {
-                PerfCounters(PerfCounters const&) = delete;
-                PerfCounters& operator=(PerfCounters const&) = delete;
-
-            public:
-                PerfCounters() = default;
-
-                openvino::itt::handle_t operator[](::ngraph::Node::type_info_t const& type_inf)
-                {
-                    std::lock_guard<std::mutex> guard(m_mutex);
-                    auto it = m_counters.find(&type_inf);
-                    if (it != m_counters.end())
-                        return it->second;
-                    return m_counters[&type_inf] = openvino::itt::handle(type_inf.name);
-                }
-
-            private:
-                using key = ::ngraph::Node::type_info_t const*;
-                using value = openvino::itt::handle_t;
-                using counters_map = std::unordered_map<key, value>;
-
-                std::mutex m_mutex;
-                counters_map m_counters;
-            };
-
             PerfCounters& perf_counters()
             {
                 static PerfCounters counters;

--- a/ngraph/core/src/pass/perf_counters.cpp
+++ b/ngraph/core/src/pass/perf_counters.cpp
@@ -7,7 +7,8 @@ namespace ngraph
 {
     namespace pass
     {
-        openvino::itt::handle_t PerfCounters::operator[](::ngraph::Node::type_info_t const& type_inf)
+        openvino::itt::handle_t
+            PerfCounters::operator[](::ngraph::Node::type_info_t const& type_inf)
         {
             std::lock_guard<std::mutex> guard(m_mutex);
             auto it = m_counters.find(&type_inf);

--- a/ngraph/core/src/pass/perf_counters.cpp
+++ b/ngraph/core/src/pass/perf_counters.cpp
@@ -1,0 +1,19 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#include "perf_counters.hpp"
+
+namespace ngraph
+{
+    namespace pass
+    {
+        openvino::itt::handle_t PerfCounters::operator[](::ngraph::Node::type_info_t const& type_inf)
+        {
+            std::lock_guard<std::mutex> guard(m_mutex);
+            auto it = m_counters.find(&type_inf);
+            if (it != m_counters.end())
+                return it->second;
+            return m_counters[&type_inf] = openvino::itt::handle(type_inf.name);
+        }
+    }
+}

--- a/ngraph/core/src/pass/perf_counters.hpp
+++ b/ngraph/core/src/pass/perf_counters.hpp
@@ -1,0 +1,34 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+#include <mutex>
+#include <unordered_map>
+
+#include <itt.hpp>
+#include <ngraph/node.hpp>
+
+namespace ngraph
+{
+    namespace pass
+    {
+        class PerfCounters
+        {
+            PerfCounters(PerfCounters const&) = delete;
+            PerfCounters& operator=(PerfCounters const&) = delete;
+
+        public:
+            PerfCounters() = default;
+
+            openvino::itt::handle_t operator[](::ngraph::Node::type_info_t const& type_inf);
+
+        private:
+            using key = ::ngraph::Node::type_info_t const*;
+            using value = openvino::itt::handle_t;
+            using counters_map = std::unordered_map<key, value>;
+
+            std::mutex m_mutex;
+            counters_map m_counters;
+        };
+    }
+}


### PR DESCRIPTION
### Details:
 - Itt counetr nmes like "OV_PP_CAT3(evaluate_covert_out, _, f32)" are fixed.
 - MatcherPass names fixed. Names like "ngraph::pass::MatcherPass::apply" wasn't entirely clear.
