### PR TITLE
Enable NormalizeL2Fusion and LeakyReluFusion inside MOC

### DIFF
--- a/inference-engine/src/mkldnn_plugin/mkldnn_plugin.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_plugin.cpp
@@ -24,9 +24,7 @@
 #include <transformations/common_optimizations/common_optimizations.hpp>
 #include <transformations/common_optimizations/weights_dequantize_to_fake_quantize.hpp>
 #include "transformations/common_optimizations/convert_quantize_dequantize.hpp"
-#include <transformations/common_optimizations/depth_to_space_fusion.hpp>
 #include <transformations/common_optimizations/softmax_fusion.hpp>
-#include <transformations/common_optimizations/normalize_l2_fusion.hpp>
 #include <transformations/op_conversions/convert_depth_to_space.hpp>
 #include <transformations/op_conversions/convert_shuffle_channels3.hpp>
 #include <transformations/op_conversions/convert_space_to_depth.hpp>
@@ -37,9 +35,9 @@
 #include <transformations/op_conversions/hswish_decomposition.hpp>
 #include <transformations/op_conversions/hsigmoid_decomposition.hpp>
 #include <transformations/op_conversions/mvn6_decomposition.hpp>
+#include <transformations/op_conversions/normalize_l2_decomposition.hpp>
 #include <transformations/op_conversions/reduce_l1_decomposition.hpp>
 #include <transformations/op_conversions/reduce_l2_decomposition.hpp>
-#include <transformations/op_conversions/convert_pad_to_group_conv.hpp>
 #include <transformations/op_conversions/softplus_decomposition.hpp>
 #include <transformations/op_conversions/convert_space_to_batch.hpp>
 #include <transformations/op_conversions/convert_batch_to_space.hpp>
@@ -53,7 +51,6 @@
 #include <transformations/op_conversions/gru_cell_decomposition.hpp>
 #include <transformations/op_conversions/log_softmax_decomposition.hpp>
 #include <transformations/op_conversions/convert_interpolate1_to_interpolate4.hpp>
-#include <transformations/op_conversions/convert_shuffle_channels3.hpp>
 #include <transformations/op_conversions/simplify_ctc_greedy_decoder_seq_len.hpp>
 #include <transformations/op_conversions/convert_previous_nms_to_nms_5.hpp>
 #include <transformations/op_conversions/convert_nms_to_nms_ie_internal.hpp>
@@ -249,8 +246,9 @@ static void Transformation(CNNNetwork& clonedNetwork, const Config& conf) {
         return false;
     };
 
-    pass_config->set_callback<ngraph::pass::ConvertRNNSequenceToTensorIterator, ngraph::pass::ConvertGRUSequenceToTensorIterator,
-            ngraph::pass::ConvertLSTMSequenceToTensorIterator>(
+    pass_config->set_callback<ngraph::pass::ConvertRNNSequenceToTensorIterator,
+                              ngraph::pass::ConvertGRUSequenceToTensorIterator,
+                              ngraph::pass::ConvertLSTMSequenceToTensorIterator>(
             [isSequencePrimitiveSupported](const_node_ptr &node) -> bool {
                 return isSequencePrimitiveSupported(node);
             });
@@ -280,17 +278,16 @@ static void Transformation(CNNNetwork& clonedNetwork, const Config& conf) {
                 return MKLDNNMVNNode::isSupportedOperation(node, errorMessage);
             });
 
+    pass_config->set_callback<ngraph::pass::NormalizeL2Decomposition>(
+            [](const_node_ptr &node) -> bool {
+                std::string errorMsg;
+                return MKLDNNNormalizeL2Node::isSupportedOperation(node, errorMsg);
+            });
+
     pass_config->set_callback<ngraph::pass::SoftmaxFusion>(
             [](const_node_ptr &node) -> bool {
                 return node->input_value(0).get_partial_shape().rank().get_length() > 5;
             });
-
-    auto normalizeL2FusionCallback = [](const_node_ptr &node) -> bool {
-        std::string errorMsg;
-        return !MKLDNNNormalizeL2Node::isSupportedOperation(node, errorMsg);
-    };
-    pass_config->set_callback<ngraph::pass::NormalizeL2FusionWithAdd>(normalizeL2FusionCallback);
-    pass_config->set_callback<ngraph::pass::NormalizeL2FusionWithMax>(normalizeL2FusionCallback);
 
     // List of enabled/disabled transformations
     pass_config->disable<ngraph::pass::ConvertGELU>();
