### PR TITLE
Revert "Azure CI: Remove IncrediBuild on Windows (#7085)"

### DIFF
--- a/.ci/azure/windows.yml
+++ b/.ci/azure/windows.yml
@@ -16,7 +16,7 @@ jobs:
   timeoutInMinutes: 120
 
   pool:
-    name: WIN_VMSS_VENV_F16S_WU2
+    name: WIN_VMSS_VENV_F8S_WU2
 
   variables:
     system.debug: true
@@ -34,6 +34,8 @@ jobs:
     INSTALL_DIR: $(WORK_DIR)\install_pkg
     INSTALL_TEST_DIR: $(INSTALL_DIR)\tests
     SETUPVARS: $(INSTALL_DIR)\bin\setupvars.bat
+    IB_DIR: C:\Program Files (x86)\IncrediBuild
+    IB_TESTCONSOLE: $(IB_DIR)\IBTestConsole.exe
 
   steps:
   - script: |
@@ -56,6 +58,12 @@ jobs:
       rd /Q /S $(BUILD_DIR) & mkdir $(BUILD_DIR)
       rd /Q /S $(BUILD_SAMPLES_DIR) & mkdir $(BUILD_SAMPLES_DIR)
     displayName: 'Make dir'
+
+  - script: |
+      certutil -urlcache -split -f https://openvinoweb.z5.web.core.windows.net/incredibuild/install_ib_console.bat install_ib_console.bat
+      call install_ib_console.bat
+    workingDirectory: $(WORK_DIR)
+    displayName: 'Install IncrediBuild'
 
   - checkout: self
     clean: true
@@ -101,7 +109,9 @@ jobs:
   - script: dir $(REPO_DIR)\inference-engine\temp\ /s
     displayName: 'List temp SDKs'
 
-  - script: call "$(MSVS_VARS_PATH)" && $(WORK_DIR)\ninja-win\ninja
+  - script: |
+      set PATH=$(WORK_DIR)\ninja-win;%PATH%
+      call "$(MSVS_VARS_PATH)" && "C:\Program Files (x86)\IncrediBuild\BuildConsole.exe" /COMMAND="ninja"
     workingDirectory: $(BUILD_DIR)
     displayName: 'Build Win'
 
@@ -143,8 +153,10 @@ jobs:
     displayName: 'PaddlePaddle Frontend UT'
     continueOnError: false
 
-  - script: call $(SETUPVARS) && $(INSTALL_TEST_DIR)\InferenceEngineUnitTests.exe --gtest_output=xml:TEST-InferenceEngineUnitTests.xml
-    displayName: 'IE UT old'
+  - script: |
+      set PATH=$(IB_DIR);%PATH%
+      call $(SETUPVARS) && "$(IB_TESTCONSOLE)" $(INSTALL_TEST_DIR)\InferenceEngineUnitTests.exe --gtest_output=xml:TEST-InferenceEngineUnitTests-IB.xml
+    displayName: 'IE UT old - IB'
     continueOnError: false
 
   - script: call $(SETUPVARS) && $(INSTALL_TEST_DIR)\ieUnitTests --gtest_output=xml:TEST-ieUnitTests.xml
@@ -175,8 +187,11 @@ jobs:
     displayName: 'TEMPLATE FuncTests'
     continueOnError: false
 
-  - script: $(SETUPVARS) && $(INSTALL_TEST_DIR)\cpuFuncTests.exe --gtest_filter=*smoke* --gtest_output=xml:TEST-cpuFuncTests.xml
-    displayName: 'CPU FuncTests'
+    # call $(SETUPVARS) && $(INSTALL_TEST_DIR)\cpuFuncTests.exe --gtest_filter=*smoke* --gtest_output=xml:TEST-cpuFuncTests.xml
+  - script: |
+      set PATH=$(IB_DIR);%PATH%
+      call $(SETUPVARS) && "$(IB_TESTCONSOLE)" $(INSTALL_TEST_DIR)\cpuFuncTests.exe --gtest_filter=*smoke*:-*CompareWithRefs/base_size=16_pre_nms_topn=100_post_nms_topn=100_nms_thresh=0.7_feat_stride=1_min_size=1_ratio*:*smoke_GRUSequenceCommonZeroClip/GRUSequenceTest.CompareWithRefs/mode=CONVERT_TO_TI_MAX_SEQ_LEN_CONST_seq_lengths* --gtest_output=xml:TEST-cpuFuncTests-IB.xml /testlevel=24
+    displayName: 'CPU FuncTests - IB'
     continueOnError: false
 
   - script: |
@@ -198,3 +213,8 @@ jobs:
       buildPlatform: 'x64' # Optional
       buildConfiguration: 'Windows' # Optional
       #publishRunAttachments: true # Optional
+
+  - script: echo Stop IncrediBuild_Agent && net stop IncrediBuild_Agent
+    displayName: Stop IncrediBuild
+    continueOnError: true
+    enabled: false


### PR DESCRIPTION
Issue with VMem overflow due to PDPD tests has been fixed in master, restoring IncrediBuild

This reverts commit 1aca3019eca6fa27f94a366a6265220711e2c2e7.

