### PR TITLE
[MO] exclude build artifacts and add unit_tests to cpack

### DIFF
--- a/model-optimizer/CMakeLists.txt
+++ b/model-optimizer/CMakeLists.txt
@@ -37,6 +37,8 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
         PATTERN "extensions/front/caffe/CustomLayersMapping.xml" EXCLUDE
         PATTERN "mo/utils/convert.py" EXCLUDE
         PATTERN "unit_tests" EXCLUDE
+        PATTERN "openvino_mo.egg-info" EXCLUDE
+        PATTERN "build" EXCLUDE
         
         REGEX ".*__pycache__.*" EXCLUDE
         REGEX ".*\\.pyc$" EXCLUDE
@@ -44,3 +46,8 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
         REGEX ".*\\.DS_Store$" EXCLUDE
         REGEX ".*_test\.py$" EXCLUDE
         )
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/unit_tests
+        DESTINATION deployment_tools/model_optimizer
+        COMPONENT tests
+        EXCLUDE_FROM_ALL)


### PR DESCRIPTION
### Details:
 - Exclude "openvino_mo.egg-info" and "build" folders (generated during wheels building) from cpack archives
 - Add unit_tests folder to tests cpack component

### Tickets:
 - 58434
 - 58695