### PR TITLE
[VPU] changed calling of sem_timedwait() to account for EINTR  error

### DIFF
--- a/inference-engine/thirdparty/movidius/XLink/shared/src/XLinkSemaphore.c
+++ b/inference-engine/thirdparty/movidius/XLink/shared/src/XLinkSemaphore.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <errno.h>
 #include "XLinkSemaphore.h"
 #include "XLinkErrorUtils.h"
 #include "XLinkLog.h"
@@ -104,7 +105,9 @@ int XLink_sem_timedwait(XLink_sem_t* sem, const struct timespec* abstime)
     XLINK_RET_ERR_IF(abstime == NULL, -1);
 
     XLINK_RET_IF_FAIL(XLink_sem_inc(sem));
-    int ret = sem_timedwait(&sem->psem, abstime);
+    int ret;
+    while(((ret = sem_timedwait(&sem->psem, abstime)) == -1) && errno == EINTR)
+        continue;
     XLINK_RET_IF_FAIL(XLink_sem_dec(sem));
 
     return ret;


### PR DESCRIPTION
### Details:
 - changed calling of sem_timedwait() to account for EINTR  error code, so it would be restarted.


### Tickets:
 - CVS-58042
