### PR TITLE
Added MVN fusion for case with constants inside

### DIFF
--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_mvn_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_mvn_node.h
@@ -103,7 +103,7 @@ private:
 
     void setPostOps(mkldnn::primitive_attr &attr, bool initWeights = false);
 
-    void transformTo5DCase(const ngraph::Shape& shape);
+    void transformTo5DCase(const InferenceEngine::SizeVector& shape);
 
     std::tuple<size_t, size_t, size_t, size_t, size_t> shape5D;
 

--- a/inference-engine/src/transformations/include/transformations/common_optimizations/mvn_fusion.hpp
+++ b/inference-engine/src/transformations/include/transformations/common_optimizations/mvn_fusion.hpp
@@ -16,7 +16,9 @@
 namespace ngraph {
 namespace pass {
 
-    class TRANSFORMATIONS_API MVNFusion;
+class TRANSFORMATIONS_API MVNFusion;
+class TRANSFORMATIONS_API MVNFusionWithoutConstants;
+class TRANSFORMATIONS_API MVNFusionWithConstantsInside;
 
 }  // namespace pass
 }  // namespace ngraph
@@ -26,8 +28,32 @@ namespace pass {
  * @brief MVNFusion transformation replaces group of
  * operations: (x - ReduceMean(x, axes)) / (Sqrt(ReduceMean((x - ReduceMean(x, axes)) ^ 2)) + eps) to MVN op.
  */
-class ngraph::pass::MVNFusion : public ngraph::pass::MatcherPass {
+class ngraph::pass::MVNFusionWithoutConstants : public ngraph::pass::MatcherPass {
 public:
     NGRAPH_RTTI_DECLARATION;
-    MVNFusion();
+    MVNFusionWithoutConstants();
+};
+
+/**
+ * @ingroup ie_transformation_common_api
+ * @brief MVNFusion transformation replaces group of
+ * operations: gamma * (x - ReduceMean(x, axes)) / (Sqrt(ReduceMean((x - ReduceMean(x, axes)) ^ 2)) + eps) + beta to MVN op.
+ */
+class ngraph::pass::MVNFusionWithConstantsInside : public ngraph::pass::MatcherPass {
+public:
+    NGRAPH_RTTI_DECLARATION;
+    MVNFusionWithConstantsInside();
+};
+
+/**
+ * @ingroup ie_transformation_common_api
+ * @brief MVNFusion transformation replaces various sub-graphs with a MVN op.
+ */
+class ngraph::pass::MVNFusion: public ngraph::pass::GraphRewrite {
+public:
+    NGRAPH_RTTI_DECLARATION;
+    MVNFusion() {
+        add_matcher<ngraph::pass::MVNFusionWithoutConstants>();
+        add_matcher<ngraph::pass::MVNFusionWithConstantsInside>();
+    }
 };

--- a/inference-engine/src/transformations/src/transformations/common_optimizations/mvn_fusion.cpp
+++ b/inference-engine/src/transformations/src/transformations/common_optimizations/mvn_fusion.cpp
@@ -27,8 +27,10 @@ std::function<bool(ngraph::Output<ngraph::Node>)> value_is_equal_to(const std::v
     };
 }
 
-ngraph::pass::MVNFusion::MVNFusion() {
-    MATCHER_SCOPE(MVNFusion);
+NGRAPH_RTTI_DEFINITION(ngraph::pass::MVNFusionWithoutConstants, "MVNFusionWithoutConstants", 0);
+
+ngraph::pass::MVNFusionWithoutConstants::MVNFusionWithoutConstants() {
+    MATCHER_SCOPE(MVNFusionWithoutConstants);
     // Detect MVN decomposition pattern:
     // (x - ReduceMean(x, axes)) / (Sqrt(ReduceMean((x - ReduceMean(x, axes)) ^ 2)) + eps)
     auto x = pattern::any_input();
@@ -186,5 +188,114 @@ ngraph::pass::MVNFusion::MVNFusion() {
     };
 
     auto m = std::make_shared<ngraph::pattern::Matcher>(powerMulOrDiv, matcher_name);
+    register_matcher(m, matcher_pass_callback);
+}
+
+NGRAPH_RTTI_DEFINITION(ngraph::pass::MVNFusionWithConstantsInside, "MVNFusionWithConstantsInside", 0);
+
+ngraph::pass::MVNFusionWithConstantsInside::MVNFusionWithConstantsInside() {
+    MATCHER_SCOPE(MVNFusionWithConstantsInside);
+    // Detect MVN decomposition pattern:
+    // (x - ReduceMean(x, axes)) * gamma / (Sqrt(ReduceMean((x - ReduceMean(x, axes)) ^ 2)) + eps) + beta
+    auto x = pattern::any_input();
+
+    // (x - ReduceMean(x, axes))^2
+    //     `------mean1-------'
+    auto mean1_axes = pattern::wrap_type<opset6::Constant>();
+    auto mean1 = pattern::wrap_type<opset6::ReduceMean>({ x, mean1_axes });
+
+    // (x - ReduceMean(x, axes))^2
+    // `-squared_difference------'
+    auto squared_difference = pattern::wrap_type<opset6::SquaredDifference>({ x, mean1 });
+
+    // 1 / Sqrt(ReduceMean((x - ReduceMean(x, axes)) ^ 2) + eps)
+    //         `---mean2--------------------------------'
+    auto mean2_axes = pattern::wrap_type<opset6::Constant>();
+    auto mean2 = pattern::wrap_type<opset6::ReduceMean>({ squared_difference, mean2_axes });
+
+    // 1 / Sqrt(ReduceMean((x - ReduceMean(x, axes)) ^ 2) + eps)
+    //         `------------------------------------------add--'
+    auto eps = pattern::wrap_type<opset6::Constant>();
+    auto add_eps = pattern::wrap_type<opset6::Add>({ mean2, eps });
+
+    // 1 / Sqrt(ReduceMean((x - ReduceMean(x, axes)) ^ 2) + eps)
+    // `-power-------------------------------------------------'
+    auto const_0_5 = pattern::wrap_type<opset6::Constant>(value_is_equal_to<float>({-0.5}));
+    auto power = pattern::wrap_type<opset6::Power>({ add_eps, const_0_5 });
+
+    // gamma / Sqrt(ReduceMean((x - ReduceMean(x, axes)) ^ 2) + eps)
+    // `---mul1----------------------------------------------------'
+    auto gamma = pattern::wrap_type<opset6::Constant>();
+    auto mul1 = pattern::wrap_type<opset6::Multiply>({ power, gamma });
+
+    // x * gamma / Sqrt(ReduceMean((x - ReduceMean(x, axes)) ^ 2) + eps)
+    // `---mul2--------------------------------------------------------'
+    auto mul2 = pattern::wrap_type<opset6::Multiply>({ x, mul1 });
+
+    // ReduceMean(x, axes) * gamma / Sqrt(ReduceMean((x - ReduceMean(x, axes)) ^ 2) + eps) - beta
+    // `-------------------mul3----------------------------------------------------------'
+    auto mul3 = pattern::wrap_type<opset6::Multiply>({ mul1, mean1 });
+
+    // beta - ReduceMean(x, axes) * gamma / Sqrt(ReduceMean((x - ReduceMean(x, axes)) ^ 2) + eps)
+    // `---sub-----------------------------------------------------------------------------------'
+    auto beta = pattern::wrap_type<opset6::Constant>();
+    auto sub = pattern::wrap_type<opset6::Subtract>({ beta, mul3 });
+
+    // Final Add
+    // x * gamma / Sqrt(ReduceMean((x - ReduceMean(x, axes)) ^ 2) + eps) +
+    // beta - ReduceMean(x, axes) * gamma / Sqrt(ReduceMean((x - ReduceMean(x, axes)) ^ 2) + eps) =
+    // gamma * (x - ReduceMean(x, axes)) / Sqrt(ReduceMean((x - ReduceMean(x, axes)) ^ 2) + eps) + beta
+    auto add = pattern::wrap_type<opset6::Add>({ mul2, sub });
+
+    ngraph::matcher_pass_callback matcher_pass_callback = [=](ngraph::pattern::Matcher& m) {
+        auto& pattern_to_output = m.get_pattern_value_map();
+        auto x_output = pattern_to_output.at(x);
+
+        auto const_0_5_node = std::dynamic_pointer_cast<ngraph::opset6::Constant>(pattern_to_output.at(const_0_5).get_node_shared_ptr());
+        auto const_gamma_node = std::dynamic_pointer_cast<ngraph::opset6::Constant>(pattern_to_output.at(gamma).get_node_shared_ptr());
+        auto const_beta_node = std::dynamic_pointer_cast<ngraph::opset6::Constant>(pattern_to_output.at(beta).get_node_shared_ptr());
+        auto const_eps_node = std::dynamic_pointer_cast<ngraph::opset6::Constant>(pattern_to_output.at(eps).get_node_shared_ptr());
+        if (!const_0_5_node || !const_beta_node || !const_gamma_node || !const_eps_node) {
+            return false;
+        }
+
+        float eps_value;
+        bool valid_constant_values = op::util::has_constant_value<float>(const_0_5_node, -0.5) && op::util::get_single_value(const_eps_node, eps_value);
+        if (!valid_constant_values) {
+            return false;
+        }
+
+        auto axes_1_node = std::dynamic_pointer_cast<ngraph::opset6::Constant>(pattern_to_output.at(mean1_axes).get_node_shared_ptr());
+        auto axes_2_node = std::dynamic_pointer_cast<ngraph::opset6::Constant>(pattern_to_output.at(mean2_axes).get_node_shared_ptr());
+        if (!axes_1_node || !axes_2_node) {
+            return false;
+        }
+
+        auto axes_1_value = axes_1_node->cast_vector<int64_t>();
+        auto axes_2_value = axes_2_node->cast_vector<int64_t>();
+        if (axes_1_value != axes_2_value) {
+            return false;
+        }
+
+        auto mvn = std::make_shared<ngraph::opset6::MVN>(x_output, axes_1_node, true, eps_value, op::MVNEpsMode::INSIDE_SQRT);
+        auto mul_gamma = std::make_shared<ngraph::opset6::Multiply>(mvn, const_gamma_node);
+        auto add_beta = std::make_shared<ngraph::opset6::Add>(mul_gamma, const_beta_node);
+
+        ngraph::copy_runtime_info({ pattern_to_output.at(mean1).get_node_shared_ptr(),
+                                   pattern_to_output.at(squared_difference).get_node_shared_ptr(),
+                                   pattern_to_output.at(add_eps).get_node_shared_ptr(),
+                                   pattern_to_output.at(power).get_node_shared_ptr(),
+                                   pattern_to_output.at(mul1).get_node_shared_ptr(),
+                                   pattern_to_output.at(mul2).get_node_shared_ptr(),
+                                   pattern_to_output.at(mul3).get_node_shared_ptr(),
+                                   pattern_to_output.at(sub).get_node_shared_ptr(),
+                                   pattern_to_output.at(add).get_node_shared_ptr() },
+                                  { mvn, const_gamma_node, mul_gamma, const_beta_node, add_beta });
+        add_beta->set_friendly_name(m.get_match_root()->get_friendly_name());
+        ngraph::replace_node(m.get_match_root(), add_beta);
+        return true;
+    };
+
+    auto m = std::make_shared<ngraph::pattern::Matcher>(add, matcher_name);
     register_matcher(m, matcher_pass_callback);
 }

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/mvn.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/mvn.cpp
@@ -10,6 +10,9 @@
 using namespace LayerTestsDefinitions;
 
 const std::vector<std::vector<size_t>> inputShapes = {
+    {8},
+    {1, 16},
+    {3, 19},
     {1, 32, 17},
     {1, 37, 9},
     {1, 16, 5, 8},

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/mvn_multiply_add.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/mvn_multiply_add.cpp
@@ -1,0 +1,93 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "subgraph_tests/mvn_multiply_add.hpp"
+
+using namespace SubgraphTestsDefinitions;
+
+namespace {
+
+const std::vector<InferenceEngine::Precision> netPrecision = {
+        InferenceEngine::Precision::FP32
+};
+
+std::vector<InferenceEngine::Precision> idxPrecision = {
+        InferenceEngine::Precision::I64
+};
+
+const std::vector<bool> acrossChannels = {
+        true,
+        false
+};
+
+const std::vector<bool> normalizeVariance = {
+        true,
+        false
+};
+
+const std::vector<float> epsilon = {
+        0.000000001
+};
+
+const std::vector<std::string> epsMode = {
+        "inside_sqrt",
+        "outside_sqrt"
+};
+
+const std::vector<std::tuple<InferenceEngine::SizeVector, InferenceEngine::SizeVector>> shapes_1D = {
+        { std::vector<size_t>{5}, std::vector<size_t>{5}},
+        { std::vector<size_t>{64}, std::vector<size_t>{64}},
+};
+
+const std::vector<std::tuple<InferenceEngine::SizeVector, InferenceEngine::SizeVector>> shapes_2D = {
+        { std::vector<size_t>{1, 5}, std::vector<size_t>{1, 5}},
+        { std::vector<size_t>{2, 17}, std::vector<size_t>{1, 17}},
+        { std::vector<size_t>{9, 64}, std::vector<size_t>{1, 64}},
+        { std::vector<size_t>{5, 15}, std::vector<size_t>{1, 15}},
+};
+
+const std::vector<std::tuple<InferenceEngine::SizeVector, InferenceEngine::SizeVector>> shapes_3D = {
+        { std::vector<size_t>{1, 5, 8}, std::vector<size_t>{1, 5, 8}},
+        { std::vector<size_t>{2, 17, 9}, std::vector<size_t>{1, 1, 9}},
+        { std::vector<size_t>{1, 1, 10}, std::vector<size_t>{1, 1, 10}},
+        { std::vector<size_t>{2, 3, 3}, std::vector<size_t>{2, 3, 3}},
+};
+
+INSTANTIATE_TEST_CASE_P(smoke_MVNMultiplyAdd_1D, MVNMultiplyAdd,
+                        ::testing::Combine(
+                                ::testing::ValuesIn(shapes_1D),
+                                ::testing::ValuesIn(netPrecision),
+                                ::testing::ValuesIn(idxPrecision),
+                                ::testing::Values(std::vector<int>{0}),
+                                ::testing::ValuesIn(normalizeVariance),
+                                ::testing::ValuesIn(epsilon),
+                                ::testing::ValuesIn(epsMode),
+                                ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                        MVNMultiplyAdd::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_MVNMultiplyAdd_2D, MVNMultiplyAdd,
+                        ::testing::Combine(
+                                ::testing::ValuesIn(shapes_2D),
+                                ::testing::ValuesIn(netPrecision),
+                                ::testing::ValuesIn(idxPrecision),
+                                ::testing::Values(std::vector<int>{1}),
+                                ::testing::ValuesIn(normalizeVariance),
+                                ::testing::ValuesIn(epsilon),
+                                ::testing::ValuesIn(epsMode),
+                                ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                        MVNMultiplyAdd::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_MVNMultiplyAdd_3D, MVNMultiplyAdd,
+                        ::testing::Combine(
+                                ::testing::ValuesIn(shapes_3D),
+                                ::testing::ValuesIn(netPrecision),
+                                ::testing::ValuesIn(idxPrecision),
+                                ::testing::Values(std::vector<int>{2}),
+                                ::testing::ValuesIn(normalizeVariance),
+                                ::testing::ValuesIn(epsilon),
+                                ::testing::ValuesIn(epsMode),
+                                ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                            MVNMultiplyAdd::getTestCaseName);
+
+}  // namespace

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/mvn_multiply_add.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/mvn_multiply_add.cpp
@@ -36,22 +36,22 @@ const std::vector<std::string> epsMode = {
 };
 
 const std::vector<std::tuple<InferenceEngine::SizeVector, InferenceEngine::SizeVector>> shapes_1D = {
-        { std::vector<size_t>{5}, std::vector<size_t>{5}},
-        { std::vector<size_t>{64}, std::vector<size_t>{64}},
+        { InferenceEngine::SizeVector{5}, InferenceEngine::SizeVector{5}},
+        { InferenceEngine::SizeVector{64}, InferenceEngine::SizeVector{64}},
 };
 
 const std::vector<std::tuple<InferenceEngine::SizeVector, InferenceEngine::SizeVector>> shapes_2D = {
-        { std::vector<size_t>{1, 5}, std::vector<size_t>{1, 5}},
-        { std::vector<size_t>{2, 17}, std::vector<size_t>{1, 17}},
-        { std::vector<size_t>{9, 64}, std::vector<size_t>{1, 64}},
-        { std::vector<size_t>{5, 15}, std::vector<size_t>{1, 15}},
+        { InferenceEngine::SizeVector{1, 5}, InferenceEngine::SizeVector{1, 5}},
+        { InferenceEngine::SizeVector{2, 17}, InferenceEngine::SizeVector{1, 17}},
+        { InferenceEngine::SizeVector{9, 64}, InferenceEngine::SizeVector{1, 64}},
+        { InferenceEngine::SizeVector{5, 15}, InferenceEngine::SizeVector{1, 15}},
 };
 
 const std::vector<std::tuple<InferenceEngine::SizeVector, InferenceEngine::SizeVector>> shapes_3D = {
-        { std::vector<size_t>{1, 5, 8}, std::vector<size_t>{1, 5, 8}},
-        { std::vector<size_t>{2, 17, 9}, std::vector<size_t>{1, 1, 9}},
-        { std::vector<size_t>{1, 1, 10}, std::vector<size_t>{1, 1, 10}},
-        { std::vector<size_t>{2, 3, 3}, std::vector<size_t>{2, 3, 3}},
+        { InferenceEngine::SizeVector{1, 5, 8}, InferenceEngine::SizeVector{1, 5, 8}},
+        { InferenceEngine::SizeVector{2, 17, 9}, InferenceEngine::SizeVector{1, 1, 9}},
+        { InferenceEngine::SizeVector{1, 1, 10}, InferenceEngine::SizeVector{1, 1, 10}},
+        { InferenceEngine::SizeVector{2, 3, 3}, InferenceEngine::SizeVector{2, 3, 3}},
 };
 
 INSTANTIATE_TEST_CASE_P(smoke_MVNMultiplyAdd_1D, MVNMultiplyAdd,

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/mvn_multiply_add.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/subgraph_tests/mvn_multiply_add.cpp
@@ -5,15 +5,16 @@
 #include "subgraph_tests/mvn_multiply_add.hpp"
 
 using namespace SubgraphTestsDefinitions;
+using namespace InferenceEngine;
 
 namespace {
 
-const std::vector<InferenceEngine::Precision> netPrecision = {
-        InferenceEngine::Precision::FP32
+const std::vector<Precision> netPrecision = {
+        Precision::FP32
 };
 
-std::vector<InferenceEngine::Precision> idxPrecision = {
-        InferenceEngine::Precision::I64
+std::vector<Precision> idxPrecision = {
+        Precision::I64
 };
 
 const std::vector<bool> acrossChannels = {
@@ -35,23 +36,23 @@ const std::vector<std::string> epsMode = {
         "outside_sqrt"
 };
 
-const std::vector<std::tuple<InferenceEngine::SizeVector, InferenceEngine::SizeVector>> shapes_1D = {
-        { InferenceEngine::SizeVector{5}, InferenceEngine::SizeVector{5}},
-        { InferenceEngine::SizeVector{64}, InferenceEngine::SizeVector{64}},
+const std::vector<std::pair<SizeVector, SizeVector>> shapes_1D = {
+        std::pair<SizeVector, SizeVector>{ SizeVector{5}, SizeVector{5}},
+        std::pair<SizeVector, SizeVector>{ SizeVector{64}, SizeVector{64}},
 };
 
-const std::vector<std::tuple<InferenceEngine::SizeVector, InferenceEngine::SizeVector>> shapes_2D = {
-        { InferenceEngine::SizeVector{1, 5}, InferenceEngine::SizeVector{1, 5}},
-        { InferenceEngine::SizeVector{2, 17}, InferenceEngine::SizeVector{1, 17}},
-        { InferenceEngine::SizeVector{9, 64}, InferenceEngine::SizeVector{1, 64}},
-        { InferenceEngine::SizeVector{5, 15}, InferenceEngine::SizeVector{1, 15}},
+const std::vector<std::pair<SizeVector, SizeVector>> shapes_2D = {
+        std::pair<SizeVector, SizeVector>{ SizeVector{1, 5}, SizeVector{1, 5}},
+        std::pair<SizeVector, SizeVector>{ SizeVector{2, 17}, SizeVector{1, 17}},
+        std::pair<SizeVector, SizeVector>{ SizeVector{9, 64}, SizeVector{1, 64}},
+        std::pair<SizeVector, SizeVector>{ SizeVector{5, 15}, SizeVector{1, 15}},
 };
 
-const std::vector<std::tuple<InferenceEngine::SizeVector, InferenceEngine::SizeVector>> shapes_3D = {
-        { InferenceEngine::SizeVector{1, 5, 8}, InferenceEngine::SizeVector{1, 5, 8}},
-        { InferenceEngine::SizeVector{2, 17, 9}, InferenceEngine::SizeVector{1, 1, 9}},
-        { InferenceEngine::SizeVector{1, 1, 10}, InferenceEngine::SizeVector{1, 1, 10}},
-        { InferenceEngine::SizeVector{2, 3, 3}, InferenceEngine::SizeVector{2, 3, 3}},
+const std::vector<std::pair<SizeVector, SizeVector>> shapes_3D = {
+        std::pair<SizeVector, SizeVector>{ SizeVector{1, 5, 8}, SizeVector{1, 5, 8}},
+        std::pair<SizeVector, SizeVector>{ SizeVector{2, 17, 9}, SizeVector{1, 1, 9}},
+        std::pair<SizeVector, SizeVector>{ SizeVector{1, 1, 10}, SizeVector{1, 1, 10}},
+        std::pair<SizeVector, SizeVector>{ SizeVector{2, 3, 3}, SizeVector{2, 3, 3}},
 };
 
 INSTANTIATE_TEST_CASE_P(smoke_MVNMultiplyAdd_1D, MVNMultiplyAdd,

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/mvn.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/mvn.cpp
@@ -78,6 +78,16 @@ TEST_P(MvnLayerCPUTest, CompareWithRefs) {
 }
 
 namespace {
+const std::vector<std::vector<size_t>> inputShapes_1D = {
+        {5},
+        {16},
+};
+
+const std::vector<std::vector<size_t>> inputShapes_2D = {
+        {1, 32},
+        {16, 64},
+};
+
 const std::vector<std::vector<size_t>> inputShapes_3D = {
         {1, 32, 17},
         {1, 37, 9},
@@ -130,6 +140,36 @@ std::vector<CPUSpecificParams> cpuParams_5D = {
         CPUSpecificParams({nCdhw16c}, {nCdhw16c}, {}, {}),
         CPUSpecificParams({ncdhw}, {ncdhw}, {}, {})
 };
+
+const auto Mvn1D = ::testing::Combine(
+        ::testing::Combine(
+                ::testing::ValuesIn(inputShapes_1D),
+                ::testing::Values(InferenceEngine::Precision::FP32),
+                ::testing::ValuesIn(acrossChannels),
+                ::testing::ValuesIn(normalizeVariance),
+                ::testing::ValuesIn(epsilon),
+                ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+        ::testing::Values(emptyCPUSpec),
+        ::testing::Values(emptyFusingSpec),
+        ::testing::ValuesIn(inpOutPrc),
+        ::testing::ValuesIn(inpOutPrc));
+
+INSTANTIATE_TEST_CASE_P(smoke_CompareWithRefs_1D, MvnLayerCPUTest, Mvn1D, MvnLayerCPUTest::getTestCaseName);
+
+const auto Mvn2D = ::testing::Combine(
+        ::testing::Combine(
+                ::testing::ValuesIn(inputShapes_2D),
+                ::testing::Values(InferenceEngine::Precision::FP32),
+                ::testing::ValuesIn(acrossChannels),
+                ::testing::ValuesIn(normalizeVariance),
+                ::testing::ValuesIn(epsilon),
+        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+        ::testing::Values(emptyCPUSpec),
+        ::testing::Values(emptyFusingSpec),
+        ::testing::ValuesIn(inpOutPrc),
+        ::testing::ValuesIn(inpOutPrc));
+
+INSTANTIATE_TEST_CASE_P(smoke_CompareWithRefs_2D, MvnLayerCPUTest, Mvn2D, MvnLayerCPUTest::getTestCaseName);
 
 const auto Mvn3D = ::testing::Combine(
         ::testing::Combine(
@@ -186,7 +226,24 @@ std::vector<fusingSpecificParams> fusingParamsSet {
         fusingFakeQuantizePerChannel,
         fusingFakeQuantizePerChannelRelu,
         fusingFakeQuantizePerTensorRelu,
+        /* another patterns */
+        fusingScaleShift,
 };
+
+const auto Mvn2DFuse = ::testing::Combine(
+        ::testing::Combine(
+                ::testing::ValuesIn(inputShapes_2D),
+                ::testing::Values(InferenceEngine::Precision::FP32),
+                ::testing::Values(false),
+                ::testing::Values(true),
+                ::testing::ValuesIn(epsilon),
+                ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+        ::testing::Values(emptyCPUSpec),
+        ::testing::ValuesIn(fusingParamsSet),
+        ::testing::ValuesIn(inpOutPrc),
+        ::testing::ValuesIn(inpOutPrc));
+
+INSTANTIATE_TEST_CASE_P(smoke_CompareWithRefs_2D_Fuse, MvnLayerCPUTest, Mvn2DFuse, MvnLayerCPUTest::getTestCaseName);
 
 const auto Mvn3DFuse = ::testing::Combine(
         ::testing::Combine(

--- a/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/mvn_multiply_add.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/mvn_multiply_add.hpp
@@ -1,0 +1,15 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "shared_test_classes/subgraph/mvn_multiply_add.hpp"
+
+namespace SubgraphTestsDefinitions {
+
+TEST_P(MVNMultiplyAdd, CompareWithRefs){
+    Run();
+};
+
+}  // namespace SubgraphTestsDefinitions

--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/mvn_multiply_add.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/mvn_multiply_add.hpp
@@ -14,7 +14,7 @@
 namespace SubgraphTestsDefinitions {
 
 typedef std::tuple<
-    std::tuple<InferenceEngine::SizeVector, InferenceEngine::SizeVector>, // Input shape, Constant shape
+    std::pair<InferenceEngine::SizeVector, InferenceEngine::SizeVector>,  // Input shape, Constant shape
     InferenceEngine::Precision,                                           // Data precision
     InferenceEngine::Precision,                                           // Axes precision
     std::vector<int>,                                                     // Axes

--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/mvn_multiply_add.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/mvn_multiply_add.hpp
@@ -1,0 +1,34 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <string>
+#include <vector>
+
+#include "shared_test_classes/base/layer_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+
+namespace SubgraphTestsDefinitions {
+
+typedef std::tuple<
+    std::tuple<InferenceEngine::SizeVector, InferenceEngine::SizeVector>, // Input shape, Constant shape
+    InferenceEngine::Precision,                                           // Data precision
+    InferenceEngine::Precision,                                           // Axes precision
+    std::vector<int>,                                                     // Axes
+    bool,                                                                 // Normalize variance
+    float,                                                                // Epsilon
+    std::string,                                                          // Epsilon mode
+    std::string                                                           // Device name
+> mvnMultiplyAddParams;
+
+class MVNMultiplyAdd: public testing::WithParamInterface<mvnMultiplyAddParams>,
+                      public LayerTestsUtils::LayerTestsCommon{
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<mvnMultiplyAddParams> &obj);
+protected:
+    void SetUp() override;
+};
+}  // namespace SubgraphTestsDefinitions

--- a/inference-engine/tests/functional/shared_test_classes/src/subgraph/mvn_multiply_add.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/subgraph/mvn_multiply_add.cpp
@@ -1,0 +1,59 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/subgraph/mvn_multiply_add.hpp"
+
+namespace SubgraphTestsDefinitions {
+
+std::string MVNMultiplyAdd::getTestCaseName(const testing::TestParamInfo<mvnMultiplyAddParams> &obj) {
+    std::tuple<InferenceEngine::SizeVector, InferenceEngine::SizeVector> shapes;
+    InferenceEngine::SizeVector inputShapes, constantShapes;
+    InferenceEngine::Precision dataPrecision, axesPrecision;
+    std::vector<int> axes;
+    bool normalizeVariance;
+    float eps;
+    std::string epsMode;
+    std::string targetDevice;
+    std::tie(shapes, dataPrecision, axesPrecision, axes, normalizeVariance, eps, epsMode, targetDevice) = obj.param;
+    std::tie(inputShapes, constantShapes) = shapes;
+    std::ostringstream result;
+    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "CS=" << CommonTestUtils::vec2str(constantShapes) << "_";
+    result << "DataPrc=" << dataPrecision.name() << "_";
+    result << "AxPrc=" << axesPrecision.name() << "_";
+    result << "Ax=" << CommonTestUtils::vec2str(axes) << "_";
+    result << "NormVariance=" << (normalizeVariance ? "TRUE" : "FALSE") << "_";
+    result << "Eps=" << eps << "_";
+    result << "EM=" << epsMode << "_";
+    result << "TargetDevice=" << targetDevice;
+    return result.str();
+}
+
+void MVNMultiplyAdd::SetUp() {
+    std::tuple<InferenceEngine::SizeVector, InferenceEngine::SizeVector> shapes;
+    InferenceEngine::SizeVector inputShapes, constantShapes;
+    InferenceEngine::Precision dataPrecision, axesPrecision;
+    std::vector<int> axes;
+    bool normalizeVariance;
+    float eps;
+    std::string epsMode;
+    std::tie(shapes, dataPrecision, axesPrecision, axes, normalizeVariance, eps, epsMode, targetDevice) = this->GetParam();
+    std::tie(inputShapes, constantShapes) = shapes;
+
+    auto dataType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(dataPrecision);
+    auto axesType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(axesPrecision);
+
+    auto param = ngraph::builder::makeParams(dataType, {inputShapes});
+    auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(param));
+    auto axesNode = ngraph::builder::makeConstant(axesType, ngraph::Shape{axes.size()}, axes);
+    auto mvn = ngraph::builder::makeMVN6(paramOuts[0], axesNode, normalizeVariance, eps, epsMode);
+    auto gamma = ngraph::builder::makeConstant<float>(dataType, constantShapes, {}, true);
+    auto mul = std::make_shared<ngraph::opset7::Multiply>(mvn, gamma);
+    auto beta = ngraph::builder::makeConstant<float>(dataType, constantShapes, {}, true);
+    auto add = std::make_shared<ngraph::opset7::Add>(mul, beta);
+
+    ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(add)};
+    function = std::make_shared<ngraph::Function>(results, param, "MVNMultiplyAdd");
+}
+} // namespace SubgraphTestsDefinitions

--- a/inference-engine/tests/functional/shared_test_classes/src/subgraph/mvn_multiply_add.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/subgraph/mvn_multiply_add.cpp
@@ -7,7 +7,7 @@
 namespace SubgraphTestsDefinitions {
 
 std::string MVNMultiplyAdd::getTestCaseName(const testing::TestParamInfo<mvnMultiplyAddParams> &obj) {
-    std::tuple<InferenceEngine::SizeVector, InferenceEngine::SizeVector> shapes;
+    std::pair<InferenceEngine::SizeVector, InferenceEngine::SizeVector> shapes;
     InferenceEngine::SizeVector inputShapes, constantShapes;
     InferenceEngine::Precision dataPrecision, axesPrecision;
     std::vector<int> axes;
@@ -31,7 +31,7 @@ std::string MVNMultiplyAdd::getTestCaseName(const testing::TestParamInfo<mvnMult
 }
 
 void MVNMultiplyAdd::SetUp() {
-    std::tuple<InferenceEngine::SizeVector, InferenceEngine::SizeVector> shapes;
+    std::pair<InferenceEngine::SizeVector, InferenceEngine::SizeVector> shapes;
     InferenceEngine::SizeVector inputShapes, constantShapes;
     InferenceEngine::Precision dataPrecision, axesPrecision;
     std::vector<int> axes;


### PR DESCRIPTION
### Details:
 - Added MVN fusion for specific case when constants are inside subgraph
 - Removed creating shape5D from MVN ctor and added it to `createPrimitive` because node initializing is before `CommonOptimization` in `MKLDNNGraph`. So when we changed parameter `across_channels` in MVN ctor in method `tranformTo5DCase` for 1D and 2D shapes, there were [incorrect result](https://github.com/a-sidorova/openvino/blob/15ffe41cec807a0177e25cff4044f080815a2ada/inference-engine/src/mkldnn_plugin/mkldnn_graph_optimizer.cpp#L1131) of condition in fusing MVN and eltwise nodes (`beta` and `gamma`) in `FuseMVNAndSimpleOperations` 

### Tickets:
 - 48955