@@ -309,6 +306,7 @@ static void Transformation(CNNNetwork& clonedNetwork, const Config& conf) {
     pass_config->disable<ngraph::pass::ConvertGather7ToGather1>();
     pass_config->disable<ngraph::pass::ConvertDeformableConv8To1>();
 
+    pass_config->enable<ngraph::pass::NormalizeL2Decomposition>();
     pass_config->enable<ngraph::pass::ConvertInterpolate1ToInterpolate4>();
     pass_config->enable<ngraph::pass::ConvertGather1ToGather7>();
     pass_config->enable<ngraph::pass::ConvertGather8ToGather7>();

--- a/inference-engine/src/offline_transformations/src/moc_transformations.cpp
+++ b/inference-engine/src/offline_transformations/src/moc_transformations.cpp
@@ -35,6 +35,8 @@
 #include <transformations/common_optimizations/conv_mul_fusion.hpp>
 #include <transformations/common_optimizations/nop_elimination.hpp>
 #include <transformations/low_precision/disable_convert_constant_folding_on_const_path.hpp>
+#include <transformations/common_optimizations/leaky_relu_fusion.hpp>
+#include <transformations/common_optimizations/normalize_l2_fusion.hpp>
 
 NGRAPH_RTTI_DEFINITION(ngraph::pass::MOCTransformations, "MOCTransformations", 0);
 
@@ -79,11 +81,13 @@ bool ngraph::pass::MOCTransformations::run_on_function(std::shared_ptr<ngraph::F
     common_fusions->add_matcher<ngraph::pass::SwishFusion>();
     common_fusions->add_matcher<ngraph::pass::HSwishFusion>();
     common_fusions->add_matcher<ngraph::pass::HSigmoidFusion>();
+    common_fusions->add_matcher<ngraph::pass::NormalizeL2Fusion>();
     common_fusions->add_matcher<ngraph::pass::ClampFusion>();
     common_fusions->add_matcher<ngraph::pass::PadFusion>();
     common_fusions->add_matcher<ngraph::pass::MVNFusion>();
     common_fusions->add_matcher<ngraph::pass::DilatedConvolutionConverter>();
     common_fusions->add_matcher<ngraph::pass::GeluFusion>();
+    common_fusions->add_matcher<ngraph::pass::LeakyReluFusion>();
     common_fusions->set_name("ngraph::pass::CommonFusions");
 
     manager.register_pass<ngraph::pass::BinarizeWeights>();

--- a/inference-engine/src/transformations/include/transformations/op_conversions/normalize_l2_decomposition.hpp
+++ b/inference-engine/src/transformations/include/transformations/op_conversions/normalize_l2_decomposition.hpp
@@ -4,29 +4,29 @@
 
 #pragma once
 
-#include <utility>
+#include <vector>
 #include <memory>
 
 #include <transformations_visibility.hpp>
+
+#include <ngraph/ngraph.hpp>
 #include <ngraph/pass/graph_rewrite.hpp>
 #include "ngraph/pattern/matcher.hpp"
 
 namespace ngraph {
 namespace pass {
 
-class TRANSFORMATIONS_API NormalizeL2Fusion;
+class TRANSFORMATIONS_API NormalizeL2Decomposition;
 
 }  // namespace pass
 }  // namespace ngraph
 
 /**
  * @ingroup ie_transformation_common_api
- * @brief NormalizeL2Fusion transformation replaces various sub-graphs with a NormalizeL2 op:
- * x/(max(sqrt(sum(x[j0, ..., jN]**2), eps)) with a NormalizeL2 op.
- * x/(add(sqrt(sum(x[j0, ..., jN]**2), eps)) with a NormalizeL2 op.
+ * @brief Decomposes NormalizeL2 into subgraph
  */
-class ngraph::pass::NormalizeL2Fusion: public ngraph::pass::MatcherPass {
+class ngraph::pass::NormalizeL2Decomposition: public ngraph::pass::MatcherPass {
 public:
     NGRAPH_RTTI_DECLARATION;
-    NormalizeL2Fusion();
+    NormalizeL2Decomposition();
 };

--- a/inference-engine/src/transformations/src/transformations/common_optimizations/common_optimizations.cpp
+++ b/inference-engine/src/transformations/src/transformations/common_optimizations/common_optimizations.cpp
@@ -78,6 +78,7 @@
 #include <ngraph/pass/constant_folding.hpp>
 #include <transformations/common_optimizations/weights_dequantize_to_fake_quantize.hpp>
 #include <transformations/common_optimizations/simplify_shape_of_sub_graph.hpp>
+#include <transformations/op_conversions/normalize_l2_decomposition.hpp>
 
 NGRAPH_RTTI_DEFINITION(ngraph::pass::CommonOptimizations, "CommonOptimizations", 0);
 
@@ -160,6 +161,7 @@ bool ngraph::pass::CommonOptimizations::run_on_function(std::shared_ptr<ngraph::
     decomp->add_matcher<ngraph::pass::ConvertSpaceToDepth>();
     decomp->add_matcher<ngraph::pass::BatchNormDecomposition>();
     decomp->add_matcher<ngraph::pass::MVN6Decomposition>();
+    decomp->add_matcher<ngraph::pass::NormalizeL2Decomposition, false>();
     decomp->add_matcher<ngraph::pass::SimplifyCTCGreedyDecoderSeqLen>();
     decomp->add_matcher<ngraph::pass::EinsumDecomposition>();
     decomp->add_matcher<ngraph::pass::GatherNegativeConstIndicesNormalize>();

--- a/inference-engine/src/transformations/src/transformations/common_optimizations/leaky_relu_fusion.cpp
+++ b/inference-engine/src/transformations/src/transformations/common_optimizations/leaky_relu_fusion.cpp
@@ -24,14 +24,13 @@ ngraph::pass::LeakyReluFusion::LeakyReluFusion() {
     auto max_pattern = ngraph::pattern::wrap_type<opset8::Maximum>({data_pattern, multiply_pattern});
 
     ngraph::matcher_pass_callback callback = [=](pattern::Matcher& m) {
-        auto pattern_map = m.get_pattern_value_map();
-        auto data = pattern_map.at(data_pattern);
+        const auto & pattern_map = m.get_pattern_value_map();
         const auto & original_alpha_pattern = pattern_map.at(alpha_pattern);
 
         if (shape_size(original_alpha_pattern.get_shape()) != 1)
             return false;
 
-        auto leaky_relu = register_new_node<ngraph::opset8::PRelu>(data, original_alpha_pattern);
+        auto leaky_relu = register_new_node<ngraph::opset8::PRelu>(pattern_map.at(data_pattern), original_alpha_pattern);
         auto maximum = pattern_map.at(max_pattern);
         leaky_relu->set_friendly_name(maximum.get_node()->get_friendly_name());
 

--- a/inference-engine/src/transformations/src/transformations/common_optimizations/normalize_l2_fusion.cpp
+++ b/inference-engine/src/transformations/src/transformations/common_optimizations/normalize_l2_fusion.cpp
@@ -9,34 +9,37 @@
 #include <memory>
 #include <vector>
 
-#include <ngraph/opsets/opset4.hpp>
+#include <ngraph/opsets/opset8.hpp>
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
+#include <ngraph/pattern/op/or.hpp>
 
 NGRAPH_RTTI_DEFINITION(ngraph::pass::NormalizeL2Fusion, "NormalizeL2Fusion", 0);
 
-NGRAPH_RTTI_DEFINITION(ngraph::pass::NormalizeL2FusionWithMax, "NormalizeL2FusionWithMax", 0);
-
-ngraph::pass::NormalizeL2FusionWithMax::NormalizeL2FusionWithMax() {
-    MATCHER_SCOPE(NormalizeL2FusionWithMax);
+ngraph::pass::NormalizeL2Fusion::NormalizeL2Fusion() {
+    MATCHER_SCOPE(NormalizeL2Fusion);
     auto input = ngraph::pattern::any_input();
 
-    auto exp = ngraph::pattern::wrap_type<ngraph::opset4::Constant>();
-    auto pow = std::make_shared<ngraph::opset4::Power>(input, exp);
-    auto axes = ngraph::pattern::wrap_type<ngraph::opset4::Constant>();
-    auto reduce_sum = std::make_shared<ngraph::opset4::ReduceSum>(pow, axes);
-    auto eps_const = ngraph::pattern::wrap_type<ngraph::opset4::Constant>();
-    auto max = std::make_shared<ngraph::opset4::Maximum>(reduce_sum, eps_const);
-    auto sqrt = std::make_shared<ngraph::opset4::Sqrt>(max);
-    auto divide = std::make_shared<ngraph::opset4::Divide>(input, sqrt);
+    auto exp = ngraph::pattern::wrap_type<ngraph::opset8::Constant>();
+    auto pow = std::make_shared<ngraph::opset8::Power>(input, exp);
+    auto axes = ngraph::pattern::wrap_type<ngraph::opset8::Constant>();
+    auto reduce_sum = std::make_shared<ngraph::opset8::ReduceSum>(pow, axes);
+    auto eps_const = ngraph::pattern::wrap_type<ngraph::opset8::Constant>();
 
-    ngraph::matcher_pass_callback matcher_pass_callback = [=](ngraph::pattern::Matcher& m) {
-        auto& pattern_to_output = m.get_pattern_value_map();
+    auto max = std::make_shared<ngraph::opset8::Maximum>(reduce_sum, eps_const);
+    auto add = std::make_shared<ngraph::opset8::Add>(reduce_sum, eps_const);
+    auto max_or_add = std::make_shared<pattern::op::Or>(OutputVector{max, add});
+
+    auto sqrt = std::make_shared<ngraph::opset8::Sqrt>(max_or_add);
+    auto divide = std::make_shared<ngraph::opset8::Divide>(input, sqrt);
+
+    ngraph::matcher_pass_callback callback = [=](ngraph::pattern::Matcher& m) {
+        const auto& pattern_to_output = m.get_pattern_value_map();
 
         const auto data_input = pattern_to_output.at(input);
-        const auto exp_input = std::dynamic_pointer_cast<ngraph::opset4::Constant>(pattern_to_output.at(exp).get_node_shared_ptr());
-        const auto axes_input = std::dynamic_pointer_cast<ngraph::opset4::Constant>(pattern_to_output.at(axes).get_node_shared_ptr());
-        const auto eps_attr = std::dynamic_pointer_cast<ngraph::opset4::Constant>(pattern_to_output.at(eps_const).get_node_shared_ptr());
+        const auto exp_input = std::dynamic_pointer_cast<ngraph::opset8::Constant>(pattern_to_output.at(exp).get_node_shared_ptr());
+        const auto axes_input = std::dynamic_pointer_cast<ngraph::opset8::Constant>(pattern_to_output.at(axes).get_node_shared_ptr());
+        const auto eps_attr = std::dynamic_pointer_cast<ngraph::opset8::Constant>(pattern_to_output.at(eps_const).get_node_shared_ptr());
 
         if (!exp_input || !axes_input || !eps_attr) {
             return false;
@@ -51,7 +54,19 @@ ngraph::pass::NormalizeL2FusionWithMax::NormalizeL2FusionWithMax() {
         }
         const auto eps_attr_value = eps_attr->cast_vector<float>()[0];
 
-        auto normalize_l2 = std::make_shared<ngraph::opset4::NormalizeL2>(data_input, axes_input, eps_attr_value, op::EpsMode::MAX);
+        op::EpsMode mode;
+        Output<Node> eps_node;
+        if (pattern_to_output.count(max)) {
+            mode = op::EpsMode::MAX;
+            eps_node = pattern_to_output.at(max);
+        } else if (pattern_to_output.count(add)) {
+            mode = op::EpsMode::ADD;
+            eps_node = pattern_to_output.at(add);
+        } else {
+            return false;
+        }
+
+        auto normalize_l2 = std::make_shared<ngraph::opset8::NormalizeL2>(data_input, axes_input, eps_attr_value, mode);
         if (transformation_callback(normalize_l2))
             return false;
 
@@ -59,64 +74,8 @@ ngraph::pass::NormalizeL2FusionWithMax::NormalizeL2FusionWithMax() {
         ngraph::copy_runtime_info({pattern_to_output.at(pow).get_node_shared_ptr(),
                                    pattern_to_output.at(reduce_sum).get_node_shared_ptr(),
                                    pattern_to_output.at(sqrt).get_node_shared_ptr(),
-                                   pattern_to_output.at(max).get_node_shared_ptr(),
-                                   pattern_to_output.at(divide).get_node_shared_ptr()
-                                   },
-                                   normalize_l2);
-        ngraph::replace_node(m.get_match_root(), normalize_l2);
-        return true;
-    };
-
-    auto m = std::make_shared<ngraph::pattern::Matcher>(divide, matcher_name);
-    register_matcher(m, matcher_pass_callback);
-}
-
-NGRAPH_RTTI_DEFINITION(ngraph::pass::NormalizeL2FusionWithAdd, "NormalizeL2FusionWithAdd", 0);
-
-ngraph::pass::NormalizeL2FusionWithAdd::NormalizeL2FusionWithAdd() {
-    MATCHER_SCOPE(NormalizeL2FusionWithAdd);
-    auto input = ngraph::pattern::any_input();
-
-    auto exp = ngraph::pattern::wrap_type<ngraph::opset4::Constant>();
-    auto pow = std::make_shared<ngraph::opset4::Power>(input, exp);
-    auto axes = ngraph::pattern::wrap_type<ngraph::opset4::Constant>();
-    auto reduce_sum = std::make_shared<ngraph::opset4::ReduceSum>(pow, axes);
-    auto eps_const = ngraph::pattern::wrap_type<ngraph::opset4::Constant>();
-    auto add = std::make_shared<ngraph::opset4::Add>(reduce_sum, eps_const);
-    auto sqrt = std::make_shared<ngraph::opset4::Sqrt>(add);
-    auto divide = std::make_shared<ngraph::opset4::Divide>(input, sqrt);
-
-    ngraph::matcher_pass_callback callback = [=](ngraph::pattern::Matcher& m) {
-        auto& pattern_to_output = m.get_pattern_value_map();
-
-        const auto data_input = pattern_to_output.at(input);
-        const auto exp_input = std::dynamic_pointer_cast<ngraph::opset4::Constant>(pattern_to_output.at(exp).get_node_shared_ptr());
-        const auto axes_input = std::dynamic_pointer_cast<ngraph::opset4::Constant>(pattern_to_output.at(axes).get_node_shared_ptr());
-        const auto eps_attr = std::dynamic_pointer_cast<ngraph::opset4::Constant>(pattern_to_output.at(eps_const).get_node_shared_ptr());
-
-        if (!exp_input || !axes_input || !eps_attr) {
-            return false;
-        }
-
-        const bool is_square_pow = shape_size(exp_input->get_shape()) <= 1 && exp_input->cast_vector<int64_t>()[0] == 2;
-        if (!is_square_pow) {
-            return false;
-        }
-        if (shape_size(eps_attr->get_shape()) > 1) {
-            return false;
-        }
-        const auto eps_attr_value = op::util::has_constant_value<float>(exp_input, 2.0f);
-
-        auto normalize_l2 = std::make_shared<ngraph::opset4::NormalizeL2>(data_input, axes_input, eps_attr_value, op::EpsMode::ADD);
-        if (transformation_callback(normalize_l2))
-            return false;
-
-        normalize_l2->set_friendly_name(m.get_match_root()->get_friendly_name());
-        ngraph::copy_runtime_info({pattern_to_output.at(pow).get_node_shared_ptr(),
-                                   pattern_to_output.at(reduce_sum).get_node_shared_ptr(),
-                                   pattern_to_output.at(sqrt).get_node_shared_ptr(),
-                                   pattern_to_output.at(add).get_node_shared_ptr(),
-                                   pattern_to_output.at(divide).get_node_shared_ptr()
+                                   pattern_to_output.at(divide).get_node_shared_ptr(),
+                                   eps_node.get_node_shared_ptr()
                                    },
                                    normalize_l2);
         ngraph::replace_node(m.get_match_root(), normalize_l2);

--- a/inference-engine/src/transformations/src/transformations/op_conversions/normalize_l2_decomposition.cpp
+++ b/inference-engine/src/transformations/src/transformations/op_conversions/normalize_l2_decomposition.cpp
@@ -26,7 +26,7 @@ ngraph::pass::NormalizeL2Decomposition::NormalizeL2Decomposition() {
 
         auto power = std::make_shared<opset8::Power>(normalize_l2->input_value(0),
                                                      opset8::Constant::create(normalize_l2->get_input_element_type(0), Shape{}, {2.0}));
-        auto reduce_sum = std::make_shared<opset8::ReduceSum>(power, normalize_l2->input_value(1));
+        auto reduce_sum = std::make_shared<opset8::ReduceSum>(power, normalize_l2->input_value(1), true);
 
         std::shared_ptr<Node> eps_node;
         auto eps_const_node = opset8::Constant::create(normalize_l2->get_input_element_type(0), Shape{}, {normalize_l2->get_eps()});

--- a/inference-engine/src/transformations/src/transformations/op_conversions/normalize_l2_decomposition.cpp
+++ b/inference-engine/src/transformations/src/transformations/op_conversions/normalize_l2_decomposition.cpp
@@ -1,0 +1,56 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "itt.hpp"
+#include "transformations/op_conversions/normalize_l2_decomposition.hpp"
+
+#include <memory>
+
+#include <ngraph/opsets/opset8.hpp>
+#include <ngraph/rt_info.hpp>
+#include <ngraph/pattern/op/wrap_type.hpp>
+
+NGRAPH_RTTI_DEFINITION(ngraph::pass::NormalizeL2Decomposition, "NormalizeL2Decomposition", 0);
+
+ngraph::pass::NormalizeL2Decomposition::NormalizeL2Decomposition() {
+    MATCHER_SCOPE(NormalizeL2Decomposition);
+    auto normalize_l2_pattern = ngraph::pattern::wrap_type<opset8::NormalizeL2>();
+
+    ngraph::matcher_pass_callback callback = [=](ngraph::pattern::Matcher &m) {
+        auto normalize_l2 = std::dynamic_pointer_cast<opset8::NormalizeL2>(m.get_match_root());
+
+        if (!normalize_l2 || transformation_callback(normalize_l2)) {
+            return false;
+        }
+
+        auto power = std::make_shared<opset8::Power>(normalize_l2->input_value(0),
+                                                     opset8::Constant::create(normalize_l2->get_input_element_type(0), Shape{}, {2.0}));
+        auto reduce_sum = std::make_shared<opset8::ReduceSum>(power, normalize_l2->input_value(1));
+
+        std::shared_ptr<Node> eps_node;
+        auto eps_const_node = opset8::Constant::create(normalize_l2->get_input_element_type(0), Shape{}, {normalize_l2->get_eps()});
+        switch (normalize_l2->get_eps_mode()) {
+            case op::EpsMode::ADD:
+                eps_node = std::make_shared<opset8::Add>(reduce_sum, eps_const_node);
+                break;
+            case op::EpsMode::MAX:
+                eps_node = std::make_shared<opset8::Maximum>(reduce_sum, eps_const_node);
+                break;
+            default:
+                return false;
+        }
+
+        auto sqrt = std::make_shared<opset8::Sqrt>(eps_node);
+        auto div = std::make_shared<opset8::Divide>(normalize_l2->input_value(0), sqrt);
+
+        div->set_friendly_name(normalize_l2->get_friendly_name());
+        ngraph::copy_runtime_info(normalize_l2, {power, reduce_sum, eps_node, sqrt, div});
+        ngraph::replace_node(normalize_l2, div);
+        return true;
+    };
+
+    auto m = std::make_shared<ngraph::pattern::Matcher>(normalize_l2_pattern, matcher_name);
+    register_matcher(m, callback);
+}
+

--- a/inference-engine/tests/functional/inference_engine/transformations/normalize_l2_decomposition_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/normalize_l2_decomposition_test.cpp
@@ -23,7 +23,7 @@ TEST(TransformationTests, NormalizeL2DecomositionFusionWithMax) {
     const float eps_value = 0.000099f;
     {
         auto input = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f16, ngraph::PartialShape::dynamic(3));
-        auto axes_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {0, 1});
+        auto axes_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {1, 2});
         auto normalize_l2 = std::make_shared<ngraph::opset8::NormalizeL2>(input, axes_const, eps_value, ngraph::op::EpsMode::MAX);
 
         f = std::make_shared<ngraph::Function>(ngraph::NodeVector{normalize_l2}, ngraph::ParameterVector{input});
@@ -39,8 +39,8 @@ TEST(TransformationTests, NormalizeL2DecomositionFusionWithMax) {
         auto input = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f16, ngraph::PartialShape::dynamic(3));
         auto exp = ngraph::opset8::Constant::create(ngraph::element::f16, ngraph::Shape{}, {2.f});
         auto pow = std::make_shared<ngraph::opset8::Power>(input, exp);
-        auto axes_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {0, 1});
-        auto reduce_sum = std::make_shared<ngraph::opset8::ReduceSum>(pow, axes_const);
+        auto axes_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {1, 2});
+        auto reduce_sum = std::make_shared<ngraph::opset8::ReduceSum>(pow, axes_const, true);
         auto eps_const = ngraph::opset8::Constant::create(ngraph::element::f16, ngraph::Shape{}, {eps_value});
         auto max = std::make_shared<ngraph::opset8::Maximum>(reduce_sum, eps_const);
         auto sqrt = std::make_shared<ngraph::opset8::Sqrt>(max);
@@ -76,7 +76,7 @@ TEST(TransformationTests, NormalizeL2DecomositionFusionWithAdd) {
         auto exp = ngraph::opset8::Constant::create(ngraph::element::f16, ngraph::Shape{}, {2.f});
         auto pow = std::make_shared<ngraph::opset8::Power>(input, exp);
         auto axes_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {0, 1});
-        auto reduce_sum = std::make_shared<ngraph::opset8::ReduceSum>(pow, axes_const);
+        auto reduce_sum = std::make_shared<ngraph::opset8::ReduceSum>(pow, axes_const, true);
         auto eps_const = ngraph::opset8::Constant::create(ngraph::element::f16, ngraph::Shape{}, {eps_value});
         auto max = std::make_shared<ngraph::opset8::Add>(reduce_sum, eps_const);
         auto sqrt = std::make_shared<ngraph::opset8::Sqrt>(max);

--- a/inference-engine/tests/functional/inference_engine/transformations/normalize_l2_decomposition_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/normalize_l2_decomposition_test.cpp
@@ -1,0 +1,91 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <memory>
+
+#include <ngraph/function.hpp>
+#include <ngraph/opsets/opset8.hpp>
+#include <ngraph/pass/manager.hpp>
+#include <transformations/op_conversions/normalize_l2_decomposition.hpp>
+#include <transformations/init_node_info.hpp>
+#include <transformations/utils/utils.hpp>
+
+#include "common_test_utils/ngraph_test_utils.hpp"
+
+using namespace testing;
+
+TEST(TransformationTests, NormalizeL2DecomositionFusionWithMax) {
+    std::shared_ptr<ngraph::Function> f, f_ref;
+    const float eps_value = 0.000099f;
+    {
+        auto input = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f16, ngraph::PartialShape::dynamic(3));
+        auto axes_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {0, 1});
+        auto normalize_l2 = std::make_shared<ngraph::opset8::NormalizeL2>(input, axes_const, eps_value, ngraph::op::EpsMode::MAX);
+
+        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{normalize_l2}, ngraph::ParameterVector{input});
+
+        ngraph::pass::Manager manager;
+        manager.register_pass<ngraph::pass::InitNodeInfo>();
+        manager.register_pass<ngraph::pass::NormalizeL2Decomposition>();
+        manager.run_passes(f);
+        ASSERT_NO_THROW(check_rt_info(f));
+    }
+
+    {
+        auto input = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f16, ngraph::PartialShape::dynamic(3));
+        auto exp = ngraph::opset8::Constant::create(ngraph::element::f16, ngraph::Shape{}, {2.f});
+        auto pow = std::make_shared<ngraph::opset8::Power>(input, exp);
+        auto axes_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {0, 1});
+        auto reduce_sum = std::make_shared<ngraph::opset8::ReduceSum>(pow, axes_const);
+        auto eps_const = ngraph::opset8::Constant::create(ngraph::element::f16, ngraph::Shape{}, {eps_value});
+        auto max = std::make_shared<ngraph::opset8::Maximum>(reduce_sum, eps_const);
+        auto sqrt = std::make_shared<ngraph::opset8::Sqrt>(max);
+        auto divide = std::make_shared<ngraph::opset8::Divide>(input, sqrt);
+
+        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{divide}, ngraph::ParameterVector{input});
+    }
+
+    const auto fc = FunctionsComparator::with_default().enable(FunctionsComparator::ATTRIBUTES);
+    const auto res = fc.compare(f, f_ref);
+    ASSERT_TRUE(res.valid) << res.message;
+}
+
+TEST(TransformationTests, NormalizeL2DecomositionFusionWithAdd) {
+    std::shared_ptr<ngraph::Function> f, f_ref;
+    const float eps_value = 0.000099f;
+    {
+        auto input = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f16, ngraph::PartialShape::dynamic(3));
+        auto axes_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {0, 1});
+        auto normalize_l2 = std::make_shared<ngraph::opset8::NormalizeL2>(input, axes_const, eps_value, ngraph::op::EpsMode::ADD);
+
+        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{normalize_l2}, ngraph::ParameterVector{input});
+
+        ngraph::pass::Manager manager;
+        manager.register_pass<ngraph::pass::InitNodeInfo>();
+        manager.register_pass<ngraph::pass::NormalizeL2Decomposition>();
+        manager.run_passes(f);
+        ASSERT_NO_THROW(check_rt_info(f));
+    }
+
+    {
+        auto input = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f16, ngraph::PartialShape::dynamic(3));
+        auto exp = ngraph::opset8::Constant::create(ngraph::element::f16, ngraph::Shape{}, {2.f});
+        auto pow = std::make_shared<ngraph::opset8::Power>(input, exp);
+        auto axes_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {0, 1});
+        auto reduce_sum = std::make_shared<ngraph::opset8::ReduceSum>(pow, axes_const);
+        auto eps_const = ngraph::opset8::Constant::create(ngraph::element::f16, ngraph::Shape{}, {eps_value});
+        auto max = std::make_shared<ngraph::opset8::Add>(reduce_sum, eps_const);
+        auto sqrt = std::make_shared<ngraph::opset8::Sqrt>(max);
+        auto divide = std::make_shared<ngraph::opset8::Divide>(input, sqrt);
+
+        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{divide}, ngraph::ParameterVector{input});
+    }
+
+    const auto fc = FunctionsComparator::with_default().enable(FunctionsComparator::ATTRIBUTES);
+    const auto res = fc.compare(f, f_ref);
+    ASSERT_TRUE(res.valid) << res.message;
+}

