### PR TITLE
Enable zero epsilon attribute in BatchNormInference operation

### DIFF
--- a/docs/ops/normalization/BatchNormInference_1.md
+++ b/docs/ops/normalization/BatchNormInference_1.md
@@ -58,7 +58,7 @@ For a particular activation, consider a mini-batch \f$\mathcal{B}\f$ of m values
 
 * *epsilon*
   * **Description**: *epsilon* is a constant added to the variance for numerical stability.
-  * **Range of values**: a positive floating-point number
+  * **Range of values**: a floating-point number greater than or equal to zero
   * **Type**: `float`
   * **Default value**: none
   * **Required**: *yes*

--- a/docs/ops/normalization/BatchNormInference_5.md
+++ b/docs/ops/normalization/BatchNormInference_5.md
@@ -58,7 +58,7 @@ For a particular activation, consider a mini-batch \f$\mathcal{B}\f$ of m values
 
 * *epsilon*
   * **Description**: *epsilon* is a constant added to the variance for numerical stability.
-  * **Range of values**: a positive floating-point number
+  * **Range of values**: a floating-point number greater than or equal to zero
   * **Type**: `float`
   * **Default value**: none
   * **Required**: *yes*

--- a/inference-engine/tests/functional/inference_engine/serialization/single_layer/batch_norm.cpp
+++ b/inference-engine/tests/functional/inference_engine/serialization/single_layer/batch_norm.cpp
@@ -20,6 +20,7 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
 };
 
 const std::vector<double> epsilon = {
+    0.0,
     1e-6,
     1e-5,
     1e-4

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/batch_norm.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/batch_norm.cpp
@@ -15,6 +15,7 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
 };
 
 const std::vector<double> epsilon = {
+    0.0,
     1e-6,
     1e-5,
     1e-4

--- a/ngraph/core/src/op/batch_norm.cpp
+++ b/ngraph/core/src/op/batch_norm.cpp
@@ -42,8 +42,8 @@ void op::v0::BatchNormInference::validate_and_infer_types()
 
     NODE_VALIDATION_CHECK(
         this,
-        m_epsilon > 0,
-        "Attribute 'epsilon' must have non-zero positive floating-point value. Got: ",
+        m_epsilon >= 0,
+        "Attribute 'epsilon' must be a floating-point value greater than or equal to zero. Got: ",
         m_epsilon);
 
     set_output_size(1);
@@ -102,8 +102,8 @@ void op::v5::BatchNormInference::validate_and_infer_types()
 
     NODE_VALIDATION_CHECK(
         this,
-        m_epsilon > 0,
-        "Attribute 'epsilon' must have non-zero positive floating-point value. Got: ",
+        m_epsilon >= 0,
+        "Attribute 'epsilon' must be a floating-point value greater than or equal to zero. Got: ",
         m_epsilon);
 
     set_output_size(1);

--- a/ngraph/test/type_prop/batch_norm.cpp
+++ b/ngraph/test/type_prop/batch_norm.cpp
@@ -497,29 +497,20 @@ TYPED_TEST_P(BatchNormTest, batch_norm_inference_invalid_epsilon)
         {inputs_et, PartialShape{100}, "variance"}
     };
 
-    double eps_zero = 0.0;
     double eps_neg = -1.0;
-
-    const std::vector<BatchNormInferParams> bn_tests{
-        BatchNormInferParams{inputs_et, data_batch_shape, ch_inputs, eps_zero},
-        BatchNormInferParams{inputs_et, data_batch_shape, ch_inputs, eps_neg}
-    };
-
-    for(const auto& params : bn_tests)
+    const BatchNormInferParams params{inputs_et, data_batch_shape, ch_inputs, eps_neg};
+    try
     {
-        try
-        {
-            auto bn = makeBatchNormOp<TypeParam>(params);
-            FAIL() << "Invalid 'epsilon' attribute value not detected";
-        }
-        catch (const NodeValidationFailure& error)
-        {
-            EXPECT_HAS_SUBSTRING(error.what(), "Attribute 'epsilon' must have non-zero positive floating-point value.");
-        }
-        catch (...)
-        {
-            FAIL() << "Positive 'epsilon' attribute value check failed for unexpected reason";
-        }
+        auto bn = makeBatchNormOp<TypeParam>(params);
+        FAIL() << "Invalid 'epsilon' attribute value not detected";
+    }
+    catch (const NodeValidationFailure& error)
+    {
+        EXPECT_HAS_SUBSTRING(error.what(), "Attribute 'epsilon' must be a floating-point value greater than or equal to zero.");
+    }
+    catch (...)
+    {
+        FAIL() << "Non-negative 'epsilon' attribute value check failed for unexpected reason";
     }
 }
 
@@ -542,4 +533,4 @@ REGISTER_TYPED_TEST_CASE_P(
     batch_norm_inference_invalid_epsilon);
 
 using Types = ::testing::Types<op::v0::BatchNormInference, op::v5::BatchNormInference>;
-INSTANTIATE_TYPED_TEST_CASE_P(type_prop, BatchNormTest, Types, );
+INSTANTIATE_TYPED_TEST_CASE_P(type_prop, BatchNormTest, Types);


### PR DESCRIPTION
Details: Enable epsilon attribute value to be zero

- Modify node validation check for epsilon attribute to allow zero value
- Modified type_prop test case for invalid (negative) epsilon value
- Add epsilon 0 test case to SLT and Serialization SLT

Ticket: 55721