### PR TITLE
[IE TESTS] [CPU] extended cpu specific tests to support int8 precision

### DIFF
--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution.cpp
@@ -132,10 +132,13 @@ protected:
         auto convolutionNode = builder::makeConvolutionRelaxed(paramOuts.front(), weiPrc, kernel, stride, padBegin,
             padEnd, dilation, padType, convOutChannels);
 
-        if (inPrc == Precision::U8 || inPrc == Precision::I8) {
+        if (outPrc == Precision::U8 || outPrc == Precision::I8) {
             threshold = 1.001f;
             outElemType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(outPrc);
             quantizeInHigh = calculateQuantizeInHigh(kernel, inputShape[1]);
+        }
+
+        if (inPrc == Precision::U8 || inPrc == Precision::I8) {
             additionalPasses.push_back(std::make_shared<pass::ConvertPrecision<element::i8, element::f32>>());
             additionalPasses.push_back(std::make_shared<pass::ConvertPrecision<element::u8, element::f32>>());
         }

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution_backprop_data.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution_backprop_data.cpp
@@ -110,10 +110,13 @@ protected:
         auto deconvolutionNode = builder::makeConvolutionBackpropDataRelaxed(paramOuts.front(), weiPrc,
                 kernel, stride, padBegin, padEnd, dilation, padType, convOutChannels);
 
-        if (inPrc == Precision::U8 || inPrc == Precision::I8) {
+        if (outPrc == Precision::U8 || outPrc == Precision::I8) {
             threshold = 1.001f;
             outElemType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(outPrc);
             quantizeInHigh = calculateQuantizeInHigh(kernel, inputShape[1]);
+        }
+
+        if (inPrc == Precision::U8 || inPrc == Precision::I8) {
             additionalPasses.push_back(std::make_shared<pass::ConvertPrecision<element::i8, element::f32>>());
             additionalPasses.push_back(std::make_shared<pass::ConvertPrecision<element::u8, element::f32>>());
         }

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
@@ -121,10 +121,13 @@ protected:
         auto groupConv = builder::makeGroupConvolutionRelaxed(paramOuts[0], weiPrc, kernel, stride, padBegin,
                 padEnd, dilation, padType, convOutChannels, numGroups);
 
-        if (inPrc == Precision::U8 || inPrc == Precision::I8) {
+        if (outPrc == Precision::U8 || outPrc == Precision::I8) {
             threshold = 1.001f;
             outElemType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(outPrc);
             quantizeInHigh = calculateQuantizeInHigh(kernel, inputShape[1], numGroups);
+        }
+
+        if (inPrc == Precision::U8 || inPrc == Precision::I8) {
             additionalPasses.push_back(std::make_shared<pass::ConvertPrecision<element::i8, element::f32>>());
             additionalPasses.push_back(std::make_shared<pass::ConvertPrecision<element::u8, element::f32>>());
         }

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution_backprop_data.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution_backprop_data.cpp
@@ -108,10 +108,13 @@ protected:
         auto groupConv = ngraph::builder::makeGroupConvolutionBackpropDataRelaxed(paramOuts[0], weiPrc, kernel,
                     stride, padBegin, padEnd, dilation, padType, convOutChannels, numGroups);
 
-        if (inPrc == Precision::U8 || inPrc == Precision::I8) {
+        if (outPrc == Precision::U8 || outPrc == Precision::I8) {
             threshold = 1.001f;
             outElemType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(outPrc);
             quantizeInHigh = calculateQuantizeInHigh(kernel, inputShape[1], numGroups);
+        }
+
+        if (inPrc == Precision::U8 || inPrc == Precision::I8) {
             additionalPasses.push_back(std::make_shared<pass::ConvertPrecision<element::i8, element::f32>>());
             additionalPasses.push_back(std::make_shared<pass::ConvertPrecision<element::u8, element::f32>>());
         }

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution_backprop_data.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution_backprop_data.cpp
@@ -49,7 +49,18 @@ public:
     }
 
 protected:
+    int calculateQuantizeInHigh(const InferenceEngine::SizeVector& kernel, const int ic, const int groups,
+            const int maxIn0 = 10, const int maxIn1 = 10) const {
+        auto quantizeInHigh = maxIn0 * maxIn1;
+        quantizeInHigh *= (ic / groups);
+        for (int i = 0; i < kernel.size(); i++) {
+            quantizeInHigh *= kernel[i];
+        }
+        return quantizeInHigh;
+    }
+
     void SetUp() override {
+        using namespace ngraph;
         groupConvBackpropDataLayerTestParamsSet basicParamsSet;
         CPUSpecificParams cpuParams;
         fusingSpecificParams fusingParams;
@@ -66,34 +77,46 @@ protected:
         auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
         std::tie(groupConvParams, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, outputShape, targetDevice) = basicParamsSet;
 
-        if (inPrc == Precision::UNSPECIFIED) {
-            selectedType += std::string("_") + Precision(Precision::FP32).name();
+        if (inPrc == Precision::UNSPECIFIED)
+            inPrc = Precision::FP32;
+        if (outPrc == Precision::UNSPECIFIED)
+            outPrc = Precision::FP32;
+
+        if (inPrc == Precision::U8) {
+            selectedType += std::string("_") + Precision(Precision::I8).name();
         } else {
             selectedType += std::string("_") + inPrc.name();
         }
 
-        ngraph::op::PadType padType;
+        op::PadType padType;
         InferenceEngine::SizeVector kernel, stride, dilation;
         std::vector<ptrdiff_t> padBegin, padEnd, outputPadding;
         size_t convOutChannels, numGroups;
         std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, numGroups, padType, outputPadding) = groupConvParams;
+        auto inElementType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrc);
+        auto outElementType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(outPrc);
+        if (inPrc == Precision::BF16)
+            inElementType = element::f32;
+        if (outPrc == Precision::BF16)
+            outElementType = element::f32;
 
-        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
-        auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
-        auto paramOuts = ngraph::helpers::convert2OutputVector(
-                ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
-        std::shared_ptr<ngraph::op::v1::GroupConvolutionBackpropData> groupConv;
-        if (!outputShape.empty()) {
-            auto outShape = ngraph::opset3::Constant::create(ngraph::element::i64, {outputShape.size()}, outputShape);
-            groupConv = std::dynamic_pointer_cast<ngraph::opset1::GroupConvolutionBackpropData>(
-            ngraph::builder::makeGroupConvolutionBackpropData(paramOuts[0], outShape, ngPrc, kernel, stride, padBegin,
-                                                            padEnd, dilation, padType, convOutChannels, numGroups, false, outputPadding));
-        } else {
-            groupConv = std::dynamic_pointer_cast<ngraph::opset1::GroupConvolutionBackpropData>(
-            ngraph::builder::makeGroupConvolutionBackpropData(paramOuts[0], ngPrc, kernel, stride, padBegin,
-                                                padEnd, dilation, padType, convOutChannels, numGroups, false, outputPadding));
+        auto inputParams = builder::makeParams(inElementType, { inputShape });
+        auto paramOuts = helpers::convert2OutputVector(helpers::castOps2Nodes<op::Parameter>(inputParams));
+
+        auto weiPrc = (inElementType == element::u8) ? element::i8 : inElementType;
+
+        auto groupConv = ngraph::builder::makeGroupConvolutionBackpropDataRelaxed(paramOuts[0], weiPrc, kernel,
+                    stride, padBegin, padEnd, dilation, padType, convOutChannels, numGroups);
+
+        if (inPrc == Precision::U8 || inPrc == Precision::I8) {
+            threshold = 1.001f;
+            outElemType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(outPrc);
+            quantizeInHigh = calculateQuantizeInHigh(kernel, inputShape[1], numGroups);
+            additionalPasses.push_back(std::make_shared<pass::ConvertPrecision<element::i8, element::f32>>());
+            additionalPasses.push_back(std::make_shared<pass::ConvertPrecision<element::u8, element::f32>>());
         }
-        function = makeNgraphFunction(ngPrc, params, groupConv, "groupConvolutionBackpropData");
+
+        function = makeNgraphFunction(element::f32, inputParams, groupConv, "groupConvolutionBackpropData");
     }
 };
 
@@ -105,28 +128,6 @@ TEST_P(GroupDeconvolutionLayerCPUTest, CompareWithRefs) {
 }
 
 namespace {
-
-/* GROUP CONV TEST UTILS */
-std::vector<groupDeconvLayerCPUTestParamsSet> filterParamsSetForDevice(std::vector<groupDeconvLayerCPUTestParamsSet> paramsSet) {
-    std::vector<groupDeconvLayerCPUTestParamsSet> resParamsSet;
-    const int cpuParamsIndex = 1;
-    const int selectedTypeIndex = 3;
-
-    for (auto param : paramsSet) {
-        auto cpuParams = std::get<cpuParamsIndex>(param);
-        auto selectedTypeStr = std::get<selectedTypeIndex>(cpuParams);
-
-        if (selectedTypeStr.find("jit") != std::string::npos && !with_cpu_x86_sse42())
-            continue;
-        if (selectedTypeStr.find("avx512") != std::string::npos && !with_cpu_x86_avx512f())
-            continue;
-
-        resParamsSet.push_back(param);
-    }
-
-    return resParamsSet;
-}
-/* ===================== */
 
 /* COMMON PARAMS */
 std::vector<fusingSpecificParams> fusingParamsSet {
@@ -403,5 +404,211 @@ INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_2D_DW_BF16, GroupDeconvolutionLayerCP
         ::testing::Values(cpuBF16PluginConfig)),
     GroupDeconvolutionLayerCPUTest::getTestCaseName);
 } // namespace
+
+/* ============= U8/I8 Deconvolution ============= */
+namespace int8 {
+
+const std::vector<SizeVector> kernels2di8 = { {3, 3} };
+const std::vector<SizeVector> strides2di8 = { {1, 1}, {2, 2} };
+const std::vector<std::vector<ptrdiff_t>> padBegins2di8 = { {0, 0}, {1, 1} };
+const std::vector<std::vector<ptrdiff_t>> padEnds2di8 = { {0, 0}, {1, 1} };
+const std::vector<SizeVector> dilations2di8 = { {1, 1}/*, {2, 2}*/ };
+
+const auto groupDeconvParams_2D_I8 = ::testing::Combine(
+        ::testing::ValuesIn(kernels2di8),
+        ::testing::ValuesIn(strides2di8),
+        ::testing::ValuesIn(padBegins2di8),
+        ::testing::ValuesIn(padEnds2di8),
+        ::testing::ValuesIn(dilations2di8),
+        ::testing::ValuesIn(numOutChannels_Blocked),
+        ::testing::ValuesIn(numGroups_Blocked),
+        ::testing::Values(ngraph::op::PadType::EXPLICIT),
+        ::testing::ValuesIn(emptyOutputPadding)
+);
+
+const std::vector<fusingSpecificParams> fusingParamsSetI8{
+        emptyFusingSpec,
+//        // activations
+        fusingElu,
+        fusingSigmoid,
+        fusingPReluPerChannel,
+        fusingSwish,
+        fusingMish,
+//        // other patterns
+        fusingAddPerChannel
+};
+
+const std::vector<CPUSpecificParams> CPUParams_2D_I8 = {
+        conv_sse42_2D_nspc,
+        conv_avx2_2D_nspc,
+        conv_avx512_2D_nspc
+};
+
+INSTANTIATE_TEST_CASE_P(smoke_GroupDeconv_2D_I8, GroupDeconvolutionLayerCPUTest,
+        ::testing::Combine(
+                ::testing::Combine(
+                        groupDeconvParams_2D_I8,
+                        ::testing::Values(Precision::FP32),
+                        ::testing::Values(Precision::U8, Precision::I8),
+                        ::testing::Values(Precision::FP32, Precision::U8, Precision::I8),
+                        ::testing::Values(Layout::ANY),
+                        ::testing::Values(Layout::ANY),
+                        ::testing::Values(std::vector<size_t >({ 2, 64, 7, 7 })),
+                        ::testing::ValuesIn(emptyOutputShape),
+                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_2D_I8)),
+                ::testing::ValuesIn(fusingParamsSetI8),
+                ::testing::Values(cpuEmptyPluginConfig)),
+        GroupDeconvolutionLayerCPUTest::getTestCaseName);
+
+// temporarily disabled support for 3D cases in the plug-in
+/* ============= GroupDeconvolution params I8 (3D) ============= */
+//const std::vector<SizeVector> kernels3di8 = { {3, 3, 3} };
+//const std::vector<SizeVector> strides3di8 = { {1, 1, 1}, {2, 2, 2} };
+//const std::vector<std::vector<ptrdiff_t>> padBegins3di8 = { {0, 0, 0}, {1, 1, 1} };
+//const std::vector<std::vector<ptrdiff_t>> padEnds3di8 = { {0, 0, 0}, {1, 1, 1} };
+//const std::vector<SizeVector> dilations3di8 = { {1, 1, 1}/*, {2, 2, 2}*/ };
+//
+//const auto groupDeconvParams_3D_I8 = ::testing::Combine(
+//        ::testing::ValuesIn(kernels3di8),
+//        ::testing::ValuesIn(strides3di8),
+//        ::testing::ValuesIn(padBegins3di8),
+//        ::testing::ValuesIn(padEnds3di8),
+//        ::testing::ValuesIn(dilations3di8),
+//        ::testing::ValuesIn(numOutChannels_Blocked),
+//        ::testing::ValuesIn(numGroups_Blocked),
+//        ::testing::Values(ngraph::op::PadType::EXPLICIT),
+//        ::testing::ValuesIn(emptyOutputPadding)
+//);
+//
+//const std::vector<CPUSpecificParams> CPUParams_3D_I8 = {
+//        conv_sse42_3D_nspc,
+//        conv_avx2_3D_nspc,
+//        conv_avx512_3D_nspc
+//};
+//
+//INSTANTIATE_TEST_CASE_P(smoke_GroupDeconv_3D_I8, GroupDeconvolutionLayerCPUTest,
+//        ::testing::Combine(
+//                ::testing::Combine(
+//                        groupDeconvParams_3D_I8,
+//                        ::testing::Values(Precision::FP32),
+//                        ::testing::Values(Precision::U8, Precision::I8),
+//                        ::testing::Values(Precision::FP32, Precision::U8, Precision::I8),
+//                        ::testing::Values(Layout::ANY),
+//                        ::testing::Values(Layout::ANY),
+//                        ::testing::Values(std::vector<size_t >({ 2, 64, 7, 7, 7 })),
+//                        ::testing::ValuesIn(emptyOutputShape),
+//                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+//                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_3D_I8)),
+//                ::testing::ValuesIn(fusingParamsSetI8),
+//                ::testing::Values(cpuEmptyPluginConfig)),
+//        GroupDeconvolutionLayerCPUTest::getTestCaseName);
+
+/* ============= GroupDeconvolution params 1x1 I8 (2D) ============= */
+const auto groupDeconvParams_1x1_2D_I8 = ::testing::Combine(
+        ::testing::Values(SizeVector({1, 1})),
+        ::testing::Values(SizeVector({1, 1})),
+        ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
+        ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
+        ::testing::Values(SizeVector({1, 1})),
+        ::testing::ValuesIn(numOutChannels_Blocked),
+        ::testing::ValuesIn(numGroups_Blocked),
+        ::testing::Values(ngraph::op::PadType::EXPLICIT),
+        ::testing::ValuesIn(emptyOutputPadding)
+);
+
+const std::vector<CPUSpecificParams> CPUParams_2D_1x1_I8 = {
+        // not supported 1x1 grouped conv for avx2/sse41 isa
+        // conv_sse42_2D_1x1_I8,
+        // conv_avx2_2D_1x1_I8,
+        conv_avx512_2D_1x1_nspc
+};
+
+INSTANTIATE_TEST_CASE_P(smoke_GroupDeconv_1x1_2D_I8, GroupDeconvolutionLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Combine(
+                                        groupDeconvParams_1x1_2D_I8,
+                                        ::testing::Values(Precision::FP32),
+                                        ::testing::Values(Precision::U8, Precision::I8),
+                                        ::testing::Values(Precision::FP32, Precision::U8, Precision::I8),
+                                        ::testing::Values(Layout::ANY),
+                                        ::testing::Values(Layout::ANY),
+                                        ::testing::Values(std::vector<size_t >({ 2, 64, 7, 7 })),
+                                        ::testing::ValuesIn(emptyOutputShape),
+                                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_2D_1x1_I8)),
+                                ::testing::ValuesIn(fusingParamsSetI8),
+                                ::testing::Values(cpuEmptyPluginConfig)),
+                        GroupDeconvolutionLayerCPUTest::getTestCaseName);
+
+// temporarily disabled support for 3D cases in the plug-in
+/* ============= GroupDeconvolution params 1x1 I8 (3D) ============= */
+//const auto groupDeconvParams_1x1_3D_I8 = ::testing::Combine(
+//        ::testing::Values(SizeVector({1, 1, 1})),
+//        ::testing::Values(SizeVector({1, 1, 1})),
+//        ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),
+//        ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),
+//        ::testing::Values(SizeVector({1, 1, 1})),
+//        ::testing::ValuesIn(numOutChannels_Blocked),
+//        ::testing::ValuesIn(numGroups_Blocked),
+//        ::testing::Values(ngraph::op::PadType::EXPLICIT),
+//        ::testing::ValuesIn(emptyOutputPadding)
+//);
+//
+//const std::vector<CPUSpecificParams> CPUParams_3D_1x1_I8 = {
+//        // not supported 1x1 grouped conv for avx2/sse41 isa
+//        // conv_sse42_3D_1x1_I8,
+//        // conv_avx2_3D_1x1_I8,
+//        conv_avx512_3D_1x1_nspc
+//};
+//
+//INSTANTIATE_TEST_CASE_P(smoke_GroupDeconv_1x1_3D_I8, GroupDeconvolutionLayerCPUTest,
+//                        ::testing::Combine(
+//                                ::testing::Combine(
+//                                        groupDeconvParams_1x1_3D_I8,
+//                                        ::testing::Values(Precision::FP32),
+//                                        ::testing::Values(Precision::U8, Precision::I8),
+//                                        ::testing::Values(Precision::FP32, Precision::U8, Precision::I8),
+//                                        ::testing::Values(Layout::ANY),
+//                                        ::testing::Values(Layout::ANY),
+//                                        ::testing::Values(std::vector<size_t >({ 2, 64, 7, 7, 7 })),
+//                                        ::testing::ValuesIn(emptyOutputShape),
+//                                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+//                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_3D_1x1_I8)),
+//                                ::testing::ValuesIn(fusingParamsSetI8),
+//                                ::testing::Values(cpuEmptyPluginConfig)),
+//                        GroupDeconvolutionLayerCPUTest::getTestCaseName);
+
+/* ============= GroupDeconvolution params I8 (DW 2D) ============= */
+const auto groupDeconvParams_DW_2D_I8 = ::testing::Combine(
+        ::testing::ValuesIn(kernels2di8),
+        ::testing::ValuesIn(strides2di8),
+        ::testing::ValuesIn(padBegins2di8),
+        ::testing::ValuesIn(padEnds2di8),
+        ::testing::ValuesIn(dilations2di8),
+        ::testing::ValuesIn(numOutChannels_DW),
+        ::testing::ValuesIn(numGroups_DW),
+        ::testing::Values(ngraph::op::PadType::EXPLICIT),
+        ::testing::ValuesIn(emptyOutputPadding)
+);
+
+INSTANTIATE_TEST_CASE_P(smoke_GroupDeconv_2D_DW_I8, GroupDeconvolutionLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Combine(
+                                        groupDeconvParams_DW_2D_I8,
+                                        ::testing::Values(Precision::FP32),
+                                        ::testing::Values(Precision::U8), // I8 and 3D DW deconvolution not supported in oneDNN
+                                        ::testing::Values(Precision::FP32, Precision::U8, Precision::I8),
+                                        ::testing::Values(Layout::ANY),
+                                        ::testing::Values(Layout::ANY),
+                                        ::testing::Values(std::vector<size_t >({ 2, 32, 7, 7 })),
+                                        ::testing::ValuesIn(emptyOutputShape),
+                                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_2D_I8)),
+                                ::testing::ValuesIn(fusingParamsSetI8),
+                                ::testing::Values(cpuEmptyPluginConfig)),
+                        GroupDeconvolutionLayerCPUTest::getTestCaseName);
+
+} // namespace int8
 
 } // namespace CPULayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/convolution_params.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/convolution_params.hpp
