### PR TITLE
Fix deformable_convolution

### DIFF
--- a/ngraph/core/reference/include/ngraph/runtime/reference/deformable_convolution.hpp
+++ b/ngraph/core/reference/include/ngraph/runtime/reference/deformable_convolution.hpp
@@ -221,7 +221,6 @@ namespace ngraph
 
                 const Shape group_offset_shape =
                     shape_scale(shape_reduce(o_shape), deformable_groups);
-                const size_t group_offset_size = shape_size(group_offset_shape);
                 const size_t group_offset_batch_size = shape_size(shape_reduce(o_shape));
 
                 const size_t group_filters_count = f_shape[filter_out_ch_axis] / groups;


### PR DESCRIPTION
I think there is a error about the reference implementation of deformable_convolution.
The two parameters group and deformable_group is independent, and there are details about the parameter deformable_group in [MXNet](https://github.com/apache/incubator-mxnet/blob/master/src/operator/contrib/nn/deformable_im2col.h#L230)
Suppose that the shape of input data is (1,6,5,5), the shape of filter is (2,3,3,3), the shape of the offset is (1,54,3,3), group is 2, deformable_group is 3. And an error will occur on line 256 when group_idx equals 1.