### PR TITLE
Failed conversion from ONNX to IR

### DIFF
--- a/model-optimizer/mo/back/ie_ir_ver_2/emitter.py
+++ b/model-optimizer/mo/back/ie_ir_ver_2/emitter.py
@@ -227,7 +227,7 @@ def serialize_element(
         if value is not None:
             element.set(key, str(value))
     serialize_node_attributes(graph, node, subelements, element, edges, unsupported)
-    if len(element.attrib) == 0 and len(element.getchildren()) == 0:
+    if len(element.attrib) == 0 and len(list(element)) == 0:
         parent_element.remove(element)
 
 


### PR DESCRIPTION
Root cause analysis: According to https://phabricator.wikimedia.org/T213814, the method `xml.etree.ElementTree.Element.getchildren()` is deprecated from Python 3.2 and has been removed in Python 3.9. As a result, we have failure of conversion of some ONNX models, if the Python version is greater or equal than 3.9.

Solution: Replace `element.getchildren()` with `list(element)` in the file `model-optimizer\mo\back\ie_ir_ver_2\emitter.py`.

Ticket: 55705

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR: N/A because there are no new transformations
* [x]  Transformation preserves original framework node names: N/A because there are no new transformations


Validation:
* [x]  Unit tests: N/A
* [x]  Framework operation tests: N/A - No new enabled operations;
* [x]  Transformation tests: N/A - No new implemented transformations;
* [x]  Model Optimizer IR Reader check: N/A

Documentation:
* [x]  Supported frameworks operations list: N/A - No new supported operations;
* [x]  Supported **public** models list: N/A - Nothing to add;
* [x]  User guide update: N/A - Nothing to update.