### PR TITLE
[CPU] Fix for  CoreThreadingTestsWithIterations tests

### DIFF
--- a/inference-engine/src/mkldnn_plugin/mkldnn_weights_cache.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_weights_cache.cpp
@@ -43,8 +43,7 @@ MKLDNNWeightsSharing::MKLDNNSharedMemory::Ptr MKLDNNWeightsSharing::findOrCreate
     MKLDNNMemoryPtr newPtr;
 
     if (found == sharedWeights.end()
-        || !(ptr = found->second)
-        || ptr->sharedMemory.expired()) {
+        || !((ptr = found->second) && (newPtr = ptr->sharedMemory.lock()))) {
         newPtr = create();
         ptr = std::make_shared<MKLDNNMemoryInfo>(newPtr, valid);
         sharedWeights[key] = ptr;

--- a/inference-engine/src/mkldnn_plugin/mkldnn_weights_cache.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_weights_cache.cpp
@@ -59,15 +59,15 @@ MKLDNNWeightsSharing::MKLDNNSharedMemory::Ptr MKLDNNWeightsSharing::get(const st
     auto found = sharedWeights.find(key);
 
     MKLDNNMemoryInfo::Ptr ptr;
+    MKLDNNMemoryPtr newPtr;
 
     if (found == sharedWeights.end()
-        || !(ptr = found->second)
-        || ptr->sharedMemory.expired())
+        || !((ptr = found->second) && (newPtr = ptr->sharedMemory.lock())))
         IE_THROW() << "Unknown shared memory with key " << key;
 
     return std::make_shared<MKLDNNSharedMemory>(ptr->valid
                                                 ? std::unique_lock<std::mutex>(ptr->guard, std::defer_lock)
-                                                : std::unique_lock<std::mutex>(ptr->guard), ptr);
+                                                : std::unique_lock<std::mutex>(ptr->guard), ptr, newPtr);
 }
 
 NumaNodesWeights::NumaNodesWeights() {

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
@@ -52,9 +52,6 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*BinaryConvolutionLayerTest.*)",
         R"(.*ClampLayerTest.*netPrc=(I64|I32).*)",
         R"(.*ClampLayerTest.*netPrc=U64.*)",
-        // TODO: 42538. Unexpected application crash
-        R"(.*CoreThreadingTestsWithIterations\.smoke_LoadNetwork.t.*)",
-        R"(.*CoreThreadingTestsWithIterations\.smoke_LoadNetworkAccuracy.*AUTO.*)",
         // TODO: 53618. BF16 gemm ncsp convolution crash
         R"(.*_GroupConv.*_inPRC=BF16.*_inFmts=nc.*_primitive=jit_gemm.*)",
         // TODO: 53578. fork DW bf16 convolution does not support 3d cases yet


### PR DESCRIPTION
### Details:
Prevent destruction of the shared memory object if the last stream that holds the memory was destroyed between checking the week pointer expiration and acquisition by a new stream.

### Tickets:
 - 42538
