### PR TITLE
PDPD frontend - support of protobuf_lite

### DIFF
--- a/ngraph/frontend/paddlepaddle/src/proto/framework.proto
+++ b/ngraph/frontend/paddlepaddle/src/proto/framework.proto
@@ -11,9 +11,12 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
+// Modification Copyright (C) 2021 Intel Corporation
 
 syntax = "proto2";
 package paddle.framework.proto;
+
+option optimize_for = LITE_RUNTIME; // Added by Intel Corporation 2021
 
 // Any incompatible changes to ProgramDesc and its dependencies should
 // raise the version defined version.h.


### PR DESCRIPTION
### Details:
 - Added optimization for Protobuf-lite runtime (don't include unnecessary features)
 - Binary size for libpaddlepaddle_frontend.so is reduced from 1.6MB to 740KB
 - Unit-tests are working now with NGRAPH_USE_PROTOBUF_LITE=ON option

### Tickets:
 - 60823
