### PR TITLE
[LPT] INT16, INT32 Quantization support

### DIFF
--- a/inference-engine/src/low_precision_transformations/include/low_precision/layer_transformation.hpp
+++ b/inference-engine/src/low_precision_transformations/include/low_precision/layer_transformation.hpp
@@ -57,52 +57,81 @@ public:
             hasZeroPoint(hasZeroPoint) {}
 
     static bool isSupported(const element::Type& precision) {
-        return (precision == element::u8) || (precision == element::i8);
+        static const std::set<element::Type_t> lowPrecision = {
+                element::i8, element::u8,
+                element::i16, element::u16,
+                element::i32, element::u32
+        };
+        return lowPrecision.count(precision) == 1;
     }
 
     static float getMinValue(const element::Type precision, const size_t levels) {
-        if (precision == element::i8) {
-            if (levels == 255) {
-                return static_cast<float>(std::numeric_limits<signed char>::lowest()) + 1.f;
-            } else if (levels == 256) {
-                return static_cast<float>(std::numeric_limits<signed char>::lowest());
-            } else {
-                NGRAPH_CHECK(false, "unexpected levels ", levels, " for precision ", precision);
-            }
-        } else if (precision == element::u8) {
-            return static_cast<float>(std::numeric_limits<unsigned char>::lowest());
-        } else if (precision == element::f16) {
-            return -1.0e15f;
-        } else if (precision == element::f32) {
-            return std::numeric_limits<float>::lowest();
-        } else if (precision == element::i4) {
-            return -8.f;
-        } else if (precision == element::u4) {
-            return 0.f;
-        } else {
-            NGRAPH_CHECK(false, "unexpected precision ", precision);
+        switch (precision) {
+            case element::u4:
+            case element::u8:
+            case element::u16:
+            case element::u32:
+                return 0.f;
+            case element::i4:
+                return -8.f;
+            case element::i8:
+                switch (levels) {
+                    case 255:
+                        return -127.f;
+                    case 256:
+                        return -128.f;
+                }
+                break;
+            case element::i16:
+                switch (levels) {
+                    case 65536:
+                        return -32768.f;
+                    case 65535:
+                        return -32767.f;
+                }
+                break;
+            case element::i32:
+                switch (levels) {
+                    case 4294967296:
+                        return -2147483648.f;
+                    case 4294967295:
+                        return -2147483647.f;
+                }
+                break;
+            case element::f16:
+                return -1.0e15f;
+            case element::f32:
+                return std::numeric_limits<float>::lowest();
+            default:
+                NGRAPH_CHECK(false, "unexpected precision ", precision);
         }
+        NGRAPH_CHECK(false, "unexpected levels ", levels, " for precision ", precision);
     }
 
     static float getMaxValue(const element::Type precision, const size_t levels) {
-        if ((levels != 255ul) && (levels != 256ul)) {
-            THROW_TRANSFORMATION_EXCEPTION << "unexpected levels " << levels;
-        }
-
-        if (precision == element::i8) {
-            return static_cast<float>(std::numeric_limits<signed char>::max());
-        } else if (precision == element::u8) {
-            return static_cast<float>(std::numeric_limits<unsigned char>::max()) - (256 - levels);
-        } else if (precision == element::f16) {
-            return 1.0e15f;
-        } else if (precision == element::f32) {
-            return std::numeric_limits<float>::max();
-        } else if (precision == element::i4) {
-            return 7.f;
-        } else if (precision == element::u4) {
-            return 15.f;
-        } else {
-            THROW_TRANSFORMATION_EXCEPTION << "unexpected precision " << precision;
+        switch (precision) {
+            case element::u4:
+                return 15.f;
+            case element::u8:
+                return 255.f;
+            case element::u16:
+                return 32767.f;
+            case element::u32:
+                return 4294967296.f;
+            case element::i4:
+                return 7.f;
+            case element::i8:
+                return 127.f;
+            case element::i16:
+                return 32767.f;
+            case element::i32:
+                return 2147483647.f;
+            case element::f16:
+                return 1.0e15f;
+            case element::f32:
+                return std::numeric_limits<float>::max();
+            default:
+                NGRAPH_CHECK(false, "unexpected precision ", precision);
         }
     }
 

--- a/inference-engine/src/low_precision_transformations/include/low_precision/layer_transformation.hpp
+++ b/inference-engine/src/low_precision_transformations/include/low_precision/layer_transformation.hpp
@@ -92,7 +92,7 @@ public:
                 break;
             case element::i32:
                 switch (levels) {
-                    case 4294967296:
+                    case static_cast<size_t>(4294967296):
                         return -2147483648.f;
                     case 4294967295:
                         return -2147483647.f;

--- a/inference-engine/src/low_precision_transformations/include/low_precision/layer_transformation.hpp
+++ b/inference-engine/src/low_precision_transformations/include/low_precision/layer_transformation.hpp
@@ -115,7 +115,7 @@ public:
             case element::u8:
                 return 255.f;
             case element::u16:
-                return 32767.f;
+                return 65535.f;
             case element::u32:
                 return 4294967296.f;
             case element::i4:

--- a/inference-engine/src/low_precision_transformations/include/low_precision/low_precision.hpp
+++ b/inference-engine/src/low_precision_transformations/include/low_precision/low_precision.hpp
@@ -65,6 +65,8 @@ public:
     bool run_on_function(std::shared_ptr<ngraph::Function> f) override;
 
     static bool isFunctionQuantized(const std::shared_ptr<const ngraph::Function>& function);
+    static bool isFQLevelsPresent(const std::shared_ptr<const ngraph::Function>& function, const std::set<size_t>& levels);
+    static void setDefaultPrecisions(const std::vector<element::Type>& precisions);
 
 protected:
     std::vector<OperationPrecisionRestriction> precisionRestrictions;

--- a/inference-engine/src/low_precision_transformations/include/low_precision/rt_info/precisions_attribute.hpp
+++ b/inference-engine/src/low_precision_transformations/include/low_precision/rt_info/precisions_attribute.hpp
@@ -31,7 +31,7 @@ using PrecisionsAttributePtr = std::shared_ptr<PrecisionsAttribute>;
 
 class LP_TRANSFORMATIONS_API PrecisionsAttribute : public SharedValueAttribute<PrecisionsSharedValue> {
 public:
-    static const std::vector<ngraph::element::Type> defaultPrecisions;
+    static std::vector<ngraph::element::Type> defaultPrecisions;
     PrecisionsAttribute(const std::vector<ngraph::element::Type>& precisions = defaultPrecisions);
 };
 } // namespace ngraph

--- a/inference-engine/src/low_precision_transformations/src/fake_quantize_decomposition.cpp
+++ b/inference-engine/src/low_precision_transformations/src/fake_quantize_decomposition.cpp
@@ -124,7 +124,7 @@ DataPrecision getDataPrecisionByOutputPort(std::shared_ptr<opset1::FakeQuantize>
         case 65535:
             precisionsForLevels = {element::u16, element::i16};
             break;
-        case 4294967296:
+        case static_cast<size_t>(4294967296):
         case 4294967295:
             precisionsForLevels = {element::u32, element::i32};
             break;

--- a/inference-engine/src/low_precision_transformations/src/fake_quantize_decomposition.cpp
+++ b/inference-engine/src/low_precision_transformations/src/fake_quantize_decomposition.cpp
@@ -118,18 +118,32 @@ DataPrecision getDataPrecisionByOutputPort(std::shared_ptr<opset1::FakeQuantize>
     }
 
     const auto& precisions = precisionsAttribute->get()->sharedValue->precisions;
+    std::vector<element::Type> precisionsForLevels{};
+    switch (levels) {
+        case 65536:
+        case 65535:
+            precisionsForLevels = {element::u16, element::i16};
+            break;
+        case 4294967296:
+        case 4294967295:
+            precisionsForLevels = {element::u32, element::i32};
+            break;
+        default:
+            precisionsForLevels = {element::u8, element::i8};
+    }
+    const auto resultPrecisions = NetworkHelper::precisionIntersection(precisions, precisionsForLevels);
 
     ngraph::element::Type precision;
     bool hasZeroPoint;
-    if (precisions.size() > 1ul) {
+    if (resultPrecisions.size() > 1ul) {
         LayerTransformation::PrecisionDetails precisionDetailsAtOutputIntervals = LayerTransformation::getPrecisionDetails(
             levels,
             outputLowValues,
             outputHighValues);
-        const auto foundIt = std::find(precisions.begin(), precisions.end(), precisionDetailsAtOutputIntervals.precision);
+        const auto foundIt = std::find(resultPrecisions.begin(), resultPrecisions.end(), precisionDetailsAtOutputIntervals.precision);
 
-        if (foundIt == precisions.end()) {
-            precision = *precisions.begin();
+        if (foundIt == resultPrecisions.end()) {
+            precision = *resultPrecisions.begin();
             hasZeroPoint = true;
         } else {
             precision = precisionDetailsAtOutputIntervals.precision;
@@ -140,7 +154,7 @@ DataPrecision getDataPrecisionByOutputPort(std::shared_ptr<opset1::FakeQuantize>
         precisionsAttribute->get()->sharedValue->precisions = { precision };
     } else {
         // use only available precision
-        precision = *precisions.begin();
+        precision = *resultPrecisions.begin();
         LayerTransformation::PrecisionDetails precisionDetailsAtOutputIntervals = LayerTransformation::getPrecisionDetails(
             levels,
             outputLowValues,

--- a/inference-engine/src/low_precision_transformations/src/fake_quantize_dequantization.cpp
+++ b/inference-engine/src/low_precision_transformations/src/fake_quantize_dequantization.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 
 #include <ngraph/opsets/opset1.hpp>
+#include <low_precision/network_helper.hpp>
 
 #include "low_precision/common/fake_quantize_dequantization.hpp"
 #include "low_precision/common/ie_lpt_exception.hpp"
@@ -71,7 +72,7 @@ bool FakeQuantizeDequantization::isShared() const {
 }
 
 bool FakeQuantizeDequantization::isLowPrecision() const {
-    return (data.get_element_type() == element::i8) || (data.get_element_type() == element::u8);
+    return DataPrecision::isSupported(data.get_element_type());
 }
 
 bool FakeQuantizeDequantization::checkShape(const std::shared_ptr<ngraph::Node>& elementwise) noexcept {

--- a/inference-engine/src/low_precision_transformations/src/layer_transformation.cpp
+++ b/inference-engine/src/low_precision_transformations/src/layer_transformation.cpp
@@ -202,7 +202,7 @@ LayerTransformation::PrecisionDetails LayerTransformation::getPrecisionDetails(
     const float zeroThreshold = 1.e-6f;
     const float quantizationIntervalAsymmetryThreshold = 0.002f;
 
-    const float asymmetricIntervalSideRatio256 = -128.f / 127.f;
+    float asymmetricIntervalSideRatio = -static_cast<float>(quantizationLevels) / (quantizationLevels - 2.f);
     bool hasNegative = false;
     bool signedPrecision = true;
     bool unsignedPrecision = true;
@@ -218,7 +218,7 @@ LayerTransformation::PrecisionDetails LayerTransformation::getPrecisionDetails(
 
             if (outputHighValues[i] != 0.f) {
                 const float expectedRatio = (quantizationLevels == 256 || quantizationLevels == 65536 || quantizationLevels == 4294967296) ?
-                        asymmetricIntervalSideRatio256 : -1.f;
+                                            asymmetricIntervalSideRatio : -1.f;
                 const float actualRatio = outputLowValues[i] / outputHighValues[i];
                 const float actual = std::fabs((actualRatio - expectedRatio) / std::min(actualRatio, expectedRatio));
                 if (actual > quantizationIntervalAsymmetryThreshold) {

--- a/inference-engine/src/low_precision_transformations/src/layer_transformation.cpp
+++ b/inference-engine/src/low_precision_transformations/src/layer_transformation.cpp
@@ -217,7 +217,8 @@ LayerTransformation::PrecisionDetails LayerTransformation::getPrecisionDetails(
             hasNegative = true;
 
             if (outputHighValues[i] != 0.f) {
-                const float expectedRatio = quantizationLevels == 256 ? asymmetricIntervalSideRatio256 : -1.f;
+                const float expectedRatio = (quantizationLevels == 256 || quantizationLevels == 65536 || quantizationLevels == 4294967296) ?
+                        asymmetricIntervalSideRatio256 : -1.f;
                 const float actualRatio = outputLowValues[i] / outputHighValues[i];
                 const float actual = std::fabs((actualRatio - expectedRatio) / std::min(actualRatio, expectedRatio));
                 if (actual > quantizationIntervalAsymmetryThreshold) {
@@ -262,17 +263,44 @@ LayerTransformation::PrecisionDetails LayerTransformation::getPrecisionDetails(
 //
 //    THROW_TRANSFORMATION_EXCEPTION << "unexpected interval";
 
+    element::Type resultPrecision = element::undefined;
     if (!hasZeroPoint) {
         if (signedPrecision && (!unsignedPrecision)) {
-            return LayerTransformation::PrecisionDetails(element::i8, hasNegative, hasZeroPoint);
+            switch (quantizationLevels) {
+                case 256:
+                case 255:
+                    resultPrecision = element::i8;
+                    break;
+                case 65536:
+                case 65535:
+                    resultPrecision = element::i16;
+                    break;
+                case 4294967296:
+                case 4294967295:
+                    resultPrecision = element::i32;
+                    break;
+            }
         }
 
         if ((!signedPrecision) && unsignedPrecision) {
-            return LayerTransformation::PrecisionDetails(element::u8, hasNegative, hasZeroPoint);
+            switch (quantizationLevels) {
+                case 256:
+                case 255:
+                    resultPrecision = element::u8;
+                    break;
+                case 65536:
+                case 65535:
+                    resultPrecision = element::u16;
+                    break;
+                case 4294967296:
+                case 4294967295:
+                    resultPrecision = element::u32;
+                    break;
+            }
         }
     }
 
-    return LayerTransformation::PrecisionDetails(element::undefined, hasNegative, hasZeroPoint);
+    return LayerTransformation::PrecisionDetails(resultPrecision, hasNegative, hasZeroPoint);
 }
 
 LayerTransformation::PrecisionDetails LayerTransformation::getPrecisionDetails(const QuantizationDetails& quantizationDetails) {
@@ -296,6 +324,22 @@ DataPrecision LayerTransformation::getDataPrecision(
 #ifdef LPT_PRINT_DEQUANTIZATION_INFO
     printDequantizationInfo(layer);
 #endif
+    std::vector<element::Type> resultPrecisions = precisions;
+    std::vector<element::Type> FQPrecisions;
+    switch (quantizationDetails.levels) {
+        case 255:
+        case 256:
+            FQPrecisions = {element::u8, element::i8};
+            break;
+        case 65535:
+        case 65536:
+            FQPrecisions = {element::u16, element::i16};
+            break;
+        case 4294967295:
+        case 4294967296:
+            FQPrecisions = {element::u32, element::i32};
+    }
+    resultPrecisions = NetworkHelper::precisionIntersection(precisions, FQPrecisions);
     PrecisionDetails precisionDetailsAtOutputIntervals = getPrecisionDetails(quantizationDetails);
 
     if (precisionDetailsAtOutputIntervals.precision != element::undefined) {

--- a/inference-engine/src/low_precision_transformations/src/layer_transformation.cpp
+++ b/inference-engine/src/low_precision_transformations/src/layer_transformation.cpp
@@ -275,7 +275,7 @@ LayerTransformation::PrecisionDetails LayerTransformation::getPrecisionDetails(
                 case 65535:
                     resultPrecision = element::i16;
                     break;
-                case 4294967296:
+                case static_cast<size_t>(4294967296):
                 case 4294967295:
                     resultPrecision = element::i32;
                     break;
@@ -292,7 +292,7 @@ LayerTransformation::PrecisionDetails LayerTransformation::getPrecisionDetails(
                 case 65535:
                     resultPrecision = element::u16;
                     break;
-                case 4294967296:
+                case static_cast<size_t>(4294967296):
                 case 4294967295:
                     resultPrecision = element::u32;
                     break;
@@ -336,7 +336,7 @@ DataPrecision LayerTransformation::getDataPrecision(
             FQPrecisions = {element::u16, element::i16};
             break;
         case 4294967295:
-        case 4294967296:
+        case static_cast<size_t>(4294967296):
             FQPrecisions = {element::u32, element::i32};
     }
     resultPrecisions = NetworkHelper::precisionIntersection(precisions, FQPrecisions);

--- a/inference-engine/src/low_precision_transformations/src/low_precision.cpp
+++ b/inference-engine/src/low_precision_transformations/src/low_precision.cpp
@@ -29,6 +29,7 @@
 #include "low_precision/fold_convert.hpp"
 #include "low_precision/pull_reshape_through_dequantization.hpp"
 #include "low_precision/pull_transpose_through_dequantization.hpp"
+#include "low_precision/rt_info/precisions_attribute.hpp"
 
 // branch specific transformations
 #include "low_precision/concat.hpp"
@@ -282,4 +283,25 @@ bool ngraph::pass::low_precision::LowPrecision::isFunctionQuantized(const std::s
         }
     }
     return false;
+}
+
+bool ngraph::pass::low_precision::LowPrecision::isFQLevelsPresent(
+        const std::shared_ptr<const ngraph::Function>& function,
+        const std::set<size_t>& levels) {
+    std::vector<std::shared_ptr<ngraph::Node>> nodes = function->get_ops();
+    for (auto& node : nodes) {
+        for (size_t i = 0; i < node->inputs().size(); ++i) {
+            const auto fakeQuantize = as_type_ptr<ngraph::opset1::FakeQuantize>(node);
+            if (fakeQuantize != nullptr) {
+                if (levels.count(fakeQuantize->get_levels()) == 1) {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
+void ngraph::pass::low_precision::LowPrecision::setDefaultPrecisions(const std::vector<element::Type>& precisions) {
+    ngraph::PrecisionsAttribute::defaultPrecisions = precisions;
 }

--- a/inference-engine/src/low_precision_transformations/src/quantization_details.cpp
+++ b/inference-engine/src/low_precision_transformations/src/quantization_details.cpp
@@ -154,7 +154,7 @@ std::vector<float> QuantizationDetails::getBlobValue(std::shared_ptr<Node> const
 }
 
 bool QuantizationDetails::isSupportedLevel(const size_t level) {
-    static const std::unordered_set<size_t> supported_levels = { 255ul, 256ul };
+    static const std::unordered_set<size_t> supported_levels = { 255, 256, 65536, 65535, 4294967296, 4294967295 };
     return supported_levels.find(level) != supported_levels.end();
 }
 

--- a/inference-engine/src/low_precision_transformations/src/quantization_details.cpp
+++ b/inference-engine/src/low_precision_transformations/src/quantization_details.cpp
@@ -154,7 +154,7 @@ std::vector<float> QuantizationDetails::getBlobValue(std::shared_ptr<Node> const
 }
 
 bool QuantizationDetails::isSupportedLevel(const size_t level) {
-    static const std::unordered_set<size_t> supported_levels = { 255, 256, 65536, 65535, 4294967296, 4294967295 };
+    static const std::unordered_set<size_t> supported_levels = { 255, 256, 65536, 65535, static_cast<size_t>(4294967296), 4294967295 };
     return supported_levels.find(level) != supported_levels.end();
 }
 

--- a/inference-engine/src/low_precision_transformations/src/rt_info/precisions_attribute.cpp
+++ b/inference-engine/src/low_precision_transformations/src/rt_info/precisions_attribute.cpp
@@ -17,7 +17,7 @@ using namespace ngraph;
 using namespace ov;
 
 // order defines default precision
-const std::vector<ngraph::element::Type> PrecisionsAttribute::defaultPrecisions = { ngraph::element::u8, ngraph::element::i8 };
+std::vector<ngraph::element::Type> PrecisionsAttribute::defaultPrecisions = {ngraph::element::u8,  ngraph::element::i8};
 
 PrecisionsAttribute::PrecisionsAttribute(const std::vector<ngraph::element::Type>& precisions) {
     sharedValue->precisions = precisions;

--- a/inference-engine/src/mkldnn_plugin/mkldnn_plugin.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_plugin.cpp
@@ -21,7 +21,6 @@
 #include <ie_system_conf.h>
 #include <nodes/list.hpp>
 #include <ie_ngraph_utils.hpp>
-#include "transformations/serialize.hpp"
 
 #include <transformations/opset_conversions/convert_opset3_to_opset2.hpp>
 #include <transformations/opset_conversions/convert_opset2_to_opset1.hpp>

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/fake_quantize_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/fake_quantize_transformation.cpp
@@ -14,6 +14,7 @@
 #include <low_precision/avg_pool.hpp>
 #include <low_precision/common/operation_precision_restriction.hpp>
 #include <low_precision/fake_quantize_decomposition.hpp>
+#include <low_precision/low_precision.hpp>
 #include "common_test_utils/ngraph_test_utils.hpp"
 
 #include "lpt_ngraph_functions/fake_quantize_function.hpp"
@@ -84,6 +85,14 @@ public:
         const FakeQuantizeTransformationTestValues fakeQuantizeOnData = std::get<3>(GetParam());
 
         const auto params = TestTransformationParams(fakeQuantizeOnData.params).setUpdatePrecisions(updatePrecision);
+
+        if (fakeQuantizeOnData.actual.quantizationLevel != 256) {
+            low_precision::LowPrecision::setDefaultPrecisions({
+                 ngraph::element::u8, ngraph::element::i8,
+                 ngraph::element::u16, ngraph::element::i16,
+                 ngraph::element::u32, ngraph::element::i32
+            });
+        }
 
         actualFunction = ngraph::builder::subgraph::FakeQuantizeFunction::getOriginal(
             TestTransformationParams::toParams(fakeQuantizeOnData.params),
@@ -252,7 +261,50 @@ const std::vector<FakeQuantizeTransformationTestValues> fakeQuantizeTransformati
             { ngraph::element::f16, {{ngraph::element::f16}, { }, { 1e-32f }} }
         }
     },
-
+    // U16
+    {
+        LayerTransformation::createParamsU8I8(),
+        { 65536ul, {}, { 0.f }, { 65.535f }, { 0.f }, { 65.535f } },
+        { 65536ul, {}, { 0.f }, { 65.535f }, { 0.f }, { 65535.f } },
+        ngraph::element::u16,
+        {
+            { ngraph::element::f32, { {ngraph::element::f32}, {}, { 0.001f }} },
+            { ngraph::element::f16, { {ngraph::element::f16}, {}, { 0.001f }} }
+        }
+    },
+    // I16
+    {
+        LayerTransformation::createParamsU8I8(),
+        { 65536ul, {}, { -32.768f }, { 32.767f }, { -32.768f }, { 32.767f } },
+        { 65536ul, {}, { -32.768f }, { 32.767f }, { -32768.f }, { 32767.f } },
+        ngraph::element::i16,
+        {
+            { ngraph::element::f32, { {ngraph::element::f32}, {}, { 0.001f }} },
+            { ngraph::element::f16, { {ngraph::element::f16}, {}, { 0.001f }} }
+        }
+    },
+    // U32
+    {
+        LayerTransformation::createParamsU8I8(),
+        { 4294967296, {}, { 0.f }, { 4.294967295f }, { 0.f }, { 4.294967295f } },
+        { 4294967296, {}, { 0.f }, { 4.294967295f }, { 0.f }, { 4294967295.f } },
+        ngraph::element::u32,
+        {
+            { ngraph::element::f32, { {ngraph::element::f32}, {}, { 0.000000001f }} },
+            { ngraph::element::f16, { {ngraph::element::f16}, {}, { 0.000000001f }} }
+        }
+    },
+    // I32
+    {
+        LayerTransformation::createParamsU8I8(),
+        { 4294967296, {}, { -2.147483648f }, { 2.147483647f }, { -2.147483648f }, { 2.147483647f } },
+        { 4294967296, {}, { -2.147483648f }, { 2.147483647f }, { -2147483648.f }, { 2147483647.f } },
+        ngraph::element::i32,
+        {
+            { ngraph::element::f32, { {ngraph::element::f32}, {}, { 0.000000001f }} },
+            { ngraph::element::f16, { {ngraph::element::f16}, {}, { 0.000000001f }} }
+        }
+    },
     // Failed when updatePrecisions = false, U8 per-channel
     //{
     //    LayerTransformation::createParamsU8I8(),

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/fake_quantize_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/fake_quantize_transformation.cpp
@@ -286,8 +286,8 @@ const std::vector<FakeQuantizeTransformationTestValues> fakeQuantizeTransformati
     // U32
     {
         LayerTransformation::createParamsU8I8(),
-        { 4294967296, {}, { 0.f }, { 4.294967295f }, { 0.f }, { 4.294967295f } },
-        { 4294967296, {}, { 0.f }, { 4.294967295f }, { 0.f }, { 4294967295.f } },
+        { static_cast<size_t>(4294967296), {}, { 0.f }, { 4.294967295f }, { 0.f }, { 4.294967295f } },
+        { static_cast<size_t>(4294967296), {}, { 0.f }, { 4.294967295f }, { 0.f }, { 4294967295.f } },
         ngraph::element::u32,
         {
             { ngraph::element::f32, { {ngraph::element::f32}, {}, { 0.000000001f }} },
@@ -297,8 +297,8 @@ const std::vector<FakeQuantizeTransformationTestValues> fakeQuantizeTransformati
     // I32
     {
         LayerTransformation::createParamsU8I8(),
-        { 4294967296, {}, { -2.147483648f }, { 2.147483647f }, { -2.147483648f }, { 2.147483647f } },
-        { 4294967296, {}, { -2.147483648f }, { 2.147483647f }, { -2147483648.f }, { 2147483647.f } },
+        { static_cast<size_t>(4294967296), {}, { -2.147483648f }, { 2.147483647f }, { -2.147483648f }, { 2.147483647f } },
+        { static_cast<size_t>(4294967296), {}, { -2.147483648f }, { 2.147483647f }, { -2147483648.f }, { 2147483647.f } },
         ngraph::element::i32,
         {
             { ngraph::element::f32, { {ngraph::element::f32}, {}, { 0.000000001f }} },

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/fake_quantize_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/fake_quantize_transformation.cpp
@@ -46,12 +46,30 @@ const std::vector<FakeQuantizeTransformationParam> fakeQuantizeOnDataValues = {
         { 256ul, {}, { -127.5f }, { 0.f }, { -127.5f }, { 0.f } },
         "Pooling", "U8"
     },
+    // INT4 FQ's are not transformed and inferred via FP32
     {
         { 16ul, {}, { 0.f }, { 1.5f }, { 0.f }, { 1.5f } },
         "Pooling", "FP32"
     },
     {
         { 16ul, {}, { -8.f }, { 7.f }, { -0.8f }, { 0.7f } },
+        "Pooling", "FP32"
+    },
+    // INT16, INT32 FQ's are transformed, but updatePrecision = false for inference on CPU Plugin and inferred via FP32
+    {
+        { 65536, {}, { 0.f }, { 65.535f }, { 0.f }, { 65.535f } },
+        "Pooling", "FP32"
+    },
+    {
+        { 65536, {}, { -32.768f }, { 32.767f }, { -32.768f }, { 32.767f } },
+        "Pooling", "FP32"
+    },
+    {
+        { 4294967296, {}, { 0.f }, { 4.294967295f }, { 0.f }, { 4.294967295f } },
+        "Pooling", "FP32"
+    },
+    {
+        { 4294967296, {}, { -2.147483648f }, { 2.147483647f }, { -2.147483648f }, { 2.147483647f } },
         "Pooling", "FP32"
     },
     // nGraph: I8->FP32 Convert is not supported


### PR DESCRIPTION
### Details:
 - *Support INT16, INT32 quantization pipeline through Low Precision Transformations*
 - *Computing Quantization/Dequantization scales and shifts in double precision under macros `FQ_DOUBLE_PRECISION`*

### Tickets:
 - 40265
