### PR TITLE
Fixing Split-Concat reverse input channel

### DIFF
--- a/model-optimizer/extensions/back/ReverseInputChannels.py
+++ b/model-optimizer/extensions/back/ReverseInputChannels.py
@@ -94,23 +94,49 @@ class ReverseChannelsPropagationDown(BackReplacementPattern):
 
         'Shape': lambda node, rc: ReverseChannelsPropagationDown.pass_rc_through_shape(node, rc),
         'ShapeOf': lambda node, rc: ReverseChannelsPropagationDown.pass_rc_through_shape(node, rc),
+
+        'Pad': lambda node, rc: ReverseChannelsPropagationDown.pass_rc_through(node, rc),
     }
+
+    @staticmethod
+    def pass_rc_through(node: Node, reverse_channels: Node):
+        r"""
+        BEFORE                          AFTER
+          previous_op
+              |
+        ReverseChannels  previous_op     previous_op  previous_op
+                     \     /                      \     /
+                       Node                         Node
+                                                     |
+                                              ReverseChannels
+        returns boolean value whatever we should continue propagating current ReverseChannels operation down or not
+        """
+        # detaching reverse_channels node from the graph
+        if reverse_channels.is_in_port_connected(0) and reverse_channels.is_out_port_connected(0) \
+                and node.is_out_port_connected(0):
+            reverse_channels.out_port(0).get_connection().set_source(
+                reverse_channels.in_port(0).get_connection().get_source())
+            reverse_channels.in_port(0).disconnect()
+
+            node.out_port(0).get_connection().set_source(reverse_channels.out_port(0))
+            node.out_port(0).disconnect()
+            node.out_port(0).connect(reverse_channels.in_port(0))
+            return True
+        return False
 
     @staticmethod
     def pass_rc_through_conv(node, reverse_channels):
         r"""
         For non grouped convolution:
         BEFORE                          AFTER
-
           previous_op                                   weights
               |                                          |
         ReverseChannels    weights   previous_op   ReverseChannels
                      \     /                 \     /
                       Conv                    Conv
-            
+
         For grouped convolution:
         BEFORE                          AFTER
-
           previous_op                                   weights
               |                                          |
         ReverseChannels    weights   previous_op   ReverseChannels
@@ -118,7 +144,6 @@ class ReverseChannelsPropagationDown(BackReplacementPattern):
                       Conv                    Conv
                                                |
                                         ReverseChannels
-
         returns boolean value whatever we should continue propagating current ReverseChannels operation down or not
         """
         channel_idx = node.soft_get("input_feature_channel", None)
@@ -170,7 +195,6 @@ class ReverseChannelsPropagationDown(BackReplacementPattern):
     def pass_rc_through_eltwise(node, reverse_channels):
         r"""
         BEFORE                              AFTER
-
           previous_op                                       previous_op'
               |                                                 |
         ReverseChannels  previous_op'    previous_op     ReverseChannels
@@ -178,7 +202,6 @@ class ReverseChannelsPropagationDown(BackReplacementPattern):
                      Eltwise                        Eltwise
                                                       |
                                                 ReverseChannels
-
         returns boolean value whatever we should continue propagating current ReverseChannels operation down or not
         """
         before_shape = reverse_channels.out_port(0).data.get_shape()
@@ -265,13 +288,41 @@ class ReverseChannelsPropagationUp(BackReplacementPattern):
         'Subtract': lambda node, rc: ReverseChannelsPropagationUp.lift_up_through_eltwise(node, rc),
         'Pow': lambda node, rc: ReverseChannelsPropagationUp.lift_up_through_eltwise(node, rc),
         'Convert': lambda node, rc: ReverseChannelsPropagationUp.lift_up_through_eltwise(node, rc),
+
+        'Pad': lambda node, rc: ReverseChannelsPropagationUp.lift_up_through(node, rc),
     }
+
+    @staticmethod
+    def lift_up_through(node: Node, reverse_channels: Node):
+        r"""
+        BEFORE                       AFTER
+                                     previous_op
+                                          \
+        previous_op  previous_op       ReverseChannels  previous_op
+                 \     /                           \     /
+                   Node                             Node
+                    |                                |
+              ReverseChannels                      next_op
+                    |
+                 next_op
+        returns boolean value whatever we should continue propagating current ReverseChannels operation up or not
+        """
+        if node.is_in_port_connected(0):
+            node_input_port_0 = node.in_port(0)
+            reverse_channels_out_npde = reverse_channels.out_port(0).get_connection().get_destination().node
+            reverse_channels.out_port(0).disconnect()
+
+            src = node_input_port_0.get_connection().get_source()
+            node_input_port_0.get_connection().set_source(reverse_channels.out_port(0))
+            src.connect(reverse_channels.in_port(0))
+            node.out_port(0).get_connection().set_destination(reverse_channels_out_npde.in_port(0))
+            return True
+        return False
 
     @staticmethod
     def lift_up_through_eltwise(node: Node, reverse_channels: Node):
         r"""
         BEFORE                      AFTER
-
                                     previous_op              previous_op'
                                           \                    /
         previous_op  previous_op'     ReverseChannels     ReverseChannels
@@ -281,7 +332,6 @@ class ReverseChannelsPropagationUp(BackReplacementPattern):
              ReverseChannels                       next_op
                   |
                 next_op
-
         returns two objects:
         first - boolean value whatever we should continue propagating current ReverseChannels operation up or not
         second - list of new ReverseChannels operations that were produced while propagating reverse_channels up
@@ -405,7 +455,7 @@ class ApplyReverseChannels(BackReplacementPattern):
 
     def find_and_replace_pattern(self, graph: Graph):
         """
