### PR TITLE
Fixed MO CMakeList to remove unit_tests directory

### DIFF
--- a/model-optimizer/CMakeLists.txt
+++ b/model-optimizer/CMakeLists.txt
@@ -21,7 +21,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
         
         PATTERN "extensions/front/caffe/CustomLayersMapping.xml" EXCLUDE
         PATTERN "mo/utils/convert.py" EXCLUDE
-        PATTERN "mo/utils/unittest" EXCLUDE
+        PATTERN "unit_tests" EXCLUDE
         
         REGEX ".*__pycache__.*" EXCLUDE
         REGEX ".*\\.pyc$" EXCLUDE


### PR DESCRIPTION
### Details:
 - Updated CMakeList.txt to remove unit_tests directory from the MO package created for the installer.

### Tickets:
 - 55855
