### PR TITLE
Fix building MKLDNNPlugin when the source path contains spaces

### DIFF
--- a/cmake/developer_package/cross_compile/cross_compiled_disp_gen.cmake
+++ b/cmake/developer_package/cross_compile/cross_compiled_disp_gen.cmake
@@ -10,7 +10,7 @@
 #   XARCH_FUNC_NAME -- name of function to dispatch
 #   XARCH_NAMESPACES -- full namespace used to keep ODR
 #   XARCH_DISP_FILE -- dispatcher file name to generate
-#   XARCH_SET -- set of ARCH supported by dispatcher. space delimited
+#   XARCH_SET -- set of ARCH supported by dispatcher. semicolon-delimited
 #
 # =================================================================
 
@@ -24,7 +24,6 @@ function(_generate_dispatcher)
     _find_signature_in_file(${XARCH_API_HEADER} ${XARCH_FUNC_NAME} SIGNATURE)
     _generate_call_line_from_signature("${SIGNATURE}" CALL_LINE)
 
-    string(REPLACE " " ";" XARCH_SET "${XARCH_SET}")
     string(REPLACE "::" ";" XARCH_NAMESPACES "${XARCH_NAMESPACES}")
 
     list(GET XARCH_NAMESPACES -1 XARCH_CURRENT_NAMESPACE)


### PR DESCRIPTION
The key changes are:

* Using `VERBATIM` to ensure CMake property passes command-line arguments to child processes.

* Using the `INCLUDE_DIRECTORIES` property instead of `COMPILE_FLAGS` to add include directories, because `COMPILE_FLAGS` are treated as space-separated values. (A small side benefit is that this doesn't rely on `-I` being the include directory option.)

In addition, some changes had to be made in order to preserve behavior:

* The `_GEN_ARGS_LIST` variable has to be inlined, because `ARCH_SET` is a list, and therefore the `-DXARCH_SET=...` argument gets split into multiple arguments (this happens to work by coincidence without `VERBATIM`). IMO, the code looks better this way anyway.

* It's no longer necessary to replace spaces in `XARCH_SET` in `cross_compiled_disp_gen.cmake`, because those spaces were an artifact of how the CMake arguments were passed before.