### PR TITLE
Add time_tests dir path to sys.path

### DIFF
--- a/tests/time_tests/README.md
+++ b/tests/time_tests/README.md
@@ -29,6 +29,7 @@ cmake .. -DInferenceEngineDeveloperPackage_DIR=$(realpath ../../../build) && mak
 
 2. Run test:
 ``` bash
+export PYTHONPATH=$PYTHONPATH:/openvino/tests/time_tests/
 ./scripts/run_timetest.py ../../bin/intel64/Release/timetest_infer -m model.xml -d CPU
 ```
 


### PR DESCRIPTION
to prevent ModuleNotFoundError
