### PR TITLE
Remove comparison with references from time_tests as unused

### DIFF
--- a/tests/time_tests/test_runner/test_timetest.py
+++ b/tests/time_tests/test_runner/test_timetest.py
@@ -70,17 +70,3 @@ def test_timetest(instance, executable, niter, cl_cache_dir, model_cache_dir, te
     # Add timetest results to submit to database and save in new test conf as references
     test_info["results"] = aggr_stats
     test_info["raw_results"] = raw_stats
-
-    # Compare with references
-    comparison_status = 0
-    for step_name, references in instance["references"].items():
-        for metric, reference_val in references.items():
-            if aggr_stats[step_name][metric] > reference_val * REFS_FACTOR:
-                logging.error("Comparison failed for '{}' step for '{}' metric. Reference: {}. Current values: {}"
-                              .format(step_name, metric, reference_val, aggr_stats[step_name][metric]))
-                comparison_status = 1
-            else:
-                logging.info("Comparison passed for '{}' step for '{}' metric. Reference: {}. Current values: {}"
-                             .format(step_name, metric, reference_val, aggr_stats[step_name][metric]))
-
-    assert comparison_status == 0, "Comparison with references failed"


### PR DESCRIPTION
### Details:
 - Remove comparison with references and reference dump as unused to do it on reporter side. After removing tests execution status will show only all is OK or not