### PR TITLE
[Samples] Enabled oname for imported models (#7227)

### DIFF
--- a/inference-engine/samples/speech_sample/main.cpp
+++ b/inference-engine/samples/speech_sample/main.cpp
@@ -688,8 +688,10 @@ int main(int argc, char* argv[]) {
                 }
             }
 
-            for (size_t i = 0; i < outputs.size(); i++) {
-                network.addOutput(outputs[i], ports[i]);
+            if (!FLAGS_m.empty()) {
+                for (size_t i = 0; i < outputs.size(); i++) {
+                    network.addOutput(outputs[i], ports[i]);
+                }
             }
         }
         if (!FLAGS_m.empty()) {


### PR DESCRIPTION
Merge #7227 

### Details:
- Speech sample crashes if oname option is used with an imported network. This option can be used to get the results from specific output ports.

### Tickets:
 - 63230