### PR TITLE
Fix external_port_id serialization for loop op.

### DIFF
--- a/inference-engine/tests/functional/inference_engine/ir_serialization/tensor_iterator.cpp
+++ b/inference-engine/tests/functional/inference_engine/ir_serialization/tensor_iterator.cpp
@@ -9,6 +9,7 @@
 #include "ie_core.hpp"
 #include "ie_blob.h"
 #include "common_test_utils/data_utils.hpp"
+#include "pugixml.hpp"
 
 #ifndef IR_SERIALIZATION_MODELS_PATH  // should be already defined by cmake
 #define IR_SERIALIZATION_MODELS_PATH ""
@@ -83,4 +84,41 @@ TEST_F(SerializationTensorIteratorTest, TiNegativeStride) {
     data[393732] = 256;
 
     serialize_and_compare(model_path, weights);
+}
+
+TEST_F(SerializationTensorIteratorTest, SerializationExternalPortIdInXmlFile) {
+    const std::string model_path = IR_SERIALIZATION_MODELS_PATH "loop_2d_add.xml";
+    const std::string binary_path = IR_SERIALIZATION_MODELS_PATH "loop_2d_add.bin";
+
+    InferenceEngine::Core ie;
+    InferenceEngine::CNNNetwork expected;
+    pugi::xml_document loop_orig;
+    pugi::xml_document loop_serialized;
+
+    expected = ie.ReadNetwork(model_path, binary_path);
+    expected.serialize(m_out_xml_path, m_out_bin_path);
+
+    pugi::xml_parse_result result = loop_orig.load_file(model_path.c_str());
+    ASSERT_FALSE(result.status) << result.description();
+    result = loop_serialized.load_file(m_out_xml_path.c_str());
+    ASSERT_FALSE(result.status) << result.description();
+
+    auto node1 = loop_orig.child("net").child("layers").find_child_by_attribute("type", "Loop");
+    auto node2 = loop_serialized.child("net").child("layers").find_child_by_attribute("type", "Loop");
+    auto node2_port_map = node2.child("port_map").first_child();
+
+    for (auto ch = node1.child("port_map").first_child(); !ch.empty(); ch = ch.next_sibling()) {
+        auto node1_external_port_id = std::stoi(ch.attribute("external_port_id").value());
+        auto node2_external_port_id = std::stoi(node2_port_map.attribute("external_port_id").value());
+
+        if (node1_external_port_id == -1) {
+            continue;
+        }
+        if (node2_external_port_id == -1) {
+            node2_external_port_id = std::stoi(node2_port_map.next_sibling().attribute("external_port_id").value());
+        }
+        node2_port_map = node2_port_map.next_sibling();
+
+        EXPECT_EQ(node1_external_port_id, node2_external_port_id);
+    }
 }


### PR DESCRIPTION
### Details:
 - external_port_id for TI/Loop ops takes into account number of op inputs instead of input descriptors size.

### Tickets:
 - 55420
