### PR TITLE
fix bug: assert is keyword, not function

### DIFF
--- a/model-optimizer/extensions/middle/MakeKaldiConstReshapable.py
+++ b/model-optimizer/extensions/middle/MakeKaldiConstReshapable.py
@@ -98,7 +98,7 @@ class MakeKaldiConstReshapable(MiddleReplacementPattern):
         # check that all Parameters have the same batch
         for p in params:
             assert p.shape[0] == batch, \
-                   "Parameter {} have batch different from the {}".format(p.soft_get('name', p.id),
+                   "Parameter {} has batch different from the {}".format(p.soft_get('name', p.id),
                                                                           params[0].soft_get('name', params[0].id))
 
         # make constants for initialization of ReadValue reshapable

--- a/model-optimizer/extensions/middle/MakeKaldiConstReshapable.py
+++ b/model-optimizer/extensions/middle/MakeKaldiConstReshapable.py
@@ -97,9 +97,9 @@ class MakeKaldiConstReshapable(MiddleReplacementPattern):
 
         # check that all Parameters have the same batch
         for p in params:
-            assert(p.shape[0] == batch,
+            assert p.shape[0] == batch, \
                    "Parameter {} have batch different from the {}".format(p.soft_get('name', p.id),
-                                                                          params[0].soft_get('name', params[0].id)))
+                                                                          params[0].soft_get('name', params[0].id))
 
         # make constants for initialization of ReadValue reshapable
         for read in graph.get_op_nodes(op='ReadValue'):


### PR DESCRIPTION
Root cause analysis: assert is keyword and shouldn't be used with brackets (brackets create tuple and send as 1 argument instead of sending 2)

Solution: remove brackets 

Ticket: 52577


Code:
* [x]  Comments **Not applicable**
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR **Not applicable**
* [x]  Transformation preserves original framework node names **Not applicable**


Validation:
* [x]  Unit tests **Not applicable**
* [x]  Framework operation tests **Not applicable**
* [x]  Transformation tests **Not applicable**
* [x]  Model Optimizer IR Reader check **Not applicable**

Documentation:
* [x]  Supported frameworks operations list **Not applicable**
* [x]  Guide on how to convert the **public** model **Not applicable**
* [x]  User guide update **Not applicable**
