### PR TITLE
Develop installation rules for time and stress tests

### DIFF
--- a/tests/stress_tests/CMakeLists.txt
+++ b/tests/stress_tests/CMakeLists.txt
@@ -9,25 +9,12 @@ if (CMAKE_BUILD_TYPE STREQUAL "")
     set(CMAKE_BUILD_TYPE "Release")
 endif()
 
+# Define directory where artifacts will be placed
+set(OUTPUT_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
+
 find_package(InferenceEngineDeveloperPackage REQUIRED)
 
 set(OpenVINO_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../")
-
-if(EXISTS "${OpenVINO_SOURCE_DIR}/thirdparty/gflags")
-    function(add_gflags)
-        set(GFLAGS_IS_SUBPROJECT TRUE)
-        set(HAVE_SYS_STAT_H 1)
-        set(HAVE_INTTYPES_H 1)
-        set(INTTYPES_FORMAT C99)
-        set(BUILD_TESTING OFF)
-        set(BUILD_SHARED_LIBS OFF)
-        add_subdirectory(${OpenVINO_SOURCE_DIR}/thirdparty/gflags
-                         ${CMAKE_CURRENT_BINARY_DIR}/gflags_build
-                         EXCLUDE_FROM_ALL)
-        set_target_properties(gflags_nothreads_static PROPERTIES FOLDER thirdparty)
-    endfunction()
-    add_gflags()
-endif()
 
 add_subdirectory(common)
 add_subdirectory(unittests)

--- a/tests/stress_tests/common/CMakeLists.txt
+++ b/tests/stress_tests/common/CMakeLists.txt
@@ -11,10 +11,27 @@ add_library(${TARGET_NAME} STATIC ${SRC} ${HDR})
 
 target_include_directories(${TARGET_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
+if(EXISTS "${OpenVINO_SOURCE_DIR}/thirdparty/gflags")
+    function(add_gflags)
+        set(GFLAGS_IS_SUBPROJECT TRUE)
+        set(HAVE_SYS_STAT_H 1)
+        set(HAVE_INTTYPES_H 1)
+        set(INTTYPES_FORMAT C99)
+        set(BUILD_TESTING OFF)
+        set(BUILD_SHARED_LIBS OFF)
+        add_subdirectory(${OpenVINO_SOURCE_DIR}/thirdparty/gflags
+                         ${CMAKE_CURRENT_BINARY_DIR}/gflags_build
+                         EXCLUDE_FROM_ALL)
+        set_target_properties(gflags_nothreads_static PROPERTIES FOLDER thirdparty)
+    endfunction()
+    add_gflags()
+endif()
+
 target_link_libraries(${TARGET_NAME}
     PUBLIC
         IE::gtest
         IE::pugixml
         ${InferenceEngine_LIBRARIES}
+        gflags
     PRIVATE
         IE::gtest_main)

--- a/tests/stress_tests/memcheck_tests/CMakeLists.txt
+++ b/tests/stress_tests/memcheck_tests/CMakeLists.txt
@@ -11,7 +11,10 @@ file (GLOB_RECURSE HDR *.h)
 add_executable(${TARGET_NAME} ${HDR} ${SRC})
 
 target_include_directories(${TARGET_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(${TARGET_NAME} PRIVATE StressTestsCommon gflags)
+target_link_libraries(${TARGET_NAME} PRIVATE StressTestsCommon)
+
+install(TARGETS ${TARGET_NAME}
+            RUNTIME DESTINATION tests COMPONENT tests EXCLUDE_FROM_ALL)
 
 # Copy local configs to BIN_FOLDER
 configure_file(local_configs/test_config.xml 

--- a/tests/stress_tests/memleaks_tests/CMakeLists.txt
+++ b/tests/stress_tests/memleaks_tests/CMakeLists.txt
@@ -10,7 +10,10 @@ file (GLOB_RECURSE HDR *.h)
 # Create library file from sources.
 add_executable(${TARGET_NAME} ${HDR} ${SRC})
 
-target_link_libraries(${TARGET_NAME} PRIVATE StressTestsCommon gflags)
+target_link_libraries(${TARGET_NAME} PRIVATE StressTestsCommon)
+
+install(TARGETS ${TARGET_NAME}
+            RUNTIME DESTINATION tests COMPONENT tests EXCLUDE_FROM_ALL)
 
 # Copy local configs to BIN_FOLDER
 configure_file(local_configs/test_config.xml

--- a/tests/stress_tests/unittests/CMakeLists.txt
+++ b/tests/stress_tests/unittests/CMakeLists.txt
@@ -10,7 +10,10 @@ file (GLOB_RECURSE HDR *.h)
 # Create library file from sources.
 add_executable(${TARGET_NAME} ${HDR} ${SRC})
 
-target_link_libraries(${TARGET_NAME} PRIVATE StressTestsCommon gflags)
+target_link_libraries(${TARGET_NAME} PRIVATE StressTestsCommon)
+
+install(TARGETS ${TARGET_NAME}
+            RUNTIME DESTINATION tests COMPONENT tests EXCLUDE_FROM_ALL)
 
 # Copy local configs to BIN_FOLDER
 configure_file(local_configs/test_config.xml

--- a/tests/time_tests/CMakeLists.txt
+++ b/tests/time_tests/CMakeLists.txt
@@ -10,16 +10,13 @@ project(time_tests)
 
 set(OpenVINO_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../")
 
-# Search OpenVINO Inference Engine via InferenceEngine_DIR
-find_package(IEDevScripts REQUIRED
-             PATHS "${OpenVINO_SOURCE_DIR}/cmake/developer_package"
-             NO_CMAKE_FIND_ROOT_PATH
-             NO_DEFAULT_PATH)
-
 # Search OpenVINO Inference Engine installed
 find_package(InferenceEngine)
 
 if(NOT InferenceEngine_FOUND)
+    # Define directory where artifacts will be placed
+    set(OUTPUT_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
+
     # Search OpenVINO Inference Engine via InferenceEngineDeveloperPackage_DIR
     # in order to provide backward compatibility with old OpenVINO packages
     find_package(InferenceEngineDeveloperPackage REQUIRED)

--- a/tests/time_tests/src/timetests/CMakeLists.txt
+++ b/tests/time_tests/src/timetests/CMakeLists.txt
@@ -16,4 +16,7 @@ foreach(test_source ${tests})
     target_link_libraries(${test_name} PRIVATE IE::inference_engine timetests_helper)
 
     add_dependencies(time_tests ${test_name})
+
+    install(TARGETS ${test_name}
+            RUNTIME DESTINATION tests COMPONENT tests EXCLUDE_FROM_ALL)
 endforeach()


### PR DESCRIPTION
### Details:
 - Parallel build of stress and time tests lead to race while rebuild libgflags_nothreads.a (gflags isn't available in IE installed via installer, so targets should build it from sources by itself). As a solution each target will build artifacts to it's own folder, and it will be copied to a correct place via installation
 - In addition move `gflags` to `StressTestsCommon` library to pass dependency to each target via library

### Tickets:
 - 55465
