### PR TITLE
[CPU] Optimized reorder using memcpy

### DIFF
--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reorder_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reorder_node.cpp
@@ -146,7 +146,7 @@ void MKLDNNReorderNode::prepareParams() {
             useDirectCopy = useDirectCopy && std::equal(srcStrides.begin() + startAxis, srcStrides.end(), dstStrides.begin() + startAxis);
 
             //Check that the tensors are dense
-            useDirectCopy = srcStrides.back() == 1;
+            useDirectCopy = useDirectCopy && srcStrides.back() == 1;
             auto &blkDims = srcBlockDesc->getBlockDims();
             for (size_t i = startAxis; useDirectCopy && i < srcStrides.size() - 1; ++i) {
                 useDirectCopy = useDirectCopy && (srcStrides[i] == blkDims[i + 1] * srcStrides[i + 1]);

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reorder_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reorder_node.h
@@ -75,6 +75,13 @@ private:
     bool isNspc2NcspCase = false;
     bool canUseNspc2Ncsp = false;
     bool canUseNcsp2Nspc = false;
+    bool useDirectCopy = false;
+
+    struct DirectCopyParams {
+        MKLDNNMemoryCPtr srcMem;
+        MKLDNNMemoryPtr dstMem;
+        size_t dataSize;
+    } directCopyParams;
 
     void optimizedNspc2Ncsp();
     void optimizedNcsp2Nspc();

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reorder_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reorder_node.h
@@ -86,6 +86,7 @@ private:
     void optimizedNspc2Ncsp();
     void optimizedNcsp2Nspc();
     void createReorderPrimitive(const mkldnn::memory::desc &srcDesc, void* srcPtr, const mkldnn::memory::desc &dstDesc, void* dstPtr);
+    bool canUseDirectCopy();
 };
 
 }  // namespace MKLDNNPlugin


### PR DESCRIPTION
### Details:
This PR adds yet another reorder implementation for cases where we just need to copy a large chunks of memory. In such a case `memcpy` function is used, and all preliminary checks are done at the load stage. Typical use case is copy reorder that is inserted due to an inPlace conflict.

### Tickets:
 - 63051