### PR TITLE
Export GetListOfDevicesInRegistry api for AUTO plugin

### DIFF
--- a/inference-engine/include/ie_core.hpp
+++ b/inference-engine/include/ie_core.hpp
@@ -244,6 +244,13 @@ public:
     std::vector<std::string> GetAvailableDevices() const;
 
     /**
+     * @brief Returns device plugin list in registry
+     *
+     * @return A vector of registered device plugins. The devices are defined in plugins.xml
+     */
+    std::vector<std::string> GetListOfDevicesInRegistry() const;
+
+    /**
      * @brief Register new device and plugin which implement this device inside Inference Engine.
      *
      * @param pluginName A name of plugin. Depending on platform pluginName is wrapped with shared library suffix and

--- a/inference-engine/src/inference_engine/ie_core.cpp
+++ b/inference-engine/src/inference_engine/ie_core.cpp
@@ -737,7 +737,7 @@ public:
      * @brief Porvides a list of plugin names in registry; physically such plugins may not be created
      * @return A list of plugin names
      */
-    std::vector<std::string> GetListOfDevicesInRegistry() const {
+    std::vector<std::string> GetListOfDevicesInRegistry() const override {
         std::lock_guard<std::mutex> lock(pluginsMutex);
 
         std::vector<std::string> listOfDevices;
@@ -1044,6 +1044,10 @@ Parameter Core::GetMetric(const std::string& deviceName, const std::string& name
 
 std::vector<std::string> Core::GetAvailableDevices() const {
     return _impl->GetAvailableDevices();
+}
+
+std::vector<std::string> Core::GetListOfDevicesInRegistry() const {
+    return _impl->GetListOfDevicesInRegistry();
 }
 
 void Core::RegisterPlugin(const std::string& pluginName, const std::string& deviceName) {

--- a/inference-engine/src/plugin_api/ie_icore.hpp
+++ b/inference-engine/src/plugin_api/ie_icore.hpp
@@ -109,6 +109,13 @@ public:
     virtual std::vector<std::string> GetAvailableDevices() const = 0;
 
     /**
+     * @brief Returns device plugin list in registry
+     *
+     * @return A vector of registered device plugins. The devices are defined in plugins.xml
+     */
+    virtual std::vector<std::string> GetListOfDevicesInRegistry() const = 0;
+
+    /**
      * @brief Default virtual destructor
      */
     virtual ~ICore() = default;

--- a/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/cpp_interfaces/interface/mock_icore.hpp
+++ b/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/cpp_interfaces/interface/mock_icore.hpp
@@ -29,6 +29,7 @@ public:
 
     MOCK_QUALIFIED_METHOD2(GetMetric, const, InferenceEngine::Parameter(const std::string&, const std::string&));
     MOCK_QUALIFIED_METHOD0(GetAvailableDevices, const, std::vector<std::string>());
+    MOCK_QUALIFIED_METHOD0(GetListOfDevicesInRegistry, const, std::vector<std::string>());
 
     ~MockICore() = default;
 };


### PR DESCRIPTION
We expected to get available devices by querying Metric like GetMetric(), but currently `GetCore()->GetAvailableDevices();` will call AUTO plugin `GetMetric(AVAILABLE_DEVICES)` and then if it call `GetCore()->GetAvailableDevices();` again, it will be recursive. Maybe it is a good way to get plugin devices by current implementation of `GetListOfDevicesInRegistry` in ie_core.cpp. 

let's discuss this top in this loop and this is a proposal for the implementation.

