### PR TITLE
[GNA] Disabled TransposeReduction  (#7011)

### DIFF
--- a/inference-engine/src/gna_plugin/gna_plugin.cpp
+++ b/inference-engine/src/gna_plugin/gna_plugin.cpp
@@ -54,6 +54,7 @@
 #include <transformations/common_optimizations/pull_transpose_through_fq.hpp>
 #include <transformations/common_optimizations/relu_fake_quantize_fusion.hpp>
 #include <transformations/common_optimizations/add_fake_quantize_fusion.hpp>
+#include <transformations/common_optimizations/transpose_sinking.hpp>
 #include <transformations/utils/utils.hpp>
 
 #include "transformations/remove_extra_reshapes.hpp"
@@ -708,6 +709,8 @@ void GNAPlugin::LoadNetwork(CNNNetwork & _network) {
         pass_config->disable<ngraph::pass::ReluFakeQuantizeFusion>();
         // Consider to enable after per-channel quantization on FakeQuantize layer is supported in GNAPlugin, see issue 52034
         pass_config->disable<ngraph::pass::AddFakeQuantizeFusion>();
+        // TransposeReduction can be enabled when Transpose-Conv-Transpose patterns will be handled in ngraph transformations
+        pass_config->disable<ngraph::pass::TransposeReduction>();
         manager.run_passes(graph);
         convertedNetwork = InferenceEngine::details::convertFunctionToICNNNetwork(graph, clonedNetwork);
     }

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/transpose_conv_transpose_squeeze.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/transpose_conv_transpose_squeeze.cpp
@@ -1,0 +1,49 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+#include <gna/gna_config.hpp>
+
+#include "subgraph_tests/transpose_conv_transpose_squeeze.hpp"
+#include "common_test_utils/test_constants.hpp"
+
+using namespace SubgraphTestsDefinitions;
+
+namespace {
+
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+        InferenceEngine::Precision::FP32, InferenceEngine::Precision::FP16,
+};
+
+const std::vector<std::map<std::string, std::string>> configs = {
+        {{"GNA_DEVICE_MODE", "GNA_SW_FP32"}},
+        {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}}
+};
+
+const std::vector<std::vector<size_t>> inputShapes = {
+        {1, 8192}
+};
+
+const std::vector<std::vector<size_t>> kernels = {{1, 3}, {1, 4}, {1, 8}, {1, 9}};
+const std::vector<std::vector<size_t>> strides = {{1, 1}};
+const std::vector<size_t> inputChannels = {64};
+const std::vector<size_t> outputChannels {4, 8, 16};
+
+const auto convParams = ::testing::Combine(
+        ::testing::ValuesIn(kernels),
+        ::testing::ValuesIn(strides),
+        ::testing::ValuesIn(inputChannels),
+        ::testing::ValuesIn(outputChannels)
+);
+
+INSTANTIATE_TEST_SUITE_P(smoke_TransposeConvTest, TransposeConvTest,
+                        ::testing::Combine(
+                                convParams,
+                                ::testing::ValuesIn(netPrecisions),
+                                ::testing::ValuesIn(inputShapes),
+                                ::testing::Values(CommonTestUtils::DEVICE_GNA),
+                                ::testing::ValuesIn(configs)),
+                        TransposeConvTest::getTestCaseName);
+
+}  // namespace

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/transpose_conv_transpose_squeeze.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/transpose_conv_transpose_squeeze.cpp
@@ -37,7 +37,7 @@ const auto convParams = ::testing::Combine(
         ::testing::ValuesIn(outputChannels)
 );
 
-INSTANTIATE_TEST_SUITE_P(smoke_TransposeConvTest, TransposeConvTest,
+INSTANTIATE_TEST_CASE_P(smoke_TransposeConvTest, TransposeConvTest,
                         ::testing::Combine(
                                 convParams,
                                 ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/transpose_conv_transpose_squeeze.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/transpose_conv_transpose_squeeze.hpp
@@ -1,0 +1,15 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "shared_test_classes/subgraph/transpose_conv_transpose_squeeze.hpp"
+
+namespace SubgraphTestsDefinitions {
+
+TEST_P(TransposeConvTest, CompareWithRefImpl) {
+    Run();
+};
+
+}  // namespace SubgraphTestsDefinitions

--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/transpose_conv_transpose_squeeze.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/transpose_conv_transpose_squeeze.hpp
@@ -1,0 +1,49 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <vector>
+#include <string>
+#include <memory>
+
+#include "shared_test_classes/base/layer_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+namespace SubgraphTestsDefinitions {
+
+typedef std::tuple<
+        std::vector<size_t>,                 // Kernel Shape
+        std::vector<size_t>,                 // Strides
+        size_t,                              // Input channels
+        size_t                               // Output channels
+> ConvParams;
+
+typedef std::tuple<
+        ConvParams,
+        InferenceEngine::Precision,        // Net precision
+        InferenceEngine::SizeVector,       // Input shapes
+        LayerTestsUtils::TargetDevice,     // Device name
+        std::map<std::string, std::string> // Additional backend configuration and alis name to it
+> TransposeConvTestParams;
+
+class TransposeConvTest : public testing::WithParamInterface<TransposeConvTestParams>,
+                   virtual public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<TransposeConvTestParams> obj);
+
+protected:
+    void SetUp() override;
+    InferenceEngine::Blob::Ptr GenerateInput(const InferenceEngine::InputInfo &info) const override;
+
+protected:
+    float inputDataMin        = 0.0;
+    float inputDataMax        = 0.2;
+    float inputDataResolution = 1;
+    int32_t  seed = 1;
+};
+
+}  // namespace SubgraphTestsDefinitions

