### PR TITLE
Generate vector extended to support any type

### DIFF
--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/builders.hpp
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/builders.hpp
@@ -27,7 +27,7 @@ makeParams(const element::Type &type, const std::vector<std::pair<std::string, s
 template<typename T>
 std::shared_ptr<Node> makeConstant(const element::Type &type, const std::vector<size_t> &shape,
                                    const std::vector<T> &data, bool random = false,
-                                   uint32_t upTo = 10, uint32_t startFrom = 1, const int seed = 1) {
+                                   T upTo = 10, T startFrom = 1, const int seed = 1) {
     std::shared_ptr<ngraph::Node> weightsNode;
 
 #define makeNode(TYPE) \

--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/utils/data_utils.hpp
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/utils/data_utils.hpp
@@ -17,12 +17,24 @@ namespace Utils {
 
 template<ngraph::element::Type_t dType>
 std::vector<typename ngraph::helpers::nGraphTypesTrait<dType>::value_type> inline
-generateVector(size_t vec_len, uint32_t upTo = 10, uint32_t startFrom = 1, int32_t seed = 1) {
-    std::vector<typename ngraph::helpers::nGraphTypesTrait<dType>::value_type> res;
+generateVector(size_t vec_len, typename ngraph::helpers::nGraphTypesTrait<dType>::value_type upTo = 10,
+               typename ngraph::helpers::nGraphTypesTrait<dType>::value_type startFrom = 1, int32_t seed = 1) {
+    using DataType = typename ngraph::helpers::nGraphTypesTrait<dType>::value_type;
+    // chose values between int and bool
+    using cast_bool_to_int = typename std::conditional<
+            std::is_same<DataType, bool>::value,
+            unsigned int,
+            DataType> :: type;
+
+    std::vector<DataType> res;
 
     std::mt19937 gen(seed);
     // chose values between this range to avoid type overrun (e.g. in case of I8 precision)
-    std::uniform_int_distribution<unsigned long> dist(startFrom, upTo);
+    typename std::conditional<
+            std::is_integral<DataType>::value,
+            std::uniform_int_distribution<cast_bool_to_int>,
+            std::uniform_real_distribution<cast_bool_to_int>>::type dist(
+                    static_cast<cast_bool_to_int>(startFrom), static_cast<cast_bool_to_int>(upTo));
 
     for (size_t i = 0; i < vec_len; i++) {
         res.push_back(

--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/src/batch_norm.cpp
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/src/batch_norm.cpp
@@ -15,9 +15,9 @@ std::shared_ptr<ngraph::Node> makeBatchNormInference(const ngraph::Output<Node>&
     size_t C   = data.get_shape().at(1);
     bool random = true;
     std::vector<float> values(C);
-    auto gamma = ngraph::builder::makeConstant(ngPrc, ngraph::Shape{C}, values, random, 1, 0);
-    auto beta  = ngraph::builder::makeConstant(ngPrc, ngraph::Shape{C}, values, random, 1, 0);
-    auto mean  = ngraph::builder::makeConstant(ngPrc, ngraph::Shape{C}, values, random, 1, 0);
+    auto gamma = ngraph::builder::makeConstant(ngPrc, ngraph::Shape{C}, values, random, 1.f, 0.f);
+    auto beta  = ngraph::builder::makeConstant(ngPrc, ngraph::Shape{C}, values, random, 1.f, 0.f);
+    auto mean  = ngraph::builder::makeConstant(ngPrc, ngraph::Shape{C}, values, random, 1.f, 0.f);
 
     // Fill the vector for variance with positive values
     std::default_random_engine gen;

--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/src/fake_quantize.cpp
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/src/fake_quantize.cpp
@@ -70,10 +70,10 @@ std::shared_ptr<ngraph::Node> makeFakeQuantize(const ngraph::Output<ngraph::Node
             outputHighData[i] += 1;
     }
 
-    auto inputLowNode = ngraph::builder::makeConstant(type, constShapes, inputLowData, inputLowData.empty(), seed);
-    auto inputHighNode = ngraph::builder::makeConstant(type, constShapes, inputHighData, inputHighData.empty(), seed);
-    auto outputLowNode = ngraph::builder::makeConstant(type, constShapes, outputLowData, outputLowData.empty(), seed);
-    auto outputHighNode = ngraph::builder::makeConstant(type, constShapes, outputHighData, outputHighData.empty(), seed);
+    auto inputLowNode = ngraph::builder::makeConstant(type, constShapes, inputLowData, inputLowData.empty(), {}, {}, seed);
+    auto inputHighNode = ngraph::builder::makeConstant(type, constShapes, inputHighData, inputHighData.empty(), {}, {}, seed);
+    auto outputLowNode = ngraph::builder::makeConstant(type, constShapes, outputLowData, outputLowData.empty(), {}, {}, seed);
+    auto outputHighNode = ngraph::builder::makeConstant(type, constShapes, outputHighData, outputHighData.empty(), {}, {}, seed);
 
     auto fq = std::make_shared<ngraph::opset1::FakeQuantize>(in, inputLowNode, inputHighNode, outputLowNode, outputHighNode, levels);
 

--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/src/gru_cell.cpp
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/src/gru_cell.cpp
@@ -42,7 +42,7 @@ std::shared_ptr<ngraph::Node> makeGRU(const OutputVector& in,
                 for (size_t i = 0; i <= in[0].get_shape().at(0); ++i) {
                     std::vector<float> lengths;
                     seq_lengths = ngraph::builder::makeConstant(element::i64, constants[3], lengths, true,
-                                                                in[0].get_shape()[1], 0);
+                                                                static_cast<float>(in[0].get_shape()[1]), 0.f);
                 }
                 break;
             }

--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/src/lstm_cell.cpp
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/src/lstm_cell.cpp
@@ -40,7 +40,7 @@ std::shared_ptr<ngraph::Node> makeLSTM(const std::vector<ngraph::Output<Node>>& 
                 for (size_t i = 0; i <= in[0].get_shape().at(0); ++i) {
                     std::vector<float> lengths;
                     seq_lengths = ngraph::builder::makeConstant(element::i64, constants[3], lengths, true,
-                                                                in[0].get_shape()[1], 0);
+                                                                static_cast<float>(in[0].get_shape()[1]), 0.f);
                 }
                 break;
             }

--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/src/rnn_cell.cpp
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/src/rnn_cell.cpp
@@ -40,7 +40,7 @@ std::shared_ptr<ngraph::Node> makeRNN(const OutputVector& in,
                 for (size_t i = 0; i <= in[0].get_shape().at(0); ++i) {
                     std::vector<float> lengths;
                     seq_lengths = ngraph::builder::makeConstant(element::i64, constants[3], lengths, true,
-                                                                in[0].get_shape()[1], 0);
+                                                                static_cast<float>(in[0].get_shape()[1]), 0.f);
                 }
                 break;
             }


### PR DESCRIPTION
### Details:
Added possibility of generate test vector of "any" type
Fixed misuse of seed params instead  of range 

### Tickets:
 - *ticket-id*