--- a/inference-engine/tests/functional/inference_engine/transformations/normalize_l2_fusion_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/normalize_l2_fusion_test.cpp
@@ -36,7 +36,7 @@ TEST(TransformationTests, NormalizeL2FusionWithMax) {
 
         ngraph::pass::Manager manager;
         manager.register_pass<ngraph::pass::InitNodeInfo>();
-        manager.register_pass<ngraph::pass::NormalizeL2FusionWithMax>();
+        manager.register_pass<ngraph::pass::NormalizeL2Fusion>();
         manager.run_passes(f);
         ASSERT_NO_THROW(check_rt_info(f));
     }
@@ -49,8 +49,9 @@ TEST(TransformationTests, NormalizeL2FusionWithMax) {
         f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{normalize_l2}, ngraph::ParameterVector{input});
     }
 
-    auto res = compare_functions(f, f_ref);
-    ASSERT_TRUE(res.first) << res.second;
+    const auto fc = FunctionsComparator::with_default().enable(FunctionsComparator::ATTRIBUTES);
+    const auto res = fc.compare(f, f_ref);
+    ASSERT_TRUE(res.valid) << res.message;
 }
 
 TEST(TransformationTests, NormalizeL2FusionWithMaxIncorrectExp) {
@@ -71,7 +72,7 @@ TEST(TransformationTests, NormalizeL2FusionWithMaxIncorrectExp) {
 
         ngraph::pass::Manager manager;
         manager.register_pass<ngraph::pass::InitNodeInfo>();
-        manager.register_pass<ngraph::pass::NormalizeL2FusionWithMax>();
+        manager.register_pass<ngraph::pass::NormalizeL2Fusion>();
         manager.run_passes(f);
     }
 
@@ -89,8 +90,9 @@ TEST(TransformationTests, NormalizeL2FusionWithMaxIncorrectExp) {
         f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{divide}, ngraph::ParameterVector{input});
     }
 
