### PR TITLE
[LPT] Some LP Transformations improvements

### DIFF
--- a/inference-engine/src/low_precision_transformations/src/layer_transformation.cpp
+++ b/inference-engine/src/low_precision_transformations/src/layer_transformation.cpp
@@ -120,13 +120,13 @@ bool LayerTransformation::canBeTransformed(const TransformationContext& context,
 
         if ((dequantization.subtract != nullptr) && (!perChannelQuantization(
             dequantization.subtract->get_output_partial_shape(0),
-            dequantization.subtract->get_input_shape(1)))) {
+            dequantization.subtractConstant->get_shape()))) {
             return false;
         }
 
         if ((dequantization.multiply != nullptr) && (!perChannelQuantization(
             dequantization.multiply->get_output_partial_shape(0),
-            dequantization.multiply->get_input_shape(1)))) {
+            dequantization.multiplyConstant->get_shape()))) {
             return false;
         }
     }

--- a/inference-engine/src/low_precision_transformations/src/network_helper.cpp
+++ b/inference-engine/src/low_precision_transformations/src/network_helper.cpp
@@ -1437,14 +1437,14 @@ NetworkHelper::InsertDequantizationResult NetworkHelper::moveDequantizationAfter
         if (updatePrecision) {
             op->set_overridden_output_type(newOperation->get_input_element_type(0));
         } else if (dequantization.multiply) {
-            op->set_overridden_output_type(dequantization.multiply->get_input_element_type(1));
+            op->set_overridden_output_type(dequantization.multiplyConstant->get_element_type());
         } else if (dequantization.subtract) {
-            op->set_overridden_output_type(dequantization.subtract->get_input_element_type(1));
+            op->set_overridden_output_type(dequantization.subtractConstant->get_element_type());
         }
         std::dynamic_pointer_cast<ngraph::Node>(newOperation)->validate_and_infer_types();
     }
 
-    const element::Type deqPrecision = dequantization.multiply->get_input_node_shared_ptr(1)->get_output_element_type(0);
+    const element::Type deqPrecision = dequantization.multiplyConstant->get_element_type();
     const bool shouldConvert = (newOperation->get_output_element_type(0) != deqPrecision);
 
     auto parent = newOperation;
