### PR TITLE
Deprecation of Node::get_default_value and some cleanup

### DIFF
--- a/ngraph/core/include/ngraph/node.hpp
+++ b/ngraph/core/include/ngraph/node.hpp
@@ -434,6 +434,8 @@ namespace ngraph
 
         /// \return Version of this node
         virtual size_t get_version() const { return get_type_info().version; }
+
+        NGRAPH_DEPRECATED("This method is deprecated and will be removed soon.")
         virtual std::shared_ptr<Node> get_default_value() const { return nullptr; }
         /// Use instance ids for comparison instead of memory addresses to improve determinism
         bool operator<(const Node& other) const { return m_instance_id < other.m_instance_id; }

--- a/ngraph/core/include/ngraph/op/add.hpp
+++ b/ngraph/core/include/ngraph/op/add.hpp
@@ -48,7 +48,6 @@ namespace ngraph
 
                 bool visit_attributes(AttributeVisitor& visitor) override;
 
-                size_t get_version() const override { return 1; }
                 bool evaluate(const HostTensorVector& outputs,
                               const HostTensorVector& inputs) const override;
                 bool has_evaluate() const override;

--- a/ngraph/core/include/ngraph/op/avg_pool.hpp
+++ b/ngraph/core/include/ngraph/op/avg_pool.hpp
@@ -49,7 +49,6 @@ namespace ngraph
                         op::RoundingType rounding_type = op::RoundingType::FLOOR,
                         const PadType& auto_pad = op::PadType::EXPLICIT);
 
-                size_t get_version() const override { return 1; }
                 void validate_and_infer_types() override;
                 bool visit_attributes(AttributeVisitor& visitor) override;
 

--- a/ngraph/core/include/ngraph/op/avg_pool.hpp
+++ b/ngraph/core/include/ngraph/op/avg_pool.hpp
@@ -75,7 +75,9 @@ namespace ngraph
                 op::RoundingType get_rounding_type() const;
                 void set_rounding_type(op::RoundingType rounding_type);
                 /// \return The default value for AvgPool.
+                NGRAPH_SUPPRESS_DEPRECATED_START
                 virtual std::shared_ptr<Node> get_default_value() const override;
+                NGRAPH_SUPPRESS_DEPRECATED_END
 
             protected:
                 Shape m_kernel;

--- a/ngraph/core/include/ngraph/op/binary_convolution.hpp
+++ b/ngraph/core/include/ngraph/op/binary_convolution.hpp
@@ -59,7 +59,6 @@ namespace ngraph
                                   float pad_value,
                                   const PadType& auto_pad = PadType::EXPLICIT);
 
-                size_t get_version() const override { return 1; }
                 void validate_and_infer_types() override;
 
                 bool visit_attributes(AttributeVisitor& visitor) override;

--- a/ngraph/core/include/ngraph/op/convolution.hpp
+++ b/ngraph/core/include/ngraph/op/convolution.hpp
@@ -72,7 +72,9 @@ namespace ngraph
                 const PadType& get_auto_pad() const { return m_auto_pad; }
                 void set_auto_pad(const PadType& auto_pad) { m_auto_pad = auto_pad; }
                 /// \return The default value for Convolution.
+                NGRAPH_SUPPRESS_DEPRECATED_START
                 virtual std::shared_ptr<Node> get_default_value() const override;
+                NGRAPH_SUPPRESS_DEPRECATED_END
 
             protected:
                 Strides m_strides;

--- a/ngraph/core/include/ngraph/op/cum_sum.hpp
+++ b/ngraph/core/include/ngraph/op/cum_sum.hpp
@@ -91,7 +91,9 @@ namespace ngraph
                 void validate_and_infer_types() override;
 
                 /// \return The default value for CumSum.
+                NGRAPH_SUPPRESS_DEPRECATED_START
                 virtual std::shared_ptr<Node> get_default_value() const override;
+                NGRAPH_SUPPRESS_DEPRECATED_END
                 bool is_exclusive() const { return m_exclusive; }
                 bool is_reverse() const { return m_reverse; }
 

--- a/ngraph/core/include/ngraph/op/divide.hpp
+++ b/ngraph/core/include/ngraph/op/divide.hpp
@@ -50,7 +50,6 @@ namespace ngraph
                 virtual std::shared_ptr<Node>
                     clone_with_new_inputs(const OutputVector& new_args) const override;
 
-                size_t get_version() const override { return 1; }
                 bool evaluate(const HostTensorVector& outputs,
                               const HostTensorVector& inputs) const override;
                 bool has_evaluate() const override;

--- a/ngraph/core/include/ngraph/op/group_conv.hpp
+++ b/ngraph/core/include/ngraph/op/group_conv.hpp
@@ -71,7 +71,9 @@ namespace ngraph
                 const PadType& get_auto_pad() const { return m_auto_pad; }
                 void set_auto_pad(const PadType& auto_pad) { m_auto_pad = auto_pad; }
                 /// \return The default value for Convolution.
