### PR TITLE
[ONNX] Add Constant op from opset 13

### DIFF
--- a/ngraph/frontend/onnx_import/include/onnx_import/core/node.hpp
+++ b/ngraph/frontend/onnx_import/include/onnx_import/core/node.hpp
@@ -59,6 +59,7 @@ namespace ngraph
             const std::string& domain() const;
             const std::string& op_type() const;
             const std::string& get_name() const;
+            std::vector<std::string> get_attribute_names() const;
 
             /// \brief Describe the ONNX Node to make debugging graphs easier
             /// Function will return the Node's name if it has one, or the names of its outputs.

--- a/ngraph/frontend/onnx_import/include/onnx_import/core/node.hpp
+++ b/ngraph/frontend/onnx_import/include/onnx_import/core/node.hpp
@@ -41,6 +41,7 @@ namespace ngraph
         class Graph;
         class Subgraph;
         class Tensor;
+        class Attribute;
 
         class ONNX_IMPORTER_API Node
         {
@@ -60,6 +61,7 @@ namespace ngraph
             const std::string& op_type() const;
             const std::string& get_name() const;
             std::vector<std::string> get_attribute_names() const;
+            const Attribute& get_attribute(const std::string& name) const;
 
             /// \brief Describe the ONNX Node to make debugging graphs easier
             /// Function will return the Node's name if it has one, or the names of its outputs.

--- a/ngraph/frontend/onnx_import/src/core/node.cpp
+++ b/ngraph/frontend/onnx_import/src/core/node.cpp
@@ -220,6 +220,20 @@ namespace ngraph
             return attr_names;
         }
 
+        const Attribute& Node::get_attribute(const std::string& name) const
+        {
+            const auto& node_attributes = m_pimpl->attributes();
+            auto found_attr =
+                std::find_if(std::begin(node_attributes),
+                             std::end(node_attributes),
+                             [&name](const Attribute& a) { return a.get_name() == name; });
+            if (found_attr == std::end(node_attributes))
+            {
+                throw error::node::UnknownAttribute{this->get_name(), name};
+            }
+            return *found_attr;
+        }
+
         template <>
         float Node::get_attribute_value(const std::string& name, float default_value) const
         {

--- a/ngraph/frontend/onnx_import/src/core/node.cpp
+++ b/ngraph/frontend/onnx_import/src/core/node.cpp
@@ -30,6 +30,7 @@ namespace ngraph
             }
 
             const std::vector<Attribute>& attributes() const;
+            std::vector<std::string> get_attribute_names() const;
             OutputVector get_ng_nodes(const Node& node) const;
             OutputVector get_ng_inputs() const;
 
@@ -205,6 +206,18 @@ namespace ngraph
         bool Node::has_attribute(const std::string& name) const
         {
             return m_pimpl->has_attribute(name);
+        }
+
+        std::vector<std::string> Node::get_attribute_names() const
+        {
+            std::vector<std::string> attr_names;
+            const auto& node_attributes = m_pimpl->attributes();
+            attr_names.reserve(node_attributes.size());
+            std::transform(std::begin(node_attributes),
+                           std::end(node_attributes),
+                           std::back_inserter(attr_names),
+                           [](const Attribute& a) { return a.get_name(); });
+            return attr_names;
         }
 
         template <>

--- a/ngraph/frontend/onnx_import/src/core/node.cpp
+++ b/ngraph/frontend/onnx_import/src/core/node.cpp
@@ -30,7 +30,6 @@ namespace ngraph
             }
 
             const std::vector<Attribute>& attributes() const;
-            std::vector<std::string> get_attribute_names() const;
             OutputVector get_ng_nodes(const Node& node) const;
             OutputVector get_ng_inputs() const;
 

--- a/ngraph/frontend/onnx_import/src/core/tensor.hpp
+++ b/ngraph/frontend/onnx_import/src/core/tensor.hpp
@@ -249,6 +249,26 @@ namespace ngraph
                 }
 
                 template <>
