### PR TITLE
samples: fix klocwork fiunitialized infilename variable

### DIFF
--- a/inference-engine/samples/common/utils/include/samples/csv_dumper.hpp
+++ b/inference-engine/samples/common/utils/include/samples/csv_dumper.hpp
@@ -18,7 +18,7 @@
  */
 class CsvDumper {
     std::ofstream file;
-    std::string filename;
+    std::string filename = "";
     bool canDump = true;
     char delimiter = ';';
 


### PR DESCRIPTION
### Details:
 - fix klocwork: 'this->filename' is not initialized in this constructor.
