### PR TITLE
[IE CLDNN] Disable blobs reuse if shapes differ

### DIFF
--- a/inference-engine/src/cldnn_engine/cldnn_program.h
+++ b/inference-engine/src/cldnn_engine/cldnn_program.h
@@ -90,7 +90,8 @@ public:
 
     std::map<std::string, InferenceEngine::SizeVector> outputDims;
     std::map<std::string, cldnn::layout> inputLayouts;
-    std::map<const char *, cldnn::primitive_id> blobMemCache;
+    using BlobCacheKey = std::pair<const char*, std::vector<size_t>>;
+    std::map<BlobCacheKey, cldnn::primitive_id> blobMemCache;
 
     int m_max_batch;
     int m_curBatch;

--- a/inference-engine/src/cldnn_engine/ops/constant.cpp
+++ b/inference-engine/src/cldnn_engine/ops/constant.cpp
@@ -163,7 +163,8 @@ void CreateConstantOp(Program& p, const std::shared_ptr<ngraph::op::v0::Constant
     cldnn::primitive_id constPrimID;
     auto data = op->get_data_ptr<char>();
 
-    auto bufIter = p.blobMemCache.find(data);
+
+    auto bufIter = p.blobMemCache.find(std::make_pair(data, constDims));
 
     if (bufIter != p.blobMemCache.end()) {
         constPrimID = bufIter->second;
@@ -198,7 +199,7 @@ void CreateConstantOp(Program& p, const std::shared_ptr<ngraph::op::v0::Constant
             std::memcpy(&buf[0], &data[0], bufSize);
         }
         p.AddPrimitive(cldnn::data(initialconstPrimID, mem));
-        p.blobMemCache[data] = initialconstPrimID;
+        p.blobMemCache[std::make_pair(data, constDims)] = initialconstPrimID;
         constPrimID = initialconstPrimID;
     }
 

--- a/inference-engine/src/cldnn_engine/ops/parameter.cpp
+++ b/inference-engine/src/cldnn_engine/ops/parameter.cpp
@@ -154,7 +154,7 @@ void CreateParameterOp(Program& p, const std::shared_ptr<ngraph::op::v0::Paramet
 
         auto data = static_cast<const char *>(meanBlobPtr->buffer());
 
-        auto bufIter = p.blobMemCache.find(data);
+        auto bufIter = p.blobMemCache.find(std::make_pair(data, meanDims));
         if (bufIter != p.blobMemCache.end()) {
             meanBlobID = bufIter->second;
         } else {
@@ -166,7 +166,7 @@ void CreateParameterOp(Program& p, const std::shared_ptr<ngraph::op::v0::Paramet
             std::memcpy(&buf[0], &data[0], bufSize);
 
             p.AddPrimitive(cldnn::data(meanBlobID, mem));
-            p.blobMemCache[data] = meanBlobID;
+            p.blobMemCache[std::make_pair(data, meanDims)] = meanBlobID;
         }
         break;
     }


### PR DESCRIPTION
### Details:
 - If blobs are reused, then same data node is used as input to multiple nodes which expect constants with different shapes, which leads to invalid shapes propagation in cldnn.

### Tickets:
 - 55151
