### PR TITLE
[CPU BF16] Nspc layout enabling in the FP32/BF16 convolutions

### DIFF
--- a/inference-engine/src/low_precision_transformations/include/low_precision/transformer.hpp
+++ b/inference-engine/src/low_precision_transformations/include/low_precision/transformer.hpp
@@ -278,7 +278,7 @@ class TRANSFORMATIONS_API LowPrecisionTransformer : public IParamsManager, ILaye
 public:
     static LowPrecisionTransformations getAllTransformations(const LayerTransformation::Params& params = LayerTransformation::Params());
 
-    static bool isFunctionQuantized(const std::shared_ptr<Function>& function);
+    static bool isFunctionQuantized(const std::shared_ptr<const Function>& function);
 
     LowPrecisionTransformer();
     LowPrecisionTransformer(const LowPrecisionTransformations& transformations);

--- a/inference-engine/src/low_precision_transformations/src/transformer.cpp
+++ b/inference-engine/src/low_precision_transformations/src/transformer.cpp
@@ -259,7 +259,7 @@ LowPrecisionTransformations LowPrecisionTransformer::getAllTransformations(const
     return transformer;
 }
 
-bool LowPrecisionTransformer::isFunctionQuantized(const std::shared_ptr<Function>& function) {
+bool LowPrecisionTransformer::isFunctionQuantized(const std::shared_ptr<const Function>& function) {
     std::set<std::shared_ptr<Node>> handledNodes;
     std::deque<std::shared_ptr<Node>> nodes;
     for (auto result : function->get_results()) {

--- a/inference-engine/src/mkldnn_plugin/mkldnn_extension_utils.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_extension_utils.cpp
@@ -134,15 +134,6 @@ PartialBlkDesc PartialBlkDesc::makeCBlocked(const InferenceEngine::SizeVector &d
     return res;
 }
 
-PartialBlkDesc PartialBlkDesc::makeTailC(const InferenceEngine::SizeVector &dims) {
-    PartialBlkDesc res = makePlain(dims);
-    if (dims.size() > 2) {
-        auto itr = res.outer_order.begin() + 1;
-        std::rotate(itr, itr + 1, res.outer_order.end());
-    }
-    return res;
-}
-
 PartialBlkDesc PartialBlkDesc::extractFrom(const InferenceEngine::TensorDesc &desc) {
     if (desc.getLayout() == InferenceEngine::ANY)
         IE_THROW() << "Cannot extract partial blocked descriptor for `ANY` layout";

--- a/inference-engine/src/mkldnn_plugin/mkldnn_extension_utils.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_extension_utils.cpp
@@ -134,6 +134,15 @@ PartialBlkDesc PartialBlkDesc::makeCBlocked(const InferenceEngine::SizeVector &d
     return res;
 }
 
+PartialBlkDesc PartialBlkDesc::makeTailC(const InferenceEngine::SizeVector &dims) {
+    PartialBlkDesc res = makePlain(dims);
+    if (dims.size() > 2) {
+        auto itr = res.outer_order.begin() + 1;
+        std::rotate(itr, itr + 1, res.outer_order.end());
+    }
+    return res;
+}
+
 PartialBlkDesc PartialBlkDesc::extractFrom(const InferenceEngine::TensorDesc &desc) {
     if (desc.getLayout() == InferenceEngine::ANY)
         IE_THROW() << "Cannot extract partial blocked descriptor for `ANY` layout";

--- a/inference-engine/src/mkldnn_plugin/mkldnn_extension_utils.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_extension_utils.h
@@ -59,6 +59,9 @@ public:
     /** Construct blocked Channel PartialBlkDesc based on dims information */
     static PartialBlkDesc makeCBlocked(const InferenceEngine::SizeVector &dims, size_t block_size);
 
+    /** Construct per Channel PartialBlkDesc based on dims information */
+    static PartialBlkDesc makeTailC(const InferenceEngine::SizeVector &dims);
+
     /** Compare operators. Allow to use it as key for std::map */
     bool operator == (const PartialBlkDesc& it) const;
     bool operator < (const PartialBlkDesc& it) const;

--- a/inference-engine/src/mkldnn_plugin/mkldnn_extension_utils.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_extension_utils.h
@@ -59,9 +59,6 @@ public:
     /** Construct blocked Channel PartialBlkDesc based on dims information */
     static PartialBlkDesc makeCBlocked(const InferenceEngine::SizeVector &dims, size_t block_size);
 
-    /** Construct per Channel PartialBlkDesc based on dims information */
-    static PartialBlkDesc makeTailC(const InferenceEngine::SizeVector &dims);
-
     /** Compare operators. Allow to use it as key for std::map */
     bool operator == (const PartialBlkDesc& it) const;
     bool operator < (const PartialBlkDesc& it) const;

--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph.cpp
@@ -45,6 +45,7 @@
 #include <ngraph/variant.hpp>
 #include <ngraph/ops.hpp>
 #include <transformations/utils/utils.hpp>
+#include <low_precision/transformer.hpp>
 
 /*****************************************************
  * Debug capability
@@ -89,6 +90,8 @@ void MKLDNNGraph::Replicate(const std::shared_ptr<const ngraph::Function> &subgr
     this->_name = "subgraph";
     this->reuse_io_tensors = false;
 
+    checkFuncQuantized(subgraph);
+
     // Map data object onto producer node
     std::map<std::shared_ptr<ngraph::Node>, std::pair<MKLDNNNodePtr, int>> op2node;
 
@@ -109,6 +112,10 @@ void MKLDNNGraph::Replicate(const std::shared_ptr<const ngraph::Function> &subgr
 
     for (const auto op : subgraph->get_ordered_ops()) {
         const MKLDNNNodePtr node {MKLDNNNode::factory().create(op, getEngine(), extMgr, weightsCache)};
+        if (isQuantized()) {
+            node->setQuantizedGraphFlag(true);
+        }
+
         graphNodes.push_back(node);
 
         if (op->get_type_info() == ngraph::op::v0::Parameter::type_info) {
@@ -180,6 +187,8 @@ void MKLDNNGraph::Replicate(const CNNNetwork &network, const MKLDNNExtensionMana
         IE_THROW() << "Function pointer inside CNNNetwork is nullptr";
     }
 
+    checkFuncQuantized(func);
+
     auto orderedOps = func->get_ordered_ops();
 
     // TODO [NM]: unordered_map is preferred from performance perspective. Needs hash for ngraph::Node
@@ -202,6 +211,9 @@ void MKLDNNGraph::Replicate(const CNNNetwork &network, const MKLDNNExtensionMana
     // Replicate All Nodes in topological order
     for (const auto& op : orderedOps) {
         const MKLDNNNodePtr node(MKLDNNNode::factory().create(op, getEngine(), extMgr, weightsCache));
+        if (isQuantized()) {
+            node->setQuantizedGraphFlag(true);
+        }
         graphNodes.push_back(node);
 
         if (op->get_type_info() == ngraph::op::v0::Parameter::type_info) {
@@ -1162,6 +1174,10 @@ bool MKLDNNGraph::InsertNode(MKLDNNNodePtr parent, MKLDNNNodePtr child, MKLDNNNo
     afterNode->getParent()->childEdges.push_back(afterNode);
     child->parentEdges.push_back(afterNode);
 
+    if (isQuantized()) {
+        node->setQuantizedGraphFlag(true);
+    }
+
     if (initNode) {
         node->getSupportedDescriptors();
         node->initSupportedPrimitiveDescriptors();
@@ -1178,15 +1194,9 @@ bool MKLDNNGraph::InsertNode(MKLDNNNodePtr parent, MKLDNNNodePtr child, MKLDNNNo
 
 // Set all non const data paths precision to BF16
 void MKLDNNGraph::EnforceBF16() {
-    bool isQuantizedModel = false;
-    for (auto& node : graphNodes) {
-        if (node->getType() == FakeQuantize)
-            isQuantizedModel = true;
-    }
-
     // Floating point parts of FP32 + INT8 or FP32 + BIN mixed precision models will be executed in BF16 precision
     // only if enforceBF16 flag was set manually because current performance is not good enough to enable it by default
-    if (implication(isQuantizedModel, config.manualEnforceBF16)) {
+    if (implication(isQuantized(), config.manualEnforceBF16)) {
         for (auto &node : graphNodes) {
             if (node->getType() != Input && node->getType() != Output) {
                 for (size_t i = 0; i < node->getOriginalInputsNumber(); i++) {
@@ -1226,4 +1236,9 @@ void MKLDNNGraph::printGraphInfo() const {
         }
         std::cout << " ]"  << std::endl;
     }
+}
+
+void MKLDNNGraph::checkFuncQuantized(std::shared_ptr<const ngraph::Function> func) {
+    isQuantizedFlag = (config.lpTransformsMode == Config::LPTransformsMode::On) &&
+            ngraph::pass::low_precision::LowPrecisionTransformer::isFunctionQuantized(func);
 }

--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph.cpp
@@ -90,7 +90,8 @@ void MKLDNNGraph::Replicate(const std::shared_ptr<const ngraph::Function> &subgr
     this->_name = "subgraph";
     this->reuse_io_tensors = false;
 
-    checkFuncQuantized(subgraph);
+    isQuantizedFlag = (config.lpTransformsMode == Config::On) &&
+                      ngraph::pass::low_precision::LowPrecisionTransformer::isFunctionQuantized(subgraph);
 
     // Map data object onto producer node
     std::map<std::shared_ptr<ngraph::Node>, std::pair<MKLDNNNodePtr, int>> op2node;
@@ -187,7 +188,8 @@ void MKLDNNGraph::Replicate(const CNNNetwork &network, const MKLDNNExtensionMana
         IE_THROW() << "Function pointer inside CNNNetwork is nullptr";
     }
 
-    checkFuncQuantized(func);
+    isQuantizedFlag = (config.lpTransformsMode == Config::On) &&
+                      ngraph::pass::low_precision::LowPrecisionTransformer::isFunctionQuantized(func);
 
     auto orderedOps = func->get_ordered_ops();
 
@@ -1236,9 +1238,4 @@ void MKLDNNGraph::printGraphInfo() const {
         }
         std::cout << " ]"  << std::endl;
     }
-}
-
-void MKLDNNGraph::checkFuncQuantized(std::shared_ptr<const ngraph::Function> func) {
-    isQuantizedFlag = (config.lpTransformsMode == Config::LPTransformsMode::On) &&
-            ngraph::pass::low_precision::LowPrecisionTransformer::isFunctionQuantized(func);
 }

--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph.h
@@ -153,6 +153,10 @@ public:
 
     void SortTopologically();
 
+    bool isQuantized() const {
+        return isQuantizedFlag;
+    }
+
 protected:
     void VisitNode(MKLDNNNodePtr node, std::vector<MKLDNNNodePtr>& sortedNodes);
 
@@ -185,6 +189,8 @@ protected:
     std::map<std::string, MeanImage> _meanImages;
     std::string _name;
 
+    bool isQuantizedFlag = false;
+
     static mkldnn::engine eng;
 
     void Replicate(const InferenceEngine::CNNNetwork &network, const MKLDNNExtensionManager::Ptr& extMgr);
@@ -206,6 +212,7 @@ protected:
 private:
     void EnforceBF16();
     void printGraphInfo() const;
+    void checkFuncQuantized(std::shared_ptr<const ngraph::Function> func);
 };
 
 }  // namespace MKLDNNPlugin

--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph.h
@@ -212,7 +212,6 @@ protected:
 private:
     void EnforceBF16();
     void printGraphInfo() const;
-    void checkFuncQuantized(std::shared_ptr<const ngraph::Function> func);
 };
 
 }  // namespace MKLDNNPlugin

--- a/inference-engine/src/mkldnn_plugin/mkldnn_node.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_node.h
@@ -586,6 +586,10 @@ public:
         return false;
     }
 
+    void setQuantizedGraphFlag(bool flag) {
+        isInQuantizedGraph = flag;
+    }
+
 protected:
     bool canBePerformedAsScaleShift(const MKLDNNNode *parentNode = nullptr) const;
     bool canFuseSimpleOperation(const MKLDNNNodePtr& node) const;
@@ -651,6 +655,8 @@ protected:
     MKLDNNWeightsSharing::Ptr weightCache;
 
     Algorithm algorithm = Algorithm::Undefined;
+
+    bool isInQuantizedGraph = false;
 
     friend class MKLDNNEdge;
     friend class MKLDNNGraph;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
@@ -777,9 +777,9 @@ bool MKLDNNConvolutionNode::isNspcAvailable() const {
         // it was empirically observed that the nspc convolutions perform much slower than the blocked ones if the channels number more than the specific value
         size_t activationSize = ndims - 2; //two means batch dim plus channels dim
 
-        bool is1x1 = !isGrouped;
+        bool is1x1 = false;
 
-        if (is1x1) {
+        if (!isGrouped) {
             auto weightDimsReversItr = weightDims.crbegin();
             auto inpDimsReversItr = inpDims.crbegin();
             auto outDimsReversItr = outDims.crbegin();
@@ -787,7 +787,7 @@ bool MKLDNNConvolutionNode::isNspcAvailable() const {
             auto paddingRreversItr = paddingR.crbegin();
 
             for (size_t i = 0; i < activationSize; ++i) {
-                is1x1 = is1x1
+                is1x1 = true
                         && *(weightDimsReversItr++) == 1
                         && *(inpDimsReversItr++) == *(outDimsReversItr++)
                         && *(paddingLreversItr++) == 0

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
@@ -264,55 +264,55 @@ void MKLDNNConvolutionNode::getSupportedDescriptors() {
         }
 
         if (ndims == 4) {
-            if (IC == 1 && groupOC == 1) {
-                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nchw);
-                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nchw);
-                createDescriptor({in_candidate}, {out_candidate});
-            } else if (IC == 3 || IC == 1) {
-                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nchw);
-                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nChw16c);
-                createDescriptor({in_candidate}, {out_candidate});
-                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nChw8c);
-                createDescriptor({in_candidate}, {out_candidate});
-            } else {
-                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nChw16c);
-                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nChw16c);
-                createDescriptor({in_candidate}, {out_candidate});
-                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nChw8c);
-                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nChw8c);
-                createDescriptor({in_candidate}, {out_candidate});
-            }
-
-            in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nchw);
-            out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nchw);
-            createDescriptor({in_candidate}, {out_candidate});
+//            if (IC == 1 && groupOC == 1) {
+//                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nchw);
+//                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nchw);
+//                createDescriptor({in_candidate}, {out_candidate});
+//            } else if (IC == 3 || IC == 1) {
+//                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nchw);
+//                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nChw16c);
+//                createDescriptor({in_candidate}, {out_candidate});
+//                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nChw8c);
+//                createDescriptor({in_candidate}, {out_candidate});
+//            } else {
+//                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nChw16c);
+//                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nChw16c);
+//                createDescriptor({in_candidate}, {out_candidate});
+//                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nChw8c);
+//                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nChw8c);
+//                createDescriptor({in_candidate}, {out_candidate});
+//            }
+//
+//            in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nchw);
+//            out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nchw);
+//            createDescriptor({in_candidate}, {out_candidate});
 
             in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nhwc);
             out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nhwc);
             createDescriptor({in_candidate}, {out_candidate});
         } else if (ndims == 5) {
-            if (IC == 1 && groupOC == 1) {
-                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::ncdhw);
-                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::ncdhw);
-                createDescriptor({in_candidate}, {out_candidate});
-            } else if (IC == 3 || IC == 1) {
-                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::ncdhw);
-                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nCdhw16c);
-                createDescriptor({in_candidate}, {out_candidate});
-                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nCdhw8c);
-                createDescriptor({in_candidate}, {out_candidate});
-            } else {
-                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nCdhw16c);
-                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nCdhw16c);
-                createDescriptor({in_candidate}, {out_candidate});
-                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nCdhw8c);
-                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nCdhw8c);
-                createDescriptor({in_candidate}, {out_candidate});
-            }
-
-            in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::ncdhw);
-            out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::ncdhw);
-            createDescriptor({in_candidate}, {out_candidate});
+//            if (IC == 1 && groupOC == 1) {
+//                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::ncdhw);
+//                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::ncdhw);
+//                createDescriptor({in_candidate}, {out_candidate});
+//            } else if (IC == 3 || IC == 1) {
+//                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::ncdhw);
+//                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nCdhw16c);
+//                createDescriptor({in_candidate}, {out_candidate});
+//                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nCdhw8c);
+//                createDescriptor({in_candidate}, {out_candidate});
+//            } else {
+//                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nCdhw16c);
+//                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nCdhw16c);
+//                createDescriptor({in_candidate}, {out_candidate});
+//                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nCdhw8c);
+//                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nCdhw8c);
+//                createDescriptor({in_candidate}, {out_candidate});
+//            }
+//
+//            in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::ncdhw);
+//            out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::ncdhw);
+//            createDescriptor({in_candidate}, {out_candidate});
 
             in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::ndhwc);
             out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::ndhwc);

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
@@ -286,6 +286,10 @@ void MKLDNNConvolutionNode::getSupportedDescriptors() {
             in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nchw);
             out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nchw);
             createDescriptor({in_candidate}, {out_candidate});
+
+            in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nhwc);
+            out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nhwc);
+            createDescriptor({in_candidate}, {out_candidate});
         } else if (ndims == 5) {
             if (IC == 1 && groupOC == 1) {
                 in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::ncdhw);
@@ -308,6 +312,10 @@ void MKLDNNConvolutionNode::getSupportedDescriptors() {
 
             in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::ncdhw);
             out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::ncdhw);
+            createDescriptor({in_candidate}, {out_candidate});
+
+            in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::ndhwc);
+            out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::ndhwc);
             createDescriptor({in_candidate}, {out_candidate});
         }
     }

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
@@ -265,37 +265,37 @@ void MKLDNNConvolutionNode::getSupportedDescriptors() {
         }
 
         if (one_of(ndims, 4, 5)) {
-            memory::format_tag plainTag = ndims == 4 ? memory::format_tag::nchw : memory::format_tag::ncdhw;
-            memory::format_tag nxcTag = ndims == 4 ? memory::format_tag::nhwc : memory::format_tag::ndhwc;
-            memory::format_tag blockedTag16C = ndims == 4 ? memory::format_tag::nChw16c : memory::format_tag::nCdhw16c;
-            memory::format_tag blockedTag8C = ndims == 4 ? memory::format_tag::nChw8c : memory::format_tag::nCdhw8c;
+            memory::format_tag ncsp = ndims == 4 ? memory::format_tag::nchw : memory::format_tag::ncdhw;
+            memory::format_tag nspc = ndims == 4 ? memory::format_tag::nhwc : memory::format_tag::ndhwc;
+            memory::format_tag nCsp16c = ndims == 4 ? memory::format_tag::nChw16c : memory::format_tag::nCdhw16c;
+            memory::format_tag nCsp8c = ndims == 4 ? memory::format_tag::nChw8c : memory::format_tag::nCdhw8c;
 
             if (IC == 1 && groupOC == 1) {
-                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, plainTag);
-                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, plainTag);
+                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, ncsp);
+                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, ncsp);
                 createDescriptor({in_candidate}, {out_candidate});
             } else if (IC < 4 && getParentEdgeAt(0)->getParent()->getType() != Convolution) {
-                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, plainTag);
-                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, blockedTag16C);
+                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, ncsp);
+                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, nCsp16c);
                 createDescriptor({in_candidate}, {out_candidate});
-                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, blockedTag8C);
+                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, nCsp8c);
                 createDescriptor({in_candidate}, {out_candidate});
             } else {
-                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, blockedTag16C);
-                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, blockedTag16C);
+                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, nCsp16c);
+                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, nCsp16c);
                 createDescriptor({in_candidate}, {out_candidate});
-                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, blockedTag8C);
-                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, blockedTag8C);
+                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, nCsp8c);
+                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, nCsp8c);
                 createDescriptor({in_candidate}, {out_candidate});
             }
 
-            in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, plainTag);
-            out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, plainTag);
+            in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, ncsp);
+            out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, ncsp);
             createDescriptor({in_candidate}, {out_candidate});
 
             if (inputDataType != memory::data_type::bf16 && isNspcAvailable()) {
-                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, nxcTag);
-                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, nxcTag);
+                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, nspc);
+                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, nspc);
                 createDescriptor({in_candidate}, {out_candidate});
             }
         }

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
@@ -234,8 +234,10 @@ void MKLDNNConvolutionNode::getSupportedDescriptors() {
                                                                                                   : memory::format_tag::nhwc);
         createDescriptor({in_candidate}, {out_candidate});
     } else {
-        inputDataType = (getOriginalInputPrecisionAtPort(0) == Precision::BF16) ? memory::data_type::bf16 : memory::data_type::f32;
-        outputDataType = (getOriginalOutputPrecisionAtPort(0) == Precision::BF16) ? memory::data_type::bf16 : memory::data_type::f32;
+        inputDataType = (getOriginalInputPrecisionAtPort(0) == Precision::BF16
+                && !(isDW && ndims == 5)) ? memory::data_type::bf16 : memory::data_type::f32;
+        outputDataType = (getOriginalOutputPrecisionAtPort(0) == Precision::BF16
+                && !(isDW && ndims == 5)) ? memory::data_type::bf16 : memory::data_type::f32;
         eltwisePrecision = Precision::FP32;
         for (int i = 0; i < fusedWith.size(); i++) {
             if (fusedWith[i]->getAlgorithm() == EltwiseAdd) {

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
@@ -288,7 +288,7 @@ void MKLDNNConvolutionNode::getSupportedDescriptors() {
             out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nchw);
             createDescriptor({in_candidate}, {out_candidate});
 
-            if (isNspcAvailable()) {
+            if (inputDataType != memory::data_type::bf16 && isNspcAvailable()) {
                 in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nhwc);
                 out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nhwc);
                 createDescriptor({in_candidate}, {out_candidate});
@@ -317,7 +317,7 @@ void MKLDNNConvolutionNode::getSupportedDescriptors() {
             out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::ncdhw);
             createDescriptor({in_candidate}, {out_candidate});
 
-            if (isNspcAvailable()) {
+            if (inputDataType != memory::data_type::bf16 && isNspcAvailable()) {
                 in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::ndhwc);
                 out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::ndhwc);
                 createDescriptor({in_candidate}, {out_candidate});
@@ -775,7 +775,7 @@ bool MKLDNNConvolutionNode::isNspcAvailable() const {
         }
     } else {
         // it was empirically observed that the nspc convolutions perform much slower than the blocked ones if the channels number more than the specific value
-        size_t activationSize = ndims - 2; //two means batch dim plus channels dim
+        size_t spatialRank = ndims - 2; //two means batch dim plus channels dim
 
         bool is1x1 = false;
 
@@ -786,7 +786,7 @@ bool MKLDNNConvolutionNode::isNspcAvailable() const {
             auto paddingLreversItr = paddingL.crbegin();
             auto paddingRreversItr = paddingR.crbegin();
 
-            for (size_t i = 0; i < activationSize; ++i) {
+            for (size_t i = 0; i < spatialRank; ++i) {
                 is1x1 = true
                         && *(weightDimsReversItr++) == 1
                         && *(inpDimsReversItr++) == *(outDimsReversItr++)

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
@@ -274,7 +274,7 @@ void MKLDNNConvolutionNode::getSupportedDescriptors() {
                 in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, ncsp);
                 out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, ncsp);
                 createDescriptor({in_candidate}, {out_candidate});
-            } else if (IC < 4 && getParentEdgeAt(0)->getParent()->getType() != Convolution) {
+            } else if (IC < 4) {
                 in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, ncsp);
                 out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, nCsp16c);
                 createDescriptor({in_candidate}, {out_candidate});
@@ -791,8 +791,10 @@ bool MKLDNNConvolutionNode::isNspcAvailable() const {
         }
 
         unsigned thresholdNumChannels = 128u; // for avx and below
-        if (mayiuse(impl::cpu::x64::avx512_common) || is1x1) {
+        if (is1x1) {
             thresholdNumChannels = 2048u;
+        } else if (mayiuse(impl::cpu::x64::avx512_common)) {
+            thresholdNumChannels = 512u;
         }
 
         size_t OC = outDims[1];

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
@@ -234,10 +234,8 @@ void MKLDNNConvolutionNode::getSupportedDescriptors() {
                                                                                                   : memory::format_tag::nhwc);
         createDescriptor({in_candidate}, {out_candidate});
     } else {
-        inputDataType = (getOriginalInputPrecisionAtPort(0) == Precision::BF16 && !(isGrouped && ndims == 5)) ? memory::data_type::bf16
-                                                                                                           : memory::data_type::f32;
-        outputDataType = (getOriginalOutputPrecisionAtPort(0) == Precision::BF16 && !(isGrouped && ndims == 5)) ? memory::data_type::bf16
-                                                                                                             : memory::data_type::f32;
+        inputDataType = (getOriginalInputPrecisionAtPort(0) == Precision::BF16) ? memory::data_type::bf16 : memory::data_type::f32;
+        outputDataType = (getOriginalOutputPrecisionAtPort(0) == Precision::BF16) ? memory::data_type::bf16 : memory::data_type::f32;
         eltwisePrecision = Precision::FP32;
         for (int i = 0; i < fusedWith.size(); i++) {
             if (fusedWith[i]->getAlgorithm() == EltwiseAdd) {

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
@@ -9,6 +9,7 @@
 #include "mkldnn_fake_quantize_node.h"
 #include "mkldnn_pooling_node.h"
 #include "mkldnn_concat_node.h"
+#include "cpu/x64/cpu_isa_traits.hpp"
 #include <string>
 #include <vector>
 #include <mkldnn_types.h>
@@ -264,59 +265,63 @@ void MKLDNNConvolutionNode::getSupportedDescriptors() {
         }
 
         if (ndims == 4) {
-//            if (IC == 1 && groupOC == 1) {
-//                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nchw);
-//                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nchw);
-//                createDescriptor({in_candidate}, {out_candidate});
-//            } else if (IC == 3 || IC == 1) {
-//                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nchw);
-//                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nChw16c);
-//                createDescriptor({in_candidate}, {out_candidate});
-//                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nChw8c);
-//                createDescriptor({in_candidate}, {out_candidate});
-//            } else {
-//                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nChw16c);
-//                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nChw16c);
-//                createDescriptor({in_candidate}, {out_candidate});
-//                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nChw8c);
-//                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nChw8c);
-//                createDescriptor({in_candidate}, {out_candidate});
-//            }
-//
-//            in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nchw);
-//            out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nchw);
-//            createDescriptor({in_candidate}, {out_candidate});
+            if (IC == 1 && groupOC == 1) {
+                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nchw);
+                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nchw);
+                createDescriptor({in_candidate}, {out_candidate});
+            } else if (IC == 3 || IC == 1) {
+                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nchw);
+                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nChw16c);
+                createDescriptor({in_candidate}, {out_candidate});
+                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nChw8c);
+                createDescriptor({in_candidate}, {out_candidate});
+            } else {
+                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nChw16c);
+                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nChw16c);
+                createDescriptor({in_candidate}, {out_candidate});
+                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nChw8c);
+                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nChw8c);
+                createDescriptor({in_candidate}, {out_candidate});
+            }
 
-            in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nhwc);
-            out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nhwc);
+            in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nchw);
+            out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nchw);
             createDescriptor({in_candidate}, {out_candidate});
+
+            if (isNspcAvailable()) {
+                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nhwc);
+                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nhwc);
+                createDescriptor({in_candidate}, {out_candidate});
+            }
         } else if (ndims == 5) {
-//            if (IC == 1 && groupOC == 1) {
-//                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::ncdhw);
-//                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::ncdhw);
-//                createDescriptor({in_candidate}, {out_candidate});
-//            } else if (IC == 3 || IC == 1) {
-//                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::ncdhw);
-//                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nCdhw16c);
-//                createDescriptor({in_candidate}, {out_candidate});
-//                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nCdhw8c);
-//                createDescriptor({in_candidate}, {out_candidate});
-//            } else {
-//                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nCdhw16c);
-//                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nCdhw16c);
-//                createDescriptor({in_candidate}, {out_candidate});
-//                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nCdhw8c);
-//                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nCdhw8c);
-//                createDescriptor({in_candidate}, {out_candidate});
-//            }
-//
-//            in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::ncdhw);
-//            out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::ncdhw);
-//            createDescriptor({in_candidate}, {out_candidate});
+            if (IC == 1 && groupOC == 1) {
+                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::ncdhw);
+                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::ncdhw);
+                createDescriptor({in_candidate}, {out_candidate});
+            } else if (IC == 3 || IC == 1) {
+                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::ncdhw);
+                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nCdhw16c);
+                createDescriptor({in_candidate}, {out_candidate});
+                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nCdhw8c);
+                createDescriptor({in_candidate}, {out_candidate});
+            } else {
+                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nCdhw16c);
+                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nCdhw16c);
+                createDescriptor({in_candidate}, {out_candidate});
+                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::nCdhw8c);
+                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::nCdhw8c);
+                createDescriptor({in_candidate}, {out_candidate});
+            }
 
-            in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::ndhwc);
-            out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::ndhwc);
+            in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::ncdhw);
+            out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::ncdhw);
             createDescriptor({in_candidate}, {out_candidate});
+
+            if (isNspcAvailable()) {
+                in_candidate = MKLDNNMemoryDesc(getParentEdgeAt(0)->getDims(), inputDataType, memory::format_tag::ndhwc);
+                out_candidate = MKLDNNMemoryDesc(getChildEdgeAt(0)->getDims(), outputDataType, memory::format_tag::ndhwc);
+                createDescriptor({in_candidate}, {out_candidate});
+            }
         }
     }
 }
@@ -753,6 +758,78 @@ InferenceEngine::Precision MKLDNNConvolutionNode::getRuntimePrecision() const {
     }
 
     return MKLDNNExtensionUtils::getMaxPrecision(inputPrecisions);
+}
+
+void MKLDNNConvolutionNode::selectOptimalPrimitiveDescriptor() {
+    // use the default choice
+    MKLDNNNode::selectOptimalPrimitiveDescriptor();
+
+    auto nspcPartialDesc = PartialBlkDesc::makeTailC(getChildEdgeAt(0)->getDims().ToSizeVector());
+    auto selectedSpd = getSelectedPrimitiveDescriptor();
+    if (!selectedSpd) {
+        IE_THROW() << "Cannot get selected primitive descriptor for node: " << getName();
+    }
+
+    // nspc pd has been already chosen
+    if (nspcPartialDesc == PartialBlkDesc::extractFrom(selectedSpd->getConfig().inConfs[0].desc)) {
+        return;
+    }
+
+    // Additional heuristic that forces the convolution to be executed with nspc layout in the accuracy aware quantized networks
+    bool hasNspcOutput = false;
+    for (size_t i = 0; i < getChildEdges().size(); ++i) {
+        auto childNode = getChildEdgeAt(i)->getChild();
+        if (childNode->getType() == Convolution) {
+            if (auto childConv = std::dynamic_pointer_cast<MKLDNNConvolutionNode>(childNode)) {
+                hasNspcOutput = childConv->canBeExecutedInInt8();
+            }
+        }
+    }
+
+    if (hasNspcOutput) {
+        auto type = selectedSpd->getImplementationType(); // prevent less optimized implementation
+        for (size_t i = 0; i < getSupportedPrimitiveDescriptors().size(); i++) {
+            impl_desc_type supportedType = getSupportedPrimitiveDescriptors()[i].getImplementationType();
+            if (type == supportedType) {
+                if (nspcPartialDesc == PartialBlkDesc::extractFrom(getSupportedPrimitiveDescriptors()[i].getConfig().outConfs[0].desc)) {
+                    selectPrimitiveDescriptorByIndex(i);
+                    break;
+                }
+            }
+        }
+    }
+}
+
+bool MKLDNNConvolutionNode::isNspcAvailable() const {
+    using impl::cpu::x64::mayiuse;
+    // A bunch of heuristics are designed to cut off not optimal nspc convolution applications
+    auto * convLayer = dynamic_cast<ConvolutionLayer*>(getCnnLayer().get());
+    if (convLayer == nullptr)
+        IE_THROW() << "Cannot convert convolution layer.";
+
+    auto& inpDims = convLayer->input()->getDims();
+
+    if (isDW) {
+        // 1d equivalent cases are painfully slow
+        if (1 == inpDims[inpDims.size() - 2]) {
+            return false;
+        }
+    } else {
+        // it was empirically observed that the nspc convolutions perform much slower than the blocked ones if the channels number more than 2048
+        size_t IC = inpDims[1];
+        size_t OC = convLayer->_out_depth;
+        if (std::max(IC, OC) >= 2048) {
+            return false;
+        }
+        if (!mayiuse(impl::cpu::x64::avx)) {
+            // SSE41 nspc convolutions do not support ic and oc tails yet and the blocked implementation will be much better than the gemm
+            if ((IC % 8) || (OC % 8)) {
+                return false;
+            }
+        }
+    }
+
+    return true;
 }
 
 REG_MKLDNN_PRIM_FOR(MKLDNNConvolutionNode, Convolution);

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.h
@@ -38,6 +38,7 @@ public:
 
     bool canBeExecutedInInt8() const;
     size_t getGroupNum() const { return groupNum; }
+    void selectOptimalPrimitiveDescriptor() override;
 
     std::vector<uint8_t> inputZeroPoints;
     std::vector<float> weightsZeroPoints;
@@ -56,6 +57,7 @@ public:
 
 protected:
     InferenceEngine::Precision fusedEltwisePrecision(const MKLDNNNodePtr& fusingNode) const;
+    bool isNspcAvailable() const;
 
 private:
     void addZeroPoints(mkldnn::primitive_attr& attr) const;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.h
@@ -38,7 +38,6 @@ public:
 
     bool canBeExecutedInInt8() const;
     size_t getGroupNum() const { return groupNum; }
-    void selectOptimalPrimitiveDescriptor() override;
 
     std::vector<uint8_t> inputZeroPoints;
     std::vector<float> weightsZeroPoints;
@@ -57,13 +56,13 @@ public:
 
 protected:
     InferenceEngine::Precision fusedEltwisePrecision(const MKLDNNNodePtr& fusingNode) const;
-    bool isNspcAvailable() const;
 
 private:
     void addZeroPoints(mkldnn::primitive_attr& attr) const;
     void setPostOps(mkldnn::primitive_attr &attr, bool initWeights) const;
     void filterSupportedDescriptors();
     bool isPossibleToSkipInitConfig(MKLDNNDescriptor &desc) const;
+    bool isNspcAvailable() const;
 
     bool withBiases;
     bool withSum;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_eltwise_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_eltwise_node.cpp
@@ -1210,6 +1210,11 @@ void MKLDNNEltwiseNode::createPrimitive() {
             size_t startOff = outOrder.size() != config.outConfs[0].desc.getDims().size() &&
                               outOrder[outOrder.size() - 1] != inOrder[inOrder.size() - 1] ? 1 : 0;
 
+            // WA to handle nspc layout with 1D tensors
+            if (1 == inRank) {
+                if (outRank > 2 && 1 == outOrder.back()) startOff = 1;
+            }
+
             for (int j = 0; j < inRank; j++) {
                 dims_in[i][dims_in[i].size() - 1 - j - startOff] = config.inConfs[i].desc.getBlockingDesc().getBlockDims()[inRank - 1 - j];
             }

--- a/inference-engine/tests/functional/plugin/cpu/bfloat16/elt_x3.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/bfloat16/elt_x3.cpp
@@ -171,10 +171,10 @@ protected:
         // threshold = 0.6f;  // Max in fp32 network by output: 12.0983
 
         // 3 channels, 4 x 4 size
-        threshold = 20.6f;  // Max in fp32 network by output: 879.077
+        threshold = 30.6f;  // Max in fp32 network by output: 879.077
 
         // STAGE3:
-        // filling of expected precision of layer execution defined by precisoin of input tensor to the primitive and reflected in
+        // filling of expected precision of layer execution defined by precision of input tensor to the primitive and reflected in
         // performance counters
         expectedPrecisions["Convolution_1"] = "BF16";
         expectedPrecisions["Convolution_2"] = "BF16";

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
@@ -53,15 +53,19 @@ std::vector<std::string> disabledTestPatterns() {
         // TODO: 42538. Unexpected application crush
         R"(.*CoreThreadingTestsWithIterations\.smoke_LoadNetwork.t.*)",
         R"(.*CoreThreadingTestsWithIterations\.smoke_LoadNetworkAccuracy.*AUTO.*)",
+            // TODO: 53618. BF16 gemm ncsp convolution crush
+        R"(.*_GroupConv.*_inPRC=BF16.*_inFmts=nc.*_primitive=jit_gemm.*)",
+            // TODO: 53578. fork DW bf16 convolution does not support 3d cases yet
+        R"(.*_DW_GroupConv.*_inPRC=BF16.*_inFmts=(ndhwc|nCdhw16c).*)"
 
         // incorrect reference implementation
         R"(.*NormalizeL2LayerTest.*axes=\(\).*)",
-        // lpt transformation produce the same names for MatMul and Multiply
+            // lpt transformation produce the same names for MatMul and Multiply
         R"(.*MatMulTransformation.*)",
-        // incorrect jit_uni_planar_convolution with dilation = {1, 2, 1} and output channel 1
+            // incorrect jit_uni_planar_convolution with dilation = {1, 2, 1} and output channel 1
         R"(.*smoke_Convolution3D.*D=\(1.2.1\)_O=1.*)",
 
-        // Unsupported operation of type: NormalizeL2 name : Doesn't support reduction axes: (2.2)
+            // Unsupported operation of type: NormalizeL2 name : Doesn't support reduction axes: (2.2)
         R"(.*BF16NetworkRestore1.*)",
         R"(.*MobileNet_ssd_with_branching.*)",
 

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
@@ -55,17 +55,17 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*CoreThreadingTestsWithIterations\.smoke_LoadNetworkAccuracy.*AUTO.*)",
             // TODO: 53618. BF16 gemm ncsp convolution crush
         R"(.*_GroupConv.*_inPRC=BF16.*_inFmts=nc.*_primitive=jit_gemm.*)",
-            // TODO: 53578. fork DW bf16 convolution does not support 3d cases yet
-        R"(.*_DW_GroupConv.*_inPRC=BF16.*_inFmts=(ndhwc|nCdhw16c).*)"
+        // TODO: 53578. fork DW bf16 convolution does not support 3d cases yet
+        R"(.*_DW_GroupConv.*_inPRC=BF16.*_inFmts=(ndhwc|nCdhw16c).*)",
 
         // incorrect reference implementation
         R"(.*NormalizeL2LayerTest.*axes=\(\).*)",
-            // lpt transformation produce the same names for MatMul and Multiply
+        // lpt transformation produce the same names for MatMul and Multiply
         R"(.*MatMulTransformation.*)",
-            // incorrect jit_uni_planar_convolution with dilation = {1, 2, 1} and output channel 1
+        // incorrect jit_uni_planar_convolution with dilation = {1, 2, 1} and output channel 1
         R"(.*smoke_Convolution3D.*D=\(1.2.1\)_O=1.*)",
 
-            // Unsupported operation of type: NormalizeL2 name : Doesn't support reduction axes: (2.2)
+        // Unsupported operation of type: NormalizeL2 name : Doesn't support reduction axes: (2.2)
         R"(.*BF16NetworkRestore1.*)",
         R"(.*MobileNet_ssd_with_branching.*)",
 

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
@@ -50,13 +50,15 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*BinaryConvolutionLayerTest.*)",
         R"(.*ClampLayerTest.*netPrc=(I64|I32).*)",
         R"(.*ClampLayerTest.*netPrc=U64.*)",
-        // TODO: 42538. Unexpected application crush
+        // TODO: 42538. Unexpected application crash
         R"(.*CoreThreadingTestsWithIterations\.smoke_LoadNetwork.t.*)",
         R"(.*CoreThreadingTestsWithIterations\.smoke_LoadNetworkAccuracy.*AUTO.*)",
-            // TODO: 53618. BF16 gemm ncsp convolution crush
+            // TODO: 53618. BF16 gemm ncsp convolution crash
         R"(.*_GroupConv.*_inPRC=BF16.*_inFmts=nc.*_primitive=jit_gemm.*)",
         // TODO: 53578. fork DW bf16 convolution does not support 3d cases yet
         R"(.*_DW_GroupConv.*_inPRC=BF16.*_inFmts=(ndhwc|nCdhw16c).*)",
+        // TODO: 56143. Enable nspc convolutions for bf16 precision
+        R"(.*ConvolutionLayerCPUTest.*BF16.*_inFmts=(ndhwc|nhwc).*)",
 
         // incorrect reference implementation
         R"(.*NormalizeL2LayerTest.*axes=\(\).*)",

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
@@ -53,7 +53,7 @@ std::vector<std::string> disabledTestPatterns() {
         // TODO: 42538. Unexpected application crash
         R"(.*CoreThreadingTestsWithIterations\.smoke_LoadNetwork.t.*)",
         R"(.*CoreThreadingTestsWithIterations\.smoke_LoadNetworkAccuracy.*AUTO.*)",
-            // TODO: 53618. BF16 gemm ncsp convolution crash
+        // TODO: 53618. BF16 gemm ncsp convolution crash
         R"(.*_GroupConv.*_inPRC=BF16.*_inFmts=nc.*_primitive=jit_gemm.*)",
         // TODO: 53578. fork DW bf16 convolution does not support 3d cases yet
         R"(.*_DW_GroupConv.*_inPRC=BF16.*_inFmts=(ndhwc|nCdhw16c).*)",

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution.cpp
@@ -148,40 +148,31 @@ namespace {
 /* COMMON PARAMS */
 const std::vector<fusingSpecificParams> fusingParamsSet{
         emptyFusingSpec,
-        // activations
+        // eltwise
         fusingRelu,
-        fusingElu,
-        fusingSigmoid,
-        fusingClamp,
-        fusingPReluPerChannel,
-        fusingSwish,
-        fusingHSwish,
-        fusingMish,
-        fusingSoftPlus,
-        // other patterns
-        fusingReluAdd,
+        fusingPRelu1D,
+        // depthwise
         fusingReluScaleShift,
+        // fake quantize
         fusingFakeQuantizePerTensorRelu,
         fusingFakeQuantizePerChannelRelu,
+        // sum
         fusingSumEluFQ,
-        fusingSum,
-        fusingPRelu1D,
-        fusingAddPerChannel // bias
+        fusingSum
+        // bias
+        fusingAddPerChannel
 };
 
 const std::vector<fusingSpecificParams> fusingParamsSetBF16{
         emptyFusingSpec,
-        // activations
+        // eltwise
         fusingRelu,
-        fusingElu,
-        fusingSigmoid,
-        fusingClamp,
-        fusingPReluPerChannel,
-        fusingSwish,
-        // other patterns
-        fusingReluAdd,
+        // depthwise
         fusingReluScaleShift,
+        // sum
         fusingSum
+        // bias
+        fusingAddPerChannel
 };
 
 const std::map<std::string, std::string> cpuEmptyPluginConfig;

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution.cpp
@@ -660,7 +660,75 @@ INSTANTIATE_TEST_CASE_P(smoke_Conv_1D, ConvolutionLayerCPUTest,
         ::testing::Values(cpuEmptyPluginConfig)),
     ConvolutionLayerCPUTest::getTestCaseName);
 
-/* ========= */
+/* ============= Jit Planar ============= */
+
+/* ============= Convolution planar params (2D) ============= */
+const std::vector<CPUSpecificParams> CPUParams_Jit_Planar_2D = {
+        // sse42 is not supported
+        conv_avx2_planar_2D,
+        conv_avx512_planar_2D,
+};
+
+const auto convParams_Planar_ExplicitPadding_2D = ::testing::Combine(
+        ::testing::ValuesIn(kernels2d),
+        ::testing::Values(SizeVector{1, 1}),
+        ::testing::ValuesIn(padBegins2d),
+        ::testing::ValuesIn(padEnds2d),
+        ::testing::ValuesIn(dilations2d),
+        ::testing::Values(1),
+        ::testing::Values(ngraph::op::PadType::EXPLICIT)
+);
+
+INSTANTIATE_TEST_CASE_P(smoke_Conv_Jit_Planar_2D_FP32, ConvolutionLayerCPUTest,
+    ::testing::Combine(
+        ::testing::Combine(
+            convParams_Planar_ExplicitPadding_2D,
+            ::testing::Values(Precision::FP32),
+            ::testing::Values(Precision::UNSPECIFIED),
+            ::testing::Values(Precision::UNSPECIFIED),
+            ::testing::Values(Layout::ANY),
+            ::testing::Values(Layout::ANY),
+            ::testing::ValuesIn(inputShapes2d),
+            ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+        ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Jit_Planar_2D)),
+        ::testing::Values(emptyFusingSpec, fusingRelu),
+        ::testing::Values(cpuEmptyPluginConfig)),
+    ConvolutionLayerCPUTest::getTestCaseName);
+
+/* ============= Convolution planar params (3D) ============= */
+const std::vector<CPUSpecificParams> CPUParams_Jit_Planar_3D = {
+        // sse42 is not supported
+        conv_avx2_planar_3D,
+        conv_avx512_planar_3D,
+};
+
+const auto convParams_Planar_ExplicitPadding_3D = ::testing::Combine(
+        ::testing::ValuesIn(kernels3d),
+        ::testing::Values(SizeVector{1, 1, 1}),
+        ::testing::ValuesIn(padBegins3d),
+        ::testing::ValuesIn(padEnds3d),
+        ::testing::ValuesIn(dilations3d),
+        ::testing::Values(1),
+        ::testing::Values(ngraph::op::PadType::EXPLICIT)
+);
+
+INSTANTIATE_TEST_CASE_P(smoke_Conv_Jit_Planar_3D_FP32, ConvolutionLayerCPUTest,
+    ::testing::Combine(
+        ::testing::Combine(
+            convParams_Planar_ExplicitPadding_3D,
+            ::testing::Values(Precision::FP32),
+            ::testing::Values(Precision::UNSPECIFIED),
+            ::testing::Values(Precision::UNSPECIFIED),
+            ::testing::Values(Layout::ANY),
+            ::testing::Values(Layout::ANY),
+            ::testing::ValuesIn(inputShapes3d),
+            ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+        ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Jit_Planar_3D)),
+        ::testing::Values(emptyFusingSpec, fusingRelu),
+        ::testing::Values(cpuEmptyPluginConfig)),
+    ConvolutionLayerCPUTest::getTestCaseName);
+
+/* ============= */
 
 } // namespace
 } // namespace CPULayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution.cpp
