### PR TITLE
[IE PYTHON] Release GIL in some functions 

### DIFF
--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pyx
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pyx
@@ -1224,7 +1224,8 @@ cdef class InferRequest:
             self._fill_inputs(inputs)
         if self._py_callback_used:
             self._py_callback_called.clear()
-        deref(self.impl).infer_async()
+        with nogil:
+            deref(self.impl).infer_async()
 
     ## Waits for the result to become available. Blocks until specified timeout elapses or the result
     #  becomes available, whichever comes first.

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl_defs.pxd
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl_defs.pxd
@@ -165,7 +165,7 @@ cdef extern from "ie_api_impl.hpp" namespace "InferenceEnginePython":
         shared_ptr[CExecutableNetwork] getPluginLink() except +
 
     cdef cppclass IENetwork:
-        IENetwork() except +
+        IENetwork() nogil except +
         IENetwork(object) except +
         IENetwork(const string &, const string &) except +
         string name
@@ -203,11 +203,11 @@ cdef extern from "ie_api_impl.hpp" namespace "InferenceEnginePython":
         vector[CVariableState] queryState() except +
 
     cdef cppclass IECore:
-        IECore() except +
-        IECore(const string & xml_config_file) except +
+        IECore() nogil except +
+        IECore(const string & xml_config_file) nogil except +
         map[string, Version] getVersions(const string & deviceName) except +
