### PR TITLE
CVS-56144 Enable all OMZ scope

### DIFF
--- a/inference-engine/tests/functional/plugin/conformance/test_runner/skip_configs/skip_config_cpu.lst
+++ b/inference-engine/tests/functional/plugin/conformance/test_runner/skip_configs/skip_config_cpu.lst
@@ -1,9 +1,3 @@
-# OMZ:
-# Hang:
-.*AvgPool_1199829.*
-.*AvgPool_1201153.*
-.*ROIPooling_1199827.*
-
 # DLB:
 # Hang:
 .*Convolution_1301086.*


### PR DESCRIPTION
### Details:
 - remove from skip_config_cpu.lst disabled OMZ tests

### Tickets:
 - CVS-56144