### PR TITLE
[VPU WIP] switch CNNLayer -> std::shared_ptr<ngraph::Node>

### DIFF
--- a/inference-engine/src/vpu/common/include/vpu/ngraph/operations/fully_connected.hpp
+++ b/inference-engine/src/vpu/common/include/vpu/ngraph/operations/fully_connected.hpp
@@ -1,0 +1,51 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <ie_api.h>
+
+#include "ngraph/node.hpp"
+#include "ngraph/op/op.hpp"
+
+namespace ngraph {
+namespace vpu {
+namespace op {
+
+/// \brief Operator performing Matrix Multiplication.
+class FullyConnected : public ngraph::op::Op {
+public:
+    static constexpr NodeTypeInfo type_info{"FullyConnected", 0};
+    const NodeTypeInfo& get_type_info() const override { return type_info; }
+    FullyConnected() = default;
+    /// \brief Constructs an FullyConnected operation.
+    ///
+    /// \param A Matrix A
+    /// \param B Matrix B
+    /// \param C Matrix C
+    FullyConnected(const Output<Node> & A,
+                   const Output<Node> & B,
+                   const Output<Node> & C,
+                   const Shape & output_shape,
+                   const element::Type output_type = element::undefined);
+
+    bool visit_attributes(AttributeVisitor &visitor) override;
+
+    void validate_and_infer_types() override;
+
+    std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
+
+    size_t get_out_size() const { return m_output_size; }
+
+    element::Type get_output_type() const { return m_output_type; }
+
+private:
+    size_t m_output_size = 0;
+    Shape m_output_shape = {};
+    element::Type m_output_type;
+};
+
+}  // namespace op
+}  // namespace vpu
+}  // namespace ngraph

--- a/inference-engine/src/vpu/common/include/vpu/ngraph/operations/static_shape_non_maximum_suppression.hpp
+++ b/inference-engine/src/vpu/common/include/vpu/ngraph/operations/static_shape_non_maximum_suppression.hpp
@@ -13,7 +13,7 @@
 
 namespace ngraph { namespace vpu { namespace op {
 
-class StaticShapeNonMaxSuppression : public ngraph::op::NonMaxSuppressionIE3 {
+class StaticShapeNonMaxSuppression : public ngraph::opset5::NonMaxSuppression {
 public:
     static constexpr NodeTypeInfo type_info{"StaticShapeNonMaxSuppression", 0};
     const NodeTypeInfo& get_type_info() const override { return type_info; }
@@ -26,7 +26,7 @@ public:
                                  const Output<Node>& iouThreshold,
                                  const Output<Node>& scoreThreshold,
                                  const Output<Node>& softNmsSigma,
-                                 int centerPointBox = 0,
+                                 ngraph::op::v5::NonMaxSuppression::BoxEncodingType boxEncodingType = ngraph::op::v5::NonMaxSuppression::BoxEncodingType::CENTER,
                                  bool sortResultDescending = true,
                                  const ngraph::element::Type& outputType = ngraph::element::i64);
 

--- a/inference-engine/src/vpu/common/include/vpu/ngraph/transformations/convert_matmul_to_fc.hpp
+++ b/inference-engine/src/vpu/common/include/vpu/ngraph/transformations/convert_matmul_to_fc.hpp
@@ -1,0 +1,18 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <ngraph/pass/graph_rewrite.hpp>
+
+namespace vpu {
+
+
+class ConvertMatMulToFC: public ngraph::pass::MatcherPass {
+public:
+    NGRAPH_RTTI_DECLARATION;
+    ConvertMatMulToFC();
+};
+
+}

--- a/inference-engine/src/vpu/common/include/vpu/utils/ie_helpers.hpp
+++ b/inference-engine/src/vpu/common/include/vpu/utils/ie_helpers.hpp
@@ -13,8 +13,9 @@
 #include <ie_blob.h>
 #include <legacy/ie_layers.h>
 
+#include <ngraph/node.hpp>
 namespace vpu {
-
+using NodePtr = std::shared_ptr<ngraph::Node>;
 namespace ie = InferenceEngine;
 
 VPU_DECLARE_ENUM(LayoutPreference,
@@ -33,6 +34,6 @@ void copyBlob(const ie::Blob::Ptr& in, const ie::Blob::Ptr& out);
 
 void printTo(DotLabel& lbl, const ie::DataPtr& ieData);
 void printTo(DotLabel& lbl, const ie::Blob::Ptr& ieBlob);
-void printTo(DotLabel& lbl, const ie::CNNLayerPtr& ieLayer);
+void printTo(DotLabel& lbl, const NodePtr& node);
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/common/src/ngraph/operations/fully_connected.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/operations/fully_connected.cpp
@@ -1,0 +1,46 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "vpu/ngraph/operations/fully_connected.hpp"
+
+#include <memory>
+#include <numeric>
+
+using namespace std;
+using namespace ngraph;
+namespace ngraph {
+namespace vpu {
+namespace op {
+constexpr NodeTypeInfo FullyConnected::type_info;
+
+op::FullyConnected::FullyConnected(
+    const Output<Node>& A,
+    const Output<Node>& B,
+    const Output<Node>& C,
+    const Shape & output_shape,
+    const element::Type output_type)
+    : Op({A, B, C}), m_output_shape(output_shape), m_output_type(output_type) {
+    constructor_validate_and_infer_types();
+}
+
+shared_ptr<Node> FullyConnected::clone_with_new_inputs(const OutputVector& new_args) const {
+    check_new_args_count(this, new_args);
+    return make_shared<FullyConnected>(new_args.at(0), new_args.at(1), new_args.at(2), m_output_shape);
+}
+
+void FullyConnected::validate_and_infer_types() {
+    m_output_size = m_output_shape.back();
+    set_output_type(
+        0,
+        m_output_type == element::undefined ? input_value(0).get_element_type() : m_output_type,
+        m_output_shape);
+}
+
+bool FullyConnected::visit_attributes(AttributeVisitor &visitor) {
+    visitor.on_attribute("out-size", m_output_size);
+    return true;
+}
+}  // namespace op
+}  // namespace vpu  
+}  // namespace ngraph  

--- a/inference-engine/src/vpu/common/src/ngraph/operations/static_shape_non_maximum_suppression.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/operations/static_shape_non_maximum_suppression.cpp
@@ -20,7 +20,7 @@ StaticShapeNonMaxSuppression::StaticShapeNonMaxSuppression(const ngraph::opset5:
         nms.get_input_size() > 3 ? nms.input_value(3) : ngraph::opset5::Constant::create(ngraph::element::f32, ngraph::Shape{}, {.0f}),
         nms.get_input_size() > 4 ? nms.input_value(4) : ngraph::opset5::Constant::create(ngraph::element::f32, ngraph::Shape{}, {.0f}),
         nms.get_input_size() > 5 ? nms.input_value(5) : ngraph::opset5::Constant::create(ngraph::element::f32, ngraph::Shape{}, {.0f}),
-        nms.get_box_encoding() == ngraph::opset5::NonMaxSuppression::BoxEncodingType::CENTER ? 1 : 0,
+        nms.get_box_encoding(),
         nms.get_sort_result_descending(),
         nms.get_output_type()) {}
 
@@ -31,10 +31,10 @@ StaticShapeNonMaxSuppression::StaticShapeNonMaxSuppression(
         const Output<Node>& iouThreshold,
         const Output<Node>& scoreThreshold,
         const Output<Node>& softNmsSigma,
-        int centerPointBox,
+        ngraph::op::v5::NonMaxSuppression::BoxEncodingType centerPointBox,
         const bool sortResultDescending,
         const element::Type& outputType)
-        : ngraph::op::NonMaxSuppressionIE3(
+        : ngraph::opset5::NonMaxSuppression(
         boxes, scores, maxOutputBoxesPerClass, iouThreshold, scoreThreshold,
         softNmsSigma, centerPointBox, sortResultDescending, outputType) {
     constructor_validate_and_infer_types();
@@ -44,12 +44,12 @@ std::shared_ptr<Node>
 StaticShapeNonMaxSuppression::clone_with_new_inputs(const OutputVector& new_args) const {
     check_new_args_count(this, new_args);
     return std::make_shared<StaticShapeNonMaxSuppression>(new_args.at(0), new_args.at(1), new_args.at(2), new_args.at(3),
-                                                          new_args.at(4), new_args.at(5), m_center_point_box, m_sort_result_descending,
+                                                          new_args.at(4), new_args.at(5), m_box_encoding, m_sort_result_descending,
                                                           m_output_type);
 }
 
 void StaticShapeNonMaxSuppression::validate_and_infer_types() {
-    ngraph::op::NonMaxSuppressionIE3::validate_and_infer_types();
+    ngraph::opset5::NonMaxSuppression::validate_and_infer_types();
 
     auto outIndicesShape = get_output_partial_shape(0);
     auto outScoresShape = get_output_partial_shape(1);

--- a/inference-engine/src/vpu/common/src/ngraph/transformations/convert_matmul_to_fc.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/transformations/convert_matmul_to_fc.cpp
@@ -1,0 +1,170 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "vpu/ngraph/operations/fully_connected.hpp"
+#include "vpu/ngraph/transformations/convert_matmul_to_fc.hpp"
+#include <ngraph/rt_info.hpp>
+
+#include <algorithm>
+#include <utility>
+#include <memory>
+#include <vector>
+#include <string>
+#include <numeric>
+
+#include <ngraph/opsets/opset1.hpp>
+#include <ngraph/rt_info.hpp>
+#include <ngraph/pattern/op/wrap_type.hpp>
+
+#include <transformations/utils/utils.hpp>
+
+NGRAPH_RTTI_DEFINITION(vpu::ConvertMatMulToFC, "ConvertMatMulToFC", 0);
+
+namespace vpu {
+ConvertMatMulToFC::ConvertMatMulToFC() {
+    auto matmul = ngraph::pattern::wrap_type<ngraph::opset1::MatMul>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
+                                                      ngraph::pattern::any_input(ngraph::pattern::has_static_shape())},
+                                                      ngraph::pattern::has_static_shape());
+
+    ngraph::matcher_pass_callback callback = [this](ngraph::pattern::Matcher& m) {
+        auto matmul = std::dynamic_pointer_cast<ngraph::opset1::MatMul>(m.get_match_root());
+        if (!matmul || transformation_callback(matmul)) {
+            return false;
+        }
+
+        auto input_a = matmul->input(0).get_source_output();
+        auto input_b = matmul->input(1).get_source_output();
+
+        auto shape_a = input_a.get_shape();
+        auto shape_b = input_b.get_shape();
+        auto output_shape = matmul->get_shape();
+
+        // Transformation to FC is not supported for 1D second input
+        if (shape_b.size() == 1) {
+            return false;
+        }
+
+        /*
+         *  get_aligned_shapes function align two input shapes to have the same size and
+         *  the same batch dimensions (last two dimensions are not comparable).
+         *  It also checks that dimensions are compatible so in case with two shapes
+         *  for example: [2, 32, 64] [3, 64, 64] it will raise an exception.
+         */
+
+        auto get_aligned_shapes = [shape_a, shape_b, &matmul]() -> std::pair<ngraph::Shape, ngraph::Shape> {
+            ngraph::Shape shape_a_aligned(shape_a), shape_b_aligned(shape_b);
+            size_t max_size = std::max(shape_a_aligned.size(), shape_b_aligned.size());
+            for (size_t i = 0, cnt = max_size - shape_a_aligned.size(); i < cnt; ++i)
+                shape_a_aligned.insert(shape_a_aligned.begin(), 1);
+            for (size_t i = 0, cnt = max_size - shape_b_aligned.size(); i < cnt; ++i)
+                shape_b_aligned.insert(shape_b_aligned.begin(), 1);
+
+            if (matmul->get_transpose_a() && shape_a.size() != 1) {
+                std::swap(*(shape_a_aligned.end() - 1), *(shape_a_aligned.end() - 2));
+            }
+            if (matmul->get_transpose_b()) {
+                std::swap(*(shape_b_aligned.end() - 1), *(shape_b_aligned.end() - 2));
+            }
+
+            for (size_t i = 0; i < max_size - 2; ++i) {
+                if (shape_a_aligned[i] != shape_b_aligned[i] && shape_a_aligned[i] > 1 && shape_b_aligned[i] > 1) {
+                    std::ostringstream stream;
+                    stream << "Shapes can't be aligned: " << shape_a_aligned << " " << shape_b_aligned;
+                    throw ngraph::ngraph_error(stream.str());
+                }
+                size_t max_value = std::max(shape_a_aligned[i], shape_b_aligned[i]);
+                shape_a_aligned[i] = shape_b_aligned[i] = max_value;
+            }
+
+            return {shape_a_aligned, shape_b_aligned};
+        };
+
+        /*
+         *  create_transpose function return Transpose operation to replace transpose_a or transpose_b
+         *  arguments with an operation. In other words in this function we create Transpose operation
+         *  with order length equal to output_shape length of given node and fill order with increasing
+         *  sequence starting from 0 and replace last two dimension. For example for length = 4  the
+         *  order will be [0, 1, 3, 2] that emulates transpose_a or transpose_b attribute.
+         */
+
+        auto create_transpose = [this](ngraph::Output<ngraph::Node> node, const std::string& transpose_name) -> std::shared_ptr<ngraph::Node> {
+            ngraph::Shape output_shape = node.get_node_shared_ptr()->get_shape();
+
+            std::vector<size_t> transpose_order(output_shape.size());
+            std::iota(transpose_order.begin(), transpose_order.end(), 0);
+            std::swap(*(transpose_order.end() - 1), *(transpose_order.end() - 2));
+
+            auto transpose = register_new_node<ngraph::opset1::Transpose>(
+                    node, ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape {transpose_order.size()}, transpose_order));
+            transpose->set_friendly_name(transpose_name);
+            return transpose;
+        };
+
+        // fc_input_a and fc_input_b - are the final inputs that will be set to FullyConnected of GemmIE operations.
+        // So in case of adding new operations that takes matmul inputs we need keep update fc_input_a and
+        // fc_input_b updated.
+        auto fc_input_a = input_a, fc_input_b = input_b;
+
+        // vector of new nGraph operations
+        ngraph::NodeVector new_ops;
+
+        // Check that if second inputs is Constant operation and it's shape without ones dimensions has length <= 2
+        // we replace MatMul with FullyConnected operation.
+        // Otherwise we replace MatMul with Gemm.
+        if ((std::dynamic_pointer_cast<ngraph::opset1::Constant>    (fc_input_b.get_node_shared_ptr())  ||
+             std::dynamic_pointer_cast<ngraph::opset1::FakeQuantize>(fc_input_b.get_node_shared_ptr())) &&
+            std::count_if(shape_b.begin(), shape_b.end(), [](size_t x) {
+                return x != 1;
+            }) <= 2) {
+            ngraph::Shape shape_a_aligned, shape_b_aligned;
+            std::tie(shape_a_aligned, shape_b_aligned) = get_aligned_shapes();
+
+            if (shape_a_aligned.size() < 2 || shape_b_aligned.size() < 2) {
+                throw ngraph::ngraph_error("MatMul " + matmul->get_friendly_name() + " shapes are inconsistent.");
+            }
+
+            // Transferring from MatMul representation: [B, I, K] * [B, K, O] = [B, I, O]
+            // to FullyConnected representation: [I, K] * [O, K] = [I, O]
+            size_t K = *(shape_a_aligned.end() - 1);
+            size_t O = *(shape_b_aligned.end() - 1);
+            ngraph::Shape B(shape_a_aligned.begin(), shape_a_aligned.end() - 2);
+
+            // Weights normalization
+            if (!matmul->get_transpose_b()) {
+                fc_input_b = create_transpose(fc_input_b, matmul->get_friendly_name() + "/transpose_b");
+                new_ops.push_back(fc_input_b.get_node_shared_ptr());
+            }
+
+            if (shape_b.size() != 2) {
+                auto reshape_shape =
+                        ngraph::opset1::Constant::create<int64_t>(ngraph::element::i64, ngraph::Shape {2}, {-1ll, static_cast<int64_t>(K)});
+                fc_input_b = std::make_shared<ngraph::opset1::Reshape>(fc_input_b, reshape_shape, true);
+                new_ops.push_back(fc_input_b.get_node_shared_ptr());
+            }
+
+            // Input normalization
+            if (matmul->get_transpose_a() && shape_a.size() != 1) {
+                fc_input_a = create_transpose(fc_input_a, matmul->get_friendly_name() + "/transpose_a");
+                new_ops.push_back(fc_input_a.get_node_shared_ptr());
+            }
+
+            // Create FullyConnected
+            std::vector<float> bias_value(O, 0);
+            auto fc_bias = ngraph::opset1::Constant::create(matmul->get_output_element_type(0), ngraph::Shape {O}, bias_value);
+
+            auto fc = std::make_shared<ngraph::vpu::op::FullyConnected>(fc_input_a, fc_input_b, fc_bias, output_shape, matmul->output(0).get_element_type());
+            fc->set_friendly_name(matmul->get_friendly_name());
+            new_ops.push_back(fc);
+
+            ngraph::copy_runtime_info(matmul, new_ops);
+            ngraph::replace_node(matmul, fc);
+            return true;
+        }
+        return false;
+    };
+
+    auto m = std::make_shared<ngraph::pattern::Matcher>(matmul, "ConvertMatMulToFC");
+    this->register_matcher(m, callback);
+}
+}  // namespace vpu

--- a/inference-engine/src/vpu/common/src/utils/ie_helpers.cpp
+++ b/inference-engine/src/vpu/common/src/utils/ie_helpers.cpp
@@ -165,13 +165,13 @@ void printTo(DotLabel& lbl, const ie::Blob::Ptr& ieBlob) {
     }
 }
 
-void printTo(DotLabel& lbl, const ie::CNNLayerPtr& ieLayer) {
-    VPU_INTERNAL_CHECK(ieLayer != nullptr, "NULL pointer");
+void printTo(DotLabel& lbl, const NodePtr& node) {
+    VPU_INTERNAL_CHECK(node != nullptr, "NULL pointer");
 
     DotLabel subLbl(lbl);
-    subLbl.appendPair("name", ieLayer->name);
-    subLbl.appendPair("type", ieLayer->type);
-    subLbl.appendPair("precision", ieLayer->precision.name());
+    subLbl.appendPair("name", node->get_friendly_name());
+    subLbl.appendPair("type", node->get_type_name());
+    subLbl.appendPair("precision", node->get_element_type());
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/include/vpu/backend/backend.hpp
+++ b/inference-engine/src/vpu/graph_transformer/include/vpu/backend/backend.hpp
@@ -26,7 +26,7 @@ public:
 
     CompiledGraph::Ptr build(
             const Model& model,
-            const std::vector<ie::CNNLayerPtr>& allLayers);
+            const ngraph::NodeVector& allNodes);
 
     void dumpModel(
             const Model& model,
@@ -58,7 +58,7 @@ private:
 
     void getMetaData(
             const Model& model,
-            const std::vector<ie::CNNLayerPtr>& allLayers,
+            const ngraph::NodeVector& allNodes,
             GraphMetaInfo& graphMetaData);
 
     void extractDataInfo(

--- a/inference-engine/src/vpu/graph_transformer/include/vpu/frontend/frontend.hpp
+++ b/inference-engine/src/vpu/graph_transformer/include/vpu/frontend/frontend.hpp
@@ -13,17 +13,62 @@
 #include <set>
 
 #include <ie_icore.hpp>
+#include <caseless.hpp>
 #include <cpp/ie_cnn_network.h>
 
 #include <vpu/stage_builder.hpp>
 #include <vpu/frontend/ie_parsed_network.hpp>
-#include <vpu/frontend/custom_layer.hpp>
 #include <vpu/model/model.hpp>
 #include <vpu/utils/enums.hpp>
 #include <vpu/utils/func_ref.hpp>
 
+#include <ngraph/opsets/opset1.hpp>
+#include <ngraph/opsets/opset3.hpp>
+#include <ngraph/opsets/opset4.hpp>
+#include <ngraph/opsets/opset5.hpp>
+#include <ngraph/opsets/opset6.hpp>
+#include <ngraph/util.hpp>
+#include "transformations/utils/utils.hpp"
 namespace vpu {
+enum EltwiseOperation {
+    Sub = 0,
+    Sum,          
+    Prod,         
+    Max,          
+    Div,          
+    Min,          
+    Squared_diff, 
+    Equal,        
+    Not_equal,    
+    Greater,      
+    Greater_equal,
+    Less,         
+    Less_equal,   
+    Logical_NOT,  
+    Logical_AND,  
+    Logical_OR,   
+    Logical_XOR,  
+    Pow,          
+    Floor_mod,    
+};
+enum PoolNDMethod   { PoolND_max = 1, PoolND_avg = 2 };
 
+enum PoolNDRounding { PoolND_floor = 3, PoolND_ceil  = 4 };
+
+enum PoolMethod   { Pool_max = 1, Pool_avg = 2 };
+struct PoolingParams {
+    std::vector<size_t> kernel;
+    std::vector<size_t> strides;
+    std::vector<size_t> padsBegin;
+    std::vector<size_t> padsEnd;
+    std::string autoPad;
+    bool excludePad;
+    PoolMethod poolMethod;
+
+};
+
+using OutNode = ngraph::Output<ngraph::Node>;
+using NodePtr = std::shared_ptr<ngraph::Node>;
 namespace ie = InferenceEngine;
 
 class FrontEnd final {
@@ -36,9 +81,9 @@ public:
 
     std::set<std::string> checkSupportedLayers(const ie::CNNNetwork& network);
 
-    const std::vector<ie::CNNLayerPtr>& origLayers() const {
-        return _ieParsedNetwork.orderedLayers;
-    }
+    const ngraph::NodeVector& origNodes() const {
+        return _ieParsedNetwork.orderedOps;
+    } 
 
 //
 // Passes
@@ -47,10 +92,10 @@ public:
 private:
     ModelPtr runCommonPasses(const ie::CNNNetwork& network);
 
-    using SupportedLayerCallback = std::function<void(const ie::CNNLayerPtr&)>;
-    using UnsupportedLayerCallback = std::function<void(const Model&, const ie::CNNLayerPtr&, const DataVector&, const DataVector&, const std::string&)>;
-    ModelPtr runCommonPasses(ie::CNNNetwork network, const UnsupportedLayerCallback& unsupportedLayer,
-                             const SupportedLayerCallback& supportedLayer = nullptr);
+    using SupportedNodeCallback = std::function<void(const NodePtr&)>;
+    using UnsupportedNodeCallback = std::function<void(const Model&, const NodePtr&, const DataVector&, const DataVector&, const std::string&)>;
+    ModelPtr runCommonPasses(ie::CNNNetwork network, const UnsupportedNodeCallback& unsupportedLayer,
+                             const SupportedNodeCallback& supportedLayer = nullptr);
 
     //
     // Update IE Network
@@ -85,130 +130,160 @@ public:
     // Layers that might be both SW and HW
     //
 
-    void parseConvolution(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parsePooling(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseFullyConnected(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
+    void parseConvolution(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const; // 2d conv: ok, nd conv should be reworked
+    void parseGroupConvolution(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const; // 1d and 3d cases works bad
+    void parseAvgPooling(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const; // ok  ok
+    void parseMaxPooling(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const; // ok  ok
+    void parseFullyConnected(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const; // looks ok. 
 
     //
     // SW only layers
     //
 
-    void parseReLU(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseSoftMax(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseGRN(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseMVN(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseNorm(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parsePower(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseScale(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parsePermute(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseDetectionOutput(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseEltwise(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseSigmoid(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseTanH(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parsePReLU(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseBatchNorm(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseDeconvolution(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseCopy(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseELU(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseCrop(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseTile(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseNormalize(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseRegionYolo(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseReorgYolo(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseBias(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseCTCDecoder(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseInterp(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseClamp(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseProposal(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseROIPooling(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parsePSROIPooling(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseMTCNN(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parsePad(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseResample(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseInterpolate(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseRNN(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseGEMM(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseLog(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseExp(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseReverseSequence(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseGather(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseReduce(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseFloor(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseTopK(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseSelect(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseExpDetectionOutput(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseROIFeatureExtractor(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseConvert(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseErf(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseOneHot(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseExpPriorGridGenerator(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseExpGenerateProposals(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseScatterUpdate(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseScatterElementsUpdate(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseExpTopKROIs(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseNonZero(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseROIAlign(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseOutShapeOfReshape(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseBroadcast(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseStaticShapeNMS(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseMish(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseGelu(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseSoftPlus(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseSwish(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseActivation(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseLogicalNot(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseGatherND(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseHSwish(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseCeiling(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseRound(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseCTCGreedyDecoderSeqLen(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
+    void parseReLU(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok test -
+    void parseSoftMax(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok test +-?
+    void parseGRN(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok ok
+    void parseMVN(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok ok
+    void parseNorm(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok test
+    void parsePower(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const; // doesn't work correctly
+    void parseSqrt(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const; // ok, test is not created 
+    void parseScale(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const; // convert_mul_add_to_scaleshift_or_power.cpp ?? 
+    void parsePermute(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;   // ok, test is not created 
+    void parseDetectionOutput(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const; // ok; tests problems:  batch, decreaseLabelId, shareLocation
+    // void parseEltwise(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;
+    void parseSubtract(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok ok
+    void parseAdd(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok ok
+    void parseMultiply(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok ok
+    void parseMaximum(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok ok
+    void parseDivide(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok ok
+    void parseMinimum(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok ok
+    void parseSquaredDifference(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok ok
+    void parseEqual(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok ok
+    void parseNotEqual(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok ok
+    void parseGreater(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok ok
+    void parseGreaterEqual(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok ok
+    void parseLess(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok ok
+    void parseLessEqual(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok ok
+    void parseLogicalNot(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok ok
+    void parseLogicalAnd(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok ok
+    void parseLogicalOr(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok ok
+    void parseLogicalXor(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok ok
+    void parseFloorMod(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok ok
+
+    void parseSigmoid(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok, test is not created 
+    void parseTanH(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok, test is not created
+    void parsePReLU(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok, test is not created
+    // void parseBatchNorm(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok?
+    void parseDeconvolution(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok
+    // void parseCopy(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // lgtm
+    void parseELU(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const; // lgtm
+    void parseCrop(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const; // strided slice? 
+    void parseTile(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok 
+    void parseNormalize(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const; // ok
+    void parseRegionYolo(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // lgtm
+    void parseReorgYolo(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // not sure
+    // void parseBias(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // not sure
+    void parseCTCDecoder(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // lgtm
+    // void parseInterp(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // need to add fnct ngraph::interp::mode->vpu::mode
+    void parseClamp(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // lgtm
+    void parseProposal(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  //  not sure
+    void parseROIPooling(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok; ok
+    void parsePSROIPooling(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // lgtm
+    // void parseMTCNN(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // need to remove?
+    void parsePad(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  //  ok, test ok
+    // void parseResample(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // 
+    void parseInterpolate(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok; ok 
+    void parseRNN(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok; ok;
+    void parseGEMM(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok; ok
+    void parseLog(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // not sure
+    void parseExp(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // not sure
+    void parseReverseSequence(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // lgtm
+    void parseGather(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // not sure
+    void parseReduceAnd(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;
+    void parseReduceMin(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;
+    void parseReduceMax(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;
+    void parseReduceSum(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;
+    void parseReduceMean(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;
+    void parseFloor(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // lgtm
+    void parseTopK(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok, ok
+    void parseSelect(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // lgtm
+    void parseExpDetectionOutput(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // lgtm
+    void parseROIFeatureExtractor(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok
+    void parseConvert(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // lgtm
+    void parseErf(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // lgtm
+    void parseOneHot(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok
+    void parseExpPriorGridGenerator(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const; // lgtm
+    void parseExpGenerateProposals(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const; // lgtm
+    void parseScatterUpdate(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // lgtm
+    void parseScatterElementsUpdate(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const; // lgtm
+    void parseExpTopKROIs(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // lgtm
+    void parseNonZero(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ????
+    void parseROIAlign(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // lgtm
+    void parseOutShapeOfReshape(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // lgtm
+    void parseBroadcast(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // lgtm
+    void parseStaticShapeNMS(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // need to rework layer??
+    void parseMish(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // lgtm
+    void parseGelu(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // lgtm
+    void parseSoftPlus(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // lgtm
+    void parseSwish(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  //  ok
+    // void parseActivation(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // need to investigate
+    // void parseLogicalNot(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // need to investigate
+    void parseGatherND(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // lgtm
+    void parseHSwish(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // lgtm
+    void parseCeiling(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // lgtm
+    void parseRound(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // lgtm
+    void parseCTCGreedyDecoderSeqLen(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok ok
 
     //
     // Special layers
     //
 
-    void parsePriorBox(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parsePriorBoxClustered(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseReshape(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseConcat(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseSplit(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseStridedSlice(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const;
-    void parseDSR(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs);
-    void parseGatherElements(const Model &model, const ie::CNNLayerPtr &layer, const DataVector &inputs, const DataVector &outputs) const;
+    void parsePriorBox(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // lgtm
+    void parsePriorBoxClustered(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // lgtm
+    void parseReshape(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // lgtm
+    void parseConcat(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok, ok
+    void parseSplit(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok+- ok
+    void parseStridedSlice(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const;  // ok; ok
+    void parseDSR(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs);  // lgtm
+    void parseGatherElements(const Model &model, const NodePtr& node, const DataVector &inputs, const DataVector &outputs) const;  // ok ok
 
     //
     // Parser with data sharing
     //
 
-    void parseCustom(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs);
-    void parseLSTMCell(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs);
-    void parseTensorIterator(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs);
+    // void parseCustom(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs); // ???
+    void parseLSTMCell(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs);  // ok
+    // void parseTensorIterator(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs);  // ???
 
     //
     // Utility
     //
-
-    static CustomLayer::Ptr getSuitableCustomLayer(const std::vector<CustomLayer::Ptr>& customLayers, const ie::CNNLayerPtr&cnnLayer);
+    
+    // static CustomLayer::Ptr getSuitableCustomLayer(const std::vector<CustomLayer::Ptr>& customLayers, const NodePtr&cnnLayer);
+    void parsePoolingImpl(const Model& model, const NodePtr& node,const DataVector & inputs, const DataVector& outputs, const PoolingParams & params) const;
+    void parseEltwiseImpl(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs, const EltwiseOperation eltwiseOperation) const;
+    void parseReduceImpl(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs, vpu::StageType reduceType, bool keepDims) const;  // not sure
     static ie::CNNNetwork convertNetwork(ie::CNNNetwork& network);
 
 private:
-    Data getVpuData(const ie::DataPtr& ieData) const;
-    void bindData(const Data& data, const ie::DataPtr& ieData);
+    Data getVpuData(const OutNode& ieData) const;
+    void bindData(const Data& data, const OutNode& nodeOutput, NodePtr origNode);
 
     void getInputAndOutputData(
             const Model& model,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             DataVector& inputs,
             DataVector& outputs);
 
-    std::tuple<Data, Data> getWeightsAndBiases(const Model& model, const ie::CNNLayerPtr& layer) const;
+    static ie::Blob::Ptr shareWeights(const NodePtr& constLayer);
+    std::tuple<Data, Data> getWeightsAndBiases(const Model& model, const std::string nodeName, const NodePtr& weightsNode, const NodePtr& biasesNode) const;
 
-    void defaultOnUnsupportedLayerCallback(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs,
+    void defaultOnUnsupportedLayerCallback(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs,
                                            const std::string& extraMessage);
 
-    void parseLayer(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs);
-    void parseLayer(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs,
-                    const UnsupportedLayerCallback& onUnsupported, const SupportedLayerCallback& onSupported = nullptr);
+    void parseLayer(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs);
+    void parseLayer(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs,
+                    const UnsupportedNodeCallback& onUnsupported, const SupportedNodeCallback& onSupported = nullptr);
 
     void processTrivialCases(const Model& model);
 
@@ -218,16 +293,16 @@ private:
 
     IeParsedNetwork _ieParsedNetwork;
     std::unordered_set<ie::DataPtr> _unbatchedOutputs;
-    ie::details::caseless_map<std::string, std::vector<CustomLayer::Ptr>> _customLayers;
+    // ie::details::caseless_map<std::string, std::vector<CustomLayer::Ptr>> _customLayers;
 
 #define LAYER_PARSER(functor_name)                                                                                \
-    [this](const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) \
-        { functor_name(model, layer, inputs, outputs); }
+    [this](const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) \
+        { functor_name(model, node, inputs, outputs); }
 
-    using LayerParser = std::function<void(const Model&, const ie::CNNLayerPtr&, const DataVector&, const DataVector&)>;
+    using LayerParser = std::function<void(const Model&, const NodePtr&, const DataVector&, const DataVector&)>;
     const ie::details::caseless_map<std::string, LayerParser> parsers;
 
-    std::unordered_map<ie::DataPtr, Data> _ieToVpuMap;
+    std::map<OutNode, Data> _ieToVpuMap;
     ie::details::caseless_map<std::string, Data> _kernelNodes;
     std::unordered_map<ie::Blob::Ptr, Data> _lstmWeights;
     std::unordered_map<ie::Blob::Ptr, Data> _lstmBiases;

--- a/inference-engine/src/vpu/graph_transformer/include/vpu/frontend/ie_parsed_network.hpp
+++ b/inference-engine/src/vpu/graph_transformer/include/vpu/frontend/ie_parsed_network.hpp
@@ -6,19 +6,27 @@
 
 #include <vector>
 #include <unordered_map>
-
 #include <legacy/ie_layers.h>
 #include <cpp/ie_cnn_network.h>
+#include <ngraph/node_output.hpp>
+#include <ngraph/output_vector.hpp>
 
 namespace vpu {
-
+using OutNode = ngraph::Output<ngraph::Node>;
+using NodePtr = std::shared_ptr<ngraph::Node>;
 namespace ie = InferenceEngine;
 
 struct IeParsedNetwork final {
     ie::InputsDataMap networkInputs;
     ie::OutputsDataMap networkOutputs;
-    std::vector<std::pair<ie::DataPtr, ie::Blob::Ptr>> constDatas;
-    std::vector<ie::CNNLayerPtr> orderedLayers;
+
+    // Nodes that shouldn't be executed
+    ngraph::NodeVector networkParameters;
+    ngraph::NodeVector networkConstants;
+    ngraph::NodeVector networkResults;
+
+    // Nodes that should be executed
+    ngraph::NodeVector orderedOps;
 };
 
 IeParsedNetwork parseNetwork(const ie::CNNNetwork& network);

--- a/inference-engine/src/vpu/graph_transformer/include/vpu/model/data.hpp
+++ b/inference-engine/src/vpu/graph_transformer/include/vpu/model/data.hpp
@@ -11,7 +11,7 @@
 #include <vpu/backend/blob_serializer.hpp>
 #include <vpu/utils/enums.hpp>
 #include <vpu/utils/func_ref.hpp>
-
+#include <ngraph/node_output.hpp>
 #include <ie_data.h>
 #include <ie_blob.h>
 
@@ -21,7 +21,8 @@
 #include <vector>
 
 namespace vpu {
-
+using OutNode = ngraph::Output<ngraph::Node>;
+using NodePtr = std::shared_ptr<ngraph::Node>;
 namespace ie = InferenceEngine;
 
 //
@@ -117,8 +118,8 @@ class DataNode final :
     // Bindings with IE
     //
 
-    VPU_MODEL_ATTRIBUTE(ie::DataPtr, origData, nullptr)
-
+    VPU_MODEL_ATTRIBUTE(NodePtr, origNode, nullptr)
+    VPU_MODEL_ATTRIBUTE(OutNode, origOutput, OutNode())
     //
     // Edges
     //
@@ -232,7 +233,8 @@ public:
     // Bindings with IE
     //
 
-    inline void setOrigData(const ie::DataPtr& origData) { _origData = origData; }
+    inline void setOrigNode(const NodePtr& origNode) { _origNode = origNode; }
+    inline void setOrigOutput(const OutNode& origOutput) { _origOutput = origOutput; }
 
     //
     // StridesRequirement

--- a/inference-engine/src/vpu/graph_transformer/include/vpu/model/data_contents/priorbox_contents.hpp
+++ b/inference-engine/src/vpu/graph_transformer/include/vpu/model/data_contents/priorbox_contents.hpp
@@ -5,8 +5,9 @@
 #pragma once
 
 #include <legacy/ie_layers.h>
+#include <vpu/frontend/frontend.hpp>
 #include <vpu/model/data_contents/calculated_data_content.hpp>
-
+#include <vpu/model/model.hpp>
 namespace vpu {
 
 //
@@ -19,7 +20,7 @@ public:
             const DataDesc& inDesc0,
             const DataDesc& inDesc1,
             const DataDesc& outDesc,
-            const ie::CNNLayerPtr &layer);
+            const NodePtr &node);
 
     size_t byteSize() const override;
 
@@ -30,7 +31,7 @@ private:
     DataDesc _inDesc0;
     DataDesc _inDesc1;
     DataDesc _outDesc;
-    ie::CNNLayerPtr _layer;
+    NodePtr _node;
 };
 
 //
@@ -43,7 +44,7 @@ public:
             const DataDesc& inDesc0,
             const DataDesc& inDesc1,
             const DataDesc& outDesc,
-            const ie::CNNLayerPtr& layer);
+            const NodePtr& node);
 
     size_t byteSize() const override;
 
@@ -54,7 +55,7 @@ private:
     DataDesc _inDesc0;
     DataDesc _inDesc1;
     DataDesc _outDesc;
-    ie::CNNLayerPtr _layer;
+    NodePtr _node;
 };
 
 } // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/include/vpu/model/data_desc.hpp
+++ b/inference-engine/src/vpu/graph_transformer/include/vpu/model/data_desc.hpp
@@ -15,7 +15,8 @@
 #include <utility>
 
 #include <ie_layouts.h>
-
+#include <ie_ngraph_utils.hpp>
+#include <ngraph/descriptor/tensor.hpp>
 #include <vpu/utils/enums.hpp>
 #include <vpu/utils/io.hpp>
 #include <vpu/utils/dot_io.hpp>
@@ -539,6 +540,7 @@ public:
     explicit DataDesc(const std::vector<IntValue>& dims) : DataDesc(DataType::FP16, DimsOrder::fromNumDims(dims.size()), dims) {}
 
     explicit DataDesc(const ie::TensorDesc& ieDesc);
+    explicit DataDesc(const ngraph::descriptor::Tensor& ngraphDesc);
 
     DataDesc(DataType type, DimsOrder dimsOrder, const DimValues& dims);
 

--- a/inference-engine/src/vpu/graph_transformer/include/vpu/model/model.hpp
+++ b/inference-engine/src/vpu/graph_transformer/include/vpu/model/model.hpp
@@ -18,10 +18,12 @@
 #include <vpu/utils/dot_io.hpp>
 #include <vpu/middleend/allocator/allocator.hpp>
 
+#include <ngraph/ops.hpp>
+#include <ngraph/node.hpp>
+
 #include <utility>
 
 namespace vpu {
-
 //
 // Resources
 //
@@ -114,7 +116,7 @@ public:
     Stage addNewStage(
             const std::string& name,
             StageType type,
-            const ie::CNNLayerPtr& origLayer,
+            const NodePtr& origNode,
             const DataVector& inputs,
             const DataVector& outputs);
 
@@ -333,7 +335,7 @@ private:
     Stage addNewStageImpl(
         const std::string& name,
         StageType type,
-        const ie::CNNLayerPtr& origLayer,
+        const NodePtr& origNode,
         const DataVector& inputs,
         const DataVector& outputs,
         const FuncRef<StagePtr()>& creator);
@@ -381,10 +383,10 @@ template <class StageImpl>
 inline Stage ModelObj::addNewStage(
         const std::string& name,
         StageType type,
-        const ie::CNNLayerPtr& origLayer,
+        const NodePtr& origNode,
         const DataVector& inputs,
         const DataVector& outputs) {
-    auto newStage = addNewStageImpl(name, type, origLayer, inputs, outputs, []() { return std::make_shared<StageImpl>(); });
+    auto newStage = addNewStageImpl(name, type, origNode, inputs, outputs, []() { return std::make_shared<StageImpl>(); });
     if (onNewStageCallback) {
         onNewStageCallback(newStage);
     }

--- a/inference-engine/src/vpu/graph_transformer/include/vpu/model/stage.hpp
+++ b/inference-engine/src/vpu/graph_transformer/include/vpu/model/stage.hpp
@@ -19,7 +19,7 @@
 #include <vpu/backend/blob_serializer.hpp>
 #include <vpu/utils/enums.hpp>
 #include <vpu/utils/optional.hpp>
-
+#include <ngraph/node.hpp>
 namespace vpu {
 
 //
@@ -400,9 +400,9 @@ class StageNode :
     // Bindings with IE
     //
 
-    IE_SUPPRESS_DEPRECATED_START
-    VPU_MODEL_ATTRIBUTE(ie::CNNLayerPtr, origLayer, nullptr)
-    IE_SUPPRESS_DEPRECATED_END
+
+    VPU_MODEL_ATTRIBUTE(NodePtr, origNode, nullptr)
+    VPU_MODEL_ATTRIBUTE(OutNode, origOutput, OutNode())
 
     //
     // Edges
@@ -574,10 +574,8 @@ public:
     // Bindings with IE
     //
 
-    inline std::string origLayerName() const {
-        IE_SUPPRESS_DEPRECATED_START
-        return _origLayer != nullptr ? _origLayer->name : std::string();
-        IE_SUPPRESS_DEPRECATED_END
+    std::string origLayerName() const {
+        return _origNode != nullptr ? _origNode->get_friendly_name() : std::string();
     }
 
     //

--- a/inference-engine/src/vpu/graph_transformer/include/vpu/stage_builder.hpp
+++ b/inference-engine/src/vpu/graph_transformer/include/vpu/stage_builder.hpp
@@ -14,8 +14,6 @@
 
 namespace vpu {
 
-IE_SUPPRESS_DEPRECATED_START
-
 class StageBuilder final {
 public:
     using Ptr = std::shared_ptr<StageBuilder>;
@@ -31,7 +29,7 @@ public:
     Stage addSumStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             const Data& input0,
             const Data& input1,
             const Data& output);
@@ -39,7 +37,7 @@ public:
     Stage addMaxStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             const Data& input0,
             const Data& input1,
             const Data& output);
@@ -47,7 +45,7 @@ public:
     Stage addBiasStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             const Data& input,
             const Data& biases,
             const Data& output);
@@ -55,7 +53,7 @@ public:
     Stage addScaleStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             const Data& input,
             const Data& scales,
             const Data& output);
@@ -63,7 +61,7 @@ public:
     Stage addCopyStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             const Data& input,
             const Data& output,
             const std::string& origin);
@@ -71,7 +69,7 @@ public:
     Stage addPadStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             PadMode padMode,
             float pad_value,
             const DimValues& pads_begin,
@@ -82,14 +80,14 @@ public:
     Stage addNoneStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             const DataVector& inputs,
             const DataVector& outputs);
 
     Stage addPowerStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             float scale,
             float power,
             float bias,
@@ -99,7 +97,7 @@ public:
     Stage addReLUStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             float negativeSlope,
             const Data& input,
             const Data& output,
@@ -108,14 +106,14 @@ public:
     Stage addReshapeStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             const Data& input,
             const Data& output);
 
     Stage addConcatStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             Dim axis,
             const DataVector& inputs,
             const Data& output,
@@ -124,7 +122,7 @@ public:
     Stage addConcatStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             std::vector<DimValues>&& offsets,
             const DataVector& inputs,
             const Data& output);
@@ -132,7 +130,7 @@ public:
     Stage addSplitStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             Dim axis,
             const Data& input,
             const DataVector& outputs);
@@ -140,14 +138,14 @@ public:
     Stage addSplitStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             std::vector<DimValues>&& offsets,
             const Data& input,
             const DataVector& outputs);
 
     Stage addScalingStage(
             const Model& model,
-            const ie::CNNLayerPtr& origLayer,
+            const NodePtr& node,
             float scale,
             const Data& input,
             const Data& output);
@@ -155,7 +153,7 @@ public:
     Stage addSwFullyConnectedStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             const Data& input,
             const Data& weights,
             const Data& biases,
@@ -165,7 +163,7 @@ public:
     Stage addExpandStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             const Data& input,
             const Data& output,
             const DimValues& offset = DimValues());
@@ -173,7 +171,7 @@ public:
     Stage addCropStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             const Data& input,
             const Data& output,
             const DimValues& offset = DimValues());
@@ -181,7 +179,7 @@ public:
     Stage addSoftMaxStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             const Data& input,
             const Data& output,
             Dim axis);
@@ -189,7 +187,7 @@ public:
     Stage addClampStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             float min,
             float max,
             const Data& input,
@@ -198,7 +196,7 @@ public:
     Stage addGemmStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             float alpha,
             float beta,
             bool transposeA,
@@ -209,7 +207,7 @@ public:
     Stage addPoolingStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             const Data& input,
             const Data& output,
             const ie::PoolingLayer::PoolType& poolType);
@@ -217,7 +215,7 @@ public:
     Stage addGatherStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             const Data& input0,
             const Data& input1,
             const Data& output,
@@ -226,7 +224,7 @@ public:
     Stage addPermuteStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             const Data& input,
             const Data& output,
             const DimValues_<Dim>& permutation);
@@ -234,7 +232,7 @@ public:
     Stage addSCReluStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             float negativeSlope,
             Dim axis,
             const Data& input,
@@ -245,14 +243,14 @@ public:
     Stage addReorderStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             const Data& input,
             const Data& output);
 
     Stage addConvolutionStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             const Data& input,
             const Data& output,
             const Data& weights,
@@ -263,7 +261,7 @@ public:
             const Model& model,
             const std::string& name,
             StageType reduceType,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             bool keep_dims,
             const DataVector& inputs,
             const Data& output);
@@ -271,7 +269,7 @@ public:
     Stage addScatterUpdateStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             const Data& input,
             const Data& output,
             const Data& indices,
@@ -281,7 +279,7 @@ public:
     Stage addScatterElementsUpdateStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             const Data& input,
             const Data& output,
             const Data& indices,
@@ -303,14 +301,14 @@ public:
     Stage addSigmoidStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             const DataVector& inputs,
             const DataVector& outputs);
 
     Stage addProdStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             const Data& input0,
             const Data& input1,
             const Data& output);
@@ -318,7 +316,7 @@ public:
     Stage addGatherNDStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             const Data& input,
             const Data& indices,
             const Data& output,
@@ -327,7 +325,7 @@ public:
     Stage addInterpStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             bool align_corners,
             InterpolateMode mode,
             InterpolateCoordTransMode coordinateTransformationMode,
@@ -337,7 +335,7 @@ public:
     Stage addResampleNearestStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             bool antialias,
             InterpolateCoordTransMode coordinateTransformationMode,
             InterpolateNearestMode nearestMode,
@@ -345,22 +343,20 @@ public:
             const Data& input,
             const Data& output);
 
-    Stage addGatherElementsStage(const Model &model,
-                                 const std::string &name,
-                                 const ie::CNNLayerPtr &layer,
-                                 const DataVector &inputs,
-                                 const Data &output, int32_t axis,
+    Stage addGatherElementsStage(const Model& model,
+                                 const std::string& name,
+                                 const NodePtr& node,
+                                 const DataVector& inputs,
+                                 const Data& output, int32_t axis,
                                  bool rowIndicesMode);
 
     Stage addCTCGreedyDecoderSeqLenStage(const Model& model,
                                          const std::string& name,
-                                         const ie::CNNLayerPtr& layer,
+                                         const NodePtr& node,
                                          const DataVector& inputs,
                                          const DataVector& outputs,
                                          bool mergeRepeated,
                                          int32_t blankIndex);
 };
-
-IE_SUPPRESS_DEPRECATED_END
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/backend/backend.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/backend/backend.cpp
@@ -43,7 +43,7 @@ void BackEnd::extractDataInfo(
 
 CompiledGraph::Ptr BackEnd::build(
         const Model& model,
-        const std::vector<ie::CNNLayerPtr>& allLayers) {
+        const ngraph::NodeVector& allLayers) {
     auto compiledGraph = std::make_shared<CompiledGraph>();
 
     compiledGraph->networkName = model->name();

--- a/inference-engine/src/vpu/graph_transformer/src/backend/dump_to_dot.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/backend/dump_to_dot.cpp
@@ -73,8 +73,8 @@ void dumpStageToDot(DotSerializer& out, const Stage& stage, int stageExecIdx) {
 
         DotLabel lbl(caption.str(), out);
         lbl.appendPair("type", stage->type());
-        if (stage->origLayer() != nullptr) {
-            lbl.appendPair("origLayer", stage->origLayer());
+        if (stage->origNode() != nullptr) {
+            lbl.appendPair("origLayer", stage->origNode());
         }
         lbl.appendPair("numSHAVEs", stage->numSHAVEs());
         if (!stage->attrs().empty()) {
@@ -154,8 +154,8 @@ void BackEnd::dumpModelToDot(
                 lbl.appendPair("desc", data->desc());
                 lbl.appendPair("requiredStrides", data->requiredStrides());
                 lbl.appendPair("strides", data->strides());
-                if (data->origData() != nullptr) {
-                    lbl.appendPair("origData", data->origData());
+                if (data->origNode() != nullptr) {
+                    lbl.appendPair("origNode", data->origNode());
                 }
                 if (data->content() != nullptr) {
                     if (data->desc().type() == DataType::U8) {

--- a/inference-engine/src/vpu/graph_transformer/src/frontend/detect_network_batch.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/frontend/detect_network_batch.cpp
@@ -73,7 +73,6 @@ void FrontEnd::detectNetworkBatch(
             }
         }
     }
-
     if (inputBatch == 1) {
         env.log->trace("Network is batch 1. Not need to reshape");
         return;
@@ -83,7 +82,6 @@ void FrontEnd::detectNetworkBatch(
         env.log->trace("Unable to decide on network batch size.");
         return;
     }
-
     ShapesMap inputShapes;
 
     for (const auto& inputInfo : inputsInfo) {
@@ -108,10 +106,10 @@ void FrontEnd::detectNetworkBatch(
     for (const auto& op : operations) {
         if (!ngraph::as_type_ptr<ngraph::op::DetectionOutput>(op))
             continue;
-        env.log->trace("Found DetectionOutput layer [%s]", op->get_name());
+        env.log->trace("Found DetectionOutput layer [%s]", op->get_friendly_name());
 
         VPU_THROW_UNLESS(op->get_output_size() == 1, "Layer {} with type {} must have only 1 output but {} provided",
-                         op->get_name(), op->get_type_name(), op->get_output_size());
+                         op->get_friendly_name(), op->get_type_name(), op->get_output_size());
         model->attrs().set<bool>("withDetectionOutput", true);
     }
 
@@ -154,7 +152,6 @@ void FrontEnd::detectNetworkBatch(
 
         const auto origShape = outputShapes[p.first];
         const auto newShape = ieData->getDims();
-
         if (origShape == newShape) {
             env.log->trace("Output [%s] is unbatched", p.first);
 

--- a/inference-engine/src/vpu/graph_transformer/src/frontend/frontend.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/frontend/frontend.cpp
@@ -21,9 +21,6 @@
 
 #include <legacy/convert_function_to_cnn_network.hpp>
 #include <ngraph/pass/manager.hpp>
-#include <ngraph/opsets/opset3.hpp>
-#include <ngraph/opsets/opset4.hpp>
-#include <ngraph/opsets/opset5.hpp>
 #include <ngraph/pass/constant_folding.hpp>
 #include <transformations/opset_conversions/convert_opset3_to_opset2.hpp>
 #include <transformations/opset_conversions/convert_opset2_to_opset1.hpp>
@@ -42,6 +39,7 @@
 #include <vpu/ngraph/transformations/merge_subsequent_dsr_operations.hpp>
 #include "vpu/ngraph/transformations/dynamic_to_static_shape.hpp"
 #include "vpu/ngraph/transformations/eliminate_shapeof_after_dsr.hpp"
+#include "vpu/ngraph/transformations/convert_matmul_to_fc.hpp"
 #include <vpu/ngraph/operations/dynamic_shape_resolver.hpp>
 #include <vpu/ngraph/utilities.hpp>
 #include <legacy/ie_util_internal.hpp>
@@ -51,46 +49,69 @@
 #include <vpu/ngraph/transformations/extract_dynamic_batch/extract_dynamic_batch.hpp>
 #include <vpu/ngraph/transformations/merge_gather_gather_elements.hpp>
 #include <transformations/op_conversions/mvn6_decomposition.hpp>
+/// debug
+#include <ngraph/pass/visualize_tree.hpp>
 namespace vpu {
 FrontEnd::FrontEnd(StageBuilder::Ptr stageBuilder, const ie::ICore* core)
     : _stageBuilder(std::move(stageBuilder)),
     _core(core),
     parsers{{
         {"Convolution",                                        LAYER_PARSER(parseConvolution)},
-        {"Pooling",                                            LAYER_PARSER(parsePooling)},
+        {"GroupConvolution",                                   LAYER_PARSER(parseGroupConvolution)},
+        {"AvgPool",                                            LAYER_PARSER(parseAvgPooling)},
+        {"MaxPool",                                            LAYER_PARSER(parseMaxPooling)},
         {"ReLU",                                               LAYER_PARSER(parseReLU)},
         {"Clamp",                                              LAYER_PARSER(parseClamp)},
         {"FullyConnected",                                     LAYER_PARSER(parseFullyConnected)},
         {"SoftMax",                                            LAYER_PARSER(parseSoftMax)},
         {"GRN",                                                LAYER_PARSER(parseGRN)},
         {"MVN",                                                LAYER_PARSER(parseMVN)},
-        {"Norm",                                               LAYER_PARSER(parseNorm)},
+        {"LRN",                                                LAYER_PARSER(parseNorm)},
         {"Concat",                                             LAYER_PARSER(parseConcat)},
-        {"Eltwise",                                            LAYER_PARSER(parseEltwise)},
+        // {"Eltwise",                                            LAYER_PARSER(parseEltwise)},
+        {"Subtract",                                           LAYER_PARSER(parseSubtract)},
+        {"Add",                                                LAYER_PARSER(parseAdd)},
+        {"Multiply",                                           LAYER_PARSER(parseMultiply)},
+        {"Maximum",                                            LAYER_PARSER(parseMaximum)},
+        {"Divide",                                             LAYER_PARSER(parseDivide)},
+        {"Minimum",                                            LAYER_PARSER(parseMinimum)},
+        {"SquaredDifference",                                  LAYER_PARSER(parseSquaredDifference)},
+        {"Equal",                                              LAYER_PARSER(parseEqual)},
+        {"NotEqual",                                           LAYER_PARSER(parseNotEqual)},
+        {"Greater",                                            LAYER_PARSER(parseGreater)},
+        {"GreaterEqual",                                       LAYER_PARSER(parseGreaterEqual)},
+        {"Less",                                               LAYER_PARSER(parseLess)},
+        {"LessEqual",                                          LAYER_PARSER(parseLessEqual)},
+        {"LogicalNot",                                         LAYER_PARSER(parseLogicalNot)},
+        {"LogicalAnd",                                         LAYER_PARSER(parseLogicalAnd)},
+        {"LogicalOr",                                          LAYER_PARSER(parseLogicalOr)},
+        {"LogicalXor",                                         LAYER_PARSER(parseLogicalXor)},
+        {"FloorMod",                                           LAYER_PARSER(parseFloorMod)},
         // Slice is represented as Split in VPU model
         {"Split",                                              LAYER_PARSER(parseSplit)},
         {"Slice",                                              LAYER_PARSER(parseSplit)},
         {"Sigmoid",                                            LAYER_PARSER(parseSigmoid)},
         {"TanH",                                               LAYER_PARSER(parseTanH)},
         {"PReLU",                                              LAYER_PARSER(parsePReLU)},
-        {"Bias",                                               LAYER_PARSER(parseBias)},
-        {"BatchNormalization",                                 LAYER_PARSER(parseBatchNorm)},
-        {"ScaleShift",                                         LAYER_PARSER(parseScale)},
+        // {"Bias",                                               LAYER_PARSER(parseBias)},
+        // {"BatchNormalization",                                 LAYER_PARSER(parseBatchNorm)},
+        // {"ScaleShift",                                         LAYER_PARSER(parseScale)},
         {"Deconvolution",                                      LAYER_PARSER(parseDeconvolution)},
         {"Power",                                              LAYER_PARSER(parsePower)},
-        {"Copy",                                               LAYER_PARSER(parseCopy)},
+        {"Sqrt",                                               LAYER_PARSER(parseSqrt)},
+        // {"Copy",                                               LAYER_PARSER(parseCopy)},
         {"ELU",                                                LAYER_PARSER(parseELU)},
         // Flatten, Squeeze and Unsqueeze are represented as Reshape in VPU model
         {"Reshape",                                            LAYER_PARSER(parseReshape)},
-        {"Flatten",                                            LAYER_PARSER(parseReshape)},
+        // {"Flatten",                                            LAYER_PARSER(parseReshape)},
         {"Squeeze",                                            LAYER_PARSER(parseReshape)},
         {"Unsqueeze",                                          LAYER_PARSER(parseReshape)},
         {"Crop",                                               LAYER_PARSER(parseCrop)},
         {"Tile",                                               LAYER_PARSER(parseTile)},
-        {"Normalize",                                          LAYER_PARSER(parseNormalize)},
+        {"NormalizeL2",                                          LAYER_PARSER(parseNormalize)},
         {"PriorBox",                                           LAYER_PARSER(parsePriorBox)},
         {"PriorBoxClustered",                                  LAYER_PARSER(parsePriorBoxClustered)},
-        {"Permute",                                            LAYER_PARSER(parsePermute)},
+        {"Transpose",                                          LAYER_PARSER(parsePermute)},
         {"DetectionOutput",                                    LAYER_PARSER(parseDetectionOutput)},
         {"RegionYolo",                                         LAYER_PARSER(parseRegionYolo)},
         {"ReorgYolo",                                          LAYER_PARSER(parseReorgYolo)},
@@ -98,33 +119,33 @@ FrontEnd::FrontEnd(StageBuilder::Ptr stageBuilder, const ie::ICore* core)
         {"Proposal",                                           LAYER_PARSER(parseProposal)},
         {"ROIPooling",                                         LAYER_PARSER(parseROIPooling)},
         {"PSROIPooling",                                       LAYER_PARSER(parsePSROIPooling)},
-        {"Interp",                                             LAYER_PARSER(parseInterp)},
+        // {"Interp",                                             LAYER_PARSER(parseInterp)},
         {"Interpolate",                                        LAYER_PARSER(parseInterpolate)},
-        {"Custom",                                             LAYER_PARSER(parseCustom)},
-        {"MTCNN",                                              LAYER_PARSER(parseMTCNN)},
+        // {"Custom",                                             LAYER_PARSER(parseCustom)},
+        // {"MTCNN",                                              LAYER_PARSER(parseMTCNN)},
         {"LSTMCell",                                           LAYER_PARSER(parseLSTMCell)},
         {"Pad",                                                LAYER_PARSER(parsePad)},
-        {"Resample",                                           LAYER_PARSER(parseResample)},
+        // {"Resample",                                           LAYER_PARSER(parseResample)},
         {"LSTMSequence",                                       LAYER_PARSER(parseRNN)},
-        {"GEMM",                                               LAYER_PARSER(parseGEMM)},
+        {"MatMul",                                             LAYER_PARSER(parseGEMM)},
         {"Log",                                                LAYER_PARSER(parseLog)},
         {"Exp",                                                LAYER_PARSER(parseExp)},
         {"ReverseSequence",                                    LAYER_PARSER(parseReverseSequence)},
         {"Gather",                                             LAYER_PARSER(parseGather)},
-        {"ReduceAnd",                                          LAYER_PARSER(parseReduce)},
         {"Floor",                                              LAYER_PARSER(parseFloor)},
         {"TopK",                                               LAYER_PARSER(parseTopK)},
-        {"ReduceMin",                                          LAYER_PARSER(parseReduce)},
         {"StridedSlice",                                       LAYER_PARSER(parseStridedSlice)},
         {"Select",                                             LAYER_PARSER(parseSelect)},
         {"Erf",                                                LAYER_PARSER(parseErf)},
         {"ExperimentalDetectronDetectionOutput",               LAYER_PARSER(parseExpDetectionOutput)},
         {"ExperimentalDetectronROIFeatureExtractor",           LAYER_PARSER(parseROIFeatureExtractor)},
         {"Convert",                                            LAYER_PARSER(parseConvert)},
-        {"ReduceMax",                                          LAYER_PARSER(parseReduce)},
-        {"ReduceSum",                                          LAYER_PARSER(parseReduce)},
-        {"ReduceMean",                                         LAYER_PARSER(parseReduce)},
-        {"TensorIterator",                                     LAYER_PARSER(parseTensorIterator)},
+        {"ReduceAnd",                                          LAYER_PARSER(parseReduceAnd)},
+        {"ReduceMin",                                          LAYER_PARSER(parseReduceMin)},
+        {"ReduceMax",                                          LAYER_PARSER(parseReduceMax)},
+        {"ReduceSum",                                          LAYER_PARSER(parseReduceSum)},
+        {"ReduceMean",                                         LAYER_PARSER(parseReduceMean)},
+        // {"TensorIterator",                                     LAYER_PARSER(parseTensorIterator)},
         {"OneHot",                                             LAYER_PARSER(parseOneHot)},
         {"ExperimentalDetectronPriorGridGenerator",            LAYER_PARSER(parseExpPriorGridGenerator)},
         {"ExperimentalDetectronGenerateProposalsSingleImage",  LAYER_PARSER(parseExpGenerateProposals)},
@@ -136,13 +157,13 @@ FrontEnd::FrontEnd(StageBuilder::Ptr stageBuilder, const ie::ICore* core)
         {"DynamicShapeResolver",                               LAYER_PARSER(parseDSR)},
         {"OutShapeOfReshape",                                  LAYER_PARSER(parseOutShapeOfReshape)},
         {"StaticShapeBroadcast",                               LAYER_PARSER(parseBroadcast)},
-        {"StaticShapeNonMaxSuppression",                       LAYER_PARSER(parseStaticShapeNMS)},
+        // {"StaticShapeNonMaxSuppression",                       LAYER_PARSER(parseStaticShapeNMS)},
         {"StaticShapeReshape",                                 LAYER_PARSER(parseReshape)},
         {"Mish",                                               LAYER_PARSER(parseMish)},
         {"Gelu",                                               LAYER_PARSER(parseGelu)},
         {"SoftPlus",                                           LAYER_PARSER(parseSoftPlus)},
         {"Swish",                                              LAYER_PARSER(parseSwish)},
-        {"Activation",                                         LAYER_PARSER(parseActivation)},
+        // {"Activation",                                         LAYER_PARSER(parseActivation)},
         {"GatherND",                                           LAYER_PARSER(parseGatherND)},
         {"HSwish",                                             LAYER_PARSER(parseHSwish)},
         {"Ceiling",                                            LAYER_PARSER(parseCeiling)},
@@ -170,7 +191,7 @@ ie::CNNNetwork FrontEnd::convertNetwork(ie::CNNNetwork& network) {
     ngraph::pass::Manager manager;
     manager.register_pass<::ngraph::pass::InitNodeInfo>();
     // WA: ConvertPriorBox must be executed before the 1st ConstantFolding pass
-    manager.register_pass<::ngraph::pass::ConvertPriorBox>();
+    // manager.register_pass<::ngraph::pass::ConvertPriorBox>();
     manager.register_pass<ngraph::pass::ConvertNMS1ToNMS5>();
     manager.register_pass<ngraph::pass::ConvertNMS3ToNMS5>();
     manager.register_pass<ngraph::pass::ConvertNMS4ToNMS5>();
@@ -185,12 +206,14 @@ ie::CNNNetwork FrontEnd::convertNetwork(ie::CNNNetwork& network) {
     manager.register_pass<vpu::DynamicToStaticShape>();
     manager.register_pass<vpu::EliminateShapeOfAfterDSR>();
     manager.register_pass<vpu::ConvertExtractImagePatchesToReorgYolo>();
+    manager.register_pass<vpu::ConvertMatMulToFC>();
     // ConstantFolding placed here to avoid precision type missmatch when we try to evaluate nodes with BOOL output.
     // For example evaluate_greater_equal calls set_broadcast function with hardcoded BOOL precision.
     // In set_broadcast function we compare original node's precision with hardcoded so we get an error if we change precision before.
     manager.register_pass<ngraph::pass::ConstantFolding>();
     manager.register_pass<ngraph::pass::ConvertOpSet3ToOpSet2>();
     manager.register_pass<ngraph::pass::ConvertOpSet2ToOpSet1>();
+    // manager.register_pass<ngraph::pass::ConvertMatMulToFCorGemm>();
     // ConvertPrecision must be executed before ConvertOpSet1ToLegacy due to this pass works with operations from opsets only
     static const precisions_array precisions = {
         { ngraph::element::i64, ngraph::element::i32 },
@@ -200,9 +223,9 @@ ie::CNNNetwork FrontEnd::convertNetwork(ie::CNNNetwork& network) {
     };
     manager.register_pass<ngraph::pass::ConvertPrecision>(precisions, myriadTypeToFuseMap);
 
-    manager.register_pass<ngraph::pass::ConvertOpSet1ToLegacy>();
+    // manager.register_pass<ngraph::pass::ConvertOpSet1ToLegacy>();
     //  ConvertOpSet1ToLegacy can produce constants with I64 precision
-    manager.register_pass<ngraph::pass::ConvertPrecision>(precisions_array {{ ngraph::element::i64, ngraph::element::i32 }}, myriadTypeToFuseMap);
+    // manager.register_pass<ngraph::pass::ConvertPrecision>(precisions_array {{ ngraph::element::i64, ngraph::element::i32 }}, myriadTypeToFuseMap);
     manager.register_pass<vpu::MergeSubsequentDSROperations>();
 
     auto pass_config = manager.get_pass_config();
@@ -221,9 +244,9 @@ ie::CNNNetwork FrontEnd::convertNetwork(ie::CNNNetwork& network) {
                               ngraph::pass::ConvertStridedSliceToCropMatcher>(transformationPredicate);
 
     manager.run_passes(nGraphFunc);
-    IE_SUPPRESS_DEPRECATED_START
-    return ie::CNNNetwork(ie::details::convertFunctionToICNNNetwork(nGraphFunc, network));
-    IE_SUPPRESS_DEPRECATED_END
+    ngraph::pass::VisualizeTree("/home/akorolev/work/tmp/cnnlayer_to_ngraph/top_k_test.svg").run_on_function(nGraphFunc);
+
+    return network;
 }
 
 std::set<std::string> FrontEnd::checkSupportedLayers(const ie::CNNNetwork& network) {
@@ -236,17 +259,17 @@ std::set<std::string> FrontEnd::checkSupportedLayers(const ie::CNNNetwork& netwo
 
     std::set<std::string> supportedLayers;
 
-    const auto onSupportedLayer = [&supportedLayers](const ie::CNNLayerPtr& layer) {
-        supportedLayers.insert(layer->name);
+    const auto onSupportedLayer = [&supportedLayers](const NodePtr& node) {
+        supportedLayers.insert(node->get_friendly_name());
     };
 
     const auto onUnsupportedLayer = [this](
         const Model& model,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         const DataVector& inputs,
         const DataVector& outputs,
         const std::string& /*extraMsg*/) {
-        _stageBuilder->addNoneStage(model, layer->name, layer, inputs, outputs);
+        _stageBuilder->addNoneStage(model, node->get_friendly_name(), node, inputs, outputs);
     };
 
     runCommonPasses(cloneNetwork(network), onUnsupportedLayer, onSupportedLayer);
@@ -260,156 +283,83 @@ std::atomic<int> g_counter(0);
 
 }  // namespace
 
-CustomLayer::Ptr FrontEnd::getSuitableCustomLayer(const std::vector<CustomLayer::Ptr>& customLayers,
-                                                  const ie::CNNLayerPtr& cnnLayer) {
-    const auto& env = CompileEnv::get();
-    env.log->trace("Check for suitable custom implementation for layer %s:%s",
-                   cnnLayer->name, cnnLayer->type);
-    VPU_LOGGER_SECTION(env.log);
+// std::vector<vpu::CustomLayer::Ptr> getSuitableCustomLayers(const std::vector<vpu::CustomLayer::Ptr>& customLayers,
+//                                                            const std::shared_ptr<ngraph::Node>& node) {
+//     const auto isSuitableLayer = [&](const vpu::CustomLayer::Ptr& customLayer) {
+//         paramVisitor visitor;
+//         node->visit_attributes(visitor);
+//         auto layerParams = visitor.GetMap();
 
-    const auto cnnInputs = [&] {
-        auto inputs = SmallVector<CustomDataFormat>{};
-        inputs.reserve(cnnLayer->insData.size());
-        for (const auto& input : cnnLayer->insData) {
-            const auto layout = input.lock()->getLayout();
-            const auto format = CustomLayer::formatFromLayout(layout);
-            inputs.push_back(format);
-        }
-        return inputs;
-    }();
+//         if (!customLayer->meetsWhereRestrictions(layerParams)) {
+//             return false;
+//         }
 
-    const auto cnnOutputs = [&] {
-        auto outputs = SmallVector<CustomDataFormat>{};
-        outputs.reserve(cnnLayer->outData.size());
-        for (const auto& output : cnnLayer->outData) {
-            const auto layout = output->getLayout();
-            const auto format = CustomLayer::formatFromLayout(layout);
-            outputs.push_back(format);
-        }
-        return outputs;
-    }();
+//         SizeRuleValidator validator{customLayer, layerParams};
+//         for (const auto& kernel : customLayer->kernels()) {
+//             kernel->accept(validator);
+//             if (!validator.result()) {
+//                 return false;
+//             }
+//         }
 
-    const auto isSuitableLayer = [&env, &cnnLayer](const CustomLayer::Ptr& customLayer) {
-        env.log->trace("Check next custom layer : %v", customLayer->layerName());
-        VPU_LOGGER_SECTION(env.log);
+//         return true;
+//     };
 
-        if (!customLayer->meetsWhereRestrictions(cnnLayer->params)) {
-            env.log->trace("Where restrictions are not met");
-            return false;
-        }
+//     auto suitableCustomLayers = std::vector<vpu::CustomLayer::Ptr>{};
 
-        for (const auto& kernel : customLayer->kernels()) {
-            const auto& gws = kernel.globalGridSizeRules();
-            const auto& lws = kernel.localGridSizeRules();
+//     std::copy_if(begin(customLayers), end(customLayers), back_inserter(suitableCustomLayers), isSuitableLayer);
 
-            const auto validSizeRule = [&](const std::string& rule) {
-                return CustomLayer::isLegalSizeRule(rule, cnnLayer->params);
-            };
+//     return suitableCustomLayers;
+// }
 
-            const auto validGridSizes = std::all_of(begin(gws), end(gws), validSizeRule) &&
-                                        std::all_of(begin(lws), end(lws), validSizeRule);
-
-            if (!validGridSizes) {
-                env.log->trace("Work group grid sizes are not valid");
-                return false;
-            }
-        }
-
-        return true;
-    };
-
-    auto suitableCustomLayers = SmallVector<CustomLayer::Ptr>{};
-
-    std::copy_if(begin(customLayers), end(customLayers),
-        back_inserter(suitableCustomLayers), isSuitableLayer);
-
-    if (suitableCustomLayers.empty()) {
-      return nullptr;
-    }
-
-    const auto inputsLayoutMatch = [&](const SmallVector<CustomDataFormat>& cnnEdges,
-                                       const std::map<int, CustomDataFormat>& clEdges) {
-        for (const auto clEdge : clEdges) {
-            const auto port = clEdge.first;
-            VPU_THROW_UNLESS(port < cnnEdges.size(),
-                "Can't bind custom layer edge with port '%s' to CNNNetwork layer", port);
-
-            const auto clFormat = clEdge.second;
-            const auto cnnFormat = cnnEdges[port];
-            if (cnnFormat != clFormat &&
-                cnnFormat != CustomDataFormat::Any &&
-                clFormat != CustomDataFormat::Any) {
-                return false;
-            }
-        }
-        return true;
-    };
-
-
-    for (const auto& customLayer : suitableCustomLayers) {
-        const auto clInputs = customLayer->inputs();
-
-        if (inputsLayoutMatch(cnnInputs, clInputs)) {
-            env.log->trace("Found suitable '%s' custom layer", customLayer->layerName());
-            return customLayer;
-        }
-    }
-
-    const auto firstGoodLayer = suitableCustomLayers.front();
-    env.log->trace("Found suitable custom layer '%s', but input layouts "
-                   "have not matched with what CNNNetwork expected",
-                   firstGoodLayer->layerName());
-    return firstGoodLayer;
-}
-
-
-void FrontEnd::parseLayer(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) {
-    parseLayer(model, layer, inputs, outputs,
-        [this](const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs,
+void FrontEnd::parseLayer(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) {
+    parseLayer(model, node, inputs, outputs,
+        [this](const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs,
                             const std::string& extraMessage)
-        { defaultOnUnsupportedLayerCallback(model, layer, inputs, outputs, extraMessage); });
+        { defaultOnUnsupportedLayerCallback(model, node, inputs, outputs, extraMessage); });
 }
 
-void FrontEnd::parseLayer(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs,
-                          const FrontEnd::UnsupportedLayerCallback& onUnsupported, const FrontEnd::SupportedLayerCallback& onSupported) {
-    const auto customLayer = _customLayers.find(layer->type);
-    const bool isCustomLayer = customLayer != _customLayers.end() && getSuitableCustomLayer(customLayer->second, layer);
+void FrontEnd::parseLayer(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs,
+                          const FrontEnd::UnsupportedNodeCallback& onUnsupported, const FrontEnd::SupportedNodeCallback& onSupported) {
+    // const auto customLayer = _customLayers.find(node->get_type_name());
+    // const bool isCustomLayer = customLayer != _customLayers.end() && getSuitableCustomLayer(customLayer->second, node);
 
-    const auto& type = isCustomLayer ? "Custom" : layer->type;
+    const auto& type = /*isCustomLayer ? "Custom" : */node->get_type_name();
     if (parsers.count(type) == 0) {
         if (onUnsupported) {
-            onUnsupported(model, layer, inputs, outputs, formatString("unsupported layer type \"%v\"", type));
+            onUnsupported(model, node, inputs, outputs, formatString("unsupported layer type \"%v\"", type));
         }
         return;
     }
 
     try {
-        parsers.at(type)(model, layer, inputs, outputs);
+        parsers.at(type)(model, node, inputs, outputs);
         if (onSupported) {
-            onSupported(layer);
+            onSupported(node);
         }
     } catch (const details::UnsupportedLayerException&) {
         throw;
     } catch (const std::exception& error) {
         if (onUnsupported) {
-            onUnsupported(model, layer, inputs, outputs, error.what());
+            onUnsupported(model, node, inputs, outputs, error.what());
         }
     }
 }
 
 void FrontEnd::processTrivialCases(const Model& model) {
-    std::unordered_map<ie::DataPtr, std::pair<Data, Data>> ieDataToTrivialCase;
+    std::map<OutNode, std::pair<Data, Data>> ieDataToTrivialCase;
     for (const auto& data : model->datas()) {
-        const auto& origData = data->origData();
-        if (origData == nullptr) {
+        const auto& origNode = data->origNode();
+        const auto& origOutput = data->origOutput();
+        if (origNode == nullptr) {
             continue;
         }
 
-        auto& trivialCase = ieDataToTrivialCase[origData];
+        auto& trivialCase = ieDataToTrivialCase[origOutput];
         auto& destination = data->usage() == DataUsage::Output ? trivialCase.second : trivialCase.first;
-        VPU_THROW_UNLESS(ieDataToTrivialCase.count(origData) == 0 || destination == nullptr,
-            "Encountered IE data object {} which has two vpu data objects {} and {} of the same type {} associated with it, while only one is permitted",
-            origData->getName(), destination->name(), data->name(), destination->usage());
+        VPU_THROW_UNLESS(ieDataToTrivialCase.count(origOutput) == 0 || destination == nullptr,
+            "Encountered node {} which has two vpu data objects {} and {} of the same type {} associated with it, while only one is permitted",
+            origNode->get_friendly_name(), destination->name(), data->name(), destination->usage());
         destination = data;
     }
 
@@ -433,21 +383,22 @@ void FrontEnd::processTrivialCases(const Model& model) {
     }
 }
 
-void FrontEnd::defaultOnUnsupportedLayerCallback(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs,
+void FrontEnd::defaultOnUnsupportedLayerCallback(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs,
                                                  const std::string& extraMessage) {
     const auto& env = CompileEnv::get();
-    VPU_THROW_UNSUPPORTED_LAYER_UNLESS(env.config.compileConfig().ignoreUnknownLayers, "Failed to compile layer \"%v\": %v", layer->name, extraMessage);
-    _stageBuilder->addNoneStage(model, layer->name, layer, inputs, outputs);
+    VPU_THROW_UNSUPPORTED_LAYER_UNLESS(env.config.compileConfig().ignoreUnknownLayers, "Failed to compile node with name \"%v\" and type \"%v\" : %v",
+                                       node->get_friendly_name(), node->get_type_name(), extraMessage);
+    _stageBuilder->addNoneStage(model, node->get_friendly_name(), node, inputs, outputs);
 }
 
 ModelPtr FrontEnd::runCommonPasses(const ie::CNNNetwork& network) {
     return runCommonPasses(cloneNetwork(network),
-        [this](const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs, const std::string& extraMessage) {
-            defaultOnUnsupportedLayerCallback(model, layer, inputs, outputs, extraMessage);});
+        [this](const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs, const std::string& extraMessage) {
+            defaultOnUnsupportedLayerCallback(model, node, inputs, outputs, extraMessage);});
 }
 
 ModelPtr FrontEnd::runCommonPasses(ie::CNNNetwork network,
-    const UnsupportedLayerCallback& unsupportedLayer, const SupportedLayerCallback& supportedLayer) {
+    const UnsupportedNodeCallback& unsupportedLayer, const SupportedNodeCallback& supportedLayer) {
     const auto& env = CompileEnv::get();
 
     //
@@ -457,7 +408,7 @@ ModelPtr FrontEnd::runCommonPasses(ie::CNNNetwork network,
     _ieParsedNetwork = {};
     _unbatchedOutputs.clear();
     _ieToVpuMap.clear();
-    _customLayers.clear();
+    // _customLayers.clear();
     _kernelNodes.clear();
     _lstmWeights.clear();
     _lstmBiases.clear();
@@ -466,16 +417,16 @@ ModelPtr FrontEnd::runCommonPasses(ie::CNNNetwork network,
     // Parse custom layers
     //
 
-    if (!env.config.compileConfig().customLayers.empty()) {
-        env.log->trace("Parse custom layers : %s", env.config.compileConfig().customLayers);
-        VPU_LOGGER_SECTION(env.log);
+    // if (!env.config.compileConfig().customLayers.empty()) {
+    //     env.log->trace("Parse custom layers : %s", env.config.compileConfig().customLayers);
+    //     VPU_LOGGER_SECTION(env.log);
 
-        if (env.platform != ncDevicePlatform_t::NC_MYRIAD_X) {
-            VPU_THROW_FORMAT("Custom layers are not supported for %v platforms", env.platform);
-        }
+    //     if (env.platform != Platform::MYRIAD_X) {
+    //         VPU_THROW_FORMAT("Custom layers are not supported for %v platforms", env.platform);
+    //     }
 
-        _customLayers = CustomLayer::loadFromFile(env.config.compileConfig().customLayers);
-    }
+    //     _customLayers = CustomLayer::loadFromFile(env.config.compileConfig().customLayers);
+    // }
 
     //
     // Create new VPU model
@@ -494,15 +445,13 @@ ModelPtr FrontEnd::runCommonPasses(ie::CNNNetwork network,
         env.log->trace("Update IE Network");
         VPU_LOGGER_SECTION(env.log);
 
-        if (network.getFunction() && env.config.compileConfig().forceDeprecatedCnnConversion) {
-            network = convertNetwork(network);
-        }
-
         detectNetworkBatch(network, model);
 
-        if (network.getFunction()) {
-            network = convertNetwork(network);
-        }
+        //
+        // Running ngraph passes
+        //
+
+        network = convertNetwork(network);
 
         const std::vector<std::pair<ngraph::element::Type, ngraph::element::Type>> convert_precision_list {
             {ngraph::element::i64, ngraph::element::i32},
@@ -518,9 +467,7 @@ ModelPtr FrontEnd::runCommonPasses(ie::CNNNetwork network,
                                             InferenceEngine::details::convertPrecision(precision.first),
                                             InferenceEngine::details::convertPrecision(precision.second));
         }
-        removeConstLayers(network);
-
-        unrollLoops(network);
+        // removeConstLayers(network);
     }
 
     //
@@ -556,24 +503,24 @@ ModelPtr FrontEnd::runCommonPasses(ie::CNNNetwork network,
     // Parse original layers
     //
 
-    env.log->trace("Parse original layers");
+    env.log->trace("Parse original nodes");
 
     DataVector inputs, outputs;
-    for (const auto& layer : origLayers()) {
+    for (const auto& node : origNodes()) {
         VPU_LOGGER_SECTION(env.log);
 
-        env.log->trace("Try to parse layer %s:%s", layer->name, layer->type);
+        env.log->trace("Try to parse node %s:%s", node->get_friendly_name(), node->get_type_name());
         VPU_LOGGER_SECTION(env.log);
 
-        getInputAndOutputData(model, layer, inputs, outputs);
+        getInputAndOutputData(model, node, inputs, outputs);
 
-        if (env.config.compileConfig().skipAllLayers() || env.config.compileConfig().skipLayerType(layer->type)) {
-            _stageBuilder->addNoneStage(model, layer->name, layer, inputs, outputs);
-            supportedLayer(layer);
+        if (env.config.compileConfig().skipAllLayers() || env.config.compileConfig().skipLayerType(node->get_type_name())) {
+            _stageBuilder->addNoneStage(model, node->get_friendly_name(), node, inputs, outputs);
+            supportedLayer(node);
             continue;
         }
-
-        parseLayer(model, layer, inputs, outputs, unsupportedLayer, supportedLayer);
+        std::cout << "Parse layer with name " << node->get_friendly_name() << " and type " << node->get_type_name() << std::endl;
+        parseLayer(model, node, inputs, outputs, unsupportedLayer, supportedLayer);
     }
 
     //
@@ -590,10 +537,10 @@ ModelPtr FrontEnd::runCommonPasses(ie::CNNNetwork network,
     return model;
 }
 
-Data FrontEnd::getVpuData(const ie::DataPtr& ieData) const {
-    IE_ASSERT(ieData != nullptr);
+Data FrontEnd::getVpuData(const OutNode& outNode) const {
+    IE_ASSERT(outNode.get_node_shared_ptr() != nullptr);
 
-    const auto it = _ieToVpuMap.find(ieData);
+    const auto it = _ieToVpuMap.find(outNode);
     if (it == _ieToVpuMap.end()) {
         return nullptr;
     }
@@ -601,80 +548,102 @@ Data FrontEnd::getVpuData(const ie::DataPtr& ieData) const {
     return it->second;
 }
 
-void FrontEnd::bindData(const Data& data, const ie::DataPtr& ieData) {
-    _ieToVpuMap[ieData] = data;
-    data->setOrigData(ieData);
+void FrontEnd::bindData(const Data& data, const OutNode& nodeOutput, NodePtr origNode) {
+    _ieToVpuMap[nodeOutput] = data;
+    data->setOrigNode(origNode);
+    data->setOrigOutput(nodeOutput);
 }
 
 void FrontEnd::getInputAndOutputData(
         const Model& model,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         DataVector& inputs,
         DataVector& outputs) {
-    IE_ASSERT(layer != nullptr);
+    IE_ASSERT(node != nullptr);
 
-    inputs.resize(layer->insData.size());
-    for (size_t i = 0; i < layer->insData.size(); ++i) {
-        const auto layerInput = layer->insData[i].lock();
-        IE_ASSERT(layerInput != nullptr);
-
-        inputs[i] = getVpuData(layerInput);
+    inputs.resize(node->get_input_size());
+    for (size_t i = 0; i < node->get_input_size(); ++i) {
+        const auto& inputNodeOutput = node->get_input_source_output(i);
+        IE_ASSERT(inputNodeOutput.get_node_shared_ptr() != nullptr);
+        inputs[i] = getVpuData(inputNodeOutput);
         IE_ASSERT(inputs[i] != nullptr);
     }
 
-    outputs.resize(layer->outData.size());
-    for (size_t i = 0; i < layer->outData.size(); ++i) {
-        const auto layerOutput = layer->outData[i];
-        IE_ASSERT(layerOutput != nullptr);
-
-        if (const auto data = getVpuData(layerOutput)) {
+    outputs.resize(node->get_output_size());
+    for (int i = 0; i < node->get_output_size(); ++i) {
+        const auto& outputNode = node->output(i);
+        if (const auto data = getVpuData(outputNode)) {
             outputs[i] = data;
         } else {
-            DataDesc dataDesc(layerOutput->getTensorDesc());
+            const auto& desc = node->get_output_tensor(i);
+            DataDesc dataDesc(desc);
             if (dataDesc.type() == DataType::FP32) {
                 // To infer the same FP32 models on different devices (CPU, GPU, VPU and so on)
                 dataDesc.setType(DataType::FP16);
             }
 
             // Skip adding data if it not utilized
-            const bool isNetworkOutput = _ieParsedNetwork.networkOutputs.count(layerOutput->getName()) > 0;
-            const auto isLeaf = getInputTo(layerOutput).empty();
-            if (!isNetworkOutput && isLeaf) {
-                outputs[i] = nullptr;
-                continue;
-            }
+
+            // REWROK
+            // const bool isNetworkOutput = _ieParsedNetwork.networkOutputs.count(layerOutput->getName()) > 0;
+            // const auto isLeaf = getInputTo(layerOutput).empty();
+            // if (!isNetworkOutput && isLeaf) {
+            //     outputs[i] = nullptr;
+            //     continue;
+            // }
 
             outputs[i] = model->addNewData(
-                layerOutput->getName(),
+                outputNode.get_node_shared_ptr()->get_friendly_name(),
                 dataDesc);
-
-            bindData(outputs[i], layerOutput);
+            bindData(outputs[i], outputNode, node);
         }
     }
 }
 
-std::tuple<Data, Data> FrontEnd::getWeightsAndBiases(const Model& model, const ie::CNNLayerPtr& layer) const {
-    const auto baseLayer = std::dynamic_pointer_cast<ie::WeightableLayer>(layer);
-    IE_ASSERT(baseLayer != nullptr);
+ie::Blob::Ptr FrontEnd::shareWeights(const NodePtr& node)  {
+    auto constLayer = ngraph::as_type_ptr<ngraph::opset4::Constant>(node);
+    if (!constLayer) IE_THROW() << "Cannot share weights! Constant operation is empty!";
+    auto dataPrecision = ie::details::convertPrecision(constLayer->get_element_type());
 
-    const auto origWeights = baseLayer->_weights;
-    VPU_THROW_UNLESS(origWeights != nullptr, "Layer %s has no weights", layer->name);
+    size_t shapeSize = ngraph::shape_size(constLayer->get_shape());
+    size_t byte_size{8};
+    if (dataPrecision == ie::Precision::BIN) {
+        shapeSize = (shapeSize + (byte_size - 1)) / byte_size;
+    }
+
+    ie::TensorDesc td(dataPrecision, {shapeSize}, ie::Layout::C);
+
+    auto blob = make_blob_with_precision(td, std::make_shared<ie::details::ConstAllocatorWrapper>(constLayer));
+    blob->allocate();
+
+    return blob;
+}
+
+std::tuple<Data, Data> FrontEnd::getWeightsAndBiases(const Model& model, const std::string nodeName,
+                                                     const NodePtr& weightsNode, const NodePtr& biasesNode) const {
+    auto constant = ngraph::as_type_ptr<ngraph::opset4::Constant>(weightsNode);
+    VPU_THROW_UNLESS(constant != nullptr, "Can't get weights. Node with name {} has no constant input", nodeName);
+    
+    const auto origWeights = shareWeights(weightsNode);
+    VPU_THROW_UNLESS(origWeights != nullptr, "Can't get weights. Node with name {} has no constant input", nodeName);
 
     const auto weights = model->addConstData(
-        layer->name + "@weights",
+        nodeName + "@weights",
         DataDesc({origWeights->size()}),
         ieBlobContent(origWeights));
 
-    const auto origBiases = baseLayer->_biases;
-
     Data biases;
-    if (origBiases == nullptr) {
-        biases = model->addFakeData();
-    } else {
+    if (biasesNode != nullptr) {
+        auto constBiasesNode = ngraph::as_type_ptr<ngraph::opset4::Constant>(biasesNode);
+        VPU_THROW_UNLESS(constBiasesNode != nullptr, "Can't get biases. Node with name {} has no constant input", nodeName);
+
+        const auto origBiases = shareWeights(biasesNode);
         biases = model->addConstData(
-            layer->name + "@biases",
+            nodeName + "@biases",
             DataDesc({origBiases->size()}),
             ieBlobContent(origBiases));
+    } else {
+        biases = model->addFakeData();
     }
 
     return std::make_tuple(weights, biases);

--- a/inference-engine/src/vpu/graph_transformer/src/frontend/in_out_convert.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/frontend/in_out_convert.cpp
@@ -49,7 +49,7 @@ void FrontEnd::addDataTypeConvertStages(const Model& model) {
                             input,
                             postfix.str());
 
-                    bindData(scaledInput, input->origData());
+                    bindData(scaledInput, input->origOutput(), input->origNode());
 
                     _stageBuilder->addPowerStage(
                             model,
@@ -78,7 +78,7 @@ void FrontEnd::addDataTypeConvertStages(const Model& model) {
 
                 input->attrs().set<Data>("fp16_copy", inputFP16);
 
-                bindData(inputFP16, input->origData());
+                bindData(inputFP16, input->origOutput(), input->origNode());
 
                 for (const auto consumerEdge : input->consumerEdges()) {
                     model->replaceStageInput(consumerEdge, inputFP16);
@@ -128,7 +128,7 @@ void FrontEnd::addDataTypeConvertStages(const Model& model) {
 
         output->attrs().set<Data>("fp16_copy", outputFP16);
 
-        bindData(outputFP16, output->origData());
+        bindData(outputFP16, output->origOutput(), output->origNode());
 
         if (const auto producerEdge = output->producerEdge()) {
             model->replaceStageOutput(producerEdge, outputFP16);
@@ -142,8 +142,11 @@ void FrontEnd::addDataTypeConvertStages(const Model& model) {
 
         const auto withDetectionOutput = model->attrs().getOrDefault<bool>("withDetectionOutput", false);
         stage->attrs().set<bool>("convertFromDetOutput", withDetectionOutput);
-
-        const auto haveBatch = model->batchSize() != 1 && _unbatchedOutputs.count(output->origData()) == 0;
+        auto outputName = output->origNode()->get_friendly_name();
+        auto unbatchedOutputIt = std::find_if(_unbatchedOutputs.begin(), _unbatchedOutputs.end(), [&outputName](ie::DataPtr ieData) {
+            return ieData->getName() == outputName;
+        });
+        const auto haveBatch = model->batchSize() != 1 && unbatchedOutputIt == _unbatchedOutputs.end();
         stage->attrs().set<bool>("haveBatch", haveBatch);
     }
 }

--- a/inference-engine/src/vpu/graph_transformer/src/graph_transformer.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/graph_transformer.cpp
@@ -177,7 +177,7 @@ CompiledGraph::Ptr compileImpl(const ie::CNNNetwork& network, const ie::ICore* c
                           env.config.compileConfig().irWithVpuScalesDir + "/" + network.getName() + "_scales.bin");
     }
 
-    return backEnd->build(model, frontEnd->origLayers());
+    return backEnd->build(model, frontEnd->origNodes());
 }
 
 CompiledGraph::Ptr compileImpl(const Model& model) {

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/hw/pooling_tiling/hw_stage_tiler.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/hw/pooling_tiling/hw_stage_tiler.cpp
@@ -78,7 +78,7 @@ Data HWPoolStageTiler::createInputTile(const HwPoolPlaneTilePtr& planeTile, cons
         _stageBuilder->addCopyStage(
             _model,
             _original->name() + tilePostfix + "@align-input-ptr",
-            _original->origLayer(),
+            _original->origNode(),
             hwInputTile,
             hwInputTileAligned,
             "HWPoolTiler::input");
@@ -116,7 +116,7 @@ Data HWPoolStageTiler::createOutputTile(const HwPoolPlaneTilePtr& planeTile, con
         _stageBuilder->addCopyStage(
             _model,
             _original->name() + tilePostfix + "@align-output-ptr",
-            _original->origLayer(),
+            _original->origNode(),
             hwOutputTileAligned,
             hwOutputTile,
             "HWPoolTiler::output");
@@ -139,7 +139,7 @@ Data HWPoolStageTiler::createOutputTile(const HwPoolPlaneTilePtr& planeTile, con
         _stageBuilder->addCropStage(
             _model,
             _original->name() + tilePostfix + "@remove-junk",
-            _original->origLayer(),
+            _original->origNode(),
             hwOutputTileWithJunk,
             hwOutputTile,
             innerOffset);
@@ -164,7 +164,7 @@ void HWPoolStageTiler::createHWStageForTile(const Data& hwInputTile,
     auto hwStage = _model->addNewStage<MyriadXHwStage>(
         _original->name() + tilePostfix,
         StageType::MyriadXHwOp,
-        _original->origLayer(),
+        _original->origNode(),
         {hwInputTile, hwTileWeights, hwTileBiases, hwTileScales},
         {hwOutputTile});
 

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/adjust_data_layout.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/adjust_data_layout.cpp
@@ -100,7 +100,7 @@ void PassImpl::run(const Model& model) {
                     _stageBuilder->addReorderStage(model,
                                                    formatString("%s@reorder-input-data=%d", stage->name(),
                                                                 inEdge->portInd()),
-                                                   stage->origLayer(),
+                                                   stage->origNode(),
                                                    input,
                                                    newInput);
                     convertedData.emplace_back(newInput);
@@ -154,7 +154,7 @@ void PassImpl::run(const Model& model) {
                     _stageBuilder->addReorderStage(model,
                                                    formatString("%s@reorder-output-data=%d", stage->name(),
                                                                 outEdge->portInd()),
-                                                   stage->origLayer(),
+                                                   stage->origNode(),
                                                    newOutput,
                                                    output);
                 } else {
@@ -216,7 +216,7 @@ void PassImpl::run(const Model& model) {
                     _stageBuilder->addCopyStage(
                         model,
                         formatString("%s@input=%d@align-strides", stage->name(), inEdge->portInd()),
-                        stage->origLayer(),
+                        stage->origNode(),
                         input,
                         newInput,
                         "adjustDataLayout::input");
@@ -281,7 +281,7 @@ void PassImpl::run(const Model& model) {
                     _stageBuilder->addCopyStage(
                         model,
                         formatString("%s@input=%d@align-strides", stage->name(), portInd),
-                        stage->origLayer(),
+                        stage->origNode(),
                         newOutput,
                         output,
                         "adjustDataLayout::output");

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/adjust_data_location.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/adjust_data_location.cpp
@@ -86,7 +86,7 @@ void PassImpl::copyHwNetOutputs(const Model& model) {
             _stageBuilder->addCopyStage(
                 model,
                 stage->name() + "@flush-output",
-                stage->origLayer(),
+                stage->origNode(),
                 newOutput,
                 output,
                 "copyHwNetOutputs");
@@ -300,7 +300,7 @@ void PassImpl::adjustModelForMemReqs(const Model& model) {
                 auto copyStage = _stageBuilder->addCopyStage(
                     model,
                     formatString("%s@move-to-DDR", cmxData->name()),
-                    failedStage->origLayer(),
+                    failedStage->origNode(),
                     cmxData,
                     ddrCopy,
                     "CopyFromCMXToDDRAdjustment");
@@ -371,7 +371,7 @@ void PassImpl::copyHwMisalignedInput(const Model& model) {
             _stageBuilder->addCopyStage(
                 model,
                 stage->name() + "@align-input-ptr",
-                stage->origLayer(),
+                stage->origNode(),
                 input,
                 newInput,
                 "copyHwMisalignedInput");

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/eliminate_copy.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/eliminate_copy.cpp
@@ -125,7 +125,7 @@ void PassImpl::run(const Model& model) {
         auto copyOutputTopParent = copyOutput->getTopParentData();
 
         auto copyStageName = copyStage->name();
-        auto copyOrigLayer = copyStage->origLayer();
+        auto copyOrigLayer = copyStage->origNode();
 
         auto copyProducer = copyInput->producer();
         auto specialConsumer = copyOutput->singleConsumer();

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/eliminate_redundant_conversions.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/eliminate_redundant_conversions.cpp
@@ -57,7 +57,7 @@ void PassImpl::runForStage(const Model& model, const Stage& convert) {
         _stageBuilder->addCopyStage(
                 model,
                 convert->name() + "@replaced-with-copy",
-                convert->origLayer(),
+                convert->origNode(),
                 input,
                 output,
                 "eliminateRedundantConversions");

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/gemm_transpose.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/gemm_transpose.cpp
@@ -82,7 +82,7 @@ void PassImpl::run(const Model& model) {
         _stageBuilder->addPermuteStage(
             model,
             stage->name() + "@transpose",
-            stage->origLayer(),
+            stage->origNode(),
             inputA,
             inputATranspose,
             permMap);

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/hw_conv_tiling.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/hw_conv_tiling.cpp
@@ -126,7 +126,7 @@ void PassImpl::run(const Model& model) {
                 _stageBuilder->addReLUStage(
                     model,
                     origStage->name() + "@ReLU",
-                    origStage->origLayer(),
+                    origStage->origNode(),
                     stageOptions.negativeSlope,
                     swConvOutput,
                     swReluOutput);
@@ -144,7 +144,7 @@ void PassImpl::run(const Model& model) {
                 _stageBuilder->addClampStage(
                     model,
                     origStage->name() + "@Clamp",
-                    origStage->origLayer(),
+                    origStage->origNode(),
                     0.0,
                     stageOptions.clampMax,
                     swConvOutput,
@@ -157,7 +157,7 @@ void PassImpl::run(const Model& model) {
                 auto hwPoolStage = model->addNewStage<StubStage>(
                     origStage->name() + "@Pool",
                     StageType::StubMaxPool,
-                    origStage->origLayer(),
+                    origStage->origNode(),
                     {hwPoolInput},
                     {stageIO.origOutput});
 
@@ -200,7 +200,7 @@ void PassImpl::run(const Model& model) {
                 _stageBuilder->addSplitStage(
                     model,
                     origStage->name() + "@split-input",
-                    origStage->origLayer(),
+                    origStage->origNode(),
                     std::move(hwStageTiler.hwInputTilesOffsets),
                     hwStageTiler.hwInput,
                     hwStageTiler.hwInputTiles);
@@ -210,7 +210,7 @@ void PassImpl::run(const Model& model) {
                 _stageBuilder->addSplitStage(
                     model,
                     origStage->name() + "@split-input2",
-                    origStage->origLayer(),
+                    origStage->origNode(),
                     std::move(hwStageTiler.hwWeightsTilesOffsets),
                     stageIO.origWeights,
                     hwStageTiler.hwWeightsTiles);
@@ -220,7 +220,7 @@ void PassImpl::run(const Model& model) {
                 _stageBuilder->addConcatStage(
                     model,
                     origStage->name() + "@concat-output",
-                    origStage->origLayer(),
+                    origStage->origNode(),
                     std::move(hwStageTiler.hwOutputTilesOffsets),
                     hwStageTiler.hwOutputTiles,
                     hwStageTiler.hwOutput);

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/hw_extra_split.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/hw_extra_split.cpp
@@ -209,7 +209,7 @@ void PassImpl::splitStagesWithOneDescriptor(
             _stageBuilder->addConcatStage(
                 model,
                 stage->name() + "@concat-output",
-                stage->origLayer(),
+                stage->origNode(),
                 Dim::N,
                 dimOutputs,
                 output);
@@ -295,7 +295,7 @@ void PassImpl::splitStagesWithManyDescriptors(
             _stageBuilder->addConcatStage(
                 model,
                 stage->name() + "@concat-output",
-                stage->origLayer(),
+                stage->origNode(),
                 Dim::N,
                 dimOutputs,
                 output);
@@ -459,7 +459,7 @@ void PassImpl::splitHwConv(
     _stageBuilder->addConcatStage(
         model,
         stage->name() + "@concat-output",
-        stage->origLayer(),
+        stage->origNode(),
         Dim::C,
         newOutputs,
         output);
@@ -525,7 +525,7 @@ Data PassImpl::splitHwPool(
     _stageBuilder->addSplitStage(
         model,
         stage->name() + "@dim-split",
-        stage->origLayer(),
+        stage->origNode(),
         std::move(inputOffsets),
         input,
         newInputs);
@@ -537,7 +537,7 @@ Data PassImpl::splitHwPool(
     _stageBuilder->addConcatStage(
         model,
         stage->name() + "@dim-concat",
-        stage->origLayer(),
+        stage->origNode(),
         Dim::C,
         newOutputs,
         newOutput);

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/hw_fc_tiling.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/hw_fc_tiling.cpp
@@ -170,7 +170,7 @@ Data createHWInput(const Model& model, const Stage& original, Stage& relayout) {
         relayout = model->addNewStage<HwFcRelayoutStage>(
             original->name() + "@input-relayout",
             StageType::HwFcRelayout,
-            original->origLayer(),
+            original->origNode(),
             {hwInput},
             {hwInputAsVec});
 
@@ -342,7 +342,7 @@ public:
             auto hwStage = model->addNewStage<MyriadXHwStage>(
                 origStage->name(),
                 StageType::MyriadXHwOp,
-                origStage->origLayer(),
+                origStage->origNode(),
                 {hwInput, hwWeights, hwBiases, hwScales},
                 {origStage->output(0)});
 
@@ -365,7 +365,7 @@ private:
         _stageBuilder->addExpandStage(
             model,
             original->name() + "@expand-input",
-            original->origLayer(),
+            original->origNode(),
             hwInput,
             hwInputExtended);
 
@@ -389,7 +389,7 @@ private:
             _stageBuilder->addReLUStage(
                 model,
                 original->name() + "@ReLU",
-                original->origLayer(),
+                original->origNode(),
                 // LeakyReLU cannot be merged into FullyConnected
                 0.0,
                 swOutput,

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/hw_padding.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/hw_padding.cpp
@@ -143,7 +143,7 @@ void insertPaddingStageBefore(const Model& model, StageBuilder::Ptr& stageBuilde
     auto paddingStage = stageBuilder->addPadStage(
         model,
         origStage->name() + "@padding",
-        origStage->origLayer(),
+        origStage->origNode(),
         (origStage->type() == StageType::StubMaxPool) ? PadMode::Edge : PadMode::Constant,
         0.0f,
         DimValues({

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/hw_pooling_tiling.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/hw_pooling_tiling.cpp
@@ -84,7 +84,7 @@ void PassImpl::run(const Model& model) {
                 _stageBuilder->addReLUStage(
                     model,
                     origStage->name() + "@ReLU",
-                    origStage->origLayer(),
+                    origStage->origNode(),
                     0.0,
                     swOutput,
                     stageIO.origOutput);
@@ -110,7 +110,7 @@ void PassImpl::run(const Model& model) {
                 _stageBuilder->addSplitStage(
                     model,
                     origStage->name() + "@split-input",
-                    origStage->origLayer(),
+                    origStage->origNode(),
                     std::move(hwStageTiler.hwInputTilesOffsets),
                     hwStageTiler.hwInput,
                     hwStageTiler.hwInputTiles);
@@ -120,7 +120,7 @@ void PassImpl::run(const Model& model) {
                 _stageBuilder->addConcatStage(
                     model,
                     origStage->name() + "@concat-output",
-                    origStage->origLayer(),
+                    origStage->origNode(),
                     std::move(hwStageTiler.hwOutputTilesOffsets),
                     hwStageTiler.hwOutputTiles,
                     hwStageTiler.hwOutput);

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/merge_permute_stages.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/merge_permute_stages.cpp
@@ -175,7 +175,7 @@ void PassImpl::run(const Model& model) {
             auto permuteOutput = firstPermuteStage->output(0);
             if (permuteInput->desc().dimsOrder() == permuteOutput->desc().dimsOrder()) {
                 auto stageName     = firstPermuteStage->name();
-                auto origLayer     = firstPermuteStage->origLayer();
+                auto origLayer     = firstPermuteStage->origNode();
                 model->removeStage(firstPermuteStage);
 
                 if (permuteInput->desc().dims() == permuteOutput->desc().dims()) {

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/merge_relu_and_bias.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/merge_relu_and_bias.cpp
@@ -42,7 +42,7 @@ void PassImpl::run(const Model& model) {
             auto reluOutput = reluStage->output(0);
 
             auto reluStageName = reluStage->name();
-            auto reluOrigLayer = reluStage->origLayer();
+            auto reluOrigLayer = reluStage->origNode();
             auto negativeSlope = reluStage->attrs().get<float>("negativeSlope");
 
             model->removeStage(biasStage);

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/replace_deconv_by_conv.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/replace_deconv_by_conv.cpp
@@ -148,7 +148,7 @@ void PassImpl::run(const Model& model) {
         auto output = stage->output(0);
         const auto& env = CompileEnv::get();
 
-        if (env.config.compileConfig().hwDisabled(stage->origLayer()->name)) {
+        if (env.config.compileConfig().hwDisabled(stage->origNode()->get_friendly_name())) {
             continue;
         }
 
@@ -179,7 +179,7 @@ void PassImpl::run(const Model& model) {
         auto upsampleStage = model->addNewStage<UpsamplingStage>(
                 stage->origLayerName() + "@Upsample",
                 StageType::Upsampling,
-                stage->origLayer(),
+                stage->origNode(),
                 {input},
                 {newOutput});
 
@@ -196,7 +196,7 @@ void PassImpl::run(const Model& model) {
         auto newStage = model->addNewStage<StubStage>(
                 stage->origLayerName() + "@UpsampleConv",
                 StageType::StubConv,
-                stage->origLayer(),
+                stage->origNode(),
                 {newOutput, newWeights, biases, scales},
                 {output});
 

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/replace_fc_by_conv.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/replace_fc_by_conv.cpp
@@ -134,7 +134,7 @@ void PassImpl::run(const Model& model) {
             _stageBuilder->addReshapeStage(
                 model,
                 convInput->name(),
-                stage->origLayer(),
+                stage->origNode(),
                 input,
                 convInput);
         } else {
@@ -147,7 +147,7 @@ void PassImpl::run(const Model& model) {
             _stageBuilder->addReshapeStage(
                 model,
                 reshaped->name(),
-                stage->origLayer(),
+                stage->origNode(),
                 input,
                 reshaped);
 
@@ -160,7 +160,7 @@ void PassImpl::run(const Model& model) {
             _stageBuilder->addPermuteStage(
                 model,
                 permuted->name(),
-                stage->origLayer(),
+                stage->origNode(),
                 reshaped,
                 permuted,
                 DimValues_<Dim>{{Dim::W, Dim::W}, {Dim::H, Dim::C}, {Dim::D, Dim::H}, {Dim::C, Dim::N}, {Dim::N, Dim::D}});
@@ -174,7 +174,7 @@ void PassImpl::run(const Model& model) {
             _stageBuilder->addReshapeStage(
                 model,
                 merged->name(),
-                stage->origLayer(),
+                stage->origNode(),
                 permuted,
                 merged);
 
@@ -191,7 +191,7 @@ void PassImpl::run(const Model& model) {
             _stageBuilder->addReshapeStage(
                 model,
                 convOutput->name(),
-                stage->origLayer(),
+                stage->origNode(),
                 convOutput,
                 output);
         } else {
@@ -204,7 +204,7 @@ void PassImpl::run(const Model& model) {
             _stageBuilder->addReshapeStage(
                 model,
                 reshaped->name(),
-                stage->origLayer(),
+                stage->origNode(),
                 reshaped,
                 output);
 
@@ -217,7 +217,7 @@ void PassImpl::run(const Model& model) {
             _stageBuilder->addPermuteStage(
                 model,
                 permuted->name(),
-                stage->origLayer(),
+                stage->origNode(),
                 permuted,
                 reshaped,
                 DimValues_<Dim>{{Dim::W, Dim::W}, {Dim::H, Dim::D}, {Dim::D, Dim::N}, {Dim::C, Dim::H}, {Dim::N, Dim::C}});
@@ -231,7 +231,7 @@ void PassImpl::run(const Model& model) {
             _stageBuilder->addReshapeStage(
                 model,
                 merged->name(),
-                stage->origLayer(),
+                stage->origNode(),
                 merged,
                 permuted);
 
@@ -250,7 +250,7 @@ void PassImpl::run(const Model& model) {
         auto convStage = model->addNewStage<StubStage>(
             stage->name() + "@fc-to-conv",
             StageType::StubConv,
-            stage->origLayer(),
+            stage->origNode(),
             {convInput, convWeights, biases, scales},
             {convOutput});
         convStage->attrs().copyFrom(stage->attrs());

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/replace_gemm_by_conv.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/replace_gemm_by_conv.cpp
@@ -84,7 +84,7 @@ void PassImpl::run(const Model& model) {
             _stageBuilder->addPermuteStage(
                 model,
                 stage->name() + "@transposeB",
-                stage->origLayer(),
+                stage->origNode(),
                 inputB,
                 inputBTransposed,
                 DimValues_<Dim>{{Dim::N, Dim::N}, {Dim::H, Dim::W}, {Dim::W, Dim::H},   {Dim::D, Dim::D}, {Dim::C, Dim::C}});
@@ -124,21 +124,21 @@ void PassImpl::run(const Model& model) {
             _stageBuilder->addReshapeStage(
                 model,
                 stage->name() + postfix + "@reshapeB",
-                stage->origLayer(),
+                stage->origNode(),
                 subInputsB[batchIndex],
                 convolvedB);
 
             auto convStage = model->addNewStage<StubStage>(
                 stage->origLayerName() + postfix + "@GEMM_HWConv",
                 StageType::StubConv,
-                stage->origLayer(),
+                stage->origNode(),
                 {convolvedB, subInputsA[batchIndex], model->addFakeData(), model->addFakeData()},
                 {convolvedOutput});
 
             _stageBuilder->addReshapeStage(
                 model,
                 stage->name() + postfix + "@reshapeOutput",
-                stage->origLayer(),
+                stage->origNode(),
                 convolvedOutput,
                 subOutputs[batchIndex]);
 
@@ -160,7 +160,7 @@ void PassImpl::run(const Model& model) {
         _stageBuilder->addSplitStage(
             model,
             stage->name() + "@splitA",
-            stage->origLayer(),
+            stage->origNode(),
             Dim::C,
             inputA,
             subInputsA);
@@ -168,7 +168,7 @@ void PassImpl::run(const Model& model) {
         _stageBuilder->addSplitStage(
             model,
             stage->name() + "@splitB",
-            stage->origLayer(),
+            stage->origNode(),
             Dim::C,
             inputB,
             subInputsB);
@@ -176,7 +176,7 @@ void PassImpl::run(const Model& model) {
         _stageBuilder->addConcatStage(
             model,
             stage->name() + "@concat",
-            stage->origLayer(),
+            stage->origNode(),
             Dim::C,
             subOutputs,
             output);

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/replace_priorbox_with_const.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/replace_priorbox_with_const.cpp
@@ -87,7 +87,7 @@ void PassImpl::run(const vpu::Model &model) {
         IE_ASSERT(stage->numInputs() == 2);
         IE_ASSERT(stage->numOutputs() == 1);
 
-        const auto& layer = stage->origLayer();
+        const auto& layer = stage->origNode();
         const auto& input0 = stage->input(0);
         const auto& input1 = stage->input(1);
         const auto& output = stage->output(0);

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/replace_with_reduce_mean.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/replace_with_reduce_mean.cpp
@@ -61,7 +61,7 @@ void PassImpl::run(const Model& model) {
         const bool isGlobalAvgPooling = (isGlobalPoolingOutputFormat && (isOverlapByKernel && (paddingsNotExist || excludePad)));
 
         if (isGlobalAvgPooling) {
-            auto origLayer = stage->origLayer();
+            auto origLayer = stage->origNode();
 
             model->removeStage(stage);
 
@@ -74,7 +74,7 @@ void PassImpl::run(const Model& model) {
                 buffer[1] = numInputDims - 2;
             };
 
-            auto axesData = model->addConstData(origLayer->name + "@axes", DataDesc(DataType::S32, DimsOrder::C, {2}), generator);
+            auto axesData = model->addConstData(origLayer->get_friendly_name() + "@axes", DataDesc(DataType::S32, DimsOrder::C, {2}), generator);
 
             _stageBuilder->addReduceStage(
                     model,

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/replace_with_screlu.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/replace_with_screlu.cpp
@@ -101,7 +101,7 @@ void PassImpl::run(const Model& model) {
         _stageBuilder->addSCReluStage(
                 model,
                 "SCRelu",
-                convolutionStage->origLayer(),
+                convolutionStage->origNode(),
                 negSlope,
                 axis,
                 convStageOut,

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/reshape_conv.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/reshape_conv.cpp
@@ -54,14 +54,15 @@ void PassImpl::run(const Model& model) {
         int resultH = 0;
         int resultW = 0;
 
-        if (stage->origLayer()->params.count("alt_width")) {
-            const auto alt_width = stage->origLayer()->params.at("alt_width");
-            if (!alt_width.empty() &&
-                std::find_if(alt_width.begin(), alt_width.end(),
-                             [](unsigned char c) { return !std::isdigit(c); }) == alt_width.end()) {
-                resultW = std::stoul(alt_width);
-            }
-        }
+        // need to invistigate
+        // if (stage->origLayer()->params.count("alt_width")) {
+        //     const auto alt_width = stage->origLayer()->params.at("alt_width");
+        //     if (!alt_width.empty() &&
+        //         std::find_if(alt_width.begin(), alt_width.end(),
+        //                      [](unsigned char c) { return !std::isdigit(c); }) == alt_width.end()) {
+        //         resultW = std::stoul(alt_width);
+        //     }
+        // }
 
         if (resultW == 0) {
             continue;

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/split_grouped_conv.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/split_grouped_conv.cpp
@@ -232,7 +232,7 @@ void PassImpl::run(const Model& model) {
         _stageBuilder->addSplitStage(
             model,
             stage->name() + "@split",
-            stage->origLayer(),
+            stage->origNode(),
             Dim::C,
             input,
             subInputs);
@@ -240,7 +240,7 @@ void PassImpl::run(const Model& model) {
         _stageBuilder->addConcatStage(
             model,
             stage->name() + "@concat",
-            stage->origLayer(),
+            stage->origNode(),
             Dim::C,
             subOutputs,
             output);

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/split_hw_conv_and_pool.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/split_hw_conv_and_pool.cpp
@@ -235,7 +235,7 @@ void PassImpl::run(const Model& model) {
         _stageBuilder->addConcatStage(
             model,
             poolStage->name() + "@concat",
-            poolStage->origLayer(),
+            poolStage->origNode(),
             Dim::C,
             subOutputs,
             poolOutput);

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/split_hw_depth_convolution.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/split_hw_depth_convolution.cpp
@@ -281,7 +281,7 @@ void PassImpl::run(const Model& model) {
         _stageBuilder->addSplitStage(
             model,
             stage->name() + "@split",
-            stage->origLayer(),
+            stage->origNode(),
             Dim::C,
             input,
             subInputs);
@@ -289,7 +289,7 @@ void PassImpl::run(const Model& model) {
         _stageBuilder->addConcatStage(
             model,
             stage->name() + "@concat",
-            stage->origLayer(),
+            stage->origNode(),
             Dim::C,
             subOutputs,
             output);

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/split_large_kernel_conv.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/split_large_kernel_conv.cpp
@@ -87,7 +87,7 @@ void PassImpl::run(const Model& model) {
             _stageBuilder->addCropStage(
                     model,
                     stage->name() + postfix,
-                    stage->origLayer(),
+                    stage->origNode(),
                     input,
                     subInputs[groupInd],
                     std::move(offsets));
@@ -145,7 +145,7 @@ void PassImpl::run(const Model& model) {
         _stageBuilder->addSumStage(
             model,
             stage->name() + "@sum",
-            stage->origLayer(),
+            stage->origNode(),
             subOutputs[0],
             subOutputs[1],
             output);

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/sw_conv_adaptation.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/sw_conv_adaptation.cpp
@@ -255,7 +255,7 @@ void PassImpl::run(const Model& model) {
             continue;
 
         auto origStageName = stage->name();
-        auto origLayer = stage->origLayer();
+        auto origNode = stage->origNode();
 
         auto input = stage->input(0);
         auto weights = stage->input(1);
@@ -315,7 +315,7 @@ void PassImpl::run(const Model& model) {
                 _stageBuilder->addSwFullyConnectedStage(
                     model,
                     origStageName,
-                    origLayer,
+                    origNode,
                     input,
                     weights,
                     biases,
@@ -327,7 +327,7 @@ void PassImpl::run(const Model& model) {
                     swStage = model->addNewStage<ConvStage>(
                         origStageName,
                         StageType::Conv,
-                        origLayer,
+                        origNode,
                         {input, weights},
                         {output});
                 } else {
@@ -338,7 +338,7 @@ void PassImpl::run(const Model& model) {
 #else
                         StageType::Im2ColConvolution,
 #endif
-                        origLayer,
+                        origNode,
                         {input, weights},
                         {output});
                 }
@@ -372,7 +372,7 @@ void PassImpl::run(const Model& model) {
                     _stageBuilder->addBiasStage(
                         model,
                         origStageName + "@biases",
-                        origLayer,
+                        origNode,
                         biasesInput, biases,
                         output);
                 }
@@ -388,7 +388,7 @@ void PassImpl::run(const Model& model) {
                     _stageBuilder->addScaleStage(
                         model,
                         origStageName + "@scales",
-                        origLayer,
+                        origNode,
                         scalesInput, scales,
                         output);
                 }
@@ -398,7 +398,7 @@ void PassImpl::run(const Model& model) {
             auto swStage = model->addNewStage<ConvStage>(
                 origStageName,
                 StageType::DepthConv,
-                origLayer,
+                origNode,
                 {input, weights},
                 {output});
 
@@ -427,7 +427,7 @@ void PassImpl::run(const Model& model) {
                 _stageBuilder->addBiasStage(
                     model,
                     origStageName + "@biases",
-                    origLayer,
+                    origNode,
                     biasesInput, biases,
                     output);
             }
@@ -443,7 +443,7 @@ void PassImpl::run(const Model& model) {
                 _stageBuilder->addScaleStage(
                     model,
                     origStageName + "@scales",
-                    origLayer,
+                    origNode,
                     scalesInput, scales,
                     output);
             }

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/sw_deconv_adaptation.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/sw_deconv_adaptation.cpp
@@ -242,7 +242,7 @@ void PassImpl::run(const Model& model) {
             auto swStage = model->addNewStage<DeconvStage>(
                 stage->name(),
                 StageType::Deconvolution,
-                stage->origLayer(),
+                stage->origNode(),
                 {input, weights},
                 {output});
 
@@ -268,7 +268,7 @@ void PassImpl::run(const Model& model) {
                 _stageBuilder->addBiasStage(
                     model,
                     stage->name() + "@biases",
-                    stage->origLayer(),
+                    stage->origNode(),
                     biasesInput, biases,
                     output);
             }
@@ -284,7 +284,7 @@ void PassImpl::run(const Model& model) {
                 _stageBuilder->addScaleStage(
                     model,
                     stage->name() + "@scales",
-                    stage->origLayer(),
+                    stage->origNode(),
                     scalesInput, scales,
                     output);
             }
@@ -293,7 +293,7 @@ void PassImpl::run(const Model& model) {
             auto swStage = model->addNewStage<DeconvStage>(
                 stage->name(),
                 StageType::DepthDeconv,
-                stage->origLayer(),
+                stage->origNode(),
                 {input, weights},
                 {output});
 
@@ -319,7 +319,7 @@ void PassImpl::run(const Model& model) {
                 _stageBuilder->addBiasStage(
                     model,
                     stage->name() + "@biases",
-                    stage->origLayer(),
+                    stage->origNode(),
                     biasesInput, biases,
                     output);
             }
@@ -335,7 +335,7 @@ void PassImpl::run(const Model& model) {
                 _stageBuilder->addScaleStage(
                     model,
                     stage->name() + "@scales",
-                    stage->origLayer(),
+                    stage->origNode(),
                     scalesInput, scales,
                     output);
             }

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/sw_fc_adaptation.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/sw_fc_adaptation.cpp
@@ -108,7 +108,7 @@ void PassImpl::run(const Model& model) {
         model->addNewStage<FullyConnectedStage>(
             stage->name(),
             StageType::FC,
-            stage->origLayer(),
+            stage->origNode(),
             {input, weights},
             {output});
 
@@ -123,7 +123,7 @@ void PassImpl::run(const Model& model) {
             _stageBuilder->addBiasStage(
                 model,
                 stage->name() + "@biases",
-                stage->origLayer(),
+                stage->origNode(),
                 biasesInput, biases,
                 output);
         }
@@ -139,7 +139,7 @@ void PassImpl::run(const Model& model) {
             _stageBuilder->addScaleStage(
                 model,
                 stage->name() + "@scales",
-                stage->origLayer(),
+                stage->origNode(),
                 scalesInput, scales,
                 output);
         }
@@ -157,7 +157,7 @@ Pass::Ptr PassManager::swFullyConnectedAdaptation() {
 Stage StageBuilder::addSwFullyConnectedStage(
         const Model& model,
         const std::string& name,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         const Data& input,
         const Data& weights,
         const Data& biases,
@@ -174,7 +174,7 @@ Stage StageBuilder::addSwFullyConnectedStage(
     auto fcStage = model->addNewStage<FullyConnectedStage>(
         name,
         StageType::FC,
-        layer,
+        node,
         {input, fcWeights},
         {output});
 
@@ -189,7 +189,7 @@ Stage StageBuilder::addSwFullyConnectedStage(
         addBiasStage(
             model,
             name + "@biases",
-            layer,
+            node,
             biasesInput, biases,
             output);
     }
@@ -205,7 +205,7 @@ Stage StageBuilder::addSwFullyConnectedStage(
         addScaleStage(
             model,
             name + "@scales",
-            layer,
+            node,
             scalesInput, scales,
             output);
     }

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/sw_pooling_adaptation.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/sw_pooling_adaptation.cpp
@@ -131,7 +131,7 @@ void PassImpl::run(const Model& model) {
         auto swStage = model->addNewStage<PoolStage>(
             stage->name(),
             stageType,
-            stage->origLayer(),
+            stage->origNode(),
             {input},
             {output});
 

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/passes/weights_analysis.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/passes/weights_analysis.cpp
@@ -217,16 +217,17 @@ void PassImpl::run(const Model& model) {
 
     bool firstStage = true;
     int  normalVal  = 0;
-    const auto& env = CompileEnv::get();
+    // const auto& env = CompileEnv::get();
 
     for (const auto& stage : model->getStages()) {
         if (!isScalable(stage)) {
             continue;
         }
-        IE_ASSERT(stage->origLayer() != nullptr);
+        IE_ASSERT(stage->origNode() != nullptr);
 
         // Get scale from IR, compute if it was absent
-        auto scale = stage->origLayer()->GetParamAsFloat("vpu_scale", 0);
+        // auto scale = stage->origNode()->GetParamAsFloat("vpu_scale", 0); looks unused
+        auto scale = 0.f;
         if (!scale) {
             auto weights = stage->input(1);
 
@@ -248,7 +249,7 @@ void PassImpl::run(const Model& model) {
                 if (firstStage && shift < 4 && isGrowingOutput && weights->desc().dim(Dim::C) > 1) {
                     normalVal = 5;
                 }
-                shift = correctShift(shift, firstStage, stage->origLayer()->type);
+                shift = correctShift(shift, firstStage, stage->origNode()->get_type_name());
                 shift -= normalVal;
             }
 
@@ -257,10 +258,10 @@ void PassImpl::run(const Model& model) {
             if (shift >= scaleThreshold) {
                 scale = static_cast<float>(1ULL << static_cast<std::uint32_t>(shift));
             }
-
-            if (!env.config.compileConfig().irWithVpuScalesDir.empty()) {
-                stage->origLayer()->params["vpu_scale"] = toString(scale);
-            }
+            // should be removed
+            // if (!env.config.compileConfig().irWithVpuScalesDir.empty()) {
+            //     stage->origNode()->params["vpu_scale"] = toString(scale);
+            // }
         }
         scaleWeightableStage(model, stage, scale);
     }

--- a/inference-engine/src/vpu/graph_transformer/src/middleend/special_stage_processor.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/middleend/special_stage_processor.cpp
@@ -155,7 +155,7 @@ Data insertCopyOfInput(const Model& model,
     auto copyStage = _stageBuilder->addCopyStage(
             model,
             formatString("%s%s@copy-for-%s", stage->name(), inputNumStr, typeAsString),
-            stage->origLayer(),
+            stage->origNode(),
             data,
             copy,
             formatString("special::%s", typeAsString));
@@ -189,7 +189,7 @@ Data insertCopyOfOutput(const Model& model,
     auto copyStage = _stageBuilder->addCopyStage(
             model,
             formatString("%s%s@copy-for-%s", stage->name(), outputNumStr, typeAsString),
-            stage->origLayer(),
+            stage->origNode(),
             copy,
             data,
             formatString("special::%s", typeAsString));
@@ -252,7 +252,6 @@ void SpecialStageProcessor::processConcat(
 
     const auto& offsets = stage->attrs().get<std::vector<DimValues>>("offsets");
     IE_ASSERT(offsets.size() == checked_cast<size_t>(stage->numInputs()));
-
     for (const auto& inEdge : stage->inputEdges()) {
         IE_ASSERT(inEdge->portInd() >= 0);
         IE_ASSERT(checked_cast<size_t>(inEdge->portInd()) < offsets.size());

--- a/inference-engine/src/vpu/graph_transformer/src/model/data_contents/priorbox_contents.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/model/data_contents/priorbox_contents.cpp
@@ -20,10 +20,10 @@ PriorBoxContent::PriorBoxContent(
         const DataDesc& inDesc0,
         const DataDesc& inDesc1,
         const DataDesc& outDesc,
-        const ie::CNNLayerPtr &layer) :
+        const NodePtr &node) :
         _inDesc0(inDesc0), _inDesc1(inDesc1), _outDesc(outDesc),
-        _layer(layer) {
-    IE_ASSERT(layer != nullptr);
+        _node(node) {
+    IE_ASSERT(node != nullptr);
 }
 
 size_t PriorBoxContent::byteSize() const {
@@ -35,22 +35,29 @@ void PriorBoxContent::fillTempBuf(void* tempBuf) const {
     VPU_PROFILE(PriorBoxContent);
 
     auto tempPtr = static_cast<fp16_t*>(tempBuf);
+    auto priorBox = ngraph::as_type_ptr<ngraph::opset4::PriorBox>(_node);
+    IE_ASSERT(priorBox != nullptr);
+    auto attrs = priorBox->get_attrs();
+    auto _min_sizes = attrs.min_size;
+    auto _max_sizes = attrs.max_size;
+    auto aspect_ratios = attrs.aspect_ratio;
+    auto _flip = attrs.flip;
+    auto _clip = attrs.clip;
+    auto _variance = attrs.variance;
+    // TODO: rework logic
+    auto imgPartShape = priorBox->get_input_partial_shape(1);
+    VPU_THROW_UNLESS(!imgPartShape.is_dynamic(),"Dynamic 1-port input of PriorBox is not supported");
+    auto imgShape = imgPartShape.to_shape();
+    auto _img_h = imgShape[2]; // attrs. _layer->GetParamAsInt("img_h", 0);
+    auto _img_w = imgShape[3]; //_layer->GetParamAsInt("img_w", 0);
+    //
+    auto _step = attrs.step;
+    auto _offset = attrs.offset;
+    auto _scale_all_sizes = attrs.scale_all_sizes; // static_cast<bool>(_layer->GetParamAsInt("scale_all_sizes", 1));
 
-    auto _min_sizes = _layer->GetParamAsFloats("min_size", {});
-    auto _max_sizes = _layer->GetParamAsFloats("max_size", {});
-    auto aspect_ratios = _layer->GetParamAsFloats("aspect_ratio");
-    auto _flip = static_cast<bool>(_layer->GetParamAsInt("flip"));
-    auto _clip = static_cast<bool>(_layer->GetParamAsInt("clip"));
-    auto _variance = _layer->GetParamAsFloats("variance");
-    auto _img_h = _layer->GetParamAsInt("img_h", 0);
-    auto _img_w = _layer->GetParamAsInt("img_w", 0);
-    auto _step = _layer->GetParamAsFloat("step", 0);
-    auto _offset = _layer->GetParamAsFloat("offset", 0);
-    auto _scale_all_sizes = static_cast<bool>(_layer->GetParamAsInt("scale_all_sizes", 1));
-
-    auto _fixed_sizes = _layer->GetParamAsFloats("fixed_size", {});
-    auto _fixed_ratios = _layer->GetParamAsFloats("fixed_ratio", {});
-    auto _densitys = _layer->GetParamAsFloats("density", {});
+    auto _fixed_sizes = attrs.fixed_size; // _layer->GetParamAsFloats("fixed_size", {});
+    auto _fixed_ratios = attrs.fixed_ratio; // _layer->GetParamAsFloats("fixed_ratio", {});
+    auto _densitys = attrs.density; //  _layer->GetParamAsFloats("density", {});
 
     SmallVector<float> _aspect_ratios;
     _aspect_ratios.reserve(aspect_ratios.size() + 1);
@@ -133,7 +140,7 @@ void PriorBoxContent::fillTempBuf(void* tempBuf) const {
     if (_outDesc.dim(Dim::W) != dim || _outDesc.dim(Dim::H) != 2) {
         IE_THROW() << "[VPU] PriorBox output have invalid dimension, exptected " << dim << "x2"
                            << ", got " << _outDesc.dim(Dim::W) << "x" << _outDesc.dim(Dim::H)
-                           << ", layer name is: " << _layer->name;
+                           << ", layer name is: " << _node->get_friendly_name();
     }
 
     auto max_fp16 = [](const float value, const float min) {
@@ -287,10 +294,10 @@ PriorBoxClusteredContent::PriorBoxClusteredContent(
         const DataDesc& inDesc0,
         const DataDesc& inDesc1,
         const DataDesc& outDesc,
-        const ie::CNNLayerPtr& layer) :
+        const NodePtr& node) :
         _inDesc0(inDesc0), _inDesc1(inDesc1), _outDesc(outDesc),
-        _layer(layer) {
-    IE_ASSERT(layer != nullptr);
+        _node(node) {
+    IE_ASSERT(node != nullptr);
 }
 
 size_t PriorBoxClusteredContent::byteSize() const {
@@ -301,24 +308,27 @@ size_t PriorBoxClusteredContent::byteSize() const {
 void PriorBoxClusteredContent::fillTempBuf(void* tempBuf) const {
     VPU_PROFILE(PriorBoxClusteredContent);
 
+    auto priorBoxClustered = ngraph::as_type_ptr<ngraph::opset4::PriorBoxClustered>(_node);
+    VPU_THROW_UNLESS(priorBoxClustered != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", _node->get_friendly_name(), _node->get_type_name());
     auto tempPtr = static_cast<fp16_t*>(tempBuf);
-
-    auto widths_ = _layer->GetParamAsFloats("width");
-    auto heights_ = _layer->GetParamAsFloats("height");
-    auto clip_ = _layer->GetParamAsInt("clip");
-    auto variance_ = _layer->GetParamAsFloats("variance");
-    auto img_h_ = _layer->GetParamAsInt("img_h", 0);
-    auto img_w_ = _layer->GetParamAsInt("img_w", 0);
-    auto step_ = _layer->GetParamAsFloat("step", 0);
-    auto step_h_ = _layer->GetParamAsFloat("step_h", 0);
-    auto step_w_ = _layer->GetParamAsFloat("step_w", 0);
-    auto offset_ = _layer->GetParamAsFloat("offset", 0);
+    auto attrs = priorBoxClustered->get_attrs();
+    auto widths_ = attrs.widths; // priorBoxClustered->get_a _layer->GetParamAsFloats("width");
+    auto heights_ = attrs.heights; // _layer->GetParamAsFloats("height");
+    auto clip_ = attrs.clip; // _layer->GetParamAsInt("clip");
+    auto variance_ = attrs.variances; // = ->GetParamAsFloats("variance");
+    // TODO: rework logic
+    auto imgPartShape = priorBoxClustered->get_input_partial_shape(1);
+    VPU_THROW_UNLESS(!imgPartShape.is_dynamic(),"Dynamic 1-port input of PriorBox is not supported");
+    auto imgShape = imgPartShape.to_shape();
+    auto img_h_ = imgShape[2]; // _layer->GetParamAsInt("img_h", 0);
+    auto img_w_ = imgShape[3]; //_layer->GetParamAsInt("img_w", 0);
+    //
+    auto step_h_ = attrs.step_heights; // _layer->GetParamAsFloat("step_h", 0);
+    auto step_w_ = attrs.step_widths; // _layer->GetParamAsFloat("step_w", 0);
+    auto step_ = (std::abs(step_h_ - step_w_) < 1e-5)  ? step_w_ : 0; // = res->params["step_w"];_layer->GetParamAsFloat("step", 0);
+    auto offset_ = attrs.offset; // _layer->GetParamAsFloat("offset", 0);
 
     auto num_priors_ = widths_.size();
-
-    if (variance_.empty()) {
-        variance_.push_back(0.1f);
-    }
 
     auto layer_width  = _inDesc0.dim(Dim::W);
     auto layer_height = _inDesc0.dim(Dim::H);
@@ -336,7 +346,7 @@ void PriorBoxClusteredContent::fillTempBuf(void* tempBuf) const {
     auto expetected_output_dimx = layer_height * layer_width * num_priors_ * 4;
     if (_outDesc.dim(Dim::W) != expetected_output_dimx || _outDesc.dim(Dim::H) != 2) {
         IE_THROW() << "PriorBoxClustered output has invalid dimension, exptected " << expetected_output_dimx << "x2"
-                           << ", got " << _outDesc.dim(Dim::W) << "x" << _outDesc.dim(Dim::H) << ", layer name is: " << _layer->name;
+                           << ", got " << _outDesc.dim(Dim::W) << "x" << _outDesc.dim(Dim::H) << ", layer name is: " << _node->get_friendly_name();
     }
 
     auto offset = _outDesc.dim(Dim::W);

--- a/inference-engine/src/vpu/graph_transformer/src/model/data_desc.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/model/data_desc.cpp
@@ -355,6 +355,18 @@ DataDesc::DataDesc(DataType type, DimsOrder dimsOrder, const DimValues& dims) :
     }
 }
 
+DataDesc::DataDesc(const ngraph::descriptor::Tensor& ngraphDesc) {
+    _type = fromIEPrecision(ie::details::convertPrecision(ngraphDesc.get_element_type()));
+    ngraphDesc.get_shape();
+
+    const auto& ieDims = ngraphDesc.get_shape().empty() ? ie::SizeVector{1} : static_cast<std::vector<size_t>>(ngraphDesc.get_shape());
+    _dimsOrder = DimsOrder::fromNumDims(ngraphDesc.get_shape().size());
+    const auto perm = DimsOrder::fromNumDims(ieDims.size()).toPermutation();
+    for (size_t i = 0; i < perm.size(); ++i) {
+        _dims.set(perm[i], static_cast<int>(ieDims[ieDims.size() - 1 - i]));
+    }
+}
+
 int DataDesc::elemSize() const {
     switch (_type) {
     case DataType::U8:

--- a/inference-engine/src/vpu/graph_transformer/src/model/model.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/model/model.cpp
@@ -193,7 +193,8 @@ Data ModelObj::duplicateData(
 
     if (newDataUsage == DataUsage::Const) {
         const auto& content = newContent != nullptr ? newContent : origData->content();
-        const auto& desc = newDesc != DataDesc() ? newDesc : origData->desc();
+        const auto& desc = newDesc != DataDesc() ? newDesc 
+                                                 : origData->desc();
 
         VPU_THROW_UNLESS(desc.totalDimSize() * desc.elemSize() == content->byteSize(),
             "duplicateData error: while duplicating {} Const data got different "
@@ -259,7 +260,7 @@ Stage ModelObj::duplicateStage(
     stage->_name      = origStage->name() + postfix;
     stage->_id        = _stagesIdCount++;
     stage->_type      = origStage->_type;
-    stage->_origLayer = origStage->_origLayer;
+    stage->_origNode  = origStage->_origNode;
     stage->_model     = this;
 
     _initialStages.emplace(stage);
@@ -2082,7 +2083,7 @@ void ModelObj::runDFS(
 Stage ModelObj::addNewStageImpl(
     const std::string& name,
     StageType type,
-    const ie::CNNLayerPtr& origLayer,
+    const NodePtr& origNode,
     const DataVector& inputs,
     const DataVector& outputs,
     const FuncRef<StagePtr()>& creator) {
@@ -2122,7 +2123,7 @@ Stage ModelObj::addNewStageImpl(
     stage->_name      = name;
     stage->_id        = _stagesIdCount++;
     stage->_type      = type;
-    stage->_origLayer = origLayer;
+    stage->_origNode  = origNode;
     stage->_model     = this;
 
     for (const auto& input : inputs) {

--- a/inference-engine/src/vpu/graph_transformer/src/stages/activation.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/activation.cpp
@@ -1,33 +1,35 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
 
-#include <vpu/frontend/frontend.hpp>
+// #include <vpu/frontend/frontend.hpp>
 
-using namespace InferenceEngine;
+// using namespace InferenceEngine;
 
-namespace vpu {
+// namespace vpu {
+//     //parse eltwise 
 
-void FrontEnd::parseLogicalNot(const Model &model, const ie::CNNLayerPtr &layer, const DataVector &inputs, const DataVector &outputs) const {
-    LayerParams params = {layer->name, "Eltwise", layer->precision};
-    auto res = std::make_shared<InferenceEngine::EltwiseLayer>(params);
-    res->_operation = InferenceEngine::EltwiseLayer::Logical_NOT;
+// void FrontEnd::parseLogicalNot(const Model &model, const NodePtr& node, const DataVector &inputs, const DataVector &outputs) const {
+//     // LayerParams params = {layer->name, "Eltwise", layer->precision};
+//     // auto res = std::make_shared<InferenceEngine::EltwiseLayer>(params);
+//     // res->_operation = InferenceEngine::EltwiseLayer::Logical_NOT;
 
-    parseEltwise(model, res, inputs, outputs);
-}
+//     // parseEltwise(model, res, inputs, outputs);
+// }
 
-void FrontEnd::parseActivation(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
-    const ie::details::caseless_map<std::string, LayerParser> activationParsers {
-        {"not", LAYER_PARSER(parseLogicalNot)},
-    };
+// void FrontEnd::parseActivation(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+//     // const ie::details::caseless_map<std::string, LayerParser> activationParsers {
+//     //     {"not", LAYER_PARSER(parseLogicalNot)},
+//     // };
 
-    const auto type = layer->GetParamAsString("type");
+//     // const auto type = layer->GetParamAsString("type");
 
-    const auto activationParserIt = activationParsers.find(type);
-    VPU_THROW_UNSUPPORTED_LAYER_UNLESS(activationParserIt != activationParsers.end(),
-                                 "Failed to compile layer \"%v\"(type = %v) ", layer->name, type);
+//     // const auto activationParserIt = activationParsers.find(type);
+//     // VPU_THROW_UNSUPPORTED_LAYER_UNLESS(activationParserIt != activationParsers.end(),
+//     //                              "Failed to compile layer \"%v\"(type = %v) ", layer->name, type);
 
-    activationParserIt->second(model, layer, inputs, outputs);
-}
 
-} // namespace vpu
+//     // activationParserIt->second(model, layer, inputs, outputs);
+// }
+
+// } // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/batch_norm.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/batch_norm.cpp
@@ -17,36 +17,37 @@
 
 namespace vpu {
 
-void FrontEnd::parseBatchNorm(const Model& model, const ie::CNNLayerPtr& _layer, const DataVector& inputs, const DataVector& outputs) const {
-    IE_ASSERT(inputs.size() == 1);
-    IE_ASSERT(outputs.size() == 1);
+// void FrontEnd::parseBatchNorm(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+//     IE_ASSERT(inputs.size() == 1);
+//     IE_ASSERT(outputs.size() == 1);
 
-    auto layer = std::dynamic_pointer_cast<ie::BatchNormalizationLayer>(_layer);
-    IE_ASSERT(layer != nullptr);
+//     const auto& batchNorm = ngraph::as_type_ptr<ngraph::opset4::BatchNormInference>(node);
+//     VPU_THROW_UNLESS(batchNorm != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", batchNorm->get_friendly_name(), batchNorm->get_type_name());
 
-    auto input = inputs[0];
-    auto output = outputs[0];
+//     auto input = inputs[0];
+//     auto output = outputs[0];
 
-    Data origWeights, origBiases;
-    std::tie(origWeights, origBiases) = getWeightsAndBiases(model, layer);
+//     Data origWeights, origBiases;
+    
+//     std::tie(origWeights, origBiases) = getWeightsAndBiases(model, batchNorm);
 
-    IE_ASSERT(origWeights->desc().totalDimSize() >= input->desc().dim(Dim::C));
-    auto weights = model->duplicateData(origWeights, "@batch-norm", DataDesc({input->desc().dim(Dim::C)}),
-        std::make_shared<BatchNormalizationWeightsContent>(origWeights->content(), layer->epsilon));
+//     IE_ASSERT(origWeights->desc().totalDimSize() >= input->desc().dim(Dim::C));
+//     auto weights = model->duplicateData(origWeights, "@batch-norm", DataDesc({input->desc().dim(Dim::C)}),
+//         std::make_shared<BatchNormalizationWeightsContent>(origWeights->content(), batchNorm->get_eps_value()));
 
-    if (origBiases->usage() != DataUsage::Fake) {
-        IE_ASSERT(origBiases->desc().totalDimSize() >= input->desc().dim(Dim::C));
-        auto biases = model->duplicateData(origBiases, "@batch-norm", DataDesc({input->desc().dim(Dim::C)}),
-            std::make_shared<BatchNormalizationBiasesContent>(origBiases->content(), weights->content()));
+//     if (origBiases->usage() != DataUsage::Fake) {
+//         IE_ASSERT(origBiases->desc().totalDimSize() >= input->desc().dim(Dim::C));
+//         auto biases = model->duplicateData(origBiases, "@batch-norm", DataDesc({input->desc().dim(Dim::C)}),
+//             std::make_shared<BatchNormalizationBiasesContent>(origBiases->content(), weights->content()));
 
-        auto tempOutput = model->duplicateData(output, "@temp");
+//         auto tempOutput = model->duplicateData(output, "@temp");
 
-        _stageBuilder->addBiasStage(model, layer->name, layer, tempOutput, biases, output);
+//         _stageBuilder->addBiasStage(model, batchNorm->get_friendly_name(), batchNorm, tempOutput, biases, output);
 
-        output = tempOutput;
-    }
+//         output = tempOutput;
+//     }
 
-    _stageBuilder->addScaleStage(model, layer->name, layer, input, weights, output);
-}
+//     _stageBuilder->addScaleStage(model, batchNorm->get_friendly_name(), batchNorm, input, weights, output);
+// }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/bias.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/bias.cpp
@@ -11,16 +11,16 @@
 
 namespace vpu {
 
-void FrontEnd::parseBias(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
-    IE_ASSERT(inputs.size() == 2);
-    IE_ASSERT(outputs.size() == 1);
+// void FrontEnd::parseBias(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    // IE_ASSERT(inputs.size() == 2);
+    // IE_ASSERT(outputs.size() == 1);
 
-    auto input = inputs[0];
-    auto biases = inputs[1];
-    auto output = outputs[0];
+    // auto input = inputs[0];
+    // auto biases = inputs[1];
+    // auto output = outputs[0];
 
-    _stageBuilder->addBiasStage(model, layer->name, layer, input, biases, output);
-}
+    // _stageBuilder->addBiasStage(model, node->get_friendly_name(), node, input, biases, output);
+// }
 
 namespace {
 class BiasStage final : public PostOpStage {
@@ -41,14 +41,14 @@ protected:
 Stage StageBuilder::addBiasStage(
         const Model& model,
         const std::string& name,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         const Data& input,
         const Data& biases,
         const Data& output) {
     return model->addNewStage<BiasStage>(
         name,
         StageType::Bias,
-        layer,
+        node,
         {input, biases},
         {output});
 }

--- a/inference-engine/src/vpu/graph_transformer/src/stages/broadcast.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/broadcast.cpp
@@ -95,19 +95,36 @@ protected:
 };
 
 }  // namespace
+static std::string getModeAsString(const ngraph::op::BroadcastType mode) {
 
+    switch (mode)
+    {
+    case ngraph::op::BroadcastType::EXPLICIT :
+        return "explicit";
+    case ngraph::op::BroadcastType::BIDIRECTIONAL :
+        return "bidirectional";
+    case ngraph::op::BroadcastType::PDPD :
+        return "pdpd";
+    case ngraph::op::BroadcastType::NUMPY :
+        return "numpy";
+    default:
+        return "";
+    }
+}
 void FrontEnd::parseBroadcast(
         const Model& model,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         const DataVector& inputs,
         const DataVector& outputs) const {
-    VPU_THROW_UNLESS(layer != nullptr,
-                     "parseBroadcast expects valid CNNLayerPtr, got nullptr");
+    auto broadcast = ngraph::as_type_ptr<ngraph::opset4::Broadcast>(node);
+    VPU_THROW_UNLESS(broadcast != nullptr,
+                     "parseBroadcast expects valid NodePtr, got nullptr");
     VPU_THROW_UNLESS(outputs.size() == 1,
                      "{} layer with name {} must have only 1 output, actually provided {} outputs",
-                     layer->type, layer->name, outputs.size());
+                     broadcast->get_type_name(), broadcast->get_friendly_name(), outputs.size());
     const auto output = outputs[0];
-    const auto modeString = layer->GetParamAsString("mode", "numpy");
+    const auto broadcastMode =  broadcast->get_broadcast_spec().m_type;
+    std::string modeString = getModeAsString(broadcastMode);
     const std::map<std::string, BroadcastMode> modeFromString = {
         {"numpy", BroadcastMode::NUMPY},
         {"explicit", BroadcastMode::EXPLICIT},
@@ -116,31 +133,31 @@ void FrontEnd::parseBroadcast(
     const auto& modeFind = modeFromString.find(modeString);
     VPU_THROW_UNLESS(modeFind != modeFromString.end(),
                      "{} layer with name {}: Graph Transformer doesn't support {} mode",
-                     layer->type, layer->name, modeString);
+                     node->get_type_name(), node->get_friendly_name(), modeString);
     const auto mode = modeFind->second;
     if (mode == BroadcastMode::NUMPY || mode == BroadcastMode::BIDIRECTIONAL) {
         VPU_THROW_UNLESS(inputs.size() == 2,
                          "{} layer with name {} and {} mode must have 2 inputs, actually "
-                         "provided {} inputs", layer->type, layer->name, modeString, inputs.size());
+                         "provided {} inputs", node->get_type_name(), node->get_friendly_name(), modeString, inputs.size());
     } else if (mode == BroadcastMode::EXPLICIT) {
         VPU_THROW_UNLESS(inputs.size() == 3,
                          "{} layer with name {} and explicit mode must have 3 inputs, actually "
-                         "provided {} inputs", layer->type, layer->name, inputs.size());
+                         "provided {} inputs", node->get_type_name(), node->get_friendly_name(), inputs.size());
         const auto axesMappingDesc = inputs[2]->desc();
         const auto axesMappingPerm = axesMappingDesc.dimsOrder().toPermutation();
         const auto axesMappingDim = axesMappingDesc.dim(axesMappingPerm.at(0));
         VPU_THROW_UNLESS(axesMappingDesc.numDims() == 1,
                          "{} layer with name {} and explicit mode must have 1D axesMapping tensor, "
                          "actually provided {}D tensor",
-                         layer->type, layer->name, axesMappingDesc.numDims());
+                         node->get_type_name(), node->get_friendly_name(), axesMappingDesc.numDims());
         VPU_THROW_UNLESS(axesMappingDim == inputs[0]->desc().numDims(),
                          "{} layer with name {} and explicit mode must have axesMapping tensor with "
                          "size equals to number of output dims, expected [{}], provided [{}]",
-                         layer->type, layer->name, output->desc().numDims(), axesMappingDim);
+                         node->get_type_name(), node->get_friendly_name(), output->desc().numDims(), axesMappingDim);
 
     } else {
         VPU_THROW_FORMAT("{} layer with name {}: Graph Transformer doesn't support {} mode",
-                         layer->type, layer->name, modeString);
+                         node->get_type_name(), node->get_friendly_name(), modeString);
     }
 
     const auto shape = inputs[1];
@@ -149,16 +166,16 @@ void FrontEnd::parseBroadcast(
     VPU_THROW_UNLESS(shapeDesc.numDims() == 1,
                      "{} layer with name {} and explicit mode must have 1D target shape tensor, "
                      "actually provided {}D tensor",
-                     layer->type, layer->name, shapeDesc.numDims());
+                     node->get_type_name(), node->get_friendly_name(), shapeDesc.numDims());
     VPU_THROW_UNLESS(shapeDim == output->desc().numDims() || mode != BroadcastMode::EXPLICIT,
                      "{} layer with name {} and explicit mode must have target shape tensor with "
                      "size equals to number of output dims, expected [{}], provided [{}]",
-                     layer->type, layer->name, output->desc().numDims(), shapeDim);
+                     node->get_type_name(), node->get_friendly_name(), output->desc().numDims(), shapeDim);
 
     auto stage = model->addNewStage<BroadcastStage>(
-            layer->name,
+            node->get_friendly_name(),
             StageType::Broadcast,
-            layer,
+            node,
             inputs,
             outputs);
 

--- a/inference-engine/src/vpu/graph_transformer/src/stages/ceiling.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/ceiling.cpp
@@ -28,16 +28,16 @@ private:
 
 }  // namespace
 
-void FrontEnd::parseCeiling(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parseCeiling(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
     VPU_THROW_UNLESS(inputs.size() == 1,
                      "Ceiling stage with name {} must have only 1 input, actually provided {} inputs",
-                     layer->name, inputs.size());
+                     node->get_friendly_name(), inputs.size());
 
     VPU_THROW_UNLESS(outputs.size() == 1,
                      "Ceiling stage with name {} must have only 1 output, actually provided {} outputs",
-                     layer->name, outputs.size());
+                     node->get_friendly_name(), outputs.size());
 
-    model->addNewStage<CeilingStage>(layer->name, StageType::Ceiling, layer, inputs, outputs);
+    model->addNewStage<CeilingStage>(node->get_friendly_name(), StageType::Ceiling, node, inputs, outputs);
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/clamp.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/clamp.cpp
@@ -35,20 +35,19 @@ protected:
 
 }  // namespace
 
-void FrontEnd::parseClamp(const Model& model, const ie::CNNLayerPtr& _layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parseClamp(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
     IE_ASSERT(inputs.size() == 1);
     IE_ASSERT(outputs.size() == 1);
+    const auto& clamp = ngraph::as_type_ptr<ngraph::opset4::Clamp>(node);
+    VPU_THROW_UNLESS(clamp != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
 
-    auto layer = std::dynamic_pointer_cast<ie::ClampLayer>(_layer);
-    IE_ASSERT(layer != nullptr);
-
-    _stageBuilder->addClampStage(model, layer->name, layer, layer->min_value,  layer->max_value, inputs[0], outputs[0]);
+    _stageBuilder->addClampStage(model, clamp->get_friendly_name(), clamp, clamp->get_min(),  clamp->get_max(), inputs[0], outputs[0]);
 }
 
 Stage StageBuilder::addClampStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             float min,
             float max,
             const Data& input,
@@ -56,7 +55,7 @@ Stage StageBuilder::addClampStage(
         auto stage = model->addNewStage<ClampStage>(
                 name,
                 StageType::Clamp,
-                layer,
+                node,
                 {input},
                 {output});
 

--- a/inference-engine/src/vpu/graph_transformer/src/stages/concat.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/concat.cpp
@@ -263,51 +263,45 @@ protected:
 
 void FrontEnd::parseConcat(
         const Model& model,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         const DataVector& inputs,
         const DataVector& outputs) const {
+    auto concat = ngraph::as_type_ptr<ngraph::opset4::Concat>(node);
     VPU_THROW_UNLESS(!inputs.empty(),
                      "{} layer with name {} must have no less than 1 input, "
-                     "actually provided 0 inputs", layer->type, layer->name);
+                     "actually provided 0 inputs", concat->get_type_name(), concat->get_friendly_name());
     VPU_THROW_UNLESS(outputs.size() == 1,
                      "{} layer with name {} must have only 1 output, actually provided {} outputs",
-                     layer->type, layer->name, outputs.size());
+                     concat->get_type_name(), concat->get_friendly_name(), outputs.size());
 
     auto output = outputs[0];
 
-    VPU_THROW_UNLESS(layer != nullptr,
-                     "parseConcat expects valid CNNLayerPtr, got nullptr");
-    auto concat = std::dynamic_pointer_cast<ie::ConcatLayer>(layer);
-    VPU_THROW_UNLESS(concat != nullptr,
-                     "{} layer with name {} must be able to convert to ie::ConcatLayer",
-                     layer->type, layer->name);
+    VPU_THROW_UNLESS(concat != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
 
-    VPU_THROW_UNLESS(static_cast<int>(concat->_axis) < output->desc().numDims(),
+    VPU_THROW_UNLESS(static_cast<int>(concat->get_axis()) < output->desc().numDims(),
                      "{} layer with name {} must have axis attribute no grater than number of "
                      "dimensions, actually provided axis = {}, numDims = {}",
-                     layer->type, layer->name, concat->_axis, output->desc().numDims());
+                     concat->get_type_name(), concat->get_friendly_name(), concat->get_axis(), output->desc().numDims());
 
     auto perm = DimsOrder::fromNumDims(output->desc().numDims()).toPermutation();
-    auto axis = perm[output->desc().numDims() - 1 - concat->_axis];
+    auto axis = perm[output->desc().numDims() - 1 - concat->get_axis()];
 
     // If there is DSR as concat's output in the transformed graph, then we need to infer
     // concat on the device side. In other cases StubConcat stage will be added and it will
     // be replace with Data <-> Data edges.
     auto inferRequirement = ConcatInferRequirement::CanBeReplaced;
-    if (auto concatOp = std::dynamic_pointer_cast<ngraph::opset3::Concat>(layer->getNode())) {
-        inferRequirement = concatOp->get_input_source_output(0).get_node_shared_ptr()->get_type_info() ==
-                           ngraph::vpu::op::DynamicShapeResolver::type_info
-                           ? ConcatInferRequirement::NeedToInfer
-                           : ConcatInferRequirement::CanBeReplaced;
-    }
-
-    _stageBuilder->addConcatStage(model, concat->name, concat, axis, inputs, output, inferRequirement);
+    
+    inferRequirement = concat->get_input_source_output(0).get_node_shared_ptr()->get_type_info() ==
+                        ngraph::vpu::op::DynamicShapeResolver::type_info
+                        ? ConcatInferRequirement::NeedToInfer
+                        : ConcatInferRequirement::CanBeReplaced;
+    _stageBuilder->addConcatStage(model, concat->get_friendly_name(), concat, axis, inputs, output, inferRequirement);
 }
 
 Stage StageBuilder::addConcatStage(
         const Model& model,
         const std::string& name,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         Dim axis,
         const DataVector& inputs,
         const Data& output,
@@ -318,9 +312,9 @@ Stage StageBuilder::addConcatStage(
     Stage stage;
     if (inferRequirement == ConcatInferRequirement::NeedToInfer) {
         stage = model->addNewStage<ConcatStage>(
-                layer->name,
+                node->get_friendly_name(),
                 StageType::Concat,
-                layer,
+                node,
                 inputs,
                 {output});
     } else {
@@ -330,7 +324,7 @@ Stage StageBuilder::addConcatStage(
             curOffset.set(axis, curOffset[axis] + input->desc().dim(axis));
         }
 
-        stage = addConcatStage(model, name, layer, std::move(offsets), inputs, output);
+        stage = addConcatStage(model, name, node, std::move(offsets), inputs, output);
     }
 
     stage->attrs().set("axis", axis);
@@ -341,7 +335,7 @@ Stage StageBuilder::addConcatStage(
 Stage StageBuilder::addConcatStage(
         const Model& model,
         const std::string& name,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         std::vector<DimValues>&& offsets,
         const DataVector& inputs,
         const Data& output) {
@@ -352,7 +346,7 @@ Stage StageBuilder::addConcatStage(
     auto stage = model->addNewStage<StubConcatStage>(
         name,
         StageType::StubConcat,
-        layer,
+        node,
         inputs,
         {output});
 

--- a/inference-engine/src/vpu/graph_transformer/src/stages/convert.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/convert.cpp
@@ -126,20 +126,22 @@ Stage StageBuilder::createConvertStage(
 
 void FrontEnd::parseConvert(
         const Model &model,
-        const ie::CNNLayerPtr &layer,
+        const NodePtr& node,
         const DataVector &inputs,
         const DataVector &outputs) const {
+    auto convert = ngraph::as_type_ptr<ngraph::opset4::Convert>(node);
+    IE_ASSERT(convert != nullptr);
     VPU_THROW_UNLESS(inputs.size() == 1,
                      "Convert stage with name %s has invalid number of inputs: expected 1, "
-                     "actually provided %u", layer->name, inputs.size());
+                     "actually provided %u", convert->get_friendly_name(), inputs.size());
     VPU_THROW_UNLESS(outputs.size() == 1,
                      "Convert stage with name %s has invalid number of outputs: expected 1, "
-                     "actually provided %u", layer->name, outputs.size());
+                     "actually provided %u", convert->get_friendly_name(), outputs.size());
 
     auto stage = model->addNewStage<ConvertStage>(
-            layer->name,
+            convert->get_friendly_name(),
             StageType::Convert,
-            layer, inputs,
+            convert, inputs,
             outputs);
 
     stage->attrs().set("scale", 1.f);

--- a/inference-engine/src/vpu/graph_transformer/src/stages/copy.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/copy.cpp
@@ -13,12 +13,12 @@
 
 namespace vpu {
 
-void FrontEnd::parseCopy(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
-    IE_ASSERT(inputs.size() == 1);
-    IE_ASSERT(outputs.size() == 1);
+// void FrontEnd::parseCopy(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+//     IE_ASSERT(inputs.size() == 1);
+//     IE_ASSERT(outputs.size() == 1);
 
-    _stageBuilder->addCopyStage(model, layer->name, layer, inputs[0], outputs[0], "parseCopy");
-}
+//     _stageBuilder->addCopyStage(model, node->get_friendly_name(), node, inputs[0], outputs[0], "parseCopy");
+// }
 
 namespace {
 
@@ -74,14 +74,14 @@ protected:
 Stage StageBuilder::addCopyStage(
         const Model& model,
         const std::string& name,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         const Data& input,
         const Data& output,
         const std::string& origin) {
     Stage copyStage = model->addNewStage<CopyStage>(
         name,
         StageType::Copy,
-        layer,
+        node,
         {input},
         {output});
     copyStage->attrs().set<std::string>("origin", origin);

--- a/inference-engine/src/vpu/graph_transformer/src/stages/crop.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/crop.cpp
@@ -119,14 +119,14 @@ protected:
 Stage StageBuilder::addCropStage(
         const Model& model,
         const std::string& name,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         const Data& input,
         const Data& output,
         const DimValues& offset) {
     auto stage = model->addNewStage<CropStage>(
         name,
         StageType::Crop,
-        layer,
+        node,
         {input},
         {output});
 
@@ -137,53 +137,55 @@ Stage StageBuilder::addCropStage(
 
 void FrontEnd::parseCrop(
         const Model& model,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         const DataVector& inputs,
         const DataVector& outputs) const {
-    VPU_THROW_UNLESS(inputs.size() == 1 || inputs.size() == 2,
-                     "Crop: number of inputs must be 1 or 2, actually provided: %u", inputs.size());
-    VPU_THROW_UNLESS(outputs.size() == 1,
-                     "Crop: number of outputs must be 1, actually provided: %u", outputs.size());
+    // const auto& crop = ngraph::as_type_ptr<ngraph::opset4::StridedSlice>(node);
+    // VPU_THROW_UNLESS(crop != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+    // VPU_THROW_UNLESS(inputs.size() == 1 || inputs.size() == 2,
+    //                  "Crop: number of inputs must be 1 or 2, actually provided: %u", inputs.size());
+    // VPU_THROW_UNLESS(outputs.size() == 1,
+    //                  "Crop: number of outputs must be 1, actually provided: %u", outputs.size());
 
-    auto axisParam   = layer->GetParamAsInts("axis");
-    auto offsetParam = layer->GetParamAsInts("offset");
-    VPU_THROW_UNLESS(axisParam.size() == offsetParam.size(),
-                     "Crop: sizes of `axis` and `offset` must be equal");
+    // auto axisParam   = layer->GetParamAsInts("axis");
+    // auto offsetParam = layer->GetParamAsInts("offset");
+    // VPU_THROW_UNLESS(axisParam.size() == offsetParam.size(),
+    //                  "Crop: sizes of `axis` and `offset` must be equal");
 
-    //
-    // Parse offset attribute as DimValues
-    //
+    // //
+    // // Parse offset attribute as DimValues
+    // //
 
-    DimValues offset;
-    const auto ndims = inputs[0]->desc().numDims();
-    const auto perm = DimsOrder::fromNumDims(ndims).toPermutation();
+    // DimValues offset;
+    // const auto ndims = inputs[0]->desc().numDims();
+    // const auto perm = DimsOrder::fromNumDims(ndims).toPermutation();
 
-    for (int i = 0; i < axisParam.size(); ++i) {
-        auto axisVal   = axisParam[i];
-        auto offsetVal = offsetParam[i];
+    // for (int i = 0; i < axisParam.size(); ++i) {
+    //     auto axisVal   = axisParam[i];
+    //     auto offsetVal = offsetParam[i];
 
-        if (axisVal < 0) {
-            axisVal += ndims;
-        }
-        VPU_THROW_UNLESS(axisVal >= 0 && axisVal < ndims,
-                         "Layer %s [%s] has invalid axis value. "
-                         "Expected: 0 <= axis < %d, Actual: %d",
-                         layer->name, layer->type, ndims, axisVal);
+    //     if (axisVal < 0) {
+    //         axisVal += ndims;
+    //     }
+    //     VPU_THROW_UNLESS(axisVal >= 0 && axisVal < ndims,
+    //                      "Layer %s [%s] has invalid axis value. "
+    //                      "Expected: 0 <= axis < %d, Actual: %d",
+    //                      layer->name, layer->type, ndims, axisVal);
 
-        offset.set(perm[ndims - 1 - axisVal], offsetVal);
-    }
+    //     offset.set(perm[ndims - 1 - axisVal], offsetVal);
+    // }
 
-    VPU_THROW_UNLESS(offset.get(Dim::N, 0) == 0 || model->batchSize() == 1,
-                     "Crop: batch cropping is not supported");
+    // VPU_THROW_UNLESS(offset.get(Dim::N, 0) == 0 || model->batchSize() == 1,
+    //                  "Crop: batch cropping is not supported");
 
-    auto stage = model->addNewStage<CropStage>(
-            layer->name,
-            StageType::Crop,
-            layer,
-            inputs,
-            outputs);
+    // auto stage = model->addNewStage<CropStage>(
+    //         layer->name,
+    //         StageType::Crop,
+    //         layer,
+    //         inputs,
+    //         outputs);
 
-    stage->attrs().set("offset", offset);
+    // stage->attrs().set("offset", offset);
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/ctc_decoder.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/ctc_decoder.cpp
@@ -66,19 +66,20 @@ private:
 
 }  // namespace
 
-void FrontEnd::parseCTCDecoder(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parseCTCDecoder(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
     IE_ASSERT(inputs.size() == 2);
     IE_ASSERT(outputs.size() == 1);
-
-    auto ctc_merge_repeated_ = layer->GetParamAsInt("ctc_merge_repeated", 1);
+    const auto& ctcDecoder = ngraph::as_type_ptr<ngraph::opset4::CTCGreedyDecoder>(node);
+    VPU_THROW_UNLESS(ctcDecoder != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+    auto ctc_merge_repeated_ = ctcDecoder->get_ctc_merge_repeated();
     if (ctc_merge_repeated_ != 1) {
         VPU_THROW_EXCEPTION
-            << layer->name <<  " [" << layer->type
+            << ctcDecoder->get_friendly_name() <<  " [" << ctcDecoder->get_type_name()
             << "] has incorrect ctc_merge_repeated param value."
             << " Kernel support case when ctc_merge_repeated_ == 1 only";
     }
 
-    model->addNewStage<CTCDecoderStage>(layer->name, StageType::CTCDecoder, layer, inputs, outputs);
+    model->addNewStage<CTCDecoderStage>(ctcDecoder->get_friendly_name(), StageType::CTCDecoder, ctcDecoder, inputs, outputs);
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/ctc_greedy_decoder_seq_len.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/ctc_greedy_decoder_seq_len.cpp
@@ -105,37 +105,38 @@ private:
 
 Stage StageBuilder::addCTCGreedyDecoderSeqLenStage(const Model& model,
                                                    const std::string& name,
-                                                   const ie::CNNLayerPtr& layer,
+                                                   const NodePtr& node,
                                                    const DataVector& inputs,
                                                    const DataVector& outputs,
                                                    bool mergeRepeated,
                                                    int32_t blankIndex) {
     auto stage = model->addNewStage<CTCGreedyDecoderSeqLenStage>(name,
                                                                  StageType::CTCGreedyDecoderSeqLen,
-                                                                 layer, inputs, outputs);
+                                                                 node, inputs, outputs);
     stage->attrs().set<bool>("mergeRepeated", mergeRepeated);
     stage->attrs().set<int32_t>("blankIndex", blankIndex);
 
     return stage;
 }
 
-void FrontEnd::parseCTCGreedyDecoderSeqLen(const Model& model, const ie::CNNLayerPtr& layer,
+void FrontEnd::parseCTCGreedyDecoderSeqLen(const Model& model, const NodePtr& node,
                                            const DataVector& inputs, const DataVector& outputs) const {
-    VPU_THROW_UNLESS(layer, "CNNLayer pointer is null.");
+    auto ctcGreedyDecoderSeqLen = ngraph::as_type_ptr<ngraph::op::v6::CTCGreedyDecoderSeqLen>(node);
+    VPU_THROW_UNLESS(ctcGreedyDecoderSeqLen != nullptr, "Node pointer is null.");
     VPU_THROW_UNLESS(inputs.size() == 2 || inputs.size() == 3,
                      "{} layer with name {} must have 2 or 3 inputs, actually "
                      "provided {} inputs",
-                     layer->type, layer->name, inputs.size());
+                     ctcGreedyDecoderSeqLen->get_type_name(), ctcGreedyDecoderSeqLen->get_friendly_name(), inputs.size());
     VPU_THROW_UNLESS(outputs.size() == 2,
                      "{} layer with name {} must have 2 outputs, actually "
                      "provided {} outputs",
-                     layer->type, layer->name, outputs.size());
+                     ctcGreedyDecoderSeqLen->get_type_name(), ctcGreedyDecoderSeqLen->get_friendly_name(), outputs.size());
 
     DataVector conditionalOutputs(2);
     conditionalOutputs[0] = outputs[0];
     conditionalOutputs[1] = outputs[1] != nullptr ? outputs[1] : model->addFakeData();
 
-    const auto mergeRepeated = layer->GetParamAsBool("merge_repeated");
+    const auto mergeRepeated = ctcGreedyDecoderSeqLen->get_merge_repeated();
     const auto blankIndex = [&] {
         if (inputs.size() == 3) {
             VPU_THROW_UNLESS(inputs[2]->usage() == DataUsage::Const,
@@ -160,16 +161,16 @@ void FrontEnd::parseCTCGreedyDecoderSeqLen(const Model& model, const ie::CNNLaye
         return result;
     };
 
-    const auto classesIndexType = toUpper(layer->GetParamAsString("classes_index_type"));
-    const auto sequenceLengthType = toUpper(layer->GetParamAsString("sequence_length_type"));
+    const auto classesIndexType = ctcGreedyDecoderSeqLen->get_classes_index_type();//  toUpper(layer->GetParamAsString("classes_index_type"));
+    const auto sequenceLengthType = ctcGreedyDecoderSeqLen->get_sequence_length_type();
 
-    VPU_THROW_UNLESS(classesIndexType == "I32", "classes_index_type == %s. Only I32 is supported",
+    VPU_THROW_UNLESS(classesIndexType == ngraph::element::i32, "classes_index_type == %s. Only I32 is supported",
                      classesIndexType);
 
-    VPU_THROW_UNLESS(sequenceLengthType == "I32", "sequence_length_type == %s. Only I32 is supported",
+    VPU_THROW_UNLESS(sequenceLengthType == ngraph::element::i32, "sequence_length_type == %s. Only I32 is supported",
                      sequenceLengthType);
 
-    _stageBuilder->addCTCGreedyDecoderSeqLenStage(model, layer->name, layer,
+    _stageBuilder->addCTCGreedyDecoderSeqLenStage(model, ctcGreedyDecoderSeqLen->get_friendly_name(), ctcGreedyDecoderSeqLen,
                                                   inputs, conditionalOutputs, mergeRepeated, blankIndex);
 }
 

--- a/inference-engine/src/vpu/graph_transformer/src/stages/custom.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/custom.cpp
@@ -1,485 +1,487 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
-
-#include <vpu/frontend/frontend.hpp>
-
-#include <vpu/frontend/custom_layer.hpp>
-#include <vpu/utils/simple_math.hpp>
-#include <vpu/model/data_contents/kernel_binary_content.hpp>
-#include <vpu/model/data_contents/ie_blob_content.hpp>
-
-#include <vector>
-#include <memory>
-#include <string>
-#include <map>
-#include <utility>
-#include <algorithm>
-#include <tuple>
-
-namespace vpu {
-
-static SmallVector<int> calcSizesFromParams(const DataDesc& desc, const SmallVector<std::string>& bufferSizeRules,
-                                            std::map<std::string, std::string> layerParams);
-
-namespace {
-
-class CustomStage final : public StageNode {
-public:
-    using StageNode::StageNode;
-
-private:
-    StagePtr cloneImpl() const override {
-        return std::make_shared<CustomStage>(*this);
-    }
-
-    void propagateDataOrderImpl(StageDataInfo<DimsOrder>& orderInfo) override {
-        const auto& inputOrders = attrs().get<std::map<int, DimsOrder>>("inputOrders");
-        const auto& outputOrders = attrs().get<std::map<int, DimsOrder>>("outputOrders");
-
-        for (const auto& inEdge : inputEdges()) {
-            // last input is always OpenCL binary, so use it as is.
-            if (inEdge->portInd() == numInputs() - 1) {
-                break;
-            }
-
-            auto it = inputOrders.find(inEdge->portInd());
-            if (it != inputOrders.end()) {
-                auto requiredOrder = it->second;
-                orderInfo.setInput(inEdge, requiredOrder);
-            }
-        }
-
-        for (const auto& outEdge : outputEdges()) {
-            auto it = outputOrders.find(outEdge->portInd());
-            if (it != outputOrders.end()) {
-                auto requiredOrder = it->second;
-                orderInfo.setOutput(outEdge, requiredOrder);
-            }
-        }
-    }
-
-    void getDataStridesRequirementsImpl(StageDataInfo<StridesRequirement>& stridesInfo) override {
-        for (const auto& inEdge : inputEdges()) {
-            // last input is always OpenCL binary, so use it as is.
-            if (inEdge->portInd() == numInputs() - 1) {
-                break;
-            }
-
-            stridesInfo.setInput(inEdge, StridesRequirement::compact());
-        }
-        for (const auto& outEdge : outputEdges()) {
-            stridesInfo.setOutput(outEdge, StridesRequirement::compact());
-        }
-    }
-
-    void finalizeDataLayoutImpl() override {
-    }
-
-    void getBatchSupportInfoImpl(StageDataInfo<BatchSupport>& batchInfo) override {
-        std::vector<CustomDataFormat> formats = attrs().get<std::vector<CustomDataFormat>>("formats");
-
-        for (const auto& inEdge : inputEdges()) {
-            IE_ASSERT(inEdge->portInd() < formats.size());
-
-            // last input is always OpenCL binary, so use it as is.
-            if ((inEdge->portInd() == numInputs() - 1) || (formats[inEdge->portInd()] == CustomDataFormat::Any)) {
-                break;
-            }
-
-            batchInfo.setInput(inEdge, BatchSupport::Split);
-        }
-        for (const auto& outEdge : outputEdges()) {
-            batchInfo.setOutput(outEdge, BatchSupport::Split);
-        }
-    }
-
-    void serializeParamsImpl(BlobSerializer& serializer) const override {
-        const auto& kernel = attrs().get<CustomKernel>("customKernel");
-        const auto& gws = attrs().get<SmallVector<int>>("gws");
-        const auto& lws = attrs().get<SmallVector<int>>("lws");
-        const auto& ports = attrs().get<std::map<std::string, int>>("ports");
-        const auto& localDataSizes = attrs().get<std::map<std::string, int>>("localDataSizes");
-
-        for (int i = 0; i < gws.size(); ++i) {
-            serializer.append(static_cast<uint32_t>(gws[i] / lws[i]));
-        }
-
-        for (auto x : lws) {
-            serializer.append(static_cast<uint32_t>(x));
-        }
-
-        for (int i = 0; i < lws.size(); ++i) {
-            serializer.append(static_cast<uint32_t>(0));
-        }
-
-        serializer.append(static_cast<uint32_t>(kernel.maxShaves()));
-        serializer.append(static_cast<uint32_t>(kernel.kernelId()));
-        serializer.append(static_cast<uint32_t>(kernel.inputDataCount()));
-        serializer.append(static_cast<int32_t>(numInputs() + numOutputs()));
-        serializer.append(static_cast<uint32_t>(kernel.parameters().size()));
-
-        std::map<std::string, CustomKernel::KernelParam> b2b;
-        for (const auto& kp : kernel.bindings()) {
-            b2b[kp.argName] = kp;
-        }
-
-        IE_ASSERT(origLayer() != nullptr);
-
-        for (const auto& kp : kernel.parameters()) {
-            const auto& parameter = b2b[kp];
-
-            switch (parameter.type) {
-            case CustomParamType::Input:
-            case CustomParamType::Output:
-            case CustomParamType::InputBuffer:
-            case CustomParamType::OutputBuffer:
-            case CustomParamType::Data: {
-                const auto& kpIt = ports.find(kp);
-                VPU_THROW_UNLESS(kpIt != ports.end(),
-                    "XML specification for %s layer has no definition for '%s' parameter. Layer name: %s",
-                    origLayer()->type, kp, origLayer()->name);
-
-                int id = kpIt->second;
-                serializer.append(static_cast<uint32_t>(0));
-                serializer.append(static_cast<uint32_t>(id));
-                break;
-            }
-            case CustomParamType::Int:
-            case CustomParamType::Float: {
-                const auto cnnParam = origLayer()->params.find(parameter.irSource);
-                if (cnnParam != origLayer()->params.end()) {
-                    const auto param = [&]() -> std::string {
-                        if (parameter.portIndex < 0) {
-                            return cnnParam->second;
-                        }
-
-                        VPU_THROW_UNLESS(cnnParam->second.find(',') != std::string::npos,
-                            "Error while parsing CNNetwork parameter '%s' for '%s' layer: port-index=%d is set, "
-                            "but parameter is neither a tensor, nor an array type.",
-                            cnnParam->first, origLayer()->type, parameter.portIndex);
-
-                        std::string value;
-                        std::stringstream parameterStream{cnnParam->second};
-                        for (int i = 0; i <= parameter.portIndex; i++) {
-                            getline(parameterStream, value, ',');
-                        }
-                        return value;
-                    }();
-
-                    if (parameter.type == CustomParamType::Int) {
-                        serializer.append(static_cast<int32_t>(std::stoi(param)));
-                        serializer.append(static_cast<int32_t>(-1));
-                    } else {
-                        serializer.append(static_cast<float>(std::stof(param)));
-                        serializer.append(static_cast<int32_t>(-2));
-                    }
-                    break;
-                } else {
-                    auto pos = parameter.irSource.find_first_of('.');
-                    if (pos != std::string::npos) {
-                        auto blob = parameter.irSource.substr(0, pos);
-                        auto dim = parameter.irSource.substr(pos + 1, std::string::npos);
-
-                        VPU_THROW_UNLESS(dim.length() == 1,
-                            "Unable to deduce parameter '%s' for '%s' layer. Name is: '%s'",
-                            parameter.argName, origLayer()->type, origLayer()->name);
-
-                        char dimLetter = dim[0];
-
-                        ie::DataPtr origData;
-                        if (blob == "I") {
-                            origData = origLayer()->insData[parameter.portIndex].lock();
-                        } else {
-                            origData = origLayer()->outData[parameter.portIndex];
-                        }
-                        IE_ASSERT(origData != nullptr);
-
-                        auto dims = origData->getDims();
-                        auto ndims = dims.size();
-
-                        if (ndims > 4) {
-                            VPU_THROW_UNLESS(dim.length() == 1,
-                                 "Unable to deduce parameter '%s' for '%s' layer. Name is: '%s'",
-                                 parameter.argName, origLayer()->type, origLayer()->name);
-                        }
-                        const std::map<char, int> vars = {
-                            {'b', 0}, {'B', 0},
-                            {'f', 1}, {'F', 1},
-                            {'y', 2}, {'Y', 2},
-                            {'x', 3}, {'X', 3},
-                        };
-
-                        auto var = vars.find(dimLetter);
-                        if (var != vars.end()) {
-                            auto res = dims.at(var->second - 4 + ndims);
-
-                            serializer.append(static_cast<uint32_t>(res));
-                            serializer.append(static_cast<int32_t>(-1));
-                        } else {
-                            VPU_THROW_FORMAT("Unable to deduce parameter '%s' for '%s' layer. Name is: '%s'",
-                                parameter.argName, origLayer()->type, origLayer()->name);
-                        }
-
-                        break;
-                    } else {
-                        VPU_THROW_UNLESS(parameter.portIndex < 0,
-                            "Unable to deduce parameter '%s' for '%s' layer: port-index=%d is set, "
-                            "but parameter is neither a tensor, nor an array type.",
-                            parameter.argName, origLayer()->type, parameter.portIndex);
-                        try {
-                            if (parameter.type == CustomParamType::Int) {
-                                serializer.append(static_cast<int32_t>(std::stoi(parameter.irSource)));
-                                serializer.append(static_cast<int32_t>(-1));
-                            } else {
-                                serializer.append(static_cast<float>(std::stof(parameter.irSource)));
-                                serializer.append(static_cast<int32_t>(-2));
-                            }
-                            break;
-                        } catch (const std::invalid_argument&) {
-                            VPU_THROW_FORMAT("Unable to deduce parameter '%s' for '%s' layer. "
-                                "Name is: '%s', parameter is: '%s'",
-                                parameter.argName, origLayer()->type, origLayer()->name, parameter.irSource);
-                        }
-                    }
-                }
-            }
-            case CustomParamType::LocalData: {
-                const auto size = localDataSizes.at(parameter.argName);
-                serializer.append(static_cast<int32_t>(size));
-                serializer.append(static_cast<int32_t>(-3));
-
-                break;
-            }
-            default:
-                VPU_THROW_FORMAT("Unable to deduce parameter '%s' for '%s' layer. Name is: '%s'",
-                    parameter.argName, origLayer()->type, origLayer()->name);
-            }
-        }
-    }
-
-    void serializeDataImpl(BlobSerializer& serializer) const override {
-        IE_ASSERT(numTempBuffers() == 1);
-
-        for (const auto& inEdge : inputEdges()) {
-            inEdge->input()->serializeBuffer(serializer);
-        }
-
-        for (const auto& outEdge : outputEdges()) {
-            outEdge->output()->serializeBuffer(serializer);
-        }
-
-        for (const auto& tempEdge : tempBufferEdges()) {
-            tempEdge->tempBuffer()->serializeBuffer(serializer);
-        }
-    }
-};
-
-}  // namespace
-
-static SmallVector<int> calcSizesFromParams(const DataDesc& desc, const SmallVector<std::string>& bufferSizeRules,
-                                            std::map<std::string, std::string> layerParams) {
-    {
-        const auto B = std::to_string(desc.dim(Dim::N, 1));
-        const auto F = std::to_string(desc.dim(Dim::C, 1));
-        const auto Y = std::to_string(desc.dim(Dim::H, 1));
-        const auto X = std::to_string(desc.dim(Dim::W, 1));
-
-        auto sizes = std::vector<std::pair<std::string, std::string>> {
-            {"b", B}, {"B", B},
-            {"f", F}, {"F", F},
-            {"y", Y}, {"Y", Y},
-            {"x", X}, {"X", X},
-        };
-
-        std::move(begin(sizes), end(sizes), inserter(layerParams, end(layerParams)));
-    }
-
-    MathExpression expr;
-    expr.setVariables(layerParams);
-    const auto parseSizeRule = [&expr](const std::string& rule) {
-        expr.parse(rule);
-        return expr.evaluate();
-    };
-
-    auto sizes = SmallVector<int>{};
-    sizes.reserve(bufferSizeRules.size());
-    std::transform(begin(bufferSizeRules), end(bufferSizeRules), std::back_inserter(sizes), parseSizeRule);
-
-    return sizes;
-}
-
-void FrontEnd::parseCustom(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) {
-    IE_ASSERT(layer != nullptr);
-    IE_ASSERT(outputs.size() == 1);
-
-    const auto suitableLayer = [&] {
-        const auto customLayersForType = _customLayers.find(layer->type);
-        IE_ASSERT(customLayersForType != _customLayers.end());
-        return getSuitableCustomLayer(customLayersForType->second, layer);
-    }();
-    IE_ASSERT(suitableLayer);
-
-    const auto kernels = suitableLayer->kernels();
-    // Get all buffers, buffers must be unique associated by port index
-    std::map<int, Data> tempBuffsMap;
-    for (const auto& kernel : kernels) {
-        for (const auto& param : kernel.bindings()) {
-            if (param.type == CustomParamType::InputBuffer || param.type == CustomParamType::OutputBuffer) {
-                const auto desc = (param.dimSource == CustomDimSource::Input) ? inputs[param.dimIdx]->desc()
-                                                                              : outputs[param.dimIdx]->desc();
-                const auto sizes = calcSizesFromParams(desc, { param.bufferSizeRule }, layer->params);
-                const auto buf = model->addNewData("custom_" + layer->type + "_buf", DataDesc({sizes[0], 1, 1, 1}));
-                if (tempBuffsMap.find(param.portIndex) == tempBuffsMap.end()) {
-                    tempBuffsMap[param.portIndex] = buf;
-                }
-            }
-        }
-    }
-
-    // Gather inputs and outputs for each stage for the layer
-    for (int stage_num = 0; stage_num < kernels.size(); stage_num++) {
-        const auto& kernel = kernels[stage_num];
-
-        std::map<std::string, int> ports;
-        std::vector<CustomDataFormat> formats;
-
-        // Gather inputs
-        DataVector stageInputs;
-        for (auto& param : kernel.bindings()) {
-            if (param.type == CustomParamType::Input) {
-                ports[param.argName] = stageInputs.size();
-                formats.emplace_back(param.format);
-                stageInputs.emplace_back(inputs[param.portIndex]);
-            } else if (param.type == CustomParamType::InputBuffer) {
-                ports[param.argName] = stageInputs.size();
-                formats.emplace_back(CustomDataFormat::BFYX);
-                stageInputs.emplace_back(tempBuffsMap[param.portIndex]);
-            }
-        }
-
-        // Gather data blobs
-        for (auto& param : kernel.bindings()) {
-            if (param.type == CustomParamType::Data) {
-                auto blobIterator = layer->blobs.find(param.irSource);
-                if (blobIterator != layer->blobs.end()) {
-                    auto origBlob = blobIterator->second;
-                    auto customBlob = model->addConstData(
-                        layer->name + "@" + param.irSource,
-                        DataDesc({origBlob->size()}),
-                        ieBlobContent(origBlob));
-                    ports[param.argName] = stageInputs.size();
-                    formats.emplace_back(param.format);
-                    stageInputs.emplace_back(std::move(customBlob));
-                }
-            }
-        }
-
-        formats.emplace_back(CustomDataFormat::Any);
-
-        // Get kernel binary
-        auto kernelNode = _kernelNodes.find(kernel.kernelBinary());
-        if (kernelNode != _kernelNodes.end()) {
-            stageInputs.emplace_back((kernelNode->second));
-        } else {
-            auto kernelBinaryDesc = DataDesc({kernel.kernelBinary().length()});
-            kernelBinaryDesc.setType(DataType::U8);
-
-            auto kernelBinary = model->addConstData(
-                layer->type + "@kernelBinary",
-                kernelBinaryDesc,
-                std::make_shared<KernelBinaryContent>(kernel.kernelBinary()));
-            stageInputs.emplace_back((kernelBinary));
-            _kernelNodes[kernel.kernelBinary()] = kernelBinary;
-        }
-
-        DataVector stageOutputs;
-        for (auto& param : kernel.bindings()) {
-            if (param.type == CustomParamType::Output) {
-                ports[param.argName] = stageInputs.size() + stageOutputs.size();
-                stageOutputs.emplace_back(outputs[param.portIndex]);
-            } else if (param.type == CustomParamType::OutputBuffer) {
-                ports[param.argName] = stageInputs.size() + stageOutputs.size();
-                stageOutputs.emplace_back(tempBuffsMap[param.portIndex]);
-            }
-        }
-
-        auto stage = model->addNewStage<CustomStage>(
-            layer->name + ((kernels.size() == 1) ? "" : "@stage_" + std::to_string(stage_num)),
-            StageType::Custom,
-            layer,
-            stageInputs,
-            stageOutputs);
-
-        stage->attrs().set("customKernel", suitableLayer->kernels()[stage_num]);
-        stage->attrs().set("ports", ports);
-        stage->attrs().set("formats", formats);
-
-        const auto& dimSource = (kernel.dimSource() == CustomDimSource::Input) ? inputs : outputs;
-        const auto& dataDesc = dimSource[kernel.dimSourceIndex()]->desc();
-
-        const auto gws = calcSizesFromParams(dataDesc, kernel.globalGridSizeRules(), layer->params);
-        const auto lws = calcSizesFromParams(dataDesc, kernel.localGridSizeRules(), layer->params);
-
-        stage->attrs().set("gws", gws);
-        stage->attrs().set("lws", lws);
-
-        const auto localDataSizes = [&] {
-            auto sizes = std::map<std::string, int>{};
-            for (const auto& bind : kernel.bindings()) {
-                if (bind.type == CustomParamType::LocalData) {
-                    const auto& source = bind.dimSource == CustomDimSource::Input ? inputs : outputs;
-                    const auto& desc = source[bind.dimIdx]->desc();
-                    const auto size = calcSizesFromParams(desc, { bind.bufferSizeRule }, layer->params);
-                    sizes.emplace(bind.argName, size[0]);
-                }
-            }
-            return sizes;
-        }();
-
-        stage->attrs().set("localDataSizes", localDataSizes);
-
-        std::map<int, DimsOrder> inputOrders;
-        std::map<int, DimsOrder> outputOrders;
-
-        std::map<std::string, CustomKernel::KernelParam> b2b;
-        for (const auto& kp : kernel.bindings()) {
-            b2b[kp.argName] = kp;
-        }
-
-        const std::map<CustomDataFormat, DimsOrder> formatsMap = {
-            { CustomDataFormat::BYXF, DimsOrder::NHWC },
-            { CustomDataFormat::BFYX, DimsOrder::NCHW },
-            { CustomDataFormat::YXF, DimsOrder::HWC },
-            { CustomDataFormat::FYX, DimsOrder::CHW }
-        };
-
-        for (const auto& kp : kernel.parameters()) {
-            const auto& parameter = b2b[kp];
-
-            if (parameter.type == CustomParamType::Input) {
-                auto it = formatsMap.find(parameter.format);
-                if (it != formatsMap.end()) {
-                    auto requiredOrder = it->second;
-                    inputOrders[parameter.portIndex] = requiredOrder;
-                }
-            }
-
-            if (parameter.type == CustomParamType::Output) {
-                auto it = formatsMap.find(parameter.format);
-                if (it != formatsMap.end()) {
-                    auto requiredOrder = it->second;
-                    outputOrders[parameter.portIndex] = requiredOrder;
-                }
-            }
-        }
-
-        stage->attrs().set("inputOrders", std::move(inputOrders));
-        stage->attrs().set("outputOrders", std::move(outputOrders));
-
-        auto buffer_size = kernel.kernelBinary().length() + 1024;
-        model->addTempBuffer(stage, buffer_size);
-    }
-}
-
-}  // namespace vpu
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
+
+// #include <vpu/frontend/frontend.hpp>
+
+// #include <vpu/frontend/custom_layer.hpp>
+// #include <vpu/utils/simple_math.hpp>
+// #include <vpu/model/data_contents/kernel_binary_content.hpp>
+// #include <vpu/model/data_contents/ie_blob_content.hpp>
+
+// #include <vector>
+// #include <memory>
+// #include <string>
+// #include <map>
+// #include <utility>
+// #include <algorithm>
+// #include <tuple>
+
+// namespace vpu {
+
+// static SmallVector<int> calcSizesFromParams(const DataDesc& desc, const SmallVector<std::string>& bufferSizeRules,
+//                                             std::map<std::string, std::string> layerParams);
+
+// namespace {
+
+// class CustomStage final : public StageNode {
+// public:
+//     using StageNode::StageNode;
+
+// private:
+//     StagePtr cloneImpl() const override {
+//         return std::make_shared<CustomStage>(*this);
+//     }
+
+//     void propagateDataOrderImpl(StageDataInfo<DimsOrder>& orderInfo) override {
+//         const auto& inputOrders = attrs().get<std::map<int, DimsOrder>>("inputOrders");
+//         const auto& outputOrders = attrs().get<std::map<int, DimsOrder>>("outputOrders");
+
+//         for (const auto& inEdge : inputEdges()) {
+//             // last input is always OpenCL binary, so use it as is.
+//             if (inEdge->portInd() == numInputs() - 1) {
+//                 break;
+//             }
+
+//             auto it = inputOrders.find(inEdge->portInd());
+//             if (it != inputOrders.end()) {
+//                 auto requiredOrder = it->second;
+//                 orderInfo.setInput(inEdge, requiredOrder);
+//             }
+//         }
+
+//         for (const auto& outEdge : outputEdges()) {
+//             auto it = outputOrders.find(outEdge->portInd());
+//             if (it != outputOrders.end()) {
+//                 auto requiredOrder = it->second;
+//                 orderInfo.setOutput(outEdge, requiredOrder);
+//             }
+//         }
+//     }
+
+//     void getDataStridesRequirementsImpl(StageDataInfo<StridesRequirement>& stridesInfo) override {
+//         for (const auto& inEdge : inputEdges()) {
+//             // last input is always OpenCL binary, so use it as is.
+//             if (inEdge->portInd() == numInputs() - 1) {
+//                 break;
+//             }
+
+//             stridesInfo.setInput(inEdge, StridesRequirement::compact());
+//         }
+//         for (const auto& outEdge : outputEdges()) {
+//             stridesInfo.setOutput(outEdge, StridesRequirement::compact());
+//         }
+//     }
+
+//     void finalizeDataLayoutImpl() override {
+//     }
+
+//     void getBatchSupportInfoImpl(StageDataInfo<BatchSupport>& batchInfo) override {
+//         // std::vector<CustomDataFormat> formats = attrs().get<std::vector<CustomDataFormat>>("formats");
+
+//         // for (const auto& inEdge : inputEdges()) {
+//         //     IE_ASSERT(inEdge->portInd() < formats.size());
+
+//         //     // last input is always OpenCL binary, so use it as is.
+//         //     if ((inEdge->portInd() == numInputs() - 1) || (formats[inEdge->portInd()] == CustomDataFormat::Any)) {
+//         //         break;
+//         //     }
+
+//         //     batchInfo.setInput(inEdge, BatchSupport::Split);
+//         // }
+//         // for (const auto& outEdge : outputEdges()) {
+//         //     batchInfo.setOutput(outEdge, BatchSupport::Split);
+//         // }
+//     }
+
+//     void serializeParamsImpl(BlobSerializer& serializer) const override {
+//         // const auto& kernel = attrs().get<CustomKernel>("customKernel");
+//         // const auto& gws = attrs().get<SmallVector<int>>("gws");
+//         // const auto& lws = attrs().get<SmallVector<int>>("lws");
+//         // const auto& ports = attrs().get<std::map<std::string, int>>("ports");
+//         // const auto& localDataSizes = attrs().get<std::map<std::string, int>>("localDataSizes");
+
+//         // for (int i = 0; i < gws.size(); ++i) {
+//         //     serializer.append(static_cast<uint32_t>(gws[i] / lws[i]));
+//         // }
+
+//         // for (auto x : lws) {
+//         //     serializer.append(static_cast<uint32_t>(x));
+//         // }
+
+//         // for (int i = 0; i < lws.size(); ++i) {
+//         //     serializer.append(static_cast<uint32_t>(0));
+//         // }
+
+//         // serializer.append(static_cast<uint32_t>(kernel.maxShaves()));
+//         // serializer.append(static_cast<uint32_t>(kernel.kernelId()));
+//         // serializer.append(static_cast<uint32_t>(kernel.inputDataCount()));
+//         // serializer.append(static_cast<int32_t>(numInputs() + numOutputs()));
+//         // serializer.append(static_cast<uint32_t>(kernel.parameters().size()));
+
+//         // std::map<std::string, CustomKernel::KernelParam> b2b;
+//         // for (const auto& kp : kernel.bindings()) {
+//         //     b2b[kp.argName] = kp;
+//         // }
+
+//         // IE_ASSERT(origNode() != nullptr);
+
+//         // for (const auto& kp : kernel.parameters()) {
+//         //     const auto& parameter = b2b[kp];
+
+//         //     switch (parameter.type) {
+//         //     case CustomParamType::Input:
+//         //     case CustomParamType::Output:
+//         //     case CustomParamType::InputBuffer:
+//         //     case CustomParamType::OutputBuffer:
+//         //     case CustomParamType::Data: {
+//         //         const auto& kpIt = ports.find(kp);
+//         //         VPU_THROW_UNLESS(kpIt != ports.end(),
+//         //             "XML specification for %s layer has no definition for '%s' parameter. Layer name: %s",
+//         //             origLayer()->type, kp, origLayer()->name);
+
+//         //         int id = kpIt->second;
+//         //         serializer.append(static_cast<uint32_t>(0));
+//         //         serializer.append(static_cast<uint32_t>(id));
+//         //         break;
+//         //     }
+//         //     case CustomParamType::Int:
+//         //     case CustomParamType::Float: {
+//         //         const auto cnnParam = origLayer()->params.find(parameter.irSource);
+//         //         if (cnnParam != origLayer()->params.end()) {
+//         //             const auto param = [&]() -> std::string {
+//         //                 if (parameter.portIndex < 0) {
+//         //                     return cnnParam->second;
+//         //                 }
+
+//         //                 VPU_THROW_UNLESS(cnnParam->second.find(',') != std::string::npos,
+//         //                     "Error while parsing CNNetwork parameter '%s' for '%s' layer: port-index=%d is set, "
+//         //                     "but parameter is neither a tensor, nor an array type.",
+//         //                     cnnParam->first, origLayer()->type, parameter.portIndex);
+
+//         //                 std::string value;
+//         //                 std::stringstream parameterStream{cnnParam->second};
+//         //                 for (int i = 0; i <= parameter.portIndex; i++) {
+//         //                     getline(parameterStream, value, ',');
+//         //                 }
+//         //                 return value;
+//         //             }();
+
+//         //             if (parameter.type == CustomParamType::Int) {
+//         //                 serializer.append(static_cast<int32_t>(std::stoi(param)));
+//         //                 serializer.append(static_cast<int32_t>(-1));
+//         //             } else {
+//         //                 serializer.append(static_cast<float>(std::stof(param)));
+//         //                 serializer.append(static_cast<int32_t>(-2));
+//         //             }
+//         //             break;
+//         //         } else {
+//         //             auto pos = parameter.irSource.find_first_of('.');
+//         //             if (pos != std::string::npos) {
+//         //                 auto blob = parameter.irSource.substr(0, pos);
+//         //                 auto dim = parameter.irSource.substr(pos + 1, std::string::npos);
+
+//         //                 VPU_THROW_UNLESS(dim.length() == 1,
+//         //                     "Unable to deduce parameter '%s' for '%s' layer. Name is: '%s'",
+//         //                     parameter.argName, origLayer()->type, origLayer()->name);
+
+//         //                 char dimLetter = dim[0];
+
+//         //                 ie::DataPtr origData;
+//         //                 if (blob == "I") {
+//         //                     origData = origLayer()->insData[parameter.portIndex].lock();
+//         //                 } else {
+//         //                     origData = origLayer()->outData[parameter.portIndex];
+//         //                 }
+//         //                 IE_ASSERT(origData != nullptr);
+
+//         //                 auto dims = origData->getDims();
+//         //                 auto ndims = dims.size();
+
+//         //                 if (ndims > 4) {
+//         //                     VPU_THROW_UNLESS(dim.length() == 1,
+//         //                          "Unable to deduce parameter '%s' for '%s' layer. Name is: '%s'",
+//         //                          parameter.argName, origLayer()->type, origLayer()->name);
+//         //                 }
+//         //                 const std::map<char, int> vars = {
+//         //                     {'b', 0}, {'B', 0},
+//         //                     {'f', 1}, {'F', 1},
+//         //                     {'y', 2}, {'Y', 2},
+//         //                     {'x', 3}, {'X', 3},
+//         //                 };
+
+//         //                 auto var = vars.find(dimLetter);
+//         //                 if (var != vars.end()) {
+//         //                     auto res = dims.at(var->second - 4 + ndims);
+
+//         //                     serializer.append(static_cast<uint32_t>(res));
+//         //                     serializer.append(static_cast<int32_t>(-1));
+//         //                 } else {
+//         //                     VPU_THROW_FORMAT("Unable to deduce parameter '%s' for '%s' layer. Name is: '%s'",
+//         //                         parameter.argName, origLayer()->type, origLayer()->name);
+//         //                 }
+
+//         //                 break;
+//         //             } else {
+//         //                 VPU_THROW_UNLESS(parameter.portIndex < 0,
+//         //                     "Unable to deduce parameter '%s' for '%s' layer: port-index=%d is set, "
+//         //                     "but parameter is neither a tensor, nor an array type.",
+//         //                     parameter.argName, origLayer()->type, parameter.portIndex);
+//         //                 try {
+//         //                     if (parameter.type == CustomParamType::Int) {
+//         //                         serializer.append(static_cast<int32_t>(std::stoi(parameter.irSource)));
+//         //                         serializer.append(static_cast<int32_t>(-1));
+//         //                     } else {
+//         //                         serializer.append(static_cast<float>(std::stof(parameter.irSource)));
+//         //                         serializer.append(static_cast<int32_t>(-2));
+//         //                     }
+//         //                     break;
+//         //                 } catch (const std::invalid_argument&) {
+//         //                     VPU_THROW_FORMAT("Unable to deduce parameter '%s' for '%s' layer. "
+//         //                         "Name is: '%s', parameter is: '%s'",
+//         //                         parameter.argName, origLayer()->type, origLayer()->name, parameter.irSource);
+//         //                 }
+//         //             }
+//         //         }
+//         //     }
+//         //     case CustomParamType::LocalData: {
+//         //         const auto size = localDataSizes.at(parameter.argName);
+//         //         serializer.append(static_cast<int32_t>(size));
+//         //         serializer.append(static_cast<int32_t>(-3));
+
+//         //         break;
+//         //     }
+//         //     default:
+//         //         VPU_THROW_FORMAT("Unable to deduce parameter '%s' for '%s' layer. Name is: '%s'",
+//         //             parameter.argName, origLayer()->type, origLayer()->name);
+//         //     }
+//         // }
+//     }
+
+//     // void serializeDataImpl(BlobSerializer& serializer) const override {
+//         // IE_ASSERT(numTempBuffers() == 1);
+
+//         // for (const auto& inEdge : inputEdges()) {
+//         //     inEdge->input()->serializeBuffer(serializer);
+//         // }
+
+//         // for (const auto& outEdge : outputEdges()) {
+//         //     outEdge->output()->serializeBuffer(serializer);
+//         // }
+
+//         // for (const auto& tempEdge : tempBufferEdges()) {
+//         //     tempEdge->tempBuffer()->serializeBuffer(serializer);
+//         // }
+//     // }
+// };
+
+// }  // namespace
+
+// // static SmallVector<int> calcSizesFromParams(const DataDesc& desc, const SmallVector<std::string>& bufferSizeRules,
+//                                             // std::map<std::string, std::string> layerParams) {
+//     // {
+//     //     const auto B = std::to_string(desc.dim(Dim::N, 1));
+//     //     const auto F = std::to_string(desc.dim(Dim::C, 1));
+//     //     const auto Y = std::to_string(desc.dim(Dim::H, 1));
+//     //     const auto X = std::to_string(desc.dim(Dim::W, 1));
+
+//     //     auto sizes = std::vector<std::pair<std::string, std::string>> {
+//     //         {"b", B}, {"B", B},
+//     //         {"f", F}, {"F", F},
+//     //         {"y", Y}, {"Y", Y},
+//     //         {"x", X}, {"X", X},
+//     //     };
+
+//     //     std::move(begin(sizes), end(sizes), inserter(layerParams, end(layerParams)));
+//     // }
+
+//     // MathExpression expr;
+//     // expr.setVariables(layerParams);
+//     // const auto parseSizeRule = [&expr](const std::string& rule) {
+//     //     expr.parse(rule);
+//     //     return expr.evaluate();
+//     // };
+
+//     // auto sizes = SmallVector<int>{};
+//     // sizes.reserve(bufferSizeRules.size());
+//     // std::transform(begin(bufferSizeRules), end(bufferSizeRules), std::back_inserter(sizes), parseSizeRule);
+
+//     // return sizes;
+// // }
+
+// void FrontEnd::parseCustom(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) {
+//     // IE_ASSERT(node != nullptr);
+//     // IE_ASSERT(outputs.size() == 1);
+
+//     // const auto suitableLayer = [&] {
+//     //     const auto customLayersForType = _customLayers.find(node->get_type_name());
+//     //     IE_ASSERT(customLayersForType != _customLayers.end());
+//     //     return getSuitableCustomLayer(customLayersForType->second, node);
+//     // }();
+//     // IE_ASSERT(suitableLayer);
+
+//     // const auto kernels = suitableLayer->kernels();
+//     // // Get all buffers, buffers must be unique associated by port index
+//     // std::map<int, Data> tempBuffsMap;
+//     // for (const auto& kernel : kernels) {
+//     //     for (const auto& param : kernel.bindings()) {
+//     //         if (param.type == CustomParamType::InputBuffer || param.type == CustomParamType::OutputBuffer) {
+//     //             const auto desc = (param.dimSource == CustomDimSource::Input) ? inputs[param.dimIdx]->desc()
+//     //                                                                           : outputs[param.dimIdx]->desc();
+//     //             const auto sizes = calcSizesFromParams(desc, { param.bufferSizeRule }, layer->params);
+//     //             const auto buf = model->addNewData("custom_" + layer->type + "_buf", DataDesc({sizes[0], 1, 1, 1}));
+//     //             if (tempBuffsMap.find(param.portIndex) == tempBuffsMap.end()) {
+//     //                 tempBuffsMap[param.portIndex] = buf;
+//     //             }
+//     //         }
+//     //     }
+//     // }
+
+//     // // Gather inputs and outputs for each stage for the layer
+//     // for (int stage_num = 0; stage_num < kernels.size(); stage_num++) {
+//     //     const auto& kernel = kernels[stage_num];
+
+//     //     std::map<std::string, int> ports;
+//     //     std::vector<CustomDataFormat> formats;
+
+//     //     // Gather inputs
+//     //     DataVector stageInputs;
+//     //     for (auto& param : kernel.bindings()) {
+//     //         if (param.type == CustomParamType::Input) {
+//     //             ports[param.argName] = stageInputs.size();
+//     //             formats.emplace_back(param.format);
+//     //             stageInputs.emplace_back(inputs[param.portIndex]);
+//     //         } else if (param.type == CustomParamType::InputBuffer) {
+//     //             ports[param.argName] = stageInputs.size();
+//     //             formats.emplace_back(CustomDataFormat::BFYX);
+//     //             stageInputs.emplace_back(tempBuffsMap[param.portIndex]);
+//     //         }
+//     //     }
+
+//     //     // Gather data blobs
+//     //     for (auto& param : kernel.bindings()) {
+//     //         if (param.type == CustomParamType::Data) {
+//     //             auto blobIterator = layer->blobs.find(param.irSource);
+//     //             if (blobIterator != layer->blobs.end()) {
+//     //                 auto origBlob = blobIterator->second;
+//     //                 auto customBlob = model->addConstData(
+//     //                     layer->name + "@" + param.irSource,
+//     //                     DataDesc({origBlob->size()}),
+//     //                     ieBlobContent(origBlob));
+//     //                 ports[param.argName] = stageInputs.size();
+//     //                 formats.emplace_back(param.format);
+//     //                 stageInputs.emplace_back(std::move(customBlob));
+//     //             }
+//     //         }
+//     //     }
+
+//     //     formats.emplace_back(CustomDataFormat::Any);
+
+//     //     // Get kernel binary
+//     //     auto kernelNode = _kernelNodes.find(kernel.kernelBinary());
+//     //     if (kernelNode != _kernelNodes.end()) {
+//     //         stageInputs.emplace_back((kernelNode->second));
+//     //     } else {
+//     //         auto kernelBinaryDesc = DataDesc({kernel.kernelBinary().length()});
+//     //         kernelBinaryDesc.setType(DataType::U8);
+
+//     //         auto kernelBinary = model->addConstData(
+//     //             layer->type + "@kernelBinary",
+//     //             kernelBinaryDesc,
+//     //             std::make_shared<KernelBinaryContent>(kernel.kernelBinary()));
+//     //         stageInputs.emplace_back((kernelBinary));
+//     //         _kernelNodes[kernel.kernelBinary()] = kernelBinary;
+//     //     }
+
+//     //     DataVector stageOutputs;
+//     //     for (auto& param : kernel.bindings()) {
+//     //         if (param.type == CustomParamType::Output) {
+//     //             ports[param.argName] = stageInputs.size() + stageOutputs.size();
+//     //             stageOutputs.emplace_back(outputs[param.portIndex]);
+//     //         } else if (param.type == CustomParamType::OutputBuffer) {
+//     //             ports[param.argName] = stageInputs.size() + stageOutputs.size();
+//     //             stageOutputs.emplace_back(tempBuffsMap[param.portIndex]);
+//     //         }
+//     //     }
+
+//     //     auto stage = model->addNewStage<CustomStage>(
+//     //         layer->name + ((kernels.size() == 1) ? "" : "@stage_" + std::to_string(stage_num)),
+//     //         StageType::Custom,
+//     //         layer,
+//     //         stageInputs,
+//     //         stageOutputs);
+
+//     //     stage->attrs().set("customKernel", suitableLayer->kernels()[stage_num]);
+//     //     stage->attrs().set("ports", ports);
+//     //     stage->attrs().set("formats", formats);
+
+//     //     const auto& dimSource = (kernel.dimSource() == CustomDimSource::Input) ? inputs : outputs;
+//     //     const auto& dataDesc = dimSource[kernel.dimSourceIndex()]->desc();
+
+//     //     const auto gws = calcSizesFromParams(dataDesc, kernel.globalGridSizeRules(), layer->params);
+//     //     const auto lws = calcSizesFromParams(dataDesc, kernel.localGridSizeRules(), layer->params);
+
+//     //     stage->attrs().set("gws", gws);
+//     //     stage->attrs().set("lws", lws);
+
+//     //     const auto localDataSizes = [&] {
+//     //         auto sizes = std::map<std::string, int>{};
+//     //         for (const auto& bind : kernel.bindings()) {
+//     //             if (bind.type == CustomParamType::LocalData) {
+//     //                 const auto& source = bind.dimSource == CustomDimSource::Input ? inputs : outputs;
+//     //                 const auto& desc = source[bind.dimIdx]->desc();
+//     //                 const auto size = calcSizesFromParams(desc, { bind.bufferSizeRule }, layer->params);
+//     //                 sizes.emplace(bind.argName, size[0]);
+//     //             }
+//     //         }
+//     //         return sizes;
+//     //     }();
+
+//     //     stage->attrs().set("localDataSizes", localDataSizes);
+
+//     //     std::map<int, DimsOrder> inputOrders;
+//     //     std::map<int, DimsOrder> outputOrders;
+
+//     //     std::map<std::string, CustomKernel::KernelParam> b2b;
+//     //     for (const auto& kp : kernel.bindings()) {
+//     //         b2b[kp.argName] = kp;
+//     //     }
+
+//     //     const std::map<CustomDataFormat, DimsOrder> formatsMap = {
+//     //         { CustomDataFormat::BYXF, DimsOrder::NHWC },
+//     //         { CustomDataFormat::BFYX, DimsOrder::NCHW },
+//     //         { CustomDataFormat::YXF, DimsOrder::HWC },
+//     //         { CustomDataFormat::FYX, DimsOrder::CHW }
+//     //     };
+
+//     //     for (const auto& kp : kernel.parameters()) {
+//     //         const auto& parameter = b2b[kp];
+
+//     //         if (parameter.type == CustomParamType::Input) {
+//     //             auto it = formatsMap.find(parameter.format);
+//     //             if (it != formatsMap.end()) {
+//     //                 auto requiredOrder = it->second;
+//     //                 inputOrders[parameter.portIndex] = requiredOrder;
+//     //             }
+//     //         }
+
+//     //         if (parameter.type == CustomParamType::Output) {
+//     //             auto it = formatsMap.find(parameter.format);
+//     //             if (it != formatsMap.end()) {
+//     //                 auto requiredOrder = it->second;
+//     //                 outputOrders[parameter.portIndex] = requiredOrder;
+//     //             }
+//     //         }
+//     //     }
+
+//     //     stage->attrs().set("inputOrders", std::move(inputOrders));
+//     //     stage->attrs().set("outputOrders", std::move(outputOrders));
+
+//     //     auto buffer_size = kernel.kernelBinary().length() + 1024;
+//     //     model->addTempBuffer(stage, buffer_size);
+//     // }
+// }
+
+
+
+// }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/deconvolution.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/deconvolution.cpp
@@ -15,33 +15,37 @@
 
 namespace vpu {
 
-void FrontEnd::parseDeconvolution(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parseDeconvolution(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
     IE_ASSERT(inputs.size() == 1);
     IE_ASSERT(outputs.size() == 1);
-
+    auto deconv = ngraph::as_type_ptr<ngraph::opset4::ConvolutionBackpropData>(node);
+    VPU_THROW_UNLESS(deconv != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", deconv->get_friendly_name(), deconv->get_type_name());
     //
     // Extract parameters
     //
+    auto filtersShape = deconv->input_value(1).get_partial_shape().to_shape();
+    auto strides = deconv->get_strides();
+    auto padsBegin = deconv->get_pads_begin();
+    auto padsEnd = deconv->get_pads_end();
+    auto dilations = deconv->get_dilations();
+    size_t group = deconv->input_value(1).get_shape()[0];
 
-    auto deconvLayer = std::dynamic_pointer_cast<ie::DeconvolutionLayer>(layer);
-    IE_ASSERT(deconvLayer != nullptr);
+    int kernelSizeX = filtersShape[1]; //deconvLayer->_kernel_x;
+    int kernelSizeY = filtersShape[0];
 
-    int kernelSizeX = deconvLayer->_kernel_x;
-    int kernelSizeY = deconvLayer->_kernel_y;
+    int kernelStrideX = strides[1];  //deconvLayer->_stride_x;
+    int kernelStrideY = strides[0];  //deconvLayer->_stride_y;
 
-    int kernelStrideX = deconvLayer->_stride_x;
-    int kernelStrideY = deconvLayer->_stride_y;
+    // auto paddings = getPaddings(*deconvLayer);
+    int padLeft = padsBegin[1]; // paddings.begin.exist(ie::X_AXIS) ? paddings.begin[ie::X_AXIS] : 0;
+    int padRight = padsEnd[1];  // paddings.end.exist(ie::X_AXIS) ? paddings.end[ie::X_AXIS] : padLeft;
+    int padTop =  padsBegin[0]; // paddings.begin.exist(ie::Y_AXIS) ? paddings.begin[ie::Y_AXIS] : 0;
+    int padBottom = padsEnd[0]; // paddings.end.exist(ie::Y_AXIS) ? paddings.end[ie::Y_AXIS] : 0;
 
-    auto paddings = getPaddings(*deconvLayer);
-    int padLeft = paddings.begin.exist(ie::X_AXIS) ? paddings.begin[ie::X_AXIS] : 0;
-    int padRight = paddings.end.exist(ie::X_AXIS) ? paddings.end[ie::X_AXIS] : padLeft;
-    int padTop = paddings.begin.exist(ie::Y_AXIS) ? paddings.begin[ie::Y_AXIS] : 0;
-    int padBottom = paddings.end.exist(ie::Y_AXIS) ? paddings.end[ie::Y_AXIS] : 0;
+    int dilationX = dilations[1]; // deconvLayer->_dilation_x;
+    int dilationY = dilations[0]; // deconvLayer->_dilation_y;
 
-    int dilationX = deconvLayer->_dilation_x;
-    int dilationY = deconvLayer->_dilation_y;
-
-    int groupSize = deconvLayer->_group;
+    int groupSize = group; // deconvLayer->_group;
 
     //
     // Create const datas
@@ -59,7 +63,9 @@ void FrontEnd::parseDeconvolution(const Model& model, const ie::CNNLayerPtr& lay
     }
 
     Data weights, biases;
-    std::tie(weights, biases) = getWeightsAndBiases(model, layer);
+    const auto weightsNode = deconv->input_value(1).get_node_shared_ptr();
+    const auto biasNode = deconv->inputs().size() == 3 ? deconv->input_value(2).get_node_shared_ptr() : NodePtr();
+    std::tie(weights, biases) = getWeightsAndBiases(model, deconv->get_friendly_name(), weightsNode, biasNode);
 
     IE_ASSERT(weights->desc().totalDimSize() >=
               kernelSizeX * kernelSizeY * (input->desc().dim(Dim::C) / groupSize) * output->desc().dim(Dim::C));
@@ -85,9 +91,9 @@ void FrontEnd::parseDeconvolution(const Model& model, const ie::CNNLayerPtr& lay
     //
 
     auto stage = model->addNewStage<StubStage>(
-        layer->name,
+        deconv->get_friendly_name(),
         StageType::StubDeconv,
-        layer,
+        deconv,
         {input, weights, biases, model->addFakeData()},
         {output});
 

--- a/inference-engine/src/vpu/graph_transformer/src/stages/detection_output.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/detection_output.cpp
@@ -149,9 +149,11 @@ private:
 
 }  // namespace
 
-void FrontEnd::parseDetectionOutput(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parseDetectionOutput(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
     const auto& env = CompileEnv::get();
 
+    const auto& detectionOutput = ngraph::as_type_ptr<ngraph::opset4::DetectionOutput>(node);
+    VPU_THROW_UNLESS(detectionOutput != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
     IE_ASSERT(inputs.size() == 3 || inputs.size() == 5);
     IE_ASSERT(outputs.size() == 1);
 
@@ -160,21 +162,22 @@ void FrontEnd::parseDetectionOutput(const Model& model, const ie::CNNLayerPtr& l
     auto priors = inputs[2];
 
     DetectionOutputParams detParams;
-    detParams.num_classes = layer->GetParamAsInt("num_classes", 0);
-    detParams.background_label_id = layer->GetParamAsInt("background_label_id", 0);
-    detParams.top_k = layer->GetParamAsInt("top_k", -1);
-    detParams.variance_encoded_in_target = layer->GetParamAsInt("variance_encoded_in_target", 0);
-    detParams.keep_top_k = layer->GetParamAsInt("keep_top_k", -1);
-    detParams.nms_threshold = layer->GetParamAsFloat("nms_threshold", 0);
-    detParams.confidence_threshold = layer->GetParamAsFloat("confidence_threshold", -1.0f);
-    detParams.share_location = layer->GetParamAsInt("share_location", 1);
-    detParams.clip_before_nms = layer->GetParamAsInt("clip_before_nms", 0) || layer->GetParamAsInt("clip", 0);
-    detParams.clip_after_nms = layer->GetParamAsInt("clip_after_nms", 0);
-    detParams.decrease_label_id = layer->GetParamAsInt("decrease_label_id", 0);
-    detParams.normalized = layer->GetParamAsInt("normalized", 1);
-    detParams.image_height = layer->GetParamAsInt("input_height", 1);
-    detParams.image_width = layer->GetParamAsInt("input_width", 1);
-    detParams.objectness_score = layer->GetParamAsFloat("objectness_score", -1.0f);
+    const auto detectionOutputAttrs = detectionOutput->get_attrs();
+    detParams.num_classes = detectionOutputAttrs.num_classes;
+    detParams.background_label_id = detectionOutputAttrs.background_label_id;
+    detParams.top_k = detectionOutputAttrs.top_k;
+    detParams.variance_encoded_in_target = detectionOutputAttrs.variance_encoded_in_target;
+    detParams.keep_top_k = detectionOutputAttrs.keep_top_k[0];  //  ???
+    detParams.nms_threshold = detectionOutputAttrs.nms_threshold;
+    detParams.confidence_threshold = detectionOutputAttrs.confidence_threshold;
+    detParams.share_location = detectionOutputAttrs.share_location;
+    detParams.clip_before_nms = detectionOutputAttrs.clip_before_nms;
+    detParams.clip_after_nms = detectionOutputAttrs.clip_after_nms;
+    detParams.decrease_label_id = static_cast<int>(detectionOutputAttrs.decrease_label_id);
+    detParams.normalized = detectionOutputAttrs.normalized;
+    detParams.image_height = detectionOutputAttrs.input_height;
+    detParams.image_width = detectionOutputAttrs.input_width;
+    detParams.objectness_score = detectionOutputAttrs.objectness_score;
     detParams.has_arm_inputs = inputs.size() == 5 ? 1 : 0;
 
     int prior_size = detParams.normalized ? 4 : 5;
@@ -183,7 +186,7 @@ void FrontEnd::parseDetectionOutput(const Model& model, const ie::CNNLayerPtr& l
     detParams.num_priors = static_cast<int>(priors->desc().dim(Dim::W) / prior_size);
     detParams.num = static_cast<int>(conf->desc().dim(Dim::N));
 
-    auto code_type_str = layer->GetParamAsString("code_type", "caffe.PriorBoxParameter.CENTER_SIZE");
+    auto code_type_str = detectionOutputAttrs.code_type;
     if (code_type_str.find("CORNER_SIZE") != std::string::npos) {
         detParams.code_type = CORNER_SIZE;
     } else if (code_type_str.find("CENTER_SIZE") != std::string::npos) {
@@ -191,7 +194,7 @@ void FrontEnd::parseDetectionOutput(const Model& model, const ie::CNNLayerPtr& l
     } else if (code_type_str.find("CORNER") != std::string::npos) {
         detParams.code_type = CORNER;
     } else {
-        VPU_THROW_EXCEPTION << "Unknown code_type " << code_type_str << " for DetectionOutput layer " << layer->name;
+        VPU_THROW_EXCEPTION << "Unknown code_type " << code_type_str << " for DetectionOutput layer " << detectionOutput->get_friendly_name();
     }
 
     if (detParams.keep_top_k < 0)
@@ -212,7 +215,7 @@ void FrontEnd::parseDetectionOutput(const Model& model, const ie::CNNLayerPtr& l
     if (outputs[0]->desc().dim(Dim::W) != 7)
         VPU_THROW_EXCEPTION << "Detection Output: Support only 7 vals per detection.";
 
-    auto stage = model->addNewStage<DetectionOutputStage>(layer->name, StageType::DetectionOutput, layer, inputs, outputs);
+    auto stage = model->addNewStage<DetectionOutputStage>(detectionOutput->get_friendly_name(), StageType::DetectionOutput, detectionOutput, inputs, outputs);
 
     stage->attrs().set("params", detParams);
 

--- a/inference-engine/src/vpu/graph_transformer/src/stages/dynamic_shape_resolver.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/dynamic_shape_resolver.cpp
@@ -5,44 +5,44 @@
 #include <vpu/frontend/frontend.hpp>
 #include <vpu/utils/shape_io.hpp>
 
-#include <ngraph/node.hpp>
-
+#include "vpu/ngraph/operations/dynamic_shape_resolver.hpp"
 namespace vpu {
 
-void FrontEnd::parseDSR(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) {
+void FrontEnd::parseDSR(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) {
+    auto dsr = ngraph::as_type_ptr<ngraph::vpu::op::DynamicShapeResolver>(node);
     VPU_THROW_UNLESS(inputs.size() == 2, "Error while parsing {} of type {}, got {} inputs, while {} were expected",
-        layer->name, layer->type, inputs.size(), 2);
+        dsr->get_friendly_name(), dsr->get_type_name(), inputs.size(), 2);
     const auto& data = inputs[0];
     const auto& shape = inputs[1];
 
     VPU_THROW_UNLESS(outputs.size() == 1, "Parsing layer {} of type {} failed: got {} outputs, while {} were expected",
-         layer->name, layer->type, outputs.size(), 1);
+         dsr->get_friendly_name(), dsr->get_type_name(), outputs.size(), 1);
     auto dataOutput = outputs[0];
 
-    const auto ngraphNode = layer->getNode();
-    VPU_THROW_UNLESS(!ngraphNode || ngraphNode->get_input_source_output(0).get_target_inputs().size() == 1,
+    VPU_THROW_UNLESS(!dsr || dsr->get_input_source_output(0).get_target_inputs().size() == 1,
         "Parsing layer {} of type {} failed: input with index {} (of name {}) must not be an input for any operation except current "
         "of type {}, actual number of operations for which data is input is {}. "
         "DynamicToStaticShape transformations should add {} operation after all operations with dynamic output as only "
         "consumer. All operations that were previously original output data consumers should now consume the output data "
         "from {}. Otherwise the consumer which was not redirected to {} output would process garbage data.",
-        layer->name, layer->type, 0, data->name(), layer->type, ngraphNode->get_input_source_output(0).get_target_inputs().size(),
-        layer->type, layer->type);
+        dsr->get_friendly_name(), dsr->get_type_name(), 0, data->name(), dsr->get_type_name(), dsr->get_input_source_output(0).get_target_inputs().size(),
+        dsr->get_friendly_name(), dsr->get_type_name());
+
     VPU_THROW_UNLESS(data->consumerEdges().size() == 0,
         "Parsing layer {} of type {} failed: input with index {} (of name {}) must have no consumers, actual: {}. "
         "DynamicToStaticShape transformations should add {} operation after all operations with dynamic output as only "
         "consumer. All operations that were previously original output data consumers should now consume the output data "
         "from {}. Otherwise the consumer which was not redirected to {} output would process garbage data.",
-        layer->name, layer->type, 0, data->name(), data->consumerEdges().size(), layer->type, layer->type, layer->type);
+        dsr->get_friendly_name(), dsr->get_type_name(), 0, data->name(), data->consumerEdges().size(), dsr->get_type_name(), dsr->get_type_name(), dsr->get_type_name());
 
     VPU_THROW_UNLESS(shape->desc().numDims() == 1,
         "Parsing layer {} of type {} failed: input with index {} (of name {}) must have rank equal to {}, actual is {}",
-        layer->name, layer->type, 0, shape->name(), 1, shape->desc().numDims());
+        dsr->get_friendly_name(), dsr->get_type_name(), 0, shape->name(), 1, shape->desc().numDims());
 
     VPU_THROW_UNLESS(shape->desc().totalDimSize() == data->desc().numDims(),
         "Parsing layer {} of type {} failed: input with index {} (of name {}) must have the same total elements number as "
         "input with index {} (of name {}), actual {} and {} respectively",
-        layer->name, layer->type, 0, shape->name(), 1, data->name(), shape->desc().totalDimSize(), data->desc().numDims());
+        dsr->get_friendly_name(), dsr->get_type_name(), 0, shape->name(), 1, data->name(), shape->desc().totalDimSize(), data->desc().numDims());
 
     const auto dataProducerEdge = data->producerEdge();
     const auto shapeProducerEdge = shape->producerEdge();
@@ -50,19 +50,19 @@ void FrontEnd::parseDSR(const Model& model, const ie::CNNLayerPtr& layer, const 
     if (dataProducerEdge == nullptr) {
         VPU_THROW_UNLESS(data->usage() == DataUsage::Input,
             "Parsing layer {} of type {} failed: if input with index {} (of name {}) has not a producer, it must have Input "
-            "data usage, actual: {}", layer->name, layer->type, 0, data->name(), data->usage());
-        const auto& origData = dataOutput->origData();
-        VPU_THROW_UNLESS(origData != nullptr,
+            "data usage, actual: {}", dsr->get_friendly_name(), dsr->get_type_name(), 0, data->name(), data->usage());
+        const auto& origNode = dataOutput->origNode();
+        VPU_THROW_UNLESS(origNode != nullptr,
             "Parsing layer {} of type {} failed: output data with index {} (of name {}) must have original IE data",
-            layer->name, layer->type, 0, dataOutput->name());
+            dsr->get_friendly_name(), dsr->get_type_name(), 0, dataOutput->name());
 
-        bindData(data, origData);
+        bindData(data, origNode->get_input_source_output(0), origNode);
         model->removeUnusedData(dataOutput);
         dataOutput = data;
     } else {
         VPU_THROW_UNLESS(data->usage() == DataUsage::Intermediate,
             "Parsing layer {} of type {} failed: if input with index {} (of name {}) has a producer, it must have Intermediate "
-            "data usage, actual: {}", layer->name, layer->type, 0, data->name(), data->usage());
+            "data usage, actual: {}", dsr->get_friendly_name(), dsr->get_type_name(), 0, data->name(), data->usage());
 
         if (auto dataToShapeEdge = data->parentDataToShapeEdge()) {
             const auto& parent = dataToShapeEdge->parent();
@@ -73,8 +73,8 @@ void FrontEnd::parseDSR(const Model& model, const ie::CNNLayerPtr& layer, const 
                 "with name \"{}\". The case of connected inputs is considered as \"{}\" that goes directly to \"{}\" as a result of "
                 "some optimization (operation between them has been optimized out). Other cases, when some input already has a "
                 "connection, but with other data object are prohibited.",
-                layer->type, layer->name, 0, data->name(), 1, shape->name(),
-                layer->type, parent->name(), layer->type, layer->type);
+                dsr->get_friendly_name(), dsr->get_type_name(), 0, data->name(), 1, shape->name(),
+                 dsr->get_type_name(), parent->name(), dsr->get_type_name(), dsr->get_type_name());
             model->disconnectDatas(dataToShapeEdge);
         }
         model->replaceStageOutput(dataProducerEdge, dataOutput);
@@ -84,19 +84,19 @@ void FrontEnd::parseDSR(const Model& model, const ie::CNNLayerPtr& layer, const 
     if (shapeProducerEdge == nullptr) {
         VPU_THROW_UNLESS(shape->usage() == DataUsage::Input,
             "Parsing layer {} of type {} failed: if input with index {} (of name {}) has not a producer, it must have Input "
-            "data usage, actual: {}", layer->name, layer->type, 1, shape->name(), shape->usage());
+            "data usage, actual: {}", dsr->get_friendly_name(), dsr->get_type_name(), 1, shape->name(), shape->usage());
     } else {
         VPU_THROW_UNLESS(shape->usage() == DataUsage::Intermediate || shape->usage() == DataUsage::Output,
             "Parsing layer {} of type {} failed: if input with index {} (of name {}) has a producer, it must have Intermediate "
             "or Output (if already has been associated with other output data) data usage, actual: {}",
-            layer->name, layer->type, 1, shape->name(), shape->usage());
+            dsr->get_friendly_name(), dsr->get_type_name(), 1, shape->name(), shape->usage());
     }
 
     auto shapeDataObject = shape;
     if (dataOutput->usage() == DataUsage::Output && shapeDataObject->usage() != DataUsage::Output) {
         const auto& shapeOutput = model->addOutputData(createIOShapeName(dataOutput->name()), shape->desc());
 
-        bindData(shapeOutput, shape->origData());
+        bindData(shapeOutput, shape->origNode()->get_input_source_output(0), shape->origNode());
         for (const auto& shapeConsumerEdge : shape->consumerEdges()) {
             model->replaceStageInput(shapeConsumerEdge, shapeOutput);
         }
@@ -108,8 +108,8 @@ void FrontEnd::parseDSR(const Model& model, const ie::CNNLayerPtr& layer, const 
         if (!shapeProducerEdge) {
             _stageBuilder->addCopyStage(
                     model,
-                    layer->name + "@copy-for-dynamic-output",
-                    layer,
+                    dsr->get_friendly_name() + "@copy-for-dynamic-output",
+                    dsr,
                     shape,
                     shapeOutput,
                     "DynamicShapeResolver");

--- a/inference-engine/src/vpu/graph_transformer/src/stages/eltwise.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/eltwise.cpp
@@ -15,14 +15,22 @@
 
 #include <vpu/utils/numeric.hpp>
 
-#define MAP_ELEMENTS(op, f) {InferenceEngine::EltwiseLayer::eOperation::op, &f<StageType::op>}
+#define MAP_ELEMENTS(op, f) {vpu::EltwiseOperation::op, &f<StageType::op>}
+
+
+// void FrontEnd::parseSubtract(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+//     auto subtract = ngraph::as_type_ptr<ngraph::opset4::Subtract>(node);
+//     VPU_THROW_UNLESS(subtract != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+//     auto eltwiseOp = EltwiseOperation::Sub;
+//     parseEltwiseImpl(model, node, inputs, outputs, eltwiseOp);
+    
+// }
 
 namespace vpu {
 
 namespace {
-
 template<StageType T>
-StageType onlyOneInput(ie::EltwiseLayer::eOperation op, size_t input_size) {
+StageType onlyOneInput(EltwiseOperation op, size_t input_size) {
     if (input_size != 1) {
         VPU_THROW_EXCEPTION << "Eltwise operation: " << T << " supports only one input";
     }
@@ -30,7 +38,7 @@ StageType onlyOneInput(ie::EltwiseLayer::eOperation op, size_t input_size) {
 }
 
 template<StageType T>
-StageType onlyTwoInputs(ie::EltwiseLayer::eOperation op, size_t input_size) {
+StageType onlyTwoInputs(EltwiseOperation op, size_t input_size) {
     if (input_size != 2) {
         VPU_THROW_EXCEPTION << "Eltwise operation: " << T << " supports only two inputs";
     }
@@ -38,7 +46,7 @@ StageType onlyTwoInputs(ie::EltwiseLayer::eOperation op, size_t input_size) {
 }
 
 template<StageType T>
-StageType moreThanOneInput(ie::EltwiseLayer::eOperation op, size_t input_size) {
+StageType moreThanOneInput(EltwiseOperation op, size_t input_size) {
     if (input_size < 2) {
         VPU_THROW_EXCEPTION << "Eltwise operation: " << T << " supports two inputs and more";
     }
@@ -46,14 +54,14 @@ StageType moreThanOneInput(ie::EltwiseLayer::eOperation op, size_t input_size) {
 }
 
 template<StageType T>
-StageType onlyThreeInputs(ie::EltwiseLayer::eOperation op, size_t input_size) {
+StageType onlyThreeInputs(EltwiseOperation op, size_t input_size) {
     if (input_size != 3) {
         VPU_THROW_EXCEPTION << "Eltwise operation: " << T << " supports only three inputs";
     }
     return T;
 }
 
-static const std::map<ie::EltwiseLayer::eOperation, std::function<StageType(ie::EltwiseLayer::eOperation, size_t)>> eltwise_map = {
+static const std::map<EltwiseOperation, std::function<StageType(EltwiseOperation, size_t)>> eltwise_map = {
         MAP_ELEMENTS(Sum,           moreThanOneInput),
         MAP_ELEMENTS(Prod,          moreThanOneInput),
         MAP_ELEMENTS(Max,           moreThanOneInput),
@@ -220,37 +228,150 @@ private:
 
 }  // namespace
 
-void FrontEnd::parseEltwise(const Model& model, const ie::CNNLayerPtr& _layer, const DataVector& inputs, const DataVector& outputs) const {
-    auto layer = std::dynamic_pointer_cast<ie::EltwiseLayer>(_layer);
-    IE_ASSERT(layer != nullptr);
+
+// Rework it by using macroses
+void FrontEnd::parseSubtract(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    auto subtract = ngraph::as_type_ptr<ngraph::opset4::Subtract>(node);
+    VPU_THROW_UNLESS(subtract != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+    auto eltwiseOp = EltwiseOperation::Sub;
+    parseEltwiseImpl(model, node, inputs, outputs, eltwiseOp);
+    
+}
+
+void FrontEnd::parseAdd(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    auto subtract = ngraph::as_type_ptr<ngraph::opset4::Add>(node);
+    VPU_THROW_UNLESS(subtract != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+    auto eltwiseOp = EltwiseOperation::Sum;
+    parseEltwiseImpl(model, node, inputs, outputs, eltwiseOp);
+}
+
+void FrontEnd::parseMultiply(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    auto subtract = ngraph::as_type_ptr<ngraph::opset4::Multiply>(node);
+    VPU_THROW_UNLESS(subtract != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+    auto eltwiseOp = EltwiseOperation::Prod;
+    parseEltwiseImpl(model, node, inputs, outputs, eltwiseOp);
+}
+void FrontEnd::parseMaximum(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    auto subtract = ngraph::as_type_ptr<ngraph::opset4::Maximum>(node);
+    VPU_THROW_UNLESS(subtract != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+    auto eltwiseOp = EltwiseOperation::Max;
+    parseEltwiseImpl(model, node, inputs, outputs, eltwiseOp);
+}
+void FrontEnd::parseDivide(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    auto subtract = ngraph::as_type_ptr<ngraph::opset4::Divide>(node);
+    VPU_THROW_UNLESS(subtract != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+    auto eltwiseOp = EltwiseOperation::Div;
+    parseEltwiseImpl(model, node, inputs, outputs, eltwiseOp);
+}
+void FrontEnd::parseMinimum(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    auto subtract = ngraph::as_type_ptr<ngraph::opset4::Minimum>(node);
+    VPU_THROW_UNLESS(subtract != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+    auto eltwiseOp = EltwiseOperation::Min;
+    parseEltwiseImpl(model, node, inputs, outputs, eltwiseOp);
+}
+void FrontEnd::parseSquaredDifference(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    auto subtract = ngraph::as_type_ptr<ngraph::opset4::SquaredDifference>(node);
+    VPU_THROW_UNLESS(subtract != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+    auto eltwiseOp = EltwiseOperation::Squared_diff;
+    parseEltwiseImpl(model, node, inputs, outputs, eltwiseOp);
+}
+void FrontEnd::parseEqual(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    auto subtract = ngraph::as_type_ptr<ngraph::opset4::Equal>(node);
+    VPU_THROW_UNLESS(subtract != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+    auto eltwiseOp = EltwiseOperation::Equal;
+    parseEltwiseImpl(model, node, inputs, outputs, eltwiseOp);
+}
+void FrontEnd::parseNotEqual(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    auto subtract = ngraph::as_type_ptr<ngraph::opset4::NotEqual>(node);
+    VPU_THROW_UNLESS(subtract != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+    auto eltwiseOp = EltwiseOperation::Not_equal;
+    parseEltwiseImpl(model, node, inputs, outputs, eltwiseOp);
+}
+void FrontEnd::parseGreater(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    auto subtract = ngraph::as_type_ptr<ngraph::opset4::Greater>(node);
+    VPU_THROW_UNLESS(subtract != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+    auto eltwiseOp = EltwiseOperation::Greater;
+    parseEltwiseImpl(model, node, inputs, outputs, eltwiseOp);
+}
+void FrontEnd::parseGreaterEqual(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    auto subtract = ngraph::as_type_ptr<ngraph::opset4::GreaterEqual>(node);
+    VPU_THROW_UNLESS(subtract != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+    auto eltwiseOp = EltwiseOperation::Greater_equal;
+    parseEltwiseImpl(model, node, inputs, outputs, eltwiseOp);
+}
+void FrontEnd::parseLess(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    auto subtract = ngraph::as_type_ptr<ngraph::opset4::Less>(node);
+    VPU_THROW_UNLESS(subtract != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+    auto eltwiseOp = EltwiseOperation::Less;
+    parseEltwiseImpl(model, node, inputs, outputs, eltwiseOp);
+}
+void FrontEnd::parseLessEqual(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    auto subtract = ngraph::as_type_ptr<ngraph::opset4::LessEqual>(node);
+    VPU_THROW_UNLESS(subtract != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+    auto eltwiseOp = EltwiseOperation::Less_equal;
+    parseEltwiseImpl(model, node, inputs, outputs, eltwiseOp);
+}
+void FrontEnd::parseLogicalNot(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    auto subtract = ngraph::as_type_ptr<ngraph::opset4::LogicalNot>(node);
+    VPU_THROW_UNLESS(subtract != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+    auto eltwiseOp = EltwiseOperation::Logical_NOT;
+    parseEltwiseImpl(model, node, inputs, outputs, eltwiseOp);
+}
+void FrontEnd::parseLogicalAnd(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    auto subtract = ngraph::as_type_ptr<ngraph::opset4::LogicalAnd>(node);
+    VPU_THROW_UNLESS(subtract != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+    auto eltwiseOp = EltwiseOperation::Logical_AND;
+    parseEltwiseImpl(model, node, inputs, outputs, eltwiseOp);
+}
+void FrontEnd::parseLogicalOr(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    auto subtract = ngraph::as_type_ptr<ngraph::opset4::LogicalOr>(node);
+    VPU_THROW_UNLESS(subtract != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+    auto eltwiseOp = EltwiseOperation::Logical_OR;
+    parseEltwiseImpl(model, node, inputs, outputs, eltwiseOp);
+}
+void FrontEnd::parseLogicalXor(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    auto subtract = ngraph::as_type_ptr<ngraph::opset4::LogicalXor>(node);
+    VPU_THROW_UNLESS(subtract != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+    auto eltwiseOp = EltwiseOperation::Logical_XOR;
+    parseEltwiseImpl(model, node, inputs, outputs, eltwiseOp);
+}
+
+void FrontEnd::parseFloorMod(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    auto subtract = ngraph::as_type_ptr<ngraph::opset4::FloorMod>(node);
+    VPU_THROW_UNLESS(subtract != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+    auto eltwiseOp = EltwiseOperation::Floor_mod;
+    parseEltwiseImpl(model, node, inputs, outputs, eltwiseOp);
+}
+
+void FrontEnd::parseEltwiseImpl(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs, const EltwiseOperation eltwiseOperation) const {
 
     IE_ASSERT(outputs.size() == 1);
-
     auto stageType = StageType::None;
     auto subCoefficient = 1;
 
-    if (layer->_operation == ie::EltwiseLayer::eOperation::Sub) {
+    if (eltwiseOperation == EltwiseOperation::Sub) {
         if (inputs.size() != 2) {
-            VPU_THROW_EXCEPTION << "Eltwise operation: " << layer->_operation << " with multiple inputs is not supported";
+            VPU_THROW_EXCEPTION << "Eltwise operation: " << node->get_type_name() << " with multiple inputs is not supported";
         }
         stageType = StageType::Sum;
         subCoefficient = -1;
-    } else if (layer->_operation == ie::EltwiseLayer::eOperation::Mean) {
-        if (inputs.size() != 2) {
-            VPU_THROW_EXCEPTION << "Eltwise operation: " << layer->_operation << " with multiple inputs is not supported";
-        }
-        stageType = StageType::Sum;
-    } else {
-        if (eltwise_map.find(layer->_operation) != eltwise_map.end()) {
-            stageType = eltwise_map.at(layer->_operation)(layer->_operation, inputs.size());
+    }
+    //  else if (/*layer->_operation == ie::EltwiseLayer::eOperation::Mean*/1) {
+    //     if (inputs.size() != 2) {
+    //         VPU_THROW_EXCEPTION << "Eltwise operation: " << eltwiseOperation << " with multiple inputs is not supported";
+    //     }
+    //     stageType = StageType::Sum;
+    else {
+        if (eltwise_map.find(eltwiseOperation) != eltwise_map.end()) {
+            stageType = eltwise_map.at(eltwiseOperation)(eltwiseOperation, inputs.size());
         } else {
-            VPU_THROW_EXCEPTION << "Eltwise operation: " << layer->_operation << " is not supported";
+            VPU_THROW_EXCEPTION << "Eltwise operation: " << eltwiseOperation << " is not supported";
         }
     }
 
-    if (stageType != StageType::Sum && !layer->coeff.empty()) {
-        VPU_THROW_EXCEPTION << layer->name << " coefficients only supported for Sum/Sub operations.";
-    }
+    // if (stageType != StageType::Sum && !layer->coeff.empty()) {
+    //     VPU_THROW_EXCEPTION << layer->name << " coefficients only supported for Sum/Sub operations.";
+    // }
 
     auto output = outputs[0];
 
@@ -271,32 +392,33 @@ void FrontEnd::parseEltwise(const Model& model, const ie::CNNLayerPtr& _layer, c
 
     tempInputs[2] = model->addFakeData();
 
-    auto stage = model->addNewStage<EltwiseStage>(layer->name, stageType, layer, tempInputs, {tempOutput});
+    auto stage = model->addNewStage<EltwiseStage>(node->get_friendly_name(), stageType, node, tempInputs, {tempOutput});
 
     const auto& type = inputs.front()->desc().type();
     IE_ASSERT(type == DataType::FP16 || type == DataType::S32);
 
-    if (layer->_operation == ie::EltwiseLayer::eOperation::Mean) {
-        // Mean supports only FP16
-        IE_ASSERT(type == DataType::FP16);
-        stage->attrs().set<float>("coeff1",  0.5);
-        stage->attrs().set<float>("coeff2",  0.5);
-    } else {
-        if (layer->coeff.size() > 0) {
-            if (type == DataType::FP16) {
-                stage->attrs().set<float>("coeff1", layer->coeff[0]);
-            } else {
-                stage->attrs().set<std::int32_t>("coeff1", static_cast<int32_t>(layer->coeff[0]));
-            }
-        }
-        if (layer->coeff.size() > 1 || subCoefficient != 1) {
-            if (type == DataType::FP16) {
-                stage->attrs().set<float>("coeff2", subCoefficient * (layer->coeff.size() > 1 ? layer->coeff[1] : 1.0f));
-            } else {
-                stage->attrs().set<std::int32_t>("coeff2", subCoefficient * (layer->coeff.size() > 1 ? static_cast<int32_t>(layer->coeff[1]) : 1));
-            }
-        }
-    }
+    // if (eltwiseOperation == ie::EltwiseLayer::eOperation::Mean) {
+    //     // Mean supports only FP16
+    //     auto mean = ngraph::as_type_ptr<ngraph::opset4::Add>(node);
+    //     IE_ASSERT(type == DataType::FP16);
+    //     stage->attrs().set<float>("coeff1",  0.5);
+    //     stage->attrs().set<float>("coeff2",  0.5);
+    // } else {
+    //     if (layer->coeff.size() > 0) {
+    //         if (type == DataType::FP16) {
+    //             stage->attrs().set<float>("coeff1", layer->coeff[0]);
+    //         } else {
+    //             stage->attrs().set<std::int32_t>("coeff1", static_cast<int32_t>(layer->coeff[0]));
+    //         }
+    //     }
+    //     if (layer->coeff.size() > 1 || subCoefficient != 1) {
+    //         if (type == DataType::FP16) {
+    //             stage->attrs().set<float>("coeff2", subCoefficient * (layer->coeff.size() > 1 ? layer->coeff[1] : 1.0f));
+    //         } else {
+    //             stage->attrs().set<std::int32_t>("coeff2", subCoefficient * (layer->coeff.size() > 1 ? static_cast<int32_t>(layer->coeff[1]) : 1));
+    //         }
+    //     }
+    // }
 
     stage->attrs().set<StageType>("postOperation", StageType::Empty);
 
@@ -313,35 +435,34 @@ void FrontEnd::parseEltwise(const Model& model, const ie::CNNLayerPtr& _layer, c
         }
 
         stage = model->addNewStage<EltwiseStage>(
-            layer->name + "@" + std::to_string(ind - 1),
+            node->get_friendly_name() + "@" + std::to_string(ind - 1),
             stageType,
-            layer,
+            node,
             tempInputs,
             {tempOutput});
 
-        if (layer->coeff.size() > ind) {
-            stage->attrs().set<float>("coeff2", layer->coeff[ind]);
-        }
+        // if (layer->coeff.size() > ind) {
+        //     stage->attrs().set<float>("coeff2", layer->coeff[ind]);
+        // }
 
         tempInputs[0] = tempOutput;
     }
 }
 
-void FrontEnd::parseSelect(const Model& model, const ie::CNNLayerPtr& _layer, const DataVector& inputs, const DataVector& outputs) const {
-    auto layer = std::dynamic_pointer_cast<ie::SelectLayer>(_layer);
-    IE_ASSERT(layer != nullptr);
-
+void FrontEnd::parseSelect(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    auto select = ngraph::as_type_ptr<ngraph::opset4::Select>(node);
+    VPU_THROW_UNLESS(select != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
     if (inputs.size() != 3) {
         VPU_THROW_EXCEPTION << "Select supports only three inputs";
     }
 
-    auto stage = model->addNewStage<EltwiseStage>(layer->name, StageType::Select, layer, inputs, outputs);
+    auto stage = model->addNewStage<EltwiseStage>(select->get_friendly_name(), StageType::Select, select, inputs, outputs);
 }
 
 Stage StageBuilder::addSumStage(
         const Model& model,
         const std::string& name,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         const Data& input0,
         const Data& input1,
         const Data& output) {
@@ -349,7 +470,7 @@ Stage StageBuilder::addSumStage(
     return model->addNewStage<EltwiseStage>(
         name,
         StageType::Sum,
-        layer,
+        node,
         {input0, input1, fakeInput2},
         {output});
 }
@@ -357,7 +478,7 @@ Stage StageBuilder::addSumStage(
 Stage StageBuilder::addProdStage(
         const Model& model,
         const std::string& name,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         const Data& input0,
         const Data& input1,
         const Data& output) {
@@ -365,7 +486,7 @@ Stage StageBuilder::addProdStage(
     return model->addNewStage<EltwiseStage>(
             name,
             StageType::Prod,
-            layer,
+            node,
             {input0, input1, fakeInput2},
             {output});
 }
@@ -373,7 +494,7 @@ Stage StageBuilder::addProdStage(
 Stage StageBuilder::addMaxStage(
         const Model& model,
         const std::string& name,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         const Data& input0,
         const Data& input1,
         const Data& output) {
@@ -381,7 +502,7 @@ Stage StageBuilder::addMaxStage(
     return model->addNewStage<EltwiseStage>(
         name,
         StageType::Max,
-        layer,
+        node,
         {input0, input1, fakeInput2},
         {output});
 }

--- a/inference-engine/src/vpu/graph_transformer/src/stages/elu.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/elu.cpp
@@ -32,13 +32,15 @@ private:
 
 }  // namespace
 
-void FrontEnd::parseELU(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parseELU(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    const auto& elu = ngraph::as_type_ptr<ngraph::opset4::Elu>(node);
+    VPU_THROW_UNLESS(elu != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
     IE_ASSERT(inputs.size() == 1);
     IE_ASSERT(outputs.size() == 1);
 
-    auto alpha = layer->GetParamAsFloat("alpha", 1.0f);
+    auto alpha = elu->get_alpha();
 
-    auto stage = model->addNewStage<EluStage>(layer->name, StageType::Elu, layer, inputs, outputs);
+    auto stage = model->addNewStage<EluStage>(elu->get_friendly_name(), StageType::Elu, elu, inputs, outputs);
     stage->attrs().set<float>("alpha", alpha);
 }
 

--- a/inference-engine/src/vpu/graph_transformer/src/stages/erf.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/erf.cpp
@@ -29,11 +29,11 @@ private:
 
 }  // namespace
 
-void FrontEnd::parseErf(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parseErf(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
     IE_ASSERT(inputs.size() == 1);
     IE_ASSERT(outputs.size() == 1);
 
-    model->addNewStage<ErfStage>(layer->name, StageType::Erf, layer, inputs, outputs);
+    model->addNewStage<ErfStage>(node->get_friendly_name(), StageType::Erf, node, inputs, outputs);
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/exp.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/exp.cpp
@@ -29,11 +29,11 @@ private:
 
 }  // namespace
 
-void FrontEnd::parseExp(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parseExp(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
     IE_ASSERT(inputs.size() == 1);
     IE_ASSERT(outputs.size() == 1);
 
-    model->addNewStage<ExpStage>(layer->name, StageType::Exp, layer, inputs, outputs);
+    model->addNewStage<ExpStage>(node->get_friendly_name(), StageType::Exp, node, inputs, outputs);
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/exp_detectionoutput.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/exp_detectionoutput.cpp
@@ -80,24 +80,26 @@ private:
 
 }  // namespace
 
-void FrontEnd::parseExpDetectionOutput(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parseExpDetectionOutput(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    auto expDetectionOutput = ngraph::as_type_ptr<ngraph::opset6::ExperimentalDetectronDetectionOutput>(node);
+    VPU_THROW_UNLESS(expDetectionOutput != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
     IE_ASSERT(inputs.size() == 4);
     IE_ASSERT(outputs.size() == 3);
 
     ExpDetectionOutputParams params;
-
-    const auto deltas_weights = layer->GetParamAsFloats("deltas_weights", {0.0f, 0.0f, 0.0f, 0.0f});
+    const auto attrs = expDetectionOutput->get_attrs();
+    const auto deltas_weights = attrs.deltas_weights;
     IE_ASSERT(deltas_weights.size() == numDeltasWeights);
     for (int i = 0; i < numDeltasWeights; ++i)
         params.deltas_weights[i] = deltas_weights[i];
 
-    params.max_delta_log_wh = layer->GetParamAsFloat("max_delta_log_wh", 0.0f);
-    params.nms_threshold = layer->GetParamAsFloat("nms_threshold", 0.0f);
-    params.score_threshold = layer->GetParamAsFloat("score_threshold", 0.0f);
-    params.max_detections_per_image = layer->GetParamAsInt("max_detections_per_image", 0);
-    params.num_classes = layer->GetParamAsInt("num_classes", 0);
-    params.post_nms_count = layer->GetParamAsInt("post_nms_count", 0);
-    params.class_agnostic_box_regression = layer->GetParamAsBool("class_agnostic_box_regression", false);
+    params.max_delta_log_wh = attrs.max_delta_log_wh;
+    params.nms_threshold = attrs.nms_threshold;
+    params.score_threshold = attrs.score_threshold;
+    params.max_detections_per_image = attrs.max_detections_per_image;
+    params.num_classes = attrs.num_classes;
+    params.post_nms_count = attrs.post_nms_count;
+    params.class_agnostic_box_regression = attrs.class_agnostic_box_regression;
 
     auto inputBoxes    = inputs[0];   // [numRois][4]
     auto inputDeltas   = inputs[1];   // [numRois]([numClasses][4])
@@ -134,7 +136,7 @@ void FrontEnd::parseExpDetectionOutput(const Model& model, const ie::CNNLayerPtr
     IE_ASSERT((outputScores->desc().dims().size() == 1) &&
               (outputScores->desc().dim(Dim::C) >= maxDetections));
 
-    auto stage = model->addNewStage<ExpDetectionOutputStage>(layer->name, StageType::ExpDetectionOutput, layer, inputs, outputs);
+    auto stage = model->addNewStage<ExpDetectionOutputStage>(expDetectionOutput->get_friendly_name(), StageType::ExpDetectionOutput, expDetectionOutput, inputs, outputs);
 
     stage->attrs().set("params", params);
 }

--- a/inference-engine/src/vpu/graph_transformer/src/stages/exp_generateproposals.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/exp_generateproposals.cpp
@@ -70,18 +70,19 @@ private:
 
 void FrontEnd::parseExpGenerateProposals(
         const Model& model,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         const DataVector& inputs,
         const DataVector& outputs) const {
-    VPU_THROW_UNLESS(inputs.size() == 4, "Layer %s must have 4 input tensors.", layer->name);
-    VPU_THROW_UNLESS(outputs.size() == 2, "Layer %s must have 2 output tensors.", layer->name);
+    auto expGenerateProposals = ngraph::as_type_ptr<ngraph::opset6::ExperimentalDetectronGenerateProposalsSingleImage>(node);
+    VPU_THROW_UNLESS(inputs.size() == 4, "Layer %s must have 4 input tensors.", expGenerateProposals->get_friendly_name());
+    VPU_THROW_UNLESS(outputs.size() == 2, "Layer %s must have 2 output tensors.", expGenerateProposals->get_friendly_name());
 
     ExpGenerateProposalsParams params;
-
-    params.min_size      = layer->GetParamAsFloat("min_size", 0.0f);
-    params.nms_threshold = layer->GetParamAsFloat("nms_threshold", 0.7f);
-    params.pre_nms_topn  = layer->GetParamAsInt("pre_nms_count", 1000);
-    params.post_nms_topn = layer->GetParamAsInt("post_nms_count", 1000);
+    const auto attrs = expGenerateProposals->get_attrs();
+    params.min_size      = attrs.min_size;
+    params.nms_threshold = attrs.nms_threshold;
+    params.pre_nms_topn  = attrs.pre_nms_count;
+    params.post_nms_topn = attrs.post_nms_count;
 
     auto imInfo       = inputs[0];
     auto inputAnchors = inputs[1];
@@ -93,41 +94,41 @@ void FrontEnd::parseExpGenerateProposals(
     VPU_THROW_UNLESS((inputAnchors->desc().dims().size() == 2) &&
                      (inputAnchors->desc().dim(Dim::C) == 4),
                      "Wrong shape for input 1 of layer %s, expected (N, 4), got: dims size = %lu, dim C = %d",
-                     layer->name, inputAnchors->desc().dims().size(), inputAnchors->desc().dim(Dim::C));
+                     expGenerateProposals->get_friendly_name(), inputAnchors->desc().dims().size(), inputAnchors->desc().dim(Dim::C));
     VPU_THROW_UNLESS((imInfo->desc().dims().size() == 1) &&
                      (imInfo->desc().dim(Dim::C) == 3),
                      "Wrong shape for input 0 of layer %s, expected (3), got: dims size = %lu, dim C = %d",
-                     layer->name, imInfo->desc().dims().size(), imInfo->desc().dim(Dim::C));
+                     expGenerateProposals->get_friendly_name(), imInfo->desc().dims().size(), imInfo->desc().dim(Dim::C));
 
     VPU_THROW_UNLESS(inputDeltas->desc().dims().size() == 3,
                      "Wrong shape for input 2 of layer %s, expected dim size = 3, got: %lu",
-                     layer->name, inputDeltas->desc().dims().size());
+                     expGenerateProposals->get_friendly_name(), inputDeltas->desc().dims().size());
     VPU_THROW_UNLESS(inputScores->desc().dims().size() == 3,
                      "Wrong shape for input 3 of layer %s, expected dim size = 3, got: %lu",
-                     layer->name, inputScores->desc().dims().size());
+                     expGenerateProposals->get_friendly_name(), inputScores->desc().dims().size());
 
     VPU_THROW_UNLESS((inputDeltas->desc().dim(Dim::H) == inputScores->desc().dim(Dim::H)) &&
                      (inputDeltas->desc().dim(Dim::W) == inputScores->desc().dim(Dim::W)),
                      "Inputs 2 and 3 of layer %s must have same H and W, got: input2 (H = %d, W = %d), input3 (H = %d, W = %d)",
-                     layer->name, inputDeltas->desc().dim(Dim::H), inputDeltas->desc().dim(Dim::W),
+                     expGenerateProposals->get_friendly_name(), inputDeltas->desc().dim(Dim::H), inputDeltas->desc().dim(Dim::W),
                      inputScores->desc().dim(Dim::H), inputScores->desc().dim(Dim::W));
 
     VPU_THROW_UNLESS((outputRois->desc().dims().size() == 2) &&
                      (outputRois->desc().dim(Dim::C) == 4),
                      "Wrong shape for output 0 of layer %s, expected (N, 4), got: dims size = %lu, dim C = %d",
-                     layer->name, outputRois->desc().dims().size(), outputRois->desc().dim(Dim::C));
+                     expGenerateProposals->get_friendly_name(), outputRois->desc().dims().size(), outputRois->desc().dim(Dim::C));
     VPU_THROW_UNLESS(outputScores->desc().dims().size() == 1,
                      "Wrong shape for output 1 of layer %s, expected dim size = 1, got: %lu",
-                     layer->name, outputScores->desc().dims().size());
+                     expGenerateProposals->get_friendly_name(), outputScores->desc().dims().size());
 
     VPU_THROW_UNLESS(outputRois->desc().dim(Dim::N) == outputScores->desc().dim(Dim::C),
                      "Layer %s: output0 dim N and output1 dim C must be equal, got: output0 (N = %d), output1 (C = %d)",
-                     layer->name, outputRois->desc().dim(Dim::N), outputScores->desc().dim(Dim::C));
+                     expGenerateProposals->get_friendly_name(), outputRois->desc().dim(Dim::N), outputScores->desc().dim(Dim::C));
 
     auto stage = model->addNewStage<ExpGenerateProposalsStage>(
-        layer->name,
+        expGenerateProposals->get_friendly_name(),
         StageType::ExpGenerateProposals,
-        layer,
+        expGenerateProposals,
         inputs,
         outputs);
 

--- a/inference-engine/src/vpu/graph_transformer/src/stages/exp_priorgridgenerator.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/exp_priorgridgenerator.cpp
@@ -67,19 +67,20 @@ private:
 
 void FrontEnd::parseExpPriorGridGenerator(
         const Model& model,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         const DataVector& inputs,
         const DataVector& outputs) const {
     IE_ASSERT(inputs.size() >= 1 && inputs.size() <= 3);
     IE_ASSERT(outputs.size() == 1);
-
+    auto expPriorGridGenerator = ngraph::as_type_ptr<ngraph::opset6::ExperimentalDetectronPriorGridGenerator>(node);
+    VPU_THROW_UNLESS(expPriorGridGenerator != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
     ExpPriorGridGeneratorParams params;
-
-    params.flatten  = layer->GetParamAsInt("flatten", 1);
-    params.grid_w   = layer->GetParamAsInt("w", 0);
-    params.grid_h   = layer->GetParamAsInt("h", 0);
-    params.stride_w = layer->GetParamAsFloat("stride_x", 0.0f);
-    params.stride_h = layer->GetParamAsFloat("stride_y", 0.0f);
+    const auto attrs = expPriorGridGenerator->get_attrs();
+    params.flatten  = attrs.flatten;
+    params.grid_w   = attrs.w;
+    params.grid_h   = attrs.h;
+    params.stride_w = attrs.stride_x;
+    params.stride_h = attrs.stride_y;
 
     auto inputPriors     = inputs[0];   // [n][4]
     auto inputFeatureMap = inputs[1];   // [b, c, h, w]
@@ -91,31 +92,31 @@ void FrontEnd::parseExpPriorGridGenerator(
     VPU_THROW_UNLESS((inputPriors->desc().dims().size() == 2) &&
                      (inputPriors->desc().dim(Dim::C) == 4),
                      "Wrong shape for input 0 of layer %s, expected (N, 4), got: dims size = %lu, dim C = %d",
-                     layer->name, inputPriors->desc().dims().size(), inputPriors->desc().dim(Dim::C));
+                     expPriorGridGenerator->get_friendly_name(), inputPriors->desc().dims().size(), inputPriors->desc().dim(Dim::C));
 
     if (params.grid_h == 0 || params.grid_w == 0) {
         VPU_THROW_UNLESS((inputFeatureMap->desc().dims().size() == 4) &&
                          (inputFeatureMap->desc().dim(Dim::N) == batch),
                          "Wrong shape for input 1 of layer %s, expected 4-dimensional"
                          "with batch = %d, got: dims size = %lu, batch = %d",
-                         layer->name, batch, inputFeatureMap->desc().dims().size(), inputPriors->desc().dim(Dim::N));
+                         expPriorGridGenerator->get_friendly_name(), batch, inputFeatureMap->desc().dims().size(), inputPriors->desc().dim(Dim::N));
     }
 
     if (params.stride_w == 0 || params.stride_h == 0) {
         VPU_THROW_UNLESS(inputImage->desc().dims().size() == 4,
                          "Wrong shape for input 2 of layer %s, expected 4-dimensional, got: dims size = %lu",
-                         layer->name, inputImage->desc().dims().size());
+                         expPriorGridGenerator->get_friendly_name(), inputImage->desc().dims().size());
     }
 
     VPU_THROW_UNLESS((outputPriorGrid->desc().dims().size() == 2) &&
                      (outputPriorGrid->desc().dim(Dim::C) == 4),
                      "Wrong shape for output of layer %s, expected (N, 4), got: dims size = %lu, dim C = %d",
-                     layer->name, outputPriorGrid->desc().dims().size(), outputPriorGrid->desc().dim(Dim::C));
+                     expPriorGridGenerator->get_friendly_name(), outputPriorGrid->desc().dims().size(), outputPriorGrid->desc().dim(Dim::C));
 
     auto stage = model->addNewStage<ExpPriorGridGeneratorStage>(
-        layer->name,
+        expPriorGridGenerator->get_friendly_name(),
         StageType::ExpPriorGridGenerator,
-        layer,
+        expPriorGridGenerator,
         inputs,
         outputs);
 

--- a/inference-engine/src/vpu/graph_transformer/src/stages/exp_topkrois.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/exp_topkrois.cpp
@@ -57,13 +57,15 @@ private:
 
 void FrontEnd::parseExpTopKROIs(
         const Model& model,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         const DataVector& inputs,
         const DataVector& outputs) const {
-    VPU_THROW_UNLESS(inputs.size() == 2, "Layer %s must have 2 input tensors.", layer->name);
-    VPU_THROW_UNLESS(outputs.size() == 1, "Layer %s must have 1 output tensor.", layer->name);
+    auto expTopKROIs = ngraph::as_type_ptr<ngraph::op::v6::ExperimentalDetectronTopKROIs>(node);
+    VPU_THROW_UNLESS(expTopKROIs != nullptr, "Can't parse node with name %s and type %s is nullptr", expTopKROIs->get_friendly_name(), expTopKROIs->get_type_name());
+    VPU_THROW_UNLESS(inputs.size() == 2, "Layer %s must have 2 input tensors.", expTopKROIs->get_friendly_name());
+    VPU_THROW_UNLESS(outputs.size() == 1, "Layer %s must have 1 output tensor.", expTopKROIs->get_friendly_name());
 
-    int32_t max_rois = layer->GetParamAsInt("max_rois", 0);
+    int32_t max_rois = expTopKROIs->get_max_rois();
 
     auto inputRois  = inputs[0];
     auto inputProbs = inputs[1];
@@ -72,29 +74,29 @@ void FrontEnd::parseExpTopKROIs(
     VPU_THROW_UNLESS((inputRois->desc().dims().size() == 2) &&
                      (inputRois->desc().dim(Dim::C) == 4),
                      "Wrong shape for input 0 of layer %s, expected (N, 4), got: dims size = %lu, dim C = %d",
-                     layer->name, inputRois->desc().dims().size(), inputRois->desc().dim(Dim::C));
+                     expTopKROIs->get_friendly_name(), inputRois->desc().dims().size(), inputRois->desc().dim(Dim::C));
 
     VPU_THROW_UNLESS(inputProbs->desc().dims().size() == 1,
                      "Wrong shape for input 1 of layer %s, expected dim size = 1, got: %lu",
-                     layer->name, inputProbs->desc().dims().size());
+                     expTopKROIs->get_friendly_name(), inputProbs->desc().dims().size());
 
     VPU_THROW_UNLESS(inputProbs->desc().dim(Dim::C) == inputRois->desc().dim(Dim::N),
                      "Layer %s: input0 dim N and input1 dim C must be equal, got: input0 (N = %d), input1 (C = %d)",
-                     layer->name, inputProbs->desc().dim(Dim::N), inputProbs->desc().dim(Dim::C));
+                     expTopKROIs->get_friendly_name(), inputProbs->desc().dim(Dim::N), inputProbs->desc().dim(Dim::C));
 
     VPU_THROW_UNLESS((outputRois->desc().dims().size() == 2) &&
                      (outputRois->desc().dim(Dim::C) == 4),
                      "Wrong shape for output 0 of layer %s, expected (N, 4), got: dims size = %lu, dim C = %d",
-                     layer->name, outputRois->desc().dims().size(), outputRois->desc().dim(Dim::C));
+                     expTopKROIs->get_friendly_name(), outputRois->desc().dims().size(), outputRois->desc().dim(Dim::C));
 
     VPU_THROW_UNLESS(outputRois->desc().dim(Dim::N) == max_rois,
                      "Wrong shape for output 0 of layer %s, expected dim N = %d, got: dim N = %d",
-                     layer->name, static_cast<int>(max_rois), outputRois->desc().dim(Dim::N));
+                     expTopKROIs->get_friendly_name(), static_cast<int>(max_rois), outputRois->desc().dim(Dim::N));
 
     auto stage = model->addNewStage<ExpTopKROIsStage>(
-        layer->name,
+        expTopKROIs->get_friendly_name(),
         StageType::ExpTopKROIs,
-        layer,
+        expTopKROIs,
         inputs,
         outputs);
 

--- a/inference-engine/src/vpu/graph_transformer/src/stages/expand.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/expand.cpp
@@ -115,14 +115,14 @@ protected:
 Stage StageBuilder::addExpandStage(
         const Model& model,
         const std::string& name,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         const Data& input,
         const Data& output,
         const DimValues& offset) {
     auto stage = model->addNewStage<ExpandStage>(
         name,
         StageType::Expand,
-        layer,
+        node,
         {input},
         {output});
 

--- a/inference-engine/src/vpu/graph_transformer/src/stages/floor.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/floor.cpp
@@ -29,11 +29,11 @@ private:
 
 }  // namespace
 
-void FrontEnd::parseFloor(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parseFloor(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
     IE_ASSERT(inputs.size() == 1);
     IE_ASSERT(outputs.size() == 1);
 
-    model->addNewStage<FloorStage>(layer->name, StageType::Floor, layer, inputs, outputs);
+    model->addNewStage<FloorStage>(node->get_friendly_name(), StageType::Floor, node, inputs, outputs);
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/gather.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/gather.cpp
@@ -13,8 +13,9 @@
 
 namespace vpu {
 
-void FrontEnd::parseGather(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
-    VPU_THROW_UNLESS(layer != nullptr, "Encountered nullptr CNN layer");
+void FrontEnd::parseGather(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    const auto& gather = ngraph::as_type_ptr<ngraph::opset4::Gather>(node);
+    VPU_THROW_UNLESS(gather != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
     VPU_THROW_UNLESS(inputs.size() == 3, "Expected {} inputs (data, indices, axis), got {}", 3, inputs.size());
     VPU_THROW_UNLESS(outputs.size() == 1, "Expected {} outputs, got {}", 1, outputs.size());
 
@@ -32,7 +33,7 @@ void FrontEnd::parseGather(const Model& model, const ie::CNNLayerPtr& layer, con
     const auto perm = DimsOrder::fromNumDims(input->desc().numDims()).toPermutation();
     const auto axisDim = perm[input->desc().numDims() - 1 - ieNormalizedAxis];
 
-    _stageBuilder->addGatherStage(model, layer->name, layer, inputs[0], inputs[1], outputs[0], axisDim);
+    _stageBuilder->addGatherStage(model, gather->get_friendly_name(), gather, inputs[0], inputs[1], outputs[0], axisDim);
 }
 
 namespace {
@@ -102,7 +103,7 @@ protected:
 Stage StageBuilder::addGatherStage(
         const Model& model,
         const std::string& name,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         const Data& input0,
         const Data& input1,
         const Data& output,
@@ -110,7 +111,7 @@ Stage StageBuilder::addGatherStage(
     auto stage = model->addNewStage<GatherStage>(
         name,
         StageType::Gather,
-        layer,
+        node,
         {input0, input1},
         {output});
 

--- a/inference-engine/src/vpu/graph_transformer/src/stages/gather_elements.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/gather_elements.cpp
@@ -109,14 +109,14 @@ protected:
 
 }// namespace
 
-Stage StageBuilder::addGatherElementsStage(const Model &model,
-                                           const std::string &name,
-                                           const ie::CNNLayerPtr &layer,
-                                           const DataVector &inputs,
-                                           const Data &output, int32_t axis,
+Stage StageBuilder::addGatherElementsStage(const Model& model,
+                                           const std::string& name,
+                                           const NodePtr& node,
+                                           const DataVector& inputs,
+                                           const Data& output, int32_t axis,
                                            bool rowIndicesMode) {
     auto stage = model->addNewStage<GatherElementsStage>(
-        layer->name, StageType::GatherElements, layer, inputs, {output});
+        node->get_friendly_name(), StageType::GatherElements, node, inputs, {output});
 
     stage->attrs().set<int32_t>("axis", axis);
     stage->attrs().set<int32_t>("rowIndicesMode", rowIndicesMode);
@@ -124,22 +124,23 @@ Stage StageBuilder::addGatherElementsStage(const Model &model,
     return stage;
 }
 
-void FrontEnd::parseGatherElements(const Model &model, const ie::CNNLayerPtr &layer,
+void FrontEnd::parseGatherElements(const Model &model, const NodePtr& node,
                                    const DataVector &inputs,
                                    const DataVector &outputs) const {
-    VPU_THROW_UNLESS(layer != nullptr, "CNNLayer pointer is null.");
+    auto gatherElements = ngraph::as_type_ptr<ngraph::op::v6::GatherElements>(node);
+    VPU_THROW_UNLESS(gatherElements != nullptr, "Node pointer is null.");
     VPU_THROW_UNLESS(inputs.size() == 2 || inputs.size() == 3,
                      "{} layer with name {} must have 2 inputs, actually "
                      "provided {} inputs",
-                     layer->type, layer->name, inputs.size());
+                     gatherElements->get_type_name(), gatherElements->get_friendly_name(), inputs.size());
     VPU_THROW_UNLESS(outputs.size() == 1,
                      "{} layer with name {} must have only 1 output, actually "
                      "provided {} outputs",
-                     layer->type, layer->name, outputs.size());
+                     gatherElements->get_type_name(), gatherElements->get_friendly_name(), outputs.size());
 
     bool rowIndicesMode = (inputs.size() == 3);
 
-    const auto axis = layer->GetParamAsInt("axis");
+    const auto axis = gatherElements->get_axis();
     const auto rank = inputs[0]->desc().numDims();
 
     VPU_THROW_UNLESS(rank >= 1, "rank has to be more than or equal to 1, actually {}", rank);
@@ -161,7 +162,7 @@ void FrontEnd::parseGatherElements(const Model &model, const ie::CNNLayerPtr &la
                         rank, axis);
     }
 
-    _stageBuilder->addGatherElementsStage(model, layer->name, layer, inputs, outputs[0], axis, rowIndicesMode);
+    _stageBuilder->addGatherElementsStage(model, gatherElements->get_friendly_name(), gatherElements, inputs, outputs[0], axis, rowIndicesMode);
 }
 
 }// namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/gather_nd.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/gather_nd.cpp
@@ -86,35 +86,36 @@ protected:
 
 }// namespace
 
-Stage StageBuilder::addGatherNDStage(const Model &model,
-                                     const std::string &name,
-                                     const ie::CNNLayerPtr &layer,
-                                     const Data &input, const Data &indices,
-                                     const Data &output, int32_t batchDims) {
+Stage StageBuilder::addGatherNDStage(const Model& model,
+                                     const std::string& name,
+                                     const NodePtr& node,
+                                     const Data& input, const Data& indices,
+                                     const Data& output, int32_t batchDims) {
     auto stage = model->addNewStage<GatherNDStage>(
-        layer->name, StageType::GatherND, layer, {input, indices}, {output});
+        node->get_friendly_name(), StageType::GatherND, node, {input, indices}, {output});
 
     stage->attrs().set<int32_t>("batch_dims", batchDims);
 
     return stage;
 }
 
-void FrontEnd::parseGatherND(const Model &model, const ie::CNNLayerPtr &layer,
+void FrontEnd::parseGatherND(const Model &model, const NodePtr& node,
                              const DataVector &inputs,
                              const DataVector &outputs) const {
-    VPU_THROW_UNLESS(layer, "CNNLayer pointer is null.");
+    auto gatherND = ngraph::as_type_ptr<ngraph::op::v5::GatherND>(node);                                 
+    VPU_THROW_UNLESS(gatherND != nullptr, "Node pointer is null.");
     VPU_THROW_UNLESS(inputs.size() == 2,
                      "{} layer with name {} must have 2 inputs, actually "
                      "provided {} inputs",
-                     layer->type, layer->name, inputs.size());
+                     gatherND->get_type_name(), gatherND->get_friendly_name(), inputs.size());
     VPU_THROW_UNLESS(outputs.size() == 1,
                      "{} layer with name {} must have 1 output, actually "
                      "provided {} outputs",
-                     layer->type, layer->name, outputs.size());
+                     gatherND->get_type_name(), gatherND->get_friendly_name(), outputs.size());
 
-    const auto batchDims = layer->GetParamAsInt("batch_dims", 0);
+    const auto batchDims = gatherND->get_batch_dims();
 
-    _stageBuilder->addGatherNDStage(model, layer->name, layer, inputs[0],
+    _stageBuilder->addGatherNDStage(model, gatherND->get_friendly_name(), gatherND, inputs[0],
                                     inputs[1], outputs[0], batchDims);
 }
 

--- a/inference-engine/src/vpu/graph_transformer/src/stages/gelu.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/gelu.cpp
@@ -24,15 +24,15 @@ private:
 
 }  // namespace
 
-void FrontEnd::parseGelu(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parseGelu(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
     VPU_THROW_UNLESS(inputs.size() == 1,
                      "Gelu stage with name %s must have only 1 input, "
-                     "actually provided %d", layer->name, inputs.size());
+                     "actually provided %d", node->get_friendly_name(), inputs.size());
     VPU_THROW_UNLESS(outputs.size() == 1,
                      "Gelu stage with name %s must have only 1 output, "
-                     "actually provided %d", layer->name, outputs.size());
+                     "actually provided %d", node->get_friendly_name(), outputs.size());
 
-    model->addNewStage<GeluStage>(layer->name, StageType::Gelu, layer, inputs, outputs);
+    model->addNewStage<GeluStage>(node->get_friendly_name(), StageType::Gelu, node, inputs, outputs);
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/grn.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/grn.cpp
@@ -60,15 +60,16 @@ private:
 
 }  // namespace
 
-void FrontEnd::parseGRN(const Model& model, const ie::CNNLayerPtr& _layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parseGRN(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
     IE_ASSERT(inputs.size() == 1);
     IE_ASSERT(outputs.size() == 1);
 
-    auto layer = std::dynamic_pointer_cast<ie::GRNLayer>(_layer);
-    IE_ASSERT(layer != nullptr);
+    const auto& grn = ngraph::as_type_ptr<ngraph::opset4::GRN>(node);
+    VPU_THROW_UNLESS(grn != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
 
-    auto stage = model->addNewStage<GRNStage>(layer->name, StageType::GRN, layer, inputs, outputs);
-    stage->attrs().set<float>("bias", layer->bias);
+    auto stage = model->addNewStage<GRNStage>(grn->get_friendly_name(), StageType::GRN, grn, inputs, outputs);
+
+    stage->attrs().set<float>("bias", grn->get_bias());
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/hswish.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/hswish.cpp
@@ -24,15 +24,15 @@ private:
 
 }  // namespace
 
-void FrontEnd::parseHSwish(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parseHSwish(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
     VPU_THROW_UNLESS((inputs.size() == 1),
                      "HSwish stage with name {} must have only 1 input, "
-                     "actually provided {}", layer->name, inputs.size());
+                     "actually provided {}", node->get_friendly_name(), inputs.size());
     VPU_THROW_UNLESS(outputs.size() == 1,
                      "HSwish stage with name {} must have only 1 output, "
-                     "actually provided {}", layer->name, outputs.size());
+                     "actually provided {}", node->get_friendly_name(), outputs.size());
 
-    model->addNewStage<HSwishStage>(layer->name, StageType::HSwish, layer, inputs, outputs);
+    model->addNewStage<HSwishStage>(node->get_friendly_name(), StageType::HSwish, node, inputs, outputs);
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/interp.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/interp.cpp
@@ -68,39 +68,18 @@ private:
 Stage StageBuilder::addInterpStage(
                         const Model& model,
                         const std::string& name,
-                        const ie::CNNLayerPtr& layer,
+                        const NodePtr& node,
                         bool align_corners,
                         InterpolateMode mode,
                         InterpolateCoordTransMode coordinateTransMode,
                         const Data& input,
                         const Data& output) {
-    auto stage = model->addNewStage<InterpStage>(layer->name, StageType::Interp, layer, {input}, {output});
+    auto stage = model->addNewStage<InterpStage>(node->get_friendly_name(), StageType::Interp, node, {input}, {output});
     stage->attrs().set<bool>(g_align_corners, align_corners);
     stage->attrs().set<InterpolateMode>(g_mode, mode);
     stage->attrs().set<InterpolateCoordTransMode>(g_coordinate_transformation_mode, coordinateTransMode);
 
     return stage;
-}
-
-void FrontEnd::parseInterp(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
-    VPU_THROW_UNLESS(inputs.size() == 1,
-                     "Interp stage with name {} must have only 1 input, "
-                     "actually provided {}", layer->name, inputs.size());
-    VPU_THROW_UNLESS(outputs.size() == 1,
-                     "Interp stage with name {} must have only 1 output, "
-                     "actually provided {}", layer->name, outputs.size());
-    const auto coord = layer->GetParamAsString(g_coordinate_transformation_mode, g_half_pixel);
-    const auto interpMode = layer->GetParamAsString(g_mode, g_linear);
-    const auto interpModeIt = interpModeMap.find(interpMode);
-    const auto coordModeIt  = coordTransformModeMap.find(coord);
-    VPU_THROW_UNLESS(interpModeIt != interpModeMap.end(), "Interp stage with name {} does not support this interp mode", layer->name);
-    VPU_THROW_UNLESS(interpModeIt->second == InterpolateMode::Linear || interpModeIt->second  == InterpolateMode::LinearOnnx,
-                     "Interp stage supports linear and linear_onnx modes");
-    VPU_THROW_UNLESS(coordModeIt != coordTransformModeMap.end(), "Interp stage does not support this coordinate transforation mode");
-    auto coordinateTransMode = coordModeIt->second;
-    auto mode = interpModeIt->second;
-
-    _stageBuilder->addInterpStage(model, layer->name, layer, layer->GetParamAsInt(g_align_corners, 0), mode, coordinateTransMode, inputs[0], outputs[0]);
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/interpolate.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/interpolate.cpp
@@ -17,17 +17,74 @@
 using namespace InferenceEngine;
 
 namespace vpu {
+static InterpolateCoordTransMode getVpuCoordTransMode (ngraph::op::v4::Interpolate::CoordinateTransformMode mode) {
+    switch (mode)
+    {
+    case ngraph::op::v4::Interpolate::CoordinateTransformMode::align_corners :
+        return InterpolateCoordTransMode::AlignCorners;
+    case ngraph::op::v4::Interpolate::CoordinateTransformMode::asymmetric :
+        return InterpolateCoordTransMode::Asymmetric;
+    case ngraph::op::v4::Interpolate::CoordinateTransformMode::half_pixel :
+        return InterpolateCoordTransMode::HalfPixel;
+    case ngraph::op::v4::Interpolate::CoordinateTransformMode::pytorch_half_pixel :
+        return InterpolateCoordTransMode::PytorchHalfPixel;
+    case ngraph::op::v4::Interpolate::CoordinateTransformMode::tf_half_pixel_for_nn :
+        return InterpolateCoordTransMode::TfHalfPixelForNn;
+    default:
+        VPU_THROW_UNLESS(false, "Can't convert ngraph CoordinateTransformMode to vpu mode");
+        // should never be returned
+        return InterpolateCoordTransMode::TfHalfPixelForNn;
+    }
+}
+static InterpolateNearestMode getVpuNearestMode (ngraph::op::v4::Interpolate::NearestMode mode) {
+    switch (mode)
+    {
+    case ngraph::op::v4::Interpolate::NearestMode::ceil :
+        return InterpolateNearestMode::Ceil;
+    case ngraph::op::v4::Interpolate::NearestMode::floor :
+        return InterpolateNearestMode::Floor;
+    case ngraph::op::v4::Interpolate::NearestMode::round_prefer_floor :
+        return InterpolateNearestMode::RoundPreferFloor;
+    case ngraph::op::v4::Interpolate::NearestMode::round_prefer_ceil :
+        return InterpolateNearestMode::RoundPreferCeil;
+    case ngraph::op::v4::Interpolate::NearestMode::simple :
+        return InterpolateNearestMode::Simple;
+    default:
+        VPU_THROW_UNLESS(false, "Can't convert ngraph CoordinateTransformMode to vpu mode");
+        // should never be returned
+        return InterpolateNearestMode::Simple;
+    }
+}
+static InterpolateMode getVpuInterpolateMode (ngraph::op::v4::Interpolate::InterpolateMode mode) {
+    switch (mode)
+    {
+    case ngraph::op::v4::Interpolate::InterpolateMode::cubic :
+        return InterpolateMode::Cubic;
+    case ngraph::op::v4::Interpolate::InterpolateMode::linear :
+        return InterpolateMode::Linear;
+    case ngraph::op::v4::Interpolate::InterpolateMode::linear_onnx :
+        return InterpolateMode::LinearOnnx;
+    case ngraph::op::v4::Interpolate::InterpolateMode::nearest :
+        return InterpolateMode::Nearest;
 
-void FrontEnd::parseInterpolate(const Model& model, const ie::CNNLayerPtr& _layer, const DataVector& inputs, const DataVector& outputs) const {
+    default:
+        VPU_THROW_UNLESS(false, "Can't convert ngraph CoordinateTransformMode to vpu mode");
+        // should never be returned
+        return InterpolateMode::Nearest;
+    }
+}
+void FrontEnd::parseInterpolate(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    const auto& interpolate = ngraph::as_type_ptr<ngraph::op::v4::Interpolate>(node);
+    IE_ASSERT(interpolate != nullptr);
     VPU_THROW_UNLESS(inputs.size() <= 4 && inputs.size() >= 1,
                      "Interpolate stage with name {} must have no more than 4 inputs and no less than 1 input, actually provided {} inputs",
-                     _layer->name, inputs.size());
+                     interpolate->get_friendly_name(), inputs.size());
 
     VPU_THROW_UNLESS(outputs.size() == 1,
                      "Interpolate stage with name {} must have only 1 output, actually provided {} outputs",
-                     _layer->name, outputs.size());
-
-    const auto interpolateMode = _layer->GetParamAsString(g_mode, g_nearest);
+                     interpolate->get_friendly_name(), outputs.size());
+    const auto& attrs = interpolate->get_attrs();
+    const auto interpolateMode = attrs.mode;
 
     const auto input  = inputs[0];
     const auto output = outputs[0];
@@ -42,23 +99,23 @@ void FrontEnd::parseInterpolate(const Model& model, const ie::CNNLayerPtr& _laye
 
     VPU_THROW_UNLESS(in == on, "incompatible: input batch=%d, output batch=%d", in, on);
 
-    auto padsBegin = _layer->GetParamAsInts(g_pads_begin, {});
-    auto padsEnd   = _layer->GetParamAsInts(g_pads_end, {});
+    auto padsBegin = attrs.pads_begin;
+    auto padsEnd   = attrs.pads_end;
 
-    const auto isPadZeros = [](const std::vector<int>& pad) {
-        return std::all_of(pad.begin(), pad.end(), [](int i) { return i == 0; });
+    const auto isPadZeros = [](const std::vector<size_t>& pad) {
+        return std::all_of(pad.begin(), pad.end(), [](size_t i) { return i == 0; });
     };
 
     const auto orderIsSupported = input->desc().dimsOrder() == DimsOrder::NCHW || input->desc().dimsOrder() == DimsOrder::NHWC
                                || input->desc().dimsOrder() == DimsOrder::CHW  || input->desc().dimsOrder() == DimsOrder::HWC;
     VPU_THROW_UNLESS(orderIsSupported, "Current Interpolate supports (N)HWC, (N)CHW data orders only, actual {}", input->desc().dimsOrder());
 
-    const auto interpolateModeIt = interpModeMap.find(interpolateMode);
-    VPU_THROW_UNLESS(interpolateModeIt != interpModeMap.end(),
-                     "Current Interpolate supports 'nearest' and 'linear' modes only, actual {}", interpolateMode);
-    const auto modeIsSupported = interpolateModeIt->second == InterpolateMode::Nearest ||
-                                 interpolateModeIt->second == InterpolateMode::Linear  ||
-                                 interpolateModeIt->second == InterpolateMode::LinearOnnx;
+    //const auto interpolateModeIt = interpModeMap.find(interpolateMode);
+    // VPU_THROW_UNLESS(interpolateModeIt != interpModeMap.end(),
+    //                  "Current Interpolate supports 'nearest' and 'linear' modes only, actual {}", interpolateMode);
+    const auto modeIsSupported = interpolateMode == ngraph::op::v4::Interpolate::InterpolateMode::nearest ||
+                                 interpolateMode == ngraph::op::v4::Interpolate::InterpolateMode::linear  ||
+                                 interpolateMode == ngraph::op::v4::Interpolate::InterpolateMode::linear_onnx;
     VPU_THROW_UNLESS(modeIsSupported, "Current Interpolate supports 'nearest' and 'linear' modes only, actual {}", interpolateMode);
 
     auto paramIsSupported = ic == oc;
@@ -66,49 +123,46 @@ void FrontEnd::parseInterpolate(const Model& model, const ie::CNNLayerPtr& _laye
     paramIsSupported = isPadZeros(padsBegin) && isPadZeros(padsEnd);
     VPU_THROW_UNLESS(paramIsSupported, "Current Interpolate does not support paddings");
 
-    if (interpolateModeIt->second == InterpolateMode::Nearest) {
+    if (interpolateMode == ngraph::op::v4::Interpolate::InterpolateMode::nearest) {
         // current "Resample" supports the following "Interpolate" modes only:
         // coordinate_transformation_mode = half_pixel; nearest_mode = round_prefer_ceil;
         // coordinate_transformation_mode = asymmetric; nearest_mode = floor;
         // other "Interpolate" modes are translated to the default ones
-        const auto anti = _layer->GetParamAsBool(g_antialias, false);
-        const auto coordinateTransformation = _layer->GetParamAsString(g_coordinate_transformation_mode, g_half_pixel);
-        const auto near = _layer->GetParamAsString(g_nearest_mode, g_round_prefer_floor);
+        const auto anti = attrs.antialias;
+        const auto coordinateTransformationMode = getVpuCoordTransMode(attrs.coordinate_transformation_mode);
+        const auto nearestMode = getVpuNearestMode(attrs.nearest_mode);
 
-        const auto coordModeIt   = coordTransformModeMap.find(coordinateTransformation);
-        const auto nearestModeIt = nearestModeMap.find(near);
-        VPU_THROW_UNLESS(coordModeIt != coordTransformModeMap.end(), "Interpolate stage does not support this coordinate transforation mode");
-        VPU_THROW_UNLESS(nearestModeIt != nearestModeMap.end(), "Interpolate stage does not support this nearest transforation mode");
-        auto coordinateTransformationMode = coordModeIt->second;
-        auto nearestMode = nearestModeIt->second;
+        // const auto coordModeIt   = coordTransformModeMap.find(coordinateTransformation);
+        // const auto nearestModeIt = nearestModeMap.find(near);
+        // VPU_THROW_UNLESS(coordModeIt != coordTransformModeMap.end(), "Interpolate stage does not support this coordinate transforation mode");
+        // VPU_THROW_UNLESS(nearestModeIt != nearestModeMap.end(), "Interpolate stage does not support this nearest transforation mode");
 
         _stageBuilder->addResampleNearestStage(model,
-                                                _layer->name,
-                                                _layer,
+                                                interpolate->get_friendly_name(),
+                                                interpolate,
                                                 anti,
                                                 coordinateTransformationMode,
                                                 nearestMode,
                                                 -1.0f,
                                                 input,
                                                 output);
-    } else if (interpolateModeIt->second == InterpolateMode::Linear ||
-               interpolateModeIt->second == InterpolateMode::LinearOnnx) {
+    } else if (interpolateMode == ngraph::op::v4::Interpolate::InterpolateMode::linear  ||
+               interpolateMode == ngraph::op::v4::Interpolate::InterpolateMode::linear_onnx) {
         // current "Interp" supports modes "align_corners" and "asymmetric" only
         // other "Interpolate" modes are translated to the default ones
-        const auto coordinateTransformation = _layer->GetParamAsString(g_coordinate_transformation_mode, g_half_pixel);
-        const auto coordModeIt  = coordTransformModeMap.find(coordinateTransformation);
-        VPU_THROW_UNLESS(interpolateModeIt != interpModeMap.end(), "Interp stage with name {} does not support this interp mode", _layer->name);
-        VPU_THROW_UNLESS(interpolateModeIt->second == InterpolateMode::Linear || interpolateModeIt->second  == InterpolateMode::LinearOnnx,
-                            "Interp stage supports linear and linear_onnx modes");
-        VPU_THROW_UNLESS(coordModeIt != coordTransformModeMap.end(), "Interp stage does not support this coordinate transforation mode");
-        auto coordinateTransformationMode = coordModeIt->second;
-        auto mode = interpolateModeIt->second;
+        const auto coordinateTransformationMode = getVpuCoordTransMode(attrs.coordinate_transformation_mode);
+        
+        // VPU_THROW_UNLESS(interpolateModeIt != interpModeMap.end(), "Interp stage with name {} does not support this interp mode", _layer->name);
+        // VPU_THROW_UNLESS(interpolateModeIt->second == InterpolateMode::Linear || interpolateModeIt->second  == InterpolateMode::LinearOnnx,
+                            // "Interp stage supports linear and linear_onnx modes");
+        // VPU_THROW_UNLESS(coordModeIt != coordTransformModeMap.end(), "Interp stage does not support this coordinate transforation mode");
+        auto mode = attrs.mode;
 
         _stageBuilder->addInterpStage(model,
-                                        _layer->name,
-                                        _layer,
-                                        coordModeIt->second == InterpolateCoordTransMode::AlignCorners,
-                                        mode,
+                                        interpolate->get_friendly_name(),
+                                        interpolate,
+                                        coordinateTransformationMode == vpu::InterpolateCoordTransMode::AlignCorners,
+                                        getVpuInterpolateMode(mode),
                                         coordinateTransformationMode,
                                         input,
                                         output);

--- a/inference-engine/src/vpu/graph_transformer/src/stages/log.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/log.cpp
@@ -29,11 +29,11 @@ private:
 
 }  // namespace
 
-void FrontEnd::parseLog(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parseLog(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
     IE_ASSERT(inputs.size() == 1);
     IE_ASSERT(outputs.size() == 1);
 
-    model->addNewStage<LogStage>(layer->name, StageType::Log, layer, inputs, outputs);
+    model->addNewStage<LogStage>(node->get_friendly_name(), StageType::Log, node, inputs, outputs);
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/mish.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/mish.cpp
@@ -28,15 +28,15 @@ private:
 
 }  // namespace
 
-void FrontEnd::parseMish(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parseMish(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
     VPU_THROW_UNLESS(inputs.size() == 1,
                      "Mish stage with name %s must have only 1 input, "
-                     "actually provided %d", layer->name, inputs.size());
+                     "actually provided %d", node->get_friendly_name(), inputs.size());
     VPU_THROW_UNLESS(outputs.size() == 1,
                      "Mish stage with name %s must have only 1 output, "
-                     "actually provided %d", layer->name, outputs.size());
+                     "actually provided %d", node->get_friendly_name(), outputs.size());
 
-    model->addNewStage<MishStage>(layer->name, StageType::Mish, layer, inputs, outputs);
+    model->addNewStage<MishStage>(node->get_friendly_name(), StageType::Mish, node, inputs, outputs);
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/mtcnn.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/mtcnn.cpp
@@ -1,255 +1,255 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
 
-#include <vpu/frontend/frontend.hpp>
+// #include <vpu/frontend/frontend.hpp>
 
-#include <vpu/graph_transformer.hpp>
-#include <vpu/compile_env.hpp>
-#include <vpu/utils/file_system.hpp>
-#include <vpu/model/data_contents/mtcnn_blob_content.hpp>
+// #include <vpu/graph_transformer.hpp>
+// #include <vpu/compile_env.hpp>
+// #include <vpu/utils/file_system.hpp>
+// #include <vpu/model/data_contents/mtcnn_blob_content.hpp>
 
-#include <vector>
-#include <fstream>
-#include <string>
-#include <utility>
-#include <memory>
-#include <set>
+// #include <vector>
+// #include <fstream>
+// #include <string>
+// #include <utility>
+// #include <memory>
+// #include <set>
 
-namespace vpu {
+// namespace vpu {
 
-// Must be synchronized with MvTensor
-VPU_DECLARE_ENUM(MTCNN_Mode,
-    AVA_FaceDetector = 0,
-    Public = 1)
+// // Must be synchronized with MvTensor
+// VPU_DECLARE_ENUM(MTCNN_Mode,
+//     AVA_FaceDetector = 0,
+//     Public = 1)
 
-namespace {
+// namespace {
 
-class MTCNNStage final : public StageNode {
-public:
-    using StageNode::StageNode;
+// class MTCNNStage final : public StageNode {
+// public:
+//     using StageNode::StageNode;
 
-private:
-    StagePtr cloneImpl() const override {
-        return std::make_shared<MTCNNStage>(*this);
-    }
+// private:
+//     StagePtr cloneImpl() const override {
+//         return std::make_shared<MTCNNStage>(*this);
+//     }
 
-    void propagateDataOrderImpl(StageDataInfo<DimsOrder>& orderInfo) override {
-        auto input = inputEdge(0)->input();
-        auto output = outputEdge(0)->output();
+//     void propagateDataOrderImpl(StageDataInfo<DimsOrder>& orderInfo) override {
+//         auto input = inputEdge(0)->input();
+//         auto output = outputEdge(0)->output();
 
-        orderInfo.setInput(inputEdge(0), input->desc().dimsOrder().createMovedDim(Dim::C, 2));
-        orderInfo.setOutput(outputEdge(0), output->desc().dimsOrder().createMovedDim(Dim::C, 0));
-    }
+//         orderInfo.setInput(inputEdge(0), input->desc().dimsOrder().createMovedDim(Dim::C, 2));
+//         orderInfo.setOutput(outputEdge(0), output->desc().dimsOrder().createMovedDim(Dim::C, 0));
+//     }
 
-    void getDataStridesRequirementsImpl(StageDataInfo<StridesRequirement>& stridesInfo) override {
-        stridesInfo.setInput(inputEdge(0), StridesRequirement::compact());
-        stridesInfo.setOutput(outputEdge(0), StridesRequirement::compact());
-    }
+//     void getDataStridesRequirementsImpl(StageDataInfo<StridesRequirement>& stridesInfo) override {
+//         stridesInfo.setInput(inputEdge(0), StridesRequirement::compact());
+//         stridesInfo.setOutput(outputEdge(0), StridesRequirement::compact());
+//     }
 
-    void finalizeDataLayoutImpl() override {
-    }
+//     void finalizeDataLayoutImpl() override {
+//     }
 
-    void getBatchSupportInfoImpl(StageDataInfo<BatchSupport>& batchInfo) override {
-        batchInfo.setInput(inputEdge(0), BatchSupport::Split);
-        batchInfo.setOutput(outputEdge(0), BatchSupport::Split);
-    }
+//     void getBatchSupportInfoImpl(StageDataInfo<BatchSupport>& batchInfo) override {
+//         batchInfo.setInput(inputEdge(0), BatchSupport::Split);
+//         batchInfo.setOutput(outputEdge(0), BatchSupport::Split);
+//     }
 
-    void initialCheckImpl() const override {
-        assertInputsOutputsTypes(this,
-            {{DataType::U8, DataType::FP16}, {DataType::U8, DataType::FP16}},
-            {{DataType::FP16}});
-    }
+//     void initialCheckImpl() const override {
+//         assertInputsOutputsTypes(this,
+//             {{DataType::U8, DataType::FP16}, {DataType::U8, DataType::FP16}},
+//             {{DataType::FP16}});
+//     }
 
-    void serializeParamsImpl(BlobSerializer& serializer) const override {
-        auto debug_pnet_post_nms = attrs().get<int>("debug_pnet_post_nms");
-        auto debug_rnet_post_nms = attrs().get<int>("debug_rnet_post_nms");
-        auto mode = attrs().get<MTCNN_Mode>("mode");
-        const auto& pyramid = attrs().get<SmallVector<std::pair<int, int>>>("pyramid");
-        auto stage2_zdir_batch_size = attrs().get<int>("stage2_zdir_batch_size");
+//     void serializeParamsImpl(BlobSerializer& serializer) const override {
+//         auto debug_pnet_post_nms = attrs().get<int>("debug_pnet_post_nms");
+//         auto debug_rnet_post_nms = attrs().get<int>("debug_rnet_post_nms");
+//         auto mode = attrs().get<MTCNN_Mode>("mode");
+//         const auto& pyramid = attrs().get<SmallVector<std::pair<int, int>>>("pyramid");
+//         auto stage2_zdir_batch_size = attrs().get<int>("stage2_zdir_batch_size");
 
-        serializer.append(static_cast<int32_t>(pyramid.size()));
-        for (const auto& elem : pyramid) {
-            serializer.append(static_cast<int32_t>(elem.first));
-            serializer.append(static_cast<int32_t>(elem.second));
-        }
+//         serializer.append(static_cast<int32_t>(pyramid.size()));
+//         for (const auto& elem : pyramid) {
+//             serializer.append(static_cast<int32_t>(elem.first));
+//             serializer.append(static_cast<int32_t>(elem.second));
+//         }
 
-        serializer.append(static_cast<int32_t>(debug_pnet_post_nms));
-        serializer.append(static_cast<int32_t>(debug_rnet_post_nms));
-        serializer.append(static_cast<int32_t>(mode));
-        serializer.append(static_cast<int32_t>(stage2_zdir_batch_size));
-    }
+//         serializer.append(static_cast<int32_t>(debug_pnet_post_nms));
+//         serializer.append(static_cast<int32_t>(debug_rnet_post_nms));
+//         serializer.append(static_cast<int32_t>(mode));
+//         serializer.append(static_cast<int32_t>(stage2_zdir_batch_size));
+//     }
 
-    void serializeDataImpl(BlobSerializer& serializer) const override {
-        auto input0 = inputEdge(0)->input();
-        auto input1 = inputEdge(1)->input();
-        auto output = outputEdge(0)->output();
+//     void serializeDataImpl(BlobSerializer& serializer) const override {
+//         auto input0 = inputEdge(0)->input();
+//         auto input1 = inputEdge(1)->input();
+//         auto output = outputEdge(0)->output();
 
-        input0->serializeBuffer(serializer);
-        output->serializeBuffer(serializer);
+//         input0->serializeBuffer(serializer);
+//         output->serializeBuffer(serializer);
 
-        IE_ASSERT(inputEdge(1)->input()->desc().dimsOrder() == DimsOrder::C);
-        input1->serializeBuffer(serializer);
-    }
-};
+//         IE_ASSERT(inputEdge(1)->input()->desc().dimsOrder() == DimsOrder::C);
+//         input1->serializeBuffer(serializer);
+//     }
+// };
 
-std::pair<int, int> getResolution(const std::string& str) {
-    std::istringstream stream(str);
-    std::string output;
-    std::getline(stream, output, 'x');
-    auto width = std::stoi(output);
-    std::getline(stream, output, 'x');
-    auto height = std::stoi(output);
-    return std::make_pair(width, height);
-}
+// std::pair<int, int> getResolution(const std::string& str) {
+//     std::istringstream stream(str);
+//     std::string output;
+//     std::getline(stream, output, 'x');
+//     auto width = std::stoi(output);
+//     std::getline(stream, output, 'x');
+//     auto height = std::stoi(output);
+//     return std::make_pair(width, height);
+// }
 
-ie::CNNNetwork loadSubNetwork(
-        const std::string& fileName,
-        const std::pair<int, int>& imgSize,
-        const ie::ICore* core,
-        int* zdir_batchsize = nullptr) {
-    //
-    // Load network
-    //
+// ie::CNNNetwork loadSubNetwork(
+//         const std::string& fileName,
+//         const std::pair<int, int>& imgSize,
+//         const ie::ICore* core,
+//         int* zdir_batchsize = nullptr) {
+//     //
+//     // Load network
+//     //
 
-    auto network = core->ReadNetwork(fileName, std::string());
+//     auto network = core->ReadNetwork(fileName, std::string());
 
-    //
-    // Set precision of input/output
-    //
+//     //
+//     // Set precision of input/output
+//     //
 
-    auto networkInputs = network.getInputsInfo();
-    IE_ASSERT(networkInputs.size() == 1);
+//     auto networkInputs = network.getInputsInfo();
+//     IE_ASSERT(networkInputs.size() == 1);
 
-    auto networkOutputs = network.getOutputsInfo();
-    IE_ASSERT(networkOutputs.size() == 1);
+//     auto networkOutputs = network.getOutputsInfo();
+//     IE_ASSERT(networkOutputs.size() == 1);
 
-    networkInputs.begin()->second->setPrecision(ie::Precision::FP16);
-    networkInputs.begin()->second->setLayout(ie::Layout::NCHW);
+//     networkInputs.begin()->second->setPrecision(ie::Precision::FP16);
+//     networkInputs.begin()->second->setLayout(ie::Layout::NCHW);
 
-    networkOutputs.begin()->second->setPrecision(ie::Precision::FP16);
-    networkOutputs.begin()->second->setLayout(ie::Layout::NCHW);
+//     networkOutputs.begin()->second->setPrecision(ie::Precision::FP16);
+//     networkOutputs.begin()->second->setLayout(ie::Layout::NCHW);
 
-    //
-    // Change input shape
-    //
+//     //
+//     // Change input shape
+//     //
 
-    auto inputShapes = network.getInputShapes();
-    IE_ASSERT(inputShapes.size() == 1);
+//     auto inputShapes = network.getInputShapes();
+//     IE_ASSERT(inputShapes.size() == 1);
 
-    std::string inputName;
-    ie::SizeVector inputShape;
-    std::tie(inputName, inputShape) = *inputShapes.begin();
-    if (zdir_batchsize != nullptr)
-        *zdir_batchsize = static_cast<int>(inputShape[1]/3);
-    inputShape[0] = 1;                // set batch size to the first input dimension
-    inputShape[2] = imgSize.second;   // changes input height to the image one
-    inputShape[3] = imgSize.first;    // changes input width to the image one
-    inputShapes[inputName] = inputShape;
+//     std::string inputName;
+//     ie::SizeVector inputShape;
+//     std::tie(inputName, inputShape) = *inputShapes.begin();
+//     if (zdir_batchsize != nullptr)
+//         *zdir_batchsize = static_cast<int>(inputShape[1]/3);
+//     inputShape[0] = 1;                // set batch size to the first input dimension
+//     inputShape[2] = imgSize.second;   // changes input height to the image one
+//     inputShape[3] = imgSize.first;    // changes input width to the image one
+//     inputShapes[inputName] = inputShape;
 
-    network.reshape(inputShapes);
+//     network.reshape(inputShapes);
 
-    return network;
-}
+//     return network;
+// }
 
-}  // namespace
+// }  // namespace
 
-void FrontEnd::parseMTCNN(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
-    const auto& env = CompileEnv::get();
+// void FrontEnd::parseMTCNN(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+//     const auto& env = CompileEnv::get();
 
-    ie::details::CaselessEq<std::string> cmp;
+//     ie::details::CaselessEq<std::string> cmp;
 
-    IE_ASSERT(inputs.size() == 1);
-    IE_ASSERT(outputs.size() == 1);
+//     IE_ASSERT(inputs.size() == 1);
+//     IE_ASSERT(outputs.size() == 1);
 
-    if (!env.config.compileConfig().hwOptimization) {
-        VPU_THROW_EXCEPTION << "MTCNN layer supports Myriad X with NCE only";
-    }
+//     if (!env.config.hwOptimization) {
+//         VPU_THROW_EXCEPTION << "MTCNN layer supports Myriad X with NCE only";
+//     }
 
-    auto input = inputs[0];
-    auto output = outputs[0];
+//     auto input = inputs[0];
+//     auto output = outputs[0];
 
-    auto modeStr = layer->GetParamAsString("mode", "PUBLIC_MTCNN");
+//     auto modeStr = layer->GetParamAsString("mode", "PUBLIC_MTCNN");
 
-    auto pnet_ir_name = layer->GetParamAsString("pnet_ir");
-    auto rnet_ir_name = layer->GetParamAsString("rnet_ir");
-    auto onet_ir_name = layer->GetParamAsString("onet_ir");
-    auto pnet_resolutions_str = layer->GetParamAsString("pnet_resolutions");
+//     auto pnet_ir_name = layer->GetParamAsString("pnet_ir");
+//     auto rnet_ir_name = layer->GetParamAsString("rnet_ir");
+//     auto onet_ir_name = layer->GetParamAsString("onet_ir");
+//     auto pnet_resolutions_str = layer->GetParamAsString("pnet_resolutions");
 
-    std::pair<int, int> r_net_input = {24, 24};
-    std::pair<int, int> o_net_input = {48, 48};
+//     std::pair<int, int> r_net_input = {24, 24};
+//     std::pair<int, int> o_net_input = {48, 48};
 
-    SmallVector<std::pair<int, int>> pyramid;
+//     SmallVector<std::pair<int, int>> pyramid;
 
-    std::istringstream stream(pnet_resolutions_str);
-    std::string str;
-    while (getline(stream, str, ',')) {
-        pyramid.emplace_back(getResolution(str));
-    }
+//     std::istringstream stream(pnet_resolutions_str);
+//     std::string str;
+//     while (getline(stream, str, ',')) {
+//         pyramid.emplace_back(getResolution(str));
+//     }
 
-    // Assert that the first stage in the pyramid is the largest one
-    for (const auto& p_net_input : pyramid) {
-        if (p_net_input.first > pyramid[0].first || p_net_input.second > pyramid[0].second) {
-            VPU_THROW_EXCEPTION << "MTCNN layer: first stage in pyramid should be the largest one";
-        }
-    }
+//     // Assert that the first stage in the pyramid is the largest one
+//     for (const auto& p_net_input : pyramid) {
+//         if (p_net_input.first > pyramid[0].first || p_net_input.second > pyramid[0].second) {
+//             VPU_THROW_EXCEPTION << "MTCNN layer: first stage in pyramid should be the largest one";
+//         }
+//     }
 
-    SmallVector<CompiledGraph::Ptr> compiledSubNetworks;
-    compiledSubNetworks.reserve(pyramid.size() + 2);
+//     SmallVector<CompiledGraph::Ptr> compiledSubNetworks;
+//     compiledSubNetworks.reserve(pyramid.size() + 2);
 
-    //
-    // Compile sub-networks with std::async to avoid current CompileEnv modification.
-    //
-    size_t mergedBlobSize = 0;
+//     //
+//     // Compile sub-networks with std::async to avoid current CompileEnv modification.
+//     //
+//     size_t mergedBlobSize = 0;
 
-    // Convert p-nets
-    for (const auto& p_net_input : pyramid) {
-        auto pNet = loadSubNetwork(pnet_ir_name, p_net_input, _core);
-        auto res = compileSubNetwork(pNet, env.config, _core);
-        mergedBlobSize += res->blob.size();
-        compiledSubNetworks.emplace_back(std::move(res));
-    }
+//     // Convert p-nets
+//     for (const auto& p_net_input : pyramid) {
+//         auto pNet = loadSubNetwork(pnet_ir_name, p_net_input, _core);
+//         auto res = compileSubNetwork(pNet, env.config, _core);
+//         mergedBlobSize += res->blob.size();
+//         compiledSubNetworks.emplace_back(std::move(res));
+//     }
 
-    int stage2_zdir_batchsize = 1;
-    // Convert r-net
-    {
-        auto rNet = loadSubNetwork(rnet_ir_name, r_net_input, _core, &stage2_zdir_batchsize);
-        auto res = compileSubNetwork(rNet, env.config, _core);
-        mergedBlobSize += res->blob.size();
-        compiledSubNetworks.emplace_back(std::move(res));
-    }
+//     int stage2_zdir_batchsize = 1;
+//     // Convert r-net
+//     {
+//         auto rNet = loadSubNetwork(rnet_ir_name, r_net_input, _core, &stage2_zdir_batchsize);
+//         auto res = compileSubNetwork(rNet, env.config, _core);
+//         mergedBlobSize += res->blob.size();
+//         compiledSubNetworks.emplace_back(std::move(res));
+//     }
 
-    // Convert o-net
-    {
-        auto oNet = loadSubNetwork(onet_ir_name, o_net_input, _core);
-        auto res = compileSubNetwork(oNet, env.config, _core);
-        mergedBlobSize += res->blob.size();
-        compiledSubNetworks.emplace_back(std::move(res));
-    }
+//     // Convert o-net
+//     {
+//         auto oNet = loadSubNetwork(onet_ir_name, o_net_input, _core);
+//         auto res = compileSubNetwork(oNet, env.config, _core);
+//         mergedBlobSize += res->blob.size();
+//         compiledSubNetworks.emplace_back(std::move(res));
+//     }
 
-    //
-    // Merge sub networks blobs
-    //
+//     //
+//     // Merge sub networks blobs
+//     //
 
-    std::vector<char> mergedBlob(mergedBlobSize);
+//     std::vector<char> mergedBlob(mergedBlobSize);
 
-    size_t curOffset = 0;
-    for (const auto& subRes : compiledSubNetworks) {
-        std::copy_n(subRes->blob.data(), subRes->blob.size(), mergedBlob.data() + curOffset);
-        curOffset += subRes->blob.size();
-    }
+//     size_t curOffset = 0;
+//     for (const auto& subRes : compiledSubNetworks) {
+//         std::copy_n(subRes->blob.data(), subRes->blob.size(), mergedBlob.data() + curOffset);
+//         curOffset += subRes->blob.size();
+//     }
 
-    auto innerGraphsDesc = DataDesc({mergedBlob.size()});
-    innerGraphsDesc.setType(DataType::U8);
+//     auto innerGraphsDesc = DataDesc({mergedBlob.size()});
+//     innerGraphsDesc.setType(DataType::U8);
 
-    auto innerGraphs = model->addConstData(layer->name + "@innerGraphs", innerGraphsDesc, std::make_shared<MTCNNBlobContent>(mergedBlob));
+//     auto innerGraphs = model->addConstData(layer->name + "@innerGraphs", innerGraphsDesc, std::make_shared<MTCNNBlobContent>(mergedBlob));
 
-    auto stage = model->addNewStage<MTCNNStage>(layer->name, StageType::MTCNN, layer, {input, innerGraphs}, {output});
-    stage->attrs().set("pyramid", pyramid);
-    stage->attrs().set<int>("debug_pnet_post_nms", layer->GetParamAsInt("debug_pnet_post_nms", 0));
-    stage->attrs().set<int>("debug_rnet_post_nms", layer->GetParamAsInt("debug_rnet_post_nms", 0));
-    stage->attrs().set<MTCNN_Mode>("mode", cmp(modeStr, "AVA_FaceDetector") ? MTCNN_Mode::AVA_FaceDetector : MTCNN_Mode::Public);
-    stage->attrs().set<int>("stage2_zdir_batch_size", stage2_zdir_batchsize);
-}
+//     auto stage = model->addNewStage<MTCNNStage>(layer->name, StageType::MTCNN, layer, {input, innerGraphs}, {output});
+//     stage->attrs().set("pyramid", pyramid);
+//     stage->attrs().set<int>("debug_pnet_post_nms", layer->GetParamAsInt("debug_pnet_post_nms", 0));
+//     stage->attrs().set<int>("debug_rnet_post_nms", layer->GetParamAsInt("debug_rnet_post_nms", 0));
+//     stage->attrs().set<MTCNN_Mode>("mode", cmp(modeStr, "AVA_FaceDetector") ? MTCNN_Mode::AVA_FaceDetector : MTCNN_Mode::Public);
+//     stage->attrs().set<int>("stage2_zdir_batch_size", stage2_zdir_batchsize);
+// }
 
-}  // namespace vpu
+// }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/mvn.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/mvn.cpp
@@ -66,16 +66,19 @@ private:
 
 }  // namespace
 
-void FrontEnd::parseMVN(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parseMVN(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+
+std::cout << "\n parse MNV 6 \n";
+    const auto& mvn = ngraph::as_type_ptr<ngraph::opset6::MVN>(node);
     VPU_THROW_UNLESS(inputs.size() == 2, "%d inputs provided to %s layer, but 2 expected.",
-                                            inputs.size(), layer->name);
+                                            inputs.size(), mvn->get_friendly_name());
     VPU_THROW_UNLESS(outputs.size() == 1, "%d outputs provided to %s layer, but 1 expected.",
-                                            outputs.size(), layer->name);
+                                            outputs.size(), mvn->get_friendly_name());
 
     const auto& input = inputs[0];
     const auto ndims = input->desc().numDims();
     VPU_THROW_UNLESS(ndims == 3 || ndims == 4, "%d input rank provided to %s layer, but only 3D and 4D supported.",
-                                            ndims, layer->name);
+                                            ndims, mvn->get_friendly_name());
 
     const auto& indices = inputs[1];
     const auto indicesSize = indices->desc().totalDimSize();
@@ -91,17 +94,20 @@ void FrontEnd::parseMVN(const Model& model, const ie::CNNLayerPtr& layer, const 
 
     VPU_THROW_UNLESS(!axes.count(Dim::N) && axes.count(Dim::H) && axes.count(Dim::W),
                      "Unsupported combination of indices in layer \"%s\". "
-                     "Only across channel and full batch supported.", layer->name);
+                     "Only across channel and full batch supported.", mvn->get_friendly_name());
     const auto acrossChannels = axes.count(Dim::C) != 0;
 
-    const auto normVariance = layer->GetParamAsBool("normalize_variance");
-    const auto eps = layer->GetParamAsFloat("eps");
-    const auto epsMode = layer->GetParamAsString("eps_mode", "outside_sqrt");
-    VPU_THROW_UNLESS(epsMode == "outside_sqrt",
-                     "eps_mode == %s provided to %s layer, but only eps_mode == \"outside_sqrt\" supported.",
-                     epsMode, layer->name);
+    
+    const auto normVariance = mvn->get_normalize_variance();
 
-    auto stage = model->addNewStage<MVNStage>(layer->name, StageType::MVN, layer, inputs, outputs);
+    const auto eps = mvn->get_eps();
+    const auto epsMode = mvn->get_eps_mode();// == ngraph::op::MVNEpsMode::INSIDE_SQRT ? "inside_sqrt" : "outside_sqrt";
+
+    VPU_THROW_UNLESS(epsMode == ngraph::op::MVNEpsMode::OUTSIDE_SQRT,
+                     "eps_mode == %s provided to %s layer, but only eps_mode == \"outside_sqrt\" supported.",
+                     epsMode, node->get_friendly_name());
+
+    auto stage = model->addNewStage<MVNStage>(mvn->get_friendly_name(), StageType::MVN, mvn, inputs, outputs);
     stage->attrs().set<int>("normalize", normVariance);
     stage->attrs().set<int>("across_channels", acrossChannels);
     stage->attrs().set<float>("eps", eps);

--- a/inference-engine/src/vpu/graph_transformer/src/stages/none.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/none.cpp
@@ -50,13 +50,13 @@ private:
 Stage StageBuilder::addNoneStage(
         const Model& model,
         const std::string& name,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         const DataVector& inputs,
         const DataVector& outputs) {
     return model->addNewStage<NoneStage>(
         name,
         StageType::None,
-        layer,
+        node,
         {inputs},
         {outputs});
 }

--- a/inference-engine/src/vpu/graph_transformer/src/stages/nonzero.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/nonzero.cpp
@@ -3,6 +3,7 @@
 //
 
 #include <vpu/frontend/frontend.hpp>
+#include <vpu/ngraph/operations/static_shape_nonzero.hpp>
 #include <precision_utils.h>
 #include <memory>
 #include <set>
@@ -66,15 +67,17 @@ private:
 
 void FrontEnd::parseNonZero(
         const Model& model,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         const DataVector& inputs,
         const DataVector& outputs) const {
+    auto nonZero = ngraph::as_type_ptr<ngraph::vpu::op::StaticShapeNonZero>(node);
+    VPU_THROW_UNLESS(nonZero != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", nonZero->get_friendly_name(), nonZero->get_type_name());
     VPU_THROW_UNLESS(inputs.size() == 1,
                      "Nonzero layer with name %s must have only 1 input, actually provided %d",
-                     layer->name, inputs.size());
+                     nonZero->get_friendly_name(), inputs.size());
     VPU_THROW_UNLESS(outputs.size() == 2,
                      "Nonzero layer with name %s must have only 2 outputs, actually provided %d",
-                     layer->name, outputs.size());
+                     nonZero->get_friendly_name(), outputs.size());
 
     const auto input = inputs[0];
     const auto inputNumDims = input->desc().numDims();
@@ -87,15 +90,15 @@ void FrontEnd::parseNonZero(
     VPU_THROW_UNLESS(outIndicesDesc.numDims() == 2,
                      "NonZero layer with name %s must have 2D output Indices tensor, "
                      "actually provided %dD tensor",
-                     layer->name, outIndicesDesc.numDims());
+                     nonZero->get_friendly_name(), outIndicesDesc.numDims());
     VPU_THROW_UNLESS(minorIndicesDim >= totalIndicesDimSize,
                      "NonZero layer with name %s must have output Indices tensor with minor dim "
                      "size >= total amount of elements of input tensor, actually provided %d >= %d",
-                     layer->name, minorIndicesDim, totalIndicesDimSize);
+                     nonZero->get_friendly_name(), minorIndicesDim, totalIndicesDimSize);
     VPU_THROW_UNLESS(majorIndicesDim == inputNumDims,
                      "NonZero layer with name %s must have output Indices tensor with major dim "
                      "size == number of dimensions of input tensor, actually provided %d == %d",
-                     layer->name, majorIndicesDim, inputNumDims);
+                     nonZero->get_friendly_name(), majorIndicesDim, inputNumDims);
 
     const auto outDimsDesc = outputs[1]->desc();
     const auto outDimsPerm = outDimsDesc.dimsOrder().toPermutation();
@@ -103,16 +106,16 @@ void FrontEnd::parseNonZero(
     VPU_THROW_UNLESS(outDimsDesc.numDims() == 1,
                      "NonZero layer with name %s must have 1D output Dims tensor, "
                      "actually provided %dD tensor",
-                     layer->name, outDimsDesc.numDims());
+                     nonZero->get_friendly_name(), outDimsDesc.numDims());
     VPU_THROW_UNLESS(minorDimsDim >= 2,
                      "NonZero layer with name %s must have output Dims tensor with minor dim "
                      "size >= 2, actually provided %d",
-                     layer->name, minorDimsDim);
+                     nonZero->get_friendly_name(), minorDimsDim);
 
     model->addNewStage<NonZero>(
-            layer->name,
+            nonZero->get_friendly_name(),
             StageType::NonZero,
-            layer,
+            nonZero,
             inputs,
             outputs);
 }

--- a/inference-engine/src/vpu/graph_transformer/src/stages/normalize.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/normalize.cpp
@@ -69,34 +69,61 @@ private:
         output->serializeBuffer(serializer);
         scales->serializeBuffer(serializer);
     }
+    struct NormalizeParams {
+        int acrossSpatial;
+        int channelShared;
+    };
+
+    NormalizeParams getParamsFromNode(const NodePtr& node) {
+        auto normalize = ngraph::as_type_ptr<ngraph::opset4::NormalizeL2>(node);
+        IE_ASSERT(normalize != nullptr);
+        auto const_axis = std::dynamic_pointer_cast<ngraph::opset4::Constant> (normalize->input(1).get_source_output().get_node_shared_ptr());
+        IE_ASSERT(const_axis != nullptr);
+
+        NormalizeParams outputParams;
+        auto axis = const_axis->cast_vector<size_t>();
+        outputParams.acrossSpatial = !(axis.size() == 1 && axis[0] == 1);
+        outputParams.channelShared = true;
+        return outputParams;
+    }
 };
 
 }  // namespace
 
-void FrontEnd::parseNormalize(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+
+void FrontEnd::parseNormalize(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    const auto& normalize = ngraph::as_type_ptr<ngraph::opset4::NormalizeL2>(node);
+    VPU_THROW_UNLESS(normalize != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
     IE_ASSERT(inputs.size() == 1);
     IE_ASSERT(outputs.size() == 1);
 
-    auto acrossSpatial = layer->GetParamAsInt("across_spatial", 0);
-    auto channelShared = layer->GetParamAsInt("channel_shared", 0);
-    float eps = layer->GetParamAsFloat("eps", 0.0f);
+    int acrossSpatial;
+    int channelShared;
+    auto const_axis = std::dynamic_pointer_cast<ngraph::opset4::Constant>(normalize->input(1).get_source_output().get_node_shared_ptr());
+    IE_ASSERT(const_axis != nullptr);
 
-    auto weightsIt = layer->blobs.find("weights");
-    if (weightsIt == layer->blobs.end()) {
-        VPU_THROW_EXCEPTION << "Missing weights for " << layer->name << " layer";
-    }
+    
+    auto axis = const_axis->cast_vector<size_t>();
+    acrossSpatial = !(axis.size() == 1 && axis[0] == 1);
+    channelShared = 1;
 
-    auto weightsBlob = weightsIt->second;
+    float eps = normalize->get_eps();
+    const auto weightsNode = node->input_value(1).get_node_shared_ptr();
+    Data weightsBlob;
+    std::tie(weightsBlob, std::ignore) = getWeightsAndBiases(model, normalize->get_friendly_name(), weightsNode, NodePtr());
+
     IE_ASSERT(weightsBlob != nullptr);
 
     auto output = outputs[0];
 
-    auto scales = model->addConstData(layer->name + "@scales", DataDesc({weightsBlob->size()}), ieBlobContent(weightsBlob));
+    auto scales = model->addConstData(normalize->get_friendly_name() + "@scales", weightsBlob->desc());
 
-    auto stage = model->addNewStage<NormalizeStage>(layer->name, StageType::Normalize, layer, {inputs[0], scales}, outputs);
+    auto stage = model->addNewStage<NormalizeStage>(normalize->get_friendly_name(), StageType::Normalize, normalize, {inputs[0], scales}, outputs);
     stage->attrs().set<bool>("acrossSpatial", acrossSpatial);
     stage->attrs().set<bool>("channelShared", channelShared);
     stage->attrs().set<float>("eps", eps);
 }
+
+
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/oneHot.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/oneHot.cpp
@@ -70,22 +70,29 @@ private:
 
 }  // namespace
 
-void FrontEnd::parseOneHot(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
-    IE_ASSERT(layer != nullptr);
+void FrontEnd::parseOneHot(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    auto oneHot = ngraph::as_type_ptr<ngraph::opset4::OneHot>(node);
+    VPU_THROW_UNLESS(oneHot != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
     IE_ASSERT(inputs.size() == 1);
     IE_ASSERT(outputs.size() == 1);
 
-    auto oneHot = std::dynamic_pointer_cast<ie::OneHotLayer>(layer);
-    IE_ASSERT(oneHot != nullptr);
+    const auto depthNode = std::dynamic_pointer_cast<ngraph::opset1::Constant>(oneHot->input_value(1).get_node_shared_ptr());
+    const auto onValueNode = std::dynamic_pointer_cast<ngraph::opset1::Constant>(oneHot->input_value(2).get_node_shared_ptr());
+    const auto offValueNode = std::dynamic_pointer_cast<ngraph::opset1::Constant>(oneHot->input_value(3).get_node_shared_ptr());
+    VPU_THROW_UNLESS(depthNode != nullptr && onValueNode != nullptr && offValueNode != nullptr,
+                    "Can't parse node with name %s and type %s. Can't get params", node->get_friendly_name(), node->get_type_name());
 
-    auto axis = oneHot->axis == -1 ? 0 : inputs[0]->desc().numDims() - oneHot->axis;
+    int axis = oneHot->get_axis() == -1 ? 0 : inputs[0]->desc().numDims() - oneHot->get_axis();
+    auto depthValue = std::stoi(depthNode->convert_value_to_string(0));
+    auto onValue = std::stof(onValueNode->convert_value_to_string(0));
+    auto offValue = std::stof(offValueNode->convert_value_to_string(0));
 
-    auto stage = model->addNewStage<OneHot>(layer->name, StageType::OneHot, layer, inputs, outputs);
+    auto stage = model->addNewStage<OneHot>(oneHot->get_friendly_name(), StageType::OneHot, oneHot, inputs, outputs);
 
     stage->attrs().set<int>("axis", axis);
-    stage->attrs().set<unsigned int>("depth", oneHot->depth);
-    stage->attrs().set<float>("on_value", oneHot->on_value);
-    stage->attrs().set<float>("off_value", oneHot->off_value);
+    stage->attrs().set<unsigned int>("depth", depthValue);
+    stage->attrs().set<float>("on_value", onValue);
+    stage->attrs().set<float>("off_value", offValue);
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/out_shape_of_reshape.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/out_shape_of_reshape.cpp
@@ -5,7 +5,7 @@
 #include <vpu/frontend/frontend.hpp>
 
 #include <vpu/model/data_contents/ie_blob_content.hpp>
-
+#include "vpu/ngraph/operations/out_shape_of_reshape.hpp"
 #include <vector>
 #include <map>
 #include <unordered_set>
@@ -57,15 +57,17 @@ private:
 
 void FrontEnd::parseOutShapeOfReshape(
         const Model& model,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         const DataVector& inputs,
         const DataVector& outputs) const {
+    auto outShapeOfReshape = ngraph::as_type_ptr<ngraph::vpu::op::OutShapeOfReshape>(node);
+    IE_ASSERT(outShapeOfReshape != nullptr);
     VPU_THROW_UNLESS(inputs.size() == 2,
                      "OutShapeOfReshape stage with name %s must have only 2 inputs, "
-                     "actually provided %d", layer->name, inputs.size());
+                     "actually provided %d", outShapeOfReshape->get_friendly_name(), inputs.size());
     VPU_THROW_UNLESS(outputs.size() == 1,
                      "OutShapeOfReshape stage with name %s must have only 1 output, "
-                     "actually provided %d", layer->name, outputs.size());
+                     "actually provided %d", outShapeOfReshape->get_friendly_name(), outputs.size());
 
     auto inDataShape = inputs[0];
     auto outShapeDescriptor = inputs[1];
@@ -73,30 +75,30 @@ void FrontEnd::parseOutShapeOfReshape(
 
     VPU_THROW_UNLESS(inDataShape->desc().numDims() == 1,
                      "OutShapeOfReshape stage with name %s must have 1D input data shape tensor, "
-                     "actually provided %dD tensor", layer->name, inDataShape->desc().numDims());
+                     "actually provided %dD tensor", outShapeOfReshape->get_friendly_name(), inDataShape->desc().numDims());
     VPU_THROW_UNLESS(outShapeDescriptor->desc().numDims() == 1,
                      "OutShapeOfReshape stage with name %s must have 1D output shape descriptor "
                      "tensor, actually provided %dD tensor",
-                     layer->name, outShapeDescriptor->desc().numDims());
+                     outShapeOfReshape->get_friendly_name(), outShapeDescriptor->desc().numDims());
     VPU_THROW_UNLESS(outDataShape->desc().numDims() == 1,
                      "OutShapeOfReshape stage with name %s must have 1D output data shape tensor, "
-                     "actually provided %dD tensor", layer->name, outDataShape->desc().numDims());
+                     "actually provided %dD tensor", outShapeOfReshape->get_friendly_name(), outDataShape->desc().numDims());
 
     VPU_THROW_UNLESS(outShapeDescriptor->desc().totalDimSize() == outDataShape->desc().totalDimSize(),
                      "OutShapeOfReshape stage with name %s must have output shape descriptor and "
                      "output data shape tensor with equal length, actually provided %d vs %d",
-                     layer->name, outShapeDescriptor->desc().totalDimSize(),
+                     outShapeOfReshape->get_friendly_name(), outShapeDescriptor->desc().totalDimSize(),
                      outDataShape->desc().totalDimSize());
 
 
     auto outShapeOfReshapeStage = model->addNewStage<OutShapeOfReshapeStage>(
-            layer->name,
+            outShapeOfReshape->get_friendly_name(),
             StageType::OutShapeOfReshape,
-            layer,
+            outShapeOfReshape,
             inputs,
             outputs);
 
-    auto specialZero = layer->GetParamAsBool("special_zero", false);
+    auto specialZero = outShapeOfReshape->getSpecialZero();
     outShapeOfReshapeStage->attrs().set<bool>("specialZero", specialZero);
 }
 

--- a/inference-engine/src/vpu/graph_transformer/src/stages/pad.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/pad.cpp
@@ -85,41 +85,55 @@ private:
 };
 
 }  // namespace
-
-void FrontEnd::parsePad(const Model& model, const ie::CNNLayerPtr& _layer, const DataVector& inputs, const DataVector& outputs) const {
-    IE_ASSERT(inputs.size() == 1);
+float getPadValue (const NodePtr& pad) {
+    auto result = 0.f;
+    if (pad->inputs().size() == 4) {
+        auto const_node =
+            std::dynamic_pointer_cast<ngraph::opset4::Constant>(pad->input(3).get_source_output().get_node_shared_ptr());
+        if (!const_node) {
+            VPU_THROW_UNLESS(false, "Pad {} with not constant pad_value is not allowed", pad->get_friendly_name());
+        }
+        //rework
+        result = const_node->get_vector<fp16_t>()[0];
+    }
+    return result;
+}
+void FrontEnd::parsePad(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    const auto& pad = ngraph::as_type_ptr<ngraph::opset4::Pad>(node);
+    VPU_THROW_UNLESS(pad != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+    // IE_ASSERT(inputs.size() == 1);
     IE_ASSERT(outputs.size() == 1);
 
-    auto layer = std::dynamic_pointer_cast<ie::PadLayer>(_layer);
-    IE_ASSERT(layer != nullptr);
-
     const auto ndims = inputs[0]->desc().dimsOrder().numDims();
-    VPU_THROW_UNLESS(ndims == 3 || ndims == 4, "Layer %s support only 3D and 4D input, but %dD provided", layer->name, ndims);
+    VPU_THROW_UNLESS(ndims == 3 || ndims == 4, "Layer %s support only 3D and 4D input, but %dD provided", pad->get_friendly_name(), ndims);
 
-    VPU_THROW_UNLESS(layer->pads_begin.size() <= 4, "Layer %s support pads_begin size less than or equal 4, but %d provided",
-                     layer->name, layer->pads_begin.size());
-    VPU_THROW_UNLESS(layer->pads_end.size() <= 4, "Layer %s support pads_end size less than or equal 4, but %d provided",
-            layer->name, layer->pads_end.size());
+    VPU_THROW_UNLESS(pad->get_pads_begin().size() <= 4, "Layer %s support pads_begin size less than or equal 4, but %d provided",
+                     pad->get_friendly_name(), pad->get_pads_begin().size());
+    VPU_THROW_UNLESS(pad->get_pads_end().size() <= 4, "Layer %s support pads_end size less than or equal 4, but %d provided",
+                     pad->get_friendly_name(), pad->get_pads_end().size());
 
     DimsOrder dimsOrder = inputs[0]->desc().dimsOrder();
+    auto padsBegin = pad->get_pads_begin();
+    auto padsEnd = pad->get_pads_end();
     DimValues pads_begin;
-    pads_begin.set(Dim::W, dimsOrder.hasDim(Dim::W) ? layer->pads_begin[dimToIeInd(Dim::W, ndims)] : 0);
-    pads_begin.set(Dim::H, dimsOrder.hasDim(Dim::H) ? layer->pads_begin[dimToIeInd(Dim::H, ndims)] : 0);
-    pads_begin.set(Dim::C, dimsOrder.hasDim(Dim::C) ? layer->pads_begin[dimToIeInd(Dim::C, ndims)] : 0);
-    pads_begin.set(Dim::N, dimsOrder.hasDim(Dim::N) ? layer->pads_begin[dimToIeInd(Dim::N, ndims)] : 0);
+    pads_begin.set(Dim::W, dimsOrder.hasDim(Dim::W) ? padsBegin[dimToIeInd(Dim::W, ndims)] : 0);
+    pads_begin.set(Dim::H, dimsOrder.hasDim(Dim::H) ? padsBegin[dimToIeInd(Dim::H, ndims)] : 0);
+    pads_begin.set(Dim::C, dimsOrder.hasDim(Dim::C) ? padsBegin[dimToIeInd(Dim::C, ndims)] : 0);
+    pads_begin.set(Dim::N, dimsOrder.hasDim(Dim::N) ? padsBegin[dimToIeInd(Dim::N, ndims)] : 0);
 
     DimValues pads_end;
-    pads_end.set(Dim::W, dimsOrder.hasDim(Dim::W) ? layer->pads_end[dimToIeInd(Dim::W, ndims)] : 0);
-    pads_end.set(Dim::H, dimsOrder.hasDim(Dim::H) ? layer->pads_end[dimToIeInd(Dim::H, ndims)] : 0);
-    pads_end.set(Dim::C, dimsOrder.hasDim(Dim::C) ? layer->pads_end[dimToIeInd(Dim::C, ndims)] : 0);
-    pads_end.set(Dim::N, dimsOrder.hasDim(Dim::N) ? layer->pads_end[dimToIeInd(Dim::N, ndims)] : 0);
+    pads_end.set(Dim::W, dimsOrder.hasDim(Dim::W) ? padsEnd[dimToIeInd(Dim::W, ndims)] : 0);
+    pads_end.set(Dim::H, dimsOrder.hasDim(Dim::H) ? padsEnd[dimToIeInd(Dim::H, ndims)] : 0);
+    pads_end.set(Dim::C, dimsOrder.hasDim(Dim::C) ? padsEnd[dimToIeInd(Dim::C, ndims)] : 0);
+    pads_end.set(Dim::N, dimsOrder.hasDim(Dim::N) ? padsEnd[dimToIeInd(Dim::N, ndims)] : 0);
+    auto padValue = getPadValue(pad);
 
     _stageBuilder->addPadStage(
         model,
-        layer->name,
-        layer,
-        static_cast<PadMode>(layer->pad_mode),
-        layer->pad_value,
+        pad->get_friendly_name(),
+        pad,
+        static_cast<PadMode>(pad->get_pad_mode()),
+        padValue,
         pads_begin,
         pads_end,
         inputs[0],
@@ -129,7 +143,7 @@ void FrontEnd::parsePad(const Model& model, const ie::CNNLayerPtr& _layer, const
 Stage StageBuilder::addPadStage(
         const Model& model,
         const std::string& name,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         PadMode padMode,
         float pad_value,
         const DimValues& pads_begin,
@@ -139,7 +153,7 @@ Stage StageBuilder::addPadStage(
     auto stage = model->addNewStage<PadStage>(
         name,
         StageType::Pad,
-        layer,
+        node,
         {input},
         {output});
 

--- a/inference-engine/src/vpu/graph_transformer/src/stages/permute.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/permute.cpp
@@ -78,11 +78,21 @@ private:
 
 }  // namespace
 
-void FrontEnd::parsePermute(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
-    IE_ASSERT(inputs.size() == 1);
+void FrontEnd::parsePermute(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    // IE_ASSERT(inputs.size() == 1);
     IE_ASSERT(outputs.size() == 1);
-
-    const auto ieOrder = layer->GetParamAsUInts("order");
+    auto permute = ngraph::as_type_ptr<ngraph::opset4::Transpose>(node);
+    VPU_THROW_UNLESS(permute != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", permute->get_friendly_name(), permute->get_type_name());
+    auto transposeConst = std::dynamic_pointer_cast<ngraph::op::Constant>(node->input_value(1).get_node_shared_ptr());
+    // transposeConst->get_data_ptr();
+    VPU_THROW_UNLESS(transposeConst != nullptr, "Can't parse node with name %s and type %s. Data node is nullptr", transposeConst->get_friendly_name(), transposeConst->get_type_name());
+    auto intOrder = transposeConst->cast_vector<int64_t>();
+    std::string stringOrder;
+    for (const auto& item : intOrder) {
+        if (!stringOrder.empty()) stringOrder += ",";
+        stringOrder += std::to_string(item);
+    } 
+    const auto ieOrder = stringOrder;
     const auto perm = DimsOrder::fromNumDims(checked_cast<int>(ieOrder.size())).toPermutation();
 
     PermutationDimsMap permutation;
@@ -92,13 +102,13 @@ void FrontEnd::parsePermute(const Model& model, const ie::CNNLayerPtr& layer, co
         permutation.set(dstDim, srcDim);
     }
 
-    _stageBuilder->addPermuteStage(model, layer->name, layer, inputs[0], outputs[0], permutation);
+    _stageBuilder->addPermuteStage(model, permute->get_friendly_name(), permute, inputs[0], outputs[0], permutation);
 }
 
 Stage StageBuilder::addPermuteStage(
         const Model& model,
         const std::string& name,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         const Data& input,
         const Data& output,
         const PermutationDimsMap& permutation) {
@@ -109,7 +119,7 @@ Stage StageBuilder::addPermuteStage(
     auto stage = model->addNewStage<PermuteStage>(
         name,
         StageType::Permute,
-        layer,
+        node,
         {input},
         {output});
     stage->attrs().set(permutationKey, permutation);
@@ -119,7 +129,7 @@ Stage StageBuilder::addPermuteStage(
 Stage StageBuilder::addReorderStage(
         const Model& model,
         const std::string& name,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         const Data& input,
         const Data& output) {
     const auto* env = CompileEnv::getOrNull();
@@ -137,7 +147,7 @@ Stage StageBuilder::addReorderStage(
         permutationMap.set(dim, dim);
     }
 
-    auto stage = addPermuteStage(model, name, layer, input, output, permutationMap);
+    auto stage = addPermuteStage(model, name, node, input, output, permutationMap);
     stage->attrs().set(outputOrderKey, output->desc().dimsOrder());
     return stage;
 }

--- a/inference-engine/src/vpu/graph_transformer/src/stages/pooling.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/pooling.cpp
@@ -17,10 +17,12 @@
 #include <vpu/compile_env.hpp>
 #include <vpu/stages/stub_stage.hpp>
 
-namespace vpu {
+#include <ngraph/ops.hpp>
 
+namespace vpu {
+namespace {
 static
-bool canTryHW(const ie::PoolingLayer::PoolType poolType,
+bool canTryHW(const PoolMethod poolType,
               const int inputWidth,
               const int inputHeight,
               const int outputWidth,
@@ -82,21 +84,21 @@ bool canTryHW(const ie::PoolingLayer::PoolType poolType,
     }
 
     // TODO: 3x3s2 Avg pooling is not supported by HW
-    if (kernelSizeX == 3 && kernelSizeY == 3 && kernelStrideX == 2 && poolType == ie::PoolingLayer::AVG) {
+    if (kernelSizeX == 3 && kernelSizeY == 3 && kernelStrideX == 2 && poolType == PoolMethod::Pool_avg) {
         tryHW = false;
     }
 
     // TODO: Avg pooling with even kernel size and odd input is not supported
     if ((kernelSizeX % 2 == 0 || kernelSizeY % 2 == 0)) {
         if (inputWidth % 2 == 1 || inputHeight % 2 == 1) {
-            if (poolType == ie::PoolingLayer::PoolType::AVG) {
+            if (poolType == PoolMethod::Pool_avg) {
                 tryHW = false;
             }
         }
     }
 
     // TODO : 5x5s3 Avg pooling hangs device
-    if (kernelSizeX == 5 && kernelSizeY == 5 && kernelStrideX == 3 && poolType == ie::PoolingLayer::PoolType::AVG) {
+    if (kernelSizeX == 5 && kernelSizeY == 5 && kernelStrideX == 3 && poolType == PoolMethod::Pool_avg) {
         tryHW = false;
     }
 
@@ -110,7 +112,7 @@ bool canTryHW(const ie::PoolingLayer::PoolType poolType,
     // TODO: 3x3s2 Max Pooling with [2,2] padding is not supported by HW
     if (kernelSizeX == 3 && kernelSizeY == 3 &&
         kernelStrideX == 2 && kernelStrideY == 2 &&
-        poolType == ie::PoolingLayer::MAX &&
+        poolType == PoolMethod::Pool_max &&
         padLeft == 0 && padTop == 0 &&
         padRight == 2 && padBottom == 2) {
         tryHW = false;
@@ -119,7 +121,7 @@ bool canTryHW(const ie::PoolingLayer::PoolType poolType,
     //  FIX #14949, enable HW AVG pooling, need SW postproc
     //  HW AVG pooling will output wrong results in borders when excludePad=true
     bool hasPad = padLeft || padTop || padRight || padBottom;
-    if (excludePad && hasPad && poolType == ie::PoolingLayer::PoolType::AVG) {
+    if (excludePad && hasPad && poolType == PoolMethod::Pool_avg) {
         // Only apply to small output tensors for now
         // May need to loose the condition if accuracy issues are met
         if (outputWidth <= 5 && outputHeight <= 5) {
@@ -128,7 +130,7 @@ bool canTryHW(const ie::PoolingLayer::PoolType poolType,
     }
 
     // FIX #16406, #18639 AVG pooling result is always 0 in case of 1x1 kernel
-    if (kernelSizeX == 1 && kernelSizeY == 1 && poolType == ie::PoolingLayer::PoolType::AVG) {
+    if (kernelSizeX == 1 && kernelSizeY == 1 && poolType == PoolMethod::Pool_avg) {
         tryHW = false;
     }
 
@@ -146,7 +148,7 @@ bool canTryHW(const ie::PoolingLayer::PoolType poolType,
     if (inputWidth == 382 && inputHeight == 214 &&
         kernelSizeX == 2 && kernelSizeY == 2 &&
         kernelStrideX == 2 && kernelStrideY ==2 &&
-        poolType == ie::PoolingLayer::MAX) {
+        poolType == PoolMethod::Pool_max) {
         tryHW = false;
     }
 
@@ -159,61 +161,56 @@ bool canTryHW(const ie::PoolingLayer::PoolType poolType,
 
 static
 void parsePool2D(const     Model      & model,
-                 const ie::CNNLayerPtr& layer,
+                 const     NodePtr    & node,
                  const     Data       & input,
-                 const     Data       & output) {
+                 const     Data       & output,
+                 const     PoolingParams & poolParams) {
     //
     // Extract parameters
     //
-
-    auto poolLayer = std::dynamic_pointer_cast<ie::PoolingLayer>(layer);
-    VPU_THROW_UNLESS(poolLayer != nullptr, "failed dynamic cast to PoolingLayer");
-
-    int kernelSizeX = poolLayer->_kernel_x;
-    int kernelSizeY = poolLayer->_kernel_y;
-
-    int kernelStrideX = poolLayer->_stride_x;
-    int kernelStrideY = poolLayer->_stride_y;
-
-    auto paddings  = getPaddings(*poolLayer);
-    int  padLeft   = paddings.begin.exist(ie::X_AXIS) ? paddings.begin[ie::X_AXIS] : 0;
-    int  padRight  = paddings.end.exist(ie::X_AXIS)   ? paddings.end[ie::X_AXIS]   : padLeft;
-    int  padTop    = paddings.begin.exist(ie::Y_AXIS) ? paddings.begin[ie::Y_AXIS] : 0;
-    int  padBottom = paddings.end.exist(ie::Y_AXIS)   ? paddings.end[ie::Y_AXIS]   : padTop;
+    int kernelSizeX = poolParams.kernel[1]; //poolLayer->_kernel_x;
+    int kernelSizeY = poolParams.kernel[0]; //->_kernel_y;
+    int kernelStrideX = poolParams.strides[1];
+    int kernelStrideY = poolParams.strides[0];
+    // auto paddings  = getPaddings(*poolLayer);
+    int  padLeft   = poolParams.padsBegin[1];//  paddings.begin.exist(ie::X_AXIS) ? paddings.begin[ie::X_AXIS] : 0;
+    int  padRight  = poolParams.padsEnd[1];  //paddings.end.exist(ie::X_AXIS)   ? paddings.end[ie::X_AXIS]   : padLeft;
+    int  padTop    = poolParams.padsBegin[0]; //paddings.begin.exist(ie::Y_AXIS) ? paddings.begin[ie::Y_AXIS] : 0;
+    int  padBottom = poolParams.padsEnd[0]; // paddings.end.exist(ie::Y_AXIS)   ? paddings.end[ie::Y_AXIS]   : padTop;
 
     // for old IR's IE doesn't return valid padding. Fix paddings
-    {
-        int iw = input->desc().dim(Dim::W);
-        int ih = input->desc().dim(Dim::H);
+    // {
+    //     int iw = input->desc().dim(Dim::W);
+    //     int ih = input->desc().dim(Dim::H);
 
-        int ow = output->desc().dim(Dim::W);
-        int oh = output->desc().dim(Dim::H);
+    //     int ow = output->desc().dim(Dim::W);
+    //     int oh = output->desc().dim(Dim::H);
 
-        int expectedIW = (ow - 1)*kernelStrideX + kernelSizeX;
-        int expectedOW = (oh - 1)*kernelStrideY + kernelSizeY;
+    //     int expectedIW = (ow - 1)*kernelStrideX + kernelSizeX;
+    //     int expectedOW = (oh - 1)*kernelStrideY + kernelSizeY;
 
-        if (expectedIW > iw + padLeft + padRight) {
-            padRight  = expectedIW - (iw + padLeft);
-        }
+    //     if (expectedIW > iw + padLeft + padRight) {
+    //         padRight  = expectedIW - (iw + padLeft);
+    //     }
 
-        if (expectedOW > ih + padTop + padBottom) {
-            padBottom = expectedOW - (ih + padTop);
-        }
-    }
+    //     if (expectedOW > ih + padTop + padBottom) {
+    //         padBottom = expectedOW - (ih + padTop);
+    //     }
+    // }
 
-    auto poolType = poolLayer->_type;
+    auto poolType = poolParams.poolMethod;
 
-    auto excludePad = poolLayer->_exclude_pad;
+    auto excludePad = poolParams.excludePad;
 
-    auto autoPad = poolLayer->_auto_pad;
+    auto autoPad = poolParams.autoPad;
 
     auto stageType = StageType::None;
-    if (poolType == ie::PoolingLayer::MAX) {
+    if (poolType == PoolMethod::Pool_max) {
         stageType = StageType::StubMaxPool;
-    } else if (poolType == ie::PoolingLayer::AVG) {
+    } else if (poolType == PoolMethod::Pool_avg) {
         stageType = StageType::StubAvgPool;
     } else {
-        VPU_THROW_EXCEPTION << "Pooling Layer " << poolLayer->name << " has unsupported type: " << poolType;
+        VPU_THROW_EXCEPTION << "Pooling Layer " << node->get_friendly_name() << " has unsupported type: " << poolType;
     }
 
     //
@@ -222,7 +219,7 @@ void parsePool2D(const     Model      & model,
 
     const auto& env = CompileEnv::get();
     bool hwOptimization = env.config.compileConfig().hwOptimization;
-    bool hwDisabled = env.config.compileConfig().hwDisabled(layer->name);
+    bool hwDisabled = env.config.compileConfig().hwDisabled(node->get_friendly_name() );
 
     int inputWidth = input->desc().dim(Dim::W);
     int inputHeight = input->desc().dim(Dim::H);
@@ -256,9 +253,9 @@ void parsePool2D(const     Model      & model,
     //
 
     auto stage = model->addNewStage<StubStage>(
-        layer->name,
+        node->get_friendly_name(),
         stageType,
-        layer,
+        node,
         {input},
         {output});
 
@@ -280,11 +277,6 @@ void parsePool2D(const     Model      & model,
 
 //----------------------------------------------------------------------
 
-enum PoolNDMethod   { PoolND_max = 1, PoolND_avg = 2 };
-
-enum PoolNDRounding { PoolND_floor = 3, PoolND_ceil  = 4 };
-
-namespace {
 
 class PoolNDStage final : public StageNode {
 public:
@@ -372,21 +364,19 @@ private:
     }
 };
 
-}  // namespace
+
 
 static
 void parsePoolND(const     Model      & model,
-                 const ie::CNNLayerPtr& layer,
+                 const     NodePtr    & node,
                  const     Data       & input,
-                 const     Data       & output) {
+                 const     Data       & output,
+                 const     PoolingParams & poolparams) {
     //
     // Check layer parameters
     //
 
-    auto poolLayer = std::dynamic_pointer_cast<ie::PoolingLayer>(layer);
-    VPU_THROW_UNLESS(poolLayer != nullptr, "failed dynamic cast to PoolingLayer");
-
-    auto kernel_shape = poolLayer->_kernel;
+    auto kernel_shape =  poolparams.kernel; // poolLayer->_kernel;
     int kernel_ndims = static_cast<int>(kernel_shape.size());
     // Yet, only 3D kernel supported (NCDHW)
     // Later, if support 4D, 5D, etc, please
@@ -395,9 +385,9 @@ void parsePoolND(const     Model      & model,
     // parsePool2D() function
     VPU_THROW_UNLESS(kernel_ndims == 3, "unsupported kernel ndims=%d", kernel_ndims);
 
-    auto paddings = getPaddings(*poolLayer);
-    auto pads_begin = paddings.begin;
-    auto pads_end   = paddings.end;
+    //auto paddings = getPaddings(*poolLayer);
+    auto pads_begin = poolparams.padsBegin; // paddings.begin;
+    auto pads_end   = poolparams.padsEnd; // paddings.end;
     VPU_THROW_UNLESS(pads_begin.size() == kernel_ndims,
                      "incompatible pad ndims: actual=%lu, expected=%d",
                      pads_begin.size(), kernel_ndims);
@@ -405,7 +395,7 @@ void parsePoolND(const     Model      & model,
                      "incompatible pad ndims: actual=%lu, expected=%d",
                      pads_end.size(), kernel_ndims);
 
-    auto strides = poolLayer->_stride;
+    auto strides = poolparams.strides;
     VPU_THROW_UNLESS(strides.size() == kernel_ndims,
                      "incompatible stride ndims: actual=%lu, expected=%d",
                      strides.size(), kernel_ndims);
@@ -459,13 +449,13 @@ void parsePoolND(const     Model      & model,
     int interleaved = 0;
 
     int pooling_method;
-    if (poolLayer->_type == ie::PoolingLayer::MAX) {
+    if (poolparams.poolMethod == PoolMethod::Pool_max) {
         pooling_method = PoolND_max;
-    } else if (poolLayer->_type == ie::PoolingLayer::AVG) {
+    } else if (poolparams.poolMethod == PoolMethod::Pool_avg) {
         pooling_method = PoolND_avg;
     } else {
-        VPU_THROW_EXCEPTION << "Pooling Layer " << poolLayer->name
-                   << " has unsupported type: " << poolLayer->_type;
+        VPU_THROW_EXCEPTION << "Pooling Layer " << node->get_friendly_name()
+                   << " has unsupported type: " << node->get_type_name();
     }
 
     // TODO: Check rounding type! (after this becomes possible)
@@ -473,7 +463,7 @@ void parsePoolND(const     Model      & model,
     // so by default we assume rounding type is `floor`
     int rounding_type = PoolND_floor;
 
-    int exclude_pad = poolLayer->_exclude_pad ? 1 : 0;
+    int exclude_pad = poolparams.excludePad ? 1 : 0;
 
     //
     // Check if HW is applicable
@@ -481,9 +471,9 @@ void parsePoolND(const     Model      & model,
 
     const auto& env = CompileEnv::get();
     bool hwOptimization = env.config.compileConfig().hwOptimization;
-    bool hwDisabled = env.config.compileConfig().hwDisabled(layer->name);
+    bool hwDisabled = env.config.compileConfig().hwDisabled(node->get_friendly_name());
 
-    bool tryHW = canTryHW(poolLayer->_type,
+    bool tryHW = canTryHW(poolparams.poolMethod,
                           input_shape[0],
                           input_shape[1],
                           output_shape[0],
@@ -496,8 +486,8 @@ void parsePoolND(const     Model      & model,
                           pads_end[0],
                           pads_begin[1],
                           pads_end[1],
-                          poolLayer->_auto_pad,
-                          poolLayer->_exclude_pad,
+                          poolparams.autoPad,
+                          poolparams.excludePad,
                           hwOptimization,
                           hwDisabled);
     int try_hw = tryHW ? 1 : 0;
@@ -507,9 +497,9 @@ void parsePoolND(const     Model      & model,
     //
 
     auto stage = model->addNewStage<PoolNDStage>(
-        layer->name,
+        node->get_friendly_name(),
         StageType::PoolND,
-        layer,
+        node,
         {input},
         {output});
 
@@ -525,13 +515,73 @@ void parsePoolND(const     Model      & model,
 
     stage->attrs().set("try_hw", try_hw);
 }
-
+}  // namespace
 //----------------------------------------------------------------------
+PoolingParams getPoolingParams(const ngraph::Strides strides, const ngraph::Shape kernel, const ngraph::Shape pads_begin,
+                                const ngraph::Shape pads_end, const ngraph::op::PadType padType, bool excludePad) {
+    PoolingParams result;
+    result.kernel = static_cast<std::vector<size_t>>(kernel);
+    result.strides = static_cast<std::vector<size_t>>(strides);
+    result.padsBegin = static_cast<std::vector<size_t>>(pads_begin);
+    result.padsEnd = static_cast<std::vector<size_t>>(pads_end);
+    result.excludePad = excludePad;
+    
+    switch (padType)
+    {
+    case ngraph::op::PadType::EXPLICIT :
+        result.autoPad = "explicit";
+        break;
+    case ngraph::op::PadType::SAME_UPPER :
+        result.autoPad = "same_upper";
+        break;
+    case ngraph::op::PadType::SAME_LOWER :
+        result.autoPad = "same_lower";
+        break;
+    case ngraph::op::PadType::VALID :
+        result.autoPad = "valid";
+        break;
+    default:
+        result.autoPad = "explicit";
+        break;
+    }
+    return result;
+}
+void FrontEnd::parseAvgPooling(const     Model      & model,
+                               const     NodePtr    & node,
+                               const     DataVector & inputs,
+                               const     DataVector & outputs) const {
+    auto pool = ngraph::as_type_ptr<ngraph::opset4::AvgPool>(node);
+    VPU_THROW_UNLESS(pool != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+    auto params = getPoolingParams(pool->get_strides(),
+                                   pool->get_kernel(),
+                                   pool->get_pads_begin(),
+                                   pool->get_pads_end(),
+                                   pool->get_auto_pad(),
+                                   pool->get_exclude_pad());
+    params.poolMethod = Pool_avg;
+    parsePoolingImpl(model, node, inputs, outputs, params);
+}
 
-void FrontEnd::parsePooling(const     Model      & model,
-                            const ie::CNNLayerPtr& layer,
-                            const     DataVector & inputs,
-                            const     DataVector & outputs) const {
+void FrontEnd::parseMaxPooling(const     Model      & model,
+                               const     NodePtr    & node,
+                               const     DataVector & inputs,
+                               const     DataVector & outputs) const {
+    auto pool = ngraph::as_type_ptr<ngraph::opset4::MaxPool>(node);
+    VPU_THROW_UNLESS(pool != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+    auto params = getPoolingParams(pool->get_strides(),
+                                   pool->get_kernel(), 
+                                   pool->get_pads_begin(),
+                                   pool->get_pads_end(),
+                                   pool->get_auto_pad(),
+                                   false);
+    params.poolMethod = Pool_max;
+    parsePoolingImpl(model, node, inputs, outputs, params);
+}
+void FrontEnd::parsePoolingImpl(const     Model         & model,
+                                const     NodePtr       & node,
+                                const     DataVector    & inputs,
+                                const     DataVector    & outputs,
+                                const     PoolingParams & params) const {
     VPU_THROW_UNLESS(inputs.size() == 1, "number of inputs must be equal to 1, but it equals to %lu", inputs.size());
     VPU_THROW_UNLESS(outputs.size() == 1, "number of outputs must be equal to 1, but it equals to %lu", outputs.size());
 
@@ -552,18 +602,17 @@ void FrontEnd::parsePooling(const     Model      & model,
                 input->desc().numDims() == 4;  // CHW or NCHW, but not NCDWH or 6D or ...
 
     if (is2D) {
-        parsePool2D(model, layer, input, output);
+        parsePool2D(model, node, input, output, params);
     } else {
-        parsePoolND(model, layer, input, output);
+        parsePoolND(model, node, input, output, params);
     }
 }
-
 //----------------------------------------------------------------------
 
 Stage StageBuilder::addPoolingStage(
         const Model& model,
         const std::string& name,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         const Data& input,
         const Data& output,
         const ie::PoolingLayer::PoolType& poolType) {
@@ -593,7 +642,7 @@ Stage StageBuilder::addPoolingStage(
     //
     auto stage = model->addNewStage<StubStage>(name,
                                                stageType,
-                                               layer,
+                                               node,
                                                {input},
                                                {output});
     return stage;

--- a/inference-engine/src/vpu/graph_transformer/src/stages/power.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/power.cpp
@@ -13,17 +13,39 @@
 
 namespace vpu {
 
-void FrontEnd::parsePower(const Model& model, const ie::CNNLayerPtr& _layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parsePower(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    // IE_ASSERT(inputs.size() == 1);
+    IE_ASSERT(outputs.size() == 1);
+
+    for (auto in : node->inputs()) {
+        std::cout << " type is " << in.get_source_output().get_node_shared_ptr()->get_type_name() << std::endl;
+    }
+
+    auto input = inputs[0];
+    auto output = outputs[0];
+    auto power = ngraph::as_type_ptr<ngraph::opset4::Power>(node);
+    VPU_THROW_UNLESS(power != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+    auto pow = 2.f;
+    // try to get the pow parameter
+    auto powerInput = power->get_input_node_shared_ptr(1);
+    if (const auto& constNode = std::dynamic_pointer_cast<ngraph::opset4::Constant>(powerInput)) {
+        pow = constNode->get_vector<float>()[0]; // not sure
+    }
+    
+    _stageBuilder->addPowerStage(model, power->get_friendly_name(), power, 1.0f, pow, 0.0f, inputs[0], outputs[0]);
+}
+
+void FrontEnd::parseSqrt(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
     IE_ASSERT(inputs.size() == 1);
     IE_ASSERT(outputs.size() == 1);
 
     auto input = inputs[0];
     auto output = outputs[0];
-
-    auto layer = std::dynamic_pointer_cast<ie::PowerLayer>(_layer);
-    IE_ASSERT(layer != nullptr);
-
-    _stageBuilder->addPowerStage(model, layer->name, layer, layer->scale, layer->power, layer->offset, inputs[0], outputs[0]);
+    auto sqrt = ngraph::as_type_ptr<ngraph::opset4::Sqrt>(node);
+    
+    VPU_THROW_UNLESS(sqrt != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+    
+    _stageBuilder->addPowerStage(model, sqrt->get_friendly_name(), sqrt, 1.0f, 0.5f, 0.0f, inputs[0], outputs[0]);
 }
 
 namespace {
@@ -53,7 +75,7 @@ private:
 Stage StageBuilder::addPowerStage(
         const Model& model,
         const std::string& name,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         float scale,
         float power,
         float bias,
@@ -62,7 +84,7 @@ Stage StageBuilder::addPowerStage(
     auto stage = model->addNewStage<PowerStage>(
         name,
         StageType::Power,
-        layer,
+        node,
         {input},
         {output});
 

--- a/inference-engine/src/vpu/graph_transformer/src/stages/priorbox.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/priorbox.cpp
@@ -55,18 +55,18 @@ private:
 
 }  // namespace
 
-void FrontEnd::parsePriorBox(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parsePriorBox(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
     IE_ASSERT(inputs.size() == 2);
     IE_ASSERT(outputs.size() == 1);
 
-    model->addNewStage<StubPriorBoxStage>(layer->name, StageType::StubPriorBox, layer, inputs, outputs);
+    model->addNewStage<StubPriorBoxStage>(node->get_friendly_name(), StageType::StubPriorBox, node, inputs, outputs);
 }
 
-void FrontEnd::parsePriorBoxClustered(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parsePriorBoxClustered(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
     IE_ASSERT(inputs.size() == 2);
     IE_ASSERT(outputs.size() == 1);
 
-    model->addNewStage<StubPriorBoxStage>(layer->name, StageType::StubPriorBoxClustered, layer, inputs, outputs);
+    model->addNewStage<StubPriorBoxStage>(node->get_friendly_name(), StageType::StubPriorBoxClustered, node, inputs, outputs);
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/proposal.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/proposal.cpp
@@ -122,15 +122,17 @@ private:
 
 }  // namespace
 
-void FrontEnd::parseProposal(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
-    ie::details::CaselessEq<std::string> cmp;
+void FrontEnd::parseProposal(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    // ie::details::CaselessEq<std::string> cmp;
 
+    const auto& proposal = ngraph::as_type_ptr<ngraph::opset4::Proposal>(node);
+    VPU_THROW_UNLESS(proposal != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
     VPU_THROW_UNLESS((inputs.size() == 3),
                      "Proposal stage with name %s must have 3 inputs, "
-                     "actually provided %d", layer->name, inputs.size());
+                     "actually provided %d", proposal->get_friendly_name(), inputs.size());
     VPU_THROW_UNLESS((outputs.size() == 1) || (outputs.size() == 2),
                      "Proposal stage with name %s must have only 1 or 2 outputs, "
-                     "actually provided %d", layer->name, outputs.size());
+                     "actually provided %d", proposal->get_friendly_name(), outputs.size());
 
     DataVector tempOutputs(2);
     tempOutputs[0] = outputs[0];
@@ -140,40 +142,41 @@ void FrontEnd::parseProposal(const Model& model, const ie::CNNLayerPtr& layer, c
     else
         tempOutputs[1] = outputs[1];
 
-    auto stage = model->addNewStage<ProposalStage>(layer->name, StageType::Proposal, layer, inputs, tempOutputs);
+    auto stage = model->addNewStage<ProposalStage>(proposal->get_friendly_name(), StageType::Proposal, proposal, inputs, tempOutputs);
+    const auto& attrs = proposal->get_attrs();
+    stage->attrs().set<int>("feat_stride", attrs.feat_stride);
+    stage->attrs().set<int>("base_size", attrs.base_size);
+    stage->attrs().set<int>("min_size", attrs.min_size);
+    stage->attrs().set<int>("pre_nms_topn", attrs.pre_nms_topn);
+    stage->attrs().set<int>("post_nms_topn", attrs.post_nms_topn);
+    stage->attrs().set<float>("nms_thresh", attrs.nms_thresh);
+    stage->attrs().set<float>("pre_nms_thresh", attrs.nms_thresh); // not sure
+    stage->attrs().set<float>("box_size_scale", attrs.box_size_scale);
+    stage->attrs().set<float>("box_coordinate_scale", attrs.box_coordinate_scale);
+    stage->attrs().set<bool>("clip_before_nms", attrs.clip_before_nms);
+    stage->attrs().set<bool>("clip_after_nms", attrs.clip_after_nms);
+    stage->attrs().set<bool>("normalize", attrs.normalize);
+    
+    // if (cmp(layer->GetParamAsString("framework", ""), "TensorFlow")) {
+    //     // Settings for TensorFlow
+    //     stage->attrs().set<float>("coordinates_offset", 0.0f);
+    //     stage->attrs().set<bool>("initial_clip", true);
+    //     stage->attrs().set<bool>("shift_anchors", true);
+    //     stage->attrs().set<bool>("round_ratios", false);
+    //     stage->attrs().set<bool>("swap_xy", true);
+    // } else {                                                                         // not sure
+    //     // Settings for Caffe
 
-    stage->attrs().set<int>("feat_stride", layer->GetParamAsInt("feat_stride", 16));
-    stage->attrs().set<int>("base_size", layer->GetParamAsInt("base_size", 16));
-    stage->attrs().set<int>("min_size", layer->GetParamAsInt("min_size", 16));
-    stage->attrs().set<int>("pre_nms_topn", layer->GetParamAsInt("pre_nms_topn", 6000));
-    stage->attrs().set<int>("post_nms_topn", layer->GetParamAsInt("post_nms_topn", 300));
-    stage->attrs().set<float>("nms_thresh", layer->GetParamAsFloat("nms_thresh", 0.7f));
-    stage->attrs().set<float>("pre_nms_thresh", layer->GetParamAsFloat("pre_nms_thresh", 0.1f));
-    stage->attrs().set<float>("box_size_scale", layer->GetParamAsFloat("box_size_scale", 1.0f));
-    stage->attrs().set<float>("box_coordinate_scale", layer->GetParamAsFloat("box_coordinate_scale", 1.0f));
-    stage->attrs().set<bool>("clip_before_nms", layer->GetParamAsBool("clip_before_nms", true));
-    stage->attrs().set<bool>("clip_after_nms", layer->GetParamAsBool("clip_after_nms", false));
-    stage->attrs().set<bool>("normalize", layer->GetParamAsBool("normalize", false));
+    //     stage->attrs().set<float>("coordinates_offset", 1.0f);
+    //     stage->attrs().set<bool>("initial_clip", false);
+    //     stage->attrs().set<bool>("shift_anchors", false);
+    //     stage->attrs().set<bool>("round_ratios", true);
+    //     stage->attrs().set<bool>("swap_xy", false);
+    // }
+    
 
-    if (cmp(layer->GetParamAsString("framework", ""), "TensorFlow")) {
-        // Settings for TensorFlow
-        stage->attrs().set<float>("coordinates_offset", 0.0f);
-        stage->attrs().set<bool>("initial_clip", true);
-        stage->attrs().set<bool>("shift_anchors", true);
-        stage->attrs().set<bool>("round_ratios", false);
-        stage->attrs().set<bool>("swap_xy", true);
-    } else {
-        // Settings for Caffe
-
-        stage->attrs().set<float>("coordinates_offset", 1.0f);
-        stage->attrs().set<bool>("initial_clip", false);
-        stage->attrs().set<bool>("shift_anchors", false);
-        stage->attrs().set<bool>("round_ratios", true);
-        stage->attrs().set<bool>("swap_xy", false);
-    }
-
-    auto scales = layer->GetParamAsFloats("scale", {});
-    auto ratios = layer->GetParamAsFloats("ratio", {});
+    auto scales = attrs.scale;
+    auto ratios = attrs.ratio;
 
     stage->attrs().set("scales", scales);
     stage->attrs().set("ratios", ratios);

--- a/inference-engine/src/vpu/graph_transformer/src/stages/psroipooling.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/psroipooling.cpp
@@ -69,14 +69,16 @@ private:
 
 }  // namespace
 
-void FrontEnd::parsePSROIPooling(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parsePSROIPooling(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    const auto& psROIPooling = ngraph::as_type_ptr<ngraph::opset4::PSROIPooling>(node);
+    VPU_THROW_UNLESS(psROIPooling != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
     IE_ASSERT(inputs.size() == 2);
     IE_ASSERT(outputs.size() == 1);
 
-    auto stage = model->addNewStage<PSROIPoolingStage>(layer->name, StageType::PSROIPooling, layer, inputs, outputs);
-    stage->attrs().set<int>("group_size", layer->GetParamAsInt("group_size", 7));
-    stage->attrs().set<int>("output_dim", layer->GetParamAsInt("output_dim", 21));
-    stage->attrs().set<float>("spatial_scale", layer->GetParamAsFloat("spatial_scale", 0.0625f));
+    auto stage = model->addNewStage<PSROIPoolingStage>(psROIPooling->get_friendly_name(), StageType::PSROIPooling, psROIPooling, inputs, outputs);
+    stage->attrs().set<int>("group_size", psROIPooling->get_group_size());
+    stage->attrs().set<int>("output_dim", psROIPooling->get_output_dim());
+    stage->attrs().set<float>("spatial_scale", psROIPooling->get_spatial_scale());
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/region_yolo.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/region_yolo.cpp
@@ -69,18 +69,20 @@ private:
 
 }  // namespace
 
-void FrontEnd::parseRegionYolo(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parseRegionYolo(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
     IE_ASSERT(inputs.size() == 1);
     IE_ASSERT(outputs.size() == 1);
+    const auto& regionYolo = ngraph::as_type_ptr<ngraph::opset4::RegionYolo>(node);
+    VPU_THROW_UNLESS(regionYolo != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+    auto mask = regionYolo->get_mask();
 
-    auto mask = layer->GetParamAsInts("mask", {});
+    auto stage = model->addNewStage<RegionYoloStage>(regionYolo->get_friendly_name(), StageType::RegionYolo, regionYolo, inputs, outputs);
 
-    auto stage = model->addNewStage<RegionYoloStage>(layer->name, StageType::RegionYolo, layer, inputs, outputs);
-    stage->attrs().set<int>("classes", layer->GetParamAsInt("classes", 20));
-    stage->attrs().set<int>("coords", layer->GetParamAsInt("coords", 4));
-    stage->attrs().set<int>("num", layer->GetParamAsInt("num", 5));
+    stage->attrs().set<int>("classes", regionYolo->get_num_classes());  // GetParamAsInt("classes", 20));
+    stage->attrs().set<int>("coords", regionYolo->get_num_coords());  // layer->GetParamAsInt("coords", 4));
+    stage->attrs().set<int>("num", regionYolo->get_num_regions());  // layer->GetParamAsInt("num", 5));
     stage->attrs().set<int>("maskSize", static_cast<int>(mask.size()));
-    stage->attrs().set<bool>("doSoftMax", layer->GetParamAsInt("do_softmax", 1));
+    stage->attrs().set<bool>("doSoftMax", regionYolo->get_do_softmax()); // GetParamAsInt("do_softmax", 1));
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/reorg_yolo.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/reorg_yolo.cpp
@@ -68,18 +68,19 @@ private:
 
 }  // namespace
 
-void FrontEnd::parseReorgYolo(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parseReorgYolo(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
     IE_ASSERT(inputs.size() == 1);
     IE_ASSERT(outputs.size() == 1);
-
+    const auto& reorgYolo = ngraph::as_type_ptr<ngraph::opset4::ReorgYolo>(node);
+    VPU_THROW_UNLESS(reorgYolo != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
     auto stage = model->addNewStage<ReorgYoloStage>(
-        layer->name,
+        reorgYolo->get_friendly_name(),
         StageType::ReorgYolo,
-        layer,
+        reorgYolo,
         inputs,
         outputs);
 
-    stage->attrs().set<int>("stride", layer->GetParamAsInt("stride", 2));
+    stage->attrs().set<int>("stride", reorgYolo->get_strides()[0]);  // add some condition?
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/resample.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/resample.cpp
@@ -79,14 +79,14 @@ private:
 Stage StageBuilder::addResampleNearestStage(
             const Model& model,
             const std::string& name,
-            const ie::CNNLayerPtr& layer,
+            const NodePtr& node,
             bool antialias,
             InterpolateCoordTransMode coordinateTransformationMode,
             InterpolateNearestMode nearestMode,
             float factor,
             const Data& input,
             const Data& output) {
-    auto stage = model->addNewStage<ResampleStage>(layer->name, StageType::Resample, layer, {input}, {output});
+    auto stage = model->addNewStage<ResampleStage>(node->get_friendly_name(), StageType::Resample, node, {input}, {output});
 
     stage->attrs().set<bool>(g_antialias, antialias);
     stage->attrs().set<InterpolateCoordTransMode>(g_coordinate_transformation_mode, coordinateTransformationMode);
@@ -95,40 +95,6 @@ Stage StageBuilder::addResampleNearestStage(
     stage->attrs().set<ResampleType>(g_type, ResampleType::Nearest);
 
     return stage;
-}
-
-void FrontEnd::parseResample(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
-    VPU_THROW_UNLESS(inputs.size() == 1,
-                     "Resample stage with name {} must have only 1 input, "
-                     "actually provided {}", layer->name, inputs.size());
-    VPU_THROW_UNLESS(outputs.size() == 1,
-                     "Resample stage with name {} must have only 1 output, "
-                     "actually provided {}", layer->name, outputs.size());
-
-    ie::details::CaselessEq<std::string> cmp;
-    const auto method  = layer->GetParamAsString(g_type, "caffe.ResampleParameter.NEAREST");
-    const auto coord   = layer->GetParamAsString(g_coordinate_transformation_mode, g_half_pixel);
-    const auto nearest = layer->GetParamAsString(g_nearest_mode, g_round_prefer_ceil);
-
-    const auto coordModeIt   = coordTransformModeMap.find(coord);
-    const auto nearestModeIt = nearestModeMap.find(nearest);
-    VPU_THROW_UNLESS(coordModeIt != coordTransformModeMap.end(), "Resample stage does not support this coordinate transforation mode");
-    VPU_THROW_UNLESS(nearestModeIt != nearestModeMap.end(), "Resample stage does not support this nearest transforation mode");
-    auto coordinateTransformationMode = coordModeIt->second;
-    auto nearestMode = nearestModeIt->second;
-
-    if (cmp(method, "caffe.ResampleParameter.NEAREST")) {
-        _stageBuilder->addResampleNearestStage(model,
-                                               layer->name,
-                                               layer,
-                                               layer->GetParamAsInt(g_antialias, 0),
-                                               coordinateTransformationMode, nearestMode,
-                                               layer->GetParamAsFloat(g_factor, -1),
-                                               inputs[0],
-                                               outputs[0]);
-    } else {
-        VPU_THROW_EXCEPTION << "Layer with name " << layer->name << " supports only caffe.ResampleParameter.NEAREST resample type";
-    }
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/reshape.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/reshape.cpp
@@ -60,17 +60,17 @@ private:
 
 }  // namespace
 
-void FrontEnd::parseReshape(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parseReshape(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
     VPU_THROW_UNLESS(inputs.size() == 1 || inputs.size() == 2,
-        "%v of type %v is not supported with dynamic shape", layer->name, layer->type);
+        "%v of type %v is not supported with dynamic shape", node->get_friendly_name(), node->get_type_name());
     IE_ASSERT(outputs.size() == 1);
-    _stageBuilder->addReshapeStage(model, layer->name, layer, inputs[0], outputs[0]);
+    _stageBuilder->addReshapeStage(model, node->get_friendly_name(), node, inputs[0], outputs[0]);
 }
 
 Stage StageBuilder::addReshapeStage(
         const Model& model,
         const std::string& name,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         const Data& input,
         const Data& output) {
     IE_ASSERT(input->desc().totalDimSize() == output->desc().totalDimSize());
@@ -78,7 +78,7 @@ Stage StageBuilder::addReshapeStage(
     return model->addNewStage<ReshapeStage>(
         name,
         StageType::Reshape,
-        layer,
+        node,
         {input},
         {output});
 }

--- a/inference-engine/src/vpu/graph_transformer/src/stages/reverse_sequence.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/reverse_sequence.cpp
@@ -64,18 +64,20 @@ private:
 
 }  // namespace
 
-void FrontEnd::parseReverseSequence(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parseReverseSequence(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    const auto& reverseSequence = ngraph::as_type_ptr<ngraph::opset4::ReverseSequence>(node);
+    VPU_THROW_UNLESS(reverseSequence != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
     IE_ASSERT(inputs.size() == 2);
     IE_ASSERT(outputs.size() == 1);
 
-    auto stage = model->addNewStage<ReverseSequenceStage>(layer->name, StageType::ReverseSequence, layer, inputs, outputs);
+    auto stage = model->addNewStage<ReverseSequenceStage>(reverseSequence->get_friendly_name(), StageType::ReverseSequence, reverseSequence, inputs, outputs);
 
     auto input = inputs[0];
 
     auto perm = DimsOrder::fromNumDims(input->desc().numDims()).toPermutation();
-    auto seq_axis = layer->GetParamAsInt("seq_axis");
+    auto seq_axis = reverseSequence->get_sequence_axis();
     auto seq_axis_index = perm[input->desc().numDims() - 1 - seq_axis];
-    auto batch_axis = layer->GetParamAsInt("batch_axis");
+    auto batch_axis = reverseSequence->get_batch_axis();
     auto batch_axis_index = perm[input->desc().numDims() - 1 - batch_axis];
 
     stage->attrs().set<Dim>("seq_axis", seq_axis_index);

--- a/inference-engine/src/vpu/graph_transformer/src/stages/roi_align.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/roi_align.cpp
@@ -93,17 +93,20 @@ private:
 
 }  // namespace
 
-void FrontEnd::parseROIAlign(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parseROIAlign(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    auto roiAlign = ngraph::as_type_ptr<ngraph::opset4::ROIAlign>(node);
+    VPU_THROW_UNLESS(roiAlign != nullptr, "Can't parse node with name %s and type %s is nullptr", roiAlign->get_friendly_name(), roiAlign->get_type_name());
     VPU_THROW_UNLESS(inputs.size() == 3 || inputs.size() == 1,
                     "ROIAlign stage with name {} has invalid number of inputs: expected 3 or 1 "
-                    "actually provided {}", layer->name, inputs.size());
+                    "actually provided {}", roiAlign->get_friendly_name(), inputs.size());
     VPU_THROW_UNLESS(outputs.size() == 1,
                     "ROIAlign stage with name {} has invalid number of outputs: expected 1, "
-                    "actually provided {}", layer->name, outputs.size());
+                    "actually provided {}", roiAlign->get_friendly_name(), outputs.size());
 
-    const auto mode = layer->GetParamAsString("mode", "");
-    VPU_THROW_UNLESS(mode == "avg" || mode == "max", "Layer with name {} supports only (avg, max) mode", layer->name);
-    ROIAlignMode roi_align_mode = (mode == "avg") ? ROIAlignMode::Average : ROIAlignMode::Max;
+    const auto mode = roiAlign->get_mode();
+    VPU_THROW_UNLESS(mode == ngraph::op::v3::ROIAlign::PoolingMode::AVG || mode == ngraph::op::v3::ROIAlign::PoolingMode::MAX,
+                    "Layer with name {} supports only (avg, max) mode", roiAlign->get_friendly_name());
+    ROIAlignMode roi_align_mode = (mode == ngraph::op::v3::ROIAlign::PoolingMode::AVG) ? ROIAlignMode::Average : ROIAlignMode::Max;
 
     const auto width = inputs[0]->desc().dim(Dim::W);
     const auto is_input_static = (inputs[0]->parentDataToShapeEdge() == nullptr);
@@ -113,25 +116,25 @@ void FrontEnd::parseROIAlign(const Model& model, const ie::CNNLayerPtr& layer, c
     if (use_chwc_repacking) {
         repackedInput = model->duplicateData(inputs[0], formatString("@ROIAlignRepacked"));
 
-        const auto repacking_stage = model->addNewStage<ROIAlignStage>(layer->name + "Repacking",
-                                                                       StageType::ROIAlign, layer,
+        const auto repacking_stage = model->addNewStage<ROIAlignStage>(roiAlign->get_friendly_name() + "Repacking",
+                                                                       StageType::ROIAlign, roiAlign,
                                                                        {inputs[0]}, {repackedInput});
 
-        repacking_stage->attrs().set<int>(s_pooled_w, layer->GetParamAsInt("pooled_w"));
-        repacking_stage->attrs().set<int>(s_pooled_h, layer->GetParamAsInt("pooled_h"));
-        repacking_stage->attrs().set<int>(s_sampling_ratio, layer->GetParamAsInt("sampling_ratio"));
-        repacking_stage->attrs().set<float>(s_spatial_scale, layer->GetParamAsFloat("spatial_scale"));
+        repacking_stage->attrs().set<int>(s_pooled_w, roiAlign->get_pooled_w());
+        repacking_stage->attrs().set<int>(s_pooled_h, roiAlign->get_pooled_h());
+        repacking_stage->attrs().set<int>(s_sampling_ratio, roiAlign->get_sampling_ratio());
+        repacking_stage->attrs().set<float>(s_spatial_scale, roiAlign->get_spatial_scale());
         repacking_stage->attrs().set<ROIAlignMode>(s_mode, ROIAlignMode::Average);
         repacking_stage->attrs().set<ROIAlignStep>(s_step_number, ROIAlignStep::Repacking);
     }
 
-    const auto stage = model->addNewStage<ROIAlignStage>(layer->name, StageType::ROIAlign, layer, {repackedInput, inputs[1], inputs[2]}, outputs);
+    const auto stage = model->addNewStage<ROIAlignStage>(roiAlign->get_friendly_name(), StageType::ROIAlign, roiAlign, {repackedInput, inputs[1], inputs[2]}, outputs);
 
     stage->attrs().set<ROIAlignMode>(s_mode, roi_align_mode);
-    stage->attrs().set<int>(s_pooled_w, layer->GetParamAsInt("pooled_w"));
-    stage->attrs().set<int>(s_pooled_h, layer->GetParamAsInt("pooled_h"));
-    stage->attrs().set<int>(s_sampling_ratio, layer->GetParamAsInt("sampling_ratio"));
-    stage->attrs().set<float>(s_spatial_scale, layer->GetParamAsFloat("spatial_scale"));
+    stage->attrs().set<int>(s_pooled_w, roiAlign->get_pooled_w());
+    stage->attrs().set<int>(s_pooled_h, roiAlign->get_pooled_h());
+    stage->attrs().set<int>(s_sampling_ratio, roiAlign->get_sampling_ratio());
+    stage->attrs().set<float>(s_spatial_scale, roiAlign->get_spatial_scale());
     stage->attrs().set<ROIAlignStep>(s_step_number, use_chwc_repacking ? ROIAlignStep::ROIAlignCHWc : ROIAlignStep::ROIAlign);
 }
 

--- a/inference-engine/src/vpu/graph_transformer/src/stages/roipooling.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/roipooling.cpp
@@ -79,20 +79,20 @@ private:
 
 }  // namespace
 
-void FrontEnd::parseROIPooling(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
-    ie::details::CaselessEq<std::string> cmp;
-
+void FrontEnd::parseROIPooling(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    const auto& roiPooling = ngraph::as_type_ptr<ngraph::op::v0::ROIPooling>(node);
+    VPU_THROW_UNLESS(roiPooling != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
     IE_ASSERT(inputs.size() == 2);
     IE_ASSERT(outputs.size() == 1);
 
-    auto stage = model->addNewStage<ROIPoolingStage>(layer->name, StageType::ROIPooling, layer, inputs, outputs);
+    auto stage = model->addNewStage<ROIPoolingStage>(roiPooling->get_friendly_name(), StageType::ROIPooling, roiPooling, inputs, outputs);
+    
+    stage->attrs().set<int>("pooled_w", roiPooling->get_output_size()[1]);
+    stage->attrs().set<int>("pooled_h", roiPooling->get_output_size()[0]);
+    stage->attrs().set<float>("spatial_scale", roiPooling->get_spatial_scale());
 
-    stage->attrs().set<int>("pooled_w", layer->GetParamAsInt("pooled_w", 7));
-    stage->attrs().set<int>("pooled_h", layer->GetParamAsInt("pooled_h", 7));
-    stage->attrs().set<float>("spatial_scale", layer->GetParamAsFloat("spatial_scale", 0.0625f));
-
-    auto method = layer->GetParamAsString("method", "max");
-    if (cmp(method, "bilinear")) {
+    const auto method = roiPooling->get_method();
+    if (method == "bilinear") {
         stage->attrs().set("method", ROIPoolingMethod::Bilinear);
     } else {
         stage->attrs().set("method", ROIPoolingMethod::Max);

--- a/inference-engine/src/vpu/graph_transformer/src/stages/round.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/round.cpp
@@ -30,28 +30,20 @@ private:
 
 }  // namespace
 
-void FrontEnd::parseRound(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parseRound(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    auto round = ngraph::as_type_ptr<ngraph::op::v5::Round>(node);
+    IE_ASSERT(node != nullptr);
     VPU_THROW_UNLESS(inputs.size() == 1,
                      "Round stage with name {} must have only 1 input, actually provided {} inputs",
-                     layer->name, inputs.size());
+                     round->get_friendly_name(), inputs.size());
 
     VPU_THROW_UNLESS(outputs.size() == 1,
                      "Round stage with name {} must have only 1 output, actually provided {} outputs",
-                     layer->name, outputs.size());
+                     round->get_friendly_name(), outputs.size());
 
-    const std::map<std::string, RoundMode> modeFromString = {
-        {"half_to_even", RoundMode::HALF_TO_EVEN},
-        {"half_away_from_zero", RoundMode::HALF_AWAY_FROM_ZERO}
-    };
-
-    const auto modeString = layer->GetParamAsString("mode", "half_to_even");
-    const auto& modeFind = modeFromString.find(modeString);
-    VPU_THROW_UNLESS(modeFind != modeFromString.end(),
-                    "{} layer with name {}: Graph Transformer doesn't support {} mode",
-                    layer->type, layer->name, modeString);
-
-    const auto mode = modeFind->second;
-    auto stage = model->addNewStage<RoundStage>(layer->name, StageType::Round, layer, inputs, outputs);
+    const auto mode = round->get_mode() == ngraph::op::v5::Round::RoundMode::HALF_AWAY_FROM_ZERO ?
+                                           RoundMode::HALF_AWAY_FROM_ZERO : RoundMode::HALF_TO_EVEN;
+    auto stage = model->addNewStage<RoundStage>(round->get_friendly_name(), StageType::Round, round, inputs, outputs);
     stage->attrs().set("mode", mode);
 }
 

--- a/inference-engine/src/vpu/graph_transformer/src/stages/scale.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/scale.cpp
@@ -33,51 +33,53 @@ private:
 Stage StageBuilder::addScaleStage(
         const Model& model,
         const std::string& name,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         const Data& input,
         const Data& scales,
         const Data& output) {
     return model->addNewStage<ScaleStage>(
         name,
         StageType::Scale,
-        layer,
+        node,
         {input, scales},
         {output});
 }
 
-void FrontEnd::parseScale(const Model& model, const ie::CNNLayerPtr& _layer, const DataVector& inputs, const DataVector& outputs) const {
-    IE_ASSERT(inputs.size() == 1);
-    IE_ASSERT(outputs.size() == 1);
+// scaleshift case
+void FrontEnd::parseScale(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+//     IE_ASSERT(inputs.size() == 1);
+//     IE_ASSERT(outputs.size() == 1);
 
-    auto layer = std::dynamic_pointer_cast<ie::ScaleShiftLayer>(_layer);
-    IE_ASSERT(layer != nullptr);
+//     auto scaleShift = ngraph::as_type_ptr<ngraph::opset4::Scale>(node);
 
-    if (layer->_broadcast != 0) {
-        VPU_THROW_EXCEPTION <<
-            "Layer " << layer->name << " doesn't support broadcast param";
-    }
+//     IE_ASSERT(layer != nullptr);
 
-    auto input = inputs[0];
-    auto output = outputs[0];
+//     if (layer->_broadcast != 0) {
+//         VPU_THROW_EXCEPTION <<
+//             "Layer " << layer->name << " doesn't support broadcast param";
+//     }
 
-    Data scales, biases;
-    std::tie(scales, biases) = getWeightsAndBiases(model, layer);
+//     auto input = inputs[0];
+//     auto output = outputs[0];
 
-    if (biases->usage() == DataUsage::Fake) {
-        model->addNewStage<ScaleStage>(
-            layer->name,
-            StageType::Scale,
-            layer,
-            {input, scales},
-            {output});
-    } else {
-        model->addNewStage<ScaleStage>(
-            layer->name,
-            StageType::ScaleShift,
-            layer,
-            {input, scales, biases},
-            {output});
-    }
+//     Data scales, biases;
+//     std::tie(scales, biases) = getWeightsAndBiases(model, layer);
+
+//     if (biases->usage() == DataUsage::Fake) {
+//         model->addNewStage<ScaleStage>(
+//             layer->name,
+//             StageType::Scale,
+//             layer,
+//             {input, scales},
+//             {output});
+//     } else {
+//         model->addNewStage<ScaleStage>(
+//             layer->name,
+//             StageType::ScaleShift,
+//             layer,
+//             {input, scales, biases},
+//             {output});
+//     }
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/scatter_elements_update.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/scatter_elements_update.cpp
@@ -191,9 +191,14 @@ void checkTensorShapes(const vpu::Data& input,
 }
 
 void FrontEnd::parseScatterElementsUpdate(const Model      & model,
-                                          const CNNLayerPtr& layer,
+                                          const NodePtr    & node,
                                           const DataVector & inputs,
                                           const DataVector & outputs) const {
+    auto scatterElementsUpdate = ngraph::as_type_ptr<ngraph::op::v3::ScatterElementsUpdate>(node);
+    VPU_THROW_UNLESS(scatterElementsUpdate != nullptr,
+                     "this node is not an instance of ScatterElementsUpdateLayer: "
+                     "node name = \"%s\", node type = \"%s\"",
+                     scatterElementsUpdate->get_friendly_name(), scatterElementsUpdate->get_type_name());
     VPU_THROW_UNLESS(inputs.size() == 4, "invalid number of inputs: %lu", inputs.size());
     VPU_THROW_UNLESS(outputs.size() == 1, "invalid number of outputs: %lu", outputs.size());
 
@@ -205,30 +210,25 @@ void FrontEnd::parseScatterElementsUpdate(const Model      & model,
 
     checkTensorShapes(input, output, indices, updates, axis);
 
-    auto scatterElementsUpdateLayer = std::dynamic_pointer_cast<ie::ScatterElementsUpdateLayer>(layer);
+    
 
-    VPU_THROW_UNLESS(scatterElementsUpdateLayer != nullptr,
-                     "this layer is not an instance of ScatterElementsUpdateLayer: "
-                     "layer name = \"%s\", layer type = \"%s\"",
-                     layer->name.c_str(), layer->type.c_str());
-
-    auto stage = model->addNewStage<ScatterElementsUpdateStage>(layer->name,
+    auto stage = model->addNewStage<ScatterElementsUpdateStage>(scatterElementsUpdate->get_friendly_name(),
                                                                 StageType::ScatterElementsUpdate,
-                                                                layer,
+                                                                scatterElementsUpdate,
                                                                 {input, indices, updates, axis},
                                                                 {output});
 
     VPU_THROW_UNLESS(stage != nullptr,
                      "failed to create ScatterElementsUpdateStage: "
                      "layer name = \"%s\", layer type = \"%s\"",
-                     layer->name.c_str(), layer->type.c_str());
+                     scatterElementsUpdate->get_friendly_name(), scatterElementsUpdate->get_type_name());
 }
 
 //----------------------------------------------------------------------
 
 Stage StageBuilder::addScatterElementsUpdateStage(const Model& model,
                                                   const std::string& name,
-                                                  const ie::CNNLayerPtr& layer,
+                                                  const NodePtr& node,
                                                   const Data& input,
                                                   const Data& output,
                                                   const Data& indices,
@@ -238,14 +238,14 @@ Stage StageBuilder::addScatterElementsUpdateStage(const Model& model,
 
     auto stage = model->addNewStage<ScatterElementsUpdateStage>(name,
                                                                 StageType::ScatterElementsUpdate,
-                                                                layer,
+                                                                node,
                                                                 {input, indices, updates, axis},
                                                                 {output});
 
     VPU_THROW_UNLESS(stage != nullptr,
                      "failed to create ScatterElementsUpdateStage: "
-                     "layer name = \"%s\", layer type = \"%s\"",
-                     layer->name.c_str(), layer->type.c_str());
+                     "layer name = \"{}\", layer type = \"{}\"",
+                     node->get_friendly_name(), node->get_type_name());
 
     return stage;
 }

--- a/inference-engine/src/vpu/graph_transformer/src/stages/scatter_update.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/scatter_update.cpp
@@ -198,9 +198,14 @@ void checkTensorShapes(const vpu::Data& input,
 }
 
 void FrontEnd::parseScatterUpdate(const Model      & model,
-                                  const CNNLayerPtr& layer,
+                                  const NodePtr& node,
                                   const DataVector & inputs,
                                   const DataVector & outputs) const {
+    auto scatterUpdate = ngraph::as_type_ptr<ngraph::opset4::ScatterUpdate>(node);
+    VPU_THROW_UNLESS(scatterUpdate != nullptr,
+                     "this layer is not an instance of ScatterUpdateLayer: "
+                     "layer name = \"%s\", layer type = \"%s\"",
+                     scatterUpdate->get_friendly_name(), scatterUpdate->get_type_name());
     VPU_THROW_UNLESS(inputs.size() == 4, "invalid number of inputs: %lu", inputs.size());
     VPU_THROW_UNLESS(outputs.size() == 1, "invalid number of outputs: %lu", outputs.size());
 
@@ -212,23 +217,16 @@ void FrontEnd::parseScatterUpdate(const Model      & model,
 
     checkTensorShapes(input, output, indices, updates, axis);
 
-    auto scatterUpdateLayer = std::dynamic_pointer_cast<ie::ScatterUpdateLayer>(layer);
-
-    VPU_THROW_UNLESS(scatterUpdateLayer != nullptr,
-                     "this layer is not an instance of ScatterUpdateLayer: "
-                     "layer name = \"%s\", layer type = \"%s\"",
-                     layer->name.c_str(), layer->type.c_str());
-
-    auto stage = model->addNewStage<ScatterUpdateStage>(layer->name,
+    auto stage = model->addNewStage<ScatterUpdateStage>(scatterUpdate->get_friendly_name(),
                                                         StageType::ScatterUpdate,
-                                                        layer,
+                                                        scatterUpdate,
                                                         {input, indices, updates, axis},
                                                         {output});
 
     VPU_THROW_UNLESS(stage != nullptr,
                      "failed to create ScatterUpdateStage: "
-                     "layer name = \"%s\", layer type = \"%s\"",
-                     layer->name.c_str(), layer->type.c_str());
+                     "node name = \"%s\", node type = \"%s\"",
+                     scatterUpdate->get_friendly_name(), scatterUpdate->get_type_name());
 }
 
 //----------------------------------------------------------------------
@@ -236,7 +234,7 @@ void FrontEnd::parseScatterUpdate(const Model      & model,
 Stage StageBuilder::addScatterUpdateStage(
         const Model& model,
         const std::string& name,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         const Data& input,
         const Data& output,
         const Data& indices,
@@ -246,14 +244,14 @@ Stage StageBuilder::addScatterUpdateStage(
 
     auto stage = model->addNewStage<ScatterUpdateStage>(name,
                                                         StageType::ScatterUpdate,
-                                                        layer,
+                                                        node,
                                                         {input, indices, updates, axis},
                                                         {output});
 
     VPU_THROW_UNLESS(stage != nullptr,
                      "failed to create ScatterUpdateStage: "
-                     "layer name = \"%s\", layer type = \"%s\"",
-                     layer->name.c_str(), layer->type.c_str());
+                     "layer name = \"{}\", layer type = \"{}\"",
+                     node->get_friendly_name(), node->get_type_name());
 
     return stage;
 }

--- a/inference-engine/src/vpu/graph_transformer/src/stages/screlu.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/screlu.cpp
@@ -89,22 +89,22 @@ private:
 }  // namespace
 
 Stage StageBuilder::addSCReluStage(
-        const vpu::Model &model,
-        const std::string &name,
-        const InferenceEngine::CNNLayerPtr &layer,
+        const vpu::Model& model,
+        const std::string& name,
+        const NodePtr& node,
         float negativeSlope,
         Dim axis,
-        const vpu::Data &input,
-        const vpu::Data &output,
-        const vpu::Data &scales,
-        const vpu::Data &biases
+        const vpu::Data& input,
+        const vpu::Data& output,
+        const vpu::Data& scales,
+        const vpu::Data& biases
         ) {
     auto stageType = StageType::SCRelu;
     const Data& fakeInput = model->addFakeData();
     auto stage = model->addNewStage<SCReluStage>(
             name,
             stageType,
-            layer,
+            node,
             {input},
             {output});
 

--- a/inference-engine/src/vpu/graph_transformer/src/stages/sigmoid.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/sigmoid.cpp
@@ -29,20 +29,21 @@ private:
 
 }  // namespace
 
-void FrontEnd::parseSigmoid(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parseSigmoid(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
     IE_ASSERT(inputs.size() == 1);
     IE_ASSERT(outputs.size() == 1);
-
-    _stageBuilder->addSigmoidStage(model, layer->name, layer, inputs, outputs);
+    auto sigmoid = ngraph::as_type_ptr<ngraph::opset4::Tanh>(node);
+    VPU_THROW_UNLESS(sigmoid != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+    _stageBuilder->addSigmoidStage(model, node->get_friendly_name(), node, inputs, outputs);
 }
 
 Stage StageBuilder::addSigmoidStage(
         const Model& model,
         const std::string& name,
-        const ie::CNNLayerPtr& layer,
+        const NodePtr& node,
         const DataVector& inputs,
         const DataVector& outputs) {
-    return model->addNewStage<SigmoidStage>(name, StageType::Sigmoid, layer, inputs, outputs);
+    return model->addNewStage<SigmoidStage>(name, StageType::Sigmoid, node, inputs, outputs);
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/softplus.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/softplus.cpp
@@ -24,15 +24,15 @@ private:
 
 }  // namespace
 
-void FrontEnd::parseSoftPlus(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parseSoftPlus(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
     VPU_THROW_UNLESS(inputs.size() == 1,
                      "SoftPlus stage with name %s must have only 1 input, "
-                     "actually provided %d", layer->name, inputs.size());
+                     "actually provided %d", node->get_friendly_name(), inputs.size());
     VPU_THROW_UNLESS(outputs.size() == 1,
                      "SoftPlus stage with name %s must have only 1 output, "
-                     "actually provided %d", layer->name, outputs.size());
+                     "actually provided %d", node->get_friendly_name(), outputs.size());
 
-    model->addNewStage<SoftPlusStage>(layer->name, StageType::SoftPlus, layer, inputs, outputs);
+    model->addNewStage<SoftPlusStage>(node->get_friendly_name(), StageType::SoftPlus, node, inputs, outputs);
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/static_shape_nms.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/static_shape_nms.cpp
@@ -4,6 +4,7 @@
 
 #include <vpu/frontend/frontend.hpp>
 #include <vpu/compile_env.hpp>
+#include "vpu/ngraph/operations/static_shape_non_maximum_suppression.hpp"
 #include <precision_utils.h>
 
 #include <memory>
@@ -105,25 +106,27 @@ bool isOneSliceEnough(int cmxSize, const std::vector<int>& bufferSizes) {
 }  // namespace
 
 
-void FrontEnd::parseStaticShapeNMS(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parseStaticShapeNMS(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    auto staticShapeNMS = ngraph::as_type_ptr<ngraph::vpu::op::StaticShapeNonMaxSuppression>(node);
+    IE_ASSERT(staticShapeNMS != nullptr);
     VPU_THROW_UNLESS(inputs.size() == 6,
         "StaticShapeNMS with name {} parsing failed, expected number of inputs: 6, but {} provided",
-        layer->name, inputs.size());
+        staticShapeNMS->get_friendly_name(), inputs.size());
     VPU_THROW_UNLESS(outputs.size() == 3,
         "StaticShapeNMS with name {} parsing failed, expected number of outputs: 4, but {} provided",
-        layer->name, outputs.size());
+        staticShapeNMS->get_friendly_name(), outputs.size());
 
     const auto softNMSSigmaData = inputs[5];
     VPU_THROW_UNLESS(softNMSSigmaData->usage() == DataUsage::Const,
         "StaticShapeNMS with name {} parsing failed: softNMSSigma should have usage {} while it actually has {}",
-        layer->type, DataUsage::Const, softNMSSigmaData->usage());
+        staticShapeNMS->get_type_name(), DataUsage::Const, softNMSSigmaData->usage());
     VPU_THROW_UNLESS(softNMSSigmaData->desc().totalDimSize() == 1,
         "StaticShapeNMS with name {} parsing failed: softNMSSigma input should contain 1 value, while it has {} values",
-        layer->type, softNMSSigmaData->desc().totalDimSize());
+        staticShapeNMS->get_type_name(), softNMSSigmaData->desc().totalDimSize());
     const auto softNMSSigma = InferenceEngine::PrecisionUtils::f16tof32(softNMSSigmaData->content()->get<InferenceEngine::ie_fp16>()[0]);
     VPU_THROW_UNLESS(softNMSSigma == 0,
         "StaticShapeNMS with name {} parsing failed: the only supported value for softNMSSigma is 0, while it actually equal to {}",
-        layer->name, softNMSSigma);
+        staticShapeNMS->get_friendly_name(), softNMSSigma);
 
     auto usedInputs = inputs;
     // Erase unused softNMSSigma input
@@ -135,15 +138,15 @@ void FrontEnd::parseStaticShapeNMS(const Model& model, const ie::CNNLayerPtr& la
 
     VPU_THROW_UNLESS(outScores == nullptr,
         "StaticShapeNMS with name {} parsing failed: selected_scores output is not supported {}",
-        layer->name);
+        staticShapeNMS->get_friendly_name());
 
-    const auto sortResultDescending = layer->GetParamAsBool("sort_result_descending");
-    const auto centerPointBox = layer->GetParamAsBool("center_point_box");
+    const auto sortResultDescending = staticShapeNMS->get_sort_result_descending();
+    const auto centerPointBox = staticShapeNMS->get_box_encoding() == ngraph::op::v5::NonMaxSuppression::BoxEncodingType::CENTER ? true : false;
 
     VPU_THROW_UNLESS(sortResultDescending == false,
-        "StaticShapeNMS with name {}: parameter sortResultDescending=true is not supported on VPU", layer->name);
+        "StaticShapeNMS with name {}: parameter sortResultDescending=true is not supported on VPU", staticShapeNMS->get_friendly_name());
 
-    auto stage = model->addNewStage<StaticShapeNMS>(layer->name, StageType::StaticShapeNMS, layer, usedInputs, DataVector{outIndices, outShape});
+    auto stage = model->addNewStage<StaticShapeNMS>(staticShapeNMS->get_friendly_name(), StageType::StaticShapeNMS, staticShapeNMS, usedInputs, DataVector{outIndices, outShape});
     stage->attrs().set<bool>("center_point_box", centerPointBox);
 
     const auto inputDims0 = inputs[0]->desc().dims();

--- a/inference-engine/src/vpu/graph_transformer/src/stages/tanh.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/tanh.cpp
@@ -29,11 +29,12 @@ private:
 
 }  // namespace
 
-void FrontEnd::parseTanH(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) const {
+void FrontEnd::parseTanH(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
     IE_ASSERT(inputs.size() == 1);
     IE_ASSERT(outputs.size() == 1);
-
-    model->addNewStage<TanHStage>(layer->name, StageType::Tanh, layer, inputs, outputs);
+    auto tanh = ngraph::as_type_ptr<ngraph::opset4::Tanh>(node);
+    VPU_THROW_UNLESS(tanh != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+    model->addNewStage<TanHStage>(node->get_friendly_name(), StageType::Tanh, node, inputs, outputs);
 }
 
 }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/tensor_iterator.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/tensor_iterator.cpp
@@ -1,551 +1,551 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
-
-#include "vpu/frontend/frontend.hpp"
-#include "vpu/stages/iteration_rule.hpp"
-#include "vpu/utils/auto_scope.hpp"
-#include <legacy/graph_transformer.h>
-#include "vpu/model/data_contents/ie_blob_content.hpp"
-
-#include <legacy/ie_layers_internal.hpp>
-#include <legacy/net_pass.h>
-
-#include <memory>
-#include <utility>
-#include <vector>
-#include <map>
-#include <string>
-
-namespace vpu {
-
-namespace {
-
-using PortMap = ie::TensorIterator::PortMap;
-
-constexpr auto s_curIterPort   = "loop_body_current_iteration_idx";
-constexpr auto s_tripCountPort = "loop_trip_count_idx";
-constexpr auto s_initCondPort  = "loop_execution_condition_idx";
-constexpr auto s_condPort      = "loop_body_condition_output_idx";
-
-bool isIterable(const PortMap& rule) {
-    return rule.axis != -1;
-}
-
-bool isIterableInput(const ie::DataPtr& data, const std::shared_ptr<ie::TensorIterator>& tensorIterator) {
-    const auto isInput = [&data, &tensorIterator](const PortMap& rule) { return tensorIterator->body.inputs[rule.to] == data; };
-    const auto& rules = tensorIterator->input_port_map;
-    return std::any_of(rules.begin(), rules.end(), [&isInput](const PortMap& rule) { return isIterable(rule) && isInput(rule); });
-}
-
-bool isIterableOutput(const ie::DataPtr& data, const std::shared_ptr<ie::TensorIterator>& tensorIterator) {
-    const auto isOutput = [&data, &tensorIterator](const PortMap& rule) { return tensorIterator->body.outputs[rule.to] == data; };
-    const auto& rules = tensorIterator->output_port_map;
-    return std::any_of(rules.begin(), rules.end(), [&isOutput](const PortMap& rule) { return isIterable(rule) && isOutput(rule); });
-}
-
-bool isIterable(const ie::DataPtr& data, const std::shared_ptr<ie::TensorIterator>& tensorIterator) {
-    const auto& bodyInputs = tensorIterator->body.inputs;
-    const auto& bodyOutputs = tensorIterator->body.outputs;
-
-    const bool isBodyInput = std::find(bodyInputs.begin(), bodyInputs.end(), data) != bodyInputs.end();
-    const bool isBodyOutput = std::find(bodyOutputs.begin(), bodyOutputs.end(), data) != bodyOutputs.end();
-    VPU_THROW_UNLESS(isBodyInput || isBodyOutput, "Check on iterable component is valid only for Tensor Iterator's body input and output data objects");
-
-    return isIterableInput(data, tensorIterator) || isIterableOutput(data, tensorIterator);
-}
-
-bool hasBackEdgeConnectionTo(const ie::DataPtr& data, const std::shared_ptr<ie::TensorIterator>& tensorIterator) {
-    const auto& rules = tensorIterator->back_edges;
-    return std::any_of(rules.begin(), rules.end(), [&data, &tensorIterator](const PortMap& rule) { return tensorIterator->body.inputs[rule.to] == data; });
-}
-
-bool isConst(const ie::CNNLayerPtr& layer) {
-    return layer->type == "Const" && layer->outData.size() == 1 && layer->blobs.size() == 1;
-}
-
-bool isConst(const ie::DataPtr& data) {
-    const auto creator = getCreatorLayer(data).lock();
-    return creator != nullptr && isConst(creator);
-}
-
-bool isFakeHolder(const ie::DataPtr& data) {
-    return data->getPrecision() == ie::Precision::UNSPECIFIED;
-}
-
-}  // namespace
-
-void FrontEnd::parseTensorIterator(const Model& model, const ie::CNNLayerPtr& layer, const DataVector& inputs, const DataVector& outputs) {
-    IE_ASSERT(!inputs.empty());
-    IE_ASSERT(!outputs.empty());
-
-    auto tensorIterator = std::dynamic_pointer_cast<ie::TensorIterator>(layer);
-    IE_ASSERT(tensorIterator != nullptr);
-
-    auto createDescriptor = [&](const ie::TensorDesc& original) {
-        auto vpuDescriptor = DataDesc{original};
-        if (vpuDescriptor.type() == DataType::FP32) {
-            // to infer the same FP32 models on different devices (CPU, GPU, VPU and so on)
-            vpuDescriptor.setType(DataType::FP16);
-        }
-        return vpuDescriptor;
-    };
-
-    auto createData = [&](const ie::DataPtr& original) {
-        return model->addNewData(original->getName(), createDescriptor(original->getTensorDesc()));;
-    };
-
-    auto createConstData = [&](const ie::DataPtr& original) {
-        VPU_THROW_UNLESS(isConst(original), "VPU const data object can be created only from const IE data object");
-
-        const auto& creator = getCreatorLayer(original).lock();
-        const auto& descriptor = createDescriptor(original->getTensorDesc());
-        const auto& blob = ieBlobContent(creator->blobs.begin()->second, descriptor.type());
-
-        return model->addConstData(original->getName(), descriptor, blob);
-    };
-
-    auto findTIInputsDataByBodyData = [&](const ie::DataPtr& bodyData) -> std::vector<ie::DataPtr> {
-        std::vector<ie::DataPtr> tensorIteratorInputs;
-        for (const auto& rule : tensorIterator->input_port_map) {
-            if (tensorIterator->body.inputs[rule.to] == bodyData) {
-                tensorIteratorInputs.push_back(tensorIterator->insData[rule.from].lock());
-            }
-        }
-        return tensorIteratorInputs;
-    };
-
-    auto findTIOutputsDataByBodyData = [&](const ie::DataPtr& bodyData) -> std::vector<ie::DataPtr> {
-        std::vector<ie::DataPtr> tensorIteratorOutputs;
-        for (const auto& rule : tensorIterator->output_port_map) {
-            if (tensorIterator->body.outputs[rule.to] == bodyData) {
-                tensorIteratorOutputs.push_back(tensorIterator->outData[rule.from]);
-            }
-        }
-        return tensorIteratorOutputs;
-    };
-
-    auto getBodyOutputsByBodyInput = [&](const ie::DataPtr& bodyInput) -> std::vector<ie::DataPtr> {
-        std::vector<ie::DataPtr> bodyOutputs;
-        for (const auto& rule : tensorIterator->back_edges) {
-            if (tensorIterator->body.inputs[rule.to] == bodyInput) {
-                bodyOutputs.push_back(tensorIterator->body.outputs[rule.from]);
-            }
-        }
-        return bodyOutputs;
-    };
-
-    auto getInputIterableRule = [&](const ie::DataPtr& from, const ie::DataPtr& to) {
-        std::vector<PortMap> rules;
-        for (const auto& rule : tensorIterator->input_port_map) {
-            if (isIterable(rule) && tensorIterator->insData[rule.from].lock() == from && tensorIterator->body.inputs[rule.to] == to) {
-                rules.push_back(rule);
-            }
-        }
-        VPU_THROW_UNLESS(!rules.empty(), "There must be an iterable rule between data objects");
-        VPU_THROW_UNLESS(rules.size() == 1, "There cannot be more than one iterable rule with the same source and destination");
-        return rules.front();
-    };
-
-    auto getOutputIterableRule = [&](const ie::DataPtr& from, const ie::DataPtr& to) {
-        std::vector<PortMap> rules;
-        for (const auto& rule : tensorIterator->output_port_map) {
-            if (isIterable(rule) && tensorIterator->outData[rule.from] == from && tensorIterator->body.outputs[rule.to] == to) {
-                rules.push_back(rule);
-            }
-        }
-        VPU_THROW_UNLESS(!rules.empty(), "There must be an iterable rule between data objects");
-        VPU_THROW_UNLESS(rules.size() == 1, "There cannot be more than one iterable rule with the same source and destination");
-        return rules.front();
-    };
-
-    auto allTheSame = [](const std::vector<ie::DataPtr>& dataObjects) -> bool {
-        if (dataObjects.empty()) {
-            return true;
-        }
-
-        const auto& first = dataObjects.front();
-        return std::all_of(dataObjects.begin(), dataObjects.end(),
-            [&first](const ie::DataPtr& current) { return first->getTensorDesc() == current->getTensorDesc(); });
-    };
-
-    auto introduceLoopStart = [&]() -> Stage {
-        // there may be several back-edge connections with the same pair of Tensor Iterator's input data object and body's output data object,
-        // but different body's input data objects - they represent the same back-edge connection
-        // nevertheless, we need to keep track of all body's input data object to correctly connect Loop Start's outputs and body's input stages
-        std::map<std::pair<ie::DataPtr, ie::DataPtr>, std::vector<ie::DataPtr>> backedges;
-
-        // iteration component inside Tensor Iterator's body can be used as an input for several stages at the same time
-        std::map<std::pair<ie::DataPtr, IterationRule>, std::vector<ie::DataPtr>> iterations;
-        std::map<ie::DataPtr, std::vector<ie::DataPtr>> intermediateDataObjects;
-
-        // some Tensor Iterator's input data objects may be connected with several Tensor Iterator's body input data objects at the same time
-        // back-edge connection is defined as a connection between Tensor Iterator's body output object and body input object
-        // this way there can be different back-edge connections to the same Tensor Iterator's input object
-        // to correctly handle this case we have to parse body inputs, not Tensor Iterator's inputs
-        const auto& bodyInputs = tensorIterator->body.inputs;
-        VPU_THROW_UNLESS(!bodyInputs.empty(), "If there is no an input for Tensor Iterator's body, so there is no iteration in tensor iterator");
-
-        for (std::size_t bodyInputPort = 0; bodyInputPort < bodyInputs.size(); ++bodyInputPort) {
-            const auto& bodyInput = bodyInputs[bodyInputPort];
-            const bool isLast = bodyInputPort == (bodyInputs.size() - 1);
-            VPU_THROW_UNLESS(!isFakeHolder(bodyInput) || isLast , "There can be only one fake holder and it can be only the last Tensor Iterator body input");
-            if (isFakeHolder(bodyInput)) {
-                // fake holder keeps strong references on const data objects that are not presented in Tensor Iterator's body input vector
-                // these const data objects will be process during parsing Tensor Iterator's body layers
-                continue;
-            }
-
-            VPU_THROW_UNLESS(!(isIterable(bodyInput, tensorIterator) && hasBackEdgeConnectionTo(bodyInput, tensorIterator)),
-                             "There must not be a back-edge connection to iterable component");
-
-            const auto& tensorIteratorInputs = findTIInputsDataByBodyData(bodyInput);
-            VPU_THROW_UNLESS(tensorIteratorInputs.size() == 1,
-                             "There must be exactly one Tensor Iterator's input data object for each body's input data object except fake holder");
-            const auto& tensorIteratorInput = tensorIteratorInputs.front();
-
-            if (isIterable(bodyInput, tensorIterator)) {
-                const auto& rule = getInputIterableRule(tensorIteratorInput, bodyInput);
-                auto perm = DimsOrder::fromNumDims(tensorIteratorInput->getDims().size()).toPermutation();
-                auto axis = perm[tensorIteratorInput->getDims().size() - 1 - rule.axis];
-                iterations[std::make_pair(tensorIteratorInput, IterationRule{axis, rule.start, rule.stride, rule.end})].push_back(bodyInput);
-            } else if (hasBackEdgeConnectionTo(bodyInput, tensorIterator)) {
-                const auto& bodyOutputs = getBodyOutputsByBodyInput(bodyInput);
-                VPU_THROW_UNLESS(bodyOutputs.size() == 1,
-                                 "There must be exactly one Tensor Iterator's body output data object for each back-edge connection "
-                                 "with the same Tensor Iterator's body input data object");
-                const auto& bodyOutput = bodyOutputs.front();
-
-                backedges[std::make_pair(bodyOutput, tensorIteratorInput)].push_back(bodyInput);
-            } else {
-                VPU_THROW_UNLESS(!isConst(bodyInput), "Const inputs of Tensor Iterator's body are hold by fake holder");
-                VPU_THROW_UNLESS(!findTIInputsDataByBodyData(bodyInput).empty(), "There must be corresponding Tensor Iterator's input data object");
-
-                intermediateDataObjects[tensorIteratorInput].push_back(bodyInput);
-            }
-        }
-
-        auto loopStartInputs  = DataVector{};
-        auto loopStartOutputs = DataVector{};
-
-        for (const auto& backedge : backedges) {
-            const auto& tensorIteratorInput = backedge.first.second;
-            const auto& vpuTensorIteratorInput = getVpuData(tensorIteratorInput);
-            VPU_THROW_UNLESS(vpuTensorIteratorInput != nullptr, "Tensor Iterator's inputs must be parsed already");
-
-            auto loopStartInput = vpuTensorIteratorInput;
-            if (!vpuTensorIteratorInput->canHaveAParent()) {
-                auto copied = model->addNewData(vpuTensorIteratorInput->name() + "@copy-for-backedge", vpuTensorIteratorInput->desc());
-                _stageBuilder->addCopyStage(model, "copy-for-backedge", nullptr, vpuTensorIteratorInput, copied, "copy for backedge");
-                loopStartInput = copied;
-            }
-
-            const auto& backedgeInputs = backedge.second;
-            VPU_THROW_UNLESS(allTheSame(backedgeInputs), "Different data objects cannot be mapped into the same data object");
-            VPU_THROW_UNLESS(!backedgeInputs.empty(), "Back-edges are specified only from body output to body input");
-            const auto& backedgeInput = backedgeInputs.front();
-
-            VPU_THROW_UNLESS(getVpuData(backedgeInput) == nullptr, "Tensor Iterator's body input data objects were not parsed yet");
-            auto loopStartOutput = createData(backedgeInput);
-
-            // to introduce shared data allocation edge later in Middle-End
-            loopStartInput->attrs().set<Data>("start-shared-allocation", loopStartOutput);
-
-            loopStartInputs.push_back(loopStartInput);
-            loopStartOutputs.push_back(loopStartOutput);
-
-            for (const auto& data : backedgeInputs) {
-                bindData(loopStartOutput, data);
-            }
-        }
-
-        vpu::Optional<std::uint32_t> batchIdx{};
-        if (tensorIterator->params.count(s_tripCountPort)) {
-            VPU_THROW_UNLESS(!iterations.empty(),
-                "Encountered Loop which is supposed to be loop by dynamic batch (dynamic iterations count), but didn't find an iteration component");
-            VPU_THROW_UNLESS(!tensorIterator->params.count(s_curIterPort), "Current iteration port for body of Loop operation is not supported");
-            batchIdx = static_cast<std::uint32_t>(loopStartInputs.size());
-        }
-
-        if (tensorIterator->params.count(s_initCondPort)) {
-            const auto& input = tensorIterator->insData[tensorIterator->GetParamAsUInt(s_initCondPort)].lock();
-            VPU_THROW_UNLESS(isConst(input), "Execution condition for Loop must be constant true");
-
-            const auto& creator = getCreatorLayer(input).lock();
-            VPU_THROW_UNLESS(creator->blobs.size() == 1, "Execution condition for Loop must contain exactly one blob, got {}", creator->blobs.size());
-
-            const auto& blob = creator->blobs.begin()->second;
-            VPU_THROW_UNLESS(blob->size() == 1, "Execution condition for Loop must be single value, got {} values", blob->size());
-            VPU_THROW_UNLESS(blob->getTensorDesc().getPrecision() == InferenceEngine::Precision::I32,
-                             "Execution condition for Loop must have I32 type, got {}", blob->getTensorDesc().getPrecision());
-
-            const auto value = blob->buffer().as<std::int32_t*>()[0];
-            VPU_THROW_UNLESS(value == 1, "Execution condition for Loop must be true, got {} as value", value);
-        }
-
-        IterationComponents start_iteration_components;
-        for (const auto& iteration : iterations) {
-            const auto& tensorIteratorInput = iteration.first.first;
-            const auto& rule = iteration.first.second;
-            const auto& vpuTensorIteratorInput = getVpuData(tensorIteratorInput);
-            VPU_THROW_UNLESS(vpuTensorIteratorInput != nullptr, "Tensor Iterator's inputs must be parsed already");
-
-            const auto& loopStartInput = vpuTensorIteratorInput;
-
-            const auto& iterationInputs = iteration.second;
-            VPU_THROW_UNLESS(allTheSame(iterationInputs), "Different data objects cannot be mapped into the same data object");
-            VPU_THROW_UNLESS(!iterationInputs.empty(), "Iteration components are specified only from Tensor Iterator's input to body input");
-            const auto& iterationInput = iterationInputs.front();
-
-            VPU_THROW_UNLESS(getVpuData(iterationInput) == nullptr, "Tensor Iterator's body input data objects were not parsed yet");
-            auto loopStartOutput = createData(iterationInput);
-
-            start_iteration_components.emplace(std::make_pair(loopStartInputs.size(), rule), loopStartOutputs.size());
-            loopStartInputs.push_back(loopStartInput);
-            loopStartOutputs.push_back(loopStartOutput);
-
-            for (const auto& data : iterationInputs) {
-                bindData(loopStartOutput, data);
-            }
-        }
-
-        for (const auto& intermediateDataObject : intermediateDataObjects) {
-            const auto& tensorIteratorInput = intermediateDataObject.first;
-            const auto& vpuTensorIteratorInput = getVpuData(tensorIteratorInput);
-            VPU_THROW_UNLESS(vpuTensorIteratorInput != nullptr, "Tensor Iterator's inputs must be parsed already");
-
-            const auto& loopStartInput = vpuTensorIteratorInput;
-
-            const auto& intermediateDataInputs = intermediateDataObject.second;
-            VPU_THROW_UNLESS(allTheSame(intermediateDataInputs), "Different data objects cannot be mapped into the same data object");
-            VPU_THROW_UNLESS(!intermediateDataInputs.empty(), "There must be at least one corresponding data object as body's input");
-
-            const auto& intermediateDataInput = intermediateDataInputs.front();
-            VPU_THROW_UNLESS(getVpuData(intermediateDataInput) == nullptr, "Tensor Iterator's body input data objects were not parsed yet");
-
-            const auto& loopStartOutput = createData(intermediateDataInput);
-            bindData(loopStartOutput, intermediateDataInput);
-
-            // to introduce shared data allocation edge later in Middle-End
-            loopStartInput->attrs().set<Data>("start-shared-allocation", loopStartOutput);
-
-            loopStartInputs.push_back(loopStartInput);
-            loopStartOutputs.push_back(loopStartOutput);
-
-            for (const auto& data : intermediateDataInputs) {
-                bindData(loopStartOutput, data);
-            }
-        }
-
-        auto loopStart = _stageBuilder->addLoopStartStage(model, tensorIterator->name + "@LoopStart", loopStartInputs, loopStartOutputs);
-        loopStart->attrs().set("start-iteration-components", start_iteration_components);
-        if (batchIdx.hasValue()) {
-            loopStart->attrs().set("batchId", batchIdx.get());
-        }
-
-        for (const auto& backedge : backedges) {
-            const auto& parent = getVpuData(backedge.first.first);
-            VPU_THROW_UNLESS(parent != nullptr, "Loop End's inputs must be already parsed");
-
-            const auto& child = getVpuData(backedge.second.front());
-            VPU_THROW_UNLESS(child != nullptr, "Loop Start's outputs must be already parsed");
-
-            const auto& src_copy = parent;
-            auto dst_copy = model->duplicateData(child, "@copy-for-backedge");
-            for (const auto& consumerEdge : src_copy->consumerEdges()) {
-                model->replaceStageInput(consumerEdge, dst_copy);
-            }
-
-            _stageBuilder->addCopyStage(model, "copy-for-backedge", nullptr, src_copy, dst_copy, "copy for backedge");
-
-            // keep track of back-edges to introduce shared data allocation edges in Middle-End
-            loopStart->attrs().getOrSet<HandleMultiMap<DataNode, Data>>("backedges", {}).emplace(dst_copy, child);
-        }
-
-        return loopStart;
-    };
-
-    auto introduceLoopEnd = [&]() -> Stage {
-        std::map<std::pair<ie::DataPtr, IterationRule>, ie::DataPtr> iterations;
-        std::map<ie::DataPtr, ie::DataPtr> intermediateDataObjects;
-
-        auto loopEndInputs = DataVector{};
-
-        const auto& bodyOutputs = tensorIterator->body.outputs;
-        VPU_THROW_UNLESS(!bodyOutputs.empty(), "If there is no an output for Tensor Iterator's body, so there is no iteration in tensor iterator");
-
-        for (std::size_t bodyOutputIdx = 0; bodyOutputIdx < bodyOutputs.size(); ++bodyOutputIdx) {
-            const auto& bodyOutput = bodyOutputs[bodyOutputIdx];
-
-            if (tensorIterator->params.count(s_condPort) && tensorIterator->GetParamAsUInt(s_condPort) == bodyOutputIdx) {
-                const auto& creator = getCreatorLayer(bodyOutput).lock();
-                if (!creator) {
-                    // ConstTransformer leaves constant without creator
-                    // Assume it's true
-                    continue;
-                }
-                VPU_THROW_UNLESS(isConst(bodyOutput), "Body execution condition must be constant true");
-
-                VPU_THROW_UNLESS(creator->blobs.size() == 1, "Body execution condition constant must have one blob");
-                const auto& blob = creator->blobs.begin()->second;
-                VPU_THROW_UNLESS(blob->size() == 1, "Body execution condition must be single value");
-                VPU_THROW_UNLESS(blob->getTensorDesc().getPrecision() == InferenceEngine::Precision::I32, "Body execution condition must be I32");
-                const auto value = blob->buffer().as<std::int32_t*>()[0];
-                VPU_THROW_UNLESS(value == 1, "Body execution condition must be true");
-                continue;
-            }
-
-            VPU_THROW_UNLESS(!isFakeHolder(bodyOutput), "Fake holder can be only in body's input");
-
-            const auto& tensorIteratorOutputs = findTIOutputsDataByBodyData(bodyOutput);
-            VPU_THROW_UNLESS(tensorIteratorOutputs.empty() || tensorIteratorOutputs.size() == 1,
-                "There may be only one Tensor Iterator's output data object for body's output data object if any");
-
-            if (tensorIteratorOutputs.empty()) {
-                // there can be no Tensor Iterator's output data object for body's output
-                // in such a case there is no consumer for this data object, however, it's not a network's output
-                // in this case we connect this data object with Loop End
-                VPU_THROW_UNLESS(!isIterable(bodyOutput, tensorIterator),
-                    "Body's output with no corresponding Tensor Iterator's output data object cannot be iterable component");
-
-                auto loopEndInput = createData(bodyOutput);
-                bindData(loopEndInput, bodyOutput);
-                loopEndInputs.push_back(loopEndInput);
-            } else {
-                const auto& tensorIteratorOutput = tensorIteratorOutputs.front();
-                if (isIterable(bodyOutput, tensorIterator)) {
-                    const auto& rule = getOutputIterableRule(tensorIteratorOutput, bodyOutput);
-                    auto perm = DimsOrder::fromNumDims(tensorIteratorOutput->getDims().size()).toPermutation();
-                    auto axis = perm[tensorIteratorOutput->getDims().size() - 1 - rule.axis];
-                    iterations[std::make_pair(tensorIteratorOutput, IterationRule{axis, rule.start, rule.stride, rule.end})] = bodyOutput;
-                } else {
-                    VPU_THROW_UNLESS(intermediateDataObjects.count(tensorIteratorOutput) == 0,
-                        "There can be only one body's output data object for Tensor Iterator's output");
-                    VPU_THROW_UNLESS(!isConst(tensorIteratorOutput), "Tensor Iterator's body cannot have const data object as output");
-
-                    intermediateDataObjects[tensorIteratorOutput] = bodyOutput;
-                }
-            }
-        }
-
-        auto loopEndOutputs = DataVector{};
-
-        vpu::Optional<std::uint32_t> batchIdx{};
-        if (tensorIterator->params.count(s_tripCountPort)) {
-            VPU_THROW_UNLESS(!iterations.empty(),
-                "Encountered Loop which is supposed to be loop by dynamic batch (dynamic iterations count), but didn't find an iteration component");
-            VPU_THROW_UNLESS(!tensorIterator->params.count(s_curIterPort), "Current iteration port for body of Loop operation is not supported");
-            batchIdx = static_cast<std::uint32_t>(loopEndOutputs.size());
-        }
-
-        IterationComponents end_iteration_components;
-        for (const auto& iteration : iterations) {
-            const auto& tensorIteratorOutput = iteration.first.first;
-            const auto& rule = iteration.first.second;
-            const auto& vpuTensorIteratorOutput = getVpuData(tensorIteratorOutput);
-            VPU_THROW_UNLESS(vpuTensorIteratorOutput != nullptr, "Tensor Iterator's outputs must be parsed already");
-
-            const auto& loopEndOutput = vpuTensorIteratorOutput;
-
-            const auto& iterationInput = iteration.second;
-            VPU_THROW_UNLESS(getVpuData(iterationInput) == nullptr, "Tensor Iterator's body output data objects were not parsed yet");
-            auto loopEndInput = createData(iterationInput);
-
-            end_iteration_components.emplace(std::make_pair(loopEndOutputs.size(), rule), loopEndInputs.size());
-            loopEndInputs.push_back(loopEndInput);
-            loopEndOutputs.push_back(loopEndOutput);
-
-            bindData(loopEndInput, iterationInput);
-        }
-
-        for (const auto& intermediateDataObject : intermediateDataObjects) {
-            const auto& tensorIteratorOutput = intermediateDataObject.first;
-            const auto& vpuTensorIteratorOutput = getVpuData(tensorIteratorOutput);
-            VPU_THROW_UNLESS(vpuTensorIteratorOutput != nullptr, "Tensor Iterator's outputs must be parsed already");
-
-            auto loopEndOutput = vpuTensorIteratorOutput;
-            if (loopEndOutput->usage() == DataUsage::Output) {
-                auto to_copy = model->addNewData(loopEndOutput->name() + "@copy-for-backedge", loopEndOutput->desc());
-                _stageBuilder->addCopyStage(model, "copy-for-tensor-iterator-output", nullptr, to_copy, loopEndOutput, "copy for TI output");
-                loopEndOutput = to_copy;
-            }
-
-            const auto& intermediateDataInput = intermediateDataObject.second;
-            VPU_THROW_UNLESS(getVpuData(intermediateDataInput) == nullptr, "Tensor Iterator's body output data objects were not parsed yet");
-
-            auto loopEndInput = createData(intermediateDataInput);
-
-            // to introduce shared data allocation edge later in Middle-End
-            loopEndOutput->attrs().set<Data>("end-shared-allocation", loopEndInput);
-
-            loopEndInputs.push_back(loopEndInput);
-            loopEndOutputs.push_back(loopEndOutput);
-
-            bindData(loopEndInput, intermediateDataInput);
-        }
-
-        auto loopEnd = _stageBuilder->addLoopEndStage(model, tensorIterator->name + "@LoopEnd", loopEndInputs, loopEndOutputs);
-        loopEnd->attrs().set("end-iteration-components", end_iteration_components);
-        if (batchIdx.hasValue()) {
-            loopEnd->attrs().set("batchId", batchIdx.get());
-        }
-
-        return loopEnd;
-    };
-
-    // Loop End must be introduced first to parse Tensor Iterator's body output data objects before parsing back-edge connections
-    auto loopEnd = introduceLoopEnd();
-    auto loopStart = introduceLoopStart();
-
-    if (!tensorIterator->params.count(s_tripCountPort)) {
-        const auto iterationsCount = getNumIteration(*tensorIterator);
-        VPU_THROW_UNLESS(iterationsCount >= 0, "Encountered Tensor Iterator with iterations count equal to {}, but only non-negative values are supported",
-            iterationsCount);
-        loopStart->attrs().set<std::uint32_t>("iterations-count", static_cast<std::uint32_t>(iterationsCount));
-        loopEnd->attrs().set<std::uint32_t>("iterations-count", static_cast<std::uint32_t>(iterationsCount));
-    }
-
-    // to allocate LoopEnd and LoopStart at the same time
-    loopStart->attrs().set<Stage>("loop-end", loopEnd);
-
-    // to be sure all loop's inputs are still alive during loop execution
-    // force they to be alive as long as loop's outputs
-    for (const auto& loopStartInput : loopStart->inputs()) {
-        model->addStageInput(loopEnd, loopStartInput);
-    }
-
-    for (const auto& bodyLayer : ie::NetPass::TIBodySortTopologically(tensorIterator->body)) {
-        if (bodyLayer->type == "Const") {
-            // since Tensor Iterator's body is a kind of CNNNetwork it may has const data objects as inputs
-            // const data objects are hold by "Const" layers
-            // we don't need them during iteration and ignore the same way as compilation process of regular network
-            continue;
-        }
-
-        auto stageInputs = DataVector{};
-        for (const auto& data : bodyLayer->insData) {
-            const auto ieInput = data.lock();
-            const auto vpuInput = isConst(ieInput) ? createConstData(ieInput) : getVpuData(ieInput);
-            VPU_THROW_UNLESS(vpuInput != nullptr,
-                "Non-const input of a stage must be already parsed due to either topological order or as Loop Start's output");
-
-            stageInputs.push_back(vpuInput);
-        }
-
-        auto stageOutputs = DataVector{};
-        for (const auto& data : bodyLayer->outData) {
-            auto output = getVpuData(data);
-            // output of a stage might be already parsed as Loop End's output
-            if (output == nullptr) {
-                output = createData(data);
-                bindData(output, data);
-            }
-
-            stageOutputs.push_back(output);
-        }
-
-        parseLayer(model, bodyLayer, stageInputs, stageOutputs);
-    }
-}
-
-}  // namespace vpu
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
+
+// #include "vpu/frontend/frontend.hpp"
+// #include "vpu/stages/iteration_rule.hpp"
+// #include "vpu/utils/auto_scope.hpp"
+// #include <legacy/graph_transformer.h>
+// #include "vpu/model/data_contents/ie_blob_content.hpp"
+
+// #include <legacy/ie_layers_internal.hpp>
+// #include <legacy/net_pass.h>
+
+// #include <memory>
+// #include <utility>
+// #include <vector>
+// #include <map>
+// #include <string>
+
+// namespace vpu {
+
+// namespace {
+
+// using PortMap = ie::TensorIterator::PortMap;
+
+// constexpr auto s_curIterPort   = "loop_body_current_iteration_idx";
+// constexpr auto s_tripCountPort = "loop_trip_count_idx";
+// constexpr auto s_initCondPort  = "loop_execution_condition_idx";
+// constexpr auto s_condPort      = "loop_body_condition_output_idx";
+
+// bool isIterable(const PortMap& rule) {
+//     return rule.axis != -1;
+// }
+
+// bool isIterableInput(const ie::DataPtr& data, const std::shared_ptr<ie::TensorIterator>& tensorIterator) {
+//     const auto isInput = [&data, &tensorIterator](const PortMap& rule) { return tensorIterator->body.inputs[rule.to] == data; };
+//     const auto& rules = tensorIterator->input_port_map;
+//     return std::any_of(rules.begin(), rules.end(), [&isInput](const PortMap& rule) { return isIterable(rule) && isInput(rule); });
+// }
+
+// bool isIterableOutput(const ie::DataPtr& data, const std::shared_ptr<ie::TensorIterator>& tensorIterator) {
+//     const auto isOutput = [&data, &tensorIterator](const PortMap& rule) { return tensorIterator->body.outputs[rule.to] == data; };
+//     const auto& rules = tensorIterator->output_port_map;
+//     return std::any_of(rules.begin(), rules.end(), [&isOutput](const PortMap& rule) { return isIterable(rule) && isOutput(rule); });
+// }
+
+// bool isIterable(const ie::DataPtr& data, const std::shared_ptr<ie::TensorIterator>& tensorIterator) {
+//     const auto& bodyInputs = tensorIterator->body.inputs;
+//     const auto& bodyOutputs = tensorIterator->body.outputs;
+
+//     const bool isBodyInput = std::find(bodyInputs.begin(), bodyInputs.end(), data) != bodyInputs.end();
+//     const bool isBodyOutput = std::find(bodyOutputs.begin(), bodyOutputs.end(), data) != bodyOutputs.end();
+//     VPU_THROW_UNLESS(isBodyInput || isBodyOutput, "Check on iterable component is valid only for Tensor Iterator's body input and output data objects");
+
+//     return isIterableInput(data, tensorIterator) || isIterableOutput(data, tensorIterator);
+// }
+
+// bool hasBackEdgeConnectionTo(const ie::DataPtr& data, const std::shared_ptr<ie::TensorIterator>& tensorIterator) {
+//     const auto& rules = tensorIterator->back_edges;
+//     return std::any_of(rules.begin(), rules.end(), [&data, &tensorIterator](const PortMap& rule) { return tensorIterator->body.inputs[rule.to] == data; });
+// }
+
+// bool isConst(const ie::CNNLayerPtr& layer) {
+//     return layer->type == "Const" && layer->outData.size() == 1 && layer->blobs.size() == 1;
+// }
+
+// bool isConst(const ie::DataPtr& data) {
+//     const auto creator = getCreatorLayer(data).lock();
+//     return creator != nullptr && isConst(creator);
+// }
+
+// bool isFakeHolder(const ie::DataPtr& data) {
+//     return data->getPrecision() == ie::Precision::UNSPECIFIED;
+// }
+
+// }  // namespace
+
+// void FrontEnd::parseTensorIterator(const Model& model, const NodePtr& layer, const DataVector& inputs, const DataVector& outputs) {
+//     IE_ASSERT(!inputs.empty());
+//     IE_ASSERT(!outputs.empty());
+
+//     auto tensorIterator = std::dynamic_pointer_cast<ie::TensorIterator>(layer);
+//     IE_ASSERT(tensorIterator != nullptr);
+
+//     auto createDescriptor = [&](const ie::TensorDesc& original) {
+//         auto vpuDescriptor = DataDesc{original};
+//         if (vpuDescriptor.type() == DataType::FP32) {
+//             // to infer the same FP32 models on different devices (CPU, GPU, VPU and so on)
+//             vpuDescriptor.setType(DataType::FP16);
+//         }
+//         return vpuDescriptor;
+//     };
+
+//     auto createData = [&](const ie::DataPtr& original) {
+//         return model->addNewData(original->getName(), createDescriptor(original->getTensorDesc()));;
+//     };
+
+//     auto createConstData = [&](const ie::DataPtr& original) {
+//         VPU_THROW_UNLESS(isConst(original), "VPU const data object can be created only from const IE data object");
+
+//         const auto& creator = getCreatorLayer(original).lock();
+//         const auto& descriptor = createDescriptor(original->getTensorDesc());
+//         const auto& blob = ieBlobContent(creator->blobs.begin()->second, descriptor.type());
+
+//         return model->addConstData(original->getName(), descriptor, blob);
+//     };
+
+//     auto findTIInputsDataByBodyData = [&](const ie::DataPtr& bodyData) -> std::vector<ie::DataPtr> {
+//         std::vector<ie::DataPtr> tensorIteratorInputs;
+//         for (const auto& rule : tensorIterator->input_port_map) {
+//             if (tensorIterator->body.inputs[rule.to] == bodyData) {
+//                 tensorIteratorInputs.push_back(tensorIterator->insData[rule.from].lock());
+//             }
+//         }
+//         return tensorIteratorInputs;
+//     };
+
+//     auto findTIOutputsDataByBodyData = [&](const ie::DataPtr& bodyData) -> std::vector<ie::DataPtr> {
+//         std::vector<ie::DataPtr> tensorIteratorOutputs;
+//         for (const auto& rule : tensorIterator->output_port_map) {
+//             if (tensorIterator->body.outputs[rule.to] == bodyData) {
+//                 tensorIteratorOutputs.push_back(tensorIterator->outData[rule.from]);
+//             }
+//         }
+//         return tensorIteratorOutputs;
+//     };
+
+//     auto getBodyOutputsByBodyInput = [&](const ie::DataPtr& bodyInput) -> std::vector<ie::DataPtr> {
+//         std::vector<ie::DataPtr> bodyOutputs;
+//         for (const auto& rule : tensorIterator->back_edges) {
+//             if (tensorIterator->body.inputs[rule.to] == bodyInput) {
+//                 bodyOutputs.push_back(tensorIterator->body.outputs[rule.from]);
+//             }
+//         }
+//         return bodyOutputs;
+//     };
+
+//     auto getInputIterableRule = [&](const ie::DataPtr& from, const ie::DataPtr& to) {
+//         std::vector<PortMap> rules;
+//         for (const auto& rule : tensorIterator->input_port_map) {
+//             if (isIterable(rule) && tensorIterator->insData[rule.from].lock() == from && tensorIterator->body.inputs[rule.to] == to) {
+//                 rules.push_back(rule);
+//             }
+//         }
+//         VPU_THROW_UNLESS(!rules.empty(), "There must be an iterable rule between data objects");
+//         VPU_THROW_UNLESS(rules.size() == 1, "There cannot be more than one iterable rule with the same source and destination");
+//         return rules.front();
+//     };
+
+//     auto getOutputIterableRule = [&](const ie::DataPtr& from, const ie::DataPtr& to) {
+//         std::vector<PortMap> rules;
+//         for (const auto& rule : tensorIterator->output_port_map) {
+//             if (isIterable(rule) && tensorIterator->outData[rule.from] == from && tensorIterator->body.outputs[rule.to] == to) {
+//                 rules.push_back(rule);
+//             }
+//         }
+//         VPU_THROW_UNLESS(!rules.empty(), "There must be an iterable rule between data objects");
+//         VPU_THROW_UNLESS(rules.size() == 1, "There cannot be more than one iterable rule with the same source and destination");
+//         return rules.front();
+//     };
+
+//     auto allTheSame = [](const std::vector<ie::DataPtr>& dataObjects) -> bool {
+//         if (dataObjects.empty()) {
+//             return true;
+//         }
+
+//         const auto& first = dataObjects.front();
+//         return std::all_of(dataObjects.begin(), dataObjects.end(),
+//             [&first](const ie::DataPtr& current) { return first->getTensorDesc() == current->getTensorDesc(); });
+//     };
+
+//     auto introduceLoopStart = [&]() -> Stage {
+//         // there may be several back-edge connections with the same pair of Tensor Iterator's input data object and body's output data object,
+//         // but different body's input data objects - they represent the same back-edge connection
+//         // nevertheless, we need to keep track of all body's input data object to correctly connect Loop Start's outputs and body's input stages
+//         std::map<std::pair<ie::DataPtr, ie::DataPtr>, std::vector<ie::DataPtr>> backedges;
+
+//         // iteration component inside Tensor Iterator's body can be used as an input for several stages at the same time
+//         std::map<std::pair<ie::DataPtr, IterationRule>, std::vector<ie::DataPtr>> iterations;
+//         std::map<ie::DataPtr, std::vector<ie::DataPtr>> intermediateDataObjects;
+
+//         // some Tensor Iterator's input data objects may be connected with several Tensor Iterator's body input data objects at the same time
+//         // back-edge connection is defined as a connection between Tensor Iterator's body output object and body input object
+//         // this way there can be different back-edge connections to the same Tensor Iterator's input object
+//         // to correctly handle this case we have to parse body inputs, not Tensor Iterator's inputs
+//         const auto& bodyInputs = tensorIterator->body.inputs;
+//         VPU_THROW_UNLESS(!bodyInputs.empty(), "If there is no an input for Tensor Iterator's body, so there is no iteration in tensor iterator");
+
+//         for (std::size_t bodyInputPort = 0; bodyInputPort < bodyInputs.size(); ++bodyInputPort) {
+//             const auto& bodyInput = bodyInputs[bodyInputPort];
+//             const bool isLast = bodyInputPort == (bodyInputs.size() - 1);
+//             VPU_THROW_UNLESS(!isFakeHolder(bodyInput) || isLast , "There can be only one fake holder and it can be only the last Tensor Iterator body input");
+//             if (isFakeHolder(bodyInput)) {
+//                 // fake holder keeps strong references on const data objects that are not presented in Tensor Iterator's body input vector
+//                 // these const data objects will be process during parsing Tensor Iterator's body layers
+//                 continue;
+//             }
+
+//             VPU_THROW_UNLESS(!(isIterable(bodyInput, tensorIterator) && hasBackEdgeConnectionTo(bodyInput, tensorIterator)),
+//                              "There must not be a back-edge connection to iterable component");
+
+//             const auto& tensorIteratorInputs = findTIInputsDataByBodyData(bodyInput);
+//             VPU_THROW_UNLESS(tensorIteratorInputs.size() == 1,
+//                              "There must be exactly one Tensor Iterator's input data object for each body's input data object except fake holder");
+//             const auto& tensorIteratorInput = tensorIteratorInputs.front();
+
+//             if (isIterable(bodyInput, tensorIterator)) {
+//                 const auto& rule = getInputIterableRule(tensorIteratorInput, bodyInput);
+//                 auto perm = DimsOrder::fromNumDims(tensorIteratorInput->getDims().size()).toPermutation();
+//                 auto axis = perm[tensorIteratorInput->getDims().size() - 1 - rule.axis];
+//                 iterations[std::make_pair(tensorIteratorInput, IterationRule{axis, rule.start, rule.stride, rule.end})].push_back(bodyInput);
+//             } else if (hasBackEdgeConnectionTo(bodyInput, tensorIterator)) {
+//                 const auto& bodyOutputs = getBodyOutputsByBodyInput(bodyInput);
+//                 VPU_THROW_UNLESS(bodyOutputs.size() == 1,
+//                                  "There must be exactly one Tensor Iterator's body output data object for each back-edge connection "
+//                                  "with the same Tensor Iterator's body input data object");
+//                 const auto& bodyOutput = bodyOutputs.front();
+
+//                 backedges[std::make_pair(bodyOutput, tensorIteratorInput)].push_back(bodyInput);
+//             } else {
+//                 VPU_THROW_UNLESS(!isConst(bodyInput), "Const inputs of Tensor Iterator's body are hold by fake holder");
+//                 VPU_THROW_UNLESS(!findTIInputsDataByBodyData(bodyInput).empty(), "There must be corresponding Tensor Iterator's input data object");
+
+//                 intermediateDataObjects[tensorIteratorInput].push_back(bodyInput);
+//             }
+//         }
+
+//         auto loopStartInputs  = DataVector{};
+//         auto loopStartOutputs = DataVector{};
+
+//         for (const auto& backedge : backedges) {
+//             const auto& tensorIteratorInput = backedge.first.second;
+//             const auto& vpuTensorIteratorInput = getVpuData(tensorIteratorInput);
+//             VPU_THROW_UNLESS(vpuTensorIteratorInput != nullptr, "Tensor Iterator's inputs must be parsed already");
+
+//             auto loopStartInput = vpuTensorIteratorInput;
+//             if (!vpuTensorIteratorInput->canHaveAParent()) {
+//                 auto copied = model->addNewData(vpuTensorIteratorInput->name() + "@copy-for-backedge", vpuTensorIteratorInput->desc());
+//                 _stageBuilder->addCopyStage(model, "copy-for-backedge", nullptr, vpuTensorIteratorInput, copied, "copy for backedge");
+//                 loopStartInput = copied;
+//             }
+
+//             const auto& backedgeInputs = backedge.second;
+//             VPU_THROW_UNLESS(allTheSame(backedgeInputs), "Different data objects cannot be mapped into the same data object");
+//             VPU_THROW_UNLESS(!backedgeInputs.empty(), "Back-edges are specified only from body output to body input");
+//             const auto& backedgeInput = backedgeInputs.front();
+
+//             VPU_THROW_UNLESS(getVpuData(backedgeInput) == nullptr, "Tensor Iterator's body input data objects were not parsed yet");
+//             auto loopStartOutput = createData(backedgeInput);
+
+//             // to introduce shared data allocation edge later in Middle-End
+//             loopStartInput->attrs().set<Data>("start-shared-allocation", loopStartOutput);
+
+//             loopStartInputs.push_back(loopStartInput);
+//             loopStartOutputs.push_back(loopStartOutput);
+
+//             for (const auto& data : backedgeInputs) {
+//                 bindData(loopStartOutput, data);
+//             }
+//         }
+
+//         vpu::Optional<std::uint32_t> batchIdx{};
+//         if (tensorIterator->params.count(s_tripCountPort)) {
+//             VPU_THROW_UNLESS(!iterations.empty(),
+//                 "Encountered Loop which is supposed to be loop by dynamic batch (dynamic iterations count), but didn't find an iteration component");
+//             VPU_THROW_UNLESS(!tensorIterator->params.count(s_curIterPort), "Current iteration port for body of Loop operation is not supported");
+//             batchIdx = static_cast<std::uint32_t>(loopStartInputs.size());
+//         }
+
+//         if (tensorIterator->params.count(s_initCondPort)) {
+//             const auto& input = tensorIterator->insData[tensorIterator->GetParamAsUInt(s_initCondPort)].lock();
+//             VPU_THROW_UNLESS(isConst(input), "Execution condition for Loop must be constant true");
+
+//             const auto& creator = getCreatorLayer(input).lock();
+//             VPU_THROW_UNLESS(creator->blobs.size() == 1, "Execution condition for Loop must contain exactly one blob, got {}", creator->blobs.size());
+
+//             const auto& blob = creator->blobs.begin()->second;
+//             VPU_THROW_UNLESS(blob->size() == 1, "Execution condition for Loop must be single value, got {} values", blob->size());
+//             VPU_THROW_UNLESS(blob->getTensorDesc().getPrecision() == InferenceEngine::Precision::I32,
+//                              "Execution condition for Loop must have I32 type, got {}", blob->getTensorDesc().getPrecision());
+
+//             const auto value = blob->buffer().as<std::int32_t*>()[0];
+//             VPU_THROW_UNLESS(value == 1, "Execution condition for Loop must be true, got {} as value", value);
+//         }
+
+//         IterationComponents start_iteration_components;
+//         for (const auto& iteration : iterations) {
+//             const auto& tensorIteratorInput = iteration.first.first;
+//             const auto& rule = iteration.first.second;
+//             const auto& vpuTensorIteratorInput = getVpuData(tensorIteratorInput);
+//             VPU_THROW_UNLESS(vpuTensorIteratorInput != nullptr, "Tensor Iterator's inputs must be parsed already");
+
+//             const auto& loopStartInput = vpuTensorIteratorInput;
+
+//             const auto& iterationInputs = iteration.second;
+//             VPU_THROW_UNLESS(allTheSame(iterationInputs), "Different data objects cannot be mapped into the same data object");
+//             VPU_THROW_UNLESS(!iterationInputs.empty(), "Iteration components are specified only from Tensor Iterator's input to body input");
+//             const auto& iterationInput = iterationInputs.front();
+
+//             VPU_THROW_UNLESS(getVpuData(iterationInput) == nullptr, "Tensor Iterator's body input data objects were not parsed yet");
+//             auto loopStartOutput = createData(iterationInput);
+
+//             start_iteration_components.emplace(std::make_pair(loopStartInputs.size(), rule), loopStartOutputs.size());
+//             loopStartInputs.push_back(loopStartInput);
+//             loopStartOutputs.push_back(loopStartOutput);
+
+//             for (const auto& data : iterationInputs) {
+//                 bindData(loopStartOutput, data);
+//             }
+//         }
+
+//         for (const auto& intermediateDataObject : intermediateDataObjects) {
+//             const auto& tensorIteratorInput = intermediateDataObject.first;
+//             const auto& vpuTensorIteratorInput = getVpuData(tensorIteratorInput);
+//             VPU_THROW_UNLESS(vpuTensorIteratorInput != nullptr, "Tensor Iterator's inputs must be parsed already");
+
+//             const auto& loopStartInput = vpuTensorIteratorInput;
+
+//             const auto& intermediateDataInputs = intermediateDataObject.second;
+//             VPU_THROW_UNLESS(allTheSame(intermediateDataInputs), "Different data objects cannot be mapped into the same data object");
+//             VPU_THROW_UNLESS(!intermediateDataInputs.empty(), "There must be at least one corresponding data object as body's input");
+
+//             const auto& intermediateDataInput = intermediateDataInputs.front();
+//             VPU_THROW_UNLESS(getVpuData(intermediateDataInput) == nullptr, "Tensor Iterator's body input data objects were not parsed yet");
+
+//             const auto& loopStartOutput = createData(intermediateDataInput);
+//             bindData(loopStartOutput, intermediateDataInput);
+
+//             // to introduce shared data allocation edge later in Middle-End
+//             loopStartInput->attrs().set<Data>("start-shared-allocation", loopStartOutput);
+
+//             loopStartInputs.push_back(loopStartInput);
+//             loopStartOutputs.push_back(loopStartOutput);
+
+//             for (const auto& data : intermediateDataInputs) {
+//                 bindData(loopStartOutput, data);
+//             }
+//         }
+
+//         auto loopStart = _stageBuilder->addLoopStartStage(model, tensorIterator->name + "@LoopStart", loopStartInputs, loopStartOutputs);
+//         loopStart->attrs().set("start-iteration-components", start_iteration_components);
+//         if (batchIdx.hasValue()) {
+//             loopStart->attrs().set("batchId", batchIdx.get());
+//         }
+
+//         for (const auto& backedge : backedges) {
+//             const auto& parent = getVpuData(backedge.first.first);
+//             VPU_THROW_UNLESS(parent != nullptr, "Loop End's inputs must be already parsed");
+
+//             const auto& child = getVpuData(backedge.second.front());
+//             VPU_THROW_UNLESS(child != nullptr, "Loop Start's outputs must be already parsed");
+
+//             const auto& src_copy = parent;
+//             auto dst_copy = model->duplicateData(child, "@copy-for-backedge");
+//             for (const auto& consumerEdge : src_copy->consumerEdges()) {
+//                 model->replaceStageInput(consumerEdge, dst_copy);
+//             }
+
+//             _stageBuilder->addCopyStage(model, "copy-for-backedge", nullptr, src_copy, dst_copy, "copy for backedge");
+
+//             // keep track of back-edges to introduce shared data allocation edges in Middle-End
+//             loopStart->attrs().getOrSet<HandleMultiMap<DataNode, Data>>("backedges", {}).emplace(dst_copy, child);
+//         }
+
+//         return loopStart;
+//     };
+
+//     auto introduceLoopEnd = [&]() -> Stage {
+//         std::map<std::pair<ie::DataPtr, IterationRule>, ie::DataPtr> iterations;
+//         std::map<ie::DataPtr, ie::DataPtr> intermediateDataObjects;
+
+//         auto loopEndInputs = DataVector{};
+
+//         const auto& bodyOutputs = tensorIterator->body.outputs;
+//         VPU_THROW_UNLESS(!bodyOutputs.empty(), "If there is no an output for Tensor Iterator's body, so there is no iteration in tensor iterator");
+
+//         for (std::size_t bodyOutputIdx = 0; bodyOutputIdx < bodyOutputs.size(); ++bodyOutputIdx) {
+//             const auto& bodyOutput = bodyOutputs[bodyOutputIdx];
+
+//             if (tensorIterator->params.count(s_condPort) && tensorIterator->GetParamAsUInt(s_condPort) == bodyOutputIdx) {
+//                 const auto& creator = getCreatorLayer(bodyOutput).lock();
+//                 if (!creator) {
+//                     // ConstTransformer leaves constant without creator
+//                     // Assume it's true
+//                     continue;
+//                 }
+//                 VPU_THROW_UNLESS(isConst(bodyOutput), "Body execution condition must be constant true");
+
+//                 VPU_THROW_UNLESS(creator->blobs.size() == 1, "Body execution condition constant must have one blob");
+//                 const auto& blob = creator->blobs.begin()->second;
+//                 VPU_THROW_UNLESS(blob->size() == 1, "Body execution condition must be single value");
+//                 VPU_THROW_UNLESS(blob->getTensorDesc().getPrecision() == InferenceEngine::Precision::I32, "Body execution condition must be I32");
+//                 const auto value = blob->buffer().as<std::int32_t*>()[0];
+//                 VPU_THROW_UNLESS(value == 1, "Body execution condition must be true");
+//                 continue;
+//             }
+
+//             VPU_THROW_UNLESS(!isFakeHolder(bodyOutput), "Fake holder can be only in body's input");
+
+//             const auto& tensorIteratorOutputs = findTIOutputsDataByBodyData(bodyOutput);
+//             VPU_THROW_UNLESS(tensorIteratorOutputs.empty() || tensorIteratorOutputs.size() == 1,
+//                 "There may be only one Tensor Iterator's output data object for body's output data object if any");
+
+//             if (tensorIteratorOutputs.empty()) {
+//                 // there can be no Tensor Iterator's output data object for body's output
+//                 // in such a case there is no consumer for this data object, however, it's not a network's output
+//                 // in this case we connect this data object with Loop End
+//                 VPU_THROW_UNLESS(!isIterable(bodyOutput, tensorIterator),
+//                     "Body's output with no corresponding Tensor Iterator's output data object cannot be iterable component");
+
+//                 auto loopEndInput = createData(bodyOutput);
+//                 bindData(loopEndInput, bodyOutput);
+//                 loopEndInputs.push_back(loopEndInput);
+//             } else {
+//                 const auto& tensorIteratorOutput = tensorIteratorOutputs.front();
+//                 if (isIterable(bodyOutput, tensorIterator)) {
+//                     const auto& rule = getOutputIterableRule(tensorIteratorOutput, bodyOutput);
+//                     auto perm = DimsOrder::fromNumDims(tensorIteratorOutput->getDims().size()).toPermutation();
+//                     auto axis = perm[tensorIteratorOutput->getDims().size() - 1 - rule.axis];
+//                     iterations[std::make_pair(tensorIteratorOutput, IterationRule{axis, rule.start, rule.stride, rule.end})] = bodyOutput;
+//                 } else {
+//                     VPU_THROW_UNLESS(intermediateDataObjects.count(tensorIteratorOutput) == 0,
+//                         "There can be only one body's output data object for Tensor Iterator's output");
+//                     VPU_THROW_UNLESS(!isConst(tensorIteratorOutput), "Tensor Iterator's body cannot have const data object as output");
+
+//                     intermediateDataObjects[tensorIteratorOutput] = bodyOutput;
+//                 }
+//             }
+//         }
+
+//         auto loopEndOutputs = DataVector{};
+
+//         vpu::Optional<std::uint32_t> batchIdx{};
+//         if (tensorIterator->params.count(s_tripCountPort)) {
+//             VPU_THROW_UNLESS(!iterations.empty(),
+//                 "Encountered Loop which is supposed to be loop by dynamic batch (dynamic iterations count), but didn't find an iteration component");
+//             VPU_THROW_UNLESS(!tensorIterator->params.count(s_curIterPort), "Current iteration port for body of Loop operation is not supported");
+//             batchIdx = static_cast<std::uint32_t>(loopEndOutputs.size());
+//         }
+
+//         IterationComponents end_iteration_components;
+//         for (const auto& iteration : iterations) {
+//             const auto& tensorIteratorOutput = iteration.first.first;
+//             const auto& rule = iteration.first.second;
+//             const auto& vpuTensorIteratorOutput = getVpuData(tensorIteratorOutput);
+//             VPU_THROW_UNLESS(vpuTensorIteratorOutput != nullptr, "Tensor Iterator's outputs must be parsed already");
+
+//             const auto& loopEndOutput = vpuTensorIteratorOutput;
+
+//             const auto& iterationInput = iteration.second;
+//             VPU_THROW_UNLESS(getVpuData(iterationInput) == nullptr, "Tensor Iterator's body output data objects were not parsed yet");
+//             auto loopEndInput = createData(iterationInput);
+
+//             end_iteration_components.emplace(std::make_pair(loopEndOutputs.size(), rule), loopEndInputs.size());
+//             loopEndInputs.push_back(loopEndInput);
+//             loopEndOutputs.push_back(loopEndOutput);
+
+//             bindData(loopEndInput, iterationInput);
+//         }
+
+//         for (const auto& intermediateDataObject : intermediateDataObjects) {
+//             const auto& tensorIteratorOutput = intermediateDataObject.first;
+//             const auto& vpuTensorIteratorOutput = getVpuData(tensorIteratorOutput);
+//             VPU_THROW_UNLESS(vpuTensorIteratorOutput != nullptr, "Tensor Iterator's outputs must be parsed already");
+
+//             auto loopEndOutput = vpuTensorIteratorOutput;
+//             if (loopEndOutput->usage() == DataUsage::Output) {
+//                 auto to_copy = model->addNewData(loopEndOutput->name() + "@copy-for-backedge", loopEndOutput->desc());
+//                 _stageBuilder->addCopyStage(model, "copy-for-tensor-iterator-output", nullptr, to_copy, loopEndOutput, "copy for TI output");
+//                 loopEndOutput = to_copy;
+//             }
+
+//             const auto& intermediateDataInput = intermediateDataObject.second;
+//             VPU_THROW_UNLESS(getVpuData(intermediateDataInput) == nullptr, "Tensor Iterator's body output data objects were not parsed yet");
+
+//             auto loopEndInput = createData(intermediateDataInput);
+
+//             // to introduce shared data allocation edge later in Middle-End
+//             loopEndOutput->attrs().set<Data>("end-shared-allocation", loopEndInput);
+
+//             loopEndInputs.push_back(loopEndInput);
+//             loopEndOutputs.push_back(loopEndOutput);
+
+//             bindData(loopEndInput, intermediateDataInput);
+//         }
+
+//         auto loopEnd = _stageBuilder->addLoopEndStage(model, tensorIterator->name + "@LoopEnd", loopEndInputs, loopEndOutputs);
+//         loopEnd->attrs().set("end-iteration-components", end_iteration_components);
+//         if (batchIdx.hasValue()) {
+//             loopEnd->attrs().set("batchId", batchIdx.get());
+//         }
+
+//         return loopEnd;
+//     };
+
+//     // Loop End must be introduced first to parse Tensor Iterator's body output data objects before parsing back-edge connections
+//     auto loopEnd = introduceLoopEnd();
+//     auto loopStart = introduceLoopStart();
+
+//     if (!tensorIterator->params.count(s_tripCountPort)) {
+//         const auto iterationsCount = getNumIteration(*tensorIterator);
+//         VPU_THROW_UNLESS(iterationsCount >= 0, "Encountered Tensor Iterator with iterations count equal to {}, but only non-negative values are supported",
+//             iterationsCount);
+//         loopStart->attrs().set<std::uint32_t>("iterations-count", static_cast<std::uint32_t>(iterationsCount));
+//         loopEnd->attrs().set<std::uint32_t>("iterations-count", static_cast<std::uint32_t>(iterationsCount));
+//     }
+
+//     // to allocate LoopEnd and LoopStart at the same time
+//     loopStart->attrs().set<Stage>("loop-end", loopEnd);
+
+//     // to be sure all loop's inputs are still alive during loop execution
+//     // force they to be alive as long as loop's outputs
+//     for (const auto& loopStartInput : loopStart->inputs()) {
+//         model->addStageInput(loopEnd, loopStartInput);
+//     }
+
+//     for (const auto& bodyLayer : ie::NetPass::TIBodySortTopologically(tensorIterator->body)) {
+//         if (bodyLayer->type == "Const") {
+//             // since Tensor Iterator's body is a kind of CNNNetwork it may has const data objects as inputs
+//             // const data objects are hold by "Const" layers
+//             // we don't need them during iteration and ignore the same way as compilation process of regular network
+//             continue;
+//         }
+
+//         auto stageInputs = DataVector{};
+//         for (const auto& data : bodyLayer->insData) {
+//             const auto ieInput = data.lock();
+//             const auto vpuInput = isConst(ieInput) ? createConstData(ieInput) : getVpuData(ieInput);
+//             VPU_THROW_UNLESS(vpuInput != nullptr,
+//                 "Non-const input of a stage must be already parsed due to either topological order or as Loop Start's output");
+
+//             stageInputs.push_back(vpuInput);
+//         }
+
+//         auto stageOutputs = DataVector{};
+//         for (const auto& data : bodyLayer->outData) {
+//             auto output = getVpuData(data);
+//             // output of a stage might be already parsed as Loop End's output
+//             if (output == nullptr) {
+//                 output = createData(data);
+//                 bindData(output, data);
+//             }
+
+//             stageOutputs.push_back(output);
+//         }
+
+//         parseLayer(model, bodyLayer, stageInputs, stageOutputs);
+//     }
+// }
+
+// }  // namespace vpu

--- a/inference-engine/src/vpu/graph_transformer/src/stages/tile.cpp
+++ b/inference-engine/src/vpu/graph_transformer/src/stages/tile.cpp
@@ -73,25 +73,88 @@ protected:
 };
 
 }  // namespace
+struct TileParams {
+    size_t axis;
+    size_t tiles;
+};
+TileParams getAxisAndTiles (const NodePtr& node) {
+        auto tile = std::dynamic_pointer_cast<ngraph::opset1::Tile> (node);
+        if (!tile) {
+        }
 
-void FrontEnd::parseTile(const Model& model, const ie::CNNLayerPtr& _layer, const DataVector& inputs, const DataVector& outputs) const {
+        auto tiles_node = std::dynamic_pointer_cast<ngraph::opset1::Constant> (tile->input_value(1).get_node_shared_ptr());
+        if (!tiles_node) {
+        }
+
+        auto tiles = tiles_node->cast_vector<int64_t>();
+        auto input_shape_rank = tile->get_input_partial_shape(0).rank().get_length();
+        int64_t cur_dim_id = tiles.size() - 1;
+
+        IE_ASSERT(!(static_cast<int64_t>(tiles.size()) != input_shape_rank));
+
+        // IE Tile operations supports only one axis to be tiled
+        // bool already_set = false;
+        // int64_t axis, tiles;
+        // for (size_t i = 0; i < input_shape.size(); ++i) {
+        //     if (shape[i] != 1) {
+        //         if (already_set) return false;
+        //         axis = i;
+        //         tiles = shape[i];
+        //         already_set = true;
+        //     }
+        // }
+        //
+        // if (!already_set) return false;
+        auto last_node = tile->input_value(0);
+        auto friendly_name = tile->get_friendly_name();
+
+        int num_of_tile_dims = 0;
+        for (auto t : tiles) {
+            if (t != 1) {
+                num_of_tile_dims++;
+            }
+        }
+        // Will generate sequence of Tile operations if num_of_tile_dims != 1
+        // because IE Tile operations supports only one axis to be tiled.
+        // To keep op name unique will use special IE specific delimiter ':'
+        // Original frameworks doesn't use such delimiter in names, so it will
+        // guarantee that newly generated name like "original_name:_1" doesn't
+        // match with already existed names.
+        if (num_of_tile_dims > 1) {
+            friendly_name += ":";
+        }
+
+        ngraph::NodeVector new_ops;
+        TileParams outTileParams;
+        auto tiles_it = tiles.rbegin();
+        while (tiles_it != tiles.rend()) {
+            int64_t tile_dim = *tiles_it;
+            if (tile_dim != 1) {
+                outTileParams.axis = cur_dim_id;
+                outTileParams.tiles = tile_dim;
+            }
+            --cur_dim_id;
+            ++tiles_it;
+        }
+        return outTileParams;
+}
+void FrontEnd::parseTile(const Model& model, const NodePtr& node, const DataVector& inputs, const DataVector& outputs) const {
+    const auto& tile = ngraph::as_type_ptr<ngraph::opset4::Tile>(node);
+    VPU_THROW_UNLESS(tile != nullptr, "Can't parse node with name %s and type %s. Node is nullptr", node->get_friendly_name(), node->get_type_name());
+    auto params = getAxisAndTiles(tile);
     IE_ASSERT(inputs.size() == 1);
     IE_ASSERT(outputs.size() == 1);
-
-    auto layer = std::dynamic_pointer_cast<ie::TileLayer>(_layer);
-    IE_ASSERT(layer != nullptr);
 
     auto input = inputs[0];
     auto output = outputs[0];
 
-    IE_ASSERT(layer->axis < input->desc().numDims());
+    IE_ASSERT(params.axis < input->desc().numDims());
 
     auto perm = DimsOrder::fromNumDims(input->desc().numDims()).toPermutation();
-    auto axis = perm[input->desc().numDims() - 1 - layer->axis];
+    auto axis = perm[input->desc().numDims() - 1 -  params.axis];
 
-    auto stage = model->addNewStage<TileStage>(layer->name, StageType::Tile, layer, {input}, {output});
+    auto stage = model->addNewStage<TileStage>(tile->get_friendly_name(), StageType::Tile, tile, {input}, {output});
     stage->attrs().set("axis", axis);
-    stage->attrs().set("tiles", layer->tiles);
+    stage->attrs().set("tiles", params.tiles);
 }
-
 }  // namespace vpu

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/detection_output.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/detection_output.cpp
@@ -1,0 +1,85 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "single_layer_tests/detection_output.hpp"
+
+using namespace LayerTestsDefinitions;
+
+namespace {
+
+const int numClasses = 11;
+const int backgroundLabelId = 0;
+const std::vector<int> topK = {75};
+const std::vector<std::vector<int>> keepTopK = { {50}, {100} };
+const std::vector<std::string> codeType = {"caffe.PriorBoxParameter.CORNER", "caffe.PriorBoxParameter.CENTER_SIZE"};
+const float nmsThreshold = 0.5f;
+const float confidenceThreshold = 0.3f;
+const std::vector<bool> clipAfterNms = {true, false};
+const std::vector<bool> clipBeforeNms = {true, false};
+const std::vector<bool> decreaseLabelId = {true, };
+const float objectnessScore = 0.4f;
+const std::vector<size_t> numberBatch = {1, };
+
+const auto commonAttributes = ::testing::Combine(
+        ::testing::Values(numClasses),
+        ::testing::Values(backgroundLabelId),
+        ::testing::ValuesIn(topK),
+        ::testing::ValuesIn(keepTopK),
+        ::testing::ValuesIn(codeType),
+        ::testing::Values(nmsThreshold),
+        ::testing::Values(confidenceThreshold),
+        ::testing::ValuesIn(clipAfterNms),
+        ::testing::ValuesIn(clipBeforeNms),
+        ::testing::ValuesIn(decreaseLabelId)
+);
+
+/* =============== 3 inputs cases =============== */
+
+const std::vector<ParamsWhichSizeDepends> specificParams3In = {
+    ParamsWhichSizeDepends{true, true, true, 1, 1, {1, 60}, {1, 165}, {1, 1, 60}, {}, {}},
+    ParamsWhichSizeDepends{true, false, true, 1, 1, {1, 660}, {1, 165}, {1, 1, 60}, {}, {}},
+    // ParamsWhichSizeDepends{false, true, true, 1, 1, {1, 60}, {1, 165}, {1, 2, 60}, {}, {}},
+    ParamsWhichSizeDepends{false, false, true, 1, 1, {1, 660}, {1, 165}, {1, 2, 60}, {}, {}},
+
+    // ParamsWhichSizeDepends{true, true, false, 10, 10, {1, 60}, {1, 165}, {1, 1, 75}, {}, {}},
+    ParamsWhichSizeDepends{true, false, false, 10, 10, {1, 660}, {1, 165}, {1, 1, 75}, {}, {}},
+    // ParamsWhichSizeDepends{false, true, false, 10, 10, {1, 60}, {1, 165}, {1, 2, 75}, {}, {}},
+    ParamsWhichSizeDepends{false, false, false, 10, 10, {1, 660}, {1, 165}, {1, 2, 75}, {}, {}}
+};
+
+const auto params3Inputs = ::testing::Combine(
+        commonAttributes,
+        ::testing::ValuesIn(specificParams3In),
+        ::testing::ValuesIn(numberBatch),
+        ::testing::Values(0.0f),
+        ::testing::Values(CommonTestUtils::DEVICE_MYRIAD)
+);
+
+INSTANTIATE_TEST_SUITE_P(smoke_DetectionOutput3In, DetectionOutputLayerTest, params3Inputs, DetectionOutputLayerTest::getTestCaseName);
+
+/* =============== 5 inputs cases =============== */
+
+const std::vector<ParamsWhichSizeDepends> specificParams5In = {
+    ParamsWhichSizeDepends{true, true, true, 1, 1, {1, 60}, {1, 165}, {1, 1, 60}, {1, 30}, {1, 60}},
+    ParamsWhichSizeDepends{true, false, true, 1, 1, {1, 660}, {1, 165}, {1, 1, 60}, {1, 30}, {1, 660}},
+    ParamsWhichSizeDepends{false, true, true, 1, 1, {1, 60}, {1, 165}, {1, 2, 60}, {1, 30}, {1, 60}},
+    ParamsWhichSizeDepends{false, false, true, 1, 1, {1, 660}, {1, 165}, {1, 2, 60}, {1, 30}, {1, 660}},
+
+    ParamsWhichSizeDepends{true, true, false, 10, 10, {1, 60}, {1, 165}, {1, 1, 75}, {1, 30}, {1, 60}},
+    ParamsWhichSizeDepends{true, false, false, 10, 10, {1, 660}, {1, 165}, {1, 1, 75}, {1, 30}, {1, 660}},
+    ParamsWhichSizeDepends{false, true, false, 10, 10, {1, 60}, {1, 165}, {1, 2, 75}, {1, 30}, {1, 60}},
+    ParamsWhichSizeDepends{false, false, false, 10, 10, {1, 660}, {1, 165}, {1, 2, 75}, {1, 30}, {1, 660}}
+};
+
+const auto params5Inputs = ::testing::Combine(
+        commonAttributes,
+        ::testing::ValuesIn(specificParams5In),
+        ::testing::ValuesIn(numberBatch),
+        ::testing::Values(objectnessScore),
+        ::testing::Values(CommonTestUtils::DEVICE_MYRIAD)
+);
+
+INSTANTIATE_TEST_SUITE_P(smoke_DetectionOutput5In, DetectionOutputLayerTest, params5Inputs, DetectionOutputLayerTest::getTestCaseName);
+
+}  // namespace

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/grn.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/grn.cpp
@@ -1,0 +1,34 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+#include "single_layer_tests/grn.hpp"
+#include "common_test_utils/test_constants.hpp"
+
+using namespace LayerTestsDefinitions;
+using namespace ngraph::helpers;
+
+namespace {
+    // Common params
+    const std::vector<InferenceEngine::Precision> netPrecisions = {
+            InferenceEngine::Precision::FP32,
+            InferenceEngine::Precision::FP16
+    };
+
+    const auto basicCases = ::testing::Combine(
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(std::vector<size_t>({ 1, 3, 30, 30 }),
+                            std::vector<size_t>({ 4, 16, 15, 20})),
+        ::testing::Values(0.33f, 1.1f),
+        ::testing::Values(CommonTestUtils::DEVICE_MYRIAD));
+
+    INSTANTIATE_TEST_SUITE_P(smoke_Grn_Basic, GrnLayerTest,
+                            basicCases,
+                            GrnLayerTest::getTestCaseName);
+
+}  // namespace

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/group_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/group_convolution.cpp
@@ -1,0 +1,157 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "common_test_utils/test_constants.hpp"
+#include "single_layer_tests/group_convolution.hpp"
+
+using namespace LayerTestsDefinitions;
+
+namespace {
+
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32, InferenceEngine::Precision::FP16,
+};
+
+/* ============= 1D GroupConvolution ============= */
+const std::vector<std::vector<size_t>> kernels1d = {{3}};
+const std::vector<std::vector<size_t>> strides1d = {{1}};
+const std::vector<std::vector<ptrdiff_t>> padBegins1d = {{0}};
+const std::vector<std::vector<ptrdiff_t>> padEnds1d = {{0}};
+const std::vector<std::vector<size_t>> dilations1d = {{1}};
+const std::vector<size_t> numOutChannels1d = {8, 16};
+const std::vector<size_t> numGroups1d = {2, 8};
+const auto inputShapes1d = std::vector<size_t>({1, 16, 30});
+
+const auto groupConv1DParams_ExplicitPadding = ::testing::Combine(
+    ::testing::ValuesIn(kernels1d), ::testing::ValuesIn(strides1d),
+    ::testing::ValuesIn(padBegins1d), ::testing::ValuesIn(padEnds1d),
+    ::testing::ValuesIn(dilations1d), ::testing::ValuesIn(numOutChannels1d),
+    ::testing::ValuesIn(numGroups1d),
+    ::testing::Values(ngraph::op::PadType::EXPLICIT));
+const auto groupConv1DParams_AutoPadValid = ::testing::Combine(
+    ::testing::ValuesIn(kernels1d), ::testing::ValuesIn(strides1d),
+    ::testing::Values(std::vector<ptrdiff_t>({0})),
+    ::testing::Values(std::vector<ptrdiff_t>({0})),
+    ::testing::ValuesIn(dilations1d), ::testing::ValuesIn(numOutChannels1d),
+    ::testing::ValuesIn(numGroups1d),
+    ::testing::Values(ngraph::op::PadType::VALID));
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_GroupConvolution1D_ExplicitPadding, GroupConvolutionLayerTest,
+    ::testing::Combine(
+        groupConv1DParams_ExplicitPadding, ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(InferenceEngine::Precision::FP16),
+        ::testing::Values(InferenceEngine::Precision::FP16),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(std::vector<size_t>(inputShapes1d)),
+        ::testing::Values(CommonTestUtils::DEVICE_MYRIAD)),
+    GroupConvolutionLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_GroupConvolution1D_AutoPadValid, GroupConvolutionLayerTest,
+    ::testing::Combine(
+        groupConv1DParams_AutoPadValid, ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(InferenceEngine::Precision::FP16),
+        ::testing::Values(InferenceEngine::Precision::FP16),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(std::vector<size_t>({1, 16, 30})),
+        ::testing::Values(CommonTestUtils::DEVICE_MYRIAD)),
+    GroupConvolutionLayerTest::getTestCaseName);
+
+/* ============= 2D GroupConvolution ============= */
+const std::vector<std::vector<size_t>> kernels = {{3, 3}};
+const std::vector<std::vector<size_t>> strides = {{1, 1}};
+const std::vector<std::vector<ptrdiff_t>> padBegins = {{0, 0}};
+const std::vector<std::vector<ptrdiff_t>> padEnds = {{0, 0}};
+const std::vector<std::vector<size_t>> dilations = {{1, 1}};
+const std::vector<size_t> numOutChannels = {8, 16};
+const std::vector<size_t> numGroups = {2, 8};
+const auto inputShapes = std::vector<size_t>({1, 16, 30, 30});
+
+const auto groupConv2DParams_ExplicitPadding = ::testing::Combine(
+    ::testing::ValuesIn(kernels), ::testing::ValuesIn(strides),
+    ::testing::ValuesIn(padBegins), ::testing::ValuesIn(padEnds),
+    ::testing::ValuesIn(dilations), ::testing::ValuesIn(numOutChannels),
+    ::testing::ValuesIn(numGroups),
+    ::testing::Values(ngraph::op::PadType::EXPLICIT));
+const auto groupConv2DParams_AutoPadValid = ::testing::Combine(
+    ::testing::ValuesIn(kernels), ::testing::ValuesIn(strides),
+    ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
+    ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
+    ::testing::ValuesIn(dilations), ::testing::ValuesIn(numOutChannels),
+    ::testing::ValuesIn(numGroups),
+    ::testing::Values(ngraph::op::PadType::VALID));
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_GroupConvolution2D_ExplicitPadding, GroupConvolutionLayerTest,
+    ::testing::Combine(
+        groupConv2DParams_ExplicitPadding, ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(InferenceEngine::Precision::FP16),
+        ::testing::Values(InferenceEngine::Precision::FP16),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(std::vector<size_t>(inputShapes)),
+        ::testing::Values(CommonTestUtils::DEVICE_MYRIAD)),
+    GroupConvolutionLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_GroupConvolution2D_AutoPadValid, GroupConvolutionLayerTest,
+    ::testing::Combine(
+        groupConv2DParams_AutoPadValid, ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(InferenceEngine::Precision::FP16),
+        ::testing::Values(InferenceEngine::Precision::FP16),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(std::vector<size_t>({1, 16, 30, 30})),
+        ::testing::Values(CommonTestUtils::DEVICE_MYRIAD)),
+    GroupConvolutionLayerTest::getTestCaseName);
+
+/* ============= 3D GroupConvolution ============= */
+const std::vector<std::vector<size_t>> kernels3d = {{3, 3, 3}};
+const std::vector<std::vector<ptrdiff_t>> paddings3d = {{0, 0, 0}};
+const std::vector<std::vector<size_t>> strides3d = {{1, 1, 1}};
+const std::vector<std::vector<size_t>> dilations3d = {{1, 1, 1}};
+const auto inputShapes3d = std::vector<size_t>({1, 4, 10, 10, 10});
+
+const auto groupConv3DParams_ExplicitPadding = ::testing::Combine(
+    ::testing::ValuesIn(kernels3d), ::testing::ValuesIn(strides3d),
+    ::testing::ValuesIn(paddings3d), ::testing::ValuesIn(paddings3d),
+    ::testing::ValuesIn(dilations3d), ::testing::Values(4),
+    ::testing::Values(2), ::testing::Values(ngraph::op::PadType::EXPLICIT));
+const auto groupConv3DParams_AutoPadValid = ::testing::Combine(
+    ::testing::ValuesIn(kernels3d), ::testing::ValuesIn(strides3d),
+    ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),
+    ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),
+    ::testing::ValuesIn(dilations3d), ::testing::Values(4),
+    ::testing::Values(2), ::testing::Values(ngraph::op::PadType::VALID));
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_GroupConvolution3D_ExplicitPadding, GroupConvolutionLayerTest,
+    ::testing::Combine(
+        groupConv3DParams_ExplicitPadding, ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(InferenceEngine::Precision::FP16),
+        ::testing::Values(InferenceEngine::Precision::FP16),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(std::vector<size_t>(inputShapes3d)),
+        ::testing::Values(CommonTestUtils::DEVICE_MYRIAD)),
+    GroupConvolutionLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_GroupConvolution3D_AutoPadValid, GroupConvolutionLayerTest,
+    ::testing::Combine(
+        groupConv3DParams_AutoPadValid, ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(InferenceEngine::Precision::FP16),
+        ::testing::Values(InferenceEngine::Precision::FP16),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(std::vector<size_t>({1, 4, 10, 10, 10})),
+        ::testing::Values(CommonTestUtils::DEVICE_MYRIAD)),
+    GroupConvolutionLayerTest::getTestCaseName);
+
+}  // namespace

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/lrn.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/lrn.cpp
@@ -1,0 +1,95 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "single_layer_tests/lrn.hpp"
+
+#include <vector>
+
+#include "common_test_utils/test_constants.hpp"
+
+using namespace LayerTestsDefinitions;
+
+const std::vector<InferenceEngine::Precision> netPrecisions{
+    InferenceEngine::Precision::FP32
+};
+const double alpha = 9.9e-05;
+const double beta = 2;
+const double bias = 1.0;
+const size_t size = 5;
+
+// namespace LRN2D {
+
+// const std::vector<std::vector<int64_t>> axes = {{1}};
+
+// INSTANTIATE_TEST_SUITE_P(smoke_LrnCheck_2D, LrnLayerTest,
+//                         ::testing::Combine(::testing::Values(alpha),
+//                                            ::testing::Values(beta),
+//                                            ::testing::Values(bias),
+//                                            ::testing::Values(size),
+//                                            ::testing::ValuesIn(axes),
+//                                            ::testing::ValuesIn(netPrecisions),
+//                                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+//                                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+//                                            ::testing::Values(std::vector<size_t>({10, 16})),
+//                                            ::testing::Values(CommonTestUtils::DEVICE_MYRIAD)),
+//                         LrnLayerTest::getTestCaseName);
+
+// } // namespace LRN2D
+
+// namespace LRN3D {
+
+// const std::vector<std::vector<int64_t>> axes = {{1}, {2}};
+
+// INSTANTIATE_TEST_SUITE_P(smoke_LrnCheck_3D, LrnLayerTest,
+//                         ::testing::Combine(::testing::Values(alpha),
+//                                            ::testing::Values(beta),
+//                                            ::testing::Values(bias),
+//                                            ::testing::Values(size),
+//                                            ::testing::ValuesIn(axes),
+//                                            ::testing::ValuesIn(netPrecisions),
+//                                            ::testing::Values(InferenceEngine::Precision::FP16),
+//                                            ::testing::Values(InferenceEngine::Precision::FP16),
+//                                            ::testing::Values(std::vector<size_t>({6, 10, 16})),
+//                                            ::testing::Values(CommonTestUtils::DEVICE_MYRIAD)),
+//                         LrnLayerTest::getTestCaseName);
+
+// } // namespace LRN3D
+
+namespace LRN4D {
+
+const std::vector<std::vector<int64_t>> axes = {{1}, {2, 3}, {3, 2}};
+
+INSTANTIATE_TEST_SUITE_P(smoke_LrnCheck_4D, LrnLayerTest,
+                        ::testing::Combine(::testing::Values(alpha),
+                                           ::testing::Values(beta),
+                                           ::testing::Values(bias),
+                                           ::testing::Values(size),
+                                           ::testing::ValuesIn(axes),
+                                           ::testing::ValuesIn(netPrecisions),
+                                           ::testing::Values(InferenceEngine::Precision::FP16),
+                                           ::testing::Values(InferenceEngine::Precision::FP16),
+                                           ::testing::Values(std::vector<size_t>({10, 10, 3, 8})),
+                                           ::testing::Values(CommonTestUtils::DEVICE_MYRIAD)),
+                        LrnLayerTest::getTestCaseName);
+
+} // namespace LRN4D
+
+namespace LRN5D {
+
+const std::vector<std::vector<int64_t>> axes = {{1}, {2, 3, 4}, {4, 2, 3}};
+
+INSTANTIATE_TEST_SUITE_P(smoke_LrnCheck_5D, LrnLayerTest,
+                        ::testing::Combine(::testing::Values(alpha),
+                                           ::testing::Values(beta),
+                                           ::testing::Values(bias),
+                                           ::testing::Values(size),
+                                           ::testing::ValuesIn(axes),
+                                           ::testing::ValuesIn(netPrecisions),
+                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+                                           ::testing::Values(std::vector<size_t>({1, 10, 10, 7, 4})),
+                                           ::testing::Values(CommonTestUtils::DEVICE_MYRIAD)),
+                        LrnLayerTest::getTestCaseName);
+
+} // namespace LRN5D

--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/softmax.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/softmax.cpp
@@ -1,0 +1,80 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "single_layer_tests/softmax.hpp"
+#include "common_test_utils/test_constants.hpp"
+
+using namespace LayerTestsDefinitions;
+
+namespace {
+
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP16,
+};
+
+const std::vector<InferenceEngine::Layout> inputLayouts2D = {
+    InferenceEngine::Layout::NC,
+};
+
+const std::vector<InferenceEngine::SizeVector> inputShapes2D = {
+    InferenceEngine::SizeVector {1, 100},
+    InferenceEngine::SizeVector {100, 1},
+    InferenceEngine::SizeVector {10, 10},
+};
+
+const std::vector<size_t> axis2D = {
+    0, 1
+};
+
+const auto params2D = testing::Combine(
+    testing::ValuesIn(netPrecisions),
+    testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+    testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+    testing::ValuesIn(inputLayouts2D),
+    testing::Values(InferenceEngine::Layout::ANY),
+    testing::ValuesIn(inputShapes2D),
+    testing::ValuesIn(axis2D),
+    testing::Values(CommonTestUtils::DEVICE_MYRIAD),
+    testing::Values(std::map<std::string, std::string>())
+);
+
+INSTANTIATE_TEST_SUITE_P(
+        smoke_SoftMax2D,
+        SoftMaxLayerTest,
+        params2D,
+        SoftMaxLayerTest::getTestCaseName
+);
+
+const std::vector<InferenceEngine::SizeVector> inputShapes4D = {
+    InferenceEngine::SizeVector {1, 100, 1, 1},
+    InferenceEngine::SizeVector {1, 3, 4, 3},
+    InferenceEngine::SizeVector {2, 3, 4, 5},
+    InferenceEngine::SizeVector {1, 1, 32, 32},
+    InferenceEngine::SizeVector {1, 1024, 7, 7}
+};
+
+const std::vector<size_t> axis4D = {0, 1, 2, 3};
+
+const auto params4D = testing::Combine(
+    testing::ValuesIn(netPrecisions),
+    testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+    testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+    testing::Values(InferenceEngine::Layout::NCHW),
+    testing::Values(InferenceEngine::Layout::ANY),
+    testing::ValuesIn(inputShapes4D),
+    testing::ValuesIn(axis4D),
+    testing::Values(CommonTestUtils::DEVICE_MYRIAD),
+    testing::Values(std::map<std::string, std::string>())
+);
+
+INSTANTIATE_TEST_SUITE_P(
+        smoke_SoftMax4D,
+        SoftMaxLayerTest,
+        params4D,
+        SoftMaxLayerTest::getTestCaseName
+);
+
+}  // namespace

--- a/inference-engine/tests/functional/plugin/myriad/single_layer_tests/static_shape_nms.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/single_layer_tests/static_shape_nms.cpp
@@ -89,7 +89,7 @@ protected:
 
         const auto staticShapeNMS = std::make_shared<ngraph::vpu::op::StaticShapeNonMaxSuppression>(
                 inputBoxes, inputScores, maxOutputBoxesPerClassConst, iouThresholdConst, scoreThresholdConst, softNMSSigmaConst,
-                0, false, ngraph::element::i32);
+                ngraph::op::v5::NonMaxSuppression::BoxEncodingType::CENTER, false, ngraph::element::i32);
 
         ngraph::ResultVector results{std::make_shared<ngraph::opset3::Result>(staticShapeNMS->output(0)),
                                      std::make_shared<ngraph::opset3::Result>(staticShapeNMS->output(1))};

--- a/inference-engine/tests/unit/vpu/base/graph_transformer_tests.cpp
+++ b/inference-engine/tests/unit/vpu/base/graph_transformer_tests.cpp
@@ -1,362 +1,362 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
-
-#include "graph_transformer_tests.hpp"
-
-#include <vpu/utils/io.hpp>
-
-#include <vpu/configuration/options/log_level.hpp>
-#include <vpu/configuration/options/copy_optimization.hpp>
-
-#include <atomic>
-#include <iomanip>
-
-namespace vpu {
-
-StagePtr TestStage::cloneImpl() const {
-    return std::make_shared<TestStage>(*this);
-}
-
-namespace {
-
-template <typename Value>
-void setInOutPortInfo(
-        const Stage& stage,
-        const std::string& attrBaseName,
-        StageDataInfo<Value>& info) {
-    auto inAttrName = formatString("test_input_%s_info", attrBaseName);
-    auto outAttrName = formatString("test_output_%s_info", attrBaseName);
-
-    if (stage->attrs().has(inAttrName)) {
-        const auto& inputInfo = stage->attrs().get<InOutPortMap<Value>>(inAttrName);
-
-        for (const auto& p : inputInfo) {
-            info.setInput(stage->inputEdge(p.first), p.second);
-        }
-    }
-
-    if (stage->attrs().has(outAttrName)) {
-        const auto& outputInfo = stage->attrs().get<InOutPortMap<Value>>(outAttrName);
-
-        for (const auto& p : outputInfo) {
-            info.setOutput(stage->outputEdge(p.first), p.second);
-        }
-    }
-}
-
-} // namespace
-
-InputInfo InputInfo::fromNetwork(int ind) {
-    InputInfo info;
-    info.type = InputType::Original;
-    info.originalInputInd = ind;
-    return info;
-}
-
-InputInfo InputInfo::fromPrevStage(int ind, int outputInd) {
-    InputInfo info;
-    info.type = InputType::PrevStageOutput;
-    info.prevStageInd = ind;
-    info.prevStageOutputInd = outputInd;
-    return info;
-}
-
-InputInfo& InputInfo::output(int ind) {
-    assert(type == InputType::PrevStageOutput);
-    prevStageOutputInd = ind;
-    return *this;
-}
-
-OutputInfo OutputInfo::fromNetwork(int ind) {
-    OutputInfo info;
-    info.type = OutputType::Original;
-    info.originalOutputInd = ind;
-    return info;
-}
-
-InputInfo InputInfo::constant(const DataDesc& desc) {
-    InputInfo info;
-    info.type = InputType::Constant;
-    info.desc = desc;
-    return info;
-}
-
-OutputInfo OutputInfo::intermediate(const DataDesc& desc) {
-    OutputInfo info;
-    info.type = OutputType::Intermediate;
-    info.desc = desc;
-    return info;
-}
-
-OutputInfo OutputInfo::intermediate(MemoryType memReq) {
-    OutputInfo info;
-    info.type = OutputType::Intermediate;
-    info.desc = DataDesc{};
-    info.memReq = memReq;
-    return info;
-}
-
-void TestStage::propagateDataOrderImpl(StageDataInfo<DimsOrder>& orderInfo) {
-    setInOutPortInfo(this, "DataOrder", orderInfo);
-}
-
-void TestStage::getDataStridesRequirementsImpl(StageDataInfo<StridesRequirement>& stridesInfo) {
-    setInOutPortInfo(this, "Strides", stridesInfo);
-}
-
-void TestStage::finalizeDataLayoutImpl() {
-}
-
-void TestStage::getBatchSupportInfoImpl(StageDataInfo<BatchSupport>& batchInfo) {
-    setInOutPortInfo(this, "Batch", batchInfo);
-
-    if (attrs().has("test_input_Batch_info")) {
-        for (const auto& outEdge : outputEdges()) {
-            batchInfo.setOutput(outEdge, BatchSupport::Split);
-        }
-    }
-}
-
-void TestStage::serializeParamsImpl(BlobSerializer&) const {
-}
-
-void TestStage::serializeDataImpl(BlobSerializer&) const {
-}
-
-TestModel::TestModel(const Model& model) : _model(model) {}
-
-const Model& TestModel::getBaseModel() const {
-    return _model;
-}
-
-const DataVector& TestModel::getInputs() const {
-    return _inputs;
-}
-
-const DataVector& TestModel::getOutputs() const {
-    return _outputs;
-}
-
-const StageVector& TestModel::getStages() const {
-    return _stages;
-}
-
-void TestModel::createInputs(std::vector<DataDesc> descriptors) {
-    const auto& inputDescs = descriptors.empty() ? std::vector<DataDesc>{DataDesc{}} : descriptors;
-    const auto numInputs = inputDescs.size();
-
-    _model->attrs().set<int>("numInputs", numInputs);
-    _inputs.resize(numInputs);
-
-    for (int i = 0; i < numInputs; ++i) {
-        _inputs[i] = _model->addInputData(formatString("Input %d", i), inputDescs[i]);
-    }
-}
-
-void TestModel::createOutputs(std::vector<DataDesc> descriptors) {
-    const auto& outputDescs = descriptors.empty() ? std::vector<DataDesc>{DataDesc{}} : descriptors;
-    const auto numOutputs = outputDescs.size();
-
-    _model->attrs().set<int>("numOutputs", numOutputs);
-    _outputs.resize(numOutputs);
-
-    for (int i = 0; i < numOutputs; ++i) {
-        _outputs[i] = _model->addOutputData(formatString("Output %d", i), outputDescs[i]);
-    }
-}
-
-Stage TestModel::addStage(
-        const std::vector<InputInfo>& curInputInfos,
-        const std::vector<OutputInfo>& curOutputInfos,
-        StageType stageType) {
-    DataVector curInputs;
-    for (const auto& info : curInputInfos) {
-        if (info.type == InputType::Original) {
-            curInputs.push_back(_inputs.at(info.originalInputInd));
-        } else if (info.type == InputType::Constant) {
-            curInputs.push_back(_model->addConstData(formatString("Const {} / {}", _stages.size(), curInputs.size()), info.desc));
-        } else {
-            curInputs.push_back(_stages.at(info.prevStageInd)->output(info.prevStageOutputInd));
-        }
-    }
-
-    DataVector curOutputs;
-    for (const auto& info : curOutputInfos) {
-        if (info.type == OutputType::Original) {
-            curOutputs.push_back(_outputs.at(info.originalOutputInd));
-        } else {
-            auto data = _model->addNewData(formatString("Data %d / %d", _stages.size(), curOutputs.size()), info.desc);
-            data->setMemReqs(info.memReq);
-            curOutputs.push_back(std::move(data));
-        }
-    }
-
-    auto stage = _model->addNewStage<TestStage>(
-            formatString("Stage %m%m%d", std::setw(2), std::setfill('0'), _stages.size()),
-            stageType,
-            nullptr,
-            curInputs,
-            curOutputs);
-    stage->attrs().set<int>("test_ind", _stages.size());
-
-    _stages.push_back(stage);
-
-    return stage;
-}
-void TestModel::setStageDataOrderInfo(
-        int stageInd,
-        const InOutPortMap<DimsOrder>& inputInfo,
-        const InOutPortMap<DimsOrder>& outputInfo) {
-    if (!inputInfo.empty()) {
-        _stages.at(stageInd)->attrs().set("test_input_DataOrder_info", inputInfo);
-    }
-    if (!outputInfo.empty()) {
-        _stages.at(stageInd)->attrs().set("test_input_DataOrder_info", outputInfo);
-    }
-}
-
-void TestModel::setStageStridesInfo(
-        int stageInd,
-        const InOutPortMap<StridesRequirement>& inputInfo,
-        const InOutPortMap<StridesRequirement>& outputInfo) {
-    if (!inputInfo.empty()) {
-        _stages.at(stageInd)->attrs().set("test_input_Strides_info", inputInfo);
-    }
-    if (!outputInfo.empty()) {
-        _stages.at(stageInd)->attrs().set("test_input_Strides_info", outputInfo);
-    }
-}
-
-void TestModel::setStageBatchInfo(
-        int stageInd,
-        const InOutPortMap<BatchSupport>& inputInfo) {
-    if (!inputInfo.empty()) {
-        _stages.at(stageInd)->attrs().set("test_input_Batch_info", inputInfo);
-    }
-}
-
-template <class StageRange>
-void checkStageTestInds(const StageRange& stageRange, std::initializer_list<int> expectedInds) {
-    auto stageVector = toVector(stageRange);
-
-    ASSERT_EQ(expectedInds.size(), stageVector.size());
-
-    size_t stageInd = 0;
-    for (auto expectedInd : expectedInds) {
-        ASSERT_EQ(expectedInd, stageVector[stageInd]->attrs().template get<int>("test_ind"));
-        ++stageInd;
-    }
-}
-
-template <class StageRange>
-void checkStageTestInds(const StageRange& stageRange, std::initializer_list<int> expectedInds, const std::function<void(const Stage&)>& extraCheck) {
-    auto stageVector = toVector(stageRange);
-
-    ASSERT_EQ(expectedInds.size(), stageVector.size());
-
-    size_t stageInd = 0;
-    for (auto expectedInd : expectedInds) {
-        ASSERT_EQ(expectedInd, stageVector[stageInd]->attrs().template get<int>("test_ind"));
-        ++stageInd;
-
-        ASSERT_NO_FATAL_FAILURE(extraCheck(stageVector[stageInd]));
-    }
-}
-
-bool checkExecutionOrder(const Model& model, const std::vector<int>& execOrder) {
-    auto it = execOrder.begin();
-
-    for (const auto& stage : model->getStages()) {
-        if (it == execOrder.end()) {
-            return true;
-        }
-
-        if (stage->id() == *it) {
-            ++it;
-        }
-    }
-
-    return it == execOrder.end();
-}
-
-void GraphTransformerTest::SetUp() {
-    _log = std::make_shared<Logger>(
-            "Test",
-            LogLevel::Debug,
-            consoleOutput());
-
-    stageBuilder = std::make_shared<StageBuilder>();
-    frontEnd = std::make_shared<FrontEnd>(stageBuilder, &_mockCore);
-    backEnd = std::make_shared<BackEnd>();
-    passManager = std::make_shared<PassManager>(stageBuilder, backEnd);
-
-    config = createConfiguration();
-}
-
-void GraphTransformerTest::TearDown() {
-    for (const auto& model : _models) {
-        backEnd->dumpModel(model);
-    }
-
-    if (compileEnvInitialized) {
-        CompileEnv::free();
-    }
-}
-
-void GraphTransformerTest::InitCompileEnv() {
-    if (const auto envVar = std::getenv("IE_VPU_DUMP_INTERNAL_GRAPH_FILE_NAME")) {
-        config.compileConfig().dumpInternalGraphFileName = envVar;
-    }
-    if (const auto envVar = std::getenv("IE_VPU_DUMP_INTERNAL_GRAPH_DIRECTORY")) {
-        config.compileConfig().dumpInternalGraphDirectory = envVar;
-    }
-    if (const auto envVar = std::getenv("IE_VPU_DUMP_ALL_PASSES")) {
-        config.compileConfig().dumpAllPasses = std::stoi(envVar) != 0;
-    }
-
-    CompileEnv::init(platform, config, _log);
-    compileEnvInitialized = true;
-}
-
-namespace {
-
-    std::atomic<int> g_counter(0);
-
-}
-
-Model GraphTransformerTest::CreateModel() {
-    const auto& env = CompileEnv::get();
-
-    auto unitTest = testing::UnitTest::GetInstance();
-    IE_ASSERT(unitTest != nullptr);
-    auto curTestInfo = unitTest->current_test_info();
-    IE_ASSERT(curTestInfo != nullptr);
-
-    auto model = std::make_shared<ModelObj>(
-            formatString("%s/%s", curTestInfo->test_case_name(), curTestInfo->name()));
-    model->attrs().set<int>("index", g_counter.fetch_add(1));
-    model->attrs().set<Resources>("resources", env.resources);
-
-    _models.push_back(model);
-
-    return model;
-}
-
-TestModel GraphTransformerTest::CreateTestModel() {
-    return TestModel(CreateModel());
-}
-
-PluginConfiguration createConfiguration() {
-    PluginConfiguration configuration;
-    configuration.registerOption<LogLevelOption>();
-    configuration.registerOption<CopyOptimizationOption>();
-
-IE_SUPPRESS_DEPRECATED_START
-    configuration.registerDeprecatedOption<LogLevelOption>(VPU_CONFIG_KEY(LOG_LEVEL));
-IE_SUPPRESS_DEPRECATED_END
-
-    return configuration;
-}
-
-} // namespace vpu
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
+
+// #include "graph_transformer_tests.hpp"
+
+// #include <vpu/utils/io.hpp>
+
+// #include <vpu/configuration/options/log_level.hpp>
+// #include <vpu/configuration/options/copy_optimization.hpp>
+
+// #include <atomic>
+// #include <iomanip>
+
+// namespace vpu {
+
+// StagePtr TestStage::cloneImpl() const {
+//     return std::make_shared<TestStage>(*this);
+// }
+
+// namespace {
+
+// template <typename Value>
+// void setInOutPortInfo(
+//         const Stage& stage,
+//         const std::string& attrBaseName,
+//         StageDataInfo<Value>& info) {
+//     auto inAttrName = formatString("test_input_%s_info", attrBaseName);
+//     auto outAttrName = formatString("test_output_%s_info", attrBaseName);
+
+//     if (stage->attrs().has(inAttrName)) {
+//         const auto& inputInfo = stage->attrs().get<InOutPortMap<Value>>(inAttrName);
+
+//         for (const auto& p : inputInfo) {
+//             info.setInput(stage->inputEdge(p.first), p.second);
+//         }
+//     }
+
+//     if (stage->attrs().has(outAttrName)) {
+//         const auto& outputInfo = stage->attrs().get<InOutPortMap<Value>>(outAttrName);
+
+//         for (const auto& p : outputInfo) {
+//             info.setOutput(stage->outputEdge(p.first), p.second);
+//         }
+//     }
+// }
+
+// } // namespace
+
+// InputInfo InputInfo::fromNetwork(int ind) {
+//     InputInfo info;
+//     info.type = InputType::Original;
+//     info.originalInputInd = ind;
+//     return info;
+// }
+
+// InputInfo InputInfo::fromPrevStage(int ind, int outputInd) {
+//     InputInfo info;
+//     info.type = InputType::PrevStageOutput;
+//     info.prevStageInd = ind;
+//     info.prevStageOutputInd = outputInd;
+//     return info;
+// }
+
+// InputInfo& InputInfo::output(int ind) {
+//     assert(type == InputType::PrevStageOutput);
+//     prevStageOutputInd = ind;
+//     return *this;
+// }
+
+// OutputInfo OutputInfo::fromNetwork(int ind) {
+//     OutputInfo info;
+//     info.type = OutputType::Original;
+//     info.originalOutputInd = ind;
+//     return info;
+// }
+
+// InputInfo InputInfo::constant(const DataDesc& desc) {
+//     InputInfo info;
+//     info.type = InputType::Constant;
+//     info.desc = desc;
+//     return info;
+// }
+
+// OutputInfo OutputInfo::intermediate(const DataDesc& desc) {
+//     OutputInfo info;
+//     info.type = OutputType::Intermediate;
+//     info.desc = desc;
+//     return info;
+// }
+
+// OutputInfo OutputInfo::intermediate(MemoryType memReq) {
+//     OutputInfo info;
+//     info.type = OutputType::Intermediate;
+//     info.desc = DataDesc{};
+//     info.memReq = memReq;
+//     return info;
+// }
+
+// void TestStage::propagateDataOrderImpl(StageDataInfo<DimsOrder>& orderInfo) {
+//     setInOutPortInfo(this, "DataOrder", orderInfo);
+// }
+
+// void TestStage::getDataStridesRequirementsImpl(StageDataInfo<StridesRequirement>& stridesInfo) {
+//     setInOutPortInfo(this, "Strides", stridesInfo);
+// }
+
+// void TestStage::finalizeDataLayoutImpl() {
+// }
+
+// void TestStage::getBatchSupportInfoImpl(StageDataInfo<BatchSupport>& batchInfo) {
+//     setInOutPortInfo(this, "Batch", batchInfo);
+
+//     if (attrs().has("test_input_Batch_info")) {
+//         for (const auto& outEdge : outputEdges()) {
+//             batchInfo.setOutput(outEdge, BatchSupport::Split);
+//         }
+//     }
+// }
+
+// void TestStage::serializeParamsImpl(BlobSerializer&) const {
+// }
+
+// void TestStage::serializeDataImpl(BlobSerializer&) const {
+// }
+
+// TestModel::TestModel(const Model& model) : _model(model) {}
+
+// const Model& TestModel::getBaseModel() const {
+//     return _model;
+// }
+
+// const DataVector& TestModel::getInputs() const {
+//     return _inputs;
+// }
+
+// const DataVector& TestModel::getOutputs() const {
+//     return _outputs;
+// }
+
+// const StageVector& TestModel::getStages() const {
+//     return _stages;
+// }
+
+// void TestModel::createInputs(std::vector<DataDesc> descriptors) {
+//     const auto& inputDescs = descriptors.empty() ? std::vector<DataDesc>{DataDesc{}} : descriptors;
+//     const auto numInputs = inputDescs.size();
+
+//     _model->attrs().set<int>("numInputs", numInputs);
+//     _inputs.resize(numInputs);
+
+//     for (int i = 0; i < numInputs; ++i) {
+//         _inputs[i] = _model->addInputData(formatString("Input %d", i), inputDescs[i]);
+//     }
+// }
+
+// void TestModel::createOutputs(std::vector<DataDesc> descriptors) {
+//     const auto& outputDescs = descriptors.empty() ? std::vector<DataDesc>{DataDesc{}} : descriptors;
+//     const auto numOutputs = outputDescs.size();
+
+//     _model->attrs().set<int>("numOutputs", numOutputs);
+//     _outputs.resize(numOutputs);
+
+//     for (int i = 0; i < numOutputs; ++i) {
+//         _outputs[i] = _model->addOutputData(formatString("Output %d", i), outputDescs[i]);
+//     }
+// }
+
+// Stage TestModel::addStage(
+//         const std::vector<InputInfo>& curInputInfos,
+//         const std::vector<OutputInfo>& curOutputInfos,
+//         StageType stageType) {
+//     DataVector curInputs;
+//     for (const auto& info : curInputInfos) {
+//         if (info.type == InputType::Original) {
+//             curInputs.push_back(_inputs.at(info.originalInputInd));
+//         } else if (info.type == InputType::Constant) {
+//             curInputs.push_back(_model->addConstData(formatString("Const {} / {}", _stages.size(), curInputs.size()), info.desc));
+//         } else {
+//             curInputs.push_back(_stages.at(info.prevStageInd)->output(info.prevStageOutputInd));
+//         }
+//     }
+
+//     DataVector curOutputs;
+//     for (const auto& info : curOutputInfos) {
+//         if (info.type == OutputType::Original) {
+//             curOutputs.push_back(_outputs.at(info.originalOutputInd));
+//         } else {
+//             auto data = _model->addNewData(formatString("Data %d / %d", _stages.size(), curOutputs.size()), info.desc);
+//             data->setMemReqs(info.memReq);
+//             curOutputs.push_back(std::move(data));
+//         }
+//     }
+
+//     auto stage = _model->addNewStage<TestStage>(
+//             formatString("Stage %m%m%d", std::setw(2), std::setfill('0'), _stages.size()),
+//             stageType,
+//             nullptr,
+//             curInputs,
+//             curOutputs);
+//     stage->attrs().set<int>("test_ind", _stages.size());
+
+//     _stages.push_back(stage);
+
+//     return stage;
+// }
+// void TestModel::setStageDataOrderInfo(
+//         int stageInd,
+//         const InOutPortMap<DimsOrder>& inputInfo,
+//         const InOutPortMap<DimsOrder>& outputInfo) {
+//     if (!inputInfo.empty()) {
+//         _stages.at(stageInd)->attrs().set("test_input_DataOrder_info", inputInfo);
+//     }
+//     if (!outputInfo.empty()) {
+//         _stages.at(stageInd)->attrs().set("test_input_DataOrder_info", outputInfo);
+//     }
+// }
+
+// void TestModel::setStageStridesInfo(
+//         int stageInd,
+//         const InOutPortMap<StridesRequirement>& inputInfo,
+//         const InOutPortMap<StridesRequirement>& outputInfo) {
+//     if (!inputInfo.empty()) {
+//         _stages.at(stageInd)->attrs().set("test_input_Strides_info", inputInfo);
+//     }
+//     if (!outputInfo.empty()) {
+//         _stages.at(stageInd)->attrs().set("test_input_Strides_info", outputInfo);
+//     }
+// }
+
+// void TestModel::setStageBatchInfo(
+//         int stageInd,
+//         const InOutPortMap<BatchSupport>& inputInfo) {
+//     if (!inputInfo.empty()) {
+//         _stages.at(stageInd)->attrs().set("test_input_Batch_info", inputInfo);
+//     }
+// }
+
+// template <class StageRange>
+// void checkStageTestInds(const StageRange& stageRange, std::initializer_list<int> expectedInds) {
+//     auto stageVector = toVector(stageRange);
+
+//     ASSERT_EQ(expectedInds.size(), stageVector.size());
+
+//     size_t stageInd = 0;
+//     for (auto expectedInd : expectedInds) {
+//         ASSERT_EQ(expectedInd, stageVector[stageInd]->attrs().template get<int>("test_ind"));
+//         ++stageInd;
+//     }
+// }
+
+// template <class StageRange>
+// void checkStageTestInds(const StageRange& stageRange, std::initializer_list<int> expectedInds, const std::function<void(const Stage&)>& extraCheck) {
+//     auto stageVector = toVector(stageRange);
+
+//     ASSERT_EQ(expectedInds.size(), stageVector.size());
+
+//     size_t stageInd = 0;
+//     for (auto expectedInd : expectedInds) {
+//         ASSERT_EQ(expectedInd, stageVector[stageInd]->attrs().template get<int>("test_ind"));
+//         ++stageInd;
+
+//         ASSERT_NO_FATAL_FAILURE(extraCheck(stageVector[stageInd]));
+//     }
+// }
+
+// bool checkExecutionOrder(const Model& model, const std::vector<int>& execOrder) {
+//     auto it = execOrder.begin();
+
+//     for (const auto& stage : model->getStages()) {
+//         if (it == execOrder.end()) {
+//             return true;
+//         }
+
+//         if (stage->id() == *it) {
+//             ++it;
+//         }
+//     }
+
+//     return it == execOrder.end();
+// }
+
+// void GraphTransformerTest::SetUp() {
+//     _log = std::make_shared<Logger>(
+//             "Test",
+//             LogLevel::Debug,
+//             consoleOutput());
+
+//     stageBuilder = std::make_shared<StageBuilder>();
+//     frontEnd = std::make_shared<FrontEnd>(stageBuilder, &_mockCore);
+//     backEnd = std::make_shared<BackEnd>();
+//     passManager = std::make_shared<PassManager>(stageBuilder, backEnd);
+
+//     config = createConfiguration();
+// }
+
+// void GraphTransformerTest::TearDown() {
+//     for (const auto& model : _models) {
+//         backEnd->dumpModel(model);
+//     }
+
+//     if (compileEnvInitialized) {
+//         CompileEnv::free();
+//     }
+// }
+
+// void GraphTransformerTest::InitCompileEnv() {
+//     if (const auto envVar = std::getenv("IE_VPU_DUMP_INTERNAL_GRAPH_FILE_NAME")) {
+//         config.compileConfig().dumpInternalGraphFileName = envVar;
+//     }
+//     if (const auto envVar = std::getenv("IE_VPU_DUMP_INTERNAL_GRAPH_DIRECTORY")) {
+//         config.compileConfig().dumpInternalGraphDirectory = envVar;
+//     }
+//     if (const auto envVar = std::getenv("IE_VPU_DUMP_ALL_PASSES")) {
+//         config.compileConfig().dumpAllPasses = std::stoi(envVar) != 0;
+//     }
+
+//     CompileEnv::init(platform, config, _log);
+//     compileEnvInitialized = true;
+// }
+
+// namespace {
+
+//     std::atomic<int> g_counter(0);
+
+// }
+
+// Model GraphTransformerTest::CreateModel() {
+//     const auto& env = CompileEnv::get();
+
+//     auto unitTest = testing::UnitTest::GetInstance();
+//     IE_ASSERT(unitTest != nullptr);
+//     auto curTestInfo = unitTest->current_test_info();
+//     IE_ASSERT(curTestInfo != nullptr);
+
+//     auto model = std::make_shared<ModelObj>(
+//             formatString("%s/%s", curTestInfo->test_case_name(), curTestInfo->name()));
+//     model->attrs().set<int>("index", g_counter.fetch_add(1));
+//     model->attrs().set<Resources>("resources", env.resources);
+
+//     _models.push_back(model);
+
+//     return model;
+// }
+
+// TestModel GraphTransformerTest::CreateTestModel() {
+//     return TestModel(CreateModel());
+// }
+
+// PluginConfiguration createConfiguration() {
+//     PluginConfiguration configuration;
+//     configuration.registerOption<LogLevelOption>();
+//     configuration.registerOption<CopyOptimizationOption>();
+
+// IE_SUPPRESS_DEPRECATED_START
+//     configuration.registerDeprecatedOption<LogLevelOption>(VPU_CONFIG_KEY(LOG_LEVEL));
+// IE_SUPPRESS_DEPRECATED_END
+
+//     return configuration;
+// }
+
+// } // namespace vpu

--- a/inference-engine/tests/unit/vpu/base/graph_transformer_tests.hpp
+++ b/inference-engine/tests/unit/vpu/base/graph_transformer_tests.hpp
@@ -1,162 +1,176 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
 
-#pragma once
+// #pragma once
 
-#include <list>
+// #include <list>
 
-#include <gtest/gtest.h>
+// #include <gtest/gtest.h>
 
-#include <vpu/compile_env.hpp>
-#include <vpu/model/stage.hpp>
-#include <vpu/model/model.hpp>
-#include <vpu/frontend/frontend.hpp>
-#include <vpu/middleend/pass_manager.hpp>
-#include <vpu/backend/backend.hpp>
-#include <vpu/utils/ie_helpers.hpp>
+// #include <vpu/compile_env.hpp>
+// #include <vpu/model/stage.hpp>
+// #include <vpu/model/model.hpp>
+// #include <vpu/frontend/frontend.hpp>
+// #include <vpu/middleend/pass_manager.hpp>
+// #include <vpu/backend/backend.hpp>
+// #include <vpu/utils/ie_helpers.hpp>
 
-#include <unit_test_utils/mocks/cpp_interfaces/interface/mock_icore.hpp>
+// #include <unit_test_utils/mocks/cpp_interfaces/interface/mock_icore.hpp>
 
-namespace vpu {
+// namespace vpu {
 
-template <typename Value>
-using InOutPortMap = std::unordered_map<int, Value>;
+// template <typename Value>
+// using InOutPortMap = std::unordered_map<int, Value>;
 
-class TestStage final : public StageNode {
-public:
-    using StageNode::StageNode;
+// class TestStage final : public StageNode {
+// public:
+//     using StageNode::StageNode;
 
-private:
-    StagePtr cloneImpl() const override;
+// private:
+//     StagePtr cloneImpl() const override;
 
-    void propagateDataOrderImpl(StageDataInfo<DimsOrder>& orderInfo) override;
+//     void propagateDataOrderImpl(StageDataInfo<DimsOrder>& orderInfo) override;
 
-    void getDataStridesRequirementsImpl(StageDataInfo<StridesRequirement>& stridesInfo) override;
+//     void getDataStridesRequirementsImpl(StageDataInfo<StridesRequirement>& stridesInfo) override;
 
-    void finalizeDataLayoutImpl() override;
+//     void finalizeDataLayoutImpl() override;
 
-    void getBatchSupportInfoImpl(StageDataInfo<BatchSupport>& batchInfo) override;
+//     void getBatchSupportInfoImpl(StageDataInfo<BatchSupport>& batchInfo) override;
 
-    void serializeParamsImpl(BlobSerializer&) const override;
+//     void serializeParamsImpl(BlobSerializer&) const override;
 
-    void serializeDataImpl(BlobSerializer&) const override;
-};
+//     void serializeDataImpl(BlobSerializer&) const override;
+// };
 
-enum class InputType {
-    Original,
-    PrevStageOutput,
-    Intermediate,
-    Constant
-};
+// enum class InputType {
+//     Original,
+//     PrevStageOutput,
+//     Intermediate,
+//     Constant
+// };
 
-struct InputInfo final {
-    InputType type = InputType::Original;
-    int originalInputInd = -1;
-    int prevStageInd = -1;
-    int prevStageOutputInd = -1;
-    DataDesc desc = DataDesc();
+// struct InputInfo final {
+//     InputType type = InputType::Original;
+//     int originalInputInd = -1;
+//     int prevStageInd = -1;
+//     int prevStageOutputInd = -1;
+//     DataDesc desc = DataDesc();
 
-    static InputInfo fromNetwork(int ind = 0);
+//     static InputInfo fromNetwork(int ind = 0);
 
-    static InputInfo fromPrevStage(int ind, int outputInd = 0);
-    static InputInfo constant(const DataDesc& desc);
+//     static InputInfo fromPrevStage(int ind, int outputInd = 0);
+//     static InputInfo constant(const DataDesc& desc);
 
-    InputInfo& output(int ind);
-};
+//     InputInfo& output(int ind);
+// };
 
-enum class OutputType {
-    Original,
-    Intermediate
-};
+// enum class OutputType {
+//     Original,
+//     Intermediate
+// };
 
-struct OutputInfo final {
-    OutputType type = OutputType::Original;
-    int originalOutputInd = -1;
-    DataDesc desc = DataDesc();
-    MemoryType memReq = MemoryType::DDR;
+// struct OutputInfo final {
+//     OutputType type = OutputType::Original;
+//     int originalOutputInd = -1;
+//     DataDesc desc = DataDesc();
+//     MemoryType memReq = MemoryType::DDR;
 
-    static OutputInfo fromNetwork(int ind = 0);
+//     static OutputInfo fromNetwork(int ind = 0);
 
-    static OutputInfo intermediate(const DataDesc& desc = DataDesc());
-    static OutputInfo intermediate(MemoryType memReq = MemoryType::DDR);
-};
+//     static OutputInfo intermediate(const DataDesc& desc = DataDesc());
+//     static OutputInfo intermediate(MemoryType memReq = MemoryType::DDR);
+// };
 
-class TestModel final {
-public:
-    TestModel() = default;
-    TestModel(const Model& model);
+// class TestModel final {
+// public:
+//     TestModel() = default;
+//     TestModel(const Model& model);
 
-    const Model& getBaseModel() const;
-    const DataVector& getInputs() const;
-    const DataVector& getOutputs() const;
-    const StageVector& getStages() const;
+//     const Model& getBaseModel() const;
+//     const DataVector& getInputs() const;
+//     const DataVector& getOutputs() const;
+//     const StageVector& getStages() const;
 
-    void createInputs(std::vector<DataDesc> inputDescs = {});
-    void createOutputs(std::vector<DataDesc> outputDescs = {});
+//     void createInputs(std::vector<DataDesc> inputDescs = {});
+//     void createOutputs(std::vector<DataDesc> outputDescs = {});
 
-    Stage addStage(
-            const std::vector<InputInfo>& curInputInfos,
-            const std::vector<OutputInfo>& curOutputInfos,
-            StageType stageType = StageType::None);
+//     Stage addStage(
+//             const std::vector<InputInfo>& curInputInfos,
+//             const std::vector<OutputInfo>& curOutputInfos,
+//             StageType stageType = StageType::None);
 
-    void setStageDataOrderInfo(
-            int stageInd,
-            const InOutPortMap<DimsOrder>& inputInfo,
-            const InOutPortMap<DimsOrder>& outputInfo);
+//     void setStageDataOrderInfo(
+//             int stageInd,
+//             const InOutPortMap<DimsOrder>& inputInfo,
+//             const InOutPortMap<DimsOrder>& outputInfo);
 
-    void setStageStridesInfo(
-            int stageInd,
-            const InOutPortMap<StridesRequirement>& inputInfo,
-            const InOutPortMap<StridesRequirement>& outputInfo);
+//     void setStageStridesInfo(
+//             int stageInd,
+//             const InOutPortMap<StridesRequirement>& inputInfo,
+//             const InOutPortMap<StridesRequirement>& outputInfo);
 
-    void setStageBatchInfo(
-            int stageInd,
-            const InOutPortMap<BatchSupport>& inputInfo);
+//     void setStageBatchInfo(
+//             int stageInd,
+//             const InOutPortMap<BatchSupport>& inputInfo);
 
-private:
-    Model _model;
+// private:
+//     Model _model;
 
-    DataVector _inputs;
-    DataVector _outputs;
-    StageVector _stages;
-};
+//     DataVector _inputs;
+//     DataVector _outputs;
+//     StageVector _stages;
+// };
 
-template <class StageRange>
-void checkStageTestInds(const StageRange& stageRange, std::initializer_list<int> expectedInds);
+// template <class StageRange>
+// void checkStageTestInds(const StageRange& stageRange, std::initializer_list<int> expectedInds);
 
-template <class StageRange>
-void checkStageTestInds(const StageRange& stageRange, std::initializer_list<int> expectedInds, const std::function<void(const Stage&)>& extraCheck);
+// template <class StageRange>
+// void checkStageTestInds(const StageRange& stageRange, std::initializer_list<int> expectedInds, const std::function<void(const Stage&)>& extraCheck);
 
-bool checkExecutionOrder(const Model& model, const std::vector<int>& execOrder);
+// bool checkExecutionOrder(const Model& model, const std::vector<int>& execOrder);
 
-PluginConfiguration createConfiguration();
+// <<<<<<< HEAD
+// <<<<<<< HEAD
+// PluginConfiguration createConfiguration();
 
-class GraphTransformerTest : public ::testing::Test {
-public:
-    ncDevicePlatform_t platform = ncDevicePlatform_t::NC_MYRIAD_X;
-    PluginConfiguration config;
+// class GraphTransformerTest : public ::testing::Test {
+// public:
+//     ncDevicePlatform_t platform = ncDevicePlatform_t::NC_MYRIAD_X;
+//     PluginConfiguration config;
+// =======
+// // class GraphTransformerTest : public ::testing::Test {
+// // public:
+// //     Platform platform = Platform::MYRIAD_X;
+// //     CompilationConfig config;
+// >>>>>>> [VPU] switch CNNLayer -> ngraph
+// =======
+// class GraphTransformerTest : public ::testing::Test {
+// public:
+//     Platform platform = Platform::MYRIAD_X;
+//     CompilationConfig config;
+// >>>>>>> refactoring
 
-    StageBuilder::Ptr stageBuilder;
-    FrontEnd::Ptr frontEnd;
-    PassManager::Ptr passManager;
-    BackEnd::Ptr backEnd;
+//     StageBuilder::Ptr stageBuilder;
+//     FrontEnd::Ptr frontEnd;
+//     PassManager::Ptr passManager;
+//     BackEnd::Ptr backEnd;
 
-    bool compileEnvInitialized = false;
+//     bool compileEnvInitialized = false;
 
-    void SetUp() override;
-    void TearDown() override;
+//     void SetUp() override;
+//     void TearDown() override;
 
-    void InitCompileEnv();
+//     void InitCompileEnv();
 
-    Model CreateModel();
+//     Model CreateModel();
 
-    TestModel CreateTestModel();
+//     TestModel CreateTestModel();
 
-private:
-    MockICore  _mockCore;
-    Logger::Ptr _log;
-    std::list<ModelPtr> _models;
-};
+// private:
+//     MockICore  _mockCore;
+//     Logger::Ptr _log;
+//     std::list<ModelPtr> _models;
+// };
 
-} // namespace vpu
+// } // namespace vpu

--- a/inference-engine/tests/unit/vpu/blob_reader_tests.cpp
+++ b/inference-engine/tests/unit/vpu/blob_reader_tests.cpp
@@ -1,204 +1,204 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
 
-#include <gtest/gtest.h>
-#include <memory>
+// #include <gtest/gtest.h>
+// #include <memory>
 
-#include <ie_common.h>
-#include <cpp/ie_cnn_network.h>
+// #include <ie_common.h>
+// #include <cpp/ie_cnn_network.h>
 
-#include <vpu/blob_reader.hpp>
-#include <vpu/graph_transformer.hpp>
-#include <vpu/utils/logger.hpp>
+// #include <vpu/blob_reader.hpp>
+// #include <vpu/graph_transformer.hpp>
+// #include <vpu/utils/logger.hpp>
 
-#include "graph_transformer_tests.hpp"
+// #include "graph_transformer_tests.hpp"
 
-#include <ngraph/op/util/attr_types.hpp>
-#include <ngraph_functions/subgraph_builders.hpp>
+// #include <ngraph/op/util/attr_types.hpp>
+// #include <ngraph_functions/subgraph_builders.hpp>
 
-#include <unit_test_utils/mocks/cpp_interfaces/interface/mock_icore.hpp>
+// #include <unit_test_utils/mocks/cpp_interfaces/interface/mock_icore.hpp>
 
-using namespace ::testing;
-using namespace vpu;
-using namespace InferenceEngine;
+// using namespace ::testing;
+// using namespace vpu;
+// using namespace InferenceEngine;
 
-class VPUBlobReaderHeaderTests: public ::testing::Test, public testing::WithParamInterface<std::vector<size_t>> {
-private:
-    std::vector<size_t> inputShape;
+// class VPUBlobReaderHeaderTests: public ::testing::Test, public testing::WithParamInterface<std::vector<size_t>> {
+// private:
+//     std::vector<size_t> inputShape;
 
-public:
-    size_t getElemSizeByPrecision(Precision precision) {
-        size_t elemSize = 0;
-        switch (precision) {
-        case Precision::U8:
-            elemSize = 1;
-        case Precision::FP16:
-            elemSize = 2;
-            break;
-        case Precision::FP32:
-            elemSize = 4;
-            break;
-        default:
-            throw std::runtime_error(std::string("unsupported precision: ") + precision.name() );
-        }
+// public:
+//     size_t getElemSizeByPrecision(Precision precision) {
+//         size_t elemSize = 0;
+//         switch (precision) {
+//         case Precision::U8:
+//             elemSize = 1;
+//         case Precision::FP16:
+//             elemSize = 2;
+//             break;
+//         case Precision::FP32:
+//             elemSize = 4;
+//             break;
+//         default:
+//             throw std::runtime_error(std::string("unsupported precision: ") + precision.name() );
+//         }
 
-        return elemSize;
-    }
+//         return elemSize;
+//     }
 
-    void SetUp() override {
-        auto fn_ptr = ngraph::builder::subgraph::makeSplitConvConcat();
-        ASSERT_NO_THROW(_network = InferenceEngine::CNNNetwork(fn_ptr));
+//     void SetUp() override {
+//         auto fn_ptr = ngraph::builder::subgraph::makeSplitConvConcat();
+//         ASSERT_NO_THROW(_network = InferenceEngine::CNNNetwork(fn_ptr));
 
-        auto log = std::make_shared<Logger>("GraphCompiler", LogLevel::None, consoleOutput());
-        _compiledGraph = compileNetwork(_network, ncDevicePlatform_t::NC_MYRIAD_X, createConfiguration(), log, &_mockCore);
-    }
+//         auto log = std::make_shared<Logger>("GraphCompiler", LogLevel::None, consoleOutput());
+//         _compiledGraph = compileNetwork(_network, ncDevicePlatform_t::NC_MYRIAD_X, createConfiguration(), log, &_mockCore);
+//     }
 
-    CNNNetwork _network;
-    CompiledGraph::Ptr _compiledGraph;
-    MockICore _mockCore;
-};
+//     CNNNetwork _network;
+//     CompiledGraph::Ptr _compiledGraph;
+//     MockICore _mockCore;
+// };
 
-TEST_P(VPUBlobReaderHeaderTests, canReadCorrectMagicNumber) {
-    SetUp();
-    BlobReader blobReader;
-    ASSERT_NO_THROW(blobReader.parse(_compiledGraph->blob));
+// TEST_P(VPUBlobReaderHeaderTests, canReadCorrectMagicNumber) {
+//     SetUp();
+//     BlobReader blobReader;
+//     ASSERT_NO_THROW(blobReader.parse(_compiledGraph->blob));
 
-    ASSERT_EQ(BLOB_MAGIC_NUMBER, blobReader.getMagicNumber());
-}
+//     ASSERT_EQ(BLOB_MAGIC_NUMBER, blobReader.getMagicNumber());
+// }
 
-TEST_P(VPUBlobReaderHeaderTests, canReadCorrectStageCount) {
-    SetUp();
-    BlobReader blobReader;
-    ASSERT_NO_THROW(blobReader.parse(_compiledGraph->blob));
+// TEST_P(VPUBlobReaderHeaderTests, canReadCorrectStageCount) {
+//     SetUp();
+//     BlobReader blobReader;
+//     ASSERT_NO_THROW(blobReader.parse(_compiledGraph->blob));
 
-    ASSERT_EQ(_compiledGraph->numActiveStages, blobReader.getStageCount());
-}
+//     ASSERT_EQ(_compiledGraph->numActiveStages, blobReader.getStageCount());
+// }
 
-TEST_P(VPUBlobReaderHeaderTests, canReadCorrectBlobVersion) {
-    SetUp();
-    BlobReader blobReader;
-    ASSERT_NO_THROW(blobReader.parse(_compiledGraph->blob));
+// TEST_P(VPUBlobReaderHeaderTests, canReadCorrectBlobVersion) {
+//     SetUp();
+//     BlobReader blobReader;
+//     ASSERT_NO_THROW(blobReader.parse(_compiledGraph->blob));
 
-    ASSERT_EQ(BLOB_VERSION_MAJOR, blobReader.getVersionMajor());
-    ASSERT_EQ(BLOB_VERSION_MINOR, blobReader.getVersionMinor());
-}
+//     ASSERT_EQ(BLOB_VERSION_MAJOR, blobReader.getVersionMajor());
+//     ASSERT_EQ(BLOB_VERSION_MINOR, blobReader.getVersionMinor());
+// }
 
-using VPUBlobReaderInputTests = VPUBlobReaderHeaderTests;
+// using VPUBlobReaderInputTests = VPUBlobReaderHeaderTests;
 
-TEST_P(VPUBlobReaderInputTests, areEqualTotalInputSizeFromBlobAndCalculatedFromInputDesc) {
-    SetUp();
-    BlobReader blobReader;
-    ASSERT_NO_THROW(blobReader.parse(_compiledGraph->blob));
+// TEST_P(VPUBlobReaderInputTests, areEqualTotalInputSizeFromBlobAndCalculatedFromInputDesc) {
+//     SetUp();
+//     BlobReader blobReader;
+//     ASSERT_NO_THROW(blobReader.parse(_compiledGraph->blob));
 
-    size_t inputTotalSize = 0;
-    for (const auto &input : blobReader.getNetworkInputs()) {
-        auto dims = input.second->getTensorDesc().getDims();
-        auto precision = blobReader.getNetworkInputs().begin()->second->getPrecision();
+//     size_t inputTotalSize = 0;
+//     for (const auto &input : blobReader.getNetworkInputs()) {
+//         auto dims = input.second->getTensorDesc().getDims();
+//         auto precision = blobReader.getNetworkInputs().begin()->second->getPrecision();
 
-        inputTotalSize += std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<size_t>()) * getElemSizeByPrecision(precision);
-    }
+//         inputTotalSize += std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<size_t>()) * getElemSizeByPrecision(precision);
+//     }
 
-    auto inputInfo = blobReader.getInputInfo();
-    ASSERT_GE(inputInfo.totalSize, inputTotalSize);
-}
+//     auto inputInfo = blobReader.getInputInfo();
+//     ASSERT_GE(inputInfo.totalSize, inputTotalSize);
+// }
 
-TEST_P(VPUBlobReaderInputTests, canGetCorrectInputDimsFromImportedNetwork) {
-    SetUp();
-    BlobReader blobReader;
-    ASSERT_NO_THROW(blobReader.parse(_compiledGraph->blob));
+// TEST_P(VPUBlobReaderInputTests, canGetCorrectInputDimsFromImportedNetwork) {
+//     SetUp();
+//     BlobReader blobReader;
+//     ASSERT_NO_THROW(blobReader.parse(_compiledGraph->blob));
 
-    auto parsedNetworkInputs = blobReader.getNetworkInputs();
-    auto expectedNetworkInputs = _network.getInputsInfo();
+//     auto parsedNetworkInputs = blobReader.getNetworkInputs();
+//     auto expectedNetworkInputs = _network.getInputsInfo();
 
-    for (auto&& actual : parsedNetworkInputs) {
-        auto actualDims = actual.second->getTensorDesc().getDims();
-        size_t actualTotalSize = std::accumulate(actualDims.begin(), actualDims.end(), 1, std::multiplies<size_t>());
+//     for (auto&& actual : parsedNetworkInputs) {
+//         auto actualDims = actual.second->getTensorDesc().getDims();
+//         size_t actualTotalSize = std::accumulate(actualDims.begin(), actualDims.end(), 1, std::multiplies<size_t>());
 
-        ASSERT_GT(expectedNetworkInputs.count(actual.first), 0);
-        auto expectedDims = expectedNetworkInputs[actual.first]->getTensorDesc().getDims();
-        size_t expectedTotalSize = std::accumulate(expectedDims.begin(), expectedDims.end(), 1, std::multiplies<size_t>());
+//         ASSERT_GT(expectedNetworkInputs.count(actual.first), 0);
+//         auto expectedDims = expectedNetworkInputs[actual.first]->getTensorDesc().getDims();
+//         size_t expectedTotalSize = std::accumulate(expectedDims.begin(), expectedDims.end(), 1, std::multiplies<size_t>());
 
-        ASSERT_EQ(actualTotalSize, expectedTotalSize);
-    }
-}
+//         ASSERT_EQ(actualTotalSize, expectedTotalSize);
+//     }
+// }
 
-TEST_P(VPUBlobReaderInputTests, canGetCorrectInputNamesFromImportedNetwork) {
-    SetUp();
-    BlobReader blobReader;
-    ASSERT_NO_THROW(blobReader.parse(_compiledGraph->blob));
+// TEST_P(VPUBlobReaderInputTests, canGetCorrectInputNamesFromImportedNetwork) {
+//     SetUp();
+//     BlobReader blobReader;
+//     ASSERT_NO_THROW(blobReader.parse(_compiledGraph->blob));
 
-    auto parsedNetworkInputs   = blobReader.getNetworkInputs();
-    auto expectedNetworkInputs = _network.getInputsInfo();
+//     auto parsedNetworkInputs   = blobReader.getNetworkInputs();
+//     auto expectedNetworkInputs = _network.getInputsInfo();
 
-    for (auto&& actual : parsedNetworkInputs) {
-        ASSERT_GT(expectedNetworkInputs.count(actual.first), 0);
-    }
+//     for (auto&& actual : parsedNetworkInputs) {
+//         ASSERT_GT(expectedNetworkInputs.count(actual.first), 0);
+//     }
 
-    for (auto&& expected : expectedNetworkInputs) {
-        ASSERT_GT(parsedNetworkInputs.count(expected.first), 0);
-    }
-}
+//     for (auto&& expected : expectedNetworkInputs) {
+//         ASSERT_GT(parsedNetworkInputs.count(expected.first), 0);
+//     }
+// }
 
-using VPUBlobReaderOutputTests = VPUBlobReaderHeaderTests;
+// // using VPUBlobReaderOutputTests = VPUBlobReaderHeaderTests;
 
-TEST_P(VPUBlobReaderOutputTests, areEqualTotalOutputSizeFromBlobAndCalculatedFromOutputDesc) {
-    SetUp();
-    BlobReader blobReader;
-    ASSERT_NO_THROW(blobReader.parse(_compiledGraph->blob));
+// // TEST_P(VPUBlobReaderOutputTests, areEqualTotalOutputSizeFromBlobAndCalculatedFromOutputDesc) {
+// //     SetUp();
+// //     BlobReader blobReader;
+// //     ASSERT_NO_THROW(blobReader.parse(_compiledGraph->blob));
 
-    size_t outputTotalSize = 0;
-    for (const auto &input : blobReader.getNetworkOutputs()) {
-        auto dims = input.second->getDims();
-        auto precision = blobReader.getNetworkOutputs().begin()->second->getPrecision();
+// //     size_t outputTotalSize = 0;
+// //     for (const auto &input : blobReader.getNetworkOutputs()) {
+// //         auto dims = input.second->getDims();
+// //         auto precision = blobReader.getNetworkOutputs().begin()->second->getPrecision();
 
-        outputTotalSize += std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<size_t>()) * getElemSizeByPrecision(precision);
-    }
+// //         outputTotalSize += std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<size_t>()) * getElemSizeByPrecision(precision);
+// //     }
 
-    auto outputInfo = blobReader.getOutputInfo();
-    ASSERT_GE(outputInfo.totalSize, outputTotalSize);
-}
+// //     auto outputInfo = blobReader.getOutputInfo();
+// //     ASSERT_GE(outputInfo.totalSize, outputTotalSize);
+// // }
 
-TEST_P(VPUBlobReaderOutputTests, canGetCorrectOutputDimsFromImportedNetwork) {
-    SetUp();
-    BlobReader blobReader;
-    ASSERT_NO_THROW(blobReader.parse(_compiledGraph->blob));
+// // TEST_P(VPUBlobReaderOutputTests, canGetCorrectOutputDimsFromImportedNetwork) {
+// //     SetUp();
+// //     BlobReader blobReader;
+// //     ASSERT_NO_THROW(blobReader.parse(_compiledGraph->blob));
 
-    auto parsedNetworkOutputs = blobReader.getNetworkOutputs();
-    auto expectedNetworkOutputs = _network.getOutputsInfo();
+// //     auto parsedNetworkOutputs = blobReader.getNetworkOutputs();
+// //     auto expectedNetworkOutputs = _network.getOutputsInfo();
 
-    for (auto&& actual : parsedNetworkOutputs) {
-        auto actualDims = actual.second->getDims();
-        size_t actualTotalSize = std::accumulate(actualDims.begin(), actualDims.end(), 1, std::multiplies<size_t>());
+// //     for (auto&& actual : parsedNetworkOutputs) {
+// //         auto actualDims = actual.second->getDims();
+// //         size_t actualTotalSize = std::accumulate(actualDims.begin(), actualDims.end(), 1, std::multiplies<size_t>());
 
-        ASSERT_GT(expectedNetworkOutputs.count(actual.first), 0);
-        auto expectedDims = expectedNetworkOutputs[actual.first]->getDims();
-        size_t expectedTotalSize = std::accumulate(expectedDims.begin(), expectedDims.end(), 1, std::multiplies<size_t>());
+// //         ASSERT_GT(expectedNetworkOutputs.count(actual.first), 0);
+// //         auto expectedDims = expectedNetworkOutputs[actual.first]->getDims();
+// //         size_t expectedTotalSize = std::accumulate(expectedDims.begin(), expectedDims.end(), 1, std::multiplies<size_t>());
 
-        ASSERT_EQ(actualTotalSize, expectedTotalSize);
-    }
-}
+// //         ASSERT_EQ(actualTotalSize, expectedTotalSize);
+// //     }
+// // }
 
-TEST_P(VPUBlobReaderOutputTests, canGetCorrectOutputNamesFromImportedNetwork) {
-    SetUp();
-    BlobReader blobReader;
-    ASSERT_NO_THROW(blobReader.parse(_compiledGraph->blob));
+// // TEST_P(VPUBlobReaderOutputTests, canGetCorrectOutputNamesFromImportedNetwork) {
+// //     SetUp();
+// //     BlobReader blobReader;
+// //     ASSERT_NO_THROW(blobReader.parse(_compiledGraph->blob));
 
-    auto parsedNetworkOutputs   = blobReader.getNetworkOutputs();
-    auto expectedNetworkOutputs = _network.getOutputsInfo();
+// //     auto parsedNetworkOutputs   = blobReader.getNetworkOutputs();
+// //     auto expectedNetworkOutputs = _network.getOutputsInfo();
 
-    for (auto&& actual : parsedNetworkOutputs) {
-        ASSERT_GT(expectedNetworkOutputs.count(actual.first), 0);
-    }
+// //     for (auto&& actual : parsedNetworkOutputs) {
+// //         ASSERT_GT(expectedNetworkOutputs.count(actual.first), 0);
+// //     }
 
-    for (auto&& expected : expectedNetworkOutputs) {
-        ASSERT_GT(parsedNetworkOutputs.count(expected.first), 0);
-    }
-}
+// //     for (auto&& expected : expectedNetworkOutputs) {
+// //         ASSERT_GT(parsedNetworkOutputs.count(expected.first), 0);
+// //     }
+// // }
 
 
-const std::vector<size_t> inputShape = {{1, 4, 10, 10}};
+// // const std::vector<size_t> inputShape = {{1, 4, 10, 10}};
 
-INSTANTIATE_TEST_SUITE_P(myriadBlobReader_nightly, VPUBlobReaderHeaderTests, ::testing::Values(inputShape));
-INSTANTIATE_TEST_SUITE_P(myriadBlobReader_nightly, VPUBlobReaderInputTests, ::testing::Values(inputShape));
-INSTANTIATE_TEST_SUITE_P(myriadBlobReader_nightly, VPUBlobReaderOutputTests, ::testing::Values(inputShape));
+// // INSTANTIATE_TEST_SUITE_P(myriadBlobReader_nightly, VPUBlobReaderHeaderTests, ::testing::Values(inputShape));
+// // INSTANTIATE_TEST_SUITE_P(myriadBlobReader_nightly, VPUBlobReaderInputTests, ::testing::Values(inputShape));
+// // INSTANTIATE_TEST_SUITE_P(myriadBlobReader_nightly, VPUBlobReaderOutputTests, ::testing::Values(inputShape));

--- a/inference-engine/tests/unit/vpu/frontend_tests/dsr_parsing_tests.cpp
+++ b/inference-engine/tests/unit/vpu/frontend_tests/dsr_parsing_tests.cpp
@@ -1,257 +1,257 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
 
-#include "graph_transformer_tests.hpp"
+// #include "graph_transformer_tests.hpp"
 
-#include <vpu/ngraph/operations/static_shape_nonzero.hpp>
-#include <vpu/ngraph/operations/dynamic_shape_resolver.hpp>
+// #include <vpu/ngraph/operations/static_shape_nonzero.hpp>
+// #include <vpu/ngraph/operations/dynamic_shape_resolver.hpp>
 
-#include "ngraph/ngraph.hpp"
-#include "ngraph/opsets/opset3.hpp"
+// #include "ngraph/ngraph.hpp"
+// #include "ngraph/opsets/opset3.hpp"
 
-IE_SUPPRESS_DEPRECATED_START
+// IE_SUPPRESS_DEPRECATED_START
 
-namespace vpu {
+// namespace vpu {
 
-namespace ie = InferenceEngine;
+// namespace ie = InferenceEngine;
 
-class DSRParsingTests : public GraphTransformerTest {
-protected:
-    void SetUp() override {
-        ASSERT_NO_FATAL_FAILURE(GraphTransformerTest::SetUp());
+// class DSRParsingTests : public GraphTransformerTest {
+// protected:
+//     void SetUp() override {
+//         ASSERT_NO_FATAL_FAILURE(GraphTransformerTest::SetUp());
 
-        ASSERT_NO_FATAL_FAILURE(InitCompileEnv());
+//         ASSERT_NO_FATAL_FAILURE(InitCompileEnv());
 
-        _testModel = CreateTestModel();
-    }
+//         _testModel = CreateTestModel();
+//     }
 
-    void checkShapeConnection(const Data& parent, const Data& child) {
-        ASSERT_NE(child->parentDataToShapeEdge(), nullptr);
-        ASSERT_EQ(child->childDataToShapeEdges().size(), 0);
-        const auto& parentDataToShapeEdge = child->parentDataToShapeEdge();
-        ASSERT_EQ(parentDataToShapeEdge->parent(), parent);
-        ASSERT_EQ(parentDataToShapeEdge->child(), child);
+//     void checkShapeConnection(const Data& parent, const Data& child) {
+//         ASSERT_NE(child->parentDataToShapeEdge(), nullptr);
+//         ASSERT_EQ(child->childDataToShapeEdges().size(), 0);
+//         const auto& parentDataToShapeEdge = child->parentDataToShapeEdge();
+//         ASSERT_EQ(parentDataToShapeEdge->parent(), parent);
+//         ASSERT_EQ(parentDataToShapeEdge->child(), child);
 
-        ASSERT_EQ(parent->parentDataToShapeEdge(), nullptr);
+//         ASSERT_EQ(parent->parentDataToShapeEdge(), nullptr);
 
-        const auto& childDataToShapeEdges = parent->childDataToShapeEdges();
+//         const auto& childDataToShapeEdges = parent->childDataToShapeEdges();
 
-        const auto& it = std::find(childDataToShapeEdges.begin(), childDataToShapeEdges.end(), parentDataToShapeEdge);
-        ASSERT_NE(it, childDataToShapeEdges.end());
-    }
+//         const auto& it = std::find(childDataToShapeEdges.begin(), childDataToShapeEdges.end(), parentDataToShapeEdge);
+//         ASSERT_NE(it, childDataToShapeEdges.end());
+//     }
 
-    ie::CNNLayerPtr createDSRLayer() {
-        return std::make_shared<ie::CNNLayer>(ie::LayerParams{"DSR", "DynamicShapeResolver", ie::Precision::I32});
-    }
+//     ie::CNNLayerPtr createDSRLayer() {
+//         return std::make_shared<ie::CNNLayer>(ie::LayerParams{"DSR", "DynamicShapeResolver", ie::Precision::I32});
+//     }
 
-protected:
-    TestModel _testModel;
-    DataDesc _dataDesc = {800};
-    DataDesc _correstShapeDesc = {1};
-    DataDesc _incorrestShapeDesc = {2};
-};
+// protected:
+//     TestModel _testModel;
+//     DataDesc _dataDesc = {800};
+//     DataDesc _correstShapeDesc = {1};
+//     DataDesc _incorrestShapeDesc = {2};
+// };
 
-TEST_F(DSRParsingTests, DSRParserAssertsOnInputDSR) {
-    _testModel.createInputs({_dataDesc, _correstShapeDesc});
-    _testModel.createOutputs({_dataDesc});
+// TEST_F(DSRParsingTests, DSRParserAssertsOnInputDSR) {
+//     _testModel.createInputs({_dataDesc, _correstShapeDesc});
+//     _testModel.createOutputs({_dataDesc});
 
-    const auto& dsrLayer = createDSRLayer();
+//     const auto& dsrLayer = createDSRLayer();
 
-    ASSERT_ANY_THROW(frontEnd->parseDSR(_testModel.getBaseModel(), dsrLayer,
-                                        {_testModel.getInputs()[0], _testModel.getInputs()[1]}, _testModel.getOutputs()));
-}
+//     ASSERT_ANY_THROW(frontEnd->parseDSR(_testModel.getBaseModel(), dsrLayer,
+//                                         {_testModel.getInputs()[0], _testModel.getInputs()[1]}, _testModel.getOutputs()));
+// }
 
-TEST_F(DSRParsingTests, DSRParserAssertsOnIncorrectDimensions) {
-    _testModel.createInputs({_dataDesc});
-    _testModel.createOutputs({_dataDesc});
+// TEST_F(DSRParsingTests, DSRParserAssertsOnIncorrectDimensions) {
+//     _testModel.createInputs({_dataDesc});
+//     _testModel.createOutputs({_dataDesc});
 
-    const auto& inputStage = _testModel.addStage({InputInfo::fromNetwork(0)},
-            {OutputInfo::intermediate(_dataDesc), OutputInfo::intermediate(_incorrestShapeDesc)});
+//     const auto& inputStage = _testModel.addStage({InputInfo::fromNetwork(0)},
+//             {OutputInfo::intermediate(_dataDesc), OutputInfo::intermediate(_incorrestShapeDesc)});
 
-    const auto& dsrLayer = createDSRLayer();
+//     const auto& dsrLayer = createDSRLayer();
 
-    ASSERT_ANY_THROW(frontEnd->parseDSR(_testModel.getBaseModel(), dsrLayer,
-                                        {inputStage->output(0), inputStage->output(1)}, _testModel.getOutputs()));
-}
+//     ASSERT_ANY_THROW(frontEnd->parseDSR(_testModel.getBaseModel(), dsrLayer,
+//                                         {inputStage->output(0), inputStage->output(1)}, _testModel.getOutputs()));
+// }
 
-TEST_F(DSRParsingTests, DSRParserAssertsOnIncorrectNumInputs) {
-    _testModel.createInputs({_dataDesc});
-    _testModel.createOutputs({_dataDesc});
+// TEST_F(DSRParsingTests, DSRParserAssertsOnIncorrectNumInputs) {
+//     _testModel.createInputs({_dataDesc});
+//     _testModel.createOutputs({_dataDesc});
 
-    const auto& inputStage = _testModel.addStage({InputInfo::fromNetwork(0)},
-                                                {OutputInfo::intermediate(_dataDesc)});
+//     const auto& inputStage = _testModel.addStage({InputInfo::fromNetwork(0)},
+//                                                 {OutputInfo::intermediate(_dataDesc)});
 
-    const auto& dsrLayer = createDSRLayer();
+//     const auto& dsrLayer = createDSRLayer();
 
-    ASSERT_ANY_THROW(frontEnd->parseDSR(_testModel.getBaseModel(), dsrLayer,
-                                        {inputStage->output(0)}, _testModel.getOutputs()));
-}
+//     ASSERT_ANY_THROW(frontEnd->parseDSR(_testModel.getBaseModel(), dsrLayer,
+//                                         {inputStage->output(0)}, _testModel.getOutputs()));
+// }
 
-TEST_F(DSRParsingTests, DSRParserAssertsOnIncorrectNumOutputs) {
-    _testModel.createInputs({_dataDesc});
-    _testModel.createOutputs({_dataDesc, _dataDesc});
+// TEST_F(DSRParsingTests, DSRParserAssertsOnIncorrectNumOutputs) {
+//     _testModel.createInputs({_dataDesc});
+//     _testModel.createOutputs({_dataDesc, _dataDesc});
 
-    const auto& inputStage = _testModel.addStage({InputInfo::fromNetwork(0)},
-            {OutputInfo::intermediate(_dataDesc), OutputInfo::intermediate(_correstShapeDesc)});
+//     const auto& inputStage = _testModel.addStage({InputInfo::fromNetwork(0)},
+//             {OutputInfo::intermediate(_dataDesc), OutputInfo::intermediate(_correstShapeDesc)});
 
-    const auto& dsrLayer = createDSRLayer();
+//     const auto& dsrLayer = createDSRLayer();
 
-    ASSERT_ANY_THROW(frontEnd->parseDSR(_testModel.getBaseModel(), dsrLayer,
-                                        {inputStage->output(0), inputStage->output(1)}, _testModel.getOutputs()));
-}
+//     ASSERT_ANY_THROW(frontEnd->parseDSR(_testModel.getBaseModel(), dsrLayer,
+//                                         {inputStage->output(0), inputStage->output(1)}, _testModel.getOutputs()));
+// }
 
-TEST_F(DSRParsingTests, DSRParserDoesntAssertOnCorrectIO) {
-    _testModel.createInputs({_dataDesc});
-    _testModel.createOutputs({_dataDesc});
+// TEST_F(DSRParsingTests, DSRParserDoesntAssertOnCorrectIO) {
+//     _testModel.createInputs({_dataDesc});
+//     _testModel.createOutputs({_dataDesc});
 
-    const auto& inputStage = _testModel.addStage({InputInfo::fromNetwork(0)},
-                                                {OutputInfo::intermediate(_dataDesc), OutputInfo::intermediate(_correstShapeDesc)});
+//     const auto& inputStage = _testModel.addStage({InputInfo::fromNetwork(0)},
+//                                                 {OutputInfo::intermediate(_dataDesc), OutputInfo::intermediate(_correstShapeDesc)});
 
-    const auto& dsrLayer = createDSRLayer();
+//     const auto& dsrLayer = createDSRLayer();
 
-    ASSERT_NO_THROW(frontEnd->parseDSR(_testModel.getBaseModel(), dsrLayer,
-                                       {inputStage->output(0), inputStage->output(1)}, _testModel.getOutputs()));
-}
+//     ASSERT_NO_THROW(frontEnd->parseDSR(_testModel.getBaseModel(), dsrLayer,
+//                                        {inputStage->output(0), inputStage->output(1)}, _testModel.getOutputs()));
+// }
 
-TEST_F(DSRParsingTests, DSRParserDoesntAssertOnTwoOutputsWithSameShapeData) {
-    _testModel.createInputs({_dataDesc});
-    _testModel.createOutputs({_dataDesc, _dataDesc});
+// TEST_F(DSRParsingTests, DSRParserDoesntAssertOnTwoOutputsWithSameShapeData) {
+//     _testModel.createInputs({_dataDesc});
+//     _testModel.createOutputs({_dataDesc, _dataDesc});
 
-    const auto& inputStage = _testModel.addStage(
-            {InputInfo::fromNetwork(0)},
-            {OutputInfo::intermediate(_dataDesc), OutputInfo::intermediate(_dataDesc), OutputInfo::intermediate(_correstShapeDesc)});
+//     const auto& inputStage = _testModel.addStage(
+//             {InputInfo::fromNetwork(0)},
+//             {OutputInfo::intermediate(_dataDesc), OutputInfo::intermediate(_dataDesc), OutputInfo::intermediate(_correstShapeDesc)});
 
-    const auto& dsrLayer1 = createDSRLayer();
-    const auto& dsrLayer2 = createDSRLayer();
+//     const auto& dsrLayer1 = createDSRLayer();
+//     const auto& dsrLayer2 = createDSRLayer();
 
-    ASSERT_NO_THROW(frontEnd->parseDSR(_testModel.getBaseModel(), dsrLayer1,
-                                       {inputStage->output(0), inputStage->output(2)}, {_testModel.getOutputs()[0]}));
-    ASSERT_NO_THROW(frontEnd->parseDSR(_testModel.getBaseModel(), dsrLayer2,
-                                       {inputStage->output(1), inputStage->output(2)}, {_testModel.getOutputs()[1]}));
-}
+//     ASSERT_NO_THROW(frontEnd->parseDSR(_testModel.getBaseModel(), dsrLayer1,
+//                                        {inputStage->output(0), inputStage->output(2)}, {_testModel.getOutputs()[0]}));
+//     ASSERT_NO_THROW(frontEnd->parseDSR(_testModel.getBaseModel(), dsrLayer2,
+//                                        {inputStage->output(1), inputStage->output(2)}, {_testModel.getOutputs()[1]}));
+// }
 
-TEST_F(DSRParsingTests, DSRParserPreservesConnectionsOnOutputDSR) {
-    _testModel.createInputs({_dataDesc});
-    _testModel.createOutputs({_dataDesc});
+// TEST_F(DSRParsingTests, DSRParserPreservesConnectionsOnOutputDSR) {
+//     _testModel.createInputs({_dataDesc});
+//     _testModel.createOutputs({_dataDesc});
 
-    const auto& model = _testModel.getBaseModel();
+//     const auto& model = _testModel.getBaseModel();
 
-    const auto& inputStage = _testModel.addStage({InputInfo::fromNetwork(0)},
-                                                 {OutputInfo::intermediate(_dataDesc), OutputInfo::intermediate(_correstShapeDesc)});
+//     const auto& inputStage = _testModel.addStage({InputInfo::fromNetwork(0)},
+//                                                  {OutputInfo::intermediate(_dataDesc), OutputInfo::intermediate(_correstShapeDesc)});
 
-    model->connectDataWithShape(inputStage->output(1), inputStage->output(0));
+//     model->connectDataWithShape(inputStage->output(1), inputStage->output(0));
 
-    checkShapeConnection(inputStage->output(1), inputStage->output(0));
+//     checkShapeConnection(inputStage->output(1), inputStage->output(0));
 
-    const auto& outputStage = _testModel.addStage({InputInfo::fromPrevStage(0)},
-                                                  {OutputInfo::intermediate(_dataDesc)});
+//     const auto& outputStage = _testModel.addStage({InputInfo::fromPrevStage(0)},
+//                                                   {OutputInfo::intermediate(_dataDesc)});
 
-    const auto& dsrLayer = createDSRLayer();
+//     const auto& dsrLayer = createDSRLayer();
 
-    ASSERT_NO_THROW(frontEnd->parseDSR(_testModel.getBaseModel(), dsrLayer,
-    {outputStage->output(0), inputStage->output(1)}, _testModel.getOutputs()));
+//     ASSERT_NO_THROW(frontEnd->parseDSR(_testModel.getBaseModel(), dsrLayer,
+//     {outputStage->output(0), inputStage->output(1)}, _testModel.getOutputs()));
 
-    checkShapeConnection(inputStage->output(1), inputStage->output(0));
-    checkShapeConnection(inputStage->output(1), outputStage->output(0));
-}
+//     checkShapeConnection(inputStage->output(1), inputStage->output(0));
+//     checkShapeConnection(inputStage->output(1), outputStage->output(0));
+// }
 
-typedef DSRParsingTests DSRParsingFromNgraphTests;
+// typedef DSRParsingTests DSRParsingFromNgraphTests;
 
-TEST_F(DSRParsingFromNgraphTests, DSRParserCreatesAndConnectsTwoOutputsOnOutputDSR) {
-    const auto& inPrecision = ::ngraph::element::Type(::ngraph::element::Type_t::i32);
+// TEST_F(DSRParsingFromNgraphTests, DSRParserCreatesAndConnectsTwoOutputsOnOutputDSR) {
+//     const auto& inPrecision = ::ngraph::element::Type(::ngraph::element::Type_t::i32);
 
-    const auto& tensor = std::make_shared<ngraph::opset3::Parameter>(inPrecision, ngraph::Shape{1, 800});
-    const auto& staticShapeNonZero = std::make_shared<ngraph::vpu::op::StaticShapeNonZero>(tensor);
-    const auto& dynamicShapeResolver = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(
-            staticShapeNonZero->output(0), staticShapeNonZero->output(1));
+//     const auto& tensor = std::make_shared<ngraph::opset3::Parameter>(inPrecision, ngraph::Shape{1, 800});
+//     const auto& staticShapeNonZero = std::make_shared<ngraph::vpu::op::StaticShapeNonZero>(tensor);
+//     const auto& dynamicShapeResolver = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(
+//             staticShapeNonZero->output(0), staticShapeNonZero->output(1));
 
-    const auto& fnPtr = std::make_shared<ngraph::Function>(ngraph::NodeVector{dynamicShapeResolver}, ngraph::ParameterVector{tensor});
+//     const auto& fnPtr = std::make_shared<ngraph::Function>(ngraph::NodeVector{dynamicShapeResolver}, ngraph::ParameterVector{tensor});
 
-    InferenceEngine::CNNNetwork cnnNet(fnPtr);
-    for (const auto& outputInfo : cnnNet.getOutputsInfo()) {
-        outputInfo.second->setPrecision(ie::Precision::I32);
-    }
+//     InferenceEngine::CNNNetwork cnnNet(fnPtr);
+//     for (const auto& outputInfo : cnnNet.getOutputsInfo()) {
+//         outputInfo.second->setPrecision(ie::Precision::I32);
+//     }
 
-    ModelPtr model;
-    ASSERT_NO_THROW(model = frontEnd->buildInitialModel(cnnNet));
-    int numOutputs = 0;
-    for (const auto& data : model->datas()) {
-        if (data->usage() == DataUsage::Output) {
-            numOutputs++;
-        }
-    }
-    ASSERT_EQ(numOutputs, 2);
+//     ModelPtr model;
+//     ASSERT_NO_THROW(model = frontEnd->buildInitialModel(cnnNet));
+//     int numOutputs = 0;
+//     for (const auto& data : model->datas()) {
+//         if (data->usage() == DataUsage::Output) {
+//             numOutputs++;
+//         }
+//     }
+//     ASSERT_EQ(numOutputs, 2);
 
-    const auto& it = std::find_if(model->getStages().begin(), model->getStages().end(), [](const Stage& stage) {
-        return stage->type() == StageType::NonZero;
-    });
+//     const auto& it = std::find_if(model->getStages().begin(), model->getStages().end(), [](const Stage& stage) {
+//         return stage->type() == StageType::NonZero;
+//     });
 
-    ASSERT_NE(it, model->getStages().end());
-    const auto& nonZeroStage = *it;
+//     ASSERT_NE(it, model->getStages().end());
+//     const auto& nonZeroStage = *it;
 
-    checkShapeConnection(nonZeroStage->output(1), nonZeroStage->output(0));
-}
+//     checkShapeConnection(nonZeroStage->output(1), nonZeroStage->output(0));
+// }
 
-TEST_F(DSRParsingFromNgraphTests, DSRWithSingleProducerCreatesConnectionBetweenDataAndShape) {
-    const auto& inPrecision = ::ngraph::element::Type(::ngraph::element::Type_t::i32);
+// TEST_F(DSRParsingFromNgraphTests, DSRWithSingleProducerCreatesConnectionBetweenDataAndShape) {
+//     const auto& inPrecision = ::ngraph::element::Type(::ngraph::element::Type_t::i32);
 
-    const auto& tensor = std::make_shared<ngraph::opset3::Parameter>(inPrecision, ngraph::Shape{800});
-    const auto& staticShapeNonZero = std::make_shared<ngraph::vpu::op::StaticShapeNonZero>(tensor);
-    const auto& dynamicShapeResolver = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(
-            staticShapeNonZero->output(0), staticShapeNonZero->output(1));
-    const auto& gatherIndices = std::make_shared<ngraph::opset3::Constant>(ngraph::element::i64, ngraph::Shape{1}, std::vector<int64_t>{0});
-    const auto& gatherAxis = std::make_shared<ngraph::opset3::Constant>(ngraph::element::i64, ngraph::Shape{1}, std::vector<int64_t>{1});
-    const auto& gather = std::make_shared<ngraph::opset3::Gather>(dynamicShapeResolver->output(0), gatherIndices, gatherAxis);
+//     const auto& tensor = std::make_shared<ngraph::opset3::Parameter>(inPrecision, ngraph::Shape{800});
+//     const auto& staticShapeNonZero = std::make_shared<ngraph::vpu::op::StaticShapeNonZero>(tensor);
+//     const auto& dynamicShapeResolver = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(
+//             staticShapeNonZero->output(0), staticShapeNonZero->output(1));
+//     const auto& gatherIndices = std::make_shared<ngraph::opset3::Constant>(ngraph::element::i64, ngraph::Shape{1}, std::vector<int64_t>{0});
+//     const auto& gatherAxis = std::make_shared<ngraph::opset3::Constant>(ngraph::element::i64, ngraph::Shape{1}, std::vector<int64_t>{1});
+//     const auto& gather = std::make_shared<ngraph::opset3::Gather>(dynamicShapeResolver->output(0), gatherIndices, gatherAxis);
 
-    const auto& fnPtr = std::make_shared<ngraph::Function>(ngraph::NodeVector{gather}, ngraph::ParameterVector{tensor});
+//     const auto& fnPtr = std::make_shared<ngraph::Function>(ngraph::NodeVector{gather}, ngraph::ParameterVector{tensor});
 
-    InferenceEngine::CNNNetwork cnnNet(fnPtr);
+//     InferenceEngine::CNNNetwork cnnNet(fnPtr);
 
-    ModelPtr model;
-    ASSERT_NO_THROW(model = frontEnd->buildInitialModel(cnnNet));
+//     ModelPtr model;
+//     ASSERT_NO_THROW(model = frontEnd->buildInitialModel(cnnNet));
 
-    const auto& it = std::find_if(model->getStages().begin(), model->getStages().end(), [](const Stage& stage) {
-        return stage->type() == StageType::NonZero;
-    });
+//     const auto& it = std::find_if(model->getStages().begin(), model->getStages().end(), [](const Stage& stage) {
+//         return stage->type() == StageType::NonZero;
+//     });
 
-    ASSERT_NE(it, model->getStages().end());
-    const auto& nonZeroStage = *it;
+//     ASSERT_NE(it, model->getStages().end());
+//     const auto& nonZeroStage = *it;
 
-    checkShapeConnection(nonZeroStage->output(1), nonZeroStage->output(0));
-}
+//     checkShapeConnection(nonZeroStage->output(1), nonZeroStage->output(0));
+// }
 
-TEST_F(DSRParsingFromNgraphTests, DSRWithTwoProducersCreatesConnectionBetweenDataAndShape) {
-    const auto& inPrecision = ::ngraph::element::Type(::ngraph::element::Type_t::i32);
+// TEST_F(DSRParsingFromNgraphTests, DSRWithTwoProducersCreatesConnectionBetweenDataAndShape) {
+//     const auto& inPrecision = ::ngraph::element::Type(::ngraph::element::Type_t::i32);
 
-    const auto& tensor = std::make_shared<ngraph::opset3::Parameter>(inPrecision, ngraph::Shape{800});
-    const auto& staticShapeNonZero = std::make_shared<ngraph::vpu::op::StaticShapeNonZero>(tensor);
-    const auto& reluData = std::make_shared<ngraph::opset3::Relu>(staticShapeNonZero->output(0));
-    const auto& reluShape = std::make_shared<ngraph::opset3::Relu>(staticShapeNonZero->output(1));
-    const auto& dynamicShapeResolver = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(
-        reluData->output(0), reluShape->output(0));
-    const auto& gatherIndices = std::make_shared<ngraph::opset3::Constant>(ngraph::element::i64, ngraph::Shape{1}, std::vector<int64_t>{0});
-    const auto& gatherAxis = std::make_shared<ngraph::opset3::Constant>(ngraph::element::i64, ngraph::Shape{1}, std::vector<int64_t>{1});
-    const auto& gather = std::make_shared<ngraph::opset3::Gather>(dynamicShapeResolver->output(0), gatherIndices, gatherAxis);
+//     const auto& tensor = std::make_shared<ngraph::opset3::Parameter>(inPrecision, ngraph::Shape{800});
+//     const auto& staticShapeNonZero = std::make_shared<ngraph::vpu::op::StaticShapeNonZero>(tensor);
+//     const auto& reluData = std::make_shared<ngraph::opset3::Relu>(staticShapeNonZero->output(0));
+//     const auto& reluShape = std::make_shared<ngraph::opset3::Relu>(staticShapeNonZero->output(1));
+//     const auto& dynamicShapeResolver = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(
+//         reluData->output(0), reluShape->output(0));
+//     const auto& gatherIndices = std::make_shared<ngraph::opset3::Constant>(ngraph::element::i64, ngraph::Shape{1}, std::vector<int64_t>{0});
+//     const auto& gatherAxis = std::make_shared<ngraph::opset3::Constant>(ngraph::element::i64, ngraph::Shape{1}, std::vector<int64_t>{1});
+//     const auto& gather = std::make_shared<ngraph::opset3::Gather>(dynamicShapeResolver->output(0), gatherIndices, gatherAxis);
 
-    const auto& fnPtr = std::make_shared<ngraph::Function>(ngraph::NodeVector{gather}, ngraph::ParameterVector{tensor});
+//     const auto& fnPtr = std::make_shared<ngraph::Function>(ngraph::NodeVector{gather}, ngraph::ParameterVector{tensor});
 
-    InferenceEngine::CNNNetwork cnnNet(fnPtr);
+//     InferenceEngine::CNNNetwork cnnNet(fnPtr);
 
-    ModelPtr model;
-    ASSERT_NO_THROW(model = frontEnd->buildInitialModel(cnnNet));
+//     ModelPtr model;
+//     ASSERT_NO_THROW(model = frontEnd->buildInitialModel(cnnNet));
 
-    const auto& it = std::find_if(model->getStages().begin(), model->getStages().end(), [](const Stage& stage) {
-        return stage->type() == StageType::NonZero;
-    });
+//     const auto& it = std::find_if(model->getStages().begin(), model->getStages().end(), [](const Stage& stage) {
+//         return stage->type() == StageType::NonZero;
+//     });
 
-    ASSERT_NE(it, model->getStages().end());
-    const auto& nonZeroStage = *it;
+//     ASSERT_NE(it, model->getStages().end());
+//     const auto& nonZeroStage = *it;
 
-    const auto& stageReluData = nonZeroStage->output(0)->singleConsumer();
-    const auto& stageReluShape = nonZeroStage->output(1)->singleConsumer();
+//     const auto& stageReluData = nonZeroStage->output(0)->singleConsumer();
+//     const auto& stageReluShape = nonZeroStage->output(1)->singleConsumer();
 
-    checkShapeConnection(stageReluShape->output(0), stageReluData->output(0));
-}
+//     checkShapeConnection(stageReluShape->output(0), stageReluData->output(0));
+// }
 
-} // namespace vpu
+// } // namespace vpu

--- a/inference-engine/tests/unit/vpu/middleend_tests/edges_tests/data_to_shape_edge.cpp
+++ b/inference-engine/tests/unit/vpu/middleend_tests/edges_tests/data_to_shape_edge.cpp
@@ -1,414 +1,414 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
 
-#include "graph_transformer_tests.hpp"
+// #include "graph_transformer_tests.hpp"
 
-namespace vpu {
+// namespace vpu {
 
-namespace ie = InferenceEngine;
+// namespace ie = InferenceEngine;
 
-class DataToShapeEdgeProcessingTests : public GraphTransformerTest {
-protected:
-    void SetUp() override {
-        ASSERT_NO_FATAL_FAILURE(GraphTransformerTest::SetUp());
+// class DataToShapeEdgeProcessingTests : public GraphTransformerTest {
+// protected:
+//     void SetUp() override {
+//         ASSERT_NO_FATAL_FAILURE(GraphTransformerTest::SetUp());
 
-        ASSERT_NO_FATAL_FAILURE(InitCompileEnv());
+//         ASSERT_NO_FATAL_FAILURE(InitCompileEnv());
 
-        _middleEnd = passManager->buildMiddleEnd();
-        _testModel = CreateTestModel();
-    }
+//         _middleEnd = passManager->buildMiddleEnd();
+//         _testModel = CreateTestModel();
+//     }
 
-    void setupNetWithNonProcessingShape() {
-        //
-        //                       -> [Shape]
-        // [Input] -> (ShapeProd)      |
-        //                       -> [Data] -> (Stage) -> [Output]
-        //
+//     void setupNetWithNonProcessingShape() {
+//         //
+//         //                       -> [Shape]
+//         // [Input] -> (ShapeProd)      |
+//         //                       -> [Data] -> (Stage) -> [Output]
+//         //
 
-        const auto& dataDesc = DataDesc({800});
-        const auto& shapeDesc = DataDesc({1});
+//         const auto& dataDesc = DataDesc({800});
+//         const auto& shapeDesc = DataDesc({1});
 
-        _testModel.createInputs({dataDesc});
-        _testModel.createOutputs({dataDesc});
+//         _testModel.createInputs({dataDesc});
+//         _testModel.createOutputs({dataDesc});
 
-        auto shapeParent = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(dataDesc),
-                                                                            OutputInfo::intermediate(shapeDesc)});
-        _testModel.addStage({InputInfo::fromPrevStage(0)}, {OutputInfo::fromNetwork()});
+//         auto shapeParent = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(dataDesc),
+//                                                                             OutputInfo::intermediate(shapeDesc)});
+//         _testModel.addStage({InputInfo::fromPrevStage(0)}, {OutputInfo::fromNetwork()});
 
-        auto model = _testModel.getBaseModel();
-        model->connectDataWithShape(shapeParent->output(1), shapeParent->output(0));
-    }
+//         auto model = _testModel.getBaseModel();
+//         model->connectDataWithShape(shapeParent->output(1), shapeParent->output(0));
+//     }
 
-    void setupNetWithShapeBeingProcessedOnce() {
-        //
-        //                       -> [Shape] -> (ShapeProc) -> [Shape]
-        // [Input] -> (ShapeProd)      |                         |
-        //                       -> [Data]  -> (DataProc)  -> [Data] -> (Stage) -> [Output]
-        //
+//     void setupNetWithShapeBeingProcessedOnce() {
+//         //
+//         //                       -> [Shape] -> (ShapeProc) -> [Shape]
+//         // [Input] -> (ShapeProd)      |                         |
+//         //                       -> [Data]  -> (DataProc)  -> [Data] -> (Stage) -> [Output]
+//         //
 
-        const auto& dataDesc = DataDesc({800});
-        const auto& shapeDesc = DataDesc({1});
+//         const auto& dataDesc = DataDesc({800});
+//         const auto& shapeDesc = DataDesc({1});
 
-        _testModel.createInputs({dataDesc});
-        _testModel.createOutputs({dataDesc});
+//         _testModel.createInputs({dataDesc});
+//         _testModel.createOutputs({dataDesc});
 
-        auto model = _testModel.getBaseModel();
+//         auto model = _testModel.getBaseModel();
 
-        auto dataAndShapeParent = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(dataDesc),
-                                                                            OutputInfo::intermediate(shapeDesc)});
-        model->connectDataWithShape(dataAndShapeParent->output(1), dataAndShapeParent->output(0));
+//         auto dataAndShapeParent = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(dataDesc),
+//                                                                             OutputInfo::intermediate(shapeDesc)});
+//         model->connectDataWithShape(dataAndShapeParent->output(1), dataAndShapeParent->output(0));
 
-        auto dataChild = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::intermediate(dataDesc)});
-        auto shapeChild = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::intermediate(shapeDesc)});
-        _testModel.addStage({InputInfo::fromPrevStage(1)}, {OutputInfo::fromNetwork()});
+//         auto dataChild = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::intermediate(dataDesc)});
+//         auto shapeChild = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::intermediate(shapeDesc)});
+//         _testModel.addStage({InputInfo::fromPrevStage(1)}, {OutputInfo::fromNetwork()});
 
-        model->connectDataWithShape(shapeChild->output(0), dataChild->output(0));
-    }
+//         model->connectDataWithShape(shapeChild->output(0), dataChild->output(0));
+//     }
 
-    void setupNetWithShapeBeingProcessedTwice() {
-        //
-        //                       -> [Shape] -> (ShapeProc) -> [Shape] -> (ShapeProc) -> [Shape]
-        // [Input] -> (ShapeProd)      |                         |                         |
-        //                       -> [Data]  -> (DataProc)  -> [Data]  -> (DataProc)  -> [Data] -> (Stage) -> [Output]
-        //
+//     void setupNetWithShapeBeingProcessedTwice() {
+//         //
+//         //                       -> [Shape] -> (ShapeProc) -> [Shape] -> (ShapeProc) -> [Shape]
+//         // [Input] -> (ShapeProd)      |                         |                         |
+//         //                       -> [Data]  -> (DataProc)  -> [Data]  -> (DataProc)  -> [Data] -> (Stage) -> [Output]
+//         //
 
-        const auto& dataDesc = DataDesc({800});
-        const auto& shapeDesc = DataDesc({1});
+//         const auto& dataDesc = DataDesc({800});
+//         const auto& shapeDesc = DataDesc({1});
 
-        _testModel.createInputs({dataDesc});
-        _testModel.createOutputs({dataDesc});
+//         _testModel.createInputs({dataDesc});
+//         _testModel.createOutputs({dataDesc});
 
-        auto model = _testModel.getBaseModel();
+//         auto model = _testModel.getBaseModel();
 
-        auto dataAndShapeParent = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(dataDesc),
-                                                                                   OutputInfo::intermediate(shapeDesc)});
-        model->connectDataWithShape(dataAndShapeParent->output(1), dataAndShapeParent->output(0));
+//         auto dataAndShapeParent = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(dataDesc),
+//                                                                                    OutputInfo::intermediate(shapeDesc)});
+//         model->connectDataWithShape(dataAndShapeParent->output(1), dataAndShapeParent->output(0));
 
-        auto dataChild = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::intermediate(dataDesc)});
-        auto shapeChild = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::intermediate(shapeDesc)});
-        model->connectDataWithShape(shapeChild->output(0), dataChild->output(0));
+//         auto dataChild = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::intermediate(dataDesc)});
+//         auto shapeChild = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::intermediate(shapeDesc)});
+//         model->connectDataWithShape(shapeChild->output(0), dataChild->output(0));
 
-        dataChild = _testModel.addStage({InputInfo::fromPrevStage(1).output(0)}, {OutputInfo::intermediate(dataDesc)});
-        shapeChild = _testModel.addStage({InputInfo::fromPrevStage(2).output(0)}, {OutputInfo::intermediate(shapeDesc)});
-        model->connectDataWithShape(shapeChild->output(0), dataChild->output(0));
+//         dataChild = _testModel.addStage({InputInfo::fromPrevStage(1).output(0)}, {OutputInfo::intermediate(dataDesc)});
+//         shapeChild = _testModel.addStage({InputInfo::fromPrevStage(2).output(0)}, {OutputInfo::intermediate(shapeDesc)});
+//         model->connectDataWithShape(shapeChild->output(0), dataChild->output(0));
 
-        _testModel.addStage({InputInfo::fromPrevStage(3)}, {OutputInfo::fromNetwork()});
-    }
+//         _testModel.addStage({InputInfo::fromPrevStage(3)}, {OutputInfo::fromNetwork()});
+//     }
 
-protected:
-    TestModel _testModel;
-    PassSet::Ptr _middleEnd = nullptr;
-};
+// protected:
+//     TestModel _testModel;
+//     PassSet::Ptr _middleEnd = nullptr;
+// };
 
-TEST_F(DataToShapeEdgeProcessingTests, ShapeDataWithoutConsumerDoesntThrow) {
-    setupNetWithNonProcessingShape();
+// TEST_F(DataToShapeEdgeProcessingTests, ShapeDataWithoutConsumerDoesntThrow) {
+//     setupNetWithNonProcessingShape();
 
-    ASSERT_NO_THROW(_middleEnd->run(_testModel.getBaseModel()));
-}
+//     ASSERT_NO_THROW(_middleEnd->run(_testModel.getBaseModel()));
+// }
 
-TEST_F(DataToShapeEdgeProcessingTests, DataToShapeEdgeSharesMemory) {
-    setupNetWithNonProcessingShape();
+// TEST_F(DataToShapeEdgeProcessingTests, DataToShapeEdgeSharesMemory) {
+//     setupNetWithNonProcessingShape();
 
-    const auto& model = _testModel.getBaseModel();
+//     const auto& model = _testModel.getBaseModel();
 
-    ASSERT_NO_THROW(_middleEnd->run(model));
+//     ASSERT_NO_THROW(_middleEnd->run(model));
 
-    // Find shape producer
-    auto it = std::find_if(model->getStages().begin(), model->getStages().end(), [](const Stage& stage) {
-        return stage->numOutputs() == 2;
-    });
+//     // Find shape producer
+//     auto it = std::find_if(model->getStages().begin(), model->getStages().end(), [](const Stage& stage) {
+//         return stage->numOutputs() == 2;
+//     });
 
-    ASSERT_NE(it, model->getStages().end());
+//     ASSERT_NE(it, model->getStages().end());
 
-    auto shapeProducer = *it;
+//     auto shapeProducer = *it;
 
-    const auto& data = shapeProducer->output(0);
-    ASSERT_NE(data->parentDataToShapeEdge(), nullptr);
-    const auto& edge = data->parentDataToShapeEdge();
-    ASSERT_NE(edge->parent(), nullptr);
+//     const auto& data = shapeProducer->output(0);
+//     ASSERT_NE(data->parentDataToShapeEdge(), nullptr);
+//     const auto& edge = data->parentDataToShapeEdge();
+//     ASSERT_NE(edge->parent(), nullptr);
 
-    const auto& shapeDataLocation = edge->parent()->dataLocation();
+//     const auto& shapeDataLocation = edge->parent()->dataLocation();
 
-    const auto& dataShapeLocation = data->shapeLocation();
+//     const auto& dataShapeLocation = data->shapeLocation();
 
-    ASSERT_EQ(shapeDataLocation.location, dataShapeLocation.dimsLocation);
-    ASSERT_EQ(shapeDataLocation.offset, dataShapeLocation.dimsOffset);
-}
+//     ASSERT_EQ(shapeDataLocation.location, dataShapeLocation.dimsLocation);
+//     ASSERT_EQ(shapeDataLocation.offset, dataShapeLocation.dimsOffset);
+// }
 
-TEST_F(DataToShapeEdgeProcessingTests, ShapeProcessingOnceDoesntThrow) {
-    setupNetWithShapeBeingProcessedOnce();
+// TEST_F(DataToShapeEdgeProcessingTests, ShapeProcessingOnceDoesntThrow) {
+//     setupNetWithShapeBeingProcessedOnce();
 
-    ASSERT_NO_THROW(_middleEnd->run(_testModel.getBaseModel()));
-}
+//     ASSERT_NO_THROW(_middleEnd->run(_testModel.getBaseModel()));
+// }
 
-TEST_F(DataToShapeEdgeProcessingTests, ShapeProcessingOnceSharesMemory) {
-    setupNetWithShapeBeingProcessedOnce();
+// TEST_F(DataToShapeEdgeProcessingTests, ShapeProcessingOnceSharesMemory) {
+//     setupNetWithShapeBeingProcessedOnce();
 
-    const auto& model = _testModel.getBaseModel();
+//     const auto& model = _testModel.getBaseModel();
 
-    ASSERT_NO_THROW(_middleEnd->run(model));
+//     ASSERT_NO_THROW(_middleEnd->run(model));
 
-    // Find shape producer
-    auto it = std::find_if(model->getStages().begin(), model->getStages().end(), [](const Stage& stage) {
-        return stage->numOutputs() == 2;
-    });
+//     // Find shape producer
+//     auto it = std::find_if(model->getStages().begin(), model->getStages().end(), [](const Stage& stage) {
+//         return stage->numOutputs() == 2;
+//     });
 
-    ASSERT_NE(it, model->getStages().end());
+//     ASSERT_NE(it, model->getStages().end());
 
-    auto shapeProducer = *it;
+//     auto shapeProducer = *it;
 
-    const auto& data = shapeProducer->output(0);
-    ASSERT_NE(data->parentDataToShapeEdge(), nullptr);
-    auto edge = data->parentDataToShapeEdge();
-    ASSERT_NE(edge->parent(), nullptr);
+//     const auto& data = shapeProducer->output(0);
+//     ASSERT_NE(data->parentDataToShapeEdge(), nullptr);
+//     auto edge = data->parentDataToShapeEdge();
+//     ASSERT_NE(edge->parent(), nullptr);
 
-    const auto& shapeDataLocation = edge->parent()->dataLocation();
-    const auto& dataShapeLocation = data->shapeLocation();
+//     const auto& shapeDataLocation = edge->parent()->dataLocation();
+//     const auto& dataShapeLocation = data->shapeLocation();
 
-    ASSERT_EQ(shapeDataLocation.location, dataShapeLocation.dimsLocation);
-    ASSERT_EQ(shapeDataLocation.offset, dataShapeLocation.dimsOffset);
+//     ASSERT_EQ(shapeDataLocation.location, dataShapeLocation.dimsLocation);
+//     ASSERT_EQ(shapeDataLocation.offset, dataShapeLocation.dimsOffset);
 
-    const auto& processedData = data->singleConsumer()->output(0);
-    ASSERT_NE(processedData->parentDataToShapeEdge(), nullptr);
-    edge = processedData->parentDataToShapeEdge();
-    ASSERT_NE(edge->parent(), nullptr);
+//     const auto& processedData = data->singleConsumer()->output(0);
+//     ASSERT_NE(processedData->parentDataToShapeEdge(), nullptr);
+//     edge = processedData->parentDataToShapeEdge();
+//     ASSERT_NE(edge->parent(), nullptr);
 
-    const auto& processedShapeDataLocation = edge->parent()->dataLocation();
-    const auto& processedDataShapeLocation = processedData->shapeLocation();
+//     const auto& processedShapeDataLocation = edge->parent()->dataLocation();
+//     const auto& processedDataShapeLocation = processedData->shapeLocation();
 
-    ASSERT_EQ(processedShapeDataLocation.location, processedDataShapeLocation.dimsLocation);
-    ASSERT_EQ(processedShapeDataLocation.offset, processedDataShapeLocation.dimsOffset);
-}
+//     ASSERT_EQ(processedShapeDataLocation.location, processedDataShapeLocation.dimsLocation);
+//     ASSERT_EQ(processedShapeDataLocation.offset, processedDataShapeLocation.dimsOffset);
+// }
 
-TEST_F(DataToShapeEdgeProcessingTests, ShapeProcessingOnceHasCorrectExecutionOrder) {
-    setupNetWithShapeBeingProcessedOnce();
+// TEST_F(DataToShapeEdgeProcessingTests, ShapeProcessingOnceHasCorrectExecutionOrder) {
+//     setupNetWithShapeBeingProcessedOnce();
 
-    const auto& model = _testModel.getBaseModel();
+//     const auto& model = _testModel.getBaseModel();
 
-    ASSERT_NO_THROW(_middleEnd->run(model));
+//     ASSERT_NO_THROW(_middleEnd->run(model));
 
-    // Find shape producer
-    auto it = std::find_if(model->getStages().begin(), model->getStages().end(), [](const Stage& stage) {
-        return stage->numOutputs() == 2;
-    });
+//     // Find shape producer
+//     auto it = std::find_if(model->getStages().begin(), model->getStages().end(), [](const Stage& stage) {
+//         return stage->numOutputs() == 2;
+//     });
 
-    ASSERT_NE(it, model->getStages().end());
+//     ASSERT_NE(it, model->getStages().end());
 
-    auto shapeProducer = *it;
+//     auto shapeProducer = *it;
 
-    const auto dataProcessor = shapeProducer->output(0)->singleConsumer();
-    ASSERT_NE(shapeProducer->output(0)->parentDataToShapeEdge(), nullptr);
-    const auto& edge = shapeProducer->output(0)->parentDataToShapeEdge();
-    ASSERT_NE(edge->parent(), nullptr);
+//     const auto dataProcessor = shapeProducer->output(0)->singleConsumer();
+//     ASSERT_NE(shapeProducer->output(0)->parentDataToShapeEdge(), nullptr);
+//     const auto& edge = shapeProducer->output(0)->parentDataToShapeEdge();
+//     ASSERT_NE(edge->parent(), nullptr);
 
-    ASSERT_TRUE(checkExecutionOrder(model, {edge->parent()->producer()->id(), dataProcessor->id()}));
-}
+//     ASSERT_TRUE(checkExecutionOrder(model, {edge->parent()->producer()->id(), dataProcessor->id()}));
+// }
 
-TEST_F(DataToShapeEdgeProcessingTests, ShapeProcessingTwiceDoesntThrow) {
-    setupNetWithShapeBeingProcessedTwice();
+// TEST_F(DataToShapeEdgeProcessingTests, ShapeProcessingTwiceDoesntThrow) {
+//     setupNetWithShapeBeingProcessedTwice();
 
-    ASSERT_NO_THROW(_middleEnd->run(_testModel.getBaseModel()));
-}
+//     ASSERT_NO_THROW(_middleEnd->run(_testModel.getBaseModel()));
+// }
 
-TEST_F(DataToShapeEdgeProcessingTests, ShapeProcessingTwiceSharesMemory) {
-    setupNetWithShapeBeingProcessedTwice();
+// TEST_F(DataToShapeEdgeProcessingTests, ShapeProcessingTwiceSharesMemory) {
+//     setupNetWithShapeBeingProcessedTwice();
 
-    const auto& model = _testModel.getBaseModel();
+//     const auto& model = _testModel.getBaseModel();
 
-    ASSERT_NO_THROW(_middleEnd->run(model));
+//     ASSERT_NO_THROW(_middleEnd->run(model));
 
-    // Find shape producer
-    auto it = std::find_if(model->getStages().begin(), model->getStages().end(), [](const Stage& stage) {
-        return stage->numOutputs() == 2;
-    });
+//     // Find shape producer
+//     auto it = std::find_if(model->getStages().begin(), model->getStages().end(), [](const Stage& stage) {
+//         return stage->numOutputs() == 2;
+//     });
 
-    ASSERT_NE(it, model->getStages().end());
+//     ASSERT_NE(it, model->getStages().end());
 
-    auto shapeProducer = *it;
+//     auto shapeProducer = *it;
 
-    const auto& data = shapeProducer->output(0);
-    ASSERT_NE(data->parentDataToShapeEdge(), nullptr);
-    auto edge = data->parentDataToShapeEdge();
-    ASSERT_NE(edge->parent(), nullptr);
+//     const auto& data = shapeProducer->output(0);
+//     ASSERT_NE(data->parentDataToShapeEdge(), nullptr);
+//     auto edge = data->parentDataToShapeEdge();
+//     ASSERT_NE(edge->parent(), nullptr);
 
-    const auto& shapeDataLocation = edge->parent()->dataLocation();
-    const auto& dataShapeLocation = data->shapeLocation();
+//     const auto& shapeDataLocation = edge->parent()->dataLocation();
+//     const auto& dataShapeLocation = data->shapeLocation();
 
-    ASSERT_EQ(shapeDataLocation.location, dataShapeLocation.dimsLocation);
-    ASSERT_EQ(shapeDataLocation.offset, dataShapeLocation.dimsOffset);
+//     ASSERT_EQ(shapeDataLocation.location, dataShapeLocation.dimsLocation);
+//     ASSERT_EQ(shapeDataLocation.offset, dataShapeLocation.dimsOffset);
 
-    const auto& dataProcessedOnce = data->singleConsumer()->output(0);
-    ASSERT_NE(dataProcessedOnce->parentDataToShapeEdge(), nullptr);
-    edge = dataProcessedOnce->parentDataToShapeEdge();
-    ASSERT_NE(edge->parent(), nullptr);
+//     const auto& dataProcessedOnce = data->singleConsumer()->output(0);
+//     ASSERT_NE(dataProcessedOnce->parentDataToShapeEdge(), nullptr);
+//     edge = dataProcessedOnce->parentDataToShapeEdge();
+//     ASSERT_NE(edge->parent(), nullptr);
 
-    auto processedShapeDataLocation = edge->parent()->dataLocation();
-    auto processedDataShapeLocation = dataProcessedOnce->shapeLocation();
+//     auto processedShapeDataLocation = edge->parent()->dataLocation();
+//     auto processedDataShapeLocation = dataProcessedOnce->shapeLocation();
 
-    ASSERT_EQ(processedShapeDataLocation.location, processedDataShapeLocation.dimsLocation);
-    ASSERT_EQ(processedShapeDataLocation.offset, processedDataShapeLocation.dimsOffset);
+//     ASSERT_EQ(processedShapeDataLocation.location, processedDataShapeLocation.dimsLocation);
+//     ASSERT_EQ(processedShapeDataLocation.offset, processedDataShapeLocation.dimsOffset);
 
-    const auto dataProcessedTwice = dataProcessedOnce->singleConsumer()->output(0);
-    ASSERT_NE(dataProcessedTwice->parentDataToShapeEdge(), nullptr);
-    edge = dataProcessedTwice->parentDataToShapeEdge();
-    ASSERT_NE(edge->parent(), nullptr);
+//     const auto dataProcessedTwice = dataProcessedOnce->singleConsumer()->output(0);
+//     ASSERT_NE(dataProcessedTwice->parentDataToShapeEdge(), nullptr);
+//     edge = dataProcessedTwice->parentDataToShapeEdge();
+//     ASSERT_NE(edge->parent(), nullptr);
 
-    processedShapeDataLocation = edge->parent()->dataLocation();
-    processedDataShapeLocation = dataProcessedTwice->shapeLocation();
+//     processedShapeDataLocation = edge->parent()->dataLocation();
+//     processedDataShapeLocation = dataProcessedTwice->shapeLocation();
 
-    ASSERT_EQ(processedShapeDataLocation.location, processedDataShapeLocation.dimsLocation);
-    ASSERT_EQ(processedShapeDataLocation.offset, processedDataShapeLocation.dimsOffset);
-}
+//     ASSERT_EQ(processedShapeDataLocation.location, processedDataShapeLocation.dimsLocation);
+//     ASSERT_EQ(processedShapeDataLocation.offset, processedDataShapeLocation.dimsOffset);
+// }
 
-TEST_F(DataToShapeEdgeProcessingTests, ShapeProcessingTwiceHasCorrectExecutionOrder) {
-    setupNetWithShapeBeingProcessedTwice();
+// TEST_F(DataToShapeEdgeProcessingTests, ShapeProcessingTwiceHasCorrectExecutionOrder) {
+//     setupNetWithShapeBeingProcessedTwice();
 
-    const auto& model = _testModel.getBaseModel();
+//     const auto& model = _testModel.getBaseModel();
 
-    ASSERT_NO_THROW(_middleEnd->run(model));
+//     ASSERT_NO_THROW(_middleEnd->run(model));
 
-    // Find shape producer
-    auto it = std::find_if(model->getStages().begin(), model->getStages().end(), [](const Stage& stage) {
-        return stage->numOutputs() == 2;
-    });
+//     // Find shape producer
+//     auto it = std::find_if(model->getStages().begin(), model->getStages().end(), [](const Stage& stage) {
+//         return stage->numOutputs() == 2;
+//     });
 
-    ASSERT_NE(it, model->getStages().end());
+//     ASSERT_NE(it, model->getStages().end());
 
-    auto shapeProducer = *it;
+//     auto shapeProducer = *it;
 
-    const auto dataFirstProcessor = shapeProducer->output(0)->singleConsumer();
-    ASSERT_NE(shapeProducer->output(0)->parentDataToShapeEdge(), nullptr);
-    auto edge = shapeProducer->output(0)->parentDataToShapeEdge();
-    ASSERT_NE(edge->parent(), nullptr);
+//     const auto dataFirstProcessor = shapeProducer->output(0)->singleConsumer();
+//     ASSERT_NE(shapeProducer->output(0)->parentDataToShapeEdge(), nullptr);
+//     auto edge = shapeProducer->output(0)->parentDataToShapeEdge();
+//     ASSERT_NE(edge->parent(), nullptr);
 
-    ASSERT_TRUE(checkExecutionOrder(model, {edge->parent()->producer()->id(), dataFirstProcessor->id()}));
+//     ASSERT_TRUE(checkExecutionOrder(model, {edge->parent()->producer()->id(), dataFirstProcessor->id()}));
 
-    const auto dataSecondProcessor = dataFirstProcessor->output(0)->singleConsumer();
-    ASSERT_NE(dataSecondProcessor->input(0)->parentDataToShapeEdge(), nullptr);
-    edge = dataSecondProcessor->input(0)->parentDataToShapeEdge();
-    ASSERT_NE(edge->parent(), nullptr);
+//     const auto dataSecondProcessor = dataFirstProcessor->output(0)->singleConsumer();
+//     ASSERT_NE(dataSecondProcessor->input(0)->parentDataToShapeEdge(), nullptr);
+//     edge = dataSecondProcessor->input(0)->parentDataToShapeEdge();
+//     ASSERT_NE(edge->parent(), nullptr);
 
-    ASSERT_TRUE(checkExecutionOrder(model, {edge->parent()->producer()->id(), dataSecondProcessor->id()}));
-}
+//     ASSERT_TRUE(checkExecutionOrder(model, {edge->parent()->producer()->id(), dataSecondProcessor->id()}));
+// }
 
-TEST_F(DataToShapeEdgeProcessingTests, ReplaceDataToShapeParentReplacesConnections) {
-    //
-    //                    -> [Shape] -> (ShapeProc) -> [Shape]
-    //                                                    |
-    // [Input] -> (Stage) -> [Data]  -> (DataProc)  -> [Data]
-    //                                                    |
-    //                    -> [Shape] -> (ShapeProc) -> [Shape]
-    //
+// TEST_F(DataToShapeEdgeProcessingTests, ReplaceDataToShapeParentReplacesConnections) {
+//     //
+//     //                    -> [Shape] -> (ShapeProc) -> [Shape]
+//     //                                                    |
+//     // [Input] -> (Stage) -> [Data]  -> (DataProc)  -> [Data]
+//     //                                                    |
+//     //                    -> [Shape] -> (ShapeProc) -> [Shape]
+//     //
 
-    const auto& desc = DataDesc({1});
+//     const auto& desc = DataDesc({1});
 
-    _testModel.createInputs({desc});
-    _testModel.createOutputs({desc, desc, desc});
+//     _testModel.createInputs({desc});
+//     _testModel.createOutputs({desc, desc, desc});
 
-    const auto dataAndShapeParent = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
-                                                                               OutputInfo::intermediate(desc),
-                                                                               OutputInfo::intermediate(desc)});
-    const auto firstShapeProcessor = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
-    const auto dataProcessor = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
-    const auto secondShapeProcessor = _testModel.addStage({InputInfo::fromPrevStage(0).output(2)}, {OutputInfo::fromNetwork(2)});
+//     const auto dataAndShapeParent = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
+//                                                                                OutputInfo::intermediate(desc),
+//                                                                                OutputInfo::intermediate(desc)});
+//     const auto firstShapeProcessor = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
+//     const auto dataProcessor = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
+//     const auto secondShapeProcessor = _testModel.addStage({InputInfo::fromPrevStage(0).output(2)}, {OutputInfo::fromNetwork(2)});
 
-    const auto& model = _testModel.getBaseModel();
-    const auto& processedData = dataProcessor->output(0);
-    const auto& initialShape = firstShapeProcessor->output(0);
-    const auto& finalShape = secondShapeProcessor->output(0);
-    ASSERT_NO_THROW(model->connectDataWithShape(initialShape, processedData));
+//     const auto& model = _testModel.getBaseModel();
+//     const auto& processedData = dataProcessor->output(0);
+//     const auto& initialShape = firstShapeProcessor->output(0);
+//     const auto& finalShape = secondShapeProcessor->output(0);
+//     ASSERT_NO_THROW(model->connectDataWithShape(initialShape, processedData));
 
-    const auto& dataToShapeEdge = processedData->parentDataToShapeEdge();
-    ASSERT_NE(dataToShapeEdge, nullptr);
+//     const auto& dataToShapeEdge = processedData->parentDataToShapeEdge();
+//     ASSERT_NE(dataToShapeEdge, nullptr);
 
-    ASSERT_NO_THROW(model->replaceDataToShapeParent(dataToShapeEdge, finalShape));
+//     ASSERT_NO_THROW(model->replaceDataToShapeParent(dataToShapeEdge, finalShape));
 
-    ASSERT_TRUE(initialShape->childDataToShapeEdges().empty());
-    ASSERT_EQ(finalShape->childDataToShapeEdges().front(), dataToShapeEdge);
-    ASSERT_EQ(dataToShapeEdge->parent(), finalShape);
+//     ASSERT_TRUE(initialShape->childDataToShapeEdges().empty());
+//     ASSERT_EQ(finalShape->childDataToShapeEdges().front(), dataToShapeEdge);
+//     ASSERT_EQ(dataToShapeEdge->parent(), finalShape);
 
-    ASSERT_TRUE(firstShapeProcessor->childDependencyEdges().empty());
-    ASSERT_FALSE(secondShapeProcessor->childDependencyEdges().empty());
+//     ASSERT_TRUE(firstShapeProcessor->childDependencyEdges().empty());
+//     ASSERT_FALSE(secondShapeProcessor->childDependencyEdges().empty());
 
-    const auto& stageDependencyEdge = secondShapeProcessor->childDependencyEdges().front();
-    ASSERT_EQ(stageDependencyEdge->child(), dataProcessor);
-    ASSERT_EQ(stageDependencyEdge->parent(), secondShapeProcessor);
-}
+//     const auto& stageDependencyEdge = secondShapeProcessor->childDependencyEdges().front();
+//     ASSERT_EQ(stageDependencyEdge->child(), dataProcessor);
+//     ASSERT_EQ(stageDependencyEdge->parent(), secondShapeProcessor);
+// }
 
-TEST_F(DataToShapeEdgeProcessingTests, ReplaceDataToShapeChildReplacesConnections) {
-    //
-    //                    -> [Data]  -> (DataProc)  -> [Data]
-    //                                                    |
-    // [Input] -> (Stage) -> [Shape] -> (ShapeProc) -> [Shape]
-    //                                                    |
-    //                    -> [Data]  -> (DataProc)  -> [Data]
-    //
+// TEST_F(DataToShapeEdgeProcessingTests, ReplaceDataToShapeChildReplacesConnections) {
+//     //
+//     //                    -> [Data]  -> (DataProc)  -> [Data]
+//     //                                                    |
+//     // [Input] -> (Stage) -> [Shape] -> (ShapeProc) -> [Shape]
+//     //                                                    |
+//     //                    -> [Data]  -> (DataProc)  -> [Data]
+//     //
 
-    const auto& desc = DataDesc({1});
+//     const auto& desc = DataDesc({1});
 
-    _testModel.createInputs({desc});
-    _testModel.createOutputs({desc, desc, desc});
+//     _testModel.createInputs({desc});
+//     _testModel.createOutputs({desc, desc, desc});
 
-    const auto dataAndShapeParent = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
-                                                                                     OutputInfo::intermediate(desc),
-                                                                                     OutputInfo::intermediate(desc)});
-    const auto firstDataProcessor = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
-    const auto shapeProcessor = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
-    const auto secondDataProcessor = _testModel.addStage({InputInfo::fromPrevStage(0).output(2)}, {OutputInfo::fromNetwork(2)});
+//     const auto dataAndShapeParent = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
+//                                                                                      OutputInfo::intermediate(desc),
+//                                                                                      OutputInfo::intermediate(desc)});
+//     const auto firstDataProcessor = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
+//     const auto shapeProcessor = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
+//     const auto secondDataProcessor = _testModel.addStage({InputInfo::fromPrevStage(0).output(2)}, {OutputInfo::fromNetwork(2)});
 
-    const auto& model = _testModel.getBaseModel();
-    const auto& processedShape = shapeProcessor->output(0);
-    const auto& initialData = firstDataProcessor->output(0);
-    const auto& finalData = secondDataProcessor->output(0);
-    ASSERT_NO_THROW(model->connectDataWithShape(processedShape, initialData));
+//     const auto& model = _testModel.getBaseModel();
+//     const auto& processedShape = shapeProcessor->output(0);
+//     const auto& initialData = firstDataProcessor->output(0);
+//     const auto& finalData = secondDataProcessor->output(0);
+//     ASSERT_NO_THROW(model->connectDataWithShape(processedShape, initialData));
 
-    const auto& dataToShapeEdge = processedShape->childDataToShapeEdges().front();
-    ASSERT_NE(dataToShapeEdge, nullptr);
+//     const auto& dataToShapeEdge = processedShape->childDataToShapeEdges().front();
+//     ASSERT_NE(dataToShapeEdge, nullptr);
 
-    ASSERT_NO_THROW(model->replaceDataToShapeChild(dataToShapeEdge, finalData));
+//     ASSERT_NO_THROW(model->replaceDataToShapeChild(dataToShapeEdge, finalData));
 
-    ASSERT_EQ(initialData->parentDataToShapeEdge(), nullptr);
-    ASSERT_EQ(finalData->parentDataToShapeEdge(), dataToShapeEdge);
-    ASSERT_EQ(dataToShapeEdge->child(), finalData);
+//     ASSERT_EQ(initialData->parentDataToShapeEdge(), nullptr);
+//     ASSERT_EQ(finalData->parentDataToShapeEdge(), dataToShapeEdge);
+//     ASSERT_EQ(dataToShapeEdge->child(), finalData);
 
-    ASSERT_FALSE(shapeProcessor->childDependencyEdges().empty());
-    const auto& stageDependencyEdge = shapeProcessor->childDependencyEdges().front();
+//     ASSERT_FALSE(shapeProcessor->childDependencyEdges().empty());
+//     const auto& stageDependencyEdge = shapeProcessor->childDependencyEdges().front();
 
-    ASSERT_EQ(stageDependencyEdge->child(), secondDataProcessor);
-    ASSERT_EQ(stageDependencyEdge->parent(), shapeProcessor);
-}
+//     ASSERT_EQ(stageDependencyEdge->child(), secondDataProcessor);
+//     ASSERT_EQ(stageDependencyEdge->parent(), shapeProcessor);
+// }
 
-TEST_F(DataToShapeEdgeProcessingTests, DisconnectDatasRemovesConnections) {
-    //
-    //                    -> [Shape] -> (ShapeProc) -> [Shape]
-    // [Input] -> (Stage)                                 |
-    //                    -> [Data]  -> (DataProc)  -> [Data]
-    //
+// TEST_F(DataToShapeEdgeProcessingTests, DisconnectDatasRemovesConnections) {
+//     //
+//     //                    -> [Shape] -> (ShapeProc) -> [Shape]
+//     // [Input] -> (Stage)                                 |
+//     //                    -> [Data]  -> (DataProc)  -> [Data]
+//     //
 
-    const auto& desc = DataDesc({1});
+//     const auto& desc = DataDesc({1});
 
-    _testModel.createInputs({desc});
-    _testModel.createOutputs({desc, desc});
+//     _testModel.createInputs({desc});
+//     _testModel.createOutputs({desc, desc});
 
-    const auto dataAndShapeParent = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
-                                                                                     OutputInfo::intermediate(desc)});
-    const auto dataProcessor = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
-    const auto shapeProcessor = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
+//     const auto dataAndShapeParent = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
+//                                                                                      OutputInfo::intermediate(desc)});
+//     const auto dataProcessor = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
+//     const auto shapeProcessor = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
 
-    const auto& model = _testModel.getBaseModel();
-    const auto& processedData = dataProcessor->output(0);
-    const auto& processedShape = shapeProcessor->output(0);
-    ASSERT_NO_THROW(model->connectDataWithShape(processedShape, processedData));
+//     const auto& model = _testModel.getBaseModel();
+//     const auto& processedData = dataProcessor->output(0);
+//     const auto& processedShape = shapeProcessor->output(0);
+//     ASSERT_NO_THROW(model->connectDataWithShape(processedShape, processedData));
 
-    const auto& dataToShapeEdge = processedShape->childDataToShapeEdges().front();
-    ASSERT_NE(dataToShapeEdge, nullptr);
+//     const auto& dataToShapeEdge = processedShape->childDataToShapeEdges().front();
+//     ASSERT_NE(dataToShapeEdge, nullptr);
 
-    ASSERT_NO_THROW(model->disconnectDatas(dataToShapeEdge));
+//     ASSERT_NO_THROW(model->disconnectDatas(dataToShapeEdge));
 
-    ASSERT_EQ(processedData->parentDataToShapeEdge(), nullptr);
-    ASSERT_TRUE(processedShape->childDataToShapeEdges().empty());
-    ASSERT_TRUE(shapeProcessor->childDependencyEdges().empty());
-}
+//     ASSERT_EQ(processedData->parentDataToShapeEdge(), nullptr);
+//     ASSERT_TRUE(processedShape->childDataToShapeEdges().empty());
+//     ASSERT_TRUE(shapeProcessor->childDependencyEdges().empty());
+// }
 
-} // namespace vpu
+// } // namespace vpu

--- a/inference-engine/tests/unit/vpu/middleend_tests/edges_tests/stage_dependency_edge.cpp
+++ b/inference-engine/tests/unit/vpu/middleend_tests/edges_tests/stage_dependency_edge.cpp
@@ -1,320 +1,320 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
 
-#include "graph_transformer_tests.hpp"
+// #include "graph_transformer_tests.hpp"
 
-namespace vpu {
+// namespace vpu {
 
-namespace ie = InferenceEngine;
+// namespace ie = InferenceEngine;
 
-class StageDependencyEdgeProcessingTests : public GraphTransformerTest {
-protected:
-    void SetUp() override {
-        ASSERT_NO_FATAL_FAILURE(GraphTransformerTest::SetUp());
+// class StageDependencyEdgeProcessingTests : public GraphTransformerTest {
+// protected:
+//     void SetUp() override {
+//         ASSERT_NO_FATAL_FAILURE(GraphTransformerTest::SetUp());
 
-        ASSERT_NO_FATAL_FAILURE(InitCompileEnv());
+//         ASSERT_NO_FATAL_FAILURE(InitCompileEnv());
 
-        _testModel = CreateTestModel();
-    }
+//         _testModel = CreateTestModel();
+//     }
 
-protected:
-    TestModel _testModel;
-};
+// protected:
+//     TestModel _testModel;
+// };
 
-TEST_F(StageDependencyEdgeProcessingTests, AddStageDependencyDoesNotAssertOnOutputProducer) {
-    //
-    //                    -> [Data] -> (Stage) -> [Output]
-    // [Input] -> (Stage)                 |
-    //                    -> [Data] -> (Stage) -> [Output]
-    //
+// TEST_F(StageDependencyEdgeProcessingTests, AddStageDependencyDoesNotAssertOnOutputProducer) {
+//     //
+//     //                    -> [Data] -> (Stage) -> [Output]
+//     // [Input] -> (Stage)                 |
+//     //                    -> [Data] -> (Stage) -> [Output]
+//     //
 
-    const DataDesc desc{1};
+//     const DataDesc desc{1};
 
-    _testModel.createInputs({desc});
-    _testModel.createOutputs({desc, desc});
+//     _testModel.createInputs({desc});
+//     _testModel.createOutputs({desc, desc});
 
-    _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
-                                                     OutputInfo::intermediate(desc)});
-    auto childStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
-    auto parentStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
+//     _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
+//                                                      OutputInfo::intermediate(desc)});
+//     auto childStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
+//     auto parentStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
 
-    auto model = _testModel.getBaseModel();
+//     auto model = _testModel.getBaseModel();
 
-    ASSERT_NO_THROW(model->addStageDependency(parentStage, childStage));
-}
+//     ASSERT_NO_THROW(model->addStageDependency(parentStage, childStage));
+// }
 
-TEST_F(StageDependencyEdgeProcessingTests, AddStageDependencyAssertsIfDependencyExists) {
-    //
-    //                    -> [Data] -> (Stage) -> [Output]
-    // [Input] -> (Stage)                 |
-    //                    -> [Data] -> (Stage) -> [Output]
-    //
+// TEST_F(StageDependencyEdgeProcessingTests, AddStageDependencyAssertsIfDependencyExists) {
+//     //
+//     //                    -> [Data] -> (Stage) -> [Output]
+//     // [Input] -> (Stage)                 |
+//     //                    -> [Data] -> (Stage) -> [Output]
+//     //
 
-    const DataDesc desc{1};
+//     const DataDesc desc{1};
 
-    _testModel.createInputs({desc});
-    _testModel.createOutputs({desc, desc});
+//     _testModel.createInputs({desc});
+//     _testModel.createOutputs({desc, desc});
 
-    _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
-                                                     OutputInfo::intermediate(desc)});
-    auto childStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
-    auto parentStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
+//     _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
+//                                                      OutputInfo::intermediate(desc)});
+//     auto childStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
+//     auto parentStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
 
-    auto model = _testModel.getBaseModel();
+//     auto model = _testModel.getBaseModel();
 
-    ASSERT_NO_THROW(model->addStageDependency(parentStage, childStage));
-    ASSERT_ANY_THROW(model->addStageDependency(parentStage, childStage));
-}
+//     ASSERT_NO_THROW(model->addStageDependency(parentStage, childStage));
+//     ASSERT_ANY_THROW(model->addStageDependency(parentStage, childStage));
+// }
 
-TEST_F(StageDependencyEdgeProcessingTests, NetWithTwoStagesHasCorrectExecOrder) {
-    //
-    //                    -> [Data] -> (Stage) -> [Data] -> (Stage) -> [Output]
-    // [Input] -> (Stage)                 |
-    //                    -> [Data] -> (Stage) -> [Output]
-    //
+// TEST_F(StageDependencyEdgeProcessingTests, NetWithTwoStagesHasCorrectExecOrder) {
+//     //
+//     //                    -> [Data] -> (Stage) -> [Data] -> (Stage) -> [Output]
+//     // [Input] -> (Stage)                 |
+//     //                    -> [Data] -> (Stage) -> [Output]
+//     //
 
-    const DataDesc desc{1};
+//     const DataDesc desc{1};
 
-    _testModel.createInputs({desc});
-    _testModel.createOutputs({desc, desc});
+//     _testModel.createInputs({desc});
+//     _testModel.createOutputs({desc, desc});
 
-    _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
-                                                     OutputInfo::intermediate(desc)});
-    auto childStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
-    auto parentStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::intermediate(desc)});
-    _testModel.addStage({InputInfo::fromPrevStage(2)}, {OutputInfo::fromNetwork(1)});
+//     _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
+//                                                      OutputInfo::intermediate(desc)});
+//     auto childStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
+//     auto parentStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::intermediate(desc)});
+//     _testModel.addStage({InputInfo::fromPrevStage(2)}, {OutputInfo::fromNetwork(1)});
 
-    auto model = _testModel.getBaseModel();
+//     auto model = _testModel.getBaseModel();
 
-    ASSERT_TRUE(checkExecutionOrder(model, {childStage->id(), parentStage->id()}));
+//     ASSERT_TRUE(checkExecutionOrder(model, {childStage->id(), parentStage->id()}));
 
-    ASSERT_NO_THROW(model->addStageDependency(parentStage, childStage));
+//     ASSERT_NO_THROW(model->addStageDependency(parentStage, childStage));
 
-    ASSERT_TRUE(checkExecutionOrder(model, {parentStage->id(), childStage->id()}));
-}
+//     ASSERT_TRUE(checkExecutionOrder(model, {parentStage->id(), childStage->id()}));
+// }
 
-TEST_F(StageDependencyEdgeProcessingTests, NetWithThreeStagesHasCorrectExecOrder) {
-    //
-    //                    -> [Data] -> (Stage) -> [Data] -> (Stage) -> [Data] -> (Stage) -> [Output]
-    // [Input] -> (Stage)                                      |
-    //                    -> [Data] ----------------------> (Stage) -> [Output]
-    //
+// TEST_F(StageDependencyEdgeProcessingTests, NetWithThreeStagesHasCorrectExecOrder) {
+//     //
+//     //                    -> [Data] -> (Stage) -> [Data] -> (Stage) -> [Data] -> (Stage) -> [Output]
+//     // [Input] -> (Stage)                                      |
+//     //                    -> [Data] ----------------------> (Stage) -> [Output]
+//     //
 
-    const DataDesc desc{1};
+//     const DataDesc desc{1};
 
-    _testModel.createInputs({desc});
-    _testModel.createOutputs({desc, desc});
+//     _testModel.createInputs({desc});
+//     _testModel.createOutputs({desc, desc});
 
-    _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
-                                                     OutputInfo::intermediate(desc)});
-    auto childStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
-    _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::intermediate(desc)});
-    auto parentStage = _testModel.addStage({InputInfo::fromPrevStage(2)}, {OutputInfo::intermediate(desc)});
-    _testModel.addStage({InputInfo::fromPrevStage(3)}, {OutputInfo::fromNetwork(1)});
+//     _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
+//                                                      OutputInfo::intermediate(desc)});
+//     auto childStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
+//     _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::intermediate(desc)});
+//     auto parentStage = _testModel.addStage({InputInfo::fromPrevStage(2)}, {OutputInfo::intermediate(desc)});
+//     _testModel.addStage({InputInfo::fromPrevStage(3)}, {OutputInfo::fromNetwork(1)});
 
-    auto model = _testModel.getBaseModel();
+//     auto model = _testModel.getBaseModel();
 
-    ASSERT_TRUE(checkExecutionOrder(model, {childStage->id(), parentStage->id()}));
+//     ASSERT_TRUE(checkExecutionOrder(model, {childStage->id(), parentStage->id()}));
 
-    ASSERT_NO_THROW(model->addStageDependency(parentStage, childStage));
+//     ASSERT_NO_THROW(model->addStageDependency(parentStage, childStage));
 
-    ASSERT_TRUE(checkExecutionOrder(model, {parentStage->id(), childStage->id()}));
-}
+//     ASSERT_TRUE(checkExecutionOrder(model, {parentStage->id(), childStage->id()}));
+// }
 
-TEST_F(StageDependencyEdgeProcessingTests, ReplaceStageDependencyParentAssertsIfDependencyExists) {
-    //
-    //                    -> [Data] -> (Stage) -> [Output]
-    // [Input] -> (Stage)                 |
-    //                    -> [Data] -> (Stage) -> [Output]
-    //
+// TEST_F(StageDependencyEdgeProcessingTests, ReplaceStageDependencyParentAssertsIfDependencyExists) {
+//     //
+//     //                    -> [Data] -> (Stage) -> [Output]
+//     // [Input] -> (Stage)                 |
+//     //                    -> [Data] -> (Stage) -> [Output]
+//     //
 
-    const DataDesc desc{1};
+//     const DataDesc desc{1};
 
-    _testModel.createInputs({desc});
-    _testModel.createOutputs({desc, desc});
+//     _testModel.createInputs({desc});
+//     _testModel.createOutputs({desc, desc});
 
-    _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
-                                                     OutputInfo::intermediate(desc)});
-    auto childStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
-    auto parentStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
+//     _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
+//                                                      OutputInfo::intermediate(desc)});
+//     auto childStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
+//     auto parentStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
 
-    auto model = _testModel.getBaseModel();
+//     auto model = _testModel.getBaseModel();
 
-    ASSERT_NO_THROW(model->addStageDependency(parentStage, childStage));
+//     ASSERT_NO_THROW(model->addStageDependency(parentStage, childStage));
 
-    const auto edge = parentStage->childDependencyEdges().front();
+//     const auto edge = parentStage->childDependencyEdges().front();
 
-    ASSERT_ANY_THROW(model->replaceStageDependencyParent(edge, parentStage));
-}
+//     ASSERT_ANY_THROW(model->replaceStageDependencyParent(edge, parentStage));
+// }
 
-TEST_F(StageDependencyEdgeProcessingTests, ReplaceStageDependencyParentReplacesConnection) {
-    //
-    //                    -> [Data] -> (Stage) -> [Output]
-    //
-    // [Input] -> (Stage) -> [Data] -> (Stage) -> [Output]
-    //                                    |
-    //                    -> [Data] -> (Stage) -> [Output]
-    //
+// TEST_F(StageDependencyEdgeProcessingTests, ReplaceStageDependencyParentReplacesConnection) {
+//     //
+//     //                    -> [Data] -> (Stage) -> [Output]
+//     //
+//     // [Input] -> (Stage) -> [Data] -> (Stage) -> [Output]
+//     //                                    |
+//     //                    -> [Data] -> (Stage) -> [Output]
+//     //
 
-    const DataDesc desc{1};
+//     const DataDesc desc{1};
 
-    _testModel.createInputs({desc});
-    _testModel.createOutputs({desc, desc, desc});
+//     _testModel.createInputs({desc});
+//     _testModel.createOutputs({desc, desc, desc});
 
-    _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
-                                                     OutputInfo::intermediate(desc),
-                                                     OutputInfo::intermediate(desc)});
-    auto childStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
-    auto initialParentStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
-    auto resultParentStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(2)}, {OutputInfo::fromNetwork(2)});
+//     _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
+//                                                      OutputInfo::intermediate(desc),
+//                                                      OutputInfo::intermediate(desc)});
+//     auto childStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
+//     auto initialParentStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
+//     auto resultParentStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(2)}, {OutputInfo::fromNetwork(2)});
 
-    auto model = _testModel.getBaseModel();
+//     auto model = _testModel.getBaseModel();
 
-    ASSERT_NO_THROW(model->addStageDependency(initialParentStage, childStage));
+//     ASSERT_NO_THROW(model->addStageDependency(initialParentStage, childStage));
 
-    ASSERT_TRUE(checkExecutionOrder(model, {initialParentStage->id(), childStage->id()}));
-    ASSERT_TRUE(checkExecutionOrder(model, {childStage->id(), resultParentStage->id()}));
+//     ASSERT_TRUE(checkExecutionOrder(model, {initialParentStage->id(), childStage->id()}));
+//     ASSERT_TRUE(checkExecutionOrder(model, {childStage->id(), resultParentStage->id()}));
 
-    const auto edge = initialParentStage->childDependencyEdges().front();
+//     const auto edge = initialParentStage->childDependencyEdges().front();
 
-    ASSERT_NO_THROW(model->replaceStageDependencyParent(edge, resultParentStage));
+//     ASSERT_NO_THROW(model->replaceStageDependencyParent(edge, resultParentStage));
 
-    ASSERT_EQ(initialParentStage->childDependencyEdges().size(), 0);
-    ASSERT_EQ(edge->parent(), resultParentStage);
+//     ASSERT_EQ(initialParentStage->childDependencyEdges().size(), 0);
+//     ASSERT_EQ(edge->parent(), resultParentStage);
 
-    ASSERT_TRUE(checkExecutionOrder(model, {resultParentStage->id(), childStage->id()}));
-}
+//     ASSERT_TRUE(checkExecutionOrder(model, {resultParentStage->id(), childStage->id()}));
+// }
 
-TEST_F(StageDependencyEdgeProcessingTests, ReplaceStageDependencyChildAssertsIfDependencyExists) {
-    //
-    //                    -> [Data] -> (Stage) -> [Output]
-    // [Input] -> (Stage)                 |
-    //                    -> [Data] -> (Stage) -> [Output]
-    //
+// TEST_F(StageDependencyEdgeProcessingTests, ReplaceStageDependencyChildAssertsIfDependencyExists) {
+//     //
+//     //                    -> [Data] -> (Stage) -> [Output]
+//     // [Input] -> (Stage)                 |
+//     //                    -> [Data] -> (Stage) -> [Output]
+//     //
 
-    const DataDesc desc{1};
+//     const DataDesc desc{1};
 
-    _testModel.createInputs({desc});
-    _testModel.createOutputs({desc, desc});
+//     _testModel.createInputs({desc});
+//     _testModel.createOutputs({desc, desc});
 
-    _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
-                                                     OutputInfo::intermediate(desc)});
-    auto childStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
-    auto parentStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
+//     _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
+//                                                      OutputInfo::intermediate(desc)});
+//     auto childStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
+//     auto parentStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
 
-    auto model = _testModel.getBaseModel();
+//     auto model = _testModel.getBaseModel();
 
-    ASSERT_NO_THROW(model->addStageDependency(parentStage, childStage));
+//     ASSERT_NO_THROW(model->addStageDependency(parentStage, childStage));
 
-    const auto edge = parentStage->childDependencyEdges().front();
+//     const auto edge = parentStage->childDependencyEdges().front();
 
-    ASSERT_ANY_THROW(model->replaceStageDependencyChild(edge, childStage));
-}
+//     ASSERT_ANY_THROW(model->replaceStageDependencyChild(edge, childStage));
+// }
 
-TEST_F(StageDependencyEdgeProcessingTests, ReplaceStageDependencyChildReplacesConnection) {
-    //
-    //                    -> [Data] -> (Stage) -> [Output]
-    //
-    // [Input] -> (Stage) -> [Data] -> (Stage) -> [Output]
-    //                                    |
-    //                    -> [Data] -> (Stage) -> [Output]
-    //
+// TEST_F(StageDependencyEdgeProcessingTests, ReplaceStageDependencyChildReplacesConnection) {
+//     //
+//     //                    -> [Data] -> (Stage) -> [Output]
+//     //
+//     // [Input] -> (Stage) -> [Data] -> (Stage) -> [Output]
+//     //                                    |
+//     //                    -> [Data] -> (Stage) -> [Output]
+//     //
 
-    const DataDesc desc{1};
+//     const DataDesc desc{1};
 
-    _testModel.createInputs({desc});
-    _testModel.createOutputs({desc, desc, desc});
+//     _testModel.createInputs({desc});
+//     _testModel.createOutputs({desc, desc, desc});
 
-    _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
-                                                     OutputInfo::intermediate(desc),
-                                                     OutputInfo::intermediate(desc)});
-    auto initialChildStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
-    auto resultChildStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
-    auto parentStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(2)}, {OutputInfo::fromNetwork(2)});
+//     _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
+//                                                      OutputInfo::intermediate(desc),
+//                                                      OutputInfo::intermediate(desc)});
+//     auto initialChildStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
+//     auto resultChildStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
+//     auto parentStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(2)}, {OutputInfo::fromNetwork(2)});
 
-    auto model = _testModel.getBaseModel();
+//     auto model = _testModel.getBaseModel();
 
-    ASSERT_NO_THROW(model->addStageDependency(parentStage, initialChildStage));
+//     ASSERT_NO_THROW(model->addStageDependency(parentStage, initialChildStage));
 
-    ASSERT_TRUE(checkExecutionOrder(model, {parentStage->id(), initialChildStage->id()}));
-    ASSERT_TRUE(checkExecutionOrder(model, {resultChildStage->id(), parentStage->id()}));
+//     ASSERT_TRUE(checkExecutionOrder(model, {parentStage->id(), initialChildStage->id()}));
+//     ASSERT_TRUE(checkExecutionOrder(model, {resultChildStage->id(), parentStage->id()}));
 
-    const auto edge = parentStage->childDependencyEdges().front();
+//     const auto edge = parentStage->childDependencyEdges().front();
 
-    ASSERT_NO_THROW(model->replaceStageDependencyChild(edge, resultChildStage));
+//     ASSERT_NO_THROW(model->replaceStageDependencyChild(edge, resultChildStage));
 
-    ASSERT_EQ(edge->child(), resultChildStage);
+//     ASSERT_EQ(edge->child(), resultChildStage);
 
-    ASSERT_TRUE(checkExecutionOrder(model, {parentStage->id(), resultChildStage->id()}));
-}
+//     ASSERT_TRUE(checkExecutionOrder(model, {parentStage->id(), resultChildStage->id()}));
+// }
 
-TEST_F(StageDependencyEdgeProcessingTests, RemoveStageDependencyUpdatesNextPrevStages) {
-    //
-    //                    -> [Data] -> (Stage) -> [Output]
-    // [Input] -> (Stage)                 |
-    //                    -> [Data] -> (Stage) -> [Output]
-    //
+// TEST_F(StageDependencyEdgeProcessingTests, RemoveStageDependencyUpdatesNextPrevStages) {
+//     //
+//     //                    -> [Data] -> (Stage) -> [Output]
+//     // [Input] -> (Stage)                 |
+//     //                    -> [Data] -> (Stage) -> [Output]
+//     //
 
-    const DataDesc desc{1};
+//     const DataDesc desc{1};
 
-    _testModel.createInputs({desc});
-    _testModel.createOutputs({desc, desc});
+//     _testModel.createInputs({desc});
+//     _testModel.createOutputs({desc, desc});
 
-    _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
-                                                     OutputInfo::intermediate(desc)});
-    auto childStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
-    auto parentStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
+//     _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
+//                                                      OutputInfo::intermediate(desc)});
+//     auto childStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
+//     auto parentStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
 
-    auto model = _testModel.getBaseModel();
+//     auto model = _testModel.getBaseModel();
 
-    ASSERT_NO_THROW(model->addStageDependency(parentStage, childStage));
+//     ASSERT_NO_THROW(model->addStageDependency(parentStage, childStage));
 
-    const auto edge = parentStage->childDependencyEdges().front();
+//     const auto edge = parentStage->childDependencyEdges().front();
 
-    ASSERT_NO_THROW(model->removeStageDependency(edge));
+//     ASSERT_NO_THROW(model->removeStageDependency(edge));
 
-    const auto prevStages = childStage->prevStages();
-    const auto nextStages = parentStage->prevStages();
+//     const auto prevStages = childStage->prevStages();
+//     const auto nextStages = parentStage->prevStages();
 
-    auto it = std::find(prevStages.begin(), prevStages.end(), parentStage);
-    ASSERT_EQ(it, prevStages.end());
+//     auto it = std::find(prevStages.begin(), prevStages.end(), parentStage);
+//     ASSERT_EQ(it, prevStages.end());
 
-    it = std::find(nextStages.begin(), nextStages.end(), childStage);
-    ASSERT_EQ(it, nextStages.end());
-}
+//     it = std::find(nextStages.begin(), nextStages.end(), childStage);
+//     ASSERT_EQ(it, nextStages.end());
+// }
 
-TEST_F(StageDependencyEdgeProcessingTests, RemoveStageDependencyViaDataToShapeEdgeUpdatesNextPrevStages) {
-    //
-    //                    -> [Data] -> (Stage) -> [Output]
-    // [Input] -> (Stage)                            |
-    //                    -> [Data] ------------> (Stage) -> [Output]
-    //
+// TEST_F(StageDependencyEdgeProcessingTests, RemoveStageDependencyViaDataToShapeEdgeUpdatesNextPrevStages) {
+//     //
+//     //                    -> [Data] -> (Stage) -> [Output]
+//     // [Input] -> (Stage)                            |
+//     //                    -> [Data] ------------> (Stage) -> [Output]
+//     //
 
-    const DataDesc desc{1};
+//     const DataDesc desc{1};
 
-    _testModel.createInputs({desc});
-    _testModel.createOutputs({desc, desc});
+//     _testModel.createInputs({desc});
+//     _testModel.createOutputs({desc, desc});
 
-    _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
-                                                     OutputInfo::intermediate(desc)});
-    auto childStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
-    auto parentStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
+//     _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
+//                                                      OutputInfo::intermediate(desc)});
+//     auto childStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
+//     auto parentStage = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
 
-    auto model = _testModel.getBaseModel();
+//     auto model = _testModel.getBaseModel();
 
-    ASSERT_NO_THROW(model->addStageDependency(parentStage, childStage));
+//     ASSERT_NO_THROW(model->addStageDependency(parentStage, childStage));
 
-    ASSERT_NO_THROW(model->removeStageDependency(parentStage, childStage));
+//     ASSERT_NO_THROW(model->removeStageDependency(parentStage, childStage));
 
-    const auto prevStages = childStage->prevStages();
-    const auto nextStages = parentStage->prevStages();
+//     const auto prevStages = childStage->prevStages();
+//     const auto nextStages = parentStage->prevStages();
 
-    auto it = std::find(prevStages.begin(), prevStages.end(), parentStage);
-    ASSERT_EQ(it, prevStages.end());
+//     auto it = std::find(prevStages.begin(), prevStages.end(), parentStage);
+//     ASSERT_EQ(it, prevStages.end());
 
-    it = std::find(nextStages.begin(), nextStages.end(), childStage);
-    ASSERT_EQ(it, nextStages.end());
-}
+//     it = std::find(nextStages.begin(), nextStages.end(), childStage);
+//     ASSERT_EQ(it, nextStages.end());
+// }
 
-} // namespace vpu
+// } // namespace vpu

--- a/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/add_copy_for_outputs_inside_network.cpp
+++ b/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/add_copy_for_outputs_inside_network.cpp
@@ -1,217 +1,217 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
 
-#include "graph_transformer_tests.hpp"
+// #include "graph_transformer_tests.hpp"
 
-namespace {
+// namespace {
 
-class AddCopyForOutputsInsideNetwork : public vpu::GraphTransformerTest {
-protected:
-    void SetUp() override {
-        ASSERT_NO_FATAL_FAILURE(GraphTransformerTest::SetUp());
-        ASSERT_NO_FATAL_FAILURE(InitCompileEnv());
-        ASSERT_NO_FATAL_FAILURE(InitPipeline());
+// class AddCopyForOutputsInsideNetwork : public vpu::GraphTransformerTest {
+// protected:
+//     void SetUp() override {
+//         ASSERT_NO_FATAL_FAILURE(GraphTransformerTest::SetUp());
+//         ASSERT_NO_FATAL_FAILURE(InitCompileEnv());
+//         ASSERT_NO_FATAL_FAILURE(InitPipeline());
 
-        m_testModel = CreateTestModel();
-    }
+//         m_testModel = CreateTestModel();
+//     }
 
-    void CheckOutputs(const vpu::DataMap<vpu::Data>& parentShapes = {}, const vpu::DataMap<vpu::DataVector>& childShapes = {}) {
-        for (const auto& output : m_testModel.getOutputs()) {
-            ASSERT_TRUE(output->consumerEdges().empty());
-            ASSERT_TRUE((parentShapes.count(output) == 0 && output->parentDataToShapeEdge() == nullptr) ||
-                (parentShapes.count(output) == 1 && output->parentDataToShapeEdge()->parent() == parentShapes.at(output)));
-            ASSERT_FALSE((childShapes.count(output) == 0) ^ output->childDataToShapeEdges().empty());
-            if (output->childDataToShapeEdges().empty()) {
-                continue;
-            }
+//     void CheckOutputs(const vpu::DataMap<vpu::Data>& parentShapes = {}, const vpu::DataMap<vpu::DataVector>& childShapes = {}) {
+//         for (const auto& output : m_testModel.getOutputs()) {
+//             ASSERT_TRUE(output->consumerEdges().empty());
+//             ASSERT_TRUE((parentShapes.count(output) == 0 && output->parentDataToShapeEdge() == nullptr) ||
+//                 (parentShapes.count(output) == 1 && output->parentDataToShapeEdge()->parent() == parentShapes.at(output)));
+//             ASSERT_FALSE((childShapes.count(output) == 0) ^ output->childDataToShapeEdges().empty());
+//             if (output->childDataToShapeEdges().empty()) {
+//                 continue;
+//             }
 
-            vpu::DataVector actualChildDataObjects;
-            const auto& actualChildShapesEdges = output->childDataToShapeEdges();
-            std::transform(actualChildShapesEdges.begin(), actualChildShapesEdges.end(), std::back_inserter(actualChildDataObjects),
-                [](const vpu::DataToShapeAllocation& edge) { return edge->child(); });
-            ASSERT_EQ(actualChildDataObjects, childShapes.at(output));
-        }
-    }
+//             vpu::DataVector actualChildDataObjects;
+//             const auto& actualChildShapesEdges = output->childDataToShapeEdges();
+//             std::transform(actualChildShapesEdges.begin(), actualChildShapesEdges.end(), std::back_inserter(actualChildDataObjects),
+//                 [](const vpu::DataToShapeAllocation& edge) { return edge->child(); });
+//             ASSERT_EQ(actualChildDataObjects, childShapes.at(output));
+//         }
+//     }
 
-    void Compile() {
-        m_pipeline.run(m_testModel.getBaseModel());
-    }
+//     void Compile() {
+//         m_pipeline.run(m_testModel.getBaseModel());
+//     }
 
-    void InitPipeline() {
-        m_pipeline = vpu::PassSet();
-        m_pipeline.addPass(passManager->dumpModel("before-addCopyForOutputsInsideNetwork"));
-        m_pipeline.addPass(passManager->addCopyForOutputsInsideNetwork());
-        m_pipeline.addPass(passManager->dumpModel("after-addCopyForOutputsInsideNetwork"));
-    }
+//     void InitPipeline() {
+//         m_pipeline = vpu::PassSet();
+//         m_pipeline.addPass(passManager->dumpModel("before-addCopyForOutputsInsideNetwork"));
+//         m_pipeline.addPass(passManager->addCopyForOutputsInsideNetwork());
+//         m_pipeline.addPass(passManager->dumpModel("after-addCopyForOutputsInsideNetwork"));
+//     }
 
-protected:
-    vpu::PassSet m_pipeline;
-    vpu::TestModel m_testModel;
+// protected:
+//     vpu::PassSet m_pipeline;
+//     vpu::TestModel m_testModel;
 
-    const vpu::DataDesc m_defaultDescriptor = {1};
-};
+//     const vpu::DataDesc m_defaultDescriptor = {1};
+// };
 
-TEST_F(AddCopyForOutputsInsideNetwork, DynamicOutputWithoutConsumer) {
-    m_testModel.createInputs({m_defaultDescriptor, m_defaultDescriptor, m_defaultDescriptor, m_defaultDescriptor});
-    m_testModel.createOutputs({m_defaultDescriptor, m_defaultDescriptor});
-    m_testModel.addStage({vpu::InputInfo::fromNetwork(0), vpu::InputInfo::fromNetwork(1)}, {vpu::OutputInfo::fromNetwork(0)});
+// TEST_F(AddCopyForOutputsInsideNetwork, DynamicOutputWithoutConsumer) {
+//     m_testModel.createInputs({m_defaultDescriptor, m_defaultDescriptor, m_defaultDescriptor, m_defaultDescriptor});
+//     m_testModel.createOutputs({m_defaultDescriptor, m_defaultDescriptor});
+//     m_testModel.addStage({vpu::InputInfo::fromNetwork(0), vpu::InputInfo::fromNetwork(1)}, {vpu::OutputInfo::fromNetwork(0)});
 
-    auto shapeProducer = m_testModel.addStage(
-        {vpu::InputInfo::fromPrevStage(0, 0), vpu::InputInfo::constant(m_defaultDescriptor)},
-        {vpu::OutputInfo::intermediate(m_defaultDescriptor)});
+//     auto shapeProducer = m_testModel.addStage(
+//         {vpu::InputInfo::fromPrevStage(0, 0), vpu::InputInfo::constant(m_defaultDescriptor)},
+//         {vpu::OutputInfo::intermediate(m_defaultDescriptor)});
 
-    m_testModel.addStage(
-        {
-            vpu::InputInfo::fromPrevStage(1, 0),
-            vpu::InputInfo::fromNetwork(2),
-            vpu::InputInfo::constant(m_defaultDescriptor),
-            vpu::InputInfo::constant(m_defaultDescriptor),
-            vpu::InputInfo::constant(m_defaultDescriptor),
-            vpu::InputInfo::fromNetwork(3),
-        },
-        {vpu::OutputInfo::fromNetwork(1)});
+//     m_testModel.addStage(
+//         {
+//             vpu::InputInfo::fromPrevStage(1, 0),
+//             vpu::InputInfo::fromNetwork(2),
+//             vpu::InputInfo::constant(m_defaultDescriptor),
+//             vpu::InputInfo::constant(m_defaultDescriptor),
+//             vpu::InputInfo::constant(m_defaultDescriptor),
+//             vpu::InputInfo::fromNetwork(3),
+//         },
+//         {vpu::OutputInfo::fromNetwork(1)});
 
-    ASSERT_NO_THROW(m_testModel.getBaseModel()->connectDataWithShape(shapeProducer->output(0), m_testModel.getOutputs().back()));
-    ASSERT_NO_THROW(Compile());
-    CheckOutputs({{m_testModel.getOutputs().back(), shapeProducer->output(0)}});
-}
+//     ASSERT_NO_THROW(m_testModel.getBaseModel()->connectDataWithShape(shapeProducer->output(0), m_testModel.getOutputs().back()));
+//     ASSERT_NO_THROW(Compile());
+//     CheckOutputs({{m_testModel.getOutputs().back(), shapeProducer->output(0)}});
+// }
 
-TEST_F(AddCopyForOutputsInsideNetwork, StaticOutputWithConsumer) {
-    m_testModel.createInputs({m_defaultDescriptor, m_defaultDescriptor});
-    m_testModel.createOutputs({m_defaultDescriptor, m_defaultDescriptor});
+// TEST_F(AddCopyForOutputsInsideNetwork, StaticOutputWithConsumer) {
+//     m_testModel.createInputs({m_defaultDescriptor, m_defaultDescriptor});
+//     m_testModel.createOutputs({m_defaultDescriptor, m_defaultDescriptor});
 
-    m_testModel.addStage(
-        {
-            vpu::InputInfo::fromNetwork(0),
-            vpu::InputInfo::fromNetwork(1),
-            vpu::InputInfo::constant(m_defaultDescriptor),
-            vpu::InputInfo::constant(m_defaultDescriptor),
-            vpu::InputInfo::constant(m_defaultDescriptor)
-        },
-        {
-            vpu::OutputInfo::fromNetwork(0),
-            vpu::OutputInfo::fromNetwork(1)});
+//     m_testModel.addStage(
+//         {
+//             vpu::InputInfo::fromNetwork(0),
+//             vpu::InputInfo::fromNetwork(1),
+//             vpu::InputInfo::constant(m_defaultDescriptor),
+//             vpu::InputInfo::constant(m_defaultDescriptor),
+//             vpu::InputInfo::constant(m_defaultDescriptor)
+//         },
+//         {
+//             vpu::OutputInfo::fromNetwork(0),
+//             vpu::OutputInfo::fromNetwork(1)});
 
-    const auto shapeProducer = m_testModel.addStage(
-        {
-            vpu::InputInfo::fromPrevStage(0, 0),
-            vpu::InputInfo::constant(m_defaultDescriptor)
-        },
-        {
-            vpu::OutputInfo::intermediate(m_defaultDescriptor)
-        });
+//     const auto shapeProducer = m_testModel.addStage(
+//         {
+//             vpu::InputInfo::fromPrevStage(0, 0),
+//             vpu::InputInfo::constant(m_defaultDescriptor)
+//         },
+//         {
+//             vpu::OutputInfo::intermediate(m_defaultDescriptor)
+//         });
 
-    m_testModel.getBaseModel()->connectDataWithShape(shapeProducer->output(0), m_testModel.getOutputs().back());
+//     m_testModel.getBaseModel()->connectDataWithShape(shapeProducer->output(0), m_testModel.getOutputs().back());
 
-    ASSERT_NO_THROW(Compile());
-    CheckOutputs({{m_testModel.getOutputs().back(), shapeProducer->output(0)}});
-}
+//     ASSERT_NO_THROW(Compile());
+//     CheckOutputs({{m_testModel.getOutputs().back(), shapeProducer->output(0)}});
+// }
 
-TEST_F(AddCopyForOutputsInsideNetwork, DynamicOutputWithConsumer) {
-    m_testModel.createInputs({m_defaultDescriptor, m_defaultDescriptor, m_defaultDescriptor});
-    m_testModel.createOutputs({m_defaultDescriptor, m_defaultDescriptor, m_defaultDescriptor});
+// TEST_F(AddCopyForOutputsInsideNetwork, DynamicOutputWithConsumer) {
+//     m_testModel.createInputs({m_defaultDescriptor, m_defaultDescriptor, m_defaultDescriptor});
+//     m_testModel.createOutputs({m_defaultDescriptor, m_defaultDescriptor, m_defaultDescriptor});
 
-    m_testModel.addStage(
-        {
-            vpu::InputInfo::fromNetwork(0),
-            vpu::InputInfo::fromNetwork(1),
-            vpu::InputInfo::constant(m_defaultDescriptor),
-            vpu::InputInfo::constant(m_defaultDescriptor),
-            vpu::InputInfo::constant(m_defaultDescriptor)
-        },
-        {
-            vpu::OutputInfo::fromNetwork(0),
-            vpu::OutputInfo::fromNetwork(1)});
+//     m_testModel.addStage(
+//         {
+//             vpu::InputInfo::fromNetwork(0),
+//             vpu::InputInfo::fromNetwork(1),
+//             vpu::InputInfo::constant(m_defaultDescriptor),
+//             vpu::InputInfo::constant(m_defaultDescriptor),
+//             vpu::InputInfo::constant(m_defaultDescriptor)
+//         },
+//         {
+//             vpu::OutputInfo::fromNetwork(0),
+//             vpu::OutputInfo::fromNetwork(1)});
 
-    const auto shapeProducer = m_testModel.addStage(
-        {
-            vpu::InputInfo::fromPrevStage(0, 0),
-            vpu::InputInfo::constant(m_defaultDescriptor)
-        },
-        {
-            vpu::OutputInfo::intermediate(m_defaultDescriptor)
-        });
+//     const auto shapeProducer = m_testModel.addStage(
+//         {
+//             vpu::InputInfo::fromPrevStage(0, 0),
+//             vpu::InputInfo::constant(m_defaultDescriptor)
+//         },
+//         {
+//             vpu::OutputInfo::intermediate(m_defaultDescriptor)
+//         });
 
-    m_testModel.getBaseModel()->connectDataWithShape(shapeProducer->output(0), m_testModel.getOutputs()[1]);
+//     m_testModel.getBaseModel()->connectDataWithShape(shapeProducer->output(0), m_testModel.getOutputs()[1]);
 
-    m_testModel.addStage(
-        {
-            vpu::InputInfo::fromNetwork(2),
-            vpu::InputInfo::fromPrevStage(1, 0),
-            vpu::InputInfo::constant(m_defaultDescriptor),
-            vpu::InputInfo::constant(m_defaultDescriptor),
-            vpu::InputInfo::constant(m_defaultDescriptor),
-            vpu::InputInfo::fromPrevStage(0, 1),
-        },
-        {vpu::OutputInfo::fromNetwork(2)});
+//     m_testModel.addStage(
+//         {
+//             vpu::InputInfo::fromNetwork(2),
+//             vpu::InputInfo::fromPrevStage(1, 0),
+//             vpu::InputInfo::constant(m_defaultDescriptor),
+//             vpu::InputInfo::constant(m_defaultDescriptor),
+//             vpu::InputInfo::constant(m_defaultDescriptor),
+//             vpu::InputInfo::fromPrevStage(0, 1),
+//         },
+//         {vpu::OutputInfo::fromNetwork(2)});
 
-    ASSERT_NO_THROW(Compile());
-    CheckOutputs({{m_testModel.getOutputs()[1], shapeProducer->output(0)}});
-}
+//     ASSERT_NO_THROW(Compile());
+//     CheckOutputs({{m_testModel.getOutputs()[1], shapeProducer->output(0)}});
+// }
 
-TEST_F(AddCopyForOutputsInsideNetwork, StaticOutputWithConsumerAndDynamicOutputWithConsumer) {
-    m_testModel.createInputs({m_defaultDescriptor, m_defaultDescriptor, m_defaultDescriptor, m_defaultDescriptor});
-    m_testModel.createOutputs({m_defaultDescriptor, m_defaultDescriptor, m_defaultDescriptor, m_defaultDescriptor});
+// TEST_F(AddCopyForOutputsInsideNetwork, StaticOutputWithConsumerAndDynamicOutputWithConsumer) {
+//     m_testModel.createInputs({m_defaultDescriptor, m_defaultDescriptor, m_defaultDescriptor, m_defaultDescriptor});
+//     m_testModel.createOutputs({m_defaultDescriptor, m_defaultDescriptor, m_defaultDescriptor, m_defaultDescriptor});
 
-    m_testModel.addStage(
-        {
-            vpu::InputInfo::fromNetwork(0),
-            vpu::InputInfo::fromNetwork(1),
-            vpu::InputInfo::constant(m_defaultDescriptor),
-            vpu::InputInfo::constant(m_defaultDescriptor),
-            vpu::InputInfo::constant(m_defaultDescriptor)
-        },
-        {
-            vpu::OutputInfo::fromNetwork(0),
-            vpu::OutputInfo::fromNetwork(1)});
+//     m_testModel.addStage(
+//         {
+//             vpu::InputInfo::fromNetwork(0),
+//             vpu::InputInfo::fromNetwork(1),
+//             vpu::InputInfo::constant(m_defaultDescriptor),
+//             vpu::InputInfo::constant(m_defaultDescriptor),
+//             vpu::InputInfo::constant(m_defaultDescriptor)
+//         },
+//         {
+//             vpu::OutputInfo::fromNetwork(0),
+//             vpu::OutputInfo::fromNetwork(1)});
 
-    const auto shapeProducer_0 = m_testModel.addStage(
-        {
-            vpu::InputInfo::fromPrevStage(0, 0),
-            vpu::InputInfo::constant(m_defaultDescriptor)
-        },
-        {
-            vpu::OutputInfo::intermediate(m_defaultDescriptor)
-        });
+//     const auto shapeProducer_0 = m_testModel.addStage(
+//         {
+//             vpu::InputInfo::fromPrevStage(0, 0),
+//             vpu::InputInfo::constant(m_defaultDescriptor)
+//         },
+//         {
+//             vpu::OutputInfo::intermediate(m_defaultDescriptor)
+//         });
 
-    m_testModel.getBaseModel()->connectDataWithShape(shapeProducer_0->output(0), m_testModel.getOutputs()[1]);
+//     m_testModel.getBaseModel()->connectDataWithShape(shapeProducer_0->output(0), m_testModel.getOutputs()[1]);
 
-    m_testModel.addStage(
-        {
-            vpu::InputInfo::fromNetwork(2),
-            vpu::InputInfo::fromNetwork(3),
-        },
-        {
-            vpu::OutputInfo::fromNetwork(3)
-        });
+//     m_testModel.addStage(
+//         {
+//             vpu::InputInfo::fromNetwork(2),
+//             vpu::InputInfo::fromNetwork(3),
+//         },
+//         {
+//             vpu::OutputInfo::fromNetwork(3)
+//         });
 
-    const auto shapeProducer_1 = m_testModel.addStage(
-        {
-            vpu::InputInfo::fromPrevStage(2, 0),
-            vpu::InputInfo::constant(m_defaultDescriptor)
-        },
-        {
-            vpu::OutputInfo::intermediate(m_defaultDescriptor)
-        });
+//     const auto shapeProducer_1 = m_testModel.addStage(
+//         {
+//             vpu::InputInfo::fromPrevStage(2, 0),
+//             vpu::InputInfo::constant(m_defaultDescriptor)
+//         },
+//         {
+//             vpu::OutputInfo::intermediate(m_defaultDescriptor)
+//         });
 
-    m_testModel.addStage(
-        {
-            vpu::InputInfo::fromPrevStage(3, 0),
-            vpu::InputInfo::fromPrevStage(1, 0),
-            vpu::InputInfo::constant(m_defaultDescriptor),
-            vpu::InputInfo::constant(m_defaultDescriptor),
-            vpu::InputInfo::constant(m_defaultDescriptor),
-            vpu::InputInfo::fromPrevStage(0, 1),
-        },
-        {vpu::OutputInfo::fromNetwork(2)});
+//     m_testModel.addStage(
+//         {
+//             vpu::InputInfo::fromPrevStage(3, 0),
+//             vpu::InputInfo::fromPrevStage(1, 0),
+//             vpu::InputInfo::constant(m_defaultDescriptor),
+//             vpu::InputInfo::constant(m_defaultDescriptor),
+//             vpu::InputInfo::constant(m_defaultDescriptor),
+//             vpu::InputInfo::fromPrevStage(0, 1),
+//         },
+//         {vpu::OutputInfo::fromNetwork(2)});
 
-    m_testModel.getBaseModel()->connectDataWithShape(shapeProducer_1->output(0), m_testModel.getOutputs()[2]);
+//     m_testModel.getBaseModel()->connectDataWithShape(shapeProducer_1->output(0), m_testModel.getOutputs()[2]);
 
-    ASSERT_NO_THROW(Compile());
-    CheckOutputs({
-        {m_testModel.getOutputs()[1], shapeProducer_0->output(0)},
-        {m_testModel.getOutputs()[2], shapeProducer_1->output(0)}});
-}
+//     ASSERT_NO_THROW(Compile());
+//     CheckOutputs({
+//         {m_testModel.getOutputs()[1], shapeProducer_0->output(0)},
+//         {m_testModel.getOutputs()[2], shapeProducer_1->output(0)}});
+// }
 
-} // namespace
+// } // namespace

--- a/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/adjust_data_batch_tests.cpp
+++ b/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/adjust_data_batch_tests.cpp
@@ -1,354 +1,354 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
-
-#include <vpu/stages/mx_stage.hpp>
-#include <vpu/utils/numeric.hpp>
-
-#include "graph_transformer_tests.hpp"
-
-using namespace vpu;
-
-class VPU_AdjustDataBatchTest : public GraphTransformerTest {
-protected:
-    const int batchSize = 4;
-    TestModel testModel;
-
-public:
-    void SetUp() override {
-        ASSERT_NO_FATAL_FAILURE(GraphTransformerTest::SetUp());
-
-        ASSERT_NO_FATAL_FAILURE(InitCompileEnv());
-
-        testModel = CreateTestModel();
-    }
-
-    void RunPass() {
-        PassSet pipeline;
-        pipeline.addPass(passManager->dumpModel("initial"));
-        pipeline.addPass(passManager->adjustDataBatch());
-        pipeline.addPass(passManager->dumpModel("adjustDataBatch"));
-        pipeline.run(testModel.getBaseModel());
-    }
-
-    DataVector checkSingleLoopStart(const Data& data) {
-        EXPECT_EQ(data->desc().dim(Dim::N), 4);
-        EXPECT_EQ(data->numConsumers(), 2);
-
-        DataVector outputs;
-        for (const auto& consumer : data->consumers()) {
-            EXPECT_TRUE(consumer->type() == StageType::LoopStart || consumer->type() == StageType::LoopEnd);
-            if (consumer->type() == StageType::LoopStart) {
-                for (const auto& output : consumer->outputs()) {
-                    EXPECT_EQ(output->desc().dim(Dim::N), 1);
-                    outputs.push_back(output);
-                }
-            }
-        }
-
-        return outputs;
-    }
-
-    DataVector checkBranches(const Data& root, const std::vector<StageType>& consumersTypes) {
-        auto successors = DataVector{};
-
-        const auto& consumers = root->consumers() | asVector();
-        EXPECT_EQ(consumers.size(), consumersTypes.size());
-        for (std::size_t i = 0; i < consumers.size(); ++i) {
-            const auto& consumer = consumers[i];
-            const auto& expected = consumersTypes[i];
-            EXPECT_EQ(consumer->type(), expected);
-
-            EXPECT_EQ(consumer->numOutputs(), 1);
-            const auto& output = consumer->output(0);
-            successors.push_back(output);
-
-            if (expected == StageType::LoopStart) {
-                EXPECT_EQ(consumer->numOutputs(), 1);
-                EXPECT_EQ(output->desc().dim(Dim::N), 1);
-            } else if (expected == StageType::LoopEnd) {
-                EXPECT_EQ(output->desc().dim(Dim::N), 4);
-            }
-        }
-
-        return successors;
-    }
-
-    DataVector checkSingleLoopEnd(const Data& data) {
-        EXPECT_EQ(data->numConsumers(), 1);
-
-        const auto& consumer = data->singleConsumer();
-        EXPECT_EQ(consumer->type(), StageType::LoopEnd);
-        DataVector outputs;
-        for (const auto& output : consumer->outputs()) {
-            EXPECT_EQ(output->desc().dim(Dim::N), 4);
-            outputs.push_back(output);
-        }
-
-        return outputs;
-    }
-
-    static Data CheckSingleConnection(const Data& data, int testInd, int batch = 1) {
-        EXPECT_EQ(data->numConsumers(), 1);
-
-        const auto& consumer = data->singleConsumer();
-        EXPECT_EQ(consumer->type(), StageType::None);
-        EXPECT_EQ(consumer->attrs().get<int>("test_ind"), testInd);
-        EXPECT_EQ(consumer->numOutputs(), 1);
-        const auto& output = consumer->output(0);
-        EXPECT_EQ(output->desc().dim(Dim::N), batch);
-        return output;
-    }
-
-    static Data singleElement(const DataVector& dataObjects) {
-        EXPECT_EQ(dataObjects.size(), 1);
-        return dataObjects.front();
-    }
-};
-
-TEST_F(VPU_AdjustDataBatchTest, LinearWithBatchedInTheEnd) {
-    //
-    // [Input] -> (Split) -> (Split) -> (Split) -> (Split) -> (Split) -> (Split) -> (Batched) -> [Output]
-    //
-    const DataDesc desc{16, 16, 3, batchSize};
-
-    testModel.createInputs({desc});
-    testModel.createOutputs({desc});
-
-    for (int i = 0; i < 6; i++) {
-        if (i > 0)
-            testModel.addStage({InputInfo::fromPrevStage(i - 1)}, {OutputInfo::intermediate(desc)});
-        else
-            testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc)});
-        testModel.setStageBatchInfo(i, {{0, BatchSupport::Split}});
-    }
-    testModel.addStage({InputInfo::fromPrevStage(5)}, {OutputInfo::fromNetwork(0)});
-
-    RunPass();
-
-    const auto& data0 = singleElement(checkSingleLoopStart(testModel.getInputs().at(0)));
-    const auto& data1 = CheckSingleConnection(data0, 0);
-    const auto& data2 = CheckSingleConnection(data1, 1);
-    const auto& data3 = CheckSingleConnection(data2, 2);
-    const auto& data4 = CheckSingleConnection(data3, 3);
-    const auto& data5 = CheckSingleConnection(data4, 4);
-    const auto& data6 = CheckSingleConnection(data5, 5);
-    const auto& data7 = singleElement(checkSingleLoopEnd(data6));
-
-    const auto& data8 = CheckSingleConnection(data7, 6, batchSize);
-
-    ASSERT_EQ(data8, testModel.getOutputs().at(0));
-}
-
-TEST_F(VPU_AdjustDataBatchTest, BranchedWithBatchSplitItems) {
-    //                                                                                      -> (Batched) -> [Output]
-    // [Input] -> (Split) -> (Split) -> (Split) -> (Split) -> (Split) -> (Split) -> (Split)
-    //                                                                                      -> (Batched) -> [Output]
-    const DataDesc desc{16, 16, 3, batchSize};
-
-    testModel.createInputs({desc});
-    testModel.createOutputs({desc, desc});
-
-    for (int i = 0; i < 7; i++) {
-        if (i > 0)
-            testModel.addStage({InputInfo::fromPrevStage(i - 1)}, {OutputInfo::intermediate(desc)});
-        else
-            testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc)});
-        testModel.setStageBatchInfo(i, {{0, BatchSupport::Split}});
-    }
-
-    testModel.addStage({InputInfo::fromPrevStage(6)}, {OutputInfo::fromNetwork(0)});
-    testModel.addStage({InputInfo::fromPrevStage(6)}, {OutputInfo::fromNetwork(1)});
-
-    RunPass();
-
-    const auto& data0 = singleElement(checkSingleLoopStart(testModel.getInputs().at(0)));
-    const auto& data1 = CheckSingleConnection(data0, 0);
-    const auto& data2 = CheckSingleConnection(data1, 1);
-    const auto& data3 = CheckSingleConnection(data2, 2);
-    const auto& data4 = CheckSingleConnection(data3, 3);
-    const auto& data5 = CheckSingleConnection(data4, 4);
-    const auto& data6 = CheckSingleConnection(data5, 5);
-    const auto& data7 = CheckSingleConnection(data6, 6);
-    const auto& data8 = singleElement(checkSingleLoopEnd(data7));
-
-    const auto& branches = checkBranches(data8, {StageType::None, StageType::None});
-    const auto& withBatch = branches[0];
-    const auto& withBatch_1 = branches[1];
-
-    ASSERT_EQ(withBatch->producer()->attrs().get<int>("test_ind"), 7);
-    ASSERT_EQ(withBatch->desc().dim(Dim::N), batchSize);
-    ASSERT_EQ(withBatch, testModel.getOutputs().at(0));
-
-    ASSERT_EQ(withBatch_1->producer()->attrs().get<int>("test_ind"), 8);
-    ASSERT_EQ(withBatch_1->desc().dim(Dim::N), batchSize);
-    ASSERT_EQ(withBatch_1, testModel.getOutputs().at(1));
-}
-
-TEST_F(VPU_AdjustDataBatchTest, LinearWithBatchedInTheBeginning) {
-    //
-    // [Input] -> (Batched) -> (Split) -> (Split) -> (Split) -> (Split) -> (Split) -> (Split) -> [Output]
-    //
-    const DataDesc desc{16, 16, 3, batchSize};
-
-    testModel.createInputs({desc});
-    testModel.createOutputs({desc});
-
-    for (int i = 0; i < 6; i++) {
-        if (i > 0)
-            testModel.addStage({InputInfo::fromPrevStage(i - 1)}, {OutputInfo::intermediate(desc)});
-        else
-            testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc)});
-        if (i > 0)
-            testModel.setStageBatchInfo(i, {{0, BatchSupport::Split}});
-    }
-
-    testModel.addStage({InputInfo::fromPrevStage(5)}, {OutputInfo::fromNetwork()});
-    testModel.setStageBatchInfo(6, {{0, BatchSupport::Split}});
-
-    RunPass();
-
-    const auto& data0 = CheckSingleConnection(testModel.getInputs().at(0), 0, batchSize);
-    const auto& data7 = singleElement(checkSingleLoopStart(data0));
-    const auto& data3 = CheckSingleConnection(data7, 1);
-    const auto& data4 = CheckSingleConnection(data3, 2);
-    const auto& data5 = CheckSingleConnection(data4, 3);
-    const auto& data6 = CheckSingleConnection(data5, 4);
-    const auto& data8 = CheckSingleConnection(data6, 5);
-    const auto& data10 = CheckSingleConnection(data8, 6);
-    const auto& data11 = checkSingleLoopEnd(data10);
-
-    ASSERT_EQ(data11, testModel.getOutputs());
-}
-
-TEST_F(VPU_AdjustDataBatchTest, BranchedWithBatchItemsInTheEnd) {
-    //                                                                                      -> (Batched) -> [Output]
-    // [Input] -> (Split) -> (Split) -> (Split) -> (Split) -> (Split) -> (Split) -> (Batch)
-    //                                                                                      -> (Batched) -> [Output]
-    const DataDesc desc{16, 16, 3, batchSize};
-
-    testModel.createInputs({desc});
-    testModel.createOutputs({desc, desc});
-
-    for (int i = 0; i < 6; i++) {
-        if (i > 0)
-            testModel.addStage({InputInfo::fromPrevStage(i - 1)}, {OutputInfo::intermediate(desc)});
-        else
-            testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc)});
-        testModel.setStageBatchInfo(i, {{0, BatchSupport::Split}});
-    }
-
-    testModel.addStage({InputInfo::fromPrevStage(5)}, {OutputInfo::intermediate(desc)});
-    testModel.addStage({InputInfo::fromPrevStage(6)}, {OutputInfo::fromNetwork(0)});
-    testModel.addStage({InputInfo::fromPrevStage(6)}, {OutputInfo::fromNetwork(1)});
-
-    RunPass();
-
-    const auto& data0 = singleElement(checkSingleLoopStart(testModel.getInputs().at(0)));
-    const auto& data1 = CheckSingleConnection(data0, 0);
-    const auto& data2 = CheckSingleConnection(data1, 1);
-    const auto& data3 = CheckSingleConnection(data2, 2);
-    const auto& data4 = CheckSingleConnection(data3, 3);
-    const auto& data5 = CheckSingleConnection(data4, 4);
-    const auto& data6 = CheckSingleConnection(data5, 5);
-    const auto& data7 = singleElement(checkSingleLoopEnd(data6));
-
-    const auto& data8 = CheckSingleConnection(data7, 6, batchSize);
-
-    const auto& branches = checkBranches(data8, {StageType::None, StageType::None});
-    const auto& withBatch = branches[0];
-    const auto& withBatch_1 = branches[1];
-
-    ASSERT_EQ(withBatch->producer()->attrs().get<int>("test_ind"), 7);
-    ASSERT_EQ(withBatch->desc().dim(Dim::N), batchSize);
-    ASSERT_EQ(withBatch, testModel.getOutputs().at(0));
-
-    ASSERT_EQ(withBatch_1->producer()->attrs().get<int>("test_ind"), 8);
-    ASSERT_EQ(withBatch_1->desc().dim(Dim::N), batchSize);
-    ASSERT_EQ(withBatch_1, testModel.getOutputs().at(1));
-}
-
-TEST_F(VPU_AdjustDataBatchTest, DISABLED_BranchedWithSplitAndBatchItemsInTheEnd) {
-    //
-    //                                         -> (Split) -> (Batched) -> [Output]
-    // [Input] -> (Split) -> (Split) -> (Split)
-    //                                         -> (Split) -> [Output]
-    //
-    const DataDesc desc{16, 16, 3, batchSize};
-
-    testModel.createInputs({desc});
-    testModel.createOutputs({desc, desc});
-
-    for (int i = 0; i < 5; i++) {
-        if (i > 0)
-            testModel.addStage({InputInfo::fromPrevStage(i - 1)}, {OutputInfo::intermediate(desc)});
-        else
-            testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc)});
-        if (i != 3)
-            testModel.setStageBatchInfo(i, {{0, BatchSupport::Split}});
-    }
-
-    testModel.addStage({InputInfo::fromPrevStage(2)}, {OutputInfo::fromNetwork(1)});
-    testModel.setStageBatchInfo(5, {{0, BatchSupport::Split}});
-
-    RunPass();
-
-    const auto& data0 = singleElement(checkSingleLoopStart(testModel.getInputs().at(0)));
-    const auto& data1 = CheckSingleConnection(data0, 0);
-    const auto& data2 = CheckSingleConnection(data1, 1);
-    const auto& data3 = CheckSingleConnection(data2, 2);
-
-    const auto& branches = checkBranches(data3, {StageType::None, StageType::LoopEnd});
-    const auto& branch1 = branches[0];
-    const auto& branch2 = branches[1];
-
-    const auto& data4 = CheckSingleConnection(branch1, 3);
-    const auto& data7 = singleElement(checkSingleLoopEnd(data4));
-    const auto& data5 = CheckSingleConnection(data7, 4, batchSize);
-    ASSERT_EQ(data5, testModel.getOutputs().at(0));
-    const auto& data6 = CheckSingleConnection(branch2, 5);
-    ASSERT_EQ(data6, testModel.getOutputs().at(1));
-}
-
-TEST_F(VPU_AdjustDataBatchTest, DISABLED_BranchedWithBatchAndSplitItemsInTheEnd) {
-    //
-    //                                         -> (Split) -> [Output]
-    // [Input] -> (Split) -> (Split) -> (Split)
-    //                                         -> (Split) -> [Output]
-    //
-    const DataDesc desc{16, 16, 3, batchSize};
-
-    testModel.createInputs({desc});
-    testModel.createOutputs({desc, desc});
-
-    for (int i = 0; i < 3; i++) {
-        if (i > 0)
-            testModel.addStage({InputInfo::fromPrevStage(i - 1)}, {OutputInfo::intermediate(desc)});
-        else
-            testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc)});
-        testModel.setStageBatchInfo(i, {{0, BatchSupport::Split}});
-    }
-    for (int i = 0; i < 2; i++) {
-        testModel.addStage({InputInfo::fromNetwork(2)}, {OutputInfo::intermediate(desc)});
-        testModel.setStageBatchInfo(3 + i, {{0, BatchSupport::Split}});
-    }
-
-    testModel.addStage({InputInfo::fromPrevStage(2)}, {OutputInfo::fromNetwork(0)});
-    testModel.setStageBatchInfo(3, {{0, BatchSupport::Split}});
-    testModel.addStage({InputInfo::fromPrevStage(2)}, {OutputInfo::fromNetwork(1)});
-    testModel.setStageBatchInfo(4, {{0, BatchSupport::Split}});
-
-    RunPass();
-
-    const auto& data1 = singleElement(checkSingleLoopStart(testModel.getInputs().at(0)));
-    const auto& data2 = CheckSingleConnection(data1, 1);
-    const auto& data3 = CheckSingleConnection(data2, 2);
-    const auto& branches = checkBranches(data3, {StageType::None, StageType::LoopEnd});
-    const auto& branch1 = branches[0];
-    const auto& branch2 = branches[1];
-    const auto& data4 = CheckSingleConnection(branch1, 3);
-    (void)data4;
-    const auto& data5 = CheckSingleConnection(branch2, 4);
-    const auto& data6 = checkSingleLoopEnd(data5);
-    (void)data6;
-}
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
+
+// #include <vpu/stages/mx_stage.hpp>
+// #include <vpu/utils/numeric.hpp>
+
+// #include "graph_transformer_tests.hpp"
+
+// using namespace vpu;
+
+// class VPU_AdjustDataBatchTest : public GraphTransformerTest {
+// protected:
+//     const int batchSize = 4;
+//     TestModel testModel;
+
+// public:
+//     void SetUp() override {
+//         ASSERT_NO_FATAL_FAILURE(GraphTransformerTest::SetUp());
+
+//         ASSERT_NO_FATAL_FAILURE(InitCompileEnv());
+
+//         testModel = CreateTestModel();
+//     }
+
+//     void RunPass() {
+//         PassSet pipeline;
+//         pipeline.addPass(passManager->dumpModel("initial"));
+//         pipeline.addPass(passManager->adjustDataBatch());
+//         pipeline.addPass(passManager->dumpModel("adjustDataBatch"));
+//         pipeline.run(testModel.getBaseModel());
+//     }
+
+//     DataVector checkSingleLoopStart(const Data& data) {
+//         EXPECT_EQ(data->desc().dim(Dim::N), 4);
+//         EXPECT_EQ(data->numConsumers(), 2);
+
+//         DataVector outputs;
+//         for (const auto& consumer : data->consumers()) {
+//             EXPECT_TRUE(consumer->type() == StageType::LoopStart || consumer->type() == StageType::LoopEnd);
+//             if (consumer->type() == StageType::LoopStart) {
+//                 for (const auto& output : consumer->outputs()) {
+//                     EXPECT_EQ(output->desc().dim(Dim::N), 1);
+//                     outputs.push_back(output);
+//                 }
+//             }
+//         }
+
+//         return outputs;
+//     }
+
+//     DataVector checkBranches(const Data& root, const std::vector<StageType>& consumersTypes) {
+//         auto successors = DataVector{};
+
+//         const auto& consumers = root->consumers() | asVector();
+//         EXPECT_EQ(consumers.size(), consumersTypes.size());
+//         for (std::size_t i = 0; i < consumers.size(); ++i) {
+//             const auto& consumer = consumers[i];
+//             const auto& expected = consumersTypes[i];
+//             EXPECT_EQ(consumer->type(), expected);
+
+//             EXPECT_EQ(consumer->numOutputs(), 1);
+//             const auto& output = consumer->output(0);
+//             successors.push_back(output);
+
+//             if (expected == StageType::LoopStart) {
+//                 EXPECT_EQ(consumer->numOutputs(), 1);
+//                 EXPECT_EQ(output->desc().dim(Dim::N), 1);
+//             } else if (expected == StageType::LoopEnd) {
+//                 EXPECT_EQ(output->desc().dim(Dim::N), 4);
+//             }
+//         }
+
+//         return successors;
+//     }
+
+//     DataVector checkSingleLoopEnd(const Data& data) {
+//         EXPECT_EQ(data->numConsumers(), 1);
+
+//         const auto& consumer = data->singleConsumer();
+//         EXPECT_EQ(consumer->type(), StageType::LoopEnd);
+//         DataVector outputs;
+//         for (const auto& output : consumer->outputs()) {
+//             EXPECT_EQ(output->desc().dim(Dim::N), 4);
+//             outputs.push_back(output);
+//         }
+
+//         return outputs;
+//     }
+
+//     static Data CheckSingleConnection(const Data& data, int testInd, int batch = 1) {
+//         EXPECT_EQ(data->numConsumers(), 1);
+
+//         const auto& consumer = data->singleConsumer();
+//         EXPECT_EQ(consumer->type(), StageType::None);
+//         EXPECT_EQ(consumer->attrs().get<int>("test_ind"), testInd);
+//         EXPECT_EQ(consumer->numOutputs(), 1);
+//         const auto& output = consumer->output(0);
+//         EXPECT_EQ(output->desc().dim(Dim::N), batch);
+//         return output;
+//     }
+
+//     static Data singleElement(const DataVector& dataObjects) {
+//         EXPECT_EQ(dataObjects.size(), 1);
+//         return dataObjects.front();
+//     }
+// };
+
+// TEST_F(VPU_AdjustDataBatchTest, LinearWithBatchedInTheEnd) {
+//     //
+//     // [Input] -> (Split) -> (Split) -> (Split) -> (Split) -> (Split) -> (Split) -> (Batched) -> [Output]
+//     //
+//     const DataDesc desc{16, 16, 3, batchSize};
+
+//     testModel.createInputs({desc});
+//     testModel.createOutputs({desc});
+
+//     for (int i = 0; i < 6; i++) {
+//         if (i > 0)
+//             testModel.addStage({InputInfo::fromPrevStage(i - 1)}, {OutputInfo::intermediate(desc)});
+//         else
+//             testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc)});
+//         testModel.setStageBatchInfo(i, {{0, BatchSupport::Split}});
+//     }
+//     testModel.addStage({InputInfo::fromPrevStage(5)}, {OutputInfo::fromNetwork(0)});
+
+//     RunPass();
+
+//     const auto& data0 = singleElement(checkSingleLoopStart(testModel.getInputs().at(0)));
+//     const auto& data1 = CheckSingleConnection(data0, 0);
+//     const auto& data2 = CheckSingleConnection(data1, 1);
+//     const auto& data3 = CheckSingleConnection(data2, 2);
+//     const auto& data4 = CheckSingleConnection(data3, 3);
+//     const auto& data5 = CheckSingleConnection(data4, 4);
+//     const auto& data6 = CheckSingleConnection(data5, 5);
+//     const auto& data7 = singleElement(checkSingleLoopEnd(data6));
+
+//     const auto& data8 = CheckSingleConnection(data7, 6, batchSize);
+
+//     ASSERT_EQ(data8, testModel.getOutputs().at(0));
+// }
+
+// TEST_F(VPU_AdjustDataBatchTest, BranchedWithBatchSplitItems) {
+//     //                                                                                      -> (Batched) -> [Output]
+//     // [Input] -> (Split) -> (Split) -> (Split) -> (Split) -> (Split) -> (Split) -> (Split)
+//     //                                                                                      -> (Batched) -> [Output]
+//     const DataDesc desc{16, 16, 3, batchSize};
+
+//     testModel.createInputs({desc});
+//     testModel.createOutputs({desc, desc});
+
+//     for (int i = 0; i < 7; i++) {
+//         if (i > 0)
+//             testModel.addStage({InputInfo::fromPrevStage(i - 1)}, {OutputInfo::intermediate(desc)});
+//         else
+//             testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc)});
+//         testModel.setStageBatchInfo(i, {{0, BatchSupport::Split}});
+//     }
+
+//     testModel.addStage({InputInfo::fromPrevStage(6)}, {OutputInfo::fromNetwork(0)});
+//     testModel.addStage({InputInfo::fromPrevStage(6)}, {OutputInfo::fromNetwork(1)});
+
+//     RunPass();
+
+//     const auto& data0 = singleElement(checkSingleLoopStart(testModel.getInputs().at(0)));
+//     const auto& data1 = CheckSingleConnection(data0, 0);
+//     const auto& data2 = CheckSingleConnection(data1, 1);
+//     const auto& data3 = CheckSingleConnection(data2, 2);
+//     const auto& data4 = CheckSingleConnection(data3, 3);
+//     const auto& data5 = CheckSingleConnection(data4, 4);
+//     const auto& data6 = CheckSingleConnection(data5, 5);
+//     const auto& data7 = CheckSingleConnection(data6, 6);
+//     const auto& data8 = singleElement(checkSingleLoopEnd(data7));
+
+//     const auto& branches = checkBranches(data8, {StageType::None, StageType::None});
+//     const auto& withBatch = branches[0];
+//     const auto& withBatch_1 = branches[1];
+
+//     ASSERT_EQ(withBatch->producer()->attrs().get<int>("test_ind"), 7);
+//     ASSERT_EQ(withBatch->desc().dim(Dim::N), batchSize);
+//     ASSERT_EQ(withBatch, testModel.getOutputs().at(0));
+
+//     ASSERT_EQ(withBatch_1->producer()->attrs().get<int>("test_ind"), 8);
+//     ASSERT_EQ(withBatch_1->desc().dim(Dim::N), batchSize);
+//     ASSERT_EQ(withBatch_1, testModel.getOutputs().at(1));
+// }
+
+// TEST_F(VPU_AdjustDataBatchTest, LinearWithBatchedInTheBeginning) {
+//     //
+//     // [Input] -> (Batched) -> (Split) -> (Split) -> (Split) -> (Split) -> (Split) -> (Split) -> [Output]
+//     //
+//     const DataDesc desc{16, 16, 3, batchSize};
+
+//     testModel.createInputs({desc});
+//     testModel.createOutputs({desc});
+
+//     for (int i = 0; i < 6; i++) {
+//         if (i > 0)
+//             testModel.addStage({InputInfo::fromPrevStage(i - 1)}, {OutputInfo::intermediate(desc)});
+//         else
+//             testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc)});
+//         if (i > 0)
+//             testModel.setStageBatchInfo(i, {{0, BatchSupport::Split}});
+//     }
+
+//     testModel.addStage({InputInfo::fromPrevStage(5)}, {OutputInfo::fromNetwork()});
+//     testModel.setStageBatchInfo(6, {{0, BatchSupport::Split}});
+
+//     RunPass();
+
+//     const auto& data0 = CheckSingleConnection(testModel.getInputs().at(0), 0, batchSize);
+//     const auto& data7 = singleElement(checkSingleLoopStart(data0));
+//     const auto& data3 = CheckSingleConnection(data7, 1);
+//     const auto& data4 = CheckSingleConnection(data3, 2);
+//     const auto& data5 = CheckSingleConnection(data4, 3);
+//     const auto& data6 = CheckSingleConnection(data5, 4);
+//     const auto& data8 = CheckSingleConnection(data6, 5);
+//     const auto& data10 = CheckSingleConnection(data8, 6);
+//     const auto& data11 = checkSingleLoopEnd(data10);
+
+//     ASSERT_EQ(data11, testModel.getOutputs());
+// }
+
+// TEST_F(VPU_AdjustDataBatchTest, BranchedWithBatchItemsInTheEnd) {
+//     //                                                                                      -> (Batched) -> [Output]
+//     // [Input] -> (Split) -> (Split) -> (Split) -> (Split) -> (Split) -> (Split) -> (Batch)
+//     //                                                                                      -> (Batched) -> [Output]
+//     const DataDesc desc{16, 16, 3, batchSize};
+
+//     testModel.createInputs({desc});
+//     testModel.createOutputs({desc, desc});
+
+//     for (int i = 0; i < 6; i++) {
+//         if (i > 0)
+//             testModel.addStage({InputInfo::fromPrevStage(i - 1)}, {OutputInfo::intermediate(desc)});
+//         else
+//             testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc)});
+//         testModel.setStageBatchInfo(i, {{0, BatchSupport::Split}});
+//     }
+
+//     testModel.addStage({InputInfo::fromPrevStage(5)}, {OutputInfo::intermediate(desc)});
+//     testModel.addStage({InputInfo::fromPrevStage(6)}, {OutputInfo::fromNetwork(0)});
+//     testModel.addStage({InputInfo::fromPrevStage(6)}, {OutputInfo::fromNetwork(1)});
+
+//     RunPass();
+
+//     const auto& data0 = singleElement(checkSingleLoopStart(testModel.getInputs().at(0)));
+//     const auto& data1 = CheckSingleConnection(data0, 0);
+//     const auto& data2 = CheckSingleConnection(data1, 1);
+//     const auto& data3 = CheckSingleConnection(data2, 2);
+//     const auto& data4 = CheckSingleConnection(data3, 3);
+//     const auto& data5 = CheckSingleConnection(data4, 4);
+//     const auto& data6 = CheckSingleConnection(data5, 5);
+//     const auto& data7 = singleElement(checkSingleLoopEnd(data6));
+
+//     const auto& data8 = CheckSingleConnection(data7, 6, batchSize);
+
+//     const auto& branches = checkBranches(data8, {StageType::None, StageType::None});
+//     const auto& withBatch = branches[0];
+//     const auto& withBatch_1 = branches[1];
+
+//     ASSERT_EQ(withBatch->producer()->attrs().get<int>("test_ind"), 7);
+//     ASSERT_EQ(withBatch->desc().dim(Dim::N), batchSize);
+//     ASSERT_EQ(withBatch, testModel.getOutputs().at(0));
+
+//     ASSERT_EQ(withBatch_1->producer()->attrs().get<int>("test_ind"), 8);
+//     ASSERT_EQ(withBatch_1->desc().dim(Dim::N), batchSize);
+//     ASSERT_EQ(withBatch_1, testModel.getOutputs().at(1));
+// }
+
+// TEST_F(VPU_AdjustDataBatchTest, DISABLED_BranchedWithSplitAndBatchItemsInTheEnd) {
+//     //
+//     //                                         -> (Split) -> (Batched) -> [Output]
+//     // [Input] -> (Split) -> (Split) -> (Split)
+//     //                                         -> (Split) -> [Output]
+//     //
+//     const DataDesc desc{16, 16, 3, batchSize};
+
+//     testModel.createInputs({desc});
+//     testModel.createOutputs({desc, desc});
+
+//     for (int i = 0; i < 5; i++) {
+//         if (i > 0)
+//             testModel.addStage({InputInfo::fromPrevStage(i - 1)}, {OutputInfo::intermediate(desc)});
+//         else
+//             testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc)});
+//         if (i != 3)
+//             testModel.setStageBatchInfo(i, {{0, BatchSupport::Split}});
+//     }
+
+//     testModel.addStage({InputInfo::fromPrevStage(2)}, {OutputInfo::fromNetwork(1)});
+//     testModel.setStageBatchInfo(5, {{0, BatchSupport::Split}});
+
+//     RunPass();
+
+//     const auto& data0 = singleElement(checkSingleLoopStart(testModel.getInputs().at(0)));
+//     const auto& data1 = CheckSingleConnection(data0, 0);
+//     const auto& data2 = CheckSingleConnection(data1, 1);
+//     const auto& data3 = CheckSingleConnection(data2, 2);
+
+//     const auto& branches = checkBranches(data3, {StageType::None, StageType::LoopEnd});
+//     const auto& branch1 = branches[0];
+//     const auto& branch2 = branches[1];
+
+//     const auto& data4 = CheckSingleConnection(branch1, 3);
+//     const auto& data7 = singleElement(checkSingleLoopEnd(data4));
+//     const auto& data5 = CheckSingleConnection(data7, 4, batchSize);
+//     ASSERT_EQ(data5, testModel.getOutputs().at(0));
+//     const auto& data6 = CheckSingleConnection(branch2, 5);
+//     ASSERT_EQ(data6, testModel.getOutputs().at(1));
+// }
+
+// TEST_F(VPU_AdjustDataBatchTest, DISABLED_BranchedWithBatchAndSplitItemsInTheEnd) {
+//     //
+//     //                                         -> (Split) -> [Output]
+//     // [Input] -> (Split) -> (Split) -> (Split)
+//     //                                         -> (Split) -> [Output]
+//     //
+//     const DataDesc desc{16, 16, 3, batchSize};
+
+//     testModel.createInputs({desc});
+//     testModel.createOutputs({desc, desc});
+
+//     for (int i = 0; i < 3; i++) {
+//         if (i > 0)
+//             testModel.addStage({InputInfo::fromPrevStage(i - 1)}, {OutputInfo::intermediate(desc)});
+//         else
+//             testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc)});
+//         testModel.setStageBatchInfo(i, {{0, BatchSupport::Split}});
+//     }
+//     for (int i = 0; i < 2; i++) {
+//         testModel.addStage({InputInfo::fromNetwork(2)}, {OutputInfo::intermediate(desc)});
+//         testModel.setStageBatchInfo(3 + i, {{0, BatchSupport::Split}});
+//     }
+
+//     testModel.addStage({InputInfo::fromPrevStage(2)}, {OutputInfo::fromNetwork(0)});
+//     testModel.setStageBatchInfo(3, {{0, BatchSupport::Split}});
+//     testModel.addStage({InputInfo::fromPrevStage(2)}, {OutputInfo::fromNetwork(1)});
+//     testModel.setStageBatchInfo(4, {{0, BatchSupport::Split}});
+
+//     RunPass();
+
+//     const auto& data1 = singleElement(checkSingleLoopStart(testModel.getInputs().at(0)));
+//     const auto& data2 = CheckSingleConnection(data1, 1);
+//     const auto& data3 = CheckSingleConnection(data2, 2);
+//     const auto& branches = checkBranches(data3, {StageType::None, StageType::LoopEnd});
+//     const auto& branch1 = branches[0];
+//     const auto& branch2 = branches[1];
+//     const auto& data4 = CheckSingleConnection(branch1, 3);
+//     (void)data4;
+//     const auto& data5 = CheckSingleConnection(branch2, 4);
+//     const auto& data6 = checkSingleLoopEnd(data5);
+//     (void)data6;
+// }

--- a/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/adjust_dynamic_batch.cpp
+++ b/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/adjust_dynamic_batch.cpp
@@ -1,148 +1,148 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
 
-#include "graph_transformer_tests.hpp"
+// #include "graph_transformer_tests.hpp"
 
-#include "ie_memcpy.h"
+// #include "ie_memcpy.h"
 
-namespace vpu {
+// namespace vpu {
 
-namespace ie = InferenceEngine;
+// namespace ie = InferenceEngine;
 
-class AdjustDynamicBatchTests : public GraphTransformerTest {
-protected:
-    void SetUp() override {
-        ASSERT_NO_FATAL_FAILURE(GraphTransformerTest::SetUp());
-        ASSERT_NO_FATAL_FAILURE(InitCompileEnv());
-        ASSERT_NO_FATAL_FAILURE(InitPipeline());
+// class AdjustDynamicBatchTests : public GraphTransformerTest {
+// protected:
+//     void SetUp() override {
+//         ASSERT_NO_FATAL_FAILURE(GraphTransformerTest::SetUp());
+//         ASSERT_NO_FATAL_FAILURE(InitCompileEnv());
+//         ASSERT_NO_FATAL_FAILURE(InitPipeline());
 
-        _testModel = CreateTestModel();
-    }
+//         _testModel = CreateTestModel();
+//     }
 
-    void Compile() {
-        _pipeline.run(_testModel.getBaseModel());
-    }
+//     void Compile() {
+//         _pipeline.run(_testModel.getBaseModel());
+//     }
 
-    void InitPipeline() {
-        _pipeline = PassSet();
-        _pipeline.addPass(passManager->dumpModel("before-adjust-batch"));
-        _pipeline.addPass(passManager->initialCheck());
-        _pipeline.addPass(passManager->adjustDataBatch());
-        _pipeline.addPass(passManager->dumpModel("after-adjust-batch"));
-    }
+//     void InitPipeline() {
+//         _pipeline = PassSet();
+//         _pipeline.addPass(passManager->dumpModel("before-adjust-batch"));
+//         _pipeline.addPass(passManager->initialCheck());
+//         _pipeline.addPass(passManager->adjustDataBatch());
+//         _pipeline.addPass(passManager->dumpModel("after-adjust-batch"));
+//     }
 
-    static Data singleElement(const DataVector& dataObjects) {
-        EXPECT_EQ(dataObjects.size(), 1);
-        return dataObjects.front();
-    }
+//     static Data singleElement(const DataVector& dataObjects) {
+//         EXPECT_EQ(dataObjects.size(), 1);
+//         return dataObjects.front();
+//     }
 
-    DataVector checkSingleLoopStart(const Data& data) {
-        EXPECT_EQ(data->numConsumers(), 2);
+//     DataVector checkSingleLoopStart(const Data& data) {
+//         EXPECT_EQ(data->numConsumers(), 2);
 
-        DataVector outputs;
-        for (const auto& consumer : data->consumers()) {
-            EXPECT_TRUE(consumer->type() == StageType::LoopStart || consumer->type() == StageType::LoopEnd);
-            if (consumer->type() == StageType::LoopStart) {
-                for (const auto& output : consumer->outputs()) {
-                    EXPECT_EQ(output->desc().dim(Dim::N), 1);
-                    outputs.push_back(output);
-                }
-            }
-        }
+//         DataVector outputs;
+//         for (const auto& consumer : data->consumers()) {
+//             EXPECT_TRUE(consumer->type() == StageType::LoopStart || consumer->type() == StageType::LoopEnd);
+//             if (consumer->type() == StageType::LoopStart) {
+//                 for (const auto& output : consumer->outputs()) {
+//                     EXPECT_EQ(output->desc().dim(Dim::N), 1);
+//                     outputs.push_back(output);
+//                 }
+//             }
+//         }
 
-        return outputs;
-    }
+//         return outputs;
+//     }
 
-    static Data checkSingleConnection(const Data& data, int testInd, int batch = 1) {
-        EXPECT_EQ(data->numConsumers(), 1);
+//     static Data checkSingleConnection(const Data& data, int testInd, int batch = 1) {
+//         EXPECT_EQ(data->numConsumers(), 1);
 
-        const auto& consumer = data->singleConsumer();
-        EXPECT_EQ(consumer->type(), StageType::None);
-        EXPECT_EQ(consumer->attrs().get<int>("test_ind"), testInd);
-        EXPECT_EQ(consumer->numOutputs(), 1);
-        const auto& output = consumer->output(0);
-        EXPECT_EQ(output->desc().dim(Dim::N), batch);
-        return output;
-    }
+//         const auto& consumer = data->singleConsumer();
+//         EXPECT_EQ(consumer->type(), StageType::None);
+//         EXPECT_EQ(consumer->attrs().get<int>("test_ind"), testInd);
+//         EXPECT_EQ(consumer->numOutputs(), 1);
+//         const auto& output = consumer->output(0);
+//         EXPECT_EQ(output->desc().dim(Dim::N), batch);
+//         return output;
+//     }
 
-    DataVector checkSingleLoopEnd(const Data& data) {
-        EXPECT_EQ(data->numConsumers(), 1);
+//     DataVector checkSingleLoopEnd(const Data& data) {
+//         EXPECT_EQ(data->numConsumers(), 1);
 
-        const auto& consumer = data->singleConsumer();
-        EXPECT_EQ(consumer->type(), StageType::LoopEnd);
-        DataVector outputs;
-        for (const auto& output : consumer->outputs()) {
-            outputs.push_back(output);
-        }
+//         const auto& consumer = data->singleConsumer();
+//         EXPECT_EQ(consumer->type(), StageType::LoopEnd);
+//         DataVector outputs;
+//         for (const auto& output : consumer->outputs()) {
+//             outputs.push_back(output);
+//         }
 
-        return outputs;
-    }
+//         return outputs;
+//     }
 
-protected:
-    PassSet _pipeline;
-    TestModel _testModel;
-};
+// protected:
+//     PassSet _pipeline;
+//     TestModel _testModel;
+// };
 
-TEST_F(AdjustDynamicBatchTests, AdjustBatch_oneStage) {
-    //
-    // [Input] -> (Split) -> [Output]
-    //
+// TEST_F(AdjustDynamicBatchTests, AdjustBatch_oneStage) {
+//     //
+//     // [Input] -> (Split) -> [Output]
+//     //
 
-    const DataDesc desc_input{3, 3, 3, 3};
-    const DataDesc desc_input_shape{4};
+//     const DataDesc desc_input{3, 3, 3, 3};
+//     const DataDesc desc_input_shape{4};
 
-    const DataDesc desc_output{3, 3, 3, 3};
+//     const DataDesc desc_output{3, 3, 3, 3};
 
-    _testModel.createInputs({desc_input, desc_input_shape});
-    _testModel.createOutputs({desc_output});
+//     _testModel.createInputs({desc_input, desc_input_shape});
+//     _testModel.createOutputs({desc_output});
 
-    auto stage = _testModel.addStage({InputInfo::fromNetwork(0)}, {OutputInfo::fromNetwork(0)});
-    _testModel.setStageBatchInfo(0, {{0, BatchSupport::Split}});
+//     auto stage = _testModel.addStage({InputInfo::fromNetwork(0)}, {OutputInfo::fromNetwork(0)});
+//     _testModel.setStageBatchInfo(0, {{0, BatchSupport::Split}});
 
-    auto model = _testModel.getBaseModel();
+//     auto model = _testModel.getBaseModel();
 
-    ASSERT_NO_THROW(model->connectDataWithShape(_testModel.getInputs()[1], _testModel.getInputs()[0]));
-    ASSERT_NO_THROW(model->connectDataWithShape(_testModel.getInputs()[1], _testModel.getOutputs()[0]));
+//     ASSERT_NO_THROW(model->connectDataWithShape(_testModel.getInputs()[1], _testModel.getInputs()[0]));
+//     ASSERT_NO_THROW(model->connectDataWithShape(_testModel.getInputs()[1], _testModel.getOutputs()[0]));
 
-    ASSERT_NO_THROW(Compile());
+//     ASSERT_NO_THROW(Compile());
 
-    const auto& data0 = singleElement(checkSingleLoopStart(_testModel.getInputs()[0]));
-    const auto& data1 = checkSingleConnection(data0, 0);
-    const auto& data2 = checkSingleLoopEnd(data1);
-    ASSERT_EQ(data2, _testModel.getOutputs());
-}
+//     const auto& data0 = singleElement(checkSingleLoopStart(_testModel.getInputs()[0]));
+//     const auto& data1 = checkSingleConnection(data0, 0);
+//     const auto& data2 = checkSingleLoopEnd(data1);
+//     ASSERT_EQ(data2, _testModel.getOutputs());
+// }
 
-TEST_F(AdjustDynamicBatchTests, AdjustBatch) {
-    //
-    // [Input] -> (Split) -> (Split) -> (Split) -> [Output]
-    //
+// TEST_F(AdjustDynamicBatchTests, AdjustBatch) {
+//     //
+//     // [Input] -> (Split) -> (Split) -> (Split) -> [Output]
+//     //
 
-    const DataDesc desc_input{3, 3, 3, 3};
-    const DataDesc desc_input_shape{4};
+//     const DataDesc desc_input{3, 3, 3, 3};
+//     const DataDesc desc_input_shape{4};
 
-    const DataDesc desc_output{3, 3, 3, 3};
+//     const DataDesc desc_output{3, 3, 3, 3};
 
-    _testModel.createInputs({desc_input, desc_input_shape});
-    _testModel.createOutputs({desc_output});
+//     _testModel.createInputs({desc_input, desc_input_shape});
+//     _testModel.createOutputs({desc_output});
 
-    auto stage1 = _testModel.addStage({InputInfo::fromNetwork(0)}, {OutputInfo::intermediate(desc_input)});
-    _testModel.setStageBatchInfo(0, {{0, BatchSupport::Split}});
-    auto stage2 = _testModel.addStage({InputInfo::fromPrevStage(0)}, {OutputInfo::fromNetwork(0)});
-    _testModel.setStageBatchInfo(1, {{0, BatchSupport::Split}});
+//     auto stage1 = _testModel.addStage({InputInfo::fromNetwork(0)}, {OutputInfo::intermediate(desc_input)});
+//     _testModel.setStageBatchInfo(0, {{0, BatchSupport::Split}});
+//     auto stage2 = _testModel.addStage({InputInfo::fromPrevStage(0)}, {OutputInfo::fromNetwork(0)});
+//     _testModel.setStageBatchInfo(1, {{0, BatchSupport::Split}});
 
-    auto model = _testModel.getBaseModel();
+//     auto model = _testModel.getBaseModel();
 
-    ASSERT_NO_THROW(model->connectDataWithShape(_testModel.getInputs()[1], _testModel.getInputs()[0]));
-    ASSERT_NO_THROW(model->connectDataWithShape(_testModel.getInputs()[1], _testModel.getOutputs()[0]));
+//     ASSERT_NO_THROW(model->connectDataWithShape(_testModel.getInputs()[1], _testModel.getInputs()[0]));
+//     ASSERT_NO_THROW(model->connectDataWithShape(_testModel.getInputs()[1], _testModel.getOutputs()[0]));
 
-    ASSERT_NO_THROW(Compile());
+//     ASSERT_NO_THROW(Compile());
 
-    const auto& data0 = singleElement(checkSingleLoopStart(_testModel.getInputs()[0]));
-    const auto& data1 = checkSingleConnection(data0, 0);
-    const auto& data2 = checkSingleConnection(data1, 1);
-    const auto& data3 = checkSingleLoopEnd(data2);
-    ASSERT_EQ(data3, _testModel.getOutputs());
-}
+//     const auto& data0 = singleElement(checkSingleLoopStart(_testModel.getInputs()[0]));
+//     const auto& data1 = checkSingleConnection(data0, 0);
+//     const auto& data2 = checkSingleConnection(data1, 1);
+//     const auto& data3 = checkSingleLoopEnd(data2);
+//     ASSERT_EQ(data3, _testModel.getOutputs());
+// }
 
-} // namespace vpu
+// } // namespace vpu

--- a/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/annotate_memory_types.cpp
+++ b/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/annotate_memory_types.cpp
@@ -1,116 +1,116 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
 
-#include "graph_transformer_tests.hpp"
-#include "common_test_utils/common_utils.hpp"
+// #include "graph_transformer_tests.hpp"
+// #include "common_test_utils/common_utils.hpp"
 
-namespace vpu {
+// namespace vpu {
 
-namespace ie = InferenceEngine;
+// namespace ie = InferenceEngine;
 
-namespace {
+// namespace {
 
-using TestParam = std::tuple<
-    // input MemoryType of first stage is always DDR
-    std::tuple<MemoryType, MemoryType, MemoryType>, // outputs MemoryTypes for first stage
-    std::tuple<MemoryType, MemoryType>              // outputs MemoryTypes for second stage
-    // output MemoryType of third stage is always DDR
->;
+// using TestParam = std::tuple<
+//     // input MemoryType of first stage is always DDR
+//     std::tuple<MemoryType, MemoryType, MemoryType>, // outputs MemoryTypes for first stage
+//     std::tuple<MemoryType, MemoryType>              // outputs MemoryTypes for second stage
+//     // output MemoryType of third stage is always DDR
+// >;
 
-}
+// }
 
-class AnnotateMemoryTypes : public GraphTransformerTest, public testing::WithParamInterface<TestParam> {
-protected:
-    void SetUp() override {
-        ASSERT_NO_FATAL_FAILURE(GraphTransformerTest::SetUp());
-        config.compileConfig().enableMemoryTypesAnnotation = true;
+// class AnnotateMemoryTypes : public GraphTransformerTest, public testing::WithParamInterface<TestParam> {
+// protected:
+//     void SetUp() override {
+//         ASSERT_NO_FATAL_FAILURE(GraphTransformerTest::SetUp());
+//         config.compileConfig().enableMemoryTypesAnnotation = true;
 
-        ASSERT_NO_FATAL_FAILURE(InitCompileEnv());
-        ASSERT_NO_FATAL_FAILURE(InitPipeline());
+//         ASSERT_NO_FATAL_FAILURE(InitCompileEnv());
+//         ASSERT_NO_FATAL_FAILURE(InitPipeline());
 
-        const auto& parameters = GetParam();
-        const auto& firstStageOutputs = CommonTestUtils::tuple2Vector(std::get<0>(parameters));
-        const auto& secondStageOutputs = CommonTestUtils::tuple2Vector(std::get<1>(parameters));
-        ASSERT_NO_FATAL_FAILURE(InitModel(firstStageOutputs, secondStageOutputs));
-        ASSERT_NO_FATAL_FAILURE(Compile());
-        ASSERT_NO_FATAL_FAILURE(Validate(firstStageOutputs, secondStageOutputs));
-    }
+//         const auto& parameters = GetParam();
+//         const auto& firstStageOutputs = CommonTestUtils::tuple2Vector(std::get<0>(parameters));
+//         const auto& secondStageOutputs = CommonTestUtils::tuple2Vector(std::get<1>(parameters));
+//         ASSERT_NO_FATAL_FAILURE(InitModel(firstStageOutputs, secondStageOutputs));
+//         ASSERT_NO_FATAL_FAILURE(Compile());
+//         ASSERT_NO_FATAL_FAILURE(Validate(firstStageOutputs, secondStageOutputs));
+//     }
 
-    void Compile() {
-        m_pipeline.run(m_testModel.getBaseModel());
-    }
+//     void Compile() {
+//         m_pipeline.run(m_testModel.getBaseModel());
+//     }
 
-    void Validate(const std::vector<MemoryType>& firstStageOutputs, const std::vector<MemoryType>& secondStageOutputs) {
-        const auto& stages = m_testModel.getStages();
-        ASSERT_EQ(stages.size(), 3);
+//     void Validate(const std::vector<MemoryType>& firstStageOutputs, const std::vector<MemoryType>& secondStageOutputs) {
+//         const auto& stages = m_testModel.getStages();
+//         ASSERT_EQ(stages.size(), 3);
 
-        const auto& stage0 = stages.front();
-        const auto& stage1 = stages[1];
-        const auto& stage2 = stages.back();
+//         const auto& stage0 = stages.front();
+//         const auto& stage1 = stages[1];
+//         const auto& stage2 = stages.back();
 
-        ASSERT_TRUE(CommonTestUtils::endsWith(stage0->name(), "@[DDR]->" + GenerateSuffix(firstStageOutputs)));
-        ASSERT_TRUE(CommonTestUtils::endsWith(stage1->name(), "@" + GenerateSuffix(firstStageOutputs) + "->" + GenerateSuffix(secondStageOutputs)));
-        ASSERT_TRUE(CommonTestUtils::endsWith(stage2->name(), "@" + GenerateSuffix(secondStageOutputs) + "->[DDR]"));
-    }
+//         ASSERT_TRUE(CommonTestUtils::endsWith(stage0->name(), "@[DDR]->" + GenerateSuffix(firstStageOutputs)));
+//         ASSERT_TRUE(CommonTestUtils::endsWith(stage1->name(), "@" + GenerateSuffix(firstStageOutputs) + "->" + GenerateSuffix(secondStageOutputs)));
+//         ASSERT_TRUE(CommonTestUtils::endsWith(stage2->name(), "@" + GenerateSuffix(secondStageOutputs) + "->[DDR]"));
+//     }
 
-protected:
-    TestModel m_testModel;
+// protected:
+//     TestModel m_testModel;
 
-private:
-    void InitModel(const std::vector<MemoryType>& firstStageOutputs, const std::vector<MemoryType>& secondStageOutputs) {
-        m_testModel = CreateTestModel();
+// private:
+//     void InitModel(const std::vector<MemoryType>& firstStageOutputs, const std::vector<MemoryType>& secondStageOutputs) {
+//         m_testModel = CreateTestModel();
 
-        m_testModel.createInputs();
-        m_testModel.createOutputs();
+//         m_testModel.createInputs();
+//         m_testModel.createOutputs();
 
-        const auto generateInputs = [](const std::vector<MemoryType>& inputsMemoryTypes, std::size_t prevStageIndex) {
-            std::vector<int> indices(inputsMemoryTypes.size());
-            std::iota(indices.begin(), indices.end(), 0);
-            std::vector<InputInfo> inputs;
-            std::transform(indices.cbegin(), indices.cend(), std::back_inserter(inputs),
-                [&prevStageIndex](int index) { return InputInfo::fromPrevStage(static_cast<int>(prevStageIndex), index); });
-            return inputs;
-        };
+//         const auto generateInputs = [](const std::vector<MemoryType>& inputsMemoryTypes, std::size_t prevStageIndex) {
+//             std::vector<int> indices(inputsMemoryTypes.size());
+//             std::iota(indices.begin(), indices.end(), 0);
+//             std::vector<InputInfo> inputs;
+//             std::transform(indices.cbegin(), indices.cend(), std::back_inserter(inputs),
+//                 [&prevStageIndex](int index) { return InputInfo::fromPrevStage(static_cast<int>(prevStageIndex), index); });
+//             return inputs;
+//         };
 
-        const auto generateOutputs = [](const std::vector<MemoryType>& outputsMemoryTypes) {
-            std::vector<OutputInfo> outputs;
-            std::transform(outputsMemoryTypes.cbegin(), outputsMemoryTypes.cend(), std::back_inserter(outputs),
-                [](MemoryType type) { return OutputInfo::intermediate(type); });
-            return outputs;
-        };
+//         const auto generateOutputs = [](const std::vector<MemoryType>& outputsMemoryTypes) {
+//             std::vector<OutputInfo> outputs;
+//             std::transform(outputsMemoryTypes.cbegin(), outputsMemoryTypes.cend(), std::back_inserter(outputs),
+//                 [](MemoryType type) { return OutputInfo::intermediate(type); });
+//             return outputs;
+//         };
 
-        m_testModel.addStage({InputInfo::fromNetwork()}, generateOutputs(firstStageOutputs));
-        m_testModel.addStage(generateInputs(firstStageOutputs, 0), generateOutputs(secondStageOutputs));
-        m_testModel.addStage(generateInputs(secondStageOutputs, 1), {OutputInfo::fromNetwork()});
-    }
+//         m_testModel.addStage({InputInfo::fromNetwork()}, generateOutputs(firstStageOutputs));
+//         m_testModel.addStage(generateInputs(firstStageOutputs, 0), generateOutputs(secondStageOutputs));
+//         m_testModel.addStage(generateInputs(secondStageOutputs, 1), {OutputInfo::fromNetwork()});
+//     }
 
-    void InitPipeline() {
-        m_pipeline = PassSet();
-        m_pipeline.addPass(passManager->annotateMemoryTypes());
-    }
+//     void InitPipeline() {
+//         m_pipeline = PassSet();
+//         m_pipeline.addPass(passManager->annotateMemoryTypes());
+//     }
 
-    template<class T>
-    static std::string GenerateSuffix(const T& outputs) {
-        std::stringstream suffix;
-        printTo(suffix, outputs);
-        return suffix.str();
-    }
+//     template<class T>
+//     static std::string GenerateSuffix(const T& outputs) {
+//         std::stringstream suffix;
+//         printTo(suffix, outputs);
+//         return suffix.str();
+//     }
 
-    PassSet m_pipeline;
-};
+//     PassSet m_pipeline;
+// };
 
-TEST_P(AnnotateMemoryTypes, SubgraphOf3Stages) {
-}
+// TEST_P(AnnotateMemoryTypes, SubgraphOf3Stages) {
+// }
 
-INSTANTIATE_TEST_SUITE_P(unit, AnnotateMemoryTypes, testing::Combine(
-    testing::Combine(
-        testing::Values(MemoryType::DDR, MemoryType::CMX),
-        testing::Values(MemoryType::DDR, MemoryType::CMX),
-        testing::Values(MemoryType::DDR, MemoryType::CMX)),
-    testing::Combine(
-        testing::Values(MemoryType::DDR, MemoryType::CMX),
-        testing::Values(MemoryType::DDR, MemoryType::CMX))
-));
+// INSTANTIATE_TEST_CASE_P(unit, AnnotateMemoryTypes, testing::Combine(
+//     testing::Combine(
+//         testing::Values(MemoryType::DDR, MemoryType::CMX),
+//         testing::Values(MemoryType::DDR, MemoryType::CMX),
+//         testing::Values(MemoryType::DDR, MemoryType::CMX)),
+//     testing::Combine(
+//         testing::Values(MemoryType::DDR, MemoryType::CMX),
+//         testing::Values(MemoryType::DDR, MemoryType::CMX))
+// ));
 
-} // namespace vpu
+// } // namespace vpu

--- a/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/convert_shape_notation.cpp
+++ b/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/convert_shape_notation.cpp
@@ -1,435 +1,435 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
 
-#include "graph_transformer_tests.hpp"
-
-#include "ie_memcpy.h"
+// #include "graph_transformer_tests.hpp"
+
+// #include "ie_memcpy.h"
 
-namespace vpu {
+// namespace vpu {
 
-namespace ie = InferenceEngine;
+// namespace ie = InferenceEngine;
 
-class ConvertShapeNotationTests : public GraphTransformerTest {
-protected:
-    void SetUp() override {
-        ASSERT_NO_FATAL_FAILURE(GraphTransformerTest::SetUp());
-        ASSERT_NO_FATAL_FAILURE(InitCompileEnv());
-        ASSERT_NO_FATAL_FAILURE(InitPipeline());
+// class ConvertShapeNotationTests : public GraphTransformerTest {
+// protected:
+//     void SetUp() override {
+//         ASSERT_NO_FATAL_FAILURE(GraphTransformerTest::SetUp());
+//         ASSERT_NO_FATAL_FAILURE(InitCompileEnv());
+//         ASSERT_NO_FATAL_FAILURE(InitPipeline());
 
-        _testModel = CreateTestModel();
-    }
+//         _testModel = CreateTestModel();
+//     }
 
-    void Compile() {
-        _pipeline.run(_testModel.getBaseModel());
-    }
+//     void Compile() {
+//         _pipeline.run(_testModel.getBaseModel());
+//     }
 
-    void InitPipeline() {
-        _pipeline = PassSet();
-        _pipeline.addPass(passManager->dumpModel("before-convert-shape-notation"));
-        _pipeline.addPass(passManager->initialCheck());
-        _pipeline.addPass(passManager->convertShapeNotation());
-        _pipeline.addPass(passManager->dumpModel("after-convert-shape-notation"));
-    }
+//     void InitPipeline() {
+//         _pipeline = PassSet();
+//         _pipeline.addPass(passManager->dumpModel("before-convert-shape-notation"));
+//         _pipeline.addPass(passManager->initialCheck());
+//         _pipeline.addPass(passManager->convertShapeNotation());
+//         _pipeline.addPass(passManager->dumpModel("after-convert-shape-notation"));
+//     }
 
-    int getGathersCount() {
-        int gathersCount = 0;
+//     int getGathersCount() {
+//         int gathersCount = 0;
 
-        for (const auto& stage : _testModel.getBaseModel()->getStages()) {
-            if (stage->type() == StageType::Gather) {
-                gathersCount++;
-            }
-        }
+//         for (const auto& stage : _testModel.getBaseModel()->getStages()) {
+//             if (stage->type() == StageType::Gather) {
+//                 gathersCount++;
+//             }
+//         }
 
-        return gathersCount;
-    }
-
-    void checkGatherParams() {
-        for (const auto& gather : _testModel.getBaseModel()->getStages()) {
-            if (gather->type() != StageType::Gather) {
-                continue;
-            }
-
-            const auto gatherIndices = gather->input(1);
-            ASSERT_NE(gatherIndices, nullptr);
-
-            const auto indicesDesc = gatherIndices->desc();
-            ASSERT_EQ(indicesDesc.type(), DataType::S32);
-            ASSERT_EQ(indicesDesc.dims().size(), 1);
-
-            const auto indicesCount = static_cast<size_t>(indicesDesc.totalDimSize());
-            const auto indicesBuffer = gatherIndices->content()->get<int32_t*>();
-
-            std::vector<int32_t> expectedIndices(indicesCount);
-            std::iota(expectedIndices.rbegin(), expectedIndices.rend(), 0);
-
-            std::vector<int32_t> actualIndices(indicesCount);
-            ie_memcpy(actualIndices.data(), indicesCount, indicesBuffer, indicesCount);
-
-            ASSERT_TRUE(std::equal(actualIndices.begin(), actualIndices.end(), expectedIndices.begin()));
-        }
-    }
-
-    Data findConvertedShape(const Data& shape) {
-        for (const auto& consumer : shape->consumers()) {
-            if (consumer->type() == StageType::Gather) {
-                return consumer->output(0);
-            }
-        }
-        return nullptr;
-    }
+//         return gathersCount;
+//     }
+
+//     void checkGatherParams() {
+//         for (const auto& gather : _testModel.getBaseModel()->getStages()) {
+//             if (gather->type() != StageType::Gather) {
+//                 continue;
+//             }
+
+//             const auto gatherIndices = gather->input(1);
+//             ASSERT_NE(gatherIndices, nullptr);
+
+//             const auto indicesDesc = gatherIndices->desc();
+//             ASSERT_EQ(indicesDesc.type(), DataType::S32);
+//             ASSERT_EQ(indicesDesc.dims().size(), 1);
+
+//             const auto indicesCount = static_cast<size_t>(indicesDesc.totalDimSize());
+//             const auto indicesBuffer = gatherIndices->content()->get<int32_t*>();
+
+//             std::vector<int32_t> expectedIndices(indicesCount);
+//             std::iota(expectedIndices.rbegin(), expectedIndices.rend(), 0);
+
+//             std::vector<int32_t> actualIndices(indicesCount);
+//             ie_memcpy(actualIndices.data(), indicesCount, indicesBuffer, indicesCount);
+
+//             ASSERT_TRUE(std::equal(actualIndices.begin(), actualIndices.end(), expectedIndices.begin()));
+//         }
+//     }
+
+//     Data findConvertedShape(const Data& shape) {
+//         for (const auto& consumer : shape->consumers()) {
+//             if (consumer->type() == StageType::Gather) {
+//                 return consumer->output(0);
+//             }
+//         }
+//         return nullptr;
+//     }
 
-    void checkDataToShapeDependency(const Data& shape, const Data& data) {
-        ASSERT_FALSE(shape->childDataToShapeEdges().empty());
-        ASSERT_NE(data->parentDataToShapeEdge(), nullptr);
+//     void checkDataToShapeDependency(const Data& shape, const Data& data) {
+//         ASSERT_FALSE(shape->childDataToShapeEdges().empty());
+//         ASSERT_NE(data->parentDataToShapeEdge(), nullptr);
 
-        const auto& edge = data->parentDataToShapeEdge();
+//         const auto& edge = data->parentDataToShapeEdge();
 
-        ASSERT_EQ(edge->child(), data);
-        ASSERT_EQ(edge->parent(), shape);
-    }
-
-    void checkStageDependency(const Stage& parent, const Stage& child) {
-        ASSERT_FALSE(parent->childDependencyEdges().empty());
-        const auto& childDependencyEdges = parent->childDependencyEdges();
+//         ASSERT_EQ(edge->child(), data);
+//         ASSERT_EQ(edge->parent(), shape);
+//     }
+
+//     void checkStageDependency(const Stage& parent, const Stage& child) {
+//         ASSERT_FALSE(parent->childDependencyEdges().empty());
+//         const auto& childDependencyEdges = parent->childDependencyEdges();
 
-        auto it = std::find_if(childDependencyEdges.begin(), childDependencyEdges.end(),
-                               [&child](const StageDependency& edge) {
-                                   return edge->child() == child;
-                               });
+//         auto it = std::find_if(childDependencyEdges.begin(), childDependencyEdges.end(),
+//                                [&child](const StageDependency& edge) {
+//                                    return edge->child() == child;
+//                                });
 
-        ASSERT_NE(it, childDependencyEdges.end());
-    }
+//         ASSERT_NE(it, childDependencyEdges.end());
+//     }
 
-    void checkNoDataToShapeDependency(const Data& shape, const Data& data) {
-        ASSERT_TRUE(!data->parentDataToShapeEdge() || data->parentDataToShapeEdge()->parent() != shape);
+//     void checkNoDataToShapeDependency(const Data& shape, const Data& data) {
+//         ASSERT_TRUE(!data->parentDataToShapeEdge() || data->parentDataToShapeEdge()->parent() != shape);
 
-        const auto& childDataToShapeEdges = shape->childDataToShapeEdges();
+//         const auto& childDataToShapeEdges = shape->childDataToShapeEdges();
 
-        auto it = std::find_if(childDataToShapeEdges.begin(), childDataToShapeEdges.end(),
-                               [&data](const DataToShapeAllocation& edge) {
-                                   return edge->child() == data;
-                               });
+//         auto it = std::find_if(childDataToShapeEdges.begin(), childDataToShapeEdges.end(),
+//                                [&data](const DataToShapeAllocation& edge) {
+//                                    return edge->child() == data;
+//                                });
 
-        ASSERT_EQ(it, childDataToShapeEdges.end());
-    }
+//         ASSERT_EQ(it, childDataToShapeEdges.end());
+//     }
 
-    void checkNoStageDependency(const Stage& parent, const Stage& child) {
-        const auto& childDependencyEdges = parent->childDependencyEdges();
+//     void checkNoStageDependency(const Stage& parent, const Stage& child) {
+//         const auto& childDependencyEdges = parent->childDependencyEdges();
 
-        auto it = std::find_if(childDependencyEdges.begin(), childDependencyEdges.end(),
-                               [&child](const StageDependency& edge) {
-                                   return edge->child() == child;
-                               });
+//         auto it = std::find_if(childDependencyEdges.begin(), childDependencyEdges.end(),
+//                                [&child](const StageDependency& edge) {
+//                                    return edge->child() == child;
+//                                });
 
-        ASSERT_EQ(it, parent->childDependencyEdges().end());
-    }
+//         ASSERT_EQ(it, parent->childDependencyEdges().end());
+//     }
 
-    void checkGathers(int gathersCount) {
-        ASSERT_EQ(getGathersCount(), gathersCount);
-        checkGatherParams();
-    }
+//     void checkGathers(int gathersCount) {
+//         ASSERT_EQ(getGathersCount(), gathersCount);
+//         checkGatherParams();
+//     }
 
-    void checkShapeWithConsumers(const Data& shape, const DataVector& datasConsumingShape) {
-        const auto convertedShape = findConvertedShape(shape);
+//     void checkShapeWithConsumers(const Data& shape, const DataVector& datasConsumingShape) {
+//         const auto convertedShape = findConvertedShape(shape);
 
-        for (const auto& dataConsumingShape : datasConsumingShape) {
-            checkDataToShapeDependency(convertedShape, dataConsumingShape);
-            checkNoDataToShapeDependency(shape, dataConsumingShape);
+//         for (const auto& dataConsumingShape : datasConsumingShape) {
+//             checkDataToShapeDependency(convertedShape, dataConsumingShape);
+//             checkNoDataToShapeDependency(shape, dataConsumingShape);
 
-            Stage dependentStage;
-            if (shape->producer() && shape->producer() == dataConsumingShape->producer()) {
-                dependentStage = dataConsumingShape->singleConsumer();
-            } else {
-                ASSERT_NE(dataConsumingShape->producer(), nullptr);
-                dependentStage = dataConsumingShape->producer();
-            }
+//             Stage dependentStage;
+//             if (shape->producer() && shape->producer() == dataConsumingShape->producer()) {
+//                 dependentStage = dataConsumingShape->singleConsumer();
+//             } else {
+//                 ASSERT_NE(dataConsumingShape->producer(), nullptr);
+//                 dependentStage = dataConsumingShape->producer();
+//             }
 
-            checkStageDependency(convertedShape->producer(), dependentStage);
-            checkNoStageDependency(shape->producer(), dependentStage);
-        }
-    }
+//             checkStageDependency(convertedShape->producer(), dependentStage);
+//             checkNoStageDependency(shape->producer(), dependentStage);
+//         }
+//     }
 
-protected:
-    PassSet _pipeline;
-    TestModel _testModel;
-};
+// protected:
+//     PassSet _pipeline;
+//     TestModel _testModel;
+// };
 
-TEST_F(ConvertShapeNotationTests, BothDataAndShapeIntermediate) {
-    //
-    //                    -> [Shape] -> (Stage) -> [Output]
-    // [Input] -> (Stage)       |
-    //                    -> [Data]  -> (Stage) -> [Output]
-    //
+// TEST_F(ConvertShapeNotationTests, BothDataAndShapeIntermediate) {
+//     //
+//     //                    -> [Shape] -> (Stage) -> [Output]
+//     // [Input] -> (Stage)       |
+//     //                    -> [Data]  -> (Stage) -> [Output]
+//     //
 
-    const DataDesc desc{1};
+//     const DataDesc desc{1};
 
-    _testModel.createInputs({desc});
-    _testModel.createOutputs({desc, desc});
+//     _testModel.createInputs({desc});
+//     _testModel.createOutputs({desc, desc});
 
-    auto shapeProducer = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
-                                                                          OutputInfo::intermediate(desc)});
-    _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
-    _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
+//     auto shapeProducer = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
+//                                                                           OutputInfo::intermediate(desc)});
+//     _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
+//     _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
 
-    auto model = _testModel.getBaseModel();
+//     auto model = _testModel.getBaseModel();
 
-    ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(0)));
+//     ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(0)));
 
-    ASSERT_NO_THROW(Compile());
+//     ASSERT_NO_THROW(Compile());
 
-    checkGathers(1);
-    checkShapeWithConsumers(shapeProducer->output(1), {shapeProducer->output(0)});
-}
+//     checkGathers(1);
+//     checkShapeWithConsumers(shapeProducer->output(1), {shapeProducer->output(0)});
+// }
 
-TEST_F(ConvertShapeNotationTests, DataOutputShapeIntermediate) {
-    //
-    //                    -> [Shape] -> (Stage) -> [Output]
-    // [Input] -> (Stage)       |
-    //                    -> [Data]
-    //
+// TEST_F(ConvertShapeNotationTests, DataOutputShapeIntermediate) {
+//     //
+//     //                    -> [Shape] -> (Stage) -> [Output]
+//     // [Input] -> (Stage)       |
+//     //                    -> [Data]
+//     //
 
-    const DataDesc desc{1};
+//     const DataDesc desc{1};
 
-    _testModel.createInputs({desc});
-    _testModel.createOutputs({desc, desc});
+//     _testModel.createInputs({desc});
+//     _testModel.createOutputs({desc, desc});
 
-    auto shapeProducer = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(0),
-                                                                          OutputInfo::intermediate(desc)});
-    _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
+//     auto shapeProducer = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(0),
+//                                                                           OutputInfo::intermediate(desc)});
+//     _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
 
-    auto model = _testModel.getBaseModel();
+//     auto model = _testModel.getBaseModel();
 
-    ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(0)));
+//     ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(0)));
 
-    ASSERT_NO_THROW(Compile());
+//     ASSERT_NO_THROW(Compile());
 
-    checkGathers(1);
-    checkShapeWithConsumers(shapeProducer->output(1), {});
-}
+//     checkGathers(1);
+//     checkShapeWithConsumers(shapeProducer->output(1), {});
+// }
 
-TEST_F(ConvertShapeNotationTests, DataIntermediateShapeOutput) {
-    //
-    //                    -> [Shape]
-    // [Input] -> (Stage)       |
-    //                    -> [Data]  -> (Stage) -> [Output]
-    //
+// TEST_F(ConvertShapeNotationTests, DataIntermediateShapeOutput) {
+//     //
+//     //                    -> [Shape]
+//     // [Input] -> (Stage)       |
+//     //                    -> [Data]  -> (Stage) -> [Output]
+//     //
 
-    const DataDesc desc{1};
+//     const DataDesc desc{1};
 
-    _testModel.createInputs({desc});
-    _testModel.createOutputs({desc, desc});
+//     _testModel.createInputs({desc});
+//     _testModel.createOutputs({desc, desc});
 
-    auto shapeProducer = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
-                                                                          OutputInfo::fromNetwork(1)});
-    _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
+//     auto shapeProducer = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
+//                                                                           OutputInfo::fromNetwork(1)});
+//     _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
 
-    auto model = _testModel.getBaseModel();
+//     auto model = _testModel.getBaseModel();
 
-    ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(0)));
+//     ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(0)));
 
-    ASSERT_NO_THROW(Compile());
+//     ASSERT_NO_THROW(Compile());
 
-    checkGathers(1);
-    checkShapeWithConsumers(shapeProducer->output(1), {shapeProducer->output(0)});
-}
+//     checkGathers(1);
+//     checkShapeWithConsumers(shapeProducer->output(1), {shapeProducer->output(0)});
+// }
 
-TEST_F(ConvertShapeNotationTests, BothDataAndShapeOutput) {
-    //
-    //                    -> [Shape]
-    // [Input] -> (Stage)       |
-    //                    -> [Data]
-    //
+// TEST_F(ConvertShapeNotationTests, BothDataAndShapeOutput) {
+//     //
+//     //                    -> [Shape]
+//     // [Input] -> (Stage)       |
+//     //                    -> [Data]
+//     //
 
-    const DataDesc desc{1};
+//     const DataDesc desc{1};
 
-    _testModel.createInputs({desc});
-    _testModel.createOutputs({desc, desc});
+//     _testModel.createInputs({desc});
+//     _testModel.createOutputs({desc, desc});
 
-    auto shapeProducer = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(0),
-                                                                          OutputInfo::fromNetwork(1)});
+//     auto shapeProducer = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(0),
+//                                                                           OutputInfo::fromNetwork(1)});
 
-    auto model = _testModel.getBaseModel();
+//     auto model = _testModel.getBaseModel();
 
-    ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(0)));
+//     ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(0)));
 
-    ASSERT_NO_THROW(Compile());
+//     ASSERT_NO_THROW(Compile());
 
-    checkGathers(1);
-    checkShapeWithConsumers(shapeProducer->output(1), {});
-}
+//     checkGathers(1);
+//     checkShapeWithConsumers(shapeProducer->output(1), {});
+// }
 
-TEST_F(ConvertShapeNotationTests, TwoShapeConsumersAllInterm) {
-    //
-    //                    -> [Data]  -> (Stage) -> [Output]
-    //                          |
-    // [Input] -> (Stage) -> [Shape] -> (Stage) -> [Output]
-    //                          |
-    //                    -> [Data]  -> (Stage) -> [Output]
-    //
+// TEST_F(ConvertShapeNotationTests, TwoShapeConsumersAllInterm) {
+//     //
+//     //                    -> [Data]  -> (Stage) -> [Output]
+//     //                          |
+//     // [Input] -> (Stage) -> [Shape] -> (Stage) -> [Output]
+//     //                          |
+//     //                    -> [Data]  -> (Stage) -> [Output]
+//     //
 
-    const DataDesc desc{1};
+//     const DataDesc desc{1};
 
-    _testModel.createInputs({desc});
-    _testModel.createOutputs({desc, desc, desc});
+//     _testModel.createInputs({desc});
+//     _testModel.createOutputs({desc, desc, desc});
 
-    auto shapeProducer = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
-                                                                          OutputInfo::intermediate(desc),
-                                                                          OutputInfo::intermediate(desc)});
-    _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
-    _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
-    _testModel.addStage({InputInfo::fromPrevStage(0).output(2)}, {OutputInfo::fromNetwork(2)});
+//     auto shapeProducer = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
+//                                                                           OutputInfo::intermediate(desc),
+//                                                                           OutputInfo::intermediate(desc)});
+//     _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
+//     _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
+//     _testModel.addStage({InputInfo::fromPrevStage(0).output(2)}, {OutputInfo::fromNetwork(2)});
 
-    auto model = _testModel.getBaseModel();
+//     auto model = _testModel.getBaseModel();
 
-    ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(0)));
-    ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(2)));
+//     ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(0)));
+//     ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(2)));
 
-    ASSERT_NO_THROW(Compile());
+//     ASSERT_NO_THROW(Compile());
 
-    checkGathers(1);
-    checkShapeWithConsumers(shapeProducer->output(1), {shapeProducer->output(0), shapeProducer->output(2)});
-}
+//     checkGathers(1);
+//     checkShapeWithConsumers(shapeProducer->output(1), {shapeProducer->output(0), shapeProducer->output(2)});
+// }
 
-TEST_F(ConvertShapeNotationTests, TwoShapeConsumersShapeOutput) {
-    //
-    //                    -> [Data]  -> (Stage) -> [Output]
-    //                          |
-    // [Input] -> (Stage) -> [Shape]
-    //                          |
-    //                    -> [Data]  -> (Stage) -> [Output]
-    //
+// TEST_F(ConvertShapeNotationTests, TwoShapeConsumersShapeOutput) {
+//     //
+//     //                    -> [Data]  -> (Stage) -> [Output]
+//     //                          |
+//     // [Input] -> (Stage) -> [Shape]
+//     //                          |
+//     //                    -> [Data]  -> (Stage) -> [Output]
+//     //
 
-    const DataDesc desc{1};
+//     const DataDesc desc{1};
 
-    _testModel.createInputs({desc});
-    _testModel.createOutputs({desc, desc, desc});
+//     _testModel.createInputs({desc});
+//     _testModel.createOutputs({desc, desc, desc});
 
-    auto shapeProducer = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
-                                                                          OutputInfo::fromNetwork(1),
-                                                                          OutputInfo::intermediate(desc)});
-    _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
-    _testModel.addStage({InputInfo::fromPrevStage(0).output(2)}, {OutputInfo::fromNetwork(2)});
+//     auto shapeProducer = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate(desc),
+//                                                                           OutputInfo::fromNetwork(1),
+//                                                                           OutputInfo::intermediate(desc)});
+//     _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
+//     _testModel.addStage({InputInfo::fromPrevStage(0).output(2)}, {OutputInfo::fromNetwork(2)});
 
-    auto model = _testModel.getBaseModel();
+//     auto model = _testModel.getBaseModel();
 
-    ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(0)));
-    ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(2)));
+//     ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(0)));
+//     ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(2)));
 
-    ASSERT_NO_THROW(Compile());
+//     ASSERT_NO_THROW(Compile());
 
-    checkGathers(1);
-    checkShapeWithConsumers(shapeProducer->output(1), {shapeProducer->output(0), shapeProducer->output(2)});
-}
+//     checkGathers(1);
+//     checkShapeWithConsumers(shapeProducer->output(1), {shapeProducer->output(0), shapeProducer->output(2)});
+// }
 
-TEST_F(ConvertShapeNotationTests, DataAndShapeHaveDifferentProducers) {
-    //
-    //                       [Shape] -> (Stage) -> [Shape]
-    // [Input] -> (Stage) ->                          |
-    //                       [Data]  -> (Stage) -> [Data]  -> (Stage) -> [Output]
-    //
+// TEST_F(ConvertShapeNotationTests, DataAndShapeHaveDifferentProducers) {
+//     //
+//     //                       [Shape] -> (Stage) -> [Shape]
+//     // [Input] -> (Stage) ->                          |
+//     //                       [Data]  -> (Stage) -> [Data]  -> (Stage) -> [Output]
+//     //
 
-    const DataDesc desc{1};
+//     const DataDesc desc{1};
 
-    _testModel.createInputs({desc});
-    _testModel.createOutputs({desc, desc});
+//     _testModel.createInputs({desc});
+//     _testModel.createOutputs({desc, desc});
 
-    _testModel.addStage({InputInfo::fromNetwork(0)}, {OutputInfo::intermediate(desc), OutputInfo::intermediate(desc)});
-    auto dataProducer = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::intermediate(desc)});
-    auto shapeProducer = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
-    _testModel.addStage({InputInfo::fromPrevStage(1)}, {OutputInfo::fromNetwork(0)});
+//     _testModel.addStage({InputInfo::fromNetwork(0)}, {OutputInfo::intermediate(desc), OutputInfo::intermediate(desc)});
+//     auto dataProducer = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::intermediate(desc)});
+//     auto shapeProducer = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
+//     _testModel.addStage({InputInfo::fromPrevStage(1)}, {OutputInfo::fromNetwork(0)});
 
-    auto model = _testModel.getBaseModel();
+//     auto model = _testModel.getBaseModel();
 
-    ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(0), dataProducer->output(0)));
+//     ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(0), dataProducer->output(0)));
 
-    ASSERT_NO_THROW(Compile());
+//     ASSERT_NO_THROW(Compile());
 
-    checkGathers(1);
-    checkShapeWithConsumers(shapeProducer->output(0), {dataProducer->output(0)});
-}
+//     checkGathers(1);
+//     checkShapeWithConsumers(shapeProducer->output(0), {dataProducer->output(0)});
+// }
 
-TEST_F(ConvertShapeNotationTests, TwoConsumersWithSameShape) {
-    //
-    //                       [Shape]-------------------
-    // [Input] -> (Stage) ->    |                     |
-    //                       [Data]  -> (Stage) -> [Output]
-    //
+// TEST_F(ConvertShapeNotationTests, TwoConsumersWithSameShape) {
+//     //
+//     //                       [Shape]-------------------
+//     // [Input] -> (Stage) ->    |                     |
+//     //                       [Data]  -> (Stage) -> [Output]
+//     //
 
-    const DataDesc desc{1};
+//     const DataDesc desc{1};
 
-    _testModel.createInputs({desc});
-    _testModel.createOutputs({desc, desc});
+//     _testModel.createInputs({desc});
+//     _testModel.createOutputs({desc, desc});
 
-    auto shapeProducer = _testModel.addStage({InputInfo::fromNetwork(0)}, {OutputInfo::intermediate(desc), OutputInfo::fromNetwork(1)});
-    auto dataProcessor = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
+//     auto shapeProducer = _testModel.addStage({InputInfo::fromNetwork(0)}, {OutputInfo::intermediate(desc), OutputInfo::fromNetwork(1)});
+//     auto dataProcessor = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::fromNetwork(0)});
 
-    auto model = _testModel.getBaseModel();
+//     auto model = _testModel.getBaseModel();
 
-    ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(0)));
-    ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), dataProcessor->output(0)));
+//     ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(0)));
+//     ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), dataProcessor->output(0)));
 
-    ASSERT_NO_THROW(Compile());
+//     ASSERT_NO_THROW(Compile());
 
-    checkGathers(1);
-    checkShapeWithConsumers(shapeProducer->output(1), {shapeProducer->output(0), dataProcessor->output(0)});
-}
+//     checkGathers(1);
+//     checkShapeWithConsumers(shapeProducer->output(1), {shapeProducer->output(0), dataProcessor->output(0)});
+// }
 
-TEST_F(ConvertShapeNotationTests, ThreeConsumersWithSameShape) {
-    //
-    //                       [Shape]-----------------------------------------
-    // [Input] -> (Stage) ->    |                     |                     |
-    //                       [Data]  -> (Stage) -> [Data] -> (Stage) -> [Output]
-    //
+// TEST_F(ConvertShapeNotationTests, ThreeConsumersWithSameShape) {
+//     //
+//     //                       [Shape]-----------------------------------------
+//     // [Input] -> (Stage) ->    |                     |                     |
+//     //                       [Data]  -> (Stage) -> [Data] -> (Stage) -> [Output]
+//     //
 
-    const DataDesc desc{1};
+//     const DataDesc desc{1};
 
-    _testModel.createInputs({desc});
-    _testModel.createOutputs({desc, desc});
+//     _testModel.createInputs({desc});
+//     _testModel.createOutputs({desc, desc});
 
-    auto shapeProducer = _testModel.addStage({InputInfo::fromNetwork(0)}, {OutputInfo::intermediate(desc), OutputInfo::fromNetwork(1)});
-    auto firstDataProcessor = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::intermediate(desc)});
-    auto secondDataProcessor = _testModel.addStage({InputInfo::fromPrevStage(1).output(0)}, {OutputInfo::fromNetwork(0)});
+//     auto shapeProducer = _testModel.addStage({InputInfo::fromNetwork(0)}, {OutputInfo::intermediate(desc), OutputInfo::fromNetwork(1)});
+//     auto firstDataProcessor = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::intermediate(desc)});
+//     auto secondDataProcessor = _testModel.addStage({InputInfo::fromPrevStage(1).output(0)}, {OutputInfo::fromNetwork(0)});
 
-    auto model = _testModel.getBaseModel();
+//     auto model = _testModel.getBaseModel();
 
-    ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(0)));
-    ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), firstDataProcessor->output(0)));
-    ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), secondDataProcessor->output(0)));
+//     ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), shapeProducer->output(0)));
+//     ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), firstDataProcessor->output(0)));
+//     ASSERT_NO_THROW(model->connectDataWithShape(shapeProducer->output(1), secondDataProcessor->output(0)));
 
-    ASSERT_NO_THROW(Compile());
+//     ASSERT_NO_THROW(Compile());
 
-    checkGathers(1);
-    checkShapeWithConsumers(shapeProducer->output(1), {shapeProducer->output(0), firstDataProcessor->output(0), secondDataProcessor->output(0)});
-}
+//     checkGathers(1);
+//     checkShapeWithConsumers(shapeProducer->output(1), {shapeProducer->output(0), firstDataProcessor->output(0), secondDataProcessor->output(0)});
+// }
 
-TEST_F(ConvertShapeNotationTests, TwoShapesTwoConsumers) {
-    //
-    //                       [Shape] -> (Stage) -> [Shape]
-    // [Input] -> (Stage) ->    |                     |
-    //                       [Data]  -> (Stage) -> [Data]  -> (Stage) -> [Output]
-    //
+// TEST_F(ConvertShapeNotationTests, TwoShapesTwoConsumers) {
+//     //
+//     //                       [Shape] -> (Stage) -> [Shape]
+//     // [Input] -> (Stage) ->    |                     |
+//     //                       [Data]  -> (Stage) -> [Data]  -> (Stage) -> [Output]
+//     //
 
-    const DataDesc desc{1};
+//     const DataDesc desc{1};
 
-    _testModel.createInputs({desc});
-    _testModel.createOutputs({desc, desc});
+//     _testModel.createInputs({desc});
+//     _testModel.createOutputs({desc, desc});
 
-    auto firstShapeProducer = _testModel.addStage({InputInfo::fromNetwork(0)}, {OutputInfo::intermediate(desc), OutputInfo::intermediate(desc)});
-    auto firstDataProducer = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::intermediate(desc)});
-    auto secondShapeProducer = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
-    auto secondDataProducer = _testModel.addStage({InputInfo::fromPrevStage(1)}, {OutputInfo::fromNetwork(0)});
+//     auto firstShapeProducer = _testModel.addStage({InputInfo::fromNetwork(0)}, {OutputInfo::intermediate(desc), OutputInfo::intermediate(desc)});
+//     auto firstDataProducer = _testModel.addStage({InputInfo::fromPrevStage(0).output(0)}, {OutputInfo::intermediate(desc)});
+//     auto secondShapeProducer = _testModel.addStage({InputInfo::fromPrevStage(0).output(1)}, {OutputInfo::fromNetwork(1)});
+//     auto secondDataProducer = _testModel.addStage({InputInfo::fromPrevStage(1)}, {OutputInfo::fromNetwork(0)});
 
-    auto model = _testModel.getBaseModel();
+//     auto model = _testModel.getBaseModel();
 
-    ASSERT_NO_THROW(model->connectDataWithShape(firstShapeProducer->output(1), firstShapeProducer->output(0)));
-    ASSERT_NO_THROW(model->connectDataWithShape(secondShapeProducer->output(0), firstDataProducer->output(0)));
+//     ASSERT_NO_THROW(model->connectDataWithShape(firstShapeProducer->output(1), firstShapeProducer->output(0)));
+//     ASSERT_NO_THROW(model->connectDataWithShape(secondShapeProducer->output(0), firstDataProducer->output(0)));
 
-    ASSERT_NO_THROW(Compile());
+//     ASSERT_NO_THROW(Compile());
 
-    checkGathers(2);
-    checkShapeWithConsumers(firstShapeProducer->output(1), {firstShapeProducer->output(0)});
-    checkShapeWithConsumers(secondShapeProducer->output(0), {firstDataProducer->output(0)});
-}
+//     checkGathers(2);
+//     checkShapeWithConsumers(firstShapeProducer->output(1), {firstShapeProducer->output(0)});
+//     checkShapeWithConsumers(secondShapeProducer->output(0), {firstDataProducer->output(0)});
+// }
 
-} // namespace vpu
+// } // namespace vpu

--- a/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/inject_sw.cpp
+++ b/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/inject_sw.cpp
@@ -1,141 +1,141 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
 
-#include "graph_transformer_tests.hpp"
+// #include "graph_transformer_tests.hpp"
 
-namespace vpu {
+// namespace vpu {
 
-namespace ie = InferenceEngine;
+// namespace ie = InferenceEngine;
 
-class InjectStageTests : public GraphTransformerTest {
-protected:
-    void SetUp() override {
-        ASSERT_NO_FATAL_FAILURE(GraphTransformerTest::SetUp());
+// class InjectStageTests : public GraphTransformerTest {
+// protected:
+//     void SetUp() override {
+//         ASSERT_NO_FATAL_FAILURE(GraphTransformerTest::SetUp());
 
-        ASSERT_NO_FATAL_FAILURE(InitCompileEnv());
+//         ASSERT_NO_FATAL_FAILURE(InitCompileEnv());
 
-        _testModel = CreateTestModel();
-    }
+//         _testModel = CreateTestModel();
+//     }
 
-protected:
-    TestModel _testModel;
-};
+// protected:
+//     TestModel _testModel;
+// };
 
-TEST_F(InjectStageTests, InjectionRedirectsChildStageDependency) {
-    //
-    //         -> (Stage) -> [Output]
-    // [Input] -> (Stage) -> [Output]
-    //         -> (Stage) -> [Output]
-    //
+// TEST_F(InjectStageTests, InjectionRedirectsChildStageDependency) {
+//     //
+//     //         -> (Stage) -> [Output]
+//     // [Input] -> (Stage) -> [Output]
+//     //         -> (Stage) -> [Output]
+//     //
 
-    const DataDesc desc{1};
+//     const DataDesc desc{1};
 
-    _testModel.createInputs({desc});
-    _testModel.createOutputs({desc, desc, desc});
+//     _testModel.createInputs({desc});
+//     _testModel.createOutputs({desc, desc, desc});
 
-    const auto hwStage = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(0)}, StageType::MyriadXHwOp);
-    const auto swStage = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(1)}, StageType::Copy);
-    const auto childStage = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(2)});
+//     const auto hwStage = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(0)}, StageType::MyriadXHwOp);
+//     const auto swStage = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(1)}, StageType::Copy);
+//     const auto childStage = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(2)});
 
-    auto model = _testModel.getBaseModel();
+//     auto model = _testModel.getBaseModel();
 
-    ASSERT_NO_THROW(model->addStageDependency(swStage, childStage));
-    ASSERT_TRUE(checkExecutionOrder(model, {swStage->id(), childStage->id()}));
+//     ASSERT_NO_THROW(model->addStageDependency(swStage, childStage));
+//     ASSERT_TRUE(checkExecutionOrder(model, {swStage->id(), childStage->id()}));
 
-    ASSERT_NO_THROW(model->injectStage()
-                            .parentHW(hwStage)
-                            .childSW(swStage)
-                            .done());
-    ASSERT_TRUE(checkExecutionOrder(model, {hwStage->id(), childStage->id()}));
-}
+//     ASSERT_NO_THROW(model->injectStage()
+//                             .parentHW(hwStage)
+//                             .childSW(swStage)
+//                             .done());
+//     ASSERT_TRUE(checkExecutionOrder(model, {hwStage->id(), childStage->id()}));
+// }
 
-TEST_F(InjectStageTests, InjectionRedirectsParentStageDependency) {
-    //
-    //         -> (Stage) -> [Output]
-    // [Input] -> (Stage) -> [Output]
-    //         -> (Stage) -> [Output]
-    //
+// TEST_F(InjectStageTests, InjectionRedirectsParentStageDependency) {
+//     //
+//     //         -> (Stage) -> [Output]
+//     // [Input] -> (Stage) -> [Output]
+//     //         -> (Stage) -> [Output]
+//     //
 
-    const DataDesc desc{1};
+//     const DataDesc desc{1};
 
-    _testModel.createInputs({desc});
-    _testModel.createOutputs({desc, desc, desc});
+//     _testModel.createInputs({desc});
+//     _testModel.createOutputs({desc, desc, desc});
 
-    const auto hwStage = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(0)}, StageType::MyriadXHwOp);
-    const auto swStage = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(1)}, StageType::Copy);
-    const auto parentStage = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(2)});
+//     const auto hwStage = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(0)}, StageType::MyriadXHwOp);
+//     const auto swStage = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(1)}, StageType::Copy);
+//     const auto parentStage = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(2)});
 
-    auto model = _testModel.getBaseModel();
+//     auto model = _testModel.getBaseModel();
 
-    ASSERT_NO_THROW(model->addStageDependency(parentStage, swStage));
-    ASSERT_TRUE(checkExecutionOrder(model, {parentStage->id(), swStage->id()}));
+//     ASSERT_NO_THROW(model->addStageDependency(parentStage, swStage));
+//     ASSERT_TRUE(checkExecutionOrder(model, {parentStage->id(), swStage->id()}));
 
-    ASSERT_NO_THROW(model->injectStage()
-                            .parentHW(hwStage)
-                            .childSW(swStage)
-                            .done());
-    ASSERT_TRUE(checkExecutionOrder(model, {parentStage->id(), hwStage->id()}));
-}
+//     ASSERT_NO_THROW(model->injectStage()
+//                             .parentHW(hwStage)
+//                             .childSW(swStage)
+//                             .done());
+//     ASSERT_TRUE(checkExecutionOrder(model, {parentStage->id(), hwStage->id()}));
+// }
 
-TEST_F(InjectStageTests, RevertInjectionRedirectsChildStageDependency) {
-    //
-    //         -> (Stage) -> [Output]
-    // [Input] -> (Stage) -> [Output]
-    //         -> (Stage) -> [Output]
-    //
+// TEST_F(InjectStageTests, RevertInjectionRedirectsChildStageDependency) {
+//     //
+//     //         -> (Stage) -> [Output]
+//     // [Input] -> (Stage) -> [Output]
+//     //         -> (Stage) -> [Output]
+//     //
 
-    const DataDesc desc{1};
+//     const DataDesc desc{1};
 
-    _testModel.createInputs({desc});
-    _testModel.createOutputs({desc, desc, desc});
+//     _testModel.createInputs({desc});
+//     _testModel.createOutputs({desc, desc, desc});
 
-    const auto hwStage = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(0)}, StageType::MyriadXHwOp);
-    const auto swStage = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(1)}, StageType::Copy);
-    const auto parentStage = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(2)});
+//     const auto hwStage = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(0)}, StageType::MyriadXHwOp);
+//     const auto swStage = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(1)}, StageType::Copy);
+//     const auto parentStage = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(2)});
 
-    auto model = _testModel.getBaseModel();
+//     auto model = _testModel.getBaseModel();
 
-    ASSERT_NO_THROW(model->addStageDependency(parentStage, swStage));
-    ASSERT_TRUE(checkExecutionOrder(model, {parentStage->id(), swStage->id()}));
+//     ASSERT_NO_THROW(model->addStageDependency(parentStage, swStage));
+//     ASSERT_TRUE(checkExecutionOrder(model, {parentStage->id(), swStage->id()}));
 
-    Injection edge;
-    ASSERT_NO_THROW(edge = model->injectStage()
-                                .parentHW(hwStage)
-                                .childSW(swStage)
-                                .done());
-    ASSERT_NO_THROW(model->revertInjection(edge));
-    ASSERT_TRUE(checkExecutionOrder(model, {parentStage->id(), swStage->id()}));
-}
+//     Injection edge;
+//     ASSERT_NO_THROW(edge = model->injectStage()
+//                                 .parentHW(hwStage)
+//                                 .childSW(swStage)
+//                                 .done());
+//     ASSERT_NO_THROW(model->revertInjection(edge));
+//     ASSERT_TRUE(checkExecutionOrder(model, {parentStage->id(), swStage->id()}));
+// }
 
-TEST_F(InjectStageTests, RevertInjectionRedirectsParentStageDependency) {
-    //
-    //         -> (Stage) -> [Output]
-    // [Input] -> (Stage) -> [Output]
-    //         -> (Stage) -> [Output]
-    //
+// TEST_F(InjectStageTests, RevertInjectionRedirectsParentStageDependency) {
+//     //
+//     //         -> (Stage) -> [Output]
+//     // [Input] -> (Stage) -> [Output]
+//     //         -> (Stage) -> [Output]
+//     //
 
-    const DataDesc desc{1};
+//     const DataDesc desc{1};
 
-    _testModel.createInputs({desc});
-    _testModel.createOutputs({desc, desc, desc});
+//     _testModel.createInputs({desc});
+//     _testModel.createOutputs({desc, desc, desc});
 
-    const auto hwStage = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(0)}, StageType::MyriadXHwOp);
-    const auto swStage = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(1)}, StageType::Copy);
-    const auto parentStage = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(2)});
+//     const auto hwStage = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(0)}, StageType::MyriadXHwOp);
+//     const auto swStage = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(1)}, StageType::Copy);
+//     const auto parentStage = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork(2)});
 
-    auto model = _testModel.getBaseModel();
+//     auto model = _testModel.getBaseModel();
 
-    ASSERT_NO_THROW(model->addStageDependency(parentStage, swStage));
-    ASSERT_TRUE(checkExecutionOrder(model, {parentStage->id(), swStage->id()}));
+//     ASSERT_NO_THROW(model->addStageDependency(parentStage, swStage));
+//     ASSERT_TRUE(checkExecutionOrder(model, {parentStage->id(), swStage->id()}));
 
-    Injection edge;
-    ASSERT_NO_THROW(edge = model->injectStage()
-                            .parentHW(hwStage)
-                            .childSW(swStage)
-                            .done());
-    ASSERT_NO_THROW(model->revertInjection(edge));
-    ASSERT_TRUE(checkExecutionOrder(model, {parentStage->id(), swStage->id()}));
-}
+//     Injection edge;
+//     ASSERT_NO_THROW(edge = model->injectStage()
+//                             .parentHW(hwStage)
+//                             .childSW(swStage)
+//                             .done());
+//     ASSERT_NO_THROW(model->revertInjection(edge));
+//     ASSERT_TRUE(checkExecutionOrder(model, {parentStage->id(), swStage->id()}));
+// }
 
-} // namespace vpu
+// } // namespace vpu

--- a/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/mark_fast_stages.cpp
+++ b/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/mark_fast_stages.cpp
@@ -1,62 +1,62 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
 
-#include "graph_transformer_tests.hpp"
+// #include "graph_transformer_tests.hpp"
 
-namespace vpu {
+// namespace vpu {
 
-namespace ie = InferenceEngine;
+// namespace ie = InferenceEngine;
 
-class MarkFastStagesTests : public GraphTransformerTest {
-protected:
-    void SetUp() override {
-        ASSERT_NO_FATAL_FAILURE(GraphTransformerTest::SetUp());
-        ASSERT_NO_FATAL_FAILURE(InitCompileEnv());
-        ASSERT_NO_FATAL_FAILURE(InitPipeline());
+// class MarkFastStagesTests : public GraphTransformerTest {
+// protected:
+//     void SetUp() override {
+//         ASSERT_NO_FATAL_FAILURE(GraphTransformerTest::SetUp());
+//         ASSERT_NO_FATAL_FAILURE(InitCompileEnv());
+//         ASSERT_NO_FATAL_FAILURE(InitPipeline());
 
-        _testModel = CreateTestModel();
-    }
+//         _testModel = CreateTestModel();
+//     }
 
-    void Compile() {
-        _pipeline.run(_testModel.getBaseModel());
-    }
+//     void Compile() {
+//         _pipeline.run(_testModel.getBaseModel());
+//     }
 
-    void InitPipeline() {
-        _pipeline = PassSet();
-        _pipeline.addPass(passManager->dumpModel("before-mark-fast-stages"));
-        _pipeline.addPass(passManager->initialCheck());
-        _pipeline.addPass(passManager->markFastStages());
-        _pipeline.addPass(passManager->dumpModel("after-mark-fast-stages"));
-    }
+//     void InitPipeline() {
+//         _pipeline = PassSet();
+//         _pipeline.addPass(passManager->dumpModel("before-mark-fast-stages"));
+//         _pipeline.addPass(passManager->initialCheck());
+//         _pipeline.addPass(passManager->markFastStages());
+//         _pipeline.addPass(passManager->dumpModel("after-mark-fast-stages"));
+//     }
 
-protected:
-    PassSet _pipeline;
-    TestModel _testModel;
-};
+// protected:
+//     PassSet _pipeline;
+//     TestModel _testModel;
+// };
 
-TEST_F(MarkFastStagesTests, FastStageIsMarked) {
-    const DataDesc desc{1};
+// TEST_F(MarkFastStagesTests, FastStageIsMarked) {
+//     const DataDesc desc{1};
 
-    _testModel.createInputs({desc});
-    _testModel.createOutputs({desc});
+//     _testModel.createInputs({desc});
+//     _testModel.createOutputs({desc});
 
-    auto stage = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork()});
-    ASSERT_NO_THROW(Compile());
+//     auto stage = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork()});
+//     ASSERT_NO_THROW(Compile());
 
-    ASSERT_NE(stage->name().find("@fast-stage"), std::string::npos);
-}
+//     ASSERT_NE(stage->name().find("@fast-stage"), std::string::npos);
+// }
 
-TEST_F(MarkFastStagesTests, SlowStageIsNotMarked) {
-    const DataDesc desc{1000};
+// TEST_F(MarkFastStagesTests, SlowStageIsNotMarked) {
+//     const DataDesc desc{1000};
 
-    _testModel.createInputs({desc});
-    _testModel.createOutputs({desc});
+//     _testModel.createInputs({desc});
+//     _testModel.createOutputs({desc});
 
-    auto stage = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork()});
-    ASSERT_NO_THROW(Compile());
+//     auto stage = _testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::fromNetwork()});
+//     ASSERT_NO_THROW(Compile());
 
-    ASSERT_EQ(stage->name().find("@fast-stage"), std::string::npos);
-}
+//     ASSERT_EQ(stage->name().find("@fast-stage"), std::string::npos);
+// }
 
-} // namespace vpu
+// } // namespace vpu

--- a/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/split_large_kernel_conv_tests.cpp
+++ b/inference-engine/tests/unit/vpu/middleend_tests/passes_tests/split_large_kernel_conv_tests.cpp
@@ -1,105 +1,105 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
 
-#include "graph_transformer_tests.hpp"
-#include <vpu/stages/mx_stage.hpp>
-#include <vpu/middleend/hw/utility.hpp>
+// #include "graph_transformer_tests.hpp"
+// #include <vpu/stages/mx_stage.hpp>
+// #include <vpu/middleend/hw/utility.hpp>
 
-using namespace vpu;
+// using namespace vpu;
 
-IE_SUPPRESS_DEPRECATED_START
+// IE_SUPPRESS_DEPRECATED_START
 
-class VPU_SplitLargeKernelConvTest : public GraphTransformerTest {
- protected:
-    PassSet pipeline;
-    Model model;
+// class VPU_SplitLargeKernelConvTest : public GraphTransformerTest {
+//  protected:
+//     PassSet pipeline;
+//     Model model;
 
- public:
-    void InitConvStage(int inputX = 8960, int inputY = 1, bool isOutput4D = true) {
-        int kernelx = 16;
-        int kernely = 1;
-        int kernelStrideX = 1;
-        int kernelStrideY = 1;
-        int dilationX = 1;
-        int dilationY = 1;
-        int padx_begin = 7;
-        int pady_begin = 0;
-        int padx_end = 8;
-        int pady_end = 0;
-        model = CreateModel();
+//  public:
+//     void InitConvStage(int inputX = 8960, int inputY = 1, bool isOutput4D = true) {
+//         int kernelx = 16;
+//         int kernely = 1;
+//         int kernelStrideX = 1;
+//         int kernelStrideY = 1;
+//         int dilationX = 1;
+//         int dilationY = 1;
+//         int padx_begin = 7;
+//         int pady_begin = 0;
+//         int padx_end = 8;
+//         int pady_end = 0;
+//         model = CreateModel();
 
-        auto input = model->addInputData(
-            "Input",
-            DataDesc(DataType::FP16, DimsOrder::NCHW, {inputX, inputY, 8, 1}));
-        model->attrs().set<int>("numInputs", 1);
+//         auto input = model->addInputData(
+//             "Input",
+//             DataDesc(DataType::FP16, DimsOrder::NCHW, {inputX, inputY, 8, 1}));
+//         model->attrs().set<int>("numInputs", 1);
 
-        Data output;
-        if (isOutput4D) {
-            output = model->addOutputData(
-                "Output",
-                DataDesc(DataType::FP16,
-                              DimsOrder::NCHW,
-                              {(inputX + padx_begin + padx_end - kernelx) / kernelStrideX + 1,
-                                (inputY + pady_begin + pady_end - kernely) / kernelStrideY + 1, 8, 1}));
-        } else {
-            output = model->addOutputData(
-                "Output",
-                DataDesc(DataType::FP16,
-                              DimsOrder::CHW,
-                              {(inputX + padx_begin + padx_end - kernelx) / kernelStrideX + 1,
-                                (inputY + pady_begin + pady_end - kernely) / kernelStrideY + 1, 8}));
-        }
+//         Data output;
+//         if (isOutput4D) {
+//             output = model->addOutputData(
+//                 "Output",
+//                 DataDesc(DataType::FP16,
+//                               DimsOrder::NCHW,
+//                               {(inputX + padx_begin + padx_end - kernelx) / kernelStrideX + 1,
+//                                 (inputY + pady_begin + pady_end - kernely) / kernelStrideY + 1, 8, 1}));
+//         } else {
+//             output = model->addOutputData(
+//                 "Output",
+//                 DataDesc(DataType::FP16,
+//                               DimsOrder::CHW,
+//                               {(inputX + padx_begin + padx_end - kernelx) / kernelStrideX + 1,
+//                                 (inputY + pady_begin + pady_end - kernely) / kernelStrideY + 1, 8}));
+//         }
 
-        auto conv = std::make_shared<ie::ConvolutionLayer>(ie::LayerParams{"conv", "Convolution", ie::Precision::FP16});
-        conv->_kernel_x = kernelx;
-        conv->_kernel_y = kernely;
-        conv->_stride_x = kernelStrideX;
-        conv->_stride_y = kernelStrideY;
-        conv->_dilation_x = dilationX;
-        conv->_dilation_x = dilationY;
+//         auto conv = std::make_shared<ie::ConvolutionLayer>(ie::LayerParams{"conv", "Convolution", ie::Precision::FP16});
+//         conv->_kernel_x = kernelx;
+//         conv->_kernel_y = kernely;
+//         conv->_stride_x = kernelStrideX;
+//         conv->_stride_y = kernelStrideY;
+//         conv->_dilation_x = dilationX;
+//         conv->_dilation_x = dilationY;
 
-        conv->_padding.insert(0, padx_begin);
-        conv->_padding.insert(1, pady_begin);
-        conv->_pads_end.insert(0, padx_end);
-        conv->_pads_end.insert(1, pady_end);
-        conv->_auto_pad = "same_upper";
+//         conv->_padding.insert(0, padx_begin);
+//         conv->_padding.insert(1, pady_begin);
+//         conv->_pads_end.insert(0, padx_end);
+//         conv->_pads_end.insert(1, pady_end);
+//         conv->_auto_pad = "same_upper";
 
-        conv->_weights = ie::make_shared_blob<short>({ ie::Precision::FP16, {static_cast<size_t>(kernelx * kernely * 8 * 8)}, ie::Layout::C });
-        conv->_weights->allocate();
+//         conv->_weights = ie::make_shared_blob<short>({ ie::Precision::FP16, {static_cast<size_t>(kernelx * kernely * 8 * 8)}, ie::Layout::C });
+//         conv->_weights->allocate();
 
-        frontEnd->parseConvolution(model, conv, {input}, {output});
+//         frontEnd->parseConvolution(model, conv, {input}, {output});
 
-        pipeline.addPass(passManager->dumpModel("initial"));
+//         pipeline.addPass(passManager->dumpModel("initial"));
 
-        pipeline.addPass(passManager->hwPadding());
-        pipeline.addPass(passManager->dumpModel("hwPadding"));
+//         pipeline.addPass(passManager->hwPadding());
+//         pipeline.addPass(passManager->dumpModel("hwPadding"));
 
-        // if large kernel conv converted to conv that can be ran on HW, then hwConvTiling will work - if not will got an exception
-        pipeline.addPass(passManager->splitLargeKernelConv());
-        pipeline.addPass(passManager->dumpModel("splitLargeKernelConv"));
+//         // if large kernel conv converted to conv that can be ran on HW, then hwConvTiling will work - if not will got an exception
+//         pipeline.addPass(passManager->splitLargeKernelConv());
+//         pipeline.addPass(passManager->dumpModel("splitLargeKernelConv"));
 
-        pipeline.addPass(passManager->hwConvTiling());
-        pipeline.addPass(passManager->dumpModel("hwConvTiling"));
+//         pipeline.addPass(passManager->hwConvTiling());
+//         pipeline.addPass(passManager->dumpModel("hwConvTiling"));
 
-        pipeline.addPass(passManager->adjustDataLayout());
-        pipeline.addPass(passManager->dumpModel("adjustDataLayout"));
+//         pipeline.addPass(passManager->adjustDataLayout());
+//         pipeline.addPass(passManager->dumpModel("adjustDataLayout"));
 
-        pipeline.addPass(passManager->processSpecialStages());
-        pipeline.addPass(passManager->dumpModel("processSpecialStages"));
+//         pipeline.addPass(passManager->processSpecialStages());
+//         pipeline.addPass(passManager->dumpModel("processSpecialStages"));
 
-        pipeline.addPass(passManager->adjustDataLocation());
-        pipeline.addPass(passManager->dumpModel("adjustDataLocation"));
+//         pipeline.addPass(passManager->adjustDataLocation());
+//         pipeline.addPass(passManager->dumpModel("adjustDataLocation"));
 
-        pipeline.addPass(passManager->finalCheck());
-    }
-};
+//         pipeline.addPass(passManager->finalCheck());
+//     }
+// };
 
-// Test is going to fail if target convolution is not converted to HW stage
-// Conversion to HW stage fails due to #-33366
-TEST_F(VPU_SplitLargeKernelConvTest, DISABLED_splitLargeKernelConvIfKernelSizeIs1x16) {
-    InitCompileEnv();
-    InitConvStage();
+// // Test is going to fail if target convolution is not converted to HW stage
+// // Conversion to HW stage fails due to #-33366
+// TEST_F(VPU_SplitLargeKernelConvTest, DISABLED_splitLargeKernelConvIfKernelSizeIs1x16) {
+//     InitCompileEnv();
+//     InitConvStage();
 
-    ASSERT_NO_THROW(pipeline.run(model));
-}
+//     ASSERT_NO_THROW(pipeline.run(model));
+// }

--- a/inference-engine/tests/unit/vpu/utils_tests/heap_test.cpp
+++ b/inference-engine/tests/unit/vpu/utils_tests/heap_test.cpp
@@ -1,178 +1,178 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
 
-#include <string>
-#include <vector>
-#include <gtest/gtest.h>
-#include <gmock/gmock.h>
+// #include <string>
+// #include <vector>
+// #include <gtest/gtest.h>
+// #include <gmock/gmock.h>
 
-#include "vpu/utils/heap.hpp"
-
-
-template<typename T>
-std::vector<T> MakeHeap(const std::initializer_list<T> &list) {
-    std::vector<T> v;
-    v.reserve(list.size());
-    for (auto i : list) {
-        v.push_back(i);
-        std::push_heap(v.begin(), v.end());
-    }
-    return v;
-}
-
-template<typename T>
-std::vector<T> FixedMaxHeapToVector(const vpu::FixedMaxHeap<T> &FMH) {
-    std::vector<T> v;
-    for (auto i : FMH)
-        v.push_back(i);
-    return v;
-}
-
-TEST(VPU_FixedMaxHeapTest, DefaultConstructor) {
-    ASSERT_NO_THROW(vpu::FixedMaxHeap<int>(10));
-}
-
-TEST(VPU_FixedMaxHeapTest, ConstructorWithInit) {
-    std::initializer_list<int> arr = {3, 4, 1, 2, 5, 9, 5};
-    std::vector<int> ref_v = MakeHeap(arr);
-
-    vpu::FixedMaxHeap<int> heap(arr.size(), arr);
-    std::vector<int> v = FixedMaxHeapToVector(heap);
-
-    ASSERT_THAT(v, testing::ElementsAreArray(ref_v));
-}
+// #include "vpu/utils/heap.hpp"
 
 
-TEST(VPU_FixedMaxHeapTest, CanBeCopied) {
-    std::initializer_list<int> arr = {3, 4, 1, 2, 5, 9, 5};
-    std::vector<int> ref_v = MakeHeap(arr);
+// template<typename T>
+// std::vector<T> MakeHeap(const std::initializer_list<T> &list) {
+//     std::vector<T> v;
+//     v.reserve(list.size());
+//     for (auto i : list) {
+//         v.push_back(i);
+//         std::push_heap(v.begin(), v.end());
+//     }
+//     return v;
+// }
 
-    {
-        vpu::FixedMaxHeap<int> heap(arr.size(), arr);
-        vpu::FixedMaxHeap<int> heap2(heap);
-        std::vector<int> v = FixedMaxHeapToVector(heap2);
+// template<typename T>
+// std::vector<T> FixedMaxHeapToVector(const vpu::FixedMaxHeap<T> &FMH) {
+//     std::vector<T> v;
+//     for (auto i : FMH)
+//         v.push_back(i);
+//     return v;
+// }
 
-        EXPECT_THAT(v, testing::ElementsAreArray(ref_v));
-    }
+// TEST(VPU_FixedMaxHeapTest, DefaultConstructor) {
+//     ASSERT_NO_THROW(vpu::FixedMaxHeap<int>(10));
+// }
 
-    {
-        vpu::FixedMaxHeap<int> heap(arr.size(), arr);
-        vpu::FixedMaxHeap<int> heap2(arr.size());
-        heap2 = heap;
-        std::vector<int> v = FixedMaxHeapToVector(heap2);
+// TEST(VPU_FixedMaxHeapTest, ConstructorWithInit) {
+//     std::initializer_list<int> arr = {3, 4, 1, 2, 5, 9, 5};
+//     std::vector<int> ref_v = MakeHeap(arr);
 
-        EXPECT_THAT(v, testing::ElementsAreArray(ref_v));
-    }
+//     vpu::FixedMaxHeap<int> heap(arr.size(), arr);
+//     std::vector<int> v = FixedMaxHeapToVector(heap);
 
-    // TODO: extend with rvalue copy
-}
+//     ASSERT_THAT(v, testing::ElementsAreArray(ref_v));
+// }
 
 
-TEST(VPU_FixedMaxHeapTest, Front) {
-    {
-        vpu::FixedMaxHeap<int> heap(3, {3, 4, 100});
-        EXPECT_EQ(heap.front(), 100);
-    }
+// TEST(VPU_FixedMaxHeapTest, CanBeCopied) {
+//     std::initializer_list<int> arr = {3, 4, 1, 2, 5, 9, 5};
+//     std::vector<int> ref_v = MakeHeap(arr);
 
-    {
-        vpu::FixedMaxHeap<int> heap(3, {0, -4, -100});
-        EXPECT_EQ(heap.front(), 0);
-    }
-}
+//     {
+//         vpu::FixedMaxHeap<int> heap(arr.size(), arr);
+//         vpu::FixedMaxHeap<int> heap2(heap);
+//         std::vector<int> v = FixedMaxHeapToVector(heap2);
 
-TEST(VPU_FixedMaxHeapTest, Size) {
-    {
-        vpu::FixedMaxHeap<int> heap(0);
-        EXPECT_EQ(heap.size(), 0);
-    }
+//         EXPECT_THAT(v, testing::ElementsAreArray(ref_v));
+//     }
 
-    {
-        vpu::FixedMaxHeap<int> heap(3);
-        EXPECT_EQ(heap.size(), 0);
-    }
+//     {
+//         vpu::FixedMaxHeap<int> heap(arr.size(), arr);
+//         vpu::FixedMaxHeap<int> heap2(arr.size());
+//         heap2 = heap;
+//         std::vector<int> v = FixedMaxHeapToVector(heap2);
 
-    {
-        vpu::FixedMaxHeap<int> heap(3, {3, 4, 100});
-        EXPECT_EQ(heap.size(), 3);
-    }
+//         EXPECT_THAT(v, testing::ElementsAreArray(ref_v));
+//     }
 
-    {
-        vpu::FixedMaxHeap<int> heap(3, {0, -4, -100, 10, 15});
-        EXPECT_EQ(heap.size(), 3);
-    }
-}
+//     // TODO: extend with rvalue copy
+// }
 
-TEST(VPU_FixedMaxHeapTest, Empty) {
-    {
-        vpu::FixedMaxHeap<int> heap(3);
-        EXPECT_TRUE(heap.empty());
-    }
 
-    {
-        vpu::FixedMaxHeap<int> heap(3, {3, 4, 100});
-        EXPECT_FALSE(heap.empty());
-    }
-}
+// TEST(VPU_FixedMaxHeapTest, Front) {
+//     {
+//         vpu::FixedMaxHeap<int> heap(3, {3, 4, 100});
+//         EXPECT_EQ(heap.front(), 100);
+//     }
 
-TEST(VPU_FixedMaxHeapTest, Push) {
-    {
-        std::vector<int> ref_v = MakeHeap({3, 4, 5, 100});
-        vpu::FixedMaxHeap<int> heap(4, {3, 4, 5});
-        heap.push(100);
-        std::vector<int> v = FixedMaxHeapToVector(heap);
-        EXPECT_THAT(v, testing::ElementsAreArray(ref_v));
-    }
+//     {
+//         vpu::FixedMaxHeap<int> heap(3, {0, -4, -100});
+//         EXPECT_EQ(heap.front(), 0);
+//     }
+// }
 
-    {
-        std::vector<int> ref_v = MakeHeap({3, 4, 5});
-        vpu::FixedMaxHeap<int> heap(3, {3, 4, 5});
-        heap.push(100);
-        std::vector<int> v = FixedMaxHeapToVector(heap);
-        EXPECT_THAT(v, testing::ElementsAreArray(ref_v));
-    }
+// TEST(VPU_FixedMaxHeapTest, Size) {
+//     {
+//         vpu::FixedMaxHeap<int> heap(0);
+//         EXPECT_EQ(heap.size(), 0);
+//     }
 
-    {
-        std::vector<int> ref_v = MakeHeap({3, 4, 2});
-        vpu::FixedMaxHeap<int> heap(3, {3, 4, 5});
-        heap.push(2);
-        std::vector<int> v = FixedMaxHeapToVector(heap);
-        EXPECT_THAT(v, testing::ElementsAreArray(ref_v));
-    }
-}
+//     {
+//         vpu::FixedMaxHeap<int> heap(3);
+//         EXPECT_EQ(heap.size(), 0);
+//     }
 
-TEST(VPU_FixedMaxHeapTest, Sorted) {
-    vpu::FixedMaxHeap<int> heap(10, {10, -9, 8, -7, 6, -5, 4, -3, 2, -1});
-    auto s = heap.sorted();
-    ASSERT_FALSE(s.empty());
-    ASSERT_TRUE(std::is_sorted(s.begin(), s.end()));
-}
+//     {
+//         vpu::FixedMaxHeap<int> heap(3, {3, 4, 100});
+//         EXPECT_EQ(heap.size(), 3);
+//     }
 
-TEST(VPU_FixedMaxHeapTest, Print) {
-    std::initializer_list<int> arr = {10, -9, 8, -7, 6, -5, 4, -3, 2, -1};
-    int heap_capacity = arr.size() + 2;
-    vpu::FixedMaxHeap<int> heap(heap_capacity, arr);
+//     {
+//         vpu::FixedMaxHeap<int> heap(3, {0, -4, -100, 10, 15});
+//         EXPECT_EQ(heap.size(), 3);
+//     }
+// }
 
-    std::ostringstream ref_ostr;
-    ref_ostr << "Heap [" << arr.size() << " / " << heap_capacity << "]: ";
-    for (auto i : heap)
-        ref_ostr << i << " ";
-    std::string ref_s = ref_ostr.str();
+// TEST(VPU_FixedMaxHeapTest, Empty) {
+//     {
+//         vpu::FixedMaxHeap<int> heap(3);
+//         EXPECT_TRUE(heap.empty());
+//     }
 
-    std::ostringstream ostr;
-    ostr << heap;
-    std::string s = ostr.str();
-    ASSERT_STREQ(ref_s.c_str(), s.c_str());
-}
+//     {
+//         vpu::FixedMaxHeap<int> heap(3, {3, 4, 100});
+//         EXPECT_FALSE(heap.empty());
+//     }
+// }
 
-TEST(VPU_FixedMaxHeapTest, FixedMaxHeapFloat) {
-    vpu::FixedMaxHeap<float> heap(3, {3., 4., 5.});
+// TEST(VPU_FixedMaxHeapTest, Push) {
+//     {
+//         std::vector<int> ref_v = MakeHeap({3, 4, 5, 100});
+//         vpu::FixedMaxHeap<int> heap(4, {3, 4, 5});
+//         heap.push(100);
+//         std::vector<int> v = FixedMaxHeapToVector(heap);
+//         EXPECT_THAT(v, testing::ElementsAreArray(ref_v));
+//     }
 
-    for (auto i : heap)
-        EXPECT_EQ(typeid(i), typeid(float));
+//     {
+//         std::vector<int> ref_v = MakeHeap({3, 4, 5});
+//         vpu::FixedMaxHeap<int> heap(3, {3, 4, 5});
+//         heap.push(100);
+//         std::vector<int> v = FixedMaxHeapToVector(heap);
+//         EXPECT_THAT(v, testing::ElementsAreArray(ref_v));
+//     }
 
-    EXPECT_NO_THROW(heap.push(0.));
+//     {
+//         std::vector<int> ref_v = MakeHeap({3, 4, 2});
+//         vpu::FixedMaxHeap<int> heap(3, {3, 4, 5});
+//         heap.push(2);
+//         std::vector<int> v = FixedMaxHeapToVector(heap);
+//         EXPECT_THAT(v, testing::ElementsAreArray(ref_v));
+//     }
+// }
 
-    for (auto i : heap.sorted())
-        EXPECT_EQ(typeid(i), typeid(float));
-}
+// TEST(VPU_FixedMaxHeapTest, Sorted) {
+//     vpu::FixedMaxHeap<int> heap(10, {10, -9, 8, -7, 6, -5, 4, -3, 2, -1});
+//     auto s = heap.sorted();
+//     ASSERT_FALSE(s.empty());
+//     ASSERT_TRUE(std::is_sorted(s.begin(), s.end()));
+// }
+
+// TEST(VPU_FixedMaxHeapTest, Print) {
+//     std::initializer_list<int> arr = {10, -9, 8, -7, 6, -5, 4, -3, 2, -1};
+//     int heap_capacity = arr.size() + 2;
+//     vpu::FixedMaxHeap<int> heap(heap_capacity, arr);
+
+//     std::ostringstream ref_ostr;
+//     ref_ostr << "Heap [" << arr.size() << " / " << heap_capacity << "]: ";
+//     for (auto i : heap)
+//         ref_ostr << i << " ";
+//     std::string ref_s = ref_ostr.str();
+
+//     std::ostringstream ostr;
+//     ostr << heap;
+//     std::string s = ostr.str();
+//     ASSERT_STREQ(ref_s.c_str(), s.c_str());
+// }
+
+// TEST(VPU_FixedMaxHeapTest, FixedMaxHeapFloat) {
+//     vpu::FixedMaxHeap<float> heap(3, {3., 4., 5.});
+
+//     for (auto i : heap)
+//         EXPECT_EQ(typeid(i), typeid(float));
+
+//     EXPECT_NO_THROW(heap.push(0.));
+
+//     for (auto i : heap.sorted())
+//         EXPECT_EQ(typeid(i), typeid(float));
+// }

--- a/inference-engine/tests_deprecated/unit/engines/vpu/adjust_data_batch_tests.cpp
+++ b/inference-engine/tests_deprecated/unit/engines/vpu/adjust_data_batch_tests.cpp
@@ -1,348 +1,348 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
-
-#include <vpu/middleend/allocator/allocator.hpp>
-#include <vpu/stages/mx_stage.hpp>
-#include <vpu/utils/numeric.hpp>
-
-#include "graph_transformer_tests.hpp"
-
-using namespace vpu;
-
-class VPU_AdjustDataBatchTest : public GraphTransformerTest {
-public:
-    int batchSize;
-
-    TestModel testModel;
-
-    void SetUp() override {
-        ASSERT_NO_FATAL_FAILURE(GraphTransformerTest::SetUp());
-
-        ASSERT_NO_FATAL_FAILURE(InitCompileEnv());
-
-        batchSize = 4;
-
-        DataDesc dataDesc(DataType::FP16, DimsOrder::NCHW, {16, 16, 3, batchSize});
-        testModel = CreateTestModel(dataDesc);
-    }
-
-    void RunPass() {
-        PassSet pipeline;
-        pipeline.addPass(passManager->dumpModel("initial"));
-        pipeline.addPass(passManager->adjustDataBatch());
-        pipeline.addPass(passManager->dumpModel("adjustDataBatch"));
-        pipeline.run(testModel.getBaseModel());
-    }
-
-    DataVector checkSingleLoopStart(const Data& data) {
-        EXPECT_EQ(data->desc().dim(Dim::N), batchSize);
-        EXPECT_EQ(data->numConsumers(), 2);
-
-        DataVector outputs;
-        for (const auto& consumer : data->consumers()) {
-            EXPECT_TRUE(consumer->type() == StageType::LoopStart || consumer->type() == StageType::LoopEnd);
-            if (consumer->type() == StageType::LoopStart) {
-                for (const auto& output : consumer->outputs()) {
-                    EXPECT_EQ(output->desc().dim(Dim::N), 1);
-                    outputs.push_back(output);
-                }
-            }
-        }
-
-        return outputs;
-    }
-
-    DataVector checkBranches(const Data& root, const std::vector<StageType>& consumersTypes) {
-        auto successors = DataVector{};
-
-        const auto& consumers = root->consumers() | asVector();
-        EXPECT_EQ(consumers.size(), consumersTypes.size());
-        for (std::size_t i = 0; i < consumers.size(); ++i) {
-            const auto& consumer = consumers[i];
-            const auto& expected = consumersTypes[i];
-            EXPECT_EQ(consumer->type(), expected);
-
-            EXPECT_EQ(consumer->numOutputs(), 1);
-            const auto& output = consumer->output(0);
-            successors.push_back(output);
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
+
+// #include <vpu/middleend/allocator/allocator.hpp>
+// #include <vpu/stages/mx_stage.hpp>
+// #include <vpu/utils/numeric.hpp>
+
+// #include "graph_transformer_tests.hpp"
+
+// using namespace vpu;
+
+// class VPU_AdjustDataBatchTest : public GraphTransformerTest {
+// public:
+//     int batchSize;
+
+//     TestModel testModel;
+
+//     void SetUp() override {
+//         ASSERT_NO_FATAL_FAILURE(GraphTransformerTest::SetUp());
+
+//         ASSERT_NO_FATAL_FAILURE(InitCompileEnv());
+
+//         batchSize = 4;
+
+//         DataDesc dataDesc(DataType::FP16, DimsOrder::NCHW, {16, 16, 3, batchSize});
+//         testModel = CreateTestModel(dataDesc);
+//     }
+
+//     void RunPass() {
+//         PassSet pipeline;
+//         pipeline.addPass(passManager->dumpModel("initial"));
+//         pipeline.addPass(passManager->adjustDataBatch());
+//         pipeline.addPass(passManager->dumpModel("adjustDataBatch"));
+//         pipeline.run(testModel.getBaseModel());
+//     }
+
+//     DataVector checkSingleLoopStart(const Data& data) {
+//         EXPECT_EQ(data->desc().dim(Dim::N), batchSize);
+//         EXPECT_EQ(data->numConsumers(), 2);
+
+//         DataVector outputs;
+//         for (const auto& consumer : data->consumers()) {
+//             EXPECT_TRUE(consumer->type() == StageType::LoopStart || consumer->type() == StageType::LoopEnd);
+//             if (consumer->type() == StageType::LoopStart) {
+//                 for (const auto& output : consumer->outputs()) {
+//                     EXPECT_EQ(output->desc().dim(Dim::N), 1);
+//                     outputs.push_back(output);
+//                 }
+//             }
+//         }
+
+//         return outputs;
+//     }
+
+//     DataVector checkBranches(const Data& root, const std::vector<StageType>& consumersTypes) {
+//         auto successors = DataVector{};
+
+//         const auto& consumers = root->consumers() | asVector();
+//         EXPECT_EQ(consumers.size(), consumersTypes.size());
+//         for (std::size_t i = 0; i < consumers.size(); ++i) {
+//             const auto& consumer = consumers[i];
+//             const auto& expected = consumersTypes[i];
+//             EXPECT_EQ(consumer->type(), expected);
+
+//             EXPECT_EQ(consumer->numOutputs(), 1);
+//             const auto& output = consumer->output(0);
+//             successors.push_back(output);
 
-            if (expected == StageType::LoopStart) {
-                EXPECT_EQ(consumer->numOutputs(), 1);
-                EXPECT_EQ(output->desc().dim(Dim::N), 1);
-            } else if (expected == StageType::LoopEnd) {
-                EXPECT_EQ(output->desc().dim(Dim::N), batchSize);
-            }
-        }
+//             if (expected == StageType::LoopStart) {
+//                 EXPECT_EQ(consumer->numOutputs(), 1);
+//                 EXPECT_EQ(output->desc().dim(Dim::N), 1);
+//             } else if (expected == StageType::LoopEnd) {
+//                 EXPECT_EQ(output->desc().dim(Dim::N), batchSize);
+//             }
+//         }
 
-        return successors;
-    }
+//         return successors;
+//     }
 
-    DataVector checkSingleLoopEnd(const Data& data) {
-        EXPECT_EQ(data->numConsumers(), 1);
-
-        const auto& consumer = data->singleConsumer();
-        EXPECT_EQ(consumer->type(), StageType::LoopEnd);
-        DataVector outputs;
-        for (const auto& output : consumer->outputs()) {
-            EXPECT_EQ(output->desc().dim(Dim::N), batchSize);
-            outputs.push_back(output);
-        }
-
-        return outputs;
-    }
-
-    static Data CheckSingleConnection(const Data& data, int testInd, int batch = 1) {
-        EXPECT_EQ(data->numConsumers(), 1);
-
-        const auto& consumer = data->singleConsumer();
-        EXPECT_EQ(consumer->type(), StageType::None);
-        EXPECT_EQ(consumer->attrs().get<int>("test_ind"), testInd);
-        EXPECT_TRUE(consumer->numOutputs() == 1);
-        const auto& output = consumer->output(0);
-        EXPECT_EQ(output->desc().dim(Dim::N), batch);
-        return output;
-    }
+//     DataVector checkSingleLoopEnd(const Data& data) {
+//         EXPECT_EQ(data->numConsumers(), 1);
+
+//         const auto& consumer = data->singleConsumer();
+//         EXPECT_EQ(consumer->type(), StageType::LoopEnd);
+//         DataVector outputs;
+//         for (const auto& output : consumer->outputs()) {
+//             EXPECT_EQ(output->desc().dim(Dim::N), batchSize);
+//             outputs.push_back(output);
+//         }
+
+//         return outputs;
+//     }
+
+//     static Data CheckSingleConnection(const Data& data, int testInd, int batch = 1) {
+//         EXPECT_EQ(data->numConsumers(), 1);
+
+//         const auto& consumer = data->singleConsumer();
+//         EXPECT_EQ(consumer->type(), StageType::None);
+//         EXPECT_EQ(consumer->attrs().get<int>("test_ind"), testInd);
+//         EXPECT_TRUE(consumer->numOutputs() == 1);
+//         const auto& output = consumer->output(0);
+//         EXPECT_EQ(output->desc().dim(Dim::N), batch);
+//         return output;
+//     }
 
-    static Data singleElement(const DataVector& dataObjects) {
-        EXPECT_EQ(dataObjects.size(), 1);
-        return dataObjects.front();
-    }
-};
+//     static Data singleElement(const DataVector& dataObjects) {
+//         EXPECT_EQ(dataObjects.size(), 1);
+//         return dataObjects.front();
+//     }
+// };
 
 
-TEST_F(VPU_AdjustDataBatchTest, Case1_LinearSplit) {
-    //
-    // [Input] -> (Split) -> (Split) -> (Split) -> [Output]
-    //
+// TEST_F(VPU_AdjustDataBatchTest, Case1_LinearSplit) {
+//     //
+//     // [Input] -> (Split) -> (Split) -> (Split) -> [Output]
+//     //
 
-    testModel.createInputs(1);
-    testModel.createOutputs(1);
+//     testModel.createInputs(1);
+//     testModel.createOutputs(1);
 
-    testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate()});
-    testModel.setStageBatchInfo(0, {{0, BatchSupport::Split}});
+//     testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate()});
+//     testModel.setStageBatchInfo(0, {{0, BatchSupport::Split}});
 
-    testModel.addStage({InputInfo::fromPrevStage(0)}, {OutputInfo::intermediate()});
-    testModel.setStageBatchInfo(1, {{0, BatchSupport::Split}});
+//     testModel.addStage({InputInfo::fromPrevStage(0)}, {OutputInfo::intermediate()});
+//     testModel.setStageBatchInfo(1, {{0, BatchSupport::Split}});
 
-    testModel.addStage({InputInfo::fromPrevStage(1)}, {OutputInfo::fromNetwork()});
-    testModel.setStageBatchInfo(2, {{0, BatchSupport::Split}});
+//     testModel.addStage({InputInfo::fromPrevStage(1)}, {OutputInfo::fromNetwork()});
+//     testModel.setStageBatchInfo(2, {{0, BatchSupport::Split}});
 
-    RunPass();
+//     RunPass();
 
-    const auto& data0 = singleElement(checkSingleLoopStart(testModel.getInputs().at(0)));
-    const auto& data1 = CheckSingleConnection(data0, 0);
-    const auto& data2 = CheckSingleConnection(data1, 1);
-    const auto& data3 = CheckSingleConnection(data2, 2);
-    const auto& data4 = checkSingleLoopEnd(data3);
-    ASSERT_EQ(data4, testModel.getOutputs());
-}
+//     const auto& data0 = singleElement(checkSingleLoopStart(testModel.getInputs().at(0)));
+//     const auto& data1 = CheckSingleConnection(data0, 0);
+//     const auto& data2 = CheckSingleConnection(data1, 1);
+//     const auto& data3 = CheckSingleConnection(data2, 2);
+//     const auto& data4 = checkSingleLoopEnd(data3);
+//     ASSERT_EQ(data4, testModel.getOutputs());
+// }
 
-TEST_F(VPU_AdjustDataBatchTest, Case2_LinearWithBatchedInMiddle) {
-    //
-    // [Input] -> (Split) -> (Split) -> (Split) -> (Batched) -> (Split) -> (Split) -> (Split) -> [Output]
-    //
+// TEST_F(VPU_AdjustDataBatchTest, Case2_LinearWithBatchedInMiddle) {
+//     //
+//     // [Input] -> (Split) -> (Split) -> (Split) -> (Batched) -> (Split) -> (Split) -> (Split) -> [Output]
+//     //
 
-    testModel.createInputs(1);
-    testModel.createOutputs(1);
+//     testModel.createInputs(1);
+//     testModel.createOutputs(1);
 
-    testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate()});
-    testModel.setStageBatchInfo(0, {{0, BatchSupport::Split}});
+//     testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate()});
+//     testModel.setStageBatchInfo(0, {{0, BatchSupport::Split}});
 
-    testModel.addStage({InputInfo::fromPrevStage(0)}, {OutputInfo::intermediate()});
-    testModel.setStageBatchInfo(1, {{0, BatchSupport::Split}});
+//     testModel.addStage({InputInfo::fromPrevStage(0)}, {OutputInfo::intermediate()});
+//     testModel.setStageBatchInfo(1, {{0, BatchSupport::Split}});
 
-    testModel.addStage({InputInfo::fromPrevStage(1)}, {OutputInfo::intermediate()});
-    testModel.setStageBatchInfo(2, {{0, BatchSupport::Split}});
+//     testModel.addStage({InputInfo::fromPrevStage(1)}, {OutputInfo::intermediate()});
+//     testModel.setStageBatchInfo(2, {{0, BatchSupport::Split}});
 
-    testModel.addStage({InputInfo::fromPrevStage(2)}, {OutputInfo::intermediate()});
+//     testModel.addStage({InputInfo::fromPrevStage(2)}, {OutputInfo::intermediate()});
 
-    testModel.addStage({InputInfo::fromPrevStage(3)}, {OutputInfo::intermediate()});
-    testModel.setStageBatchInfo(4, {{0, BatchSupport::Split}});
+//     testModel.addStage({InputInfo::fromPrevStage(3)}, {OutputInfo::intermediate()});
+//     testModel.setStageBatchInfo(4, {{0, BatchSupport::Split}});
 
-    testModel.addStage({InputInfo::fromPrevStage(4)}, {OutputInfo::intermediate()});
-    testModel.setStageBatchInfo(5, {{0, BatchSupport::Split}});
+//     testModel.addStage({InputInfo::fromPrevStage(4)}, {OutputInfo::intermediate()});
+//     testModel.setStageBatchInfo(5, {{0, BatchSupport::Split}});
 
-    testModel.addStage({InputInfo::fromPrevStage(5)}, {OutputInfo::fromNetwork()});
-    testModel.setStageBatchInfo(6, {{0, BatchSupport::Split}});
+//     testModel.addStage({InputInfo::fromPrevStage(5)}, {OutputInfo::fromNetwork()});
+//     testModel.setStageBatchInfo(6, {{0, BatchSupport::Split}});
 
-    RunPass();
+//     RunPass();
 
-    const auto& data0 = singleElement(checkSingleLoopStart(testModel.getInputs().at(0)));
-    const auto& data1 = CheckSingleConnection(data0, 0);
-    const auto& data2 = CheckSingleConnection(data1, 1);
-    const auto& data3 = CheckSingleConnection(data2, 2);
-    const auto& data4 = singleElement(checkSingleLoopEnd(data3));
+//     const auto& data0 = singleElement(checkSingleLoopStart(testModel.getInputs().at(0)));
+//     const auto& data1 = CheckSingleConnection(data0, 0);
+//     const auto& data2 = CheckSingleConnection(data1, 1);
+//     const auto& data3 = CheckSingleConnection(data2, 2);
+//     const auto& data4 = singleElement(checkSingleLoopEnd(data3));
 
-    const auto& data5 = CheckSingleConnection(data4, 3, batchSize);
+//     const auto& data5 = CheckSingleConnection(data4, 3, batchSize);
 
-    const auto& data6 = singleElement(checkSingleLoopStart(data5));
-    const auto& data7 = CheckSingleConnection(data6, 4);
-    const auto& data8 = CheckSingleConnection(data7, 5);
-    const auto& data9 = CheckSingleConnection(data8, 6);
-    const auto& data10 = checkSingleLoopEnd(data9);
+//     const auto& data6 = singleElement(checkSingleLoopStart(data5));
+//     const auto& data7 = CheckSingleConnection(data6, 4);
+//     const auto& data8 = CheckSingleConnection(data7, 5);
+//     const auto& data9 = CheckSingleConnection(data8, 6);
+//     const auto& data10 = checkSingleLoopEnd(data9);
 
-    ASSERT_EQ(data10, testModel.getOutputs());
-}
+//     ASSERT_EQ(data10, testModel.getOutputs());
+// }
 
-TEST_F(VPU_AdjustDataBatchTest, Case3_SubGraphsWithSinglePlainInput) {
-    //
-    //         -> (Batched) -> (Batched) -> (Batched) -> [Output]
-    // [Input]
-    //         -> (Split) - > (Split) -> (Split) -> [Output]
-    //
-
-    testModel.createInputs(1);
-    testModel.createOutputs(2);
+// TEST_F(VPU_AdjustDataBatchTest, Case3_SubGraphsWithSinglePlainInput) {
+//     //
+//     //         -> (Batched) -> (Batched) -> (Batched) -> [Output]
+//     // [Input]
+//     //         -> (Split) - > (Split) -> (Split) -> [Output]
+//     //
+
+//     testModel.createInputs(1);
+//     testModel.createOutputs(2);
 
-    testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate()});
-    testModel.addStage({InputInfo::fromPrevStage(0)}, {OutputInfo::intermediate()});
-    testModel.addStage({InputInfo::fromPrevStage(1)}, {OutputInfo::fromNetwork(0)});
+//     testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate()});
+//     testModel.addStage({InputInfo::fromPrevStage(0)}, {OutputInfo::intermediate()});
+//     testModel.addStage({InputInfo::fromPrevStage(1)}, {OutputInfo::fromNetwork(0)});
 
-    testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate()});
-    testModel.setStageBatchInfo(3, {{0, BatchSupport::Split}});
+//     testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate()});
+//     testModel.setStageBatchInfo(3, {{0, BatchSupport::Split}});
 
-    testModel.addStage({InputInfo::fromPrevStage(3)}, {OutputInfo::intermediate()});
-    testModel.setStageBatchInfo(4, {{0, BatchSupport::Split}});
+//     testModel.addStage({InputInfo::fromPrevStage(3)}, {OutputInfo::intermediate()});
+//     testModel.setStageBatchInfo(4, {{0, BatchSupport::Split}});
 
-    testModel.addStage({InputInfo::fromPrevStage(4)}, {OutputInfo::fromNetwork(1)});
-    testModel.setStageBatchInfo(5, {{0, BatchSupport::Split}});
+//     testModel.addStage({InputInfo::fromPrevStage(4)}, {OutputInfo::fromNetwork(1)});
+//     testModel.setStageBatchInfo(5, {{0, BatchSupport::Split}});
 
-    RunPass();
+//     RunPass();
 
-    const auto& branches = checkBranches(testModel.getInputs().at(0), {StageType::None, StageType::LoopStart, StageType::LoopEnd});
-    const auto& withBatch = branches[0];
-    const auto& withLoop = branches[1];
-    ASSERT_EQ(branches[2], testModel.getOutputs().at(1));
+//     const auto& branches = checkBranches(testModel.getInputs().at(0), {StageType::None, StageType::LoopStart, StageType::LoopEnd});
+//     const auto& withBatch = branches[0];
+//     const auto& withLoop = branches[1];
+//     ASSERT_EQ(branches[2], testModel.getOutputs().at(1));
 
-    ASSERT_EQ(withBatch->producer()->attrs().get<int>("test_ind"), 0);
-    ASSERT_EQ(withBatch->desc().dim(Dim::N), batchSize);
-    const auto& withBatch0 = CheckSingleConnection(withBatch,  1, batchSize);
-    const auto& withBatch1 = CheckSingleConnection(withBatch0, 2, batchSize);
-    ASSERT_EQ(withBatch1, testModel.getOutputs().at(0));
+//     ASSERT_EQ(withBatch->producer()->attrs().get<int>("test_ind"), 0);
+//     ASSERT_EQ(withBatch->desc().dim(Dim::N), batchSize);
+//     const auto& withBatch0 = CheckSingleConnection(withBatch,  1, batchSize);
+//     const auto& withBatch1 = CheckSingleConnection(withBatch0, 2, batchSize);
+//     ASSERT_EQ(withBatch1, testModel.getOutputs().at(0));
 
-    const auto& withLoop0 = CheckSingleConnection(withLoop,  3);
-    const auto& withLoop1 = CheckSingleConnection(withLoop0, 4);
-    const auto& withLoop2 = CheckSingleConnection(withLoop1, 5);
-    const auto& withLoop3 = singleElement(checkSingleLoopEnd(withLoop2));
-    ASSERT_EQ(withLoop3, testModel.getOutputs().at(1));
-}
+//     const auto& withLoop0 = CheckSingleConnection(withLoop,  3);
+//     const auto& withLoop1 = CheckSingleConnection(withLoop0, 4);
+//     const auto& withLoop2 = CheckSingleConnection(withLoop1, 5);
+//     const auto& withLoop3 = singleElement(checkSingleLoopEnd(withLoop2));
+//     ASSERT_EQ(withLoop3, testModel.getOutputs().at(1));
+// }
 
-TEST_F(VPU_AdjustDataBatchTest, Case4_SubGraphsWithSingleSplitInput) {
-    //
-    //                                          -> (Batched) -> (Batched) -> (Batched) -> [Output]
-    // [Input] -> (Split) -> (Split) -> (Split)
-    //                                          -> (Split) -> (Split) -> (Split) -> [Output]
-    //
+// TEST_F(VPU_AdjustDataBatchTest, Case4_SubGraphsWithSingleSplitInput) {
+//     //
+//     //                                          -> (Batched) -> (Batched) -> (Batched) -> [Output]
+//     // [Input] -> (Split) -> (Split) -> (Split)
+//     //                                          -> (Split) -> (Split) -> (Split) -> [Output]
+//     //
 
-    testModel.createInputs(1);
-    testModel.createOutputs(2);
+//     testModel.createInputs(1);
+//     testModel.createOutputs(2);
 
-    testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate()});
-    testModel.setStageBatchInfo(0, {{0, BatchSupport::Split}});
+//     testModel.addStage({InputInfo::fromNetwork()}, {OutputInfo::intermediate()});
+//     testModel.setStageBatchInfo(0, {{0, BatchSupport::Split}});
 
-    testModel.addStage({InputInfo::fromPrevStage(0)}, {OutputInfo::intermediate()});
-    testModel.setStageBatchInfo(1, {{0, BatchSupport::Split}});
+//     testModel.addStage({InputInfo::fromPrevStage(0)}, {OutputInfo::intermediate()});
+//     testModel.setStageBatchInfo(1, {{0, BatchSupport::Split}});
 
-    testModel.addStage({InputInfo::fromPrevStage(1)}, {OutputInfo::intermediate()});
-    testModel.setStageBatchInfo(2, {{0, BatchSupport::Split}});
+//     testModel.addStage({InputInfo::fromPrevStage(1)}, {OutputInfo::intermediate()});
+//     testModel.setStageBatchInfo(2, {{0, BatchSupport::Split}});
 
-    testModel.addStage({InputInfo::fromPrevStage(2)}, {OutputInfo::intermediate()});
-    testModel.addStage({InputInfo::fromPrevStage(3)}, {OutputInfo::intermediate()});
-    testModel.addStage({InputInfo::fromPrevStage(4)}, {OutputInfo::fromNetwork(0)});
+//     testModel.addStage({InputInfo::fromPrevStage(2)}, {OutputInfo::intermediate()});
+//     testModel.addStage({InputInfo::fromPrevStage(3)}, {OutputInfo::intermediate()});
+//     testModel.addStage({InputInfo::fromPrevStage(4)}, {OutputInfo::fromNetwork(0)});
 
-    testModel.addStage({InputInfo::fromPrevStage(2)}, {OutputInfo::intermediate()});
-    testModel.setStageBatchInfo(6, {{0, BatchSupport::Split}});
+//     testModel.addStage({InputInfo::fromPrevStage(2)}, {OutputInfo::intermediate()});
+//     testModel.setStageBatchInfo(6, {{0, BatchSupport::Split}});
 
-    testModel.addStage({InputInfo::fromPrevStage(6)}, {OutputInfo::intermediate()});
-    testModel.setStageBatchInfo(7, {{0, BatchSupport::Split}});
+//     testModel.addStage({InputInfo::fromPrevStage(6)}, {OutputInfo::intermediate()});
+//     testModel.setStageBatchInfo(7, {{0, BatchSupport::Split}});
 
-    testModel.addStage({InputInfo::fromPrevStage(7)}, {OutputInfo::fromNetwork(1)});
-    testModel.setStageBatchInfo(8, {{0, BatchSupport::Split}});
+//     testModel.addStage({InputInfo::fromPrevStage(7)}, {OutputInfo::fromNetwork(1)});
+//     testModel.setStageBatchInfo(8, {{0, BatchSupport::Split}});
 
-    RunPass();
+//     RunPass();
 
-    const auto& data0 = singleElement(checkSingleLoopStart(testModel.getInputs().at(0)));
-    const auto& data1 = CheckSingleConnection(data0, 0);
-    const auto& data2 = CheckSingleConnection(data1, 1);
-    const auto& data3 = CheckSingleConnection(data2, 2);
-    const auto& data4 = singleElement(checkSingleLoopEnd(data3));
+//     const auto& data0 = singleElement(checkSingleLoopStart(testModel.getInputs().at(0)));
+//     const auto& data1 = CheckSingleConnection(data0, 0);
+//     const auto& data2 = CheckSingleConnection(data1, 1);
+//     const auto& data3 = CheckSingleConnection(data2, 2);
+//     const auto& data4 = singleElement(checkSingleLoopEnd(data3));
 
-    const auto& branches = checkBranches(data4, {StageType::None, StageType::LoopStart, StageType::LoopEnd});
-    const auto& withBatch = branches[0];
-    const auto& withLoop = branches[1];
-    ASSERT_EQ(branches[2], testModel.getOutputs().at(1));
+//     const auto& branches = checkBranches(data4, {StageType::None, StageType::LoopStart, StageType::LoopEnd});
+//     const auto& withBatch = branches[0];
+//     const auto& withLoop = branches[1];
+//     ASSERT_EQ(branches[2], testModel.getOutputs().at(1));
 
-    ASSERT_EQ(withBatch->producer()->attrs().get<int>("test_ind"), 3);
-    ASSERT_EQ(withBatch->desc().dim(Dim::N), batchSize);
-    const auto& withBatch0 = CheckSingleConnection(withBatch,  4, batchSize);
-    const auto& withBatch1 = CheckSingleConnection(withBatch0, 5, batchSize);
-    ASSERT_EQ(withBatch1, testModel.getOutputs().at(0));
+//     ASSERT_EQ(withBatch->producer()->attrs().get<int>("test_ind"), 3);
+//     ASSERT_EQ(withBatch->desc().dim(Dim::N), batchSize);
+//     const auto& withBatch0 = CheckSingleConnection(withBatch,  4, batchSize);
+//     const auto& withBatch1 = CheckSingleConnection(withBatch0, 5, batchSize);
+//     ASSERT_EQ(withBatch1, testModel.getOutputs().at(0));
 
-    const auto& withLoop0 = CheckSingleConnection(withLoop,  6);
-    const auto& withLoop1 = CheckSingleConnection(withLoop0, 7);
-    const auto& withLoop2 = CheckSingleConnection(withLoop1, 8);
-    const auto& withLoop3 = singleElement(checkSingleLoopEnd(withLoop2));
-    ASSERT_EQ(withLoop3, testModel.getOutputs().at(1));
-}
+//     const auto& withLoop0 = CheckSingleConnection(withLoop,  6);
+//     const auto& withLoop1 = CheckSingleConnection(withLoop0, 7);
+//     const auto& withLoop2 = CheckSingleConnection(withLoop1, 8);
+//     const auto& withLoop3 = singleElement(checkSingleLoopEnd(withLoop2));
+//     ASSERT_EQ(withLoop3, testModel.getOutputs().at(1));
+// }
 
-TEST_F(VPU_AdjustDataBatchTest, Case5_MergeSubGraphs) {
-    //
-    // [Input] -> (Batched) -> (Batched) -> (Batched) ->
-    //                                                   (Split) -> (Split) -> (Split) -> [Output]
-    // [Input] -> (Split) -> (Split) -> (Split)       ->
-    //
+// TEST_F(VPU_AdjustDataBatchTest, Case5_MergeSubGraphs) {
+//     //
+//     // [Input] -> (Batched) -> (Batched) -> (Batched) ->
+//     //                                                   (Split) -> (Split) -> (Split) -> [Output]
+//     // [Input] -> (Split) -> (Split) -> (Split)       ->
+//     //
 
-    testModel.createInputs(2);
-    testModel.createOutputs(1);
+//     testModel.createInputs(2);
+//     testModel.createOutputs(1);
 
-    testModel.addStage({InputInfo::fromNetwork(0)}, {OutputInfo::intermediate()});
-    testModel.addStage({InputInfo::fromPrevStage(0)}, {OutputInfo::intermediate()});
-    testModel.addStage({InputInfo::fromPrevStage(1)}, {OutputInfo::intermediate()});
+//     testModel.addStage({InputInfo::fromNetwork(0)}, {OutputInfo::intermediate()});
+//     testModel.addStage({InputInfo::fromPrevStage(0)}, {OutputInfo::intermediate()});
+//     testModel.addStage({InputInfo::fromPrevStage(1)}, {OutputInfo::intermediate()});
 
-    testModel.addStage({InputInfo::fromNetwork(1)}, {OutputInfo::intermediate()});
-    testModel.setStageBatchInfo(3, {{0, BatchSupport::Split}});
+//     testModel.addStage({InputInfo::fromNetwork(1)}, {OutputInfo::intermediate()});
+//     testModel.setStageBatchInfo(3, {{0, BatchSupport::Split}});
 
-    testModel.addStage({InputInfo::fromPrevStage(3)}, {OutputInfo::intermediate()});
-    testModel.setStageBatchInfo(4, {{0, BatchSupport::Split}});
+//     testModel.addStage({InputInfo::fromPrevStage(3)}, {OutputInfo::intermediate()});
+//     testModel.setStageBatchInfo(4, {{0, BatchSupport::Split}});
 
-    testModel.addStage({InputInfo::fromPrevStage(4)}, {OutputInfo::intermediate()});
-    testModel.setStageBatchInfo(5, {{0, BatchSupport::Split}});
+//     testModel.addStage({InputInfo::fromPrevStage(4)}, {OutputInfo::intermediate()});
+//     testModel.setStageBatchInfo(5, {{0, BatchSupport::Split}});
 
-    testModel.addStage({InputInfo::fromPrevStage(2), InputInfo::fromPrevStage(5)}, {OutputInfo::intermediate()});
-    testModel.setStageBatchInfo(6, {{0, BatchSupport::Split}, {1, BatchSupport::Split}});
+//     testModel.addStage({InputInfo::fromPrevStage(2), InputInfo::fromPrevStage(5)}, {OutputInfo::intermediate()});
+//     testModel.setStageBatchInfo(6, {{0, BatchSupport::Split}, {1, BatchSupport::Split}});
 
-    testModel.addStage({InputInfo::fromPrevStage(6)}, {OutputInfo::intermediate()});
-    testModel.setStageBatchInfo(7, {{0, BatchSupport::Split}});
+//     testModel.addStage({InputInfo::fromPrevStage(6)}, {OutputInfo::intermediate()});
+//     testModel.setStageBatchInfo(7, {{0, BatchSupport::Split}});
 
-    testModel.addStage({InputInfo::fromPrevStage(7)}, {OutputInfo::fromNetwork()});
-    testModel.setStageBatchInfo(8, {{0, BatchSupport::Split}});
+//     testModel.addStage({InputInfo::fromPrevStage(7)}, {OutputInfo::fromNetwork()});
+//     testModel.setStageBatchInfo(8, {{0, BatchSupport::Split}});
 
-    RunPass();
+//     RunPass();
 
-    const auto& data0 = CheckSingleConnection(testModel.getInputs().at(0), 0, batchSize);
-    const auto& data1 = CheckSingleConnection(data0, 1, batchSize);
-    const auto& data2 = CheckSingleConnection(data1, 2, batchSize);
-    const auto& loopStartOutputs0 = checkSingleLoopStart(data2);
+//     const auto& data0 = CheckSingleConnection(testModel.getInputs().at(0), 0, batchSize);
+//     const auto& data1 = CheckSingleConnection(data0, 1, batchSize);
+//     const auto& data2 = CheckSingleConnection(data1, 2, batchSize);
+//     const auto& loopStartOutputs0 = checkSingleLoopStart(data2);
 
-    const auto& data3 = singleElement(checkSingleLoopStart(testModel.getInputs().at(1)));
-    const auto& data4 = CheckSingleConnection(data3, 3);
-    const auto& data5 = CheckSingleConnection(data4, 4);
-    const auto& data6 = CheckSingleConnection(data5, 5);
-    const auto& data7 = singleElement(checkSingleLoopEnd(data6));
-    const auto& loopStartOutputs1 = checkSingleLoopStart(data7);
+//     const auto& data3 = singleElement(checkSingleLoopStart(testModel.getInputs().at(1)));
+//     const auto& data4 = CheckSingleConnection(data3, 3);
+//     const auto& data5 = CheckSingleConnection(data4, 4);
+//     const auto& data6 = CheckSingleConnection(data5, 5);
+//     const auto& data7 = singleElement(checkSingleLoopEnd(data6));
+//     const auto& loopStartOutputs1 = checkSingleLoopStart(data7);
 
-    ASSERT_EQ(loopStartOutputs0, loopStartOutputs1);
-    ASSERT_EQ(loopStartOutputs0.size(), 2);
-    const auto& data8 = loopStartOutputs0.front();
-    const auto& data9 = loopStartOutputs0.back();
+//     ASSERT_EQ(loopStartOutputs0, loopStartOutputs1);
+//     ASSERT_EQ(loopStartOutputs0.size(), 2);
+//     const auto& data8 = loopStartOutputs0.front();
+//     const auto& data9 = loopStartOutputs0.back();
 
-    const auto& data10 = CheckSingleConnection(data8, 6);
-    const auto& data11 = CheckSingleConnection(data9, 6);
-    ASSERT_EQ(data10, data11);
+//     const auto& data10 = CheckSingleConnection(data8, 6);
+//     const auto& data11 = CheckSingleConnection(data9, 6);
+//     ASSERT_EQ(data10, data11);
 
-    const auto& data12 = CheckSingleConnection(data10, 7);
-    const auto& data13 = CheckSingleConnection(data12, 8);
-    const auto& data14 = singleElement(checkSingleLoopEnd(data13));
-    ASSERT_EQ(data14, testModel.getOutputs().at(0));
-}
+//     const auto& data12 = CheckSingleConnection(data10, 7);
+//     const auto& data13 = CheckSingleConnection(data12, 8);
+//     const auto& data14 = singleElement(checkSingleLoopEnd(data13));
+//     ASSERT_EQ(data14, testModel.getOutputs().at(0));
+// }

--- a/inference-engine/tests_deprecated/unit/engines/vpu/adjust_data_location_tests.cpp
+++ b/inference-engine/tests_deprecated/unit/engines/vpu/adjust_data_location_tests.cpp
@@ -1,167 +1,167 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
 
-#include <vpu/middleend/allocator/allocator.hpp>
-#include <vpu/stages/mx_stage.hpp>
-#include <vpu/middleend/hw/utility.hpp>
-#include <vpu/utils/numeric.hpp>
+// #include <vpu/middleend/allocator/allocator.hpp>
+// #include <vpu/stages/mx_stage.hpp>
+// #include <vpu/middleend/hw/utility.hpp>
+// #include <vpu/utils/numeric.hpp>
 
-#include "graph_transformer_tests.hpp"
+// #include "graph_transformer_tests.hpp"
 
-using namespace vpu;
+// using namespace vpu;
 
-using VPU_AdjustDataLocationTest = GraphTransformerTest;
+// using VPU_AdjustDataLocationTest = GraphTransformerTest;
 
-//                                            -> [Data 2] -> (4/SW) -> [Output 1]
-//                               -> (2/Split)
-//                                            -> [Data 3] -> (5/SW) -> [Output 2]
-// [Input] -> (1/HW) -> [Data 1]
-//                                            -> [Data 4] -> (6/SW) -> [Output 3]
-//                               -> (3/Split)
-//                                            -> [Data 5] -> (7/SW) -> [Output 4]
-//
-// In order to allocate SHAVEs for SW Stages we need to move [Data 1] to DDR and redirect its consumers.
-//
+// //                                            -> [Data 2] -> (4/SW) -> [Output 1]
+// //                               -> (2/Split)
+// //                                            -> [Data 3] -> (5/SW) -> [Output 2]
+// // [Input] -> (1/HW) -> [Data 1]
+// //                                            -> [Data 4] -> (6/SW) -> [Output 3]
+// //                               -> (3/Split)
+// //                                            -> [Data 5] -> (7/SW) -> [Output 4]
+// //
+// // In order to allocate SHAVEs for SW Stages we need to move [Data 1] to DDR and redirect its consumers.
+// //
 
-TEST_F(VPU_AdjustDataLocationTest, FlushCMX_TwoSpecialConsumers) {
-    config.compileConfig().numSHAVEs = 1;
-    config.compileConfig().numCMXSlices = 1;
-    InitCompileEnv();
+// TEST_F(VPU_AdjustDataLocationTest, FlushCMX_TwoSpecialConsumers) {
+//     config.compileConfig().numSHAVEs = 1;
+//     config.compileConfig().numCMXSlices = 1;
+//     InitCompileEnv();
 
-    DataDesc dataDesc1(DataType::FP16, DimsOrder::NCHW, {CMX_SLICE_SIZE / (2 * 2), 1, 2, 1});
-    DataDesc dataDesc2(DataType::FP16, DimsOrder::NCHW, {CMX_SLICE_SIZE / (2 * 2), 1, 1, 1});
+//     DataDesc dataDesc1(DataType::FP16, DimsOrder::NCHW, {CMX_SLICE_SIZE / (2 * 2), 1, 2, 1});
+//     DataDesc dataDesc2(DataType::FP16, DimsOrder::NCHW, {CMX_SLICE_SIZE / (2 * 2), 1, 1, 1});
 
-    auto model = CreateModel();
+//     auto model = CreateModel();
 
-    auto input = model->addInputData("Input", dataDesc1);
-    model->attrs().set<int>("numInputs", 1);
+//     auto input = model->addInputData("Input", dataDesc1);
+//     model->attrs().set<int>("numInputs", 1);
 
-    auto output1 = model->addOutputData("Output 1", dataDesc2);
-    auto output2 = model->addOutputData("Output 2", dataDesc2);
-    auto output3 = model->addOutputData("Output 3", dataDesc2);
-    auto output4 = model->addOutputData("Output 4", dataDesc2);
-    model->attrs().set<int>("numOutputs", 4);
+//     auto output1 = model->addOutputData("Output 1", dataDesc2);
+//     auto output2 = model->addOutputData("Output 2", dataDesc2);
+//     auto output3 = model->addOutputData("Output 3", dataDesc2);
+//     auto output4 = model->addOutputData("Output 4", dataDesc2);
+//     model->attrs().set<int>("numOutputs", 4);
 
-    auto data1 = model->addNewData("Data 1", dataDesc1);
-    auto data2 = model->addNewData("Data 2", dataDesc2);
-    auto data3 = model->addNewData("Data 3", dataDesc2);
-    auto data4 = model->addNewData("Data 4", dataDesc2);
-    auto data5 = model->addNewData("Data 5", dataDesc2);
+//     auto data1 = model->addNewData("Data 1", dataDesc1);
+//     auto data2 = model->addNewData("Data 2", dataDesc2);
+//     auto data3 = model->addNewData("Data 3", dataDesc2);
+//     auto data4 = model->addNewData("Data 4", dataDesc2);
+//     auto data5 = model->addNewData("Data 5", dataDesc2);
 
-    auto fake = model->addFakeData();
+//     auto fake = model->addFakeData();
 
-    auto hwStage = model->addNewStage<MyriadXHwStage>(
-        "1/HW",
-        StageType::MyriadXHwOp,
-        nullptr,
-        {input, fake, fake, fake},
-        {data1});
-    hwStage->attrs().set<HwOpType>("hwOpType", HwOpType::POOL);
+//     auto hwStage = model->addNewStage<MyriadXHwStage>(
+//         "1/HW",
+//         StageType::MyriadXHwOp,
+//         nullptr,
+//         {input, fake, fake, fake},
+//         {data1});
+//     hwStage->attrs().set<HwOpType>("hwOpType", HwOpType::POOL);
 
-    stageBuilder->addSplitStage(model, "2/Split", nullptr, Dim::C, data1, {data2, data3});
-    stageBuilder->addSplitStage(model, "3/Split", nullptr, Dim::C, data1, {data4, data5});
+//     stageBuilder->addSplitStage(model, "2/Split", nullptr, Dim::C, data1, {data2, data3});
+//     stageBuilder->addSplitStage(model, "3/Split", nullptr, Dim::C, data1, {data4, data5});
 
-    stageBuilder->addSoftMaxStage(model, "4/SW", nullptr, data2, output1, Dim::W);
-    stageBuilder->addSoftMaxStage(model, "5/SW", nullptr, data3, output2, Dim::W);
-    stageBuilder->addSoftMaxStage(model, "6/SW", nullptr, data4, output3, Dim::W);
-    stageBuilder->addSoftMaxStage(model, "7/SW", nullptr, data5, output4, Dim::W);
+//     stageBuilder->addSoftMaxStage(model, "4/SW", nullptr, data2, output1, Dim::W);
+//     stageBuilder->addSoftMaxStage(model, "5/SW", nullptr, data3, output2, Dim::W);
+//     stageBuilder->addSoftMaxStage(model, "6/SW", nullptr, data4, output3, Dim::W);
+//     stageBuilder->addSoftMaxStage(model, "7/SW", nullptr, data5, output4, Dim::W);
 
-    PassSet pipeline;
-    pipeline.addPass(passManager->dumpModel("initial"));
-    pipeline.addPass(passManager->adjustDataLayout());
-    pipeline.addPass(passManager->dumpModel("adjustDataLayout"));
-    pipeline.addPass(passManager->processSpecialStages());
-    pipeline.addPass(passManager->dumpModel("processSpecialStages"));
-    pipeline.addPass(passManager->adjustDataLocation());
-    pipeline.addPass(passManager->dumpModel("adjustDataLocation"));
-    pipeline.addPass(passManager->finalCheck());
+//     PassSet pipeline;
+//     pipeline.addPass(passManager->dumpModel("initial"));
+//     pipeline.addPass(passManager->adjustDataLayout());
+//     pipeline.addPass(passManager->dumpModel("adjustDataLayout"));
+//     pipeline.addPass(passManager->processSpecialStages());
+//     pipeline.addPass(passManager->dumpModel("processSpecialStages"));
+//     pipeline.addPass(passManager->adjustDataLocation());
+//     pipeline.addPass(passManager->dumpModel("adjustDataLocation"));
+//     pipeline.addPass(passManager->finalCheck());
 
-    pipeline.run(model);
+//     pipeline.run(model);
 
-    ASSERT_EQ(data1->dataLocation().location, Location::CMX);
-    ASSERT_EQ(data1->numConsumers(), 1);
+//     ASSERT_EQ(data1->dataLocation().location, Location::CMX);
+//     ASSERT_EQ(data1->numConsumers(), 1);
 
-    auto data1Consumer = data1->singleConsumer();
-    auto data1ConsumerOutput = data1Consumer->output(0);
-    ASSERT_EQ(data1Consumer->type(), StageType::Copy);
-    ASSERT_EQ(data1ConsumerOutput->dataLocation().location, Location::BSS);
-    ASSERT_EQ(data1ConsumerOutput->numChildDatas(), 4);
-    ASSERT_TRUE(contains(data1ConsumerOutput->childDataToDataEdges(), [data2](const DataToDataAllocation& e) { return e->child() == data2; }));
-    ASSERT_TRUE(contains(data1ConsumerOutput->childDataToDataEdges(), [data3](const DataToDataAllocation& e) { return e->child() == data3; }));
-    ASSERT_TRUE(contains(data1ConsumerOutput->childDataToDataEdges(), [data4](const DataToDataAllocation& e) { return e->child() == data4; }));
-    ASSERT_TRUE(contains(data1ConsumerOutput->childDataToDataEdges(), [data5](const DataToDataAllocation& e) { return e->child() == data5; }));
-}
+//     auto data1Consumer = data1->singleConsumer();
+//     auto data1ConsumerOutput = data1Consumer->output(0);
+//     ASSERT_EQ(data1Consumer->type(), StageType::Copy);
+//     ASSERT_EQ(data1ConsumerOutput->dataLocation().location, Location::BSS);
+//     ASSERT_EQ(data1ConsumerOutput->numChildDatas(), 4);
+//     ASSERT_TRUE(contains(data1ConsumerOutput->childDataToDataEdges(), [data2](const DataToDataAllocation& e) { return e->child() == data2; }));
+//     ASSERT_TRUE(contains(data1ConsumerOutput->childDataToDataEdges(), [data3](const DataToDataAllocation& e) { return e->child() == data3; }));
+//     ASSERT_TRUE(contains(data1ConsumerOutput->childDataToDataEdges(), [data4](const DataToDataAllocation& e) { return e->child() == data4; }));
+//     ASSERT_TRUE(contains(data1ConsumerOutput->childDataToDataEdges(), [data5](const DataToDataAllocation& e) { return e->child() == data5; }));
+// }
 
-//
-//                               -> (HW 2) -> [Data 2] ->
-// [Input] -> (HW 1) -> [Data 1]                          (Sum) -> [Output]
-//                                                     ->
-//
+// //
+// //                               -> (HW 2) -> [Data 2] ->
+// // [Input] -> (HW 1) -> [Data 1]                          (Sum) -> [Output]
+// //                                                     ->
+// //
 
-TEST_F(VPU_AdjustDataLocationTest, SpillWithBranch) {
-    InitCompileEnv();
+// TEST_F(VPU_AdjustDataLocationTest, SpillWithBranch) {
+//     InitCompileEnv();
 
-    const auto& env = CompileEnv::get();
+//     const auto& env = CompileEnv::get();
 
-    const auto maxCmxSizeBytes = env.resources.numCMXSlices * CMX_SLICE_SIZE;
-    const auto maxCmxSizeElems = maxCmxSizeBytes / sizeof(fp16_t);
-    const auto testSizeElems = alignVal<int>((2 * maxCmxSizeElems) / 3, HW_STRIDE_ALIGNMENT / sizeof(fp16_t));
+//     const auto maxCmxSizeBytes = env.resources.numCMXSlices * CMX_SLICE_SIZE;
+//     const auto maxCmxSizeElems = maxCmxSizeBytes / sizeof(fp16_t);
+//     const auto testSizeElems = alignVal<int>((2 * maxCmxSizeElems) / 3, HW_STRIDE_ALIGNMENT / sizeof(fp16_t));
 
-    DataDesc dataDesc(DataType::FP16, DimsOrder::NCHW, {testSizeElems, 1, 1, 1});
+//     DataDesc dataDesc(DataType::FP16, DimsOrder::NCHW, {testSizeElems, 1, 1, 1});
 
-    auto model = CreateModel();
+//     auto model = CreateModel();
 
-    auto input = model->addInputData("Input", dataDesc);
-    model->attrs().set<int>("numInputs", 1);
+//     auto input = model->addInputData("Input", dataDesc);
+//     model->attrs().set<int>("numInputs", 1);
 
-    auto output = model->addOutputData("Output", dataDesc);
-    model->attrs().set<int>("numOutputs", 1);
+//     auto output = model->addOutputData("Output", dataDesc);
+//     model->attrs().set<int>("numOutputs", 1);
 
-    auto data1 = model->addNewData("Data 1", dataDesc);
-    auto data2 = model->addNewData("Data 2", dataDesc);
+//     auto data1 = model->addNewData("Data 1", dataDesc);
+//     auto data2 = model->addNewData("Data 2", dataDesc);
 
-    auto fake = model->addFakeData();
+//     auto fake = model->addFakeData();
 
-    auto hw1 = model->addNewStage<MyriadXHwStage>(
-        "HW 1",
-        StageType::MyriadXHwOp,
-        nullptr,
-        {input, fake, fake, fake},
-        {data1});
-    hw1->attrs().set<HwOpType>("hwOpType", HwOpType::POOL);
+//     auto hw1 = model->addNewStage<MyriadXHwStage>(
+//         "HW 1",
+//         StageType::MyriadXHwOp,
+//         nullptr,
+//         {input, fake, fake, fake},
+//         {data1});
+//     hw1->attrs().set<HwOpType>("hwOpType", HwOpType::POOL);
 
-    // Create Sum first, so it will be the first consumer of "Data 1"
-    auto sum = stageBuilder->addSumStage(model, "Sum", nullptr, data1, data2, output);
+//     // Create Sum first, so it will be the first consumer of "Data 1"
+//     auto sum = stageBuilder->addSumStage(model, "Sum", nullptr, data1, data2, output);
 
-    auto hw2 = model->addNewStage<MyriadXHwStage>(
-        "HW 2",
-        StageType::MyriadXHwOp,
-        nullptr,
-        {data1, fake, fake, fake},
-        {data2});
-    hw2->attrs().set<HwOpType>("hwOpType", HwOpType::POOL);
+//     auto hw2 = model->addNewStage<MyriadXHwStage>(
+//         "HW 2",
+//         StageType::MyriadXHwOp,
+//         nullptr,
+//         {data1, fake, fake, fake},
+//         {data2});
+//     hw2->attrs().set<HwOpType>("hwOpType", HwOpType::POOL);
 
-    PassSet pipeline;
-    pipeline.addPass(passManager->dumpModel("initial"), "dump");
-    pipeline.addPass(passManager->adjustDataLayout(), "adjustDataLayout");
-    pipeline.addPass(passManager->dumpModel("adjustDataLayout"), "dump");
-    pipeline.addPass(passManager->adjustDataLocation(), "adjustDataLocation");
-    pipeline.addPass(passManager->dumpModel("adjustDataLocation"), "dump");
+//     PassSet pipeline;
+//     pipeline.addPass(passManager->dumpModel("initial"), "dump");
+//     pipeline.addPass(passManager->adjustDataLayout(), "adjustDataLayout");
+//     pipeline.addPass(passManager->dumpModel("adjustDataLayout"), "dump");
+//     pipeline.addPass(passManager->adjustDataLocation(), "adjustDataLocation");
+//     pipeline.addPass(passManager->dumpModel("adjustDataLocation"), "dump");
 
-    pipeline.run(model);
+//     pipeline.run(model);
 
-    auto hw1Output = hw1->output(0);
-    ASSERT_EQ(hw1Output->dataLocation().location, Location::CMX);
+//     auto hw1Output = hw1->output(0);
+//     ASSERT_EQ(hw1Output->dataLocation().location, Location::CMX);
 
-    auto copyStage = hw1Output->singleConsumer();
-    ASSERT_EQ(copyStage->type(), StageType::Copy);
+//     auto copyStage = hw1Output->singleConsumer();
+//     ASSERT_EQ(copyStage->type(), StageType::Copy);
 
-    auto copyStageOutput = copyStage->output(0);
-    ASSERT_EQ(copyStageOutput->dataLocation().location, Location::BSS);
+//     auto copyStageOutput = copyStage->output(0);
+//     ASSERT_EQ(copyStageOutput->dataLocation().location, Location::BSS);
 
-    ASSERT_EQ(copyStageOutput->numConsumers(), 2);
-    for (const auto& copyStageOutputConsumer : copyStageOutput->consumers()) {
-        ASSERT_TRUE(copyStageOutputConsumer == hw2 || copyStageOutputConsumer == sum);
-    }
-}
+//     ASSERT_EQ(copyStageOutput->numConsumers(), 2);
+//     for (const auto& copyStageOutputConsumer : copyStageOutput->consumers()) {
+//         ASSERT_TRUE(copyStageOutputConsumer == hw2 || copyStageOutputConsumer == sum);
+//     }
+// }

--- a/inference-engine/tests_deprecated/unit/engines/vpu/eliminate_const_concat_tests.cpp
+++ b/inference-engine/tests_deprecated/unit/engines/vpu/eliminate_const_concat_tests.cpp
@@ -1,126 +1,126 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
 
-#include "graph_transformer_tests.hpp"
-#include <vpu/model/data_contents/replicated_data_content.hpp>
+// #include "graph_transformer_tests.hpp"
+// #include <vpu/model/data_contents/replicated_data_content.hpp>
 
-#include <precision_utils.h>
+// #include <precision_utils.h>
 
-using namespace vpu;
+// using namespace vpu;
 
-using VPU_EliminateConstConcatTest = GraphTransformerTest;
+// using VPU_EliminateConstConcatTest = GraphTransformerTest;
 
-TEST_F(VPU_EliminateConstConcatTest, EliminateCase_1D) {
-    InitCompileEnv();
+// TEST_F(VPU_EliminateConstConcatTest, EliminateCase_1D) {
+//     InitCompileEnv();
 
-    const DataDesc dataDesc1(DataType::FP16, DimsOrder::C, {8});
-    const DataDesc dataDesc2(DataType::FP16, DimsOrder::C, {4});
+//     const DataDesc dataDesc1(DataType::FP16, DimsOrder::C, {8});
+//     const DataDesc dataDesc2(DataType::FP16, DimsOrder::C, {4});
 
-    const DataDesc dataDescConcat(DataType::FP16, DimsOrder::C, {dataDesc1.dim(Dim::C) + dataDesc2.dim(Dim::C)});
+//     const DataDesc dataDescConcat(DataType::FP16, DimsOrder::C, {dataDesc1.dim(Dim::C) + dataDesc2.dim(Dim::C)});
 
-    const auto model = CreateModel();
+//     const auto model = CreateModel();
 
-    const auto constData1 = model->addConstData("const1", dataDesc1, replicateContent(1.0f, dataDesc1.totalDimSize(), dataDesc1));
-    const auto constData2 = model->addConstData("const2", dataDesc2, replicateContent(2.0f, dataDesc2.totalDimSize(), dataDesc2));
+//     const auto constData1 = model->addConstData("const1", dataDesc1, replicateContent(1.0f, dataDesc1.totalDimSize(), dataDesc1));
+//     const auto constData2 = model->addConstData("const2", dataDesc2, replicateContent(2.0f, dataDesc2.totalDimSize(), dataDesc2));
 
-    const auto concatData = model->addNewData("concat", dataDescConcat);
+//     const auto concatData = model->addNewData("concat", dataDescConcat);
 
-    const auto input = model->addInputData("input", dataDescConcat);
-    const auto output = model->addOutputData("output", dataDescConcat);
+//     const auto input = model->addInputData("input", dataDescConcat);
+//     const auto output = model->addOutputData("output", dataDescConcat);
 
-    model->attrs().set<int>("numInputs", 1);
-    model->attrs().set<int>("numOutputs", 1);
+//     model->attrs().set<int>("numInputs", 1);
+//     model->attrs().set<int>("numOutputs", 1);
 
-    stageBuilder->addConcatStage(model, "concat", nullptr, Dim::C, {constData1, constData2}, concatData);
-    stageBuilder->addNoneStage(model, "none", nullptr, {input, concatData}, {output});
+//     stageBuilder->addConcatStage(model, "concat", nullptr, Dim::C, {constData1, constData2}, concatData);
+//     stageBuilder->addNoneStage(model, "none", nullptr, {input, concatData}, {output});
 
-    PassSet pipeline;
-    pipeline.addPass(passManager->dumpModel("initial"));
-    pipeline.addPass(passManager->eliminateConstConcat());
-    pipeline.addPass(passManager->dumpModel("eliminateConstConcat"));
+//     PassSet pipeline;
+//     pipeline.addPass(passManager->dumpModel("initial"));
+//     pipeline.addPass(passManager->eliminateConstConcat());
+//     pipeline.addPass(passManager->dumpModel("eliminateConstConcat"));
 
-    pipeline.run(model);
+//     pipeline.run(model);
 
-    ASSERT_EQ(model->numStages(), 1);
+//     ASSERT_EQ(model->numStages(), 1);
 
-    const auto noneStage = model->getStages().front();
-    ASSERT_EQ(noneStage->type(), StageType::None);
+//     const auto noneStage = model->getStages().front();
+//     ASSERT_EQ(noneStage->type(), StageType::None);
 
-    ASSERT_EQ(noneStage->numInputs(), 2);
-    ASSERT_EQ(noneStage->input(0), input);
+//     ASSERT_EQ(noneStage->numInputs(), 2);
+//     ASSERT_EQ(noneStage->input(0), input);
 
-    const auto mergedConcatData = noneStage->input(1);
-    ASSERT_EQ(mergedConcatData->usage(), DataUsage::Const);
-    ASSERT_EQ(mergedConcatData->desc().dimsOrder(), dataDescConcat.dimsOrder());
-    ASSERT_EQ(mergedConcatData->desc().dims(), dataDescConcat.dims());
+//     const auto mergedConcatData = noneStage->input(1);
+//     ASSERT_EQ(mergedConcatData->usage(), DataUsage::Const);
+//     ASSERT_EQ(mergedConcatData->desc().dimsOrder(), dataDescConcat.dimsOrder());
+//     ASSERT_EQ(mergedConcatData->desc().dims(), dataDescConcat.dims());
 
-    const auto mergedContent = mergedConcatData->content();
-    const auto mergedContentPtr = mergedContent->get<fp16_t>();
+//     const auto mergedContent = mergedConcatData->content();
+//     const auto mergedContentPtr = mergedContent->get<fp16_t>();
 
-    for (int ind = 0; ind < dataDesc1.dim(Dim::C); ++ind) {
-        ASSERT_EQ(mergedContentPtr[ind], ie::PrecisionUtils::f32tof16(1.0f)) << ind;
-    }
-    for (int ind = 0; ind < dataDesc2.dim(Dim::C); ++ind) {
-        ASSERT_EQ(mergedContentPtr[ind + dataDesc1.dim(Dim::C)], ie::PrecisionUtils::f32tof16(2.0f)) << ind;
-    }
-}
+//     for (int ind = 0; ind < dataDesc1.dim(Dim::C); ++ind) {
+//         ASSERT_EQ(mergedContentPtr[ind], ie::PrecisionUtils::f32tof16(1.0f)) << ind;
+//     }
+//     for (int ind = 0; ind < dataDesc2.dim(Dim::C); ++ind) {
+//         ASSERT_EQ(mergedContentPtr[ind + dataDesc1.dim(Dim::C)], ie::PrecisionUtils::f32tof16(2.0f)) << ind;
+//     }
+// }
 
-TEST_F(VPU_EliminateConstConcatTest, EliminateCase_2D) {
-    InitCompileEnv();
+// TEST_F(VPU_EliminateConstConcatTest, EliminateCase_2D) {
+//     InitCompileEnv();
 
-    const DataDesc dataDesc1(DataType::FP16, DimsOrder::NC, {4, 4});
-    const DataDesc dataDesc2(DataType::FP16, DimsOrder::NC, {2, 4});
+//     const DataDesc dataDesc1(DataType::FP16, DimsOrder::NC, {4, 4});
+//     const DataDesc dataDesc2(DataType::FP16, DimsOrder::NC, {2, 4});
 
-    const DataDesc dataDescConcat(DataType::FP16, DimsOrder::NC, {dataDesc1.dim(Dim::C) + dataDesc2.dim(Dim::C), dataDesc1.dim(Dim::N)});
+//     const DataDesc dataDescConcat(DataType::FP16, DimsOrder::NC, {dataDesc1.dim(Dim::C) + dataDesc2.dim(Dim::C), dataDesc1.dim(Dim::N)});
 
-    const auto model = CreateModel();
+//     const auto model = CreateModel();
 
-    const auto constData1 = model->addConstData("const1", dataDesc1, replicateContent(1.0f, dataDesc1.totalDimSize(), dataDesc1));
-    const auto constData2 = model->addConstData("const2", dataDesc2, replicateContent(2.0f, dataDesc2.totalDimSize(), dataDesc2));
+//     const auto constData1 = model->addConstData("const1", dataDesc1, replicateContent(1.0f, dataDesc1.totalDimSize(), dataDesc1));
+//     const auto constData2 = model->addConstData("const2", dataDesc2, replicateContent(2.0f, dataDesc2.totalDimSize(), dataDesc2));
 
-    const auto concatData = model->addNewData("concat", dataDescConcat);
+//     const auto concatData = model->addNewData("concat", dataDescConcat);
 
-    const auto input = model->addInputData("input", dataDescConcat);
-    const auto output = model->addOutputData("output", dataDescConcat);
+//     const auto input = model->addInputData("input", dataDescConcat);
+//     const auto output = model->addOutputData("output", dataDescConcat);
 
-    model->attrs().set<int>("numInputs", 1);
-    model->attrs().set<int>("numOutputs", 1);
+//     model->attrs().set<int>("numInputs", 1);
+//     model->attrs().set<int>("numOutputs", 1);
 
-    stageBuilder->addConcatStage(model, "concat", nullptr, Dim::C, {constData1, constData2}, concatData);
-    stageBuilder->addNoneStage(model, "none", nullptr, {input, concatData}, {output});
+//     stageBuilder->addConcatStage(model, "concat", nullptr, Dim::C, {constData1, constData2}, concatData);
+//     stageBuilder->addNoneStage(model, "none", nullptr, {input, concatData}, {output});
 
-    PassSet pipeline;
-    pipeline.addPass(passManager->dumpModel("initial"));
-    pipeline.addPass(passManager->eliminateConstConcat());
-    pipeline.addPass(passManager->dumpModel("eliminateConstConcat"));
+//     PassSet pipeline;
+//     pipeline.addPass(passManager->dumpModel("initial"));
+//     pipeline.addPass(passManager->eliminateConstConcat());
+//     pipeline.addPass(passManager->dumpModel("eliminateConstConcat"));
 
-    pipeline.run(model);
+//     pipeline.run(model);
 
-    ASSERT_EQ(model->numStages(), 1);
+//     ASSERT_EQ(model->numStages(), 1);
 
-    const auto noneStage = model->getStages().front();
-    ASSERT_EQ(noneStage->type(), StageType::None);
+//     const auto noneStage = model->getStages().front();
+//     ASSERT_EQ(noneStage->type(), StageType::None);
 
-    ASSERT_EQ(noneStage->numInputs(), 2);
-    ASSERT_EQ(noneStage->input(0), input);
+//     ASSERT_EQ(noneStage->numInputs(), 2);
+//     ASSERT_EQ(noneStage->input(0), input);
 
-    const auto mergedConcatData = noneStage->input(1);
-    ASSERT_EQ(mergedConcatData->usage(), DataUsage::Const);
-    ASSERT_EQ(mergedConcatData->desc().dimsOrder(), dataDescConcat.dimsOrder());
-    ASSERT_EQ(mergedConcatData->desc().dims(), dataDescConcat.dims());
+//     const auto mergedConcatData = noneStage->input(1);
+//     ASSERT_EQ(mergedConcatData->usage(), DataUsage::Const);
+//     ASSERT_EQ(mergedConcatData->desc().dimsOrder(), dataDescConcat.dimsOrder());
+//     ASSERT_EQ(mergedConcatData->desc().dims(), dataDescConcat.dims());
 
-    const auto mergedContent = mergedConcatData->content();
-    const auto mergedContentPtr = mergedContent->get<fp16_t>();
+//     const auto mergedContent = mergedConcatData->content();
+//     const auto mergedContentPtr = mergedContent->get<fp16_t>();
 
-    for (int indN = 0; indN < dataDescConcat.dim(Dim::N); ++indN) {
-        for (int indC = 0; indC < dataDesc1.dim(Dim::C); ++indC) {
-            const auto mergedContentInd = mergedConcatData->elemOffset(DimValues{{Dim::C, indC}, {Dim::N, indN}}) / sizeof(fp16_t);
-            ASSERT_EQ(mergedContentPtr[mergedContentInd], ie::PrecisionUtils::f32tof16(1.0f)) << indC;
-        }
-        for (int indC = 0; indC < dataDesc2.dim(Dim::C); ++indC) {
-            const auto mergedContentInd = mergedConcatData->elemOffset(DimValues{{Dim::C, dataDesc1.dim(Dim::C) + indC}, {Dim::N, indN}}) / sizeof(fp16_t);
-            ASSERT_EQ(mergedContentPtr[mergedContentInd], ie::PrecisionUtils::f32tof16(2.0f)) << indC;
-        }
-    }
-}
+//     for (int indN = 0; indN < dataDescConcat.dim(Dim::N); ++indN) {
+//         for (int indC = 0; indC < dataDesc1.dim(Dim::C); ++indC) {
+//             const auto mergedContentInd = mergedConcatData->elemOffset(DimValues{{Dim::C, indC}, {Dim::N, indN}}) / sizeof(fp16_t);
+//             ASSERT_EQ(mergedContentPtr[mergedContentInd], ie::PrecisionUtils::f32tof16(1.0f)) << indC;
+//         }
+//         for (int indC = 0; indC < dataDesc2.dim(Dim::C); ++indC) {
+//             const auto mergedContentInd = mergedConcatData->elemOffset(DimValues{{Dim::C, dataDesc1.dim(Dim::C) + indC}, {Dim::N, indN}}) / sizeof(fp16_t);
+//             ASSERT_EQ(mergedContentPtr[mergedContentInd], ie::PrecisionUtils::f32tof16(2.0f)) << indC;
+//         }
+//     }
+// }

--- a/inference-engine/tests_deprecated/unit/engines/vpu/eliminate_copy_tests.cpp
+++ b/inference-engine/tests_deprecated/unit/engines/vpu/eliminate_copy_tests.cpp
@@ -1,94 +1,94 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
 
-#include <vpu/stages/mx_stage.hpp>
-#include <vpu/middleend/hw/utility.hpp>
+// #include <vpu/stages/mx_stage.hpp>
+// #include <vpu/middleend/hw/utility.hpp>
 
-#include "graph_transformer_tests.hpp"
+// #include "graph_transformer_tests.hpp"
 
-using namespace vpu;
+// using namespace vpu;
 
-using VPU_EliminateCopyTest = GraphTransformerTest;
+// using VPU_EliminateCopyTest = GraphTransformerTest;
 
-TEST_F(VPU_EliminateCopyTest, OneInputTwoConcats) {
-    InitCompileEnv();
+// TEST_F(VPU_EliminateCopyTest, OneInputTwoConcats) {
+//     InitCompileEnv();
 
-    auto model = CreateModel();
+//     auto model = CreateModel();
 
-    auto input = model->addInputData(
-        "Input",
-        DataDesc(DataType::FP16, DimsOrder::NCHW, {16, 16, 3, 1}));
-    model->attrs().set<int>("numInputs", 1);
+//     auto input = model->addInputData(
+//         "Input",
+//         DataDesc(DataType::FP16, DimsOrder::NCHW, {16, 16, 3, 1}));
+//     model->attrs().set<int>("numInputs", 1);
 
-    auto output1 = model->addOutputData(
-        "Output1",
-        DataDesc(DataType::FP16, DimsOrder::NCHW, {16, 16, 4, 1}));
-    auto output2 = model->addOutputData(
-        "Output2",
-        DataDesc(DataType::FP16, DimsOrder::NCHW, {16, 16, 4, 1}));
-    model->attrs().set<int>("numOutputs", 2);
+//     auto output1 = model->addOutputData(
+//         "Output1",
+//         DataDesc(DataType::FP16, DimsOrder::NCHW, {16, 16, 4, 1}));
+//     auto output2 = model->addOutputData(
+//         "Output2",
+//         DataDesc(DataType::FP16, DimsOrder::NCHW, {16, 16, 4, 1}));
+//     model->attrs().set<int>("numOutputs", 2);
 
-    auto outputCopy1 = model->duplicateData(output1, "copy");
-    auto outputCopy2 = model->duplicateData(output2, "copy");
-    stageBuilder->addCopyStage(model, outputCopy1->name(), nullptr, outputCopy1, output1, "test1");
-    stageBuilder->addCopyStage(model, outputCopy2->name(), nullptr, outputCopy2, output2, "test2");
+//     auto outputCopy1 = model->duplicateData(output1, "copy");
+//     auto outputCopy2 = model->duplicateData(output2, "copy");
+//     stageBuilder->addCopyStage(model, outputCopy1->name(), nullptr, outputCopy1, output1, "test1");
+//     stageBuilder->addCopyStage(model, outputCopy2->name(), nullptr, outputCopy2, output2, "test2");
 
-    auto data1 = model->addNewData(
-        "data1",
-        DataDesc(DataType::FP16, DimsOrder::NCHW, {16, 16, 3, 1}));
+//     auto data1 = model->addNewData(
+//         "data1",
+//         DataDesc(DataType::FP16, DimsOrder::NCHW, {16, 16, 3, 1}));
 
-    auto fake = model->addFakeData();
+//     auto fake = model->addFakeData();
 
-    auto hwStage = model->addNewStage<MyriadXHwStage>(
-        "HW",
-        StageType::MyriadXHwOp,
-        nullptr,
-        {input, fake, fake, fake},
-        {data1});
-    hwStage->attrs().set<HwOpType>("hwOpType", HwOpType::POOL);
+//     auto hwStage = model->addNewStage<MyriadXHwStage>(
+//         "HW",
+//         StageType::MyriadXHwOp,
+//         nullptr,
+//         {input, fake, fake, fake},
+//         {data1});
+//     hwStage->attrs().set<HwOpType>("hwOpType", HwOpType::POOL);
 
-    auto data2 = model->addNewData(
-        "data2",
-        DataDesc(DataType::FP16, DimsOrder::NCHW, {16, 16, 1, 1}));
-    auto data3 = model->addNewData(
-        "data3",
-        DataDesc(DataType::FP16, DimsOrder::NCHW, {16, 16, 1, 1}));
+//     auto data2 = model->addNewData(
+//         "data2",
+//         DataDesc(DataType::FP16, DimsOrder::NCHW, {16, 16, 1, 1}));
+//     auto data3 = model->addNewData(
+//         "data3",
+//         DataDesc(DataType::FP16, DimsOrder::NCHW, {16, 16, 1, 1}));
 
-    stageBuilder->addConcatStage(
-        model,
-        "Concat1",
-        nullptr,
-        Dim::C,
-        {data1, data2},
-        outputCopy1);
-    stageBuilder->addConcatStage(
-        model,
-        "Concat2",
-        nullptr,
-        Dim::C,
-        {data1, data3},
-        outputCopy2);
+//     stageBuilder->addConcatStage(
+//         model,
+//         "Concat1",
+//         nullptr,
+//         Dim::C,
+//         {data1, data2},
+//         outputCopy1);
+//     stageBuilder->addConcatStage(
+//         model,
+//         "Concat2",
+//         nullptr,
+//         Dim::C,
+//         {data1, data3},
+//         outputCopy2);
 
-    PassSet pipeline;
-    pipeline.addPass(passManager->dumpModel("initial"));
-    pipeline.addPass(passManager->adjustDataLayout());
-    pipeline.addPass(passManager->dumpModel("adjustDataLayout"));
-    pipeline.addPass(passManager->processSpecialStages());
-    pipeline.addPass(passManager->dumpModel("processSpecialStages"));
-    pipeline.addPass(passManager->adjustDataLocation());
-    pipeline.addPass(passManager->dumpModel("adjustDataLocation"));
-    pipeline.addPass(passManager->eliminateCopyStages());
-    pipeline.addPass(passManager->dumpModel("eliminateCopyStages"));
-    pipeline.addPass(passManager->finalCheck());
+//     PassSet pipeline;
+//     pipeline.addPass(passManager->dumpModel("initial"));
+//     pipeline.addPass(passManager->adjustDataLayout());
+//     pipeline.addPass(passManager->dumpModel("adjustDataLayout"));
+//     pipeline.addPass(passManager->processSpecialStages());
+//     pipeline.addPass(passManager->dumpModel("processSpecialStages"));
+//     pipeline.addPass(passManager->adjustDataLocation());
+//     pipeline.addPass(passManager->dumpModel("adjustDataLocation"));
+//     pipeline.addPass(passManager->eliminateCopyStages());
+//     pipeline.addPass(passManager->dumpModel("eliminateCopyStages"));
+//     pipeline.addPass(passManager->finalCheck());
 
-    pipeline.run(model);
+//     pipeline.run(model);
 
-    const auto& hwOutput = hwStage->output(0);
-    ASSERT_NE(hwOutput->parentDataToDataEdge(), nullptr);
-    ASSERT_EQ(hwOutput->parentData(), outputCopy1);
+//     const auto& hwOutput = hwStage->output(0);
+//     ASSERT_NE(hwOutput->parentDataToDataEdge(), nullptr);
+//     ASSERT_EQ(hwOutput->parentData(), outputCopy1);
 
-    ASSERT_EQ(hwOutput->numConsumers(), 2);
-    ASSERT_TRUE(contains(hwOutput->consumers(), [](const Stage& stage) { return stage->type() == StageType::StubConcat; }));
-    ASSERT_TRUE(contains(hwOutput->consumers(), [](const Stage& stage) { return stage->type() == StageType::Copy; }));
-}
+//     ASSERT_EQ(hwOutput->numConsumers(), 2);
+//     ASSERT_TRUE(contains(hwOutput->consumers(), [](const Stage& stage) { return stage->type() == StageType::StubConcat; }));
+//     ASSERT_TRUE(contains(hwOutput->consumers(), [](const Stage& stage) { return stage->type() == StageType::Copy; }));
+// }

--- a/inference-engine/tests_deprecated/unit/engines/vpu/get_vpu_scale_from_ir_tests.cpp
+++ b/inference-engine/tests_deprecated/unit/engines/vpu/get_vpu_scale_from_ir_tests.cpp
@@ -1,128 +1,233 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // // Copyright (C) 2018-2021 Intel Corporation
+// // // SPDX-License-Identifier: Apache-2.0
+// // //
 
-#include "graph_transformer_tests.hpp"
-#include "tests_vpu_common.hpp"
+// // #include "graph_transformer_tests.hpp"
+// // #include "tests_vpu_common.hpp"
 
-#include <cpp/ie_executable_network.hpp>
+// // #include <cpp/ie_executable_network.hpp>
 
-#include <ngraph/type/element_type.hpp>
-#include <ngraph/op/parameter.hpp>
-#include <ngraph/ops.hpp>
-#include <legacy/ngraph_ops/fully_connected.hpp>
-#include <ngraph/op/constant.hpp>
-#include <ngraph/opsets/opset1.hpp>
-#include <limits>
+// // #include <ngraph/type/element_type.hpp>
+// // #include <ngraph/op/parameter.hpp>
+// // #include <ngraph/ops.hpp>
+// // #include <legacy/ngraph_ops/fully_connected.hpp>
+// // #include <ngraph/op/constant.hpp>
+// // #include <ngraph/opsets/opset1.hpp>
+// // #include <limits>
 
-using namespace vpu;
-using namespace InferenceEngine;
+// // using namespace vpu;
+// // using namespace InferenceEngine;
 
-using VPU_AddVpuScaleTest = GraphTransformerTest;
+// // using VPU_AddVpuScaleTest = GraphTransformerTest;
 
-TEST_F(VPU_AddVpuScaleTest, CanAddVpuScaleToNetwork) {
-    InitCompileEnv();
+// // TEST_F(VPU_AddVpuScaleTest, CanAddVpuScaleToNetwork) {
+// //     // InitCompileEnv();
 
-    auto& env = CompileEnv::get();
-    auto config = createConfiguration();
-    config.compileConfig().irWithVpuScalesDir = "/";
-    env.updateConfig(config);
+// //     // auto& env = CompileEnv::get();
+// //     // CompilationConfig config{};
+// //     // config.irWithVpuScalesDir = "/";
+// //     // env.updateConfig(config);
 
-    std::shared_ptr<ngraph::Function> function;
+// //     // std::shared_ptr<ngraph::Function> function;
 
-    {
-        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f16, ngraph::Shape{4, 2, 2});
-        input->set_friendly_name("input");
-        auto weights = ngraph::opset1::Constant::create(ngraph::element::f16, ngraph::Shape{2, 2}, {1});
-        auto bias = ngraph::opset1::Constant::create(ngraph::element::f16, ngraph::Shape{2}, {1});
-        auto fc = std::make_shared<ngraph::op::FullyConnected>(input, weights, bias, ngraph::Shape{4, 2, 2});
-        fc->set_friendly_name("FullyConnected");
-        auto result = std::make_shared<ngraph::op::Result>(fc);
-        ngraph::ResultVector results { result };
-        ngraph::ParameterVector params {input };
-        function = std::make_shared<ngraph::Function>(results, params);
-    }
+// //     // {
+// //     //     auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f16, ngraph::Shape{4, 2, 2});
+// //     //     input->set_friendly_name("input");
+// //     //     auto weights = ngraph::opset1::Constant::create(ngraph::element::f16, ngraph::Shape{2, 2}, {1});
+// //     //     auto bias = ngraph::opset1::Constant::create(ngraph::element::f16, ngraph::Shape{2}, {1});
+// //     //     auto fc = std::make_shared<ngraph::op::FullyConnected>(input, weights, bias, ngraph::Shape{4, 2, 2});
+// //     //     fc->set_friendly_name("FullyConnected");
+// //     //     auto result = std::make_shared<ngraph::op::Result>(fc);
+// //     //     ngraph::ResultVector results { result };
+// //     //     ngraph::ParameterVector params {input };
+// //     //     function = std::make_shared<ngraph::Function>(results, params);
+// //     // }
 
-    auto network = InferenceEngine::CNNNetwork(function);
-    auto model = frontEnd->buildInitialModel(network);
+// //     // auto network = InferenceEngine::CNNNetwork(function);
+// //     // auto model = frontEnd->buildInitialModel(network);
 
-    const auto getFullyConnectedStage = [model]() -> Stage {
-        const auto isFullyConnected = [](const Stage& stage) {
-            const auto& layer = stage->origLayer();
-            return layer && layer->type == "FullyConnected";
-        };
-        const auto stages = model->getStages();
-        const auto stageIt = std::find_if(begin(stages), end(stages), isFullyConnected);
-        return *stageIt;
-    };
+// //     // const auto getFullyConnectedStage = [model]() -> Stage {
+// //     //     const auto isFullyConnected = [](const Stage& stage) {
+// //     //         const auto& layer = stage->origNode();
+// //     //         return layer && layer->type == "FullyConnected";
+// //     //     };
+// //     //     const auto stages = model->getStages();
+// //     //     const auto stageIt = std::find_if(begin(stages), end(stages), isFullyConnected);
+// //     //     return *stageIt;
+// //     // };
 
-    const auto fcStage = getFullyConnectedStage();
-    EXPECT_EQ(fcStage->origLayer()->params.find("vpu_scale"), fcStage->origLayer()->params.end());
+// //     // const auto fcStage = getFullyConnectedStage();
+// //     // // EXPECT_EQ(fcStage->origNode()->params.find("vpu_scale"), fcStage->origNode()->params.end());
 
-    auto middleEnd = passManager->buildMiddleEnd();
-    middleEnd->run(model);
+// //     // auto middleEnd = passManager->buildMiddleEnd();
+// //     // middleEnd->run(model);
 
-    const auto fcStageAfterMiddleEnd = getFullyConnectedStage();
-    EXPECT_NE(fcStageAfterMiddleEnd->origLayer()->params.find("vpu_scale"), fcStageAfterMiddleEnd->origLayer()->params.end());
-}
+// //     // const auto fcStageAfterMiddleEnd = getFullyConnectedStage();
+// //     // EXPECT_NE(fcStageAfterMiddleEnd->origNode()->params.find("vpu_scale"), fcStageAfterMiddleEnd->origNode()->params.end());
+// // }
 
-TEST_F(VPU_AddVpuScaleTest, VpuScaleFromIrChangesWeights) {
-    InitCompileEnv();
-    const auto& env = CompileEnv::get();
-    auto config = createConfiguration();
-    config.compileConfig().irWithVpuScalesDir = "/";
-    env.updateConfig(config);
+// // TEST_F(VPU_AddVpuScaleTest, VpuScaleFromIrChangesWeights) {
+// //     // InitCompileEnv();
+// //     // const auto& env = CompileEnv::get();
+// //     // CompilationConfig config{};
+// //     // config.irWithVpuScalesDir = "/";
+// //     // env.updateConfig(config);
 
-    std::shared_ptr<ngraph::Function> function;
-    {
-        ngraph::element::Type elementType = ngraph::element::Type_t::f16;
-        ngraph::Shape shape { 1, 1, 4, 5 };
-        auto input = std::make_shared<ngraph::op::Parameter>(elementType, shape);
-        input->set_friendly_name("input");
+// //     // std::shared_ptr<ngraph::Function> function;
+// //     // {
+// //     //     ngraph::element::Type elementType = ngraph::element::Type_t::f16;
+// //     //     ngraph::Shape shape { 1, 1, 4, 5 };
+// //     //     auto input = std::make_shared<ngraph::op::Parameter>(elementType, shape);
+// //     //     input->set_friendly_name("input");
 
-        auto weights = std::make_shared<ngraph::op::Constant>(
-                elementType, ngraph::Shape{1, 1, 1, 1}, std::vector<float>(1, 1.0f));
-        auto conv = std::make_shared<ngraph::op::v1::Convolution>(
-                input, weights, ngraph::Strides {1, 1},
-                ngraph::CoordinateDiff{0, 0}, ngraph::CoordinateDiff{0, 0}, ngraph::Strides{1, 1});
-        conv->set_friendly_name("Convolution");
-        auto result = std::make_shared<ngraph::op::Result>(conv);
+// //     //     auto weights = std::make_shared<ngraph::op::Constant>(
+// //     //             elementType, ngraph::Shape{1, 1, 1, 1}, std::vector<float>(1, 1.0f));
+// //     //     auto conv = std::make_shared<ngraph::op::v1::Convolution>(
+// //     //             input, weights, ngraph::Strides {1, 1},
+// //     //             ngraph::CoordinateDiff{0, 0}, ngraph::CoordinateDiff{0, 0}, ngraph::Strides{1, 1});
+// //     //     conv->set_friendly_name("Convolution");
+// //     //     auto result = std::make_shared<ngraph::op::Result>(conv);
 
-        ngraph::ResultVector results { result };
-        ngraph::ParameterVector params { input };
-        function = std::make_shared<ngraph::Function>(results, params);
-    }
+// //     //     ngraph::ResultVector results { result };
+// //     //     ngraph::ParameterVector params { input };
+// //     //     function = std::make_shared<ngraph::Function>(results, params);
+// //     // }
 
-    auto network = InferenceEngine::CNNNetwork(function);
-    auto model = frontEnd->buildInitialModel(network);
+// //     // auto network = InferenceEngine::CNNNetwork(function);
+// //     // auto model = frontEnd->buildInitialModel(network);
 
-    auto middleEnd = passManager->buildMiddleEnd();
-    auto checkWeightWasChanged = [this, &network](const float scale) {
-        auto model = frontEnd->buildInitialModel(network);
-        for (const auto& stage : model->getStages()) {
-            if (stage->name() == "Convolution") {
-                stage->origLayer()->params["vpu_scale"] = toString(scale);
-            }
-        }
+// //     // auto middleEnd = passManager->buildMiddleEnd();
+// //     // auto checkWeightWasChanged = [this, &network](const float scale) {
+// //     //     auto model = frontEnd->buildInitialModel(network);
+// //     //     for (const auto& stage : model->getStages()) {
+// //     //         if (stage->name() == "Convolution") {
+// //     //             stage->origLayer()->params["vpu_scale"] = toString(scale);
+// //     //         }
+// //     //     }
 
-        auto middleEnd = passManager->buildMiddleEnd();
-        middleEnd->run(model);
-        for (const auto& stage : model->getStages()) {
-            if (stage->name() == "Convolution") {
-                auto content = stage->input(1)->content()->get<ie_fp16>();
-                if (scale < 0) {
-                    EXPECT_EQ(scale, PrecisionUtils::f16tof32(content[0]));
-                } else {
-                    EXPECT_EQ(scale, fabs(PrecisionUtils::f16tof32(content[0])));
-                }
-            }
-        }
-    };
+// //     //     auto middleEnd = passManager->buildMiddleEnd();
+// //     //     middleEnd->run(model);
+// //     //     for (const auto& stage : model->getStages()) {
+// //     //         if (stage->name() == "Convolution") {
+// //     //             auto content = stage->input(1)->content()->get<ie_fp16>();
+// //     //             if (scale < 0) {
+// //     //                 EXPECT_EQ(scale, PrecisionUtils::f16tof32(content[0]));
+// //     //             } else {
+// //     //                 EXPECT_EQ(scale, fabs(PrecisionUtils::f16tof32(content[0])));
+// //     //             }
+// //     //         }
+// //     //     }
+// //     // };
 
-    const auto maxVal = std::numeric_limits<float>::infinity();
+// //     // const auto maxVal = std::numeric_limits<float>::infinity();
 
-    checkWeightWasChanged(32);
-    checkWeightWasChanged(64);
-    checkWeightWasChanged(maxVal);
+// //     // checkWeightWasChanged(32);
+// //     // checkWeightWasChanged(64);
+// //     // checkWeightWasChanged(maxVal);
 
-}
+// // }
+//     // InitCompileEnv();
+
+//     // auto& env = CompileEnv::get();
+//     // CompilationConfig config{};
+//     // config.irWithVpuScalesDir = "/";
+//     // env.updateConfig(config);
+
+//     // std::shared_ptr<ngraph::Function> function;
+
+//     // {
+//     //     auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f16, ngraph::Shape{4, 2, 2});
+//     //     input->set_friendly_name("input");
+//     //     auto weights = ngraph::opset1::Constant::create(ngraph::element::f16, ngraph::Shape{2, 2}, {1});
+//     //     auto bias = ngraph::opset1::Constant::create(ngraph::element::f16, ngraph::Shape{2}, {1});
+//     //     auto fc = std::make_shared<ngraph::op::FullyConnected>(input, weights, bias, ngraph::Shape{4, 2, 2});
+//     //     fc->set_friendly_name("FullyConnected");
+//     //     auto result = std::make_shared<ngraph::op::Result>(fc);
+//     //     ngraph::ResultVector results { result };
+//     //     ngraph::ParameterVector params {input };
+//     //     function = std::make_shared<ngraph::Function>(results, params);
+//     // }
+
+//     // auto network = InferenceEngine::CNNNetwork(function);
+//     // auto model = frontEnd->buildInitialModel(network);
+
+//     // const auto getFullyConnectedStage = [model]() -> Stage {
+//     //     const auto isFullyConnected = [](const Stage& stage) {
+//     //         const auto& layer = stage->origNode();
+//     //         return layer && layer->type == "FullyConnected";
+//     //     };
+//     //     const auto stages = model->getStages();
+//     //     const auto stageIt = std::find_if(begin(stages), end(stages), isFullyConnected);
+//     //     return *stageIt;
+//     // };
+
+//     // const auto fcStage = getFullyConnectedStage();
+//     // // EXPECT_EQ(fcStage->origNode()->params.find("vpu_scale"), fcStage->origNode()->params.end());
+
+//     // auto middleEnd = passManager->buildMiddleEnd();
+//     // middleEnd->run(model);
+
+//     // const auto fcStageAfterMiddleEnd = getFullyConnectedStage();
+//     // EXPECT_NE(fcStageAfterMiddleEnd->origNode()->params.find("vpu_scale"), fcStageAfterMiddleEnd->origNode()->params.end());
+// // }
+
+// // TEST_F(VPU_AddVpuScaleTest, VpuScaleFromIrChangesWeights) {
+//     // InitCompileEnv();
+//     // const auto& env = CompileEnv::get();
+//     // CompilationConfig config{};
+//     // config.irWithVpuScalesDir = "/";
+//     // env.updateConfig(config);
+
+//     // std::shared_ptr<ngraph::Function> function;
+//     // {
+//     //     ngraph::element::Type elementType = ngraph::element::Type_t::f16;
+//     //     ngraph::Shape shape { 1, 1, 4, 5 };
+//     //     auto input = std::make_shared<ngraph::op::Parameter>(elementType, shape);
+//     //     input->set_friendly_name("input");
+
+//     //     auto weights = std::make_shared<ngraph::op::Constant>(
+//     //             elementType, ngraph::Shape{1, 1, 1, 1}, std::vector<float>(1, 1.0f));
+//     //     auto conv = std::make_shared<ngraph::op::v1::Convolution>(
+//     //             input, weights, ngraph::Strides {1, 1},
+//     //             ngraph::CoordinateDiff{0, 0}, ngraph::CoordinateDiff{0, 0}, ngraph::Strides{1, 1});
+//     //     conv->set_friendly_name("Convolution");
+//     //     auto result = std::make_shared<ngraph::op::Result>(conv);
+
+//     //     ngraph::ResultVector results { result };
+//     //     ngraph::ParameterVector params { input };
+//     //     function = std::make_shared<ngraph::Function>(results, params);
+//     // }
+
+//     // auto network = InferenceEngine::CNNNetwork(function);
+//     // auto model = frontEnd->buildInitialModel(network);
+
+//     // auto middleEnd = passManager->buildMiddleEnd();
+//     // auto checkWeightWasChanged = [this, &network](const float scale) {
+//     //     auto model = frontEnd->buildInitialModel(network);
+//     //     for (const auto& stage : model->getStages()) {
+//     //         if (stage->name() == "Convolution") {
+//     //             stage->origLayer()->params["vpu_scale"] = toString(scale);
+//     //         }
+//     //     }
+
+//     //     auto middleEnd = passManager->buildMiddleEnd();
+//     //     middleEnd->run(model);
+//     //     for (const auto& stage : model->getStages()) {
+//     //         if (stage->name() == "Convolution") {
+//     //             auto content = stage->input(1)->content()->get<ie_fp16>();
+//     //             if (scale < 0) {
+//     //                 EXPECT_EQ(scale, PrecisionUtils::f16tof32(content[0]));
+//     //             } else {
+//     //                 EXPECT_EQ(scale, fabs(PrecisionUtils::f16tof32(content[0])));
+//     //             }
+//     //         }
+//     //     }
+//     // };
+
+//     // const auto maxVal = std::numeric_limits<float>::infinity();
+
+//     // checkWeightWasChanged(32);
+//     // checkWeightWasChanged(64);
+//     // checkWeightWasChanged(maxVal);
+
+// }

--- a/inference-engine/tests_deprecated/unit/engines/vpu/graph_transformer_tests.cpp
+++ b/inference-engine/tests_deprecated/unit/engines/vpu/graph_transformer_tests.cpp
@@ -1,246 +1,246 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
 
-#include "graph_transformer_tests.hpp"
+// #include "graph_transformer_tests.hpp"
 
-#include <atomic>
-#include <iomanip>
+// #include <atomic>
+// #include <iomanip>
 
-#include <vpu/utils/io.hpp>
-#include <vpu/configuration/options/log_level.hpp>
-#include <vpu/configuration/options/copy_optimization.hpp>
+// #include <vpu/utils/io.hpp>
+// #include <vpu/configuration/options/log_level.hpp>
+// #include <vpu/configuration/options/copy_optimization.hpp>
 
-namespace vpu {
+// namespace vpu {
 
-StagePtr TestStage::cloneImpl() const {
-    return std::make_shared<TestStage>(*this);
-}
+// StagePtr TestStage::cloneImpl() const {
+//     return std::make_shared<TestStage>(*this);
+// }
 
-namespace {
+// namespace {
 
-template <typename Value>
-void setInOutPortInfo(
-        const Stage& stage,
-        const std::string& attrBaseName,
-        StageDataInfo<Value>& info) {
-    auto inAttrName = formatString("test_input_%s_info", attrBaseName);
-    auto outAttrName = formatString("test_output_%s_info", attrBaseName);
+// template <typename Value>
+// void setInOutPortInfo(
+//         const Stage& stage,
+//         const std::string& attrBaseName,
+//         StageDataInfo<Value>& info) {
+//     auto inAttrName = formatString("test_input_%s_info", attrBaseName);
+//     auto outAttrName = formatString("test_output_%s_info", attrBaseName);
 
-    if (stage->attrs().has(inAttrName)) {
-        const auto& inputInfo = stage->attrs().get<InOutPortMap<Value>>(inAttrName);
+//     if (stage->attrs().has(inAttrName)) {
+//         const auto& inputInfo = stage->attrs().get<InOutPortMap<Value>>(inAttrName);
 
-        for (const auto& p : inputInfo) {
-            info.setInput(stage->inputEdge(p.first), p.second);
-        }
-    }
+//         for (const auto& p : inputInfo) {
+//             info.setInput(stage->inputEdge(p.first), p.second);
+//         }
+//     }
 
-    if (stage->attrs().has(outAttrName)) {
-        const auto& outputInfo = stage->attrs().get<InOutPortMap<Value>>(outAttrName);
+//     if (stage->attrs().has(outAttrName)) {
+//         const auto& outputInfo = stage->attrs().get<InOutPortMap<Value>>(outAttrName);
 
-        for (const auto& p : outputInfo) {
-            info.setOutput(stage->outputEdge(p.first), p.second);
-        }
-    }
-}
+//         for (const auto& p : outputInfo) {
+//             info.setOutput(stage->outputEdge(p.first), p.second);
+//         }
+//     }
+// }
 
-}
+// }
 
-void TestStage::propagateDataOrderImpl(StageDataInfo<DimsOrder>& orderInfo) {
-    setInOutPortInfo(this, "DataOrder", orderInfo);
-}
+// void TestStage::propagateDataOrderImpl(StageDataInfo<DimsOrder>& orderInfo) {
+//     setInOutPortInfo(this, "DataOrder", orderInfo);
+// }
 
-void TestStage::getDataStridesRequirementsImpl(StageDataInfo<StridesRequirement>& stridesInfo) {
-    setInOutPortInfo(this, "Strides", stridesInfo);
-}
+// void TestStage::getDataStridesRequirementsImpl(StageDataInfo<StridesRequirement>& stridesInfo) {
+//     setInOutPortInfo(this, "Strides", stridesInfo);
+// }
 
-void TestStage::finalizeDataLayoutImpl() {
-}
+// void TestStage::finalizeDataLayoutImpl() {
+// }
 
-void TestStage::getBatchSupportInfoImpl(StageDataInfo<BatchSupport>& batchInfo) {
-    setInOutPortInfo(this, "Batch", batchInfo);
+// void TestStage::getBatchSupportInfoImpl(StageDataInfo<BatchSupport>& batchInfo) {
+//     setInOutPortInfo(this, "Batch", batchInfo);
 
-    if (attrs().has("test_input_Batch_info")) {
-        for (const auto& outEdge : outputEdges()) {
-            batchInfo.setOutput(outEdge, BatchSupport::Split);
-        }
-    }
-}
+//     if (attrs().has("test_input_Batch_info")) {
+//         for (const auto& outEdge : outputEdges()) {
+//             batchInfo.setOutput(outEdge, BatchSupport::Split);
+//         }
+//     }
+// }
 
-void TestStage::serializeParamsImpl(BlobSerializer&) const {
-}
+// void TestStage::serializeParamsImpl(BlobSerializer&) const {
+// }
 
-void TestStage::serializeDataImpl(BlobSerializer&) const {
-}
+// void TestStage::serializeDataImpl(BlobSerializer&) const {
+// }
 
-TestModel::TestModel(const Model& model, const DataDesc& dataDesc) :
-        _model(model), _dataDesc(dataDesc) {
-}
+// TestModel::TestModel(const Model& model, const DataDesc& dataDesc) :
+//         _model(model), _dataDesc(dataDesc) {
+// }
 
-void TestModel::createInputs(int numInputs) {
-    _model->attrs().set<int>("numInputs", numInputs);
-    _inputs.resize(numInputs);
+// void TestModel::createInputs(int numInputs) {
+//     _model->attrs().set<int>("numInputs", numInputs);
+//     _inputs.resize(numInputs);
 
-    for (int i = 0; i < numInputs; ++i) {
-        _inputs[i] = _model->addInputData(formatString("Input %d", i), _dataDesc);
-    }
-}
+//     for (int i = 0; i < numInputs; ++i) {
+//         _inputs[i] = _model->addInputData(formatString("Input %d", i), _dataDesc);
+//     }
+// }
 
-void TestModel::createOutputs(int numOutputs) {
-    _model->attrs().set<int>("numOutputs", numOutputs);
-    _outputs.resize(numOutputs);
+// void TestModel::createOutputs(int numOutputs) {
+//     _model->attrs().set<int>("numOutputs", numOutputs);
+//     _outputs.resize(numOutputs);
 
-    for (int i = 0; i < numOutputs; ++i) {
-        _outputs[i] = _model->addOutputData(formatString("Output %d", i), _dataDesc);
-    }
-}
+//     for (int i = 0; i < numOutputs; ++i) {
+//         _outputs[i] = _model->addOutputData(formatString("Output %d", i), _dataDesc);
+//     }
+// }
 
-int TestModel::addStage(
-        std::initializer_list<InputInfo> curInputInfos,
-        std::initializer_list<OutputInfo> curOutputInfos) {
-    DataVector curInputs;
-    for (const auto& info : curInputInfos) {
-        if (info.type == InputType::Original) {
-            curInputs.push_back(_inputs.at(info.originalInputInd));
-        } else {
-            curInputs.push_back(_stages.at(info.prevStageInd)->output(info.prevStageOutputInd));
-        }
-    }
+// int TestModel::addStage(
+//         std::initializer_list<InputInfo> curInputInfos,
+//         std::initializer_list<OutputInfo> curOutputInfos) {
+//     DataVector curInputs;
+//     for (const auto& info : curInputInfos) {
+//         if (info.type == InputType::Original) {
+//             curInputs.push_back(_inputs.at(info.originalInputInd));
+//         } else {
+//             curInputs.push_back(_stages.at(info.prevStageInd)->output(info.prevStageOutputInd));
+//         }
+//     }
 
-    DataVector curOutputs;
-    for (const auto& info : curOutputInfos) {
-        if (info.type == OutputType::Original) {
-            curOutputs.push_back(_outputs.at(info.originalOutputInd));
-        } else {
-            curOutputs.push_back(_model->addNewData(formatString("Data %d / %d", _stages.size(), curOutputs.size()), _dataDesc));
-        }
-    }
+//     DataVector curOutputs;
+//     for (const auto& info : curOutputInfos) {
+//         if (info.type == OutputType::Original) {
+//             curOutputs.push_back(_outputs.at(info.originalOutputInd));
+//         } else {
+//             curOutputs.push_back(_model->addNewData(formatString("Data %d / %d", _stages.size(), curOutputs.size()), _dataDesc));
+//         }
+//     }
 
-    auto stage = _model->addNewStage<TestStage>(
-        formatString("Stage %m%m%d", std::setw(2), std::setfill('0'), _stages.size()),
-        StageType::None,
-        nullptr,
-        curInputs,
-        curOutputs);
-    stage->attrs().set<int>("test_ind", _stages.size());
+//     auto stage = _model->addNewStage<TestStage>(
+//         formatString("Stage %m%m%d", std::setw(2), std::setfill('0'), _stages.size()),
+//         StageType::None,
+//         nullptr,
+//         curInputs,
+//         curOutputs);
+//     stage->attrs().set<int>("test_ind", _stages.size());
 
-    _stages.push_back(stage);
+//     _stages.push_back(stage);
 
-    return _stages.size() - 1;
-}
-void TestModel::setStageDataOrderInfo(
-        int stageInd,
-        const InOutPortMap<DimsOrder>& inputInfo,
-        const InOutPortMap<DimsOrder>& outputInfo) {
-    if (!inputInfo.empty()) {
-        _stages.at(stageInd)->attrs().set("test_input_DataOrder_info", inputInfo);
-    }
-    if (!outputInfo.empty()) {
-        _stages.at(stageInd)->attrs().set("test_input_DataOrder_info", outputInfo);
-    }
-}
+//     return _stages.size() - 1;
+// }
+// void TestModel::setStageDataOrderInfo(
+//         int stageInd,
+//         const InOutPortMap<DimsOrder>& inputInfo,
+//         const InOutPortMap<DimsOrder>& outputInfo) {
+//     if (!inputInfo.empty()) {
+//         _stages.at(stageInd)->attrs().set("test_input_DataOrder_info", inputInfo);
+//     }
+//     if (!outputInfo.empty()) {
+//         _stages.at(stageInd)->attrs().set("test_input_DataOrder_info", outputInfo);
+//     }
+// }
 
-void TestModel::setStageStridesInfo(
-        int stageInd,
-        const InOutPortMap<StridesRequirement>& inputInfo,
-        const InOutPortMap<StridesRequirement>& outputInfo) {
-    if (!inputInfo.empty()) {
-        _stages.at(stageInd)->attrs().set("test_input_Strides_info", inputInfo);
-    }
-    if (!outputInfo.empty()) {
-        _stages.at(stageInd)->attrs().set("test_input_Strides_info", outputInfo);
-    }
-}
+// void TestModel::setStageStridesInfo(
+//         int stageInd,
+//         const InOutPortMap<StridesRequirement>& inputInfo,
+//         const InOutPortMap<StridesRequirement>& outputInfo) {
+//     if (!inputInfo.empty()) {
+//         _stages.at(stageInd)->attrs().set("test_input_Strides_info", inputInfo);
+//     }
+//     if (!outputInfo.empty()) {
+//         _stages.at(stageInd)->attrs().set("test_input_Strides_info", outputInfo);
+//     }
+// }
 
-void TestModel::setStageBatchInfo(
-        int stageInd,
-        const InOutPortMap<BatchSupport>& inputInfo) {
-    if (!inputInfo.empty()) {
-        _stages.at(stageInd)->attrs().set("test_input_Batch_info", inputInfo);
-    }
-}
+// void TestModel::setStageBatchInfo(
+//         int stageInd,
+//         const InOutPortMap<BatchSupport>& inputInfo) {
+//     if (!inputInfo.empty()) {
+//         _stages.at(stageInd)->attrs().set("test_input_Batch_info", inputInfo);
+//     }
+// }
 
-PluginConfiguration createConfiguration() {
-    PluginConfiguration configuration;
-    configuration.registerOption<LogLevelOption>();
-    configuration.registerOption<CopyOptimizationOption>();
+// PluginConfiguration createConfiguration() {
+//     PluginConfiguration configuration;
+//     configuration.registerOption<LogLevelOption>();
+//     configuration.registerOption<CopyOptimizationOption>();
 
-IE_SUPPRESS_DEPRECATED_START
-    configuration.registerDeprecatedOption<LogLevelOption>(VPU_CONFIG_KEY(LOG_LEVEL));
-IE_SUPPRESS_DEPRECATED_END
+// IE_SUPPRESS_DEPRECATED_START
+//     configuration.registerDeprecatedOption<LogLevelOption>(VPU_CONFIG_KEY(LOG_LEVEL));
+// IE_SUPPRESS_DEPRECATED_END
 
-    return configuration;
-}
+//     return configuration;
+// }
 
-void GraphTransformerTest::SetUp() {
-    ASSERT_NO_FATAL_FAILURE(TestsCommon::SetUp());
+// void GraphTransformerTest::SetUp() {
+//     ASSERT_NO_FATAL_FAILURE(TestsCommon::SetUp());
 
-    _log = std::make_shared<Logger>(
-        "Test",
-        LogLevel::Debug,
-        consoleOutput());
+//     _log = std::make_shared<Logger>(
+//         "Test",
+//         LogLevel::Debug,
+//         consoleOutput());
 
-    stageBuilder = std::make_shared<StageBuilder>();
-    frontEnd = std::make_shared<FrontEnd>(stageBuilder, &_mockCore);
-    backEnd = std::make_shared<BackEnd>();
-    passManager = std::make_shared<PassManager>(stageBuilder, backEnd);
+//     stageBuilder = std::make_shared<StageBuilder>();
+//     frontEnd = std::make_shared<FrontEnd>(stageBuilder, &_mockCore);
+//     backEnd = std::make_shared<BackEnd>();
+//     passManager = std::make_shared<PassManager>(stageBuilder, backEnd);
 
-    config = createConfiguration();
-}
+//     config = createConfiguration();
+// }
 
-void GraphTransformerTest::TearDown() {
-    for (const auto& model : _models) {
-        backEnd->dumpModel(model);
-    }
+// void GraphTransformerTest::TearDown() {
+//     for (const auto& model : _models) {
+//         backEnd->dumpModel(model);
+//     }
 
-    if (compileEnvInitialized) {
-        CompileEnv::free();
-    }
+//     if (compileEnvInitialized) {
+//         CompileEnv::free();
+//     }
 
-    TestsCommon::TearDown();
-}
+//     TestsCommon::TearDown();
+// }
 
-void GraphTransformerTest::InitCompileEnv() {
-    if (const auto envVar = std::getenv("IE_VPU_DUMP_INTERNAL_GRAPH_FILE_NAME")) {
-        config.compileConfig().dumpInternalGraphFileName = envVar;
-    }
-    if (const auto envVar = std::getenv("IE_VPU_DUMP_INTERNAL_GRAPH_DIRECTORY")) {
-        config.compileConfig().dumpInternalGraphDirectory = envVar;
-    }
-    if (const auto envVar = std::getenv("IE_VPU_DUMP_ALL_PASSES")) {
-        config.compileConfig().dumpAllPasses = std::stoi(envVar) != 0;
-    }
+// void GraphTransformerTest::InitCompileEnv() {
+//     if (const auto envVar = std::getenv("IE_VPU_DUMP_INTERNAL_GRAPH_FILE_NAME")) {
+//         config.compileConfig().dumpInternalGraphFileName = envVar;
+//     }
+//     if (const auto envVar = std::getenv("IE_VPU_DUMP_INTERNAL_GRAPH_DIRECTORY")) {
+//         config.compileConfig().dumpInternalGraphDirectory = envVar;
+//     }
+//     if (const auto envVar = std::getenv("IE_VPU_DUMP_ALL_PASSES")) {
+//         config.compileConfig().dumpAllPasses = std::stoi(envVar) != 0;
+//     }
 
-    CompileEnv::init(platform, config, _log);
-    compileEnvInitialized = true;
-}
+//     CompileEnv::init(platform, config, _log);
+//     compileEnvInitialized = true;
+// }
 
-namespace {
+// namespace {
 
-std::atomic<int> g_counter(0);
+// std::atomic<int> g_counter(0);
 
-}
+// }
 
-Model GraphTransformerTest::CreateModel() {
-    const auto& env = CompileEnv::get();
+// Model GraphTransformerTest::CreateModel() {
+//     const auto& env = CompileEnv::get();
 
-    auto unitTest = testing::UnitTest::GetInstance();
-    IE_ASSERT(unitTest != nullptr);
-    auto curTestInfo = unitTest->current_test_info();
-    IE_ASSERT(curTestInfo != nullptr);
+//     auto unitTest = testing::UnitTest::GetInstance();
+//     IE_ASSERT(unitTest != nullptr);
+//     auto curTestInfo = unitTest->current_test_info();
+//     IE_ASSERT(curTestInfo != nullptr);
 
-    auto model = std::make_shared<ModelObj>(
-        formatString("%s/%s", curTestInfo->test_case_name(), curTestInfo->name()));
-    model->attrs().set<int>("index", g_counter.fetch_add(1));
-    model->attrs().set<Resources>("resources", env.resources);
+//     auto model = std::make_shared<ModelObj>(
+//         formatString("%s/%s", curTestInfo->test_case_name(), curTestInfo->name()));
+//     model->attrs().set<int>("index", g_counter.fetch_add(1));
+//     model->attrs().set<Resources>("resources", env.resources);
 
-    _models.push_back(model);
+//     _models.push_back(model);
 
-    return model;
-}
+//     return model;
+// }
 
-TestModel GraphTransformerTest::CreateTestModel(const DataDesc& dataDesc) {
-    return TestModel(CreateModel(), dataDesc);
-}
+// TestModel GraphTransformerTest::CreateTestModel(const DataDesc& dataDesc) {
+//     return TestModel(CreateModel(), dataDesc);
+// }
 
-}
+// }

--- a/inference-engine/tests_deprecated/unit/engines/vpu/graph_transformer_tests.hpp
+++ b/inference-engine/tests_deprecated/unit/engines/vpu/graph_transformer_tests.hpp
@@ -1,208 +1,208 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
 
-#pragma once
+// #pragma once
 
-#include <list>
+// #include <list>
 
-#include <gtest/gtest.h>
-#include <tests_common.hpp>
+// #include <gtest/gtest.h>
+// #include <tests_common.hpp>
 
-#include <vpu/compile_env.hpp>
-#include <vpu/model/stage.hpp>
-#include <vpu/model/model.hpp>
-#include <vpu/frontend/frontend.hpp>
-#include <vpu/stage_builder.hpp>
-#include <vpu/middleend/pass_manager.hpp>
-#include <vpu/backend/backend.hpp>
+// #include <vpu/compile_env.hpp>
+// #include <vpu/model/stage.hpp>
+// #include <vpu/model/model.hpp>
+// #include <vpu/frontend/frontend.hpp>
+// #include <vpu/stage_builder.hpp>
+// #include <vpu/middleend/pass_manager.hpp>
+// #include <vpu/backend/backend.hpp>
 
-#include <unit_test_utils/mocks/cpp_interfaces/interface/mock_icore.hpp>
+// #include <unit_test_utils/mocks/cpp_interfaces/interface/mock_icore.hpp>
 
-namespace vpu {
+// namespace vpu {
 
-template <class Cont, class Cond>
-bool contains(const Cont& cont, const Cond& cond) {
-    for (const auto& val : cont) {
-        if (cond(val)) {
-            return true;
-        }
-    }
-    return false;
-}
+// template <class Cont, class Cond>
+// bool contains(const Cont& cont, const Cond& cond) {
+//     for (const auto& val : cont) {
+//         if (cond(val)) {
+//             return true;
+//         }
+//     }
+//     return false;
+// }
 
-template <typename Value>
-using InOutPortMap = std::unordered_map<int, Value>;
+// template <typename Value>
+// using InOutPortMap = std::unordered_map<int, Value>;
 
-class TestStage final : public StageNode {
-public:
-    using StageNode::StageNode;
+// class TestStage final : public StageNode {
+// public:
+//     using StageNode::StageNode;
 
-private:
-    StagePtr cloneImpl() const override;
+// private:
+//     StagePtr cloneImpl() const override;
 
-    void propagateDataOrderImpl(StageDataInfo<DimsOrder>& orderInfo) override;
+//     void propagateDataOrderImpl(StageDataInfo<DimsOrder>& orderInfo) override;
 
-    void getDataStridesRequirementsImpl(StageDataInfo<StridesRequirement>& stridesInfo) override;
+//     void getDataStridesRequirementsImpl(StageDataInfo<StridesRequirement>& stridesInfo) override;
 
-    void finalizeDataLayoutImpl() override;
+//     void finalizeDataLayoutImpl() override;
 
-    void getBatchSupportInfoImpl(StageDataInfo<BatchSupport>& batchInfo) override;
+//     void getBatchSupportInfoImpl(StageDataInfo<BatchSupport>& batchInfo) override;
 
-    void serializeParamsImpl(BlobSerializer&) const override;
+//     void serializeParamsImpl(BlobSerializer&) const override;
 
-    void serializeDataImpl(BlobSerializer&) const override;
-};
+//     void serializeDataImpl(BlobSerializer&) const override;
+// };
 
-enum class InputType {
-    Original,
-    PrevStageOutput
-};
+// enum class InputType {
+//     Original,
+//     PrevStageOutput
+// };
 
-struct InputInfo final {
-    InputType type = InputType::Original;
-    int originalInputInd = -1;
-    int prevStageInd = -1;
-    int prevStageOutputInd = -1;
+// struct InputInfo final {
+//     InputType type = InputType::Original;
+//     int originalInputInd = -1;
+//     int prevStageInd = -1;
+//     int prevStageOutputInd = -1;
 
-    static InputInfo fromNetwork(int ind = 0) {
-        InputInfo info;
-        info.type = InputType::Original;
-        info.originalInputInd = ind;
-        return info;
-    }
+//     static InputInfo fromNetwork(int ind = 0) {
+//         InputInfo info;
+//         info.type = InputType::Original;
+//         info.originalInputInd = ind;
+//         return info;
+//     }
 
-    static InputInfo fromPrevStage(int ind) {
-        InputInfo info;
-        info.type = InputType::PrevStageOutput;
-        info.prevStageInd = ind;
-        info.prevStageOutputInd = 0;
-        return info;
-    }
+//     static InputInfo fromPrevStage(int ind) {
+//         InputInfo info;
+//         info.type = InputType::PrevStageOutput;
+//         info.prevStageInd = ind;
+//         info.prevStageOutputInd = 0;
+//         return info;
+//     }
 
-    InputInfo& output(int ind) {
-        assert(type == InputType::PrevStageOutput);
-        prevStageOutputInd = ind;
-        return *this;
-    }
-};
+//     InputInfo& output(int ind) {
+//         assert(type == InputType::PrevStageOutput);
+//         prevStageOutputInd = ind;
+//         return *this;
+//     }
+// };
 
-enum class OutputType {
-    Original,
-    Intermediate
-};
+// enum class OutputType {
+//     Original,
+//     Intermediate
+// };
 
-struct OutputInfo final {
-    OutputType type = OutputType::Original;
-    int originalOutputInd = -1;
+// struct OutputInfo final {
+//     OutputType type = OutputType::Original;
+//     int originalOutputInd = -1;
 
-    static OutputInfo fromNetwork(int ind = 0) {
-        OutputInfo info;
-        info.type = OutputType::Original;
-        info.originalOutputInd = ind;
-        return info;
-    }
+//     static OutputInfo fromNetwork(int ind = 0) {
+//         OutputInfo info;
+//         info.type = OutputType::Original;
+//         info.originalOutputInd = ind;
+//         return info;
+//     }
 
-    static OutputInfo intermediate() {
-        OutputInfo info;
-        info.type = OutputType::Intermediate;
-        return info;
-    }
-};
+//     static OutputInfo intermediate() {
+//         OutputInfo info;
+//         info.type = OutputType::Intermediate;
+//         return info;
+//     }
+// };
 
-class TestModel final {
-public:
-    TestModel() = default;
-    TestModel(const Model& model, const DataDesc& dataDesc);
+// class TestModel final {
+// public:
+//     TestModel() = default;
+//     TestModel(const Model& model, const DataDesc& dataDesc);
 
-    const Model& getBaseModel() const { return _model; }
-    const DataVector& getInputs() const { return _inputs; }
-    const DataVector& getOutputs() const { return _outputs; }
-    const StageVector& getStages() const { return _stages; }
+//     const Model& getBaseModel() const { return _model; }
+//     const DataVector& getInputs() const { return _inputs; }
+//     const DataVector& getOutputs() const { return _outputs; }
+//     const StageVector& getStages() const { return _stages; }
 
-    void createInputs(int numInputs);
-    void createOutputs(int numOutputs);
+//     void createInputs(int numInputs);
+//     void createOutputs(int numOutputs);
 
-    int addStage(
-            std::initializer_list<InputInfo> curInputInfos,
-            std::initializer_list<OutputInfo> curOutputInfos);
+//     int addStage(
+//             std::initializer_list<InputInfo> curInputInfos,
+//             std::initializer_list<OutputInfo> curOutputInfos);
 
-    void setStageDataOrderInfo(
-            int stageInd,
-            const InOutPortMap<DimsOrder>& inputInfo,
-            const InOutPortMap<DimsOrder>& outputInfo);
-    void setStageStridesInfo(
-            int stageInd,
-            const InOutPortMap<StridesRequirement>& inputInfo,
-            const InOutPortMap<StridesRequirement>& outputInfo);
-    void setStageBatchInfo(
-            int stageInd,
-            const InOutPortMap<BatchSupport>& inputInfo);
+//     void setStageDataOrderInfo(
+//             int stageInd,
+//             const InOutPortMap<DimsOrder>& inputInfo,
+//             const InOutPortMap<DimsOrder>& outputInfo);
+//     void setStageStridesInfo(
+//             int stageInd,
+//             const InOutPortMap<StridesRequirement>& inputInfo,
+//             const InOutPortMap<StridesRequirement>& outputInfo);
+//     void setStageBatchInfo(
+//             int stageInd,
+//             const InOutPortMap<BatchSupport>& inputInfo);
 
-private:
-    Model _model;
-    DataDesc _dataDesc;
+// private:
+//     Model _model;
+//     DataDesc _dataDesc;
 
-    DataVector _inputs;
-    DataVector _outputs;
-    StageVector _stages;
-};
+//     DataVector _inputs;
+//     DataVector _outputs;
+//     StageVector _stages;
+// };
 
-template <class StageRange>
-void CheckStageTestInds(const StageRange& stageRange, std::initializer_list<int> expectedInds) {
-    auto stageVector = toVector(stageRange);
+// template <class StageRange>
+// void CheckStageTestInds(const StageRange& stageRange, std::initializer_list<int> expectedInds) {
+//     auto stageVector = toVector(stageRange);
 
-    ASSERT_EQ(expectedInds.size(), stageVector.size());
+//     ASSERT_EQ(expectedInds.size(), stageVector.size());
 
-    size_t stageInd = 0;
-    for (auto expectedInd : expectedInds) {
-        ASSERT_EQ(expectedInd, stageVector[stageInd]->attrs().template get<int>("test_ind"));
-        ++stageInd;
-    }
-}
+//     size_t stageInd = 0;
+//     for (auto expectedInd : expectedInds) {
+//         ASSERT_EQ(expectedInd, stageVector[stageInd]->attrs().template get<int>("test_ind"));
+//         ++stageInd;
+//     }
+// }
 
-template <class StageRange>
-void CheckStageTestInds(const StageRange& stageRange, std::initializer_list<int> expectedInds, const std::function<void(const Stage&)>& extraCheck) {
-    auto stageVector = toVector(stageRange);
+// template <class StageRange>
+// void CheckStageTestInds(const StageRange& stageRange, std::initializer_list<int> expectedInds, const std::function<void(const Stage&)>& extraCheck) {
+//     auto stageVector = toVector(stageRange);
 
-    ASSERT_EQ(expectedInds.size(), stageVector.size());
+//     ASSERT_EQ(expectedInds.size(), stageVector.size());
 
-    size_t stageInd = 0;
-    for (auto expectedInd : expectedInds) {
-        ASSERT_EQ(expectedInd, stageVector[stageInd]->attrs().template get<int>("test_ind"));
-        ++stageInd;
+//     size_t stageInd = 0;
+//     for (auto expectedInd : expectedInds) {
+//         ASSERT_EQ(expectedInd, stageVector[stageInd]->attrs().template get<int>("test_ind"));
+//         ++stageInd;
 
-        ASSERT_NO_FATAL_FAILURE(extraCheck(stageVector[stageInd]));
-    }
-}
+//         ASSERT_NO_FATAL_FAILURE(extraCheck(stageVector[stageInd]));
+//     }
+// }
 
-PluginConfiguration createConfiguration();
+// PluginConfiguration createConfiguration();
 
-class GraphTransformerTest : public TestsCommon {
-public:
-    ncDevicePlatform_t platform = ncDevicePlatform_t::NC_MYRIAD_X;
-    PluginConfiguration config;
+// class GraphTransformerTest : public TestsCommon {
+// public:
+//     ncDevicePlatform_t platform = ncDevicePlatform_t::NC_MYRIAD_X;
+//     PluginConfiguration config;
 
-    StageBuilder::Ptr stageBuilder;
-    FrontEnd::Ptr frontEnd;
-    PassManager::Ptr passManager;
-    BackEnd::Ptr backEnd;
+//     StageBuilder::Ptr stageBuilder;
+//     FrontEnd::Ptr frontEnd;
+//     PassManager::Ptr passManager;
+//     BackEnd::Ptr backEnd;
 
-    bool compileEnvInitialized = false;
+//     bool compileEnvInitialized = false;
 
-    void SetUp() override;
-    void TearDown() override;
+//     void SetUp() override;
+//     void TearDown() override;
 
-    void InitCompileEnv();
+//     void InitCompileEnv();
 
-    Model CreateModel();
+//     Model CreateModel();
 
-    TestModel CreateTestModel(const DataDesc& dataDesc);
+//     TestModel CreateTestModel(const DataDesc& dataDesc);
 
-private:
-    MockICore  _mockCore;
-    Logger::Ptr _log;
-    std::list<ModelPtr> _models;
-};
+// private:
+//     MockICore  _mockCore;
+//     Logger::Ptr _log;
+//     std::list<ModelPtr> _models;
+// };
 
-}
+// }

--- a/inference-engine/tests_deprecated/unit/engines/vpu/graph_transformer_tests_constructs.cpp
+++ b/inference-engine/tests_deprecated/unit/engines/vpu/graph_transformer_tests_constructs.cpp
@@ -1,37 +1,37 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
 
-#include "graph_transformer_tests.hpp"
+// #include "graph_transformer_tests.hpp"
 
-#include <atomic>
+// #include <atomic>
 
-#include <vpu/utils/io.hpp>
+// #include <vpu/utils/io.hpp>
 
-using namespace vpu;
+// using namespace vpu;
 
-TEST_F(GraphTransformerTest, CantConnectInputOutputDatas) {
-    InitCompileEnv();
+// TEST_F(GraphTransformerTest, CantConnectInputOutputDatas) {
+//     InitCompileEnv();
 
-    auto model = CreateModel();
+//     auto model = CreateModel();
 
-    auto input = model->addInputData(
-            "Input",
-            DataDesc(DataType::FP16, DimsOrder::NCHW, {16, 16, 3, 1}));
-    model->attrs().set<int>("numInputs", 1);
+//     auto input = model->addInputData(
+//             "Input",
+//             DataDesc(DataType::FP16, DimsOrder::NCHW, {16, 16, 3, 1}));
+//     model->attrs().set<int>("numInputs", 1);
 
-    auto output = model->addOutputData(
-            "Output",
-            DataDesc(DataType::FP16, DimsOrder::NCHW, {16, 16, 4, 1}));
-    model->attrs().set<int>("numOutputs", 1);
+//     auto output = model->addOutputData(
+//             "Output",
+//             DataDesc(DataType::FP16, DimsOrder::NCHW, {16, 16, 4, 1}));
+//     model->attrs().set<int>("numOutputs", 1);
 
-    ASSERT_ANY_THROW(
-    model->connectDataWithData()
-        .parent(input)
-        .child(output)
-        .mode(SharedDataMode::ROI)
-        .order(SharedDataOrder::ChildWritesToParent)
-        .offset(DimValues())
-        .done()
-    ) << "Can not short connect arbitrary input/output datas";
-}
+//     ASSERT_ANY_THROW(
+//     model->connectDataWithData()
+//         .parent(input)
+//         .child(output)
+//         .mode(SharedDataMode::ROI)
+//         .order(SharedDataOrder::ChildWritesToParent)
+//         .offset(DimValues())
+//         .done()
+//     ) << "Can not short connect arbitrary input/output datas";
+// }

--- a/inference-engine/tests_deprecated/unit/engines/vpu/merge_parallel_fc.cpp
+++ b/inference-engine/tests_deprecated/unit/engines/vpu/merge_parallel_fc.cpp
@@ -1,360 +1,360 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
 
-#include "graph_transformer_tests.hpp"
+// #include "graph_transformer_tests.hpp"
 
-#include <vpu/stages/stub_stage.hpp>
-#include <vpu/model/data_contents/ie_blob_content.hpp>
+// #include <vpu/stages/stub_stage.hpp>
+// #include <vpu/model/data_contents/ie_blob_content.hpp>
 
-#include <initializer_list>
+// #include <initializer_list>
 
-using namespace vpu;
+// using namespace vpu;
 
-namespace {
+// namespace {
 
-using Dimensions = std::vector<std::size_t>;
+// using Dimensions = std::vector<std::size_t>;
 
-struct FCDescriptor {
-    Dimensions weights;
-    Dimensions biases;
-    Dimensions scales;
-    Dimensions output;
+// struct FCDescriptor {
+//     Dimensions weights;
+//     Dimensions biases;
+//     Dimensions scales;
+//     Dimensions output;
 
-    FCDescriptor(Dimensions new_weights, Dimensions new_biases, Dimensions new_scales, Dimensions new_output)
-        : weights(std::move(new_weights))
-        , biases(std::move(new_biases))
-        , scales(std::move(new_scales))
-        , output(std::move(new_output)) {}
-};
+//     FCDescriptor(Dimensions new_weights, Dimensions new_biases, Dimensions new_scales, Dimensions new_output)
+//         : weights(std::move(new_weights))
+//         , biases(std::move(new_biases))
+//         , scales(std::move(new_scales))
+//         , output(std::move(new_output)) {}
+// };
 
-class VPU_MergeParallelFCTestBase : public GraphTransformerTest, public testing::WithParamInterface<std::tuple<Dimensions, std::vector<FCDescriptor>>> {
-public:
-    void SetUp() override {
-        GraphTransformerTest::SetUp();
-        InitCompileEnv();
-        InitPipeline();
-    }
+// class VPU_MergeParallelFCTestBase : public GraphTransformerTest, public testing::WithParamInterface<std::tuple<Dimensions, std::vector<FCDescriptor>>> {
+// public:
+//     void SetUp() override {
+//         GraphTransformerTest::SetUp();
+//         InitCompileEnv();
+//         InitPipeline();
+//     }
 
-    void CreateModelWithParallelFC(const Dimensions& inputDimensions, const std::vector<FCDescriptor>& descriptors) {
-        model = CreateModel();
+//     void CreateModelWithParallelFC(const Dimensions& inputDimensions, const std::vector<FCDescriptor>& descriptors) {
+//         model = CreateModel();
 
-        const auto input = model->addInputData("Input", CreateDescriptor(inputDimensions));
-        model->attrs().set<int>("numInputs", 1);
+//         const auto input = model->addInputData("Input", CreateDescriptor(inputDimensions));
+//         model->attrs().set<int>("numInputs", 1);
 
-        for (std::size_t i = 0; i < descriptors.size(); ++i) {
-            const auto& fcDims = descriptors[i];
-            const auto& weights = model->addConstData("Weights#" + std::to_string(i), DataDesc{fcDims.weights});
-            const auto& biases  = fcDims.biases.empty() ? model->addFakeData() : model->addConstData("Biases#" + std::to_string(i), DataDesc{fcDims.biases});
-            const auto& scales  = fcDims.scales.empty() ? model->addFakeData() : model->addConstData("Scales#" + std::to_string(i), DataDesc{fcDims.scales});
-            const auto& output  = model->addNewData("Output#" + std::to_string(i), CreateDescriptor(fcDims.output));
-            model->addNewStage<StubStage>(
-                "FC#" + std::to_string(i),
-                StageType::StubFullyConnected,
-                nullptr,
-                {input, weights, biases, scales},
-                {output});
+//         for (std::size_t i = 0; i < descriptors.size(); ++i) {
+//             const auto& fcDims = descriptors[i];
+//             const auto& weights = model->addConstData("Weights#" + std::to_string(i), DataDesc{fcDims.weights});
+//             const auto& biases  = fcDims.biases.empty() ? model->addFakeData() : model->addConstData("Biases#" + std::to_string(i), DataDesc{fcDims.biases});
+//             const auto& scales  = fcDims.scales.empty() ? model->addFakeData() : model->addConstData("Scales#" + std::to_string(i), DataDesc{fcDims.scales});
+//             const auto& output  = model->addNewData("Output#" + std::to_string(i), CreateDescriptor(fcDims.output));
+//             model->addNewStage<StubStage>(
+//                 "FC#" + std::to_string(i),
+//                 StageType::StubFullyConnected,
+//                 nullptr,
+//                 {input, weights, biases, scales},
+//                 {output});
 
-            stageBuilder->addReLUStage(
-                model,
-                "ReLU#" + std::to_string(i),
-                nullptr,
-                0.0f,
-                output,
-                model->addOutputData("NetworkOutput#" + std::to_string(i), CreateDescriptor(fcDims.output)));
-        }
-    }
+//             stageBuilder->addReLUStage(
+//                 model,
+//                 "ReLU#" + std::to_string(i),
+//                 nullptr,
+//                 0.0f,
+//                 output,
+//                 model->addOutputData("NetworkOutput#" + std::to_string(i), CreateDescriptor(fcDims.output)));
+//         }
+//     }
 
-    void Compile() {
-        pipeline.run(model);
-    }
+//     void Compile() {
+//         pipeline.run(model);
+//     }
 
-protected:
-    static DataDesc CreateReferenceOutputDescriptor(const std::vector<FCDescriptor>& descriptors) {
-        std::vector<DataDesc> outputDescriptors;
-        std::transform(descriptors.begin(), descriptors.end(), std::back_inserter(outputDescriptors),
-            [](const FCDescriptor& fcDescriptor) { return CreateDescriptor(fcDescriptor.output); });
+// protected:
+//     static DataDesc CreateReferenceOutputDescriptor(const std::vector<FCDescriptor>& descriptors) {
+//         std::vector<DataDesc> outputDescriptors;
+//         std::transform(descriptors.begin(), descriptors.end(), std::back_inserter(outputDescriptors),
+//             [](const FCDescriptor& fcDescriptor) { return CreateDescriptor(fcDescriptor.output); });
 
-        return mergeDescriptors(outputDescriptors);
-    }
+//         return mergeDescriptors(outputDescriptors);
+//     }
 
-    static DataDesc CreateReferenceScalesDescriptor(const std::vector<FCDescriptor>& descriptors) {
-        if (descriptors.front().scales.size() == 0) {
-            return DataDesc{{1}};
-        }
+//     static DataDesc CreateReferenceScalesDescriptor(const std::vector<FCDescriptor>& descriptors) {
+//         if (descriptors.front().scales.size() == 0) {
+//             return DataDesc{{1}};
+//         }
 
-        std::vector<DataDesc> scalesDescriptors;
-        std::transform(descriptors.begin(), descriptors.end(), std::back_inserter(scalesDescriptors),
-            [](const FCDescriptor& fcDescriptor) { return CreateDescriptor(fcDescriptor.scales); });
+//         std::vector<DataDesc> scalesDescriptors;
+//         std::transform(descriptors.begin(), descriptors.end(), std::back_inserter(scalesDescriptors),
+//             [](const FCDescriptor& fcDescriptor) { return CreateDescriptor(fcDescriptor.scales); });
 
-        return mergeDescriptors(scalesDescriptors);
-    }
+//         return mergeDescriptors(scalesDescriptors);
+//     }
 
-    static DataDesc CreateReferenceBiasesDescriptor(const std::vector<FCDescriptor>& descriptors) {
-        if (descriptors.front().biases.size() == 0) {
-            return DataDesc{{1}};
-        }
+//     static DataDesc CreateReferenceBiasesDescriptor(const std::vector<FCDescriptor>& descriptors) {
+//         if (descriptors.front().biases.size() == 0) {
+//             return DataDesc{{1}};
+//         }
 
-        std::vector<DataDesc> biasesDescriptors;
-        std::transform(descriptors.begin(), descriptors.end(), std::back_inserter(biasesDescriptors),
-            [](const FCDescriptor& fcDescriptor) { return CreateDescriptor(fcDescriptor.biases); });
+//         std::vector<DataDesc> biasesDescriptors;
+//         std::transform(descriptors.begin(), descriptors.end(), std::back_inserter(biasesDescriptors),
+//             [](const FCDescriptor& fcDescriptor) { return CreateDescriptor(fcDescriptor.biases); });
 
-        return mergeDescriptors(biasesDescriptors);
-    }
+//         return mergeDescriptors(biasesDescriptors);
+//     }
 
-    static DataDesc CreateReferenceWeightsDescriptor(const std::vector<FCDescriptor>& descriptors) {
-        std::vector<DataDesc> weightsDescriptors;
-        std::transform(descriptors.begin(), descriptors.end(), std::back_inserter(weightsDescriptors),
-            [](const FCDescriptor& fcDescriptor) { return CreateDescriptor(fcDescriptor.weights); });
+//     static DataDesc CreateReferenceWeightsDescriptor(const std::vector<FCDescriptor>& descriptors) {
+//         std::vector<DataDesc> weightsDescriptors;
+//         std::transform(descriptors.begin(), descriptors.end(), std::back_inserter(weightsDescriptors),
+//             [](const FCDescriptor& fcDescriptor) { return CreateDescriptor(fcDescriptor.weights); });
 
-        return mergeDescriptors(weightsDescriptors);
-    }
+//         return mergeDescriptors(weightsDescriptors);
+//     }
 
-    static DataDesc mergeDescriptors(const std::vector<DataDesc>& descriptors) {
-        auto merged = descriptors.front();
-        merged.setDim(Dim::C, std::accumulate(descriptors.begin(), descriptors.end(), 0,
-            [](int reduction, const DataDesc& descriptor) { return reduction + descriptor.dim(Dim::C); }));
-        return merged;
-    }
+//     static DataDesc mergeDescriptors(const std::vector<DataDesc>& descriptors) {
+//         auto merged = descriptors.front();
+//         merged.setDim(Dim::C, std::accumulate(descriptors.begin(), descriptors.end(), 0,
+//             [](int reduction, const DataDesc& descriptor) { return reduction + descriptor.dim(Dim::C); }));
+//         return merged;
+//     }
 
-    static DataDesc CreateDescriptor(const Dimensions& dimensions) {
-        return DataDesc{dimensions};
-    }
+//     static DataDesc CreateDescriptor(const Dimensions& dimensions) {
+//         return DataDesc{dimensions};
+//     }
 
-    void InitPipeline() {
-        pipeline = PassSet();
-        pipeline.addPass(passManager->dumpModel("before-merge-parallel-fc"));
-        pipeline.addPass(passManager->initialCheck());
-        pipeline.addPass(passManager->mergeParallelFC());
-        pipeline.addPass(passManager->dumpModel("after-merge-parallel-fc"));
-    }
+//     void InitPipeline() {
+//         pipeline = PassSet();
+//         pipeline.addPass(passManager->dumpModel("before-merge-parallel-fc"));
+//         pipeline.addPass(passManager->initialCheck());
+//         pipeline.addPass(passManager->mergeParallelFC());
+//         pipeline.addPass(passManager->dumpModel("after-merge-parallel-fc"));
+//     }
 
-    PassSet pipeline;
-    Model model;
-};
+//     PassSet pipeline;
+//     Model model;
+// };
 
-class VPU_MergeParallelFCTest : public VPU_MergeParallelFCTestBase {
-public:
-    void AssertMergedCorrectly(const Dimensions& inputDimensions, const std::vector<FCDescriptor>& descriptors) const {
-        if (descriptors.empty()) {
-            return;
-        }
+// class VPU_MergeParallelFCTest : public VPU_MergeParallelFCTestBase {
+// public:
+//     void AssertMergedCorrectly(const Dimensions& inputDimensions, const std::vector<FCDescriptor>& descriptors) const {
+//         if (descriptors.empty()) {
+//             return;
+//         }
 
-        const auto& stages = model->getStages() | asVector();
+//         const auto& stages = model->getStages() | asVector();
 
-        ASSERT_EQ(stages.size(), 2 + descriptors.size());
-        const auto& fc = stages.front();
-        const auto& split = stages[1];
+//         ASSERT_EQ(stages.size(), 2 + descriptors.size());
+//         const auto& fc = stages.front();
+//         const auto& split = stages[1];
 
-        ASSERT_EQ(fc->type(), StageType::StubFullyConnected);
-        ASSERT_EQ(split->type(), StageType::Split);
+//         ASSERT_EQ(fc->type(), StageType::StubFullyConnected);
+//         ASSERT_EQ(split->type(), StageType::Split);
 
-        ASSERT_TRUE(fc->numInputs() >= 2 && fc->numInputs() <= 4);
+//         ASSERT_TRUE(fc->numInputs() >= 2 && fc->numInputs() <= 4);
 
-        ASSERT_EQ(fc->input(0)->desc(), CreateDescriptor(inputDimensions));
-        ASSERT_EQ(fc->input(1)->desc(), CreateReferenceWeightsDescriptor(descriptors));
-        ASSERT_EQ(fc->input(2)->desc(), CreateReferenceBiasesDescriptor(descriptors));
-        ASSERT_EQ(fc->input(3)->desc(), CreateReferenceScalesDescriptor(descriptors));
+//         ASSERT_EQ(fc->input(0)->desc(), CreateDescriptor(inputDimensions));
+//         ASSERT_EQ(fc->input(1)->desc(), CreateReferenceWeightsDescriptor(descriptors));
+//         ASSERT_EQ(fc->input(2)->desc(), CreateReferenceBiasesDescriptor(descriptors));
+//         ASSERT_EQ(fc->input(3)->desc(), CreateReferenceScalesDescriptor(descriptors));
 
-        ASSERT_TRUE(fc->numOutputs() == 1);
-        ASSERT_EQ(fc->output(0)->desc(), CreateReferenceOutputDescriptor(descriptors));
+//         ASSERT_TRUE(fc->numOutputs() == 1);
+//         ASSERT_EQ(fc->output(0)->desc(), CreateReferenceOutputDescriptor(descriptors));
 
-        ASSERT_EQ(split->numInputs(), 1);
-        ASSERT_EQ(split->input(0)->desc(), fc->output(0)->desc());
+//         ASSERT_EQ(split->numInputs(), 1);
+//         ASSERT_EQ(split->input(0)->desc(), fc->output(0)->desc());
 
-        ASSERT_EQ(split->numOutputs(), descriptors.size());
-        for (std::size_t i = 0; i < split->numOutputs(); ++i) {
-            ASSERT_EQ(split->output(i)->desc(), CreateDescriptor(descriptors[i].output));
-        }
+//         ASSERT_EQ(split->numOutputs(), descriptors.size());
+//         for (std::size_t i = 0; i < split->numOutputs(); ++i) {
+//             ASSERT_EQ(split->output(i)->desc(), CreateDescriptor(descriptors[i].output));
+//         }
 
-        for (std::size_t i = 2; i < stages.size(); ++i) {
-            const auto& relu  = stages[i];
-            ASSERT_EQ(relu->type(), StageType::Relu);
+//         for (std::size_t i = 2; i < stages.size(); ++i) {
+//             const auto& relu  = stages[i];
+//             ASSERT_EQ(relu->type(), StageType::Relu);
 
-            ASSERT_EQ(relu->numInputs(), 1);
-            ASSERT_EQ(relu->numOutputs(), 1);
+//             ASSERT_EQ(relu->numInputs(), 1);
+//             ASSERT_EQ(relu->numOutputs(), 1);
 
-            ASSERT_EQ(split->output(i - 2)->desc(), relu->input(0)->desc());
-            ASSERT_EQ(CreateDescriptor(descriptors[i - 2].output), relu->output(0)->desc());
-        }
-    }
-};
+//             ASSERT_EQ(split->output(i - 2)->desc(), relu->input(0)->desc());
+//             ASSERT_EQ(CreateDescriptor(descriptors[i - 2].output), relu->output(0)->desc());
+//         }
+//     }
+// };
 
-class VPU_NoMergeParallelFCTest : public VPU_MergeParallelFCTestBase {
-public:
-    void AssertNotMergedCorrectly(const Dimensions& inputDimensions, const std::vector<FCDescriptor>& descriptors) {
-        if (descriptors.empty()) {
-            return;
-        }
+// class VPU_NoMergeParallelFCTest : public VPU_MergeParallelFCTestBase {
+// public:
+//     void AssertNotMergedCorrectly(const Dimensions& inputDimensions, const std::vector<FCDescriptor>& descriptors) {
+//         if (descriptors.empty()) {
+//             return;
+//         }
 
-        const auto& stages = model->getStages() | asVector();
-        ASSERT_EQ(stages.size(), 2 * descriptors.size());
+//         const auto& stages = model->getStages() | asVector();
+//         ASSERT_EQ(stages.size(), 2 * descriptors.size());
 
-        for (std::size_t i = 0; i < descriptors.size(); ++i) {
-            ASSERT_EQ(stages[2 * i + 0]->type(), StageType::StubFullyConnected);
-            ASSERT_EQ(stages[2 * i + 1]->type(), StageType::Relu);
-        }
-    }
-};
+//         for (std::size_t i = 0; i < descriptors.size(); ++i) {
+//             ASSERT_EQ(stages[2 * i + 0]->type(), StageType::StubFullyConnected);
+//             ASSERT_EQ(stages[2 * i + 1]->type(), StageType::Relu);
+//         }
+//     }
+// };
 
-const std::initializer_list<Dimensions> inputDimensions = {
-    {13, 21}
-};
+// const std::initializer_list<Dimensions> inputDimensions = {
+//     {13, 21}
+// };
 
-const std::initializer_list<std::vector<FCDescriptor>> FCDescriptorsMerge = {
-    {
-        FCDescriptor({7, 21}, {}, {}, {13, 7}),
-        FCDescriptor({5, 21}, {}, {}, {13, 5}),
-    },
-    {
-        FCDescriptor({7, 21}, {}, {21}, {13, 7}),
-        FCDescriptor({5, 21}, {}, {21}, {13, 5}),
-    },
-    {
-        FCDescriptor({7, 21}, {21}, {}, {13, 7}),
-        FCDescriptor({5, 21}, {21}, {}, {13, 5}),
-    },
-    {
-        FCDescriptor({7, 21}, {21}, {21}, {13, 7}),
-        FCDescriptor({5, 21}, {21}, {21}, {13, 5}),
-    },
-    {
-        FCDescriptor({7, 21}, {}, {}, {13, 7}),
-        FCDescriptor({5, 21}, {}, {}, {13, 5}),
-        FCDescriptor({11, 21}, {}, {}, {13, 11}),
-    },
-    {
-        FCDescriptor({7, 21}, {}, {21}, {13, 7}),
-        FCDescriptor({5, 21}, {}, {21}, {13, 5}),
-        FCDescriptor({11, 21}, {}, {21}, {13, 11}),
-    },
-    {
-        FCDescriptor({7, 21}, {21}, {}, {13, 7}),
-        FCDescriptor({5, 21}, {21}, {}, {13, 5}),
-        FCDescriptor({11, 21}, {21}, {}, {13, 11}),
-    },
-    {
-        FCDescriptor({7, 21}, {21}, {21}, {13, 7}),
-        FCDescriptor({5, 21}, {21}, {21}, {13, 5}),
-        FCDescriptor({11, 21}, {21}, {21}, {13, 11}),
-    }
-};
+// const std::initializer_list<std::vector<FCDescriptor>> FCDescriptorsMerge = {
+//     {
+//         FCDescriptor({7, 21}, {}, {}, {13, 7}),
+//         FCDescriptor({5, 21}, {}, {}, {13, 5}),
+//     },
+//     {
+//         FCDescriptor({7, 21}, {}, {21}, {13, 7}),
+//         FCDescriptor({5, 21}, {}, {21}, {13, 5}),
+//     },
+//     {
+//         FCDescriptor({7, 21}, {21}, {}, {13, 7}),
+//         FCDescriptor({5, 21}, {21}, {}, {13, 5}),
+//     },
+//     {
+//         FCDescriptor({7, 21}, {21}, {21}, {13, 7}),
+//         FCDescriptor({5, 21}, {21}, {21}, {13, 5}),
+//     },
+//     {
+//         FCDescriptor({7, 21}, {}, {}, {13, 7}),
+//         FCDescriptor({5, 21}, {}, {}, {13, 5}),
+//         FCDescriptor({11, 21}, {}, {}, {13, 11}),
+//     },
+//     {
+//         FCDescriptor({7, 21}, {}, {21}, {13, 7}),
+//         FCDescriptor({5, 21}, {}, {21}, {13, 5}),
+//         FCDescriptor({11, 21}, {}, {21}, {13, 11}),
+//     },
+//     {
+//         FCDescriptor({7, 21}, {21}, {}, {13, 7}),
+//         FCDescriptor({5, 21}, {21}, {}, {13, 5}),
+//         FCDescriptor({11, 21}, {21}, {}, {13, 11}),
+//     },
+//     {
+//         FCDescriptor({7, 21}, {21}, {21}, {13, 7}),
+//         FCDescriptor({5, 21}, {21}, {21}, {13, 5}),
+//         FCDescriptor({11, 21}, {21}, {21}, {13, 11}),
+//     }
+// };
 
-const std::initializer_list<std::vector<FCDescriptor>> FCDescriptorsNoMerge {
-    {
-        FCDescriptor({7, 21}, {}, {}, {13, 7}),
-    },
-    {
-        FCDescriptor({7, 21}, {}, {21}, {13, 7}),
-    },
-    {
-        FCDescriptor({7, 21}, {21}, {}, {13, 7}),
-    },
-    {
-        FCDescriptor({7, 21}, {21}, {21}, {13, 7}),
-    },
+// const std::initializer_list<std::vector<FCDescriptor>> FCDescriptorsNoMerge {
+//     {
+//         FCDescriptor({7, 21}, {}, {}, {13, 7}),
+//     },
+//     {
+//         FCDescriptor({7, 21}, {}, {21}, {13, 7}),
+//     },
+//     {
+//         FCDescriptor({7, 21}, {21}, {}, {13, 7}),
+//     },
+//     {
+//         FCDescriptor({7, 21}, {21}, {21}, {13, 7}),
+//     },
 
-    {
-        FCDescriptor({7, 21}, {}, {}, {13, 7}),
-        FCDescriptor({7, 21}, {}, {21}, {13, 7}),
-    },
-    {
-        FCDescriptor({7, 21}, {}, {}, {13, 7}),
-        FCDescriptor({7, 21}, {21}, {}, {13, 7}),
-    },
-    {
-        FCDescriptor({7, 21}, {}, {}, {13, 7}),
-        FCDescriptor({7, 21}, {21}, {21}, {13, 7}),
-    },
+//     {
+//         FCDescriptor({7, 21}, {}, {}, {13, 7}),
+//         FCDescriptor({7, 21}, {}, {21}, {13, 7}),
+//     },
+//     {
+//         FCDescriptor({7, 21}, {}, {}, {13, 7}),
+//         FCDescriptor({7, 21}, {21}, {}, {13, 7}),
+//     },
+//     {
+//         FCDescriptor({7, 21}, {}, {}, {13, 7}),
+//         FCDescriptor({7, 21}, {21}, {21}, {13, 7}),
+//     },
 
-    {
-        FCDescriptor({7, 21}, {}, {21}, {13, 7}),
-        FCDescriptor({7, 21}, {21}, {}, {13, 7}),
-    },
-    {
-        FCDescriptor({7, 21}, {}, {21}, {13, 7}),
-        FCDescriptor({7, 21}, {21}, {21}, {13, 7}),
-    },
+//     {
+//         FCDescriptor({7, 21}, {}, {21}, {13, 7}),
+//         FCDescriptor({7, 21}, {21}, {}, {13, 7}),
+//     },
+//     {
+//         FCDescriptor({7, 21}, {}, {21}, {13, 7}),
+//         FCDescriptor({7, 21}, {21}, {21}, {13, 7}),
+//     },
 
-    {
-        FCDescriptor({7, 21}, {21}, {}, {13, 7}),
-        FCDescriptor({7, 21}, {}, {21}, {13, 7}),
-    },
-    {
-        FCDescriptor({7, 21}, {21}, {}, {13, 7}),
-        FCDescriptor({7, 21}, {21}, {21}, {13, 7}),
-    },
+//     {
+//         FCDescriptor({7, 21}, {21}, {}, {13, 7}),
+//         FCDescriptor({7, 21}, {}, {21}, {13, 7}),
+//     },
+//     {
+//         FCDescriptor({7, 21}, {21}, {}, {13, 7}),
+//         FCDescriptor({7, 21}, {21}, {21}, {13, 7}),
+//     },
 
-    {
-        FCDescriptor({7, 21}, {}, {}, {13, 7}),
-        FCDescriptor({7, 21}, {}, {21}, {13, 7}),
-        FCDescriptor({7, 21}, {}, {21}, {13, 7}),
-    },
-    {
-        FCDescriptor({7, 21}, {}, {}, {13, 7}),
-        FCDescriptor({7, 21}, {21}, {}, {13, 7}),
-        FCDescriptor({7, 21}, {21}, {}, {13, 7}),
-    },
-    {
-        FCDescriptor({7, 21}, {}, {}, {13, 7}),
-        FCDescriptor({7, 21}, {21}, {21}, {13, 7}),
-        FCDescriptor({7, 21}, {21}, {21}, {13, 7}),
-    },
+//     {
+//         FCDescriptor({7, 21}, {}, {}, {13, 7}),
+//         FCDescriptor({7, 21}, {}, {21}, {13, 7}),
+//         FCDescriptor({7, 21}, {}, {21}, {13, 7}),
+//     },
+//     {
+//         FCDescriptor({7, 21}, {}, {}, {13, 7}),
+//         FCDescriptor({7, 21}, {21}, {}, {13, 7}),
+//         FCDescriptor({7, 21}, {21}, {}, {13, 7}),
+//     },
+//     {
+//         FCDescriptor({7, 21}, {}, {}, {13, 7}),
+//         FCDescriptor({7, 21}, {21}, {21}, {13, 7}),
+//         FCDescriptor({7, 21}, {21}, {21}, {13, 7}),
+//     },
 
-    {
-        FCDescriptor({7, 21}, {}, {21}, {13, 7}),
-        FCDescriptor({7, 21}, {21}, {}, {13, 7}),
-        FCDescriptor({7, 21}, {21}, {}, {13, 7}),
-    },
-    {
-        FCDescriptor({7, 21}, {}, {21}, {13, 7}),
-        FCDescriptor({7, 21}, {21}, {21}, {13, 7}),
-        FCDescriptor({7, 21}, {21}, {21}, {13, 7}),
-    },
+//     {
+//         FCDescriptor({7, 21}, {}, {21}, {13, 7}),
+//         FCDescriptor({7, 21}, {21}, {}, {13, 7}),
+//         FCDescriptor({7, 21}, {21}, {}, {13, 7}),
+//     },
+//     {
+//         FCDescriptor({7, 21}, {}, {21}, {13, 7}),
+//         FCDescriptor({7, 21}, {21}, {21}, {13, 7}),
+//         FCDescriptor({7, 21}, {21}, {21}, {13, 7}),
+//     },
 
-    {
-        FCDescriptor({7, 21}, {21}, {}, {13, 7}),
-        FCDescriptor({7, 21}, {}, {21}, {13, 7}),
-        FCDescriptor({7, 21}, {}, {21}, {13, 7}),
-    },
-    {
-        FCDescriptor({7, 21}, {21}, {}, {13, 7}),
-        FCDescriptor({7, 21}, {21}, {21}, {13, 7}),
-        FCDescriptor({7, 21}, {21}, {21}, {13, 7}),
-    },
-};
+//     {
+//         FCDescriptor({7, 21}, {21}, {}, {13, 7}),
+//         FCDescriptor({7, 21}, {}, {21}, {13, 7}),
+//         FCDescriptor({7, 21}, {}, {21}, {13, 7}),
+//     },
+//     {
+//         FCDescriptor({7, 21}, {21}, {}, {13, 7}),
+//         FCDescriptor({7, 21}, {21}, {21}, {13, 7}),
+//         FCDescriptor({7, 21}, {21}, {21}, {13, 7}),
+//     },
+// };
 
-TEST_P(VPU_MergeParallelFCTest, MergeParallelFCMergeCases) {
-    const auto& testParams          = GetParam();
-    const auto& testInputDimensions = std::get<0>(testParams);
-    const auto& testFCDescriptors   = std::get<1>(testParams);
+// TEST_P(VPU_MergeParallelFCTest, MergeParallelFCMergeCases) {
+//     const auto& testParams          = GetParam();
+//     const auto& testInputDimensions = std::get<0>(testParams);
+//     const auto& testFCDescriptors   = std::get<1>(testParams);
 
-    CreateModelWithParallelFC(testInputDimensions, testFCDescriptors);
-    ASSERT_NO_THROW(Compile());
+//     CreateModelWithParallelFC(testInputDimensions, testFCDescriptors);
+//     ASSERT_NO_THROW(Compile());
 
-    AssertMergedCorrectly(testInputDimensions, testFCDescriptors);
-}
+//     AssertMergedCorrectly(testInputDimensions, testFCDescriptors);
+// }
 
-TEST_P(VPU_NoMergeParallelFCTest, NoMergeParallelFCMergeCases) {
-    const auto& testParams          = GetParam();
-    const auto& testInputDimensions = std::get<0>(testParams);
-    const auto& testFCDescriptors   = std::get<1>(testParams);
+// TEST_P(VPU_NoMergeParallelFCTest, NoMergeParallelFCMergeCases) {
+//     const auto& testParams          = GetParam();
+//     const auto& testInputDimensions = std::get<0>(testParams);
+//     const auto& testFCDescriptors   = std::get<1>(testParams);
 
-    CreateModelWithParallelFC(testInputDimensions, testFCDescriptors);
-    ASSERT_NO_THROW(Compile());
+//     CreateModelWithParallelFC(testInputDimensions, testFCDescriptors);
+//     ASSERT_NO_THROW(Compile());
 
-    AssertNotMergedCorrectly(testInputDimensions, testFCDescriptors);
-}
+//     AssertNotMergedCorrectly(testInputDimensions, testFCDescriptors);
+// }
 
-INSTANTIATE_TEST_SUITE_P(MergeParallelFCTest, VPU_MergeParallelFCTest, testing::Combine(
-    testing::ValuesIn(inputDimensions),
-    testing::ValuesIn(FCDescriptorsMerge)
-));
+// INSTANTIATE_TEST_CASE_P(MergeParallelFCTest, VPU_MergeParallelFCTest, testing::Combine(
+//     testing::ValuesIn(inputDimensions),
+//     testing::ValuesIn(FCDescriptorsMerge)
+// ));
 
-INSTANTIATE_TEST_SUITE_P(NoMergeParallelFCTest, VPU_NoMergeParallelFCTest, testing::Combine(
-    testing::ValuesIn(inputDimensions),
-    testing::ValuesIn(FCDescriptorsNoMerge)
-));
+// INSTANTIATE_TEST_CASE_P(NoMergeParallelFCTest, VPU_NoMergeParallelFCTest, testing::Combine(
+//     testing::ValuesIn(inputDimensions),
+//     testing::ValuesIn(FCDescriptorsNoMerge)
+// ));
 
-}
+// }
 

--- a/inference-engine/tests_deprecated/unit/engines/vpu/merge_permute_stages_tests.cpp
+++ b/inference-engine/tests_deprecated/unit/engines/vpu/merge_permute_stages_tests.cpp
@@ -1,401 +1,401 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
 
-#include "graph_transformer_tests.hpp"
+// #include "graph_transformer_tests.hpp"
 
-using namespace vpu;
+// using namespace vpu;
 
-class VPU_MergePermuteTest : public GraphTransformerTest {
- protected:
-    PassSet pipeline;
-    Model model;
-    using PermuteDims = PermutationDimsMap;
- public:
-    void SetUp() override {
-        GraphTransformerTest::SetUp();
-        InitCompileEnv();
-    }
+// class VPU_MergePermuteTest : public GraphTransformerTest {
+//  protected:
+//     PassSet pipeline;
+//     Model model;
+//     using PermuteDims = PermutationDimsMap;
+//  public:
+//     void SetUp() override {
+//         GraphTransformerTest::SetUp();
+//         InitCompileEnv();
+//     }
 
-    void CreateModelWithTwoPermutes(const DimsOrder& layout, const PermuteDims& firstPermute, const PermuteDims& secondPermute) {
-        model = CreateModel();
+//     void CreateModelWithTwoPermutes(const DimsOrder& layout, const PermuteDims& firstPermute, const PermuteDims& secondPermute) {
+//         model = CreateModel();
 
-        const DataDesc dataDesc(DataType::FP16, layout, MakeStubDims(layout));
-        auto input = model->addInputData("Input", dataDesc);
-        model->attrs().set<int>("numInputs", 1);
+//         const DataDesc dataDesc(DataType::FP16, layout, MakeStubDims(layout));
+//         auto input = model->addInputData("Input", dataDesc);
+//         model->attrs().set<int>("numInputs", 1);
 
-        auto output = model->addOutputData("Output", dataDesc);
-        model->attrs().set<int>("numOutputs", 1);
+//         auto output = model->addOutputData("Output", dataDesc);
+//         model->attrs().set<int>("numOutputs", 1);
 
-        auto data1 = model->addNewData("data1", dataDesc);
+//         auto data1 = model->addNewData("data1", dataDesc);
 
-        stageBuilder->addPermuteStage(model,
-                                      "Permute1",
-                                      nullptr,
-                                      input,
-                                      data1,
-                                      firstPermute
-                                    );
+//         stageBuilder->addPermuteStage(model,
+//                                       "Permute1",
+//                                       nullptr,
+//                                       input,
+//                                       data1,
+//                                       firstPermute
+//                                     );
 
-        stageBuilder->addPermuteStage(model,
-                                      "Permute2",
-                                      nullptr,
-                                      data1,
-                                      output,
-                                      secondPermute
-                                    );
-        InitPipeline();
-    }
+//         stageBuilder->addPermuteStage(model,
+//                                       "Permute2",
+//                                       nullptr,
+//                                       data1,
+//                                       output,
+//                                       secondPermute
+//                                     );
+//         InitPipeline();
+//     }
 
-    void CreateModelWithThreePermutes(const DimsOrder& layout, const PermuteDims& firstPermute, const PermuteDims& secondPermute, const PermuteDims& thirdPermute) {
-        model = CreateModel();
+//     void CreateModelWithThreePermutes(const DimsOrder& layout, const PermuteDims& firstPermute, const PermuteDims& secondPermute, const PermuteDims& thirdPermute) {
+//         model = CreateModel();
 
-        const DataDesc dataDesc(DataType::FP16, layout, MakeStubDims(layout));
-        auto input = model->addInputData("Input", dataDesc);
-        model->attrs().set<int>("numInputs", 1);
+//         const DataDesc dataDesc(DataType::FP16, layout, MakeStubDims(layout));
+//         auto input = model->addInputData("Input", dataDesc);
+//         model->attrs().set<int>("numInputs", 1);
 
-        auto output = model->addOutputData("Output", dataDesc);
-        model->attrs().set<int>("numOutputs", 1);
+//         auto output = model->addOutputData("Output", dataDesc);
+//         model->attrs().set<int>("numOutputs", 1);
 
-        auto data1 = model->addNewData("data1", dataDesc);
-        auto data2 = model->addNewData("data2", dataDesc);
+//         auto data1 = model->addNewData("data1", dataDesc);
+//         auto data2 = model->addNewData("data2", dataDesc);
 
-        stageBuilder->addPermuteStage(model,
-                                      "Permute1",
-                                      nullptr,
-                                      input,
-                                      data1,
-                                      firstPermute
-                                    );
+//         stageBuilder->addPermuteStage(model,
+//                                       "Permute1",
+//                                       nullptr,
+//                                       input,
+//                                       data1,
+//                                       firstPermute
+//                                     );
 
-        stageBuilder->addPermuteStage(model,
-                                      "Permute2",
-                                      nullptr,
-                                      data1,
-                                      data2,
-                                      secondPermute
-                                    );
+//         stageBuilder->addPermuteStage(model,
+//                                       "Permute2",
+//                                       nullptr,
+//                                       data1,
+//                                       data2,
+//                                       secondPermute
+//                                     );
 
-        stageBuilder->addPermuteStage(model,
-                                      "Permute3",
-                                      nullptr,
-                                      data2,
-                                      output,
-                                      thirdPermute
-                                    );
-        InitPipeline();
-    }
+//         stageBuilder->addPermuteStage(model,
+//                                       "Permute3",
+//                                       nullptr,
+//                                       data2,
+//                                       output,
+//                                       thirdPermute
+//                                     );
+//         InitPipeline();
+//     }
 
-    void CreateModelWithPermuteAndReorder(const DimsOrder& layoutIn, const DimsOrder& layoutOut, const PermuteDims& firstPermute) {
-        model = CreateModel();
+//     void CreateModelWithPermuteAndReorder(const DimsOrder& layoutIn, const DimsOrder& layoutOut, const PermuteDims& firstPermute) {
+//         model = CreateModel();
 
-        const DataDesc dataDescIn (DataType::FP16, layoutIn,  MakeStubDims(layoutIn));
-        const DataDesc dataDescOut(DataType::FP16, layoutOut, MakeStubDims(layoutIn));  // That's not a typo: we use same Dim-to-size mapping for in and out.
-        auto input = model->addInputData("Input", dataDescIn);
-        model->attrs().set<int>("numInputs", 1);
+//         const DataDesc dataDescIn (DataType::FP16, layoutIn,  MakeStubDims(layoutIn));
+//         const DataDesc dataDescOut(DataType::FP16, layoutOut, MakeStubDims(layoutIn));  // That's not a typo: we use same Dim-to-size mapping for in and out.
+//         auto input = model->addInputData("Input", dataDescIn);
+//         model->attrs().set<int>("numInputs", 1);
 
-        auto output = model->addOutputData("Output", dataDescOut);
-        model->attrs().set<int>("numOutputs", 1);
+//         auto output = model->addOutputData("Output", dataDescOut);
+//         model->attrs().set<int>("numOutputs", 1);
 
-        auto data1 = model->addNewData("data1", dataDescIn);
+//         auto data1 = model->addNewData("data1", dataDescIn);
 
-        stageBuilder->addPermuteStage(model,
-                                      "Permute",
-                                      nullptr,
-                                      input,
-                                      data1,
-                                      firstPermute
-                                    );
+//         stageBuilder->addPermuteStage(model,
+//                                       "Permute",
+//                                       nullptr,
+//                                       input,
+//                                       data1,
+//                                       firstPermute
+//                                     );
 
-        stageBuilder->addReorderStage(model,
-                                      "Reorder",
-                                      nullptr,
-                                      data1,
-                                      output
-                                    );
-        InitPipeline();
-    }
+//         stageBuilder->addReorderStage(model,
+//                                       "Reorder",
+//                                       nullptr,
+//                                       data1,
+//                                       output
+//                                     );
+//         InitPipeline();
+//     }
 
-    void InitPipeline() {
-        pipeline = PassSet();
-        pipeline.addPass(passManager->dumpModel("initial"));
-        pipeline.addPass(passManager->adjustDataLayout());
-        pipeline.addPass(passManager->dumpModel("adjustDataLayout"));
-        pipeline.addPass(passManager->mergePermuteStages());
-        pipeline.addPass(passManager->dumpModel("mergePermuteStages"));
-        pipeline.addPass(passManager->adjustDataLocation());
-        pipeline.addPass(passManager->dumpModel("adjustDataLocation"));
-        pipeline.addPass(passManager->finalCheck());
-    }
+//     void InitPipeline() {
+//         pipeline = PassSet();
+//         pipeline.addPass(passManager->dumpModel("initial"));
+//         pipeline.addPass(passManager->adjustDataLayout());
+//         pipeline.addPass(passManager->dumpModel("adjustDataLayout"));
+//         pipeline.addPass(passManager->mergePermuteStages());
+//         pipeline.addPass(passManager->dumpModel("mergePermuteStages"));
+//         pipeline.addPass(passManager->adjustDataLocation());
+//         pipeline.addPass(passManager->dumpModel("adjustDataLocation"));
+//         pipeline.addPass(passManager->finalCheck());
+//     }
 
-    // Create fake dimension size array, using dimension count from layout
-    DimValues MakeStubDims(const DimsOrder& layout)
-    {
-        const auto perm = layout.toPermutation();
-        const int numDms = layout.numDims();
-        DimValues dims;
-        for (int ind = 0; ind < numDms; ++ind) {
-            dims.set(perm[ind], 2 + ind * 2); // 2, 4, 6 ...
-        }
-        return dims;
-    }
+//     // Create fake dimension size array, using dimension count from layout
+//     DimValues MakeStubDims(const DimsOrder& layout)
+//     {
+//         const auto perm = layout.toPermutation();
+//         const int numDms = layout.numDims();
+//         DimValues dims;
+//         for (int ind = 0; ind < numDms; ++ind) {
+//             dims.set(perm[ind], 2 + ind * 2); // 2, 4, 6 ...
+//         }
+//         return dims;
+//     }
 
-    const PermuteDims& GetPermuteDimsForStage(size_t index) {
-        auto stages = model->getStages();
-        auto stageIter = stages.begin();
-        std::advance(stageIter, index);
-        auto permuteStage = *stageIter;
+//     const PermuteDims& GetPermuteDimsForStage(size_t index) {
+//         auto stages = model->getStages();
+//         auto stageIter = stages.begin();
+//         std::advance(stageIter, index);
+//         auto permuteStage = *stageIter;
 
-        IE_ASSERT(permuteStage->type() == StageType::Permute);
-        return permuteStage->attrs().get<PermutationDimsMap>("permutation");
-    }
+//         IE_ASSERT(permuteStage->type() == StageType::Permute);
+//         return permuteStage->attrs().get<PermutationDimsMap>("permutation");
+//     }
 
-};
-TEST_F(VPU_MergePermuteTest, InternalFunctions) {
-    // Meaning of integer permutation vectors:
-    // suppose you have vector {1, 2, 0}, expand it in mapping, where key would be vector index:
-    // [0] = 1
-    // [1] = 2
-    // [2] = 0
-    // The key is destination dimension, and the value is the source dimension.
-    // For CHW, C==2, H==1, W==0 index, so permutation above would be equal to:
-    // W <- H
-    // H <- C
-    // C <- W
+// };
+// TEST_F(VPU_MergePermuteTest, InternalFunctions) {
+//     // Meaning of integer permutation vectors:
+//     // suppose you have vector {1, 2, 0}, expand it in mapping, where key would be vector index:
+//     // [0] = 1
+//     // [1] = 2
+//     // [2] = 0
+//     // The key is destination dimension, and the value is the source dimension.
+//     // For CHW, C==2, H==1, W==0 index, so permutation above would be equal to:
+//     // W <- H
+//     // H <- C
+//     // C <- W
 
-    const auto order = DimsOrder::NCDHW;
-    auto origMapping = PermuteDims{{Dim::N, Dim::C}, {Dim::C, Dim::D}, {Dim::D, Dim::H}, {Dim::H, Dim::W}, {Dim::W, Dim::N}};
-    auto permVector = permuteMapToVector(origMapping, order, order);
-    {
-        ASSERT_EQ(permVector, (PermutationIndexVector{4, 0, 1, 2, 3}));
-        auto identityCheckMapping = permuteVectorToMap(permVector, order, order);
-        ASSERT_EQ(origMapping, identityCheckMapping);
-    }
+//     const auto order = DimsOrder::NCDHW;
+//     auto origMapping = PermuteDims{{Dim::N, Dim::C}, {Dim::C, Dim::D}, {Dim::D, Dim::H}, {Dim::H, Dim::W}, {Dim::W, Dim::N}};
+//     auto permVector = permuteMapToVector(origMapping, order, order);
+//     {
+//         ASSERT_EQ(permVector, (PermutationIndexVector{4, 0, 1, 2, 3}));
+//         auto identityCheckMapping = permuteVectorToMap(permVector, order, order);
+//         ASSERT_EQ(origMapping, identityCheckMapping);
+//     }
 
-    {
-        auto permVectorCombined = combinePermutationVectors(permVector, permVector);
-        ASSERT_EQ(permVectorCombined, (PermutationIndexVector{3, 4, 0, 1, 2}));
-        auto combinedMapping = permuteVectorToMap(permVectorCombined, order, order);
-        auto identityCombinedMapping = PermuteDims{{Dim::N, Dim::D}, {Dim::C, Dim::H}, {Dim::D, Dim::W}, {Dim::H, Dim::N}, {Dim::W, Dim::C}};
-        ASSERT_EQ(combinedMapping, identityCombinedMapping);
+//     {
+//         auto permVectorCombined = combinePermutationVectors(permVector, permVector);
+//         ASSERT_EQ(permVectorCombined, (PermutationIndexVector{3, 4, 0, 1, 2}));
+//         auto combinedMapping = permuteVectorToMap(permVectorCombined, order, order);
+//         auto identityCombinedMapping = PermuteDims{{Dim::N, Dim::D}, {Dim::C, Dim::H}, {Dim::D, Dim::W}, {Dim::H, Dim::N}, {Dim::W, Dim::C}};
+//         ASSERT_EQ(combinedMapping, identityCombinedMapping);
 
-    }
-    {
-        auto permVectorCombined = combinePermutationVectors(PermutationIndexVector{0, 1, 2, 4, 3}, PermutationIndexVector{0, 1, 3, 2, 4});
-        ASSERT_EQ(permVectorCombined, (PermutationIndexVector{0, 1, 4, 2, 3}));
-    }
+//     }
+//     {
+//         auto permVectorCombined = combinePermutationVectors(PermutationIndexVector{0, 1, 2, 4, 3}, PermutationIndexVector{0, 1, 3, 2, 4});
+//         ASSERT_EQ(permVectorCombined, (PermutationIndexVector{0, 1, 4, 2, 3}));
+//     }
 
-    {
-        auto permVector1 = permuteMapToVector(PermuteDims{{Dim::H, Dim::C}, {Dim::W, Dim::H}, {Dim::C, Dim::W}},
-                                              DimsOrder::CHW, DimsOrder::CHW);
-        ASSERT_EQ(permVector1, (PermutationIndexVector{1, 2, 0}));
-        auto permVector2 = permuteMapToVector(PermuteDims{{Dim::H, Dim::C}, {Dim::C, Dim::H}, {Dim::W, Dim::W}},
-                                              DimsOrder::CHW, DimsOrder::CHW);
-        ASSERT_EQ(permVector2, (PermutationIndexVector{0, 2, 1}));
+//     {
+//         auto permVector1 = permuteMapToVector(PermuteDims{{Dim::H, Dim::C}, {Dim::W, Dim::H}, {Dim::C, Dim::W}},
+//                                               DimsOrder::CHW, DimsOrder::CHW);
+//         ASSERT_EQ(permVector1, (PermutationIndexVector{1, 2, 0}));
+//         auto permVector2 = permuteMapToVector(PermuteDims{{Dim::H, Dim::C}, {Dim::C, Dim::H}, {Dim::W, Dim::W}},
+//                                               DimsOrder::CHW, DimsOrder::CHW);
+//         ASSERT_EQ(permVector2, (PermutationIndexVector{0, 2, 1}));
 
-        auto permVectorCombined = combinePermutationVectors(permVector1, permVector2);
-        ASSERT_EQ(permVectorCombined, (PermutationIndexVector{1, 0, 2}));
-    }
-}
+//         auto permVectorCombined = combinePermutationVectors(permVector1, permVector2);
+//         ASSERT_EQ(permVectorCombined, (PermutationIndexVector{1, 0, 2}));
+//     }
+// }
 
-TEST_F(VPU_MergePermuteTest, TwoPermutes) {
-    // TLDR: {H, C} + {W, H} => {W, C}.
-    // How does permutation should combine?
-    // according to stages/permute.cpp, parsePermute() stage, in  PermutationDimsMap first is destination dimension,
-    // and the second value in pair - is source dimension.
-    // for {Dim::W, Dim::H}, data in W output will be relevant to H dimension.
-    // If we have {Dim::H, Dim::C} in first permute, and {Dim::W, Dim::H} in the second, the resulting permutation is
-    // {Dim::W, Dim::C}  - basically, we taking the dest (first in pair) from the second permute,
-    // and the source (second in pair) value  from the first permute.
+// TEST_F(VPU_MergePermuteTest, TwoPermutes) {
+//     // TLDR: {H, C} + {W, H} => {W, C}.
+//     // How does permutation should combine?
+//     // according to stages/permute.cpp, parsePermute() stage, in  PermutationDimsMap first is destination dimension,
+//     // and the second value in pair - is source dimension.
+//     // for {Dim::W, Dim::H}, data in W output will be relevant to H dimension.
+//     // If we have {Dim::H, Dim::C} in first permute, and {Dim::W, Dim::H} in the second, the resulting permutation is
+//     // {Dim::W, Dim::C}  - basically, we taking the dest (first in pair) from the second permute,
+//     // and the source (second in pair) value  from the first permute.
 
-    // clockwise permutes on 4 dims.
-    CreateModelWithTwoPermutes(DimsOrder::NCHW,
-                               PermuteDims{{Dim::W, Dim::H}, {Dim::H, Dim::C}, {Dim::C, Dim::N}, {Dim::N, Dim::W}},
-                               PermuteDims{{Dim::W, Dim::H}, {Dim::H, Dim::C}, {Dim::C, Dim::N}, {Dim::N, Dim::W}});
-    ASSERT_NO_THROW(pipeline.run(model));
-    ASSERT_EQ(model->getStages().size(), 1U);
-    ASSERT_EQ(GetPermuteDimsForStage(0), (PermuteDims{{Dim::W, Dim::C}, {Dim::H, Dim::N}, {Dim::C, Dim::W}, {Dim::N, Dim::H}}));
+//     // clockwise permutes on 4 dims.
+//     CreateModelWithTwoPermutes(DimsOrder::NCHW,
+//                                PermuteDims{{Dim::W, Dim::H}, {Dim::H, Dim::C}, {Dim::C, Dim::N}, {Dim::N, Dim::W}},
+//                                PermuteDims{{Dim::W, Dim::H}, {Dim::H, Dim::C}, {Dim::C, Dim::N}, {Dim::N, Dim::W}});
+//     ASSERT_NO_THROW(pipeline.run(model));
+//     ASSERT_EQ(model->getStages().size(), 1U);
+//     ASSERT_EQ(GetPermuteDimsForStage(0), (PermuteDims{{Dim::W, Dim::C}, {Dim::H, Dim::N}, {Dim::C, Dim::W}, {Dim::N, Dim::H}}));
 
-    // counter-clockwise permutes on 5 dims
-    CreateModelWithTwoPermutes(DimsOrder::NCDHW,
-                               PermuteDims{{Dim::N, Dim::C}, {Dim::C, Dim::D}, {Dim::D, Dim::H}, {Dim::H, Dim::W}, {Dim::W, Dim::N}},
-                               PermuteDims{{Dim::N, Dim::C}, {Dim::C, Dim::D}, {Dim::D, Dim::H}, {Dim::H, Dim::W}, {Dim::W, Dim::N}});
-    ASSERT_NO_THROW(pipeline.run(model));
-    ASSERT_EQ(model->getStages().size(), 1U);
-    ASSERT_EQ(GetPermuteDimsForStage(0), (PermuteDims{{Dim::N, Dim::D}, {Dim::C, Dim::H}, {Dim::D, Dim::W}, {Dim::H, Dim::N}, {Dim::W, Dim::C}}));
+//     // counter-clockwise permutes on 5 dims
+//     CreateModelWithTwoPermutes(DimsOrder::NCDHW,
+//                                PermuteDims{{Dim::N, Dim::C}, {Dim::C, Dim::D}, {Dim::D, Dim::H}, {Dim::H, Dim::W}, {Dim::W, Dim::N}},
+//                                PermuteDims{{Dim::N, Dim::C}, {Dim::C, Dim::D}, {Dim::D, Dim::H}, {Dim::H, Dim::W}, {Dim::W, Dim::N}});
+//     ASSERT_NO_THROW(pipeline.run(model));
+//     ASSERT_EQ(model->getStages().size(), 1U);
+//     ASSERT_EQ(GetPermuteDimsForStage(0), (PermuteDims{{Dim::N, Dim::D}, {Dim::C, Dim::H}, {Dim::D, Dim::W}, {Dim::H, Dim::N}, {Dim::W, Dim::C}}));
 
-    // partial compensation (3 dim)
-    CreateModelWithTwoPermutes(DimsOrder::CHW,
-                               PermuteDims{{Dim::H, Dim::C}, {Dim::W, Dim::H}, {Dim::C, Dim::W}},
-                               PermuteDims{{Dim::C, Dim::H}, {Dim::W, Dim::W}, {Dim::H, Dim::C}});
-    ASSERT_NO_THROW(pipeline.run(model));
-    ASSERT_EQ(model->getStages().size(), 1U);
-    ASSERT_EQ(GetPermuteDimsForStage(0), (PermuteDims{{Dim::H, Dim::W}, {Dim::W, Dim::H}, {Dim::C, Dim::C}}));
+//     // partial compensation (3 dim)
+//     CreateModelWithTwoPermutes(DimsOrder::CHW,
+//                                PermuteDims{{Dim::H, Dim::C}, {Dim::W, Dim::H}, {Dim::C, Dim::W}},
+//                                PermuteDims{{Dim::C, Dim::H}, {Dim::W, Dim::W}, {Dim::H, Dim::C}});
+//     ASSERT_NO_THROW(pipeline.run(model));
+//     ASSERT_EQ(model->getStages().size(), 1U);
+//     ASSERT_EQ(GetPermuteDimsForStage(0), (PermuteDims{{Dim::H, Dim::W}, {Dim::W, Dim::H}, {Dim::C, Dim::C}}));
 
-    // two compensating permutes (3 dim)
-    CreateModelWithTwoPermutes(DimsOrder::CHW,
-                               PermuteDims{{Dim::W, Dim::H}, {Dim::H, Dim::C}, {Dim::C, Dim::W}},
-                               PermuteDims{{Dim::H, Dim::W}, {Dim::C, Dim::H}, {Dim::W, Dim::C}});
-    ASSERT_NO_THROW(pipeline.run(model));
-    ASSERT_EQ(model->getStages().size(), 1U);
-    ASSERT_EQ(model->getStages().front()->type(), StageType::Copy);
-}
+//     // two compensating permutes (3 dim)
+//     CreateModelWithTwoPermutes(DimsOrder::CHW,
+//                                PermuteDims{{Dim::W, Dim::H}, {Dim::H, Dim::C}, {Dim::C, Dim::W}},
+//                                PermuteDims{{Dim::H, Dim::W}, {Dim::C, Dim::H}, {Dim::W, Dim::C}});
+//     ASSERT_NO_THROW(pipeline.run(model));
+//     ASSERT_EQ(model->getStages().size(), 1U);
+//     ASSERT_EQ(model->getStages().front()->type(), StageType::Copy);
+// }
 
-TEST_F(VPU_MergePermuteTest, ThreePermutes) {
-    // three compensating permutes (3 dim)
-    CreateModelWithThreePermutes(DimsOrder::CHW,
-                                 PermuteDims{{Dim::W, Dim::H}, {Dim::H, Dim::C}, {Dim::C, Dim::W}},
-                                 PermuteDims{{Dim::W, Dim::H}, {Dim::H, Dim::C}, {Dim::C, Dim::W}},
-                                 PermuteDims{{Dim::W, Dim::H}, {Dim::H, Dim::C}, {Dim::C, Dim::W}});
-    ASSERT_NO_THROW(pipeline.run(model));
-    ASSERT_EQ(model->getStages().size(), 1U);
-    ASSERT_EQ(model->getStages().front()->type(), StageType::Copy);
+// TEST_F(VPU_MergePermuteTest, ThreePermutes) {
+//     // three compensating permutes (3 dim)
+//     CreateModelWithThreePermutes(DimsOrder::CHW,
+//                                  PermuteDims{{Dim::W, Dim::H}, {Dim::H, Dim::C}, {Dim::C, Dim::W}},
+//                                  PermuteDims{{Dim::W, Dim::H}, {Dim::H, Dim::C}, {Dim::C, Dim::W}},
+//                                  PermuteDims{{Dim::W, Dim::H}, {Dim::H, Dim::C}, {Dim::C, Dim::W}});
+//     ASSERT_NO_THROW(pipeline.run(model));
+//     ASSERT_EQ(model->getStages().size(), 1U);
+//     ASSERT_EQ(model->getStages().front()->type(), StageType::Copy);
 
-    // three merging permutes (5 dim)
-    CreateModelWithThreePermutes(DimsOrder::NCDHW,
-                                 PermuteDims{{Dim::N, Dim::C}, {Dim::C, Dim::N}, {Dim::D, Dim::D}, {Dim::H, Dim::H}, {Dim::W, Dim::W}},
-                                 PermuteDims{{Dim::N, Dim::N}, {Dim::C, Dim::D}, {Dim::D, Dim::C}, {Dim::H, Dim::H}, {Dim::W, Dim::W}},
-                                 PermuteDims{{Dim::N, Dim::N}, {Dim::C, Dim::C}, {Dim::D, Dim::H}, {Dim::H, Dim::D}, {Dim::W, Dim::W}});
-    ASSERT_NO_THROW(pipeline.run(model));
-    ASSERT_EQ(model->getStages().size(), 1U);
-    ASSERT_EQ(GetPermuteDimsForStage(0), (PermuteDims{{Dim::H, Dim::N}, {Dim::C, Dim::D}, {Dim::N, Dim::C}, {Dim::D, Dim::H}, {Dim::W, Dim::W}}));
-}
+//     // three merging permutes (5 dim)
+//     CreateModelWithThreePermutes(DimsOrder::NCDHW,
+//                                  PermuteDims{{Dim::N, Dim::C}, {Dim::C, Dim::N}, {Dim::D, Dim::D}, {Dim::H, Dim::H}, {Dim::W, Dim::W}},
+//                                  PermuteDims{{Dim::N, Dim::N}, {Dim::C, Dim::D}, {Dim::D, Dim::C}, {Dim::H, Dim::H}, {Dim::W, Dim::W}},
+//                                  PermuteDims{{Dim::N, Dim::N}, {Dim::C, Dim::C}, {Dim::D, Dim::H}, {Dim::H, Dim::D}, {Dim::W, Dim::W}});
+//     ASSERT_NO_THROW(pipeline.run(model));
+//     ASSERT_EQ(model->getStages().size(), 1U);
+//     ASSERT_EQ(GetPermuteDimsForStage(0), (PermuteDims{{Dim::H, Dim::N}, {Dim::C, Dim::D}, {Dim::N, Dim::C}, {Dim::D, Dim::H}, {Dim::W, Dim::W}}));
+// }
 
-TEST_F(VPU_MergePermuteTest, TwoSequences) {
-    model = CreateModel();
-    const auto layout = DimsOrder::CHW;
-    const DataDesc dataDesc(DataType::FP16, layout, MakeStubDims(layout));
-    auto input = model->addInputData("Input", dataDesc);
-    model->attrs().set<int>("numInputs", 1);
+// TEST_F(VPU_MergePermuteTest, TwoSequences) {
+//     model = CreateModel();
+//     const auto layout = DimsOrder::CHW;
+//     const DataDesc dataDesc(DataType::FP16, layout, MakeStubDims(layout));
+//     auto input = model->addInputData("Input", dataDesc);
+//     model->attrs().set<int>("numInputs", 1);
 
-    auto output = model->addOutputData("Output", dataDesc);
-    model->attrs().set<int>("numOutputs", 1);
+//     auto output = model->addOutputData("Output", dataDesc);
+//     model->attrs().set<int>("numOutputs", 1);
 
-    // sequence: input - Permute11 - data1 - Permute12 - data2 - Copy - data3 - Permute21 - data4 - Permute22 - output
+//     // sequence: input - Permute11 - data1 - Permute12 - data2 - Copy - data3 - Permute21 - data4 - Permute22 - output
 
-    auto data1 = model->addNewData("data1", dataDesc);
-    auto data2 = model->addNewData("data2", dataDesc);
-    auto data3 = model->addNewData("data3", dataDesc);
-    auto data4 = model->addNewData("data4", dataDesc);
+//     auto data1 = model->addNewData("data1", dataDesc);
+//     auto data2 = model->addNewData("data2", dataDesc);
+//     auto data3 = model->addNewData("data3", dataDesc);
+//     auto data4 = model->addNewData("data4", dataDesc);
 
-    stageBuilder->addPermuteStage(model,
-                                  "Permute11",
-                                  nullptr,
-                                  input,
-                                  data1,
-                                  PermuteDims{{Dim::W, Dim::H}, {Dim::H, Dim::C}, {Dim::C, Dim::W}}
-                                );
-    stageBuilder->addPermuteStage(model,
-                                  "Permute12",
-                                  nullptr,
-                                  data1,
-                                  data2,
-                                  PermuteDims{{Dim::W, Dim::H}, {Dim::H, Dim::C}, {Dim::C, Dim::W}}
-                                );
+//     stageBuilder->addPermuteStage(model,
+//                                   "Permute11",
+//                                   nullptr,
+//                                   input,
+//                                   data1,
+//                                   PermuteDims{{Dim::W, Dim::H}, {Dim::H, Dim::C}, {Dim::C, Dim::W}}
+//                                 );
+//     stageBuilder->addPermuteStage(model,
+//                                   "Permute12",
+//                                   nullptr,
+//                                   data1,
+//                                   data2,
+//                                   PermuteDims{{Dim::W, Dim::H}, {Dim::H, Dim::C}, {Dim::C, Dim::W}}
+//                                 );
 
-    stageBuilder->addCopyStage(model,
-                               "Copy",
-                               nullptr,
-                               data2,
-                               data3,
-                               ""
-                               );
+//     stageBuilder->addCopyStage(model,
+//                                "Copy",
+//                                nullptr,
+//                                data2,
+//                                data3,
+//                                ""
+//                                );
 
-    stageBuilder->addPermuteStage(model,
-                                  "Permute21",
-                                  nullptr,
-                                  data3,
-                                  data4,
-                                  PermuteDims{{Dim::W, Dim::H}, {Dim::H, Dim::C}, {Dim::C, Dim::W}}
-                                );
-    stageBuilder->addPermuteStage(model,
-                                  "Permute22",
-                                  nullptr,
-                                  data4,
-                                  output,
-                                  PermuteDims{{Dim::W, Dim::H}, {Dim::H, Dim::C}, {Dim::C, Dim::W}}
-                                );
-    InitPipeline();
+//     stageBuilder->addPermuteStage(model,
+//                                   "Permute21",
+//                                   nullptr,
+//                                   data3,
+//                                   data4,
+//                                   PermuteDims{{Dim::W, Dim::H}, {Dim::H, Dim::C}, {Dim::C, Dim::W}}
+//                                 );
+//     stageBuilder->addPermuteStage(model,
+//                                   "Permute22",
+//                                   nullptr,
+//                                   data4,
+//                                   output,
+//                                   PermuteDims{{Dim::W, Dim::H}, {Dim::H, Dim::C}, {Dim::C, Dim::W}}
+//                                 );
+//     InitPipeline();
 
-    ASSERT_NO_THROW(pipeline.run(model));
-    ASSERT_EQ(model->getStages().size(), 3U); // 2 Permute and 1 copy stage.
-}
+//     ASSERT_NO_THROW(pipeline.run(model));
+//     ASSERT_EQ(model->getStages().size(), 3U); // 2 Permute and 1 copy stage.
+// }
 
-TEST_F(VPU_MergePermuteTest, OutputBeteweenPermutes) {
-    model = CreateModel();
-    const auto layout = DimsOrder::CHW;
-    const DataDesc dataDesc(DataType::FP16, layout, MakeStubDims(layout));
-    auto input = model->addInputData("Input", dataDesc);
-    model->attrs().set<int>("numInputs", 1);
+// TEST_F(VPU_MergePermuteTest, OutputBeteweenPermutes) {
+//     model = CreateModel();
+//     const auto layout = DimsOrder::CHW;
+//     const DataDesc dataDesc(DataType::FP16, layout, MakeStubDims(layout));
+//     auto input = model->addInputData("Input", dataDesc);
+//     model->attrs().set<int>("numInputs", 1);
 
-    auto output1 = model->addOutputData("Output1", dataDesc);
-    auto output2 = model->addOutputData("Output2", dataDesc);
-    model->attrs().set<int>("numOutputs", 2);
+//     auto output1 = model->addOutputData("Output1", dataDesc);
+//     auto output2 = model->addOutputData("Output2", dataDesc);
+//     model->attrs().set<int>("numOutputs", 2);
 
-    // sequence: input - Permute1 - Output1 - Permute2 - Output2
+//     // sequence: input - Permute1 - Output1 - Permute2 - Output2
 
-    stageBuilder->addPermuteStage(model,
-                                  "Permute1",
-                                  nullptr,
-                                  input,
-                                  output1,
-                                  PermuteDims{{Dim::W, Dim::H}, {Dim::H, Dim::C}, {Dim::C, Dim::W}}
-                                );
-    stageBuilder->addPermuteStage(model,
-                                  "Permute2",
-                                  nullptr,
-                                  output1,
-                                  output2,
-                                  PermuteDims{{Dim::W, Dim::H}, {Dim::H, Dim::C}, {Dim::C, Dim::W}}
-                                );
-    InitPipeline();
+//     stageBuilder->addPermuteStage(model,
+//                                   "Permute1",
+//                                   nullptr,
+//                                   input,
+//                                   output1,
+//                                   PermuteDims{{Dim::W, Dim::H}, {Dim::H, Dim::C}, {Dim::C, Dim::W}}
+//                                 );
+//     stageBuilder->addPermuteStage(model,
+//                                   "Permute2",
+//                                   nullptr,
+//                                   output1,
+//                                   output2,
+//                                   PermuteDims{{Dim::W, Dim::H}, {Dim::H, Dim::C}, {Dim::C, Dim::W}}
+//                                 );
+//     InitPipeline();
 
-    ASSERT_NO_THROW(pipeline.run(model));
-    ASSERT_EQ(model->getStages().size(), 2U);
-}
+//     ASSERT_NO_THROW(pipeline.run(model));
+//     ASSERT_EQ(model->getStages().size(), 2U);
+// }
 
-TEST_F(VPU_MergePermuteTest, DataSourceSplitBeteweenPermutes) {
-    model = CreateModel();
-    const auto layout = DimsOrder::CHW;
-    const DataDesc dataDesc(DataType::FP16, layout, MakeStubDims(layout));
-    auto input = model->addInputData("Input", dataDesc);
-    model->attrs().set<int>("numInputs", 1);
+// TEST_F(VPU_MergePermuteTest, DataSourceSplitBeteweenPermutes) {
+//     model = CreateModel();
+//     const auto layout = DimsOrder::CHW;
+//     const DataDesc dataDesc(DataType::FP16, layout, MakeStubDims(layout));
+//     auto input = model->addInputData("Input", dataDesc);
+//     model->attrs().set<int>("numInputs", 1);
 
-    auto output1 = model->addOutputData("Output1", dataDesc);
-    auto output2 = model->addOutputData("Output2", dataDesc);
-    model->attrs().set<int>("numOutputs", 2);
+//     auto output1 = model->addOutputData("Output1", dataDesc);
+//     auto output2 = model->addOutputData("Output2", dataDesc);
+//     model->attrs().set<int>("numOutputs", 2);
 
-    auto data1 = model->addNewData("data1", dataDesc);
+//     auto data1 = model->addNewData("data1", dataDesc);
 
-    // sequence: input - Permute1 - data1 - Permute2 - Output1
-    //                                    \ Copy     - Output2
+//     // sequence: input - Permute1 - data1 - Permute2 - Output1
+//     //                                    \ Copy     - Output2
 
-    stageBuilder->addPermuteStage(model,
-                                  "Permute1",
-                                  nullptr,
-                                  input,
-                                  data1,
-                                  PermuteDims{{Dim::W, Dim::H}, {Dim::H, Dim::C}, {Dim::C, Dim::W}}
-                                );
-    stageBuilder->addPermuteStage(model,
-                                  "Permute2",
-                                  nullptr,
-                                  data1,
-                                  output1,
-                                  PermuteDims{{Dim::W, Dim::H}, {Dim::H, Dim::C}, {Dim::C, Dim::W}}
-                                );
-    stageBuilder->addCopyStage(model, "Copy", nullptr, data1, output2, "");
-    InitPipeline();
+//     stageBuilder->addPermuteStage(model,
+//                                   "Permute1",
+//                                   nullptr,
+//                                   input,
+//                                   data1,
+//                                   PermuteDims{{Dim::W, Dim::H}, {Dim::H, Dim::C}, {Dim::C, Dim::W}}
+//                                 );
+//     stageBuilder->addPermuteStage(model,
+//                                   "Permute2",
+//                                   nullptr,
+//                                   data1,
+//                                   output1,
+//                                   PermuteDims{{Dim::W, Dim::H}, {Dim::H, Dim::C}, {Dim::C, Dim::W}}
+//                                 );
+//     stageBuilder->addCopyStage(model, "Copy", nullptr, data1, output2, "");
+//     InitPipeline();
 
-    ASSERT_NO_THROW(pipeline.run(model));
-    ASSERT_EQ(model->getStages().size(), 3U);
-}
+//     ASSERT_NO_THROW(pipeline.run(model));
+//     ASSERT_EQ(model->getStages().size(), 3U);
+// }
 
-TEST_F(VPU_MergePermuteTest, PermuteAndReorder) {
-    CreateModelWithPermuteAndReorder(DimsOrder::CHW,
-                                     DimsOrder::HWC,
-                                     PermuteDims{{Dim::W, Dim::W}, {Dim::H, Dim::C}, {Dim::C, Dim::H}});
-    ASSERT_NO_THROW(pipeline.run(model));
-    ASSERT_EQ(model->getStages().size(), 1U);
-    ASSERT_EQ(GetPermuteDimsForStage(0), (PermuteDims{{Dim::W, Dim::W}, {Dim::H, Dim::C}, {Dim::C, Dim::H}}));
-}
+// TEST_F(VPU_MergePermuteTest, PermuteAndReorder) {
+//     CreateModelWithPermuteAndReorder(DimsOrder::CHW,
+//                                      DimsOrder::HWC,
+//                                      PermuteDims{{Dim::W, Dim::W}, {Dim::H, Dim::C}, {Dim::C, Dim::H}});
+//     ASSERT_NO_THROW(pipeline.run(model));
+//     ASSERT_EQ(model->getStages().size(), 1U);
+//     ASSERT_EQ(GetPermuteDimsForStage(0), (PermuteDims{{Dim::W, Dim::W}, {Dim::H, Dim::C}, {Dim::C, Dim::H}}));
+// }

--- a/inference-engine/tests_deprecated/unit/engines/vpu/replace_deconv_by_conv_tests.cpp
+++ b/inference-engine/tests_deprecated/unit/engines/vpu/replace_deconv_by_conv_tests.cpp
@@ -1,128 +1,128 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
 
-#include "graph_transformer_tests.hpp"
+// #include "graph_transformer_tests.hpp"
 
-using namespace vpu;
+// using namespace vpu;
 
-class VPU_ReplaceDeconvByConvTest : public GraphTransformerTest {
- protected:
-    PassSet pipeline;
-    Model model;
+// class VPU_ReplaceDeconvByConvTest : public GraphTransformerTest {
+//  protected:
+//     PassSet pipeline;
+//     Model model;
 
- public:
-    void InitDeconvStage(
-        int kernelx,
-        int kernely,
-        int inputX=16,
-        int inputY=16,
-        bool onlySwConvAdaptation = false,
-        bool isOutput4D = true) {
+//  public:
+//     void InitDeconvStage(
+//         int kernelx,
+//         int kernely,
+//         int inputX=16,
+//         int inputY=16,
+//         bool onlySwConvAdaptation = false,
+//         bool isOutput4D = true) {
 
-        int kernelStrideX = 1;
-        int kernelStrideY = 1;
-        int dilationX = 1;
-        int dilationY = 1;
-        model = CreateModel();
+//         int kernelStrideX = 1;
+//         int kernelStrideY = 1;
+//         int dilationX = 1;
+//         int dilationY = 1;
+//         model = CreateModel();
 
-        auto input = model->addInputData(
-            "Input",
-            DataDesc(DataType::FP16, DimsOrder::NCHW, {inputX, inputY, 2, 1}));
-        model->attrs().set<int>("numInputs", 1);
+//         auto input = model->addInputData(
+//             "Input",
+//             DataDesc(DataType::FP16, DimsOrder::NCHW, {inputX, inputY, 2, 1}));
+//         model->attrs().set<int>("numInputs", 1);
 
-        Data output;
-        if (isOutput4D) {
-            output = model->addOutputData(
-                "Output",
-                DataDesc(DataType::FP16,
-                              DimsOrder::NCHW,
-                              {kernelx + (inputX - 1) * kernelStrideX, kernely + (inputY - 1) * kernelStrideY, 2, 1}));
-        } else {
-            output = model->addOutputData(
-                "Output",
-                DataDesc(DataType::FP16,
-                              DimsOrder::CHW,
-                              {kernelx + (inputX - 1) * kernelStrideX, kernely + (inputY - 1) * kernelStrideY, 2}));
-        }
+//         Data output;
+//         if (isOutput4D) {
+//             output = model->addOutputData(
+//                 "Output",
+//                 DataDesc(DataType::FP16,
+//                               DimsOrder::NCHW,
+//                               {kernelx + (inputX - 1) * kernelStrideX, kernely + (inputY - 1) * kernelStrideY, 2, 1}));
+//         } else {
+//             output = model->addOutputData(
+//                 "Output",
+//                 DataDesc(DataType::FP16,
+//                               DimsOrder::CHW,
+//                               {kernelx + (inputX - 1) * kernelStrideX, kernely + (inputY - 1) * kernelStrideY, 2}));
+//         }
 
-        auto deconv = std::make_shared<ie::DeconvolutionLayer>(ie::LayerParams{"deconv", "Deconvolution", ie::Precision::FP16});
-        deconv->_kernel_x = kernelx;
-        deconv->_kernel_y = kernely;
-        deconv->_stride_x = kernelStrideX;
-        deconv->_stride_y = kernelStrideY;
-        deconv->_dilation_x = dilationX;
-        deconv->_dilation_x = dilationY;
+//         auto deconv = std::make_shared<ie::DeconvolutionLayer>(ie::LayerParams{"deconv", "Deconvolution", ie::Precision::FP16});
+//         deconv->_kernel_x = kernelx;
+//         deconv->_kernel_y = kernely;
+//         deconv->_stride_x = kernelStrideX;
+//         deconv->_stride_y = kernelStrideY;
+//         deconv->_dilation_x = dilationX;
+//         deconv->_dilation_x = dilationY;
 
-        deconv->_weights = ie::make_shared_blob<short>({ ie::Precision::FP16, {static_cast<size_t>(kernelx * kernely * 2 * 2)}, ie::Layout::C });
-        deconv->_weights->allocate();
+//         deconv->_weights = ie::make_shared_blob<short>({ ie::Precision::FP16, {static_cast<size_t>(kernelx * kernely * 2 * 2)}, ie::Layout::C });
+//         deconv->_weights->allocate();
 
-        frontEnd->parseDeconvolution(model, deconv, {input}, {output});
+//         frontEnd->parseDeconvolution(model, deconv, {input}, {output});
 
-        pipeline.addPass(passManager->dumpModel("initial"));
+//         pipeline.addPass(passManager->dumpModel("initial"));
 
-        // if deconv converted to conv than swConvAdaptaion will work - if not will got an exception
-        pipeline.addPass(passManager->replaceDeconvByConv());
-        pipeline.addPass(passManager->dumpModel("replaceDeconvByConv"));
+//         // if deconv converted to conv than swConvAdaptaion will work - if not will got an exception
+//         pipeline.addPass(passManager->replaceDeconvByConv());
+//         pipeline.addPass(passManager->dumpModel("replaceDeconvByConv"));
 
-        pipeline.addPass(passManager->swConvAdaptation());
-        pipeline.addPass(passManager->dumpModel("swConvAdaptation"));
+//         pipeline.addPass(passManager->swConvAdaptation());
+//         pipeline.addPass(passManager->dumpModel("swConvAdaptation"));
 
-        if (!onlySwConvAdaptation) {
-            pipeline.addPass(passManager->adjustDataLayout());
-            pipeline.addPass(passManager->dumpModel("adjustDataLayout"));
+//         if (!onlySwConvAdaptation) {
+//             pipeline.addPass(passManager->adjustDataLayout());
+//             pipeline.addPass(passManager->dumpModel("adjustDataLayout"));
 
-            pipeline.addPass(passManager->processSpecialStages());
-            pipeline.addPass(passManager->dumpModel("processSpecialStages"));
+//             pipeline.addPass(passManager->processSpecialStages());
+//             pipeline.addPass(passManager->dumpModel("processSpecialStages"));
 
-            pipeline.addPass(passManager->adjustDataLocation());
-            pipeline.addPass(passManager->dumpModel("adjustDataLocation"));
+//             pipeline.addPass(passManager->adjustDataLocation());
+//             pipeline.addPass(passManager->dumpModel("adjustDataLocation"));
 
-            pipeline.addPass(passManager->finalCheck());
-        }
-    }
-};
+//             pipeline.addPass(passManager->finalCheck());
+//         }
+//     }
+// };
 
-TEST_F(VPU_ReplaceDeconvByConvTest, deconvReplacedByConvIfKernelSizeFitsHWUnit) {
-    InitCompileEnv();
-    InitDeconvStage(15, 15);
+// TEST_F(VPU_ReplaceDeconvByConvTest, deconvReplacedByConvIfKernelSizeFitsHWUnit) {
+//     InitCompileEnv();
+//     InitDeconvStage(15, 15);
 
-    ASSERT_NO_THROW(pipeline.run(model));
-}
+//     ASSERT_NO_THROW(pipeline.run(model));
+// }
 
-TEST_F(VPU_ReplaceDeconvByConvTest, deconvCannotBeReplacedByConvIfDisabledInConfig) {
-    config.compileConfig().hwBlackList.insert("deconv");
-    InitCompileEnv();
-    InitDeconvStage(16, 15);
+// TEST_F(VPU_ReplaceDeconvByConvTest, deconvCannotBeReplacedByConvIfDisabledInConfig) {
+//     config.compileConfig().hwBlackList.insert("deconv");
+//     InitCompileEnv();
+//     InitDeconvStage(16, 15);
 
-    ASSERT_ANY_THROW(pipeline.run(model));
-}
+//     ASSERT_ANY_THROW(pipeline.run(model));
+// }
 
-TEST_F(VPU_ReplaceDeconvByConvTest, deconvCannotBeReplacedByConvIfKernelSizeXToBig) {
-    InitCompileEnv();
-    InitDeconvStage(16, 15);
+// TEST_F(VPU_ReplaceDeconvByConvTest, deconvCannotBeReplacedByConvIfKernelSizeXToBig) {
+//     InitCompileEnv();
+//     InitDeconvStage(16, 15);
 
-    ASSERT_ANY_THROW(pipeline.run(model));
-}
+//     ASSERT_ANY_THROW(pipeline.run(model));
+// }
 
-TEST_F(VPU_ReplaceDeconvByConvTest, deconvCannotBeReplacedByConvIfKernelSizeYToBig) {
-    InitCompileEnv();
-    InitDeconvStage(15, 16);
+// TEST_F(VPU_ReplaceDeconvByConvTest, deconvCannotBeReplacedByConvIfKernelSizeYToBig) {
+//     InitCompileEnv();
+//     InitDeconvStage(15, 16);
 
-    ASSERT_ANY_THROW(pipeline.run(model));
-}
+//     ASSERT_ANY_THROW(pipeline.run(model));
+// }
 
-TEST_F(VPU_ReplaceDeconvByConvTest, deconvCannotBeReplacedByConvIfOutputNot4D) {
-    InitCompileEnv();
-    InitDeconvStage(15, 15, 16, 16, false, false);
+// TEST_F(VPU_ReplaceDeconvByConvTest, deconvCannotBeReplacedByConvIfOutputNot4D) {
+//     InitCompileEnv();
+//     InitDeconvStage(15, 15, 16, 16, false, false);
 
-    ASSERT_ANY_THROW(pipeline.run(model));
-}
+//     ASSERT_ANY_THROW(pipeline.run(model));
+// }
 
-TEST_F(VPU_ReplaceDeconvByConvTest, canNotDetectIm2CollBufferOverFlow) {
-    InitCompileEnv();
-    // remaining only sw conv adaptation - since big output might not fit shaves / cmx memory, but we need an im2coll error here
-    InitDeconvStage(15, 15, 16, 20000, true);
+// TEST_F(VPU_ReplaceDeconvByConvTest, canNotDetectIm2CollBufferOverFlow) {
+//     InitCompileEnv();
+//     // remaining only sw conv adaptation - since big output might not fit shaves / cmx memory, but we need an im2coll error here
+//     InitDeconvStage(15, 15, 16, 20000, true);
 
-    ASSERT_NO_THROW(pipeline.run(model));
-}
+//     ASSERT_NO_THROW(pipeline.run(model));
+// }

--- a/inference-engine/tests_deprecated/unit/engines/vpu/replace_with_reduce_mean_tests.cpp
+++ b/inference-engine/tests_deprecated/unit/engines/vpu/replace_with_reduce_mean_tests.cpp
@@ -1,54 +1,54 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
 
-#include <vpu/stages/stub_stage.hpp>
+// #include <vpu/stages/stub_stage.hpp>
 
-#include "graph_transformer_tests.hpp"
+// #include "graph_transformer_tests.hpp"
 
-using namespace vpu;
+// using namespace vpu;
 
-class VPU_ReplaceWithReduceMeanTest : public GraphTransformerTest {
-protected:
-    PassSet pipeline;
-    Model model;
-public:
-    void InitPipeline() {
-        pipeline = PassSet();
-        pipeline.addPass(passManager->dumpModel("initial"));
-        pipeline.addPass(passManager->replaceWithReduceMean());
-        pipeline.addPass(passManager->dumpModel("replaceWithReduceMean"));
-    }
-};
+// class VPU_ReplaceWithReduceMeanTest : public GraphTransformerTest {
+// protected:
+//     PassSet pipeline;
+//     Model model;
+// public:
+//     void InitPipeline() {
+//         pipeline = PassSet();
+//         pipeline.addPass(passManager->dumpModel("initial"));
+//         pipeline.addPass(passManager->replaceWithReduceMean());
+//         pipeline.addPass(passManager->dumpModel("replaceWithReduceMean"));
+//     }
+// };
 
-TEST_F(VPU_ReplaceWithReduceMeanTest, ReplaceAvgPoolWithReduceMean) {
-    InitCompileEnv();
+// TEST_F(VPU_ReplaceWithReduceMeanTest, ReplaceAvgPoolWithReduceMean) {
+//     InitCompileEnv();
 
-    model = CreateModel();
+//     model = CreateModel();
 
-    int inputW = 112;
-    int inputH = 112;
+//     int inputW = 112;
+//     int inputH = 112;
 
-    auto input = model->addInputData("Input", DataDesc(DataType::FP16, DimsOrder::NCHW, {inputW, inputH, 32, 1}));
-    model->attrs().set<int>("numInputs", 1);
+//     auto input = model->addInputData("Input", DataDesc(DataType::FP16, DimsOrder::NCHW, {inputW, inputH, 32, 1}));
+//     model->attrs().set<int>("numInputs", 1);
 
-    auto output = model->addOutputData("Output", DataDesc(DataType::FP16, DimsOrder::NCHW, {1, 1, 32, 1}));
-    model->attrs().set<int>("numOutputs", 1);
+//     auto output = model->addOutputData("Output", DataDesc(DataType::FP16, DimsOrder::NCHW, {1, 1, 32, 1}));
+//     model->attrs().set<int>("numOutputs", 1);
 
-    auto pool = std::make_shared<ie::PoolingLayer>(ie::LayerParams{"pool", "Pooling", ie::Precision::FP16});
+//     auto pool = std::make_shared<ie::PoolingLayer>(ie::LayerParams{"pool", "Pooling", ie::Precision::FP16});
 
-    pool->_kernel_x = inputW;
-    pool->_kernel_y = inputH;
-    pool->_stride_x = 1;
-    pool->_stride_y = 1;
-    pool->_type = ie::PoolingLayer::PoolType::AVG;
+//     pool->_kernel_x = inputW;
+//     pool->_kernel_y = inputH;
+//     pool->_stride_x = 1;
+//     pool->_stride_y = 1;
+//     pool->_type = ie::PoolingLayer::PoolType::AVG;
 
-    frontEnd->parsePooling(model, pool, {input}, {output});
+//     frontEnd->parsePooling(model, pool, {input}, {output});
 
-    InitPipeline();
+//     InitPipeline();
 
-    ASSERT_NO_THROW(pipeline.run(model));
-    ASSERT_EQ(model->getStages().size(), 1);
-    auto stages = model->getStages();
-    ASSERT_EQ(stages.front()->type(), StageType::ReduceMean);
-}
+//     ASSERT_NO_THROW(pipeline.run(model));
+//     ASSERT_EQ(model->getStages().size(), 1);
+//     auto stages = model->getStages();
+//     ASSERT_EQ(stages.front()->type(), StageType::ReduceMean);
+// }

--- a/inference-engine/tests_deprecated/unit/engines/vpu/replace_with_screlu_tests.cpp
+++ b/inference-engine/tests_deprecated/unit/engines/vpu/replace_with_screlu_tests.cpp
@@ -1,111 +1,111 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
 
-#include <vpu/stages/stub_stage.hpp>
+// #include <vpu/stages/stub_stage.hpp>
 
-#include "graph_transformer_tests.hpp"
-#include "vpu/model/data_contents/ie_blob_content.hpp"
+// #include "graph_transformer_tests.hpp"
+// #include "vpu/model/data_contents/ie_blob_content.hpp"
 
-using namespace vpu;
+// using namespace vpu;
 
-class VPU_ReplaceWithSCReluTest : public GraphTransformerTest {
-protected:
-    PassSet pipeline;
-    Model model;
-public:
-    void CreateModelSCRelu() {
-        model = CreateModel();
+// class VPU_ReplaceWithSCReluTest : public GraphTransformerTest {
+// protected:
+//     PassSet pipeline;
+//     Model model;
+// public:
+//     void CreateModelSCRelu() {
+//         model = CreateModel();
 
-        int inputW = 16;
-        int inputH = 16;
+//         int inputW = 16;
+//         int inputH = 16;
 
-        auto input = model->addInputData("Input", DataDesc(DataType::FP16, DimsOrder::NCHW, {inputW, inputH, 2, 1}));
-        model->attrs().set<int>("numInputs", 1);
+//         auto input = model->addInputData("Input", DataDesc(DataType::FP16, DimsOrder::NCHW, {inputW, inputH, 2, 1}));
+//         model->attrs().set<int>("numInputs", 1);
 
-        int kernelx = 16;
-        int kernely = 16;
-        int kernelStrideX = 1;
-        int kernelStrideY = 1;
-        int dilationX = 1;
-        int dilationY = 1;
+//         int kernelx = 16;
+//         int kernely = 16;
+//         int kernelStrideX = 1;
+//         int kernelStrideY = 1;
+//         int dilationX = 1;
+//         int dilationY = 1;
 
-        int outW = (inputW - kernelx) / kernelStrideX + 1;
-        int outH = (inputH - kernely) / kernelStrideY + 1;
+//         int outW = (inputW - kernelx) / kernelStrideX + 1;
+//         int outH = (inputH - kernely) / kernelStrideY + 1;
 
-        auto data0 = model->addNewData("data0", DataDesc(DataType::FP16, DimsOrder::NCHW, {outW, outH, 2, 1}));
-        auto data1 = model->addNewData("data1", DataDesc(DataType::FP16, DimsOrder::NCHW, {outW, outH, 2, 1}));
-        auto data2 = model->addNewData("data2", DataDesc(DataType::FP16, DimsOrder::NCHW, {outW, outH, 4, 1}));
-        auto data3 = model->addNewData("data3", DataDesc(DataType::FP16, DimsOrder::NCHW, {outW, outH, 4, 1}));
+//         auto data0 = model->addNewData("data0", DataDesc(DataType::FP16, DimsOrder::NCHW, {outW, outH, 2, 1}));
+//         auto data1 = model->addNewData("data1", DataDesc(DataType::FP16, DimsOrder::NCHW, {outW, outH, 2, 1}));
+//         auto data2 = model->addNewData("data2", DataDesc(DataType::FP16, DimsOrder::NCHW, {outW, outH, 4, 1}));
+//         auto data3 = model->addNewData("data3", DataDesc(DataType::FP16, DimsOrder::NCHW, {outW, outH, 4, 1}));
 
-        auto output = model->addOutputData("Output", DataDesc(DataType::FP16, DimsOrder::NCHW, {outW, outH, 4, 1}));
-        model->attrs().set<int>("numOutputs", 1);
+//         auto output = model->addOutputData("Output", DataDesc(DataType::FP16, DimsOrder::NCHW, {outW, outH, 4, 1}));
+//         model->attrs().set<int>("numOutputs", 1);
 
-        auto scales = model->addConstData("scales", DataDesc(DataType::FP16, DimsOrder::C, {4}));
+//         auto scales = model->addConstData("scales", DataDesc(DataType::FP16, DimsOrder::C, {4}));
 
-        float negSlope = -1.0f;
+//         float negSlope = -1.0f;
 
-        auto conv = std::make_shared<ie::ConvolutionLayer>(ie::LayerParams{"conv", "StubConv", ie::Precision::FP16});
+//         auto conv = std::make_shared<ie::ConvolutionLayer>(ie::LayerParams{"conv", "StubConv", ie::Precision::FP16});
 
-        conv->_kernel_x = kernelx;
-        conv->_kernel_y = kernely;
-        conv->_stride_x = kernelStrideX;
-        conv->_stride_y = kernelStrideY;
-        conv->_dilation_x = dilationX;
-        conv->_dilation_x = dilationY;
+//         conv->_kernel_x = kernelx;
+//         conv->_kernel_y = kernely;
+//         conv->_stride_x = kernelStrideX;
+//         conv->_stride_y = kernelStrideY;
+//         conv->_dilation_x = dilationX;
+//         conv->_dilation_x = dilationY;
 
-        conv->_weights = ie::make_shared_blob<short>({ ie::Precision::FP16, {static_cast<size_t>(kernelx * kernely * 2 * 2)}, ie::Layout::C });
-        conv->_weights->allocate();
+//         conv->_weights = ie::make_shared_blob<short>({ ie::Precision::FP16, {static_cast<size_t>(kernelx * kernely * 2 * 2)}, ie::Layout::C });
+//         conv->_weights->allocate();
 
-        frontEnd->parseConvolution(model, conv, {input}, {data0});
+//         frontEnd->parseConvolution(model, conv, {input}, {data0});
 
-        stageBuilder->addPowerStage(model,
-                                    "Power",
-                                    nullptr,
-                                    -1.0f,
-                                    1.0f,
-                                    0.0f,
-                                    data0,
-                                    data1);
+//         stageBuilder->addPowerStage(model,
+//                                     "Power",
+//                                     nullptr,
+//                                     -1.0f,
+//                                     1.0f,
+//                                     0.0f,
+//                                     data0,
+//                                     data1);
 
-        stageBuilder->addConcatStage(model,
-                                    "Concat",
-                                    nullptr,
-                                    Dim::C,
-                                    {data0, data1},
-                                    data2);
+//         stageBuilder->addConcatStage(model,
+//                                     "Concat",
+//                                     nullptr,
+//                                     Dim::C,
+//                                     {data0, data1},
+//                                     data2);
 
-        stageBuilder->addScaleStage(model,
-                                    "ScaleShift",
-                                    nullptr,
-                                    data2,
-                                    scales,
-                                    data3);
+//         stageBuilder->addScaleStage(model,
+//                                     "ScaleShift",
+//                                     nullptr,
+//                                     data2,
+//                                     scales,
+//                                     data3);
 
-        stageBuilder->addReLUStage(model,
-                                    "Relu",
-                                    nullptr,
-                                    negSlope,
-                                    data3,
-                                    output);
+//         stageBuilder->addReLUStage(model,
+//                                     "Relu",
+//                                     nullptr,
+//                                     negSlope,
+//                                     data3,
+//                                     output);
 
-        InitPipeline();
-    }
+//         InitPipeline();
+//     }
 
-    void InitPipeline() {
-        pipeline = PassSet();
-        pipeline.addPass(passManager->dumpModel("initial"));
-        pipeline.addPass(passManager->replaceWithSCReLU());
-        pipeline.addPass(passManager->dumpModel("replaceWithSCReLU"));
-    }
-};
+//     void InitPipeline() {
+//         pipeline = PassSet();
+//         pipeline.addPass(passManager->dumpModel("initial"));
+//         pipeline.addPass(passManager->replaceWithSCReLU());
+//         pipeline.addPass(passManager->dumpModel("replaceWithSCReLU"));
+//     }
+// };
 
-TEST_F(VPU_ReplaceWithSCReluTest, CheckStagesReplacement) {
-    InitCompileEnv();
+// TEST_F(VPU_ReplaceWithSCReluTest, CheckStagesReplacement) {
+//     InitCompileEnv();
 
-    CreateModelSCRelu();
-    ASSERT_NO_THROW(pipeline.run(model));
-    ASSERT_EQ(model->getStages().size(), 2);
-    auto stages = model->getStages();
-    ASSERT_EQ(stages.back()->type(), StageType::SCRelu);
-}
+//     CreateModelSCRelu();
+//     ASSERT_NO_THROW(pipeline.run(model));
+//     ASSERT_EQ(model->getStages().size(), 2);
+//     auto stages = model->getStages();
+//     ASSERT_EQ(stages.back()->type(), StageType::SCRelu);
+// }

--- a/inference-engine/tests_deprecated/unit/engines/vpu/reshape_dilation_conv_tests.cpp
+++ b/inference-engine/tests_deprecated/unit/engines/vpu/reshape_dilation_conv_tests.cpp
@@ -1,85 +1,85 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
 
-#include "graph_transformer_tests.hpp"
+// #include "graph_transformer_tests.hpp"
 
-using namespace vpu;
+// using namespace vpu;
 
-class VPU_ReshapeDilationConvTest: public GraphTransformerTest {
-protected:
-    PassSet pipeline;
-    Model model;
+// class VPU_ReshapeDilationConvTest: public GraphTransformerTest {
+// protected:
+//     PassSet pipeline;
+//     Model model;
 
-public:
-    void InitDilationConvStage(int kernelx, int kernely, int dilationX,
-            int dilationY, int padX, int padY, int inputX = 16, int inputY = 16,
-            bool onlySwConvAdaptation = false) {
+// public:
+//     void InitDilationConvStage(int kernelx, int kernely, int dilationX,
+//             int dilationY, int padX, int padY, int inputX = 16, int inputY = 16,
+//             bool onlySwConvAdaptation = false) {
 
-        int kernelStrideX = 1;
-        int kernelStrideY = 1;
-        model = CreateModel();
+//         int kernelStrideX = 1;
+//         int kernelStrideY = 1;
+//         model = CreateModel();
 
-        auto input = model->addInputData("Input",
-                DataDesc(DataType::FP16, DimsOrder::NCHW,
-                        { inputX, inputY, 2, 1 }));
-        model->attrs().set<int>("numInputs", 1);
+//         auto input = model->addInputData("Input",
+//                 DataDesc(DataType::FP16, DimsOrder::NCHW,
+//                         { inputX, inputY, 2, 1 }));
+//         model->attrs().set<int>("numInputs", 1);
 
-        auto padx_new = padX - (kernelx - 1) * (dilationX - 1) / 2;
-        auto pady_new = padY - (kernely - 1) * (dilationY - 1) / 2;
-        Data output;
+//         auto padx_new = padX - (kernelx - 1) * (dilationX - 1) / 2;
+//         auto pady_new = padY - (kernely - 1) * (dilationY - 1) / 2;
+//         Data output;
 
-        output = model->addOutputData("Output",
-                DataDesc(DataType::FP16, DimsOrder::NCHW,
-                        { (inputX + 2 * padx_new - kernelx) / kernelStrideX + 1,
-                                (inputY + 2 * pady_new - kernely)
-                                        / kernelStrideY + 1, 2, 1 }));
+//         output = model->addOutputData("Output",
+//                 DataDesc(DataType::FP16, DimsOrder::NCHW,
+//                         { (inputX + 2 * padx_new - kernelx) / kernelStrideX + 1,
+//                                 (inputY + 2 * pady_new - kernely)
+//                                         / kernelStrideY + 1, 2, 1 }));
 
-        auto dilationconv = std::make_shared < ie::ConvolutionLayer
-                > (ie::LayerParams { "dilationconv", "StubConv",
-                        ie::Precision::FP16 });
-        dilationconv->_kernel_x = kernelx;
-        dilationconv->_kernel_y = kernely;
-        dilationconv->_stride_x = kernelStrideX;
-        dilationconv->_stride_y = kernelStrideY;
-        dilationconv->_dilation_x = dilationX;
-        dilationconv->_dilation_y = dilationY;
-        dilationconv->_padding_x = padX;
-        dilationconv->_padding_y = padY;
+//         auto dilationconv = std::make_shared < ie::ConvolutionLayer
+//                 > (ie::LayerParams { "dilationconv", "StubConv",
+//                         ie::Precision::FP16 });
+//         dilationconv->_kernel_x = kernelx;
+//         dilationconv->_kernel_y = kernely;
+//         dilationconv->_stride_x = kernelStrideX;
+//         dilationconv->_stride_y = kernelStrideY;
+//         dilationconv->_dilation_x = dilationX;
+//         dilationconv->_dilation_y = dilationY;
+//         dilationconv->_padding_x = padX;
+//         dilationconv->_padding_y = padY;
 
-        dilationconv->_weights = ie::make_shared_blob<short>(
-                { ie::Precision::FP16, { static_cast<size_t>(kernelx * kernely
-                        * 2 * 2) }, ie::Layout::C });
-        dilationconv->_weights->allocate();
+//         dilationconv->_weights = ie::make_shared_blob<short>(
+//                 { ie::Precision::FP16, { static_cast<size_t>(kernelx * kernely
+//                         * 2 * 2) }, ie::Layout::C });
+//         dilationconv->_weights->allocate();
 
-        frontEnd->parseConvolution(model, dilationconv, { input }, { output });
+//         frontEnd->parseConvolution(model, dilationconv, { input }, { output });
 
-        pipeline.addPass(passManager->dumpModel("initial"));
+//         pipeline.addPass(passManager->dumpModel("initial"));
 
-        pipeline.addPass(passManager->reshapeDilationConv());
-        pipeline.addPass(passManager->dumpModel("reshapeDilationConv"));
+//         pipeline.addPass(passManager->reshapeDilationConv());
+//         pipeline.addPass(passManager->dumpModel("reshapeDilationConv"));
 
-        pipeline.addPass(passManager->swConvAdaptation());
-        pipeline.addPass(passManager->dumpModel("swConvAdaptation"));
+//         pipeline.addPass(passManager->swConvAdaptation());
+//         pipeline.addPass(passManager->dumpModel("swConvAdaptation"));
 
-        if (!onlySwConvAdaptation) {
-            pipeline.addPass(passManager->adjustDataLayout());
-            pipeline.addPass(passManager->dumpModel("adjustDataLayout"));
+//         if (!onlySwConvAdaptation) {
+//             pipeline.addPass(passManager->adjustDataLayout());
+//             pipeline.addPass(passManager->dumpModel("adjustDataLayout"));
 
-            pipeline.addPass(passManager->processSpecialStages());
-            pipeline.addPass(passManager->dumpModel("processSpecialStages"));
+//             pipeline.addPass(passManager->processSpecialStages());
+//             pipeline.addPass(passManager->dumpModel("processSpecialStages"));
 
-            pipeline.addPass(passManager->adjustDataLocation());
-            pipeline.addPass(passManager->dumpModel("adjustDataLocation"));
+//             pipeline.addPass(passManager->adjustDataLocation());
+//             pipeline.addPass(passManager->dumpModel("adjustDataLocation"));
 
-            pipeline.addPass(passManager->finalCheck());
-        }
-    }
-};
+//             pipeline.addPass(passManager->finalCheck());
+//         }
+//     }
+// };
 
-TEST_F(VPU_ReshapeDilationConvTest, reshapeDilationConvIfFitsHWUnit) {
-    InitCompileEnv();
-    InitDilationConvStage(3, 3, 2, 2, 1, 1);
+// TEST_F(VPU_ReshapeDilationConvTest, reshapeDilationConvIfFitsHWUnit) {
+//     InitCompileEnv();
+//     InitDilationConvStage(3, 3, 2, 2, 1, 1);
 
-    ASSERT_NO_THROW(pipeline.run(model));
-}
+//     ASSERT_NO_THROW(pipeline.run(model));
+// }

--- a/inference-engine/tests_deprecated/unit/engines/vpu/sw_conv_adaptation.cpp
+++ b/inference-engine/tests_deprecated/unit/engines/vpu/sw_conv_adaptation.cpp
@@ -1,124 +1,124 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
 
-#include "graph_transformer_tests.hpp"
+// #include "graph_transformer_tests.hpp"
 
-#include <myriad_test_case.h>
-#include <precision_utils.h>
-#include <single_layer_common.hpp>
+// #include <myriad_test_case.h>
+// #include <precision_utils.h>
+// #include <single_layer_common.hpp>
 
-#include <random>
+// #include <random>
 
-using namespace vpu;
-using namespace ie;
+// using namespace vpu;
+// using namespace ie;
 
-struct param_size {
-    size_t x;
-    size_t y;
-};
+// struct param_size {
+//     size_t x;
+//     size_t y;
+// };
 
-using Kernel = param_size;
-using Stride = param_size;
-using Pad = param_size;
+// using Kernel = param_size;
+// using Stride = param_size;
+// using Pad = param_size;
 
-class VPU_SWConvolutionAdaptation : public GraphTransformerTest {
-protected:
-    PassSet pipeline;
-    Model model;
+// class VPU_SWConvolutionAdaptation : public GraphTransformerTest {
+// protected:
+//     PassSet pipeline;
+//     Model model;
 
-public:
-    void InitConvStage(
-            DimValues inDims,
-            int outChannels,
-            Kernel kernel,
-            Stride stride,
-            Pad pad,
-            int group = 1) {
-        model = CreateModel();
+// public:
+//     void InitConvStage(
+//             DimValues inDims,
+//             int outChannels,
+//             Kernel kernel,
+//             Stride stride,
+//             Pad pad,
+//             int group = 1) {
+//         model = CreateModel();
 
-        const auto input = model->addInputData(
-            "Input",
-            DataDesc(DataType::FP16, DimsOrder::NCHW, inDims));
-        model->attrs().set<int>("numInputs", 1);
+//         const auto input = model->addInputData(
+//             "Input",
+//             DataDesc(DataType::FP16, DimsOrder::NCHW, inDims));
+//         model->attrs().set<int>("numInputs", 1);
 
-        const auto outDims = DimValues{
-            {Dim::N, 1},
-            {Dim::C, outChannels},
-            {Dim::H, (inDims.get(Dim::H, 1) + 2 * pad.y - kernel.y) / stride.y + 1},
-            {Dim::W, (inDims.get(Dim::W, 1) + 2 * pad.x - kernel.x) / stride.x + 1}};
-        const auto outDesc = DataDesc(DataType::FP16, DimsOrder::NCHW, outDims);
-        const auto output = model->addOutputData("Output", outDesc);
+//         const auto outDims = DimValues{
+//             {Dim::N, 1},
+//             {Dim::C, outChannels},
+//             {Dim::H, (inDims.get(Dim::H, 1) + 2 * pad.y - kernel.y) / stride.y + 1},
+//             {Dim::W, (inDims.get(Dim::W, 1) + 2 * pad.x - kernel.x) / stride.x + 1}};
+//         const auto outDesc = DataDesc(DataType::FP16, DimsOrder::NCHW, outDims);
+//         const auto output = model->addOutputData("Output", outDesc);
 
-        const auto convLayer = std::make_shared<ConvolutionLayer>(
-            LayerParams{"conv", "Convolution", Precision::FP16});
-        convLayer->_kernel_x = kernel.x;
-        convLayer->_kernel_y = kernel.y;
-        convLayer->_stride_x = stride.x;
-        convLayer->_stride_y = stride.y;
-        convLayer->_padding_x = pad.y;
-        convLayer->_padding_y = pad.y;
-        convLayer->_group = group;
+//         const auto convLayer = std::make_shared<ConvolutionLayer>(
+//             LayerParams{"conv", "Convolution", Precision::FP16});
+//         convLayer->_kernel_x = kernel.x;
+//         convLayer->_kernel_y = kernel.y;
+//         convLayer->_stride_x = stride.x;
+//         convLayer->_stride_y = stride.y;
+//         convLayer->_padding_x = pad.y;
+//         convLayer->_padding_y = pad.y;
+//         convLayer->_group = group;
 
-        const auto weightsSize = kernel.x * kernel.y * inDims.get(Dim::C, 1) * outChannels;
-        convLayer->_weights = make_shared_blob<short>(
-            {Precision::FP16, {weightsSize}, Layout::C});
-        convLayer->_weights->allocate();
-        smallWeightsRange(convLayer->_weights);
+//         const auto weightsSize = kernel.x * kernel.y * inDims.get(Dim::C, 1) * outChannels;
+//         convLayer->_weights = make_shared_blob<short>(
+//             {Precision::FP16, {weightsSize}, Layout::C});
+//         convLayer->_weights->allocate();
+//         smallWeightsRange(convLayer->_weights);
 
-        const auto biasSize = static_cast<size_t>(outChannels);
-        convLayer->_biases = make_shared_blob<short>(
-            {Precision::FP16, {biasSize}, Layout::C});
-        convLayer->_weights->allocate();
-        smallWeightsRange(convLayer->_weights);
+//         const auto biasSize = static_cast<size_t>(outChannels);
+//         convLayer->_biases = make_shared_blob<short>(
+//             {Precision::FP16, {biasSize}, Layout::C});
+//         convLayer->_weights->allocate();
+//         smallWeightsRange(convLayer->_weights);
 
-        frontEnd->parseConvolution(model, convLayer, {input}, {output});
+//         frontEnd->parseConvolution(model, convLayer, {input}, {output});
 
-        pipeline.addPass(passManager->dumpModel("initial"));
+//         pipeline.addPass(passManager->dumpModel("initial"));
 
-        pipeline.addPass(passManager->analyzeWeightableLayers());
-        pipeline.addPass(passManager->dumpModel("analyzeWeightableLayers"));
+//         pipeline.addPass(passManager->analyzeWeightableLayers());
+//         pipeline.addPass(passManager->dumpModel("analyzeWeightableLayers"));
 
-        pipeline.addPass(passManager->hwConvTiling());
-        pipeline.addPass(passManager->dumpModel("hwConvTiling"));
+//         pipeline.addPass(passManager->hwConvTiling());
+//         pipeline.addPass(passManager->dumpModel("hwConvTiling"));
 
-        pipeline.addPass(passManager->swConvAdaptation());
-        pipeline.addPass(passManager->dumpModel("swConvAdaptation"));
-    }
-private:
-    static void smallWeightsRange(const Blob::Ptr& blob) {
-        const auto ptr = blob->buffer().as<ie_fp16*>();
+//         pipeline.addPass(passManager->swConvAdaptation());
+//         pipeline.addPass(passManager->dumpModel("swConvAdaptation"));
+//     }
+// private:
+//     static void smallWeightsRange(const Blob::Ptr& blob) {
+//         const auto ptr = blob->buffer().as<ie_fp16*>();
 
-        std::mt19937 generator(DEFAULT_SEED_VALUE);
-        std::uniform_real_distribution<float> dist(-1.f, 1.f);
+//         std::mt19937 generator(DEFAULT_SEED_VALUE);
+//         std::uniform_real_distribution<float> dist(-1.f, 1.f);
 
-        for (size_t count = 0 ; count < blob->size(); ++count) {
-            float val = dist(generator) / 512;
-            ptr[count] = PrecisionUtils::f32tof16(val);
-        }
-    }
-};
+//         for (size_t count = 0 ; count < blob->size(); ++count) {
+//             float val = dist(generator) / 512;
+//             ptr[count] = PrecisionUtils::f32tof16(val);
+//         }
+//     }
+// };
 
-TEST_F(VPU_SWConvolutionAdaptation, rightOrderOfBiasAndScaleStagesWhenUnsuccsessfullTiling) {
-    InitCompileEnv();
-    const auto inDims = DimValues{{Dim::N, 1},
-                                  {Dim::C, 1024},
-                                  {Dim::H, 38},
-                                  {Dim::W, 38}};
-    const int outChannels = 3240;
-    const Kernel kernel = {1, 1};
-    const Stride stride = {1, 1};
-    const Pad pad = {0, 0};
-    InitConvStage(inDims, outChannels, kernel, stride, pad);
+// TEST_F(VPU_SWConvolutionAdaptation, rightOrderOfBiasAndScaleStagesWhenUnsuccsessfullTiling) {
+//     InitCompileEnv();
+//     const auto inDims = DimValues{{Dim::N, 1},
+//                                   {Dim::C, 1024},
+//                                   {Dim::H, 38},
+//                                   {Dim::W, 38}};
+//     const int outChannels = 3240;
+//     const Kernel kernel = {1, 1};
+//     const Stride stride = {1, 1};
+//     const Pad pad = {0, 0};
+//     InitConvStage(inDims, outChannels, kernel, stride, pad);
 
-    ASSERT_NO_THROW(pipeline.run(model));
+//     ASSERT_NO_THROW(pipeline.run(model));
 
-    const auto& stages = model->getStages();
-    for (const auto& stage : stages) {
-        if (stage->type() == StageType::Scale) {
-            ASSERT_FALSE(std::any_of(stage->nextStages().begin(), stage->nextStages().end(),
-                                     [](const Stage& stage) { return stage->type() == StageType::Bias; }));
-            ASSERT_TRUE(stage->input(0)->producer()->type() == StageType::Bias);
-        }
-    }
-}
+//     const auto& stages = model->getStages();
+//     for (const auto& stage : stages) {
+//         if (stage->type() == StageType::Scale) {
+//             ASSERT_FALSE(std::any_of(stage->nextStages().begin(), stage->nextStages().end(),
+//                                      [](const Stage& stage) { return stage->type() == StageType::Bias; }));
+//             ASSERT_TRUE(stage->input(0)->producer()->type() == StageType::Bias);
+//         }
+//     }
+// }

--- a/inference-engine/tests_deprecated/unit/engines/vpu/uplift_activation_stages_tests.cpp
+++ b/inference-engine/tests_deprecated/unit/engines/vpu/uplift_activation_stages_tests.cpp
@@ -1,100 +1,100 @@
-// Copyright (C) 2018-2021 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+// // Copyright (C) 2018-2021 Intel Corporation
+// // SPDX-License-Identifier: Apache-2.0
+// //
 
-#include "graph_transformer_tests.hpp"
+// #include "graph_transformer_tests.hpp"
 
-using namespace vpu;
+// using namespace vpu;
 
-class VPU_UpliftReluTest : public GraphTransformerTest {
- protected:
-    PassSet pipeline;
-    Model model;
-    const DimsOrder layout  = DimsOrder::CHW;
-    const DataDesc dataDesc = {DataType::FP16, layout, {3, 5, 6}};
- public:
-    void InitPipeline() {
-        pipeline = PassSet();
-        pipeline.addPass(passManager->dumpModel("initial"));
-        pipeline.addPass(passManager->upliftActivationStages());
-        pipeline.addPass(passManager->dumpModel("upliftActivationStages"));
-        pipeline.addPass(passManager->adjustDataLayout());
-        pipeline.addPass(passManager->dumpModel("adjustDataLayout"));
-        pipeline.addPass(passManager->adjustDataLocation());
-        pipeline.addPass(passManager->dumpModel("adjustDataLocation"));
-        pipeline.addPass(passManager->finalCheck());
-    }
+// class VPU_UpliftReluTest : public GraphTransformerTest {
+//  protected:
+//     PassSet pipeline;
+//     Model model;
+//     const DimsOrder layout  = DimsOrder::CHW;
+//     const DataDesc dataDesc = {DataType::FP16, layout, {3, 5, 6}};
+//  public:
+//     void InitPipeline() {
+//         pipeline = PassSet();
+//         pipeline.addPass(passManager->dumpModel("initial"));
+//         pipeline.addPass(passManager->upliftActivationStages());
+//         pipeline.addPass(passManager->dumpModel("upliftActivationStages"));
+//         pipeline.addPass(passManager->adjustDataLayout());
+//         pipeline.addPass(passManager->dumpModel("adjustDataLayout"));
+//         pipeline.addPass(passManager->adjustDataLocation());
+//         pipeline.addPass(passManager->dumpModel("adjustDataLocation"));
+//         pipeline.addPass(passManager->finalCheck());
+//     }
 
-    Stage GetStage(size_t index) {
-        auto stages = model->getStages();
-        auto stageIter = stages.begin();
-        std::advance(stageIter, index);
-        return *stageIter;
-    }
+//     Stage GetStage(size_t index) {
+//         auto stages = model->getStages();
+//         auto stageIter = stages.begin();
+//         std::advance(stageIter, index);
+//         return *stageIter;
+//     }
 
-};
-TEST_F(VPU_UpliftReluTest, CopyAndRelu) {
-    InitCompileEnv();
+// };
+// TEST_F(VPU_UpliftReluTest, CopyAndRelu) {
+//     InitCompileEnv();
 
-    model = CreateModel();
-    auto input = model->addInputData("Input", dataDesc);
-    model->attrs().set<int>("numInputs", 1);
+//     model = CreateModel();
+//     auto input = model->addInputData("Input", dataDesc);
+//     model->attrs().set<int>("numInputs", 1);
 
-    auto output = model->addOutputData("Output", dataDesc);
-    model->attrs().set<int>("numOutputs", 1);
+//     auto output = model->addOutputData("Output", dataDesc);
+//     model->attrs().set<int>("numOutputs", 1);
 
-    auto data1 = model->addNewData("data1", dataDesc);
-    auto data2 = model->addNewData("data2", dataDesc);
+//     auto data1 = model->addNewData("data1", dataDesc);
+//     auto data2 = model->addNewData("data2", dataDesc);
 
-    // sequence : input                  - Copy1 - data1 - Copy2 - data2 - ReLU - Output
-    // optimized: input - ReLU - dataNew - Copy1 - data1 - Copy2 -              - Output
+//     // sequence : input                  - Copy1 - data1 - Copy2 - data2 - ReLU - Output
+//     // optimized: input - ReLU - dataNew - Copy1 - data1 - Copy2 -              - Output
 
-    stageBuilder->addCopyStage(model, "Copy1", nullptr,        input,  data1, "");
-    stageBuilder->addCopyStage(model, "Copy2", nullptr,        data1,  data2, "");
-    stageBuilder->addReLUStage(model, "ReLU",  nullptr, 0.01f, data2,  output);
-    InitPipeline();
+//     stageBuilder->addCopyStage(model, "Copy1", nullptr,        input,  data1, "");
+//     stageBuilder->addCopyStage(model, "Copy2", nullptr,        data1,  data2, "");
+//     stageBuilder->addReLUStage(model, "ReLU",  nullptr, 0.01f, data2,  output);
+//     InitPipeline();
 
-    ASSERT_NO_THROW(pipeline.run(model));
-    ASSERT_EQ(model->getStages().size(), 3U);
-    ASSERT_EQ(GetStage(0)->type(), StageType::LeakyRelu);
-}
+//     ASSERT_NO_THROW(pipeline.run(model));
+//     ASSERT_EQ(model->getStages().size(), 3U);
+//     ASSERT_EQ(GetStage(0)->type(), StageType::LeakyRelu);
+// }
 
 
-TEST_F(VPU_UpliftReluTest, StopOnNonTransitive) {
-    InitCompileEnv();
+// TEST_F(VPU_UpliftReluTest, StopOnNonTransitive) {
+//     InitCompileEnv();
 
-    model = CreateModel();
-    auto input = model->addInputData("Input", dataDesc);
-    model->attrs().set<int>("numInputs", 1);
+//     model = CreateModel();
+//     auto input = model->addInputData("Input", dataDesc);
+//     model->attrs().set<int>("numInputs", 1);
 
-    auto output1 = model->addOutputData("Output1", dataDesc);
-    auto output2 = model->addOutputData("Output2", dataDesc);
-    model->attrs().set<int>("numOutputs", 2);
+//     auto output1 = model->addOutputData("Output1", dataDesc);
+//     auto output2 = model->addOutputData("Output2", dataDesc);
+//     model->attrs().set<int>("numOutputs", 2);
 
-    auto data1 = model->addNewData("data1", dataDesc);
-    auto data2 = model->addNewData("data2", dataDesc);
+//     auto data1 = model->addNewData("data1", dataDesc);
+//     auto data2 = model->addNewData("data2", dataDesc);
 
-    // sequence : input  - Copy1 - data1                   - Copy2 - data2 - ReLU - Output1
-    //                                  \- CopyO - Output2
-    // optimized: input - Copy1 - data1  - ReLU  - dataNew - Copy2 -              - Output1
-    //                                  \- CopyO - Output2
+//     // sequence : input  - Copy1 - data1                   - Copy2 - data2 - ReLU - Output1
+//     //                                  \- CopyO - Output2
+//     // optimized: input - Copy1 - data1  - ReLU  - dataNew - Copy2 -              - Output1
+//     //                                  \- CopyO - Output2
 
-    auto copy1stage = stageBuilder->addCopyStage(model, "Copy1", nullptr,     input,  data1  , "");
-    auto copy2stage = stageBuilder->addCopyStage(model, "Copy2", nullptr,     data1,  data2  , "");
-    auto copyOstage = stageBuilder->addCopyStage(model, "CopyO", nullptr,     data1,  output2, "");
-    auto reluStage  = stageBuilder->addReLUStage(model, "ReLU",  nullptr, 0., data2,  output1);
-    InitPipeline();
+//     auto copy1stage = stageBuilder->addCopyStage(model, "Copy1", nullptr,     input,  data1  , "");
+//     auto copy2stage = stageBuilder->addCopyStage(model, "Copy2", nullptr,     data1,  data2  , "");
+//     auto copyOstage = stageBuilder->addCopyStage(model, "CopyO", nullptr,     data1,  output2, "");
+//     auto reluStage  = stageBuilder->addReLUStage(model, "ReLU",  nullptr, 0., data2,  output1);
+//     InitPipeline();
 
-    ASSERT_NO_THROW(pipeline.run(model));
-    ASSERT_EQ(model->getStages().size(), 4U);
-    ASSERT_EQ(GetStage(0)->type(), StageType::Copy);
-    ASSERT_EQ(copy1stage->input(0)->name(), input->name());
-    // Copy2 should have changed its input
-    ASSERT_NE(copy2stage->input(0)->name(), data1->name());
+//     ASSERT_NO_THROW(pipeline.run(model));
+//     ASSERT_EQ(model->getStages().size(), 4U);
+//     ASSERT_EQ(GetStage(0)->type(), StageType::Copy);
+//     ASSERT_EQ(copy1stage->input(0)->name(), input->name());
+//     // Copy2 should have changed its input
+//     ASSERT_NE(copy2stage->input(0)->name(), data1->name());
 
-    // inserted description should be identical
-    ASSERT_EQ(copy2stage->input(0)->desc().toTensorDesc(), data1->desc().toTensorDesc());
+//     // inserted description should be identical
+//     ASSERT_EQ(copy2stage->input(0)->desc().toTensorDesc(), data1->desc().toTensorDesc());
 
-    ASSERT_EQ(reluStage->input(0)->name(), data1->name());
-    ASSERT_EQ(copyOstage->input(0)->name(), data1->name());
-}
+//     ASSERT_EQ(reluStage->input(0)->name(), data1->name());
+//     ASSERT_EQ(copyOstage->input(0)->name(), data1->name());
+// }


### PR DESCRIPTION
### Details:

 - In this PR the switch from CNNLayer to std::shared_ptr\<ngraph::Node\> takes place

### Tasks:
 - [ ] Move all supporting functions / `enums` and `usings` into one place 
 - [x] Rewrite SSNMS
 - [ ] Remove VPU scale from plugin
 - [x] Rewrite `BackEnd::getMetaData` method
 - [ ] Rewrite `TensorIterator` parser
 - [ ] Rewrite `CustomLayers` parser
 - [x] Rewrite `FrontEnd::processTrivialCases` method
 - [ ] Rewrite `FrontEnd::addPreProcessStages`
 - [ ] Rewrite `FrontEnd::parseBatchNorm`
 - [ ] Add logic for switch `Crop`/`StridedSlice`
 - [ ] Add Template for `Eltwise/Reduce` parsers
 - [ ] Porting pass `convert_matmul_to_fc_or_gemm`
 - [ ] Add logic for `Interp/Resample`
 - [ ] Remove `MTCNN` parser
 - [ ] Rewrite `FrontEnd::parseScale`
 - [ ] Rewrite/turn on commented tests
 - [ ] Refactoring
 - [ ] Cherry-pick #5466
 - [ ] Validation
 - [ ] Internal validation
