### PR TITLE
[GPU] Replace internal TBlobs with mappable ClBlobs 

### DIFF
--- a/inference-engine/src/cldnn_engine/cldnn_graph.h
+++ b/inference-engine/src/cldnn_engine/cldnn_graph.h
@@ -51,8 +51,10 @@ public:
     InferenceEngine::SizeVector GetOutputSize(std::string outName) const;
     std::string MapOutputName(std::string outName) const;
     std::string getName() const { return m_networkName; }
+    std::mutex& get_mutex() { return m_infer_mutex; }
 
 protected:
+    std::mutex m_infer_mutex;
     std::string m_networkName;
     Config m_config;
 

--- a/inference-engine/src/cldnn_engine/cldnn_infer_request.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_infer_request.cpp
@@ -17,122 +17,36 @@
 
 using namespace InferenceEngine;
 
-namespace CLDNNPlugin {
+namespace {
 
 const char fp32_suffix[] = "_fp32";
-const char str_not_allocated[] = "Input data was not allocated.";
 const char cannot_set_compound[] = "cannot set compound blob: supported only for input pre-processing";
 const char wrong_nv12_blob[] = "NV12 input blob is expected for input with NV12 color format";
-const char unsupported_batched_blob[] = "Batched input blob is expected to contain nv12 blobs";
+const char unsupported_batched_blob[] = "Batched input blob is expected to contain NV12 blobs";
+const char str_input_not_allocated[] = "Input data was not allocated.";
+const char str_output_not_allocated[] = "Output data was not allocated.";
 
-Blob::Ptr CLDNNInferRequest::createInputBlob(const TensorDesc& desc, uint8_t* mem_ptr) {
-    OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::createInputBlob");
-    const Precision p = desc.getPrecision();
-
-    switch (p) {
-    case Precision::FP32:
-        if (mem_ptr != nullptr)
-            return make_shared_blob<float>(desc, reinterpret_cast<float*>(mem_ptr));
-        else
-            return make_shared_blob<float>(desc);
-    case Precision::FP16:
-        if (mem_ptr != nullptr)
-            return make_shared_blob<uint16_t>(desc, reinterpret_cast<uint16_t*>(mem_ptr));
-        else
-            return make_shared_blob<uint16_t>(desc);
-    case Precision::I16:
-        if (mem_ptr != nullptr)
-            return make_shared_blob<int16_t>(desc, reinterpret_cast<int16_t*>(mem_ptr));
-        else
-            return make_shared_blob<int16_t>(desc);
-    case Precision::U16:
-        if (mem_ptr != nullptr)
-            return make_shared_blob<uint16_t>(desc, reinterpret_cast<uint16_t*>(mem_ptr));
-        else
-            return make_shared_blob<uint16_t>(desc);
-    case Precision::I32:
-        if (mem_ptr != nullptr)
-            return make_shared_blob<int32_t>(desc, reinterpret_cast<int32_t*>(mem_ptr));
-        else
-            return make_shared_blob<int32_t>(desc);
-    case Precision::I64:
-        if (mem_ptr != nullptr)
-            return make_shared_blob<int64_t>(desc, reinterpret_cast<int64_t*>(mem_ptr));
-        else
-            return make_shared_blob<int64_t>(desc);
-    case Precision::I8:
-        if (mem_ptr != nullptr)
-            return make_shared_blob<int8_t>(desc, reinterpret_cast<int8_t*>(mem_ptr));
-        else
-            return make_shared_blob<int8_t>(desc);
-    case Precision::U8:
-        if (mem_ptr != nullptr)
-            return make_shared_blob<uint8_t>(desc, reinterpret_cast<uint8_t*>(mem_ptr));
-        else
-            return make_shared_blob<uint8_t>(desc);
-    case Precision::BOOL:
-        if (mem_ptr != nullptr)
-            return make_shared_blob<uint8_t>(desc, reinterpret_cast<uint8_t*>(mem_ptr));
-        else
-            return make_shared_blob<uint8_t>(desc);
-    default:
-        IE_THROW() << "The plugin does not support input " << p.name() << " precision";
+template <typename T>
+void copyToFloat(float* dst, const InferenceEngine::Blob* src) {
+    if (!dst) {
+        return;
     }
-}
-
-Blob::Ptr CLDNNInferRequest::createOutputBlob(const TensorDesc& desc, uint8_t* mem_ptr) {
-    OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::createOutputBlob");
-    const Precision p = desc.getPrecision();
-
-    switch (p) {
-    case Precision::FP32:
-        if (mem_ptr != nullptr)
-            return make_shared_blob<float>(desc, reinterpret_cast<float*>(mem_ptr));
-        else
-            return make_shared_blob<float>(desc);
-    case Precision::FP16:
-        if (mem_ptr != nullptr)
-            return make_shared_blob<uint16_t>(desc, reinterpret_cast<uint16_t*>(mem_ptr));
-        else
-            return make_shared_blob<uint16_t>(desc);
-    case Precision::I32:
-        if (mem_ptr != nullptr)
-            return make_shared_blob<int32_t>(desc, reinterpret_cast<int32_t*>(mem_ptr));
-        else
-            return make_shared_blob<int32_t>(desc);
-     case Precision::I64:
-        if (mem_ptr != nullptr)
-            return make_shared_blob<int64_t>(desc, reinterpret_cast<int64_t*>(mem_ptr));
-        else
-            return make_shared_blob<int64_t>(desc);
-    default:
-        IE_THROW() << "The plugin does not support output " << p.name() << " precision";
+    auto t_blob = dynamic_cast<const InferenceEngine::TBlob<T>*>(src);
+    if (!t_blob) {
+        IE_THROW() << "input type is " << src->getTensorDesc().getPrecision() << " but input is not "
+                   << typeid(T).name();
     }
-}
 
-void CLDNNInferRequest::input_attach(cldnn::primitive_id name, cldnn::memory::ptr inputMem) {
-    OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::input_attach");
-    auto impl = getContextImpl(m_graph->GetContext());
-    impl->acquire_lock();
-
-    auto mem_itr = inputsMemory.find(name);
-
-    if (mem_itr != inputsMemory.end())
-        mem_itr->second = inputMem;
-    else
-        inputsMemory.insert({ name, inputMem });
-
-    impl->release_lock();
-}
-
-void CLDNNInferRequest::input_alloc(cldnn::primitive_id name, const cldnn::layout& layout) {
-    OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::input_alloc");
-    cldnn::memory::ptr input_mem = m_graph->GetEngine()->allocate_memory(layout);
-    input_attach(name, input_mem);
+    const T* srcPtr = t_blob->readOnly();
+    if (!srcPtr) {
+        IE_THROW(NotAllocated) << str_input_not_allocated;
+    }
+    for (size_t i = 0; i < t_blob->size(); i++)
+        dst[i] = srcPtr[i];
 }
 
 template<typename T>
-void copyResultToOutputBlob(cldnn::memory::ptr src, Blob::Ptr dst, buf_info* bi, cldnn::stream& stream) {
+void copyResultToOutputBlob(cldnn::memory::ptr src, Blob::Ptr dst, CLDNNPlugin::buf_info* bi, cldnn::stream& stream) {
     size_t n = (bi == nullptr) ? dst->size() : bi->buf_size;
     size_t offset = (bi == nullptr) ? 0 : bi->buf_offset;
 
@@ -169,80 +83,15 @@ void copyResultToOutputBlob(cldnn::memory::ptr src, Blob::Ptr dst, buf_info* bi,
     }
 }
 
-void CLDNNInferRequest::copyOutputData(cldnn::memory::ptr src, Blob::Ptr dst, buf_info* bi) {
-    OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::copyOutputData");
-    auto& stream = m_graph->GetNetwork()->get_stream();
-    switch (dst->getTensorDesc().getPrecision()) {
-    case Precision::FP32: copyResultToOutputBlob<float>(src, dst, bi, stream);    break;
-    case Precision::FP16: copyResultToOutputBlob<uint16_t>(src, dst, bi, stream); break;
-    case Precision::I32:  copyResultToOutputBlob<int32_t>(src, dst, bi, stream);  break;
-    case Precision::I64:  copyResultToOutputBlob<int64_t>(src, dst, bi, stream);  break;
-    default: IE_THROW(NotImplemented) << "The plugin does not support output " << dst->getTensorDesc().getPrecision() << " precision";
+inline void checkAlloc(const Blob::Ptr& blob, const std::string& err_str) {
+    bool not_allocated = false;
+    if (!blob->is<gpu::ClBlob>()) {
+        not_allocated = (blob->buffer() == nullptr);
+    } else {
+        not_allocated = !CLDNNPlugin::getBlobImpl(blob->as<gpu::ClBlob>())->is_allocated();
     }
-}
-
-void CLDNNInferRequest::copyInputData(std::shared_ptr<cldnn::network> network,
-                                      const cldnn::primitive_id &inputName,
-                                      const cldnn::layout& inputLayout,
-                                      const Blob &inputBlob, buf_info* bi) {
-    OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::copyInputData");
-
-    size_t offset = (bi == nullptr) ? 0 : bi->buf_offset;
-
-    cldnn::primitive_id internalName = "parameter:" + inputName;
-    auto locked = inputBlob.cbuffer();
-    switch (inputBlob.getTensorDesc().getPrecision()) {
-    case Precision::FP32: {
-        float* blob_ptr = const_cast<float*>(locked.as<const float*>()) + offset;
-        network->set_input_data(internalName, network->get_engine().attach_memory(inputLayout, blob_ptr));
-        break;
-    }
-    case Precision::I32: {
-        int32_t* blob_ptr = const_cast<int32_t*>(locked.as<const int32_t*>()) + offset;
-        network->set_input_data(internalName, network->get_engine().attach_memory(inputLayout, blob_ptr));
-        break;
-    }
-    case Precision::I64: {
-        int64_t* blob_ptr = const_cast<int64_t*>(locked.as<const int64_t*>()) + offset;
-        network->set_input_data(internalName, network->get_engine().attach_memory(inputLayout, blob_ptr));
-        break;
-    }
-    case Precision::FP16: {
-        uint16_t* blob_ptr = const_cast<uint16_t*>(locked.as<const uint16_t*>()) + offset;
-        network->set_input_data(internalName, network->get_engine().attach_memory(inputLayout, blob_ptr));
-        break;
-    }
-    case Precision::I8: {
-        int8_t* blob_ptr = const_cast<int8_t*>(locked.as<const int8_t*>()) + offset;
-        network->set_input_data(internalName, network->get_engine().attach_memory(inputLayout, blob_ptr));
-        break;
-    }
-    case Precision::U8: {
-        uint8_t* blob_ptr = const_cast<uint8_t*>(locked.as<const uint8_t*>()) + offset;
-        network->set_input_data(internalName, network->get_engine().attach_memory(inputLayout, blob_ptr));
-        break;
-    }
-    case Precision::BOOL: {
-        uint8_t* blob_ptr = const_cast<uint8_t*>(locked.as<const uint8_t*>()) + offset;
-        network->set_input_data(internalName, network->get_engine().attach_memory(inputLayout, blob_ptr));
-        break;
-    }
-    default:
-        IE_THROW() << "The plugin does not support input " << inputBlob.getTensorDesc().getPrecision() << " precision";
-    }
-}
-
-void checkInputBlobNV12(const NV12Blob *nv12_ptr) {
-    auto y_ptr = nv12_ptr->y()->as<gpu::ClBlob>();
-
-    // if the blobs are not remote, check their size
-    if (!y_ptr) {
-        if (nv12_ptr->y()->buffer() == nullptr) IE_THROW(NotAllocated) << str_not_allocated;
-    }
-
-    auto uv_ptr = nv12_ptr->uv()->as<gpu::ClBlob>();
-    if (!uv_ptr) {
-        if (nv12_ptr->uv()->buffer() == nullptr) IE_THROW(NotAllocated) << str_not_allocated;
+    if (not_allocated) {
+        IE_THROW(NotAllocated) << err_str;
     }
 }
 
@@ -260,17 +109,19 @@ void checkInputBlob(const Blob::Ptr &blob,
     const std::string strNotMatched("The input blob size is not equal to the network input size");
 
     if (!blob) {
-        IE_THROW() << str_not_allocated;
+        IE_THROW(NotAllocated) << str_input_not_allocated;
     }
 
     if (ColorFormat::NV12 == foundInput->getPreProcess().getColorFormat() &&
         nv12_two_inputs) {
         if (auto nv12_ptr = blob->as<NV12Blob>()) {
-            checkInputBlobNV12(nv12_ptr);
+            checkAlloc(nv12_ptr->y(), str_input_not_allocated);
+            checkAlloc(nv12_ptr->uv(), str_input_not_allocated);
         } else if (auto batched_ptr = blob->as<BatchedBlob>()) {
             for (auto i = 0; i < batched_ptr->size(); i++) {
                 auto nv12_ptr = getNV12BlobOrException(batched_ptr, i);
-                checkInputBlobNV12(nv12_ptr);
+                checkAlloc(nv12_ptr->y(), str_input_not_allocated);
+                checkAlloc(nv12_ptr->uv(), str_input_not_allocated);
             }
         } else {
             IE_THROW(ParameterMismatch) << wrong_nv12_blob;
@@ -287,20 +138,17 @@ void checkInputBlob(const Blob::Ptr &blob,
             IE_THROW() << strNotMatched + ": got " << blob->size() << " expecting " << refSize;
         }
 
-        if (!blob->is<gpu::ClBlob>()) {
-            if (blob->buffer() == nullptr) IE_THROW() << str_not_allocated;
-        }
+        checkAlloc(blob, str_input_not_allocated);
     }
 }
 
 void checkOutputBlob(const Blob::Ptr &blob,
     const std::string &name,
     const DataPtr foundOutput) {
-    const std::string strNotAllocated("Output data was not allocated.");
     const std::string strNotMatched("The output blob size is not equal to the network output size");
 
     if (!blob) {
-        IE_THROW() << strNotAllocated;
+        IE_THROW(NotAllocated) << str_output_not_allocated;
     }
     SizeVector dims = foundOutput->getTensorDesc().getDims();
     size_t refSize = foundOutput->getTensorDesc().getLayout() != SCALAR
@@ -311,43 +159,17 @@ void checkOutputBlob(const Blob::Ptr &blob,
         IE_THROW() << strNotMatched + ": got " << blob->size() << " expecting " << refSize;
     }
 
-    if (!blob->is<gpu::ClBlob>()) {
-        if (blob->buffer() == nullptr) IE_THROW() << strNotAllocated;
-    }
+    checkAlloc(blob, str_output_not_allocated);
 }
 
-void CLDNNInferRequest::checkBlobs() {
-    OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::checkBlobs");
-    for (auto const &input : _inputs) {
-        InputInfo::Ptr foundInput = nullptr;
-        auto foundInputPair = std::find_if(std::begin(_networkInputs), std::end(_networkInputs),
-            [&](const std::pair<std::string, InputInfo::Ptr> &pair) {
-            return pair.first == input.first;
-        });
-        if (foundInputPair != std::end(_networkInputs)) {
-            foundInput = foundInputPair->second;
-        } else {
-            IE_THROW(NotFound)
-                << "Failed to find input with name: \'" << input.first << "\'";
-        }
-        checkInputBlob(input.second, input.first, foundInput, m_graph->getConfig().nv12_two_inputs);
-    }
-    for (auto const &output : _outputs) {
-        DataPtr foundOutput;
-        auto foundOutputPair = std::find_if(std::begin(_networkOutputs), std::end(_networkOutputs),
-            [&](const std::pair<std::string, DataPtr> &pair) {
-            return pair.first == output.first;
-        });
-        if (foundOutputPair != std::end(_networkOutputs)) {
-            foundOutput = foundOutputPair->second;
-        } else {
-            IE_THROW(NotFound)
-                << "Failed to find output with name: \'" << output.first << "\'";
-        }
-        checkOutputBlob(output.second, output.first, foundOutput);
-    }
-}
+}  // namespace
 
+namespace CLDNNPlugin {
+
+
+// ----------------------------------------------------------------------------------------- //
+// ---------------------------- IE API impl ------------------------------------------------ //
+// ----------------------------------------------------------------------------------------- //
 Blob::Ptr CLDNNInferRequest::GetBlob(const std::string& name) {
     OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::GetBlob");
     Blob::Ptr data;
@@ -371,7 +193,7 @@ Blob::Ptr CLDNNInferRequest::GetBlob(const std::string& name) {
     return data;
 }
 
-void CLDNNInferRequest::SetBlob(const std::string& name, const Blob::Ptr &data) {
+void CLDNNInferRequest::SetBlob(const std::string& name, const Blob::Ptr& data) {
     OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::SetBlob");
 
     // perform all common checks first
@@ -397,69 +219,73 @@ void CLDNNInferRequest::SetBlob(const std::string& name, const Blob::Ptr &data) 
         : foundOutput->getTensorDesc();
 
     if (desc.getPrecision() != blobDesc.getPrecision()) {
-        IE_THROW(ParameterMismatch)
-            << "Failed to set Blob with precision not corresponding to user "
-            << (is_input ? "input" : "output") << " precision";
+        IE_THROW(ParameterMismatch) << "Failed to set Blob with precision not corresponding to user "
+                                    << (is_input ? "input" : "output") << " precision";
     }
 
     auto remote_ptr = data->as<gpu::ClBlob>();
     bool is_remote = remote_ptr != nullptr;
     if (is_remote) {
         auto impl = getBlobImpl(remote_ptr);
-        impl->allocate_if_needed();
+        impl->allocate();
     }
-
     if (is_input) {
-        cldnn::primitive_id internalName(name);
-
         if (is_remote) {
-            auto inputMem = getBlobImpl(remote_ptr)->getMemory();
-            input_attach(internalName, inputMem);
+            _deviceInputs[name] = data;
             _inputs[name] = data;
-        } else if (compoundBlobPassed) {
+        } else {
+            auto nv12_ptr = data->as<NV12Blob>();
+            auto batched_ptr = data->as<BatchedBlob>();
+            bool is_batched = batched_ptr != nullptr;
+            bool is_nv12 = nv12_ptr != nullptr;
+            int expected_batch = is_batched ? desc.getDims()[0] : 1;
             if (ColorFormat::NV12 == foundInput->getPreProcess().getColorFormat() &&
                 m_graph->getConfig().nv12_two_inputs) {
                 // try extracting Y and UV remote blobs from it
                 // and put them into appropriate network inputs
                 // that should then go into biplanar NV12 reorder
-                auto nv12_ptr = data->as<NV12Blob>();
-                auto batched_ptr = data->as<BatchedBlob>();
 
-                if (nv12_ptr != nullptr || batched_ptr != nullptr) {
-                    int num_blobs = batched_ptr != nullptr ? batched_ptr->size() : 1;
-
-                    for (auto i = 0; i < num_blobs; i++) {
-                        if (batched_ptr != nullptr)
-                            nv12_ptr = getNV12BlobOrException(batched_ptr, i);
+                if (is_nv12 || is_batched) {
+                    int num_blobs = is_batched ? batched_ptr->size() : 1;
+                    for (auto i = 0; i < expected_batch; i++) {
+                        std::string y_name = name + "_Y" + std::to_string(i);
+                        std::string uv_name = name + "_UV" + std::to_string(i);
+                        if (is_batched) {
+                            int idx = i < num_blobs ? i : num_blobs-1;
+                            nv12_ptr = getNV12BlobOrException(batched_ptr, idx);
+                        }
 
                         auto y_ptr = nv12_ptr->y()->as<gpu::ClBlob>();
                         if (y_ptr) {
                             auto y_impl = getBlobImpl(y_ptr);
-                            y_impl->allocate_if_needed();
-                            input_attach(internalName + "_Y" + std::to_string(i), y_impl->getMemory());
+                            y_impl->allocate();
+                            _deviceInputs[y_name] = nv12_ptr->y();
                             is_remote = true;
                         }
 
                         auto uv_ptr = nv12_ptr->uv()->as<gpu::ClBlob>();
                         if (uv_ptr) {
                             auto uv_impl = getBlobImpl(uv_ptr);
-                            uv_impl->allocate_if_needed();
-                            input_attach(internalName + "_UV" + std::to_string(i), uv_impl->getMemory());
+                            uv_impl->allocate();
+                            _deviceInputs[uv_name] = nv12_ptr->uv();
                             is_remote = true;
                         }
                     }
-                } else {
-                    IE_THROW(ParameterMismatch) << wrong_nv12_blob;
                 }
-
-                if (is_remote) _inputs[name] = data;
             }
+            if (is_remote)
+                _inputs[name] = data;
         }
 
         if (!is_remote) {
             if (preProcessingRequired(foundInput, data)) {
                 // Stores the given blob as ROI blob. It will be used to fill in network input
                 // during pre-processing
+                if (_inputs[name]->is<gpu::ClBlob>()) {
+                    Blob::Ptr inputHostBlob = create_input_host_blob(desc);
+                    inputHostBlob->allocate();
+                    _inputs[name] = inputHostBlob;
+                }
                 _preProcData[name] = CreatePreprocDataHelper();
                 _preProcData[name]->isApplicable(data, _inputs[name]);
                 _preProcData[name]->setRoiBlob(data);
@@ -467,17 +293,16 @@ void CLDNNInferRequest::SetBlob(const std::string& name, const Blob::Ptr &data) 
                 if (compoundBlobPassed) {
                     IE_THROW(NotImplemented) << cannot_set_compound;
                 }
-
                 size_t blobSize = desc.getLayout() != SCALAR
                     ? details::product(desc.getDims())
                     : 1;
                 if (dataSize != blobSize) {
                     IE_THROW() << "Input blob size is not equal network input size ("
-                        << dataSize << "!=" << blobSize << ").";
+                               << dataSize << "!=" << blobSize << ").";
                 }
 
                 if (data->buffer() == nullptr)
-                    IE_THROW() << str_not_allocated << " Input name: \'" << name << "\'";
+                    IE_THROW(NotAllocated) << str_input_not_allocated << " Input name: \'" << name << "\'";
                 _inputs[name] = data;
             }
         }
@@ -487,148 +312,49 @@ void CLDNNInferRequest::SetBlob(const std::string& name, const Blob::Ptr &data) 
         }
 
         if (is_remote) {
-            std::string outputID = m_graph->MapOutputName(name);
-            auto impl = getBlobImpl(remote_ptr);
-            m_graph->GetNetwork()->set_output_memory(outputID, impl->getMemory());
+            _deviceOutputs[name] = data;
         } else {
             size_t outputSize = desc.getLayout() != SCALAR
                 ? details::product(desc.getDims())
                 : 1;
             if (dataSize != outputSize) {
                 IE_THROW() << "Output blob size is not equal network output size (" << dataSize
-                    << "!=" << outputSize << ").";
+                           << "!=" << outputSize << ").";
             }
             if (data->buffer() == nullptr)
-                IE_THROW() << str_not_allocated << " Input name: \'" << name << "\'";
+                IE_THROW(NotAllocated) << str_input_not_allocated << " Input name: \'" << name << "\'";
         }
         _outputs[name] = data;
     }
 }
 
-void CLDNNInferRequest::AllocateInputs() {
-    OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::AllocateInputs");
-    auto inputLayouts = m_graph->GetInputLayouts();
-    auto& stream = m_graph->GetNetwork()->get_stream();
-    // allocate inputs
-    for (auto& ni : _networkInputs) {
-        std::string name = ni.first;
-        const TensorDesc& desc = ni.second->getTensorDesc();
-
-        if (ColorFormat::NV12 == ni.second->getPreProcess().getColorFormat() &&
-            m_graph->getConfig().nv12_two_inputs) {
-            std::vector<Blob::Ptr> blobs;
-            for (auto i = 0; i < desc.getDims()[0]; i++) {
-                cldnn::primitive_id YName(name + "_Y" + std::to_string(i));
-                cldnn::primitive_id UVName(name + "_UV" + std::to_string(i));
-
-                if (inputLayouts.find(YName) == inputLayouts.end()) {
-                    IE_THROW(ParameterMismatch) << "Input layout for " << YName << " is not found";
-                }
-                if (inputLayouts.find(UVName) == inputLayouts.end()) {
-                    IE_THROW(ParameterMismatch) << "Input layout for " << YName << " is not found";
-                }
-                input_alloc(YName, inputLayouts.at(YName));
-                input_alloc(UVName, inputLayouts.at(UVName));
-
-                size_t height = desc.getDims()[2], width = desc.getDims()[3];
-                cldnn::mem_lock<uint8_t> input_mem_ptr_Y{inputsMemory.at(YName), stream};
-                TensorDesc ydesc(Precision::U8, { 1, 1, height, width }, Layout::NHWC);
-                auto blobY = createInputBlob(ydesc, input_mem_ptr_Y.data());
-
-                cldnn::mem_lock<uint8_t> input_mem_ptr_UV{ inputsMemory.at(UVName), stream };
-                TensorDesc uvdesc(Precision::U8, { 1, 2, height / 2, width / 2 }, Layout::NHWC);
-                auto blobUV = createInputBlob(uvdesc, input_mem_ptr_UV.data());
-
-                blobs.push_back(make_shared_blob<NV12Blob>(blobY, blobUV));
-            }
-            _inputs[name] = desc.getDims()[0] == 1 ? blobs[0] : make_shared_blob<BatchedBlob>(blobs);
+void CLDNNInferRequest::checkBlobs() {
+    OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::checkBlobs");
+    for (auto const &input : _inputs) {
+        InputInfo::Ptr foundInput = nullptr;
+        auto foundInputPair = std::find_if(std::begin(_networkInputs), std::end(_networkInputs),
+            [&](const std::pair<std::string, InputInfo::Ptr> &pair) {
+            return pair.first == input.first;
+        });
+        if (foundInputPair != std::end(_networkInputs)) {
+            foundInput = foundInputPair->second;
         } else {
-            if (inputLayouts.find(name) == inputLayouts.end()) {
-                IE_THROW() << "Input layout for " << name << " is not found";
-            }
-            cldnn::layout layout = inputLayouts.at(name);
-            input_alloc(name, layout);
-            cldnn::mem_lock<uint8_t> mem_ptr{inputsMemory.at(name), stream};
-            _inputs[name] = createInputBlob(desc, mem_ptr.data());
-
-            if (desc.getPrecision() == Precision::I16 || desc.getPrecision() == Precision::U16) {
-                cldnn::layout layout_fp32 = layout;
-                layout_fp32.data_type = cldnn::data_types::f32;
-                input_alloc(name + fp32_suffix, layout_fp32);
-            }
+            IE_THROW(NotFound) << "Failed to find input with name: \'" << input.first << "\'";
         }
+        checkInputBlob(input.second, input.first, foundInput, m_graph->getConfig().nv12_two_inputs);
     }
-}
-
-void CLDNNInferRequest::AllocateInputsDyn() {
-    OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::AllocateInputsDyn");
-    // allocate inputs
-    for (auto &input : m_graph->GetInputLayouts()) {
-        InputInfo::Ptr ni = _networkInputs.at(input.first);
-        TensorDesc desc = ni->getTensorDesc();
-        SizeVector& dims = desc.getDims();
-
-        if (!dims.empty()) {
-            *dims.begin() = static_cast<size_t>(m_graph->GetMaxDynamicBatchSize());
+    for (auto const &output : _outputs) {
+        DataPtr foundOutput = nullptr;
+        auto foundOutputPair = std::find_if(std::begin(_networkOutputs), std::end(_networkOutputs),
+            [&](const std::pair<std::string, DataPtr> &pair) {
+            return pair.first == output.first;
+        });
+        if (foundOutputPair != std::end(_networkOutputs)) {
+            foundOutput = foundOutputPair->second;
         } else {
-            IE_THROW() << "Empty dimensions for input blob " << input.first;
+            IE_THROW(NotFound) << "Failed to find output with name: \'" << output.first << "\'";
         }
-
-        Blob::Ptr inputBlob = createInputBlob(desc);
-        if (desc.getPrecision() == Precision::I16 || desc.getPrecision() == Precision::U16) {
-            desc.setPrecision(Precision::FP32);
-            auto fp32inputBlob = InferenceEngine::make_shared_blob<float>(desc);
-            fp32inputBlob->allocate();
-            _inputs[input.first + fp32_suffix] = fp32inputBlob;
-        }
-        inputBlob->allocate();
-        _inputs[input.first] = inputBlob;
-    }
-}
-
-void CLDNNInferRequest::AllocateOutputs() {
-    OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::AllocateOutputs");
-    // allocate outputs
-    bool can_reuse_internal_mem = !m_useStreams;
-    for (auto& no : _networkOutputs) {
-        std::string outputID = m_graph->MapOutputName(no.first);
-        cldnn::memory::ptr output_mem = m_graph->GetNetwork()->get_output_memory(outputID);
-        cldnn::mem_lock<uint8_t> output_mem_ptr{output_mem, m_graph->GetNetwork()->get_stream()};
-        if (output_mem_ptr.data() == nullptr) {
-            IE_THROW() << "Empty output memory for primitive " << outputID;
-        }
-
-        DataPtr oi = no.second;
-        const TensorDesc& desc = oi->getTensorDesc();
-
-        if (can_reuse_internal_mem) {
-            _outputs[no.first] = createOutputBlob(desc, output_mem_ptr.data());
-        } else {
-            Blob::Ptr outputBlob = createOutputBlob(desc);
-            outputBlob->allocate();
-            _outputs[no.first] = outputBlob;
-        }
-        outputsMap[no.first] = outputID;
-    }
-}
-
-void CLDNNInferRequest::AllocateOutputsDyn() {
-    OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::AllocateOutputsDyn");
-    // allocate outputs
-    for (auto& no : _networkOutputs) {
-        DataPtr oi = no.second;
-        TensorDesc desc = oi->getTensorDesc();
-        SizeVector& dims = desc.getDims();
-
-        if (!dims.empty()) {
-            *dims.begin() = static_cast<size_t>(m_graph->GetMaxDynamicBatchSize());
-        } else {
-            IE_THROW() << "Empty dimensions for output blob " << no.first;
-        }
-
-        Blob::Ptr outputBlob = createOutputBlob(desc);
-        outputBlob->allocate();
-        _outputs[no.first] = outputBlob;
+        checkOutputBlob(output.second, output.first, foundOutput);
     }
 }
 
@@ -642,11 +368,11 @@ void CLDNNInferRequest::SetGraph(std::shared_ptr<CLDNNPlugin::CLDNNGraph> graph)
 
     if (m_graph->GetMaxDynamicBatchSize() > 1) {
         SetBatch(m_graph->GetMaxDynamicBatchSize());
-        AllocateInputsDyn();
-        AllocateOutputsDyn();
+        allocate_inputs_dynamic();
+        allocate_outputs_dynamic();
     } else {
-        AllocateInputs();
-        AllocateOutputs();
+        allocate_inputs();
+        allocate_outputs();
     }
 }
 
@@ -728,40 +454,272 @@ CLDNNInferRequest::CLDNNInferRequest(InputsDataMap networkInputs, OutputsDataMap
     streamExecutor = dynamic_cast<InferenceEngine::IStreamsExecutor*>(execNetwork->m_taskExecutor.get());
 }
 
-void CLDNNInferRequest::execAndParse() {
-    OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::execAndParse");
-    auto networkOutputs = m_graph->GetNetwork()->execute();
+// ----------------------------------------------------------------------------------------- //
+// ---------------------------- internal utils --------- ----------------------------------- //
+// ----------------------------------------------------------------------------------------- //
+
+Blob::Ptr CLDNNInferRequest::create_input_host_blob(const TensorDesc& desc, uint8_t* mem_ptr) {
+    OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::create_input_host_blob");
+    const Precision& p = desc.getPrecision();
+
+    switch (p) {
+    case Precision::FP32:
+        if (mem_ptr != nullptr)
+            return make_shared_blob<float>(desc, reinterpret_cast<float*>(mem_ptr));
+        else
+            return make_shared_blob<float>(desc);
+    case Precision::FP16:
+        if (mem_ptr != nullptr)
+            return make_shared_blob<uint16_t>(desc, reinterpret_cast<uint16_t*>(mem_ptr));
+        else
+            return make_shared_blob<uint16_t>(desc);
+    case Precision::I16:
+        if (mem_ptr != nullptr)
+            return make_shared_blob<int16_t>(desc, reinterpret_cast<int16_t*>(mem_ptr));
+        else
+            return make_shared_blob<int16_t>(desc);
+    case Precision::U16:
+        if (mem_ptr != nullptr)
+            return make_shared_blob<uint16_t>(desc, reinterpret_cast<uint16_t*>(mem_ptr));
+        else
+            return make_shared_blob<uint16_t>(desc);
+    case Precision::I32:
+        if (mem_ptr != nullptr)
+            return make_shared_blob<int32_t>(desc, reinterpret_cast<int32_t*>(mem_ptr));
+        else
+            return make_shared_blob<int32_t>(desc);
+    case Precision::I64:
+        if (mem_ptr != nullptr)
+            return make_shared_blob<int64_t>(desc, reinterpret_cast<int64_t*>(mem_ptr));
+        else
+            return make_shared_blob<int64_t>(desc);
+    case Precision::I8:
+        if (mem_ptr != nullptr)
+            return make_shared_blob<int8_t>(desc, reinterpret_cast<int8_t*>(mem_ptr));
+        else
+            return make_shared_blob<int8_t>(desc);
+    case Precision::U8:
+        if (mem_ptr != nullptr)
+            return make_shared_blob<uint8_t>(desc, reinterpret_cast<uint8_t*>(mem_ptr));
+        else
+            return make_shared_blob<uint8_t>(desc);
+    case Precision::BOOL:
+        if (mem_ptr != nullptr)
+            return make_shared_blob<uint8_t>(desc, reinterpret_cast<uint8_t*>(mem_ptr));
+        else
+            return make_shared_blob<uint8_t>(desc);
+    default:
+        IE_THROW(NotImplemented) << "The plugin does not support input " << p.name() << " precision";
+    }
+}
+
+Blob::Ptr CLDNNInferRequest::create_output_host_blob(const TensorDesc& desc, uint8_t* mem_ptr) {
+    OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::create_output_host_blob");
+    const Precision& p = desc.getPrecision();
+
+    switch (p) {
+    case Precision::FP32:
+        if (mem_ptr != nullptr)
+            return make_shared_blob<float>(desc, reinterpret_cast<float*>(mem_ptr));
+        else
+            return make_shared_blob<float>(desc);
+    case Precision::FP16:
+        if (mem_ptr != nullptr)
+            return make_shared_blob<uint16_t>(desc, reinterpret_cast<uint16_t*>(mem_ptr));
+        else
+            return make_shared_blob<uint16_t>(desc);
+    case Precision::I32:
+        if (mem_ptr != nullptr)
+            return make_shared_blob<int32_t>(desc, reinterpret_cast<int32_t*>(mem_ptr));
+        else
+            return make_shared_blob<int32_t>(desc);
+     case Precision::I64:
+        if (mem_ptr != nullptr)
+            return make_shared_blob<int64_t>(desc, reinterpret_cast<int64_t*>(mem_ptr));
+        else
+            return make_shared_blob<int64_t>(desc);
+    default:
+        IE_THROW() << "The plugin does not support output " << p.name() << " precision";
+    }
+}
+
+void CLDNNInferRequest::copy_output_data(cldnn::memory::ptr src, Blob::Ptr dst, buf_info* bi) {
+    OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::copy_output_data");
     auto& stream = m_graph->GetNetwork()->get_stream();
+    switch (dst->getTensorDesc().getPrecision()) {
+    case Precision::FP32: copyResultToOutputBlob<float>(src, dst, bi, stream);    break;
+    case Precision::FP16: copyResultToOutputBlob<uint16_t>(src, dst, bi, stream); break;
+    case Precision::I32:  copyResultToOutputBlob<int32_t>(src, dst, bi, stream);  break;
+    case Precision::I64:  copyResultToOutputBlob<int64_t>(src, dst, bi, stream);  break;
+    default: IE_THROW(NotImplemented) << "The plugin does not support output " << dst->getTensorDesc().getPrecision() << " precision";
+    }
+}
+
+void CLDNNInferRequest::copy_input_data(std::shared_ptr<cldnn::network> network,
+                                        const cldnn::primitive_id &inputName,
+                                        const cldnn::layout& inputLayout,
+                                        const Blob &inputBlob, buf_info* bi) {
+    OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::copy_input_data");
+
+    size_t offset = (bi == nullptr) ? 0 : bi->buf_offset;
+
+    cldnn::primitive_id internalName = "parameter:" + inputName;
+    auto locked = inputBlob.cbuffer();
+    switch (inputBlob.getTensorDesc().getPrecision()) {
+    case Precision::FP32: {
+        float* blob_ptr = const_cast<float*>(locked.as<const float*>()) + offset;
+        network->set_input_data(internalName, network->get_engine().attach_memory(inputLayout, blob_ptr));
+        break;
+    }
+    case Precision::I32: {
+        int32_t* blob_ptr = const_cast<int32_t*>(locked.as<const int32_t*>()) + offset;
+        network->set_input_data(internalName, network->get_engine().attach_memory(inputLayout, blob_ptr));
+        break;
+    }
+    case Precision::I64: {
+        int64_t* blob_ptr = const_cast<int64_t*>(locked.as<const int64_t*>()) + offset;
+        network->set_input_data(internalName, network->get_engine().attach_memory(inputLayout, blob_ptr));
+        break;
+    }
+    case Precision::FP16: {
+        uint16_t* blob_ptr = const_cast<uint16_t*>(locked.as<const uint16_t*>()) + offset;
+        network->set_input_data(internalName, network->get_engine().attach_memory(inputLayout, blob_ptr));
+        break;
+    }
+    case Precision::I8: {
+        int8_t* blob_ptr = const_cast<int8_t*>(locked.as<const int8_t*>()) + offset;
+        network->set_input_data(internalName, network->get_engine().attach_memory(inputLayout, blob_ptr));
+        break;
+    }
+    case Precision::U8: {
+        uint8_t* blob_ptr = const_cast<uint8_t*>(locked.as<const uint8_t*>()) + offset;
+        network->set_input_data(internalName, network->get_engine().attach_memory(inputLayout, blob_ptr));
+        break;
+    }
+    case Precision::BOOL: {
+        uint8_t* blob_ptr = const_cast<uint8_t*>(locked.as<const uint8_t*>()) + offset;
+        network->set_input_data(internalName, network->get_engine().attach_memory(inputLayout, blob_ptr));
+        break;
+    }
+    default:
+        IE_THROW() << "The plugin does not support input " << inputBlob.getTensorDesc().getPrecision() << " precision";
+    }
+}
+
+void CLDNNInferRequest::allocate_inputs() {
+    OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::allocate_inputs");
+    auto inputLayouts = m_graph->GetInputLayouts();
+    // allocate inputs
+    for (auto& ni : _networkInputs) {
+        std::string name = ni.first;
+        const TensorDesc& desc = ni.second->getTensorDesc();
+
+        if (ColorFormat::NV12 == ni.second->getPreProcess().getColorFormat() &&
+            m_graph->getConfig().nv12_two_inputs) {
+        } else {
+            auto litr = inputLayouts.find(name);
+            if (litr == inputLayouts.end()) {
+                IE_THROW() << "Input layout for " << name << " is not found";
+            }
+
+            if (desc.getPrecision() == Precision::I16 || desc.getPrecision() == Precision::U16) {
+                TensorDesc desc_fp32 = desc;
+                desc_fp32.setPrecision(Precision::FP32);
+                auto blobPtr = create_device_blob(desc_fp32, litr->second);
+                _deviceInputs[name] = blobPtr;
+                Blob::Ptr inputBlob = create_input_host_blob(desc);
+                inputBlob->allocate();
+                _inputs[name] = inputBlob;
+            } else {
+                auto blobPtr = create_device_blob(desc, litr->second);
+                _deviceInputs[name] = blobPtr;
+                _inputs[name] = blobPtr;
+            }
+        }
+    }
+}
+
+void CLDNNInferRequest::allocate_inputs_dynamic() {
+    OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::allocate_inputs_dynamic");
+    // allocate inputs
+    for (auto &input : m_graph->GetInputLayouts()) {
+        InputInfo::Ptr ni = _networkInputs.at(input.first);
+        TensorDesc desc = ni->getTensorDesc();
+        SizeVector& dims = desc.getDims();
+
+        if (!dims.empty()) {
+            *dims.begin() = static_cast<size_t>(m_graph->GetMaxDynamicBatchSize());
+        } else {
+            IE_THROW() << "Empty dimensions for input blob " << input.first;
+        }
+
+        Blob::Ptr inputBlob = create_input_host_blob(desc);
+        if (desc.getPrecision() == Precision::I16 || desc.getPrecision() == Precision::U16) {
+            desc.setPrecision(Precision::FP32);
+            auto fp32inputBlob = InferenceEngine::make_shared_blob<float>(desc);
+            fp32inputBlob->allocate();
+            _inputs[input.first + fp32_suffix] = fp32inputBlob;
+        }
+        inputBlob->allocate();
+        _inputs[input.first] = inputBlob;
+    }
+}
+
+void CLDNNInferRequest::allocate_outputs() {
+    OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::allocate_outputs");
+    // allocate outputs
+    for (auto& no : _networkOutputs) {
+        std::string outputID = m_graph->MapOutputName(no.first);
+        const cldnn::layout output_layout = m_graph->GetNetwork()->get_output_memory(outputID)->get_layout();
+        const TensorDesc& desc = no.second->getTensorDesc();
+
+        auto blobPtr = create_device_blob(desc, output_layout);
+        _deviceOutputs[no.first] = blobPtr;
+        _outputs[no.first] = blobPtr;
+        outputsMap[no.first] = outputID;
+    }
+}
+
+void CLDNNInferRequest::allocate_outputs_dynamic() {
+    OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::allocate_outputs_dynamic");
+    // allocate outputs
+    for (auto& no : _networkOutputs) {
+        DataPtr oi = no.second;
+        TensorDesc desc = oi->getTensorDesc();
+        SizeVector& dims = desc.getDims();
+
+        if (!dims.empty()) {
+            *dims.begin() = static_cast<size_t>(m_graph->GetMaxDynamicBatchSize());
+        } else {
+            IE_THROW() << "Empty dimensions for output blob " << no.first;
+        }
+
+        Blob::Ptr outputBlob = create_output_host_blob(desc);
+        outputBlob->allocate();
+        _outputs[no.first] = outputBlob;
+    }
+}
+
+void CLDNNInferRequest::exec_and_parse(const std::vector<cldnn::event::ptr>& dependencies) {
+    OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::execAndParse");
+    auto networkOutputs = m_graph->GetNetwork()->execute(dependencies);
 
     // Collect outputs as requested by the model
     for (auto& no : _networkOutputs) {
         Blob::Ptr bptr = _outputs[no.first];
-
-        std::string outputID = outputsMap[no.first];
+        std::string outputID = outputsMap.at(no.first);
         auto outputMemory = networkOutputs.at(outputID).get_memory();
 
         // mapping remote blobs not needed -
         // let the user take care of them explicitly
         if (!bptr->is<gpu::ClBlob>()) {
-            cldnn::mem_lock<uint8_t> out_ptr{outputMemory, stream};
-            auto blob_ptr = bptr->buffer().as<uint8_t*>();
-
-            // If Async API is used, copy of output blobs is not needed, unless SetBlob function was called.
-            // But in the case when old API is used we have to copy data to memory provided by user.
-            if (blob_ptr != out_ptr.data()) {
-                copyOutputData(outputMemory, bptr);
-            }
+            copy_output_data(outputMemory, bptr);
         }
-    }
-
-    // finally collect profiling info
-    if (m_useProfiling) {
-        m_graph->UpdatePerfStatistics();
     }
 }
 
-void CLDNNInferRequest::execAndParseDyn() {
-    OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::execAndParseDyn");
+void CLDNNInferRequest::exec_and_parse_dynamic() {
+    OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::exec_and_parse_dynamic");
     std::vector<std::map<cldnn::primitive_id, cldnn::network_output>> networkOutputs(m_graph->GetNetworksCount());
 
     // set up exection and put all graphs into driver queue
@@ -769,6 +727,14 @@ void CLDNNInferRequest::execAndParseDyn() {
         unsigned int mask = 1 << nb;
 
         if (m_curBatch & mask) {
+            for (auto& item : _inputs) {
+                const cldnn::primitive_id& inputName = item.first;
+                const Blob::Ptr inputBlob = item.second;
+
+                auto inputLayout = m_graph->GetInputLayouts().at(inputName);
+                inputLayout.size.batch[0] = mask;
+                copy_input_data(m_graph->GetNetwork(nb), inputName, inputLayout, *inputBlob, &batchInputs[inputName][nb]);
+            }
             networkOutputs[nb] = m_graph->GetNetwork(nb)->execute();
         }
     }
@@ -783,7 +749,7 @@ void CLDNNInferRequest::execAndParseDyn() {
                 auto outputMemory = networkOutputs[nb].at(outputID).get_memory();
                 Blob::Ptr bptr = _outputs[no.first];
 
-                copyOutputData(outputMemory, bptr, &batchOutputs[no.first][nb]);
+                copy_output_data(outputMemory, bptr, &batchOutputs[no.first][nb]);
             }
         }
     }
@@ -799,38 +765,61 @@ void CLDNNInferRequest::InferImpl() {
     // execute input pre-processing.
     execDataPreprocessing(_inputs, true);  // "true" stands for serial preprocessing in case of OpenMP
 
-    for (auto &item : _inputs) {
-        std::string name = item.first;
-        Blob::Ptr inputBlob = item.second;
+    if (m_graph->GetMaxDynamicBatchSize() > 1) {
+        exec_and_parse_dynamic();
+        return;
+    }
 
-        if (m_graph->GetMaxDynamicBatchSize() > 1) {
-            PrepareInputDyn(name, *inputBlob);
-        } else {
+    {
+        // try locking stream infer mutex
+        const std::lock_guard<std::mutex> lock(m_graph->get_mutex());
+
+        // set input and output memory from request blob maps
+        // into the network object primitives
+        std::vector<cldnn::event::ptr> dependencies;
+        for (auto& item : _inputs) {
+            std::string inputName = item.first;
+            Blob::Ptr& inputBlob = item.second;
+
             auto nv12_ptr = inputBlob->as<NV12Blob>();
             auto batched_ptr = inputBlob->as<BatchedBlob>();
+            bool is_batched = batched_ptr != nullptr;
+            bool is_nv12 = nv12_ptr != nullptr;
 
-            if (nv12_ptr != nullptr || batched_ptr != nullptr) {
-                // special case for NV12 input blob
-                int num_blobs = batched_ptr != nullptr ? batched_ptr->size() : 1;
-                for (auto i = 0; i < num_blobs; i++) {
-                    if (batched_ptr != nullptr)
-                        nv12_ptr = getNV12BlobOrException(batched_ptr, i);
-
-                    PrepareInput(name + "_Y" + std::to_string(i), *nv12_ptr->y());
-                    PrepareInput(name + "_UV" + std::to_string(i), *nv12_ptr->uv());
+            if (is_nv12 || is_batched) {
+                int num_blobs = is_batched ? batched_ptr->size() : 1;
+                int expected_batch = is_batched
+                    ? _networkInputs.at(inputName)->getTensorDesc().getDims()[0]
+                    : 1;
+                for (auto i = 0; i < expected_batch; i++) {
+                    std::string y_name = inputName + "_Y" + std::to_string(i);
+                    std::string uv_name = inputName + "_UV" + std::to_string(i);
+                    if (is_batched) {
+                        int idx = i < num_blobs ? i : num_blobs - 1;
+                        nv12_ptr = getNV12BlobOrException(batched_ptr, idx);
+                    }
+                    prepare_input(y_name, nv12_ptr->y(), dependencies);
+                    prepare_input(uv_name, nv12_ptr->uv(), dependencies);
                 }
             } else {
                 // regular blob
-                PrepareInput(name, *inputBlob);
+                prepare_input(inputName, inputBlob, dependencies);
             }
         }
-    }
 
-    // The actual inference
-    if (m_graph->GetMaxDynamicBatchSize() > 1) {
-        execAndParseDyn();
-    } else {
-        execAndParse();
+        for (auto& item : _outputs) {
+            std::string outputName = item.first;
+            Blob::Ptr& outputBlob = item.second;
+            prepare_output(outputName, outputBlob);
+        }
+
+        // The actual inference
+        exec_and_parse(dependencies);
+
+        // finally collect profiling info
+        if (m_useProfiling) {
+            m_graph->UpdatePerfStatistics();
+        }
     }
 }
 
@@ -843,101 +832,83 @@ std::map<std::string, InferenceEngineProfileInfo> CLDNNInferRequest::GetPerforma
     }
 }
 
-namespace {
-
-template <typename T>
-void copyToFloat(float* dst, const InferenceEngine::Blob* src) {
-    OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "copyToFloat");
-    if (!dst) {
-        return;
-    }
-    const InferenceEngine::TBlob<T>* t_blob = dynamic_cast<const InferenceEngine::TBlob<T>*>(src);
-    if (t_blob == nullptr) {
-        IE_THROW() << "input type is " << src->getTensorDesc().getPrecision() << " but input is not "
-                           << typeid(T).name();
-    }
-
-    const T* srcPtr = t_blob->readOnly();
-    if (srcPtr == nullptr) {
-        IE_THROW() << "Input data was not allocated.";
-    }
-    for (size_t i = 0; i < t_blob->size(); i++) dst[i] = srcPtr[i];
-}
-
-}  // namespace
-
-void CLDNNInferRequest::PrepareInput(const cldnn::primitive_id &inputName, const Blob &inputBlob) {
-    OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::PrepareInput");
-    // Get input layout
-    if (m_graph->GetInputLayouts().find(inputName) == m_graph->GetInputLayouts().end()) {
+void CLDNNInferRequest::prepare_input(const cldnn::primitive_id& inputName, Blob::Ptr& inputBlob,
+                                      std::vector<cldnn::event::ptr>& dependencies) {
+    OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::prepare_input");
+    auto inputLayoutItr = m_graph->GetInputLayouts().find(inputName);
+    if (inputLayoutItr == m_graph->GetInputLayouts().end()) {
         IE_THROW() << "Input name mismatch.";
     }
-    auto inputLayout = m_graph->GetInputLayouts().at(inputName);
-    auto is_same_buffer = [&](const Blob& blob, cldnn::memory::ptr memory) -> bool {
-        const std::string str_not_allocated("Input data was not allocated.");
-        cldnn::mem_lock<uint8_t> ptr{memory, m_graph->GetNetwork()->get_stream()};
-        const uint8_t* blob_ptr = blob.cbuffer().as<const uint8_t*>();
-        const uint8_t* mem_ptr = ptr.data();
-        if (blob_ptr == nullptr || mem_ptr == nullptr) {
-            IE_THROW() << str_not_allocated;
-        }
-        return (blob_ptr == mem_ptr) && (blob.byteSize() == memory->size());
-    };
-
-    cldnn::primitive_id internalName = "parameter:" + inputName;
-    cldnn::memory::ptr memory = inputsMemory.at(inputName);
-    auto& stream = m_graph->GetNetwork()->get_stream();
+    Blob::Ptr reqBlob = _deviceInputs.at(inputName);
     auto _nw_ptr = m_graph->GetNetwork();
-    auto prec = inputBlob.getTensorDesc().getPrecision();
-
-    if (inputBlob.is<gpu::ClBlob>()) {
-        // no need to check for reuse
-        _nw_ptr->set_input_data(internalName, memory);
-    } else if (prec == Precision::I16 || prec == Precision::U16) {
-        // clDNN doesn't support I16 input precision, so we always have to convert input data to fp32 precision
-        cldnn::memory::ptr fp32_mem = inputsMemory.at(inputName+fp32_suffix);
-        cldnn::mem_lock<float> ptr {fp32_mem, stream};
-        if (prec == Precision::I16) {
-            copyToFloat<int16_t>(ptr.data(), &inputBlob);
-        } else {
-            copyToFloat<uint16_t>(ptr.data(), &inputBlob);
-        }
-
-        _nw_ptr->set_input_data(internalName, fp32_mem);
-    } else if (is_same_buffer(inputBlob, memory)) {
-        // If input memory was allocated by cldnn engine and wasn't overwritten by user set_input_data method won't copy input data.
-        switch (prec) {
-            case Precision::FP32:
-            case Precision::FP16:
-            case Precision::I8:
-            case Precision::U8:
-            case Precision::BOOL:
-            case Precision::I32:
-            case Precision::I64: {
-                _nw_ptr->set_input_data(internalName, memory);
-                break;
+    cldnn::primitive_id internalName = "parameter:" + inputName;
+    const auto& prec = inputBlob->getTensorDesc().getPrecision();
+    auto remote_ptr = inputBlob->as<gpu::ClBlob>();
+    auto& stream = m_graph->GetNetwork()->get_stream();
+    bool is_dev_input = remote_ptr != nullptr;
+    switch (prec) {
+        case Precision::FP32:
+        case Precision::FP16:
+        case Precision::I8:
+        case Precision::U8:
+        case Precision::BOOL:
+        case Precision::I16:
+        case Precision::U16:
+        case Precision::I32:
+        case Precision::I64: {
+            auto impl = getBlobImpl(is_dev_input ?
+                                    remote_ptr :
+                                    reqBlob->as<gpu::ClBlob>());
+            if (!impl->is_allocated()) {
+                IE_THROW() << str_input_not_allocated;
             }
-            default:
-                IE_THROW() << "Unsupported input precision " << prec;
+            auto inputMem = impl->getMemory();
+
+            if (!is_dev_input) {
+                if (prec == Precision::I16 || prec == Precision::U16) {
+                    // clDNN doesn't support I16 input precision,
+                    // so have to convert input data to fp32 precision
+                    cldnn::mem_lock<float> ptr{ inputMem, stream };
+                    if (prec == Precision::I16) {
+                        copyToFloat<int16_t>(ptr.data(), inputBlob.get());
+                    } else {
+                        copyToFloat<uint16_t>(ptr.data(), inputBlob.get());
+                    }
+                } else {
+                    auto src_lock = inputBlob->cbuffer();
+                    auto ev = inputMem->copy_from(stream, src_lock.as<const uint8_t*>());
+                    dependencies.push_back(ev);
+                }
+            }
+            _nw_ptr->set_input_data(internalName, inputMem);
+            break;
         }
-    } else {
-        // Otherwise, we have to attach to user memory and then copy the data.
-        copyInputData(_nw_ptr, inputName, inputLayout, inputBlob);
+        default:
+            IE_THROW() << "Unsupported input precision " << prec;
     }
 }
 
-void CLDNNInferRequest::PrepareInputDyn(const cldnn::primitive_id &inputName, const Blob &inputBlob) {
-    OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::PrepareInputDyn");
-    // now try to get execution results
-    for (unsigned nb = 0; nb < m_graph->GetNetworksCount(); nb++) {
-        unsigned int mask = 1 << nb;
-
-        if (m_curBatch & mask) {
-            auto inputLayout = m_graph->GetInputLayouts().at(inputName);
-            inputLayout.size.batch[0] = mask;
-            copyInputData(m_graph->GetNetwork(nb), inputName, inputLayout, inputBlob, &batchInputs[inputName][nb]);
-        }
+void CLDNNInferRequest::prepare_output(const cldnn::primitive_id& outputName, Blob::Ptr& outputBlob) {
+    OV_ITT_SCOPED_TASK(itt::domains::CLDNNPlugin, "CLDNNInferRequest::prepare_output");
+    Blob::Ptr reqBlob = _deviceOutputs.at(outputName);
+    cldnn::primitive_id internalName = outputsMap[outputName];
+    auto _nw_ptr = m_graph->GetNetwork();
+    auto remote_ptr = outputBlob->as<gpu::ClBlob>();
+    auto output_blob_ptr = (reqBlob != outputBlob && remote_ptr != nullptr)
+        ? remote_ptr
+        : reqBlob->as<gpu::ClBlob>();
+    auto impl = getBlobImpl(output_blob_ptr);
+    if (!impl->is_allocated()) {
+        IE_THROW(NotAllocated) << str_output_not_allocated;
     }
+    auto outputMem = impl->getMemory();
+    _nw_ptr->set_output_memory(internalName, outputMem);
+}
+
+InferenceEngine::Blob::Ptr CLDNNInferRequest::create_device_blob(const InferenceEngine::TensorDesc& desc, const cldnn::layout& layout) {
+    auto blobPtr = std::make_shared<CLDNNRemoteCLbuffer>(m_graph->GetContext(), m_graph->GetNetwork()->get_stream(), desc, layout);
+    getBlobImpl(blobPtr.get())->allocate();
+    return blobPtr;
 }
 
 }  // namespace CLDNNPlugin

--- a/inference-engine/src/cldnn_engine/cldnn_infer_request.h
+++ b/inference-engine/src/cldnn_engine/cldnn_infer_request.h
@@ -23,6 +23,7 @@ class CLDNNExecNetwork;
 
 class CLDNNInferRequest : public InferenceEngine::IInferRequestInternal {
 public:
+    using Ptr = std::shared_ptr<CLDNNInferRequest>;
     // make sure all blobs and cldnn::memory objects
     // are in place and valid
     void checkBlobs() override;
@@ -45,8 +46,9 @@ public:
     void EnableProfiling() { m_useProfiling = true; }
     void EnableStreams() { m_useStreams = true; }
 
-protected:
-    std::map<std::string, cldnn::memory::ptr> inputsMemory;
+private:
+    InferenceEngine::BlobMap _deviceOutputs;
+    std::map<std::string, cldnn::primitive_id> inputsMap;
     std::map<std::string, cldnn::primitive_id> outputsMap;
 
     bool m_useProfiling;
@@ -58,24 +60,25 @@ protected:
     std::map<std::string, std::vector<buf_info>> batchOutputs;
     InferenceEngine::IStreamsExecutor* streamExecutor = nullptr;
 
-    InferenceEngine::Blob::Ptr createInputBlob(const InferenceEngine::TensorDesc& desc, uint8_t* mem_ptr = nullptr);
-    InferenceEngine::Blob::Ptr createOutputBlob(const InferenceEngine::TensorDesc& desc, uint8_t* mem_ptr = nullptr);
-    void copyOutputData(cldnn::memory::ptr outputMemory, InferenceEngine::Blob::Ptr bptr, buf_info* bi = nullptr);
-    void copyInputData(std::shared_ptr<cldnn::network> network, const cldnn::primitive_id &inputName,
-                       const cldnn::layout& inputLayout, const InferenceEngine::Blob &inputBlob,
-                       buf_info* bi = nullptr);
+    void prepare_input(const cldnn::primitive_id &inputName, InferenceEngine::Blob::Ptr &inputBlob,
+                       std::vector<cldnn::event::ptr>& dependencies);
+    void prepare_output(const cldnn::primitive_id& outputName, InferenceEngine::Blob::Ptr& outputBlob);
 
-    void input_attach(cldnn::primitive_id name, cldnn::memory::ptr inputMem);
-    void input_alloc(cldnn::primitive_id name, const cldnn::layout& layout);
-    void AllocateInputs();
-    void AllocateOutputs();
-    void AllocateInputsDyn();
-    void AllocateOutputsDyn();
-    void execAndParse();
-    void execAndParseDyn();
+    InferenceEngine::Blob::Ptr create_input_host_blob(const InferenceEngine::TensorDesc& desc, uint8_t* mem_ptr = nullptr);
+    InferenceEngine::Blob::Ptr create_output_host_blob(const InferenceEngine::TensorDesc& desc, uint8_t* mem_ptr = nullptr);
+    InferenceEngine::Blob::Ptr create_device_blob(const InferenceEngine::TensorDesc& desc, const cldnn::layout& layout);
 
-    void PrepareInput(const cldnn::primitive_id &inputName, const InferenceEngine::Blob &inputBlob);
-    void PrepareInputDyn(const cldnn::primitive_id &inputName, const InferenceEngine::Blob &inputBlob);
+    void copy_output_data(cldnn::memory::ptr outputMemory, InferenceEngine::Blob::Ptr bptr, buf_info* bi = nullptr);
+    void copy_input_data(std::shared_ptr<cldnn::network> network, const cldnn::primitive_id &inputName,
+                         const cldnn::layout& inputLayout, const InferenceEngine::Blob &inputBlob,
+                         buf_info* bi = nullptr);
+
+    void allocate_inputs();
+    void allocate_outputs();
+    void allocate_inputs_dynamic();
+    void allocate_outputs_dynamic();
+    void exec_and_parse(const std::vector<cldnn::event::ptr>& dependencies);
+    void exec_and_parse_dynamic();
 };
 
 };  // namespace CLDNNPlugin

--- a/inference-engine/src/cldnn_engine/cldnn_remote_context.h
+++ b/inference-engine/src/cldnn_engine/cldnn_remote_context.h
@@ -44,8 +44,8 @@ public:
     explicit CLDNNRemoteBlobImpl(InferenceEngine::gpu::ClContext::Ptr context,
                                  cldnn::stream& stream,
                                  const cldnn::layout& layout,
-                                 cldnn::shared_handle mem,
-                                 cldnn::shared_surface surf,
+                                 cldnn::shared_handle mem = nullptr,
+                                 cldnn::shared_surface surf = 0,
                                  uint32_t plane = 0,
                                  BlobType mem_type = BT_BUF_INTERNAL);
 
@@ -64,7 +64,6 @@ public:
 
     bool is_allocated() const noexcept;
     bool is_locked() const noexcept;
-    void allocate_if_needed();
     cldnn::memory::ptr getMemory() { return m_memObject; }
 
 protected:
@@ -99,10 +98,10 @@ public:
                                   cldnn::stream& stream,
                                   const InferenceEngine::TensorDesc& desc,
                                   const cldnn::layout& layout,
-                                  cldnn::shared_handle mem,
-                                  cldnn::shared_surface surf,
-                                  uint32_t plane,
-                                  CLDNNRemoteBlobImpl::BlobType mem_type)
+                                  cldnn::shared_handle mem = nullptr,
+                                  cldnn::shared_surface surf = 0,
+                                  uint32_t plane = 0,
+                                  CLDNNRemoteBlobImpl::BlobType mem_type = CLDNNRemoteBlobImpl::BlobType::BT_BUF_INTERNAL)
         : _impl(context, stream, layout, mem, surf, plane, mem_type)
         , TpublicAPI(desc) {}
 
@@ -184,7 +183,7 @@ public:
     * @brief Maps handle to heap memory accessible by any memory manipulation routines.
     * @return Generic pointer to memory
     */
-    void* lock(void* handle, InferenceEngine::LockOp = InferenceEngine::LOCK_FOR_WRITE)  noexcept override { return nullptr; };
+    void* lock(void* handle, InferenceEngine::LockOp = InferenceEngine::LOCK_FOR_WRITE)  noexcept override { return handle; };
     /**
     * @brief Unmaps memory by handle with multiple sequential mappings of the same handle.
     * The multiple sequential mappings of the same handle are suppose to get the same

--- a/inference-engine/thirdparty/clDNN/api/cldnn/graph/network.hpp
+++ b/inference-engine/thirdparty/clDNN/api/cldnn/graph/network.hpp
@@ -181,6 +181,7 @@ public:
                                     bool reusable = true);
 
 private:
+    using output_chains_map = std::map<primitive_id, std::vector<std::shared_ptr<primitive_inst>>>;
     uint32_t net_id = 0;
     program::ptr _program;
     stream::ptr _stream;
@@ -196,6 +197,7 @@ private:
     std::list<std::shared_ptr<primitive_inst>> _data_outputs;
 
     std::unordered_map<primitive_id, event::ptr> _events;
+    output_chains_map _output_chains;
 
     void build_exec_order();
     void allocate_primitive_instance(program_node const& node);
@@ -204,5 +206,7 @@ private:
     std::shared_ptr<primitive_inst> find_in_internal_networks(const primitive_id& id);
     std::shared_ptr<primitive_inst> find_primitive(const primitive_id& id);
     void check_names();
+    void add_default_output_chains();
+    output_chains_map::iterator add_output_chain(std::shared_ptr<primitive_inst>& p_inst);
 };
 }  // namespace cldnn

--- a/inference-engine/thirdparty/clDNN/api/cldnn/runtime/memory_caps.hpp
+++ b/inference-engine/thirdparty/clDNN/api/cldnn/runtime/memory_caps.hpp
@@ -74,7 +74,10 @@ enum class shared_mem_type {
     shared_mem_vasurface,
 
     /// @brief Structure describes shared D3D11 buffer
-    shared_mem_dxbuffer
+    shared_mem_dxbuffer,
+
+    /// @brief Structure describes shared USM memory.
+    shared_mem_usm
 };
 
 using shared_handle = void*;

--- a/inference-engine/thirdparty/clDNN/runtime/ocl/ocl_memory.cpp
+++ b/inference-engine/thirdparty/clDNN/runtime/ocl/ocl_memory.cpp
@@ -73,8 +73,14 @@ shared_mem_params gpu_buffer::get_internal_params() const {
         0};
 }
 
-event::ptr gpu_buffer::copy_from(stream& /* stream */, const memory& /* other */) {
-    throw std::runtime_error("[clDNN] copy_from is not implemented for gpu_buffer");
+event::ptr gpu_buffer::copy_from(stream& stream, const memory& other) {
+    auto& cl_stream = downcast<ocl_stream>(stream);
+    auto& mem_inst = downcast<const gpu_buffer>(other);
+    auto ev = stream.create_base_event();
+    cl::Event ev_ocl = std::dynamic_pointer_cast<ocl_event>(ev)->get();
+    cl_stream.get_cl_queue().enqueueCopyBuffer(mem_inst.get_buffer(), get_buffer(), 0, 0, other.size(), nullptr, &ev_ocl);
+
+    return ev;
 }
 
 event::ptr gpu_buffer::copy_from(stream& stream, const void* host_ptr) {
@@ -324,17 +330,26 @@ event::ptr gpu_usm::copy_from(stream& stream, const memory& other) {
     return stream.create_user_event(true);
 }
 
-event::ptr gpu_usm::copy_from(stream& /* stream */, const void* /* host_ptr */) {
-    throw std::runtime_error("[clDNN] copy_from is not implemented for gpu_usm");
+event::ptr gpu_usm::copy_from(stream& stream, const void* host_ptr) {
+    auto& cl_stream = downcast<ocl_stream>(stream);
+    auto ev = stream.create_base_event();
+    auto dst_ptr = get_buffer().get();
+    cl_stream.get_usm_helper().enqueue_memcpy(cl_stream.get_cl_queue(),
+                                              dst_ptr,
+                                              host_ptr,
+                                              _bytes_count,
+                                              true);
+
+    return ev;
 }
 
 shared_mem_params gpu_usm::get_internal_params() const {
     auto cl_engine = downcast<const ocl_engine>(_engine);
     return {
-        shared_mem_type::shared_mem_empty,  // shared_mem_type
+        shared_mem_type::shared_mem_usm,  // shared_mem_type
         static_cast<shared_handle>(cl_engine->get_cl_context().get()),  // context handle
-        nullptr,  // user_device handle
-        nullptr,  // mem handle
+        nullptr,        // user_device handle
+        _buffer.get(),  // mem handle
 #ifdef _WIN32
         nullptr,  // surface handle
 #else

--- a/inference-engine/thirdparty/clDNN/src/include/loop_inst.h
+++ b/inference-engine/thirdparty/clDNN/src/include/loop_inst.h
@@ -560,6 +560,8 @@ public:
     void preprocess_input_memory();
     void preprocess_output_memory();
     void preprocess_backedge_memory();
+    void update_mapped_memory();
+    void set_output_memory(memory::ptr mem, bool check = true) override;
     const backedge_memory_mapping& get_current_iteration_backedge_mapping() const {
         if (!node.is_current_iteration_used()) {
             CLDNN_ERROR_MESSAGE(node.id(), "no backedge mapping for current_iteration");

--- a/inference-engine/thirdparty/clDNN/src/include/mutable_data_inst.h
+++ b/inference-engine/thirdparty/clDNN/src/include/mutable_data_inst.h
@@ -39,6 +39,7 @@ public:
     static std::string to_string(mutable_data_node const& node);
 
     typed_primitive_inst(network& network, mutable_data_node const& node);
+    void set_output_memory(memory::ptr mem, bool check = true) override;
 };
 
 using mutable_data_inst = typed_primitive_inst<mutable_data>;

--- a/inference-engine/thirdparty/clDNN/src/include/primitive_inst.h
+++ b/inference-engine/thirdparty/clDNN/src/include/primitive_inst.h
@@ -88,7 +88,7 @@ public:
     program_node const& get_node() const { return _node; }
     network& get_network() const { return _network; }
     uint32_t get_network_id() const;
-    void set_output_memory(memory::ptr mem);
+    virtual void set_output_memory(memory::ptr mem, bool check = true);
     void check_memory_to_set(const memory& mem, const layout& layout) const;
     const std::list<const cldnn::program_node *>& get_users() const { return _node.get_users(); }
 

--- a/inference-engine/thirdparty/clDNN/src/mutable_data.cpp
+++ b/inference-engine/thirdparty/clDNN/src/mutable_data.cpp
@@ -57,6 +57,25 @@ std::string mutable_data_inst::to_string(mutable_data_node const& node) {
     return primitive_description.str();
 }
 
+void mutable_data_inst::set_output_memory(memory::ptr mem_new, bool check) {
+    auto& eng = _network.get_engine();
+    auto& mem_node = const_cast<program_node&>(_node).as<mutable_data>();
+    auto& mem_attached = mem_node.get_attached_memory();
+    const auto& mem_orig = *_output;
+
+    if (!eng.is_the_same_buffer(*mem_new, mem_attached)) {
+        if (_node.is_input()) {
+            mem_new->copy_from(_network.get_stream(), *_output);
+        }
+
+        // re-attach mutable_data internal memory if necessary
+        if (eng.is_the_same_buffer(mem_orig, mem_attached)) {
+            mem_node.attach_memory(eng.reinterpret_buffer(*mem_new, mem_attached.get_layout()));
+        }
+    }
+    primitive_inst::set_output_memory(mem_new, check);
+}
+
 mutable_data_inst::typed_primitive_inst(network& network, mutable_data_node const& node)
     : parent(network, node, attach_or_copy_data(network, node.get_attached_memory_ptr(), network.is_primary_stream())) {}
 

--- a/inference-engine/thirdparty/clDNN/tests/test_cases/loop_gpu_test.cpp
+++ b/inference-engine/thirdparty/clDNN/tests/test_cases/loop_gpu_test.cpp
@@ -39,18 +39,17 @@ TEST(loop_gpu, basic_no_concat)
         1.0f,  2.0f, -15.f,  3.0f, 4.0f, -15.f, 5.0f,  6.0f, -15.f, 7.0f,
         -15.f, 0.0f,  0.0f, -15.f, 0.5f, -0.5f, -15.f, 8.0f,  1.5f,  5.2f
     };
-    set_values(input_mem, input_data);
-
     std::vector<float> eltwise_operand {
         1.f, -2.f, 3.f, -4.f, 3.0f, -2.0f, 1.f, -2.f, 3.0f, -4.0f,
         3.f, -2.f, 1.f, -2.f, 3.5f, -4.5f, 5.f, -4.f, 3.5f, -2.2f
     };
-    set_values(operand_mem, eltwise_operand);
-
     int trip_count = 8;
-    set_values(trip_count_mem, {trip_count});
-
     int initial_condition = 1;
+
+    // initialize input buffers
+    set_values(input_mem, input_data);
+    set_values(operand_mem, eltwise_operand);
+    set_values(trip_count_mem, { trip_count });
     set_values(initial_condition_mem, {initial_condition});
 
     topology body(
@@ -91,10 +90,35 @@ TEST(loop_gpu, basic_no_concat)
     EXPECT_EQ(output_layout.size.spatial[1], 5);
 
     // value check
-    mem_lock<float> output_ptr{output, get_test_stream()};
-    EXPECT_EQ(output_ptr.size(), input_data.size());
-    for (size_t i = 0, iend = input_data.size(); i<iend; ++i) {
-        EXPECT_FLOAT_EQ(output_ptr[i], input_data[i] + eltwise_operand[i] * trip_count);
+    {
+        mem_lock<float> output_ptr{ output, get_test_stream() };
+        EXPECT_EQ(output_ptr.size(), input_data.size());
+        for (size_t i = 0, iend = input_data.size(); i < iend; ++i) {
+            ASSERT_FLOAT_EQ(output_ptr[i], input_data[i] + eltwise_operand[i] * trip_count);
+        }
+    }
+
+    // allocate new output memory
+    layout loop_l = network.get_output_memory("loop")->get_layout();
+    auto output_mem = engine.allocate_memory(loop_l);
+    network.set_output_memory("loop", output_mem);
+
+    //one more execute
+    set_values(input_mem, input_data);
+    set_values(operand_mem, eltwise_operand);
+    set_values(trip_count_mem, { trip_count });
+    set_values(initial_condition_mem, { initial_condition });
+    outputs = network.execute();
+
+    // check everything once again
+    EXPECT_EQ(outputs.size(), 1);
+    auto output2 = outputs.begin()->second.get_memory();
+    {
+        mem_lock<float> output_ptr2{ output2, get_test_stream() };
+        EXPECT_EQ(output_ptr2.size(), input_data.size());
+        for (size_t i = 0, iend = input_data.size(); i < iend; ++i) {
+            ASSERT_FLOAT_EQ(output_ptr2[i], input_data[i] + eltwise_operand[i] * trip_count);
+        }
     }
 }
 
@@ -112,17 +136,16 @@ TEST(loop_gpu, basic_concat)
         1.0f,  2.0f, -15.f,  3.0f, 4.0f, -15.f, 5.0f,  6.0f, -15.f, 7.0f,
         -15.f, 0.0f,  0.0f, -15.f, 0.5f, -0.5f, -15.f, 8.0f,  1.5f,  5.2f
     };
-    set_values(input_mem, input_data);
-
     std::vector<float> eltwise_operand {
         1.f, -2.f, 3.f, -4.f
     };
-    set_values(operand_mem, eltwise_operand);
-
     size_t trip_count = input_data.size()/eltwise_operand.size();
-    set_values(trip_count_mem, {trip_count});
-
     int initial_condition = 1;
+
+    // initialize input buffers
+    set_values(input_mem, input_data);
+    set_values(operand_mem, eltwise_operand);
+    set_values(trip_count_mem, {trip_count});
     set_values(initial_condition_mem, {initial_condition});
 
     topology body(
@@ -162,11 +185,33 @@ TEST(loop_gpu, basic_concat)
     EXPECT_EQ(output_layout.size.spatial[1], 5);
 
     // value check
-    mem_lock<float> output_ptr{output, get_test_stream()};
-    for (size_t i=0, iend = input_data.size(); i<iend; ++i) {
-        const size_t j = i % eltwise_operand.size();
-        float expected = input_data[i] + eltwise_operand[j];
-        EXPECT_FLOAT_EQ(output_ptr[i], expected);
+    {
+        mem_lock<float> output_ptr{ output, get_test_stream() };
+        for (size_t i = 0, iend = input_data.size(); i < iend; ++i) {
+            const size_t j = i % eltwise_operand.size();
+            float expected = input_data[i] + eltwise_operand[j];
+            ASSERT_FLOAT_EQ(output_ptr[i], expected);
+        }
+    }
+
+    // allocate new output memory
+    layout loop_l = network.get_output_memory("loop")->get_layout();
+    auto output_mem = engine.allocate_memory(loop_l);
+    network.set_output_memory("loop", output_mem);
+
+    set_values(input_mem, input_data);
+    set_values(operand_mem, eltwise_operand);
+    set_values(trip_count_mem, { trip_count });
+    set_values(initial_condition_mem, { initial_condition });
+    outputs = network.execute();
+    auto output2 = outputs.begin()->second.get_memory();
+    {
+        mem_lock<float> output_ptr2{ output2, get_test_stream() };
+        for (size_t i = 0, iend = input_data.size(); i < iend; ++i) {
+            const size_t j = i % eltwise_operand.size();
+            float expected = input_data[i] + eltwise_operand[j];
+            ASSERT_FLOAT_EQ(output_ptr2[i], expected);
+        }
     }
 }
 
@@ -190,25 +235,22 @@ TEST(loop_gpu, basic_concat_nested)
         1.0f,  2.0f, -15.f,  3.0f, 4.0f, -15.f, 5.0f,  6.0f, -15.f, 7.0f,
         -15.f, 0.0f,  0.0f, -15.f, 0.5f, -0.5f, -15.f, 8.0f,  1.5f,  5.2f
     };
-    set_values(input_mem, input_data);
 
     std::vector<float> inner_eltwise_operand {
         1.f, -2.f, 3.f, -4.f
     };
-    set_values(inner_operand_mem, inner_eltwise_operand);
 
     size_t inner_trip_count = input_data.size() / inner_eltwise_operand.size();
-    set_values(inner_trip_count_mem, {inner_trip_count});
-
     int inner_initial_condition = 1;
-    set_values(inner_initial_condition_mem, {inner_initial_condition});
-
     int outer_trip_count = 8;
-    set_values(trip_count_mem, {outer_trip_count});
-
     int outer_initial_condition = 1;
-    set_values(initial_condition_mem, {outer_initial_condition});
 
+    set_values(input_mem, input_data);
+    set_values(inner_operand_mem, inner_eltwise_operand);
+    set_values(inner_trip_count_mem, { inner_trip_count });
+    set_values(inner_initial_condition_mem, { inner_initial_condition });
+    set_values(trip_count_mem, { outer_trip_count });
+    set_values(initial_condition_mem, { outer_initial_condition });
 
     /////////////////////////////////
     // set inner loop body
@@ -295,11 +337,34 @@ TEST(loop_gpu, basic_concat_nested)
     EXPECT_EQ(output_layout.size.feature[0], 1);
     EXPECT_EQ(output_layout.size.spatial[0], 4);
     EXPECT_EQ(output_layout.size.spatial[1], 5);
-
+    
     // check output values
     EXPECT_EQ(output_layout.count(), expected.size());
-    mem_lock<float> output_ptr{output, get_test_stream()};
-    for (size_t i=0 ;i<output_layout.count(); ++i) {
-        EXPECT_FLOAT_EQ(output_ptr[i], expected.at(i));
+    {
+        mem_lock<float> output_ptr{ output, get_test_stream() };
+        for (size_t i = 0; i < output_layout.count(); ++i) {
+            ASSERT_FLOAT_EQ(output_ptr[i], expected.at(i));
+        }
+    }
+
+    // allocate new output memory, run and test everything once again
+    layout loop_l = network.get_output_memory("loop")->get_layout();
+    auto output_mem = engine.allocate_memory(loop_l);
+    network.set_output_memory("loop", output_mem);
+
+    set_values(input_mem, input_data);
+    set_values(inner_operand_mem, inner_eltwise_operand);
+    set_values(inner_trip_count_mem, { inner_trip_count });
+    set_values(inner_initial_condition_mem, { inner_initial_condition });
+    set_values(trip_count_mem, { outer_trip_count });
+    set_values(initial_condition_mem, { outer_initial_condition });
+
+    outputs = network.execute();
+    auto output2 = outputs.begin()->second.get_memory();
+    {
+        mem_lock<float> output_ptr{ output2, get_test_stream() };
+        for (size_t i = 0; i < output_layout.count(); ++i) {
+            ASSERT_FLOAT_EQ(output_ptr[i], expected.at(i));
+        }
     }
 }

--- a/inference-engine/thirdparty/clDNN/tests/test_cases/set_output_memory_gpu_test.cpp
+++ b/inference-engine/thirdparty/clDNN/tests/test_cases/set_output_memory_gpu_test.cpp
@@ -1,0 +1,345 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include <cstddef>
+
+#include "test_utils.h"
+
+#include <cldnn/primitives/arg_max_min.hpp>
+#include <cldnn/primitives/mutable_data.hpp>
+#include <cldnn/primitives/reshape.hpp>
+#include <cldnn/primitives/concatenation.hpp>
+
+using namespace cldnn;
+using namespace tests;
+
+template<typename T = float>
+static std::vector<T> generateVector(size_t sz) {
+    std::vector<T> vec(sz);
+    T n = 0;
+    std::generate(vec.begin(), vec.end(), [&n]() {
+            return n++;
+        });
+    return vec;
+}
+
+TEST(set_output_memory_gpu, basic) {
+    auto& engine = get_test_engine();
+
+    const int b = 3;
+    const int f = 2;
+    const int y = 5;
+    const int x = 5;
+
+    auto input_data = engine.allocate_memory({ data_types::f32, format::bfyx, { b, f, x, y } });
+    auto output_mem = engine.allocate_memory({ data_types::f32, format::bfyx, { b, f, x, y } });
+
+    const int inputSize = input_data->get_layout().count();
+    auto inputVals = generateVector(inputSize);
+    set_values(input_data, inputVals);
+
+    topology topology;
+    topology.add(input_layout("Input", input_data->get_layout()));
+    topology.add(
+        reorder("reorder", "Input", input_data->get_layout())
+    );
+
+    network network(engine, topology);
+
+    network.set_input_data("Input", input_data);
+    network.set_output_memory("reorder", output_mem);
+
+    auto outputs = network.execute();
+
+    auto output = outputs.at("reorder").get_memory();
+    EXPECT_TRUE(engine.is_the_same_buffer(*output_mem, *output));
+
+    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+
+    for (size_t i = 0; i < inputVals.size(); ++i) {
+        EXPECT_TRUE(are_equal(inputVals[i], output_ptr[i])) << i;
+    }
+}
+
+TEST(set_output_memory_gpu, basic_const) {
+    auto& engine = get_test_engine();
+
+    const int b = 3;
+    const int f = 2;
+    const int y = 5;
+    const int x = 5;
+
+    auto input_data = engine.allocate_memory({ data_types::f32, format::bfyx, { b, f, x, y } });
+    auto const_data = engine.allocate_memory({ data_types::f32, format::bfyx, { b, f, x, y } });
+    auto output_mem = engine.allocate_memory({ data_types::f32, format::bfyx, { b, f, x, y } });
+    auto output_const_mem = engine.allocate_memory({ data_types::f32, format::bfyx, { b, f, x, y } });
+
+    const int inputSize = input_data->get_layout().count();
+    auto inputVals = generateVector(inputSize);
+    auto constVals = generateVector(inputSize);
+    set_values(input_data, inputVals);
+    set_values(const_data, constVals);
+
+    topology topology;
+    topology.add(input_layout("Input", input_data->get_layout()));
+    topology.add(data("Const", const_data));
+    topology.add(
+            reorder("reorder_dyn", "Input", input_data->get_layout()),
+            reorder("reorder_const", "Const", input_data->get_layout())
+    );
+
+    network network(engine, topology);
+
+    network.set_input_data("Input", input_data);
+    network.set_output_memory("reorder_dyn", output_mem);
+    network.set_output_memory("reorder_const", output_const_mem);
+
+    auto outputs = network.execute();
+
+    auto output_dyn = outputs.at("reorder_dyn").get_memory();
+    auto output_const = outputs.at("reorder_const").get_memory();
+    EXPECT_TRUE(engine.is_the_same_buffer(*output_mem, *output_dyn));
+
+    cldnn::mem_lock<float> output_dyn_ptr(output_dyn, get_test_stream());
+    cldnn::mem_lock<float> output_const_ptr(output_const, get_test_stream());
+
+    for (size_t i = 0; i < inputVals.size(); ++i) {
+        EXPECT_TRUE(are_equal(inputVals[i], output_dyn_ptr[i])) << i;
+    }
+
+    for (size_t i = 0; i < inputVals.size(); ++i) {
+        EXPECT_TRUE(are_equal(inputVals[i], output_const_ptr[i])) << i;
+    }
+}
+
+TEST(set_output_memory_gpu, basic_mutable) {
+    auto& engine = get_test_engine();
+
+    const int b = 3;
+    const int f = 2;
+    const int y = 5;
+    const int x = 5;
+    auto input_data = engine.allocate_memory({ data_types::f32, format::bfyx, { b, f, x, y } });
+    auto md = engine.allocate_memory({ data_types::f32, format::bfyx, { b, f, x, y } });
+    auto output_mem = engine.allocate_memory({ data_types::f32, format::bfyx, { b, f, x, y } });
+    auto output_mutable_mem = engine.allocate_memory({ data_types::f32, format::bfyx, { b, f, x, y } });
+    const int inputSize = input_data->get_layout().count();
+    auto inputVals = generateVector(inputSize);
+    auto mutableVals = generateVector(inputSize);
+    set_values(input_data, inputVals);
+    set_values(md, mutableVals);
+
+    topology topology;
+    topology.add(input_layout("Input", input_data->get_layout()));
+    topology.add(mutable_data("Mutable", md));
+    topology.add(
+            reorder("reorder_dyn", "Input", input_data->get_layout()),
+            reorder("reorder_mutable", "Mutable", input_data->get_layout())
+    );
+
+    network network(engine, topology);
+
+    network.set_input_data("Input", input_data);
+    network.set_output_memory("reorder_dyn", output_mem);
+    network.set_output_memory("reorder_mutable", output_mutable_mem);
+
+    auto outputs = network.execute();
+
+    auto output_dyn = outputs.at("reorder_dyn").get_memory();
+    auto output_mutable = outputs.at("reorder_mutable").get_memory();
+    EXPECT_TRUE(engine.is_the_same_buffer(*output_mem, *output_dyn));
+    EXPECT_TRUE(engine.is_the_same_buffer(*output_mutable_mem, *output_mutable));
+
+    cldnn::mem_lock<float> output_dyn_ptr(output_dyn, get_test_stream());
+    cldnn::mem_lock<float> output_mutable_mem_ptr(output_mutable_mem, get_test_stream());
+
+    for (size_t i = 0; i < inputVals.size(); ++i) {
+        EXPECT_TRUE(are_equal(inputVals[i], output_dyn_ptr[i])) << i;
+    }
+
+    for (size_t i = 0; i < inputVals.size(); ++i) {
+        EXPECT_TRUE(are_equal(inputVals[i], output_mutable_mem_ptr[i])) << i;
+    }
+}
+
+TEST(set_output_memory_gpu, top_k1) {
+    static const int32_t x_size = 2, y_size = 2, feature_num = 4, batch_num = 2;
+    auto& engine = get_test_engine();
+    const int top_k = 1;
+    auto input = engine.allocate_memory({data_types::f32, format::bfyx, {batch_num, feature_num, x_size, y_size}});
+    auto top_k_input = engine.allocate_memory({data_types::f32, format::bfyx, {1, 1, 1, 1}});
+    auto output_mem =
+        engine.allocate_memory({data_types::f32, format::bfyx, {top_k, feature_num, x_size, y_size}});
+    topology topology;
+    topology.add(input_layout("input", input->get_layout()));
+    topology.add(cldnn::data("const", top_k_input));
+    topology.add(arg_max_min("arg_max", { "input", "const" }, arg_max_min::min, top_k, arg_max_min::batch));
+    topology.add(reorder("reorder", "arg_max", output_mem->get_layout()));
+
+    std::vector<float> input_vec = {
+            //y0x0 y0x1 y1x0 y1x1
+            /*b0f0*/0.1f, -0.1f, 0.9f,  1.5f,
+            /*b0f1*/0.2f, 0.2f,  -10.f, 5.2f,
+            /*b0f2*/0.2f, 0.2f,  -10.f, 5.2f,
+            /*b0f3*/0.2f, 0.2f,  -10.f, 4.2f,
+
+            /*b1f0*/3.f,  0.5f,  7.f,   10.f,
+            /*b1f1*/4.f,  0.5f,  8.f,   8.2f,
+            /*b1f2*/0.2f, 0.2f,  -10.f, 5.2f,
+            /*b1f3*/4.f,  0.5f,  8.f,   8.2f
+    };
+    set_values(input, input_vec);
+
+    network network(engine, topology);
+
+    network.set_input_data("input", input);
+    network.set_output_memory("reorder", output_mem);
+    auto outputs = network.execute();
+
+    auto output = outputs.at("reorder").get_memory();
+    EXPECT_TRUE(engine.is_the_same_buffer(*output_mem, *output));
+
+    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float> output_mem_ptr(output_mem, get_test_stream());
+
+    for (size_t i = 0; i < output_ptr.size(); ++i) {
+        EXPECT_TRUE(are_equal(output_mem_ptr[i], output_ptr[i])) << i;
+    }
+}
+
+TEST(set_output_memory_gpu, top_k2) {
+    static const int32_t x_size = 2, y_size = 2, feature_num = 4, batch_num = 2;
+    auto& engine = get_test_engine();
+    const int top_k = 2;
+    auto input = engine.allocate_memory({ data_types::f32, format::bfyx,{ batch_num, feature_num, x_size , y_size } });
+    auto top_k_input = engine.allocate_memory({ data_types::f32, format::bfyx,{ 1, 1, 1, 1 } });
+    auto second_output = engine.allocate_memory({ data_types::f32, format::bfyx, { top_k, feature_num, x_size , y_size } });
+    auto second_output_mem = engine.allocate_memory({ data_types::f32, format::bfyx, { top_k, feature_num, x_size , y_size } });
+    topology topology;
+    topology.add(input_layout("input", input->get_layout()));
+    topology.add(cldnn::data("const", top_k_input));
+    topology.add(mutable_data("second_output", second_output));
+    topology.add(arg_max_min("arg_max", { "input", "const", "second_output" }, arg_max_min::min, top_k, arg_max_min::batch));
+    topology.add(reorder("reorder", "arg_max", second_output->get_layout()));
+
+    std::vector<float> input_vec = {
+            //y0x0 y0x1 y1x0 y1x1
+            /*b0f0*/0.1f, -0.1f, 0.9f,  1.5f,
+            /*b0f1*/0.2f, 0.2f,  -10.f, 5.2f,
+            /*b0f2*/0.2f, 0.2f,  -10.f, 5.2f,
+            /*b0f3*/0.2f, 0.2f,  -10.f, 4.2f,
+
+            /*b1f0*/3.f,  0.5f,  7.f,   10.f,
+            /*b1f1*/4.f,  0.5f,  8.f,   8.2f,
+            /*b1f2*/0.2f, 0.2f,  -10.f, 5.2f,
+            /*b1f3*/4.f,  0.5f,  8.f,   8.2f
+    };
+    set_values(input, input_vec);
+
+    network network(engine, topology);
+
+    network.set_input_data("input", input);
+    network.set_output_memory("reorder", second_output_mem);
+    auto outputs = network.execute();
+
+    auto output = outputs.at("reorder").get_memory();
+    EXPECT_TRUE(engine.is_the_same_buffer(*second_output_mem, *output));
+
+    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float> output_mem_ptr(second_output_mem, get_test_stream());
+
+    for (size_t i = 0; i < output_ptr.size(); ++i) {
+        EXPECT_TRUE(are_equal(output_mem_ptr[i], output_ptr[i])) << i;
+    }
+}
+
+TEST(set_output_memory_gpu, basic_opt) {
+    GTEST_SKIP();
+    static const int32_t x_size = 2, y_size = 2, feature_num = 4, batch_num = 1;
+    auto& engine = get_test_engine();
+
+    tensor ishape = { batch_num, feature_num, x_size , y_size };
+    layout il = { data_types::f32, format::bfyx, ishape };
+
+    tensor oshape = { batch_num*2, feature_num, x_size , y_size };
+    layout ol = { data_types::f32, format::bfyx, oshape };
+
+    auto input1 = engine.allocate_memory(il);
+    std::vector<float> input_vec1 = {
+        //y0x0 y0x1 y1x0 y1x1
+        /*b0f0*/0.1f, -2.1f, -3.1f, -4.1f,
+        /*b0f1*/2.1f,  2.1f,  3.1f,  4.1f,
+        /*b0f2*/3.1f, -3.1f,  3.1f,  5.1f,
+        /*b0f3*/1.1f,  1.1f,  1.1f,  1.1f
+    };
+    set_values(input1, input_vec1);
+
+    auto input2 = engine.allocate_memory(il);
+    std::vector<float> input_vec2 = {
+        //y0x0 y0x1 y1x0 y1x1
+        /*b1f0*/0.2f, -2.2f, -3.2f, -4.2f,
+        /*b1f1*/2.2f,  2.2f,  3.2f,  4.2f,
+        /*b1f2*/3.2f, -3.2f,  3.2f,  5.2f,
+        /*b1f3*/1.2f,  1.2f,  1.2f, -1.2f
+    };
+    set_values(input2, input_vec2);
+
+    activation_additional_params params1 = { 0.5f, 2.5f };
+    activation_additional_params params2 = { -2.5f, 0.5f };
+
+    std::vector<float> output_vec = {
+        //y0x0 y0x1 y1x0 y1x1
+        /*b0f0*/0.5f, 0.5f, 0.5f, 0.5f,
+        /*b0f1*/2.1f, 2.1f, 2.5f, 2.5f,
+        /*b0f2*/2.5f, 0.5f, 2.5f, 2.5f,
+        /*b0f3*/1.1f, 1.1f, 1.1f, 1.1f,
+
+        /*b1f0*/0.2f, -2.2f, -2.5f, -2.5f,
+        /*b1f1*/0.5f,  0.5f,  0.5f,  0.5f,
+        /*b1f2*/0.5f, -2.5f,  0.5f,  0.5f,
+        /*b1f3*/0.5f,  0.5f,  0.5f, -1.2f
+    };
+    auto output_mem = engine.allocate_memory(ol);
+
+    topology topology;
+    topology.add(input_layout("input1", il));
+    topology.add(activation("clamp1", "input1", activation_func::clamp, params1));
+    topology.add(input_layout("input2", il));
+    topology.add(activation("clamp2", "input2", activation_func::clamp, params2));
+    topology.add(reshape("reshape1", "clamp1", ishape));
+    topology.add(reshape("reshape2", "clamp2", ishape));
+    topology.add(concatenation("concat", { "reshape1", "reshape2" },
+        concatenation::concatenation_axis::along_b, data_types::f32));
+    topology.add(reshape("reshape3", "concat", oshape));
+    topology.add(reorder("reorder", "reshape3", ol));
+    topology.add(reorder("reorder2", "reorder", ol));
+
+    primitive_id outputID = "reorder3";
+    topology.add(reorder(outputID, "concat", ol));
+
+    build_options bo;
+    bo.set_option(build_option::optimize_data(true));
+    network network(engine, topology, bo);
+
+    network.set_input_data("input1", input1);
+    network.set_input_data("input2", input2);
+    network.set_output_memory(outputID, output_mem);
+ 
+    auto outputs = network.execute();
+    auto output = outputs.at(outputID).get_memory();
+    //  check for correct output memory setting
+    EXPECT_TRUE(engine.is_the_same_buffer(*output_mem, *output));
+    //  check for memory set propagation
+    EXPECT_TRUE(engine.is_the_same_buffer(*output_mem, *network.get_output_memory("concat")));
+    EXPECT_TRUE(engine.is_the_same_buffer(*output_mem, *network.get_output_memory("clamp1")));
+    EXPECT_TRUE(engine.is_the_same_buffer(*output_mem, *network.get_output_memory("clamp2")));
+
+    //  check for correct result
+    cldnn::mem_lock<float> output_ptr(output_mem, get_test_stream());
+    for (size_t i = 0; i < output_ptr.size(); ++i) {
+        EXPECT_TRUE(are_equal(output_ptr[i], output_vec[i])) << i;
+    }
+}


### PR DESCRIPTION
The patch replaces host blobs with mappable ClBlobs in all InferRequests.

Details:
- Ensures that each InferRequest has its own set of input/output GPU memory objects
- Fixes memory corruptions when multiple InferRequests are ran simultaneously
- Enables correct video surfaces sharing when multiple streams are used
- Should enable correct mapping of input/result blobs on dGPUs

Will be merged instead of #5319