-    auto res = compare_functions(f, f_ref);
-    ASSERT_TRUE(res.first) << res.second;
+    const auto fc = FunctionsComparator::with_default().enable(FunctionsComparator::ATTRIBUTES);
+    const auto res = fc.compare(f, f_ref);
+    ASSERT_TRUE(res.valid) << res.message;
 }
 
 TEST(TransformationTests, NormalizeL2FusionWithMaxIncorrectEpsValueShape) {
@@ -110,7 +112,7 @@ TEST(TransformationTests, NormalizeL2FusionWithMaxIncorrectEpsValueShape) {
 
         ngraph::pass::Manager manager;
         manager.register_pass<ngraph::pass::InitNodeInfo>();
-        manager.register_pass<ngraph::pass::NormalizeL2FusionWithMax>();
+        manager.register_pass<ngraph::pass::NormalizeL2Fusion>();
         manager.run_passes(f);
     }
 
@@ -128,8 +130,9 @@ TEST(TransformationTests, NormalizeL2FusionWithMaxIncorrectEpsValueShape) {
         f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{divide}, ngraph::ParameterVector{input});
     }
 
-    auto res = compare_functions(f, f_ref);
-    ASSERT_TRUE(res.first) << res.second;
+    const auto fc = FunctionsComparator::with_default().enable(FunctionsComparator::ATTRIBUTES);
+    const auto res = fc.compare(f, f_ref);
+    ASSERT_TRUE(res.valid) << res.message;
 }
 
 TEST(TransformationTests, NormalizeL2FusionWithAdd) {
@@ -150,7 +153,7 @@ TEST(TransformationTests, NormalizeL2FusionWithAdd) {
 
         ngraph::pass::Manager manager;
         manager.register_pass<ngraph::pass::InitNodeInfo>();
-        manager.register_pass<ngraph::pass::NormalizeL2FusionWithAdd>();
+        manager.register_pass<ngraph::pass::NormalizeL2Fusion>();
         manager.run_passes(f);
         ASSERT_NO_THROW(check_rt_info(f));
     }
@@ -163,8 +166,9 @@ TEST(TransformationTests, NormalizeL2FusionWithAdd) {
         f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{normalize_l2}, ngraph::ParameterVector{input});
     }
 
