### PR TITLE
Hiding the problem, Validate() changes 'function'

### DIFF
--- a/inference-engine/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
@@ -45,21 +45,22 @@ void LayerTestsCommon::Run() {
         s.updateOPsStats(function, PassRate::Statuses::CRASHED);
     }
 
+    auto function_ = function;
     try {
         LoadNetwork();
         GenerateInputs();
         Infer();
         Validate();
-        s.updateOPsStats(function, PassRate::Statuses::PASSED);
+        s.updateOPsStats(function_, PassRate::Statuses::PASSED);
     }
     catch (const std::runtime_error &re) {
-        s.updateOPsStats(function, PassRate::Statuses::FAILED);
+        s.updateOPsStats(function_, PassRate::Statuses::FAILED);
         GTEST_FATAL_FAILURE_(re.what());
     } catch (const std::exception &ex) {
-        s.updateOPsStats(function, PassRate::Statuses::FAILED);
+        s.updateOPsStats(function_, PassRate::Statuses::FAILED);
         GTEST_FATAL_FAILURE_(ex.what());
     } catch (...) {
-        s.updateOPsStats(function, PassRate::Statuses::FAILED);
+        s.updateOPsStats(function_, PassRate::Statuses::FAILED);
         GTEST_FATAL_FAILURE_("Unknown failure occurred.");
     }
 }


### PR DESCRIPTION
### Details:
 - The **Validate()** function call on line 52 in openvino/inference-engine/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp **screws up** the value of the **'function' variable**, but not expected. Need a new ticket for this.

### Tickets:
 - CVS-56973
