### PR TITLE
[CPU] Concat convolution sum inPlace conflict fix

### DIFF
--- a/inference-engine/src/mkldnn_plugin/mkldnn_edge.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_edge.cpp
@@ -74,47 +74,88 @@ bool MKLDNNEdge::needReorder() {
     bool canBeInPlaceConflicts = false;
     auto parentNode = getParent();
     auto parentSPD = parentNode->getSelectedPrimitiveDescriptor();
-    auto childSPD = getChild()->getSelectedPrimitiveDescriptor();
+    auto childNode = getChild();
+    auto childSPD = childNode->getSelectedPrimitiveDescriptor();
     if (!parentSPD || !childSPD)
         IE_THROW() << "Cannot make a decision about reorder. Primitive descriptors weren't selected.";
 
-    int outNumber = getOutputNum();
-    int inNumber = getInputNum();
-    bool in_place = inPlace();
-    bool childCanChangeMem = childSPD->getConfig().outConfs.empty();
-    for (const auto& conf : childSPD->getConfig().outConfs) {
-        if (conf.inPlace == outNumber && outNumber >= 0)
-            childCanChangeMem = true;
-    }
+    auto childCanChangeMem = [](const MKLDNNEdge& edge) {
+        bool result = false;
+        int outNumber = edge.getOutputNum();
+        if (auto childSPD = edge.getChild()->getSelectedPrimitiveDescriptor()) {
+            result = childSPD->getConfig().outConfs.empty();
+            for (const auto& conf : childSPD->getConfig().outConfs) {
+                if (conf.inPlace == outNumber && outNumber >= 0)
+                    result = true;
+            }
+        }
+        return result;
+    };
 
-    const auto& detectInPlaceChildrenNum = [](const std::vector<MKLDNNEdgePtr>& edges) -> size_t {
+    const auto& detectInPlaceChildrenNum = [&childCanChangeMem](const std::vector<MKLDNNEdgePtr>& edges) -> size_t {
         size_t count = 0;
         for (const auto& edge : edges) {
-            auto childSPD = edge->getChild()->getSelectedPrimitiveDescriptor();
-            int outNumber = edge->getOutputNum();
-            if (childSPD->getConfig().outConfs.empty())
+            if (childCanChangeMem(*edge)) {
                 count++;
-            for (const auto& conf : childSPD->getConfig().outConfs) {
-                if (conf.inPlace == outNumber)
-                    count++;
             }
         }
         return count;
     };
 
+    std::function<void(const MKLDNNEdge& edge, std::vector<MKLDNNNodePtr>& result)> collectConsumers;
+    collectConsumers = [&collectConsumers](const MKLDNNEdge& edge, std::vector<MKLDNNNodePtr>& result) {
+        if (edge.inPlace(LOOK_DOWN)) {
+            if (auto peerChildSPD = edge.getChild()->getSelectedPrimitiveDescriptor()) {
+                auto peerOutputNum = edge.getOutputNum();
+                auto peerInPlacePort = peerChildSPD->getConfig().inConfs[peerOutputNum].inPlace;
+                auto& vecChildEdges = edge.getChild()->getChildEdgesAtPort(peerInPlacePort);
+                for (auto childEdge : vecChildEdges) {
+                    collectConsumers(*childEdge, result);
+                }
+            }
+        } else {
+            result.push_back(edge.getChild());
+        }
+    };
+
+    bool isInPlace = inPlace();
+    int inNumber = getInputNum();
     const auto portChildEdges = parentNode->getChildEdgesAtPort(inNumber);
-    if (in_place && childCanChangeMem && portChildEdges.size() > 1 && detectInPlaceChildrenNum(portChildEdges) > 1)
-        canBeInPlaceConflicts = true;
-    if (!canBeInPlaceConflicts && in_place && !parentNode->getChildEdges().empty()) {
-        for (auto &p_edge_peer : portChildEdges) {
-            if (p_edge_peer.get() == this)
-                continue;
-            if (p_edge_peer->getChild()->getType() != Reorder && p_edge_peer->inPlace(LOOK_DOWN))
-                canBeInPlaceConflicts = true;
+    if (childCanChangeMem(*this) && portChildEdges.size() > 1) {
+        if (childNode->getType() == Convolution) {
+            auto execIndex = childNode->getExecIndex();
+            for (auto pEdgePeer : portChildEdges) {
+                if (pEdgePeer.get() == this)
+                    continue;
+                std::vector<MKLDNNNodePtr> vecConsumers;
+                collectConsumers(*pEdgePeer, vecConsumers);
+
+                for (auto node : vecConsumers) {
+                    if (node->getExecIndex() >= execIndex) {
+                        canBeInPlaceConflicts = true;
+                        break;
+                    }
+                }
+                if (canBeInPlaceConflicts) break;
+            }
+        } else if (isInPlace && detectInPlaceChildrenNum(portChildEdges) > 1) {
+            canBeInPlaceConflicts = true;
         }
     }
 
-    if (in_place) {
+    if (!canBeInPlaceConflicts && isInPlace && !parentNode->getChildEdges().empty()) {
+        for (auto &pEdgePeer : portChildEdges) {
+            if (pEdgePeer.get() == this)
+                continue;
+            if (pEdgePeer->getChild()->getType() != Reorder && pEdgePeer->inPlace(LOOK_DOWN)) {
+                canBeInPlaceConflicts = true;
+                break;
+            }
+        }
+    }
+
+    if (isInPlace) {
+        int outNumber = getOutputNum();
         if (inNumber >= 0 && inNumber < parentSPD->getConfig().outConfs.size() && parentSPD->getConfig().outConfs[inNumber].inPlace >= 0 &&
             outNumber >= 0 && outNumber < childSPD->getConfig().inConfs.size() && childSPD->getConfig().inConfs[outNumber].inPlace >= 0)
             canBeInPlaceConflicts = true;
@@ -461,7 +502,7 @@ MKLDNNEdgePtr MKLDNNEdge::getBaseEdge(int look) {
     return edges_for_same_port[0];
 }
 
-bool MKLDNNEdge::inPlace(LOOK look) {
+bool MKLDNNEdge::inPlace(LOOK look) const {
     auto parentSPD = getParent()->getSelectedPrimitiveDescriptor();
     auto childSPD = getChild()->getSelectedPrimitiveDescriptor();
     if (!parentSPD || !childSPD)

--- a/inference-engine/src/mkldnn_plugin/mkldnn_edge.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_edge.cpp
@@ -65,6 +65,25 @@ void MKLDNNEdge::drop() {
     _drop_from(getChild()->parentEdges);
 }
 
+/**
+ * Collect all nodes that really read the memory. Nodes with inPlace inputs are skipped since they do not read the memory.
+ *
+ * @param vector of all consumer nodes
+ */
+void MKLDNNEdge::collectConsumers(std::vector<MKLDNNNodePtr>& result) const {
+    if (this->inPlace(LOOK_DOWN)) {
+        if (auto peerChildSPD = this->getChild()->getSelectedPrimitiveDescriptor()) {
+            auto peerOutputNum = this->getOutputNum();
+            auto peerInPlacePort = peerChildSPD->getConfig().inConfs[peerOutputNum].inPlace;
+            auto& vecChildEdges = this->getChild()->getChildEdgesAtPort(peerInPlacePort);
+            for (auto childEdge : vecChildEdges) {
+                childEdge->collectConsumers(result);
+            }
+        }
+    } else {
+        result.push_back(this->getChild());
+    }
+}
 
 bool MKLDNNEdge::needReorder() {
     if (!getInputDesc().isCompatible(getOutputDesc())) {
@@ -102,22 +121,6 @@ bool MKLDNNEdge::needReorder() {
         return count;
     };
 
-    std::function<void(const MKLDNNEdge& edge, std::vector<MKLDNNNodePtr>& result)> collectConsumers;
-    collectConsumers = [&collectConsumers](const MKLDNNEdge& edge, std::vector<MKLDNNNodePtr>& result) {
-        if (edge.inPlace(LOOK_DOWN)) {
-            if (auto peerChildSPD = edge.getChild()->getSelectedPrimitiveDescriptor()) {
-                auto peerOutputNum = edge.getOutputNum();
-                auto peerInPlacePort = peerChildSPD->getConfig().inConfs[peerOutputNum].inPlace;
-                auto& vecChildEdges = edge.getChild()->getChildEdgesAtPort(peerInPlacePort);
-                for (auto childEdge : vecChildEdges) {
-                    collectConsumers(*childEdge, result);
-                }
-            }
-        } else {
-            result.push_back(edge.getChild());
-        }
-    };
-
     bool isInPlace = inPlace();
     int inNumber = getInputNum();
     const auto portChildEdges = parentNode->getChildEdgesAtPort(inNumber);
@@ -128,7 +131,7 @@ bool MKLDNNEdge::needReorder() {
                 if (pEdgePeer.get() == this)
                     continue;
                 std::vector<MKLDNNNodePtr> vecConsumers;
-                collectConsumers(*pEdgePeer, vecConsumers);
+                pEdgePeer->collectConsumers(vecConsumers);
 
                 for (auto node : vecConsumers) {
                     if (node->getExecIndex() >= execIndex) {

--- a/inference-engine/src/mkldnn_plugin/mkldnn_edge.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_edge.h
@@ -86,6 +86,8 @@ private:
     const MemoryDesc& getOutputDesc() const;
     const MemoryDesc& getDesc() const;
 
+    void collectConsumers(std::vector<std::shared_ptr<MKLDNNPlugin::MKLDNNNode>>& result) const;
+
     enum LOOK { LOOK_UP = 1, LOOK_DOWN = 2, LOOK_BOTH = LOOK_UP | LOOK_DOWN, LOOK_NO_RECURRENT = 4 };
 
     MKLDNNEdgePtr getBaseEdge(int look = LOOK_BOTH);

--- a/inference-engine/src/mkldnn_plugin/mkldnn_edge.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_edge.h
@@ -89,7 +89,7 @@ private:
     enum LOOK { LOOK_UP = 1, LOOK_DOWN = 2, LOOK_BOTH = LOOK_UP | LOOK_DOWN, LOOK_NO_RECURRENT = 4 };
 
     MKLDNNEdgePtr getBaseEdge(int look = LOOK_BOTH);
-    bool inPlace(LOOK look = LOOK_BOTH);
+    bool inPlace(LOOK look = LOOK_BOTH) const;
     friend class MKLDNNGraph;
 };
 

--- a/inference-engine/tests/functional/plugin/cpu/subgraph_tests/src/concat_conv_sum_inplace.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/subgraph_tests/src/concat_conv_sum_inplace.cpp
@@ -1,0 +1,83 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "test_utils/cpu_test_utils.hpp"
+#include "shared_test_classes/base/layer_test_utils.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+#include "ngraph_functions/builders.hpp"
+
+using namespace CPUTestUtils;
+using namespace InferenceEngine;
+
+namespace SubgraphTestsDefinitions {
+// Subgraph:
+/*
+ *          paramter1         parameter2
+ *                  \             /
+ *                   \           /
+ *                   ReLu1    ReLu2
+ *                   / \       /
+ *                  /   \     /
+ *                 /     \   /
+ *                 |     Concat (inPlace)
+ *                 |       |
+ *                 |      Conv
+ *                 |       |
+ *                 |      Add_Const (Bias)
+ *                  \      |
+ *                   \     |
+ *                    \    |
+ *                     \   |
+ *                       Sum
+ *                        |
+ *                       ReLu3
+ *                        |
+ *                      Result
+ */
+
+class ConcatConvSumInPlaceTest : virtual public LayerTestsUtils::LayerTestsCommon {
+public:
+    void SetUp() override {
+        const std::vector<size_t> inputShape = {1, 64, 12, 12};
+        const InferenceEngine::SizeVector kernel = {1, 1};
+        const InferenceEngine::SizeVector stride = {1, 1};
+        const InferenceEngine::SizeVector dilation = {1, 1};
+        const std::vector<ptrdiff_t> padBegin = {0, 0};
+        const std::vector<ptrdiff_t> padEnd = {0, 0};
+        const size_t convOutChannels = 64;
+        const auto targetFormat = with_cpu_x86_avx512_core() ? nChw16c : nChw8c;
+
+
+        auto inputParams = ngraph::builder::makeParams(ngraph::element::f32, {inputShape, inputShape});
+
+        auto Relu1 = std::make_shared<ngraph::opset3::Relu>(inputParams[0]);
+        Relu1->get_rt_info() = CPUTestsBase::makeCPUInfo({targetFormat}, {targetFormat}, {});
+        auto Relu2 = std::make_shared<ngraph::opset3::Relu>(inputParams[1]);
+        Relu2->get_rt_info() = CPUTestsBase::makeCPUInfo({targetFormat}, {targetFormat}, {});
+
+        auto concat = ngraph::builder::makeConcat(ngraph::OutputVector{Relu1, Relu2}, 1);
+
+        auto conv = ngraph::builder::makeConvolution(concat, ngraph::element::f32, kernel, stride, padBegin,
+                                                     padEnd, dilation, ngraph::op::PadType::AUTO, convOutChannels);
+        auto bias = ngraph::builder::makeConstant<float>(ngraph::element::Type_t::f32, ngraph::Shape({1, convOutChannels, 1, 1}), {}, true);
+        auto convBiasAdd = std::make_shared<ngraph::opset3::Add>(conv, bias);
+
+        auto sum = std::make_shared<ngraph::opset3::Add>(convBiasAdd, Relu1);
+
+        auto Relu3 = std::make_shared<ngraph::opset3::Relu>(sum);
+
+        ngraph::ResultVector results{std::make_shared<ngraph::opset3::Result>(Relu3)};
+        function = std::make_shared<ngraph::Function>(results, inputParams, "ConcatConvSumInPlace");
+        targetDevice = CommonTestUtils::DEVICE_CPU;
+    }
+};
+
+namespace {
+    TEST_F(ConcatConvSumInPlaceTest, smoke_ConcatConvSumInPlace_CPU) {
+        SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+        Run();
+    }
+} // namespace
+} // namespace SubgraphTestsDefinitions


### PR DESCRIPTION
### Details:
There is a pattern where an inPlace memory is used as the input and output at the same time in convolution node due to the sum fusing. This PR fixes this issue and adds a subgraph test to cover such a pattern.

### Tickets:
 - 43602
 - 82022