### PR TITLE
Fixed sort port bug in SortTopologically

### DIFF
--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph.cpp
@@ -886,7 +886,7 @@ void MKLDNNGraph::SortTopologically() {
             for (int i = 0; i < node->parentEdges.size(); i++) {
                 auto edge = node->getParentEdgeAt(i);
                 int port = edge->getOutputNum();
-                if (!res[port])
+                if (port < port_num && !res[port])
                     res[port] = edge;
                 else
                     res.push_back(edge);
@@ -900,7 +900,7 @@ void MKLDNNGraph::SortTopologically() {
             for (int i = 0; i < node->childEdges.size(); i++) {
                 auto edge = node->getChildEdgeAt(i);
                 int port = edge->getInputNum();
-                if (!res[port])
+                if (port < port_num && !res[port])
                     res[port] = edge;
                 else
                     res.push_back(edge);


### PR DESCRIPTION
if port > port_num, the behavior of res[port] is undefined.

Signed-off-by: fengyi.sun <fengyi.sun@intel.com>
Reviewed-by: Wu, Jiangming <jiangming.wu@intel.com>