### PR TITLE
Improvements for plugin extensions management

### DIFF
--- a/docs/template_plugin/src/template_plugin.cpp
+++ b/docs/template_plugin/src/template_plugin.cpp
@@ -186,13 +186,6 @@ InferenceEngine::QueryNetworkResult Plugin::QueryNetwork(const InferenceEngine::
 }
 // ! [plugin:query_network]
 
-// ! [plugin:add_extension]
-void Plugin::AddExtension(const InferenceEngine::IExtensionPtr& /*extension*/) {
-    // TODO: add extensions if plugin supports extensions
-    IE_THROW(NotImplemented);
-}
-// ! [plugin:add_extension]
-
 // ! [plugin:set_config]
 void Plugin::SetConfig(const ConfigMap& config) {
     _cfg = Configuration {config, _cfg};

--- a/docs/template_plugin/src/template_plugin.hpp
+++ b/docs/template_plugin/src/template_plugin.hpp
@@ -25,7 +25,6 @@ public:
                                                      const std::map<std::string, std::string>& config) const override;
     InferenceEngine::IExecutableNetworkInternal::Ptr LoadExeNetworkImpl(const InferenceEngine::CNNNetwork& network,
                                                                         const std::map<std::string, std::string>& config) override;
-    void AddExtension(const std::shared_ptr<InferenceEngine::IExtension>& extension) override;
     InferenceEngine::Parameter GetConfig(const std::string& name, const std::map<std::string, InferenceEngine::Parameter>& options) const override;
     InferenceEngine::Parameter GetMetric(const std::string& name, const std::map<std::string, InferenceEngine::Parameter>& options) const override;
     InferenceEngine::IExecutableNetworkInternal::Ptr ImportNetwork(std::istream& model, const std::map<std::string, std::string>& config) override;

--- a/inference-engine/include/ie_core.hpp
+++ b/inference-engine/include/ie_core.hpp
@@ -151,6 +151,7 @@ public:
      * @param extension Pointer to already loaded extension
      * @param deviceName Device name to identify plugin to add an executable extension
      */
+    INFERENCE_ENGINE_DEPRECATED("Use Core::AddExtension without device name")
     void AddExtension(IExtensionPtr extension, const std::string& deviceName);
 
     /**
@@ -282,9 +283,6 @@ public:
      * <ie>
      *     <plugins>
      *         <plugin name="" location="">
-     *             <extensions>
-     *                 <extension location=""/>
-     *             </extensions>
      *             <properties>
      *                 <property key="" value=""/>
      *             </properties>
@@ -297,7 +295,6 @@ public:
      * - `location` specifies absolute path to dynamic library with plugin. A path can also be relative to inference
      * engine shared library. It allows to have common config for different systems with different configurations.
      * - Properties are set to plugin via the `SetConfig` method.
-     * - Extensions are set to plugin via the `AddExtension` method.
      *
      * @param xmlConfigFile A path to .xml file with plugins to register.
      */

--- a/inference-engine/src/gna_plugin/gna_plugin.cpp
+++ b/inference-engine/src/gna_plugin/gna_plugin.cpp
@@ -1664,8 +1664,6 @@ std::map<std::string, InferenceEngine::InferenceEngineProfileInfo> GNAPlugin::Ge
     }
 }
 
