### PR TITLE
[LPT] MarkupCanBeQuantized: handled unsupported concat

### DIFF
--- a/inference-engine/src/low_precision_transformations/include/low_precision/concat.hpp
+++ b/inference-engine/src/low_precision_transformations/include/low_precision/concat.hpp
@@ -26,6 +26,7 @@ public:
     bool transform(TransformationContext& context, ngraph::pattern::Matcher &m) override;
     bool isPrecisionPreserved(std::shared_ptr<Node> layer) const noexcept override;
     bool canBeTransformed(const TransformationContext& context, std::shared_ptr<Node> layer) const override;
+    static bool isQuantizedStatic(const std::shared_ptr<const Node>& layer) noexcept;
 
 protected:
     static bool isHandled(

--- a/inference-engine/src/low_precision_transformations/src/concat.cpp
+++ b/inference-engine/src/low_precision_transformations/src/concat.cpp
@@ -297,6 +297,22 @@ bool ConcatTransformation::isHandled(const TransformationContext& context, const
     return false;
 }
 
+bool ConcatTransformation::isQuantizedStatic(const std::shared_ptr<const Node>& layer) noexcept {
+    const auto concat = as_type_ptr<const opset1::Concat>(layer);
+    if (concat == nullptr) {
+        return false;
+    }
+
+    const auto axis = concat->get_axis();
+    const auto outputRank = concat->get_output_partial_shape(0).rank();
+    if (axis < 0 && outputRank.is_dynamic()) {
+        return false;
+    }
+
+    const size_t normalizedAxis = ngraph::normalize_axis(concat->get_friendly_name(), axis, outputRank);
+    return normalizedAxis == 1ul;
+}
+
 } // namespace low_precision
 } // namespace pass
 } // namespace ngraph

--- a/inference-engine/src/low_precision_transformations/src/markup_can_be_quantized.cpp
+++ b/inference-engine/src/low_precision_transformations/src/markup_can_be_quantized.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include <ngraph/opsets/opset1.hpp>
+#include "low_precision/concat.hpp"
 #include "low_precision/convolution.hpp"
 #include "low_precision/convolution_backprop_data.hpp"
 #include "low_precision/group_convolution.hpp"
