### PR TITLE
[IE CLDNN] Add additional cost metric for deciding deconv kernel

### DIFF
--- a/inference-engine/thirdparty/clDNN/src/layout_optimizer.cpp
+++ b/inference-engine/thirdparty/clDNN/src/layout_optimizer.cpp
@@ -772,8 +772,9 @@ layout layout_optimizer::get_expected_layout(layout const& current_layout,
         auto input_tensor = node.get_dependency(0).get_output_layout().size;
         int input_features = input_tensor.feature[0];
         int output_features = expected_tensor.feature[0];
-        float r = static_cast<float>(input_features * output_features) / (align_to(input_features, 16) * align_to(output_features, 16));
-        if (r > 0.5f)
+        float f_cost = static_cast<float>(input_features * output_features) / (align_to(input_features, 16) * align_to(output_features, 16));
+        float stride_cost = 1/static_cast<float>(prim->stride.spatial[0]);
+        if (f_cost * stride_cost > 0.1f)
             expected_format = cldnn::format::b_fs_yx_fsv16;
         else
             expected_format = cldnn::format::bfyx;


### PR DESCRIPTION

### Details:
gen9_common_conv_bwd_data_kernel (used for fsv16 format) has additional overhead w.r.t stride. 
Current intention of the kernel implementation is to reuse kernel b/w multiple input values but if the stride gets bigger the reusable rate descreses.
Thus, added additional panelty for deciding deconv kernel (format)


### Tickets:
 - 49756
