### PR TITLE
[MO] Fix showing graceful error message when no ngraph case

### DIFF
--- a/model-optimizer/mo/main.py
+++ b/model-optimizer/mo/main.py
@@ -21,6 +21,8 @@ except ImportError:
 
 from extensions.back.SpecialNodesFinalization import RemoveConstOps, CreateConstNodesReplacement, NormalizeTI
 from mo.back.ie_ir_ver_2.emitter import append_ir_info
+from mo.moc_frontend.pipeline import moc_pipeline
+from mo.moc_frontend.serialize import moc_emit_ir
 from mo.graph.graph import Graph
 from mo.middle.pattern_match import for_graph_and_each_sub_graph_recursively
 from mo.pipeline.common import prepare_emit_ir, get_ir_version
@@ -40,6 +42,9 @@ from mo.utils.utils import refer_to_faq_msg
 from mo.utils.telemetry_utils import send_params_info, send_framework_info
 from mo.utils.version import get_version, get_simplified_mo_version, get_simplified_ie_version
 from mo.utils.versions_checker import check_requirements  # pylint: disable=no-name-in-module
+
+# pylint: disable=no-name-in-module,import-error
+from ngraph.frontend import FrontEndManager
 
 
 def replace_ext(name: str, old: str, new: str):
@@ -265,7 +270,6 @@ def prepare_ir(argv: argparse.Namespace):
     if argv.feManager is None or argv.framework not in new_front_ends:
         graph = unified_pipeline(argv)
     else:
-        from mo.moc_frontend.pipeline import moc_pipeline
         ngraph_function = moc_pipeline(argv)
     return graph, ngraph_function
 
@@ -354,7 +358,6 @@ def driver(argv: argparse.Namespace):
     if graph is not None:
         ret_res = emit_ir(graph, argv)
     else:
-        from mo.moc_frontend.serialize import moc_emit_ir
         ret_res = moc_emit_ir(ngraph_function, argv)
 
     if ret_res != 0:
@@ -375,7 +378,7 @@ def driver(argv: argparse.Namespace):
     return ret_res
 
 
-def main(cli_parser: argparse.ArgumentParser, frontEndManager, framework: str):
+def main(cli_parser: argparse.ArgumentParser, fem: FrontEndManager, framework: str):
     telemetry = tm.Telemetry(app_name='Model Optimizer', app_version=get_simplified_mo_version())
     telemetry.start_session('mo')
     telemetry.send_event('mo', 'version', get_simplified_mo_version())
@@ -389,7 +392,7 @@ def main(cli_parser: argparse.ArgumentParser, frontEndManager, framework: str):
 
         if framework:
             argv.framework = framework
-        argv.feManager = frontEndManager
+        argv.feManager = fem
 
         ov_update_message = None
         if not hasattr(argv, 'silent') or not argv.silent:
@@ -432,12 +435,5 @@ def main(cli_parser: argparse.ArgumentParser, frontEndManager, framework: str):
 
 if __name__ == "__main__":
     from mo.utils.cli_parser import get_all_cli_parser
-    fem = None
-    try:
-        # pylint: disable=no-name-in-module,import-error
-        from ngraph.frontend import FrontEndManager
-        fem = FrontEndManager()
-    except ImportError:
-        pass
-
+    fem = FrontEndManager()
     sys.exit(main(get_all_cli_parser(fem), fem, None))

--- a/model-optimizer/mo/subprocess_main.py
+++ b/model-optimizer/mo/subprocess_main.py
@@ -23,11 +23,15 @@ def setup_env():
 
     from mo.utils.find_ie_version import find_ie_version
 
+    ie_found = True
     try:
-        if not find_ie_version(silent=True):
-            return False
+        ie_found = find_ie_version(silent=True)
     except Exception:
-        return False
+        ie_found = False
+
+    if not ie_found:
+        log_ie_not_found()
+        sys.exit(1)
 
     mo_root_path = os.path.join(os.path.dirname(__file__), os.pardir)
 
@@ -48,9 +52,7 @@ def subprocess_main(framework=None):
         just add paths to Python modules and libraries into current env. So to make Inference Engine
         Python API to be available inside MO we need to use subprocess with new env.
     """
-    if not setup_env():
-        log_ie_not_found()
-        sys.exit(1)
+    setup_env()
 
     path_to_main = os.path.join(os.path.realpath(os.path.dirname(__file__)),
                                 'main_{}.py'.format(framework) if framework else 'main.py')

--- a/model-optimizer/requirements_dev.txt
+++ b/model-optimizer/requirements_dev.txt
@@ -5,3 +5,4 @@ pyenchant==1.6.11
 test-generator==0.1.1
 defusedxml>=0.5.0
 requests>=2.20.0
+pytest>=6.2.4

--- a/model-optimizer/unit_tests/mo/frontend_ngraph_test.py
+++ b/model-optimizer/unit_tests/mo/frontend_ngraph_test.py
@@ -1,11 +1,29 @@
 # Copyright (C) 2018-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+import logging as log
 import os
 import subprocess
 import sys
+import unittest
+from unittest.mock import patch
 
-from mo.subprocess_main import setup_env
+from mo.subprocess_main import setup_env, subprocess_main
+
+import pytest
+
+
+class TestNoInferenceEngine(unittest.TestCase):
+    @patch('mo.utils.find_ie_version.find_ie_version')
+    def test_no_ie_ngraph(self, mock_find):
+        mock_find.return_value = False
+        with pytest.raises(SystemExit) as e, self.assertLogs(log.getLogger(), level="ERROR") as cm:
+            subprocess_main()
+        assert e.value.code == 1
+        res = [i for i in cm.output if
+               'Consider building the Inference Engine and nGraph Python APIs from sources' in i]
+        assert res
+
 
 def test_frontends():
     setup_env()


### PR DESCRIPTION
### Details:
- Add error message when InferenceEngine or nGraph Python API is not found to beginning of subprocess_main
- Show graceful error message before doing anything if IE or nGraph Python API is not found

Root cause analysis: It was assumed that Inference Engine or nGraph API is always available when inner 'subprocess' is being executed. So developer is able to 'import ngraph' in beginning of file. However the real check if ngrpah/ie python API existence is done after parsing command line parameters. So invalid imports show unfriendly messages about import errors inside Model-optimizer. Before PR #6001 there were no such situations and graceful error message was shown

Solution:
- Add error message when InferenceEngine or nGraph Python API is not found to beginning of subprocess_main
- Show graceful error message before doing anything if IE or nGraph Python API is not found

Ticket: 58701

Code:
* [N/A ]  Comments (code is self-explained)
* [X]  Code style (PEP8)
* [N/A]  Transformation generates reshape-able IR
* [N/A]  Transformation preserves original framework node names


Validation:
* [X]  Unit tests
* [N/A]  Framework operation tests
* [N/A]  Transformation tests
* [N/A]  Model Optimizer IR Reader check

Documentation:
* [N/A]  Supported frameworks operations list
* [N/A]  Guide on how to convert the **public** model
* [N/A]  User guide update


### Validation
Unset PYTHONPATH, don't build 'model-optimizer' target

Test 1:
>  ./mo.py --framework tf --saved_model_dir ~/models/exported-models/saved_model
Expected output:
mo.utils.error.Error: Could not find the Inference Engine or nGraph Python API.
Consider building the Inference Engine and nGraph Python APIs from sources or try to install OpenVINO (TM) Toolkit using "install_prerequisites.sh"

Test 2:

>  ./mo.py --help
It was decided to still show error message even for '--help' option. This is because possible input parameters depend on IE & nGraph runtime (like list of available frontends or list of available transformations)
