### PR TITLE
[IE CLDNN] Revert performance of unrolled loops

### DIFF
--- a/inference-engine/thirdparty/clDNN/src/engine.cpp
+++ b/inference-engine/thirdparty/clDNN/src/engine.cpp
@@ -202,8 +202,9 @@ void engine_impl::release_pending_memory(uint32_t net_id) { get_context()->relea
 program_impl::ptr engine_impl::build_program(const topology_impl& topology,
                                             const build_options& options,
                                             bool is_internal,
-                                            bool no_optimizations) {
-    program_impl::ptr progr_impl{ new program_impl(*this, topology, options, is_internal, no_optimizations), false };
+                                            bool no_optimizations,
+                                            bool is_body_program) {
+    program_impl::ptr progr_impl{ new program_impl(*this, topology, options, is_internal, no_optimizations, is_body_program), false };
     return progr_impl;
 }
 

--- a/inference-engine/thirdparty/clDNN/src/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/inference-engine/thirdparty/clDNN/src/graph_optimizer/prepare_buffer_fusing.cpp
@@ -284,7 +284,7 @@ void prepare_buffer_fusing::run(program_impl& p) {
             }
 
             if (node.get_dependencies().size() == 1 && node.get_users().size() > 0) {
-                if (node.get_dependency(0).is_type<lstm_elt>()) {
+                if (p.is_loop_body() && node.get_dependency(0).is_type<lstm_elt>()) {
                     return;
                 }
                 // optimization is available for cropping across depth(features) only

--- a/inference-engine/thirdparty/clDNN/src/include/engine_impl.h
+++ b/inference-engine/thirdparty/clDNN/src/include/engine_impl.h
@@ -60,7 +60,8 @@ public:
     refcounted_obj_ptr<program_impl> build_program(const topology_impl& topology,
                                                    const build_options& options,
                                                    bool is_internal = false,
-                                                   bool no_optimizations = false);
+                                                   bool no_optimizations = false,
+                                                   bool is_body_program = false);
     refcounted_obj_ptr<program_impl> build_program(const std::set<std::shared_ptr<program_node>>& nodes,
                                                    const build_options& options,
                                                    bool is_internal);

--- a/inference-engine/thirdparty/clDNN/src/include/loop_inst.h
+++ b/inference-engine/thirdparty/clDNN/src/include/loop_inst.h
@@ -266,7 +266,7 @@ public:
         auto opts = get_program().get_options();
         std::vector<primitive_id> output_names_vec(output_names.begin(), output_names.end());
         opts.set_option(build_option::outputs(output_names_vec));
-        body_program = get_program().get_engine().build_program(body, opts, false);
+        body_program = get_program().get_engine().build_program(body, opts, false, false, true);
     }
 
     const primitive_id& get_trip_count_id() const { return get_primitive()->trip_count_id; }

--- a/inference-engine/thirdparty/clDNN/src/include/program_impl.h
+++ b/inference-engine/thirdparty/clDNN/src/include/program_impl.h
@@ -125,7 +125,8 @@ public:
                  topology_impl const& topology,
                  build_options const& options,
                  bool is_internal,
-                 bool no_optimizations = false);
+                 bool no_optimizations = false,
+                 bool is_body_program = false);
     /* constructor used to build a program from subset of nodes of other program (used in propagate_constants) */
     program_impl(engine_impl& engine_ref,
                  std::set<std::shared_ptr<program_node>> const& nodes,
@@ -140,6 +141,7 @@ public:
     std::vector<program_node*>& get_outputs() {
         return outputs;
     }  // ToDo: redesign reorder-inputs pass to make it const as_well as get_engine and get options
+    bool is_loop_body() const { return is_body_program; }
     bool is_debug_build() const { return options.get<build_option_type::debug>()->enabled(); }
     const nodes_ordering& get_processing_order() const;
     nodes_ordering& get_processing_order();
@@ -218,6 +220,7 @@ private:
     std::list<program_node*> inputs;
     std::vector<program_node*> outputs;
     nodes_ordering processing_order;
+    bool is_body_program;
     std::unique_ptr<pass_manager> pm;
 
     std::map<primitive_id, std::shared_ptr<program_node>> nodes_map;

--- a/inference-engine/thirdparty/clDNN/src/program.cpp
+++ b/inference-engine/thirdparty/clDNN/src/program.cpp
@@ -91,10 +91,12 @@ program_impl::program_impl(engine_impl& engine_ref,
                            topology_impl const& topology,
                            build_options const& options,
                            bool is_internal,
-                           bool no_optimizations)
+                           bool no_optimizations,
+                           bool is_body_program)
     : engine(&engine_ref),
       options(options),
-      processing_order() {
+      processing_order(),
+      is_body_program(is_body_program) {
     kernel_selector::KernelBase::ResetCounter();
     set_options();
     pm = std::unique_ptr<pass_manager>(new pass_manager(*this));


### PR DESCRIPTION


### Details:
- Corresponding PR : https://github.com/openvinotoolkit/openvino/pull/6192
- Previously crop optimization was disabled to improve cldnn::loop body networks performance, however this caused perf degradation of unrolled loop.
- Fix: Prevent crop optimization only when the node is inside a loop operation

### Tickets:
 - 57872
