### PR TITLE
Fetch ONNX and Protobuf in shallow mode

### DIFF
--- a/ngraph/cmake/external_onnx.cmake
+++ b/ngraph/cmake/external_onnx.cmake
@@ -23,6 +23,7 @@ FetchContent_Declare(
     ext_onnx
     GIT_REPOSITORY ${ONNX_GIT_REPO_URL}
     GIT_TAG ${ONNX_GIT_BRANCH}
+    GIT_SHALLOW TRUE
     # apply patch to fix problems with symbols visibility for MSVC
     PATCH_COMMAND git reset --hard HEAD && git apply --ignore-space-change --ignore-whitespace --verbose ${ONNX_PATCH_FILE}
 )

--- a/ngraph/cmake/external_protobuf.cmake
+++ b/ngraph/cmake/external_protobuf.cmake
@@ -68,6 +68,7 @@ else()
             ext_protobuf
             GIT_REPOSITORY ${NGRAPH_PROTOBUF_GIT_REPO_URL}
             GIT_TAG ${NGRAPH_PROTOBUF_GIT_TAG}
+            GIT_SHALLOW TRUE
         )
 
         FetchContent_GetProperties(ext_protobuf)


### PR DESCRIPTION
Clone a particular revision for both ONNX and Protobuf. Decreases the amount of data being downloaded in each cmake invocation and slightly reduces the build configuration time (35s vs 32s when the connection is stable).

Without shallow clone:

```
    138M    ./ext_protobuf-src
    1.2M    ./ext_protobuf-build
    160K    ./ext_onnx-subbuild
    164K    ./ext_protobuf-subbuild
    592K    ./ext_onnx-build
    71M     ./ext_onnx-src
    211M    .
```

With shallow clone:

``` 
    76M     ./ext_protobuf-src
    1.2M    ./ext_protobuf-build
    160K    ./ext_onnx-subbuild
    164K    ./ext_protobuf-subbuild
    592K    ./ext_onnx-build
    60M     ./ext_onnx-src
    138M    .
```