### PR TITLE
[IE clDNN] Add order index param in GetOptimalLocalWorkGroupSizes.

### DIFF
--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/common/kernel_selector_utils.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/common/kernel_selector_utils.h
@@ -24,6 +24,6 @@ bool UpdateWeightsParams(weight_bias_params& newParams,
                          bool rotate = false);
 JitConstants GetTensorFriendlyWorkGroupsJit(const DataTensor& t);
 std::vector<size_t> GetTensorFriendlyWorkGroups(const DataTensor& t);
-std::vector<size_t> GetOptimalLocalWorkGroupSizes(std::vector<size_t> gws, const EngineInfo& info);
+std::vector<size_t> GetOptimalLocalWorkGroupSizes(std::vector<size_t> gws, const EngineInfo& info, std::vector<size_t> order = {});
 bool CheckInputsOutputNoPitchSameDims(const base_params& params);
 }  // namespace kernel_selector


### PR DESCRIPTION
lws shape can effect the performance depends on DataLayout.
Add paramter when creating lws for the gws order.

Signed-off-by: hyunback <hyunback.kim@intel.com>
