### PR TITLE
[2021.3] Fix missed POT content for wheels

### DIFF
--- a/inference-engine/ie_bridges/python/wheel/meta/openvino-dev.setup.cfg
+++ b/inference-engine/ie_bridges/python/wheel/meta/openvino-dev.setup.cfg
@@ -9,6 +9,7 @@ py_modules =
 
 [options.package_data]
 	mo = *.txt
+	compression.configs.hardware = *.json
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
### Details:
 - *add missed POT configs from compression.configs.hardware*
merge of https://github.com/openvinotoolkit/openvino/pull/5044  for 2021.3


