### PR TITLE
[nGraph] Add documentation strings

### DIFF
--- a/ngraph/python/src/pyngraph/axis_set.cpp
+++ b/ngraph/python/src/pyngraph/axis_set.cpp
@@ -18,10 +18,14 @@ void regclass_pyngraph_AxisSet(py::module m)
 {
     py::class_<ngraph::AxisSet, std::shared_ptr<ngraph::AxisSet>> axis_set(m, "AxisSet");
     axis_set.doc() = "ngraph.impl.AxisSet wraps ngraph::AxisSet";
-    axis_set.def(py::init<const std::initializer_list<size_t>&>());
-    axis_set.def(py::init<const std::set<size_t>&>());
-    axis_set.def(py::init<const std::vector<size_t>&>());
-    axis_set.def(py::init<const ngraph::AxisSet&>());
+    axis_set.def(py::init<const std::initializer_list<size_t>&>(),
+                 py::arg("axes"));
+    axis_set.def(py::init<const std::set<size_t>&>(),
+                 py::arg("axes"));
+    axis_set.def(py::init<const std::vector<size_t>&>(),
+                 py::arg("axes"));
+    axis_set.def(py::init<const ngraph::AxisSet&>(),
+                 py::arg("axes"));
 
     axis_set.def("__len__", [](const ngraph::AxisSet& v) { return v.size(); });
 

--- a/ngraph/python/src/pyngraph/axis_vector.cpp
+++ b/ngraph/python/src/pyngraph/axis_vector.cpp
@@ -15,7 +15,10 @@ void regclass_pyngraph_AxisVector(py::module m)
     py::class_<ngraph::AxisVector, std::shared_ptr<ngraph::AxisVector>> axis_vector(m,
                                                                                     "AxisVector");
     axis_vector.doc() = "ngraph.impl.AxisVector wraps ngraph::AxisVector";
-    axis_vector.def(py::init<const std::initializer_list<size_t>&>());
-    axis_vector.def(py::init<const std::vector<size_t>&>());
-    axis_vector.def(py::init<const ngraph::AxisVector&>());
+    axis_vector.def(py::init<const std::initializer_list<size_t>&>(),
+                    py::arg("axes"));
+    axis_vector.def(py::init<const std::vector<size_t>&>(),
+                    py::arg("axes"));
+    axis_vector.def(py::init<const ngraph::AxisVector&>(),
+                    py::arg("axes"));
 }

