### PR TITLE
[CPU] Disable zero points fusing for 3D DW int8 convolutions

### DIFF
--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph_optimizer.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph_optimizer.cpp
@@ -421,7 +421,17 @@ void MKLDNNGraphOptimizer::FuseConvolutionAndZeroPoints(MKLDNNGraph &graph) {
     auto& graphNodes = graph.GetNodes();
 
     auto isSutableConvNode = [](MKLDNNNodePtr node) {
-        return node->getType() == Convolution;
+        bool retVal = false;
+        if (node->getType() == Convolution) {
+            if (auto convNode = std::dynamic_pointer_cast<MKLDNNConvolutionNode>(node)) {
+                auto ndims = convNode->getParentEdgeAt(0)->getDims().ndims();
+                // int8 depthwise convolution does not support fusing zero points in 3D case
+                if (implication(convNode->isDepthWise(), ndims == 4)) {
+                    retVal = true;
+                }
+            }
+        }
+        return retVal;
     };
 
     auto initializeInputZeroPoints = [](MKLDNNNodePtr node, MKLDNNNodePtr parent0, MKLDNNNodePtr parent1) {

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.h
@@ -51,6 +51,9 @@ public:
     const std::vector<ptrdiff_t> &getPaddingR() { return paddingR; }
 
     bool canFuse(const MKLDNNNodePtr& node) const override;
+    bool isDepthWise() const {
+        return isGrouped && 1 == groupOC && 1 == groupIC;
+    }
 
 protected:
     InferenceEngine::Precision fusedEltwisePrecision(const MKLDNNNodePtr& fusingNode) const;


### PR DESCRIPTION
### Details:
This is a temporal fix to prevent falling back on the Gemm implementations in case of 3D DW convolutions with fused zero points. This is necessary because the jit kernels do not yet support such a case.

### Tickets:
 - 55240
