### PR TITLE
[IE CLDNN] Crop fsv16 i8/u8 input support

### DIFF
--- a/inference-engine/thirdparty/clDNN/src/gpu/crop_gpu.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/crop_gpu.cpp
@@ -95,6 +95,8 @@ attach_crop_gpu::attach_crop_gpu() {
     implementation_map<crop>::add(std::make_tuple(engine_types::ocl, data_types::i8, format::bfwzyx), val_fw);
     implementation_map<crop>::add(std::make_tuple(engine_types::ocl, data_types::u8, format::bfwzyx), val_fw);
 
+    implementation_map<crop>::add(std::make_tuple(engine_types::ocl, data_types::i8, format::b_fs_yx_fsv16), val_fw);
+    implementation_map<crop>::add(std::make_tuple(engine_types::ocl, data_types::u8, format::b_fs_yx_fsv16), val_fw);
     implementation_map<crop>::add(std::make_tuple(engine_types::ocl, data_types::f32, format::b_fs_yx_fsv16), val_fw);
     implementation_map<crop>::add(std::make_tuple(engine_types::ocl, data_types::f16, format::b_fs_yx_fsv16), val_fw);
 


### PR DESCRIPTION
### Details:
This patch adds support of i8/u8 inputs for b_fs_yx_fsv16 format for crop primitive

### Tickets:
55548
