### PR TITLE
ShuffleChannels - add to revised ops

### DIFF
--- a/inference-engine/tests/ie_test_utils/functional_test_utils/layer_tests_summary/utils/constants.py
+++ b/inference-engine/tests/ie_test_utils/functional_test_utils/layer_tests_summary/utils/constants.py
@@ -91,6 +91,7 @@ VERIFIED_OP_REFERENCES = [
     'ScatterNDUpdate-4',
     'ShapeOf-1',
     'ShapeOf-3',
+    'ShuffleChannels-1',
     'Sigmoid-1',
     'Sin-1',
     'Sinh-1'

--- a/ngraph/test/visitors/op/shuffle_channels.cpp
+++ b/ngraph/test/visitors/op/shuffle_channels.cpp
@@ -5,7 +5,7 @@
 #include "gtest/gtest.h"
 
 #include "ngraph/ngraph.hpp"
-#include "ngraph/opsets/opset1.hpp"
+#include "ngraph/opsets/opset3.hpp"
 
 #include "util/visitor.hpp"
 
@@ -15,7 +15,7 @@ using ngraph::test::NodeBuilder;
 
 TEST(attributes, shuffle_channels_op)
 {
-    using ShuffleChannels = opset1::ShuffleChannels;
+    using ShuffleChannels = opset3::ShuffleChannels;
 
     NodeBuilder::get_ops().register_factory<ShuffleChannels>();
     auto data = make_shared<op::Parameter>(element::i32, Shape{200});

--- a/ngraph/test/visitors/op/shuffle_channels.cpp
+++ b/ngraph/test/visitors/op/shuffle_channels.cpp
@@ -18,8 +18,8 @@ TEST(attributes, shuffle_channels_op)
     using ShuffleChannels = opset3::ShuffleChannels;
 
     NodeBuilder::get_ops().register_factory<ShuffleChannels>();
-    auto data = make_shared<op::Parameter>(element::i32, Shape{200});
-    auto axis = 0;
+    auto data = make_shared<op::Parameter>(element::i32, Shape{2, 64, 16, 16});
+    auto axis = 1;
     auto groups = 2;
     auto shuffle_channels = make_shared<ShuffleChannels>(data, axis, groups);
     NodeBuilder builder(shuffle_channels);


### PR DESCRIPTION
### Details:
- [ ] Add ShuffleChannels to revised ops (all related PRs are merged)
- [ ] Update attributes test 
(upgrade test opset as ShuffleChannels was officially introduced from opset3)
(make test input shape more reasonable)

### Tickets:
 45790
