### PR TITLE
Fix for data race in MKLDNNSharedMemory::valid

### DIFF
--- a/inference-engine/src/mkldnn_plugin/mkldnn_weights_cache.hpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_weights_cache.hpp
@@ -10,6 +10,7 @@
 #include <functional>
 #include <string>
 #include <memory>
+#include <atomic>
 #include <mutex>
 #include <map>
 
@@ -62,7 +63,7 @@ class MKLDNNWeightsSharing {
 
         std::mutex guard;
         std::weak_ptr<MKLDNNMemory> sharedMemory;
-        bool valid;
+        std::atomic<bool> valid;
     };
 
 public:


### PR DESCRIPTION
### Details:
 - Fix for data race in MKLDNNSharedMemory::valid

### Tickets:
 - CVS-55643
