### PR TITLE
Fix constant sub-graph folding and dynamic shape issues inside Pruning transformation

### DIFF
--- a/inference-engine/src/offline_transformations/src/pruning/pruning.cpp
+++ b/inference-engine/src/offline_transformations/src/pruning/pruning.cpp
@@ -51,7 +51,6 @@ bool ngraph::pass::Pruning::run_on_function(std::shared_ptr<Function> f) {
 #endif
 
     manager.register_pass<ShrinkWeights>();
-    manager.register_pass<ConstantFolding>();
 
 #ifdef NGRAPH_DEBUG_ENABLE
     // Uncomment following line and change path to resulting svg file

--- a/inference-engine/src/offline_transformations/src/pruning/shrink_weights.cpp
+++ b/inference-engine/src/offline_transformations/src/pruning/shrink_weights.cpp
@@ -71,7 +71,7 @@ bool ngraph::pass::ShrinkWeights::run_on_function(std::shared_ptr<ngraph::Functi
                 NGRAPH_DEBUG << "Transform(" << prev_name << "): " << prev_shape << " to " << last_output.get_partial_shape();
 
                 if (prev_shape.is_static() && last_output.get_partial_shape().is_static()) {
-                    reduced_weights_count += shape_size(prev_shape) - shape_size(last_output.get_shape());
+                    reduced_weights_count += shape_size(prev_shape.get_shape()) - shape_size(last_output.get_shape());
                 } else {
                     NGRAPH_DEBUG << "[ WARNING ] Can not find the number of reduced elements due to dynamic shapes.";
                 }

--- a/inference-engine/src/offline_transformations/src/pruning/shrink_weights.cpp
+++ b/inference-engine/src/offline_transformations/src/pruning/shrink_weights.cpp
@@ -11,6 +11,7 @@
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/opsets/opset6.hpp>
 #include <ngraph/log.hpp>
+#include <ngraph/ngraph.hpp>
 
 NGRAPH_RTTI_DEFINITION(ngraph::pass::ShrinkWeights, "ShrinkWeights", 0);
 
@@ -62,14 +63,22 @@ bool ngraph::pass::ShrinkWeights::run_on_function(std::shared_ptr<ngraph::Functi
                     }
                 }
 
-                const auto & prev_shape = last_output.get_shape();
+                const auto & prev_shape = last_output.get_partial_shape();
                 const auto & prev_name = last_output.get_node()->get_friendly_name();
                 last_output = std::make_shared<opset6::Gather>(last_output,
                                                                opset6::Constant::create(element::i64, Shape{dims_to_keep.size()}, dims_to_keep),
                                                                opset6::Constant::create(element::i64, Shape{}, {dim}));
-                NGRAPH_DEBUG << "Transform(" << prev_name << "): " << prev_shape << " to " << last_output.get_shape();
+                NGRAPH_DEBUG << "Transform(" << prev_name << "): " << prev_shape << " to " << last_output.get_partial_shape();
 
-                reduced_weights_count += shape_size(prev_shape) - shape_size(last_output.get_shape());
+                if (prev_shape.is_static() && last_output.get_partial_shape().is_static()) {
+                    reduced_weights_count += shape_size(prev_shape) - shape_size(last_output.get_shape());
+                } else {
+                    NGRAPH_DEBUG << "[ WARNING ] Can not find the number of reduced elements due to dynamic shapes.";
+                }
+            }
+            // Trying to fold sequence of Gather ops to avoid additional constant folding.
+            if (auto folded_const = ngraph::get_constant_from_source(last_output)) {
+                last_output = folded_const;
             }
             // as we insert Gather operations after Constant we need to reconnect all
             // Constant consumers to the latest Gather.


### PR DESCRIPTION
### Description

Replaced ConstantFolding pass with local constant folding using `get_constant_from_source` method to avoid constant sub-graph folding. Also dynamic checks were added to the Pruning transformation to avoid failures when dynamic shape occurs.

@jane-intel I checked IR generation with dynamic model and now ShapeOf operations remain in IR.