### PR TITLE
Add Average adaptive pooling evaluate()

### DIFF
--- a/ngraph/core/include/ngraph/op/adaptive_avg_pool.hpp
+++ b/ngraph/core/include/ngraph/op/adaptive_avg_pool.hpp
@@ -37,6 +37,10 @@ namespace ngraph
 
                 std::shared_ptr<Node>
                     clone_with_new_inputs(const OutputVector& new_args) const override;
+
+                bool evaluate(const HostTensorVector& outputs,
+                              const HostTensorVector& inputs) const override;
+                bool has_evaluate() const override;
             };
         } // namespace v8
     }     // namespace op

--- a/ngraph/core/src/op/adaptive_avg_pool.cpp
+++ b/ngraph/core/src/op/adaptive_avg_pool.cpp
@@ -27,15 +27,8 @@ namespace adaptive_avg_pool
         bool rc = true;
         switch (arg0->get_element_type())
         {
-            NGRAPH_TYPE_CASE(evaluate_add, i8, arg0, out);
-            NGRAPH_TYPE_CASE(evaluate_add, i16, arg0, out);
             NGRAPH_TYPE_CASE(evaluate_add, i32, arg0, out);
             NGRAPH_TYPE_CASE(evaluate_add, i64, arg0, out);
-            NGRAPH_TYPE_CASE(evaluate_add, u8, arg0, out);
-            NGRAPH_TYPE_CASE(evaluate_add, u16, arg0, out);
-            NGRAPH_TYPE_CASE(evaluate_add, u32, arg0, out);
-            NGRAPH_TYPE_CASE(evaluate_add, u64, arg0, out);
-            NGRAPH_TYPE_CASE(evaluate_add, bf16, arg0, out);
             NGRAPH_TYPE_CASE(evaluate_add, f16, arg0, out);
             NGRAPH_TYPE_CASE(evaluate_add, f32, arg0, out);
         default: rc = false; break;
@@ -117,15 +110,8 @@ bool op::v8::AdaptiveAvgPool::has_evaluate() const
     NGRAPH_OP_SCOPE(v8_AdaptiveAvgPool_has_evaluate);
     switch (get_input_element_type(0))
     {
-    case ngraph::element::i8:
-    case ngraph::element::i16:
     case ngraph::element::i32:
     case ngraph::element::i64:
-    case ngraph::element::u8:
-    case ngraph::element::u16:
-    case ngraph::element::u32:
-    case ngraph::element::u64:
-    case ngraph::element::bf16:
     case ngraph::element::f16:
     case ngraph::element::f32: return true;
     default: break;

--- a/ngraph/test/runtime/interpreter/evaluates_map.cpp
+++ b/ngraph/test/runtime/interpreter/evaluates_map.cpp
@@ -2824,19 +2824,6 @@ namespace
     }
 
     template <element::Type_t ET>
-    bool evaluate(const shared_ptr<op::v8::AdaptiveAvgPool>& op,
-                  const HostTensorVector& outputs,
-                  const HostTensorVector& inputs)
-    {
-        using T = typename element_type_traits<ET>::value_type;
-        runtime::reference::adaptive_avg_pool(inputs[0]->get_data_ptr<T>(),
-                                              outputs[0]->get_data_ptr<T>(),
-                                              inputs[0]->get_shape(),
-                                              op->get_output_shape(0));
-        return true;
-    }
-
-    template <element::Type_t ET>
     bool evaluate(const shared_ptr<op::v8::AdaptiveMaxPool>& op,
                   const HostTensorVector& outputs,
                   const HostTensorVector& inputs)


### PR DESCRIPTION
### Details:
 - *Add Average adaptive pooling evaluate() to support FastSCNN adaptive pooling fallback to ngraph reference implementation*

### Tickets:
 - *CVS-55578*