+                NGRAPH_SUPPRESS_DEPRECATED_START
                 virtual std::shared_ptr<Node> get_default_value() const override;
+                NGRAPH_SUPPRESS_DEPRECATED_END
 
             protected:
                 Strides m_strides;

--- a/ngraph/core/include/ngraph/op/log_softmax.hpp
+++ b/ngraph/core/include/ngraph/op/log_softmax.hpp
@@ -30,7 +30,6 @@ namespace ngraph
                 bool visit_attributes(AttributeVisitor& visitor) override;
                 void validate_and_infer_types() override;
 
-                size_t get_version() const override { return 1; }
                 virtual std::shared_ptr<Node>
                     clone_with_new_inputs(const OutputVector& new_args) const override;
 

--- a/ngraph/core/include/ngraph/op/max_pool.hpp
+++ b/ngraph/core/include/ngraph/op/max_pool.hpp
@@ -68,7 +68,9 @@ namespace ngraph
                     m_rounding_type = rounding_mode;
                 }
                 /// \return The default value for MaxPool.
+                NGRAPH_SUPPRESS_DEPRECATED_START
                 virtual std::shared_ptr<Node> get_default_value() const override;
+                NGRAPH_SUPPRESS_DEPRECATED_END
 
                 bool evaluate(const HostTensorVector& outputs,
                               const HostTensorVector& inputs) const override;

--- a/ngraph/core/include/ngraph/op/max_pool.hpp
+++ b/ngraph/core/include/ngraph/op/max_pool.hpp
@@ -41,7 +41,6 @@ namespace ngraph
                         const PadType& auto_pad = op::PadType::EXPLICIT);
 
                 bool visit_attributes(AttributeVisitor& visitor) override;
-                size_t get_version() const override { return 1; }
                 void validate_and_infer_types() override;
 
                 virtual std::shared_ptr<Node>

--- a/ngraph/core/include/ngraph/op/pad.hpp
+++ b/ngraph/core/include/ngraph/op/pad.hpp
@@ -57,7 +57,6 @@ namespace ngraph
                 Pad() = default;
 
                 bool visit_attributes(AttributeVisitor& visitor) override;
-                size_t get_version() const override { return 1; }
                 void validate_and_infer_types() override;
                 virtual std::shared_ptr<Node>
                     clone_with_new_inputs(const OutputVector& new_args) const override;

--- a/ngraph/core/include/ngraph/op/reduce_l1.hpp
+++ b/ngraph/core/include/ngraph/op/reduce_l1.hpp
@@ -32,7 +32,9 @@ namespace ngraph
                          bool keep_dims = false);
 
                 /// \return The default value for Reduce.
+                NGRAPH_SUPPRESS_DEPRECATED_START
                 virtual std::shared_ptr<Node> get_default_value() const override;
+                NGRAPH_SUPPRESS_DEPRECATED_END
 
                 virtual std::shared_ptr<Node>
                     clone_with_new_inputs(const OutputVector& new_args) const override;

--- a/ngraph/core/include/ngraph/op/reduce_l1.hpp
+++ b/ngraph/core/include/ngraph/op/reduce_l1.hpp
@@ -31,7 +31,6 @@ namespace ngraph
                          const Output<Node>& reduction_axes,
                          bool keep_dims = false);
 
-                size_t get_version() const override { return 4; }
                 /// \return The default value for Reduce.
                 virtual std::shared_ptr<Node> get_default_value() const override;
 

--- a/ngraph/core/include/ngraph/op/reduce_l2.hpp
+++ b/ngraph/core/include/ngraph/op/reduce_l2.hpp
@@ -31,7 +31,9 @@ namespace ngraph
                          bool keep_dims = false);
 
                 /// \return The default value for Reduce.
+                NGRAPH_SUPPRESS_DEPRECATED_START
                 virtual std::shared_ptr<Node> get_default_value() const override;
+                NGRAPH_SUPPRESS_DEPRECATED_END
 
                 virtual std::shared_ptr<Node>
                     clone_with_new_inputs(const OutputVector& new_args) const override;

--- a/ngraph/core/include/ngraph/op/reduce_l2.hpp
+++ b/ngraph/core/include/ngraph/op/reduce_l2.hpp
@@ -30,7 +30,6 @@ namespace ngraph
                          const Output<Node>& reduction_axes,
                          bool keep_dims = false);
 
-                size_t get_version() const override { return 4; }
                 /// \return The default value for Reduce.
                 virtual std::shared_ptr<Node> get_default_value() const override;
 