@@ -1459,16 +1459,16 @@ NetworkHelper::InsertDequantizationResult NetworkHelper::moveDequantizationAfter
     if (moveSubtract && (dequantization.subtract != nullptr)) {
         if (dequantization.subtractConvert == nullptr) {
             const element::Type parentPrecision = parent->get_output_element_type(0);
-            if (parentPrecision.bitwidth() < dequantization.subtractConstant->output(0).get_element_type().bitwidth()) {
+            if (parentPrecision.bitwidth() < dequantization.subtractConstant->get_element_type().bitwidth()) {
                 THROW_IE_LPT_EXCEPTION(*parent) <<
                     "unexpected precisions: on data " << parent->get_friendly_name() << ":" << parentPrecision <<
                     ", subtract dequantization constant " << dequantization.subtractConstant->get_friendly_name() << ":" <<
-                    dequantization.subtractConstant->output(0).get_element_type();
+                    dequantization.subtractConstant->get_element_type();
             }
 
             parent = std::make_shared<DequantizationSubtract>(
                 parent,
-                dequantization.subtractConstant->output(0).get_element_type() == parentPrecision ?
+                dequantization.subtractConstant->get_element_type() == parentPrecision ?
                     dequantization.subtractConstant :
                     foldConvert(dequantization.subtractConstant, parentPrecision));
             ngraph::copy_runtime_info({ newOperation, parent }, parent);
@@ -1479,12 +1479,12 @@ NetworkHelper::InsertDequantizationResult NetworkHelper::moveDequantizationAfter
     }
 
     if (dequantization.multiply != nullptr) {
-        auto multiplyConstant = dequantization.multiply->get_input_node_shared_ptr(1);
+        auto multiplyConstant = dequantization.multiplyConstant;
         const element::Type parentPrecision = parent->get_output_element_type(0);
-        if (parentPrecision.bitwidth() < multiplyConstant->output(0).get_element_type().bitwidth()) {
+        if (parentPrecision.bitwidth() < multiplyConstant->get_element_type().bitwidth()) {
             THROW_IE_LPT_EXCEPTION(*parent) <<
                 "unexpected precisions: on data " << parent->get_friendly_name() << ":" << parentPrecision <<
-                ", multiply dequantization constant " << multiplyConstant->get_friendly_name() << ":" << multiplyConstant->output(0).get_element_type();
+                ", multiply dequantization constant " << multiplyConstant->get_friendly_name() << ":" << multiplyConstant->get_element_type();
         }
 
         parent = std::make_shared<op::TypeRelaxed<DequantizationMultiply>>(

--- a/inference-engine/src/low_precision_transformations/src/reshape.cpp
+++ b/inference-engine/src/low_precision_transformations/src/reshape.cpp
@@ -39,13 +39,8 @@ void reshapeDequantizationConstant(const std::shared_ptr<opset1::Reshape>& resha
 
             // reshape for element-wise constant is not required
             if (shape_size(constantShape) == 1ul) {
-                if (constantShape.size() > 1ul) {
-                    const Shape newConstShape = Shape(reshape->get_output_partial_shape(0).rank().get_length(), 1ul);
-                    const auto newConstant = opset1::Constant::create(
-                        originalConstant->get_element_type(), newConstShape, originalConstant->cast_vector<float>());
-                    replace_node(op->get_input_node_shared_ptr(constantIndex), newConstant);
-                }
-
+                const auto newConstant = NetworkHelper::toScalar(originalConstant);
+                replace_node(op->get_input_node_shared_ptr(constantIndex), newConstant);
                 return;
             }
 

--- a/inference-engine/src/low_precision_transformations/src/squeeze.cpp
+++ b/inference-engine/src/low_precision_transformations/src/squeeze.cpp
@@ -33,9 +33,14 @@ bool SqueezeTransformation::transform(TransformationContext& context, ngraph::pa
                                 const std::shared_ptr<ngraph::opset1::Constant>& dequantizationOpConstant,
                                 const ngraph::PartialShape& inputShape) {
         const size_t inputRankValue = inputShape.rank().get_length();
-        if (dequantizationOpConstant->get_shape().size() == inputRankValue) {
+        const auto constantShape = dequantizationOpConstant->get_shape();
+        if (shape_size(constantShape) == 1ul) {
+            return NetworkHelper::toScalar(dequantizationOpConstant);
+        }
+        if (constantShape.size() == inputRankValue) {
             return as_type_ptr<opset1::Constant>(fold<opset1::Squeeze>(dequantizationOpConstant, squeeze->get_input_node_shared_ptr(1)));
         }
+
         return dequantizationOpConstant;
     };
 

--- a/inference-engine/src/low_precision_transformations/src/unsqueeze.cpp
+++ b/inference-engine/src/low_precision_transformations/src/unsqueeze.cpp
@@ -33,11 +33,18 @@ bool UnsqueezeTransformation::transform(TransformationContext& context, ngraph::
                                 const std::shared_ptr<ngraph::opset1::Constant>& dequantizationOpConstant,
                                 const ngraph::PartialShape& inputShape) {
         const size_t inputRankValue = inputShape.rank().get_length();
-        if (dequantizationOpConstant->get_shape().size() == inputRankValue) {
+        const auto constantShape = dequantizationOpConstant->get_shape();
+        if (shape_size(constantShape) == 1ul) {
+            return NetworkHelper::toScalar(dequantizationOpConstant);
+        }
+
+        if (constantShape.size() == inputRankValue) {
             return as_type_ptr<opset1::Constant>(fold<opset1::Unsqueeze>(dequantizationOpConstant, unsqueeze->get_input_node_shared_ptr(1)));
         }
+
         return dequantizationOpConstant;
     };
+
 
     const std::shared_ptr<Node> unsqueeze = NetworkHelper::separateInStandaloneBranch(m.get_match_root());
     FakeQuantizeDequantization dequantization = NetworkHelper::getDequantization(unsqueeze);

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/reshape_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/reshape_transformation.cpp
@@ -619,7 +619,7 @@ const std::vector<ReshapeTransformationTestValues> testValues = {
             ngraph::element::u8,
             {{}, {}, {}},
             ngraph::element::u8,
-            {{ngraph::element::f32}, {}, {{0.1f}, ngraph::element::f32, {1, 1}}}
+            {{ngraph::element::f32}, {}, {0.1f}}
         }
     },
     // U8: no subtract 4D -> 2D: channels are not affected
@@ -635,7 +635,7 @@ const std::vector<ReshapeTransformationTestValues> testValues = {
             ngraph::element::u8,
             {{}, {}, {}},
             ngraph::element::u8,
-            {{ngraph::element::f32}, {}, {{0.1f}, ngraph::element::f32, {1, 1}}}
+            {{ngraph::element::f32}, {}, {0.1f}}
         }
     },
     // U8: no subtract 4D -> 2D: channels are not affected, dynamic batch
@@ -651,7 +651,7 @@ const std::vector<ReshapeTransformationTestValues> testValues = {
             ngraph::element::u8,
             {{}, {}, {}},
             ngraph::element::u8,
-            {{ngraph::element::f32}, {}, {{0.1f}, ngraph::element::f32, {1, 1}}}
+            {{ngraph::element::f32}, {}, {0.1f}}
         }
     },
     // U8: no subtract 4D -> 4D: channels are affected


### PR DESCRIPTION
### Details:
 - ReshapeTransformation: use NetworkHelper::toScalar for scalar-like dequantization constants instead of constant folding
 - Squeeze/UnsqueezeTransformarion refactoring
 - LayerTransformation::canBeTransformed: use FakeQuantizeDequantization fields instead of moving around the graph
 - NetworkHelper::moveDequantizationAfter: use FakeQuantizeDequantization fields instead of moving around the graph

### Tickets:
 - *58596*
