### PR TITLE
[CPU] Add reorder if the constant memory is not aligned, and isa is SSE

### DIFF
--- a/inference-engine/src/mkldnn_plugin/mkldnn_memory.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_memory.h
@@ -148,7 +148,7 @@ public:
      */
     void* GetData() const {
         void* data = prim->get_data_handle();
-        if (data == nullptr)
+        if (data == nullptr && pMemDesc->getShape().getElementsCount() != 0)
             IE_THROW() << "Cannot get memory!";
         return data;
     }

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reorder_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reorder_node.cpp
@@ -133,9 +133,10 @@ void MKLDNNReorderNode::createReorderPrimitive(const mkldnn::memory::desc &srcDe
         // split group dimension in separate shape dimension. IE use OIHW, but mkldnn expect GOIHW.
         // So we will perform implicit reshape to dst shape.
         //
-        // MKLDNN doesn't support direct reorders from planar data formats to grouped weights formats.
-        // Code block below tries to detect such cases and reinterpret data planar formats (e.g. nchw)
-        // as grouped weights planar formats (e.g. goihw) since they have same physical memory layout.
+        // MKLDNN doesn't support direct reorders for tensors of different rank. The code below tries to
+        // perform such conversion if the source tensor can be reshaped to the destination rank. This is
+        // useful in situations when rank in IR does not much rank that is required by the oneDNN primitive,
+        // but the input tensor can be reshaped (e.g. weights for grouped convolutions, biases etc.)
         if (src_blocked->GetDesc().hasLayoutType(LayoutType::ncsp) &&
             src_blocked->GetDims().size() != dst_blocked->GetDims().size()) {
             const auto newDims = dst_blocked->GetDims();

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reorder_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reorder_node.cpp
@@ -137,7 +137,7 @@ void MKLDNNReorderNode::createReorderPrimitive(const mkldnn::memory::desc &srcDe
         // Code block below tries to detect such cases and reinterpret data planar formats (e.g. nchw)
         // as grouped weights planar formats (e.g. goihw) since they have same physical memory layout.
         if (src_blocked->GetDesc().hasLayoutType(LayoutType::ncsp) &&
-            src_blocked->GetDims().size() + 1 == dst_blocked->GetDims().size()) {
+            src_blocked->GetDims().size() != dst_blocked->GetDims().size()) {
             const auto newDims = dst_blocked->GetDims();
             const auto newFormat = MKLDNNMemory::GetPlainFormatByRank(newDims.size());
 


### PR DESCRIPTION
### Details:
In the most part of the legacy SSE, operations memory operands (m128) must be aligned on a 16-byte boundary, therefore we have to ensure that all memory pointers passed to the sse primitives are properly aligned. Since some constants are used directly from ngraph allocated memory, we cannot guarantee that all the pointers are properly aligned, so the `needReorder()` has been updated to handle such cases. If the constant address is not aligned, a reorder is inserted to copy the data to the properly aligned region. 

### Tickets:
 - 60959
