### PR TITLE
[CPU][IE TESTS] Added Gather-7 I8 test support

### DIFF
--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
@@ -67,8 +67,6 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*CoreThreading.*smoke_QueryNetwork.*targetDevice=AUTO_config.*)",
         // Unsupported config KEY_ENFORCE_BF16 for AUTO plugin
         R"(.*smoke_SetBlobOfKindAUTO.*SetBlobOfKindTest.CompareWithRefs.*)",
-        // reference doesn't cover I8, U8 cases. Issue: 55842
-        R"(.*Gather7LayerTest.*netPRC=I8.*)",
         // TODO: 57562 No dynamic output shape support
         R"(.*NonZeroLayerTest.*)",
         // need to implement Export / Import


### PR DESCRIPTION
### Details:
 - *[PR#6195](https://github.com/openvinotoolkit/openvino/pull/6195) with i8/u8 support for reference was merged. So we can launch Gather-7 CPU tests for i8*

### Tickets:
 - *N/A*