-    auto res = compare_functions(f, f_ref);
-    ASSERT_TRUE(res.first) << res.second;
+    const auto fc = FunctionsComparator::with_default().enable(FunctionsComparator::ATTRIBUTES);
+    const auto res = fc.compare(f, f_ref);
+    ASSERT_TRUE(res.valid) << res.message;
 }
 
 TEST(TransformationTests, NormalizeL2FusionWithAddIncorrectExp) {
@@ -185,7 +189,7 @@ TEST(TransformationTests, NormalizeL2FusionWithAddIncorrectExp) {
 
         ngraph::pass::Manager manager;
         manager.register_pass<ngraph::pass::InitNodeInfo>();
-        manager.register_pass<ngraph::pass::NormalizeL2FusionWithAdd>();
+        manager.register_pass<ngraph::pass::NormalizeL2Fusion>();
         manager.run_passes(f);
         ASSERT_NO_THROW(check_rt_info(f));
     }
@@ -204,8 +208,9 @@ TEST(TransformationTests, NormalizeL2FusionWithAddIncorrectExp) {
         f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{divide}, ngraph::ParameterVector{input});
     }
 
-    auto res = compare_functions(f, f_ref);
-    ASSERT_TRUE(res.first) << res.second;
+    const auto fc = FunctionsComparator::with_default().enable(FunctionsComparator::ATTRIBUTES);
+    const auto res = fc.compare(f, f_ref);
+    ASSERT_TRUE(res.valid) << res.message;
 }
 
 TEST(TransformationTests, NormalizeL2FusionWithAddIncorrectEpsValueShape) {
@@ -225,7 +230,7 @@ TEST(TransformationTests, NormalizeL2FusionWithAddIncorrectEpsValueShape) {
 
         ngraph::pass::Manager manager;
         manager.register_pass<ngraph::pass::InitNodeInfo>();
-        manager.register_pass<ngraph::pass::NormalizeL2FusionWithMax>();
+        manager.register_pass<ngraph::pass::NormalizeL2Fusion>();
         manager.run_passes(f);
     }
 
@@ -243,6 +248,7 @@ TEST(TransformationTests, NormalizeL2FusionWithAddIncorrectEpsValueShape) {
         f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{divide}, ngraph::ParameterVector{input});
     }
 
