### PR TITLE
[GNA] Use compile target in export tests for SUE

### DIFF
--- a/inference-engine/src/gna_plugin/gna_device.hpp
+++ b/inference-engine/src/gna_plugin/gna_device.hpp
@@ -145,7 +145,6 @@ public:
         return dev <= Gna2DeviceVersion2_0 && isGnaHw(dev);
     }
     bool enforceLegacyCnnNeeded() const;
-    Gna2DeviceVersion getExecutionTargetDevice() const;
     static void checkGna2Status(Gna2Status status, const std::string& from);
     static void checkGna2Status(Gna2Status status, const Gna2Model& gnaModel);
 #endif
@@ -197,6 +196,9 @@ public:
     static const std::map <const std::pair<Gna2OperationType, int32_t>, const std::string > operandTypes;
 
     static void enforceLegacyCnns(Gna2Model& gnaModel);
+    Gna2DeviceVersion parseDeclaredTarget(std::string target, const bool execTarget) const;
+    Gna2DeviceVersion getDefaultTarget() const;
+    Gna2DeviceVersion getTargetDevice(bool execTarget) const;
 #endif
     void setOMPThreads(uint8_t const n_threads);
 

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/behavior/infer_request_config.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/behavior/infer_request_config.cpp
@@ -19,7 +19,9 @@ namespace {
     const std::vector<std::map<std::string, std::string>> Inconfigs = {
             {{InferenceEngine::GNAConfigParams::KEY_GNA_SCALE_FACTOR, "1.0"}},
             {{InferenceEngine::GNAConfigParams::KEY_GNA_PRECISION, "I8"}},
-            {{InferenceEngine::GNAConfigParams::KEY_GNA_FIRMWARE_MODEL_IMAGE, "gfile"}},
+            {{InferenceEngine::GNAConfigParams::KEY_GNA_FIRMWARE_MODEL_IMAGE, "gfile"},
+             {InferenceEngine::GNAConfigParams::KEY_GNA_EXEC_TARGET, InferenceEngine::GNAConfigParams::GNA_TARGET_2_0},
+             {InferenceEngine::GNAConfigParams::KEY_GNA_COMPILE_TARGET, InferenceEngine::GNAConfigParams::GNA_TARGET_2_0}},
             {{InferenceEngine::GNAConfigParams::KEY_GNA_DEVICE_MODE, InferenceEngine::GNAConfigParams::GNA_AUTO}},
             {{InferenceEngine::GNAConfigParams::KEY_GNA_DEVICE_MODE, InferenceEngine::GNAConfigParams::GNA_SW_FP32}},
             {{InferenceEngine::GNAConfigParams::KEY_GNA_DEVICE_MODE, InferenceEngine::GNAConfigParams::GNA_SW}},


### PR DESCRIPTION
### Details:
 - Use compile target in export tests for SUE
 - Fix tests with GNA 2.1 library (Some tests in gnaFuncTest Failed when replacing 1047 with 1095 GNA Library)

### Tickets:
 - CVS-54602