+                inline std::vector<ngraph::bfloat16>
+                    get_data(const ONNX_NAMESPACE::TensorProto& tensor)
+                {
+                    if (detail::has_tensor_external_data(tensor))
+                    {
+                        return detail::get_external_data<bfloat16>(tensor);
+                    }
+                    if (tensor.has_raw_data())
+                    {
+                        return detail::__get_raw_data<ngraph::bfloat16>(tensor.raw_data(),
+                                                                        tensor.data_type());
+                    }
+                    if (tensor.data_type() == ONNX_NAMESPACE::TensorProto_DataType_BFLOAT16)
+                    {
+                        return detail::__get_data<ngraph::bfloat16>(tensor.int32_data());
+                    }
+                    throw error::tensor::invalid_data_type{tensor.data_type()};
+                }
+
+                template <>
                 inline std::vector<int8_t> get_data(const ONNX_NAMESPACE::TensorProto& tensor)
                 {
                     if (detail::has_tensor_external_data(tensor))
@@ -441,6 +461,7 @@ namespace ngraph
                 float64 = ONNX_NAMESPACE::TensorProto_DataType_DOUBLE,
                 uint32 = ONNX_NAMESPACE::TensorProto_DataType_UINT32,
                 uint64 = ONNX_NAMESPACE::TensorProto_DataType_UINT64,
+                bfloat16 = ONNX_NAMESPACE::TensorProto_DataType_BFLOAT16,
                 complex64 = ONNX_NAMESPACE::TensorProto_DataType_COMPLEX64,
                 complex128 = ONNX_NAMESPACE::TensorProto_DataType_COMPLEX128
             };
@@ -526,6 +547,8 @@ namespace ngraph
                     return element::u32;
                 case ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_UINT64:
                     return element::u64;
+                case ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_BFLOAT16:
+                    return element::bf16;
                 case ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_UNDEFINED:
                     throw error::tensor::data_type_undefined{};
                 default: throw error::tensor::unsupported_data_type{m_tensor_proto->data_type()};
@@ -561,6 +584,8 @@ namespace ngraph
                     return make_ng_constant<uint32_t>(element::u32);
                 case ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_UINT64:
                     return make_ng_constant<uint64_t>(element::u64);
+                case ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_BFLOAT16:
+                    return make_ng_constant<ngraph::bfloat16>(element::bf16);
                 default: throw error::tensor::unsupported_data_type{m_tensor_proto->data_type()};
                 }
             }

--- a/ngraph/frontend/onnx_import/src/op/constant.cpp
+++ b/ngraph/frontend/onnx_import/src/op/constant.cpp
@@ -135,6 +135,13 @@ namespace ngraph
                     return __make_ng_constant<char>(element::boolean, tensor);
                 }
 
+                template <>
+                inline std::shared_ptr<default_opset::Constant>
+                    make_ng_constant<Tensor::Type::bfloat16>(const Tensor& tensor)
+                {
+                    return __make_ng_constant<ngraph::bfloat16>(element::bf16, tensor);
+                }
+
                 inline std::shared_ptr<default_opset::Constant> make_constant(const Tensor& tensor)
                 {
 #define MAKE_NG_CONSTANT(data_type_)                                                               \
@@ -154,6 +161,7 @@ namespace ngraph
                         MAKE_NG_CONSTANT(Tensor::Type::uint32);
                         MAKE_NG_CONSTANT(Tensor::Type::uint64);
                         MAKE_NG_CONSTANT(Tensor::Type::boolean);
+                        MAKE_NG_CONSTANT(Tensor::Type::bfloat16);
                     default: throw error::tensor::invalid_data_type{tensor};
                     }
                 }
@@ -202,16 +210,6 @@ namespace ngraph
                         return {default_opset::Constant::create(
                             element::i64, ngraph::Shape{values.size()}, values)};
                     }
