### PR TITLE
Pruning with FQ support

### DIFF
--- a/inference-engine/src/offline_transformations/include/pruning.hpp
+++ b/inference-engine/src/offline_transformations/include/pruning.hpp
@@ -14,6 +14,7 @@ namespace ngraph {
 namespace pass {
 
 class InitConstMask;
+class InitMasks;
 class PropagateMasks;
 class ShrinkWeights;
 
@@ -21,6 +22,16 @@ class Pruning;
 
 } // namespace pass
 } // namespace ngraph
+
+/**
+ * @ingroup ie_transformation_common_api
+ * @brief Initialising masks for pruned operations
+ */
+class ngraph::pass::InitMasks : public ngraph::pass::GraphRewrite {
+public:
+    NGRAPH_RTTI_DECLARATION;
+    InitMasks();
+};
 
 /**
  * @ingroup ie_transformation_common_api

--- a/inference-engine/src/offline_transformations/src/pruning/init_const_mask.cpp
+++ b/inference-engine/src/offline_transformations/src/pruning/init_const_mask.cpp
@@ -17,7 +17,7 @@ NGRAPH_RTTI_DEFINITION(ngraph::pass::InitConstMask, "InitConstMask", 0);
 ngraph::pass::InitConstMask::InitConstMask(const ngraph::AxisSet & dims,
                                            const std::function<bool(const double & value)> & condition) {
     auto constant = pattern::wrap_type<opset6::Constant>(
-            pattern::type_matches_any({ element::i8, element::u8, element::f16, element::f32, element::f64}));
+            pattern::type_matches_any({element::i8, element::u8, element::f16, element::f32, element::f64}));
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
         auto const_node = std::dynamic_pointer_cast<opset6::Constant>(m.get_match_root());

--- a/inference-engine/src/offline_transformations/src/pruning/init_const_mask.cpp
+++ b/inference-engine/src/offline_transformations/src/pruning/init_const_mask.cpp
@@ -17,7 +17,7 @@ NGRAPH_RTTI_DEFINITION(ngraph::pass::InitConstMask, "InitConstMask", 0);
 ngraph::pass::InitConstMask::InitConstMask(const ngraph::AxisSet & dims,
                                            const std::function<bool(const double & value)> & condition) {
     auto constant = pattern::wrap_type<opset6::Constant>(
-            pattern::type_matches_any({element::f16, element::f32, element::f64}));
+            pattern::type_matches_any({ element::i8, element::u8, element::f16, element::f32, element::f64}));
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
         auto const_node = std::dynamic_pointer_cast<opset6::Constant>(m.get_match_root());

--- a/inference-engine/src/offline_transformations/src/pruning/init_masks.cpp
+++ b/inference-engine/src/offline_transformations/src/pruning/init_masks.cpp
@@ -1,0 +1,65 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "pruning.hpp"
+#include "mask_attribute.hpp"
+
+#include <ngraph/pattern/op/wrap_type.hpp>
+#include <ngraph/opsets/opset6.hpp>
+#include <ngraph/log.hpp>
+
+NGRAPH_RTTI_DEFINITION(ngraph::pass::InitMasks, "InitMasks", 0);
+
+namespace ngraph {
+namespace pass {
+namespace init_masks {
+
+class InitConvMask;
+
+} // namespace init_masks
+} // namespace pass
+} // namespace ngraph
+
+// TODO: add same for Group Conv
+class ngraph::pass::init_masks::InitConvMask : public MatcherPass {
+public:
+    InitConvMask() {
+        auto input = pattern::any_input();
+        auto weights = pattern::any_input();
+        auto conv = pattern::wrap_type<opset6::Convolution>({input, weights});
+
+        ngraph::matcher_pass_callback callback = [=](ngraph::pattern::Matcher& m) {
+            const auto & pattern_map = m.get_pattern_value_map();
+            const auto & m_output = pattern_map.at(conv);
+
+            // Initializing weights mask:
+            // 1. Looking for Const node with weights
+            std::vector<std::shared_ptr<Node>> weights_calculation_nodes;
+            auto cur_node = m_output.get_node()->get_input_node_shared_ptr(1);
+
+            while (!ngraph::is_type<opset6::Constant>(cur_node) && cur_node->inputs().size()) {
+                weights_calculation_nodes.push_back(cur_node);
+                cur_node = cur_node->get_input_node_shared_ptr(0);
+            }
+            if (!ngraph::is_type<opset6::Constant>(cur_node)) {
+                NGRAPH_DEBUG << "Can't find Constant weights for Convolution: " <<
+                m_output.get_node()->get_friendly_name() << std::endl;
+                return false;
+            }
+
+            // 2. Init mask for Const node
+            InitConstMask({0}/* check only output channels dim */).apply(cur_node);
+            return true;
+        };
+
+        auto m = std::make_shared<ngraph::pattern::Matcher>(conv, "ConvolutionInitMask");
+        register_matcher(m, callback);
+    }
+};
+
+
+ngraph::pass::InitMasks::InitMasks() {
+    add_matcher<init_masks::InitConvMask>();
+}
+

--- a/inference-engine/src/offline_transformations/src/pruning/init_masks.cpp
+++ b/inference-engine/src/offline_transformations/src/pruning/init_masks.cpp
@@ -27,7 +27,7 @@ public:
     InitConvMask() {
         auto input = pattern::any_input();
         auto weights = pattern::any_input();
-        auto conv = pattern::wrap_type<opset6::Convolution>({input, weights});
+        auto conv = pattern::wrap_type<opset6::Convolution, opset6::GroupConvolution>({input, weights});
 
         ngraph::matcher_pass_callback callback = [=](ngraph::pattern::Matcher& m) {
             const auto & pattern_map = m.get_pattern_value_map();

--- a/inference-engine/src/offline_transformations/src/pruning/init_masks.cpp
+++ b/inference-engine/src/offline_transformations/src/pruning/init_masks.cpp
@@ -21,7 +21,6 @@ class InitConvMask;
 } // namespace pass
 } // namespace ngraph
 
