### PR TITLE
Pyngraph tests: Install & run on Azure-Linux CI

### DIFF
--- a/.ci/azure/linux.yml
+++ b/.ci/azure/linux.yml
@@ -166,6 +166,11 @@ jobs:
     displayName: 'Clean build dir'
     continueOnError: false
 
+    # Skip test_onnx/test_zoo_models and test_onnx/test_backend due to long execution time
+  - script: . $(SETUPVARS) -pyver 3.8 && python3 -m pytest -s $(INSTALL_TEST_DIR)/tests/pyngraph --junitxml=TEST-Pyngraph.xml --junitxml=TEST-Pyngraph.xml --ignore=$(INSTALL_TEST_DIR)/tests/pyngraph/tests/test_onnx/test_zoo_models.py --ignore=$(INSTALL_TEST_DIR)/tests/pyngraph/pyngraph/tests/test_onnx/test_backend.py
+    displayName: 'nGraph Python Bindings Tests'
+    continueOnError: false
+
   - script: |
       export MO_ROOT=$(INSTALL_DIR)/deployment_tools/model_optimizer
       . $(SETUPVARS) -pyver 3.8 && python3 -m pytest -s $(INSTALL_DIR)/deployment_tools/model_optimizer/unit_tests --junitxml=TEST-ModelOptimizer.xml

--- a/.ci/azure/linux.yml
+++ b/.ci/azure/linux.yml
@@ -167,7 +167,7 @@ jobs:
     continueOnError: false
 
     # Skip test_onnx/test_zoo_models and test_onnx/test_backend due to long execution time
-  - script: . $(SETUPVARS) -pyver 3.8 && python3 -m pytest -s $(INSTALL_TEST_DIR)/pyngraph --junitxml=TEST-Pyngraph.xml --junitxml=TEST-Pyngraph.xml --ignore=$(INSTALL_TEST_DIR)/tests/pyngraph/tests/test_onnx/test_zoo_models.py --ignore=$(INSTALL_TEST_DIR)/tests/pyngraph/pyngraph/tests/test_onnx/test_backend.py
+  - script: . $(SETUPVARS) -pyver 3.8 && python3 -m pytest -s $(INSTALL_TEST_DIR)/pyngraph --junitxml=TEST-Pyngraph.xml --ignore=$(INSTALL_TEST_DIR)/pyngraph/tests/test_onnx/test_zoo_models.py --ignore=$(INSTALL_TEST_DIR)/pyngraph/tests/test_onnx/test_backend.py
     displayName: 'nGraph Python Bindings Tests'
     continueOnError: false
 

--- a/.ci/azure/linux.yml
+++ b/.ci/azure/linux.yml
@@ -167,7 +167,7 @@ jobs:
     continueOnError: false
 
     # Skip test_onnx/test_zoo_models and test_onnx/test_backend due to long execution time
-  - script: . $(SETUPVARS) -pyver 3.8 && python3 -m pytest -s $(INSTALL_TEST_DIR)/tests/pyngraph --junitxml=TEST-Pyngraph.xml --junitxml=TEST-Pyngraph.xml --ignore=$(INSTALL_TEST_DIR)/tests/pyngraph/tests/test_onnx/test_zoo_models.py --ignore=$(INSTALL_TEST_DIR)/tests/pyngraph/pyngraph/tests/test_onnx/test_backend.py
+  - script: . $(SETUPVARS) -pyver 3.8 && python3 -m pytest -s $(INSTALL_TEST_DIR)/pyngraph --junitxml=TEST-Pyngraph.xml --junitxml=TEST-Pyngraph.xml --ignore=$(INSTALL_TEST_DIR)/tests/pyngraph/tests/test_onnx/test_zoo_models.py --ignore=$(INSTALL_TEST_DIR)/tests/pyngraph/pyngraph/tests/test_onnx/test_backend.py
     displayName: 'nGraph Python Bindings Tests'
     continueOnError: false
 

--- a/ngraph/python/CMakeLists.txt
+++ b/ngraph/python/CMakeLists.txt
@@ -104,5 +104,9 @@ if(OpenVINO_SOURCE_DIR OR InferenceEngineDeveloperPackage_FOUND)
             COMPONENT pyngraph_${PYTHON_VERSION}
             USE_SOURCE_PERMISSIONS)
 
+    install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/tests
+            DESTINATION tests/${PROJECT_NAME}
+            COMPONENT tests EXCLUDE_FROM_ALL)
+
     ie_cpack(pyngraph_${PYTHON_VERSION})
 endif()

--- a/ngraph/python/tests/mock/mock_py_ngraph_frontend/CMakeLists.txt
+++ b/ngraph/python/tests/mock/mock_py_ngraph_frontend/CMakeLists.txt
@@ -18,3 +18,7 @@ target_include_directories(${TARGET_FE_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
 target_link_libraries(${TARGET_FE_NAME} PRIVATE ngraph::frontend_manager::static)
 
 add_clang_format_target(${TARGET_FE_NAME}_clang FOR_TARGETS ${TARGET_FE_NAME})
+
+install(TARGETS ${TARGET_FE_NAME}
+        RUNTIME DESTINATION ${NGRAPH_INSTALL_LIB} COMPONENT tests EXCLUDE_FROM_ALL
+        LIBRARY DESTINATION ${NGRAPH_INSTALL_LIB} COMPONENT tests EXCLUDE_FROM_ALL)

--- a/ngraph/python/tests/mock/pyngraph_fe_mock_api/CMakeLists.txt
+++ b/ngraph/python/tests/mock/pyngraph_fe_mock_api/CMakeLists.txt
@@ -14,3 +14,7 @@ pybind11_add_module(${PYBIND_FE_NAME} MODULE ${PYBIND_FE_SRC})
 target_link_libraries(${PYBIND_FE_NAME} PRIVATE ${TARGET_FE_NAME} ngraph::frontend_manager::static)
 
 add_clang_format_target(${PYBIND_FE_NAME}_clang FOR_TARGETS ${PYBIND_FE_NAME})
+
+install(TARGETS ${PYBIND_FE_NAME}
+        DESTINATION python/${PYTHON_VERSION}
+        COMPONENT tests EXCLUDE_FROM_ALL)


### PR DESCRIPTION
### Details:
 - Added install rules for 'pyngraph' tests  mock frontends
 - Add execution of pyngraph-tests to Azure-Linux CI
 - There are some tests which take long time to execute (onnx_zoo models + onnx_backend)
 - Also some tests are failed from onnx_zoo and onnx_backend but since these are ignored anyway this doesn't block this CI task

### Tickets:
 - *ticket-id*
