### PR TITLE
Add Model Optimizer --transform option

### DIFF
--- a/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api.pyx
+++ b/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api.pyx
@@ -6,6 +6,7 @@ from ..inference_engine.ie_api cimport IENetwork
 
 from libcpp cimport bool
 from libcpp.string cimport string
+from libc.stdint cimport int64_t
 
 
 def ApplyMOCTransformations(IENetwork network, bool cf):
@@ -16,8 +17,8 @@ def ApplyPOTTransformations(IENetwork network, string device):
     C.ApplyPOTTransformations(network.impl, device)
 
 
-def ApplyLowLatencyTransformation(IENetwork network):
-    C.ApplyLowLatencyTransformation(network.impl)
+def ApplyLowLatencyTransformation(IENetwork network, int64_t num_iterations=1):
+    C.ApplyLowLatencyTransformation(network.impl, num_iterations)
 
 
 def ApplyPruningTransformation(IENetwork network):

--- a/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api_impl.cpp
+++ b/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api_impl.cpp
@@ -26,8 +26,9 @@ void InferenceEnginePython::ApplyPOTTransformations(InferenceEnginePython::IENet
     manager.run_passes(network.actual->getFunction());
 }
 
-void InferenceEnginePython::ApplyLowLatencyTransformation(InferenceEnginePython::IENetwork network) {
+void InferenceEnginePython::ApplyLowLatencyTransformation(InferenceEnginePython::IENetwork network, int64_t num_iterations) {
     ngraph::pass::Manager manager;
+    // TODO: pass num_iterations to LowLatency
     manager.register_pass<ngraph::pass::LowLatency>();
     manager.register_pass<ngraph::pass::UnrollTensorIterator>();
 

--- a/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api_impl.hpp
+++ b/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api_impl.hpp
@@ -15,7 +15,7 @@ void ApplyMOCTransformations(InferenceEnginePython::IENetwork network, bool cf);
 
 void ApplyPOTTransformations(InferenceEnginePython::IENetwork network, std::string device);
 
-void ApplyLowLatencyTransformation(InferenceEnginePython::IENetwork network);
+void ApplyLowLatencyTransformation(InferenceEnginePython::IENetwork network, int64_t num_iterations);
 
 void ApplyPruningTransformation(InferenceEnginePython::IENetwork network);
 

--- a/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api_impl_defs.pxd
+++ b/inference-engine/ie_bridges/python/src/openvino/offline_transformations/offline_transformations_api_impl_defs.pxd
@@ -3,6 +3,7 @@
 
 from libcpp cimport bool
 from libcpp.string cimport string
+from libc.stdint cimport int64_t
 
 from ..inference_engine.ie_api_impl_defs cimport IENetwork
 
@@ -11,7 +12,7 @@ cdef extern from "offline_transformations_api_impl.hpp" namespace "InferenceEngi
 
     cdef void ApplyPOTTransformations(IENetwork network, string device)
 
-    cdef void ApplyLowLatencyTransformation(IENetwork network)
+    cdef void ApplyLowLatencyTransformation(IENetwork network, int64_t num_iterations)
 
     cdef void ApplyPruningTransformation(IENetwork network)
 

--- a/model-optimizer/automation/package_BOM.txt
+++ b/model-optimizer/automation/package_BOM.txt
@@ -1009,6 +1009,7 @@ mo/ops/unsqueeze.py
 mo/pipeline/__init__.py
 mo/pipeline/common.py
 mo/pipeline/unified.py
+mo/subprocess_main.py
 mo/utils/__init__.py
 mo/utils/broadcasting.py
 mo/utils/check_ie_bindings.py

--- a/model-optimizer/automation/package_BOM.txt
+++ b/model-optimizer/automation/package_BOM.txt
@@ -939,6 +939,11 @@ mo/graph/graph.py
 mo/graph/perm_inputs.py
 mo/graph/port.py
 mo/main.py
+mo/main_caffe.py
+mo/main_kaldi.py
+mo/main_mxnet.py
+mo/main_onnx.py
+mo/main_tf.py
 mo/middle/__init__.py
 mo/middle/passes/__init__.py
 mo/middle/passes/conv.py

--- a/model-optimizer/mo.py
+++ b/model-optimizer/mo.py
@@ -5,5 +5,5 @@
 
 
 if __name__ == "__main__":
-    from mo.main import subprocess_main
+    from mo.main import subprocess_main # pylint: disable=no-name-in-module
     subprocess_main(framework=None)

--- a/model-optimizer/mo.py
+++ b/model-optimizer/mo.py
@@ -5,5 +5,5 @@
 
 
 if __name__ == "__main__":
-    from mo.main import subprocess_main  # pylint: disable=no-name-in-module
+    from mo.subprocess_main import subprocess_main  # pylint: disable=no-name-in-module
     subprocess_main(framework=None)

--- a/model-optimizer/mo.py
+++ b/model-optimizer/mo.py
@@ -5,5 +5,5 @@
 
 
 if __name__ == "__main__":
-    from mo.main import subprocess_main # pylint: disable=no-name-in-module
+    from mo.main import subprocess_main  # pylint: disable=no-name-in-module
     subprocess_main(framework=None)

--- a/model-optimizer/mo.py
+++ b/model-optimizer/mo.py
@@ -3,16 +3,7 @@
 # Copyright (C) 2018-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
-
-from mo.utils.versions_checker import check_python_version  # pylint: disable=no-name-in-module
 
 if __name__ == "__main__":
-    ret_code = check_python_version()
-    if ret_code:
-        sys.exit(ret_code)
-
-    from mo.main import main
-    from mo.utils.cli_parser import get_all_cli_parser  # pylint: disable=no-name-in-module
-
-    sys.exit(main(get_all_cli_parser(), None))
+    from mo.main import subprocess_main
+    subprocess_main(framework=None)

--- a/model-optimizer/mo/__main__.py
+++ b/model-optimizer/mo/__main__.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2018-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from mo.main import subprocess_main
+from mo.subprocess_main import subprocess_main
 subprocess_main(framework=None)

--- a/model-optimizer/mo/__main__.py
+++ b/model-optimizer/mo/__main__.py
@@ -1,16 +1,5 @@
 # Copyright (C) 2018-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
-
-from mo.utils.versions_checker import check_python_version  # pylint: disable=no-name-in-module
-
-ret_code = check_python_version()
-if ret_code:
-    sys.exit(ret_code)
-
-from mo.main import main
-from mo.utils.cli_parser import get_all_cli_parser  # pylint: disable=no-name-in-module
-
-sys.exit(main(get_all_cli_parser(), None))
-
+from mo.main import subprocess_main
+subprocess_main(framework=None)

--- a/model-optimizer/mo/back/offline_transformations.py
+++ b/model-optimizer/mo/back/offline_transformations.py
@@ -9,7 +9,7 @@ from mo.utils.cli_parser import parse_transform
 
 def get_available_transformations():
     try:
-        from openvino.offline_transformations import ApplyLowLatencyTransformation # pylint: disable=import-error
+        from openvino.offline_transformations import ApplyLowLatencyTransformation  # pylint: disable=import-error
         return {
             'LowLatency': ApplyLowLatencyTransformation,
         }
@@ -20,10 +20,10 @@ def get_available_transformations():
 def apply_offline_transformations(input_model: str, framework: str, transforms: list):
     # This variable is only needed by GenerateMappingFile transformation
     # to produce correct mapping
-    extract_names = True if framework in ['tf', 'mxnet', 'kaldi'] else False
+    extract_names = framework in ['tf', 'mxnet', 'kaldi']
 
-    from openvino.inference_engine import read_network # pylint: disable=import-error
-    from openvino.offline_transformations import ApplyMOCTransformations, GenerateMappingFile # pylint: disable=import-error
+    from openvino.inference_engine import read_network  # pylint: disable=import-error
+    from openvino.offline_transformations import ApplyMOCTransformations, GenerateMappingFile  # pylint: disable=import-error
 
     net = read_network(input_model + "_tmp.xml", input_model + "_tmp.bin")
 
@@ -47,4 +47,4 @@ if __name__ == "__main__":
     parser.add_argument("--transform")
     args = parser.parse_args()
 
-    apply_offline_transformations(args.input_model, args.framework, parse_transform(args.transform, True))
+    apply_offline_transformations(args.input_model, args.framework, parse_transform(args.transform))

--- a/model-optimizer/mo/back/offline_transformations.py
+++ b/model-optimizer/mo/back/offline_transformations.py
@@ -1,18 +1,11 @@
 # Copyright (C) 2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import argparse
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--input_model")
-    parser.add_argument("--framework")
-    args = parser.parse_args()
-    path_to_model = args.input_model
-
+def apply_offline_transformations(input_model: str, framework: str):
     # This variable is only needed by GenerateMappingFile transformation
     # to produce correct mapping
-    extract_names = True if args.framework in ['tf', 'mxnet', 'kaldi'] else False
+    extract_names = True if framework in ['tf', 'mxnet', 'kaldi'] else False
 
     try:
         from openvino.inference_engine import IECore, read_network # pylint: disable=import-error
@@ -23,8 +16,9 @@ if __name__ == "__main__":
 
     CheckAPI()
 
-    net = read_network(path_to_model + "_tmp.xml", path_to_model + "_tmp.bin")
-    net.serialize(path_to_model + ".xml", path_to_model + ".bin")
-    path_to_mapping = path_to_model + ".mapping"
+    net = read_network(input_model + "_tmp.xml", input_model + "_tmp.bin")
+    net.serialize(input_model + ".xml", input_model + ".bin")
+    path_to_mapping = input_model + ".mapping"
     GenerateMappingFile(net, path_to_mapping.encode('utf-8'), extract_names)
 
+    return 0

--- a/model-optimizer/mo/back/offline_transformations.py
+++ b/model-optimizer/mo/back/offline_transformations.py
@@ -1,6 +1,20 @@
 # Copyright (C) 2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+import logging as log
+
+from mo.utils.error import Error
+
+
+def get_available_transformations():
+    try:
+        from openvino.offline_transformations import ApplyLowLatencyTransformation # pylint: disable=import-error
+        return {
+            'LowLatency': ApplyLowLatencyTransformation,
+        }
+    except Exception as e:
+        return {}
+
 
 def apply_offline_transformations(input_model: str, framework: str, transforms: list):
     # This variable is only needed by GenerateMappingFile transformation
@@ -8,19 +22,22 @@ def apply_offline_transformations(input_model: str, framework: str, transforms: 
     extract_names = True if framework in ['tf', 'mxnet', 'kaldi'] else False
 
     try:
-        from openvino.inference_engine import IECore, read_network # pylint: disable=import-error
-        from openvino.offline_transformations import ApplyMOCTransformations, GenerateMappingFile, CheckAPI # pylint: disable=import-error
+        from openvino.inference_engine import read_network # pylint: disable=import-error
+        from openvino.offline_transformations import ApplyMOCTransformations, GenerateMappingFile # pylint: disable=import-error
     except Exception as e:
         print("[ WARNING ] {}".format(e))
-        exit(1)
-
-    CheckAPI()
+        return 1
 
     net = read_network(input_model + "_tmp.xml", input_model + "_tmp.bin")
 
-    for transform in transforms:
-        # TODO: apply transformations from transforms list
-        pass
+    available_transformations = get_available_transformations()
+
+    for name, args in transforms:
+        if name not in available_transformations.keys():
+            raise Error("Transformation {} is not available.".format(name))
+
+        print("[ INFO ] Applying {} with {} args".format(name, args))
+        available_transformations[name](net, **args)
 
     net.serialize(input_model + ".xml", input_model + ".bin")
     path_to_mapping = input_model + ".mapping"

--- a/model-optimizer/mo/back/offline_transformations.py
+++ b/model-optimizer/mo/back/offline_transformations.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-def apply_offline_transformations(input_model: str, framework: str):
+def apply_offline_transformations(input_model: str, framework: str, transforms: list):
     # This variable is only needed by GenerateMappingFile transformation
     # to produce correct mapping
     extract_names = True if framework in ['tf', 'mxnet', 'kaldi'] else False
@@ -17,6 +17,11 @@ def apply_offline_transformations(input_model: str, framework: str):
     CheckAPI()
 
     net = read_network(input_model + "_tmp.xml", input_model + "_tmp.bin")
+
+    for transform in transforms:
+        # TODO: apply transformations from transforms list
+        pass
+
     net.serialize(input_model + ".xml", input_model + ".bin")
     path_to_mapping = input_model + ".mapping"
     GenerateMappingFile(net, path_to_mapping.encode('utf-8'), extract_names)

--- a/model-optimizer/mo/main.py
+++ b/model-optimizer/mo/main.py
@@ -259,7 +259,7 @@ def emit_ir(graph: Graph, argv: argparse.Namespace):
     mean_data = deepcopy(graph.graph['mf']) if 'mf' in graph.graph else None
     input_names = deepcopy(graph.graph['input_names']) if 'input_names' in graph.graph else []
 
-    # Remove temporary ie_is_available key form argv no to have it in IR
+    # Remove temporary ie_is_available key from argv no to have it in IR
     ie_is_available = argv.ie_is_available
     del argv.ie_is_available
 

--- a/model-optimizer/mo/main.py
+++ b/model-optimizer/mo/main.py
@@ -259,6 +259,10 @@ def emit_ir(graph: Graph, argv: argparse.Namespace):
     mean_data = deepcopy(graph.graph['mf']) if 'mf' in graph.graph else None
     input_names = deepcopy(graph.graph['input_names']) if 'input_names' in graph.graph else []
 
+    # Remove temporary ie_is_available key form argv no to have it in IR
+    ie_is_available = argv.ie_is_available
+    del argv.ie_is_available
+
     prepare_emit_ir(graph=graph,
                     data_type=graph.graph['cmd_params'].data_type,
                     output_dir=argv.output_dir,
@@ -279,7 +283,7 @@ def emit_ir(graph: Graph, argv: argparse.Namespace):
         # This try-except is additional reinsurance that the IE
         # dependency search does not break the MO pipeline
         try:
-            if not argv.legacy_ir_generation and argv.ie_is_available:
+            if not argv.legacy_ir_generation and ie_is_available:
                 path_to_offline_transformations = os.path.join(os.path.realpath(os.path.dirname(__file__)), 'back',
                                                                'offline_transformations.py')
                 status = subprocess.run([sys.executable, path_to_offline_transformations,

--- a/model-optimizer/mo/main.py
+++ b/model-optimizer/mo/main.py
@@ -34,7 +34,7 @@ from mo.utils.logger import init_logger
 from mo.utils.model_analysis import AnalysisResults
 from mo.utils.utils import refer_to_faq_msg
 from mo.utils.version import get_version, get_simplified_mo_version, get_simplified_ie_version
-from mo.utils.versions_checker import check_requirements, check_python_version  # pylint: disable=no-name-in-module
+from mo.utils.versions_checker import check_requirements  # pylint: disable=no-name-in-module
 
 
 def replace_ext(name: str, old: str, new: str):
@@ -421,33 +421,6 @@ def main(cli_parser: argparse.ArgumentParser, framework: str):
     telemetry.end_session()
     telemetry.force_shutdown(1.0)
     return 1
-
-
-def subprocess_main(framework=None):
-    """
-        This function checks that Inference Engine Python API available and working as expected
-        and then in sub-process it executes main_<fw>.py files. Due to some OSs specifics we can't
-        just add paths to Python modules and libraries into current env. So to make Inference Engine
-        Python API to be available inside MO we need to use subprocess with new env.
-    """
-    ret_code = check_python_version()
-    if ret_code:
-        sys.exit(ret_code)
-
-    from mo.utils.find_ie_version import find_ie_version
-    find_ie_version(silent=True)
-
-    mo_root_path = os.path.join(os.path.dirname(__file__), os.pardir)
-
-    python_path_key = 'PYTHONPATH'
-    if python_path_key not in os.environ:
-        os.environ[python_path_key] = mo_root_path
-    else:
-        os.environ[python_path_key] = os.pathsep.join([os.environ[python_path_key], mo_root_path])
-
-    path_to_main = os.path.join(os.path.realpath(os.path.dirname(__file__)), 'main_{}.py'.format(framework) if framework else 'main.py')
-    status = subprocess.run([sys.executable, path_to_main, *sys.argv[1:]], env=os.environ)
-    sys.exit(status.returncode)
 
 
 if __name__ == "__main__":

--- a/model-optimizer/mo/main.py
+++ b/model-optimizer/mo/main.py
@@ -21,7 +21,7 @@ from mo.middle.pattern_match import for_graph_and_each_sub_graph_recursively
 from mo.pipeline.common import prepare_emit_ir, get_ir_version
 from mo.pipeline.unified import unified_pipeline
 from mo.utils import import_extensions
-from mo.utils.cli_parser import get_placeholder_shapes, get_tuple_values, get_model_name, \
+from mo.utils.cli_parser import get_placeholder_shapes, get_tuple_values, get_model_name, parse_transform, \
     get_common_cli_options, get_caffe_cli_options, get_tf_cli_options, get_mxnet_cli_options, get_kaldi_cli_options, \
     get_onnx_cli_options, get_mean_scale_dictionary, parse_tuple_pairs, get_freeze_placeholder_values, get_meta_info
 from mo.utils.error import Error, FrameworkError
@@ -152,6 +152,8 @@ def prepare_ir(argv: argparse.Namespace):
     except Exception as e:
         argv.ie_is_available = False
 
+    argv.transform = parse_transform(argv.transform)
+
     ret_code = check_requirements(framework=argv.framework)
     if ret_code:
         raise Error('check_requirements exit with return code {}'.format(ret_code))
@@ -274,7 +276,7 @@ def emit_ir(graph: Graph, argv: argparse.Namespace):
         try:
             if not argv.legacy_ir_generation and argv.ie_is_available:
                 from mo.back.offline_transformations import apply_offline_transformations
-                return_code = apply_offline_transformations(orig_model_name, argv.framework)
+                return_code = apply_offline_transformations(orig_model_name, argv.framework, argv.transform)
         except Exception as e:
             return_code = "failed"
             log.error(e, extra={'is_warning': True})

--- a/model-optimizer/mo/main_caffe.py
+++ b/model-optimizer/mo/main_caffe.py
@@ -1,0 +1,10 @@
+# Copyright (C) 2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+from mo.utils.cli_parser import get_caffe_cli_parser
+
+if __name__ == "__main__":
+    from mo.main import main
+    sys.exit(main(get_caffe_cli_parser(), 'caffe'))

--- a/model-optimizer/mo/main_kaldi.py
+++ b/model-optimizer/mo/main_kaldi.py
@@ -1,0 +1,10 @@
+# Copyright (C) 2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+from mo.utils.cli_parser import get_kaldi_cli_parser
+
+if __name__ == "__main__":
+    from mo.main import main
+    sys.exit(main(get_kaldi_cli_parser(), 'kaldi'))

--- a/model-optimizer/mo/main_mxnet.py
+++ b/model-optimizer/mo/main_mxnet.py
@@ -1,0 +1,10 @@
+# Copyright (C) 2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+from mo.utils.cli_parser import get_mxnet_cli_parser
+
+if __name__ == "__main__":
+    from mo.main import main
+    sys.exit(main(get_mxnet_cli_parser(), 'mxnet'))

--- a/model-optimizer/mo/main_onnx.py
+++ b/model-optimizer/mo/main_onnx.py
@@ -1,0 +1,10 @@
+# Copyright (C) 2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+from mo.utils.cli_parser import get_onnx_cli_parser
+
+if __name__ == "__main__":
+    from mo.main import main
+    sys.exit(main(get_onnx_cli_parser(), 'onnx'))

--- a/model-optimizer/mo/main_tf.py
+++ b/model-optimizer/mo/main_tf.py
@@ -1,0 +1,10 @@
+# Copyright (C) 2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+from mo.utils.cli_parser import get_tf_cli_parser
+
+if __name__ == "__main__":
+    from mo.main import main
+    sys.exit(main(get_tf_cli_parser(), 'tf'))

--- a/model-optimizer/mo/subprocess_main.py
+++ b/model-optimizer/mo/subprocess_main.py
@@ -1,0 +1,42 @@
+# Copyright (C) 2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+import subprocess
+
+from mo.utils.versions_checker import check_python_version  # pylint: disable=no-name-in-module
+
+
+def subprocess_main(framework=None):
+    """
+        Please keep this file compatible with python2 in order to check user python version.
+
+        This function checks that Inference Engine Python API available and working as expected
+        and then in sub-process it executes main_<fw>.py files. Due to some OSs specifics we can't
+        just add paths to Python modules and libraries into current env. So to make Inference Engine
+        Python API to be available inside MO we need to use subprocess with new env.
+    """
+    ret_code = check_python_version()
+    if ret_code:
+        sys.exit(ret_code)
+
+    from mo.utils.find_ie_version import find_ie_version
+    find_ie_version(silent=True)
+
+    mo_root_path = os.path.join(os.path.dirname(__file__), os.pardir)
+
+    python_path_key = 'PYTHONPATH'
+    if python_path_key not in os.environ:
+        os.environ[python_path_key] = mo_root_path
+    else:
+        os.environ[python_path_key] = os.pathsep.join([os.environ[python_path_key], mo_root_path])
+
+    path_to_main = os.path.join(os.path.realpath(os.path.dirname(__file__)),
+                                'main_{}.py'.format(framework) if framework else 'main.py')
+    # python2 compatible code. Do not remove.
+    args = [sys.executable, path_to_main]
+    for arg in sys.argv[1:]:
+        args.append(arg)
+    status = subprocess.run(args, env=os.environ)
+    sys.exit(status.returncode)

--- a/model-optimizer/mo/utils/check_ie_bindings.py
+++ b/model-optimizer/mo/utils/check_ie_bindings.py
@@ -32,6 +32,15 @@ def send_telemetry(mo_version: str, message: str, event_type: str):
 
 
 def import_core_modules(silent: bool, path_to_module: str):
+    """
+        This function checks that InferenceEngine Python API is available
+        and necessary python modules exists. So the next list of imports
+        must contain all IE/NG Python API imports that are used inside MO.
+
+    :param silent: enables or disables logs printing to stdout
+    :param path_to_module: path where python API modules were found
+    :return: True if all imports were successful and False otherwise
+    """
     try:
         from openvino.inference_engine import get_version, read_network # pylint: disable=import-error
         from openvino.offline_transformations import ApplyMOCTransformations, ApplyLowLatencyTransformation, GenerateMappingFile # pylint: disable=import-error

--- a/model-optimizer/mo/utils/check_ie_bindings.py
+++ b/model-optimizer/mo/utils/check_ie_bindings.py
@@ -33,8 +33,8 @@ def send_telemetry(mo_version: str, message: str, event_type: str):
 
 def import_core_modules(silent: bool, path_to_module: str):
     try:
-        from openvino.inference_engine import IECore, get_version # pylint: disable=import-error
-        from openvino.offline_transformations import ApplyMOCTransformations, CheckAPI # pylint: disable=import-error
+        from openvino.inference_engine import get_version, read_network # pylint: disable=import-error
+        from openvino.offline_transformations import ApplyMOCTransformations, ApplyLowLatencyTransformation, GenerateMappingFile # pylint: disable=import-error
 
         import openvino # pylint: disable=import-error
 

--- a/model-optimizer/mo/utils/check_ie_bindings.py
+++ b/model-optimizer/mo/utils/check_ie_bindings.py
@@ -42,10 +42,10 @@ def import_core_modules(silent: bool, path_to_module: str):
     :return: True if all imports were successful and False otherwise
     """
     try:
-        from openvino.inference_engine import get_version, read_network # pylint: disable=import-error
-        from openvino.offline_transformations import ApplyMOCTransformations, ApplyLowLatencyTransformation, GenerateMappingFile # pylint: disable=import-error
+        from openvino.inference_engine import get_version, read_network  # pylint: disable=import-error
+        from openvino.offline_transformations import ApplyMOCTransformations, ApplyLowLatencyTransformation, GenerateMappingFile  # pylint: disable=import-error
 
-        import openvino # pylint: disable=import-error
+        import openvino  # pylint: disable=import-error
 
         if silent:
             return True

--- a/model-optimizer/mo/utils/check_ie_bindings.py
+++ b/model-optimizer/mo/utils/check_ie_bindings.py
@@ -46,15 +46,10 @@ def import_core_modules(silent: bool, path_to_module: str):
 
         print("\t- {}: \t{}".format("Inference Engine found in", os.path.dirname(openvino.__file__)))
         print("{}: \t{}".format("Inference Engine version", ie_version))
-        print("{}: \t    {}".format("Model Optimizer version", mo_version))
+        print("{}: \t{}".format("Model Optimizer version", mo_version))
 
         versions_mismatch = False
-        # MO and IE version have a small difference in the beginning of version because
-        # IE version also includes API version. For example:
-        #   Inference Engine version: 2.1.custom_HEAD_4c8eae0ee2d403f8f5ae15b2c9ad19cfa5a9e1f9
-        #   Model Optimizer version:      custom_HEAD_4c8eae0ee2d403f8f5ae15b2c9ad19cfa5a9e1f9
-        # So to match this versions we skip IE API version.
-        if not re.match(r"^([0-9]+).([0-9]+).{}$".format(mo_version), ie_version):
+        if mo_version != ie_version:
             versions_mismatch = True
             extracted_mo_release_version = v.extract_release_version(mo_version)
             mo_is_custom = extracted_mo_release_version == (None, None)

--- a/model-optimizer/mo/utils/cli_parser.py
+++ b/model-optimizer/mo/utils/cli_parser.py
@@ -1203,7 +1203,8 @@ def parse_transform(transform: str, ie_is_available=True) -> list:
             missing_transformations.append(name)
 
     if len(missing_transformations) != 0:
-        raise Error('Following transformations {} are not available.'.format(','.join(missing_transformations)))
+        raise Error('Following transformations ({}) are not available. List with available transformations ({})'.format(','.join(missing_transformations),
+                                                                                                                        ','.join(available_transforms.keys())))
 
     return transforms
 

--- a/model-optimizer/mo/utils/cli_parser.py
+++ b/model-optimizer/mo/utils/cli_parser.py
@@ -1150,7 +1150,7 @@ def detect_value_type(value: str):
     return values[0] if len(values) == 1 else values
 
 
-def parse_transform(transform: str, ie_is_available: bool) -> list:
+def parse_transform(transform: str, ie_is_available=True) -> list:
     transforms = []
 
     if len(transform) == 0:

--- a/model-optimizer/mo/utils/cli_parser.py
+++ b/model-optimizer/mo/utils/cli_parser.py
@@ -255,8 +255,8 @@ def get_common_cli_parser(parser: argparse.ArgumentParser = None):
                               default='float')
     common_group.add_argument('--transform',
                               help='Apply additional transformations. ' +
-                                   'Usage: "--transform pass_name1[args],pass_name2..." ' +
-                                   'where [args] is key=value pairs separated by semicolon' +
+                                   'Usage: "--transform transformation_name1[args],transformation_name2..." ' +
+                                   'where [args] is key=value pairs separated by semicolon. ' +
                                    'Examples: "--transform LowLatency" or ' +
                                    '          "--transform LowLatency[num_iterations=2]" ' +
                                    'Available transformations: "LowLatency"',

--- a/model-optimizer/mo/utils/cli_parser.py
+++ b/model-optimizer/mo/utils/cli_parser.py
@@ -11,7 +11,6 @@ from itertools import zip_longest
 
 import numpy as np
 
-from mo.back.offline_transformations import get_available_transformations
 from mo.front.extractor import split_node_in_port
 from mo.middle.passes.convert_data_type import destination_type_to_np_data_type
 from mo.utils import import_extensions
@@ -1195,6 +1194,7 @@ def parse_transform(transform: str, ie_is_available: bool) -> list:
         raise Error('Can not apply {} transformations due to missing Inference Engine Python API'.format(
             ','.join([name for name, _ in transforms])))
 
+    from mo.back.offline_transformations import get_available_transformations
     available_transforms = get_available_transformations()
 
     missing_transformations = []

--- a/model-optimizer/mo/utils/version.py
+++ b/model-optimizer/mo/utils/version.py
@@ -65,4 +65,9 @@ def get_simplified_ie_version(env=dict(), version=None):
             version = subprocess.check_output([sys.executable, os.path.join(os.path.dirname(__file__), "ie_version.py")], timeout=2, env=env).strip().decode()
         except:
             return "ie not found"
+
+    # To support legacy IE versions
+    m = re.match(r"^([0-9]+).([0-9]+).(.*)", version)
+    if m and len(m.groups()) == 3:
+        return simplify_version(m.group(3))
     return simplify_version(version)

--- a/model-optimizer/mo/utils/version.py
+++ b/model-optimizer/mo/utils/version.py
@@ -65,7 +65,4 @@ def get_simplified_ie_version(env=dict(), version=None):
             version = subprocess.check_output([sys.executable, os.path.join(os.path.dirname(__file__), "ie_version.py")], timeout=2, env=env).strip().decode()
         except:
             return "ie not found"
-    m = re.match(r"^([0-9]+).([0-9]+).(.*)", version)
-    if m and len(m.groups()) == 3:
-        return simplify_version(m.group(3))
-    return "custom"
+    return simplify_version(version)

--- a/model-optimizer/mo_caffe.py
+++ b/model-optimizer/mo_caffe.py
@@ -5,5 +5,5 @@
 
 
 if __name__ == "__main__":
-    from mo.main import subprocess_main
+    from mo.subprocess_main import subprocess_main
     subprocess_main(framework='caffe')

--- a/model-optimizer/mo_caffe.py
+++ b/model-optimizer/mo_caffe.py
@@ -3,16 +3,7 @@
 # Copyright (C) 2018-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
-
-from mo.utils.versions_checker import check_python_version
 
 if __name__ == "__main__":
-    ret_code = check_python_version()
-    if ret_code:
-        sys.exit(ret_code)
-
-    from mo.main import main
-    from mo.utils.cli_parser import get_caffe_cli_parser
-
-    sys.exit(main(get_caffe_cli_parser(), 'caffe'))
+    from mo.main import subprocess_main
+    subprocess_main(framework='caffe')

--- a/model-optimizer/mo_caffe.py
+++ b/model-optimizer/mo_caffe.py
@@ -5,5 +5,5 @@
 
 
 if __name__ == "__main__":
-    from mo.main import subprocess_main # pylint: disable=no-name-in-module
+    from mo.main import subprocess_main
     subprocess_main(framework='caffe')

--- a/model-optimizer/mo_caffe.py
+++ b/model-optimizer/mo_caffe.py
@@ -5,5 +5,5 @@
 
 
 if __name__ == "__main__":
-    from mo.main import subprocess_main
+    from mo.main import subprocess_main # pylint: disable=no-name-in-module
     subprocess_main(framework='caffe')

--- a/model-optimizer/mo_kaldi.py
+++ b/model-optimizer/mo_kaldi.py
@@ -3,16 +3,7 @@
 # Copyright (C) 2018-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
-
-from mo.utils.versions_checker import check_python_version
 
 if __name__ == "__main__":
-    ret_code = check_python_version()
-    if ret_code:
-        sys.exit(ret_code)
-
-    from mo.main import main
-    from mo.utils.cli_parser import get_kaldi_cli_parser
-
-    sys.exit(main(get_kaldi_cli_parser(), 'kaldi'))
+    from mo.main import subprocess_main
+    subprocess_main(framework='kaldi')

--- a/model-optimizer/mo_kaldi.py
+++ b/model-optimizer/mo_kaldi.py
@@ -5,5 +5,5 @@
 
 
 if __name__ == "__main__":
-    from mo.main import subprocess_main
+    from mo.subprocess_main import subprocess_main
     subprocess_main(framework='kaldi')

--- a/model-optimizer/mo_mxnet.py
+++ b/model-optimizer/mo_mxnet.py
@@ -5,5 +5,5 @@
 
 
 if __name__ == "__main__":
-    from mo.main import subprocess_main
+    from mo.subprocess_main import subprocess_main
     subprocess_main(framework='mxnet')

--- a/model-optimizer/mo_mxnet.py
+++ b/model-optimizer/mo_mxnet.py
@@ -3,16 +3,7 @@
 # Copyright (C) 2018-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
-
-from mo.utils.versions_checker import check_python_version
 
 if __name__ == "__main__":
-    ret_code = check_python_version()
-    if ret_code:
-        sys.exit(ret_code)
-
-    from mo.main import main
-    from mo.utils.cli_parser import get_mxnet_cli_parser
-
-    sys.exit(main(get_mxnet_cli_parser(), 'mxnet'))
+    from mo.main import subprocess_main
+    subprocess_main(framework='mxnet')

--- a/model-optimizer/mo_onnx.py
+++ b/model-optimizer/mo_onnx.py
@@ -3,16 +3,7 @@
 # Copyright (C) 2018-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
-
-from mo.utils.versions_checker import check_python_version
 
 if __name__ == "__main__":
-    ret_code = check_python_version()
-    if ret_code:
-        sys.exit(ret_code)
-
-    from mo.main import main
-    from mo.utils.cli_parser import get_onnx_cli_parser
-
-    sys.exit(main(get_onnx_cli_parser(), 'onnx'))
+    from mo.main import subprocess_main
+    subprocess_main(framework='onnx')

--- a/model-optimizer/mo_onnx.py
+++ b/model-optimizer/mo_onnx.py
@@ -5,5 +5,5 @@
 
 
 if __name__ == "__main__":
-    from mo.main import subprocess_main
+    from mo.subprocess_main import subprocess_main
     subprocess_main(framework='onnx')

--- a/model-optimizer/mo_tf.py
+++ b/model-optimizer/mo_tf.py
@@ -3,16 +3,7 @@
 # Copyright (C) 2018-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
-
-from mo.utils.versions_checker import check_python_version
 
 if __name__ == "__main__":
-    ret_code = check_python_version()
-    if ret_code:
-        sys.exit(ret_code)
-
-    from mo.main import main
-    from mo.utils.cli_parser import get_tf_cli_parser
-
-    sys.exit(main(get_tf_cli_parser(), 'tf'))
+    from mo.main import subprocess_main
+    subprocess_main(framework='tf')

--- a/model-optimizer/mo_tf.py
+++ b/model-optimizer/mo_tf.py
@@ -5,5 +5,5 @@
 
 
 if __name__ == "__main__":
-    from mo.main import subprocess_main
+    from mo.subprocess_main import subprocess_main
     subprocess_main(framework='tf')

--- a/model-optimizer/unit_tests/mo/utils/cli_parser_test.py
+++ b/model-optimizer/unit_tests/mo/utils/cli_parser_test.py
@@ -14,7 +14,7 @@ import numpy.testing as npt
 
 from mo.utils.cli_parser import get_placeholder_shapes, get_tuple_values, get_mean_scale_dictionary, get_model_name, \
     parse_tuple_pairs, check_positive, writable_dir, readable_dirs, \
-    readable_file, get_freeze_placeholder_values
+    readable_file, get_freeze_placeholder_values, parse_transform
 from mo.utils.error import Error
 
 
@@ -898,3 +898,61 @@ class PathCheckerFunctions(unittest.TestCase):
     def test_non_readable_file(self):
         with self.assertRaises(Error) as cm:
             readable_file(__class__.NOT_EXISTING_FILE)
+
+
+class TransformChecker(unittest.TestCase):
+    def test_empty(self):
+        self.assertEqual(parse_transform(""), [])
+
+    def test_single_pass(self):
+        self.assertEqual(parse_transform("LowLatency"), [("LowLatency", {})])
+
+    def test_single_pass_with_args(self):
+        self.assertEqual(parse_transform("LowLatency[num_iterations=2]"),
+                         [("LowLatency", {"num_iterations": 2})])
+
+    def test_single_pass_with_multiple_args(self):
+        self.assertEqual(parse_transform("LowLatency[num_iterations=2;dummy_attr=3.14]"),
+                         [("LowLatency", {"num_iterations": 2, "dummy_attr": 3.14})])
+
+    def test_multiple_passes_with_args(self):
+        self.assertEqual(parse_transform("LowLatency[num_iterations=2],DummyPass[type=ReLU]"),
+                         [("LowLatency", {"num_iterations": 2}),
+                          ("DummyPass", {"type": "ReLU"})])
+
+    def test_multiple_passes_with_args2(self):
+        self.assertEqual(parse_transform("LowLatency[num_iterations=2,3,4.15],DummyPass1,DummyPass2[types=ReLU,PReLU;values=1,2,3]"),
+                         [("LowLatency",  {"num_iterations": [2,3,4.15]}),
+                          ("DummyPass1",  {}),
+                          ("DummyPass2",  {"types": ["ReLU", "PReLU"], "values": [1,2,3]})])
+
+    def test_multiple_passes_no_args(self):
+        self.assertEqual(parse_transform("DummyPass,LowLatency2"),
+                         [("DummyPass", {}), ("LowLatency2", {})])
+
+    def test_single_pass_neg(self):
+        self.assertRaises(Error, parse_transform, "LowLatency!")
+
+    def test_single_pass_neg(self):
+        self.assertRaises(Error, parse_transform, "LowLatency!")
+
+    def test_multiple_passes_neg(self):
+        self.assertRaises(Error, parse_transform, "LowLatency;DummyPass")
+
+    def test_single_pass_with_args_neg1(self):
+        self.assertRaises(Error, parse_transform, "LowLatency[=2]")
+
+    def test_single_pass_with_args_neg2(self):
+        self.assertRaises(Error, parse_transform, "LowLatency[key=]")
+
+    def test_single_pass_with_args_neg3(self):
+        self.assertRaises(Error, parse_transform, "LowLatency[]")
+
+    def test_single_pass_with_args_neg4(self):
+        self.assertRaises(Error, parse_transform, "LowLatency[key=value;]")
+
+    def test_single_pass_with_args_neg5(self):
+        self.assertRaises(Error, parse_transform, "LowLatency[value]")
+
+    def test_single_pass_with_args_neg6(self):
+        self.assertRaises(Error, parse_transform, "LowLatency[key=value")

--- a/model-optimizer/unit_tests/mo/utils/cli_parser_test.py
+++ b/model-optimizer/unit_tests/mo/utils/cli_parser_test.py
@@ -14,7 +14,7 @@ import numpy.testing as npt
 
 from mo.utils.cli_parser import get_placeholder_shapes, get_tuple_values, get_mean_scale_dictionary, get_model_name, \
     parse_tuple_pairs, check_positive, writable_dir, readable_dirs, \
-    readable_file, get_freeze_placeholder_values, parse_transform
+    readable_file, get_freeze_placeholder_values, parse_transform, check_available_transforms
 from mo.utils.error import Error
 
 
@@ -904,41 +904,29 @@ class TransformChecker(unittest.TestCase):
     def test_empty(self):
         self.assertEqual(parse_transform(""), [])
 
-    @patch("mo.back.offline_transformations.get_available_transformations")
-    def test_single_pass(self, available_transformations):
-        available_transformations.return_value = {"LowLatency": None}
+    def test_single_pass(self):
         self.assertEqual(parse_transform("LowLatency"), [("LowLatency", {})])
 
-    @patch("mo.back.offline_transformations.get_available_transformations")
-    def test_single_pass_with_args(self, available_transformations):
-        available_transformations.return_value = {"LowLatency": None}
+    def test_single_pass_with_args(self):
         self.assertEqual(parse_transform("LowLatency[num_iterations=2]"),
                          [("LowLatency", {"num_iterations": 2})])
 
-    @patch("mo.back.offline_transformations.get_available_transformations")
-    def test_single_pass_with_multiple_args(self, available_transformations):
-        available_transformations.return_value = {"LowLatency": None}
+    def test_single_pass_with_multiple_args(self):
         self.assertEqual(parse_transform("LowLatency[num_iterations=2;dummy_attr=3.14]"),
                          [("LowLatency", {"num_iterations": 2, "dummy_attr": 3.14})])
 
-    @patch("mo.back.offline_transformations.get_available_transformations")
-    def test_multiple_passes_with_args(self, available_transformations):
-        available_transformations.return_value = {"DummyPass": None, "LowLatency": None}
+    def test_multiple_passes_with_args(self):
         self.assertEqual(parse_transform("LowLatency[num_iterations=2],DummyPass[type=ReLU]"),
                          [("LowLatency", {"num_iterations": 2}),
                           ("DummyPass", {"type": "ReLU"})])
 
-    @patch("mo.back.offline_transformations.get_available_transformations")
-    def test_multiple_passes_with_args2(self, available_transformations):
-        available_transformations.return_value = {"DummyPass1": None, "DummyPass2": None, "LowLatency": None}
+    def test_multiple_passes_with_args2(self):
         self.assertEqual(parse_transform("LowLatency[num_iterations=2,3,4.15],DummyPass1,DummyPass2[types=ReLU,PReLU;values=1,2,3]"),
                          [("LowLatency",  {"num_iterations": [2,3,4.15]}),
                           ("DummyPass1",  {}),
                           ("DummyPass2",  {"types": ["ReLU", "PReLU"], "values": [1,2,3]})])
 
-    @patch("mo.back.offline_transformations.get_available_transformations")
-    def test_multiple_passes_no_args(self, available_transformations):
-        available_transformations.return_value = {"DummyPass": None, "LowLatency2": None}
+    def test_multiple_passes_no_args(self):
         self.assertEqual(parse_transform("DummyPass,LowLatency2"),
                          [("DummyPass", {}), ("LowLatency2", {})])
 
@@ -965,3 +953,16 @@ class TransformChecker(unittest.TestCase):
 
     def test_single_pass_with_args_neg6(self):
         self.assertRaises(Error, parse_transform, "LowLatency[key=value")
+
+    @patch("mo.back.offline_transformations.get_available_transformations")
+    def test_check_low_latency_is_available(self, available_transformations):
+        available_transformations.return_value = {"LowLatency": None}
+        try:
+            check_available_transforms([("LowLatency" ,"")], True)
+        except Error as e:
+            self.assertTrue(False, "Exception \"{}\" is unexpected".format(e))
+
+    @patch("mo.back.offline_transformations.get_available_transformations")
+    def test_check_dummy_pass_is_available(self, available_transformations):
+        available_transformations.return_value = {"LowLatency": None}
+        self.assertRaises(Error, check_available_transforms, [("DummyPass", "")], True)

--- a/model-optimizer/unit_tests/mo/utils/cli_parser_test.py
+++ b/model-optimizer/unit_tests/mo/utils/cli_parser_test.py
@@ -904,34 +904,43 @@ class TransformChecker(unittest.TestCase):
     def test_empty(self):
         self.assertEqual(parse_transform(""), [])
 
-    def test_single_pass(self):
+    @patch("mo.back.offline_transformations.get_available_transformations")
+    def test_single_pass(self, available_transformations):
+        available_transformations.return_value = {"LowLatency": None}
         self.assertEqual(parse_transform("LowLatency"), [("LowLatency", {})])
 
-    def test_single_pass_with_args(self):
+    @patch("mo.back.offline_transformations.get_available_transformations")
+    def test_single_pass_with_args(self, available_transformations):
+        available_transformations.return_value = {"LowLatency": None}
         self.assertEqual(parse_transform("LowLatency[num_iterations=2]"),
                          [("LowLatency", {"num_iterations": 2})])
 
-    def test_single_pass_with_multiple_args(self):
+    @patch("mo.back.offline_transformations.get_available_transformations")
+    def test_single_pass_with_multiple_args(self, available_transformations):
+        available_transformations.return_value = {"LowLatency": None}
         self.assertEqual(parse_transform("LowLatency[num_iterations=2;dummy_attr=3.14]"),
                          [("LowLatency", {"num_iterations": 2, "dummy_attr": 3.14})])
 
-    def test_multiple_passes_with_args(self):
+    @patch("mo.back.offline_transformations.get_available_transformations")
+    def test_multiple_passes_with_args(self, available_transformations):
+        available_transformations.return_value = {"DummyPass": None, "LowLatency": None}
         self.assertEqual(parse_transform("LowLatency[num_iterations=2],DummyPass[type=ReLU]"),
                          [("LowLatency", {"num_iterations": 2}),
                           ("DummyPass", {"type": "ReLU"})])
 
-    def test_multiple_passes_with_args2(self):
+    @patch("mo.back.offline_transformations.get_available_transformations")
+    def test_multiple_passes_with_args2(self, available_transformations):
+        available_transformations.return_value = {"DummyPass1": None, "DummyPass2": None, "LowLatency": None}
         self.assertEqual(parse_transform("LowLatency[num_iterations=2,3,4.15],DummyPass1,DummyPass2[types=ReLU,PReLU;values=1,2,3]"),
                          [("LowLatency",  {"num_iterations": [2,3,4.15]}),
                           ("DummyPass1",  {}),
                           ("DummyPass2",  {"types": ["ReLU", "PReLU"], "values": [1,2,3]})])
 
-    def test_multiple_passes_no_args(self):
+    @patch("mo.back.offline_transformations.get_available_transformations")
+    def test_multiple_passes_no_args(self, available_transformations):
+        available_transformations.return_value = {"DummyPass": None, "LowLatency2": None}
         self.assertEqual(parse_transform("DummyPass,LowLatency2"),
                          [("DummyPass", {}), ("LowLatency2", {})])
-
-    def test_single_pass_neg(self):
-        self.assertRaises(Error, parse_transform, "LowLatency!")
 
     def test_single_pass_neg(self):
         self.assertRaises(Error, parse_transform, "LowLatency!")

--- a/model-optimizer/unit_tests/mo/utils/version_test.py
+++ b/model-optimizer/unit_tests/mo/utils/version_test.py
@@ -52,11 +52,14 @@ class TestingVersion(unittest.TestCase):
         mock_open.return_value.__enter__ = mock_open
         self.assertEqual(get_simplified_mo_version(), "custom")
 
-    def test_simplify_ie_version_release(self):
+    def test_simplify_ie_version_release_legacy(self):
         self.assertEqual(get_simplified_ie_version(version="2.1.custom_releases/2021/3_4c8eae"), "2021.3")
 
-    def test_simplify_ie_version_release_neg(self):
-        self.assertEqual(get_simplified_ie_version(version="custom_releases/2021/3_4c8eae"), "custom")
+    def test_simplify_ie_version_release(self):
+        self.assertEqual(get_simplified_ie_version(version="custom_releases/2021/3_4c8eae"), "2021.3")
+
+    def test_simplify_ie_version_custom_legacy(self):
+        self.assertEqual(get_simplified_ie_version(version="2.1.custom_my/branch/3_4c8eae"), "custom")
 
     def test_simplify_ie_version_custom(self):
-        self.assertEqual(get_simplified_ie_version(version="2.1.custom_my/branch/3_4c8eae"), "custom")
+        self.assertEqual(get_simplified_ie_version(version="custom_my/branch/3_4c8eae"), "custom")


### PR DESCRIPTION
### Description
This PR introduces next important changes to the Model Optimizer and offline transformations execution:
1. IE Python API check was moved to the mo_<framework>.py files so inside MO pipeline we don't have to check for IE Python API existence and we can just rely on argv.ie_is_available key value.
2. `--transform transformation_name[args],transformation_name...` cmd key was added to allow MO users to execute specific nGraph transformations in offline.
3. Added additional logic to notify MO user if IE is not available but --transform was used.
4. LowLatency transformation was added to the list with available offline transformations inside MO.
5. Fixed MO vs IE versions comparison due to recent change in IE version structure.
