### PR TITLE
WIP: [IE TESTS] [CPU] extended cpu specific tests to support int8 precision

### DIFF
--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution_backprop_data.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution_backprop_data.cpp
@@ -52,6 +52,7 @@ public:
     }
 protected:
     void SetUp() override {
+        using namespace ngraph;
         convBackpropLayerTestParamsSet basicParamsSet;
         CPUSpecificParams cpuParams;
         fusingSpecificParams fusingParams;
@@ -69,32 +70,53 @@ protected:
         auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
         std::tie(convParams, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, outputShape, targetDevice) = basicParamsSet;
 
-        if (inPrc == Precision::UNSPECIFIED) {
-            selectedType += std::string("_") + Precision(Precision::FP32).name();
+        if (inPrc == Precision::UNSPECIFIED)
+            inPrc = Precision::FP32;
+        if (outPrc == Precision::UNSPECIFIED)
+            outPrc = Precision::FP32;
+
+        if (inPrc == Precision::U8) {
+            selectedType += std::string("_") + Precision(Precision::I8).name();
         } else {
             selectedType += std::string("_") + inPrc.name();
         }
 
-        ngraph::op::PadType padType;
+        op::PadType padType;
         InferenceEngine::SizeVector kernel, stride, dilation;
         std::vector<ptrdiff_t> padBegin, padEnd, outPadding;
         size_t convOutChannels;
         std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType, outPadding) = convParams;
-        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+        auto inElementType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrc);
+        auto outElementType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(outPrc);
+        if (inPrc == Precision::BF16)
+            inElementType = element::f32;
+        if (outPrc == Precision::BF16)
+            outElementType = element::f32;
 
-        auto inputParams = ngraph::builder::makeParams(ngraph::element::f32, { inputShape });
-        auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(inputParams));
+        auto inputParams = builder::makeParams(inElementType, { inputShape });
+        auto paramOuts = helpers::convert2OutputVector(helpers::castOps2Nodes<op::Parameter>(inputParams));
 
-        auto deconvolutionNode = ngraph::builder::makeConvolutionBackpropData(paramOuts.front(), ngPrc, kernel, stride, padBegin,
-                padEnd, dilation, padType, convOutChannels, false, outPadding);
+        auto weiPrc = (inElementType == element::u8) ? element::i8 : inElementType;
 
+        auto deconvolutionNode = builder::makeConvolutionBackpropDataRelaxed(paramOuts.front(), weiPrc, outElementType,
+                kernel, stride, padBegin, padEnd, dilation, padType, convOutChannels);
+
+        // todo:
         if (!outputShape.empty()) {
             auto outShape = ngraph::opset3::Constant::create(ngraph::element::i64, {outputShape.size()}, outputShape);
-            deconvolutionNode = ngraph::builder::makeConvolutionBackpropData(paramOuts.front(), outShape, ngPrc, kernel, stride, padBegin,
+            deconvolutionNode = ngraph::builder::makeConvolutionBackpropData(paramOuts.front(), outShape, weiPrc, kernel, stride, padBegin,
                 padEnd, dilation, padType, convOutChannels);
         }
 
-        function = makeNgraphFunction(ngPrc, inputParams, deconvolutionNode, "convolutionBackpropData");
+        function = makeNgraphFunction(element::f32, inputParams, deconvolutionNode, "convolutionBackpropData");
+
+        if (inPrc == Precision::U8 || inPrc == Precision::I8) {
+            additionalPasses.push_back(std::make_shared<pass::ConvertPrecision<element::i8, element::f32>>());
+            additionalPasses.push_back(std::make_shared<pass::ConvertPrecision<element::u8, element::f32>>());
+        }
+        if (outPrc != Precision::FP32 && outPrc != Precision::BF16) {
+            additionalPasses.push_back(std::make_shared<ConvertPrecision<opset1::ConvolutionBackpropData>>());
+        }
     }
 };
 
@@ -186,7 +208,7 @@ INSTANTIATE_TEST_CASE_P(smoke_Deconv_2D_Planar_BF16, DeconvolutionLayerCPUTest,
         ::testing::Values(cpuBF16PluginConfig)),
     DeconvolutionLayerCPUTest::getTestCaseName);
 
-/* ============= GroupDeconvolution (Planar 3D) ============= */
+/* ============= Deconvolution (Planar 3D) ============= */
 const auto convParams_ExplicitPadding_Planar_3D = ::testing::Combine(
     ::testing::ValuesIn(kernels3d),
     ::testing::ValuesIn(strides3d),
@@ -370,6 +392,151 @@ INSTANTIATE_TEST_CASE_P(smoke_Deconv_2D_1x1_BF16, DeconvolutionLayerCPUTest,
         ::testing::ValuesIn(fusingParamsSet),
         ::testing::Values(cpuBF16PluginConfig)),
     DeconvolutionLayerCPUTest::getTestCaseName);
