### PR TITLE
Add more passes to the MOC backend

### DIFF
--- a/inference-engine/src/offline_transformations/src/moc_transformations.cpp
+++ b/inference-engine/src/offline_transformations/src/moc_transformations.cpp
@@ -18,6 +18,13 @@
 #include <transformations/common_optimizations/convert_quantize_dequantize.hpp>
 #include <transformations/common_optimizations/pad_fusion.hpp>
 #include <transformations/common_optimizations/simplify_shape_of_sub_graph.hpp>
+#include <transformations/op_conversions/convert_scatter_elements_to_scatter.hpp>
+#include <transformations/common_optimizations/clamp_fusion.hpp>
+#include <transformations/common_optimizations/mvn_fusion.hpp>
+#include <transformations/common_optimizations/dilated_convolution_converter.hpp>
+#include <transformations/common_optimizations/binarize_weights.hpp>
+#include <transformations/common_optimizations/conv_to_binary_conv.hpp>
+#include <transformations/common_optimizations/eliminate_unsqueeze_gather.hpp>
 
 NGRAPH_RTTI_DEFINITION(ngraph::pass::MOCTransformations, "MOCTransformations", 0);
 
@@ -38,15 +45,26 @@ bool ngraph::pass::MOCTransformations::run_on_function(std::shared_ptr<ngraph::F
     manager.register_pass<ngraph::pass::ConvertQuantizeDequantize>();
     manager.register_pass<ngraph::pass::SimplifyShapeOfSubGraph>();
 
+    auto eliminations = manager.register_pass<ngraph::pass::GraphRewrite>();
+    eliminations->add_matcher<ngraph::pass::EliminateUnsqueezeGather>();
+    eliminations->set_name("ngraph::pass::CommonEliminations");
+
     auto common_fusions = manager.register_pass<ngraph::pass::GraphRewrite>();
+    common_fusions->add_matcher<ngraph::pass::ConvertScatterElementsToScatter>();
     common_fusions->add_matcher<ngraph::pass::SoftPlusFusion>();
     common_fusions->add_matcher<ngraph::pass::SoftPlusToMishFusion>();
     common_fusions->add_matcher<ngraph::pass::SwishFusion>();
     common_fusions->add_matcher<ngraph::pass::HSwishFusion>();
     common_fusions->add_matcher<ngraph::pass::HSigmoidFusion>();
+    common_fusions->add_matcher<ngraph::pass::ClampFusion>();
     common_fusions->add_matcher<ngraph::pass::PadFusion>();
+    common_fusions->add_matcher<ngraph::pass::MVNFusion>();
+    common_fusions->add_matcher<ngraph::pass::DilatedConvolutionConverter>();
     common_fusions->add_matcher<ngraph::pass::GeluFusion>();
     common_fusions->set_name("ngraph::pass::CommonFusions");
+
+    manager.register_pass<ngraph::pass::BinarizeWeights>();
+    manager.register_pass<ngraph::pass::ConvToBinaryConv>();
 
     manager.run_passes(f);
 


### PR DESCRIPTION
### Description
Enable additional plugin independent fusions into MOC backend phase. Validation shows that this transformations additionally optimize graphs. For example MVN fusion pass fuse a lot of sub-graphs in bert models family. Also Clamp fusion sucessfully works on some super resolution networks. All other passes have implementation inside MO legacy frontends so they currently doesn't optimize graphs but they will be necessary for new frontends.

### nGraph Transformations Transition Status
<details>
  <summary>Click to expand!</summary>

|FINAL MOC PIPELINE|CURRENT MOC PIPELINE|
|---|---|
|InitNodeInfo|InitNodeInfo|
|ConstantFolding| |
|SimplifyShapeOfSubGraph|SimplifyShapeOfSubGraph|
|RemoveFilteringBoxesBySize|RemoveFilteringBoxesBySize|
|ConvertQuantizeDequantize|ConvertQuantizeDequantize|
| | |
|TransposeFQReduction| |
|TransposeReduction| |
|TransposeFuse| |
| | |
|SplitSqueezeConcatFusion | |
| | |
|EliminateUnsqueezeGather|**EliminateUnsqueezeGather**|
| | |
|ConvertScatterElementsToScatter|**ConvertScatterElementsToScatter**|
|BroadcastElementwiseFusion| |
|SoftPlusFusion|SoftPlusFusion|
|SoftPlusToMishFusion|SoftPlusToMishFusion|
|SwishFusion|SwishFusion|
|HSwishFusion|HSwishFusion|
|HSigmoidFusion|HSigmoidFusion|
|NormalizeL2Fusion| |
|ClampFusion|**ClampFusion**|
|PadFusion|PadFusion|
|SoftmaxFusion| |
|MVNFusion|**MVNFusion**| 
|DilatedConvolutionConverter|**DilatedConvolutionConverter**|
|GeluFusion|GeluFusion|
| | |
|BinarizeWeights|**BinarizeWeights**|
|ConvToBinaryConv|**ConvToBinaryConv**|
| | |
|LinOpSequenceFusion| |
| | |
|ConvolutionMultiplyFusion| |
|GroupConvolutionMultiplyFusion| |
|ConvolutionBackpropDataMultiplyFusion| |
|GroupConvolutionBackpropDataMultiplyFusion| |

_Note: transformations marked as **bold** were enabled in current PR_
</details>