### PR TITLE
Enabled ONNX importer part on ia32 arch

### DIFF
--- a/cmake/toolchains/ia32.linux.toolchain.cmake
+++ b/cmake/toolchains/ia32.linux.toolchain.cmake
@@ -19,7 +19,3 @@ endmacro()
 
 # need libusb 32-bits version
 _set_if_not_defined(ENABLE_VPU OFF)
-
-# fix conversion from uint64_t / int64_t to size_t
-_set_if_not_defined(NGRAPH_ONNX_IMPORT_ENABLE OFF)
-_set_if_not_defined(NGRAPH_ONNX_EDITOR_ENABLE OFF)


### PR DESCRIPTION
### Details:
 - Looks like ONNX imported is fixed for ia32

### Tickets:
 - CVS-48064