-                    // else if(attribute.is_string())
-                    // {
-                    //    return {default_opset::Constant::create(element::string, ngraph::Shape{},
-                    //    {attribute.get_string()})};
-                    // }
-                    // else if (attribute.is_string_array()){
-                    //    auto values = attribute.get_string_array();
-                    //    return {default_opset::Constant::create(element::string,
-                    //    ngraph::Shape{values.size()}, values)};
-                    // }
                     return {make_constant(node.get_attribute_value<Tensor>(attributes_names[0]))};
                 }
 

--- a/ngraph/frontend/onnx_import/src/op/constant.cpp
+++ b/ngraph/frontend/onnx_import/src/op/constant.cpp
@@ -14,158 +14,171 @@ namespace ngraph
     {
         namespace op
         {
-            namespace set_1
+            namespace
             {
-                namespace
+                template <typename T>
+                inline std::shared_ptr<default_opset::Constant>
+                    __make_ng_constant(const element::Type& type, const Tensor& tensor)
                 {
-                    template <typename T>
-                    inline std::shared_ptr<default_opset::Constant>
-                        __make_ng_constant(const element::Type& type, const Tensor& tensor)
+                    std::shared_ptr<default_opset::Constant> constant{nullptr};
+                    try
                     {
-                        std::shared_ptr<default_opset::Constant> constant{nullptr};
-                        try
-                        {
-                            constant = std::make_shared<default_opset::Constant>(
-                                type, tensor.get_shape(), tensor.get_data<T>());
-                        }
-                        catch (const ngraph::ngraph_error& exc)
-                        {
-                            NGRAPH_WARN
-                                << "\nCould not create an nGraph Constant for an ONNX Constant "
-                                   "node. "
-                                << "Constant with a 0 value was created instead.\n"
-                                << "Verify if the ONNX Constant node contains a correct number of "
-                                   "elements matching the node's shape. \n"
-                                << "Detailed error:\n"
-                                << exc.what();
-                            constant = std::make_shared<default_opset::Constant>(type, Shape{}, 0);
-                        }
-
-                        return constant;
+                        constant = std::make_shared<default_opset::Constant>(
+                            type, tensor.get_shape(), tensor.get_data<T>());
+                    }
+                    catch (const ngraph::ngraph_error& exc)
+                    {
+                        NGRAPH_WARN
+                            << "\nCould not create an nGraph Constant for an ONNX Constant "
+                               "node. "
+                            << "Constant with a 0 value was created instead.\n"
+                            << "Verify if the ONNX Constant node contains a correct number of "
+                               "elements matching the node's shape. \n"
+                            << "Detailed error:\n"
+                            << exc.what();
+                        constant = std::make_shared<default_opset::Constant>(type, Shape{}, 0);
                     }
 
-                    template <Tensor::Type>
-                    inline std::shared_ptr<default_opset::Constant>
-                        make_ng_constant(const Tensor& tensor)
-                    {
-                        throw error::tensor::unsupported_data_type{tensor};
-                    }
+                    return constant;
+                }
 
-                    template <>
-                    inline std::shared_ptr<default_opset::Constant>
-                        make_ng_constant<Tensor::Type::float16>(const Tensor& tensor)
-                    {
-                        return __make_ng_constant<ngraph::float16>(element::f16, tensor);
-                    }
+                template <Tensor::Type>
+                inline std::shared_ptr<default_opset::Constant>
+                    make_ng_constant(const Tensor& tensor)
+                {
+                    throw error::tensor::unsupported_data_type{tensor};
+                }
 
-                    template <>
-                    inline std::shared_ptr<default_opset::Constant>
-                        make_ng_constant<Tensor::Type::float32>(const Tensor& tensor)
-                    {
-                        return __make_ng_constant<float>(element::f32, tensor);
-                    }
+                template <>
+                inline std::shared_ptr<default_opset::Constant>
+                    make_ng_constant<Tensor::Type::float16>(const Tensor& tensor)
+                {
+                    return __make_ng_constant<ngraph::float16>(element::f16, tensor);
+                }
 
-                    template <>
-                    inline std::shared_ptr<default_opset::Constant>
-                        make_ng_constant<Tensor::Type::float64>(const Tensor& tensor)
-                    {
-                        return __make_ng_constant<double>(element::f64, tensor);
-                    }
+                template <>
+                inline std::shared_ptr<default_opset::Constant>
+                    make_ng_constant<Tensor::Type::float32>(const Tensor& tensor)
+                {
+                    return __make_ng_constant<float>(element::f32, tensor);
+                }
 
-                    template <>
-                    inline std::shared_ptr<default_opset::Constant>
-                        make_ng_constant<Tensor::Type::int8>(const Tensor& tensor)
-                    {
-                        return __make_ng_constant<int8_t>(element::i8, tensor);
-                    }
+                template <>
+                inline std::shared_ptr<default_opset::Constant>
+                    make_ng_constant<Tensor::Type::float64>(const Tensor& tensor)
+                {
+                    return __make_ng_constant<double>(element::f64, tensor);
+                }
 
-                    template <>
-                    inline std::shared_ptr<default_opset::Constant>
-                        make_ng_constant<Tensor::Type::int16>(const Tensor& tensor)
-                    {
-                        return __make_ng_constant<int16_t>(element::i16, tensor);
-                    }
+                template <>
+                inline std::shared_ptr<default_opset::Constant>
+                    make_ng_constant<Tensor::Type::int8>(const Tensor& tensor)
+                {
+                    return __make_ng_constant<int8_t>(element::i8, tensor);
+                }
 
-                    template <>
-                    inline std::shared_ptr<default_opset::Constant>
-                        make_ng_constant<Tensor::Type::int32>(const Tensor& tensor)
-                    {
-                        return __make_ng_constant<int32_t>(element::i32, tensor);
-                    }
+                template <>
+                inline std::shared_ptr<default_opset::Constant>
+                    make_ng_constant<Tensor::Type::int16>(const Tensor& tensor)
+                {
+                    return __make_ng_constant<int16_t>(element::i16, tensor);
+                }
 
-                    template <>
-                    inline std::shared_ptr<default_opset::Constant>
-                        make_ng_constant<Tensor::Type::int64>(const Tensor& tensor)
-                    {
-                        return __make_ng_constant<int64_t>(element::i64, tensor);
-                    }
+                template <>
+                inline std::shared_ptr<default_opset::Constant>
+                    make_ng_constant<Tensor::Type::int32>(const Tensor& tensor)
+                {
+                    return __make_ng_constant<int32_t>(element::i32, tensor);
+                }
 
-                    template <>
-                    inline std::shared_ptr<default_opset::Constant>
-                        make_ng_constant<Tensor::Type::uint8>(const Tensor& tensor)
-                    {
-                        return __make_ng_constant<uint8_t>(element::u8, tensor);
-                    }
+                template <>
+                inline std::shared_ptr<default_opset::Constant>
+                    make_ng_constant<Tensor::Type::int64>(const Tensor& tensor)
+                {
+                    return __make_ng_constant<int64_t>(element::i64, tensor);
+                }
 
-                    template <>
-                    inline std::shared_ptr<default_opset::Constant>
-                        make_ng_constant<Tensor::Type::uint16>(const Tensor& tensor)
-                    {
-                        return __make_ng_constant<uint16_t>(element::u16, tensor);
-                    }
+                template <>
+                inline std::shared_ptr<default_opset::Constant>
+                    make_ng_constant<Tensor::Type::uint8>(const Tensor& tensor)
+                {
+                    return __make_ng_constant<uint8_t>(element::u8, tensor);
+                }
 
-                    template <>
-                    inline std::shared_ptr<default_opset::Constant>
-                        make_ng_constant<Tensor::Type::uint32>(const Tensor& tensor)
-                    {
-                        return __make_ng_constant<uint32_t>(element::u32, tensor);
-                    }
+                template <>
+                inline std::shared_ptr<default_opset::Constant>
+                    make_ng_constant<Tensor::Type::uint16>(const Tensor& tensor)
+                {
+                    return __make_ng_constant<uint16_t>(element::u16, tensor);
+                }
 
-                    template <>
-                    inline std::shared_ptr<default_opset::Constant>
-                        make_ng_constant<Tensor::Type::uint64>(const Tensor& tensor)
-                    {
-                        return __make_ng_constant<uint64_t>(element::u64, tensor);
-                    }
+                template <>
+                inline std::shared_ptr<default_opset::Constant>
+                    make_ng_constant<Tensor::Type::uint32>(const Tensor& tensor)
+                {
+                    return __make_ng_constant<uint32_t>(element::u32, tensor);
+                }
 
-                    template <>
-                    inline std::shared_ptr<default_opset::Constant>
-                        make_ng_constant<Tensor::Type::boolean>(const Tensor& tensor)
-                    {
-                        return __make_ng_constant<char>(element::boolean, tensor);
-                    }
+                template <>
+                inline std::shared_ptr<default_opset::Constant>
+                    make_ng_constant<Tensor::Type::uint64>(const Tensor& tensor)
+                {
+                    return __make_ng_constant<uint64_t>(element::u64, tensor);
+                }
 
-                    inline std::shared_ptr<default_opset::Constant>
-                        make_constant(const Tensor& tensor)
-                    {
+                template <>
+                inline std::shared_ptr<default_opset::Constant>
+                    make_ng_constant<Tensor::Type::boolean>(const Tensor& tensor)
+                {
+                    return __make_ng_constant<char>(element::boolean, tensor);
+                }
+
+                inline std::shared_ptr<default_opset::Constant> make_constant(const Tensor& tensor)
+                {
 #define MAKE_NG_CONSTANT(data_type_)                                                               \
     case data_type_: return make_ng_constant<data_type_>(tensor)
 
-                        switch (tensor.get_type())
-                        {
-                            MAKE_NG_CONSTANT(Tensor::Type::float16);
-                            MAKE_NG_CONSTANT(Tensor::Type::float32);
-                            MAKE_NG_CONSTANT(Tensor::Type::float64);
-                            MAKE_NG_CONSTANT(Tensor::Type::int8);
-                            MAKE_NG_CONSTANT(Tensor::Type::int16);
-                            MAKE_NG_CONSTANT(Tensor::Type::int32);
-                            MAKE_NG_CONSTANT(Tensor::Type::int64);
-                            MAKE_NG_CONSTANT(Tensor::Type::uint8);
-                            MAKE_NG_CONSTANT(Tensor::Type::uint16);
-                            MAKE_NG_CONSTANT(Tensor::Type::uint32);
-                            MAKE_NG_CONSTANT(Tensor::Type::uint64);
-                            MAKE_NG_CONSTANT(Tensor::Type::boolean);
-                        default: throw error::tensor::invalid_data_type{tensor};
-                        }
+                    switch (tensor.get_type())
+                    {
+                        MAKE_NG_CONSTANT(Tensor::Type::float16);
+                        MAKE_NG_CONSTANT(Tensor::Type::float32);
+                        MAKE_NG_CONSTANT(Tensor::Type::float64);
+                        MAKE_NG_CONSTANT(Tensor::Type::int8);
+                        MAKE_NG_CONSTANT(Tensor::Type::int16);
+                        MAKE_NG_CONSTANT(Tensor::Type::int32);
+                        MAKE_NG_CONSTANT(Tensor::Type::int64);
+                        MAKE_NG_CONSTANT(Tensor::Type::uint8);
+                        MAKE_NG_CONSTANT(Tensor::Type::uint16);
+                        MAKE_NG_CONSTANT(Tensor::Type::uint32);
+                        MAKE_NG_CONSTANT(Tensor::Type::uint64);
+                        MAKE_NG_CONSTANT(Tensor::Type::boolean);
+                    default: throw error::tensor::invalid_data_type{tensor};
                     }
-                } // namespace
+                }
+            } // namespace
 
+            namespace set_1
+            {
                 OutputVector constant(const onnx_import::Node& node)
                 {
                     return {make_constant(node.get_attribute_value<Tensor>("value"))};
                 }
 
             } // namespace set_1
+
+            namespace set_13
+            {
+                OutputVector constant(const onnx_import::Node& node)
+                {
+                    auto attributes = node.get_attribute_names();
+                    NGRAPH_CHECK(attributes.size() == 1,
+                                 "The Constant op expects exactly one attribute."
+                                 "Got: ",
+                                 attributes.size());
+                    return {make_constant(node.get_attribute_value<Tensor>(attributes[0]))};
+                }
+
+            } // namespace set_13
 
         } // namespace op
 

--- a/ngraph/frontend/onnx_import/src/op/constant.hpp
+++ b/ngraph/frontend/onnx_import/src/op/constant.hpp
@@ -19,6 +19,12 @@ namespace ngraph
 
             } // namespace set_1
 
