### PR TITLE
Dynamic shape propagation for Pad

### DIFF
--- a/ngraph/core/src/op/pad.cpp
+++ b/ngraph/core/src/op/pad.cpp
@@ -152,26 +152,21 @@ void op::v1::Pad::validate_and_infer_types()
         std::vector<Dimension> result_dims(implied_rank, Dimension::dynamic());
         for (size_t i = 0; i < implied_rank; i++)
         {
-            if (arg_shape[i].is_static())
+            result_dims[i] = arg_shape[i] + pads_begin_coord[i] + pads_end_coord[i];
+            if (i > 1)
             {
-                ptrdiff_t result_dim =
-                    pads_begin_coord[i] + arg_shape[i].get_length() + pads_end_coord[i];
-                result_dims[i] = static_cast<size_t>(result_dim);
-                if (i > 1)
-                {
-                    NODE_VALIDATION_CHECK(this,
-                                          m_pad_mode != op::PadMode::EDGE ||
-                                              arg_shape[i].get_length() >= 1,
-                                          "EDGE padding mode requires an input of dimension of "
-                                          "at least 1 at each "
-                                          "spatial axis.");
-                    NODE_VALIDATION_CHECK(this,
-                                          m_pad_mode != op::PadMode::REFLECT ||
-                                              arg_shape[i].get_length() >= 2,
-                                          "REFLECT padding mode requires an input of dimension "
-                                          "of at least 2 at each "
-                                          "spatial axis.");
-                }
+                NODE_VALIDATION_CHECK(this,
+                                      m_pad_mode != op::PadMode::EDGE || arg_shape[i].is_dynamic() ||
+                                          arg_shape[i].get_length() >= 1,
+                                      "EDGE padding mode requires an input of dimension of "
+                                      "at least 1 at each "
+                                      "spatial axis.");
+                NODE_VALIDATION_CHECK(this,
+                                      m_pad_mode != op::PadMode::REFLECT || arg_shape[i].is_dynamic() ||
+                                          arg_shape[i].get_length() >= 2,
+                                      "REFLECT padding mode requires an input of dimension "
+                                      "of at least 2 at each "
+                                      "spatial axis.");
             }
         }
         set_output_type(0, get_input_element_type(0), result_dims);

--- a/ngraph/core/src/op/pad.cpp
+++ b/ngraph/core/src/op/pad.cpp
@@ -156,13 +156,15 @@ void op::v1::Pad::validate_and_infer_types()
             if (i > 1)
             {
                 NODE_VALIDATION_CHECK(this,
-                                      m_pad_mode != op::PadMode::EDGE || arg_shape[i].is_dynamic() ||
+                                      m_pad_mode != op::PadMode::EDGE ||
+                                          arg_shape[i].is_dynamic() ||
                                           arg_shape[i].get_length() >= 1,
                                       "EDGE padding mode requires an input of dimension of "
                                       "at least 1 at each "
                                       "spatial axis.");
                 NODE_VALIDATION_CHECK(this,
-                                      m_pad_mode != op::PadMode::REFLECT || arg_shape[i].is_dynamic() ||
+                                      m_pad_mode != op::PadMode::REFLECT ||
+                                          arg_shape[i].is_dynamic() ||
                                           arg_shape[i].get_length() >= 2,
                                       "REFLECT padding mode requires an input of dimension "
                                       "of at least 2 at each "

--- a/ngraph/test/type_prop/pad.cpp
+++ b/ngraph/test/type_prop/pad.cpp
@@ -293,3 +293,15 @@ TEST(type_prop, pad_v1_dynamic_output_with_static_rank)
         make_shared<op::v1::Pad>(arg, pads_begin, pads_end, arg_pad_value, op::PadMode::CONSTANT);
     ASSERT_EQ(pad->get_output_partial_shape(0), PartialShape::dynamic(3));
 }
+
+TEST(type_prop, pad_v1_interval_input_with_constant_begin_end)
+{
+    auto arg = make_shared<op::Parameter>(element::f32, PartialShape{{0, 1}, {0, 151}, -1, -1, 0});
+    auto pads_begin = op::Constant::create(element::i32, Shape{5}, {5, 7, 9, 11, 0});
+    auto pads_end = op::Constant::create(element::i64, Shape{5}, {3, 2, 1, 0, 0});
+    auto arg_pad_value = op::Constant::create(element::f32, Shape{}, {0});
+
+    auto pad =
+        make_shared<op::v1::Pad>(arg, pads_begin, pads_end, arg_pad_value, op::PadMode::CONSTANT);
+    ASSERT_EQ(pad->get_output_partial_shape(0), PartialShape({Dimension(8, 9), Dimension(9, 160), Dimension(10, -1), Dimension(11, -1), 0}));
+}


### PR DESCRIPTION
### Details:
 - *fixed dynamic shape propagation for [opset1::Pad](https://github.com/openvinotoolkit/openvino/blob/master/docs/ops/movement/Pad_1.md) operation*

### Tickets:
 - *56176*
