### PR TITLE
Align PyPI requests version with OV repo 

### DIFF
--- a/.ci/openvino-onnx/watchdog/requirements.txt
+++ b/.ci/openvino-onnx/watchdog/requirements.txt
@@ -2,5 +2,5 @@ python-jenkins==1.7.0
 retrying==1.3.3
 pygithub==1.51
 timeout-decorator==0.4.1
-requests==2.23.0
+requests>=2.23.0
 wheel


### PR DESCRIPTION
### Details:
 - Align PyPI requests version with OV repo 

We have conflicts requirements for OpenVINO repo:
Collecting urllib3>=1.26.4
ERROR: Cannot install requests==2.23.0 and requests>=2.25.1 because these package versions have conflicting dependencies.

The conflict is caused by:
 The user requested requests==2.23.0
 The user requested requests>=2.25.1