### PR TITLE
[GNA] fix pwl for Sigmoid quantised with signed range

### DIFF
--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/skip_tests_config.cpp
@@ -34,6 +34,7 @@ std::vector<std::string> disabledTestPatterns() {
         ".*Behavior.*CallbackThrowException.*",
         // TODO: FIX BUG 32210
         R"(.*ActivationLayerTest.CompareWithRefs/(Sigmoid|Tanh|Exp|Log).*)",
+        R"(.*ActivationFQSubgraph.*activation=(Exp|Log).*)",
         // TODO: Issue 32542
         R"(.*(EltwiseLayerTest).*eltwiseOpType=(Sum|Sub).*opType=SCALAR.*)",
         R"(.*(EltwiseLayerTest).*eltwiseOpType=Prod.*secondaryInputType=PARAMETER.*opType=SCALAR.*)",

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/activation_fq.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/activation_fq.cpp
@@ -1,0 +1,83 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+#include <gna/gna_config.hpp>
+
+#include "subgraph_tests/activation_fq.hpp"
+#include "common_test_utils/test_constants.hpp"
+
+using namespace SubgraphTestsDefinitions;
+
+namespace {
+
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+        InferenceEngine::Precision::FP16,
+        InferenceEngine::Precision::FP32
+};
+
+
+using ConfigType = std::map<std::string, std::string>;
+const ConfigType configFP32 = {
+        {"GNA_DEVICE_MODE", "GNA_SW_FP32"},
+};
+
+const ConfigType configSWExact = {
+        {"GNA_DEVICE_MODE", "GNA_SW_EXACT"},
+        {"GNA_COMPACT_MODE", "NO"}
+};
+
+const std::vector<std::pair<std::string, ConfigType>> gnaQuantModes = {
+        {"sw_fp32", configFP32},
+        {"sw_exact", configSWExact}
+};
+
+const std::vector<std::vector<size_t>> inputShapes = {
+        {1, 250},
+        {1, 640},
+        {1, 1024}
+};
+
+const std::vector<size_t> level = {65535};
+const std::vector<std::vector<float>> inputParams = {
+        {-1, 1, 0.01},
+        {-5, 5, 1},
+        {-100, 100, 1},
+        {-16, 16, 1}
+};
+
+const std::vector<std::vector<std::vector<size_t>>> constShapes = {
+        {{1}}
+};
+
+const auto fqParams = ::testing::Combine(
+        ::testing::Values(level),
+        ::testing::ValuesIn(constShapes),
+        ::testing::ValuesIn(inputParams)
+);
+
+const std::vector<ngraph::helpers::ActivationTypes> activations = {
+    ngraph::helpers::ActivationTypes::Sigmoid,
+    ngraph::helpers::ActivationTypes::Tanh,
+    ngraph::helpers::ActivationTypes::Relu,
+    ngraph::helpers::ActivationTypes::Log,
+    ngraph::helpers::ActivationTypes::Abs,
+    ngraph::helpers::ActivationTypes::Sign,
+    ngraph::helpers::ActivationTypes::Exp
+};
+
+INSTANTIATE_TEST_CASE_P(smoke_ActivationFQSubgraph, ActivationFakeQuantizeSubgraphTest,
+                        ::testing::Combine(
+                                fqParams,
+                                ::testing::ValuesIn(activations),
+                                ::testing::ValuesIn(netPrecisions),
+                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+                                ::testing::Values(InferenceEngine::Layout::ANY),
+                                ::testing::Values(InferenceEngine::Layout::ANY),
+                                ::testing::ValuesIn(inputShapes),
+                                ::testing::Values(CommonTestUtils::DEVICE_GNA),
+                                ::testing::ValuesIn(gnaQuantModes)),
+                        ActivationFakeQuantizeSubgraphTest::getTestCaseName);
+} // namespace

--- a/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/activation_fq.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/activation_fq.hpp
@@ -1,0 +1,15 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "shared_test_classes/subgraph/activation_fq.hpp"
+
+namespace SubgraphTestsDefinitions {
+
+TEST_P(ActivationFakeQuantizeSubgraphTest, CompareWithRefs) {
+    Run();
+}
+
+}  // namespace SubgraphTestsDefinitions

--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/activation_fq.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/activation_fq.hpp
@@ -1,0 +1,60 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <vector>
+#include <string>
+#include <memory>
+#include <ie_precision.hpp>
+#include <ie_common.h>
+#include "shared_test_classes/base/layer_test_utils.hpp"
+
+namespace SubgraphTestsDefinitions {
+static std::map<ngraph::helpers::ActivationTypes, std::string> activationNames = {
+        {ngraph::helpers::ActivationTypes::Sigmoid,               "Sigmoid"},
+        {ngraph::helpers::ActivationTypes::Tanh,                  "Tanh"},
+        {ngraph::helpers::ActivationTypes::Relu,                  "Relu"},
+        {ngraph::helpers::ActivationTypes::Exp,                   "Exp"},
+        {ngraph::helpers::ActivationTypes::Log,                   "Log"},
+        {ngraph::helpers::ActivationTypes::Sign,                  "Sign"},
+        {ngraph::helpers::ActivationTypes::Abs,                   "Abs"},
+};
+
+typedef std::tuple<
+        std::vector<size_t>,              // levels
+        std::vector<std::vector<size_t>>, // const inputs shape
+        std::vector<float>                // input generator data: low, high, resolution
+> fqSpecificParams;
+
+typedef std::tuple<
+        fqSpecificParams,
+        ngraph::helpers::ActivationTypes,
+        InferenceEngine::Precision,        // Net precision
+        InferenceEngine::Precision,        // Input precision
+        InferenceEngine::Precision,        // Output precision
+        InferenceEngine::Layout,           // Input layout
+        InferenceEngine::Layout,           // Output layout
+        InferenceEngine::SizeVector,       // Input shapes
+        LayerTestsUtils::TargetDevice,     // Device name
+        std::pair<std::string, std::map<std::string, std::string>> // Additional backend configuration and alis name to it
+> fqSubgraphTestParamsSet;
+
+class ActivationFakeQuantizeSubgraphTest : public testing::WithParamInterface<fqSubgraphTestParamsSet>,
+                                           virtual public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<fqSubgraphTestParamsSet> obj);
+
+protected:
+    void SetUp() override;
+    InferenceEngine::Blob::Ptr GenerateInput(const InferenceEngine::InputInfo &info) const override;
+
+protected:
+    float inputDataMin        = 0.0;
+    float inputDataMax        = 10.0;
+    float inputDataResolution = 1.0;
+    int32_t seed = 1;
+};
+} // namespace SubgraphTestsDefinitions

