### PR TITLE
Remove deprecated MVNLayerTest class for SLTs

### DIFF
--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/mvn.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/mvn.hpp
@@ -8,11 +8,6 @@
 
 namespace LayerTestsDefinitions {
 
-// DEPRECATED, remove MvnLayerTest when KMB and ARM plugin will switch to use Mvn1LayerTest (#60420)
-TEST_P(MvnLayerTest, CompareWithRefs) {
-    Run();
-};
-
 TEST_P(Mvn1LayerTest, CompareWithRefs) {
     Run();
 };

--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/mvn.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/mvn.hpp
@@ -11,23 +11,6 @@
 
 namespace LayerTestsDefinitions {
 
-// DEPRECATED, remove MvnLayerTest when KMB and ARM plugin will switch to use Mvn1LayerTest (#60420)
-typedef std::tuple<
-        InferenceEngine::SizeVector, // Input shapes
-        InferenceEngine::Precision,  // Input precision
-        bool,                        // Across channels
-        bool,                        // Normalize variance
-        double,                      // Epsilon
-        std::string> mvnParams;      // Device name
-
-class MvnLayerTest : public testing::WithParamInterface<mvnParams>, virtual public LayerTestsUtils::LayerTestsCommon {
-public:
-    static std::string getTestCaseName(const testing::TestParamInfo<mvnParams>& obj);
-
-protected:
-    void SetUp() override;
-};
-
 typedef std::tuple<
         InferenceEngine::SizeVector, // Input shapes
         InferenceEngine::Precision,  // Input precision

--- a/inference-engine/tests/functional/shared_test_classes/src/single_layer/mvn.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/single_layer/mvn.cpp
@@ -7,38 +7,6 @@
 
 namespace LayerTestsDefinitions {
 
-// DEPRECATED, remove MvnLayerTest when KMB and ARM plugin will switch to use Mvn1LayerTest (#60420)
-std::string MvnLayerTest::getTestCaseName(const testing::TestParamInfo<mvnParams>& obj) {
-    InferenceEngine::SizeVector inputShapes;
-    InferenceEngine::Precision inputPrecision;
-    bool acrossChannels, normalizeVariance;
-    double eps;
-    std::string targetDevice;
-    std::tie(inputShapes, inputPrecision, acrossChannels, normalizeVariance, eps, targetDevice) = obj.param;
-    std::ostringstream result;
-    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
-    result << "Precision=" << inputPrecision.name() << "_";
-    result << "AcrossChannels=" << (acrossChannels ? "TRUE" : "FALSE") << "_";
-    result << "NormalizeVariance=" << (normalizeVariance ? "TRUE" : "FALSE") << "_";
-    result << "Epsilon=" << eps << "_";
-    result << "TargetDevice=" << targetDevice;
-    return result.str();
-}
-
-void MvnLayerTest::SetUp() {
-    InferenceEngine::SizeVector inputShapes;
-    InferenceEngine::Precision inputPrecision;
-    bool acrossChanels, normalizeVariance;
-    double eps;
-    std::tie(inputShapes, inputPrecision, acrossChanels, normalizeVariance, eps, targetDevice) = this->GetParam();
-    auto inType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inputPrecision);
-    auto param = ngraph::builder::makeParams(inType, {inputShapes});
-    auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(param));
-    auto mvn = std::dynamic_pointer_cast<ngraph::op::MVN>(ngraph::builder::makeMVN(paramOuts[0], acrossChanels, normalizeVariance, eps));
-    ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(mvn)};
-    function = std::make_shared<ngraph::Function>(results, param, "mvn");
-}
-
 std::string Mvn1LayerTest::getTestCaseName(const testing::TestParamInfo<mvn1Params>& obj) {
     InferenceEngine::SizeVector inputShapes;
     InferenceEngine::Precision inputPrecision;


### PR DESCRIPTION
### Details:
 - *Deprecated MVNLayerTest class, removed from code base*

### Tickets:
 - *60420*
