### PR TITLE
[CPU] Disable NotImpelmented exceptions mechanism for generic node.

### DIFF
--- a/inference-engine/src/mkldnn_plugin/mkldnn_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_node.cpp
@@ -1256,20 +1256,10 @@ MKLDNNNode* MKLDNNNode::NodesFactory::create(const std::shared_ptr<ngraph::Node>
                                              const MKLDNNExtensionManager::Ptr& extMgr, MKLDNNWeightsSharing::Ptr &w_cache) {
     MKLDNNNode *newNode = nullptr;
     std::string errorMessage;
-    try {
+    {
         std::unique_ptr<MKLDNNNode> ol(createNodeIfRegistered(MKLDNNPlugin, Generic, op, eng, w_cache));
         if (ol != nullptr && ol->created(extMgr))
             newNode = ol.release();
-    } catch (const InferenceEngine::Exception& ex) {
-        IE_SUPPRESS_DEPRECATED_START
-        if (ex.getStatus() != NOT_IMPLEMENTED) {
-            throw;
-        } else {
-            const auto currErrorMess = getExceptionDescWithoutStatus(ex);
-            if (!currErrorMess.empty())
-                errorMessage += "\n" + currErrorMess;
-        }
-        IE_SUPPRESS_DEPRECATED_END
     }
 
     if (newNode == nullptr) {

--- a/inference-engine/src/mkldnn_plugin/mkldnn_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_node.cpp
@@ -1254,6 +1254,24 @@ InferenceEngine::Precision MKLDNNNode::getRuntimePrecision() const {
 
 MKLDNNNode* MKLDNNNode::NodesFactory::create(const std::shared_ptr<ngraph::Node>& op, const mkldnn::engine& eng,
                                              const MKLDNNExtensionManager::Ptr& extMgr, MKLDNNWeightsSharing::Ptr &w_cache) {
+    // getExceptionDescWithoutStatus removes redundant information from the exception message. For instance, the NotImplemented
+    // exception is generated in the form: full_path_to_src_file:line_number [ NOT_IMPLEMENTED ] reason.
+    // An example for gather node:
+    // /path-to-openVino-root/inference-engine/src/mkldnn_plugin/nodes/mkldnn_gather_node.cpp:42 [ NOT_IMPLEMENTED ] Only opset7 Gather operation is supported
+    // The most important part of the message is the reason, so the lambda trims everything up to "]"
+    // Note that the op type and its friendly name will also be provided if we fail to create the node.
+    auto getExceptionDescWithoutStatus = [](const InferenceEngine::Exception& ex) {
+        std::string desc = ex.what();
+        size_t pos = desc.find("]");
+        if (pos != std::string::npos) {
+            if (desc.size() == pos + 1) {
+                desc.erase(0, pos + 1);
+            } else {
+                desc.erase(0, pos + 2);
+            }
+        }
+        return desc;
+    };
     MKLDNNNode *newNode = nullptr;
     std::string errorMessage;
     {
@@ -1268,15 +1286,11 @@ MKLDNNNode* MKLDNNNode::NodesFactory::create(const std::shared_ptr<ngraph::Node>
             if (ol != nullptr && ol->created(extMgr))
                 newNode = ol.release();
         } catch (const InferenceEngine::Exception& ex) {
-            IE_SUPPRESS_DEPRECATED_START
-            if (ex.getStatus() != NOT_IMPLEMENTED) {
-                throw;
+            if (dynamic_cast<const NotImplemented*>(&ex) != nullptr) {
+                errorMessage += getExceptionDescWithoutStatus(ex);
             } else {
-                const auto currErrorMess = getExceptionDescWithoutStatus(ex);
-                if (!currErrorMess.empty())
-                    errorMessage += "\n" + currErrorMess;
+                throw;
             }
-            IE_SUPPRESS_DEPRECATED_END
         }
     }
 
@@ -1286,15 +1300,13 @@ MKLDNNNode* MKLDNNNode::NodesFactory::create(const std::shared_ptr<ngraph::Node>
             if (ol != nullptr && ol->created(extMgr))
                 newNode = ol.release();
         } catch (const InferenceEngine::Exception& ex) {
-            IE_SUPPRESS_DEPRECATED_START
-            if (ex.getStatus() != NOT_IMPLEMENTED) {
-                throw;
-            } else {
+            if (dynamic_cast<const NotImplemented*>(&ex) != nullptr) {
                 const auto currErrorMess = getExceptionDescWithoutStatus(ex);
                 if (!currErrorMess.empty())
-                    errorMessage += "\n" + currErrorMess;
+                    errorMessage += errorMessage.empty() ? currErrorMess : "\n" + currErrorMess;
+            } else {
+                throw;
             }
-            IE_SUPPRESS_DEPRECATED_END
         }
     }
 
@@ -1308,7 +1320,7 @@ MKLDNNNode* MKLDNNNode::NodesFactory::create(const std::shared_ptr<ngraph::Node>
     if (!newNode) {
         std::string errorDetails;
         if (!errorMessage.empty()) {
-            errorDetails = "\nDetails: " + errorMessage;
+            errorDetails = "\nDetails:\n" + errorMessage;
         }
         IE_THROW() << "Unsupported operation of type: " << op->get_type_name() << " name: " << op->get_friendly_name() << errorDetails;
     }

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_generic_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_generic_node.cpp
@@ -113,13 +113,13 @@ bool MKLDNNGenericNode::created(const MKLDNNExtensionManager::Ptr &extMgr) {
             extFactory = extMgr->CreateExtensionFactory(ngraphOp);
 
             if (!extFactory)
-                IE_THROW(NotImplemented);
+                return false;
 
             std::vector<InferenceEngine::ILayerImpl::Ptr> impls_no_exec;
             InferenceEngine::ResponseDesc resp;
             InferenceEngine::StatusCode rc = extFactory->getImplementations(impls_no_exec, &resp);
             if (rc == InferenceEngine::NOT_IMPLEMENTED) {
-                IE_THROW(NotImplemented) << resp.msg;
+                return false;
             } else if (rc != InferenceEngine::OK) {
                 IE_THROW() << resp.msg;
             }
@@ -131,8 +131,7 @@ bool MKLDNNGenericNode::created(const MKLDNNExtensionManager::Ptr &extMgr) {
             }
         }
 
-        if (extFactory || !impls.empty())
-            setType(Generic);
+        setType(Generic);
     }
     return created();
 }

--- a/inference-engine/src/mkldnn_plugin/utils/general_utils.h
+++ b/inference-engine/src/mkldnn_plugin/utils/general_utils.h
@@ -41,24 +41,6 @@ constexpr inline bool implication(bool cause, bool cond) {
     return !cause || !!cond;
 }
 
-inline std::string getExceptionDescWithoutStatus(const InferenceEngine::Exception& ex) {
-    std::string desc = ex.what();
-    IE_SUPPRESS_DEPRECATED_START
-    if (ex.getStatus() != 0) {
-        size_t pos = desc.find("]");
-        if (pos != std::string::npos) {
-            if (desc.size() == pos + 1) {
-                desc.erase(0, pos + 1);
-            } else {
-                desc.erase(0, pos + 2);
-            }
-        }
-    }
-    IE_SUPPRESS_DEPRECATED_END
-
-    return desc;
-}
-
 template<typename T>
 std::string vec2str(const std::vector<T> &vec) {
     if (!vec.empty()) {


### PR DESCRIPTION
### Details:
 - *The mechanism of NotImplemented exceptions in MKLDNN NodesFactory is deprecated and should be removed to prevent probable linking issues*

### Tickets:
 - *61707*
