### PR TITLE
Fix deformable_convolution

### DIFF
--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/deformable_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/deformable_convolution.cpp
@@ -25,9 +25,10 @@ const std::vector<std::vector<size_t>> dilations = {{1, 1}};
 const std::vector<size_t> groups = {1};
 const std::vector<size_t> defor_groups = {1};
 const std::vector<size_t> numOutChannels = {1, 5};
-const std::vector<size_t> multiple_defor_groups = {4};
-const std::vector<std::vector<size_t>> deform_vals = {{1, 200, 220, 220}};
-const std::vector<std::vector<size_t>> kernel = {{64, 4, 5, 5}};
+const std::vector<size_t> multiple_groups = {2};
+const std::vector<size_t> multiple_defor_groups = {3};
+const std::vector<std::vector<size_t>> deform_vals = {{1, 54, 28, 28}};
+const std::vector<std::vector<size_t>> kernel = {{2, 3, 3, 3}};
 
 const auto deformableConv2DParams_ExplicitPadding = ::testing::Combine(
     ::testing::ValuesIn(deformable_vals),
@@ -50,7 +51,7 @@ const auto deformableConv2DParams_DeformableGroups_AutoPadExplicit = ::testing::
     ::testing::ValuesIn(kernel), ::testing::ValuesIn(strides),
     ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
     ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
-    ::testing::ValuesIn(dilations), ::testing::ValuesIn(groups),
+    ::testing::ValuesIn(dilations), ::testing::ValuesIn(multiple_groups),
     ::testing::ValuesIn(multiple_defor_groups), ::testing::ValuesIn(numOutChannels),
     ::testing::Values(ngraph::op::PadType::EXPLICIT));
 
@@ -86,7 +87,7 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
         ::testing::Values(InferenceEngine::Layout::ANY),
         ::testing::Values(InferenceEngine::Layout::ANY),
-        ::testing::Values(std::vector<size_t>({1, 4, 224, 224})),
+        ::testing::Values(std::vector<size_t>({1, 6, 30, 30})),
         ::testing::Values(CommonTestUtils::DEVICE_CPU)),
     DeformableConvolutionLayerTest::getTestCaseName);
 }  // namespace

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/deformable_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/deformable_convolution.cpp
@@ -25,10 +25,9 @@ const std::vector<std::vector<size_t>> dilations = {{1, 1}};
 const std::vector<size_t> groups = {1};
 const std::vector<size_t> defor_groups = {1};
 const std::vector<size_t> numOutChannels = {1, 5};
-const std::vector<size_t> multiple_groups = {2};
-const std::vector<size_t> multiple_defor_groups = {3};
-const std::vector<std::vector<size_t>> deform_vals = {{1, 54, 28, 28}};
-const std::vector<std::vector<size_t>> kernel = {{2, 3, 3, 3}};
+const std::vector<size_t> multiple_defor_groups = {4};
+const std::vector<std::vector<size_t>> deform_vals = {{1, 200, 220, 220}};
+const std::vector<std::vector<size_t>> kernel = {{64, 4, 5, 5}};
 
 const auto deformableConv2DParams_ExplicitPadding = ::testing::Combine(
     ::testing::ValuesIn(deformable_vals),
@@ -51,7 +50,7 @@ const auto deformableConv2DParams_DeformableGroups_AutoPadExplicit = ::testing::
     ::testing::ValuesIn(kernel), ::testing::ValuesIn(strides),
     ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
     ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
-    ::testing::ValuesIn(dilations), ::testing::ValuesIn(multiple_groups),
+    ::testing::ValuesIn(dilations), ::testing::ValuesIn(groups),
     ::testing::ValuesIn(multiple_defor_groups), ::testing::ValuesIn(numOutChannels),
     ::testing::Values(ngraph::op::PadType::EXPLICIT));
 
@@ -87,7 +86,33 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
         ::testing::Values(InferenceEngine::Layout::ANY),
         ::testing::Values(InferenceEngine::Layout::ANY),
-        ::testing::Values(std::vector<size_t>({1, 6, 30, 30})),
+        ::testing::Values(std::vector<size_t>({1, 4, 224, 224})),
         ::testing::Values(CommonTestUtils::DEVICE_CPU)),
     DeformableConvolutionLayerTest::getTestCaseName);
+
+/* ============= Single Test Case ============= */
+const std::vector<std::vector<size_t>> single_deform_vals = {{1, 54, 28, 28}};
+const std::vector<std::vector<size_t>> single_kernel = {{1, 3, 3, 3}};
+const std::vector<size_t> single_deform_groups = {3};
+
+const auto deformableConv2DParams_SingleTestCase = ::testing::Combine(
+    ::testing::ValuesIn(single_deform_vals),
+    ::testing::ValuesIn(single_kernel), ::testing::ValuesIn(strides),
+    ::testing::ValuesIn(padBegins), ::testing::ValuesIn(padEnds),
+    ::testing::ValuesIn(dilations), ::testing::ValuesIn(groups),
+    ::testing::ValuesIn(single_deform_groups), ::testing::ValuesIn(numOutChannels),
+    ::testing::Values(ngraph::op::PadType::EXPLICIT));
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_DeformableConvolution2D_SingleTestCase, DeformableConvolutionLayerTest,
+    ::testing::Combine(
+        deformableConv2DParams_SingleTestCase, ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),
+        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+    DeformableConvolutionLayerTest::getTestCaseName);
+
 }  // namespace

--- a/ngraph/core/reference/include/ngraph/runtime/reference/deformable_convolution.hpp
+++ b/ngraph/core/reference/include/ngraph/runtime/reference/deformable_convolution.hpp
@@ -221,7 +221,6 @@ namespace ngraph
 
                 const Shape group_offset_shape =
                     shape_scale(shape_reduce(o_shape), deformable_groups);
-                const size_t group_offset_size = shape_size(group_offset_shape);
                 const size_t group_offset_batch_size = shape_size(shape_reduce(o_shape));
 
                 const size_t group_filters_count = f_shape[filter_out_ch_axis] / groups;


### PR DESCRIPTION
I think there is a error about the reference implementation of deformable_convolution.
The two parameters group and deformable_group is independent, and there are details about the parameter deformable_group in [MXNet](https://github.com/apache/incubator-mxnet/blob/master/src/operator/contrib/nn/deformable_im2col.h#L230)
Suppose that the shape of input data is (1,6,5,5), the shape of filter is (2,3,3,3), the shape of the offset is (1,54,3,3), group is 2, deformable_group is 3. And an error will occur on line 256 when group_idx equals 1.