@@ -188,7 +188,7 @@ const std::map<std::string, std::string> cpuEmptyPluginConfig;
 const std::map<std::string, std::string> cpuBF16PluginConfig = { { PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES } };
 
 /* ============= Convolution params (GEMM layout) ============= */
-const SizeVector numOutChannels_Planar = { 6 };
+const SizeVector numOutChannels_Gemm = {6 };
 
 /* ============= Convolution params (blocked and nspc layout) ============= */
 const SizeVector numOutChannels = { 64, 63 };
@@ -211,14 +211,14 @@ const std::vector<SizeVector> inputShapes3d = { {1, 64, 7, 7, 7}, {1, 67, 7, 7, 
 /* ============= */
 
 /* INSTANCES */
-/* ============= Convolution (Planar 2D) ============= */
+/* ============= Convolution (Gemm 2D) ============= */
 const auto convParams_ExplicitPadding_GEMM_2D = ::testing::Combine(
     ::testing::ValuesIn(kernels2d),
     ::testing::ValuesIn(strides2d),
     ::testing::ValuesIn(padBegins2d),
     ::testing::ValuesIn(padEnds2d),
     ::testing::ValuesIn(dilations2d),
-    ::testing::ValuesIn(numOutChannels_Planar),
+    ::testing::ValuesIn(numOutChannels_Gemm),
     ::testing::Values(ngraph::op::PadType::EXPLICIT)
 );
 
@@ -259,7 +259,7 @@ INSTANTIATE_TEST_CASE_P(smoke_Conv_2D_GEMM_BF16, ConvolutionLayerCPUTest,
         ::testing::Values(cpuBF16PluginConfig)),
     ConvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(smoke_Conv_2D_Planar_I8, ConvolutionLayerCPUTest,
+INSTANTIATE_TEST_CASE_P(smoke_Conv_2D_GEMM_I8, ConvolutionLayerCPUTest,
     ::testing::Combine(
         ::testing::Combine(
             convParams_ExplicitPadding_GEMM_2D,
@@ -282,7 +282,7 @@ const auto convParams_ExplicitPadding_GEMM_3D = ::testing::Combine(
     ::testing::ValuesIn(padBegins3d),
     ::testing::ValuesIn(padEnds3d),
     ::testing::ValuesIn(dilations3d),
-    ::testing::ValuesIn(numOutChannels_Planar),
+    ::testing::ValuesIn(numOutChannels_Gemm),
     ::testing::Values(ngraph::op::PadType::EXPLICIT)
 );
 

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution.cpp
@@ -126,8 +126,8 @@ TEST_P(ConvolutionLayerCPUTest, CompareWithRefs) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 
     // Skip tests for sse41 convolution where ic or oc cannot be exactly divided by the block size,
-    // since tails processing for sse41 nspc layout is not supported.
-    if ( (inFmts.front() == nhwc || inFmts.front() == ndhwc) && selectedType.find("jit_sse") != std::string::npos ) {
+    // since tails processing for sse41 nspc layout is not supported yet (see 52736).
+    if ((inFmts.front() == nhwc || inFmts.front() == ndhwc) && selectedType.find("jit_sse") != std::string::npos) {
         auto inpChannels = function->get_parameters().front()->get_shape()[1];
         auto outChannels = function->get_output_shape(0)[1];
         if ((inpChannels % 8) || (outChannels % 8)) {

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution.cpp
@@ -127,7 +127,7 @@ TEST_P(ConvolutionLayerCPUTest, CompareWithRefs) {
 
     // Skip tests for sse41 convolution where ic or oc cannot be exactly divided by the block size,
     // since tails processing for sse41 nspc layout is not supported yet (see 52736).
-    if ((inFmts.front() == nhwc || inFmts.front() == ndhwc) && selectedType.find("jit_sse") != std::string::npos) {
+    if (!inFmts.empty() && (inFmts.front() == nhwc || inFmts.front() == ndhwc) && selectedType.find("jit_sse") != std::string::npos) {
         auto inpChannels = function->get_parameters().front()->get_shape()[1];
         auto outChannels = function->get_output_shape(0)[1];
         if ((inpChannels % 8) || (outChannels % 8)) {
@@ -158,7 +158,7 @@ const std::vector<fusingSpecificParams> fusingParamsSet{
         fusingFakeQuantizePerChannelRelu,
         // sum
         fusingSumEluFQ,
-        fusingSum
+        fusingSum,
         // bias
         fusingAddPerChannel
 };
@@ -170,7 +170,7 @@ const std::vector<fusingSpecificParams> fusingParamsSetBF16{
         // depthwise
         fusingReluScaleShift,
         // sum
-        fusingSum
+        fusingSum,
         // bias
         fusingAddPerChannel
 };
@@ -625,7 +625,7 @@ const auto convParams_1D = ::testing::Combine(
     ::testing::ValuesIn(padBegins1d),
     ::testing::ValuesIn(padEnds1d),
     ::testing::ValuesIn(dilations1d),
-    ::testing::ValuesIn(numOutChannels_Blocked),
+    ::testing::ValuesIn(numOutChannels),
     ::testing::Values(ngraph::op::PadType::EXPLICIT)
 );
 

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution_backprop_data.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution_backprop_data.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "test_utils/cpu_test_utils.hpp"
+#include "test_utils/convolution_params.hpp"
 #include "test_utils/fusing_test_utils.hpp"
 #include "shared_test_classes/base/layer_test_utils.hpp"
 #include "ngraph_functions/utils/ngraph_helpers.hpp"

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/eltwise.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/eltwise.cpp
@@ -361,5 +361,33 @@ const auto params_4D_1D = ::testing::Combine(
 
 INSTANTIATE_TEST_CASE_P(smoke_CompareWithRefs_4D_1D, EltwiseLayerCPUTest, params_4D_1D, EltwiseLayerCPUTest::getTestCaseName);
 
+std::vector<std::vector<std::vector<size_t>>> inShapes_5D_1D = {
+        {{2, 17, 5, 4, 10}, {10}},
+        {{1, 3, 3, 3, 3}, {3}},
+};
+
+std::vector<CPUSpecificParams> cpuParams_5D_1D = {
+        CPUSpecificParams({nCdhw16c, x}, {nCdhw16c}, {}, {}),
+        CPUSpecificParams({ndhwc, x}, {ndhwc}, {}, {}),
+        CPUSpecificParams({ncdhw, x}, {ncdhw}, {}, {})
+};
+
+const auto params_5D_1D = ::testing::Combine(
+        ::testing::Combine(
+                ::testing::ValuesIn(inShapes_5D_1D),
+                ::testing::Values(ngraph::helpers::EltwiseTypes::ADD, ngraph::helpers::EltwiseTypes::MULTIPLY),
+                ::testing::ValuesIn(secondaryInputTypes),
+                ::testing::ValuesIn(opTypes),
+                ::testing::ValuesIn(netPrc),
+                ::testing::Values(InferenceEngine::Precision::FP32),
+                ::testing::Values(InferenceEngine::Precision::FP32),
+                ::testing::Values(InferenceEngine::Layout::ANY),
+                ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                ::testing::Values(additional_config)),
+        ::testing::ValuesIn(filterCPUSpecificParams(cpuParams_5D_1D)));
+
+INSTANTIATE_TEST_CASE_P(smoke_CompareWithRefs_5D_1D, EltwiseLayerCPUTest, params_5D_1D, EltwiseLayerCPUTest::getTestCaseName);
+
+
 } // namespace
 } // namespace CPULayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/eltwise.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/eltwise.cpp
@@ -333,5 +333,33 @@ const auto params_5D_Planar_Blocked = ::testing::Combine(
 
 INSTANTIATE_TEST_CASE_P(smoke_CompareWithRefs_5D_Planar_Blocked, EltwiseLayerCPUTest, params_5D_Planar_Blocked, EltwiseLayerCPUTest::getTestCaseName);
 
+
+std::vector<std::vector<std::vector<size_t>>> inShapes_4D_1D = {
+        {{2, 17, 5, 4}, {4}},
+        {{1, 3, 3, 3}, {3}},
+};
+
+std::vector<CPUSpecificParams> cpuParams_4D_1D = {
+        CPUSpecificParams({nChw16c, x}, {nChw16c}, {}, {}),
+        CPUSpecificParams({nhwc, x}, {nhwc}, {}, {}),
+        CPUSpecificParams({nchw, x}, {nchw}, {}, {})
+};
+
+const auto params_4D_1D = ::testing::Combine(
+        ::testing::Combine(
+                ::testing::ValuesIn(inShapes_4D_1D),
+                ::testing::Values(ngraph::helpers::EltwiseTypes::ADD, ngraph::helpers::EltwiseTypes::MULTIPLY),
+                ::testing::ValuesIn(secondaryInputTypes),
+                ::testing::ValuesIn(opTypes),
+                ::testing::ValuesIn(netPrc),
+                ::testing::Values(InferenceEngine::Precision::FP32),
+                ::testing::Values(InferenceEngine::Precision::FP32),
+                ::testing::Values(InferenceEngine::Layout::ANY),
+                ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                ::testing::Values(additional_config)),
+        ::testing::ValuesIn(filterCPUSpecificParams(cpuParams_4D_1D)));
+
+INSTANTIATE_TEST_CASE_P(smoke_CompareWithRefs_4D_1D, EltwiseLayerCPUTest, params_4D_1D, EltwiseLayerCPUTest::getTestCaseName);
+
 } // namespace
 } // namespace CPULayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
@@ -96,6 +96,13 @@ protected:
         size_t convOutChannels, numGroups;
         std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, numGroups, padType) = groupConvParams;
 
+        //todo[mkutakov]: to add nxc support to the DW fork convolution
+        if (inFmts.front() == nhwc) {
+            if ((padBegin == std::vector<ptrdiff_t>{1, 1}) && (kernel == SizeVector{1, 1})) {
+                selectedType = "jit_gemm_FP32";
+            }
+        }
+
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
         auto paramOuts = ngraph::helpers::convert2OutputVector(
@@ -169,8 +176,8 @@ std::vector<fusingSpecificParams> fusingParamsSet {
 
 
 /* ============= GroupConvolution params (planar layout) ============= */
-const SizeVector numOutChannels_Planar = {6};
-const SizeVector numGroups_Planar = {2, 3};
+const SizeVector numOutChannels_Gemm = {6};
+const SizeVector numGroups_Gemm = {2, 3};
 
 /* ============= GroupConvolution params (blocked layout) ============= */
 const SizeVector numOutChannels_Blocked = {64};
@@ -197,26 +204,27 @@ const std::vector<SizeVector> dilations3d = {{1, 1, 1}, {2, 2, 2}};
 
 
 /* INSTANCES */
-/* ============= GroupConvolution (Planar 2D) ============= */
-const auto groupConvParams_ExplicitPadding_Planar_2D = ::testing::Combine(
+/* ============= GroupConvolution (GEMM 2D) ============= */
+const auto groupConvParams_ExplicitPadding_Gemm_2D = ::testing::Combine(
         ::testing::ValuesIn(kernels2d),
         ::testing::ValuesIn(strides2d),
         ::testing::ValuesIn(padBegins2d),
         ::testing::ValuesIn(padEnds2d),
         ::testing::ValuesIn(dilations2d),
-        ::testing::ValuesIn(numOutChannels_Planar),
-        ::testing::ValuesIn(numGroups_Planar),
+        ::testing::ValuesIn(numOutChannels_Gemm),
+        ::testing::ValuesIn(numGroups_Gemm),
         ::testing::Values(ngraph::op::PadType::EXPLICIT)
 );
 
-const std::vector<CPUSpecificParams> CPUParams_Planar_2D = {
-        conv_gemm_2D
+const std::vector<CPUSpecificParams> CPUParams_Gemm_2D = {
+        conv_gemm_2D,
+        conv_gemm_2D_nspc
 };
 
-INSTANTIATE_TEST_CASE_P(smoke_GroupConv_2D_Planar_FP32, GroupConvolutionLayerCPUTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConv_2D_Gemm_FP32, GroupConvolutionLayerCPUTest,
                         ::testing::Combine(
                                 ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_Planar_2D,
+                                        groupConvParams_ExplicitPadding_Gemm_2D,
                                         ::testing::Values(Precision::FP32),
                                         ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
                                         ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
@@ -224,30 +232,31 @@ INSTANTIATE_TEST_CASE_P(smoke_GroupConv_2D_Planar_FP32, GroupConvolutionLayerCPU
                                         ::testing::Values(InferenceEngine::Layout::ANY),
                                         ::testing::Values(std::vector<size_t >({2, 12, 7, 7})),
                                         ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Planar_2D)),
+                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Gemm_2D)),
                                 ::testing::ValuesIn(fusingParamsSet)),
                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
-/* ============= GroupConvolution (Planar 3D) ============= */
-const auto groupConvParams_ExplicitPadding_Planar_3D = ::testing::Combine(
+/* ============= GroupConvolution (Gemm 3D) ============= */
+const auto groupConvParams_ExplicitPadding_Gemm_3D = ::testing::Combine(
         ::testing::ValuesIn(kernels3d),
         ::testing::ValuesIn(strides3d),
         ::testing::ValuesIn(padBegins3d),
         ::testing::ValuesIn(padEnds3d),
         ::testing::ValuesIn(dilations3d),
-        ::testing::ValuesIn(numOutChannels_Planar),
-        ::testing::ValuesIn(numGroups_Planar),
+        ::testing::ValuesIn(numOutChannels_Gemm),
+        ::testing::ValuesIn(numGroups_Gemm),
         ::testing::Values(ngraph::op::PadType::EXPLICIT)
 );
 
-const std::vector<CPUSpecificParams> CPUParams_Planar_3D = {
-        conv_gemm_3D
+const std::vector<CPUSpecificParams> CPUParams_Gemm_3D = {
+        conv_gemm_3D,
+        conv_gemm_3D_nspc
 };
 
-INSTANTIATE_TEST_CASE_P(smoke_GroupConv_3D_Planar_FP32, GroupConvolutionLayerCPUTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConv_3D_Gemm_FP32, GroupConvolutionLayerCPUTest,
                         ::testing::Combine(
                                 ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_Planar_3D,
+                                        groupConvParams_ExplicitPadding_Gemm_3D,
                                         ::testing::Values(Precision::FP32),
                                         ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
                                         ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
@@ -255,12 +264,12 @@ INSTANTIATE_TEST_CASE_P(smoke_GroupConv_3D_Planar_FP32, GroupConvolutionLayerCPU
                                         ::testing::Values(InferenceEngine::Layout::ANY),
                                         ::testing::Values(std::vector<size_t >({2, 12, 7, 7, 7})),
                                         ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Planar_3D)),
+                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Gemm_3D)),
                                 ::testing::ValuesIn(fusingParamsSet)),
                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
-/* ============= GroupConvolution (Blocked 2D) ============= */
-const auto groupConvParams_ExplicitPadding_Blocked_2D = ::testing::Combine(
+/* ============= GroupConvolution (2D) ============= */
+const auto groupConvParams_ExplicitPadding_2D = ::testing::Combine(
         ::testing::ValuesIn(kernels2d),
         ::testing::ValuesIn(strides2d),
         ::testing::ValuesIn(padBegins2d),
@@ -271,16 +280,19 @@ const auto groupConvParams_ExplicitPadding_Blocked_2D = ::testing::Combine(
         ::testing::Values(ngraph::op::PadType::EXPLICIT)
 );
 
-const std::vector<CPUSpecificParams> CPUParams_Blocked_2D = {
+const std::vector<CPUSpecificParams> CPUParams_2D = {
         conv_sse42_2D,
         conv_avx2_2D,
-        conv_avx512_2D
+        conv_avx512_2D,
+        conv_sse42_2D_nspc,
+        conv_avx2_2D_nspc,
+        conv_avx512_2D_nspc
 };
 
-INSTANTIATE_TEST_CASE_P(smoke_GroupConv_2D_Blocked_FP32, GroupConvolutionLayerCPUTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConv_2D_FP32, GroupConvolutionLayerCPUTest,
                         ::testing::Combine(
                                 ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_Blocked_2D,
+                                        groupConvParams_ExplicitPadding_2D,
                                         ::testing::Values(Precision::FP32),
                                         ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
                                         ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
@@ -288,12 +300,12 @@ INSTANTIATE_TEST_CASE_P(smoke_GroupConv_2D_Blocked_FP32, GroupConvolutionLayerCP
                                         ::testing::Values(InferenceEngine::Layout::ANY),
                                         ::testing::Values(std::vector<size_t >({2, 64, 7, 7})),
                                         ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Blocked_2D)),
+                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_2D)),
                                 ::testing::ValuesIn(fusingParamsSet)),
                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
-/* ============= GroupConvolution (Blocked 3D) ============= */
-const auto groupConvParams_ExplicitPadding_Blocked_3D = ::testing::Combine(
+/* ============= GroupConvolution (3D) ============= */
+const auto groupConvParams_ExplicitPadding_3D = ::testing::Combine(
         ::testing::ValuesIn(kernels3d),
         ::testing::ValuesIn(strides3d),
         ::testing::ValuesIn(padBegins3d),
@@ -304,16 +316,18 @@ const auto groupConvParams_ExplicitPadding_Blocked_3D = ::testing::Combine(
         ::testing::Values(ngraph::op::PadType::EXPLICIT)
 );
 
-const std::vector<CPUSpecificParams> CPUParams_Blocked_3D = {
+const std::vector<CPUSpecificParams> CPUParams_3D = {
 //        conv_sse42_3D, // not supported jit_sse42 for 3d
         conv_avx2_3D,
-        conv_avx512_3D
+        conv_avx512_3D,
+        conv_avx2_3D_nspc,
+        conv_avx512_3D_nspc
 };
 
-INSTANTIATE_TEST_CASE_P(smoke_GroupConv_3D_Blocked_FP32, GroupConvolutionLayerCPUTest,
+INSTANTIATE_TEST_CASE_P(smoke_GroupConv_3D_FP32, GroupConvolutionLayerCPUTest,
                         ::testing::Combine(
                                 ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_Blocked_3D,
+                                        groupConvParams_ExplicitPadding_3D,
                                         ::testing::Values(Precision::FP32),
                                         ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
                                         ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
@@ -321,7 +335,7 @@ INSTANTIATE_TEST_CASE_P(smoke_GroupConv_3D_Blocked_FP32, GroupConvolutionLayerCP
                                         ::testing::Values(InferenceEngine::Layout::ANY),
                                         ::testing::Values(std::vector<size_t >({2, 64, 7, 7, 7})),
                                         ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Blocked_3D)),
+                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_3D)),
                                 ::testing::ValuesIn(fusingParamsSet)),
                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
@@ -340,7 +354,10 @@ const auto groupConvParams_ExplicitPadding_DW_2D = ::testing::Combine(
 const std::vector<CPUSpecificParams> CPUParams_DW_2D = {
         conv_sse42_dw_2D,
         conv_avx2_dw_2D,
-        conv_avx512_dw_2D
+        conv_avx512_dw_2D,
+        conv_sse42_dw_2D_nspc,
+        conv_avx2_dw_2D_nspc,
+        conv_avx512_dw_2D_nspc
 };
 
 INSTANTIATE_TEST_CASE_P(smoke_GroupConv_2D_DW_FP32, GroupConvolutionLayerCPUTest,
@@ -373,7 +390,11 @@ const auto groupConvParams_ExplicitPadding_DW_3D = ::testing::Combine(
 const std::vector<CPUSpecificParams> CPUParams_DW_3D = {
         conv_sse42_dw_3D,
         conv_avx2_dw_3D,
-        conv_avx512_dw_3D
+        conv_avx512_dw_3D,
+//                                __
+//        conv_sse42_dw_3D_nspc,    |
+//        conv_avx2_dw_3D_nspc,     >   fork  dw convolution does not support nspc layout
+//        conv_avx512_dw_3D_nspc  __|
 };
 
 INSTANTIATE_TEST_CASE_P(smoke_GroupConv_3D_DW_FP32, GroupConvolutionLayerCPUTest,
@@ -394,10 +415,11 @@ INSTANTIATE_TEST_CASE_P(smoke_GroupConv_3D_DW_FP32, GroupConvolutionLayerCPUTest
 
 
 /* ============= SINGLE TEST CASES ============= */
-groupConvLayerCPUTestParamsSet makeSingleGroupConvCPUTestCase(SizeVector kernels, SizeVector strides, SizeVector dilations,
-                                                        std::vector<ptrdiff_t> padBegins, std::vector<ptrdiff_t> padEnds, ngraph::op::PadType padType,
-                                                        int groups, int mb, SizeVector spDims, int inGroupSize, int outGroupSize,
-                                                        CPUSpecificParams CPUParams) {
+std::vector<groupConvLayerCPUTestParamsSet> makeSingleGroupConvCPUTestCases(SizeVector kernels, SizeVector strides, SizeVector dilations,
+                                                                            std::vector<ptrdiff_t> padBegins, std::vector<ptrdiff_t> padEnds,
+                                                                            ngraph::op::PadType padType, int groups, int mb, SizeVector spDims,
+                                                                            int inGroupSize, int outGroupSize,
+                                                                            const std::vector<CPUSpecificParams>& CPUParams) {
     int inChannels = groups * inGroupSize;
     int outChannels = groups * outGroupSize;
 
@@ -408,41 +430,66 @@ groupConvLayerCPUTestParamsSet makeSingleGroupConvCPUTestCase(SizeVector kernels
 
     groupConvSpecificParams specificParams(kernels, strides, padBegins, padEnds, dilations, outChannels, groups, padType);
     groupConvLayerTestParamsSet basicParamsSet(specificParams, Precision::FP32,
-        InferenceEngine::Precision::UNSPECIFIED,
-        InferenceEngine::Precision::UNSPECIFIED,
-        InferenceEngine::Layout::ANY,
-        InferenceEngine::Layout::ANY, inputShapes, CommonTestUtils::DEVICE_CPU);
-    return groupConvLayerCPUTestParamsSet(basicParamsSet, CPUParams, emptyFusingSpec);
+                                               InferenceEngine::Precision::UNSPECIFIED,
+                                               InferenceEngine::Precision::UNSPECIFIED,
+                                               InferenceEngine::Layout::ANY,
+                                               InferenceEngine::Layout::ANY, inputShapes, CommonTestUtils::DEVICE_CPU);
+    std::vector<groupConvLayerCPUTestParamsSet> retVector;
+    for (auto& item : CPUParams) {
+        retVector.push_back(groupConvLayerCPUTestParamsSet(basicParamsSet, item, emptyFusingSpec));
+    }
+    return  retVector;
 }
 
+template<typename T>
+void concatTestCases(std::vector<groupConvLayerCPUTestParamsSet>& resultVec, T tesCase) {
+    resultVec.insert(resultVec.begin(), std::make_move_iterator(tesCase.begin()), std::make_move_iterator(tesCase.end()));
+}
+
+template<typename T, typename... Args>
+void concatTestCases(std::vector<groupConvLayerCPUTestParamsSet>& resultVec, T&& tesCase, Args&&... args) {
+    concatTestCases(resultVec, std::forward<T>(tesCase));
+    concatTestCases(resultVec, std::forward<Args>(args)...);
+}
+
+template<typename... Args>
+std::vector<groupConvLayerCPUTestParamsSet> generateSingleGroupConvCPUTestCases(Args&&... args) {
+    std::vector<groupConvLayerCPUTestParamsSet> retVec;
+    concatTestCases(retVec, std::forward<Args>(args)...);
+    return retVec;
+}
+
+
 /* ============= GEMM GroupConvolution ============= */
-const std::vector<groupConvLayerCPUTestParamsSet> gemmGroupConvTestCases = {
+const std::vector<groupConvLayerCPUTestParamsSet> gemmGroupConvTestCases = generateSingleGroupConvCPUTestCases(
         //  1. is_depthwise (true, false)
         //  2. jcp.im2col_sz (=0,>0)
         //  3. is_blocking_applicable (true, false)
 
         //  is_depthwise == false, im2col_sz > 0
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 2, 2, conv_gemm_2D),
+                makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 2, 2, CPUParams_Gemm_2D),
         //  is_depthwise == true
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 1, 1, conv_gemm_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 1, 1, CPUParams_Gemm_2D),
         //  im2col_sz == 0, is_blocking_applicable == true
-        makeSingleGroupConvCPUTestCase({1, 1}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 2, 2, conv_gemm_2D),
+        makeSingleGroupConvCPUTestCases({1, 1}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 2, 2, CPUParams_Gemm_2D),
         //  is_blocking_applicable == false ((jcp.im2col_sz == 0) && (jcp.ic / jcp.oc >= 42))
-        makeSingleGroupConvCPUTestCase({1, 1}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 42, 1, conv_gemm_2D),
+        makeSingleGroupConvCPUTestCases({1, 1}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 42, 1, CPUParams_Gemm_2D),
 
         //  "hard" cases
-        makeSingleGroupConvCPUTestCase({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 3, 2, {129, 129}, 4, 2, conv_gemm_2D),
-        makeSingleGroupConvCPUTestCase({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT, 2, 1, {10, 10}, 3, 3, conv_gemm_2D),
-        makeSingleGroupConvCPUTestCase({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
-                3, 2, {33, 33, 33}, 4, 2, conv_gemm_3D),
-        makeSingleGroupConvCPUTestCase({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                2, 1, {10, 10, 10}, 3, 3, conv_gemm_3D),
-};
+        makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 3, 2, {129, 129}, 4, 2, CPUParams_Gemm_2D),
+        makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT, 2, 1, {10, 10}, 3, 3, CPUParams_Gemm_2D),
+        makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
+                                        3, 2, {33, 33, 33}, 4, 2, CPUParams_Gemm_3D),
+        makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
+                                        2, 1, {10, 10, 10}, 3, 3, CPUParams_Gemm_3D)
+);
 
-INSTANTIATE_TEST_CASE_P(smoke_GEMM_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(gemmGroupConvTestCases)));
+INSTANTIATE_TEST_CASE_P(smoke_GEMM_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(gemmGroupConvTestCases)),
+                        GroupConvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= JIT SSE42 GroupConvolution ============= */
-const std::vector<groupConvLayerCPUTestParamsSet> JIT_SSE42_GroupConvTestCases = {
+const std::vector<CPUSpecificParams> sse42_GroupConv = {conv_sse42_2D, conv_sse42_2D_nspc};
+const std::vector<groupConvLayerCPUTestParamsSet> JIT_SSE42_GroupConvTestCases = generateSingleGroupConvCPUTestCases(
         //  1. jcp.ur_w (=3,<3)
         //  2. jcp.ur_w_tail (=0,>0)
         //  3. jcp.kw (>7,<=7)
@@ -451,37 +498,40 @@ const std::vector<groupConvLayerCPUTestParamsSet> JIT_SSE42_GroupConvTestCases =
         //  6. ocb_work
 
         //  jcp.ur_w == 3, jcp.ur_w_tail == 2
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 10}, 8, 8, conv_sse42_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 10}, 8, 8, sse42_GroupConv),
         //  jcp.ur_w < 3 (jcp.ur_w == jcp.ow)
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 4}, 8, 8, conv_sse42_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 4}, 8, 8, sse42_GroupConv),
         //  jcp.ur_w == 3, jcp.ur_w_tail == 0
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 11}, 8, 8, conv_sse42_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 11}, 8, 8, sse42_GroupConv),
         //  jcp.kw > 7
-        makeSingleGroupConvCPUTestCase({3, 8}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 10}, 8, 8, conv_sse42_2D),
+        makeSingleGroupConvCPUTestCases({3, 8}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 10}, 8, 8, sse42_GroupConv),
         //  jcp.nb_oc == 2
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 8, 16, conv_sse42_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 8, 16, sse42_GroupConv),
         //  jcp.nb_ic == 2
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 16, 8, conv_sse42_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 16, 8, sse42_GroupConv),
         //  ocb_work > 1 (ocb_work == 2)
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 8, 40, conv_sse42_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 8, 40, sse42_GroupConv),
         //  jcp.nb_ic == 2, ocb_work == 2
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 16, 40, conv_sse42_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 16, 40, sse42_GroupConv),
 
         //  "hard" cases
-        makeSingleGroupConvCPUTestCase({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 3, 2, {129, 129}, 8, 8, conv_sse42_2D),
-        makeSingleGroupConvCPUTestCase({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT, 2, 1, {10, 10}, 8, 8, conv_sse42_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 3, 2, {129, 129}, 8, 8, sse42_GroupConv),
+        makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT, 2, 1, {10, 10}, 8, 8, sse42_GroupConv)
 
         //  not supported jit_sse42 for 3d
-        //  makeSingleGroupConvCPUTestCase({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
+        //  makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
         //                              3, 2, {33, 33, 33}, 8, 8, cpuParams_sse42_3D),
-        //  makeSingleGroupConvCPUTestCase({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
+        //  makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
         //                              2, 1, {10, 10, 10}, 8, 8, cpuParams_sse42_3D),
-};
+);
 
-INSTANTIATE_TEST_CASE_P(smoke_JIT_SSE42_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(JIT_SSE42_GroupConvTestCases)));
+INSTANTIATE_TEST_CASE_P(smoke_JIT_SSE42_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(JIT_SSE42_GroupConvTestCases)),
+                        GroupConvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= JIT AVX2 GroupConvolution ============= */
-const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX2_GroupConvTestCases = {
+const std::vector<CPUSpecificParams> avx2_GroupConv_2D = {conv_sse42_2D, conv_sse42_2D_nspc};
+const std::vector<CPUSpecificParams> avx2_GroupConv_3D = {conv_avx2_3D, conv_avx2_3D_nspc};
+const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX2_GroupConvTestCases = generateSingleGroupConvCPUTestCases(
         //  1. jcp.ur_w (=3,<3)
         //  2. jcp.ur_w_tail (=0,>0)
         //  3. jcp.kw (>7,<=7)
@@ -490,144 +540,155 @@ const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX2_GroupConvTestCases = 
         //  6. ocb_work
 
         //  jcp.ur_w == 3, jcp.ur_w_tail == 2
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 10}, 8, 8, conv_avx2_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 10}, 8, 8, avx2_GroupConv_2D),
         //  jcp.ur_w < 3 (jcp.ur_w == jcp.ow)
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 4}, 8, 8, conv_avx2_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 4}, 8, 8, avx2_GroupConv_2D),
         //  jcp.ur_w == 3, jcp.ur_w_tail == 0
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 11}, 8, 8, conv_avx2_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 11}, 8, 8, avx2_GroupConv_2D),
         //  jcp.kw > 7
