### PR TITLE
Redundant copying of weights and biases for convolution layer

### DIFF
--- a/inference-engine/src/mkldnn_plugin/mkldnn_edge.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_edge.h
@@ -46,6 +46,7 @@ public:
     void init();
     void allocate(const void* mem_ptr = nullptr);
     void externalAllocate(MKLDNNWeightsSharing::Ptr weightsCache);
+    void reuse(MKLDNNMemoryPtr ptr);
     void validate();
     void drop();
 

--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph.cpp
@@ -574,7 +574,7 @@ void MKLDNNGraph::AllocateWithReuse() {
                 && edge->getParent()->isConstant()) {
                 if (edge->getParent()->getType() == Input) {
                     auto constNode = std::static_pointer_cast<MKLDNNInputNode>(edge->getParent());
-                    edge->reuse(constNode->getMemoryPtr());
+                    edge->reuse(std::const_pointer_cast<MKLDNNMemory>(constNode->getMemoryPtr()));
                 } else {
                     edge->externalAllocate(weightsCache);
                 }

--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph.cpp
@@ -572,7 +572,12 @@ void MKLDNNGraph::AllocateWithReuse() {
         for (auto &edge : cluster) {
             if (edge->getStatus() == MKLDNNEdge::Status::NeedAllocation
                 && edge->getParent()->isConstant()) {
-                edge->externalAllocate(weightsCache);
+                if (edge->getParent()->getType() == Input) {
+                    auto constNode = std::static_pointer_cast<MKLDNNInputNode>(edge->getParent());
+                    edge->reuse(constNode->getMemoryPtr());
+                } else {
+                    edge->externalAllocate(weightsCache);
+                }
                 erase = true;
             }
         }

--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph_optimizer.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph_optimizer.cpp
@@ -478,11 +478,11 @@ void MKLDNNGraphOptimizer::FuseConvolutionAndZeroPoints(MKLDNNGraph &graph) {
                 if (zeroPointsConstant == nullptr)
                     IE_THROW() << "Cannot cast to Input node";
 
-                auto zeroPointsBlob = dynamic_cast<const TBlob<uint8_t>*>(zeroPointsConstant->getConstBlob().get());
+                auto zeroPointsBlob = zeroPointsConstant->getMemoryPtr();
                 if (zeroPointsBlob == nullptr)
                     IE_THROW() << "Cannot cast to TBlob internal zero points blob";
 
-                auto zeroPointsData = zeroPointsBlob->cbuffer().as<uint8_t*>();
+                auto zeroPointsData = static_cast<const uint8_t*>(zeroPointsBlob->GetPtr());
                 if (zeroPointsData == nullptr)
                     IE_THROW() << "zeroPointsBlob has not allocated buffer";
 
@@ -515,11 +515,11 @@ void MKLDNNGraphOptimizer::FuseConvolutionAndZeroPoints(MKLDNNGraph &graph) {
         if (!weightsConstant || !weightsConstant->isConstant())
             return;
 
-        auto weightsBlob = dynamic_cast<const TBlob<int8_t>*>(weightsConstant->getConstBlob().get());
+        auto weightsBlob = weightsConstant->getMemoryPtr();
         if (weightsBlob == nullptr)
             IE_THROW() << "Cannot cast to TBlob internal weights blob";
 
-        auto weightsPtr = weightsBlob->cbuffer().as<int8_t*>();
+        auto weightsPtr = static_cast<const int8_t*>(weightsBlob->GetPtr());
         if (weightsPtr == nullptr)
             IE_THROW() << "weightsBlob has not allocated buffer";
 

--- a/inference-engine/src/mkldnn_plugin/mkldnn_memory.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_memory.h
@@ -172,5 +172,6 @@ private:
 };
 
 using MKLDNNMemoryPtr = std::shared_ptr<MKLDNNMemory>;
+using MKLDNNMemoryCPtr = std::shared_ptr<const MKLDNNMemory>;
 
 }  // namespace MKLDNNPlugin

--- a/inference-engine/src/mkldnn_plugin/mkldnn_node.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_node.h
@@ -364,13 +364,13 @@ public:
         this->fusingPort = fusingPort;
     }
 
-    const std::string getName() const {
+    const std::string &getName() const {
         return name;
     }
 
     void addOriginalLayer(const std::string& layerName);
 
-    const std::string getOriginalLayers() const {
+    const std::string &getOriginalLayers() const {
         return originalLayers;
     }
 
@@ -665,7 +665,7 @@ protected:
 
     bool isUninitTensorDesc(const InferenceEngine::TensorDesc& desc) const;
     bool isInitConfig(const InferenceEngine::LayerConfig& config) const;
-    virtual void selectPreferPrimitiveDescriptor(const std::vector<impl_desc_type>& priority);
+    void selectPreferPrimitiveDescriptor(const std::vector<impl_desc_type>& priority, bool ignoreConstInputs);
     virtual bool canBeInPlace() const;
 
     virtual const std::vector<impl_desc_type>& getPrimitivesPriority();

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
@@ -876,21 +876,26 @@ InferenceEngine::Blob::Ptr MKLDNNConvolutionNode::createInternalBlob(InferenceEn
     if (!constNode) {
         IE_THROW() << "Cannot cast " << edgeNum << " input to Input node for " << getName() << ".";
     }
-    InferenceEngine::Blob::CPtr blb = constNode->getConstBlob();
+    auto blb = constNode->getMemoryPtr();
     if (blb == nullptr)
         IE_THROW() << "Cannot get const blob for node " << getName() << ".";
+
+    auto const elementsCount = blb->GetElementsCount();
 
     InferenceEngine::TensorDesc desc(InferenceEngine::Precision::FP32, dims, getWeightsLayoutByDims(dims, isGrouped));
 
     Blob::Ptr internalBlob = InferenceEngine::make_shared_blob<float>(desc);
     internalBlob->allocate();
 
-    if (internalBlob->size() != blb->size()) {
+    if (internalBlob->size() != elementsCount) {
         IE_THROW() << "Created internal blob and const blob has different size for node: " << getName() << ".";
     }
 
-    cpu_convert(blb->cbuffer(), internalBlob->buffer(), blb->getTensorDesc().getPrecision(), internalBlob->getTensorDesc().getPrecision(),
-                internalBlob->size());
+    cpu_convert(blb->GetPtr(),
+                internalBlob->buffer(),
+                MKLDNNExtensionUtils::DataTypeToIEPrecision(blb->GetDataType()),
+                internalBlob->getTensorDesc().getPrecision(),
+                elementsCount);
 
     return internalBlob;
 }

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
@@ -402,6 +402,10 @@ void MKLDNNConvolutionNode::setPostOps(mkldnn::primitive_attr &attr, bool initWe
     attr.set_post_ops(ops);
 }
 
+void MKLDNNConvolutionNode::selectOptimalPrimitiveDescriptor() {
+    selectPreferPrimitiveDescriptor(getPrimitivesPriority(), true);
+}
+
 void MKLDNNConvolutionNode::initSupportedPrimitiveDescriptors() {
     if (!supportedPrimitiveDescriptors.empty())
         return;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.h
@@ -24,6 +24,7 @@ public:
                           const std::vector<InferenceEngine::TensorDesc>& outputDesc) override;
     void initDescriptor(const InferenceEngine::LayerConfig& config) override;
     void createPrimitive() override;
+    void selectOptimalPrimitiveDescriptor() override;
     void initSupportedPrimitiveDescriptors() override;
     void filterSupportedPrimitiveDescriptors() override;
     bool created() const override;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_eltwise_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_eltwise_node.cpp
@@ -1406,54 +1406,7 @@ void MKLDNNEltwiseNode::createPrimitive() {
 }
 
 void MKLDNNEltwiseNode::selectOptimalPrimitiveDescriptor() {
-    for (auto& type : getPrimitivesPriority()) {
-        int selectedPrimitive = -1;
-        int equalsFormatCount = -1;
-        for (size_t i = 0; i < getSupportedPrimitiveDescriptors().size(); i++) {
-            impl_desc_type supportedType = getSupportedPrimitiveDescriptors()[i].getImplementationType();
-            if (type == supportedType) {
-                int equalsLocalFormatCount = 0;
-                if (getSupportedPrimitiveDescriptors()[i].getConfig().inConfs.size() > getParentEdges().size())
-                    continue;
-                for (size_t j = 0; j < getSupportedPrimitiveDescriptors()[i].getConfig().inConfs.size(); j++) {
-                    auto parentEdge = getParentEdgeAt(j);
-                    auto parentPtr = parentEdge->getParent();
-                    // We don't take into account constant edges since reorders on them will be executed on load network stage
-                    if (j > 0 && parentPtr->isConstant()) {
-                        equalsLocalFormatCount++;
-                        continue;
-                    }
-
-                    auto parent_spd = parentPtr->getSelectedPrimitiveDescriptor();
-
-                    if (parent_spd != nullptr && !parent_spd->getConfig().outConfs.empty()) {
-                        int inNum = parentEdge->getInputNum();
-                        if (inNum < 0 || inNum >= parent_spd->getConfig().outConfs.size()) {
-                            inNum = 0;
-                        }
-                        if (MKLDNNExtensionUtils::initTensorsAreEqual(
-                                getSupportedPrimitiveDescriptors()[i].getConfig().inConfs[j].desc,
-                                parent_spd->getConfig().outConfs[inNum].desc)) {
-                            equalsLocalFormatCount++;
-                        }
-                    }
-                }
-                if (equalsLocalFormatCount > equalsFormatCount) {
-                    equalsFormatCount = equalsLocalFormatCount;
-                    selectedPrimitive = static_cast<int>(i);
-                }
-            }
-        }
-        if (selectedPrimitive >= 0) {
-            selectPrimitiveDescriptorByIndex(selectedPrimitive);
-            return;
-        }
-    }
-
-    if (getSupportedPrimitiveDescriptors().empty())
-        IE_THROW() << "Supported primitive descriptors list is empty for node: " << getName();
-    // fallback. If there are no primitives from priority list just select a first
-    selectPrimitiveDescriptorByIndex(0);
+    selectPreferPrimitiveDescriptor(getPrimitivesPriority(), true);
 }
 
 void MKLDNNEltwiseNode::initOptimalPrimitiveDescriptor() {

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_input_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_input_node.h
@@ -21,19 +21,18 @@ public:
     void createPrimitive() override;
     bool created() const override;
 
-    void execute(mkldnn::stream strm) override;
-    void withMeanImage() {
-        isMeanImage = true;
-    }
-
-    const InferenceEngine::Blob::CPtr getConstBlob() const {
-        return constBlob;
-    }
+    void withMeanImage();
+    const InferenceEngine::Blob::CPtr getConstBlob() const;
+    MKLDNNMemoryPtr getMemoryPtr() const;
 
 private:
-    InferenceEngine::Precision precision;
+    void cloneBlobIfRequired(const MKLDNNDims& dims, const InferenceEngine::Precision& prec);
 
+private:
+    std::shared_ptr<ngraph::Node> origLayer;
+    InferenceEngine::Precision precision;
     InferenceEngine::Blob::Ptr constBlob = nullptr;
+    MKLDNNMemoryPtr memoryPtr;
     bool isMeanImage = false;
 };
 

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_input_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_input_node.h
@@ -6,6 +6,7 @@
 
 #include <ie_common.h>
 #include <mkldnn_node.h>
+#include <ngraph/op/constant.hpp>
 #include <string>
 
 namespace MKLDNNPlugin {
@@ -22,17 +23,15 @@ public:
     bool created() const override;
 
     void withMeanImage();
-    const InferenceEngine::Blob::CPtr getConstBlob() const;
-    MKLDNNMemoryPtr getMemoryPtr() const;
+    MKLDNNMemoryCPtr getMemoryPtr() const;
 
 private:
-    void cloneBlobIfRequired(const MKLDNNDims& dims, const InferenceEngine::Precision& prec);
+    void cloneBlobIfRequired();
 
 private:
-    std::shared_ptr<ngraph::Node> origLayer;
+    std::shared_ptr<ngraph::op::Constant> constOp;
     InferenceEngine::Precision precision;
-    InferenceEngine::Blob::Ptr constBlob = nullptr;
-    MKLDNNMemoryPtr memoryPtr;
+    MKLDNNMemoryCPtr memoryPtr;
     bool isMeanImage = false;
 };
 

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_strided_slice_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_strided_slice_node.cpp
@@ -138,10 +138,10 @@ void MKLDNNStridedSliceNode::getSupportedDescriptors() {
 
     if (params.parametersAreConstant) {
         auto fillingInParameters = [&](std::vector<int> &parameter, const size_t type, const size_t size, const int value) {
-            auto blob = std::dynamic_pointer_cast<MKLDNNInputNode>(getParentEdgesAtPort(type)[0]->getParent())->getConstBlob();
-            if (blob->getTensorDesc().getPrecision() != Precision::I32)
+            auto blob = std::dynamic_pointer_cast<MKLDNNInputNode>(getParentEdgesAtPort(type)[0]->getParent())->getMemoryPtr();
+            if (blob->GetDataType() != mkldnn::memory::data_type::s32)
                 THROW_ERROR << "supports only parameters input with precision I32";
-            const int *ptr = blob->cbuffer().as<const int *>() + blob->getTensorDesc().getBlockingDesc().getOffsetPadding();
+            const int *ptr = static_cast<const int*>(blob->GetPtr());
             parameter.assign(ptr, ptr + size);
 
             if (ellipsisMaskCounter == 0 && size < nDims) {

--- a/inference-engine/src/transformations/src/transformations/rt_info/fused_names_attribute.cpp
+++ b/inference-engine/src/transformations/src/transformations/rt_info/fused_names_attribute.cpp
@@ -67,6 +67,8 @@ std::string getFusedNames(const std::shared_ptr<ngraph::Node> &node) {
 }
 
 std::vector<std::string> getFusedNamesVector(const std::shared_ptr<ngraph::Node> &node) {
+    if (!node) return {};
+
     const auto &rtInfo = node->get_rt_info();
     using FusedNamesWrapper = VariantWrapper<FusedNames>;
 


### PR DESCRIPTION
### Details:
 - Redundant copying of weights and biases removed for convolution layer.
 - Some legacy code removed from MKLDNN convolution layer

### Tickets:
 - CVS-46997
