### PR TITLE
[IE CLDNN] disabled crop optimization prior to NMS

### DIFF
--- a/inference-engine/thirdparty/clDNN/src/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/inference-engine/thirdparty/clDNN/src/graph_optimizer/prepare_buffer_fusing.cpp
@@ -17,6 +17,7 @@
 #include "depth_to_space_inst.h"
 #include "resample_inst.h"
 #include "loop_inst.h"
+#include "non_max_suppression_inst.h"
 
 #include "pass_manager.h"
 #include "program_helpers.h"
@@ -278,7 +279,7 @@ void prepare_buffer_fusing::run(program_impl& p) {
             for (auto user : node.get_users()) {
                 if (user->is_type<concatenation>() && !user->is_output())
                     return;
-                if (user->is_type<loop>())
+                if (user->is_type<loop>() || user->is_type<non_max_suppression>())
                     return;
             }
 


### PR DESCRIPTION
### Details:
 crop + NMS should not be merged because optimizing out crop will add padding input for NMS while NMS is not supporting padding currently


### Tickets:
 - 52279