-        makeSingleGroupConvCPUTestCase({3, 8}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 10}, 8, 8, conv_avx2_2D),
+        makeSingleGroupConvCPUTestCases({3, 8}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 10}, 8, 8, avx2_GroupConv_2D),
         //  jcp.nb_oc == 2
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 8, 16, conv_avx2_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 8, 16, avx2_GroupConv_2D),
         //  jcp.nb_ic == 2
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 16, 8, conv_avx2_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 16, 8, avx2_GroupConv_2D),
         //  ocb_work > 1 (ocb_work == 2)
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 8, 40, conv_avx2_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 8, 40, avx2_GroupConv_2D),
         //  jcp.nb_ic == 2, ocb_work == 2
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 16, 40, conv_avx2_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 16, 40, avx2_GroupConv_2D),
 
         //  "hard" cases
-        makeSingleGroupConvCPUTestCase({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 3, 2, {129, 129}, 8, 8, conv_avx2_2D),
-        makeSingleGroupConvCPUTestCase({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT, 2, 1, {10, 10}, 8, 8, conv_avx2_2D),
-        makeSingleGroupConvCPUTestCase({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
-                                    3, 2, {33, 33, 33}, 8, 8, conv_avx2_3D),
-        makeSingleGroupConvCPUTestCase({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                                    2, 1, {10, 10, 10}, 8, 8, conv_avx2_3D),
-};
+        makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 3, 2, {129, 129}, 8, 8, avx2_GroupConv_2D),
+        makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT, 2, 1, {10, 10}, 8, 8, avx2_GroupConv_2D),
+        makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
+                                        3, 2, {33, 33, 33}, 8, 8, avx2_GroupConv_3D),
+        makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
+                                        2, 1, {10, 10, 10}, 8, 8, avx2_GroupConv_3D)
+);
 