--- a/ngraph/python/src/pyngraph/dimension.cpp
+++ b/ngraph/python/src/pyngraph/dimension.cpp
@@ -82,7 +82,7 @@ void regclass_pyngraph_Dimension(py::module m)
     dim.def("get_length",
             &ngraph::Dimension::get_length,
             R"(
-                Convert this dimension to integer.
+                Return this dimension as integer.
                 This dimension must be static and non-negative.
 
                 Returns
@@ -93,7 +93,7 @@ void regclass_pyngraph_Dimension(py::module m)
     dim.def("get_min_length",
             &ngraph::Dimension::get_min_length,
             R"(
-                Convert this dimension's min_dimension to integer.
+                Return this dimension's min_dimension as integer.
                 This dimension must be dynamic and non-negative.
 
                 Returns
@@ -104,7 +104,7 @@ void regclass_pyngraph_Dimension(py::module m)
     dim.def("get_max_length",
             &ngraph::Dimension::get_max_length,
             R"(
-                Convert this dimension's max_dimension to integer.
+                Return this dimension's max_dimension as integer.
                 This dimension must be dynamic and non-negative.
 
                 Returns
@@ -117,7 +117,7 @@ void regclass_pyngraph_Dimension(py::module m)
             &ngraph::Dimension::same_scheme,
             py::arg("dim"),
             R"(
-                Convert this dimension's max_dimension to integer.
+                Return this dimension's max_dimension as integer.
                 This dimension must be dynamic and non-negative.
 
                 Parameters

--- a/ngraph/python/src/pyngraph/dimension.cpp
+++ b/ngraph/python/src/pyngraph/dimension.cpp
@@ -153,7 +153,13 @@ void regclass_pyngraph_Dimension(py::module m)
             py::arg("d"),
             R"(
                 Check whether this dimension is a relaxation of the argument.
-                
+                This dimension relaxes (or is a relaxation of) d if:
+
+                (1) this and d are static and equal
+                (2) this dimension contains d dimension
+
+                this.relaxes(d) is equivalent to d.refines(this).
+
                 Parameters
                 ----------
                 d : Dimension
@@ -169,6 +175,12 @@ void regclass_pyngraph_Dimension(py::module m)
             py::arg("d"),
             R"(
                 Check whether this dimension is a refinement of the argument.
+                This dimension refines (or is a refinement of) d if:
+
+                (1) this and d are static and equal
+                (2) d dimension contains this dimension
+
+                this.refines(d) is equivalent to d.relaxes(this).
 
                 Parameters
                 ----------

--- a/ngraph/python/src/pyngraph/dimension.cpp
+++ b/ngraph/python/src/pyngraph/dimension.cpp
@@ -23,18 +23,18 @@ void regclass_pyngraph_Dimension(py::module m)
     dim.def(py::init<>());
     dim.def(py::init<value_type&>(),
             py::arg("dimension"),
-            R"mydelimiter(
+            R"(
                 Construct a static dimension.
 
                 Parameters
                 ----------
                  dimension : int
                     Value of the dimension.
-            )mydelimiter");
+            )");
     dim.def(py::init<value_type&, value_type&>(),
             py::arg("min_dimension"),
             py::arg("max_dimension"),
-            R"mydelimiter(
+            R"(
                 Construct a dynamic dimension with bounded range.
 
                 Parameters
@@ -44,30 +44,30 @@ void regclass_pyngraph_Dimension(py::module m)
 
                 max_dimension : int
                     The upper inclusive limit for the dimension.
-            )mydelimiter");
+            )");
 
     dim.def_static("dynamic", &ngraph::Dimension::dynamic);
 
     dim.def_property_readonly("is_dynamic",
                               &ngraph::Dimension::is_dynamic,
-                              R"mydelimiter(
+                              R"(
                                 Check if Dimension is dynamic.
 
                                 Returns
                                 ----------
                                 is_dynamic : bool
                                     False if dynamic, else True.
-                              )mydelimiter");
+                              )");
     dim.def_property_readonly("is_static",
                               &ngraph::Dimension::is_static,
-                              R"mydelimiter(
+                              R"(
                                 Check if Dimension is static.
 
                                 Returns
                                 ----------
                                 is_static : bool
                                     False if static, else True.
-                              )mydelimiter");
+                              )");
 
     dim.def(
         "__eq__",
@@ -81,7 +81,7 @@ void regclass_pyngraph_Dimension(py::module m)
     dim.def("__len__", &ngraph::Dimension::get_length);
     dim.def("get_length",
             &ngraph::Dimension::get_length,
-            R"mydelimiter(
+            R"(
                 Convert this dimension to integer.
                 This dimension must be static and non-negative.
 
@@ -89,10 +89,10 @@ void regclass_pyngraph_Dimension(py::module m)
                 ----------
                 get_length : int
                     Value of the dimension.
-            )mydelimiter");
+            )");
     dim.def("get_min_length",
             &ngraph::Dimension::get_min_length,
-            R"mydelimiter(
+            R"(
                 Convert this dimension's min_dimension to integer.
                 This dimension must be dynamic and non-negative.
 
@@ -100,10 +100,10 @@ void regclass_pyngraph_Dimension(py::module m)
                 ----------
                 get_min_length : int
                     Value of the dimension.
-            )mydelimiter");
+            )");
     dim.def("get_max_length",
             &ngraph::Dimension::get_max_length,
-            R"mydelimiter(
+            R"(
                 Convert this dimension's max_dimension to integer.
                 This dimension must be dynamic and non-negative.
 
@@ -111,12 +111,12 @@ void regclass_pyngraph_Dimension(py::module m)
                 ----------
                 get_max_length : int
                     Value of the dimension.
-            )mydelimiter");
+            )");
 
     dim.def("same_scheme",
             &ngraph::Dimension::same_scheme,
             py::arg("dim"),
-            R"mydelimiter(
+            R"(
                 Convert this dimension's max_dimension to integer.
                 This dimension must be dynamic and non-negative.
 
@@ -130,11 +130,11 @@ void regclass_pyngraph_Dimension(py::module m)
                 same_scheme : bool
                     True if this dimension and dim are both dynamic,
                     or if they are both static and equal, otherwise False.
-            )mydelimiter");
+            )");
     dim.def("compatible",
             &ngraph::Dimension::compatible,
             py::arg("d"),
-            R"mydelimiter(
+            R"(
                 Check whether this dimension is capable of being merged 
                 with the argument dimension.
 
@@ -147,11 +147,11 @@ void regclass_pyngraph_Dimension(py::module m)
                 ----------
                 compatible : bool
                     True if this dimension is compatible with d, else False.
-            )mydelimiter");
+            )");
     dim.def("relaxes",
             &ngraph::Dimension::relaxes,
             py::arg("d"),
-            R"mydelimiter(
+            R"(
                 Check whether this dimension is a relaxation of the argument.
                 
                 Parameters
@@ -163,11 +163,11 @@ void regclass_pyngraph_Dimension(py::module m)
                 ----------
                 relaxes : bool
                     True if this dimension relaxes d, else False.
-            )mydelimiter");
+            )");
     dim.def("refines",
             &ngraph::Dimension::refines,
             py::arg("d"),
-            R"mydelimiter(
+            R"(
                 Check whether this dimension is a refinement of the argument.
 
                 Parameters
@@ -179,7 +179,7 @@ void regclass_pyngraph_Dimension(py::module m)
                 ----------
                 relaxes : bool
                     True if this dimension refines d, else False.
-            )mydelimiter");
+            )");
 
     dim.def("__str__", [](const ngraph::Dimension& self) -> std::string {
         std::stringstream ss;

--- a/ngraph/python/src/pyngraph/dimension.cpp
+++ b/ngraph/python/src/pyngraph/dimension.cpp
@@ -21,13 +21,53 @@ void regclass_pyngraph_Dimension(py::module m)
     py::class_<ngraph::Dimension, std::shared_ptr<ngraph::Dimension>> dim(m, "Dimension");
     dim.doc() = "ngraph.impl.Dimension wraps ngraph::Dimension";
     dim.def(py::init<>());
-    dim.def(py::init<value_type&>());
-    dim.def(py::init<value_type&, value_type&>());
+    dim.def(py::init<value_type&>(),
+            py::arg("dimension"),
+            R"mydelimiter(
+                Construct a static dimension.
+
+                Parameters
+                ----------
+                 dimension : int
+                    Value of the dimension.
+            )mydelimiter");
+    dim.def(py::init<value_type&, value_type&>(),
+            py::arg("min_dimension"),
+            py::arg("max_dimension"),
+            R"mydelimiter(
+                Construct a dynamic dimension with bounded range.
+
+                Parameters
+                ----------
+                min_dimension : int
+                    The lower inclusive limit for the dimension.
+
+                max_dimension : int
+                    The upper inclusive limit for the dimension.
+            )mydelimiter");
 
     dim.def_static("dynamic", &ngraph::Dimension::dynamic);
 
-    dim.def_property_readonly("is_dynamic", &ngraph::Dimension::is_dynamic);
-    dim.def_property_readonly("is_static", &ngraph::Dimension::is_static);
+    dim.def_property_readonly("is_dynamic",
+                              &ngraph::Dimension::is_dynamic,
+                              R"mydelimiter(
+                                Check if Dimension is dynamic.
+
+                                Returns
+                                ----------
+                                is_dynamic : bool
+                                    False if dynamic, else True.
+                              )mydelimiter");
+    dim.def_property_readonly("is_static",
+                              &ngraph::Dimension::is_static,
+                              R"mydelimiter(
+                                Check if Dimension is static.
+
+                                Returns
+                                ----------
+                                is_static : bool
+                                    False if static, else True.
+                              )mydelimiter");
 
     dim.def(
         "__eq__",
@@ -39,14 +79,107 @@ void regclass_pyngraph_Dimension(py::module m)
         py::is_operator());
 
     dim.def("__len__", &ngraph::Dimension::get_length);
-    dim.def("get_length", &ngraph::Dimension::get_length);
-    dim.def("get_min_length", &ngraph::Dimension::get_min_length);
-    dim.def("get_max_length", &ngraph::Dimension::get_max_length);
+    dim.def("get_length",
+            &ngraph::Dimension::get_length,
+            R"mydelimiter(
+                Convert this dimension to integer.
+                This dimension must be static and non-negative.
 
-    dim.def("same_scheme", &ngraph::Dimension::same_scheme);
-    dim.def("compatible", &ngraph::Dimension::compatible);
-    dim.def("relaxes", &ngraph::Dimension::relaxes);
-    dim.def("refines", &ngraph::Dimension::refines);
+                Returns
+                ----------
+                get_length : int
+                    Value of the dimension.
+            )mydelimiter");
+    dim.def("get_min_length",
+            &ngraph::Dimension::get_min_length,
+            R"mydelimiter(
+                Convert this dimension's min_dimension to integer.
+                This dimension must be dynamic and non-negative.
+
+                Returns
+                ----------
+                get_min_length : int
+                    Value of the dimension.
+            )mydelimiter");
+    dim.def("get_max_length",
+            &ngraph::Dimension::get_max_length,
+            R"mydelimiter(
+                Convert this dimension's max_dimension to integer.
+                This dimension must be dynamic and non-negative.
+
+                Returns
+                ----------
+                get_max_length : int
+                    Value of the dimension.
+            )mydelimiter");
+
+    dim.def("same_scheme",
+            &ngraph::Dimension::same_scheme,
+            py::arg("dim"),
+            R"mydelimiter(
+                Convert this dimension's max_dimension to integer.
+                This dimension must be dynamic and non-negative.
+
+                Parameters
+                ----------
+                dim : Dimension
+                    The other dimension to compare this dimension to.
+
+                Returns
+                ----------
+                same_scheme : bool
+                    True if this dimension and dim are both dynamic,
+                    or if they are both static and equal, otherwise False.
+            )mydelimiter");
+    dim.def("compatible",
+            &ngraph::Dimension::compatible,
+            py::arg("d"),
+            R"mydelimiter(
+                Check whether this dimension is capable of being merged 
+                with the argument dimension.
+
+                Parameters
+                ----------
+                d : Dimension
+                    The dimension to compare this dimension with.
+
+                Returns
+                ----------
+                compatible : bool
+                    True if this dimension is compatible with d, else False.
+            )mydelimiter");
+    dim.def("relaxes",
+            &ngraph::Dimension::relaxes,
+            py::arg("d"),
+            R"mydelimiter(
+                Check whether this dimension is a relaxation of the argument.
+                
+                Parameters
+                ----------
+                d : Dimension
+                    The dimension to compare this dimension with.
+
+                Returns
+                ----------
+                relaxes : bool
+                    True if this dimension relaxes d, else False.
+            )mydelimiter");
+    dim.def("refines",
+            &ngraph::Dimension::refines,
+            py::arg("d"),
+            R"mydelimiter(
+                Check whether this dimension is a refinement of the argument.
+
+                Parameters
+                ----------
+                d : Dimension
+                    The dimension to compare this dimension with.
+
+                Returns
+                ----------
+                relaxes : bool
+                    True if this dimension refines d, else False.
+            )mydelimiter");
 
     dim.def("__str__", [](const ngraph::Dimension& self) -> std::string {
         std::stringstream ss;

--- a/ngraph/python/src/pyngraph/dimension.cpp
+++ b/ngraph/python/src/pyngraph/dimension.cpp
@@ -56,7 +56,7 @@ void regclass_pyngraph_Dimension(py::module m)
                                 Returns
                                 ----------
                                 is_dynamic : bool
-                                    False if dynamic, else True.
+                                    True if dynamic, else False.
                               )");
     dim.def_property_readonly("is_static",
                               &ngraph::Dimension::is_static,
@@ -66,7 +66,7 @@ void regclass_pyngraph_Dimension(py::module m)
                                 Returns
                                 ----------
                                 is_static : bool
-                                    False if static, else True.
+                                    True if static, else False.
                               )");
 
     dim.def(

--- a/ngraph/python/src/pyngraph/function.cpp
+++ b/ngraph/python/src/pyngraph/function.cpp
@@ -24,7 +24,7 @@ void regclass_pyngraph_Function(py::module m)
                  py::arg("parameters"),
                  py::arg("name"),
                  R"(
-                    Create Function.
+                    Create user-defined Function which is a representation of a model.
 
                     Parameters
                     ----------
@@ -44,7 +44,7 @@ void regclass_pyngraph_Function(py::module m)
                  py::arg("parameters"),
                  py::arg("name"),
                  R"(
-                    Create Function.
+                    Create user-defined Function which is a representation of a model.
 
                     Parameters
                     ----------
@@ -80,7 +80,7 @@ void regclass_pyngraph_Function(py::module m)
     function.def("get_ordered_ops",
                  &ngraph::Function::get_ordered_ops,
                  R"(
-                    Return ordered ops used in the function.
+                    Return ops used in the function in topological order.
 
                     Returns
                     ----------

--- a/ngraph/python/src/pyngraph/function.cpp
+++ b/ngraph/python/src/pyngraph/function.cpp
@@ -19,10 +19,44 @@ void regclass_pyngraph_Function(py::module m)
     function.doc() = "ngraph.impl.Function wraps ngraph::Function";
     function.def(py::init<const std::vector<std::shared_ptr<ngraph::Node>>&,
                           const std::vector<std::shared_ptr<ngraph::op::Parameter>>&,
-                          const std::string&>());
+                          const std::string&>(),
+                 py::arg("results"),
+                 py::arg("parameters"),
+                 py::arg("name"),
+                 R"mydelimiter(
+                    Create Function.
+
+                    Parameters
+                    ----------
+                    results : List[Node]
+                        List of Nodes to be used as results.
+
+                    parameters : List[op.Parameter]
+                        List of parameters.
+
+                    name : str
+                        String to set as function's freindly name.
+                 )mydelimiter");
     function.def(py::init<const std::shared_ptr<ngraph::Node>&,
                           const std::vector<std::shared_ptr<ngraph::op::Parameter>>&,
-                          const std::string&>());
+                          const std::string&>(),
+                 py::arg("result"),
+                 py::arg("parameters"),
+                 py::arg("name"),
+                 R"mydelimiter(
+                    Create Function.
+
+                    Parameters
+                    ----------
+                    results : Node
+                        Node to be used as result.
+
+                    parameters : List[op.Parameter]
+                        List of parameters.
+
+                    name : str
+                        String to set as function's freindly name.
+                 )mydelimiter");
     function.def("get_output_size",
                  &ngraph::Function::get_output_size,
                  R"mydelimiter(
@@ -120,22 +154,22 @@ void regclass_pyngraph_Function(py::module m)
     function.def("get_parameters",
                  &ngraph::Function::get_parameters,
                  R"mydelimiter(
-                    Return the function parameters
+                    Return the function parameters.
 
                     Returns
                     ----------
                     get_parameters : ParameterVector
-                        ParameterVector containing function parameters
+                        ParameterVector containing function parameters.
                  )mydelimiter");
     function.def("get_results",
                  &ngraph::Function::get_results,
                  R"mydelimiter(
-                    Return a list of function outputs
+                    Return a list of function outputs.
 
                     Returns
                     ----------
                     get_results : ResultVector
-                        ResultVector containing function parameters
+                        ResultVector containing function parameters.
                  )mydelimiter");
     function.def("get_result",
                  &ngraph::Function::get_result,
@@ -162,7 +196,7 @@ void regclass_pyngraph_Function(py::module m)
                  R"mydelimiter(
                     Gets the friendly name for a function. If no
                     friendly name has been set via set_friendly_name
-                    then the function's unique name is returned
+                    then the function's unique name is returned.
 
                     Returns
                     ----------
@@ -187,7 +221,7 @@ void regclass_pyngraph_Function(py::module m)
                  &ngraph::Function::is_dynamic,
                  R"mydelimiter(
                     Returns true if any of the op's defined in the function 
-                    contains partial shape
+                    contains partial shape.
 
                     Returns
                     ----------

--- a/ngraph/python/src/pyngraph/function.cpp
+++ b/ngraph/python/src/pyngraph/function.cpp
@@ -26,7 +26,22 @@ void regclass_pyngraph_Function(py::module m)
     function.def("get_output_size", &ngraph::Function::get_output_size);
     function.def("get_ops", &ngraph::Function::get_ops);
     function.def("get_ordered_ops", &ngraph::Function::get_ordered_ops);
-    function.def("get_output_op", &ngraph::Function::get_output_op);
+    function.def("get_output_op",
+                 &ngraph::Function::get_output_op,
+                 py::arg("i"),
+                 R"mydelimiter(
+                    Return the op that generates output i
+
+                    Parameters
+                    ----------
+                    i : int
+                        output index
+
+                    Returns
+                    ----------
+                    get_output_op : Node
+                        Node object that generates output i
+                )mydelimiter");
     function.def("get_output_element_type", &ngraph::Function::get_output_element_type);
     function.def("get_output_shape", &ngraph::Function::get_output_shape);
     function.def("get_output_partial_shape", &ngraph::Function::get_output_partial_shape);

--- a/ngraph/python/src/pyngraph/function.cpp
+++ b/ngraph/python/src/pyngraph/function.cpp
@@ -23,7 +23,7 @@ void regclass_pyngraph_Function(py::module m)
                  py::arg("results"),
                  py::arg("parameters"),
                  py::arg("name"),
-                 R"mydelimiter(
+                 R"(
                     Create Function.
 
                     Parameters
@@ -36,14 +36,14 @@ void regclass_pyngraph_Function(py::module m)
 
                     name : str
                         String to set as function's freindly name.
-                 )mydelimiter");
+                 )");
     function.def(py::init<const std::shared_ptr<ngraph::Node>&,
                           const std::vector<std::shared_ptr<ngraph::op::Parameter>>&,
                           const std::string&>(),
                  py::arg("result"),
                  py::arg("parameters"),
                  py::arg("name"),
-                 R"mydelimiter(
+                 R"(
                     Create Function.
 
                     Parameters
@@ -56,41 +56,41 @@ void regclass_pyngraph_Function(py::module m)
 
                     name : str
                         String to set as function's freindly name.
-                 )mydelimiter");
+                 )");
     function.def("get_output_size",
                  &ngraph::Function::get_output_size,
-                 R"mydelimiter(
+                 R"(
                     Return the number of outputs for the function.
 
                     Returns
                     ----------
                     get_output_size : int
                         Number of outputs.
-                 )mydelimiter");
+                 )");
     function.def("get_ops",
                  &ngraph::Function::get_ops,
-                 R"mydelimiter(
+                 R"(
                     Return ops used in the function.
 
                     Returns
                     ----------
                     get_ops : List[Node]
                         List of Nodes representing ops used in function.
-                 )mydelimiter");
+                 )");
     function.def("get_ordered_ops",
                  &ngraph::Function::get_ordered_ops,
-                 R"mydelimiter(
+                 R"(
                     Return ordered ops used in the function.
 
                     Returns
                     ----------
                     get_ordered_ops : List[Node]
                         List of sorted Nodes representing ops used in function.
-                 )mydelimiter");
+                 )");
     function.def("get_output_op",
                  &ngraph::Function::get_output_op,
                  py::arg("i"),
-                 R"mydelimiter(
+                 R"(
                     Return the op that generates output i
 
                     Parameters
@@ -102,11 +102,11 @@ void regclass_pyngraph_Function(py::module m)
                     ----------
                     get_output_op : Node
                         Node object that generates output i
-                )mydelimiter");
+                )");
     function.def("get_output_element_type",
                  &ngraph::Function::get_output_element_type,
                  py::arg("i"),
-                 R"mydelimiter(
+                 R"(
                     Return the element type of output i
 
                     Parameters
@@ -118,11 +118,11 @@ void regclass_pyngraph_Function(py::module m)
                     ----------
                     get_output_op : Type
                         Type object of output i
-                 )mydelimiter");
+                 )");
     function.def("get_output_shape",
                  &ngraph::Function::get_output_shape,
                  py::arg("i"),
-                 R"mydelimiter(
+                 R"(
                     Return the shape of element i
 
                     Parameters
@@ -134,11 +134,11 @@ void regclass_pyngraph_Function(py::module m)
                     ----------
                     get_output_shape : Shape
                         Shape object of element i
-                 )mydelimiter");
+                 )");
     function.def("get_output_partial_shape",
                  &ngraph::Function::get_output_partial_shape,
                  py::arg("i"),
-                 R"mydelimiter(
+                 R"(
                     Return the partial shape of element i
 
                     Parameters
@@ -150,50 +150,50 @@ void regclass_pyngraph_Function(py::module m)
                     ----------
                     get_output_partial_shape : PartialShape
                         PartialShape object of element i
-                 )mydelimiter");
+                 )");
     function.def("get_parameters",
                  &ngraph::Function::get_parameters,
-                 R"mydelimiter(
+                 R"(
                     Return the function parameters.
 
                     Returns
                     ----------
                     get_parameters : ParameterVector
                         ParameterVector containing function parameters.
-                 )mydelimiter");
+                 )");
     function.def("get_results",
                  &ngraph::Function::get_results,
-                 R"mydelimiter(
+                 R"(
                     Return a list of function outputs.
 
                     Returns
                     ----------
                     get_results : ResultVector
                         ResultVector containing function parameters.
-                 )mydelimiter");
+                 )");
     function.def("get_result",
                  &ngraph::Function::get_result,
-                 R"mydelimiter(
+                 R"(
                     Return single result.
 
                     Returns
                     ----------
                     get_result : Node
                         Node object representing result.
-                 )mydelimiter");
+                 )");
     function.def("get_name",
                  &ngraph::Function::get_name,
-                 R"mydelimiter(
+                 R"(
                     Get the unique name of the function.
 
                     Returns
                     ----------
                     get_name : str
                         String with a name of the function.
-                 )mydelimiter");
+                 )");
     function.def("get_friendly_name",
                  &ngraph::Function::get_friendly_name,
-                 R"mydelimiter(
+                 R"(
                     Gets the friendly name for a function. If no
                     friendly name has been set via set_friendly_name
                     then the function's unique name is returned.
@@ -202,11 +202,11 @@ void regclass_pyngraph_Function(py::module m)
                     ----------
                     get_friendly_name : str
                         String with a friendly name of the function.
-                 )mydelimiter");
+                 )");
     function.def("set_friendly_name",
                  &ngraph::Function::set_friendly_name,
                  py::arg("name"),
-                 R"mydelimiter(
+                 R"(
                     Sets a friendly name for a function. This does
                     not overwrite the unique name of the function and
                     is retrieved via get_friendly_name(). Used mainly
@@ -216,17 +216,17 @@ void regclass_pyngraph_Function(py::module m)
                     ----------
                     name : str
                         String to set as the friendly name.
-                 )mydelimiter");
+                 )");
     function.def("is_dynamic",
                  &ngraph::Function::is_dynamic,
-                 R"mydelimiter(
+                 R"(
                     Returns true if any of the op's defined in the function 
                     contains partial shape.
 
                     Returns
                     ----------
                     is_dynamic : bool
-                 )mydelimiter");
+                 )");
     function.def("__repr__", [](const ngraph::Function& self) {
         std::string class_name = py::cast(self).get_type().attr("__name__").cast<std::string>();
         std::stringstream shapes_ss;

--- a/ngraph/python/src/pyngraph/function.cpp
+++ b/ngraph/python/src/pyngraph/function.cpp
@@ -23,9 +23,36 @@ void regclass_pyngraph_Function(py::module m)
     function.def(py::init<const std::shared_ptr<ngraph::Node>&,
                           const std::vector<std::shared_ptr<ngraph::op::Parameter>>&,
                           const std::string&>());
-    function.def("get_output_size", &ngraph::Function::get_output_size);
-    function.def("get_ops", &ngraph::Function::get_ops);
-    function.def("get_ordered_ops", &ngraph::Function::get_ordered_ops);
+    function.def("get_output_size",
+                 &ngraph::Function::get_output_size,
+                 R"mydelimiter(
+                    Return the number of outputs for the function.
+
+                    Returns
+                    ----------
+                    get_output_size : int
+                        Number of outputs.
+                 )mydelimiter");
+    function.def("get_ops",
+                 &ngraph::Function::get_ops,
+                 R"mydelimiter(
+                    Return ops used in the function.
+
+                    Returns
+                    ----------
+                    get_ops : List[Node]
+                        List of Nodes representing ops used in function.
+                 )mydelimiter");
+    function.def("get_ordered_ops",
+                 &ngraph::Function::get_ordered_ops,
+                 R"mydelimiter(
+                    Return ordered ops used in the function.
+
+                    Returns
+                    ----------
+                    get_ordered_ops : List[Node]
+                        List of sorted Nodes representing ops used in function.
+                 )mydelimiter");
     function.def("get_output_op",
                  &ngraph::Function::get_output_op,
                  py::arg("i"),
@@ -42,16 +69,130 @@ void regclass_pyngraph_Function(py::module m)
                     get_output_op : Node
                         Node object that generates output i
                 )mydelimiter");
-    function.def("get_output_element_type", &ngraph::Function::get_output_element_type);
-    function.def("get_output_shape", &ngraph::Function::get_output_shape);
-    function.def("get_output_partial_shape", &ngraph::Function::get_output_partial_shape);
-    function.def("get_parameters", &ngraph::Function::get_parameters);
-    function.def("get_results", &ngraph::Function::get_results);
-    function.def("get_result", &ngraph::Function::get_result);
-    function.def("get_name", &ngraph::Function::get_name);
-    function.def("get_friendly_name", &ngraph::Function::get_friendly_name);
-    function.def("set_friendly_name", &ngraph::Function::set_friendly_name);
-    function.def("is_dynamic", &ngraph::Function::is_dynamic);
+    function.def("get_output_element_type",
+                 &ngraph::Function::get_output_element_type,
+                 py::arg("i"),
+                 R"mydelimiter(
+                    Return the element type of output i
+
+                    Parameters
+                    ----------
+                    i : int
+                        output index
+
+                    Returns
+                    ----------
+                    get_output_op : Type
+                        Type object of output i
+                 )mydelimiter");
+    function.def("get_output_shape",
+                 &ngraph::Function::get_output_shape,
+                 py::arg("i"),
+                 R"mydelimiter(
+                    Return the shape of element i
+
+                    Parameters
+                    ----------
+                    i : int
+                        element index
+
+                    Returns
+                    ----------
+                    get_output_shape : Shape
+                        Shape object of element i
+                 )mydelimiter");
+    function.def("get_output_partial_shape",
+                 &ngraph::Function::get_output_partial_shape,
+                 py::arg("i"),
+                 R"mydelimiter(
+                    Return the partial shape of element i
+
+                    Parameters
+                    ----------
+                    i : int
+                        element index
+
+                    Returns
+                    ----------
+                    get_output_partial_shape : PartialShape
+                        PartialShape object of element i
+                 )mydelimiter");
+    function.def("get_parameters",
+                 &ngraph::Function::get_parameters,
+                 R"mydelimiter(
+                    Return the function parameters
+
+                    Returns
+                    ----------
+                    get_parameters : ParameterVector
+                        ParameterVector containing function parameters
+                 )mydelimiter");
+    function.def("get_results",
+                 &ngraph::Function::get_results,
+                 R"mydelimiter(
+                    Return a list of function outputs
+
+                    Returns
+                    ----------
+                    get_results : ResultVector
+                        ResultVector containing function parameters
+                 )mydelimiter");
+    function.def("get_result",
+                 &ngraph::Function::get_result,
+                 R"mydelimiter(
+                    Return single result.
+
+                    Returns
+                    ----------
+                    get_result : Node
+                        Node object representing result.
+                 )mydelimiter");
+    function.def("get_name",
+                 &ngraph::Function::get_name,
+                 R"mydelimiter(
+                    Get the unique name of the function.
+
+                    Returns
+                    ----------
+                    get_name : str
+                        String with a name of the function.
+                 )mydelimiter");
+    function.def("get_friendly_name",
+                 &ngraph::Function::get_friendly_name,
+                 R"mydelimiter(
+                    Gets the friendly name for a function. If no
+                    friendly name has been set via set_friendly_name
+                    then the function's unique name is returned
+
+                    Returns
+                    ----------
+                    get_friendly_name : str
+                        String with a friendly name of the function.
+                 )mydelimiter");
+    function.def("set_friendly_name",
+                 &ngraph::Function::set_friendly_name,
+                 py::arg("name"),
+                 R"mydelimiter(
+                    Sets a friendly name for a function. This does
+                    not overwrite the unique name of the function and
+                    is retrieved via get_friendly_name(). Used mainly
+                    for debugging.
+
+                    Parameters
+                    ----------
+                    name : str
+                        String to set as the friendly name.
+                 )mydelimiter");
+    function.def("is_dynamic",
+                 &ngraph::Function::is_dynamic,
+                 R"mydelimiter(
+                    Returns true if any of the op's defined in the function 
+                    contains partial shape
+
+                    Returns
+                    ----------
+                    is_dynamic : bool
+                 )mydelimiter");
     function.def("__repr__", [](const ngraph::Function& self) {
         std::string class_name = py::cast(self).get_type().attr("__name__").cast<std::string>();
         std::stringstream shapes_ss;

--- a/ngraph/python/src/pyngraph/node.cpp
+++ b/ngraph/python/src/pyngraph/node.cpp
@@ -72,26 +72,182 @@ void regclass_pyngraph_Node(py::module m)
         return "<" + type_name + ": '" + self.get_friendly_name() + "' (" + shapes_ss.str() + ")>";
     });
 
-    node.def("get_element_type", &ngraph::Node::get_element_type);
-    node.def("get_output_size", &ngraph::Node::get_output_size);
-    node.def("get_output_element_type", &ngraph::Node::get_output_element_type);
-    node.def("get_output_shape", &ngraph::Node::get_output_shape);
-    node.def("get_output_partial_shape", &ngraph::Node::get_output_partial_shape);
-    node.def("get_type_name", &ngraph::Node::get_type_name);
-    node.def("get_name", &ngraph::Node::get_name);
-    node.def("get_friendly_name", &ngraph::Node::get_friendly_name);
-    node.def("set_friendly_name", &ngraph::Node::set_friendly_name);
-    node.def("input", (ngraph::Input<ngraph::Node>(ngraph::Node::*)(size_t)) & ngraph::Node::input);
+    node.def("get_element_type",
+             &ngraph::Node::get_element_type,
+             R"(
+                Checks that there is exactly one output and returns it's element type.
+
+                Returns
+                ----------
+                get_element_type : Type
+                    Type of the output.
+             )");
+    node.def("get_output_size",
+             &ngraph::Node::get_output_size,
+             R"(
+                Returns the number of outputs from the node.
+
+                Returns
+                ----------
+                get_element_type : int
+                    Number of outputs.
+             )");
+    node.def("get_output_element_type",
+             &ngraph::Node::get_output_element_type,
+             py::arg("i"),
+             R"(
+                Returns the element type for output i
+
+                Parameters
+                ----------
+                i : int
+                    Index of the output.
+
+                Returns
+                ----------
+                get_output_element_type : Type
+                    Type of the output i
+             )");
+    node.def("get_output_shape",
+             &ngraph::Node::get_output_shape,
+             py::arg("i"),
+             R"(
+                Returns the shape for output i
+
+                Parameters
+                ----------
+                i : int
+                    Index of the output.
+
+                Returns
+                ----------
+                get_output_shape : Shape
+                    Shape of the output i
+             )");
+    node.def("get_output_partial_shape",
+             &ngraph::Node::get_output_partial_shape,
+             py::arg("i"),
+             R"(
+                Returns the partial shape for output i
+
+                Parameters
+                ----------
+                i : int
+                    Index of the output.
+
+                Returns
+                ----------
+                get_output_partial_shape : PartialShape
+                    PartialShape of the output i
+             )");
+    node.def("get_type_name",
+             &ngraph::Node::get_type_name,
+             R"(
+                Returns Type's name from the node.
+
+                Returns
+                ----------
+                get_type_name : str
+                    String repesenting Type's name. 
+             )");
+    node.def("get_name",
+             &ngraph::Node::get_name,
+             R"(
+                Get the unique name of the node
+
+                Returns
+                ----------
+                get_name : str
+                    Unique name of the node.
+             )");
+    node.def("get_friendly_name",
+             &ngraph::Node::get_friendly_name,
+             R"(
+                Gets the friendly name for a node. If no friendly name has 
+                been set via set_friendly_name then the node's unique name
+                is returned.
+
+                Returns
+                ----------
+                get_name : str
+                    Friendly name of the node.
+             )");
+    node.def("set_friendly_name",
+             &ngraph::Node::set_friendly_name,
+             py::arg("name"),
+             R"(
+                Sets a friendly name for a node. This does not overwrite the unique name
+                of the node and is retrieved via get_friendly_name(). Used mainly for 
+                debugging. The friendly name may be set exactly once.
+
+                Parameters
+                ----------
+                name : str
+                    Friendly name to set.
+             )");
+    node.def("input",
+             (ngraph::Input<ngraph::Node>(ngraph::Node::*)(size_t)) & ngraph::Node::input,
+             py::arg("input_index"),
+             R"(
+                A handle to the input_index input of this node.
+
+                Parameters
+                ----------
+                input_index : int
+                    Index of Input.
+
+                Returns
+                ----------
+                input : Input
+                    Input of this node.
+             )");
     node.def("inputs",
-             (std::vector<ngraph::Input<ngraph::Node>>(ngraph::Node::*)()) & ngraph::Node::inputs);
+             (std::vector<ngraph::Input<ngraph::Node>>(ngraph::Node::*)()) & ngraph::Node::inputs,
+             R"(
+                A list containing a handle for each of this node's inputs, in order.
+
+                Returns
+                ----------
+                inputs : List[Input]
+                    List of node's inputs.
+             )");
     node.def("output",
-             (ngraph::Output<ngraph::Node>(ngraph::Node::*)(size_t)) & ngraph::Node::output);
+             (ngraph::Output<ngraph::Node>(ngraph::Node::*)(size_t)) & ngraph::Node::output,
+             py::arg("output_index"),
+             R"(
+                A handle to the output_index output of this node.
+
+                Parameters
+                ----------
+                output_index : int
+                    Index of Output.
+
+                Returns
+                ----------
+                input : Output
+                    Output of this node.
+             )");
     node.def("outputs",
-             (std::vector<ngraph::Output<ngraph::Node>>(ngraph::Node::*)()) &
-                 ngraph::Node::outputs);
+             (std::vector<ngraph::Output<ngraph::Node>>(ngraph::Node::*)()) & ngraph::Node::outputs,
+             R"(
+                A list containing a handle for each of this node's outputs, in order.
+
+                Returns
+                ----------
+                inputs : List[Output]
+                    List of node's outputs.
+             )");
     node.def("get_rt_info",
              (PyRTMap & (ngraph::Node::*)()) & ngraph::Node::get_rt_info,
-             py::return_value_policy::reference_internal);
+             py::return_value_policy::reference_internal,
+             R"(
+                Returns PyRTMap which is a dictionary of user defined runtime info.
+
+                Returns
+                ----------
+                get_rt_info : PyRTMap
+                    A dictionary of user defined data.
+             )");
 
     node.def_property_readonly("shape", &ngraph::Node::get_shape);
     node.def_property_readonly("name", &ngraph::Node::get_name);

