### PR TITLE
[INT8+BF16] x8s8s32x_deconv_fwd bf16 output case elimination

### DIFF
--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_deconv_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_deconv_node.cpp
@@ -202,7 +202,13 @@ void MKLDNNDeconvolutionNode::getSupportedDescriptors() {
 
     InferenceEngine::Precision inPrecision = getOriginalInputPrecisionAtPort(0);
     InferenceEngine::Precision outPrecision = getOriginalOutputPrecisionAtPort(0);
-    if (!isInt8) {
+    if (isInt8) {
+        // TODO: We have to extend jit_avx512_core_x8s8s32x_deconv_fwd_kernel from oneDNN to support BF16 output data type
+        if (InferenceEngine::Precision::BF16 == inPrecision)
+            inPrecision = InferenceEngine::Precision::FP32;
+        if (InferenceEngine::Precision::BF16 == outPrecision)
+            outPrecision = InferenceEngine::Precision::FP32;
+    } else {
         if (!one_of(inPrecision, InferenceEngine::Precision::FP32, InferenceEngine::Precision::BF16))
             inPrecision = InferenceEngine::Precision::FP32;
         if (!one_of(outPrecision, InferenceEngine::Precision::FP32, InferenceEngine::Precision::BF16))


### PR DESCRIPTION
### Details:
 - *jit_avx512_core_x8s8s32x_deconv_fwd_kernel doesn't support BF16 output and this fix sets the deconvolution node in FP32 precision. This is a reason of error on model unet-camvid-int8-onnx-0001/caffe2. In future, we have to extend jit_avx512_core_x8s8s32x_deconv_fwd_kernel from oneDNN to support BF16 output data type*

### Ticket:
- *55902*