### PR TITLE
Build samples with clang against gcc artifacts

### DIFF
--- a/.ci/azure/linux.yml
+++ b/.ci/azure/linux.yml
@@ -46,6 +46,7 @@ jobs:
       echo clang-11 info ; which clang-11 ; clang-11 --version
       echo clang++-11 info ; which clang++-11 ; clang++-11 --version
       echo cmake info ; which cmake ; cmake --version
+      echo ccache show-stats ; which ccache ; ccache --show-stats
       lsb_release
       env
       cat /proc/cpuinfo
@@ -125,6 +126,8 @@ jobs:
         -DENABLE_FASTER_BUILD=ON
         -DENABLE_STRICT_DEPENDENCIES=OFF
         -DENABLE_REQUIREMENTS_INSTALL=OFF
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache
         -DIE_EXTRA_MODULES=$(OPENVINO_CONTRIB_REPO_DIR)/modules
         $(REPO_DIR)
       workingDirectory: $(BUILD_DIR)

--- a/.ci/azure/linux.yml
+++ b/.ci/azure/linux.yml
@@ -86,7 +86,7 @@ jobs:
       python3 -m pip install -r $(REPO_DIR)/inference-engine/ie_bridges/python/requirements.txt
       python3 -m pip install -r $(REPO_DIR)/inference-engine/ie_bridges/python/wheel/requirements-dev.txt
       # Build C++ / C samples with clang
-      sudo apt --assume-yes install clang-9 clang++-9
+      sudo apt --assume-yes install clang clang++
       # For running Python API tests
       python3 -m pip install -r $(REPO_DIR)/inference-engine/ie_bridges/python/src/requirements-dev.txt
       # For running PaddlePaddle frontend unit tests
@@ -172,7 +172,7 @@ jobs:
     displayName: 'Build cpp samples'
 
   - script: |
-      CC=clang-9 CXX=clang++-9 $(INSTALL_DIR)/deployment_tools/inference_engine/samples/cpp/build_samples.sh
+      CC=clang CXX=clang++ $(INSTALL_DIR)/deployment_tools/inference_engine/samples/cpp/build_samples.sh
     workingDirectory: $(BUILD_SAMPLES_CLANG_DIR)
     displayName: 'Build cpp samples with clang'
 
@@ -181,7 +181,7 @@ jobs:
     displayName: 'Build c samples'
 
   - script: |
-      CC=clang-9 CXX=clang++-9 $(INSTALL_DIR)/deployment_tools/inference_engine/samples/c/build_samples.sh
+      CC=clang CXX=clang++ $(INSTALL_DIR)/deployment_tools/inference_engine/samples/c/build_samples.sh
     workingDirectory: $(BUILD_SAMPLES_CLANG_DIR)
     displayName: 'Build c samples with clang'
 

--- a/.ci/azure/linux.yml
+++ b/.ci/azure/linux.yml
@@ -29,6 +29,7 @@ jobs:
     WORK_DIR: $(Pipeline.Workspace)/_w
     BUILD_DIR: $(WORK_DIR)/build
     BUILD_SAMPLES_DIR: $(WORK_DIR)/build_samples
+    BUILD_SAMPLES_CLANG_DIR: $(WORK_DIR)/build_samples_clang
     INSTALL_DIR: $(WORK_DIR)/install_pkg
     INSTALL_TEST_DIR: $(INSTALL_DIR)/tests
     SETUPVARS: $(INSTALL_DIR)/bin/setupvars.sh
@@ -42,6 +43,8 @@ jobs:
       echo Python info ; which python ; python --version
       echo Java info ; which java ; java -version
       echo gcc info ; which gcc ; gcc --version
+      echo clang-11 info ; which clang-11 ; clang-11 --version
+      echo clang++-11 info ; which clang++-11 ; clang++-11 --version
       echo cmake info ; which cmake ; cmake --version
       lsb_release
       env
@@ -58,6 +61,7 @@ jobs:
       rm -rf $(WORK_DIR) ; mkdir $(WORK_DIR)
       rm -rf $(BUILD_DIR) ; mkdir $(BUILD_DIR)
       rm -rf $(BUILD_SAMPLES_DIR) ; mkdir $(BUILD_SAMPLES_DIR)
+      rm -rf $(BUILD_SAMPLES_CLANG_DIR) ; mkdir $(BUILD_SAMPLES_CLANG_DIR)
       echo TargetBranch: $(System.PullRequest.TargetBranch)
       echo SourceBranch: $(Build.SourceBranch)
     displayName: 'Make dir'