-INSTANTIATE_TEST_CASE_P(smoke_JIT_AVX2_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(JIT_AVX2_GroupConvTestCases)));
+INSTANTIATE_TEST_CASE_P(smoke_JIT_AVX2_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(JIT_AVX2_GroupConvTestCases)),
+                        GroupConvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= JIT AVX512 GroupConvolution ============= */
-const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX512_GroupConvTestCases = {
+const std::vector<CPUSpecificParams> avx512_GroupConv_2D = {conv_avx512_2D, conv_avx512_2D_nspc};
+const std::vector<CPUSpecificParams> avx512_GroupConv_3D = {conv_avx512_3D, conv_avx512_3D_nspc};
+const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX512_GroupConvTestCases = generateSingleGroupConvCPUTestCases(
         //  1. "blocked to blocked" or "planar to blocked"
         //  2. jcp.nb_ic, jcp.nb_oc
 
         //  blocked to blocked
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 16, 16, conv_avx512_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 16, 16, avx512_GroupConv_2D),
         //  jcp.nb_ic == 2
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 32, 16, conv_avx512_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 32, 16, avx512_GroupConv_2D),
         //  jcp.nb_oc == 2
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 16, 32, conv_avx512_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 16, 32, avx512_GroupConv_2D),
 
         //  "hard" cases
