### PR TITLE
[MULTI] Fixed devices comparison to respect default device id

### DIFF
--- a/inference-engine/src/cldnn_engine/cldnn_config.h
+++ b/inference-engine/src/cldnn_engine/cldnn_config.h
@@ -30,7 +30,7 @@ struct Config {
                tuningConfig(),
                graph_dumps_dir(""),
                sources_dumps_dir(""),
-               device_id(""),
+               device_id("0"),
                kernels_cache_dir(""),
                n_threads(std::max(static_cast<unsigned int>(1), std::thread::hardware_concurrency())),
                enable_loop_unrolling(true) {

--- a/inference-engine/src/inference_engine/src/ie_core.cpp
+++ b/inference-engine/src/inference_engine/src/ie_core.cpp
@@ -594,6 +594,15 @@ public:
         return copyParameterValue(GetCPPPluginByName(parsed._deviceName).get_metric(name, parsed._config));
     }
 
+    ie::Parameter GetConfig(const std::string& deviceName, const std::string& name) const override {
+        auto parsed = parseDeviceNameIntoConfig(deviceName);
+
+        // we need to return a copy of Parameter object which is created on Core side,
+        // not in InferenceEngine plugin side, which can be unloaded from Core in a parallel thread
+        // TODO: remove this WA after *-31417 is resolved
+        return copyParameterValue(GetCPPPluginByName(parsed._deviceName).get_config(name, parsed._config));
+    }
+
     /**
      * @brief Returns devices available for neural networks inference
      *

--- a/inference-engine/src/multi_device/multi_device_async_infer_request.cpp
+++ b/inference-engine/src/multi_device/multi_device_async_infer_request.cpp
@@ -9,6 +9,9 @@
 #include <map>
 
 #include "multi_device_async_infer_request.hpp"
+#include <ie_icore.hpp>
+#include <ie_metric_helpers.hpp>
+#include <ie_plugin_config.hpp>
 
 namespace MultiDevicePlugin {
     using namespace InferenceEngine;
@@ -35,31 +38,32 @@ MultiDeviceAsyncInferRequest::MultiDeviceAsyncInferRequest(
     _pipeline = {
         // if the request is coming with device-specific remote blobs make sure it is scheduled to the specific device only:
         { /*TaskExecutor*/ std::make_shared<ImmediateExecutor>(), /*task*/ [this] {
-               // by default, no preferred device:
-               _multiDeviceExecutableNetwork->_thisPreferredDeviceName = "";
-               // if any input is remote (e.g. was set with SetBlob), let' use the corresponding device
-               for (const auto &it : _multiDeviceExecutableNetwork->GetInputsInfo()) {
-                   auto b = _inferRequest->GetBlob(it.first);
-                   auto r = b->as<RemoteBlob>();
-                   if (r) {
-                       const auto name = r->getDeviceName();
-                       const auto res = std::find_if(
-                               _multiDeviceExecutableNetwork->_devicePrioritiesInitial.cbegin(),
-                               _multiDeviceExecutableNetwork->_devicePrioritiesInitial.cend(),
-                               [&name](const MultiDevicePlugin::DeviceInformation& d){
-                                    return d.deviceName == name; });
-                       if (_multiDeviceExecutableNetwork->_devicePrioritiesInitial.cend() == res) {
-                           IE_THROW() << "None of the devices (for which current MULTI-device configuration was "
-                                                 "initialized) supports a remote blob created on the device named " << name;
+                // by default, no preferred device:
+                _multiDeviceExecutableNetwork->_thisPreferredDeviceName = "";
+                // if any input is remote (e.g. was set with SetBlob), let' use the corresponding device
+                for (const auto &it : _multiDeviceExecutableNetwork->GetInputsInfo()) {
+                    auto b = _inferRequest->GetBlob(it.first);
+                    auto r = b->as<RemoteBlob>();
+                    if (r) {
+                        const auto name = r->getDeviceName();
+                        const auto res = std::find_if(
+                                _multiDeviceExecutableNetwork->_devicePrioritiesInitial.cbegin(),
+                                _multiDeviceExecutableNetwork->_devicePrioritiesInitial.cend(),
+                                [&name](const MultiDevicePlugin::DeviceInformation& d) {
+                                    return (d.defaultDeviceID.empty() ? d.deviceName : (d.deviceName + "." + d.defaultDeviceID)) == name;
+                                });
+                        if (_multiDeviceExecutableNetwork->_devicePrioritiesInitial.cend() == res) {
+                            IE_THROW() << "None of the devices (for which current MULTI-device configuration was "
+                                          "initialized) supports a remote blob created on the device named " << name;
 
-                       } else {
+                        } else {
                             // it is ok to take the c_str() here (as pointed in the multi_device_exec_network.hpp we need to use const char*)
                             // as the original strings are from the "persistent" vector (with the right lifetime)
-                           _multiDeviceExecutableNetwork->_thisPreferredDeviceName = res->deviceName.c_str();
-                           break;
-                       }
-                   }
-               }
+                            _multiDeviceExecutableNetwork->_thisPreferredDeviceName = res->deviceName.c_str();
+                            break;
+                        }
+                    }
+                }
         }},
         // as the scheduling algo may select any device, this stage accepts the scheduling decision (actual workerRequest)
         // then sets the device-agnostic blobs to the actual (device-specific) request

