### PR TITLE
Use extern template instantiation only for Clang (RTTI mess)

### DIFF
--- a/inference-engine/include/ie_blob.h
+++ b/inference-engine/include/ie_blob.h
@@ -576,7 +576,12 @@ public:
     /**
      *@brief Virtual destructor.
      */
+#ifdef __ANDROID__
     virtual ~TBlob();
+#else
+    virtual ~TBlob() { free(); }
+#endif
+
 
     /**
      * @brief Gets the size of the given type.
@@ -798,6 +803,23 @@ protected:
         _handle = origBlob._handle;
     }
 };
+
+#ifdef __ANDROID__
+extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<float>);
+extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<double>);
+extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<int8_t>);
+extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<uint8_t>);
+extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<int16_t>);
+extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<uint16_t>);
+extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<int32_t>);
+extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<uint32_t>);
+extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<long>);
+extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<long long>);
+extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<unsigned long>);
+extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<unsigned long long>);
+extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<bool>);
+extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<char>);
+#endif
 
 /**
  * @brief Creates a blob with the given tensor descriptor.

--- a/inference-engine/include/ie_blob.h
+++ b/inference-engine/include/ie_blob.h
@@ -576,12 +576,7 @@ public:
     /**
      *@brief Virtual destructor.
      */
-#ifdef __ANDROID__
     virtual ~TBlob();