-void GNAPlugin::AddExtension(const InferenceEngine::IExtensionPtr& extension) {}
-
 void GNAPlugin::SetConfig(const std::map<std::string, std::string> &config_map) {
     config.UpdateFromMap(config_map);
     UpdateFieldsFromConfig();

--- a/inference-engine/src/gna_plugin/gna_plugin.hpp
+++ b/inference-engine/src/gna_plugin/gna_plugin.hpp
@@ -99,7 +99,6 @@ class GNAPlugin : public InferenceEngine::IInferencePlugin {
 
     bool Infer(const InferenceEngine::BlobMap &input, InferenceEngine::BlobMap &result);
     std::map<std::string, InferenceEngine::InferenceEngineProfileInfo> GetPerformanceCounts();
-    void AddExtension(const InferenceEngine::IExtensionPtr& extension) override;
 
     void SetConfig(const std::map<std::string, std::string> &config) override;
     bool Infer(const InferenceEngine::Blob &input, InferenceEngine::Blob &result);

--- a/inference-engine/src/inference_engine/cpp/ie_plugin.hpp
+++ b/inference-engine/src/inference_engine/cpp/ie_plugin.hpp
@@ -52,10 +52,6 @@ public:
         PLUGIN_CALL_STATEMENT(return _ptr->GetVersion());
     }
 
-    void AddExtension(const InferenceEngine::IExtensionPtr& extension) {
-        PLUGIN_CALL_STATEMENT(_ptr->AddExtension(extension));
-    }
-
     void SetConfig(const std::map<std::string, std::string>& config) {
         PLUGIN_CALL_STATEMENT(_ptr->SetConfig(config));
     }

--- a/inference-engine/src/inference_engine/cpp_interfaces/interface/ie_iplugin_internal.cpp
+++ b/inference-engine/src/inference_engine/cpp_interfaces/interface/ie_iplugin_internal.cpp
@@ -132,10 +132,6 @@ std::shared_ptr<IExecutableNetworkInternal> IInferencePlugin::LoadNetwork(const 
     return GetCore()->LoadNetwork(cnnNet, GetName(), config);
 }
 
-void IInferencePlugin::AddExtension(const std::shared_ptr<IExtension>&) {
-    IE_THROW(NotImplemented);
-}
-
 void IInferencePlugin::SetConfig(const std::map<std::string, std::string>&) {
     IE_THROW(NotImplemented);
 }

--- a/inference-engine/src/mkldnn_plugin/mkldnn_extension_mngr.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_extension_mngr.cpp
@@ -7,12 +7,13 @@
 #include <algorithm>
 
 #include "mkldnn_extension_mngr.h"
+#include "nodes/list.hpp"
 
 using namespace MKLDNNPlugin;
 using namespace InferenceEngine;
 
-void MKLDNNExtensionManager::AddExtension(const IExtensionPtr& extension) {
-    _extensions.push_back(extension);
+MKLDNNExtensionManager::MKLDNNExtensionManager()
+    : _extensions {{ std::make_shared<Extensions::Cpu::MKLDNNExtensions>() }} {
 }
 
 InferenceEngine::ILayerImpl::Ptr MKLDNNExtensionManager::CreateImplementation(const std::shared_ptr<ngraph::Node>& op) {
@@ -50,4 +51,8 @@ std::shared_ptr<InferenceEngine::ILayerImplFactory> MKLDNNExtensionManager::Crea
         }
     }
     return factory;
+}
+
+const std::vector<InferenceEngine::IExtensionPtr> & MKLDNNExtensionManager::Extensions() const {
+    return _extensions;
 }

--- a/inference-engine/src/mkldnn_plugin/mkldnn_extension_mngr.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_extension_mngr.h
@@ -15,10 +15,10 @@ namespace MKLDNNPlugin {
 class MKLDNNExtensionManager {
 public:
     using Ptr = std::shared_ptr<MKLDNNExtensionManager>;
-    MKLDNNExtensionManager() = default;
+    MKLDNNExtensionManager();
     InferenceEngine::ILayerImpl::Ptr CreateImplementation(const std::shared_ptr<ngraph::Node>& op);
     std::shared_ptr<InferenceEngine::ILayerImplFactory> CreateExtensionFactory(const std::shared_ptr<ngraph::Node>& op);
-    void AddExtension(const InferenceEngine::IExtensionPtr& extension);
+    const std::vector<InferenceEngine::IExtensionPtr> & Extensions() const;
 
 private:
     std::vector<InferenceEngine::IExtensionPtr> _extensions;

--- a/inference-engine/src/mkldnn_plugin/mkldnn_plugin.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_plugin.h
@@ -25,8 +25,6 @@ public:
     LoadExeNetworkImpl(const InferenceEngine::CNNNetwork &network,
                        const std::map<std::string, std::string> &config) override;
 
-    void AddExtension(const InferenceEngine::IExtensionPtr& extension) override;
-
     void SetConfig(const std::map<std::string, std::string> &config) override;
 
     InferenceEngine::Parameter GetConfig(const std::string& name, const std::map<std::string, InferenceEngine::Parameter>& options) const override;
@@ -35,6 +33,8 @@ public:
 
     InferenceEngine::QueryNetworkResult QueryNetwork(const InferenceEngine::CNNNetwork& network,
                                                      const std::map<std::string, std::string>& config) const override;
+
+    void SetCore(std::weak_ptr<InferenceEngine::ICore> core) final;
 
 private:
     Config engConfig;

--- a/inference-engine/src/plugin_api/cpp_interfaces/interface/ie_iplugin_internal.hpp
+++ b/inference-engine/src/plugin_api/cpp_interfaces/interface/ie_iplugin_internal.hpp
@@ -160,12 +160,6 @@ public:
                                                                     const std::map<std::string, std::string>& config);
 
     /**
-     * @brief Registers extension within plugin
-     * @param extension - pointer to already loaded extension
-     */
-    virtual void AddExtension(const std::shared_ptr<IExtension>& extension);
-
-    /**
      * @brief Sets configuration for plugin, acceptable keys can be found in ie_plugin_config.hpp
      * @param config string-string map of config parameters
      */

--- a/inference-engine/src/plugin_api/ie_icore.hpp
+++ b/inference-engine/src/plugin_api/ie_icore.hpp
@@ -136,6 +136,24 @@ public:
     virtual bool DeviceSupportsImportExport(const std::string& deviceName) const = 0;
 
     /**
+     * @brief Registers extension
+     * @param extension Pointer to already loaded extension
+     */
+    virtual void AddExtension(const IExtensionPtr& extension) = 0;
+
+    /**
+     * @brief Unregisters extension
+     * @param extension Pointer to already loaded extension
+     */
+    virtual void DelExtension(const IExtensionPtr& extension) = 0;
+
+    /**
+     * @brief Provides a list of extensions
+     * @return A list of registered extensions
+     */
+    virtual std::vector<IExtensionPtr> GetExtensions() const = 0;
+
+    /**
      * @brief Default virtual destructor
      */
     virtual ~ICore() = default;

--- a/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/cpp_interfaces/impl/mock_inference_plugin_internal.hpp
+++ b/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/cpp_interfaces/impl/mock_inference_plugin_internal.hpp
@@ -21,7 +21,6 @@ public:
     MOCK_METHOD2(LoadNetwork, std::shared_ptr<InferenceEngine::IExecutableNetworkInternal>(
             const InferenceEngine::CNNNetwork &,
             const std::map<std::string, std::string> &));
-    MOCK_METHOD1(AddExtension, void(InferenceEngine::IExtensionPtr ext_ptr));
     MOCK_METHOD1(SetConfig, void(const std::map <std::string, std::string> &));
 };
 
