### PR TITLE
[CPU] Fixed blocked layout conditions for DepthToSpace, SpaceToDepth

### DIFF
--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_depth_to_space_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_depth_to_space_node.cpp
@@ -124,7 +124,8 @@ void MKLDNNDepthToSpaceNode::initSupportedPrimitiveDescriptors() {
     std::vector<TensorDescCreatorTypes> supportedTypes;
     if (nDims > 2) {
         auto canUseBlocked = [=](const size_t block) {
-            return srcDims[1] % block == 0 && (mode == Mode::BLOCKS_FIRST ? (srcDims[1] / block) % blockStep == 0 : block % blockStep == 0);
+            return srcDims[1] % block == 0 && (srcDims[1] / block) % blockStep == 0 &&
+                   (mode == Mode::DEPTH_FIRST ? block % blockStep == 0 : true);
         };
 
         supportedTypes.push_back(TensorDescCreatorTypes::nspc);
@@ -209,7 +210,7 @@ void MKLDNNDepthToSpaceNode::createPrimitive() {
             orderShiftForDims = 3;
 
             size_t newBlockSize = srcBlockedDims.back() / blockStep;
-            size_t newBlocksCount = srcBlockedDims[1] * newBlockSize / srcBlockedDims.back();
+            size_t newBlocksCount = srcBlockedDims[1] / blockStep;
             params.src_block_dims[1] = newBlocksCount;
             params.src_block_dims[2] = srcBlockedDims[1] / newBlocksCount;
             params.src_block_dims[lastIdx - nSpatialDims] = newBlockSize;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_space_to_depth_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_space_to_depth_node.cpp
@@ -124,7 +124,7 @@ void MKLDNNSpaceToDepthNode::initSupportedPrimitiveDescriptors() {
     std::vector<TensorDescCreatorTypes> supportedTypes;
     if (nDims > 2) {
         auto canUseBlocked = [=](const size_t block) {
-            return mode == Mode::DEPTH_FIRST ? block % blockStep == 0 : true;
+            return srcDims[1] % block == 0 && (mode == Mode::DEPTH_FIRST ? block % blockStep == 0 : true);
         };
 
         supportedTypes.push_back(TensorDescCreatorTypes::nspc);

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/depth_to_space.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/depth_to_space.cpp
@@ -98,7 +98,7 @@ const std::vector<DepthToSpace::DepthToSpaceMode> depthToSpaceModes = {
 };
 
 const std::vector<std::vector<size_t >> inputShapesBS2_4D = {
-        {1, 64, 1, 1}, {1, 64, 1, 3}, {1, 128, 3, 3}, {2, 128, 1, 1}, {2, 256, 2, 3}
+        {1, 64, 1, 1}, {1, 64, 1, 3}, {1, 128, 3, 3}, {2, 128, 1, 1}, {1, 192, 2, 2}, {2, 256, 2, 3}, {1, 512, 2, 1}
 };
 
 const std::vector<std::vector<size_t >> inputShapesBS3_4D = {
@@ -145,7 +145,7 @@ const auto depthToSpaceBS3_4DParams = testing::Combine(
 INSTANTIATE_TEST_CASE_P(smoke_CPUDepthToSpaceBS3_4D, DepthToSpaceLayerCPUTest, depthToSpaceBS3_4DParams, DepthToSpaceLayerCPUTest::getTestCaseName);
 
 const std::vector<std::vector<size_t >> inputShapesBS2_5D = {
-        {1, 128, 1, 1, 1}, {1, 128, 2, 1, 2}, {1, 256, 2, 1, 3}, {2, 256, 3, 1, 1}, {2, 512, 1, 2, 1}
+        {1, 128, 1, 1, 1}, {1, 128, 2, 1, 2}, {1, 256, 2, 1, 3}, {2, 256, 3, 1, 1}, {1, 384, 1, 2, 2}, {2, 512, 1, 2, 1}
 };
 
 const std::vector<std::vector<size_t >> inputShapesBS3_5D = {

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/space_to_depth.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/space_to_depth.cpp
@@ -98,7 +98,7 @@ const std::vector<SpaceToDepth::SpaceToDepthMode> spaceToDepthModes = {
 };
 
 const std::vector<std::vector<size_t>> inputShapesBS2_4D = {
-        {1, 16, 2, 2}, {1, 16, 4, 2}, {1, 32, 6, 8}, {2, 32, 4, 6}, {2, 64, 8, 2},
+        {1, 16, 2, 2}, {1, 16, 4, 2}, {1, 32, 6, 8}, {2, 32, 4, 6}, {2, 48, 4, 4}, {2, 64, 8, 2},
 };
 
 const std::vector<std::vector<size_t >> inputShapesBS3_4D = {
@@ -145,7 +145,7 @@ const auto spaceToDepthBS3_4DParams = testing::Combine(
 INSTANTIATE_TEST_CASE_P(smoke_CPUSpaceToDepthBS3_4D, SpaceToDepthLayerCPUTest, spaceToDepthBS3_4DParams, SpaceToDepthLayerCPUTest::getTestCaseName);
 
 const std::vector<std::vector<size_t >> inputShapesBS2_5D = {
-        {1, 16, 2, 2, 2}, {1, 16, 4, 4, 2}, {1, 32, 2, 6, 2}, {2, 32, 4, 2, 2}, {2, 64, 2, 2, 6}
+        {1, 16, 2, 2, 2}, {1, 16, 4, 4, 2}, {1, 32, 2, 6, 2}, {2, 32, 4, 2, 2}, {1, 48, 6, 2, 2}, {2, 64, 2, 2, 6}
 };
 
 const std::vector<std::vector<size_t >> inputShapesBS3_5D = {


### PR DESCRIPTION
### Details:
 - *Changed check for blocked layouts so that [NewBlockCount is not 0](https://github.com/a-sidorova/openvino/blob/e27933654122f920995246c4ae3724b2335565fd/inference-engine/src/mkldnn_plugin/nodes/mkldnn_depth_to_space_node.cpp#L213) for DepthToSpace*
 - *Added new default check for blocked layouts for SpaceToDepth*

### Tickets:
 - *54454*
