### PR TITLE
fixed several issues in time tests

### DIFF
--- a/tests/time_tests/scripts/run_timetest.py
+++ b/tests/time_tests/scripts/run_timetest.py
@@ -58,7 +58,7 @@ def run_cmd(args: list, log=None, verbose=True):
     return proc.returncode, ''.join(output)
 
 
-def parse_stats(stats: dict, res: dict):
+def parse_stats(stats: list, res: dict):
     """Parse raw statistics from nested list to flatten dict"""
     for element in stats:
         if isinstance(element, (int, float)):
@@ -104,7 +104,7 @@ def run_timetest(args: dict, log=None):
         if retcode != 0:
             log.error("Run of executable '{}' failed with return code '{}'. Error: {}\n"
                       "Statistics aggregation is skipped.".format(args["executable"], retcode, msg))
-            return retcode, {}
+            return retcode, msg, {}, {}
 
         # Read raw statistics
         with open(tmp_stats_path, "r") as file:
@@ -129,7 +129,7 @@ def run_timetest(args: dict, log=None):
     aggregated_stats = aggregate_stats(filtered_stats)
     log.debug("Aggregated statistics after full run: {}".format(aggregated_stats))
 
-    return 0, aggregated_stats, stats
+    return 0, "", aggregated_stats, stats
 
 
 def check_positive_int(val):
@@ -178,7 +178,8 @@ if __name__ == "__main__":
     logging.basicConfig(format="[ %(levelname)s ] %(message)s",
                         level=logging.DEBUG, stream=sys.stdout)
 
-    exit_code, aggr_stats, _ = run_timetest(dict(args._get_kwargs()), log=logging)  # pylint: disable=protected-access
+    exit_code, _, aggr_stats, _ = run_timetest(dict(args._get_kwargs()),
+                                               log=logging)  # pylint: disable=protected-access
 
     if args.stats_path:
         # Save aggregated results to a file

--- a/tests/time_tests/test_runner/requirements.txt
+++ b/tests/time_tests/test_runner/requirements.txt
@@ -4,3 +4,5 @@ PyYAML==5.4.1
 jsonschema==3.2.0
 distro==1.5.0
 numpy==1.18.5
+pymongo
+pytest-html

--- a/tests/time_tests/test_runner/test_timetest.py
+++ b/tests/time_tests/test_runner/test_timetest.py
@@ -57,15 +57,15 @@ def test_timetest(instance, executable, niter, cl_cache_dir, model_cache_dir, te
         "niter": niter
     }
     logging.info("Run timetest once to generate any cache")
-    retcode, _, _ = run_timetest({**exe_args, "niter": 1}, log=logging)
-    assert retcode == 0, "Run of executable for warm up failed"
+    retcode, msg, _, _ = run_timetest({**exe_args, "niter": 1}, log=logging)
+    assert retcode == 0, f"Run of executable for warm up failed: {msg}"
     if cl_cache_dir:
         assert os.listdir(cl_cache_dir), "cl_cache isn't generated"
     if model_cache_dir:
         assert os.listdir(model_cache_dir), "model_cache isn't generated"
 
-    retcode, aggr_stats, raw_stats = run_timetest(exe_args, log=logging)
-    assert retcode == 0, "Run of executable failed"
+    retcode, msg, aggr_stats, raw_stats = run_timetest(exe_args, log=logging)
+    assert retcode == 0, f"Run of executable failed: {msg}"
 
     # Add timetest results to submit to database and save in new test conf as references
     test_info["results"] = aggr_stats


### PR DESCRIPTION
* Fixed return in `run_timetest`

* Fixed `parse_stats()` argument type notation

* Pass message from `timetest` exe to test error msg to be uploaded to DB
