### PR TITLE
Added BackwardGraphRewrite And Input<Node> RTInfo

### DIFF
--- a/ngraph/core/include/ngraph/node_input.hpp
+++ b/ngraph/core/include/ngraph/node_input.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstring>
+#include <map>
 
 #include "ngraph/descriptor/tensor.hpp"
 #include "ngraph/partial_shape.hpp"
@@ -22,6 +23,8 @@ namespace ngraph
     class Input
     {
     };
+
+    class Variant;
 
     /// \brief A handle for one of a node's inputs.
     template <>
@@ -57,6 +60,12 @@ namespace ngraph
         /// \brief Replaces the source output of this input.
         /// \param new_source_output A handle for the output that will replace this input's source.
         void replace_source_output(const Output<Node>& new_source_output) const;
+
+        using RTMap = std::map<std::string, std::shared_ptr<Variant>>;
+        /// \return The reference to runtime info map
+        RTMap& get_rt_info();
+        /// \return The constant reference to runtime info map
+        const RTMap& get_rt_info() const;
 
         bool operator==(const Input& other) const;
         bool operator!=(const Input& other) const;
@@ -100,6 +109,10 @@ namespace ngraph
         bool get_is_relevant_to_shapes() const;
         /// \return true if this input is relevant to its node's output values; else false.
         bool get_is_relevant_to_values() const;
+
+        using RTMap = std::map<std::string, std::shared_ptr<Variant>>;
+        /// \return The constant reference to runtime info map
+        const RTMap& get_rt_info() const;
 
         bool operator==(const Input& other) const;
         bool operator!=(const Input& other) const;

--- a/ngraph/core/include/ngraph/pass/graph_rewrite.hpp
+++ b/ngraph/core/include/ngraph/pass/graph_rewrite.hpp
@@ -219,9 +219,27 @@ namespace ngraph
             void set_pass_config(const std::shared_ptr<PassConfig>& pass_config) override;
 
         protected:
+            bool apply_matcher_passes(std::shared_ptr<Function> f,
+                                      std::deque<std::shared_ptr<Node>> nodes_to_run);
+
             bool m_enable_shape_inference = false;
 
             std::vector<std::shared_ptr<ngraph::pass::MatcherPass>> m_matchers;
+        };
+
+        class NGRAPH_API BackwardGraphRewrite : public ngraph::pass::GraphRewrite
+        {
+        public:
+            NGRAPH_RTTI_DECLARATION;
+
+            BackwardGraphRewrite() = default;
+
+            explicit BackwardGraphRewrite(const std::shared_ptr<MatcherPass>& pass)
+                : GraphRewrite(pass)
+            {
+            }
+
+            bool run_on_function(std::shared_ptr<ngraph::Function> f) override;
         };
 
         class NGRAPH_API RecurrentGraphRewrite : public ngraph::pass::FunctionPass

--- a/ngraph/core/src/node_input.cpp
+++ b/ngraph/core/src/node_input.cpp
@@ -82,6 +82,20 @@ namespace ngraph
     {
     }
 
+    using RTMap = std::map<std::string, std::shared_ptr<Variant>>;
+
+    RTMap& Input<Node>::get_rt_info() { return m_node->m_outputs.at(m_index).get_rt_info(); }
+
+    const RTMap& Input<Node>::get_rt_info() const
+    {
+        return m_node->m_outputs.at(m_index).get_rt_info();
+    }
+
+    const RTMap& Input<const Node>::get_rt_info() const
+    {
+        return m_node->m_outputs.at(m_index).get_rt_info();
+    }
+
     const Node* Input<const Node>::get_node() const { return m_node; }
     size_t Input<const Node>::get_index() const { return m_index; }
     const element::Type& Input<const Node>::get_element_type() const

--- a/ngraph/test/op.cpp
+++ b/ngraph/test/op.cpp
@@ -124,9 +124,25 @@ TEST(op, variant)
     EXPECT_EQ(ship.y, 4);
 
     auto node = make_shared<op::Parameter>(element::f32, Shape{1});
+    // Check Node RTInfo
     node->get_rt_info()["A"] = var_ship;
     auto node_var_ship = node->get_rt_info().at("A");
     ASSERT_TRUE((is_type<VariantWrapper<Ship>>(node_var_ship)));
     Ship& node_ship = as_type_ptr<VariantWrapper<Ship>>(node_var_ship)->get();
     EXPECT_EQ(&node_ship, &ship);
+
+    // Check Node Input<Node> RTInfo
+    auto relu = make_shared<op::Relu>(node);
+    relu->input(0).get_rt_info()["A"] = var_ship;
+    auto node_input_var_ship = node->get_rt_info().at("A");
+    ASSERT_TRUE((is_type<VariantWrapper<Ship>>(node_input_var_ship)));
+    Ship& node_input_ship = as_type_ptr<VariantWrapper<Ship>>(node_input_var_ship)->get();
+    EXPECT_EQ(&node_input_ship, &ship);
+
+    // Check Node Input<Node> RTInfo
+    node->output(0).get_rt_info()["A"] = var_ship;
+    auto node_output_var_ship = node->get_rt_info().at("A");
+    ASSERT_TRUE((is_type<VariantWrapper<Ship>>(node_output_var_ship)));
+    Ship& node_output_ship = as_type_ptr<VariantWrapper<Ship>>(node_input_var_ship)->get();
+    EXPECT_EQ(&node_output_ship, &ship);
 }


### PR DESCRIPTION
### Description
In this PR I added BackwardGraphRewrite facility required by some transformation algorithms to avoid manual graph traversal. In addition RTInfo was added to Input<Node> class.