### PR TITLE
DO NOT MERGE: Use windows soft affinity pinning

### DIFF
--- a/inference-engine/src/inference_engine/ie_system_conf.cpp
+++ b/inference-engine/src/inference_engine/ie_system_conf.cpp
@@ -102,7 +102,7 @@ std::vector<int> getAvailableNUMANodes() {
 }
 // this is impl only with the TBB
 std::vector<int> getAvailableCoresTypes() {
-    return custom::info::core_types();
+    return {std::begin(custom::info::core_types()), std::end(custom::info::core_types())};
 }
 #else
 // as the core types support exists only with the TBB, the fallback is same for any other threading API

--- a/inference-engine/src/inference_engine/ie_system_conf.cpp
+++ b/inference-engine/src/inference_engine/ie_system_conf.cpp
@@ -102,7 +102,8 @@ std::vector<int> getAvailableNUMANodes() {
 }
 // this is impl only with the TBB
 std::vector<int> getAvailableCoresTypes() {
-    return {std::begin(custom::info::core_types()), std::end(custom::info::core_types())};
+    auto core_types = custom::info::core_types();
+    return std::vector<int>(std::begin(core_types), std::end(core_types));
 }
 #else
 // as the core types support exists only with the TBB, the fallback is same for any other threading API

--- a/inference-engine/src/inference_engine/os/win/win_system_conf.cpp
+++ b/inference-engine/src/inference_engine/os/win/win_system_conf.cpp
@@ -37,8 +37,10 @@ int getNumberOfCPUCores(bool bigCoresOnly) {
     auto core_types = custom::info::core_types();
     if (bigCoresOnly && core_types.size() > 1) /*Hybrid CPU*/ {
         phys_cores = custom::info::default_concurrency(custom::task_arena::constraints{}
-                                                               .set_core_type(core_types.back())
-                                                               .set_max_threads_per_core(1));
+                                                               .set_core_type(core_types.back()));
+        if (phys_cores > 1) { // disable hyperthreading manually
+            phys_cores /= 2;
+        }
     }
     #endif
     return phys_cores;

