### PR TITLE
Fix openvino build without OpenCV.

### DIFF
--- a/docs/snippets/CMakeLists.txt
+++ b/docs/snippets/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 
 # remove OpenCV related sources
 find_package(OpenCV QUIET)
-if(NOT OpenCV_FOUND)
+if((NOT ENABLE_OPENCV) OR (NOT OpenCV_FOUND))
     list(REMOVE_ITEM SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/dldt_optimization_guide5.cpp"
                              "${CMAKE_CURRENT_SOURCE_DIR}/ShapeInference.cpp")
 endif()

--- a/docs/snippets/CMakeLists.txt
+++ b/docs/snippets/CMakeLists.txt
@@ -15,8 +15,13 @@ if(NOT CLDNN__IOCL_ICD_INCDIRS OR TRUE)
 endif()
 
 # remove OpenCV related sources
-find_package(OpenCV QUIET)
-if((NOT ENABLE_OPENCV) OR (NOT OpenCV_FOUND))
+if (ENABLE_OPENCV)
+  find_package(OpenCV QUIET)
+else()
+  set(OpenCV_FOUND FALSE)
+endif()
+
+if(NOT OpenCV_FOUND)
     list(REMOVE_ITEM SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/dldt_optimization_guide5.cpp"
                              "${CMAKE_CURRENT_SOURCE_DIR}/ShapeInference.cpp")
 endif()


### PR DESCRIPTION
Within `docs/snippets` the CMakeLists.txt searches for any kind of OpenCV package and if found tries to compile an OpenCV dependent target even if the `ENABLE_OPENCV` project option is explicitly disabled. This target may fail to compile if the OpenCV build that was found doesn't provide the `highgui` module for example.

This PR adds a check for the `ENABLE_OPENCV` project option in order to prevent those OpenCV dependent targets from being built by accident.