### PR TITLE
Template plugin support in ONNX compliance tests

### DIFF
--- a/ngraph/python/tests/conftest.py
+++ b/ngraph/python/tests/conftest.py
@@ -17,7 +17,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--backend",
         default="CPU",
-        choices=["CPU", "GPU", "FPGA", "HDDL", "MYRIAD", "HETERO"],
+        choices=["CPU", "GPU", "FPGA", "HDDL", "MYRIAD", "HETERO", "TEMPLATE"],
         help="Select target device",
     )
     parser.addoption(
@@ -46,6 +46,7 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "skip_on_hddl: Skip test on HDDL")
     config.addinivalue_line("markers", "skip_on_myriad: Skip test on MYRIAD")
     config.addinivalue_line("markers", "skip_on_hetero: Skip test on HETERO")
+    config.addinivalue_line("markers", "skip_on_template: Skip test on TEMPLATE")
     config.addinivalue_line("markers", "onnx_coverage: Collect ONNX operator coverage")
 
 
@@ -61,6 +62,7 @@ def pytest_collection_modifyitems(config, items):
         "HDDL": "skip_on_hddl",
         "MYRIAD": "skip_on_myriad",
         "HETERO": "skip_on_hetero",
+        "TEMPLATE": "skip_on_template",
     }
 
     skip_markers = {
@@ -70,6 +72,7 @@ def pytest_collection_modifyitems(config, items):
         "HDDL": pytest.mark.skip(reason="Skipping test on the HDDL backend."),
         "MYRIAD": pytest.mark.skip(reason="Skipping test on the MYRIAD backend."),
         "HETERO": pytest.mark.skip(reason="Skipping test on the HETERO backend."),
+        "TEMPLATE": pytest.mark.skip(reason="Skipping test on the TEMPLATE backend."),
     }
 
     for item in items:


### PR DESCRIPTION
### Details:
 - TEMPLATE can now be used as a value of `--backend` switch of the `pytest` command
 - To be able to execute the tests via this plugin, 2 manual steps need to be taken (description in wiki)
