### PR TITLE
[GNA] KSOFunction test fix

### DIFF
--- a/inference-engine/src/gna_plugin/gna_plugin.cpp
+++ b/inference-engine/src/gna_plugin/gna_plugin.cpp
@@ -752,12 +752,14 @@ void GNAPlugin::LoadNetwork(CNNNetwork & _network) {
         passes->registerPass<FuseFQIntoWeightsPass>();
         passes->registerPass<MoveFakeQuantizeLayerIntoQuantParamsPass>();
 
+        passes->registerPass<SubstituteScaleShiftBroadCastPass>();
+        passes->registerPass<BroadcastConstPass>();
+
         passes->registerPass<TransposeWeightsFromNCHWToNHWCPass>();
 
         passes->registerPass<SubstitutePReluPass>();
         passes->registerPass<SubstituteSoftSignPass>();
 
-        passes->registerPass<BroadcastConstPass>();
         passes->registerPass<ReorderMaxPoolPass>();
         passes->registerPass<EltwiseSplitOverChannelsPass>();
         passes->registerPass<InsertSplitAligningFilterPass>();
@@ -775,7 +777,6 @@ void GNAPlugin::LoadNetwork(CNNNetwork & _network) {
 #if GNA_LIB_VER == 2
         passes->registerPass<ForbidActivationFusingPass>();
 #endif
-        passes->registerPass<SubstituteScaleShiftBroadCastPass>();
         passes->registerPass<FuseMultipleIdentitiesPass>();
         passIdx = passes->run(passIdx);
     };

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/skip_tests_config.cpp
@@ -44,8 +44,6 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*ConstantResultSubgraphTest.*inPrc=(U8|I8|I32|U64|I64|BOOL).*)",
         // TODO: Issue 51528
         R"(.*CachingSupport.*_(u8|i16)_.*)",
-        // TODO: Issue 51525
-        R"(.*CachingSupport.*KSOFunction.*)",
         // TODO: Issue 57363 (Param -> Result subgraphs)
         R"(.*smoke_MemoryTest.*LOW_LATENCY.*iteration_count=1_.*)",
         // TODO: Issue 57368 (accuracy)

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/eltwise_reshape_activation.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/eltwise_reshape_activation.cpp
@@ -13,7 +13,8 @@ const std::vector<std::vector<std::vector<size_t>>> shapes = {
     {{1, 64}, {64, 1}},
     {{8, 256}, {16, 128}},
     {{6, 384}, {18, 128}},
-    {{8, 2048}, {32, 512}}
+    {{8, 2048}, {32, 512}},
+    {{2, 4, 64, 64}, {1, 8, 64, 64}}
 };
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {


### PR DESCRIPTION
### Details:
 - Deprecated check has been removed in `SubstituteScaleShiftBroadCastPass`
 - Changed order of passes in `gna_lugin.cpp` due to dimensions inconsistency and memory errors in `TransposeWeightsFromNCHWToNHWCPass`
 - Added check in `TransposeWeightsFromNCHWToNHWCPass` to avoid memory errors in future
 - Added 4d shape in `EltwiseReshapeActivation` test
 - Removed string related to `KSOFunction` test in GNA skip config

### Tickets:
 - *51525*