--- a/ngraph/python/src/pyngraph/node_input.cpp
+++ b/ngraph/python/src/pyngraph/node_input.cpp
@@ -16,10 +16,64 @@ void regclass_pyngraph_Input(py::module m)
         m, "Input", py::dynamic_attr());
     input.doc() = "ngraph.impl.Input wraps ngraph::Input<Node>";
 
-    input.def("get_node", &ngraph::Input<ngraph::Node>::get_node);
-    input.def("get_index", &ngraph::Input<ngraph::Node>::get_index);
-    input.def("get_element_type", &ngraph::Input<ngraph::Node>::get_element_type);
-    input.def("get_shape", &ngraph::Input<ngraph::Node>::get_shape);
-    input.def("get_partial_shape", &ngraph::Input<ngraph::Node>::get_partial_shape);
-    input.def("get_source_output", &ngraph::Input<ngraph::Node>::get_source_output);
+    input.def("get_node",
+              &ngraph::Input<ngraph::Node>::get_node,
+              R"mydelimiter(
+                Get node referenced by this input handle.
+
+                Returns
+                ----------
+                get_node : Node
+                    Node object referenced by this input handle.
+              )mydelimiter");
+    input.def("get_index",
+              &ngraph::Input<ngraph::Node>::get_index,
+              R"mydelimiter(
+                The index of the input referred to by this input handle.
+
+                Returns
+                ----------
+                get_index : int
+                    Index value as integer.
+              )mydelimiter");
+    input.def("get_element_type",
+              &ngraph::Input<ngraph::Node>::get_element_type,
+              R"mydelimiter(
+                The element type of the input referred to by this input handle.
+
+                Returns
+                ----------
+                get_element_type : Type
+                    Type of the input.
+              )mydelimiter");
+    input.def("get_shape",
+              &ngraph::Input<ngraph::Node>::get_shape,
+              R"mydelimiter(
+                The shape of the input referred to by this input handle.
+
+                Returns
+                ----------
+                get_shape : Shape
+                    Shape of the input.
+              )mydelimiter");
+    input.def("get_partial_shape",
+              &ngraph::Input<ngraph::Node>::get_partial_shape,
+              R"mydelimiter(
+                The partial shape of the input referred to by this input handle.
+
+                Returns
+                ----------
+                get_partial_shape : PartialShape
+                    PartialShape of the input.
+              )mydelimiter");
+    input.def("get_source_output",
+              &ngraph::Input<ngraph::Node>::get_source_output,
+              R"mydelimiter(
+                A handle to the output that is connected to this input.
+
+                Returns
+                ----------
+                get_source_output : Output
+                    Output that is connected to the input.
+              )mydelimiter");
 }