@@ -157,9 +161,19 @@ jobs:
     workingDirectory: $(BUILD_SAMPLES_DIR)
     displayName: 'Build cpp samples'
 
+  - script: |
+      CC=clang-11 CXX=clang++-11 $(INSTALL_DIR)/deployment_tools/inference_engine/samples/cpp/build_samples.sh
+    workingDirectory: $(BUILD_SAMPLES_CLANG_DIR)
+    displayName: 'Build cpp samples with clang'
+
   - script: $(INSTALL_DIR)/deployment_tools/inference_engine/samples/c/build_samples.sh
     workingDirectory: $(BUILD_SAMPLES_DIR)
     displayName: 'Build c samples'
+
+  - script: |
+      CC=clang-11 CXX=clang++-11 $(INSTALL_DIR)/deployment_tools/inference_engine/samples/c/build_samples.sh
+    workingDirectory: $(BUILD_SAMPLES_CLANG_DIR)
+    displayName: 'Build c samples with clang'
 
   - script: rm -fr $(BUILD_DIR)
     displayName: 'Clean build dir'

--- a/.ci/azure/linux.yml
+++ b/.ci/azure/linux.yml
@@ -86,7 +86,7 @@ jobs:
       python3 -m pip install -r $(REPO_DIR)/inference-engine/ie_bridges/python/requirements.txt
       python3 -m pip install -r $(REPO_DIR)/inference-engine/ie_bridges/python/wheel/requirements-dev.txt
       # Build C++ / C samples with clang
-      sudo apt --assume-yes install clang-11 clang++-11
+      sudo apt --assume-yes install clang-9 clang++-9
       # For running Python API tests
       python3 -m pip install -r $(REPO_DIR)/inference-engine/ie_bridges/python/src/requirements-dev.txt
       # For running PaddlePaddle frontend unit tests
@@ -170,7 +170,7 @@ jobs:
     displayName: 'Build cpp samples'
 
   - script: |
-      CC=clang-11 CXX=clang++-11 $(INSTALL_DIR)/deployment_tools/inference_engine/samples/cpp/build_samples.sh
+      CC=clang-9 CXX=clang++-9 $(INSTALL_DIR)/deployment_tools/inference_engine/samples/cpp/build_samples.sh
     workingDirectory: $(BUILD_SAMPLES_CLANG_DIR)
     displayName: 'Build cpp samples with clang'
 
@@ -179,7 +179,7 @@ jobs:
     displayName: 'Build c samples'
 
   - script: |
-      CC=clang-11 CXX=clang++-11 $(INSTALL_DIR)/deployment_tools/inference_engine/samples/c/build_samples.sh
+      CC=clang-9 CXX=clang++-9 $(INSTALL_DIR)/deployment_tools/inference_engine/samples/c/build_samples.sh
     workingDirectory: $(BUILD_SAMPLES_CLANG_DIR)
     displayName: 'Build c samples with clang'
 

--- a/.ci/azure/linux.yml
+++ b/.ci/azure/linux.yml
@@ -86,7 +86,7 @@ jobs:
       python3 -m pip install -r $(REPO_DIR)/inference-engine/ie_bridges/python/requirements.txt
       python3 -m pip install -r $(REPO_DIR)/inference-engine/ie_bridges/python/wheel/requirements-dev.txt
       # Build C++ / C samples with clang
-      sudo apt --assume-yes install clang clang++
+      sudo apt --assume-yes install clang-7 clang++-7
       # For running Python API tests
       python3 -m pip install -r $(REPO_DIR)/inference-engine/ie_bridges/python/src/requirements-dev.txt
       # For running PaddlePaddle frontend unit tests
@@ -172,7 +172,7 @@ jobs:
     displayName: 'Build cpp samples'
 
   - script: |
-      CC=clang CXX=clang++ $(INSTALL_DIR)/deployment_tools/inference_engine/samples/cpp/build_samples.sh
+      CC=clang-7 CXX=clang++-7 $(INSTALL_DIR)/deployment_tools/inference_engine/samples/cpp/build_samples.sh
     workingDirectory: $(BUILD_SAMPLES_CLANG_DIR)
     displayName: 'Build cpp samples with clang'
 
@@ -181,7 +181,7 @@ jobs:
     displayName: 'Build c samples'
 
   - script: |
-      CC=clang CXX=clang++ $(INSTALL_DIR)/deployment_tools/inference_engine/samples/c/build_samples.sh
+      CC=clang-7 CXX=clang++-7 $(INSTALL_DIR)/deployment_tools/inference_engine/samples/c/build_samples.sh
     workingDirectory: $(BUILD_SAMPLES_CLANG_DIR)
     displayName: 'Build c samples with clang'
 

