### PR TITLE
Fixed AlignedBuffer destructor

### DIFF
--- a/ngraph/core/include/ngraph/runtime/aligned_buffer.hpp
+++ b/ngraph/core/include/ngraph/runtime/aligned_buffer.hpp
@@ -25,7 +25,7 @@ namespace ngraph
             AlignedBuffer(size_t byte_size, size_t alignment = 64);
 
             AlignedBuffer();
-            ~AlignedBuffer();
+            virtual ~AlignedBuffer();
 
             AlignedBuffer(AlignedBuffer&& other);
             AlignedBuffer& operator=(AlignedBuffer&& other);


### PR DESCRIPTION
### Details:
 - AlignedBuffer doesn't have virtual destructor

### Tickets:
 - NA
