### PR TITLE
[IE CLDNN] Fix for a segfault discovered in ONNX Pad tests

### DIFF
--- a/inference-engine/src/cldnn_engine/ops/pad.cpp
+++ b/inference-engine/src/cldnn_engine/ops/pad.cpp
@@ -27,8 +27,10 @@ static std::vector<int32_t> GetPermuteOrder(const ngraph::CoordinateDiff& ie_ord
     std::vector<int32_t> cldnn_order(ie_order.begin(), ie_order.end());
 
     // 1. Align to min. 4 sizes
-    if (cldnn_order.size() < 4)
-        cldnn_order.push_back(0);
+    if (cldnn_order.size() < 4) {
+        const auto zeros_to_add = 4 - ie_order.size();
+        cldnn_order.insert(cldnn_order.end(), zeros_to_add, 0);
+    }
 
     // 2. Swap spatial positions
     for (int i = 0; i < (cldnn_order.size() - 2) / 2; i++) {


### PR DESCRIPTION
### Details:
 - Fixes a segfault in ONNX Pad operator tests
 - The tests still fail but because of the dynamic shapes support
 - The segfault doesn't occur any more, an exception is thrown instead
 - Affected tests: test_constant_pad_cpu, test_edge_pad_cpu, test_reflect_pad_cpu