### PR TITLE
[CPU] Fix eltwise precision fusing on non-zero ports

### DIFF
--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_eltwise_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_eltwise_node.cpp
@@ -1020,8 +1020,9 @@ void MKLDNNEltwiseNode::initSupportedPrimitiveDescriptors() {
 
     for (auto& fusedNode : fusedWith) {
         if (fusedNode->getType() == Eltwise) {
-            for (int i = 1; i < fusedNode->getOriginalInputsNumber(); i++) {
-                inputPrecisions.push_back(fusedNode->getOriginalInputPrecisionAtPort(i));
+            for (int i = 0; i < fusedNode->getOriginalInputsNumber(); i++) {
+                if (fusedNode->getFusingPort() != i)
+                    inputPrecisions.push_back(fusedNode->getOriginalInputPrecisionAtPort(i));
             }
         }
     }


### PR DESCRIPTION
### Details:
 - Fix input precision of fused eltwise node, when fusing occurs on non-zero port

### Tickets:
 - 55889
 - 56104
