### PR TITLE
Disable IEClassNetworkTestP.LoadNetworkActualNoThrow test

### DIFF
--- a/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/myriad/shared_tests_instances/skip_tests_config.cpp
@@ -42,10 +42,13 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*ActivationLayerTest.*SoftPlus.*)",
         // TODO: Issue 54722
         R"(.*IS=\(16\.16\.96\)\(96\)_eltwiseOpType=FloorMod_secondaryInputType=PARAMETER_opType=VECTOR_netPRC=FP32.*)",
-        // TODO: Issue CVS-57108
+        // TODO: Issue 57108
         R"(.*QueryNetworkHETEROWithMULTINoThrow_V10.*)",
         R"(.*QueryNetworkMULTIWithHETERONoThrow_V10.*)",
-        // TODO: Issue CVS-58162
-        R"(.*HoldersTestOnImportedNetwork\.CreateRequestWithCoreRemoved.*)"
+        // TODO: Issue 58162
+        R"(.*HoldersTestOnImportedNetwork\.CreateRequestWithCoreRemoved.*)",
+        // TODO: Issue 58621
+        R"(.*IEClassNetworkTestP\.LoadNetworkActualNoThrow.*)",
+        R"(.*IEClassNetworkTestP\.LoadNetworkActualHeteroDeviceNoThrow.*)"
     };
 }


### PR DESCRIPTION
### Details:
 - IEClassNetworkTestP.LoadNetworkActualNoThrow fails on Ununtu20. Disabled it and added TODO
 - *...*

### Tickets:
 - 58621
