### PR TITLE
Reduce node feature extension

### DIFF
--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph_optimizer.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph_optimizer.cpp
@@ -17,6 +17,7 @@
 #include "nodes/mkldnn_mvn_node.h"
 #include <nodes/mkldnn_transpose_node.h>
 #include "nodes/mkldnn_interpolate_node.h"
+#include "nodes/mkldnn_reduce_node.h"
 #include "nodes/mkldnn_input_node.h"
 #include "nodes/mkldnn_rnn.h"
 #include "nodes/common/cpu_convert.h"
@@ -135,6 +136,10 @@ void MKLDNNGraphOptimizer::ApplyCommonGraphOptimizations(MKLDNNGraph &graph) {
 
     OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "FuseNormalizeL2AndSimpleOperation");
     FuseNormalizeL2AndSimpleOperation(graph);
+    graph.RemoveDroppedNodes();
+
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "FuseReduceAndSimpleOperation");
+    FuseReduceAndSimpleOperation(graph);
     graph.RemoveDroppedNodes();
 
     OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "FuseEltwiseAndSimple");
@@ -1352,6 +1357,44 @@ void MKLDNNGraphOptimizer::FuseNormalizeL2AndSimpleOperation(MKLDNNGraph &graph)
     }
 }
 
+void MKLDNNGraphOptimizer::FuseReduceAndSimpleOperation(MKLDNNGraph &graph) {
+    auto& graphNodes = graph.GetNodes();
+
+    auto isSuitableParentNode = [](MKLDNNNodePtr node) {
+        return node->getType() == Reduce && node->getChildEdges().size() == 1;
+    };
+
+    auto parent = graphNodes.begin();
+    while (parent != graphNodes.end()) {
+        auto parentNode = *parent;
+        if (!isSuitableParentNode(parentNode)) {
+            parent++;
+            continue;
+        }
+
+        auto childNode = parentNode->getChildEdgeAt(0)->getChild();
+        if (!parentNode->canFuse(childNode)) {
+            parent++;
+            continue;
+        }
+
+        childNode->fuseInto(parentNode);
+
+        if (childNode->getType() == FakeQuantize || childNode->getType() == Eltwise) {
+            auto parentEdges = childNode->parentEdges;
+            for (auto &parentEdge : parentEdges) {
+                auto p_edge = parentEdge.lock();
+                if (p_edge->getParent()->getType() == Reduce)
+                    continue;
+
+                graph.RemoveEdge(p_edge);
+            }
+        }
+
+        graph.DropNode(childNode);
+    }
+}
+
 void MKLDNNGraphOptimizer::FuseEltwiseAndSimple(MKLDNNGraph &graph) {
     auto& graphNodes = graph.GetNodes();
 
@@ -1918,7 +1961,7 @@ void MKLDNNGraphOptimizer::MergeTransposeAndReorder(MKLDNNGraph &graph) {
 void MKLDNNGraphOptimizer::reshapeRnnSeq(MKLDNNGraph &graph) {
     auto& graphNodes = graph.GetNodes();
 
-    auto isSutableParentNode = [](MKLDNNNodePtr node) {
+    auto isSuitableParentNode = [](MKLDNNNodePtr node) {
         if (node->type != RNNSeq)
             return false;
         auto rnnNode = std::dynamic_pointer_cast<MKLDNNRNN>(node);
@@ -1927,7 +1970,7 @@ void MKLDNNGraphOptimizer::reshapeRnnSeq(MKLDNNGraph &graph) {
 
     for (size_t i = 0; i < graphNodes.size(); i++) {
         auto parentNode = graphNodes[i];
-        if (!isSutableParentNode(parentNode)) {
+        if (!isSuitableParentNode(parentNode)) {
             continue;
         }
 

--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph_optimizer.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph_optimizer.h
@@ -32,6 +32,7 @@ private:
     void FuseMVNAndSimpleOperation(MKLDNNGraph &graph);
     void FuseInterpolateAndSimpleOperation(MKLDNNGraph &graph);
     void FuseNormalizeL2AndSimpleOperation(MKLDNNGraph &graph);
+    void FuseReduceAndSimpleOperation(MKLDNNGraph &graph);
 
     void DropDoubleReorders(MKLDNNGraph& graph);
     void FuseConvolutionAndZeroPoints(MKLDNNGraph &graph);

--- a/inference-engine/src/mkldnn_plugin/mkldnn_plugin.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_plugin.cpp
@@ -71,6 +71,7 @@
 #include <transformations/op_conversions/convert_deformable_conv_v8_to_v1.hpp>
 #include <transformations/smart_reshape/matmul_sr.hpp>
 #include <transformations/op_conversions/convert_minimum_to_power_and_max.hpp>
+#include <transformations/op_conversions/convert_reduce_to_pooling.hpp>
 #include <transformations/convert_precision.hpp>
 #include <transformations/init_node_info.hpp>
 #include <transformations/rt_info/fused_names_attribute.hpp>
@@ -367,6 +368,9 @@ static void TransformationUpToCPUSpecificOpSet(std::shared_ptr<ngraph::Function>
     pass_config->disable<ngraph::pass::ConvertGather7ToGather1>();
     pass_config->disable<ngraph::pass::ConvertMinimum>();
     pass_config->disable<ngraph::pass::ConvertBroadcastToTiles>();
+    pass_config->disable<ngraph::pass::ConvertReduceMeanToPooling>();
+    pass_config->disable<ngraph::pass::ConvertReduceMaxToPooling>();
+    pass_config->disable<ngraph::pass::ConvertReduceSumToPooling>();
 
     pass_config->enable<ngraph::pass::NormalizeL2Decomposition>();
     pass_config->enable<ngraph::pass::ConvertInterpolate1ToInterpolate4>();

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reduce_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reduce_node.cpp
@@ -5,6 +5,7 @@
 #include "mkldnn_reduce_node.h"
 
 #include "mkldnn_fake_quantize_node.h"
+#include "mkldnn_eltwise_node.h"
 #include <mkldnn.hpp>
 #include <string>
 #include <vector>
@@ -44,6 +45,7 @@ using namespace Xbyak;
                                                                 OW = width;
 
 #define GET_OFF(field) offsetof(jit_reduce_call_args, field)
+#define GET_OFF_POST(field) offsetof(jit_reduce_post_call_args, field)
 
 #define GET_PTR_N_PLN              const uint8_t    *in_ptr_n      = in_ptr       + src_data_size * ib * IC * ID * IH * IW;               \
                                          uint8_t    *out_ptr_n     = out_ptr      + dst_data_size * ob * OC * OD * OH * OW;
@@ -86,17 +88,22 @@ struct jit_uni_reduce_kernel_f32 : public jit_uni_reduce_kernel, public jit_gene
     }
 
     void generate() override {
-        exp_injector.reset(new jit_uni_eltwise_injector_f32<isa>(this, alg_kind::eltwise_exp, 0.f, 0.f, 1));
+        if (jcp_.reduce_mode == ReduceLogSumExp) {
+            exp_injector = std::make_shared<jit_uni_eltwise_injector_f32<isa>>(this, alg_kind::eltwise_exp, 0.f, 0.f, 1);
+        }
 
         if (!mayiuse(avx512_core_bf16) && mayiuse(avx512_core))
-            emu_vcvtneps2bf16.reset(new jit_emu_vcvtneps2bf16(this, isa, nullptr));
+            emu_vcvtneps2bf16 = std::make_shared<jit_emu_vcvtneps2bf16>(this, isa, nullptr);
 
         this->preamble();
+
+        planar_layout = jcp_.layout == ReduceLayoutType::reduce_ncsp || jcp_.layout == ReduceLayoutType::reduce_nspc;
 
         mov(reg_src, ptr[reg_params + GET_OFF(src)]);
         mov(reg_dst, ptr[reg_params + GET_OFF(dst)]);
         mov(reg_work_amount, ptr[reg_params + GET_OFF(work_amount)]);
-        if (jcp_.planar_layout)
+        mov(reg_work_batch, ptr[reg_params + GET_OFF(work_batch)]);
+        if (planar_layout)
             mov(reg_reduce_w, ptr[reg_params + GET_OFF(reduce_w)]);
 
         if (jcp_.reduce_mode == ReduceAnd || jcp_.reduce_mode == ReduceL1 || jcp_.reduce_mode == ReduceMax ||
@@ -131,19 +138,26 @@ private:
     using Vmm = typename conditional3<isa == cpu::x64::sse41, Xbyak::Xmm, isa == cpu::x64::avx2,
             Xbyak::Ymm, Xbyak::Zmm>::type;
     size_t vlen = cpu_isa_traits<isa>::vlen;
+    bool planar_layout;
 
     Xbyak::Address table_val(int index) { return ptr[reg_table + index * vlen]; }
 
     Xbyak::Reg64 reg_src = r8;
     Xbyak::Reg64 reg_dst = r9;
+    Xbyak::Reg64 reg_idx = rdx;
     Xbyak::Reg64 reg_work_amount = r10;
     Xbyak::Reg64 reg_reduce_w = r11;
-    Xbyak::Reg64 reg_table = r12;
+    Xbyak::Reg64 reg_reduce_stride = r12;
+    Xbyak::Reg64 reg_work_batch = r13;
+    Xbyak::Reg64 reg_table = r14;
     Xbyak::Reg64 reg_params = abi_param1;
 
-    Xbyak::Reg8 reg_tmp_8 = r13b;
-    Xbyak::Reg32 reg_tmp_32 = r13d;
-    Xbyak::Reg64 reg_tmp_64 = r13;
+    Xbyak::Reg8 reg_tmp_8 = r15b;
+    Xbyak::Reg32 reg_tmp_32 = r15d;
+    Xbyak::Reg64 reg_tmp_64 = r15;
+
+    Xbyak::Reg64 reg_src_aux = rax;
+    Xbyak::Reg64 reg_work_batch_aux = rbx;
 
     Vmm vmm_aux = Vmm(0);
     Xmm xmm_aux = Xmm(0);
@@ -154,16 +168,17 @@ private:
     Vmm vmm_zero = Vmm(3);
     Xmm xmm_zero = Xmm(3);
     Vmm vmm_dst_aux = Vmm(4);
-    Xbyak::Xmm xmm_aux1 = Xbyak::Xmm(5);
-    Xbyak::Xmm xmm_aux2 = Xbyak::Xmm(6);
-    Xbyak::Xmm xmm_aux3 = Xbyak::Xmm(7);
+    Xmm xmm_aux1 = Xmm(5);
+    Xmm xmm_aux2 = Xmm(6);
+    Xmm xmm_aux3 = Xmm(7);
+    Vmm vmm_idx = Vmm(8);
+    Vmm vmm_mask = Vmm(9);
 
     const Xbyak::Opmask k_mask = Xbyak::Opmask(1);
 
-    std::unique_ptr<jit_emu_vcvtneps2bf16> emu_vcvtneps2bf16;
-
     Xbyak::Label l_table;
 
+    std::shared_ptr<jit_emu_vcvtneps2bf16> emu_vcvtneps2bf16;
     std::shared_ptr<jit_uni_eltwise_injector_f32<isa>> exp_injector;
 
     inline void reduce_main() {
@@ -225,8 +240,12 @@ private:
         // ================================================================
         Xbyak::Label reduce_to_vector_label;
         Xbyak::Label reduce_to_scalar_label;
+        Xbyak::Label reduce_to_gather_label;
         Xbyak::Label reduce_main_end_label;
-        if (jcp_.planar_layout) {
+        if (planar_layout) {
+            cmp(reg_work_batch, 0);
+            je(reduce_to_gather_label, T_NEAR);
+
             cmp(reg_reduce_w, 1); // planar layout reducing W
             je(reduce_to_scalar_label, T_NEAR);
         }
@@ -246,29 +265,8 @@ private:
             // load
             load_dst_vector();
 
-            Xbyak::Label reduce_loop_label;
-            Xbyak::Label reduce_loop_end_label;
-
             // reduce
-            L(reduce_loop_label);
-            {
-                cmp(reg_work_amount, step);
-                jl(reduce_loop_end_label, T_NEAR);
-
-                load_vector(vmm_src, ptr[reg_src], jcp_.src_dt);
-                reduce_kernel(vmm_src, vmm_dst);
-
-                if (isa == cpu::x64::sse41) {
-                    load_vector(vmm_src, ptr[reg_src + 4 * jcp_.src_data_size], jcp_.src_dt);
-                    reduce_kernel(vmm_src, vmm_dst_aux);
-                }
-
-                add(reg_src, step * jcp_.src_data_size);
-                sub(reg_work_amount, step);
-
-                jmp(reduce_loop_label, T_NEAR);
-            }
-            L(reduce_loop_end_label);
+            reduce_kernel();
 
             // store
             store_dst_vector();
@@ -317,16 +315,57 @@ private:
             // reduce
             reduce_main_loop();
             if (jcp_.reduce_mode == ReduceOr && isa != cpu::x64::avx512_common) {
-                if (isa == cpu::x64::avx2) {
-                    vcmpneqps(vmm_dst, vmm_dst, vmm_zero);
-                } else if (isa == cpu::x64::sse41) {
-                    cmpneqps(vmm_dst, vmm_zero);
-                }
+                uni_cmpneqps(vmm_dst, vmm_dst, vmm_zero);
                 uni_vandps(vmm_dst, vmm_dst, vmm_aux);
             }
             // store
             // store after horizontal calculation and calculation with loaded original ptr[reg_dst]
-            load_embedded_horiz_reduce_store(vmm_dst, jcp_.dst_dt);
+            horiz_reduce_store(vmm_dst, jcp_.dst_dt, true);
+
+            jmp(reduce_main_end_label, T_NEAR);
+        }
+
+        // load vmm_src with gather, then store vmm_dst directly into memory after reducing
+        // cases: [planar layout reducing small W]
+        L(reduce_to_gather_label);
+        {
+            int step = 1;
+            cmp(reg_work_amount, step);
+            jl(reduce_main_end_label, T_NEAR); //avoid illegal loading and storing
+
+            mov(reg_idx, ptr[reg_params + GET_OFF(idx)]);
+            uni_vmovdqu(vmm_idx, ptr[reg_idx]);
+
+            if (jcp_.reduce_mode == ReduceL1) {
+                uni_vmovups(vmm_aux, table_val(1));
+            }
+
+            // load
+            load_dst_vector();
+
+            // reduce
+            Xbyak::Label reduce_loop_label;
+            Xbyak::Label reduce_loop_end_label;
+            L(reduce_loop_label);
+            {
+                cmp(reg_work_amount, step);
+                jl(reduce_loop_end_label, T_NEAR);
+
+                reduce_gather(vmm_dst, 0);
+                if (isa == cpu::x64::sse41) {
+                    reduce_gather(vmm_dst_aux, 4 * jcp_.src_data_size);
+                }
+
+                add(reg_src, step * jcp_.src_data_size);
+                sub(reg_work_amount, step);
+                jmp(reduce_loop_label, T_NEAR);
+            }
+            L(reduce_loop_end_label);
+
+            // store
+            store_dst_vector();
+
+            jmp(reduce_main_end_label, T_NEAR);
         }
 
         L(reduce_main_end_label);
@@ -340,7 +379,7 @@ private:
         Xbyak::Label tail_dst_shifted_label;
         Xbyak::Label tail_dst_fixed_label;
         Xbyak::Label reduce_tail_end_label;
-        if (jcp_.planar_layout) {
+        if (planar_layout) {
             cmp(reg_reduce_w, 1);  // planar layout reducing W
             je(tail_dst_fixed_label, T_NEAR);
         }
@@ -349,40 +388,7 @@ private:
         // cases: [planar layout reducing other dimensions but W] [blocked layout concern padding]
         L(tail_dst_shifted_label);
         {
-            Xbyak::Label reduce_loop_label;
-            Xbyak::Label reduce_loop_end_label;
-
-            int step = 1;
-            L(reduce_loop_label);
-            {
-                cmp(reg_work_amount, step);
-                jl(reduce_loop_end_label, T_NEAR);
-
-                // load
-                load_scalar(xmm_dst, ptr[reg_dst], jcp_.dst_dt);
-                load_scalar(xmm_src, ptr[reg_src], jcp_.src_dt);
-
-                // reduce
-                reduce_kernel_scalar(xmm_src, xmm_dst);
-                if (jcp_.reduce_mode == ReduceOr) {
-                    if (isa == cpu::x64::sse41) {
-                        cmpneqps(xmm_dst, xmm_zero);
-                    } else {
-                        vcmpneqps(xmm_dst, xmm_dst, xmm_zero);
-                    }
-                    uni_vandps(xmm_dst, xmm_dst, xmm_aux);
-                }
-
-                // store
-                store_scalar(ptr[reg_dst], xmm_dst, jcp_.dst_dt);
-
-                add(reg_dst, step * jcp_.dst_data_size);
-                add(reg_src, step * jcp_.src_data_size);
-                sub(reg_work_amount, step);
-
-                jmp(reduce_loop_label, T_NEAR);
-            }
-            L(reduce_loop_end_label);
+            reduce_kernel_tail();
 
             jmp(reduce_tail_end_label, T_NEAR);
         }
@@ -408,11 +414,7 @@ private:
 
                 reduce_kernel_scalar(xmm_src, xmm_dst);
                 if (jcp_.reduce_mode == ReduceOr) {
-                    if (isa == cpu::x64::sse41) {
-                        cmpneqps(xmm_dst, xmm_zero);
-                    } else {
-                        vcmpneqps(xmm_dst, xmm_dst, xmm_zero);
-                    }
+                    uni_cmpneqps(xmm_dst, xmm_dst, xmm_zero);
                     uni_vandps(xmm_dst, xmm_dst, xmm_aux);
                 }
 
@@ -425,10 +427,252 @@ private:
 
             // store
             store_scalar(ptr[reg_dst], xmm_dst, jcp_.dst_dt);
-            add(reg_dst, step * jcp_.dst_data_size);
         }
 
         L(reduce_tail_end_label);
+    }
+
+    inline void init_reg_reduce_stride() {
+        mov(reg_reduce_stride, ptr[reg_params + GET_OFF(reduce_stride)]);
+        mul_by_const(reg_reduce_stride, reg_tmp_64, jcp_.src_data_size);
+    }
+
+    inline void reduce_kernel() {
+        Xbyak::Label reduce_label;
+        Xbyak::Label reduce_end_label;
+        Xbyak::Label reduce_batch_label;
+        Xbyak::Label reduce_batch_end_label;
+
+        int step = vlen / sizeof(float) < 8 ? 8 : vlen / sizeof(float);
+        cmp(reg_work_batch, 1);
+        je(reduce_label, T_NEAR);
+
+        init_reg_reduce_stride();
+
+        L(reduce_batch_label);
+        {
+            cmp(reg_work_amount, step);
+            jl(reduce_end_label, T_NEAR);
+
+            reduce_batch();
+
+            add(reg_src, step * jcp_.src_data_size);
+            sub(reg_work_amount, step);
+            jmp(reduce_batch_label, T_NEAR);
+        }
+        L(reduce_batch_end_label);
+
+        L(reduce_label);
+        {
+            cmp(reg_work_amount, step);
+            jl(reduce_end_label, T_NEAR);
+
+            reduce_once();
+
+            add(reg_src, step * jcp_.src_data_size);
+            sub(reg_work_amount, step);
+            jmp(reduce_label, T_NEAR);
+        }
+        L(reduce_end_label);
+    }
+
+    inline void reduce_once() {
+        load_vector(vmm_src, ptr[reg_src], jcp_.src_dt);
+        reduce_kernel(vmm_src, vmm_dst);
+
+        if (isa == cpu::x64::sse41) {
+            load_vector(vmm_src, ptr[reg_src + 4 * jcp_.src_data_size], jcp_.src_dt);
+            reduce_kernel(vmm_src, vmm_dst_aux);
+        }
+    }
+
+    inline void reduce_batch() {
+        mov(reg_src_aux, reg_src);
+        mov(reg_work_batch_aux, reg_work_batch);
+
+        Xbyak::Label reduce_batch_loop_label;
+        Xbyak::Label reduce_batch_loop_end_label;
+        L(reduce_batch_loop_label);
+        {
+            cmp(reg_work_batch_aux, 1);
+            jl(reduce_batch_loop_end_label, T_NEAR);
+
+            load_vector(vmm_src, ptr[reg_src_aux], jcp_.src_dt);
+            reduce_kernel(vmm_src, vmm_dst);
+            if (isa == cpu::x64::sse41) {
+                load_vector(vmm_src, ptr[reg_src_aux + 4 * jcp_.src_data_size], jcp_.src_dt);
+                reduce_kernel(vmm_src, vmm_dst_aux);
+            }
+
+            add(reg_src_aux, reg_reduce_stride);
+            sub(reg_work_batch_aux, 1);
+            jmp(reduce_batch_loop_label, T_NEAR);
+        }
+        L(reduce_batch_loop_end_label);
+    }
+
+    inline void reduce_gather(Vmm vmm_dst, int offset) {
+        switch (jcp_.src_dt) {
+            case memory::data_type::f32:
+            case memory::data_type::s32:
+                if (isa == cpu::x64::avx512_common) {
+                    kxnord(k_mask, k_mask, k_mask);
+                    vgatherdps(vmm_src | k_mask, ptr[reg_src + offset + vmm_idx]);
+                } else if (isa == cpu::x64::avx2) {
+                    uni_vpcmpeqd(vmm_mask, vmm_mask, vmm_mask);
+                    vgatherdps(vmm_src, ptr[reg_src + offset + vmm_idx], vmm_mask);
+                } else {
+                    pack_gathered_vector(vmm_src, vmm_idx, offset, jcp_.src_dt);
+                }
+                break;
+            case memory::data_type::bf16:
+            case memory::data_type::s8:
+            case memory::data_type::u8:
+                pack_gathered_vector(vmm_src, vmm_idx, offset, jcp_.src_dt);
+                break;
+            default:
+                assert(!"unknown src_dt");
+        }
+        reduce_kernel(vmm_src, vmm_dst);
+    }
+
+    inline void pack_gathered_vector(Vmm vmm_val, Vmm vmm_index, int offset, memory::data_type src_dt) {
+        sub(rsp, vlen);
+        uni_vmovdqu(ptr[rsp], vmm_index);
+        int repeats = vlen / sizeof(float);
+        for (size_t i = 0; i < repeats; i++) {
+            mov(reg_tmp_64.cvt32(), ptr[rsp + i * sizeof(int)]);
+            Xbyak::Address table_idx = ptr[reg_src + offset + reg_tmp_64];
+            switch (src_dt) {
+                case memory::data_type::f32:
+                case memory::data_type::s32:
+                    mov(reg_tmp_64.cvt32(), table_idx);
+                    mov(ptr[rsp + i * sizeof(int)], reg_tmp_64.cvt32());
+                    break;
+                case memory::data_type::bf16:
+                    mov(reg_tmp_64.cvt16(), table_idx);
+                    mov(ptr[rsp + i * sizeof(MKLDNNPlugin::bfloat16_t)], reg_tmp_64.cvt16());
+                    break;
+                case memory::data_type::s8:
+                case memory::data_type::u8:
+                    mov(reg_tmp_64.cvt8(), table_idx);
+                    mov(ptr[rsp + i * sizeof(char)], reg_tmp_64.cvt8());
+                    break;
+                default:
+                    assert(!"unknown src_dt");
+            }
+        }
+
+        switch (src_dt) {
+            case memory::data_type::f32:
+            case memory::data_type::s32:
+                uni_vmovups(vmm_val, ptr[rsp]);
+                break;
+            case memory::data_type::bf16:
+                uni_vpmovzxwd(vmm_val, ptr[rsp]);
+                uni_vpslld(vmm_val, vmm_val, 16);
+            break;
+            case memory::data_type::s8:
+                uni_vpmovsxbd(vmm_val, ptr[rsp]);
+                break;
+            case memory::data_type::u8:
+                uni_vpmovzxbd(vmm_val, ptr[rsp]);
+                break;
+            default:
+                assert(!"unknown src_dt");
+        }
+        add(rsp, vlen);
+    }
+
+    inline void reduce_kernel_tail() {
+        Xbyak::Label reduce_label;
+        Xbyak::Label reduce_end_label;
+        Xbyak::Label reduce_batch_label;
+        Xbyak::Label reduce_batch_end_label;
+
+        int step = 1;
+        cmp(reg_work_batch, 1);
+        je(reduce_label, T_NEAR);
+
+        init_reg_reduce_stride();
+
+        L(reduce_batch_label);
+        {
+            cmp(reg_work_amount, step);
+            jl(reduce_end_label, T_NEAR);
+
+            // load
+            load_scalar(xmm_dst, ptr[reg_dst], jcp_.dst_dt);
+
+            // reduce
+            reduce_batch_tail();
+
+            // store
+            store_scalar(ptr[reg_dst], xmm_dst, jcp_.dst_dt);
+
+            add(reg_dst, step * jcp_.dst_data_size);
+            add(reg_src, step * jcp_.src_data_size);
+            sub(reg_work_amount, step);
+
+            jmp(reduce_batch_label, T_NEAR);
+        }
+        L(reduce_batch_end_label);
+
+        L(reduce_label);
+        {
+            cmp(reg_work_amount, step);
+            jl(reduce_end_label, T_NEAR);
+
+            // load
+            load_scalar(xmm_dst, ptr[reg_dst], jcp_.dst_dt);
+
+            // reduce
+            reduce_batch_tail();
+
+            // store
+            store_scalar(ptr[reg_dst], xmm_dst, jcp_.dst_dt);
+
+            add(reg_dst, step * jcp_.dst_data_size);
+            add(reg_src, step * jcp_.src_data_size);
+            sub(reg_work_amount, step);
+
+            jmp(reduce_label, T_NEAR);
+        }
+        L(reduce_end_label);
+    }
+
+    inline void reduce_once_tail() {
+        load_scalar(xmm_src, ptr[reg_src], jcp_.src_dt);
+        reduce_kernel_scalar(xmm_src, xmm_dst);
+        if (jcp_.reduce_mode == ReduceOr) {
+            uni_cmpneqps(xmm_dst, xmm_dst, xmm_zero);
+            uni_vandps(xmm_dst, xmm_dst, xmm_aux);
+        }
+    }
+
+    inline void reduce_batch_tail() {
+        mov(reg_src_aux, reg_src);
+        mov(reg_work_batch_aux, reg_work_batch);
+
+        Xbyak::Label reduce_batch_loop_label;
+        Xbyak::Label reduce_batch_loop_end_label;
+        L(reduce_batch_loop_label);
+        {
+            cmp(reg_work_batch_aux, 1);
+            jl(reduce_batch_loop_end_label, T_NEAR);
+
+            load_scalar(xmm_src, ptr[reg_src_aux], jcp_.src_dt);
+            reduce_kernel_scalar(xmm_src, xmm_dst);
+            if (jcp_.reduce_mode == ReduceOr) {
+                uni_cmpneqps(xmm_dst, xmm_dst, xmm_zero);
+                uni_vandps(xmm_dst, xmm_dst, xmm_aux);
+            }
+
+            add(reg_src_aux, reg_reduce_stride);
+            sub(reg_work_batch_aux, 1);
+            jmp(reduce_batch_loop_label, T_NEAR);
+        }
+        L(reduce_batch_loop_end_label);
     }
 
     inline void reduce_main_loop() {
@@ -463,10 +707,8 @@ private:
                 if (isa == cpu::x64::avx512_common) {
                     vcmpps(k_mask, vmm_src, vmm_zero, _cmp_neq_uq);
                     vblendmps(vmm_src | k_mask, vmm_zero, vmm_aux);
-                } else if (isa == cpu::x64::avx2) {
-                    vcmpneqps(vmm_src, vmm_src, vmm_zero);
                 } else {
-                    cmpneqps(vmm_src, vmm_zero);
+                    uni_cmpneqps(vmm_src, vmm_src, vmm_zero);
                 }
                 uni_vandps(vmm_dst, vmm_dst, vmm_src);
                 break;
@@ -512,11 +754,7 @@ private:
     inline void reduce_kernel_scalar(Xmm xmm_src, Xmm xmm_dst) {
         switch (jcp_.reduce_mode) {
             case ReduceAnd:
-                if (isa == cpu::x64::sse41) {
-                    cmpneqps(xmm_src, xmm_zero);
-                } else {
-                    vcmpneqps(xmm_src, xmm_src, xmm_zero);
-                }
+                uni_cmpneqps(xmm_src, xmm_src, xmm_zero);
                 uni_vandps(xmm_dst, xmm_dst, xmm_src);
                 break;
             case ReduceL1:
@@ -562,15 +800,11 @@ private:
 
     inline void store_dst_vector() {
         if (jcp_.reduce_mode == ReduceOr && isa != cpu::x64::avx512_common) {
-            if (isa == cpu::x64::avx2) {
-                vcmpneqps(vmm_dst, vmm_dst, vmm_zero);
-            } else if (isa == cpu::x64::sse41) {
-                cmpneqps(vmm_dst, vmm_zero);
-            }
+            uni_cmpneqps(vmm_dst, vmm_dst, vmm_zero);
             uni_vandps(vmm_dst, vmm_dst, vmm_aux);
 
             if (isa == cpu::x64::sse41) {
-                cmpneqps(vmm_dst_aux, vmm_zero);
+                uni_cmpneqps(vmm_dst_aux, vmm_dst_aux, vmm_zero);
                 uni_vandps(vmm_dst_aux, vmm_dst_aux, vmm_aux);
             }
         }
@@ -607,19 +841,19 @@ private:
         switch (src_dt) {
             case memory::data_type::f32:
             case memory::data_type::s32:
-                movss(xmm_src, op);
+                uni_vmovss(xmm_src, op);
                 break;
             case memory::data_type::bf16:
-                pinsrw(xmm_src, op, 0x0);
+                uni_vpinsrw(xmm_src, xmm_src, op, 0x0);
                 uni_vpslld(xmm_src, xmm_src, 16);
                 break;
             case memory::data_type::s8:
                 movsx(reg_tmp_32, op);
-                movq(xmm_src, reg_tmp_64);
+                uni_vmovq(xmm_src, reg_tmp_64);
                 break;
             case memory::data_type::u8:
                 movzx(reg_tmp_32, op);
-                movq(xmm_src, reg_tmp_64);
+                uni_vmovq(xmm_src, reg_tmp_64);
                 break;
             default:
                 assert(!"unknown src_dt");
@@ -662,7 +896,7 @@ private:
                     if (isa != cpu::x64::sse41)
                         vmovq(op, xmm_dst);
                     else
-                        movd(op, xmm_dst);
+                        uni_vmovd(op, xmm_dst);
                 }
                 break;
             case memory::data_type::u8:
@@ -676,7 +910,7 @@ private:
                     if (isa != cpu::x64::sse41)
                         vmovq(op, xmm_dst);
                     else
-                        movd(op, xmm_dst);
+                        uni_vmovd(op, xmm_dst);
                 }
                 break;
             default:
@@ -692,22 +926,22 @@ private:
         switch (dst_dt) {
             case memory::data_type::f32:
             case memory::data_type::s32:
-                movss(op, xmm_dst);
+                uni_vmovss(op, xmm_dst);
                 break;
             case memory::data_type::bf16:
                 uni_vpsrld(xmm_dst, xmm_dst, 16);
-                pextrw(op, xmm_dst, 0x0);
+                uni_vpextrw(op, xmm_dst, 0x0);
                 break;
             case memory::data_type::s8:
                 uni_vpackssdw(xmm_dst, xmm_dst, xmm_dst);
                 uni_vpacksswb(xmm_dst, xmm_dst, xmm_dst);
-                movq(reg_tmp_64, xmm_dst);
+                uni_vmovq(reg_tmp_64, xmm_dst);
                 mov(op, reg_tmp_8);
                 break;
             case memory::data_type::u8:
                 uni_vpackusdw(xmm_dst, xmm_dst, xmm_dst);
                 uni_vpackuswb(xmm_dst, xmm_dst, xmm_dst);
-                movq(reg_tmp_64, xmm_dst);
+                uni_vmovq(reg_tmp_64, xmm_dst);
                 mov(op, reg_tmp_8);
                 break;
             default:
@@ -715,15 +949,15 @@ private:
         }
     }
 
-    inline void load_embedded_horiz_reduce_store(Vmm vmm_dst, memory::data_type dst_dt) {
+    inline void horiz_reduce_store(Vmm vmm_dst, memory::data_type dst_dt, bool load_embedded = false) {
         if (isa == cpu::x64::sse41) {
-            load_embedded_horiz_store(vmm_dst, dst_dt);
+            horiz_store(vmm_dst, dst_dt, load_embedded);
         } else if (isa == cpu::x64::avx2) {
             Xbyak::Ymm ymm_dst = Xbyak::Ymm(vmm_dst.getIdx());
             vextractf128(xmm_aux1, ymm_dst, 0);
             vextractf128(xmm_aux2, ymm_dst, 1);
             horiz_ps(xmm_aux1, xmm_aux2);
-            load_embedded_horiz_store(xmm_aux1, dst_dt);
+            horiz_store(xmm_aux1, dst_dt, load_embedded);
         } else {
             Xbyak::Zmm zmm_dst = Xbyak::Zmm(vmm_dst.getIdx());
             vextractf32x4(xmm_aux1, zmm_dst, 0);
@@ -733,51 +967,26 @@ private:
             vextractf32x4(xmm_aux3, zmm_dst, 3);
             horiz_ps(xmm_aux2, xmm_aux3);
             horiz_ps(xmm_aux1, xmm_aux2);
-            load_embedded_horiz_store(xmm_aux1, dst_dt);
+            horiz_store(xmm_aux1, dst_dt, load_embedded);
         }
     }
 
-    inline void load_embedded_horiz_store(Xbyak::Xmm xmm_dst, memory::data_type dst_dt) {
-        movshdup(xmm_aux3, xmm_dst); // dst:1,2,3,4; aux3:2,2,4,4
-        horiz_ps(xmm_dst, xmm_aux3); // dst:f(1,2),f(2,2),f(3,4),f(4,4)
-        movhlps(xmm_aux3, xmm_dst);  // aux3:f(3,4),f(4,4),4,4
-        horiz_ps(xmm_dst, xmm_aux3); // dst:f(1,2,3,4),...
-        load_scalar(xmm_aux3, ptr[reg_dst], dst_dt);
-
-        switch (dst_dt) {
-            case memory::data_type::f32:
-            case memory::data_type::bf16:
-                horiz_ps(xmm_dst, xmm_aux3);
-                store_scalar(ptr[reg_dst], xmm_dst, dst_dt);
-                break;
-            case memory::data_type::s32:
-                horiz_ps(xmm_dst, xmm_aux3);
-                uni_vcvtps2dq(xmm_dst, xmm_dst);
-                movss(ptr[reg_dst], xmm_dst);
-                break;
-            case memory::data_type::u8:
-                horiz_ps(xmm_dst, xmm_aux3);
-                uni_vcvtps2dq(xmm_dst, xmm_dst);
-                uni_vpackusdw(xmm_dst, xmm_dst, xmm_dst);
-                uni_vpackuswb(xmm_dst, xmm_dst, xmm_dst);
-                pextrb(ptr[reg_dst], xmm_dst, 0);
-                break;
-            case memory::data_type::s8:
-                horiz_ps(xmm_dst, xmm_aux3);
-                uni_vcvtps2dq(xmm_dst, xmm_dst);
-                uni_vpackssdw(xmm_dst, xmm_dst, xmm_dst);
-                uni_vpacksswb(xmm_dst, xmm_dst, xmm_dst);
-                pextrb(ptr[reg_dst], xmm_dst, 0);
-                break;
-            default:
-                assert(!"unknown dst_dt");
+    inline void horiz_store(Xbyak::Xmm xmm_dst, memory::data_type dst_dt, bool load_embedded) {
+        uni_movshdup(xmm_aux3, xmm_dst); // dst:1,2,3,4; aux3:2,2,4,4
+        horiz_ps(xmm_dst, xmm_aux3);     // dst:f(1,2),f(2,2),f(3,4),f(4,4)
+        uni_movhlps(xmm_aux3, xmm_dst);  // aux3:f(3,4),f(4,4),4,4
+        horiz_ps(xmm_dst, xmm_aux3);     // dst:f(1,2,3,4),...
+        if (load_embedded) {
+            load_scalar(xmm_aux3, ptr[reg_dst], dst_dt);
+            horiz_ps(xmm_dst, xmm_aux3);
         }
+        store_scalar(ptr[reg_dst], xmm_dst, dst_dt);
     }
 
     inline void horiz_ps(const Xmm& xmm, const Operand& op) {
         switch (jcp_.reduce_mode) {
             case ReduceAnd:
-                andps(xmm, op);
+                uni_vandps(xmm, xmm, op);
                 break;
             case ReduceL1:
             case ReduceL2:
@@ -786,19 +995,19 @@ private:
             case ReduceSum:
             case ReduceSumSquare:
             case ReduceLogSumExp:
-                addps(xmm, op);
+                uni_vaddps(xmm, xmm, op);
                 break;
             case ReduceMax:
-                maxps(xmm, op);
+                uni_vmaxps(xmm, xmm, op);
                 break;
             case ReduceMin:
-                minps(xmm, op);
+                uni_vminps(xmm, xmm, op);
                 break;
             case ReduceOr:
-                orps(xmm, op);
+                uni_vorps(xmm, xmm, op);
                 break;
             case ReduceProd:
-                mulps(xmm, op);
+                uni_vmulps(xmm, xmm, op);
                 break;
             default:
                 assert(!"unsupported reduce mode");
@@ -837,8 +1046,8 @@ template <cpu_isa_t isa>
 struct jit_uni_reduce_post_kernel_f32 : public jit_uni_reduce_post_kernel, public jit_generator {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_reduce_post_kernel_f32)
 
-    explicit jit_uni_reduce_post_kernel_f32(jit_reduce_config_params jcp)
-    : jit_uni_reduce_post_kernel(jcp), jit_generator() {}
+    explicit jit_uni_reduce_post_kernel_f32(jit_reduce_config_params jcp, const mkldnn_primitive_attr &attr)
+    : jit_uni_reduce_post_kernel(jcp, attr), jit_generator() {}
 
     void create_ker() override {
         jit_generator::create_kernel();
@@ -846,25 +1055,69 @@ struct jit_uni_reduce_post_kernel_f32 : public jit_uni_reduce_post_kernel, publi
     }
 
     void generate() override {
-        log_injector.reset(new jit_uni_eltwise_injector_f32<isa>(this, alg_kind::eltwise_log, 0.f, 0.f, 1.f));
+        const auto &p = attr_.post_ops_;
+        for (int i = 0; i < p.len(); i++) {
+            auto &post_op = p.entry_[i];
+            if (post_op.is_eltwise()) {
+                eltwise_injectors.push_back(std::make_shared<jit_uni_eltwise_injector_f32<isa>>(
+                        this, post_op.eltwise.alg, post_op.eltwise.alpha, post_op.eltwise.beta, post_op.eltwise.scale));
+            } else if (post_op.is_depthwise()) {
+                depthwise_injectors.push_back(std::make_shared<jit_uni_depthwise_injector_f32<isa>>(
+                        this, post_op.depthwise.alg));
+            } else if (post_op.is_quantization()) {
+                quantization_injectors.push_back(std::make_shared<jit_uni_quantization_injector_f32<isa>>(
+                        this, post_op, vmm_d_weights, vmm_d_bias, reg_d_weights, reg_d_bias));
+            }
+        }
+
+        if (jcp_.reduce_mode == ReduceLogSum || jcp_.reduce_mode == ReduceLogSumExp) {
+            log_injector = std::make_shared<jit_uni_eltwise_injector_f32<isa>>(this, alg_kind::eltwise_log, 0.f, 0.f, 1.f);
+        }
 
         if (!mayiuse(avx512_core_bf16) && mayiuse(avx512_core))
-            emu_vcvtneps2bf16.reset(new jit_emu_vcvtneps2bf16(this, isa, nullptr));
+            emu_vcvtneps2bf16 = std::make_shared<jit_emu_vcvtneps2bf16>(this, isa, nullptr);
 
         this->preamble();
 
-        mov(reg_dst, ptr[reg_params + GET_OFF(dst)]);
-        mov(reg_work_amount, ptr[reg_params + GET_OFF(work_amount)]);
-        mov(reg_divisor, ptr[reg_params + GET_OFF(divisor)]);
-        if (!jcp_.planar_layout)
-            mov(reg_reduce_c, ptr[reg_params + GET_OFF(reduce_c)]);
+        planar_layout = jcp_.layout == ReduceLayoutType::reduce_ncsp || jcp_.layout == ReduceLayoutType::reduce_nspc;
+
+        mov(reg_dst, ptr[reg_params + GET_OFF_POST(dst)]);
+        mov(reg_work_amount, ptr[reg_params + GET_OFF_POST(work_amount)]);
+        mov(reg_channel_size, ptr[reg_params + GET_OFF_POST(channel_size)]);
+        mov(reg_divisor, ptr[reg_params + GET_OFF_POST(divisor)]);
+        if (!planar_layout)
+            mov(reg_reduce_c, ptr[reg_params + GET_OFF_POST(reduce_c)]);
+        if (attr_.post_ops_.len() != 0)
+            mov(reg_oc_off, ptr[reg_params + GET_OFF_POST(oc_off)]);
 
         if (isa == cpu::x64::avx512_common)
             uni_vpxor(vmm_zero, vmm_zero, vmm_zero);
 
-        reduce_post_main();
-        if (jcp_.planar_layout)
+        if (jcp_.layout == ReduceLayoutType::reduce_blocked) {
+            reduce_post_main();
+        } else if (jcp_.layout == ReduceLayoutType::reduce_nspc && attr_.post_ops_.len() != 0) {
+            // the tail of channel dimension should always be concerned during post ops fusing for nspc layout
+            Xbyak::Label reduce_nspc_loop_label;
+            Xbyak::Label reduce_nspc_loop_end_label;
+            mov(reg_total_work_amount, reg_work_amount);
+            L(reduce_nspc_loop_label);
+            {
+                cmp(reg_total_work_amount, 0);
+                jle(reduce_nspc_loop_end_label, T_NEAR);
+
+                mov(reg_oc_off, 0);
+                mov(reg_work_amount, reg_channel_size);
+                reduce_post_main();
+                reduce_post_tail();
+
+                sub(reg_total_work_amount, reg_channel_size);
+                jmp(reduce_nspc_loop_label, T_NEAR);
+            }
+            L(reduce_nspc_loop_end_label);
+        } else {
+            reduce_post_main();
             reduce_post_tail();
+        }
 
         this->postamble();
 
@@ -874,22 +1127,32 @@ struct jit_uni_reduce_post_kernel_f32 : public jit_uni_reduce_post_kernel, publi
         if (jcp_.reduce_mode == ReduceLogSum || jcp_.reduce_mode == ReduceLogSumExp) {
             log_injector->prepare_table();
         }
+
+        for (auto& inj : eltwise_injectors)
+            inj->prepare_table();
     }
 
 private:
     using Vmm = typename conditional3<isa == cpu::x64::sse41, Xbyak::Xmm, isa == cpu::x64::avx2,
             Xbyak::Ymm, Xbyak::Zmm>::type;
     size_t vlen = cpu_isa_traits<isa>::vlen;
+    bool planar_layout;
 
     Xbyak::Reg64 reg_dst = r8;
     Xbyak::Reg64 reg_work_amount = r9;
-    Xbyak::Reg64 reg_divisor = r10;
-    Xbyak::Reg64 reg_reduce_c = r11;
+    Xbyak::Reg64 reg_total_work_amount = r10;
+    Xbyak::Reg64 reg_channel_size = r11;
+    Xbyak::Reg64 reg_divisor = r12;
+    Xbyak::Reg64 reg_reduce_c = r13;
     Xbyak::Reg64 reg_params = abi_param1;
 
-    Xbyak::Reg8 reg_tmp_8 = r12b;
-    Xbyak::Reg32 reg_tmp_32 = r12d;
-    Xbyak::Reg64 reg_tmp_64 = r12;
+    Xbyak::Reg8 reg_tmp_8 = r14b;
+    Xbyak::Reg32 reg_tmp_32 = r14d;
+    Xbyak::Reg64 reg_tmp_64 = r14;
+
+    Xbyak::Reg64 reg_oc_off = rax;
+    Xbyak::Reg64 reg_d_weights = rbx;
+    Xbyak::Reg64 reg_d_bias = rdx;
 
     Vmm vmm_aux = Vmm(0);
     Xmm xmm_aux = Xmm(0);
@@ -901,14 +1164,20 @@ private:
     Xbyak::Xmm xmm_aux2 = Xbyak::Xmm(5);
     Xbyak::Xmm xmm_aux3 = Xbyak::Xmm(6);
 
-    std::unique_ptr<jit_emu_vcvtneps2bf16> emu_vcvtneps2bf16;
+    Vmm vmm_d_weights = Vmm(7);
+    Vmm vmm_d_bias = Vmm(8);
 
+    std::shared_ptr<jit_emu_vcvtneps2bf16> emu_vcvtneps2bf16;
     std::shared_ptr<jit_uni_eltwise_injector_f32<isa>> log_injector;
+
+    std::vector<std::shared_ptr<jit_uni_eltwise_injector_f32<isa>>> eltwise_injectors;
+    std::vector<std::shared_ptr<jit_uni_depthwise_injector_f32<isa>>> depthwise_injectors;
+    std::vector<std::shared_ptr<jit_uni_quantization_injector_f32<isa>>> quantization_injectors;
 
     inline void reduce_post_main() {
         Xbyak::Label reduce_channel_label;
         Xbyak::Label reduce_map_label;
-        if (jcp_.planar_layout) {
+        if (planar_layout) {
             jmp(reduce_map_label, T_NEAR);
         } else {
             cmp(reg_reduce_c, 1);
@@ -937,7 +1206,7 @@ private:
                 // reduce and store
                 horiz_reduce_store(vmm_dst, jcp_.dst_dt);
                 if (isa == cpu::x64::sse41)
-                    load_embedded_horiz_reduce_store(vmm_dst_aux, jcp_.dst_dt);
+                    horiz_reduce_store(vmm_dst_aux, jcp_.dst_dt, true);
 
                 add(reg_dst, step * jcp_.dst_data_size);
                 sub(reg_work_amount, step);
@@ -946,8 +1215,8 @@ private:
             }
             L(reduce_loop_end_label);
 
-            mov(reg_dst, ptr[reg_params + GET_OFF(dst)]);
-            mov(reg_work_amount, ptr[reg_params + GET_OFF(work_amount)]);
+            mov(reg_dst, ptr[reg_params + GET_OFF_POST(dst)]);
+            mov(reg_work_amount, ptr[reg_params + GET_OFF_POST(work_amount)]);
         }
 
         // reduce map for value in dst memory
@@ -968,27 +1237,67 @@ private:
                     cmp(reg_work_amount, step);
                     jl(reduce_loop_end_label, T_NEAR);
 
-                    // load
                     load_vector(vmm_dst, ptr[reg_dst], jcp_.dst_dt);
-                    if (isa == cpu::x64::sse41)
-                        load_vector(vmm_dst_aux, ptr[reg_dst + 4 * jcp_.dst_data_size], jcp_.dst_dt);
-
-                    // reduce
                     reduce_map_kernel(vmm_dst);
-                    if (isa == cpu::x64::sse41)
-                        reduce_map_kernel(vmm_dst_aux);
-
-                    // store
+                    if (attr_.post_ops_.len() != 0)
+                        apply_post_ops(jcp_.dst_dt, jcp_.layout == ReduceLayoutType::reduce_ncsp);
                     store_vector(ptr[reg_dst], vmm_dst, jcp_.dst_dt);
-                    if (isa == cpu::x64::sse41)
-                        store_vector(ptr[reg_dst + 4 * jcp_.dst_data_size], vmm_dst_aux, jcp_.dst_dt);
+
+                    if (isa == cpu::x64::sse41) {
+                        load_vector(vmm_dst, ptr[reg_dst + 4 * jcp_.dst_data_size], jcp_.dst_dt);
+                        reduce_map_kernel(vmm_dst);
+                        if (attr_.post_ops_.len() != 0) {
+                            if (jcp_.layout != ReduceLayoutType::reduce_ncsp)
+                                add(reg_oc_off, 4 * sizeof(float));
+                            apply_post_ops(jcp_.dst_dt, jcp_.layout == ReduceLayoutType::reduce_ncsp);
+                            if (jcp_.layout != ReduceLayoutType::reduce_ncsp)
+                                sub(reg_oc_off, 4 * sizeof(float));
+                        }
+                        store_vector(ptr[reg_dst + 4 * jcp_.dst_data_size], vmm_dst, jcp_.dst_dt);
+                    }
 
                     add(reg_dst, step * jcp_.dst_data_size);
+                    if (jcp_.layout == ReduceLayoutType::reduce_nspc && attr_.post_ops_.len() != 0)
+                        add(reg_oc_off, step * sizeof(float));
                     sub(reg_work_amount, step);
 
                     jmp(reduce_loop_label, T_NEAR);
                 }
                 L(reduce_loop_end_label);
+            } else {
+                if (attr_.post_ops_.len() != 0) {
+                    Xbyak::Label reduce_loop_label;
+                    Xbyak::Label reduce_loop_end_label;
+
+                    int step = vlen / sizeof(float) < 8 ? 8 : vlen / sizeof(float);
+                    L(reduce_loop_label);
+                    {
+                        cmp(reg_work_amount, step);
+                        jl(reduce_loop_end_label, T_NEAR);
+
+                        load_vector(vmm_dst, ptr[reg_dst], jcp_.dst_dt);
+                        apply_post_ops(jcp_.dst_dt, jcp_.layout == ReduceLayoutType::reduce_ncsp);
+                        store_vector(ptr[reg_dst], vmm_dst, jcp_.dst_dt);
+
+                        if (isa == cpu::x64::sse41) {
+                            load_vector(vmm_dst, ptr[reg_dst + 4 * jcp_.dst_data_size], jcp_.dst_dt);
+                            if (jcp_.layout != ReduceLayoutType::reduce_ncsp)
+                                add(reg_oc_off, 4 * sizeof(float));
+                            apply_post_ops(jcp_.dst_dt, jcp_.layout == ReduceLayoutType::reduce_ncsp);
+                            if (jcp_.layout != ReduceLayoutType::reduce_ncsp)
+                                sub(reg_oc_off, 4 * sizeof(float));
+                            store_vector(ptr[reg_dst + 4 * jcp_.dst_data_size], vmm_dst, jcp_.dst_dt);
+                        }
+
+                        add(reg_dst, step * jcp_.dst_data_size);
+                        if (jcp_.layout == ReduceLayoutType::reduce_nspc && attr_.post_ops_.len() != 0)
+                            add(reg_oc_off, step * sizeof(float));
+                        sub(reg_work_amount, step);
+
+                        jmp(reduce_loop_label, T_NEAR);
+                    }
+                    L(reduce_loop_end_label);
+                }
             }
         }
     }
@@ -1017,14 +1326,84 @@ private:
                 reduce_map_kernel_scalar(xmm_dst);
 
                 // store
+                if (attr_.post_ops_.len() != 0)
+                    apply_post_ops(jcp_.dst_dt, jcp_.layout == ReduceLayoutType::reduce_ncsp);
                 store_scalar(ptr[reg_dst], xmm_dst, jcp_.dst_dt);
 
                 add(reg_dst, step * jcp_.dst_data_size);
+                if (jcp_.layout == ReduceLayoutType::reduce_nspc && attr_.post_ops_.len() != 0)
+                    add(reg_oc_off, step * sizeof(float));
                 sub(reg_work_amount, step);
 
                 jmp(reduce_loop_label, T_NEAR);
             }
             L(reduce_loop_end_label);
+        } else {
+            if (attr_.post_ops_.len() != 0) {
+                Xbyak::Label reduce_loop_label;
+                Xbyak::Label reduce_loop_end_label;
+
+                int step = 1;
+                L(reduce_loop_label);
+                {
+                    cmp(reg_work_amount, step);
+                    jl(reduce_loop_end_label, T_NEAR);
+
+                    // load
+                    load_scalar(xmm_dst, ptr[reg_dst], jcp_.dst_dt);
+
+                    // store
+                    apply_post_ops(jcp_.dst_dt, jcp_.layout == ReduceLayoutType::reduce_ncsp);
+                    store_scalar(ptr[reg_dst], xmm_dst, jcp_.dst_dt);
+
+                    add(reg_dst, step * jcp_.dst_data_size);
+                    if (jcp_.layout == ReduceLayoutType::reduce_nspc && attr_.post_ops_.len() != 0)
+                        add(reg_oc_off, step * sizeof(float));
+                    sub(reg_work_amount, step);
+
+                    jmp(reduce_loop_label, T_NEAR);
+                }
+                L(reduce_loop_end_label);
+            }
+        }
+    }
+
+    void apply_post_ops(memory::data_type dst_dt, bool is_broadcast) {
+        const auto &p = attr_.post_ops_;
+        int eltwise_inj_idx = 0;
+        int depthwise_inj_idx = 0;
+        int quantization_inj_idx = 0;
+        for (int i = 0; i < p.len(); i++) {
+            auto& post_op = p.entry_[i];
+            if (post_op.is_eltwise()) {
+                eltwise_injectors[eltwise_inj_idx]->compute_vector_range(vmm_dst.getIdx(), vmm_dst.getIdx() + 1);
+                eltwise_inj_idx++;
+            } else if (post_op.is_depthwise()) {
+                mov(reg_d_weights, reinterpret_cast<size_t>(post_op.depthwise.weights_data));
+                mov(reg_d_bias, reinterpret_cast<size_t>(post_op.depthwise.biases_data));
+                add(reg_d_weights, reg_oc_off);
+                add(reg_d_bias, reg_oc_off);
+                depthwise_injectors[depthwise_inj_idx]->compute_vector_range(vmm_dst.getIdx(), vmm_dst.getIdx() + 1, reg_d_weights, reg_d_bias, is_broadcast);
+                depthwise_inj_idx++;
+            } else if (post_op.is_quantization()) {
+                bool do_dequantization = post_op.quantization.alg == alg_kind::quantization_quantize_dequantize;
+                bool do_rounding = do_dequantization || isFloatCompatible(dst_dt) || i != p.len() - 1;
+
+                int s_idx = vmm_dst.getIdx();
+
+                quantization_injectors[quantization_inj_idx]->init_crop_ptrs(reg_oc_off);
+                quantization_injectors[quantization_inj_idx]->compute_crop(s_idx, s_idx + 1, 0, 0, is_broadcast);
+
+                quantization_injectors[quantization_inj_idx]->init_input_scale_shift_ptrs(reg_oc_off);
+                quantization_injectors[quantization_inj_idx]->compute_input_scale_shift(s_idx, s_idx + 1, 0, do_rounding, 0, is_broadcast);
+
+                if (do_dequantization) {
+                    quantization_injectors[quantization_inj_idx]->init_output_scale_shift_ptrs(reg_oc_off);
+                    quantization_injectors[quantization_inj_idx]->compute_output_scale_shift(s_idx, s_idx + 1, 0, 0, is_broadcast);
+                }
+
+                quantization_inj_idx++;
+            }
         }
     }
 
@@ -1074,19 +1453,19 @@ private:
         switch (src_dt) {
             case memory::data_type::f32:
             case memory::data_type::s32:
-                movss(xmm_src, op);
+                uni_vmovss(xmm_src, op);
                 break;
             case memory::data_type::bf16:
-                pinsrw(xmm_src, op, 0x0);
+                uni_vpinsrw(xmm_src, xmm_src, op, 0x0);
                 uni_vpslld(xmm_src, xmm_src, 16);
                 break;
             case memory::data_type::s8:
                 movsx(reg_tmp_32, op);
-                movq(xmm_src, reg_tmp_64);
+                uni_vmovq(xmm_src, reg_tmp_64);
                 break;
             case memory::data_type::u8:
                 movzx(reg_tmp_32, op);
-                movq(xmm_src, reg_tmp_64);
+                uni_vmovq(xmm_src, reg_tmp_64);
                 break;
             default:
                 assert(!"unknown src_dt");
@@ -1129,7 +1508,7 @@ private:
                     if (isa != cpu::x64::sse41)
                         vmovq(op, xmm_dst);
                     else
-                        movd(op, xmm_dst);
+                        uni_vmovd(op, xmm_dst);
                 }
                 break;
             case memory::data_type::u8:
@@ -1143,7 +1522,7 @@ private:
                     if (isa != cpu::x64::sse41)
                         vmovq(op, xmm_dst);
                     else
-                        movd(op, xmm_dst);
+                        uni_vmovd(op, xmm_dst);
                 }
                 break;
             default:
@@ -1159,22 +1538,22 @@ private:
         switch (dst_dt) {
             case memory::data_type::f32:
             case memory::data_type::s32:
-                movss(op, xmm_dst);
+                uni_vmovss(op, xmm_dst);
                 break;
             case memory::data_type::bf16:
                 uni_vpsrld(xmm_dst, xmm_dst, 16);
-                pextrw(op, xmm_dst, 0x0);
+                uni_vpextrw(op, xmm_dst, 0x0);
                 break;
             case memory::data_type::s8:
                 uni_vpackssdw(xmm_dst, xmm_dst, xmm_dst);
                 uni_vpacksswb(xmm_dst, xmm_dst, xmm_dst);
-                movq(reg_tmp_64, xmm_dst);
+                uni_vmovq(reg_tmp_64, xmm_dst);
                 mov(op, reg_tmp_8);
                 break;
             case memory::data_type::u8:
                 uni_vpackusdw(xmm_dst, xmm_dst, xmm_dst);
                 uni_vpackuswb(xmm_dst, xmm_dst, xmm_dst);
-                movq(reg_tmp_64, xmm_dst);
+                uni_vmovq(reg_tmp_64, xmm_dst);
                 mov(op, reg_tmp_8);
                 break;
             default:
@@ -1182,15 +1561,15 @@ private:
         }
     }
 
-    inline void horiz_reduce_store(Vmm vmm_dst, memory::data_type dst_dt) {
+    inline void horiz_reduce_store(Vmm vmm_dst, memory::data_type dst_dt, bool load_embedded = false) {
         if (isa == cpu::x64::sse41) {
-            horize_store(vmm_dst, dst_dt);
+            horiz_store(vmm_dst, dst_dt, load_embedded);
         } else if (isa == cpu::x64::avx2) {
             Xbyak::Ymm ymm_dst = Xbyak::Ymm(vmm_dst.getIdx());
             vextractf128(xmm_aux1, ymm_dst, 0);
             vextractf128(xmm_aux2, ymm_dst, 1);
             horiz_ps(xmm_aux1, xmm_aux2);
-            horize_store(xmm_aux1, dst_dt);
+            horiz_store(xmm_aux1, dst_dt, load_embedded);
         } else {
             Xbyak::Zmm zmm_dst = Xbyak::Zmm(vmm_dst.getIdx());
             vextractf32x4(xmm_aux1, zmm_dst, 0);
@@ -1200,107 +1579,26 @@ private:
             vextractf32x4(xmm_aux3, zmm_dst, 3);
             horiz_ps(xmm_aux2, xmm_aux3);
             horiz_ps(xmm_aux1, xmm_aux2);
-            horize_store(xmm_aux1, dst_dt);
+            horiz_store(xmm_aux1, dst_dt, load_embedded);
         }
     }
 
-    inline void horize_store(Xbyak::Xmm xmm_dst, memory::data_type dst_dt) {
-        movshdup(xmm_aux3, xmm_dst); // dst:1,2,3,4; aux3:2,2,4,4
-        horiz_ps(xmm_dst, xmm_aux3); // dst:f(1,2),f(2,2),f(3,4),f(4,4)
-        movhlps(xmm_aux3, xmm_dst);  // aux3:f(3,4),f(4,4),4,4
-        horiz_ps(xmm_dst, xmm_aux3); // dst:f(1,2,3,4),...
-        switch (dst_dt) {
-            case memory::data_type::f32:
-                movss(ptr[reg_dst], xmm_dst);
-                break;
-            case memory::data_type::bf16:
-                uni_vpsrld(xmm_dst, xmm_dst, 16);
-                pextrw(ptr[reg_dst], xmm_dst, 0x0);
-                break;
-            case memory::data_type::s32:
-                uni_vcvtps2dq(xmm_dst, xmm_dst);
-                movss(ptr[reg_dst], xmm_dst);
-                break;
-            case memory::data_type::u8:
-                uni_vcvtps2dq(xmm_dst, xmm_dst);
-                uni_vpackusdw(xmm_dst, xmm_dst, xmm_dst);
-                uni_vpackuswb(xmm_dst, xmm_dst, xmm_dst);
-                pextrb(ptr[reg_dst], xmm_dst, 0);
-                break;
-            case memory::data_type::s8:
-                uni_vcvtps2dq(xmm_dst, xmm_dst);
-                uni_vpackssdw(xmm_dst, xmm_dst, xmm_dst);
-                uni_vpacksswb(xmm_dst, xmm_dst, xmm_dst);
-                pextrb(ptr[reg_dst], xmm_dst, 0);
-                break;
-            default:
-                assert(!"unknown dst_dt");
+    inline void horiz_store(Xbyak::Xmm xmm_dst, memory::data_type dst_dt, bool load_embedded) {
+        uni_movshdup(xmm_aux3, xmm_dst); // dst:1,2,3,4; aux3:2,2,4,4
+        horiz_ps(xmm_dst, xmm_aux3);     // dst:f(1,2),f(2,2),f(3,4),f(4,4)
+        uni_movhlps(xmm_aux3, xmm_dst);  // aux3:f(3,4),f(4,4),4,4
+        horiz_ps(xmm_dst, xmm_aux3);     // dst:f(1,2,3,4),...
+        if (load_embedded) {
+            load_scalar(xmm_aux3, ptr[reg_dst], dst_dt);
+            horiz_ps(xmm_dst, xmm_aux3);
         }
-    }
-
-    inline void load_embedded_horiz_reduce_store(Vmm vmm_dst, memory::data_type dst_dt) {
-        if (isa == cpu::x64::sse41) {
-            load_embedded_horiz_store(vmm_dst, dst_dt);
-        } else if (isa == cpu::x64::avx2) {
-            Xbyak::Ymm ymm_dst = Xbyak::Ymm(vmm_dst.getIdx());
-            vextractf128(xmm_aux1, ymm_dst, 0);
-            vextractf128(xmm_aux2, ymm_dst, 1);
-            horiz_ps(xmm_aux1, xmm_aux2);
-            load_embedded_horiz_store(xmm_aux1, dst_dt);
-        } else {
-            Xbyak::Zmm zmm_dst = Xbyak::Zmm(vmm_dst.getIdx());
-            vextractf32x4(xmm_aux1, zmm_dst, 0);
-            vextractf32x4(xmm_aux2, zmm_dst, 1);
-            horiz_ps(xmm_aux1, xmm_aux2);
-            vextractf32x4(xmm_aux2, zmm_dst, 2);
-            vextractf32x4(xmm_aux3, zmm_dst, 3);
-            horiz_ps(xmm_aux2, xmm_aux3);
-            horiz_ps(xmm_aux1, xmm_aux2);
-            load_embedded_horiz_store(xmm_aux1, dst_dt);
-        }
-    }
-
-    inline void load_embedded_horiz_store(Xbyak::Xmm xmm_dst, memory::data_type dst_dt) {
-        movshdup(xmm_aux3, xmm_dst); // dst:1,2,3,4; aux3:2,2,4,4
-        horiz_ps(xmm_dst, xmm_aux3); // dst:f(1,2),f(2,2),f(3,4),f(4,4)
-        movhlps(xmm_aux3, xmm_dst);  // aux3:f(3,4),f(4,4),4,4
-        horiz_ps(xmm_dst, xmm_aux3); // dst:f(1,2,3,4),...
-        load_scalar(xmm_aux3, ptr[reg_dst], dst_dt);
-
-        switch (dst_dt) {
-            case memory::data_type::f32:
-            case memory::data_type::bf16:
-                horiz_ps(xmm_dst, xmm_aux3);
-                store_scalar(ptr[reg_dst], xmm_dst, dst_dt);
-                break;
-            case memory::data_type::s32:
-                horiz_ps(xmm_dst, xmm_aux3);
-                uni_vcvtps2dq(xmm_dst, xmm_dst);
-                movss(ptr[reg_dst], xmm_dst);
-                break;
-            case memory::data_type::u8:
-                horiz_ps(xmm_dst, xmm_aux3);
-                uni_vcvtps2dq(xmm_dst, xmm_dst);
-                uni_vpackusdw(xmm_dst, xmm_dst, xmm_dst);
-                uni_vpackuswb(xmm_dst, xmm_dst, xmm_dst);
-                pextrb(ptr[reg_dst], xmm_dst, 0);
-                break;
-            case memory::data_type::s8:
-                horiz_ps(xmm_dst, xmm_aux3);
-                uni_vcvtps2dq(xmm_dst, xmm_dst);
-                uni_vpackssdw(xmm_dst, xmm_dst, xmm_dst);
-                uni_vpacksswb(xmm_dst, xmm_dst, xmm_dst);
-                pextrb(ptr[reg_dst], xmm_dst, 0);
-                break;
-            default:
-                assert(!"unknown dst_dt");
-        }
+        store_scalar(ptr[reg_dst], xmm_dst, dst_dt);
     }
 
     inline void horiz_ps(const Xmm& xmm, const Operand& op) {
         switch (jcp_.reduce_mode) {
             case ReduceAnd:
-                andps(xmm, op);
+                uni_vandps(xmm, xmm, op);
                 break;
             case ReduceL1:
             case ReduceL2:
@@ -1309,19 +1607,19 @@ private:
             case ReduceSum:
             case ReduceSumSquare:
             case ReduceLogSumExp:
-                addps(xmm, op);
+                uni_vaddps(xmm, xmm, op);
                 break;
             case ReduceMax:
-                maxps(xmm, op);
+                uni_vmaxps(xmm, xmm, op);
                 break;
             case ReduceMin:
-                minps(xmm, op);
+                uni_vminps(xmm, xmm, op);
                 break;
             case ReduceOr:
-                orps(xmm, op);
+                uni_vorps(xmm, xmm, op);
                 break;
             case ReduceProd:
-                mulps(xmm, op);
+                uni_vmulps(xmm, xmm, op);
                 break;
             default:
                 assert(!"unsupported reduce mode");
@@ -1370,6 +1668,20 @@ bool MKLDNNReduceNode::isSupportedOperation(const std::shared_ptr<const ngraph::
             errorMessage = "Reduce node with name " + op->get_friendly_name() + " is not derived from ArithmeticReductionKeepDims or LogicalReductionKeepDims";
             return false;
         }
+        if (const auto reduce = std::dynamic_pointer_cast<const ngraph::op::util::ArithmeticReductionKeepDims>(op)) {
+            auto reduceConst = std::dynamic_pointer_cast<const ngraph::opset1::Constant>(reduce->get_input_node_shared_ptr(REDUCE_INDEXES));
+            if (!reduceConst) {
+                errorMessage = "Second tensor is not constant";
+                return false;
+            }
+        }
+        if (const auto reduce = std::dynamic_pointer_cast<const ngraph::op::util::LogicalReductionKeepDims>(op)) {
+            auto reduceConst = std::dynamic_pointer_cast<const ngraph::opset1::Constant>(reduce->get_input_node_shared_ptr(REDUCE_INDEXES));
+            if (!reduceConst) {
+                errorMessage = "Second tensor is not constant";
+                return false;
+            }
+        }
         if (initializers.find(op->get_type_info()) == initializers.end()) {
             errorMessage = "Doesn't support Reduce algorithm: " +  std::string(op->get_type_info().name);
             return false;
@@ -1392,9 +1704,12 @@ MKLDNNReduceNode::MKLDNNReduceNode(const std::shared_ptr<ngraph::Node>& op, cons
         initializers.at(op->get_type_info())(op, *this);
         if (const auto reduce = std::dynamic_pointer_cast<ngraph::op::util::ArithmeticReductionKeepDims>(op)) {
             keep_dims = reduce->get_keep_dims();
+            raw_axes = std::dynamic_pointer_cast<const ngraph::opset1::Constant>(reduce->get_input_node_shared_ptr(REDUCE_INDEXES))->cast_vector<int>();
         } else if (const auto reduce = std::dynamic_pointer_cast<ngraph::op::util::LogicalReductionKeepDims>(op)) {
             keep_dims = reduce->get_keep_dims();
+            raw_axes = std::dynamic_pointer_cast<const ngraph::opset1::Constant>(reduce->get_input_node_shared_ptr(REDUCE_INDEXES))->cast_vector<int>();
         }
+        setJITBeyond5D();
     } else {
         IE_THROW(NotImplemented) << errorMessage;
     }
@@ -1403,6 +1718,8 @@ MKLDNNReduceNode::MKLDNNReduceNode(const std::shared_ptr<ngraph::Node>& op, cons
 void MKLDNNReduceNode::getSupportedDescriptors() {
     if (!descs.empty())
         return;
+
+    setPostOps(attr, true);
 
     if (getParentEdges().size() != 2)
         IE_THROW() << errorPrefix << " gets incorrect number of input edges!";
@@ -1429,38 +1746,30 @@ void MKLDNNReduceNode::initSupportedPrimitiveDescriptors() {
     if (!supportedPrimitiveDescriptors.empty())
         return;
 
-    static const Precision supportedPrecisions[] = {
-            Precision::FP32,
-            Precision::BF16,
-            Precision::I32,
-            Precision::I8,
-            Precision::U8
-    };
+    input_prec = getOriginalInputPrecisionAtPort(REDUCE_DATA);
+    output_prec = getOriginalOutputPrecisionAtPort(0);
 
-    Precision inputPrecision = getOriginalInputPrecisionAtPort(REDUCE_DATA);
-    Precision outputPrecision = getOriginalOutputPrecisionAtPort(0);
+    if (!fusedWith.empty()) {
+        output_prec = fusedWith[fusedWith.size() - 1]->getOriginalOutputPrecisionAtPort(0);
+    }
 
-    jit_mode = (mayiuse(cpu::x64::sse41)) && getInputShapeAtPort(REDUCE_DATA).getRank() <= 5 &&
-               std::find(std::begin(supportedPrecisions), std::end(supportedPrecisions), inputPrecision) != std::end(supportedPrecisions) &&
-               std::find(std::begin(supportedPrecisions), std::end(supportedPrecisions), outputPrecision) != std::end(supportedPrecisions);
+    jit_mode = canApplyJIT(input_prec, output_prec);
 
     if (jit_mode) {
         // Since in jit mode we use the output memory as an intermediate accumulator for certain reduce modes, we can't use BF16 output precision due to
         // the possible accuracy loss. Therefore, for such mods, we will change the output precision to FP32.
-        if (Precision::BF16 == outputPrecision) {
+        if (Precision::BF16 == output_prec) {
             if (!mayiuse(avx512_core)) {
-                    outputPrecision = Precision::FP32;
+                    output_prec = Precision::FP32;
             } else if (algorithm != ReduceAnd && algorithm != ReduceOr &&
                        algorithm != ReduceMin && algorithm != ReduceMax) {
-                            outputPrecision = Precision::FP32;
+                            output_prec = Precision::FP32;
             }
         }
     }
 
-    input_prec = inputPrecision;
-    output_prec = outputPrecision;
-    src_data_size = inputPrecision.size();
-    dst_data_size = outputPrecision.size();
+    src_data_size = input_prec.size();
+    dst_data_size = output_prec.size();
 
     NodeConfig config;
     config.dynBatchSupport = false;
@@ -1475,12 +1784,12 @@ void MKLDNNReduceNode::initSupportedPrimitiveDescriptors() {
 
     auto& creatorsMap = BlockedDescCreator::getCommonCreators();
 
-    auto pushDesc = [&](LayoutType inFormat, LayoutType outFormat, InferenceEngine::Precision inDataType,
-            InferenceEngine::Precision outDataType, impl_desc_type impl_type) {
-        config.inConfs[REDUCE_DATA].desc = creatorsMap.at(inFormat)->createSharedDesc(inDataType, getInputShapeAtPort(REDUCE_DATA));
+    auto pushDesc = [&](LayoutType inFormat, LayoutType outFormat, InferenceEngine::Precision inPrecision,
+            InferenceEngine::Precision outPrecision, impl_desc_type impl_type) {
+        config.inConfs[REDUCE_DATA].desc = creatorsMap.at(inFormat)->createSharedDesc(inPrecision, getInputShapeAtPort(REDUCE_DATA));
         config.inConfs[REDUCE_INDEXES].desc = creatorsMap.at(LayoutType::ncsp)->createSharedDesc(InferenceEngine::Precision::I32,
                                                                                                  getInputShapeAtPort(REDUCE_INDEXES));
-        config.outConfs[0].desc = creatorsMap.at(outFormat)->createSharedDesc(outDataType, getOutputShapeAtPort(0));
+        config.outConfs[0].desc = creatorsMap.at(outFormat)->createSharedDesc(outPrecision, getOutputShapeAtPort(0));
         supportedPrimitiveDescriptors.push_back({config, impl_type});
     };
 
@@ -1492,14 +1801,24 @@ void MKLDNNReduceNode::initSupportedPrimitiveDescriptors() {
             impl_type = impl_desc_type::jit_avx2;
         }
 
-        pushDesc(LayoutType::ncsp, LayoutType::ncsp, inputPrecision, outputPrecision, impl_type);
-        if (keep_dims) {
-            if ((getInputShapeAtPort(REDUCE_DATA).getRank() == 4 || getInputShapeAtPort(REDUCE_DATA).getRank() == 5) &&
-                    getInputShapeAtPort(REDUCE_DATA).getStaticDims()[1] > 1) {
+        pushDesc(LayoutType::ncsp, LayoutType::ncsp, input_prec, output_prec, impl_type);
+        if ((getInputShapeAtPort(REDUCE_DATA).getRank() == 4 || getInputShapeAtPort(REDUCE_DATA).getRank() == 5) &&
+                getInputShapeAtPort(REDUCE_DATA).getStaticDims()[1] > 1) {
+            if (keep_dims) {
                 if (mayiuse(cpu::x64::avx512_common)) {
-                    pushDesc(LayoutType::nCsp16c, LayoutType::nCsp16c, inputPrecision, outputPrecision, impl_type);
+                    pushDesc(LayoutType::nspc, LayoutType::nspc, input_prec, output_prec, impl_type);
+                    pushDesc(LayoutType::nCsp16c, LayoutType::nCsp16c, input_prec, output_prec, impl_type);
                 } else if (mayiuse(cpu::x64::avx2) || mayiuse(cpu::x64::sse41)) {
-                    pushDesc(LayoutType::nCsp8c, LayoutType::nCsp8c, inputPrecision, outputPrecision, impl_type);
+                    pushDesc(LayoutType::nspc, LayoutType::nspc, input_prec, output_prec, impl_type);
+                    pushDesc(LayoutType::nCsp8c, LayoutType::nCsp8c, input_prec, output_prec, impl_type);
+                }
+            } else {
+                if (mayiuse(cpu::x64::avx512_common)) {
+                    pushDesc(LayoutType::nspc, LayoutType::ncsp, input_prec, output_prec, impl_type);
+                    pushDesc(LayoutType::nCsp16c, LayoutType::ncsp, input_prec, output_prec, impl_type);
+                } else if (mayiuse(cpu::x64::avx2) || mayiuse(cpu::x64::sse41)) {
+                    pushDesc(LayoutType::nspc, LayoutType::ncsp, input_prec, output_prec, impl_type);
+                    pushDesc(LayoutType::nCsp8c, LayoutType::ncsp, input_prec, output_prec, impl_type);
                 }
             }
         }
@@ -1510,37 +1829,59 @@ void MKLDNNReduceNode::initSupportedPrimitiveDescriptors() {
 
 void MKLDNNReduceNode::createPrimitive() {
     auto &dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
-    auto &srcDataMemPtr = getParentEdgeAt(REDUCE_DATA)->getMemoryPtr();
-    auto &srcIndexesMemPtr = getParentEdgeAt(REDUCE_INDEXES)->getMemoryPtr();
+    auto &srcMemPtr = getParentEdgeAt(REDUCE_DATA)->getMemoryPtr();
     if (!dstMemPtr || !dstMemPtr->GetPrimitivePtr())
         IE_THROW() << errorPrefix << " has not allocated destination memory.";
-    if (!srcDataMemPtr || !srcDataMemPtr->GetPrimitivePtr() || !srcIndexesMemPtr || !srcIndexesMemPtr->GetPrimitivePtr())
+    if (!srcMemPtr || !srcMemPtr->GetPrimitivePtr())
         IE_THROW() << errorPrefix << " has not allocate input memory.";
     if (getSelectedPrimitiveDescriptor() == nullptr)
         IE_THROW() << errorPrefix << " has nullable preferable primitive descriptor";
 
-    auto selectedPD = getSelectedPrimitiveDescriptor();
-    planar_layout = getParentEdgeAt(REDUCE_DATA)->getMemory().getDesc().hasLayoutType(LayoutType::ncsp);
+    if (getParentEdgeAt(REDUCE_DATA)->getMemory().getDesc().hasLayoutType(LayoutType::ncsp)) {
+        layout = ReduceLayoutType::reduce_ncsp;
+    } else if (getParentEdgeAt(REDUCE_DATA)->getMemory().getDesc().hasLayoutType(LayoutType::nspc)) {
+        layout = ReduceLayoutType::reduce_nspc;
+    } else {
+        layout = ReduceLayoutType::reduce_blocked;
+    }
+
+    // hybrid layout: nspc/blocked layout for input and ncsp for output
+    // !keep_dims is needed to avoid hybrid layout for cases eg. (A, B, C, D) reduce to (A, 1, 1, 1)
+    if (!keep_dims && (layout == ReduceLayoutType::reduce_nspc || layout == ReduceLayoutType::reduce_blocked)) {
+        is_hybrid_layout = getChildEdgeAt(REDUCE_DATA)->getMemory().getDesc().hasLayoutType(LayoutType::ncsp);
+    }
+
+    src_dims = getInputShapeAtPort(REDUCE_DATA).getStaticDims();
+    if (jit_mode && jit_beyond_5D) {
+        update_src_dims();
+    }
+
+    dst_size = dstMemPtr->GetSize();
+    calc_process_dst_dims();
+    if (jit_mode) {
+        set_reduce_dim_flags();
+    }
 
     auto jcp = jit_reduce_config_params();
+    auto selectedPD = getSelectedPrimitiveDescriptor();
     jcp.src_dt = MKLDNNExtensionUtils::IEPrecisionToDataType(selectedPD->getConfig().inConfs[REDUCE_DATA].desc->getPrecision());
     jcp.dst_dt = MKLDNNExtensionUtils::IEPrecisionToDataType(selectedPD->getConfig().outConfs[0].desc->getPrecision());
     jcp.src_data_size = MKLDNNExtensionUtils::sizeOfDataType(jcp.src_dt);
     jcp.dst_data_size = MKLDNNExtensionUtils::sizeOfDataType(jcp.dst_dt);
-    jcp.planar_layout = planar_layout;
+    jcp.layout = layout;
     jcp.reduce_mode = getAlgorithm();
 
     if (mayiuse(cpu::x64::avx512_common)) {
         reduce_kernel.reset(new jit_uni_reduce_kernel_f32<cpu::x64::avx512_common>(jcp));
-        reduce_post_kernel.reset(new jit_uni_reduce_post_kernel_f32<cpu::x64::avx512_common>(jcp));
+        reduce_post_kernel.reset(new jit_uni_reduce_post_kernel_f32<cpu::x64::avx512_common>(jcp, *attr.get()));
         blk_size = 16;
     } else if (mayiuse(cpu::x64::avx2)) {
         reduce_kernel.reset(new jit_uni_reduce_kernel_f32<cpu::x64::avx2>(jcp));
-        reduce_post_kernel.reset(new jit_uni_reduce_post_kernel_f32<cpu::x64::avx2>(jcp));
+        reduce_post_kernel.reset(new jit_uni_reduce_post_kernel_f32<cpu::x64::avx2>(jcp, *attr.get()));
         blk_size = 8;
     } else if (mayiuse(cpu::x64::sse41)) {
         reduce_kernel.reset(new jit_uni_reduce_kernel_f32<cpu::x64::sse41>(jcp));
-        reduce_post_kernel.reset(new jit_uni_reduce_post_kernel_f32<cpu::x64::sse41>(jcp));
+        reduce_post_kernel.reset(new jit_uni_reduce_post_kernel_f32<cpu::x64::sse41>(jcp, *attr.get()));
         blk_size = 8;
     }
 
@@ -1550,52 +1891,23 @@ void MKLDNNReduceNode::createPrimitive() {
     if (reduce_post_kernel)
         reduce_post_kernel->create_ker();
 
-    jit_mode = jit_mode && reduce_kernel;
+    jit_mode = jit_mode && reduce_kernel && reduce_post_kernel;
 }
 
 void MKLDNNReduceNode::execute(mkldnn::stream strm) {
     auto &dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
     auto &srcMemPtr = getParentEdgeAt(REDUCE_DATA)->getMemoryPtr();
-    auto &srcIndexesMemPtr = getParentEdgeAt(REDUCE_INDEXES)->getMemoryPtr();
-
-    const auto idx_data = reinterpret_cast<const int32_t *>(srcIndexesMemPtr->GetData());
-    size_t dst_size = dstMemPtr->GetSize();
-    src_dims = getParentEdgeAt(REDUCE_DATA)->getMemory().getStaticDims();
-    src_strides = getParentEdgeAt(REDUCE_DATA)->getMemory().GetDescWithType<BlockedMemoryDesc>()->getStrides();
-    dims_size = src_dims.size();
-    calc_process_dst_dims(idx_data);
-
-    if (dims_size <= 5) {
-        if (dims_size == 5) {
-            SET_SRC_DIM_VALUE(src_dims[0], src_dims[1], src_dims[2], src_dims[3], src_dims[4]);
-            SET_DST_DIM_VALUE(process_dst_dims[0], process_dst_dims[1], process_dst_dims[2], process_dst_dims[3], process_dst_dims[4]);
-        } else if (dims_size == 4) {
-            SET_SRC_DIM_VALUE(src_dims[0], src_dims[1], 1, src_dims[2], src_dims[3]);
-            SET_DST_DIM_VALUE(process_dst_dims[0], process_dst_dims[1], 1, process_dst_dims[2], process_dst_dims[3]);
-        } else if (dims_size == 3) {
-            SET_SRC_DIM_VALUE(1, src_dims[0], 1, src_dims[1], src_dims[2]);
-            SET_DST_DIM_VALUE(1, process_dst_dims[0], 1, process_dst_dims[1], process_dst_dims[2]);
-        } else if (dims_size == 2) {
-            SET_SRC_DIM_VALUE(1, 1, 1, src_dims[0], src_dims[1]);
-            SET_DST_DIM_VALUE(1, 1, 1, process_dst_dims[0], process_dst_dims[1]);
-        } else {
-            SET_SRC_DIM_VALUE(1, src_dims[0], 1, 1, 1);
-            SET_DST_DIM_VALUE(1, process_dst_dims[0], 1, 1, 1);
-        }
-
-        ReduceN = IB != OB && OB == 1;
-        ReduceC = IC != OC && OC == 1;
-        ReduceD = ID != OD && OD == 1;
-        ReduceH = IH != OH && OH == 1;
-        ReduceW = IW != OW && OW == 1;
-    }
 
     const uint8_t *src_data = reinterpret_cast<const uint8_t *>(srcMemPtr->GetPtr());
     uint8_t *dst_data = reinterpret_cast<uint8_t *>(dstMemPtr->GetPtr());
+
     if (jit_mode) {
+        if (is_hybrid_layout) {
+            dst_data = reinterpret_cast<uint8_t *>(prc_mem->get_data_handle());
+        }
         reduce_type(src_data, dst_data, dst_size);
     } else {
-        if (planar_layout) {
+        if (layout == ReduceLayoutType::reduce_ncsp) {
             auto in_ptr = reinterpret_cast<const float *>(src_data);
             auto out_ptr = reinterpret_cast<float *>(dst_data);
             reduce_ref(in_ptr, out_ptr);
@@ -1607,71 +1919,175 @@ void MKLDNNReduceNode::execute(mkldnn::stream strm) {
 
 void MKLDNNReduceNode::reduce_type(const uint8_t *in_ptr, uint8_t *out_ptr, size_t dst_size) {
     init_dst_data(out_ptr, dst_size);
+    reduce_stride = IW;
 
-    if (planar_layout) {
+    if (layout == ReduceLayoutType::reduce_ncsp || layout == ReduceLayoutType::reduce_nspc) {
         reduce_PLN(in_ptr, out_ptr);
     } else {
-        if ((algorithm == ReduceAnd || algorithm == ReduceLogSumExp || algorithm == ReduceMax ||
-             algorithm == ReduceMin || algorithm == ReduceProd) && ReduceC) {
+        if (ReduceC && (IC % blk_size)) {
             reduce_BLK_concern_padding(in_ptr, out_ptr);
         } else {
             reduce_BLK(in_ptr, out_ptr);
         }
     }
+
+    if (is_hybrid_layout) {
+        uint8_t *proc_ptr = out_ptr;
+        auto &dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+        out_ptr = reinterpret_cast<uint8_t *>(dstMemPtr->GetPtr());
+        if (layout == ReduceLayoutType::reduce_nspc) {
+            nspc2ncsp(proc_ptr, out_ptr);
+        } else {
+            blocked2ncsp(proc_ptr, out_ptr);
+        }
+    }
 }
 
 void MKLDNNReduceNode::reduce_PLN(const uint8_t *in_ptr, uint8_t *out_ptr) {
-    for (size_t ib = 0; ib < IB; ib++) {
-        size_t ob = ReduceN ? 0 : ib; GET_PTR_N_PLN;
-        if (!ReduceC && !ReduceD && ReduceH && ReduceW) {
-            parallel_for2d(IC, ID, [&](size_t ic, size_t id) {
-                size_t oc = ic, od = id; GET_PTR_NCD_BASE_PTR_N_PLN;
-                reduce_kernel_process(in_ptr_ncd, out_ptr_ncd, IH * IW, 1);
-            });
-        } else if (ReduceH && ReduceW) {
-            for (size_t ic = 0; ic < IC; ic++) {
-                size_t oc = ReduceC ? 0 : ic; GET_PTR_NC_PLN;
-                for (size_t id = 0; id < ID; id++) {
-                    size_t od = ReduceD ? 0 : id; GET_PTR_NCD_PLN;
-                    reduce_kernel_process(in_ptr_ncd, out_ptr_ncd, IH * IW, 1);
-                }
-            }
-        } else if (!ReduceH && ReduceW) {
-            for (size_t ic = 0; ic < IC; ic++) {
-                size_t oc = ReduceC ? 0 : ic; GET_PTR_NC_PLN;
-                for (size_t id = 0; id < ID; id++) {
-                    size_t od = ReduceD ? 0 : id; GET_PTR_NCD_PLN;
-                    parallel_for(IH, [&](size_t ih){
-                        size_t oh = ih; GET_PTR_NCDH_PLN;
-                        reduce_kernel_process(in_ptr_ncdh, out_ptr_ncdh, IW, 1);
+    if (ReduceN && !ReduceC && !ReduceD && !ReduceH && !ReduceW) {
+        size_t IA = IC * ID * IH * IW;
+        reduce_stride = IA;
+        parallel_for(IA / blk_size, [&](size_t iba){
+            size_t oba = iba;
+            reduce_kernel_process(in_ptr + iba * blk_size * src_data_size, out_ptr + oba * blk_size * dst_data_size,
+                                  blk_size, 0, IB);
+        });
+
+        size_t tail_start = IA / blk_size * blk_size;
+        reduce_kernel_process(in_ptr + tail_start * src_data_size, out_ptr + tail_start * dst_data_size,
+                              IA - tail_start, 0, IB);
+    } else {
+        for (size_t ib = 0; ib < IB; ib++) {
+            size_t ob = ReduceN ? 0 : ib; GET_PTR_N_PLN;
+            if (!ReduceC && !ReduceD && ReduceW) {
+                size_t work_amount = ReduceH ? IH * IW : IW;
+                if (work_amount < blk_size && mayiuse(cpu::x64::avx2)) {
+                    size_t outer_size = ReduceH ? IC * ID : IC * ID * IH;
+                    size_t inner_size = ReduceH ? IH * IW : IW;
+                    size_t output_inner_size = ReduceH ? OH * OW : OW;
+                    size_t IK = outer_size / blk_size;
+                    std::vector<int> index_buf(blk_size);
+                    for (size_t i = 0; i < blk_size; i++) {
+                        index_buf[i] = i * work_amount * src_data_size;
+                    }
+                    parallel_for(IK, [&](size_t ik) {
+                        size_t ok = ik;
+                        reduce_kernel_process(in_ptr_n + ik * blk_size * inner_size * src_data_size,
+                                              out_ptr_n + ok * blk_size * output_inner_size * dst_data_size,
+                                              work_amount, 1, 0, static_cast<int *>(&index_buf[0]));
                     });
-                }
-            }
-        } else if (ReduceW) {
-            for (size_t ic = 0; ic < IC; ic++) {
-                size_t oc = ReduceC ? 0 : ic; GET_PTR_NC_PLN;
-                for (size_t id = 0; id < ID; id++) {
-                    size_t od = ReduceD ? 0 : id; GET_PTR_NCD_PLN;
-                    for (size_t ih = 0; ih < IH; ih++) {
-                        size_t oh = ReduceH ? 0 : ih; GET_PTR_NCDH_PLN;
-                        reduce_kernel_process(in_ptr_ncdh, out_ptr_ncdh, IW, 1);
+                    size_t tail_start = IK * blk_size;
+                    size_t IT = outer_size - tail_start;
+                    parallel_for(IT, [&](size_t it) {
+                        size_t ot = it;
+                        reduce_kernel_process(in_ptr_n + (tail_start + it) * inner_size * src_data_size,
+                                              out_ptr_n + (tail_start + ot) * output_inner_size * dst_data_size, work_amount, 1);
+                    });
+                } else {
+                    if (ReduceH) {
+                        parallel_for2d(IC, ID, [&](size_t ic, size_t id) {
+                            size_t oc = ic, od = id; GET_PTR_NCD_BASE_PTR_N_PLN;
+                            reduce_kernel_process(in_ptr_ncd, out_ptr_ncd, work_amount, 1);
+                        });
+                    } else {
+                        parallel_for3d(IC, ID, IH, [&](size_t ic, size_t id, size_t ih) {
+                            size_t oc = ic, od = id; GET_PTR_NCD_BASE_PTR_N_PLN;
+                            size_t oh = ih; GET_PTR_NCDH_PLN;
+                            reduce_kernel_process(in_ptr_ncdh, out_ptr_ncdh, work_amount, 1);
+                        });
                     }
                 }
-            }
-        } else {
-            for (size_t ic = 0; ic < IC; ic++) {
-                size_t oc = ReduceC ? 0 : ic; GET_PTR_NC_PLN;
-                for (size_t id = 0; id < ID; id++) {
-                    size_t od = ReduceD ? 0 : id; GET_PTR_NCD_PLN;
-                    for (size_t ih = 0; ih < IH; ih++) {
-                        size_t oh = ReduceH ? 0 : ih; GET_PTR_NCDH_PLN;
-                        for (size_t ibw = 0; ibw < IW / blk_size; ibw++) {
-                            size_t obw = ibw;
-                            reduce_kernel_process(in_ptr_ncdh + ibw * blk_size * src_data_size,
-                                                  out_ptr_ncdh + obw * blk_size * dst_data_size, blk_size, 0);
+            } else if (ReduceH && ReduceW) {
+                for (size_t ic = 0; ic < IC; ic++) {
+                    size_t oc = ReduceC ? 0 : ic; GET_PTR_NC_PLN;
+                    for (size_t id = 0; id < ID; id++) {
+                        size_t od = ReduceD ? 0 : id; GET_PTR_NCD_PLN;
+                        reduce_kernel_process(in_ptr_ncd, out_ptr_ncd, IH * IW, 1);
+                    }
+                }
+            } else if (!ReduceH && ReduceW) {
+                for (size_t ic = 0; ic < IC; ic++) {
+                    size_t oc = ReduceC ? 0 : ic; GET_PTR_NC_PLN;
+                    for (size_t id = 0; id < ID; id++) {
+                        size_t od = ReduceD ? 0 : id; GET_PTR_NCD_PLN;
+                        parallel_for(IH, [&](size_t ih){
+                            size_t oh = ih; GET_PTR_NCDH_PLN;
+                            reduce_kernel_process(in_ptr_ncdh, out_ptr_ncdh, IW, 1);
+                        });
+                    }
+                }
+            } else if (ReduceW) {
+                for (size_t ic = 0; ic < IC; ic++) {
+                    size_t oc = ReduceC ? 0 : ic; GET_PTR_NC_PLN;
+                    for (size_t id = 0; id < ID; id++) {
+                        size_t od = ReduceD ? 0 : id; GET_PTR_NCD_PLN;
+                        for (size_t ih = 0; ih < IH; ih++) {
+                            size_t oh = ReduceH ? 0 : ih; GET_PTR_NCDH_PLN;
+                            reduce_kernel_process(in_ptr_ncdh, out_ptr_ncdh, IW, 1);
                         }
-                        size_t tail_start = IW / blk_size * blk_size;
-                        reduce_kernel_process(in_ptr_ncdh + tail_start * src_data_size, out_ptr_ncdh + tail_start * dst_data_size, IW - tail_start, 0);
+                    }
+                }
+            } else if (!ReduceC && !ReduceD && ReduceH && !ReduceW) {
+                parallel_for2d(IC, ID, [&](size_t ic, size_t id) {
+                    size_t oc = ic, od = id; GET_PTR_NCD_BASE_PTR_N_PLN;
+                    parallel_for(IW / blk_size, [&](size_t ibw){
+                        size_t obw = ibw;
+                        reduce_kernel_process(in_ptr_ncd + ibw * blk_size * src_data_size, out_ptr_ncd + obw * blk_size * dst_data_size,
+                                              blk_size, 0, IH);
+                    });
+                    size_t tail_start = IW / blk_size * blk_size;
+                    reduce_kernel_process(in_ptr_ncd + tail_start * src_data_size, out_ptr_ncd + tail_start * dst_data_size,
+                                          IW - tail_start, 0, IH);
+                });
+            } else if (!ReduceC && ReduceD && ReduceH && !ReduceW) {
+                parallel_for(IC, [&](size_t ic) {
+                    size_t oc = ic; GET_PTR_NC_PLN;
+                    parallel_for(IW / blk_size, [&](size_t ibw){
+                        size_t obw = ibw;
+                        reduce_kernel_process(in_ptr_nc + ibw * blk_size * src_data_size, out_ptr_nc + obw * blk_size * dst_data_size,
+                                              blk_size, 0, ID * IH);
+                    });
+                    size_t tail_start = IW / blk_size * blk_size;
+                    reduce_kernel_process(in_ptr_nc + tail_start * src_data_size, out_ptr_nc + tail_start * dst_data_size,
+                                          IW - tail_start, 0, ID * IH);
+                });
+            } else if (ReduceC && ReduceD && ReduceH && !ReduceW) {
+                parallel_for(IW / blk_size, [&](size_t ibw){
+                    size_t obw = ibw;
+                    reduce_kernel_process(in_ptr_n + ibw * blk_size * src_data_size, out_ptr_n + obw * blk_size * dst_data_size,
+                                          blk_size, 0, IC * ID * IH);
+                });
+
+                size_t tail_start = IW / blk_size * blk_size;
+                reduce_kernel_process(in_ptr_n + tail_start * src_data_size, out_ptr_n + tail_start * dst_data_size,
+                                      IW - tail_start, 0, IC * ID * IH);
+            } else if (ReduceC && !ReduceD && !ReduceH && !ReduceW) {
+                size_t IS = ID * IH * IW;
+                reduce_stride = IS;
+                parallel_for(IS / blk_size, [&](size_t ibs){
+                    size_t obs = ibs;
+                    reduce_kernel_process(in_ptr_n + ibs * blk_size * src_data_size, out_ptr_n + obs * blk_size * dst_data_size,
+                                          blk_size, 0, IC);
+                });
+
+                size_t tail_start = IS / blk_size * blk_size;
+                reduce_kernel_process(in_ptr_n + tail_start * src_data_size, out_ptr_n + tail_start * dst_data_size,
+                                      IS - tail_start, 0, IC);
+            } else {
+                for (size_t ic = 0; ic < IC; ic++) {
+                    size_t oc = ReduceC ? 0 : ic; GET_PTR_NC_PLN;
+                    for (size_t id = 0; id < ID; id++) {
+                        size_t od = ReduceD ? 0 : id; GET_PTR_NCD_PLN;
+                        for (size_t ih = 0; ih < IH; ih++) {
+                            size_t oh = ReduceH ? 0 : ih; GET_PTR_NCDH_PLN;
+                            for (size_t ibw = 0; ibw < IW / blk_size; ibw++) {
+                                size_t obw = ibw;
+                                reduce_kernel_process(in_ptr_ncdh + ibw * blk_size * src_data_size,
+                                                      out_ptr_ncdh + obw * blk_size * dst_data_size, blk_size, 0);
+                            }
+                            size_t tail_start = IW / blk_size * blk_size;
+                            reduce_kernel_process(in_ptr_ncdh + tail_start * src_data_size, out_ptr_ncdh + tail_start * dst_data_size, IW - tail_start, 0);
+                        }
                     }
                 }
             }
@@ -1692,13 +2108,24 @@ void MKLDNNReduceNode::reduce_BLK(const uint8_t *in_ptr, uint8_t *out_ptr) {
                 size_t ocb = icb, od = id; GET_PTR_NCD_BASE_PTR_N_BLK;
                 reduce_kernel_process(in_ptr_ncd, out_ptr_ncd, IH * IW * blk_size);
             });
-        } else if (ReduceH && ReduceW) {
-            for (size_t icb = 0; icb < ICB; icb++) {
-                size_t ocb = ReduceC ? 0 : icb; GET_PTR_NC_BLK;
-                for (size_t id = 0; id < ID; id++) {
-                    size_t od = ReduceD ? 0 : id; GET_PTR_NCD_BLK;
-                    reduce_kernel_process(in_ptr_ncd, out_ptr_ncd, IH * IW * blk_size);
-                }
+        } else if (ReduceC && ReduceD && ReduceH && ReduceW) {
+            if (input_prec != output_prec || getAlgorithm() == ReduceL2 ||
+                 algorithm == ReduceLogSumExp || algorithm == ReduceSumSquare) {
+                reduce_kernel_process(in_ptr_n, out_ptr_n, ICB * ID * IH * IW * blk_size);
+            } else {
+                // reduce parallelly
+                // step1: !ReduceC && ReduceD && ReduceH && ReduceW
+                size_t prc_size = ICB * blk_size * dst_data_size;
+                std::vector<uint8_t> vec_prc(prc_size);
+                init_dst_data(vec_prc.data(), prc_size);
+                uint8_t *out_ptr_n_cp = out_ptr_n;
+                out_ptr_n = vec_prc.data();
+                parallel_for(ICB, [&](size_t icb) {
+                    size_t ocb = icb; GET_PTR_NC_BLK;
+                    reduce_kernel_process(in_ptr_nc, out_ptr_nc, ID * IH * IW * blk_size);
+                });
+                // step2: ReduceC
+                reduce_kernel_process(out_ptr_n, out_ptr_n_cp, ICB * blk_size);
             }
         } else if (ReduceW) {
             for (size_t icb = 0; icb < ICB; icb++) {
@@ -1711,6 +2138,15 @@ void MKLDNNReduceNode::reduce_BLK(const uint8_t *in_ptr, uint8_t *out_ptr) {
                     }
                 }
             }
+        } else if (ReduceC && !ReduceD && !ReduceH && !ReduceW) {
+            reduce_stride = ID * IH * IW * blk_size;
+            parallel_for3d(ID, IH, IW, [&](size_t id, size_t ih, size_t iw) {
+                size_t icb = 0, ocb = 0; GET_PTR_NC_BLK;
+                size_t od = id; GET_PTR_NCD_BLK;
+                size_t oh = ih; GET_PTR_NCDH_BLK;
+                size_t ow = iw; GET_PTR_NCDHW_BLK;
+                reduce_kernel_process(in_ptr_ncdhw, out_ptr_ncdhw, blk_size, 0, ICB);
+            });
         } else {
             for (size_t icb = 0; icb < ICB; icb++) {
                 size_t ocb = ReduceC ? 0 : icb; GET_PTR_NC_BLK;
@@ -1815,40 +2251,176 @@ void MKLDNNReduceNode::reduce_BLK_concern_padding(const uint8_t *in_ptr, uint8_t
     reduce_kernel_post_process(out_ptr);
 }
 
-inline void MKLDNNReduceNode::reduce_kernel_process(const uint8_t *in_p, uint8_t *out_p, size_t work_amount, size_t reduce_w) {
+inline void MKLDNNReduceNode::reduce_kernel_process(const uint8_t *in_p, uint8_t *out_p, size_t work_amount,
+                                                    size_t reduce_w, size_t work_batch, const int *tab_idx) {
     auto arg = jit_reduce_call_args();
     arg.src = static_cast<const void *>(in_p);
+    arg.idx = tab_idx;
     arg.dst = static_cast<void *>(out_p);
     arg.work_amount = work_amount;
+    arg.work_batch = work_batch;
     arg.reduce_w = reduce_w;
+    arg.reduce_stride = reduce_stride;
+
     (*reduce_kernel)(&arg);
 }
 
 inline void MKLDNNReduceNode::reduce_kernel_post_process(uint8_t *out_ptr) {
     const size_t integerDivisor = IB * IC * ID * IH * IW / (OB * OC * OD * OH * OW);
     const float divisor = static_cast<float>(integerDivisor);
-    if (planar_layout) {
-        size_t parallel_amount = OB * OC * OD;
-        parallel_for(parallel_amount, [&](size_t i) {
-            uint8_t *out_p = out_ptr + i * OH * OW * dst_data_size;
-            auto arg = jit_reduce_call_args();
+    if (layout == ReduceLayoutType::reduce_ncsp || layout == ReduceLayoutType::reduce_nspc) {
+        parallel_for2d(OB, OC, [&](size_t ob, size_t oc) {
+            uint8_t *out_p = out_ptr + (ob * OC + oc) * OD * OH * OW * dst_data_size;
+            auto arg = jit_reduce_post_call_args();
             arg.dst = static_cast<void *>(out_p);
-            arg.reduce_c = 2;
-            arg.work_amount = OH * OW;
+            arg.oc_off = layout == ReduceLayoutType::reduce_nspc ? 0 : oc * sizeof(float);
+            arg.channel_size = layout == ReduceLayoutType::reduce_nspc ? OW : OC; // OW is related to nspc-ncsp dimension reinterpret
+            arg.work_amount = OD * OH * OW;
             arg.divisor = &divisor;
             (*reduce_post_kernel)(&arg);
         });
     } else {
         size_t OCB = div_up(OC, blk_size);
-        size_t parallel_amount = OB * OCB * OD;
-        parallel_for(parallel_amount, [&](size_t i) {
-            uint8_t *out_p = out_ptr + i * OH * OW * blk_size * dst_data_size;
-            auto arg = jit_reduce_call_args();
+        parallel_for2d(OB, OCB, [&](size_t ob, size_t ocb) {
+            uint8_t *out_p = out_ptr + (ob * OCB + ocb) * OD * OH * OW * blk_size * dst_data_size;
+            auto arg = jit_reduce_post_call_args();
             arg.dst = static_cast<void *>(out_p);
             arg.reduce_c = ReduceC ? 1 : 0;
-            arg.work_amount = OH * OW * blk_size;
+            arg.oc_off = ocb * blk_size * sizeof(float);
+            arg.work_amount = OD * OH * OW * blk_size;
             arg.divisor = &divisor;
             (*reduce_post_kernel)(&arg);
+        });
+    }
+}
+
+void MKLDNNReduceNode::nspc2ncsp(uint8_t *proc_ptr, uint8_t *out_ptr) {
+    // dimension reinterpret after nspc reusing routine reduce_PLN
+    // demote -- nspc -- ncsp
+    //  DIM0  --   B  --  B
+    //  DIM1  --   C  --  W
+    //  DIM2  --   D  --  C
+    //  DIM3  --   H  --  D
+    //  DIM4  --   W  --  H
+    const size_t DIM0 = OB;
+    const size_t DIM1 = OW;
+    const size_t DIM2 = OC;
+    const size_t DIM3 = OD;
+    const size_t DIM4 = OH;
+    const size_t stride1 = DIM2 * DIM3 * DIM4;
+    const size_t stride0 = stride1 * DIM1;
+
+    if (dst_data_size == 4) {
+        auto src_data = reinterpret_cast<const float *>(proc_ptr);
+        auto dst_data = reinterpret_cast<float *>(out_ptr);
+        parallel_for2d(DIM0, stride1, [&](size_t b, size_t j) {
+            auto src_off = b * stride0 + j * DIM1;
+            auto dst_off = b * stride0 + j;
+            for (size_t dim1 = 0; dim1 < DIM1; dim1++) {
+                dst_data[dst_off] = src_data[src_off];
+                src_off++;
+                dst_off += stride1;
+            }
+        });
+    } else if (dst_data_size == 2) {
+        auto src_data = reinterpret_cast<const uint16_t *>(proc_ptr);
+        auto dst_data = reinterpret_cast<uint16_t *>(out_ptr);
+        parallel_for2d(DIM0, stride1, [&](size_t b, size_t j) {
+            auto src_off = b * stride0 + j * DIM1;
+            auto dst_off = b * stride0 + j;
+            for (size_t dim1 = 0; dim1 < DIM1; dim1++) {
+                dst_data[dst_off] = src_data[src_off];
+                src_off++;
+                dst_off += stride1;
+            }
+        });
+    } else {
+        auto src_data = reinterpret_cast<const uint8_t *>(proc_ptr);
+        auto dst_data = reinterpret_cast<uint8_t *>(out_ptr);
+        parallel_for2d(DIM0, stride1, [&](size_t b, size_t j) {
+            auto src_off = b * stride0 + j * DIM1;
+            auto dst_off = b * stride0 + j;
+            for (size_t dim1 = 0; dim1 < DIM1; dim1++) {
+                dst_data[dst_off] = src_data[src_off];
+                src_off++;
+                dst_off += stride1;
+            }
+        });
+    }
+}
+
+void MKLDNNReduceNode::blocked2ncsp(uint8_t *proc_ptr, uint8_t *out_ptr) {
+    const size_t DIM0 = OB;
+    const size_t DIM1 = OC;
+    const size_t DIM2 = OD;
+    const size_t DIM3 = OH;
+    const size_t DIM4 = OW;
+    const size_t stride1 = DIM2 * DIM3 * DIM4;
+    const size_t src_stride0 = stride1 * div_up(OC, blk_size) * blk_size;
+    const size_t dst_stride0 = stride1 * DIM1;
+
+    if (dst_data_size == 4) {
+        auto src_data = reinterpret_cast<const float *>(proc_ptr);
+        auto dst_data = reinterpret_cast<float *>(out_ptr);
+        parallel_for2d(DIM0, stride1, [&](size_t b, size_t j) {
+            auto src_off = b * src_stride0 + j * blk_size;
+            auto dst_off = b * dst_stride0 + j;
+            for (size_t dim1 = 0; dim1 + blk_size <= DIM1; dim1 += blk_size) {
+                for (size_t k = 0; k < blk_size; k++) {
+                    dst_data[dst_off] = src_data[src_off];
+                    src_off++;
+                    dst_off += stride1;
+                }
+                src_off += (stride1 - 1) * blk_size;
+            }
+            size_t tail = DIM1 % blk_size;
+            for (size_t k = 0; k < tail; k++) {
+                dst_data[dst_off] = src_data[src_off];
+                src_off++;
+                dst_off += stride1;
+            }
+        });
+    } else if (dst_data_size == 2) {
+        auto src_data = reinterpret_cast<const uint16_t *>(proc_ptr);
+        auto dst_data = reinterpret_cast<uint16_t *>(out_ptr);
+        parallel_for2d(DIM0, stride1, [&](size_t b, size_t j) {
+            auto src_off = b * src_stride0 + j * blk_size;
+            auto dst_off = b * dst_stride0 + j;
+            for (size_t dim1 = 0; dim1 + blk_size <= DIM1; dim1 += blk_size) {
+                for (size_t k = 0; k < blk_size; k++) {
+                    dst_data[dst_off] = src_data[src_off];
+                    src_off++;
+                    dst_off += stride1;
+                }
+                src_off += (stride1 - 1) * blk_size;
+            }
+            size_t tail = DIM1 % blk_size;
+            for (size_t k = 0; k < tail; k++) {
+                dst_data[dst_off] = src_data[src_off];
+                src_off++;
+                dst_off += stride1;
+            }
+        });
+    } else {
+        auto src_data = reinterpret_cast<const uint8_t *>(proc_ptr);
+        auto dst_data = reinterpret_cast<uint8_t *>(out_ptr);
+        parallel_for2d(DIM0, stride1, [&](size_t b, size_t j) {
+            auto src_off = b * src_stride0 + j * blk_size;
+            auto dst_off = b * dst_stride0 + j;
+            for (size_t dim1 = 0; dim1 + blk_size <= DIM1; dim1 += blk_size) {
+                for (size_t k = 0; k < blk_size; k++) {
+                    dst_data[dst_off] = src_data[src_off];
+                    src_off++;
+                    dst_off += stride1;
+                }
+                src_off += (stride1 - 1) * blk_size;
+            }
+            size_t tail = DIM1 % blk_size;
+            for (size_t k = 0; k < tail; k++) {
+                dst_data[dst_off] = src_data[src_off];
+                src_off++;
+                dst_off += stride1;
+            }
         });
     }
 }
@@ -1925,12 +2497,22 @@ inline void MKLDNNReduceNode::init_dst_data(uint8_t *out_ptr, size_t dst_size) {
     }
 }
 
-inline void MKLDNNReduceNode::calc_process_dst_dims(const int32_t *idx_data) {
+inline void MKLDNNReduceNode::create_working_memory() {
+    auto rank = getInputShapeAtPort(REDUCE_DATA).getRank();
+    memory::format_tag format = (layout == ReduceLayoutType::reduce_nspc) ? (rank == 4 ? memory::format_tag::nhwc : memory::format_tag::ndhwc)
+                                        : (rank == 4 ? (mayiuse(cpu::x64::avx512_common) ? memory::format_tag::nChw16c : memory::format_tag::nChw8c)
+                                                     : (mayiuse(cpu::x64::avx512_common) ? memory::format_tag::nCdhw16c : memory::format_tag::nCdhw8c));
+    auto prc_dims = rank == 4 ? std::vector<size_t>{OB, OC, OH, OW} : std::vector<size_t>{OB, OC, OD, OH, OW};
+    auto desc = mkldnn::memory::desc(MKLDNNExtensionUtils::convertToDnnlDims(prc_dims), MKLDNNExtensionUtils::IEPrecisionToDataType(output_prec), format);
+    prc_mem = std::make_shared<mkldnn::memory>(desc, getEngine());
+    dst_size = desc.get_size();
+}
+
+inline void MKLDNNReduceNode::calc_process_dst_dims() {
+    std::set<size_t> axes;
     SizeVector out_dims;
     SizeVector dst_dims = getOutputShapeAtPort(0).getStaticDims();
-    std::set<size_t> axes;
-    for (size_t i = 0; i < getParentEdgeAt(REDUCE_INDEXES)->getMemory().getStaticDims()[0]; i++) {
-        int32_t axis = idx_data[i];
+    for (auto &axis : raw_axes) {
         if (axis < 0)
             axis += src_dims.size();
         if (static_cast<size_t>(axis) > src_dims.size())
@@ -1954,9 +2536,66 @@ inline void MKLDNNReduceNode::calc_process_dst_dims(const int32_t *idx_data) {
             process_dst_dims.push_back(src_dims[i]);
         }
     }
-    for (size_t i = 0; i < std::min(out_dims.size(), dst_dims.size()); i++) {
-        if (out_dims[i] != dst_dims[i])
+    if (jit_mode && jit_beyond_5D) {
+        if (std::accumulate(out_dims.begin(), out_dims.end(), 1, std::multiplies<double>()) !=
+            std::accumulate(dst_dims.begin(), dst_dims.end(), 1, std::multiplies<double>()))
             IE_THROW() << errorPrefix << "gets incorrect number of output dimensions!";
+    } else {
+        for (size_t i = 0; i < std::min(out_dims.size(), dst_dims.size()); i++) {
+            if (out_dims[i] != dst_dims[i])
+                IE_THROW() << errorPrefix << "gets incorrect number of output dimensions!";
+        }
+    }
+}
+
+inline void MKLDNNReduceNode::set_reduce_dim_flags() {
+    size_t dims_size = src_dims.size();
+    if (dims_size == 5) {
+        SET_SRC_DIM_VALUE(src_dims[0], src_dims[1], src_dims[2], src_dims[3], src_dims[4]);
+        SET_DST_DIM_VALUE(process_dst_dims[0], process_dst_dims[1], process_dst_dims[2], process_dst_dims[3], process_dst_dims[4]);
+    } else if (dims_size == 4) {
+        SET_SRC_DIM_VALUE(src_dims[0], src_dims[1], 1, src_dims[2], src_dims[3]);
+        SET_DST_DIM_VALUE(process_dst_dims[0], process_dst_dims[1], 1, process_dst_dims[2], process_dst_dims[3]);
+    } else if (dims_size == 3) {
+        SET_SRC_DIM_VALUE(1, src_dims[0], 1, src_dims[1], src_dims[2]);
+        SET_DST_DIM_VALUE(1, process_dst_dims[0], 1, process_dst_dims[1], process_dst_dims[2]);
+    } else if (dims_size == 2) {
+        SET_SRC_DIM_VALUE(1, 1, 1, src_dims[0], src_dims[1]);
+        SET_DST_DIM_VALUE(1, 1, 1, process_dst_dims[0], process_dst_dims[1]);
+    } else {
+        SET_SRC_DIM_VALUE(1, src_dims[0], 1, 1, 1);
+        SET_DST_DIM_VALUE(1, process_dst_dims[0], 1, 1, 1);
+    }
+
+    // must be done before the following dimension change
+    if (is_hybrid_layout) {
+        create_working_memory();
+    }
+
+    // Reducing a dimesion in nspc layout can be treated as reducing another dimension in ncsp layout,
+    // eg. reducing C in nspc can be treated as reducing W in ncsp layout, so that the routine reduce_PLN can be reused.
+    // nspc -- ncsp
+    //    D -- C
+    //    H -- D
+    //    W -- H
+    //    C -- W
+    if (layout == ReduceLayoutType::reduce_nspc) {
+        size_t ITmp = IC; IC = ID; ID = IH; IH = IW; IW = ITmp;
+        size_t OTmp = OC; OC = OD; OD = OH; OH = OW; OW = OTmp;
+    }
+
+    ReduceN = IB != OB && OB == 1;
+    ReduceC = IC != OC && OC == 1;
+    ReduceD = ID != OD && OD == 1;
+    ReduceH = IH != OH && OH == 1;
+    ReduceW = IW != OW && OW == 1;
+
+    // suit for parallel
+    if (ReduceH && IW == 1) {
+        ReduceW = true;
+    }
+    if (ReduceC && ReduceH && ID == 1) {
+        ReduceD = true;
     }
 }
 
@@ -2013,6 +2652,7 @@ void MKLDNNReduceNode::reduce_ref_process(const float *in_ptr, float *out_ptr, f
         reduced_dims_work_amount *= src_dims[i];
     reduced_dims_work_amount /= work_amount_dst;
 
+    SizeVector src_strides = getParentEdgeAt(REDUCE_DATA)->getMemory().GetDescWithType<BlockedMemoryDesc>()->getStrides();
     parallel_nt(0, [&](const int ithr, const int nthr) {
         int j;
         size_t i, start = 0, end = 0;
@@ -2089,6 +2729,111 @@ inline void MKLDNNReduceNode::reduce_ref_map(float *out_ptr, size_t work_amount_
         default:
             IE_THROW() << errorPrefix << "gets unsupported reduce mode.";
     }
+}
+
+void MKLDNNReduceNode::setPostOps(mkldnn::primitive_attr &attr, bool initWeights) {
+    mkldnn::post_ops ops;
+    for (auto &node : fusedWith) {
+        auto* fakeQuantizeNode = dynamic_cast<MKLDNNFakeQuantizeNode *>(node.get());
+        if (fakeQuantizeNode) {
+            fakeQuantizeNode->appendPostOps(ops);
+            continue;
+        }
+
+        auto* eltwiseNode = dynamic_cast<MKLDNNEltwiseNode *>(node.get());
+        if (eltwiseNode) {
+            // TODO [DS]: change to shape from memory
+            constexpr int align = 16;
+            eltwiseNode->appendPostOps(ops, getOutputShapeAtPort(0).getStaticDims(), align);
+            continue;
+        }
+        IE_THROW() << "Fusing of " << NameFromType(node->getType()) << " operation to " << NameFromType(this->getType()) << " node is not implemented";
+    }
+    attr.set_post_ops(ops);
+}
+
+void MKLDNNReduceNode::setJITBeyond5D() {
+    jit_beyond_5D = false;
+    if (getInputShapeAtPort(REDUCE_DATA).getRank() > 5) {
+        for (auto &axis : raw_axes) {
+            if (axis < 0)
+                axis += static_cast<int>(getInputShapeAtPort(REDUCE_DATA).getRank());
+        }
+
+        if (raw_axes.size() <= 1) {
+            jit_beyond_5D = true;
+        } else {
+            for (size_t i = 1; i < raw_axes.size(); i++) {
+                if (raw_axes[i] != raw_axes[i - 1] + 1) {
+                    jit_beyond_5D = false;
+                    break;
+                }
+                jit_beyond_5D = true;
+            }
+        }
+    }
+}
+
+void MKLDNNReduceNode::update_src_dims() {
+    if (raw_axes.size() < 1)
+        return;
+
+    size_t axis_dim = 1;
+    size_t outer_dim = 1;
+    size_t inner_dim = 1;
+    int outer_end = raw_axes[0];
+    int inner_start = raw_axes[raw_axes.size() - 1];
+    for (size_t i = 0; i < src_dims.size(); i++) {
+        if (i < outer_end) {
+            outer_dim *= src_dims[i];
+        } else if (i > inner_start) {
+            inner_dim *= src_dims[i];
+        } else {
+            axis_dim *= src_dims[i];
+        }
+    }
+
+    raw_axes.clear();
+    raw_axes.push_back(1);
+
+    src_dims.clear();
+    src_dims.push_back(outer_dim);
+    src_dims.push_back(axis_dim);
+    src_dims.push_back(inner_dim);
+}
+
+bool MKLDNNReduceNode::canApplyJIT(const Precision &input_prec, const Precision &output_prec) const {
+    static const Precision supportedPrecisions[] = {
+            Precision::FP32,
+            Precision::BF16,
+            Precision::I32,
+            Precision::I8,
+            Precision::U8
+    };
+
+    return (mayiuse(cpu::x64::sse41)) && (getInputShapeAtPort(REDUCE_DATA).getRank() <= 5 || jit_beyond_5D) &&
+           std::find(std::begin(supportedPrecisions), std::end(supportedPrecisions), input_prec) != std::end(supportedPrecisions) &&
+           std::find(std::begin(supportedPrecisions), std::end(supportedPrecisions), output_prec) != std::end(supportedPrecisions);
+}
+
+bool MKLDNNReduceNode::canFuse(const MKLDNNNodePtr& node) const {
+    Precision input_prec = getOriginalInputPrecisionAtPort(REDUCE_DATA);
+    Precision output_prec = getOriginalOutputPrecisionAtPort(0);
+    if (!canApplyJIT(input_prec, output_prec) || jit_beyond_5D || algorithm == ReduceAnd || algorithm == ReduceOr) {
+        return false;
+    }
+
+    // In jit mode we use the output memory as an intermediate accumulator for certain reduce modes.
+    // If the post ops node has a lower precision for such modes, post ops fusing won't be supposted, in order to avoid accuracy loss.
+    if (output_prec == Precision::FP32 &&
+        !node->getOriginalOutputPrecisions().empty() && node->getOriginalOutputPrecisionAtPort(0) != Precision::FP32) {
+        if (algorithm != ReduceAnd && algorithm != ReduceOr &&
+            algorithm != ReduceMin && algorithm != ReduceMax) {
+            return false;
+        }
+    }
+
+    return canFuseSimpleOperation(node);
 }
 
 bool MKLDNNReduceNode::created() const {

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reduce_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reduce_node.h
@@ -12,8 +12,14 @@
 
 namespace MKLDNNPlugin {
 
+enum ReduceLayoutType {
+    reduce_ncsp,
+    reduce_nspc,
+    reduce_blocked
+};
+
 struct jit_reduce_config_params {
-    bool planar_layout;
+    ReduceLayoutType layout;
     Algorithm reduce_mode;
     mkldnn::memory::data_type src_dt;
     mkldnn::memory::data_type dst_dt;
@@ -23,11 +29,22 @@ struct jit_reduce_config_params {
 
 struct jit_reduce_call_args {
     const void *src;
+    const int *idx;
     void *dst;
     size_t work_amount;
-    size_t reduce_w = 2;  // only used in planar layout  [1: reduce width dimension]   [0: reduce other dimension] [other value: N/A]
-    size_t reduce_c = 2;  // only used in blocked layout [1: reduce channel dimension] [0: reduce other dimension] [other value: N/A]
-    const float *divisor; // mean = sum / divisor
+    size_t work_batch;
+    size_t reduce_w = 2;    // only used in planar layout  [1: reduce width dimension]   [0: reduce other dimension] [other value: N/A]
+    size_t reduce_stride;   // only used in planar layout while reducing dimensions except for width
+};
+
+struct jit_reduce_post_call_args {
+    const void *src;
+    void *dst;
+    size_t work_amount;
+    size_t reduce_c = 2;    // only used in blocked layout [1: reduce channel dimension] [0: reduce other dimension] [other value: N/A]
+    size_t oc_off;          // offset in byte along channel on output tensor
+    size_t channel_size;    // only for post ops fusion of nspc layout
+    const float *divisor;   // mean = sum / divisor
 };
 
 struct jit_uni_reduce_kernel {
@@ -47,19 +64,20 @@ struct jit_uni_reduce_kernel {
 };
 
 struct jit_uni_reduce_post_kernel {
-    void (*ker_)(const jit_reduce_call_args *);
+    void (*ker_)(const jit_reduce_post_call_args *);
 
-    void operator()(const jit_reduce_call_args *args) {
+    void operator()(const jit_reduce_post_call_args *args) {
         assert(ker_);
         ker_(args);
     }
 
-    virtual void create_ker() = 0;
-
-    explicit jit_uni_reduce_post_kernel(jit_reduce_config_params jcp) : ker_(nullptr), jcp_(jcp) {}
+    explicit jit_uni_reduce_post_kernel(jit_reduce_config_params jcp, const mkldnn_primitive_attr &attr) : ker_(nullptr), jcp_(jcp), attr_(attr) {}
     virtual ~jit_uni_reduce_post_kernel() {}
 
+    virtual void create_ker() = 0;
+
     jit_reduce_config_params jcp_;
+    const mkldnn_primitive_attr &attr_;
 };
 
 class MKLDNNReduceNode : public MKLDNNNode {
@@ -71,6 +89,7 @@ public:
     void createPrimitive() override;
     bool created() const override;
     void execute(mkldnn::stream strm) override;
+    bool canFuse(const MKLDNNNodePtr& node) const override;
     bool canBeInPlace() const override {
         return false;
     }
@@ -82,30 +101,46 @@ private:
     void reduce_PLN(const uint8_t *in_ptr, uint8_t *out_ptr);
     void reduce_BLK(const uint8_t *in_ptr, uint8_t *out_ptr);
     void reduce_BLK_concern_padding(const uint8_t *in_ptr, uint8_t *out_ptr);
-    inline void reduce_kernel_process(const uint8_t *in_p, uint8_t *out_p, size_t work_amount, size_t reduce_w = 2);
+    inline void reduce_kernel_process(const uint8_t *in_p, uint8_t *out_p, size_t work_amount,
+                                      size_t reduce_w = 2, size_t work_batch = 1, const int *tab_idx = NULL);
     inline void reduce_kernel_post_process(uint8_t *out_ptr);
     inline void init_dst_data(uint8_t *out_ptr, size_t dst_size);
-    inline void calc_process_dst_dims(const int32_t *idx_data);
+    inline void create_working_memory();
+    inline void calc_process_dst_dims();
+    inline void set_reduce_dim_flags();
     inline void reduce_ref(const float *in_ptr, float *out_ptr);
     void reduce_ref_process(const float *in_ptr, float *out_ptr, float init_value, std::function<float(float, float)> func);
     inline void reduce_ref_map(float *out_ptr, size_t work_amount_dst, size_t reduced_dims_work_amount);
+    void nspc2ncsp(uint8_t *proc_ptr, uint8_t *out_ptr);
+    void blocked2ncsp(uint8_t *proc_ptr, uint8_t *out_ptr);
+    void setPostOps(mkldnn::primitive_attr &attr, bool initWeights = false);
+    void setJITBeyond5D();
+    void update_src_dims();
+    bool canApplyJIT(const InferenceEngine::Precision &input_prec, const InferenceEngine::Precision &output_prec) const;
 
     size_t blk_size;
-    size_t dims_size;
+    size_t dst_size;
     static const size_t REDUCE_DATA = 0;
     static const size_t REDUCE_INDEXES = 1;
-    bool planar_layout = true;
+    bool jit_beyond_5D = false;
     bool jit_mode = true;
     bool keep_dims = true;
+    bool is_hybrid_layout = false;
     bool ReduceN, ReduceC, ReduceD, ReduceH, ReduceW;
     size_t IB, IC, ID, IH, IW;
     size_t OB, OC, OD, OH, OW;
     size_t src_data_size, dst_data_size;
+    size_t reduce_stride;
+    ReduceLayoutType layout;
     InferenceEngine::Precision input_prec, output_prec;
     InferenceEngine::SizeVector src_dims;
-    InferenceEngine::SizeVector src_strides;
     InferenceEngine::SizeVector process_dst_dims;
     InferenceEngine::SizeVector axes_for_reduction;
+    std::vector<int> raw_axes;
+
+    mkldnn::primitive_attr attr;
+
+    std::shared_ptr<mkldnn::memory> prc_mem;
 
     std::shared_ptr<jit_uni_reduce_kernel> reduce_kernel;
     std::shared_ptr<jit_uni_reduce_post_kernel> reduce_post_kernel;

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/reduce_max_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/reduce_max_transformation.cpp
@@ -33,21 +33,21 @@ const std::vector<LayerTestsDefinitions::ReduceMaxTransformationParam> params = 
         { 256ul, ngraph::Shape{ 1, 1, 1, 1 }, { 0.f }, { 255.f }, { 0.f }, { 127.f } },
         { 2, 3 },
         false,
-        "Output/pool",
+        "Output_original",
         "U8"
     },
     {
         { 256ul, ngraph::Shape{ 1, 1, 1, 1 }, { 0.f }, { 255.f }, { 0.f }, { 127.f } },
         { 1 },
         true,
-        "Output/pool",
+        "Output_original",
         "U8"
     },
     {
         { 256ul, ngraph::Shape{ 1, 1, 1, 1 }, { 0.f }, { 255.f }, { 0.f }, { 127.f } },
         { 1 },
         false,
-        "Output/pool",
+        "Output_original",
         "U8"
     },
     {
@@ -73,7 +73,7 @@ const std::vector<LayerTestsDefinitions::ReduceMaxTransformationParam> params = 
         },
         { 2, 3 },
         false,
-        "Output/pool",
+        "Output_original",
         "U8"
     },
     {
@@ -86,7 +86,7 @@ const std::vector<LayerTestsDefinitions::ReduceMaxTransformationParam> params = 
         },
         { 0, 1 },
         true,
-        "Output/pool",
+        "Output",
         "FP32"
     },
     {
@@ -99,7 +99,7 @@ const std::vector<LayerTestsDefinitions::ReduceMaxTransformationParam> params = 
         },
         { 0, 1 },
         false,
-        "Output/pool",
+        "Output",
         "FP32"
     },
 };

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/reduce_mean_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/reduce_mean_transformation.cpp
@@ -33,21 +33,21 @@ const std::vector<LayerTestsDefinitions::ReduceMeanTransformationParam> params =
         { 256ul, ngraph::Shape{ 1, 1, 1, 1 }, { 0.f }, { 255.f }, { 0.f }, { 127.f } },
         { 2, 3 },
         false,
-        "Output/pool",
+        "Output_original",
         "U8"
     },
     {
         { 256ul, ngraph::Shape{ 1, 1, 1, 1 }, { 0.f }, { 255.f }, { 0.f }, { 127.f } },
         { 1 },
         true,
-        "Output/pool",
+        "Output_original",
         "U8"
     },
     {
         { 256ul, ngraph::Shape{ 1, 1, 1, 1 }, { 0.f }, { 255.f }, { 0.f }, { 127.f } },
         { 1 },
         false,
-        "Output/pool",
+        "Output_original",
         "U8"
     },
     {
@@ -73,7 +73,7 @@ const std::vector<LayerTestsDefinitions::ReduceMeanTransformationParam> params =
         },
         { 2, 3 },
         false,
-        "Output/pool",
+        "Output_original",
         "U8"
     },
     {
@@ -86,7 +86,7 @@ const std::vector<LayerTestsDefinitions::ReduceMeanTransformationParam> params =
         },
         { 0, 1 },
         true,
-        "Output/pool",
+        "Output",
         "FP32"
     },
     {
@@ -99,7 +99,7 @@ const std::vector<LayerTestsDefinitions::ReduceMeanTransformationParam> params =
         },
         { 0, 1 },
         false,
-        "Output/pool",
+        "Output",
         "FP32"
     },
 };

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/reduce_sum_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/reduce_sum_transformation.cpp
@@ -26,14 +26,14 @@ const std::vector<LayerTestsDefinitions::ReduceSumTransformationParam> params = 
         { 256ul, ngraph::Shape{ 1, 1, 1, 1 }, { 0.f }, { 255.f }, { 0.f }, { 127.f } },
         { 2, 3 },
         true,
-        "Output/pool",
+        "Output_original",
         "U8"
     },
     {
         { 256ul, ngraph::Shape{ 1, 1, 1, 1 }, { 2.f }, { 10.f }, { 2.f }, { 10.f } },
         { 2, 3 },
         false,
-        "Output/pool",
+        "Output_original",
         "U8"
     },
     {
@@ -46,7 +46,7 @@ const std::vector<LayerTestsDefinitions::ReduceSumTransformationParam> params = 
         },
         { 2, 3 },
         true,
-        "Output/pool",
+        "Output_original",
         "U8"
     },
     {
@@ -59,7 +59,7 @@ const std::vector<LayerTestsDefinitions::ReduceSumTransformationParam> params = 
         },
         { 2, 3 },
         false,
-        "Output/pool",
+        "Output_original",
         "U8"
     },
     {
@@ -72,7 +72,7 @@ const std::vector<LayerTestsDefinitions::ReduceSumTransformationParam> params = 
         },
         { 0, 1 },
         true,
-        "Output/pool",
+        "Output",
         "FP32"
     },
     {
@@ -85,7 +85,7 @@ const std::vector<LayerTestsDefinitions::ReduceSumTransformationParam> params = 
         },
         { 0, 1 },
         false,
-        "Output/pool",
+        "Output",
         "FP32"
     },
 };

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
@@ -84,6 +84,8 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*(Auto|Multi).*Behavior.*IncorrectConfigTests.*CanNotLoadNetworkWithIncorrectConfig.*)",
         R"(.*OVExecutableNetworkBaseTest.*(CanGetInputsInfoAndCheck|CanSetConfigToExecNet).*)",
         R"(.*Behavior.*CorrectConfigCheck.*(canSetConfigAndCheckGetConfig|canSetConfigTwiceAndCheckGetConfig).*CPU_BIND_THREAD=YES.*)",
+        // Issue: 62846 Here shape[1] is not the channel dimension size
+        R"(.*smoke_Reduce.*KeepNoDims.*(_axes=\((0.*|.*1.*)).*Fused=.*PerChannel.*)",
         // TODO: 56520 Accuracy mismatch
         R"(.*ReduceOpsLayerTest.*type=Mean_.*netPRC=(I64|I32).*)",
         R"(.*ReduceOpsLayerTest.*type=Mean_.*netPRC=U64.*)",


### PR DESCRIPTION
### Details:
 - *Support nspc layout*
 - *Support hybrid layouts*
 -  - *blocked layout for input and ncsp for output*
 -  - *nspc layout for input and ncsp for output*
 - *Disable the reduce to pooling transformation when reducing by spatial dimensions*
 - *Support eltwise, depthwise and fake quantize post operations*
 - *Improvement on cases of non-width reducing, full reducing and some corner cases*
 - *Extend to support JIT optimization of some cases of reducing dimensions beyond 5D*

### Tickets:
 - *53914*
 - *58821*

### oneDNN PR:
- *https://github.com/openvinotoolkit/oneDNN/pull/93*