-        makeSingleGroupConvCPUTestCase({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 3, 2, {129, 129}, 16, 16,
-                                       conv_avx512_2D),
-        makeSingleGroupConvCPUTestCase({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT, 2, 1, {10, 10}, 16, 16, conv_avx512_2D),
-        makeSingleGroupConvCPUTestCase({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
-                                    3, 2, {33, 33, 33}, 16, 16, conv_avx512_3D),
-        makeSingleGroupConvCPUTestCase({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                                    2, 1, {10, 10, 10}, 16, 16, conv_avx512_3D),
-};
+        makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 3, 2, {129, 129}, 16, 16,
+                                        avx512_GroupConv_2D),
+        makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT, 2, 1, {10, 10}, 16, 16, avx512_GroupConv_2D),
+        makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
+                                        3, 2, {33, 33, 33}, 16, 16, avx512_GroupConv_3D),
+        makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
+                                        2, 1, {10, 10, 10}, 16, 16, avx512_GroupConv_3D)
+);
 
-INSTANTIATE_TEST_CASE_P(smoke_JIT_AVX512_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(JIT_AVX512_GroupConvTestCases)));
+INSTANTIATE_TEST_CASE_P(smoke_JIT_AVX512_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(JIT_AVX512_GroupConvTestCases)),
+                        GroupConvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= JIT SSE42 DW GroupConvolution ============= */
-const std::vector<groupConvLayerCPUTestParamsSet> JIT_SSE42_DW_GroupConvTestCases = {
+const std::vector<CPUSpecificParams> sse42_DW_2D = {conv_sse42_dw_2D, conv_sse42_dw_2D_nspc};
+const std::vector<CPUSpecificParams> sse42_DW_3D = {conv_sse42_dw_3D, conv_sse42_dw_3D_nspc};
+const std::vector<groupConvLayerCPUTestParamsSet> JIT_SSE42_DW_GroupConvTestCases = generateSingleGroupConvCPUTestCases(
         //  1. jcp.ngroups % simd_w (=0,!=0)
         //  2. jcp.nb_ch
         //  3. jcp.nb_ch_blocking (=2,<2)
         //  4. jcp.ur_w == 3
 
         //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 1, jcp.nb_ch_blocking == 1 (jcp.ngroups == 8)
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 8, 1, {5, 5}, 1, 1, conv_sse42_dw_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 8, 1, {5, 5}, 1, 1, sse42_DW_2D),
         //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 2, jcp.nb_ch_blocking == 2 (jcp.ngroups == 16)
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 16, 1, {5, 5}, 1, 1, conv_sse42_dw_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 16, 1, {5, 5}, 1, 1, sse42_DW_2D),
         //  jcp.ngroups % simd_w != 0, jcp.nb_ch == 3, jcp.nb_ch_blocking == 2 (jcp.ngroups == 17) TODO: pad channels not supported for SSE42
-        //  makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 17, 1, {5, 5}, 1, 1, conv_sse42_dw_2D),
+        //  makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 17, 1, {5, 5}, 1, 1, conv_sse42_dw_2D),
         //  jcp.ow > jcp.ur_w (jcp.ow == 7)
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 8, 1, {5, 9}, 1, 1, conv_sse42_dw_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 8, 1, {5, 9}, 1, 1, sse42_DW_2D),
 
         //  "hard" cases
-        makeSingleGroupConvCPUTestCase({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 8, 2, {129, 129}, 1, 1,
-                                       conv_sse42_dw_2D),
-        makeSingleGroupConvCPUTestCase({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT, 8, 1, {10, 10}, 1, 1, conv_sse42_dw_2D),
-        makeSingleGroupConvCPUTestCase({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
-                                    8, 2, {33, 33, 33}, 1, 1, conv_sse42_dw_3D),
-        makeSingleGroupConvCPUTestCase({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                                    8, 1, {10, 10, 10}, 1, 1, conv_sse42_dw_3D),
-};
+        makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 8, 2, {129, 129}, 1, 1,
+                                        sse42_DW_2D),
+        makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT, 8, 1, {10, 10}, 1, 1, sse42_DW_2D),
+        makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
+                                        8, 2, {33, 33, 33}, 1, 1, /*sse42_DW_3D*/{conv_sse42_dw_3D}), // todo [mkutakov] : add nspc support to fork dw conv
+        makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
+                                        8, 1, {10, 10, 10}, 1, 1, /*sse42_DW_3D*/{conv_sse42_dw_3D}) // todo [mkutakov] : add nspc support to fork dw conv
+);
 
 INSTANTIATE_TEST_CASE_P(smoke_JIT_SSE42_DW_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice
-(JIT_SSE42_DW_GroupConvTestCases)));
+(JIT_SSE42_DW_GroupConvTestCases)), GroupConvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= JIT AVX2 DW GroupConvolution ============= */
-const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX2_DW_GroupConvTestCases = {
+const std::vector<CPUSpecificParams> avx2_DW_2D = {conv_avx2_dw_2D, conv_avx2_dw_2D_nspc};
+const std::vector<CPUSpecificParams> avx2_DW_3D = {conv_avx2_dw_3D, conv_avx2_dw_3D_nspc};
+const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX2_DW_GroupConvTestCases = generateSingleGroupConvCPUTestCases(
         //  1. jcp.ngroups % simd_w (=0,!=0)
         //  2. jcp.nb_ch
         //  3. jcp.nb_ch_blocking (=3,<3)
         //  4. jcp.ur_w == 4
 
         //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 1, jcp.nb_ch_blocking == 1 (jcp.ngroups == 8)
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 8, 1, {5, 5}, 1, 1, conv_avx2_dw_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 8, 1, {5, 5}, 1, 1, avx2_DW_2D),
         //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 3, jcp.nb_ch_blocking == 3 (jcp.ngroups == 24)
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 24, 1, {5, 5}, 1, 1, conv_avx2_dw_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 24, 1, {5, 5}, 1, 1, avx2_DW_2D),
         //  jcp.ngroups % simd_w != 0, jcp.nb_ch == 4, jcp.nb_ch_blocking == 3 (jcp.ngroups == 25)
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 25, 1, {5, 5}, 1, 1, conv_avx2_dw_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        25, 1, {5, 5}, 1, 1, /*avx2_DW_2D*/ {conv_avx2_dw_2D}), // todo [mkutakov] : add nspc support to fork dw conv
         //  jcp.ow > jcp.ur_w (jcp.ow == 7)
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 8, 1, {5, 9}, 1, 1, conv_avx2_dw_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 8, 1, {5, 9}, 1, 1, avx2_DW_2D),
 
         //  "hard" cases
-        makeSingleGroupConvCPUTestCase({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 8, 2, {129, 129}, 1, 1,
-                                       conv_avx2_dw_2D),
-        makeSingleGroupConvCPUTestCase({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT, 8, 1, {10, 10}, 1, 1, conv_avx2_dw_2D),
-        makeSingleGroupConvCPUTestCase({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
-                                    8, 2, {33, 33, 33}, 1, 1, conv_avx2_dw_3D),
-        makeSingleGroupConvCPUTestCase({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                                    8, 1, {10, 10, 10}, 1, 1, conv_avx2_dw_3D),
-};
+        makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 8, 2, {129, 129}, 1, 1,
+                                        avx2_DW_2D),
+        makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT, 8, 1, {10, 10}, 1, 1, avx2_DW_2D),
+        makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
+                                        8, 2, {33, 33, 33}, 1, 1, /*avx2_DW_3D*/{conv_avx2_dw_3D}), // todo [mkutakov] : add nspc support to fork dw conv
+        makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
+                                        8, 1, {10, 10, 10}, 1, 1, /*avx2_DW_3D*/{conv_avx2_dw_3D}) // todo [mkutakov] : add nspc support to fork dw conv
+);
 
 INSTANTIATE_TEST_CASE_P(smoke_JIT_AVX2_DW_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice
-(JIT_AVX2_DW_GroupConvTestCases)));
+(JIT_AVX2_DW_GroupConvTestCases)), GroupConvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= JIT AVX512 DW GroupConvolution ============= */
-const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX512_DW_GroupConvTestCases = {
+const std::vector<CPUSpecificParams> avx512_DW_2D = {conv_avx512_dw_2D, conv_avx512_dw_2D_nspc};
+const std::vector<CPUSpecificParams> avx512_DW_3D = {conv_avx512_dw_3D, conv_avx512_dw_3D_nspc};
+const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX512_DW_GroupConvTestCases = generateSingleGroupConvCPUTestCases(
         //  1. jcp.ngroups % simd_w (=0,!=0)
         //  2. jcp.nb_ch
         //  3. jcp.nb_ch_blocking (=4,<4)
         //  4. jcp.ur_w == 6
 
         //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 1, jcp.nb_ch_blocking == 1 (jcp.ngroups == 16)
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 16, 1, {5, 5}, 1, 1, conv_avx512_dw_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 16, 1, {5, 5}, 1, 1, avx512_DW_2D),
         //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 4, jcp.nb_ch_blocking == 4 (jcp.ngroups == 64)
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 64, 1, {5, 5}, 1, 1, conv_avx512_dw_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 64, 1, {5, 5}, 1, 1, avx512_DW_2D),
         //  jcp.ngroups % simd_w != 0, jcp.nb_ch == 5, jcp.nb_ch_blocking == 4 (jcp.ngroups == 65)
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 65, 1, {5, 5}, 1, 1, conv_avx512_dw_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 65, 1, {5, 5}, 1, 1, avx512_DW_2D),
         //  jcp.ow > jcp.ur_w (jcp.ow == 7)
-        makeSingleGroupConvCPUTestCase({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 8, 1, {5, 9}, 1, 1, conv_avx512_dw_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 8, 1, {5, 9}, 1, 1, avx512_DW_2D),
 
         //  "hard" cases
-        makeSingleGroupConvCPUTestCase({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 16, 2, {129, 129}, 1, 1,
-                                       conv_avx512_dw_2D),
-        makeSingleGroupConvCPUTestCase({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT, 16, 1, {10, 10}, 1, 1,
-                                       conv_avx512_dw_2D),
-        makeSingleGroupConvCPUTestCase({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
-                                    16, 2, {33, 33, 33}, 1, 1, conv_avx512_dw_3D),
-        makeSingleGroupConvCPUTestCase({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                                    16, 1, {10, 10, 10}, 1, 1, conv_avx512_dw_3D),
-};
+        makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 16, 2, {129, 129}, 1, 1,
+                                        avx512_DW_2D),
+        makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT, 16, 1, {10, 10}, 1, 1,
+                                        avx512_DW_2D),
+        makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
+                                        16, 2, {33, 33, 33}, 1, 1, avx512_DW_3D),
+        makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
+                                        16, 1, {10, 10, 10}, 1, 1, avx512_DW_3D)
+);
 
 INSTANTIATE_TEST_CASE_P(smoke_JIT_AVX512_DW_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice
-(JIT_AVX512_DW_GroupConvTestCases)));
+(JIT_AVX512_DW_GroupConvTestCases)), GroupConvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= JIT SSE42 1x1 Convolution (not supported with groups) ============= */
 /* ============= JIT AVX2 1x1 Convolution (not supported with groups) ============= */

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
@@ -579,15 +579,15 @@ const VecFusingParams fusingParamsSetReducedBF16 {
         fusingSum,
 };
 
-const VecPrcConnectedParams vecPrcConnectParamsFP32 = {{Precision::FP32, Precision::FP32, fusingParamsSetReducedFP32}};
-const VecPrcConnectedParams vecPrcConnectParams = {{Precision::FP32, Precision::FP32, fusingParamsSetReducedFP32},
-                                                   {Precision::BF16, Precision::BF16, fusingParamsSetReducedBF16},
-                                                   {Precision::BF16, Precision::FP32, fusingParamsSetReducedBF16}};
+const VecPrcConnectedParams vecPrcConnectParamsFP32 = {PrcConnectedParams{Precision::FP32, Precision::FP32, fusingParamsSetReducedFP32}};
+const VecPrcConnectedParams vecPrcConnectParams = {PrcConnectedParams{Precision::FP32, Precision::FP32, fusingParamsSetReducedFP32},
+                                                   PrcConnectedParams{Precision::BF16, Precision::BF16, fusingParamsSetReducedBF16},
+                                                   PrcConnectedParams{Precision::BF16, Precision::FP32, fusingParamsSetReducedBF16}};
 
-const VecPrcConnectedParams vecPrcConnectParamsFP32Default = {{Precision::FP32, Precision::FP32, VecFusingParams{emptyFusingSpec}}};
-const VecPrcConnectedParams vecPrcConnectParamsDefault = {{Precision::FP32, Precision::FP32, VecFusingParams{emptyFusingSpec}},
-                                                          {Precision::BF16, Precision::BF16, VecFusingParams{emptyFusingSpec}},
-                                                          {Precision::BF16, Precision::FP32, VecFusingParams{emptyFusingSpec}}};
+const VecPrcConnectedParams vecPrcConnectParamsFP32Default = {PrcConnectedParams{Precision::FP32, Precision::FP32, VecFusingParams{emptyFusingSpec}}};
+const VecPrcConnectedParams vecPrcConnectParamsDefault = {PrcConnectedParams{Precision::FP32, Precision::FP32, VecFusingParams{emptyFusingSpec}},
+                                                          PrcConnectedParams{Precision::BF16, Precision::BF16, VecFusingParams{emptyFusingSpec}},
+                                                          PrcConnectedParams{Precision::BF16, Precision::FP32, VecFusingParams{emptyFusingSpec}}};
 
 /* ============= GEMM GroupConvolution ============= */
 const std::vector<groupConvLayerCPUTestParamsSet> gemmGroupConvTestCases = generateSingleGroupConvCPUTestCases(

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
@@ -516,7 +516,8 @@ std::vector<groupConvLayerCPUTestParamsSet> makeSingleGroupConvCPUTestCases(Size
                                                                             std::vector<ptrdiff_t> padBegins, std::vector<ptrdiff_t> padEnds,
                                                                             ngraph::op::PadType padType, int groups, int mb, SizeVector spDims,
                                                                             int inGroupSize, int outGroupSize,
-                                                                            const std::vector<CPUSpecificParams>& CPUParams) {
+                                                                            const std::vector<CPUSpecificParams>& CPUParams,
+                                                                            const std::vector<fusingSpecificParams>& fusingParams) {
     int inChannels = groups * inGroupSize;
     int outChannels = groups * outGroupSize;
 
@@ -533,7 +534,9 @@ std::vector<groupConvLayerCPUTestParamsSet> makeSingleGroupConvCPUTestCases(Size
                                                InferenceEngine::Layout::ANY, inputShapes, CommonTestUtils::DEVICE_CPU);
     std::vector<groupConvLayerCPUTestParamsSet> retVector;
     for (auto& item : CPUParams) {
-        retVector.push_back(groupConvLayerCPUTestParamsSet(basicParamsSet, item, emptyFusingSpec));
+        for (auto& fusingParam : fusingParams) {
+            retVector.push_back(groupConvLayerCPUTestParamsSet(basicParamsSet, item, fusingParam));
+        }
     }
     return  retVector;
 }
@@ -556,6 +559,20 @@ std::vector<groupConvLayerCPUTestParamsSet> generateSingleGroupConvCPUTestCases(
     return retVec;
 }
 
+/* COMMON PARAMS */
+std::vector<fusingSpecificParams> fusingParamsSetReduced {
+        emptyFusingSpec,
+        // eltwise
+        fusingRelu,
+        // depthwise
+        fusingReluScaleShift,
+        // fake quantize
+        fusingFakeQuantizePerTensorRelu,
+        fusingFakeQuantizePerChannelRelu,
+        // sum
+        fusingSumEluFQ,
+        fusingSum,
+};
 
 /* ============= GEMM GroupConvolution ============= */
 const std::vector<groupConvLayerCPUTestParamsSet> gemmGroupConvTestCases = generateSingleGroupConvCPUTestCases(
@@ -564,21 +581,27 @@ const std::vector<groupConvLayerCPUTestParamsSet> gemmGroupConvTestCases = gener
         //  3. is_blocking_applicable (true, false)
 
         //  is_depthwise == false, im2col_sz > 0
-                makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 2, 2, CPUParams_Gemm_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        2, 1, {5, 5}, 2, 2, CPUParams_Gemm_2D, fusingParamsSetReduced),
         //  is_depthwise == true
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 1, 1, CPUParams_Gemm_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 1, 1,
+                                        CPUParams_Gemm_2D, fusingParamsSetReduced),
         //  im2col_sz == 0, is_blocking_applicable == true
-        makeSingleGroupConvCPUTestCases({1, 1}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 2, 2, CPUParams_Gemm_2D),
+        makeSingleGroupConvCPUTestCases({1, 1}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        2, 1, {5, 5}, 2, 2, CPUParams_Gemm_2D, fusingParamsSetReduced),
         //  is_blocking_applicable == false ((jcp.im2col_sz == 0) && (jcp.ic / jcp.oc >= 42))
-        makeSingleGroupConvCPUTestCases({1, 1}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 42, 1, CPUParams_Gemm_2D),
+        makeSingleGroupConvCPUTestCases({1, 1}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        2, 1, {5, 5}, 42, 1, CPUParams_Gemm_2D, fusingParamsSetReduced),
 
         //  "hard" cases
-        makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 3, 2, {129, 129}, 4, 2, CPUParams_Gemm_2D),
-        makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT, 2, 1, {10, 10}, 3, 3, CPUParams_Gemm_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT,
+                                        3, 2, {129, 129}, 4, 2, CPUParams_Gemm_2D, fusingParamsSetReduced),
+        makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT,
+                                        2, 1, {10, 10}, 3, 3, CPUParams_Gemm_2D, fusingParamsSetReduced),
         makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
-                                        3, 2, {33, 33, 33}, 4, 2, CPUParams_Gemm_3D),
+                                        3, 2, {33, 33, 33}, 4, 2, CPUParams_Gemm_3D, fusingParamsSetReduced),
         makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        2, 1, {10, 10, 10}, 3, 3, CPUParams_Gemm_3D)
+                                        2, 1, {10, 10, 10}, 3, 3, CPUParams_Gemm_3D, fusingParamsSetReduced)
 );
 
 INSTANTIATE_TEST_CASE_P(smoke_GEMM_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(gemmGroupConvTestCases)),
