### PR TITLE
Fix for the paddings attribute handling for ONNX Pad@1

### DIFF
--- a/ngraph/frontend/onnx_import/src/utils/convpool.cpp
+++ b/ngraph/frontend/onnx_import/src/utils/convpool.cpp
@@ -130,6 +130,11 @@ namespace ngraph
                     auto pads_int64 = node.get_attribute_value<std::vector<int64_t>>("pads");
                     pads = CoordinateDiff{std::begin(pads_int64), std::end(pads_int64)};
                 }
+                else if (node.has_attribute("paddings"))
+                {
+                    auto pads_int64 = node.get_attribute_value<std::vector<int64_t>>("paddings");
+                    pads = CoordinateDiff{std::begin(pads_int64), std::end(pads_int64)};
+                }
 
                 if (pads.size() == kernel_rank * 2)
                 {

--- a/ngraph/python/tests/__init__.py
+++ b/ngraph/python/tests/__init__.py
@@ -47,7 +47,6 @@ xfail_issue_33651 = xfail_test(reason="RuntimeError: nGraph does not support the
 xfail_issue_33581 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations:"
                                       "GatherElements")
 xfail_issue_33633 = xfail_test(reason="MaxPool: dilations unsupported")
-xfail_issue_35911 = xfail_test(reason="Assertion error: Pad model mismatch error")
 xfail_issue_35923 = xfail_test(reason="RuntimeError: PReLU without weights is not supported")
 xfail_issue_35927 = xfail_test(reason="RuntimeError: B has zero dimension that is not allowable")
 xfail_issue_36486 = xfail_test(reason="RuntimeError: HardSigmoid operation should be converted "

--- a/ngraph/python/tests/test_onnx/test_ops_convpool.py
+++ b/ngraph/python/tests/test_onnx/test_ops_convpool.py
@@ -5,6 +5,7 @@ import numpy as np
 import onnx
 import pytest
 from onnx.helper import make_graph, make_model, make_node, make_tensor_value_info
+from onnx.onnx_cpp2py_export.checker import ValidationError
 
 from tests.runtime import get_runtime
 from tests.test_onnx.utils import get_node_model, import_onnx_model, run_model, run_node
@@ -279,7 +280,6 @@ def test_pad_opset_1():
 
     # no paddings arttribute
     model = get_node_model("Pad", x)
-    from onnx.onnx_cpp2py_export.checker import ValidationError
     with pytest.raises(ValidationError):
         import_onnx_model(model)
 

--- a/ngraph/python/tests/test_onnx/test_ops_convpool.py
+++ b/ngraph/python/tests/test_onnx/test_ops_convpool.py
@@ -281,7 +281,8 @@ def test_pad_opset_1():
 
     # no paddings arttribute
     model = get_node_model("Pad", x)
-    with pytest.raises(RuntimeError):
+    from onnx.onnx_cpp2py_export.checker import ValidationError
+    with pytest.raises(ValidationError):
         import_onnx_model(model)
 
 

--- a/ngraph/python/tests/test_onnx/test_ops_convpool.py
+++ b/ngraph/python/tests/test_onnx/test_ops_convpool.py
@@ -8,7 +8,6 @@ from onnx.helper import make_graph, make_model, make_node, make_tensor_value_inf
 
 from tests.runtime import get_runtime
 from tests.test_onnx.utils import get_node_model, import_onnx_model, run_model, run_node
-from tests import xfail_issue_35911
 
 
 @pytest.fixture
@@ -257,7 +256,6 @@ def test_2d_conv_transpose():
     )
 
 
-@xfail_issue_35911
 def test_pad_opset_1():
     x = np.ones((2, 2), dtype=np.float32)
     y = np.pad(x, pad_width=1, mode="constant")


### PR DESCRIPTION
### Details:
 - The "paddings" attribute name is different in opset1 and all other opsets. It was not handled correctly in the helper. https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Pad-1
 - The test did not catch the correct exception type.

### Tickets:
 - 35911
