### PR TITLE
[MO] turn on MarkSubGraphsWithCorrectLayout for TF NCHW

### DIFF
--- a/model-optimizer/extensions/middle/MarkSubgraphsWithCorrectLayout.py
+++ b/model-optimizer/extensions/middle/MarkSubgraphsWithCorrectLayout.py
@@ -25,7 +25,8 @@ class MarkSubGraphsWithCorrectLayout(MiddleReplacementPattern):
     3. Marks nodes along the weight path of convolutions as in correct layout to not permute them from NHWC to NCHW
     """
     enabled = True
-    graph_condition = [lambda graph: graph.graph['layout'] == 'NHWC']
+    # can't be turned on for Kaldi until permutation logic will be aligned
+    graph_condition = [lambda graph: graph.graph['fw'] != 'kaldi']
     op_conditions = [lambda n: n.soft_get('op') == 'MatMul' and
                                any([len(port.data.get_shape()) in (4, 5) for port in n.in_ports().values()]),
                      ]

--- a/model-optimizer/extensions/middle/MarkSubgraphsWithCorrectLayout.py
+++ b/model-optimizer/extensions/middle/MarkSubgraphsWithCorrectLayout.py
@@ -22,7 +22,11 @@ class MarkSubGraphsWithCorrectLayout(MiddleReplacementPattern):
     1. Prevents from adding Transpose operations before and after "reinterp_shape" like operations which change rank of
     the input and output tensors of this layout agnostic op.
     2. Disable attributes permutation for all intermediate ops between these "reinterp_shape" nodes.
-    3. Marks nodes along the weight path of convolutions as in correct layout to not permute them from NHWC to NCHW
+    3. Marks nodes along the weight path of convolutions as in correct layout to not permute them from NHWC to NCHW.
+    The latest is needed for TF NCHW graphs as well. In Conv/Deconv infer functions "set_permutation()"
+    ads "permutation" attr to weights data node even for NCHW, it is needed to permute Conv weights from the
+    original TF layout into IE even for NCHW graphs. Therefore for TF models
+    to prevent unwarranted permutations need to mark weights path as having correct layout even for NCHW graphs.
     """
     enabled = True
     graph_condition = [lambda graph: graph.graph['fw'] == 'tf']

--- a/model-optimizer/extensions/middle/MarkSubgraphsWithCorrectLayout.py
+++ b/model-optimizer/extensions/middle/MarkSubgraphsWithCorrectLayout.py
@@ -25,8 +25,7 @@ class MarkSubGraphsWithCorrectLayout(MiddleReplacementPattern):
     3. Marks nodes along the weight path of convolutions as in correct layout to not permute them from NHWC to NCHW
     """
     enabled = True
-    # can't be turned on for Kaldi until permutation logic will be aligned
-    graph_condition = [lambda graph: graph.graph['fw'] != 'kaldi']
+    graph_condition = [lambda graph: graph.graph['fw'] == 'tf']
     op_conditions = [lambda n: n.soft_get('op') == 'MatMul' and
                                any([len(port.data.get_shape()) in (4, 5) for port in n.in_ports().values()]),
                      ]

--- a/model-optimizer/mo/ops/convolution.py
+++ b/model-optimizer/mo/ops/convolution.py
@@ -256,6 +256,9 @@ class Convolution(Op):
                                                        ('output_feature_channel', 'input:{}'.format(weights_index)),
                                                        ])
 
+        # is needed to permute Conv weights from the original TF [H, W, C_IN, C_OUT] into IE [C_OUT, C_IN, H, W]
+        # but for other nodes in weights subgraph permutations must turned off
+        # by marking with MarkSubGraphsWithCorrectLayout even if graph layout is NCHW.
         PermuteAttrs.set_permutation(node.in_node(weights_index), node, node.soft_get('get_weights_permute', None))
         PermuteInputs().set_input_permutation(
             node.in_node(weights_index), node, 'input:{}'.format(weights_index), 'transpose')

--- a/model-optimizer/mo/ops/deconvolution.py
+++ b/model-optimizer/mo/ops/deconvolution.py
@@ -99,7 +99,10 @@ class Deconvolution(Op):
                                                        ('input_feature_channel', 'input:1'),
                                                        ('output_feature_channel', 'input:1'),
                                                        ])
-
+        
+        # is needed to permute Deconv weights from the original TF [H, W, C_OUT, C_IN] into IE [C_IN, C_OUT, H, W]
+        # but for other nodes in weights subgraph permutations must turned off
+        # by marking with MarkSubGraphsWithCorrectLayout even if graph layout is NCHW.
         PermuteAttrs.set_permutation(node.in_node(1), node, node.soft_get('get_weights_permute', None))
         PermuteInputs().set_input_permutation(node.in_node(1), node, 'input:1', 'transpose')
         PermuteInputs().set_input_permutation(node.in_node(2), node, 'input:0', 'shape')


### PR DESCRIPTION
#### Root cause analysis:
TF model StyleGAN2 was not converted because of wrong layout permutation. Additional changes were done around Reshape node because Convolution infer function manually inserts `'layout'` attribute to weights data node.

Convolution data input is already in NCHW layout and in the whole graph it's needed only to transpose Convolution weights from to `[C_OUT, C_IN, H, W]` from original TF `[H, W, C_IN, C_OUT]`  leaving other parts of the graph unchanged.

If TF model in NCHW contains Deconvolution nodes need to transpose weights from `[H, W, C_OUT, C_IN]`) into `[C_IN, C_OUT, H, W]` without any other changes for layout permutation.

#### Solution: 
There is already a transformation which marks nodes that are not needed to permute.
 - [extensions/middle/MarkSubgraphsWithCorrectLayout.py#L25](https://github.com/openvinotoolkit/openvino/blob/ca889f530dd354a57f393d8af75a96c910196b05/model-optimizer/extensions/middle/MarkSubgraphsWithCorrectLayout.py#L25)
 - [extensions/middle/MarkSubgraphsWithCorrectLayout.py#L146](https://github.com/openvinotoolkit/openvino/blob/ca889f530dd354a57f393d8af75a96c910196b05/model-optimizer/extensions/middle/MarkSubgraphsWithCorrectLayout.py#L146)

Need to unblock it for NCWH graphs as well.

Validated on DL Benchmark, no regression introduced

#### Ticket:
 - xxx-59852

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names

Validation:
* [x]  Unit tests: N/A
* [x]  Framework operation tests: Checked inference manually. Layer tests are not written since TF Convolution in NCHW layout can not be inferred without GPU with CUDA.
* [x]  Transformation tests: N/A
* [x]  Model Optimizer IR Reader check: **DONE**

Documentation:
* [x]  Supported frameworks operations list: N/A
* [x]  Guide on how to convert the **public** model: N/A
* [x]  User guide update: N/A