@@ -51,6 +52,12 @@ bool ngraph::pass::low_precision::MarkupCanBeQuantized::run_on_function(std::sha
         if (const auto groupConvolution = std::dynamic_pointer_cast<ngraph::opset1::GroupConvolution>(node)) {
             if (!GroupConvolutionTransformation::isQuantizedStatic(groupConvolution)) {
                 setEmptyPrecisions(groupConvolution);
+            }
+            continue;
+        }
+        if (const auto concat = std::dynamic_pointer_cast<ngraph::opset1::Concat>(node)) {
+            if (!ConcatTransformation::isQuantizedStatic(concat)) {
+                setEmptyPrecisions(concat);
             }
             continue;
         }

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/concat_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/concat_transformation.cpp
@@ -230,16 +230,18 @@ TEST_P(ConcatTransformation, CompareFunctions) {
     auto res = compare_functions(referenceFunction, actualFunction, true, true, false, true, false);
     ASSERT_TRUE(res.first) << res.second;
 
-    const auto actualFakeQuantizes = LayerTransformation::get<opset1::FakeQuantize>(actualFunction);
-    ASSERT_TRUE(checkIfOutputAttributesSharedValuesAreTheSame<std::shared_ptr<PrecisionsAttribute>>(actualFakeQuantizes)) <<
-        "PrecisionsAttribute are not the same";
-
     ConcatTransformationTestValues testValues = std::get<2>(GetParam());
-    if (testValues.checkIntervalsAlignmentAttributes) {
-        auto operations = LayerTransformation::get<opset1::Concat>(actualFunction);
-        operations.insert(operations.end(), actualFakeQuantizes.begin(), actualFakeQuantizes.end());
-        ASSERT_TRUE(checkIfAttributesSharedValuesAreTheSame<std::shared_ptr<IntervalsAlignmentAttribute>>(operations)) <<
-            "IntervalsAlignmentAttribute are not the same";
+    const auto actualFakeQuantizes = LayerTransformation::get<opset1::FakeQuantize>(actualFunction);
+    if (testValues.axis == 1) {
+        ASSERT_TRUE(checkIfOutputAttributesSharedValuesAreTheSame<std::shared_ptr<PrecisionsAttribute>>(actualFakeQuantizes)) <<
+            "PrecisionsAttribute are not the same";
+
+        if (testValues.checkIntervalsAlignmentAttributes) {
+            auto operations = LayerTransformation::get<opset1::Concat>(actualFunction);
+            operations.insert(operations.end(), actualFakeQuantizes.begin(), actualFakeQuantizes.end());
+            ASSERT_TRUE(checkIfAttributesSharedValuesAreTheSame<std::shared_ptr<IntervalsAlignmentAttribute>>(operations)) <<
+                "IntervalsAlignmentAttribute are not the same";
+        }
     }
 }
 

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/concat_with_unsupported_axis_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/concat_with_unsupported_axis_transformation.cpp
@@ -1,0 +1,37 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "layer_transformation.hpp"
+
+#include <gtest/gtest.h>
+
+#include "lpt_ngraph_functions/concat_function.hpp"
+#include "simple_low_precision_transformer.hpp"
+
+using namespace ::testing;
+
+class smoke_LPT_ConcatWithUnsupportedAxis : public Test {};
+
+TEST_F(smoke_LPT_ConcatWithUnsupportedAxis, rtInfoCheck) {
+    using namespace ngraph::builder::subgraph;
+
+    const ngraph::element::Type precision = ngraph::element::f32;
+    const ngraph::PartialShape inputPShape = PartialShape{ 1, 3, 16, 16 };
+    const std::int64_t unsupportedAxis = 2;
+    const auto fakeQuantize = FakeQuantizeOnData{ 256ul, ngraph::Shape({}), {0.f}, {2.55f}, {0.f}, {2.55f} };
+
+    std::shared_ptr<ngraph::Function> function = ConcatFunction::getOriginalWithDifferentPrecisionOnChildren(
+        precision,
+        inputPShape,
+        unsupportedAxis,
+        fakeQuantize,
+        fakeQuantize);
+
+    SimpleLowPrecisionTransformer transformer;
+    transformer.transform(function);
+
+    const auto actualConcat = LayerTransformation::get<opset1::Concat>(function)[0];
+    const auto& rtInfo = actualConcat->get_rt_info();
+    ASSERT_TRUE(rtInfo.empty()) << "Unsupported concat mustn't contain LPT runtime attributes";
+}

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/concat_with_different_precision_on_children.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/concat_with_different_precision_on_children.cpp
@@ -16,34 +16,41 @@ const std::vector<ngraph::element::Type> netPrecisions = {
 };
 
 const std::vector<ngraph::pass::low_precision::LayerTransformation::Params> trasformationParamValues = {
-    // LayerTestsUtils::LayerTransformationParamsNGraphFactory::createParamsI8I8(),
     LayerTestsUtils::LayerTransformationParamsNGraphFactory::createParamsU8I8()
 };
 
 const std::vector<ConcatWithDifferentChildrenTransformationParam> testValues = {
     // U8
     {
+        1,
+        { 256ul, ngraph::Shape({}), {0.f}, {2.55f}, {0.f}, {2.55f} },
+        { 256ul, ngraph::Shape({}), {0.f}, {2.55f}, {0.f}, {2.55f / 2.f} }
+    },
+    // U8 and unsupported concat axis
+    {
+        2,
         { 256ul, ngraph::Shape({}), {0.f}, {2.55f}, {0.f}, {2.55f} },
         { 256ul, ngraph::Shape({}), {0.f}, {2.55f}, {0.f}, {2.55f / 2.f} }
     },
     // I8
     {
+        1,
         { 256ul, ngraph::Shape({}), {-1.28f}, {1.27f}, {-1.28f}, {1.27f} },
         { 256ul, ngraph::Shape({}), {-1.28f}, {1.27f}, {-1.28f / 2.f}, {1.27f / 2.f} }
     },
     // mixed: U8 + I8
     {
+        1,
         { 256ul, ngraph::Shape({}), {0.f}, {2.55f}, {0.f}, {2.55f} },
         { 256ul, ngraph::Shape({}), {-1.28f}, {1.27f}, {-1.28f}, {1.27f} }
     },
     // mixed: I8 + U8
     {
+        1,
         { 256ul, ngraph::Shape({}), {-1.28f}, {1.27f}, {-1.28f}, {1.27f} },
         { 256ul, ngraph::Shape({}), {0.f}, {2.55f}, {0.f}, {2.55f} }
     }
 };
-
-const std::vector<bool> multiChannel = { true/*, false*/ };
 
 INSTANTIATE_TEST_SUITE_P(smoke_LPT, ConcatWithDifferentChildrenTransformation,
     ::testing::Combine(
@@ -51,7 +58,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_LPT, ConcatWithDifferentChildrenTransformation,
         ::testing::Values(ngraph::PartialShape({ 1, 6, 10, 10 })),
         ::testing::Values(CommonTestUtils::DEVICE_CPU),
         ::testing::ValuesIn(testValues),
-        ::testing::ValuesIn(trasformationParamValues),
-        ::testing::ValuesIn(multiChannel)),
+        ::testing::ValuesIn(trasformationParamValues)),
     ConcatWithDifferentChildrenTransformation::getTestCaseName);
 }  // namespace

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/concat_with_different_precision_on_children.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/concat_with_different_precision_on_children.cpp
@@ -16,34 +16,41 @@ const std::vector<ngraph::element::Type> netPrecisions = {
 };
 
 const std::vector<ngraph::pass::low_precision::LayerTransformation::Params> trasformationParamValues = {
-    // LayerTestsUtils::LayerTransformationParamsNGraphFactory::createParamsI8I8(),
     LayerTestsUtils::LayerTransformationParamsNGraphFactory::createParamsU8I8()
 };
 
 const std::vector<ConcatWithDifferentChildrenTransformationParam> testValues = {
     // U8
     {
+        1,
+        { 256ul, ngraph::Shape({}), {0.f}, {2.55f}, {0.f}, {2.55f} },
+        { 256ul, ngraph::Shape({}), {0.f}, {2.55f}, {0.f}, {2.55f / 2.f} }
+    },
+    // U8 and unsupported concat axis
+    {
+        2,
         { 256ul, ngraph::Shape({}), {0.f}, {2.55f}, {0.f}, {2.55f} },
         { 256ul, ngraph::Shape({}), {0.f}, {2.55f}, {0.f}, {2.55f / 2.f} }
     },
     // I8
     {
-        { 256ul, ngraph::Shape({}), {-128.f}, {127.f}, {-1.28f}, {1.27f} },
-        { 256ul, ngraph::Shape({}), {-128.f}, {127.f}, {-1.28f / 2}, {1.27f / 2} }
+        1,
+        { 256ul, ngraph::Shape({}), {-1.28f}, {1.27f}, {-1.28f}, {1.27f} },
+        { 256ul, ngraph::Shape({}), {-1.28f}, {1.27f}, {-1.28f / 2.f}, {1.27f / 2.f} }
     },
     // mixed: U8 + I8
     {
+        1,
         { 256ul, ngraph::Shape({}), {0.f}, {2.55f}, {0.f}, {2.55f} },
         { 256ul, ngraph::Shape({}), {-1.28f}, {1.27f}, {-1.28f}, {1.27f} }
     },
     // mixed: I8 + U8
     {
+        1,
         { 256ul, ngraph::Shape({}), {-1.28f}, {1.27f}, {-1.28f}, {1.27f} },
         { 256ul, ngraph::Shape({}), {0.f}, {2.55f}, {0.f}, {2.55f} }
     }
 };
