### PR TITLE
Deprecated legacy maximum_value method

### DIFF
--- a/inference-engine/src/vpu/common/src/ngraph/operations/static_shape_broadcast.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/operations/static_shape_broadcast.cpp
@@ -8,7 +8,6 @@
 #include "vpu/utils/error.hpp"
 
 #include "ngraph/opsets/opset3.hpp"
-#include "ngraph/evaluator.hpp"
 #include <ngraph/validation_util.hpp>
 
 namespace ngraph { namespace vpu { namespace op {

--- a/inference-engine/src/vpu/common/src/ngraph/utilities.cpp
+++ b/inference-engine/src/vpu/common/src/ngraph/utilities.cpp
@@ -6,7 +6,6 @@
 
 #include "ngraph/opsets/opset3.hpp"
 #include "ngraph/opsets/opset5.hpp"
-#include "ngraph/evaluator.hpp"
 
 #include <numeric>
 

--- a/ngraph/core/include/ngraph/validation_util.hpp
+++ b/ngraph/core/include/ngraph/validation_util.hpp
@@ -234,7 +234,9 @@ namespace ngraph
     /// \brief Try to compute the maximum value of value
     /// \return (true, max_value) if can be determined, or (false, numeric_limits<uint64_t>::max())
     /// if not.
-    NGRAPH_DEPRECATED("Use evaluate_upper_bound: it would return HostTensorPtr to the value instead of a pair")
+    /// \deprecated Use evaluate_upper_bound instead
+    NGRAPH_DEPRECATED(
+        "Use evaluate_upper_bound: it would return HostTensorPtr to the value instead of a pair")
     NGRAPH_API std::pair<bool, uint64_t> maximum_value(const Output<Node>& value);
 
     /// \brief Evaluates outputs, treating values in value_map as already computed. value_map is

--- a/ngraph/core/include/ngraph/validation_util.hpp
+++ b/ngraph/core/include/ngraph/validation_util.hpp
@@ -234,6 +234,7 @@ namespace ngraph
     /// \brief Try to compute the maximum value of value
     /// \return (true, max_value) if can be determined, or (false, numeric_limits<uint64_t>::max())
     /// if not.
+    NGRAPH_DEPRECATED("Use evaluate_upper_bound: it would return HostTensorPtr to the value instead of a pair")
     NGRAPH_API std::pair<bool, uint64_t> maximum_value(const Output<Node>& value);
 
     /// \brief Evaluates outputs, treating values in value_map as already computed. value_map is


### PR DESCRIPTION
### Details:
 - *new value propagation mechanism is more reliable -- so we deprecate the legacy method which is unused currently in the product to delete it in the future with all the custom MaxValue structures*

### Tickets:
 - *58089*
