### PR TITLE
MaxPool-8: pads_value attribute removal from the operator definition

### DIFF
--- a/ngraph/core/include/ngraph/op/max_pool.hpp
+++ b/ngraph/core/include/ngraph/op/max_pool.hpp
@@ -122,7 +122,7 @@ public:
 
 private:
     Strides m_dilations;
-    element::Type m_index_element_type{element::i32};
+    element::Type m_index_element_type{element::i64};
     int64_t m_axis{0};
 };
 }  // namespace v8

--- a/ngraph/core/include/ngraph/op/max_pool.hpp
+++ b/ngraph/core/include/ngraph/op/max_pool.hpp
@@ -89,8 +89,7 @@ public:
             const op::RoundingType rounding_type = op::RoundingType::FLOOR,
             const PadType auto_pad = op::PadType::EXPLICIT,
             const element::Type index_element_type = element::i64,
-            const int64_t axis = 0,
-            const float pads_value = -std::numeric_limits<float>::infinity());
+            const int64_t axis = 0);
 
     bool visit_attributes(AttributeVisitor& visitor) override;
     void validate_and_infer_types() override;
@@ -121,19 +120,10 @@ public:
         m_axis = axis;
     }
 
-    // \return The value stored in the padding cells.
-    float get_pads_value() const {
-        return m_pads_value;
-    }
-    void set_pads_value(const float pads_value) {
-        m_pads_value = pads_value;
-    }
-
 private:
     Strides m_dilations;
     element::Type m_index_element_type{element::i32};
     int64_t m_axis{0};
-    float m_pads_value{-std::numeric_limits<float>::infinity()};
 };
 }  // namespace v8
 }  // namespace op

--- a/ngraph/core/src/op/max_pool.cpp
+++ b/ngraph/core/src/op/max_pool.cpp
@@ -171,13 +171,11 @@ op::v8::MaxPool::MaxPool(const Output<Node>& arg,
                          const op::RoundingType rounding_type,
                          const PadType auto_pad,
                          const element::Type index_element_type,
-                         const int64_t axis,
-                         const float pads_value)
+                         const int64_t axis)
     : op::util::MaxPoolBase(arg, strides, pads_begin, pads_end, kernel, rounding_type, auto_pad),
       m_dilations{dilations},
       m_index_element_type{index_element_type},
-      m_axis{axis},
-      m_pads_value{pads_value} {
+      m_axis{axis} {
     constructor_validate_and_infer_types();
 }
 
@@ -192,7 +190,6 @@ bool ngraph::op::v8::MaxPool::visit_attributes(AttributeVisitor& visitor) {
     visitor.on_attribute("auto_pad", m_auto_pad);
     visitor.on_attribute("index_element_type", m_index_element_type);
     visitor.on_attribute("axis", m_axis);
-    visitor.on_attribute("pads_value", m_pads_value);
     return true;
 }
 
@@ -224,6 +221,5 @@ shared_ptr<Node> op::v8::MaxPool::clone_with_new_inputs(const OutputVector& new_
                                     m_rounding_type,
                                     m_auto_pad,
                                     m_index_element_type,
-                                    m_axis,
-                                    m_pads_value);
+                                    m_axis);
 }


### PR DESCRIPTION
Adjusting the op to match latest specification changes https://github.com/openvinotoolkit/openvino/pull/5359 