--- a/ngraph/python/src/pyngraph/node_input.cpp
+++ b/ngraph/python/src/pyngraph/node_input.cpp
@@ -18,62 +18,62 @@ void regclass_pyngraph_Input(py::module m)
 
     input.def("get_node",
               &ngraph::Input<ngraph::Node>::get_node,
-              R"mydelimiter(
+              R"(
                 Get node referenced by this input handle.
 
                 Returns
                 ----------
                 get_node : Node
                     Node object referenced by this input handle.
-              )mydelimiter");
+              )");
     input.def("get_index",
               &ngraph::Input<ngraph::Node>::get_index,
-              R"mydelimiter(
+              R"(
                 The index of the input referred to by this input handle.
 
                 Returns
                 ----------
                 get_index : int
                     Index value as integer.
-              )mydelimiter");
+              )");
     input.def("get_element_type",
               &ngraph::Input<ngraph::Node>::get_element_type,
-              R"mydelimiter(
+              R"(
                 The element type of the input referred to by this input handle.
 
                 Returns
                 ----------
                 get_element_type : Type
                     Type of the input.
-              )mydelimiter");
+              )");
     input.def("get_shape",
               &ngraph::Input<ngraph::Node>::get_shape,
-              R"mydelimiter(
+              R"(
                 The shape of the input referred to by this input handle.
 
                 Returns
                 ----------
                 get_shape : Shape
                     Shape of the input.
-              )mydelimiter");
+              )");
     input.def("get_partial_shape",
               &ngraph::Input<ngraph::Node>::get_partial_shape,
-              R"mydelimiter(
+              R"(
                 The partial shape of the input referred to by this input handle.
 
                 Returns
                 ----------
                 get_partial_shape : PartialShape
                     PartialShape of the input.
-              )mydelimiter");
+              )");
     input.def("get_source_output",
               &ngraph::Input<ngraph::Node>::get_source_output,
-              R"mydelimiter(
+              R"(
                 A handle to the output that is connected to this input.
 
                 Returns
                 ----------
                 get_source_output : Output
                     Output that is connected to the input.
-              )mydelimiter");
+              )");
 }

