### PR TITLE
Сheck all symbols in dload, not lazy

### DIFF
--- a/inference-engine/src/inference_engine/os/lin/lin_shared_object_loader.cpp
+++ b/inference-engine/src/inference_engine/os/lin/lin_shared_object_loader.cpp
@@ -18,7 +18,7 @@ private:
 
 public:
     explicit Impl(const char* pluginName) {
-        shared_object = dlopen(pluginName, RTLD_LAZY);
+        shared_object = dlopen(pluginName, RTLD_NOW);
 
         if (shared_object == nullptr)
             IE_THROW() << "Cannot load library '" << pluginName << "': " << dlerror();


### PR DESCRIPTION
### Details:
 - We should check all symbols in library in loading time, not in runtime to dispatch cases when dependencies of loadable library can't be resolved