+
+/* ============= Deconvolution params I8 (2D) ============= */
+const std::vector<SizeVector> kernels2di8 = { {3, 3} };
+const std::vector<SizeVector> strides2di8 = { {1, 1}, {2, 2} };
+const std::vector<std::vector<ptrdiff_t>> padBegins2di8 = { {0, 0}, {1, 1} };
+const std::vector<std::vector<ptrdiff_t>> padEnds2di8 = { {0, 0}, {1, 1} };
+const std::vector<SizeVector> dilations2di8 = { {1, 1}/*, {2, 2}*/ };
+
+const auto deconvParams_2D_I8 = ::testing::Combine(
+        ::testing::ValuesIn(kernels2di8),
+        ::testing::ValuesIn(strides2di8),
+        ::testing::ValuesIn(padBegins2di8),
+        ::testing::ValuesIn(padEnds2di8),
+        ::testing::ValuesIn(dilations2di8),
+        ::testing::ValuesIn(numOutChannels_Planar),
+        ::testing::Values(ngraph::op::PadType::EXPLICIT)
+);
+
+const std::vector<fusingSpecificParams> fusingParamsSetI8{
+        emptyFusingSpec,
+        fusingRelu,
+        fusingElu,
+        fusingSigmoid,
+        fusingClamp,
+        fusingPReluPerChannel,
+        fusingFakeQuantizePerChannel,
+        fusingReluScaleShift,
+};
+
+const std::vector<CPUSpecificParams> CPUParams_2D_I8 = {
+        conv_sse42_2D_nspc,
+        conv_avx2_2D_nspc,
+        conv_avx512_2D_nspc
+};
+
+INSTANTIATE_TEST_CASE_P(smoke_Deconv_2D_I8, DeconvolutionLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Combine(
+                                        deconvParams_2D_I8,
+                                        ::testing::Values(Precision::FP32),
+                                        ::testing::Values(Precision::U8, Precision::I8),
+                                        ::testing::Values(Precision::FP32/*, Precision::I32*/),
+                                        ::testing::Values(Layout::ANY),
+                                        ::testing::Values(Layout::ANY),
+                                        ::testing::Values(std::vector<size_t >({ 2, 12, 7, 7 })),
+                                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_2D_I8)),
+                                ::testing::ValuesIn(fusingParamsSetI8),
+                                ::testing::Values(cpuEmptyPluginConfig)),
+                        DeconvolutionLayerCPUTest::getTestCaseName);
+
+/* ============= Deconvolution params I8 (3D) ============= */
+const std::vector<SizeVector> kernels3di8 = { {3, 3, 3} };
+const std::vector<SizeVector> strides3di8 = { {1, 1, 1}, {2, 2, 2} };
+const std::vector<std::vector<ptrdiff_t>> padBegins3di8 = { {0, 0, 0}, {1, 1, 1} };
+const std::vector<std::vector<ptrdiff_t>> padEnds3di8 = { {0, 0, 0}, {1, 1, 1} };
+const std::vector<SizeVector> dilations3di8 = { {1, 1, 1}/*, {2, 2, 2}*/ };
+
+const auto deconvParams_3D_I8 = ::testing::Combine(
+        ::testing::ValuesIn(kernels3di8),
+        ::testing::ValuesIn(strides3di8),
+        ::testing::ValuesIn(padBegins3di8),
+        ::testing::ValuesIn(padEnds3di8),
+        ::testing::ValuesIn(dilations3di8),
+        ::testing::ValuesIn(numOutChannels_Planar),
+        ::testing::Values(ngraph::op::PadType::EXPLICIT)
+);
+
+const std::vector<CPUSpecificParams> CPUParams_3D_I8 = {
+        conv_sse42_3D_nspc,
+        conv_avx2_3D_nspc,
+        conv_avx512_3D_nspc
+};
+
+INSTANTIATE_TEST_CASE_P(smoke_Deconv_3D_I8, DeconvolutionLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Combine(
+                                        deconvParams_3D_I8,
+                                        ::testing::Values(Precision::FP32),
+                                        ::testing::Values(Precision::U8, Precision::I8),
+                                        ::testing::Values(Precision::FP32/*, Precision::I32*/),
+                                        ::testing::Values(Layout::ANY),
+                                        ::testing::Values(Layout::ANY),
+                                        ::testing::Values(std::vector<size_t >({ 2, 12, 7, 7, 7 })),
+                                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_3D_I8)),
+                                ::testing::ValuesIn(fusingParamsSetI8),
+                                ::testing::Values(cpuEmptyPluginConfig)),
+                        DeconvolutionLayerCPUTest::getTestCaseName);
+
+const std::vector<CPUSpecificParams> CPUParams_2D_1x1_I8 = {
+        conv_sse42_2D_1x1_nspc,
+        conv_avx2_2D_1x1_nspc,
+        conv_avx512_2D_1x1_nspc
+};
+
+INSTANTIATE_TEST_CASE_P(smoke_Deconv_2D_1x1_I8, DeconvolutionLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Combine(
+                                        convParams_ExplicitPadding_1x1_2D,
+                                        ::testing::Values(Precision::FP32),
+                                        ::testing::Values(Precision::U8, Precision::I8),
+                                        ::testing::Values(Precision::FP32/*, Precision::I32*/),
+                                        ::testing::Values(Layout::ANY),
+                                        ::testing::Values(Layout::ANY),
+                                        ::testing::Values(std::vector<size_t >({ 2, 67, 7, 7 })),
+                                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_2D_1x1_I8)),
+                                ::testing::ValuesIn(fusingParamsSetI8),
+                                ::testing::Values(cpuEmptyPluginConfig)),
+                        DeconvolutionLayerCPUTest::getTestCaseName);
+
+/* ============= Kernel_1x1 (3D) ============= */
+
+const auto convParams_ExplicitPadding_1x1_3D = ::testing::Combine(
+        ::testing::Values(SizeVector({1, 1, 1})),
+        ::testing::Values(SizeVector({1, 1, 1})),
+        ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),
+        ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),
+        ::testing::Values(SizeVector({1, 1, 1})),
+        ::testing::ValuesIn(numOutChannels_Blocked),
+        ::testing::Values(ngraph::op::PadType::EXPLICIT)
+);
+
+const std::vector<CPUSpecificParams> CPUParams_3D_1x1_I8 = {
+        conv_sse42_3D_1x1_nspc,
+        conv_avx2_3D_1x1_nspc,
+        conv_avx512_3D_1x1_nspc
+};
+
+INSTANTIATE_TEST_CASE_P(smoke_Deconv_3D_1x1_I8, DeconvolutionLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Combine(
+                                        convParams_ExplicitPadding_1x1_3D,
+                                        ::testing::Values(Precision::FP32),
+                                        ::testing::Values(Precision::U8, Precision::I8),
+                                        ::testing::Values(Precision::FP32/*, Precision::I32*/),
+                                        ::testing::Values(Layout::ANY),
+                                        ::testing::Values(Layout::ANY),
+                                        ::testing::Values(std::vector<size_t >({ 2, 67, 7, 7, 7 })),
+                                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_3D_1x1_I8)),
+                                ::testing::ValuesIn(fusingParamsSetI8),
+                                ::testing::Values(cpuEmptyPluginConfig)),
+                        DeconvolutionLayerCPUTest::getTestCaseName);
 
 /* ========= */
 

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution_backprop_data.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution_backprop_data.cpp
@@ -407,7 +407,8 @@ const auto deconvParams_2D_I8 = ::testing::Combine(
         ::testing::ValuesIn(padEnds2di8),
         ::testing::ValuesIn(dilations2di8),
         ::testing::ValuesIn(numOutChannels_Planar),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT)
+        ::testing::Values(ngraph::op::PadType::EXPLICIT),
+        ::testing::ValuesIn(emptyOutputPadding)
 );
 
 const std::vector<fusingSpecificParams> fusingParamsSetI8{
@@ -437,6 +438,7 @@ INSTANTIATE_TEST_CASE_P(smoke_Deconv_2D_I8, DeconvolutionLayerCPUTest,
                                         ::testing::Values(Layout::ANY),
                                         ::testing::Values(Layout::ANY),
                                         ::testing::Values(std::vector<size_t >({ 2, 12, 7, 7 })),
+                                        ::testing::ValuesIn(emptyOutputShape),
                                         ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                                 ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_2D_I8)),
                                 ::testing::ValuesIn(fusingParamsSetI8),
@@ -457,7 +459,8 @@ const auto deconvParams_3D_I8 = ::testing::Combine(
         ::testing::ValuesIn(padEnds3di8),
         ::testing::ValuesIn(dilations3di8),
         ::testing::ValuesIn(numOutChannels_Planar),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT)
+        ::testing::Values(ngraph::op::PadType::EXPLICIT),
+        ::testing::ValuesIn(emptyOutputPadding)
 );
 
 const std::vector<CPUSpecificParams> CPUParams_3D_I8 = {
@@ -476,6 +479,7 @@ INSTANTIATE_TEST_CASE_P(smoke_Deconv_3D_I8, DeconvolutionLayerCPUTest,
                                         ::testing::Values(Layout::ANY),
                                         ::testing::Values(Layout::ANY),
                                         ::testing::Values(std::vector<size_t >({ 2, 12, 7, 7, 7 })),
+                                        ::testing::ValuesIn(emptyOutputShape),
                                         ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                                 ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_3D_I8)),
                                 ::testing::ValuesIn(fusingParamsSetI8),
@@ -498,6 +502,7 @@ INSTANTIATE_TEST_CASE_P(smoke_Deconv_2D_1x1_I8, DeconvolutionLayerCPUTest,
                                         ::testing::Values(Layout::ANY),
                                         ::testing::Values(Layout::ANY),
                                         ::testing::Values(std::vector<size_t >({ 2, 67, 7, 7 })),
+                                        ::testing::ValuesIn(emptyOutputShape),
                                         ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                                 ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_2D_1x1_I8)),
                                 ::testing::ValuesIn(fusingParamsSetI8),
@@ -513,7 +518,8 @@ const auto convParams_ExplicitPadding_1x1_3D = ::testing::Combine(
         ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),
         ::testing::Values(SizeVector({1, 1, 1})),
         ::testing::ValuesIn(numOutChannels_Blocked),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT)
