### PR TITLE
[GPU] Don't add padding for some fsv16 convolutions

### DIFF
--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_kernel_b_fs_yx_fsv16.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_kernel_b_fs_yx_fsv16.cpp
@@ -145,7 +145,7 @@ KernelsPriority ConvolutionKernel_b_fs_yx_fsv16::GetKernelsPriority(const Params
 }
 
 bool ConvolutionKernel_b_fs_yx_fsv16::Validate(const Params& p, const optional_params& o) const {
-    if (!ConvolutionKernelBase::Validate(p, o) || !CovolutionCheckInput(p, o)) {
+    if (!ConvolutionKernelBase::Validate(p, o)) {
         return false;
     }
 
@@ -215,7 +215,7 @@ JitConstants ConvolutionKernel_b_fs_yx_fsv16::GetJitConstants(const convolution_
     }
 
     size_t input_line_size = std::min(params.stride.x * (blockWidth - 1) + (params.weights.X().v - 1)*params.dilation.x + 1,
-                                      input.X().v + input.X().pad.Total());
+                                      input.X().v + params.padding.x * 2);
 
     auto outFeaturesPerGroup = output.Feature().v / params.groups;
     auto inFeaturesPerGroup = input.Feature().v / params.groups;

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_kernel_b_fs_yx_fsv16_imad_1x1.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_kernel_b_fs_yx_fsv16_imad_1x1.h
@@ -26,7 +26,6 @@ protected:
     bool Validate(const Params& params, const optional_params& options) const override;
     JitConstants GetJitConstants(const convolution_params& params, const DispatchData& dispatchData) const override;
     DispatchData SetDefault(const convolution_params& params, int autoTuneIndex = -1) const override;
-    bool NeedPaddedInput() const override { return true; }
     WeightsLayout GetPreferredWeightsLayout(const convolution_params&) const override;
 
     std::vector<FusedOpType> GetSupportedFusedOps() const override {

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/convolution_gpu_bfyx_f16.cl
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/convolution_gpu_bfyx_f16.cl
@@ -221,37 +221,51 @@ KERNEL(convolution_bfyx_f16)(
 #endif  // INPUT_LEFTOVERS
                 {
                     int xb = 0;
-                    for (; xb + 8 <= INPUT_LINE_SIZE; xb += 8) {
-                        INPUT_TYPE8 vv = INPUT_BLOCK_READ8(input, grouped_input_offset +
-                                                                  icb * input_fs_pitch +
-                                                                  kh * DILATION_SIZE_Y * input_y_pitch +
-                                                                  xb * input_x_pitch);
+                    if (input_x >= 0 && input_x + INPUT_LINE_SIZE < INPUT0_SIZE_X) {
+                        for (; xb + 8 <= INPUT_LINE_SIZE; xb += 8) {
+                            INPUT_TYPE8 vv = INPUT_BLOCK_READ8(input, grouped_input_offset +
+                                                                      icb * input_fs_pitch +
+                                                                      kh * DILATION_SIZE_Y * input_y_pitch +
+                                                                      xb * input_x_pitch);
 
-                        line_cache[xb + 0] = vv[0];
-                        line_cache[xb + 1] = vv[1];
-                        line_cache[xb + 2] = vv[2];
-                        line_cache[xb + 3] = vv[3];
-                        line_cache[xb + 4] = vv[4];
-                        line_cache[xb + 5] = vv[5];
-                        line_cache[xb + 6] = vv[6];
-                        line_cache[xb + 7] = vv[7];
-                    }
-                    for (; xb + 4 <= INPUT_LINE_SIZE; xb += 4) {
-                        INPUT_TYPE4 vv = INPUT_BLOCK_READ4(input, grouped_input_offset +
-                                                                  icb * input_fs_pitch +
-                                                                  kh * DILATION_SIZE_Y * input_y_pitch +
-                                                                  xb * input_x_pitch);
+                            line_cache[xb + 0] = vv[0];
+                            line_cache[xb + 1] = vv[1];
+                            line_cache[xb + 2] = vv[2];
+                            line_cache[xb + 3] = vv[3];
+                            line_cache[xb + 4] = vv[4];
+                            line_cache[xb + 5] = vv[5];
+                            line_cache[xb + 6] = vv[6];
+                            line_cache[xb + 7] = vv[7];
+                        }
+                        for (; xb + 4 <= INPUT_LINE_SIZE; xb += 4) {
+                            INPUT_TYPE4 vv = INPUT_BLOCK_READ4(input, grouped_input_offset +
+                                                                      icb * input_fs_pitch +
+                                                                      kh * DILATION_SIZE_Y * input_y_pitch +
+                                                                      xb * input_x_pitch);
 
-                        line_cache[xb + 0] = vv[0];
-                        line_cache[xb + 1] = vv[1];
-                        line_cache[xb + 2] = vv[2];
-                        line_cache[xb + 3] = vv[3];
-                    }
-                    for (; xb < INPUT_LINE_SIZE; xb++) {
-                        line_cache[xb] = INPUT_BLOCK_READ(input, grouped_input_offset +
-                                                                 icb * input_fs_pitch +
-                                                                 kh * DILATION_SIZE_Y * input_y_pitch +
-                                                                 xb * input_x_pitch);
+                            line_cache[xb + 0] = vv[0];
+                            line_cache[xb + 1] = vv[1];
+                            line_cache[xb + 2] = vv[2];
+                            line_cache[xb + 3] = vv[3];
+                        }
+                        for (; xb < INPUT_LINE_SIZE; xb++) {
+                            line_cache[xb] = INPUT_BLOCK_READ(input, grouped_input_offset +
+                                                                     icb * input_fs_pitch +
+                                                                     kh * DILATION_SIZE_Y * input_y_pitch +
+                                                                     xb * input_x_pitch);
+                        }
+
+                    } else {
+                        for (; xb < INPUT_LINE_SIZE; xb++) {
+                            if (input_x + xb >= 0 && input_x + xb < INPUT0_SIZE_X) {
+                                line_cache[xb] = INPUT_BLOCK_READ(input, grouped_input_offset +
+                                                                         icb * input_fs_pitch +
+                                                                         kh * DILATION_SIZE_Y * input_y_pitch +
+                                                                         xb * input_x_pitch);
+                            } else {
+                                line_cache[xb] = 0;
+                            }
+                        }
                     }
                 }
 

--- a/inference-engine/thirdparty/clDNN/runtime/memory.cpp
+++ b/inference-engine/thirdparty/clDNN/runtime/memory.cpp
@@ -17,30 +17,29 @@
 
 namespace cldnn {
 
+
 memory::memory(engine* engine, const layout& layout, allocation_type type, bool reused)
     : _engine(engine), _layout(layout), _bytes_count(_layout.bytes_count()), _type(type), _reused(reused) {
     if (!_reused && _engine) {
         _engine->add_memory_used(_bytes_count);
-    }
-
-    GPU_DEBUG_GET_INSTANCE(debug_config);
-    GPU_DEBUG_IF(debug_config->verbose >= 1) {
-        GPU_DEBUG_COUT << "Allocate " << _bytes_count << " bytes of " << type << " allocation type"
-                       << " (current=" << _engine->get_used_device_memory() << ";"
-                       << " max=" << _engine->get_max_used_device_memory() << ")" << std::endl;
+        GPU_DEBUG_GET_INSTANCE(debug_config);
+        GPU_DEBUG_IF(debug_config->verbose >= 1) {
+            GPU_DEBUG_COUT << "Allocate " << _bytes_count << " bytes of " << type << " allocation type"
+                           << " (current=" << _engine->get_used_device_memory() << ";"
+                           << " max=" << _engine->get_max_used_device_memory() << ")" << std::endl;
+        }
     }
 }
 
 memory::~memory() {
     if (!_reused && _engine) {
         _engine->subtract_memory_used(_bytes_count);
-    }
-
-    GPU_DEBUG_GET_INSTANCE(debug_config);
-    GPU_DEBUG_IF(debug_config->verbose >= 1) {
-        GPU_DEBUG_COUT << "Free " << _bytes_count << " bytes"
-                       << " (current=" << _engine->get_used_device_memory() << ";"
-                       << " max=" << _engine->get_max_used_device_memory() << ")" << std::endl;
+        GPU_DEBUG_GET_INSTANCE(debug_config);
+        GPU_DEBUG_IF(debug_config->verbose >= 1) {
+            GPU_DEBUG_COUT << "Free " << _bytes_count << " bytes"
+                           << " (current=" << _engine->get_used_device_memory() << ";"
+                           << " max=" << _engine->get_max_used_device_memory() << ")" << std::endl;
+        }
     }
 }
 


### PR DESCRIPTION
### Details:
 - fp16/fp32 fsv16 generic convolution kernel doesn't require physical padding. This patch disables adding pad for such cases
 - 

### Tickets:
 - *60861*
