### PR TITLE
Make time && stress tests independent from IEDeveloperPackage

### DIFF
--- a/tests/stress_tests/CMakeLists.txt
+++ b/tests/stress_tests/CMakeLists.txt
@@ -4,6 +4,14 @@
 
 cmake_minimum_required(VERSION 3.13)
 
+set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_EXTENSIONS OFF)
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set (CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+endif()
+
+
 if (CMAKE_BUILD_TYPE STREQUAL "")
     message(STATUS "CMAKE_BUILD_TYPE not defined, 'Release' will be used")
     set(CMAKE_BUILD_TYPE "Release")

--- a/tests/stress_tests/CMakeLists.txt
+++ b/tests/stress_tests/CMakeLists.txt
@@ -9,12 +9,10 @@ if (CMAKE_BUILD_TYPE STREQUAL "")
     set(CMAKE_BUILD_TYPE "Release")
 endif()
 
-# Define directory where artifacts will be placed
-set(OUTPUT_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
-
-find_package(InferenceEngineDeveloperPackage REQUIRED)
-
 set(OpenVINO_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../")
+
+# Search OpenVINO Inference Engine installed
+find_package(InferenceEngine REQUIRED)
 
 add_subdirectory(common)
 add_subdirectory(unittests)

--- a/tests/stress_tests/README.md
+++ b/tests/stress_tests/README.md
@@ -32,27 +32,12 @@ one at a time to mitigate memory statistics pollution. You can use
 
 ### Building Tests
 
-Stress tests should be built in 2 steps.
-
-1. Build `openvino`
-
-Build `openvino` as usual but with `-DENABLE_TESTS=ON`.
-
-2. Build `stress_tests`
-
-Stress tests depend from the Inference Engine Developer Package located in the
-`openvino` build directory.
-
-In the command line snippet bellow, it is assumed that the Inference Engine
-Developer Package CMake module can be found in the directory `build` under
-`openvino` repository root.
-
+To build the tests, you need to have OpenVINO™ installed or build from source.
+Before build the tests, open a terminal, set OpenVINO™ environment, and after that
+run the commands below:
 ``` bash
-(
-export OPENVINO_BUILD_DIR=$(git rev-parse --show-toplevel)/build
-mkdir -p build && cd build && \
-cmake -DInferenceEngineDeveloperPackage_DIR=$OPENVINO_BUILD_DIR .. && make -j$(nproc) \
-)
+mkdir build && cd build
+cmake .. && make
 ```
 
 ### Preparing Test Data

--- a/tests/time_tests/CMakeLists.txt
+++ b/tests/time_tests/CMakeLists.txt
@@ -11,16 +11,7 @@ project(time_tests)
 set(OpenVINO_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../")
 
 # Search OpenVINO Inference Engine installed
-find_package(InferenceEngine)
-
-if(NOT InferenceEngine_FOUND)
-    # Define directory where artifacts will be placed
-    set(OUTPUT_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
-
-    # Search OpenVINO Inference Engine via InferenceEngineDeveloperPackage_DIR
-    # in order to provide backward compatibility with old OpenVINO packages
-    find_package(InferenceEngineDeveloperPackage REQUIRED)
-endif()
+find_package(InferenceEngine REQUIRED)
 
 add_subdirectory(src)
 

--- a/tests/time_tests/CMakeLists.txt
+++ b/tests/time_tests/CMakeLists.txt
@@ -4,6 +4,13 @@
 
 cmake_minimum_required(VERSION 3.13)
 
+set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_EXTENSIONS OFF)
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set (CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+endif()
+
 set (CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the build type")
 
 project(time_tests)

--- a/tests/time_tests/README.md
+++ b/tests/time_tests/README.md
@@ -19,17 +19,6 @@ mkdir build && cd build
 cmake .. && make time_tests
 ```
 
-If you don't have OpenVINO™ installed you need to have the `build` folder, which
-is created when you configure and build OpenVINO™ from sources:
-
-``` bash
-cmake .. -DInferenceEngine_DIR=$(realpath ../../../build) && make time_tests
-```
-For old versions of OpenVINO™ from sources use `-DInferenceEngineDeveloperPackage_DIR`:
-``` bash
-cmake .. -DInferenceEngineDeveloperPackage_DIR=$(realpath ../../../build) && make time_tests
-```
-
 2. Run test:
 ``` bash
 ./scripts/run_timetest.py ../../bin/intel64/Release/timetest_infer -m model.xml -d CPU


### PR DESCRIPTION
### Details:
 - Get rid of InferenceEngineDeveloperPackage_DIR in order to provide possibility to build tests on installed OpenVINO. To achieve it, include gflags and gtest building into stress tests build

### Tickets:
 - 49280