+        ::testing::Values(ngraph::op::PadType::EXPLICIT),
+        ::testing::ValuesIn(emptyOutputPadding)
 );
 
 const std::vector<CPUSpecificParams> CPUParams_3D_1x1_I8 = {
@@ -532,6 +538,7 @@ INSTANTIATE_TEST_CASE_P(smoke_Deconv_3D_1x1_I8, DeconvolutionLayerCPUTest,
                                         ::testing::Values(Layout::ANY),
                                         ::testing::Values(Layout::ANY),
                                         ::testing::Values(std::vector<size_t >({ 2, 67, 7, 7, 7 })),
+                                        ::testing::ValuesIn(emptyOutputShape),
                                         ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                                 ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_3D_1x1_I8)),
                                 ::testing::ValuesIn(fusingParamsSetI8),

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution_backprop_data.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution_backprop_data.cpp
@@ -446,45 +446,45 @@ INSTANTIATE_TEST_CASE_P(smoke_Deconv_2D_I8, DeconvolutionLayerCPUTest,
                         DeconvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= Deconvolution params I8 (3D) ============= */
-const std::vector<SizeVector> kernels3di8 = { {3, 3, 3} };
-const std::vector<SizeVector> strides3di8 = { {1, 1, 1}, {2, 2, 2} };
-const std::vector<std::vector<ptrdiff_t>> padBegins3di8 = { {0, 0, 0}, {1, 1, 1} };
-const std::vector<std::vector<ptrdiff_t>> padEnds3di8 = { {0, 0, 0}, {1, 1, 1} };
-const std::vector<SizeVector> dilations3di8 = { {1, 1, 1}/*, {2, 2, 2}*/ };
-
-const auto deconvParams_3D_I8 = ::testing::Combine(
-        ::testing::ValuesIn(kernels3di8),
-        ::testing::ValuesIn(strides3di8),
-        ::testing::ValuesIn(padBegins3di8),
-        ::testing::ValuesIn(padEnds3di8),
-        ::testing::ValuesIn(dilations3di8),
-        ::testing::ValuesIn(numOutChannels_Planar),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT),
-        ::testing::ValuesIn(emptyOutputPadding)
-);
-
-const std::vector<CPUSpecificParams> CPUParams_3D_I8 = {
-        conv_sse42_3D_nspc,
-        conv_avx2_3D_nspc,
-        conv_avx512_3D_nspc
-};
-
-INSTANTIATE_TEST_CASE_P(smoke_Deconv_3D_I8, DeconvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        deconvParams_3D_I8,
-                                        ::testing::Values(Precision::FP32),
-                                        ::testing::Values(Precision::U8, Precision::I8),
-                                        ::testing::Values(Precision::FP32/*, Precision::I32*/),
-                                        ::testing::Values(Layout::ANY),
-                                        ::testing::Values(Layout::ANY),
-                                        ::testing::Values(std::vector<size_t >({ 2, 12, 7, 7, 7 })),
-                                        ::testing::ValuesIn(emptyOutputShape),
-                                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_3D_I8)),
-                                ::testing::ValuesIn(fusingParamsSetI8),
-                                ::testing::Values(cpuEmptyPluginConfig)),
-                        DeconvolutionLayerCPUTest::getTestCaseName);
+//const std::vector<SizeVector> kernels3di8 = { {3, 3, 3} };
+//const std::vector<SizeVector> strides3di8 = { {1, 1, 1}, {2, 2, 2} };
+//const std::vector<std::vector<ptrdiff_t>> padBegins3di8 = { {0, 0, 0}, {1, 1, 1} };
+//const std::vector<std::vector<ptrdiff_t>> padEnds3di8 = { {0, 0, 0}, {1, 1, 1} };
+//const std::vector<SizeVector> dilations3di8 = { {1, 1, 1}/*, {2, 2, 2}*/ };
+//
+//const auto deconvParams_3D_I8 = ::testing::Combine(
+//        ::testing::ValuesIn(kernels3di8),
+//        ::testing::ValuesIn(strides3di8),
+//        ::testing::ValuesIn(padBegins3di8),
+//        ::testing::ValuesIn(padEnds3di8),
+//        ::testing::ValuesIn(dilations3di8),
+//        ::testing::ValuesIn(numOutChannels_Planar),
+//        ::testing::Values(ngraph::op::PadType::EXPLICIT),
+//        ::testing::ValuesIn(emptyOutputPadding)
+//);
+//
+//const std::vector<CPUSpecificParams> CPUParams_3D_I8 = {
+//        conv_sse42_3D_nspc,
+//        conv_avx2_3D_nspc,
+//        conv_avx512_3D_nspc
+//};
+//
+//INSTANTIATE_TEST_CASE_P(smoke_Deconv_3D_I8, DeconvolutionLayerCPUTest,
+//                        ::testing::Combine(
+//                                ::testing::Combine(
+//                                        deconvParams_3D_I8,
+//                                        ::testing::Values(Precision::FP32),
+//                                        ::testing::Values(Precision::U8, Precision::I8),
+//                                        ::testing::Values(Precision::FP32/*, Precision::I32*/),
+//                                        ::testing::Values(Layout::ANY),
+//                                        ::testing::Values(Layout::ANY),
+//                                        ::testing::Values(std::vector<size_t >({ 2, 12, 7, 7, 7 })),
+//                                        ::testing::ValuesIn(emptyOutputShape),
+//                                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+//                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_3D_I8)),
+//                                ::testing::ValuesIn(fusingParamsSetI8),
+//                                ::testing::Values(cpuEmptyPluginConfig)),
+//                        DeconvolutionLayerCPUTest::getTestCaseName);
 
 const std::vector<CPUSpecificParams> CPUParams_2D_1x1_I8 = {
         conv_sse42_2D_1x1_nspc,
@@ -511,39 +511,39 @@ INSTANTIATE_TEST_CASE_P(smoke_Deconv_2D_1x1_I8, DeconvolutionLayerCPUTest,
 
 /* ============= Kernel_1x1 (3D) ============= */
 
-const auto convParams_ExplicitPadding_1x1_3D = ::testing::Combine(
-        ::testing::Values(SizeVector({1, 1, 1})),
-        ::testing::Values(SizeVector({1, 1, 1})),
-        ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),
-        ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),
-        ::testing::Values(SizeVector({1, 1, 1})),
-        ::testing::ValuesIn(numOutChannels_Blocked),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT),
-        ::testing::ValuesIn(emptyOutputPadding)
-);
-
-const std::vector<CPUSpecificParams> CPUParams_3D_1x1_I8 = {
-        conv_sse42_3D_1x1_nspc,
-        conv_avx2_3D_1x1_nspc,
-        conv_avx512_3D_1x1_nspc
-};
-
-INSTANTIATE_TEST_CASE_P(smoke_Deconv_3D_1x1_I8, DeconvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        convParams_ExplicitPadding_1x1_3D,
-                                        ::testing::Values(Precision::FP32),
-                                        ::testing::Values(Precision::U8, Precision::I8),
-                                        ::testing::Values(Precision::FP32/*, Precision::I32*/),
-                                        ::testing::Values(Layout::ANY),
-                                        ::testing::Values(Layout::ANY),
-                                        ::testing::Values(std::vector<size_t >({ 2, 67, 7, 7, 7 })),
-                                        ::testing::ValuesIn(emptyOutputShape),
-                                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_3D_1x1_I8)),
-                                ::testing::ValuesIn(fusingParamsSetI8),
-                                ::testing::Values(cpuEmptyPluginConfig)),
-                        DeconvolutionLayerCPUTest::getTestCaseName);
+//const auto convParams_ExplicitPadding_1x1_3D = ::testing::Combine(
+//        ::testing::Values(SizeVector({1, 1, 1})),
+//        ::testing::Values(SizeVector({1, 1, 1})),
+//        ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),
+//        ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),
+//        ::testing::Values(SizeVector({1, 1, 1})),
+//        ::testing::ValuesIn(numOutChannels_Blocked),
+//        ::testing::Values(ngraph::op::PadType::EXPLICIT),
+//        ::testing::ValuesIn(emptyOutputPadding)
+//);
+//
+//const std::vector<CPUSpecificParams> CPUParams_3D_1x1_I8 = {
+//        conv_sse42_3D_1x1_nspc,
+//        conv_avx2_3D_1x1_nspc,
+//        conv_avx512_3D_1x1_nspc
+//};
+//
+//INSTANTIATE_TEST_CASE_P(smoke_Deconv_3D_1x1_I8, DeconvolutionLayerCPUTest,
+//                        ::testing::Combine(
+//                                ::testing::Combine(
+//                                        convParams_ExplicitPadding_1x1_3D,
+//                                        ::testing::Values(Precision::FP32),
+//                                        ::testing::Values(Precision::U8, Precision::I8),
+//                                        ::testing::Values(Precision::FP32/*, Precision::I32*/),
+//                                        ::testing::Values(Layout::ANY),
+//                                        ::testing::Values(Layout::ANY),
+//                                        ::testing::Values(std::vector<size_t >({ 2, 67, 7, 7, 7 })),
+//                                        ::testing::ValuesIn(emptyOutputShape),
+//                                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+//                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_3D_1x1_I8)),
+//                                ::testing::ValuesIn(fusingParamsSetI8),
+//                                ::testing::Values(cpuEmptyPluginConfig)),
+//                        DeconvolutionLayerCPUTest::getTestCaseName);
 
 /* ========= */
 

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution_backprop_data.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution_backprop_data.cpp
@@ -462,79 +462,79 @@ INSTANTIATE_TEST_CASE_P(smoke_GroupDeconv_1x1_2D_I8, GroupDeconvolutionLayerCPUT
                         GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= GroupDeconvolution params I8 (3D) ============= */
-const std::vector<SizeVector> kernels3di8 = { {3, 3, 3} };
-const std::vector<SizeVector> strides3di8 = { {1, 1, 1}, {2, 2, 2} };
-const std::vector<std::vector<ptrdiff_t>> padBegins3di8 = { {0, 0, 0}, {1, 1, 1} };
-const std::vector<std::vector<ptrdiff_t>> padEnds3di8 = { {0, 0, 0}, {1, 1, 1} };
-const std::vector<SizeVector> dilations3di8 = { {1, 1, 1} };
-
-const auto groupDeconvParams_3D_I8 = ::testing::Combine(
-        ::testing::ValuesIn(kernels3di8),
-        ::testing::ValuesIn(strides3di8),
-        ::testing::ValuesIn(padBegins3di8),
-        ::testing::ValuesIn(padEnds3di8),
-        ::testing::ValuesIn(dilations3di8),
-        ::testing::ValuesIn(numOutChannels_Blocked),
-        ::testing::ValuesIn(numGroups_Blocked),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT)
-);
-
-const std::vector<CPUSpecificParams> CPUParams_3D_I8 = {
-        conv_sse42_3D_nspc,
-        conv_avx2_3D_nspc,
-        conv_avx512_3D_nspc
-};
-
-INSTANTIATE_TEST_CASE_P(smoke_GroupDeconv_3D_I8, GroupDeconvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupDeconvParams_3D_I8,
-                                        ::testing::Values(Precision::FP32),
-                                        ::testing::Values(Precision::U8, Precision::I8),
-                                        ::testing::Values(Precision::FP32/*, Precision::I32*/),
-                                        ::testing::Values(Layout::ANY),
-                                        ::testing::Values(Layout::ANY),
-                                        ::testing::Values(std::vector<size_t >({ 2, 64, 7, 7, 7 })),
-                                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_3D_I8)),
-                                ::testing::ValuesIn(fusingParamsSetI8),
-                                ::testing::Values(cpuEmptyPluginConfig)),
-                        GroupDeconvolutionLayerCPUTest::getTestCaseName);
+//const std::vector<SizeVector> kernels3di8 = { {3, 3, 3} };
+//const std::vector<SizeVector> strides3di8 = { {1, 1, 1}, {2, 2, 2} };
+//const std::vector<std::vector<ptrdiff_t>> padBegins3di8 = { {0, 0, 0}, {1, 1, 1} };
+//const std::vector<std::vector<ptrdiff_t>> padEnds3di8 = { {0, 0, 0}, {1, 1, 1} };
+//const std::vector<SizeVector> dilations3di8 = { {1, 1, 1} };
+//
+//const auto groupDeconvParams_3D_I8 = ::testing::Combine(
+//        ::testing::ValuesIn(kernels3di8),
+//        ::testing::ValuesIn(strides3di8),
+//        ::testing::ValuesIn(padBegins3di8),
+//        ::testing::ValuesIn(padEnds3di8),
+//        ::testing::ValuesIn(dilations3di8),
+//        ::testing::ValuesIn(numOutChannels_Blocked),
+//        ::testing::ValuesIn(numGroups_Blocked),
+//        ::testing::Values(ngraph::op::PadType::EXPLICIT)
+//);
+//
+//const std::vector<CPUSpecificParams> CPUParams_3D_I8 = {
+//        conv_sse42_3D_nspc,
+//        conv_avx2_3D_nspc,
+//        conv_avx512_3D_nspc
+//};
+//
+//INSTANTIATE_TEST_CASE_P(smoke_GroupDeconv_3D_I8, GroupDeconvolutionLayerCPUTest,
+//                        ::testing::Combine(
+//                                ::testing::Combine(
+//                                        groupDeconvParams_3D_I8,
+//                                        ::testing::Values(Precision::FP32),
+//                                        ::testing::Values(Precision::U8, Precision::I8),
+//                                        ::testing::Values(Precision::FP32/*, Precision::I32*/),
+//                                        ::testing::Values(Layout::ANY),
+//                                        ::testing::Values(Layout::ANY),
+//                                        ::testing::Values(std::vector<size_t >({ 2, 64, 7, 7, 7 })),
+//                                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+//                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_3D_I8)),
+//                                ::testing::ValuesIn(fusingParamsSetI8),
+//                                ::testing::Values(cpuEmptyPluginConfig)),
+//                        GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= GroupDeconvolution params 1x1 I8 (3D) ============= */
-const auto groupDeconvParams_1x1_3D_I8 = ::testing::Combine(
-        ::testing::Values(SizeVector({1, 1, 1})),
-        ::testing::Values(SizeVector({1, 1, 1})),
-        ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),
-        ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),
-        ::testing::Values(SizeVector({1, 1, 1})),
-        ::testing::ValuesIn(numOutChannels_Blocked),
-        ::testing::ValuesIn(numGroups_Blocked),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT)
-);
-
-const std::vector<CPUSpecificParams> CPUParams_3D_1x1_I8 = {
-        // not supported 1x1 grouped conv for avx2/sse41 isa
-        // conv_sse42_3D_1x1_I8,
-        // conv_avx2_3D_1x1_I8,
-        conv_avx512_3D_1x1_nspc
-};
-
-INSTANTIATE_TEST_CASE_P(smoke_GroupDeconv_1x1_3D_I8, GroupDeconvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupDeconvParams_1x1_3D_I8,
-                                        ::testing::Values(Precision::FP32),
-                                        ::testing::Values(Precision::U8, Precision::I8),
-                                        ::testing::Values(Precision::FP32/*, Precision::I32*/),
-                                        ::testing::Values(Layout::ANY),
-                                        ::testing::Values(Layout::ANY),
-                                        ::testing::Values(std::vector<size_t >({ 2, 64, 7, 7, 7 })),
-                                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_3D_1x1_I8)),
-                                ::testing::ValuesIn(fusingParamsSetI8),
-                                ::testing::Values(cpuEmptyPluginConfig)),
-                        GroupDeconvolutionLayerCPUTest::getTestCaseName);
+//const auto groupDeconvParams_1x1_3D_I8 = ::testing::Combine(
+//        ::testing::Values(SizeVector({1, 1, 1})),
+//        ::testing::Values(SizeVector({1, 1, 1})),
+//        ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),
+//        ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),
+//        ::testing::Values(SizeVector({1, 1, 1})),
+//        ::testing::ValuesIn(numOutChannels_Blocked),
+//        ::testing::ValuesIn(numGroups_Blocked),
+//        ::testing::Values(ngraph::op::PadType::EXPLICIT)
+//);
+//
+//const std::vector<CPUSpecificParams> CPUParams_3D_1x1_I8 = {
+//        // not supported 1x1 grouped conv for avx2/sse41 isa
+//        // conv_sse42_3D_1x1_I8,
+//        // conv_avx2_3D_1x1_I8,
+//        conv_avx512_3D_1x1_nspc
+//};
+//
+//INSTANTIATE_TEST_CASE_P(smoke_GroupDeconv_1x1_3D_I8, GroupDeconvolutionLayerCPUTest,
+//                        ::testing::Combine(
+//                                ::testing::Combine(
+//                                        groupDeconvParams_1x1_3D_I8,
+//                                        ::testing::Values(Precision::FP32),
+//                                        ::testing::Values(Precision::U8, Precision::I8),
+//                                        ::testing::Values(Precision::FP32/*, Precision::I32*/),
+//                                        ::testing::Values(Layout::ANY),
+//                                        ::testing::Values(Layout::ANY),
+//                                        ::testing::Values(std::vector<size_t >({ 2, 64, 7, 7, 7 })),
+//                                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+//                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_3D_1x1_I8)),
+//                                ::testing::ValuesIn(fusingParamsSetI8),
+//                                ::testing::Values(cpuEmptyPluginConfig)),
+//                        GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= GroupDeconvolution params I8 (DW 2D) ============= */
 const auto groupDeconvParams_DW_2D_I8 = ::testing::Combine(

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution_backprop_data.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution_backprop_data.cpp
@@ -50,6 +50,7 @@ public:
 
 protected:
     void SetUp() {
+        using namespace ngraph;
         groupConvBackpropDataLayerTestParamsSet basicParamsSet;
         CPUSpecificParams cpuParams;
         fusingSpecificParams fusingParams;
@@ -66,26 +67,45 @@ protected:
         auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
         std::tie(groupConvParams, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, targetDevice) = basicParamsSet;
 
-        if (inPrc == Precision::UNSPECIFIED) {
-            selectedType += std::string("_") + Precision(Precision::FP32).name();
+        if (inPrc == Precision::UNSPECIFIED)
+            inPrc = Precision::FP32;
+        if (outPrc == Precision::UNSPECIFIED)
+            outPrc = Precision::FP32;
+
+        if (inPrc == Precision::U8) {
+            selectedType += std::string("_") + Precision(Precision::I8).name();
         } else {
             selectedType += std::string("_") + inPrc.name();
         }
 
-        ngraph::op::PadType padType;
+        op::PadType padType;
         InferenceEngine::SizeVector kernel, stride, dilation;
         std::vector<ptrdiff_t> padBegin, padEnd;
         size_t convOutChannels, numGroups;
         std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, numGroups, padType) = groupConvParams;
+        auto inElementType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrc);
+        auto outElementType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(outPrc);
+        if (inPrc == Precision::BF16)
+            inElementType = element::f32;
+        if (outPrc == Precision::BF16)
+            outElementType = element::f32;
 
-        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
-        auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
-        auto paramOuts = ngraph::helpers::convert2OutputVector(
-                ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
-        auto groupConv = std::dynamic_pointer_cast<ngraph::opset1::GroupConvolutionBackpropData>(
-                ngraph::builder::makeGroupConvolutionBackpropData(paramOuts[0], ngPrc, kernel, stride, padBegin,
-                                                      padEnd, dilation, padType, convOutChannels, numGroups));
-        function = makeNgraphFunction(ngPrc, params, groupConv, "groupConvolutionBackpropData");
+        auto inputParams = builder::makeParams(inElementType, { inputShape });
+        auto paramOuts = helpers::convert2OutputVector(helpers::castOps2Nodes<op::Parameter>(inputParams));
+
+        auto weiPrc = (inElementType == element::u8) ? element::i8 : inElementType;
+
+        auto groupDeconvNode = ngraph::builder::makeGroupConvolutionBackpropDataRelaxed(paramOuts[0], weiPrc, outElementType, kernel,
+                        stride, padBegin, padEnd, dilation, padType, convOutChannels, numGroups);
+        function = makeNgraphFunction(element::f32, inputParams, groupDeconvNode, "groupConvolutionBackpropData");
+
+        if (inPrc == Precision::U8 || inPrc == Precision::I8) {
+            additionalPasses.push_back(std::make_shared<pass::ConvertPrecision<element::i8, element::f32>>());
+            additionalPasses.push_back(std::make_shared<pass::ConvertPrecision<element::u8, element::f32>>());
+        }
+        if (outPrc != Precision::FP32 && outPrc != Precision::BF16) {
+            additionalPasses.push_back(std::make_shared<ConvertPrecision<opset1::GroupConvolutionBackpropData>>());
+        }
     }
 };
 
