### PR TITLE
Turn on IE and NG python APIs by default inside Model Optimizer

### DIFF
--- a/.github/workflows/mo.yml
+++ b/.github/workflows/mo.yml
@@ -62,42 +62,4 @@ jobs:
           mkdir ../mo-ut-logs
           python3 -m xmlrunner discover -p *_test.py --output=../mo-ut-logs
         working-directory: model-optimizer
-  
-  build_wheel:
-    name: Build Python wheel
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v2
 
-      - name: Install dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install wheel setuptools
-          python3 -m pip install tensorflow==2.3.0
-      
-      - name: Build
-        run: |
-          python3 setup.py sdist bdist_wheel
-        working-directory: model-optimizer
-      
-      - name: Test package content
-        run: |
-          echo "src = open('openvino_mo.egg-info/SOURCES.txt', 'rt').read().split()" | tee -a test_wheel.py
-          echo "ref = open('automation/package_BOM.txt', 'rt').read().split()"       | tee -a test_wheel.py
-          echo "for name in ref:"                                                    | tee -a test_wheel.py
-          echo "  if name.endswith('.py'):"                                          | tee -a test_wheel.py
-          echo "    assert name in src or './' + name in src, name + ' file missed'" | tee -a test_wheel.py
-          python3 test_wheel.py
-        working-directory: model-optimizer
-
-      - name: Test conversion
-        run: |
-          wget -q http://download.tensorflow.org/models/mobilenet_v1_2018_08_02/mobilenet_v1_1.0_224.tgz
-          tar -xf mobilenet_v1_1.0_224.tgz
-          python3 -m pip install model-optimizer/dist/*.whl
-          python3 -m mo --input_model mobilenet_v1_1.0_224_frozen.pb --input_shape "[1,224,224,3]"
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: mo_wheel
-          path: "model-optimizer/dist/*.whl"

--- a/inference-engine/ie_bridges/python/CMakeLists.txt
+++ b/inference-engine/ie_bridges/python/CMakeLists.txt
@@ -68,6 +68,10 @@ if(ENABLE_WHEEL)
     add_subdirectory(wheel)
 endif()
 
+if (NGRAPH_PYTHON_BUILD_ENABLE)
+    add_dependencies(ie_api _pyngraph)
+endif()
+
 # install
 
 ie_cpack_add_component(${PYTHON_VERSION})

--- a/model-optimizer/CMakeLists.txt
+++ b/model-optimizer/CMakeLists.txt
@@ -1,6 +1,14 @@
 # Copyright (C) 2018-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+if (NOT NGRAPH_PYTHON_BUILD_ENABLE)
+    message(WARNING "Please enable nGraph Python API (_pyngraph) target to enable Model Optimizer target")
+elseif(NOT ENABLE_PYTHON)
+    message(WARNING "Please enable IE Python API (ie_api and offline_transformations_api) targets to enable Model Optimizer target")
+else()
+    add_custom_target(model_optimizer DEPENDS ie_api offline_transformations_api inference_engine_ir_reader)
+endif()
+
 # install
 ie_cpack_add_component(model_optimizer)
 

--- a/model-optimizer/mo/utils/check_ie_bindings.py
+++ b/model-optimizer/mo/utils/check_ie_bindings.py
@@ -52,7 +52,7 @@ def import_core_modules(silent: bool, path_to_module: str):
             GenerateMappingFile  # pylint: disable=import-error,no-name-in-module
 
         # TODO: it is temporary import to check that nGraph python API is available. But in future
-        # we need to replace it with Frontedn imports
+        # we need to replace it with Frontend imports
         from ngraph.impl.op import Parameter  # pylint: disable=import-error,no-name-in-module
         from _pyngraph import PartialShape, Dimension  # pylint: disable=import-error,no-name-in-module
 
@@ -66,7 +66,7 @@ def import_core_modules(silent: bool, path_to_module: str):
         mo_version = str(v.get_version())  # pylint: disable=no-member,no-name-in-module
 
         print("\t- {}: \t{}".format("Inference Engine found in", os.path.dirname(openvino.__file__)))
-        # TODO: when nGraph version will be available we need to start compare it to IE and MO versions
+        # TODO: when nGraph version will be available we need to start compare it to IE and MO versions. Ticket: 58091
         print("\t- {}: \t{}".format("nGraph found in", os.path.dirname(ngraph.__file__)))
         print("{}: \t{}".format("Inference Engine version", ie_version))
         print("{}: \t{}".format("Model Optimizer version", mo_version))

--- a/model-optimizer/mo/utils/check_ie_bindings.py
+++ b/model-optimizer/mo/utils/check_ie_bindings.py
@@ -51,7 +51,13 @@ def import_core_modules(silent: bool, path_to_module: str):
         from openvino.offline_transformations import ApplyMOCTransformations, ApplyLowLatencyTransformation, \
             GenerateMappingFile  # pylint: disable=import-error,no-name-in-module
 
+        # TODO: it is temporary import to check that nGraph python API is available. But in future
+        # we need to replace it with Frontedn imports
+        from ngraph.impl.op import Parameter  # pylint: disable=import-error,no-name-in-module
+        from _pyngraph import PartialShape, Dimension  # pylint: disable=import-error,no-name-in-module
+
         import openvino  # pylint: disable=import-error,no-name-in-module
+        import ngraph  # pylint: disable=import-error,no-name-in-module
 
         if silent:
             return True
@@ -60,6 +66,8 @@ def import_core_modules(silent: bool, path_to_module: str):
         mo_version = str(v.get_version())  # pylint: disable=no-member,no-name-in-module
 
         print("\t- {}: \t{}".format("Inference Engine found in", os.path.dirname(openvino.__file__)))
+        # TODO: when nGraph version will be available we need to start compare it to IE and MO versions
+        print("\t- {}: \t{}".format("nGraph found in", os.path.dirname(ngraph.__file__)))
         print("{}: \t{}".format("Inference Engine version", ie_version))
         print("{}: \t{}".format("Model Optimizer version", mo_version))
 

--- a/model-optimizer/mo/utils/cli_parser.py
+++ b/model-optimizer/mo/utils/cli_parser.py
@@ -1221,7 +1221,6 @@ def check_available_transforms(transforms: list):
     """
     This function check that transformations specified by user are available.
     :param transforms: list of user specified transformations
-    :param ie_is_available: True if IE Python API is available and False if it is not
     :return: raises an Error if transformation is not available
     """
     from mo.back.offline_transformations import get_available_transformations

--- a/model-optimizer/mo/utils/cli_parser.py
+++ b/model-optimizer/mo/utils/cli_parser.py
@@ -1217,17 +1217,13 @@ def parse_transform(transform: str) -> list:
     return transforms
 
 
-def check_available_transforms(transforms: list, ie_is_available: bool):
+def check_available_transforms(transforms: list):
     """
     This function check that transformations specified by user are available.
     :param transforms: list of user specified transformations
     :param ie_is_available: True if IE Python API is available and False if it is not
-    :return: raises an Error if IE or transformation is not available
+    :return: raises an Error if transformation is not available
     """
-    if not ie_is_available and len(transforms) != 0:
-        raise Error('Can not apply {} transformations due to missing Inference Engine Python API'.format(
-            ','.join([name for name, _ in transforms])))
-
     from mo.back.offline_transformations import get_available_transformations
     available_transforms = get_available_transformations()
 

--- a/model-optimizer/unit_tests/mo/utils/cli_parser_test.py
+++ b/model-optimizer/unit_tests/mo/utils/cli_parser_test.py
@@ -959,11 +959,11 @@ class TransformChecker(unittest.TestCase):
     def test_check_low_latency_is_available(self, available_transformations):
         available_transformations.return_value = {"LowLatency2": None}
         try:
-            check_available_transforms([("LowLatency2", "")], True)
+            check_available_transforms([("LowLatency2", "")])
         except Error as e:
             self.assertTrue(False, "Exception \"{}\" is unexpected".format(e))
 
     @patch("mo.back.offline_transformations.get_available_transformations")
     def test_check_dummy_pass_is_available(self, available_transformations):
         available_transformations.return_value = {"LowLatency2": None}
-        self.assertRaises(Error, check_available_transforms, [("DummyPass", "")], True)
+        self.assertRaises(Error, check_available_transforms, [("DummyPass", "")])


### PR DESCRIPTION
### Description
In this PR I finally enable IE/NG python API dependency inside Model Optimizer. This is a prerequisite for nGraph transformations execution inside Model Optimizer backend which is targeted for the 22.1 release.

* "Build Python wheel" test was removed as it became obsolete after we published openvino-dev package. This change is aligned with @dkurt and we agreed that new tests for MO packaging will be implemented as a part of openvino-dev package validation.
* Added `_pyngraph` dependency to the ie_api target to simplify python APIs building process.
* Model Optimizer was updated to require IE and NG python APIs as a strong dependencies. And now it throws an exception if one of APIs is missing.
* Model Optimizer fallback path (which was used to produce an IR when IE wasn't available) was removed.
* Validation was made on multiple internal CIs. As a result some of them were updated to build NG python API. Now everything works fine.
* New model_optimizer custom target was added to simplify local build for Model Optimizer execution.
### Ticket
XXX-56031