### PR TITLE
Remove CMAKE_STAGING_PREFIX initialization 

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -7,10 +7,6 @@ cmake_policy(SET CMP0054 NEW)
 # TODO: fix it
 set_temp_directory(TEMP "${IE_MAIN_SOURCE_DIR}")
 
-if(CMAKE_CROSSCOMPILING)
-    set(CMAKE_STAGING_PREFIX "${TEMP}")
-endif()
-
 if(ENABLE_SAME_BRANCH_FOR_MODELS)
     branchName(MODELS_BRANCH)
 else()


### PR DESCRIPTION
It seems that it's not necessary to define `CMAKE_STAGING_PREFIX` for cross-compilation build.
The installation path is defined by config `CMAKE_INSTALL_PREFIX`.