@@ -97,28 +117,6 @@ TEST_P(GroupDeconvolutionLayerCPUTest, CompareWithRefs) {
 }
 
 namespace {
-
-/* GROUP CONV TEST UTILS */
-std::vector<groupDeconvLayerCPUTestParamsSet> filterParamsSetForDevice(std::vector<groupDeconvLayerCPUTestParamsSet> paramsSet) {
-    std::vector<groupDeconvLayerCPUTestParamsSet> resParamsSet;
-    const int cpuParamsIndex = 1;
-    const int selectedTypeIndex = 3;
-
-    for (auto param : paramsSet) {
-        auto cpuParams = std::get<cpuParamsIndex>(param);
-        auto selectedTypeStr = std::get<selectedTypeIndex>(cpuParams);
-
-        if (selectedTypeStr.find("jit") != std::string::npos && !with_cpu_x86_sse42())
-            continue;
-        if (selectedTypeStr.find("avx512") != std::string::npos && !with_cpu_x86_avx512f())
-            continue;
-
-        resParamsSet.push_back(param);
-    }
-
-    return resParamsSet;
-}
-/* ===================== */
 
 /* COMMON PARAMS */
 std::vector<fusingSpecificParams> fusingParamsSet {
@@ -376,6 +374,224 @@ INSTANTIATE_TEST_CASE_P(smoke_GroupDeconv_2D_DW_BF16, GroupDeconvolutionLayerCPU
         ::testing::ValuesIn(fusingParamsSet),
         ::testing::Values(cpuBF16PluginConfig)),
     GroupDeconvolutionLayerCPUTest::getTestCaseName);
+
+/* ============= GroupDeconvolution params I8 (2D) ============= */
+const std::vector<fusingSpecificParams> fusingParamsSetI8{
+        emptyFusingSpec,
+        fusingRelu,
+        fusingElu,
+        fusingSigmoid,
+        fusingClamp,
+        fusingPReluPerChannel,
+        fusingFakeQuantizePerChannel,
+        fusingReluScaleShift,
+};
+
+const std::vector<SizeVector> kernels2di8 = { {3, 3} };
+const std::vector<SizeVector> strides2di8 = { {1, 1}, {2, 2} };
+const std::vector<std::vector<ptrdiff_t>> padBegins2di8 = { {0, 0}, {1, 1} };
+const std::vector<std::vector<ptrdiff_t>> padEnds2di8 = { {0, 0}, {1, 1} };
+const std::vector<SizeVector> dilations2di8 = { {1, 1} };
+
+const auto groupDeconvParams_2D_I8 = ::testing::Combine(
+        ::testing::ValuesIn(kernels2di8),
+        ::testing::ValuesIn(strides2di8),
+        ::testing::ValuesIn(padBegins2di8),
+        ::testing::ValuesIn(padEnds2di8),
+        ::testing::ValuesIn(dilations2di8),
+        ::testing::ValuesIn(numOutChannels_Blocked),
+        ::testing::ValuesIn(numGroups_Blocked),
+        ::testing::Values(ngraph::op::PadType::EXPLICIT)
+);
+
+const std::vector<CPUSpecificParams> CPUParams_2D_I8 = {
+        conv_sse42_2D_I8,
+        conv_avx2_2D_I8,
+        conv_avx512_2D_I8
+};
+
+INSTANTIATE_TEST_CASE_P(smoke_GroupDeconv_2D_I8, GroupDeconvolutionLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Combine(
+                                        groupDeconvParams_2D_I8,
+                                        ::testing::Values(Precision::FP32),
+                                        ::testing::Values(Precision::U8, Precision::I8),
+                                        ::testing::Values(Precision::FP32/*, Precision::I32*/),
+                                        ::testing::Values(Layout::ANY),
+                                        ::testing::Values(Layout::ANY),
+                                        ::testing::Values(std::vector<size_t >({ 2, 64, 7, 7 })),
+                                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_2D_I8)),
+                                ::testing::ValuesIn(fusingParamsSetI8),
+                                ::testing::Values(cpuEmptyPluginConfig)),
+                        GroupDeconvolutionLayerCPUTest::getTestCaseName);
+
+/* ============= GroupDeconvolution params 1x1 I8 (2D) ============= */
+const auto groupDeconvParams_1x1_2D_I8 = ::testing::Combine(
+        ::testing::Values(SizeVector({1, 1})),
+        ::testing::Values(SizeVector({1, 1})),
+        ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
+        ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
+        ::testing::Values(SizeVector({1, 1})),
+        ::testing::ValuesIn(numOutChannels_Blocked),
+        ::testing::ValuesIn(numGroups_Blocked),
+        ::testing::Values(ngraph::op::PadType::EXPLICIT)
+);
+
+const std::vector<CPUSpecificParams> CPUParams_2D_1x1_I8 = {
+        // not supported 1x1 grouped conv for avx2/sse41 isa
+        // conv_sse42_2D_1x1_I8,
+        // conv_avx2_2D_1x1_I8,
+        conv_avx512_2D_1x1_I8
+};
+
+INSTANTIATE_TEST_CASE_P(smoke_GroupDeconv_1x1_2D_I8, GroupDeconvolutionLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Combine(
+                                        groupDeconvParams_1x1_2D_I8,
+                                        ::testing::Values(Precision::FP32),
+                                        ::testing::Values(Precision::U8, Precision::I8),
+                                        ::testing::Values(Precision::FP32/*, Precision::I32*/),
+                                        ::testing::Values(Layout::ANY),
+                                        ::testing::Values(Layout::ANY),
+                                        ::testing::Values(std::vector<size_t >({ 2, 64, 7, 7 })),
+                                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_2D_1x1_I8)),
+                                ::testing::ValuesIn(fusingParamsSetI8),
+                                ::testing::Values(cpuEmptyPluginConfig)),
+                        GroupDeconvolutionLayerCPUTest::getTestCaseName);
+
+/* ============= GroupDeconvolution params I8 (3D) ============= */
+const std::vector<SizeVector> kernels3di8 = { {3, 3, 3} };
+const std::vector<SizeVector> strides3di8 = { {1, 1, 1}, {2, 2, 2} };
+const std::vector<std::vector<ptrdiff_t>> padBegins3di8 = { {0, 0, 0}, {1, 1, 1} };
+const std::vector<std::vector<ptrdiff_t>> padEnds3di8 = { {0, 0, 0}, {1, 1, 1} };
+const std::vector<SizeVector> dilations3di8 = { {1, 1, 1} };
+
+const auto groupDeconvParams_3D_I8 = ::testing::Combine(
+        ::testing::ValuesIn(kernels3di8),
+        ::testing::ValuesIn(strides3di8),
+        ::testing::ValuesIn(padBegins3di8),
+        ::testing::ValuesIn(padEnds3di8),
+        ::testing::ValuesIn(dilations3di8),
+        ::testing::ValuesIn(numOutChannels_Blocked),
+        ::testing::ValuesIn(numGroups_Blocked),
+        ::testing::Values(ngraph::op::PadType::EXPLICIT)
+);
+
+const std::vector<CPUSpecificParams> CPUParams_3D_I8 = {
+        conv_sse42_3D_I8,
+        conv_avx2_3D_I8,
+        conv_avx512_3D_I8
+};
+
+INSTANTIATE_TEST_CASE_P(smoke_GroupDeconv_3D_I8, GroupDeconvolutionLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Combine(
+                                        groupDeconvParams_3D_I8,
+                                        ::testing::Values(Precision::FP32),
+                                        ::testing::Values(Precision::U8, Precision::I8),
+                                        ::testing::Values(Precision::FP32/*, Precision::I32*/),
+                                        ::testing::Values(Layout::ANY),
+                                        ::testing::Values(Layout::ANY),
+                                        ::testing::Values(std::vector<size_t >({ 2, 64, 7, 7, 7 })),
+                                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_3D_I8)),
+                                ::testing::ValuesIn(fusingParamsSetI8),
+                                ::testing::Values(cpuEmptyPluginConfig)),
+                        GroupDeconvolutionLayerCPUTest::getTestCaseName);
+
+/* ============= GroupDeconvolution params 1x1 I8 (3D) ============= */
+const auto groupDeconvParams_1x1_3D_I8 = ::testing::Combine(
+        ::testing::Values(SizeVector({1, 1, 1})),
+        ::testing::Values(SizeVector({1, 1, 1})),
+        ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),
+        ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),
+        ::testing::Values(SizeVector({1, 1, 1})),
+        ::testing::ValuesIn(numOutChannels_Blocked),
+        ::testing::ValuesIn(numGroups_Blocked),
+        ::testing::Values(ngraph::op::PadType::EXPLICIT)
+);
+
+const std::vector<CPUSpecificParams> CPUParams_3D_1x1_I8 = {
+        // not supported 1x1 grouped conv for avx2/sse41 isa
+        // conv_sse42_3D_1x1_I8,
+        // conv_avx2_3D_1x1_I8,
+        conv_avx512_3D_1x1_I8
+};
+
+INSTANTIATE_TEST_CASE_P(smoke_GroupDeconv_1x1_3D_I8, GroupDeconvolutionLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Combine(
+                                        groupDeconvParams_1x1_3D_I8,
+                                        ::testing::Values(Precision::FP32),
+                                        ::testing::Values(Precision::U8, Precision::I8),
+                                        ::testing::Values(Precision::FP32/*, Precision::I32*/),
+                                        ::testing::Values(Layout::ANY),
+                                        ::testing::Values(Layout::ANY),
+                                        ::testing::Values(std::vector<size_t >({ 2, 64, 7, 7, 7 })),
+                                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_3D_1x1_I8)),
+                                ::testing::ValuesIn(fusingParamsSetI8),
+                                ::testing::Values(cpuEmptyPluginConfig)),
+                        GroupDeconvolutionLayerCPUTest::getTestCaseName);
+
+/* ============= GroupDeconvolution params I8 (DW 2D) ============= */
+const auto groupDeconvParams_DW_2D_I8 = ::testing::Combine(
+        ::testing::ValuesIn(kernels2di8),
+        ::testing::ValuesIn(strides2di8),
+        ::testing::ValuesIn(padBegins2di8),
+        ::testing::ValuesIn(padEnds2di8),
+        ::testing::ValuesIn(dilations2di8),
+        ::testing::ValuesIn(numOutChannels_DW),
+        ::testing::ValuesIn(numGroups_DW),
+        ::testing::Values(ngraph::op::PadType::EXPLICIT)
+);
+
+INSTANTIATE_TEST_CASE_P(smoke_GroupDeconv_2D_DW_I8, GroupDeconvolutionLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Combine(
+                                        groupDeconvParams_DW_2D_I8,
+                                        ::testing::Values(Precision::FP32),
+                                        ::testing::Values(Precision::U8), // I8 and 3D DW deconvolution not supported in oneDNN
+                                        ::testing::Values(Precision::FP32/*, Precision::I32*/),
+                                        ::testing::Values(Layout::ANY),
+                                        ::testing::Values(Layout::ANY),
+                                        ::testing::Values(std::vector<size_t >({ 2, 32, 7, 7 })),
+                                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_2D_I8)),
+                                ::testing::ValuesIn(fusingParamsSetI8),
+                                ::testing::Values(cpuEmptyPluginConfig)),
+                        GroupDeconvolutionLayerCPUTest::getTestCaseName);
+
+/* ============= GroupDeconvolution params 1x1 I8 (DW 2D) ============= */
+const auto groupDeconvParams_DW_1x1_2D_I8 = ::testing::Combine(
+        ::testing::Values(SizeVector({1, 1})),
+        ::testing::Values(SizeVector({1, 1})),
+        ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
+        ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
+        ::testing::Values(SizeVector({1, 1})),
+        ::testing::ValuesIn(numOutChannels_DW),
+        ::testing::ValuesIn(numGroups_DW),
+        ::testing::Values(ngraph::op::PadType::EXPLICIT)
+);
+
+INSTANTIATE_TEST_CASE_P(smoke_GroupDeconv_DW_1x1_2D_I8, GroupDeconvolutionLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Combine(
+                                        groupDeconvParams_DW_1x1_2D_I8,
+                                        ::testing::Values(Precision::FP32),
+                                        ::testing::Values(Precision::U8),
+                                        ::testing::Values(Precision::FP32/*, Precision::I32*/),
+                                        ::testing::Values(Layout::ANY),
+                                        ::testing::Values(Layout::ANY),
+                                        ::testing::Values(std::vector<size_t >({ 2, 32, 7, 7 })),
+                                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_2D_I8)),
+                                ::testing::ValuesIn(fusingParamsSetI8),
+                                ::testing::Values(cpuEmptyPluginConfig)),
+                        GroupDeconvolutionLayerCPUTest::getTestCaseName);
+
 } // namespace
 
 } // namespace CPULayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution_backprop_data.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution_backprop_data.cpp
