### PR TITLE
Revise single layer tests for Reduce ops

### DIFF
--- a/inference-engine/tests/functional/inference_engine/serialization/single_layer/reduce_ops.cpp
+++ b/inference-engine/tests/functional/inference_engine/serialization/single_layer/reduce_ops.cpp
@@ -1,0 +1,177 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "shared_test_classes/single_layer/reduce_ops.hpp"
+
+using namespace LayerTestsDefinitions;
+
+namespace {
+TEST_P(ReduceOpsLayerTest, Serialize) {
+    Serialize();
+}
+
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+        InferenceEngine::Precision::FP32,
+        InferenceEngine::Precision::I32,
+        InferenceEngine::Precision::U8,
+        InferenceEngine::Precision::I8,
+};
+
+const std::vector<bool> keepDims = {
+        true,
+        false,
+};
+
+std::vector<CommonTestUtils::OpType> opTypes = {
+        CommonTestUtils::OpType::SCALAR,
+        CommonTestUtils::OpType::VECTOR,
+};
+
+const std::vector<ngraph::helpers::ReductionType> reductionTypes = {
+        ngraph::helpers::ReductionType::Mean,
+        ngraph::helpers::ReductionType::Min,
+        ngraph::helpers::ReductionType::Max,
+        ngraph::helpers::ReductionType::Sum,
+        ngraph::helpers::ReductionType::Prod,
+        ngraph::helpers::ReductionType::L1,
+        ngraph::helpers::ReductionType::L2,
+};
+
+const std::vector<ngraph::helpers::ReductionType> reductionLogicalTypes = {
+        ngraph::helpers::ReductionType::LogicalOr,
+        ngraph::helpers::ReductionType::LogicalAnd
+};
+
+const std::vector<std::vector<size_t>> inputShapesOneAxis = {
+        std::vector<size_t>{10, 20, 30, 40},
+        std::vector<size_t>{3, 5, 7, 9},
+        std::vector<size_t>{10},
+};
+
+const std::vector<std::vector<size_t>> inputShapes = {
+        std::vector<size_t>{10, 20, 30, 40},
+        std::vector<size_t>{3, 5, 7, 9},
+};
+
+const std::vector<std::vector<int>> axes = {
+        {0},
+        {1},
+        {2},
+        {3},
+        {0, 1},
+        {0, 2},
+        {0, 3},
+        {1, 2},
+        {1, 3},
+        {2, 3},
+        {0, 1, 2},
+        {0, 1, 3},
+        {0, 2, 3},
+        {1, 2, 3},
+        {0, 1, 2, 3},
+        {1, -1}
+};
+
+const auto paramsOneAxis = testing::Combine(
+        testing::Values(std::vector<int>{0}),
+        testing::ValuesIn(opTypes),
+        testing::ValuesIn(keepDims),
+        testing::ValuesIn(reductionTypes),
+        testing::Values(netPrecisions[0]),
+        testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        testing::Values(InferenceEngine::Layout::ANY),
+        testing::ValuesIn(inputShapesOneAxis),
+        testing::Values(CommonTestUtils::DEVICE_CPU)
+);
+
+const auto paramsOneAxisLogical = testing::Combine(
+        testing::Values(std::vector<int>{0}),
+        testing::ValuesIn(opTypes),
+        testing::ValuesIn(keepDims),
+        testing::ValuesIn(reductionLogicalTypes),
+        testing::Values(InferenceEngine::Precision::BOOL),
+        testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        testing::Values(InferenceEngine::Layout::ANY),
+        testing::ValuesIn(inputShapesOneAxis),
+        testing::Values(CommonTestUtils::DEVICE_CPU)
+);
+
+const auto params_Axes = testing::Combine(
+        testing::ValuesIn(axes),
+        testing::Values(opTypes[1]),
+        testing::ValuesIn(keepDims),
+        testing::Values(reductionTypes[0]),
+        testing::Values(netPrecisions[0]),
+        testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        testing::Values(InferenceEngine::Layout::ANY),
+        testing::ValuesIn(inputShapes),
+        testing::Values(CommonTestUtils::DEVICE_CPU)
+);
+
+const auto params_ReductionTypes = testing::Combine(
+        testing::Values(std::vector<int>{0, 1, 3}),
+        testing::Values(opTypes[1]),
+        testing::ValuesIn(keepDims),
+        testing::ValuesIn(reductionTypes),
+        testing::ValuesIn(netPrecisions),
+        testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        testing::Values(InferenceEngine::Layout::ANY),
+        testing::Values(std::vector<size_t>{2, 9, 2, 9}),
+        testing::Values(CommonTestUtils::DEVICE_CPU)
+);
+
+const auto params_ReductionTypesLogical = testing::Combine(
+        testing::Values(std::vector<int>{0, 1, 3}),
+        testing::Values(opTypes[1]),
+        testing::ValuesIn(keepDims),
+        testing::ValuesIn(reductionLogicalTypes),
+        testing::Values(InferenceEngine::Precision::BOOL),
+        testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        testing::Values(InferenceEngine::Layout::ANY),
+        testing::Values(std::vector<size_t>{2, 9, 2, 9}),
+        testing::Values(CommonTestUtils::DEVICE_CPU)
+);
+
+INSTANTIATE_TEST_CASE_P(
+        smoke_ReduceOneAxis_Serialization,
+        ReduceOpsLayerTest,
+        paramsOneAxis,
+        ReduceOpsLayerTest::getTestCaseName
+);
+
+INSTANTIATE_TEST_CASE_P(
+        smoke_ReduceLogicalOneAxis_Serialization,
+        ReduceOpsLayerTest,
+        paramsOneAxisLogical,
+        ReduceOpsLayerTest::getTestCaseName
+);
+
+INSTANTIATE_TEST_CASE_P(
+        smoke_ReduceAxes_Serialization,
+        ReduceOpsLayerTest,
+        params_Axes,
+        ReduceOpsLayerTest::getTestCaseName
+);
+
+INSTANTIATE_TEST_CASE_P(
+        smoke_Reduce_ReductionTypes_Serialization,
+        ReduceOpsLayerTest,
+        params_ReductionTypes,
+        ReduceOpsLayerTest::getTestCaseName
+);
+
+INSTANTIATE_TEST_CASE_P(
+        smoke_ReduceLogical_ReductionTypes_Serialization,
+        ReduceOpsLayerTest,
+        params_ReductionTypesLogical,
+        ReduceOpsLayerTest::getTestCaseName
+);
+}   // namespace

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/reduce_ops.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/reduce_ops.cpp
@@ -12,9 +12,7 @@ using namespace LayerTestsDefinitions;
 namespace {
 const std::vector<InferenceEngine::Precision> netPrecisions = {
         InferenceEngine::Precision::FP32,
-        InferenceEngine::Precision::I32,
-        InferenceEngine::Precision::U8,
-        InferenceEngine::Precision::I8,
+        InferenceEngine::Precision::I32
 };
 
 const std::vector<bool> keepDims = {
@@ -75,9 +73,9 @@ const std::vector<ngraph::helpers::ReductionType> reductionLogicalTypes = {
 const auto paramsOneAxis = testing::Combine(
         testing::Values(std::vector<int>{0}),
         testing::ValuesIn(opTypes),
-        testing::Values(true, false),
+        testing::ValuesIn(keepDims),
         testing::ValuesIn(reductionTypes),
-        testing::Values(InferenceEngine::Precision::FP32),
+        testing::Values(netPrecisions[0]),
         testing::Values(InferenceEngine::Precision::UNSPECIFIED),
         testing::Values(InferenceEngine::Precision::UNSPECIFIED),
         testing::Values(InferenceEngine::Layout::ANY),
@@ -88,7 +86,7 @@ const auto paramsOneAxis = testing::Combine(
 const auto paramsOneAxisLogical = testing::Combine(
         testing::Values(std::vector<int>{0}),
         testing::ValuesIn(opTypes),
-        testing::Values(true, false),
+        testing::ValuesIn(keepDims),
         testing::ValuesIn(reductionLogicalTypes),
         testing::Values(InferenceEngine::Precision::BOOL),
         testing::Values(InferenceEngine::Precision::UNSPECIFIED),
@@ -103,8 +101,7 @@ const auto params_Precisions = testing::Combine(
         testing::Values(opTypes[1]),
         testing::ValuesIn(keepDims),
         testing::Values(ngraph::helpers::ReductionType::Sum),
-        testing::Values(InferenceEngine::Precision::FP32,
-                        InferenceEngine::Precision::I32),
+        testing::ValuesIn(netPrecisions),
         testing::Values(InferenceEngine::Precision::UNSPECIFIED),
         testing::Values(InferenceEngine::Precision::UNSPECIFIED),
         testing::Values(InferenceEngine::Layout::ANY),
@@ -117,7 +114,7 @@ const auto params_InputShapes = testing::Combine(
         testing::Values(opTypes[1]),
         testing::ValuesIn(keepDims),
         testing::Values(ngraph::helpers::ReductionType::Mean),
-        testing::Values(InferenceEngine::Precision::FP32),
+        testing::Values(netPrecisions[0]),
         testing::Values(InferenceEngine::Precision::UNSPECIFIED),
         testing::Values(InferenceEngine::Precision::UNSPECIFIED),
         testing::Values(InferenceEngine::Layout::ANY),
@@ -135,7 +132,7 @@ const auto params_Axes = testing::Combine(
         testing::Values(opTypes[1]),
         testing::ValuesIn(keepDims),
         testing::Values(ngraph::helpers::ReductionType::Mean),
-        testing::Values(InferenceEngine::Precision::FP32),
+        testing::Values(netPrecisions[0]),
         testing::Values(InferenceEngine::Precision::UNSPECIFIED),
         testing::Values(InferenceEngine::Precision::UNSPECIFIED),
         testing::Values(InferenceEngine::Layout::ANY),
@@ -148,7 +145,7 @@ const auto params_ReductionTypes = testing::Combine(
         testing::Values(opTypes[1]),
         testing::ValuesIn(keepDims),
         testing::ValuesIn(reductionTypes),
-        testing::Values(InferenceEngine::Precision::FP32),
+        testing::Values(netPrecisions[0]),
         testing::Values(InferenceEngine::Precision::UNSPECIFIED),
         testing::Values(InferenceEngine::Precision::UNSPECIFIED),
         testing::Values(InferenceEngine::Layout::ANY),

--- a/inference-engine/tests/ie_test_utils/functional_test_utils/layer_tests_summary/utils/constants.py
+++ b/inference-engine/tests/ie_test_utils/functional_test_utils/layer_tests_summary/utils/constants.py
@@ -64,6 +64,7 @@ VERIFIED_OP_REFERENCES = [
     'ReduceL1-4',
     'ReduceL2-4',
     'ReduceMean-1',
+    'ReduceSum-1',
     'RegionYOLO-1',
     'Relu-1',
     'ReorgYOLO-2',


### PR DESCRIPTION
Details:

- Add serialization single layer tests for reduction operations
- Minor changes in single layer tests
- ReduceSum operation added to trusted op list

Ticket: 45960