### PR TITLE
ConcatTransformation fix

### DIFF
--- a/inference-engine/src/low_precision_transformations/src/concat.cpp
+++ b/inference-engine/src/low_precision_transformations/src/concat.cpp
@@ -414,7 +414,13 @@ void ConcatTransformation::addDequantizationLayers(
                         const std::string originalName = layer->get_friendly_name();
                         const std::string newName = layer->get_friendly_name() + LayerTransformation::originalLayerPostfix;
                         layer->set_friendly_name(newName);
-                        source->set_friendly_name(originalName);
+
+                        // Split & VariadicSplit have other naming rules
+                        if (is_type<opset1::Split>(layer) || is_type<opset1::VariadicSplit>(layer)) {
+                            source->set_friendly_name(originalName + "." + std::to_string(i));
+                        } else {
+                            source->set_friendly_name(originalName);
+                        }
                         subgraph.layers[layer->get_friendly_name()] = layer;
                     }
                 }

--- a/inference-engine/src/low_precision_transformations/src/split.cpp
+++ b/inference-engine/src/low_precision_transformations/src/split.cpp
@@ -110,10 +110,8 @@ void SplitTransformation::updateOutputs(
                 std::shared_ptr<ngraph::Node> result = context.function->get_output_op(i);
                 std::shared_ptr<ngraph::Node> outputNode = result->get_input_node_shared_ptr(0);
                 if (outputNode.get() == lastNode.get()) {
-                    std::ostringstream oss;
-                    oss << i;
                     originalNode->set_friendly_name(originalName + LayerTransformation::originalLayerPostfix);
-                    lastNode->set_friendly_name(originalName + "." + oss.str());
+                    lastNode->set_friendly_name(originalName + "." + std::to_string(i));
                     break;
                 }
             }

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/concat_with_split_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/concat_with_split_transformation.cpp
@@ -74,20 +74,23 @@ inline std::ostream& operator<<(std::ostream& out, const ConcatTransformationTes
 
 typedef std::tuple <
     ngraph::element::Type,
-    ConcatTransformationTestValues
+    ConcatTransformationTestValues,
+    bool // additional Convolution after Split
 > ConcatTransformationParams;
 
 class ConcatWithSplitTransformation : public LayerTransformation, public testing::WithParamInterface<ConcatTransformationParams> {
 public:
     void SetUp() override {
         const ngraph::element::Type precision = std::get<0>(GetParam());
-        ConcatTransformationTestValues testValues = std::get<1>(GetParam());
+        const ConcatTransformationTestValues testValues = std::get<1>(GetParam());
+        const bool addConvolution = std::get<2>(GetParam());
 
         actualFunction = ngraph::builder::subgraph::ConcatFunction::getOriginalWithSplitedIntermediate(
             precision,
             testValues.inputShape,
             testValues.actual.fakeQuantize1,
-            testValues.actual.fakeQuantize2);
+            testValues.actual.fakeQuantize2,
+            addConvolution);
 
         SimpleLowPrecisionTransformer transform;
         if (testValues.multiChannels) {
@@ -107,6 +110,7 @@ public:
             testValues.result.dequantizationBefore1,
             testValues.result.dequantizationBefore2,
             testValues.result.precisionAfterOperation,
+            addConvolution,
             testValues.result.dequantizationOperations1,
             testValues.result.dequantizationOperations2);
     }
@@ -114,11 +118,13 @@ public:
     static std::string getTestCaseName(testing::TestParamInfo<ConcatTransformationParams> obj) {
         const ngraph::element::Type precision = std::get<0>(obj.param);
         const ConcatTransformationTestValues testValues = std::get<1>(obj.param);
+        const bool addConvolution = std::get<2>(obj.param);
 
         std::ostringstream result;
         result <<
             LayerTransformation::getTestCaseNameByParams(precision, testValues.inputShape, testValues.params) << "_" <<
             (testValues.multiChannels ? "multiChannels_" : "notMultiChannels_") <<
+            (addConvolution ? "" : "without_convolution_") <<
             testValues.actual << "_" <<
             testValues.result << "_";
         return result.str();
@@ -127,7 +133,7 @@ public:
 
 TEST_P(ConcatWithSplitTransformation, CompareFunctions) {
     actualFunction->validate_nodes_and_infer_types();
-    auto res = compare_functions(referenceFunction, actualFunction, true);
+    auto res = compare_functions(referenceFunction, actualFunction, true, true);
     ASSERT_TRUE(res.first) << res.second;
 }
 
@@ -136,6 +142,7 @@ const std::vector<ngraph::element::Type> precisions = {
     // ngraph::element::f16
 };
 
+namespace casesWithConvolution {
 const std::vector<ConcatTransformationTestValues> testValues = {
     // U8: concat
     {
@@ -298,6 +305,43 @@ INSTANTIATE_TEST_CASE_P(
     ConcatWithSplitTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(precisions),
-        ::testing::ValuesIn(testValues)),
+        ::testing::ValuesIn(testValues),
+        ::testing::Values(true)),
     ConcatWithSplitTransformation::getTestCaseName);
+} // namespace casesWithConvolution
+
+// test cases to check output names
+namespace casesWithoutConvolution {
+const std::vector<ConcatTransformationTestValues> testValues = {
+    {
+        { 1, 6, 10, 10 },
+        LayerTransformation::createParamsU8I8(),
+        true,
+        {
+            { 256ul, ngraph::Shape({}), {0.f}, {2.55f}, {0.f}, {2.55f} },
+            { 256ul, ngraph::Shape({}), {0.f}, {2.55f / 2.f}, {0.f}, {2.55f / 2.f} }
+        },
+        {
+            { 256ul, ngraph::Shape({}), {0.f}, {2.55f}, {0.f}, {255.f}},
+            { 256ul, ngraph::Shape({}), {0.f}, {2.55f / 2.f}, {0.f}, { 255.f}},
+            ngraph::element::u8,
+            {{}, {}, {}},
+            {{}, {}, {}},
+            ngraph::element::u8,
+            { ngraph::element::f32, {}, {{ 0.01f, 0.01f, 0.01f, 0.005f, 0.005f, 0.005f }} },
+            { ngraph::element::f32, {}, { 0.005f } }
+        }
+    },
+};
+
+INSTANTIATE_TEST_CASE_P(
+    smoke_LPT,
+    ConcatWithSplitTransformation,
+    ::testing::Combine(
+        ::testing::ValuesIn(precisions),
+        ::testing::ValuesIn(testValues),
+        ::testing::Values(false)),
+    ConcatWithSplitTransformation::getTestCaseName);
+} // namespace casesWithoutConvolution
+
 }  // namespace

--- a/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_split_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_split_transformation.cpp
@@ -63,7 +63,8 @@ void ConcatWithSplitTransformation::SetUp() {
         netPrecision,
         inputShapes,
         param.fqOnData1,
-        param.fqOnData2);
+        param.fqOnData2,
+        true);
 }
 
 TEST_P(ConcatWithSplitTransformation, CompareWithRefImpl) {

--- a/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/concat_function.hpp
+++ b/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/concat_function.hpp
@@ -53,7 +53,8 @@ public:
         const ngraph::element::Type precision,
         const ngraph::Shape& inputShape,
         const FakeQuantizeOnData& fqOnData1,
-        const FakeQuantizeOnData& fqOnData2);
+        const FakeQuantizeOnData& fqOnData2,
+        const bool addConvolution);
 
     static std::shared_ptr<ngraph::Function> getOriginalSelectionWithIntermediate(
         const ngraph::element::Type precision,
@@ -151,6 +152,7 @@ public:
         const DequantizationOperations& dequantizationBefore1,
         const DequantizationOperations& dequantizationBefore2,
         const ngraph::element::Type precisionAfterOperation,
+        const bool addConvolution,
         const DequantizationOperations& dequantizationOperations1,
         const DequantizationOperations& dequantizationOperations2);
 

