### PR TITLE
Fuse add transformation fix

### DIFF
--- a/model-optimizer/mo/middle/passes/fusing/fuse_linear_ops.py
+++ b/model-optimizer/mo/middle/passes/fusing/fuse_linear_ops.py
@@ -110,12 +110,12 @@ def _fuse_mul(graph: Graph, node: Node, fuse_nodes: list, backward: bool = True)
         w_const = weights_port.get_source()
 
         r"""
-        In this transformation we take Mul or Div node (node) that goes after fuse_node and
-        insert it before the fuse_node (w_mul) with the corrected const value (mul_const). 
-        So the input data of fuse_node becomes different. For this reason we need to use 
-        set_destination from previous operation to w_mul which guaranties that data node 
-        will be reused on previous_op -> w_mul connection and its attributes won't be copied 
-        to w_mul -> fuse_node connection.   
+        In this transformation we remove Mul or Div node (node) that goes after fuse_node and
+        create new Mul node (w_mul), connect it with the corrected const value (mul_const) and
+        insert w_mul before the fuse_node. So the input data of fuse_node becomes different. 
+        For this reason we need to use set_destination from previous operation to w_mul which 
+        guaranties that data node will be reused on previous_op -> w_mul connection and its 
+        attributes won't be copied to w_mul -> fuse_node connection.   
         
         BEFORE                        AFTER
 

--- a/model-optimizer/mo/middle/passes/fusing/fuse_linear_ops.py
+++ b/model-optimizer/mo/middle/passes/fusing/fuse_linear_ops.py
@@ -115,7 +115,7 @@ def _fuse_mul(graph: Graph, node: Node, fuse_nodes: list, backward: bool = True)
         insert w_mul before the fuse_node. So the input data of fuse_node becomes different. 
         For this reason we need to use set_destination from previous operation to w_mul which 
         guaranties that data node will be reused on previous_op -> w_mul connection and its 
-        attributes won't be copied to w_mul -> fuse_node connection.   
+        attributes won't be copied to the data node of w_mul -> fuse_node connection.   
         
         BEFORE                        AFTER
 


### PR DESCRIPTION
Root cause analysis: 
_fuse_add transformation finds MatMul node and a Mul node that goes after it, than removes Mul node and inserts a new Mul node before the MatMul using set_source() method. set_source() copies attributes from the data node of old connection to the new data node. But the data node that goes to MatMul no longer correspond to original data tensor and as previous node stays in graph it leads to appearance of two data nodes with the same name. 

After the constant folding and graph cleanup the operation that goes to the new data node is deleted as const producer and the new Const op is created with the name obtained from data node which leads to the error, that graph contains two nodes with the same name.

Solution: If we use set_destination() in _fuse_add old data node is reused in previous op -> new Mul connection and attributes are not copied to new Mul-> MatMul 

Ticket: 54845


Code:
* [ ]  Comments
* [ ]  Code style (PEP8)
* [ ]  Transformation generates reshape-able IR
* [ ]  Transformation preserves original framework node names


Validation:
* [ ]  Unit tests
* [ ]  Framework operation tests - N/A
* [ ]  Transformation tests - N/A
* [ ]  Model Optimizer IR Reader check

Documentation:
* [ ]  Supported frameworks operations list - N/A
* [ ]  Guide on how to convert the **public** model - N/A
* [ ]  User guide update - N/A