--- a/ngraph/python/src/pyngraph/node_output.cpp
+++ b/ngraph/python/src/pyngraph/node_output.cpp
@@ -16,10 +16,64 @@ void regclass_pyngraph_Output(py::module m)
         m, "Output", py::dynamic_attr());
     output.doc() = "ngraph.impl.Output wraps ngraph::Output<Node>";
 
-    output.def("get_node", &ngraph::Output<ngraph::Node>::get_node);
-    output.def("get_index", &ngraph::Output<ngraph::Node>::get_index);
-    output.def("get_element_type", &ngraph::Output<ngraph::Node>::get_element_type);
-    output.def("get_shape", &ngraph::Output<ngraph::Node>::get_shape);
-    output.def("get_partial_shape", &ngraph::Output<ngraph::Node>::get_partial_shape);
-    output.def("get_target_inputs", &ngraph::Output<ngraph::Node>::get_target_inputs);
+    output.def("get_node",
+               &ngraph::Output<ngraph::Node>::get_node,
+               R"mydelimiter(
+                Get node referenced by this output handle.
+
+                Returns
+                ----------
+                get_node : Node
+                    Node object referenced by this output handle.
+               )mydelimiter");
+    output.def("get_index",
+               &ngraph::Output<ngraph::Node>::get_index,
+               R"mydelimiter(
+                The index of the output referred to by this output handle.
+
+                Returns
+                ----------
+                get_index : int
+                    Index value as integer.
+               )mydelimiter");
+    output.def("get_element_type",
+               &ngraph::Output<ngraph::Node>::get_element_type,
+               R"mydelimiter(
+                The element type of the output referred to by this output handle.
+
+                Returns
+                ----------
+                get_element_type : Type
+                    Type of the output.
+               )mydelimiter");
+    output.def("get_shape",
+               &ngraph::Output<ngraph::Node>::get_shape,
+               R"mydelimiter(
+                The shape of the output referred to by this output handle.
+
+                Returns
+                ----------
+                get_shape : Shape
+                    Shape of the output.
+               )mydelimiter");
+    output.def("get_partial_shape",
+               &ngraph::Output<ngraph::Node>::get_partial_shape,
+               R"mydelimiter(
+                The partial shape of the output referred to by this output handle.
+
+                Returns
+                ----------
+                get_partial_shape : PartialShape
+                    PartialShape of the output.
+               )mydelimiter");
+    output.def("get_target_inputs",
+               &ngraph::Output<ngraph::Node>::get_target_inputs,
+               R"mydelimiter(
+                A set containing handles for all inputs targeted by the output
+                referenced by this output handle.
+                Returns
+                ----------
+                get_target_inputs : Set[Input]
+                    Set of Inputs.
+               )mydelimiter");
 }