--- a/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/src/concat_function.cpp
+++ b/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/src/concat_function.cpp
@@ -239,7 +239,8 @@ std::shared_ptr<ngraph::Function> ConcatFunction::getOriginalWithSplitedIntermed
     const ngraph::element::Type precision,
     const ngraph::Shape& inputShape,
     const FakeQuantizeOnData& fqOnData1,
-    const FakeQuantizeOnData& fqOnData2) {
+    const FakeQuantizeOnData& fqOnData2,
+    const bool addConvolution) {
     size_t numSplit = 2;
     size_t splitedAxis = 1;
 
@@ -272,24 +273,28 @@ std::shared_ptr<ngraph::Function> ConcatFunction::getOriginalWithSplitedIntermed
 
     const std::shared_ptr<ngraph::opset1::Concat> concat = std::make_shared<ngraph::opset1::Concat>(
         ngraph::OutputVector{ fakeQuantize1->output(0), intermediateOp->output(0) }, splitedAxis);
-    concat->set_friendly_name("concat");
+    concat->set_friendly_name("output_1");
 
     auto& rtInfo = concat->get_rt_info();
     rtInfo["Variant::std::string"] = std::make_shared<VariantWrapper<std::string>>("concat");
 
-    auto weights = ngraph::opset1::Constant::create(precision, ngraph::Shape{ inputShape[1] / numSplit, inputShape[1] / numSplit, 1, 1 }, { 1 });
-    auto convolution = std::make_shared<ngraph::opset1::Convolution>(
-        intermediateOp->output(1),
-        weights,
-        ngraph::Strides{ 1, 1 },
-        ngraph::CoordinateDiff{ 0, 0 },
-        ngraph::CoordinateDiff{ 0, 0 },
-        ngraph::Strides{ 1, 1 });
-    convolution->set_friendly_name("convolution");
+    Output<Node> lastOutput = intermediateOp->output(1);
+    if (addConvolution) {
+        auto weights = ngraph::opset1::Constant::create(precision, ngraph::Shape{ inputShape[1] / numSplit, inputShape[1] / numSplit, 1, 1 }, { 1 });
+        auto convolution = std::make_shared<ngraph::opset1::Convolution>(
+            intermediateOp->output(1),
+            weights,
+            ngraph::Strides{ 1, 1 },
+            ngraph::CoordinateDiff{ 0, 0 },
+            ngraph::CoordinateDiff{ 0, 0 },
+            ngraph::Strides{ 1, 1 });
+        lastOutput = convolution->output(0);
+    }
+    lastOutput.get_node_shared_ptr()->set_friendly_name("output_2");
 
     ngraph::ResultVector results{
         std::make_shared<ngraph::opset1::Result>(concat),
-        std::make_shared<ngraph::opset1::Result>(convolution),
+        std::make_shared<ngraph::opset1::Result>(lastOutput),
     };
 
     std::shared_ptr<ngraph::Function> function = std::make_shared<ngraph::Function>(
@@ -964,6 +969,7 @@ std::shared_ptr<ngraph::Function> ConcatFunction::getReferenceWithSplitedInterme
     const DequantizationOperations& dequantizationBefore1,
     const DequantizationOperations& dequantizationBefore2,
     const ngraph::element::Type precisionAfterOperation,
+    const bool addConvolution,
     const DequantizationOperations& dequantizationOperations1,
     const DequantizationOperations& dequantizationOperations2) {
     size_t numSplit = 2;
@@ -1005,7 +1011,6 @@ std::shared_ptr<ngraph::Function> ConcatFunction::getReferenceWithSplitedInterme
 
     const auto constant = std::make_shared<ngraph::opset1::Constant>(element::i64, Shape{ }, splitedAxis);
     intermediateOp = std::make_shared<ngraph::opset1::Split>(deqBefore2, constant, numSplit);
-
     intermediateOp->set_friendly_name("intermediate");
 
     const std::shared_ptr<ngraph::opset1::Concat> concat = std::make_shared<ngraph::opset1::Concat>(
@@ -1017,23 +1022,30 @@ std::shared_ptr<ngraph::Function> ConcatFunction::getReferenceWithSplitedInterme
 
     const auto lastDequantization1 = makeDequantization(concat, dequantizationOperations1);
     const auto lastDequantization2 = makeDequantization(intermediateOp->output(1), dequantizationOperations2);
+    lastDequantization1->set_friendly_name("output_1");
 
-    auto weights = ngraph::opset1::Constant::create(
-        precision,
-        ngraph::Shape{ inputShape[1] / numSplit, inputShape[1] / numSplit, 1, 1 }, { 1 });
+    Output<Node> lastOutput = lastDequantization2;
+    if (addConvolution) {
+        auto weights = ngraph::opset1::Constant::create(
+            precision,
+            ngraph::Shape{ inputShape[1] / numSplit, inputShape[1] / numSplit, 1, 1 }, { 1 });
 
-    auto convolution = std::make_shared<ngraph::opset1::Convolution>(
-        lastDequantization2,
-        weights,
-        ngraph::Strides{ 1, 1 },
-        ngraph::CoordinateDiff{ 0, 0 },
-        ngraph::CoordinateDiff{ 0, 0 },
-        ngraph::Strides{ 1, 1 });
-    convolution->set_friendly_name("convolution");
+        auto convolution = std::make_shared<ngraph::opset1::Convolution>(
+            lastDequantization2,
+            weights,
+            ngraph::Strides{ 1, 1 },
+            ngraph::CoordinateDiff{ 0, 0 },
+            ngraph::CoordinateDiff{ 0, 0 },
+            ngraph::Strides{ 1, 1 });
+        convolution->set_friendly_name("output_2");
+        lastOutput = convolution->output(0);
+    } else {
+        lastOutput.get_node_shared_ptr()->set_friendly_name("output_2.1");
+    }
 
     ngraph::ResultVector results{
         std::make_shared<ngraph::opset1::Result>(lastDequantization1),
-        std::make_shared<ngraph::opset1::Result>(convolution)
+        std::make_shared<ngraph::opset1::Result>(lastOutput)
     };
 
     std::shared_ptr<ngraph::Function> function = std::make_shared<ngraph::Function>(


### PR DESCRIPTION
- ConcatTransformation::addDequantizationLayers: fix of dequantization operations naming after Split/VariadicSplit
- ConcatWithSplitTransformation functional tests: added verification of output names

Issue 53449

Validation: developer-services/job/accuracy/1905/ (reference: developer-services/job/accuracy/1907/)