### PR TITLE
Suppress obsolete MO parameters in help

### DIFF
--- a/model-optimizer/mo/utils/cli_parser.py
+++ b/model-optimizer/mo/utils/cli_parser.py
@@ -334,9 +334,7 @@ def get_common_cli_parser(parser: argparse.ArgumentParser = None):
                                    'Use --input option to specify a value for freezing.',
                               default=None)
     common_group.add_argument('--generate_deprecated_IR_V7',
-                              help='Force to generate deprecated IR V7 with layers from old IR specification.',
-                              action=IgnoredAction,
-                              default=False)
+                              help=argparse.SUPPRESS, action=IgnoredAction, default=False)
     common_group.add_argument('--static_shape',
                               help='Enables IR generation for fixed input shape (folding `ShapeOf` operations and '
                                    'shape-calculating sub-graphs to `Constant`). Changing model input shape using '
@@ -358,8 +356,7 @@ def get_common_cli_parser(parser: argparse.ArgumentParser = None):
                           help='Use the configuration file with transformations description.',
                           action=CanonicalizePathCheckExistenceAction)
     common_group.add_argument('--legacy_ir_generation',
-                              help='Use legacy IR serialization engine',
-                              action=DeprecatedStoreTrue, default=False)
+                              help=argparse.SUPPRESS, action=DeprecatedStoreTrue, default=False)
     return parser
 
 


### PR DESCRIPTION
**Root cause analysis:** We keep obsolete MO parameter (for generation of IRv7) for several releases that can confuse customers.

**Solution:** Use argparse.SUPPRESS for obsolete MO params help

**Ticket:** 61180


Code:
* [x]  Comments - N/A
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR - N/A
* [x]  Transformation preserves original framework node names - N/A


Validation:
* [x]  Unit tests - N/A
* [x]  Framework operation tests - N/A
* [x]  Transformation tests - N/A
* [x]  Model Optimizer IR Reader check - N/A

Documentation:
* [x]  Supported frameworks operations list - N/A
* [x]  Guide on how to convert the **public** model - N/A
* [x]  User guide update - N/A