### PR TITLE
ValidateBlobs in base reference test class does not compare output shapes

### DIFF
--- a/docs/template_plugin/tests/functional/op_reference/base_reference_test.cpp
+++ b/docs/template_plugin/tests/functional/op_reference/base_reference_test.cpp
@@ -102,6 +102,7 @@ void CommonReferenceTest::ValidateBlobs(const InferenceEngine::Blob::Ptr& refBlo
     ASSERT_TRUE(outBlob != nullptr);
     ASSERT_EQ(refBlob->getTensorDesc().getPrecision(), outBlob->getTensorDesc().getPrecision());
     ASSERT_EQ(refBlob->byteSize(), outBlob->byteSize());
+    ASSERT_EQ(refBlob->getTensorDesc().getDims(), outBlob->getTensorDesc().getDims());
 
     auto mRef = as<InferenceEngine::MemoryBlob>(refBlob);
     IE_ASSERT(mRef);

--- a/docs/template_plugin/tests/functional/op_reference/conversion.hpp
+++ b/docs/template_plugin/tests/functional/op_reference/conversion.hpp
@@ -25,8 +25,8 @@ struct ConvertParams {
     template <class IT, class OT>
     ConvertParams(ngraph::helpers::ConversionTypes convType, const ngraph::PartialShape& shape, const ngraph::element::Type& iType,
                   const ngraph::element::Type& oType, const std::vector<IT>& iValues, const std::vector<OT>& oValues, size_t iSize = 0, size_t oSize = 0)
-        : conversionType(convType), pshape(shape), inType(iType), outType(oType), inputData(CreateBlob(iType, iValues, iSize)),
-          refData(CreateBlob(oType, oValues, oSize)) {}
+        : conversionType(convType), pshape(shape), inType(iType), outType(oType), inputData(CreateBlob(iType, shape, iValues, iSize)),
+          refData(CreateBlob(oType, shape, oValues, oSize)) {}
     ngraph::helpers::ConversionTypes conversionType;
     ngraph::PartialShape pshape;
     ngraph::element::Type inType;

--- a/docs/template_plugin/tests/functional/op_reference/erf.cpp
+++ b/docs/template_plugin/tests/functional/op_reference/erf.cpp
@@ -20,7 +20,7 @@ using namespace InferenceEngine;
 struct ErfParams {
     template <class IT>
     ErfParams(const ngraph::PartialShape& shape, const ngraph::element::Type& iType, const std::vector<IT>& iValues)
-        : pshape(shape), inType(iType), outType(iType), inputData(CreateBlob(iType, iValues)) {
+        : pshape(shape), inType(iType), outType(iType), inputData(CreateBlob(iType, shape, iValues)) {
         std::vector<IT> oValues;
         std::vector<double> output;
         for (auto element : iValues)
@@ -38,7 +38,7 @@ struct ErfParams {
 
         for (auto element : output)
             oValues.push_back(static_cast<IT>(element));
-        refData = CreateBlob(outType, oValues);
+        refData = CreateBlob(outType, pshape, oValues);
     }
     ngraph::PartialShape pshape;
     ngraph::element::Type inType;


### PR DESCRIPTION
### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*
