### PR TITLE
[GNA] Transpose bias

### DIFF
--- a/inference-engine/tests/unit/gna/CMakeLists.txt
+++ b/inference-engine/tests/unit/gna/CMakeLists.txt
@@ -8,6 +8,8 @@ addIeTargetTest(
         NAME ${TARGET_NAME}
         ROOT ${CMAKE_CURRENT_SOURCE_DIR}
         LINK_LIBRARIES
+            PRIVATE
+                ngraphFunctions
             gmock
             commonTestUtils_s
             GNAPlugin_test_static

--- a/inference-engine/tests/unit/gna/ngraph/transformations/gna_convert_matmul_to_pointwise_convolution.cpp
+++ b/inference-engine/tests/unit/gna/ngraph/transformations/gna_convert_matmul_to_pointwise_convolution.cpp
@@ -14,6 +14,7 @@
 #include <ngraph/opsets/opset7.hpp>
 #include <ngraph/pass/manager.hpp>
 #include <transformations/init_node_info.hpp>
+#include "ngraph_functions/builders.hpp"
 
 namespace testing {
 
@@ -127,7 +128,10 @@ protected:
 };
 
 void CreateAdd::updateGraph(Graph& graph) {
-    auto bias = ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{1}, {1});
+    auto shape = graph.output->get_output_shape(0);
+    std::vector<size_t> axes(shape.size(), 1);
+    axes.back() = shape.back();
+    auto bias = ngraph::builder::makeConstant<float>(ngraph::element::i64, axes, {}, true);
     auto add_node = std::make_shared<ngraph::opset7::Add>(graph.output, bias);
     graph.output = add_node;
 }
@@ -191,7 +195,7 @@ Graph createReferenceGraph(bool addConstFakeQuantizeNode, bool insertAddNode, bo
     parent_node = conv_node;
 
     if (insertAddNode) {
-        auto bias = ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{1}, {1});
+        auto bias = ngraph::builder::makeConstant<float>(ngraph::element::i64, {1, 8, 1, 1}, {}, true);
         auto add_node = std::make_shared<ngraph::opset7::Add>(parent_node, bias);
         parent_node = add_node;
     }

--- a/inference-engine/tests/unit/gna/ngraph/transformations/gna_convert_matmul_to_pointwise_convolution.cpp
+++ b/inference-engine/tests/unit/gna/ngraph/transformations/gna_convert_matmul_to_pointwise_convolution.cpp
@@ -120,6 +120,7 @@ void CreateMatMul::updateGraph(Graph& graph) {
     graph.output = matmul_node;
 }
 
+template<bool ONE_DIMENSIONAL_BIAS_SHAPE>
 class CreateAdd : public CreateGraphDecorator {
 public:
     CreateAdd(CreateGraphDecoratorPtr prev_builder = nullptr) : CreateGraphDecorator(std::move(prev_builder)) {}
@@ -127,10 +128,18 @@ protected:
     void updateGraph(Graph&) override;
 };
 
