### PR TITLE
Fix ConvertPrecision for Constants

### DIFF
--- a/inference-engine/tests/functional/inference_engine/transformations/convert_precision.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_precision.cpp
@@ -119,6 +119,29 @@ TEST(TransformationTests, ConvertPrecision_ShapeOf) {
     ASSERT_FALSE(has_type<ngraph::element::Type_t::f16>(f));
 }
 
+TEST(TransformationTests, ConvertPrecision_ConstantRelu) {
+    std::shared_ptr<Function> f(nullptr);
+    {
+        auto input = opset4::Constant::create(element::f16, Shape{1, 1000, 4}, {0});
+        auto relu1 = std::make_shared<opset4::Relu>(input);
+        auto relu2 = std::make_shared<opset4::Relu>(relu1);
+
+        f = std::make_shared<Function>(NodeVector{relu2}, ParameterVector{});
+
+        pass::Manager manager;
+
+        static const precisions_array precisions = {
+                { ngraph::element::f16, ngraph::element::f32 }
+        };
+
+        manager.register_pass<ngraph::pass::ConvertPrecision>(precisions);
+        manager.run_passes(f);
+    }
+
+    ASSERT_FALSE(has_type<ngraph::element::Type_t::i64>(f));
+    ASSERT_FALSE(has_type<ngraph::element::Type_t::f16>(f));
+}
+
 TEST(TransformationTests, ConvertPrecision_Convert) {
     std::shared_ptr<Function> f(nullptr);
     {

--- a/ngraph/core/src/pass/convert_precision.cpp
+++ b/ngraph/core/src/pass/convert_precision.cpp
@@ -917,6 +917,7 @@ bool fuse_type_to_constant(const std::shared_ptr<ngraph::Node>& node,
 
         new_const->validate_and_infer_types();
         new_const->set_friendly_name(constant->get_friendly_name());
+        return true;
     }
     return false;
 }


### PR DESCRIPTION
### Description
ConvertPrecision pass was recently updated to avoid unnecessary Function validations. And this functionality relies on returned status from functions that perform precision change. And for Constant operation this function was always returning false so Function validation wasn't applied and new precisions wasn't propagated.

### Ticket
XXX-55848