### PR TITLE
TBlob explicit declaration

### DIFF
--- a/inference-engine/include/ie_blob.h
+++ b/inference-engine/include/ie_blob.h
@@ -799,7 +799,6 @@ protected:
     }
 };
 
-#ifdef __clang__
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<float>);
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<double>);
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<int8_t>);
@@ -814,7 +813,6 @@ extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<unsigned
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<unsigned long long>);
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<bool>);
 extern template class INFERENCE_ENGINE_API_CLASS(InferenceEngine::TBlob<char>);
-#endif  // __clang__
 
 /**
  * @brief Creates a blob with the given tensor descriptor.

--- a/inference-engine/src/inference_engine/ie_common.cpp
+++ b/inference-engine/src/inference_engine/ie_common.cpp
@@ -145,19 +145,19 @@ TBlob<T, U>::~TBlob() {
     free();
 }
 
-template class INFERENCE_ENGINE_API_CLASS(TBlob<float>);
-template class INFERENCE_ENGINE_API_CLASS(TBlob<double>);
-template class INFERENCE_ENGINE_API_CLASS(TBlob<int8_t>);
-template class INFERENCE_ENGINE_API_CLASS(TBlob<uint8_t>);
-template class INFERENCE_ENGINE_API_CLASS(TBlob<int16_t>);
-template class INFERENCE_ENGINE_API_CLASS(TBlob<uint16_t>);
-template class INFERENCE_ENGINE_API_CLASS(TBlob<int32_t>);
-template class INFERENCE_ENGINE_API_CLASS(TBlob<uint32_t>);
-template class INFERENCE_ENGINE_API_CLASS(TBlob<long>);
-template class INFERENCE_ENGINE_API_CLASS(TBlob<long long>);
-template class INFERENCE_ENGINE_API_CLASS(TBlob<unsigned long>);
-template class INFERENCE_ENGINE_API_CLASS(TBlob<unsigned long long>);
-template class INFERENCE_ENGINE_API_CLASS(TBlob<bool>);
-template class INFERENCE_ENGINE_API_CLASS(TBlob<char>);
+template class TBlob<float>;
+template class TBlob<double>;
+template class TBlob<int8_t>;
+template class TBlob<uint8_t>;
+template class TBlob<int16_t>;
+template class TBlob<uint16_t>;
+template class TBlob<int32_t>;
+template class TBlob<uint32_t>;
+template class TBlob<long>;
+template class TBlob<long long>;
+template class TBlob<unsigned long>;
+template class TBlob<unsigned long long>;
+template class TBlob<bool>;
+template class TBlob<char>;
 
 }  // namespace InferenceEngine


### PR DESCRIPTION
### Details:

This fixes problems when linking gcc compiled IE with clang compiled
applications.

Previous to this change, only clang compilers would consider TBlob<T>
templated types as declared externally. When *declared* explictly (with
the `extern template` syntax), the C++ spec says
that any inline methods of the templated class (such as TBlob<T>
constructors) should be ignored in favor of the externally instantiated
version of that templated type:

    "An explicit instantiation declaration (an extern template) skips
    implicit instantiation step: the code that would otherwise cause an
    implicit instantiation instead uses the explicit instantiation
    definition provided elsewhere (resulting in link errors if no such
    instantiation exists)."

However, when IE is compiled with gcc, it does not see the explicit
`extern template` declarations of TBlob<T> (due to the `#ifdef
__clang__` guards in `ie_blob.h`). As an end result, presumably due to
link-time-optimizations during IE library compilation(?), none of the
TBlob<T> implementations are actually included in the IE dynamic
libraries.

### Tickets:
 - Fixes #6454