### PR TITLE
Fix CMakeList.txt GEMM install parameter #5965

### DIFF
--- a/inference-engine/src/mkldnn_plugin/CMakeLists.txt
+++ b/inference-engine/src/mkldnn_plugin/CMakeLists.txt
@@ -109,7 +109,7 @@ if(GEMM STREQUAL "MKL")
     install(DIRECTORY "${MKL}/include"
             DESTINATION ${IE_CPACK_IE_DIR}/external/mkltiny_lnx
             COMPONENT cpu)
-    install(FILES "${MKLLIB}"
+    install(DIRECTORY "${MKLLIB}"
             DESTINATION ${IE_CPACK_IE_DIR}/external/mkltiny_lnx/lib
             COMPONENT cpu)
     install(FILES "${MKL}/version.info"


### PR DESCRIPTION
### Details:
I fix cmake failure problem on mkl in version 2021.3
 - Modify `inference-engine/src/mkldnn_plugin/CMakeList.txt` line 112 
 -`install(FILES ...` to `install(DIRECTORY ...`

### Tickets:
 - 5965 (https://github.com/openvinotoolkit/openvino/issues/5965) 