@@ -595,25 +618,35 @@ const std::vector<groupConvLayerCPUTestParamsSet> JIT_SSE42_GroupConvTestCases =
         //  6. ocb_work
 
         //  jcp.ur_w == 3, jcp.ur_w_tail == 2
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 10}, 8, 8, sse42_GroupConv),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        2, 1, {5, 10}, 8, 8, sse42_GroupConv, fusingParamsSetReduced),
         //  jcp.ur_w < 3 (jcp.ur_w == jcp.ow)
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 4}, 8, 8, sse42_GroupConv),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        2, 1, {5, 4}, 8, 8, sse42_GroupConv, fusingParamsSetReduced),
         //  jcp.ur_w == 3, jcp.ur_w_tail == 0
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 11}, 8, 8, sse42_GroupConv),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        2, 1, {5, 11}, 8, 8, sse42_GroupConv, fusingParamsSetReduced),
         //  jcp.kw > 7
-        makeSingleGroupConvCPUTestCases({3, 8}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 10}, 8, 8, sse42_GroupConv),
+        makeSingleGroupConvCPUTestCases({3, 8}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        2, 1, {5, 10}, 8, 8, sse42_GroupConv, fusingParamsSetReduced),
         //  jcp.nb_oc == 2
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 8, 16, sse42_GroupConv),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        2, 1, {5, 5}, 8, 16, sse42_GroupConv, fusingParamsSetReduced),
         //  jcp.nb_ic == 2
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 16, 8, sse42_GroupConv),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        2, 1, {5, 5}, 16, 8, sse42_GroupConv, fusingParamsSetReduced),
         //  ocb_work > 1 (ocb_work == 2)
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 8, 40, sse42_GroupConv),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        2, 1, {5, 5}, 8, 40, sse42_GroupConv, fusingParamsSetReduced),
         //  jcp.nb_ic == 2, ocb_work == 2
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 16, 40, sse42_GroupConv),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        2, 1, {5, 5}, 16, 40, sse42_GroupConv, fusingParamsSetReduced),
 
         //  "hard" cases
-        makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 3, 2, {129, 129}, 8, 8, sse42_GroupConv),
-        makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT, 2, 1, {10, 10}, 8, 8, sse42_GroupConv)
+        makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT,
+                                        3, 2, {129, 129}, 8, 8, sse42_GroupConv, fusingParamsSetReduced),
+        makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT,
+                                        2, 1, {10, 10}, 8, 8, sse42_GroupConv, fusingParamsSetReduced)
 
         //  not supported jit_sse42 for 3d
         //  makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
@@ -637,29 +670,39 @@ const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX2_GroupConvTestCases = 
         //  6. ocb_work
 
         //  jcp.ur_w == 3, jcp.ur_w_tail == 2
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 10}, 8, 8, avx2_GroupConv_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        2, 1, {5, 10}, 8, 8, avx2_GroupConv_2D, fusingParamsSetReduced),
         //  jcp.ur_w < 3 (jcp.ur_w == jcp.ow)
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 4}, 8, 8, avx2_GroupConv_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        2, 1, {5, 4}, 8, 8, avx2_GroupConv_2D, fusingParamsSetReduced),
         //  jcp.ur_w == 3, jcp.ur_w_tail == 0
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 11}, 8, 8, avx2_GroupConv_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        2, 1, {5, 11}, 8, 8, avx2_GroupConv_2D, fusingParamsSetReduced),
         //  jcp.kw > 7
-        makeSingleGroupConvCPUTestCases({3, 8}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 10}, 8, 8, avx2_GroupConv_2D),
+        makeSingleGroupConvCPUTestCases({3, 8}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        2, 1, {5, 10}, 8, 8, avx2_GroupConv_2D, fusingParamsSetReduced),
         //  jcp.nb_oc == 2
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 8, 16, avx2_GroupConv_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        2, 1, {5, 5}, 8, 16, avx2_GroupConv_2D, fusingParamsSetReduced),
         //  jcp.nb_ic == 2
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 16, 8, avx2_GroupConv_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        2, 1, {5, 5}, 16, 8, avx2_GroupConv_2D, fusingParamsSetReduced),
         //  ocb_work > 1 (ocb_work == 2)
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 8, 40, avx2_GroupConv_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        2, 1, {5, 5}, 8, 40, avx2_GroupConv_2D, fusingParamsSetReduced),
         //  jcp.nb_ic == 2, ocb_work == 2
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 16, 40, avx2_GroupConv_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        2, 1, {5, 5}, 16, 40, avx2_GroupConv_2D, fusingParamsSetReduced),
 
         //  "hard" cases
-        makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 3, 2, {129, 129}, 8, 8, avx2_GroupConv_2D),
-        makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT, 2, 1, {10, 10}, 8, 8, avx2_GroupConv_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT,
+                                        3, 2, {129, 129}, 8, 8, avx2_GroupConv_2D, fusingParamsSetReduced),
+        makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT,
+                                        2, 1, {10, 10}, 8, 8, avx2_GroupConv_2D, fusingParamsSetReduced),
         makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
-                                        3, 2, {33, 33, 33}, 8, 8, avx2_GroupConv_3D),
+                                        3, 2, {33, 33, 33}, 8, 8, avx2_GroupConv_3D, fusingParamsSetReduced),
         makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        2, 1, {10, 10, 10}, 8, 8, avx2_GroupConv_3D)
+                                        2, 1, {10, 10, 10}, 8, 8, avx2_GroupConv_3D, fusingParamsSetReduced)
 );
 
 INSTANTIATE_TEST_CASE_P(smoke_JIT_AVX2_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(JIT_AVX2_GroupConvTestCases)),
@@ -673,20 +716,24 @@ const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX512_GroupConvTestCases 
         //  2. jcp.nb_ic, jcp.nb_oc
 
         //  blocked to blocked
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 16, 16, avx512_GroupConv_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        2, 1, {5, 5}, 16, 16, avx512_GroupConv_2D, fusingParamsSetReduced),
         //  jcp.nb_ic == 2
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 32, 16, avx512_GroupConv_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        2, 1, {5, 5}, 32, 16, avx512_GroupConv_2D, fusingParamsSetReduced),
         //  jcp.nb_oc == 2
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 16, 32, avx512_GroupConv_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        2, 1, {5, 5}, 16, 32, avx512_GroupConv_2D, fusingParamsSetReduced),
 
         //  "hard" cases
         makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 3, 2, {129, 129}, 16, 16,
-                                        avx512_GroupConv_2D),
-        makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT, 2, 1, {10, 10}, 16, 16, avx512_GroupConv_2D),
+                                        avx512_GroupConv_2D, fusingParamsSetReduced),
+        makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT,
+                                        2, 1, {10, 10}, 16, 16, avx512_GroupConv_2D, fusingParamsSetReduced),
         makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
-                                        3, 2, {33, 33, 33}, 16, 16, avx512_GroupConv_3D),
+                                        3, 2, {33, 33, 33}, 16, 16, avx512_GroupConv_3D, fusingParamsSetReduced),
         makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        2, 1, {10, 10, 10}, 16, 16, avx512_GroupConv_3D)
+                                        2, 1, {10, 10, 10}, 16, 16, avx512_GroupConv_3D, fusingParamsSetReduced)
 );
 
 INSTANTIATE_TEST_CASE_P(smoke_JIT_AVX512_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(JIT_AVX512_GroupConvTestCases)),
@@ -702,22 +749,27 @@ const std::vector<groupConvLayerCPUTestParamsSet> JIT_SSE42_DW_GroupConvTestCase
         //  4. jcp.ur_w == 3
 
         //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 1, jcp.nb_ch_blocking == 1 (jcp.ngroups == 8)
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 8, 1, {5, 5}, 1, 1, sse42_DW_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        8, 1, {5, 5}, 1, 1, sse42_DW_2D, fusingParamsSetReduced),
         //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 2, jcp.nb_ch_blocking == 2 (jcp.ngroups == 16)
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 16, 1, {5, 5}, 1, 1, sse42_DW_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        16, 1, {5, 5}, 1, 1, sse42_DW_2D, fusingParamsSetReduced),
         //  jcp.ngroups % simd_w != 0, jcp.nb_ch == 3, jcp.nb_ch_blocking == 2 (jcp.ngroups == 17) TODO: pad channels not supported for SSE42
-        //  makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 17, 1, {5, 5}, 1, 1, conv_sse42_dw_2D),
+        //  makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+        //  17, 1, {5, 5}, 1, 1, conv_sse42_DW_2D, fusingParamsSetReduced),
         //  jcp.ow > jcp.ur_w (jcp.ow == 7)
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 8, 1, {5, 9}, 1, 1, sse42_DW_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        8, 1, {5, 9}, 1, 1, sse42_DW_2D, fusingParamsSetReduced),
 
         //  "hard" cases
         makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 8, 2, {129, 129}, 1, 1,
-                                        sse42_DW_2D),
-        makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT, 8, 1, {10, 10}, 1, 1, sse42_DW_2D),
+                                        sse42_DW_2D, fusingParamsSetReduced),
+        makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT,
+                                        8, 1, {10, 10}, 1, 1, sse42_DW_2D, fusingParamsSetReduced),
         makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
-                                        8, 2, {33, 33, 33}, 1, 1, sse42_DW_3D),
+                                        8, 2, {33, 33, 33}, 1, 1, sse42_DW_3D, fusingParamsSetReduced),
         makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        8, 1, {10, 10, 10}, 1, 1, sse42_DW_3D)
+                                        8, 1, {10, 10, 10}, 1, 1, sse42_DW_3D, fusingParamsSetReduced)
 );
 
 INSTANTIATE_TEST_CASE_P(smoke_JIT_SSE42_DW_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice
@@ -733,23 +785,27 @@ const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX2_DW_GroupConvTestCases
         //  4. jcp.ur_w == 4
 
         //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 1, jcp.nb_ch_blocking == 1 (jcp.ngroups == 8)
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 8, 1, {5, 5}, 1, 1, avx2_DW_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        8, 1, {5, 5}, 1, 1, avx2_DW_2D, fusingParamsSetReduced),
         //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 3, jcp.nb_ch_blocking == 3 (jcp.ngroups == 24)
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 24, 1, {5, 5}, 1, 1, avx2_DW_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        24, 1, {5, 5}, 1, 1, avx2_DW_2D, fusingParamsSetReduced),
         //  jcp.ngroups % simd_w != 0, jcp.nb_ch == 4, jcp.nb_ch_blocking == 3 (jcp.ngroups == 25)
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        25, 1, {5, 5}, 1, 1, /*avx2_DW_2D*/ {conv_avx2_dw_2D}), // todo [mkutakov] : add tail c support ot the nspc dw conv
+                                        25, 1, {5, 5}, 1, 1, avx2_DW_2D, fusingParamsSetReduced),
         //  jcp.ow > jcp.ur_w (jcp.ow == 7)
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 8, 1, {5, 9}, 1, 1, avx2_DW_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        8, 1, {5, 9}, 1, 1, avx2_DW_2D, fusingParamsSetReduced),
 
         //  "hard" cases
         makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 8, 2, {129, 129}, 1, 1,
-                                        avx2_DW_2D),
-        makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT, 8, 1, {10, 10}, 1, 1, avx2_DW_2D),
+                                        avx2_DW_2D, fusingParamsSetReduced),
+        makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT,
+                                        8, 1, {10, 10}, 1, 1, avx2_DW_2D, fusingParamsSetReduced),
         makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
-                                        8, 2, {33, 33, 33}, 1, 1, avx2_DW_3D),
+                                        8, 2, {33, 33, 33}, 1, 1, avx2_DW_3D, fusingParamsSetReduced),
         makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        8, 1, {10, 10, 10}, 1, 1, avx2_DW_3D)
+                                        8, 1, {10, 10, 10}, 1, 1, avx2_DW_3D, fusingParamsSetReduced)
 );
 
 INSTANTIATE_TEST_CASE_P(smoke_JIT_AVX2_DW_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice
@@ -765,25 +821,26 @@ const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX512_DW_GroupConvTestCas
         //  4. jcp.ur_w == 6
 
         //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 1, jcp.nb_ch_blocking == 1 (jcp.ngroups == 16)
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 16, 1, {5, 5}, 1, 1, avx512_DW_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        16, 1, {5, 5}, 1, 1, avx512_DW_2D, fusingParamsSetReduced),
         //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 4, jcp.nb_ch_blocking == 4 (jcp.ngroups == 64)
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 64, 1, {5, 5}, 1, 1, avx512_DW_2D),
+        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
+                                        64, 1, {5, 5}, 1, 1, avx512_DW_2D, fusingParamsSetReduced),
         //  jcp.ngroups % simd_w != 0, jcp.nb_ch == 5, jcp.nb_ch_blocking == 4 (jcp.ngroups == 65)
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        65, 1, {5, 5}, 1, 1, /*avx512_DW_2D*/{conv_avx512_dw_2D}), // todo [mkutakov] : add tail c support ot the nspc dw conv
+                                        65, 1, {5, 5}, 1, 1, avx512_DW_2D, fusingParamsSetReduced),
         //  jcp.ow > jcp.ur_w (jcp.ow == 7)
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        8, 1, {5, 9}, 1, 1, /*avx512_DW_2D*/{conv_avx512_dw_2D}), // todo [mkutakov] : add tail c support ot the nspc dw conv
-
+                                        8, 1, {5, 9}, 1, 1, avx512_DW_2D, fusingParamsSetReduced),
         //  "hard" cases
         makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 16, 2, {129, 129}, 1, 1,
-                                        avx512_DW_2D),
+                                        avx512_DW_2D, fusingParamsSetReduced),
         makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT, 16, 1, {10, 10}, 1, 1,
-                                        avx512_DW_2D),
+                                        avx512_DW_2D, fusingParamsSetReduced),
         makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
-                                        16, 2, {33, 33, 33}, 1, 1, avx512_DW_3D),
+                                        16, 2, {33, 33, 33}, 1, 1, avx512_DW_3D, fusingParamsSetReduced),
         makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        16, 1, {10, 10, 10}, 1, 1, avx512_DW_3D)
+                                        16, 1, {10, 10, 10}, 1, 1, avx512_DW_3D, fusingParamsSetReduced)
 );
 
 INSTANTIATE_TEST_CASE_P(smoke_JIT_AVX512_DW_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
@@ -148,36 +148,26 @@ std::vector<groupConvLayerCPUTestParamsSet> filterParamsSetForDevice(std::vector
 /* COMMON PARAMS */
 const std::vector<fusingSpecificParams> fusingParamsSet {
         emptyFusingSpec,
-        // activations
+        // eltwise
         fusingRelu,
-        fusingElu,
-        fusingSigmoid,
-        fusingClamp,
-        fusingPReluPerChannel,
-        fusingSwish,
-        fusingHSwish,
-        fusingMish,
-        fusingSoftPlus,
-        // other patterns
+        fusingPRelu1D,
+        // depthwise
         fusingReluScaleShift,
+        // fake quantize
         fusingFakeQuantizePerTensorRelu,
         fusingFakeQuantizePerChannelRelu,
+        // sum
         fusingSumEluFQ,
-        fusingSum,
-        fusingPRelu1D
+        fusingSum
 };
 
 const std::vector<fusingSpecificParams> fusingParamsSetBF16{
         emptyFusingSpec,
-        // activations
+        // eltwise
         fusingRelu,
-        fusingElu,
-        fusingSigmoid,
-        fusingClamp,
-        fusingPReluPerChannel,
-        fusingSwish,
-        // other patterns
+        // depthwise
         fusingReluScaleShift,
+        // sum
         fusingSum
 };
 
@@ -555,34 +545,11 @@ std::vector<groupConvLayerCPUTestParamsSet> generateSingleGroupConvCPUTestCases(
 }
 
 /* COMMON PARAMS */
-const VecFusingParams fusingParamsSetReducedFP32 {
-        emptyFusingSpec,
-        // eltwise
-        fusingRelu,
-        // depthwise
-        fusingReluScaleShift,
-        // fake quantize
-        fusingFakeQuantizePerTensorRelu,
-        fusingFakeQuantizePerChannelRelu,
-        // sum
-        fusingSumEluFQ,
-        fusingSum,
-};
 
-const VecFusingParams fusingParamsSetReducedBF16 {
-        emptyFusingSpec,
-        // eltwise
-        fusingRelu,
-        // depthwise
-        fusingReluScaleShift,
-        // sum
-        fusingSum,
-};
-
-const VecPrcConnectedParams vecPrcConnectParamsFP32 = {PrcConnectedParams{Precision::FP32, Precision::FP32, fusingParamsSetReducedFP32}};
-const VecPrcConnectedParams vecPrcConnectParams = {PrcConnectedParams{Precision::FP32, Precision::FP32, fusingParamsSetReducedFP32},
-                                                   PrcConnectedParams{Precision::BF16, Precision::BF16, fusingParamsSetReducedBF16},
-                                                   PrcConnectedParams{Precision::BF16, Precision::FP32, fusingParamsSetReducedBF16}};
+const VecPrcConnectedParams vecPrcConnectParamsFP32 = {PrcConnectedParams{Precision::FP32, Precision::FP32, fusingParamsSet}};
+const VecPrcConnectedParams vecPrcConnectParams = {PrcConnectedParams{Precision::FP32, Precision::FP32, fusingParamsSet},
+                                                   PrcConnectedParams{Precision::BF16, Precision::BF16, fusingParamsSetBF16},
+                                                   PrcConnectedParams{Precision::BF16, Precision::FP32, fusingParamsSetBF16}};
 
 const VecPrcConnectedParams vecPrcConnectParamsFP32Default = {PrcConnectedParams{Precision::FP32, Precision::FP32, VecFusingParams{emptyFusingSpec}}};
 const VecPrcConnectedParams vecPrcConnectParamsDefault = {PrcConnectedParams{Precision::FP32, Precision::FP32, VecFusingParams{emptyFusingSpec}},

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
@@ -4,6 +4,7 @@
 
 #include <shared_test_classes/single_layer/group_convolution.hpp>
 #include "test_utils/cpu_test_utils.hpp"
+#include "test_utils/convolution_params.hpp"
 #include "test_utils/fusing_test_utils.hpp"
 
 using namespace InferenceEngine;

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
@@ -254,7 +254,7 @@ INSTANTIATE_TEST_CASE_P(smoke_GroupConv_2D_Gemm_BF16, GroupConvolutionLayerCPUTe
                                         ::testing::Values(InferenceEngine::Layout::ANY),
                                         ::testing::Values(std::vector<size_t >({2, 12, 7, 7})),
                                         ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Gemm_2D)),
+                                ::testing::Values(conv_gemm_2D_nspc), //todo [mkutakov]: gemm bf16 group conv ncsp failure
                                 ::testing::ValuesIn(fusingParamsSetBF16)),
                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
@@ -301,7 +301,7 @@ INSTANTIATE_TEST_CASE_P(smoke_GroupConv_3D_Gemm_BF16, GroupConvolutionLayerCPUTe
                                         ::testing::Values(InferenceEngine::Layout::ANY),
                                         ::testing::Values(std::vector<size_t >({2, 12, 7, 7, 7})),
                                         ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Gemm_3D)),
+                                ::testing::Values(conv_gemm_3D_nspc), //todo [mkutakov]: gemm bf16 group conv ncsp failure
                                 ::testing::ValuesIn(fusingParamsSetBF16)),
                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
@@ -595,28 +595,30 @@ const std::vector<groupConvLayerCPUTestParamsSet> gemmGroupConvTestCases = gener
         //  2. jcp.im2col_sz (=0,>0)
         //  3. is_blocking_applicable (true, false)
 
+        // todo [mkutakov]: gemm bf16 convolution failures for ncsp layout
+
         //  is_depthwise == false, im2col_sz > 0
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 5}, 2, 2, CPUParams_Gemm_2D, vecPrcConnectParams),
+                                        2, 1, {5, 5}, 2, 2, { conv_gemm_2D_nspc }, vecPrcConnectParams),
         //  is_depthwise == true
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 1, 1,
-                                        CPUParams_Gemm_2D, vecPrcConnectParams),
+                                        { conv_gemm_2D_nspc }, vecPrcConnectParams),
         //  im2col_sz == 0, is_blocking_applicable == true
         makeSingleGroupConvCPUTestCases({1, 1}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 5}, 2, 2, CPUParams_Gemm_2D, vecPrcConnectParams),
