### PR TITLE
Enable new `infer_request_inference` memleak test to cover  *-52623

### DIFF
--- a/tests/stress_tests/memleaks_tests/tests.cpp
+++ b/tests/stress_tests/memleaks_tests/tests.cpp
@@ -110,6 +110,14 @@ TEST_P(MemLeaksTestSuite, reinfer_request_inference) {
     };
     test_runner(test_params.numthreads, test);
 }
+
+TEST_P(MemLeaksTestSuite, infer_request_inference) {
+    auto test_params = GetParam();
+    auto test = [&] {
+        return test_infer_request_inference(test_params.model, test_params.device, test_params.numiters);
+    };
+    test_runner(test_params.numthreads, test);
+}
 // tests_pipelines/tests_pipelines.cpp
 
 INSTANTIATE_TEST_CASE_P(MemLeaksTests, MemLeaksTestSuiteNoModel,


### PR DESCRIPTION
### Details:
 - New memleak test with Core recreation and inference

### Tickets:
 - 52623
