### PR TITLE
Add Gather-7 to MO

### DIFF
--- a/model-optimizer/extensions/front/tf/gather_ext.py
+++ b/model-optimizer/extensions/front/tf/gather_ext.py
@@ -31,5 +31,5 @@ class GatherV2FrontExtractor(FrontExtractorOp):
 
     @classmethod
     def extract(cls, node):
-        Gather.update_node_stat(node, {})
+        Gather.update_node_stat(node, {'batch_dims': node.pb.attr['batch_dims'].i})
         return cls.enabled

--- a/model-optimizer/extensions/ops/gather.py
+++ b/model-optimizer/extensions/ops/gather.py
@@ -56,8 +56,7 @@ class Gather(Op):
         assert data_shape is not None
         indices_shape = node.in_port(1).data.get_shape()
         assert indices_shape is not None
-        axis = node.in_port(2).data.get_value()
-        assert axis is not None
+        assert node.in_port(2).data.get_value() is not None
         axis = Gather.get_axis(node)
 
         # we import PermuteInputs locally because it uses Gather inside and we have recursive imports
@@ -117,17 +116,15 @@ class AttributedGather(Op):
             "AttributedGather should have 2 connected input port, but it doesn't for node: `{}`. Ports: {}" \
             "".format(name, connected_in_ports)
 
-        axis = node.soft_get('axis', None)
-        assert axis is not None
+        assert node.has_valid('axis')
+        # Convert negative axis
+        axis = Gather.get_axis(node)
+        node.axis = axis
 
         data_shape = node.in_port(0).data.get_shape()
         assert data_shape is not None
         indices_shape = node.in_port(1).data.get_shape()
         assert indices_shape is not None
-
-        # Convert negative axis
-        axis = Gather.get_axis(node)
-        node.axis = axis
 
         PermuteAttrs.create_permute_attrs(node, attrs=[('axis', 'input:0')])
 

--- a/model-optimizer/extensions/ops/gather_test.py
+++ b/model-optimizer/extensions/ops/gather_test.py
@@ -3,59 +3,168 @@
 
 import unittest
 
-import numpy as np
+import numpy.testing as npt
 
 from extensions.ops.gather import Gather
 from mo.front.common.partial_infer.utils import int64_array
 from mo.graph.graph import Node
+from mo.middle.passes.infer import partial_infer
 from mo.utils.unittest.graph import build_graph
+from mo.utils.unittest.graph import valued_const_with_data, result, regular_op_with_empty_data, connect, shaped_input
 
 
 class TestGatherPartialInfer(unittest.TestCase):
+
     @staticmethod