-// TODO: add same for Group Conv
 class ngraph::pass::init_masks::InitConvMask : public MatcherPass {
 public:
     InitConvMask() {
@@ -35,7 +34,7 @@ public:
 
             // Initializing weights mask:
             // 1. Looking for Const node with weights
-            std::vector<std::shared_ptr<Node>> weights_calculation_nodes;
+            NodeVector weights_calculation_nodes;
             auto cur_node = m_output.get_node()->get_input_node_shared_ptr(1);
 
             while (!ngraph::is_type<opset6::Constant>(cur_node) && cur_node->inputs().size()) {

--- a/inference-engine/src/offline_transformations/src/pruning/propagate_masks.cpp
+++ b/inference-engine/src/offline_transformations/src/pruning/propagate_masks.cpp
@@ -7,7 +7,9 @@
 
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/opsets/opset6.hpp>
+#include <ngraph/opsets/opset5.hpp>
 #include <ngraph/log.hpp>
+#include <ngraph/rt_info.hpp>
 
 NGRAPH_RTTI_DEFINITION(ngraph::pass::PropagateMasks, "PropagateMasks", 0);
 
@@ -20,6 +22,8 @@ class GroupConvolution;
 class Elementwise;
 class PassThrough;
 class StopPropagation;
+class FakeQuantize;
+class Concat;
 
 } // namespace mask_propagation
 } // namespace pass
@@ -38,12 +42,13 @@ public:
             const auto & m_output = pattern_map.at(conv);
             const auto & m_input = pattern_map.at(input);
 
-            // In case if weights are Constant we initialize Mask
-            InitConstMask({0}/* check only output channel */).apply(m_weights.get_node_shared_ptr());
-
             auto weights_mask = getMask(m_weights);
-            // If weights are not a Constant and we didn't set Mask value before we will get nullptr
-            if (!weights_mask) return false;
+
+            // If weights mask still not initialized -> convolution can't be pruned
+            if (!weights_mask) {
+                NGRAPH_DEBUG << "CONV: No weights mask for " << *m_output.get_node() << "\n";
+                return false;
+                }
             auto weights_mask_row = weights_mask.get();
 
             if (auto input_mask = getMask(m_input)) {
@@ -169,36 +174,57 @@ public:
     }
 };
 
