### PR TITLE
[AUTO][IE TESTS] Fix IE test issue for auto-device plugin

### DIFF
--- a/inference-engine/src/auto_plugin/auto_plugin.cpp
+++ b/inference-engine/src/auto_plugin/auto_plugin.cpp
@@ -211,14 +211,19 @@ ConfigType AutoInferencePlugin::GetSupportedConfig(const ConfigType&  config,
 
 void AutoInferencePlugin::CheckConfig(const ConfigType& config) {
     std::vector<std::string> supportedConfigKeys = GetMetric(METRIC_KEY(SUPPORTED_CONFIG_KEYS), {});
-    for (auto&& c : config) {
-        auto itKey = std::find(supportedConfigKeys.begin(), supportedConfigKeys.end(), c.first);
-        if (supportedConfigKeys.end() == itKey) {
-            // CVS-57233
-            if (c.first.find("AUTO_") == 0) {
+    for (auto&& kvp : config) {
+        if (kvp.first.find("AUTO_") == 0) {
+            continue;
+        } else if (kvp.first == IE::PluginConfigParams::KEY_PERF_COUNT) {
+            if (kvp.second == IE::PluginConfigParams::YES ||
+                kvp.second == IE::PluginConfigParams::NO) {
                 continue;
+            } else {
+                IE_THROW() << "Unsupported config value: " << kvp.second
+                           << " for key: " << kvp.first;
             }
-            IE_THROW() << "AUTO plugin doesn't support config key " << c.first;
+        } else {
+            IE_THROW() << "Unsupported config key: " << kvp.first;
         }
     }
 }

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/behavior/config.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/behavior/config.cpp
@@ -42,7 +42,8 @@ namespace {
     };
 
     const std::vector<std::map<std::string, std::string>> AutoConfigs = {
-            {{InferenceEngine::KEY_AUTO_DEVICE_LIST , CommonTestUtils::DEVICE_CPU}}
+            {{InferenceEngine::KEY_AUTO_DEVICE_LIST , CommonTestUtils::DEVICE_CPU}, {InferenceEngine::PluginConfigParams::KEY_PERF_COUNT, "YES"}},
+            {{InferenceEngine::KEY_AUTO_DEVICE_LIST , CommonTestUtils::DEVICE_CPU}, {std::string("AUTO_"), "NAN"}}
     };
 
     INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, CorrectConfigTests,
@@ -83,7 +84,9 @@ namespace {
 
     const std::vector<std::map<std::string, std::string>> autoinconfigs = {
         {{InferenceEngine::KEY_AUTO_DEVICE_LIST , CommonTestUtils::DEVICE_CPU},
-            {InferenceEngine::PluginConfigParams::KEY_CPU_THROUGHPUT_STREAMS, "OFF"}}
+            {InferenceEngine::PluginConfigParams::KEY_CPU_THROUGHPUT_STREAMS, "OFF"}},
+        {{InferenceEngine::KEY_AUTO_DEVICE_LIST , CommonTestUtils::DEVICE_CPU},
+            {InferenceEngine::PluginConfigParams::KEY_PERF_COUNT, "ON"}}
     };
 
     const std::vector<std::map<std::string, std::string>> multiconf = {
@@ -104,13 +107,6 @@ namespace {
             ::testing::ValuesIn(multiconf)),
             CorrectConfigAPITests::getTestCaseName);
 
-    INSTANTIATE_TEST_SUITE_P(smoke_Auto_BehaviorTests, CorrectConfigAPITests,
-            ::testing::Combine(
-            ::testing::ValuesIn(netPrecisions),
-            ::testing::Values(CommonTestUtils::DEVICE_AUTO),
-            ::testing::ValuesIn(AutoConfigs)),
-            CorrectConfigAPITests::getTestCaseName);
-
     INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, IncorrectConfigTests,
             ::testing::Combine(
             ::testing::ValuesIn(netPrecisions),
@@ -123,6 +119,13 @@ namespace {
             ::testing::ValuesIn(netPrecisions),
             ::testing::Values(CommonTestUtils::DEVICE_MULTI),
             ::testing::ValuesIn(multiinconfigs)),
+            IncorrectConfigTests::getTestCaseName);
+
+    INSTANTIATE_TEST_SUITE_P(smoke_Auto_BehaviorTests, IncorrectConfigTests,
+            ::testing::Combine(
+            ::testing::ValuesIn(netPrecisions),
+            ::testing::Values(CommonTestUtils::DEVICE_AUTO),
+            ::testing::ValuesIn(autoinconfigs)),
             IncorrectConfigTests::getTestCaseName);
 
     INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, IncorrectConfigAPITests,

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/behavior/infer_request.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/behavior/infer_request.cpp
@@ -42,7 +42,7 @@ namespace {
                                     ::testing::ValuesIn(Multiconfigs)),
                             InferRequestTests::getTestCaseName);
 
-    INSTANTIATE_TEST_SUITE_P(smoke_AutoPlugin_BehaviorTests, InferRequestTests,
+    INSTANTIATE_TEST_SUITE_P(smoke_Auto_BehaviorTests, InferRequestTests,
                             ::testing::Combine(
                                     ::testing::ValuesIn(netPrecisions),
                                     ::testing::Values(CommonTestUtils::DEVICE_AUTO),

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/behavior/infer_request_config.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/behavior/infer_request_config.cpp
@@ -19,10 +19,6 @@ namespace {
             {{ MULTI_CONFIG_KEY(DEVICE_PRIORITIES) , CommonTestUtils::DEVICE_CPU}}
     };
 
-    const std::vector<std::map<std::string, std::string>> autoConfigs = {
-            {{ AUTO_CONFIG_KEY(DEVICE_LIST) , CommonTestUtils::DEVICE_CPU}}
-    };
-
     const std::vector<std::map<std::string, std::string>> InConfigs = {
             {},
             {{InferenceEngine::PluginConfigParams::KEY_CPU_THROUGHPUT_STREAMS, InferenceEngine::PluginConfigParams::CPU_THROUGHPUT_AUTO}},
@@ -50,10 +46,6 @@ namespace {
              {InferenceEngine::PluginConfigParams::KEY_DYN_BATCH_LIMIT, "10"}}
     };
 
-    const std::vector<std::map<std::string, std::string>> AutoConfigs = {
-            {{InferenceEngine::KEY_AUTO_DEVICE_LIST , CommonTestUtils::DEVICE_CPU}}
-    };
-
     INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, InferConfigTests,
                             ::testing::Combine(
                                     ::testing::ValuesIn(netPrecisions),
@@ -66,13 +58,6 @@ namespace {
                                     ::testing::ValuesIn(netPrecisions),
                                     ::testing::Values(CommonTestUtils::DEVICE_MULTI),
                                     ::testing::ValuesIn(multiConfigs)),
-                            InferConfigTests::getTestCaseName);
-
-    INSTANTIATE_TEST_SUITE_P(smoke_Auto_BehaviorTests, InferConfigTests,
-                            ::testing::Combine(
-                                    ::testing::ValuesIn(netPrecisions),
-                                    ::testing::Values(CommonTestUtils::DEVICE_AUTO),
-                                    ::testing::ValuesIn(autoConfigs)),
                             InferConfigTests::getTestCaseName);
 
     INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, InferConfigInTests,
@@ -89,10 +74,4 @@ namespace {
                                     ::testing::ValuesIn(MultiInConfigs)),
                             InferConfigInTests::getTestCaseName);
 
-    INSTANTIATE_TEST_SUITE_P(smoke_Auto_BehaviorTests, InferConfigInTests,
-                            ::testing::Combine(
-                                    ::testing::ValuesIn(netPrecisions),
-                                    ::testing::Values(CommonTestUtils::DEVICE_AUTO),
-                                    ::testing::ValuesIn(AutoConfigs)),
-                            InferConfigInTests::getTestCaseName);
 }  // namespace

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/behavior/config.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/behavior/config.cpp
@@ -104,11 +104,14 @@ namespace {
     };
 
     const std::vector<std::map<std::string, std::string>> autoconf = {
-            {{InferenceEngine::KEY_AUTO_DEVICE_LIST , CommonTestUtils::DEVICE_GPU}}
-    };
-
-    const std::vector<std::map<std::string, std::string>> auto_cpu_gpu_conf = {
-        {{InferenceEngine::KEY_AUTO_DEVICE_LIST , std::string(CommonTestUtils::DEVICE_CPU) + "," + CommonTestUtils::DEVICE_GPU}}
+            {{InferenceEngine::KEY_AUTO_DEVICE_LIST , CommonTestUtils::DEVICE_GPU},
+                    {InferenceEngine::PluginConfigParams::KEY_PERF_COUNT, "YES"}},
+            {{InferenceEngine::KEY_AUTO_DEVICE_LIST , std::string(CommonTestUtils::DEVICE_CPU) + "," + CommonTestUtils::DEVICE_GPU},
+                    {InferenceEngine::PluginConfigParams::KEY_PERF_COUNT, "YES"}},
+            {{InferenceEngine::KEY_AUTO_DEVICE_LIST , CommonTestUtils::DEVICE_GPU},
+                    {std::string("AUTO_"), "NAN"}},
+            {{InferenceEngine::KEY_AUTO_DEVICE_LIST , std::string(CommonTestUtils::DEVICE_CPU) + "," + CommonTestUtils::DEVICE_GPU},
+                    {std::string("AUTO_"), "NAN"}}
     };
 
     INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, CorrectConfigAPITests,
@@ -132,19 +135,12 @@ namespace {
                     ::testing::ValuesIn(multiconf)),
             CorrectConfigAPITests::getTestCaseName);
 
-    INSTANTIATE_TEST_SUITE_P(smoke_Auto_BehaviorTests, CorrectConfigAPITests,
+    INSTANTIATE_TEST_SUITE_P(smoke_Auto_BehaviorTests, CorrectConfigTests,
             ::testing::Combine(
                     ::testing::ValuesIn(netPrecisions),
                     ::testing::Values(CommonTestUtils::DEVICE_AUTO),
                     ::testing::ValuesIn(autoconf)),
             CorrectConfigAPITests::getTestCaseName);
-
-    INSTANTIATE_TEST_SUITE_P(smoke_AutoCG_BehaviorTests, CorrectConfigAPITests,
-                            ::testing::Combine(
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(CommonTestUtils::DEVICE_AUTO),
-                                ::testing::ValuesIn(auto_cpu_gpu_conf)),
-                            CorrectConfigAPITests::getTestCaseName);
 
     INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, IncorrectConfigAPITests,
             ::testing::Combine(
@@ -166,13 +162,6 @@ namespace {
                     ::testing::Values(CommonTestUtils::DEVICE_AUTO),
                     ::testing::ValuesIn(autoinconfigs)),
             IncorrectConfigAPITests::getTestCaseName);
-
-    INSTANTIATE_TEST_SUITE_P(smoke_AutoCG_BehaviorTests, IncorrectConfigAPITests,
-                            ::testing::Combine(
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(CommonTestUtils::DEVICE_AUTO),
-                                ::testing::ValuesIn(autoinconfigs)),
-                            IncorrectConfigAPITests::getTestCaseName);
 
 
 } // namespace

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/behavior/infer_request.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/behavior/infer_request.cpp
@@ -19,11 +19,8 @@ namespace {
     };
 
     const std::vector<std::map<std::string, std::string>> autoconfigs = {
-            {{InferenceEngine::KEY_AUTO_DEVICE_LIST, CommonTestUtils::DEVICE_GPU}}
-    };
-
-    const std::vector<std::map<std::string, std::string>> auto_cpu_gpu_conf = {
-        {{InferenceEngine::KEY_AUTO_DEVICE_LIST , std::string(CommonTestUtils::DEVICE_CPU) + "," + CommonTestUtils::DEVICE_GPU}}
+            {{InferenceEngine::KEY_AUTO_DEVICE_LIST, CommonTestUtils::DEVICE_GPU}},
+            {{InferenceEngine::KEY_AUTO_DEVICE_LIST , std::string(CommonTestUtils::DEVICE_CPU) + "," + CommonTestUtils::DEVICE_GPU}}
     };
 
     INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, InferRequestTests,
@@ -47,10 +44,4 @@ namespace {
                                     ::testing::ValuesIn(autoconfigs)),
                             InferRequestTests::getTestCaseName);
 
-    INSTANTIATE_TEST_SUITE_P(smoke_AutoCG_BehaviorTests, InferRequestTests,
-                            ::testing::Combine(
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(CommonTestUtils::DEVICE_AUTO),
-                                ::testing::ValuesIn(auto_cpu_gpu_conf)),
-                            InferRequestTests::getTestCaseName);
 }  // namespace

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/behavior/infer_request_config.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/behavior/infer_request_config.cpp
@@ -19,14 +19,6 @@ namespace {
             {{InferenceEngine::MultiDeviceConfigParams::KEY_MULTI_DEVICE_PRIORITIES, CommonTestUtils::DEVICE_GPU}}
     };
 
-    const std::vector<std::map<std::string, std::string>> autoConfigs = {
-            {{InferenceEngine::KEY_AUTO_DEVICE_LIST, CommonTestUtils::DEVICE_GPU}}
-    };
-
-    const std::vector<std::map<std::string, std::string>> auto_cpu_gpu_conf = {
-        {{InferenceEngine::KEY_AUTO_DEVICE_LIST , std::string(CommonTestUtils::DEVICE_CPU) + "," + CommonTestUtils::DEVICE_GPU}}
-    };
-
     INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, InferConfigTests,
                             ::testing::Combine(
                                     ::testing::ValuesIn(netPrecisions),
@@ -41,17 +33,4 @@ namespace {
                                     ::testing::ValuesIn(multiConfigs)),
                             InferConfigTests::getTestCaseName);
 
-    INSTANTIATE_TEST_SUITE_P(smoke_Auto_BehaviorTests, InferConfigTests,
-                            ::testing::Combine(
-                                    ::testing::ValuesIn(netPrecisions),
-                                    ::testing::Values(CommonTestUtils::DEVICE_AUTO),
-                                    ::testing::ValuesIn(autoConfigs)),
-                            InferConfigTests::getTestCaseName);
-
-    INSTANTIATE_TEST_SUITE_P(smoke_AutoCG_BehaviorTests, InferConfigTests,
-                            ::testing::Combine(
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(CommonTestUtils::DEVICE_AUTO),
-                                ::testing::ValuesIn(auto_cpu_gpu_conf)),
-                            InferConfigTests::getTestCaseName);
 }  // namespace

