### PR TITLE
[GPU] Fixed default device id

### DIFF
--- a/inference-engine/src/cldnn_engine/cldnn_config.h
+++ b/inference-engine/src/cldnn_engine/cldnn_config.h
@@ -30,7 +30,7 @@ struct Config {
                tuningConfig(),
                graph_dumps_dir(""),
                sources_dumps_dir(""),
-               device_id(""),
+               device_id("0"),
                kernels_cache_dir(""),
                n_threads(std::max(static_cast<unsigned int>(1), std::thread::hardware_concurrency())),
                enable_loop_unrolling(true) {

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/behavior/config.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/behavior/config.cpp
@@ -118,6 +118,13 @@ namespace {
                 ::testing::ValuesIn(conf)),
             CorrectConfigAPITests::getTestCaseName);
 
+    INSTANTIATE_TEST_CASE_P(smoke_BehaviorTests, DefaultValuesConfigTests,
+            ::testing::Combine(
+                ::testing::ValuesIn(netPrecisions),
+                ::testing::Values(CommonTestUtils::DEVICE_GPU),
+                ::testing::ValuesIn(conf)),
+            CorrectConfigAPITests::getTestCaseName);
+
     INSTANTIATE_TEST_CASE_P(smoke_GPU_BehaviorTests, CorrectConfigAPITests,
             ::testing::Combine(
                 ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/shared/include/behavior/config.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/behavior/config.hpp
@@ -49,6 +49,24 @@ namespace BehaviorTestsDefinitions {
         ASSERT_NO_THROW(ie->SetConfig(configuration, targetDevice));
     }
 
+    using DefaultValuesConfigTests = BehaviorTestsUtils::BehaviorTestsBasic;
+
+    TEST_P(DefaultValuesConfigTests, CanSetDefaultValueBackToPlugin) {
+        // Skip test according to plugin specific disabledTestPatterns() (if any)
+        SKIP_IF_CURRENT_TEST_IS_DISABLED()
+        InferenceEngine::CNNNetwork cnnNet(function);
+        InferenceEngine::Parameter metric;
+        ASSERT_NO_THROW(metric = ie->GetMetric(targetDevice, METRIC_KEY(SUPPORTED_CONFIG_KEYS)));
+        std::vector<std::string> keys = metric;
+
+        for (auto& key : keys) {
+            InferenceEngine::Parameter configValue;
+            ASSERT_NO_THROW(configValue = ie->GetConfig(targetDevice, key));
+
+            ASSERT_NO_THROW(ie->SetConfig({{ key, configValue.as<std::string>()}}, targetDevice));
+        }
+    }
+
     using IncorrectConfigTests = BehaviorTestsUtils::BehaviorTestsBasic;
 
     TEST_P(IncorrectConfigTests, SetConfigWithIncorrectKey) {


### PR DESCRIPTION
### Details:
 - Changed default value for DEVICE_ID key from "" to "0" to allow passing default value back to plugin in `SetConfig` call
 - Copy of #7155

### Tickets:
 - *62004*
