### PR TITLE
[IE PYTHON] FIX InputInfoCPtr, DataPtr and CDataPtr deallocation

### DIFF
--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pxd
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pxd
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .cimport ie_api_impl_defs as C
-from .ie_api_impl_defs cimport CBlob, CTensorDesc, InputInfo, CPreProcessChannel, CPreProcessInfo
+from .ie_api_impl_defs cimport CBlob, CTensorDesc, InputInfo, CPreProcessChannel, CPreProcessInfo, CExecutableNetwork
 
 import os
 
@@ -43,6 +43,7 @@ cdef class InferRequest:
 
 cdef class IENetwork:
     cdef C.IENetwork impl
+    cdef shared_ptr[CExecutableNetwork] _ptr_plugin
 
 cdef class ExecutableNetwork:
     cdef unique_ptr[C.IEExecNetwork] impl
@@ -64,9 +65,11 @@ cdef class IECore:
 cdef class DataPtr:
     cdef C.DataPtr _ptr
     cdef C.IENetwork * _ptr_network
+    cdef shared_ptr[CExecutableNetwork] _ptr_plugin
 
 cdef class CDataPtr:
     cdef C.CDataPtr _ptr
+    cdef shared_ptr[CExecutableNetwork] _ptr_plugin
 
 cdef class TensorDesc:
     cdef C.CTensorDesc impl
@@ -77,6 +80,7 @@ cdef class InputInfoPtr:
 
 cdef class InputInfoCPtr:
     cdef InputInfo.CPtr _ptr
+    cdef shared_ptr[CExecutableNetwork] _ptr_plugin
 
 cdef class PreProcessInfo:
     cdef CPreProcessInfo* _ptr

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pyx
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pyx
@@ -751,6 +751,7 @@ cdef class InputInfoCPtr:
         cdef C.DataPtr c_data_ptr = deref(self._ptr).getInputData()
         data_ptr = DataPtr()
         data_ptr._ptr = c_data_ptr
+        data_ptr._ptr_plugin = self._ptr_plugin
         return data_ptr
 
     ## tensor_desc of this input
@@ -918,6 +919,7 @@ cdef class ExecutableNetwork:
         for in_ in c_inputs:
             input_info_ptr = InputInfoCPtr()
             input_info_ptr._ptr = in_.second
+            input_info_ptr._ptr_plugin = deref(self.impl).getPluginLink()
             inputs[in_.first.decode()] = input_info_ptr
         return inputs
 
@@ -937,6 +939,7 @@ cdef class ExecutableNetwork:
         for in_ in c_inputs:
             data_ptr = DataPtr()
             data_ptr._ptr = in_.second
+            data_ptr._ptr_plugin = deref(self.impl).getPluginLink()
             inputs[in_.first.decode()] = data_ptr
         return inputs
 
@@ -949,6 +952,7 @@ cdef class ExecutableNetwork:
         for in_ in c_outputs:
             data_ptr = CDataPtr()
             data_ptr._ptr = in_.second
+            data_ptr._ptr_plugin = deref(self.impl).getPluginLink()
             outputs[in_.first.decode()] = data_ptr
         return outputs
 
@@ -965,6 +969,7 @@ cdef class ExecutableNetwork:
     def get_exec_graph_info(self):
         ie_network = IENetwork()
         ie_network.impl = deref(self.impl).GetExecGraphInfo()
+        ie_network._ptr_plugin = deref(self.impl).getPluginLink()
         return ie_network
 
     ## Gets general runtime metric for an executable network. It can be network name, actual device ID on

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.hpp
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.hpp
@@ -134,8 +134,9 @@ struct InferRequestWrap {
     std::vector<InferenceEnginePython::CVariableState> queryState();
 };
 