--- a/inference-engine/tests/functional/plugin/shared/include/behavior/config.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/behavior/config.hpp
@@ -144,12 +144,8 @@ namespace BehaviorTestsDefinitions {
         SKIP_IF_CURRENT_TEST_IS_DISABLED()
         // Create CNNNetwork from ngrpah::Function
         InferenceEngine::CNNNetwork cnnNet(function);
-        if (targetDevice.find(CommonTestUtils::DEVICE_AUTO) != std::string::npos) {
-            GTEST_SKIP();
-        } else {
-            ASSERT_THROW(auto execNet = ie->LoadNetwork(cnnNet, targetDevice, configuration),
-                         InferenceEngine::Exception);
-        }
+        ASSERT_THROW(auto execNet = ie->LoadNetwork(cnnNet, targetDevice, configuration),
+                        InferenceEngine::Exception);
     }
 
     using IncorrectConfigSingleOptionTests = BehaviorTestsUtils::BehaviorTestsSingleOption;
@@ -196,10 +192,8 @@ namespace BehaviorTestsDefinitions {
             ASSERT_NO_THROW(ie->SetConfig(config, targetDevice));
         }
         // Load CNNNetwork to target plugins
-        if (targetDevice.find(CommonTestUtils::DEVICE_AUTO) == std::string::npos) {
-            auto execNet = ie->LoadNetwork(cnnNet, targetDevice, config);
-            execNet.CreateInferRequest();
-        }
+        auto execNet = ie->LoadNetwork(cnnNet, targetDevice, config);
+        execNet.CreateInferRequest();
 
         if ((targetDevice == CommonTestUtils::DEVICE_HDDL) || (targetDevice == CommonTestUtils::DEVICE_GNA)) {
             ASSERT_EQ(0u, InferenceEngine::ExecutorManager::getInstance()->getExecutorsNumber());
@@ -227,10 +221,8 @@ namespace BehaviorTestsDefinitions {
             ASSERT_NO_THROW(ie->SetConfig(config, targetDevice));
         }
         // Load CNNNetwork to target plugins
-        if (targetDevice.find(CommonTestUtils::DEVICE_AUTO) == std::string::npos) {
-            auto execNet = ie->LoadNetwork(cnnNet, targetDevice, config);
-            execNet.CreateInferRequest();
-        }
+        auto execNet = ie->LoadNetwork(cnnNet, targetDevice, config);
+        execNet.CreateInferRequest();
 
         if ((targetDevice == CommonTestUtils::DEVICE_MYRIAD) ||
             (targetDevice == CommonTestUtils::DEVICE_KEEMBAY)) {
@@ -260,10 +252,8 @@ namespace BehaviorTestsDefinitions {
                 ASSERT_NO_THROW(ie->SetConfig(config, targetDevice));
             }
             // Load CNNNetwork to target plugins
-            if (targetDevice.find(CommonTestUtils::DEVICE_AUTO) == std::string::npos) {
-                auto execNet = ie->LoadNetwork(cnnNet, targetDevice, config);
-                execNet.CreateInferRequest();
-            }
+            auto execNet = ie->LoadNetwork(cnnNet, targetDevice, config);
+            execNet.CreateInferRequest();
 
             if ((targetDevice == CommonTestUtils::DEVICE_MYRIAD) ||
                 (targetDevice == CommonTestUtils::DEVICE_KEEMBAY)) {

--- a/inference-engine/tests/functional/plugin/shared/include/behavior/infer_request_config.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/behavior/infer_request_config.hpp
@@ -42,10 +42,8 @@ TEST_P(InferConfigTests, canSetExclusiveAsyncRequests) {
         ASSERT_NO_THROW(ie->SetConfig(config, targetDevice));
     }
     // Load CNNNetwork to target plugins
-    if (targetDevice.find(CommonTestUtils::DEVICE_AUTO) == std::string::npos) {
-        auto execNet = ie->LoadNetwork(cnnNet, targetDevice, config);
-        execNet.CreateInferRequest();
-    }
+    auto execNet = ie->LoadNetwork(cnnNet, targetDevice, config);
+    execNet.CreateInferRequest();
 
     if ((targetDevice == CommonTestUtils::DEVICE_HDDL) || (targetDevice == CommonTestUtils::DEVICE_GNA)) {
         ASSERT_EQ(0u, InferenceEngine::ExecutorManager::getInstance()->getExecutorsNumber());
@@ -73,10 +71,8 @@ TEST_P(InferConfigTests, withoutExclusiveAsyncRequests) {
         ASSERT_NO_THROW(ie->SetConfig(config, targetDevice));
     }
     // Load CNNNetwork to target plugins
-    if (targetDevice.find(CommonTestUtils::DEVICE_AUTO) == std::string::npos) {
-        auto execNet = ie->LoadNetwork(cnnNet, targetDevice, config);
-        execNet.CreateInferRequest();
-    }
+    auto execNet = ie->LoadNetwork(cnnNet, targetDevice, config);
+    execNet.CreateInferRequest();
 
     if ((targetDevice == CommonTestUtils::DEVICE_GNA) || (targetDevice == CommonTestUtils::DEVICE_HDDL)) {
         ASSERT_EQ(0u, InferenceEngine::ExecutorManager::getInstance()->getExecutorsNumber());


### PR DESCRIPTION
### Details:
 - Will not skip test cases for auto-device plugin, `ASSERT_THROW` exception when using incorrectConfig;

### Tickets:
 - *57552*