--- a/ngraph/python/src/pyngraph/node_output.cpp
+++ b/ngraph/python/src/pyngraph/node_output.cpp
@@ -18,62 +18,62 @@ void regclass_pyngraph_Output(py::module m)
 
     output.def("get_node",
                &ngraph::Output<ngraph::Node>::get_node,
-               R"mydelimiter(
+               R"(
                 Get node referenced by this output handle.
 
                 Returns
                 ----------
                 get_node : Node
                     Node object referenced by this output handle.
-               )mydelimiter");
+               )");
     output.def("get_index",
                &ngraph::Output<ngraph::Node>::get_index,
-               R"mydelimiter(
+               R"(
                 The index of the output referred to by this output handle.
 
                 Returns
                 ----------
                 get_index : int
                     Index value as integer.
-               )mydelimiter");
+               )");
     output.def("get_element_type",
                &ngraph::Output<ngraph::Node>::get_element_type,
-               R"mydelimiter(
+               R"(
                 The element type of the output referred to by this output handle.
 
                 Returns
                 ----------
                 get_element_type : Type
                     Type of the output.
-               )mydelimiter");
+               )");
     output.def("get_shape",
                &ngraph::Output<ngraph::Node>::get_shape,
-               R"mydelimiter(
+               R"(
                 The shape of the output referred to by this output handle.
 
                 Returns
                 ----------
                 get_shape : Shape
                     Shape of the output.
-               )mydelimiter");
+               )");
     output.def("get_partial_shape",
                &ngraph::Output<ngraph::Node>::get_partial_shape,
-               R"mydelimiter(
+               R"(
                 The partial shape of the output referred to by this output handle.
 
                 Returns
                 ----------
                 get_partial_shape : PartialShape
                     PartialShape of the output.
-               )mydelimiter");
+               )");
     output.def("get_target_inputs",
                &ngraph::Output<ngraph::Node>::get_target_inputs,
-               R"mydelimiter(
+               R"(
                 A set containing handles for all inputs targeted by the output
                 referenced by this output handle.
                 Returns
                 ----------
                 get_target_inputs : Set[Input]
                     Set of Inputs.
-               )mydelimiter");
+               )");
 }

