### PR TITLE
use 1D convolution in split_convolution_with_large_buffer_size unit test

### DIFF
--- a/inference-engine/tests/unit/gna/ngraph/transformations/gna_split_convolution_with_large_buffer_size.cpp
+++ b/inference-engine/tests/unit/gna/ngraph/transformations/gna_split_convolution_with_large_buffer_size.cpp
@@ -78,7 +78,7 @@ protected:
 class CreateBaseDecorator : public CreateGraphDecorator {
 public:
     // always the first decorator => no prev_builder
-    CreateBaseDecorator(const ngraph::Shape& input_data_shape = ngraph::Shape{1, 64, 4096, 4096}) :
+    CreateBaseDecorator(const ngraph::Shape& input_data_shape = ngraph::Shape{1, 64, 1, 4096}) :
                         CreateGraphDecorator(nullptr),
                         input_data_shape_(input_data_shape) {}
 protected:


### PR DESCRIPTION
### Details:
 - [GNA] Fixes for GNA 3.0 library causes to work in split_convolution_with_large_buffer_size transformation only with 1D convolution

### Tickets:
 - 63541
