### PR TITLE
[CPU] Replace sgemm with MatMul primitive

### DIFF
--- a/inference-engine/src/mkldnn_plugin/cpu_types.cpp
+++ b/inference-engine/src/mkldnn_plugin/cpu_types.cpp
@@ -177,7 +177,8 @@ const InferenceEngine::details::caseless_unordered_map<std::string, Type> type_t
         { "NonMaxSuppression", NonMaxSuppression},
         { "NonMaxSuppressionIEInternal", NonMaxSuppression},
         { "MatrixNms", MatrixNms},
-        { "MulticlassNms", MulticlassNms}
+        { "MulticlassNms", MulticlassNms},
+        { "Reference", Reference},
 };
 
 Type TypeFromName(const std::string& type) {
@@ -351,6 +352,8 @@ std::string NameFromType(const Type type) {
             return "MatrixNms";
         case MulticlassNms:
             return "MulticlassNms";
+        case Reference:
+            return "Reference";
         default:
             return "Unknown";
     }

--- a/inference-engine/src/mkldnn_plugin/memory_desc/dnnl_blocked_memory_desc.h
+++ b/inference-engine/src/mkldnn_plugin/memory_desc/dnnl_blocked_memory_desc.h
@@ -13,7 +13,7 @@ namespace MKLDNNPlugin {
 class DnnlBlockedMemoryDesc : public BlockedMemoryDesc, public DnnlMemoryDesc {
 public:
     // Creates planar DnnlBlockedMemoryDesc
-    DnnlBlockedMemoryDesc(InferenceEngine::Precision prc, const Shape& shape);
+    DnnlBlockedMemoryDesc(InferenceEngine::Precision prc, const Shape& shape, const VectorDims& strides = {});
 
     DnnlBlockedMemoryDesc(const Shape& shape, mkldnn::memory::data_type dataType, mkldnn::memory::format_tag format);
 

--- a/inference-engine/src/mkldnn_plugin/mkldnn_descriptor.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_descriptor.cpp
@@ -177,3 +177,15 @@ MKLDNNDescriptor::operator std::shared_ptr<mkldnn::eltwise_forward::desc>() {
     }
     return typeDesc->getPtr();
 }
+
+MKLDNNDescriptor::MKLDNNDescriptor(std::shared_ptr<mkldnn::matmul::desc> desc) {
+    this->desc.reset(new DescFwdImpl<mkldnn::matmul::desc>(desc));
+}
+
+MKLDNNDescriptor::operator std::shared_ptr<mkldnn::matmul::desc>() {
+    auto typeDesc = std::dynamic_pointer_cast<DescFwdImpl<mkldnn::matmul::desc>>(desc);
+    if (typeDesc == nullptr) {
+        IE_THROW() << "Cannot cast descriptor!";
+    }
+    return typeDesc->getPtr();
+}

--- a/inference-engine/src/mkldnn_plugin/mkldnn_descriptor.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_descriptor.h
@@ -49,6 +49,9 @@ public:
     explicit MKLDNNDescriptor(std::shared_ptr<mkldnn::eltwise_forward::desc> desc);
     operator std::shared_ptr<mkldnn::eltwise_forward::desc>();
 
+    explicit MKLDNNDescriptor(std::shared_ptr<mkldnn::matmul::desc> desc);
+    operator std::shared_ptr<mkldnn::matmul::desc>();
+
     mkldnn::primitive_desc_iterator createPrimitiveDescriptorIterator(const mkldnn::engine &engine,
             const mkldnn::primitive_attr &attr = mkldnn::primitive_attr()) const;
 

--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph_optimizer.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph_optimizer.h
@@ -23,6 +23,7 @@ private:
     void FuseDeconvolutionAndSimpleOperation(MKLDNNGraph &graph);
     void FuseMultiplyAndAdd(MKLDNNGraph &graph);
     void FuseFullyConnectedAndSimpleOperation(MKLDNNGraph &graph);
+    void FuseMatMulAndSimpleOperation(MKLDNNGraph &graph);
     void FuseConvolutionAndSimpleOperationThroughMaxPool(MKLDNNGraph &graph);
     void FuseConvolutionAndSimpleOperation(MKLDNNGraph &graph);
     void FuseConvolutionAndDWConvolution(MKLDNNGraph &graph);

--- a/inference-engine/src/mkldnn_plugin/mkldnn_plugin.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_plugin.cpp
@@ -70,6 +70,7 @@
 #include <transformations/utils/utils.hpp>
 #include <transformations/serialize.hpp>
 
+#include <ngraph/opsets/opset1.hpp>
 #include <ngraph/opsets/opset2.hpp>
 #include <ngraph/opsets/opset3.hpp>
 #include <ngraph/opsets/opset4.hpp>
@@ -97,6 +98,7 @@
 #include "nodes/mkldnn_fake_quantize_node.h"
 #include "nodes/mkldnn_normalize_node.h"
 #include "ngraph_transformations/convert_to_cpu_specific_opset.hpp"
+#include "transformations/smart_reshape/smart_reshape.hpp"
 
 #if !defined(__arm__) && !defined(_M_ARM) && !defined(__aarch64__) && !defined(_M_ARM64)
 # ifdef _WIN32
@@ -362,6 +364,10 @@ static void TransformationUpToCPUSpecificOpSet(std::shared_ptr<ngraph::Function>
             OperationPrecisionRestriction::create<ngraph::opset1::Multiply>({
                 {0, {ngraph::element::u8}},
                 {1, {ngraph::element::i8}},
+            }),
+            OperationPrecisionRestriction::create<ngraph::opset1::MatMul>({
+                {0, {ngraph::element::u8, ngraph::element::i8}},
+                {1, {ngraph::element::i8}}
             }),
         });
 

--- a/inference-engine/src/mkldnn_plugin/ngraph_transformations/align_matmul_input_ranks.cpp
+++ b/inference-engine/src/mkldnn_plugin/ngraph_transformations/align_matmul_input_ranks.cpp
@@ -1,0 +1,142 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "align_matmul_input_ranks.hpp"
+
+#include "ngraph/op/matmul.hpp"
+#include <ngraph/opsets/opset1.hpp>
+#include <ngraph/rt_info.hpp>
+#include <ngraph/pattern/op/wrap_type.hpp>
+#include <transformations/utils/utils.hpp>
+#include <ngraph/pattern/op/or.hpp>
+
+#include <algorithm>
+
+NGRAPH_RTTI_DEFINITION(MKLDNNPlugin::AlignMatMulInputRanks, "AlignMatMulInputRanks", 0);
+
+MKLDNNPlugin::AlignMatMulInputRanks::AlignMatMulInputRanks() {
+    ngraph::OutputVector twoInputs = {
+        ngraph::pattern::any_input(ngraph::pattern::has_static_rank()),
+        ngraph::pattern::any_input(ngraph::pattern::has_static_rank())
+    };
+
+    auto matmulPattern = ngraph::pattern::wrap_type<ngraph::op::MatMul>(twoInputs);
+
+    ngraph::matcher_pass_callback callback = [this](ngraph::pattern::Matcher& m) {
+        auto matmul = std::dynamic_pointer_cast<ngraph::op::MatMul> (m.get_match_root());
+
+        if (!matmul || transformation_callback(matmul))
+            return false;
+
+        const auto& input0 = matmul->input_value(0);
+        const auto& input1 = matmul->input_value(1);
+        const auto& input0shape = input0.get_partial_shape();
+        const auto& input1shape = input1.get_partial_shape();
+        const auto& output_shape = matmul->get_output_partial_shape(0);
+
+        assert(input0shape.rank().is_static());
+        assert(input1shape.rank().is_static());
+
+        const bool transposedUnsqueeze = input1shape.size() == 1;
+
+        if (input0shape.size() == input1shape.size() &&
+            input0shape.size() != 1)
+            return false; // nothing to do
+
+        auto getUnsqueeze = [&](const ngraph::Output<ngraph::Node>& nodeFrom, const ngraph::Output<ngraph::Node>& nodeTo) {
+            auto rankFrom = nodeFrom.get_partial_shape().size();
+            auto rankTo = nodeTo.get_partial_shape().size();
+
+            std::vector<int64_t> unsqueeze_axes;
+            for (int64_t j = 0; j < rankTo - rankFrom; ++j)
+                unsqueeze_axes.push_back(j);
+
+            if (transposedUnsqueeze) // special case for one-dimensional second input
+                unsqueeze_axes[unsqueeze_axes.size() - 1]++;
+
+            auto unsqueeze = std::make_shared<ngraph::opset1::Unsqueeze>(
+                nodeFrom,
+                ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{unsqueeze_axes.size()}, unsqueeze_axes));
+
+            unsqueeze->set_friendly_name(nodeFrom.get_node()->get_friendly_name() + "/Unsqueeze");
+
+            return unsqueeze;
+        };
+
+        auto matmul_new_inputs = matmul->input_values();
+        ngraph::NodeVector new_ops;
+
+        if (input0shape.size() == 1 && input1shape.size() == 1) {
+            // If the input is 1D tensor, it is unsqueezed to 2D tensor (row vector)
+            // for the first input:  by adding axes with size 1 at ROW_INDEX_DIM
+            //                       to the left of the shape {S} -> {1, S}
+            // for the second input: by adding axes with size 1 at COL_INDEX_DIM
+            //                       to the right of the shape {S} -> {S, 1}
+            const auto unsqueezeInput0 = std::make_shared<ngraph::opset1::Unsqueeze>(
+                input0,
+                ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{1}, {0}));
+            const auto unsqueezeInput1 = std::make_shared<ngraph::opset1::Unsqueeze>(
+                input1,
+                ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{1}, {1}));
+
+            matmul_new_inputs[0] = unsqueezeInput0;
+            new_ops.push_back(unsqueezeInput0);
+            matmul_new_inputs[1] = unsqueezeInput1;
+            new_ops.push_back(unsqueezeInput1);
+            // For 1D inputs transpose flag is expected to always act like `false`
+            matmul->set_transpose_a(false);
+            matmul->set_transpose_b(false);
+        } else if (input0shape.size() < input1shape.size()) {
+            std::shared_ptr<ngraph::Node> unsqueezeInput0 = getUnsqueeze(input0, input1);
+            matmul_new_inputs[0] = unsqueezeInput0;
+            new_ops.push_back(unsqueezeInput0);
+
+            if (input0shape.size() == 1)
+                matmul->set_transpose_a(false);
+        } else if (input0shape.size() > input1shape.size()) {
+            std::shared_ptr<ngraph::Node> unsqueezeInput1 = getUnsqueeze(input1, input0);
+            matmul_new_inputs[1] = unsqueezeInput1;
+            new_ops.push_back(unsqueezeInput1);
+
+            if (input1shape.size() == 1)
+                matmul->set_transpose_b(false);
+        }
+
+        std::shared_ptr<ngraph::Node> matmul_new = matmul->clone_with_new_inputs(matmul_new_inputs);
+        new_ops.push_back(matmul_new);
+
+        if (matmul_new->get_output_partial_shape(0) != output_shape) {
+            // When one of the inputs is one-dimensional tensor, ngraph shrinks the output node by 1
+            // For example: C * AxBxCxD -> AxBxD (instead of AxBx1xD)
+            // Insert additional squeeze operation to preserve output shape
+            const auto new_out_shape_size = matmul_new->get_output_partial_shape(0).size();
+            size_t squeeze_axis = 0;
+            if (input0shape.size() == 1)
+                squeeze_axis = new_out_shape_size - 2;
+            else if (input1shape.size() == 1)
+                squeeze_axis = new_out_shape_size - 1;
+            std::shared_ptr<ngraph::Node> squeeze_output = std::make_shared<ngraph::op::v0::Squeeze>(
+                matmul_new,
+                ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{1}, {squeeze_axis}));
+
+            new_ops.push_back(squeeze_output);
+            matmul_new->set_friendly_name(matmul->get_friendly_name() + "/MM");
+            // Set the name of the last node after transformation to initial node name
+            // (in case initial node was an output node)
+            squeeze_output->set_friendly_name(matmul->get_friendly_name());
+            ngraph::copy_runtime_info(matmul, new_ops);
+            ngraph::replace_node(matmul, squeeze_output);
+        } else {
+            matmul_new->set_friendly_name(matmul->get_friendly_name());
+            ngraph::copy_runtime_info(matmul, new_ops);
+            ngraph::replace_node(matmul, matmul_new);
+        }
+
+
+        return true;
+    };
+
+    auto m = std::make_shared<ngraph::pattern::Matcher>(matmulPattern, "AlignMatMulInputRanks");
+    this->register_matcher(m, callback);
+}

