### PR TITLE
[GNA] Initial ngraph UnalignedConcatPass

### DIFF
--- a/src/inference/dev_api/memory_solver.hpp
+++ b/src/inference/dev_api/memory_solver.hpp
@@ -11,6 +11,8 @@
 #include <ie_common.h>
 #include <stdint.h>
 
+#include <fstream>
+#include <iomanip>
 #include <algorithm>
 #include <map>
 #include <vector>
@@ -160,6 +162,9 @@ public:
             _min_required = std::max(_min_required, box.id + box.size);
             _offsets[id] = box.id;  // TODO: move to constructor (use .insert instead of [])
         }
+        //
+        dumpOffsets();
+        dumpTimeline();
 
         return _min_required;
     }
@@ -213,6 +218,43 @@ private:
 
             _top_depth = std::max(_top_depth, top_depth);
             _depth = std::max(_depth, depth);
+        }
+    }
+
+    void dumpOffsets() {
+        std::ofstream dump_file("memory_boxes_offsets.txt", std::ios::out);
+        uint scale = 64;
+        std::sort(_boxes.begin(), _boxes.end(),
+            [](const Box& box_l, const Box& box_r){ return (box_l.id == box_r.id) ? box_l.start < box_r.start : box_l.id < box_r.id;});
+
+        for (const Box& box : _boxes) {
+            dump_file << std::left << std::setw(5) << box.id
+            << " "
+            << std::left << std::setw(10) << "{" + std::to_string(box.start) + "," + std::to_string(box.finish) + "}"
+            << " "
+            << std::left << std::setw(5) << box.size
+            << " "
+            << std::left << std::string(box.id / scale, ' ')
+            << std::left << std::string(box.size / scale, 'X')
+            << std::endl;
+        }
+    }
+
+    void dumpTimeline() {
+        std::ofstream dump_file("memory_boxes_timeline.txt", std::ios::out);
+        std::sort(_boxes.begin(), _boxes.end(),
+            [](const Box& box_l, const Box& box_r){ return (box_l.id == box_r.id) ? box_l.start < box_r.start : box_l.id < box_r.id;});
+
+        for (const Box& box : _boxes) {
+            dump_file << std::left << std::setw(5) << box.id
+            << " "
+            << std::left << std::setw(10) << "{" + std::to_string(box.start) + "," + std::to_string(box.finish) + "}"
+            << " "
+            << std::left << std::setw(5) << box.size
+            << " "
+            << std::left << std::string(box.start, ' ')
+            << std::left << std::string(box.finish - box.start + 1, 'X')
+            << std::endl;
         }
     }
 };

--- a/src/plugins/intel_gna/backend/gna_limitations.hpp
+++ b/src/plugins/intel_gna/backend/gna_limitations.hpp
@@ -32,6 +32,9 @@ constexpr uint32_t maxPoolMaxWindowSize = 6;
 constexpr uint32_t copyMaxGrouping = 8;
 constexpr uint32_t transposeMaxSize = 65528;
 
+constexpr size_t gnaTensorDataAlignment = 64;
+constexpr size_t gnaTensorDataAlignmentElements = gnaTensorDataAlignment / sizeof(int16_t);
+
 inline bool IsTranspose2d(const std::vector<size_t>& shape) {
     return std::count_if(std::begin(shape), std::end(shape), [](size_t dim) { return dim != 1; }) == 2;
 }

--- a/src/plugins/intel_gna/frontend/layer_quantizer.hpp
+++ b/src/plugins/intel_gna/frontend/layer_quantizer.hpp
@@ -333,6 +333,11 @@ inline void quantizeWeightsBiases(const QuantDesc & quantDesc,
         num_columns = wl->_weights->size() / num_rows;
     }
 
+    // Unaligned concat inserted matmul with changed input layout
+    if (!isDiagonal && iIdx == 3 && wl->insData[0].lock().get()->getDims()[2] * num_columns == wl->_weights->size() / num_rows &&
+        oIdx == 1 && wl->outData[0]->getDims()[0] == 1) {
+        num_columns = wl->_weights->size() / num_rows;
+    }
     if (isDiagonal) {
         std::swap(num_rows, num_columns);
     }

--- a/src/plugins/intel_gna/frontend/quantized_layer_params.hpp
+++ b/src/plugins/intel_gna/frontend/quantized_layer_params.hpp
@@ -66,6 +66,15 @@ public:
         SetMinValues(src.GetMinValues(false), false);
         SetMaxValues(src.GetMaxValues(false), false);
     }
+    void Reset() {
+        scale = 1.0f;
+        scale_set = false;
+        levels = 0;
+        input_min_values.clear();
+        input_max_values.clear();
+        output_min_values.clear();
+        output_max_values.clear();
+    }
 
 private:
     float scale = 1.0f;

--- a/src/plugins/intel_gna/frontend/quantized_layer_params.hpp
+++ b/src/plugins/intel_gna/frontend/quantized_layer_params.hpp
@@ -66,15 +66,6 @@ public:
         SetMinValues(src.GetMinValues(false), false);
         SetMaxValues(src.GetMaxValues(false), false);
     }
-    void Reset() {
-        scale = 1.0f;
-        scale_set = false;
-        levels = 0;
-        input_min_values.clear();
-        input_max_values.clear();
-        output_min_values.clear();
-        output_max_values.clear();
-    }
 
 private:
     float scale = 1.0f;