--- a/ngraph/python/src/pyngraph/partial_shape.cpp
+++ b/ngraph/python/src/pyngraph/partial_shape.cpp
@@ -35,19 +35,130 @@ void regclass_pyngraph_PartialShape(py::module m)
 
     shape.def_static("dynamic", &ngraph::PartialShape::dynamic, py::arg("r") = ngraph::Dimension());
 
-    shape.def_property_readonly("is_dynamic", &ngraph::PartialShape::is_dynamic);
-    shape.def_property_readonly("is_static", &ngraph::PartialShape::is_static);
-    shape.def_property_readonly("rank", &ngraph::PartialShape::rank);
-    shape.def_property_readonly("all_non_negative", &ngraph::PartialShape::all_non_negative);
+    shape.def_property_readonly("is_dynamic",
+                                &ngraph::PartialShape::is_dynamic,
+                                R"(
+                                    False if this shape is static, else True.
+                                    A shape is considered static if it has static rank,
+                                    and all dimensions of the shape are static.
+                                )");
+    shape.def_property_readonly("is_static",
+                                &ngraph::PartialShape::is_static,
+                                R"(
+                                    True if this shape is static, else False.
+                                    A shape is considered static if it has static rank, 
+                                    and all dimensions of the shape are static.
+                                )");
+    shape.def_property_readonly("rank",
+                                &ngraph::PartialShape::rank,
+                                R"(
+                                    The rank of the shape.
+                                )");
+    shape.def_property_readonly("all_non_negative",
+                                &ngraph::PartialShape::all_non_negative,
+                                R"(
+                                    True if all static dimensions of the tensor are 
+                                    non-negative, else False.
+                                )");
 
