### PR TITLE
Revise Split Single Layer Tests

### DIFF
--- a/inference-engine/tests/functional/inference_engine/serialization/single_layer/split.cpp
+++ b/inference-engine/tests/functional/inference_engine/serialization/single_layer/split.cpp
@@ -1,0 +1,39 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "shared_test_classes/single_layer/split.hpp"
+
+using namespace LayerTestsDefinitions;
+
+namespace {
+
+TEST_P(SplitLayerTest, Serialize) {
+    Serialize();
+}
+
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+        InferenceEngine::Precision::FP32,
+        InferenceEngine::Precision::I32,
+        InferenceEngine::Precision::U16,
+        InferenceEngine::Precision::BOOL};
+
+INSTANTIATE_TEST_CASE_P(
+    smoke_Split_Serialization, SplitLayerTest,
+    ::testing::Combine(
+        ::testing::Values(1, 2, 5, 10),
+        ::testing::Values(0, 1, 2, 3),
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(std::vector<size_t>{20, 30, 50, 50}),
+        ::testing::Values(std::vector<size_t>({})),
+        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+    SplitLayerTest::getTestCaseName
+);
+
+}   // namespace

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/split.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/split.cpp
@@ -13,12 +13,14 @@ namespace {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
         InferenceEngine::Precision::FP32,
-        InferenceEngine::Precision::FP16
+        InferenceEngine::Precision::FP16,
+        InferenceEngine::Precision::I32,
+        InferenceEngine::Precision::U8
 };
 
 INSTANTIATE_TEST_CASE_P(smoke_NumSplitsCheck, SplitLayerTest,
                         ::testing::Combine(
-                                ::testing::Values(1),
+                                ::testing::Values(1, 2, 3, 5),
                                 ::testing::Values(0, 1, 2, 3),
                                 ::testing::ValuesIn(netPrecisions),
                                 ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),

--- a/inference-engine/tests/ie_test_utils/functional_test_utils/layer_tests_summary/summarize.py
+++ b/inference-engine/tests/ie_test_utils/functional_test_utils/layer_tests_summary/summarize.py
@@ -91,6 +91,7 @@ verified_operations = [
     'Sin-0',
     'SoftPlus-4',
     'Softmax-1',
+    'Split-1',
     'StridedSlice-1',
     'Substract-1',
     'Swish-4',


### PR DESCRIPTION
Single Layer Test of Split operation refactored.

Details:
- Added Serialization Single Layer Tests
- Added more test cases of SLT with more split axes, num_splits and precisions
- Added op to script of trusted ops

Tickets: 45936, 37481