### PR TITLE
Get home directory on linux without expanding envs

### DIFF
--- a/model-optimizer/telemetry/utils/isip.py
+++ b/model-optimizer/telemetry/utils/isip.py
@@ -3,6 +3,7 @@
 
 import os
 from enum import Enum
+from pathlib import Path
 from platform import system
 
 
@@ -25,7 +26,7 @@ def isip_consent_base_dir():
     if platform == 'Windows':
         dir_to_check = '$LOCALAPPDATA'
     elif platform in ['Linux', 'Darwin']:
-        dir_to_check = '$HOME'
+        dir_to_check = Path.home()
 
     if dir_to_check is None:
         raise Exception('Failed to find location of the ISIP consent')


### PR DESCRIPTION
### Details:
In some environments, the `$HOME` environment variable can be missed. I suggest using `Path` module to get the home directory. 

