### PR TITLE
[DO NOT MERGE] AUTO inferences with CPU while the actual accelerator loads the network (CVS-56054)	

### DIFF
--- a/inference-engine/src/auto_plugin/auto_exec_network.cpp
+++ b/inference-engine/src/auto_plugin/auto_exec_network.cpp
@@ -15,40 +15,49 @@
 namespace AutoPlugin {
 using namespace InferenceEngine;
 
-AutoExecutableNetwork::AutoExecutableNetwork(const SoExecutableNetworkInternal& network) :
-    _network(network) {
+AutoExecutableNetwork::AutoExecutableNetwork(AutoPlugin::NetworkPromiseSharedPtr networkPromiseFirstReady,
+                                             AutoPlugin::NetworkPromiseSharedPtr networkPromiseActualNeeded) {
+    // we wait for any network to become ready (maybe this will already an actual device)
+    _networkFirstReady = networkPromiseFirstReady->get_future().get();
+    _networkPromiseActualNeeded = networkPromiseActualNeeded;
+    futureActualNetwork = _networkPromiseActualNeeded->get_future();
 }
 
 AutoExecutableNetwork::~AutoExecutableNetwork() = default;
 
 InferenceEngine::IInferRequestInternal::Ptr AutoExecutableNetwork::CreateInferRequestImpl(InputsDataMap networkInputs,
                                                                          OutputsDataMap networkOutputs) {
-    SoIInferRequestInternal inferRequest = {_network, _network->CreateInferRequest()};
-    return std::make_shared<AutoInferRequest>(_networkInputs, _networkOutputs, inferRequest);
+    SoIInferRequestInternal inferRequest = {_networkFirstReady, _networkFirstReady->CreateInferRequest()};
+    return std::make_shared<AutoInferRequest>(_networkInputs, _networkOutputs, inferRequest, futureActualNetwork.share());
 }
 
 void AutoExecutableNetwork::Export(std::ostream& networkModel) {
-    _network->Export(networkModel);
+    wait_for_actual_device();
+    _networkActualNeeded->Export(networkModel);
 }
 
 RemoteContext::Ptr AutoExecutableNetwork::GetContext() const {
-  return _network->GetContext();
+   wait_for_actual_device();
+   return _networkActualNeeded->GetContext();
 }
 
 InferenceEngine::CNNNetwork AutoExecutableNetwork::GetExecGraphInfo() {
-    return _network->GetExecGraphInfo();
+    wait_for_actual_device();
+    return _networkFirstReady->GetExecGraphInfo();
 }
 
 Parameter AutoExecutableNetwork::GetMetric(const std::string &name) const {
-    return _network->GetMetric(name);
+    return _networkFirstReady->GetMetric(name);
 }
 
 void AutoExecutableNetwork::SetConfig(const std::map<std::string, Parameter>& config) {
-    _network->SetConfig(config);
+    // this seems to be Not GOOD, why should we have SetConfig for the AUTO? AUTO has no config options
+    // _networkFirstReady->SetConfig(config);
 }
 
 Parameter AutoExecutableNetwork::GetConfig(const std::string& name) const {
-    return _network->GetConfig(name);
+    // fixme: also change to the FirstLoaded vs ActuallyNeeeded
+    return {};//  _networkFirstReady->GetConfig(name);
 }
 
 }  // namespace AutoPlugin

--- a/inference-engine/src/auto_plugin/auto_exec_network.cpp
+++ b/inference-engine/src/auto_plugin/auto_exec_network.cpp
@@ -20,7 +20,7 @@ AutoExecutableNetwork::AutoExecutableNetwork(AutoPlugin::NetworkPromiseSharedPtr
     // we wait for any network to become ready (maybe this will already an actual device)
     _networkFirstReady = networkPromiseFirstReady->get_future().get();
     _networkPromiseActualNeeded = networkPromiseActualNeeded;
-    futureActualNetwork = _networkPromiseActualNeeded->get_future();
+    _futureActualNetwork = _networkPromiseActualNeeded->get_future();
 }
 
 AutoExecutableNetwork::~AutoExecutableNetwork() = default;
@@ -28,36 +28,40 @@ AutoExecutableNetwork::~AutoExecutableNetwork() = default;
 InferenceEngine::IInferRequestInternal::Ptr AutoExecutableNetwork::CreateInferRequestImpl(InputsDataMap networkInputs,
                                                                          OutputsDataMap networkOutputs) {
     SoIInferRequestInternal inferRequest = {_networkFirstReady, _networkFirstReady->CreateInferRequest()};
-    return std::make_shared<AutoInferRequest>(_networkInputs, _networkOutputs, inferRequest, futureActualNetwork.share());
+    return std::make_shared<AutoInferRequest>(_networkInputs, _networkOutputs, inferRequest,
+            _futureActualNetwork.share(), _anyRequestHasHotSwapped);
 }
 
 void AutoExecutableNetwork::Export(std::ostream& networkModel) {
-    wait_for_actual_device();
-    _networkActualNeeded->Export(networkModel);
+    //fixme: the Export  should work with actual device, so we have to wait!!!
+//    wait_for_actual_device();
+//    _networkActualNeeded->Export(networkModel);
 }
 
 RemoteContext::Ptr AutoExecutableNetwork::GetContext() const {
-   wait_for_actual_device();
-   return _networkActualNeeded->GetContext();
+    // fixme: the GetContext  should work with actual device, so we have to wait!!!
+//   wait_for_actual_device();
+//   return (_networkActualNeeded) ? _networkActualNeeded->GetContext() : RemoteContext::Ptr{};
+     return RemoteContext::Ptr{};
 }
 
 InferenceEngine::CNNNetwork AutoExecutableNetwork::GetExecGraphInfo() {
-    wait_for_actual_device();
-    return _networkFirstReady->GetExecGraphInfo();
+    return _anyRequestHasHotSwapped ? _networkActualNeeded->GetExecGraphInfo() : _networkFirstReady->GetExecGraphInfo();
 }
 
 Parameter AutoExecutableNetwork::GetMetric(const std::string &name) const {
-    return _networkFirstReady->GetMetric(name);
+    //fixme: check this logic
+    return _anyRequestHasHotSwapped ? _networkActualNeeded->GetMetric(name) : _networkFirstReady->GetMetric(name);
 }
 
 void AutoExecutableNetwork::SetConfig(const std::map<std::string, Parameter>& config) {
-    // this seems to be Not GOOD, why should we have SetConfig for the AUTO? AUTO has no config options
-    // _networkFirstReady->SetConfig(config);
+     //fixme: have to store the config and reapply when the networks swapped
+    _networkFirstReady->SetConfig(config);
 }
 
 Parameter AutoExecutableNetwork::GetConfig(const std::string& name) const {
-    // fixme: also change to the FirstLoaded vs ActuallyNeeeded
-    return {};//  _networkFirstReady->GetConfig(name);
+    //fixme: carefuly select between FirstLoaded and ActuallyNeeded
+    return _networkFirstReady->GetConfig(name);
 }
 
 }  // namespace AutoPlugin