@@ -71,5 +71,9 @@ namespace CPUTestUtils {
     const auto conv_avx2_2D_1x1_nspc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_avx2_1x1"}, "jit_avx2_1x1"};
     const auto conv_avx512_2D_1x1_nspc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_avx512_1x1"}, "jit_avx512_1x1"};
 
+    const auto conv_sse42_3D_1x1_nspc = CPUSpecificParams{{ndhwc}, {ndhwc}, {"jit_sse42_1x1"}, "jit_sse42_1x1"};
+    const auto conv_avx2_3D_1x1_nspc = CPUSpecificParams{{ndhwc}, {ndhwc}, {"jit_avx2_1x1"}, "jit_avx2_1x1"};
+    const auto conv_avx512_3D_1x1_nspc = CPUSpecificParams{{ndhwc}, {ndhwc}, {"jit_avx512_1x1"}, "jit_avx512_1x1"};
+
     const auto conv_winograd = CPUSpecificParams{{nChw16c}, {nChw16c}, {"jit_avx512_winograd"}, "jit_avx512_winograd"};
 } // namespace CPUTestUtils

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.cpp
@@ -4,6 +4,7 @@
 
 #include "cpu_test_utils.hpp"
 #include "utils/rt_info/memory_formats_attribute.hpp"
+#include "ngraph_functions/builders.hpp"
 
 namespace CPUTestUtils {
 
@@ -268,6 +269,12 @@ CPUTestsBase::makeNgraphFunction(const ngraph::element::Type &ngPrc, ngraph::Par
                                  const std::shared_ptr<ngraph::Node> &lastNode, std::string name) const {
    auto newLastNode = modifyGraph(ngPrc, params, lastNode);
    ngraph::ResultVector results;
+
+   if (outElemType == ngraph::element::u8) {
+       newLastNode = ngraph::builder::makeFakeQuantize(newLastNode, ngPrc, 256, {1, 1, 1, 1}, {0}, {static_cast<float>(quantizeInHigh)}, {0}, {255});
+   } else if (outElemType == ngraph::element::i8) {
+       newLastNode = ngraph::builder::makeFakeQuantize(newLastNode, ngPrc, 255, {1, 1, 1, 1}, {0}, {static_cast<float>(quantizeInHigh)}, {-127}, {127});
+   }
 
    for (int i = 0; i < newLastNode->get_output_size(); i++)
         results.push_back(std::make_shared<ngraph::opset1::Result>(newLastNode->output(i)));

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
@@ -10,6 +10,7 @@
 #include "shared_test_classes/base/layer_test_utils.hpp"
 #include <exec_graph_info.hpp>
 #include "ie_system_conf.h"
+#include "ngraph_ops/type_relaxed.hpp"
 
 namespace CPUTestUtils {
     typedef enum {
@@ -151,6 +152,10 @@ protected:
     std::vector<cpu_memory_format_t> inFmts, outFmts;
     std::vector<std::string> priority;
     std::string selectedType;
+
+    ngraph::element::Type outElemType = ngraph::element::f32;
+    // only for int8 testing
+    int quantizeInHigh = 1;
 };
 
 const auto emptyCPUSpec = CPUSpecificParams{{}, {}, {}, {}};

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/fusing_test_utils.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/fusing_test_utils.cpp
@@ -103,7 +103,7 @@ std::string postNodesMgr::getFusedOpsNames() const {
     const char* separator = "";
     for (const auto& item : _postNodes) {
         result << separator << item.name;
-        separator = ",";
+        separator = ":";
     }
     return result.str();
 }

--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
@@ -153,6 +153,8 @@ protected:
 
     InferenceEngine::InferRequest inferRequest;
 
+    std::vector<std::shared_ptr<ngraph::pass::GraphRewrite>> additionalPasses;
+
 private:
     RefMode refMode = RefMode::INTERPRETER;
 };

--- a/inference-engine/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
@@ -354,6 +354,9 @@ std::vector<std::pair<ngraph::element::Type, std::vector<std::uint8_t>>> LayerTe
     ngraph::pass::ConvertPrecision<ngraph::element::Type_t::f16, ngraph::element::Type_t::f32>().run_on_function(function);
     ngraph::pass::ConvertPrecision<ngraph::element::Type_t::bf16, ngraph::element::Type_t::f32>().run_on_function(function);
 
+    for (const auto &pass : additionalPasses)
+        pass->run_on_function(function);
+
     function->validate_nodes_and_infer_types();
 
     auto referenceInputs = std::vector<std::vector<uint8_t>>(inputs.size());

--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/CMakeLists.txt
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/CMakeLists.txt
@@ -13,6 +13,7 @@ addIeTarget(
         INCLUDES
             PUBLIC
                 ${PUBLIC_HEADERS_DIR}
+                ${IE_MAIN_SOURCE_DIR}/src/transformations/include
         ADDITIONAL_SOURCE_DIRS
             ${CMAKE_CURRENT_SOURCE_DIR}/src
         LINK_LIBRARIES

--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/builders.hpp
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/builders.hpp
@@ -17,6 +17,7 @@
 #include <ngraph/opsets/opset8.hpp>
 
 #include "ngraph_functions/utils/data_utils.hpp"
+#include "ngraph_ops/type_relaxed.hpp"
 
 namespace ngraph {
 namespace builder {
@@ -91,6 +92,17 @@ std::shared_ptr<ngraph::Node> makeConvolution(const ngraph::Output<Node> &in,
                                               const std::vector<float> &filterWeights = {},
                                               const std::vector<float> &biasesWeights = {});
 
+std::shared_ptr<ngraph::Node> makeConvolutionRelaxed(const ngraph::Output<Node> &in,
+                                              const element::Type &type,
+                                              const std::vector<size_t> &filterSize,
+                                              const std::vector<size_t> &strides,
+                                              const std::vector<ptrdiff_t> &padsBegin,
+                                              const std::vector<ptrdiff_t> &padsEnd,
+                                              const std::vector<size_t> &dilations,
+                                              const op::PadType &autoPad,
+                                              size_t numOutChannels,
+                                              const std::vector<float> &filterWeights = {});
+
 std::shared_ptr<ngraph::Node> makeGroupConvolution(const ngraph::Output<Node> &in,
                                                    const element::Type &type,
                                                    const std::vector<size_t> &filterSize,
@@ -115,6 +127,18 @@ std::shared_ptr<ngraph::Node> makeGroupConvolution(const ngraph::Output<Node> &i
                                                    const op::PadType &autoPad,
                                                    bool addBiases = false,
                                                    const std::vector<float> &biasesWeights = {});
+
+std::shared_ptr<Node> makeGroupConvolutionRelaxed(const ngraph::Output<Node> &in,
+                                                  const element::Type &type,
+                                                  const std::vector<size_t> &filterSize,
+                                                  const std::vector<size_t> &strides,
+                                                  const std::vector<ptrdiff_t> &padsBegin,
+                                                  const std::vector<ptrdiff_t> &padsEnd,
+                                                  const std::vector<size_t> &dilations,
+                                                  const op::PadType &autoPad,
+                                                  size_t numOutChannels,
+                                                  size_t numGroups,
+                                                  const std::vector<float> &filterWeights = {});
 
 std::shared_ptr<ngraph::Node> makeConvolutionBackpropData(const ngraph::Output<Node> &in,
                                                           const element::Type &type,
@@ -156,6 +180,17 @@ std::shared_ptr<ngraph::Node> makeConvolutionBackpropData(const ngraph::Output<N
                                                           const std::vector<ptrdiff_t> &outputPadding = {},
                                                           const std::vector<float> &filterWeights = {},
                                                           const std::vector<float> &biasesWeights = {});
+
+std::shared_ptr<ngraph::Node> makeConvolutionBackpropDataRelaxed(const ngraph::Output<Node> &in,
+                                                          const element::Type &weiType,
+                                                          const std::vector<size_t> &filterSize,
+                                                          const std::vector<size_t> &strides,
+                                                          const std::vector<ptrdiff_t> &padsBegin,
+                                                          const std::vector<ptrdiff_t> &padsEnd,
+                                                          const std::vector<size_t> &dilations,
+                                                          const op::PadType &autoPad,
+                                                          size_t numOutChannels,
+                                                          const std::vector<float> &filterWeights = {});
 
 std::shared_ptr<ngraph::Node> makeCTCGreedyDecoder(
         const ngraph::Output<Node>& inputData,
@@ -228,6 +263,18 @@ std::shared_ptr<ngraph::Node> makeGroupConvolutionBackpropData(const ngraph::Out
                                                                const std::vector<ptrdiff_t> &outputPadding = {},
                                                                const std::vector<float> &filterWeights = {},
                                                                const std::vector<float> &biasesWeights = {});
+
+std::shared_ptr<Node> makeGroupConvolutionBackpropDataRelaxed(const ngraph::Output<Node> &in,
+                                                              const element::Type &weiType,
+                                                              const std::vector<size_t> &filterSize,
+                                                              const std::vector<size_t> &strides,
+                                                              const std::vector<ptrdiff_t> &padsBegin,
+                                                              const std::vector<ptrdiff_t> &padsEnd,
+                                                              const std::vector<size_t> &dilations,
+                                                              const op::PadType &autoPad,
+                                                              size_t numOutChannels,
+                                                              size_t numGroups,
+                                                              const std::vector<float> &filterWeights = {});
 
 std::shared_ptr<ngraph::Node> makeBinaryConvolution(const ngraph::Output<Node> &in,
                                                     const std::vector<size_t> &filterSize,

--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/src/convolution.cpp
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/src/convolution.cpp
@@ -39,5 +39,34 @@ std::shared_ptr<Node> makeConvolution(const ngraph::Output<Node> &in,
     }
 }
 
+std::shared_ptr<Node> makeConvolutionRelaxed(const ngraph::Output<Node> &in,
+                                      const element::Type &type,
+                                      const std::vector<size_t> &filterSize,
+                                      const std::vector<size_t> &strides,
+                                      const std::vector<ptrdiff_t> &padsBegin,
+                                      const std::vector<ptrdiff_t> &padsEnd,
+                                      const std::vector<size_t> &dilations,
+                                      const op::PadType &autoPad,
+                                      size_t numOutChannels,
+                                      const std::vector<float> &filterWeights) {
+    auto inputParamsFP32 = ngraph::builder::makeParams(ngraph::element::f32, { in.get_shape() });
+    auto paramOutsFP32 = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(inputParamsFP32));
+
+    auto convolutionNodeRelaxed = std::make_shared<op::TypeRelaxed<opset1::Convolution>>(
+            *as_type_ptr<opset1::Convolution>(ngraph::builder::makeConvolution(
+                    paramOutsFP32.front(), ngraph::element::f32, filterSize, strides, padsBegin, padsEnd, dilations, autoPad, numOutChannels)),
+            element::f32);
+
+    bool randomFilterWeights = filterWeights.empty();
+    auto shape = in.get_shape();
+    std::vector<size_t> filterWeightsShape = {numOutChannels, shape[1]};
+    filterWeightsShape.insert(filterWeightsShape.end(), filterSize.begin(), filterSize.end());
+    auto filterWeightsNode = makeConstant(type, filterWeightsShape, filterWeights, randomFilterWeights);
+
+    auto newConvolution = convolutionNodeRelaxed->copy_with_new_inputs({in, filterWeightsNode});
+
+    return newConvolution;
+}
+
 }  // namespace builder
 }  // namespace ngraph

--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/src/convolution_backprop_data.cpp
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/src/convolution_backprop_data.cpp
@@ -96,5 +96,34 @@ std::shared_ptr<Node> makeConvolutionBackpropData(const ngraph::Output<Node> &in
     }
 }
 
+std::shared_ptr<Node> makeConvolutionBackpropDataRelaxed(const ngraph::Output<Node> &in,
+                                                  const element::Type &weiType,
+                                                  const std::vector<size_t> &filterSize,
+                                                  const std::vector<size_t> &strides,
+                                                  const std::vector<ptrdiff_t> &padsBegin,
+                                                  const std::vector<ptrdiff_t> &padsEnd,
+                                                  const std::vector<size_t> &dilations,
+                                                  const op::PadType &autoPad,
+                                                  size_t numOutChannels,
+                                                  const std::vector<float> &filterWeights) {
+    auto inputParamsFP32 = ngraph::builder::makeParams(ngraph::element::f32, { in.get_shape() });
+    auto paramOutsFP32 = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(inputParamsFP32));
+
+    auto deconvolutionNodeRelaxed = std::make_shared<op::TypeRelaxed<opset1::ConvolutionBackpropData>>(
+            *as_type_ptr<opset1::ConvolutionBackpropData>(ngraph::builder::makeConvolutionBackpropData(
+                    paramOutsFP32.front(), ngraph::element::f32, filterSize, strides, padsBegin, padsEnd, dilations, autoPad, numOutChannels)),
+            element::f32);
+
+    bool randomFilterWeights = filterWeights.empty();
+    auto shape = in.get_shape();
+    std::vector<size_t> filterWeightsShape = {shape[1], numOutChannels};
+    filterWeightsShape.insert(filterWeightsShape.end(), filterSize.begin(), filterSize.end());
+    auto filterWeightsNode = makeConstant(weiType, filterWeightsShape, filterWeights, randomFilterWeights);
+
+    auto newDeconvolution = deconvolutionNodeRelaxed->copy_with_new_inputs({in, filterWeightsNode});
+
+    return newDeconvolution;
+}
+
 }  // namespace builder
 }  // namespace ngraph

--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/src/group_convolution_backprop_data.cpp
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/src/group_convolution_backprop_data.cpp
@@ -108,5 +108,39 @@ std::shared_ptr<Node> makeGroupConvolutionBackpropData(const ngraph::Output<Node
     }
 }
 
