### PR TITLE
[Python Tools] Fix cross_check_tool device config parsing

### DIFF
--- a/inference-engine/tools/cross_check_tool/utils.py
+++ b/inference-engine/tools/cross_check_tool/utils.py
@@ -295,7 +295,7 @@ def get_config_dictionary(config_file):
         return config
     with open(config_file) as f:
         config_line = f.readline()
-        key = config_line.split(config_file)[0]
+        key = config_line.split()[0]
         value = config_line[len(key):].strip()
         config[key] = value
     return config


### PR DESCRIPTION
### Details:
 - Device config is failed to parse