@@ -29,7 +28,6 @@ class MockInferencePluginInternal : public InferenceEngine::IInferencePlugin {
 public:
     MOCK_METHOD2(LoadExeNetworkImpl, std::shared_ptr<InferenceEngine::IExecutableNetworkInternal>(
             const InferenceEngine::CNNNetwork &, const std::map<std::string, std::string> &));
-    MOCK_METHOD1(AddExtension, void(InferenceEngine::IExtensionPtr ext_ptr));
     MOCK_METHOD1(SetConfig, void(const std::map <std::string, std::string> &));
 
     std::shared_ptr<InferenceEngine::IExecutableNetworkInternal>
@@ -44,6 +42,5 @@ class MockInferencePluginInternal3 : public InferenceEngine::IInferencePlugin {
 public:
     MOCK_METHOD2(LoadExeNetworkImpl, std::shared_ptr<InferenceEngine::IExecutableNetworkInternal>(
             const InferenceEngine::CNNNetwork &, const std::map<std::string, std::string> &));
-    MOCK_METHOD1(AddExtension, void(InferenceEngine::IExtensionPtr ext_ptr));
     MOCK_METHOD1(SetConfig, void(const std::map <std::string, std::string> &));
 };

--- a/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/cpp_interfaces/interface/mock_icore.hpp
+++ b/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/cpp_interfaces/interface/mock_icore.hpp
@@ -33,5 +33,9 @@ public:
     MOCK_CONST_METHOD0(GetAvailableDevices, std::vector<std::string>());
     MOCK_CONST_METHOD1(DeviceSupportsImportExport, bool(const std::string&)); // NOLINT not a cast to bool
 
+    MOCK_METHOD1(AddExtension, void(const InferenceEngine::IExtensionPtr&));
+    MOCK_METHOD1(DelExtension, void(const InferenceEngine::IExtensionPtr&));
+    MOCK_CONST_METHOD0(GetExtensions, std::vector<InferenceEngine::IExtensionPtr>());
+
     ~MockICore() = default;
 };

--- a/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/cpp_interfaces/interface/mock_iinference_plugin.hpp
+++ b/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/cpp_interfaces/interface/mock_iinference_plugin.hpp
@@ -12,7 +12,6 @@
 
 class MockIInferencePlugin : public InferenceEngine::IInferencePlugin {
 public:
-    MOCK_METHOD1(AddExtension, void(InferenceEngine::IExtensionPtr));
     MOCK_METHOD2(LoadNetwork, std::shared_ptr<InferenceEngine::IExecutableNetworkInternal>(
                 const InferenceEngine::CNNNetwork&, const std::map<std::string, std::string>&));
     MOCK_METHOD2(LoadNetwork, std::shared_ptr<InferenceEngine::IExecutableNetworkInternal>(

--- a/inference-engine/tests/unit/inference_engine/cpp_interfaces/ie_plugin_test.cpp
+++ b/inference-engine/tests/unit/inference_engine/cpp_interfaces/ie_plugin_test.cpp
@@ -164,11 +164,6 @@ TEST(InferencePluginTests, throwsOnUninitializedImportNetwork) {
     ASSERT_THROW(plg.ImportNetwork({}, {}), Exception);
 }
 
-TEST(InferencePluginTests, throwsOnUninitializedAddExtension) {
-    InferencePlugin plg;
-    ASSERT_THROW(plg.AddExtension(IExtensionPtr()), Exception);
-}
-
 TEST(InferencePluginTests, throwsOnUninitializedSetConfig) {
     InferencePlugin plg;
     ASSERT_THROW(plg.SetConfig({{}}), Exception);


### PR DESCRIPTION
### Details:
 - Improvements for plugin extensions management.
The CPU plugin has its own set of operations. After serialization, the IR Reader cannot deserialize these operations because it can't find a suitable node factory. This PR extends the ICore interface and allows plugins to manage extensions (add / remove / get).

### Tickets:
 - required for CVS-56555
