### PR TITLE
[GNA] Add transformation of padded convolutions to valid ones

### DIFF
--- a/inference-engine/src/gna_plugin/gna_graph_compiler.cpp
+++ b/inference-engine/src/gna_plugin/gna_graph_compiler.cpp
@@ -1029,13 +1029,8 @@ void GNAGraphCompiler::ConcatPrimitive(InferenceEngine::CNNLayerPtr layer) {
         auto layerInfo = LayerInfo(concatParent);
         // auto layerInfo = LayerInfo(getCreatorLayer(concatLayerInput->insData[it].lock()).lock());
         if (layerInfo.isInput()) {
-            auto & bytesAllocated = inputDesc->bytes_allocated_for_input[((InferenceEngine::CNNLayerPtr)layerInfo)->name];
-
             connectInput(layer, &concatLayerInfo.gna_ptr,
-                         concatLayerInfo.reserved_size, inputLayer.offset, idx, false);
-
-            // TODO: currently connectInput api accept only total size, for concat we need extension for allocated, and actual sizes
-            bytesAllocated = inputLayer.tensorSize;
+                inputLayer.tensorSize, inputLayer.offset, idx, false);
 
             concatLayerInfo.input_allocated = true;
         } else if (layerInfo.isMemory()) {

--- a/inference-engine/src/gna_plugin/gna_plugin.cpp
+++ b/inference-engine/src/gna_plugin/gna_plugin.cpp
@@ -672,7 +672,7 @@ void GNAPlugin::LoadNetwork(CNNNetwork & _network) {
         manager.register_pass<ngraph::pass::InitNodeInfo>();
         // WA: ConvertPriorBox must be executed before the 1st ConstantFolding pass
         manager.register_pass<ngraph::pass::ConvertPriorBox>();
-        manager.register_pass<ngraph::pass::ConvertPadded2ValidConv>();
+        manager.register_pass<ConvertPadded2ValidConv>();
         manager.register_pass<ngraph::pass::CommonOptimizations>();
         // TODO enable this transformation for networks with convolutions
         if (!ngraph::op::util::has_op_with_type<ngraph::opset7::Convolution>(graph)) {

--- a/inference-engine/src/gna_plugin/gna_plugin.cpp
+++ b/inference-engine/src/gna_plugin/gna_plugin.cpp
@@ -63,6 +63,7 @@
 #include "transformations/swap_input_matmul_gna.hpp"
 #include "transformations/convert_matmul_to_pointwise_convolution.hpp"
 #include "transformations/split_convolution_with_large_buffer_size.hpp"
+#include "transformations/convert_padded2valid_conv.hpp"
 
 #include <ngraph/opsets/opset7.hpp>
 
@@ -671,6 +672,7 @@ void GNAPlugin::LoadNetwork(CNNNetwork & _network) {
         manager.register_pass<ngraph::pass::InitNodeInfo>();
         // WA: ConvertPriorBox must be executed before the 1st ConstantFolding pass
         manager.register_pass<ngraph::pass::ConvertPriorBox>();
+        manager.register_pass<ngraph::pass::ConvertPadded2ValidConv>();
         manager.register_pass<ngraph::pass::CommonOptimizations>();
         // TODO enable this transformation for networks with convolutions
         if (!ngraph::op::util::has_op_with_type<ngraph::opset7::Convolution>(graph)) {

--- a/inference-engine/src/gna_plugin/transformations/convert_padded2valid_conv.cpp
+++ b/inference-engine/src/gna_plugin/transformations/convert_padded2valid_conv.cpp
@@ -1,0 +1,471 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "convert_padded2valid_conv.hpp"
+
+#include <memory>
+
+#include <ngraph/opsets/opset1.hpp>
+#include <ngraph/rt_info.hpp>
+
+
+using namespace ngraph;
+using namespace op;
+
+namespace {
+struct GraphData {
+    std::shared_ptr<opset1::Convolution> conv;
+    std::shared_ptr<Transpose> leading_transpose;
+    std::shared_ptr<Transpose> trailing_transpose;
+    std::shared_ptr<opset1::MaxPool> max_pool;
+    std::shared_ptr<op::util::UnaryElementwiseArithmetic> af;
+    std::shared_ptr<Node> bias_const;
+    std::shared_ptr<Node>last_op_in_sequence_for_replacement;
+    bool disable_nhwc_to_nchw_option;
+};
+
+struct ConvData {
+    size_t input_height;
+    size_t input_width;
+    size_t input_channel_count;
+    size_t filter_height;
+    size_t filter_width;
+    size_t filter_count;
+    size_t filter_dilation_x;
+    size_t filter_dilation_y;
+    size_t filter_stride_x;
+    size_t filter_stride_y;
+    size_t pads_begin_y;
+    size_t pads_begin_x;
+    size_t pads_end_y;
+    size_t pads_end_x;
+    op::PadType padding_type;
+    size_t output_channel_count;
+    Shape output_shape;
+};
+
+bool TransposeOrderMatches(std::shared_ptr<Transpose> transpose, std::vector<int64_t> order) {
+    if (!transpose)
+        return false;
+    const Output<Node>& transpose_order = transpose->input_value(1);
+    auto transpose_order_dim = transpose_order.get_shape().size();
+
+    if (transpose_order_dim != 1 || transpose_order.get_shape()[0] != order.size())
+        return false;
+
+    auto const_with_order_values = std::dynamic_pointer_cast<opset1::Constant>(transpose_order.get_node_shared_ptr());
+    if (!const_with_order_values)
+        return false;
+
+    const int64_t* data = const_with_order_values->get_data_ptr<int64_t>();
+    if (!data)
+        return false;
+
+    for (size_t i = 0; i < order.size(); i++) {
+        if (order[i] != data[i])
+            return false;
+    }
+
+    return true;
+}
+
+std::shared_ptr<opset1::StridedSlice> FlatCrop(Output<Node> input, size_t offset, size_t size) {
+    return std::make_shared<opset1::StridedSlice>(
+        input, // data
+        opset1::Constant::create(element::i64, Shape{ 2 }, { (size_t)0, offset }), // begin sice index
+        opset1::Constant::create(element::i64, Shape{ 2 }, { (size_t)0, offset + size }), // end slice index
+        opset1::Constant::create(element::i64, Shape{ 2 }, { (size_t)1, (size_t)1 }), // strides
+        std::vector<int64_t>{1, 0},  // begin mask
+        std::vector<int64_t>{1, 0}); // end mask
+}
+
+template<class T>
+bool VerifyLayer(std::shared_ptr<T> layer) {
+    auto layer_output_0 = layer->get_output_target_inputs(0);
+    return layer_output_0.size() == 1 ? true : false;
+}
+
+template<>
+bool VerifyLayer<>(std::shared_ptr<opset1::MaxPool> max_pool) {
+    auto layer_output_0 = max_pool->get_output_target_inputs(0);
+    if (layer_output_0.size() != 1)
+        return false;
+
+    auto pool_strides = max_pool->get_strides();
+    auto pool_kernel = max_pool->get_kernel();
+
+    // Check if MaxPool vertical stride == pool size (TODO: remove when 50386 and 50379 are fixed)
+    // Check if padding is VALID
+    if (max_pool->get_auto_pad() != PadType::VALID ||
+        pool_kernel.size() != 2 || pool_strides.size() != 2 ||
+        pool_kernel[0] != pool_strides[0] || pool_kernel[0] > 8)
+        return false;
+
+    return true;
+}
+
+std::shared_ptr<opset1::Convolution> DetectVerifyConvolution(std::shared_ptr<Node> node) {
+    auto conv = std::dynamic_pointer_cast<opset1::Convolution>(node);
+
+    if (conv) {
+        // check if convolution output port is connected with only one Op
+        if (!VerifyLayer(node))
+            return nullptr;
+
+        const Output<Node>& input = conv->input_value(0);
+        const Output<Node>& filters = conv->input_value(1);
+        auto output_shape = conv->get_output_shape(0);
+
+        if (!std::dynamic_pointer_cast<opset1::Constant>(filters.get_node_shared_ptr()))
+            return nullptr;
+
+        // we support only 2D conv batch 1
+        if (input.get_shape().size() != 4 ||
+            filters.get_shape().size() != 4 ||
+            output_shape.size() != 4 ||
+            conv->get_dilations().size() != 2 ||
+            conv->get_strides().size() != 2 ||
+            input.get_shape()[0] != 1) {
+            return nullptr;
+        }
+    }
+    return conv;
+}
+
+void FillConvData(std::shared_ptr<opset1::Convolution> conv, ConvData& conv_data) {
+    conv_data.output_shape = conv->get_output_shape(0);
+    conv_data.padding_type = conv->get_auto_pad();
+    conv_data.input_height = conv->input_value(0).get_shape()[2];
+    conv_data.input_width = conv->input_value(0).get_shape()[3];
+    conv_data.input_channel_count = conv->input_value(0).get_shape()[1];
+    conv_data.filter_height = conv->input_value(1).get_shape()[2];
+    conv_data.filter_width = conv->input_value(1).get_shape()[3];
+    conv_data.filter_count = conv->input_value(1).get_shape()[0];
+    conv_data.filter_dilation_x = conv->get_dilations()[1];
+    conv_data.filter_dilation_y = conv->get_dilations()[0];
+    conv_data.filter_stride_x = conv->get_strides()[1];
+    conv_data.filter_stride_y = conv->get_strides()[0];
+    conv_data.pads_begin_y = conv->get_pads_begin()[0];
+    conv_data.pads_begin_x = conv->get_pads_begin()[1];
+    conv_data.pads_end_y = conv->get_pads_end()[0];
+    conv_data.pads_end_x = conv->get_pads_end()[1];
+    conv_data.output_channel_count = conv_data.filter_count;
+}
+
+std::shared_ptr<Transpose> DetectVerifyLeadingTranspose(std::shared_ptr<opset1::Convolution> conv) {
+    const Output<Node>& input = conv->input_value(0);
+    auto leading_transpose = std::dynamic_pointer_cast<Transpose>(input.get_node_shared_ptr());
+
+    if (!leading_transpose || !TransposeOrderMatches(leading_transpose, { 0, 3, 1, 2 }))
+        return nullptr;
+
+    return leading_transpose;
+}
+
+template<class T>
+std::shared_ptr<T> DetectNextLayer(std::shared_ptr<Node> node) {
+    auto output_0_node = node->get_output_target_inputs(0).begin()->get_node()->shared_from_this();
+    return std::dynamic_pointer_cast<T>(output_0_node);
+}
+
+std::shared_ptr<Node> CreateBiasConst(std::shared_ptr<opset1::Add> conv_bias, const ConvData& conv_data) {
+    auto add_const = std::dynamic_pointer_cast<op::Constant>(conv_bias->input_value(1).get_node_shared_ptr());
+
+    if (add_const) {
+        auto bias_size = shape_size(add_const->get_shape());
+
+        // the add may be a normal add not bias, than we just go further
+        if (bias_size == conv_data.filter_count) {
+            const float* srd_data_pointer = add_const->get_data_ptr<float>();
+            std::vector<float> bias_values(srd_data_pointer, srd_data_pointer + bias_size);
+            return opset1::Constant::create(element::f32, Shape{ 1, bias_size , 1, 1 }, bias_values);
+        }
+    }
+    // BIAS size does not match (or dynamic BIAS), can't convert such convolution
+    return nullptr;
+}
+
+template<class T>
+bool DetectOptionalLayer(GraphData& graph_data, std::shared_ptr<T> layer) {
+    if ((layer = DetectNextLayer<T>(graph_data.last_op_in_sequence_for_replacement))) {
+        if (!VerifyLayer(layer))
+            return false;
+
+        // disable_nhwc_to_nchw option case
+        if (graph_data.trailing_transpose) {
+            graph_data.last_op_in_sequence_for_replacement = layer;
+            graph_data.disable_nhwc_to_nchw_option = true;
+        } else {
+            if ((graph_data.trailing_transpose = DetectNextLayer<Transpose>(layer))) {
+                graph_data.last_op_in_sequence_for_replacement = graph_data.trailing_transpose;
+            } else {
+                graph_data.last_op_in_sequence_for_replacement = layer;
+            }
+        }
+    }
+    return true;
+}
+
+bool DetectGraphSequence(GraphData& graph_data, const ConvData& conv_data) {
+    std::shared_ptr<opset1::Add> conv_bias;
+    graph_data.last_op_in_sequence_for_replacement = graph_data.conv;
+    graph_data.disable_nhwc_to_nchw_option = false;
+
+    if ((graph_data.trailing_transpose = DetectNextLayer<Transpose>(graph_data.conv))) {
+        graph_data.last_op_in_sequence_for_replacement = graph_data.trailing_transpose;
+
+        if (VerifyLayer(graph_data.trailing_transpose) &&
+            (conv_bias = DetectNextLayer<opset1::Add>(graph_data.trailing_transpose)) &&
+            (graph_data.bias_const = CreateBiasConst(conv_bias, conv_data))) {
+            graph_data.last_op_in_sequence_for_replacement = conv_bias;
+            graph_data.disable_nhwc_to_nchw_option = true;
+        }
+    } else if ((conv_bias = DetectNextLayer<opset1::Add>(graph_data.conv))) {
+        if (!VerifyLayer(conv_bias) || !(graph_data.bias_const = CreateBiasConst(conv_bias, conv_data)))
+            return false;
+
+        if ((graph_data.trailing_transpose = DetectNextLayer<Transpose>(conv_bias))) {
+            graph_data.last_op_in_sequence_for_replacement = graph_data.trailing_transpose;
+        } else {
+            graph_data.last_op_in_sequence_for_replacement = conv_bias;
+        }
+    } else {
+        // TODO: should we want to support also Transpose(NHWC->NCHW) = > conv = > MaxPool => Transpose(NCHW->NHWC)
+        // we need to remove continue then
+        return false;
+    }
+
+    // max pooling
+    if (!DetectOptionalLayer<opset1::MaxPool>(graph_data, graph_data.max_pool))
+        return false;
+
+    // and finally activation function
+    if (!DetectOptionalLayer<op::util::UnaryElementwiseArithmetic>(graph_data, graph_data.af))
+        return false;
+
+    if (!graph_data.trailing_transpose || !graph_data.last_op_in_sequence_for_replacement ||
+        !TransposeOrderMatches(graph_data.trailing_transpose, { 0, 2, 3, 1 }))
+        return false;
+    return true;
+}
+
+bool CalculatePadding(const GraphData& graph_data, ConvData& conv_data) {
+    size_t output_channel_count = conv_data.filter_count;
+    size_t output_height{ 0 };
+    size_t output_width{ 0 };
+
+    switch (conv_data.padding_type) {
+    case op::PadType::EXPLICIT:
+        // all paddings already set
+        break;
+    case op::PadType::VALID:
+        conv_data.pads_begin_y = 0;
+        conv_data.pads_begin_x = 0;
+        conv_data.pads_end_y = 0;
+        conv_data.pads_end_x = 0;
+        // all padding equal to 0 - already set
+        break;
+    case op::PadType::SAME_LOWER:
+    case op::PadType::SAME_UPPER:
+    {
+        output_height = conv_data.output_shape[2];
+        output_width = conv_data.output_shape[3];
+
+        int32_t pads_x = (output_width - 1) * conv_data.filter_stride_x +
+            (conv_data.filter_width - 1) * conv_data.filter_dilation_x + 1 - conv_data.input_width;
+        int32_t pads_y = (output_height - 1) * conv_data.filter_stride_y +
+            (conv_data.filter_height - 1) * conv_data.filter_dilation_y + 1 - conv_data.input_height;
+
+        if (pads_x < 0)
+            pads_x = 0;
+
+        if (pads_y < 0)
+            pads_y = 0;
+
+        conv_data.pads_begin_x = conv_data.pads_end_x = pads_x / 2;
+        conv_data.pads_begin_y = conv_data.pads_end_y = pads_y / 2;
+
+        if (conv_data.padding_type == op::PadType::SAME_LOWER) {
+            conv_data.pads_begin_x += (pads_x & 1);
+            conv_data.pads_begin_y += (pads_y & 1);
+        } else {
+            conv_data.pads_end_x += (pads_x & 1);
+            conv_data.pads_end_y += (pads_y & 1);
+        }
+        break;
+    }
+    default:
+        break;
+    }
+
+    output_width = (conv_data.input_width + conv_data.pads_begin_x + conv_data.pads_end_x -
+        ((conv_data.filter_width - 1) * conv_data.filter_dilation_x + 1)) / conv_data.filter_stride_x + 1;
+
+    output_height = (conv_data.input_height + conv_data.pads_begin_y + conv_data.pads_end_y -
+        ((conv_data.filter_height - 1) * conv_data.filter_dilation_y + 1)) / conv_data.filter_stride_y + 1;
+
+    if (output_channel_count != conv_data.output_shape[1] ||
+        output_height != conv_data.output_shape[2] ||
+        output_width != conv_data.output_shape[3]) {
+        return false;
+    }
+
+    // No padding - there is no need to decompose such convolution
+    if (conv_data.pads_begin_y == 0 && conv_data.pads_end_y == 0 && conv_data.pads_begin_x == 0 && conv_data.pads_end_x == 0)
+        return false;
+
+    return true;
+}
+
+void InsertPadding(OutputVector& input_rows_to_concat, size_t size, const std::shared_ptr<opset1::Convolution>& conv,
+    const std::shared_ptr<opset1::Constant> padding_const, size_t biggest_padding) {
+
+    if (size == biggest_padding) {
+        input_rows_to_concat.push_back(padding_const);
+    } else {
+        auto slice = FlatCrop(padding_const, 0, size);
+        copy_runtime_info(conv, slice);
+        input_rows_to_concat.push_back(slice);
+    }
+}
+
+std::shared_ptr<Node> CreatePaddedNet(const GraphData& graph_data, const ConvData& conv_data) {
+    size_t flat_left_padding = conv_data.input_channel_count * conv_data.pads_begin_x;
+    size_t flat_right_padding = conv_data.input_channel_count * conv_data.pads_end_x;
+    size_t padded_row_size = flat_left_padding + conv_data.input_channel_count * conv_data.input_width + flat_right_padding;
+    size_t flat_top_padding = padded_row_size * conv_data.pads_begin_y;
+    size_t flat_bottom_padding = padded_row_size * conv_data.pads_end_y;
+    size_t biggest_padding = std::max(std::max(flat_left_padding, flat_right_padding), std::max(flat_top_padding, flat_bottom_padding));
+
+    if (conv_data.input_height > 1 && (flat_top_padding > 1 || flat_bottom_padding > 1)) {
+        biggest_padding = biggest_padding > padded_row_size ? biggest_padding : padded_row_size;
+    }
+
+    auto flat_input = std::make_shared<opset1::Reshape>(graph_data.leading_transpose->input_value(0),
+        op::Constant::create(element::i64, Shape{ 2 }, Shape{ 1ull, shape_size(graph_data.leading_transpose->input_value(0).get_shape()) }), false);
+    // zero padding
+    // TODO: find biggest padding in whole network
+    auto const_holding_padding = std::make_shared<opset1::Constant>(element::f32, Shape{ 1, biggest_padding }, 0);
+
+    copy_runtime_info(graph_data.conv, const_holding_padding);
+    std::shared_ptr<Node> original_row = flat_input;
+    OutputVector input_rows_to_concat;
+
+    // Add top padding
+    for (size_t p = 0; p < conv_data.pads_begin_y; p++) {
+        InsertPadding(input_rows_to_concat, padded_row_size, graph_data.conv, const_holding_padding, biggest_padding);
+    }
+
+    // Pad every row of input plain if neccessary
+    for (size_t h = 0; h < conv_data.input_height; h++) {
+        // left padding     input     right padding
+        //     |              |           |
+        //     +--------------+-----------+
+        //                    |
+        //                 concat
+
+        if (conv_data.input_height > 1)
+            original_row = FlatCrop(flat_input, h * conv_data.input_width * conv_data.input_channel_count,
+                conv_data.input_width * conv_data.input_channel_count);
+        copy_runtime_info(graph_data.conv, original_row);
+        if (flat_left_padding || flat_right_padding) {
+            OutputVector single_row_concat_inputs;
+            if (flat_left_padding) {
+                InsertPadding(single_row_concat_inputs, flat_left_padding, graph_data.conv, const_holding_padding, biggest_padding);
+            }
+            single_row_concat_inputs.push_back(original_row);
+            if (flat_right_padding) {
+                InsertPadding(single_row_concat_inputs, flat_right_padding, graph_data.conv, const_holding_padding, biggest_padding);
+            }
+            auto padded_row_concat = std::make_shared<opset1::Concat>(single_row_concat_inputs, 1);
+            copy_runtime_info(graph_data.conv, padded_row_concat);
+            input_rows_to_concat.push_back(padded_row_concat);
+        } else {
+            input_rows_to_concat.push_back(original_row);
+        }
+    }
+
+    // Bottom padding
+    for (size_t p = 0; p < conv_data.pads_end_y; p++) {
+        InsertPadding(input_rows_to_concat, padded_row_size, graph_data.conv, const_holding_padding, biggest_padding);
+    }
+
+    auto padded_input_plane = std::make_shared<opset1::Concat>(input_rows_to_concat, 1);
+    copy_runtime_info(graph_data.conv, padded_input_plane);
+    return padded_input_plane;
+}
+
+void GeneratePadding(const GraphData& graph_data, const ConvData& conv_data) {
+    // Add padding where neccessary
+
+    // padding
+    // padding
+    // ... row ...
+    // ... row ...
+    // ...........
+    // ... row ...
+    // padding
+    // padding
+    auto padded_input_plane = CreatePaddedNet(graph_data, conv_data);
+
+    auto padded_input_plane_reshaped = std::make_shared<opset1::Reshape>(padded_input_plane,
+        op::Constant::create(element::i64, Shape{ 4 }, { static_cast<size_t>(1), conv_data.pads_begin_y + conv_data.input_height + conv_data.pads_end_y,
+            conv_data.pads_begin_x + conv_data.input_width + conv_data.pads_end_x, conv_data.input_channel_count }), false);
+    //NHWC => NCHW
+    auto transposed2chw = std::make_shared<op::Transpose>(padded_input_plane_reshaped,
+        op::Constant::create(element::i64, Shape{ 4 }, { 0ull, 3ull, 1ull, 2ull })->output(0));
+
+    auto conv_copy = std::make_shared<opset1::Convolution>(
+        transposed2chw->output(0),
+        graph_data.conv->input_value(1),
+        graph_data.conv->get_strides(),
+        CoordinateDiff{ 0, 0 },
+        CoordinateDiff{ 0, 0 },
+        graph_data.conv->get_dilations(),
+        PadType::EXPLICIT);
+
+    replace_node(graph_data.conv, conv_copy);
+}
+} // namespace
+
+// Supported cases:
+//   - Transpose(NHWC->NCHW) => conv => Transpose(NCHW->NHWC)
+//   - Transpose(NHWC->NCHW) => conv => broadcasted add (BIAS) => Transpose(NCHW->NHWC)
+//   - Transpose(NHWC->NCHW) => conv => broadcasted add (BIAS) => MaxPooling => Transpose(NCHW->NHWC) (2d max pool case)
+//   - Transpose(NHWC->NCHW) => conv => broadcasted add (BIAS) => ActivationFunction => Transpose(NCHW->NHWC)
+//   - Transpose(NHWC->NCHW) => conv => broadcasted add (BIAS) => MaxPool => ActivationFunction => Transpose(NCHW->NHWC)
+//   - Transpose(NHWC->NCHW) => conv => Transpose(NCHW->NHWC) => BIAS (output of MO --disable_nhwc_to_nchw option)
+//   - Transpose(NHWC->NCHW) => conv => Transpose(NCHW->NHWC) => BIAS => AF (output of MO --disable_nhwc_to_nchw option)
+
+NGRAPH_RTTI_DEFINITION(pass::ConvertPadded2ValidConv, "ConvertPadded2ValidConv", 0);
+bool pass::ConvertPadded2ValidConv::run_on_function(std::shared_ptr<Function> f) {
+    // Traverse nGraph Function in topological order
+    bool is_graph_modfied = false;
+
+    for (auto& node : f->get_ordered_ops()) {
+        GraphData graph_data;
+        ConvData conv_data;
+
+        if ((graph_data.conv = DetectVerifyConvolution(node)) == nullptr)
+            continue;
+
+        FillConvData(graph_data.conv, conv_data);
+
+        // we are looking for Transpose(NHWC->NCHW) => conv => Transpose(NCHW->NHWC)
+        // or similar cases so required network must be in NHWC order like in TF
+        if (!(graph_data.leading_transpose = DetectVerifyLeadingTranspose(graph_data.conv)))
+            continue;
+
+        if (!DetectGraphSequence(graph_data, conv_data))
+            continue;
+
+        if (!CalculatePadding(graph_data, conv_data))
+            continue;
+
+        GeneratePadding(graph_data, conv_data);
+
+        is_graph_modfied = true;
+    }
+    return is_graph_modfied;
+}

--- a/inference-engine/src/gna_plugin/transformations/convert_padded2valid_conv.hpp
+++ b/inference-engine/src/gna_plugin/transformations/convert_padded2valid_conv.hpp
@@ -4,23 +4,17 @@
 
 #pragma once
 
-#include <transformations_visibility.hpp>
 #include <ngraph/pass/graph_rewrite.hpp>
 
-namespace ngraph {
-namespace pass {
-
-class ConvertPadded2ValidConv;
-
-}  // namespace pass
-}  // namespace ngraph
+namespace GNAPluginNS {
 
 /**
- * @ingroup ie_transformation_common_api
- * @brief ConvertPadded2ValidConv transformation breaks down padded convolutions into a set of unpadded ones.
+ * @brief ConvertPadded2ValidConv transformation breaks down padded convolutions into a set of unpadded ones
  */
-class ngraph::pass::ConvertPadded2ValidConv : public ngraph::pass::FunctionPass {
+class ConvertPadded2ValidConv : public ngraph::pass::FunctionPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
-    bool run_on_function(std::shared_ptr<ngraph::Function> f) override;
+  NGRAPH_RTTI_DECLARATION;
+  bool run_on_function(std::shared_ptr<ngraph::Function> f) override;
 };
+
+} // namespace GNAPluginNS

--- a/inference-engine/src/gna_plugin/transformations/convert_padded2valid_conv.hpp
+++ b/inference-engine/src/gna_plugin/transformations/convert_padded2valid_conv.hpp
@@ -1,0 +1,26 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <transformations_visibility.hpp>
+#include <ngraph/pass/graph_rewrite.hpp>
+
+namespace ngraph {
+namespace pass {
+
+class ConvertPadded2ValidConv;
+
+}  // namespace pass
+}  // namespace ngraph
+
+/**
+ * @ingroup ie_transformation_common_api
+ * @brief ConvertPadded2ValidConv transformation breaks down padded convolutions into a set of unpadded ones.
+ */
+class ngraph::pass::ConvertPadded2ValidConv : public ngraph::pass::FunctionPass {
+public:
+    NGRAPH_RTTI_DECLARATION;
+    bool run_on_function(std::shared_ptr<ngraph::Function> f) override;
+};

--- a/inference-engine/tests/functional/plugin/gna/pass_tests/padded2valid_conv.cpp
+++ b/inference-engine/tests/functional/plugin/gna/pass_tests/padded2valid_conv.cpp
@@ -1,0 +1,360 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include "common_test_utils/test_common.hpp"
+#include <string>
+#include <sstream>
+#include <fstream>
+#include <memory>
+#include <queue>
+#include <map>
+
+#include "transformations/init_node_info.hpp"
+#include "ngraph_functions/builders.hpp"
+#include "shared_test_classes/base/layer_test_utils.hpp"
+#include "../shared_tests_instances/skip_tests_check.hpp"
+
+using namespace ngraph;
+using namespace ngraph::opset1;
+
+namespace LayerTestsDefinitions {
+
+enum class modelType {
+    TranspConvTransp = 0,               /* Transpose(NHWC->NCHW) => conv => Transpose(NCHW->NHWC) */
+    TranspConvBcastAddTransp,           /* Transpose(NHWC->NCHW) => conv => broadcasted add (BIAS) => Transpose(NCHW->NHWC) */
+    TranspConvBcastAddMaxPoolTransp,    /* Transpose(NHWC->NCHW) => conv => broadcasted add (BIAS) => MaxPooling => Transpose(NCHW->NHWC) (2d max pool case) */
+    TranspConvBcastAddActTransp,        /* Transpose(NHWC->NCHW) => conv => broadcasted add (BIAS) => ActivationFunction => Transpose(NCHW->NHWC) */
+    TranspConvBcastAddMaxPoolActTransp, /* Transpose(NHWC->NCHW) => conv => broadcasted add (BIAS) => MaxPool => ActivationFunction => Transpose(NCHW->NHWC) */
+    TranspConvTranspBcastAdd,           /* Transpose(NHWC->NCHW) => conv => Transpose(NCHW->NHWC) => BIAS (output of MO --disable_nhwc_to_nchw option) */
+    TranspConvTranspBcastAddAct         /* Transpose(NHWC->NCHW) => conv => Transpose(NCHW->NHWC) => BIAS => AF (output of MO --disable_nhwc_to_nchw option) */
+};
+
+typedef std::tuple<
+    InferenceEngine::SizeVector,    // Kernel size
+    InferenceEngine::SizeVector,    // Strides
+    std::vector<ptrdiff_t>,         // Pad begin
+    std::vector<ptrdiff_t>,         // Pad end
+    InferenceEngine::SizeVector,    // Dilation
+    size_t,                         // Num out channels
+    op::PadType                     // Padding type
+> convSpecificParams;
+
+typedef std::tuple<
+    InferenceEngine::SizeVector,    // Bias
+    InferenceEngine::SizeVector,    // Transposed Bias
+    InferenceEngine::SizeVector,    // Maxpool pool
+    InferenceEngine::SizeVector     // Maxpool strides
+> miscSpecificParams;
+
+typedef std::tuple<
+    convSpecificParams,                 // Convolution parameters
+    miscSpecificParams,                 // Bias & Maxpool parameters
+    InferenceEngine::Precision,         // Network Precision
+    std::string,                        // Target Device
+    std::map<std::string, std::string>, // Configuration
+    InferenceEngine::SizeVector,        // Input shapes
+    modelType                           // Test model
+> padded2ValidParams;
+
+class Padded2ValidConvTest : public testing::WithParamInterface<padded2ValidParams>,
+    virtual public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<padded2ValidParams> obj) {
+        convSpecificParams convParams;
+        miscSpecificParams miscParams;
+        InferenceEngine::Precision netPrecision;
+        std::string targetDevice;
+        std::map<std::string, std::string> configuration;
+        InferenceEngine::SizeVector inputShape;
+        modelType model;
+        std::tie(convParams, miscParams, netPrecision, targetDevice, configuration, inputShape, model) = obj.param;
+        op::PadType padType;
+        InferenceEngine::SizeVector kernel, stride, dilation, bias, transpBias, maxpool_pool, maxpool_stride;
+        std::vector<ptrdiff_t> padBegin, padEnd;
+        size_t numOutChannels;
+        std::tie(kernel, stride, padBegin, padEnd, dilation, numOutChannels, padType) = convParams;
+        std::tie(bias, transpBias, maxpool_pool, maxpool_stride) = miscParams;
+
+        std::ostringstream result;
+        result << "M=" << static_cast<uint32_t>(model) << "_";
+        result << "IS=" << CommonTestUtils::vec2str(inputShape) << "_";
+        result << "K" << CommonTestUtils::vec2str(kernel) << "_";
+        result << "S" << CommonTestUtils::vec2str(stride) << "_";
+        result << "PB" << CommonTestUtils::vec2str(padBegin) << "_";
+        result << "PE" << CommonTestUtils::vec2str(padEnd) << "_";
+        result << "D=" << CommonTestUtils::vec2str(dilation) << "_";
+        result << "O=" << numOutChannels << "_";
+        result << "AP=" << padType << "_";
+        result << "B=" << CommonTestUtils::vec2str(bias) << "_";
+        result << "B=" << CommonTestUtils::vec2str(transpBias) << "_";
+        result << "MPP=" << CommonTestUtils::vec2str(maxpool_pool) << "_";
+        result << "MPS=" << CommonTestUtils::vec2str(maxpool_stride) << "_";
+        result << "netPRC=" << netPrecision.name() << "_";
+        result << "targetDevice=" << targetDevice << "_";
+        for (auto const& configItem : configuration) {
+            result << "_configItem=" << configItem.first << "_" << configItem.second;
+        }
+        return result.str();
+    }
+
+protected:
+    void SetUp() override {
+        threshold = 0.015;
+        convSpecificParams convParams;
+        miscSpecificParams miscParams;
+        InferenceEngine::Precision netPrecision;
+        std::vector<size_t> inputShape;
+        modelType model;
+        std::tie(convParams, miscParams, netPrecision, targetDevice, configuration, inputShape, model) = this->GetParam();
+        op::PadType padType;
+        InferenceEngine::SizeVector kernel, stride, dilation, bias, transpBias, maxpool_pool, maxpool_stride;
+        std::vector<ptrdiff_t> padBegin, padEnd;
+        size_t numOutChannels;
+        std::tie(kernel, stride, padBegin, padEnd, dilation, numOutChannels, padType) = convParams;
+        std::tie(bias, transpBias, maxpool_pool, maxpool_stride) = miscParams;
+        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+
+        Shape bias_shape{ bias };
+        Shape transp_bias_shape{ transpBias };
+        Shape maxpool_shape{ maxpool_pool };
+        Strides maxpool_strides{ maxpool_stride };
+
+        auto input = builder::makeParams(ngPrc, { inputShape });
+        auto transpose_in_order = op::Constant::create(element::i64, Shape{ 4 }, { 0, 3, 1, 2 });
+        auto transpose_in = std::make_shared<Transpose>(input[0], transpose_in_order);
+        auto filter_size = std::accumulate(std::begin(kernel), std::end(kernel), 1, std::multiplies<size_t>());
+        auto filter_weights = CommonTestUtils::generate_float_numbers(numOutChannels * inputShape[3] * filter_size, -0.05f, 0.05f);
+        auto conv = builder::makeConvolution(transpose_in, ngPrc, kernel, stride, padBegin,
+            padEnd, dilation, padType, numOutChannels, false, filter_weights);
+        auto transpose_out_order = op::Constant::create(element::i64, Shape{ 4 }, { 0, 2, 3, 1 });
+        auto bias_weights = CommonTestUtils::generate_float_numbers(shape_size(bias_shape), -1.5f, 1.5f);
+        Output<Node> bias_const = std::make_shared<Constant>(ngPrc, bias_shape, bias_weights);
+        Output<Node> transp_bias_const = std::make_shared<Constant>(ngPrc, transp_bias_shape, bias_weights);
+        Output<Node> last_op = std::make_shared<Transpose>(conv, transpose_out_order);
+
+        switch (model) {
+        case modelType::TranspConvBcastAddTransp:
+        {
+            auto bias = std::make_shared<Add>(conv, bias_const);
+            last_op = std::make_shared<Transpose>(bias, transpose_out_order);
+        }
+        break;
+
+        case modelType::TranspConvBcastAddMaxPoolTransp:
+        {
+            auto bcast_add = std::make_shared<Add>(conv, bias_const);
+            auto max_pool = std::make_shared<MaxPool>(bcast_add, maxpool_strides, Shape{ 0, 0 }, Shape{ 0, 0 }, maxpool_shape,
+                op::RoundingType::FLOOR, op::PadType::VALID);
+            last_op = std::make_shared<Transpose>(max_pool, transpose_out_order);
+        }
+        break;
+
+        case modelType::TranspConvBcastAddActTransp:
+        {
+            auto bcast_add = std::make_shared<Add>(conv, bias_const);
+            auto activation = std::make_shared<Relu>(bcast_add);
+            last_op = std::make_shared<Transpose>(activation, transpose_out_order);
+        }
+        break;
+
+        case modelType::TranspConvBcastAddMaxPoolActTransp:
+        {
+            auto bcast_add = std::make_shared<Add>(conv, bias_const);
+            auto max_pool = std::make_shared<MaxPool>(bcast_add, maxpool_strides, Shape{ 0, 0 }, Shape{ 0, 0 }, maxpool_shape,
+                op::RoundingType::FLOOR, op::PadType::VALID);
+            auto activation = std::make_shared<Relu>(max_pool);
+            last_op = std::make_shared<Transpose>(activation, transpose_out_order);
+        }
+        break;
+
+        case modelType::TranspConvTranspBcastAdd:
+        {
+            bias_const = std::make_shared<Constant>(ngPrc, transp_bias_shape);
+            last_op = std::make_shared<Add>(last_op, bias_const);
+        }
+        break;
+
+        case modelType::TranspConvTranspBcastAddAct:
+        {
+            bias_const = builder::makeConstant(ngPrc, transp_bias_shape, bias_weights, true);
+            auto bcast_add = std::make_shared<Add>(last_op, bias_const);
+            last_op = std::make_shared<Relu>(bcast_add);
+        }
+        break;
+
+        case modelType::TranspConvTransp:
+        default:
+            break;
+        }
+
+        auto result = std::make_shared<Result>(last_op);
+        function = std::make_shared<Function>(ResultVector{ result }, ParameterVector{ input });
+    }
+};
+
+class Gna30Padded2ValidConvTest : public Padded2ValidConvTest, GnaLayerTestCheck {
+protected:
+    void Run() override {
+        GnaLayerTestCheck::SkipTestCheck();
+
+        if (!GnaLayerTestCheck::skipTest) {
+            Padded2ValidConvTest::Run();
+        }
+    }
+
+    void SetUp() override {
+        Padded2ValidConvTest::SetUp();
+    }
+};
+
+TEST_P(Padded2ValidConvTest, CompareWithRefs) {
+    Run();
+}
+
+TEST_P(Gna30Padded2ValidConvTest, CompareWithRefs) {
+    Run();
+}
+
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32,
+    //TODO: FP16 is currently not supported by the transform
+    //InferenceEngine::Precision::FP16
+};
+
+const std::vector<std::map<std::string, std::string>> configs1D = {
+    {
+        {"GNA_DEVICE_MODE", "GNA_SW_EXACT"},
+        {"GNA_SCALE_FACTOR_0", "1"},
+        {"GNA_EXEC_TARGET", "GNA_TARGET_2_0"}
+    }
+};
+
+const std::vector<std::map<std::string, std::string>> configs1D_Gna30 = {
+    {
+        {"GNA_DEVICE_MODE", "GNA_SW_EXACT"},
+        {"GNA_SCALE_FACTOR_0", "1"},
+        {"GNA_EXEC_TARGET", "GNA_TARGET_3_0"}
+    }
+};
+
+const std::vector<std::map<std::string, std::string>> configs2D = {
+    {
+        {"GNA_DEVICE_MODE", "GNA_SW_EXACT"},
+        {"GNA_SCALE_FACTOR_0", "1"},
+        {"GNA_EXEC_TARGET", "GNA_TARGET_3_0"}
+    }
+};
+
+const std::vector<op::PadType> padTypes = {
+        op::PadType::EXPLICIT,
+        op::PadType::SAME_LOWER,
+        op::PadType::SAME_UPPER,
+        op::PadType::VALID
+};
+
+const std::vector<modelType> models = {
+    modelType::TranspConvTransp,
+    modelType::TranspConvBcastAddTransp,
+    modelType::TranspConvBcastAddActTransp,
+    modelType::TranspConvTranspBcastAdd,
+    modelType::TranspConvTranspBcastAddAct,
+    //TODO: enable when 50386 and 50379 are fixed
+    //modelType::TranspConvBcastAddMaxPoolTransp,
+    //modelType::TranspConvBcastAddMaxPoolActTransp,
+};
+
+const std::vector<std::vector<size_t>> input1DNHWC = { {1, 1, 16, 8} };
+const std::vector<std::vector<size_t >> kernels1D = { {1, 2}, {1, 3}, {1, 4} };
+const std::vector<std::vector<size_t >> strides1D = { {1, 1} };
+const std::vector<std::vector<ptrdiff_t>> padBegins1D = { {0, 2} };
+const std::vector<std::vector<ptrdiff_t>> padEnds1D = { {0, 3} };
+const std::vector<std::vector<size_t >> dilations1D = { {1, 1} };
+const std::vector<size_t> numOutChannels1D = { 4 };
+const std::vector<std::vector<size_t >> biases1D = { {1, 4, 1, 1} };
+const std::vector<std::vector<size_t >> transp_biases1D = { {1, 1, 1, 4} };
+const std::vector<std::vector<size_t >> maxpool1D_pools = { {1, 2} };
+const std::vector<std::vector<size_t >> maxpool1D_strides = { {1, 1} };
+
+const std::vector<std::vector<size_t>> input2DNHWC = { {1, 16, 16, 32} };
+const std::vector<std::vector<size_t >> kernels2D = { {2, 2}, { 4, 1 }, { 1, 3 }};
+const std::vector<std::vector<size_t >> strides2D = { {1, 1}, {1, 2}, {2, 1}, {2, 2} };
+const std::vector<std::vector<ptrdiff_t>> padBegins2D = { {1, 2} };
+const std::vector<std::vector<ptrdiff_t>> padEnds2D = { {3, 1} };
+const std::vector<std::vector<size_t >> dilations2D = { {1, 1} };
+const std::vector<size_t> numOutChannels2D = { 32 };
+const std::vector<std::vector<size_t >> biases2D = { {1, 32, 1, 1} };
+const std::vector<std::vector<size_t >> transp_biases2D = { {1, 1, 1, 32} };
+const std::vector<std::vector<size_t >> maxpool2D_pools = { {2, 2} };
+const std::vector<std::vector<size_t >> maxpool2D_strides = { {2, 1} };
+
+const auto conv1DParams = ::testing::Combine(
+    ::testing::ValuesIn(kernels1D),
+    ::testing::ValuesIn(strides1D),
+    ::testing::ValuesIn(padBegins1D),
+    ::testing::ValuesIn(padEnds1D),
+    ::testing::ValuesIn(dilations1D),
+    ::testing::ValuesIn(numOutChannels1D),
+    ::testing::ValuesIn(padTypes)
+);
+
+const auto misc1DParams = ::testing::Combine(
+    ::testing::ValuesIn(biases1D),
+    ::testing::ValuesIn(transp_biases1D),
+    ::testing::ValuesIn(maxpool1D_pools),
+    ::testing::ValuesIn(maxpool1D_strides)
+);
+
+const auto conv2DParams = ::testing::Combine(
+    ::testing::ValuesIn(kernels2D),
+    ::testing::ValuesIn(strides2D),
+    ::testing::ValuesIn(padBegins2D),
+    ::testing::ValuesIn(padEnds2D),
+    ::testing::ValuesIn(dilations2D),
+    ::testing::ValuesIn(numOutChannels2D),
+    ::testing::ValuesIn(padTypes)
+);
+
+const auto misc2DParams = ::testing::Combine(
+    ::testing::ValuesIn(biases2D),
+    ::testing::ValuesIn(transp_biases2D),
+    ::testing::ValuesIn(maxpool2D_pools),
+    ::testing::ValuesIn(maxpool2D_strides)
+);
+
+INSTANTIATE_TEST_CASE_P(smoke_1DPadded2Valid, Padded2ValidConvTest,
+    ::testing::Combine(
+        conv1DParams,
+        misc1DParams,
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(CommonTestUtils::DEVICE_GNA),
+        ::testing::ValuesIn(configs1D),
+        ::testing::ValuesIn(input1DNHWC),
+        ::testing::ValuesIn(models)),
+    Padded2ValidConvTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_1DPadded2Valid, Gna30Padded2ValidConvTest,
+    ::testing::Combine(
+        conv1DParams,
+        misc1DParams,
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(CommonTestUtils::DEVICE_GNA),
+        ::testing::ValuesIn(configs1D_Gna30),
+        ::testing::ValuesIn(input1DNHWC),
+        ::testing::ValuesIn(models)),
+    Gna30Padded2ValidConvTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_2DPadded2Valid, Gna30Padded2ValidConvTest,
+    ::testing::Combine(
+        conv2DParams,
+        misc2DParams,
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(CommonTestUtils::DEVICE_GNA),
+        ::testing::ValuesIn(configs2D),
+        ::testing::ValuesIn(input2DNHWC),
+        ::testing::ValuesIn(models)),
+    Gna30Padded2ValidConvTest::getTestCaseName);
+
+} // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/gna/pass_tests/padded2valid_conv.cpp
+++ b/inference-engine/tests/functional/plugin/gna/pass_tests/padded2valid_conv.cpp
@@ -279,7 +279,7 @@ const std::vector<std::vector<size_t >> maxpool1D_pools = { {1, 2} };
 const std::vector<std::vector<size_t >> maxpool1D_strides = { {1, 1} };
 
 const std::vector<std::vector<size_t>> input2DNHWC = { {1, 16, 16, 32} };
-const std::vector<std::vector<size_t >> kernels2D = { {2, 2}, { 4, 1 }, { 1, 3 }};
+const std::vector<std::vector<size_t >> kernels2D = { {2, 2}, {4, 1}, {1, 3}};
 const std::vector<std::vector<size_t >> strides2D = { {1, 1}, {1, 2}, {2, 1}, {2, 2} };
 const std::vector<std::vector<ptrdiff_t>> padBegins2D = { {1, 2} };
 const std::vector<std::vector<ptrdiff_t>> padEnds2D = { {3, 1} };

--- a/inference-engine/tests/functional/plugin/gna/pass_tests/padded2valid_conv.cpp
+++ b/inference-engine/tests/functional/plugin/gna/pass_tests/padded2valid_conv.cpp
@@ -219,8 +219,7 @@ TEST_P(Gna30Padded2ValidConvTest, CompareWithRefs) {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
-    //TODO: FP16 is currently not supported by the transform
-    //InferenceEngine::Precision::FP16
+    InferenceEngine::Precision::FP16
 };
 
 const std::vector<std::map<std::string, std::string>> configs1D = {


### PR DESCRIPTION
### Details:
 - Add transformation of padded convolutions to valid ones
 - The network needs to be in NHWC order and the following cases are supported:
Transpose(NHWC>NCHW) => conv => Transpose(NCHW->NHWC)
Transpose(NHWC->NCHW) => conv => broadcasted add (BIAS) => Transpose(NCHW->NHWC)
Transpose(NHWC->NCHW) => conv => broadcasted add (BIAS) => MaxPooling => Transpose(NCHW->NHWC) (2d max pool case)
Transpose(NHWC->NCHW) => conv => broadcasted add (BIAS) => ActivationFunction => Transpose(NCHW->NHWC)
Transpose(NHWC->NCHW) => conv => broadcasted add (BIAS) => MaxPool => ActivationFunction => Transpose(NCHW->NHWC)
Transpose(NHWC->NCHW) => conv => Transpose(NCHW->NHWC) => BIAS => Transpose(NCHW->NHWC)
Transpose(NHWC->NCHW) => conv => Transpose(NCHW->NHWC) => BIAS => AF => Transpose(NCHW->NHWC).
The last two cases are output by MO with --disable_nhwc_to_nchw option.

### Tickets:
 - 24838
