### PR TITLE
[PaddlePaddle] Unit tests run on CI fixes (Win+Lin)

### DIFF
--- a/.ci/azure/linux.yml
+++ b/.ci/azure/linux.yml
@@ -155,6 +155,10 @@ jobs:
     workingDirectory: $(BUILD_SAMPLES_DIR)
     displayName: 'Build c samples'
 
+  - script: rm -fr $(BUILD_DIR)
+    displayName: 'Clean build dir'
+    continueOnError: false
+
   - script: |
       export MO_ROOT=$(INSTALL_DIR)/deployment_tools/model_optimizer
       . $(SETUPVARS) -pyver 3.6 && python3 -m pytest -s $(INSTALL_DIR)/deployment_tools/model_optimizer/unit_tests --junitxml=TEST-ModelOptimizer.xml

--- a/.ci/azure/windows.yml
+++ b/.ci/azure/windows.yml
@@ -88,7 +88,7 @@ jobs:
       rem For running Python API tests
       python -m pip install -r $(REPO_DIR)\inference-engine\ie_bridges\python\src\requirements-dev.txt
       rem For running nGraph unit tests dependent on Python frameworks
-      python -m pip install -r $(REPO_DIR)/ngraph/test/requirements_test.txt
+      python -m pip install -r $(REPO_DIR)\ngraph\test\requirements_test.txt
       rem For MO unit tests
       python -m pip install -r $(REPO_DIR)\model-optimizer\requirements.txt
       python -m pip install -r $(REPO_DIR)\model-optimizer\requirements_dev.txt
@@ -139,7 +139,13 @@ jobs:
     workingDirectory: $(BUILD_SAMPLES_DIR)
     displayName: 'Build c samples'
 
-  - script: call $(SETUPVARS) && $(INSTALL_TEST_DIR)\unit-test --gtest_print_time=1 --gtest_filter=-backend_api.config_unsupported:*IE_GPU* --gtest_output=xml:TEST-NGraphUT.xml
+  - script: rd /Q /S $(BUILD_DIR)
+    displayName: 'Clean build dir'
+    continueOnError: false
+
+  - script: |
+      set FE_TEST_MODELS=$(INSTALL_DIR)\tests
+      call $(SETUPVARS) && $(INSTALL_TEST_DIR)\unit-test --gtest_print_time=1 --gtest_filter=-backend_api.config_unsupported:*IE_GPU* --gtest_output=xml:TEST-NGraphUT.xml
     displayName: 'nGraph UT'
     continueOnError: false
 

--- a/cmake/developer_package/IEDevScriptsConfig.cmake
+++ b/cmake/developer_package/IEDevScriptsConfig.cmake
@@ -254,8 +254,10 @@ endfunction()
 function(ie_check_pip_package name message_type)
     find_package(PythonInterp 3 REQUIRED)
 
+    get_filename_component(PYTHON_EXEC_DIR ${PYTHON_EXECUTABLE} DIRECTORY)
     execute_process(
         COMMAND ${PYTHON_EXECUTABLE} -m pip show ${name}
+        WORKING_DIRECTORY ${PYTHON_EXEC_DIR}
         RESULT_VARIABLE PIP_EXIT_CODE
         OUTPUT_QUIET
     )


### PR DESCRIPTION
### Details:
 - Win+Lin: add "clean build dir" step to ensure generated test models are taken from installation
 - Windows fix: execute "pip show" on same drive where python is installed. On CI machines Python is installed on "C:" drive, but build dir is on "D:" drive
 - Windows: execute tests with FE_TEST_MODELS env variable

### Tickets:
 - 59502
