### PR TITLE
setupvars and demos: Fix getting openvino dir on macOS 10.15 with zsh shell

### DIFF
--- a/inference-engine/samples/build_samples.sh
+++ b/inference-engine/samples/build_samples.sh
@@ -14,7 +14,7 @@ error() {
 }
 trap 'error ${LINENO}' ERR
 
-SAMPLES_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SAMPLES_PATH="$( cd "$( dirname "${BASH_SOURCE[0]-$0}" )" && pwd )"
 
 printf "\nSetting environment variables for building samples...\n"
 

--- a/model-optimizer/install_prerequisites/install_prerequisites.sh
+++ b/model-optimizer/install_prerequisites/install_prerequisites.sh
@@ -35,7 +35,7 @@ for ((i=1;i <= $#;i++)) {
         esac
 }
 
-SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]-$0}" )" && pwd )"
 
 if [[ -f /etc/centos-release ]]; then
     DISTRO="centos"

--- a/scripts/demo/demo_benchmark_app.sh
+++ b/scripts/demo/demo_benchmark_app.sh
@@ -3,7 +3,7 @@
 # Copyright (C) 2018-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]-$0}" )" && pwd )"
 
 . "$ROOT_DIR/utils.sh"
 

--- a/scripts/demo/demo_security_barrier_camera.sh
+++ b/scripts/demo/demo_security_barrier_camera.sh
@@ -3,7 +3,7 @@
 # Copyright (C) 2018-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]-$0}" )" && pwd )"
 
 . "$ROOT_DIR/utils.sh"
 

--- a/scripts/demo/demo_squeezenet_download_convert_run.sh
+++ b/scripts/demo/demo_squeezenet_download_convert_run.sh
@@ -3,7 +3,7 @@
 # Copyright (C) 2018-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]-$0}" )" && pwd )"
 
 . "$ROOT_DIR/utils.sh"
 

--- a/scripts/install_dependencies/install_NEO_OCL_driver.sh
+++ b/scripts/install_dependencies/install_NEO_OCL_driver.sh
@@ -19,7 +19,7 @@ CENTOS_MINOR=
 RHEL_VERSION=
 UBUNTU_VERSION=
 DISTRO=
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]-$0}" )" >/dev/null 2>&1 && pwd )"
 INSTALL_DRIVER_VERSION='19.41.14441'
 AVAILABLE_DRIVERS=("19.41.14441" "20.35.17767")
 

--- a/scripts/install_dependencies/install_openvino_dependencies.sh
+++ b/scripts/install_dependencies/install_openvino_dependencies.sh
@@ -59,7 +59,7 @@ if [ -n "$selftest" ] ; then
             echo "||"
             echo "|| Test $image / '$opt'"
             echo "||"
-            SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+            SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]-$0}" )" >/dev/null 2>&1 && pwd )"
             docker run -it --rm \
                 --volume ${SCRIPT_DIR}:/scripts:ro,Z  \
                 --volume yum-cache:/var/cache/yum \

--- a/scripts/setupvars/setupvars.sh
+++ b/scripts/setupvars/setupvars.sh
@@ -3,7 +3,7 @@
 # Copyright (C) 2018-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]-$0}" )" >/dev/null 2>&1 && pwd )"
 BASE_DIR="$( dirname "$SCRIPT_DIR" )"
 
 INSTALLDIR="${BASE_DIR}"


### PR DESCRIPTION
### Details:
zsh shell is default shell on macOS 10.15. $BASH_SOURCE variable is not defiled in zsh and as a result $INTEL_OPENVINO_DIR is set incorrectly.
$0 can be used instead of $BASH_SOURCE in zsh.

### Tickets:
 - 52128
 - 52129
