### PR TITLE
Correct the sign definition of the result for the FloorMod operator (Sign should be like a divisor, not a dividend)

### DIFF
--- a/docs/ops/arithmetic/FloorMod_1.md
+++ b/docs/ops/arithmetic/FloorMod_1.md
@@ -13,7 +13,7 @@ As a first step input tensors *a* and *b* are broadcasted if their shapes differ
 o_{i} = a_{i} % b_{i}
 \f] 
 
-*FloorMod* operation computes a reminder of a floored division. It is the same behaviour like in Python programming language: `floor(x / y) * y + floor_mod(x, y) = x`. The sign of the result is equal to a sign of a dividend. The result of division by zero is undefined.
+*FloorMod* operation computes a reminder of a floored division. It is the same behaviour like in Python programming language: `floor(x / y) * y + floor_mod(x, y) = x`. The sign of the result is equal to a sign of a divisor. The result of division by zero is undefined.
 
 **Attributes**:
 


### PR DESCRIPTION
### Details:
This PR is related to:
https://github.com/openvinotoolkit/openvino/pull/5173

This sentence:
_The sign of the result is equal to a sign of a dividend_
appears to conflict with:
_It is the same behaviour like in Python programming language: `floor(x / y) * y + floor_mod(x, y) = x`._

Both the reference implementation and the CPU plugin take the sign from the divisor and it follows the formula above (see unit tests for this operator for details).

### Tickets:
 - 38712