--- a/inference-engine/src/mkldnn_plugin/ngraph_transformations/align_matmul_input_ranks.hpp
+++ b/inference-engine/src/mkldnn_plugin/ngraph_transformations/align_matmul_input_ranks.hpp
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <ngraph/pass/graph_rewrite.hpp>
+
+/*
+ * Description:
+ *     AlignMatMulInputRanks transformation detects MatMul operations
+ *     and unsqueezes one input to another to align the ranks of the inputs.
+ *     The transformation is required because oneDNN library
+ *     requires inputs to have equal ranks
+ */
+
+namespace MKLDNNPlugin {
+
+class AlignMatMulInputRanks: public ngraph::pass::MatcherPass {
+public:
+    NGRAPH_RTTI_DECLARATION;
+    AlignMatMulInputRanks();
+};
+
+}  // namespace MKLDNNPlugin

--- a/inference-engine/src/mkldnn_plugin/ngraph_transformations/convert_matmul_to_fc.cpp
+++ b/inference-engine/src/mkldnn_plugin/ngraph_transformations/convert_matmul_to_fc.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "convert_matmul_to_fc_or_gemm.hpp"
+#include "convert_matmul_to_fc.hpp"
 #include "op/fully_connected.hpp"
 #include <numeric>
 #include <ngraph/opsets/opset1.hpp>
