### PR TITLE
[VPU]Fix segfault Myriad plugin during LoadNetwork with Hetero plugin

### DIFF
--- a/inference-engine/src/vpu/common/src/ngraph/query_network.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/query_network.cpp
@@ -66,13 +66,11 @@ InferenceEngine::QueryNetworkResult getQueryNetwork(const InferenceEngine::CNNNe
         }
     }
 
-    for (const auto& layerName : supported) {
+    for (const auto& layerName : unsupported) {
         if (supported.empty()) {
             break;
         }
-        if (InferenceEngine::details::contains(unsupported, layerName)) {
-            supported.erase(layerName);
-        }
+        supported.erase(layerName);
     }
 
     unsupported.clear();


### PR DESCRIPTION
This PR fix segmentation fault during `LoadNetwork` call: 
```
ie.LoadNetwork(net, "HETERO:MYRIAD,CPU", config)
```

### Tickets:
 - [CVS-52046](https://jira.devtools.intel.com/browse/CVS-52046)
