### PR TITLE
Nested ITT counters lead to invalid performance measurement results

### DIFF
--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -13,7 +13,7 @@ ie_option (ENABLE_PROFILING_ITT "Build with ITT tracing. Optionally configure pr
 ie_option_enum(ENABLE_PROFILING_FILTER "Enable or disable ITT counter groups.\
 Supported values:\
  ALL - enable all ITT counters (default value)\
- FIRST_INFERENCE - enable only first inference time counters" FIRST_INFERENCE
+ FIRST_INFERENCE - enable only first inference time counters" ALL
                ALLOWED_VALUES ALL FIRST_INFERENCE)
 
 ie_option (ENABLE_PROFILING_FIRST_INFERENCE "Build with ITT tracing of first inference time." ON)

--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -10,6 +10,14 @@ ie_dependent_option (ENABLE_CLDNN "clDnn based plugin for inference engine" ON "
 
 ie_option (ENABLE_PROFILING_ITT "Build with ITT tracing. Optionally configure pre-built ittnotify library though INTEL_VTUNE_DIR variable." OFF)
 
+ie_option_enum(ENABLE_PROFILING_FILTER "Enable or disable ITT counter groups.\
+Supported values:\
+ ALL - enable all ITT counters (default value)\
+ FIRST_INFERENCE - enable only first inference time counters" FIRST_INFERENCE
+               ALLOWED_VALUES ALL FIRST_INFERENCE)
+
+ie_option (ENABLE_PROFILING_FIRST_INFERENCE "Build with ITT tracing of first inference time." ON)
+
 ie_option (ENABLE_DOCS "Build docs using Doxygen" OFF)
 
 ie_option(ENABLE_TEMPLATE_PLUGIN "Register template plugin into plugins.xml" OFF)

--- a/inference-engine/src/inference_engine/CMakeLists.txt
+++ b/inference-engine/src/inference_engine/CMakeLists.txt
@@ -117,7 +117,7 @@ target_include_directories(${TARGET_NAME}_obj PRIVATE "${CMAKE_CURRENT_SOURCE_DI
                                                       $<TARGET_PROPERTY:${TARGET_NAME}_transformations,INTERFACE_INCLUDE_DIRECTORIES>
                                                       $<TARGET_PROPERTY:${TARGET_NAME}_plugin_api,INTERFACE_INCLUDE_DIRECTORIES>)
 
-target_link_libraries(${TARGET_NAME}_obj PRIVATE ${TARGET_NAME}_reader_api)
+target_link_libraries(${TARGET_NAME}_obj PRIVATE ${TARGET_NAME}_reader_api openvino::itt)
 
 set_ie_threading_interface_for(${TARGET_NAME}_obj)
 

--- a/inference-engine/src/inference_engine/compilation_context.cpp
+++ b/inference-engine/src/inference_engine/compilation_context.cpp
@@ -87,7 +87,7 @@ std::string NetworkCompilationContext::calculateFileInfo(const std::string& file
 
 std::string NetworkCompilationContext::computeHash(const CNNNetwork& network,
                                const std::map<std::string, std::string>& compileOptions) {
-    OV_ITT_SCOPED_TASK(itt::domains::IE_LT, "NetworkCompilationContext::computeHash - CNN");
+    OV_ITT_SCOPE(FIRST_INFERENCE, itt::domains::IE_LT, "NetworkCompilationContext::computeHash - CNN");
     OstreamHashWrapper xmlHash;
     OstreamHashWrapper binHash;
     std::ostream xml(&xmlHash);
@@ -163,7 +163,7 @@ std::string NetworkCompilationContext::computeHash(const CNNNetwork& network,
 
 std::string NetworkCompilationContext::computeHash(const std::string& modelName,
                                const std::map<std::string, std::string>& compileOptions) {
-    OV_ITT_SCOPED_TASK(itt::domains::IE_LT, "NetworkCompilationContext::computeHash - ModelName");
+    OV_ITT_SCOPE(FIRST_INFERENCE, itt::domains::IE_LT, "NetworkCompilationContext::computeHash - ModelName");
     size_t seed {};
     try {
         seed = hash_combine(seed, FileUtils::absoluteFilePath(modelName));

--- a/inference-engine/src/inference_engine/ie_core.cpp
+++ b/inference-engine/src/inference_engine/ie_core.cpp
@@ -225,7 +225,7 @@ class Core::Impl : public ICore {
                                       const std::string& blobID,
                                       const std::string& modelPath = std::string(),
                                       bool forceDisableCache = false) {
-        OV_ITT_SCOPE(FIRST_INFERENCE, itt::domains::IE_LT, "Core::Impl::LoadNetworkImpl");
+        OV_ITT_SCOPED_TASK(itt::domains::IE, "Core::Impl::LoadNetworkImpl");
         ExecutableNetwork execNetwork;
         execNetwork = context ? plugin.LoadNetwork(network, context, parsedConfig) :
                                 plugin.LoadNetwork(network, parsedConfig);
@@ -429,12 +429,12 @@ public:
     }
 
     CNNNetwork ReadNetwork(const std::string& modelPath, const std::string& binPath) const override {
-        OV_ITT_SCOPED_TASK(itt::domains::IE, "Core::Impl::ReadNetwork from file");
+        OV_ITT_SCOPE(FIRST_INFERENCE, itt::domains::IE_RT, "Core::Impl::ReadNetwork from file");
         return details::ReadNetwork(modelPath, binPath, extensions);
     }
 
     CNNNetwork ReadNetwork(const std::string& model, const Blob::CPtr& weights) const override {
-        OV_ITT_SCOPED_TASK(itt::domains::IE, "Core::Impl::ReadNetwork from memory");
+        OV_ITT_SCOPE(FIRST_INFERENCE, itt::domains::IE_RT, "Core::Impl::ReadNetwork from memory");
         return details::ReadNetwork(model, weights, extensions);
     }
 

--- a/inference-engine/src/inference_engine/ie_core.cpp
+++ b/inference-engine/src/inference_engine/ie_core.cpp
@@ -225,7 +225,7 @@ class Core::Impl : public ICore {
                                       const std::string& blobID,
                                       const std::string& modelPath = std::string(),
                                       bool forceDisableCache = false) {
-        OV_ITT_SCOPED_TASK(itt::domains::IE_LT, "Core::Impl::LoadNetworkImpl");
+        OV_ITT_SCOPE(FIRST_INFERENCE, itt::domains::IE_LT, "Core::Impl::LoadNetworkImpl");
         ExecutableNetwork execNetwork;
         execNetwork = context ? plugin.LoadNetwork(network, context, parsedConfig) :
                                 plugin.LoadNetwork(network, parsedConfig);
@@ -233,7 +233,7 @@ class Core::Impl : public ICore {
         if (!forceDisableCache && cacheManager && DeviceSupportsImportExport(plugin)) {
             try {
                 // need to export network for further import from "cache"
-                OV_ITT_SCOPED_TASK(itt::domains::IE_LT, "Core::LoadNetwork::Export");
+                OV_ITT_SCOPE(FIRST_INFERENCE, itt::domains::IE_LT, "Core::LoadNetwork::Export");
                 cacheManager->writeCacheEntry(blobID, [&](std::ostream& networkStream) {
                     networkStream << CompiledBlobHeader(GetInferenceEngineVersion()->buildNumber,
                                                         NetworkCompilationContext::calculateFileInfo(modelPath));
@@ -260,7 +260,7 @@ class Core::Impl : public ICore {
         IE_ASSERT(cacheManager != nullptr);
         try {
             cacheManager->readCacheEntry(blobId, [&](std::istream &networkStream) {
-                OV_ITT_SCOPED_TASK(itt::domains::IE_LT, "Core::LoadNetworkFromCache::ReadStreamAndImport");
+                OV_ITT_SCOPE(FIRST_INFERENCE, itt::domains::IE_LT, "Core::LoadNetworkFromCache::ReadStreamAndImport");
                 try {
                     CompiledBlobHeader header;
                     networkStream >> header;
@@ -441,7 +441,7 @@ public:
     // TODO: In future this method can be added to ICore interface
     ExecutableNetwork LoadNetwork(const CNNNetwork& network, const RemoteContext::Ptr& context,
                                   const std::map<std::string, std::string>& config) {
-        OV_ITT_SCOPED_TASK(itt::domains::IE_LT, "Core::LoadNetwork::RemoteContext");
+        OV_ITT_SCOPE(FIRST_INFERENCE, itt::domains::IE_LT, "Core::LoadNetwork::RemoteContext");
         if (context == nullptr) {
             IE_THROW() << "Remote context is null";
         }
@@ -464,7 +464,7 @@ public:
 
     ExecutableNetwork LoadNetwork(const CNNNetwork& network, const std::string& deviceName,
                                   const std::map<std::string, std::string>& config) override {
-        OV_ITT_SCOPED_TASK(itt::domains::IE_LT, "Core::LoadNetwork::CNN");
+        OV_ITT_SCOPE(FIRST_INFERENCE, itt::domains::IE_LT, "Core::LoadNetwork::CNN");
         bool forceDisableCache = config.count(CONFIG_KEY_INTERNAL(FORCE_DISABLE_CACHE)) > 0;
         auto parsed = parseDeviceNameIntoConfig(deviceName, config);
         if (forceDisableCache) {
@@ -490,7 +490,7 @@ public:
     // TODO: In future this method can be added to ICore interface
     ExecutableNetwork LoadNetwork(const std::string& modelPath, const std::string& deviceName,
                                   const std::map<std::string, std::string>& config) {
-        OV_ITT_SCOPED_TASK(itt::domains::IE_LT, "Core::LoadNetwork::Path");
+        OV_ITT_SCOPE(FIRST_INFERENCE, itt::domains::IE_LT, "Core::LoadNetwork::Path");
         auto parsed = parseDeviceNameIntoConfig(deviceName, config);
         auto plugin = GetCPPPluginByName(parsed._deviceName);
         bool loadedFromCache = false;
@@ -588,7 +588,7 @@ public:
      * @return Reference to a CPP plugin wrapper
      */
     InferencePlugin GetCPPPluginByName(const std::string& deviceName) const {
-        OV_ITT_SCOPED_TASK(itt::domains::IE_LT, "Core::Impl::GetCPPPluginByName");
+        OV_ITT_SCOPE(FIRST_INFERENCE, itt::domains::IE_LT, "Core::Impl::GetCPPPluginByName");
 
         std::lock_guard<std::mutex> lock(pluginsMutex);
 

--- a/inference-engine/src/inference_engine/ie_itt.hpp
+++ b/inference-engine/src/inference_engine/ie_itt.hpp
@@ -16,6 +16,7 @@ namespace itt {
 namespace domains {
     OV_ITT_DOMAIN(IE);
     OV_ITT_DOMAIN(IE_LT);
+    OV_ITT_DOMAIN(IE_RT);
 }
 }
 }

--- a/inference-engine/src/legacy_api/CMakeLists.txt
+++ b/inference-engine/src/legacy_api/CMakeLists.txt
@@ -50,6 +50,8 @@ target_include_directories(${TARGET_NAME}_obj PRIVATE
 
 target_compile_definitions(${TARGET_NAME}_obj PRIVATE $<TARGET_PROPERTY:ngraph::ngraph,INTERFACE_COMPILE_DEFINITIONS>)
 
+target_link_libraries(${TARGET_NAME}_obj PRIVATE openvino::itt)
+
 add_cpplint_target(${TARGET_NAME}_obj_cpplint FOR_TARGETS ${TARGET_NAME}_obj)
 
 # Create shared library

--- a/inference-engine/src/legacy_api/src/ie_legacy_itt.hpp
+++ b/inference-engine/src/legacy_api/src/ie_legacy_itt.hpp
@@ -15,6 +15,7 @@ namespace InferenceEngine {
 namespace itt {
 namespace domains {
     OV_ITT_DOMAIN(IELegacy);
+    OV_ITT_DOMAIN(IELegacy_LT);
 }
 }
 }

--- a/inference-engine/src/legacy_api/src/ie_util_internal.cpp
+++ b/inference-engine/src/legacy_api/src/ie_util_internal.cpp
@@ -148,7 +148,7 @@ CNNLayerPtr clonelayer(const CNNLayer& source) {
 }
 
 CNNNetwork cloneNetwork(const CNNNetwork& network) {
-    OV_ITT_SCOPED_TASK(itt::domains::IELegacy, "cloneNetwork");
+    OV_ITT_SCOPE(FIRST_INFERENCE, itt::domains::IELegacy_LT, "cloneNetwork");
 
     if (network.getFunction()) {
         return CNNNetwork(std::make_shared<details::CNNNetworkNGraphImpl>(network));

--- a/inference-engine/src/low_precision_transformations/src/lpt_itt.h
+++ b/inference-engine/src/low_precision_transformations/src/lpt_itt.h
@@ -1,0 +1,27 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/**
+ * @brief Defines openvino domains for tracing
+ * @file lpt_itt.h
+ */
+
+#pragma once
+
+#include <openvino/itt.hpp>
+
+namespace ngraph {
+namespace pass {
+namespace low_precision {
+namespace itt {
+namespace domains {
+
+OV_ITT_DOMAIN(LPT);
+OV_ITT_DOMAIN(LPT_LT);
+
+} // namespace domains
+} // namespace itt
+} // namespace low_precision
+} // namespace pass
+} // namespace ngraph

--- a/inference-engine/src/low_precision_transformations/src/transformer.cpp
+++ b/inference-engine/src/low_precision_transformations/src/transformer.cpp
@@ -21,6 +21,8 @@
 #include "ngraph/pass/constant_folding.hpp"
 #include "ngraph/opsets/opset6.hpp"
 
+#include "lpt_itt.h"
+
 // branch specific transformations
 #include "low_precision/concat.hpp"
 #include "low_precision/concat_multi_channels.hpp"
@@ -346,6 +348,8 @@ void LowPrecisionTransformer::transform(std::shared_ptr<Function> network) {
         return;
     }
 
+    OV_ITT_SCOPE_CHAIN(FIRST_INFERENCE, taskChain, itt::domains::LPT_LT, "LowPrecisionTransformer", "transform");
+
     ngraph::pass::ConstantFolding constantFolding;
     constantFolding.run_on_function(network);
 
@@ -354,11 +358,15 @@ void LowPrecisionTransformer::transform(std::shared_ptr<Function> network) {
 
     TransformationContext context(network);
 
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "TypeRelaxedReplacer");
+
     // Extend necessary operations with polymorphic semantics
     {
         TypeRelaxedReplacer pass;
         pass.run_on_function(network);
     }
+
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "BranchSpecificTransformations");
 
     {
         // Branch specific transformations
@@ -367,12 +375,16 @@ void LowPrecisionTransformer::transform(std::shared_ptr<Function> network) {
         pass.run_on_function(network);
     }
 
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "FakeQuantizeDecomposition");
+
     {
         // Step #1: FakeQuantize decomposition transformation execution
         GraphRewrite pass;
         registerAllMatchers(transformations.decompositionTransformations, pass, context);
         pass.run_on_function(network);
     }
+
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "LayerTransformations");
 
     {
         // Step #2: layer transformations execution
@@ -381,12 +393,16 @@ void LowPrecisionTransformer::transform(std::shared_ptr<Function> network) {
         pass.run_on_function(network);
     }
 
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "CleanupTransformations");
+
     {
         // Step #3: cleanup transformations execution
         GraphRewrite pass;
         registerAllMatchers(transformations.cleanupTransformations, pass, context);
         pass.run_on_function(network);
     }
+
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "StandaloneCleanupTransformations");
 
     {
         // Step #4: standalone cleanup transformations execution

--- a/inference-engine/src/mkldnn_plugin/mkldnn_edge.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_edge.cpp
@@ -212,11 +212,11 @@ void MKLDNNEdge::externalAllocate(MKLDNNWeightsSharing::Ptr weightsCache) {
     }
 }
 
-void MKLDNNEdge::reuse(InferenceEngine::Blob::Ptr blob) {
+void MKLDNNEdge::reuse(MKLDNNMemoryPtr blob) {
     if (status != Status::NeedAllocation)
         return;
-    memoryFromBlob = blob;
-    allocate(blob->cbuffer());
+    externalMemoryPtr = blob;
+    allocate(blob->GetPtr());
 }
 
 void MKLDNNEdge::changeStatus(MKLDNNEdge::Status state) {

--- a/inference-engine/src/mkldnn_plugin/mkldnn_edge.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_edge.cpp
@@ -112,6 +112,9 @@ bool MKLDNNEdge::needReorder() {
         if (inNumber >= 0 && inNumber < parentSPD->getConfig().outConfs.size() && parentSPD->getConfig().outConfs[inNumber].inPlace >= 0 &&
             outNumber >= 0 && outNumber < childSPD->getConfig().inConfs.size() && childSPD->getConfig().inConfs[outNumber].inPlace >= 0)
             canBeInPlaceConflicts = true;
+
+        if (getParent()->getType() == Input && getParent()->isConstant())
+            canBeInPlaceConflicts = true;
     }
     return canBeInPlaceConflicts || !MKLDNNExtensionUtils::initTensorsAreEqual(getInputDesc(), getOutputDesc());
 }

--- a/inference-engine/src/mkldnn_plugin/mkldnn_edge.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_edge.cpp
@@ -112,10 +112,8 @@ bool MKLDNNEdge::needReorder() {
         if (inNumber >= 0 && inNumber < parentSPD->getConfig().outConfs.size() && parentSPD->getConfig().outConfs[inNumber].inPlace >= 0 &&
             outNumber >= 0 && outNumber < childSPD->getConfig().inConfs.size() && childSPD->getConfig().inConfs[outNumber].inPlace >= 0)
             canBeInPlaceConflicts = true;
-
-        if (getParent()->getType() == Input && getParent()->isConstant())
-            canBeInPlaceConflicts = true;
     }
+
     return canBeInPlaceConflicts || !MKLDNNExtensionUtils::initTensorsAreEqual(getInputDesc(), getOutputDesc());
 }
 
@@ -215,11 +213,11 @@ void MKLDNNEdge::externalAllocate(MKLDNNWeightsSharing::Ptr weightsCache) {
     }
 }
 
-void MKLDNNEdge::reuse(MKLDNNMemoryPtr blob) {
+void MKLDNNEdge::reuse(MKLDNNMemoryPtr ptr) {
     if (status != Status::NeedAllocation)
         return;
-    externalMemoryPtr = blob;
-    allocate(blob->GetPtr());
+    memoryPtr = ptr;
+    status = Status::Allocated;
 }
 
 void MKLDNNEdge::changeStatus(MKLDNNEdge::Status state) {

--- a/inference-engine/src/mkldnn_plugin/mkldnn_edge.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_edge.cpp
@@ -112,6 +112,8 @@ bool MKLDNNEdge::needReorder() {
         if (inNumber >= 0 && inNumber < parentSPD->getConfig().outConfs.size() && parentSPD->getConfig().outConfs[inNumber].inPlace >= 0 &&
             outNumber >= 0 && outNumber < childSPD->getConfig().inConfs.size() && childSPD->getConfig().inConfs[outNumber].inPlace >= 0)
             canBeInPlaceConflicts = true;
+        if (getParent()->getType() == Input && getParent()->isConstant())
+            canBeInPlaceConflicts = true;
     }
 
     return canBeInPlaceConflicts || !MKLDNNExtensionUtils::initTensorsAreEqual(getInputDesc(), getOutputDesc());

--- a/inference-engine/src/mkldnn_plugin/mkldnn_edge.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_edge.cpp
@@ -212,6 +212,13 @@ void MKLDNNEdge::externalAllocate(MKLDNNWeightsSharing::Ptr weightsCache) {
     }
 }
 
+void MKLDNNEdge::reuse(InferenceEngine::Blob::Ptr blob) {
+    if (status != Status::NeedAllocation)
+        return;
+    memoryFromBlob = blob;
+    allocate(blob->cbuffer());
+}
+
 void MKLDNNEdge::changeStatus(MKLDNNEdge::Status state) {
     if (state == Status::NotAllocated) {
         IE_THROW() << "Incorrect behaviour! Use method sharedMemFrom()";

--- a/inference-engine/src/mkldnn_plugin/mkldnn_edge.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_edge.h
@@ -47,7 +47,7 @@ public:
     void init();
     void allocate(const void* mem_ptr = nullptr);
     void externalAllocate(MKLDNNWeightsSharing::Ptr weightsCache);
-    void reuse(MKLDNNMemoryPtr blob);
+    void reuse(MKLDNNMemoryPtr ptr);
     void validate();
     void drop();
 
@@ -82,7 +82,6 @@ private:
     int child_port;
 
     bool externalMemoryPtr = false;
-    InferenceEngine::Blob::Ptr memoryFromBlob;
     MKLDNNEdgeWeakPtr memoryFromEdge;
     MKLDNNDims dims;
     MKLDNNMemoryPtr memoryPtr;

--- a/inference-engine/src/mkldnn_plugin/mkldnn_edge.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_edge.h
@@ -47,7 +47,7 @@ public:
     void init();
     void allocate(const void* mem_ptr = nullptr);
     void externalAllocate(MKLDNNWeightsSharing::Ptr weightsCache);
-    void reuse(InferenceEngine::Blob::Ptr blob);
+    void reuse(MKLDNNMemoryPtr blob);
     void validate();
     void drop();
 

--- a/inference-engine/src/mkldnn_plugin/mkldnn_edge.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_edge.h
@@ -47,6 +47,7 @@ public:
     void init();
     void allocate(const void* mem_ptr = nullptr);
     void externalAllocate(MKLDNNWeightsSharing::Ptr weightsCache);
+    void reuse(InferenceEngine::Blob::Ptr blob);
     void validate();
     void drop();
 
@@ -81,6 +82,7 @@ private:
     int child_port;
 
     bool externalMemoryPtr = false;
+    InferenceEngine::Blob::Ptr memoryFromBlob;
     MKLDNNEdgeWeakPtr memoryFromEdge;
     MKLDNNDims dims;
     MKLDNNMemoryPtr memoryPtr;

--- a/inference-engine/src/mkldnn_plugin/mkldnn_exec_network.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_exec_network.cpp
@@ -232,10 +232,24 @@ MKLDNNExecNetwork::MKLDNNExecNetwork(const InferenceEngine::CNNNetwork &network,
 
             if (weightsBlobIt != convLayer->blobs.end()) {
                 Blob::Ptr weightsBlob = weightsBlobIt->second;
-                std::vector<size_t> shape = { groupOC, groupIC };
-                for (int i = 1; i <= convLayer->_kernel.size(); i++) {
-                    shape.push_back(convLayer->_kernel[convLayer->_kernel.size() - i]);
+
+                std::vector<size_t> shape;
+
+                if (isGrouped) {
+                    shape.reserve(convLayer->_kernel.size() + 3);
+                    shape.emplace_back(groupNum);
+                    shape.emplace_back(groupOC);
+                    shape.emplace_back(groupIC);
+                } else {
+                    shape.reserve(convLayer->_kernel.size() + 2);
+                    shape.emplace_back(groupOC);
+                    shape.emplace_back(groupIC);
                 }
+
+                for (int i = 1; i <= convLayer->_kernel.size(); i++) {
+                    shape.emplace_back(convLayer->_kernel[convLayer->_kernel.size() - i]);
+                }
+
                 createConstInputTo(layer, weightsBlob, shape, "weights");
             }
 

--- a/inference-engine/src/mkldnn_plugin/mkldnn_exec_network.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_exec_network.cpp
@@ -46,7 +46,7 @@ MKLDNNExecNetwork::MKLDNNExecNetwork(const InferenceEngine::CNNNetwork &network,
     _cfg{cfg},
     _name{network.getName()},
     _numaNodesWeights(numaNodesWeights) {
-    OV_ITT_TASK_CHAIN(taskChain, MKLDNNPlugin::itt::domains::MKLDNN_LT, "MKLDNNExecNetwork", "cloneNet");
+    OV_ITT_SCOPE_CHAIN(FIRST_INFERENCE, taskChain, MKLDNNPlugin::itt::domains::MKLDNN_LT, "MKLDNNExecNetwork", "cloneNet");
 
     // we are cloning network if we have statistics and we can transform network.
     _clonedNetwork = cloneNetwork(network);
@@ -100,7 +100,7 @@ MKLDNNExecNetwork::MKLDNNExecNetwork(const InferenceEngine::CNNNetwork &network,
         }
     }
 
-    OV_ITT_TASK_SKIP(taskChain);
+    OV_ITT_SCOPE_SKIP(FIRST_INFERENCE, taskChain);
 
     CreateConstInputs(_clonedNetwork);
 

--- a/inference-engine/src/mkldnn_plugin/mkldnn_exec_network.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_exec_network.cpp
@@ -29,6 +29,8 @@ using namespace MKLDNNPlugin;
 using namespace InferenceEngine;
 using namespace InferenceEngine::details;
 
+void CreateConstInputs(CNNNetwork& clonedNetwork);
+
 InferenceEngine::InferRequestInternal::Ptr
 MKLDNNExecNetwork::CreateInferRequestImpl(InferenceEngine::InputsDataMap networkInputs,
                                           InferenceEngine::OutputsDataMap networkOutputs) {
@@ -98,170 +100,9 @@ MKLDNNExecNetwork::MKLDNNExecNetwork(const InferenceEngine::CNNNetwork &network,
         }
     }
 
-    OV_ITT_TASK_NEXT(taskChain, "createConstInputs");
-    auto createConstInputTo = [&](CNNLayerPtr layer, Blob::Ptr blob, const std::vector<size_t>& shape, const std::string& name) {
-        LayerParams attrs = {layer->name + "_const_" + name, "Const", blob->getTensorDesc().getPrecision()};
-        auto constLayer = std::make_shared<InferenceEngine::CNNLayer>(attrs);
-        constLayer->blobs["custom"] = blob;
-
-        const TensorDesc& td = {blob->getTensorDesc().getPrecision(), shape, TensorDesc::getLayoutByDims(shape)};
-
-        DataPtr newEdgeAfterLayer(new Data(constLayer->name, td));
-        newEdgeAfterLayer->setName(constLayer->name);
-        getCreatorLayer(newEdgeAfterLayer) = constLayer;
-        getInputTo(newEdgeAfterLayer).clear();
-
-        IE_SUPPRESS_DEPRECATED_START
-        auto icnnnet = static_cast<ICNNNetwork::Ptr>(_clonedNetwork);
-        IE_SUPPRESS_DEPRECATED_END
-        auto implNetwork = std::dynamic_pointer_cast<details::CNNNetworkImpl>(icnnnet);
-        IE_ASSERT(implNetwork != nullptr);
-        implNetwork->addData(constLayer->name.c_str(), newEdgeAfterLayer);
-        implNetwork->addLayer(constLayer);
-
-        constLayer->outData.push_back(newEdgeAfterLayer);
-        getInputTo(newEdgeAfterLayer)[layer->name] = layer;
-        layer->insData.push_back(newEdgeAfterLayer);
-    };
-
-    // The code block below transforms legacy layers to the form more compatible with opset1 in order to simplify future migration
-    // TODO: remove after plug-in is migrated on opset1
-    auto all_layers = details::CNNNetSortTopologically(_clonedNetwork);
-    for (auto &layer : all_layers) {
-        if (layer->type == "ScaleShift" && layer->insData.size() == 1) {
-            auto constDimsRank = layer->insData[0].lock()->getDims().size();
-
-            Blob::Ptr scalesBlob = layer->blobs["weights"];
-            if (scalesBlob != nullptr) {
-                std::vector<size_t> shape(constDimsRank, 1);
-                shape[shape.size() > 1 ? 1 : 0] = scalesBlob->size();
-
-                createConstInputTo(layer, scalesBlob, shape, "weights");
-            }
-
-            Blob::Ptr shiftBlob = layer->blobs["biases"];
-            if (shiftBlob != nullptr) {
-                std::vector<size_t> shape(constDimsRank, 1);
-                shape[shape.size() > 1 ? 1 : 0] = shiftBlob->size();
-
-                createConstInputTo(layer, shiftBlob, shape, "biases");
-            } else if (scalesBlob != nullptr) {
-                Blob::Ptr biases = make_shared_blob<float>(scalesBlob->getTensorDesc());
-                if (biases == nullptr)
-                    IE_THROW() << "Cannot make 'biases' shared blob";
-                biases->allocate();
-                auto biasesPtr = biases->buffer().as<float*>();
-                for (size_t i = 0; i < biases->size(); i++)
-                    biasesPtr[i] = 0;
-
-                std::vector<size_t> shape(constDimsRank, 1);
-                shape[shape.size() > 1 ? 1 : 0] = biases->size();
-
-                createConstInputTo(layer, biases, shape, "biases");
-            }
-        } else if (layer->type == "PReLU" && layer->insData.size() == 1) {
-            Blob::Ptr scalesBlob = layer->blobs["weights"];
-            if (scalesBlob != nullptr) {
-                std::vector<size_t> shape(layer->insData[0].lock()->getDims().size(), 1);
-                shape[shape.size() > 1 ? 1 : 0] = scalesBlob->size();
-
-                createConstInputTo(layer, scalesBlob, shape, "weights");
-            }
-        } else if (layer->type == "DeformableConvolution") {
-            auto * defConvLayer = dynamic_cast<DeformableConvolutionLayer*>(layer.get());
-            if (defConvLayer == nullptr)
-                IE_THROW() << "Cannot convert deformable convolution layer.";
-
-            Blob::Ptr weightsBlob = defConvLayer->blobs["weights"];
-            if (weightsBlob != nullptr) {
-                std::vector<size_t> shape;
-
-                if (defConvLayer->_group != 1) {
-                    shape.push_back(defConvLayer->_group);
-                }
-                shape.push_back(defConvLayer->_out_depth);
-                shape.push_back(defConvLayer->input()->getDims()[1]);
-                for (int i = 1; i <= defConvLayer->_kernel.size(); i++) {
-                    shape.push_back(defConvLayer->_kernel[defConvLayer->_kernel.size() - i]);
-                }
-
-                createConstInputTo(layer, weightsBlob, shape, "weights");
-
-                defConvLayer->blobs.clear();
-                defConvLayer->_weights = nullptr;
-            }
-        } else if (layer->type == "BinaryConvolution") {
-            auto * binConvLayer = dynamic_cast<BinaryConvolutionLayer*>(layer.get());
-            if (binConvLayer == nullptr)
-                IE_THROW() << "Cannot convert binary convolution layer.";
-
-            Blob::Ptr weightsBlob = binConvLayer->blobs["weights"];
-            if (weightsBlob != nullptr) {
-                std::vector<size_t> shape;
-
-                if (binConvLayer->_group != 1) {
-                    shape.push_back(binConvLayer->_group);
-                }
-                shape.push_back(binConvLayer->_out_depth);
-                shape.push_back(binConvLayer->input()->getDims()[1]);
-                for (int i = 1; i <= binConvLayer->_kernel.size(); i++) {
-                    shape.push_back(binConvLayer->_kernel[binConvLayer->_kernel.size() - i]);
-                }
-
-                createConstInputTo(layer, weightsBlob, shape, "weights");
-
-                binConvLayer->blobs.clear();
-                binConvLayer->_weights = nullptr;
-            }
-        } else if (layer->type == "Convolution") {
-            auto * convLayer = dynamic_cast<ConvolutionLayer*>(layer.get());
-            if (convLayer == nullptr)
-                THROW_IE_EXCEPTION << "Cannot convert convolution layer.";
-
-            bool const isGrouped = convLayer->_group != 1;
-            size_t const groupNum = convLayer->_group;
-            size_t const groupIC = isGrouped
-                                ? convLayer->input()->getDims()[1] / groupNum
-                                : convLayer->input()->getDims()[1];
-            size_t const groupOC = isGrouped
-                                ? convLayer->_out_depth / groupNum
-                                : convLayer->_out_depth;
-
-            auto weightsBlobIt = convLayer->blobs.find("weights");
-            auto biasesBlobIt = convLayer->blobs.find("biases");
-
-            if (weightsBlobIt != convLayer->blobs.end()) {
-                Blob::Ptr weightsBlob = weightsBlobIt->second;
-
-                std::vector<size_t> shape;
-
-                if (isGrouped) {
-                    shape.reserve(convLayer->_kernel.size() + 3);
-                    shape.emplace_back(groupNum);
-                    shape.emplace_back(groupOC);
-                    shape.emplace_back(groupIC);
-                } else {
-                    shape.reserve(convLayer->_kernel.size() + 2);
-                    shape.emplace_back(groupOC);
-                    shape.emplace_back(groupIC);
-                }
-
-                for (int i = 1; i <= convLayer->_kernel.size(); i++) {
-                    shape.emplace_back(convLayer->_kernel[convLayer->_kernel.size() - i]);
-                }
-
-                createConstInputTo(layer, weightsBlob, shape, "weights");
-            }
-
-            if (biasesBlobIt != convLayer->blobs.end()) {
-                Blob::Ptr biasesBlob = biasesBlobIt->second;
-                std::vector<size_t> shape = { groupOC * groupNum };
-                createConstInputTo(layer, biasesBlob, shape, "biases");
-            }
-        }
-    }
-
     OV_ITT_TASK_SKIP(taskChain);
+
+    CreateConstInputs(_clonedNetwork);
 
     if (_cfg.batchLimit > 1) {
         // check topology for applicability

--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph.cpp
@@ -96,7 +96,7 @@ template void MKLDNNGraph::ApplyUnrollPasses(CNNNetwork&);
 
 template<typename NET>
 void MKLDNNGraph::CreateGraph(const NET &net, const MKLDNNExtensionManager::Ptr& extMgr,
-        MKLDNNWeightsSharing::Ptr w_cache) {
+        MKLDNNWeightsSharing::Ptr &w_cache) {
     OV_ITT_SCOPED_TASK(MKLDNNPlugin::itt::domains::MKLDNN_LT, "CreateGraph");
 
     if (IsReady())
@@ -110,9 +110,9 @@ void MKLDNNGraph::CreateGraph(const NET &net, const MKLDNNExtensionManager::Ptr&
 }
 
 template void MKLDNNGraph::CreateGraph(const TensorIterator::Body&,
-        const MKLDNNExtensionManager::Ptr&, MKLDNNWeightsSharing::Ptr);
+        const MKLDNNExtensionManager::Ptr&, MKLDNNWeightsSharing::Ptr&);
 template void MKLDNNGraph::CreateGraph(const CNNNetwork&,
-        const MKLDNNExtensionManager::Ptr&, MKLDNNWeightsSharing::Ptr);
+        const MKLDNNExtensionManager::Ptr&, MKLDNNWeightsSharing::Ptr&);
 
 void MKLDNNGraph::Replicate(const TensorIterator::Body &subgraph, const MKLDNNExtensionManager::Ptr& extMgr) {
     this->_name = "subgraph";

--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph.cpp
@@ -388,13 +388,6 @@ void MKLDNNGraph::SetOriginalLayerNames() {
 
     // Do it before cleanup. Because it will lose original layers information
     for (auto &graphNode : graphNodes) {
-        auto nodeType = graphNode->getType();
-        if (nodeType == Reorder || nodeType == Output) continue;
-
-        if (graphNode->getOriginalLayers().empty()) {
-            graphNode->addOriginalLayer(graphNode->getCnnLayer());
-        }
-
         if (graphNode->getFusedWith().size() || graphNode->getMergeWith().size()) {
             // Original layer names
             std::vector<MKLDNNNodePtr> internal = graphNode->getFusedWith();

--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph.cpp
@@ -626,7 +626,12 @@ void MKLDNNGraph::AllocateWithReuse() {
         for (auto &edge : cluster) {
             if (edge->getStatus() == MKLDNNEdge::Status::NeedAllocation
                 && edge->getParent()->isConstant()) {
-                edge->externalAllocate(weightsCache);
+                if (edge->getParent()->getType() == Input) {
+                    auto constNode = std::static_pointer_cast<MKLDNNInputNode>(edge->getParent());
+                    edge->reuse(constNode->getConstBlob());
+                } else {
+                    edge->externalAllocate(weightsCache);
+                }
                 erase = true;
             }
         }

--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph.cpp
@@ -96,7 +96,7 @@ template void MKLDNNGraph::ApplyUnrollPasses(CNNNetwork&);
 
 template<typename NET>
 void MKLDNNGraph::CreateGraph(const NET &net, const MKLDNNExtensionManager::Ptr& extMgr,
-        MKLDNNWeightsSharing::Ptr &w_cache) {
+        MKLDNNWeightsSharing::Ptr w_cache) {
     OV_ITT_SCOPED_TASK(MKLDNNPlugin::itt::domains::MKLDNN_LT, "CreateGraph");
 
     if (IsReady())
@@ -110,9 +110,9 @@ void MKLDNNGraph::CreateGraph(const NET &net, const MKLDNNExtensionManager::Ptr&
 }
 
 template void MKLDNNGraph::CreateGraph(const TensorIterator::Body&,
-        const MKLDNNExtensionManager::Ptr&, MKLDNNWeightsSharing::Ptr&);
+        const MKLDNNExtensionManager::Ptr&, MKLDNNWeightsSharing::Ptr);
 template void MKLDNNGraph::CreateGraph(const CNNNetwork&,
-        const MKLDNNExtensionManager::Ptr&, MKLDNNWeightsSharing::Ptr&);
+        const MKLDNNExtensionManager::Ptr&, MKLDNNWeightsSharing::Ptr);
 
 void MKLDNNGraph::Replicate(const TensorIterator::Body &subgraph, const MKLDNNExtensionManager::Ptr& extMgr) {
     this->_name = "subgraph";

--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph.h
@@ -50,7 +50,7 @@ public:
     template<typename NET>
     void CreateGraph(const NET &network,
                      const MKLDNNExtensionManager::Ptr& extMgr,
-                     MKLDNNWeightsSharing::Ptr w_cache);
+                     MKLDNNWeightsSharing::Ptr &w_cache);
 
     bool hasMeanImageFor(const std::string& name) {
         return _meanImages.find(name) != _meanImages.end();

--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph.h
@@ -50,7 +50,7 @@ public:
     template<typename NET>
     void CreateGraph(const NET &network,
                      const MKLDNNExtensionManager::Ptr& extMgr,
-                     MKLDNNWeightsSharing::Ptr &w_cache);
+                     MKLDNNWeightsSharing::Ptr w_cache);
 
     bool hasMeanImageFor(const std::string& name) {
         return _meanImages.find(name) != _meanImages.end();

--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph_optimizer.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph_optimizer.cpp
@@ -64,8 +64,8 @@ void MKLDNNGraphOptimizer::ApplyCommonGraphOptimizations(MKLDNNGraph &graph) {
     FuseScaleShiftAndQuantize(graph);
     graph.RemoveDroppedNodes();
 
-    MergeGroupConvolution(graph);
-    graph.RemoveDroppedNodes();
+    // MergeGroupConvolution(graph);
+    // graph.RemoveDroppedNodes();
 
     FuseConvolutionAndZeroPoints(graph);
     graph.RemoveDroppedNodes();

--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph_optimizer.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph_optimizer.cpp
@@ -50,7 +50,7 @@ using namespace InferenceEngine;
 MKLDNNGraphOptimizer::MKLDNNGraphOptimizer() {}
 
 void MKLDNNGraphOptimizer::ApplyCommonGraphOptimizations(MKLDNNGraph &graph) {
-    OV_ITT_SCOPED_TASK(itt::domains::MKLDNN_LT, "MKLDNNGraphOptimizer::ApplyCommonGraphOptimizations");
+    OV_ITT_SCOPE(FIRST_INFERENCE, itt::domains::MKLDNN_LT, "MKLDNNGraphOptimizer::ApplyCommonGraphOptimizations");
 
     MergeTwoEqualScaleShifts(graph);
     graph.RemoveDroppedNodes();
@@ -131,7 +131,7 @@ void MKLDNNGraphOptimizer::ApplyCommonGraphOptimizations(MKLDNNGraph &graph) {
 }
 
 void MKLDNNGraphOptimizer::ApplyImplSpecificGraphOptimizations(MKLDNNGraph &graph) {
-    OV_ITT_SCOPED_TASK(itt::domains::MKLDNN_LT, "MKLDNNGraphOptimizer::ApplyImplSpecificGraphOptimizations");
+    OV_ITT_SCOPE(FIRST_INFERENCE, itt::domains::MKLDNN_LT, "MKLDNNGraphOptimizer::ApplyImplSpecificGraphOptimizations");
 
     RemoveIOScaleShifts(graph);
     graph.RemoveDroppedNodes();

--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph_optimizer.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph_optimizer.cpp
@@ -50,83 +50,106 @@ using namespace InferenceEngine;
 MKLDNNGraphOptimizer::MKLDNNGraphOptimizer() {}
 
 void MKLDNNGraphOptimizer::ApplyCommonGraphOptimizations(MKLDNNGraph &graph) {
-    OV_ITT_SCOPE(FIRST_INFERENCE, itt::domains::MKLDNN_LT, "MKLDNNGraphOptimizer::ApplyCommonGraphOptimizations");
-
+    OV_ITT_SCOPE_CHAIN(FIRST_INFERENCE, taskChain, itt::domains::MKLDNN_LT, "ApplyCommonGraphOptimizations", "MergeTwoEqualScaleShifts");
     MergeTwoEqualScaleShifts(graph);
     graph.RemoveDroppedNodes();
 
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "FuseBroadcastAndEltwise");
     FuseBroadcastAndEltwise(graph);
     graph.RemoveDroppedNodes();
 
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "FuseClampAndQuantize");
     FuseClampAndQuantize(graph);
     graph.RemoveDroppedNodes();
 
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "FuseScaleShiftAndQuantize");
     FuseScaleShiftAndQuantize(graph);
     graph.RemoveDroppedNodes();
 
     // MergeGroupConvolution(graph);
     // graph.RemoveDroppedNodes();
 
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "FuseConvolutionAndZeroPoints");
     FuseConvolutionAndZeroPoints(graph);
     graph.RemoveDroppedNodes();
 
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "FuseConvolutionAndDepthwise");
     FuseConvolutionAndDepthwise(graph);
     graph.RemoveDroppedNodes();
 
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "FuseConvolutionAndActivation");
     FuseConvolutionAndActivation(graph);
     graph.RemoveDroppedNodes();
 
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "FuseConvolutionAndDepthwise");
     FuseConvolutionAndDepthwise(graph);
     graph.RemoveDroppedNodes();
 
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "FuseConvolutionAndQuantize");
     FuseConvolutionAndQuantize(graph);
     graph.RemoveDroppedNodes();
 
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "RemoveDroppedEdges");
     graph.SortTopologically();
     graph.RemoveDroppedEdges();
 
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "FuseConvolutionAndDepthwise");
     FuseConvolutionAndDepthwise(graph);
     graph.RemoveDroppedNodes();
 
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "FusePoolingAndQuantize");
     FusePoolingAndQuantize(graph);
     graph.RemoveDroppedNodes();
 
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "RemoveDroppedEdges");
     graph.SortTopologically();
     graph.RemoveDroppedEdges();
 
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "FuseConvolutionAndDWConvolution");
     FuseConvolutionAndDWConvolution(graph);
     graph.RemoveDroppedNodes();
 
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "FuseBinaryConvolutionAndQuantize");
     FuseBinaryConvolutionAndQuantize(graph);
     graph.RemoveDroppedNodes();
 
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "FuseBatchNormWithScale");
     FuseBatchNormWithScale(graph);
     graph.RemoveDroppedNodes();
 
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "RemoveIdentityOperator");
     RemoveIdentityOperator(graph);
     graph.RemoveDroppedNodes();
 
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "FuseConvolutionSumAndConvolutionSumActivation");
     FuseConvolutionSumAndConvolutionSumActivation(graph);
     graph.RemoveDroppedNodes();
 
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "FuseConvolutionAndSimpleOperation");
     FuseConvolutionAndSimpleOperation(graph);
     graph.RemoveDroppedNodes();
 
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "FuseFullyConnectedAndSimpleOperation");
     FuseFullyConnectedAndSimpleOperation(graph);
     graph.RemoveDroppedNodes();
 
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "FuseMVNAndSimpleOperation");
     FuseMVNAndSimpleOperation(graph);
     graph.RemoveDroppedNodes();
 
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "FuseInterpolateAndSimpleOperation");
     FuseInterpolateAndSimpleOperation(graph);
     graph.RemoveDroppedNodes();
 
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "FuseNormalizeAndSimpleOperation");
     FuseNormalizeAndSimpleOperation(graph);
     graph.RemoveDroppedNodes();
 
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "FuseEltwiseAndSimple");
     FuseEltwiseAndSimple(graph);
     graph.RemoveDroppedNodes();
 
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "RemoveDroppedEdges");
     graph.RemoveDroppedEdges();
 }
 

--- a/inference-engine/src/mkldnn_plugin/mkldnn_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_node.cpp
@@ -274,10 +274,10 @@ bool MKLDNNNode::isEdgesEmpty(const std::vector<MKLDNNEdgeWeakPtr>& edges) const
 }
 
 void MKLDNNNode::selectOptimalPrimitiveDescriptor() {
-    selectPreferPrimitiveDescriptor(getPrimitivesPriority());
+    selectPreferPrimitiveDescriptor(getPrimitivesPriority(), false);
 }
 
-void MKLDNNNode::selectPreferPrimitiveDescriptor(const std::vector<impl_desc_type>& priority) {
+void MKLDNNNode::selectPreferPrimitiveDescriptor(const std::vector<impl_desc_type>& priority, bool ignoreConstInputs) {
     for (auto& type : priority) {
         int selectedPrimitive = -1;
         int equalsFormatCount = -1;
@@ -290,6 +290,13 @@ void MKLDNNNode::selectPreferPrimitiveDescriptor(const std::vector<impl_desc_typ
                 for (size_t j = 0; j < getSupportedPrimitiveDescriptors()[i].getConfig().inConfs.size(); j++) {
                     auto parentEdge = getParentEdgeAt(j);
                     auto parentPtr = parentEdge->getParent();
+
+                    // We don't take into account constant edges since reorders on them will be executed on load network stage
+                    if (ignoreConstInputs && j > 0 && parentPtr->isConstant()) {
+                        equalsLocalFormatCount++;
+                        continue;
+                    }
+
                     auto parent_spd = parentPtr->getSelectedPrimitiveDescriptor();
 
                     if (parent_spd != nullptr && !parent_spd->getConfig().outConfs.empty()) {

--- a/inference-engine/src/mkldnn_plugin/mkldnn_node.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_node.h
@@ -348,19 +348,19 @@ public:
 
     void addOriginalLayer(const InferenceEngine::CNNLayerPtr &layer);
 
-    const std::vector <MKLDNNNodePtr> &getMergeWith() {
+    const std::vector <MKLDNNNodePtr> & getMergeWith() {
         return mergedWith;
     }
 
-    const std::vector <MKLDNNNodePtr> &getFusedWith() {
+    const std::vector <MKLDNNNodePtr> & getFusedWith() {
         return fusedWith;
     }
 
-    const std::string getName() const {
+    const std::string & getName() const {
         return name;
     }
 
-    const std::string getOriginalLayers() const {
+    const std::string & getOriginalLayers() const {
         return originalLayers;
     }
 

--- a/inference-engine/src/mkldnn_plugin/mkldnn_node.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_node.h
@@ -586,7 +586,7 @@ protected:
 
     bool isUninitTensorDesc(const InferenceEngine::TensorDesc& desc) const;
     bool isInitConfig(const InferenceEngine::LayerConfig& config) const;
-    virtual void selectPreferPrimitiveDescriptor(const std::vector<impl_desc_type>& priority);
+    void selectPreferPrimitiveDescriptor(const std::vector<impl_desc_type>& priority, bool ignoreConstInputs);
     virtual bool canBeInPlace() const;
 
     virtual const std::vector<impl_desc_type>& getPrimitivesPriority();

--- a/inference-engine/src/mkldnn_plugin/mkldnn_plugin.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_plugin.cpp
@@ -9,6 +9,7 @@
 #include "mkldnn_itt.h"
 
 #include <legacy/net_pass.h>
+#include <legacy/details/ie_cnn_network_tools.h>
 #include <threading/ie_executor_manager.hpp>
 #include <memory>
 #include <ie_plugin_config.hpp>
@@ -107,6 +108,172 @@ Engine::~Engine() {
     ExecutorManager::getInstance()->clear("CPU");
     ExecutorManager::getInstance()->clear("CPUStreamsExecutor");
     ExecutorManager::getInstance()->clear("CPUCallbackExecutor");
+}
+
+void CreateConstInputs(CNNNetwork& clonedNetwork) {
+    OV_ITT_SCOPED_TASK(MKLDNNPlugin::itt::domains::MKLDNN_LT, "CreateConstInputs");
+
+    auto createConstInputTo = [&](CNNLayerPtr layer, Blob::Ptr blob, const std::vector<size_t>& shape, const std::string& name) {
+        LayerParams attrs = {layer->name + "_const_" + name, "Const", blob->getTensorDesc().getPrecision()};
+        auto constLayer = std::make_shared<InferenceEngine::CNNLayer>(attrs);
+        constLayer->blobs["custom"] = blob;
+
+        const TensorDesc& td = {blob->getTensorDesc().getPrecision(), shape, TensorDesc::getLayoutByDims(shape)};
+
+        DataPtr newEdgeAfterLayer(new Data(constLayer->name, td));
+        newEdgeAfterLayer->setName(constLayer->name);
+        getCreatorLayer(newEdgeAfterLayer) = constLayer;
+        getInputTo(newEdgeAfterLayer).clear();
+
+        IE_SUPPRESS_DEPRECATED_START
+        auto icnnnet = static_cast<ICNNNetwork::Ptr>(clonedNetwork);
+        IE_SUPPRESS_DEPRECATED_END
+        auto implNetwork = std::dynamic_pointer_cast<details::CNNNetworkImpl>(icnnnet);
+        IE_ASSERT(implNetwork != nullptr);
+        implNetwork->addData(constLayer->name.c_str(), newEdgeAfterLayer);
+        implNetwork->addLayer(constLayer);
+
+        constLayer->outData.push_back(newEdgeAfterLayer);
+        getInputTo(newEdgeAfterLayer)[layer->name] = layer;
+        layer->insData.push_back(newEdgeAfterLayer);
+    };
+
+    // The code block below transforms legacy layers to the form more compatible with opset1 in order to simplify future migration
+    // TODO: remove after plug-in is migrated on opset1
+    auto all_layers = details::CNNNetSortTopologically(clonedNetwork);
+    for (auto &layer : all_layers) {
+        if (InferenceEngine::details::CaselessEq<std::string>()(layer->type, "ScaleShift") && layer->insData.size() == 1) {
+            auto constDimsRank = layer->insData[0].lock()->getDims().size();
+
+            Blob::Ptr scalesBlob = layer->blobs["weights"];
+            if (scalesBlob != nullptr) {
+                std::vector<size_t> shape(constDimsRank, 1);
+                shape[shape.size() > 1 ? 1 : 0] = scalesBlob->size();
+
+                createConstInputTo(layer, scalesBlob, shape, "weights");
+            }
+
+            Blob::Ptr shiftBlob = layer->blobs["biases"];
+            if (shiftBlob != nullptr) {
+                std::vector<size_t> shape(constDimsRank, 1);
+                shape[shape.size() > 1 ? 1 : 0] = shiftBlob->size();
+
+                createConstInputTo(layer, shiftBlob, shape, "biases");
+            } else if (scalesBlob != nullptr) {
+                Blob::Ptr biases = make_shared_blob<float>(scalesBlob->getTensorDesc());
+                if (biases == nullptr)
+                    THROW_IE_EXCEPTION << "Cannot make 'biases' shared blob";
+                biases->allocate();
+                auto biasesPtr = biases->buffer().as<float*>();
+                for (size_t i = 0; i < biases->size(); i++)
+                    biasesPtr[i] = 0;
+
+                std::vector<size_t> shape(constDimsRank, 1);
+                shape[shape.size() > 1 ? 1 : 0] = biases->size();
+
+                createConstInputTo(layer, biases, shape, "biases");
+            }
+        } else if (InferenceEngine::details::CaselessEq<std::string>()(layer->type, "PReLU") && layer->insData.size() == 1) {
+            Blob::Ptr scalesBlob = layer->blobs["weights"];
+            if (scalesBlob != nullptr) {
+                std::vector<size_t> shape(layer->insData[0].lock()->getDims().size(), 1);
+                shape[shape.size() > 1 ? 1 : 0] = scalesBlob->size();
+
+                createConstInputTo(layer, scalesBlob, shape, "weights");
+            }
+        } else if (InferenceEngine::details::CaselessEq<std::string>()(layer->type, "DeformableConvolution")) {
+            auto * defConvLayer = dynamic_cast<DeformableConvolutionLayer*>(layer.get());
+            if (defConvLayer == nullptr)
+                THROW_IE_EXCEPTION << "Cannot convert deformable convolution layer.";
+
+            Blob::Ptr weightsBlob = defConvLayer->blobs["weights"];
+            if (weightsBlob != nullptr) {
+                std::vector<size_t> shape;
+
+                if (defConvLayer->_group != 1) {
+                    shape.push_back(defConvLayer->_group);
+                }
+                shape.push_back(defConvLayer->_out_depth);
+                shape.push_back(defConvLayer->input()->getDims()[1]);
+                for (int i = 1; i <= defConvLayer->_kernel.size(); i++) {
+                    shape.push_back(defConvLayer->_kernel[defConvLayer->_kernel.size() - i]);
+                }
+
+                createConstInputTo(layer, weightsBlob, shape, "weights");
+
+                defConvLayer->blobs.clear();
+                defConvLayer->_weights = nullptr;
+            }
+        } else if (InferenceEngine::details::CaselessEq<std::string>()(layer->type, "BinaryConvolution")) {
+            auto * binConvLayer = dynamic_cast<BinaryConvolutionLayer*>(layer.get());
+            if (binConvLayer == nullptr)
+                THROW_IE_EXCEPTION << "Cannot convert binary convolution layer.";
+
+            Blob::Ptr weightsBlob = binConvLayer->blobs["weights"];
+            if (weightsBlob != nullptr) {
+                std::vector<size_t> shape;
+
+                if (binConvLayer->_group != 1) {
+                    shape.push_back(binConvLayer->_group);
+                }
+                shape.push_back(binConvLayer->_out_depth);
+                shape.push_back(binConvLayer->input()->getDims()[1]);
+                for (int i = 1; i <= binConvLayer->_kernel.size(); i++) {
+                    shape.push_back(binConvLayer->_kernel[binConvLayer->_kernel.size() - i]);
+                }
+
+                createConstInputTo(layer, weightsBlob, shape, "weights");
+
+                binConvLayer->blobs.clear();
+                binConvLayer->_weights = nullptr;
+            }
+        } else if (InferenceEngine::details::CaselessEq<std::string>()(layer->type, "Convolution")  && layer->insData.size() == 1) {
+            auto * convLayer = dynamic_cast<ConvolutionLayer*>(layer.get());
+            if (convLayer == nullptr)
+                THROW_IE_EXCEPTION << "Cannot convert convolution layer.";
+
+            bool const isGrouped = convLayer->_group != 1;
+            size_t const groupNum = convLayer->_group;
+            size_t const groupIC = isGrouped
+                                ? convLayer->input()->getDims()[1] / groupNum
+                                : convLayer->input()->getDims()[1];
+            size_t const groupOC = isGrouped
+                                ? convLayer->_out_depth / groupNum
+                                : convLayer->_out_depth;
+
+            auto weightsBlobIt = convLayer->blobs.find("weights");
+            auto biasesBlobIt = convLayer->blobs.find("biases");
+
+            if (weightsBlobIt != convLayer->blobs.end()) {
+                Blob::Ptr weightsBlob = weightsBlobIt->second;
+
+                std::vector<size_t> shape;
+
+                if (isGrouped) {
+                    shape.reserve(convLayer->_kernel.size() + 3);
+                    shape.emplace_back(groupNum);
+                    shape.emplace_back(groupOC);
+                    shape.emplace_back(groupIC);
+                } else {
+                    shape.reserve(convLayer->_kernel.size() + 2);
+                    shape.emplace_back(groupOC);
+                    shape.emplace_back(groupIC);
+                }
+
+                for (int i = 1; i <= convLayer->_kernel.size(); i++) {
+                    shape.emplace_back(convLayer->_kernel[convLayer->_kernel.size() - i]);
+                }
+
+                createConstInputTo(layer, weightsBlob, shape, "weights");
+            }
+
+            if (biasesBlobIt != convLayer->blobs.end()) {
+                Blob::Ptr biasesBlob = biasesBlobIt->second;
+                std::vector<size_t> shape = { groupOC * groupNum };
+                createConstInputTo(layer, biasesBlob, shape, "biases");
+            }
+        }
+    }
 }
 
 static void Transformation(CNNNetwork& clonedNetwork, const Config& conf) {
@@ -548,6 +715,7 @@ QueryNetworkResult Engine::QueryNetwork(const CNNNetwork& network, const std::ma
 
         auto clonedNetwork = InferenceEngine::cloneNetwork(network);
         Transformation(clonedNetwork, conf);
+        CreateConstInputs(clonedNetwork);
         std::unordered_set<std::string> supported;
         std::unordered_set<std::string> unsupported;
         for (details::CNNNetworkIterator itLayer{clonedNetwork}; itLayer != details::CNNNetworkIterator(); itLayer++) {

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
@@ -798,11 +798,15 @@ MKLDNNMemoryDesc MKLDNNConvolutionNode::getSrcMemDesc(mkldnn::primitive_desc_ite
 }
 
 const mkldnn::memory& MKLDNNConvolutionNode::getWeights() const {
-    return baseInputsNumber > 1 ? getParentEdgeAt(1)->getMemory().GetPrimitive() : internalBlobMemory[0]->GetPrimitive();
+    if (baseInputsNumber > 1)
+        return getParentEdgeAt(1)->getMemory().GetPrimitive();
+    THROW_IE_EXCEPTION << "Convolution layer " << getName() << " has no input weights";
 }
 
 const mkldnn::memory& MKLDNNConvolutionNode::getBias() const {
-    return baseInputsNumber > 2 ? getParentEdgeAt(2)->getMemory().GetPrimitive() : internalBlobMemory[1]->GetPrimitive();
+    if (baseInputsNumber > 2)
+        return getParentEdgeAt(2)->getMemory().GetPrimitive();
+    THROW_IE_EXCEPTION << "Convolution layer " << getName() << " has no input biases";
 }
 
 InferenceEngine::Precision MKLDNNConvolutionNode::getRuntimePrecision() const {

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
@@ -25,11 +25,9 @@ MKLDNNConvolutionNode::MKLDNNConvolutionNode(const InferenceEngine::CNNLayerPtr&
         : MKLDNNNode(layer, eng, cache), withBiases(false), withSum(false), withDWConv(false), isDW(false), isMerged(false),
           isGrouped(false), dw_conv_oc(0), dw_conv_ih(0), dw_conv_iw(0), dw_conv_in_dt(memory::data_type::undef),
           groupNum(1lu), baseInputsNumber(1), eltwisePrecision(Precision::FP32) {
-    if (getCnnLayer()->type == "Convolution") {
-        baseInputsNumber = getCnnLayer().get()->insData.size();
-        if (baseInputsNumber < 2)
-            THROW_IE_EXCEPTION << "Incorrect number of input edges for layer " << getName();
-    }
+    baseInputsNumber = getCnnLayer().get()->insData.size();
+    if (baseInputsNumber < 2)
+        IE_THROW() << "Incorrect number of input edges for layer " << getName();
 }
 
 mkldnn::memory::data_type MKLDNNConvolutionNode::precisionToDataType(InferenceEngine::Precision prec) const {
@@ -804,13 +802,13 @@ MKLDNNMemoryDesc MKLDNNConvolutionNode::getSrcMemDesc(mkldnn::primitive_desc_ite
 const mkldnn::memory& MKLDNNConvolutionNode::getWeights() const {
     if (baseInputsNumber > 1)
         return getParentEdgeAt(1)->getMemory().GetPrimitive();
-    THROW_IE_EXCEPTION << "Convolution layer " << getName() << " has no input weights";
+    IE_THROW() << "Convolution layer " << getName() << " has no input weights";
 }
 
 const mkldnn::memory& MKLDNNConvolutionNode::getBias() const {
     if (baseInputsNumber > 2)
         return getParentEdgeAt(2)->getMemory().GetPrimitive();
-    THROW_IE_EXCEPTION << "Convolution layer " << getName() << " has no input biases";
+    IE_THROW() << "Convolution layer " << getName() << " has no input biases";
 }
 
 InferenceEngine::Precision MKLDNNConvolutionNode::getRuntimePrecision() const {

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
@@ -401,6 +401,10 @@ void MKLDNNConvolutionNode::setPostOps(mkldnn::primitive_attr &attr, bool initWe
     attr.set_post_ops(ops);
 }
 
+void MKLDNNConvolutionNode::selectOptimalPrimitiveDescriptor() {
+    selectPreferPrimitiveDescriptor(getPrimitivesPriority(), true);
+}
+
 void MKLDNNConvolutionNode::initSupportedPrimitiveDescriptors() {
     if (!supportedPrimitiveDescriptors.empty())
         return;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.h
@@ -24,6 +24,7 @@ public:
                           const std::vector<InferenceEngine::TensorDesc>& outputDesc) override;
     void initDescriptor(const InferenceEngine::LayerConfig& config) override;
     void createPrimitive() override;
+    void selectOptimalPrimitiveDescriptor() override;
     void initSupportedPrimitiveDescriptors() override;
     void filterSupportedPrimitiveDescriptors() override;
     void filterSupportedDescriptors();

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.h
@@ -48,7 +48,7 @@ public:
     const mkldnn::memory& getWeights() const;
     const mkldnn::memory& getBias() const;
 
-    bool canBeExecutedInInt8();
+    bool canBeExecutedInInt8() const;
 
     InferenceEngine::Precision getRuntimePrecision() const override;
 
@@ -57,11 +57,10 @@ public:
     std::vector<int32_t> outputCompensation;
 
 protected:
-    void addScaleToPrimitiveAttr(mkldnn::primitive_attr attr) const;
     InferenceEngine::Precision fusedEltwisePrecision(MKLDNNEltwiseNode *eltwiseNode, int findex);
 
 private:
-    mkldnn::memory::data_type precisionToDataType(InferenceEngine::Precision prec);
+    mkldnn::memory::data_type precisionToDataType(InferenceEngine::Precision prec) const;
     void addZeroPoints(mkldnn::primitive_attr& attr) const;
 
     bool withBiases;
@@ -84,8 +83,6 @@ private:
     std::vector<ptrdiff_t> dw_conv_strides;
     mkldnn::memory::data_type dw_conv_in_dt;
     std::vector<MKLDNNMemoryPtr> PostOpsIntBlobMemory;
-
-    InferenceEngine::Blob::Ptr wScale, oScale;
 
     size_t groupNum;
     int baseInputsNumber;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_eltwise_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_eltwise_node.cpp
@@ -1446,54 +1446,7 @@ void MKLDNNEltwiseNode::createPrimitive() {
 }
 
 void MKLDNNEltwiseNode::selectOptimalPrimitiveDescriptor() {
-    for (auto& type : getPrimitivesPriority()) {
-        int selectedPrimitive = -1;
-        int equalsFormatCount = -1;
-        for (size_t i = 0; i < getSupportedPrimitiveDescriptors().size(); i++) {
-            impl_desc_type supportedType = getSupportedPrimitiveDescriptors()[i].getImplementationType();
-            if (type == supportedType) {
-                int equalsLocalFormatCount = 0;
-                if (getSupportedPrimitiveDescriptors()[i].getConfig().inConfs.size() > getParentEdges().size())
-                    continue;
-                for (size_t j = 0; j < getSupportedPrimitiveDescriptors()[i].getConfig().inConfs.size(); j++) {
-                    auto parentEdge = getParentEdgeAt(j);
-                    auto parentPtr = parentEdge->getParent();
-                    // We don't take into account constant edges since reorders on them will be executed on load network stage
-                    if (j > 0 && parentPtr->isConstant()) {
-                        equalsLocalFormatCount++;
-                        continue;
-                    }
-
-                    auto parent_spd = parentPtr->getSelectedPrimitiveDescriptor();
-
-                    if (parent_spd != nullptr && !parent_spd->getConfig().outConfs.empty()) {
-                        int inNum = parentEdge->getInputNum();
-                        if (inNum < 0 || inNum >= parent_spd->getConfig().outConfs.size()) {
-                            inNum = 0;
-                        }
-                        if (MKLDNNExtensionUtils::initTensorsAreEqual(
-                                getSupportedPrimitiveDescriptors()[i].getConfig().inConfs[j].desc,
-                                parent_spd->getConfig().outConfs[inNum].desc)) {
-                            equalsLocalFormatCount++;
-                        }
-                    }
-                }
-                if (equalsLocalFormatCount > equalsFormatCount) {
-                    equalsFormatCount = equalsLocalFormatCount;
-                    selectedPrimitive = static_cast<int>(i);
-                }
-            }
-        }
-        if (selectedPrimitive >= 0) {
-            selectPrimitiveDescriptorByIndex(selectedPrimitive);
-            return;
-        }
-    }
-
-    if (getSupportedPrimitiveDescriptors().empty())
-        IE_THROW() << "Supported primitive descriptors list is empty for node: " << getName();
-    // fallback. If there are no primitives from priority list just select a first
-    selectPrimitiveDescriptorByIndex(0);
+    selectPreferPrimitiveDescriptor(getPrimitivesPriority(), true);
 }
 
 void MKLDNNEltwiseNode::initOptimalPrimitiveDescriptor() {

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_input_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_input_node.cpp
@@ -32,10 +32,12 @@ MKLDNNInputNode::MKLDNNInputNode(const InferenceEngine::CNNLayerPtr& layer, cons
     }
 }
 
-void MKLDNNInputNode::cloneIfRequired(const InferenceEngine::Blob::Ptr & blob, const InferenceEngine::TensorDesc & tensorDesc) {
+void MKLDNNInputNode::cloneIfRequired(const InferenceEngine::Blob::Ptr & blob, const InferenceEngine::TensorDesc & outTensorDesc) {
     ieConstBlob = blob;
 
-    auto memDesc = MKLDNNMemoryDesc(tensorDesc);
+    const InferenceEngine::TensorDesc& td = {blob->getTensorDesc().getPrecision(), outTensorDesc.getDims(), outTensorDesc.getLayout()};
+
+    auto memDesc = MKLDNNMemoryDesc(td);
 
     if (weightCache) {
         char ptr[32];
@@ -55,8 +57,7 @@ void MKLDNNInputNode::cloneIfRequired(const InferenceEngine::Blob::Ptr & blob, c
             return _ptr;
         };
 
-        constBlob = weightCache->findOrCreate(key, cloneBlob);
->>>>>>> 8b96e6d32... Shared weights cache usage for const input nodes
+        constBlob = *weightCache->findOrCreate(key, cloneBlob);
     } else {
         constBlob = MKLDNNMemoryPtr(new MKLDNNMemory(getEngine()));
         constBlob->Create(memDesc, blob->buffer());

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_input_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_input_node.h
@@ -24,7 +24,7 @@ public:
     MKLDNNMemoryPtr getConstBlob() const;
 
 private:
-    void cloneIfRequired(const InferenceEngine::Blob::Ptr & blob, const InferenceEngine::TensorDesc & tensorDesc);
+    void cloneIfRequired(const InferenceEngine::Blob::Ptr & blob, const InferenceEngine::TensorDesc & outTensorDesc);
 
 private:
     InferenceEngine::Precision precision;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_input_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_input_node.h
@@ -20,10 +20,8 @@ public:
     void createPrimitive() override;
     bool created() const override;
 
-    void execute(mkldnn::stream strm) override;
-    void withMeanImage() {
-        isMeanImage = true;
-    }
+    void withMeanImage();
+    InferenceEngine::Blob::Ptr getConstBlob() const;
 
 private:
     InferenceEngine::Precision precision;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_input_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_input_node.h
@@ -21,12 +21,15 @@ public:
     bool created() const override;
 
     void withMeanImage();
-    InferenceEngine::Blob::Ptr getConstBlob() const;
+    MKLDNNMemoryPtr getConstBlob() const;
+
+private:
+    void cloneIfRequired(const InferenceEngine::Blob::Ptr & blob);
 
 private:
     InferenceEngine::Precision precision;
-
-    InferenceEngine::Blob::Ptr constBlob;
+    InferenceEngine::Blob::Ptr ieConstBlob;
+    MKLDNNMemoryPtr constBlob;
     bool isMeanImage = false;
 };
 

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_input_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_input_node.h
@@ -24,7 +24,7 @@ public:
     MKLDNNMemoryPtr getConstBlob() const;
 
 private:
-    void cloneIfRequired(const InferenceEngine::Blob::Ptr & blob);
+    void cloneIfRequired(const InferenceEngine::Blob::Ptr & blob, const InferenceEngine::TensorDesc & tensorDesc);
 
 private:
     InferenceEngine::Precision precision;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_rnn.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_rnn.h
@@ -65,10 +65,6 @@ private:
     MKLDNNMemoryDesc w_data_d;
     MKLDNNMemoryDesc w_state_d;
     MKLDNNMemoryDesc w_bias_d;
-
-    // List of in/out reorders if required
-    std::vector<mkldnn::reorder> exec_before;
-    std::vector<mkldnn::reorder> exec_after;
 };
 
 }  // namespace MKLDNNPlugin

--- a/inference-engine/src/readers/ir_reader/ie_ir_parser.cpp
+++ b/inference-engine/src/readers/ir_reader/ie_ir_parser.cpp
@@ -547,7 +547,7 @@ void XmlDeserializer::on_adapter(
 
 std::shared_ptr<ngraph::Function> XmlDeserializer::parse_function(
     const pugi::xml_node& root, const Blob::CPtr& weights) {
-    OV_ITT_TASK_CHAIN(taskChain, itt::domains::V10Reader_RT, "V10Parser", "Parse");
+    OV_ITT_SCOPE_CHAIN(FIRST_INFERENCE, taskChain, itt::domains::V10Reader_RT, "V10Parser", "Parse");
 
     struct FunctionNodes {
         ngraph::ParameterVector parameters;
@@ -606,7 +606,7 @@ std::shared_ptr<ngraph::Function> XmlDeserializer::parse_function(
     };
     std::for_each(outputs.begin(), outputs.end(), dfs);
 
-    OV_ITT_TASK_NEXT(taskChain, "ConstructNgraphNodes");
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "ConstructNgraphNodes");
 
     FunctionNodes func_nodes;
 
@@ -667,7 +667,7 @@ std::shared_ptr<ngraph::Function> XmlDeserializer::parse_function(
         func_nodes.all.emplace_back(node);
     }
 
-    OV_ITT_TASK_NEXT(taskChain, "ConstructNgraphFunction");
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "ConstructNgraphFunction");
 
     auto function = std::make_shared<ngraph::Function>(
         func_nodes.results, func_nodes.sinks, func_nodes.parameters, GetStrAttr(root, "name", ""));

--- a/inference-engine/src/readers/ir_reader/ie_ir_parser.cpp
+++ b/inference-engine/src/readers/ir_reader/ie_ir_parser.cpp
@@ -885,7 +885,7 @@ std::shared_ptr<ICNNNetwork> V10Parser::parse(
     XmlDeserializer visitor(root, weights, opsets, variables);
     visitor.on_attribute("net", function);
 
-    OV_ITT_SCOPED_TASK(itt::domains::V10Reader_RT, "ConstructCNNNetwork");
+    OV_ITT_SCOPE(FIRST_INFERENCE, itt::domains::V10Reader_RT, "ConstructCNNNetwork");
 
     CNNNetwork net(function, _exts);
     parsePreProcess(net, root, weights);

--- a/inference-engine/src/readers/ir_reader/ie_ir_reader.cpp
+++ b/inference-engine/src/readers/ir_reader/ie_ir_reader.cpp
@@ -33,14 +33,19 @@ CNNNetwork IRReader::read(std::istream& model, const std::vector<IExtensionPtr>&
     return read(model, nullptr, exts);
 }
 
-CNNNetwork IRReader::read(std::istream& model, const Blob::CPtr& weights, const std::vector<IExtensionPtr>& exts) const {
-    OV_ITT_SCOPED_TASK(itt::domains::V10Reader, "IRReader::read");
-
-    pugi::xml_document xmlDoc;
+static void loadXml(pugi::xml_document &xmlDoc, std::istream& model) {
+    OV_ITT_SCOPE(FIRST_INFERENCE, itt::domains::V10Reader_RT, "loadXml");
     pugi::xml_parse_result res = xmlDoc.load(model);
     if (res.status != pugi::status_ok) {
         IE_THROW() << res.description() << "at offset " << res.offset;
     }
+}
+
+CNNNetwork IRReader::read(std::istream& model, const Blob::CPtr& weights, const std::vector<IExtensionPtr>& exts) const {
+    OV_ITT_SCOPED_TASK(itt::domains::V10Reader, "IRReader::read");
+
+    pugi::xml_document xmlDoc;
+    loadXml(xmlDoc, model);
     pugi::xml_node root = xmlDoc.document_element();
 
     auto version = details::GetIRVersion(root);

--- a/inference-engine/src/transformations/src/transformations/rt_info/fused_names_attribute.cpp
+++ b/inference-engine/src/transformations/src/transformations/rt_info/fused_names_attribute.cpp
@@ -67,6 +67,8 @@ std::string getFusedNames(const std::shared_ptr<ngraph::Node> &node) {
 }
 
 std::vector<std::string> getFusedNamesVector(const std::shared_ptr<ngraph::Node> &node) {
+    if (!node) return {};
+
     const auto &rtInfo = node->get_rt_info();
     using FusedNamesWraper = VariantWrapper<FusedNames>;
 

--- a/inference-engine/tests_deprecated/functional/mkldnn/single_layer_tests/conv_int8_tests.cpp
+++ b/inference-engine/tests_deprecated/functional/mkldnn/single_layer_tests/conv_int8_tests.cpp
@@ -303,7 +303,7 @@ protected:
 
 using smoke_conv_u8s32 = smoke_ConvolutionInt8OnlyTest<uint8_t>;
 
-TEST_P(smoke_conv_u8s32, TestsConvolution) {
+TEST_P(smoke_conv_u8s32, DISABLED_TestsConvolution) {
 }
 
 std::string getTestCaseInt8Name(testing::TestParamInfo<conv_test_params> obj) {

--- a/inference-engine/tests_deprecated/unit/engines/mkldnn/dumper_test.cpp
+++ b/inference-engine/tests_deprecated/unit/engines/mkldnn/dumper_test.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include "test_graph.hpp"
 #include "mkldnn_graph.h"
 #include "mkldnn_graph_dumper.h"
 #include "ie_blob.h"
@@ -62,7 +63,7 @@ public:
 
 TEST(MKLDNNLayersTests, DumpSimpleGraph) {
     auto net = NetGen().net();
-    MKLDNNGraph graph;
+    MKLDNNGraphTestClass graph;
     MKLDNNExtensionManager::Ptr extMgr;
     MKLDNNWeightsSharing::Ptr cache;
 
@@ -71,16 +72,19 @@ TEST(MKLDNNLayersTests, DumpSimpleGraph) {
     auto dump_net = dump_graph_as_ie_net(graph);
     auto layers = details::CNNNetSortTopologically(dump_net);
 
-    ASSERT_EQ(layers.size(), 4);
+    ASSERT_EQ(layers.size(), 7);
     ASSERT_EQ(layers[0]->type, "Input");
-    ASSERT_EQ(layers[1]->type, "Convolution");
+    ASSERT_EQ(layers[1]->type, "Const");    // Weights
     ASSERT_EQ(layers[2]->type, "Reorder");
-    ASSERT_EQ(layers[3]->type, "Output");
+    ASSERT_EQ(layers[3]->type, "Const");    // Biases
+    ASSERT_EQ(layers[4]->type, "Convolution");
+    ASSERT_EQ(layers[5]->type, "Reorder");
+    ASSERT_EQ(layers[6]->type, "Output");
 }
 
 TEST(MKLDNNLayersTests, DumpSimpleGraphToDot) {
     auto net = NetGen().net();
-    MKLDNNGraph graph;
+    MKLDNNGraphTestClass graph;
     MKLDNNExtensionManager::Ptr extMgr;
     MKLDNNWeightsSharing::Ptr cache;
     graph.CreateGraph(net, extMgr, cache);
@@ -92,7 +96,7 @@ TEST(MKLDNNLayersTests, DumpSimpleGraphToDot) {
     std::cout << dot;
     ASSERT_EQ(std::count(dot.begin(), dot.end(), '{'), 1); // 1-graph
     ASSERT_EQ(std::count(dot.begin(), dot.end(), '}'), 1);
-    ASSERT_EQ(std::count(dot.begin(), dot.end(), '['), 10); // 4-node 3-data 3-shape
-    ASSERT_EQ(std::count(dot.begin(), dot.end(), ']'), 10);
-    ASSERT_EQ(std::count(dot.begin(), dot.end(), '>'), 6); // connection
+    ASSERT_EQ(std::count(dot.begin(), dot.end(), '['), 19); // 7-nodes 6-data 6-shape
+    ASSERT_EQ(std::count(dot.begin(), dot.end(), ']'), 19);
+    ASSERT_EQ(std::count(dot.begin(), dot.end(), '>'), 12); // connection
 }

--- a/inference-engine/tests_deprecated/unit/engines/mkldnn/graph/layers/internal/graph_reorder_test.cpp
+++ b/inference-engine/tests_deprecated/unit/engines/mkldnn/graph/layers/internal/graph_reorder_test.cpp
@@ -98,7 +98,7 @@ TEST_F(MKLDNNGraphReorderTests, CreateReorder) {
             ASSERT_EQ(MKLDNNPlugin::impl_desc_type::ref_any,
                       nodes[i]->getSupportedPrimitiveDescriptors()[0].getImplementationType());
             ASSERT_EQ(1, nodes[i]->getSupportedPrimitiveDescriptors()[0].getConfig().inConfs.size());
-            if (i == 1) {
+            if (i == 2 || i == 4) {
                 ASSERT_EQ(InferenceEngine::Layout::NCHW, nodes[i]->getSupportedPrimitiveDescriptors()[0].getConfig().inConfs[0].desc.getLayout());
                 ASSERT_NE(InferenceEngine::Layout::NCHW, nodes[i]->getSupportedPrimitiveDescriptors()[0].getConfig().outConfs[0].desc.getLayout());
             } else {

--- a/inference-engine/tests_deprecated/unit/engines/mkldnn/graph/structure/graph_conv_depthwise_fusing_test.cpp
+++ b/inference-engine/tests_deprecated/unit/engines/mkldnn/graph/structure/graph_conv_depthwise_fusing_test.cpp
@@ -257,19 +257,24 @@ protected:
             auto& nodes = graph.getNodes();
             nodes = graph.getNodes();
             if (p.in.c == 3) {
-                ASSERT_EQ(nodes.size(), 3);
-                ASSERT_EQ(nodes[0].get()->getType(), MKLDNNPlugin::Type::Input);
-                ASSERT_EQ(nodes[1].get()->getType(), MKLDNNPlugin::Type::Convolution);
-                ASSERT_TRUE(nodes[1].get()->isFusedWith(MKLDNNPlugin::Type::Eltwise));
-                ASSERT_EQ(nodes[2].get()->getType(), MKLDNNPlugin::Type::Output);
-            } else {
                 ASSERT_EQ(nodes.size(), 5);
-                ASSERT_EQ(nodes[0].get()->getType(), MKLDNNPlugin::Type::Input);
-                ASSERT_EQ(nodes[1].get()->getType(), MKLDNNPlugin::Type::Reorder);
-                ASSERT_EQ(nodes[2].get()->getType(), MKLDNNPlugin::Type::Convolution);
-                ASSERT_TRUE(nodes[2].get()->isFusedWith(MKLDNNPlugin::Type::Eltwise));
-                ASSERT_EQ(nodes[3].get()->getType(), MKLDNNPlugin::Type::Reorder);
+                ASSERT_EQ(nodes[0].get()->getType(), MKLDNNPlugin::Type::Input);    // Convolution biases
+                ASSERT_EQ(nodes[1].get()->getType(), MKLDNNPlugin::Type::Input);    // Convolution weights
+                ASSERT_EQ(nodes[2].get()->getType(), MKLDNNPlugin::Type::Input);
+                ASSERT_EQ(nodes[3].get()->getType(), MKLDNNPlugin::Type::Convolution);
+                ASSERT_TRUE(nodes[3].get()->isFusedWith(MKLDNNPlugin::Type::Eltwise));
                 ASSERT_EQ(nodes[4].get()->getType(), MKLDNNPlugin::Type::Output);
+            } else {
+                ASSERT_EQ(nodes.size(), 8);
+                ASSERT_EQ(nodes[0].get()->getType(), MKLDNNPlugin::Type::Input);    // Convolution biases
+                ASSERT_EQ(nodes[1].get()->getType(), MKLDNNPlugin::Type::Input);    // Convolution weights
+                ASSERT_EQ(nodes[2].get()->getType(), MKLDNNPlugin::Type::Reorder);  // Convolution weights reorder
+                ASSERT_EQ(nodes[3].get()->getType(), MKLDNNPlugin::Type::Input);
+                ASSERT_EQ(nodes[4].get()->getType(), MKLDNNPlugin::Type::Reorder);
+                ASSERT_EQ(nodes[5].get()->getType(), MKLDNNPlugin::Type::Convolution);
+                ASSERT_TRUE(nodes[5].get()->isFusedWith(MKLDNNPlugin::Type::Eltwise));
+                ASSERT_EQ(nodes[6].get()->getType(), MKLDNNPlugin::Type::Reorder);
+                ASSERT_EQ(nodes[7].get()->getType(), MKLDNNPlugin::Type::Output);
             }
 
             InferenceEngine::SizeVector dims_src = {p.in.n, p.in.c, p.in.h, p.in.w};

--- a/ngraph/core/reference/src/runtime/reference/convert.cpp
+++ b/ngraph/core/reference/src/runtime/reference/convert.cpp
@@ -30,6 +30,7 @@ namespace ngraph
                     gen.vpmovzxbd(i32vec, u8vec);
                     gen.vcvtdq2ps(fvec, i32vec);
                     gen.vcvtps2ph(f16vec, fvec, 0);
+                    gen.vzeroupper();
                     gen.movdqu(gen.xword[dst], f16vec);
                 }
 

--- a/ngraph/core/src/function.cpp
+++ b/ngraph/core/src/function.cpp
@@ -88,7 +88,7 @@ Function::Function(const OutputVector& results,
 
 void Function::check_all_parameters_registered() const
 {
-    OV_ITT_SCOPE(FIRST_INFERENCE, ngraph::itt::domains::nGraphPass_LT,
+    OV_ITT_SCOPED_TASK(ngraph::itt::domains::nGraphPass,
                        "Function::check_all_parameters_registered");
     std::stringstream unregistered_parameters;
     for (auto& node : get_ordered_ops())
@@ -104,7 +104,7 @@ void Function::check_all_parameters_registered() const
 
 void Function::validate_nodes_and_infer_types() const
 {
-    OV_ITT_SCOPE(FIRST_INFERENCE, ngraph::itt::domains::nGraphPass_LT,
+    OV_ITT_SCOPED_TASK(ngraph::itt::domains::nGraphPass,
                        "Function::validate_nodes_and_infer_types");
 
     struct Counter

--- a/ngraph/core/src/function.cpp
+++ b/ngraph/core/src/function.cpp
@@ -88,7 +88,7 @@ Function::Function(const OutputVector& results,
 
 void Function::check_all_parameters_registered() const
 {
-    OV_ITT_SCOPED_TASK(ngraph::itt::domains::nGraphPass_LT,
+    OV_ITT_SCOPE(FIRST_INFERENCE, ngraph::itt::domains::nGraphPass_LT,
                        "Function::check_all_parameters_registered");
     std::stringstream unregistered_parameters;
     for (auto& node : get_ordered_ops())
@@ -104,7 +104,7 @@ void Function::check_all_parameters_registered() const
 
 void Function::validate_nodes_and_infer_types() const
 {
-    OV_ITT_SCOPED_TASK(ngraph::itt::domains::nGraphPass_LT,
+    OV_ITT_SCOPE(FIRST_INFERENCE, ngraph::itt::domains::nGraphPass_LT,
                        "Function::validate_nodes_and_infer_types");
 
     struct Counter

--- a/ngraph/core/src/pass/manager.cpp
+++ b/ngraph/core/src/pass/manager.cpp
@@ -97,7 +97,7 @@ void pass::Manager::run_passes(shared_ptr<Function> func)
             continue;
         }
 
-        OV_ITT_SCOPED_TASK(itt::domains::nGraphPass_LT,
+        OV_ITT_SCOPE(FIRST_INFERENCE, itt::domains::nGraphPass_LT,
                            pass::perf_counters()[pass->get_type_info()]);
 
         pass_timer.start();

--- a/openvino/conditional_compilation/include/openvino/cc/selective_build.h
+++ b/openvino/conditional_compilation/include/openvino/cc/selective_build.h
@@ -187,25 +187,8 @@ bool match(char const *region, Ctx && ctx, T && val, Case && cs, Cases&&... case
 
 #define OV_CC_DOMAINS(Module)
 
-// Placeholder for first macro argument
-#define OV_CC_SCOPE_ARG_PLACEHOLDER_1 0,
-
-// This macro returns second argument, first argument is ignored
-#define OV_CC_SCOPE_SECOND_ARG(...) OV_PP_EXPAND(OV_CC_SCOPE_SECOND_ARG_(__VA_ARGS__, 0))
-#define OV_CC_SCOPE_SECOND_ARG_(...) OV_PP_EXPAND(OV_CC_SCOPE_SECOND_ARG_GET(__VA_ARGS__))
-#define OV_CC_SCOPE_SECOND_ARG_GET(ignored, val, ...) val
-
-// Return macro argument value
-#define OV_CC_SCOPE_IS_ENABLED(x) OV_CC_SCOPE_IS_ENABLED1(x)
-
-// Generate junk macro or {0, } sequence if val is 1
-#define OV_CC_SCOPE_IS_ENABLED1(val) OV_CC_SCOPE_IS_ENABLED2(OV_PP_CAT(OV_CC_SCOPE_ARG_PLACEHOLDER_, val))
-
-// Return second argument from possible sequences {1, 0}, {0, 1, 0}
-#define OV_CC_SCOPE_IS_ENABLED2(arg1_or_junk) OV_CC_SCOPE_SECOND_ARG(arg1_or_junk 1, 0)
-
 #define OV_SCOPE(Module, region)    \
-    for (bool ovCCScopeIsEnabled = OV_CC_SCOPE_IS_ENABLED(OV_PP_CAT3(Module, _, region)); ovCCScopeIsEnabled; ovCCScopeIsEnabled = false)
+    for (bool ovCCScopeIsEnabled = OV_PP_IS_ENABLED(OV_PP_CAT3(Module, _, region)); ovCCScopeIsEnabled; ovCCScopeIsEnabled = false)
 
 // Switch is disabled
 #define OV_CC_SWITCH_0(Module, fn, ctx, val)
@@ -214,7 +197,7 @@ bool match(char const *region, Ctx && ctx, T && val, Case && cs, Cases&&... case
 #define OV_CC_SWITCH_1(Module, fn, ctx, val) openvino::cc::internal::match<fn>(ctx, val, OV_PP_CAT4(Module, _, fn, _cases));
 
 #define OV_SWITCH(Module, fn, ctx, val, ...)    \
-    OV_PP_EXPAND(OV_PP_CAT(OV_CC_SWITCH_, OV_CC_SCOPE_IS_ENABLED(OV_PP_CAT3(Module, _, fn)))(Module, fn, ctx, val))
+    OV_PP_EXPAND(OV_PP_CAT(OV_CC_SWITCH_, OV_PP_IS_ENABLED(OV_PP_CAT3(Module, _, fn)))(Module, fn, ctx, val))
 
 #define OV_CASE(Case, Type) openvino::cc::internal::make_case_wrapper<Type>(Case)
 

--- a/openvino/itt/CMakeLists.txt
+++ b/openvino/itt/CMakeLists.txt
@@ -14,6 +14,16 @@ target_link_libraries(${TARGET_NAME} PUBLIC openvino::pp)
 
 if(TARGET ittnotify)
     target_link_libraries(${TARGET_NAME} PUBLIC ittnotify)
+    if(ENABLE_PROFILING_FILTER STREQUAL "ALL")
+        target_compile_definitions(${TARGET_NAME} PUBLIC
+            ENABLE_PROFILING_ALL
+            ENABLE_PROFILING_FIRST_INFERENCE)
+    elseif(ENABLE_PROFILING_FILTER STREQUAL "FIRST_INFERENCE")
+        target_compile_definitions(${TARGET_NAME} PUBLIC
+            ENABLE_PROFILING_FIRST_INFERENCE)
+    else()
+        message(FATAL_ERROR "The ${ENABLE_PROFILING_FILTER} profiling filter isn't supported")
+    endif()
 endif()
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/openvino/itt/include/openvino/itt.hpp
+++ b/openvino/itt/include/openvino/itt.hpp
@@ -214,6 +214,8 @@ namespace openvino
  */
 #define OV_ITT_DOMAIN(...) OV_PP_OVERLOAD(OV_ITT_DOMAIN, __VA_ARGS__)
 
+#define OV_ITT_GROUP(group) OV_PP_CAT(ENABLE_PROFILING_, group)
+
 /**
  * @cond
  */
@@ -237,6 +239,37 @@ inline openvino::itt::domain_t domainName() noexcept                            
  */
 
 /**
+ * @def OV_ITT_SCOPE(domain, handleOrTaskName)
+ * @ingroup ie_dev_profiling
+ * @brief Annotate section of code till scope exit to be profiled using known @p handle or @p taskName as section id.
+ * @details In case if handle or taskName absent, the current function name is used.
+ * @param group [in] ITT counter group name used for enabling/disabling at compile time.
+ * @param domainName [in] Known at compile time name of module or library (the domain name).
+ * @param handleOrTaskName [in] The annotation name or handle for section of code. Parameter is optional.
+ */
+#define OV_ITT_SCOPE(group, ...)                                                                    \
+    OV_PP_EXPAND(OV_PP_CAT(OV_ITT_SCOPE_IMPL_, OV_PP_IS_ENABLED(OV_ITT_GROUP(group)))(__VA_ARGS__))
+
+/**
+ * @cond
+ */
+
+#define OV_ITT_SCOPE_IMPL_0(...)
+#define OV_ITT_SCOPE_IMPL_1(...) OV_PP_OVERLOAD(OV_ITT_SCOPE, __VA_ARGS__)
+
+#define OV_ITT_SCOPE_1(domain)                                                               \
+        openvino::itt::ScopedTask<domain> OV_PP_CAT(ittScopedTask, __LINE__)                        \
+                    (openvino::itt::handle<struct OV_PP_CAT(Task, __LINE__)>(ITT_FUNCTION_NAME));
+
+#define OV_ITT_SCOPE_2(domain, taskOrTaskName)                                               \
+        openvino::itt::ScopedTask<domain> OV_PP_CAT(ittScopedTask, __LINE__)                        \
+                    (openvino::itt::handle<struct OV_PP_CAT(Task, __LINE__)>(taskOrTaskName));
+
+/**
+ * @endcond
+ */
+
+/**
  * @def OV_ITT_SCOPED_TASK(domain, handleOrTaskName)
  * @ingroup ie_dev_profiling
  * @brief Annotate section of code till scope exit to be profiled using known @p handle or @p taskName as section id.
@@ -244,19 +277,97 @@ inline openvino::itt::domain_t domainName() noexcept                            
  * @param domainName [in] Known at compile time name of module or library (the domain name).
  * @param handleOrTaskName [in] The annotation name or handle for section of code. Parameter is optional.
  */
-#define OV_ITT_SCOPED_TASK(...) OV_PP_OVERLOAD(OV_ITT_SCOPED_TASK, __VA_ARGS__)
+#define OV_ITT_SCOPED_TASK(...) OV_ITT_SCOPE(ALL, __VA_ARGS__)
+
+/**
+ * @def OV_ITT_TASK_CHAIN(chainId, domain, prefix, taskName)
+ * @ingroup ie_dev_profiling
+ * @brief Begins the sequrence of an annotated sections of code using @p prefix and @p taskName as section id.
+ * @details In case if prefix absent, the current function name is used,
+ *          if taskName absent, the first chain index is used, i.e 1.
+ * @param group [in] ITT counter group name used for enabling/disabling at compile time.
+ * @param chainId [in] The tasks chain identifier.
+ * @param domainName [in] Known at compile time name of module or library (the domain name).
+ * @param prefix [in] The task chain name prefix. The task name starts with this prefix. Parameter is optional.
+ * @param taskName [in] The annotation name for section of code. Parameter is optional.
+ */
+#define OV_ITT_SCOPE_CHAIN(group, ...)                                                              \
+    OV_PP_EXPAND(OV_PP_CAT(OV_ITT_SCOPE_CHAIN_IMPL_, OV_PP_IS_ENABLED(OV_ITT_GROUP(group)))(__VA_ARGS__))
 
 /**
  * @cond
  */
 
-#define OV_ITT_SCOPED_TASK_1(domain)                                                                \
-        openvino::itt::ScopedTask<domain> OV_PP_CAT(ittScopedTask, __LINE__)                        \
-                    (openvino::itt::handle<struct OV_PP_CAT(Task, __LINE__)>(ITT_FUNCTION_NAME));
+#define OV_ITT_SCOPE_CHAIN_IMPL_0(...)
+#define OV_ITT_SCOPE_CHAIN_IMPL_1(...) OV_PP_OVERLOAD(OV_ITT_SCOPE_CHAIN, __VA_ARGS__)
 
-#define OV_ITT_SCOPED_TASK_2(domain, taskOrTaskName)                                                \
-        openvino::itt::ScopedTask<domain> OV_PP_CAT(ittScopedTask, __LINE__)                        \
-                    (openvino::itt::handle<struct OV_PP_CAT(Task, __LINE__)>(taskOrTaskName));
+#define OV_ITT_SCOPE_CHAIN_2(chainId, domain)                                                       \
+        openvino::itt::TaskChain<domain> chainId                                                    \
+            (openvino::itt::handle<struct OV_PP_CAT(Task, __LINE__)>                                \
+                (std::string(ITT_FUNCTION_NAME) + "_1"),                                            \
+            ITT_FUNCTION_NAME);
+
+#define OV_ITT_SCOPE_CHAIN_3(chainId, domain, prefix)                                               \
+        openvino::itt::TaskChain<domain> chainId                                                    \
+            (openvino::itt::handle<struct OV_PP_CAT(Task, __LINE__)>                                \
+                (std::string(prefix) + "_1"),                                                       \
+            prefix);
+
+#define OV_ITT_SCOPE_CHAIN_4(chainId, domain, prefix, taskName)                                     \
+        openvino::itt::TaskChain<domain> chainId                                                    \
+            (openvino::itt::handle<struct OV_PP_CAT(Task, __LINE__)>                                \
+                (std::string(prefix) + "_" + taskName),                                             \
+            prefix);
+
+/**
+ * @endcond
+ */
+
+/**
+ * @def OV_ITT_SCOPE_NEXT(group, chainId, taskName)
+ * @ingroup ie_dev_profiling
+ * @brief Inserts new annotated section of code to tasks chain using @p taskName as section id.
+ * @details If taskName is missing, the current chain index is used.
+ * @param group [in] ITT counter group name used for enabling/disabling at compile time.
+ * @param chainId [in] The tasks chain identifier.
+ * @param taskOrTaskName [in] The annotation name or handle for section of code. Parameter is optional.
+ */
+#define OV_ITT_SCOPE_NEXT(group, ...)                                                                \
+    OV_PP_EXPAND(OV_PP_CAT(OV_ITT_SCOPE_NEXT_IMPL_, OV_PP_IS_ENABLED(OV_ITT_GROUP(group)))(__VA_ARGS__))
+
+/**
+ * @cond
+ */
+
+#define OV_ITT_SCOPE_NEXT_IMPL_0(...)
+#define OV_ITT_SCOPE_NEXT_IMPL_1(...) OV_PP_OVERLOAD(OV_ITT_SCOPE_NEXT, __VA_ARGS__)
+
+#define OV_ITT_SCOPE_NEXT_1(chainId)                                                                 \
+        chainId.next(openvino::itt::handle<struct OV_PP_CAT(Task, __LINE__)>(chainId.taskName()));
+
+#define OV_ITT_SCOPE_NEXT_2(chainId, taskOrTaskName)                                                 \
+        chainId.next(openvino::itt::handle<struct OV_PP_CAT(Task, __LINE__)>(chainId.taskNameOrHandle(taskOrTaskName)));
+
+/**
+ * @endcond
+ */
+
+/**
+ * @def OV_ITT_SCOPE_SKIP(group, chainId)
+ * @ingroup ie_dev_profiling
+ * @brief Skips the remaining task scope.
+ * @param group [in] ITT counter group name used for enabling/disabling at compile time.
+ * @param chainId [in] The tasks chain identifier.
+ */
+#define OV_ITT_SCOPE_SKIP(group, chainId)                                                           \
+    OV_PP_EXPAND(OV_PP_CAT(OV_ITT_SCOPE_SKIP_, OV_PP_IS_ENABLED(OV_ITT_GROUP(group)))(chainId))
+
+/**
+ * @cond
+ */
+
+#define OV_ITT_SCOPE_SKIP_0(chainId)
+#define OV_ITT_SCOPE_SKIP_1(chainId) chainId.skip();
 
 /**
  * @endcond
@@ -273,33 +384,7 @@ inline openvino::itt::domain_t domainName() noexcept                            
  * @param prefix [in] The task chain name prefix. The task name starts with this prefix. Parameter is optional.
  * @param taskName [in] The annotation name for section of code. Parameter is optional.
  */
-#define OV_ITT_TASK_CHAIN(...) OV_PP_OVERLOAD(OV_ITT_TASK_CHAIN, __VA_ARGS__)
-
-/**
- * @cond
- */
-
-#define OV_ITT_TASK_CHAIN_2(chainId, domain)                                                        \
-        openvino::itt::TaskChain<domain> chainId                                                    \
-            (openvino::itt::handle<struct OV_PP_CAT(Task, __LINE__)>                                \
-                (std::string(ITT_FUNCTION_NAME) + "_1"),                                            \
-            ITT_FUNCTION_NAME);
-
-#define OV_ITT_TASK_CHAIN_3(chainId, domain, prefix)                                                \
-        openvino::itt::TaskChain<domain> chainId                                                    \
-            (openvino::itt::handle<struct OV_PP_CAT(Task, __LINE__)>                                \
-                (std::string(prefix) + "_1"),                                                       \
-            prefix);
-
-#define OV_ITT_TASK_CHAIN_4(chainId, domain, prefix, taskName)                                      \
-        openvino::itt::TaskChain<domain> chainId                                                    \
-            (openvino::itt::handle<struct OV_PP_CAT(Task, __LINE__)>                                \
-                (std::string(prefix) + "_" + taskName),                                             \
-            prefix);
-
-/**
- * @endcond
- */
+#define OV_ITT_TASK_CHAIN(...) OV_ITT_SCOPE_CHAIN(ALL, __VA_ARGS__)
 
 /**
  * @def OV_ITT_TASK_NEXT(chainId, taskName)
@@ -309,21 +394,7 @@ inline openvino::itt::domain_t domainName() noexcept                            
  * @param chainId [in] The tasks chain identifier.
  * @param taskOrTaskName [in] The annotation name or handle for section of code. Parameter is optional.
  */
-#define OV_ITT_TASK_NEXT(...) OV_PP_OVERLOAD(OV_ITT_TASK_NEXT, __VA_ARGS__)
-
-/**
- * @cond
- */
-
-#define OV_ITT_TASK_NEXT_1(chainId)                                                                 \
-        chainId.next(openvino::itt::handle<struct OV_PP_CAT(Task, __LINE__)>(chainId.taskName()));
-
-#define OV_ITT_TASK_NEXT_2(chainId, taskOrTaskName)                                                 \
-        chainId.next(openvino::itt::handle<struct OV_PP_CAT(Task, __LINE__)>(chainId.taskNameOrHandle(taskOrTaskName)));
-
-/**
- * @endcond
- */
+#define OV_ITT_TASK_NEXT(...) OV_ITT_SCOPE_NEXT(ALL, __VA_ARGS__)
 
 /**
  * @def OV_ITT_TASK_SKIP(chainId)
@@ -331,7 +402,7 @@ inline openvino::itt::domain_t domainName() noexcept                            
  * @brief Skips the remaining task scope.
  * @param chainId [in] The tasks chain identifier.
  */
-#define OV_ITT_TASK_SKIP(chainId) chainId.skip();
+#define OV_ITT_TASK_SKIP(chainId) OV_ITT_SCOPE_SKIP(ALL, chainId);
 
     } // namespace itt
 } // namespace openvino

--- a/openvino/itt/src/itt.cpp
+++ b/openvino/itt/src/itt.cpp
@@ -40,7 +40,7 @@ void taskBegin(domain_t d, handle_t t) {
 }
 
 void taskEnd(domain_t d) {
-    if (!callStackDepth() || call_stack_depth-- > 0)
+    if (!callStackDepth() || --call_stack_depth < callStackDepth())
         __itt_task_end(reinterpret_cast<__itt_domain*>(d));
 }
 

--- a/openvino/pp/include/openvino/pp.hpp
+++ b/openvino/pp/include/openvino/pp.hpp
@@ -30,3 +30,20 @@
 #define OV_PP_CAT4(x, y, z, w) OV_PP_CAT4_(x, y, z, w)
 
 #define OV_PP_OVERLOAD(NAME, ...) OV_PP_EXPAND( OV_PP_CAT3(NAME, _, OV_PP_EXPAND( OV_PP_NARG(OV_PP_NO_ARGS __VA_ARGS__ (NAME)) ))(__VA_ARGS__) )
+
+// Placeholder for first macro argument
+#define OV_PP_ARG_PLACEHOLDER_1 0,
+
+// This macro returns second argument, first argument is ignored
+#define OV_PP_SECOND_ARG(...) OV_PP_EXPAND(OV_PP_SECOND_ARG_(__VA_ARGS__, 0))
+#define OV_PP_SECOND_ARG_(...) OV_PP_EXPAND(OV_PP_SECOND_ARG_GET(__VA_ARGS__))
+#define OV_PP_SECOND_ARG_GET(ignored, val, ...) val
+
+// Return macro argument value
+#define OV_PP_IS_ENABLED(x) OV_PP_IS_ENABLED1(x)
+
+// Generate junk macro or {0, } sequence if val is 1
+#define OV_PP_IS_ENABLED1(val) OV_PP_IS_ENABLED2(OV_PP_CAT(OV_PP_ARG_PLACEHOLDER_, val))
+
+// Return second argument from possible sequences {1, 0}, {0, 1, 0}
+#define OV_PP_IS_ENABLED2(arg1_or_junk) OV_PP_SECOND_ARG(arg1_or_junk 1, 0)


### PR DESCRIPTION
### Details:
 - Compile time enabling or disabling of first inference time counters
 - New first inference time counters added
 - Counters for validate_nodes_and_infer_types and check_all_parameters_registered removed from first inference time counters scope

### Tickets:
 - CVS-52999
