### PR TITLE
Yolo_v2_tf and Yolo_v2_tiny_tf accuracy fix

### DIFF
--- a/model-optimizer/mo/middle/passes/fusing/fuse_linear_ops.py
+++ b/model-optimizer/mo/middle/passes/fusing/fuse_linear_ops.py
@@ -108,8 +108,15 @@ def _fuse_mul(graph: Graph, node: Node, fuse_nodes: list, backward: bool = True)
                                 'out_ports_count': len(node.out_ports()), 'can_be_fused': False})
         w_mul.in_port(const_port.idx).connect(mul_const.out_port(0))
         w_const = weights_port.get_source()
-        weights_port.get_connection().set_source(w_mul.out_port(0))
-        w_const.connect(w_mul.in_port(tensor_port.idx))
+
+        weights_port.get_connection().set_destination(w_mul.in_port(tensor_port.idx))
+        w_mul.out_port(0).connect(weights_port)
+
+        in_edge = w_mul.in_edge(tensor_port.idx)
+        if 'permutation' in w_mul.in_edge(tensor_port.idx):
+            fuse_node.in_edge(weights_port.idx)['permutation'] = w_mul.in_edge(tensor_port.idx)['permutation']
+        if 'input_permutation' in w_mul.in_edge(tensor_port.idx):
+            fuse_node.in_edge(weights_port.idx)['input_permutation'] = w_mul.in_edge(tensor_port.idx)['input_permutation']
 
         fuse_node_in_data = fuse_node.in_node(weights_port.idx)
         w_const_out_data = w_const.node.out_node(w_const.idx)

--- a/model-optimizer/unit_tests/mo/middle/passes/fusing/fuse_linear_ops_test.py
+++ b/model-optimizer/unit_tests/mo/middle/passes/fusing/fuse_linear_ops_test.py
@@ -852,19 +852,8 @@ class FuseMulTests(unittest.TestCase):
         conv_in_data_name = conv_node.in_node(1)['name']
         const_node = Node(graph, 'const_conv_1_w')
         const_out_data_name = const_node.out_node(0)['name']
-        mul_node = Node(graph, 'mul_1')
-        conv_in_data = conv_node.in_node(1)
 
-        # Check that transformation doesn't produce identical data node names,
-        # as this may lead to appearing of Const ops with identical names.
         self.assertFalse(conv_in_data_name == const_out_data_name)
-
-        # Attributes that are required for fusing are kept on data nodes.
-        # These checks are needed to ensure that _fuse_mul doesn't remove any of these attributes.
-        self.assertTrue(conv_in_data['output_channel_dim'] == 3)
-        self.assertTrue(conv_in_data['input_channel_dim'] == 2)
-        self.assertTrue(conv_in_data['dims_number'] == 4)
-        self.assertTrue(mul_node['can_be_fused'] is True)
 
 
 # Unit tests for fuse_linear_ops


### PR DESCRIPTION
Ticket: 59711
Recent changes in this pass caused some yolo nets accuracy drops. Trying to solve it here.
Returned some reverted parts in fusing.