--- a/inference-engine/src/auto_plugin/auto_exec_network.hpp
+++ b/inference-engine/src/auto_plugin/auto_exec_network.hpp
@@ -52,9 +52,10 @@ private:
 
     InferenceEngine::SoExecutableNetworkInternal _networkActualNeeded;
     AutoPlugin::NetworkPromiseSharedPtr _networkPromiseActualNeeded;
-    AutoPlugin::NetworkFuture futureActualNetwork; // for requests
+    AutoPlugin::NetworkFuture _futureActualNetwork; // for requests
+    std::atomic<bool> _anyRequestHasHotSwapped = {false};
     void wait_for_actual_device() const {
-        // _networkActualNeeded = _networkPromiseActualNeeded->get_future().get();
+        //        _networkActualNeeded = _futureActualNetwork.share().get();
         // todo : catch the st std::future_error / std::future_errc::promise_already_satisfied
         // todo: make the two members above volatile to keep this method const
     }

--- a/inference-engine/src/auto_plugin/auto_exec_network.hpp
+++ b/inference-engine/src/auto_plugin/auto_exec_network.hpp
@@ -24,11 +24,17 @@ struct DeviceInformation {
     std::map<std::string, std::string> config;
 };
 
+typedef std::promise<InferenceEngine::SoExecutableNetworkInternal> NetworkPromise;
+typedef std::future<InferenceEngine::SoExecutableNetworkInternal> NetworkFuture;
+typedef std::shared_future<InferenceEngine::SoExecutableNetworkInternal> NetworkSharedFuture;
+typedef std::shared_ptr<NetworkPromise> NetworkPromiseSharedPtr;
+
 class AutoExecutableNetwork : public InferenceEngine::ExecutableNetworkInternal {
 public:
     using Ptr = std::shared_ptr<AutoExecutableNetwork>;
 
-    explicit AutoExecutableNetwork(const InferenceEngine::SoExecutableNetworkInternal& network);
+    explicit AutoExecutableNetwork(AutoPlugin::NetworkPromiseSharedPtr networkFirstReady,
+                                   AutoPlugin::NetworkPromiseSharedPtr networkActualNeeded);
 
     void Export(std::ostream& networkModel) override;
     InferenceEngine::RemoteContext::Ptr GetContext() const override;
@@ -42,7 +48,16 @@ public:
     ~AutoExecutableNetwork() override;
 
 private:
-    InferenceEngine::SoExecutableNetworkInternal _network;
+    InferenceEngine::SoExecutableNetworkInternal _networkFirstReady;
+
+    InferenceEngine::SoExecutableNetworkInternal _networkActualNeeded;
+    AutoPlugin::NetworkPromiseSharedPtr _networkPromiseActualNeeded;
+    AutoPlugin::NetworkFuture futureActualNetwork; // for requests
+    void wait_for_actual_device() const {
+        // _networkActualNeeded = _networkPromiseActualNeeded->get_future().get();
+        // todo : catch the st std::future_error / std::future_errc::promise_already_satisfied
+        // todo: make the two members above volatile to keep this method const
+    }
 };
 
 }  // namespace AutoPlugin

