### PR TITLE
Enable `FetchContent` for `gflags` dependency in stress tests

### DIFF
--- a/tests/stress_tests/CMakeLists.txt
+++ b/tests/stress_tests/CMakeLists.txt
@@ -9,6 +9,9 @@ if (CMAKE_BUILD_TYPE STREQUAL "")
     set(CMAKE_BUILD_TYPE "Release")
 endif()
 
+set (HAVE_SYS_STAT_H 1)
+set (HAVE_INTTYPES_H 1)
+set (INTTYPES_FORMAT C99)
 find_package(InferenceEngineDeveloperPackage REQUIRED)
 
 add_subdirectory(unittests)

--- a/tests/stress_tests/memcheck_tests/CMakeLists.txt
+++ b/tests/stress_tests/memcheck_tests/CMakeLists.txt
@@ -19,7 +19,17 @@ file (GLOB HDR
 # Create library file from sources.
 add_executable(${TARGET_NAME} ${HDR} ${SRC})
 
-find_package(gflags REQUIRED)
+include(FetchContent)
+FetchContent_Declare(
+    gflags
+    GIT_REPOSITORY "https://github.com/gflags/gflags.git"
+    GIT_TAG "v2.2.2"
+)
+FetchContent_GetProperties(gflags)
+if(NOT gflags_POPULATED)
+    FetchContent_Populate(gflags)
+    add_subdirectory(${gflags_SOURCE_DIR} ${gflags_BINARY_DIR})
+endif()
 
 target_link_libraries(${TARGET_NAME}
         IE::gtest

--- a/tests/stress_tests/memleaks_tests/CMakeLists.txt
+++ b/tests/stress_tests/memleaks_tests/CMakeLists.txt
@@ -20,7 +20,17 @@ file (GLOB HDR
 # Create library file from sources.
 add_executable(${TARGET_NAME} ${HDR} ${SRC})
 
-find_package(gflags REQUIRED)
+include(FetchContent)
+FetchContent_Declare(
+    gflags
+    GIT_REPOSITORY "https://github.com/gflags/gflags.git"
+    GIT_TAG "v2.2.2"
+)
+FetchContent_GetProperties(gflags)
+if(NOT gflags_POPULATED)
+    FetchContent_Populate(gflags)
+    add_subdirectory(${gflags_SOURCE_DIR} ${gflags_BINARY_DIR})
+endif()
 
 target_link_libraries(${TARGET_NAME}
         IE::gtest

--- a/tests/stress_tests/unittests/CMakeLists.txt
+++ b/tests/stress_tests/unittests/CMakeLists.txt
@@ -20,7 +20,17 @@ file (GLOB HDR
 # Create library file from sources.
 add_executable(${TARGET_NAME} ${HDR} ${SRC})
 
-find_package(gflags REQUIRED)
+include(FetchContent)
+FetchContent_Declare(
+    gflags
+    GIT_REPOSITORY "https://github.com/gflags/gflags.git"
+    GIT_TAG "v2.2.2"
+)
+FetchContent_GetProperties(gflags)
+if(NOT gflags_POPULATED)
+    FetchContent_Populate(gflags)
+    add_subdirectory(${gflags_SOURCE_DIR} ${gflags_BINARY_DIR})
+endif()
 
 target_link_libraries(${TARGET_NAME}
         IE::gtest


### PR DESCRIPTION
### Tickets:
 - 50335
