### PR TITLE
%~dp0 can't handle path which include Space

### DIFF
--- a/model-optimizer/install_prerequisites/install_prerequisites.bat
+++ b/model-optimizer/install_prerequisites/install_prerequisites.bat
@@ -70,7 +70,8 @@ IF /I "%1%" EQU "" (
 pip3 install --user -r ..\requirements%postfix%.txt
 
 :: Chek MO version
-set python_command='python %~dp0..\mo\utils\extract_release_version.py'
+set sourcepath=%~dp0
+set python_command="python %sourcepath%..\mo\utils\extract_release_version.py"
 FOR /F "delims=" %%i IN (%python_command%) DO set mo_release_version=%%i
 IF "%mo_release_version%" == "None.None" (
     set mo_is_custom="true"
@@ -80,7 +81,7 @@ IF "%mo_release_version%" == "None.None" (
 
 :: Check if existing IE Python bindings satisfy requirements
 set errorlevel=
-python %~dp0..\mo\utils\find_ie_version.py
+python "%~dp0..\mo\utils\find_ie_version.py"
 IF %errorlevel% EQU 0 goto ie_search_end
 
 :: Check if OV already installed via pip
@@ -119,7 +120,7 @@ IF %errorlevel% NEQ 0 (
 )
 
 set errorlevel=
-python %~dp0..\mo\utils\find_ie_version.py
+python "%~dp0..\mo\utils\find_ie_version.py"
 IF %errorlevel% EQU 0 goto ie_search_end
 
 echo [ WARNING ] The installed OpenVINO ^(TM^) toolkit version %mo_release_version% does not work as expected. Uninstalling...
@@ -137,7 +138,7 @@ IF %errorlevel% NEQ 0 (
 )
 
 set errorlevel=
-python %~dp0..\mo\utils\find_ie_version.py
+python "%~dp0..\mo\utils\find_ie_version.py"
 IF %errorlevel% EQU 0 goto ie_search_end
 
 echo [ WARNING ] The installed highest OpenVINO ^(TM^) toolkit version doesn't work as expected. Uninstalling...


### PR DESCRIPTION
The default OpenVINO install directory is C:\\Program file(86)\\Intel\\..., which contains space. 
So when users run this script, the path is wrong.
To handle this issue, I modify two part:
one is the python_command, use a local var to store this path. 
The other is the errorlevel, just add double quotation marks
