### PR TITLE
Parameter op - remove getter which returns non const ref to internals

### DIFF
--- a/inference-engine/tests/functional/shared_test_classes/src/single_layer/activation.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/single_layer/activation.cpp
@@ -218,7 +218,7 @@ void ActivationDynamicLayerTest::Run() {
 
     // make each parameter dimension dynamic with range {1 .. prev_dim * 2}
     for (const auto& parameter : params) {
-        auto& dynamic_pshape = parameter->get_partial_shape();
+        auto dynamic_pshape = parameter->get_partial_shape();
         NGRAPH_CHECK(dynamic_pshape.rank().is_static(),
                      "tests are not prepared to work with dynamically ranked inputs");
         for (size_t i = 0; i < dynamic_pshape.rank().get_length(); ++i) {

--- a/ngraph/core/include/ngraph/op/parameter.hpp
+++ b/ngraph/core/include/ngraph/op/parameter.hpp
@@ -41,7 +41,6 @@ namespace ngraph
                 void set_is_relevant_to_shapes(bool is_relevant);
 
                 const PartialShape& get_partial_shape() const { return m_partial_shape; }
-                PartialShape& get_partial_shape() { return m_partial_shape; }
                 void set_partial_shape(const PartialShape& partial_shape)
                 {
                     m_partial_shape = partial_shape;


### PR DESCRIPTION
### Details:
 - *Parameter op - remove getter which returns non const ref to internals*

