### PR TITLE
[CPU] Changed switch case logic by precision for Transpose

### DIFF
--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_transpose_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_transpose_node.cpp
@@ -263,14 +263,12 @@ void MKLDNNTransposeNode::execute(mkldnn::stream strm) {
     int MB = batchToProcess();
 
     if (isOptimized) {
-        const auto precision = getParentEdgeAt(0)->getDesc().getPrecision();
+        const size_t dataSize = getParentEdgeAt(0)->getDesc().getPrecision().size();
         TransposeContext ctx = {this, srcMemPtr, dstMemPtr, MB};
-        OV_SWITCH(MKLDNNPlugin, TransposeOptimizedEmitter, ctx, precision,
-                  OV_CASE(InferenceEngine::Precision::FP32, float),
-                  OV_CASE(InferenceEngine::Precision::I32, int32_t),
-                  OV_CASE(InferenceEngine::Precision::BF16, bfloat16_t),
-                  OV_CASE(InferenceEngine::Precision::I8, int8_t),
-                  OV_CASE(InferenceEngine::Precision::U8, uint8_t));
+        OV_SWITCH(MKLDNNPlugin, TransposeOptimizedEmitter, ctx, dataSize,
+                  OV_CASE(1, PrecisionTrait<Precision::U8>::value_type),
+                  OV_CASE(2, PrecisionTrait<Precision::U16>::value_type),
+                  OV_CASE(4, PrecisionTrait<Precision::I32>::value_type));
 
         return;
     }

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/transpose.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/transpose.cpp
@@ -15,7 +15,9 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
         InferenceEngine::Precision::FP16,
         InferenceEngine::Precision::I64,
         InferenceEngine::Precision::I32,
-        InferenceEngine::Precision::I16
+        InferenceEngine::Precision::I16,
+        InferenceEngine::Precision::I8,
+        InferenceEngine::Precision::U8,
 };
 
 std::vector<std::vector<size_t>> inputShape2D = {{2, 10}, {10, 2}, {10, 10}};


### PR DESCRIPTION
### Details:
 - *Changed the switch case logic by the precision to by data size for Transpose*
 - *Continuation of [PR#5724](https://github.com/openvinotoolkit/openvino/pull/5724)*




