### PR TITLE
[Paddle] Combine all PDPD test models generation scripts into one cmake command

### DIFF
--- a/ngraph/test/frontend/paddlepaddle/CMakeLists.txt
+++ b/ngraph/test/frontend/paddlepaddle/CMakeLists.txt
@@ -30,23 +30,16 @@ target_compile_definitions(${TARGET_NAME} PRIVATE -D TEST_PADDLE_MODELS_DIRNAME=
 if (paddlepaddle_FOUND)
     set(TEST_PADDLE_MODELS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TEST_PADDLE_MODELS_DIRNAME}/)
 
-    file(GLOB_RECURSE PADDLE_GEN_SCRIPTS ${CMAKE_CURRENT_SOURCE_DIR}/test_models/gen_scripts/generate_*.py)
     file(GLOB_RECURSE PADDLE_ALL_SCRIPTS ${CMAKE_CURRENT_SOURCE_DIR}/*.py)
-    set(OUT_FILES "")
-    foreach(GEN_SCRIPT ${PADDLE_GEN_SCRIPTS})
-        get_filename_component(FILE_WE ${GEN_SCRIPT} NAME_WE)
-        set(OUT_DONE_FILE ${TEST_PADDLE_MODELS}/${FILE_WE}_done.txt)
-        set(OUT_FILES ${OUT_DONE_FILE} ${OUT_FILES})
-        add_custom_command(OUTPUT ${OUT_DONE_FILE}
-                COMMAND ${PYTHON_EXECUTABLE}
-                ${CMAKE_CURRENT_SOURCE_DIR}/test_models/gen_wrapper.py
-                ${GEN_SCRIPT}
-                ${TEST_PADDLE_MODELS}
-                ${OUT_DONE_FILE}
-                DEPENDS ${PADDLE_ALL_SCRIPTS}
-                )
-    endforeach()
-    add_custom_target(paddlepaddle_test_models DEPENDS ${OUT_FILES})
+    set(OUT_FILE ${TEST_PADDLE_MODELS}/generate_done.txt)
+    add_custom_command(OUTPUT ${OUT_FILE}
+            COMMAND ${PYTHON_EXECUTABLE}
+            ${CMAKE_CURRENT_SOURCE_DIR}/test_models/gen_wrapper.py
+            ${CMAKE_CURRENT_SOURCE_DIR}/test_models/gen_scripts
+            ${TEST_PADDLE_MODELS}
+            DEPENDS ${PADDLE_ALL_SCRIPTS}
+            )
+    add_custom_target(paddlepaddle_test_models DEPENDS ${OUT_FILE})
 
     install(DIRECTORY ${TEST_PADDLE_MODELS}
             DESTINATION tests/${TEST_PADDLE_MODELS_DIRNAME}

--- a/ngraph/test/frontend/paddlepaddle/test_models/gen_wrapper.py
+++ b/ngraph/test/frontend/paddlepaddle/test_models/gen_wrapper.py
@@ -1,19 +1,25 @@
+import glob
 import os
 import subprocess
-
 import sys
 
 print(sys.argv)
-if len(sys.argv) < 4:
-    print("Script, output folder and mark file must be specified as arguments")
-    exit(1)
+if len(sys.argv) < 3:
+    print("Gen folder and output folder must be specified as arguments")
+    sys.exit(1)
 
-gen_script = sys.argv[1]
+gen_folder = sys.argv[1]
 out_folder = sys.argv[2]
-mark_file = sys.argv[3]
+mark_file = os.path.join(out_folder, "generate_done.txt")
 
-print("Processing: {} ".format(gen_script))
-subprocess.run([sys.executable, gen_script, out_folder], env=os.environ)
+gen_files = glob.glob(os.path.join(gen_folder, '**/generate_*.py'), recursive=True)
+
+for gen_script in gen_files:
+    print("Processing: {} ".format(gen_script))
+    status = subprocess.run([sys.executable, gen_script, out_folder], env=os.environ)
+    if status.returncode != 0:
+        print("ERROR: PaddlePaddle model gen script FAILED: {}".format(gen_script))
+        sys.exit(1)
 
 # Create mark file indicating that script was executed
 with open(mark_file, "w") as fp:


### PR DESCRIPTION
### Details:
 Currently ~50 separate commands are executed to generate PDPD test models. It can have some negative impact on machines where expensive python environment created for each python command. E.g. 'python' require 1GB of memory, and on 32 cores it can execute 32 python scripts in parallel allocating 32GB of memory. This significantly impacts memory usage and can fail
Solution: create only one Python command which will execute all scripts. In this case 'cmake' will execute only 1 command allocating 1 core.
Cons:
- Total time of generation existing 150 models is increased on my machine from ~6 seconds to ~35 seconds
- If only one sub-script is changed, 'paddlepaddle_test_models' target will execute re-generation of all models

### Tickets:
 - N/A
