### PR TITLE
Remove using v0::NormalizeL2 from op namespace

### DIFF
--- a/ngraph/core/include/ngraph/op/normalize_l2.hpp
+++ b/ngraph/core/include/ngraph/op/normalize_l2.hpp
@@ -54,6 +54,5 @@ namespace ngraph
                 EpsMode m_eps_mode;
             };
         } // namespace v0
-        using v0::NormalizeL2;
-    } // namespace op
+    }     // namespace op
 } // namespace ngraph


### PR DESCRIPTION
### Details:
Remove using v0::NormalizeL2 from op namespace

Optional change, related to github discussion:
https://github.com/openvinotoolkit/openvino/pull/6310#discussion_r659467865

### Tickets:
 - N/A, related to 45809
