### PR TITLE
Update reshape to restore original shapes if reshape has failed

### DIFF
--- a/inference-engine/src/inference_engine/cnn_network_ngraph_impl.cpp
+++ b/inference-engine/src/inference_engine/cnn_network_ngraph_impl.cpp
@@ -325,29 +325,41 @@ void CNNNetworkNGraphImpl::reshape() {
 StatusCode
 CNNNetworkNGraphImpl::reshape(const std::map<std::string, std::vector<size_t>>& inputShapes,
                               ResponseDesc* responseDesc) noexcept {
+    const auto & params = _ngraph_function->get_parameters();
+
+    // Check that we need to do reshape only if input shapes will be changed
+    bool needReshape = false;
+    for (const auto & param : params) {
+        const auto it = inputShapes.find(param->get_friendly_name());
+        if (it == inputShapes.end()) {
+            continue;
+        }
+        if (param->get_partial_shape().is_dynamic() || param->get_shape() != it->second) {
+            needReshape = true;
+            break;
+        }
+    }
+
+    if (!needReshape) return OK;
+
+    // save original parameters shape
+    std::map<std::string, ngraph::PartialShape> originalInputShapes;
+    for (const auto & param : params) {
+        originalInputShapes[param->get_friendly_name()] = param->get_partial_shape();
+    }
+
     try {
-        auto params = _ngraph_function->get_parameters();
+        ngraph::pass::Manager ssr_manager;
+        ssr_manager.register_pass<ngraph::pass::SmartReshape>();
+        ssr_manager.run_passes(_ngraph_function);
 
-        // Check that we need to do reshape only if input shapes will be changed
-        bool needReshape = false;
-        for (size_t i = 0; i < params.size() && !inputShapes.empty(); i++) {
-            const auto& param = params[i];
-            auto it = inputShapes.find(param->get_friendly_name());
-            if (it == inputShapes.end())
-                continue;
-            if (param->get_partial_shape().is_dynamic() || param->get_shape() != it->second) {
-                needReshape = true;
-                break;
-            }
+        std::map<std::string, ngraph::PartialShape> reshapeShapes;
+        for (const auto & item : inputShapes) {
+            reshapeShapes[item.first] = ngraph::PartialShape(item.second);
         }
-        if (needReshape) {
-            ngraph::pass::Manager ssr_manager;
-            ssr_manager.register_pass<ngraph::pass::SmartReshape>();
-            ssr_manager.run_passes(_ngraph_function);
-
-            reshape(inputShapes);
-        }
+        reshape(reshapeShapes);
     } catch (std::exception& ex) {
+        reshape(originalInputShapes);
         return DescriptionBuffer(GENERAL_ERROR, responseDesc) << ex.what();
     }
 
@@ -355,7 +367,7 @@ CNNNetworkNGraphImpl::reshape(const std::map<std::string, std::vector<size_t>>& 
 }
 
 void
-CNNNetworkNGraphImpl::reshape(const std::map<std::string, std::vector<size_t>>& inputShapes) {
+CNNNetworkNGraphImpl::reshape(const std::map<std::string, ngraph::PartialShape>& inputShapes) {
     OV_ITT_SCOPED_TASK(itt::domains::IE, "CNNNetworkNGraphImpl::reshape");
 
     auto params = _ngraph_function->get_parameters();

--- a/inference-engine/src/inference_engine/cnn_network_ngraph_impl.cpp
+++ b/inference-engine/src/inference_engine/cnn_network_ngraph_impl.cpp
@@ -325,6 +325,8 @@ void CNNNetworkNGraphImpl::reshape() {
 StatusCode
 CNNNetworkNGraphImpl::reshape(const std::map<std::string, std::vector<size_t>>& inputShapes,
                               ResponseDesc* responseDesc) noexcept {
+    if (inputShapes.empty()) return OK;
+
     const auto & params = _ngraph_function->get_parameters();
 
     // Check that we need to do reshape only if input shapes will be changed

--- a/inference-engine/src/inference_engine/cnn_network_ngraph_impl.hpp
+++ b/inference-engine/src/inference_engine/cnn_network_ngraph_impl.hpp
@@ -104,7 +104,7 @@ private:
      * @brief Reshape on the same shape
      */
     void reshape();
-    void reshape(const std::map<std::string, std::vector<size_t>>& inputShapes);
+    void reshape(const std::map<std::string, ngraph::PartialShape>& inputShapes);
     void validateFunctionNames() const;
 };
 }  // namespace details

--- a/inference-engine/tests/functional/inference_engine/cnn_network/cnn_ngraph_impl_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/cnn_network/cnn_ngraph_impl_tests.cpp
@@ -42,6 +42,39 @@
 using namespace testing;
 using namespace InferenceEngine;
 
+TEST(CNNNGraphImplTests, TestInvalidReshapeNoThrow) {
+    std::shared_ptr<ngraph::Function> f;
+    {
+        auto input = std::make_shared<ngraph::opset5::Parameter>(ngraph::element::f32, ngraph::Shape{1, 1000, 4});
+        input->set_friendly_name("input");
+        auto shape = ngraph::opset5::Constant::create(ngraph::element::i64, {2}, {1, 4000});
+        auto reshape = std::make_shared<ngraph::opset5::Reshape>(input, shape, true);
+        f = std::make_shared<ngraph::Function>(ngraph::OutputVector{reshape}, ngraph::ParameterVector{input});
+    }
+
+    auto net = InferenceEngine::CNNNetwork(f);
+    ASSERT_NO_THROW(net.reshape({{"input", SizeVector({4})}}));
+}
+
+TEST(CNNNGraphImplTests, TestInvalidReshape) {
+    std::shared_ptr<ngraph::Function> f;
+    {
+        auto input = std::make_shared<ngraph::opset5::Parameter>(ngraph::element::f32, ngraph::Shape{1, 1000, 4});
+        input->set_friendly_name("input");
+        auto shape = ngraph::opset5::Constant::create(ngraph::element::i64, {2}, {1, 4000});
+        auto reshape = std::make_shared<ngraph::opset5::Reshape>(input, shape, true);
+        f = std::make_shared<ngraph::Function>(ngraph::OutputVector{reshape}, ngraph::ParameterVector{input});
+    }
+
+    auto net = InferenceEngine::CNNNetwork(f);
+    ASSERT_ANY_THROW(net.reshape({{"input", SizeVector({4})}}));
+
+    auto param = *net.getFunction()->get_parameters().begin();
+    ASSERT_EQ(param->get_output_shape(0), ngraph::Shape({1, 1000, 4}));
+
+    ASSERT_NO_THROW(net.reshape({{"input", SizeVector({1, 1000, 4})}}));
+}
+
 IE_SUPPRESS_DEPRECATED_START
 
 TEST(CNNNGraphImplTests, TestNMS5OutputNames) {

--- a/inference-engine/tests/functional/inference_engine/cnn_network/cnn_ngraph_impl_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/cnn_network/cnn_ngraph_impl_tests.cpp
@@ -42,7 +42,7 @@
 using namespace testing;
 using namespace InferenceEngine;
 
-TEST(CNNNGraphImplTests, TestInvalidReshapeNoThrow) {
+TEST(CNNNGraphImplTests, TestReshapeWithSameShape) {
     std::shared_ptr<ngraph::Function> f;
     {
         auto input = std::make_shared<ngraph::opset5::Parameter>(ngraph::element::f32, ngraph::Shape{1, 1000, 4});
@@ -53,7 +53,7 @@ TEST(CNNNGraphImplTests, TestInvalidReshapeNoThrow) {
     }
 
     auto net = InferenceEngine::CNNNetwork(f);
-    ASSERT_NO_THROW(net.reshape({{"input", SizeVector({4})}}));
+    ASSERT_NO_THROW(net.reshape({{"input", SizeVector({1, 4000})}}));
 }
 
 TEST(CNNNGraphImplTests, TestInvalidReshape) {


### PR DESCRIPTION
### Description
In cases when user calls reshape method and it fails we got invalid nGraph Function. In this PR I changed a logic in reshape method to restore original shapes if reshape has failed.

### Ticket
XXX-39136
