### PR TITLE
fix mo module version check

### DIFF
--- a/model-optimizer/mo/utils/versions_checker.py
+++ b/model-optimizer/mo/utils/versions_checker.py
@@ -35,15 +35,19 @@ def get_imported_module_version(imported_module):
     Get imported module version
     :return: version(str) or raise AttributeError exception
     """
-    version_attrs = ["__version__", "VERSION", "version"]
+    version_attrs = ("__version__", "VERSION", "version")
     installed_version = None
     for attr in version_attrs:
-        if installed_version is None:
-            installed_version = getattr(imported_module, attr, None)
-            installed_version = installed_version if isinstance(installed_version, str) else None
-        else:
-            return installed_version
-    raise AttributeError("{} module doesn't have version attribute".format(imported_module))
+        installed_version = getattr(imported_module, attr, None)
+        if isinstance(installed_version, str):
+           return installed_version
+        else: 
+            installed_version = None
+
+    if installed_version is None:
+        raise AttributeError("{} module doesn't have version attribute".format(imported_module))
+    else:
+        return installed_version
 
 
 def parse_and_filter_versions_list(required_fw_versions, version_list, env_setup):

--- a/model-optimizer/mo/utils/versions_checker.py
+++ b/model-optimizer/mo/utils/versions_checker.py
@@ -30,6 +30,21 @@ def check_python_version():
         return 1
 
 
+def get_imported_module_version(imported_module):
+    """
+    Get imported module version
+    :return: version(str) or raise AttributeError exception
+    """
+    version_attrs = ["__version__", "VERSION"]
+    installed_version = None
+    for attr in version_attrs:
+        if installed_version is None:
+            installed_version = getattr(imported_module, attr, None)
+        else:
+            return installed_version
+    raise AttributeError("{} module doesn't have version attribute".format(imported_module))
+
+
 def parse_and_filter_versions_list(required_fw_versions, version_list, env_setup):
     """
     Please do not add parameter type annotations (param:type).
@@ -210,7 +225,7 @@ def get_environment_setup(framework):
     try:
         if framework == 'tf':
             exec("import tensorflow")
-            env_setup['tensorflow'] = sys.modules["tensorflow"].__version__
+            env_setup['tensorflow'] = get_imported_module_version(sys.modules["tensorflow"])
             exec("del tensorflow")
     except (AttributeError, ImportError):
         pass
@@ -250,7 +265,7 @@ def check_requirements(framework=None):
         try:
             importable_name = modules.get(name, name)
             exec("import {}".format(importable_name))
-            installed_version = sys.modules[importable_name].__version__
+            installed_version = get_imported_module_version(sys.modules[importable_name])
             version_check(name, installed_version, required_version, key, not_satisfied_versions)
             exec("del {}".format(importable_name))
         except (AttributeError, ImportError):

--- a/model-optimizer/mo/utils/versions_checker.py
+++ b/model-optimizer/mo/utils/versions_checker.py
@@ -35,11 +35,12 @@ def get_imported_module_version(imported_module):
     Get imported module version
     :return: version(str) or raise AttributeError exception
     """
-    version_attrs = ["__version__", "VERSION"]
+    version_attrs = ["__version__", "VERSION", "version"]
     installed_version = None
     for attr in version_attrs:
         if installed_version is None:
             installed_version = getattr(imported_module, attr, None)
+            installed_version = installed_version if isinstance(installed_version, str) else None
         else:
             return installed_version
     raise AttributeError("{} module doesn't have version attribute".format(imported_module))


### PR DESCRIPTION
### Details:
fix getting imported module version, for e.g.
old behaviuor was failed with fastjsonschema pkg
**mo log**:
"Detected not satisfied dependencies:
     fastjsonschema: not installed, required:  ~= 2.15.1"
**venv**: " Collecting fastjsonschema ~=2.15.1
helper.cmd_exec INFO:   Downloading fastjsonschema-2.15.1-py3-none-any.whl
pip freeze -> fastjsonschema==2.15.1"
**missing __version__ attr:** "dir(sys.modules['fastjsonschema'])
['CodeGeneratorDraft04', 'CodeGeneratorDraft06', 'CodeGeneratorDraft07', 'JsonSchemaDefinitionException', 'JsonSchemaException', 'JsonSchemaValueException', 'RefResolver', 'VERSION', '__all__', '__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', '__spec__', '_factory', '_get_code_generator_class', 'compile', 'compile_to_code', 'draft04', 'draft06', 'draft07', 'exceptions', 'generator', 'indent', 'ref_resolver', 'validate', 'version']"
