### PR TITLE
[GNA] Add basic low precision support for more layer types

### DIFF
--- a/inference-engine/src/gna_plugin/backend/make_pwl.cpp
+++ b/inference-engine/src/gna_plugin/backend/make_pwl.cpp
@@ -21,6 +21,8 @@ void make_gna_pwl(const DnnActivation  fun,
                   const bool low_precision,
                   std::vector<gna_pwl_segment_t> &gna_pwl) {
     pwl_gna_slope_scale_t s;
+    int16_t y_min = low_precision ? INT8_MIN : INT16_MIN;
+    int16_t y_max = low_precision ? INT8_MAX : INT16_MAX;
     uint32_t pwl_size = static_cast<int32_t>(pwl.size());
     gnalog() << "make_gna_pwl\n";
     gnalog() << "   in_scale  " << in_scale << "\n";
@@ -130,8 +132,8 @@ void make_gna_pwl(const DnnActivation  fun,
             }
             // insert extra segment for xvalues > u_bound
             gna_pwl[n_segments - 1].xBase =
-                ((uint32_t)(in_scale * (INT16_MAX/out_scale - pwl[pwl_size - 2].b) / pwl[pwl_size - 2].m)) & XBASEMASK;
-            gna_pwl[n_segments - 1].yBase = INT16_MAX;
+                ((uint32_t)(in_scale * (y_max/out_scale - pwl[pwl_size - 2].b) / pwl[pwl_size - 2].m)) & XBASEMASK;
+            gna_pwl[n_segments - 1].yBase = y_max;
             gna_pwl[n_segments - 1].slope = 0;
 
             gnalog() << (gna_pwl[n_segments - 1].xBase / in_scale)
@@ -146,7 +148,7 @@ void make_gna_pwl(const DnnActivation  fun,
             // insert extra segment for x values < l_bound
             gna_pwl[0].xBase = static_cast<int32_t> (INT32_MIN & XBASEMASK);  // zero out the 2 lsb
             gnalog() << "=========================== Log Segments ===========================\n";
-            gna_pwl[0].yBase = gna_pwl[1].yBase = INT16_MIN;
+            gna_pwl[0].yBase = gna_pwl[1].yBase = y_min;
             gna_pwl[1].xBase = (static_cast<int32_t> (1 + ~XBASEMASK));  // smallest representable value
             gna_pwl[0].slope = 0;
 
@@ -188,7 +190,7 @@ void make_gna_pwl(const DnnActivation  fun,
                 gnalog() << "=========================== NegHalfLog Segments ===========================\n";
             else
                 gnalog() << "=========================== NegLog Segments ===========================\n";
-            gna_pwl[0].yBase = gna_pwl[1].yBase = INT16_MAX;
+            gna_pwl[0].yBase = gna_pwl[1].yBase = y_max;
             gna_pwl[1].xBase = (static_cast<int32_t> (1 + ~XBASEMASK));  // smallest representable value
             gna_pwl[0].slope = 0;
 
@@ -231,8 +233,8 @@ void make_gna_pwl(const DnnActivation  fun,
                 gnalog() << "=========================== LeakyReLU Segments ======================\n";
             int32_t x_lower = INT32_MIN;
             int32_t x_upper = INT32_MAX;
-            int16_t y_lower = low_precision ? INT8_MIN : INT16_MIN;
-            int16_t y_upper = INT16_MAX;
+            int16_t y_lower = y_min;
+            int16_t y_upper = y_max;
             if (fun.fqParams.set) {
                 x_lower = FLOAT_TO_INT32(*fun.fqParams.input_low * 1.25 * in_scale);
                 x_upper = FLOAT_TO_INT32(*fun.fqParams.input_high * 1.25 * in_scale);
@@ -314,8 +316,8 @@ void make_gna_pwl(const DnnActivation  fun,
         case kActFakeQuantize: {
             int32_t x_lower = INT32_MIN;
             int32_t x_upper = INT32_MAX;
-            int16_t y_lower = INT16_MIN;
-            int16_t y_upper = INT16_MAX;
+            int16_t y_lower = y_min;
+            int16_t y_upper = y_max;
             if (fun == kActFakeQuantize && fun.fqParams.set) {
                 x_lower = *fun.fqParams.input_low * in_scale;
                 x_upper = *fun.fqParams.input_high * in_scale;
@@ -383,7 +385,7 @@ void make_gna_pwl(const DnnActivation  fun,
         }
         case kActAbs: {
             int32_t x_upper = INT32_MAX;
-            int16_t y_upper = INT16_MAX;
+            int16_t y_upper = y_max;
             int32_t i = 0;
 
             auto n_segments = 2;
@@ -392,11 +394,11 @@ void make_gna_pwl(const DnnActivation  fun,
             if (x_upper > y_upper * in_scale / out_scale) x_upper = FLOAT_TO_INT32(y_upper * in_scale / out_scale);
 
             gnalog() << "=========================== Abs Segments ===========================\n";
-            if (y_upper == INT16_MAX) {  // saturation at ends - need one more segment
+            if (y_upper == y_max) {  // saturation at ends - need one more segment
                 n_segments += 1;
                 gna_pwl.resize(n_segments);
                 gna_pwl[i].xBase = INT32_MIN & XBASEMASK;  // zero out the 2 lsb
-                gna_pwl[i].yBase = INT16_MAX;
+                gna_pwl[i].yBase = y_max;
                 gna_pwl[i].slope = 0;
                 i++;
             } else {
@@ -430,8 +432,8 @@ void make_gna_pwl(const DnnActivation  fun,
                 float pow_offset = fun.args.pow.offset;
                 int32_t x_lower = INT32_MIN;
                 int32_t x_upper = INT32_MAX;
-                int16_t y_lower = INT16_MIN;
-                int16_t y_upper = INT16_MAX;
+                int16_t y_lower = y_min;
+                int16_t y_upper = y_max;
                 auto n_segments = 2;
 
                 if (pow_exponent == 0.0f) {
@@ -472,27 +474,27 @@ void make_gna_pwl(const DnnActivation  fun,
                     int32_t y_upper_new = FLOAT_TO_INT32((y_upper / out_scale + pow_offset) * out_scale);
                     y_lower = static_cast<int16_t>(y_lower_new);
                     y_upper = static_cast<int16_t>(y_upper_new);
-                    if (y_lower_new < INT16_MIN) {
-                        int32_t offset_lower = abs(y_lower_new - INT16_MIN) / out_scale * in_scale;
-                        y_lower = INT16_MIN;
+                    if (y_lower_new < y_min) {
+                        int32_t offset_lower = abs(y_lower_new - y_min) / out_scale * in_scale;
+                        y_lower = y_min;
                         x_lower = x_lower + offset_lower;
                     }
 
-                    if (y_lower_new > INT16_MAX) {
-                        int32_t offset_lower = (y_lower_new - INT16_MAX) / out_scale * in_scale;
-                        y_lower = INT16_MAX;
+                    if (y_lower_new > y_max) {
+                        int32_t offset_lower = (y_lower_new - y_max) / out_scale * in_scale;
+                        y_lower = y_max;
                         x_upper = x_upper + offset_lower;
                     }
 
-                    if (y_upper_new > INT16_MAX) {
-                        int32_t offset_upper = (y_upper_new - INT16_MAX) / out_scale * in_scale;
-                        y_upper = INT16_MAX;
+                    if (y_upper_new > y_max) {
+                        int32_t offset_upper = (y_upper_new - y_max) / out_scale * in_scale;
+                        y_upper = y_max;
                         x_upper = x_upper - offset_upper;
                     }
 
-                    if (y_upper_new < INT16_MIN) {
-                        int32_t offset_upper = abs(y_upper_new - INT16_MAX) / out_scale * in_scale;
-                        y_upper = INT16_MIN;
+                    if (y_upper_new < y_min) {
+                        int32_t offset_upper = abs(y_upper_new - y_max) / out_scale * in_scale;
+                        y_upper = y_min;
                         x_lower = x_lower - offset_upper;
                     }
                 }
@@ -567,8 +569,8 @@ void make_gna_pwl(const DnnActivation  fun,
                 }
                 // insert extra segment for xvalues > u_bound
                 gna_pwl[n_segments - 1].xBase =
-                    ((uint32_t)(in_scale * (INT16_MAX / out_scale - pwl[pwl_size - 2].b) / pwl[pwl_size - 2].m)) & XBASEMASK;
-                gna_pwl[n_segments - 1].yBase = INT16_MAX;
+                    ((uint32_t)(in_scale * (y_max / out_scale - pwl[pwl_size - 2].b) / pwl[pwl_size - 2].m)) & XBASEMASK;
+                gna_pwl[n_segments - 1].yBase = y_max;
                 gna_pwl[n_segments - 1].slope = 0;
 
                 gnalog() << (gna_pwl[n_segments - 1].xBase / in_scale)

--- a/inference-engine/src/gna_plugin/backend/make_pwl.cpp
+++ b/inference-engine/src/gna_plugin/backend/make_pwl.cpp
@@ -21,8 +21,8 @@ void make_gna_pwl(const DnnActivation  fun,
                   const bool low_precision,
                   std::vector<gna_pwl_segment_t> &gna_pwl) {
     pwl_gna_slope_scale_t s;
-    int16_t y_min = low_precision ? INT8_MIN : INT16_MIN;
-    int16_t y_max = low_precision ? INT8_MAX : INT16_MAX;
+    const int16_t y_min = low_precision ? INT8_MIN : INT16_MIN;
+    const int16_t y_max = low_precision ? INT8_MAX : INT16_MAX;
     uint32_t pwl_size = static_cast<int32_t>(pwl.size());
     gnalog() << "make_gna_pwl\n";
     gnalog() << "   in_scale  " << in_scale << "\n";
@@ -37,7 +37,7 @@ void make_gna_pwl(const DnnActivation  fun,
             gna_pwl[0].xBase = static_cast<int32_t> (INT32_MIN & XBASEMASK);  // zero out the 2 lsb
             if (fun == kActSigmoid) {
                 gnalog() <<  "=========================== Sigmoid Segments ===========================\n";
-                auto minVal = fun.fqParams.set? FLOAT_TO_INT16(*fun.fqParams.input_low * out_scale): 0;
+                auto minVal = fun.fqParams.set ? FLOAT_TO_INT16(*fun.fqParams.input_low * out_scale) : 0;
                 gna_pwl[0].yBase = gna_pwl[1].yBase = minVal;
                 gna_pwl[1].xBase = (static_cast<int32_t> (in_scale * (-pwl[0].b / pwl[0].m))) & XBASEMASK;
             } else if (fun == kActTanh) {

--- a/inference-engine/src/gna_plugin/frontend/scale_factor_calc.hpp
+++ b/inference-engine/src/gna_plugin/frontend/scale_factor_calc.hpp
@@ -264,7 +264,7 @@ class ScaleFactorPerLayer<InferenceEngine::CNNLayer *> {
 
             auto input_min_value = static_cast<double>(std::numeric_limits<int32_t>::min());
             auto input_max_value = static_cast<double>(std::numeric_limits<int32_t>::max());
-            auto output_max_value = static_cast<double>(std::numeric_limits<int16_t>::max());
+            auto output_max_value = static_cast<double>((inputsSize == 2) ? std::numeric_limits<int16_t>::max() : std::numeric_limits<int8_t>::max());
 
             auto x_min = fp32eq(fmod(powerLayer->power, 1.0), 0) ? input_min_value / quantizedParams->_src_quant.GetScale() : 0.0;
             x_min = std::max(x_min, -pow_domain);

--- a/inference-engine/src/gna_plugin/gna_graph_compiler.cpp
+++ b/inference-engine/src/gna_plugin/gna_graph_compiler.cpp
@@ -694,10 +694,12 @@ void GNAGraphCompiler::PowerPrimitive(InferenceEngine::CNNLayerPtr layer) {
 
     auto outputs = *layer->outData.begin();
     auto reshaped_dims = Get2DReshapedData(input, 8)->getDims();
+    uint32_t noOfInputsDivisor = gnaFlags->input_low_precision ?
+        GNALimitations::noOfInputsLowPrecDivisor : GNALimitations::noOfInputsDivisor;
     uint32_t num_rows_in = reshaped_dims[1];
     uint32_t num_columns_in = reshaped_dims[0];
     uint32_t num_rows_out = num_rows_in;
-    uint32_t num_padding = ALIGN(num_rows_in, 8) - num_rows_in;
+    uint32_t num_padding = ALIGN(num_rows_in, noOfInputsDivisor) - num_rows_in;
 
     size_t num_data_bytes_out = InferenceEngine::details::product(begin(outputs->getDims()), end(outputs->getDims()))
         * outputs->getPrecision().size();
@@ -720,8 +722,8 @@ void GNAGraphCompiler::PowerPrimitive(InferenceEngine::CNNLayerPtr layer) {
             input->getPrecision().size(),
             outputs->getPrecision().size(),
             // TODO: only fp32 and Int16 tested
-            quantized == nullptr ? input->getPrecision().size() : 2,
-            quantized == nullptr ? input->getPrecision().size() : 4,
+            quantized == nullptr ? input->getPrecision().size() : (!gnaFlags->input_low_precision ? 2 : 1),
+            quantized == nullptr ? input->getPrecision().size() : (!gnaFlags->input_low_precision ? 4 : 1),
             quantized == nullptr ? 1 : quantized->_weights_quant.GetScale(),
             quantized == nullptr ? 1 : quantized->_dst_quant.GetScale(),
             ptr_inputs,
@@ -739,12 +741,21 @@ void GNAGraphCompiler::PowerPrimitive(InferenceEngine::CNNLayerPtr layer) {
             gnamem->readonly().push_value(ptr_biases, power.offset, num_rows_out, 64);
         } else {
             IE_ASSERT(quantized != nullptr);
-            auto quantizedScale = FLOAT_TO_INT16(std::min(quantized->_weights_quant.GetScale() * power.scale,
-                static_cast<float>(INT16_MAX)));
-            auto quantizedOffset = FLOAT_TO_INT32(std::min(quantized->_dst_quant.GetScale() * power.offset,
-                static_cast<float>(INT32_MAX)));
-            gnamem->readonly().push_value<int16_t>(ptr_weights, quantizedScale, num_rows_out, 64);
-            gnamem->readonly().push_value<int32_t>(ptr_biases, quantizedOffset, num_rows_out, 64);
+            if (!gnaFlags->input_low_precision) {
+                auto quantizedScale = FLOAT_TO_INT16(std::min(quantized->_weights_quant.GetScale() * power.scale,
+                    static_cast<float>(INT16_MAX)));
+                auto quantizedOffset = FLOAT_TO_INT32(std::min(quantized->_dst_quant.GetScale() * power.offset,
+                    static_cast<float>(INT32_MAX)));
+                gnamem->readonly().push_value<int16_t>(ptr_weights, quantizedScale, num_rows_out, 64);
+                gnamem->readonly().push_value<int32_t>(ptr_biases, quantizedOffset, num_rows_out, 64);
+            } else {
+                auto quantizedScale = FLOAT_TO_INT8(std::min(quantized->_weights_quant.GetScale() * power.scale,
+                    static_cast<float>(INT8_MAX)));
+                auto quantizedOffset = FLOAT_TO_INT8(std::min(quantized->_dst_quant.GetScale() * power.offset,
+                    static_cast<float>(INT8_MAX)));
+                gnamem->readonly().push_value<int8_t>(ptr_weights, quantizedScale, num_rows_out, 64);
+                gnamem->readonly().push_value<int8_t>(ptr_biases, quantizedOffset, num_rows_out, 64);
+            }
         }
     } else {
         //use PWL to calculate power
@@ -1041,10 +1052,12 @@ void GNAGraphCompiler::CropPrimitive(InferenceEngine::CNNLayerPtr layer) {
             << axis.size() << ".";
     }
 
-
     auto quantized = InferenceEngine::getInjectedData<QuantizedLayerParams>(layer);
     size_t cropOffset = offset.front() * cropLayer->precision.size();
     size_t cropOutputSize = dim.front() * cropLayer->precision.size();
+    uint32_t noOfInputsDivisor = gnaFlags->input_low_precision ?
+        GNALimitations::noOfInputsLowPrecDivisor : GNALimitations::noOfInputsDivisor;
+
     // fix for crop on tensor dim > 2D
     for (int n = axis[0]+1; n < cropLayer->dim.size(); n++) {
         cropOffset *= cropLayer->dim[n];
@@ -1088,7 +1101,7 @@ void GNAGraphCompiler::CropPrimitive(InferenceEngine::CNNLayerPtr layer) {
         uint32_t num_columns_in = 1;
 
         uint32_t num_rows_out = GetDataDimSize(outputs, inputs->getDims().size() - axis.front());
-        uint32_t num_padding = ALIGN(num_rows_in, 8) - num_rows_in;
+        uint32_t num_padding = ALIGN(num_rows_in, noOfInputsDivisor) - num_rows_in;
 
         void* ptr_inputs = nullptr;
         void* ptr_outputs = nullptr;
@@ -1102,9 +1115,9 @@ void GNAGraphCompiler::CropPrimitive(InferenceEngine::CNNLayerPtr layer) {
             num_columns_in,
             num_rows_out,
             inputs->getPrecision().size(),
-            4,
-            quantized == nullptr ? inputs->getPrecision().size() : 2,
-            4,
+            outputs->getPrecision().size(),
+            quantized == nullptr ? inputs->getPrecision().size() : (!gnaFlags->input_low_precision ? 2 : 1),
+            !gnaFlags->input_low_precision ? 4 : 1,
             quantized == nullptr ? 1 : quantized->_weights_quant.GetScale(),
             quantized == nullptr ? 1 : quantized->_dst_quant.GetScale(),
             ptr_inputs,
@@ -1118,7 +1131,7 @@ void GNAGraphCompiler::CropPrimitive(InferenceEngine::CNNLayerPtr layer) {
                 begin(outputs->getDims()), end(outputs->getDims())) * 4;
 
         size_t num_data_bytes_in = num_columns_in *
-            ALIGN(num_rows_in, 8) * inputs->getPrecision().size();
+            ALIGN(num_rows_in, noOfInputsDivisor) * inputs->getPrecision().size();
 
         connectInput(layer, ptr_inputs, num_data_bytes_in, 0, 0);
         connectOutput(layer, ptr_outputs, num_data_bytes_out);
@@ -1143,7 +1156,7 @@ void GNAGraphCompiler::EltwisePrimitive(InferenceEngine::CNNLayerPtr layer) {
     auto& eltwise = dynamic_cast<EltwiseLayer&>(*layer.get());
     auto quantized = InferenceEngine::getInjectedData<QuantizedLayerParams>(layer);
     uint32_t noOfInputsDivisor = gnaFlags->input_low_precision ?
-                                  GNALimitations::noOfInputsLowPrecDivisor : GNALimitations::noOfInputsDivisor;
+        GNALimitations::noOfInputsLowPrecDivisor : GNALimitations::noOfInputsDivisor;
 
     // for eltwise sum/sub in 16-bit precision one input should be 4 bytes and one 2 bytes - detecting that below
     // the names of variables are left for clarity although not always reflecting the real precision/size
@@ -1339,8 +1352,9 @@ void GNAGraphCompiler::AffinePrimitive(InferenceEngine::CNNLayerPtr layer, bool 
     void* ptr_weights = nullptr;
     void* ptr_biases = nullptr;
 
-    // TODO: questionable why for biases that are no in Model we inventing precision
-    auto biasPrecision = weightable._biases ? weightable._biases->getTensorDesc().getPrecision() : outputs->getPrecision();
+    // TODO: questionable why for biases that are not in IR we inventing precision
+    auto biasPrecisionSize = weightable._biases ?
+        weightable._biases->getTensorDesc().getPrecision().size() : (!gnaFlags->input_low_precision ? 4 : 1);
 
     // layer without biases might be connected to functional layer without activations
     auto prevLayer = CNNNetPrevLayer(layer);
@@ -1364,7 +1378,7 @@ void GNAGraphCompiler::AffinePrimitive(InferenceEngine::CNNLayerPtr layer, bool 
         inputPrecision.size(),
         outputs->getPrecision().size(),
         weightable._weights->getTensorDesc().getPrecision().size(),
-        biasPrecision.size(),
+        biasPrecisionSize,
         quantized == nullptr ? 1 : quantized->_weights_quant.GetScale(),
         quantized == nullptr ? 1 : quantized->_dst_quant.GetScale(),
         ptr_inputs,
@@ -1517,10 +1531,12 @@ void GNAGraphCompiler::ConcatAlignFilterPrimitive(InferenceEngine::CNNLayerPtr l
     auto outputs = *layer->outData.begin();
     auto inputs = layer->insData.begin()->lock();
 
+    uint32_t noOfInputsDivisor = gnaFlags->input_low_precision ?
+        GNALimitations::noOfInputsLowPrecDivisor : GNALimitations::noOfInputsDivisor;
     uint32_t num_columns_in = GetDataDimSize(inputs, 2);
     uint32_t num_rows_out = GetDataDimSize(outputs, 1);
     uint32_t num_rows_in = filterLayer->_weights->size() / num_rows_out;
-    uint32_t num_padding = ALIGN(num_rows_in, 8) - num_rows_in;
+    uint32_t num_padding = ALIGN(num_rows_in, noOfInputsDivisor) - num_rows_in;
 
     auto numRowsPadded = filterLayer->GetParamAsInt("num_rows_padded");
     // number of rows we handled by inserting copy layer
@@ -1567,8 +1583,9 @@ void GNAGraphCompiler::ConcatAlignFilterPrimitive(InferenceEngine::CNNLayerPtr l
     }
     filterLayer->params["rows_copied_offset"] = std::to_string(num_rows_copied * inputs->getPrecision().size());
 
-
-    auto biasPrecision = filterLayer->_biases ? filterLayer->_biases->getTensorDesc().getPrecision() : outputs->getPrecision();
+    // TODO: questionable why for biases that are not in IR we inventing precision
+    auto biasPrecisionSize = filterLayer->_biases ?
+        filterLayer->_biases->getTensorDesc().getPrecision().size() : (!gnaFlags->input_low_precision ? 4 : 1);
     auto& currentComponent = dnnComponents.addComponent(layer->name, "affine");
 
     dnn->InitAffineComponent(currentComponent,
@@ -1578,7 +1595,7 @@ void GNAGraphCompiler::ConcatAlignFilterPrimitive(InferenceEngine::CNNLayerPtr l
         inputs->getPrecision().size(),
         outputs->getPrecision().size(),
         filterLayer->_weights->getTensorDesc().getPrecision().size(),
-        biasPrecision.size(),
+        biasPrecisionSize,
         quantized == nullptr ? 1 : quantized->_weights_quant.GetScale(),
         quantized == nullptr ? 1 : quantized->_dst_quant.GetScale(),
         ptr_inputs,
@@ -1589,7 +1606,7 @@ void GNAGraphCompiler::ConcatAlignFilterPrimitive(InferenceEngine::CNNLayerPtr l
 
     size_t num_data_bytes_out = num_rows_out * num_columns_in * outputs->getPrecision().size();
     size_t num_data_bytes_in = num_columns_in *
-        ALIGN(num_rows_in, 8) * inputs->getPrecision().size();
+        ALIGN(num_rows_in, noOfInputsDivisor) * inputs->getPrecision().size();
 
     connectInput(layer, ptr_inputs, num_data_bytes_in, num_rows_copied * inputs->getPrecision().size(), 0);
     connectOutput(layer, ptr_outputs, num_data_bytes_out);
@@ -1640,7 +1657,7 @@ void GNAGraphCompiler::AffineFilterPrimitive(InferenceEngine::CNNLayerPtr layer)
 
     auto prevLayer = CNNNetPrevLayer(layer.get(), 0);
     if (!LayerInfo(prevLayer).isSplit() && !LayerInfo(prevLayer).isSlice()) {
-        THROW_GNA_EXCEPTION << "Case  with Affine Aligning Filter for not Split/Slice layers is not implemented yet!";
+        THROW_GNA_EXCEPTION << "Case with Affine Aligning Filter for not Split/Slice layers is not implemented yet!";
     }
 
     void* ptr_inputs = nullptr;
@@ -1653,11 +1670,13 @@ void GNAGraphCompiler::AffineFilterPrimitive(InferenceEngine::CNNLayerPtr layer)
     auto outputs = *layer->outData.begin();
     auto inputs = layer->insData.begin()->lock();
 
+    uint32_t noOfInputsDivisor = gnaFlags->input_low_precision ?
+        GNALimitations::noOfInputsLowPrecDivisor : GNALimitations::noOfInputsDivisor;
     uint32_t num_columns_in = GetDataDimSize(inputs, 2);
     uint32_t num_rows_out = GetDataDimSize(outputs, 1);
     uint32_t num_rows_in = filterLayer->_weights->size() / num_rows_out;
 
-    uint32_t num_padding = ALIGN(num_rows_in, 8) - num_rows_in;
+    uint32_t num_padding = ALIGN(num_rows_in, noOfInputsDivisor) - num_rows_in;
     auto biasPrecision = filterLayer->_biases ? filterLayer->_biases->getTensorDesc().getPrecision() : outputs->getPrecision();
     auto& currentComponent = dnnComponents.addComponent(layer->name, "affine");
 
@@ -1682,7 +1701,7 @@ void GNAGraphCompiler::AffineFilterPrimitive(InferenceEngine::CNNLayerPtr layer)
             begin(outputs->getDims()), end(outputs->getDims())) * 4;
 
     size_t num_data_bytes_in = num_columns_in *
-        ALIGN(num_rows_in, 8) * inputs->getPrecision().size();
+        ALIGN(num_rows_in, noOfInputsDivisor) * inputs->getPrecision().size();
 
     connectInput(layer, ptr_inputs, num_data_bytes_in, 0, 0);
     connectOutput(layer, ptr_outputs, num_data_bytes_out);
@@ -1982,10 +2001,13 @@ void GNAGraphCompiler::PermutePrimitive(InferenceEngine::CNNLayerPtr layer) {
                             << std::min(squeezedInputOrder[0], squeezedInputOrder[1]) << " > 8)";
     }
 
+    uint32_t noOfInputsDivisor = gnaFlags->input_low_precision ?
+        GNALimitations::noOfInputsLowPrecDivisor : GNALimitations::noOfInputsDivisor;
+
     // now this can be run on GNA
     if (squeezedInputOrder[0] < squeezedInputOrder[1]) {  // interleave case
-        if (ALIGN(squeezedInputOrder[1], 8) != squeezedInputOrder[1]) {
-            THROW_GNA_LAYER_EXCEPTION(layer) << "unsupported permute (row size not a multiple of 8)";
+        if (ALIGN(squeezedInputOrder[1], noOfInputsDivisor) != squeezedInputOrder[1]) {
+            THROW_GNA_LAYER_EXCEPTION(layer) << "unsupported permute (row size not a multiple of " << noOfInputsDivisor << ")";
         } else {
             auto& currentComponent = dnnComponents.addComponent(layer->name, "interleave");
             dnn->InitInterleaveComponent(currentComponent,
@@ -1999,8 +2021,8 @@ void GNAGraphCompiler::PermutePrimitive(InferenceEngine::CNNLayerPtr layer) {
         }
 
     } else {  // deinterleave case
-        if (ALIGN(squeezedInputOrder[0], 8) != squeezedInputOrder[0]) {
-            THROW_GNA_LAYER_EXCEPTION(layer) << "[GNA plugin] unsupported permute (column size not a multiple of 8)";
+        if (ALIGN(squeezedInputOrder[0], noOfInputsDivisor) != squeezedInputOrder[0]) {
+            THROW_GNA_LAYER_EXCEPTION(layer) << "[GNA plugin] unsupported permute (column size not a multiple of " << noOfInputsDivisor << ")";
         } else {
             auto& currentComponent = dnnComponents.addComponent(layer->name, "deinterleave");
             dnn->InitDeinterleaveComponent(currentComponent,
@@ -2015,7 +2037,7 @@ void GNAGraphCompiler::PermutePrimitive(InferenceEngine::CNNLayerPtr layer) {
     }
 
     size_t num_data_bytes_out = ALIGN(InferenceEngine::details::product(
-            begin(outputs->getDims()), end(outputs->getDims())), 8)
+            begin(outputs->getDims()), end(outputs->getDims())), noOfInputsDivisor)
                                 * outputs->getPrecision().size();
     size_t num_data_bytes_in = squeezedInputOrder[0] * squeezedInputOrder[1] * inputs->getPrecision().size();
 
@@ -2276,7 +2298,8 @@ GNAPluginNS::ConnectionDetails GNAGraphCompiler::connectInput(CNNLayerPtr layer,
             // if request for allocation less that realTensorInput - we need to extend request
             auto minInput = inputDesc->minBytesRequiredForStoreInput(prevLayer);
             if (num_data_bytes_in < minInput) {
-                uint32_t noOfInputsDivisor = gnaFlags->input_low_precision ? GNALimitations::noOfInputsLowPrecDivisor : GNALimitations::noOfInputsDivisor;
+                uint32_t noOfInputsDivisor = gnaFlags->input_low_precision ?
+                    GNALimitations::noOfInputsLowPrecDivisor : GNALimitations::noOfInputsDivisor;
                 gnalog() << "[INPUT] : requested bytes: " << num_data_bytes_in << ", extended to" << ALIGN(minInput, noOfInputsDivisor);
                 num_data_bytes_in = ALIGN(minInput, noOfInputsDivisor);
             }

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/low_precision.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/low_precision.cpp
@@ -1,0 +1,67 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "single_layer_tests/low_precision.hpp"
+#include "common_test_utils/test_constants.hpp"
+#include "../skip_tests_check.hpp"
+
+using namespace LowPrecisionTestDefinitions;
+
+namespace {
+
+class GnaLowPrecisionTest : public LowPrecisionTest, GnaLayerTestCheck {
+protected:
+    void Run() override {
+        GnaLayerTestCheck::SkipTestCheck();
+
+        if (!GnaLayerTestCheck::skipTest) {
+            LowPrecisionTest::Run();
+        }
+    }
+
+    void SetUp() override {
+        LowPrecisionTest::SetUp();
+    }
+};
+
+TEST_P(GnaLowPrecisionTest, CompareWithRefs) {
+    Run();
+}
+
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16
+};
+
+const std::map<std::string, std::string> config_fp32 = {
+    {"GNA_DEVICE_MODE", "GNA_SW_FP32"},
+};
+
+const std::map<std::string, std::string> config_i16 = {
+    {"GNA_DEVICE_MODE", "GNA_SW_EXACT"},
+    {"GNA_SCALE_FACTOR_0", "1"},
+    {"GNA_PRECISION", "I16"},
+};
+
+const std::map<std::string, std::string> config_i8 = {
+    {"GNA_DEVICE_MODE", "GNA_SW_EXACT"},
+    {"GNA_SCALE_FACTOR_0", "1"},
+    {"GNA_PRECISION", "I8"},
+};
+
+const std::vector<std::pair<std::string, std::map<std::string, std::string>>> configs = {
+    {"sw_fp32", config_fp32},
+    {"sw_exact_i16", config_i16},
+    {"sw_exact_i8", config_i8},
+};
+
+INSTANTIATE_TEST_CASE_P(DISABLED_smoke_LowPrecision, GnaLowPrecisionTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(CommonTestUtils::DEVICE_GNA),
+        ::testing::ValuesIn(configs)),
+    GnaLowPrecisionTest::getTestCaseName);
+}  // namespace

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/low_precision.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/low_precision.hpp
@@ -1,0 +1,15 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "shared_test_classes/single_layer/low_precision.hpp"
+
+namespace LowPrecisionTestDefinitions {
+
+    TEST_P(LowPrecisionTest, CompareWithRefs) {
+        Run();
+    }
+
+}  // namespace LowPrecisionTestDefinitions

--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/low_precision.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/low_precision.hpp
@@ -1,0 +1,34 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "shared_test_classes/base/layer_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+namespace LowPrecisionTestDefinitions {
+
+typedef std::tuple<
+    InferenceEngine::Precision,                                 // Net precision
+    LayerTestsUtils::TargetDevice,                              // Device name
+    std::pair<std::string, std::map<std::string, std::string>>  // Configuration
+> lowPrecisionTestParamsSet;
+
+class LowPrecisionTest : public testing::WithParamInterface<lowPrecisionTestParamsSet>,
+    virtual public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<lowPrecisionTestParamsSet> obj);
+
+protected:
+    void SetUp() override;
+};
+// ! [test_low_precision:definition]
+
+}  // namespace LowPrecisionTestDefinitions

--- a/inference-engine/tests/functional/shared_test_classes/src/single_layer/low_precision.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/single_layer/low_precision.cpp
@@ -1,0 +1,91 @@
+// Copyright (C) 2019-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/single_layer/low_precision.hpp"
+#include "ngraph_functions/builders.hpp"
+
+namespace LowPrecisionTestDefinitions {
+
+std::string LowPrecisionTest::getTestCaseName(testing::TestParamInfo<lowPrecisionTestParamsSet> obj) {
+    InferenceEngine::Precision netPrecision;
+    std::string targetDevice;
+    std::pair<std::string, std::map<std::string, std::string>> config;
+    std::tie(netPrecision, targetDevice, config) = obj.param;
+
+    std::ostringstream result;
+    result << "netPRC=" << netPrecision.name() << "_";
+    result << "trgDev=" << targetDevice;
+    if (!config.first.empty()) {
+        result << "_targetConfig=" << config.first;
+    }
+    return result.str();
+}
+
+void LowPrecisionTest::SetUp() {
+    InferenceEngine::Precision netPrecision;
+    std::pair<std::string, std::map<std::string, std::string>> config;
+    std::tie(netPrecision, targetDevice, config) = this->GetParam();
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+    auto inputShape = ngraph::Shape{ 1, 16 };
+    auto weights1Shape = ngraph::Shape{ 16, 16 };
+    auto weights2Shape = ngraph::Shape{ 128, 32 };
+
+    // fully connected 1
+    auto input = std::make_shared<ngraph::opset1::Parameter>(ngPrc, inputShape);
+    std::vector<float> weights1Data(ngraph::shape_size(weights1Shape), 0.0f);
+
+    for (size_t i = 0; i < 16; i++) {
+        weights1Data[i * 17] = 10.0f + i;
+    }
+
+    auto weights1 = ngraph::builder::makeConstant<float>(ngPrc, weights1Shape, weights1Data);
+    auto fc1 = std::make_shared<ngraph::opset1::MatMul>(input, weights1);
+    fc1->set_friendly_name("FullyConnected_1");
+
+    // bias 1
+    std::vector<float> bias1Data(ngraph::shape_size(inputShape), 0.0f);
+    auto bias1 = ngraph::builder::makeConstant<float>(ngPrc, inputShape, bias1Data);
+    auto add1 = std::make_shared<ngraph::opset1::Add>(fc1, bias1);
+    add1->set_friendly_name("Add_1");
+#if 0
+    // ReLU 1
+    auto relu1 = std::make_shared<ngraph::opset1::Relu>(add1);
+    relu1->set_friendly_name("Relu_1");
+
+    //// fully connected 2
+    std::vector<float> weights2Data(ngraph::shape_size(weights2Shape), 0.0f);
+    std::fill(weights2Data.begin(), weights2Data.end(), 0.0001f);
+    auto weights2 = ngraph::builder::makeConstant<float>(ngPrc, weights2Shape, weights2Data);
+    auto fc2 = std::make_shared<ngraph::opset1::MatMul>(relu1, weights2);
+    fc2->set_friendly_name("FullyConnected_2");
+
+    //// bias 2
+    std::vector<float> bias2Data(ngraph::shape_size(weights2Shape), 0.0f);
+    auto bias2 = ngraph::builder::makeConstant<float>(ngPrc, weights2Shape, bias2Data);
+    auto add2 = std::make_shared<ngraph::opset1::Add>(fc2, bias2);
+    add2->set_friendly_name("Add_2");
+
+    //// ReLU 2
+    auto relu2 = std::make_shared<ngraph::opset1::Relu>(add2);
+    relu2->set_friendly_name("Relu_2");
+#endif
+    configuration = config.second;
+    function = std::make_shared<ngraph::Function>(ngraph::ResultVector{std::make_shared<ngraph::opset1::Result>(add1)},
+                                                  ngraph::ParameterVector{input},
+                                                  "LowPrecisionTest");
+}
+
+void LowPrecisionTest::Run() {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    LoadNetwork();
+    Infer();
+
+    const auto& actualOutputs = GetOutputs();
+    auto referenceOutputs = CalculateRefs();
+
+    Compare(referenceOutputs, actualOutputs);
+}
+
+}  // namespace LowPrecisionTestDefinitions

--- a/inference-engine/tests/functional/shared_test_classes/src/single_layer/low_precision.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/single_layer/low_precision.cpp
@@ -76,16 +76,4 @@ void LowPrecisionTest::SetUp() {
                                                   "LowPrecisionTest");
 }
 
-void LowPrecisionTest::Run() {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
-    LoadNetwork();
-    Infer();
-
-    const auto& actualOutputs = GetOutputs();
-    auto referenceOutputs = CalculateRefs();
-
-    Compare(referenceOutputs, actualOutputs);
-}
-
 }  // namespace LowPrecisionTestDefinitions


### PR DESCRIPTION
### Details:
Add basic 8-bit support (tensor precision, padding) for some more layer types: power, crop, concat align filter, affine filter, permute, const. The changes should allow for generation of correct GNA models for 8-bit precision for these layers. Accuracy may still be weak.
Add simple low precision test for affine + ReLU layers.

### Tickets:
52793
