### PR TITLE
[GNA] Replace int32_t type by size_t for levels in GNA quantization classes

### DIFF
--- a/inference-engine/src/gna_plugin/frontend/quantization.h
+++ b/inference-engine/src/gna_plugin/frontend/quantization.h
@@ -34,7 +34,7 @@ struct QuantizationCallback {
     uint32_t num_columns_padded;
 
     bool quantizedWeights;
-    int32_t fq_levels;
+    size_t fq_levels;
     const size_t fq_num_stats;
     const float *fq_ptr_input_low;
     const float *fq_ptr_input_high;

--- a/inference-engine/src/gna_plugin/frontend/quantized_layer_params.hpp
+++ b/inference-engine/src/gna_plugin/frontend/quantized_layer_params.hpp
@@ -18,10 +18,10 @@ public:
     bool IsScaleSet() const {
         return scale_set;
     }
-    void SetLevels(int32_t l) {
+    void SetLevels(size_t l) {
         levels = l;
     }
-    int32_t GetLevels() const {
+    size_t GetLevels() const {
         return levels;
     }
     bool IsStatsSet() const {
@@ -70,7 +70,7 @@ public:
 private:
     float scale = 1.0f;
     bool scale_set = false;
-    int32_t levels = 0;
+    size_t levels = 0;
     std::vector<float> input_min_values;
     std::vector<float> input_max_values;
     std::vector<float> output_min_values;

--- a/inference-engine/src/gna_plugin/layers/gna_fake_quantize_layer.hpp
+++ b/inference-engine/src/gna_plugin/layers/gna_fake_quantize_layer.hpp
@@ -63,7 +63,7 @@ class GNAFakeQuantizeLayer {
         return getInputLayerAt(fqLayer, 0);
     }
 
-    int32_t getLevels() {
+    size_t getLevels() {
         return fqLayer->GetParamAsSizeT("levels");
     }
 

--- a/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.cpp
+++ b/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.cpp
@@ -2146,7 +2146,10 @@ void MoveFakeQuantizeLayerIntoQuantParamsPass :: run() {
                 outputRange.first.front() << "," << outputRange.second.front() << ")";
         }
 
-        float fqLevels = fqLayer.getLevels();
+        auto fqLevels = fqLayer.getLevels();
+        if (fqLevels == 0) {
+            THROW_GNA_LAYER_EXCEPTION(fqLayer) << "Zero levels";
+        }
 
         // Before FQ layer is removed, the previous layer has to be updated with its quantization data
         auto quantParamsPrevLayer = InferenceEngine::getInjectedData<QuantizedLayerParams>(prevLayer);

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/fake_quantize.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/fake_quantize.cpp
@@ -50,7 +50,7 @@ const std::vector<std::vector<size_t>> inputShapes = {
             {8}
             };
 const std::vector<std::vector<size_t>> constShapes = {{1}};
-const std::vector<size_t> levels = {16, 255, 256};
+const std::vector<size_t> levels = {16, 255, 256, UINT32_MAX};
 
 const std::vector<std::vector<float>> fqArgs = {{}};
 const std::vector<std::vector<float>> inputParams = {{-10, 10, 0.1}, {}};
@@ -80,7 +80,7 @@ std::vector<std::vector<float>> getInputOutputShapes(const std::vector<float> in
 const auto fqParams = ::testing::Combine(
     ::testing::ValuesIn(levels),
     ::testing::ValuesIn(constShapes),
-    ::testing::ValuesIn(getInputOutputShapes(fqInputMin, fqInputMax, fqOutputMin, fqOutputMax, fqArgs)),
+    ::testing::ValuesIn(fqArgs),
     ::testing::ValuesIn(inputParams)
 );
 


### PR DESCRIPTION
### Details:
 - Replace int32_t type by size_t for levels in GNA quantization classes

### Tickets:
56549