--- a/inference-engine/tests/functional/shared_test_classes/src/subgraph/activation_fq.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/subgraph/activation_fq.cpp
@@ -1,0 +1,82 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <ngraph_functions/builders.hpp>
+#include "shared_test_classes/subgraph/activation_fq.hpp"
+
+namespace SubgraphTestsDefinitions {
+
+    std::string ActivationFakeQuantizeSubgraphTest::getTestCaseName(testing::TestParamInfo<fqSubgraphTestParamsSet> obj) {
+        fqSpecificParams fqParams;
+        ngraph::helpers::ActivationTypes activationType;
+        InferenceEngine::Precision netPrecision;
+        InferenceEngine::Precision inPrc, outPrc;
+        InferenceEngine::Layout inLayout, outLayout;
+        InferenceEngine::SizeVector inputShapes;
+        std::string targetDevice;
+        std::pair<std::string, std::map<std::string, std::string>> config;
+        std::tie(fqParams, activationType, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShapes, targetDevice, config) = obj.param;
+        std::vector<size_t> levels;
+        std::vector<std::vector<size_t>> constShape;
+        std::vector<float> inputParams;
+        std::tie(levels, constShape, inputParams) = fqParams;
+
+        std::ostringstream result;
+        result << "InputShape=" << CommonTestUtils::vec2str(inputShapes) << "_";
+        result << "CS=" << CommonTestUtils::vec2str(constShape) << "_";
+        result << "LEVELS=" << CommonTestUtils::vec2str(levels) << "_";
+        result << "netPRC=" << netPrecision.name() << "_";
+        result << "inPRC=" << inPrc.name() << "_";
+        result << "outPRC=" << outPrc.name() << "_";
+        result << "inL=" << inLayout << "_";
+        result << "outL=" << outLayout << "_";
+        result << "trgDev=" << targetDevice;
+        if (!config.first.empty()) {
+            result << "_targetConfig=" << config.first;
+        }
+        if (inputParams.size() == 3) {
+            result << "_inputArg=" << inputParams[0] << "_" << inputParams[1] << "_" << inputParams[2];
+        }
+        result << "_activation=" << activationNames[activationType];
+        return result.str();
+    }
+
+    void ActivationFakeQuantizeSubgraphTest::SetUp() {
+        fqSpecificParams fqParams;
+        ngraph::helpers::ActivationTypes activationType;
+        std::vector<size_t> inputShape;
+        std::pair<std::string, std::map<std::string, std::string>> config;
+        InferenceEngine::Precision netPrecision;
+        std::tie(fqParams, activationType, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, targetDevice, config) = this->GetParam();
+        configuration.insert(config.second.begin(), config.second.end());
+
+        std::vector<size_t> levels;
+        std::vector<std::vector<size_t>> constShape;
+        std::vector<float> inputArg;
+        std::tie(levels, constShape, inputArg) = fqParams;
+        if (inputArg.size() == 3) {
+            inputDataMin = inputArg[0];
+            inputDataMax = inputArg[1];
+            inputDataResolution = inputArg[2];
+        }
+
+        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+        auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
+
+        auto act = ngraph::builder::makeActivation(params[0], ngPrc, activationType);
+
+        auto FQNode = ngraph::builder::makeFakeQuantize(act, ngraph::element::f32, levels[0], constShape[0],
+                                                        { inputDataMin }, { inputDataMax }, { inputDataMin }, { inputDataMax });
+
+        auto FQ = std::dynamic_pointer_cast<ngraph::opset1::FakeQuantize>(FQNode);
+
+        ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(FQ)};
+        function = std::make_shared<ngraph::Function>(results, params, "ActivationFakeQuantizeSubgraph");
+    }
+
+InferenceEngine::Blob::Ptr ActivationFakeQuantizeSubgraphTest::GenerateInput(const InferenceEngine::InputInfo &info) const {
+    return FuncTestUtils::createAndFillBlob(info.getTensorDesc(), inputDataMax - inputDataMin, inputDataMin, 1 / inputDataResolution,
+                                            seed);
+}
+} // namespace SubgraphTestsDefinitions


### PR DESCRIPTION
### Details:
- Negative min value must not be used to make pwl for Sigmoid
- Check min/max values from quantization data before their using to make pwl

### Tickets:
52746
