### PR TITLE
Fixed / improved cmake for ngraph frontends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,8 +94,6 @@ function(build_ngraph)
 
     add_subdirectory(ngraph)
     set(NGRAPH_LIBRARIES ngraph PARENT_SCOPE)
-    set(FRONTEND_LIBRARIES frontend_manager PARENT_SCOPE)
-    set(NGRAPH_REF_LIBRARIES ngraph_reference PARENT_SCOPE)
 endfunction()
 
 function(openvino_developer_export_targets)

--- a/cmake/templates/ngraphConfig.cmake.in
+++ b/cmake/templates/ngraphConfig.cmake.in
@@ -18,16 +18,22 @@
 # FindNGraph
 # ------
 #
-# This will define the following variables:
+# This script defines the following variables and imported targets:
 #
-#   ngraph_FOUND               - True if the system has the nGraph library
-#   NGRAPH_LIBRARIES           - nGraph libraries
-#   ngraph::ngraph             - nGraph core target
+#   ngraph::ngraph                         - nGraph core target
+#   ngraph_FOUND                           - True if the system has the nGraph library
+#   NGRAPH_LIBRARIES                       - nGraph libraries
 #
-#   ngraph_onnx_importer_FOUND - True if the system has onnx_importer library
-#   ONNX_IMPORTER_LIBRARIES    - ONNX importer libraries
-#   ngraph::onnx_importer      - ONNX importer target
+# Frontends:
 #
+#   ngraph::frontend_manager               - nGraph frontend manager
+#
+#   ngraph_onnx_importer_FOUND             - True if the system has onnx_importer library
+#   ngraph::onnx_importer                  - ONNX importer target (optional)
+#   ONNX_IMPORTER_LIBRARIES                - ONNX importer libraries
+#
+#   ngraph_paddlepaddle_frontend_FOUND     - True if the system has PDPD frontend
+#   ngraph::paddlepaddle_ngraph_frontend   - nGraph PDPD frontend (optional)
 #
 
 @PACKAGE_INIT@
@@ -43,5 +49,7 @@ set(ngraph_onnx_importer_FOUND @NGRAPH_ONNX_IMPORT_ENABLE@)
 if(ngraph_onnx_importer_FOUND)
     set(ONNX_IMPORTER_LIBRARIES ngraph::onnx_importer)
 endif()
+
+set(ngraph_paddlepaddle_frontend_FOUND @NGRAPH_PDPD_FRONTEND_ENABLE@)
 
 check_required_components(ngraph)

--- a/inference-engine/src/snippets/CMakeLists.txt
+++ b/inference-engine/src/snippets/CMakeLists.txt
@@ -31,7 +31,7 @@ ie_add_vs_version_file(NAME ${TARGET_NAME}
 target_compile_definitions(${TARGET_NAME} PRIVATE inference_engine_transformations_EXPORTS)
 
 target_link_libraries(${TARGET_NAME} PUBLIC inference_engine_transformations ${NGRAPH_LIBRARIES}
-                                     PRIVATE ${NGRAPH_REF_LIBRARIES})
+                                     PRIVATE ngraph_reference)
 
 target_include_directories(${TARGET_NAME} PUBLIC ${PUBLIC_HEADERS_DIR}
                                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/inference-engine/src/transformations/CMakeLists.txt
+++ b/inference-engine/src/transformations/CMakeLists.txt
@@ -28,7 +28,7 @@ ie_add_vs_version_file(NAME ${TARGET_NAME}
                        FILEDESCRIPTION "Inference Engine Transformations library")
 
 target_link_libraries(${TARGET_NAME} PUBLIC ${NGRAPH_LIBRARIES}
-                                     PRIVATE ${NGRAPH_REF_LIBRARIES} openvino::itt ngraph::builder pugixml)
+                                     PRIVATE ngraph_reference openvino::itt ngraph::builder pugixml)
 
 target_include_directories(${TARGET_NAME} PUBLIC $<BUILD_INTERFACE:${PUBLIC_HEADERS_DIR}>
                                           PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src")

--- a/ngraph/frontend/CMakeLists.txt
+++ b/ngraph/frontend/CMakeLists.txt
@@ -42,6 +42,8 @@ if(NOT WIN32)
             DEPENDS ${PROTOBUF_STATIC_LIB_OUTPUT})
 endif()
 
+set(FRONTEND_INSTALL_INCLUDE "${NGRAPH_INSTALL_INCLUDE}/ngraph/frontend")
+
 add_subdirectory(frontend_manager)
 
 if (NGRAPH_ONNX_IMPORT_ENABLE)

