### PR TITLE
PDPD: Install generated PDPD test models as 'test' component

### DIFF
--- a/.ci/azure/linux.yml
+++ b/.ci/azure/linux.yml
@@ -161,7 +161,9 @@ jobs:
     displayName: 'Model Optimizer UT'
     continueOnError: false
 
-  - script: . $(SETUPVARS) && $(INSTALL_TEST_DIR)/unit-test --gtest_print_time=1 --gtest_filter=-backend_api.config_unsupported:*IE_GPU* --gtest_output=xml:TEST-NGraphUT.xml
+  - script: |
+      export FE_TEST_MODELS=$(INSTALL_DIR)/tests
+      . $(SETUPVARS) && $(INSTALL_TEST_DIR)/unit-test --gtest_print_time=1 --gtest_filter=-backend_api.config_unsupported:*IE_GPU* --gtest_output=xml:TEST-NGraphUT.xml
     displayName: 'nGraph UT'
     continueOnError: false
 

--- a/ngraph/test/CMakeLists.txt
+++ b/ngraph/test/CMakeLists.txt
@@ -549,6 +549,8 @@ file(GLOB FRONTEND_SHARED_TESTS_SRC ${CMAKE_CURRENT_SOURCE_DIR}/frontend/shared/
 file(GLOB FRONTEND_SHARED_TESTS_HDR ${CMAKE_CURRENT_SOURCE_DIR}/frontend/shared/include/*.hpp)
 set(SRC ${FRONTEND_SHARED_TESTS_SRC} ${SRC})
 
+add_definitions("-DTEST_MODEL_BUILD_DIR=\"${CMAKE_CURRENT_BINARY_DIR}\"")
+
 # ---- PaddlePaddle FrontEnd testing ------
 if (NGRAPH_PDPD_FRONTEND_ENABLE)
     ie_check_pip_package(paddlepaddle WARNING)
@@ -556,8 +558,9 @@ if (NGRAPH_PDPD_FRONTEND_ENABLE)
     if(paddlepaddle_FOUND)
         file(GLOB FRONTEND_PDPD_TESTS_SRC ${CMAKE_CURRENT_SOURCE_DIR}/frontend/paddlepaddle/*.cpp)
         set(SRC ${FRONTEND_PDPD_TESTS_SRC} ${SRC})
-        set(TEST_PDPD_MODELS ${CMAKE_CURRENT_BINARY_DIR}/pdpd_test_models/)
-        add_definitions("-DTEST_PDPD_MODELS=\"${TEST_PDPD_MODELS}\"")
+        set(PDPD_TEST_MODELS_DIRNAME pdpd_test_models)
+        set(TEST_PDPD_MODELS ${CMAKE_CURRENT_BINARY_DIR}/${PDPD_TEST_MODELS_DIRNAME}/)
+        add_definitions("-DTEST_PDPD_MODELS_DIRNAME=\"${PDPD_TEST_MODELS_DIRNAME}/\"")
     endif()
 endif()
 # ---- End PaddlePaddle FrontEnd testing ------
@@ -657,4 +660,9 @@ if (NGRAPH_PDPD_FRONTEND_ENABLE AND paddlepaddle_FOUND)
     add_custom_target(pdpd_test_models DEPENDS ${OUT_FILES})
     add_dependencies(unit-test pdpd_test_models)
     add_dependencies(unit-test paddlepaddle_ngraph_frontend)
+
+    install(DIRECTORY ${TEST_PDPD_MODELS}
+            DESTINATION tests/${PDPD_TEST_MODELS_DIRNAME}
+            COMPONENT tests
+            EXCLUDE_FROM_ALL)
 endif()

--- a/ngraph/test/frontend/paddlepaddle/basic_api.cpp
+++ b/ngraph/test/frontend/paddlepaddle/basic_api.cpp
@@ -23,6 +23,6 @@ static const std::vector<std::string> models{
 INSTANTIATE_TEST_SUITE_P(PDPDBasicTest,
                          FrontEndBasicTest,
                          ::testing::Combine(::testing::Values(PDPD),
-                                            ::testing::Values(std::string(TEST_PDPD_MODELS)),
+                                            ::testing::Values(std::string(TEST_PDPD_MODELS_DIRNAME)),
                                             ::testing::ValuesIn(models)),
                          FrontEndBasicTest::getTestCaseName);

--- a/ngraph/test/frontend/paddlepaddle/basic_api.cpp
+++ b/ngraph/test/frontend/paddlepaddle/basic_api.cpp
@@ -20,9 +20,10 @@ static const std::vector<std::string> models{
     std::string("2in_2out_dynbatch/2in_2out_dynbatch.pdmodel"),
 };
 
-INSTANTIATE_TEST_SUITE_P(PDPDBasicTest,
-                         FrontEndBasicTest,
-                         ::testing::Combine(::testing::Values(PDPD),
-                                            ::testing::Values(std::string(TEST_PDPD_MODELS_DIRNAME)),
-                                            ::testing::ValuesIn(models)),
-                         FrontEndBasicTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(
+    PDPDBasicTest,
+    FrontEndBasicTest,
+    ::testing::Combine(::testing::Values(PDPD),
+                       ::testing::Values(std::string(TEST_PDPD_MODELS_DIRNAME)),
+                       ::testing::ValuesIn(models)),
+    FrontEndBasicTest::getTestCaseName);

--- a/ngraph/test/frontend/paddlepaddle/cut_specific_model.cpp
+++ b/ngraph/test/frontend/paddlepaddle/cut_specific_model.cpp
@@ -15,7 +15,7 @@ static CutModelParam getTestData_2in_2out()
 {
     CutModelParam res;
     res.m_frontEndName = PDPD;
-    res.m_modelsPath = std::string(TEST_PDPD_MODELS);
+    res.m_modelsPath = std::string(TEST_PDPD_MODELS_DIRNAME);
     res.m_modelName = "2in_2out/2in_2out.pdmodel";
     res.m_oldInputs = {"inputX1", "inputX2"};
     res.m_newInputs = {"add1.tmp_0"};

--- a/ngraph/test/frontend/paddlepaddle/load_from.cpp
+++ b/ngraph/test/frontend/paddlepaddle/load_from.cpp
@@ -15,7 +15,7 @@ static LoadFromFEParam getTestData()
 {
     LoadFromFEParam res;
     res.m_frontEndName = PDPD;
-    res.m_modelsPath = std::string(TEST_PDPD_MODELS);
+    res.m_modelsPath = std::string(TEST_PDPD_MODELS_DIRNAME);
     res.m_file = "conv2d";
     res.m_files = {"2in_2out/2in_2out.pdmodel", "2in_2out/2in_2out.pdiparams"};
     res.m_stream = "relu/relu.pdmodel";

--- a/ngraph/test/frontend/paddlepaddle/op_fuzzy.cpp
+++ b/ngraph/test/frontend/paddlepaddle/op_fuzzy.cpp
@@ -32,9 +32,10 @@ static const std::vector<std::string> models{
     std::string("relu"),
 };
 
-INSTANTIATE_TEST_SUITE_P(PDPDFuzzyOpTest,
-                         FrontEndFuzzyOpTest,
-                         ::testing::Combine(::testing::Values(PDPD),
-                                            ::testing::Values(std::string(TEST_PDPD_MODELS_DIRNAME)),
-                                            ::testing::ValuesIn(models)),
-                         PDPDFuzzyOpTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(
+    PDPDFuzzyOpTest,
+    FrontEndFuzzyOpTest,
+    ::testing::Combine(::testing::Values(PDPD),
+                       ::testing::Values(std::string(TEST_PDPD_MODELS_DIRNAME)),
+                       ::testing::ValuesIn(models)),
+    PDPDFuzzyOpTest::getTestCaseName);

--- a/ngraph/test/frontend/paddlepaddle/op_fuzzy.cpp
+++ b/ngraph/test/frontend/paddlepaddle/op_fuzzy.cpp
@@ -35,6 +35,6 @@ static const std::vector<std::string> models{
 INSTANTIATE_TEST_SUITE_P(PDPDFuzzyOpTest,
                          FrontEndFuzzyOpTest,
                          ::testing::Combine(::testing::Values(PDPD),
-                                            ::testing::Values(std::string(TEST_PDPD_MODELS)),
+                                            ::testing::Values(std::string(TEST_PDPD_MODELS_DIRNAME)),
                                             ::testing::ValuesIn(models)),
                          PDPDFuzzyOpTest::getTestCaseName);

--- a/ngraph/test/frontend/paddlepaddle/partial_shape.cpp
+++ b/ngraph/test/frontend/paddlepaddle/partial_shape.cpp
@@ -64,7 +64,7 @@ static PartShape getTestShape_conv2d_relu()
 INSTANTIATE_TEST_SUITE_P(PDPDPartialShapeTest,
                          FrontEndPartialShapeTest,
                          ::testing::Combine(::testing::Values(BaseFEParam{
-                                                PDPD, std::string(TEST_PDPD_MODELS)}),
+                                                PDPD, std::string(TEST_PDPD_MODELS_DIRNAME)}),
                                             ::testing::ValuesIn(std::vector<PartShape>{
                                                 getTestShape_2in_2out(),
                                                 getTestShape_conv2d_relu(),

--- a/ngraph/test/frontend/paddlepaddle/places.cpp
+++ b/ngraph/test/frontend/paddlepaddle/places.cpp
@@ -9,7 +9,8 @@
 
 using namespace ngraph::frontend;
 
-const std::string model_file = "place_test_model/place_test_model.pdmodel";
+const std::string model_file =
+    std::string(TEST_PDPD_MODELS_DIRNAME) + "place_test_model/place_test_model.pdmodel";
 
 /***
 model:
@@ -57,7 +58,7 @@ TEST(PDPD_Places, check_tensor_names)
     FrontEndTestUtils::setupTestEnv();
     auto m_fem = FrontEndManager();
     auto frontend = m_fem.load_by_framework("pdpd");
-    auto input_model = frontend->load(TEST_PDPD_MODELS + model_file);
+    auto input_model = frontend->load(FrontEndTestUtils::make_model_path(model_file));
 
     for (const auto& tensor_name : tensor_names)
     {
@@ -71,7 +72,7 @@ TEST(PDPD_Places, check_input_outputs)
     FrontEndTestUtils::setupTestEnv();
     auto m_fem = FrontEndManager();
     auto frontend = m_fem.load_by_framework("pdpd");
-    auto input_model = frontend->load(TEST_PDPD_MODELS + model_file);
+    auto input_model = frontend->load(FrontEndTestUtils::make_model_path(model_file));
 
     auto inputs = input_model->get_inputs();
     auto outputs = input_model->get_outputs();
@@ -106,7 +107,7 @@ TEST(PDPD_Places, check_out_port_of_all_ops)
     FrontEndTestUtils::setupTestEnv();
     auto m_fem = FrontEndManager();
     auto frontend = m_fem.load_by_framework("pdpd");
-    auto input_model = frontend->load(TEST_PDPD_MODELS + model_file);
+    auto input_model = frontend->load(FrontEndTestUtils::make_model_path(model_file));
 
     for (const auto& tensor_name : tensor_names)
     {
@@ -129,7 +130,7 @@ TEST(PDPD_Places, check_in_out_ports_of_model_outputs)
     FrontEndTestUtils::setupTestEnv();
     auto m_fem = FrontEndManager();
     auto frontend = m_fem.load_by_framework("pdpd");
-    auto input_model = frontend->load(TEST_PDPD_MODELS + model_file);
+    auto input_model = frontend->load(FrontEndTestUtils::make_model_path(model_file));
 
     auto outputs = input_model->get_outputs();
     for (const auto& output : outputs)
@@ -164,7 +165,7 @@ TEST(PDPD_Places, check_source_target_tensors_of_model_outputs)
     FrontEndTestUtils::setupTestEnv();
     auto m_fem = FrontEndManager();
     auto frontend = m_fem.load_by_framework("pdpd");
-    auto input_model = frontend->load(TEST_PDPD_MODELS + model_file);
+    auto input_model = frontend->load(FrontEndTestUtils::make_model_path(model_file));
 
     auto outputs = input_model->get_outputs();
     for (const auto& output : outputs)
@@ -199,7 +200,7 @@ TEST(PDPD_Places, check_producing_consuming_ops_of_model_outputs)
     FrontEndTestUtils::setupTestEnv();
     auto m_fem = FrontEndManager();
     auto frontend = m_fem.load_by_framework("pdpd");
-    auto input_model = frontend->load(TEST_PDPD_MODELS + model_file);
+    auto input_model = frontend->load(FrontEndTestUtils::make_model_path(model_file));
 
     auto outputs = input_model->get_outputs();
     for (const auto& output : outputs)
@@ -235,7 +236,7 @@ TEST(PDPD_Places, check_data_flow)
     FrontEndTestUtils::setupTestEnv();
     auto m_fem = FrontEndManager();
     auto frontend = m_fem.load_by_framework("pdpd");
-    auto input_model = frontend->load(TEST_PDPD_MODELS + model_file);
+    auto input_model = frontend->load(FrontEndTestUtils::make_model_path(model_file));
 
     for (const auto& tensor_name : tensor_names)
     {
@@ -276,7 +277,7 @@ TEST(PDPD_Places, check_tensor_to_multiple_ports)
     FrontEndTestUtils::setupTestEnv();
     auto m_fem = FrontEndManager();
     auto frontend = m_fem.load_by_framework("pdpd");
-    auto input_model = frontend->load(TEST_PDPD_MODELS + model_file);
+    auto input_model = frontend->load(FrontEndTestUtils::make_model_path(model_file));
 
     for (const auto& tensor_name : tensor_names)
     {
@@ -308,7 +309,7 @@ TEST(PDPD_Places, check_consuming_ops)
     FrontEndTestUtils::setupTestEnv();
     auto m_fem = FrontEndManager();
     auto frontend = m_fem.load_by_framework("pdpd");
-    auto input_model = frontend->load(TEST_PDPD_MODELS + model_file);
+    auto input_model = frontend->load(FrontEndTestUtils::make_model_path(model_file));
 
     for (const auto& tensor_name : tensor_names)
     {
@@ -353,7 +354,7 @@ TEST(PDPD_Places, check_consuming_ops_2)
     FrontEndTestUtils::setupTestEnv();
     auto m_fem = FrontEndManager();
     auto frontend = m_fem.load_by_framework("pdpd");
-    auto input_model = frontend->load(TEST_PDPD_MODELS + model_file);
+    auto input_model = frontend->load(FrontEndTestUtils::make_model_path(model_file));
 
     auto it = find(tensor_names.begin(), tensor_names.end(), "lstm_0.tmp_2");
     EXPECT_NE(it, tensor_names.end());
@@ -395,7 +396,7 @@ TEST(PDPD_Places, check_producing_ops)
     FrontEndTestUtils::setupTestEnv();
     auto m_fem = FrontEndManager();
     auto frontend = m_fem.load_by_framework("pdpd");
-    auto input_model = frontend->load(TEST_PDPD_MODELS + model_file);
+    auto input_model = frontend->load(FrontEndTestUtils::make_model_path(model_file));
 
     for (const auto& tensor_name : tensor_names)
     {
@@ -419,7 +420,7 @@ TEST(PDPD_Places, check_input_output_ports_dy_idx)
     FrontEndTestUtils::setupTestEnv();
     auto m_fem = FrontEndManager();
     auto frontend = m_fem.load_by_framework("pdpd");
-    auto input_model = frontend->load(TEST_PDPD_MODELS + model_file);
+    auto input_model = frontend->load(FrontEndTestUtils::make_model_path(model_file));
 
     std::vector<std::string> output_names = {"save_infer_model/scale_0.tmp_1",
                                              "save_infer_model/scale_1.tmp_1",
@@ -446,7 +447,7 @@ TEST(PDPD_Places, check_ops_tensors_by_idx)
     FrontEndTestUtils::setupTestEnv();
     auto m_fem = FrontEndManager();
     auto frontend = m_fem.load_by_framework("pdpd");
-    auto input_model = frontend->load(TEST_PDPD_MODELS + model_file);
+    auto input_model = frontend->load(FrontEndTestUtils::make_model_path(model_file));
 
     std::vector<std::string> output_names = {"save_infer_model/scale_0.tmp_1",
                                              "save_infer_model/scale_1.tmp_1",

--- a/ngraph/test/frontend/paddlepaddle/set_element_type.cpp
+++ b/ngraph/test/frontend/paddlepaddle/set_element_type.cpp
@@ -15,7 +15,7 @@ static SetTypeFEParam getTestData_relu()
 {
     SetTypeFEParam res;
     res.m_frontEndName = PDPD;
-    res.m_modelsPath = std::string(TEST_PDPD_MODELS);
+    res.m_modelsPath = std::string(TEST_PDPD_MODELS_DIRNAME);
     res.m_modelName = "relu/relu.pdmodel";
     return res;
 }

--- a/ngraph/test/frontend/shared/include/utils.hpp
+++ b/ngraph/test/frontend/shared/include/utils.hpp
@@ -4,11 +4,11 @@
 
 #pragma once
 
-#include <string>
 #include <fstream>
+#include <string>
 #include "backend.hpp"
-#include "ngraph/file_util.hpp"
 #include "ngraph/env_util.hpp"
+#include "ngraph/file_util.hpp"
 
 // Helper functions
 namespace FrontEndTestUtils
@@ -49,17 +49,22 @@ namespace FrontEndTestUtils
         set_test_env("OV_FRONTEND_PATH", fePath.c_str());
     }
 
-    inline bool exists(const std::string& file) {
+    inline bool exists(const std::string& file)
+    {
         std::ifstream str(file, std::ios::in | std::ifstream::binary);
         return str.is_open();
     }
 
-    inline std::string make_model_path(const std::string& modelsRelativePath) {
+    inline std::string make_model_path(const std::string& modelsRelativePath)
+    {
         // First try build path
         auto res = std::string(TEST_MODEL_BUILD_DIR) + "/" + modelsRelativePath;
-        if (exists(res)) {
+        if (exists(res))
+        {
             return res;
-        } else {
+        }
+        else
+        {
             // Install case: if model file does not exist, use base path from env variable
             return std::string(ngraph::getenv_string("FE_TEST_MODELS")) + "/" + modelsRelativePath;
         }

--- a/ngraph/test/frontend/shared/include/utils.hpp
+++ b/ngraph/test/frontend/shared/include/utils.hpp
@@ -5,8 +5,10 @@
 #pragma once
 
 #include <string>
+#include <fstream>
 #include "backend.hpp"
 #include "ngraph/file_util.hpp"
+#include "ngraph/env_util.hpp"
 
 // Helper functions
 namespace FrontEndTestUtils
@@ -45,5 +47,21 @@ namespace FrontEndTestUtils
         std::string fePath = ngraph::file_util::get_directory(
             ngraph::runtime::Backend::get_backend_shared_library_search_directory());
         set_test_env("OV_FRONTEND_PATH", fePath.c_str());
+    }
+
+    inline bool exists(const std::string& file) {
+        std::ifstream str(file, std::ios::in | std::ifstream::binary);
+        return str.is_open();
+    }
+
+    inline std::string make_model_path(const std::string& modelsRelativePath) {
+        // First try build path
+        auto res = std::string(TEST_MODEL_BUILD_DIR) + "/" + modelsRelativePath;
+        if (exists(res)) {
+            return res;
+        } else {
+            // Install case: if model file does not exist, use base path from env variable
+            return std::string(ngraph::getenv_string("FE_TEST_MODELS")) + "/" + modelsRelativePath;
+        }
     }
 } // namespace FrontEndTestUtils

--- a/ngraph/test/frontend/shared/src/basic_api.cpp
+++ b/ngraph/test/frontend/shared/src/basic_api.cpp
@@ -25,7 +25,7 @@ void FrontEndBasicTest::SetUp()
 void FrontEndBasicTest::initParamTest()
 {
     std::tie(m_feName, m_pathToModels, m_modelFile) = GetParam();
-    m_modelFile = m_pathToModels + m_modelFile;
+    m_modelFile = FrontEndTestUtils::make_model_path(m_pathToModels + m_modelFile);
 }
 
 void FrontEndBasicTest::doLoadFromFile()

--- a/ngraph/test/frontend/shared/src/cut_specific_model.cpp
+++ b/ngraph/test/frontend/shared/src/cut_specific_model.cpp
@@ -34,7 +34,8 @@ void FrontEndCutModelTest::SetUp()
 void FrontEndCutModelTest::initParamTest()
 {
     m_param = GetParam();
-    m_param.m_modelName = FrontEndTestUtils::make_model_path(m_param.m_modelsPath + m_param.m_modelName);
+    m_param.m_modelName =
+        FrontEndTestUtils::make_model_path(m_param.m_modelsPath + m_param.m_modelName);
 }
 
 void FrontEndCutModelTest::doLoadFromFile()

--- a/ngraph/test/frontend/shared/src/cut_specific_model.cpp
+++ b/ngraph/test/frontend/shared/src/cut_specific_model.cpp
@@ -34,7 +34,7 @@ void FrontEndCutModelTest::SetUp()
 void FrontEndCutModelTest::initParamTest()
 {
     m_param = GetParam();
-    m_param.m_modelName = m_param.m_modelsPath + m_param.m_modelName;
+    m_param.m_modelName = FrontEndTestUtils::make_model_path(m_param.m_modelsPath + m_param.m_modelName);
 }
 
 void FrontEndCutModelTest::doLoadFromFile()

--- a/ngraph/test/frontend/shared/src/load_from.cpp
+++ b/ngraph/test/frontend/shared/src/load_from.cpp
@@ -27,7 +27,7 @@ void FrontEndLoadFromTest::SetUp()
 
 TEST_P(FrontEndLoadFromTest, testLoadFromFilePath)
 {
-    std::string model_path = m_param.m_modelsPath + m_param.m_file;
+    std::string model_path = FrontEndTestUtils::make_model_path(m_param.m_modelsPath + m_param.m_file);
     std::vector<std::string> frontends;
     FrontEnd::Ptr fe;
     ASSERT_NO_THROW(frontends = m_fem.get_available_front_ends());
@@ -44,8 +44,8 @@ TEST_P(FrontEndLoadFromTest, testLoadFromFilePath)
 
 TEST_P(FrontEndLoadFromTest, testLoadFromTwoFiles)
 {
-    std::string model_path = m_param.m_modelsPath + m_param.m_files[0];
-    std::string weights_path = m_param.m_modelsPath + m_param.m_files[1];
+    std::string model_path = FrontEndTestUtils::make_model_path(m_param.m_modelsPath + m_param.m_files[0]);
+    std::string weights_path = FrontEndTestUtils::make_model_path(m_param.m_modelsPath + m_param.m_files[1]);
     std::vector<std::string> frontends;
     FrontEnd::Ptr fe;
     ASSERT_NO_THROW(frontends = m_fem.get_available_front_ends());
@@ -62,7 +62,7 @@ TEST_P(FrontEndLoadFromTest, testLoadFromTwoFiles)
 
 TEST_P(FrontEndLoadFromTest, testLoadFromStream)
 {
-    auto ifs = std::make_shared<std::ifstream>(m_param.m_modelsPath + m_param.m_stream,
+    auto ifs = std::make_shared<std::ifstream>(FrontEndTestUtils::make_model_path(m_param.m_modelsPath + m_param.m_stream),
                                                std::ios::in | std::ifstream::binary);
     auto is = std::dynamic_pointer_cast<std::istream>(ifs);
     std::vector<std::string> frontends;
@@ -81,9 +81,9 @@ TEST_P(FrontEndLoadFromTest, testLoadFromStream)
 
 TEST_P(FrontEndLoadFromTest, testLoadFromTwoStreams)
 {
-    auto model_ifs = std::make_shared<std::ifstream>(m_param.m_modelsPath + m_param.m_streams[0],
+    auto model_ifs = std::make_shared<std::ifstream>(FrontEndTestUtils::make_model_path(m_param.m_modelsPath + m_param.m_streams[0]),
                                                      std::ios::in | std::ifstream::binary);
-    auto weights_ifs = std::make_shared<std::ifstream>(m_param.m_modelsPath + m_param.m_streams[1],
+    auto weights_ifs = std::make_shared<std::ifstream>(FrontEndTestUtils::make_model_path(m_param.m_modelsPath + m_param.m_streams[1]),
                                                        std::ios::in | std::ifstream::binary);
     auto model_is = std::dynamic_pointer_cast<std::istream>(model_ifs);
     auto weights_is = std::dynamic_pointer_cast<std::istream>(weights_ifs);

--- a/ngraph/test/frontend/shared/src/load_from.cpp
+++ b/ngraph/test/frontend/shared/src/load_from.cpp
@@ -27,7 +27,8 @@ void FrontEndLoadFromTest::SetUp()
 
 TEST_P(FrontEndLoadFromTest, testLoadFromFilePath)
 {
-    std::string model_path = FrontEndTestUtils::make_model_path(m_param.m_modelsPath + m_param.m_file);
+    std::string model_path =
+        FrontEndTestUtils::make_model_path(m_param.m_modelsPath + m_param.m_file);
     std::vector<std::string> frontends;
     FrontEnd::Ptr fe;
     ASSERT_NO_THROW(frontends = m_fem.get_available_front_ends());
@@ -44,8 +45,10 @@ TEST_P(FrontEndLoadFromTest, testLoadFromFilePath)
 
 TEST_P(FrontEndLoadFromTest, testLoadFromTwoFiles)
 {
-    std::string model_path = FrontEndTestUtils::make_model_path(m_param.m_modelsPath + m_param.m_files[0]);
-    std::string weights_path = FrontEndTestUtils::make_model_path(m_param.m_modelsPath + m_param.m_files[1]);
+    std::string model_path =
+        FrontEndTestUtils::make_model_path(m_param.m_modelsPath + m_param.m_files[0]);
+    std::string weights_path =
+        FrontEndTestUtils::make_model_path(m_param.m_modelsPath + m_param.m_files[1]);
     std::vector<std::string> frontends;
     FrontEnd::Ptr fe;
     ASSERT_NO_THROW(frontends = m_fem.get_available_front_ends());
@@ -62,8 +65,9 @@ TEST_P(FrontEndLoadFromTest, testLoadFromTwoFiles)
 
 TEST_P(FrontEndLoadFromTest, testLoadFromStream)
 {
-    auto ifs = std::make_shared<std::ifstream>(FrontEndTestUtils::make_model_path(m_param.m_modelsPath + m_param.m_stream),
-                                               std::ios::in | std::ifstream::binary);
+    auto ifs = std::make_shared<std::ifstream>(
+        FrontEndTestUtils::make_model_path(m_param.m_modelsPath + m_param.m_stream),
+        std::ios::in | std::ifstream::binary);
     auto is = std::dynamic_pointer_cast<std::istream>(ifs);
     std::vector<std::string> frontends;
     FrontEnd::Ptr fe;
@@ -81,10 +85,12 @@ TEST_P(FrontEndLoadFromTest, testLoadFromStream)
 
 TEST_P(FrontEndLoadFromTest, testLoadFromTwoStreams)
 {
-    auto model_ifs = std::make_shared<std::ifstream>(FrontEndTestUtils::make_model_path(m_param.m_modelsPath + m_param.m_streams[0]),
-                                                     std::ios::in | std::ifstream::binary);
-    auto weights_ifs = std::make_shared<std::ifstream>(FrontEndTestUtils::make_model_path(m_param.m_modelsPath + m_param.m_streams[1]),
-                                                       std::ios::in | std::ifstream::binary);
+    auto model_ifs = std::make_shared<std::ifstream>(
+        FrontEndTestUtils::make_model_path(m_param.m_modelsPath + m_param.m_streams[0]),
+        std::ios::in | std::ifstream::binary);
+    auto weights_ifs = std::make_shared<std::ifstream>(
+        FrontEndTestUtils::make_model_path(m_param.m_modelsPath + m_param.m_streams[1]),
+        std::ios::in | std::ifstream::binary);
     auto model_is = std::dynamic_pointer_cast<std::istream>(model_ifs);
     auto weights_is = std::dynamic_pointer_cast<std::istream>(weights_ifs);
 

--- a/ngraph/test/frontend/shared/src/op_fuzzy.cpp
+++ b/ngraph/test/frontend/shared/src/op_fuzzy.cpp
@@ -35,7 +35,7 @@ void FrontEndFuzzyOpTest::SetUp()
 void FrontEndFuzzyOpTest::initParamTest()
 {
     std::tie(m_feName, m_pathToModels, m_modelFile) = GetParam();
-    m_modelFile = m_pathToModels + m_modelFile;
+    m_modelFile = FrontEndTestUtils::make_model_path(m_pathToModels + m_modelFile);
 }
 
 void FrontEndFuzzyOpTest::doLoadFromFile()

--- a/ngraph/test/frontend/shared/src/partial_shape.cpp
+++ b/ngraph/test/frontend/shared/src/partial_shape.cpp
@@ -32,7 +32,8 @@ void FrontEndPartialShapeTest::SetUp()
 void FrontEndPartialShapeTest::initParamTest()
 {
     std::tie(m_baseParam, m_partShape) = GetParam();
-    m_partShape.m_modelName = FrontEndTestUtils::make_model_path(m_baseParam.m_modelsPath + m_partShape.m_modelName);
+    m_partShape.m_modelName =
+        FrontEndTestUtils::make_model_path(m_baseParam.m_modelsPath + m_partShape.m_modelName);
 }
 
 void FrontEndPartialShapeTest::doLoadFromFile()

--- a/ngraph/test/frontend/shared/src/partial_shape.cpp
+++ b/ngraph/test/frontend/shared/src/partial_shape.cpp
@@ -32,7 +32,7 @@ void FrontEndPartialShapeTest::SetUp()
 void FrontEndPartialShapeTest::initParamTest()
 {
     std::tie(m_baseParam, m_partShape) = GetParam();
-    m_partShape.m_modelName = m_baseParam.m_modelsPath + m_partShape.m_modelName;
+    m_partShape.m_modelName = FrontEndTestUtils::make_model_path(m_baseParam.m_modelsPath + m_partShape.m_modelName);
 }
 
 void FrontEndPartialShapeTest::doLoadFromFile()

--- a/ngraph/test/frontend/shared/src/set_element_type.cpp
+++ b/ngraph/test/frontend/shared/src/set_element_type.cpp
@@ -25,7 +25,7 @@ void FrontEndElementTypeTest::SetUp()
 void FrontEndElementTypeTest::initParamTest()
 {
     m_param = GetParam();
-    m_param.m_modelName = m_param.m_modelsPath + m_param.m_modelName;
+    m_param.m_modelName = FrontEndTestUtils::make_model_path(m_param.m_modelsPath + m_param.m_modelName);
 }
 
 void FrontEndElementTypeTest::doLoadFromFile()

--- a/ngraph/test/frontend/shared/src/set_element_type.cpp
+++ b/ngraph/test/frontend/shared/src/set_element_type.cpp
@@ -25,7 +25,8 @@ void FrontEndElementTypeTest::SetUp()
 void FrontEndElementTypeTest::initParamTest()
 {
     m_param = GetParam();
-    m_param.m_modelName = FrontEndTestUtils::make_model_path(m_param.m_modelsPath + m_param.m_modelName);
+    m_param.m_modelName =
+        FrontEndTestUtils::make_model_path(m_param.m_modelsPath + m_param.m_modelName);
 }
 
 void FrontEndElementTypeTest::doLoadFromFile()


### PR DESCRIPTION
### Details:
 - Install generated PDPD test models as 'test' component
 - Needed when test package is installed on another machine which don't have generated models
 - To search installed models, when build folder doesn't exist, 'FE_TEST_MODELS' env variable is introduced
 - CI script for openvino-lin is updated to set 'FE_TEST_MODELS' before tests execution

### How to verify locally:
 - Build OpenVINO with tests
 - Install OpenVINO and tests using cmake_install.cmake
 - Verify that `<install_dir>/tests/` folder contains pdpd_test_models
 - Remove `<cmakeDir>/ngraph/test/pdpd_test_models` dir
 - Verify that 'unit-test' is now failed
 - Do `export FE_TEST_MODELS=<install_dir>/tests`
 - Verify that unit tests can be executed now

### Tickets:
 - *ticket-id*