-    shape.def("compatible", &ngraph::PartialShape::compatible);
-    shape.def("refines", &ngraph::PartialShape::refines);
-    shape.def("relaxes", &ngraph::PartialShape::relaxes);
-    shape.def("same_scheme", &ngraph::PartialShape::same_scheme);
-    shape.def("get_max_shape", &ngraph::PartialShape::get_max_shape);
-    shape.def("get_min_shape", &ngraph::PartialShape::get_min_shape);
-    shape.def("get_shape", &ngraph::PartialShape::get_shape);
-    shape.def("to_shape", &ngraph::PartialShape::to_shape);
+    shape.def("compatible",
+              &ngraph::PartialShape::compatible,
+              py::arg("s"),
+              R"(
+                Check whether this shape is compatible with the argument, i.e.,
+                whether it is possible to merge them.
+                
+                Parameters
+                ----------
+                s : PartialShape
+                    The shape to be checked for compatibility with this shape.
+
+
+                Returns
+                ----------
+                compatible : bool
+                    True if this shape is compatible with s, else False.
+              )");
+    shape.def("refines",
+              &ngraph::PartialShape::refines,
+              py::arg("s"),
+              R"(
+                Check whether this shape is a refinement of the argument.
+
+                Parameters
+                ----------
+                s : PartialShape
+                    The shape which is being compared against this shape.        
+        
+                Returns
+                ----------
+                refines : bool
+                    True if this shape refines s, else False.
+              )");
+    shape.def("relaxes",
+              &ngraph::PartialShape::relaxes,
+              py::arg("s"),
+              R"(
+                Check whether this shape is a relaxation of the argument.
+
+                Parameters
+                ----------
+                s : PartialShape
+                    The shape which is being compared against this shape.        
+        
+                Returns
+                ----------
+                relaxes : bool
+                    True if this shape relaxes s, else False.
+              )");
+    shape.def("same_scheme",
+              &ngraph::PartialShape::same_scheme,
+              py::arg("s"),
+              R"(
+                Check whether this shape represents the same scheme as the argument.
+
+                Parameters
+                ----------
+                s : PartialShape
+                    The shape which is being compared against this shape.        
+        
+                Returns
+                ----------
+                same_scheme : bool
+                    True if shape represents the same scheme as s, else False.
+              )");
+    shape.def("get_max_shape",
+              &ngraph::PartialShape::get_max_shape,
+              R"(
+                Returns
+                ----------
+                get_max_shape : Shape
+                    Get the max bounding shape.
+              )");
+    shape.def("get_min_shape",
+              &ngraph::PartialShape::get_min_shape,
+              R"(
+                Returns
+                ----------
+                get_min_shape : Shape
+                    Get the min bounding shape.
+              )");
+    shape.def("get_shape",
+              &ngraph::PartialShape::get_shape,
+              R"(
+                Returns
+                ----------
+                get_shape : Shape
+                    Get the unique shape.
+              )");
+    shape.def("to_shape",
+              &ngraph::PartialShape::to_shape,
+              R"(
+                Returns
+                ----------
+                to_shapess : Shape
+                    Get the unique shape.
+              )");
 
     shape.def(
         "__eq__",

--- a/ngraph/python/src/pyngraph/pyngraph.cpp
+++ b/ngraph/python/src/pyngraph/pyngraph.cpp
@@ -36,20 +36,19 @@ PYBIND11_MODULE(_pyngraph, m)
 {
     m.doc() = "Package ngraph.impl that wraps nGraph's namespace ngraph";
     regclass_pyngraph_PyRTMap(m);
+    regmodule_pyngraph_types(m);
+    regclass_pyngraph_Dimension(m); // Dimension must be registered before PartialShape
+    regclass_pyngraph_Shape(m);
+    regclass_pyngraph_PartialShape(m);
     regclass_pyngraph_Node(m);
     regclass_pyngraph_Input(m);
     regclass_pyngraph_Output(m);
     regclass_pyngraph_NodeFactory(m);
-    regclass_pyngraph_Dimension(m); // Dimension must be registered before PartialShape
-    regclass_pyngraph_PartialShape(m);
-    regclass_pyngraph_Shape(m);
     regclass_pyngraph_Strides(m);
     regclass_pyngraph_CoordinateDiff(m);
     regclass_pyngraph_AxisSet(m);
     regclass_pyngraph_AxisVector(m);
     regclass_pyngraph_Coordinate(m);
-    regmodule_pyngraph_types(m);
-    regclass_pyngraph_Function(m);
     py::module m_op = m.def_submodule("op", "Package ngraph.impl.op that wraps ngraph::op");
     regclass_pyngraph_op_Constant(m_op);
     regclass_pyngraph_op_Parameter(m_op);
@@ -58,6 +57,7 @@ PYBIND11_MODULE(_pyngraph, m)
     regmodule_pyngraph_onnx_import(m);
 #endif
     regmodule_pyngraph_op_util(m_op);
+    regclass_pyngraph_Function(m);
     regmodule_pyngraph_passes(m);
     regmodule_pyngraph_util(m);
     regclass_pyngraph_Variant(m);

--- a/ngraph/python/src/pyngraph/shape.cpp
+++ b/ngraph/python/src/pyngraph/shape.cpp
@@ -18,9 +18,12 @@ void regclass_pyngraph_Shape(py::module m)
 {
     py::class_<ngraph::Shape, std::shared_ptr<ngraph::Shape>> shape(m, "Shape");
     shape.doc() = "ngraph.impl.Shape wraps ngraph::Shape";
-    shape.def(py::init<const std::initializer_list<size_t>&>());
-    shape.def(py::init<const std::vector<size_t>&>());
-    shape.def(py::init<const ngraph::Shape&>());
+    shape.def(py::init<const std::initializer_list<size_t>&>(),
+              py::arg("axis_lengths"));
+    shape.def(py::init<const std::vector<size_t>&>(),
+              py::arg("axis_lengths"));
+    shape.def(py::init<const ngraph::Shape&>(),
+              py::arg("axis_lengths"));
     shape.def("__len__", [](const ngraph::Shape& v) { return v.size(); });
     shape.def("__getitem__", [](const ngraph::Shape& v, int key) { return v[key]; });
 

--- a/ngraph/python/src/pyngraph/strides.cpp
+++ b/ngraph/python/src/pyngraph/strides.cpp
@@ -18,9 +18,12 @@ void regclass_pyngraph_Strides(py::module m)
 {
     py::class_<ngraph::Strides, std::shared_ptr<ngraph::Strides>> strides(m, "Strides");
     strides.doc() = "ngraph.impl.Strides wraps ngraph::Strides";
-    strides.def(py::init<const std::initializer_list<size_t>&>());
-    strides.def(py::init<const std::vector<size_t>&>());
-    strides.def(py::init<const ngraph::Strides&>());
+    strides.def(py::init<const std::initializer_list<size_t>&>(),
+                py::arg("axis_strides"));
+    strides.def(py::init<const std::vector<size_t>&>(),
+                py::arg("axis_strides"));
+    strides.def(py::init<const ngraph::Strides&>(),
+                py::arg("axis_strides"));
 
     strides.def("__str__", [](const ngraph::Strides& self) -> std::string {
         std::stringstream stringstream;

--- a/ngraph/python/src/pyngraph/variant.hpp
+++ b/ngraph/python/src/pyngraph/variant.hpp
@@ -52,8 +52,21 @@ extern void regclass_pyngraph_VariantWrapper(py::module m, std::string typestrin
     });
 
     variant_wrapper.def("get",
-                        (VT & (ngraph::VariantWrapper<VT>::*)()) & ngraph::VariantWrapper<VT>::get);
-    variant_wrapper.def("set", &ngraph::VariantWrapper<VT>::set);
+                        (VT & (ngraph::VariantWrapper<VT>::*)()) & ngraph::VariantWrapper<VT>::get,
+                        R"(
+                            Returns
+                            ----------
+                            get : Variant
+                                Value of Variant.
+                        )");
+    variant_wrapper.def("set",
+                        &ngraph::VariantWrapper<VT>::set,
+                        R"(
+                            Parameters
+                            ----------
+                            set : str or int
+                                Value to be set in Variant.
+                        )");
 
     variant_wrapper.def_property("value",
                                  (VT & (ngraph::VariantWrapper<VT>::*)()) &


### PR DESCRIPTION
### Details:
 - Added doc strings to nGraph classes.
 - Changed order of class registering in pybind. That allows automatic signatures generator (from pybind) to see classes in form `_pyngraph.class_name` instead of C++ notation in form of `ngraph::class_name`.
 - Added py::args to functions which suggest automatic signatures generator to replace names in signatures and allows users to specify the argument in a function call `func(argument_name = value)`.

### Tickets:
 - *51816*
