### PR TITLE
Remove empty files on failed serialization

### DIFF
--- a/inference-engine/src/transformations/src/transformations/serialize.cpp
+++ b/inference-engine/src/transformations/src/transformations/serialize.cpp
@@ -843,6 +843,8 @@ bool pass::Serialize::run_on_function(std::shared_ptr<ngraph::Function> f) {
             // optimization decission was mad to create .bin file upfront and
             // write to it directly instead of buffering its conents in memory,
             // hence we need to delete it here in case of failure
+            xml_file.close();
+            bin_file.close();
             std::remove(m_xmlPath.c_str());
             std::remove(m_binPath.c_str());
             throw;

--- a/inference-engine/src/transformations/src/transformations/serialize.cpp
+++ b/inference-engine/src/transformations/src/transformations/serialize.cpp
@@ -837,7 +837,16 @@ bool pass::Serialize::run_on_function(std::shared_ptr<ngraph::Function> f) {
         std::ofstream xml_file(m_xmlPath, std::ios::out);
         NGRAPH_CHECK(xml_file, "Can't open xml file: \"" + m_xmlPath + "\"");
 
-        serializeFunc(xml_file, bin_file);
+        try {
+            serializeFunc(xml_file, bin_file);
+        } catch (const ngraph::CheckFailure& e) {
+            // optimization decission was mad to create .bin file upfront and
+            // write to it directly instead of buffering its conents in memory,
+            // hence we need to delete it here in case of failure
+            std::remove(m_xmlPath.c_str());
+            std::remove(m_binPath.c_str());
+            throw;
+        }
     }
 
     // Return false because we didn't change nGraph Function

--- a/inference-engine/src/transformations/src/transformations/serialize.cpp
+++ b/inference-engine/src/transformations/src/transformations/serialize.cpp
@@ -840,8 +840,8 @@ bool pass::Serialize::run_on_function(std::shared_ptr<ngraph::Function> f) {
         try {
             serializeFunc(xml_file, bin_file);
         } catch (const ngraph::CheckFailure& e) {
-            // optimization decission was mad to create .bin file upfront and
-            // write to it directly instead of buffering its conents in memory,
+            // optimization decission was made to create .bin file upfront and
+            // write to it directly instead of buffering its content in memory,
             // hence we need to delete it here in case of failure
             xml_file.close();
             bin_file.close();

--- a/inference-engine/tests/functional/inference_engine/ir_serialization/cleanup.cpp
+++ b/inference-engine/tests/functional/inference_engine/ir_serialization/cleanup.cpp
@@ -1,0 +1,63 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <fstream>
+
+#include "common_test_utils/ngraph_test_utils.hpp"
+#include "gtest/gtest.h"
+#include "ie_core.hpp"
+#include "ngraph_functions/builders.hpp"
+
+#ifndef IR_SERIALIZATION_MODELS_PATH  // should be already defined by cmake
+#define IR_SERIALIZATION_MODELS_PATH ""
+#endif
+
+class SerializationCleanupTest : public CommonTestUtils::TestsCommon {
+protected:
+    const std::string test_name = GetTestName() + "_" + GetTimestamp();
+    std::string m_out_xml_path = test_name + ".xml";
+    std::string m_out_bin_path = test_name + ".bin";
+
+    void TearDown() override {
+        std::remove(m_out_xml_path.c_str());
+        std::remove(m_out_xml_path.c_str());
+    }
+};
+
+namespace {
+std::shared_ptr<ngraph::Function> CreateTestFunction(
+    const std::string& name, const ngraph::PartialShape& ps) {
+    using namespace ngraph;
+    const auto param = std::make_shared<op::Parameter>(element::f16, ps);
+    const auto convert = std::make_shared<op::Convert>(param, element::f32);
+    const auto result = std::make_shared<op::Result>(convert);
+    return std::make_shared<Function>(ResultVector{result},
+                                      ParameterVector{param}, name);
+}
+}  // namespace
+
+TEST_F(SerializationCleanupTest, SerializationShouldWork) {
+    const auto f =
+        CreateTestFunction("StaticFunction", ngraph::PartialShape{2, 2});
+
+    const InferenceEngine::CNNNetwork net{f};
+    net.serialize(m_out_xml_path, m_out_bin_path);
+
+    // .xml & .bin files should be present
+    ASSERT_TRUE(std::ifstream(m_out_xml_path, std::ios::in).good());
+    ASSERT_TRUE(std::ifstream(m_out_bin_path, std::ios::in).good());
+}
+
+TEST_F(SerializationCleanupTest, SerializationShouldFail) {
+    const auto f =
+        CreateTestFunction("DynamicFunction", ngraph::PartialShape::dynamic());
+
+    const InferenceEngine::CNNNetwork net{f};
+    ASSERT_THROW(net.serialize(m_out_xml_path, m_out_bin_path),
+                 InferenceEngine::Exception);
+
+    // .xml & .bin files shouldn't be present
+    ASSERT_FALSE(std::ifstream(m_out_xml_path, std::ios::in).good());
+    ASSERT_FALSE(std::ifstream(m_out_bin_path, std::ios::in).good());
+}


### PR DESCRIPTION
### Details:
 - When CNNNetwork (ngraph impl) serialization fails, empty XML & BIN files are produced. This PR changes that behaviour and no output files are created in case of serialization failure.

### Tickets:
 - CVS-54510
