### PR TITLE
Fix ng python ShuffleChannels group attribute

### DIFF
--- a/ngraph/python/src/ngraph/opset3/ops.py
+++ b/ngraph/python/src/ngraph/opset3/ops.py
@@ -555,7 +555,7 @@ def shape_of(data: NodeInput, output_type: str = "i64", name: Optional[str] = No
 
 
 @nameable_op
-def shuffle_channels(data: Node, axis: int, groups: int, name: Optional[str] = None) -> Node:
+def shuffle_channels(data: Node, axis: int, group: int, name: Optional[str] = None) -> Node:
     """Perform permutation on data in the channel dimension of the input tensor.
 
     @param data: The node with input tensor.
@@ -603,7 +603,7 @@ def shuffle_channels(data: Node, axis: int, groups: int, name: Optional[str] = N
     @endcode
     """
     return _get_node_factory_opset3().create(
-        "ShuffleChannels", [as_node(data)], {"axis": axis, "groups": groups}
+        "ShuffleChannels", [as_node(data)], {"axis": axis, "group": group}
     )
 
 

--- a/ngraph/python/tests/__init__.py
+++ b/ngraph/python/tests/__init__.py
@@ -53,8 +53,6 @@ xfail_issue_35925 = xfail_test(reason="Assertion error - reduction ops results m
 xfail_issue_35927 = xfail_test(reason="RuntimeError: B has zero dimension that is not allowable")
 xfail_issue_36480 = xfail_test(reason="RuntimeError: [NOT_FOUND] Unsupported property dummy_option "
                                "by CPU plugin")
-xfail_issue_36485 = xfail_test(reason="RuntimeError: Check 'm_group >= 1' failed at "
-                               "/openvino/ngraph/core/src/op/shuffle_channels.cpp:77:")
 xfail_issue_36486 = xfail_test(reason="RuntimeError: HardSigmoid operation should be converted "
                                       "to HardSigmoid_IE")
 xfail_issue_36487 = xfail_test(reason="Assertion error - mvn operator computation mismatch")

--- a/ngraph/python/tests/test_ngraph/test_ops_fused.py
+++ b/ngraph/python/tests/test_ngraph/test_ops_fused.py
@@ -6,8 +6,7 @@ import pytest
 
 import ngraph as ng
 from tests.runtime import get_runtime
-from tests import (xfail_issue_36485,
-                   xfail_issue_36486,
+from tests import (xfail_issue_36486,
                    xfail_issue_36487,
                    xfail_issue_44976)
 
@@ -276,7 +275,6 @@ def test_squared_difference_operator():
     assert np.allclose(result, expected)
 
 
-@xfail_issue_36485
 def test_shuffle_channels_operator():
     runtime = get_runtime()
 


### PR DESCRIPTION
### Details:
 - There was a mismatch between `groups` vs `group` attribute name, so op factory and attribute visitor didn't handle it correctly.
It was a root cause of the error message: 
`RuntimeError: Check 'm_group >= 1' failed at /openvino/ngraph/core/src/op/shuffle_channels.cpp:77:` 
marked as `xfail_issue_36485`


 
### Tickets:
 - 36485