+                                        2, 1, {5, 5}, 2, 2, { conv_gemm_2D_nspc }, vecPrcConnectParams),
         //  is_blocking_applicable == false ((jcp.im2col_sz == 0) && (jcp.ic / jcp.oc >= 42))
         makeSingleGroupConvCPUTestCases({1, 1}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 5}, 42, 1, CPUParams_Gemm_2D, vecPrcConnectParams),
+                                        2, 1, {5, 5}, 42, 1, { conv_gemm_2D_nspc }, vecPrcConnectParams),
 
         //  "hard" cases
         makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT,
-                                        3, 2, {129, 129}, 4, 2, CPUParams_Gemm_2D, vecPrcConnectParamsDefault),
+                                        3, 2, {129, 129}, 4, 2, { conv_gemm_2D_nspc }, vecPrcConnectParamsDefault),
         makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        2, 1, {10, 10}, 3, 3, CPUParams_Gemm_2D, vecPrcConnectParamsDefault),
+                                        2, 1, {10, 10}, 3, 3, { conv_gemm_2D_nspc }, vecPrcConnectParamsDefault),
         makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
-                                        3, 2, {33, 33, 33}, 4, 2, CPUParams_Gemm_3D, vecPrcConnectParamsDefault),
+                                        3, 2, {33, 33, 33}, 4, 2, { conv_gemm_3D_nspc }, vecPrcConnectParamsDefault),
         makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        2, 1, {10, 10, 10}, 3, 3, CPUParams_Gemm_3D, vecPrcConnectParamsDefault)
+                                        2, 1, {10, 10, 10}, 3, 3, { conv_gemm_3D_nspc }, vecPrcConnectParams)
 );
 
 INSTANTIATE_TEST_CASE_P(smoke_GEMM_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(gemmGroupConvTestCases)),
@@ -717,7 +719,7 @@ const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX2_GroupConvTestCases = 
         makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
                                         3, 2, {33, 33, 33}, 8, 8, avx2_GroupConv_3D, vecPrcConnectParamsFP32Default),
         makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        2, 1, {10, 10, 10}, 8, 8, avx2_GroupConv_3D, vecPrcConnectParamsFP32Default)
+                                        2, 1, {10, 10, 10}, 8, 8, avx2_GroupConv_3D, vecPrcConnectParamsFP32)
 );
 
 INSTANTIATE_TEST_CASE_P(smoke_JIT_AVX2_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(JIT_AVX2_GroupConvTestCases)),
@@ -748,7 +750,7 @@ const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX512_GroupConvTestCases 
         makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
                                         3, 2, {33, 33, 33}, 16, 16, avx512_GroupConv_3D, vecPrcConnectParamsDefault),
         makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        2, 1, {10, 10, 10}, 16, 16, avx512_GroupConv_3D, vecPrcConnectParamsDefault)
+                                        2, 1, {10, 10, 10}, 16, 16, avx512_GroupConv_3D, vecPrcConnectParams)
 );
 
 INSTANTIATE_TEST_CASE_P(smoke_JIT_AVX512_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(JIT_AVX512_GroupConvTestCases)),
@@ -784,7 +786,7 @@ const std::vector<groupConvLayerCPUTestParamsSet> JIT_SSE42_DW_GroupConvTestCase
         makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
                                         8, 2, {33, 33, 33}, 1, 1, sse42_DW_3D, vecPrcConnectParamsFP32Default),
         makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        8, 1, {10, 10, 10}, 1, 1, sse42_DW_3D, vecPrcConnectParamsFP32Default)
+                                        8, 1, {10, 10, 10}, 1, 1, sse42_DW_3D, vecPrcConnectParamsFP32)
 );
 
 INSTANTIATE_TEST_CASE_P(smoke_JIT_SSE42_DW_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice
@@ -814,13 +816,13 @@ const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX2_DW_GroupConvTestCases
 
         //  "hard" cases
         makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 8, 2, {129, 129}, 1, 1,
-                                        avx2_DW_2D, vecPrcConnectParamsFP32),
+                                        avx2_DW_2D, vecPrcConnectParamsFP32Default),
         makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT,
                                         8, 1, {10, 10}, 1, 1, avx2_DW_2D, vecPrcConnectParamsFP32Default),
         makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
                                         8, 2, {33, 33, 33}, 1, 1, avx2_DW_3D, vecPrcConnectParamsFP32Default),
         makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        8, 1, {10, 10, 10}, 1, 1, avx2_DW_3D, vecPrcConnectParamsFP32Default)
+                                        8, 1, {10, 10, 10}, 1, 1, avx2_DW_3D, vecPrcConnectParamsFP32)
 );
 
 INSTANTIATE_TEST_CASE_P(smoke_JIT_AVX2_DW_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice
@@ -856,7 +858,7 @@ const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX512_DW_GroupConvTestCas
         makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
                                         16, 2, {33, 33, 33}, 1, 1, avx512_DW_3D, vecPrcConnectParamsFP32Default),
         makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        16, 1, {10, 10, 10}, 1, 1, avx512_DW_3D, vecPrcConnectParamsFP32Default)
+                                        16, 1, {10, 10, 10}, 1, 1, avx512_DW_3D, vecPrcConnectParamsFP32)
 );
 
 INSTANTIATE_TEST_CASE_P(smoke_JIT_AVX512_DW_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
@@ -579,10 +579,15 @@ const VecFusingParams fusingParamsSetReducedBF16 {
         fusingSum,
 };
 
-const VecPrcConnectedParams vecPrcConnectParamsFP32only = {{Precision::FP32, Precision::FP32, fusingParamsSetReducedFP32}};
+const VecPrcConnectedParams vecPrcConnectParamsFP32 = {{Precision::FP32, Precision::FP32, fusingParamsSetReducedFP32}};
 const VecPrcConnectedParams vecPrcConnectParams = {{Precision::FP32, Precision::FP32, fusingParamsSetReducedFP32},
                                                    {Precision::BF16, Precision::BF16, fusingParamsSetReducedBF16},
                                                    {Precision::BF16, Precision::FP32, fusingParamsSetReducedBF16}};
+
+const VecPrcConnectedParams vecPrcConnectParamsFP32Default = {{Precision::FP32, Precision::FP32, VecFusingParams{emptyFusingSpec}}};
+const VecPrcConnectedParams vecPrcConnectParamsDefault = {{Precision::FP32, Precision::FP32, VecFusingParams{emptyFusingSpec}},
+                                                          {Precision::BF16, Precision::BF16, VecFusingParams{emptyFusingSpec}},
+                                                          {Precision::BF16, Precision::FP32, VecFusingParams{emptyFusingSpec}}};
 
 /* ============= GEMM GroupConvolution ============= */
 const std::vector<groupConvLayerCPUTestParamsSet> gemmGroupConvTestCases = generateSingleGroupConvCPUTestCases(
@@ -605,13 +610,13 @@ const std::vector<groupConvLayerCPUTestParamsSet> gemmGroupConvTestCases = gener
 
         //  "hard" cases
         makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT,
-                                        3, 2, {129, 129}, 4, 2, CPUParams_Gemm_2D, vecPrcConnectParams),
+                                        3, 2, {129, 129}, 4, 2, CPUParams_Gemm_2D, vecPrcConnectParamsDefault),
         makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        2, 1, {10, 10}, 3, 3, CPUParams_Gemm_2D, vecPrcConnectParams),
+                                        2, 1, {10, 10}, 3, 3, CPUParams_Gemm_2D, vecPrcConnectParamsDefault),
         makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
-                                        3, 2, {33, 33, 33}, 4, 2, CPUParams_Gemm_3D, vecPrcConnectParams),
+                                        3, 2, {33, 33, 33}, 4, 2, CPUParams_Gemm_3D, vecPrcConnectParamsDefault),
         makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        2, 1, {10, 10, 10}, 3, 3, CPUParams_Gemm_3D, vecPrcConnectParams)
+                                        2, 1, {10, 10, 10}, 3, 3, CPUParams_Gemm_3D, vecPrcConnectParamsDefault)
 );
 
 INSTANTIATE_TEST_CASE_P(smoke_GEMM_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(gemmGroupConvTestCases)),
@@ -629,34 +634,34 @@ const std::vector<groupConvLayerCPUTestParamsSet> JIT_SSE42_GroupConvTestCases =
 
         //  jcp.ur_w == 3, jcp.ur_w_tail == 2
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 10}, 8, 8, sse42_GroupConv, vecPrcConnectParamsFP32only),
+                                        2, 1, {5, 10}, 8, 8, sse42_GroupConv, vecPrcConnectParamsFP32),
         //  jcp.ur_w < 3 (jcp.ur_w == jcp.ow)
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 4}, 8, 8, sse42_GroupConv, vecPrcConnectParamsFP32only),
+                                        2, 1, {5, 4}, 8, 8, sse42_GroupConv, vecPrcConnectParamsFP32),
         //  jcp.ur_w == 3, jcp.ur_w_tail == 0
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 11}, 8, 8, sse42_GroupConv, vecPrcConnectParamsFP32only),
+                                        2, 1, {5, 11}, 8, 8, sse42_GroupConv, vecPrcConnectParamsFP32),
         //  jcp.kw > 7
         makeSingleGroupConvCPUTestCases({3, 8}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 10}, 8, 8, sse42_GroupConv, vecPrcConnectParamsFP32only),
+                                        2, 1, {5, 10}, 8, 8, sse42_GroupConv, vecPrcConnectParamsFP32),
         //  jcp.nb_oc == 2
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 5}, 8, 16, sse42_GroupConv, vecPrcConnectParamsFP32only),
+                                        2, 1, {5, 5}, 8, 16, sse42_GroupConv, vecPrcConnectParamsFP32),
         //  jcp.nb_ic == 2
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 5}, 16, 8, sse42_GroupConv, vecPrcConnectParamsFP32only),
+                                        2, 1, {5, 5}, 16, 8, sse42_GroupConv, vecPrcConnectParamsFP32),
         //  ocb_work > 1 (ocb_work == 2)
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 5}, 8, 40, sse42_GroupConv, vecPrcConnectParamsFP32only),
+                                        2, 1, {5, 5}, 8, 40, sse42_GroupConv, vecPrcConnectParamsFP32),
         //  jcp.nb_ic == 2, ocb_work == 2
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 5}, 16, 40, sse42_GroupConv, vecPrcConnectParamsFP32only),
+                                        2, 1, {5, 5}, 16, 40, sse42_GroupConv, vecPrcConnectParamsFP32),
 
         //  "hard" cases
         makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT,
-                                        3, 2, {129, 129}, 8, 8, sse42_GroupConv, vecPrcConnectParamsFP32only),
+                                        3, 2, {129, 129}, 8, 8, sse42_GroupConv, vecPrcConnectParamsFP32Default),
         makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        2, 1, {10, 10}, 8, 8, sse42_GroupConv, vecPrcConnectParamsFP32only)
+                                        2, 1, {10, 10}, 8, 8, sse42_GroupConv, vecPrcConnectParamsFP32Default)
 
         //  not supported jit_sse42 for 3d
         //  makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
@@ -681,38 +686,38 @@ const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX2_GroupConvTestCases = 
 
         //  jcp.ur_w == 3, jcp.ur_w_tail == 2
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 10}, 8, 8, avx2_GroupConv_2D, vecPrcConnectParamsFP32only),
+                                        2, 1, {5, 10}, 8, 8, avx2_GroupConv_2D, vecPrcConnectParamsFP32),
         //  jcp.ur_w < 3 (jcp.ur_w == jcp.ow)
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 4}, 8, 8, avx2_GroupConv_2D, vecPrcConnectParamsFP32only),
+                                        2, 1, {5, 4}, 8, 8, avx2_GroupConv_2D, vecPrcConnectParamsFP32),
         //  jcp.ur_w == 3, jcp.ur_w_tail == 0
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 11}, 8, 8, avx2_GroupConv_2D, vecPrcConnectParamsFP32only),
+                                        2, 1, {5, 11}, 8, 8, avx2_GroupConv_2D, vecPrcConnectParamsFP32),
         //  jcp.kw > 7
         makeSingleGroupConvCPUTestCases({3, 8}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 10}, 8, 8, avx2_GroupConv_2D, vecPrcConnectParamsFP32only),
+                                        2, 1, {5, 10}, 8, 8, avx2_GroupConv_2D, vecPrcConnectParamsFP32),
         //  jcp.nb_oc == 2
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 5}, 8, 16, avx2_GroupConv_2D, vecPrcConnectParamsFP32only),
+                                        2, 1, {5, 5}, 8, 16, avx2_GroupConv_2D, vecPrcConnectParamsFP32),
         //  jcp.nb_ic == 2
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 5}, 16, 8, avx2_GroupConv_2D, vecPrcConnectParamsFP32only),
+                                        2, 1, {5, 5}, 16, 8, avx2_GroupConv_2D, vecPrcConnectParamsFP32),
         //  ocb_work > 1 (ocb_work == 2)
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 5}, 8, 40, avx2_GroupConv_2D, vecPrcConnectParamsFP32only),
+                                        2, 1, {5, 5}, 8, 40, avx2_GroupConv_2D, vecPrcConnectParamsFP32),
         //  jcp.nb_ic == 2, ocb_work == 2
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 5}, 16, 40, avx2_GroupConv_2D, vecPrcConnectParamsFP32only),
+                                        2, 1, {5, 5}, 16, 40, avx2_GroupConv_2D, vecPrcConnectParamsFP32),
 
         //  "hard" cases
         makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT,
-                                        3, 2, {129, 129}, 8, 8, avx2_GroupConv_2D, vecPrcConnectParamsFP32only),
+                                        3, 2, {129, 129}, 8, 8, avx2_GroupConv_2D, vecPrcConnectParamsFP32Default),
         makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        2, 1, {10, 10}, 8, 8, avx2_GroupConv_2D, vecPrcConnectParamsFP32only),
+                                        2, 1, {10, 10}, 8, 8, avx2_GroupConv_2D, vecPrcConnectParamsFP32Default),
         makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
-                                        3, 2, {33, 33, 33}, 8, 8, avx2_GroupConv_3D, vecPrcConnectParamsFP32only),
+                                        3, 2, {33, 33, 33}, 8, 8, avx2_GroupConv_3D, vecPrcConnectParamsFP32Default),
         makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        2, 1, {10, 10, 10}, 8, 8, avx2_GroupConv_3D, vecPrcConnectParamsFP32only)
+                                        2, 1, {10, 10, 10}, 8, 8, avx2_GroupConv_3D, vecPrcConnectParamsFP32Default)
 );
 
 INSTANTIATE_TEST_CASE_P(smoke_JIT_AVX2_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(JIT_AVX2_GroupConvTestCases)),
@@ -739,11 +744,11 @@ const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX512_GroupConvTestCases 
         makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 3, 2, {129, 129}, 16, 16,
                                         avx512_GroupConv_2D, vecPrcConnectParams),
         makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        2, 1, {10, 10}, 16, 16, avx512_GroupConv_2D, vecPrcConnectParams),
+                                        2, 1, {10, 10}, 16, 16, avx512_GroupConv_2D, vecPrcConnectParamsDefault),
         makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
-                                        3, 2, {33, 33, 33}, 16, 16, avx512_GroupConv_3D, vecPrcConnectParams),
+                                        3, 2, {33, 33, 33}, 16, 16, avx512_GroupConv_3D, vecPrcConnectParamsDefault),
         makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        2, 1, {10, 10, 10}, 16, 16, avx512_GroupConv_3D, vecPrcConnectParams)
+                                        2, 1, {10, 10, 10}, 16, 16, avx512_GroupConv_3D, vecPrcConnectParamsDefault)
 );
 
 INSTANTIATE_TEST_CASE_P(smoke_JIT_AVX512_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(JIT_AVX512_GroupConvTestCases)),
@@ -760,26 +765,26 @@ const std::vector<groupConvLayerCPUTestParamsSet> JIT_SSE42_DW_GroupConvTestCase
 
         //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 1, jcp.nb_ch_blocking == 1 (jcp.ngroups == 8)
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        8, 1, {5, 5}, 1, 1, sse42_DW_2D, vecPrcConnectParamsFP32only),
+                                        8, 1, {5, 5}, 1, 1, sse42_DW_2D, vecPrcConnectParamsFP32),
         //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 2, jcp.nb_ch_blocking == 2 (jcp.ngroups == 16)
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        16, 1, {5, 5}, 1, 1, sse42_DW_2D, vecPrcConnectParamsFP32only),
+                                        16, 1, {5, 5}, 1, 1, sse42_DW_2D, vecPrcConnectParamsFP32),
         //  jcp.ngroups % simd_w != 0, jcp.nb_ch == 3, jcp.nb_ch_blocking == 2 (jcp.ngroups == 17) TODO: pad channels not supported for SSE42
         //  makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
         //  17, 1, {5, 5}, 1, 1, conv_sse42_DW_2D, vecPrcConnectParamsFP32only),
         //  jcp.ow > jcp.ur_w (jcp.ow == 7)
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        8, 1, {5, 9}, 1, 1, sse42_DW_2D, vecPrcConnectParamsFP32only),
+                                        8, 1, {5, 9}, 1, 1, sse42_DW_2D, vecPrcConnectParamsFP32),
 
         //  "hard" cases
         makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 8, 2, {129, 129}, 1, 1,
-                                        sse42_DW_2D, vecPrcConnectParamsFP32only),
+                                        sse42_DW_2D, vecPrcConnectParamsFP32),
         makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        8, 1, {10, 10}, 1, 1, sse42_DW_2D, vecPrcConnectParamsFP32only),
+                                        8, 1, {10, 10}, 1, 1, sse42_DW_2D, vecPrcConnectParamsFP32Default),
         makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
-                                        8, 2, {33, 33, 33}, 1, 1, sse42_DW_3D, vecPrcConnectParamsFP32only),
+                                        8, 2, {33, 33, 33}, 1, 1, sse42_DW_3D, vecPrcConnectParamsFP32Default),
         makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        8, 1, {10, 10, 10}, 1, 1, sse42_DW_3D, vecPrcConnectParamsFP32only)
+                                        8, 1, {10, 10, 10}, 1, 1, sse42_DW_3D, vecPrcConnectParamsFP32Default)
 );
 
 INSTANTIATE_TEST_CASE_P(smoke_JIT_SSE42_DW_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice
@@ -796,26 +801,26 @@ const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX2_DW_GroupConvTestCases
 
         //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 1, jcp.nb_ch_blocking == 1 (jcp.ngroups == 8)
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        8, 1, {5, 5}, 1, 1, avx2_DW_2D, vecPrcConnectParamsFP32only),
+                                        8, 1, {5, 5}, 1, 1, avx2_DW_2D, vecPrcConnectParamsFP32),
         //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 3, jcp.nb_ch_blocking == 3 (jcp.ngroups == 24)
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        24, 1, {5, 5}, 1, 1, avx2_DW_2D, vecPrcConnectParamsFP32only),
+                                        24, 1, {5, 5}, 1, 1, avx2_DW_2D, vecPrcConnectParamsFP32),
         //  jcp.ngroups % simd_w != 0, jcp.nb_ch == 4, jcp.nb_ch_blocking == 3 (jcp.ngroups == 25)
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        25, 1, {5, 5}, 1, 1, avx2_DW_2D, vecPrcConnectParamsFP32only),
+                                        25, 1, {5, 5}, 1, 1, avx2_DW_2D, vecPrcConnectParamsFP32),
         //  jcp.ow > jcp.ur_w (jcp.ow == 7)
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        8, 1, {5, 9}, 1, 1, avx2_DW_2D, vecPrcConnectParamsFP32only),
+                                        8, 1, {5, 9}, 1, 1, avx2_DW_2D, vecPrcConnectParamsFP32),
 
         //  "hard" cases
         makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 8, 2, {129, 129}, 1, 1,
