### PR TITLE
[GNA] Set input scale factors for imported model (#7139)

### DIFF
--- a/inference-engine/samples/speech_sample/main.cpp
+++ b/inference-engine/samples/speech_sample/main.cpp
@@ -621,8 +621,7 @@ int main(int argc, char* argv[]) {
 
             for (size_t i = 0; i < scaleFactorInput.size(); ++i) {
                 slog::info << "For input " << i << " using scale factor of " << scaleFactorInput[i] << slog::endl;
-                std::string scaleFactorConfigKey =
-                    GNA_CONFIG_KEY(SCALE_FACTOR) + std::string("_") + std::to_string(i);
+                std::string scaleFactorConfigKey = GNA_CONFIG_KEY(SCALE_FACTOR) + std::string("_") + std::to_string(i);
                 gnaPluginConfig[scaleFactorConfigKey] = scaleFactorInput[i];
             }
         } else {

--- a/inference-engine/samples/speech_sample/main.cpp
+++ b/inference-engine/samples/speech_sample/main.cpp
@@ -608,20 +608,22 @@ int main(int argc, char* argv[]) {
 
         if (FLAGS_q.compare("user") == 0) {
             if (!FLAGS_rg.empty()) {
-                slog::warn << "Custom scale factor will be ignored - using scale factor from provided imported gna model: " << FLAGS_rg << slog::endl;
-            } else {
-                auto scaleFactorInput = ParseScaleFactors(FLAGS_sf);
-                if (numInputFiles != scaleFactorInput.size()) {
-                    std::string errMessage("Incorrect command line for multiple inputs: " + std::to_string(scaleFactorInput.size()) +
-                                           " scale factors provided for " + std::to_string(numInputFiles) + " input files.");
-                    throw std::logic_error(errMessage);
-                }
+                slog::warn << "Custom scale factor will be used for imported gna model: " << FLAGS_rg << slog::endl;
+            }
 
-                for (size_t i = 0; i < scaleFactorInput.size(); ++i) {
-                    slog::info << "For input " << i << " using scale factor of " << scaleFactorInput[i] << slog::endl;
-                    std::string scaleFactorConfigKey = GNA_CONFIG_KEY(SCALE_FACTOR) + std::string("_") + std::to_string(i);
-                    gnaPluginConfig[scaleFactorConfigKey] = scaleFactorInput[i];
-                }
+            auto scaleFactorInput = ParseScaleFactors(FLAGS_sf);
+            if (numInputFiles != scaleFactorInput.size()) {
+                std::string errMessage(
+                    "Incorrect command line for multiple inputs: " + std::to_string(scaleFactorInput.size()) +
+                    " scale factors provided for " + std::to_string(numInputFiles) + " input files.");
+                throw std::logic_error(errMessage);
+            }
+
+            for (size_t i = 0; i < scaleFactorInput.size(); ++i) {
+                slog::info << "For input " << i << " using scale factor of " << scaleFactorInput[i] << slog::endl;
+                std::string scaleFactorConfigKey =
+                    GNA_CONFIG_KEY(SCALE_FACTOR) + std::string("_") + std::to_string(i);
+                gnaPluginConfig[scaleFactorConfigKey] = scaleFactorInput[i];
             }
         } else {
             // "static" quantization with calculated scale factor

--- a/inference-engine/samples/speech_sample/main.cpp
+++ b/inference-engine/samples/speech_sample/main.cpp
@@ -613,9 +613,8 @@ int main(int argc, char* argv[]) {
 
             auto scaleFactorInput = ParseScaleFactors(FLAGS_sf);
             if (numInputFiles != scaleFactorInput.size()) {
-                std::string errMessage(
-                    "Incorrect command line for multiple inputs: " + std::to_string(scaleFactorInput.size()) +
-                    " scale factors provided for " + std::to_string(numInputFiles) + " input files.");
+                std::string errMessage("Incorrect command line for multiple inputs: " + std::to_string(scaleFactorInput.size()) +
+                                       " scale factors provided for " + std::to_string(numInputFiles) + " input files.");
                 throw std::logic_error(errMessage);
             }
 

--- a/inference-engine/src/gna_plugin/gna_plugin.cpp
+++ b/inference-engine/src/gna_plugin/gna_plugin.cpp
@@ -1568,6 +1568,18 @@ InferenceEngine::IExecutableNetworkInternal::Ptr GNAPlugin::ImportNetwork(std::i
             transpose_inputs_info,
             transpose_outputs_info);
 
+    // If scale factors are defined in configuration we still need to use them instead of imported values,
+    // for example to change the scale factors for the old models.
+    if (!config.inputScaleFactors.empty()) {
+        IE_ASSERT(config.inputScaleFactors.size() == inputsDesc->inputScaleFactors.size());
+        for (size_t i = 0; i < config.inputScaleFactors.size(); ++i) {
+            if (config.inputScaleFactors[i] != GNAPluginNS::kScaleFactorDefault) {
+                gnalog() << "[Import Network] Using input scale factor defined in configuration for input " << i << std::endl;
+                inputsDesc->inputScaleFactors[i] = config.inputScaleFactors[i];
+            }
+        }
+    }
+
 #if GNA_LIB_VER == 2
     auto getOrientation = [](Gna2Operation & gnaOperation) {
         return gnaOperation.Type == Gna2OperationTypeConvolution ?

--- a/inference-engine/src/gna_plugin/gna_plugin_config.cpp
+++ b/inference-engine/src/gna_plugin/gna_plugin_config.cpp
@@ -95,7 +95,7 @@ void Config::UpdateFromMap(const std::map<std::string, std::string>& config) {
             }
             // missing scale factors are set to be 1.0f
             if (inputScaleFactors.size() <= input_index) {
-                inputScaleFactors.resize(input_index + 1, 1.f);
+                inputScaleFactors.resize(input_index + 1, GNAPluginNS::kScaleFactorDefault);
             }
             inputScaleFactors[input_index] = InferenceEngine::CNNLayer::ie_parse_float(value);
         } else if (key == GNA_CONFIG_KEY(FIRMWARE_MODEL_IMAGE)) {

--- a/inference-engine/src/gna_plugin/gna_plugin_config.hpp
+++ b/inference-engine/src/gna_plugin/gna_plugin_config.hpp
@@ -18,6 +18,8 @@
 
 namespace GNAPluginNS {
 
+static const float kScaleFactorDefault = 1.f;
+
 struct Config {
     Config() {
         AdjustKeyMapValues();

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/import_export_tests/import_reshape_permute_conv.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/import_export_tests/import_reshape_permute_conv.cpp
@@ -11,7 +11,7 @@ using namespace LayerTestsDefinitions;
 
 namespace {
 
-class ImportReshapePermuteConvGNA : public ImportReshapePermuteConv {
+class ImportExportGNAModelUnchanged : public ImportReshapePermuteConv {
 private:
     void exportImportNetwork() override {
         {
@@ -42,8 +42,14 @@ private:
     std::string fileName = "exported_model.blob";
 };
 
-TEST_P(ImportReshapePermuteConvGNA, CompareWithRefImpl) {
-    Run();
+class ImportExportGNAModelChanged : public ImportExportGNAModelUnchanged {};
+
+TEST_P(ImportExportGNAModelUnchanged, ReshapePermuteConv) {
+    TestRun(false);
+};
+
+TEST_P(ImportExportGNAModelChanged, ReshapePermuteConv) {
+    TestRun(true);
 };
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
@@ -58,15 +64,25 @@ const std::vector<std::map<std::string, std::string>> exportConfigs = {
     }
 };
 
-const std::vector<std::map<std::string, std::string>> importConfigs = {
+const std::vector<std::map<std::string, std::string>> importConfigsChanged = {
     {
         {"GNA_DEVICE_MODE", "GNA_SW_EXACT"},
         {"GNA_SCALE_FACTOR_0", "32767"}
-    },
+    }
+};
+
+const std::vector<std::map<std::string, std::string>> importConfigsUnchanged = {
     {
         {"GNA_DEVICE_MODE", "GNA_SW_EXACT"},
         {"GNA_SCALE_FACTOR_0", "327.67"}
     },
+    {
+        {"GNA_DEVICE_MODE", "GNA_SW_EXACT"},
+        {"GNA_SCALE_FACTOR_0", "1"}
+    },
+    {
+        {"GNA_DEVICE_MODE", "GNA_SW_EXACT"}
+    }
 };
 
 const std::vector<std::string> appHeaders = {
@@ -74,13 +90,22 @@ const std::vector<std::string> appHeaders = {
         "APPLICATION_HEADER"
 };
 
-INSTANTIATE_TEST_CASE_P(smoke_ImportNetworkCase, ImportReshapePermuteConvGNA,
+INSTANTIATE_TEST_CASE_P(smoke_ImportNetworkGNA, ImportExportGNAModelUnchanged,
                         ::testing::Combine(
                             ::testing::ValuesIn(netPrecisions),
                             ::testing::Values(CommonTestUtils::DEVICE_GNA),
                             ::testing::ValuesIn(exportConfigs),
-                            ::testing::ValuesIn(importConfigs),
+                            ::testing::ValuesIn(importConfigsUnchanged),
                             ::testing::ValuesIn(appHeaders)),
-                        ImportReshapePermuteConvGNA::getTestCaseName);
+                        ImportExportGNAModelUnchanged::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_ImportNetworkGNA, ImportExportGNAModelChanged,
+                        ::testing::Combine(
+                            ::testing::ValuesIn(netPrecisions),
+                            ::testing::Values(CommonTestUtils::DEVICE_GNA),
+                            ::testing::ValuesIn(exportConfigs),
+                            ::testing::ValuesIn(importConfigsChanged),
+                            ::testing::ValuesIn(appHeaders)),
+                        ImportExportGNAModelChanged::getTestCaseName);
 
 } // namespace

--- a/inference-engine/tests/functional/plugin/shared/include/base/import_export_base/import_export_base.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/base/import_export_base/import_export_base.hpp
@@ -23,6 +23,7 @@ class ImportNetworkTestBase : public testing::WithParamInterface<exportImportNet
 public:
     static std::string getTestCaseName(testing::TestParamInfo<exportImportNetworkParams> obj);
     void Run() override;
+    void TestRun(bool isModelChanged);
 
 protected:
     std::map<std::string, std::string> exportConfiguration;

--- a/inference-engine/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
@@ -313,6 +313,7 @@ void LayerTestsCommon::LoadNetwork() {
 }
 
 void LayerTestsCommon::GenerateInputs() {
+    inputs.clear();
     const auto& inputsInfo = executableNetwork.GetInputsInfo();
     const auto& functionParams = function->get_parameters();
     for (int i = 0; i < functionParams.size(); ++i) {


### PR DESCRIPTION
Merge #7139
### Details:
- Those changes allow GNA customers to correct the input scale factor for the old models (previously exported) using speech sample, because they don't have the latest version IR.
- If scale factors for inputs were defined in the plugin configuration we should change them for the imported model
- Ignoring default scale factors (1.0f), they should be replaced my imported values
- Modified tests to cover all cases.