+
 struct IEExecNetwork {
-    InferenceEngine::ExecutableNetwork actual;
+    std::shared_ptr<InferenceEngine::ExecutableNetwork> actual;
     std::vector<InferRequestWrap> infer_requests;
     std::string name;
     IdleInferRequestQueue::Ptr request_queue_ptr;
@@ -158,6 +159,9 @@ struct IEExecNetwork {
     int getIdleRequestId();
 
     void createInferRequests(int num_requests);
+
+    //binds plugin to InputInfo and Data, so that they can be destroyed before plugin (ussue 28996)
+    std::shared_ptr<InferenceEngine::ExecutableNetwork> getPluginLink();
 };
 
 struct IECore {

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl_defs.pxd
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl_defs.pxd
@@ -13,6 +13,8 @@ from libc.stdint cimport int64_t, uint8_t
 cdef extern from "<inference_engine.hpp>" namespace "InferenceEngine":
     ctypedef vector[size_t] SizeVector
 
+    cdef cppclass CExecutableNetwork "InferenceEngine::ExecutableNetwork"
+    
     cdef cppclass TBlob[T]:
         ctypedef shared_ptr[TBlob[T]] Ptr
 
@@ -160,6 +162,7 @@ cdef extern from "ie_api_impl.hpp" namespace "InferenceEnginePython":
         object getConfig(const string & metric_name) except +
         int wait(int num_requests, int64_t timeout)
         int getIdleRequestId()
+        shared_ptr[CExecutableNetwork] getPluginLink() except +
 
     cdef cppclass IENetwork:
         IENetwork() except +

--- a/inference-engine/ie_bridges/python/tests/test_ExecutableNetwork.py
+++ b/inference-engine/ie_bridges/python/tests/test_ExecutableNetwork.py
@@ -330,6 +330,9 @@ def test_outputs_deallocation(device):
 
 def test_exec_graph_info_deallocation(device):
     ie_core = ie.IECore()
+    if device == "CPU":
+        if ie_core.get_metric(device, "FULL_DEVICE_NAME") == "arm_compute::NEON":
+            pytest.skip("Can't run on ARM plugin due-to get_exec_graph_info method isn't implemented")
     net = ie_core.read_network(model=test_net_xml, weights=test_net_bin)
     exec_net = ie_core.load_network(net, device)
     exec_graph_info = exec_net.get_exec_graph_info()

--- a/inference-engine/ie_bridges/python/tests/test_ExecutableNetwork.py
+++ b/inference-engine/ie_bridges/python/tests/test_ExecutableNetwork.py
@@ -304,3 +304,35 @@ def test_get_config(device):
     exec_net = ie_core.load_network(net, device)
     config = exec_net.get_config("PERF_COUNT")
     assert config == "NO"
+
+
+# issue 28996
+# checks that objects can deallocate in this order, if not - segfault happends
+def test_input_info_deallocation(device):
+    ie_core = ie.IECore()
+    net = ie_core.read_network(model=test_net_xml, weights=test_net_bin)
+    exec_net = ie_core.load_network(net, device)
+    input_info = exec_net.input_info["data"]
+    del ie_core
+    del exec_net
+    del input_info
+
+
+def test_outputs_deallocation(device):
+    ie_core = ie.IECore()
+    net = ie_core.read_network(model=test_net_xml, weights=test_net_bin)
+    exec_net = ie_core.load_network(net, device)
+    output = exec_net.outputs["fc_out"]
+    del ie_core
+    del exec_net
+    del output
+
+
+def test_exec_graph_info_deallocation(device):
+    ie_core = ie.IECore()
+    net = ie_core.read_network(model=test_net_xml, weights=test_net_bin)
+    exec_net = ie_core.load_network(net, device)
+    exec_graph_info = exec_net.get_exec_graph_info()
+    del ie_core
+    del exec_net
+    del exec_graph_info

--- a/inference-engine/ie_bridges/python/tests/test_InputInfoCPtr.py
+++ b/inference-engine/ie_bridges/python/tests/test_InputInfoCPtr.py
@@ -16,6 +16,7 @@ def test_name(device):
     exec_net = ie.load_network(net, device, num_requests=5)
     assert isinstance(exec_net.input_info['data'], InputInfoCPtr)
     assert exec_net.input_info['data'].name == "data", "Incorrect name"
+    del ie
     del exec_net
 
 
@@ -25,6 +26,7 @@ def test_precision(device):
     exec_net = ie.load_network(net, device, num_requests=5)
     assert isinstance(exec_net.input_info['data'], InputInfoCPtr)
     assert exec_net.input_info['data'].precision == "FP32", "Incorrect precision"
+    del ie
     del exec_net
 
 
@@ -36,6 +38,7 @@ def test_no_precision_setter(device):
         exec_net.input_info['data'].precision = "I8"
     assert "attribute 'precision' of 'openvino.inference_engine.ie_api.InputInfoCPtr' " \
            "objects is not writable" in str(e.value)
+    del ie
     del exec_net
 
 
@@ -45,7 +48,22 @@ def test_input_data(device):
     exec_net = ie.load_network(net, device, num_requests=5)
     assert isinstance(exec_net.input_info['data'], InputInfoCPtr)
     assert isinstance(exec_net.input_info['data'].input_data, DataPtr), "Incorrect precision for layer 'fc_out'"
+    del ie
     del exec_net
+
+
+# issue 28996
+# checks that objects can deallocate in this order, if not - segfault happends
+def test_input_data_deallocation(device):
+    ie = IECore()
+    net = ie.read_network(model=test_net_xml, weights=test_net_bin)
+    exec_net = ie.load_network(net, device)
+    input_info = exec_net.input_info['data']
+    input_data = input_info.input_data
+    del ie
+    del exec_net
+    del input_info
+    del input_data
 
 
 def test_tensor_desc(device):


### PR DESCRIPTION
### Details:
 - *InputInfo and Data created in the Plugin should deallocate before deleting the Plugin*
 - *A shared pointer to the ExecutableNetwork that holds the plugin is bound to InputInfoCPtr, DataPtr and CDataPtr*

### Tickets:
 - *28996*
