### PR TITLE
IE: Fix Windows compilation on MSVC

### DIFF
--- a/inference-engine/src/inference_engine/src/compilation_context.cpp
+++ b/inference-engine/src/inference_engine/src/compilation_context.cpp
@@ -7,7 +7,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#ifndef WIN32
+#ifndef _WIN32
 #    include <unistd.h>
 #endif
 #include <xml_parse_utils.h>
@@ -23,7 +23,7 @@
 #include "transformations/rt_info/primitives_priority_attribute.hpp"
 #include "transformations/serialize.hpp"
 
-#ifdef WIN32
+#ifdef _WIN32
 #    define stat _stat
 #endif
 


### PR DESCRIPTION
`Win32` may be undefined when MSVC is used, see:
https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?redirectedfrom=MSDN&view=msvc-160

Signed-off-by: Karol Trzcinski <karolx.trzcinski@intel.com>
