### PR TITLE
Fixed Eltwise split and batch size selection during 2d reshape, transpose bias

### DIFF
--- a/inference-engine/src/gna_plugin/backend/gna_limitations.hpp
+++ b/inference-engine/src/gna_plugin/backend/gna_limitations.hpp
@@ -6,6 +6,8 @@
 
 #include "dnn_types.h"
 #include <cstdint>
+#include <ie_algorithm.hpp>
+#include <ie_data.h>
 
 namespace GNAPluginNS {
 namespace GNALimitations {
@@ -105,5 +107,10 @@ public:
         const uint32_t strideH, const uint32_t strideW) const;
 };
 } // namespace Cnn2D
+
+inline size_t GetMinBatchToFitInBuffer(InferenceEngine::DataPtr input) {
+    auto total_size = InferenceEngine::details::product(std::begin(input->getDims()), std::end(input->getDims()));
+    return total_size / bufferMaxSize + 1;
+}
 } // namespace GNALimitations
 } // namespace GNAPluginNS

--- a/inference-engine/src/gna_plugin/gna_graph_compiler.cpp
+++ b/inference-engine/src/gna_plugin/gna_graph_compiler.cpp
@@ -708,7 +708,7 @@ void GNAGraphCompiler::PowerPrimitive(InferenceEngine::CNNLayerPtr layer) {
     auto input = layer->insData[0].lock();
 
     auto outputs = *layer->outData.begin();
-    auto reshaped_dims = Get2DReshapedData(input, 8)->getDims();
+    auto reshaped_dims = Get2DReshapedData(input, GNALimitations::GetMinBatchToFitInBuffer(input), 8)->getDims();
     const uint32_t noOfInputsDivisor = gnaFlags->input_low_precision ?
         GNALimitations::noOfInputsLowPrecDivisor : GNALimitations::noOfInputsDivisor;
     uint32_t num_rows_in = reshaped_dims[1];
@@ -932,7 +932,7 @@ void GNAGraphCompiler::CopyPrimitive(InferenceEngine::CNNLayerPtr layer) {
     auto inputs = layer->insData.begin()->lock();
     auto outputs = *layer->outData.begin();
 
-    auto reshaped_dims = Get2DReshapedData(inputs, 8)->getDims();
+    auto reshaped_dims = Get2DReshapedData(inputs, GNALimitations::GetMinBatchToFitInBuffer(inputs), 8)->getDims();
     uint32_t num_rows_in = reshaped_dims[1];
     uint32_t num_columns_in = reshaped_dims[0];
     uint32_t num_rows_out = num_rows_in;
@@ -1439,7 +1439,8 @@ void GNAGraphCompiler::AffinePrimitive(InferenceEngine::CNNLayerPtr layer, bool 
         noOfInputsDivisor = GNALimitations::noOfInputsLowPrecDivisor;
     }
 
-    auto input_data = HasTo2DReshapeData(layer) ? Get2DReshapedData(inputs, 8) : inputs;
+    auto input_data = HasTo2DReshapeData(layer) ?
+        Get2DReshapedData(inputs, GNALimitations::GetMinBatchToFitInBuffer(inputs), 8) : inputs;
     auto in_dims = input_data->getDims();
     auto batch_size = (in_dims.size() == 1) ? 1 : in_dims.front();
     uint32_t num_rows_in = InferenceEngine::details::product(in_dims) / batch_size;

--- a/inference-engine/src/gna_plugin/gna_groups.hpp
+++ b/inference-engine/src/gna_plugin/gna_groups.hpp
@@ -15,7 +15,9 @@ namespace GNAPluginNS {
  * @param input a pointer to data to be reshaped
  * @param maxZeroDimSize the maximum size of zero dimension
  */
-inline InferenceEngine::DataPtr Get2DReshapedData(InferenceEngine::DataPtr input, size_t maxZeroDimSize) {
+inline InferenceEngine::DataPtr Get2DReshapedData(InferenceEngine::DataPtr input, size_t minZeroDimSize,
+    size_t maxZeroDimSize) {
+    IE_ASSERT(minZeroDimSize > 0);
     auto dims = input->getDims();
     uint32_t numRowsIn = InferenceEngine::details::product(begin(dims), end(dims));
     uint32_t numColumnsIn = 1;
@@ -23,7 +25,7 @@ inline InferenceEngine::DataPtr Get2DReshapedData(InferenceEngine::DataPtr input
     if (numRowsIn % 8 == 0) {
         if (dims.size() >= 2 || dims[0] >= maxZeroDimSize) {
             size_t indexDivide = maxZeroDimSize;
-            while (indexDivide > 1) {
+            while (indexDivide > minZeroDimSize) {
                 if ((numRowsIn / 8) % indexDivide == 0) break;
                 --indexDivide;
             }
@@ -62,4 +64,5 @@ inline bool HasTo2DReshapeData(InferenceEngine::CNNLayerPtr layer) {
     // Don't reshape diagonallayers with bias connection
     return !GNAPluginNS::LayerInfo(getCreatorLayer(layer->insData.front().lock()).lock()).has32BOutput();
 }
+
 } // namespace GNAPluginNS

--- a/inference-engine/src/gna_plugin/layers/gna_split_layer.hpp
+++ b/inference-engine/src/gna_plugin/layers/gna_split_layer.hpp
@@ -45,4 +45,18 @@ public:
     };
     std::vector<SplitConnectedLayerInfo> splitOutputLayers;
 };
+
+// @brief Returns sizes of split outputs to split the input tensor to aligned parts not greater than the specified size
+static std::vector<uint32_t> GetAlignedSplitSizes(uint32_t totalSize, uint32_t maxSplitSize, uint32_t alignment = 64) {
+    std::vector<uint32_t> splitSizes;
+    uint32_t maxAlignedSplitSize = maxSplitSize - maxSplitSize % alignment;
+    uint32_t usedSize = 0;
+    while (usedSize < totalSize) {
+        uint32_t partSize = std::min(totalSize - usedSize, maxAlignedSplitSize);
+        splitSizes.push_back(partSize);
+        usedSize += partSize;
+    }
+    return splitSizes;
+}
+
 }  // namespace GNAPluginNS

--- a/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.cpp
+++ b/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.cpp
@@ -26,6 +26,7 @@
 #include <layers/gna_copy_layer.hpp>
 
 #include "backend/dnn_types.h"
+#include "backend/gna_limitations.hpp"
 #include "gna_plugin_log.hpp"
 #include "frontend/quantization.h"
 #include "frontend/quantized_layer_params.hpp"
@@ -86,8 +87,8 @@ static void insertDiagonalLayerBetween(InferenceEngine::CNNLayerPtr prevLayer,
     });
     IE_ASSERT(inputLayer != nullptr);
     size_t weightsSize = (LayerInfo(prevLayer).has32BOutput() || LayerInfo(inputLayer).isInput()) ?
-                         nextLayer->outData[0]->getDims().back() :
-                         Get2DReshapedData(nextLayer->outData[0], 8)->getDims()[1];
+        nextLayer->outData[0]->getDims().back() :
+        Get2DReshapedData(nextLayer->outData[0], GNALimitations::GetMinBatchToFitInBuffer(nextLayer->outData[0]), 8)->getDims()[1];
     std::vector<float> weightsValues(weightsSize, fillValue);
     IE_ASSERT(diagLayer != nullptr);
     diagLayer->_weights = make_shared_blob<float>(
@@ -1197,6 +1198,9 @@ void InsertConcatAligningFilterPass::run() {
                                             SizeVector({filterWeights.size()}),
                                             Layout::C));
                 concatAligningFilter->_weights->allocate();
+                if (!concatAligningFilter->_weights->buffer().as<float*>()) {
+                    THROW_GNA_EXCEPTION << "Failed to allocate weights of size " << filterWeights.size() << " for " << filterName;
+                }
 
                 CopyVectorToBlob(concatAligningFilter->_weights, filterWeights);
 
@@ -1453,14 +1457,20 @@ void EltwiseSplitOverChannelsPass::run() {
             THROW_GNA_LAYER_EXCEPTION(l) << "number of outputs expected to be 1";
         }
         auto oData = l->outData.front();
-        auto out_width = GetDataDimSize(oData, DataDimName::W);
-        auto totalElementsForOutput = details::product(oData->getDims().begin(), oData->getDims().end());
-        auto maxAffineElements = getPassManager()->getPolicy().GNAAffineDiagonalPolicy.limitedTo;
-        if (totalElementsForOutput <= maxAffineElements) {
+        auto oDims = oData->getDims();
+        auto totalElementsSize = details::product(std::begin(oDims), std::end(oDims));
+        if (totalElementsSize <= GNALimitations::bufferMaxSize) {
             continue;
         }
 
-        auto totalSplits = 1 + totalElementsForOutput / maxAffineElements;
+        auto firstValuableDim = std::find_if(std::begin(oDims), std::end(oDims), [](size_t val) { return val > 1; });
+        IE_ASSERT(firstValuableDim != std::end(oDims));
+        auto splittedElementsSize = *firstValuableDim;
+        auto splittedDimIx = std::distance(std::begin(oDims), firstValuableDim);
+
+        // Split output size should be multiple by 64 to avoid align filters insertion
+        auto splitSizes = GetAlignedSplitSizes(splittedElementsSize,
+            GNALimitations::bufferMaxSize * splittedElementsSize / totalElementsSize);
 
         pass_trace() << "transforming " << LAYER_NAME(l) << " by splitting it to multiple eltwise operations\n";
         auto quantized = InferenceEngine::getInjectedData<QuantizedLayerParams>(l);
@@ -1478,27 +1488,13 @@ void EltwiseSplitOverChannelsPass::run() {
             auto inputDesc = l->insData[kThEltwiseInput].lock()->getTensorDesc();
 
             // create split layer outputs
-            size_t usedElements = 0;
-            for (size_t i = 0; i < totalSplits; i++) {
-                SizeVector newDims;
-                size_t elements_num = std::min(totalElementsForOutput - usedElements,
-                        static_cast<size_t>(maxAffineElements));
-                if (inputDesc.getDims().size() == 2) {
-                    newDims = SizeVector{1, elements_num};
-                } else {
-                    elements_num = elements_num - elements_num % out_width;
-                    newDims = SizeVector{1, elements_num / out_width, out_width};
-                }
-
+            for (auto elementsNum : splitSizes) {
+                auto newDims = oDims;
+                newDims[splittedDimIx] = elementsNum;
                 auto newDesc = TensorDesc(inputDesc.getPrecision(), newDims, inputDesc.getLayout());
                 auto data = std::make_shared<Data>(l->name + "/" + std::to_string(kThEltwiseInput) + "/1", newDesc);
                 getCreatorLayer(data) = split;
                 split->outData.push_back(data);
-
-                usedElements += elements_num;
-                if (usedElements == totalElementsForOutput) {
-                    break;
-                }
             }
             // replacing connection X->eltwise to X->split
             auto oData = CNNLayerFindOutData(l, kThEltwiseInput);
@@ -1518,7 +1514,7 @@ void EltwiseSplitOverChannelsPass::run() {
         concat->outData.push_back(masterEltwise->outData.front());
         getCreatorLayer(masterEltwise->outData.front()) = concat;
 
-        for (size_t k = 0; k != totalSplits; k++) {
+        for (size_t k = 0; k != splitSizes.size(); k++) {
             auto eltwiseRaw = std::make_shared<EltwiseLayer>(
                     LayerParams{l->name + "/eltwise/" + std::to_string(k), "Eltwise", Precision::FP32});
             IE_ASSERT(eltwiseRaw != nullptr);
@@ -1577,7 +1573,9 @@ void SubstituteScaleShiftBroadCastPass::run() {
         if (was_reshaped) {
             dataDims = reshaped_data[insData->getName()];
         } else {
-            dataDims = HasTo2DReshapeData(l) ? Get2DReshapedData(insData, 8)->getDims() : insData->getDims();
+            dataDims = HasTo2DReshapeData(l) ?
+                Get2DReshapedData(insData, GNALimitations::GetMinBatchToFitInBuffer(insData), 8)->getDims() :
+                insData->getDims();
         }
 
         if (dataDims.size() <= 2) {

--- a/inference-engine/src/gna_plugin/transformations/convert_matmul_to_pointwise_convolution.cpp
+++ b/inference-engine/src/gna_plugin/transformations/convert_matmul_to_pointwise_convolution.cpp
@@ -7,6 +7,7 @@
 #include <ngraph/opsets/opset7.hpp>
 #include <ngraph/pattern/op/or.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
+#include <ngraph/rt_info.hpp>
 
 #include "layers/gna_permute.hpp"
 #include "backend/gna_limitations.hpp"

--- a/inference-engine/src/gna_plugin/transformations/convert_matmul_to_pointwise_convolution.cpp
+++ b/inference-engine/src/gna_plugin/transformations/convert_matmul_to_pointwise_convolution.cpp
@@ -17,6 +17,20 @@ NGRAPH_RTTI_DEFINITION(ConvertMatmulToPointWiseConvolution, "ConvertMatmulToPoin
 NGRAPH_RTTI_DEFINITION(ConvertMatmulWithBiasToPointWiseConvolution, "ConvertMatmulWithBiasToPointWiseConvolution", 0);
 NGRAPH_RTTI_DEFINITION(ConvertMatmulWithFqToPointWiseConvolution, "ConvertMatmulWithFqToPointWiseConvolution", 0);
 
+static bool BiasValidation(const ngraph::Output<ngraph::Node>& output) {
+    auto bias_output_shape = output.get_node()->get_output_shape(0);
+    if (bias_output_shape.size() > 4) {
+        gnalog() << "bias output shape (" << output.get_node()->get_friendly_name() << ") is more than 4\n";
+        return false;
+    }
+
+    if (bias_output_shape.size() == 1) {
+        return true;
+    }
+
+    return std::count_if(bias_output_shape.begin(), bias_output_shape.end(), [](size_t el){ return el > 1; }) < 2;
+}
+
 static std::tuple<bool, uint32_t, uint32_t, uint32_t> VerifyAndGetConvParams(std::shared_ptr<ngraph::Node> matmul_node) {
     auto input1_shape = matmul_node->get_input_shape(0);
     auto input2_shape = matmul_node->get_input_shape(1);
@@ -77,9 +91,24 @@ static bool Convert(std::shared_ptr<ngraph::Node> matmul_node,
     conv_node->set_friendly_name(base_name + "/conv");
 
     std::shared_ptr<ngraph::Node> root_node = matmul_node;
-    if (bias != nullptr) {
-         conv_node = std::make_shared<ngraph::opset7::Add>(conv_node, bias);
-         root_node = add;
+    if (bias) {
+        auto bias_output_shape = bias->get_output_shape(0);
+        std::shared_ptr<ngraph::Node> new_bias = bias;
+        if (bias_output_shape.size() > 1 || bias_output_shape.at(0) > 1) {
+            std::vector<size_t> axes(4, 1);
+            auto iter = std::find_if(bias_output_shape.begin(), bias_output_shape.end(), [](size_t value) { return value > 1; });
+            if (iter != bias_output_shape.end()) {
+                axes.at(1) = *iter;
+            }
+            new_bias = std::make_shared<ngraph::opset7::Constant>(
+                bias->get_output_element_type(0),
+                axes,
+                std::dynamic_pointer_cast<ngraph::opset7::Constant>(bias)->get_data_ptr());
+        }
+
+        conv_node = std::make_shared<ngraph::opset7::Add>(conv_node, new_bias);
+        ngraph::copy_runtime_info(transpose_before, conv_node);
+        root_node = add;
     }
 
     if (fq != nullptr) {
@@ -134,7 +163,7 @@ ConvertMatmulWithBiasToPointWiseConvolution::ConvertMatmulWithBiasToPointWiseCon
         ngraph::pattern::wrap_type<ngraph::opset7::Constant>()});
     auto second_input = std::make_shared<ngraph::pattern::op::Or>(ngraph::OutputVector{const_input, const_fq});
     auto matmul = ngraph::pattern::wrap_type<ngraph::opset7::MatMul>({ngraph::pattern::any_input(), second_input});
-    auto bias = ngraph::pattern::wrap_type<ngraph::opset7::Constant>();
+    auto bias = ngraph::pattern::wrap_type<ngraph::opset7::Constant>(BiasValidation);
     auto add = ngraph::pattern::wrap_type<ngraph::opset7::Add>({matmul, bias});
 
     ngraph::matcher_pass_callback callback = [=](ngraph::pattern::Matcher &m) {
@@ -156,7 +185,7 @@ ConvertMatmulWithFqToPointWiseConvolution::ConvertMatmulWithFqToPointWiseConvolu
         ngraph::pattern::wrap_type<ngraph::opset7::Constant>()});
     auto second_input = std::make_shared<ngraph::pattern::op::Or>(ngraph::OutputVector{const_input, const_fq});
     auto matmul = ngraph::pattern::wrap_type<ngraph::opset7::MatMul>({ngraph::pattern::any_input(), second_input});
-    auto bias = ngraph::pattern::wrap_type<ngraph::opset7::Constant>();
+    auto bias = ngraph::pattern::wrap_type<ngraph::opset7::Constant>(BiasValidation);
     auto add = ngraph::pattern::wrap_type<ngraph::opset7::Add>({matmul, bias});
     auto matmul_out = std::make_shared<ngraph::pattern::op::Or>(ngraph::OutputVector{add, matmul});
     auto out_fq = ngraph::pattern::wrap_type<ngraph::opset7::FakeQuantize>({matmul_out,

--- a/inference-engine/src/gna_plugin/transformations/split_convolution_with_large_buffer_size.cpp
+++ b/inference-engine/src/gna_plugin/transformations/split_convolution_with_large_buffer_size.cpp
@@ -11,28 +11,13 @@
 #include <ngraph/pattern/op/wrap_type.hpp>
 
 #include "backend/gna_limitations.hpp"
+#include "layers/gna_split_layer.hpp"
 
 using namespace GNAPluginNS;
 
 NGRAPH_RTTI_DEFINITION(SplitConvolution, "SplitConvolution", 0);
 NGRAPH_RTTI_DEFINITION(SplitConvolutionWithBias, "SplitConvolutionWithBias", 0);
 NGRAPH_RTTI_DEFINITION(SplitConvolutionWithFq, "SplitConvolutionWithFq", 0);
-
-static std::vector<int64_t> GetConvSplitSizes(std::shared_ptr<ngraph::Node> conv) {
-    uint32_t width = conv->get_input_shape(0).back();
-    uint32_t in_channels = conv->get_input_shape(0).at(1);
-    uint32_t usedWidth = 0;
-    std::vector<int64_t> split_sizes;
-    uint32_t width_max_size = GNALimitations::bufferMaxSize / in_channels;
-    width_max_size = width_max_size - width_max_size % 64;
-    while (usedWidth < width) {
-        uint32_t width_part = std::min(width - usedWidth, width_max_size);
-        split_sizes.push_back(width_part);
-        usedWidth += width_part;
-    }
-    IE_ASSERT(usedWidth == width);
-    return split_sizes;
-}
 
 static bool Convert(std::shared_ptr<ngraph::Node> conv,
                     std::shared_ptr<ngraph::Node> add,
@@ -44,15 +29,21 @@ static bool Convert(std::shared_ptr<ngraph::Node> conv,
         return false;
     }
 
-    auto split_sizes = GetConvSplitSizes(conv);
+    uint32_t width = conv->get_input_shape(0).back();
+    uint32_t in_channels = conv->get_input_shape(0).at(1);
+    auto split_sizes = GetAlignedSplitSizes(width, GNALimitations::bufferMaxSize / in_channels);
     IE_ASSERT(split_sizes.size() > 1);
+    std::vector<int64_t> split_sizes_casted(split_sizes.size());
+    std::transform(std::begin(split_sizes), std::end(split_sizes), std::begin(split_sizes_casted), [](uint32_t size) {
+        return static_cast<int64_t>(size);
+    });
 
     /* TODO check if it's NHWC convolution wrapped with transposes or all input dimensions except of width == 1,
         otherwise this split axis isn't supported */
     const int64_t width_axis = conv->get_input_shape(0).size() - 1;
     auto split_node = std::make_shared<ngraph::opset7::VariadicSplit>(conv->input_value(0),
         ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape({1}), std::vector<int64_t>{width_axis}),
-        ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape({split_sizes.size()}), split_sizes));
+        ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape({split_sizes_casted.size()}), split_sizes_casted));
     split_node->set_friendly_name(conv->get_friendly_name() + "/split");
     ngraph::OutputVector convOutputs;
     std::shared_ptr<ngraph::Node> root_node = fq ? fq : (add ? add : conv);

--- a/inference-engine/tests/functional/plugin/gna/pass_tests/eltwise_split_over_channels_pass.cpp
+++ b/inference-engine/tests/functional/plugin/gna/pass_tests/eltwise_split_over_channels_pass.cpp
@@ -54,8 +54,8 @@ protected:
         auto params = ngraph::builder::makeParams(ngPrc, { inputShape });
         auto const_mult2 = ngraph::builder::makeConstant<float>(ngPrc, inputShape, {-1.0f});
 
-        auto sum = ngraph::builder::makeEltwise(params[0], const_mult2, ngraph::helpers::EltwiseTypes::MULTIPLY);
-        function = std::make_shared<ngraph::Function>(sum, params, "EltwiseSplitOverChannelsPassTest");
+        auto mul = ngraph::builder::makeEltwise(params[0], const_mult2, ngraph::helpers::EltwiseTypes::MULTIPLY);
+        function = std::make_shared<ngraph::Function>(mul, params, "EltwiseSplitOverChannelsPassTest");
     }
 };
 
@@ -77,7 +77,8 @@ const std::vector<std::map<std::string, std::string>> configs = {
 
 const std::vector<std::vector<size_t>> inputShape = {
     {1, 67000},
-    {1, 500000}
+    {1, 500000},
+    {1, 936, 513}
 };
 
 INSTANTIATE_TEST_CASE_P(smoke_EltwiseSplitOverChennels, EltwiseSplitOverChannelsPassTest,

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/activation.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/activation.cpp
@@ -46,7 +46,7 @@ std::map<std::vector<size_t>, std::vector<std::vector<size_t>>> basic = {
         {{1, 8, 15, 128}, {{}}},
         {{1, 4, 4, 128}, {{}}},
         {{8}, {{}}},
-        {{5}, {{}}},
+        {{5}, {{}}}
 };
 
 const auto basicCases = ::testing::Combine(

--- a/inference-engine/tests/unit/gna/CMakeLists.txt
+++ b/inference-engine/tests/unit/gna/CMakeLists.txt
@@ -9,6 +9,8 @@ addIeTargetTest(
         ROOT ${CMAKE_CURRENT_SOURCE_DIR}
         LINK_LIBRARIES
             unitTestUtils
+            PRIVATE
+                ngraphFunctions
             GNAPlugin_test_static
         ADD_CPPLINT
         LABELS

--- a/inference-engine/tests/unit/gna/gna_get_2d_reshaped_data.cpp
+++ b/inference-engine/tests/unit/gna/gna_get_2d_reshaped_data.cpp
@@ -65,7 +65,7 @@ class Get2DReshapedDataTest : public ::testing::Test {
                            InferenceEngine::Layout layout) const {
         auto data = std::make_shared<InferenceEngine::Data>(input_name,
             InferenceEngine::TensorDesc(precision, input_shape.first, layout));
-        auto new_data = GNAPluginNS::Get2DReshapedData(data, max_batch_size);
+        auto new_data = GNAPluginNS::Get2DReshapedData(data, 1, max_batch_size);
         ASSERT_EQ(new_data->getDims(), input_shape.second);
         ASSERT_EQ(new_data->getPrecision(), precision);
         ASSERT_EQ(new_data->getLayout(), layout);

--- a/inference-engine/tests/unit/gna/gna_get_aligned_split_sizes.cpp
+++ b/inference-engine/tests/unit/gna/gna_get_aligned_split_sizes.cpp
@@ -1,0 +1,36 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include <gtest/gtest.h>
+// to suppress deprecated definition errors
+#define IMPLEMENT_INFERENCE_ENGINE_PLUGIN
+#include "layers/gna_split_layer.hpp"
+
+namespace {
+
+using GetAlignedSplitSizesData = std::tuple<
+    uint32_t,               // total size
+    uint32_t,               // maximum split size
+    uint32_t,               // alignment
+    std::vector<uint32_t>   // expected sizes
+>;
+
+const std::vector<GetAlignedSplitSizesData> data = {
+    GetAlignedSplitSizesData{1024, 100, 64, std::vector<uint32_t>(16, 64)},
+    GetAlignedSplitSizesData{151, 100, 64, std::vector<uint32_t>{64, 64, 23}},
+    GetAlignedSplitSizesData{151, 65, 32, std::vector<uint32_t>{64, 64, 23}},
+    GetAlignedSplitSizesData{151, 65, 1, std::vector<uint32_t>{65, 65, 21}}
+};
+
+TEST(GetAlignedSplitSizesTest, testAlignedSplitSizes) {
+    for (const auto &dataItem : data) {
+        auto sizes = GNAPluginNS::GetAlignedSplitSizes(std::get<0>(dataItem), std::get<1>(dataItem),
+                                                       std::get<2>(dataItem));
+        ASSERT_EQ(sizes, std::get<3>(dataItem));
+    }
+}
+
+} // namespace

--- a/inference-engine/tests/unit/gna/ngraph/transformations/gna_convert_matmul_to_pointwise_convolution.cpp
+++ b/inference-engine/tests/unit/gna/ngraph/transformations/gna_convert_matmul_to_pointwise_convolution.cpp
@@ -1,0 +1,455 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <tuple>
+#include <memory>
+
+#include "transformations/convert_matmul_to_pointwise_convolution.hpp"
+
+#include "common_test_utils/ngraph_test_utils.hpp"
+#include <ngraph/function.hpp>
+#include <ngraph/opsets/opset7.hpp>
+#include <ngraph/pass/manager.hpp>
+#include <transformations/init_node_info.hpp>
+#include "ngraph_functions/builders.hpp"
+
+namespace testing {
+
+namespace {
+
+struct Graph {
+    std::shared_ptr<ngraph::Function> createFunction();
+
+    std::shared_ptr<ngraph::opset7::Parameter> input_params;
+    std::shared_ptr<ngraph::op::Op> output;
+};
+
+std::shared_ptr<ngraph::Function> Graph::createFunction() {
+    auto result = std::make_shared<ngraph::opset7::Result>(output);
+    return std::make_shared<ngraph::Function>(ngraph::ResultVector{result},
+                                              ngraph::ParameterVector{input_params});
+}
+
+// ------------------------------------------------------------------------------------------------------------
+
+// TODO: use std::make_unique when C++14 will be available
+template <typename T, typename... Args>
+std::unique_ptr<T> createUnique(Args&&... args) {
+    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+
+class CreateGraphDecorator {
+public:
+    CreateGraphDecorator(std::unique_ptr<CreateGraphDecorator> prev_builder = nullptr) : prev_builder_(std::move(prev_builder)) {}
+    virtual ~CreateGraphDecorator() = default;
+    virtual Graph build() {
+        Graph graph;
+        if (prev_builder_)
+            graph = prev_builder_->build();
+        updateGraph(graph);
+        return graph;
+    }
+protected:
+    virtual void updateGraph(Graph&) = 0;
+private:
+    CreateGraphDecorator(const CreateGraphDecorator&) = delete;
+    CreateGraphDecorator& operator=(const CreateGraphDecorator&) = delete;
+private:
+    std::unique_ptr<CreateGraphDecorator> prev_builder_;
+};
+
+using CreateGraphDecoratorPtr = std::unique_ptr<CreateGraphDecorator>;
+
+class CreateBaseDecorator : public CreateGraphDecorator {
+public:
+    // always the first decorator => no prev_builder
+    CreateBaseDecorator(const ngraph::Shape& input_data_shape,
+                        const ngraph::Shape& input_const_shape) :
+                        CreateGraphDecorator(nullptr),
+                        input_data_shape_(input_data_shape),
+                        input_const_shape_(input_const_shape) {}
+protected:
+    Graph build() override;
+    void updateGraph(Graph&) override {}
+private:
+    const ngraph::Shape input_data_shape_;
+    const ngraph::Shape input_const_shape_;
+};
+
+Graph CreateBaseDecorator::build() {
+    Graph graph;
+    graph.input_params = std::make_shared<ngraph::opset7::Parameter>(ngraph::element::i64,
+                                                                     input_data_shape_);
+    graph.output = ngraph::opset7::Constant::create(ngraph::element::i64, input_const_shape_, {1});
+    return graph;
+}
+
+class CreateFakeQuantize : public CreateGraphDecorator {
+public:
+    CreateFakeQuantize(CreateGraphDecoratorPtr prev_builder = nullptr) : CreateGraphDecorator(std::move(prev_builder)) {}
+protected:
+    void updateGraph(Graph&) override;
+};
+
+std::shared_ptr<ngraph::opset7::FakeQuantize> createFakeQuantizeNode(std::shared_ptr<ngraph::op::Op> parent_node) {
+    auto input_low = ngraph::opset7::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {1});
+    auto input_high = ngraph::opset7::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {20});
+    auto output_low = ngraph::opset7::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {0});
+    auto output_high = ngraph::opset7::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {10});
+    return std::make_shared<ngraph::opset7::FakeQuantize>(parent_node, input_low,
+                                                          input_high, output_low,
+                                                          output_high, 11);
+}
+
+void CreateFakeQuantize::updateGraph(Graph& graph) {
+    graph.output = createFakeQuantizeNode(graph.output);
+}
+
+class CreateMatMul : public CreateGraphDecorator {
+public:
+    CreateMatMul(CreateGraphDecoratorPtr prev_builder = nullptr) : CreateGraphDecorator(std::move(prev_builder)) {}
+protected:
+    void updateGraph(Graph&) override;
+};
+
+void CreateMatMul::updateGraph(Graph& graph) {
+    auto matmul_node = std::make_shared<ngraph::opset7::MatMul>(graph.input_params, graph.output);
+    graph.output = matmul_node;
+}
+
+template<bool ONE_DIMENSIONAL, bool ONE_CHANNEL>
+class CreateAdd : public CreateGraphDecorator {
+public:
+    CreateAdd(CreateGraphDecoratorPtr prev_builder = nullptr) : CreateGraphDecorator(std::move(prev_builder)) {}
+protected:
+    void updateGraph(Graph&) override;
+};
+
+template<bool ONE_DIMENSIONAL, bool ONE_CHANNEL>
+void CreateAdd<ONE_DIMENSIONAL, ONE_CHANNEL>::updateGraph(Graph& graph) {
+    std::vector<size_t> axes(1, 1);
+    if (std::is_same<std::integral_constant<bool, ONE_CHANNEL>, std::integral_constant<bool, false>>::value) {
+        auto shape = graph.output->get_output_shape(0);
+        if (std::is_same<std::integral_constant<bool, ONE_DIMENSIONAL>, std::integral_constant<bool, false>>::value) {
+            axes.resize(shape.size(), 1);
+        }
+        axes.back() = shape.back();
+    }
+
+    auto bias = ngraph::builder::makeConstant<float>(ngraph::element::i64, axes, {}, true);
+    auto add_node = std::make_shared<ngraph::opset7::Add>(graph.output, bias);
+    graph.output = add_node;
+}
+
+template<typename DecorT, typename... DecorTs, typename std::enable_if<(sizeof...(DecorTs) == 0), bool>::type = true>
+CreateGraphDecoratorPtr createBuildDecorator(const ngraph::Shape& input_data_shape = ngraph::Shape{16, 8},
+                          const ngraph::Shape& input_const_shape = ngraph::Shape{8, 8}) {
+    CreateGraphDecoratorPtr build_decorator = createUnique<CreateBaseDecorator>(input_data_shape, input_const_shape);
+    return createUnique<DecorT>(std::move(build_decorator));
+}
+
+template<typename DecorT, typename... DecorTs, typename std::enable_if<(sizeof...(DecorTs) > 0), bool>::type = true>
+CreateGraphDecoratorPtr createBuildDecorator(const ngraph::Shape& input_data_shape = ngraph::Shape{16, 8},
+                          const ngraph::Shape& input_const_shape = ngraph::Shape{8, 8}) {
+    CreateGraphDecoratorPtr build_decorator = createBuildDecorator<DecorTs...>(input_data_shape, input_const_shape);
+    return createUnique<DecorT>(std::move(build_decorator));
+}
+
+template<typename DecorT, typename... DecorTs>
+Graph createTransformedGraph(const ngraph::Shape& input_data_shape = ngraph::Shape{16, 8},
+                             const ngraph::Shape& input_const_shape = ngraph::Shape{8, 8}) {
+    CreateGraphDecoratorPtr build_decorator = createBuildDecorator<DecorT, DecorTs...>(input_data_shape, input_const_shape);
+    return build_decorator->build();
+}
+
+// ------------------------------------------------------------------------------------------------------------
+
+template<bool ADD_CONST_FAKEQUANTIZE_NODE, bool INSERT_ADD_NODE, bool ONE_CHANNEL, bool ADD_OUT_FAKEQUANTIZE_NODE>
+Graph createReferenceGraph() {
+    Graph graph;
+
+    graph.input_params = std::make_shared<ngraph::opset7::Parameter>(ngraph::element::i64,
+                                                                     ngraph::Shape{16, 8});
+    auto constant_node = ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{8, 8}, {1});
+
+    auto const_reshape_before = std::make_shared<ngraph::opset7::Constant>(ngraph::element::Type_t::i64,
+                                                                           ngraph::Shape{4},
+                                                                           ngraph::Shape{1, 1, 16, 8});
+    auto reshape_before =  std::make_shared<ngraph::opset7::Reshape>(graph.input_params, const_reshape_before, false);
+
+    auto const_transpose_before = ngraph::opset7::Constant::create(ngraph::element::i64,
+                                                                   ngraph::Shape{4},
+                                                                   ngraph::Shape{0, 3, 1, 2});
+    auto transpose_before = std::make_shared<ngraph::opset7::Transpose>(reshape_before, const_transpose_before);
+
+    std::shared_ptr<ngraph::op::Op> parent_node = constant_node;
+    if (std::is_same<std::integral_constant<bool, ADD_CONST_FAKEQUANTIZE_NODE>, std::integral_constant<bool, true>>::value) {
+        parent_node = createFakeQuantizeNode(constant_node);
+    }
+
+    auto weights_reshape_const = std::make_shared<ngraph::opset7::Constant>(ngraph::element::Type_t::i64,
+                                                                            ngraph::Shape{4}, ngraph::Shape{8, 8, 1, 1});
+    auto weights_reshaped =  std::make_shared<ngraph::opset7::Reshape>(parent_node, weights_reshape_const, false);
+
+    auto conv_node = std::make_shared<ngraph::opset7::Convolution>(transpose_before,
+                                                                    weights_reshaped,
+                                                                    ngraph::Strides{1, 1},
+                                                                    ngraph::CoordinateDiff{0, 0},
+                                                                    ngraph::CoordinateDiff{0, 0},
+                                                                    ngraph::Strides{1, 1},
+                                                                    ngraph::op::PadType::VALID);
+
+    parent_node = conv_node;
+    if (std::is_same<std::integral_constant<bool, INSERT_ADD_NODE>, std::integral_constant<bool, true>>::value) {
+        std::vector<size_t> axes(1, 1);
+        if (std::is_same<std::integral_constant<bool, ONE_CHANNEL>, std::integral_constant<bool, false>>::value) {
+            axes.resize(4, 1);
+            axes[1] = 8;
+        }
+
+        auto bias = ngraph::builder::makeConstant<float>(ngraph::element::i64, axes, {}, true);
+        auto add_node = std::make_shared<ngraph::opset7::Add>(parent_node, bias);
+        parent_node = add_node;
+    }
+
+    if (std::is_same<std::integral_constant<bool, ADD_OUT_FAKEQUANTIZE_NODE>, std::integral_constant<bool, true>>::value) {
+        parent_node = createFakeQuantizeNode(parent_node);
+    }
+
+    auto const_transpose_after = ngraph::opset7::Constant::create(ngraph::element::i64,
+                                                                  ngraph::Shape{4},
+                                                                  ngraph::Shape{0, 2, 3, 1});
+    auto transpose_after = std::make_shared<ngraph::opset7::Transpose>(parent_node, const_transpose_after);
+
+    auto const_reshape_after = std::make_shared<ngraph::opset7::Constant>(ngraph::element::Type_t::i64,
+                                                                          ngraph::Shape{2},
+                                                                          ngraph::Shape{16, 8});
+    graph.output = std::make_shared<ngraph::opset7::Reshape>(transpose_after, const_reshape_after, false);
+
+    return graph;
+}
+
+// -------------------------------------------------------------------------------------------------------
+
+class ConvertMatmulToPointWiseConvolutionFixture: public CommonTestUtils::TestsCommon,
+                                                  public ::testing::WithParamInterface<std::tuple<Graph /* tranformed */,
+                                                                                                  Graph /* reference */,
+                                                                                                  ngraph::pass::Manager>> {
+public:
+    void SetUp() override;
+public:
+    std::shared_ptr<ngraph::Function> function, reference_function;
+    ngraph::pass::Manager pass_manager;
+};
+
+void ConvertMatmulToPointWiseConvolutionFixture::SetUp() {
+    // TODO: use auto & [transformed_graph, reference_graph] = this->GetParam() when C++17
+    Graph transformed_graph;
+    Graph reference_graph;
+    std::tie(transformed_graph, reference_graph, pass_manager) = this->GetParam();
+
+    function = transformed_graph.createFunction();
+    reference_function = reference_graph.createFunction();
+}
+
+void execute_test(std::shared_ptr<ngraph::Function> function, std::shared_ptr<ngraph::Function> reference_function, ngraph::pass::Manager& pass_manager) {
+    pass_manager.run_passes(function);
+    const FunctionsComparator func_comparator = FunctionsComparator::with_default().enable(FunctionsComparator::ATTRIBUTES);
+    const FunctionsComparator::Result result = func_comparator(function, reference_function);
+    ASSERT_TRUE(result.valid);
+}
+
+template <typename TransformationT>
+ngraph::pass::Manager createPassManager() {
+    ngraph::pass::Manager manager;
+    manager.register_pass<ngraph::pass::InitNodeInfo>();
+    manager.register_pass<TransformationT>();
+    return manager;
+}
+
+TEST_P(ConvertMatmulToPointWiseConvolutionFixture, CompareFunctions) {
+    execute_test(function, reference_function, pass_manager);
+}
+
+namespace {
+    constexpr bool AddConstFakeQuantizeNode = true;
+    constexpr bool InsertAddNode = true;
+    constexpr bool OneDimensional = true;
+    constexpr bool OneChannel = true;
+    constexpr bool AddOutFakeQuantizeNode = true;
+}
+
+INSTANTIATE_TEST_SUITE_P(ConvertMatmulToPointWiseConvolutionTestSuite, ConvertMatmulToPointWiseConvolutionFixture,
+    ::testing::Values(
+        std::make_tuple(
+            createTransformedGraph<CreateMatMul>(),
+            createReferenceGraph<!AddConstFakeQuantizeNode, !InsertAddNode, !OneChannel, !AddOutFakeQuantizeNode>(),
+            createPassManager<GNAPluginNS::ConvertMatmulToPointWiseConvolution>()),
+        std::make_tuple(createTransformedGraph<CreateMatMul, CreateFakeQuantize>(),
+            createReferenceGraph<AddConstFakeQuantizeNode, !InsertAddNode, !OneChannel, !AddOutFakeQuantizeNode>(),
+            createPassManager<GNAPluginNS::ConvertMatmulToPointWiseConvolution>()),
+        std::make_tuple(createTransformedGraph<CreateAdd<OneDimensional, OneChannel>, CreateMatMul>(),
+            createReferenceGraph<!AddConstFakeQuantizeNode, InsertAddNode, OneChannel, !AddOutFakeQuantizeNode>(),
+            createPassManager<GNAPluginNS::ConvertMatmulWithBiasToPointWiseConvolution>()),
+        std::make_tuple(createTransformedGraph<CreateAdd<OneDimensional, !OneChannel>, CreateMatMul>(),
+            createReferenceGraph<!AddConstFakeQuantizeNode, InsertAddNode, !OneChannel, !AddOutFakeQuantizeNode>(),
+            createPassManager<GNAPluginNS::ConvertMatmulWithBiasToPointWiseConvolution>()),
+        std::make_tuple(createTransformedGraph<CreateAdd<!OneDimensional, !OneChannel>, CreateMatMul>(),
+            createReferenceGraph<!AddConstFakeQuantizeNode, InsertAddNode, !OneChannel, !AddOutFakeQuantizeNode>(),
+            createPassManager<GNAPluginNS::ConvertMatmulWithBiasToPointWiseConvolution>()),
+        std::make_tuple(createTransformedGraph<CreateAdd<OneDimensional, OneChannel>, CreateMatMul, CreateFakeQuantize>(),
+            createReferenceGraph<AddConstFakeQuantizeNode, InsertAddNode, OneChannel, !AddOutFakeQuantizeNode>(),
+            createPassManager<GNAPluginNS::ConvertMatmulWithBiasToPointWiseConvolution>()),
+        std::make_tuple(createTransformedGraph<CreateAdd<OneDimensional, !OneChannel>, CreateMatMul, CreateFakeQuantize>(),
+            createReferenceGraph<AddConstFakeQuantizeNode, InsertAddNode, !OneChannel, !AddOutFakeQuantizeNode>(),
+            createPassManager<GNAPluginNS::ConvertMatmulWithBiasToPointWiseConvolution>()),
+        std::make_tuple(createTransformedGraph<CreateAdd<!OneDimensional, !OneChannel>, CreateMatMul, CreateFakeQuantize>(),
+            createReferenceGraph<AddConstFakeQuantizeNode, InsertAddNode, !OneChannel, !AddOutFakeQuantizeNode>(),
+            createPassManager<GNAPluginNS::ConvertMatmulWithBiasToPointWiseConvolution>()),
+        std::make_tuple(createTransformedGraph<CreateFakeQuantize, CreateAdd<OneDimensional, OneChannel>, CreateMatMul>(),
+            createReferenceGraph<!AddConstFakeQuantizeNode, InsertAddNode, OneChannel, AddOutFakeQuantizeNode>(),
+            createPassManager<GNAPluginNS::ConvertMatmulWithFqToPointWiseConvolution>()),
+        std::make_tuple(createTransformedGraph<CreateFakeQuantize, CreateAdd<OneDimensional, !OneChannel>, CreateMatMul>(),
+            createReferenceGraph<!AddConstFakeQuantizeNode, InsertAddNode, !OneChannel, AddOutFakeQuantizeNode>(),
+            createPassManager<GNAPluginNS::ConvertMatmulWithFqToPointWiseConvolution>()),
+        std::make_tuple(createTransformedGraph<CreateFakeQuantize, CreateAdd<!OneDimensional, !OneChannel>, CreateMatMul>(),
+            createReferenceGraph<!AddConstFakeQuantizeNode, InsertAddNode, !OneChannel, AddOutFakeQuantizeNode>(),
+            createPassManager<GNAPluginNS::ConvertMatmulWithFqToPointWiseConvolution>()),
+        std::make_tuple(createTransformedGraph<CreateFakeQuantize, CreateAdd<OneDimensional, OneChannel>, CreateMatMul, CreateFakeQuantize>(),
+            createReferenceGraph<AddConstFakeQuantizeNode, InsertAddNode, OneChannel, AddOutFakeQuantizeNode>(),
+            createPassManager<GNAPluginNS::ConvertMatmulWithFqToPointWiseConvolution>()),
+        std::make_tuple(createTransformedGraph<CreateFakeQuantize, CreateAdd<OneDimensional, !OneChannel>, CreateMatMul, CreateFakeQuantize>(),
+            createReferenceGraph<AddConstFakeQuantizeNode, InsertAddNode, !OneChannel, AddOutFakeQuantizeNode>(),
+            createPassManager<GNAPluginNS::ConvertMatmulWithFqToPointWiseConvolution>()),
+        std::make_tuple(createTransformedGraph<CreateFakeQuantize, CreateAdd<!OneDimensional, !OneChannel>, CreateMatMul, CreateFakeQuantize>(),
+            createReferenceGraph<AddConstFakeQuantizeNode, InsertAddNode, !OneChannel, AddOutFakeQuantizeNode>(),
+            createPassManager<GNAPluginNS::ConvertMatmulWithFqToPointWiseConvolution>()),
+        std::make_tuple(createTransformedGraph<CreateFakeQuantize, CreateMatMul>(),
+            createReferenceGraph<!AddConstFakeQuantizeNode, !InsertAddNode, !OneChannel, AddOutFakeQuantizeNode>(),
+            createPassManager<GNAPluginNS::ConvertMatmulWithFqToPointWiseConvolution>()),
+        std::make_tuple(createTransformedGraph<CreateFakeQuantize, CreateMatMul, CreateFakeQuantize>(),
+            createReferenceGraph<AddConstFakeQuantizeNode, !InsertAddNode, !OneChannel, AddOutFakeQuantizeNode>(),
+            createPassManager<GNAPluginNS::ConvertMatmulWithFqToPointWiseConvolution>())));
+
+// -------------------------------------------------------------------------------------------------------
+
+class ITransformedGraphFactory {
+public:
+    virtual ~ITransformedGraphFactory() = default;
+    virtual Graph createGraph(const ngraph::Shape& input_data_shape,
+                              const ngraph::Shape& input_const_shape) = 0;
+};
+
+template<typename DecorT, typename... DecorTs>
+class TransformedGraphFactory : public ITransformedGraphFactory {
+public:
+    TransformedGraphFactory() = default;
+
+    Graph createGraph(const ngraph::Shape& input_data_shape,
+                      const ngraph::Shape& input_const_shape) override {
+        return createTransformedGraph<DecorT, DecorTs...>(input_data_shape, input_const_shape);
+    }
+private:
+    TransformedGraphFactory(const TransformedGraphFactory&) = delete;
+    TransformedGraphFactory& operator=(const TransformedGraphFactory&) = delete;
+};
+
+struct FixtureData {
+    std::shared_ptr<ITransformedGraphFactory> graph_factory;
+    ngraph::pass::Manager pass_manager;
+
+    template<typename TransformationT, typename DecorT, typename... DecorTs>
+    static FixtureData create() {
+        FixtureData fixture_data;
+        fixture_data.graph_factory = std::make_shared<TransformedGraphFactory<DecorT, DecorTs...>>();
+        fixture_data.pass_manager = createPassManager<TransformationT>();
+        return fixture_data;
+    }
+};
+
+using FixtureInputShapes = std::tuple<ngraph::Shape /* input data */, ngraph::Shape /* input const */>;
+
+class ConvertMatmulToPointWiseConvolutionInvalidInputFixture: public CommonTestUtils::TestsCommon,
+                                                              public ::testing::WithParamInterface<std::tuple<FixtureData,
+                                                                                                              FixtureInputShapes>> {
+public:
+    void SetUp() override;
+public:
+    std::shared_ptr<ngraph::Function> function;
+    ngraph::pass::Manager pass_manager;
+};
+
+void ConvertMatmulToPointWiseConvolutionInvalidInputFixture::SetUp() {
+    // TODO: use auto & [fixture_data, input_shapes] = this->GetParam() when C++17
+    FixtureData fixture_data;
+    FixtureInputShapes input_shapes;
+    std::tie(fixture_data, input_shapes) = this->GetParam();
+
+    ngraph::Shape input_data, input_const;
+    std::tie(input_data, input_const) = input_shapes;
+
+    function = fixture_data.graph_factory->createGraph(input_data, input_const).createFunction();
+    pass_manager = fixture_data.pass_manager;
+}
+
+void execute_test_cloned_function(std::shared_ptr<ngraph::Function> function,
+                                  ngraph::pass::Manager& pass_manager) {
+    std::shared_ptr<ngraph::Function> reference_function = ngraph::clone_function(*function);
+    pass_manager.run_passes(function);
+    const FunctionsComparator func_comparator = FunctionsComparator::with_default().enable(FunctionsComparator::ATTRIBUTES);
+    const FunctionsComparator::Result result = func_comparator(function, reference_function);
+    ASSERT_TRUE(result.valid);
+}
+
+std::vector<FixtureData> transform_types = {
+    FixtureData::create<GNAPluginNS::ConvertMatmulToPointWiseConvolution,
+                        CreateMatMul>(),
+    FixtureData::create<GNAPluginNS::ConvertMatmulToPointWiseConvolution,
+                        CreateMatMul,
+                        CreateFakeQuantize>(),
+    FixtureData::create<GNAPluginNS::ConvertMatmulWithBiasToPointWiseConvolution,
+                        CreateAdd<false, false>,
+                        CreateMatMul>(),
+    FixtureData::create<GNAPluginNS::ConvertMatmulWithBiasToPointWiseConvolution,
+                        CreateAdd<false, false>,
+                        CreateMatMul,
+                        CreateFakeQuantize>(),
+    FixtureData::create<GNAPluginNS::ConvertMatmulWithFqToPointWiseConvolution,
+                        CreateFakeQuantize,
+                        CreateAdd<false, false>,
+                        CreateMatMul>(),
+    FixtureData::create<GNAPluginNS::ConvertMatmulWithFqToPointWiseConvolution,
+                        CreateFakeQuantize,
+                        CreateAdd<false, false>,
+                        CreateMatMul,
+                        CreateFakeQuantize>(),
+    FixtureData::create<GNAPluginNS::ConvertMatmulWithFqToPointWiseConvolution,
+                        CreateFakeQuantize,
+                        CreateMatMul>(),
+    FixtureData::create<GNAPluginNS::ConvertMatmulWithFqToPointWiseConvolution,
+                        CreateFakeQuantize,
+                        CreateMatMul,
+                        CreateFakeQuantize>()
+};
+
+std::vector<FixtureInputShapes> input_shapes = {
+    std::make_tuple(ngraph::Shape{16, 16, 16}, ngraph::Shape{16, 16, 16}),
+    std::make_tuple(ngraph::Shape{16, 9}, ngraph::Shape{9, 9}),
+    std::make_tuple(ngraph::Shape{16, 65533}, ngraph::Shape{65533, 2}),
+    std::make_tuple(ngraph::Shape{16, 769}, ngraph::Shape{769, 2})
+};
+
+TEST_P(ConvertMatmulToPointWiseConvolutionInvalidInputFixture, CompareFunctions) {
+    execute_test_cloned_function(function, pass_manager);
+}
+
+INSTANTIATE_TEST_SUITE_P(ConvertMatmulToPointWiseConvolutionInvalidInputTestSuite, ConvertMatmulToPointWiseConvolutionInvalidInputFixture,
+                         ::testing::Combine(::testing::ValuesIn(transform_types),
+                                            ::testing::ValuesIn(input_shapes)));
+
+} // namespace
+
+} // namespace testing

--- a/inference-engine/tests/unit/gna/ngraph/transformations/gna_convert_matmul_to_pointwise_convolution.cpp
+++ b/inference-engine/tests/unit/gna/ngraph/transformations/gna_convert_matmul_to_pointwise_convolution.cpp
@@ -282,7 +282,7 @@ namespace {
     constexpr bool AddOutFakeQuantizeNode = true;
 }
 
-INSTANTIATE_TEST_SUITE_P(ConvertMatmulToPointWiseConvolutionTestSuite, ConvertMatmulToPointWiseConvolutionFixture,
+INSTANTIATE_TEST_CASE_P(ConvertMatmulToPointWiseConvolutionTestSuite, ConvertMatmulToPointWiseConvolutionFixture,
     ::testing::Values(
         std::make_tuple(
             createTransformedGraph<CreateMatMul>(),
@@ -446,8 +446,8 @@ TEST_P(ConvertMatmulToPointWiseConvolutionInvalidInputFixture, CompareFunctions)
     execute_test_cloned_function(function, pass_manager);
 }
 
-INSTANTIATE_TEST_SUITE_P(ConvertMatmulToPointWiseConvolutionInvalidInputTestSuite, ConvertMatmulToPointWiseConvolutionInvalidInputFixture,
-                         ::testing::Combine(::testing::ValuesIn(transform_types),
+INSTANTIATE_TEST_CASE_P(ConvertMatmulToPointWiseConvolutionInvalidInputTestSuite, ConvertMatmulToPointWiseConvolutionInvalidInputFixture,
+                        ::testing::Combine(::testing::ValuesIn(transform_types),
                                             ::testing::ValuesIn(input_shapes)));
 
 } // namespace


### PR DESCRIPTION
### Details:
 - During the transformation, the input data is transposed to NCHW before Convolution, and the bias data is not. This leads to an error when adding data from the Convolution layer and the bias.
 - if Eltwise layer buffer exceeds limitations it is splited into parts. These parts should be 64-aligned to avoid align filters insertion.
 - Some layers which shape isn't sufficient for calculations (SyntheticScaleShift, Copy, Power) are reshaped to have the most optimized batch size and 8-aligned elements size to avoid padding. But in some cases shapes which allow to avoid padding don't allow to fit them into input buffer. Allow to create shapes required padding in the case if they can't be fit into the buffer otherwise.
 - Added tests for these changes.

### Tickets:
62284
