### PR TITLE
Rework custom::task_arena initialization logic

### DIFF
--- a/inference-engine/src/inference_engine/threading/ie_cpu_streams_executor.cpp
+++ b/inference-engine/src/inference_engine/threading/ie_cpu_streams_executor.cpp
@@ -27,7 +27,7 @@ namespace InferenceEngine {
 struct CPUStreamsExecutor::Impl {
     struct Stream {
 #if IE_THREAD == IE_THREAD_TBB || IE_THREAD == IE_THREAD_TBB_AUTO
-        struct Observer: public tbb::task_scheduler_observer {
+        struct Observer: public custom::task_scheduler_observer {
             CpuSet  _mask;
             int     _ncpus                  = 0;
             int     _threadBindingStep      = 0;
@@ -39,7 +39,7 @@ struct CPUStreamsExecutor::Impl {
                      const int           threadsPerStream,
                      const int           threadBindingStep,
                      const int           threadBindingOffset) :
-                tbb::task_scheduler_observer(static_cast<tbb::task_arena&>(arena)),
+                custom::task_scheduler_observer(arena),
                 _mask{std::move(mask)},
                 _ncpus(ncpus),
                 _threadBindingStep(threadBindingStep),

--- a/inference-engine/src/inference_engine/threading/ie_parallel_custom_arena.cpp
+++ b/inference-engine/src/inference_engine/threading/ie_parallel_custom_arena.cpp
@@ -17,6 +17,7 @@
 #if defined(_WIN32) || defined(_WIN64)
 #include <windows.h>
 #endif
+#include <iostream>
 
 namespace custom {
 namespace detail {
@@ -127,7 +128,7 @@ binding_oberver_ptr construct_binding_observer(tbb::task_arena& ta, int num_slot
 #endif /*USE_TBBBIND_2_4*/
 
 #if TBB_NUMA_SUPPORT_PRESENT
-tbb::task_arena::constraints convert_constraints(custom::task_arena::constraints& c) {
+tbb::task_arena::constraints convert_constraints(const custom::task_arena::constraints& c) {
     tbb::task_arena::constraints result{};
 #if TBB_HYBRID_CPUS_SUPPORT_PRESENT
     result.core_type = c.core_type;
@@ -148,7 +149,13 @@ task_arena::task_arena(int max_concurrency_, unsigned reserved_for_masters)
 {}
 
 task_arena::task_arena(const constraints& constraints_, unsigned reserved_for_masters)
-    : my_task_arena{info::default_concurrency(constraints_), reserved_for_masters}
+#if USE_TBBBIND_2_4
+    : my_task_arena {info::default_concurrency(constraints_), reserved_for_masters}
+#elif TBB_NUMA_SUPPORT_PRESENT || TBB_HYBRID_CPUS_SUPPORT_PRESENT
+    : my_task_arena {convert_constraints(constraints_), reserved_for_masters}
+#else
+    : my_task_arena {constraints_.max_concurrency, reserved_for_masters}
+#endif
     , my_initialization_state{}
     , my_constraints{constraints_}
     , my_binding_observer{}
@@ -162,47 +169,38 @@ task_arena::task_arena(const task_arena &s)
 {}
 
 void task_arena::initialize() {
+    my_task_arena.initialize();
 #if USE_TBBBIND_2_4
     std::call_once(my_initialization_state, [this] {
-        my_task_arena.initialize();
         my_binding_observer = detail::construct_binding_observer(
             my_task_arena, my_task_arena.max_concurrency(), my_constraints);
     });
-#elif TBB_NUMA_SUPPORT_PRESENT || TBB_HYBRID_CPUS_SUPPORT_PRESENT
-    my_task_arena.initialize(convert_constraints(my_constraints));
-#else
-    my_task_arena.initialize();
 #endif
 }
 
 void task_arena::initialize(int max_concurrency_, unsigned reserved_for_masters) {
+    my_task_arena.initialize(max_concurrency_, reserved_for_masters);
 #if USE_TBBBIND_2_4
-    std::call_once(my_initialization_state, [this, &max_concurrency_, &reserved_for_masters] {
-        my_task_arena.initialize(max_concurrency_, reserved_for_masters);
+    std::call_once(my_initialization_state, [this] {
         my_binding_observer = detail::construct_binding_observer(
             my_task_arena, my_task_arena.max_concurrency(), my_constraints);
     });
-#elif TBB_NUMA_SUPPORT_PRESENT || TBB_HYBRID_CPUS_SUPPORT_PRESENT
-    my_constraints.max_concurrency = max_concurrency_;
-    my_task_arena.initialize(convert_constraints(my_constraints), reserved_for_masters);
-#else
-    my_task_arena.initialize(max_concurrency_, reserved_for_masters);
 #endif
 }
 
 void task_arena::initialize(constraints constraints_, unsigned reserved_for_masters) {
-    std::call_once(my_initialization_state, [this, &constraints_, &reserved_for_masters] {
         my_constraints = constraints_;
 #if USE_TBBBIND_2_4
         my_task_arena.initialize(info::default_concurrency(constraints_), reserved_for_masters);
-        my_binding_observer = detail::construct_binding_observer(
-            my_task_arena, my_task_arena.max_concurrency(), my_constraints);
+        std::call_once(my_initialization_state, [this] {
+            my_binding_observer = detail::construct_binding_observer(
+                my_task_arena, my_task_arena.max_concurrency(), my_constraints);
+        });
 #elif TBB_NUMA_SUPPORT_PRESENT || TBB_HYBRID_CPUS_SUPPORT_PRESENT
         my_task_arena.initialize(convert_constraints(my_constraints), reserved_for_masters);
 #else
         my_task_arena.initialize(my_constraints.max_concurrency, reserved_for_masters);
 #endif
-    });
 }
 
 task_arena::operator tbb::task_arena&() {

--- a/inference-engine/src/inference_engine/threading/ie_parallel_custom_arena.cpp
+++ b/inference-engine/src/inference_engine/threading/ie_parallel_custom_arena.cpp
@@ -17,7 +17,6 @@
 #if defined(_WIN32) || defined(_WIN64)
 #include <windows.h>
 #endif
-#include <iostream>
 
 namespace custom {
 namespace detail {

--- a/inference-engine/src/inference_engine/threading/ie_parallel_custom_arena.hpp
+++ b/inference-engine/src/inference_engine/threading/ie_parallel_custom_arena.hpp
@@ -114,6 +114,22 @@ public:
     }
 };
 
+struct task_scheduler_observer: public tbb::task_scheduler_observer {
+    task_scheduler_observer(custom::task_arena& arena) :
+        tbb::task_scheduler_observer(static_cast<tbb::task_arena&>(arena)),
+        my_arena(arena)
+    {}
+
+    void observe(bool state = true) {
+        if (state) {
+            my_arena.initialize();
+        }
+        tbb::task_scheduler_observer::observe(state);
+    }
+
+    custom::task_arena& my_arena;
+};
+
 namespace info {
     std::vector<numa_node_id> numa_nodes();
     std::vector<core_type_id> core_types();


### PR DESCRIPTION
There are several logic errors in `custom::task_arena` interface implementation. This patch reworks the custom arena construction and initialization logic to fix them.
Discovered errors:
- Several calls of concurrent unsafe `tbb::task_arena::initialize(constraints c)` via `custom::task_arena::execute()` may cause logic data race and assertion failure when using debug TBB binaries. The impact is low since may be reproduced only when using oneTBB 2021.
- When OpenVINO creates an observer for pinning threads to cores it calls the `tbb::task_scheduler_observer::observe(bool)` method, which initializes the `task_arena` instance that was passed to the observer during the construction as an argument. But we should initialize `custom::task_arena` instead of `tbb::task_arena` since `tbb::task_arena` initialization may miss creation of `binding_observer` inside the `custom::task_arena`. The impact is low since OpenVINO does not creates several observers for one arena.

The solution is to move all initialization details to `custom::task_arena` construction and create the wrapper for `task_scheduler_observer` in the `custom` namespace.

Please contact me if you need additional details.