### PR TITLE
[IE CLDNN] Fixed eltwise shrink when node has fused ops

### DIFF
--- a/inference-engine/thirdparty/clDNN/src/graph_optimizer/eltwise_shrinking.cpp
+++ b/inference-engine/thirdparty/clDNN/src/graph_optimizer/eltwise_shrinking.cpp
@@ -84,7 +84,7 @@ void eltwise_shrinking::run(program_impl& p) {
                 if (can_shrink) {
                     // add stride for every eltwise's inputs to have shrinked output
                     auto e = const_cast<eltwise*>(&(*eltw));
-                    for (size_t dep = 0; dep < node->get_dependencies().size(); dep++) {
+                    for (size_t dep = 0; dep < e->input_size(); dep++) {
                         auto dep_stride_x = stride_x;
                         auto dep_stride_y = stride_y;
                         // don't shrink if input is broadcasted


### PR DESCRIPTION
### Details:
 - eltwise shrink pass used dependencies count for adding strides, but if eltw node has fused ops, then it has extra dependencies. Replaced with input_size()

### Tickets:
 - 54264
