### PR TITLE
[Frontend] pickle.dumps support for FrontEndManager

### DIFF
--- a/ngraph/python/src/pyngraph/frontend/frontend_manager.cpp
+++ b/ngraph/python/src/pyngraph/frontend/frontend_manager.cpp
@@ -21,6 +21,10 @@ void regclass_pyngraph_FrontEndManager(py::module m)
 
     fem.def(py::init<>());
 
+    // Empty pickle dumps are supported as FrontEndManager doesn't have any state
+    fem.def(py::pickle([](const ngraph::frontend::FrontEndManager&) { return py::make_tuple(0); },
+                       [](py::tuple t) { return ngraph::frontend::FrontEndManager(); } ));
+
     fem.def("get_available_front_ends",
             &ngraph::frontend::FrontEndManager::get_available_front_ends,
             R"(

--- a/ngraph/python/src/pyngraph/frontend/frontend_manager.cpp
+++ b/ngraph/python/src/pyngraph/frontend/frontend_manager.cpp
@@ -23,7 +23,7 @@ void regclass_pyngraph_FrontEndManager(py::module m)
 
     // Empty pickle dumps are supported as FrontEndManager doesn't have any state
     fem.def(py::pickle([](const ngraph::frontend::FrontEndManager&) { return py::make_tuple(0); },
-                       [](py::tuple t) { return ngraph::frontend::FrontEndManager(); } ));
+                       [](py::tuple t) { return ngraph::frontend::FrontEndManager(); }));
 
     fem.def("get_available_front_ends",
             &ngraph::frontend::FrontEndManager::get_available_front_ends,

--- a/ngraph/python/tests/test_ngraph/test_frontendmanager.py
+++ b/ngraph/python/tests/test_ngraph/test_frontendmanager.py
@@ -1,12 +1,15 @@
 # Copyright (C) 2018-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import numpy as np
-import pytest
+import pickle
 
 from ngraph import PartialShape
 from ngraph.frontend import FrontEndCapabilities, FrontEndManager, InitializationFailure
 from ngraph.utils.types import get_element_type
+
+import numpy as np
+
+import pytest
 
 mock_available = True
 try:
@@ -25,8 +28,8 @@ mock_needed = pytest.mark.skipif(not mock_available,
 
 # ---------- FrontEnd tests ---------------
 def test_pickle():
-    import pickle
     pickle.dumps(fem)
+
 
 @mock_needed
 def test_load_by_framework_caps():

--- a/ngraph/python/tests/test_ngraph/test_frontendmanager.py
+++ b/ngraph/python/tests/test_ngraph/test_frontendmanager.py
@@ -24,6 +24,10 @@ mock_needed = pytest.mark.skipif(not mock_available,
 
 
 # ---------- FrontEnd tests ---------------
+def test_pickle():
+    import pickle
+    pickle.dumps(fem)
+
 @mock_needed
 def test_load_by_framework_caps():
     frontEnds = fem.get_available_front_ends()


### PR DESCRIPTION
### Details:
 Original issue was discovered in Model Optimizer with command:
> mo.py --framework tf --saved_model_dir path_to_saved_model
Root cause is that FrontEndManager is created and added to 'argparse' which then is serialized using pickle.dumps.
Pickle GetState/SetState shall be supported for FrontEndManager, empty implementation is enough

### Tickets:
 - 58670