-        Following transformations should run in strict order, that is why we disabled them all and run here 
+        Following transformations should run in strict order, that is why we disabled them all and run here
         """
         if graph.graph['cmd_params'].reverse_input_channels:
             InsertReverseChannels().find_and_replace_pattern(graph)

--- a/model-optimizer/extensions/back/ReverseInputChannels.py
+++ b/model-optimizer/extensions/back/ReverseInputChannels.py
@@ -102,8 +102,9 @@ class ReverseChannelsPropagationDown(BackReplacementPattern):
     def pass_rc_through(node: Node, reverse_channels: Node):
         r"""
         BEFORE                          AFTER
-          previous_op
-              |
+
+        previous_op
+            |
         ReverseChannels  previous_op     previous_op  previous_op
                      \     /                      \     /
                        Node                         Node
@@ -202,6 +203,7 @@ class ReverseChannelsPropagationDown(BackReplacementPattern):
                      Eltwise                        Eltwise
                                                       |
                                                 ReverseChannels
+
         returns boolean value whatever we should continue propagating current ReverseChannels operation down or not
         """
         before_shape = reverse_channels.out_port(0).data.get_shape()
@@ -296,6 +298,7 @@ class ReverseChannelsPropagationUp(BackReplacementPattern):
     def lift_up_through(node: Node, reverse_channels: Node):
         r"""
         BEFORE                       AFTER
+
                                      previous_op
                                           \
         previous_op  previous_op       ReverseChannels  previous_op

--- a/model-optimizer/extensions/front/tf/pad_tf_to_pad.py
+++ b/model-optimizer/extensions/front/tf/pad_tf_to_pad.py
@@ -34,12 +34,6 @@ class PadTFToPad(FrontReplacementPattern):
                 # the input with fill value is an optional third input in TF
                 if not tfpad.in_port(2).disconnected():
                     tfpad.in_port(2).get_connection().set_destination(new_pad.in_port(3))
-                else:
-                    # create Constant node of proper data type (equal to the data type of the Pad first input)
-                    convert_pad_value = create_op_with_const_inputs(graph, ConvertLike, {0: 0.0},
-                                                                    {'name': original_name + '/pad_value_convert'})
-                    convert_pad_value.in_port(1).connect(new_pad.in_port(0).get_source())
-                    new_pad.in_port(3).connect(convert_pad_value.out_port(0))
 
             # convert TF representation of the pads as [N, 2] to MO representation: [N] and [N]
             transposed_pads = create_op_with_const_inputs(graph, Transpose, {1: int64_array([1, 0])})

--- a/model-optimizer/unit_tests/extensions/back/ReverseInputChannels_test.py
+++ b/model-optimizer/unit_tests/extensions/back/ReverseInputChannels_test.py
@@ -3,9 +3,10 @@
 
 import unittest
 
-from extensions.back.ReverseInputChannels import ReverseChannelsPropagationUp
+from extensions.back.ReverseInputChannels import ReverseChannelsPropagationUp, ReverseChannelsPropagationDown
 from mo.graph.graph import Node, Graph
