### PR TITLE
[GNA]  Insert AffineFilter after split when padding is needed.

### DIFF
--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/basic_lstm.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/basic_lstm.cpp
@@ -22,10 +22,19 @@ const std::vector<std::map<std::string, std::string>> configs = {
     }
 };
 
+const std::vector<std::pair<size_t, size_t>> size_params = {
+    {49, 118},
+    {300, 38},
+};
+
+const std::vector<bool> decompose = { false, true };
+
 INSTANTIATE_TEST_CASE_P(smoke_BasicLSTM, Basic_LSTM_S,
                         ::testing::Combine(
                             ::testing::ValuesIn(netPrecisions),
                             ::testing::Values(CommonTestUtils::DEVICE_GNA),
-                            ::testing::ValuesIn(configs)),
+                            ::testing::ValuesIn(configs),
+                            ::testing::ValuesIn(size_params),
+                            ::testing::ValuesIn(decompose)),
                         Basic_LSTM_S::getTestCaseName);
 }  // namespace

--- a/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/basic_lstm.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/basic_lstm.hpp
@@ -17,11 +17,11 @@ TEST_P(Basic_LSTM_S, CompareWithRefImpl_LowLatencyTransformation) {
                                                   InferenceEngine::SizeVector({1, hidden_size}),
                                                   InferenceEngine::Layout::NC);
     // Reshape
-    auto params = ngraph::builder::makeParams(function->get_parameters().at(0)->get_element_type(), { {1, 49} });
+    auto params = ngraph::builder::makeParams(function->get_parameters().at(0)->get_element_type(), { {1, third_dim} });
     function->replace_parameter(0, params[0]);
 
     // todo: it is better to modify the model -> use ShapeOf() and Gather()
-    std::vector<uint64_t> outFormShapes1 = { 1, 1, 49 };
+    std::vector<uint64_t> outFormShapes1 = { 1, 1, third_dim };
     auto pattern1 = std::make_shared<ngraph::opset1::Constant>(ngraph::element::Type_t::i64, ngraph::Shape{3}, outFormShapes1);
     auto param_target_inputs = function->get_parameters().at(0)->output(0).get_target_inputs();
 
@@ -30,6 +30,9 @@ TEST_P(Basic_LSTM_S, CompareWithRefImpl_LowLatencyTransformation) {
         target.replace_source_output(pattern1);
     }
     function->validate_nodes_and_infer_types();
+
+    // Generate inputs
+    GenerateInputs();
 
     // Calculate References for the network before transformation passes
     auto referenceOutputs = CalculateRefs();
@@ -56,7 +59,6 @@ TEST_P(Basic_LSTM_S, CompareWithRefImpl_LowLatencyTransformation) {
         }
     }
     IE_SUPPRESS_DEPRECATED_END
-    GenerateInputs();
     // Run and compare
     Infer();
     const auto& actualOutputs = GetOutputs();

--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/basic_lstm.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/basic_lstm.hpp
@@ -18,7 +18,9 @@ namespace SubgraphTestsDefinitions {
 typedef std::tuple<
         InferenceEngine::Precision,          // Network Precision
         std::string,                         // Target Device
-        std::map<std::string, std::string>   // Configuration
+        std::map<std::string, std::string>,  // Configuration
+        std::pair<size_t, size_t>,           // Third dimenstion and hidden size
+        bool                                 // Decompose LSTMCell
 > basicLstmParams;
 
 class Basic_LSTM_S : public testing::WithParamInterface<basicLstmParams>,
@@ -32,8 +34,10 @@ public:
         const InferenceEngine::Precision& netPrecission = InferenceEngine::Precision::FP32,
         std::vector<float>* hidden_memory_init_out = nullptr,
         std::vector<float>* cell_memory_init_out = nullptr);
+    void GenerateInputs() override;
 protected:
     size_t hidden_size;
+    size_t third_dim;
     std::vector<float> hidden_memory_init;
     std::vector<float> cell_memory_init;
     void SetUp() override;


### PR DESCRIPTION
### Details:
 - *Insert AffineFilter after the split when padding is needed for the input of the child layer (input should be multiple of 8).*
 - *Fix CompareWithRefImpl_LowLatencyTransformation test: reference was calculated before setting of inputs generation what was causing non deterministic failures.*

### Tickets:
 - *56171*
