### PR TITLE
[VPU][TEST] turns back on CTCGreedyDecoderSeqLen tests

### DIFF
--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/skip_tests_config.cpp
@@ -33,8 +33,6 @@ std::vector<std::string> disabledTestPatterns() {
         ".*DSR_GatherStaticDataDynamicIdx.*f32.*1.3.200.304.*",
         // TODO: Issue 47315
         ".*ProposalLayerTest.*",
-        // TODO: Issue 48183
-        R"(.*CTCGreedyDecoderSeqLen.*?\(1.1.1\).*)",
         // TODO: Issue 51804
         ".*PreprocessConversionTest.*oPRC=U8.*",
         // TODO: Issue: 56556


### PR DESCRIPTION
### Details:
 - Turns back on `CTCGreedyDecoderSeqLen` layer tests with `(1, 1, 1)` size, since they were fixed by #5867
### Tickets:
 - CVS-48183