-    auto res = compare_functions(f, f_ref);
-    ASSERT_TRUE(res.first) << res.second;
+    const auto fc = FunctionsComparator::with_default().enable(FunctionsComparator::ATTRIBUTES);
+    const auto res = fc.compare(f, f_ref);
+    ASSERT_TRUE(res.valid) << res.message;
 }


### PR DESCRIPTION
### Description
* Refactored NormlaizeL2 fusions to use single pattern
* Enabled NormalizeL2Fusion and LeakyReluFusion inside MO transformation pipeline
Ticket: XXX-62414

### Validation:
* Functional validation shows no regressions
* IR comparison validation shows no difference in IRs which is expected

### nGraph Transformations Transition Status
<details>
  <summary>Click to expand!</summary>

|Final MOC Pipeline|Enabled|
|---|:---:|
|InitNodeInfo|:white_check_mark:|
|ConstantFolding|:white_check_mark: |
|SimplifyShapeOfSubGraph|:white_check_mark:|
|RemoveFilteringBoxesBySize|:white_check_mark:|
|ConvertQuantizeDequantize|:white_check_mark:|
| | |
|TransposeFQReduction|:white_check_mark:|
|TransposeReduction|:white_check_mark:|
|TransposeFuse|:white_check_mark:|
|SplitSqueezeConcatFusion|:white_check_mark:|
| | |
|EliminateUnsqueezeGather|:white_check_mark:|
|NopElimination|:white_check_mark: |
| | |
|ConvertScatterElementsToScatter|:white_check_mark:|
|BroadcastElementwiseFusion|:white_check_mark:|
|SoftPlusFusion|:white_check_mark:|
|SoftPlusToMishFusion|:white_check_mark:|
|SwishFusion|:white_check_mark:|
|HSwishFusion|:white_check_mark:|
|HSigmoidFusion|:white_check_mark:|
|**NormalizeL2Fusion**|:tada: |
|ClampFusion|:white_check_mark:|
|PadFusion|:white_check_mark:|
|SoftmaxFusion| |
|MVNFusion|:white_check_mark:| 
|DilatedConvolutionConverter|:white_check_mark:|
|GeluFusion|:white_check_mark:|
|**LeakyReluFusion**|:tada:|
| | |
|BinarizeWeights|:white_check_mark:|
|ConvToBinaryConv|:white_check_mark:|
| | |
|BatchNormDecomposition|:white_check_mark: |
|ConvertDivide||
|ConvertSubtract|| 
| | |
|LinOpSequenceFusion|:white_check_mark: |
| | |
|ConvolutionMultiplyFusion|:white_check_mark: |
|GroupConvolutionMultiplyFusion|:white_check_mark: |
|ConvolutionBackpropDataMultiplyFusion|:white_check_mark: |
|GroupConvolutionBackpropDataMultiplyFusion|:white_check_mark: |

_Note: transformations marked as **bold** and with :tada: were enabled in current PR_
</details>