### PR TITLE
Sqrt spec - Remove new line symbol

### DIFF
--- a/docs/ops/arithmetic/Sqrt_1.md
+++ b/docs/ops/arithmetic/Sqrt_1.md
@@ -12,8 +12,8 @@
 o_{i} = \sqrt{a_{i}}
 \f]
 
-If the input value is negative, then the result is undefined.\
-For integer element type the result is rounded (half up) to the nearest integer value.
+* If the input value is negative, then the result is undefined.
+* For integer element type the result is rounded (half up) to the nearest integer value.
 
 **Attributes**: *Sqrt* operation has no attributes.
 


### PR DESCRIPTION
### Details:

New line symbol `\` is not rendered correctly on the web page.
Replaced by `*` at the beginning of the description sentence.

### Tickets:
 - 37482 (45930)
