### PR TITLE
Python wheel: failed to set RPATH for 3rd parties

### DIFF
--- a/inference-engine/ie_bridges/python/wheel/setup.py
+++ b/inference-engine/ie_bridges/python/wheel/setup.py
@@ -167,8 +167,6 @@ class PrepareLibs(build_clib):
             self.announce(f'Adding {WHEEL_LIBS_PACKAGE} package', level=3)
             packages.append(WHEEL_LIBS_PACKAGE)
             package_data.update({WHEEL_LIBS_PACKAGE: ['*']})
-            packages.append(f'{WHEEL_LIBS_PACKAGE}.vpu_custom_kernels')
-            package_data.update({f'{WHEEL_LIBS_PACKAGE}.vpu_custom_kernels': ['*']})
 
 
 class CopyExt(build_ext):

--- a/inference-engine/ie_bridges/python/wheel/setup.py
+++ b/inference-engine/ie_bridges/python/wheel/setup.py
@@ -93,7 +93,7 @@ PY_INSTALL_CFG = {
         'name': f'pyngraph_{PYTHON_VERSION}',
         'prefix': 'site-packages',
         'install_dir': PY_PACKAGES_DIR,
-     },
+    },
 }
 
 

--- a/inference-engine/ie_bridges/python/wheel/setup.py
+++ b/inference-engine/ie_bridges/python/wheel/setup.py
@@ -227,11 +227,12 @@ def set_rpath(rpath, executable):
     print(f'Setting rpath {rpath} for {executable}')  # noqa: T001
     cmd = []
     rpath_tool = ''
-    with open(os.path.realpath(executable), 'rb') as file:
+
+    if sys.platform == 'linux':
+        with open(os.path.realpath(executable), 'rb') as file:
         if file.read(1) != b'\x7f':
             log.warn(f'WARNING: {executable}: missed ELF header')
             return
-    if sys.platform == 'linux':
         rpath_tool = 'patchelf'
         cmd = [rpath_tool, '--set-rpath', rpath, executable]
     elif sys.platform == 'darwin':

--- a/inference-engine/ie_bridges/python/wheel/setup.py
+++ b/inference-engine/ie_bridges/python/wheel/setup.py
@@ -230,9 +230,9 @@ def set_rpath(rpath, executable):
 
     if sys.platform == 'linux':
         with open(os.path.realpath(executable), 'rb') as file:
-        if file.read(1) != b'\x7f':
-            log.warn(f'WARNING: {executable}: missed ELF header')
-            return
+            if file.read(1) != b'\x7f':
+                log.warn(f'WARNING: {executable}: missed ELF header')
+                return
         rpath_tool = 'patchelf'
         cmd = [rpath_tool, '--set-rpath', rpath, executable]
     elif sys.platform == 'darwin':

--- a/inference-engine/ie_bridges/python/wheel/setup.py
+++ b/inference-engine/ie_bridges/python/wheel/setup.py
@@ -13,6 +13,7 @@ from distutils.command.install import install
 from distutils.command.build import build
 from distutils.errors import DistutilsSetupError
 from distutils.file_util import copy_file
+from distutils import log
 from setuptools import setup, find_namespace_packages, Extension
 from setuptools.command.build_ext import build_ext
 from setuptools.command.build_clib import build_clib
@@ -78,7 +79,7 @@ LIB_INSTALL_CFG = {
         'name': 'tbb',
         'prefix': 'libs.tbb',
         'install_dir': TBB_LIBS_DIR,
-        'rpath': LIBS_RPATH
+        'rpath': LIBS_RPATH,
     },
 }
 
@@ -86,12 +87,12 @@ PY_INSTALL_CFG = {
     'ie_py': {
         'name': PYTHON_VERSION,
         'prefix': 'site-packages',
-        'install_dir': PY_PACKAGES_DIR
+        'install_dir': PY_PACKAGES_DIR,
     },
     'ngraph_py': {
         'name': f'pyngraph_{PYTHON_VERSION}',
         'prefix': 'site-packages',
-        'install_dir': PY_PACKAGES_DIR
+        'install_dir': PY_PACKAGES_DIR,
      },
 }
 
@@ -230,7 +231,7 @@ def set_rpath(rpath, executable):
     rpath_tool = ''
     with open(os.path.realpath(executable), 'rb') as file:
         if file.read(1) != b'\x7f':
-            print(f'WARNING: {executable}: missed ELF header')
+            log.warn(f'WARNING: {executable}: missed ELF header')
             return
     if sys.platform == 'linux':
         rpath_tool = 'patchelf'


### PR DESCRIPTION
### Details:
 - *filter files for patchelf/install_name_tool:  skip symlinks and linker scripts*
 
### Tickets:
 - *CVS-51355*