-void CreateAdd::updateGraph(Graph& graph) {
-    auto shape = graph.output->get_output_shape(0);
-    std::vector<size_t> axes(shape.size(), 1);
-    axes.back() = shape.back();
+template<bool ONE_DIMENSIONAL_BIAS_SHAPE>
+void CreateAdd<ONE_DIMENSIONAL_BIAS_SHAPE>::updateGraph(Graph& graph) {
+    std::vector<size_t> axes(1, 1);
+    if (std::is_same<
+            std::integral_constant<bool, ONE_DIMENSIONAL_BIAS_SHAPE>,
+            std::integral_constant<bool, false>
+        >::value) {
+        auto shape = graph.output->get_output_shape(0);
+        axes.resize(shape.size(), 1);
+        axes.back() = shape.back();
+    }
+
     auto bias = ngraph::builder::makeConstant<float>(ngraph::element::i64, axes, {}, true);
     auto add_node = std::make_shared<ngraph::opset7::Add>(graph.output, bias);
     graph.output = add_node;
@@ -159,7 +168,8 @@ Graph createTransformedGraph(const ngraph::Shape& input_data_shape = ngraph::Sha
 
 // ------------------------------------------------------------------------------------------------------------
 
-Graph createReferenceGraph(bool addConstFakeQuantizeNode, bool insertAddNode, bool addOutFakeQuantizeNode) {
+template<bool ADD_CONST_FAKEQUANTIZE_NODE, bool INSERT_ADD_NODE, bool ONE_DIMENSIONAL_BIAS_SHAPE, bool ADD_OUT_FAKEQUANTIZE_NODE>
+Graph createReferenceGraph() {
     Graph graph;
 
     graph.input_params = std::make_shared<ngraph::opset7::Parameter>(ngraph::element::i64,
@@ -177,8 +187,9 @@ Graph createReferenceGraph(bool addConstFakeQuantizeNode, bool insertAddNode, bo
     auto transpose_before = std::make_shared<ngraph::opset7::Transpose>(reshape_before, const_transpose_before);
 
     std::shared_ptr<ngraph::op::Op> parent_node = constant_node;
-    if (addConstFakeQuantizeNode)
+    if (std::is_same<std::integral_constant<bool, ADD_CONST_FAKEQUANTIZE_NODE>, std::integral_constant<bool, true>>::value) {
         parent_node = createFakeQuantizeNode(constant_node);
+    }
 
     auto weights_reshape_const = std::make_shared<ngraph::opset7::Constant>(ngraph::element::Type_t::i64,
                                                                             ngraph::Shape{4}, ngraph::Shape{8, 8, 1, 1});
@@ -193,15 +204,20 @@ Graph createReferenceGraph(bool addConstFakeQuantizeNode, bool insertAddNode, bo
                                                                     ngraph::op::PadType::VALID);
 
     parent_node = conv_node;
-
-    if (insertAddNode) {
-        auto bias = ngraph::builder::makeConstant<float>(ngraph::element::i64, {1, 8, 1, 1}, {}, true);
+    if (std::is_same<std::integral_constant<bool, INSERT_ADD_NODE>, std::integral_constant<bool, true>>::value) {
+        std::vector<size_t> axes(1, 1);
+        if (std::is_same<std::integral_constant<bool, ONE_DIMENSIONAL_BIAS_SHAPE>, std::integral_constant<bool, false>>::value) {
+            axes.resize(4, 1);
+            axes[1] = 8;
+        }
+        auto bias = ngraph::builder::makeConstant<float>(ngraph::element::i64, axes, {}, true);
         auto add_node = std::make_shared<ngraph::opset7::Add>(parent_node, bias);
         parent_node = add_node;
     }
 
-    if (addOutFakeQuantizeNode)
+    if (std::is_same<std::integral_constant<bool, ADD_OUT_FAKEQUANTIZE_NODE>, std::integral_constant<bool, true>>::value) {
         parent_node = createFakeQuantizeNode(parent_node);
+    }
 
     auto const_transpose_after = ngraph::opset7::Constant::create(ngraph::element::i64,
                                                                   ngraph::Shape{4},
@@ -258,47 +274,52 @@ TEST_P(ConvertMatmulToPointWiseConvolutionFixture, CompareFunctions) {
     execute_test(function, reference_function, pass_manager);
 }
 
+namespace {
+    constexpr bool AddConstFakeQuantizeNode = true;
+    constexpr bool InsertAddNode = true;
+    constexpr bool OneDimensionalBiasShape = true;
+    constexpr bool AddOutFakeQuantizeNode = true;
+}
+
 INSTANTIATE_TEST_SUITE_P(ConvertMatmulToPointWiseConvolutionTestSuite, ConvertMatmulToPointWiseConvolutionFixture,
-                         ::testing::Values(std::make_tuple(createTransformedGraph<CreateMatMul>(),
-                                                           createReferenceGraph(false /* addConstFakeQuantizeNode */,
-                                                                                false /* insertAddNode */,
-                                                                                false /* addOutFakeQuantizeNode */),
-                                                           createPassManager<GNAPluginNS::ConvertMatmulToPointWiseConvolution>()),
-                                           std::make_tuple(createTransformedGraph<CreateMatMul, CreateFakeQuantize>(),
-                                                           createReferenceGraph(true /* addConstFakeQuantizeNode */,
-                                                                                false /* insertAddNode */,
-                                                                                false /* addOutFakeQuantizeNode */),
-                                                           createPassManager<GNAPluginNS::ConvertMatmulToPointWiseConvolution>()),
-                                           std::make_tuple(createTransformedGraph<CreateAdd, CreateMatMul>(),
-                                                           createReferenceGraph(false /* addConstFakeQuantizeNode */,
-                                                                                true /* insertAddNode */,
-                                                                                false /* addOutFakeQuantizeNode */),
-                                                           createPassManager<GNAPluginNS::ConvertMatmulWithBiasToPointWiseConvolution>()),
-                                           std::make_tuple(createTransformedGraph<CreateAdd, CreateMatMul, CreateFakeQuantize>(),
-                                                           createReferenceGraph(true /* addConstFakeQuantizeNode */,
-                                                                                true /* insertAddNode */,
-                                                                                false /* addOutFakeQuantizeNode */),
-                                                           createPassManager<GNAPluginNS::ConvertMatmulWithBiasToPointWiseConvolution>()),
-                                           std::make_tuple(createTransformedGraph<CreateFakeQuantize, CreateAdd, CreateMatMul>(),
-                                                           createReferenceGraph(false /* addConstFakeQuantizeNode */,
-                                                                                true /* insertAddNode */,
-                                                                                true /* addOutFakeQuantizeNode */),
-                                                           createPassManager<GNAPluginNS::ConvertMatmulWithFqToPointWiseConvolution>()),
-                                           std::make_tuple(createTransformedGraph<CreateFakeQuantize, CreateAdd, CreateMatMul, CreateFakeQuantize>(),
-                                                           createReferenceGraph(true /* addConstFakeQuantizeNode */,
-                                                                                true /* insertAddNode */,
-                                                                                true /* addOutFakeQuantizeNode */),
-                                                           createPassManager<GNAPluginNS::ConvertMatmulWithFqToPointWiseConvolution>()),
-                                           std::make_tuple(createTransformedGraph<CreateFakeQuantize, CreateMatMul>(),
-                                                           createReferenceGraph(false /* addConstFakeQuantizeNode */,
-                                                                                false /* insertAddNode */,
-                                                                                true /* addOutFakeQuantizeNode */),
-                                                           createPassManager<GNAPluginNS::ConvertMatmulWithFqToPointWiseConvolution>()),
-                                           std::make_tuple(createTransformedGraph<CreateFakeQuantize, CreateMatMul, CreateFakeQuantize>(),
-                                                           createReferenceGraph(true /* addConstFakeQuantizeNode */,
-                                                                                false /* insertAddNode */,
-                                                                                true /* addOutFakeQuantizeNode */),
-                                                           createPassManager<GNAPluginNS::ConvertMatmulWithFqToPointWiseConvolution>())));
+    ::testing::Values(
+        std::make_tuple(
+            createTransformedGraph<CreateMatMul>(),
+            createReferenceGraph<!AddConstFakeQuantizeNode, !InsertAddNode, !OneDimensionalBiasShape, !AddOutFakeQuantizeNode>(),
+            createPassManager<GNAPluginNS::ConvertMatmulToPointWiseConvolution>()),
+        std::make_tuple(createTransformedGraph<CreateMatMul, CreateFakeQuantize>(),
+            createReferenceGraph<AddConstFakeQuantizeNode, !InsertAddNode, !OneDimensionalBiasShape, !AddOutFakeQuantizeNode>(),
+            createPassManager<GNAPluginNS::ConvertMatmulToPointWiseConvolution>()),
+        std::make_tuple(createTransformedGraph<CreateAdd<!OneDimensionalBiasShape>, CreateMatMul>(),
+            createReferenceGraph<!AddConstFakeQuantizeNode, InsertAddNode, !OneDimensionalBiasShape, !AddOutFakeQuantizeNode>(),
+            createPassManager<GNAPluginNS::ConvertMatmulWithBiasToPointWiseConvolution>()),
+        std::make_tuple(createTransformedGraph<CreateAdd<OneDimensionalBiasShape>, CreateMatMul>(),
+            createReferenceGraph<!AddConstFakeQuantizeNode, InsertAddNode, OneDimensionalBiasShape, !AddOutFakeQuantizeNode>(),
+            createPassManager<GNAPluginNS::ConvertMatmulWithBiasToPointWiseConvolution>()),
+        std::make_tuple(createTransformedGraph<CreateAdd<!OneDimensionalBiasShape>, CreateMatMul, CreateFakeQuantize>(),
+            createReferenceGraph<AddConstFakeQuantizeNode, InsertAddNode, !OneDimensionalBiasShape, !AddOutFakeQuantizeNode>(),
+            createPassManager<GNAPluginNS::ConvertMatmulWithBiasToPointWiseConvolution>()),
+        std::make_tuple(createTransformedGraph<CreateAdd<OneDimensionalBiasShape>, CreateMatMul, CreateFakeQuantize>(),
+            createReferenceGraph<AddConstFakeQuantizeNode, InsertAddNode, OneDimensionalBiasShape, !AddOutFakeQuantizeNode>(),
+            createPassManager<GNAPluginNS::ConvertMatmulWithBiasToPointWiseConvolution>()),
+        std::make_tuple(createTransformedGraph<CreateFakeQuantize, CreateAdd<!OneDimensionalBiasShape>, CreateMatMul>(),
+            createReferenceGraph<!AddConstFakeQuantizeNode, InsertAddNode, !OneDimensionalBiasShape, AddOutFakeQuantizeNode>(),
+            createPassManager<GNAPluginNS::ConvertMatmulWithFqToPointWiseConvolution>()),
+        std::make_tuple(createTransformedGraph<CreateFakeQuantize, CreateAdd<OneDimensionalBiasShape>, CreateMatMul>(),
+            createReferenceGraph<!AddConstFakeQuantizeNode, InsertAddNode, OneDimensionalBiasShape, AddOutFakeQuantizeNode>(),
+            createPassManager<GNAPluginNS::ConvertMatmulWithFqToPointWiseConvolution>()),
+        std::make_tuple(createTransformedGraph<CreateFakeQuantize, CreateAdd<!OneDimensionalBiasShape>, CreateMatMul, CreateFakeQuantize>(),
+            createReferenceGraph<AddConstFakeQuantizeNode, InsertAddNode, !OneDimensionalBiasShape, AddOutFakeQuantizeNode>(),
+            createPassManager<GNAPluginNS::ConvertMatmulWithFqToPointWiseConvolution>()),
+        std::make_tuple(createTransformedGraph<CreateFakeQuantize, CreateAdd<OneDimensionalBiasShape>, CreateMatMul, CreateFakeQuantize>(),
+            createReferenceGraph<AddConstFakeQuantizeNode, InsertAddNode, OneDimensionalBiasShape, AddOutFakeQuantizeNode>(),
+            createPassManager<GNAPluginNS::ConvertMatmulWithFqToPointWiseConvolution>()),
+        std::make_tuple(createTransformedGraph<CreateFakeQuantize, CreateMatMul>(),
+            createReferenceGraph<!AddConstFakeQuantizeNode, !InsertAddNode, !OneDimensionalBiasShape, AddOutFakeQuantizeNode>(),
+            createPassManager<GNAPluginNS::ConvertMatmulWithFqToPointWiseConvolution>()),
+        std::make_tuple(createTransformedGraph<CreateFakeQuantize, CreateMatMul, CreateFakeQuantize>(),
+            createReferenceGraph<AddConstFakeQuantizeNode, !InsertAddNode, !OneDimensionalBiasShape, AddOutFakeQuantizeNode>(),
+            createPassManager<GNAPluginNS::ConvertMatmulWithFqToPointWiseConvolution>())));
 
 // -------------------------------------------------------------------------------------------------------
 
@@ -377,19 +398,19 @@ std::vector<FixtureData> transform_types = {
                         CreateMatMul,
                         CreateFakeQuantize>(),
     FixtureData::create<GNAPluginNS::ConvertMatmulWithBiasToPointWiseConvolution,
-                        CreateAdd,
+                        CreateAdd<false>,
                         CreateMatMul>(),
     FixtureData::create<GNAPluginNS::ConvertMatmulWithBiasToPointWiseConvolution,
-                        CreateAdd,
+                        CreateAdd<false>,
                         CreateMatMul,
                         CreateFakeQuantize>(),
     FixtureData::create<GNAPluginNS::ConvertMatmulWithFqToPointWiseConvolution,
                         CreateFakeQuantize,
-                        CreateAdd,
+                        CreateAdd<false>,
                         CreateMatMul>(),
     FixtureData::create<GNAPluginNS::ConvertMatmulWithFqToPointWiseConvolution,
                         CreateFakeQuantize,
-                        CreateAdd,
+                        CreateAdd<false>,
                         CreateMatMul,
                         CreateFakeQuantize>(),
     FixtureData::create<GNAPluginNS::ConvertMatmulWithFqToPointWiseConvolution,


### PR DESCRIPTION
**Details:**
During the transformation, the input data is transposed to NCHW before Convolution, and the bias data is not. This leads to an error when adding data from the Convolution layer and the bias.

**Ticket**
CVS-60486