-        IENetwork readNetwork(const string& modelPath, const string& binPath) except +
-        IENetwork readNetwork(const string& modelPath,uint8_t*bin, size_t bin_size) except +
+        IENetwork readNetwork(const string& modelPath, const string& binPath) nogil except +
+        IENetwork readNetwork(const string& modelPath,uint8_t*bin, size_t bin_size) nogil except +
         unique_ptr[IEExecNetwork] loadNetwork(IENetwork network, const string deviceName,
                                               const map[string, string] & config, int num_requests) nogil except +
         unique_ptr[IEExecNetwork] loadNetworkFromFile(const string & modelPath, const string & deviceName,
@@ -221,7 +221,7 @@ cdef extern from "ie_api_impl.hpp" namespace "InferenceEnginePython":
         void unregisterPlugin(const string & deviceName) except +
         void registerPlugins(const string & xmlConfigFile) except +
         void addExtension(const string & ext_lib_path, const string & deviceName) except +
-        vector[string] getAvailableDevices() except +
+        vector[string] getAvailableDevices() nogil except +
         object getMetric(const string & deviceName, const string & name) except +
         object getConfig(const string & deviceName, const string & name) except +
 

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl_defs.pxd
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl_defs.pxd
@@ -172,9 +172,9 @@ cdef extern from "ie_api_impl.hpp" namespace "InferenceEnginePython":
         size_t batch_size
         string precision
         map[string, vector[size_t]] inputs
-        const map[string, InputInfo.Ptr] getInputsInfo() except +
+        const map[string, InputInfo.Ptr] getInputsInfo() nogil except +
         const map[string, DataPtr] getInputs() except +
-        map[string, DataPtr] getOutputs() except +
+        map[string, DataPtr] getOutputs() nogil except +
         void addOutput(string &, size_t) except +
         void setAffinity(map[string, string] & types_affinity_map, map[string, string] & layers_affinity_map) except +
         void setBatch(size_t size) except +
@@ -197,7 +197,7 @@ cdef extern from "ie_api_impl.hpp" namespace "InferenceEnginePython":
         map[string, ProfileInfo] getPerformanceCounts() except +
         void infer() nogil except +
         void infer_async() except +
-        int wait(int64_t timeout) except +
+        int wait(int64_t timeout) nogil except +
         void setBatch(int size) except +
         void setCyCallback(void (*)(void*, int), void *) except +
         vector[CVariableState] queryState() except +

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl_defs.pxd
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl_defs.pxd
@@ -196,7 +196,7 @@ cdef extern from "ie_api_impl.hpp" namespace "InferenceEnginePython":
         const CPreProcessInfo& getPreProcess(const string& blob_name) except +
         map[string, ProfileInfo] getPerformanceCounts() except +
         void infer() nogil except +
-        void infer_async() except +
+        void infer_async() nogil except +
         int wait(int64_t timeout) nogil except +
         void setBatch(int size) except +
         void setCyCallback(void (*)(void*, int), void *) except +

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl_defs.pxd
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl_defs.pxd
@@ -209,9 +209,9 @@ cdef extern from "ie_api_impl.hpp" namespace "InferenceEnginePython":
         IENetwork readNetwork(const string& modelPath, const string& binPath) except +
         IENetwork readNetwork(const string& modelPath,uint8_t*bin, size_t bin_size) except +
         unique_ptr[IEExecNetwork] loadNetwork(IENetwork network, const string deviceName,
-                                              const map[string, string] & config, int num_requests) except +
+                                              const map[string, string] & config, int num_requests) nogil except +
         unique_ptr[IEExecNetwork] loadNetworkFromFile(const string & modelPath, const string & deviceName,
-                                              const map[string, string] & config, int num_requests) except +
+                                              const map[string, string] & config, int num_requests) nogil except +
         unique_ptr[IEExecNetwork] importNetwork(const string & modelFIle, const string & deviceName,
                                                 const map[string, string] & config, int num_requests) except +
         map[string, string] queryNetwork(IENetwork network, const string deviceName,

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl_defs.pxd
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl_defs.pxd
@@ -160,8 +160,8 @@ cdef extern from "ie_api_impl.hpp" namespace "InferenceEnginePython":
         void exportNetwork(const string & model_file) except +
         object getMetric(const string & metric_name) except +
         object getConfig(const string & metric_name) except +
-        int wait(int num_requests, int64_t timeout)
-        int getIdleRequestId()
+        int wait(int num_requests, int64_t timeout) nogil
+        int getIdleRequestId() nogil
         shared_ptr[CExecutableNetwork] getPluginLink() except +
 
     cdef cppclass IENetwork:
@@ -195,7 +195,7 @@ cdef extern from "ie_api_impl.hpp" namespace "InferenceEnginePython":
         void setBlob(const string &blob_name, const CBlob.Ptr &blob_ptr, CPreProcessInfo& info) except +
         const CPreProcessInfo& getPreProcess(const string& blob_name) except +
         map[string, ProfileInfo] getPerformanceCounts() except +
-        void infer() except +
+        void infer() nogil except +
         void infer_async() except +
         int wait(int64_t timeout) except +
         void setBatch(int size) except +

--- a/inference-engine/ie_bridges/python/tests/test_IECore.py
+++ b/inference-engine/ie_bridges/python/tests/test_IECore.py
@@ -7,6 +7,7 @@ from sys import platform
 from pathlib import Path
 from threading import Thread
 from time import sleep, time
+from queue import Queue
 
 from openvino.inference_engine import IENetwork, IECore, ExecutableNetwork
 from conftest import model_path, plugins_path, model_onnx_path, model_prototxt_path
@@ -259,18 +260,33 @@ def test_net_from_buffer_valid():
 
 @pytest.mark.skipif(os.environ.get("TEST_DEVICE","CPU") != "GPU", reason=f"Device dependent test")
 def test_load_network_release_gil(device):
+    running = True
+    message_queue = Queue()
     def detect_long_gil_holds():
         sleep_time = 0.01
         latency_alert_threshold = 0.1
-        while True:
+        # Send a message to indicate the thread is running and ready to detect GIL locks
+        message_queue.put("ready to detect")
+        while running:
             start_sleep = time()
             sleep(sleep_time)
             elapsed = time() - start_sleep
-            assert elapsed < latency_alert_threshold
-
+            if elapsed > latency_alert_threshold:
+                # Send a message to the testing thread that a long GIL lock occurred
+                message_queue.put(latency_alert_threshold)
     ie = IECore()
     net = ie.read_network(model=test_net_xml, weights=test_net_bin)
+    # Wait for the GIL lock detector to be up and running
     gil_hold_detection_thread = Thread(daemon=True, target=detect_long_gil_holds)
     gil_hold_detection_thread.start()
+    # Wait to make sure the thread is started and checking for GIL holds
     sleep(0.1)
+    assert message_queue.get(timeout=5) == "ready to detect"
+    # Run the function that should unlock the GIL
     exec_net = ie.load_network(net, device)
+    # Ensure resources are closed
+    running = False
+    gil_hold_detection_thread.join(timeout=5)
+    # Assert there were never any long gil locks
+    assert message_queue.qsize() == 0, \
+        f"More than 0 GIL locks occured! Latency: {message_queue.get()})"

--- a/inference-engine/ie_bridges/python/tests/test_IECore.py
+++ b/inference-engine/ie_bridges/python/tests/test_IECore.py
@@ -257,7 +257,7 @@ def test_net_from_buffer_valid():
     assert o_net.keys() == o_net2.keys()
 
 
-@pytest.mark.skipif(os.environ.get("TEST_DEVICE", "VGA") != "GPU", reason=f"Device dependent test")
+@pytest.mark.skipif(os.environ.get("TEST_DEVICE","CPU") != "GPU", reason=f"Device dependent test")
 def test_load_network_release_gil(device):
     def detect_long_gil_holds():
         sleep_time = 0.01


### PR DESCRIPTION
### Details:
 - *Some functions in python api don't release GIL, when come into cpp, where GIL is needn't.  We can release GIL in these functions, using the the nogil keyword. It will speed up code, which using multithreading in  python.*

### Tickets:
 - *57119*
