### PR TITLE
[IE CLDNN] Fixed cl codegen with custom locale

### DIFF
--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/binary_convolution/binary_convolution_kernel_1x1.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/binary_convolution/binary_convolution_kernel_1x1.cpp
@@ -139,8 +139,8 @@ JitConstants BinaryConvolutionKernel1x1::GetFusedPrimitivesJitConstants(const bi
 
         std::string data_type = fused_dep_codegen.GetInputTypeName(0, 1);
         std::string vec_data_type = fused_dep_codegen.GetInputTypeName(0, 2);
-        std::string sc = "sc" + std::to_string(op_id);
-        std::string sh = "sh" + std::to_string(op_id);
+        std::string sc = "sc" + toCodeString(op_id);
+        std::string sh = "sh" + toCodeString(op_id);
         switch (fused_dep.GetType()) {
             case KernelType::SCALE: {
                 std::string cast_type = (fused_dep.tensors[0].GetDType() == Datatype::F32) ? "as_float2" : "as_half2";
@@ -209,7 +209,7 @@ JitConstants BinaryConvolutionKernel1x1::GetFusedPrimitivesJitConstants(const bi
                 auto p = fused_dep.GetOpParams<activation_fuse_params>();
                 base_activation_params activation = p->param;
                 if (activation.function != ActivationFunction::NONE) {
-                    auto suffix = "_FUSED_OP" + std::to_string(op_id);
+                    auto suffix = "_FUSED_OP" + toCodeString(op_id);
 
                     jit.Merge(MakeActivationJitConstants(activation, fused_dep.output_tensor.GetDType(), suffix));
                     eltwise_fused_ops += "\\\n\tres = ACTIVATION" + suffix + "((OUTPUT_TYPE)res, ACTIVATION_PARAMS" + suffix + ");";

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/binary_convolution/binary_convolution_kernel_1x1_b_fs_yx_fsv16.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/binary_convolution/binary_convolution_kernel_1x1_b_fs_yx_fsv16.cpp
@@ -144,7 +144,7 @@ JitConstants BinaryConvolutionKernel1x1_b_fs_yx_fsv16::GetFusedPrimitivesJitCons
 
         std::string data_type = fused_dep_codegen.GetInputTypeName(0, 1);
         std::string vec_data_type = fused_dep_codegen.GetInputTypeName(0, 1);
-        std::string sc = "sc" + std::to_string(op_id);
+        std::string sc = "sc" + toCodeString(op_id);
         switch (fused_dep.GetType()) {
             case KernelType::SCALE: {
                 std::string cast_type = (fused_dep.tensors[0].GetDType() == Datatype::F32) ? "as_float" : "as_half";
@@ -170,7 +170,7 @@ JitConstants BinaryConvolutionKernel1x1_b_fs_yx_fsv16::GetFusedPrimitivesJitCons
                 auto p = fused_dep.GetOpParams<activation_fuse_params>();
                 base_activation_params activation = p->param;
                 if (activation.function != ActivationFunction::NONE) {
-                    auto suffix = "_FUSED_OP" + std::to_string(op_id);
+                    auto suffix = "_FUSED_OP" + toCodeString(op_id);
 
                     jit.Merge(MakeActivationJitConstants(activation, fused_dep.output_tensor.GetDType(), suffix));
                     eltwise_fused_ops += "\\\n\tres = ACTIVATION" + suffix + "((OUTPUT_TYPE)res, ACTIVATION_PARAMS" + suffix + ");";

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/binary_convolution/binary_convolution_kernel_generic.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/binary_convolution/binary_convolution_kernel_generic.cpp
@@ -133,8 +133,8 @@ JitConstants BinaryConvolutionKernelGeneric::GetFusedPrimitivesJitConstants(cons
         };
         std::string data_type = fused_dep_codegen.GetInputTypeName(0, 1);
         std::string vec_data_type = fused_dep_codegen.GetInputTypeName(0, 2);
-        std::string sc = "sc" + std::to_string(op_id);
-        std::string sh = "sh" + std::to_string(op_id);
+        std::string sc = "sc" + toCodeString(op_id);
+        std::string sh = "sh" + toCodeString(op_id);
         switch (fused_dep.GetType()) {
             case KernelType::SCALE: {
                 std::string cast_type = (fused_dep.tensors[0].GetDType() == Datatype::F32) ? "as_float2" : "as_half2";
@@ -221,7 +221,7 @@ JitConstants BinaryConvolutionKernelGeneric::GetFusedPrimitivesJitConstants(cons
                 auto p = fused_dep.GetOpParams<activation_fuse_params>();
                 base_activation_params activation = p->param;
                 if (activation.function != ActivationFunction::NONE) {
-                    auto suffix = "_FUSED_OP" + std::to_string(op_id);
+                    auto suffix = "_FUSED_OP" + toCodeString(op_id);
 
                     jit.Merge(MakeActivationJitConstants(activation, fused_dep.output_tensor.GetDType(), suffix));
                     eltwise_fused_ops += "\\\n\tres = ACTIVATION" + suffix + "((OUTPUT_TYPE)res, ACTIVATION_PARAMS" + suffix + ");";

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_kernel_b_fs_zyx_fsv16.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_kernel_b_fs_zyx_fsv16.cpp
@@ -27,13 +27,13 @@ static const size_t feature_block_size = 16;
 FusedOpsConfiguration GenerateFusedOpsConfiguration_f16(size_t conf_id, std::string input_name, Datatype dt,
                                                         bool is_vector) {
     std::vector<std::string> idx_order;
-    std::string suffix = (is_vector ? "_VEC" : "_SCALAR") + std::to_string(conf_id);
-    std::string input_var_name = input_name + std::to_string(conf_id) + (is_vector ? "" : "[i]");
+    std::string suffix = (is_vector ? "_VEC" : "_SCALAR") + toCodeString(conf_id);
+    std::string input_var_name = input_name + toCodeString(conf_id) + (is_vector ? "" : "[i]");
     size_t vec_size = is_vector ? 8 : 1;
     if (is_vector)
-        idx_order = {"(mb)", "(oc*OC_BLOCK + g*OC)", "od", "oh", "(ow + " + std::to_string(conf_id * 8) + ")"};
+        idx_order = {"(mb)", "(oc*OC_BLOCK + g*OC)", "od", "oh", "(ow + " + toCodeString(conf_id * 8) + ")"};
     else
-        idx_order = {"(mb)", "(oc*OC_BLOCK + g*OC + local_id)", "od", "oh", "(ow + " + std::to_string(conf_id * 8) + " + i)"};
+        idx_order = {"(mb)", "(oc*OC_BLOCK + g*OC + local_id)", "od", "oh", "(ow + " + toCodeString(conf_id * 8) + " + i)"};
 
     return { suffix,
              idx_order,
@@ -50,13 +50,13 @@ FusedOpsConfiguration GenerateFusedOpsConfiguration_bsv16_fsv16(size_t conf_id, 
                                                                 size_t dims) {
     std::vector<std::string> idx_order;
     if (dims == 5)
-        idx_order = {"(mb + " + std::to_string(conf_id * 8) + ")", "(oc*16)", "od", "oh", "ow"};
+        idx_order = {"(mb + " + toCodeString(conf_id * 8) + ")", "(oc*16)", "od", "oh", "ow"};
     else
-        idx_order = {"(mb + " + std::to_string(conf_id * 8) + ")", "(oc*16)", "oh", "ow"};
+        idx_order = {"(mb + " + toCodeString(conf_id * 8) + ")", "(oc*16)", "oh", "ow"};
 
-    return { "_VEC" + std::to_string(conf_id),
+    return { "_VEC" + toCodeString(conf_id),
              idx_order,
-             input_name + std::to_string(conf_id),
+             input_name + toCodeString(conf_id),
              dt,
              8,
              FusedOpsConfiguration::LoadType::LT_ALIGNED_READ,

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/eltwise/eltwise_kernel_b_fs_yx_fsv16.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/eltwise/eltwise_kernel_b_fs_yx_fsv16.cpp
@@ -53,12 +53,12 @@ JitConstants EltwiseKernel_b_fs_yx_fsv16::MakeLoadJitConstants(const eltwise_par
     JitConstants jit = {};
     std::string vload_decls;
     for (size_t op_num = 0; op_num < params.operations.size(); op_num++) {
-        const std::string op_num_str = std::to_string(op_num);
+        const std::string op_num_str = toCodeString(op_num);
         const auto &ew = params.operations[op_num];
         for (size_t input_idx = 0; input_idx < ew.inputs.size(); input_idx++) {
             const auto &input = ew.inputs[input_idx];
-            const std::string name = "INPUT_" + op_num_str + "_" + std::to_string(input_idx);
-            std::string idx_order = "INPUT" + std::to_string(input.index) + "_IDX_ORDER";
+            const std::string name = "INPUT_" + op_num_str + "_" + toCodeString(input_idx);
+            std::string idx_order = "INPUT" + toCodeString(input.index) + "_IDX_ORDER";
 
             switch (input.mode) {
                 case EltwiseInputMode::SCALAR:
@@ -68,16 +68,16 @@ JitConstants EltwiseKernel_b_fs_yx_fsv16::MakeLoadJitConstants(const eltwise_par
                     if (params.inputs[input.index].LogicalSize() == params.output.Feature().v &&
                         params.inputs[input.index].LogicalSize() == params.inputs[input.index].Feature().v) {
                         jit.AddConstant(MakeJitConstant(name,
-                                                        "UNIT_BLOCK_READ(input" + std::to_string(input.index) +
-                                                        ", INPUT"+std::to_string(input.index)+"_GET_INDEX(b, f_block*16, y, x))"));
+                                                        "UNIT_BLOCK_READ(input" + toCodeString(input.index) +
+                                                        ", INPUT"+toCodeString(input.index)+"_GET_INDEX(b, f_block*16, y, x))"));
                     } else if (params.inputs[input.index].LogicalSize() == 1) {
                         jit.AddConstant(MakeJitConstant(name,
-                                                        "input" + std::to_string(input.index) +
+                                                        "input" + toCodeString(input.index) +
                                                         "[0]"));
                     } else {
                         jit.AddConstant(MakeJitConstant(name,
-                                                        "READ_FUNC(input" + std::to_string(input.index) +
-                                                        ", INPUT"+std::to_string(input.index)+"_GET_INDEX(b, f_block*16, y, x))"));
+                                                        "READ_FUNC(input" + toCodeString(input.index) +
+                                                        ", INPUT"+toCodeString(input.index)+"_GET_INDEX(b, f_block*16, y, x))"));
                     }
                     break;
                 case EltwiseInputMode::OUTPUT_BUFFER:
@@ -86,10 +86,10 @@ JitConstants EltwiseKernel_b_fs_yx_fsv16::MakeLoadJitConstants(const eltwise_par
                 case EltwiseInputMode::UNORDERED_ACCESS_INPUT_BUFFER:
                     jit.AddConstant(MakeJitConstant(
                             name,
-                            "input" + std::to_string(input.index) + "[(size_t)tmp" + std::to_string(input.tmpIndex) + "]"));
+                            "input" + toCodeString(input.index) + "[(size_t)tmp" + toCodeString(input.tmpIndex) + "]"));
                     break;
                 case EltwiseInputMode::INTERMEDIATE_RESULTS_INDEX:
-                    jit.AddConstant(MakeJitConstant(name, "tmp" + std::to_string(input.tmpIndex)));
+                    jit.AddConstant(MakeJitConstant(name, "tmp" + toCodeString(input.tmpIndex)));
                     break;
                 default:
                     break;
@@ -117,10 +117,10 @@ JitConstants EltwiseKernel_b_fs_yx_fsv16::GetJitConstants(const eltwise_params& 
     std::string do_eltwise;
     auto& operations = params.operations;
     for (size_t op_num = 0; op_num < operations.size(); op_num++) {
-        do_eltwise += "\\\n\tOPERATION" + std::to_string(op_num) + ";";
+        do_eltwise += "\\\n\tOPERATION" + toCodeString(op_num) + ";";
     }
 
-    do_eltwise += "\\\n\tres = tmp" + std::to_string(operations.size() - 1) + ";";
+    do_eltwise += "\\\n\tres = tmp" + toCodeString(operations.size() - 1) + ";";
 
     jit.AddConstant(MakeJitConstant("DO_ELTWISE", do_eltwise));
 

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/eltwise/eltwise_kernel_b_fs_yx_fsv4.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/eltwise/eltwise_kernel_b_fs_yx_fsv4.cpp
@@ -132,7 +132,7 @@ JitConstants EltwiseKernel_b_fs_yx_fsv4::GetJitConstants(const eltwise_params& p
         }
 
         inputs_decls +=
-            const_str + " __global " + toCLType(params.inputs[i].GetDType()) + "* input" + std::to_string(i) + ", ";
+            const_str + " __global " + toCLType(params.inputs[i].GetDType()) + "* input" + toCodeString(i) + ", ";
     }
 
     jit.AddConstant(MakeJitConstant("INPUTS_DECLS", inputs_decls));
@@ -144,20 +144,20 @@ JitConstants EltwiseKernel_b_fs_yx_fsv4::GetJitConstants(const eltwise_params& p
     auto& coefficients = params.coefficients;
 
     for (size_t op_num = 0; op_num < operations.size(); op_num++) {
-        const std::string op_num_str = std::to_string(op_num);
+        const std::string op_num_str = toCodeString(op_num);
         const auto& ew = operations[op_num];
 
         for (size_t input_idx = 0; input_idx < ew.inputs.size(); input_idx++) {
             const auto& input = ew.inputs[input_idx];
-            const std::string name = "INPUT_" + op_num_str + "_" + std::to_string(input_idx);
+            const std::string name = "INPUT_" + op_num_str + "_" + toCodeString(input_idx);
             switch (input.mode) {
                 case EltwiseInputMode::SCALAR:
                     jit.AddConstant(MakeJitConstant(name, input.scalar));
                     break;
                 case EltwiseInputMode::INPUT_BUFFER:
                     jit.AddConstant(MakeJitConstant(name,
-                                                    "GET_INPUT(input" + std::to_string(input.index) + ", INPUT" +
-                                                        std::to_string(input.index) + ")"));
+                                                    "GET_INPUT(input" + toCodeString(input.index) + ", INPUT" +
+                                                        toCodeString(input.index) + ")"));
                     break;
                 case EltwiseInputMode::OUTPUT_BUFFER:
                     jit.AddConstant(MakeJitConstant(name, "output[GET_INDEX(OUTPUT, )]"));
@@ -165,10 +165,10 @@ JitConstants EltwiseKernel_b_fs_yx_fsv4::GetJitConstants(const eltwise_params& p
                 case EltwiseInputMode::UNORDERED_ACCESS_INPUT_BUFFER:
                     jit.AddConstant(MakeJitConstant(
                         name,
-                        "input" + std::to_string(input.index) + "[(size_t)tmp" + std::to_string(input.tmpIndex) + "]"));
+                        "input" + toCodeString(input.index) + "[(size_t)tmp" + toCodeString(input.tmpIndex) + "]"));
                     break;
                 case EltwiseInputMode::INTERMEDIATE_RESULTS_INDEX:
-                    jit.AddConstant(MakeJitConstant(name, "tmp" + std::to_string(input.tmpIndex)));
+                    jit.AddConstant(MakeJitConstant(name, "tmp" + toCodeString(input.tmpIndex)));
                     break;
                 default:
                     break;
@@ -189,7 +189,7 @@ JitConstants EltwiseKernel_b_fs_yx_fsv4::GetJitConstants(const eltwise_params& p
                 if (input.mode == EltwiseInputMode::INPUT_BUFFER && input.index < coefficients.size()) {
                     const float c = coefficients[input.index];
                     if (c != 1.0f)
-                        coeff_strings[input_idx] = cast_type + "(" + std::to_string(c) + ")*";
+                        coeff_strings[input_idx] = cast_type + "(" + toCodeString(c) + ")*";
                 }
             }
 
@@ -262,11 +262,11 @@ JitConstants EltwiseKernel_b_fs_yx_fsv4::GetJitConstants(const eltwise_params& p
     }
 
     for (size_t update_input_idx = 0; update_input_idx < updateInputs.size(); update_input_idx++)
-        do_eltwise += "\\\n\tinput" + std::to_string(updateInputs[update_input_idx].inputId) + "[GET_INDEX(INPUT, " +
-                      std::to_string(updateInputs[update_input_idx].inputId) + ")] = tmp" +
-                      std::to_string(updateInputs[update_input_idx].tmpId) + ";";
+        do_eltwise += "\\\n\tinput" + toCodeString(updateInputs[update_input_idx].inputId) + "[GET_INDEX(INPUT, " +
+                      toCodeString(updateInputs[update_input_idx].inputId) + ")] = tmp" +
+                      toCodeString(updateInputs[update_input_idx].tmpId) + ";";
 
-    do_eltwise += "\\\n\tres = tmp" + std::to_string(operations.size() - 1) + ";";
+    do_eltwise += "\\\n\tres = tmp" + toCodeString(operations.size() - 1) + ";";
 
     jit.AddConstant(MakeJitConstant("DO_ELTWISE", do_eltwise));
 

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/eltwise/eltwise_kernel_base.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/eltwise/eltwise_kernel_base.cpp
@@ -126,7 +126,7 @@ bool EltwiseKernelBase::Validate(const Params& p, const optional_params& o) cons
 JitConstants EltwiseKernelBase::GetOperationsJitConstants(const eltwise_params& params, bool useVload8, size_t blockSize) const {
     JitConstants jit = {};
     for (size_t op_num = 0; op_num < params.operations.size(); op_num++) {
-        const std::string op_num_str = std::to_string(op_num);
+        const std::string op_num_str = toCodeString(op_num);
         const auto& ew = params.operations[op_num];
 
         std::string op, cast_type;
@@ -155,7 +155,7 @@ JitConstants EltwiseKernelBase::GetOperationsJitConstants(const eltwise_params& 
                 if (input.mode == EltwiseInputMode::INPUT_BUFFER && input.index < coefficients.size()) {
                     const float c = coefficients[input.index];
                     if (c != 1.0f)
-                        coeff_strings[input_idx] = cast_type + "(" + std::to_string(c) + ")*";
+                        coeff_strings[input_idx] = cast_type + "(" + toCodeString(c) + ")*";
                 }
             }
 
@@ -272,12 +272,12 @@ JitConstants EltwiseKernelBase::MakeLoadJitConstants(const eltwise_params& param
     JitConstants jit = {};
     std::string vload_decls;
     for (size_t op_num = 0; op_num < params.operations.size(); op_num++) {
-        const std::string op_num_str = std::to_string(op_num);
+        const std::string op_num_str = toCodeString(op_num);
         const auto &ew = params.operations[op_num];
         for (size_t input_idx = 0; input_idx < ew.inputs.size(); input_idx++) {
             const auto &input = ew.inputs[input_idx];
-            const std::string name = "INPUT_" + op_num_str + "_" + std::to_string(input_idx);
-            std::string idx_order = "INPUT" + std::to_string(input.index) + "_IDX_ORDER";
+            const std::string name = "INPUT_" + op_num_str + "_" + toCodeString(input_idx);
+            std::string idx_order = "INPUT" + toCodeString(input.index) + "_IDX_ORDER";
 
             switch (input.mode) {
                 case EltwiseInputMode::SCALAR:
@@ -285,11 +285,11 @@ JitConstants EltwiseKernelBase::MakeLoadJitConstants(const eltwise_params& param
                     break;
                 case EltwiseInputMode::INPUT_BUFFER:
                     if (useVload8)
-                        jit.AddConstant(MakeJitConstant(name, "in" + std::to_string(input.index)));
+                        jit.AddConstant(MakeJitConstant(name, "in" + toCodeString(input.index)));
                     else
                         jit.AddConstant(MakeJitConstant(name,
-                                                        "input" + std::to_string(input.index) +
-                                                        "[GET_INDEX(INPUT, " + std::to_string(input.index) +
+                                                        "input" + toCodeString(input.index) +
+                                                        "[GET_INDEX(INPUT, " + toCodeString(input.index) +
                                                         "," + idx_order + ")]"));
                     break;
                 case EltwiseInputMode::OUTPUT_BUFFER:
@@ -298,10 +298,10 @@ JitConstants EltwiseKernelBase::MakeLoadJitConstants(const eltwise_params& param
                 case EltwiseInputMode::UNORDERED_ACCESS_INPUT_BUFFER:
                     jit.AddConstant(MakeJitConstant(
                             name,
-                            "input" + std::to_string(input.index) + "[(size_t)tmp" + std::to_string(input.tmpIndex) + "]"));
+                            "input" + toCodeString(input.index) + "[(size_t)tmp" + toCodeString(input.tmpIndex) + "]"));
                     break;
                 case EltwiseInputMode::INTERMEDIATE_RESULTS_INDEX:
-                    jit.AddConstant(MakeJitConstant(name, "tmp" + std::to_string(input.tmpIndex)));
+                    jit.AddConstant(MakeJitConstant(name, "tmp" + toCodeString(input.tmpIndex)));
                     break;
                 default:
                     break;
@@ -311,11 +311,11 @@ JitConstants EltwiseKernelBase::MakeLoadJitConstants(const eltwise_params& param
 
     if (useVload8) {
         for (size_t i = 0; i < params.inputs.size(); i++) {
-            vload_decls += "\\\n\tconst " + toCLType(params.inputs[i].GetDType()) + "8 in" + std::to_string(i);
+            vload_decls += "\\\n\tconst " + toCLType(params.inputs[i].GetDType()) + "8 in" + toCodeString(i);
             if (params.inputs[i].PhysicalSize() == 1)  // Scalar case
-                vload_decls += " = (" + toCLType(params.inputs[i].GetDType()) + "8)(input" + std::to_string(i) + "[0]";
+                vload_decls += " = (" + toCLType(params.inputs[i].GetDType()) + "8)(input" + toCodeString(i) + "[0]";
             else  // Buffer case
-                vload_decls += " = vload8(global_id, input" + std::to_string(i);
+                vload_decls += " = vload8(global_id, input" + toCodeString(i);
             vload_decls += ");";
         }
         jit.AddConstant(MakeJitConstant("VLOAD_DECLS", vload_decls));
@@ -337,7 +337,7 @@ JitConstants EltwiseKernelBase::MakeInputDeclsJitConstants(const eltwise_params&
                 break;
             }
         }
-        inputs_decls += const_str + " __global " + toCLType(params.inputs[i].GetDType()) + "* input" + std::to_string(i) + ", ";
+        inputs_decls += const_str + " __global " + toCLType(params.inputs[i].GetDType()) + "* input" + toCodeString(i) + ", ";
     }
     jit.AddConstant(MakeJitConstant("INPUTS_DECLS", inputs_decls));
     return jit;
@@ -366,8 +366,8 @@ JitConstants EltwiseKernelBase::MakeIndexJitConstants(const eltwise_params& para
         }
 
         if (!params.stride.empty()) {
-            bfyx_idx_order[2] = "(" + bfyx_idx_order[2] + "*" + std::to_string(stride.y) + ")";
-            bfyx_idx_order[3] = "(" + bfyx_idx_order[3] + "*" + std::to_string(stride.x) + ")";
+            bfyx_idx_order[2] = "(" + bfyx_idx_order[2] + "*" + toCodeString(stride.y) + ")";
+            bfyx_idx_order[3] = "(" + bfyx_idx_order[3] + "*" + toCodeString(stride.x) + ")";
         }
 
         return bfyx_idx_order;
@@ -414,12 +414,12 @@ JitConstants EltwiseKernelBase::MakeIndexJitConstants(const eltwise_params& para
         }
 
         if (!params.stride.empty()) {
-            jit.AddConstant(MakeJitConstant("INPUT" + std::to_string(i) + "_STRIDE_X", params.stride[i].x));
-            jit.AddConstant(MakeJitConstant("INPUT" + std::to_string(i) + "_STRIDE_Y", params.stride[i].y));
-            jit.AddConstant(MakeJitConstant("INPUT" + std::to_string(i) + "_STRIDE_Z", params.stride[i].z));
+            jit.AddConstant(MakeJitConstant("INPUT" + toCodeString(i) + "_STRIDE_X", params.stride[i].x));
+            jit.AddConstant(MakeJitConstant("INPUT" + toCodeString(i) + "_STRIDE_Y", params.stride[i].y));
+            jit.AddConstant(MakeJitConstant("INPUT" + toCodeString(i) + "_STRIDE_Z", params.stride[i].z));
         }
 
-        std::string idx_order = "INPUT" + std::to_string(i) + "_IDX_ORDER";
+        std::string idx_order = "INPUT" + toCodeString(i) + "_IDX_ORDER";
         if (useVload8) {
             jit.AddConstant(MakeJitConstant(idx_order, "d1"));
         } else {
@@ -475,17 +475,17 @@ JitConstants EltwiseKernelBase::GetJitConstantsCommon(const eltwise_params& para
     std::string do_eltwise;
     auto& operations = params.operations;
     for (size_t op_num = 0; op_num < operations.size(); op_num++) {
-        do_eltwise += "\\\n\tOPERATION" + std::to_string(op_num) + ";";
+        do_eltwise += "\\\n\tOPERATION" + toCodeString(op_num) + ";";
     }
 
     auto& updateInputs = params.updateInputIds;
     for (size_t update_input_idx = 0; update_input_idx < updateInputs.size(); update_input_idx++)
-        do_eltwise += "\\\n\tinput" + std::to_string(updateInputs[update_input_idx].inputId) + "[GET_INDEX(INPUT, " +
-                      std::to_string(updateInputs[update_input_idx].inputId) + ", " +
-                      "INPUT"+std::to_string(updateInputs[update_input_idx].inputId) + "_IDX_ORDER)] = tmp" +
-                      std::to_string(updateInputs[update_input_idx].tmpId) + ";";
+        do_eltwise += "\\\n\tinput" + toCodeString(updateInputs[update_input_idx].inputId) + "[GET_INDEX(INPUT, " +
+                      toCodeString(updateInputs[update_input_idx].inputId) + ", " +
+                      "INPUT"+toCodeString(updateInputs[update_input_idx].inputId) + "_IDX_ORDER)] = tmp" +
+                      toCodeString(updateInputs[update_input_idx].tmpId) + ";";
 
-    do_eltwise += "\\\n\tres = tmp" + std::to_string(operations.size() - 1) + ";";
+    do_eltwise += "\\\n\tres = tmp" + toCodeString(operations.size() - 1) + ";";
 
     jit.AddConstant(MakeJitConstant("DO_ELTWISE", do_eltwise));
 

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/eltwise/eltwise_kernel_fs_bs_yx_bsv4_fsv32.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/eltwise/eltwise_kernel_fs_bs_yx_bsv4_fsv32.cpp
@@ -95,11 +95,11 @@ JitConstants EltwiseKernel_fs_bs_yx_bsv4_fsv32::GetJitConstants(const eltwise_pa
         }
 
         inputs_decls +=
-            const_str + " __global " + toCLType(params.inputs[i].GetDType()) + "* input" + std::to_string(i) + ", ";
+            const_str + " __global " + toCLType(params.inputs[i].GetDType()) + "* input" + toCodeString(i) + ", ";
 
         if (!params.stride.empty()) {
-            jit.AddConstant(MakeJitConstant("INPUT" + std::to_string(i) + "_STRIDE_X", params.stride[i].x));
-            jit.AddConstant(MakeJitConstant("INPUT" + std::to_string(i) + "_STRIDE_Y", params.stride[i].y));
+            jit.AddConstant(MakeJitConstant("INPUT" + toCodeString(i) + "_STRIDE_X", params.stride[i].x));
+            jit.AddConstant(MakeJitConstant("INPUT" + toCodeString(i) + "_STRIDE_Y", params.stride[i].y));
         }
     }
 
@@ -112,20 +112,20 @@ JitConstants EltwiseKernel_fs_bs_yx_bsv4_fsv32::GetJitConstants(const eltwise_pa
     auto& coefficients = params.coefficients;
 
     for (size_t op_num = 0; op_num < operations.size(); op_num++) {
-        const std::string op_num_str = std::to_string(op_num);
+        const std::string op_num_str = toCodeString(op_num);
         const auto& ew = operations[op_num];
 
         for (size_t input_idx = 0; input_idx < ew.inputs.size(); input_idx++) {
             const auto& input = ew.inputs[input_idx];
-            const std::string name = "INPUT_" + op_num_str + "_" + std::to_string(input_idx);
+            const std::string name = "INPUT_" + op_num_str + "_" + toCodeString(input_idx);
             switch (input.mode) {
                 case EltwiseInputMode::SCALAR:
                     jit.AddConstant(MakeJitConstant(name, input.scalar));
                     break;
                 case EltwiseInputMode::INPUT_BUFFER:
                     jit.AddConstant(MakeJitConstant(name,
-                                                    "GET_INPUT(input" + std::to_string(input.index) + ", INPUT" +
-                                                        std::to_string(input.index) + ")"));
+                                                    "GET_INPUT(input" + toCodeString(input.index) + ", INPUT" +
+                                                        toCodeString(input.index) + ")"));
                     break;
                 case EltwiseInputMode::OUTPUT_BUFFER:
                     jit.AddConstant(MakeJitConstant(name, "output[GET_INDEX(OUTPUT, )]"));
@@ -133,10 +133,10 @@ JitConstants EltwiseKernel_fs_bs_yx_bsv4_fsv32::GetJitConstants(const eltwise_pa
                 case EltwiseInputMode::UNORDERED_ACCESS_INPUT_BUFFER:
                     jit.AddConstant(MakeJitConstant(
                         name,
-                        "input" + std::to_string(input.index) + "[(size_t)tmp" + std::to_string(input.tmpIndex) + "]"));
+                        "input" + toCodeString(input.index) + "[(size_t)tmp" + toCodeString(input.tmpIndex) + "]"));
                     break;
                 case EltwiseInputMode::INTERMEDIATE_RESULTS_INDEX:
-                    jit.AddConstant(MakeJitConstant(name, "tmp" + std::to_string(input.tmpIndex)));
+                    jit.AddConstant(MakeJitConstant(name, "tmp" + toCodeString(input.tmpIndex)));
                     break;
                 default:
                     break;
@@ -162,7 +162,7 @@ JitConstants EltwiseKernel_fs_bs_yx_bsv4_fsv32::GetJitConstants(const eltwise_pa
                 if (input.mode == EltwiseInputMode::INPUT_BUFFER && input.index < coefficients.size()) {
                     const float c = coefficients[input.index];
                     if (c != 1.0f)
-                        coeff_strings[input_idx] = cast_type + "(" + std::to_string(c) + ")*";
+                        coeff_strings[input_idx] = cast_type + "(" + toCodeString(c) + ")*";
                 }
             }
 
@@ -274,11 +274,11 @@ JitConstants EltwiseKernel_fs_bs_yx_bsv4_fsv32::GetJitConstants(const eltwise_pa
     }
 
     for (size_t update_input_idx = 0; update_input_idx < updateInputs.size(); update_input_idx++)
-        do_eltwise += "\\\n\tinput" + std::to_string(updateInputs[update_input_idx].inputId) + "[GET_INDEX(INPUT, " +
-                      std::to_string(updateInputs[update_input_idx].inputId) + ")] = tmp" +
-                      std::to_string(updateInputs[update_input_idx].tmpId) + ";";
+        do_eltwise += "\\\n\tinput" + toCodeString(updateInputs[update_input_idx].inputId) + "[GET_INDEX(INPUT, " +
+                      toCodeString(updateInputs[update_input_idx].inputId) + ")] = tmp" +
+                      toCodeString(updateInputs[update_input_idx].tmpId) + ";";
 
-    do_eltwise += "\\\n\tres = tmp" + std::to_string(operations.size() - 1) + ";";
+    do_eltwise += "\\\n\tres = tmp" + toCodeString(operations.size() - 1) + ";";
 
     jit.AddConstant(MakeJitConstant("DO_ELTWISE", do_eltwise));
 

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/select/select_kernel_base.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/select/select_kernel_base.cpp
@@ -46,7 +46,7 @@ JitConstants SelectKernelBase::GetJitConstantsCommon(const select_params& params
         std::string const_str = "const";
 
         inputs_decls +=
-            const_str + " __global " + toCLType(params.inputs[i].GetDType()) + "* input" + std::to_string(i) + ", ";
+            const_str + " __global " + toCLType(params.inputs[i].GetDType()) + "* input" + toCodeString(i) + ", ";
     }
 
     jit.AddConstant(MakeJitConstant("INPUTS_DECLS", inputs_decls));

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/common/common_kernel_base.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/common/common_kernel_base.cpp
@@ -84,7 +84,7 @@ std::string common_kernel_base::GetEntryPoint(const std::string& templateName,
     std::replace(kernelID.begin(), kernelID.end(), '.', '_');
     std::replace(kernelID.begin(), kernelID.end(), '/', '_');
 
-    kernelID += "_" + std::to_string(UniqeID());
+    kernelID += "_" + toCodeString(UniqeID());
 
     return kernelID;
 }

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/kernel_base.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/kernel_base.cpp
@@ -100,10 +100,10 @@ JitConstants KernelBase::MakeFusedOpsJitConstants(const kernel_selector::base_pa
 
             can_use_preload &= fused_dep_codegen.CanPreloadData(c);
 
-            fused_ops += "\\\n\tFUSED_OP" + std::to_string(i) + "_LOAD" + c.suffix;
-            fused_ops += "\\\n\tFUSED_OP" + std::to_string(i) + "_ACTION" + c.suffix;
-            fused_ops_preload += "\\\n\tFUSED_OP" + std::to_string(i) + "_LOAD" + c.suffix;
-            fused_ops_calc_only += "\\\n\tFUSED_OP" + std::to_string(i) + "_ACTION" + c.suffix;
+            fused_ops += "\\\n\tFUSED_OP" + toCodeString(i) + "_LOAD" + c.suffix;
+            fused_ops += "\\\n\tFUSED_OP" + toCodeString(i) + "_ACTION" + c.suffix;
+            fused_ops_preload += "\\\n\tFUSED_OP" + toCodeString(i) + "_LOAD" + c.suffix;
+            fused_ops_calc_only += "\\\n\tFUSED_OP" + toCodeString(i) + "_ACTION" + c.suffix;
         }
 
         jit.AddConstant(MakeJitConstant("FUSED_OPS" + c.suffix, fused_ops));
@@ -135,7 +135,7 @@ JitConstants KernelBase::MakeFusedOpsDeclsJitConstants(const kernel_selector::ba
         jit.Merge(fused_dep_codegen.MakeInputDeclsJitConstants(conf[0]));
         if (!params.fused_ops[i].tensors.empty()) {
             std::string optional_comma = (!input_decls.empty() ? "," : "");
-            input_decls += optional_comma + "\\\n\tFUSED_OP" + std::to_string(i) + "_DECLS";
+            input_decls += optional_comma + "\\\n\tFUSED_OP" + toCodeString(i) + "_DECLS";
         }
     }
 


### PR DESCRIPTION
### Details:
 - Floating point numbers with custom global locale could be converted with comma as separator which led to invalid OCL code generation and compilation error. So replaced all usages of `std::to_string` (which respects locale) with custom `toCodeString` function which serialize float as hex value without any separators.

### Tickets:
 - *57885*
