### PR TITLE
[IE][VPU]: Write info about booted device only on success

### DIFF
--- a/inference-engine/thirdparty/movidius/mvnc/src/mvnc_api.c
+++ b/inference-engine/thirdparty/movidius/mvnc/src/mvnc_api.c
@@ -993,9 +993,6 @@ ncStatus_t ncDeviceOpen(struct ncDeviceHandle_t **deviceHandlePtr,
                 continue;
             }
 
-            d->protocol_booted = d->protocol;
-            d->dev_addr_booted = mvnc_strdup(foundBootedDevice.name);
-
             handler->protocol = foundBootedDevice.protocol;
             handler->devicePath = (char *) foundBootedDevice.name;
 
@@ -1005,6 +1002,8 @@ ncStatus_t ncDeviceOpen(struct ncDeviceHandle_t **deviceHandlePtr,
             }
 
             if(found_new_booted_device && isDeviceConnected) {
+                d->protocol_booted = d->protocol;
+                d->dev_addr_booted = mvnc_strdup(foundBootedDevice.name);
                 break;
             }
 


### PR DESCRIPTION
### Details:
 - Copy a string with an address of the booted device only when the device has been successfully been booted. Otherwise, we should free allocated by `strdup` memory or we will get a memory leak.

### Tickets:
 - 55626