+// TODO: add Div, Power support
 class ngraph::pass::mask_propagation::Elementwise : public MatcherPass {
 public:
     Elementwise() {
         auto input = pattern::any_input();
         auto weights = pattern::any_input();
-        auto eltwise = pattern::wrap_type<op::util::BinaryElementwiseArithmetic>({input, weights},
-                                                                                 pattern::has_static_rank());
-
+        auto eltwise = pattern::wrap_type<opset6::Add, opset6::Subtract, opset6::Maximum, opset6::Minimum,
+        opset6::Multiply>({input, weights}, pattern::has_static_rank());
+        // op::util::BinaryElementwiseArithmetic
         ngraph::matcher_pass_callback callback = [=](ngraph::pattern::Matcher& m) {
             const auto & pattern_map = m.get_pattern_value_map();
             const auto & m_weights = pattern_map.at(weights);
             const auto & m_output = pattern_map.at(eltwise);
             const auto & m_input = pattern_map.at(input);
 
-            // TODO: implement check that compares input shape ranks
+            // Case when input masks should be united instead of intersection
+            bool union_eltwise_type = ngraph::is_type<opset6::Multiply>(m_output.get_node_shared_ptr());
+
             const auto & input_rank = m_input.get_partial_shape().rank().get_length();
             const auto & weights_rank = m_weights.get_partial_shape().rank().get_length();
+            // Here assuming that masks can be propagated only through 3/4 dimensional tensors
+            // (since channel dim is necessary)
             if (weights_rank < 3 || input_rank < 3) return false;
 
             // In case if one of the inputs is constant
-            // TODO: need to find channel dimension instead of hardcoded zero
-            const size_t & channel_dim = (input_rank == weights_rank ? 1 : 0);
-            InitConstMask({channel_dim}).apply(m_input.get_node_shared_ptr());
-            InitConstMask({channel_dim}).apply(m_weights.get_node_shared_ptr());
+            InitConstMask({0, 1/* potential output channel dim */}).apply(m_input.get_node_shared_ptr());
+            auto input_mask = getMask(m_input);
+            if (!input_mask) {
+                NGRAPH_DEBUG << "No input mask for: " << m_output.get_node()->get_friendly_name() << std::endl;
+                return false;
+            }
+            NGRAPH_DEBUG << "ELTWISE: input mask for " << *m_output.get_node() << input_mask->at(0) << input_mask->at(1) <<  "\n";
+
+            if (input_rank == weights_rank) {
+                if (union_eltwise_type) {
+                    InitConstMask({0, 1}).apply(m_weights.get_node_shared_ptr());
+                } else {
+                    // Using non-empty dims in input mask for initializing weights mask since masks will be intersect
+                    auto mask_dims = input_mask->get_not_empty_dims();
+
+                    InitConstMask(AxisSet(mask_dims)).apply(m_weights.get_node_shared_ptr());
+                }
+            } else {
+                InitConstMask({0}).apply(m_weights.get_node_shared_ptr());
+            }
 
             auto weights_mask = getMask(m_weights);
-            auto input_mask = getMask(m_input);
+            NGRAPH_DEBUG << "ELTWISE: weights mask for " << *m_output.get_node() << weights_mask->at(0) << weights_mask->at(1) <<  "\n";
 
-            if (!weights_mask || !input_mask) {
-                NGRAPH_DEBUG << "No mask for: " << m_output.get_node()->get_friendly_name() << std::endl;
+            if (!weights_mask) {
+                NGRAPH_DEBUG << "No weights mask for: " << m_output.get_node()->get_friendly_name() << std::endl;
                 return false;
             }
             auto input_mask_row = input_mask.get();
@@ -208,53 +234,37 @@ public:
             auto output_mask = std::make_shared<Mask>(m_output.get_partial_shape().rank().get_length());
             auto output_mask_row = output_mask.get();
 
-            auto out_mask_callback = [input_mask_row, weights_mask_row](Mask::Ptr cur_mask) -> bool {
-                auto omask_iter = cur_mask->rbegin();
-                auto imask_iter = input_mask_row->rbegin();
-                auto wmask_iter = weights_mask_row->rbegin();
-
-                for (auto & item : *cur_mask) {
-                    item.clear();
+            auto out_mask_callback = [input_mask_row, weights_mask_row, union_eltwise_type](Mask::Ptr cur_mask) -> bool {
+                Mask::Ptr result_mask;
+                if (union_eltwise_type) {
+                    result_mask = input_mask_row->union_masks_reversed(weights_mask_row);
+                } else {
+                    result_mask = input_mask_row->intersect_masks_reversed(weights_mask_row);
                 }
-
-                while (imask_iter != input_mask_row->rend() &&
-                       wmask_iter != weights_mask_row->rend()) {
-                    // Merge mask dimension values for both masks
-                    // Example: (MaskValue[1,2,3,4], MaskValue[2,3]) -> MaskValue[2,3]
-                    for (const auto & value : *imask_iter) {
-                        if (wmask_iter->count(value)) {
-                            omask_iter->insert(value);
-                        }
-                    }
-
-                    omask_iter++;
-                    imask_iter++;
-                    wmask_iter++;
-                }
+                cur_mask->copy_value_from_mask_reversed(result_mask.get());
                 return true;
             };
             output_mask->add_callback(out_mask_callback, input_mask);
-            output_mask->add_callback(out_mask_callback, weights_mask);
 
-            auto callback = [output_mask_row](Mask::Ptr cur_mask) -> bool {
-                auto omask_iter = output_mask_row->rbegin();
-                auto cmask_iter = cur_mask->rbegin();
-                while (omask_iter != output_mask_row->rend() &&
-                       cmask_iter != cur_mask->rend()) {
-                    // TODO: check
-                    *cmask_iter = *omask_iter;
-
-                    omask_iter++;
-                    cmask_iter++;
-                }
+            input_mask->add_callback([weights_mask_row](Mask::Ptr cur_mask) -> bool {
+                cur_mask->copy_value_from_mask_reversed(weights_mask_row);
                 return true;
-            };
-            input_mask->add_callback(callback, output_mask);
-            weights_mask->add_callback(callback, output_mask);
+            }, weights_mask);
+            input_mask->add_callback([output_mask_row](Mask::Ptr cur_mask) -> bool {
+                cur_mask->copy_value_from_mask_reversed(output_mask_row);
+                return true;
+            }, output_mask); // why?
+            weights_mask->add_callback([input_mask_row](Mask::Ptr cur_mask) -> bool {
+                cur_mask->copy_value_from_mask_reversed(input_mask_row);
+                return true;
+            }, input_mask);
 
-            // Init output mask
             output_mask->apply_callback(input_mask);
+            weights_mask->apply_callback(input_mask);
+
             setMask(m_output, output_mask);
+            NGRAPH_DEBUG << "ELTWISE: OUTPUT mask for " << *m_output.get_node() << output_mask->at(0) << output_mask->at(1) <<  "\n";
+
             return true;
         };
 
@@ -263,10 +273,227 @@ public:
     }
 };
 
+ngraph::Shape broadcast_shape(ngraph::Shape shape_to_broadcast,  int64_t dst_rank) {
+    auto  initial_rank = static_cast<int64_t>(shape_to_broadcast.size());
+    std::vector<size_t> dims(dst_rank);
+    for (int64_t i = 0; i < dst_rank; i++) {
+        auto dsti =
+                i < (dst_rank - initial_rank) ? 1 : shape_to_broadcast[i - (dst_rank - initial_rank)];
+        dims[i] = dsti;
+    }
+    auto new_shape = ngraph::Shape(dims);
+    return new_shape;
+}
+
+class ngraph::pass::mask_propagation::FakeQuantize : public MatcherPass{
+public:
+    FakeQuantize(){
+        auto input = pattern::any_input();
+        auto input_low = pattern::any_input();
+        auto input_high = pattern::any_input();
+        auto output_low = pattern::any_input();
+        auto output_high = pattern::any_input();
+        auto fake_quantize = pattern::wrap_type<opset6::FakeQuantize>({input, input_low, input_high, output_low,
+                                                                            output_high});
+        ngraph::matcher_pass_callback callback = [=](ngraph::pattern::Matcher& m) {
+            const auto & pattern_map = m.get_pattern_value_map();
+            const auto & m_input = pattern_map.at(input);
+            const auto & m_input_low = pattern_map.at(input_low);
+            const auto & m_input_high = pattern_map.at(input_high);
+            const auto & m_output_low = pattern_map.at(output_low);
+            const auto & m_output_high = pattern_map.at(output_high);
+            const auto & m_output = pattern_map.at(fake_quantize);
+
+            auto input_mask = getMask(m_input);
+
+            // Input mask is the only source of pruning in FQ
+            if (!input_mask) return false;
+
+            auto input_mask_row = input_mask.get();
+
+            // Propagate input mask to output mask and in the opposite direction
+            auto output_mask = std::make_shared<Mask>(m_output.get_partial_shape().rank().get_length());
+            auto output_mask_row = output_mask.get();
+
+            auto output_mask_callback = [input_mask](Mask::Ptr cur_mask) -> bool {
+                auto imask_iter = input_mask->rbegin();
+                auto cmask_iter = cur_mask->rbegin();
+                while (imask_iter != input_mask->rend() &&
+                       cmask_iter != cur_mask->rend()) {
+                    *cmask_iter = *imask_iter;
+
+                    imask_iter++;
+                    cmask_iter++;
+                }
+                return true;
+            };
+
+
+            output_mask->add_callback(output_mask_callback, input_mask);
+
+            auto input_mask_callback = [output_mask_row](Mask::Ptr cur_mask) -> bool {
+                auto omask_iter = output_mask_row->rbegin();
+                auto cmask_iter = cur_mask->rbegin();
+                while (omask_iter != output_mask_row->rend() &&
+                       cmask_iter != cur_mask->rend()) {
+                    *cmask_iter = *omask_iter;
+
+                    omask_iter++;
+                    cmask_iter++;
+                }
+                return true;
+            };
+
+            input_mask->add_callback(input_mask_callback, output_mask);
+            // Calculate output mask
+            output_mask->apply_callback(input_mask);
+            setMask(m_output, output_mask);
+
+            auto input_low_size = shape_size(m_input_low.get_shape());
+            auto input_high_size = shape_size(m_input_high.get_shape());
+            auto output_low_size = shape_size(m_output_low.get_shape());
+            auto output_high_size = shape_size(m_output_high.get_shape());
+
+            // In the per-tensor case FQ params shouldn't be pruned
+            if (input_low_size == 1 && output_low_size == 1 && input_high_size == 1 && output_high_size == 1) {
+                return true;
+            }
+
+            // If input/output ranges in FQ should be broadcasted to input shape -> broadcast this consant values
+            // for the convenience of working with the masks
+            std::vector<std::shared_ptr<Node>> fq_params_nodes{m_input_low.get_node_shared_ptr(),
+                                                               m_input_high.get_node_shared_ptr(),
+                                                               m_output_low.get_node_shared_ptr(),
+                                                               m_output_high.get_node_shared_ptr()};
+            auto fq_node = std::dynamic_pointer_cast<op::FakeQuantize>(m_output.get_node_shared_ptr());
+            size_t idx = 0;
+            if (fq_node->get_auto_broadcast() != ngraph::op::AutoBroadcastType::NONE) {
+                for (auto const_node : fq_params_nodes) {
+                    auto new_shape = broadcast_shape(const_node->get_shape(),
+                                                     m_input.get_partial_shape().rank().get_length());
+                    auto new_const = std::dynamic_pointer_cast<op::Constant>(const_node->clone_with_new_inputs(const_node->input_values()));
+                    new_const->set_data_shape(new_shape);
+                    new_const->validate_and_infer_types();
+                    new_const->set_friendly_name(const_node->get_friendly_name());
+                    ngraph::copy_runtime_info(const_node, new_const);
+                    ngraph::replace_node(const_node, new_const);
+                    fq_params_nodes[idx++] = new_const;
+                }
+            }
+
+            auto fq_params_mask_callback = [input_mask_row](Mask::Ptr cur_mask) -> bool {
+                cur_mask->at(1/* fq params have same shapes as input */) = input_mask_row->at(1 /* channel dim in data */);
+                return true;
+            };
+
+            for (auto fq_param : fq_params_nodes) {
+                auto mask = std::make_shared<Mask>(fq_param->get_shape().size());
+                mask->add_callback(fq_params_mask_callback, input_mask);
+                input_mask->add_callback([mask](Mask::Ptr cur_mask) -> bool {
+                    return true;
+                }, mask);
+                mask->apply_callback(input_mask);
+                setMask(fq_param->output(0), mask);
+            }
+
+            return true;
+        };
+
+        auto m = std::make_shared<ngraph::pattern::Matcher>(fake_quantize, "FakeQuantizeMaskPropagation");
+        register_matcher(m, callback);
+    }
+};
+
+class ngraph::pass::mask_propagation::Concat : public MatcherPass{
+public:
+    Concat() {
+        auto concat = pattern::wrap_type<opset6::Concat>();
+
+        ngraph::matcher_pass_callback callback = [=](ngraph::pattern::Matcher &m) {
+            const auto & pattern_map = m.get_pattern_value_map();
+            const auto & m_output = pattern_map.at(concat);
+            auto concat_ptr = std::dynamic_pointer_cast<opset6::Concat>(m_output.get_node_shared_ptr());
+            auto inputs = concat_ptr->inputs();
+            auto axis = concat_ptr->get_concatenation_axis();
+
+            // If all inputs haven't masks -> concat should have empty mask
+
+
+            auto output_mask = std::make_shared<Mask>(m_output.get_partial_shape().rank().get_length());
+            auto output_mask_row = output_mask.get();
+
+            auto out_mask_callback = [inputs, axis](Mask::Ptr cur_mask) -> bool {
+                int64_t cur_size = 0;
+
+                cur_mask->at(axis).clear();
+
+                for (auto input : inputs) {
+                    auto output_port = input.get_source_output();
+                    auto input_mask = getMask(output_port);
+
+                    for (auto idx : input_mask->at(axis)) {
+                        cur_mask->at(axis).insert(idx + cur_size);
+                    }
+
+                    cur_size += output_port.get_shape().at(axis);
+                }
+                return true;
+            };
+
+            auto create_input_mask_callback_for_idx = [output_mask_row, inputs, axis](size_t input_idx){
+                auto input_mask_callback = [output_mask_row, inputs, axis, input_idx](Mask::Ptr cur_mask) -> bool {
+                    cur_mask->at(axis).clear();
+                    uint64_t min_val = 0;
+                    for (size_t i = 0; i < input_idx; i++) {
+                        auto output_port = inputs[i].get_source_output();
+                        min_val += output_port.get_shape().at(axis);
+                    }
+                    uint64_t max_val = min_val + inputs[input_idx].get_shape().at(axis);
+                    for (auto idx : output_mask_row->at(axis)) {
+                        if (idx < max_val && idx >= min_val) {
+                            cur_mask->at(axis).insert(idx);
+                        }
+                    }
+                    return true;
+                };
+                return input_mask_callback;
+            };
+
+            size_t input_idx = 0;
+
+            for (auto input : inputs) {
+                auto input_mask = getMask(input.get_source_output());
+                if (input_mask) {
+                    output_mask->add_callback(out_mask_callback, input_mask);
+                    input_mask->add_callback(create_input_mask_callback_for_idx(input_idx),
+                                             output_mask);
+                }
+                input_idx++;
+            }
+
+            for (auto input : inputs) {
+                auto input_mask = getMask(input.get_source_output());
+                if (input_mask) {
+                    output_mask->apply_callback(input_mask);
+                }
+                break;
+            }
+            setMask(m_output, output_mask);
+            std::cout << m_output.get_node_shared_ptr()->get_friendly_name();
+
+            return true;
+        };
+        auto m = std::make_shared<ngraph::pattern::Matcher>(concat, "ConcatMaskPropagation");
+        register_matcher(m, callback);
+    }
+};
+
 class ngraph::pass::mask_propagation::PassThrough : public MatcherPass {
 public:
     PassThrough() {
-        auto unary_op = pattern::wrap_type<op::util::UnaryElementwiseArithmetic, opset6::Clamp>();
+        auto unary_op = pattern::wrap_type<op::util::UnaryElementwiseArithmetic, opset6::Clamp,
+                                            opset6::Convert, opset5::AvgPool, opset6::MaxPool, op::v0::ROIPooling,
+                                            opset6::PSROIPooling, opset5::Pad>();
 
         ngraph::matcher_pass_callback callback = [=](ngraph::pattern::Matcher& m) {
             const auto & pattern_map = m.get_pattern_value_map();
@@ -312,5 +539,7 @@ ngraph::pass::PropagateMasks::PropagateMasks() {
     add_matcher<mask_propagation::GroupConvolution>();
     add_matcher<mask_propagation::Elementwise>();
     add_matcher<mask_propagation::PassThrough>();
+    add_matcher<mask_propagation::FakeQuantize>();
+    add_matcher<mask_propagation::Concat>();
     add_matcher<mask_propagation::StopPropagation>();
 }

--- a/inference-engine/src/offline_transformations/src/pruning/propagate_masks.cpp
+++ b/inference-engine/src/offline_transformations/src/pruning/propagate_masks.cpp
@@ -31,13 +31,10 @@ class Reshape;
 } // namespace ngraph
 
 ngraph::Shape broadcast_shape_to_rank(ngraph::Shape shape_to_broadcast, int64_t dst_rank) {
-    auto  initial_rank = static_cast<int64_t>(shape_to_broadcast.size());
-    std::vector<size_t> dims(dst_rank);
-    for (int64_t i = 0; i < dst_rank; i++) {
-        auto dsti =
-                i < (dst_rank - initial_rank) ? 1 : shape_to_broadcast[i - (dst_rank - initial_rank)];
-        dims[i] = dsti;
-    }
+    auto initial_rank = static_cast<int64_t>(shape_to_broadcast.size());
+    auto num_of_broadcased_dims = dst_rank - initial_rank;
+    std::vector<size_t> dims(num_of_broadcased_dims, 1);
+    dims.insert(dims.end(), shape_to_broadcast.begin(), shape_to_broadcast.end());
     auto new_shape = ngraph::Shape(dims);
     return new_shape;
 }
@@ -57,9 +54,11 @@ public:
 
             auto weights_mask = getMask(m_weights);
 
-            // If weights mask still not initialized -> convolution can't be pruned
+            // Nullptr in weights-mask means that mask for this node wasn't initialized earlier.
+            // Weights mask for convolution should be initialized in the InitMasks pass (and propagate after it).
+            // If mask isn't initialized - this weights (and hence all convolution) can't be pruned for some reason.
             if (!weights_mask) {
-                NGRAPH_DEBUG << "CONV: No weights mask for " << *m_output.get_node() << "\n";
+                NGRAPH_DEBUG << "No weights mask for " << m_output.get_node()->get_friendly_name() << "\n";
                 return false;
             }
             auto weights_mask_row = weights_mask.get();
@@ -198,7 +197,10 @@ public:
     Reshape() {
         auto input = pattern::any_input(pattern::has_static_shape());
         auto shape = pattern::any_input();
-        auto reshape = pattern::wrap_type<opset6::Reshape>({input, shape});
+        // Working only for Reshapes on Group Convolution weights
+        auto reshape = pattern::wrap_type<opset6::Reshape>({input, shape}, pattern::consumers_count(1));
+        auto gconv = pattern::wrap_type<opset6::GroupConvolution>({pattern::any_input(), reshape},
+                                                                  pattern::has_static_shape());
 
         ngraph::matcher_pass_callback callback = [=](ngraph::pattern::Matcher& m) {
             const auto & pattern_map = m.get_pattern_value_map();
@@ -206,19 +208,14 @@ public:
             const auto & m_output = pattern_map.at(reshape);
             const auto & m_input = pattern_map.at(input);
 
-            auto consumers_set = m_output.get_node_shared_ptr()->output(0).get_target_inputs();
-            std::vector<Input<Node>> consumers(consumers_set.begin(), consumers_set.end() );
-
-            // Working only for Reshapes on Group Convolution weights
-            if (!(consumers.size() == 1 && ngraph::is_type<opset6::GroupConvolution>(consumers[0].get_node())
-                    && consumers[0].get_index() == 1)) {
-                std::cout << "HEY";
-                return false;
-            }
-
             auto shape_val = m_shape.get_node_shared_ptr();
 
-            // Check that only one 1-d dim is added on 1 position of constant, no actions is needed instead
+            // In Depthwise Convolutions Reshape on weights just add additional dimension for output channels count
+            // (1 in case of the depthwise) of kernel.
+            // Example: Reshape from [G, 1 (I), X, Y, Z] -> [G, 1 (O), 1 (I), X, Y, Z], where G - group numbers,
+            // X, Y, Z -  spartial dimensions (can be only X or X, Y), I, O - number of input/output channels of kernel.
+
+            // Checking that matched Reshape meets this conditions (add 1-d dim on 1 position of shape constant)
             auto inp_shape = m_input.get_shape();
             auto out_shape = m_output.get_shape();
             inp_shape.insert(inp_shape.begin() + 1, 1);
@@ -234,7 +231,8 @@ public:
             auto output_mask = std::make_shared<Mask>(m_output.get_partial_shape().rank().get_length());
             auto output_mask_row = output_mask.get();
 
-            // propagating mask from 0 dim in Reshape input to 0 in reshape output both sides
+            // Depthwise Convolution pruned only by input channels (== groups) ->
+            // Propagating mask from Group (0) dim in Reshape input to Group (0) dim in Reshape output and back
             input_mask->add_callback([output_mask_row](Mask::Ptr cur_mask) -> bool {
                 cur_mask->at(0) = output_mask_row->at(0);
                 return true;
@@ -245,14 +243,13 @@ public:
             }, input_mask);
             input_mask->apply_callback(output_mask);
 
-            auto old_shape_const = m_shape.get_node_shared_ptr();
-            auto new_shape_value = std::vector<int>(m_output.get_shape().begin(), m_output.get_shape().end());
-            new_shape_value[0] = -1;
-
-            auto new_const = opset5::Constant::create(old_shape_const->get_element_type(),
-                                                       old_shape_const->get_shape(), new_shape_value);
-
-            new_const->validate_and_infer_types();
+            // To allow pruning on weights (allow reshape input Group (0) dim changing) replace Reshape Shape constant
+            // [G, 1, 1, X, Y, Z] by [-1, 1, 1, X, Y, Z].
+            auto old_shape_const = std::dynamic_pointer_cast<opset6::Constant>(m_shape.get_node_shared_ptr());
+            auto shape_value = old_shape_const.get()->cast_vector<int64_t>();
+            shape_value[0] = -1;
+            auto new_const = opset6::Constant::create(old_shape_const->get_element_type(),
+                                                      old_shape_const->get_shape(), shape_value);
             new_const->set_friendly_name(old_shape_const->get_friendly_name());
             ngraph::copy_runtime_info(old_shape_const, new_const);
             ngraph::replace_node(old_shape_const, new_const);
@@ -298,17 +295,7 @@ public:
                 return false;
             }
 
-            if (input_rank == weights_rank) {
-                if (union_eltwise_type) {
-                    InitConstMask({0, 1}).apply(m_weights.get_node_shared_ptr());
-                } else {
-                    // Using non-empty dims in input mask for initializing weights mask since masks will be intersect
-                    auto mask_dims = input_mask->get_not_empty_dims();
-                    InitConstMask(AxisSet(mask_dims)).apply(m_weights.get_node_shared_ptr());
-                }
-            } else {
-                InitConstMask({0}).apply(m_weights.get_node_shared_ptr());
-            }
+            InitConstMask({0, 1}).apply(m_weights.get_node_shared_ptr());
 
             auto weights_mask = getMask(m_weights);
             if (!weights_mask) {
@@ -362,11 +349,11 @@ public:
 class ngraph::pass::mask_propagation::FakeQuantize : public MatcherPass{
 public:
     FakeQuantize(){
-        auto input = pattern::any_input();
-        auto input_low = pattern::any_input();
-        auto input_high = pattern::any_input();
-        auto output_low = pattern::any_input();
-        auto output_high = pattern::any_input();
+        auto input = pattern::any_input(pattern::has_static_shape());
+        auto input_low = pattern::any_input(pattern::has_static_shape());
+        auto input_high = pattern::any_input(pattern::has_static_shape());
+        auto output_low = pattern::any_input(pattern::has_static_shape());
+        auto output_high = pattern::any_input(pattern::has_static_shape());
         auto fake_quantize = pattern::wrap_type<opset6::FakeQuantize>({input, input_low, input_high, output_low,
                                                                             output_high});
         ngraph::matcher_pass_callback callback = [=](ngraph::pattern::Matcher& m) {
@@ -422,7 +409,7 @@ public:
 
             // If input/output ranges in FQ should be broadcasted to input shape -> broadcast this consant values
             // for the convenience of working with the masks
-            std::vector<std::shared_ptr<Node>> fq_params_nodes{m_input_low.get_node_shared_ptr(),
+            NodeVector fq_params_nodes{m_input_low.get_node_shared_ptr(),
                                                                m_input_high.get_node_shared_ptr(),
                                                                m_output_low.get_node_shared_ptr(),
                                                                m_output_high.get_node_shared_ptr()};
@@ -469,76 +456,93 @@ public:
 class ngraph::pass::mask_propagation::Concat : public MatcherPass{
 public:
     Concat() {
-        auto concat = pattern::wrap_type<opset6::Concat>();
+        auto concat = pattern::wrap_type<opset6::Concat>(pattern::has_static_shape());
 
         ngraph::matcher_pass_callback callback = [=](ngraph::pattern::Matcher &m) {
             const auto & pattern_map = m.get_pattern_value_map();
             const auto & m_output = pattern_map.at(concat);
             auto concat_ptr = std::dynamic_pointer_cast<opset6::Concat>(m_output.get_node_shared_ptr());
-            auto inputs = concat_ptr->inputs();
             auto axis = concat_ptr->get_concatenation_axis();
+
+            auto inputs = concat_ptr->inputs();
+            std::map<int64_t , Mask::Ptr> input_masks;
+            std::map<int64_t , Mask *> input_masks_row;
+            std::vector<int64_t> input_sizes;
+
+            size_t first_input_idx = 0;
+            Mask::Ptr first_input_mask;
+            bool first_initialized = false;
+            for (size_t i=0; i < inputs.size(); i++) {
+                auto input = inputs[i];
+                auto input_mask = getMask(input.get_source_output());
+                if (input_mask) {
+                    input_masks[i] = input_mask;
+                    input_masks_row[i] = input_mask.get();
+
+                    if (!first_initialized) {
+                        first_input_idx = i;
+                        first_input_mask = input_mask;
+                        first_initialized = true;
+                    }
+                }
+                input_sizes.push_back(input.get_shape().at(axis));
+            }
+
+            if (!first_initialized) {
+                return false;
+            }
 
             auto output_mask = std::make_shared<Mask>(m_output.get_partial_shape().rank().get_length());
             auto output_mask_row = output_mask.get();
 
-            auto out_mask_callback = [inputs, axis](Mask::Ptr cur_mask) -> bool {
+            auto out_mask_callback = [input_masks_row, input_sizes, axis](Mask::Ptr cur_mask) -> bool {
                 int64_t cur_size = 0;
-
                 cur_mask->at(axis).clear();
 
-                for (auto input : inputs) {
-                    auto output_port = input.get_source_output();
-                    auto input_mask = getMask(output_port);
-
-                    for (auto idx : input_mask->at(axis)) {
-                        cur_mask->at(axis).insert(idx + cur_size);
+                for (size_t i=0; i < input_sizes.size(); ++i) {
+                    if (input_masks_row.count(i)) {
+                        for (auto idx : input_masks_row.at(i)->at(axis)) {
+                            cur_mask->at(axis).insert(idx + cur_size);
+                        }
                     }
-
-                    cur_size += output_port.get_shape().at(axis);
+                    cur_size += input_sizes[i];
                 }
                 return true;
             };
 
-            auto create_input_mask_callback_for_idx = [output_mask_row, inputs, axis](size_t input_idx){
-                auto input_mask_callback = [output_mask_row, inputs, axis, input_idx](Mask::Ptr cur_mask) -> bool {
-                    cur_mask->at(axis).clear();
+            auto create_input_mask_callback_for_idx = [output_mask_row, input_sizes, axis](size_t input_idx){
+                auto input_mask_callback = [output_mask_row, input_sizes, axis, input_idx](Mask::Ptr cur_mask) -> bool {
+                    cur_mask->clean_dim_values();
                     uint64_t min_val = 0;
                     for (size_t i = 0; i < input_idx; i++) {
-                        auto output_port = inputs[i].get_source_output();
-                        min_val += output_port.get_shape().at(axis);
+                        min_val += input_sizes[i];
                     }
-                    uint64_t max_val = min_val + inputs[input_idx].get_shape().at(axis);
+                    uint64_t max_val = min_val + input_sizes[input_idx];
                     for (auto idx : output_mask_row->at(axis)) {
                         if (idx < max_val && idx >= min_val) {
-                            cur_mask->at(axis).insert(idx);
+                            cur_mask->at(axis).insert(idx - min_val);
                         }
                     }
                     return true;
                 };
                 return input_mask_callback;
             };
+            output_mask->add_callback(out_mask_callback, first_input_mask);
 
-            size_t input_idx = 0;
-
-            for (auto input : inputs) {
-                auto input_mask = getMask(input.get_source_output());
-                if (input_mask) {
-                    output_mask->add_callback(out_mask_callback, input_mask);
-                    input_mask->add_callback(create_input_mask_callback_for_idx(input_idx),
-                                             output_mask);
+            for (size_t i=0; i < inputs.size(); ++i) {
+                if (input_masks.count(i) && i != first_input_idx) {
+                    auto input_mask = input_masks.at(i);
+                    input_mask->add_callback(create_input_mask_callback_for_idx(i),
+                                             first_input_mask);
+                    first_input_mask->add_callback([](Mask::Ptr cur_mask) -> bool {
+                        return true;
+                    }, input_mask);
                 }
-                input_idx++;
             }
-
-            for (auto input : inputs) {
-                auto input_mask = getMask(input.get_source_output());
-                if (input_mask) {
-                    output_mask->apply_callback(input_mask);
-                }
-                break;
-            }
+            first_input_mask->add_callback(create_input_mask_callback_for_idx(first_input_idx),
+                                     output_mask);
+            output_mask->apply_callback(first_input_mask);
             setMask(m_output, output_mask);
-            std::cout << m_output.get_node_shared_ptr()->get_friendly_name();
 
             return true;
         };
@@ -551,8 +555,8 @@ class ngraph::pass::mask_propagation::PassThrough : public MatcherPass {
 public:
     PassThrough() {
         auto unary_op = pattern::wrap_type<op::util::UnaryElementwiseArithmetic, opset6::Clamp,
-                                            opset6::Convert, opset5::AvgPool, opset6::MaxPool, op::v0::ROIPooling,
-                                            opset6::PSROIPooling, opset5::Pad>();
+                                            opset6::Convert, opset6::ConvertLike, opset5::AvgPool, opset6::MaxPool,
+                                            opset6::ROIPooling, opset6::PSROIPooling, opset6::Pad>();
 
         ngraph::matcher_pass_callback callback = [=](ngraph::pattern::Matcher& m) {
             const auto & pattern_map = m.get_pattern_value_map();

--- a/inference-engine/src/offline_transformations/src/pruning/propagate_masks.cpp
+++ b/inference-engine/src/offline_transformations/src/pruning/propagate_masks.cpp
@@ -555,7 +555,7 @@ class ngraph::pass::mask_propagation::PassThrough : public MatcherPass {
 public:
     PassThrough() {
         auto unary_op = pattern::wrap_type<op::util::UnaryElementwiseArithmetic, opset6::Clamp,
-                                            opset6::Convert, opset6::ConvertLike, opset5::AvgPool, opset6::MaxPool,
+                                            opset6::Convert, opset6::ConvertLike, opset6::AvgPool, opset6::MaxPool,
                                             opset6::ROIPooling, opset6::PSROIPooling, opset6::Pad>();
 
         ngraph::matcher_pass_callback callback = [=](ngraph::pattern::Matcher& m) {

--- a/inference-engine/src/offline_transformations/src/pruning/pruning.cpp
+++ b/inference-engine/src/offline_transformations/src/pruning/pruning.cpp
@@ -16,6 +16,8 @@ NGRAPH_RTTI_DEFINITION(ngraph::pass::Pruning, "Pruning", 0);
 bool ngraph::pass::Pruning::run_on_function(std::shared_ptr<Function> f) {
     Manager manager(get_pass_config());
 
+    // Initialize masks only for Convolutions/GroupConvolutions weights (needed to init mask in source Constant of
+    // weights-calculating subgraph). For other node types masks initialized in PropagateMasks pass.
     manager.register_pass<InitMasks>();
     manager.register_pass<PropagateMasks>();
 

--- a/inference-engine/src/offline_transformations/src/pruning/pruning.cpp
+++ b/inference-engine/src/offline_transformations/src/pruning/pruning.cpp
@@ -15,7 +15,10 @@ NGRAPH_RTTI_DEFINITION(ngraph::pass::Pruning, "Pruning", 0);
 
 bool ngraph::pass::Pruning::run_on_function(std::shared_ptr<Function> f) {
     Manager manager(get_pass_config());
+
+    manager.register_pass<InitMasks>();
     manager.register_pass<PropagateMasks>();
+
 
 #ifdef NGRAPH_DEBUG_ENABLE
     // VisualizeTree modifier helps to print Masks and mark nodes with masks

--- a/inference-engine/src/offline_transformations/src/pruning/shrink_weights.cpp
+++ b/inference-engine/src/offline_transformations/src/pruning/shrink_weights.cpp
@@ -54,6 +54,8 @@ bool ngraph::pass::ShrinkWeights::run_on_function(std::shared_ptr<ngraph::Functi
             for (size_t dim = 0; dim < mask->size(); ++dim) {
                 const auto &dim_size = mask->at(dim).size();
                 if (dim_size == 0) continue;
+                // Broadcastable 1-size dimension shouldn't be shrank with mask
+                if (const_node->get_shape().at(dim) == 1 && dim_size > 1) continue;
 
                 // Convert dims that we want remove to dims that we need to keep
                 std::vector<int64_t> dims_to_keep;

--- a/inference-engine/src/offline_transformations/src/pruning/shrink_weights.cpp
+++ b/inference-engine/src/offline_transformations/src/pruning/shrink_weights.cpp
@@ -91,5 +91,8 @@ bool ngraph::pass::ShrinkWeights::run_on_function(std::shared_ptr<ngraph::Functi
     }
     NGRAPH_DEBUG << "[ INFO ]   TOTAL WEIGHTS: " << total_weights_count << std::endl;
     NGRAPH_DEBUG << "[ INFO ] REDUCED WEIGHTS: " << reduced_weights_count << std::endl;
+    std::cout << "[ INFO ]   TOTAL WEIGHTS: " << total_weights_count << std::endl;
+    std::cout << "[ INFO ] REDUCED WEIGHTS: " << reduced_weights_count << std::endl;
+    std::cout << "[ INFO ] PRUNING RATE: " << float(reduced_weights_count)/float(total_weights_count) << std::endl;
     return true;
 }

--- a/inference-engine/src/offline_transformations/src/pruning/shrink_weights.cpp
+++ b/inference-engine/src/offline_transformations/src/pruning/shrink_weights.cpp
@@ -91,8 +91,5 @@ bool ngraph::pass::ShrinkWeights::run_on_function(std::shared_ptr<ngraph::Functi
     }
     NGRAPH_DEBUG << "[ INFO ]   TOTAL WEIGHTS: " << total_weights_count << std::endl;
     NGRAPH_DEBUG << "[ INFO ] REDUCED WEIGHTS: " << reduced_weights_count << std::endl;
-    std::cout << "[ INFO ]   TOTAL WEIGHTS: " << total_weights_count << std::endl;
-    std::cout << "[ INFO ] REDUCED WEIGHTS: " << reduced_weights_count << std::endl;
-    std::cout << "[ INFO ] PRUNING RATE: " << float(reduced_weights_count)/float(total_weights_count) << std::endl;
     return true;
 }

--- a/inference-engine/tests/functional/inference_engine/transformations/pruning_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/pruning_test.cpp
@@ -175,6 +175,7 @@ TEST(TransformationTests, PropagateMasksDynamicConvolution) {
     auto f = std::make_shared<Function>(NodeVector{conv2}, ParameterVector{input});
 
     pass::Manager m;
+    m.register_pass<pass::InitMasks>();
     m.register_pass<pass::PropagateMasks>();
     m.run_passes(f);
 
@@ -209,6 +210,7 @@ TEST(TransformationTests, PropagateMasksDynamicGroupConvolution) {
     auto f = std::make_shared<Function>(NodeVector{conv2}, ParameterVector{input});
 
     pass::Manager m;
+    m.register_pass<pass::InitMasks>();
     m.register_pass<pass::PropagateMasks>();
     m.run_passes(f);
 }

--- a/model-optimizer/mo/back/offline_transformations.py
+++ b/model-optimizer/mo/back/offline_transformations.py
@@ -35,7 +35,7 @@ def apply_offline_transformations(input_model: str, framework: str, transforms: 
 
         available_transformations[name](net, **args)
 
-    ApplyMOCTransformations(net, False)
+    # ApplyMOCTransformations(net, False)
     net.serialize(input_model + ".xml", input_model + ".bin")
     path_to_mapping = input_model + ".mapping"
     GenerateMappingFile(net, path_to_mapping.encode('utf-8'), extract_names)

--- a/model-optimizer/mo/back/offline_transformations.py
+++ b/model-optimizer/mo/back/offline_transformations.py
@@ -35,7 +35,7 @@ def apply_offline_transformations(input_model: str, framework: str, transforms: 
 
         available_transformations[name](net, **args)
 
-    # ApplyMOCTransformations(net, False)
+    ApplyMOCTransformations(net, False)
     net.serialize(input_model + ".xml", input_model + ".bin")
     path_to_mapping = input_model + ".mapping"
     GenerateMappingFile(net, path_to_mapping.encode('utf-8'), extract_names)


### PR DESCRIPTION
**Ticket:** XXX-42179

In this PR:
- Added FQ pruning support (and quantized weights for Convolution/GroupConvolution)
- Eltwise pruning extended by Multiply and fixes for other cases
- Added Concat pruning support 
- Added tests for new cases
