### PR TITLE
[GPU] Allowed more complex syntax for debug config options.

### DIFF
--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -112,7 +112,11 @@ ie_dependent_option(ENABLE_TBB_RELEASE_ONLY "Only Release TBB libraries are link
 
 ie_option (ENABLE_SYSTEM_PUGIXML "use the system copy of pugixml" OFF)
 
-ie_option (ENABLE_CPU_DEBUG_CAPS "enable CPU debug capabilities at runtime" OFF)
+ie_option (ENABLE_DEBUG_CAPS "enable OpenVINO debug capabilities at runtime" OFF)
+
+ie_dependent_option (ENABLE_GPU_DEBUG_CAPS "enable GPU debug capabilities at runtime" ON "ENABLE_DEBUG_CAPS" OFF)
+
+ie_dependent_option (ENABLE_CPU_DEBUG_CAPS "enable CPU debug capabilities at runtime" ON "ENABLE_DEBUG_CAPS" OFF)
 
 if(ANDROID OR WINDOWS_STORE OR (MSVC AND (ARM OR AARCH64)))
     set(protoc_available OFF)

--- a/inference-engine/src/cldnn_engine/CMakeLists.txt
+++ b/inference-engine/src/cldnn_engine/CMakeLists.txt
@@ -12,7 +12,7 @@ if(CMAKE_COMPILER_IS_GNUCC)
     endif()
 endif()
 
-if(GPU_DEBUG_CONFIG)
+if(ENABLE_GPU_DEBUG_CAPS)
   add_definitions(-DGPU_DEBUG_CONFIG=1)
 endif()
 

--- a/inference-engine/thirdparty/CMakeLists.txt
+++ b/inference-engine/thirdparty/CMakeLists.txt
@@ -24,7 +24,6 @@ if (ENABLE_CLDNN)
         set(CLDNN__INCLUDE_TESTS OFF CACHE BOOL "" FORCE)
     endif()
     set(CLDNN_THREADING "${THREADING}" CACHE STRING "" FORCE)
-    set(GPU_DEBUG_CONFIG OFF CACHE BOOL "Enable debug config feature")
     add_subdirectory(clDNN)
 endif()
 

--- a/inference-engine/thirdparty/clDNN/CMakeLists.txt
+++ b/inference-engine/thirdparty/clDNN/CMakeLists.txt
@@ -20,7 +20,7 @@ else()
     add_definitions(-DCLDNN_THREADING=CLDNN_THREADING_THREADPOOL)
 endif()
 
-if(GPU_DEBUG_CONFIG)
+if(ENABLE_GPU_DEBUG_CAPS)
   add_definitions(-DGPU_DEBUG_CONFIG=1)
 endif()
 

--- a/inference-engine/thirdparty/clDNN/runtime/debug_configuration.cpp
+++ b/inference-engine/thirdparty/clDNN/runtime/debug_configuration.cpp
@@ -5,6 +5,8 @@
 #include "cldnn/runtime/debug_configuration.hpp"
 #include <iostream>
 #include <memory>
+#include <vector>
+#include <sstream>
 
 namespace cldnn {
 
@@ -13,22 +15,81 @@ const char *debug_configuration::prefix = "GPU_Debug: ";
 // Default policy is that dump_configuration will override other configuration from IE.
 
 #ifdef GPU_DEBUG_CONFIG
-static void print_option(std::string option_name, std::string option_value) {
+
+template<typename T>
+void print_option(std::string option_name, T option_value) {
     GPU_DEBUG_COUT << "Config " << option_name << " = " << option_value << std::endl;
 }
 
-static void get_int_env(const std::string &var, int &val) {
-    if (const auto env_var = std::getenv(var.c_str())) {
-        val = std::stoi(env_var);
-        print_option(var, std::to_string(val));
+static std::string to_upper_case(const std::string& var) {
+    std::stringstream s;
+
+    for (size_t i = 0; i < var.size(); i++) {
+        if (std::isupper(var[i])) {
+            if (i != 0) {
+                s << "_";
+            }
+            s << var[i];
+        } else {
+            s << static_cast<char>(std::toupper(var[i]));
+        }
+    }
+
+    return s.str();
+}
+
+static std::vector<std::string> get_possible_option_names(const std::string& var, std::vector<std::string> allowed_option_prefixes) {
+    std::vector<std::string> result;
+
+    for (auto& prefix : allowed_option_prefixes) {
+        result.push_back(prefix + var);
+        result.push_back(prefix + to_upper_case(var));
+    }
+
+    return result;
+}
+
+template <typename T>
+T convert_to(const std::string &str) {
+    std::istringstream ss(str);
+    T res;
+    ss >> res;
+    return res;
+}
+
+template<typename T>
+void get_debug_env_var(const std::string &var, T &val, std::vector<std::string> allowed_option_prefixes) {
+    bool found = false;
+    for (auto o : get_possible_option_names(var, allowed_option_prefixes)) {
+        if (const auto env_var = std::getenv(o.c_str())) {
+            val = convert_to<T>(env_var);
+            found = true;
+        }
+    }
+
+    if (found) {
+        print_option(var, val);
     }
 }
 
-static void get_str_env(const std::string &var, std::string &val) {
-    if (const auto env_var = std::getenv(var.c_str())) {
-        val = env_var;
-        print_option(var, val);
-    }
+template<typename T>
+void get_gpu_debug_env_var(const std::string &var, T &val) {
+    return get_debug_env_var(var, val, {"OV_GPU_"});
+}
+
+template<typename T>
+void get_common_debug_env_var(const std::string &var, T &val) {
+    // The list below should be prioritized from lowest to highest prefix priority
+    // If an option is set several times with different prefixes, version with the highest priority will be actually used.
+    // This may allow to enable global option with some value and override this value for GPU plugin
+    // For example: OV_GPU_Verbose=2 OV_Verbose=1 ./my_app => this->verbose == 2
+    // In that case we enable Verbose (with level = 1) for all OV components that support this option, but for GPU plugin we increase verbose level to 2
+    std::vector<std::string> allowed_option_prefixes = {
+        "OV_",
+        "OV_GPU_"
+    };
+
+    return get_debug_env_var(var, val, allowed_option_prefixes);
 }
 
 #endif
@@ -42,13 +103,13 @@ debug_configuration::debug_configuration()
         , dump_layers(std::string())
         , dump_layers_dst_only(0) {
 #ifdef GPU_DEBUG_CONFIG
-    get_int_env("OV_GPU_Verbose", verbose);
-    get_int_env("OV_GPU_PrintMultiKernelPerf", print_multi_kernel_perf);
-    get_int_env("OV_GPU_DisableUsm", disable_usm);
-    get_str_env("OV_GPU_DumpGraphs", dump_graphs);
-    get_str_env("OV_GPU_DumpLayersPath", dump_layers_path);
-    get_str_env("OV_GPU_DumpLayers", dump_layers);
-    get_int_env("OV_GPU_DumpLayersDstOnly", dump_layers_dst_only);
+    get_common_debug_env_var("Verbose", verbose);
+    get_gpu_debug_env_var("PrintMultiKernelPerf", print_multi_kernel_perf);
+    get_gpu_debug_env_var("DisableUsm", disable_usm);
+    get_gpu_debug_env_var("DumpGraphs", dump_graphs);
+    get_gpu_debug_env_var("DumpLayersPath", dump_layers_path);
+    get_gpu_debug_env_var("DumpLayers", dump_layers);
+    get_gpu_debug_env_var("DumpLayersDstOnly", dump_layers_dst_only);
     if (dump_layers_path.length() > 0 && !disable_usm) {
         disable_usm = 1;
         GPU_DEBUG_COUT << "DisableUsm=1 because of DumpLayersPath" << std::endl;


### PR DESCRIPTION
### Details:
 - Allowed `SNAKE_CASE_WITH_CAPITALS` and `CamelCase` for env debug options.
 - Allowed multiple possible prefixes for some options `OV_GPU` and `OV`
 - Added common cmake option for debug caps for any OV component
 - Renamed cmake option for GPU