-
-const std::vector<bool> multiChannel = { true/*, false*/ };
 
 INSTANTIATE_TEST_SUITE_P(smoke_LPT, ConcatWithDifferentChildrenTransformation,
     ::testing::Combine(
@@ -51,7 +58,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_LPT, ConcatWithDifferentChildrenTransformation,
         ::testing::Values(ngraph::PartialShape({ 1, 3, 10, 10 })),
         ::testing::Values(CommonTestUtils::DEVICE_GPU),
         ::testing::ValuesIn(testValues),
-        ::testing::ValuesIn(trasformationParamValues),
-        ::testing::ValuesIn(multiChannel)),
+        ::testing::ValuesIn(trasformationParamValues)),
     ConcatWithDifferentChildrenTransformation::getTestCaseName);
 }  // namespace

--- a/inference-engine/tests/functional/plugin/shared/include/low_precision_transformations/concat_with_different_precision_on_children.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/low_precision_transformations/concat_with_different_precision_on_children.hpp
@@ -13,6 +13,7 @@
 namespace LayerTestsDefinitions {
 class ConcatWithDifferentChildrenTransformationParam {
 public:
+    std::int64_t axis;
     ngraph::builder::subgraph::FakeQuantizeOnData fqOnData1;
     ngraph::builder::subgraph::FakeQuantizeOnData fqOnData2;
 };
@@ -22,9 +23,8 @@ typedef std::tuple<
     ngraph::PartialShape,
     std::string, // target device: CPU, GPU
     ConcatWithDifferentChildrenTransformationParam,
-    ngraph::pass::low_precision::LayerTransformation::Params, // transformation parameters
-    // multichannel
-    bool> ConcatWithDifferentChildrenTransformationParams;
+    ngraph::pass::low_precision::LayerTransformation::Params // transformation parameters
+    > ConcatWithDifferentChildrenTransformationParams;
 
 class ConcatWithDifferentChildrenTransformation :
     public testing::WithParamInterface<ConcatWithDifferentChildrenTransformationParams>,

--- a/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_different_precision_on_children.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_different_precision_on_children.cpp
@@ -25,13 +25,12 @@ std::string ConcatWithDifferentChildrenTransformation::getTestCaseName(testing::
     std::string targetDevice;
     ConcatWithDifferentChildrenTransformationParam param;
     ngraph::pass::low_precision::LayerTransformation::Params params;
-    bool multiChannel;
-    std::tie(netPrecision, inputShapes, targetDevice, param, params, multiChannel) = obj.param;
+    std::tie(netPrecision, inputShapes, targetDevice, param, params) = obj.param;
 
     std::ostringstream result;
     result <<
         getTestCaseNameByParams(netPrecision, inputShapes, targetDevice, params) <<
-        (multiChannel ? "_multichannel" : "") << param.fqOnData1 << param.fqOnData2;
+        "_axis_" << param.axis << "_" << param.fqOnData1 << param.fqOnData2;
 
     return result.str();
 }
@@ -42,8 +41,7 @@ InferenceEngine::Blob::Ptr ConcatWithDifferentChildrenTransformation::GenerateIn
     std::string targetDevice;
     ConcatWithDifferentChildrenTransformationParam param;
     ngraph::pass::low_precision::LayerTransformation::Params params;
-    bool multiChannel;
-    std::tie(netPrecision, inputShapes, targetDevice, param, params, multiChannel) = this->GetParam();
+    std::tie(netPrecision, inputShapes, targetDevice, param, params) = this->GetParam();
 
     const float k = (info.name() == "input1") ? 1.f : (info.name() == "input2" ? 2.f : 3.f);
     return LayerTransformation::GenerateInput(ngraph::element::u8, info.getTensorDesc(), k);
@@ -54,11 +52,10 @@ void ConcatWithDifferentChildrenTransformation::SetUp() {
     ngraph::PartialShape inputShapes;
     ConcatWithDifferentChildrenTransformationParam param;
     ngraph::pass::low_precision::LayerTransformation::Params params;
-    bool multiChannel;
-    std::tie(netPrecision, inputShapes, targetDevice, param, params, multiChannel) = this->GetParam();
+    std::tie(netPrecision, inputShapes, targetDevice, param, params) = this->GetParam();
 
     function = ngraph::builder::subgraph::ConcatFunction::getOriginalWithDifferentPrecisionOnChildren(
-        netPrecision, inputShapes, param.fqOnData1, param.fqOnData2);
+        netPrecision, inputShapes, param.axis, param.fqOnData1, param.fqOnData2);
 }
 
 TEST_P(ConcatWithDifferentChildrenTransformation, CompareWithRefImpl) {

--- a/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/concat_function.hpp
+++ b/inference-engine/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/concat_function.hpp
@@ -82,6 +82,7 @@ public:
     static std::shared_ptr<ngraph::Function> getOriginalWithDifferentPrecisionOnChildren(
         const ngraph::element::Type precision,
         const ngraph::PartialShape& inputShape,
+        const std::int64_t axis,
         const FakeQuantizeOnData& fqOnData1,
         const FakeQuantizeOnData& fqOnData2);
 
@@ -229,10 +230,12 @@ public:
         const ngraph::element::Type precision,
         const ngraph::PartialShape& inputShape,
         const bool multiChannel,
+        const std::int64_t axis,
         const FakeQuantizeOnData& fqOnData1,
         const FakeQuantizeOnData& fqOnData2,
         const ngraph::element::Type precisionBeforeOp,
-        const DequantizationOperations& dequantizationBefore,
+        const DequantizationOperations& dequantizationBefore1,
+        const DequantizationOperations& dequantizationBefore2,
         const ngraph::element::Type precisionAfterOperation,
         const DequantizationOperations& dequantizationAfter1,
         const DequantizationOperations& dequantizationAfter2);


### PR DESCRIPTION
### Details:
Added check on unsupported concat (axis != 1) to the MarkupCanBeQuantized pass.

### Tickets:
 - 61691

### Validation:
 - accuracy: developer-services/job/accuracy/2604/ (reference: developer-services/job/accuracy/2605/)
 - performance: developer-services/job/performance/953/ (reference: developer-services/job/performance/954/)