### PR TITLE
Fix v0::MVN default constructor

### DIFF
--- a/ngraph/core/include/ngraph/op/mvn.hpp
+++ b/ngraph/core/include/ngraph/op/mvn.hpp
@@ -17,7 +17,7 @@ class NGRAPH_API MVN : public Op {
 public:
     NGRAPH_RTTI_DECLARATION;
 
-    MVN();
+    MVN() = default;
     /// \brief Constructs an MVN operation.
     ///
     /// \param data Input tensor with data

--- a/ngraph/core/src/op/mvn.cpp
+++ b/ngraph/core/src/op/mvn.cpp
@@ -15,8 +15,6 @@ using namespace ngraph;
 
 NGRAPH_RTTI_DEFINITION(op::v0::MVN, "MVN", 0);
 
-op::v0::MVN::MVN() : Op(), m_across_channels(), m_normalize_variance(), m_reduction_axes() {}
-
 op::v0::MVN::MVN(const Output<Node>& data, bool across_channels, bool normalize_variance, double eps)
     : Op({data}),
       m_eps{eps},


### PR DESCRIPTION
### Details:
 - Fix v0::MVN default constructor 
 (Issue: 'this->m_eps' is not initialized in this constructor.)

### Tickets:
 - N/A
