### PR TITLE
Enable TransposeSyncinc and BroadcastElementwiseFusion in MOC Backend

### DIFF
--- a/inference-engine/src/offline_transformations/src/moc_transformations.cpp
+++ b/inference-engine/src/offline_transformations/src/moc_transformations.cpp
@@ -25,6 +25,9 @@
 #include <transformations/common_optimizations/binarize_weights.hpp>
 #include <transformations/common_optimizations/conv_to_binary_conv.hpp>
 #include <transformations/common_optimizations/eliminate_unsqueeze_gather.hpp>
+#include <transformations/common_optimizations/split_squeeze_concat_fusion.hpp>
+#include <transformations/common_optimizations/transpose_sinking.hpp>
+#include <transformations/common_optimizations/broadcast_elementwise_fusion.hpp>
 
 NGRAPH_RTTI_DEFINITION(ngraph::pass::MOCTransformations, "MOCTransformations", 0);
 
@@ -45,12 +48,20 @@ bool ngraph::pass::MOCTransformations::run_on_function(std::shared_ptr<ngraph::F
     manager.register_pass<ngraph::pass::ConvertQuantizeDequantize>();
     manager.register_pass<ngraph::pass::SimplifyShapeOfSubGraph>();
 
+    auto transpose_sinking = manager.register_pass<ngraph::pass::GraphRewrite>();
+    transpose_sinking->add_matcher<ngraph::pass::TransposeSinking>();
+    // SplitSqueezeConcatFusion should work in same GraphRewrite as TransposesSinking,
+    // because it replaces pattern that may contain Transposes which must be optimized before
+    // the transformation and it also inserts Transpose that can be optimized by TransposeSinking
+    transpose_sinking->add_matcher<ngraph::pass::SplitSqueezeConcatFusion>();
+
     auto eliminations = manager.register_pass<ngraph::pass::GraphRewrite>();
     eliminations->add_matcher<ngraph::pass::EliminateUnsqueezeGather>();
     eliminations->set_name("ngraph::pass::CommonEliminations");
 
     auto common_fusions = manager.register_pass<ngraph::pass::GraphRewrite>();
     common_fusions->add_matcher<ngraph::pass::ConvertScatterElementsToScatter>();
+    common_fusions->add_matcher<ngraph::pass::BroadcastElementwiseFusion>();
     common_fusions->add_matcher<ngraph::pass::SoftPlusFusion>();
     common_fusions->add_matcher<ngraph::pass::SoftPlusToMishFusion>();
     common_fusions->add_matcher<ngraph::pass::SwishFusion>();


### PR DESCRIPTION
### Description
Enable TransposeSyncing and BroadcastElementwiseFusion (plugin independent fusions) into MOC backend phase. Some of this passes doesn't have analogs in MO so we expect that IR will be changed (optimized).
Validation shows positive changes in IR. In most cases changes relates to Transpose syncing transformations that were missing in MO pipeline.

### nGraph Transformations Transition Status
<details>
  <summary>Click to expand!</summary>

|Final MOC Pipeline|Enabled|
|---|:---:|
|InitNodeInfo|:white_check_mark:|
|ConstantFolding| |
|SimplifyShapeOfSubGraph|:white_check_mark:|
|RemoveFilteringBoxesBySize|:white_check_mark:|
|ConvertQuantizeDequantize|:white_check_mark:|
| | |
|**TransposeFQReduction**|:tada:|
|**TransposeReduction**|:tada:|
|**TransposeFuse**|:tada:|
|**SplitSqueezeConcatFusion**|:tada:|
| | |
|EliminateUnsqueezeGather|:white_check_mark:|
| | |
|ConvertScatterElementsToScatter|:white_check_mark:|
|**BroadcastElementwiseFusion**|:tada:|
|SoftPlusFusion|:white_check_mark:|
|SoftPlusToMishFusion|:white_check_mark:|
|SwishFusion|:white_check_mark:|
|HSwishFusion|:white_check_mark:|
|HSigmoidFusion|:white_check_mark:|
|NormalizeL2Fusion| |
|ClampFusion|:white_check_mark:|
|PadFusion|:white_check_mark:|
|SoftmaxFusion| |
|MVNFusion|:white_check_mark:| 
|DilatedConvolutionConverter|:white_check_mark:|
|GeluFusion|:white_check_mark:|
| | |
|BinarizeWeights|:white_check_mark:|
|ConvToBinaryConv|:white_check_mark:|
| | |
|LinOpSequenceFusion| |
| | |
|ConvolutionMultiplyFusion| |
|GroupConvolutionMultiplyFusion| |
|ConvolutionBackpropDataMultiplyFusion| |
|GroupConvolutionBackpropDataMultiplyFusion| |

_Note: transformations marked as **bold** and with :tada: were enabled in current PR_
</details>