### PR TITLE
ie_precision: added FloatTrait to fix VS2015 client compilation

### DIFF
--- a/inference-engine/include/ie_precision.hpp
+++ b/inference-engine/include/ie_precision.hpp
@@ -344,72 +344,89 @@ struct PrecisionTrait {};
 template <>
 struct PrecisionTrait<Precision::FP32> {
     using value_type = float;
+    enum { is_float = true };
 };
 
 template <>
 struct PrecisionTrait<Precision::FP64> {
     using value_type = double;
+    enum { is_float = true };
 };
 
 template <>
 struct PrecisionTrait<Precision::FP16> {
     using value_type = int16_t;
+    enum { is_float = true };
 };
 template <>
 struct PrecisionTrait<Precision::BF16> {
     using value_type = int16_t;
+    enum { is_float = true };
 };
 template<>
 struct PrecisionTrait<Precision::Q78> {
     using value_type = uint16_t;
+    enum { is_float = false };
 };
 template <>
 struct PrecisionTrait<Precision::I16> {
     using value_type = int16_t;
+    enum { is_float = false };
 };
 template <>
 struct PrecisionTrait<Precision::U16> {
     using value_type = uint16_t;
+    enum { is_float = false };
 };
 template <>
 struct PrecisionTrait<Precision::U4> {
     using value_type = uint8_t;
+    enum { is_float = false };
 };
 template <>
 struct PrecisionTrait<Precision::U8> {
     using value_type = uint8_t;
+    enum { is_float = false };
 };
 template <>
 struct PrecisionTrait<Precision::I4> {
     using value_type = int8_t;
+    enum { is_float = false };
 };
 template <>
 struct PrecisionTrait<Precision::I8> {
     using value_type = int8_t;
+    enum { is_float = false };
 };
 template <>
 struct PrecisionTrait<Precision::BOOL> {
     using value_type = uint8_t;
+    enum { is_float = false };
 };
 template <>
 struct PrecisionTrait<Precision::I32> {
     using value_type = int32_t;
+    enum { is_float = false };
 };
 template <>
 struct PrecisionTrait<Precision::U32> {
     using value_type = uint32_t;
+    enum { is_float = false };
 };
 template <>
 struct PrecisionTrait<Precision::I64> {
     using value_type = int64_t;
+    enum { is_float = false };
 };
 template <>
 struct PrecisionTrait<Precision::U64> {
     using value_type = uint64_t;
+    enum { is_float = false };
 };
 template <>
 struct PrecisionTrait<Precision::BIN> {
     using value_type = int8_t;
+    enum { is_float = false };
 };
 
 template <class T>
@@ -420,6 +437,7 @@ inline uint8_t type_size_or_zero() {
 template <>
 struct PrecisionTrait<Precision::UNSPECIFIED> {
     using value_type = void;
+    enum { is_float = false };
 };
 
 template <>
@@ -430,24 +448,6 @@ inline uint8_t type_size_or_zero<void>() {
     return 0;
 }
 
-namespace {
-constexpr bool isSpecificFloatPrecision(const Precision::ePrecision& precision) {
-    return precision == Precision::FP16 || precision == Precision::BF16;
-}
-} // namespace
-
-template <Precision::ePrecision T>
-inline typename std::enable_if<isSpecificFloatPrecision(T), bool>::type
-is_floating() {
-    return true;
-}
-
-template <Precision::ePrecision T>
-inline typename std::enable_if<!isSpecificFloatPrecision(T), bool>::type
-is_floating() {
-    return std::is_floating_point<typename PrecisionTrait<T>::value_type>::value;
-}
-
 template <Precision::ePrecision precision>
 inline Precision::PrecisionInfo Precision::makePrecisionInfo(const char* name) {
     Precision::PrecisionInfo info;
@@ -455,7 +455,7 @@ inline Precision::PrecisionInfo Precision::makePrecisionInfo(const char* name) {
 
     size_t nBits = precision == BIN ? 1 : 8;
     info.bitsSize = nBits * type_size_or_zero<typename PrecisionTrait<precision>::value_type>();
-    info.isFloat = is_floating<precision>();
+    info.isFloat = PrecisionTrait<precision>::is_float;
     info.value = precision;
     return info;
 }


### PR DESCRIPTION
Related PR #5654

### Details:
Our VS2015 build has failed due to some unsupported template constructs:
```
c:\deployment_tools\inference_engine\include\ie_precision.hpp(440): error C2891: 'T': cannot take the address of a template parameter (compiling source file dnn.cpp)  
c:\deployment_tools\inference_engine\include\ie_precision.hpp(439): note: see declaration of 'T' (compiling source file dnn.cpp)
```

I understand that VS2015 is quite old and is not officially supported by OpenVINO, but since the fix is not too complex, I hope it won't break anything and can be accepted.

This patch is more naive version of the original code and I hope someone can propose better and more elegant solution in review comments. [Other idea](https://github.com/openvinotoolkit/openvino/compare/master...mshabunin:fix-vs2015-build-2) was to extend `PrecisionTrait` with something like `is_float` field or method, seemingly more extensive this change can simplify the code as a whole by omitting `is_floating` function completly.

**cc** @apertovs @ilya-lavrenov @alalek