### PR TITLE
[CPU] Exclude colon characters from test names

### DIFF
--- a/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.cpp
@@ -80,9 +80,13 @@ cpu_memory_format_t CPUTestsBase::cpu_str2fmt(const char *str) {
 }
 
 std::string CPUTestsBase::fmts2str(const std::vector<cpu_memory_format_t> &fmts) {
+    return fmts2strWithPrefix(fmts, "cpu:");
+}
+
+std::string CPUTestsBase::fmts2strWithPrefix(const std::vector<cpu_memory_format_t> &fmts, const std::string &prefix) {
     std::string str;
     for (auto &fmt : fmts) {
-        ((str += "cpu:") += cpu_fmt2str(fmt)) += ",";
+        ((str += prefix) += cpu_fmt2str(fmt)) += ",";
     }
     if (!str.empty()) {
         str.pop_back();
@@ -190,10 +194,10 @@ std::string CPUTestsBase::getTestCaseName(CPUSpecificParams params) {
     std::string selectedType;
     std::tie(inFmts, outFmts, priority, selectedType) = params;
     if (!inFmts.empty()) {
-        result << "_inFmts=" << fmts2str(inFmts);
+        result << "_inFmts=" << fmts2strWithPrefix(inFmts, "");
     }
     if (!outFmts.empty()) {
-        result << "_outFmts=" << fmts2str(outFmts);
+        result << "_outFmts=" << fmts2strWithPrefix(outFmts, "");
     }
     if (!selectedType.empty()) {
         result << "_primitive=" << selectedType;

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.cpp
@@ -79,11 +79,7 @@ cpu_memory_format_t CPUTestsBase::cpu_str2fmt(const char *str) {
     return undef;
 }
 
-std::string CPUTestsBase::fmts2str(const std::vector<cpu_memory_format_t> &fmts) {
-    return fmts2strWithPrefix(fmts, "cpu:");
-}
-
-std::string CPUTestsBase::fmts2strWithPrefix(const std::vector<cpu_memory_format_t> &fmts, const std::string &prefix) {
+std::string CPUTestsBase::fmts2str(const std::vector<cpu_memory_format_t> &fmts, const std::string &prefix) {
     std::string str;
     for (auto &fmt : fmts) {
         ((str += prefix) += cpu_fmt2str(fmt)) += ",";
@@ -194,10 +190,10 @@ std::string CPUTestsBase::getTestCaseName(CPUSpecificParams params) {
     std::string selectedType;
     std::tie(inFmts, outFmts, priority, selectedType) = params;
     if (!inFmts.empty()) {
-        result << "_inFmts=" << fmts2strWithPrefix(inFmts, "");
+        result << "_inFmts=" << fmts2str(inFmts, "");
     }
     if (!outFmts.empty()) {
-        result << "_outFmts=" << fmts2strWithPrefix(outFmts, "");
+        result << "_outFmts=" << fmts2str(outFmts, "");
     }
     if (!selectedType.empty()) {
         result << "_primitive=" << selectedType;
@@ -229,11 +225,11 @@ CPUTestsBase::makeCPUInfo(std::vector<cpu_memory_format_t> inFmts, std::vector<c
 
     if (!inFmts.empty()) {
         cpuInfo.insert({std::string(ngraph::MLKDNNInputMemoryFormatsAttr),
-                        std::make_shared<ngraph::VariantWrapper<ngraph::MLKDNNInputMemoryFormats>>(ngraph::MLKDNNInputMemoryFormats(fmts2str(inFmts)))});
+                std::make_shared<ngraph::VariantWrapper<ngraph::MLKDNNInputMemoryFormats>>(ngraph::MLKDNNInputMemoryFormats(fmts2str(inFmts, "cpu:")))});
     }
     if (!outFmts.empty()) {
         cpuInfo.insert({std::string(ngraph::MLKDNNOutputMemoryFormatsAttr),
-                        std::make_shared<ngraph::VariantWrapper<ngraph::MLKDNNOutputMemoryFormats>>(ngraph::MLKDNNOutputMemoryFormats(fmts2str(outFmts)))});
+                std::make_shared<ngraph::VariantWrapper<ngraph::MLKDNNOutputMemoryFormats>>(ngraph::MLKDNNOutputMemoryFormats(fmts2str(outFmts, "cpu:")))});
     }
     if (!priority.empty()) {
         cpuInfo.insert({"PrimitivesPriority", std::make_shared<ngraph::VariantWrapper<std::string>>(impls2str(priority))});

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
@@ -92,6 +92,7 @@ public:
     static const char *cpu_fmt2str(cpu_memory_format_t v);
     static cpu_memory_format_t cpu_str2fmt(const char *str);
     static std::string fmts2str(const std::vector<cpu_memory_format_t> &fmts);
+    static std::string fmts2strWithPrefix(const std::vector<cpu_memory_format_t> &fmts, const std::string &prefix);
     static std::string impls2str(const std::vector<std::string> &priority);
     static CPUInfo makeCPUInfo(std::vector<cpu_memory_format_t> inFmts,
                                std::vector<cpu_memory_format_t> outFmts,

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
@@ -91,8 +91,7 @@ public:
     static std::string getTestCaseName(CPUSpecificParams params);
     static const char *cpu_fmt2str(cpu_memory_format_t v);
     static cpu_memory_format_t cpu_str2fmt(const char *str);
-    static std::string fmts2str(const std::vector<cpu_memory_format_t> &fmts);
-    static std::string fmts2strWithPrefix(const std::vector<cpu_memory_format_t> &fmts, const std::string &prefix);
+    static std::string fmts2str(const std::vector<cpu_memory_format_t> &fmts, const std::string &prefix);
     static std::string impls2str(const std::vector<std::string> &priority);
     static CPUInfo makeCPUInfo(std::vector<cpu_memory_format_t> inFmts,
                                std::vector<cpu_memory_format_t> outFmts,


### PR DESCRIPTION
":" is used for specifying list of filters in '--gtest_filter=' option
So when a test name contains a colon char it is impossible to run such
test by its full name.
There is no way to escape this colon char as well.
