### PR TITLE
MO: ensure ngraph.frontend is installed

### DIFF
--- a/model-optimizer/mo/utils/check_ie_bindings.py
+++ b/model-optimizer/mo/utils/check_ie_bindings.py
@@ -58,6 +58,7 @@ def import_core_modules(silent: bool, path_to_module: str):
 
         import openvino  # pylint: disable=import-error,no-name-in-module
         import ngraph  # pylint: disable=import-error,no-name-in-module
+        import ngraph.frontend  # pylint: disable=import-error,no-name-in-module
 
         if silent:
             return True

--- a/model-optimizer/mo/utils/find_ie_version.py
+++ b/model-optimizer/mo/utils/find_ie_version.py
@@ -26,10 +26,10 @@ def setup_env(module="", libs=[]):
     :param module: path to python module
     :param libs: list with paths to libraries
     """
-    os.environ[python_path_key] = os.pathsep.join([os.environ[python_path_key], module])
-    os.environ[lib_env_key] = os.pathsep.join([os.environ[lib_env_key], *libs])
+    os.environ[python_path_key] = os.pathsep.join([module, os.environ[python_path_key]])
+    os.environ[lib_env_key] = os.pathsep.join([*libs, os.environ[lib_env_key]])
     if not os.getenv("OV_FRONTEND_PATH"):
-        os.environ["OV_FRONTEND_PATH"] = os.pathsep.join([os.environ[lib_env_key], *libs])
+        os.environ["OV_FRONTEND_PATH"] = os.pathsep.join([*libs, os.environ[lib_env_key]])
 
 
 def reset_env():


### PR DESCRIPTION
### Details:

Root cause analysis: It was not taken into account that user may have old version of OpenVINO installed but trying to use latest Model-Optimizer

Solution:
- Add 'import ngraph.frontend' to check_ie_bindings to ensure correct version of ngraph Python API is installed
- Inside setup_env - join PYTHONPATH candidate to beginning of existing PYTHONPATH 

Ticket: 60606

Code:
* [N/A ]  Comments (code is self-explained)
* [X]  Code style (PEP8)
* [N/A]  Transformation generates reshape-able IR
* [N/A]  Transformation preserves original framework node names


Validation:
* [X]  Unit tests
* [N/A]  Framework operation tests
* [N/A]  Transformation tests
* [N/A]  Model Optimizer IR Reader check

Documentation:
* [N/A]  Supported frameworks operations list
* [N/A]  Guide on how to convert the **public** model
* [N/A]  User guide update


### Validation
Build OpenVINO from 2021.4 release branch and set PYTHONPATH and LD_LIBRARY_PATH to this release location

Test 1:
> Download source code ffor openvino/model-optimizer from 'master' branch
> Don't build anything using cmake
>  path_to_master/model-optimizer/mo.py --input_model path_to_model

Expected output:
mo.utils.error.Error: Could not find the Inference Engine or nGraph Python API.
Consider building the Inference Engine and nGraph Python APIs from sources or try to install OpenVINO (TM) Toolkit using "install_prerequisites.sh"
Previous output: ModuleNotFound error 'ngraph.frontend'

Test 2:
> Get openvino/model-optimizer from 'master' branch
> Build OpenVINO from master branch
>  path_to_master/model-optimizer/mo.py --input_model path_to_model
Expected: model shall be converted
Previous: error 'ModuleNotFound' occurs due to old version of openvino/ngraph was found in PYTHOPATH