### PR TITLE
Improve Hybrid CPUs support implementation

### DIFF
--- a/inference-engine/src/inference_engine/CMakeLists.txt
+++ b/inference-engine/src/inference_engine/CMakeLists.txt
@@ -5,7 +5,10 @@
 set (TARGET_NAME "inference_engine")
 
 if(THREADING STREQUAL "TBB" OR THREADING STREQUAL "TBB_AUTO")
-    find_package(TBBBIND_2_4)
+    find_package(TBBBIND_2_4 QUIET)
+    if (TBBBIND_2_4_FOUND)
+        message(STATUS "Static tbbbind_2_4 package was found")
+    endif()
 endif()
 
 file (GLOB LIBRARY_SRC

--- a/inference-engine/src/inference_engine/threading/ie_cpu_streams_executor.cpp
+++ b/inference-engine/src/inference_engine/threading/ie_cpu_streams_executor.cpp
@@ -32,14 +32,14 @@ struct CPUStreamsExecutor::Impl {
             int     _ncpus                  = 0;
             int     _threadBindingStep      = 0;
             int     _offset                 = 0;
-            Observer(tbb::task_arena&    arena,
+            Observer(custom::task_arena&    arena,
                      CpuSet              mask,
                      int                 ncpus,
                      const int           streamId,
                      const int           threadsPerStream,
                      const int           threadBindingStep,
                      const int           threadBindingOffset) :
-                tbb::task_scheduler_observer(arena),
+                tbb::task_scheduler_observer(static_cast<tbb::task_arena&>(arena)),
                 _mask{std::move(mask)},
                 _ncpus(ncpus),
                 _threadBindingStep(threadBindingStep),

--- a/inference-engine/src/inference_engine/threading/ie_parallel_custom_arena.cpp
+++ b/inference-engine/src/inference_engine/threading/ie_parallel_custom_arena.cpp
@@ -22,8 +22,6 @@ namespace custom {
 namespace detail {
 
 #if USE_TBBBIND_2_4
-class binding_handler;
-
 extern "C" {
 void __TBB_internal_initialize_system_topology(
     std::size_t groups_num,
@@ -98,40 +96,34 @@ void initialize_system_topology() {
     });
 }
 
-class binding_observer : public tbb::task_scheduler_observer {
-    binding_handler* my_binding_handler;
-public:
-    binding_observer(tbb::task_arena& ta, int num_slots, const constraints& c)
-        : task_scheduler_observer(ta) {
-        detail::initialize_system_topology();
-        my_binding_handler = detail::__TBB_internal_allocate_binding_handler(num_slots, c.numa_id, c.core_type, c.max_threads_per_core);
-    }
-    ~binding_observer() {
-        detail::__TBB_internal_deallocate_binding_handler(my_binding_handler);
-    }
+binding_observer::binding_observer(tbb::task_arena& ta, int num_slots, const constraints& c)
+    : task_scheduler_observer(ta) {
+    detail::initialize_system_topology();
+    my_binding_handler = detail::__TBB_internal_allocate_binding_handler(num_slots, c.numa_id, c.core_type, c.max_threads_per_core);
+}
 
-    void on_scheduler_entry(bool) override {
-        detail::__TBB_internal_apply_affinity(my_binding_handler, tbb::this_task_arena::current_thread_index());
-    }
-    void on_scheduler_exit(bool) override {
-        detail::__TBB_internal_restore_affinity(my_binding_handler, tbb::this_task_arena::current_thread_index());
-    }
-};
+binding_observer::~binding_observer() {
+    detail::__TBB_internal_deallocate_binding_handler(my_binding_handler);
+}
 
-binding_observer* construct_binding_observer(tbb::task_arena& ta, int num_slots, const constraints& c) {
-    binding_observer* observer = nullptr;
+void binding_observer::on_scheduler_entry(bool) {
+    detail::__TBB_internal_apply_affinity(my_binding_handler, tbb::this_task_arena::current_thread_index());
+}
+
+void binding_observer::on_scheduler_exit(bool) {
+    detail::__TBB_internal_restore_affinity(my_binding_handler, tbb::this_task_arena::current_thread_index());
+}
+
+binding_oberver_ptr construct_binding_observer(tbb::task_arena& ta, int num_slots, const constraints& c) {
+    binding_oberver_ptr observer{};
     if (detail::is_binding_environment_valid() &&
       ((c.core_type >= 0 && info::core_types().size() > 1) || (c.numa_id >= 0 && info::numa_nodes().size() > 1) || c.max_threads_per_core > 0)) {
-        observer = new binding_observer(ta, num_slots, c);
+        observer.reset(new binding_observer{ta, num_slots, c});
         observer->observe(true);
     }
     return observer;
 }
 
-void destroy_binding_observer(binding_observer* observer) {
-    observer->observe(false);
-    delete observer;
-}
 #endif /*USE_TBBBIND_2_4*/
 
 #if TBB_NUMA_SUPPORT_PRESENT
@@ -152,21 +144,21 @@ task_arena::task_arena(int max_concurrency_, unsigned reserved_for_masters)
     : my_task_arena{max_concurrency_, reserved_for_masters}
     , my_initialization_state{}
     , my_constraints{}
-    , my_binding_observer{nullptr}
+    , my_binding_observer{}
 {}
 
 task_arena::task_arena(const constraints& constraints_, unsigned reserved_for_masters)
     : my_task_arena{info::default_concurrency(constraints_), reserved_for_masters}
     , my_initialization_state{}
     , my_constraints{constraints_}
-    , my_binding_observer{nullptr}
+    , my_binding_observer{}
 {}
 
 task_arena::task_arena(const task_arena &s)
     : my_task_arena{s.my_task_arena}
     , my_initialization_state{}
     , my_constraints{s.my_constraints}
-    , my_binding_observer{nullptr}
+    , my_binding_observer{}
 {}
 
 void task_arena::initialize() {
@@ -220,14 +212,6 @@ task_arena::operator tbb::task_arena&() {
 int task_arena::max_concurrency() {
     initialize();
     return my_task_arena.max_concurrency();
-}
-
-task_arena::~task_arena() {
-#if USE_TBBBIND_2_4
-    if (my_binding_observer != nullptr) {
-        detail::destroy_binding_observer(my_binding_observer);
-    }
-#endif
 }
 
 namespace info {


### PR DESCRIPTION
This patch improves the Hybrid CPU support feature implementation. Common improvements list:
- Change the relation between `custom::task_arena` and `tbb::task_arena` from inheritance to composition to prevent dangerous implicit casting that may cause settings missing. The explicit conversion to the lvalue tbb::task_arena reference operator is introduced to cover the `tbb::task_scheduler_observer` construction case.
- Wrap the `custom::task_arena::my_binding_observer` member to the `std::unique_ptr` class.
- Add the `QUIET` argument to the `find_package(TBBBIND_2_4)` call to prevent error message generation on systems where `tbbbind_2_4` usage is not applicable (get rid of [the warning](https://github.com/openvinotoolkit/openvino/pull/5356#issuecomment-827092978)).