--- a/inference-engine/src/inference_engine/threading/cpusets_api_observer.hpp
+++ b/inference-engine/src/inference_engine/threading/cpusets_api_observer.hpp
@@ -14,9 +14,9 @@ namespace win {
 
 constexpr bool debug_mode = false;
 
-static std::map<BYTE, std::vector<DWORD>> core_types_map{};
-static std::vector<BYTE> core_types_ids_vector{};
-static std::vector<DWORD> whole_system_ids{};
+extern std::map<BYTE, std::vector<DWORD>> core_types_map;
+extern std::vector<BYTE> core_types_ids_vector;
+extern std::vector<DWORD> whole_system_ids;
 
 inline void report_cpu_configuration(SYSTEM_CPU_SET_INFORMATION* cpuSetInfo, size_t count) {
     for (size_t i = 0; i < count; ++i) {

--- a/inference-engine/src/inference_engine/threading/cpusets_api_observer.hpp
+++ b/inference-engine/src/inference_engine/threading/cpusets_api_observer.hpp
@@ -1,0 +1,140 @@
+#pragma once
+
+#include <memory>
+#include <map>
+#include <vector>
+#include <Windows.h>
+
+#include <tbb/task_scheduler_observer.h>
+#include <tbb/task_arena.h>
+
+#if defined(_WIN32) || defined(_WIN64)
+
+namespace win {
+
+constexpr bool debug_mode = false;
+
+static std::map<BYTE, std::vector<DWORD>> core_types_map{};
+static std::vector<BYTE> core_types_ids_vector{};
+static std::vector<DWORD> whole_system_ids{};
+
+inline void report_cpu_configuration(SYSTEM_CPU_SET_INFORMATION* cpuSetInfo, size_t count) {
+    for (size_t i = 0; i < count; ++i) {
+        printf("CPU ID: %i\n\tGroup: %i"
+            "\n\tLogical index: %i\n\tCore index: %i\n\tCache ID: %i"
+            "\n\tNUMA ID: %i\n\tEfficiency class: %i\n\tAll flags: %i"
+            "\n\tAllocated: %i\n\tAllocated to target: %i"
+            "\n\tParked: %i\n\tRealtime: %i\n\tReserved flags: %i\n\tReserved: %i\n",
+            cpuSetInfo[i].CpuSet.Id,                    // Unique ID for every CPU core. This is the value to use with SetProcessDefaultCpuSets
+            cpuSetInfo[i].CpuSet.Group,                 // Some PCs (mostly servers) have groups of CPU cores
+            cpuSetInfo[i].CpuSet.LogicalProcessorIndex, // Index of the logical core of the CPU, relative to this CPU group
+            cpuSetInfo[i].CpuSet.CoreIndex,             // Index of the home core any logical core is associated with, relative to this CPU group 
+            cpuSetInfo[i].CpuSet.LastLevelCacheIndex,   // ID of the memory cache this core uses, relative to this CPU group
+            cpuSetInfo[i].CpuSet.NumaNodeIndex,         // ID of the NUMA group for this core, relative to this CPU group
+            cpuSetInfo[i].CpuSet.EfficiencyClass,
+            cpuSetInfo[i].CpuSet.AllFlags,
+            cpuSetInfo[i].CpuSet.Allocated,
+            cpuSetInfo[i].CpuSet.AllocatedToTargetProcess,
+            cpuSetInfo[i].CpuSet.Parked,
+            cpuSetInfo[i].CpuSet.RealTime,
+            cpuSetInfo[i].CpuSet.ReservedFlags,
+            cpuSetInfo[i].CpuSet.Reserved);
+    }
+}
+
+inline void report_core_types_map() {
+    printf("Size: %zd\n", core_types_map.size());
+    for (auto it = core_types_map.begin(); it != core_types_map.end(); ++it) {
+        printf("Effeciency class: %d\n", it->first);
+        printf("IDs: ");
+        for (auto id_it = it->second.begin(); id_it != it->second.end(); ++id_it) {
+            printf("%d ", *id_it);
+        }
+        printf("\n");
+    }
+}
+
+inline std::vector<BYTE> core_types() {
+    static bool initialization_state{false};
+    if (initialization_state) return core_types_ids_vector;
+
+    ULONG size;
+    HANDLE curProc = GetCurrentProcess();
+    (void)GetSystemCpuSetInformation(nullptr, 0, &size, curProc, 0);
+
+    // Get CPUs information
+    std::unique_ptr<uint8_t[]> buffer(new uint8_t[size]);
+    PSYSTEM_CPU_SET_INFORMATION cpuSets = reinterpret_cast<PSYSTEM_CPU_SET_INFORMATION>(buffer.get());
+    if (!GetSystemCpuSetInformation(cpuSets, size, &size, curProc, 0))
+    {
+        DWORD err = GetLastError();
+        if (err == ERROR_INSUFFICIENT_BUFFER)
+            throw std::exception("Insufficient buffer size for querying CPU set information");
+        else
+            throw std::exception("An unexpected error occured attempting to query CPU set information");
+    }
+
+    // Get CPUs Count
+    size_t count = 0;
+    while (size > 0)
+    {
+        size -= cpuSets[count].Size;
+        ++count;
+    }
+
+    if (debug_mode) {
+        report_cpu_configuration(cpuSets, count);
+    }
+
+    // Parse CPUs info
+    for (size_t i = 0; i < count; ++i) {
+        whole_system_ids.emplace_back(cpuSets[i].CpuSet.Id);
+        core_types_map[cpuSets[i].CpuSet.EfficiencyClass].emplace_back(cpuSets[i].CpuSet.Id);
+    }
+
+    for (auto it = core_types_map.begin(); it != core_types_map.end(); ++it) {
+        core_types_ids_vector.emplace_back(it->first);
+    }
+
+    if (debug_mode) {
+        report_core_types_map();
+    }
+
+    initialization_state = true;
+    return core_types_ids_vector;
+}
+
+inline int default_concurrency(BYTE core_type_id) {
+    return static_cast<int>(core_types_map[core_type_id].size());
+}
+
+} // namespace info
+
+class soft_affinity_observer : public tbb::task_scheduler_observer {
+    BYTE my_core_type_id;
+public:
+    soft_affinity_observer( tbb::task_arena &a, BYTE core_type_id )
+        : tbb::task_scheduler_observer(a), my_core_type_id(core_type_id)
+    {}
+
+    void on_scheduler_entry( bool ) override {
+        // for (auto& el: win::core_types_map[my_core_type_id]) {
+        //     std::cout << "pin to core: " << el << std::endl;
+        // }
+        SetThreadSelectedCpuSets(
+            GetCurrentThread(),
+            win::core_types_map[my_core_type_id].data(),
+            win::core_types_map[my_core_type_id].size()
+        );
+    }
+
+    void on_scheduler_exit( bool ) override {
+        SetThreadSelectedCpuSets(
+            GetCurrentThread(),
+            win::whole_system_ids.data(),
+            win::whole_system_ids.size()
+        );
+    }
+};
+
+#endif /*defined(_WIN32) || defined(_WIN64)*/

--- a/inference-engine/src/inference_engine/threading/ie_cpu_streams_executor.cpp
+++ b/inference-engine/src/inference_engine/threading/ie_cpu_streams_executor.cpp
@@ -21,6 +21,17 @@
 #include "threading/ie_cpu_streams_executor.hpp"
 #include <openvino/itt.hpp>
 
+#if defined(_WIN32) || defined(_WIN64)
+
+namespace win {
+
+std::map<BYTE, std::vector<DWORD>> core_types_map{};
+std::vector<BYTE> core_types_ids_vector{};
+std::vector<DWORD> whole_system_ids{};
+
+}
+#endif
+
 using namespace openvino;
 
 namespace InferenceEngine {

--- a/inference-engine/src/inference_engine/threading/ie_parallel_custom_arena.cpp
+++ b/inference-engine/src/inference_engine/threading/ie_parallel_custom_arena.cpp
@@ -6,17 +6,7 @@
 
 #if IE_THREAD == IE_THREAD_TBB || IE_THREAD == IE_THREAD_TBB_AUTO
 
-#ifndef TBBBIND_2_4_AVAILABLE
-# define TBBBIND_2_4_AVAILABLE 0
-#endif
-
-#define USE_TBBBIND_2_4 (TBBBIND_2_4_AVAILABLE && TBB_INTERFACE_VERSION < 12020)
-#define TBB_NUMA_SUPPORT_PRESENT (TBB_INTERFACE_VERSION >= 11100)
-#define TBB_HYBRID_CPUS_SUPPORT_PRESENT (TBB_INTERFACE_VERSION >= 12020)
-
-#if defined(_WIN32) || defined(_WIN64)
-#include <windows.h>
-#endif
+#if !defined(_WIN32) && !defined(_WIN64)
 
 namespace custom {
 namespace detail {
@@ -263,4 +253,7 @@ int default_concurrency(numa_node_id id) {
 
 } // namespace info
 } // namespace custom
+
+#endif
+
 #endif /*IE_THREAD == IE_THREAD_TBB || IE_THREAD == IE_THREAD_TBB_AUTO*/

--- a/inference-engine/src/inference_engine/threading/ie_parallel_custom_arena.hpp
+++ b/inference-engine/src/inference_engine/threading/ie_parallel_custom_arena.hpp
@@ -20,7 +20,180 @@
 #include <vector>
 #include <memory>
 
+#include "cpusets_api_observer.hpp"
+
+#if defined(_WIN32)  defined(_WIN64)
+#include <Windows.h>
+#endif
+
 namespace custom {
+
+#if defined(_WIN32)  defined(_WIN64)
+
+using numa_node_id = int;
+using core_type_id = BYTE;
+
+namespace detail {
+struct constraints {
+    constraints(numa_node_id id = tbb::task_arena::automatic, int maximal_concurrency = tbb::task_arena::automatic)
+        : numa_id{id}
+        , max_concurrency{maximal_concurrency}
+        , core_type{static_cast<core_type_id>(tbb::task_arena::automatic)}
+        , max_threads_per_core{tbb::task_arena::automatic}
+    {}
+
+    constraints& set_numa_id(numa_node_id id) {
+        numa_id = id;
+        return *this;
+    }
+    constraints& set_max_concurrency(int maximal_concurrency) {
+        max_concurrency = maximal_concurrency;
+        return *this;
+    }
+    constraints& set_core_type(core_type_id id) {
+        core_type = id;
+        return *this;
+    }
+    constraints& set_max_threads_per_core(int threads_number) {
+        max_threads_per_core = threads_number;
+        return *this;
+    }
+
+    numa_node_id numa_id = tbb::task_arena::automatic;
+    int max_concurrency = tbb::task_arena::automatic;
+    core_type_id core_type = tbb::task_arena::automatic;
+    int max_threads_per_core = tbb::task_arena::automatic;
+};
+
+struct soft_affinity_observer_deleter {
+    void operator()(soft_affinity_observer* observer) const {
+        observer->observe(false);
+        delete observer;
+    }
+};
+
+using binding_oberver_ptr = std::unique_ptr<soft_affinity_observer, soft_affinity_observer_deleter>;
+
+
+inline binding_oberver_ptr construct_binding_observer(tbb::task_arena& ta, const constraints& c) {
+    binding_oberver_ptr observer{};
+    if (c.core_type >= 0 && win::core_types().size() > 1) {
+        observer.reset(new soft_affinity_observer{ta, c.core_type});
+        observer->observe(true);
+    }
+    return observer;
+}
+
+} // namespace detail
+
+
+namespace info {
+    inline std::vector<numa_node_id> numa_nodes() { return {-1}; }
+    inline std::vector<core_type_id> core_types() { return win::core_types();}
+
+    inline int default_concurrency(numa_node_id id = tbb::task_arena::automatic) {
+        return tbb::this_task_arena::max_concurrency();
+    }
+    inline int default_concurrency(detail::constraints c) {
+        if (c.core_type != tbb::task_arena::automatic) {
+            return win::default_concurrency(c.core_type);
+        }
+        return tbb::this_task_arena::max_concurrency();
+    }
+} // namespace info
+
+class task_arena {
+    tbb::task_arena my_task_arena;
+    std::once_flag my_initialization_state;
+    detail::constraints my_constraints;
+    detail::binding_oberver_ptr my_binding_observer;
+
+public:
+    using constraints = detail::constraints;
+    static const int automatic = tbb::task_arena::automatic;
+
+    task_arena(int max_concurrency_ = automatic, unsigned reserved_for_masters = 1)
+        : my_task_arena{max_concurrency_, reserved_for_masters}
+        , my_initialization_state{}
+        , my_constraints{}
+        , my_binding_observer{}
+    {}
+
+    task_arena(const constraints& constraints_, unsigned reserved_for_masters = 1)
+        : my_task_arena {info::default_concurrency(constraints_), reserved_for_masters}
+        , my_initialization_state{}
+        , my_constraints{constraints_}
+        , my_binding_observer{}
+    {}
+
+    task_arena(const task_arena &s)
+        : my_task_arena{s.my_task_arena}
+        , my_initialization_state{}
+        , my_constraints{s.my_constraints}
+        , my_binding_observer{}
+    {}
+
+    void initialize() {
+        my_task_arena.initialize();
+        std::call_once(my_initialization_state, [this] {
+            my_binding_observer = detail::construct_binding_observer(
+                my_task_arena, my_constraints);
+        });
+    }
+    void initialize(int max_concurrency_, unsigned reserved_for_masters = 1) {
+        my_task_arena.initialize(max_concurrency_, reserved_for_masters);
+        std::call_once(my_initialization_state, [this] {
+            my_binding_observer = detail::construct_binding_observer(
+                my_task_arena, my_constraints);
+        });
+    }
+    void initialize(constraints constraints_, unsigned reserved_for_masters = 1) {
+        my_constraints = constraints_;
+        my_task_arena.initialize(info::default_concurrency(constraints_), reserved_for_masters);
+        std::call_once(my_initialization_state, [this] {
+            my_binding_observer = detail::construct_binding_observer(
+                my_task_arena, my_constraints);
+        });
+    }
+
+    explicit operator tbb::task_arena&() {
+        return my_task_arena;
+    }
+
+    int max_concurrency() {
+        initialize();
+        return my_task_arena.max_concurrency();
+    }
+
+    template<typename F>
+    void enqueue(F&& f) {
+        initialize();
+        my_task_arena.enqueue(std::forward<F>(f));
+    }
+    template<typename F>
+    auto execute(F&& f) -> decltype(f()) {
+        initialize();
+        return my_task_arena.execute(std::forward<F>(f));
+    }
+};
+
+struct task_scheduler_observer: public tbb::task_scheduler_observer {
+    task_scheduler_observer(custom::task_arena& arena) :
+        tbb::task_scheduler_observer(static_cast<tbb::task_arena&>(arena)),
+        my_arena(arena)
+    {}
+
+    void observe(bool state = true) {
+        if (state) {
+            my_arena.initialize();
+        }
+        tbb::task_scheduler_observer::observe(state);
+    }
+
+    custom::task_arena& my_arena;
+};
+
+#else
 
 using numa_node_id = int;
 using core_type_id = int;
@@ -137,5 +310,9 @@ namespace info {
     int default_concurrency(numa_node_id id = task_arena::automatic);
     int default_concurrency(task_arena::constraints c);
 } // namespace info
+
+#endif
+
 } // namespace custom
+
 #endif /*(IE_THREAD == IE_THREAD_TBB || IE_THREAD == IE_THREAD_TBB_AUTO)*/


### PR DESCRIPTION
A draft patch that replaces the hard affinity interface for Hybrid CPUs pinning to soft ones on Windows.