@@ -149,103 +149,5 @@ MKLDNNPlugin::ConvertMatMulToFC::ConvertMatMulToFC() {
     };
 
     auto m = std::make_shared<ngraph::pattern::Matcher>(matmul, "ConvertMatMulToFC");
-    this->register_matcher(m, callback);
-}
-
-NGRAPH_RTTI_DEFINITION(MKLDNNPlugin::ConvertMatMulToGemm, "ConvertMatMulToGemm", 0);
-
-MKLDNNPlugin::ConvertMatMulToGemm::ConvertMatMulToGemm() {
-    auto matmul = ngraph::pattern::wrap_type<ngraph::opset1::MatMul>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
-                                                                      ngraph::pattern::any_input(ngraph::pattern::has_static_shape())},
-                                                                      ngraph::pattern::has_static_shape());
-
-    ngraph::matcher_pass_callback callback = [this](ngraph::pattern::Matcher& m) {
-        auto matmul = std::dynamic_pointer_cast<ngraph::opset1::MatMul>(m.get_match_root());
-        if (!matmul) {
-            return false;
-        }
-
-        auto input_a = matmul->input(0).get_source_output();
-        auto input_b = matmul->input(1).get_source_output();
-
-        auto shape_a = input_a.get_shape();
-        auto shape_b = input_b.get_shape();
-        auto output_shape = matmul->get_shape();
-
-        auto fc_input_a = input_a, fc_input_b = input_b;
-        ngraph::NodeVector new_ops;
-
-        if (shape_a.size() == 1) {
-            // If the first input is 1D tensor, it is unsqueezed to 2D tensor (row vector)
-            // by adding axes with size 1 at ROW_INDEX_DIM, to the left of the shape.
-            // For example {S} will be reshaped to {1, S}.
-            fc_input_a = std::make_shared<ngraph::opset1::Unsqueeze>(fc_input_a,
-                ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{1}, {0}));
-            shape_a = fc_input_a.get_shape();
-            new_ops.push_back(fc_input_a.get_node_shared_ptr());
-            // For 1D inputs transpose flag is expected to always act like `false`
-            matmul->set_transpose_a(false);
-        }
-        if (shape_b.size() == 1) {
-            // If the second input is 1D tensor, it is unsqueezed to 2D tensor (column vector)
-            // by adding axes with size 1 at COL_INDEX_DIM, to the right of the shape.
-            // For example {S} will be reshaped to {S, 1}.
-            fc_input_b = std::make_shared<ngraph::opset1::Unsqueeze>(fc_input_b,
-                ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{1}, {1}));
-            shape_b = fc_input_b.get_shape();
-            new_ops.push_back(fc_input_b.get_node_shared_ptr());
-            // For 1D inputs transpose flag is expected to always act like `false`
-            matmul->set_transpose_b(false);
-        }
-
-        // WA for IE that Gemm must have inputs with the same length.
-        // If ranks of input arguments are still different,
-        // the smaller tensor is unsqueezed from the left side of the shape
-        // by necessary number of axes to make both shapes of the same rank.
-        if (shape_a.size() < shape_b.size()) {
-            // Reshape first input (fc_input_a)
-            ngraph::Shape reshape_shape(shape_b.size() - shape_a.size(), 1);
-            reshape_shape.insert(reshape_shape.end(), shape_a.begin(), shape_a.end());
-            fc_input_a = ngraph::op::util::reshapeTo(fc_input_a, reshape_shape);
-            new_ops.push_back(fc_input_a.get_node_shared_ptr());
-        } else if (shape_b.size() < shape_a.size()) {
-            // Reshape second input (fc_input_b)
-            ngraph::Shape reshape_shape(shape_a.size() - shape_b.size(), 1);
-            reshape_shape.insert(reshape_shape.end(), shape_b.begin(), shape_b.end());
-            fc_input_b = ngraph::op::util::reshapeTo(fc_input_b, reshape_shape);
-            new_ops.push_back(fc_input_b.get_node_shared_ptr());
-        }
-
-        auto gemm = matmul->copy_with_new_inputs({ fc_input_a, fc_input_b });
-        new_ops.push_back(gemm);
-
-        if (gemm->get_shape() != output_shape) {
-            // This case is possible when one of the inputs has exactly 1 dimension (that is not supported by GEMM operation)
-            // So to preserve output shape we insert additional reshape operation
-            std::shared_ptr<ngraph::Node> reshape_output;
-            if (output_shape.size() == 0) {
-                std::vector<int64_t> dim_indices(gemm->get_shape().size());
-                std::iota(dim_indices.begin(), dim_indices.end(), 0);
-                reshape_output = std::make_shared<ngraph::opset1::Squeeze>(gemm,
-                    ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{dim_indices.size()}, dim_indices));
-            } else {
-                reshape_output = ngraph::op::util::reshapeTo(gemm, output_shape);
-            }
-
-            new_ops.push_back(reshape_output);
-            gemm->set_friendly_name(matmul->get_friendly_name() + "/gemm");
-            reshape_output->set_friendly_name(matmul->get_friendly_name());
-            ngraph::copy_runtime_info(matmul, new_ops);
-            ngraph::replace_node(matmul, reshape_output);
-        } else {
-            gemm->set_friendly_name(matmul->get_friendly_name());
-            ngraph::copy_runtime_info(matmul, new_ops);
-            ngraph::replace_node(matmul, gemm);
-        }
-
-        return true;
-    };
-
-    auto m = std::make_shared<ngraph::pattern::Matcher>(matmul, "ConvertMatMulToGemm");
     this->register_matcher(m, callback);
 }