--- a/.ci/azure/linux.yml
+++ b/.ci/azure/linux.yml
@@ -43,8 +43,8 @@ jobs:
       echo Python info ; which python ; python --version
       echo Java info ; which java ; java -version
       echo gcc info ; which gcc ; gcc --version
-      echo clang-11 info ; which clang-11 ; clang-11 --version
-      echo clang++-11 info ; which clang++-11 ; clang++-11 --version
+      echo clang-9 info ; which clang-9 ; clang-9 --version
+      echo clang++-9 info ; which clang++-9 ; clang++-9 --version
       echo cmake info ; which cmake ; cmake --version
       echo ccache show-stats ; which ccache ; ccache --show-stats
       lsb_release
@@ -165,7 +165,7 @@ jobs:
     displayName: 'Build cpp samples'
 
   - script: |
-      CC=clang-11 CXX=clang++-11 $(INSTALL_DIR)/deployment_tools/inference_engine/samples/cpp/build_samples.sh
+      CC=clang-9 CXX=clang++-9 $(INSTALL_DIR)/deployment_tools/inference_engine/samples/cpp/build_samples.sh
     workingDirectory: $(BUILD_SAMPLES_CLANG_DIR)
     displayName: 'Build cpp samples with clang'
 
@@ -174,7 +174,7 @@ jobs:
     displayName: 'Build c samples'
 
   - script: |
-      CC=clang-11 CXX=clang++-11 $(INSTALL_DIR)/deployment_tools/inference_engine/samples/c/build_samples.sh
+      CC=clang-9 CXX=clang++-9 $(INSTALL_DIR)/deployment_tools/inference_engine/samples/c/build_samples.sh
     workingDirectory: $(BUILD_SAMPLES_CLANG_DIR)
     displayName: 'Build c samples with clang'
 

--- a/.ci/azure/linux.yml
+++ b/.ci/azure/linux.yml
@@ -134,7 +134,9 @@ jobs:
   - script: ls -alR $(REPO_DIR)/inference-engine/temp/
     displayName: 'List temp SDKs'
 
-  - script: ccache --zero-stats
+  - script: |
+      ccache --zero-stats
+      ccache --show-stats
     displayName: 'Clean ccache stats'
 
   - script: ninja

--- a/.ci/azure/linux.yml
+++ b/.ci/azure/linux.yml
@@ -44,7 +44,6 @@ jobs:
       echo Java info ; which java ; java -version
       echo gcc info ; which gcc ; gcc --version
       echo cmake info ; which cmake ; cmake --version
-      echo ccache show-stats ; which ccache ; ccache --show-stats
       lsb_release
       env
       cat /proc/cpuinfo
@@ -135,9 +134,15 @@ jobs:
   - script: ls -alR $(REPO_DIR)/inference-engine/temp/
     displayName: 'List temp SDKs'
 
+  - script: ccache --zero-stats
+    displayName: 'Clean ccache stats'
+
   - script: ninja
     workingDirectory: $(BUILD_DIR)
     displayName: 'Build Lin'
+
+  - script: ccache --show-stats
+    displayName: 'Show ccache stats'
 
   - script: ls -alR $(REPO_DIR)/bin/
     displayName: 'List bin files'

--- a/.ci/azure/linux.yml
+++ b/.ci/azure/linux.yml
@@ -43,8 +43,6 @@ jobs:
       echo Python info ; which python ; python --version
       echo Java info ; which java ; java -version
       echo gcc info ; which gcc ; gcc --version
-      echo clang-9 info ; which clang-9 ; clang-9 --version
-      echo clang++-9 info ; which clang++-9 ; clang++-9 --version
       echo cmake info ; which cmake ; cmake --version
       echo ccache show-stats ; which ccache ; ccache --show-stats
       lsb_release
@@ -88,6 +86,8 @@ jobs:
       python3 -m pip install --upgrade pip
       python3 -m pip install -r $(REPO_DIR)/inference-engine/ie_bridges/python/requirements.txt
       python3 -m pip install -r $(REPO_DIR)/inference-engine/ie_bridges/python/wheel/requirements-dev.txt
+      # Build C++ / C samples with clang
+      sudo apt --assume-yes install clang-11 clang++-11
       # For running Python API tests
       python3 -m pip install -r $(REPO_DIR)/inference-engine/ie_bridges/python/src/requirements-dev.txt
       # For running PaddlePaddle frontend unit tests
@@ -165,7 +165,7 @@ jobs:
     displayName: 'Build cpp samples'
 
   - script: |
