### PR TITLE
summarize_graph show error when input saved_model is selected

### DIFF
--- a/model-optimizer/mo/utils/summarize_graph.py
+++ b/model-optimizer/mo/utils/summarize_graph.py
@@ -71,9 +71,10 @@ if __name__ == "__main__":  # pragma: no cover
         print("[ ERROR ] Both keys were provided --input_model and --input_dir. Please, provide only one of them")
         sys.exit(1)
     tags = argv.saved_model_tags.split(",")
-    graph_def, _, _ = load_tf_graph_def(graph_file_name=argv.input_model, is_binary=not argv.text,
-                                        checkpoint=argv.input_checkpoint,
-                                        model_dir=argv.saved_model_dir, saved_model_tags=tags)
+    graph_def = load_tf_graph_def(graph_file_name=argv.input_model, is_binary=not argv.text,
+                                  checkpoint=argv.input_checkpoint,
+                                  model_dir=argv.saved_model_dir, saved_model_tags=tags)
+    graph_def = graph_def[0]
     summary = summarize_graph(graph_def)
     print("{} input(s) detected:".format(len(summary['inputs'])))
     for input in summary['inputs']:


### PR DESCRIPTION
Root cause analysis: For some TF saved_model, we have a framework error after running the script `summarize_graph.py`.

> Traceback (most recent call last):
File "summarize_graph.py", line 74, in <module>
graph_def, _, _ = load_tf_graph_def(graph_file_name=argv.input_model, is_binary=not argv.text,
ValueError: not enough values to unpack (expected 3, got 2)

Solution: to write 
```python3
    graph_def = load_tf_graph_def(graph_file_name=argv.input_model, is_binary=not argv.text,
                                  checkpoint=argv.input_checkpoint,
                                  model_dir=argv.saved_model_dir, saved_model_tags=tags)
    graph_def = graph_def[0]
```
instead of 
```python3
    graph_def, _, _ = load_tf_graph_def(graph_file_name=argv.input_model, is_binary=not argv.text,
                                                             checkpoint=argv.input_checkpoint,
                                                             model_dir=argv.saved_model_dir, saved_model_tags=tags)
```

### Tickets:
 - *58810*


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR: N/A because there are no new transformations
* [x]  Transformation preserves original framework node names: N/A because there are no new transformations


Validation:
* [x]  Unit tests: N/A
* [x]  Framework operation tests: N/A - No new enabled operations;
* [x]  Transformation tests: N/A - No new implemented transformations;
* [x]  Model Optimizer IR Reader check: N/A

Documentation:
* [x]  Supported frameworks operations list: N/A - No new supported operations;
* [x]  Supported **public** models list: N/A - Nothing to add;
* [x]  User guide update: N/A - Nothing to update.