### PR TITLE
[CPU] Clamp reduces float boundaries in the case of integer data

### DIFF
--- a/src/core/tests/runtime/ie/unit_test.manifest
+++ b/src/core/tests/runtime/ie/unit_test.manifest
@@ -909,9 +909,6 @@ roll_negative_axes
 #-------------------------------------------------------------------------------
 
 # Clamp op:
-# Issue 51676: Output mismatch due to wrong conversion of bounds
-IE_CPU.clamp_integral
-IE_CPU.clamp_integral_negative
 # Issue 51679: CI failure on Ubuntu 20. Overflow handling -inf lower bound
 IE_CPU.clamp_int32
 # Precision mismatch

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_eltwise_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_eltwise_node.cpp
@@ -965,6 +965,7 @@ const std::map<const ngraph::DiscreteTypeInfo, MKLDNNEltwiseNode::Initializer> M
         float alpha_ = static_cast<float>(clampOp->get_min());
         float beta_ = static_cast<float>(clampOp->get_max());
         if (clampOp->get_input_element_type(0).is_integral_number()) {
+            // according to spec, when Clamp has integer element type, min and max mist be converted to integer
             alpha_ = std::ceil(alpha_);
             beta_ = std::floor(beta_);
         }

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_eltwise_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_eltwise_node.cpp
@@ -962,8 +962,14 @@ const std::map<const ngraph::DiscreteTypeInfo, MKLDNNEltwiseNode::Initializer> M
     {ngraph::op::v0::Clamp::get_type_info_static(), [](const std::shared_ptr<ngraph::Node>& op, MKLDNNEltwiseNode& node) {
         auto clampOp = getNgraphOpAs<ngraph::op::v0::Clamp>(op);
 
-        node.alpha = static_cast<float>(clampOp->get_min());
-        node.beta = static_cast<float>(clampOp->get_max());
+        float alpha_ = static_cast<float>(clampOp->get_min());
+        float beta_ = static_cast<float>(clampOp->get_max());
+        if (clampOp->get_input_element_type(0).is_integral_number()) {
+            alpha_ = std::ceil(alpha_);
+            beta_ = std::floor(beta_);
+        }
+        node.alpha = alpha_;
+        node.beta = beta_;
         node.algorithm = EltwiseClamp;
         node.mkldnnAlgorithm = mkldnn::algorithm::eltwise_clip;
     }},

--- a/src/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
+++ b/src/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
@@ -42,8 +42,6 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*(BF|bf)16.*(jit_avx(?!5)|jit_sse|ref).*)",
         // TODO: Incorrect blob sizes for node BinaryConvolution_X
         R"(.*BinaryConvolutionLayerTest.*)",
-        R"(.*ClampLayerTest.*netPrc=(I64|I32).*)",
-        R"(.*ClampLayerTest.*netPrc=U64.*)",
         // TODO: 53618. BF16 gemm ncsp convolution crash
         R"(.*_GroupConv.*_inFmts=nc.*_primitive=jit_gemm.*ENFORCE_BF16=YES.*)",
         // TODO: 53578. fork DW bf16 convolution does not support 3d cases yet


### PR DESCRIPTION
### Details:
 - *clamp node reduces boundaries in integer case*

### Tickets:
 - *51676*