--- a/inference-engine/tests/functional/shared_test_classes/src/subgraph/transpose_conv_transpose_squeeze.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/subgraph/transpose_conv_transpose_squeeze.cpp
@@ -1,0 +1,86 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/subgraph/transpose_conv_transpose_squeeze.hpp"
+
+namespace SubgraphTestsDefinitions {
+
+std::string TransposeConvTest::getTestCaseName(testing::TestParamInfo<TransposeConvTestParams> obj) {
+    ConvParams convParams;
+    InferenceEngine::Precision netPrecision;
+    InferenceEngine::SizeVector inputShapes;
+    std::string targetDevice;
+    std::map<std::string, std::string> config;
+    std::tie(convParams, netPrecision, inputShapes, targetDevice, config) = obj.param;
+
+    std::vector<float> inputArg;
+    std::vector<size_t> kernelShape;
+    std::vector<size_t> strides;
+    size_t inputChannels;
+    size_t outputChannels;
+    std::tie(kernelShape, strides, inputChannels, outputChannels) = convParams;
+
+    std::ostringstream result;
+    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "netPRC=" << netPrecision.name() << "_";
+    result << "trgDev=" << targetDevice;
+    for (auto const& configItem : config) {
+        result << "_configItem=" << configItem.first << "_" << configItem.second;
+    }
+    result << "_KERNEL=" << CommonTestUtils::vec2str(kernelShape) << "_";
+    result << "STRIDES=" << CommonTestUtils::vec2str(strides) << "_";
+    result << "IC=" << inputChannels << "_";
+    result << "OC=" << outputChannels;
+    return result.str();
+}
+
+void TransposeConvTest::SetUp() {
+    ConvParams conv_params;
+    std::vector<size_t> input_shape;
+    std::map<std::string, std::string> config;
+    auto net_precision = InferenceEngine::Precision::UNSPECIFIED;
+    std::tie(conv_params, net_precision, input_shape, targetDevice, config) = this->GetParam();
+    configuration.insert(config.begin(), config.end());
+
+    std::vector<size_t> kernel_shape, strides;
+    size_t input_channels, output_channels;
+    std::tie(kernel_shape, strides, input_channels, output_channels) = conv_params;
+    auto ng_prc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(net_precision);
+    auto params = ngraph::builder::makeParams(ng_prc, {input_shape});
+
+    std::vector<size_t> nchw_order = { 0, 3, 1, 2 };
+    std::vector<size_t> nhwc_order = { 0, 2, 3, 1 };
+    std::vector<size_t> conv_input_shape = {1, 1, input_shape[0] * input_shape[1] / input_channels, input_channels};
+    auto reshape_pattern = std::make_shared<ngraph::opset7::Constant>(ngraph::element::Type_t::i64, ngraph::Shape{conv_input_shape.size()}, conv_input_shape);
+    auto reshape = std::make_shared<ngraph::opset7::Reshape>(params[0], reshape_pattern, false);
+
+    const auto input_order1 = std::make_shared<ngraph::opset7::Constant>(ngraph::element::i64,
+                                                                         ngraph::Shape({conv_input_shape.size()}),
+                                                                         nchw_order);
+    auto transpose1 = std::make_shared<ngraph::opset7::Transpose>(reshape, input_order1);
+
+    float weight_val = 0.02;
+    auto filter_weights_node = ngraph::builder::makeConstant<float>(ng_prc, {output_channels, input_channels, kernel_shape[0], kernel_shape[1]},
+                                                                  { weight_val });
+
+    auto conv = std::make_shared<ngraph::opset7::Convolution>(transpose1, filter_weights_node, strides, std::vector<ptrdiff_t>{ 0, 0 },
+                                                              std::vector<ptrdiff_t>{ 0, 0 }, std::vector<size_t>{ 1, 1 },
+                                                              ngraph::op::PadType::VALID);
+
+    const auto input_order2 = std::make_shared<ngraph::opset7::Constant>(ngraph::element::i64,
+                                                                         ngraph::Shape({conv_input_shape.size()}),
+                                                                         nhwc_order);
+    auto transpose2 = std::make_shared<ngraph::opset7::Transpose>(conv, input_order2);
+
+    auto constant_squeeze = std::make_shared<ngraph::op::Constant>(ngraph::element::Type_t::i64, ngraph::Shape{1}, std::vector<size_t>{0});
+    auto squeeze = std::make_shared<ngraph::op::Squeeze>(transpose2, constant_squeeze);
+
+    function = std::make_shared<ngraph::Function>(squeeze, params, "transposeConv");
+}
+
+InferenceEngine::Blob::Ptr TransposeConvTest::GenerateInput(const InferenceEngine::InputInfo &info) const {
+    return FuncTestUtils::createAndFillBlob(info.getTensorDesc(), inputDataMax - inputDataMin, inputDataMin, 1 / inputDataResolution,
+                                            seed);
+}
+}  // namespace SubgraphTestsDefinitions


### PR DESCRIPTION
### Details:
- Fixed case when the model includes convolution layer and transpose layers before and after it. Those transpose layers should not be removed by TransposeReduction
- Added the new tests

### Tickets:
 - 56722
