### PR TITLE
Define OP version in report by first occurrence in opset instead of type_info

### DIFF
--- a/inference-engine/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
@@ -27,9 +27,6 @@ LayerTestsCommon::LayerTestsCommon() : threshold(1e-2f) {
 }
 
 void LayerTestsCommon::Run() {
-    auto &s = Summary::getInstance();
-    s.setDeviceName(targetDevice);
-
     auto crashHandler = [](int errCode) {
         auto &s = Summary::getInstance();
         s.saveReport();
@@ -37,6 +34,9 @@ void LayerTestsCommon::Run() {
         std::abort();
     };
     signal(SIGSEGV, crashHandler);
+
+    auto &s = Summary::getInstance();
+    s.setDeviceName(targetDevice);
 
     if (FuncTestUtils::SkipTestsConfig::currentTestIsDisabled()) {
         s.updateOPsStats(function, PassRate::Statuses::SKIPPED);

--- a/inference-engine/tests/ie_test_utils/functional_test_utils/include/functional_test_utils/layer_test_utils/summary.hpp
+++ b/inference-engine/tests/ie_test_utils/functional_test_utils/include/functional_test_utils/layer_test_utils/summary.hpp
@@ -67,12 +67,15 @@ private:
     static size_t saveReportTimeout;
     static bool extendReport;
     static bool saveReportWithUniqueName;
-    static const char* outputFolder;
+    static const char *outputFolder;
+    std::vector<ngraph::OpSet> opsets;
 
     friend class SummaryDestroyer;
 
+    std::string getOpVersion(const ngraph::NodeTypeInfo &type_info);
+
 protected:
-    Summary() = default;
+    Summary();
 
     ~Summary() = default;
 

--- a/inference-engine/tests/ie_test_utils/functional_test_utils/src/layer_test_utils/summary.cpp
+++ b/inference-engine/tests/ie_test_utils/functional_test_utils/src/layer_test_utils/summary.cpp
@@ -23,6 +23,16 @@ void SummaryDestroyer::initialize(Summary *p) {
     p_instance = p;
 }
 
+Summary::Summary() {
+    opsets.push_back(ngraph::get_opset1());
+    opsets.push_back(ngraph::get_opset2());
+    opsets.push_back(ngraph::get_opset3());
+    opsets.push_back(ngraph::get_opset4());
+    opsets.push_back(ngraph::get_opset5());
+    opsets.push_back(ngraph::get_opset6());
+    opsets.push_back(ngraph::get_opset7());
+}
+
 Summary &Summary::getInstance() {
     if (!p_instance) {
         p_instance = new Summary();
@@ -67,6 +77,15 @@ void Summary::updateOPsStats(const ngraph::NodeTypeInfo &op, const PassRate::Sta
                 break;
         }
     }
+}
+
+std::string Summary::getOpVersion(const ngraph::NodeTypeInfo &type_info) {
+    for (size_t i = 0; i < opsets.size(); i++) {
+        if (opsets[i].contains_type(type_info)) {
+            return std::to_string(i+1);
+        }
+    }
+    return "undefined";
 }
 
 std::map<std::string, PassRate> Summary::getOpStatisticFromReport() {
@@ -138,14 +157,6 @@ void Summary::saveReport() {
 
     std::string outputFilePath = outputFolder + std::string(CommonTestUtils::FileSeparator) + filename;
 
-    std::vector<ngraph::OpSet> opsets;
-    opsets.push_back(ngraph::get_opset1());
-    opsets.push_back(ngraph::get_opset2());
-    opsets.push_back(ngraph::get_opset3());
-    opsets.push_back(ngraph::get_opset4());
-    opsets.push_back(ngraph::get_opset5());
-    opsets.push_back(ngraph::get_opset6());
-    opsets.push_back(ngraph::get_opset7());
     std::set<ngraph::NodeTypeInfo> opsInfo;
     for (const auto &opset : opsets) {
         const auto &type_info_set = opset.get_type_info_set();
@@ -165,7 +176,7 @@ void Summary::saveReport() {
     char timeNow[80];
 
     time(&rawtime);
-    // cpplint require to use localtime_r instead which is not available in C++14
+    // cpplint require to use localtime_r instead which is not available in C++11
     timeinfo = localtime(&rawtime); // NOLINT
 
     strftime(timeNow, sizeof(timeNow), "%d-%m-%Y %H:%M:%S", timeinfo);
@@ -188,16 +199,16 @@ void Summary::saveReport() {
 
     pugi::xml_node opsNode = root.append_child("ops_list");
     for (const auto &op : opsInfo) {
-        std::string name = std::string(op.name) + "-" + std::to_string(op.version);
+        std::string name = std::string(op.name) + "-" + getOpVersion(op);
         pugi::xml_node entry = opsNode.append_child(name.c_str());
-        (void)entry;
+        (void) entry;
     }
 
     pugi::xml_node resultsNode = root.child("results");
     pugi::xml_node currentDeviceNode = resultsNode.append_child(summary.deviceName.c_str());
     std::unordered_set<std::string> opList;
     for (const auto &it : stats) {
-        std::string name = std::string(it.first.name) + "-" + std::to_string(it.first.version);
+        std::string name = std::string(it.first.name) + "-" + getOpVersion(it.first);
         opList.insert(name);
         pugi::xml_node entry = currentDeviceNode.append_child(name.c_str());
         entry.append_attribute("passed").set_value(it.second.passed);
@@ -209,7 +220,7 @@ void Summary::saveReport() {
 
     if (extendReport && file) {
         auto opStataFromReport = summary.getOpStatisticFromReport();
-        for (auto& item : opStataFromReport) {
+        for (auto &item : opStataFromReport) {
             pugi::xml_node entry;
             if (opList.find(item.first) == opList.end()) {
                 entry = currentDeviceNode.append_child(item.first.c_str());


### PR DESCRIPTION
### Details:
 - Define OP version in report by first occurrence in opset instead of type_info

### Tickets:
 - 53040
