### PR TITLE
 [IE CLDNN] Improve bfyx convolution performance for shallow output ch

### DIFF
--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_kernel_bfyx_os_iyx_osv16.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_kernel_bfyx_os_iyx_osv16.cpp
@@ -93,6 +93,9 @@ static void shrink_blocks_to_output_size(size_t output_x, size_t output_y, size_
 
     block_x -= unused_x / simds_x;
     block_y -= unused_y / simds_y;
+
+    block_x = Align(block_x, 2);
+    block_y = Align(block_y, 2);
 }
 
 ConvolutionKernel_bfyx_os_iyx_osv16::AutoTuneOption ConvolutionKernel_bfyx_os_iyx_osv16::GetAutoTuneOptions(

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_kernel_bfyx_os_iyx_osv16.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_kernel_bfyx_os_iyx_osv16.h
@@ -34,6 +34,7 @@ protected:
     bool Validate(const Params& p, const optional_params& o) const override;
     bool NeedPaddedInput() const override { return true; }
     DispatchData SetDefault(const convolution_params& arg, int autoTuneIndex = -1) const override;
+    size_t GetSubGroupSize(const convolution_params& params) const { return (params.output.Feature().v > 8) ? 16 : 8; }
 
 private:
     struct AutoTuneOption {

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_kernel_bfyx_os_iyx_osv16.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_kernel_bfyx_os_iyx_osv16.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "api/cldnn/runtime/device_info.hpp"
 #include "convolution_kernel_base.h"
 #include <string>
 #include <vector>
@@ -34,7 +35,16 @@ protected:
     bool Validate(const Params& p, const optional_params& o) const override;
     bool NeedPaddedInput() const override { return true; }
     DispatchData SetDefault(const convolution_params& arg, int autoTuneIndex = -1) const override;
-    size_t GetSubGroupSize(const convolution_params& params) const { return (params.output.Feature().v > 8) ? 16 : 8; }
+    size_t GetSubGroupSize(const convolution_params& params) const {
+        if (params.engineInfo.computeUnitsCount <= 24) {
+            // Smaller # EU tends to be computation bounds.
+            // In such case, using larger worksize will result in larger computational inefficiency
+            // w.r.t the unalined output feature
+            return (params.output.Feature().v > 8) ? 16 : 8;
+        } else {
+            return 16;
+        }
+    }
 
 private:
     struct AutoTuneOption {

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/convolution_gpu_bfyx_os_iyx_osv16.cl
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/convolution_gpu_bfyx_os_iyx_osv16.cl
@@ -83,12 +83,11 @@ KERNEL(convolution_gpu_bfyx_os_iyx_osv16)(
     uint fmg = feature_idx / SUB_GROUP_SIZE;
     const uint g = split_idx;
 #endif
-
     UNIT_TYPE in[IN_BLOCK_ARRAY_SIZE];
     UNIT_TYPE out[OUTPUT_BLOCK_WIDTH * OUTPUT_BLOCK_HEIGHT];
     UNIT_TYPE w[PREFETCH];
     uint in_addr;
-    uint weight_addr = fmg * FILTER_IFM_NUM * FILTER_SIZE_X * FILTER_SIZE_Y * SUB_GROUP_SIZE + lid;
+    uint weight_addr = fmg * FILTER_IFM_NUM * FILTER_SIZE_X * FILTER_SIZE_Y * OSV_SIZE + lid;
 
 #if GROUPED
     weight_addr += g * FILTER_GROUPS_PITCH;
@@ -156,7 +155,7 @@ KERNEL(convolution_gpu_bfyx_os_iyx_osv16)(
         in_addr += INPUT0_FEATURE_PITCH;
 
         for(int pf=0; pf<PREFETCH; pf++) {
-            w[pf] = weights[weight_addr]; weight_addr += SUB_GROUP_SIZE;
+            w[pf] = weights[weight_addr]; weight_addr += OSV_SIZE;
         }
 
         uint wi = 0;
@@ -182,12 +181,12 @@ KERNEL(convolution_gpu_bfyx_os_iyx_osv16)(
                     }
                 }
                 w[wi % PREFETCH] = weights[weight_addr];
-                weight_addr += SUB_GROUP_SIZE; // weights must be stored in just the right SIMD swizzled format for this to work, see host code for details.
+                weight_addr += OSV_SIZE; // weights must be stored in just the right SIMD swizzled format for this to work, see host code for details.
                 wi++;
             });
         });
         // addr went beyond due to prefetch so move it back to correct location.
-        weight_addr -= PREFETCH * SUB_GROUP_SIZE;
+        weight_addr -= PREFETCH * OSV_SIZE;
     }
 
     uint out_split_offset = g * OUTPUT_FEATURE_PITCH * FILTER_OFM_NUM;


### PR DESCRIPTION
### Details:
- Improve computation inefficiency and cache efficiency for bfyx convolution with shallow output feature size

### Tickets:
 - 57942

