### PR TITLE
Fix for summarize_graph.py.

### DIFF
--- a/model-optimizer/mo/utils/summarize_graph.py
+++ b/model-optimizer/mo/utils/summarize_graph.py
@@ -70,9 +70,10 @@ if __name__ == "__main__":  # pragma: no cover
     if argv.input_model and argv.saved_model_dir:
         print("[ ERROR ] Both keys were provided --input_model and --input_dir. Please, provide only one of them")
         sys.exit(1)
-    graph_def, _ = load_tf_graph_def(graph_file_name=argv.input_model, is_binary=not argv.text,
-                                     checkpoint=argv.input_checkpoint,
-                                     model_dir=argv.saved_model_dir, saved_model_tags=argv.saved_model_tags)
+    tags = argv.saved_model_tags.split(",")
+    graph_def, _, _ = load_tf_graph_def(graph_file_name=argv.input_model, is_binary=not argv.text,
+                                        checkpoint=argv.input_checkpoint,
+                                        model_dir=argv.saved_model_dir, saved_model_tags=tags)
     summary = summarize_graph(graph_def)
     print("{} input(s) detected:".format(len(summary['inputs'])))
     for input in summary['inputs']:


### PR DESCRIPTION
Root cause analysis: For some TF saved_model, we have a framework error after running the script `summarize_graph.py`.

> python3 /opt/intel/openvino_2021.4.582/deployment_tools/model_optimizer/mo/utils/summarize_graph.py --input_model resnet_v2_50_inference_graph.pb
Traceback (most recent call last):
  File "/opt/intel/openvino_2021.4.582/deployment_tools/model_optimizer/mo/utils/summarize_graph.py", line 75, in <module>
    model_dir=argv.saved_model_dir, saved_model_tags=argv.saved_model_tags)
ValueError: too many values to unpack (expected 2)

Solution: to write 
```python3
    tags = argv.saved_model_tags.split(",")
    graph_def, _, _ = load_tf_graph_def(graph_file_name=argv.input_model, is_binary=not argv.text,
                                        checkpoint=argv.input_checkpoint,
                                        model_dir=argv.saved_model_dir, saved_model_tags=tags)
```
instead of 
```python3
    graph_def, _, = load_tf_graph_def(graph_file_name=argv.input_model, is_binary=not argv.text,
                                                          checkpoint=argv.input_checkpoint,
                                                          model_dir=argv.saved_model_dir, saved_model_tags=tags)
```

### Tickets:
 - *61617*


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR: N/A because there are no new transformations
* [x]  Transformation preserves original framework node names: N/A because there are no new transformations


Validation:
* [x]  Unit tests: N/A
* [x]  Framework operation tests: N/A - No new enabled operations;
* [x]  Transformation tests: N/A - No new implemented transformations;
* [x]  Model Optimizer IR Reader check: N/A

Documentation:
* [x]  Supported frameworks operations list: N/A - No new supported operations;
* [x]  Supported **public** models list: N/A - Nothing to add;
* [x]  User guide update: N/A - Nothing to update.