### PR TITLE
Fix for warnings spotted by cl compiler

### DIFF
--- a/inference-engine/src/inference_engine/precision_utils.cpp
+++ b/inference-engine/src/inference_engine/precision_utils.cpp
@@ -41,7 +41,7 @@ inline float asfloat(uint32_t v) {
     return f;
 }
 
-// Function to convert F32 into F16
+// Function to convert F16 into F32
 float f16tof32(ie_fp16 x) {
     // this is storage for output result
     uint32_t u = static_cast<uint32_t>(x);

--- a/inference-engine/tests/functional/shared_test_classes/src/subgraph/concat_multi_input.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/subgraph/concat_multi_input.cpp
@@ -70,7 +70,7 @@ void ConcatMultiInput::GenerateConstOnlyModel() {
     ngraph::OutputVector concatInputs;
 
     const int seed = 0;
-    std::mt19937 gen(static_cast<float>(seed));
+    std::mt19937 gen(seed);
 
     auto generateFloatNumbers = [gen](std::size_t vec_len, float min, float max) mutable {
         std::vector<float> res;

--- a/inference-engine/tests/functional/shared_test_classes/src/subgraph/fq_conv_fq_affine.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/subgraph/fq_conv_fq_affine.cpp
@@ -74,7 +74,7 @@ void FqConvFqAffineTest::SetUp() {
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
 
     const int seed = 0;
-    std::mt19937 gen(static_cast<float>(seed));
+    std::mt19937 gen(seed);
 
     auto inputFQNode = ngraph::builder::makeFakeQuantize(params[0], ngraph::element::f32, levels[0], std::vector<size_t>{},
         { inputDataMin }, { inputDataMax }, { inputDataMin }, { inputDataMax });

--- a/inference-engine/tests/functional/shared_test_classes/src/subgraph/memory_eltwise_reshape_concat.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/subgraph/memory_eltwise_reshape_concat.cpp
@@ -33,7 +33,7 @@ void MemoryEltwiseReshapeConcatTest::SetUp() {
     ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 
     const int seed = 0;
-    std::mt19937 gen(static_cast<float>(seed));
+    std::mt19937 gen(seed);
 
     auto generateFloatNumbers = [gen](std::size_t vec_len, float min, float max) mutable {
         std::vector<float> res;

--- a/inference-engine/tests/functional/shared_test_classes/src/subgraph/negative_memory_layer_offset.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/subgraph/negative_memory_layer_offset.cpp
@@ -30,9 +30,9 @@ namespace SubgraphTestsDefinitions {
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 
         const int seed = 0;
-        std::mt19937 gen(static_cast<float>(seed));
+        std::mt19937 gen(seed);
         std::uniform_real_distribution<float> dist(-0.2f, 0.2f);
-        for (int i = 0; i < hiddenSize; ++i)
+        for (size_t i = 0; i < hiddenSize; ++i)
             memory_init.emplace_back(static_cast<float>(dist(gen)));
 
         auto input = ngraph::builder::makeParams(ngPrc, { {1, inputSize} });

--- a/inference-engine/tests/functional/shared_test_classes/src/subgraph/two_fake_quantize_to_fullyconnected.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/subgraph/two_fake_quantize_to_fullyconnected.cpp
@@ -68,7 +68,7 @@ void FakeQuantizeSubgraphTest::SetUp() {
     auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
 
     const int seed = 0;
-    std::mt19937 gen(static_cast<float>(seed));
+    std::mt19937 gen(seed);
 
 
     auto generateFloatNumbers = [gen](std::size_t vec_len, float min, float max) mutable {

--- a/inference-engine/tests/ie_test_utils/common_test_utils/data_utils.hpp
+++ b/inference-engine/tests/ie_test_utils/common_test_utils/data_utils.hpp
@@ -53,7 +53,7 @@ inline std::vector<float> generate_float_numbers(std::size_t vec_len, float min,
  */
 template<typename T>
 inline std::vector<T>  fill_vector(std::vector<T> &res, double min, double max, int seed = 0) {
-    std::mt19937 gen(static_cast<T>(seed));
+    std::mt19937 gen(seed);
 
     std::uniform_real_distribution<double> dist(min, max);
     for (std::size_t i = 0; i < res.size(); i++)
@@ -231,9 +231,9 @@ void inline fill_data_random(InferenceEngine::Blob::Ptr &blob, const uint32_t ra
  */
 template<InferenceEngine::Precision::ePrecision PRC>
 void inline fill_random_unique_sequence(InferenceEngine::Blob::Ptr &blob,
-                                        uint32_t range,
-                                        int32_t start_from = 0,
-                                        const int32_t k = 1,
+                                        uint64_t range,
+                                        int64_t start_from = 0,
+                                        const int64_t k = 1,
                                         const int32_t seed = 1) {
     using dataType = typename InferenceEngine::PrecisionTrait<PRC>::value_type;
     auto *rawBlobDataPtr = blob->buffer().as<dataType *>();
@@ -247,7 +247,7 @@ void inline fill_random_unique_sequence(InferenceEngine::Blob::Ptr &blob,
     }
 
     std::mt19937 generator(seed);
-    std::uniform_int_distribution<int32_t> dist(k * start_from, k * (start_from + range));
+    std::uniform_int_distribution<int64_t> dist(k * start_from, k * (start_from + range));
 
     std::set<dataType> elems;
     while (elems.size() != blob->size()) {

--- a/inference-engine/tests/ie_test_utils/common_test_utils/xml_net_builder/ir_net.hpp
+++ b/inference-engine/tests/ie_test_utils/common_test_utils/xml_net_builder/ir_net.hpp
@@ -88,7 +88,7 @@ public:
         return std::shared_ptr<Layer>(new Layer(parent, id, common_attributes));
     }
 
-    Port &getPortById(int64_t id) const {
+    Port &getPortById(size_t id) const {
         if (id >= m_ports.size()) {
             IE_THROW() << "Out of range: a port with id " << id << " not found";
         }

--- a/inference-engine/tests/ie_test_utils/functional_test_utils/include/functional_test_utils/blob_utils.hpp
+++ b/inference-engine/tests/ie_test_utils/functional_test_utils/include/functional_test_utils/blob_utils.hpp
@@ -228,10 +228,10 @@ compareBlobData(const InferenceEngine::Blob::Ptr &res, const InferenceEngine::Bl
     }
 
     for (size_t i = 0; i < ref_size / sizeof(dataType); i++) {
-        auto resVal = PRC == InferenceEngine::Precision::FP16 ? InferenceEngine::PrecisionUtils::f16tof32(res_ptr[i])
-                                                              : res_ptr[i];
-        auto refVal = PRC == InferenceEngine::Precision::FP16 ? InferenceEngine::PrecisionUtils::f16tof32(ref_ptr[i])
-                                                              : ref_ptr[i];
+        auto resVal = PRC == InferenceEngine::Precision::FP16 ? InferenceEngine::PrecisionUtils::f16tof32(static_cast<InferenceEngine::ie_fp16>(res_ptr[i]))
+                                                              : static_cast<float>(res_ptr[i]);
+        auto refVal = PRC == InferenceEngine::Precision::FP16 ? InferenceEngine::PrecisionUtils::f16tof32(static_cast<InferenceEngine::ie_fp16>(ref_ptr[i]))
+                                                              : static_cast<float>(ref_ptr[i]);
         float absDiff = std::abs(resVal - refVal);
         if (absDiff > max_diff) {
             float relDiff = absDiff / std::max(res_ptr[i], ref_ptr[i]);
@@ -286,10 +286,10 @@ compareBlobs(const InferenceEngine::Blob::Ptr &res, const InferenceEngine::Blob:
 inline void GetComparisonThreshold(InferenceEngine::Precision prc, float &absoluteThreshold, float &relativeThreshold) {
     switch (prc) {
         case InferenceEngine::Precision::FP32:
-            absoluteThreshold = relativeThreshold = 1e-4;
+            absoluteThreshold = relativeThreshold = 1e-4f;
             break;
         case InferenceEngine::Precision::FP16:
-            absoluteThreshold = relativeThreshold = 1e-2;
+            absoluteThreshold = relativeThreshold = 1e-2f;
             break;
         case InferenceEngine::Precision::I16:
         case InferenceEngine::Precision::I8:
@@ -524,7 +524,7 @@ inline InferenceEngine::Blob::Ptr createAndFillBlobUniqueSequence(
     InferenceEngine::Blob::Ptr blob = make_blob_with_precision(td);
     blob->allocate();
     auto shape = td.getDims();
-    auto range = std::accumulate(begin(shape), end(shape), 1, std::multiplies<uint64_t>()) * 2;
+    auto range = std::accumulate(begin(shape), end(shape), uint64_t(1), std::multiplies<uint64_t>()) * 2;
     switch (td.getPrecision()) {
 #define CASE(X) case X: CommonTestUtils::fill_random_unique_sequence<X>(blob, range, start_from, resolution, seed); break;
         CASE(InferenceEngine::Precision::FP32)


### PR DESCRIPTION
### Details:
 - `std::mt19937` took integer type in [ctor](https://en.cppreference.com/w/cpp/numeric/random/mersenne_twister_engine/mersenne_twister_engine) (actually result_type which is integer)
 - `Port &getPortById(size_t id) const` id is `size_t` in other places
 - `std::accumulate(begin(shape), end(shape), uint64_t(1), std::multiplies<uint64_t>()) * 2;` 3rd argument is a result [type](https://en.cppreference.com/w/cpp/algorithm/accumulate). `1` is `int`
 - `1e-4` is `double`, but variables are `float`
 - `fill_random_unique_sequence` args propagated to 64 bits to avoid narrow conversion while calling (+200 lines in the same file). There is no dependencies on sizeof type. And `int32_t` can be potentially overflowed(+-2Gb is a limit for it)
 - fixed comment for `f16tof32` function