### PR TITLE
[LPT] ConvolutionBackpropData fix FQ weights folding

### DIFF
--- a/inference-engine/src/low_precision_transformations/src/convolution_backprop_data.cpp
+++ b/inference-engine/src/low_precision_transformations/src/convolution_backprop_data.cpp
@@ -72,7 +72,9 @@ bool ConvolutionBackpropDataTransformation::transform(TransformationContext &con
                          NetworkHelper::getDequantization(reshapeFromWeights);
         if (dequantization.empty()) {
             const auto fqOnWeights = getFakeQuantizeOnWeights(convolutionBackpropData);
-            std::shared_ptr<ngraph::Node> resultConstant = NetworkHelper::fold_fake_quantize(fqOnWeights);
+            auto constantShape = fqOnWeights->input(1).get_shape();
+            std::shared_ptr<ngraph::Node> resultConstant =
+                    NetworkHelper::fold_fake_quantize(fqOnWeights, false, constantShape[1] != 1ul ? 1ul : 0ul);
             if (reshapeFromWeights != nullptr) {
                 resultConstant = fold_reshape<opset1::Reshape>(
                         resultConstant,

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/convolution_backprop_data_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/convolution_backprop_data_transformation.cpp
@@ -24,6 +24,13 @@ using namespace testing;
 using namespace ngraph;
 using namespace ngraph::pass;
 
+using const_node_ptr = const std::shared_ptr<const ngraph::Node>;
+using callback_function_type = std::function<bool(const_node_ptr&)>;
+
+bool empty_callback(const std::shared_ptr<const ngraph::Node>& node) {
+    return false;
+}
+
 class ConvolutionBackpropDataTransformationTestValues {
 public:
     class Actual {
@@ -33,26 +40,31 @@ public:
         builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
         builder::subgraph::DequantizationOperations dequantizationOnWeights;
         std::shared_ptr<ngraph::opset1::Constant> weights;
+        callback_function_type callback;
 
         Actual() = default;
         Actual(
             const ngraph::element::Type& precisionBeforeDequantization,
             const ngraph::builder::subgraph::DequantizationOperations& dequantizationOnActivations,
             const builder::subgraph::FakeQuantizeOnWeights& fakeQuantizeOnWeights,
-            const std::shared_ptr<ngraph::opset1::Constant>& weights) :
+            const std::shared_ptr<ngraph::opset1::Constant>& weights,
+            const callback_function_type& callback = empty_callback) :
                 precisionBeforeDequantization(precisionBeforeDequantization),
                 dequantizationOnActivations(dequantizationOnActivations),
                 fakeQuantizeOnWeights(fakeQuantizeOnWeights),
-                weights(weights) {}
+                weights(weights),
+                callback(callback) {}
         Actual(
             const  ngraph::element::Type& precisionBeforeDequantization,
             const  ngraph::builder::subgraph::DequantizationOperations& dequantizationOnActivations,
             const  builder::subgraph::DequantizationOperations& dequantizationOnWeights,
-            const std::shared_ptr<ngraph::opset1::Constant>& weights) :
+            const std::shared_ptr<ngraph::opset1::Constant>& weights,
+            const callback_function_type& callback = empty_callback) :
             precisionBeforeDequantization(precisionBeforeDequantization),
             dequantizationOnActivations(dequantizationOnActivations),
             dequantizationOnWeights(dequantizationOnWeights),
-            weights(weights) {}
+            weights(weights),
+            callback(callback) {}
     };
 
     class Expected {
@@ -124,10 +136,11 @@ public:
                 actualWeights);
 
         SimpleLowPrecisionTransformer transform;
-        transform.add<ngraph::pass::low_precision::ConvolutionBackpropDataTransformation, ngraph::opset1::Convolution>(testValues.params);
+        transform.set_callback<low_precision::ConvolutionBackpropDataTransformation>(testValues.actual.callback);
+        transform.add<low_precision::ConvolutionBackpropDataTransformation, opset1::ConvolutionBackpropData>(testValues.params);
         transform.transform(actualFunction);
 
-        std::shared_ptr<Node> refWeights = pass::low_precision::fold<opset1::Broadcast>(
+        std::shared_ptr<Node> refWeights = low_precision::fold<opset1::Broadcast>(
                 testValues.expected.weights,
                 opset1::Constant::create(
                         element::i64,
@@ -179,7 +192,7 @@ public:
 
 TEST_P(ConvolutionBackpropDataTransformation, CompareFunctions) {
     actualFunction->validate_nodes_and_infer_types();
-    auto res = compare_functions(referenceFunction, actualFunction, true, true, true);
+    auto res = compare_functions(referenceFunction, actualFunction, true, true, false);
     ASSERT_TRUE(res.first) << res.second;
 }
 
@@ -455,15 +468,16 @@ const std::vector<ConvolutionBackpropDataTransformationTestValues> testValues = 
             true
         }
     },
-    //  issue #59593: subtract on activations, non-asymmetric, per-channel fq folding,
+    //  issue #59593: subtract on activations, non-asymmetric
     {
-        LayerTransformation::createParamsU8I8().setSupportAsymmetricQuantization(false),
+        LayerTransformation::createParamsU8I8(),
         // ActualValues
         {
             ngraph::element::u8,
             {{ngraph::element::f32}, {128.f}, {0.01f}},
-            { 255ul, Shape({ 1, 1, 1, 1 }), { 0.f }, { 254.f }, { 0.f }, { 25.4f } },
-            op::Constant::create(ngraph::element::i8, ngraph::Shape{}, std::vector<float>{ 2.f })
+            { 255ul, Shape({ 1, 2, 1, 1 }), { 0.f }, { 254.f }, { 0.f }, { 25.4f } },
+            op::Constant::create(ngraph::element::i8, ngraph::Shape{}, std::vector<float>{ 2.f }),
+            low_precision::LayerTransformation::isAsymmetricQuantization
         },
         // ExpectedValues
         {
@@ -471,8 +485,8 @@ const std::vector<ConvolutionBackpropDataTransformationTestValues> testValues = 
             {{ngraph::element::f32}, {128.f}, {0.01f}},
             {},
             {},
-            op::Constant::create(ngraph::element::f32, ngraph::Shape{}, std::vector<float>{ 0.2f }),
-            true
+            op::Constant::create(ngraph::element::f32, ngraph::Shape{}, std::vector<float>{ 2.f }),
+            false // weights are not folded because of callback returning true
         }
     },
 };

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/convolution_backprop_data_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/convolution_backprop_data_transformation.cpp
@@ -455,6 +455,26 @@ const std::vector<ConvolutionBackpropDataTransformationTestValues> testValues = 
             true
         }
     },
+    //  issue #59593: subtract on activations, non-asymmetric, per-channel fq folding,
+    {
+        LayerTransformation::createParamsU8I8().setSupportAsymmetricQuantization(false),
+        // ActualValues
+        {
+            ngraph::element::u8,
+            {{ngraph::element::f32}, {128.f}, {0.01f}},
+            { 255ul, Shape({ 1, 1, 1, 1 }), { 0.f }, { 254.f }, { 0.f }, { 25.4f } },
+            op::Constant::create(ngraph::element::i8, ngraph::Shape{}, std::vector<float>{ 2.f })
+        },
+        // ExpectedValues
+        {
+            ngraph::element::u8,
+            {{ngraph::element::f32}, {128.f}, {0.01f}},
+            {},
+            {},
+            op::Constant::create(ngraph::element::f32, ngraph::Shape{}, std::vector<float>{ 0.2f }),
+            true
+        }
+    },
 };
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
### Details:
 - Wrong channels dimension has been chosen for folding in case of not transforming ConvolutionBackpropData.


### Tickets:
 - 59593