--- a/src/plugins/intel_gna/gna2_model_debug_log.cpp
+++ b/src/plugins/intel_gna/gna2_model_debug_log.cpp
@@ -335,11 +335,11 @@ void DumpPwl(std::ostream& dumpFile, const Gna2Tensor& activation) {
         double a = static_cast<double>(segments[k].Slope) / factor;
         double b = static_cast<double>(segments[k].yBase) - ((static_cast<double>(B) * segments[k].Slope) / factor);
 
-        dumpFile << "\t\tBase value for input (B) : " << B << "\n";
-        dumpFile << "\t\tBase value for output (b) : " << segments[k].yBase << "\n";
-        dumpFile << "\t\tSegment slope (S): " << segments[k].Slope << "\n";
-        dumpFile << "\t\tShift (scale) : " << scale << "\n";
-        dumpFile << "\t\ty = ax + b:   a = " << a << ", b = " << b;
+        dumpFile << "\t\tBase input (B) : " << B << ", ";
+        dumpFile << "Base output (b) : " << segments[k].yBase << ", ";
+        dumpFile << "Slope (S): " << segments[k].Slope << ", ";
+        dumpFile << "Shift (scale) : " << scale << ", ";
+        dumpFile << "y = (" << a << ")x + (" << b << ")";
         if (segments[k].Slope != 0) {
             double x0 = static_cast<double>(B) - ((static_cast<double>(segments[k].yBase) * factor) / segments[k].Slope);
             dumpFile << ", x0 = " << x0;
@@ -369,7 +369,7 @@ void DumpCharArray(std::ostream& dumpFile, const char *carray,  size_t count) {
 
 } // namespace
 
-void DumpGna2Model(const Gna2Model& gnaModel, const std::string dumpFolderNameGNA, bool dumpData) {
+void DumpGna2Model(const Gna2Model& gnaModel, const std::string dumpFolderNameGNA, bool dumpData, const void* memoryBegin) {
     std::stringstream dumpFileName;
     uint32_t opsNo = gnaModel.NumberOfOperations;
     std::time_t currTime = std::time(nullptr);
@@ -377,7 +377,7 @@ void DumpGna2Model(const Gna2Model& gnaModel, const std::string dumpFolderNameGN
     dumpFileName << dumpFolderNameGNA << "Gna2ModelDebugDump_" << opsNo << "_layer_" << std::put_time(std::localtime(&currTime), "%Y%m%d%H%M%S");
 
     std::ofstream dumpFile(dumpFileName.str() + ".txt", std::ios::out);
-
+    dumpFile << "Memory begin: " << memoryBegin << "\n";
     dumpFile << "Layers (operations) count: " << opsNo << "\n";
 
     for (size_t i = 0; i < opsNo; i++) {
@@ -395,9 +395,11 @@ void DumpGna2Model(const Gna2Model& gnaModel, const std::string dumpFolderNameGN
                 continue;
             }
             const auto& operand = *operation.Operands[j];
+            const auto offsetFromBegin = static_cast<uint8_t*>(operand.Data) - static_cast<const uint8_t*>(memoryBegin);
             dumpFile << "\tOperand " << j << " (" << GetOperandName(operation.Type, j) << ")"
                 << " type: " << GetOperandType(operand.Type) <<
                 " shape: " << GetSimpleString(operand.Shape) <<
+                " offset: " << offsetFromBegin <<
                 " data: " << operand.Data <<
                 " layout: ";
 

--- a/src/plugins/intel_gna/gna2_model_debug_log.hpp
+++ b/src/plugins/intel_gna/gna2_model_debug_log.hpp
@@ -9,4 +9,4 @@
 #include "gna2-model-api.h"
 
 void WriteInputAndOutputTextGNAImpl(const Gna2Model & gnaModel, const std::string dumpFolderNameGNA, const std::string refFolderName);
-void DumpGna2Model(const Gna2Model& gnaModel, const std::string dumpFolderNameGNA, bool dumpData);
+void DumpGna2Model(const Gna2Model& gnaModel, const std::string dumpFolderNameGNA, bool dumpData, const void * memoryBegin);

--- a/src/plugins/intel_gna/gna_data_types.hpp
+++ b/src/plugins/intel_gna/gna_data_types.hpp
@@ -41,4 +41,5 @@ namespace GNAPluginNS {
     using SplitConnection = std::unordered_map<std::string, GNASplitLayer>;
     using CropConnection = std::unordered_map<std::string, GNACropLayer>;
     using ConstConnections = std::unordered_map<std::string, void*>;
+    using PadConnection = std::unordered_map<std::string, GNAPadLayer>;
 }  // namespace GNAPluginNS

--- a/src/plugins/intel_gna/gna_device.cpp
+++ b/src/plugins/intel_gna/gna_device.cpp
@@ -24,7 +24,7 @@
 #include "gna_plugin_log.hpp"
 #include "layers/gna_convolution_layer.hpp"
 
-//#define MODEL_DUMP
+// #define MODEL_DUMP
 
 std::mutex GNADeviceHelper::acrossPluginsSync{};
 
@@ -127,7 +127,7 @@ uint32_t GNADeviceHelper::createModel(Gna2Model& gnaModel) const {
 #else
         "./";
 #endif
-    DumpGna2Model(gnaModel, path, false);
+    DumpGna2Model(gnaModel, path, false, dumpXNNROPtr);
 #endif
     const auto status = Gna2ModelCreate(nGnaDeviceIndex, &gnaModel, &modelId);
 

--- a/src/plugins/intel_gna/gna_graph_compiler.cpp
+++ b/src/plugins/intel_gna/gna_graph_compiler.cpp
@@ -2314,7 +2314,7 @@ void GNAGraphCompiler::connectOutput(InferenceEngine::CNNLayerPtr layer,
                 auto ss = FindSSAfterCO(layer, concat, special_offset);
 
                 if (LayerInfo(ss).isCropBeforeSubgraph()) {
-                    gnamem->reserve_ptr(layer, ptr, num_data_bytes_out, 64);
+                    gnamem->reserve_ptr(nullptr, ptr, num_data_bytes_out, 64);
                     return;
                 }
                 auto newConcat = CNNNetGetNextLayerSkipCertain(ss, 0, 0, [](CNNLayerPtr) {return false; }).first;
@@ -2332,7 +2332,7 @@ void GNAGraphCompiler::connectOutput(InferenceEngine::CNNLayerPtr layer,
                     auto cropLayer = dynamic_cast<InferenceEngine::CropLayer*> (layer.get());
                     special_offset -= cropLayer->offset[1] * precision;
                 }
-                gnamem->bind_ptr(layer, ptr, &concatLayerInfoItem.gna_ptr, special_offset);
+                gnamem->bind_ptr(nullptr, ptr, &concatLayerInfoItem.gna_ptr, special_offset);
                 return;
             }
 

--- a/src/plugins/intel_gna/gna_graph_compiler.hpp
+++ b/src/plugins/intel_gna/gna_graph_compiler.hpp
@@ -41,6 +41,7 @@ private:
 
     SplitConnection  split_connection;
     CropConnection   crop_connection;
+    PadConnection    pad_connection;
 
     intel_dnn_component_t * find_first_unused_input(InferenceEngine::CNNLayerPtr current);
 
@@ -96,6 +97,12 @@ public:
                                                 int idx = 0,
                                                 bool connectTo = true);
 
+    GNAPluginNS::ConnectionDetails connectInputSplit(InferenceEngine::CNNLayerPtr splittingLayer,
+        void* ptr,
+        const InferenceEngine::CNNLayerPtr splitConsumerLayer,
+        const int splitConsumerLayerInputIndex,
+        const int offset);
+
     /**
      * Fill in the Affine layer weights
     * @param layer - affine layer pointer
@@ -125,6 +132,7 @@ public:
     void FakeQuantizePrimitive(InferenceEngine::CNNLayerPtr);
     void CopyPrimitive(InferenceEngine::CNNLayerPtr);
     void GemmPrimitive(InferenceEngine::CNNLayerPtr);
+    void PadPrimitive(InferenceEngine::CNNLayerPtr);
 
     void finalizeConvolution1DPrimitive(InferenceEngine::CNNLayerPtr,
         uint32_t in_batch, uint32_t in_channels, uint32_t in_width,

--- a/src/plugins/intel_gna/gna_graph_patterns.hpp
+++ b/src/plugins/intel_gna/gna_graph_patterns.hpp
@@ -203,7 +203,7 @@ inline InferenceEngine::CNNLayerPtr FindPermutationAfterConvolutionInKaldiModel(
 inline bool MustBeConvertedFromNCHWToNHWC(const std::vector<InferenceEngine::CNNLayerPtr> &layers) {
     for (auto& l : layers) {
         if (!LayerInfo(l).isConvolution()) continue;
-
+        if (LayerInfo(l).isConvolutionFromUnalignedConcatFilter()) continue;
         InferenceEngine::CNNLayerPtr next;
         std::tie(std::ignore, next) = FindPermutationsAroundConvolutionInNHWCModel(l);
         if (next != nullptr) return false;

--- a/src/plugins/intel_gna/gna_graph_tools.hpp
+++ b/src/plugins/intel_gna/gna_graph_tools.hpp
@@ -169,8 +169,9 @@ inline std::pair<InferenceEngine::CNNLayerPtr, std::vector<int>>  CNNNetCheckNex
     auto outLayer = getInputTo(layer->outData[oidx]).begin();
     std::advance(outLayer, iidx);
 
-    int new_oidx = shouldSkip(outLayer->second) ? 0 : oidx;
-    int new_iidx = shouldSkip(outLayer->second) ? 0 : iidx;
+    const int new_oidx = shouldSkip(outLayer->second) ? 0 : oidx;
+    const int new_iidx = shouldSkip(outLayer->second) ? 0 : iidx;
+    auto outDataFinal = layer->outData[new_oidx];
 
     while (shouldSkip(outLayer->second)) {
         if (outLayer->second->outData.size() <= new_oidx) {
@@ -183,11 +184,11 @@ inline std::pair<InferenceEngine::CNNLayerPtr, std::vector<int>>  CNNNetCheckNex
             THROW_GNA_LAYER_EXCEPTION(outLayer->second) << " no next output layer for outdata: " << new_oidx << " and inputTo index: " << new_iidx;
         }
 
-        layer = outLayer->second;
-        outLayer = getInputTo(layer->outData[new_oidx]).begin();
+        outDataFinal = outLayer->second->outData[new_oidx];
+        outLayer = getInputTo(outDataFinal).begin();
     }
 
-    auto insDataIdx = CNNLayerFindInsDataIdxes(layer->outData[new_oidx], outLayer->second);
+    auto insDataIdx = CNNLayerFindInsDataIdxes(outDataFinal, outLayer->second);
     return { outLayer->second, insDataIdx };
 }
 

--- a/src/plugins/intel_gna/gna_lib_ver_selector.hpp
+++ b/src/plugins/intel_gna/gna_lib_ver_selector.hpp
@@ -27,3 +27,13 @@
  * Used for calculating memory sizes of GNA data arrays
  */
 #define ALIGN64(number) ALIGN(number, 64)
+
+template <typename T, typename N>
+T DownAlignTo(T val, N to) {
+    return val - (val % to);
+}
+
+template <typename T, typename N>
+T UpAlignTo(T val, N to) {
+    return (val + to - 1) / to * to;
+}

--- a/src/plugins/intel_gna/gna_plugin.cpp
+++ b/src/plugins/intel_gna/gna_plugin.cpp
@@ -997,14 +997,7 @@ void GNAPlugin::LoadNetwork(CNNNetwork & _network) {
         gnamem->reserve_ptr(nullptr, &pParallelExecutionData, gnamem->getRWBytes() * (gnaFlags->gna_lib_async_threads_num - 1), 64);
     }
 
-    // TODO: Remove when issue causing failure in subset of tests from:
-    // smoke_Decompose2DConvStridesDilations/Decompose2DConvTest.CompareWithRefs including:
-    //    M=0_IS=(1.8.8.32)_K(1.2)_S(2.1)_PB(1.1)_PE(3.1)_D=(1.1)_O=4_AP=valid_B=(1.4.1.1)_B=(1.1.1.4)_MPP=(1.2)_MPS=(1.1)_netPRC=FP32
-    //    targetDevice=GNA__configItem=GNA_DEVICE_MODE_GNA_SW_FP32_configItem=GNA_EXEC_TARGET_GNA_TARGET_2_0_configItem=GNA_SCALE_FACTOR_0_1
-    // is resolved
-    const auto disableCompactMode = gnaFlags->sw_fp32 && unaligned_concat_converted;
-
-    gnamem->commit(gnaFlags->compact_mode && !disableCompactMode);
+    gnamem->commit(gnaFlags->compact_mode);
 
     dnn->Init(gnamem->getBasePtr(),
              gnamem->getTotalBytes(),

--- a/src/plugins/intel_gna/gna_plugin_log.hpp
+++ b/src/plugins/intel_gna/gna_plugin_log.hpp
@@ -75,4 +75,3 @@ if (!(expr)) { \
 #define THROW_GNA_EXCEPTION IE_THROW() << "[GNAPlugin] in function " << __PRETTY_FUNCTION__<< ": "
 #define THROW_GNA_LAYER_EXCEPTION(layer) THROW_GNA_EXCEPTION << LAYER_NAME(layer)
 #define LAYER_NAME(layer) (layer)->type << " layer : \"" << (layer)->name << "\" "
-

--- a/src/plugins/intel_gna/layers/gna_concat_layer.hpp
+++ b/src/plugins/intel_gna/layers/gna_concat_layer.hpp
@@ -10,6 +10,9 @@
 #include <legacy/ie_layers.h>
 
 namespace GNAPluginNS {
+
+constexpr int orderingConcatAxis = 1;
+
 class GNAConcatLayer {
     InferenceEngine::CNNLayerPtr concatLayer;
 
@@ -45,5 +48,27 @@ public:
     };
 
     std::vector<ConcatConnectedLayerInfo> concatInputLayers;
+
+    ConcatConnectedLayerInfo& GetInput(const std::string& name) {
+        auto it = std::find_if(concatInputLayers.begin(),
+            concatInputLayers.end(),
+            [&name](GNAPluginNS::GNAConcatLayer::ConcatConnectedLayerInfo& item) {
+                return item.name == name;
+            });
+        if (it != concatInputLayers.end()) {
+            return *it;
+        }
+        THROW_GNA_LAYER_EXCEPTION(concatLayer) << "Can not find concat input connection for " << name << " layer\n";
+    }
+};
+
+class GNAPadLayer {
+public:
+    explicit GNAPadLayer() = default;
+
+    /**
+    * pointer to gna memory request
+    */
+    void* gna_ptr = nullptr;
 };
 }  // namespace GNAPluginNS

--- a/src/plugins/intel_gna/layers/gna_crop_layer.hpp
+++ b/src/plugins/intel_gna/layers/gna_crop_layer.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <legacy/ie_layers.h>
+#include <gna_plugin_log.hpp>
 
 namespace GNAPluginNS {
 class GNACropLayer {
@@ -12,10 +13,24 @@ class GNACropLayer {
 
 public:
     explicit GNACropLayer(InferenceEngine::CNNLayerPtr layer) :
-        cropLayer(layer)
-    {}
+        cropLayer(layer) {
+        IE_ASSERT(layer != nullptr);
+    }
+    void * getGnaPtr() const {
+        gnalog() << "[GNACropLayer: " << cropLayer->name << "] getGnaPtr() == " << gna_ptr << "\n";
+        return gna_ptr;
+    }
+    void setGnaPtr(void* ptr) {
+        IE_ASSERT(ptr);
+        IE_ASSERT(gna_ptr == nullptr);
+        gna_ptr = ptr;
+        gnalog() << "[GNACropLayer: " << cropLayer->name << "] setGnaPtr(" << ptr << ")\n";
+    }
 
+private:
     InferenceEngine::CNNLayerPtr getCrop() { return cropLayer; }
+
+public:
     /**
      * pointer to gna croped memory beginning
      */

--- a/src/plugins/intel_gna/layers/gna_layer_type.hpp
+++ b/src/plugins/intel_gna/layers/gna_layer_type.hpp
@@ -49,6 +49,7 @@ enum LayerType {
     SoftSign,
     FakeQuantize,
     Gemm,
+    Pad,
     NO_TYPE
 };
 
@@ -88,6 +89,7 @@ static const InferenceEngine::details::caseless_map<std::string, GNAPluginNS::La
         { "SoftSign", SoftSign },
         { "FakeQuantize", FakeQuantize },
         {"Gemm", Gemm},
+        {"Pad", Pad},
 };
 
 GNAPluginNS::LayerType LayerTypeFromStr(const std::string &str);

--- a/src/plugins/intel_gna/layers/gna_split_layer.hpp
+++ b/src/plugins/intel_gna/layers/gna_split_layer.hpp
@@ -23,7 +23,6 @@ public:
      * gna memory of this size is reserved for split
      */
     size_t reserved_size = 0;
-    bool output_allocation_flag = false;
     /**
      * gna memory of this offset from gna_ptr
      */

--- a/src/plugins/intel_gna/memory/gna_mem_requests.hpp
+++ b/src/plugins/intel_gna/memory/gna_mem_requests.hpp
@@ -10,6 +10,8 @@
 
 #include "gna_plugin_log.hpp"
 
+#include "ie_common.h"
+
 namespace GNAPluginNS {
 namespace memory {
 
@@ -70,8 +72,34 @@ inline const char* rTypeToStr(uint8_t type) {
 struct MemRequest {
     rRegion  _region;
     uint8_t   _type;
+
     void *_ptr_out;
     const void *_ptr_in = nullptr;
+
+    bool IsPtrOutSet() const {
+        return _ptr_out != nullptr;
+    }
+    bool IsPtrInSet() const {
+        return _ptr_in != nullptr;
+    }
+    uint8_t* GetPtrOutValue() const {
+        IE_ASSERT(_ptr_out != nullptr);
+        return reinterpret_cast<uint8_t*>(*reinterpret_cast<void**>(_ptr_out));
+    }
+    void SetPtrOutValue(void * valueIn) {
+        IE_ASSERT(_ptr_out != nullptr);
+        *reinterpret_cast<void**>(_ptr_out) = valueIn;
+    }
+    bool IsInPtrEqualToOutPtrOf(const MemRequest& reference) const {
+        return _ptr_in == reference._ptr_out;
+    }
+    const void * GetInPtr() const {
+        IE_ASSERT(_ptr_in != nullptr);
+        return _ptr_in;
+    }
+    void* GetOutPtr() const {
+        return _ptr_out;
+    }
     std::function<void(void * data, size_t size)> _initializer;
     // holds arbitrary value
     std::vector<uint8_t> _data;

--- a/src/plugins/intel_gna/memory/gna_mem_requests.hpp
+++ b/src/plugins/intel_gna/memory/gna_mem_requests.hpp
@@ -76,30 +76,6 @@ struct MemRequest {
     void *_ptr_out;
     const void *_ptr_in = nullptr;
 
-    bool IsPtrOutSet() const {
-        return _ptr_out != nullptr;
-    }
-    bool IsPtrInSet() const {
-        return _ptr_in != nullptr;
-    }
-    uint8_t* GetPtrOutValue() const {
-        IE_ASSERT(_ptr_out != nullptr);
-        return reinterpret_cast<uint8_t*>(*reinterpret_cast<void**>(_ptr_out));
-    }
-    void SetPtrOutValue(void * valueIn) {
-        IE_ASSERT(_ptr_out != nullptr);
-        *reinterpret_cast<void**>(_ptr_out) = valueIn;
-    }
-    bool IsInPtrEqualToOutPtrOf(const MemRequest& reference) const {
-        return _ptr_in == reference._ptr_out;
-    }
-    const void * GetInPtr() const {
-        IE_ASSERT(_ptr_in != nullptr);
-        return _ptr_in;
-    }
-    void* GetOutPtr() const {
-        return _ptr_out;
-    }
     std::function<void(void * data, size_t size)> _initializer;
     // holds arbitrary value
     std::vector<uint8_t> _data;

--- a/src/plugins/intel_gna/memory/gna_memory.hpp
+++ b/src/plugins/intel_gna/memory/gna_memory.hpp
@@ -4,19 +4,20 @@
 
 #pragma once
 
-#include "gna_mem_requests.hpp"
 #include <ie_memcpy.h>
-#include "gna_mem_requests_queue.hpp"
 #include <cstdint>
 #include <memory>
 #include <vector>
 #include <list>
 #include <algorithm>
 #include <functional>
+
 #include <iostream>
 #include "gna_lib_ver_selector.hpp"
 #include "memory_solver.hpp"
 #include "gna_plugin_log.hpp"
+#include "gna_mem_requests.hpp"
+#include "gna_mem_requests_queue.hpp"
 
 #ifdef GNA_HEAP_PROFILER
 #include <iomanip>
@@ -131,7 +132,7 @@ class GNAMemory : public GNAMemRequestsQueue {
                 // std::cout << "  [binded=" << rTypeToStr(re._type) << ", ptr=" << re._ptr_out <<"]\n";
                 visitor(reference, re);
                 // primitive loop check
-                if (re._ptr_in == re._ptr_out) continue;
+                if (re.IsInPtrEqualToOutPtrOf(re)) continue;
                 // TODO: no circular dependency checking, only tree-style dependency with loops supported
                 iterate_binded(re, visitor);
             }

--- a/src/plugins/intel_gna/memory/gna_memory.hpp
+++ b/src/plugins/intel_gna/memory/gna_memory.hpp
@@ -132,7 +132,7 @@ class GNAMemory : public GNAMemRequestsQueue {
                 // std::cout << "  [binded=" << rTypeToStr(re._type) << ", ptr=" << re._ptr_out <<"]\n";
                 visitor(reference, re);
                 // primitive loop check
-                if (re.IsInPtrEqualToOutPtrOf(re)) continue;
+                if (re._ptr_in == re._ptr_out) continue;
                 // TODO: no circular dependency checking, only tree-style dependency with loops supported
                 iterate_binded(re, visitor);
             }

--- a/src/plugins/intel_gna/optimizer/gna_pass_manager.cpp
+++ b/src/plugins/intel_gna/optimizer/gna_pass_manager.cpp
@@ -1720,6 +1720,12 @@ void UnrollTIPass::run() {
     }
 }
 
+// Helper class to be used by RemoveConstPass
+// This class overrides InferenceEngine::ConstTransformer
+// It disallows trimming of some nodes by ConstTransformer::fullTrim()
+// The nodes which are needed to be preserved were inserted by ConvertUnalignedConcatIntoGnaGraph
+// and have to be converted to GNA primitives to properly handle unaligned Concat for GNA
+// When RemoveConstPass removed (or moved to ngraph) this class could be removed as well
 class GnaConstTransformer : public ConstTransformer {
 public:
     template<typename T>

--- a/src/plugins/intel_gna/transformations/convert_unaligned_concat_to_cnn.cpp
+++ b/src/plugins/intel_gna/transformations/convert_unaligned_concat_to_cnn.cpp
@@ -1,0 +1,554 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "convert_unaligned_concat_to_cnn.hpp"
+
+#include <openvino/cc/ngraph/itt.hpp>
+#include <ngraph/opsets/opset7.hpp>
+#include <ngraph/pattern/op/or.hpp>
+#include <ngraph/pattern/op/wrap_type.hpp>
+#include <ngraph/rt_info.hpp>
+#include <gna_plugin_log.hpp>
+
+#include <ngraph/shape.hpp>
+#include "layers/gna_concat_layer.hpp"
+#include <transformations/rt_info/disable_constant_folding.hpp>
+#include "backend/gna_limitations.hpp"
+#include "gna_lib_ver_selector.hpp"
+
+using namespace GNAPluginNS;
+using ngraph::op::Op;
+using ngraph::Output;
+
+using GNAPluginNS::GNALimitations::convMinFiltersNum;
+using GNAPluginNS::GNALimitations::convFilterSizeDivider;
+using GNAPluginNS::GNALimitations::noOfInputsDivisor;
+using GNAPluginNS::GNALimitations::gnaTensorDataAlignmentElements;
+
+typedef std::vector<float> DelayedCopyCnnFilter;
+typedef std::vector<float> DelayedCopyAffineFilter;
+
+// Example of returned vector
+// numberOfFilters = 4             0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0
+// filterLength = 16               0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0
+// delayedCopySourceOffset = 5     0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0
+//                                 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0
+static DelayedCopyCnnFilter getDelayedCopyCnnFilter(const size_t numberOfFilters,
+                                             const size_t filterLength,
+                                             const size_t delayedCopySourceOffset) {
+    IE_ASSERT(filterLength >= numberOfFilters);
+    IE_ASSERT(filterLength - numberOfFilters >= delayedCopySourceOffset);
+    const auto totalFilterLength = numberOfFilters * filterLength;
+    DelayedCopyCnnFilter value(totalFilterLength, 0.f);
+    for (uint32_t i = 0; i < numberOfFilters; i++) {
+        value.at(i * filterLength + delayedCopySourceOffset + i) = 1;
+    }
+    return value;
+}
+
+// Example of returned vector
+// numberOfInputs = 8          0 0 0 0 0 0 0 0
+// numberOfOutputs = 5         0 0 0 0 0 0 0 0
+// firstInputIndex = 0         1 0 0 0 0 0 0 0
+// firstOutputIndex = 2        0 1 0 0 0 0 0 0
+//                             0 0 1 0 0 0 0 0
+static DelayedCopyAffineFilter GetCopyAffineFilterValues(size_t numberOfInputs, size_t numberOfOutputs, size_t firstInputIndex, size_t firstOutputIndex) {
+    IE_ASSERT(numberOfInputs > 0);
+    IE_ASSERT(numberOfOutputs > 0);
+    IE_ASSERT(numberOfInputs > firstInputIndex);
+    IE_ASSERT(numberOfOutputs > firstOutputIndex);
+    DelayedCopyAffineFilter values(numberOfInputs * numberOfOutputs, 0);
+    const auto additionalOutputs = std::min(firstInputIndex, firstOutputIndex);
+    firstInputIndex -= additionalOutputs;
+    firstOutputIndex -= additionalOutputs;
+    for (; firstInputIndex < numberOfInputs && firstOutputIndex < numberOfOutputs; firstInputIndex++, firstOutputIndex++) {
+        values[firstInputIndex * numberOfOutputs + firstOutputIndex] = 1;
+    }
+    return values;
+}
+
+template <typename T, typename N>
+std::shared_ptr < ngraph::opset7::Constant > GetConstant2U(T e1, N e2) {
+    const auto values = std::vector<uint32_t>{ static_cast<uint32_t>(e1), static_cast<uint32_t>(e2) };
+    return std::make_shared< ngraph::opset7::Constant>(ov::element::u32, ngraph::Shape{ 2 }, values);
+}
+
+template <typename T>
+std::shared_ptr < ngraph::opset7::Constant > CreateConstantU64V(const std::vector<T>& values) {
+    return ngraph::opset7::Constant::create(ov::element::u64, ngraph::Shape{ values.size() }, values);
+}
+
+static std::string rtValue(size_t val) {
+    return std::to_string(val);
+}
+
+template <typename N, typename K>
+std::shared_ptr < ov::Node > AppendStridedSliceOn2DNode(
+    std::shared_ptr<ov::Node> node, N dim2Begin, K dim2End) {
+    std::vector<int64_t> mask{};
+    IE_ASSERT(node->get_output_size() == 1);
+    auto shape = node->get_output_shape(0);
+    IE_ASSERT(shape.size() == 2);
+    constexpr auto expectedDim1 = 1;
+    IE_ASSERT(shape[0] == expectedDim1);
+    if (dim2Begin == 0 && dim2End == shape[1]) {
+        return node;        // don't append crop as not needed
+    }
+    auto begin = GetConstant2U(0, dim2Begin);
+    auto end = GetConstant2U(expectedDim1, dim2End);
+    auto outputNode = std::make_shared < ngraph::opset7::StridedSlice >(node, begin, end, mask, mask);
+    return outputNode;
+}
+
+static std::shared_ptr< ngraph::opset7::MatMul> AppendAffineCopy(std::shared_ptr<ov::Node> node,
+    size_t numberOfInputs, size_t numberOfOutputs,
+    size_t firstInputIndex, size_t firstOutputIndex) {
+    IE_ASSERT(node->get_output_size() == 1);
+    IE_ASSERT(node->get_output_shape(0).size() == 2);
+    IE_ASSERT(node->get_output_shape(0)[0] == 1);
+    IE_ASSERT(node->get_output_shape(0)[1] == numberOfInputs);
+    const auto elementType = node->get_output_element_type(0);
+    auto values = GetCopyAffineFilterValues(numberOfInputs, numberOfOutputs,
+        firstInputIndex, firstOutputIndex);
+    auto shape = ngraph::Shape{ numberOfInputs, numberOfOutputs };
+    auto filter = std::make_shared< ngraph::opset7::Constant>(elementType, shape, values);
+    auto appended = std::make_shared< ngraph::opset7::MatMul>(node, filter);
+    return appended;
+}
+
+static void DisableCF(std::shared_ptr<ov::Node> node) {
+    node->get_rt_info()[ov::pass::DisableConstantFolding::get_type_info_static()];
+    // TODO: investigate why ov::disable_constant_folding(node) is not working for some tests including
+    // smoke_concat_multi_input/ConcatMultiInput.CompareWithRefConstOnly/IS=(1.3)(1.3)(1.3)_netPRC=FP32_targetDevice=GNA
+    // It would work if DisableConstantFolding.is_copyable() would return true
+}
+
+// Returns a set of GNA Prmitives for aligned component of a concat
+static ngraph::NodeVector GetComponentsForAlignedComponent(const ov::Output<ov::Node>& preToUnalignedOutputBadShape) {
+    const auto componentSize = ov::shape_size(preToUnalignedOutputBadShape.get_shape());
+    const auto lastAlignedFromTheEnd = DownAlignTo(componentSize, gnaTensorDataAlignmentElements);
+
+    auto reshape_pattern_initial_pre = CreateConstantU64V(std::vector<size_t> {1, componentSize});
+    auto initialReshape = std::make_shared<ngraph::opset7::Reshape>(preToUnalignedOutputBadShape, reshape_pattern_initial_pre, false);
+    std::shared_ptr<ov::Node> preToUnalignedNodePadded = initialReshape;
+    const auto componentSizePaddedToFc = UpAlignTo(componentSize, noOfInputsDivisor);
+    if (componentSize != componentSizePaddedToFc) {
+        preToUnalignedNodePadded = std::make_shared<ngraph::opset7::Pad>(initialReshape,
+            GetConstant2U(0, 0), GetConstant2U(0, componentSizePaddedToFc - componentSize),
+            ov::op::PadMode::CONSTANT);
+    }
+    DisableCF(preToUnalignedNodePadded);
+
+    ngraph::NodeVector allNewComponents;
+    // When component is small it will be handeled with affine filter only - no need to use Copy primitive
+    if (lastAlignedFromTheEnd != 0) {
+        auto copyComponent = AppendStridedSliceOn2DNode(preToUnalignedNodePadded, 0, lastAlignedFromTheEnd);
+        allNewComponents.push_back(copyComponent);
+    }
+
+    if (lastAlignedFromTheEnd == componentSizePaddedToFc) {
+        // GNA copy primitive is sufficient, no need for FC
+        return allNewComponents;
+    }
+
+    auto inputForFcAlignedTail = AppendStridedSliceOn2DNode(preToUnalignedNodePadded, lastAlignedFromTheEnd, componentSizePaddedToFc);
+
+    auto outputForFcAlignedTail = AppendAffineCopy(inputForFcAlignedTail,
+        componentSizePaddedToFc - lastAlignedFromTheEnd, componentSize - lastAlignedFromTheEnd, 0, 0);
+
+    allNewComponents.push_back(outputForFcAlignedTail);
+    return allNewComponents;
+}
+
+static ngraph::NodeVector GetComponentsForNotAlignedComponent(const ov::Output<ov::Node>& unalignedOutputBadShape,
+    const ov::element::Type outputType,
+    const size_t putAt) {
+    const auto putAtOffsetFromAligned = putAt % gnaTensorDataAlignmentElements;
+    if (putAtOffsetFromAligned == 0) {
+        // Aligned concat - don't need special handling using GNA primitives
+        THROW_GNA_EXCEPTION << "putAtOffsetFromAligned == 0";
+    }
+
+    const auto delayedCopySourceOffset = gnaTensorDataAlignmentElements - putAtOffsetFromAligned;
+    const auto totalElems = ov::shape_size(unalignedOutputBadShape.get_shape());
+
+    // filter length for GNA Convolution must be padded to convFilterSizeDivider, i.e., 8
+    const auto totalFilter = UpAlignTo(delayedCopySourceOffset + convMinFiltersNum, convFilterSizeDivider);
+    auto maxCnnCopyIn = DownAlignTo(totalElems, noOfInputsDivisor);
+
+    auto unalignedOutputBadShapeNode = unalignedOutputBadShape.get_node();
+    std::string unalignedOutputBadShapeNodeName;
+    size_t unalignedOutputBadShapeNodeInputsNumber = 0;
+    if (unalignedOutputBadShapeNode != nullptr) {
+        unalignedOutputBadShapeNodeName = unalignedOutputBadShapeNode->get_type_name();
+        if (unalignedOutputBadShapeNode->get_output_size() == 1) {
+            const auto unalignedOutputBadShapeNodeInputs = unalignedOutputBadShapeNode->output(0).get_target_inputs();
+            unalignedOutputBadShapeNodeInputsNumber = unalignedOutputBadShapeNodeInputs.size();
+        }
+    }
+
+    auto reshape_pattern_initial = CreateConstantU64V(std::vector<size_t> {1, totalElems});
+    auto initialReshape = std::make_shared<ngraph::opset7::Reshape>(unalignedOutputBadShape, reshape_pattern_initial, false);
+
+    // Example of concat's output
+    // (The scale is not kept)
+    //
+    // Aligned address                                 putAt                         Aligned                   Aligned
+    // X               putAtOffsetFromAligned            |                               X                        X
+    // X-----------Previous concat component-------------|---delayedCopySourceOffset-----X---effeciveOutElements--------------|--tail-----|
+    // X                                                 |            Unaligned concat component ------- totalElems ---                   |
+    std::shared_ptr < ov::Node > convolutionReshaped;
+    const auto ramainingOut = totalElems > delayedCopySourceOffset ? totalElems - delayedCopySourceOffset : 0u;
+    size_t effeciveOutElements = 0;
+    if (maxCnnCopyIn >= totalFilter && ramainingOut > 0) {
+        auto maxOutElements = maxCnnCopyIn - totalFilter + convMinFiltersNum;
+
+        // CNN input and output can be shorten if Affine filter based tail copy is needed
+        // Those outputs can be computed by the Affine filter based tail copy
+        size_t notNeededCnnOutputs = 0;
+        if (ramainingOut != maxOutElements) {
+            notNeededCnnOutputs = DownAlignTo(maxOutElements % gnaTensorDataAlignmentElements, noOfInputsDivisor);
+        }
+        effeciveOutElements = maxOutElements - notNeededCnnOutputs;
+        const auto effectiveInElements = maxCnnCopyIn - notNeededCnnOutputs;
+
+        auto ss_for_cnn_in = AppendStridedSliceOn2DNode(initialReshape, 0, effectiveInElements);
+
+        auto reshape_pattern = CreateConstantU64V(std::vector<size_t> {1, 1, 1, effectiveInElements});
+        auto reshapeCocnatInput = std::make_shared<ngraph::opset7::Reshape>(ss_for_cnn_in, reshape_pattern, false);
+
+        auto filterCnn1DNW = getDelayedCopyCnnFilter(convMinFiltersNum, totalFilter, delayedCopySourceOffset);
+
+        auto filters = std::make_shared<ngraph::opset7::Constant>(outputType,
+                                                                  ngraph::Shape{convMinFiltersNum, 1, 1, totalFilter},
+                                                                  filterCnn1DNW);
+
+        auto convolution = std::make_shared<ngraph::opset7::Convolution>(reshapeCocnatInput,
+                                                                         filters,
+                                                                         ngraph::Strides{1, convMinFiltersNum},
+            ngraph::CoordinateDiff{}, ngraph::CoordinateDiff{}, ngraph::Strides{});
+
+        auto reshape_pattern2 = GetConstant2U(1, effeciveOutElements);
+        convolutionReshaped = std::make_shared<ngraph::opset7::Reshape>(convolution, reshape_pattern2, false);
+    }
+
+    const auto minHeadCopyElems = std::min(delayedCopySourceOffset, totalElems);
+    const auto numberOfInputsForHeadAffineFilter = UpAlignTo(minHeadCopyElems, noOfInputsDivisor);
+    const auto numberOfOutputsForHeadAffineFilter =
+        std::min(gnaTensorDataAlignmentElements, minHeadCopyElems + putAtOffsetFromAligned);
+    const auto firstInputIndexForHeadAffineFilter = 0u;
+    const auto firstOutputIndexForHeadAffineFilter = putAtOffsetFromAligned;
+
+    auto tailNotNeeded = totalElems <= delayedCopySourceOffset + effeciveOutElements;
+    const auto numberOfInputsForHeadAffineFilterReduced = std::min(totalElems, numberOfInputsForHeadAffineFilter);
+    auto fcHead = AppendStridedSliceOn2DNode(initialReshape, 0, numberOfInputsForHeadAffineFilterReduced);
+    if (numberOfInputsForHeadAffineFilter != numberOfInputsForHeadAffineFilterReduced) {
+        fcHead = std::make_shared<ngraph::opset7::Pad>(fcHead,
+            GetConstant2U(0, 0), GetConstant2U(0, numberOfInputsForHeadAffineFilter - numberOfInputsForHeadAffineFilterReduced),
+            ov::op::PadMode::CONSTANT);
+        // W/A for test smoke_concat_multi_input/ConcatMultiInput.CompareWithRefConstOnly/IS=(1.3)(1.3)(1.3)_netPRC=FP32_targetDevice=GNA
+        if (unalignedOutputBadShapeNodeName == std::string("Constant") && unalignedOutputBadShapeNodeInputsNumber == 1) {
+            DisableCF(initialReshape);
+        }
+    }
+
+    auto headMatmul = AppendAffineCopy(fcHead, numberOfInputsForHeadAffineFilter, numberOfOutputsForHeadAffineFilter,
+        firstInputIndexForHeadAffineFilter, firstOutputIndexForHeadAffineFilter);
+
+    // Crop part of MatMul output from head of unaligned component
+    // Matmul produces numberOfOutputsForHeadAffineFilter outputs, but only the last delayedCopySourceOffset contain valid data
+    auto vSSHead = AppendStridedSliceOn2DNode(headMatmul, firstOutputIndexForHeadAffineFilter, numberOfOutputsForHeadAffineFilter);
+
+    std::shared_ptr < ov::Node > vSSTail;
+    if (!tailNotNeeded) {
+        const auto outOffsetForFCNotAligned = putAt + delayedCopySourceOffset + effeciveOutElements;
+        const auto outOffsetAlignedToPutTail = DownAlignTo(outOffsetForFCNotAligned, gnaTensorDataAlignmentElements);
+        const auto outnumberOfTailFCOut = putAt + totalElems - outOffsetAlignedToPutTail;
+        const auto minNeededTail = totalElems - delayedCopySourceOffset - effeciveOutElements;
+        const auto tailBegin = totalElems - outnumberOfTailFCOut;
+        const auto tailbeginAligned = DownAlignTo(tailBegin, gnaTensorDataAlignmentElements);
+        const auto realNumberofInputsForTailAffineFilter = totalElems - tailbeginAligned;
+        const auto gnaAdjustedNumberofInputsForTailAffineFilter =
+            UpAlignTo(realNumberofInputsForTailAffineFilter, noOfInputsDivisor);
+        const auto firstInputElement = realNumberofInputsForTailAffineFilter - minNeededTail;
+        const auto firstOutputElementTail = outnumberOfTailFCOut - minNeededTail;
+        auto realInputForAffineCopyFilterForTail = AppendStridedSliceOn2DNode(initialReshape,
+            tailbeginAligned, tailbeginAligned + realNumberofInputsForTailAffineFilter);
+
+        std::shared_ptr<ov::Node> inputForAffineCopyFilterForTail = realInputForAffineCopyFilterForTail;
+
+        // To handle the case where (realNumberofInputsForTailAffineFilter) is not multiple of noOfInputsDivisor (i.e., 8)
+        // Pad operation has to be inserted
+        if (gnaAdjustedNumberofInputsForTailAffineFilter != realNumberofInputsForTailAffineFilter) {
+            inputForAffineCopyFilterForTail = std::make_shared<ngraph::opset7::Pad>(realInputForAffineCopyFilterForTail,
+                GetConstant2U(0, 0), GetConstant2U(0, gnaAdjustedNumberofInputsForTailAffineFilter - realNumberofInputsForTailAffineFilter),
+                ov::op::PadMode::CONSTANT);
+            gnalog() << "Size of the tail of unaligned concat component is not multiple of noOfInputsDivisor=="
+                     << noOfInputsDivisor << ", Pad: " << inputForAffineCopyFilterForTail->get_friendly_name()
+                     << " inserted\n";
+        }
+
+        auto tailMatmul = AppendAffineCopy(inputForAffineCopyFilterForTail, gnaAdjustedNumberofInputsForTailAffineFilter, outnumberOfTailFCOut,
+            firstInputElement, firstOutputElementTail);
+
+        vSSTail = AppendStridedSliceOn2DNode(tailMatmul, firstOutputElementTail, outnumberOfTailFCOut);
+    }
+
+    ngraph::NodeVector allNewComponents;
+    allNewComponents.push_back(vSSHead);
+    if (convolutionReshaped) {
+        allNewComponents.push_back(convolutionReshaped);
+    }
+    if (vSSTail) {
+        allNewComponents.push_back(vSSTail);
+    }
+    return allNewComponents;
+}
+struct EnforceOrderResult {
+    std::shared_ptr<ov::Node> subgraph;
+    std::shared_ptr<ov::Node> previousNode;
+};
+
+// previousNodeExecutedAfter - original concat input which should be decomposed into GNA primitives
+// to be executed after the components in subgraph
+// Result:
+// previousNodeExecutedAfter     subgraph (GNA- friendly network handling (N + 1)'s component of the concat)
+//   (N's component of the concat)        / / /
+//                \                      / / /
+//                 \                    / / /
+//               Concat (for ordering purposes only)
+//              /                                |
+//             /                                 |
+//  StridedSlice                            StridedSlice
+//      |                                        |
+//   effectivelly same as                   effectivelly same as
+//   previousNodeExecutedAfter              (N + 1)'s component of the concat
+//   subgraph for N's components            goes directly to final Concat
+//   would be attached here
+static EnforceOrderResult EnforceOrder(const ngraph::NodeVector subgraph , const ov::Output<ov::Node> previousNodeExecutedAfter) {
+    const auto previousNodeShape = previousNodeExecutedAfter.get_shape();
+    IE_ASSERT(previousNodeShape.size() >= 1);
+    IE_ASSERT(previousNodeShape[0] != 0);
+    const auto previousNodeSize = ov::shape_size(previousNodeShape);
+    auto previousNodeExecutedAfterReshaped = previousNodeExecutedAfter;
+    if (previousNodeShape.size() != 2 || previousNodeShape[0] != 1) {
+        auto shape1xN = GetConstant2U(1, previousNodeSize);
+        previousNodeExecutedAfterReshaped = std::make_shared<ngraph::opset7::Reshape>(previousNodeExecutedAfter, shape1xN, false);
+    }
+    ov::OutputVector fakeConcatOutputs = { previousNodeExecutedAfterReshaped };
+    fakeConcatOutputs.insert(fakeConcatOutputs.end(), subgraph.begin(), subgraph.end());
+    // this concat could be detected using LayerInfo.isConcatOrdering()
+    std::shared_ptr<ov::Node> newFakeOrderingConcat = std::make_shared < ngraph::opset7::Concat>(fakeConcatOutputs, orderingConcatAxis);
+
+    const auto concatShape = newFakeOrderingConcat->get_shape();
+    const auto concatShapeSize = ov::shape_size(concatShape);
+
+    // Each ordering concat has two Strided Slices, the first one takes a part from the beginning
+    // and all GNA primitives needed to put them into final concat output will be appended
+    auto previousNode = AppendStridedSliceOn2DNode(newFakeOrderingConcat, 0, previousNodeSize);
+    // the second Crop takes the remiaining output from ordering concat and
+    // pass it directelly to the final concat
+    auto followingNode = AppendStridedSliceOn2DNode(newFakeOrderingConcat, previousNodeSize, concatShapeSize);
+
+    return { followingNode, previousNode };
+}
+
+static std::vector<size_t> getDataFromConstant(ov::Input<ov::Node> begin) {
+    auto out = begin.get_source_output();
+    auto node = out.get_node();
+    auto constant = dynamic_cast <ngraph::opset7::Constant*>(node);
+    if (constant == nullptr) {
+        return {};
+    }
+    auto v = constant->cast_vector<size_t>();
+    return v;
+}
+
+static bool trivialConcatFromStrides(Output<ov::Node> concatOutput) {
+    constexpr size_t supportedShapeSize = 2;
+    auto concat = concatOutput.get_node();
+    auto ssNode = concat->input(0).get_source_output().get_node();
+    if (ssNode == nullptr || ssNode->get_input_size() == 0) {
+        return false;
+    }
+    auto directNodeOutput = ssNode->input(0).get_source_output();
+
+    auto concatInputs = concat->inputs();
+    size_t expectedBegin = 0;
+    for (auto&& i : concatInputs) {
+        auto node = i.get_source_output().get_node();
+        auto ss = dynamic_cast <ngraph::opset7::StridedSlice*>(node);
+        if (ss == nullptr || ss->get_input_size() != 4) {
+            return false;
+        }
+        auto directNodeOutputThis = ss->input(0).get_source_output();
+        if (directNodeOutputThis != directNodeOutput) {
+            return false;
+        }
+        auto begin = ss->input(1);
+        auto end = ss->input(2);
+        auto stride = ss->input(3);
+
+        auto b = getDataFromConstant(begin);
+        auto e = getDataFromConstant(end);
+        auto s = getDataFromConstant(stride);
+        if (b.size() != supportedShapeSize || e.size() != supportedShapeSize || s.size() != supportedShapeSize) {
+            return false;
+        }
+        if (b[0] != 0 || b[1] != expectedBegin || e[0] != 1 || s[0] != 1 || s[1] != 1) {
+            return false;
+        }
+        expectedBegin = e[1];
+    }
+    auto directNodeOutputShape = directNodeOutput.get_shape();
+    if (directNodeOutputShape.size() != supportedShapeSize || directNodeOutputShape[0] != 1 ||
+        directNodeOutputShape[1] != expectedBegin) {
+        return false;
+    }
+
+    return true;
+}
+
+static void ConvertTrivialConcatFromStrides(std::shared_ptr<ov::Node> concat) {
+    auto ssNode = concat->input(0).get_source_output().get_node();
+    auto directNodeOutput = ssNode->input(0).get_source_output();
+    auto orgConcatOutput = concat->output(0);
+
+    const auto orgConcatOutputShape = orgConcatOutput.get_shape();
+    const auto orgConcatOutputReShape = CreateConstantU64V(orgConcatOutputShape);
+    auto concatReplacement = std::make_shared<ngraph::opset7::Reshape>(directNodeOutput, orgConcatOutputReShape, false);
+    concatReplacement->set_friendly_name(concat->get_friendly_name());
+
+    for (auto&& inputOfConcatConsumer : orgConcatOutput.get_target_inputs()) {
+        inputOfConcatConsumer.replace_source_output(concatReplacement->output(0));
+    }
+}
+
+static void ConvertUnalignedConcat(std::shared_ptr<ov::Node> orgConcatNode) {
+    constexpr int64_t newConcatAxis = 1;
+    ngraph::NodeVector allNewComponents;
+    const auto orgConcatOutput = orgConcatNode->output(0);
+    const auto concatOutputType = orgConcatOutput.get_element_type();
+    const auto inputs = orgConcatNode->inputs();
+    auto totalOffset = std::accumulate(inputs.cbegin(), inputs.cend(), static_cast<size_t>(0),
+        [](const size_t& sum, const ov::Input<ov::Node>& i) {return sum + ov::shape_size(i.get_shape()); });
+    auto outputNode = inputs.rbegin()->get_source_output();
+
+    // The loop to convert concat components into GNA-friendly primitieves goes
+    // from the last concat component as the component handling may overwrite
+    // some previous components buffer
+    for (auto input = inputs.rbegin(); input != inputs.rend(); ++input) {
+        const auto sizeCurrent = ov::shape_size(input->get_shape());
+        totalOffset -= sizeCurrent;
+        ngraph::NodeVector components;
+
+        if (totalOffset % gnaTensorDataAlignmentElements == 0) {
+            components = GetComponentsForAlignedComponent(outputNode);
+        } else {
+            components = GetComponentsForNotAlignedComponent(outputNode, concatOutputType, totalOffset);
+        }
+        const auto previousInput = std::next(input);
+        if (previousInput != inputs.rend()) {
+            auto result = EnforceOrder(components, previousInput->get_source_output());
+            components = { result.subgraph };
+            outputNode = result.previousNode;   // for the next iteration
+        }
+
+        allNewComponents.insert(allNewComponents.begin(), components.begin(), components.end());
+    }
+
+    auto newConcat = std::make_shared < ngraph::opset7::Concat>(allNewComponents, newConcatAxis);
+
+    const auto originalConcatOutputShape = orgConcatOutput.get_shape();
+    const auto originalConcatOutputReShape = CreateConstantU64V(originalConcatOutputShape);
+    auto newReshapeOutput = std::make_shared<ngraph::opset7::Reshape>(newConcat, originalConcatOutputReShape, false);
+
+    for (auto&& inputOfConcatConsumer : orgConcatOutput.get_target_inputs()) {
+        inputOfConcatConsumer.replace_source_output(newReshapeOutput);
+    }
+    newReshapeOutput->set_friendly_name(orgConcatNode->get_friendly_name());
+}
+
+static std::function<bool(Output<ov::Node>)> CheckUnalignedConcat() {
+    return [](Output<ov::Node> output) -> bool {
+        auto concat_node = output.get_node();
+        auto concat = dynamic_cast<ngraph::opset7::Concat*>(concat_node);
+        if (concat == nullptr) {
+            return false;
+        }
+        const auto numberOfInputsToConcat = concat->get_input_size();
+        if (numberOfInputsToConcat < 2) {
+            return false;
+        }
+        if (concat->get_axis() != 0) {
+            auto outputShape = concat->get_output_shape(0);
+            outputShape.resize(concat->get_axis());
+            if (ov::shape_size(outputShape) > 1) {
+                return false;
+            }
+        }
+        size_t offset = 0;
+        for (auto&& c : concat->inputs()) {
+            if (offset % gnaTensorDataAlignmentElements != 0) {
+                return true;
+            }
+            offset += ov::shape_size(c.get_shape());
+        }
+        return false;
+    };
+}
+
+static std::function<bool(Output<ov::Node>)> CheckTrivialStrideConcat() {
+    return [](Output<ov::Node> output) -> bool {
+        return trivialConcatFromStrides(output);
+    };
+}
+
+NGRAPH_RTTI_DEFINITION(ConvertUnalignedConcatIntoGnaGraph, "ConvertUnalignedConcatIntoGnaGraph", 0);
+ConvertUnalignedConcatIntoGnaGraph::ConvertUnalignedConcatIntoGnaGraph() {
+    MATCHER_SCOPE(TransformConcatForGna);
+    auto concatPattern = ngraph::pattern::wrap_type<ngraph::opset7::Concat>({}, CheckUnalignedConcat());
+
+    ngraph::matcher_pass_callback callback = [=](ngraph::pattern::Matcher& m) {
+        auto& pattern_map = m.get_pattern_value_map();
+        auto concat_node = pattern_map.at(concatPattern).get_node_shared_ptr();
+
+        ConvertUnalignedConcat(concat_node);
+        unaligned_concat_converted = true;
+        return true;
+    };
+
+    auto unalignedConcatMatcher = std::make_shared<ngraph::pattern::Matcher>(concatPattern, matcher_name);
+
+    this->register_matcher(unalignedConcatMatcher, callback);
+}
+
+NGRAPH_RTTI_DEFINITION(RemoveTrivialStrideConcatPattern, "RemoveTrivialStrideConcatPattern", 0);
+RemoveTrivialStrideConcatPattern::RemoveTrivialStrideConcatPattern() {
+    MATCHER_SCOPE(RemoveTrivialStrideConcatPattern);
+    auto concatPattern = ngraph::pattern::wrap_type<ngraph::opset7::Concat>({}, CheckTrivialStrideConcat());
+
+    ngraph::matcher_pass_callback callback = [=](ngraph::pattern::Matcher& m) {
+        auto& pattern_map = m.get_pattern_value_map();
+        auto concat_node = pattern_map.at(concatPattern).get_node_shared_ptr();
+
+        ConvertTrivialConcatFromStrides(concat_node);
+        return true;
+    };
+
+    auto unalignedConcatMatcher = std::make_shared<ngraph::pattern::Matcher>(concatPattern, matcher_name);
+
+    this->register_matcher(unalignedConcatMatcher, callback);
+}
+
+NGRAPH_RTTI_DEFINITION(TransformConcatForGna, "TransformConcatForGna", 0);
+TransformConcatForGna::TransformConcatForGna() {
+    MATCHER_SCOPE(TransformConcatForGna);
+    add_matcher<GNAPluginNS::RemoveTrivialStrideConcatPattern>();
+    convUCPass = add_matcher<GNAPluginNS::ConvertUnalignedConcatIntoGnaGraph>();
+}
+
+bool TransformConcatForGna::unalignedConcatIntoGnaGraphConverted() const {
+    return convUCPass->unaligned_concat_converted;
+}

--- a/src/plugins/intel_gna/transformations/convert_unaligned_concat_to_cnn.hpp
+++ b/src/plugins/intel_gna/transformations/convert_unaligned_concat_to_cnn.hpp
@@ -1,0 +1,35 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <ngraph/pass/graph_rewrite.hpp>
+
+namespace GNAPluginNS {
+
+class ConvertUnalignedConcatIntoGnaGraph : public ngraph::pass::MatcherPass {
+public:
+    NGRAPH_RTTI_DECLARATION;
+    ConvertUnalignedConcatIntoGnaGraph();
+    bool unaligned_concat_converted = false;
+};
+
+class RemoveTrivialStrideConcatPattern : public ngraph::pass::MatcherPass {
+public:
+    NGRAPH_RTTI_DECLARATION;
+    RemoveTrivialStrideConcatPattern();
+};
+
+class TransformConcatForGna : public ngraph::pass::GraphRewrite {
+public:
+    NGRAPH_RTTI_DECLARATION;
+    TransformConcatForGna();
+
+    bool unalignedConcatIntoGnaGraphConverted() const;
+
+private:
+    std::shared_ptr<ConvertUnalignedConcatIntoGnaGraph> convUCPass;
+};
+
+} // namespace GNAPluginNS

--- a/src/plugins/intel_gna/transformations/convert_unaligned_concat_to_cnn.hpp
+++ b/src/plugins/intel_gna/transformations/convert_unaligned_concat_to_cnn.hpp
@@ -8,6 +8,27 @@
 
 namespace GNAPluginNS {
 
+/**
+ * @brief Convert Unaligned Concat int GNA friendly graph utilizing Convolution operation.
+ * This transformation detects unaligned Concat operation and handles its inputs to copy
+ * Them using GNA Primitives to desired addresses.
+ * Unalignment problem is caused by the GNA operation restriction that tensor can only be written
+ * To address that is aligned to 64B.
+ * When destination of any of Concat input is not aligned to 64B specific approach must be used.
+ * Convolution with specially preparred filters can be used to copy input into output with some offset.
+ * Practically 4 filters of the form are used:
+ *              0 ... 0 1 0 0 0 0 ... 0
+ *              0 ... 0 0 1 0 0 0 ... 0
+ *              0 ... 0 0 0 1 0 0 ... 0
+ *              0 ... 0 0 0 0 1 0 ... 0
+ * The number of "0" before "1" int the first filter denotes the offset from the aligned address.
+ * Additional handling of head and tail of each Concat's component may be needed.
+ * If so it is done in a form of MatMul Layer and realized using GNA fully connected layer.
+ * Component that are aligned (i.e., their destination addresses are) can be handled easier -
+ * by using GNA copy operation and optional tail handling (with MatMul).
+ * Due to overwriting of the previous component by the not aligned component the order
+ * of Concat's input handling must be reversed (last component copied first).
+ */
 class ConvertUnalignedConcatIntoGnaGraph : public ngraph::pass::MatcherPass {
 public:
     NGRAPH_RTTI_DECLARATION;
@@ -15,16 +36,44 @@ public:
     bool unaligned_concat_converted = false;
 };
 
+/**
+ * @brief Fold Concat from Strided Slices from a common node.
+ * This transformation simplifies the network when detects
+ * a pattern containing Concat layer with multiple Strided Slices
+ * inputs from the common node. It is applied when Concat's output
+ * is effectively the same as the original output node.
+ * Pattern:
+ *              Original node output
+ *                        |
+ *              Multiple strided slices
+ *                        |
+ *                     Concat
+ *                        |
+ *                     Network
+ * is simplified into:
+ *              Original node output
+ *                        |
+ *                     Network
+ */
 class RemoveTrivialStrideConcatPattern : public ngraph::pass::MatcherPass {
 public:
     NGRAPH_RTTI_DECLARATION;
     RemoveTrivialStrideConcatPattern();
 };
 
+/**
+ * @brief Handle Unaligned Concat for GNA.
+ * Combination of two transformations. The first one simplifies the graph
+ * by removing some unneeded Concat nodes. The second converts Unaligned Concat
+ * into GNA friendly graph utilizing Convolution operation.
+ */
 class TransformConcatForGna : public ngraph::pass::GraphRewrite {
 public:
     NGRAPH_RTTI_DECLARATION;
-    TransformConcatForGna();
+    TransformConcatForGna() {
+        add_matcher<RemoveTrivialStrideConcatPattern>();
+        convUCPass = add_matcher<ConvertUnalignedConcatIntoGnaGraph>();
+    }
 
     bool unalignedConcatIntoGnaGraphConverted() const;
 

--- a/src/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/trivial_concat.cpp
+++ b/src/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/trivial_concat.cpp
@@ -10,16 +10,43 @@
 using namespace SubgraphTestsDefinitions;
 
 namespace {
-std::vector<std::vector<size_t>> inShapes = {
-    {1, 1, 33, 16},
-    {1, 1, 65, 16},
-    {10, 16},
-    {10, 64},
-    {15, 15},
+std::vector<std::vector<size_t>> inShapesMultipleInputs = {
+    {40, 40, 40},
+    {5, 5},
+    {32, 32, 32, 128},
+    {32, 212},
+    {132, 64},
+    {61, 53},
+    {234, 234, 222},
+    {234, 234, 222, 1, 2, 3},
+    {234, 234, 222, 64},
+    {234, 234, 222, 33, 22},
+    {234, 234, 222, 23},
+    {5, 5, 5, 5, 5, 5, 5, 5},
 };
 
-std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP32,
-    InferenceEngine::Precision::FP16};
+static std::vector<std::vector<size_t>> getInShapes() {
+    std::vector<std::vector<size_t>> shapes = {
+        {1, 1024},
+        {1, 1, 33, 16},
+        {1, 1, 65, 16},
+        {10, 16},
+        {10, 64},
+        {1, 1001},
+    };
+    for (size_t s = 1; s <= 69; s++) {
+        shapes.push_back({ 1, s });
+    }
+    for (size_t s = 100; s <= 169; s++) {
+        shapes.push_back({ 1, s });
+    }
+    return shapes;
+}
+
+std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16
+};
 
 std::map<std::string, std::string> additional_config = {
     {"GNA_COMPACT_MODE", "NO"},
@@ -29,9 +56,25 @@ std::map<std::string, std::string> additional_config = {
 
 INSTANTIATE_TEST_SUITE_P(smoke_trivial_concat_Basic, TrivialConcatLayerTest,
     ::testing::Combine(
-        ::testing::ValuesIn(inShapes),
+        ::testing::ValuesIn(getInShapes()),
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(CommonTestUtils::DEVICE_GNA),
         ::testing::Values(additional_config)),
     TrivialConcatLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_trivial_concat_Basic_2Inputs, TrivialConcatLayerTest2Inputs,
+    ::testing::Combine(
+        ::testing::ValuesIn(getInShapes()),
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(CommonTestUtils::DEVICE_GNA),
+        ::testing::Values(additional_config)),
+    TrivialConcatLayerTest2Inputs::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_trivial_concat_Basic_Multi, TrivialConcatLayerTest_MultipleInputs,
+    ::testing::Combine(
+        ::testing::ValuesIn(inShapesMultipleInputs),
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(CommonTestUtils::DEVICE_GNA),
+        ::testing::Values(additional_config)),
+    TrivialConcatLayerTest_MultipleInputs::getTestCaseName);
 }  // namespace

--- a/src/tests/functional/plugin/shared/include/subgraph_tests/trivial_concat.hpp
+++ b/src/tests/functional/plugin/shared/include/subgraph_tests/trivial_concat.hpp
@@ -12,4 +12,12 @@ TEST_P(TrivialConcatLayerTest, CompareWithRefs) {
     Run();
 };
 
+TEST_P(TrivialConcatLayerTest2Inputs, CompareWithRefs) {
+    Run();
+};
+
+TEST_P(TrivialConcatLayerTest_MultipleInputs, CompareWithRefs) {
+    Run();
+};
+
 }  // namespace SubgraphTestsDefinitions

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/trivial_concat.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/trivial_concat.hpp
@@ -29,4 +29,19 @@ protected:
     void SetUp() override;
 };
 
+class TrivialConcatLayerTest2Inputs : public testing::WithParamInterface<trivialConcatParamsTuple>,
+    virtual public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<trivialConcatParamsTuple>& obj);
+protected:
+    void SetUp() override;
+};
+
+class TrivialConcatLayerTest_MultipleInputs : public testing::WithParamInterface<trivialConcatParamsTuple>,
+    virtual public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<trivialConcatParamsTuple>& obj);
+protected:
+    void SetUp() override;
+};
 }  // namespace SubgraphTestsDefinitions

--- a/src/tests_deprecated/unit/engines/gna/layers/gna_multi_input_to_concat_test.cpp
+++ b/src/tests_deprecated/unit/engines/gna/layers/gna_multi_input_to_concat_test.cpp
@@ -96,7 +96,8 @@ TEST_P(GNAMultiInputToConcatTest, InputsToConcat) {
         auto test_object = assert_that().onInferNgraphModel(std::get<1>(model_with_io_names))
                 .inNotCompactMode()
                 .gna()
-                .withGNAConfig(GNA_CONFIG_KEY(SCALE_FACTOR), 1.0f)
+                .withGNAConfig("GNA_SCALE_FACTOR_0", 1.0f)
+                .withGNAConfig("GNA_SCALE_FACTOR_1", 1.0f)
                 .withGNAConfig(GNA_CONFIG_KEY(PRECISION), "I16")
                 .propagate_forward()
                 .called();


### PR DESCRIPTION
### Details:
 - Implement nGraph based transformation for unaligned concat.
 - Insert GNA-friendly nGraph operations to realize unaligned concat.
 - The legacy transformation is kept for some corner cases including: TensorIterator, FakeQuantized network, Legacy network loading

### Tickets:
 - 59942, 72343, 52104
