### PR TITLE
Define armv7 instruction set for IE samples built natively on x32 ARM

### DIFF
--- a/inference-engine/samples/CMakeLists.txt
+++ b/inference-engine/samples/CMakeLists.txt
@@ -87,7 +87,12 @@ if(APPLE)
     set(CMAKE_MACOSX_RPATH ON)
 endif()
 
-if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "^(arm.*|ARM.*)" AND NOT CMAKE_CROSSCOMPILING)
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64.*|aarch64.*|AARCH64.*)")
+  set(AARCH64 ON)
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm.*|ARM.*)")
+  set(ARM ON)
+endif()
+if(ARM AND NOT CMAKE_CROSSCOMPILING)
     add_compile_options(-march=armv7-a)
 endif()
 


### PR DESCRIPTION
Fix to https://github.com/openvinotoolkit/openvino/pull/6840
It sets armv7 instruction set to x32 only. Previous PR affects ARM64 as well.