### PR TITLE
Update ext_onnx only during first cmake run

### DIFF
--- a/ngraph/cmake/external_onnx.cmake
+++ b/ngraph/cmake/external_onnx.cmake
@@ -18,6 +18,7 @@ set(ONNX_GIT_REPO_URL https://github.com/onnx/onnx.git)
 set(ONNX_GIT_BRANCH rel-${ONNX_VERSION})
 set(NGRAPH_ONNX_NAMESPACE ngraph_onnx)
 set(ONNX_PATCH_FILE "${CMAKE_CURRENT_SOURCE_DIR}/cmake/patches/onnx_patch.diff")
+set(FETCHCONTENT_UPDATES_DISCONNECTED_EXT_ONNX ON CACHE BOOL "Update ext_onnx only during first cmake run" FORCE)
 
 FetchContent_Declare(
     ext_onnx


### PR DESCRIPTION
Ticket: 57213

If FetchContent has declared PATCH_COMMAND (or UPDATE_COMMAND) [even without git applying] it causes rebuilding onnx target during call cmake command.
This solution causes that the patch is applied only during the first cmake run.

The disadvantage of this solution is a scenario when we want to for example update onnx library. In such a case a user needs to remove build/_deps and run cmake again.

We can also wait for https://github.com/onnx/onnx/pull/3371 merge and a new version of onnx.


