### PR TITLE
[UnitTest] Reset shared-pointer explicitly in MklDnnFunctionalTest

### DIFF
--- a/inference-engine/tests_deprecated/functional/shared_tests/io_blob_tests/dims_tests.hpp
+++ b/inference-engine/tests_deprecated/functional/shared_tests/io_blob_tests/dims_tests.hpp
@@ -49,6 +49,7 @@ protected:
     }
 
     void TearDown() override {
+        PluginCache::get().reset();
     }
 
     std::string ConvNet(const int batch, TBlob<uint8_t>::Ptr &weights) {

--- a/inference-engine/tests_deprecated/functional/shared_tests/io_blob_tests/layout_tests.hpp
+++ b/inference-engine/tests_deprecated/functional/shared_tests/io_blob_tests/layout_tests.hpp
@@ -139,6 +139,7 @@ protected:
     }
 
     void TearDown() override {
+        PluginCache::get().reset();
     }
 
     template <Precision::ePrecision PRC>


### PR DESCRIPTION
### Details:
 - The shared-pointer wasn't released as expected after a test is finished, that's why hanging issue has been occurred.
 - Call to a method to reset explicitly in TearDown() for the test cases which use the shared-pointer.

### Tickets:
 - 33386
