### PR TITLE
[CPU][TESTS][LPT] MatMulTransformations test-cases removed from skip config

### DIFF
--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
@@ -52,8 +52,6 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*ConvolutionLayerCPUTest.*BF16.*_inFmts=(ndhwc|nhwc).*)",
         // TODO: 56827. Sporadic test failures
         R"(.*smoke_Conv.+_FP32.ConvolutionLayerCPUTest\.CompareWithRefs.IS=\(1\.67.+\).*inFmts=n.+c.*_primitive=jit_avx2.*)",
-        // lpt transformation produce the same names for MatMul and Multiply
-        R"(.*MatMulTransformation.*)",
         // incorrect jit_uni_planar_convolution with dilation = {1, 2, 1} and output channel 1
         R"(.*smoke_Convolution3D.*D=\(1.2.1\)_O=1.*)",
 


### PR DESCRIPTION
### Details:
Some MatMulTransformation tests was disabled in the cpuFunctionalTests.
Root cause was fixed in #5226, but tests is still skipped.
This PR removes these tests from the skip config.

### Ticket:
 - 63019
