### PR TITLE
[IE CLDNN] Fixed code gen with custom locale

### DIFF
--- a/inference-engine/tests/functional/plugin/gpu/behavior/locale.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/behavior/locale.cpp
@@ -1,0 +1,50 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "common_test_utils/test_common.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+#include "functional_test_utils/plugin_cache.hpp"
+#include "ngraph_functions/subgraph_builders.hpp"
+#include <ie_core.hpp>
+#include <ie_plugin_config.hpp>
+
+inline std::shared_ptr<ngraph::Function> makeTestModel(std::vector<size_t> inputShape = {1, 1, 32, 32}) {
+    ngraph::Shape in_shape(inputShape);
+    auto et = ngraph::element::Type_t::f16;
+    auto in = std::make_shared<ngraph::opset1::Parameter>(et, in_shape);
+    auto gelu = std::make_shared<ngraph::opset7::Gelu>(in);
+    auto swish_const = ngraph::op::Constant::create(et, ngraph::Shape{}, {2.5f});
+    auto swish = std::make_shared<ngraph::opset4::Swish>(gelu, swish_const);
+    ngraph::Shape reluShape = swish->outputs()[0].get_tensor().get_shape();
+    std::vector<size_t> constShape2 = {1, ngraph::shape_size(reluShape)};
+    auto const2 = ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{2}, constShape2);
+    auto reshape2 = std::make_shared<ngraph::opset1::Reshape>(swish, const2, false);
+    ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(reshape2)};
+    std::shared_ptr<ngraph::Function> fnPtr = std::make_shared<ngraph::Function>(results, ngraph::ParameterVector{in});
+    return fnPtr;
+}
+
+class CustomLocaleTest : public CommonTestUtils::TestsCommon {
+protected:
+    std::string test_name = ::testing::UnitTest::GetInstance()->current_test_info()->name();
+    std::shared_ptr<ngraph::Function> function;
+
+    void SetUp() override {
+        function = makeTestModel();
+    }
+};
+TEST_F(CustomLocaleTest, CanLoadNetworkWithCustomLocale) {
+    auto prev = std::locale();
+    try {
+        std::locale::global(std::locale("ru_RU.UTF-8"));
+    } catch (...) {
+        GTEST_SKIP();
+    }
+
+    std::shared_ptr<InferenceEngine::Core> ie = PluginCache::get().ie();
+    InferenceEngine::CNNNetwork cnnNet(function);
+    ASSERT_NO_THROW(ie->LoadNetwork(cnnNet, "GPU"));
+
+    std::locale::global(prev);
+}

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/binary_convolution/binary_convolution_kernel_1x1.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/binary_convolution/binary_convolution_kernel_1x1.cpp
@@ -129,10 +129,10 @@ JitConstants BinaryConvolutionKernel1x1::GetFusedPrimitivesJitConstants(const bi
 
         std::string data_type = fused_dep_codegen.GetInputTypeName(0, 1);
         std::string vec_data_type = fused_dep_codegen.GetInputTypeName(0, 2);
-        std::string sc = "sc" + std::to_string(op_id);
-        std::string sh = "sh" + std::to_string(op_id);
-        std::string e_add = "e_add" + std::to_string(op_id);
-        std::string e_mul = "e_mul" + std::to_string(op_id);
+        std::string sc = "sc" + toCodeString(op_id);
+        std::string sh = "sh" + toCodeString(op_id);
+        std::string e_add = "e_add" + toCodeString(op_id);
+        std::string e_mul = "e_mul" + toCodeString(op_id);
 
         switch (fused_dep.GetType()) {
             case KernelType::SCALE: {
@@ -204,7 +204,7 @@ JitConstants BinaryConvolutionKernel1x1::GetFusedPrimitivesJitConstants(const bi
                 auto p = fused_dep.GetOpParams<activation_fuse_params>();
                 base_activation_params activation = p->param;
                 if (activation.function != ActivationFunction::NONE) {
-                    auto suffix = "_FUSED_OP" + std::to_string(op_id);
+                    auto suffix = "_FUSED_OP" + toCodeString(op_id);
 
                     jit.Merge(MakeActivationJitConstants(activation, fused_dep.output_tensor.GetDType(), suffix));
                     eltwise_fused_ops += "\\\n\tres = ACTIVATION" + suffix + "((OUTPUT_TYPE)res, ACTIVATION_PARAMS" + suffix + ");";

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/binary_convolution/binary_convolution_kernel_1x1_b_fs_yx_fsv16.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/binary_convolution/binary_convolution_kernel_1x1_b_fs_yx_fsv16.cpp
@@ -134,9 +134,9 @@ JitConstants BinaryConvolutionKernel1x1_b_fs_yx_fsv16::GetFusedPrimitivesJitCons
 
         std::string data_type = fused_dep_codegen.GetInputTypeName(0, 1);
         std::string vec_data_type = fused_dep_codegen.GetInputTypeName(0, 1);
-        std::string sc = "sc" + std::to_string(op_id);
-        std::string e_add = "e_add" + std::to_string(op_id);
-        std::string e_mul = "e_mul" + std::to_string(op_id);
+        std::string sc = "sc" + toCodeString(op_id);
+        std::string e_add = "e_add" + toCodeString(op_id);
+        std::string e_mul = "e_mul" + toCodeString(op_id);
 
         switch (fused_dep.GetType()) {
             case KernelType::SCALE: {
@@ -164,7 +164,7 @@ JitConstants BinaryConvolutionKernel1x1_b_fs_yx_fsv16::GetFusedPrimitivesJitCons
                 auto p = fused_dep.GetOpParams<activation_fuse_params>();
                 base_activation_params activation = p->param;
                 if (activation.function != ActivationFunction::NONE) {
-                    auto suffix = "_FUSED_OP" + std::to_string(op_id);
+                    auto suffix = "_FUSED_OP" + toCodeString(op_id);
 
                     jit.Merge(MakeActivationJitConstants(activation, fused_dep.output_tensor.GetDType(), suffix));
                     eltwise_fused_ops += "\\\n\tres = ACTIVATION" + suffix + "((OUTPUT_TYPE)res, ACTIVATION_PARAMS" + suffix + ");";

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/binary_convolution/binary_convolution_kernel_generic.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/binary_convolution/binary_convolution_kernel_generic.cpp
@@ -124,10 +124,10 @@ JitConstants BinaryConvolutionKernelGeneric::GetFusedPrimitivesJitConstants(cons
         };
         std::string data_type = fused_dep_codegen.GetInputTypeName(0, 1);
         std::string vec_data_type = fused_dep_codegen.GetInputTypeName(0, 2);
-        std::string sc = "sc" + std::to_string(op_id);
-        std::string sh = "sh" + std::to_string(op_id);
-        std::string e_add = "e_add" + std::to_string(op_id);
-        std::string e_mul = "e_mul" + std::to_string(op_id);
+        std::string sc = "sc" + toCodeString(op_id);
+        std::string sh = "sh" + toCodeString(op_id);
+        std::string e_add = "e_add" + toCodeString(op_id);
+        std::string e_mul = "e_mul" + toCodeString(op_id);
 
         switch (fused_dep.GetType()) {
             case KernelType::SCALE: {
@@ -218,7 +218,7 @@ JitConstants BinaryConvolutionKernelGeneric::GetFusedPrimitivesJitConstants(cons
                 auto p = fused_dep.GetOpParams<activation_fuse_params>();
                 base_activation_params activation = p->param;
                 if (activation.function != ActivationFunction::NONE) {
-                    auto suffix = "_FUSED_OP" + std::to_string(op_id);
+                    auto suffix = "_FUSED_OP" + toCodeString(op_id);
 
                     jit.Merge(MakeActivationJitConstants(activation, fused_dep.output_tensor.GetDType(), suffix));
                     eltwise_fused_ops += "\\\n\tres = ACTIVATION" + suffix + "((OUTPUT_TYPE)res, ACTIVATION_PARAMS" + suffix + ");";

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_kernel_b_fs_zyx_fsv16.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_kernel_b_fs_zyx_fsv16.cpp
@@ -15,13 +15,13 @@ static const size_t feature_block_size = 16;
 FusedOpsConfiguration GenerateFusedOpsConfiguration_f16(size_t conf_id, std::string input_name, Datatype dt,
                                                         bool is_vector) {
     std::vector<std::string> idx_order;
-    std::string suffix = (is_vector ? "_VEC" : "_SCALAR") + std::to_string(conf_id);
-    std::string input_var_name = input_name + std::to_string(conf_id) + (is_vector ? "" : "[i]");
+    std::string suffix = (is_vector ? "_VEC" : "_SCALAR") + toCodeString(conf_id);
+    std::string input_var_name = input_name + toCodeString(conf_id) + (is_vector ? "" : "[i]");
     size_t vec_size = is_vector ? 8 : 1;
     if (is_vector)
-        idx_order = {"(mb)", "(oc*OC_BLOCK + g*OC)", "od", "oh", "(ow + " + std::to_string(conf_id * 8) + ")"};
+        idx_order = {"(mb)", "(oc*OC_BLOCK + g*OC)", "od", "oh", "(ow + " + toCodeString(conf_id * 8) + ")"};
     else
-        idx_order = {"(mb)", "(oc*OC_BLOCK + g*OC + local_id)", "od", "oh", "(ow + " + std::to_string(conf_id * 8) + " + i)"};
+        idx_order = {"(mb)", "(oc*OC_BLOCK + g*OC + local_id)", "od", "oh", "(ow + " + toCodeString(conf_id * 8) + " + i)"};
 
     return { suffix,
              idx_order,
@@ -36,20 +36,20 @@ FusedOpsConfiguration GenerateFusedOpsConfiguration_f16(size_t conf_id, std::str
 
 FusedOpsConfiguration GenerateFusedOpsConfiguration_bsv16_fsv16(size_t conf_id, std::string input_name, Datatype dt,
                                                                 size_t dims, bool is_vector) {
-    std::string suffix = (is_vector ? "_VEC" : "_SCALAR") + std::to_string(conf_id);
-    std::string input_var_name = input_name + std::to_string(conf_id) + (is_vector ? "" : "[i]");
+    std::string suffix = (is_vector ? "_VEC" : "_SCALAR") + toCodeString(conf_id);
+    std::string input_var_name = input_name + toCodeString(conf_id) + (is_vector ? "" : "[i]");
     size_t vec_size = is_vector ? 8 : 1;
     std::vector<std::string> idx_order;
     if (is_vector) {
         if (dims == 5)
-            idx_order = {"(mb + " + std::to_string(conf_id * 8) + ")", "(oc*16)", "od", "oh", "ow"};
+            idx_order = {"(mb + " + toCodeString(conf_id * 8) + ")", "(oc*16)", "od", "oh", "ow"};
         else
-            idx_order = {"(mb + " + std::to_string(conf_id * 8) + ")", "(oc*16)", "oh", "ow"};
+            idx_order = {"(mb + " + toCodeString(conf_id * 8) + ")", "(oc*16)", "oh", "ow"};
     } else {
         if (dims == 5)
-            idx_order = {"(mb + " + std::to_string(conf_id * 8) + ")", "(oc*16 + local_id)", "od", "oh", "(ow + i)"};
+            idx_order = {"(mb + " + toCodeString(conf_id * 8) + ")", "(oc*16 + local_id)", "od", "oh", "(ow + i)"};
         else
-            idx_order = {"(mb + " + std::to_string(conf_id * 8) + ")", "(oc*16 + local_id)", "oh", "(ow + i)"};
+            idx_order = {"(mb + " + toCodeString(conf_id * 8) + ")", "(oc*16 + local_id)", "oh", "(ow + i)"};
     }
 
     return { suffix,

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/eltwise/eltwise_kernel_b_fs_yx_fsv16.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/eltwise/eltwise_kernel_b_fs_yx_fsv16.cpp
@@ -81,11 +81,11 @@ JitConstants EltwiseKernel_b_fs_yx_fsv16::MakeLoadJitConstants(const eltwise_par
     JitConstants jit = {};
     std::string vload_decls;
     for (size_t op_num = 0; op_num < params.operations.size(); op_num++) {
-        const std::string op_num_str = std::to_string(op_num);
+        const std::string op_num_str = toCodeString(op_num);
         const auto &ew = params.operations[op_num];
         for (size_t input_idx = 0; input_idx < ew.inputs.size(); input_idx++) {
             const auto &input = ew.inputs[input_idx];
-            const std::string name = "INPUT_" + op_num_str + "_" + std::to_string(input_idx);
+            const std::string name = "INPUT_" + op_num_str + "_" + toCodeString(input_idx);
 
             switch (input.mode) {
                 case EltwiseInputMode::SCALAR:
@@ -95,10 +95,10 @@ JitConstants EltwiseKernel_b_fs_yx_fsv16::MakeLoadJitConstants(const eltwise_par
                 {
                     if (params.inputs[input.index].LogicalSize() == params.output.Feature().v &&
                         params.inputs[input.index].LogicalSize() == params.inputs[input.index].Feature().v) {
-                        std::string block_read_str = "BLOCK_READN(INPUT" + std::to_string(input.index) + "_TYPE, " +
+                        std::string block_read_str = "BLOCK_READN(INPUT" + toCodeString(input.index) + "_TYPE, " +
                                                      "1, " +
-                                                     "input" + std::to_string(input.index) +
-                                                     ", INPUT" + std::to_string(input.index);
+                                                     "input" + toCodeString(input.index) +
+                                                     ", INPUT" + toCodeString(input.index);
                         if (DataTensor::ChannelsCount(params.inputs[input_idx].GetLayout()) == 4) {
                             jit.AddConstant(MakeJitConstant(name, block_read_str + "_GET_INDEX(b, f_block*16, y, x))"));
                         } else {
@@ -106,10 +106,10 @@ JitConstants EltwiseKernel_b_fs_yx_fsv16::MakeLoadJitConstants(const eltwise_par
                         }
                     } else if (params.inputs[input.index].LogicalSize() == 1) {
                         jit.AddConstant(MakeJitConstant(name,
-                                                        "input" + std::to_string(input.index) +
+                                                        "input" + toCodeString(input.index) +
                                                         "[0]"));
                     } else {
-                        const std::string idx_order = "INPUT" + std::to_string(input.index) + "_IDX_ORDER";
+                        const std::string idx_order = "INPUT" + toCodeString(input.index) + "_IDX_ORDER";
                         if (DataTensor::ChannelsCount(params.inputs[input_idx].GetLayout()) == 4) {
                             jit.AddConstant(MakeJitConstant(idx_order, "b, f_block*16, y, x"));
                         } else {
@@ -118,25 +118,25 @@ JitConstants EltwiseKernel_b_fs_yx_fsv16::MakeLoadJitConstants(const eltwise_par
                         bool feature_broadcasting = (params.inputs[input_idx].Feature().v == 1 && params.output.Feature().v != 1);
 
                         const std::string block_read_str = "TO_TYPE(MAKE_VECTOR_TYPE(ACCUMULATOR_TYPE, BLOCK_SIZE), BLOCK_READN(INPUT" +
-                                                                std::to_string(input.index) + "_TYPE, BLOCK_SIZE, " +
-                                                                "input" + std::to_string(input.index) + ", " +
-                                                                "GET_INDEX(INPUT, " + std::to_string(input.index) + ", " + idx_order + ")))";
+                                                                toCodeString(input.index) + "_TYPE, BLOCK_SIZE, " +
+                                                                "input" + toCodeString(input.index) + ", " +
+                                                                "GET_INDEX(INPUT, " + toCodeString(input.index) + ", " + idx_order + ")))";
                         if (feature_broadcasting) {
-                            const std::string broadcast_name = "DO_FEATURE_BROADCAST" + std::to_string(op_num);
+                            const std::string broadcast_name = "DO_FEATURE_BROADCAST" + toCodeString(op_num);
                             std::string sub_group_broadcast;
                             if (GetBlockSize(params) == 1) {
-                                sub_group_broadcast = "\\\n\ttmp_b" + std::to_string(op_num) +
-                                                    " = sub_group_broadcast(tmp_b" + std::to_string(op_num) + ", 0);";
+                                sub_group_broadcast = "\\\n\ttmp_b" + toCodeString(op_num) +
+                                                    " = sub_group_broadcast(tmp_b" + toCodeString(op_num) + ", 0);";
                             } else {
-                                sub_group_broadcast = "\\\n\tunroll_for (uint i = 0; i < BLOCK_SIZE; ++i) tmp_b" + std::to_string(op_num) +
-                                                    "[i] = sub_group_broadcast(tmp_b" + std::to_string(op_num) + "[i], 0);";
+                                sub_group_broadcast = "\\\n\tunroll_for (uint i = 0; i < BLOCK_SIZE; ++i) tmp_b" + toCodeString(op_num) +
+                                                    "[i] = sub_group_broadcast(tmp_b" + toCodeString(op_num) + "[i], 0);";
                             }
 
-                            std::string broadcast_value = "\\\n\tMAKE_VECTOR_TYPE(ACCUMULATOR_TYPE, BLOCK_SIZE) tmp_b" + std::to_string(op_num) +
+                            std::string broadcast_value = "\\\n\tMAKE_VECTOR_TYPE(ACCUMULATOR_TYPE, BLOCK_SIZE) tmp_b" + toCodeString(op_num) +
                                                         " = " + block_read_str + ";" + sub_group_broadcast;
 
                             jit.AddConstant(MakeJitConstant(broadcast_name, broadcast_value));
-                            jit.AddConstant(MakeJitConstant(name, "tmp_b" + std::to_string(op_num)));
+                            jit.AddConstant(MakeJitConstant(name, "tmp_b" + toCodeString(op_num)));
                         } else {
                             jit.AddConstant(MakeJitConstant(name, block_read_str));
                         }
@@ -149,10 +149,10 @@ JitConstants EltwiseKernel_b_fs_yx_fsv16::MakeLoadJitConstants(const eltwise_par
                 case EltwiseInputMode::UNORDERED_ACCESS_INPUT_BUFFER:
                     jit.AddConstant(MakeJitConstant(
                             name,
-                            "input" + std::to_string(input.index) + "[(size_t)tmp" + std::to_string(input.tmpIndex) + "]"));
+                            "input" + toCodeString(input.index) + "[(size_t)tmp" + toCodeString(input.tmpIndex) + "]"));
                     break;
                 case EltwiseInputMode::INTERMEDIATE_RESULTS_INDEX:
-                    jit.AddConstant(MakeJitConstant(name, "tmp" + std::to_string(input.tmpIndex)));
+                    jit.AddConstant(MakeJitConstant(name, "tmp" + toCodeString(input.tmpIndex)));
                     break;
                 default:
                     break;
@@ -180,12 +180,12 @@ JitConstants EltwiseKernel_b_fs_yx_fsv16::GetJitConstants(const eltwise_params& 
     auto& operations = params.operations;
     for (size_t op_num = 0; op_num < operations.size(); op_num++) {
         if (OpHasFeatureBroadcast(params, op_num)) {
-            do_eltwise += "\\\n\tDO_FEATURE_BROADCAST" + std::to_string(op_num) + ";";
+            do_eltwise += "\\\n\tDO_FEATURE_BROADCAST" + toCodeString(op_num) + ";";
         }
-        do_eltwise += "\\\n\tOPERATION" + std::to_string(op_num) + ";";
+        do_eltwise += "\\\n\tOPERATION" + toCodeString(op_num) + ";";
     }
 
-    do_eltwise += "\\\n\tres = tmp" + std::to_string(operations.size() - 1) + ";";
+    do_eltwise += "\\\n\tres = tmp" + toCodeString(operations.size() - 1) + ";";
 
     jit.AddConstant(MakeJitConstant("DO_ELTWISE", do_eltwise));
 

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/eltwise/eltwise_kernel_b_fs_yx_fsv4.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/eltwise/eltwise_kernel_b_fs_yx_fsv4.cpp
@@ -125,11 +125,11 @@ JitConstants EltwiseKernel_b_fs_yx_fsv4::MakeLoadJitConstants(const eltwise_para
     JitConstants jit = {};
     std::string vload_decls;
     for (size_t op_num = 0; op_num < params.operations.size(); op_num++) {
-        const std::string op_num_str = std::to_string(op_num);
+        const std::string op_num_str = toCodeString(op_num);
         const auto &ew = params.operations[op_num];
         for (size_t input_idx = 0; input_idx < ew.inputs.size(); input_idx++) {
             const auto &input = ew.inputs[input_idx];
-            const std::string name = "INPUT_" + op_num_str + "_" + std::to_string(input_idx);
+            const std::string name = "INPUT_" + op_num_str + "_" + toCodeString(input_idx);
 
             switch (input.mode) {
                 case EltwiseInputMode::SCALAR:
@@ -137,36 +137,36 @@ JitConstants EltwiseKernel_b_fs_yx_fsv4::MakeLoadJitConstants(const eltwise_para
                     break;
                 case EltwiseInputMode::INPUT_BUFFER:
                 {
-                    const std::string idx_order = "INPUT" + std::to_string(input.index) + "_IDX_ORDER";
+                    const std::string idx_order = "INPUT" + toCodeString(input.index) + "_IDX_ORDER";
                     jit.AddConstant(MakeJitConstant(idx_order, "b, f_block*4, y, x"));
 
                     if (params.inputs[input.index].LogicalSize() == 1) {
-                        const std::string vload_name = "DO_VLOAD" + std::to_string(op_num) + "_" + std::to_string(input_idx);
-                        const std::string vload_value = "\\\n\tMAKE_VECTOR_TYPE(ACCUMULATOR_TYPE, 4) tmp_a" + std::to_string(op_num) +
-                                                        "_" + std::to_string(input_idx) + " = " "(MAKE_VECTOR_TYPE(ACCUMULATOR_TYPE, 4))" +
-                                                        "(input" + std::to_string(input.index) + "[0])";
+                        const std::string vload_name = "DO_VLOAD" + toCodeString(op_num) + "_" + toCodeString(input_idx);
+                        const std::string vload_value = "\\\n\tMAKE_VECTOR_TYPE(ACCUMULATOR_TYPE, 4) tmp_a" + toCodeString(op_num) +
+                                                        "_" + toCodeString(input_idx) + " = " "(MAKE_VECTOR_TYPE(ACCUMULATOR_TYPE, 4))" +
+                                                        "(input" + toCodeString(input.index) + "[0])";
                         jit.AddConstant(MakeJitConstant(vload_name, vload_value));
-                        jit.AddConstant(MakeJitConstant(name, "tmp_a" + std::to_string(op_num) + "_" + std::to_string(input_idx)));
+                        jit.AddConstant(MakeJitConstant(name, "tmp_a" + toCodeString(op_num) + "_" + toCodeString(input_idx)));
                     } else {
                         bool feature_broadcasting = (params.inputs[input_idx].Feature().v == 1 && params.output.Feature().v != 1);
 
                         if (feature_broadcasting) {
-                            const std::string broadcast_name = "DO_FEATURE_BROADCAST" + std::to_string(op_num) + "_" + std::to_string(input_idx);
-                            std::string broadcast_value = "\\\n\tMAKE_VECTOR_TYPE(ACCUMULATOR_TYPE, 4) tmp_b" + std::to_string(op_num) +
-                                                        " = " "(MAKE_VECTOR_TYPE(ACCUMULATOR_TYPE, 4))"+"(input" + std::to_string(input.index) +
-                                                        "[GET_INDEX(INPUT, " + std::to_string(input.index) + ", " + idx_order + ")]);";
+                            const std::string broadcast_name = "DO_FEATURE_BROADCAST" + toCodeString(op_num) + "_" + toCodeString(input_idx);
+                            std::string broadcast_value = "\\\n\tMAKE_VECTOR_TYPE(ACCUMULATOR_TYPE, 4) tmp_b" + toCodeString(op_num) +
+                                                        " = " "(MAKE_VECTOR_TYPE(ACCUMULATOR_TYPE, 4))"+"(input" + toCodeString(input.index) +
+                                                        "[GET_INDEX(INPUT, " + toCodeString(input.index) + ", " + idx_order + ")]);";
 
                             jit.AddConstant(MakeJitConstant(broadcast_name, broadcast_value));
-                            jit.AddConstant(MakeJitConstant(name, "tmp_b" + std::to_string(op_num)));
+                            jit.AddConstant(MakeJitConstant(name, "tmp_b" + toCodeString(op_num)));
                         } else {
-                            const std::string vload_name = "DO_VLOAD" + std::to_string(op_num) + "_" + std::to_string(input_idx);
-                            const std::string vload_value = "\\\n\tMAKE_VECTOR_TYPE(ACCUMULATOR_TYPE, 4) tmp_a" + std::to_string(op_num) +
-                                                            "_" + std::to_string(input_idx) + " = TO_TYPE(MAKE_VECTOR_TYPE(ACCUMULATOR_TYPE, " +
-                                                            std::to_string(vec_size) + "), vload4(0, &input" + std::to_string(input.index) +
-                                                            "[GET_INDEX(INPUT," + std::to_string(input.index) + ", " + idx_order + ")]));";
+                            const std::string vload_name = "DO_VLOAD" + toCodeString(op_num) + "_" + toCodeString(input_idx);
+                            const std::string vload_value = "\\\n\tMAKE_VECTOR_TYPE(ACCUMULATOR_TYPE, 4) tmp_a" + toCodeString(op_num) +
+                                                            "_" + toCodeString(input_idx) + " = TO_TYPE(MAKE_VECTOR_TYPE(ACCUMULATOR_TYPE, " +
+                                                            toCodeString(vec_size) + "), vload4(0, &input" + toCodeString(input.index) +
+                                                            "[GET_INDEX(INPUT," + toCodeString(input.index) + ", " + idx_order + ")]));";
 
                             jit.AddConstant(MakeJitConstant(vload_name, vload_value));
-                            jit.AddConstant(MakeJitConstant(name, "tmp_a" + std::to_string(op_num) + "_" + std::to_string(input_idx)));
+                            jit.AddConstant(MakeJitConstant(name, "tmp_a" + toCodeString(op_num) + "_" + toCodeString(input_idx)));
                         }
                     }
                     break;
@@ -177,10 +177,10 @@ JitConstants EltwiseKernel_b_fs_yx_fsv4::MakeLoadJitConstants(const eltwise_para
                 case EltwiseInputMode::UNORDERED_ACCESS_INPUT_BUFFER:
                     jit.AddConstant(MakeJitConstant(
                             name,
-                            "input" + std::to_string(input.index) + "[(size_t)tmp" + std::to_string(input.tmpIndex) + "]"));
+                            "input" + toCodeString(input.index) + "[(size_t)tmp" + toCodeString(input.tmpIndex) + "]"));
                     break;
                 case EltwiseInputMode::INTERMEDIATE_RESULTS_INDEX:
-                    jit.AddConstant(MakeJitConstant(name, "tmp" + std::to_string(input.tmpIndex)));
+                    jit.AddConstant(MakeJitConstant(name, "tmp" + toCodeString(input.tmpIndex)));
                     break;
                 default:
                     break;
@@ -214,15 +214,15 @@ JitConstants EltwiseKernel_b_fs_yx_fsv4::GetJitConstants(const eltwise_params& p
                 continue;
 
             if (InputHasFeatureBroadcast(params, op_num, input_idx)) {
-                do_eltwise += "\\\n\tDO_FEATURE_BROADCAST" + std::to_string(op_num) + "_" + std::to_string(input_idx) + ";";
+                do_eltwise += "\\\n\tDO_FEATURE_BROADCAST" + toCodeString(op_num) + "_" + toCodeString(input_idx) + ";";
             } else {
-                do_eltwise += "\\\n\tDO_VLOAD" + std::to_string(op_num) + "_" + std::to_string(input_idx) + ";";
+                do_eltwise += "\\\n\tDO_VLOAD" + toCodeString(op_num) + "_" + toCodeString(input_idx) + ";";
             }
         }
-        do_eltwise += "\\\n\tOPERATION" + std::to_string(op_num) + ";";
+        do_eltwise += "\\\n\tOPERATION" + toCodeString(op_num) + ";";
     }
 
-    do_eltwise += "\\\n\tres = tmp" + std::to_string(operations.size() - 1) + ";";
+    do_eltwise += "\\\n\tres = tmp" + toCodeString(operations.size() - 1) + ";";
 
     jit.AddConstant(MakeJitConstant("DO_ELTWISE", do_eltwise));
 

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/eltwise/eltwise_kernel_base.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/eltwise/eltwise_kernel_base.cpp
@@ -139,7 +139,7 @@ bool EltwiseKernelBase::IsUnsupportedModeForVecCode(const eltwise_params& params
 JitConstants EltwiseKernelBase::GetOperationsJitConstants(const eltwise_params& params, bool useVload8, size_t blockSize) const {
     JitConstants jit = {};
     for (size_t op_num = 0; op_num < params.operations.size(); op_num++) {
-        const std::string op_num_str = std::to_string(op_num);
+        const std::string op_num_str = toCodeString(op_num);
         const auto& ew = params.operations[op_num];
 
         std::string op, cast_type;
@@ -168,7 +168,7 @@ JitConstants EltwiseKernelBase::GetOperationsJitConstants(const eltwise_params& 
                 if (input.mode == EltwiseInputMode::INPUT_BUFFER && input.index < coefficients.size()) {
                     const float c = coefficients[input.index];
                     if (c != 1.0f)
-                        coeff_strings[input_idx] = cast_type + "(" + std::to_string(c) + ")*";
+                        coeff_strings[input_idx] = cast_type + "(" + toCodeString(c) + ")*";
                 }
             }
 
@@ -285,12 +285,12 @@ JitConstants EltwiseKernelBase::MakeLoadJitConstants(const eltwise_params& param
     JitConstants jit = {};
     std::string vload_decls;
     for (size_t op_num = 0; op_num < params.operations.size(); op_num++) {
-        const std::string op_num_str = std::to_string(op_num);
+        const std::string op_num_str = toCodeString(op_num);
         const auto &ew = params.operations[op_num];
         for (size_t input_idx = 0; input_idx < ew.inputs.size(); input_idx++) {
             const auto &input = ew.inputs[input_idx];
-            const std::string name = "INPUT_" + op_num_str + "_" + std::to_string(input_idx);
-            std::string idx_order = "INPUT" + std::to_string(input.index) + "_IDX_ORDER";
+            const std::string name = "INPUT_" + op_num_str + "_" + toCodeString(input_idx);
+            std::string idx_order = "INPUT" + toCodeString(input.index) + "_IDX_ORDER";
 
             switch (input.mode) {
                 case EltwiseInputMode::SCALAR:
@@ -298,11 +298,11 @@ JitConstants EltwiseKernelBase::MakeLoadJitConstants(const eltwise_params& param
                     break;
                 case EltwiseInputMode::INPUT_BUFFER:
                     if (useVload8)
-                        jit.AddConstant(MakeJitConstant(name, "in" + std::to_string(input.index)));
+                        jit.AddConstant(MakeJitConstant(name, "in" + toCodeString(input.index)));
                     else
                         jit.AddConstant(MakeJitConstant(name,
-                                                        "input" + std::to_string(input.index) +
-                                                        "[GET_INDEX(INPUT, " + std::to_string(input.index) +
+                                                        "input" + toCodeString(input.index) +
+                                                        "[GET_INDEX(INPUT, " + toCodeString(input.index) +
                                                         "," + idx_order + ")]"));
                     break;
                 case EltwiseInputMode::OUTPUT_BUFFER:
@@ -311,10 +311,10 @@ JitConstants EltwiseKernelBase::MakeLoadJitConstants(const eltwise_params& param
                 case EltwiseInputMode::UNORDERED_ACCESS_INPUT_BUFFER:
                     jit.AddConstant(MakeJitConstant(
                             name,
-                            "input" + std::to_string(input.index) + "[(size_t)tmp" + std::to_string(input.tmpIndex) + "]"));
+                            "input" + toCodeString(input.index) + "[(size_t)tmp" + toCodeString(input.tmpIndex) + "]"));
                     break;
                 case EltwiseInputMode::INTERMEDIATE_RESULTS_INDEX:
-                    jit.AddConstant(MakeJitConstant(name, "tmp" + std::to_string(input.tmpIndex)));
+                    jit.AddConstant(MakeJitConstant(name, "tmp" + toCodeString(input.tmpIndex)));
                     break;
                 default:
                     break;
@@ -324,11 +324,11 @@ JitConstants EltwiseKernelBase::MakeLoadJitConstants(const eltwise_params& param
 
     if (useVload8) {
         for (size_t i = 0; i < params.inputs.size(); i++) {
-            vload_decls += "\\\n\tconst " + toCLType(params.inputs[i].GetDType()) + "8 in" + std::to_string(i);
+            vload_decls += "\\\n\tconst " + toCLType(params.inputs[i].GetDType()) + "8 in" + toCodeString(i);
             if (params.inputs[i].PhysicalSize() == 1)  // Scalar case
-                vload_decls += " = (" + toCLType(params.inputs[i].GetDType()) + "8)(input" + std::to_string(i) + "[0]";
+                vload_decls += " = (" + toCLType(params.inputs[i].GetDType()) + "8)(input" + toCodeString(i) + "[0]";
             else  // Buffer case
-                vload_decls += " = vload8(global_id, input" + std::to_string(i);
+                vload_decls += " = vload8(global_id, input" + toCodeString(i);
             vload_decls += ");";
         }
         jit.AddConstant(MakeJitConstant("VLOAD_DECLS", vload_decls));
@@ -350,7 +350,7 @@ JitConstants EltwiseKernelBase::MakeInputDeclsJitConstants(const eltwise_params&
                 break;
             }
         }
-        inputs_decls += const_str + " __global " + toCLType(params.inputs[i].GetDType()) + "* input" + std::to_string(i) + ", ";
+        inputs_decls += const_str + " __global " + toCLType(params.inputs[i].GetDType()) + "* input" + toCodeString(i) + ", ";
     }
     jit.AddConstant(MakeJitConstant("INPUTS_DECLS", inputs_decls));
     return jit;
@@ -379,8 +379,8 @@ JitConstants EltwiseKernelBase::MakeIndexJitConstants(const eltwise_params& para
         }
 
         if (!params.stride.empty()) {
-            bfyx_idx_order[2] = "(" + bfyx_idx_order[2] + "*" + std::to_string(stride.y) + ")";
-            bfyx_idx_order[3] = "(" + bfyx_idx_order[3] + "*" + std::to_string(stride.x) + ")";
+            bfyx_idx_order[2] = "(" + bfyx_idx_order[2] + "*" + toCodeString(stride.y) + ")";
+            bfyx_idx_order[3] = "(" + bfyx_idx_order[3] + "*" + toCodeString(stride.x) + ")";
         }
 
         return bfyx_idx_order;
@@ -429,12 +429,12 @@ JitConstants EltwiseKernelBase::MakeIndexJitConstants(const eltwise_params& para
         }
 
         if (!params.stride.empty()) {
-            jit.AddConstant(MakeJitConstant("INPUT" + std::to_string(i) + "_STRIDE_X", params.stride[i].x));
-            jit.AddConstant(MakeJitConstant("INPUT" + std::to_string(i) + "_STRIDE_Y", params.stride[i].y));
-            jit.AddConstant(MakeJitConstant("INPUT" + std::to_string(i) + "_STRIDE_Z", params.stride[i].z));
+            jit.AddConstant(MakeJitConstant("INPUT" + toCodeString(i) + "_STRIDE_X", params.stride[i].x));
+            jit.AddConstant(MakeJitConstant("INPUT" + toCodeString(i) + "_STRIDE_Y", params.stride[i].y));
+            jit.AddConstant(MakeJitConstant("INPUT" + toCodeString(i) + "_STRIDE_Z", params.stride[i].z));
         }
 
-        std::string idx_order = "INPUT" + std::to_string(i) + "_IDX_ORDER";
+        std::string idx_order = "INPUT" + toCodeString(i) + "_IDX_ORDER";
         if (useVload8) {
             jit.AddConstant(MakeJitConstant(idx_order, "d1"));
         } else {
@@ -498,17 +498,17 @@ JitConstants EltwiseKernelBase::GetJitConstantsCommon(const eltwise_params& para
     std::string do_eltwise;
     auto& operations = params.operations;
     for (size_t op_num = 0; op_num < operations.size(); op_num++) {
-        do_eltwise += "\\\n\tOPERATION" + std::to_string(op_num) + ";";
+        do_eltwise += "\\\n\tOPERATION" + toCodeString(op_num) + ";";
     }
 
     auto& updateInputs = params.updateInputIds;
     for (size_t update_input_idx = 0; update_input_idx < updateInputs.size(); update_input_idx++)
-        do_eltwise += "\\\n\tinput" + std::to_string(updateInputs[update_input_idx].inputId) + "[GET_INDEX(INPUT, " +
-                      std::to_string(updateInputs[update_input_idx].inputId) + ", " +
-                      "INPUT"+std::to_string(updateInputs[update_input_idx].inputId) + "_IDX_ORDER)] = tmp" +
-                      std::to_string(updateInputs[update_input_idx].tmpId) + ";";
+        do_eltwise += "\\\n\tinput" + toCodeString(updateInputs[update_input_idx].inputId) + "[GET_INDEX(INPUT, " +
+                      toCodeString(updateInputs[update_input_idx].inputId) + ", " +
+                      "INPUT"+toCodeString(updateInputs[update_input_idx].inputId) + "_IDX_ORDER)] = tmp" +
+                      toCodeString(updateInputs[update_input_idx].tmpId) + ";";
 
-    do_eltwise += "\\\n\tres = tmp" + std::to_string(operations.size() - 1) + ";";
+    do_eltwise += "\\\n\tres = tmp" + toCodeString(operations.size() - 1) + ";";
 
     jit.AddConstant(MakeJitConstant("DO_ELTWISE", do_eltwise));
 

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/gemm/gemm_kernel_tiled_opt.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/gemm/gemm_kernel_tiled_opt.cpp
@@ -114,7 +114,7 @@ JitConstants GemmKernelTiledOpt::GetJitConstants(const gemm_params& params) cons
     if (tuning_data.tile_k_size > tuning_data.simd_size) {
         jit.AddConstants({
             MakeJitConstant("A_VEC_SIZE", tuning_data.tile_k_size / tuning_data.simd_size),
-            MakeJitConstant("A_FLOATN", std::string("UNIT_TYPE") + std::to_string(tuning_data.tile_k_size / tuning_data.simd_size)),
+            MakeJitConstant("A_FLOATN", std::string("UNIT_TYPE") + toCodeString(tuning_data.tile_k_size / tuning_data.simd_size)),
         });
     } else {
         jit.AddConstants({
@@ -126,7 +126,7 @@ JitConstants GemmKernelTiledOpt::GetJitConstants(const gemm_params& params) cons
     if (tuning_data.tile_n_size > tuning_data.simd_size) {
         jit.AddConstants({
             MakeJitConstant("B_VEC_SIZE", b_vec_size),
-            MakeJitConstant("B_FLOATN", std::string("UNIT_TYPE") + std::to_string(b_vec_size)),
+            MakeJitConstant("B_FLOATN", std::string("UNIT_TYPE") + toCodeString(b_vec_size)),
         });
     } else {
         b_vec_size = 1;

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/permute/permute_kernel_ref.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/permute/permute_kernel_ref.cpp
@@ -89,18 +89,18 @@ static std::string GetReorderedOutputOrder(const permute_params& params, const s
     } else {
         // dim is expanded
         if (dim_change.first == 4 && dim_change.second == 5) {
-            reordered_order += (permute_out_idx.back() + "/" + std::to_string(params.output.Y().v)
-                                 + ", " + permute_out_idx.back() + "%" + std::to_string(params.output.Y().v)
+            reordered_order += (permute_out_idx.back() + "/" + toCodeString(params.output.Y().v)
+                                 + ", " + permute_out_idx.back() + "%" + toCodeString(params.output.Y().v)
                                  + ", " + permute_out_idx[2]);
         } else if (dim_change.first == 4 && dim_change.second == 6) {
-            reordered_order += (permute_out_idx.back() + "/ (" + std::to_string(params.output.Y().v)
-                                 + " * " + std::to_string(params.output.Z().v) + ")"
-                                 + ", " + permute_out_idx.back() + "/" + std::to_string(params.output.Y().v)
-                                 + ", " + permute_out_idx.back() + "%" + std::to_string(params.output.Y().v)
+            reordered_order += (permute_out_idx.back() + "/ (" + toCodeString(params.output.Y().v)
+                                 + " * " + toCodeString(params.output.Z().v) + ")"
+                                 + ", " + permute_out_idx.back() + "/" + toCodeString(params.output.Y().v)
+                                 + ", " + permute_out_idx.back() + "%" + toCodeString(params.output.Y().v)
                                  + ", " + permute_out_idx[2]);
         } else if (dim_change.first == 5 && dim_change.second == 6) {
-            reordered_order += (permute_out_idx.back() + "/" + std::to_string(params.output.Z().v)
-                                 + ", " + permute_out_idx.back() + "%" + std::to_string(params.output.Z().v)
+            reordered_order += (permute_out_idx.back() + "/" + toCodeString(params.output.Z().v)
+                                 + ", " + permute_out_idx.back() + "%" + toCodeString(params.output.Z().v)
                                  + ", " + permute_out_idx[3]
                                  + ", " + permute_out_idx[2]);
         }

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/permute/permute_kernel_tile_8x8_4x4.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/permute/permute_kernel_tile_8x8_4x4.cpp
@@ -102,18 +102,18 @@ static inline std::string GetTiledOutputOrder(const permute_params& params) {
     } else {
         // dim is expanded
         if (dim_change.first == 4 && dim_change.second == 5) {
-            order_str = ("b, y,  (x * TILE_SIZE + lh) / " + std::to_string(params.output.Y().v)
-                                 + ", (x * TILE_SIZE +lh) % " + std::to_string(params.output.Y().v)
+            order_str = ("b, y,  (x * TILE_SIZE + lh) / " + toCodeString(params.output.Y().v)
+                                 + ", (x * TILE_SIZE +lh) % " + toCodeString(params.output.Y().v)
                                  + ", (f * TILE_SIZE)");
         } else if (dim_change.first == 4 && dim_change.second == 6) {
-            order_str = ("b, y, (x * TILE_SIZE + lh) / (" + std::to_string(params.output.Y().v)
-                                 + " * " + std::to_string(params.output.Z().v) + ")"
-                                 + ", (x * TILE_SIZE + lh) / " + std::to_string(params.output.Y().v)
-                                 + ", (x * TILE_SIZE + lh) % " + std::to_string(params.output.Y().v)
+            order_str = ("b, y, (x * TILE_SIZE + lh) / (" + toCodeString(params.output.Y().v)
+                                 + " * " + toCodeString(params.output.Z().v) + ")"
+                                 + ", (x * TILE_SIZE + lh) / " + toCodeString(params.output.Y().v)
+                                 + ", (x * TILE_SIZE + lh) % " + toCodeString(params.output.Y().v)
                                  + ", (f * TILE_SIZE)");
         } else if (dim_change.first == 5 && dim_change.second == 6) {
-            order_str = ("b, z, y /" + std::to_string(params.output.Z().v)
-                                 + ", y % " + std::to_string(params.output.Z().v)
+            order_str = ("b, z, y /" + toCodeString(params.output.Z().v)
+                                 + ", y % " + toCodeString(params.output.Z().v)
                                  + ", (x * TILE_SIZE + lh), (f * TILE_SIZE)");
         } else {
             throw std::runtime_error("Unsupported combination\n");

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/permute/permute_kernel_tile_8x8_4x4_fsv.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/permute/permute_kernel_tile_8x8_4x4_fsv.cpp
@@ -98,18 +98,18 @@ static inline std::string GetReorderedTiledOutputOrder(const permute_params& par
     } else {
         // dim is expanded
         if (dim_change.first == 4 && dim_change.second == 5) {
-            order_str = ("b, y + lh, x / " + std::to_string(params.output.Y().v)
-                                 + ", x % " + std::to_string(params.output.Y().v)
+            order_str = ("b, y + lh, x / " + toCodeString(params.output.Y().v)
+                                 + ", x % " + toCodeString(params.output.Y().v)
                                  + ", f");
         } else if (dim_change.first == 4 && dim_change.second == 6) {
-            order_str = ("b, y + lh, x / (" + std::to_string(params.output.Y().v)
-                                 + " * " + std::to_string(params.output.Z().v) + ")"
-                                 + ", x / " + std::to_string(params.output.Y().v)
-                                 + ", x % " + std::to_string(params.output.Y().v)
+            order_str = ("b, y + lh, x / (" + toCodeString(params.output.Y().v)
+                                 + " * " + toCodeString(params.output.Z().v) + ")"
+                                 + ", x / " + toCodeString(params.output.Y().v)
+                                 + ", x % " + toCodeString(params.output.Y().v)
                                  + ", f");
         } else if (dim_change.first == 5 && dim_change.second == 6) {
-            order_str = ("b, z + lh, y /" + std::to_string(params.output.Z().v)
-                                 + ", y % " + std::to_string(params.output.Z().v)
+            order_str = ("b, z + lh, y /" + toCodeString(params.output.Z().v)
+                                 + ", y % " + toCodeString(params.output.Z().v)
                                  + ", x, f");
         } else {
             throw std::runtime_error("Unsupported combination\n");

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/reduce/reduce_kernel_b_fs_yx_fsv16.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/reduce/reduce_kernel_b_fs_yx_fsv16.cpp
@@ -143,7 +143,7 @@ JitConstants ReduceKernel_b_fs_yx_fsv16::GetJitConstants(const reduce_params& pa
     jit.AddConstant(MakeJitConstant("COMMON_OUTPUT_FEATURE_NUM", in_dims[1].v));
     jit.AddConstant(MakeJitConstant("COMMON_OUTPUT_BATCH_NUM", in_dims[0].v));
     jit.AddConstant(MakeJitConstant("READ_OFFSET", read_offset));
-    jit.AddConstant(MakeJitConstant("BLOCK_READ(ptr,offset)", "DT_INPUT_BLOCK_READ" + std::to_string(read_offset) + "(ptr,offset)"));
+    jit.AddConstant(MakeJitConstant("BLOCK_READ(ptr,offset)", "DT_INPUT_BLOCK_READ" + toCodeString(read_offset) + "(ptr,offset)"));
     jit.Merge(MakeTypeJitConstants(GetActivationType(params), "ACTIVATION"));
     jit.Merge(MakeTypeJitConstants(GetAccumulatorType(params), "ACCUMULATOR"));
     jit.Merge(MakeTypeJitConstants(GetFinalAccumulatorType(params), "FINAL_ACCUMULATOR"));

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/select/select_kernel_base.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/select/select_kernel_base.cpp
@@ -36,7 +36,7 @@ JitConstants SelectKernelBase::GetJitConstantsCommon(const select_params& params
         std::string const_str = "const";
 
         inputs_decls +=
-            const_str + " __global " + toCLType(params.inputs[i].GetDType()) + "* input" + std::to_string(i) + ", ";
+            const_str + " __global " + toCLType(params.inputs[i].GetDType()) + "* input" + toCodeString(i) + ", ";
     }
 
     jit.AddConstant(MakeJitConstant("INPUTS_DECLS", inputs_decls));

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/common/jitter.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/common/jitter.h
@@ -14,6 +14,7 @@
 #include <vector>
 #include <memory>
 #include <utility>
+#include <locale>
 
 namespace kernel_selector {
 
@@ -79,7 +80,10 @@ std::string getMeanOpString(MeanOp op);
 // TODO improve to_code_string specializations
 template <typename T>
 std::string toCodeString(T val) {
-    return std::to_string(val);
+    std::stringstream ss;
+    ss.imbue(std::locale("C"));
+    ss << val;
+    return ss.str();
 }
 
 inline std::string toCodeString(const std::string& val) { return val; }
@@ -87,6 +91,8 @@ inline std::string toCodeString(const char* val) { return val; }
 inline std::string toCodeString(bool val) { return val ? "1" : "0"; }
 std::string toCodeString(float val);
 std::string toCodeString(double val);
+std::string toCodeString(uint8_t val);
+std::string toCodeString(int8_t val);
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // JitConstant

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/common/kernel_base_opencl.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/common/kernel_base_opencl.cpp
@@ -74,7 +74,7 @@ std::string KernelBaseOpenCL::GetEntryPoint(const std::string& templateName,
     std::replace(kernelID.begin(), kernelID.end(), '.', '_');
     std::replace(kernelID.begin(), kernelID.end(), '/', '_');
 
-    kernelID += "_" + std::to_string(UniqeID());
+    kernelID += "_" + toCodeString(UniqeID());
 
     return kernelID;
 }

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/kernel_base.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/kernel_base.cpp
@@ -130,13 +130,13 @@ JitConstants KernelBase::MakeFusedOpsJitConstants(const kernel_selector::base_pa
                 if (params.fused_ops[i].GetType() == FusedOpType::ELTWISE &&
                     c.load_type == FusedOpsConfiguration::LoadType::FEATURE_SHUFFLE)
                     can_preload_eltwise = false;
-                fused_ops += "\\\n\tFUSED_OP" + std::to_string(i) + "_LOAD" + c.suffix;
-                fused_ops += "\\\n\tFUSED_OP" + std::to_string(i) + "_ACTION" + c.suffix;
+                fused_ops += "\\\n\tFUSED_OP" + toCodeString(i) + "_LOAD" + c.suffix;
+                fused_ops += "\\\n\tFUSED_OP" + toCodeString(i) + "_ACTION" + c.suffix;
                 if (can_use_preload && can_preload_eltwise)
-                    fused_ops_preload += "\\\n\tFUSED_OP" + std::to_string(i) + "_LOAD" + c.suffix;
+                    fused_ops_preload += "\\\n\tFUSED_OP" + toCodeString(i) + "_LOAD" + c.suffix;
                 if (c.allow_for_partial_preload && (!can_use_preload || !can_preload_eltwise))
-                    fused_ops_calc += "\\\n\tFUSED_OP" + std::to_string(i) + "_LOAD" + c.suffix;
-                fused_ops_calc += "\\\n\tFUSED_OP" + std::to_string(i) + "_ACTION" + c.suffix;
+                    fused_ops_calc += "\\\n\tFUSED_OP" + toCodeString(i) + "_LOAD" + c.suffix;
+                fused_ops_calc += "\\\n\tFUSED_OP" + toCodeString(i) + "_ACTION" + c.suffix;
             }
 
             jit.AddConstant(MakeJitConstant("FUSED_OPS" + c.suffix, fused_ops));
@@ -173,7 +173,7 @@ JitConstants KernelBase::MakeFusedOpsDeclsJitConstants(const kernel_selector::ba
         jit.Merge(fused_dep_codegen.MakeInputDeclsJitConstants(conf[0]));
         if (!params.fused_ops[i].tensors.empty()) {
             std::string optional_comma = (!input_decls.empty() ? "," : "");
-            input_decls += optional_comma + "\\\n\tFUSED_OP" + std::to_string(i) + "_DECLS";
+            input_decls += optional_comma + "\\\n\tFUSED_OP" + toCodeString(i) + "_DECLS";
         }
     }
 


### PR DESCRIPTION
### Details:
 - Floating point numbers with custom global locale could be converted with comma as separator which led to invalid OCL code generation and compilation error. So replaced all usages of `std::to_string` (which respects locale) with custom `toCodeString` function which serialize float as hex value without any separators.

### Tickets:
 - *57885*
