### PR TITLE
[GNA] Fixed accuracy degradation caused by the input quantization restriction

### DIFF
--- a/inference-engine/src/gna_plugin/gna_plugin.cpp
+++ b/inference-engine/src/gna_plugin/gna_plugin.cpp
@@ -484,12 +484,12 @@ void GNAPlugin::UpdateInputScaleFromNetwork(InferenceEngine::CNNNetwork & networ
                 return (std::abs(p1 - p2) <= 0.00001f * std::min(std::abs(p1), std::abs(p2)));
             };
             // GNA input is always quantized to int16, so number of levels can't be greater than max uint16
-            size_t levels = std::min(fqLayer.getLevels(), static_cast<size_t>(std::numeric_limits<uint16_t>::max()));
+            size_t levels = std::min(fqLayer.getLevels(), static_cast<size_t>(std::numeric_limits<uint16_t>::max() + 1));
             float scaleInput = (levels - 1) / (inputRange.second[0] - inputRange.first[0]);
             auto minAbsVal = std::min(std::abs(inputRange.second[0]), std::abs(inputRange.first[0]));
             auto maxAbsVal = std::max(std::abs(inputRange.second[0]), std::abs(inputRange.first[0]));
             if (fp32eq(minAbsVal, 0.0f) && !fp32eq(maxAbsVal, 0.0f)) {
-                scaleInput = (fqLayer.getLevels() - 1) / (2 * maxAbsVal);
+                scaleInput = (levels - 1) / (2 * maxAbsVal);
             }
 
             IE_ASSERT(config.inputScaleFactors.size() > inputIdx);


### PR DESCRIPTION
### Details:
 - Accuracy degradation is caused by using max_uint16 value instead of max_uint16 + 1 as maximum levels for int16 quantization

### Tickets:
63423
