### PR TITLE
[LPT] SplitTransformation WA for unsupported concat

### DIFF
--- a/inference-engine/src/low_precision_transformations/src/split.cpp
+++ b/inference-engine/src/low_precision_transformations/src/split.cpp
@@ -130,7 +130,20 @@ bool SplitTransformation::isPrecisionPreserved(std::shared_ptr<Node> layer) cons
 }
 
 bool SplitTransformation::canBeTransformed(const TransformationContext& context, std::shared_ptr<Node> layer) const {
-    return (!NetworkHelper::getDequantization(layer).empty()) && LayerTransformation::canBeTransformed(context, layer);
+    if (!LayerTransformation::canBeTransformed(context, layer) || NetworkHelper::getDequantization(layer).empty()) {
+        return false;
+    }
+
+    const auto consumers = NetworkHelper::consumers(layer);
+    const auto concat = as_type_ptr<opset1::Concat>(consumers[0]);
+
+    // WA to avoid propagation of dequantization if after Split all consumers are the same unsupported Concat
+    if (concat && concat->get_axis() != 1ul) {
+        const size_t id = consumers[0]->get_instance_id();
+        return std::any_of(consumers.begin(), consumers.end(), [&](const std::shared_ptr<Node>& node) { return node->get_instance_id() != id; });
+    }
+
+    return true;
 }
 
 } // namespace low_precision

--- a/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/split_function.hpp
+++ b/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/split_function.hpp
@@ -25,7 +25,8 @@ public:
         const ngraph::element::Type precisionBeforeDequantization,
         const ngraph::builder::subgraph::DequantizationOperations& dequantization,
         const int64_t splitedAxis,
-        const size_t numSplits);
+        const size_t numSplits,
+        const bool addUnsupportedConcat = false);
 
     static std::shared_ptr<ngraph::Function> getOriginal(
         const ngraph::element::Type originalFunctionPrecision,
@@ -42,7 +43,8 @@ public:
         const ngraph::element::Type precisionAfterOperation,
         const std::vector<ngraph::builder::subgraph::DequantizationOperations>& dequantizationAfter,
         const int64_t splitedAxis,
-        const size_t numSplit);
+        const size_t numSplit,
+        const bool addUnsupportedConcat = false);
 };
 }  // namespace subgraph
 }  // namespace builder


### PR DESCRIPTION
### Details:
 - SplitTransformation WA: avoid propagation of dequantization operations if after Split all consumers are the same unsupported Concat

### Tickets:
 - 55548
 - 56781

### Validation
 - Accuracy: developer-services/job/accuracy/2083/ (reference: developer-services/job/accuracy/2084/)
