### PR TITLE
Fix python_tools benchmark installation location

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -45,8 +45,8 @@ if(ENABLE_PYTHON)
             DESTINATION python/${PYTHON_VERSION}/openvino/tools
             COMPONENT python_tools_${PYTHON_VERSION})
 
-    install(DIRECTORY benchmark/
-            DESTINATION python/${PYTHON_VERSION}/openvino/tools/benchmark
+    install(DIRECTORY benchmark
+            DESTINATION python/${PYTHON_VERSION}/openvino/tools
             USE_SOURCE_PERMISSIONS
             COMPONENT python_tools_${PYTHON_VERSION})
     

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -46,7 +46,7 @@ if(ENABLE_PYTHON)
             COMPONENT python_tools_${PYTHON_VERSION})
 
     install(DIRECTORY benchmark/
-            DESTINATION python/${PYTHON_VERSION}/openvino/tools
+            DESTINATION python/${PYTHON_VERSION}/openvino/tools/benchmark
             USE_SOURCE_PERMISSIONS
             COMPONENT python_tools_${PYTHON_VERSION})
     


### PR DESCRIPTION
Before this fix, when running "make install", the benchmark python files
would be installed under <python_dest_dir>/openvino/tools, instead of
<python_dest_dir>/openvino/tools/benchmark. This commit fixes this.
