### PR TITLE
Remove references to prototxt from documentation and docstrings

### DIFF
--- a/docs/IE_DG/Integrate_with_customer_application_new_API.md
+++ b/docs/IE_DG/Integrate_with_customer_application_new_API.md
@@ -35,7 +35,7 @@ Integration process includes the following steps:
 
 @snippet snippets/Integrate_with_customer_application_new_API.cpp part1
 
-**Or read the model from ONNX format** (.onnx and .prototxt are supported formats). You can find more information about the ONNX format support in the document [ONNX format support in the OpenVINO™](./ONNX_Support.md).
+**Or read the model from ONNX format**. You can find more information about the ONNX format support in the document [ONNX format support in the OpenVINO™](./ONNX_Support.md).
 
 @snippet snippets/Integrate_with_customer_application_new_API.cpp part2
 

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pyx
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pyx
@@ -304,7 +304,7 @@ cdef class IECore:
         return versions
 
     ## Reads a network from Intermediate Representation (IR) or ONNX formats and creates an `IENetwork`.
-    #  @param model: A `.xml`, `.onnx`or `.prototxt` model file or string with IR.
+    #  @param model: A `.xml` or `.onnx` model file or string with IR.
     #  @param weights: A `.bin` file of the IR. Depending on `init_from_buffer` value, can be a string path or
     #                  bytes with file content.
     #  @param init_from_buffer: Defines the way of how `model` and `weights` attributes are interpreted.

--- a/inference-engine/samples/benchmark_app/benchmark_app.hpp
+++ b/inference-engine/samples/benchmark_app/benchmark_app.hpp
@@ -19,7 +19,7 @@ static const char input_message[] =
 
 /// @brief message for model argument
 static const char model_message[] =
-    "Required. Path to an .xml/.onnx/.prototxt file with a trained model or to a .blob files with "
+    "Required. Path to an .xml/.onnx file with a trained model or to a .blob files with "
     "a trained compiled model.";
 
 /// @brief message for execution mode

--- a/inference-engine/src/inference_engine/include/ie/ie_core.hpp
+++ b/inference-engine/src/inference_engine/include/ie/ie_core.hpp
@@ -59,7 +59,7 @@ public:
      * For IR format (*.bin):
      *  * if path is empty, will try to read bin file with the same name as xml and
      *  * if bin file with the same name was not found, will load IR without weights.
-     * For ONNX format (*.onnx or *.prototxt):
+     * For ONNX format (*.onnx):
      *  * binPath parameter is not used.
      * @return CNNNetwork
      */
@@ -73,7 +73,7 @@ public:
      * For IR format (*.bin):
      *  * if path is empty, will try to read bin file with the same name as xml and
      *  * if bin file with the same name was not found, will load IR without weights.
-     * For ONNX format (*.onnx or *.prototxt):
+     * For ONNX format (*.onnx):
      *  * binPath parameter is not used.
      * @return CNNNetwork
      */

--- a/inference-engine/src/inference_engine/include/openvino/runtime/core.hpp
+++ b/inference-engine/src/inference_engine/include/openvino/runtime/core.hpp
@@ -69,7 +69,7 @@ public:
      * For IR format (*.bin):
      *  * if path is empty, will try to read bin file with the same name as xml and
      *  * if bin file with the same name was not found, will load IR without weights.
-     * For ONNX format (*.onnx or *.prototxt):
+     * For ONNX format (*.onnx):
      *  * binPath parameter is not used.
      * @return Function
      */
@@ -83,7 +83,7 @@ public:
      * For IR format (*.bin):
      *  * if path is empty, will try to read bin file with the same name as xml and
      *  * if bin file with the same name was not found, will load IR without weights.
-     * For ONNX format (*.onnx or *.prototxt):
+     * For ONNX format (*.onnx):
      *  * binPath parameter is not used.
      * @return Function
      */

--- a/tests/time_tests/scripts/run_timetest.py
+++ b/tests/time_tests/scripts/run_timetest.py
@@ -151,7 +151,7 @@ def cli_parser():
                         required=True,
                         dest="model",
                         type=Path,
-                        help='path to an .xml/.onnx/.prototxt file with a trained model or'
+                        help='path to an .xml/.onnx file with a trained model or'
                              ' to a .blob files with a trained compiled model')
     parser.add_argument('-d',
                         required=True,

--- a/tests/time_tests/src/timetests_helper/cli.h
+++ b/tests/time_tests/src/timetests_helper/cli.h
@@ -14,7 +14,7 @@ static const char help_message[] = "Print a usage message";
 
 /// @brief message for model argument
 static const char model_message[] =
-    "Required. Path to an .xml/.onnx/.prototxt file with a trained model or to "
+    "Required. Path to an .xml/.onnx file with a trained model or to "
     "a .blob files with a trained compiled model.";
 
 /// @brief message for target device argument

--- a/tools/benchmark_tool/openvino/tools/benchmark/parameters.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/parameters.py
@@ -35,7 +35,7 @@ def parse_args():
                       help='Optional. '
                            'Path to a folder with images and/or binaries or to specific image or binary file.')
     args.add_argument('-m', '--path_to_model', type=str, required=True,
-                      help='Required. Path to an .xml/.onnx/.prototxt file with a trained model or '
+                      help='Required. Path to an .xml/.onnx file with a trained model or '
                            'to a .blob file with a trained compiled model.')
     args.add_argument('-d', '--target_device', type=str, required=False, default='CPU',
                       help='Optional. Specify a target device to infer on (the list of available devices is shown below). '


### PR DESCRIPTION
### Details:
 - since we switched to using Protobuf Lite by default in the ONNX importer, we will no longer have support for reading `*.prototxt` files for ONNX models.
 - This PR aims to remove references to reading ONNX `*.prototxt` models from documentation strings.

### Tickets:
 - *63216*
