### PR TITLE
Add support for fp64 in Convert's evaluate

### DIFF
--- a/ngraph/core/src/op/convert.cpp
+++ b/ngraph/core/src/op/convert.cpp
@@ -104,6 +104,7 @@ namespace convert
             TYPE_OUT_CASE(bf16, arg, out);
             TYPE_OUT_CASE(f16, arg, out);
             TYPE_OUT_CASE(f32, arg, out);
+            TYPE_OUT_CASE(f64, arg, out);
             TYPE_OUT_CASE(boolean, arg, out);
         default: rc = false; break;
         }
@@ -129,6 +130,7 @@ namespace convert
             NGRAPH_TYPE_CASE(evaluate_convert, bf16, arg, out);
             NGRAPH_TYPE_CASE(evaluate_convert, f16, arg, out);
             NGRAPH_TYPE_CASE(evaluate_convert, f32, arg, out);
+            NGRAPH_TYPE_CASE(evaluate_convert, f64, arg, out);
             NGRAPH_TYPE_CASE(evaluate_convert, boolean, arg, out);
         default: rc = false; break;
         }
@@ -200,6 +202,7 @@ bool op::v0::Convert::has_evaluate() const
     case ngraph::element::bf16:
     case ngraph::element::f16:
     case ngraph::element::f32:
+    case ngraph::element::f64:
     case ngraph::element::boolean: break;
     default: return false;
     }
@@ -219,6 +222,7 @@ bool op::v0::Convert::has_evaluate() const
     case ngraph::element::bf16:
     case ngraph::element::f16:
     case ngraph::element::f32:
+    case ngraph::element::f64:
     case ngraph::element::boolean: break;
     default: return false;
     }

--- a/ngraph/test/constant_folding.cpp
+++ b/ngraph/test/constant_folding.cpp
@@ -459,6 +459,16 @@ TEST(constant_folding, const_convert)
         vector<bool> expected{true, false, true, false, true, false, true};
         test_const_convert(in, expected);
     }
+    {
+        vector<int64_t> in{1, 2, 3, 4, 5};
+        vector<double> expected{1.0, 2.0, 3.0, 4.0, 5.0};
+        test_const_convert(in, expected);
+    }
+    {
+        vector<double> in{1.2, 2.1, 3.3, 4.45, 5.02};
+        vector<int64_t> expected{1, 2, 3, 4, 5};
+        test_const_convert(in, expected);
+    }
 }
 
 TEST(constant_folding, shape_of_v0)


### PR DESCRIPTION
It's required for t2t-vit models.
