### PR TITLE
Use int64 for TopK indices output

### DIFF
--- a/model-optimizer/extensions/front/onnx/top_k_ext.py
+++ b/model-optimizer/extensions/front/onnx/top_k_ext.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2018-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+import numpy as np
+
 from extensions.ops.topk import TopK
 from mo.front.extractor import FrontExtractorOp
 from mo.front.onnx.extractors.utils import onnx_attr, onnx_node_has_attr
@@ -18,7 +20,8 @@ class TopKExtractor(FrontExtractorOp):
         TopK-11 (k as input, sorting manipulations through `sorted` and `largest` attrs)
         """
         attrs = {
-            'axis': onnx_attr(node, 'axis', 'i', default=-1)
+            'axis': onnx_attr(node, 'axis', 'i', default=-1),
+            'index_element_type': np.int64
         }
         if onnx_node_has_attr(node, 'k'):
             attrs['k'] = onnx_attr(node, 'k', 'i')


### PR DESCRIPTION
**Root cause analysis:** For ONNX* models MO always produces TopK with int32 indices output that will lead to type conflicts during type inference, for example, if some eltwise node consumes its TopK output of int32 and ShapeOf output of int64 type.

**Solution:** Specify *index_element_type* to int64 explicitly. It is valid because ONNX* TopK operation always produces int64 indices output according ONNX* specification (for TopK-1, 10, 11).

**Ticket:** 55596

Code:
* [x]  Comments - Not needed
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR - N/A
* [x]  Transformation preserves original framework node names - N/A


Validation:
* [x]  Unit tests - we do not develop unit-tests for extractors
* [x]  Framework operation tests - int64 already used
* [x]  Transformation tests - N/A
* [x]  Model Optimizer IR Reader check - done for ticket model

Documentation:
* [x]  Supported frameworks operations list - N/A
* [x]  Guide on how to convert the **public** model - N/A
* [x]  User guide update - N/A
