### PR TITLE
[IE Python Speech Sample] Enable `-oname` for a imported model (`-rg` option)

### DIFF
--- a/inference-engine/ie_bridges/python/sample/speech_sample/speech_sample.py
+++ b/inference-engine/ie_bridges/python/sample/speech_sample/speech_sample.py
@@ -94,7 +94,7 @@ def get_output_layer_list(net: Union[IENetwork, ExecutableNetwork],
                 log.error('Incorrect value for -oname/--output_layers option, please specify a port for output layer.')
                 sys.exit(-4)
         else:
-            return [blob_name for blob_name, port in output_name_port]
+            return [blob_name for blob_name, _ in output_name_port]
     else:
         return [list(net.outputs.keys())[-1]]
 

--- a/inference-engine/ie_bridges/python/sample/speech_sample/speech_sample.py
+++ b/inference-engine/ie_bridges/python/sample/speech_sample/speech_sample.py
@@ -2,15 +2,17 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2018-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+import argparse
 import logging as log
 import re
 import sys
 from timeit import default_timer
+from typing import Union
 
 import numpy as np
 from arg_parser import parse_args
 from file_options import read_utterance_file, write_utterance_file
-from openvino.inference_engine import ExecutableNetwork, IECore
+from openvino.inference_engine import ExecutableNetwork, IECore, IENetwork
 
 
 def get_scale_factor(matrix: np.ndarray) -> float:
@@ -75,6 +77,28 @@ def compare_with_reference(result: np.ndarray, reference: np.ndarray):
     log.info(f'stdev error: {stdev_error:.7f}')
 
 
+def get_input_layer_list(net: Union[IENetwork, ExecutableNetwork], args: argparse.Namespace) -> list:
+    return re.split(', |,', args.input_layers) if args.input_layers else [next(iter(net.input_info))]
+
+
+def get_output_layer_list(net: Union[IENetwork, ExecutableNetwork],
+                          args: argparse.Namespace, with_ports: bool) -> list:
+    if args.output_layers:
+        output_name_port = [output.split(':') for output in re.split(', |,', args.output_layers)]
+        try:
+            output_name_port = [(blob_name, int(port)) for blob_name, port in output_name_port]
+        except ValueError:
+            log.error('Output Parameter does not have a port.')
+            sys.exit(-4)
+
+        if with_ports:
+            return output_name_port
+        else:
+            return [blob_name for blob_name, port in output_name_port]
+    else:
+        return [list(net.outputs.keys())[-1]]
+
+
 def main():
     log.basicConfig(format='[ %(levelname)s ] %(message)s', level=log.INFO, stream=sys.stdout)
     args = parse_args()
@@ -91,25 +115,13 @@ def main():
 
 # ---------------------------Step 3. Configure input & output----------------------------------------------------------
         log.info('Configuring input and output blobs')
-        # Get names of input and output blobs
-        if args.input_layers:
-            input_blobs = re.split(', |,', args.input_layers)
-        else:
-            input_blobs = [next(iter(net.input_info))]
-
+        # Mark layers from args.output_layers as outputs
         if args.output_layers:
-            output_name_port = [output.split(':') for output in re.split(', |,', args.output_layers)]
-            try:
-                output_name_port = [(blob_name, int(port)) for blob_name, port in output_name_port]
-            except ValueError:
-                log.error('Output Parameter does not have a port.')
-                sys.exit(-4)
+            net.add_outputs(get_output_layer_list(net, args, with_ports=True))
 
-            net.add_outputs(output_name_port)
-
-            output_blobs = [blob_name for blob_name, port in output_name_port]
-        else:
-            output_blobs = [list(net.outputs.keys())[-1]]
+        # Get names of input and output blobs
+        input_blobs = get_input_layer_list(net, args)
+        output_blobs = get_output_layer_list(net, args, with_ports=False)
 
         # Set input and output precision manually
         for blob_name in input_blobs:
@@ -153,8 +165,8 @@ def main():
         exec_net = ie.load_network(net, device_str, plugin_config)
     else:
         exec_net = ie.import_network(args.import_gna_model, device_str, plugin_config)
-        input_blobs = [next(iter(exec_net.input_info))]
-        output_blobs = [list(exec_net.outputs.keys())[-1]]
+        input_blobs = get_input_layer_list(exec_net, args)
+        output_blobs = get_output_layer_list(exec_net, args, with_ports=False)
 
     if args.input:
         input_files = re.split(', |,', args.input)

--- a/inference-engine/ie_bridges/python/sample/speech_sample/speech_sample.py
+++ b/inference-engine/ie_bridges/python/sample/speech_sample/speech_sample.py
@@ -78,21 +78,21 @@ def compare_with_reference(result: np.ndarray, reference: np.ndarray):
 
 
 def get_input_layer_list(net: Union[IENetwork, ExecutableNetwork], args: argparse.Namespace) -> list:
+    """Get a list of input layer names"""
     return re.split(', |,', args.input_layers) if args.input_layers else [next(iter(net.input_info))]
 
 
 def get_output_layer_list(net: Union[IENetwork, ExecutableNetwork],
                           args: argparse.Namespace, with_ports: bool) -> list:
+    """Get a list of output layer names"""
     if args.output_layers:
         output_name_port = [output.split(':') for output in re.split(', |,', args.output_layers)]
-        try:
-            output_name_port = [(blob_name, int(port)) for blob_name, port in output_name_port]
-        except ValueError:
-            log.error('Output Parameter does not have a port.')
-            sys.exit(-4)
-
         if with_ports:
-            return output_name_port
+            try:
+                return [(blob_name, int(port)) for blob_name, port in output_name_port]
+            except ValueError:
+                log.error('Incorrect value for -oname/--output_layers option, please specify a port for output layer.')
+                sys.exit(-4)
         else:
             return [blob_name for blob_name, port in output_name_port]
     else:


### PR DESCRIPTION
### Details:
 - *The python version of this sample doesn't crash but it ignored `-oname` when a model was imported*
 
### Tickets:
 - *63230*