--- a/inference-engine/src/mkldnn_plugin/ngraph_transformations/convert_matmul_to_fc.hpp
+++ b/inference-engine/src/mkldnn_plugin/ngraph_transformations/convert_matmul_to_fc.hpp
@@ -14,10 +14,4 @@ public:
     ConvertMatMulToFC();
 };
 
-class ConvertMatMulToGemm: public ngraph::pass::MatcherPass {
-public:
-    NGRAPH_RTTI_DECLARATION;
-    ConvertMatMulToGemm();
-};
-
 }  // namespace MKLDNNPlugin

--- a/inference-engine/src/mkldnn_plugin/ngraph_transformations/convert_to_cpu_specific_opset.hpp
+++ b/inference-engine/src/mkldnn_plugin/ngraph_transformations/convert_to_cpu_specific_opset.hpp
@@ -3,17 +3,22 @@
 //
 
 #include <ngraph/pass/constant_folding.hpp>
-#include "convert_matmul_to_fc_or_gemm.hpp"
 #include "fc_bias_fusion.hpp"
+#include "ngraph/op/fake_quantize.hpp"
+#include "ngraph/pass/manager.hpp"
+#include "reshape_1d_ops.hpp"
 #include "reshape_fc_fusion.hpp"
 #include "reshape_fully_connected.hpp"
