### PR TITLE
samples: fix klocwork beyond boundary issue

### DIFF
--- a/inference-engine/samples/common/utils/include/samples/classification_results.h
+++ b/inference-engine/samples/common/utils/include/samples/classification_results.h
@@ -160,10 +160,10 @@ public:
 
                 const auto result =
                     moutputHolder
-                        .as<const InferenceEngine::PrecisionTrait<InferenceEngine::Precision::FP32>::value_type*>()[_results[id] +
+                        .as<const InferenceEngine::PrecisionTrait<InferenceEngine::Precision::FP32>::value_type*>()[_results.at(id) +
                                                                                                                     image_id * (_outBlob->size() / _batchSize)];
 
-                std::cout << std::setw(static_cast<int>(_classidStr.length())) << std::left << _results[id] << " ";
+                std::cout << std::setw(static_cast<int>(_classidStr.length())) << std::left << _results.at(id) << " ";
                 std::cout << std::left << std::setw(static_cast<int>(_probabilityStr.length())) << std::fixed << result;
 
                 if (!_labels.empty()) {


### PR DESCRIPTION
### Details:
 - Fix Klocwork issue: Potentially untrusted data 'id' can be used to read arbitrary data beyond boundary of array 'this->_results' at line 163 in speculative branch execution.

### Tickets:
 - 50356
