### PR TITLE
[GNA] Fix order of SwapMatMulInput transformations

### DIFF
--- a/inference-engine/src/gna_plugin/gna_plugin.cpp
+++ b/inference-engine/src/gna_plugin/gna_plugin.cpp
@@ -704,9 +704,9 @@ void GNAPlugin::LoadNetwork(CNNNetwork & _network) {
         manager.register_pass<SplitConvolutionWithBias>();
         manager.register_pass<SplitConvolution>();
         manager.register_pass<HandleTransposesAroundMatMul>();
-        manager.register_pass<SwapInputMatMul>();
-        manager.register_pass<SwapInputMatMulWithBias>();
         manager.register_pass<SwapInputMatMulWithFq>();
+        manager.register_pass<SwapInputMatMulWithBias>();
+        manager.register_pass<SwapInputMatMul>();
         manager.register_pass<InsertTransposeAfterConvOrPool>();
         manager.register_pass<ReorderActivationAndPooling>();
         manager.register_pass<ngraph::pass::ConvertOpSet3ToOpSet2>();


### PR DESCRIPTION
### Details:
 - Invalid order of SwapMatMulInput  transformations (one with the longest matcher pattern should be the first)

### Tickets:

