### PR TITLE
Add python3-gi-cairo dependency for DL Streamer on Ubuntu 20

### DIFF
--- a/scripts/install_dependencies/install_openvino_dependencies.sh
+++ b/scripts/install_dependencies/install_openvino_dependencies.sh
@@ -184,6 +184,7 @@ elif [ "$os" == "ubuntu20.04" ] ; then
         libopenexr24
         libtag-extras1
         python3-gi
+        python3-gi-cairo
         python3-gst-1.0
         vainfo
     )


### PR DESCRIPTION
### Details:
 - `pip check` produces error message `pygobject 3.36.0 requires pycairo, which is not installed` on Ubuntu 20 OpenVINO Docker images (Ubuntu 18 is not affected)
 - The solution is to install `python3-gi-cairo` apt package which provides Cairo python bindings for the GObject library  
 (`pygobject` comes from the `python3-gi` package)

### Tickets:
 - Internal 48358