-                                        avx2_DW_2D, vecPrcConnectParamsFP32only),
+                                        avx2_DW_2D, vecPrcConnectParamsFP32),
         makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        8, 1, {10, 10}, 1, 1, avx2_DW_2D, vecPrcConnectParamsFP32only),
+                                        8, 1, {10, 10}, 1, 1, avx2_DW_2D, vecPrcConnectParamsFP32Default),
         makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
-                                        8, 2, {33, 33, 33}, 1, 1, avx2_DW_3D, vecPrcConnectParamsFP32only),
+                                        8, 2, {33, 33, 33}, 1, 1, avx2_DW_3D, vecPrcConnectParamsFP32Default),
         makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        8, 1, {10, 10, 10}, 1, 1, avx2_DW_3D, vecPrcConnectParamsFP32only)
+                                        8, 1, {10, 10, 10}, 1, 1, avx2_DW_3D, vecPrcConnectParamsFP32Default)
 );
 
 INSTANTIATE_TEST_CASE_P(smoke_JIT_AVX2_DW_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice
@@ -832,25 +837,26 @@ const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX512_DW_GroupConvTestCas
 
         //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 1, jcp.nb_ch_blocking == 1 (jcp.ngroups == 16)
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        16, 1, {5, 5}, 1, 1, avx512_DW_2D, vecPrcConnectParamsFP32only),
+                                        16, 1, {5, 5}, 1, 1, avx512_DW_2D, vecPrcConnectParams),
         //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 4, jcp.nb_ch_blocking == 4 (jcp.ngroups == 64)
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        64, 1, {5, 5}, 1, 1, avx512_DW_2D, vecPrcConnectParamsFP32only),
+                                        64, 1, {5, 5}, 1, 1, avx512_DW_2D, vecPrcConnectParams),
         //  jcp.ngroups % simd_w != 0, jcp.nb_ch == 5, jcp.nb_ch_blocking == 4 (jcp.ngroups == 65)
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        65, 1, {5, 5}, 1, 1, avx512_DW_2D, vecPrcConnectParamsFP32only),
+                                        65, 1, {5, 5}, 1, 1, avx512_DW_2D, vecPrcConnectParams),
         //  jcp.ow > jcp.ur_w (jcp.ow == 7)
         makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        8, 1, {5, 9}, 1, 1, avx512_DW_2D, vecPrcConnectParamsFP32only),
+                                        8, 1, {5, 9}, 1, 1, avx512_DW_2D, vecPrcConnectParams),
         //  "hard" cases
         makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 16, 2, {129, 129}, 1, 1,
-                                        avx512_DW_2D, vecPrcConnectParamsFP32only),
+                                        avx512_DW_2D, vecPrcConnectParamsDefault),
         makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT, 16, 1, {10, 10}, 1, 1,
-                                        avx512_DW_2D, vecPrcConnectParamsFP32only),
+                                        avx512_DW_2D, vecPrcConnectParamsDefault),
+        // todo [mkutakov]: fork DW bf16 convolution does not support 3d cases yet 53578
         makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
-                                        16, 2, {33, 33, 33}, 1, 1, avx512_DW_3D, vecPrcConnectParamsFP32only),
+                                        16, 2, {33, 33, 33}, 1, 1, avx512_DW_3D, vecPrcConnectParamsFP32Default),
         makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        16, 1, {10, 10, 10}, 1, 1, avx512_DW_3D, vecPrcConnectParamsFP32only)
+                                        16, 1, {10, 10, 10}, 1, 1, avx512_DW_3D, vecPrcConnectParamsFP32Default)
 );
 
 INSTANTIATE_TEST_CASE_P(smoke_JIT_AVX512_DW_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
@@ -174,7 +174,7 @@ const std::vector<fusingSpecificParams> fusingParamsSetBF16{
         fusingElu,
         fusingSigmoid,
         fusingClamp,
-        fusingPRelu,
+        fusingPReluPerChannel,
         fusingSwish,
         // other patterns
         fusingReluScaleShift,

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution_backprop_data.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution_backprop_data.cpp
@@ -4,6 +4,7 @@
 
 #include <shared_test_classes/single_layer/group_convolution_backprop_data.hpp>
 #include "test_utils/cpu_test_utils.hpp"
+#include "test_utils/convolution_params.hpp"
 #include "test_utils/fusing_test_utils.hpp"
 
 using namespace InferenceEngine;

--- a/inference-engine/tests/functional/plugin/cpu/subgraph_tests/src/conv_concat.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/subgraph_tests/src/conv_concat.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "test_utils/convolution_params.hpp"
 #include "subgraph_tests/include/conv_concat.hpp"
 
 using namespace InferenceEngine;

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/convolution_params.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/convolution_params.hpp
@@ -37,6 +37,8 @@ namespace CPUTestUtils {
     const auto conv_avx2_3D = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {"jit_avx2"}, "jit_avx2"};
     const auto conv_avx2_dw_2D = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_avx2_dw"}, "jit_avx2_dw"};
     const auto conv_avx2_dw_3D = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {"jit_avx2_dw"}, "jit_avx2_dw"};
+    const auto conv_avx2_planar_2D = CPUSpecificParams{{nchw}, {nchw}, {"jit_avx2"}, "jit_avx2"};
+    const auto conv_avx2_planar_3D = CPUSpecificParams{{ncdhw}, {ncdhw}, {"jit_avx2"}, "jit_avx2"};
 
     const auto conv_avx2_plain_to_blocked_2D = CPUSpecificParams{{nchw}, {nChw8c}, {"jit_avx2"}, "jit_avx2"};
     const auto conv_avx2_plain_to_blocked_3D = CPUSpecificParams{{ncdhw}, {nCdhw8c}, {"jit_avx2"}, "jit_avx2"};
@@ -50,6 +52,8 @@ namespace CPUTestUtils {
     const auto conv_avx512_3D = CPUSpecificParams{{nCdhw16c}, {nCdhw16c}, {"jit_avx512"}, "jit_avx512"};
     const auto conv_avx512_dw_2D = CPUSpecificParams{{nChw16c}, {nChw16c}, {"jit_avx512_dw"}, "jit_avx512_dw"};
     const auto conv_avx512_dw_3D = CPUSpecificParams{{nCdhw16c}, {nCdhw16c}, {"jit_avx512_dw"}, "jit_avx512_dw"};
+    const auto conv_avx512_planar_2D = CPUSpecificParams{{nchw}, {nchw}, {"jit_avx512"}, "jit_avx512"};
+    const auto conv_avx512_planar_3D = CPUSpecificParams{{ncdhw}, {ncdhw}, {"jit_avx512"}, "jit_avx512"};
 
     const auto conv_avx512_plain_to_blocked_2D = CPUSpecificParams{{nchw}, {nChw16c}, {"jit_avx512"}, "jit_avx512"};
     const auto conv_avx512_plain_to_blocked_3D = CPUSpecificParams{{ncdhw}, {nCdhw16c}, {"jit_avx512"}, "jit_avx512"};

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/convolution_params.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/convolution_params.hpp
@@ -1,0 +1,60 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "cpu_test_utils.hpp"
+
+namespace CPUTestUtils {
+    const auto conv_sse42_1D = CPUSpecificParams{{}, {}, {"jit_sse42"}, "jit_sse42"};
+    const auto conv_avx2_1D = CPUSpecificParams{{}, {}, {"jit_avx2"}, "jit_avx2"};
+    const auto conv_avx512_1D = CPUSpecificParams{{}, {}, {"jit_avx512"}, "jit_avx512"};
+
+    const auto conv_ref_2D = CPUSpecificParams{{nchw}, {nchw}, {"ref_any"}, "ref_any"};
+    const auto conv_ref_3D = CPUSpecificParams{{ncdhw}, {ncdhw}, {"ref_any"}, "ref_any"};
+
+    const auto conv_gemm_2D = CPUSpecificParams{{nchw}, {nchw}, {"gemm_any"}, "jit_gemm"};
+    const auto conv_gemm_3D = CPUSpecificParams{{ncdhw}, {ncdhw}, {"gemm_any"}, "jit_gemm"};
+
+    const auto conv_gemm_2D_nspc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_gemm"}, "jit_gemm"};
+    const auto conv_gemm_3D_nspc = CPUSpecificParams{{ndhwc}, {ndhwc}, {"jit_gemm"}, "jit_gemm"};
+
+    const auto conv_sse42_2D = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_sse42"}, "jit_sse42"};
+    const auto conv_sse42_3D = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {"jit_sse42"}, "jit_sse42"};
+    const auto conv_sse42_dw_2D = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_sse42_dw"}, "jit_sse42_dw"};
+    const auto conv_sse42_dw_3D = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {"jit_sse42_dw"}, "jit_sse42_dw"};
+
+    const auto conv_sse42_2D_nspc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_sse42"}, "jit_sse42"};
+    const auto conv_sse42_3D_nspc = CPUSpecificParams{{ndhwc}, {ndhwc}, {"jit_sse42"}, "jit_sse42"};
+    const auto conv_sse42_dw_2D_nspc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_sse42_dw"}, "jit_sse42_dw"};
+    const auto conv_sse42_dw_3D_nspc = CPUSpecificParams{{ndhwc}, {ndhwc}, {"jit_sse42_dw"}, "jit_sse42_dw"};
+
+    const auto conv_avx2_2D = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_avx2"}, "jit_avx2"};
+    const auto conv_avx2_3D = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {"jit_avx2"}, "jit_avx2"};
+    const auto conv_avx2_dw_2D = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_avx2_dw"}, "jit_avx2_dw"};
+    const auto conv_avx2_dw_3D = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {"jit_avx2_dw"}, "jit_avx2_dw"};
+
+    const auto conv_avx2_2D_nspc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_avx2"}, "jit_avx2"};
+    const auto conv_avx2_3D_nspc = CPUSpecificParams{{ndhwc}, {ndhwc}, {"jit_avx2"}, "jit_avx2"};
+    const auto conv_avx2_dw_2D_nspc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_avx2_dw"}, "jit_avx2_dw"};
+    const auto conv_avx2_dw_3D_nspc = CPUSpecificParams{{ndhwc}, {ndhwc}, {"jit_avx2_dw"}, "jit_avx2_dw"};
+
+    const auto conv_avx512_2D = CPUSpecificParams{{nChw16c}, {nChw16c}, {"jit_avx512"}, "jit_avx512"};
+    const auto conv_avx512_3D = CPUSpecificParams{{nCdhw16c}, {nCdhw16c}, {"jit_avx512"}, "jit_avx512"};
+    const auto conv_avx512_dw_2D = CPUSpecificParams{{nChw16c}, {nChw16c}, {"jit_avx512_dw"}, "jit_avx512_dw"};
+    const auto conv_avx512_dw_3D = CPUSpecificParams{{nCdhw16c}, {nCdhw16c}, {"jit_avx512_dw"}, "jit_avx512_dw"};
+
+    const auto conv_avx512_2D_nspc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_avx512"}, "jit_avx512"};
+    const auto conv_avx512_3D_nspc = CPUSpecificParams{{ndhwc}, {ndhwc}, {"jit_avx512"}, "jit_avx512"};
+    const auto conv_avx512_dw_2D_nspc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_avx512_dw"}, "jit_avx512_dw"};
+    const auto conv_avx512_dw_3D_nspc = CPUSpecificParams{{ndhwc}, {ndhwc}, {"jit_avx512_dw"}, "jit_avx512_dw"};
+
+    const auto conv_sse42_2D_1x1 = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_sse42_1x1"}, "jit_sse42_1x1"};
+    const auto conv_avx2_2D_1x1 = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_avx2_1x1"}, "jit_avx2_1x1"};
+    const auto conv_avx512_2D_1x1 = CPUSpecificParams{{nChw16c}, {nChw16c}, {"jit_avx512_1x1"}, "jit_avx512_1x1"};
+
+    const auto conv_sse42_2D_1x1_nspc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_sse42_1x1"}, "jit_sse42_1x1"};
+    const auto conv_avx2_2D_1x1_nspc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_avx2_1x1"}, "jit_avx2_1x1"};
+    const auto conv_avx512_2D_1x1_nspc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_avx512_1x1"}, "jit_avx512_1x1"};
+} // namespace CPUTestUtils

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/convolution_params.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/convolution_params.hpp
@@ -25,6 +25,9 @@ namespace CPUTestUtils {
     const auto conv_sse42_dw_2D = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_sse42_dw"}, "jit_sse42_dw"};
     const auto conv_sse42_dw_3D = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {"jit_sse42_dw"}, "jit_sse42_dw"};
 
+    const auto conv_sse42_plain_to_blocked_2D = CPUSpecificParams{{nchw}, {nChw8c}, {"jit_sse42"}, "jit_sse42"};
+    const auto conv_sse42_plain_to_blocked_3D = CPUSpecificParams{{ncdhw}, {nCdhw8c}, {"jit_sse42"}, "jit_sse42"};
+
     const auto conv_sse42_2D_nspc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_sse42"}, "jit_sse42"};
     const auto conv_sse42_3D_nspc = CPUSpecificParams{{ndhwc}, {ndhwc}, {"jit_sse42"}, "jit_sse42"};
     const auto conv_sse42_dw_2D_nspc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_sse42_dw"}, "jit_sse42_dw"};
@@ -35,6 +38,9 @@ namespace CPUTestUtils {
     const auto conv_avx2_dw_2D = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_avx2_dw"}, "jit_avx2_dw"};
     const auto conv_avx2_dw_3D = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {"jit_avx2_dw"}, "jit_avx2_dw"};
 
+    const auto conv_avx2_plain_to_blocked_2D = CPUSpecificParams{{nchw}, {nChw8c}, {"jit_avx2"}, "jit_avx2"};
+    const auto conv_avx2_plain_to_blocked_3D = CPUSpecificParams{{ncdhw}, {nCdhw8c}, {"jit_avx2"}, "jit_avx2"};
+
     const auto conv_avx2_2D_nspc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_avx2"}, "jit_avx2"};
     const auto conv_avx2_3D_nspc = CPUSpecificParams{{ndhwc}, {ndhwc}, {"jit_avx2"}, "jit_avx2"};
     const auto conv_avx2_dw_2D_nspc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_avx2_dw"}, "jit_avx2_dw"};
@@ -44,6 +50,9 @@ namespace CPUTestUtils {
     const auto conv_avx512_3D = CPUSpecificParams{{nCdhw16c}, {nCdhw16c}, {"jit_avx512"}, "jit_avx512"};
     const auto conv_avx512_dw_2D = CPUSpecificParams{{nChw16c}, {nChw16c}, {"jit_avx512_dw"}, "jit_avx512_dw"};
     const auto conv_avx512_dw_3D = CPUSpecificParams{{nCdhw16c}, {nCdhw16c}, {"jit_avx512_dw"}, "jit_avx512_dw"};
+
+    const auto conv_avx512_plain_to_blocked_2D = CPUSpecificParams{{nchw}, {nChw16c}, {"jit_avx512"}, "jit_avx512"};
+    const auto conv_avx512_plain_to_blocked_3D = CPUSpecificParams{{ncdhw}, {nCdhw16c}, {"jit_avx512"}, "jit_avx512"};
 
     const auto conv_avx512_2D_nspc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_avx512"}, "jit_avx512"};
     const auto conv_avx512_3D_nspc = CPUSpecificParams{{ndhwc}, {ndhwc}, {"jit_avx512"}, "jit_avx512"};

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
@@ -148,35 +148,6 @@ protected:
 
 const auto emptyCPUSpec = CPUSpecificParams{{}, {}, {}, {}};
 
-const auto conv_sse42_1D = CPUSpecificParams{{}, {}, {"jit_sse42"}, "jit_sse42"};
-const auto conv_avx2_1D = CPUSpecificParams{{}, {}, {"jit_avx2"}, "jit_avx2"};
-const auto conv_avx512_1D = CPUSpecificParams{{}, {}, {"jit_avx512"}, "jit_avx512"};
-
-const auto conv_ref_2D = CPUSpecificParams{{nchw}, {nchw}, {"ref_any"}, "ref_any"};
-const auto conv_ref_3D = CPUSpecificParams{{ncdhw}, {ncdhw}, {"ref_any"}, "ref_any"};
-
-const auto conv_gemm_2D = CPUSpecificParams{{nchw}, {nchw}, {"gemm_any"}, "jit_gemm"};
-const auto conv_gemm_3D = CPUSpecificParams{{ncdhw}, {ncdhw}, {"gemm_any"}, "jit_gemm"};
-
-const auto conv_sse42_2D = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_sse42"}, "jit_sse42"};
-const auto conv_sse42_3D = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {"jit_sse42"}, "jit_sse42"};
-const auto conv_sse42_dw_2D = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_sse42_dw"}, "jit_sse42_dw"};
-const auto conv_sse42_dw_3D = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {"jit_sse42_dw"}, "jit_sse42_dw"};
-
-const auto conv_avx2_2D = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_avx2"}, "jit_avx2"};
-const auto conv_avx2_3D = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {"jit_avx2"}, "jit_avx2"};
-const auto conv_avx2_dw_2D = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_avx2_dw"}, "jit_avx2_dw"};
-const auto conv_avx2_dw_3D = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {"jit_avx2_dw"}, "jit_avx2_dw"};
-
-const auto conv_avx512_2D = CPUSpecificParams{{nChw16c}, {nChw16c}, {"jit_avx512"}, "jit_avx512"};
-const auto conv_avx512_3D = CPUSpecificParams{{nCdhw16c}, {nCdhw16c}, {"jit_avx512"}, "jit_avx512"};
-const auto conv_avx512_dw_2D = CPUSpecificParams{{nChw16c}, {nChw16c}, {"jit_avx512_dw"}, "jit_avx512_dw"};
-const auto conv_avx512_dw_3D = CPUSpecificParams{{nCdhw16c}, {nCdhw16c}, {"jit_avx512_dw"}, "jit_avx512_dw"};
-
-const auto conv_sse42_2D_1x1 = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_sse42_1x1"}, "jit_sse42_1x1"};
-const auto conv_avx2_2D_1x1 = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_avx2_1x1"}, "jit_avx2_1x1"};
-const auto conv_avx512_2D_1x1 = CPUSpecificParams{{nChw16c}, {nChw16c}, {"jit_avx512_1x1"}, "jit_avx512_1x1"};
-
 // utility functions
 std::vector<CPUSpecificParams> filterCPUSpecificParams(std::vector<CPUSpecificParams>& paramsVector);
 std::vector<CPUSpecificParams> filterCPUInfoForDevice(std::vector<CPUSpecificParams> CPUParams);


### PR DESCRIPTION
### Details:

Enabling nspc layout support in all the FP32/BF16 convolution primitives

## Checklist

- [x] Add all necessary tests to check nspc execution, considering channel sizes not evenly divided by the SIMD vector length 
- [x] Add nspc primitive descriptor initialization to the convolution node 
- [x] Enable BF16 3D group convolution 
- [x] Disable nspc layout for non-quantized networks 

## Additional changes
- Fixed jit planar convolution init_conf subroutine to select the right layout label
- Add planar -> blocked convolutions for IC = 2
- Fixed eltwise node to work properly with 1D nspc input

## Known issues

- SSE41 convolution kernels do not support nspc layout ( 52736 )
- GEMM BF16 ncsp convolution unexpectedly crushes during multithreaded execution  ( 53618 )
- GEMM FP32/BF16 nspc depthwise post ops fusing implementation is not optimal ( 52737 )

### Tickets:
 - 52738

OneDNN PR: https://github.com/openvinotoolkit/oneDNN/pull/47