-from unit_tests.utils.graph import build_graph, result, connect, regular_op_with_shaped_data
+from unit_tests.utils.graph import build_graph, result, connect, regular_op_with_shaped_data, valued_const_with_data
+from mo.front.common.partial_infer.utils import int64_array, float32_array
 
 nodes = {
     **regular_op_with_shaped_data('placeholder1', [1, 3, 10, 10], {'type': 'Parameter'}),
@@ -14,6 +15,22 @@ nodes = {
     **regular_op_with_shaped_data('mul', [1, 3, 10, 10], {'type': 'Multiply'}),
     **regular_op_with_shaped_data('reverse_channels', [1, 3, 10, 10], {'type': 'ReverseChannels', 'axis': 1}),
 
+
+    **regular_op_with_shaped_data('pad', [1, 3, 10, 10], {'type': 'Pad'}),
+
+    **result('result'),
+}
+
+
+nodes2 = {
+    **regular_op_with_shaped_data('placeholder', [1, 3, 10, 10], {'type': 'Parameter'}),
+
+    **valued_const_with_data('mul_const', float32_array([-127.5, -127.5, -127.5])),
+    **regular_op_with_shaped_data('mul', [1, 3, 10, 10], {'type': 'Multiply'}),
+    **valued_const_with_data('pad_const_1', int64_array([0, 0, 0, 0])),
+    **valued_const_with_data('pad_const_2', int64_array([0, 0, 1, 1])),
+    **regular_op_with_shaped_data('pad', [1, 3, 10, 10], {'type': 'Pad'}),
+    **regular_op_with_shaped_data('reverse_channels', [1, 3, 10, 10], {'type': 'ReverseChannels', 'axis': 1}),
     **result('result'),
 }
 
@@ -47,3 +64,29 @@ class ReverseInputChannelsTest(unittest.TestCase):
 
         ReverseChannelsPropagationUp.lift_up_through_eltwise(node, reverse_channels)
         self.check_graph_attrs(graph, ['placeholder1', 'placeholder2'])
+
+    def test_lift_up_through(self):
+        graph = build_graph(nodes2, [*connect('placeholder', '0:mul'), *connect('mul_const', '1:mul'),
+                                     *connect('mul', '0:pad'), *connect('pad_const_1', '1:pad'),
+                                     *connect('pad_const_2', '2:pad'), *connect('pad', 'reverse_channels'),
+                                     *connect('reverse_channels', 'result')])
+        self.set_graph_attrs(graph, ['placeholder'])
+
+        node = Node(graph, 'pad')
+        reverse_channels = Node(graph, 'reverse_channels')
+
+        ReverseChannelsPropagationUp.lift_up_through(node, reverse_channels)
+        self.check_graph_attrs(graph, ['placeholder'])
+
+    def test_pass_rc_through(self):
+        graph = build_graph(nodes2, [*connect('placeholder', '0:mul'), *connect('mul_const', '1:mul'),
+                                     *connect('mul', 'reverse_channels'),  *connect('reverse_channels', '0:pad'),
+                                     *connect('pad_const_1', '1:pad'), *connect('pad_const_2', '2:pad'),
+                                     *connect('pad', 'result')])
+        self.set_graph_attrs(graph, ['placeholder'])
+
+        node = Node(graph, 'pad')
+        reverse_channels = Node(graph, 'reverse_channels')
+
+        ReverseChannelsPropagationDown.pass_rc_through(node, reverse_channels)
+        self.check_graph_attrs(graph, ['placeholder'])

--- a/model-optimizer/unit_tests/extensions/front/tf/pad_tf_to_pad_test.py
+++ b/model-optimizer/unit_tests/extensions/front/tf/pad_tf_to_pad_test.py
@@ -74,9 +74,7 @@ class PadTFToPadTest(unittest.TestCase):
                             {}, nodes_with_edges_only=True)
         graph.get_op_nodes(op='TFPad')[0].add_input_port(2)
 
-        graph_ref = build_graph(nodes_attributes, common_edges + [('pad_fill', 'convert_like', {'in': 0, 'out': 0}),
-                                                                  ('placeholder', 'convert_like', {'in': 1, 'out': 0}),
-                                                                  ('convert_like', 'pad', {'in': 3, 'out': 0})],
+        graph_ref = build_graph(nodes_attributes, common_edges,
                                 {}, nodes_with_edges_only=True)
         self._run_test(graph, graph_ref)
 


### PR DESCRIPTION
Ticket: 59156

The is copy of code from MR https://github.com/openvinotoolkit/openvino/pull/6506 for release branch.

Pattern Split->Concat was added before Pad op.
As a part of optimizations ReverseChannels operation was replacing to pattern Split->Сoncat. Earlier if the pattern inserted before Pad layer we fused it to Pad. But it was wrong and the optimization was removed. So the root cause is that before Pad we insert  Split->Сoncat pattern and it leads to regression for some topologies.

![Screenshot (18)](https://user-images.githubusercontent.com/29801542/124589561-cc427200-de62-11eb-826e-c87da31ae9db.png)

The fix moves ReverseChannels after Pad layer. It allows optimize reverse input channels propagation and avoid work around with insert Split->Сoncat subgraph.

* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR N/A
* [x]  Transformation preserves original framework node names N/A: a special case, when we should rename the nodes

Validation:
* [x]  Unit tests
* [x]  Framework operation tests N/A
* [x]  Transformation tests N/A
* [x]  Model Optimizer IR Reader check N/A

Documentation:
* [x]  Supported frameworks operations list N/A: no new operations were enabled
* [x]  Guide on how to convert the **public** model N/A no new models were enabled
* [x]  User guide update N/A
