### PR TITLE
[IE CLDNN] Revert performance of unrolled loops

### DIFF
--- a/inference-engine/thirdparty/clDNN/src/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/inference-engine/thirdparty/clDNN/src/graph_optimizer/prepare_buffer_fusing.cpp
@@ -283,7 +283,7 @@ void prepare_buffer_fusing::run(program_impl& p) {
             }
 
             if (node.get_dependencies().size() == 1 && node.get_users().size() > 0) {
-                if (node.get_dependency(0).is_type<lstm_elt>()) {
+                if (p.is_loop_body() && node.get_dependency(0).is_type<lstm_elt>()) {
                     return;
                 }
                 // optimization is available for cropping across depth(features) only

--- a/inference-engine/thirdparty/clDNN/src/include/loop_inst.h
+++ b/inference-engine/thirdparty/clDNN/src/include/loop_inst.h
@@ -266,7 +266,7 @@ public:
         auto opts = get_program().get_options();
         std::vector<primitive_id> output_names_vec(output_names.begin(), output_names.end());
         opts.set_option(build_option::outputs(output_names_vec));
-        body_program = program_impl::build_program(get_program().get_engine(), body, opts, false);
+        body_program = program_impl::build_program(get_program().get_engine(), body, opts, false, false, true);
     }
 
     const primitive_id& get_trip_count_id() const { return get_primitive()->trip_count_id; }

--- a/inference-engine/thirdparty/clDNN/src/include/program_impl.h
+++ b/inference-engine/thirdparty/clDNN/src/include/program_impl.h
@@ -138,7 +138,8 @@ public:
                  topology_impl const& topology,
                  build_options const& options,
                  bool is_internal,
-                 bool no_optimizations = false);
+                 bool no_optimizations = false,
+                 bool is_body_program = false);
     /* constructor used to build a program from subset of nodes of other program (used in propagate_constants) */
     program_impl(engine& engine_ref,
                  std::set<std::shared_ptr<program_node>> const& nodes,
@@ -153,6 +154,7 @@ public:
     std::vector<program_node*>& get_outputs() {
         return outputs;
     }  // ToDo: redesign reorder-inputs pass to make it const as_well as get_engine and get options
+    bool is_loop_body() const { return is_body_program; }
     bool is_debug_build() const { return options.get<build_option_type::debug>()->enabled(); }
     const nodes_ordering& get_processing_order() const;
     nodes_ordering& get_processing_order();
@@ -228,7 +230,8 @@ public:
                              const topology_impl& topology,
                              const build_options& options,
                              bool is_internal = false,
-                             bool no_optimizations = false);
+                             bool no_optimizations = false,
+                             bool is_body_program = false);
     static ptr build_program(engine& engine,
                              const std::set<std::shared_ptr<program_node>>& nodes,
                              const build_options& options,
@@ -253,6 +256,7 @@ private:
     nodes_ordering processing_order;
     std::unique_ptr<pass_manager> pm;
     std::shared_ptr<kernel_selector::TuningCache> tuning_cache;
+    bool is_body_program;
 
 
     std::map<primitive_id, std::shared_ptr<program_node>> nodes_map;

--- a/inference-engine/thirdparty/clDNN/src/program.cpp
+++ b/inference-engine/thirdparty/clDNN/src/program.cpp
@@ -84,13 +84,15 @@ program_impl::program_impl(engine& engine_ref,
                            topology_impl const& topology,
                            build_options const& options,
                            bool is_internal,
-                           bool no_optimizations)
+                           bool no_optimizations,
+                           bool is_body_program)
     : _engine(engine_ref),
       _stream(_engine.create_stream()),
       program_state(_engine),
       options(options),
       processing_order(),
-      tuning_cache(nullptr) {
+      tuning_cache(nullptr),
+      is_body_program(is_body_program) {
     init_primitives();
     kernel_selector::KernelBase::ResetCounter();
     set_options();
@@ -163,8 +165,9 @@ program_impl::ptr program_impl::build_program(engine& engine,
                                               const topology_impl& topology,
                                               const build_options& options,
                                               bool is_internal,
-                                              bool no_optimizations) {
-    return std::make_shared<program_impl>(engine, topology, options, is_internal, no_optimizations);
+                                              bool no_optimizations,
+                                              bool is_body_program) {
+    return std::make_shared<program_impl>(engine, topology, options, is_internal, no_optimizations, is_body_program);
 }
 
 program_impl::ptr program_impl::build_program(engine& engine,


### PR DESCRIPTION
### Details:
 - Previously crop optimization was disabled to improve cldnn::loop body networks performance, however this caused perf degradation of unrolled loop. 
 - Fix: Prevent crop optimization only when the node is inside a loop operation
### Tickets:
 - 57872
