### PR TITLE
[GNA] Eltwise scalar input broadcasting pass

### DIFF
--- a/inference-engine/src/gna_plugin/gna_graph_tools.hpp
+++ b/inference-engine/src/gna_plugin/gna_graph_tools.hpp
@@ -634,13 +634,13 @@ inline void CNNNetworkInsertLayer(CNNLayerPtr after,
  * @param idx
  */
 template <class T>
-std::vector<std::pair<CNNLayerPtr, int> > CNNNetGetPrevLayersSkip(CNNLayerPtr origin, const T &acceptanceCriteria, int idx = -1) {
+std::vector<std::pair<CNNLayerPtr, int> > CNNNetGetPrevLayersSkip(CNNLayerPtr origin, const T &acceptanceCriteria, int idx = -1, bool recursion = true) {
     std::vector<std::pair<CNNLayerPtr, int> > prevLayers;
     for (int i = idx == -1 ? 0 : idx; CNNNetHasPrevLayer(origin.get(), i) && (idx == -1 || i == idx); i++) {
         auto prevLayer = CNNNetPrevLayer(origin, i);
         if (acceptanceCriteria(prevLayer)) {
             prevLayers.push_back({prevLayer, CNNLayerFindOutDataIdx(origin, i)});
-        } else {
+        } else if (recursion) {
             // if for some input we need to look in upper layers - original index not used here intentionally
             auto prevPrevLayers = CNNNetGetPrevLayersSkip(prevLayer, acceptanceCriteria);
             prevLayers.insert(prevLayers.end(), prevPrevLayers.begin(), prevPrevLayers.end());

--- a/inference-engine/src/gna_plugin/gna_plugin.cpp
+++ b/inference-engine/src/gna_plugin/gna_plugin.cpp
@@ -756,6 +756,7 @@ void GNAPlugin::LoadNetwork(CNNNetwork & _network) {
 
         passes->registerPass<SubstituteScaleShiftBroadCastPass>();
         passes->registerPass<BroadcastConstPass>();
+        passes->registerPass<BroadcastEltwiseScalarInputPass>();
 
         passes->registerPass<TransposeWeightsFromNCHWToNHWCPass>();
 

--- a/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.hpp
+++ b/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.hpp
@@ -184,9 +184,14 @@ DECL_PASS_BEFORE_COPY(RemoveSingleInputConcat);
 DECL_PASS(FuseMultipleIdentities);
 
 /**
-* @brief Brodcast data in Const layer
+* @brief Broadcast data in Const layer
 */
 DECL_PASS(BroadcastConst);
+
+/**
+* @brief Broadcast non const scalar inputs of Eltwise layer
+*/
+DECL_PASS(BroadcastEltwiseScalarInput);
 
 /**
 * @brief runs static quantisation on given floating weights and replaces fakeQuantize with constblobs

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/skip_tests_config.cpp
@@ -19,9 +19,6 @@ std::vector<std::string> disabledTestPatterns() {
         // TODO: FIX BUG 32210
         R"(.*ActivationLayerTest.CompareWithRefs/(Sigmoid|Tanh|Exp|Log).*)",
         R"(.*ActivationFQSubgraph.*activation=(Exp|Log).*)",
-        // TODO: Issue 32542
-        R"(.*(EltwiseLayerTest).*eltwiseOpType=(Sum|Sub).*opType=SCALAR.*)",
-        R"(.*(EltwiseLayerTest).*eltwiseOpType=Prod.*secondaryInputType=PARAMETER.*opType=SCALAR.*)",
         // TODO: Issue: 34348
         R"(.*IEClassGetAvailableDevices.*)",
         // TODO: Issue 32923


### PR DESCRIPTION
**Details:**
- Add pass to broadcast the scalar non-const type input of Eltwise layer
- Add optional argument `bool recursion` to `CNNNetGetPrevLayersSkip(...)` to be able to stop the search of previous layers in depth
- Removed patterns of fixed tests from `skip_tests_config.cpp`

**Tickets:**
- *CVS-32542*