### PR TITLE
plugin_api: fix build with gcc 11

### DIFF
--- a/inference-engine/src/plugin_api/ie_system_conf.h
+++ b/inference-engine/src/plugin_api/ie_system_conf.h
@@ -11,6 +11,7 @@
 
 #include "ie_api.h"
 #include <vector>
+#include <exception>
 
 namespace InferenceEngine {
 


### PR DESCRIPTION
Some C++ Standard Library headers have been changed in gcc 11 to no
longer include other headers that they do need to depend on.

Include <exception> explicitly to avoid:

| inference-engine/src/plugin_api/ie_system_conf.h:21:31: error: 'exception_ptr' in namespace 'std' does not name a type; did you mean 'exception'?
|    21 | INFERENCE_ENGINE_API_CPP(std::exception_ptr&) CurrentException();
|      |                               ^~~~~~~~~~~~~

Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>
