### PR TITLE
Revert "Сheck all symbols in dload, not lazy"

### DIFF
--- a/inference-engine/src/inference_engine/os/lin/lin_shared_object_loader.cpp
+++ b/inference-engine/src/inference_engine/os/lin/lin_shared_object_loader.cpp
@@ -18,7 +18,7 @@ private:
 
 public:
     explicit Impl(const char* pluginName) {
-        shared_object = dlopen(pluginName, RTLD_NOW);
+        shared_object = dlopen(pluginName, RTLD_LAZY);
 
         if (shared_object == nullptr)
             IE_THROW() << "Cannot load library '" << pluginName << "': " << dlerror();


### PR DESCRIPTION
Reverts openvinotoolkit/openvino#6381
It most likely caused failures in gna functional tests on master.