### PR TITLE
Dynamic shape propagation for StridedSlice

### DIFF
--- a/ngraph/core/src/op/strided_slice.cpp
+++ b/ngraph/core/src/op/strided_slice.cpp
@@ -185,6 +185,10 @@ void op::v1::StridedSlice::validate_and_infer_types()
     auto end_const = get_constant_from_source(input_value(2));
     auto strides = get_constant_from_source(input_value(3));
 
+    const auto& new_axis_axis_set = convert_mask_to_axis_set(get_new_axis_mask());
+    const auto& shrink_axis_axis_set = convert_mask_to_axis_set(get_shrink_axis_mask());
+    const auto& ellipsis_axis_set = convert_mask_to_axis_set(get_ellipsis_mask());
+
     if (begin_const && end_const && strides)
     {
         const auto& input_pshape = get_input_partial_shape(0);
@@ -195,9 +199,6 @@ void op::v1::StridedSlice::validate_and_infer_types()
 
         const auto& begin_axis_set = convert_mask_to_axis_set(get_begin_mask());
         const auto& end_axis_set = convert_mask_to_axis_set(get_end_mask());
-        const auto& new_axis_axis_set = convert_mask_to_axis_set(get_new_axis_mask());
-        const auto& shrink_axis_axis_set = convert_mask_to_axis_set(get_shrink_axis_mask());
-        const auto& ellipsis_axis_set = convert_mask_to_axis_set(get_ellipsis_mask());
 
         PartialShape output_pshape;
         if (input_pshape.is_static())
@@ -213,44 +214,56 @@ void op::v1::StridedSlice::validate_and_infer_types()
                                               ellipsis_axis_set);
         else
         {
-            PartialShape lower_output_pshape, upper_output_pshape;
-            auto lower_input_pshape = PartialShape::dynamic(input_pshape.rank()),
-                 upper_input_pshape = PartialShape::dynamic(input_pshape.rank());
+            // output shape dimensions of ss operation depend monotonically on the input shape
+            // dimensions: the larger the input dimensions the larger the output dimensions in order
+            // to use existing shape infer function of strided slice we split each dimension into
+            // lower and upper ones and put them into lower input shape and upper input shape
+            // correspondingly Example: data_shape = {{5, 9}, {0, 3}, -1, 5}, lower_shape = {5, 0,
+            // 0, 5}, upper_shape = {9, 3, max_int64, 5} With that we calculate two output shapes as
+            // if there were two strided slices but with different input shapes and combine them
+            // into one resulting output shape
+
+            auto lower_in_shape = PartialShape::dynamic(input_pshape.rank()),
+                 upper_in_shape = PartialShape::dynamic(input_pshape.rank());
             for (auto i = 0; i < data_rank.get_length(); ++i)
             {
-                lower_input_pshape[i] = input_pshape[i].get_min_length();
-                upper_input_pshape[i] = input_pshape[i].get_max_length();
+                lower_in_shape[i] = input_pshape[i].get_min_length();
+                upper_in_shape[i] = input_pshape[i].get_max_length();
             }
 
-            lower_output_pshape = infer_slice_shape(this,
-                                                    lower_input_pshape,
-                                                    begin_vector,
-                                                    end_vector,
-                                                    strides_vector,
-                                                    begin_axis_set,
-                                                    end_axis_set,
-                                                    new_axis_axis_set,
-                                                    shrink_axis_axis_set,
-                                                    ellipsis_axis_set);
+            auto lower_out_shape = infer_slice_shape(this,
+                                                     lower_in_shape,
+                                                     begin_vector,
+                                                     end_vector,
+                                                     strides_vector,
+                                                     begin_axis_set,
+                                                     end_axis_set,
+                                                     new_axis_axis_set,
+                                                     shrink_axis_axis_set,
+                                                     ellipsis_axis_set);
 
-            upper_output_pshape = infer_slice_shape(this,
-                                                    upper_input_pshape,
-                                                    begin_vector,
-                                                    end_vector,
-                                                    strides_vector,
-                                                    begin_axis_set,
-                                                    end_axis_set,
-                                                    new_axis_axis_set,
-                                                    shrink_axis_axis_set,
-                                                    ellipsis_axis_set);
+            auto upper_out_shape = infer_slice_shape(this,
+                                                     upper_in_shape,
+                                                     begin_vector,
+                                                     end_vector,
+                                                     strides_vector,
+                                                     begin_axis_set,
+                                                     end_axis_set,
+                                                     new_axis_axis_set,
+                                                     shrink_axis_axis_set,
+                                                     ellipsis_axis_set);
+            NODE_VALIDATION_CHECK(this,
+                                  lower_out_shape.rank().is_static() &&
+                                      upper_out_shape.rank().is_static() &&
+                                      lower_out_shape.rank() == upper_out_shape.rank());
 
-            output_pshape = PartialShape::dynamic(lower_input_pshape.rank());
-            for (auto i = 0; i < lower_input_pshape.rank().get_length(); ++i)
+            output_pshape = PartialShape::dynamic(lower_in_shape.rank());
+            for (auto i = 0; i < lower_out_shape.rank().get_length(); ++i)
             {
-                Dimension::value_type minimum =
-                    lower_output_pshape[i].is_static() ? lower_output_pshape[i].get_length() : -1;
-                Dimension::value_type maximum =
-                    upper_output_pshape[i].is_static() ? upper_output_pshape[i].get_length() : -1;
+                auto minimum =
+                    lower_out_shape[i].is_static() ? lower_out_shape[i].get_length() : -1;
+                auto maximum =
+                    upper_out_shape[i].is_static() ? upper_out_shape[i].get_length() : -1;
                 output_pshape[i] = {minimum, maximum};
             }
         }
