### PR TITLE
Fix IE Python API search inside MO for Windows platform

### DIFF
--- a/model-optimizer/mo/utils/find_ie_version.py
+++ b/model-optimizer/mo/utils/find_ie_version.py
@@ -81,8 +81,10 @@ def find_ie_version(silent=False):
     python_version = 'python{}.{}'.format(sys.version_info[0], sys.version_info[1])
 
     script_path = os.path.realpath(os.path.dirname(__file__))
-    bindings_paths = [
-        # Windows
+
+    # Windows
+    bindings_paths_windows = [
+        # Package
         {
             "module": os.path.join(script_path, '../../../../python/', python_version),
             "libs": [
@@ -90,9 +92,29 @@ def find_ie_version(silent=False):
                 os.path.join(script_path, '../../../inference_engine/external/tbb/bin'),
                 os.path.join(script_path, '../../../ngraph/lib'),
             ],
-            "condition": lambda: sys.platform == "windows"
         },
-        # Linux / Darwin
+        # Local builds
+        {
+            "module": os.path.join(script_path, '../../../bin/intel64/Release/python_api/', python_version),
+            "libs": [
+                os.path.join(script_path, '../../../bin/intel64'),
+                os.path.join(script_path, '../../../bin/intel64/Release'),
+                os.path.join(script_path, '../../../inference-engine/temp/tbb/bin'),
+            ]
+        },
+        {
+            "module": os.path.join(script_path, '../../../bin/intel64/Debug/python_api/', python_version),
+            "libs": [
+                os.path.join(script_path, '../../../bin/intel64'),
+                os.path.join(script_path, '../../../bin/intel64/Debug'),
+                os.path.join(script_path, '../../../inference-engine/temp/tbb/bin'),
+            ]
+        },
+    ]
+
+    # Linux / Darwin
+    bindings_paths_linux = [
+        # Package
         {
             "module": os.path.join(script_path, '../../../../python/', python_version),
             "libs": [
@@ -100,7 +122,6 @@ def find_ie_version(silent=False):
                 os.path.join(script_path, '../../../inference_engine/external/tbb/lib'),
                 os.path.join(script_path, '../../../ngraph/lib'),
             ],
-            "condition": lambda: sys.platform != "windows"
         },
         # Local builds
         {
@@ -109,6 +130,7 @@ def find_ie_version(silent=False):
                 os.path.join(script_path, '../../../bin/intel64/Release/lib'),
             ]
         },
+
         {
             "module": os.path.join(script_path, '../../../bin/intel64/RelWithDebInfo/lib/python_api/', python_version),
             "libs": [
@@ -123,11 +145,10 @@ def find_ie_version(silent=False):
         }
     ]
 
+    bindings_paths = bindings_paths_windows if platform.system() == "Windows" else bindings_paths_linux
     for item in bindings_paths:
         module = item['module']
         if not os.path.exists(module):
-            continue
-        if "condition" in item and not item["condition"]():
             continue
         if try_to_import_ie(module=os.path.normpath(module), libs=item['libs'] if 'libs' in item else [], silent=silent):
             return True


### PR DESCRIPTION
### Description
IE Python API search wasn't working for Windows platform for local build type. This PR includes the fix for MO which specifies necessary paths to python modules and libs for Windows platform.