### PR TITLE
[MO] Add extractor for ONNX *OrEqual operations

### DIFF
--- a/model-optimizer/extensions/front/onnx/elementwise_ext.py
+++ b/model-optimizer/extensions/front/onnx/elementwise_ext.py
@@ -4,7 +4,7 @@
 import numpy as np
 
 from extensions.ops.elementwise import Add, Sub, Mul, Div, Pow, Less, Equal, Greater, LogicalAnd, LogicalOr, LogicalXor, \
-    Round, GreaterEqual
+    Round, GreaterEqual, LessEqual, Negative
 from mo.front.extractor import FrontExtractorOp
 from mo.front.onnx.extractors.utils import onnx_attr
 from mo.graph.graph import Node
@@ -168,6 +168,16 @@ class GreaterOrEqualExtractor(FrontExtractorOp):
         return cls.enabled
 
 
+class LessOrEqualExtractor(FrontExtractorOp):
+    op = 'LessOrEqual'
+    enabled = True
+
+    @classmethod
+    def extract(cls, node):
+        GreaterEqual.update_node_stat(node)
+        return cls.enabled
+
+
 class AndExtractor(FrontExtractorOp):
     op = 'And'
     enabled = True
@@ -205,4 +215,14 @@ class RoundFrontExtractor(FrontExtractorOp):
     @classmethod
     def extract(cls, node: Node):
         Round.update_node_stat(node, {'mode': 'half_to_even'})
+        return cls.enabled
+
+
+class NegExtractor(FrontExtractorOp):
+    op = 'Neg'
+    enabled = True
+
+    @classmethod
+    def extract(cls, node):
+        Negative.update_node_stat(node)
         return cls.enabled

--- a/model-optimizer/extensions/front/onnx/elementwise_ext.py
+++ b/model-optimizer/extensions/front/onnx/elementwise_ext.py
@@ -4,7 +4,7 @@
 import numpy as np
 
 from extensions.ops.elementwise import Add, Sub, Mul, Div, Pow, Less, Equal, Greater, LogicalAnd, LogicalOr, LogicalXor, \
-    Round, GreaterEqual, LessEqual, Negative
+    Round, GreaterEqual, LessEqual
 from mo.front.extractor import FrontExtractorOp
 from mo.front.onnx.extractors.utils import onnx_attr
 from mo.graph.graph import Node
@@ -174,7 +174,7 @@ class LessOrEqualExtractor(FrontExtractorOp):
 
     @classmethod
     def extract(cls, node):
-        GreaterEqual.update_node_stat(node)
+        LessEqual.update_node_stat(node)
         return cls.enabled
 
 
@@ -215,14 +215,4 @@ class RoundFrontExtractor(FrontExtractorOp):
     @classmethod
     def extract(cls, node: Node):
         Round.update_node_stat(node, {'mode': 'half_to_even'})
-        return cls.enabled
-
-
-class NegExtractor(FrontExtractorOp):
-    op = 'Neg'
-    enabled = True
-
-    @classmethod
-    def extract(cls, node):
-        Negative.update_node_stat(node)
         return cls.enabled

--- a/model-optimizer/extensions/front/onnx/elementwise_ext.py
+++ b/model-optimizer/extensions/front/onnx/elementwise_ext.py
@@ -4,7 +4,7 @@
 import numpy as np
 
 from extensions.ops.elementwise import Add, Sub, Mul, Div, Pow, Less, Equal, Greater, LogicalAnd, LogicalOr, LogicalXor, \
-    Round
+    Round, GreaterEqual
 from mo.front.extractor import FrontExtractorOp
 from mo.front.onnx.extractors.utils import onnx_attr
 from mo.graph.graph import Node
@@ -127,6 +127,7 @@ class MinExtractor(FrontExtractorOp):
         EltwiseNMin.update_node_stat(node)
         return cls.enabled
 
+
 class EqualExtractor(FrontExtractorOp):
     op = 'Equal'
     enabled = True
@@ -154,6 +155,16 @@ class GreaterExtractor(FrontExtractorOp):
     @classmethod
     def extract(cls, node):
         Greater.update_node_stat(node)
+        return cls.enabled
+
+
+class GreaterOrEqualExtractor(FrontExtractorOp):
+    op = 'GreaterOrEqual'
+    enabled = True
+
+    @classmethod
+    def extract(cls, node):
+        GreaterEqual.update_node_stat(node)
         return cls.enabled
 
 


### PR DESCRIPTION
Root cause analysis: Extractor for ONNX operations [GreaterOrEqual](https://github.com/onnx/onnx/blob/master/docs/Operators.md#GreaterOrEqual) and [LessOrEqual](https://github.com/onnx/onnx/blob/master/docs/Operators.md#LessOrEqual) not exist, but operations marked as supported in our documentation.

Solution: Implement appropriate extractors.

Ticket: 57109

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names

Validation:
* [x]  Unit tests: N/A - implemented only extractor;
* [x]  Framework operation tests: N/A;
* [x]  Transformation tests: N/A - No new implemented transformations;
* [x]  Model Optimizer IR Reader check: Done manually.

Documentation:
* [x]  Supported frameworks operations list: This operation already added to the list;
* [x]  Supported **public** models list: N/A - Nothing to add;
* [x]  User guide update: N/A - Nothing to update.
