### PR TITLE
Adds Performance Counter and user defined Scale Factor options to Python Speech Sample

### DIFF
--- a/inference-engine/ie_bridges/python/sample/speech_sample/README.md
+++ b/inference-engine/ie_bridges/python/sample/speech_sample/README.md
@@ -77,18 +77,18 @@ python <path_to_sample>/speech_sample.py -h
 Usage message:
 
 ```
-usage: speech_sample.py [-h] (-m MODEL | -rg IMPORT_GNA_MODEL) -i INPUT       
+usage: speech_sample.py [-h] (-m MODEL | -rg IMPORT_GNA_MODEL) -i INPUT
                         [-o OUTPUT] [-r REFERENCE] [-d DEVICE]
                         [-bs BATCH_SIZE] [-qb QUANTIZATION_BITS]
-                        [-wg EXPORT_GNA_MODEL] [-iname INPUT_LAYERS]
-                        [-oname OUTPUT_LAYERS]
+                        [-sf SCALE_FACTOR] [-wg EXPORT_GNA_MODEL] [-pc]
+                        [-a ARCH] [-iname INPUT_LAYERS] [-oname OUTPUT_LAYERS]
 
 optional arguments:
   -m MODEL, --model MODEL
                         Path to an .xml file with a trained model (required if
                         -rg is missing).
   -rg IMPORT_GNA_MODEL, --import_gna_model IMPORT_GNA_MODEL
-                        Read GNA model from file using path/filename provided 
+                        Read GNA model from file using path/filename provided
                         (required if -m is missing).
 
 Options:
@@ -96,7 +96,8 @@ Options:
   -i INPUT, --input INPUT
                         Required. Path to an input file (.ark or .npz).
   -o OUTPUT, --output OUTPUT
-                        Optional. Output file name to save inference results (.ark or .npz).
+                        Optional. Output file name to save inference results
+                        (.ark or .npz).
   -r REFERENCE, --reference REFERENCE
                         Optional. Read reference score file and compare
                         scores.
@@ -113,9 +114,16 @@ Options:
   -qb QUANTIZATION_BITS, --quantization_bits QUANTIZATION_BITS
                         Optional. Weight bits for quantization: 8 or 16
                         (default 16).
+  -sf SCALE_FACTOR, --scale_factor SCALE_FACTOR
+                        Optional. Input scale factor for quantization.
   -wg EXPORT_GNA_MODEL, --export_gna_model EXPORT_GNA_MODEL
                         Optional. Write GNA model to file using path/filename
                         provided.
+  -pc, --performance_counter
+                        Optional. Enables performance report. (specify -a to
+                        ensure arch accurate results)
+  -a ARCH, --arch ARCH  Optional. Specify architecture. CORE, ATOM with
+                        combination of -pc
   -iname INPUT_LAYERS, --input_layers INPUT_LAYERS
                         Optional. Layer names for input blobs. The names are
                         separated with ",". Allows to change the order of

--- a/inference-engine/ie_bridges/python/sample/speech_sample/arg_parser.py
+++ b/inference-engine/ie_bridges/python/sample/speech_sample/arg_parser.py
@@ -28,10 +28,15 @@ def parse_args() -> argparse.Namespace:
     args.add_argument('-bs', '--batch_size', default=1, type=int, help='Optional. Batch size 1-8 (default 1).')
     args.add_argument('-qb', '--quantization_bits', default=16, type=int,
                       help='Optional. Weight bits for quantization: 8 or 16 (default 16).')
+    args.add_argument('-sf', '--scale_factor', type=float, help='Optional. Input scale factor for quantization.')
     args.add_argument('-wg', '--export_gna_model', type=str,
                       help='Optional. Write GNA model to file using path/filename provided.')
     args.add_argument('-we', '--export_embedded_gna_model', type=str, help=argparse.SUPPRESS)
     args.add_argument('-we_gen', '--embedded_gna_configuration', default='GNA1', type=str, help=argparse.SUPPRESS)
+    args.add_argument('-pc', '--performance_counter', action='store_true', 
+                        help='Optional. Enables performance report. (specify -a to ensure arch accurate results)')
+    args.add_argument('-a', '--arch', default="CORE", type=str, help='Optional. Specify architecture. CORE, ATOM'
+                        ' with combination of -pc')
     args.add_argument('-iname', '--input_layers', type=str,
                       help='Optional. Layer names for input blobs. The names are separated with ",". '
                       'Allows to change the order of input layers for -i flag. Example: Input1,Input2')


### PR DESCRIPTION
Three new cmd line arguments: 

- -pc = performance counter
- -sf = scale factor 
- -a/--arch = either CORE or ATOM

-a/--arch is a complimentary argument for when -pc is used to allow for correct interpretation of the performance counter values returned. 