### PR TITLE
Fix IE API search to check platform

### DIFF
--- a/model-optimizer/mo/utils/find_ie_version.py
+++ b/model-optimizer/mo/utils/find_ie_version.py
@@ -89,7 +89,8 @@ def find_ie_version(silent=False):
                 os.path.join(script_path, '../../../inference_engine/bin/intel64/Release'),
                 os.path.join(script_path, '../../../inference_engine/external/tbb/bin'),
                 os.path.join(script_path, '../../../ngraph/lib'),
-            ]
+            ],
+            "condition": lambda: sys.platform == "windows"
         },
         # Linux / Darwin
         {
@@ -98,7 +99,8 @@ def find_ie_version(silent=False):
                 os.path.join(script_path, '../../../inference_engine/lib/intel64'),
                 os.path.join(script_path, '../../../inference_engine/external/tbb/lib'),
                 os.path.join(script_path, '../../../ngraph/lib'),
-            ]
+            ],
+            "condition": lambda: sys.platform != "windows"
         },
         # Local builds
         {
@@ -124,6 +126,8 @@ def find_ie_version(silent=False):
     for item in bindings_paths:
         module = item['module']
         if not os.path.exists(module):
+            continue
+        if "condition" in item and not item["condition"]():
             continue
         if try_to_import_ie(module=os.path.normpath(module), libs=item['libs'] if 'libs' in item else [], silent=silent):
             return True


### PR DESCRIPTION
### Description
In find_ie_version we have two paths for finding IE Python API. And when running install_prerequisites on linux we was searching for  IE in Windows paths first and only then on Linux paths. So that was the reason of confusing warning message. This PR includes fix where IE Python API search was updated to check platform.

### Tickets:
XXX-53583
