### PR TITLE
Fix topk failure

### DIFF
--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/topk.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/topk.cpp
@@ -33,7 +33,6 @@ const std::vector<ngraph::opset4::TopK::Mode> modes = {
 };
 
 const std::vector<ngraph::opset4::TopK::SortType> sortTypes = {
-        ngraph::opset4::TopK::SortType::NONE,
         ngraph::opset4::TopK::SortType::SORT_INDICES,
         ngraph::opset4::TopK::SortType::SORT_VALUES,
 };

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
@@ -40,9 +40,6 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*ActivationLayerTest.*Ceiling.*)",
         // TODO: Issue: 32032
         R"(.*ActivationParamLayerTest.*)",
-        // TODO: Issue: 38841
-        R"(.*TopKLayerTest.*k=10.*mode=min.*sort=index.*)",
-        R"(.*TopKLayerTest.*k=5.*sort=(none|index).*)",
         // TODO: Issue: 43314
         R"(.*Broadcast.*mode=BIDIRECTIONAL.*inNPrec=BOOL.*)",
         // TODO: Issue 43417 sporadic issue, looks like an issue in test, reproducible only on Windows platform


### PR DESCRIPTION
### Details:
 - *Remove unnecessary test cases, in which output mismatch is expected, because according to spec the permutation of topk elements is undefined when SortType is NONE*.

### Tickets:
 - *38841*
