### PR TITLE
[IE CLDNN] Fixed cpplint issue with cpplint for CLDNN with Ninja generator

### DIFF
--- a/inference-engine/src/cldnn_engine/CMakeLists.txt
+++ b/inference-engine/src/cldnn_engine/CMakeLists.txt
@@ -28,9 +28,6 @@ target_link_libraries(${TARGET_NAME} PRIVATE clDNN_lib pugixml
                                              inference_engine_lp_transformations
                                              ${NGRAPH_LIBRARIES})
 
-add_cpplint_target(clDNN_lib_cpplint FOR_TARGETS clDNN_lib)
-add_cpplint_target(cldnn_kernel_selector_cpplint FOR_TARGETS cldnn_kernel_selector)
-
 set(CLDNN_TOP_FOLDER "${IE_MAIN_SOURCE_DIR}/thirdparty/clDNN")
 target_include_directories(${TARGET_NAME} PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}

--- a/inference-engine/thirdparty/clDNN/kernel_selector/CMakeLists.txt
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/CMakeLists.txt
@@ -142,6 +142,9 @@ add_library("${CLDNN_BUILD__PROJ}" STATIC
 set_property(TARGET "${CLDNN_BUILD__PROJ}" PROPERTY PROJECT_LABEL "${CLDNN_BUILD__PROJ_LABEL}")
 set_property(TARGET "${CLDNN_BUILD__PROJ}" PROPERTY OUTPUT_NAME   "${CLDNN_BUILD__PROJ_OUTPUT_NAME}")
 
+if(COMMAND add_cpplint_target)
+  add_cpplint_target("${CLDNN_BUILD__PROJ}_cpplint" FOR_TARGETS "${CLDNN_BUILD__PROJ}")
+endif()
 
 target_link_libraries("${CLDNN_BUILD__PROJ}"
     clDNN_OpenCL

--- a/inference-engine/thirdparty/clDNN/src/CMakeLists.txt
+++ b/inference-engine/thirdparty/clDNN/src/CMakeLists.txt
@@ -157,6 +157,10 @@ target_link_libraries("${CLDNN_BUILD__PROJ}" PRIVATE
     openvino::itt
   )
 
+if(COMMAND add_cpplint_target)
+  add_cpplint_target("${CLDNN_BUILD__PROJ}_cpplint" FOR_TARGETS "${CLDNN_BUILD__PROJ}")
+endif()
+
 if(COMMAND set_ie_threading_interface_for)
   set_ie_threading_interface_for("${CLDNN_BUILD__PROJ}")
 endif()


### PR DESCRIPTION
### Details:
 - Currently rebuild of the project with Ninja generator will lead to circle dependency for kernel_selector cpplint target. This patch fixes it.

### Tickets:
 - 50495
