### PR TITLE
fix stride for 1d maxpooling

### DIFF
--- a/model-optimizer/mo/front/kaldi/extractors/max_pooling_ext.py
+++ b/model-optimizer/mo/front/kaldi/extractors/max_pooling_ext.py
@@ -36,7 +36,7 @@ class MaxPoolingComponentFrontExtractor(FrontExtractorOp):
 
         mapping_rule = {
             'window': np.array([1, 1, 1, kernel], dtype=np.int64),
-            'stride': np.array([1, 1, stride, stride], dtype=np.int64),
+            'stride': np.array([1, 1, 1, stride], dtype=np.int64),
             'pool_stride': pool_stride,
             'pool_step': pool_step,
             'pad': np.array([[0, 0], [0, 0], [0, 0], [0, 0]], dtype=np.int64),

--- a/model-optimizer/unit_tests/mo/front/kaldi/extractors/max_pooling_ext_test.py
+++ b/model-optimizer/unit_tests/mo/front/kaldi/extractors/max_pooling_ext_test.py
@@ -27,7 +27,7 @@ class MaxPoolingComponentFrontExtractorTest(KaldiFrontExtractorTest):
     def test_attrs(self):
         val_attrs = {
             'window': [1, 1, 1, 2],
-            'stride': [1, 1, 2, 2],
+            'stride': [1, 1, 1, 2],
             'pool_stride': 4,
             'pad': [[[0, 0], [0, 0], [0, 0], [0, 0]]]
         }


### PR DESCRIPTION
Root cause analysis: For 1D maxpooling in Kladi we set 1d kernel but 2d stride

Solution: set 1d stride

Ticket: 54749


Code:
* [x]  Comments N/A
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR N/A
* [x]  Transformation preserves original framework node names N/A


Validation:
* [x]  Unit tests N/A
* [x]  Framework operation tests N/A
* [x]  Transformation tests N/A
* [x]  Model Optimizer IR Reader check N/A

Documentation:
* [x]  Supported frameworks operations list N/A
* [x]  Guide on how to convert the **public** model N/A
* [x]  User guide update N/A