### PR TITLE
samples: fix klocwork beyond boundary of array issue

### DIFF
--- a/inference-engine/samples/common/utils/include/samples/classification_results.h
+++ b/inference-engine/samples/common/utils/include/samples/classification_results.h
@@ -167,7 +167,7 @@ public:
                 std::cout << std::left << std::setw(static_cast<int>(_probabilityStr.length())) << std::fixed << result;
 
                 if (!_labels.empty()) {
-                    std::cout << " " + _labels[_results[id]];
+                    std::cout << " " + _labels[_results.at(id)];
                 }
                 std::cout << std::endl;
             }


### PR DESCRIPTION
### Details:
 - Fix Potentially untrusted data 'id' can be used to read arbitrary data beyond boundary of array 'this->_results' at line 170 in speculative branch execution