### PR TITLE
Fix recovery of output subscript in Einsum implicit mode

### DIFF
--- a/model-optimizer/unit_tests/extensions/ops/einsum_test.py
+++ b/model-optimizer/unit_tests/extensions/ops/einsum_test.py
@@ -60,6 +60,11 @@ class TestEinsum(unittest.TestCase):
         ([int64_array([1, 3, 5])], "AbC", int64_array([1, 5, 3])),
         # mixed case letters and equation in implicit mode
         ([int64_array([3, 11, 1, 5]), int64_array([1, 3, 1, 7])], "a...b,B...", int64_array([3, 11, 7, 1, 3, 5])),
+        # inner product in implicit mode
+        ([int64_array([3]), int64_array([3])], "i,i", int64_array([])),
+        # equation with ellipsis and repeated labels in implicit mode
+        # "a...b,b..." is equivalent to "a...b,b...->...a"
+        ([int64_array([9, 1, 4, 3]), int64_array([3, 11, 7, 1])], "a...b,b...", int64_array([11, 7, 4, 9])),
     ])
     def test_einsum(self, input_shapes, equation, ref_output_shape):
         graph = create_einsum_graph(input_shapes, equation)

--- a/ngraph/core/src/op/einsum.cpp
+++ b/ngraph/core/src/op/einsum.cpp
@@ -60,11 +60,40 @@ bool is_subscript_correct(const std::string& subscript, bool& is_ellipsis_met)
     return true;
 }
 
