### PR TITLE
[GPU] Fix Klockwork issue in loop_inst.h

### DIFF
--- a/inference-engine/thirdparty/clDNN/src/include/loop_inst.h
+++ b/inference-engine/thirdparty/clDNN/src/include/loop_inst.h
@@ -381,39 +381,39 @@ public:
         size_t total_bytes;
 
         backedge_memory_mapping(
-            std::shared_ptr<primitive_inst> from_primitive, std::shared_ptr<primitive_inst> to_primitive,
-            std::vector<memory::ptr> from_mems, memory::ptr initial_mem, cldnn::stream& stream, backedge_type type = CONCAT_OUTPUT):
-            from_primitive(from_primitive),
-            to_primitive(to_primitive),
-            from_mems(from_mems),
-            initial_mem(initial_mem),
-            stream(stream),
-            type(type),
+            std::shared_ptr<primitive_inst> _from_primitive, std::shared_ptr<primitive_inst> _to_primitive,
+            std::vector<memory::ptr> _from_mems, memory::ptr _initial_mem, cldnn::stream& _stream, backedge_type _type = CONCAT_OUTPUT):
+            from_primitive(_from_primitive),
+            to_primitive(_to_primitive),
+            from_mems(_from_mems),
+            initial_mem(_initial_mem),
+            stream(_stream),
+            type(_type),
             total_bytes(initial_mem->get_layout().bytes_count()) {
                 validate_backedge_memory();
             }
 
         backedge_memory_mapping(
-            std::shared_ptr<primitive_inst> from_primitive, std::shared_ptr<primitive_inst> to_primitive,
-            memory::ptr from_mem, memory::ptr initial_mem, cldnn::stream& stream, backedge_type type = SINGLE_SHARED):
-            from_primitive(from_primitive),
-            to_primitive(to_primitive),
-            from_mems{from_mem},
-            initial_mem(initial_mem),
-            stream(stream),
-            type(type),
+            std::shared_ptr<primitive_inst> _from_primitive, std::shared_ptr<primitive_inst> _to_primitive,
+            memory::ptr _from_mem, memory::ptr _initial_mem, cldnn::stream& _stream, backedge_type _type = SINGLE_SHARED):
+            from_primitive(_from_primitive),
+            to_primitive(_to_primitive),
+            from_mems{_from_mem},
+            initial_mem(_initial_mem),
+            stream(_stream),
+            type(_type),
             total_bytes(initial_mem->get_layout().bytes_count()) {
                 validate_backedge_memory();
             }
 
         backedge_memory_mapping(
-            std::shared_ptr<primitive_inst> from_primitive, std::shared_ptr<primitive_inst> to_primitive,
-            memory::ptr initial_mem, cldnn::stream& stream, backedge_type type = SINGLE):
-            from_primitive(from_primitive),
-            to_primitive(to_primitive),
-            initial_mem(initial_mem),
-            stream(stream),
-            type(type),
+            std::shared_ptr<primitive_inst> _from_primitive, std::shared_ptr<primitive_inst> _to_primitive,
+            memory::ptr _initial_mem, cldnn::stream& _stream, backedge_type _type = SINGLE):
+            from_primitive(_from_primitive),
+            to_primitive(_to_primitive),
+            initial_mem(_initial_mem),
+            stream(_stream),
+            type(_type),
             total_bytes(initial_mem->get_layout().bytes_count()) {
                 validate_backedge_memory();
             }


### PR DESCRIPTION
### Details:
 - *Fix Klockwork issues in loop_inst.h*
 - *Klockwork issue:* [*Variable 'initial_mem' is assigned to self*](https://klocwork-inn4.devtools.intel.com:8090/review/insight-review.html#issuedetails_goto:offset=0,problemid=48471,project=openvino_develop_windows,searchquery=owner%253A%252B%2522Ahn%252C+Paul+Y%2522+status%253AAnalyze%252C%252BFix+-file%253A%255C_deps%255C%252C%255Cpugixml%255C%252C%255Cgflags%255C%252C%255Cade%255C%252C%255Cfluid%255C%252C%255Cmkl-dnn%255C%252C%255Cprotobuf%255C%252C%255Cstb_lib%255C%252C%255Cie_bridges%255C%252C%255Cgapi_sipp%255C%252C%255Cdldt-tests-closed%255C%252C%255Ctests%255C%252C%255Ctest%255C%252C%255Copencv%255C%252C%255Ctests_deprecated%255C%252C%255Cgtest%255C%252C%255Conednn-plugin%255Cdnnl%255C%252C%255CCMakeFiles%255C%252C%255Cinference_engine%255C*.cxx%252C%255Cpybind11%255C%252C%255Copen_model_zoo%255Cdemos%255C%252C%255Ckmb-plugin%255Cthirdparty%255Cflatbuffers%255C%252Ckmb-plugin%255Cthirdparty%255Cllvm-project%252C%255Cdependencies%255Ctbb%255C%252C%255Cbuild%255Cpkg_layout%255C%252C%255Ckmb_plugin%255Cthirdparty%255Cllvm-project%255C%252C%255Coffline_transformations%255C*.cxx%252C%255Copenvino%255Cthirdparty%255Cxbyak%255C%252C%255Copenvino%255Cthirdparty%255Czlib%255C%252C%255Cboost%255C%252C%255Clevel-zero%255C,sortcolumn=id,sortdirection=ASC,start=0,view_id=1)

### Tickets:
 - *ticket-id*