+std::shared_ptr<Node> makeGroupConvolutionBackpropDataRelaxed(const ngraph::Output<Node> &in,
+                                                         const element::Type &weiType,
+                                                         const std::vector<size_t> &filterSize,
+                                                         const std::vector<size_t> &strides,
+                                                         const std::vector<ptrdiff_t> &padsBegin,
+                                                         const std::vector<ptrdiff_t> &padsEnd,
+                                                         const std::vector<size_t> &dilations,
+                                                         const op::PadType &autoPad,
+                                                         size_t numOutChannels,
+                                                         size_t numGroups,
+                                                         const std::vector<float> &filterWeights) {
+    auto inputParamsFP32 = ngraph::builder::makeParams(ngraph::element::f32, { in.get_shape() });
+    auto paramOutsFP32 = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(inputParamsFP32));
+
+    auto groupDeconvolutionNodeRelaxed = std::make_shared<op::TypeRelaxed<opset1::GroupConvolutionBackpropData>>(
+            *as_type_ptr<opset1::GroupConvolutionBackpropData>(ngraph::builder::makeGroupConvolutionBackpropData(
+                    paramOutsFP32.front(), ngraph::element::f32, filterSize, strides, padsBegin, padsEnd, dilations, autoPad,
+                    numOutChannels, numGroups)),
+            element::f32);
+
+    bool randomFilterWeights = filterWeights.empty();
+    auto shape = in.get_shape();
+    std::vector<size_t> filterWeightsShape = {shape[1], numOutChannels};
+    filterWeightsShape[0] /= numGroups;
+    filterWeightsShape[1] /= numGroups;
+    filterWeightsShape.insert(filterWeightsShape.begin(), numGroups);
+    filterWeightsShape.insert(filterWeightsShape.end(), filterSize.begin(), filterSize.end());
+    auto filterWeightsNode = makeConstant(weiType, filterWeightsShape, filterWeights, randomFilterWeights);
+
+    auto newGroupDeconvolution = groupDeconvolutionNodeRelaxed->copy_with_new_inputs({in, filterWeightsNode});
+
+    return newGroupDeconvolution;
+}
+
 }  // namespace builder
 }  // namespace ngraph


### PR DESCRIPTION
This PR contains int8 tests for nodes:

1. Convolution
2. GroupConvolution
3. ConvolutionBackpropData
4. GroupConvolutionBackpropData

**TODO**
- [x] fill Convolution and GroupConvolution tests
- [x] fill ConvolutionBackpropData and GroupConvolutionBackpropData tests
- [ ] split tests into files depending on the precision (fp32, bf16, int8)
- [ ] add dw conv fusing tests for https://github.com/openvinotoolkit/openvino/pull/6333
- [ ] add tests for issue 63021
- [ ] add tests for issue 62549