+/// \brief      Check if the given label is met in input subscripts excluding ones
+/// specified by a vector excluded_indices
+///
+/// \param      input_subscripts         The vector of the input subscripts
+/// \param      label_to_check           A label to check
+/// \param      excluded_indices         A vector of input subscript indices to be excluded
+///
+/// \return     true - met, false - otherwise
+///
+bool is_label_elsewhere(const std::vector<std::string>& input_subscripts,
+                        const std::string label_to_check,
+                        const std::vector<size_t>& excluded_indices)
+{
+    for (size_t input_ind = 0; input_ind < input_subscripts.size(); ++input_ind)
+    {
+        const auto& input_subscript = input_subscripts[input_ind];
+        // the subscript is checked only if its index is not in excluded indices list
+        bool check_subscript =
+            (std::find(excluded_indices.begin(), excluded_indices.end(), input_ind) ==
+             excluded_indices.end());
+        if (check_subscript && input_subscript.find(label_to_check) != std::string::npos)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 void op::v7::Einsum::parse_equation(const std::string& equation,
                                     std::vector<std::string>& input_subscripts,
                                     std::string& output_subscript)
 {
     NGRAPH_OP_SCOPE(v7_Einsum_parse_equation);
+    constexpr char ellipsis[] = "...";
 
     // split equation to input subscripts and an output subscript
     auto pos_output_delimeter = equation.find("->");
@@ -93,13 +122,13 @@ void op::v7::Einsum::parse_equation(const std::string& equation,
 
     if (pos_output_delimeter == std::string::npos)
     {
-        // recover output subscript
+        // equation is in implicit mode so recover output subscript
         output_subscript = "";
-        for (auto const& input_subscript : input_subscripts)
-        {
-            for (auto const& label : input_subscript)
+        for (size_t ind = 0; ind < input_subscripts.size(); ++ind) {
+            auto const& input_subscript = input_subscripts[ind];
+            for (auto const& label : extract_labels(input_subscript))
             {
-                if (std::isalpha(label) && output_subscript.find(label) == std::string::npos)
+                if (label != ellipsis && (is_label_elsewhere(input_subscripts, label, {ind}) == false))
                 {
                     output_subscript += label;
                 }

--- a/ngraph/core/src/op/einsum.cpp
+++ b/ngraph/core/src/op/einsum.cpp
@@ -70,7 +70,7 @@ bool is_subscript_correct(const std::string& subscript, bool& is_ellipsis_met)
 /// \return     true - met, false - otherwise
 ///
 bool is_label_elsewhere(const std::vector<std::string>& input_subscripts,
-                        const std::string label_to_check,
+                        const std::string& label_to_check,
                         const std::vector<size_t>& excluded_indices)
 {
     for (size_t input_ind = 0; input_ind < input_subscripts.size(); ++input_ind)
@@ -124,11 +124,13 @@ void op::v7::Einsum::parse_equation(const std::string& equation,
     {
         // equation is in implicit mode so recover output subscript
         output_subscript = "";
-        for (size_t ind = 0; ind < input_subscripts.size(); ++ind) {
+        for (size_t ind = 0; ind < input_subscripts.size(); ++ind)
+        {
             auto const& input_subscript = input_subscripts[ind];
             for (auto const& label : extract_labels(input_subscript))
             {
-                if (label != ellipsis && (is_label_elsewhere(input_subscripts, label, {ind}) == false))
+                if (label != ellipsis &&
+                    (is_label_elsewhere(input_subscripts, label, {ind}) == false))
                 {
                     output_subscript += label;
                 }

--- a/ngraph/test/type_prop/einsum.cpp
+++ b/ngraph/test/type_prop/einsum.cpp
@@ -186,6 +186,34 @@ TEST(type_prop, einsum_implicitmode_mixedcaseletters2)
     ASSERT_TRUE(O->get_output_partial_shape(0).same_scheme(out_shape));
 }
 
+TEST(type_prop, einsum_implicitmode_repeatedlabels)
+{
+    // the following equation is equivalent to "a...b,b...->...a"
+    std::string equation = "a...b,b...";
+    const auto input1_shape = PartialShape{Dimension(3, 5), 11, 1, 3};
+    const auto input2_shape = PartialShape{Dimension(1, 3), 3, 1, 7};
+    const auto out_shape = PartialShape{3, 11, 7, Dimension(3, 5)};
+    auto I1 = make_shared<op::Parameter>(element::f32, input1_shape);
+    auto I2 = make_shared<op::Parameter>(element::f32, input2_shape);
+    auto O = make_shared<op::v7::Einsum>(OutputVector{I1, I2}, equation);
+    ASSERT_EQ(O->get_element_type(), element::f32);
+    ASSERT_TRUE(O->get_output_partial_shape(0).same_scheme(out_shape));
+}
+
+TEST(type_prop, einsum_implicitmode_innerprod)
+{
+    // the following equation is equivalent to "i,i->"
+    std::string equation = "i,i";
+    const auto input1_shape = PartialShape{11};
+    const auto input2_shape = PartialShape{Dimension(1, 20)};
+    const auto out_shape = PartialShape{};
+    auto I1 = make_shared<op::Parameter>(element::f32, input1_shape);
+    auto I2 = make_shared<op::Parameter>(element::f32, input2_shape);
+    auto O = make_shared<op::v7::Einsum>(OutputVector{I1, I2}, equation);
+    ASSERT_EQ(O->get_element_type(), element::f32);
+    ASSERT_TRUE(O->get_output_partial_shape(0).same_scheme(out_shape));
+}
+
 TEST(type_prop, einsum_dynamicrank_multimatmul)
 {
     std::string equation = "ab,bcd,bc->ca";


### PR DESCRIPTION
**Ticket:** 57791

**Root cause analysis:** There is a bug in recovery of output subscript in case of *Einsum-7* implicit mode.
The repeated labels in input subscripts except of ellipsis must not be included into recovered output subscript.
Example 1: equation="i,i" in implicit mode is equivalent to "i,i->" in explicit mode. Now nGraph and MO recover "i,i->i" that is incorrect.
Example 2: equation="a...b,b..." in implicit mode is equivalent to "a...b,b...->...a" in explicit mode.

**Solution:** Fix both Einsum implementation in both nGraph core and MO. Check if the label is met in other input subscripts
before to include into the recovered output subscript.
