### PR TITLE
densenet-161 accuracy drop - workaround

### DIFF
--- a/inference-engine/src/offline_transformations/src/pruning/propagate_masks.cpp
+++ b/inference-engine/src/offline_transformations/src/pruning/propagate_masks.cpp
@@ -312,9 +312,9 @@ public:
             auto output_mask = std::make_shared<Mask>(m_output.get_partial_shape().rank().get_length());
             auto output_mask_row = output_mask.get();
 
-            auto out_mask_callback = [input_mask_row, weights_mask_row, union_eltwise_type](Mask::Ptr cur_mask) -> bool {
+            auto out_mask_callback = [input_mask_row, weights_mask_row, union_eltwise_type, m_input](Mask::Ptr cur_mask) -> bool {
                 Mask::Ptr result_mask;
-                if (union_eltwise_type) {
+                if (union_eltwise_type && !ngraph::is_type<opset6::Concat>(m_input.get_node_shared_ptr())) {
                     result_mask = input_mask_row->union_masks_reversed(weights_mask_row);
                 } else {
                     result_mask = input_mask_row->intersect_masks_reversed(weights_mask_row);


### PR DESCRIPTION
In the densenet-161 concat is followed by multiplication - pruning both of these operations sequentially negatively affects the network.
There is a workaround - if there is such a sequence, then after concat there is no multiply pruning.
A deeper analysis is now in progress, a more universal fix will be based on it. Even though only one network was affected by this transformation.