### PR TITLE
Disable Pruning Inside Model Optimizer

### DIFF
--- a/inference-engine/src/offline_transformations/src/moc_transformations.cpp
+++ b/inference-engine/src/offline_transformations/src/moc_transformations.cpp
@@ -12,9 +12,5 @@
 NGRAPH_RTTI_DEFINITION(ngraph::pass::MOCTransformations, "MOCTransformations", 0);
 
 bool ngraph::pass::MOCTransformations::run_on_function(std::shared_ptr<ngraph::Function> f) {
-    ngraph::pass::Manager m(get_pass_config());
-    m.register_pass<Pruning>();
-    m.run_passes(f);
-
     return false;
 }


### PR DESCRIPTION
### Details
Pruning transformation affects FP16 public models so we see unexpected performance degradation on some platforms. The decision was made to disable Pruning inside Model Optimizer in 21.4.