### PR TITLE
Fixed extracting TF models with string constants

### DIFF
--- a/model-optimizer/mo/front/tf/extractors/utils.py
+++ b/model-optimizer/mo/front/tf/extractors/utils.py
@@ -55,6 +55,8 @@ def tf_tensor_content(tf_dtype, shape, pb_tensor):
         raise Error("Data type is unsupported: {}. " +
                     refer_to_faq_msg(50), tf_dtype)
 
+    decode_err_msg = 'Failed to parse a tensor with Unicode characters. Note that Inference Engine does not support ' \
+                     'string literals, so the string constant should be eliminated from the graph.'
     if pb_tensor.tensor_content:
         value = np.array(np.frombuffer(pb_tensor.tensor_content, type_helper[0]))
     else:
@@ -65,23 +67,17 @@ def tf_tensor_content(tf_dtype, shape, pb_tensor):
             try:
                 value = np.array(type_helper[1](pb_tensor), dtype=type_helper[0])
             except UnicodeDecodeError:
-                log.error(
-                    'Failed to parse a tensor with Unicode characters. Note that Inference Engine does not support '
-                    'string literals, so the string constant should be eliminated from the graph.',
-                    extra={'is_warning': True})
+                log.error(decode_err_msg, extra={'is_warning': True})
                 value = np.array(type_helper[1](pb_tensor))
 
     if len(shape) == 0 or shape.prod() == 0:
         if len(value) == 1:
             # return scalar if shape is [] otherwise broadcast according to shape
             try:
-                value = np.array(type_helper[1](pb_tensor), dtype=type_helper[0])
+                return np.array(value[0], dtype=type_helper[0])
             except UnicodeDecodeError:
-                log.error(
-                    'Failed to parse a tensor with Unicode characters. Note that Inference Engine does not support '
-                    'string literals, so the string constant should be eliminated from the graph.',
-                    extra={'is_warning': True})
-                value = np.array(type_helper[1](pb_tensor))
+                log.error(decode_err_msg, extra={'is_warning': True})
+                return np.array(value[0])
         else:
             # no shape, return value as is
             return value

--- a/model-optimizer/mo/front/tf/extractors/utils.py
+++ b/model-optimizer/mo/front/tf/extractors/utils.py
@@ -74,7 +74,14 @@ def tf_tensor_content(tf_dtype, shape, pb_tensor):
     if len(shape) == 0 or shape.prod() == 0:
         if len(value) == 1:
             # return scalar if shape is [] otherwise broadcast according to shape
-            return np.array(value[0], dtype=type_helper[0])
+            try:
+                value = np.array(type_helper[1](pb_tensor), dtype=type_helper[0])
+            except UnicodeDecodeError:
+                log.error(
+                    'Failed to parse a tensor with Unicode characters. Note that Inference Engine does not support '
+                    'string literals, so the string constant should be eliminated from the graph.',
+                    extra={'is_warning': True})
+                value = np.array(type_helper[1](pb_tensor))
         else:
             # no shape, return value as is
             return value

--- a/model-optimizer/mo/front/tf/extractors/utils_test.py
+++ b/model-optimizer/mo/front/tf/extractors/utils_test.py
@@ -199,3 +199,15 @@ class TensorContentParsing(unittest.TestCase):
             self.assertEqual([warning_message], cm.output)
             self.assertEqual(ref_val, result)
 
+    def test_str_decode_list(self):
+        pb_tensor = PB({
+            'dtype': 7,
+            'string_val': [b'\377\330\377\377\330\377'],
+        })
+        shape = int64_array([])
+        warning_message = 'ERROR:root:Failed to parse a tensor with Unicode characters. Note that Inference Engine ' \
+                          'does not support string literals, so the string constant should be eliminated from the ' \
+                          'graph.'
+        with self.assertLogs(log.getLogger(), level="ERROR") as cm:
+            result = tf_tensor_content(pb_tensor.dtype, shape, pb_tensor)
+            self.assertEqual([warning_message, warning_message], cm.output)


### PR DESCRIPTION
Root cause analysis: After merge of https://github.com/openvinotoolkit/openvino/pull/3573 the MO starts to read operations located in the sub-graphs of the main model (While operation body). There is an operation inside containing string constant value. MO fails to read this constant value because it tries to convert it to numpy string and fails.

Solution: Do not try to convert the value to numpy string and use it as is. Similar fix was done for the issue before but this particular line of code was not updated.

Ticket: 47405

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR: N/A
* [x]  Transformation preserves original framework node names: N/A

Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests: N/A
* [x]  Model Optimizer IR Reader check: done manually

Documentation:
* [x]  Supported frameworks operations list: N/A no new op enabled
* [x]  Guide on how to convert the **public** model: the instruction exists already
* [x]  User guide update: N/A the instruction exists already