### PR TITLE
ConvertInterpolate1ToInterpolate4 fixes

### DIFF
--- a/inference-engine/tests/functional/inference_engine/transformations/convert_interpolate1_to_interpolate4_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_interpolate1_to_interpolate4_test.cpp
@@ -54,7 +54,7 @@ TEST(TransformationTests, ConvertInterpolate1ToInterpolate4) {
 
         auto interpolate4_attr = opset4::Interpolate::InterpolateAttrs(opset4::Interpolate::InterpolateMode::nearest,
             opset4::Interpolate::ShapeCalcMode::sizes, std::vector<size_t>{0, 0, 0, 0}, std::vector<size_t>{0, 0, 0, 0},
-            opset4::Interpolate::CoordinateTransformMode::asymmetric, opset4::Interpolate::NearestMode::floor,
+            opset4::Interpolate::CoordinateTransformMode::asymmetric, opset4::Interpolate::NearestMode::simple,
             false, -0.75);
 
         auto interpolate4 = std::make_shared<opset4::Interpolate>(data_node, out_shape_node, default_scales_node, axes_node, interpolate4_attr);
@@ -62,7 +62,7 @@ TEST(TransformationTests, ConvertInterpolate1ToInterpolate4) {
         f_ref = std::make_shared<Function>(NodeVector{interpolate4}, ParameterVector{data_node});
     }
 
-    auto res = compare_functions(f, f_ref);
+    auto res = compare_functions(f, f_ref, true, false, false, true, true);
     ASSERT_TRUE(res.first) << res.second;
 }
 
@@ -97,16 +97,16 @@ TEST(TransformationTests, ConvertInterpolate1ToInterpolate4_1) {
         auto default_scales_node = opset1::Constant::create(ngraph::element::f32, Shape{2}, {4.0f / 3.0f, 4.0f / 3.0f});
         auto axes_node = opset1::Constant::create(ngraph::element::i64, Shape{2}, {2, 3});
 
-        auto interpolate4_attr = opset4::Interpolate::InterpolateAttrs(opset4::Interpolate::InterpolateMode::linear,
+        auto interpolate4_attr = opset4::Interpolate::InterpolateAttrs(opset4::Interpolate::InterpolateMode::linear_onnx,
             opset4::Interpolate::ShapeCalcMode::sizes, std::vector<size_t>{0, 0, 0, 0}, std::vector<size_t>{0, 0, 0, 0},
-            opset4::Interpolate::CoordinateTransformMode::align_corners, opset4::Interpolate::NearestMode::floor,
-            false, -0.75);
+            opset4::Interpolate::CoordinateTransformMode::asymmetric, opset4::Interpolate::NearestMode::simple,
+            true, -0.75);
 
         auto interpolate4 = std::make_shared<opset4::Interpolate>(data_node, out_shape_node, default_scales_node, axes_node, interpolate4_attr);
 
         f_ref = std::make_shared<Function>(NodeVector{interpolate4}, ParameterVector{data_node});
     }
 
-    auto res = compare_functions(f, f_ref);
+    auto res = compare_functions(f, f_ref, true, false, false, true, true);
     ASSERT_TRUE(res.first) << res.second;
 }


### PR DESCRIPTION
Issue: 56943

For Interpolate1 we computed coordinate in original tensor in the following way:
https://github.com/openvinotoolkit/openvino/blob/e9969112affd6a103e657fb55d16e1e2eaeb4379/inference-engine/src/mkldnn_plugin/nodes/interp.cpp#L310-L316
https://github.com/openvinotoolkit/openvino/blob/e9969112affd6a103e657fb55d16e1e2eaeb4379/inference-engine/src/mkldnn_plugin/nodes/interp.cpp#L352-L353
which corresponds ```coordinate_transformation_mode == asymmetric``` for Interpolate4

Also we have tests in which reference value for ```coordinate_transformation_mode```  == ```asymmetric``` in Interpolate4
https://github.com/openvinotoolkit/openvino/blob/master/inference-engine/tests/functional/inference_engine/transformations/convert_interpolate1_to_interpolate4_test.cpp#L57
But test didn't failed, probably bug in ```compare_functions```
I printed attribute for Interpolate in ```f``` and ```f_ref``` and ```coordinate_transformation_mode``` is different but test passed
