### PR TITLE
Fuse horizontal duplicate reorders

### DIFF
--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph_optimizer.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph_optimizer.h
@@ -33,6 +33,7 @@ private:
     void FuseNormalizeL2AndSimpleOperation(MKLDNNGraph &graph);
 
     void DropDoubleReorders(MKLDNNGraph& graph);
+    void DropHorizontalReorders(MKLDNNGraph& graph);
     void FuseConvolutionAndZeroPoints(MKLDNNGraph &graph);
     void FuseBroadcastAndEltwise(MKLDNNGraph &graph);
     void FuseEltwiseAndSimple(MKLDNNGraph &graph);

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reorder_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reorder_node.cpp
@@ -244,6 +244,36 @@ void MKLDNNReorderNode::optimizedNspc2Ncsp() {
     });
 }
 
+bool MKLDNNReorderNode::isSame(const MKLDNNReorderNode* rhs) {
+    auto lpd = this->supportedPrimitiveDescriptors.at(0);
+    auto rpd = rhs->supportedPrimitiveDescriptors.at(0);
+    if (lpd.getImplementationType() != rpd.getImplementationType())
+        return false;
+    if (lpd.getOutputLayouts()[0] != rpd.getOutputLayouts()[0])
+        return false;
+    auto lconf = lpd.getConfig();
+    auto rconf = rpd.getConfig();
+    if (lconf.dynBatchSupport != rconf.dynBatchSupport)
+        return false;
+    auto lInConfs = lconf.inConfs;
+    auto rInConfs = rconf.inConfs;
+    if (lInConfs.size() != 1 || rInConfs.size() != 1)
+        return false;
+    if (lInConfs[0].constant != rInConfs[0].constant)
+        return false;
+    if (lInConfs[0].desc != rInConfs[0].desc)
+        return false;
+    auto lOutConfs = lconf.outConfs;
+    auto rOutConfs = rconf.outConfs;
+    if (lOutConfs.size() != 1 || rOutConfs.size() != 1)
+        return false;
+    if (lOutConfs[0].constant != rOutConfs[0].constant)
+        return false;
+    if (lOutConfs[0].desc != rOutConfs[0].desc)
+        return false;
+    return true;
+}
+
 void MKLDNNReorderNode::execute(mkldnn::stream strm) {
     if (isOptimized)
         return;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reorder_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reorder_node.h
@@ -42,6 +42,8 @@ public:
     const InferenceEngine::TensorDesc& getInput() { return input; }
     const InferenceEngine::TensorDesc& getOutput() { return output; }
 
+    bool isSame(const MKLDNNReorderNode* rhs);
+
     /**
      * @brief A pointer to a scales blob
      */


### PR DESCRIPTION
Same reorder layers may be inserted.
The patch will reuse reorder layer and drop duplicate reorder layers

Signed-off-by: fengyi.sun <fengyi.sun@intel.com>
Reviewed-by: Wu, Jiangming <jiangming.wu@intel.com>

### Details:
 - Graph optimization: remove duplicate reorder layers.