+            namespace set_13
+            {
+                OutputVector constant(const Node& node);
+
+            } // namespace set_13
+
         } // namespace op
 
     } // namespace onnx_import

--- a/ngraph/frontend/onnx_import/src/ops_bridge.cpp
+++ b/ngraph/frontend/onnx_import/src/ops_bridge.cpp
@@ -322,6 +322,7 @@ namespace ngraph
             REGISTER_OPERATOR("Clip", 11, clip);
             REGISTER_OPERATOR("Concat", 1, concat);
             REGISTER_OPERATOR("Constant", 1, constant);
+            REGISTER_OPERATOR("Constant", 13, constant);
             REGISTER_OPERATOR("ConstantOfShape", 1, constant_of_shape);
             REGISTER_OPERATOR("Conv", 1, conv);
             // REGISTER_OPERATOR("ConvInteger", 1, conv_integer);

--- a/ngraph/test/models/onnx/constant_bfloat_tensor.prototxt
+++ b/ngraph/test/models/onnx/constant_bfloat_tensor.prototxt
@@ -29,10 +29,10 @@ graph {
         elem_type: 16
         shape {
           dim {
-            dim_value: 5
+            dim_value: 2
           }
           dim {
-            dim_value: 5
+            dim_value: 3
           }
         }
       }

