### PR TITLE
CTCGreedyDecoder operation specification refactoring

### DIFF
--- a/docs/ops/sequence/CTCGreedyDecoder_1.md
+++ b/docs/ops/sequence/CTCGreedyDecoder_1.md
@@ -7,9 +7,6 @@
 **Short description**: *CTCGreedyDecoder* performs greedy decoding on the logits given in input (best path).
 
 **Detailed description**:
-
-This operation is similar [Reference](https://www.tensorflow.org/api_docs/python/tf/nn/ctc_greedy_decoder)
-
 Given an input sequence \f$X\f$ of length \f$T\f$, *CTCGreedyDecoder* assumes the probability of a length \f$T\f$ character sequence \f$C\f$ is given by
 \f[
 p(C|X) = \prod_{t=1}^{T} p(c_{t}|X)
@@ -24,20 +21,23 @@ Sequences in the batch can have different length. The lengths of sequences are c
 * *ctc_merge_repeated*
 
   * **Description**: *ctc_merge_repeated* is a flag for merging repeated labels during the CTC calculation.
-  * **Range of values**: true or false 
+  * **Range of values**: `true` or `false`
   * **Type**: `boolean`
-  * **Default value**: true 
+  * **Default value**: `true`
   * **Required**: *no*
 
 **Inputs**
 
-* **1**: `data` - Input tensor with a batch of sequences. Type of elements is any supported floating point type. Shape of the tensor is `[T, N, C]`, where `T` is the maximum sequence length, `N` is the batch size and `C` is the number of classes. Required.
+* **1**: `data` - input tensor with batch of sequences of type `T_F` and shape `[T, N, C]`, where `T` is the maximum sequence length, `N` is the batch size and `C` is the number of classes. **Required.**
 
-* **2**: `sequence_mask` - 2D input floating point tensor with sequence masks for each sequence in the batch. Populated with values 0 and 1. Shape of this input is `[T, N]`. Required.
+* **2**: `sequence_mask` - input tensor with sequence masks for each sequence in the batch of type `T_F` populated with values `0` and `1` and shape `[T, N]`. **Required.**
 
 **Output**
 
-* **1**: Output tensor with shape `[N, T, 1, 1]` and integer elements containing final sequence class indices. A final sequence can be shorter that the size `T` of the tensor, all elements that do not code sequence classes are filled with -1. Type of elements is floating point, but all values are integers.
+* **1**: Output tensor of type `T_F` and shape `[N, T, 1, 1]` which is filled with integer elements containing final sequence class indices. A final sequence can be shorter that the size `T` of the tensor, all elements that do not code sequence classes are filled with -1.
+
+**Types**
+* *T_F*: any supported floating point type.
 
 **Example**
 

--- a/docs/ops/sequence/CTCGreedyDecoder_1.md
+++ b/docs/ops/sequence/CTCGreedyDecoder_1.md
@@ -34,7 +34,7 @@ Sequences in the batch can have different length. The lengths of sequences are c
 
 **Output**
 
-* **1**: Output tensor of type `T_F` and shape `[N, T, 1, 1]` which is filled with integer elements containing final sequence class indices. A final sequence can be shorter that the size `T` of the tensor, all elements that do not code sequence classes are filled with -1.
+* **1**: Output tensor of type `T_F` and shape `[N, T, 1, 1]` which is filled with integer elements containing final sequence class indices. A final sequence can be shorter that the size `T` of the tensor, all elements that do not code sequence classes are filled with `-1`.
 
 **Types**
 * *T_F*: any supported floating point type.


### PR DESCRIPTION
### Details:
 - Removed link to tensorflow documentation
 - Added *Types* section
 - Added backticks to types
 - Refactor input/output tensor description to refer types section.

### Tickets:
 - *56032*
