### PR TITLE
[IE PYTHON] Fixed test_InputInfoPtr, that leads to heap-use-after-free

### DIFF
--- a/inference-engine/ie_bridges/python/tests/test_InputInfoPtr.py
+++ b/inference-engine/ie_bridges/python/tests/test_InputInfoPtr.py
@@ -76,7 +76,8 @@ def test_incorrect_layout_setter():
 
 
 def test_preprocess_info():
-    preprocess_info = get_input_info().preprocess_info
+    input_info = get_input_info()
+    preprocess_info = input_info.preprocess_info
     assert isinstance(preprocess_info, PreProcessInfo)
     assert preprocess_info.color_format == ColorFormat.RAW
 


### PR DESCRIPTION
### Details:
 - *In test_InputInfoPtr.py test_preprocess_info, preprocess_info is using after input_info has deallocated - that is not corrects*
 - *AddressSanitizer detect heap-use-after-free*

### Tickets:
 - *53920*
