### PR TITLE
Reshape OP: add SLT for special `-1` value in new shape dimensions

### DIFF
--- a/docs/template_plugin/tests/functional/shared_tests_instances/single_layer_tests/reshape.cpp
+++ b/docs/template_plugin/tests/functional/shared_tests_instances/single_layer_tests/reshape.cpp
@@ -2,43 +2,58 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "single_layer_tests/reshape.hpp"
+
 #include <vector>
 
-#include "single_layer_tests/reshape.hpp"
 #include "common_test_utils/test_constants.hpp"
 
 using namespace LayerTestsDefinitions;
 
 namespace {
 const std::vector<InferenceEngine::Precision> netPrecisions = {
-        InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP32,
 };
 
-INSTANTIATE_TEST_CASE_P(smoke_ReshapeCheckDynBatch, ReshapeLayerTest,
-        ::testing::Combine(
-                ::testing::Values(true),
-                ::testing::ValuesIn(netPrecisions),
-                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                ::testing::Values(InferenceEngine::Layout::ANY),
-                ::testing::Values(InferenceEngine::Layout::ANY),
-                ::testing::Values(std::vector<size_t>({30, 30, 30, 30})),
-                ::testing::Values(std::vector<size_t>({30, 30, 30, 30})),
-                ::testing::Values(CommonTestUtils::DEVICE_TEMPLATE),
-                ::testing::Values(std::map<std::string, std::string>({}))),
-                ReshapeLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(
+    smoke_ReshapeCheckDynBatch, ReshapeLayerTestRevise,
+    ::testing::Combine(
+        ::testing::Values(true), ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(std::vector<size_t>({30, 30, 30, 30})),
+        ::testing::Values(std::vector<int64_t>({30, 30, 30, 30})),
+        ::testing::Values(CommonTestUtils::DEVICE_TEMPLATE),
+        ::testing::Values(std::map<std::string, std::string>({}))),
+    ReshapeLayerTestRevise::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(smoke_ReshapeCheck, ReshapeLayerTest,
-        ::testing::Combine(
-                ::testing::Values(true),
-                ::testing::ValuesIn(netPrecisions),
-                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                ::testing::Values(InferenceEngine::Layout::ANY),
-                ::testing::Values(InferenceEngine::Layout::ANY),
-                ::testing::Values(std::vector<size_t>({10, 10, 10, 10})),
-                ::testing::Values(std::vector<size_t>({10, 0, 100})),
-                ::testing::Values(CommonTestUtils::DEVICE_TEMPLATE),
-                ::testing::Values(std::map<std::string, std::string>({}))),
-                ReshapeLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(
+    smoke_ReshapeCheck, ReshapeLayerTestRevise,
+    ::testing::Combine(
+        ::testing::Values(true), ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(std::vector<size_t>({10, 10, 10, 10})),
+        ::testing::Values(std::vector<int64_t>({10, 0, 100})),
+        ::testing::Values(CommonTestUtils::DEVICE_TEMPLATE),
+        ::testing::Values(std::map<std::string, std::string>({}))),
+    ReshapeLayerTestRevise::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(
+    smoke_ReshapeCheckNegative, ReshapeLayerTestRevise,
+    ::testing::Combine(
+        ::testing::Values(true), ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(std::vector<size_t>({10, 10, 10, 10})),
+        ::testing::Values(std::vector<int64_t>({10, -1, 100})),
+        ::testing::Values(CommonTestUtils::DEVICE_TEMPLATE),
+        ::testing::Values(std::map<std::string, std::string>({}))),
+    ReshapeLayerTestRevise::getTestCaseName);
 }  // namespace

--- a/inference-engine/tests/functional/inference_engine/serialization/single_layer/reshape.cpp
+++ b/inference-engine/tests/functional/inference_engine/serialization/single_layer/reshape.cpp
@@ -10,7 +10,7 @@
 using namespace LayerTestsDefinitions;
 
 namespace {
-    TEST_P(ReshapeLayerTest, Serialize) {
+    TEST_P(ReshapeLayerTestRevise, Serialize) {
         Serialize();
     }
 
@@ -19,7 +19,7 @@ namespace {
             InferenceEngine::Precision::FP16
     };
 
-    INSTANTIATE_TEST_CASE_P(smoke_ReshapeSerialization, ReshapeLayerTest,
+    INSTANTIATE_TEST_CASE_P(smoke_ReshapeSerialization, ReshapeLayerTestRevise,
             ::testing::Combine(
                 ::testing::Values(true),
                 ::testing::ValuesIn(netPrecisions),
@@ -28,8 +28,8 @@ namespace {
                 ::testing::Values(InferenceEngine::Layout::ANY),
                 ::testing::Values(InferenceEngine::Layout::ANY),
                 ::testing::Values(std::vector<size_t>({30, 30, 30, 30})),
-                ::testing::Values(std::vector<size_t>({30, 30, 30, 30})),
+                ::testing::Values(std::vector<int64_t>({30, 30, 30, 30})),
                 ::testing::Values(CommonTestUtils::DEVICE_CPU),
                 ::testing::Values(std::map<std::string, std::string>({{CONFIG_KEY(DYN_BATCH_ENABLED), CONFIG_VALUE(YES)}}))),
-                ReshapeLayerTest::getTestCaseName);
+                ReshapeLayerTestRevise::getTestCaseName);
 }  // namespace

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/reshape.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/reshape.cpp
@@ -15,7 +15,7 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
         InferenceEngine::Precision::FP16
 };
 
-INSTANTIATE_TEST_CASE_P(smoke_ReshapeCheckDynBatch, ReshapeLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_ReshapeCheckDynBatch, ReshapeLayerTestRevise,
         ::testing::Combine(
                 ::testing::Values(true),
                 ::testing::ValuesIn(netPrecisions),
@@ -24,12 +24,12 @@ INSTANTIATE_TEST_CASE_P(smoke_ReshapeCheckDynBatch, ReshapeLayerTest,
                 ::testing::Values(InferenceEngine::Layout::ANY),
                 ::testing::Values(InferenceEngine::Layout::ANY),
                 ::testing::Values(std::vector<size_t>({30, 30, 30, 30})),
-                ::testing::Values(std::vector<size_t>({30, 30, 30, 30})),
+                ::testing::Values(std::vector<int64_t>({30, 30, 30, 30})),
                 ::testing::Values(CommonTestUtils::DEVICE_CPU),
                 ::testing::Values(std::map<std::string, std::string>({{CONFIG_KEY(DYN_BATCH_ENABLED), CONFIG_VALUE(YES)}}))),
-                ReshapeLayerTest::getTestCaseName);
+                ReshapeLayerTestRevise::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(smoke_ReshapeCheck, ReshapeLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_ReshapeCheck, ReshapeLayerTestRevise,
         ::testing::Combine(
                 ::testing::Values(true),
                 ::testing::ValuesIn(netPrecisions),
@@ -38,8 +38,22 @@ INSTANTIATE_TEST_CASE_P(smoke_ReshapeCheck, ReshapeLayerTest,
                 ::testing::Values(InferenceEngine::Layout::ANY),
                 ::testing::Values(InferenceEngine::Layout::ANY),
                 ::testing::Values(std::vector<size_t>({10, 10, 10, 10})),
-                ::testing::Values(std::vector<size_t>({10, 0, 100})),
+                ::testing::Values(std::vector<int64_t>({10, 0, 100})),
                 ::testing::Values(CommonTestUtils::DEVICE_CPU),
                 ::testing::Values(std::map<std::string, std::string>({}))),
-                ReshapeLayerTest::getTestCaseName);
+                ReshapeLayerTestRevise::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_ReshapeCheckNegative, ReshapeLayerTestRevise,
+        ::testing::Combine(
+                ::testing::Values(true),
+                ::testing::ValuesIn(netPrecisions),
+                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+                ::testing::Values(InferenceEngine::Layout::ANY),
+                ::testing::Values(InferenceEngine::Layout::ANY),
+                ::testing::Values(std::vector<size_t>({10, 10, 10, 10})),
+                ::testing::Values(std::vector<int64_t>({10, -1, 100})),
+                ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                ::testing::Values(std::map<std::string, std::string>({}))),
+                ReshapeLayerTestRevise::getTestCaseName);
 }  // namespace

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/reshape.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/reshape.cpp
@@ -16,7 +16,7 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
 };
 
 //TODO: Issue : - 28981
-INSTANTIATE_TEST_CASE_P(DISABLE_smoke_ReshapeCheckDynBatch, ReshapeLayerTest,
+INSTANTIATE_TEST_CASE_P(DISABLE_smoke_ReshapeCheckDynBatch, ReshapeLayerTestRevise,
         ::testing::Combine(
                 ::testing::Values(true),
                 ::testing::ValuesIn(netPrecisions),
@@ -25,12 +25,12 @@ INSTANTIATE_TEST_CASE_P(DISABLE_smoke_ReshapeCheckDynBatch, ReshapeLayerTest,
                 ::testing::Values(InferenceEngine::Layout::ANY),
                 ::testing::Values(InferenceEngine::Layout::ANY),
                 ::testing::Values(std::vector<size_t>({1, 16, 16, 16})),
-                ::testing::Values(std::vector<size_t>({1, 0, 256})),
+                ::testing::Values(std::vector<int64_t>({1, 0, 256})),
                  ::testing::Values(CommonTestUtils::DEVICE_GPU),
                 ::testing::Values(std::map<std::string, std::string>({{CONFIG_KEY(DYN_BATCH_ENABLED), CONFIG_VALUE(YES)}}))),
-                ReshapeLayerTest::getTestCaseName);
+                ReshapeLayerTestRevise::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(smoke_ReshapeCheck, ReshapeLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_ReshapeCheck, ReshapeLayerTestRevise,
         ::testing::Combine(
                 ::testing::Values(true),
                 ::testing::ValuesIn(netPrecisions),
@@ -39,8 +39,22 @@ INSTANTIATE_TEST_CASE_P(smoke_ReshapeCheck, ReshapeLayerTest,
                 ::testing::Values(InferenceEngine::Layout::ANY),
                 ::testing::Values(InferenceEngine::Layout::ANY),
                 ::testing::Values(std::vector<size_t>({10, 10, 10, 10})),
-                ::testing::Values(std::vector<size_t>({10, 0, 100})),
+                ::testing::Values(std::vector<int64_t>({10, 0, 100})),
                 ::testing::Values(CommonTestUtils::DEVICE_GPU),
                 ::testing::Values(std::map<std::string, std::string>({}))),
-                ReshapeLayerTest::getTestCaseName);
+                ReshapeLayerTestRevise::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_ReshapeCheckNegative, ReshapeLayerTestRevise,
+        ::testing::Combine(
+                ::testing::Values(true),
+                ::testing::ValuesIn(netPrecisions),
+                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+                ::testing::Values(InferenceEngine::Layout::ANY),
+                ::testing::Values(InferenceEngine::Layout::ANY),
+                ::testing::Values(std::vector<size_t>({10, 10, 10, 10})),
+                ::testing::Values(std::vector<int64_t>({10, -1, 100})),
+                ::testing::Values(CommonTestUtils::DEVICE_GPU),
+                ::testing::Values(std::map<std::string, std::string>({}))),
+                ReshapeLayerTestRevise::getTestCaseName);
 }  // namespace

--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/reshape.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/reshape.hpp
@@ -4,36 +4,60 @@
 
 #pragma once
 
-#include <tuple>
-#include <string>
-#include <vector>
 #include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
+
 #include "ngraph_functions/builders.hpp"
 #include "ngraph_functions/utils/ngraph_helpers.hpp"
-
 #include "shared_test_classes/base/layer_test_utils.hpp"
 
 namespace LayerTestsDefinitions {
-typedef std::tuple<
-        bool,                               // SpecialZero
-        InferenceEngine::Precision,         // Network precision
-        InferenceEngine::Precision,         // Input precision
-        InferenceEngine::Precision,         // Output precision
-        InferenceEngine::Layout,            // Input layout
-        InferenceEngine::Layout,            // Output layout
-        std::vector<size_t>,                // Input shapes
-        std::vector<size_t>,                // OutForm Shapes
-        std::string,                        // Device name
-        std::map<std::string, std::string>  // Config
-> reshapeParams;
+typedef std::tuple<bool,                               // SpecialZero
+                   InferenceEngine::Precision,         // Network precision
+                   InferenceEngine::Precision,         // Input precision
+                   InferenceEngine::Precision,         // Output precision
+                   InferenceEngine::Layout,            // Input layout
+                   InferenceEngine::Layout,            // Output layout
+                   std::vector<size_t>,                // Input shapes
+                   std::vector<size_t>,                // OutForm Shapes
+                   std::string,                        // Device name
+                   std::map<std::string, std::string>  // Config
+                   >
+    reshapeParams;
 
 class ReshapeLayerTest : public testing::WithParamInterface<reshapeParams>,
                          virtual public LayerTestsUtils::LayerTestsCommon {
 public:
-    static std::string getTestCaseName(testing::TestParamInfo<reshapeParams> obj);
+    static std::string getTestCaseName(
+        testing::TestParamInfo<reshapeParams> obj);
 
 protected:
     void SetUp() override;
 };
 
+typedef std::tuple<bool,                               // SpecialZero
+                   InferenceEngine::Precision,         // Network precision
+                   InferenceEngine::Precision,         // Input precision
+                   InferenceEngine::Precision,         // Output precision
+                   InferenceEngine::Layout,            // Input layout
+                   InferenceEngine::Layout,            // Output layout
+                   std::vector<size_t>,                // Input shapes
+                   std::vector<int64_t>,               // OutForm Shapes
+                   std::string,                        // Device name
+                   std::map<std::string, std::string>  // Config
+                   >
+    reshapeParamsRevise;
+
+class ReshapeLayerTestRevise
+    : public testing::WithParamInterface<reshapeParamsRevise>,
+      virtual public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(
+        testing::TestParamInfo<reshapeParamsRevise> obj);
+
+protected:
+    void SetUp() override;
+};
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/reshape.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/reshape.hpp
@@ -14,6 +14,8 @@
 #include "shared_test_classes/base/layer_test_utils.hpp"
 
 namespace LayerTestsDefinitions {
+
+//TODO: remove this alias when ticket 57975 is done - ticket: 57976
 typedef std::tuple<bool,                               // SpecialZero
                    InferenceEngine::Precision,         // Network precision
                    InferenceEngine::Precision,         // Input precision
@@ -27,6 +29,7 @@ typedef std::tuple<bool,                               // SpecialZero
                    >
     reshapeParams;
 
+//TODO: remove this class when ticket 57975 is done - ticket: 57976
 class ReshapeLayerTest : public testing::WithParamInterface<reshapeParams>,
                          virtual public LayerTestsUtils::LayerTestsCommon {
 public:
@@ -37,6 +40,8 @@ protected:
     void SetUp() override;
 };
 
+
+//TODO: use this alias in all dependencies - ticket: 57975
 typedef std::tuple<bool,                               // SpecialZero
                    InferenceEngine::Precision,         // Network precision
                    InferenceEngine::Precision,         // Input precision
@@ -50,6 +55,7 @@ typedef std::tuple<bool,                               // SpecialZero
                    >
     reshapeParamsRevise;
 
+//TODO: use this class in all dependencies - ticket: 57975
 class ReshapeLayerTestRevise
     : public testing::WithParamInterface<reshapeParamsRevise>,
       virtual public LayerTestsUtils::LayerTestsCommon {

--- a/inference-engine/tests/functional/shared_test_classes/src/single_layer/reshape.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/single_layer/reshape.cpp
@@ -5,7 +5,7 @@
 #include "shared_test_classes/single_layer/reshape.hpp"
 
 namespace LayerTestsDefinitions {
-    std::string ReshapeLayerTest::getTestCaseName(testing::TestParamInfo<reshapeParams> obj) {
+std::string ReshapeLayerTest::getTestCaseName(testing::TestParamInfo<reshapeParams> obj) {
     InferenceEngine::Precision netPrecision;
     InferenceEngine::Precision inPrc, outPrc;
     InferenceEngine::Layout inLayout, outLayout;
@@ -44,4 +44,47 @@ void ReshapeLayerTest::SetUp() {
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(reshape)};
     function = std::make_shared<ngraph::Function>(results, paramsIn, "Reshape");
 }
+
+std::string ReshapeLayerTestRevise::getTestCaseName(testing::TestParamInfo<reshapeParamsRevise> obj) {
+    InferenceEngine::Precision netPrecision;
+    InferenceEngine::Precision inPrc, outPrc;
+    InferenceEngine::Layout inLayout, outLayout;
+    InferenceEngine::SizeVector inputShapes;
+    std::vector<int64_t> outFormShapes;
+    std::string targetDevice;
+    std::map<std::string, std::string> config;
+    bool specialZero;
+    std::tie(specialZero, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShapes, outFormShapes, targetDevice, config) = obj.param;
+    std::ostringstream result;
+    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "OS=" << CommonTestUtils::vec2str(outFormShapes) << "_";
+    result << "specialZero=" << specialZero << "_";
+    result << "netPRC=" << netPrecision.name() << "_";
+    result << "inPRC=" << inPrc.name() << "_";
+    result << "outPRC=" << outPrc.name() << "_";
+    result << "inL=" << inLayout << "_";
+    result << "outL=" << outLayout << "_";
+    result << "trgDev=" << targetDevice;
+    return result.str();
+}
+
+void ReshapeLayerTestRevise::SetUp() {
+    InferenceEngine::SizeVector inputShapes;
+    std::vector<int64_t> outFormShapes;
+    bool specialZero;
+    InferenceEngine::Precision netPrecision;
+    std::tie(specialZero, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShapes, outFormShapes, targetDevice, configuration) =
+        this->GetParam();
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+    auto paramsIn = ngraph::builder::makeParams(ngPrc, {inputShapes});
+    auto paramIn = ngraph::helpers::convert2OutputVector(
+            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(paramsIn));
+    auto constNode = std::make_shared<ngraph::opset1::Constant>(
+            ngraph::element::Type_t::i64, ngraph::Shape{outFormShapes.size()}, outFormShapes);
+    auto reshape = std::dynamic_pointer_cast<ngraph::opset1::Reshape>(
+            std::make_shared<ngraph::opset1::Reshape>(paramIn[0], constNode, specialZero));
+    ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(reshape)};
+    function = std::make_shared<ngraph::Function>(results, paramsIn, "Reshape");
+}
+
 }  // namespace LayerTestsDefinitions


### PR DESCRIPTION
### Details:
 - *add SLT for special `-1` value in new shape dimensions*

This PR contains new `ReshapeLayerTestRevise` class because ARM plugin use `ReshapeLayerTest` and it can't be changed at one PR but this required multi-PR approach. 

### Tickets:
 - *45956*
