### PR TITLE
[CPU] NormalizeL2 - unsorted axes are not supported

### DIFF
--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_normalize_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_normalize_node.cpp
@@ -690,7 +690,9 @@ bool MKLDNNNormalizeL2Node::isSupportedOperation(const std::shared_ptr<const ngr
             }
             return false;
         };
-        const auto axes = axesNode->cast_vector<size_t>();
+        auto tempAxes = axesNode->cast_vector<size_t>();
+        std::sort(tempAxes.begin(), tempAxes.end());
+        const auto axes = tempAxes;
         if (!isSupportedAxes(axes, dataDims) && ngraph::shape_size(axesNode->get_shape()) != 0) {
             errorMessage = "Doesn't support reduction axes: " + vec2str(axes);
             return false;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_normalize_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_normalize_node.cpp
@@ -682,10 +682,10 @@ bool MKLDNNNormalizeL2Node::isSupportedOperation(const std::shared_ptr<const ngr
             if (axes.size() == 1 && axes[0] == 1) {
                 return true;
             } else if (axes.size() == dataDims.size() - 1) {
-                auto tempAxes = axes;
-                std::sort(tempAxes.begin(), tempAxes.end());
-                for (size_t i = 0; i < tempAxes.size(); i++) {
-                    if (tempAxes[i] != i + 1)
+                auto sortAxes = axes;
+                std::sort(sortAxes.begin(), sortAxes.end());
+                for (size_t i = 0; i < sortAxes.size(); i++) {
+                    if (sortAxes[i] != i + 1)
                         return false;
                 }
                 return true;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_normalize_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_normalize_node.cpp
@@ -682,17 +682,17 @@ bool MKLDNNNormalizeL2Node::isSupportedOperation(const std::shared_ptr<const ngr
             if (axes.size() == 1 && axes[0] == 1) {
                 return true;
             } else if (axes.size() == dataDims.size() - 1) {
-                for (size_t i = 0; i < axes.size(); i++) {
-                    if (axes[i] != i + 1)
+                auto tempAxes = axes;
+                std::sort(tempAxes.begin(), tempAxes.end());
+                for (size_t i = 0; i < tempAxes.size(); i++) {
+                    if (tempAxes[i] != i + 1)
                         return false;
                 }
                 return true;
             }
             return false;
         };
-        auto tempAxes = axesNode->cast_vector<size_t>();
-        std::sort(tempAxes.begin(), tempAxes.end());
-        const auto axes = tempAxes;
+        const auto axes = axesNode->cast_vector<size_t>();
         if (!isSupportedAxes(axes, dataDims) && ngraph::shape_size(axesNode->get_shape()) != 0) {
             errorMessage = "Doesn't support reduction axes: " + vec2str(axes);
             return false;

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/normalize_l2.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/normalize_l2.cpp
@@ -75,9 +75,7 @@ const std::vector<std::vector<int64_t>> axes_3D = {
         {},
         {1},
         {1, 2},
-
-        // [CPU] Unsorted axes, Issue: 59794
-        // {2, 1},
+        {2, 1},
 
         // [CPU] Unsupported axes, Issue: 59791
         // {0},
@@ -107,9 +105,7 @@ const std::vector<std::vector<int64_t>> axes_4D = {
         {},
         {1},
         {1, 2, 3},
-
-        // [CPU] Unsorted axes, Issue: 59794
-        // {3, 1, 2},
+        {3, 1, 2},
 
         // [CPU] Unsupported axes, Issue: 59791
         // {0},

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
@@ -61,6 +61,8 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*NormalizeL2_5D.*)",
         // Issue: 59788. mkldnn_normalize_nchw applies eps after sqrt for across_spatial
         R"(.*NormalizeL2_.*axes=\(1.2.*_eps=100.*)",
+        R"(.*NormalizeL2_.*axes=\(2.1.*_eps=100.*)",
+        R"(.*NormalizeL2_.*axes=\(3.1.2.*_eps=100.*)",
 
         // Unsupported operation of type: NormalizeL2 name : Doesn't support reduction axes: (2.2)
         R"(.*BF16NetworkRestore1.*)",

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/normalize.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/normalize.cpp
@@ -130,6 +130,7 @@ const std::vector<std::vector<size_t>> inputShape_3D = {
 
 const std::vector<std::vector<int64_t>> axes_3D = {
     {1, 2},
+    {2, 1},
     {1}
 };
 
@@ -155,6 +156,7 @@ const std::vector<std::vector<size_t>> inputShape_4D = {
 
 const std::vector<std::vector<int64_t>> axes_4D = {
     {1, 2, 3},
+    {3, 1, 2},
     {1}
 };
 

--- a/ngraph/test/runtime/ie/unit_test.manifest
+++ b/ngraph/test/runtime/ie/unit_test.manifest
@@ -903,12 +903,6 @@ non_zero_all_0s
 IE_CPU.normalize_l2_4D_axes_123_big_eps_max
 IE_CPU.normalize_l2_4D_axes_123_big_eps_add
 
-# NomalizeL2 - unsorted axes are not supported,
-# message: "Doesn't support reduction axes: (3.1.2)"
-# Issue: 59794
-IE_CPU.normalize_l2_4D_axes_unsorted_312_max
-IE_CPU.normalize_l2_4D_axes_unsorted_312_add
-
 # NormalizeL2 - Plugins support normalize over "channel" dimension
 # or "channel + all spatial" dimensions for 2D, 3D or 4D cases
 # Issue: 35627, 59791


### PR DESCRIPTION
### Details:
 - *Added sorting of axes*

### Tickets:
 - *59794*