@@ -258,8 +271,10 @@ void op::v1::StridedSlice::validate_and_infer_types()
     }
     else
     {
-        // TODO: this isn't right -- because shrink/new_axis masks
-        set_output_type(0, get_input_element_type(0), PartialShape::dynamic(data_rank));
+        if (new_axis_axis_set.empty() && shrink_axis_axis_set.empty() && ellipsis_axis_set.empty())
+            set_output_type(0, get_input_element_type(0), PartialShape::dynamic(data_rank));
+        else
+            set_output_type(0, get_input_element_type(0), PartialShape::dynamic());
     }
 }
 

--- a/ngraph/test/type_prop/strided_slice.cpp
+++ b/ngraph/test/type_prop/strided_slice.cpp
@@ -193,3 +193,20 @@ TEST(type_prop, strided_slice_reverse_out_of_bounds)
     Shape expected{3, 4, 5};
     EXPECT_EQ(ss->get_output_shape(0), expected);
 }
+
+TEST(type_prop, strided_slice_dynamic_shape)
+{
+    auto data = std::make_shared<op::Parameter>(ngraph::element::f32, ngraph::PartialShape{{0, 1}, 64, -1, -1});
+    auto begin = op::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {0});
+    auto end = op::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {1});
+    auto stride = op::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {1});
+
+    std::vector<int64_t> begin_mask = {0, 0, 0, 0};
+    std::vector<int64_t> end_mask = {0, 0, 0, 0};
+
+    auto ss =
+        std::make_shared<op::v1::StridedSlice>(data, begin, end, stride, begin_mask, end_mask);
+
+    PartialShape expected{{0, 1}, 1, -1, -1};
+    EXPECT_EQ(ss->get_output_partial_shape(0), expected);
+}

--- a/ngraph/test/type_prop/strided_slice.cpp
+++ b/ngraph/test/type_prop/strided_slice.cpp
@@ -210,3 +210,22 @@ TEST(type_prop, strided_slice_dynamic_shape)
     PartialShape expected{{0, 1}, 1, -1, -1};
     EXPECT_EQ(ss->get_output_partial_shape(0), expected);
 }
+
+TEST(type_prop, strided_slice_dynamic_shape_shrink_and_new_axis)
+{
+    auto data = std::make_shared<op::Parameter>(ngraph::element::f32, ngraph::PartialShape{{0, 1}, 64, -1, -1});
+    auto begin = op::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {0});
+    auto end = op::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {1});
+    auto stride = op::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {1});
+
+    std::vector<int64_t> begin_mask = {0, 0, 0, 0};
+    std::vector<int64_t> end_mask = {0, 0, 0, 0};
+    std::vector<int64_t> new_axis_mask = {0, 0, 0, 1};
+    std::vector<int64_t> shrink_axis_mask = {0, 1, 0, 0};
+
+    auto ss =
+        std::make_shared<op::v1::StridedSlice>(data, begin, end, stride, begin_mask, end_mask, new_axis_mask, shrink_axis_mask);
+
+    PartialShape expected{{0, 1}, -1, 1, -1};
+    EXPECT_EQ(ss->get_output_partial_shape(0), expected);
+}


### PR DESCRIPTION
### Details:
 - *fixed dynamic shape propagation for [opset1::StridedSlice](https://github.com/openvinotoolkit/openvino/blob/master/docs/ops/movement/StridedSlice_1.md) operation*


### Tickets:
 - *56170*