-    def _create_graph():
-        nodes_attributes = {
-
-            'gather_input': {'kind': 'op'},
-            'gather_input_data': {'shape': None, 'value': None, 'kind': 'data'},
-            'gather_input2': {'kind': 'op'},
-            'gather_input2_data': {'shape': None, 'value': None, 'kind': 'data'},
-            'gather_input3': {'kind': 'op'},
-            'gather_input3_data': {'shape': None, 'value': 0, 'kind': 'data'},
-
-            'gather_node': {'op': 'Gather', 'kind': 'op'},
-            'gather_output': {'shape': None, 'value': None, 'kind': 'data'}
-
+    def build_and_test_value_inference(data, indices, axis, batch_dims, ref_value):
+        nodes = {
+            **valued_const_with_data('data', int64_array(data)),
+            **valued_const_with_data('indices', int64_array(indices)),
+            **valued_const_with_data('axis', int64_array(axis)),
+            **regular_op_with_empty_data('gather', {'op': 'Gather', 'batch_dims': batch_dims, 'infer': Gather.infer}),
+            **result('res'),
         }
-        return build_graph(nodes_attributes,
-                           [
-                               ('gather_input', 'gather_input_data'),
-                               ('gather_input2', 'gather_input2_data'),
-                               ('gather_input3', 'gather_input3_data'),
 
-                               ('gather_input_data', 'gather_node'),
-                               ('gather_input2_data', 'gather_node'),
-                               ('gather_input3_data', 'gather_node'),
+        edges = [
+            *connect('data', '0:gather'),
+            *connect('indices', '1:gather'),
+            *connect('axis', '2:gather'),
+            *connect('gather', 'res')
+        ]
 
-                               ('gather_node', 'gather_output'),
-                           ],
-                           {
-                               'gather_input_data': {'shape': int64_array([10, 15]), 'value': np.ones((3, 15))},
-                               'gather_input2_data': {'shape': int64_array([2]), 'value': np.array([0, 2])},
-                           })
+        graph = build_graph(nodes, edges)
+        graph.stage = 'middle'
+        partial_infer(graph)
 
-    def test_gather_infer(self):
-        graph = self._create_graph()
+        node = Node(graph, 'gather')
+        res = node.out_port(0).data.get_value()
+        npt.assert_array_equal(res, ref_value)
 
-        gather_node = Node(graph, 'gather_node')
-        Gather.infer(gather_node)
+    @staticmethod
+    def build_and_test_shape_inference(data_shape, indices_shape, axis, batch_dims, ref_shape):
+        nodes = {
+            **shaped_input('data', int64_array(data_shape)),
+            **shaped_input('indices', int64_array(indices_shape)),
+            **valued_const_with_data('axis', int64_array(axis)),
+            **regular_op_with_empty_data('gather', {'op': 'Gather', 'batch_dims': batch_dims, 'infer': Gather.infer}),
+            **result('res'),
+        }
 
-        exp_shape = int64_array([2, 15])
-        res_shape = graph.node['gather_output']['shape']
-        res_value = graph.node['gather_output']['value']
+        edges = [
+            *connect('data', '0:gather'),
+            *connect('indices', '1:gather'),
+            *connect('axis', '2:gather'),
+            *connect('gather', 'res')
+        ]
 
-        self.assertTrue(np.array_equal(exp_shape, res_shape),
-                        'shapes do not match expected: {} and given: {}'.format(exp_shape, res_shape))
+        graph = build_graph(nodes, edges)
+        graph.stage = 'middle'
+        partial_infer(graph)
 
-        self.assertTrue(np.array_equal(res_value, np.ones(exp_shape)),
-                        'shapes do not match expected: {} and given: {}'.format(exp_shape, res_shape))
+        node = Node(graph, 'gather')
+        res = node.out_port(0).data.get_shape()
+        npt.assert_array_equal(res, ref_shape)
+
+    def test_shape_axis_1(self):
+        self.build_and_test_shape_inference(axis=1, batch_dims=0,
+                                            data_shape=[3, 3],
+                                            indices_shape=[1, 2],
+                                            ref_shape=[3, 1, 2])
+
+    def test_shape_axis_0(self):
+        self.build_and_test_shape_inference(axis=0, batch_dims=0,
+                                            data_shape=[3, 3],
+                                            indices_shape=[1, 2],
+                                            ref_shape=[1, 2, 3])
+
+    def test_shape_axis_minus_2(self):
+        self.build_and_test_shape_inference(axis=-2, batch_dims=0,
+                                            data_shape=[2, 3, 7],
+                                            indices_shape=[1, 4],
+                                            ref_shape=[2, 1, 4, 7])
+
+    def test_shape_axis_1_batch_dims_1(self):
+        self.build_and_test_shape_inference(axis=1, batch_dims=1,
+                                            data_shape=[3, 4],
+                                            indices_shape=[3, 1, 2],
+                                            ref_shape=[3, 1, 2])
+
+    def test_shape_axis_2_batch_dims_1(self):
+        self.build_and_test_shape_inference(axis=2, batch_dims=1,
+                                            data_shape=[3, 4, 7],
+                                            indices_shape=[3, 1, 2],
+                                            ref_shape=[3, 4, 1, 2])
+
+    def test_shape_axis_2_batch_dims_minus_1(self):
+        self.build_and_test_shape_inference(axis=2, batch_dims=-1,
+                                            data_shape=[3, 4, 7],
+                                            indices_shape=[3, 1, 2],
+                                            ref_shape=[3, 4, 1, 2])
+
+    def test_axis_0_batch_dims_0(self):
+        self.build_and_test_value_inference(axis=0, batch_dims=0,
+                                            data=[1, 2, 3, 4, 5],
+                                            indices=[0, 0, 4],
+                                            ref_value=[1, 1, 5])
+
+    def test_axis_1_batch_dims_1(self):
+        self.build_and_test_value_inference(axis=1, batch_dims=1,
+                                            data=[[1, 2, 3, 4, 5],
+                                                  [6, 7, 8, 9, 10]],
+                                            indices=[[0, 0, 4],
+                                                     [4, 0, 0]],
+
+                                            ref_value=[[1, 1, 5],
+                                                       [10, 6, 6]])
+
+    def test_axis_minus_1_batch_dims_1(self):
+        self.build_and_test_value_inference(axis=-1, batch_dims=1,
+                                            data=[[1, 2, 3, 4, 5],
+                                                  [6, 7, 8, 9, 10]],
+                                            indices=[[0, 0, 4],
+                                                     [4, 0, 0]],
+
+                                            ref_value=[[1, 1, 5],
+                                                       [10, 6, 6]])
+
+    def test_axis_2_batch_dims_1(self):
+       self.build_and_test_value_inference(axis=2, batch_dims=1,
+                                           data=[[[[ 1,  2,  3,  4],  # <-- first batch
+                                                   [ 5,  6,  7,  8],
+                                                   [ 9, 10, 11, 12],
+                                                   [13, 14, 15, 16],
+                                                   [17, 18, 19, 20]]],
+                                                 [[[21, 22, 23, 24],  # < -- second batch
+                                                   [25, 26, 27, 28],
+                                                   [29, 30, 31, 32],
+                                                   [33, 34, 35, 36],
+                                                   [37, 38, 39, 40]]]],  # data_shape = (2, 1, 5, 4)
+                                           indices=[[1, 2, 4],
+                                                    [4, 3, 2]],
+                                           ref_value=[[[[ 5,  6,  7,  8],
+                                                        [ 9, 10, 11, 12],
+                                                        [17, 18, 19, 20]]],
+                                                      [[[37, 38, 39, 40],
+                                                        [33, 34, 35, 36],
+                                                        [29, 30, 31, 32]]]])
+
+    def test_axis_2_batch_dims_mimus_1(self):
+        self.build_and_test_value_inference(axis=2, batch_dims=-1,
+                                            data=[[[[ 1,  2,  3,  4],  # <-- first batch
+                                                    [ 5,  6,  7,  8],
+                                                    [ 9, 10, 11, 12],
+                                                    [13, 14, 15, 16],
+                                                    [17, 18, 19, 20]]],
+                                                  [[[21, 22, 23, 24],  # < -- second batch
+                                                    [25, 26, 27, 28],
+                                                    [29, 30, 31, 32],
+                                                    [33, 34, 35, 36],
+                                                    [37, 38, 39, 40]]]],  # data_shape = (2, 1, 5, 4)
+                                            indices=[[1, 2, 4],
+                                                     [4, 3, 2]],
+                                            ref_value=[[[[ 5,  6,  7,  8],
+                                                         [ 9, 10, 11, 12],
+                                                         [17, 18, 19, 20]]],
+                                                       [[[37, 38, 39, 40],
+                                                         [33, 34, 35, 36],
+                                                         [29, 30, 31, 32]]]])

--- a/model-optimizer/mo/utils/unittest/graph.py
+++ b/model-optimizer/mo/utils/unittest/graph.py
@@ -10,6 +10,7 @@ from mo.front.common.partial_infer.utils import int64_array
 from mo.graph.graph import Node, Graph
 from mo.middle.pattern_match import all_edges_in_nodes
 from mo.ops.const import Const
+from extensions.ops.parameter import Parameter
 from mo.utils.error import Error
 
 
@@ -274,6 +275,10 @@ valued_data = lambda name, value: {name: {'kind': 'data', 'value': value,
 shaped_data = lambda name, shape: {name: {'kind': 'data', 'value': None,
                                           'shape': int64_array(shape) if shape is not None else None}}
 empty_data = lambda name: valued_data(name, None)
+
+shaped_input = lambda name, shape: {**regular_op(name, {'op': 'Parameter', 'shape': shape,
+                                                        'infer': Parameter.infer}),
+                                    **shaped_data(name + '_d', shape)}
 
 result = lambda name=None: {name if name is not None else 'output': {'kind': 'op', 'type': 'Result', 'op': 'Result',
                                                                      'infer': lambda x: 0}}


### PR DESCRIPTION
Root cause analysis: there is no support for batch_dims attribute for TF GatherV2 operation

Solution: new operation Gather-7 supporting gathering for different batches should be added to MO

Ticket: 49166

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests: checked manually
* [x]  Transformation tests: no new tests were added
* [x]  Model Optimizer IR Reader check: successfully passed

Documentation:
* [x]  Supported frameworks operations list: acually should've been updated but for some reason we already declared full support of GatherV2
* [x]  Guide on how to convert the **public** model: N/A
* [x]  User guide update: N/A