+#include "align_matmul_input_ranks.hpp"
+#include "reshape_prelu.hpp"
 #include "convert_broadcast_to_tiles.hpp"
 #include "convert_tile_to_seq_tiles.hpp"
-#include "reshape_1d_ops.hpp"
+#include "convert_matmul_to_fc.hpp"
 #include "convert_to_power_static.hpp"
 #include "convert_to_leaky_relu.hpp"
 #include "convert_to_swish_cpu.hpp"
-#include "reshape_prelu.hpp"
+#include "transformations/convert_precision.hpp"
+#include "transformations/utils/utils.hpp"
 #include "rnn_sequences_optimization.hpp"
 
 namespace MKLDNNPlugin {
@@ -25,10 +30,10 @@ inline void ConvertToCPUSpecificOpset(std::shared_ptr<ngraph::Function> &nGraphF
     manager.register_pass<Reshape1DGroupConvolution>();
     manager.register_pass<Reshape1DAvgPool>();
     manager.register_pass<Reshape1DMaxPool>();
+    manager.register_pass<ConvertMatMulToFC>();
+    manager.register_pass<AlignMatMulInputRanks>();
     manager.register_pass<ConvertBroadcastToTiles>();
     manager.register_pass<ConvertTileToSeqTiles>();
-    manager.register_pass<ConvertMatMulToFC>();
-    manager.register_pass<ConvertMatMulToGemm>();
     manager.register_pass<FullyConnectedBiasFusion>();
     manager.register_pass<ReshapeFullyConnected>();
     manager.register_pass<ConvertToPowerStatic>();

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_broadcast_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_broadcast_node.cpp
@@ -51,7 +51,7 @@ MKLDNNBroadcastNode::MKLDNNBroadcastNode(const std::shared_ptr<ngraph::Node>& op
 
     errorPrefix = "Broadcast node with name '" + op->get_friendly_name() + "'";
     if (op->get_input_size() != 2 || op->get_output_size() != 1)
-        IE_THROW() << errorPrefix << " has incorrect number of input/output edges!";
+        IE_THROW() << errorPrefix << " has incorrect number of input/output edges! " << op->get_input_size() << "->" << op->get_output_size();
 
     SizeVector shape_dims = op->get_input_shape(BROADCAST_SHAPE);
     if (shape_dims.size() > 1)

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_matmul_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_matmul_node.h
@@ -4,10 +4,11 @@
 
 #pragma once
 
-#include <ie_common.h>
 #include <mkldnn_node.h>
+#include <ie_common.h>
 #include <string>
 #include <vector>
+#include <array>
 
 namespace MKLDNNPlugin {
 
@@ -16,60 +17,38 @@ public:
     MKLDNNMatMulNode(const std::shared_ptr<ngraph::Node>& op, const mkldnn::engine& eng, MKLDNNWeightsSharing::Ptr &cache);
 
     void getSupportedDescriptors() override;
+    void createDescriptor(const std::vector<MemoryDescPtr>& inputDesc,
+                          const std::vector<MemoryDescPtr>& outputDesc) override;
     void initSupportedPrimitiveDescriptors() override;
-    void initOptimalPrimitiveDescriptor() override;
+    MemoryDescPtr getSrcMemDesc(mkldnn::primitive_desc_iterator &primitive_desc_it, size_t idx) override;
     void createPrimitive() override;
-    void execute(mkldnn::stream strm) override;
+    bool canFuse(const MKLDNNNodePtr& node) const override;
     bool created() const override;
     size_t getMaxBatch() const override;
 
     InferenceEngine::Precision getRuntimePrecision() const override;
+    size_t descInputNumbers(MKLDNNDescriptor desc) override {
+        return getOriginalInputsNumber();
+    }
 
     static bool isSupportedOperation(const std::shared_ptr<const ngraph::Node>& op, std::string& errorMessage) noexcept;
 
+protected:
+    std::shared_ptr<mkldnn::primitive_attr> initPrimitiveAttr() const override;
+
 private:
-    float alpha = 1.f;
-    float beta = 0.f;
-    bool transposeA = false;
-    bool transposeB = false;
-
-    int xAxis = 0;
-    int yAxis = 0;
-
-    std::vector<int> aOffsets;
-    std::vector<int> bOffsets;
-    std::vector<int> cOffsets;
-
-    InferenceEngine::Precision runtimePrecision;
-
-    template<typename T0, typename T1> inline void process_data();
+    void setPostOps(mkldnn::primitive_attr &attr, bool initWeights) const;
 
     std::string errorPrefix;
 
-    struct {
-        MKLDNNMemoryPtr src0_mem_ptr = nullptr;
-        MKLDNNMemoryPtr src1_mem_ptr = nullptr;
-        MKLDNNMemoryPtr dst_mem_ptr = nullptr;
+    /* whether to transpose input */
+    std::array<bool, 2> transposeIn;
+    /* initial shapes without transpose,
+     * necessary to hide transpose effect from plugin */
+    std::array<Shape, 2> initialInShapes;
 
-        char transa = 'N';
-        char transb = 'N';
-
-        int MB1 = 1;
-        int MB2 = 1;
-
-        int M = 0;
-        int N = 0;
-        int K = 0;
-
-        int lda = 0;
-        int ldb = 0;
-        int ldc = 0;
-
-        int shift1 = 0;
-        int shift2 = 0;
-
-        size_t ndims = 0;
-    } params;
+    std::array<MemoryDescPtr, 2> inDataDesc;
+    MemoryDescPtr outDataDesc;
 };
 
 }  // namespace MKLDNNPlugin

--- a/inference-engine/src/mkldnn_plugin/utils/general_utils.h
+++ b/inference-engine/src/mkldnn_plugin/utils/general_utils.h
@@ -4,9 +4,11 @@
 
 #pragma once
 
-#include <cassert>
 #include <inference_engine.hpp>
 #include "cpu_shape.h"
+
+#include <algorithm>
+#include <cassert>
 
 namespace MKLDNNPlugin {
 
@@ -101,11 +103,10 @@ inline bool dimsEqualWeak(const std::vector<size_t>& lhs, const std::vector<size
 
 inline InferenceEngine::Precision getMaxPrecision(std::vector<InferenceEngine::Precision> precisions) {
     if (!precisions.empty()) {
-        std::sort(precisions.begin(), precisions.end(),
-                  [](const InferenceEngine::Precision &lhs, const InferenceEngine::Precision &rhs) {
-                      return lhs.size() > rhs.size();
-                  });
-        return precisions[0];
+        return *std::max_element(precisions.begin(), precisions.end(),
+                                 [](const InferenceEngine::Precision &lhs, const InferenceEngine::Precision &rhs) {
+                                     return lhs.size() > rhs.size();
+                                 });
     }
 
     return InferenceEngine::Precision::UNSPECIFIED;

--- a/inference-engine/tests/functional/plugin/cpu/subgraph_tests/src/align_mamtul_input_ranks.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/subgraph_tests/src/align_mamtul_input_ranks.cpp
@@ -1,0 +1,101 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "test_utils/cpu_test_utils.hpp"
+#include "test_utils/fusing_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+#include "common_test_utils/common_utils.hpp"
+
+#include <algorithm>
+#include <cassert>
+
+using namespace ngraph;
+using namespace InferenceEngine;
+using namespace CPUTestUtils;
+
+namespace SubgraphTestsDefinitions {
+
+using AlignMatMulInputRanksTestParams = std::tuple<std::pair<SizeVector, SizeVector>, // IS fully connected
+                                       fusingSpecificParams>;
+
+class AlignMatMulInputRanksTest : public testing::WithParamInterface<AlignMatMulInputRanksTestParams>, public CpuTestWithFusing,
+                      virtual public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<AlignMatMulInputRanksTestParams> obj) {
+        std::pair<SizeVector, SizeVector> supportedInputShapes;
+        fusingSpecificParams fusingParams;
+        std::tie(supportedInputShapes, fusingParams) = obj.param;
+        SizeVector inputShapeA = supportedInputShapes.first; SizeVector inputShapeB = supportedInputShapes.second;
+
+        std::ostringstream result;
+        result << "IS_A=" << CommonTestUtils::vec2str(inputShapeA) << "_";
+        result << "IS_B=" << CommonTestUtils::vec2str(inputShapeB) << "_";
+        result << CpuTestWithFusing::getTestCaseName(fusingParams);
+
+        return result.str();
+    }
+
+protected:
+    void SetUp() override {
+        targetDevice = CommonTestUtils::DEVICE_CPU;
+        std::pair<SizeVector, SizeVector> inShapes;
+        fusingSpecificParams fusingParams;
+        std::tie(inShapes, fusingParams) = this->GetParam();
+
+        if (inShapes.first.size() != inShapes.second.size())
+            expectedNumOfReshapes++;  // one input will be unsqueezed
+        if (inShapes.first.size() == 1 || inShapes.second.size() == 1)
+            expectedNumOfReshapes++;  // output will be squeezed
+        if (inShapes.first.size() == 1 && inShapes.second.size() == 1)
+            expectedNumOfReshapes+=2; // both inputs unsqueezed and output squeezed
+
+        if (inShapes.first.size() != 1 && inShapes.second.size() != 1) // no fusing through Reshape after output
+            std::tie(postOpMgrPtr, fusedOps) = fusingParams;
+
+        const auto ngPrec = element::f32;
+        auto inputParams = builder::makeParams(ngPrec, {inShapes.first, inShapes.second});
+        const auto outputNodes = helpers::convert2OutputVector(helpers::castOps2Nodes<op::Parameter>(inputParams));
+        const auto matMul = builder::makeMatMul(outputNodes[0], outputNodes[1], false, false);
+
+        function = makeNgraphFunction(ngPrec, inputParams, matMul, "AlignMatMulInputRanks");
+    }
+
+    int expectedNumOfReshapes = 0;
+};
+
+TEST_P(AlignMatMulInputRanksTest, supportedInputShapes) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    Run();
+    CheckNodeOfTypeCount(executableNetwork, "Reshape", expectedNumOfReshapes); // Squeeze / Unsqueeze turns into Reshape
+    CheckFusingResults(executableNetwork, "MatMul");
+}
+
+namespace {
+
+const std::vector<std::pair<SizeVector, SizeVector>> supportedInputShapes = {
+    {{4, 10, 5}, {1, 5, 10}},      // nothing to be done
+    {{3}, {3}},                    // 3x1 * 1x3 -> 1
+    {{18}, {1, 5, 18, 20}},        // 1x1x1x18 * 1x5x18x20 -> 1x5x20
+    {{2, 3, 4, 4, 4, 10, 5}, {5}}, // 2x3x4x4x4x10x5 * 1x1x1x1x1x5x1 -> 1x1x1x1x1x5
+    {{1, 18}, {1, 5, 18, 20}},
+    {{1, 70, 18}, {1, 5, 18, 20}},
+    {{7, 1, 10, 3, 2, 7}, {1, 7, 5}},
+    {{2, 3, 4, 4, 4, 10, 5}, {5, 20}},
+};
+
+// verify fusing just in case
+std::vector<fusingSpecificParams> fusingParamsSet {
+        emptyFusingSpec,
+        fusingElu,
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_Check, AlignMatMulInputRanksTest,
+                         ::testing::Combine(::testing::ValuesIn(supportedInputShapes),
+                                            ::testing::ValuesIn(fusingParamsSet)),
+                         AlignMatMulInputRanksTest::getTestCaseName);
+
+} // namespace
+
+} // namespace SubgraphTestsDefinitions

--- a/ngraph/test/backend/recurrent_cells.in.cpp
+++ b/ngraph/test/backend/recurrent_cells.in.cpp
@@ -8,15 +8,14 @@
 #endif
 // clang-format on
 
+#include "engines_util/execute_tools.hpp"
+#include "engines_util/test_case.hpp"
+#include "engines_util/test_engines.hpp"
 #include "gtest/gtest.h"
 #include "ngraph/check.hpp"
 #include "ngraph/ngraph.hpp"
 #include "ngraph/opsets/opset4.hpp"
-
-#include "engines_util/test_engines.hpp"
-#include "engines_util/test_case.hpp"
 #include "util/test_control.hpp"
-#include "engines_util/execute_tools.hpp"
 
 using namespace std;
 using namespace ngraph;

--- a/ngraph/test/runtime/ie/unit_test.manifest
+++ b/ngraph/test/runtime/ie/unit_test.manifest
@@ -1080,6 +1080,12 @@ IE_CPU.onnx_constant_sparse_tensor_double_3x4
 IE_CPU.onnx_constant_sparse_tensor_int16_3x4
 IE_CPU.onnx_constant_sparse_tensor_uint16_3x4
 
+# 48230
+# Some slight accuracy diviations after recent MatMul changes
+# (for CPU plugin gru_cell with clip decomposes into MatMuls)
+# Fix or increase threshold
+IE_CPU.gru_cell_bias_clip
+
 #-------------------------------------------------------------------------------
 #
 #       Inference Engine GPU plugin excludes


### PR DESCRIPTION
### Details:
 - SGEMM is replaced with oneDNN MatMul primitive
 - AlignMatMulInputRanks transformation is added to support oneDNN 2.3.2 MatMul limitation
 - Performance is mostly improved
 - Tests are updated with BF16 precision covered

### Tickets:
 - 48230

oneDNN update:
- https://github.com/openvinotoolkit/oneDNN/pull/62