--- a/ngraph/core/include/ngraph/op/reduce_mean.hpp
+++ b/ngraph/core/include/ngraph/op/reduce_mean.hpp
@@ -26,7 +26,6 @@ namespace ngraph
                            const Output<Node>& reduction_axes,
                            bool keep_dims = false);
 
-                size_t get_version() const override { return 1; }
                 std::shared_ptr<Node>
                     clone_with_new_inputs(const OutputVector& new_args) const override;
 

--- a/ngraph/core/include/ngraph/op/reduce_prod.hpp
+++ b/ngraph/core/include/ngraph/op/reduce_prod.hpp
@@ -31,7 +31,9 @@ namespace ngraph
                            bool keep_dims = false);
 
                 /// \return The default value for Product.
+                NGRAPH_SUPPRESS_DEPRECATED_START
                 virtual std::shared_ptr<Node> get_default_value() const override;
+                NGRAPH_SUPPRESS_DEPRECATED_END
 
                 virtual std::shared_ptr<Node>
                     clone_with_new_inputs(const OutputVector& new_args) const override;

--- a/ngraph/core/include/ngraph/op/reduce_prod.hpp
+++ b/ngraph/core/include/ngraph/op/reduce_prod.hpp
@@ -30,7 +30,6 @@ namespace ngraph
                            const Output<Node>& reduction_axes,
                            bool keep_dims = false);
 
-                size_t get_version() const override { return 1; }
                 /// \return The default value for Product.
                 virtual std::shared_ptr<Node> get_default_value() const override;
 

--- a/ngraph/core/include/ngraph/op/reduce_sum.hpp
+++ b/ngraph/core/include/ngraph/op/reduce_sum.hpp
@@ -77,8 +77,6 @@ namespace ngraph
                           const Output<Node>& reduction_axes,
                           bool keep_dims = false);
 
-                size_t get_version() const override { return 1; }
-
                 virtual std::shared_ptr<Node>
                     clone_with_new_inputs(const OutputVector& new_args) const override;
 

--- a/ngraph/core/include/ngraph/op/reduce_sum.hpp
+++ b/ngraph/core/include/ngraph/op/reduce_sum.hpp
@@ -81,7 +81,9 @@ namespace ngraph
                     clone_with_new_inputs(const OutputVector& new_args) const override;
 
                 /// \return The default value for Sum.
+                NGRAPH_SUPPRESS_DEPRECATED_START
                 virtual std::shared_ptr<Node> get_default_value() const override;
+                NGRAPH_SUPPRESS_DEPRECATED_END
 
                 bool evaluate(const HostTensorVector& outputs,
                               const HostTensorVector& inputs) const override;

--- a/ngraph/core/include/ngraph/op/reshape.hpp
+++ b/ngraph/core/include/ngraph/op/reshape.hpp
@@ -46,7 +46,6 @@ namespace ngraph
                 bool visit_attributes(AttributeVisitor& visitor) override;
                 void validate_and_infer_types() override;
 
-                size_t get_version() const override { return 1; }
                 virtual std::shared_ptr<Node>
                     clone_with_new_inputs(const OutputVector& new_args) const override;
 

