### PR TITLE
[VPU] Changes logic for MyriadMetrics::DeviceArchitecture

### DIFF
--- a/inference-engine/src/vpu/myriad_plugin/myriad_metrics.cpp
+++ b/inference-engine/src/vpu/myriad_plugin/myriad_metrics.cpp
@@ -109,10 +109,8 @@ const std::unordered_set<std::string>& MyriadMetrics::OptimizationCapabilities()
 }
 
 std::string MyriadMetrics::DeviceArchitecture(const std::map<std::string, InferenceEngine::Parameter> & options) const {
-    // TODO: Task 49309. Return same architecture for devices which can share same cache
-    // E.g. when device "MYRIAD.ma2480-1" is loaded, options.at("DEVICE_ID") will be "ma2480-1"
-    // For DEVICE_ID="ma2480-0" and DEVICE_ID="ma2480-1" this method shall return same string, like "ma2480"
-    // In this case inference engine will be able to reuse cached model and total reduce load network time
+    // Since all supported devices can use the same cashe
+    // this function returns the same value for evrything
     return "MYRIAD";
 }
 


### PR DESCRIPTION
### Details:
 - Since all of the supported devices can use the same cache there is no need to change logic in `DeviceArchitecture`.

### Tickets:
 - CVS-49309