--- a/inference-engine/src/auto_plugin/auto_infer_request.cpp
+++ b/inference-engine/src/auto_plugin/auto_infer_request.cpp
@@ -13,9 +13,9 @@ namespace AutoPlugin {
 AutoInferRequest::AutoInferRequest(const InputsDataMap&              networkInputs,
                                    const OutputsDataMap&             networkOutputs,
                                    const SoIInferRequestInternal&    inferRequest,
-                                   AutoPlugin::NetworkSharedFuture f)
+                                   AutoPlugin::NetworkSharedFuture f, std::atomic<bool>& anyRequestHasHotSwapped)
     : IInferRequestInternal(networkInputs, networkOutputs)
-    , _inferRequest(inferRequest), _sharedFutureForActualNetwork(f) {
+    , _inferRequest(inferRequest), _sharedFutureForActualNetwork(f), _anyRequestHasHotSwapped(anyRequestHasHotSwapped) {
     for (const auto &it : _networkInputs)
         _inputs[it.first] = _inferRequest->GetBlob(it.first);
     for (const auto &it : _networkOutputs)
@@ -28,18 +28,16 @@ std::map<std::string, InferenceEngine::InferenceEngineProfileInfo> AutoInferRequ
 
 void AutoInferRequest::InferImpl() {
     HotSwapRequests(); //safe to call here (before actual inference started)
-    // FIXME: change the AutoInferRequest to set the blobs (from stored internally)
+    SetBlobsToDeviceRequest();
     _inferRequest->Infer();
 }
 
 void AutoInferRequest::SetBlob(const std::string& name, const InferenceEngine::Blob::Ptr& data) {
-    // FIXME: change the AutoInferRequest to store the blobs
-    _inferRequest->SetBlob(name, data);
+    IInferRequestInternal::SetBlob(name, data);
 }
 
 Blob::Ptr AutoInferRequest::GetBlob(const std::string& name) {
-    // FIXME: change the AutoInferRequest to store the blobs, and return these
-    return _inferRequest->GetBlob(name);
+    return IInferRequestInternal::GetBlob(name);
 }
 
 void AutoInferRequest::Cancel() {
@@ -48,6 +46,7 @@ void AutoInferRequest::Cancel() {
 
 void AutoInferRequest::StartAsync() {
     HotSwapRequests(); //safe to call here (before actual inference started)
+    SetBlobsToDeviceRequest();
     _inferRequest->StartAsync();
 }
 
@@ -61,29 +60,32 @@ void AutoInferRequest::SetCallback(Callback callback) {
 }
 
 void AutoInferRequest::HotSwapRequests() {
-    if (_sharedFutureForActualNetwork.wait_for(std::chrono::nanoseconds(0)) == std::future_status::ready) {
+    if (_sharedFutureForActualNetwork.valid() && _sharedFutureForActualNetwork.wait_for(std::chrono::nanoseconds(0)) == std::future_status::ready) {
         std::lock_guard<std::mutex>{_hotswapMutex};
         if (!_hotswapDone) {
             _hotswapDone = true;
-            std::cout << "!!! DEBUG: HotSwapRequests !!!" << std::endl;
             auto actualNetwork = _sharedFutureForActualNetwork.get();
-            _inferRequest = {actualNetwork, actualNetwork->CreateInferRequest()};
-            _inferRequest->SetCallback(_callback);
+            if (actualNetwork) { // if this was CPU only and no accel, the network would be NULL
+                std::cout << "!!! DEBUG: HotSwapRequests !!!" << std::endl;
+                _inferRequest = {actualNetwork, actualNetwork->CreateInferRequest()};
+                _inferRequest->SetCallback(_callback);
+                _anyRequestHasHotSwapped = true;
+            }
         }
     }
 }
 
 void AutoInferRequest::SetBlobsToDeviceRequest() {
         for (const auto &it : _networkInputs) {
-            auto &name = it.first;
-            // this request is already in BUSY state, so using the internal functions safely
+            const auto &name = it.first;
+            // this assumes the request is already in BUSY state
             auto blob = GetBlob(name);
             if (_inferRequest->GetBlob(name) != blob)
                 _inferRequest->SetBlob(name, blob);
         }
         for (const auto &it : _networkOutputs) {
-            auto &name = it.first;
-            // this request is already in BUSY state, so using the internal functions safely
+            const auto &name = it.first;
+            // this assumes the request is already in BUSY state
             auto blob = GetBlob(name);
             if (_inferRequest->GetBlob(name) != blob)
                 _inferRequest->SetBlob(name, blob);

--- a/inference-engine/src/auto_plugin/auto_infer_request.cpp
+++ b/inference-engine/src/auto_plugin/auto_infer_request.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <iostream>
 #include "auto_infer_request.hpp"
 #include <ie_input_info.hpp>
 #include <cpp_interfaces/interface/ie_iinfer_request_internal.hpp>
@@ -11,9 +12,14 @@ namespace AutoPlugin {
 
 AutoInferRequest::AutoInferRequest(const InputsDataMap&              networkInputs,
                                    const OutputsDataMap&             networkOutputs,
-                                   const SoIInferRequestInternal&    inferRequest)
+                                   const SoIInferRequestInternal&    inferRequest,
+                                   AutoPlugin::NetworkSharedFuture f)
     : IInferRequestInternal(networkInputs, networkOutputs)
-    , _inferRequest(inferRequest) {
+    , _inferRequest(inferRequest), _sharedFutureForActualNetwork(f) {
+    for (const auto &it : _networkInputs)
+        _inputs[it.first] = _inferRequest->GetBlob(it.first);
+    for (const auto &it : _networkOutputs)
+        _outputs[it.first] = _inferRequest->GetBlob(it.first);
 }
 
 std::map<std::string, InferenceEngine::InferenceEngineProfileInfo> AutoInferRequest::GetPerformanceCounts() const {
@@ -21,14 +27,18 @@ std::map<std::string, InferenceEngine::InferenceEngineProfileInfo> AutoInferRequ
 }
 
 void AutoInferRequest::InferImpl() {
+    HotSwapRequests(); //safe to call here (before actual inference started)
+    // FIXME: change the AutoInferRequest to set the blobs (from stored internally)
     _inferRequest->Infer();
 }
 
 void AutoInferRequest::SetBlob(const std::string& name, const InferenceEngine::Blob::Ptr& data) {
+    // FIXME: change the AutoInferRequest to store the blobs
     _inferRequest->SetBlob(name, data);
 }
 
 Blob::Ptr AutoInferRequest::GetBlob(const std::string& name) {
+    // FIXME: change the AutoInferRequest to store the blobs, and return these
     return _inferRequest->GetBlob(name);
 }
 
@@ -37,6 +47,7 @@ void AutoInferRequest::Cancel() {
 }
 
 void AutoInferRequest::StartAsync() {
+    HotSwapRequests(); //safe to call here (before actual inference started)
     _inferRequest->StartAsync();
 }
 
@@ -45,7 +56,39 @@ InferenceEngine::StatusCode AutoInferRequest::Wait(int64_t millis_timeout) {
 }
 
 void AutoInferRequest::SetCallback(Callback callback) {
+    _callback = callback;
     _inferRequest->SetCallback(callback);
 }
+
+void AutoInferRequest::HotSwapRequests() {
+    if (_sharedFutureForActualNetwork.wait_for(std::chrono::nanoseconds(0)) == std::future_status::ready) {
+        std::lock_guard<std::mutex>{_hotswapMutex};
+        if (!_hotswapDone) {
+            _hotswapDone = true;
+            std::cout << "!!! DEBUG: HotSwapRequests !!!" << std::endl;
+            auto actualNetwork = _sharedFutureForActualNetwork.get();
+            _inferRequest = {actualNetwork, actualNetwork->CreateInferRequest()};
+            _inferRequest->SetCallback(_callback);
+        }
+    }
+}
+
+void AutoInferRequest::SetBlobsToDeviceRequest() {
+        for (const auto &it : _networkInputs) {
+            auto &name = it.first;
+            // this request is already in BUSY state, so using the internal functions safely
+            auto blob = GetBlob(name);
+            if (_inferRequest->GetBlob(name) != blob)
+                _inferRequest->SetBlob(name, blob);
+        }
+        for (const auto &it : _networkOutputs) {
+            auto &name = it.first;
+            // this request is already in BUSY state, so using the internal functions safely
+            auto blob = GetBlob(name);
+            if (_inferRequest->GetBlob(name) != blob)
+                _inferRequest->SetBlob(name, blob);
+        }
+    }
+
 
 }  // namespace AutoPlugin

--- a/inference-engine/src/auto_plugin/auto_infer_request.hpp
+++ b/inference-engine/src/auto_plugin/auto_infer_request.hpp
@@ -27,7 +27,8 @@ public:
     explicit AutoInferRequest(const InferenceEngine::InputsDataMap&             networkInputs,
                               const InferenceEngine::OutputsDataMap&            networkOutputs,
                               const InferenceEngine::SoIInferRequestInternal&   inferRequest,
-                              AutoPlugin::NetworkSharedFuture f);
+                              AutoPlugin::NetworkSharedFuture f,
+                              std::atomic<bool>& anyRequestHasHotSwapped);
     std::map<std::string, InferenceEngine::InferenceEngineProfileInfo> GetPerformanceCounts() const override;
     void InferImpl() override;
     void SetBlob(const std::string& name, const InferenceEngine::Blob::Ptr& data) override;
@@ -46,6 +47,7 @@ private:
 
     std::mutex _hotswapMutex;
     bool _hotswapDone = false;
+    std::atomic<bool>& _anyRequestHasHotSwapped;
     void HotSwapRequests();
     void SetBlobsToDeviceRequest();
 };

--- a/inference-engine/src/auto_plugin/auto_plugin.cpp
+++ b/inference-engine/src/auto_plugin/auto_plugin.cpp
@@ -240,7 +240,6 @@ DeviceInformation AutoInferencePlugin::SelectDevice(const std::vector<DeviceInfo
 
     // Sort GPU by name: GPU.2 > GPU.1 > GPU.0 > GPU, so we always choose the GPU[0] as best device
     std::sort(GPU.begin(), GPU.end(), [](const DeviceInformation& a, const DeviceInformation& b)->bool{return b.deviceName < a.deviceName;});
-    return GPU[0];
 
     for (auto&& item : GPU) {
         std::vector<std::string> capability = GetCore()->GetMetric(item.deviceName, METRIC_KEY(OPTIMIZATION_CAPABILITIES));

--- a/inference-engine/src/auto_plugin/auto_plugin.cpp
+++ b/inference-engine/src/auto_plugin/auto_plugin.cpp
@@ -240,6 +240,7 @@ DeviceInformation AutoInferencePlugin::SelectDevice(const std::vector<DeviceInfo
 
     // Sort GPU by name: GPU.2 > GPU.1 > GPU.0 > GPU, so we always choose the GPU[0] as best device
     std::sort(GPU.begin(), GPU.end(), [](const DeviceInformation& a, const DeviceInformation& b)->bool{return b.deviceName < a.deviceName;});
+    return GPU[0];
 
     for (auto&& item : GPU) {
         std::vector<std::string> capability = GetCore()->GetMetric(item.deviceName, METRIC_KEY(OPTIMIZATION_CAPABILITIES));

--- a/inference-engine/src/auto_plugin/auto_plugin.hpp
+++ b/inference-engine/src/auto_plugin/auto_plugin.hpp
@@ -49,7 +49,7 @@ private:
         auto metaDevices = GetDeviceChoice(fullConfig);
         NetworkPromiseSharedPtr promiseFirstDevice = std::make_shared<NetworkPromise>();
         NetworkPromiseSharedPtr promiseActualDevice = std::make_shared<NetworkPromise>();
-        auto LoadNetworkAsync = [=](bool bIsAccel, const DeviceInformation device) {
+        auto LoadNetworkAsync = [this, param, promiseFirstDevice, promiseActualDevice](bool bIsAccel, const DeviceInformation device) {
             std::cout << "!!! DEBUG: Starting Async loading to the " << device.deviceName<<  " !!!" << std::endl;
             auto executableNetwork = GetCore()->LoadNetwork(param, device.deviceName, device.config);
             try {
@@ -78,6 +78,8 @@ private:
         // loading to the CPU in parallel, if it is not already an accelrator
         if (isAccelerator)
             async_load_threads.push_back(std::thread([=] { LoadNetworkAsync(false, CPU); }));
+        else
+            promiseActualDevice->set_value({});
 
         // FIXME: revert the exception handling logic back to gracefully handle LoadNetwork failures
         // DeviceInformation selectedDevice;

--- a/inference-engine/src/auto_plugin/auto_plugin.hpp
+++ b/inference-engine/src/auto_plugin/auto_plugin.hpp
@@ -21,7 +21,11 @@ using ConfigType = std::map<std::string, std::string>;
 class AutoInferencePlugin : public IE::InferencePluginInternal {
 public:
     AutoInferencePlugin();
-    ~AutoInferencePlugin() = default;
+    ~AutoInferencePlugin() {
+        // will discuss cancelable LoadNEtwork in the Arch Forum, but now have to wait
+        for (auto& t : async_load_threads)
+            t.join();
+    }
     IE::ExecutableNetworkInternal::Ptr LoadExeNetworkImpl(const IE::CNNNetwork& network, const ConfigType& config) override;
     IE::IExecutableNetworkInternal::Ptr LoadNetwork(const std::string& fileName, const ConfigType& config) override;
     IE::QueryNetworkResult QueryNetwork(const IE::CNNNetwork& network, const ConfigType& config) const override;
@@ -35,7 +39,7 @@ private:
     DeviceInformation SelectDevice(const std::vector<DeviceInformation>& metaDevices, const std::string& networkPrecision = METRIC_VALUE(FP32));
     ConfigType GetSupportedConfig(const ConfigType& config, const AutoPlugin::DeviceName & deviceName) const;
     static ConfigType mergeConfigs(ConfigType config, const ConfigType& local);
-
+    std::vector<std::thread> async_load_threads;
     template <typename T>
     std::shared_ptr<AutoExecutableNetwork> LoadNetworkImpl(const T &param, const ConfigType &config, const std::string &networkPrecision = METRIC_VALUE(FP32)) {
         if (GetCore() == nullptr) {
@@ -43,32 +47,67 @@ private:
         }
         auto fullConfig = mergeConfigs(_config, config);
         auto metaDevices = GetDeviceChoice(fullConfig);
-        DeviceInformation selectedDevice;
-        IE::SoExecutableNetworkInternal executableNetwork;
-        while (!metaDevices.empty()) {
-            selectedDevice = SelectDevice(metaDevices, networkPrecision);
+        NetworkPromiseSharedPtr promiseFirstDevice = std::make_shared<NetworkPromise>();
+        NetworkPromiseSharedPtr promiseActualDevice = std::make_shared<NetworkPromise>();
+        auto LoadNetworkAsync = [=](bool bIsAccel, const DeviceInformation device) {
+            std::cout << "!!! DEBUG: Starting Async loading to the " << device.deviceName<<  " !!!" << std::endl;
+            auto executableNetwork = GetCore()->LoadNetwork(param, device.deviceName, device.config);
             try {
-                executableNetwork = GetCore()->LoadNetwork(param, selectedDevice.deviceName, selectedDevice.config);
-                break;
-            } catch (...) {
-                auto eraseDevice = std::find_if(metaDevices.begin(), metaDevices.end(),
-                    [=](const DeviceInformation& d)->bool{return d.deviceName == selectedDevice.deviceName;});
-                if (eraseDevice == metaDevices.end()) {
-                    IE_THROW() << "Didn't find the selected device name";
-                }
-                metaDevices.erase(eraseDevice);
-                executableNetwork = {};
+                promiseFirstDevice->set_value(executableNetwork);
+                std::cout << "!!! DEBUG: " << device.deviceName <<  " was loaded first !!!" << std::endl;
             }
-        }
-        if (!executableNetwork) {
-            IE_THROW() << "Failed to load network by AUTO plugin";
-        }
-        auto impl = std::make_shared<AutoExecutableNetwork>(executableNetwork);
+            catch (const std::future_error &e) {
+//                if (e.code() == std::future_errc::promise_already_satisfied) {
+//                    std::cout << "!!! DEBUG: " << (bIsAccel? "Accelerator" : "CPU") <<
+//                        " was already loaded to the promiseFirstDevice !!!" << std::endl;
+//                }
+            }
+            if (bIsAccel) {
+                promiseActualDevice->set_value(executableNetwork);
+                std::cout << "!!! DEBUG: Accelerator" << device.deviceName <<  " was loaded !!!" << std::endl;
+            }
+        };
 
-        if (std::is_same<std::string, T>::value) {
-            SetExeNetworkInfo(impl, executableNetwork->GetInputsInfo(),
-                                    executableNetwork->GetOutputsInfo());
-        }
+        const auto accelerator = SelectDevice(metaDevices, networkPrecision);
+        // fixme (use CPU config, etc):
+        const DeviceInformation CPU = {"CPU", {} };
+        // start loading of the netwrok to the accel
+        bool isAccelerator = accelerator.deviceName != "CPU";
+        // FIXME: change to the default task-executor as in MULTI (but add an async Run() to that)
+        async_load_threads.push_back(std::thread([=] {LoadNetworkAsync(isAccelerator, accelerator);}));
+        // loading to the CPU in parallel, if it is not already an accelrator
+        if (isAccelerator)
+            async_load_threads.push_back(std::thread([=] { LoadNetworkAsync(false, CPU); }));
+
+        // FIXME: revert the exception handling logic back to gracefully handle LoadNetwork failures
+        // DeviceInformation selectedDevice;
+        // IE::SoExecutableNetworkInternal executableNetwork;
+//            while (!metaDevices.empty()) {
+//            selectedDevice = SelectDevice(metaDevices, networkPrecision);
+//              try {
+//                executableNetwork = GetCore()->LoadNetwork(param, selectedDevice.deviceName,
+//                                                                    selectedDevice.config);
+//                break;
+//            } catch (...) {
+//                auto eraseDevice = std::find_if(metaDevices.begin(), metaDevices.end(),
+//                    [=](const DeviceInformation& d)->bool{return d.deviceName == selectedDevice.deviceName;});
+//                if (eraseDevice == metaDevices.end()) {
+//                    IE_THROW() << "Didn't find the selected device name";
+//                }
+//                metaDevices.erase(eraseDevice);
+//                executableNetwork = {};
+//            }
+//        }
+//        if (!executableNetwork) {
+//            IE_THROW() << "Failed to load network by AUTO plugin";
+//        }
+        // AutoExecutableNetwork constructor blocks until any network is ready
+        auto impl = std::make_shared<AutoExecutableNetwork>(promiseFirstDevice, promiseActualDevice);
+
+//        if (std::is_same<std::string, T>::value) {
+//            SetExeNetworkInfo(impl, executableNetwork->GetInputsInfo(),
+//                                    executableNetwork->GetOutputsInfo());
+//        }
 
         return impl;
     }


### PR DESCRIPTION
This is really a draft and lot's of semantic/behaviour opens to address and/or raise to the Arch forum, e.g.

So the TODOs are (marked as "fixme in the code)":
- shall the SetConfig/GetConfig keep the settings and reapply to the actual (accelerator)  network when it is ready.
- what the GetRemoteContext should return (e.g. shall it wait for the actual accelerator to load the network first?)
- Metrics etc
- finally, there are subtle details of asynchronocity (e.g. calling the StartAsync from two threads simultaneously <which should normally throw an exception), while the devices HotSwap amy happen in-between). Currently the implemented solution is likely incomplete.
All these should be verified with (updated) behaviour tests.