--- a/ngraph/core/include/ngraph/op/reverse.hpp
+++ b/ngraph/core/include/ngraph/op/reverse.hpp
@@ -15,14 +15,14 @@ namespace ngraph
             class NGRAPH_API Reverse : public Op
             {
             public:
+                NGRAPH_RTTI_DECLARATION;
+
                 enum class Mode
                 {
                     INDEX,
                     MASK
                 };
 
-                static constexpr NodeTypeInfo type_info{"Reverse", 1};
-                const NodeTypeInfo& get_type_info() const override { return type_info; }
                 Reverse() = default;
                 /// \brief Constructs a reverse operation.
                 ///
@@ -47,7 +47,6 @@ namespace ngraph
                 /// \return The second input data interpretation mode.
                 Mode get_mode() const { return m_mode; }
                 void set_mode(const Mode mode) { m_mode = mode; }
-                virtual size_t get_version() const override { return 1; }
                 bool evaluate(const HostTensorVector& outputs,
                               const HostTensorVector& inputs) const override;
                 bool has_evaluate() const override;

--- a/ngraph/core/include/ngraph/op/softmax.hpp
+++ b/ngraph/core/include/ngraph/op/softmax.hpp
@@ -15,8 +15,8 @@ namespace ngraph
             class NGRAPH_API Softmax : public Op
             {
             public:
-                static constexpr NodeTypeInfo type_info{"Softmax", 1};
-                const NodeTypeInfo& get_type_info() const override { return type_info; }
+                NGRAPH_RTTI_DECLARATION;
+
                 Softmax()
                     : m_axis(0)
                 {
@@ -34,7 +34,6 @@ namespace ngraph
                 bool visit_attributes(AttributeVisitor& visitor) override;
                 void validate_and_infer_types() override;
 
-                size_t get_version() const override { return 1; }
                 virtual std::shared_ptr<Node>
                     clone_with_new_inputs(const OutputVector& new_args) const override;
 

--- a/ngraph/core/include/ngraph/op/strided_slice.hpp
+++ b/ngraph/core/include/ngraph/op/strided_slice.hpp
@@ -90,7 +90,6 @@ namespace ngraph
                 std::shared_ptr<Node>
                     clone_with_new_inputs(const OutputVector& new_args) const override;
                 void validate_and_infer_types() override;
-                size_t get_version() const override { return 1; }
                 bool evaluate(const HostTensorVector& output_values,
                               const HostTensorVector& input_values) const override;
                 bool has_evaluate() const override;

--- a/ngraph/core/include/ngraph/op/topk.hpp
+++ b/ngraph/core/include/ngraph/op/topk.hpp
@@ -21,11 +21,11 @@ namespace ngraph
             class NGRAPH_API TopK : public Op
             {
             public:
+                NGRAPH_RTTI_DECLARATION;
+
                 using SortType = TopKSortType;
                 using Mode = TopKMode;
 
-                static constexpr NodeTypeInfo type_info{"TopK", 1};
-                const NodeTypeInfo& get_type_info() const override { return type_info; }
                 /// \brief Constructs a TopK operation
                 TopK() = default;
                 /// \brief Constructs a TopK operation with two outputs: values and indices.
@@ -60,7 +60,6 @@ namespace ngraph
                 virtual std::shared_ptr<Node>
                     clone_with_new_inputs(const OutputVector& new_args) const override;
 
-                virtual size_t get_version() const override { return 1; }
                 /// \brief Returns axis value after normalization
                 /// \note If input rank required to normalization is dynamic, the exception is
                 /// thrown

--- a/ngraph/core/src/op/reverse.cpp
+++ b/ngraph/core/src/op/reverse.cpp
@@ -18,7 +18,7 @@
 using namespace std;
 using namespace ngraph;
 
-constexpr NodeTypeInfo op::v1::Reverse::type_info;
+NGRAPH_RTTI_DEFINITION(op::v1::Reverse, "Reverse", 1);
 
 op::v1::Reverse::Reverse(const Output<Node>& data,
                          const Output<Node>& reversed_axes,

--- a/ngraph/core/src/op/softmax.cpp
+++ b/ngraph/core/src/op/softmax.cpp
@@ -51,7 +51,7 @@ namespace
 } // namespace
 
 // *** SOFTMAX OP SET V1 ***
-constexpr NodeTypeInfo op::v1::Softmax::type_info;
+NGRAPH_RTTI_DEFINITION(op::v1::Softmax, "Softmax", 1);
 
 op::v1::Softmax::Softmax(const Output<Node>& arg, const size_t axis)
     : Op({arg})

--- a/ngraph/core/src/op/topk.cpp
+++ b/ngraph/core/src/op/topk.cpp
@@ -205,7 +205,7 @@ namespace topk
 } // namespace topk
 
 // v1 version starts
-constexpr NodeTypeInfo op::v1::TopK::type_info;
+NGRAPH_RTTI_DEFINITION(op::v1::TopK, "TopK", 1);
 
 static const std::uint64_t UNKNOWN_NORMALIZED_AXIS = std::numeric_limits<uint64_t>::max();
 

--- a/ngraph/test/runtime/op/avg_pool.hpp
+++ b/ngraph/test/runtime/op/avg_pool.hpp
@@ -146,7 +146,9 @@ namespace ngraph
                 bool get_ceil_mode() const;
                 void set_ceil_mode(bool ceil_mode);
                 /// \return The default value for AvgPool.
+                NGRAPH_SUPPRESS_DEPRECATED_START
                 virtual std::shared_ptr<Node> get_default_value() const override;
+                NGRAPH_SUPPRESS_DEPRECATED_END
 
             protected:
                 Shape m_window_shape;

--- a/ngraph/test/runtime/op/convolution.hpp
+++ b/ngraph/test/runtime/op/convolution.hpp
@@ -178,7 +178,9 @@ namespace ngraph
                 const PadType& get_pad_type() const { return m_pad_type; }
                 void set_pad_type(const PadType& pad_type) { m_pad_type = pad_type; }
                 /// \return The default value for Convolution.
+                NGRAPH_SUPPRESS_DEPRECATED_START
                 virtual std::shared_ptr<Node> get_default_value() const override;
+                NGRAPH_SUPPRESS_DEPRECATED_END
 
             protected:
                 Strides m_window_movement_strides;


### PR DESCRIPTION
### Details:
 - The get_default_value node is a leftover from the old ngraph repository and has been marked as deprecated in this PR
 - Obsolete and incorrect get_version() overrides have been removed from the op classes that still had those implementations
 - Follow-up task: 26703

### Tickets:
 - 58140
