### PR TITLE
Make stress and time tests build dependent from gflags from samples

### DIFF
--- a/tests/stress_tests/CMakeLists.txt
+++ b/tests/stress_tests/CMakeLists.txt
@@ -9,10 +9,30 @@ if (CMAKE_BUILD_TYPE STREQUAL "")
     set(CMAKE_BUILD_TYPE "Release")
 endif()
 
+set (GFLAGS_IS_SUBPROJECT TRUE)
 set (HAVE_SYS_STAT_H 1)
 set (HAVE_INTTYPES_H 1)
 set (INTTYPES_FORMAT C99)
+set (BUILD_TESTING OFF)
+
 find_package(InferenceEngineDeveloperPackage REQUIRED)
+
+set(OpenVINO_MAIN_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../")
+
+if(EXISTS "${OpenVINO_MAIN_SOURCE_DIR}/inference-engine/samples/thirdparty/gflags")
+    function(add_gflags)
+        if(NOT WIN32)
+            set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-all")
+            set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-all")
+        endif()
+        set(BUILD_SHARED_LIBS OFF)
+        add_subdirectory(${OpenVINO_MAIN_SOURCE_DIR}/inference-engine/samples/thirdparty/gflags
+                         ${CMAKE_CURRENT_BINARY_DIR}/gflags_build
+                         EXCLUDE_FROM_ALL)
+        set_target_properties(gflags_nothreads_static PROPERTIES FOLDER thirdparty)
+    endfunction()
+    add_gflags()
+endif()
 
 add_subdirectory(unittests)
 add_subdirectory(memleaks_tests)

--- a/tests/stress_tests/memcheck_tests/CMakeLists.txt
+++ b/tests/stress_tests/memcheck_tests/CMakeLists.txt
@@ -19,18 +19,6 @@ file (GLOB HDR
 # Create library file from sources.
 add_executable(${TARGET_NAME} ${HDR} ${SRC})
 
-include(FetchContent)
-FetchContent_Declare(
-    gflags
-    GIT_REPOSITORY "https://github.com/gflags/gflags.git"
-    GIT_TAG "v2.2.2"
-)
-FetchContent_GetProperties(gflags)
-if(NOT gflags_POPULATED)
-    FetchContent_Populate(gflags)
-    add_subdirectory(${gflags_SOURCE_DIR} ${gflags_BINARY_DIR})
-endif()
-
 target_link_libraries(${TARGET_NAME}
         IE::gtest
         IE::gtest_main

--- a/tests/stress_tests/memleaks_tests/CMakeLists.txt
+++ b/tests/stress_tests/memleaks_tests/CMakeLists.txt
@@ -20,18 +20,6 @@ file (GLOB HDR
 # Create library file from sources.
 add_executable(${TARGET_NAME} ${HDR} ${SRC})
 
-include(FetchContent)
-FetchContent_Declare(
-    gflags
-    GIT_REPOSITORY "https://github.com/gflags/gflags.git"
-    GIT_TAG "v2.2.2"
-)
-FetchContent_GetProperties(gflags)
-if(NOT gflags_POPULATED)
-    FetchContent_Populate(gflags)
-    add_subdirectory(${gflags_SOURCE_DIR} ${gflags_BINARY_DIR})
-endif()
-
 target_link_libraries(${TARGET_NAME}
         IE::gtest
         IE::gtest_main

--- a/tests/stress_tests/unittests/CMakeLists.txt
+++ b/tests/stress_tests/unittests/CMakeLists.txt
@@ -20,18 +20,6 @@ file (GLOB HDR
 # Create library file from sources.
 add_executable(${TARGET_NAME} ${HDR} ${SRC})
 
-include(FetchContent)
-FetchContent_Declare(
-    gflags
-    GIT_REPOSITORY "https://github.com/gflags/gflags.git"
-    GIT_TAG "v2.2.2"
-)
-FetchContent_GetProperties(gflags)
-if(NOT gflags_POPULATED)
-    FetchContent_Populate(gflags)
-    add_subdirectory(${gflags_SOURCE_DIR} ${gflags_BINARY_DIR})
-endif()
-
 target_link_libraries(${TARGET_NAME}
         IE::gtest
         IE::gtest_main

--- a/tests/time_tests/CMakeLists.txt
+++ b/tests/time_tests/CMakeLists.txt
@@ -5,10 +5,27 @@
 cmake_minimum_required(VERSION 3.13)
 
 set (CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the build type")
-set (CMAKE_CXX_STANDARD 11)
 
 project(time_tests)
 
 set(OpenVINO_MAIN_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../")
+
+# Search OpenVINO Inference Engine installed
+find_package(InferenceEngine)
+if (NOT InferenceEngine_FOUND)
+    # Search OpenVINO Inference Engine via InferenceEngine_DIR
+    find_package(IEDevScripts
+                 PATHS "${OpenVINO_MAIN_SOURCE_DIR}/cmake/developer_package"
+                 NO_CMAKE_FIND_ROOT_PATH
+                 NO_DEFAULT_PATH)
+    if (NOT InferenceEngine_FOUND)
+        # Search OpenVINO Inference Engine via InferenceEngineDeveloperPackage_DIR
+        # in order to provide backward compatibility with old OpenVINO packages
+        set (HAVE_SYS_STAT_H 1)
+        set (HAVE_INTTYPES_H 1)
+        set (INTTYPES_FORMAT C99)
+        find_package(InferenceEngineDeveloperPackage REQUIRED)
+    endif()
+endif()
 
 add_subdirectory(src)

--- a/tests/time_tests/CMakeLists.txt
+++ b/tests/time_tests/CMakeLists.txt
@@ -5,16 +5,10 @@
 cmake_minimum_required(VERSION 3.13)
 
 set (CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the build type")
+set (CMAKE_CXX_STANDARD 11)
 
 project(time_tests)
 
-
-find_package(InferenceEngine)
-if (NOT InferenceEngine_FOUND)
-    set (HAVE_SYS_STAT_H 1)
-    set (HAVE_INTTYPES_H 1)
-    set (INTTYPES_FORMAT C99)
-    find_package(InferenceEngineDeveloperPackage REQUIRED)
-endif()
+set(OpenVINO_MAIN_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../")
 
 add_subdirectory(src)

--- a/tests/time_tests/README.md
+++ b/tests/time_tests/README.md
@@ -23,9 +23,12 @@ If you don't have OpenVINO™ installed you need to have the `build` folder, whi
 is created when you configure and build OpenVINO™ from sources:
 
 ``` bash
+cmake .. -DInferenceEngine_DIR=$(realpath ../../../build) && make time_tests
+```
+For old versions of OpenVINO™ from sources use `-DInferenceEngineDeveloperPackage_DIR`:
+``` bash
 cmake .. -DInferenceEngineDeveloperPackage_DIR=$(realpath ../../../build) && make time_tests
 ```
-
 
 2. Run test:
 ``` bash

--- a/tests/time_tests/src/timetests/CMakeLists.txt
+++ b/tests/time_tests/src/timetests/CMakeLists.txt
@@ -5,6 +5,24 @@
 # add dummy `time_tests` target combines all time tests
 add_custom_target(time_tests)
 
+# Search OpenVINO Inference Engine installed
+find_package(InferenceEngine)
+if (NOT InferenceEngine_FOUND)
+    # Search OpenVINO Inference Engine via InferenceEngine_DIR
+    find_package(IEDevScripts
+                 PATHS "${OpenVINO_MAIN_SOURCE_DIR}/cmake/developer_package"
+                 NO_CMAKE_FIND_ROOT_PATH
+                 NO_DEFAULT_PATH)
+    if (NOT InferenceEngine_FOUND)
+        # Search OpenVINO Inference Engine via InferenceEngineDeveloperPackage_DIR
+        # in order to provide backward compatibility with old OpenVINO packages
+        set (HAVE_SYS_STAT_H 1)
+        set (HAVE_INTTYPES_H 1)
+        set (INTTYPES_FORMAT C99)
+        find_package(InferenceEngineDeveloperPackage REQUIRED)
+    endif()
+endif()
+
 # Build test from every source file.
 # Test target name is source file name without extension.
 FILE(GLOB tests "*.cpp")

--- a/tests/time_tests/src/timetests/CMakeLists.txt
+++ b/tests/time_tests/src/timetests/CMakeLists.txt
@@ -5,24 +5,6 @@
 # add dummy `time_tests` target combines all time tests
 add_custom_target(time_tests)
 
-# Search OpenVINO Inference Engine installed
-find_package(InferenceEngine)
-if (NOT InferenceEngine_FOUND)
-    # Search OpenVINO Inference Engine via InferenceEngine_DIR
-    find_package(IEDevScripts
-                 PATHS "${OpenVINO_MAIN_SOURCE_DIR}/cmake/developer_package"
-                 NO_CMAKE_FIND_ROOT_PATH
-                 NO_DEFAULT_PATH)
-    if (NOT InferenceEngine_FOUND)
-        # Search OpenVINO Inference Engine via InferenceEngineDeveloperPackage_DIR
-        # in order to provide backward compatibility with old OpenVINO packages
-        set (HAVE_SYS_STAT_H 1)
-        set (HAVE_INTTYPES_H 1)
-        set (INTTYPES_FORMAT C99)
-        find_package(InferenceEngineDeveloperPackage REQUIRED)
-    endif()
-endif()
-
 # Build test from every source file.
 # Test target name is source file name without extension.
 FILE(GLOB tests "*.cpp")

--- a/tests/time_tests/src/timetests_helper/CMakeLists.txt
+++ b/tests/time_tests/src/timetests_helper/CMakeLists.txt
@@ -8,16 +8,25 @@ file (GLOB SRC *.cpp)
 add_library(${TARGET_NAME} STATIC ${SRC})
 target_include_directories(${TARGET_NAME} PUBLIC "${CMAKE_SOURCE_DIR}/include")
 
-include(FetchContent)
-FetchContent_Declare(
-    gflags
-    GIT_REPOSITORY "https://github.com/gflags/gflags.git"
-    GIT_TAG "v2.2.2"
-)
-FetchContent_GetProperties(gflags)
-if(NOT gflags_POPULATED)
-    FetchContent_Populate(gflags)
-    add_subdirectory(${gflags_SOURCE_DIR} ${gflags_BINARY_DIR})
+set (GFLAGS_IS_SUBPROJECT TRUE)
+set (HAVE_SYS_STAT_H 1)
+set (HAVE_INTTYPES_H 1)
+set (INTTYPES_FORMAT C99)
+set (BUILD_TESTING OFF)
+
+if(EXISTS "${OpenVINO_MAIN_SOURCE_DIR}/inference-engine/samples/thirdparty/gflags")
+    function(add_gflags)
+        if(NOT WIN32)
+            set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-all")
+            set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-all")
+        endif()
+        set(BUILD_SHARED_LIBS OFF)
+        add_subdirectory(${OpenVINO_MAIN_SOURCE_DIR}/inference-engine/samples/thirdparty/gflags
+                         ${CMAKE_CURRENT_BINARY_DIR}/gflags_build
+                         EXCLUDE_FROM_ALL)
+        set_target_properties(gflags_nothreads_static PROPERTIES FOLDER thirdparty)
+    endfunction()
+    add_gflags()
 endif()
 
 target_link_libraries(${TARGET_NAME} gflags)

--- a/tests/time_tests/src/timetests_helper/CMakeLists.txt
+++ b/tests/time_tests/src/timetests_helper/CMakeLists.txt
@@ -9,10 +9,11 @@ add_library(${TARGET_NAME} STATIC ${SRC})
 target_include_directories(${TARGET_NAME} PUBLIC "${CMAKE_SOURCE_DIR}/include")
 
 set (GFLAGS_IS_SUBPROJECT TRUE)
+set (BUILD_TESTING OFF)
+
 set (HAVE_SYS_STAT_H 1)
 set (HAVE_INTTYPES_H 1)
 set (INTTYPES_FORMAT C99)
-set (BUILD_TESTING OFF)
 
 if(EXISTS "${OpenVINO_MAIN_SOURCE_DIR}/inference-engine/samples/thirdparty/gflags")
     function(add_gflags)


### PR DESCRIPTION
### Original issue:
Stress and Time tests are suffered from sporadic issues caused by fail on building of `gflags_nothreads_shared`. Possible rootcause is a network issue while downloading `gflags` sources via cmake FetchContent. With aim to resolve that rootcause and unify `gflags` source for OpenVINO, `gflags` will be consumed as OpenVINO git submodule 
### Details:
 - Time tests now based on IEDevScripts. InferenceEngineDeveloperPackage dependency left in order to provide backward compatibility
 - Stress tests based on InferenceEngineDeveloperPackage because it requires gtest from IE tests

### Tickets:
 - 55465
