### PR TITLE
Fixed callback copy count

### DIFF
--- a/inference-engine/src/plugin_api/cpp_interfaces/impl/ie_infer_async_request_thread_safe_default.hpp
+++ b/inference-engine/src/plugin_api/cpp_interfaces/impl/ie_infer_async_request_thread_safe_default.hpp
@@ -404,14 +404,17 @@ private:
                         {
                             std::lock_guard<std::mutex> lock{_mutex};
                             _state = InferState::Idle;
-                            callback = _callback;
+                            std::swap(callback, _callback);
                         }
                         if (callback) {
                             try {
-                                auto local_callback = std::move(callback);
-                                local_callback(currentException);
+                                callback(currentException);
                             } catch (...) {
                                 currentException = std::current_exception();
+                            }
+                            std::lock_guard<std::mutex> lock{_mutex};
+                            if (!_callback) {
+                                std::swap(callback, _callback);
                             }
                         }
                         if (nullptr == currentException) {

--- a/inference-engine/tests/functional/plugin/shared/include/behavior/infer_request/callback.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/behavior/infer_request/callback.hpp
@@ -145,4 +145,21 @@ TEST_P(InferRequestCallbackTests, ReturnResultNotReadyFromWaitInAsyncModeForTooS
     ASSERT_NO_THROW(req.Wait(InferenceEngine::InferRequest::WaitMode::RESULT_READY));
 }
 
+TEST_P(InferRequestCallbackTests, ImplDoseNotCopyCallback) {
+    // Skip test according to plugin specific disabledTestPatterns() (if any)
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+    InferenceEngine::CNNNetwork cnnNet(function);
+    auto execNet = ie->LoadNetwork(cnnNet, targetDevice, configuration);
+    auto req = execNet.CreateInferRequest();
+    {
+        auto somePtr = std::make_shared<int>(42);
+        req.SetCompletionCallback([somePtr] {
+            ASSERT_EQ(1, somePtr.use_count());
+        });
+    }
+
+    ASSERT_NO_THROW(req.StartAsync());
+    ASSERT_NO_THROW(req.Wait(InferenceEngine::InferRequest::WaitMode::RESULT_READY));
+}
+
 }  // namespace BehaviorTestsDefinitions


### PR DESCRIPTION
### Details:
 - If a callback has an internal state it is not copied in the default implementation