-#else
-    virtual ~TBlob() { free(); }
-#endif
-
 
     /**
      * @brief Gets the size of the given type.
@@ -804,7 +799,7 @@ protected:
     }
 };
 
-#ifdef __ANDROID__
+#ifdef __clang__
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<float>);
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<double>);
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<int8_t>);
@@ -819,7 +814,7 @@ extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<unsigned
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<unsigned long long>);
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<bool>);
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<char>);
-#endif
+#endif  // __clang__
 
 /**
  * @brief Creates a blob with the given tensor descriptor.

--- a/inference-engine/include/ie_blob.h
+++ b/inference-engine/include/ie_blob.h
@@ -799,21 +799,6 @@ protected:
     }
 };
 
-extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<float>);
-extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<double>);
-extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<int8_t>);
-extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<uint8_t>);
-extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<int16_t>);
-extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<uint16_t>);
-extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<int32_t>);
-extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<uint32_t>);
-extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<long>);
-extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<long long>);
-extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<unsigned long>);
-extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<unsigned long long>);
-extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<bool>);
-extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<char>);
-
 /**
  * @brief Creates a blob with the given tensor descriptor.
  *

--- a/inference-engine/src/inference_engine/ie_common.cpp
+++ b/inference-engine/src/inference_engine/ie_common.cpp
@@ -124,19 +124,19 @@ TBlob<T, U>::~TBlob() {
     free();
 }
 
-template class TBlob<float>;
-template class TBlob<double>;
-template class TBlob<int8_t>;
-template class TBlob<uint8_t>;
-template class TBlob<int16_t>;
-template class TBlob<uint16_t>;
-template class TBlob<int32_t>;
-template class TBlob<uint32_t>;
-template class TBlob<long>;
-template class TBlob<long long>;
-template class TBlob<unsigned long>;
-template class TBlob<unsigned long long>;
-template class TBlob<bool>;
-template class TBlob<char>;
+template class INFERENCE_ENGINE_API_CLASS(TBlob<float>);
+template class INFERENCE_ENGINE_API_CLASS(TBlob<double>);
+template class INFERENCE_ENGINE_API_CLASS(TBlob<int8_t>);
+template class INFERENCE_ENGINE_API_CLASS(TBlob<uint8_t>);
+template class INFERENCE_ENGINE_API_CLASS(TBlob<int16_t>);
+template class INFERENCE_ENGINE_API_CLASS(TBlob<uint16_t>);
+template class INFERENCE_ENGINE_API_CLASS(TBlob<int32_t>);
+template class INFERENCE_ENGINE_API_CLASS(TBlob<uint32_t>);
+template class INFERENCE_ENGINE_API_CLASS(TBlob<long>);
+template class INFERENCE_ENGINE_API_CLASS(TBlob<long long>);
+template class INFERENCE_ENGINE_API_CLASS(TBlob<unsigned long>);
+template class INFERENCE_ENGINE_API_CLASS(TBlob<unsigned long long>);
+template class INFERENCE_ENGINE_API_CLASS(TBlob<bool>);
+template class INFERENCE_ENGINE_API_CLASS(TBlob<char>);
 
 }  // namespace InferenceEngine

--- a/inference-engine/src/inference_engine/ie_common.cpp
+++ b/inference-engine/src/inference_engine/ie_common.cpp
@@ -113,7 +113,6 @@ template struct Parameter::RealData<std::vector<unsigned long>>;
 template struct Parameter::RealData<std::tuple<unsigned int, unsigned int>>;
 template struct Parameter::RealData<std::tuple<unsigned int, unsigned int, unsigned int>>;
 template struct Parameter::RealData<Blob::Ptr>;
-#endif
 
 //
 // ie_blob.h
@@ -124,19 +123,21 @@ TBlob<T, U>::~TBlob() {
     free();
 }
 
-}  // namespace InferenceEngine
+template class TBlob<float>;
+template class TBlob<double>;
+template class TBlob<int8_t>;
+template class TBlob<uint8_t>;
+template class TBlob<int16_t>;
+template class TBlob<uint16_t>;
+template class TBlob<int32_t>;
+template class TBlob<uint32_t>;
+template class TBlob<long>;
+template class TBlob<long long>;
+template class TBlob<unsigned long>;
+template class TBlob<unsigned long long>;
+template class TBlob<bool>;
+template class TBlob<char>;
 
-template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<float>);
-template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<double>);
-template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<int8_t>);
-template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<uint8_t>);
-template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<int16_t>);
-template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<uint16_t>);
-template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<int32_t>);
-template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<uint32_t>);
-template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<long>);
-template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<long long>);
-template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<unsigned long>);
-template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<unsigned long long>);
-template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<bool>);
-template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<char>);
+#endif
+
+}  // namespace InferenceEngine

--- a/inference-engine/src/inference_engine/ie_common.cpp
+++ b/inference-engine/src/inference_engine/ie_common.cpp
@@ -124,19 +124,19 @@ TBlob<T, U>::~TBlob() {
     free();
 }
 
-template class INFERENCE_ENGINE_API_CLASS(TBlob<float>);
-template class INFERENCE_ENGINE_API_CLASS(TBlob<double>);
-template class INFERENCE_ENGINE_API_CLASS(TBlob<int8_t>);
-template class INFERENCE_ENGINE_API_CLASS(TBlob<uint8_t>);
-template class INFERENCE_ENGINE_API_CLASS(TBlob<int16_t>);
-template class INFERENCE_ENGINE_API_CLASS(TBlob<uint16_t>);
-template class INFERENCE_ENGINE_API_CLASS(TBlob<int32_t>);
-template class INFERENCE_ENGINE_API_CLASS(TBlob<uint32_t>);
-template class INFERENCE_ENGINE_API_CLASS(TBlob<long>);
-template class INFERENCE_ENGINE_API_CLASS(TBlob<long long>);
-template class INFERENCE_ENGINE_API_CLASS(TBlob<unsigned long>);
-template class INFERENCE_ENGINE_API_CLASS(TBlob<unsigned long long>);
-template class INFERENCE_ENGINE_API_CLASS(TBlob<bool>);
-template class INFERENCE_ENGINE_API_CLASS(TBlob<char>);
-
 }  // namespace InferenceEngine
+
+template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<float>);
+template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<double>);
+template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<int8_t>);
+template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<uint8_t>);
+template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<int16_t>);
+template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<uint16_t>);
+template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<int32_t>);
+template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<uint32_t>);
+template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<long>);
+template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<long long>);
+template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<unsigned long>);
+template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<unsigned long long>);
+template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<bool>);
+template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<char>);

--- a/inference-engine/src/inference_engine/ie_common.cpp
+++ b/inference-engine/src/inference_engine/ie_common.cpp
@@ -113,6 +113,7 @@ template struct Parameter::RealData<std::vector<unsigned long>>;
 template struct Parameter::RealData<std::tuple<unsigned int, unsigned int>>;
 template struct Parameter::RealData<std::tuple<unsigned int, unsigned int, unsigned int>>;
 template struct Parameter::RealData<Blob::Ptr>;
+#endif
 
 //
 // ie_blob.h
@@ -123,21 +124,19 @@ TBlob<T, U>::~TBlob() {
     free();
 }
 
-template class TBlob<float>;
-template class TBlob<double>;
-template class TBlob<int8_t>;
-template class TBlob<uint8_t>;
-template class TBlob<int16_t>;
-template class TBlob<uint16_t>;
-template class TBlob<int32_t>;
-template class TBlob<uint32_t>;
-template class TBlob<long>;
-template class TBlob<long long>;
-template class TBlob<unsigned long>;
-template class TBlob<unsigned long long>;
-template class TBlob<bool>;
-template class TBlob<char>;
-
-#endif
+template class INFERENCE_ENGINE_API_CLASS(TBlob<float>);
+template class INFERENCE_ENGINE_API_CLASS(TBlob<double>);
+template class INFERENCE_ENGINE_API_CLASS(TBlob<int8_t>);
+template class INFERENCE_ENGINE_API_CLASS(TBlob<uint8_t>);
+template class INFERENCE_ENGINE_API_CLASS(TBlob<int16_t>);
+template class INFERENCE_ENGINE_API_CLASS(TBlob<uint16_t>);
+template class INFERENCE_ENGINE_API_CLASS(TBlob<int32_t>);
+template class INFERENCE_ENGINE_API_CLASS(TBlob<uint32_t>);
+template class INFERENCE_ENGINE_API_CLASS(TBlob<long>);
+template class INFERENCE_ENGINE_API_CLASS(TBlob<long long>);
+template class INFERENCE_ENGINE_API_CLASS(TBlob<unsigned long>);
+template class INFERENCE_ENGINE_API_CLASS(TBlob<unsigned long long>);
+template class INFERENCE_ENGINE_API_CLASS(TBlob<bool>);
+template class INFERENCE_ENGINE_API_CLASS(TBlob<char>);
 
 }  // namespace InferenceEngine

--- a/ngraph/test/util/engine/ie_engines.cpp
+++ b/ngraph/test/util/engine/ie_engines.cpp
@@ -341,6 +341,7 @@ void test::IE_Engine::reset()
 
 namespace InferenceEngine
 {
+#ifdef __ANDROID__
 // Without this section the linker is not able to find destructors for missing TBlob specializations
 // which are instantiated in the unit tests that use TestCase and this engine
     template <typename T, typename U>
@@ -351,4 +352,5 @@ namespace InferenceEngine
 
     template class TBlob<ngraph::bfloat16>;
     template class TBlob<ngraph::float16>;
+#endif
 } // namespace InferenceEngine

--- a/ngraph/test/util/engine/ie_engines.cpp
+++ b/ngraph/test/util/engine/ie_engines.cpp
@@ -341,7 +341,6 @@ void test::IE_Engine::reset()
 
 namespace InferenceEngine
 {
-#ifdef __ANDROID__
 // Without this section the linker is not able to find destructors for missing TBlob specializations
 // which are instantiated in the unit tests that use TestCase and this engine
     template <typename T, typename U>
@@ -352,5 +351,4 @@ namespace InferenceEngine
 
     template class TBlob<ngraph::bfloat16>;
     template class TBlob<ngraph::float16>;
-#endif
 } // namespace InferenceEngine


### PR DESCRIPTION
### Tickets:
 - tickets: 55462, 55669

origin: https://github.com/openvinotoolkit/openvino/pull/4575

Also, tried to build OpenVINO with GCC 7.5.0 and then link with application using Clang-8 (Ubuntu 18.04) - works fine so ticket **41513** won't appear.