-      CC=clang-9 CXX=clang++-9 $(INSTALL_DIR)/deployment_tools/inference_engine/samples/cpp/build_samples.sh
+      CC=clang-11 CXX=clang++-11 $(INSTALL_DIR)/deployment_tools/inference_engine/samples/cpp/build_samples.sh
     workingDirectory: $(BUILD_SAMPLES_CLANG_DIR)
     displayName: 'Build cpp samples with clang'
 
@@ -174,7 +174,7 @@ jobs:
     displayName: 'Build c samples'
 
   - script: |
-      CC=clang-9 CXX=clang++-9 $(INSTALL_DIR)/deployment_tools/inference_engine/samples/c/build_samples.sh
+      CC=clang-11 CXX=clang++-11 $(INSTALL_DIR)/deployment_tools/inference_engine/samples/c/build_samples.sh
     workingDirectory: $(BUILD_SAMPLES_CLANG_DIR)
     displayName: 'Build c samples with clang'
 

--- a/.ci/azure/linux_onnxruntime.yml
+++ b/.ci/azure/linux_onnxruntime.yml
@@ -96,6 +96,8 @@ jobs:
         -DENABLE_SPEECH_DEMO=OFF
         -DNGRAPH_ONNX_FRONTEND_ENABLE=ON
         -DNGRAPH_DEBUG_ENABLE=OFF
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache
         $(REPO_DIR)
       workingDirectory: $(BUILD_DIR)
 

--- a/.ci/azure/mac.yml
+++ b/.ci/azure/mac.yml
@@ -92,7 +92,9 @@ jobs:
     workingDirectory: $(BUILD_DIR)
     displayName: 'CMake'
 
-  - script: ccache --zero-stats
+  - script: |
+      ccache --zero-stats
+      ccache --show-stats
     displayName: 'Clean ccache stats'
 
   - script: ninja

--- a/.ci/azure/mac.yml
+++ b/.ci/azure/mac.yml
@@ -77,6 +77,7 @@ jobs:
       brew install automake
       python3 -m pip install -r $(REPO_DIR)/ngraph/test/requirements_test_onnx.txt
       # Speed up build
+      brew install ccache
       brew install ninja
       # Speed up tests
       git clone https://github.com/google/gtest-parallel.git
@@ -87,7 +88,7 @@ jobs:
       export PATH="/usr/local/opt/cython/bin:$PATH"
       export CC=gcc
       export CXX=g++
-      cmake -GNinja -DVERBOSE_BUILD=ON -DENABLE_REQUIREMENTS_INSTALL=OFF -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DENABLE_PYTHON=ON -DENABLE_TESTS=ON -DENABLE_STRICT_DEPENDENCIES=OFF -DIE_EXTRA_MODULES=$(OPENVINO_CONTRIB_REPO_DIR)/modules $(REPO_DIR)
+      cmake -GNinja -DVERBOSE_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DENABLE_REQUIREMENTS_INSTALL=OFF -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DENABLE_PYTHON=ON -DENABLE_TESTS=ON -DENABLE_STRICT_DEPENDENCIES=OFF -DIE_EXTRA_MODULES=$(OPENVINO_CONTRIB_REPO_DIR)/modules $(REPO_DIR)
     workingDirectory: $(BUILD_DIR)
     displayName: 'CMake'
 

--- a/.ci/azure/mac.yml
+++ b/.ci/azure/mac.yml
@@ -92,9 +92,15 @@ jobs:
     workingDirectory: $(BUILD_DIR)
     displayName: 'CMake'
 
+  - script: ccache --zero-stats
+    displayName: 'Clean ccache stats'
+
   - script: ninja
     workingDirectory: $(BUILD_DIR)
     displayName: 'Build Mac'
+
+  - script: ccache --show-stats
+    displayName: 'Show ccache stats'
 
   - script: ls -alR $(REPO_DIR)/bin/
     displayName: 'List files'

--- a/.ci/openvino-onnx/Dockerfile
+++ b/.ci/openvino-onnx/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
         automake \
         build-essential \
         cmake \
+        ccache \
         curl \
         git \
         libtool \

--- a/install_build_dependencies.sh
+++ b/install_build_dependencies.sh
@@ -33,6 +33,7 @@ if [ -f /etc/lsb-release ]; then
     sudo -E apt-get install -y \
             build-essential \
             cmake \
+            ccache \
             curl \
             wget \
             libssl-dev \


### PR DESCRIPTION
### Details:
 - We have sometimes tickets that gcc-compiled artifacts cannot be used with clang. But there is not such incompatibility actually,  we need to checks that we don't introduce it explicitly / implicitly. 
 
### Tickets:
 - 59012