--- a/ngraph/test/models/onnx/constant_bfloat_tensor.prototxt
+++ b/ngraph/test/models/onnx/constant_bfloat_tensor.prototxt
@@ -1,0 +1,44 @@
+ir_version: 7
+producer_name: "backend-test"
+graph {
+  node {
+    output: "values"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 2
+        dims: 3
+        data_type: 16
+        int32_data: 0
+        int32_data: 5
+        int32_data: 10
+        int32_data: 15
+        int32_data: 20
+        int32_data: 25
+        name: "const_tensor"
+      }
+      type: TENSOR
+    }
+  }
+  name: "test_constant"
+  output {
+    name: "values"
+    type {
+      tensor_type {
+        elem_type: 16
+        shape {
+          dim {
+            dim_value: 5
+          }
+          dim {
+            dim_value: 5
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 13
+}

--- a/ngraph/test/models/onnx/constant_float_array.prototxt
+++ b/ngraph/test/models/onnx/constant_float_array.prototxt
@@ -1,0 +1,32 @@
+ir_version: 7
+producer_name: "backend-test"
+graph {
+  node {
+    output: "values"
+    op_type: "Constant"
+    attribute {
+      name: "value_floats"
+      floats: 0.5
+      floats: 1.0
+      floats: 1.5
+      type: FLOATS
+    }
+  }
+  name: "test_constant"
+  output {
+    name: "values"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim{
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 13
+}

--- a/ngraph/test/models/onnx/constant_float_scalar.prototxt
+++ b/ngraph/test/models/onnx/constant_float_scalar.prototxt
@@ -1,0 +1,28 @@
+ir_version: 7
+producer_name: "backend-test"
+graph {
+  node {
+    output: "values"
+    op_type: "Constant"
+    attribute {
+      name: "value_float"
+      f: 0.5
+      type: FLOAT
+    }
+  }
+  name: "test_constant"
+  output {
+    name: "values"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 13
+}

--- a/ngraph/test/models/onnx/constant_float_tensor.prototxt
+++ b/ngraph/test/models/onnx/constant_float_tensor.prototxt
@@ -1,0 +1,44 @@
+ir_version: 7
+producer_name: "backend-test"
+graph {
+  node {
+    output: "values"
+    op_type: "Constant"
+    attribute {
+      name: "value_floats"
+      t {
+        dims: 2
+        dims: 3
+        data_type: 1
+        float_data: 0
+        float_data: 0.5
+        float_data: 1.0
+        float_data: 1.5
+        float_data: 2
+        float_data: 2.5
+        name: "const_tensor"
+      }
+      type: TENSOR
+    }
+  }
+  name: "test_constant"
+  output {
+    name: "values"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 5
+          }
+          dim {
+            dim_value: 5
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 13
+}

--- a/ngraph/test/models/onnx/constant_float_tensor.prototxt
+++ b/ngraph/test/models/onnx/constant_float_tensor.prototxt
@@ -5,7 +5,7 @@ graph {
     output: "values"
     op_type: "Constant"
     attribute {
-      name: "value_floats"
+      name: "value"
       t {
         dims: 2
         dims: 3

--- a/ngraph/test/models/onnx/constant_float_tensor.prototxt
+++ b/ngraph/test/models/onnx/constant_float_tensor.prototxt
@@ -29,10 +29,10 @@ graph {
         elem_type: 1
         shape {
           dim {
-            dim_value: 5
+            dim_value: 2
           }
           dim {
-            dim_value: 5
+            dim_value: 3
           }
         }
       }

--- a/ngraph/test/models/onnx/constant_integer_array.prototxt
+++ b/ngraph/test/models/onnx/constant_integer_array.prototxt
@@ -1,0 +1,32 @@
+ir_version: 7
+producer_name: "backend-test"
+graph {
+  node {
+    output: "values"
+    op_type: "Constant"
+    attribute {
+      name: "value_ints"
+      ints: 0
+      ints: 1
+      ints: 2
+      type: INTS
+    }
+  }
+  name: "test_constant"
+  output {
+    name: "values"
+    type {
+      tensor_type {
+        elem_type: 7
+        shape {
+          dim{
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 13
+}

--- a/ngraph/test/models/onnx/constant_integer_scalar.prototxt
+++ b/ngraph/test/models/onnx/constant_integer_scalar.prototxt
@@ -1,0 +1,28 @@
+ir_version: 7
+producer_name: "backend-test"
+graph {
+  node {
+    output: "values"
+    op_type: "Constant"
+    attribute {
+      name: "value_int"
+      i: 1
+      type: INT
+    }
+  }
+  name: "test_constant"
+  output {
+    name: "values"
+    type {
+      tensor_type {
+        elem_type: 7
+        shape {
+
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 13
+}

--- a/ngraph/test/onnx/onnx_import.in.cpp
+++ b/ngraph/test/onnx/onnx_import.in.cpp
@@ -4309,6 +4309,17 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_float_tensor)
     test_case.run();
 }
 
+NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_bfloat_tensor)
+{
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(SERIALIZED_ZOO, "onnx/constant_bfloat_tensor.prototxt"));
+
+    auto test_case = test::TestCase<TestEngine>(function);
+    test_case.add_expected_output<bfloat16>(Shape{2, 3}, {0, 5, 10, 15, 20, 25});
+    test_case.run();
+}
+
+
 NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_float_scalar)
 {
     auto function = onnx_import::import_onnx_model(

--- a/ngraph/test/onnx/onnx_import.in.cpp
+++ b/ngraph/test/onnx/onnx_import.in.cpp
@@ -4298,3 +4298,13 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_fill_shape_attribute)
     test_case.add_expected_output<int32_t>(Shape{2, 3, 4}, std::vector<int32_t>(24, 5));
     test_case.run();
 }
+
+NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_float_tensor)
+{
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(SERIALIZED_ZOO, "onnx/constant_float_tensor.prototxt"));
+
+    auto test_case = test::TestCase<TestEngine>(function);
+    test_case.add_expected_output<float>(Shape{2, 3}, {0.0f, 0.5f, 1.f, 1.5f, 2.f, 2.5f});
+    test_case.run();
+}

--- a/ngraph/test/onnx/onnx_import.in.cpp
+++ b/ngraph/test/onnx/onnx_import.in.cpp
@@ -4308,3 +4308,43 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_float_tensor)
     test_case.add_expected_output<float>(Shape{2, 3}, {0.0f, 0.5f, 1.f, 1.5f, 2.f, 2.5f});
     test_case.run();
 }
+
+NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_float_scalar)
+{
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(SERIALIZED_ZOO, "onnx/constant_float_scalar.prototxt"));
+
+    auto test_case = test::TestCase<TestEngine>(function);
+    test_case.add_expected_output<float>(Shape{}, {0.5f});
+    test_case.run();
+}
+
+NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_float_array)
+{
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(SERIALIZED_ZOO, "onnx/constant_float_array.prototxt"));
+
+    auto test_case = test::TestCase<TestEngine>(function);
+    test_case.add_expected_output<float>(Shape{3}, {0.5f, 1.f, 1.5f});
+    test_case.run();
+}
+
+NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_integer_scalar)
+{
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(SERIALIZED_ZOO, "onnx/constant_integer_scalar.prototxt"));
+
+    auto test_case = test::TestCase<TestEngine>(function);
+    test_case.add_expected_output<std::int64_t>(Shape{}, {1});
+    test_case.run();
+}
+
+NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_integer_array)
+{
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(SERIALIZED_ZOO, "onnx/constant_integer_array.prototxt"));
+
+    auto test_case = test::TestCase<TestEngine>(function);
+    test_case.add_expected_output<std::int64_t>(Shape{3}, {0, 1, 2});
+    test_case.run();
+}

--- a/ngraph/test/onnx/onnx_import.in.cpp
+++ b/ngraph/test/onnx/onnx_import.in.cpp
@@ -4315,7 +4315,7 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_bfloat_tensor)
         file_util::path_join(SERIALIZED_ZOO, "onnx/constant_bfloat_tensor.prototxt"));
 
     auto test_case = test::TestCase<TestEngine>(function);
-    test_case.add_expected_output<bfloat16>(Shape{2, 3}, {0, 5, 10, 15, 20, 25});
+    test_case.add_expected_output<bfloat16>(Shape{2, 3}, {0.f, 5.f, 10.f, 15.f, 20.f, 25.f});
     test_case.run();
 }
 

--- a/ngraph/test/runtime/ie/unit_test.manifest
+++ b/ngraph/test/runtime/ie/unit_test.manifest
@@ -575,6 +575,10 @@ broadcast_vector_rowwise_int64
 broadcast_scalar_to_matrix_int64
 abc_int64
 
+# [NOT_IMPLEMENTED] Output format I64 is not supported yet...
+onnx_constant_integer_scalar
+onnx_constant_integer_array
+
 # Unsupported primitive of type: SigmoidBackprop
 sigmoid_bprop_n1c1h4
 


### PR DESCRIPTION
### Details:
This PR provides partial support for a new version of Constant op from ONNX opset v13.

The following new attributes have been added to Constant v13:
- `value_float` : the value for the sole element for the scalar, float32, output tensor,
- `value_floats` : the values for the elements for the 1D, float32, output tensor,
- `value_int` : the value for the sole element for the scalar, int64, output tensor,
- `value_ints` : the values for the elements for the 1D, int64, output tensor.

Moreover, support for `bfloat16` has been added to `Tensor`.

### Tickets:
 - *53305*
