### PR TITLE
[GNA] Fix identity insertion into LSTMCell

### DIFF
--- a/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.cpp
+++ b/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.cpp
@@ -1680,13 +1680,8 @@ void InsertIdentityToLSTMCellPass::run() {
                 for (auto& input : input_to) {
                     auto& next_layer = input.second;
                     activationInputTo[input.first] = next_layer;
-                    for (int i = next_layer->insData.size() -1; i>= 0; i--) {
-                        auto ins = next_layer->insData[i].lock();
-                        if (ins == output) {
-                            next_layer->insData.erase(next_layer->insData.begin() + i);
-                        }
-                    }
-                    next_layer->insData.push_back(dataPtr);
+                    std::replace_if(std::begin(next_layer->insData), std::end(next_layer->insData),
+                        [output](DataWeakPtr data) { return data.lock() == output; }, dataPtr);
                 }
                 input_to.clear();
                 input_to[activationName] = activationLayerWithQuant;


### PR DESCRIPTION
### Details:
- Identity insertion into LSTM cell can change the order of inputs for the next LSTM cell. Its inputs should be just replaced without order change.
- The problem is reproduced by MultipleLSTMCellTest with low latency transformation when TI unrolling is done inside this transformation before network loading to GNA plugin (after implementation of ticket 48754).

### Tickets:
 56397
