### PR TITLE
Handle Android-specific file paths

### DIFF
--- a/inference-engine/src/inference_engine/file_utils.cpp
+++ b/inference-engine/src/inference_engine/file_utils.cpp
@@ -99,6 +99,12 @@ long long FileUtils::fileSize(const char* charfilepath) {
 #if defined(ENABLE_UNICODE_PATH_SUPPORT) && defined(_WIN32)
     std::wstring widefilename = FileUtils::multiByteCharToWString(charfilepath);
     const wchar_t* fileName = widefilename.c_str();
+#elif defined(__ANDROID__) || defined(ANDROID)
+    std::string fileName = charfilepath;
+    std::string::size_type pos = fileName.find('!');
+    if (pos != std::string::npos) {
+        fileName = fileName.substr(0, pos);
+    }
 #else
     const char* fileName = charfilepath;
 #endif


### PR DESCRIPTION
### Details:
 - On non-root Android systems OpenVINO .so libraries can't be loaded because file exist check failed
 - File exist check failed because `FileUtils::fileSize` can't open `ifstream` using file path with "!" character
 - Character "!" divides the path to apk file and the path to a file within apk archive, for instance: `/data/app/com.example.ovapp-wX6xOF5_h2XQiYI4shqLyg==/base.apk!/lib/arm64-v8a/libinference_engine_ir_reader.so`
 - PR suggests a workaround to handle such Android-specific file paths with "!" delimiter.

### Tickets:
 - N/A
