### PR TITLE
Add transformation pipeline for POT

### DIFF
--- a/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api.pyx
+++ b/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api.pyx
@@ -5,9 +5,13 @@ from .cimport offline_transformations_api_impl_defs as C
 from ..inference_engine.ie_api cimport IENetwork
 
 from libcpp cimport bool
+from libcpp.string cimport string
 
 def ApplyMOCTransformations(IENetwork network, bool cf):
     C.ApplyMOCTransformations(network.impl, cf)
+
+def ApplyPOTTransformations(IENetwork network, string device):
+    C.ApplyPOTTransformations(network.impl, device)
 
 def ApplyLowLatencyTransformation(IENetwork network):
     C.ApplyLowLatencyTransformation(network.impl)

--- a/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api_impl.cpp
+++ b/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api_impl.cpp
@@ -5,6 +5,7 @@
 #include "offline_transformations_api_impl.hpp"
 
 #include <moc_transformations.hpp>
+#include <pot_transformations.hpp>
 #include <pruning.hpp>
 
 #include <transformations/control_flow/unroll_tensor_iterator.hpp>
@@ -18,6 +19,12 @@
 void InferenceEnginePython::ApplyMOCTransformations(InferenceEnginePython::IENetwork network, bool cf) {
     ngraph::pass::Manager manager;
     manager.register_pass<ngraph::pass::MOCTransformations>(cf);
+    manager.run_passes(network.actual->getFunction());
+}
+
+void InferenceEnginePython::ApplyPOTTransformations(InferenceEnginePython::IENetwork network, std::string device) {
+    ngraph::pass::Manager manager;
+    manager.register_pass<ngraph::pass::POTTransformations>(std::move(device));
     manager.run_passes(network.actual->getFunction());
 }
 

--- a/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api_impl.hpp
+++ b/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api_impl.hpp
@@ -4,12 +4,16 @@
 
 #pragma once
 
+#include <string>
+
 #include "Python.h"
 #include "ie_api_impl.hpp"
 
 namespace InferenceEnginePython {
 
 void ApplyMOCTransformations(InferenceEnginePython::IENetwork network, bool cf);
+
+void ApplyPOTTransformations(InferenceEnginePython::IENetwork network, std::string device);
 
 void ApplyLowLatencyTransformation(InferenceEnginePython::IENetwork network);
 

--- a/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api_impl_defs.pxd
+++ b/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api_impl_defs.pxd
@@ -2,10 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from libcpp cimport bool
+from libcpp.string cimport string
+
 from ..inference_engine.ie_api_impl_defs cimport IENetwork
 
 cdef extern from "offline_transformations_api_impl.hpp" namespace "InferenceEnginePython":
     cdef void ApplyMOCTransformations(IENetwork network, bool cf)
+
+    cdef void ApplyPOTTransformations(IENetwork network, string device)
 
     cdef void ApplyLowLatencyTransformation(IENetwork network)
 

--- a/inference-engine/src/offline_transformations/include/pot_transformations.hpp
+++ b/inference-engine/src/offline_transformations/include/pot_transformations.hpp
@@ -1,0 +1,33 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <ngraph/pass/graph_rewrite.hpp>
+
+namespace ngraph {
+namespace pass {
+
+class POTTransformations;
+
+}  // namespace pass
+}  // namespace ngraph
+
+/**
+ * @brief This transformation is an entry point for nGraph transformations that will be
+ * executed inside POT.
+ */
+
+class ngraph::pass::POTTransformations: public ngraph::pass::FunctionPass {
+    std::string m_device;
+
+public:
+    NGRAPH_RTTI_DECLARATION;
+    explicit POTTransformations(std::string device) : m_device(std::move(device)) {}
+
+    bool run_on_function(std::shared_ptr<ngraph::Function>) override;
+};

--- a/inference-engine/src/offline_transformations/src/pot_transformations.cpp
+++ b/inference-engine/src/offline_transformations/src/pot_transformations.cpp
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <memory>
+
+#include <ngraph/pass/manager.hpp>
+
+#include <transformations/op_conversions/lstm_cell_decomposition.hpp>
+
+#include "pot_transformations.hpp"
+
+NGRAPH_RTTI_DEFINITION(ngraph::pass::POTTransformations, "POTTransformations", 0);
+
+bool ngraph::pass::POTTransformations::run_on_function(std::shared_ptr<ngraph::Function> f) {
+    ngraph::pass::Manager manager(get_pass_config());
+    if (m_device == "CPU") {
+        // TODO: register CPU passes
+        // manager.register_pass<ngraph::pass::LSTMCellDecomposition>();
+    } else {
+        throw ngraph_error("Device name is unsupported");
+    }
+    manager.run_passes(f);
+    return false;
+}


### PR DESCRIPTION
### Description
Added transformation pipeline for POT into offline transformation library. This transformation pipeline can be used directly from python via Inference Engine Python API (see example below). To fill pipeline with new transformations you just need to add additional passes to pass Manager inside `pot_transformations.cpp`.

### Usage
```py
from openvino.inference_engine import IECore
from openvino.offline_transformations import ApplyPOTTransformations
ie = IECore()
net = ie.read_network(model="path_to_xml", weights="path_to_bin")
ApplyPOTTransformations(net, "CPU")
net.serialize("path_to_xml", "path_to_bin")
```

### Ticket
XXX-48739