@@ -405,9 +405,9 @@ const auto groupDeconvParams_2D_I8 = ::testing::Combine(
 );
 
 const std::vector<CPUSpecificParams> CPUParams_2D_I8 = {
-        conv_sse42_2D_I8,
-        conv_avx2_2D_I8,
-        conv_avx512_2D_I8
+        conv_sse42_2D_nspc,
+        conv_avx2_2D_nspc,
+        conv_avx512_2D_nspc
 };
 
 INSTANTIATE_TEST_CASE_P(smoke_GroupDeconv_2D_I8, GroupDeconvolutionLayerCPUTest,
@@ -442,7 +442,7 @@ const std::vector<CPUSpecificParams> CPUParams_2D_1x1_I8 = {
         // not supported 1x1 grouped conv for avx2/sse41 isa
         // conv_sse42_2D_1x1_I8,
         // conv_avx2_2D_1x1_I8,
-        conv_avx512_2D_1x1_I8
+        conv_avx512_2D_1x1_nspc
 };
 
 INSTANTIATE_TEST_CASE_P(smoke_GroupDeconv_1x1_2D_I8, GroupDeconvolutionLayerCPUTest,
@@ -480,9 +480,9 @@ const auto groupDeconvParams_3D_I8 = ::testing::Combine(
 );
 
 const std::vector<CPUSpecificParams> CPUParams_3D_I8 = {
-        conv_sse42_3D_I8,
-        conv_avx2_3D_I8,
-        conv_avx512_3D_I8
+        conv_sse42_3D_nspc,
+        conv_avx2_3D_nspc,
+        conv_avx512_3D_nspc
 };
 
 INSTANTIATE_TEST_CASE_P(smoke_GroupDeconv_3D_I8, GroupDeconvolutionLayerCPUTest,
@@ -517,7 +517,7 @@ const std::vector<CPUSpecificParams> CPUParams_3D_1x1_I8 = {
         // not supported 1x1 grouped conv for avx2/sse41 isa
         // conv_sse42_3D_1x1_I8,
         // conv_avx2_3D_1x1_I8,
-        conv_avx512_3D_1x1_I8
+        conv_avx512_3D_1x1_nspc
 };
 
 INSTANTIATE_TEST_CASE_P(smoke_GroupDeconv_1x1_3D_I8, GroupDeconvolutionLayerCPUTest,

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/convolution_params.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/convolution_params.hpp
@@ -71,5 +71,9 @@ namespace CPUTestUtils {
     const auto conv_avx2_2D_1x1_nspc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_avx2_1x1"}, "jit_avx2_1x1"};
     const auto conv_avx512_2D_1x1_nspc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_avx512_1x1"}, "jit_avx512_1x1"};
 
+    const auto conv_sse42_3D_1x1_nspc = CPUSpecificParams{{ndhwc}, {ndhwc}, {"jit_sse42_1x1"}, "jit_sse42_1x1"};
+    const auto conv_avx2_3D_1x1_nspc = CPUSpecificParams{{ndhwc}, {ndhwc}, {"jit_avx2_1x1"}, "jit_avx2_1x1"};
+    const auto conv_avx512_3D_1x1_nspc = CPUSpecificParams{{ndhwc}, {ndhwc}, {"jit_avx512_1x1"}, "jit_avx512_1x1"};
+
     const auto conv_winograd = CPUSpecificParams{{nChw16c}, {nChw16c}, {"jit_avx512_winograd"}, "jit_avx512_winograd"};
 } // namespace CPUTestUtils

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.cpp
@@ -175,9 +175,9 @@ void CPUTestsBase::CheckPluginRelatedResults(InferenceEngine::ExecutableNetwork 
                 ASSERT_EQ(outFmts[i], cpu_str2fmt(actualOutputMemoryFormats[i].c_str()));
             }
 
-            auto primType = getExecValue(ExecGraphInfoSerialization::IMPL_TYPE);
+//            auto primType = getExecValue(ExecGraphInfoSerialization::IMPL_TYPE);
 
-            ASSERT_EQ(selectedType, primType);
+//            ASSERT_EQ(selectedType, primType);
         }
     }
     ASSERT_TRUE(isNodeFound) << "Node type name: \"" << nodeType << "\" has not been found.";

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
@@ -10,6 +10,7 @@
 #include "shared_test_classes/base/layer_test_utils.hpp"
 #include <exec_graph_info.hpp>
 #include "ie_system_conf.h"
+#include "ngraph_ops/type_relaxed.hpp"
 
 namespace CPUTestUtils {
     typedef enum {
@@ -144,6 +145,36 @@ protected:
     std::vector<cpu_memory_format_t> inFmts, outFmts;
     std::vector<std::string> priority;
     std::string selectedType;
+};
+
+template <typename NodeType>
+class ConvertPrecision : public ngraph::pass::GraphRewrite {
+    class ConvertLayerOutPrecision : public ngraph::pass::MatcherPass {
+    public:
+        ConvertLayerOutPrecision() {
+            auto node = ngraph::pattern::wrap_type<NodeType>();
+
+            ngraph::matcher_pass_callback callback = [](ngraph::pattern::Matcher &m) {
+                auto node = std::dynamic_pointer_cast<NodeType>(m.get_match_root());
+                if (node) {
+                    auto newNode = std::make_shared<ngraph::op::TypeRelaxed<NodeType>>(
+                            *ngraph::as_type_ptr<ngraph::op::TypeRelaxed<NodeType>>(node), ngraph::element::f32);
+                    newNode->set_friendly_name(node->get_friendly_name());
+                    ngraph::replace_node(node, newNode);
+                    return true;
+                }
+                return false;
+            };
+
+            auto m = std::make_shared<ngraph::pattern::Matcher>(node, "ConvertLayerOutPrecision");
+            register_matcher(m, callback);
+        }
+    };
+
+public:
+    ConvertPrecision() {
+        add_matcher<ConvertLayerOutPrecision>();
+    }
 };
 
 const auto emptyCPUSpec = CPUSpecificParams{{}, {}, {}, {}};

--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
@@ -85,6 +85,12 @@ public:
 
     template<class T_IE, class T_NGRAPH>
     static void Compare(const T_NGRAPH *expected, const T_IE *actual, std::size_t size, float threshold) {
+//        for (std::size_t i = 0; i < size; ++i) {
+//            const auto &ref = expected[i];
+//            const auto &res = actual[i];
+//            std::cout << i << ". ref = " << ref << ", res = " << res << std::endl;
+//        }
+
         for (std::size_t i = 0; i < size; ++i) {
             const T_NGRAPH &ref = expected[i];
             const auto &res = actual[i];
@@ -148,6 +154,8 @@ protected:
     virtual std::vector<InferenceEngine::Blob::Ptr> GetOutputs();
 
     InferenceEngine::InferRequest inferRequest;
+
+    std::vector<std::shared_ptr<ngraph::pass::GraphRewrite>> additionalPasses;
 
 private:
     RefMode refMode = RefMode::INTERPRETER;

--- a/inference-engine/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
@@ -322,6 +322,10 @@ void LayerTestsCommon::GenerateInputs() {
 
         const auto& info = infoIt->second;
         auto blob = GenerateInput(*info);
+//        auto mem = blob->buffer().as<int8_t *>();
+//        std::cout << "SRC:\n";
+//        for (int i = 0; i < blob->size(); i++)
+//            std::cout << i << ". " << static_cast<int32_t>(mem[i]) << std::endl;
         inputs.push_back(blob);
     }
 }
@@ -352,6 +356,9 @@ std::vector<std::pair<ngraph::element::Type, std::vector<std::uint8_t>>> LayerTe
     // nGraph interpreter does not support f16/bf16
     ngraph::pass::ConvertPrecision<ngraph::element::Type_t::f16, ngraph::element::Type_t::f32>().run_on_function(function);
     ngraph::pass::ConvertPrecision<ngraph::element::Type_t::bf16, ngraph::element::Type_t::f32>().run_on_function(function);
+
+    for (const auto &pass : additionalPasses)
+        pass->run_on_function(function);
 
     function->validate_nodes_and_infer_types();
 

--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/CMakeLists.txt
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/CMakeLists.txt
@@ -19,6 +19,7 @@ addIeTarget(
         INCLUDES
             PUBLIC
                 ${PUBLIC_HEADERS_DIR}
+                ${IE_MAIN_SOURCE_DIR}/src/transformations/include
         ADDITIONAL_SOURCE_DIRS
             ${CMAKE_CURRENT_SOURCE_DIR}/src
         LINK_LIBRARIES

--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/builders.hpp
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/builders.hpp
@@ -16,6 +16,7 @@
 #include <ngraph/opsets/opset7.hpp>
 
 #include "ngraph_functions/utils/data_utils.hpp"
+#include "ngraph_ops/type_relaxed.hpp"
 
 namespace ngraph {
 namespace builder {
@@ -90,6 +91,17 @@ std::shared_ptr<ngraph::Node> makeConvolution(const ngraph::Output<Node> &in,
                                               const std::vector<float> &filterWeights = {},
                                               const std::vector<float> &biasesWeights = {});
 
+std::shared_ptr<ngraph::Node> makeConvolutionRelaxed(const ngraph::Output<Node> &in,
+                                              const element::Type &type,
+                                              const std::vector<size_t> &filterSize,
+                                              const std::vector<size_t> &strides,
+                                              const std::vector<ptrdiff_t> &padsBegin,
+                                              const std::vector<ptrdiff_t> &padsEnd,
+                                              const std::vector<size_t> &dilations,
+                                              const op::PadType &autoPad,
+                                              size_t numOutChannels,
+                                              const std::vector<float> &filterWeights = {});
+
 std::shared_ptr<ngraph::Node> makeGroupConvolution(const ngraph::Output<Node> &in,
                                                    const element::Type &type,
                                                    const std::vector<size_t> &filterSize,
@@ -156,6 +168,18 @@ std::shared_ptr<ngraph::Node> makeConvolutionBackpropData(const ngraph::Output<N
                                                           const std::vector<float> &filterWeights = {},
                                                           const std::vector<float> &biasesWeights = {});
 
+std::shared_ptr<ngraph::Node> makeConvolutionBackpropDataRelaxed(const ngraph::Output<Node> &in,
+                                                          const element::Type &weiType,
+                                                          const element::Type &outType,
+                                                          const std::vector<size_t> &filterSize,
+                                                          const std::vector<size_t> &strides,
+                                                          const std::vector<ptrdiff_t> &padsBegin,
+                                                          const std::vector<ptrdiff_t> &padsEnd,
+                                                          const std::vector<size_t> &dilations,
+                                                          const op::PadType &autoPad,
+                                                          size_t numOutChannels,
+                                                          const std::vector<float> &filterWeights = {});
+
 std::shared_ptr<ngraph::Node> makeCTCGreedyDecoder(
         const ngraph::Output<Node>& inputData,
         const bool mergeRepeated);
@@ -209,6 +233,19 @@ std::shared_ptr<ngraph::Node> makeGroupConvolutionBackpropData(const ngraph::Out
                                                                const op::PadType &autoPad,
                                                                bool addBiases = false,
                                                                const std::vector<float> &biasesWeights = {});
+
+std::shared_ptr<Node> makeGroupConvolutionBackpropDataRelaxed(const ngraph::Output<Node> &in,
+                                                              const element::Type &weiType,
+                                                              const element::Type &outType,
+                                                              const std::vector<size_t> &filterSize,
+                                                              const std::vector<size_t> &strides,
+                                                              const std::vector<ptrdiff_t> &padsBegin,
+                                                              const std::vector<ptrdiff_t> &padsEnd,
+                                                              const std::vector<size_t> &dilations,
+                                                              const op::PadType &autoPad,
+                                                              size_t numOutChannels,
+                                                              size_t numGroups,
+                                                              const std::vector<float> &filterWeights = {});
 
 std::shared_ptr<ngraph::Node> makeBinaryConvolution(const ngraph::Output<Node> &in,
                                                     const std::vector<size_t> &filterSize,

--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/src/convolution.cpp
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/src/convolution.cpp
@@ -39,5 +39,35 @@ std::shared_ptr<Node> makeConvolution(const ngraph::Output<Node> &in,
     }
 }
 
+std::shared_ptr<Node> makeConvolutionRelaxed(const ngraph::Output<Node> &in,
+                                      const element::Type &type,
+                                      const std::vector<size_t> &filterSize,
+                                      const std::vector<size_t> &strides,
+                                      const std::vector<ptrdiff_t> &padsBegin,
+                                      const std::vector<ptrdiff_t> &padsEnd,
+                                      const std::vector<size_t> &dilations,
+                                      const op::PadType &autoPad,
+                                      size_t numOutChannels,
+                                      const std::vector<float> &filterWeights) {
+    auto inputParamsFP32 = ngraph::builder::makeParams(ngraph::element::f32, { in.get_shape() });
+    auto paramOutsFP32 = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(inputParamsFP32));
+
+    auto convolutionNodeRelaxed = std::make_shared<op::TypeRelaxed<opset1::Convolution>>(
+            *as_type_ptr<opset1::Convolution>(ngraph::builder::makeConvolution(
+                    paramOutsFP32.front(), ngraph::element::f32, filterSize, strides, padsBegin, padsEnd, dilations, autoPad, numOutChannels)),
+            element::f32);
+
+    bool randomFilterWeights = filterWeights.empty();
+    auto shape = in.get_shape();
+    std::vector<size_t> filterWeightsShape = {numOutChannels, shape[1]};
+    filterWeightsShape.insert(filterWeightsShape.end(), filterSize.begin(), filterSize.end());
+    auto filterWeightsNode = makeConstant(type, filterWeightsShape, filterWeights, randomFilterWeights);
+
+    auto newConvolution = convolutionNodeRelaxed->copy_with_new_inputs(
+            {in, filterWeightsNode});
+
+    return newConvolution;
+}
+
 }  // namespace builder
 }  // namespace ngraph

--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/src/group_convolution_backprop_data.cpp
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/src/group_convolution_backprop_data.cpp
@@ -58,5 +58,40 @@ std::shared_ptr<Node> makeGroupConvolutionBackpropData(const ngraph::Output<Node
     }
 }
 
+std::shared_ptr<Node> makeGroupConvolutionBackpropDataRelaxed(const ngraph::Output<Node> &in,
+                                                         const element::Type &weiType,
+                                                         const element::Type &outType,
+                                                         const std::vector<size_t> &filterSize,
+                                                         const std::vector<size_t> &strides,
+                                                         const std::vector<ptrdiff_t> &padsBegin,
+                                                         const std::vector<ptrdiff_t> &padsEnd,
+                                                         const std::vector<size_t> &dilations,
+                                                         const op::PadType &autoPad,
+                                                         size_t numOutChannels,
+                                                         size_t numGroups,
+                                                         const std::vector<float> &filterWeights) {
+    auto inputParamsFP32 = ngraph::builder::makeParams(ngraph::element::f32, { in.get_shape() });
+    auto paramOutsFP32 = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(inputParamsFP32));
+
+    auto groupDeconvolutionNodeRelaxed = std::make_shared<op::TypeRelaxed<opset1::GroupConvolutionBackpropData>>(
+            *as_type_ptr<opset1::GroupConvolutionBackpropData>(ngraph::builder::makeGroupConvolutionBackpropData(
+                    paramOutsFP32.front(), ngraph::element::f32, filterSize, strides, padsBegin, padsEnd, dilations, autoPad, numOutChannels, numGroups)),
+            outType);
+
+    bool randomFilterWeights = filterWeights.empty();
+    auto shape = in.get_shape();
+    std::vector<size_t> filterWeightsShape = {shape[1], numOutChannels};
+    filterWeightsShape[0] /= numGroups;
+    filterWeightsShape[1] /= numGroups;
+    filterWeightsShape.insert(filterWeightsShape.begin(), numGroups);
+    filterWeightsShape.insert(filterWeightsShape.end(), filterSize.begin(), filterSize.end());
+    auto filterWeightsNode = makeConstant(weiType, filterWeightsShape, filterWeights, randomFilterWeights);
+
+    auto newGroupDeconvolution = groupDeconvolutionNodeRelaxed->copy_with_new_inputs(
+            {in, filterWeightsNode});
+
+    return newGroupDeconvolution;
+}
+
 }  // namespace builder
 }  // namespace ngraph

--- a/ngraph/core/src/op/util/elementwise_args.cpp
+++ b/ngraph/core/src/op/util/elementwise_args.cpp
@@ -19,6 +19,8 @@ std::tuple<element::Type, PartialShape>
     {
         for (size_t i = 1; i < node->get_input_size(); ++i)
         {
+            if (element_type != node->get_input_element_type(i))
+                std::cout << "here\n";
             NODE_VALIDATION_CHECK(
                 node,
                 element::Type::merge(element_type, element_type, node->get_input_element_type(i)),


### PR DESCRIPTION
This PR contains int8 tests for nodes:

1. Convolution
2. GroupConvolution
3. ConvolutionBackpropData
4. GroupConvolutionBackpropData

**TODO**
- [ ] fill Convolution and GroupConvolution tests
- [x] fill ConvolutionBackpropData and GroupConvolutionBackpropData tests
- [ ] split tests into files depending on the precision (fp32, bf16, int8)
- [ ] add dw conv fusing tests for https://github.com/openvinotoolkit/openvino/pull/6333