--- a/ngraph/frontend/frontend_manager/CMakeLists.txt
+++ b/ngraph/frontend/frontend_manager/CMakeLists.txt
@@ -15,10 +15,11 @@ source_group("include" FILES ${LIBRARY_HEADERS})
 source_group("public include" FILES ${LIBRARY_PUBLIC_HEADERS})
 
 # Create shared library
+
 add_library(${TARGET_NAME} SHARED ${LIBRARY_SRC} ${LIBRARY_HEADERS} ${LIBRARY_PUBLIC_HEADERS})
 add_library(ngraph::${TARGET_NAME} ALIAS ${TARGET_NAME})
 
-target_link_libraries(${TARGET_NAME} PRIVATE ${CMAKE_DL_LIBS} ngraph)
+target_link_libraries(${TARGET_NAME} PRIVATE ${CMAKE_DL_LIBS} PUBLIC ngraph)
 
 add_clang_format_target(${TARGET_NAME}_clang FOR_TARGETS ${TARGET_NAME})
 
@@ -27,14 +28,13 @@ if(COMMAND ie_add_vs_version_file)
                            FILEDESCRIPTION "Manager of OpenVINO nGraph Frontends")
 endif()
 
-set(FRONTEND_INSTALL_INCLUDE "${NGRAPH_INSTALL_INCLUDE}/ngraph/frontend/frontend_manager")
 target_include_directories(${TARGET_NAME} PUBLIC $<BUILD_INTERFACE:${FRONTEND_INCLUDE_DIR}>
-                                                       $<INSTALL_INTERFACE:${FRONTEND_INSTALL_INCLUDE}>)
-target_include_directories(${TARGET_NAME} PRIVATE ${NGRAPH_INCLUDE_PATH} ${FRONTEND_INCLUDE_DIR})
+                                                 $<INSTALL_INTERFACE:${FRONTEND_INSTALL_INCLUDE}>)
 
 target_include_directories(${TARGET_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 # Installation rules
+
 install(TARGETS ${TARGET_NAME} EXPORT ngraphTargets
         RUNTIME DESTINATION ${NGRAPH_INSTALL_LIB} COMPONENT ngraph
         ARCHIVE DESTINATION ${NGRAPH_INSTALL_LIB} COMPONENT ngraph
@@ -42,10 +42,7 @@ install(TARGETS ${TARGET_NAME} EXPORT ngraphTargets
 
 install(DIRECTORY ${FRONTEND_INCLUDE_DIR}/frontend_manager
     DESTINATION ${FRONTEND_INSTALL_INCLUDE}
-    COMPONENT ngraph
-    FILES_MATCHING
-        PATTERN "*.hpp"
-)
+    COMPONENT ngraph_dev
+    FILES_MATCHING PATTERN "*.hpp")
 
 export(TARGETS ${TARGET_NAME} NAMESPACE ngraph:: APPEND FILE "${NGRAPH_TARGETS_FILE}")
-

--- a/ngraph/frontend/onnx_common/CMakeLists.txt
+++ b/ngraph/frontend/onnx_common/CMakeLists.txt
@@ -22,15 +22,14 @@ add_library(ngraph::onnx_common ALIAS ${TARGET_NAME})
 
 set(ONNX_COMMON_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set(ONNX_COMMON_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
-set(ONNX_COMMON_INSTALL_INCLUDE "${NGRAPH_INSTALL_INCLUDE}/ngraph/frontend")
 
 target_include_directories(${TARGET_NAME} PUBLIC $<BUILD_INTERFACE:${ONNX_COMMON_INCLUDE_DIR}>
-                                                 $<INSTALL_INTERFACE:${ONNX_COMMON_INSTALL_INCLUDE}>)
+                                                 $<INSTALL_INTERFACE:${FRONTEND_INSTALL_INCLUDE}>)
 
 target_link_libraries(${TARGET_NAME} PRIVATE ngraph)
 target_link_libraries(${TARGET_NAME} PUBLIC onnx_proto onnx ${Protobuf_LIBRARIES})
 
-target_include_directories(${TARGET_NAME} PRIVATE ${ONNX_COMMON_SRC_DIR} ${NGRAPH_INCLUDE_PATH} ${Protobuf_INCLUDE_DIRS})
+target_include_directories(${TARGET_NAME} PRIVATE ${ONNX_COMMON_SRC_DIR})
 
 if(NGRAPH_USE_PROTOBUF_LITE)
     target_compile_definitions(${TARGET_NAME} PRIVATE NGRAPH_USE_PROTOBUF_LITE)

--- a/ngraph/frontend/onnx_editor/CMakeLists.txt
+++ b/ngraph/frontend/onnx_editor/CMakeLists.txt
@@ -27,12 +27,11 @@ target_link_libraries(${TARGET_NAME} PRIVATE onnx_common onnx_importer
 
 set(ONNX_EDITOR_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set(ONNX_EDITOR_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
-set(ONNX_EDITOR_INSTALL_INCLUDE "${NGRAPH_INSTALL_INCLUDE}/ngraph/frontend")
 
 target_include_directories(${TARGET_NAME} PUBLIC $<BUILD_INTERFACE:${ONNX_EDITOR_INCLUDE_DIR}>
-                                                 $<INSTALL_INTERFACE:${ONNX_EDITOR_INSTALL_INCLUDE}>)
+                                                 $<INSTALL_INTERFACE:${FRONTEND_INSTALL_INCLUDE}>)
 
-target_include_directories(${TARGET_NAME} PRIVATE ${ONNX_EDITOR_SRC_DIR} ${NGRAPH_INCLUDE_PATH} ${Protobuf_INCLUDE_DIRS})
+target_include_directories(${TARGET_NAME} PRIVATE ${ONNX_EDITOR_SRC_DIR})
 
 if(NGRAPH_USE_PROTOBUF_LITE)
     target_compile_definitions(${TARGET_NAME} PRIVATE NGRAPH_USE_PROTOBUF_LITE)

--- a/ngraph/frontend/onnx_import/CMakeLists.txt
+++ b/ngraph/frontend/onnx_import/CMakeLists.txt
@@ -48,12 +48,10 @@ endif()
 target_link_libraries(onnx_importer PRIVATE onnx_common ngraph::builder
     PUBLIC ngraph)
 
-set(ONNX_INSTALL_INCLUDE "${NGRAPH_INSTALL_INCLUDE}/ngraph/frontend")
-target_include_directories(onnx_importer SYSTEM PUBLIC $<BUILD_INTERFACE:${ONNX_IMPORT_INCLUDE_DIR}>
-                                                       $<INSTALL_INTERFACE:${ONNX_INSTALL_INCLUDE}>)
+target_include_directories(onnx_importer PUBLIC $<BUILD_INTERFACE:${ONNX_IMPORT_INCLUDE_DIR}>
+                                                $<INSTALL_INTERFACE:${FRONTEND_INSTALL_INCLUDE}>)
 
-target_include_directories(onnx_importer PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src 
-                                                 ${NGRAPH_INCLUDE_PATH} ${Protobuf_INCLUDE_DIRS})
+target_include_directories(onnx_importer PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 target_compile_definitions(onnx_importer PRIVATE ONNX_OPSET_VERSION=${ONNX_OPSET_VERSION})
 
@@ -73,11 +71,8 @@ install(TARGETS onnx_importer EXPORT ngraphTargets
         LIBRARY DESTINATION ${NGRAPH_INSTALL_LIB} COMPONENT ngraph)
 
 install(DIRECTORY ${ONNX_IMPORT_INCLUDE_DIR}/onnx_import
-    DESTINATION ${ONNX_INSTALL_INCLUDE}
-    COMPONENT ngraph
-    FILES_MATCHING
-        PATTERN "*.hpp"
-        PATTERN "*.h"
-)
+        DESTINATION ${FRONTEND_INSTALL_INCLUDE}
+        COMPONENT ngraph_dev
+        FILES_MATCHING PATTERN "*.hpp")
 
 export(TARGETS onnx_importer NAMESPACE ngraph:: APPEND FILE "${NGRAPH_TARGETS_FILE}")

--- a/ngraph/frontend/paddlepaddle/CMakeLists.txt
+++ b/ngraph/frontend/paddlepaddle/CMakeLists.txt
@@ -8,10 +8,6 @@ file(GLOB_RECURSE LIBRARY_SRC ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 file(GLOB_RECURSE LIBRARY_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/src/*.hpp)
 file(GLOB_RECURSE LIBRARY_PUBLIC_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp)
 
-if (TARGET ext_protobuf)
-    add_dependencies(${TARGET_NAME} ext_protobuf)
-endif()
-
 set(${TARGET_NAME}_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 # Create named folders for the sources within the .vcproj
@@ -58,8 +54,6 @@ set_source_files_properties(${PROTO_SRCS} ${PROTO_HDRS} PROPERTIES GENERATED TRU
 # Disable all warnings for generated code
 set_source_files_properties(${PROTO_SRCS} ${PROTO_HDRS} PROPERTIES COMPILE_FLAGS -w)
 
-include_directories(${Protobuf_INCLUDE_DIRS} ${${TARGET_NAME}_INCLUDE_DIR})
-
 # Create shared library
 add_library(${TARGET_NAME} SHARED  ${LIBRARY_SRC} ${LIBRARY_HEADERS} ${LIBRARY_PUBLIC_HEADERS} ${PROTO_SRCS} ${PROTO_HDRS})
 
@@ -70,10 +64,17 @@ if(NOT WIN32)
     add_dependencies(${TARGET_NAME} libprotobuf_static)
 endif()
 
+if (TARGET ext_protobuf)
+    add_dependencies(${TARGET_NAME} ext_protobuf)
+endif()
+
 target_include_directories(${TARGET_NAME}
+        PUBLIC
+            $<BUILD_INTERFACE:${${TARGET_NAME}_INCLUDE_DIR}>
+            $<INSTALL_INTERFACE:${FRONTEND_INSTALL_INCLUDE}>
         PRIVATE
+            ${Protobuf_INCLUDE_DIRS}
             ${CMAKE_CURRENT_SOURCE_DIR}/src
-            ${FRONTEND_INCLUDE_PATH}
             ${CMAKE_CURRENT_BINARY_DIR})
 
 if(COMMAND ie_add_vs_version_file)
@@ -82,12 +83,13 @@ if(COMMAND ie_add_vs_version_file)
 endif()
 
 if(WIN32)
-    target_link_libraries(${TARGET_NAME} PRIVATE libprotobuf PUBLIC ngraph PRIVATE ngraph::builder)
+    target_link_libraries(${TARGET_NAME} PRIVATE libprotobuf)
 else()
-    target_link_libraries(${TARGET_NAME} PRIVATE ${PROTOBUF_STATIC_LIB_OUTPUT} PUBLIC ngraph PRIVATE ngraph::builder)
+    target_link_libraries(${TARGET_NAME} PRIVATE ${PROTOBUF_STATIC_LIB_OUTPUT})
 endif()
 
-target_link_libraries(${TARGET_NAME} PRIVATE frontend_manager)
+target_link_libraries(${TARGET_NAME} PUBLIC frontend_manager
+                                     PRIVATE ngraph::builder)
 
 add_clang_format_target(${TARGET_NAME}_clang FOR_TARGETS ${TARGET_NAME}
                         EXCLUDE_PATTERNS ${PROTO_SRCS} ${PROTO_HDRS})
@@ -96,5 +98,11 @@ install(TARGETS ${TARGET_NAME} EXPORT ngraphTargets
         RUNTIME DESTINATION ${NGRAPH_INSTALL_LIB} COMPONENT ngraph
         ARCHIVE DESTINATION ${NGRAPH_INSTALL_LIB} COMPONENT ngraph
         LIBRARY DESTINATION ${NGRAPH_INSTALL_LIB} COMPONENT ngraph)
+
+install(DIRECTORY ${${TARGET_NAME}_INCLUDE_DIR}/paddlepaddle_frontend
+        DESTINATION ${FRONTEND_INSTALL_INCLUDE}
+        COMPONENT ngraph_dev
+        FILES_MATCHING PATTERN "*.hpp"
+)
 
 export(TARGETS ${TARGET_NAME} NAMESPACE ngraph:: APPEND FILE "${NGRAPH_TARGETS_FILE}")

--- a/ngraph/test/frontend/CMakeLists.txt
+++ b/ngraph/test/frontend/CMakeLists.txt
@@ -9,7 +9,6 @@ target_compile_definitions(mock1_ngraph_frontend PRIVATE "-DMOCK_VARIANT=\"1\"")
 
 target_include_directories(mock1_ngraph_frontend PRIVATE ".")
 
-target_include_directories(mock1_ngraph_frontend PRIVATE ${FRONTEND_INCLUDE_PATH} ${NGRAPH_INCLUDE_PATH})
 target_link_libraries(mock1_ngraph_frontend PRIVATE frontend_manager)
 add_dependencies(unit-test mock1_ngraph_frontend)
 


### PR DESCRIPTION
### Details:
 - Added install for PDPD FE headers
 - Proper folder location for `frontend_manager`
 - Updated `ngraphConfig.cmake.in` to reflect FE manager and PDPD FE
 - Used `ngraph_dev` component for frontends headers