### PR TITLE
Fix an initialization issue in `ie_core_create`

### DIFF
--- a/inference-engine/ie_bridges/c/src/ie_c_api.cpp
+++ b/inference-engine/ie_bridges/c/src/ie_c_api.cpp
@@ -235,9 +235,8 @@ IEStatusCode ie_core_create(const char *xml_config_file, ie_core_t **core) {
 
     IEStatusCode status = IEStatusCode::OK;
     try {
-        std::unique_ptr<ie_core_t> tmp(new ie_core_t);
-        tmp->object = IE::Core(xml_config_file);
-        *core = tmp.release();
+        auto object = IE::Core(xml_config_file);
+        *core = new ie_core_t { std::move(object) };
     } CATCH_IE_EXCEPTIONS
 
     return status;


### PR DESCRIPTION


### Details:
- Fix InferenceEngine::Core initialization. Previously IE::Core was
  default constructed first, then overwritten by another instance.
  This causes problems if the library user attempts to opt-out of the
  default "plugins.xml" plugin loading mechanism.

### Tickets:
