### PR TITLE
Disable check on result in CheckExecGraphInfoBeforeExecution

### DIFF
--- a/inference-engine/tests/functional/plugin/shared/include/behavior/exec_graph_info.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/behavior/exec_graph_info.hpp
@@ -71,10 +71,6 @@ TEST_P(ExecGraphTests, CheckExecGraphInfoBeforeExecution) {
         const auto originalLayers = function->get_ops();
         std::map<std::string, int> originalLayersMap;
         for (const auto &layer : originalLayers) {
-            if (layer->description() == "Result" &&
-                targetDevice != CommonTestUtils::DEVICE_CPU &&
-                targetDevice != CommonTestUtils::DEVICE_AUTO)
-                continue;
             originalLayersMap[layer->get_friendly_name()] = 0;
         }
         int IteratorForLayersConstant = 0;


### PR DESCRIPTION
### Details:
Need to check how it will be work for other plug-ins