--- a/inference-engine/src/multi_device/multi_device_exec_network.cpp
+++ b/inference-engine/src/multi_device/multi_device_exec_network.cpp
@@ -372,6 +372,10 @@ std::shared_ptr<InferenceEngine::RemoteContext> MultiDeviceExecutableNetwork::Ge
                              << " Current list of devices allowed via the DEVICE_PRIORITIES config: " << devices_names;
 }
 
+std::shared_ptr<InferenceEngine::ICore> MultiDeviceExecutableNetwork::GetCore() const {
+    return _plugin->GetCore();
+}
+
 InferenceEngine::IInferRequestInternal::Ptr MultiDeviceExecutableNetwork::CreateInferRequestImpl(InferenceEngine::InputsDataMap networkInputs,
                                                                                                 InferenceEngine::OutputsDataMap networkOutputs) {
     auto num = _numRequestsCreated++;

--- a/inference-engine/src/multi_device/multi_device_exec_network.hpp
+++ b/inference-engine/src/multi_device/multi_device_exec_network.hpp
@@ -36,6 +36,7 @@ struct DeviceInformation {
     DeviceName deviceName;
     std::map<std::string, std::string> config;
     int numRequestsPerDevices;
+    std::string defaultDeviceID;
 };
 
 template<typename T>
@@ -131,6 +132,7 @@ public:
     InferenceEngine::IInferRequestInternal::Ptr CreateInferRequestImpl(InferenceEngine::InputsDataMap networkInputs,
                                                                        InferenceEngine::OutputsDataMap networkOutputs) override;
     std::shared_ptr<InferenceEngine::RemoteContext> GetContext() const override;
+    std::shared_ptr<InferenceEngine::ICore> GetCore() const;
     ~MultiDeviceExecutableNetwork() override;
 
     void ScheduleToWorkerInferRequest(InferenceEngine::Task, DeviceName preferred_device = "");

--- a/inference-engine/src/plugin_api/ie_icore.hpp
+++ b/inference-engine/src/plugin_api/ie_icore.hpp
@@ -119,6 +119,17 @@ public:
     virtual Parameter GetMetric(const std::string& deviceName, const std::string& name) const = 0;
 
     /**
+     * @brief Gets configuration dedicated to device behaviour.
+     *
+     * The method is targeted to extract information which can be set via SetConfig method.
+     *
+     * @param deviceName  - A name of a device to get a configuration value.
+     * @param name  - config key.
+     * @return Value of config corresponding to config key.
+     */
+    virtual Parameter GetConfig(const std::string& deviceName, const std::string& name) const = 0;
+
+    /**
      * @brief Returns devices available for neural networks inference
      *
      * @return A vector of devices. The devices are returned as { CPU, GPU.0, GPU.1, MYRIAD }

--- a/inference-engine/src/plugin_api/ie_performance_hints.hpp
+++ b/inference-engine/src/plugin_api/ie_performance_hints.hpp
@@ -72,7 +72,7 @@ struct PerfHintsConfig {
      * @return configuration value
      */
     static std::string CheckPerformanceHintValue(const std::string& val) {
-        if (val == PluginConfigParams::LATENCY || val == PluginConfigParams::THROUGHPUT)
+        if (val == PluginConfigParams::LATENCY || val == PluginConfigParams::THROUGHPUT || val == "")
             return val;
         else
             IE_THROW() << "Wrong value for property key " << PluginConfigParams::KEY_PERFORMANCE_HINT
@@ -88,7 +88,7 @@ struct PerfHintsConfig {
         int val_i = -1;
         try {
             val_i = std::stoi(val);
-            if (val_i > 0)
+            if (val_i >= 0)
                 return val_i;
             else
                 throw std::logic_error("wrong val");

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/behavior/config.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/behavior/config.cpp
@@ -125,6 +125,13 @@ namespace {
                 ::testing::ValuesIn(conf)),
             CorrectConfigAPITests::getTestCaseName);
 
+    INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, DefaultValuesConfigTests,
+            ::testing::Combine(
+                ::testing::ValuesIn(netPrecisions),
+                ::testing::Values(CommonTestUtils::DEVICE_GPU),
+                ::testing::ValuesIn(conf)),
+            CorrectConfigAPITests::getTestCaseName);
+
     INSTANTIATE_TEST_SUITE_P(smoke_GPU_BehaviorTests, CorrectConfigAPITests,
             ::testing::Combine(
                 ::testing::ValuesIn(netPrecisions),

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/multi/gpu_remote_blob_tests.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/multi/gpu_remote_blob_tests.cpp
@@ -10,6 +10,7 @@
 
 const std::vector<DevicesNamesAndSupportPair> device_names_and_support_for_remote_blobs {
         {{GPU}, true}, // GPU via MULTI,
+        {{"GPU.0"}, true}, // GPU.0 via MULTI,
 #ifdef ENABLE_MKL_DNN
         {{GPU, CPU}, true}, // GPU+CPU
         {{CPU, GPU}, true}, // CPU+GPU

--- a/inference-engine/tests/functional/plugin/shared/include/behavior/config.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/behavior/config.hpp
@@ -147,7 +147,10 @@ namespace BehaviorTestsDefinitions {
             InferenceEngine::Parameter configValue;
             ASSERT_NO_THROW(configValue = ie->GetConfig(targetDevice, key));
 
-            ASSERT_NO_THROW(ie->SetConfig({{ key, configValue.as<std::string>()}}, targetDevice));
+            ASSERT_NO_THROW(ie->SetConfig({{ key, configValue.as<std::string>()}}, targetDevice))
+                << "device=" << targetDevice << " "
+                << "config key=" << key << " "
+                << "value=" << configValue.as<std::string>();
         }
     }
 

--- a/inference-engine/tests/functional/plugin/shared/include/behavior/config.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/behavior/config.hpp
@@ -133,6 +133,24 @@ namespace BehaviorTestsDefinitions {
         ASSERT_EQ(std::find(supportedOptions.cbegin(), supportedOptions.cend(), key), supportedOptions.cend());
     }
 
+    using DefaultValuesConfigTests = BehaviorTestsUtils::BehaviorTestsBasic;
+
+    TEST_P(DefaultValuesConfigTests, CanSetDefaultValueBackToPlugin) {
+        // Skip test according to plugin specific disabledTestPatterns() (if any)
+        SKIP_IF_CURRENT_TEST_IS_DISABLED()
+        InferenceEngine::CNNNetwork cnnNet(function);
+        InferenceEngine::Parameter metric;
+        ASSERT_NO_THROW(metric = ie->GetMetric(targetDevice, METRIC_KEY(SUPPORTED_CONFIG_KEYS)));
+        std::vector<std::string> keys = metric;
+
+        for (auto& key : keys) {
+            InferenceEngine::Parameter configValue;
+            ASSERT_NO_THROW(configValue = ie->GetConfig(targetDevice, key));
+
+            ASSERT_NO_THROW(ie->SetConfig({{ key, configValue.as<std::string>()}}, targetDevice));
+        }
+    }
+
     using IncorrectConfigTests = BehaviorTestsUtils::BehaviorTestsBasic;
 
     TEST_P(IncorrectConfigTests, SetConfigWithIncorrectKey) {

--- a/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/cpp_interfaces/interface/mock_icore.hpp
+++ b/inference-engine/tests/ie_test_utils/unit_test_utils/mocks/cpp_interfaces/interface/mock_icore.hpp
@@ -30,6 +30,7 @@ public:
         const InferenceEngine::CNNNetwork&, const std::string&, const std::map<std::string, std::string>&));
 
     MOCK_CONST_METHOD2(GetMetric, InferenceEngine::Parameter(const std::string&, const std::string&));
+    MOCK_CONST_METHOD2(GetConfig, InferenceEngine::Parameter(const std::string&, const std::string&));
     MOCK_CONST_METHOD0(GetAvailableDevices, std::vector<std::string>());
     MOCK_CONST_METHOD1(DeviceSupportsImportExport, bool(const std::string&)); // NOLINT not a cast to bool
 


### PR DESCRIPTION
### Details:
 - [GPU] Changed default value for DEVICE_ID key from "" to "0" to allow passing default value back to plugin in SetConfig call
 - [MULTI] Fixed device name comparison logic in multi plugin to process device ID correctly.

### Tickets:
 - *62004*
