### PR TITLE
Gna 2dconv30 releases

### DIFF
--- a/inference-engine/src/gna_plugin/backend/am_intel_dnn.cpp
+++ b/inference-engine/src/gna_plugin/backend/am_intel_dnn.cpp
@@ -1763,7 +1763,8 @@ void GNAPluginNS::backend::AMIntelDNN::InitGNAStruct(intel_nnet_type_t *ptr_nnet
                         || (component[i - 1].operation == kDnnConvolutional1dOp)
                         || (component[i - 1].operation == kDnnConvolutional2dOp)
                         || ((component[i - 1].operation == kDnnMaxPoolOp) &&
-                        (component[i - 2].operation == kDnnConvolutional1dOp))) {
+                        (component[i - 2].operation == kDnnConvolutional1dOp
+                            || component[i - 2].operation == kDnnConvolutional2dOp))) {
                         if (gnaOperation->Operands[PwlOpIdx] == nullptr) {
                             HelperGna2OperationSetOperand(gnaOperation, gnaUserAllocator, gnaUserFree, PwlOpIdx, createGna2TensorPwl(1, nullptr));
                         }

--- a/inference-engine/src/gna_plugin/backend/dnn_types.h
+++ b/inference-engine/src/gna_plugin/backend/dnn_types.h
@@ -201,18 +201,6 @@ enum OvGnaType {
     OvGnaTypePwl = 8,
 };
 
-#if GNA_LIB_VER == 2
-enum OvGnaMode {
-    OvGnaModeDefault = 0,
-    OvGnaModeDisabled = -1
-};
-
-struct OvGnaTensor {
-    std::vector<uint32_t> dimensions;
-    OvGnaType type;
-    OvGnaMode mode;
-};
-
 template <class T>
 OvGnaType OvGnaTypeIntFromBytes(T bytesPerElement) {
     static const std::map<T, OvGnaType> m = {
@@ -226,6 +214,18 @@ OvGnaType OvGnaTypeIntFromBytes(T bytesPerElement) {
     }
     return r->second;
 }
+
+#if GNA_LIB_VER == 2
+enum OvGnaMode {
+    OvGnaModeDefault = 0,
+    OvGnaModeDisabled = -1
+};
+
+struct OvGnaTensor {
+    std::vector<uint32_t> dimensions;
+    OvGnaType type;
+    OvGnaMode mode;
+};
 
 static std::string OvGnaTypeToString(OvGnaType type) {
     static const std::map<OvGnaType, std::string> typeToString = {

--- a/inference-engine/src/gna_plugin/backend/gna_limitations.cpp
+++ b/inference-engine/src/gna_plugin/backend/gna_limitations.cpp
@@ -94,17 +94,23 @@ std::string VectorOrSquareLimitByChannelsAndPrecision::GetErrorOrEmpty(const uin
 }
 
 bool Validator::ValidateCnn2D(std::string name, const uint32_t inHeight, const uint32_t inWidth,
-    const uint32_t inChannels, const uint32_t kH, const uint32_t kW, const uint32_t kN,
+    const uint32_t inChannels, const uint32_t kernelH, const uint32_t kernelW, const uint32_t kernelN,
     const uint32_t strideH, const uint32_t strideW, const uint32_t dilationH, const uint32_t dilationW,
     OvGnaType inPrecision, bool exception) const {
     const std::string prefix = "Layer Convolution2D: " + name + ":";
     auto error = inputHWLimit.GetErrorOrEmpty(inHeight, inWidth);
 
-    error += kernelNumberLimit.GetErrorOrEmpty(kN);
-
+    error += kernelNumberLimit.GetErrorOrEmpty(kernelN);
     error += inputChannelsNumberLimit.GetErrorOrEmpty(inChannels);
-    error += kernelLimit.GetErrorOrEmpty(kH, kW, inPrecision, inChannels, "kernel");
+    error += kernelLimit.GetErrorOrEmpty(kernelH, kernelW, inPrecision, inChannels, "kernel");
     error += strideLimit.GetErrorOrEmpty(strideH, strideW, inPrecision, inChannels, "convolution stride");
+
+    const RangeLimit kernelStrideHLimit{1, kernelH, "kernel stride height (must be up to kernel height)"};
+    const RangeLimit kernelStrideWLimit{1, kernelW, "kernel stride width (must be up to kernel width)"};
+
+    error += kernelStrideHLimit.GetErrorOrEmpty(strideH);
+    error += kernelStrideWLimit.GetErrorOrEmpty(strideW);
+
     error += dilationLimit.GetErrorOrEmpty(dilationH, dilationW);
 
     if (exception)

--- a/inference-engine/src/gna_plugin/backend/gna_limitations.hpp
+++ b/inference-engine/src/gna_plugin/backend/gna_limitations.hpp
@@ -95,10 +95,10 @@ class Validator {
     RangeMultipleLimit inputChannelsNumberLimit{ {8, 384, "number of input channels"}, 8 };
 
     RangeMultipleLimit kernelNumberLimit{ {8, 256, "number of kernels"}, 8 };
-    VectorOrSquareLimitByChannelsAndPrecision kernelLimit {
+    VectorOrSquareLimitByChannelsAndPrecision kernelLimit{
         { 240, { 3, 7, 3 }, { 2, 7, 2 } },
         { 120, { 3, 7, 3 }, { 1, 7, 1 } } };
-    VectorOrSquareLimitByChannelsAndPrecision& strideLimit = kernelLimit;
+    VectorOrSquareLimitByChannelsAndPrecision & strideLimit = kernelLimit;
     RangeLimit2D dilationLimit{{convDilationHeight, convDilationHeight, "dilation height"},
         {convDilationWidth, convDilationWidth, "dilation width"}};
     const VectorOrSquareLimit poolingWindowLimit{ 3, 1, 1 };

--- a/inference-engine/src/gna_plugin/backend/gna_limitations.hpp
+++ b/inference-engine/src/gna_plugin/backend/gna_limitations.hpp
@@ -16,6 +16,8 @@ constexpr uint32_t bufferMaxSize = 65528;
 
 constexpr uint32_t convMinFiltersNum = 4;
 constexpr uint32_t convMaxFiltersNum = 65532;
+constexpr uint32_t convDilationHeight = 1;
+constexpr uint32_t convDilationWidth = 1;
 constexpr uint32_t convFiltersNumDivider = 4;
 constexpr uint32_t convFilterSizeDivider = 8;
 constexpr uint32_t convFilterMaxSize = 768;
@@ -25,6 +27,8 @@ constexpr uint32_t noOfInputsLowPrecDivisor = 16;
 
 constexpr uint32_t affineMaxBatchSize = 8;
 
+constexpr uint32_t maxPoolMaxWindowSize = 6;
+constexpr uint32_t copyMaxGrouping = 8;
 constexpr uint32_t transposeMaxSize = 65528;
 
 inline bool IsTransposeSupported(const std::vector<size_t>& shape) {
@@ -95,17 +99,21 @@ class Validator {
         { 240, { 3, 7, 3 }, { 2, 7, 2 } },
         { 120, { 3, 7, 3 }, { 1, 7, 1 } } };
     VectorOrSquareLimitByChannelsAndPrecision& strideLimit = kernelLimit;
+    RangeLimit2D dilationLimit{{convDilationHeight, convDilationHeight, "dilation height"},
+        {convDilationWidth, convDilationWidth, "dilation width"}};
     const VectorOrSquareLimit poolingWindowLimit{ 3, 1, 1 };
 
     static void ThrowIfNotEmpty(const std::string prefix, const std::string error);
 public:
-    void ValidateCnn2D(std::string name, const uint32_t inHeight, const uint32_t inWidth,
+    bool ValidateCnn2D(std::string name, const uint32_t inHeight, const uint32_t inWidth,
         const uint32_t inChannels, const uint32_t kH, const uint32_t kW, const uint32_t kN,
-        const uint32_t strideH, const uint32_t strideW, OvGnaType inPrecision) const;
+        const uint32_t strideH, const uint32_t strideW, const uint32_t dilationH, const uint32_t dilationW,
+        OvGnaType inPrecision, bool exception = true) const;
 
-    void ValidatePooling2D(std::string name,
+    bool ValidatePooling2D(std::string name,
         const uint32_t windowH, const uint32_t windowW,
-        const uint32_t strideH, const uint32_t strideW) const;
+        const uint32_t strideH, const uint32_t strideW,
+        bool exception = true) const;
 };
 } // namespace Cnn2D
 

--- a/inference-engine/src/gna_plugin/gna_graph_compiler.cpp
+++ b/inference-engine/src/gna_plugin/gna_graph_compiler.cpp
@@ -588,7 +588,8 @@ void GNAGraphCompiler::finalizeConvolution2DPrimitive(InferenceEngine::CNNLayerP
 
     cnn2dValidator.ValidateCnn2D(layer->name,
         in_height, in_width, in_channels,
-        convolution._kernel_y, convolution._kernel_x, filter_n, convolution._stride_y, convolution._stride_x, inputPrec);
+        convolution._kernel_y, convolution._kernel_x, filter_n, convolution._stride_y, convolution._stride_x,
+        convolution._dilation_y, convolution._dilation_x, inputPrec);
 
     float weight_scale_factor = getScaleFactor(layer, QuantizedDataType::weights);
     float output_scale_factor = getScaleFactor(layer, QuantizedDataType::output);
@@ -1003,13 +1004,8 @@ void GNAGraphCompiler::ConcatPrimitive(InferenceEngine::CNNLayerPtr layer) {
         auto layerInfo = LayerInfo(concatParent);
         // auto layerInfo = LayerInfo(getCreatorLayer(concatLayerInput->insData[it].lock()).lock());
         if (layerInfo.isInput()) {
-            auto & bytesAllocated = inputDesc->bytes_allocated_for_input[((InferenceEngine::CNNLayerPtr)layerInfo)->name];
-
             connectInput(layer, &concatLayerInfo.gna_ptr,
-                         concatLayerInfo.reserved_size, inputLayer.offset, idx, false);
-
-            // TODO: currently connectInput api accept only total size, for concat we need extension for allocated, and actual sizes
-            bytesAllocated = inputLayer.tensorSize;
+                inputLayer.tensorSize, inputLayer.offset, idx, false);
 
             concatLayerInfo.input_allocated = true;
         } else if (layerInfo.isMemory()) {

--- a/inference-engine/src/gna_plugin/transformations/convert_padded_to_valid_convolution.cpp
+++ b/inference-engine/src/gna_plugin/transformations/convert_padded_to_valid_convolution.cpp
@@ -1,0 +1,235 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <openvino/cc/ngraph/itt.hpp>
+
+#include "transformations/convert_padded_to_valid_convolution.hpp"
+
+#include <memory>
+
+#include <ngraph/opsets/opset7.hpp>
+#include <ngraph/pattern/op/wrap_type.hpp>
+#include <ngraph/pattern/op/or.hpp>
+#include <ngraph/rt_info.hpp>
+#include <ngraph/pass/manager.hpp>
+#include <ie_common.h>
+#include "utils/transformation_helper.hpp"
+
+
+using namespace GNAPluginNS;
+
+NGRAPH_RTTI_DEFINITION(ConvertPaddedToValidConv, "ConvertPaddedToValidConv", 0);
+
+static bool VerifyAndGetConvData(std::shared_ptr<ngraph::opset7::Convolution> conv, ConvData& conv_data) {
+    const auto& input = conv->input_value(0);
+
+    // We support only batch 1
+    if (input.get_shape()[0] != 1) {
+        return false;
+    }
+
+    GetConvData(conv, conv_data);
+
+    return conv_data.pads_begin_height || conv_data.pads_end_height || conv_data.pads_begin_width || conv_data.pads_end_width;
+}
+
+static void InsertPadding(ngraph::OutputVector& input_rows_to_concat, size_t size, const std::shared_ptr<ngraph::opset7::Convolution>& conv,
+    const std::shared_ptr<ngraph::opset7::Constant> padding_const, size_t biggest_padding) {
+
+    if (size == biggest_padding) {
+        input_rows_to_concat.push_back(padding_const);
+    } else {
+        auto slice = FlatCrop(padding_const, 0, size);
+        copy_runtime_info(conv, slice);
+        input_rows_to_concat.push_back(slice);
+    }
+}
+
+static std::shared_ptr<ngraph::Node> CreatePaddedNet(std::shared_ptr<ngraph::opset7::Transpose> leading_transpose,
+    std::shared_ptr<ngraph::opset7::Convolution> conv, const ConvData& conv_data) {
+    size_t flat_left_padding = conv_data.input_channel_count * conv_data.pads_begin_width;
+    size_t flat_right_padding = conv_data.input_channel_count * conv_data.pads_end_width;
+    size_t padded_row_size = flat_left_padding + conv_data.input_channel_count * conv_data.input_width + flat_right_padding;
+    size_t flat_top_padding = padded_row_size * conv_data.pads_begin_height;
+    size_t flat_bottom_padding = padded_row_size * conv_data.pads_end_height;
+    size_t biggest_padding = std::max(std::max(flat_left_padding, flat_right_padding), std::max(flat_top_padding, flat_bottom_padding));
+
+    if (conv_data.input_height > 1 && (flat_top_padding > 1 || flat_bottom_padding > 1)) {
+        biggest_padding = biggest_padding > padded_row_size ? biggest_padding : padded_row_size;
+    }
+
+    auto flat_input = std::make_shared<ngraph::opset7::Reshape>(leading_transpose->input_value(0),
+        ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{2},
+            ngraph::Shape{1ull, shape_size(leading_transpose->input_value(0).get_shape())}), false);
+
+    // Constant with zero padding
+    auto const_holding_padding = std::make_shared<ngraph::opset7::Constant>(conv_data.element_type, ngraph::Shape{1, biggest_padding}, 0);
+
+    copy_runtime_info(conv, const_holding_padding);
+    std::shared_ptr<ngraph::Node> original_row = flat_input;
+    ngraph::OutputVector input_rows_to_concat;
+
+    // Add top padding
+    for (size_t p = 0; p < conv_data.pads_begin_height; p++) {
+        InsertPadding(input_rows_to_concat, padded_row_size, conv, const_holding_padding, biggest_padding);
+    }
+
+    if (flat_left_padding || flat_right_padding) {
+        // Pad every row of input plain if neccessary
+        for (size_t h = 0; h < conv_data.input_height; h++) {
+            // left padding     input     right padding
+            //     |              |           |
+            //     +--------------+-----------+
+            //                    |
+            //                 concat
+
+            if (conv_data.input_height > 1)
+                original_row = FlatCrop(flat_input, h * conv_data.input_width * conv_data.input_channel_count,
+                    conv_data.input_width * conv_data.input_channel_count);
+            copy_runtime_info(conv, original_row);
+
+            ngraph::OutputVector single_row_concat_inputs;
+            if (flat_left_padding) {
+                InsertPadding(single_row_concat_inputs, flat_left_padding, conv, const_holding_padding, biggest_padding);
+            }
+            single_row_concat_inputs.push_back(original_row);
+            if (flat_right_padding) {
+                InsertPadding(single_row_concat_inputs, flat_right_padding, conv, const_holding_padding, biggest_padding);
+            }
+            auto padded_row_concat = std::make_shared<ngraph::opset7::Concat>(single_row_concat_inputs, 1);
+            copy_runtime_info(conv, padded_row_concat);
+            input_rows_to_concat.push_back(padded_row_concat);
+        }
+    } else {
+        copy_runtime_info(conv, original_row);
+        input_rows_to_concat.push_back(original_row);
+    }
+
+    // Bottom padding
+    for (size_t p = 0; p < conv_data.pads_end_height; p++) {
+        InsertPadding(input_rows_to_concat, padded_row_size, conv, const_holding_padding, biggest_padding);
+    }
+
+    auto padded_input_plane = std::make_shared<ngraph::opset7::Concat>(input_rows_to_concat, 1);
+    copy_runtime_info(conv, padded_input_plane);
+    return padded_input_plane;
+}
+
+static void GeneratePadding(std::shared_ptr<ngraph::opset7::Transpose> leading_transpose,
+    std::shared_ptr<ngraph::opset7::Convolution> conv, const ConvData& conv_data) {
+    // Add padding where neccessary
+
+    // padding
+    // padding
+    // ... row ...
+    // ... row ...
+    // ...........
+    // ... row ...
+    // padding
+    // padding
+    auto padded_input_plane = CreatePaddedNet(leading_transpose, conv, conv_data);
+
+    auto padded_input_plane_reshaped = std::make_shared<ngraph::opset7::Reshape>(padded_input_plane,
+        ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {static_cast<size_t>(1),
+            conv_data.pads_begin_height + conv_data.input_height + conv_data.pads_end_height,
+            conv_data.pads_begin_width + conv_data.input_width + conv_data.pads_end_width,
+            conv_data.input_channel_count}), false);
+
+    // NHWC => NCHW
+    auto transposed2chw = std::make_shared<ngraph::opset7::Transpose>(padded_input_plane_reshaped,
+        ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {0ull, 3ull, 1ull, 2ull})->output(0));
+
+    auto conv_copy = std::make_shared<ngraph::opset7::Convolution>(
+        transposed2chw->output(0),
+        conv->input_value(1),
+        conv->get_strides(),
+        ngraph::CoordinateDiff{0, 0},
+        ngraph::CoordinateDiff{0, 0},
+        conv->get_dilations(),
+        ngraph::op::PadType::EXPLICIT);
+
+    replace_node(conv, conv_copy);
+}
+
+static bool Convert(std::shared_ptr<ngraph::Node> leading_transpose,
+    std::shared_ptr<ngraph::Node> conv,
+    std::shared_ptr<ngraph::Node> trailing_transpose,
+    std::shared_ptr<ngraph::Node> bias) {
+
+    ConvData conv_data;
+
+    if (!VerifyAndGetConvData(std::dynamic_pointer_cast<ngraph::opset7::Convolution>(conv), conv_data))
+        return false;
+
+    // We are looking for Transpose(NHWC->NCHW) => Conv => Transpose(NCHW->NHWC)
+    // or similar cases, so required network must be in NHWC order like in TF
+    if (!TransposeOrderMatches(std::dynamic_pointer_cast<ngraph::opset7::Transpose>(leading_transpose), {0, 3, 1, 2}))
+        return false;
+
+    if (!TransposeOrderMatches(std::dynamic_pointer_cast<ngraph::opset7::Transpose>(trailing_transpose), {0, 2, 3, 1}))
+        return false;
+
+    GeneratePadding(std::dynamic_pointer_cast<ngraph::opset7::Transpose>(leading_transpose),
+        std::dynamic_pointer_cast<ngraph::opset7::Convolution>(conv), conv_data);
+
+    return true;
+}
+
+static std::function<bool(ngraph::Output<ngraph::Node>)> consumers_and_rank(const size_t expected_count, const ngraph::Dimension& expected_rank) {
+    return [=](ngraph::Output<ngraph::Node> output) -> bool {
+        return ngraph::pattern::consumers_count(expected_count) && ngraph::pattern::rank_equals(expected_rank);
+    };
+}
+
+ConvertPaddedToValidConv::ConvertPaddedToValidConv() {
+    MATCHER_SCOPE(ConvertPaddedToValidConv);
+
+    auto const_input = ngraph::pattern::wrap_type<ngraph::opset7::Constant>();
+    auto leading_transpose = ngraph::pattern::wrap_type<ngraph::opset7::Transpose>({ngraph::pattern::any_input(), const_input},
+        consumers_and_rank(1, 4));
+    auto conv = ngraph::pattern::wrap_type<ngraph::opset7::Convolution>(
+        {leading_transpose, ngraph::pattern::wrap_type<ngraph::opset7::Constant, ngraph::opset7::FakeQuantize>(ngraph::pattern::rank_equals(4))},
+        ngraph::pattern::consumers_count(1));
+    auto bias = ngraph::pattern::wrap_type<ngraph::opset7::Add>({conv, const_input},
+        ngraph::pattern::consumers_count(1));
+    auto fq_bias = ngraph::pattern::wrap_type<ngraph::opset7::FakeQuantize>({bias, const_input, const_input, const_input, const_input},
+        ngraph::pattern::consumers_count(1));
+    auto max_pool1 = ngraph::pattern::wrap_type<ngraph::opset7::MaxPool>({bias},
+        ngraph::pattern::consumers_count(1));
+    auto max_pool2 = ngraph::pattern::wrap_type<ngraph::opset7::MaxPool>({fq_bias},
+        ngraph::pattern::consumers_count(1));
+    auto af1 = ngraph::pattern::wrap_type<ngraph::opset7::Relu, ngraph::opset7::Sigmoid,
+        ngraph::opset7::Tanh, ngraph::opset7::Abs, ngraph::opset7::Log, ngraph::opset7::Exp,
+        ngraph::opset7::Sign, ngraph::opset7::Clamp>({bias}, ngraph::pattern::consumers_count(1));
+    auto af2 = ngraph::pattern::wrap_type<ngraph::opset7::Relu, ngraph::opset7::Sigmoid,
+        ngraph::opset7::Tanh, ngraph::opset7::Abs, ngraph::opset7::Log, ngraph::opset7::Exp,
+        ngraph::opset7::Sign, ngraph::opset7::Clamp>({fq_bias}, ngraph::pattern::consumers_count(1));
+    auto af3 = ngraph::pattern::wrap_type<ngraph::opset7::Relu, ngraph::opset7::Sigmoid,
+        ngraph::opset7::Tanh, ngraph::opset7::Abs, ngraph::opset7::Log, ngraph::opset7::Exp,
+        ngraph::opset7::Sign, ngraph::opset7::Clamp>({max_pool1}, ngraph::pattern::consumers_count(1));
+    auto af4 = ngraph::pattern::wrap_type<ngraph::opset7::Relu, ngraph::opset7::Sigmoid,
+        ngraph::opset7::Tanh, ngraph::opset7::Abs, ngraph::opset7::Log, ngraph::opset7::Exp,
+        ngraph::opset7::Sign, ngraph::opset7::Clamp>({max_pool2}, ngraph::pattern::consumers_count(1));
+    auto fq_af = ngraph::pattern::wrap_type<ngraph::opset7::FakeQuantize>({af4, const_input, const_input, const_input, const_input},
+        ngraph::pattern::consumers_count(1));
+    auto transpose_input =
+        std::make_shared<ngraph::pattern::op::Or>(ngraph::OutputVector{conv, bias, max_pool1, max_pool2, fq_bias, af1, af2, af3, af4, fq_af});
+    auto trailing_transpose = ngraph::pattern::wrap_type<ngraph::opset7::Transpose>({transpose_input, const_input},
+        consumers_and_rank(1, 4));
+
+    ngraph::matcher_pass_callback callback = [=](ngraph::pattern::Matcher& m) {
+        const auto& pattern_map = m.get_pattern_value_map();
+        auto bias_it = pattern_map.find(bias);
+        auto bias_node = (bias_it == std::end(pattern_map) ? nullptr : bias_it->second.get_node_shared_ptr());
+
+        if (bias_node && !VerifyBiasGetConst(pattern_map.at(conv).get_node_shared_ptr(), bias_node))
+            return false;
+
+        return Convert(pattern_map.at(leading_transpose).get_node_shared_ptr(), pattern_map.at(conv).get_node_shared_ptr(),
+            pattern_map.at(trailing_transpose).get_node_shared_ptr(), bias_node);
+    };
+
+    auto m = std::make_shared<ngraph::pattern::Matcher>(trailing_transpose, matcher_name);
+    this->register_matcher(m, callback);
+}

--- a/inference-engine/src/gna_plugin/transformations/convert_padded_to_valid_convolution.cpp
+++ b/inference-engine/src/gna_plugin/transformations/convert_padded_to_valid_convolution.cpp
@@ -197,20 +197,25 @@ ConvertPaddedToValidConv::ConvertPaddedToValidConv() {
         ngraph::pattern::consumers_count(1));
     auto af1 = ngraph::pattern::wrap_type<ngraph::opset7::Relu, ngraph::opset7::Sigmoid,
         ngraph::opset7::Tanh, ngraph::opset7::Abs, ngraph::opset7::Log, ngraph::opset7::Exp,
-        ngraph::opset7::Sign, ngraph::opset7::Clamp>({bias}, ngraph::pattern::consumers_count(1));
+        ngraph::opset7::Sign, ngraph::opset7::Clamp>({conv}, ngraph::pattern::consumers_count(1));
     auto af2 = ngraph::pattern::wrap_type<ngraph::opset7::Relu, ngraph::opset7::Sigmoid,
         ngraph::opset7::Tanh, ngraph::opset7::Abs, ngraph::opset7::Log, ngraph::opset7::Exp,
-        ngraph::opset7::Sign, ngraph::opset7::Clamp>({fq_bias}, ngraph::pattern::consumers_count(1));
+        ngraph::opset7::Sign, ngraph::opset7::Clamp>({bias}, ngraph::pattern::consumers_count(1));
     auto af3 = ngraph::pattern::wrap_type<ngraph::opset7::Relu, ngraph::opset7::Sigmoid,
         ngraph::opset7::Tanh, ngraph::opset7::Abs, ngraph::opset7::Log, ngraph::opset7::Exp,
-        ngraph::opset7::Sign, ngraph::opset7::Clamp>({max_pool1}, ngraph::pattern::consumers_count(1));
+        ngraph::opset7::Sign, ngraph::opset7::Clamp>({fq_bias}, ngraph::pattern::consumers_count(1));
     auto af4 = ngraph::pattern::wrap_type<ngraph::opset7::Relu, ngraph::opset7::Sigmoid,
         ngraph::opset7::Tanh, ngraph::opset7::Abs, ngraph::opset7::Log, ngraph::opset7::Exp,
+        ngraph::opset7::Sign, ngraph::opset7::Clamp>({max_pool1}, ngraph::pattern::consumers_count(1));
+    auto af5 = ngraph::pattern::wrap_type<ngraph::opset7::Relu, ngraph::opset7::Sigmoid,
+        ngraph::opset7::Tanh, ngraph::opset7::Abs, ngraph::opset7::Log, ngraph::opset7::Exp,
         ngraph::opset7::Sign, ngraph::opset7::Clamp>({max_pool2}, ngraph::pattern::consumers_count(1));
-    auto fq_af = ngraph::pattern::wrap_type<ngraph::opset7::FakeQuantize>({af4, const_input, const_input, const_input, const_input},
+    auto fq_af1 = ngraph::pattern::wrap_type<ngraph::opset7::FakeQuantize>({af3, const_input, const_input, const_input, const_input},
+        ngraph::pattern::consumers_count(1));
+    auto fq_af2 = ngraph::pattern::wrap_type<ngraph::opset7::FakeQuantize>({af5, const_input, const_input, const_input, const_input},
         ngraph::pattern::consumers_count(1));
     auto transpose_input =
-        std::make_shared<ngraph::pattern::op::Or>(ngraph::OutputVector{conv, bias, max_pool1, max_pool2, fq_bias, af1, af2, af3, af4, fq_af});
+        std::make_shared<ngraph::pattern::op::Or>(ngraph::OutputVector{conv, bias, max_pool1, max_pool2, fq_bias, af1, af2, af3, af4, af5, fq_af1, fq_af2});
     auto trailing_transpose = ngraph::pattern::wrap_type<ngraph::opset7::Transpose>({transpose_input, const_input},
         consumers_and_rank(1, 4));
 

--- a/inference-engine/src/gna_plugin/transformations/convert_padded_to_valid_convolution.cpp
+++ b/inference-engine/src/gna_plugin/transformations/convert_padded_to_valid_convolution.cpp
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include <openvino/cc/ngraph/itt.hpp>
-
 #include "transformations/convert_padded_to_valid_convolution.hpp"
 
 #include <memory>
@@ -183,8 +181,6 @@ static std::function<bool(ngraph::Output<ngraph::Node>)> consumers_and_rank(cons
 }
 
 ConvertPaddedToValidConv::ConvertPaddedToValidConv() {
-    MATCHER_SCOPE(ConvertPaddedToValidConv);
-
     auto const_input = ngraph::pattern::wrap_type<ngraph::opset7::Constant>();
     auto leading_transpose = ngraph::pattern::wrap_type<ngraph::opset7::Transpose>({ngraph::pattern::any_input(), const_input},
         consumers_and_rank(1, 4));
@@ -230,6 +226,6 @@ ConvertPaddedToValidConv::ConvertPaddedToValidConv() {
             pattern_map.at(trailing_transpose).get_node_shared_ptr(), bias_node);
     };
 
-    auto m = std::make_shared<ngraph::pattern::Matcher>(trailing_transpose, matcher_name);
+    auto m = std::make_shared<ngraph::pattern::Matcher>(trailing_transpose, "ConvertPaddedToValidConv");
     this->register_matcher(m, callback);
 }

--- a/inference-engine/src/gna_plugin/transformations/convert_padded_to_valid_convolution.hpp
+++ b/inference-engine/src/gna_plugin/transformations/convert_padded_to_valid_convolution.hpp
@@ -1,0 +1,37 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <ngraph/pass/graph_rewrite.hpp>
+
+namespace GNAPluginNS {
+
+/**
+ * @brief Convert a padded convolution with bias, max pooling and activation function
+ * wrapped with transposes, to a valid convolution with padding added before the leading transpose,
+ * POT precessed models are supported (fake quantized layers omitted below for clarity):
+ *
+ *                                                  Padding
+ *                                                     |
+ *   Transpose (NHWC -> NCHW)               Transpose (NHWC -> NCHW)
+ *              |                                      |
+ *   Convolution with padding                  Valid convolution
+ *              |                                      |
+ *   Broadcast Bias (optional)              Broadcast Bias (optional)
+ *              |                                      |
+ *    Max Pooling (optional)                 Max Pooling (optional)
+ *              |                                      |
+ * Activation Function (optional)       Activation Function (optional)
+ *              |                                      |
+ *   Transpose (NCHW -> NHWC)               Transpose (NCHW -> NHWC)
+ *
+ */
+class ConvertPaddedToValidConv : public ngraph::pass::MatcherPass {
+public:
+  NGRAPH_RTTI_DECLARATION;
+  ConvertPaddedToValidConv();
+};
+
+} // namespace GNAPluginNS

--- a/inference-engine/src/gna_plugin/transformations/decompose_2d_convolution.cpp
+++ b/inference-engine/src/gna_plugin/transformations/decompose_2d_convolution.cpp
@@ -1,0 +1,656 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <openvino/cc/ngraph/itt.hpp>
+
+#include "transformations/decompose_2d_convolution.hpp"
+
+#include <ngraph/opsets/opset7.hpp>
+#include <ngraph/pattern/op/wrap_type.hpp>
+#include <transformations/utils/utils.hpp>
+#include <ngraph/pattern/op/or.hpp>
+#include <ngraph/rt_info.hpp>
+#include <ngraph/pass/manager.hpp>
+#include "utils/transformation_helper.hpp"
+#include <gna/gna_config.hpp>
+#include "backend/gna_limitations.hpp"
+#include "layers/gna_convolution_layer.hpp"
+
+
+using namespace GNAPluginNS;
+
+NGRAPH_RTTI_DEFINITION(Decompose2DConv, "Decompose2DConv", 0);
+NGRAPH_RTTI_DEFINITION(Decompose2DConvTransposedWithBias, "Decompose2DConvTransposedWithBias", 0);
+NGRAPH_RTTI_DEFINITION(Decompose2DConvTransposedWithBiasAF, "Decompose2DConvTransposedWithBiasAF", 0);
+
+struct GraphData {
+    std::shared_ptr<ngraph::opset7::Transpose>leading_transpose;
+    std::shared_ptr<ngraph::opset7::FakeQuantize>fq_conv;
+    std::shared_ptr<ngraph::opset7::Convolution>conv;
+    std::shared_ptr<ngraph::opset7::Transpose>trailing_transpose;
+    std::shared_ptr<ngraph::opset7::FakeQuantize>fq_bias;
+    std::shared_ptr<ngraph::opset7::MaxPool>max_pool;
+    std::shared_ptr<ngraph::op::util::UnaryElementwiseArithmetic>af;
+    std::shared_ptr<ngraph::opset7::FakeQuantize>fq_af;
+    std::shared_ptr<ngraph::Node>last_op_in_sequence_for_replacement;
+    std::shared_ptr<ngraph::Node>bias_const;
+    size_t conv_count;
+    size_t pool_size_width;
+    size_t pool_stride_width;
+    // TODO: currently 2D max pool is not supported
+    //size_t pool_size_height;
+    //size_t pool_stride_height;
+};
+
+static bool VerifyAndGetConvData(std::shared_ptr<ngraph::opset7::Convolution> conv, ConvData& conv_data) {
+    const auto& input = conv->input_value(0);
+    const auto& filters = conv->input_value(1);
+
+    // We support only batch == 1
+    if (input.get_shape()[0] != 1) {
+        return false;
+    }
+
+    size_t filter_height = filters.get_shape()[2];
+    size_t filter_width = filters.get_shape()[3];
+
+    if (filter_width > GNALimitations::copyMaxGrouping || filter_height > GNALimitations::copyMaxGrouping) {
+        return false;
+    }
+
+    GetConvData(conv, conv_data);
+
+    IE_ASSERT(conv_data.output_channel_count == conv->get_output_shape(0)[1]);
+
+    return true;
+}
+
+static bool VerifyMaxPool(GraphData& graph_data, std::shared_ptr<ngraph::opset7::MaxPool> max_pool) {
+    auto pool_filter = max_pool->get_kernel();
+    auto pool_strides = max_pool->get_strides();
+
+    // Check Max Pool padding and limitations
+    if ((max_pool->get_auto_pad() != ngraph::op::PadType::VALID &&
+        (max_pool->get_auto_pad() != ngraph::op::PadType::EXPLICIT ||
+            max_pool->get_pads_begin() != ngraph::Shape({0, 0}) || max_pool->get_pads_end() != ngraph::Shape({0, 0}))) ||
+        pool_filter.size() != 2 || pool_strides.size() != 2 ||
+        pool_filter[0] > GNALimitations::maxPoolMaxWindowSize)
+        return false;
+
+    graph_data.pool_size_width = pool_filter[1];
+    graph_data.pool_stride_width = pool_strides[1];
+    return true;
+}
+
+static bool GNA30SupportedConv(const std::string& gnaCompileTarget, const InferenceEngine::Precision& gnaPrecision,
+    const GNALimitations::Cnn2D::Validator& cnn2dValidator, const GraphData& graph_data, const ConvData& conv_data) {
+    return (gnaCompileTarget == InferenceEngine::GNAConfigParams::GNA_TARGET_3_0 &&
+        cnn2dValidator.ValidateCnn2D(graph_data.conv->get_friendly_name(),
+            conv_data.input_height, conv_data.input_width, conv_data.input_channel_count,
+            conv_data.filter_height, conv_data.filter_width, conv_data.filter_channel_count,
+            conv_data.filter_stride_height, conv_data.filter_stride_width, conv_data.filter_dilation_height, conv_data.filter_dilation_width,
+            OvGnaTypeIntFromBytes(gnaPrecision.size()), false) &&
+        (!graph_data.max_pool || cnn2dValidator.ValidatePooling2D(graph_data.conv->get_friendly_name(),
+            graph_data.max_pool->get_kernel()[0], graph_data.max_pool->get_kernel()[1],
+            graph_data.max_pool->get_strides()[0], graph_data.max_pool->get_strides()[1],
+            false))) ? true : false;
+}
+
+static size_t CalculateConvCount(const ConvData& conv_data) {
+    // Check if split of plane due to GNA HW limitations of 768 filter elements is possible
+    size_t conv_count = 1;
+    size_t total_factorized_conv_channel_count = (conv_data.input_channel_count * conv_data.filter_height * conv_data.filter_width);
+    while (total_factorized_conv_channel_count / conv_count > GNALimitations::convFilterMaxSize ||
+        total_factorized_conv_channel_count % conv_count != 0 || conv_data.filter_channel_count % conv_count != 0)
+        conv_count++;
+
+    return conv_count;
+}
+
+static bool ShouldDecompose(GraphData& graph_data, const ConvData& conv_data) {
+    // Calculate the number of splits required
+    graph_data.conv_count = CalculateConvCount(conv_data);
+
+    // Concat (copy) layer limitation allows to split up to a certain limit
+    // Currently we are able to split only convolutions without pooling in horizontal dimension
+    if (graph_data.conv_count > GNALimitations::copyMaxGrouping ||
+        ((graph_data.pool_size_width > 1 || graph_data.pool_stride_width > 1) && graph_data.conv_count > 1))
+        return false;
+
+    // GNA supported features or handled otherwise - there is no need to decompose such convolution
+    if (graph_data.conv_count == 1 && (((conv_data.input_height == 1 || conv_data.input_width == 1) &&
+        conv_data.filter_dilation_width == 1 && conv_data.filter_dilation_height == 1) ||
+        GNAConvolutionLayer::isMappableFrom2DTo1D(conv_data.input_height, conv_data.input_width, conv_data.filter_width, conv_data.filter_stride_width)))
+        return false;
+
+    return true;
+}
+
+static std::vector<std::shared_ptr<ngraph::Node>> Split2DConvFilters(std::shared_ptr<ngraph::opset7::Constant>& filters,
+    const bool& vertical_permute, const bool& horizontal_permute, const size_t& split_channels) {
+
+    if (!horizontal_permute && !vertical_permute && split_channels == 1)
+        return {filters};
+
+    std::vector <std::shared_ptr<ngraph::Node>> result;
+    ngraph::Shape reshape_shape;
+    auto flat_filters = filters->outputs();
+    const auto filter_shape = filters->get_output_shape(0);
+    IE_ASSERT(filter_shape.size() == 4);
+
+    if (split_channels > 1) {
+        const auto axis_node = ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{}, {1});
+        const auto split = std::make_shared<ngraph::opset7::Split>(filters, axis_node, split_channels);
+        flat_filters = split->outputs();
+    }
+
+    for (size_t split_index = 0; split_index < split_channels; split_index++) {
+        ngraph::Output<ngraph::Node>& flat_filter = flat_filters[split_index];
+        if (horizontal_permute && !vertical_permute) {
+            result.push_back(std::make_shared<ngraph::opset7::Transpose>(flat_filter,
+                ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{4}, ngraph::Shape{0, 1, 3, 2})));
+        } else {
+            result.push_back(flat_filter.get_node_shared_ptr());
+        }
+    }
+
+    if (vertical_permute && horizontal_permute) {
+        reshape_shape = ngraph::Shape{filter_shape[0], filter_shape[1] * filter_shape[2] * filter_shape[3] / split_channels, 1, 1};
+    } else if (vertical_permute && !horizontal_permute) {
+        reshape_shape = ngraph::Shape{filter_shape[0], filter_shape[1] * filter_shape[2] / split_channels, 1, filter_shape[3]};
+    } else if (!vertical_permute && horizontal_permute) {
+        reshape_shape = ngraph::Shape{filter_shape[0], filter_shape[1] * filter_shape[3] / split_channels, filter_shape[2], 1};
+    } else {
+        reshape_shape = ngraph::Shape{filter_shape[0], filter_shape[1] / split_channels, filter_shape[2], filter_shape[3]};
+    }
+
+    for (auto &new_filter : result)
+        new_filter = ngraph::op::util::make_try_fold<ngraph::opset7::Reshape>(new_filter,
+            ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{4}, reshape_shape), false);
+
+    return result;
+}
+
+static ngraph::OutputVector SplitInput(const GraphData& graph_data, ConvData& conv_data) {
+    // We need to have proper input shape first
+    ngraph::OutputVector split_planes;
+    auto padded_input_plane = std::make_shared<ngraph::opset7::Reshape>(graph_data.leading_transpose->input_value(0),
+        ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{2},
+            ngraph::Shape{1, shape_size(graph_data.leading_transpose->input_value(0).get_shape())}), false);
+    copy_runtime_info(graph_data.conv, padded_input_plane);
+
+    if (graph_data.conv_count > 1) {
+        // If we have split input plane and convolutions due to GNA limitation - we must sum their results at the end
+        conv_data.input_channel_count /= graph_data.conv_count;
+
+        auto reshape_before_transpose = std::make_shared<ngraph::opset7::Reshape>(padded_input_plane,
+            ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{2},
+                {shape_size(padded_input_plane->get_shape()) / graph_data.conv_count, graph_data.conv_count}), false);
+
+        auto transpose_before_channel_wise_split = std::make_shared<ngraph::opset7::Transpose>(reshape_before_transpose,
+            ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {1, 0})->output(0));
+
+        const auto axis_node = ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{}, {0});
+        const auto split = std::make_shared<ngraph::opset7::Split>(transpose_before_channel_wise_split, axis_node, graph_data.conv_count);
+        split_planes = split->outputs();
+    } else {
+        split_planes.push_back(padded_input_plane);
+    }
+
+    return split_planes;
+}
+
+static std::vector<std::shared_ptr<ngraph::Node>> SplitFilters(const GraphData& graph_data, ConvData& conv_data) {
+    // If the input plane exceeds GNA limits and we have split into several convolutions, then we need to split filter data as well;
+    // we also need to take filter height and potential dilation into account when modifying the filters
+
+    // Take account of fake quantize when getting filter values
+    auto filter_values = std::dynamic_pointer_cast<ngraph::opset7::Constant>(graph_data.fq_conv == nullptr ?
+        graph_data.conv->input_value(1).get_node_shared_ptr() : graph_data.fq_conv->input_value(0).get_node_shared_ptr());
+    bool vertical_permute = (conv_data.filter_height > 1);
+    bool horizontal_permute = (conv_data.filter_dilation_width > 1);
+    std::vector<std::shared_ptr<ngraph::Node>> h_1_filters{};
+
+    h_1_filters = Split2DConvFilters(filter_values, vertical_permute, horizontal_permute, graph_data.conv_count);
+
+    for (auto filter : h_1_filters)
+        copy_runtime_info(graph_data.conv, filter);
+
+    return h_1_filters;
+}
+
+static void TransformInput(const GraphData& graph_data, const ConvData& conv_data, ngraph::Output<ngraph::Node>& split_input_plane) {
+    /*
+    *              Padded row - NHWC order
+    *                  |
+    *        Split in vertical dim (filter height)
+    *                / | \
+    *                Concat
+    *                  |
+    *              Transpose
+    */
+
+    // First we need to prepare flat (height = 1) slices of input data proper for flattened (height = 1) filters created later on;
+    // the input data is overlapping (duplicated)
+    ngraph::OutputVector dilated_input_planes;
+    for (size_t filter_height = 0; filter_height < conv_data.filter_height; filter_height++) {
+        size_t offset;
+
+        if (conv_data.filter_stride_height > 1) {
+            // Prepare strided slices of input data
+            for (size_t output_height = 0; output_height < conv_data.output_height; output_height++) {
+                offset = (filter_height * conv_data.filter_dilation_height + output_height * conv_data.filter_stride_height) *
+                    conv_data.input_width * conv_data.input_channel_count;
+                auto slice = FlatCrop(split_input_plane, offset, conv_data.input_width * conv_data.input_channel_count);
+                copy_runtime_info(graph_data.conv, slice);
+                dilated_input_planes.push_back(slice);
+            }
+        } else {
+            offset = filter_height * conv_data.filter_dilation_height * conv_data.input_width * conv_data.input_channel_count;
+            auto slice = FlatCrop(split_input_plane, offset, conv_data.input_width * conv_data.input_channel_count * conv_data.output_height);
+            copy_runtime_info(graph_data.conv, slice);
+            dilated_input_planes.push_back(slice);
+        }
+    }
+
+    // Interleaving dilated input planes
+    std::shared_ptr<ngraph::Node> dilated_chunks_concat = std::make_shared<ngraph::opset7::Concat>(dilated_input_planes, 0);
+
+    // Additional reshape is required for strided slices of input intended for each filter row
+    if (conv_data.filter_stride_height > 1) {
+        dilated_chunks_concat = std::make_shared<ngraph::opset7::Reshape>(dilated_chunks_concat,
+            ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{2},
+                {conv_data.filter_height, conv_data.input_width * conv_data.input_channel_count * conv_data.output_height}), false);
+    }
+
+    auto transposed_dilated_chunks = std::make_shared<ngraph::opset7::Transpose>(dilated_chunks_concat,
+        ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {1, 0})->output(0));
+
+    // Flattening of interleaved input planes
+    auto flattened_dilated_transposed_input = std::make_shared<ngraph::opset7::Reshape>(transposed_dilated_chunks,
+        ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{2},
+            {(size_t)1, conv_data.input_width * conv_data.input_channel_count * conv_data.output_height * conv_data.filter_height}), false);
+
+    copy_runtime_info(graph_data.conv, {dilated_chunks_concat, flattened_dilated_transposed_input, transposed_dilated_chunks });
+    split_input_plane = flattened_dilated_transposed_input;
+}
+
+// Valid 1D (decomposed 2D) convolution wrapped with transposes NHWC => NCHW => conv => NCHW => NHWC
+static std::shared_ptr<ngraph::Node> Create1DConv(const GraphData& graph_data, const ConvData& conv_data, const ngraph::Output<ngraph::Node>& input,
+    std::shared_ptr<ngraph::Node> filters, const size_t conv_index, const size_t h_index) {
+        // Transpose NHWC => NCHW
+        std::shared_ptr<ngraph::Node> nchw_input = std::make_shared<ngraph::opset7::Transpose>(input,
+            ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {0, 3, 1, 2})->output(0));
+
+        // Fake quantize
+        filters = InsertFQLayer(graph_data.fq_conv, filters);
+
+        // 1D Convolution
+        auto conv = std::make_shared<ngraph::opset7::Convolution>(nchw_input, filters,
+            ngraph::Strides{1, conv_data.filter_stride_width}, ngraph::CoordinateDiff{0, 0}, ngraph::CoordinateDiff{0, 0},
+            ngraph::Strides{1, 1}, ngraph::op::PadType::VALID);
+        std::string conv_name = graph_data.conv->get_friendly_name() + "_H_" + std::to_string(h_index) + "_CH_" + std::to_string(0);
+        conv->set_friendly_name(conv_name);
+        std::shared_ptr<ngraph::Node> last_conv_block_op = conv;
+
+        // Bias & fake quantize
+        if (graph_data.bias_const && conv_index == 0) {
+            auto bias_size = shape_size(graph_data.bias_const->get_shape());
+            auto reshaped_bias_const = ngraph::op::util::make_try_fold<ngraph::opset7::Reshape>(graph_data.bias_const,
+                ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{4}, ngraph::Shape{1, bias_size, 1, 1}), false);
+            last_conv_block_op = std::make_shared<ngraph::opset7::Add>(conv, reshaped_bias_const);
+            copy_runtime_info(graph_data.conv, last_conv_block_op);
+            last_conv_block_op = InsertFQLayer(graph_data.fq_bias, last_conv_block_op);
+        }
+
+        // Max pooling
+        if ((graph_data.max_pool && graph_data.pool_size_width > 1) || graph_data.pool_stride_width > 1) {
+            last_conv_block_op = std::make_shared<ngraph::opset7::MaxPool>(last_conv_block_op,
+                ngraph::Strides{1, graph_data.pool_stride_width}, ngraph::Shape{0, 0}, ngraph::Shape{0, 0},
+                ngraph::Shape{1, graph_data.pool_size_width}, graph_data.max_pool->get_rounding_type(), ngraph::op::PadType::VALID);
+        }
+
+        // Activation function & fake quantize
+        if (graph_data.af && graph_data.conv_count == 1) {
+            last_conv_block_op = graph_data.af->copy_with_new_inputs({last_conv_block_op});
+            copy_runtime_info(conv, last_conv_block_op);
+            last_conv_block_op = InsertFQLayer(graph_data.fq_af, last_conv_block_op);
+        }
+
+        // Transpose NCHW => NHWC
+        auto nhwc_output = std::make_shared<ngraph::opset7::Transpose>(last_conv_block_op,
+            ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {0, 2, 3, 1})->output(0));
+        copy_runtime_info(graph_data.conv, {nchw_input, conv, nhwc_output});
+        return nhwc_output;
+}
+
+static std::shared_ptr<ngraph::Node> CreateDecomposedConv(const GraphData& graph_data, ConvData& conv_data,
+    ngraph::Output<ngraph::Node>& reduced_input_plane, const std::vector<std::shared_ptr<ngraph::Node>>& h_1_filters, const size_t conv_index) {
+    ngraph::OutputVector result_chunks;
+    std::shared_ptr<ngraph::Node> last_op;
+    bool horizontal_permute = (conv_data.filter_dilation_width > 1);
+    size_t h_1_filter_channel_count = (conv_data.input_channel_count * conv_data.filter_height);
+
+    for (size_t output_height = 0; output_height < conv_data.output_height; output_height++) {
+        size_t offset = output_height * conv_data.input_width * h_1_filter_channel_count;
+        auto row = (conv_data.output_height == 1) ? reduced_input_plane :
+            FlatCrop(reduced_input_plane, offset, conv_data.input_width * h_1_filter_channel_count);
+        /*
+            *              Padded row
+            *                  |
+            *        ??? <Dilation !=1> ???
+            *                  |
+            *         Split in vertical dim
+            *                / | \
+            *                Concat
+            *                  |
+            *               Permute
+            *                  |
+            *              Transpose (NHWC => NCHW)
+            *                  |
+            *                1D Conv (Bias | MaxPooling)
+            *                  |
+            *              Transpose (NCHW => NHWC)
+            */
+        auto nhwc_conv_y_input = row;
+
+        if (horizontal_permute) {
+            // Horizontal split - transform input accordingly
+            ngraph::OutputVector dilated_chunks;
+            std::shared_ptr<ngraph::Node> dilated_chunks_concat = nhwc_conv_y_input.get_node_shared_ptr();
+
+            // We need to calculate some parameters in case horizontal stride > 1 is used, because if we use the ones available from the original convolution
+            // we won't take into account the fact horizontal strides will be supported by the newly created 1D convolution, and not by decomposition
+            size_t filter_dilation_width = conv_data.filter_width > 1 ? conv_data.filter_dilation_width : 1;
+            size_t output_width = (conv_data.input_width - (filter_dilation_width * (conv_data.filter_width - 1)));
+
+            if (conv_data.filter_width > 1) {
+                for (size_t filter_width = 0; filter_width < conv_data.filter_width; filter_width++) {
+                    size_t offset = filter_width * conv_data.filter_dilation_width * h_1_filter_channel_count;
+                    auto slice = FlatCrop(row, offset, h_1_filter_channel_count * output_width);
+                    copy_runtime_info(graph_data.conv, slice);
+                    dilated_chunks.push_back(slice);
+                }
+
+                dilated_chunks_concat = std::make_shared<ngraph::opset7::Concat>(dilated_chunks, 0);
+            }
+
+            auto transposed_dilated_chunks = std::make_shared<ngraph::opset7::Transpose>(dilated_chunks_concat,
+                ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {1, 0})->output(0));
+
+            auto flattened_dilated_conv_input = std::make_shared<ngraph::opset7::Reshape>(transposed_dilated_chunks,
+                ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{4},
+                    ngraph::Shape{1, 1, output_width, h_1_filter_channel_count * conv_data.filter_width}), false);
+
+            copy_runtime_info(graph_data.conv, ngraph::NodeVector{flattened_dilated_conv_input, transposed_dilated_chunks, dilated_chunks_concat});
+
+            nhwc_conv_y_input = flattened_dilated_conv_input;
+        } else {
+            // If no horizontal split is done, only reshape is required before decomposed convolution
+            nhwc_conv_y_input = std::make_shared<ngraph::opset7::Reshape>(nhwc_conv_y_input,
+                ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{4},
+                    ngraph::Shape{1, 1, conv_data.input_width, h_1_filter_channel_count}), false);
+        }
+
+        // Pointwise convolutions
+        // Valid 1D convolution wrapped with transposes NHWC => NCHW => Conv => NCHW => NHWC
+        // Activation function can be fused with convolution only if it isn't split
+        auto nhwc_y_output = Create1DConv(graph_data, conv_data, nhwc_conv_y_input, h_1_filters[conv_index], conv_index, output_height);
+        result_chunks.push_back(nhwc_y_output);
+        last_op = nhwc_y_output;
+    }
+
+    // Horizontal dimemsion greater than 1
+    if (result_chunks.size() > 1) {
+        // Concat in horizontal dimension
+        // In NHWC index of H is 1
+        auto concatenated_sub_results = std::make_shared<ngraph::opset7::Concat>(result_chunks, 1);
+        copy_runtime_info(graph_data.conv, concatenated_sub_results);
+        last_op = concatenated_sub_results;
+    }
+    return last_op;
+}
+
+static void Decompose(const GraphData& graph_data, ConvData& conv_data) {
+    std::vector<std::shared_ptr<ngraph::Node>> partial_conv_results;
+
+    // Split input due to GNA filter element count limit
+    auto split_planes = SplitInput(graph_data, conv_data);
+    // Split filters due to GNA filter element count limit, 2D convolution shape, or dilations
+    auto h_1_filters = SplitFilters(graph_data, conv_data);
+
+    // Do transformations in each of the splits created above
+    for (size_t conv_index = 0; conv_index < graph_data.conv_count; conv_index++) {
+        ngraph::Output<ngraph::Node>& split_input_plane = split_planes[conv_index];
+
+        // Input data needs to be prepared before 2D convolution decomposition
+        if (conv_data.filter_height > 1 || conv_data.filter_stride_height > 1) {
+            TransformInput(graph_data, conv_data, split_input_plane);
+        }
+
+        auto flat_conv = CreateDecomposedConv(graph_data, conv_data, split_input_plane, h_1_filters, conv_index);
+        partial_conv_results.push_back(flat_conv);
+    }
+
+    std::shared_ptr<ngraph::Node> conv_result = partial_conv_results.front();
+    for (size_t i = 1; i < partial_conv_results.size(); i++) {
+        auto add_result = std::make_shared<ngraph::opset7::Add>(partial_conv_results[i], conv_result);
+        copy_runtime_info(graph_data.conv, add_result);
+        conv_result = add_result;
+    }
+
+    // TODO: Max Pool 2D case
+    //if (graph_data.max_pool && (graph_data.pool_size_height > 1 || graph_data.pool_stride_height > 1)) {
+    //}
+
+    // Activation function after trailing Transpose NCHW->NHWC
+    if (graph_data.af && graph_data.conv_count > 1) {
+        auto af_result = graph_data.af->copy_with_new_inputs({conv_result});
+        copy_runtime_info(graph_data.conv, af_result);
+        conv_result = af_result;
+    }
+    // We need to put the same name as before for the Convolution layer, so its output can be used as network result
+    std::string conv_result_name = graph_data.last_op_in_sequence_for_replacement->get_friendly_name();
+    replace_node(graph_data.last_op_in_sequence_for_replacement, conv_result);
+    conv_result->set_friendly_name(conv_result_name);
+}
+
+static bool Convert(const std::string& gnaCompileTarget,
+    const InferenceEngine::Precision& gnaPrecision,
+    std::shared_ptr<ngraph::Node> leading_transpose,
+    std::shared_ptr<ngraph::Node> fq_conv,
+    std::shared_ptr<ngraph::Node> conv,
+    std::shared_ptr<ngraph::Node> trailing_transpose,
+    std::shared_ptr<ngraph::Node> bias,
+    std::shared_ptr<ngraph::Node> bias_const,
+    std::shared_ptr<ngraph::Node> fq_bias,
+    std::shared_ptr<ngraph::Node> max_pool,
+    std::shared_ptr<ngraph::Node> af,
+    std::shared_ptr<ngraph::Node> fq_af,
+    std::shared_ptr<ngraph::Node> last_op_for_replacement) {
+    const GNALimitations::Cnn2D::Validator cnn2dValidator;
+    GraphData graph_data{std::dynamic_pointer_cast<ngraph::opset7::Transpose>(leading_transpose),
+        std::dynamic_pointer_cast<ngraph::opset7::FakeQuantize>(fq_conv),
+        std::dynamic_pointer_cast<ngraph::opset7::Convolution>(conv),
+        std::dynamic_pointer_cast<ngraph::opset7::Transpose>(trailing_transpose),
+        std::dynamic_pointer_cast<ngraph::opset7::FakeQuantize>(fq_bias),
+        std::dynamic_pointer_cast<ngraph::opset7::MaxPool>(max_pool),
+        std::dynamic_pointer_cast<ngraph::op::util::UnaryElementwiseArithmetic>(af),
+        std::dynamic_pointer_cast<ngraph::opset7::FakeQuantize>(fq_af),
+        last_op_for_replacement, bias_const, 1, 1, 1};
+    ConvData conv_data;
+
+    if (!VerifyAndGetConvData(std::dynamic_pointer_cast<ngraph::opset7::Convolution>(conv), conv_data))
+        return false;
+
+    if (max_pool && !VerifyMaxPool(graph_data, std::dynamic_pointer_cast<ngraph::opset7::MaxPool>(max_pool)))
+        return false;
+
+    // If compile target is GNA 3.0 and the convolution is supported on it, then skip decomposition
+    if (GNA30SupportedConv(gnaCompileTarget, gnaPrecision, cnn2dValidator, graph_data, conv_data))
+        return false;
+
+    // We are looking for Transpose(NHWC->NCHW) => Conv => Transpose(NCHW->NHWC)
+    // or similar cases, so required network must be in NHWC order like in TF
+    if (!TransposeOrderMatches(std::dynamic_pointer_cast<ngraph::opset7::Transpose>(leading_transpose), {0, 3, 1, 2}))
+        return false;
+
+    if (!TransposeOrderMatches(std::dynamic_pointer_cast<ngraph::opset7::Transpose>(trailing_transpose), {0, 2, 3, 1}))
+        return false;
+
+    if (!ShouldDecompose(graph_data, conv_data))
+        return false;
+
+    // All checks applied - now we may start decomposition
+    Decompose(graph_data, conv_data);
+
+    return true;
+}
+
+Decompose2DConv::Decompose2DConv(const std::string& gnaCompileTarget, const InferenceEngine::Precision& gnaPrecision) {
+    MATCHER_SCOPE(Decompose2DConv);
+
+    auto const_input = ngraph::pattern::wrap_type<ngraph::opset7::Constant>();
+    auto leading_transpose = ngraph::pattern::wrap_type<ngraph::opset7::Transpose>({ngraph::pattern::any_input(), const_input},
+        consumers_and_rank(1, 4));
+    auto filters_const = ngraph::pattern::wrap_type<ngraph::opset7::Constant>(ngraph::pattern::rank_equals(4));
+    auto fq_conv = ngraph::pattern::wrap_type<ngraph::opset7::FakeQuantize>({const_input, const_input, const_input, const_input, const_input},
+        consumers_and_rank(1, 4));
+    auto filters = std::make_shared<ngraph::pattern::op::Or>(ngraph::OutputVector{filters_const, fq_conv});
+    auto conv = ngraph::pattern::wrap_type<ngraph::opset7::Convolution>({leading_transpose, filters},
+        consumers_and_rank(1, 4));
+    auto bias = ngraph::pattern::wrap_type<ngraph::opset7::Add>({conv, const_input},
+        ngraph::pattern::consumers_count(1));
+    auto fq_bias = ngraph::pattern::wrap_type<ngraph::opset7::FakeQuantize>({bias, const_input, const_input, const_input, const_input},
+        ngraph::pattern::consumers_count(1));
+    auto max_pool1 = ngraph::pattern::wrap_type<ngraph::opset7::MaxPool>({bias},
+        ngraph::pattern::consumers_count(1));
+    auto max_pool2 = ngraph::pattern::wrap_type<ngraph::opset7::MaxPool>({fq_bias},
+        ngraph::pattern::consumers_count(1));
+    auto af1 = ngraph::pattern::wrap_type<ngraph::opset7::Relu, ngraph::opset7::Sigmoid,
+        ngraph::opset7::Tanh, ngraph::opset7::Abs, ngraph::opset7::Log, ngraph::opset7::Exp,
+        ngraph::opset7::Sign, ngraph::opset7::Clamp>({bias}, ngraph::pattern::consumers_count(1));
+    auto af2 = ngraph::pattern::wrap_type<ngraph::opset7::Relu, ngraph::opset7::Sigmoid,
+        ngraph::opset7::Tanh, ngraph::opset7::Abs, ngraph::opset7::Log, ngraph::opset7::Exp,
+        ngraph::opset7::Sign, ngraph::opset7::Clamp>({fq_bias}, ngraph::pattern::consumers_count(1));
+    auto af3 = ngraph::pattern::wrap_type<ngraph::opset7::Relu, ngraph::opset7::Sigmoid,
+        ngraph::opset7::Tanh, ngraph::opset7::Abs, ngraph::opset7::Log, ngraph::opset7::Exp,
+        ngraph::opset7::Sign, ngraph::opset7::Clamp>({max_pool1}, ngraph::pattern::consumers_count(1));
+    auto af4 = ngraph::pattern::wrap_type<ngraph::opset7::Relu, ngraph::opset7::Sigmoid,
+        ngraph::opset7::Tanh, ngraph::opset7::Abs, ngraph::opset7::Log, ngraph::opset7::Exp,
+        ngraph::opset7::Sign, ngraph::opset7::Clamp>({max_pool2}, ngraph::pattern::consumers_count(1));
+    auto fq_af = ngraph::pattern::wrap_type<ngraph::opset7::FakeQuantize>({af4, const_input, const_input, const_input, const_input},
+        ngraph::pattern::consumers_count(1));
+    auto transpose_input =
+        std::make_shared<ngraph::pattern::op::Or>(ngraph::OutputVector{conv, bias, max_pool1, max_pool2, fq_bias, af1, af2, af3, af4, fq_af});
+    auto trailing_transpose = ngraph::pattern::wrap_type<ngraph::opset7::Transpose>({transpose_input, const_input},
+        consumers_and_rank(1, 4));
+
+    ngraph::matcher_pass_callback callback = [=](ngraph::pattern::Matcher& m) {
+        const auto& pattern_map = m.get_pattern_value_map();
+        auto fq_conv_it = pattern_map.find(fq_conv);
+        auto fq_conv_node = (fq_conv_it == std::end(pattern_map) ? nullptr : fq_conv_it->second.get_node_shared_ptr());
+        auto bias_it = pattern_map.find(bias);
+        auto bias_node = (bias_it == std::end(pattern_map) ? nullptr : bias_it->second.get_node_shared_ptr());
+        std::shared_ptr<ngraph::Node> bias_const_node = nullptr;
+
+        if (bias_node && !(bias_const_node = VerifyBiasGetConst(pattern_map.at(conv).get_node_shared_ptr(), bias_node)))
+            return false;
+
+        auto fq_bias_it = pattern_map.find(fq_bias);
+        auto fq_bias_node = (fq_bias_it == std::end(pattern_map) ? nullptr : fq_bias_it->second.get_node_shared_ptr());
+        auto fq_af_it = pattern_map.find(fq_af);
+        auto fq_af_node = (fq_af_it == std::end(pattern_map) ? nullptr : fq_af_it->second.get_node_shared_ptr());
+        auto max_pool1_it = pattern_map.find(max_pool1);
+        auto max_pool2_it = pattern_map.find(max_pool2);
+        auto max_pool_node = (max_pool1_it == std::end(pattern_map) ?
+            ((max_pool2_it == std::end(pattern_map) ? nullptr : max_pool2_it->second.get_node_shared_ptr())) : max_pool1_it->second.get_node_shared_ptr());
+        std::shared_ptr<ngraph::Node> af_node = nullptr;
+        std::vector<ngraph::pattern::PatternValueMap::const_iterator> af_it
+        {pattern_map.find(af1), pattern_map.find(af2), pattern_map.find(af3), pattern_map.find(af4)};
+
+        for (auto const& af : af_it) {
+            if (af != std::end(pattern_map)) {
+                af_node = af->second.get_node_shared_ptr();
+                break;
+            }
+        }
+
+        return Convert(gnaCompileTarget, gnaPrecision,
+            pattern_map.at(leading_transpose).get_node_shared_ptr(), fq_conv_node, pattern_map.at(conv).get_node_shared_ptr(),
+            pattern_map.at(trailing_transpose).get_node_shared_ptr(), bias_node, bias_const_node, fq_bias_node, max_pool_node, af_node, fq_af_node,
+            pattern_map.at(trailing_transpose).get_node_shared_ptr());
+    };
+
+    auto m = std::make_shared<ngraph::pattern::Matcher>(trailing_transpose, matcher_name);
+    this->register_matcher(m, callback);
+}
+
+Decompose2DConvTransposedWithBias::Decompose2DConvTransposedWithBias(const std::string& gnaCompileTarget, const InferenceEngine::Precision& gnaPrecision) {
+    MATCHER_SCOPE(Decompose2DConvTransposedWithBias);
+
+    auto const_input_i64 = ngraph::pattern::wrap_type<ngraph::opset7::Constant>(ngraph::pattern::type_matches(ngraph::element::i64));
+    auto const_input = ngraph::pattern::wrap_type<ngraph::opset7::Constant>();
+    auto leading_transpose = ngraph::pattern::wrap_type<ngraph::opset7::Transpose>({ngraph::pattern::any_input(), const_input_i64},
+        consumers_and_rank(1, 4));
+    auto conv = ngraph::pattern::wrap_type<ngraph::opset7::Convolution>(
+        {leading_transpose, ngraph::pattern::wrap_type<ngraph::opset7::Constant>(ngraph::pattern::rank_equals(4))},
+        consumers_and_rank(1, 4));
+    auto trailing_transpose = ngraph::pattern::wrap_type<ngraph::opset7::Transpose>({conv, const_input_i64},
+        consumers_and_rank(1, 4));
+    auto bias = ngraph::pattern::wrap_type<ngraph::opset7::Add>({trailing_transpose, const_input},
+        ngraph::pattern::consumers_count(1));
+
+    ngraph::matcher_pass_callback callback = [=](ngraph::pattern::Matcher& m) {
+        const auto& pattern_map = m.get_pattern_value_map();
+        std::shared_ptr<ngraph::Node> bias_const_node = nullptr;
+
+        if (!(bias_const_node = VerifyBiasGetConst(pattern_map.at(conv).get_node_shared_ptr(), pattern_map.at(bias).get_node_shared_ptr())))
+            return false;
+
+        return Convert(gnaCompileTarget, gnaPrecision,
+            pattern_map.at(leading_transpose).get_node_shared_ptr(), nullptr, pattern_map.at(conv).get_node_shared_ptr(),
+            pattern_map.at(trailing_transpose).get_node_shared_ptr(), pattern_map.at(bias).get_node_shared_ptr(), bias_const_node, nullptr, nullptr,
+            nullptr, nullptr, pattern_map.at(bias).get_node_shared_ptr());
+    };
+
+    auto m = std::make_shared<ngraph::pattern::Matcher>(bias, matcher_name);
+    this->register_matcher(m, callback);
+}
+
+Decompose2DConvTransposedWithBiasAF::Decompose2DConvTransposedWithBiasAF(const std::string& gnaCompileTarget, const InferenceEngine::Precision& gnaPrecision) {
+    MATCHER_SCOPE(Decompose2DConvTransposedWithBiasAF);
+
+    auto const_input_i64 = ngraph::pattern::wrap_type<ngraph::opset7::Constant>(ngraph::pattern::type_matches(ngraph::element::i64));
+    auto const_input = ngraph::pattern::wrap_type<ngraph::opset7::Constant>();
+    auto leading_transpose = ngraph::pattern::wrap_type<ngraph::opset7::Transpose>({ngraph::pattern::any_input(), const_input_i64},
+        consumers_and_rank(1, 4));
+    auto conv = ngraph::pattern::wrap_type<ngraph::opset7::Convolution>(
+        {leading_transpose, ngraph::pattern::wrap_type<ngraph::opset7::Constant>(ngraph::pattern::rank_equals(4))},
+        consumers_and_rank(1, 4));
+    auto trailing_transpose = ngraph::pattern::wrap_type<ngraph::opset7::Transpose>({conv, const_input_i64},
+        consumers_and_rank(1, 4));
+    auto bias = ngraph::pattern::wrap_type<ngraph::opset7::Add>({trailing_transpose, const_input},
+        ngraph::pattern::consumers_count(1));
+    auto af = ngraph::pattern::wrap_type<ngraph::opset7::Relu, ngraph::opset7::Sigmoid,
+        ngraph::opset7::Tanh, ngraph::opset7::Abs, ngraph::opset7::Log, ngraph::opset7::Exp,
+        ngraph::opset7::Sign, ngraph::opset7::Clamp>({bias},
+        ngraph::pattern::consumers_count(1));
+
+    ngraph::matcher_pass_callback callback = [=](ngraph::pattern::Matcher& m) {
+        const auto& pattern_map = m.get_pattern_value_map();
+        std::shared_ptr<ngraph::Node> bias_const_node = nullptr;
+
+        if (!(bias_const_node = VerifyBiasGetConst(pattern_map.at(conv).get_node_shared_ptr(), pattern_map.at(bias).get_node_shared_ptr())))
+            return false;
+
+        return Convert(gnaCompileTarget, gnaPrecision,
+            pattern_map.at(leading_transpose).get_node_shared_ptr(), nullptr, pattern_map.at(conv).get_node_shared_ptr(),
+            pattern_map.at(trailing_transpose).get_node_shared_ptr(), pattern_map.at(bias).get_node_shared_ptr(), bias_const_node, nullptr,
+            nullptr, pattern_map.at(af).get_node_shared_ptr(), nullptr, pattern_map.at(af).get_node_shared_ptr());
+    };
+
+    auto m = std::make_shared<ngraph::pattern::Matcher>(af, matcher_name);
+    this->register_matcher(m, callback);
+}

--- a/inference-engine/src/gna_plugin/transformations/decompose_2d_convolution.hpp
+++ b/inference-engine/src/gna_plugin/transformations/decompose_2d_convolution.hpp
@@ -1,0 +1,81 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <ngraph/pass/graph_rewrite.hpp>
+#include <ie_precision.hpp>
+
+namespace GNAPluginNS {
+
+/**
+ * @brief Decompose a 2D convolution, wrapped with transposes,
+ * to a set of valid 1D convolutions with padding added in front of the set:
+ *
+ *                                                  Padding
+ *                                                     |
+ *   Transpose (NHWC -> NCHW)               Transpose (NHWC -> NCHW)
+ *              |                                      |
+ *   Convolution with padding                  Valid convolution
+ *              |                                      |
+ *   Broadcast Bias (optional)              Broadcast Bias (optional)
+ *              |                                      |
+ *    Max Pooling (optional)                 Max Pooling (optional)
+ *              |                                      |
+ * Activation Function (optional)       Activation Function (optional)
+ *              |                                      |
+ *   Transpose (NCHW -> NHWC)               Transpose (NCHW -> NHWC)
+ *
+ */
+class Decompose2DConv : public ngraph::pass::MatcherPass {
+public:
+    NGRAPH_RTTI_DECLARATION;
+    Decompose2DConv(const std::string& gnaCompileTarget, const InferenceEngine::Precision& gnaPrecision);
+};
+
+/**
+ * @brief Decomopose a 2D convolution wrapped with transposes, with bias after trailing transpose,
+ * to a set of valid 1D convolutions with padding added in front of the set:
+ *
+ *                                              Padding
+ *                                                 |
+ * Transpose (NHWC -> NCHW)             Transpose (NHWC -> NCHW)
+ *            |                                    |
+ * Convolution with padding                Valid convolution
+ *            |                                    |
+ * Transpose (NCHW -> NHWC)             Transpose (NCHW -> NHWC)
+ *            |                                    |
+ *      Broadcast Bias                       Broadcast Bias
+ *
+ */
+class Decompose2DConvTransposedWithBias : public ngraph::pass::MatcherPass {
+public:
+    NGRAPH_RTTI_DECLARATION;
+    Decompose2DConvTransposedWithBias(const std::string& gnaCompileTarget, const InferenceEngine::Precision& gnaPrecision);
+};
+
+/**
+ * @brief Decomopose a 2D convolution wrapped with transposes, with bias
+ * to a set of valid 1D convolutions with padding added in front of the set:
+ *
+ *                                              Padding
+ *                                                 |
+ * Transpose (NHWC -> NCHW)             Transpose (NHWC -> NCHW)
+ *            |                                    |
+ * Convolution with padding                Valid convolution
+ *            |                                    |
+ * Transpose (NCHW -> NHWC)             Transpose (NCHW -> NHWC)
+ *            |                                    |
+ *      Broadcast Bias                       Broadcast Bias
+ *            |                                    |
+ *   Activation Function                  Activation Function
+ * 
+ */
+class Decompose2DConvTransposedWithBiasAF : public ngraph::pass::MatcherPass {
+public:
+    NGRAPH_RTTI_DECLARATION;
+    Decompose2DConvTransposedWithBiasAF(const std::string& gnaCompileTarget, const InferenceEngine::Precision& gnaPrecision);
+};
+
+} // namespace GNAPluginNS

--- a/inference-engine/src/gna_plugin/transformations/utils/transformation_helper.cpp
+++ b/inference-engine/src/gna_plugin/transformations/utils/transformation_helper.cpp
@@ -1,0 +1,106 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+#include <ngraph/opsets/opset7.hpp>
+#include <ngraph/pattern/op/wrap_type.hpp>
+#include <ngraph/rt_info.hpp>
+#include "transformation_helper.hpp"
+
+
+namespace GNAPluginNS {
+
+void GetConvData(std::shared_ptr<ngraph::opset7::Convolution> conv, ConvData& conv_data) {
+    conv_data.output_height = conv->get_output_shape(0)[2];
+    conv_data.output_width = conv->get_output_shape(0)[3];
+    conv_data.input_channel_count = conv->input_value(0).get_shape()[1];
+    conv_data.input_height = conv->input_value(0).get_shape()[2];
+    conv_data.input_width = conv->input_value(0).get_shape()[3];
+    conv_data.filter_count = conv->input_value(1).get_shape()[0];
+    conv_data.filter_channel_count = conv->input_value(1).get_shape()[1];
+    conv_data.filter_height = conv->input_value(1).get_shape()[2];
+    conv_data.filter_width = conv->input_value(1).get_shape()[3];
+    conv_data.filter_dilation_height = conv->get_dilations()[0];
+    conv_data.filter_dilation_width = conv->get_dilations()[1];
+    conv_data.filter_stride_height = conv->get_strides()[0];
+    conv_data.filter_stride_width = conv->get_strides()[1];
+    conv_data.output_channel_count = conv_data.filter_count;
+    conv_data.pads_begin_height = conv->get_pads_begin()[0];
+    conv_data.pads_begin_width = conv->get_pads_begin()[1];
+    conv_data.pads_end_height = conv->get_pads_end()[0];
+    conv_data.pads_end_width = conv->get_pads_end()[1];
+    conv_data.padding_type = conv->get_auto_pad();
+    conv_data.element_type = conv->get_element_type();
+}
+
+std::function<bool(ngraph::Output<ngraph::Node>)> consumers_and_rank(const size_t expected_count, const ngraph::Dimension& expected_rank) {
+    return [=](ngraph::Output<ngraph::Node> output) -> bool {
+        return ngraph::pattern::consumers_count(expected_count)(output) && ngraph::pattern::rank_equals(expected_rank)(output);
+    };
+}
+
+bool TransposeOrderMatches(std::shared_ptr<ngraph::opset7::Transpose> transpose, std::vector<size_t> order) {
+    if (!transpose)
+        return false;
+    const ngraph::Output<ngraph::Node>& transpose_order = transpose->input_value(1);
+    auto transpose_order_dim = transpose_order.get_shape().size();
+
+    if (transpose_order_dim != 1 || transpose_order.get_shape()[0] != order.size())
+        return false;
+
+    auto const_with_order_values = std::dynamic_pointer_cast<ngraph::opset7::Constant>(transpose_order.get_node_shared_ptr());
+    if (!const_with_order_values)
+        return false;
+
+    const auto data = const_with_order_values->cast_vector<size_t>();
+    if (data.empty())
+        return false;
+
+    if (!std::equal(order.begin(), order.end(), data.begin()))
+        return false;
+
+    return true;
+}
+
+std::shared_ptr<ngraph::opset7::StridedSlice> FlatCrop(ngraph::Output<ngraph::Node> input, size_t offset, size_t size) {
+    return std::make_shared<ngraph::opset7::StridedSlice>(
+        input,                                                                                                  // data
+        ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {(size_t)0, offset}),          // begin sice index
+        ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {(size_t)0, offset + size}),   // end slice index
+        ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {(size_t)1, (size_t)1}),       // strides
+        std::vector<int64_t>{1, 0},                                                                             // begin mask
+        std::vector<int64_t>{1, 0});                                                                            // end mask
+}
+
+std::shared_ptr<ngraph::Node> VerifyBiasGetConst(std::shared_ptr<ngraph::Node> conv, std::shared_ptr<ngraph::Node> bias) {
+    auto add_const = std::dynamic_pointer_cast<ngraph::opset7::Constant>(bias->input_value(1).get_node_shared_ptr());
+
+    // We need to check both inputs of Add when looking for constant
+    if (!add_const) {
+        add_const = std::dynamic_pointer_cast<ngraph::opset7::Constant>(bias->input_value(0).get_node_shared_ptr());
+    }
+
+    // Check if it's really a bias and not just addition
+    if (add_const) {
+        auto bias_size = shape_size(add_const->get_shape());
+        auto conv_filter_count = conv->get_output_shape(0)[1];
+        if (bias_size == conv_filter_count)
+            return add_const;
+    }
+    return nullptr;
+}
+
+std::shared_ptr<ngraph::Node> InsertFQLayer(const std::shared_ptr<ngraph::opset7::FakeQuantize> fq_layer,
+    std::shared_ptr<ngraph::Node> last_node) {
+    if (fq_layer != nullptr) {
+        auto new_fq = fq_layer->clone_with_new_inputs({last_node,
+            fq_layer->input_value(1), fq_layer->input_value(2),
+            fq_layer->input_value(3), fq_layer->input_value(4)});
+        ngraph::copy_runtime_info(new_fq, fq_layer);
+        return new_fq;
+    }
+    return last_node;
+}
+
+} // namespace GNAPluginNS

--- a/inference-engine/src/gna_plugin/transformations/utils/transformation_helper.hpp
+++ b/inference-engine/src/gna_plugin/transformations/utils/transformation_helper.hpp
@@ -1,0 +1,81 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+namespace GNAPluginNS {
+
+struct ConvData {
+    size_t input_height;
+    size_t input_width;
+    size_t input_channel_count;
+    size_t filter_height;
+    size_t filter_width;
+    size_t filter_count;
+    size_t filter_channel_count;
+    size_t filter_dilation_height;
+    size_t filter_dilation_width;
+    size_t filter_stride_height;
+    size_t filter_stride_width;
+    size_t output_height;
+    size_t output_width;
+    size_t output_channel_count;
+    size_t pads_begin_width;
+    size_t pads_begin_height;
+    size_t pads_end_width;
+    size_t pads_end_height;
+    ngraph::op::PadType padding_type;
+    ngraph::element::Type element_type;
+};
+
+/**
+ * @brief gets all convolution related data into a struct for further processing
+ * @param conv convolution node to get data of
+ * @param conv_data convolution data structure to put data into
+ * @return void
+ */
+void GetConvData(std::shared_ptr<ngraph::opset7::Convolution> conv, ConvData& conv_data);
+
+/**
+ * @brief ngraph matcher predicate fusing existing predicates for consumers count and rank of a layer
+ * @param expected_count expected consumers count for of node
+ * @param expected_rank expected node rank
+ * @return predicate function wrapper
+ */
+std::function<bool(ngraph::Output<ngraph::Node>)> consumers_and_rank(const size_t expected_count, const ngraph::Dimension& expected_rank);
+
+/**
+ * @brief checks whether transpose matches a given order
+ * @param transpose transpose layer
+ * @param order order of transposition to be compared with
+ * @return true if the order matches, false otherwise
+ */
+bool TransposeOrderMatches(std::shared_ptr<ngraph::opset7::Transpose> transpose, std::vector<size_t> order);
+
+/**
+ * @brief performs a crop of a flattened input tensor
+ * @param input input layer
+ * @param offset offset to start the crop at* 
+ * @param size size of the crop
+ * @return pointer to the newly created slice
+ */
+std::shared_ptr<ngraph::opset7::StridedSlice> FlatCrop(ngraph::Output<ngraph::Node> input, size_t offset, size_t size);
+
+/**
+ * @brief checks whether an add present after convolution is a bias and gets its const input
+ * @param conv convolution layer preceding potential bias
+ * @param bias potential bias layer passed from ngraph matcher
+ * @return bias const if the add layer present after convolution is a bias, nullptr otherwise
+ */
+std::shared_ptr<ngraph::Node> VerifyBiasGetConst(std::shared_ptr<ngraph::Node> conv, std::shared_ptr<ngraph::Node> bias);
+
+/**
+ * @brief inserts a new fake quantize layer (if it exists) copied from an existing fake quantize layer and conncts it to the output of a given layer
+ * @param fq_layer existing fake quantize layer to be copied
+ * @param last_node the node to which output the new fake quantize layer will be connected
+ * @return new fake quantize layer or the last node
+ */
+std::shared_ptr<ngraph::Node> InsertFQLayer(const std::shared_ptr<ngraph::opset7::FakeQuantize> fq_layer, std::shared_ptr<ngraph::Node> last_node);
+
+} // namespace GNAPluginNS

--- a/inference-engine/tests/functional/plugin/gna/pass_tests/convert_padded_to_valid_conv.cpp
+++ b/inference-engine/tests/functional/plugin/gna/pass_tests/convert_padded_to_valid_conv.cpp
@@ -277,8 +277,8 @@ const std::vector<std::vector<size_t >> maxpool1DPools = {{1, 2}};
 const std::vector<std::vector<size_t >> maxpool1DStrides = {{1, 1}};
 
 const std::vector<std::vector<size_t>> input2DNHWC = {{1, 16, 16, 32}};
-const std::vector<std::vector<size_t >> kernels2D = {{2, 2}, {4, 1}, {1, 3}};
-const std::vector<std::vector<size_t >> strides2D = {{1, 1}, {1, 2}, {2, 1}, {2, 2}};
+const std::vector<std::vector<size_t >> kernels2D = {{2, 2}, {4, 1}};
+const std::vector<std::vector<size_t >> strides2D = {{1, 1}, {2, 1}};
 const std::vector<std::vector<ptrdiff_t>> padBegins2D = {{1, 2}};
 const std::vector<std::vector<ptrdiff_t>> padEnds2D = {{3, 1}};
 const std::vector<std::vector<size_t >> dilations2D = {{1, 1}};

--- a/inference-engine/tests/functional/plugin/gna/pass_tests/convert_padded_to_valid_conv.cpp
+++ b/inference-engine/tests/functional/plugin/gna/pass_tests/convert_padded_to_valid_conv.cpp
@@ -1,0 +1,358 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include "common_test_utils/test_common.hpp"
+#include <string>
+#include <sstream>
+#include <fstream>
+#include <memory>
+#include <queue>
+#include <map>
+
+#include "transformations/init_node_info.hpp"
+#include "ngraph_functions/builders.hpp"
+#include "shared_test_classes/base/layer_test_utils.hpp"
+#include "../shared_tests_instances/skip_tests_check.hpp"
+
+using namespace ngraph;
+using namespace ngraph::opset7;
+
+namespace LayerTestsDefinitions {
+
+enum class modelType {
+    TranspConvTransp = 0,               /* Transpose(NHWC->NCHW) => Conv => Transpose(NCHW->NHWC) */
+    TranspConvBcastAddTransp,           /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => Transpose(NCHW->NHWC) */
+    TranspConvBcastAddMaxPoolTransp,    /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => MaxPooling => Transpose(NCHW->NHWC) (2D Max Pool case) */
+    TranspConvBcastAddActTransp,        /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => Activation Function => Transpose(NCHW->NHWC) */
+    TranspConvBcastAddMaxPoolActTransp, /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => MaxPool => Activation Function => Transpose(NCHW->NHWC) */
+    TranspConvTranspBcastAdd,           /* Transpose(NHWC->NCHW) => Conv => Transpose(NCHW->NHWC) => Bias */
+    TranspConvTranspBcastAddAct         /* Transpose(NHWC->NCHW) => Conv => Transpose(NCHW->NHWC) => Bias => Activation Function */
+};
+
+typedef std::tuple<
+    InferenceEngine::SizeVector,    // Kernel size
+    InferenceEngine::SizeVector,    // Strides
+    std::vector<ptrdiff_t>,         // Pad begin
+    std::vector<ptrdiff_t>,         // Pad end
+    InferenceEngine::SizeVector,    // Dilation
+    size_t,                         // Num out channels
+    op::PadType                     // Padding type
+> convSpecificParams;
+
+typedef std::tuple<
+    InferenceEngine::SizeVector,    // Bias
+    InferenceEngine::SizeVector,    // Transposed Bias
+    InferenceEngine::SizeVector,    // Maxpool pool
+    InferenceEngine::SizeVector     // Maxpool strides
+> miscSpecificParams;
+
+typedef std::tuple<
+    convSpecificParams,                 // Convolution parameters
+    miscSpecificParams,                 // Bias & Maxpool parameters
+    InferenceEngine::Precision,         // Network Precision
+    std::string,                        // Target Device
+    std::map<std::string, std::string>, // Configuration
+    InferenceEngine::SizeVector,        // Input shapes
+    modelType                           // Test model
+> paddedToValidParams;
+
+class PaddedToValidConvTest : public testing::WithParamInterface<paddedToValidParams>,
+    virtual public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<paddedToValidParams> obj) {
+        convSpecificParams convParams;
+        miscSpecificParams miscParams;
+        InferenceEngine::Precision netPrecision;
+        std::string targetDevice;
+        std::map<std::string, std::string> configuration;
+        InferenceEngine::SizeVector inputShape;
+        modelType model;
+        std::tie(convParams, miscParams, netPrecision, targetDevice, configuration, inputShape, model) = obj.param;
+        op::PadType padType;
+        InferenceEngine::SizeVector kernel, stride, dilation, bias, transpBias, maxpoolPool, maxpoolStride;
+        std::vector<ptrdiff_t> padBegin, padEnd;
+        size_t numOutChannels;
+        std::tie(kernel, stride, padBegin, padEnd, dilation, numOutChannels, padType) = convParams;
+        std::tie(bias, transpBias, maxpoolPool, maxpoolStride) = miscParams;
+
+        std::ostringstream result;
+        result << "M=" << static_cast<uint32_t>(model) << "_";
+        result << "IS=" << CommonTestUtils::vec2str(inputShape) << "_";
+        result << "K" << CommonTestUtils::vec2str(kernel) << "_";
+        result << "S" << CommonTestUtils::vec2str(stride) << "_";
+        result << "PB" << CommonTestUtils::vec2str(padBegin) << "_";
+        result << "PE" << CommonTestUtils::vec2str(padEnd) << "_";
+        result << "D=" << CommonTestUtils::vec2str(dilation) << "_";
+        result << "O=" << numOutChannels << "_";
+        result << "AP=" << padType << "_";
+        result << "B=" << CommonTestUtils::vec2str(bias) << "_";
+        result << "B=" << CommonTestUtils::vec2str(transpBias) << "_";
+        result << "MPP=" << CommonTestUtils::vec2str(maxpoolPool) << "_";
+        result << "MPS=" << CommonTestUtils::vec2str(maxpoolStride) << "_";
+        result << "netPRC=" << netPrecision.name() << "_";
+        result << "targetDevice=" << targetDevice << "_";
+        for (auto const& configItem : configuration) {
+            result << "_configItem=" << configItem.first << "_" << configItem.second;
+        }
+        return result.str();
+    }
+
+protected:
+    void SetUp() override {
+        threshold = 0.015f;
+        convSpecificParams convParams;
+        miscSpecificParams miscParams;
+        InferenceEngine::Precision netPrecision;
+        std::vector<size_t> inputShape;
+        modelType model;
+        std::tie(convParams, miscParams, netPrecision, targetDevice, configuration, inputShape, model) = this->GetParam();
+        op::PadType padType;
+        InferenceEngine::SizeVector kernel, stride, dilation, bias, transpBias, maxpoolPool, maxpoolStride;
+        std::vector<ptrdiff_t> padBegin, padEnd;
+        size_t numOutChannels;
+        std::tie(kernel, stride, padBegin, padEnd, dilation, numOutChannels, padType) = convParams;
+        std::tie(bias, transpBias, maxpoolPool, maxpoolStride) = miscParams;
+        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+
+        Shape biasShape{bias};
+        Shape transpBiasShape{transpBias};
+        Shape maxpoolShape{maxpoolPool};
+        Strides maxpoolStrides{maxpoolStride};
+
+        auto input = builder::makeParams(ngPrc, {inputShape});
+        auto transposeInOrder = op::Constant::create(element::i64, Shape{4}, {0, 3, 1, 2});
+        auto transposeIn = std::make_shared<Transpose>(input[0], transposeInOrder);
+        auto filterSize = std::accumulate(std::begin(kernel), std::end(kernel), 1ull, std::multiplies<size_t>());
+        auto filterWeights = CommonTestUtils::generate_float_numbers(numOutChannels * inputShape[3] * filterSize, -0.05f, 0.05f);
+        auto conv = builder::makeConvolution(transposeIn, ngPrc, kernel, stride, padBegin,
+            padEnd, dilation, padType, numOutChannels, false, filterWeights);
+        auto transposeOutOrder = op::Constant::create(element::i64, Shape{4}, {0, 2, 3, 1});
+        auto biasWeights = CommonTestUtils::generate_float_numbers(shape_size(biasShape), -1.5f, 1.5f);
+        Output<Node> biasConst = std::make_shared<Constant>(ngPrc, biasShape, biasWeights);
+        Output<Node> lastOp = std::make_shared<Transpose>(conv, transposeOutOrder);
+
+        switch (model) {
+        case modelType::TranspConvBcastAddTransp:
+        {
+            auto bias = std::make_shared<Add>(conv, biasConst);
+            lastOp = std::make_shared<Transpose>(bias, transposeOutOrder);
+        }
+        break;
+
+        case modelType::TranspConvBcastAddMaxPoolTransp:
+        {
+            auto bcastAdd = std::make_shared<Add>(conv, biasConst);
+            auto maxpool = std::make_shared<MaxPool>(bcastAdd, maxpoolStrides, Shape{0, 0}, Shape{0, 0}, maxpoolShape,
+                op::RoundingType::FLOOR, op::PadType::VALID);
+            auto transpose = std::make_shared<Transpose>(maxpool, transposeOutOrder);
+            auto lastOp = std::make_shared<Relu>(transpose);
+        }
+        break;
+
+        case modelType::TranspConvBcastAddActTransp:
+        {
+            auto bcastAdd = std::make_shared<Add>(conv, biasConst);
+            auto activation = std::make_shared<Relu>(bcastAdd);
+            lastOp = std::make_shared<Transpose>(activation, transposeOutOrder);
+        }
+        break;
+
+        case modelType::TranspConvBcastAddMaxPoolActTransp:
+        {
+            auto bcastAdd = std::make_shared<Add>(conv, biasConst);
+            auto maxpool = std::make_shared<MaxPool>(bcastAdd, maxpoolStrides, Shape{0, 0}, Shape{0, 0}, maxpoolShape,
+                op::RoundingType::FLOOR, op::PadType::VALID);
+            auto activation = std::make_shared<Relu>(maxpool);
+            lastOp = std::make_shared<Transpose>(activation, transposeOutOrder);
+        }
+        break;
+
+        case modelType::TranspConvTranspBcastAdd:
+        {
+            biasConst = std::make_shared<Constant>(ngPrc, transpBiasShape);
+            lastOp = std::make_shared<Add>(lastOp, biasConst);
+        }
+        break;
+
+        case modelType::TranspConvTranspBcastAddAct:
+        {
+            biasConst = builder::makeConstant(ngPrc, transpBiasShape, biasWeights, true);
+            auto bcastAdd = std::make_shared<Add>(lastOp, biasConst);
+            lastOp = std::make_shared<Relu>(bcastAdd);
+        }
+        break;
+
+        case modelType::TranspConvTransp:
+        default:
+            break;
+        }
+
+        auto result = std::make_shared<Result>(lastOp);
+        function = std::make_shared<Function>(ResultVector{result}, ParameterVector{input});
+    }
+};
+
+class Gna30PaddedToValidConvTest : public PaddedToValidConvTest, GnaLayerTestCheck {
+protected:
+    void Run() override {
+        GnaLayerTestCheck::SkipTestCheck();
+
+        if (!GnaLayerTestCheck::skipTest) {
+            PaddedToValidConvTest::Run();
+        }
+    }
+
+    void SetUp() override {
+        PaddedToValidConvTest::SetUp();
+    }
+};
+
+TEST_P(PaddedToValidConvTest, CompareWithRefs) {
+    Run();
+}
+
+TEST_P(Gna30PaddedToValidConvTest, CompareWithRefs) {
+    Run();
+}
+
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16
+};
+
+const std::vector<std::map<std::string, std::string>> configs1D = {
+    {
+        {"GNA_DEVICE_MODE", "GNA_SW_EXACT"},
+        {"GNA_SCALE_FACTOR_0", "1"},
+        {"GNA_EXEC_TARGET", "GNA_TARGET_2_0"}
+    }
+};
+
+const std::vector<std::map<std::string, std::string>> configs1D_Gna30 = {
+    {
+        {"GNA_DEVICE_MODE", "GNA_SW_EXACT"},
+        {"GNA_SCALE_FACTOR_0", "1"},
+        {"GNA_EXEC_TARGET", "GNA_TARGET_3_0"}
+    }
+};
+
+const std::vector<std::map<std::string, std::string>> configs2D = {
+    {
+        {"GNA_DEVICE_MODE", "GNA_SW_EXACT"},
+        {"GNA_SCALE_FACTOR_0", "1"},
+        {"GNA_EXEC_TARGET", "GNA_TARGET_3_0"}
+    }
+};
+
+const std::vector<op::PadType> padTypes = {
+        op::PadType::VALID,
+        op::PadType::EXPLICIT,
+        op::PadType::SAME_LOWER,
+        op::PadType::SAME_UPPER
+};
+
+const std::vector<modelType> models = {
+    modelType::TranspConvTransp,
+    modelType::TranspConvBcastAddTransp,
+    modelType::TranspConvBcastAddActTransp,
+    modelType::TranspConvTranspBcastAdd,
+    modelType::TranspConvTranspBcastAddAct,
+    modelType::TranspConvBcastAddMaxPoolTransp,
+    modelType::TranspConvBcastAddMaxPoolActTransp
+};
+
+const std::vector<std::vector<size_t>> input1DNHWC = {{1, 1, 16, 8}};
+const std::vector<std::vector<size_t >> kernels1D = {{1, 2}, {1, 3}, {1, 4}};
+const std::vector<std::vector<size_t >> strides1D = {{1, 1}};
+const std::vector<std::vector<ptrdiff_t>> padBegins1D = {{0, 2}};
+const std::vector<std::vector<ptrdiff_t>> padEnds1D = {{0, 3}};
+const std::vector<std::vector<size_t >> dilations1D = {{1, 1}};
+const std::vector<size_t> numOutChannels1D = {4};
+const std::vector<std::vector<size_t >> biases1D = {{1, 4, 1, 1}};
+const std::vector<std::vector<size_t >> transpBiases1D = {{1, 1, 1, 4}};
+const std::vector<std::vector<size_t >> maxpool1DPools = {{1, 2}};
+const std::vector<std::vector<size_t >> maxpool1DStrides = {{1, 1}};
+
+const std::vector<std::vector<size_t>> input2DNHWC = {{1, 16, 16, 32}};
+const std::vector<std::vector<size_t >> kernels2D = {{2, 2}, {4, 1}, {1, 3}};
+const std::vector<std::vector<size_t >> strides2D = {{1, 1}, {1, 2}, {2, 1}, {2, 2}};
+const std::vector<std::vector<ptrdiff_t>> padBegins2D = {{1, 2}};
+const std::vector<std::vector<ptrdiff_t>> padEnds2D = {{3, 1}};
+const std::vector<std::vector<size_t >> dilations2D = {{1, 1}};
+const std::vector<size_t> numOutChannels2D = {8};
+const std::vector<std::vector<size_t >> biases2D = {{1, 8, 1, 1}};
+const std::vector<std::vector<size_t >> transpBiases2D = {{1, 1, 1, 8}};
+const std::vector<std::vector<size_t >> maxpool2DPools = {{2, 2}};
+const std::vector<std::vector<size_t >> maxpool2DStrides = {{2, 1}};
+
+const auto conv1DParams = ::testing::Combine(
+    ::testing::ValuesIn(kernels1D),
+    ::testing::ValuesIn(strides1D),
+    ::testing::ValuesIn(padBegins1D),
+    ::testing::ValuesIn(padEnds1D),
+    ::testing::ValuesIn(dilations1D),
+    ::testing::ValuesIn(numOutChannels1D),
+    ::testing::ValuesIn(padTypes)
+);
+
+const auto misc1DParams = ::testing::Combine(
+    ::testing::ValuesIn(biases1D),
+    ::testing::ValuesIn(transpBiases1D),
+    ::testing::ValuesIn(maxpool1DPools),
+    ::testing::ValuesIn(maxpool1DStrides)
+);
+
+const auto conv2DParams = ::testing::Combine(
+    ::testing::ValuesIn(kernels2D),
+    ::testing::ValuesIn(strides2D),
+    ::testing::ValuesIn(padBegins2D),
+    ::testing::ValuesIn(padEnds2D),
+    ::testing::ValuesIn(dilations2D),
+    ::testing::ValuesIn(numOutChannels2D),
+    ::testing::ValuesIn(padTypes)
+);
+
+const auto misc2DParams = ::testing::Combine(
+    ::testing::ValuesIn(biases2D),
+    ::testing::ValuesIn(transpBiases2D),
+    ::testing::ValuesIn(maxpool2DPools),
+    ::testing::ValuesIn(maxpool2DStrides)
+);
+
+INSTANTIATE_TEST_CASE_P(smoke_1DPaddedToValid, PaddedToValidConvTest,
+    ::testing::Combine(
+        conv1DParams,
+        misc1DParams,
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(CommonTestUtils::DEVICE_GNA),
+        ::testing::ValuesIn(configs1D),
+        ::testing::ValuesIn(input1DNHWC),
+        ::testing::ValuesIn(models)),
+    PaddedToValidConvTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_1DPaddedToValid, Gna30PaddedToValidConvTest,
+    ::testing::Combine(
+        conv1DParams,
+        misc1DParams,
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(CommonTestUtils::DEVICE_GNA),
+        ::testing::ValuesIn(configs1D_Gna30),
+        ::testing::ValuesIn(input1DNHWC),
+        ::testing::ValuesIn(models)),
+    Gna30PaddedToValidConvTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_2DPaddedToValid, Gna30PaddedToValidConvTest,
+    ::testing::Combine(
+        conv2DParams,
+        misc2DParams,
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(CommonTestUtils::DEVICE_GNA),
+        ::testing::ValuesIn(configs2D),
+        ::testing::ValuesIn(input2DNHWC),
+        ::testing::ValuesIn(models)),
+    Gna30PaddedToValidConvTest::getTestCaseName);
+
+} // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/gna/pass_tests/convert_padded_to_valid_conv.cpp
+++ b/inference-engine/tests/functional/plugin/gna/pass_tests/convert_padded_to_valid_conv.cpp
@@ -25,6 +25,7 @@ namespace LayerTestsDefinitions {
 enum class modelType {
     TranspConvTransp = 0,               /* Transpose(NHWC->NCHW) => Conv => Transpose(NCHW->NHWC) */
     TranspConvBcastAddTransp,           /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => Transpose(NCHW->NHWC) */
+    TranspConvActTransp,                /* Transpose(NHWC->NCHW) => Conv => Activation Function => Transpose(NCHW->NHWC) */
     TranspConvBcastAddMaxPoolTransp,    /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => MaxPooling => Transpose(NCHW->NHWC) (2D Max Pool case) */
     TranspConvBcastAddActTransp,        /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => Activation Function => Transpose(NCHW->NHWC) */
     TranspConvBcastAddMaxPoolActTransp, /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => MaxPool => Activation Function => Transpose(NCHW->NHWC) */
@@ -139,6 +140,13 @@ protected:
         {
             auto bias = std::make_shared<Add>(conv, biasConst);
             lastOp = std::make_shared<Transpose>(bias, transposeOutOrder);
+        }
+        break;
+
+        case modelType::TranspConvActTransp:
+        {
+            auto activation = std::make_shared<Relu>(conv);
+            lastOp = std::make_shared<Transpose>(activation, transposeOutOrder);
         }
         break;
 
@@ -257,6 +265,7 @@ const std::vector<op::PadType> padTypes = {
 const std::vector<modelType> models = {
     modelType::TranspConvTransp,
     modelType::TranspConvBcastAddTransp,
+    modelType::TranspConvActTransp,
     modelType::TranspConvBcastAddActTransp,
     modelType::TranspConvTranspBcastAdd,
     modelType::TranspConvTranspBcastAddAct,

--- a/inference-engine/tests/functional/plugin/gna/pass_tests/decompose_2d_conv.cpp
+++ b/inference-engine/tests/functional/plugin/gna/pass_tests/decompose_2d_conv.cpp
@@ -1,0 +1,373 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include "common_test_utils/test_common.hpp"
+#include <string>
+#include <sstream>
+#include <fstream>
+#include <memory>
+#include <queue>
+#include <map>
+
+#include "transformations/init_node_info.hpp"
+#include "ngraph_functions/builders.hpp"
+#include "shared_test_classes/base/layer_test_utils.hpp"
+
+using namespace ngraph;
+using namespace opset1;
+
+namespace LayerTestsDefinitions {
+
+enum class modelType {
+    TranspConvTransp = 0,               /* Transpose(NHWC->NCHW) => Conv => Transpose(NCHW->NHWC) */
+    TranspConvBcastAddTransp,           /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => Transpose(NCHW->NHWC) */
+    TranspConvBcastAddMaxPoolTransp,    /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => MaxPooling => Transpose(NCHW->NHWC) (2D Max Pool case) */
+    TranspConvBcastAddActTransp,        /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => Activation Function => Transpose(NCHW->NHWC) */
+    TranspConvBcastAddMaxPoolActTransp, /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => MaxPool => Activation Function => Transpose(NCHW->NHWC) */
+    TranspConvTranspBcastAdd,           /* Transpose(NHWC->NCHW) => Conv => Transpose(NCHW->NHWC) => Bias */
+    TranspConvTranspBcastAddAct         /* Transpose(NHWC->NCHW) => Conv => Transpose(NCHW->NHWC) => Bias => AF */
+};
+
+typedef std::tuple<
+    InferenceEngine::SizeVector,    // Kernel size
+    InferenceEngine::SizeVector,    // Strides
+    std::vector<ptrdiff_t>,         // Pad begin
+    std::vector<ptrdiff_t>,         // Pad end
+    InferenceEngine::SizeVector,    // Dilation
+    size_t,                         // Num out channels
+    op::PadType                     // Padding type
+> convSpecificParams;
+
+typedef std::tuple<
+    InferenceEngine::SizeVector,    // Bias
+    InferenceEngine::SizeVector,    // Transposed Bias
+    InferenceEngine::SizeVector,    // Maxpool pool
+    InferenceEngine::SizeVector     // Maxpool strides
+> miscSpecificParams;
+
+typedef std::tuple<
+    convSpecificParams,                 // Convolution parameters
+    miscSpecificParams,                 // Bias & Maxpool parameters
+    InferenceEngine::Precision,         // Network Precision
+    std::string,                        // Target Device
+    std::map<std::string, std::string>, // Configuration
+    InferenceEngine::SizeVector,        // Input shapes
+    modelType                           // Test model
+> decompose2DConvParams;
+
+class Decompose2DConvTest : public testing::WithParamInterface<decompose2DConvParams>,
+    virtual public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<decompose2DConvParams> obj) {
+        convSpecificParams convParams;
+        miscSpecificParams miscParams;
+        InferenceEngine::Precision netPrecision;
+        std::string targetDevice;
+        std::map<std::string, std::string> configuration;
+        InferenceEngine::SizeVector inputShape;
+        modelType model;
+        std::tie(convParams, miscParams, netPrecision, targetDevice, configuration, inputShape, model) = obj.param;
+        op::PadType padType;
+        InferenceEngine::SizeVector kernel, stride, dilation, bias, transpBias, maxpoolPool, maxpoolStride;
+        std::vector<ptrdiff_t> padBegin, padEnd;
+        size_t numOutChannels;
+        std::tie(kernel, stride, padBegin, padEnd, dilation, numOutChannels, padType) = convParams;
+        std::tie(bias, transpBias, maxpoolPool, maxpoolStride) = miscParams;
+
+        std::ostringstream result;
+        result << "M=" << static_cast<uint32_t>(model) << "_";
+        result << "IS=" << CommonTestUtils::vec2str(inputShape) << "_";
+        result << "K" << CommonTestUtils::vec2str(kernel) << "_";
+        result << "S" << CommonTestUtils::vec2str(stride) << "_";
+        result << "PB" << CommonTestUtils::vec2str(padBegin) << "_";
+        result << "PE" << CommonTestUtils::vec2str(padEnd) << "_";
+        result << "D=" << CommonTestUtils::vec2str(dilation) << "_";
+        result << "O=" << numOutChannels << "_";
+        result << "AP=" << padType << "_";
+        result << "B=" << CommonTestUtils::vec2str(bias) << "_";
+        result << "B=" << CommonTestUtils::vec2str(transpBias) << "_";
+        result << "MPP=" << CommonTestUtils::vec2str(maxpoolPool) << "_";
+        result << "MPS=" << CommonTestUtils::vec2str(maxpoolStride) << "_";
+        result << "netPRC=" << netPrecision.name() << "_";
+        result << "targetDevice=" << targetDevice << "_";
+        for (auto const& configItem : configuration) {
+            result << "_configItem=" << configItem.first << "_" << configItem.second;
+        }
+        return result.str();
+    }
+
+protected:
+    void SetUp() override {
+        threshold = 0.015f;
+        convSpecificParams convParams;
+        miscSpecificParams miscParams;
+        InferenceEngine::Precision netPrecision;
+        std::vector<size_t> inputShape;
+        modelType model;
+        std::tie(convParams, miscParams, netPrecision, targetDevice, configuration, inputShape, model) = this->GetParam();
+        op::PadType padType;
+        InferenceEngine::SizeVector kernel, stride, dilation, bias, transpBias, maxpoolPool, maxpoolStride;
+        std::vector<ptrdiff_t> padBegin, padEnd;
+        size_t numOutChannels;
+        std::tie(kernel, stride, padBegin, padEnd, dilation, numOutChannels, padType) = convParams;
+        std::tie(bias, transpBias, maxpoolPool, maxpoolStride) = miscParams;
+        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+
+        Shape biasShape{bias};
+        Shape transpBiasShape{transpBias};
+        Shape maxpoolShape{maxpoolPool};
+        Strides maxpoolStrides{maxpoolStride};
+
+        auto input = builder::makeParams(ngPrc, {inputShape});
+        auto transposeInOrder = opset7::Constant::create(element::i64, Shape{4}, {0, 3, 1, 2});
+        auto transposeIn = std::make_shared<Transpose>(input[0], transposeInOrder);
+        auto filterSize = std::accumulate(std::begin(kernel), std::end(kernel), 1ull, std::multiplies<size_t>());
+        auto filterWeights = CommonTestUtils::generate_float_numbers(numOutChannels * inputShape[3] * filterSize, -0.03f, 0.03f);
+        auto conv = builder::makeConvolution(transposeIn, ngPrc, kernel, stride, padBegin,
+            padEnd, dilation, padType, numOutChannels, false, filterWeights);
+        auto transposeOutOrder = opset7::Constant::create(element::i64, Shape{4}, {0, 2, 3, 1});
+        auto biasWeights = CommonTestUtils::generate_float_numbers(shape_size(biasShape), -1.5f, 1.5f);
+        Output<Node> biasConst = std::make_shared<Constant>(ngPrc, biasShape, biasWeights);
+        Output<Node> lastOp = std::make_shared<Transpose>(conv, transposeOutOrder);
+
+        switch (model) {
+        case modelType::TranspConvBcastAddTransp:
+        {
+            auto bias = std::make_shared<Add>(conv, biasConst);
+            lastOp = std::make_shared<Transpose>(bias, transposeOutOrder);
+        }
+        break;
+
+        case modelType::TranspConvBcastAddMaxPoolTransp:
+        {
+            auto bcastAdd = std::make_shared<Add>(conv, biasConst);
+            auto maxpool = std::make_shared<MaxPool>(bcastAdd, maxpoolStrides, Shape{0, 0}, Shape{0, 0}, maxpoolShape,
+                op::RoundingType::FLOOR, op::PadType::VALID);
+            auto transpose = std::make_shared<Transpose>(maxpool, transposeOutOrder);
+            lastOp = std::make_shared<Relu>(transpose);
+        }
+        break;
+
+        case modelType::TranspConvBcastAddActTransp:
+        {
+            auto bcastAdd = std::make_shared<Add>(conv, biasConst);
+            auto activation = std::make_shared<Sigmoid>(bcastAdd);
+            lastOp = std::make_shared<Transpose>(activation, transposeOutOrder);
+        }
+        break;
+
+        case modelType::TranspConvBcastAddMaxPoolActTransp:
+        {
+            auto bcastAdd = std::make_shared<Add>(conv, biasConst);
+            auto max_pool = std::make_shared<MaxPool>(bcastAdd, Strides{1, 1}, Shape{0, 0}, Shape{0, 0}, maxpoolShape,
+                op::RoundingType::FLOOR, op::PadType::VALID);
+            auto activation = std::make_shared<Relu>(max_pool);
+            lastOp = std::make_shared<Transpose>(activation, transposeOutOrder);
+        }
+        break;
+
+        case modelType::TranspConvTranspBcastAdd:
+        {
+            biasConst = std::make_shared<Constant>(ngPrc, transpBiasShape);
+            lastOp = std::make_shared<Add>(lastOp, biasConst);
+        }
+        break;
+
+        case modelType::TranspConvTranspBcastAddAct:
+        {
+            biasConst = builder::makeConstant(ngPrc, transpBiasShape, biasWeights, true);
+            auto bcastAdd = std::make_shared<Add>(lastOp, biasConst);
+            lastOp = std::make_shared<Relu>(bcastAdd);
+        }
+        break;
+
+        case modelType::TranspConvTransp:
+        default:
+            break;
+        }
+
+        auto result = std::make_shared<Result>(lastOp);
+        function = std::make_shared<Function>(ResultVector{result}, ParameterVector{input});
+    }
+};
+
+TEST_P(Decompose2DConvTest, CompareWithRefs) {
+    Run();
+}
+
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16
+};
+
+const std::vector<std::map<std::string, std::string>> configs = {
+    {
+        {"GNA_DEVICE_MODE", "GNA_SW_EXACT"},
+        {"GNA_SCALE_FACTOR_0", "1"},
+        {"GNA_EXEC_TARGET", "GNA_TARGET_2_0"}
+    }
+};
+
+const std::vector<op::PadType> padTypes = {
+        op::PadType::VALID,
+        op::PadType::EXPLICIT,
+        op::PadType::SAME_LOWER,
+        op::PadType::SAME_UPPER
+};
+
+const std::vector<modelType> models = {
+    modelType::TranspConvTransp,
+    modelType::TranspConvBcastAddTransp,
+    modelType::TranspConvBcastAddActTransp,
+    modelType::TranspConvTranspBcastAdd,
+    modelType::TranspConvTranspBcastAddAct,
+    modelType::TranspConvBcastAddMaxPoolTransp,
+    modelType::TranspConvBcastAddMaxPoolActTransp
+};
+
+const std::vector<std::vector<size_t>> input2DNHWC = {{1, 4, 4, 32}};
+const std::vector<std::vector<size_t >> kernels2D = {{1, 2}, {2, 1}, {2, 2}};
+const std::vector<std::vector<size_t >> strides2D = {{1, 1}};
+const std::vector<std::vector<ptrdiff_t>> padBegins2D = {{1, 1}};
+const std::vector<std::vector<ptrdiff_t>> padEnds2D = {{3, 1}};
+const std::vector<std::vector<size_t >> dilations2D = {{1, 1}, {1, 2}, {2, 1}, {2, 2}};
+const std::vector<size_t> numOutChannels2D = {4};
+const std::vector<std::vector<size_t >> biases2D = {{1, 4, 1, 1}};
+const std::vector<std::vector<size_t >> transpBiases2D = {{1, 1, 1, 4}};
+const std::vector<std::vector<size_t >> maxpool1DPools = {{1, 2}};
+const std::vector<std::vector<size_t >> maxpool1DStrides = {{1, 1}};
+
+const auto conv2DParams = ::testing::Combine(
+    ::testing::ValuesIn(kernels2D),
+    ::testing::ValuesIn(strides2D),
+    ::testing::ValuesIn(padBegins2D),
+    ::testing::ValuesIn(padEnds2D),
+    ::testing::ValuesIn(dilations2D),
+    ::testing::ValuesIn(numOutChannels2D),
+    ::testing::ValuesIn(padTypes)
+);
+
+const auto miscParams = ::testing::Combine(
+    ::testing::ValuesIn(biases2D),
+    ::testing::ValuesIn(transpBiases2D),
+    ::testing::ValuesIn(maxpool1DPools),
+    ::testing::ValuesIn(maxpool1DStrides)
+);
+
+INSTANTIATE_TEST_CASE_P(smoke_Decompose2DConv, Decompose2DConvTest,
+    ::testing::Combine(
+        conv2DParams,
+        miscParams,
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(CommonTestUtils::DEVICE_GNA),
+        ::testing::ValuesIn(configs),
+        ::testing::ValuesIn(input2DNHWC),
+        ::testing::ValuesIn(models)),
+    Decompose2DConvTest::getTestCaseName);
+
+
+/* ============= Strides & Dilations Combination ============= */
+
+const std::vector<std::map<std::string, std::string>> configsStrides = {
+    {
+        {"GNA_DEVICE_MODE", "GNA_SW_FP32"},
+        {"GNA_SCALE_FACTOR_0", "1"},
+        {"GNA_EXEC_TARGET", "GNA_TARGET_2_0"}
+    }
+};
+
+const std::vector<op::PadType> padTypesStrides = {
+    op::PadType::VALID,
+};
+
+const std::vector<modelType> modelsStrides = {
+    modelType::TranspConvTransp,
+};
+
+const std::vector<std::vector<size_t>> input2DNHWCStrides = {{1, 8, 8, 32}};
+const std::vector<std::vector<size_t >> kernels2DStrides = {{1, 2}, {2, 1}, {2, 2}};
+const std::vector<std::vector<size_t >> strides2DStrides = {{1, 1}, {2, 1}, {1, 2}, {2, 2}};
+const std::vector<std::vector<size_t >> dilations2DStrides = {{1, 1}, {1, 2}, {2, 1}, {2, 2}};
+
+const auto conv2DParamsStrides = ::testing::Combine(
+    ::testing::ValuesIn(kernels2DStrides),
+    ::testing::ValuesIn(strides2DStrides),
+    ::testing::ValuesIn(padBegins2D),
+    ::testing::ValuesIn(padEnds2D),
+    ::testing::ValuesIn(dilations2DStrides),
+    ::testing::ValuesIn(numOutChannels2D),
+    ::testing::ValuesIn(padTypesStrides)
+);
+
+INSTANTIATE_TEST_CASE_P(smoke_Decompose2DConvStridesDilations, Decompose2DConvTest,
+    ::testing::Combine(
+        conv2DParamsStrides,
+        miscParams,
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(CommonTestUtils::DEVICE_GNA),
+        ::testing::ValuesIn(configsStrides),
+        ::testing::ValuesIn(input2DNHWCStrides),
+        ::testing::ValuesIn(modelsStrides)),
+    Decompose2DConvTest::getTestCaseName);
+
+/* ============= GNA 3.0 Supported Convolutions Combination ============= */
+
+const std::vector<std::map<std::string, std::string>> configsGNA30 = {
+    {
+        {"GNA_DEVICE_MODE", "GNA_SW_EXACT"},
+        {"GNA_SCALE_FACTOR_0", "1"},
+        {"GNA_EXEC_TARGET", "GNA_TARGET_3_0"}
+    }
+};
+
+const std::vector<op::PadType> padTypesGNA30 = {
+    op::PadType::VALID,
+};
+
+const std::vector<modelType> modelsGNA30 = {
+    modelType::TranspConvBcastAddMaxPoolTransp,
+};
+
+// TODO: add data sets which should be decomposed and which should be skipped
+const std::vector<std::vector<size_t>> input2DNHWCGNA30 = {{1, 16, 16, 32}};
+const std::vector<std::vector<size_t >> kernels2DGNA30 = {{1, 2}, {1, 4}};
+const std::vector<std::vector<size_t >> strides2DGNA30 = {{1, 1}};
+const std::vector<std::vector<size_t >> dilations2DGNA30 = {{1, 1}, {1, 2}};
+const std::vector<size_t> numOutChannels2DGNA30 = {8};
+const std::vector<std::vector<size_t >> biases2DGNA30 = {{1, 8, 1, 1}};
+const std::vector<std::vector<size_t >> transpBiases2DGNA30 = {{1, 1, 1, 8}};
+const std::vector<std::vector<size_t >> maxpool2DPoolsGNA30 = {{1, 1}, {1, 2}};
+const std::vector<std::vector<size_t >> maxpoo2DStridesGNA30 = {{1, 1}};
+
+const auto conv2DParamsGNA30 = ::testing::Combine(
+    ::testing::ValuesIn(kernels2DGNA30),
+    ::testing::ValuesIn(strides2DGNA30),
+    ::testing::ValuesIn(padBegins2D),
+    ::testing::ValuesIn(padEnds2D),
+    ::testing::ValuesIn(dilations2DGNA30),
+    ::testing::ValuesIn(numOutChannels2DGNA30),
+    ::testing::ValuesIn(padTypesGNA30)
+);
+
+const auto miscParamsGNA30 = ::testing::Combine(
+    ::testing::ValuesIn(biases2DGNA30),
+    ::testing::ValuesIn(transpBiases2DGNA30),
+    ::testing::ValuesIn(maxpool2DPoolsGNA30),
+    ::testing::ValuesIn(maxpoo2DStridesGNA30)
+);
+
+INSTANTIATE_TEST_CASE_P(smoke_Decompose2DConvGNA30, Decompose2DConvTest,
+    ::testing::Combine(
+        conv2DParamsGNA30,
+        miscParamsGNA30,
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(CommonTestUtils::DEVICE_GNA),
+        ::testing::ValuesIn(configsGNA30),
+        ::testing::ValuesIn(input2DNHWCGNA30),
+        ::testing::ValuesIn(modelsGNA30)),
+    Decompose2DConvTest::getTestCaseName);
+
+} // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/gna/pass_tests/decompose_2d_conv.cpp
+++ b/inference-engine/tests/functional/plugin/gna/pass_tests/decompose_2d_conv.cpp
@@ -24,6 +24,7 @@ namespace LayerTestsDefinitions {
 enum class modelType {
     TranspConvTransp = 0,               /* Transpose(NHWC->NCHW) => Conv => Transpose(NCHW->NHWC) */
     TranspConvBcastAddTransp,           /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => Transpose(NCHW->NHWC) */
+    TranspConvActTransp,                /* Transpose(NHWC->NCHW) => Conv => Activation Function => Transpose(NCHW->NHWC) */
     TranspConvBcastAddMaxPoolTransp,    /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => MaxPooling => Transpose(NCHW->NHWC) (2D Max Pool case) */
     TranspConvBcastAddActTransp,        /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => Activation Function => Transpose(NCHW->NHWC) */
     TranspConvBcastAddMaxPoolActTransp, /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => MaxPool => Activation Function => Transpose(NCHW->NHWC) */
@@ -141,6 +142,13 @@ protected:
         }
         break;
 
+        case modelType::TranspConvActTransp:
+        {
+            auto activation = std::make_shared<Relu>(conv);
+            lastOp = std::make_shared<Transpose>(activation, transposeOutOrder);
+        }
+        break;
+
         case modelType::TranspConvBcastAddMaxPoolTransp:
         {
             auto bcastAdd = std::make_shared<Add>(conv, biasConst);
@@ -221,6 +229,7 @@ const std::vector<op::PadType> padTypes = {
 const std::vector<modelType> models = {
     modelType::TranspConvTransp,
     modelType::TranspConvBcastAddTransp,
+    modelType::TranspConvActTransp,
     modelType::TranspConvBcastAddActTransp,
     modelType::TranspConvTranspBcastAdd,
     modelType::TranspConvTranspBcastAddAct,
@@ -331,7 +340,6 @@ const std::vector<modelType> modelsGNA30 = {
     modelType::TranspConvBcastAddMaxPoolTransp,
 };
 
-// TODO: add data sets which should be decomposed and which should be skipped
 const std::vector<std::vector<size_t>> input2DNHWCGNA30 = {{1, 16, 16, 32}};
 const std::vector<std::vector<size_t >> kernels2DGNA30 = {{1, 2}, {1, 4}};
 const std::vector<std::vector<size_t >> strides2DGNA30 = {{1, 1}};

--- a/inference-engine/tests/unit/gna/ngraph/transformations/gna_convert_padded_to_valid_convolution.cpp
+++ b/inference-engine/tests/unit/gna/ngraph/transformations/gna_convert_padded_to_valid_convolution.cpp
@@ -1,0 +1,480 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <tuple>
+
+#include "transformations/convert_padded_to_valid_convolution.hpp"
+#include "common_test_utils/ngraph_test_utils.hpp"
+#include <ngraph/function.hpp>
+#include <ngraph/opsets/opset7.hpp>
+#include <ngraph/pass/manager.hpp>
+#include <transformations/init_node_info.hpp>
+
+namespace testing {
+
+namespace {
+
+enum class modelType {
+    TranspConvTransp = 0,               /* Transpose(NHWC->NCHW) => Conv => Transpose(NCHW->NHWC) */
+    TranspConvBcastAddTransp,           /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => Transpose(NCHW->NHWC) */
+    TranspConvBcastAddMaxPoolTransp,    /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => MaxPooling => Transpose(NCHW->NHWC) (2D Max Pool case) */
+    TranspConvBcastAddActTransp,        /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => Activation Function => Transpose(NCHW->NHWC) */
+    TranspConvBcastAddMaxPoolActTransp, /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => MaxPool => Activation Function => Transpose(NCHW->NHWC) */
+    TranspConvTranspBcastAdd,           /* Transpose(NHWC->NCHW) => conv => Transpose(NCHW->NHWC) => Bias */
+    TranspConvTranspBcastAddAct         /* Transpose(NHWC->NCHW) => Conv => Transpose(NCHW->NHWC) => Bias => Activation Function */
+};
+
+typedef std::tuple<
+    modelType,              // Test model
+    ngraph::PartialShape,   // Input shape
+    ngraph::Shape,          // Convolution filter shape
+    ngraph::Strides,        // Convolution stride
+    ngraph::CoordinateDiff, // Convolution pads begin
+    ngraph::CoordinateDiff, // Convolution pads end
+    ngraph::Strides,        // Convolution dilation
+    ngraph::Shape,          // Bias shape
+    ngraph::Strides,        // Max Pool stride
+    ngraph::Shape,          // Max Pool shape
+    ngraph::op::PadType     // Padding type
+> paddedToValidConvParams;
+
+typedef std::tuple<
+    bool,                   // With / without Fake Quantize layers
+    paddedToValidConvParams      // Test parameters
+> fqPaddedToValidConvParams;
+
+struct ConvData {
+    size_t input_height;
+    size_t input_width;
+    size_t input_channel_count;
+    size_t pads_begin_width;
+    size_t pads_begin_height;
+    size_t pads_end_width;
+    size_t pads_end_height;
+};
+
+void GetConvParams(std::shared_ptr<ngraph::opset7::Convolution> conv, ConvData& conv_data) {
+    conv_data.input_channel_count = conv->input_value(0).get_shape()[1];
+    conv_data.input_height = conv->input_value(0).get_shape()[2];
+    conv_data.input_width = conv->input_value(0).get_shape()[3];
+    conv_data.pads_begin_height = conv->get_pads_begin()[0];
+    conv_data.pads_begin_width = conv->get_pads_begin()[1];
+    conv_data.pads_end_height = conv->get_pads_end()[0];
+    conv_data.pads_end_width = conv->get_pads_end()[1];
+}
+
+std::shared_ptr<ngraph::opset7::FakeQuantize> createFQ(ngraph::Output<ngraph::Node>& in_node) {
+    auto input_low = ngraph::opset7::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {1});
+    auto input_high = ngraph::opset7::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {5});
+    auto output_low = ngraph::opset7::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {0});
+    auto output_high = ngraph::opset7::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {10});
+    return std::make_shared<ngraph::opset7::FakeQuantize>(in_node, input_low, input_high, output_low, output_high, 11);
+}
+
+ngraph::Output<ngraph::Node> createBiasFQ(const ngraph::Output<ngraph::Node>& in_node,
+    std::shared_ptr<ngraph::opset7::Constant>& bias_const, const bool& fq) {
+    ngraph::Output<ngraph::Node> bcast_add = std::make_shared<ngraph::opset7::Add>(in_node, bias_const);
+
+    if (fq) {
+        bcast_add = createFQ(bcast_add);
+    }
+
+    return bcast_add;
+}
+
+std::shared_ptr<ngraph::opset7::Result> createFunction(const bool& fq,
+    const modelType& model,
+    const ngraph::Output<ngraph::Node>& input_node,
+    const ngraph::Shape& filters_shape,
+    const ngraph::Strides& conv_stride,
+    const ngraph::CoordinateDiff& pads_begin,
+    const ngraph::CoordinateDiff& pads_end,
+    const ngraph::Strides& conv_dilation,
+    const ngraph::Shape& bias_shape,
+    const ngraph::Strides& maxpool_stride,
+    const ngraph::Shape& maxpool_shape,
+    const ngraph::op::PadType& pad_type,
+    ConvData* conv_data) {
+    auto transpose_in_order = std::make_shared<ngraph::opset7::Constant>(ngraph::element::i64, ngraph::Shape{4}, std::vector<int64_t>{0, 3, 1, 2});
+    auto transpose_in = std::make_shared<ngraph::opset7::Transpose>(input_node, transpose_in_order);
+    ngraph::Output<ngraph::Node> filters = std::make_shared<ngraph::opset7::Constant>(ngraph::element::i64,
+        ngraph::Shape{4, input_node.get_shape()[3], filters_shape[0], filters_shape[1]});
+
+    if (fq) {
+        filters = createFQ(filters);
+    }
+
+    auto conv = std::make_shared<ngraph::opset7::Convolution>(transpose_in, filters, conv_stride, pads_begin, pads_end, conv_dilation, pad_type);
+    if (conv_data)
+        GetConvParams(conv, *conv_data);
+    auto transpose_out_order = std::make_shared<ngraph::opset7::Constant>(ngraph::element::i64, ngraph::Shape{4}, std::vector<int64_t>{0, 2, 3, 1});
+    auto bias_const = std::make_shared<ngraph::opset7::Constant>(ngraph::element::i64, bias_shape);
+
+    ngraph::Output<ngraph::Node> last_op = std::make_shared<ngraph::opset7::Transpose>(conv, transpose_out_order);
+
+    switch (model) {
+    case modelType::TranspConvBcastAddTransp:
+    {
+        auto bcast_add = createBiasFQ(conv, bias_const, fq);
+        last_op = std::make_shared<ngraph::opset7::Transpose>(bcast_add, transpose_out_order);
+    }
+    break;
+
+    case modelType::TranspConvBcastAddMaxPoolTransp:
+    {
+        auto bcast_add = createBiasFQ(conv, bias_const, fq);
+        auto maxpool = std::make_shared<ngraph::opset7::MaxPool>(bcast_add, maxpool_stride, ngraph::Shape{0, 0}, ngraph::Shape{0, 0}, maxpool_shape,
+            ngraph::op::RoundingType::FLOOR, ngraph::op::PadType::VALID);
+        auto transpose = std::make_shared<ngraph::opset7::Transpose>(maxpool, transpose_out_order);
+        last_op = std::make_shared<ngraph::opset7::Relu>(transpose);
+    }
+    break;
+
+    case modelType::TranspConvBcastAddActTransp:
+    {
+        auto bcast_add = createBiasFQ(conv, bias_const, fq);
+        auto activation = std::make_shared<ngraph::opset7::Relu>(bcast_add);
+        last_op = std::make_shared<ngraph::opset7::Transpose>(activation, transpose_out_order);
+    }
+    break;
+
+    case modelType::TranspConvBcastAddMaxPoolActTransp:
+    {
+        auto bcast_add = createBiasFQ(conv, bias_const, fq);
+        auto maxpool = std::make_shared<ngraph::opset7::MaxPool>(bcast_add, maxpool_stride, ngraph::Shape{0, 0}, ngraph::Shape{0, 0}, maxpool_shape,
+            ngraph::op::RoundingType::FLOOR, ngraph::op::PadType::VALID);
+        auto activation = std::make_shared<ngraph::opset7::Relu>(maxpool);
+        last_op = std::make_shared<ngraph::opset7::Transpose>(activation, transpose_out_order);
+    }
+    break;
+
+    case modelType::TranspConvTranspBcastAdd:
+    {
+        last_op = createBiasFQ(last_op, bias_const, fq);
+    }
+    break;
+
+    case modelType::TranspConvTranspBcastAddAct:
+    {
+        auto bcast_add = createBiasFQ(last_op, bias_const, fq);
+        last_op = std::make_shared<ngraph::opset7::Relu>(bcast_add);
+    }
+    break;
+
+    case modelType::TranspConvTransp:
+    default:
+        break;
+    }
+
+    return std::make_shared<ngraph::opset7::Result>(last_op);
+}
+
+std::shared_ptr<ngraph::Function> get_initial_function(const bool& fq,
+    const modelType& model,
+    const ngraph::PartialShape& input_shape,
+    const ngraph::Shape& filters_shape,
+    const ngraph::Strides& conv_stride,
+    const ngraph::CoordinateDiff& pads_begin,
+    const ngraph::CoordinateDiff& pads_end,
+    const ngraph::Strides& conv_dilation,
+    const ngraph::Shape& bias_shape,
+    const ngraph::Strides& maxpool_stride,
+    const ngraph::Shape& maxpool_shape,
+    const ngraph::op::PadType& pad_type,
+    ConvData& conv_data) {
+    auto input_params = std::make_shared<ngraph::opset7::Parameter>(ngraph::element::i64, input_shape);
+    auto result = createFunction(fq, model, input_params, filters_shape, conv_stride, pads_begin, pads_end, conv_dilation, bias_shape,
+        maxpool_stride, maxpool_shape, pad_type, &conv_data);
+    return std::make_shared<ngraph::Function>(ngraph::ResultVector{result}, ngraph::ParameterVector{input_params});
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+class ConvertPaddedToValidConvTestInvalidFixture : public CommonTestUtils::TestsCommon,
+    public ::testing::WithParamInterface<fqPaddedToValidConvParams> {
+public:
+    void SetUp() override;
+public:
+    std::shared_ptr<ngraph::Function> function, reference_function;
+};
+
+void ConvertPaddedToValidConvTestInvalidFixture::SetUp() {
+    bool fq;
+    paddedToValidConvParams params;
+    modelType model;
+    ngraph::PartialShape input_shape;
+    ngraph::Shape filters_shape, bias_shape, maxpool_shape;
+    ngraph::Strides conv_stride, conv_dilation, maxpool_stride;
+    ngraph::CoordinateDiff pads_begin, pads_end;
+    ngraph::op::PadType pad_type;
+    ConvData conv_data;
+    std::tie(fq, params) = this->GetParam();
+    std::tie(model, input_shape, filters_shape, conv_stride, pads_begin, pads_end, conv_dilation,
+        bias_shape, maxpool_stride, maxpool_shape, pad_type) = params;
+
+    function = get_initial_function(fq, model, input_shape, filters_shape, conv_stride, pads_begin, pads_end, conv_dilation,
+        bias_shape, maxpool_stride, maxpool_shape, pad_type, conv_data);
+    reference_function = get_initial_function(fq, model, input_shape, filters_shape, conv_stride, pads_begin, pads_end, conv_dilation,
+        bias_shape, maxpool_stride, maxpool_shape, pad_type, conv_data);
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+class ConvertPaddedToValidConvTestFixture: public CommonTestUtils::TestsCommon,
+    public ::testing::WithParamInterface<fqPaddedToValidConvParams> {
+public:
+    void SetUp() override;
+    std::shared_ptr<ngraph::Function> get_reference(const bool& fq,
+        const modelType& model,
+        const ngraph::PartialShape& input_shape,
+        const ngraph::Shape& filters_shape,
+        const ngraph::Strides& conv_stride,
+        const ngraph::CoordinateDiff& pads_begin,
+        const ngraph::CoordinateDiff& pads_end,
+        const ngraph::Strides& conv_dilation,
+        const ngraph::Shape& bias_shape,
+        const ngraph::Strides& maxpool_stride,
+        const ngraph::Shape& maxpool_shape,
+        const ngraph::op::PadType& pad_type,
+        const ConvData& conv_data);
+public:
+    std::shared_ptr<ngraph::Function> function, reference_function;
+};
+
+void ConvertPaddedToValidConvTestFixture::SetUp() {
+    bool fq;
+    paddedToValidConvParams params;
+    modelType model;
+    ngraph::PartialShape input_shape;
+    ngraph::Shape filters_shape, bias_shape, maxpool_shape;
+    ngraph::Strides conv_stride, conv_dilation, maxpool_stride;
+    ngraph::CoordinateDiff pads_begin, pads_end;
+    ngraph::op::PadType pad_type;
+    ConvData conv_data;
+    std::tie(fq, params) = this->GetParam();
+    std::tie(model, input_shape, filters_shape, conv_stride, pads_begin, pads_end, conv_dilation,
+        bias_shape, maxpool_stride, maxpool_shape, pad_type) = params;
+
+    function = get_initial_function(fq, model, input_shape, filters_shape, conv_stride, pads_begin, pads_end, conv_dilation,
+        bias_shape, maxpool_stride, maxpool_shape, pad_type, conv_data);
+    reference_function = get_reference(fq, model, input_shape, filters_shape, conv_stride, pads_begin, pads_end, conv_dilation,
+        bias_shape, maxpool_stride, maxpool_shape, pad_type, conv_data);
+}
+
+std::shared_ptr<ngraph::opset7::StridedSlice> FlatCrop(ngraph::Output<ngraph::Node> input, size_t offset, size_t size) {
+    return std::make_shared<ngraph::opset7::StridedSlice>(
+        input, // data
+        ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {(size_t)0, offset}), // begin sice index
+        ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {(size_t)0, offset + size}), // end slice index
+        ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {(size_t)1, (size_t)1}), // strides
+        std::vector<int64_t>{1, 0},  // begin mask
+        std::vector<int64_t>{1, 0}); // end mask
+}
+
+void InsertPadding(ngraph::OutputVector& input_rows_to_concat, size_t size,
+    const std::shared_ptr<ngraph::opset7::Constant> padding_const, size_t biggest_padding) {
+
+    if (size == biggest_padding) {
+        input_rows_to_concat.push_back(padding_const);
+    } else {
+        auto slice = FlatCrop(padding_const, 0, size);
+        input_rows_to_concat.push_back(slice);
+    }
+}
+
+std::shared_ptr<ngraph::Node> CreatePaddedNet(const ngraph::Output<ngraph::Node>& input_node,
+    const ConvData& conv_data) {
+    size_t flat_left_padding = conv_data.input_channel_count * conv_data.pads_begin_width;
+    size_t flat_right_padding = conv_data.input_channel_count * conv_data.pads_end_width;
+    size_t padded_row_size = flat_left_padding + conv_data.input_channel_count * conv_data.input_width + flat_right_padding;
+    size_t flat_top_padding = padded_row_size * conv_data.pads_begin_height;
+    size_t flat_bottom_padding = padded_row_size * conv_data.pads_end_height;
+    size_t biggest_padding = std::max(std::max(flat_left_padding, flat_right_padding), std::max(flat_top_padding, flat_bottom_padding));
+
+    if (conv_data.input_height > 1 && (flat_top_padding > 1 || flat_bottom_padding > 1)) {
+        biggest_padding = biggest_padding > padded_row_size ? biggest_padding : padded_row_size;
+    }
+
+    if (!biggest_padding)
+        return nullptr;
+
+    auto flat_input = std::make_shared<ngraph::opset7::Reshape>(input_node,
+        ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{2},
+            ngraph::Shape{1ull, shape_size(input_node.get_shape())}), false);
+
+    // Constant with zero padding
+    auto const_holding_padding = std::make_shared<ngraph::opset7::Constant>(ngraph::element::i64, ngraph::Shape{1, biggest_padding}, 0);
+
+    std::shared_ptr<ngraph::Node> original_row = flat_input;
+    ngraph::OutputVector input_rows_to_concat;
+
+    // Add top padding
+    for (size_t p = 0; p < conv_data.pads_begin_height; p++) {
+        InsertPadding(input_rows_to_concat, padded_row_size, const_holding_padding, biggest_padding);
+    }
+
+    if (flat_left_padding || flat_right_padding) {
+        // Pad every row of input plain if neccessary
+        for (size_t h = 0; h < conv_data.input_height; h++) {
+            // left padding     input     right padding
+            //     |              |           |
+            //     +--------------+-----------+
+            //                    |
+            //                 concat
+
+            if (conv_data.input_height > 1)
+                original_row = FlatCrop(flat_input, h * conv_data.input_width * conv_data.input_channel_count,
+                    conv_data.input_width * conv_data.input_channel_count);
+
+            ngraph::OutputVector single_row_concat_inputs;
+            if (flat_left_padding) {
+                InsertPadding(single_row_concat_inputs, flat_left_padding, const_holding_padding, biggest_padding);
+            }
+            single_row_concat_inputs.push_back(original_row);
+            if (flat_right_padding) {
+                InsertPadding(single_row_concat_inputs, flat_right_padding, const_holding_padding, biggest_padding);
+            }
+            auto padded_row_concat = std::make_shared<ngraph::opset7::Concat>(single_row_concat_inputs, 1);
+
+            input_rows_to_concat.push_back(padded_row_concat);
+        }
+    } else {
+        input_rows_to_concat.push_back(original_row);
+    }
+
+    // Bottom padding
+    for (size_t p = 0; p < conv_data.pads_end_height; p++) {
+        InsertPadding(input_rows_to_concat, padded_row_size, const_holding_padding, biggest_padding);
+    }
+
+    auto padded_input_plane = std::make_shared<ngraph::opset7::Concat>(input_rows_to_concat, 1);
+    return padded_input_plane;
+}
+
+std::shared_ptr<ngraph::Function> ConvertPaddedToValidConvTestFixture::get_reference(const bool& fq,
+    const modelType& model,
+    const ngraph::PartialShape& input_shape,
+    const ngraph::Shape& filters_shape,
+    const ngraph::Strides& conv_stride,
+    const ngraph::CoordinateDiff& pads_begin,
+    const ngraph::CoordinateDiff& pads_end,
+    const ngraph::Strides& conv_dilation,
+    const ngraph::Shape& bias_shape,
+    const ngraph::Strides& maxpool_stride,
+    const ngraph::Shape& maxpool_shape,
+    const ngraph::op::PadType& pad_type,
+    const ConvData& conv_data) {
+    auto input_params = std::make_shared<ngraph::opset7::Parameter>(ngraph::element::i64, input_shape);
+
+    // Add padding where neccessary
+
+    // padding
+    // padding
+    // ... row ...
+    // ... row ...
+    // ...........
+    // ... row ...
+    // padding
+    // padding
+    auto padded_input_plane = CreatePaddedNet(input_params, conv_data);
+    std::shared_ptr<ngraph::opset7::Result> result;
+
+    if (padded_input_plane) {
+        auto shape_const = std::make_shared<ngraph::opset7::Constant>(ngraph::element::i64, ngraph::Shape{4},
+            ngraph::Shape{static_cast<size_t>(1),
+            conv_data.pads_begin_height + conv_data.input_height + conv_data.pads_end_height,
+            conv_data.pads_begin_width + conv_data.input_width + conv_data.pads_end_width,
+            conv_data.input_channel_count});
+        auto padded_input_plane_reshaped = std::make_shared<ngraph::opset7::Reshape>(padded_input_plane, shape_const, false);
+        result = createFunction(fq, model, padded_input_plane_reshaped, filters_shape, conv_stride,
+            ngraph::CoordinateDiff{0, 0}, ngraph::CoordinateDiff{0, 0}, conv_dilation, bias_shape,
+            maxpool_stride, maxpool_shape, ngraph::op::PadType::EXPLICIT, nullptr);
+    } else {
+        // Valid padding
+        result = createFunction(fq, model, input_params, filters_shape, conv_stride, pads_begin, pads_end, conv_dilation, bias_shape,
+            maxpool_stride, maxpool_shape, pad_type, nullptr);
+    }
+
+    return std::make_shared<ngraph::Function>(ngraph::ResultVector{result}, ngraph::ParameterVector{input_params});
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+void execute_test(std::shared_ptr<ngraph::Function> function, std::shared_ptr<ngraph::Function> reference_function) {
+    ngraph::pass::Manager manager;
+    manager.register_pass<ngraph::pass::InitNodeInfo>();
+    manager.register_pass<GNAPluginNS::ConvertPaddedToValidConv>();
+    manager.run_passes(function);
+    const FunctionsComparator func_comparator = FunctionsComparator::with_default().enable(FunctionsComparator::ATTRIBUTES);
+    const FunctionsComparator::Result result = func_comparator(function, reference_function);
+    ASSERT_TRUE(result.valid);
+}
+
+TEST_P(ConvertPaddedToValidConvTestFixture, CompareFunctions) {
+    execute_test(function, reference_function);
+}
+
+INSTANTIATE_TEST_SUITE_P(ConvertPaddedToValidConvTestSuite, ConvertPaddedToValidConvTestFixture,
+    ::testing::Combine(
+        // With / without Fake Quantize layers
+        ::testing::Values(true, false),
+        ::testing::Values(
+            std::make_tuple(modelType::TranspConvTransp, ngraph::PartialShape{1, 1, 16, 8}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::CoordinateDiff{0, 2}, ngraph::CoordinateDiff{0, 3}, ngraph::Strides{1, 1},
+                ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 2}, ngraph::op::PadType::EXPLICIT),
+            std::make_tuple(modelType::TranspConvBcastAddTransp, ngraph::PartialShape{1, 1, 16, 8}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::CoordinateDiff{0, 2}, ngraph::CoordinateDiff{0, 3}, ngraph::Strides{1, 1},
+                ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 2}, ngraph::op::PadType::EXPLICIT),
+            std::make_tuple(modelType::TranspConvBcastAddMaxPoolTransp, ngraph::PartialShape{1, 1, 16, 8}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::CoordinateDiff{0, 2}, ngraph::CoordinateDiff{0, 3}, ngraph::Strides{1, 1},
+                ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 2}, ngraph::op::PadType::EXPLICIT),
+            std::make_tuple(modelType::TranspConvBcastAddActTransp, ngraph::PartialShape{1, 1, 16, 8}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::CoordinateDiff{0, 2}, ngraph::CoordinateDiff{0, 3}, ngraph::Strides{1, 1},
+                ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 2}, ngraph::op::PadType::SAME_LOWER),
+            std::make_tuple(modelType::TranspConvBcastAddMaxPoolActTransp, ngraph::PartialShape{1, 1, 16, 8}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::CoordinateDiff{0, 2}, ngraph::CoordinateDiff{0, 3}, ngraph::Strides{1, 1},
+                ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 2}, ngraph::op::PadType::SAME_UPPER),
+            std::make_tuple(modelType::TranspConvTranspBcastAdd, ngraph::PartialShape{1, 1, 16, 8}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::CoordinateDiff{0, 2}, ngraph::CoordinateDiff{0, 3}, ngraph::Strides{1, 1},
+                ngraph::Shape{1, 1, 1, 4}, ngraph::Strides{1, 1}, ngraph::Shape{1, 2}, ngraph::op::PadType::EXPLICIT),
+            std::make_tuple(modelType::TranspConvTranspBcastAddAct, ngraph::PartialShape{1, 1, 16, 8}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::CoordinateDiff{0, 2}, ngraph::CoordinateDiff{0, 3}, ngraph::Strides{1, 1},
+                ngraph::Shape{1, 1, 1, 4}, ngraph::Strides{1, 1}, ngraph::Shape{1, 2}, ngraph::op::PadType::EXPLICIT))));
+
+TEST_P(ConvertPaddedToValidConvTestInvalidFixture, CompareFunctions) {
+    execute_test(function, reference_function);
+}
+
+INSTANTIATE_TEST_SUITE_P(ConvertPaddedToValidConvInvalidTestSuite, ConvertPaddedToValidConvTestInvalidFixture,
+    ::testing::Combine(
+        // With / without Fake Quantize layers
+        ::testing::Values(true, false),
+        ::testing::Values(
+            std::make_tuple(modelType::TranspConvTransp, ngraph::PartialShape{2, 1, 16, 8}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::CoordinateDiff{0, 2}, ngraph::CoordinateDiff{0, 3}, ngraph::Strides{1, 1},
+                ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 2}, ngraph::op::PadType::SAME_UPPER),
+            std::make_tuple(modelType::TranspConvBcastAddTransp, ngraph::PartialShape{2, 1, 16, 8}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::CoordinateDiff{0, 2}, ngraph::CoordinateDiff{0, 3}, ngraph::Strides{1, 1},
+                ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 2}, ngraph::op::PadType::EXPLICIT),
+            std::make_tuple(modelType::TranspConvBcastAddMaxPoolTransp, ngraph::PartialShape{2, 16, 16, 8}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::CoordinateDiff{0, 2}, ngraph::CoordinateDiff{0, 3}, ngraph::Strides{1, 1},
+                ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{5, 1}, ngraph::op::PadType::EXPLICIT),
+            std::make_tuple(modelType::TranspConvBcastAddActTransp, ngraph::PartialShape{2, 1, 16, 8}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::CoordinateDiff{0, 2}, ngraph::CoordinateDiff{0, 3}, ngraph::Strides{1, 1},
+                ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 2}, ngraph::op::PadType::SAME_LOWER),
+            std::make_tuple(modelType::TranspConvBcastAddMaxPoolActTransp, ngraph::PartialShape{2, 1, 16, 8}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::CoordinateDiff{0, 5}, ngraph::CoordinateDiff{0, 3}, ngraph::Strides{1, 1},
+                ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 4}, ngraph::op::PadType::SAME_UPPER),
+            std::make_tuple(modelType::TranspConvTranspBcastAdd, ngraph::PartialShape{2, 1, 16, 8}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::CoordinateDiff{0, 2}, ngraph::CoordinateDiff{0, 3}, ngraph::Strides{1, 1},
+                ngraph::Shape{1, 1, 1, 4}, ngraph::Strides{1, 1}, ngraph::Shape{1, 2}, ngraph::op::PadType::EXPLICIT),
+            std::make_tuple(modelType::TranspConvTranspBcastAddAct, ngraph::PartialShape{2, 1, 16, 8}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::CoordinateDiff{0, 2}, ngraph::CoordinateDiff{0, 3}, ngraph::Strides{1, 1},
+                ngraph::Shape{1, 1, 1, 4}, ngraph::Strides{1, 1}, ngraph::Shape{1, 2}, ngraph::op::PadType::EXPLICIT))));
+
+} // namespace
+
+} // namespace testing

--- a/inference-engine/tests/unit/gna/ngraph/transformations/gna_convert_padded_to_valid_convolution.cpp
+++ b/inference-engine/tests/unit/gna/ngraph/transformations/gna_convert_padded_to_valid_convolution.cpp
@@ -20,6 +20,7 @@ namespace {
 enum class modelType {
     TranspConvTransp = 0,               /* Transpose(NHWC->NCHW) => Conv => Transpose(NCHW->NHWC) */
     TranspConvBcastAddTransp,           /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => Transpose(NCHW->NHWC) */
+    TranspConvActTransp,                /* Transpose(NHWC->NCHW) => Conv => Activation Function => Transpose(NCHW->NHWC) */
     TranspConvBcastAddMaxPoolTransp,    /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => MaxPooling => Transpose(NCHW->NHWC) (2D Max Pool case) */
     TranspConvBcastAddActTransp,        /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => Activation Function => Transpose(NCHW->NHWC) */
     TranspConvBcastAddMaxPoolActTransp, /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => MaxPool => Activation Function => Transpose(NCHW->NHWC) */
@@ -66,7 +67,7 @@ void GetConvParams(std::shared_ptr<ngraph::opset7::Convolution> conv, ConvData& 
     conv_data.pads_end_width = conv->get_pads_end()[1];
 }
 
-std::shared_ptr<ngraph::opset7::FakeQuantize> createFQ(ngraph::Output<ngraph::Node>& in_node) {
+std::shared_ptr<ngraph::opset7::FakeQuantize> createFQ(std::shared_ptr<ngraph::Node>& in_node) {
     auto input_low = ngraph::opset7::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {1});
     auto input_high = ngraph::opset7::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {5});
     auto output_low = ngraph::opset7::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {0});
@@ -76,7 +77,7 @@ std::shared_ptr<ngraph::opset7::FakeQuantize> createFQ(ngraph::Output<ngraph::No
 
 ngraph::Output<ngraph::Node> createBiasFQ(const ngraph::Output<ngraph::Node>& in_node,
     std::shared_ptr<ngraph::opset7::Constant>& bias_const, const bool& fq) {
-    ngraph::Output<ngraph::Node> bcast_add = std::make_shared<ngraph::opset7::Add>(in_node, bias_const);
+    std::shared_ptr<ngraph::Node> bcast_add = std::make_shared<ngraph::opset7::Add>(in_node, bias_const);
 
     if (fq) {
         bcast_add = createFQ(bcast_add);
@@ -100,7 +101,7 @@ std::shared_ptr<ngraph::opset7::Result> createFunction(const bool& fq,
     ConvData* conv_data) {
     auto transpose_in_order = std::make_shared<ngraph::opset7::Constant>(ngraph::element::i64, ngraph::Shape{4}, std::vector<int64_t>{0, 3, 1, 2});
     auto transpose_in = std::make_shared<ngraph::opset7::Transpose>(input_node, transpose_in_order);
-    ngraph::Output<ngraph::Node> filters = std::make_shared<ngraph::opset7::Constant>(ngraph::element::i64,
+    std::shared_ptr<ngraph::Node> filters = std::make_shared<ngraph::opset7::Constant>(ngraph::element::i64,
         ngraph::Shape{4, input_node.get_shape()[3], filters_shape[0], filters_shape[1]});
 
     if (fq) {
@@ -120,6 +121,19 @@ std::shared_ptr<ngraph::opset7::Result> createFunction(const bool& fq,
     {
         auto bcast_add = createBiasFQ(conv, bias_const, fq);
         last_op = std::make_shared<ngraph::opset7::Transpose>(bcast_add, transpose_out_order);
+    }
+    break;
+
+    case modelType::TranspConvActTransp:
+    {
+        auto bcast_add = createBiasFQ(conv, bias_const, fq);
+        std::shared_ptr<ngraph::Node> activation = std::make_shared<ngraph::opset7::Relu>(bcast_add);
+
+        if (fq) {
+            activation = createFQ(activation);
+        }
+
+        last_op = std::make_shared<ngraph::opset7::Transpose>(activation, transpose_out_order);
     }
     break;
 
@@ -428,6 +442,9 @@ INSTANTIATE_TEST_CASE_P(ConvertPaddedToValidConvTestSuite, ConvertPaddedToValidC
             std::make_tuple(modelType::TranspConvBcastAddTransp, ngraph::PartialShape{1, 1, 16, 8}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
                 ngraph::CoordinateDiff{0, 2}, ngraph::CoordinateDiff{0, 3}, ngraph::Strides{1, 1},
                 ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 2}, ngraph::op::PadType::EXPLICIT),
+            std::make_tuple(modelType::TranspConvActTransp, ngraph::PartialShape{1, 1, 16, 8}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::CoordinateDiff{0, 2}, ngraph::CoordinateDiff{0, 3}, ngraph::Strides{1, 1},
+                ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 2}, ngraph::op::PadType::EXPLICIT),
             std::make_tuple(modelType::TranspConvBcastAddMaxPoolTransp, ngraph::PartialShape{1, 1, 16, 8}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
                 ngraph::CoordinateDiff{0, 2}, ngraph::CoordinateDiff{0, 3}, ngraph::Strides{1, 1},
                 ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 2}, ngraph::op::PadType::EXPLICIT),
@@ -457,6 +474,9 @@ INSTANTIATE_TEST_CASE_P(ConvertPaddedToValidConvInvalidTestSuite, ConvertPaddedT
                 ngraph::CoordinateDiff{0, 2}, ngraph::CoordinateDiff{0, 3}, ngraph::Strides{1, 1},
                 ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 2}, ngraph::op::PadType::SAME_UPPER),
             std::make_tuple(modelType::TranspConvBcastAddTransp, ngraph::PartialShape{2, 1, 16, 8}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::CoordinateDiff{0, 2}, ngraph::CoordinateDiff{0, 3}, ngraph::Strides{1, 1},
+                ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 2}, ngraph::op::PadType::EXPLICIT),
+            std::make_tuple(modelType::TranspConvActTransp, ngraph::PartialShape{2, 1, 16, 8}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
                 ngraph::CoordinateDiff{0, 2}, ngraph::CoordinateDiff{0, 3}, ngraph::Strides{1, 1},
                 ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 2}, ngraph::op::PadType::EXPLICIT),
             std::make_tuple(modelType::TranspConvBcastAddMaxPoolTransp, ngraph::PartialShape{2, 16, 16, 8}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},

--- a/inference-engine/tests/unit/gna/ngraph/transformations/gna_convert_padded_to_valid_convolution.cpp
+++ b/inference-engine/tests/unit/gna/ngraph/transformations/gna_convert_padded_to_valid_convolution.cpp
@@ -417,7 +417,7 @@ TEST_P(ConvertPaddedToValidConvTestFixture, CompareFunctions) {
     execute_test(function, reference_function);
 }
 
-INSTANTIATE_TEST_SUITE_P(ConvertPaddedToValidConvTestSuite, ConvertPaddedToValidConvTestFixture,
+INSTANTIATE_TEST_CASE_P(ConvertPaddedToValidConvTestSuite, ConvertPaddedToValidConvTestFixture,
     ::testing::Combine(
         // With / without Fake Quantize layers
         ::testing::Values(true, false),
@@ -448,7 +448,7 @@ TEST_P(ConvertPaddedToValidConvTestInvalidFixture, CompareFunctions) {
     execute_test(function, reference_function);
 }
 
-INSTANTIATE_TEST_SUITE_P(ConvertPaddedToValidConvInvalidTestSuite, ConvertPaddedToValidConvTestInvalidFixture,
+INSTANTIATE_TEST_CASE_P(ConvertPaddedToValidConvInvalidTestSuite, ConvertPaddedToValidConvTestInvalidFixture,
     ::testing::Combine(
         // With / without Fake Quantize layers
         ::testing::Values(true, false),

--- a/inference-engine/tests/unit/gna/ngraph/transformations/gna_decompose_2d_convolution.cpp
+++ b/inference-engine/tests/unit/gna/ngraph/transformations/gna_decompose_2d_convolution.cpp
@@ -1,0 +1,772 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <tuple>
+
+#include "transformations/decompose_2d_convolution.hpp"
+#include "common_test_utils/ngraph_test_utils.hpp"
+#include <ngraph/function.hpp>
+#include <ngraph/opsets/opset7.hpp>
+#include <ngraph/pass/manager.hpp>
+#include <transformations/init_node_info.hpp>
+#include <transformations/utils/utils.hpp>
+#include "backend/gna_limitations.hpp"
+
+namespace testing {
+
+namespace {
+
+enum class modelType {
+    TranspConvTransp = 0,               /* Transpose(NHWC->NCHW) => Conv => Transpose(NCHW->NHWC) */
+    TranspConvBcastAddTransp,           /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => Transpose(NCHW->NHWC) */
+    TranspConvBcastAddMaxPoolTransp,    /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => MaxPooling => Transpose(NCHW->NHWC) (2D Max Pool case) */
+    TranspConvBcastAddActTransp,        /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => Activation Function => Transpose(NCHW->NHWC) */
+    TranspConvBcastAddMaxPoolActTransp, /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => MaxPool => Activation Function => Transpose(NCHW->NHWC) */
+    TranspConvTranspBcastAdd,           /* Transpose(NHWC->NCHW) => conv => Transpose(NCHW->NHWC) => Bias */
+    TranspConvTranspBcastAddAct         /* Transpose(NHWC->NCHW) => Conv => Transpose(NCHW->NHWC) => Bias => Activation Function */
+};
+
+typedef std::tuple<
+    modelType,              // Test model
+    ngraph::PartialShape,   // Input shape
+    ngraph::Shape,          // Convolution filter shape
+    ngraph::Strides,        // Convolution stride
+    ngraph::Strides,        // Convolution dilation
+    ngraph::Shape,          // Bias shape
+    ngraph::Strides,        // Max Pool stride
+    ngraph::Shape           // Max Pool shape
+> decompose2DConvParams;
+
+typedef std::tuple<
+    bool,                   // With / without Fake Quantize layers
+    decompose2DConvParams   // Test parameters
+> fqDecompose2DConvParams;
+
+struct GraphData {
+    std::shared_ptr<ngraph::Node> input_node;
+    std::shared_ptr<ngraph::opset7::FakeQuantize>fq_conv;
+    std::shared_ptr<ngraph::opset7::Convolution> conv;
+    std::shared_ptr<ngraph::opset7::Add> bias;
+    std::shared_ptr<ngraph::opset7::FakeQuantize>fq_bias;
+    std::shared_ptr<ngraph::opset7::MaxPool> max_pool;
+    std::shared_ptr<ngraph::op::util::UnaryElementwiseArithmetic> af;
+    std::shared_ptr<ngraph::opset7::FakeQuantize>fq_af;
+    std::shared_ptr<ngraph::Node> bias_const;
+    std::shared_ptr<ngraph::Node> last_op_in_sequence_for_replacement;
+    size_t conv_count;
+    size_t pool_size_width;
+    size_t pool_stride_width;
+};
+
+struct ConvParams {
+    size_t input_height;
+    size_t input_width;
+    size_t input_channel_count;
+    size_t output_channel_count;
+    size_t filter_height;
+    size_t filter_width;
+    size_t filter_count;
+    size_t filter_channel_count;
+    size_t filter_dilation_height;
+    size_t filter_dilation_width;
+    size_t filter_stride_height;
+    size_t filter_stride_width;
+    size_t output_height;
+    size_t output_width;
+};
+
+void GetConvParams(std::shared_ptr<ngraph::opset7::Convolution> conv, ConvParams& conv_params) {
+    conv_params.output_height = conv->get_output_shape(0)[2];
+    conv_params.output_width = conv->get_output_shape(0)[3];
+    conv_params.input_channel_count = conv->input_value(0).get_shape()[1];
+    conv_params.input_height = conv->input_value(0).get_shape()[2];
+    conv_params.input_width = conv->input_value(0).get_shape()[3];
+    conv_params.filter_count = conv->input_value(1).get_shape()[0];
+    conv_params.filter_channel_count = conv->input_value(1).get_shape()[1];
+    conv_params.filter_height = conv->input_value(1).get_shape()[2];
+    conv_params.filter_width = conv->input_value(1).get_shape()[3];
+    conv_params.filter_dilation_height = conv->get_dilations()[0];
+    conv_params.filter_dilation_width = conv->get_dilations()[1];
+    conv_params.filter_stride_height = conv->get_strides()[0];
+    conv_params.filter_stride_width = conv->get_strides()[1];
+    conv_params.output_channel_count = conv_params.filter_count;
+}
+
+std::shared_ptr<ngraph::opset7::FakeQuantize> createFQ(std::shared_ptr<ngraph::Node>& in_node) {
+    auto input_low = ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{1}, {1});
+    auto input_high = ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{1}, {5});
+    auto output_low = ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{1}, {0});
+    auto output_high = ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{1}, {10});
+    return std::make_shared<ngraph::opset7::FakeQuantize>(in_node, input_low, input_high, output_low, output_high, 11);
+}
+
+std::shared_ptr<ngraph::Node> createBiasFQ(const ngraph::Output<ngraph::Node>& in_node,
+    std::shared_ptr<ngraph::opset7::Constant>& bias_const, std::shared_ptr<ngraph::opset7::Add>& bias, const bool& fq) {
+    std::shared_ptr<ngraph::Node> node;
+    bias = std::make_shared<ngraph::opset7::Add>(in_node, bias_const);
+    node = bias;
+
+    if (fq) {
+        node = createFQ(node);
+    }
+
+    return node;
+}
+
+std::shared_ptr<ngraph::opset7::Result> createFunction(const bool& fq,
+    const modelType& model,
+    const ngraph::Output<ngraph::Node>& input_node,
+    const ngraph::Shape& filters_shape,
+    const ngraph::Strides& conv_stride,
+    const ngraph::Strides& conv_dilation,
+    const ngraph::Shape& bias_shape,
+    const ngraph::Strides& maxpool_stride,
+    const ngraph::Shape& maxpool_shape,
+    GraphData* graph_data,
+    ConvParams* conv_params) {
+    auto transpose_in_order = std::make_shared<ngraph::opset7::Constant>(ngraph::element::i64, ngraph::Shape{4}, std::vector<int64_t>{0, 3, 1, 2});
+    auto transpose_in = std::make_shared<ngraph::opset7::Transpose>(input_node, transpose_in_order);
+    std::shared_ptr<ngraph::Node> fq_filters = std::make_shared<ngraph::opset7::Constant>(ngraph::element::i64,
+        ngraph::Shape{4, input_node.get_shape()[3], filters_shape[0], filters_shape[1]});
+
+    if (fq) {
+        fq_filters = createFQ(fq_filters);
+    }
+
+    auto conv = std::make_shared<ngraph::opset7::Convolution>(transpose_in, fq_filters, conv_stride,
+        ngraph::CoordinateDiff{0, 0}, ngraph::CoordinateDiff{0, 0}, conv_dilation, ngraph::op::PadType::VALID);
+    if (conv_params)
+        GetConvParams(conv, *conv_params);
+
+    auto transpose_out_order = std::make_shared<ngraph::opset7::Constant>(ngraph::element::i64, ngraph::Shape{4}, std::vector<int64_t>{0, 2, 3, 1});
+    auto bias_const = std::make_shared<ngraph::opset7::Constant>(ngraph::element::i64, bias_shape);
+    std::shared_ptr<ngraph::opset7::Add> bias = nullptr;
+    std::shared_ptr<ngraph::Node> fq_bias = nullptr, fq_af = nullptr;
+    std::shared_ptr<ngraph::opset7::MaxPool> max_pool = nullptr;
+    std::shared_ptr<ngraph::Node> activation = nullptr;
+    std::shared_ptr<ngraph::Node> last_op = std::make_shared<ngraph::opset7::Transpose>(conv, transpose_out_order);
+
+    switch (model) {
+    case modelType::TranspConvBcastAddTransp:
+    {
+        fq_bias = createBiasFQ(conv, bias_const, bias, fq);
+        last_op = std::make_shared<ngraph::opset7::Transpose>(fq_bias, transpose_out_order);
+    }
+    break;
+
+    case modelType::TranspConvBcastAddMaxPoolTransp:
+    {
+        fq_bias = createBiasFQ(conv, bias_const, bias, fq);
+        max_pool = std::make_shared<ngraph::opset7::MaxPool>(fq_bias, maxpool_stride, ngraph::Shape{0, 0}, ngraph::Shape{0, 0}, maxpool_shape,
+            ngraph::op::RoundingType::FLOOR, ngraph::op::PadType::VALID);
+        auto transpose = std::make_shared<ngraph::opset7::Transpose>(max_pool, transpose_out_order);
+        last_op = std::make_shared<ngraph::opset7::Relu>(transpose);
+    }
+    break;
+
+    case modelType::TranspConvBcastAddActTransp:
+    {
+        fq_bias = createBiasFQ(conv, bias_const, bias, fq);
+        activation = std::make_shared<ngraph::opset7::Relu>(fq_bias);
+        last_op = std::make_shared<ngraph::opset7::Transpose>(activation, transpose_out_order);
+    }
+    break;
+
+    case modelType::TranspConvBcastAddMaxPoolActTransp:
+    {
+        fq_bias = createBiasFQ(conv, bias_const, bias, fq);
+        max_pool = std::make_shared<ngraph::opset7::MaxPool>(fq_bias, maxpool_stride, ngraph::Shape{0, 0}, ngraph::Shape{0, 0}, maxpool_shape,
+            ngraph::op::RoundingType::FLOOR, ngraph::op::PadType::VALID);
+        activation = std::make_shared<ngraph::opset7::Relu>(max_pool);
+        if (fq) {
+            fq_af = createFQ(activation);
+        }
+        last_op = std::make_shared<ngraph::opset7::Transpose>(fq_af ? fq_af : activation, transpose_out_order);
+    }
+    break;
+
+    case modelType::TranspConvTranspBcastAdd:
+    {
+        last_op = createBiasFQ(last_op, bias_const, bias, fq);
+    }
+    break;
+
+    case modelType::TranspConvTranspBcastAddAct:
+    {
+        fq_bias = createBiasFQ(last_op, bias_const, bias, fq);
+        last_op = std::make_shared<ngraph::opset7::Relu>(fq_bias);
+    }
+    break;
+
+    case modelType::TranspConvTransp:
+    default:
+        break;
+    }
+
+    if (graph_data) {
+        graph_data->fq_conv = fq ? std::dynamic_pointer_cast<ngraph::opset7::FakeQuantize>(fq_filters) : nullptr;
+        graph_data->conv = conv;
+        graph_data->bias = bias;
+        graph_data->fq_bias = fq ? std::dynamic_pointer_cast<ngraph::opset7::FakeQuantize>(fq_bias) : nullptr;
+        graph_data->af = std::dynamic_pointer_cast<ngraph::op::util::UnaryElementwiseArithmetic>(activation);
+        graph_data->fq_af = fq ? std::dynamic_pointer_cast<ngraph::opset7::FakeQuantize>(fq_af) : nullptr;
+        graph_data->max_pool = max_pool;
+        graph_data->last_op_in_sequence_for_replacement = last_op;
+        graph_data->bias_const = nullptr;
+        graph_data->conv_count = 0;
+
+        if (max_pool) {
+            graph_data->pool_size_width = max_pool->get_kernel()[1];
+            graph_data->pool_stride_width = max_pool->get_strides()[1];
+        }
+    }
+
+    return std::make_shared<ngraph::opset7::Result>(last_op);
+}
+
+std::shared_ptr<ngraph::Function> get_initial_function(const bool& fq,
+    const modelType& model,
+    const ngraph::PartialShape& input_shape,
+    const ngraph::Shape& filters_shape,
+    const ngraph::Strides& conv_stride,
+    const ngraph::Strides& conv_dilation,
+    const ngraph::Shape& bias_shape,
+    const ngraph::Strides& maxpool_stride,
+    const ngraph::Shape& maxpool_shape,
+    GraphData& graph_data,
+    ConvParams& conv_params) {
+    auto input_params = std::make_shared<ngraph::opset7::Parameter>(ngraph::element::i64, input_shape);
+    auto result = createFunction(fq, model, input_params, filters_shape, conv_stride, conv_dilation, bias_shape,
+        maxpool_stride, maxpool_shape, &graph_data , &conv_params);
+    return std::make_shared<ngraph::Function>(ngraph::ResultVector{result}, ngraph::ParameterVector{input_params});
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+class Decompose2DConvTestInvalidFixture : public CommonTestUtils::TestsCommon,
+    public ::testing::WithParamInterface<fqDecompose2DConvParams> {
+public:
+    void SetUp() override;
+public:
+    std::shared_ptr<ngraph::Function> function, reference_function;
+    modelType model;
+};
+
+void Decompose2DConvTestInvalidFixture::SetUp() {
+    bool fq;
+    decompose2DConvParams params;
+    ngraph::PartialShape input_shape;
+    ngraph::Shape filters_shape, bias_shape, maxpool_shape;
+    ngraph::Strides conv_stride, conv_dilation, maxpool_stride;
+    GraphData graph_data{};
+    ConvParams conv_params{};
+    std::tie(fq, params) = this->GetParam();
+    std::tie(model, input_shape, filters_shape, conv_stride, conv_dilation,
+        bias_shape, maxpool_stride, maxpool_shape) = params;
+
+    function = get_initial_function(fq, model, input_shape, filters_shape, conv_stride, conv_dilation,
+        bias_shape, maxpool_stride, maxpool_shape, graph_data, conv_params);
+    reference_function = get_initial_function(fq, model, input_shape, filters_shape, conv_stride, conv_dilation,
+        bias_shape, maxpool_stride, maxpool_shape, graph_data, conv_params);
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+class Decompose2DConvTestFixture: public CommonTestUtils::TestsCommon,
+    public ::testing::WithParamInterface<fqDecompose2DConvParams> {
+public:
+    void SetUp() override;
+    std::shared_ptr<ngraph::Function> get_reference(const bool& fq,
+        const modelType& model,
+        const ngraph::PartialShape& input_shape,
+        GraphData& graph_data,
+        ConvParams& conv_params);
+public:
+    std::shared_ptr<ngraph::Function> function, reference_function;
+    modelType model;
+};
+
+void Decompose2DConvTestFixture::SetUp() {
+    bool fq;
+    decompose2DConvParams params;
+    ngraph::PartialShape input_shape;
+    ngraph::Shape filters_shape, bias_shape, maxpool_shape;
+    ngraph::Strides conv_stride, conv_dilation, maxpool_stride;
+    GraphData graph_data{};
+    ConvParams conv_params{};
+    std::tie(fq, params) = this->GetParam();
+    std::tie(model, input_shape, filters_shape, conv_stride, conv_dilation,
+        bias_shape, maxpool_stride, maxpool_shape) = params;
+
+    function = get_initial_function(fq, model, input_shape, filters_shape, conv_stride, conv_dilation,
+        bias_shape, maxpool_stride, maxpool_shape, graph_data, conv_params);
+    reference_function = get_reference(fq, model, input_shape, graph_data, conv_params);
+}
+
+std::shared_ptr<ngraph::Node> ReshapeBiasConst(std::shared_ptr<ngraph::opset7::Add> conv_bias, const ConvParams& conv_params) {
+    auto add_const = std::dynamic_pointer_cast<ngraph::opset7::Constant>(conv_bias->input_value(1).get_node_shared_ptr());
+
+    IE_ASSERT(add_const);
+
+    auto bias_size = shape_size(add_const->get_shape());
+    return ngraph::op::util::make_try_fold<ngraph::opset7::Reshape>(add_const,
+        ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{4}, ngraph::Shape{1, bias_size, 1, 1}), false);
+}
+
+std::shared_ptr<ngraph::opset7::StridedSlice> FlatCrop(ngraph::Output<ngraph::Node> input, size_t offset, size_t size) {
+    auto shape = input.get_shape();
+    return std::make_shared<ngraph::opset7::StridedSlice>(
+        input,                                                                                                  // data
+        ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {(size_t)0, offset}),          // begin slice index
+        ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {(size_t)0, offset + size}),   // end slice index
+        ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {(size_t)1, (size_t)1}),       // strides
+        std::vector<int64_t>{1, 0},                                                                             // begin mask
+        std::vector<int64_t>{1, 0});                                                                            // end mask
+}
+
+static std::vector<std::shared_ptr<ngraph::Node>> Split2DConvFilters(std::shared_ptr<ngraph::opset7::Constant>& filters,
+    const bool& vertical_permute, const bool& horizontal_permute, const size_t& split_channels) {
+
+    if (!horizontal_permute && !vertical_permute && split_channels == 1)
+        return {filters};
+
+    std::vector <std::shared_ptr<ngraph::Node>> result;
+    ngraph::Shape reshape_shape;
+    auto flat_filters = filters->outputs();
+    const auto filter_shape = filters->get_output_shape(0);
+    IE_ASSERT(filter_shape.size() == 4);
+
+    if (split_channels > 1) {
+        const auto axis_node = ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{}, {1});
+        const auto split = std::make_shared<ngraph::opset7::Split>(filters, axis_node, split_channels);
+        flat_filters = split->outputs();
+    }
+
+    if (horizontal_permute) {
+        for (size_t split_index = 0; split_index < split_channels; split_index++) {
+            ngraph::Output<ngraph::Node>& flat_filter = flat_filters[split_index];
+            result.push_back(std::make_shared<ngraph::opset7::Transpose>(flat_filter,
+                ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{4}, ngraph::Shape{0, 1, 3, 2})));
+        }
+    }
+
+    if (vertical_permute && horizontal_permute) {
+        reshape_shape = ngraph::Shape{filter_shape[0], filter_shape[1] * filter_shape[2] * filter_shape[3] / split_channels, 1, 1};
+    } else if (vertical_permute && !horizontal_permute) {
+        reshape_shape = ngraph::Shape{filter_shape[0], filter_shape[1] * filter_shape[2] / split_channels, 1, filter_shape[3]};
+    } else if (!vertical_permute && horizontal_permute) {
+        reshape_shape = ngraph::Shape{filter_shape[0], filter_shape[1] * filter_shape[3] / split_channels, filter_shape[2], 1};
+    } else {
+        reshape_shape = ngraph::Shape{filter_shape[0], filter_shape[1] / split_channels, filter_shape[2], filter_shape[3]};
+    }
+
+    for (auto& new_filter : result)
+        new_filter = ngraph::op::util::make_try_fold<ngraph::opset7::Reshape>(new_filter,
+            ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{4}, reshape_shape), false);
+
+    return result;
+}
+
+ngraph::OutputVector SplitInput(const GraphData& graph_data, ConvParams& conv_params) {
+    // We need to have proper input shape first
+    ngraph::OutputVector split_planes;
+    auto padded_input_plane = std::make_shared<ngraph::opset7::Reshape>(graph_data.input_node,
+        ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{2},
+            ngraph::Shape{1, shape_size(graph_data.input_node->get_shape())}), false);
+
+    if (graph_data.conv_count > 1) {
+        // If we split input plane and filters due to GNA limitations - we must sum their results at the end
+        conv_params.input_channel_count /= graph_data.conv_count;
+
+        auto reshape_before_transpose = std::make_shared<ngraph::opset7::Reshape>(padded_input_plane,
+            ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{2},
+                {shape_size(padded_input_plane->get_shape()) / graph_data.conv_count, graph_data.conv_count}), false);
+
+        auto transpose_before_channel_wise_split = std::make_shared<ngraph::opset7::Transpose>(reshape_before_transpose,
+            ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {1, 0})->output(0));
+
+        const auto axis_node = ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{}, {0});
+        const auto split = std::make_shared<ngraph::opset7::Split>(transpose_before_channel_wise_split, axis_node, graph_data.conv_count);
+        split_planes = split->outputs();
+    } else {
+        split_planes.push_back(padded_input_plane);
+    }
+
+    return split_planes;
+}
+
+std::vector<std::shared_ptr<ngraph::Node>> SplitFilters(const GraphData& graph_data, ConvParams& conv_params) {
+    // If the input plane exceeds GNA limits and we have split into several convolutions, then we need to split filter data as well;
+    // we also need to take filter height and potential dilation into account when modifying the filters
+
+    // Take account of fake quantize when getting filter values
+    auto filter_values = std::dynamic_pointer_cast<ngraph::opset7::Constant>(graph_data.fq_conv == nullptr ?
+        graph_data.conv->input_value(1).get_node_shared_ptr() : graph_data.fq_conv->input_value(0).get_node_shared_ptr());
+    bool vertical_permute = (conv_params.filter_height > 1);
+    bool horizontal_permute = (conv_params.filter_dilation_width > 1);
+    std::vector<std::shared_ptr<ngraph::Node>> h_1_filters{};
+
+    h_1_filters = Split2DConvFilters(filter_values, vertical_permute, horizontal_permute, graph_data.conv_count);
+
+    return h_1_filters;
+}
+
+void TransformInput(const GraphData& graph_data, const ConvParams& conv_params, ngraph::Output<ngraph::Node>& split_input_plane) {
+    /*
+    *              Padded row - NHWC order
+    *                  |
+    *        Split in vertical dim (filter height)
+    *                / | \
+    *                Concat
+    *                  |
+    *              Transpose
+    */
+
+    // First we need to prepare flat (height = 1) slices of input data proper for flattened (height = 1) filters created later on;
+    // the input data is overlapping (duplicated)
+    ngraph::OutputVector dilated_input_planes;
+    for (size_t filter_height = 0; filter_height < conv_params.filter_height; filter_height++) {
+        size_t offset;
+
+        if (conv_params.filter_stride_height > 1) {
+            // Prepare strided slices of input data
+            for (size_t output_height = 0; output_height < conv_params.output_height; output_height++) {
+                offset = (filter_height * conv_params.filter_dilation_height + output_height * conv_params.filter_stride_height) *
+                    conv_params.input_width * conv_params.input_channel_count;
+                auto slice = FlatCrop(split_input_plane, offset, conv_params.input_width * conv_params.input_channel_count);
+                dilated_input_planes.push_back(slice);
+            }
+        } else {
+            offset = filter_height * conv_params.filter_dilation_height * conv_params.input_width * conv_params.input_channel_count;
+            auto slice = FlatCrop(split_input_plane, offset, conv_params.input_width * conv_params.input_channel_count * conv_params.output_height);
+            dilated_input_planes.push_back(slice);
+        }
+    }
+
+    // Interleaving dilated input planes
+    std::shared_ptr<ngraph::Node> dilated_chunks_concat = std::make_shared<ngraph::opset7::Concat>(dilated_input_planes, 0);
+
+    // Additional reshape is required for strided slices of input intended for each filter row
+    if (conv_params.filter_stride_height > 1) {
+        dilated_chunks_concat = std::make_shared<ngraph::opset7::Reshape>(dilated_chunks_concat,
+            ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{2},
+                {conv_params.filter_height, conv_params.input_width * conv_params.input_channel_count * conv_params.output_height}), false);
+    }
+
+    auto transposed_dilated_chunks = std::make_shared<ngraph::opset7::Transpose>(dilated_chunks_concat,
+        ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {1, 0})->output(0));
+
+    // Flattening of interleaved input planes
+    auto flattened_dilated_transposed_input = std::make_shared<ngraph::opset7::Reshape>(transposed_dilated_chunks,
+        ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{2},
+            {(size_t)1, conv_params.input_width * conv_params.input_channel_count * conv_params.output_height * conv_params.filter_height}), false);
+
+    split_input_plane = flattened_dilated_transposed_input;
+}
+
+static void InsertFQLayer(const std::shared_ptr<ngraph::opset7::FakeQuantize> fqLayer,
+    std::shared_ptr<ngraph::Node> lastNode) {
+    if (fqLayer != nullptr) {
+        lastNode = fqLayer->clone_with_new_inputs({lastNode,
+            fqLayer->input_value(1), fqLayer->input_value(2),
+            fqLayer->input_value(3), fqLayer->input_value(4)});
+    }
+}
+
+std::shared_ptr<ngraph::Node> Create1DConv(const GraphData& graph_data, const ConvParams& conv_params, const ngraph::Output<ngraph::Node>& input,
+    std::shared_ptr<ngraph::Node> filters, const size_t conv_index, const size_t h_index) {
+        // Transpose NHWC => NCHW
+        std::shared_ptr<ngraph::Node> nchw_input = std::make_shared<ngraph::opset7::Transpose>(input,
+            ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {0, 3, 1, 2})->output(0));
+
+        // Fake quantize
+        InsertFQLayer(graph_data.fq_conv, filters);
+
+        // 1D Convolution
+        auto conv = std::make_shared<ngraph::opset7::Convolution>(nchw_input, filters,
+            ngraph::Strides{1, conv_params.filter_stride_width}, ngraph::CoordinateDiff{0, 0}, ngraph::CoordinateDiff{0, 0},
+            ngraph::Strides{1, 1}, ngraph::op::PadType::VALID);
+        std::string conv_name = graph_data.conv->get_friendly_name() + "_H_" + std::to_string(h_index) + "_CH_" + std::to_string(0);
+        conv->set_friendly_name(conv_name);
+
+        // Bias
+        std::shared_ptr<ngraph::Node> last_conv_block_op = conv;
+        if (graph_data.bias_const && conv_index == 0) {
+            last_conv_block_op = std::make_shared<ngraph::opset7::Add>(conv, graph_data.bias_const);
+            InsertFQLayer(graph_data.fq_bias, last_conv_block_op);
+        }
+
+        // Max pooling
+        if (graph_data.pool_size_width > 1 || graph_data.pool_stride_width > 1) {
+            last_conv_block_op = std::make_shared<ngraph::opset7::MaxPool>(last_conv_block_op, ngraph::Strides{1, graph_data.pool_stride_width},
+                ngraph::Shape{0, 0}, ngraph::Shape{0, 0}, ngraph::Shape{1, graph_data.pool_size_width}, graph_data.max_pool->get_rounding_type(),
+                ngraph::op::PadType::VALID);
+        }
+        // Activation function
+        if (graph_data.af && graph_data.conv_count == 1) {
+            last_conv_block_op = graph_data.af->copy_with_new_inputs({last_conv_block_op});
+            InsertFQLayer(graph_data.fq_af, last_conv_block_op);
+        }
+
+        // Transpose NCHW => NHWC
+        auto nhwc_output = std::make_shared<ngraph::opset7::Transpose>(last_conv_block_op,
+            ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {0, 2, 3, 1})->output(0));
+        return nhwc_output;
+}
+
+std::shared_ptr<ngraph::Node> CreateDeomposedConv(const GraphData& graph_data, ConvParams& conv_params,
+    ngraph::Output<ngraph::Node>& reduced_input_plane, const std::vector<std::shared_ptr<ngraph::Node>>& h_1_filters, const size_t conv_index) {
+    ngraph::OutputVector result_chunks;
+    std::shared_ptr<ngraph::Node> last_op;
+    bool horizontal_permute = (conv_params.filter_dilation_width > 1);
+    size_t h_1_filter_channel_count = (conv_params.input_channel_count * conv_params.filter_height);
+
+    for (size_t output_height = 0; output_height < conv_params.output_height; output_height++) {
+        size_t offset = output_height * conv_params.input_width * h_1_filter_channel_count;
+        auto row = (conv_params.output_height == 1) ? reduced_input_plane :
+            FlatCrop(reduced_input_plane, offset, conv_params.input_width * h_1_filter_channel_count);
+        /*
+            *              Padded row
+            *                  |
+            *        ??? <Dilation !=1> ???
+            *                  |
+            *         Split in vertical dim
+            *                / | \
+            *                Concat
+            *                  |
+            *               Permute
+            *                  |
+            *              Transpose (NHWC => NCHW)
+            *                  |
+            *                1D Conv (Bias | MaxPooling)
+            *                  |
+            *              Transpose (NCHW => NHWC)
+            */
+        auto nhwc_conv_y_input = row;
+
+        if (horizontal_permute) {
+            // Horizontal split - transform input accordingly
+            ngraph::OutputVector dilated_chunks;
+            std::shared_ptr<ngraph::Node> dilated_chunks_concat = nhwc_conv_y_input.get_node_shared_ptr();
+
+            // We need to calculate some parameters in case horizontal stride > 1 is used, because if we use the ones available from the original convolution
+            // we won't take into account the fact horizontal strides will be supported by the newly created 1D convolution, and not by decomposition
+            size_t filter_dilation_width = conv_params.filter_width > 1 ? conv_params.filter_dilation_width : 1;
+            size_t output_width = (conv_params.input_width - (conv_params.filter_width + filter_dilation_width - 2));
+
+            if (conv_params.filter_width > 1) {
+                for (size_t filter_width = 0; filter_width < conv_params.filter_width; filter_width++) {
+                    size_t offset = filter_width * conv_params.filter_dilation_width * h_1_filter_channel_count;
+                    auto slice = FlatCrop(row, offset, h_1_filter_channel_count * output_width);
+                    dilated_chunks.push_back(slice);
+                }
+
+                dilated_chunks_concat = std::make_shared<ngraph::opset7::Concat>(dilated_chunks, 0);
+            }
+
+            auto transposed_dilated_chunks = std::make_shared<ngraph::opset7::Transpose>(dilated_chunks_concat,
+                ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {1, 0})->output(0));
+
+            auto flattened_dilated_conv_input = std::make_shared<ngraph::opset7::Reshape>(transposed_dilated_chunks,
+                ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{4},
+                    ngraph::Shape{1, 1, output_width, h_1_filter_channel_count * conv_params.filter_width}), false);
+
+            nhwc_conv_y_input = flattened_dilated_conv_input;
+        } else {
+            // If no horizontal split is done, only reshape is required before decomposed convolution
+            nhwc_conv_y_input = std::make_shared<ngraph::opset7::Reshape>(nhwc_conv_y_input,
+                ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{4},
+                    ngraph::Shape{1, 1, conv_params.input_width, h_1_filter_channel_count}), false);
+        }
+
+        // Pointwise convolutions
+        // Valid 1D convolution wrapped with transposes NHWC => NCHW => Conv => NCHW => NHWC
+        // Activation function can be fused with convolution only if it isn't split
+        auto nhwc_y_output = Create1DConv(graph_data, conv_params, nhwc_conv_y_input, h_1_filters[conv_index], conv_index, output_height);
+        result_chunks.push_back(nhwc_y_output);
+        last_op = nhwc_y_output;
+    }
+
+    // Horizontal dimemsion greater than 1
+    if (result_chunks.size() > 1) {
+        // Concat in horizontal dimension
+        // In NHWC index of H is 1
+        auto concatenated_sub_results = std::make_shared<ngraph::opset7::Concat>(result_chunks, 1);
+        last_op = concatenated_sub_results;
+    }
+    return last_op;
+}
+
+static size_t CalculateConvCount(const ConvParams& conv_params) {
+    // Check if split of plane due to GNA HW limitations of 768 filter elements is possible
+    size_t conv_count = 1;
+    size_t total_factorized_conv_channel_count = (conv_params.input_channel_count * conv_params.filter_height * conv_params.filter_width);
+    while (total_factorized_conv_channel_count / conv_count > GNAPluginNS::GNALimitations::convFilterMaxSize ||
+        total_factorized_conv_channel_count % conv_count != 0 || conv_params.filter_channel_count % conv_count != 0)
+        conv_count++;
+
+    return conv_count++;
+}
+
+static bool ShouldDecompose(GraphData& graph_data, const ConvParams& conv_params) {
+    // Calculate the number of splits required
+    graph_data.conv_count = CalculateConvCount(conv_params);
+
+    // Concat (copy) layer limitation allows to split up to a certain limit
+    // Currently we are able to split only convolutions without pooling in horizontal dimension
+    if (graph_data.conv_count > GNAPluginNS::GNALimitations::copyMaxGrouping ||
+        ((graph_data.pool_size_width > 1 || graph_data.pool_stride_width > 1) && graph_data.conv_count > 1))
+        return false;
+
+    // GNA supported features or handled otherwise - there is no need to decompose such convolution
+    if (graph_data.conv_count == 1 && (((conv_params.input_height == 1 || conv_params.input_width == 1) &&
+        conv_params.filter_dilation_width == 1 && conv_params.filter_dilation_height == 1) ||
+        (conv_params.input_height > 1 && conv_params.input_width > 1 &&
+            conv_params.input_width == conv_params.filter_width && conv_params.filter_stride_width == 1)))
+        return false;
+
+    return true;
+}
+
+std::shared_ptr<ngraph::opset7::Result> Decompose(const GraphData& graph_data, ConvParams& conv_params) {
+    std::vector<std::shared_ptr<ngraph::Node>> partial_conv_results;
+
+    // Split input and filters due to GNA filter element count limit
+    auto split_planes = SplitInput(graph_data, conv_params);
+    auto h_1_filters = SplitFilters(graph_data, conv_params);
+
+    // Do transformations in each of the splits created above
+    for (size_t conv_index = 0; conv_index < graph_data.conv_count; conv_index++) {
+        ngraph::Output<ngraph::Node>& split_input_plane = split_planes[conv_index];
+
+        // Input data needs to be prepared before 2D convolution decomposition
+        if (conv_params.filter_height > 1 || conv_params.filter_stride_height > 1) {
+            TransformInput(graph_data, conv_params, split_input_plane);
+        }
+
+        auto flat_conv = CreateDeomposedConv(graph_data, conv_params, split_input_plane, h_1_filters, conv_index);
+        partial_conv_results.push_back(flat_conv);
+    }
+
+    std::shared_ptr<ngraph::Node> conv_result = partial_conv_results.front();
+    for (size_t i = 1; i < partial_conv_results.size(); i++) {
+        auto add_result = std::make_shared<ngraph::opset7::Add>(partial_conv_results[i], conv_result);
+        conv_result = add_result;
+    }
+
+    // Activation function after trailing Transpose NCHW->NHWC
+    if (graph_data.af && graph_data.conv_count > 1) {
+        auto af_result = graph_data.af->copy_with_new_inputs({conv_result});
+        conv_result = af_result;
+    }
+    // We need to put the same name as before for the Convolution layer, so its output can be used as network result
+    std::string conv_result_name = graph_data.last_op_in_sequence_for_replacement->get_friendly_name();
+    ngraph::replace_node(graph_data.last_op_in_sequence_for_replacement, conv_result);
+    conv_result->set_friendly_name(conv_result_name);
+
+    return std::make_shared<ngraph::opset7::Result>(conv_result);
+}
+
+std::shared_ptr<ngraph::Function> Decompose2DConvTestFixture::get_reference(const bool& fq,
+    const modelType& model,
+    const ngraph::PartialShape& input_shape,
+    GraphData& graph_data,
+    ConvParams& conv_params) {
+    auto input_params = std::make_shared<ngraph::opset7::Parameter>(ngraph::element::i64, input_shape);
+    graph_data.input_node = input_params;
+
+    ShouldDecompose(graph_data, conv_params);
+
+    if (model != modelType::TranspConvTransp) {
+        graph_data.bias_const = ReshapeBiasConst(std::dynamic_pointer_cast<ngraph::opset7::Add>(graph_data.bias), conv_params);
+    }
+
+    // Create decomposed reference function
+    std::shared_ptr<ngraph::opset7::Result> result;
+    result = Decompose(graph_data, conv_params);
+    return std::make_shared<ngraph::Function>(ngraph::ResultVector{result}, ngraph::ParameterVector{input_params});
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+void execute_test(modelType model, std::shared_ptr<ngraph::Function> function, std::shared_ptr<ngraph::Function> reference_function) {
+    ngraph::pass::Manager manager;
+    manager.register_pass<ngraph::pass::InitNodeInfo>();
+
+    switch (model) {
+    default:
+    case modelType::TranspConvTransp:
+    case modelType::TranspConvBcastAddTransp:
+    case modelType::TranspConvBcastAddMaxPoolTransp:
+    case modelType::TranspConvBcastAddActTransp:
+    case modelType::TranspConvBcastAddMaxPoolActTransp:
+        manager.register_pass<GNAPluginNS::Decompose2DConv>();
+        break;
+    case modelType::TranspConvTranspBcastAdd:
+        manager.register_pass<GNAPluginNS::Decompose2DConvTransposedWithBias>();
+        break;
+    case modelType::TranspConvTranspBcastAddAct:
+        manager.register_pass<GNAPluginNS::Decompose2DConvTransposedWithBiasAF>();
+        break;
+    }
+
+    manager.run_passes(function);
+    const FunctionsComparator func_comparator = FunctionsComparator::with_default().enable(FunctionsComparator::ATTRIBUTES);
+    const FunctionsComparator::Result result = func_comparator(function, reference_function);
+    ASSERT_TRUE(result.valid);
+}
+
+TEST_P(Decompose2DConvTestFixture, CompareFunctions) {
+    execute_test(model, function, reference_function);
+}
+
+INSTANTIATE_TEST_SUITE_P(Decompose2DConvTestSuite, Decompose2DConvTestFixture,
+    ::testing::Combine(
+        // With / without Fake Quantize layers
+        ::testing::Values(true, false),
+        ::testing::Values(
+            std::make_tuple(modelType::TranspConvTransp, ngraph::PartialShape{1, 4, 4, 32}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::Strides{1, 1}, ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 1}),
+            std::make_tuple(modelType::TranspConvBcastAddTransp, ngraph::PartialShape{1, 4, 4, 32}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::Strides{1, 1}, ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 1}),
+            std::make_tuple(modelType::TranspConvBcastAddMaxPoolTransp, ngraph::PartialShape{1, 4, 4, 32}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::Strides{1, 1}, ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 1}),
+            std::make_tuple(modelType::TranspConvBcastAddActTransp, ngraph::PartialShape{1, 4, 4, 32}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::Strides{1, 1}, ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 1}),
+            std::make_tuple(modelType::TranspConvBcastAddMaxPoolActTransp, ngraph::PartialShape{1, 4, 4, 32}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::Strides{1, 1}, ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 1}),
+            std::make_tuple(modelType::TranspConvTranspBcastAdd, ngraph::PartialShape{1, 4, 4, 32}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::Strides{1, 1}, ngraph::Shape{1, 1, 1, 4}, ngraph::Strides{1, 1}, ngraph::Shape{1, 1}),
+            std::make_tuple(modelType::TranspConvTranspBcastAddAct, ngraph::PartialShape{1, 4, 4, 32}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::Strides{1, 1}, ngraph::Shape{1, 1, 1, 4}, ngraph::Strides{1, 1}, ngraph::Shape{1, 1}))));
+
+TEST_P(Decompose2DConvTestInvalidFixture, CompareFunctions) {
+    execute_test(model, function, reference_function);
+}
+
+INSTANTIATE_TEST_SUITE_P(Decompose2DConvInvalidTestSuite, Decompose2DConvTestInvalidFixture,
+    ::testing::Combine(
+        // With / without Fake Quantize layers
+        ::testing::Values(true, false),
+        ::testing::Values(
+            std::make_tuple(modelType::TranspConvTransp, ngraph::PartialShape{1, 1, 4, 8}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::Strides{1, 1}, ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 2}),
+            std::make_tuple(modelType::TranspConvBcastAddTransp, ngraph::PartialShape{2, 4, 4, 32}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::Strides{1, 1}, ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 2}),
+            std::make_tuple(modelType::TranspConvBcastAddMaxPoolTransp, ngraph::PartialShape{1, 16, 16, 128}, ngraph::Shape{5, 5}, ngraph::Strides{1, 1},
+                ngraph::Strides{1, 1}, ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{2, 2}),
+            std::make_tuple(modelType::TranspConvBcastAddActTransp, ngraph::PartialShape{2, 4, 4, 32}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::Strides{1, 1}, ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 2}),
+            std::make_tuple(modelType::TranspConvBcastAddMaxPoolActTransp, ngraph::PartialShape{1, 16, 16, 128}, ngraph::Shape{4, 4}, ngraph::Strides{1, 1},
+                ngraph::Strides{1, 1}, ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{2, 2}, ngraph::Shape{1, 2}),
+            std::make_tuple(modelType::TranspConvTranspBcastAdd, ngraph::PartialShape{2, 4, 4, 32}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::Strides{1, 1}, ngraph::Shape{1, 1, 1, 4}, ngraph::Strides{1, 1}, ngraph::Shape{1, 2}),
+            std::make_tuple(modelType::TranspConvTranspBcastAddAct, ngraph::PartialShape{2, 4, 4, 32}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::Strides{1, 1}, ngraph::Shape{1, 1, 1, 4}, ngraph::Strides{1, 1}, ngraph::Shape{1, 2}))));
+
+} // namespace
+
+} // namespace testing

--- a/inference-engine/tests/unit/gna/ngraph/transformations/gna_decompose_2d_convolution.cpp
+++ b/inference-engine/tests/unit/gna/ngraph/transformations/gna_decompose_2d_convolution.cpp
@@ -695,6 +695,7 @@ std::shared_ptr<ngraph::Function> Decompose2DConvTestFixture::get_reference(cons
 void execute_test(modelType model, std::shared_ptr<ngraph::Function> function, std::shared_ptr<ngraph::Function> reference_function) {
     ngraph::pass::Manager manager;
     manager.register_pass<ngraph::pass::InitNodeInfo>();
+    InferenceEngine::Precision gnaPrecision = InferenceEngine::Precision::I16;
 
     switch (model) {
     default:
@@ -703,13 +704,13 @@ void execute_test(modelType model, std::shared_ptr<ngraph::Function> function, s
     case modelType::TranspConvBcastAddMaxPoolTransp:
     case modelType::TranspConvBcastAddActTransp:
     case modelType::TranspConvBcastAddMaxPoolActTransp:
-        manager.register_pass<GNAPluginNS::Decompose2DConv>();
+        manager.register_pass<GNAPluginNS::Decompose2DConv>("", gnaPrecision);
         break;
     case modelType::TranspConvTranspBcastAdd:
-        manager.register_pass<GNAPluginNS::Decompose2DConvTransposedWithBias>();
+        manager.register_pass<GNAPluginNS::Decompose2DConvTransposedWithBias>("", gnaPrecision);
         break;
     case modelType::TranspConvTranspBcastAddAct:
-        manager.register_pass<GNAPluginNS::Decompose2DConvTransposedWithBiasAF>();
+        manager.register_pass<GNAPluginNS::Decompose2DConvTransposedWithBiasAF>("", gnaPrecision);
         break;
     }
 
@@ -723,7 +724,7 @@ TEST_P(Decompose2DConvTestFixture, CompareFunctions) {
     execute_test(model, function, reference_function);
 }
 
-INSTANTIATE_TEST_SUITE_P(Decompose2DConvTestSuite, Decompose2DConvTestFixture,
+INSTANTIATE_TEST_CASE_P(Decompose2DConvTestSuite, Decompose2DConvTestFixture,
     ::testing::Combine(
         // With / without Fake Quantize layers
         ::testing::Values(true, false),
@@ -747,7 +748,7 @@ TEST_P(Decompose2DConvTestInvalidFixture, CompareFunctions) {
     execute_test(model, function, reference_function);
 }
 
-INSTANTIATE_TEST_SUITE_P(Decompose2DConvInvalidTestSuite, Decompose2DConvTestInvalidFixture,
+INSTANTIATE_TEST_CASE_P(Decompose2DConvInvalidTestSuite, Decompose2DConvTestInvalidFixture,
     ::testing::Combine(
         // With / without Fake Quantize layers
         ::testing::Values(true, false),

--- a/inference-engine/tests/unit/gna/ngraph/transformations/gna_decompose_2d_convolution.cpp
+++ b/inference-engine/tests/unit/gna/ngraph/transformations/gna_decompose_2d_convolution.cpp
@@ -22,6 +22,7 @@ namespace {
 enum class modelType {
     TranspConvTransp = 0,               /* Transpose(NHWC->NCHW) => Conv => Transpose(NCHW->NHWC) */
     TranspConvBcastAddTransp,           /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => Transpose(NCHW->NHWC) */
+    TranspConvActTransp,                /* Transpose(NHWC->NCHW) => Conv => Activation Function => Transpose(NCHW->NHWC) */
     TranspConvBcastAddMaxPoolTransp,    /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => MaxPooling => Transpose(NCHW->NHWC) (2D Max Pool case) */
     TranspConvBcastAddActTransp,        /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => Activation Function => Transpose(NCHW->NHWC) */
     TranspConvBcastAddMaxPoolActTransp, /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => MaxPool => Activation Function => Transpose(NCHW->NHWC) */
@@ -154,6 +155,19 @@ std::shared_ptr<ngraph::opset7::Result> createFunction(const bool& fq,
     {
         fq_bias = createBiasFQ(conv, bias_const, bias, fq);
         last_op = std::make_shared<ngraph::opset7::Transpose>(fq_bias, transpose_out_order);
+    }
+    break;
+
+    case modelType::TranspConvActTransp:
+    {
+        fq_bias = createBiasFQ(conv, bias_const, bias, fq);
+        std::shared_ptr<ngraph::Node> activation = std::make_shared<ngraph::opset7::Relu>(fq_bias);
+
+        if (fq) {
+            activation = createFQ(activation);
+        }
+
+        last_op = std::make_shared<ngraph::opset7::Transpose>(activation, transpose_out_order);
     }
     break;
 
@@ -701,6 +715,7 @@ void execute_test(modelType model, std::shared_ptr<ngraph::Function> function, s
     default:
     case modelType::TranspConvTransp:
     case modelType::TranspConvBcastAddTransp:
+    case modelType::TranspConvActTransp:
     case modelType::TranspConvBcastAddMaxPoolTransp:
     case modelType::TranspConvBcastAddActTransp:
     case modelType::TranspConvBcastAddMaxPoolActTransp:
@@ -733,6 +748,8 @@ INSTANTIATE_TEST_CASE_P(Decompose2DConvTestSuite, Decompose2DConvTestFixture,
                 ngraph::Strides{1, 1}, ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 1}),
             std::make_tuple(modelType::TranspConvBcastAddTransp, ngraph::PartialShape{1, 4, 4, 32}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
                 ngraph::Strides{1, 1}, ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 1}),
+            std::make_tuple(modelType::TranspConvActTransp, ngraph::PartialShape{1, 4, 4, 32}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::Strides{1, 1}, ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 1}),
             std::make_tuple(modelType::TranspConvBcastAddMaxPoolTransp, ngraph::PartialShape{1, 4, 4, 32}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
                 ngraph::Strides{1, 1}, ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 1}),
             std::make_tuple(modelType::TranspConvBcastAddActTransp, ngraph::PartialShape{1, 4, 4, 32}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
@@ -756,6 +773,8 @@ INSTANTIATE_TEST_CASE_P(Decompose2DConvInvalidTestSuite, Decompose2DConvTestInva
             std::make_tuple(modelType::TranspConvTransp, ngraph::PartialShape{1, 1, 4, 8}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
                 ngraph::Strides{1, 1}, ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 2}),
             std::make_tuple(modelType::TranspConvBcastAddTransp, ngraph::PartialShape{2, 4, 4, 32}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
+                ngraph::Strides{1, 1}, ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 2}),
+            std::make_tuple(modelType::TranspConvActTransp, ngraph::PartialShape{2, 4, 4, 32}, ngraph::Shape{1, 2}, ngraph::Strides{1, 1},
                 ngraph::Strides{1, 1}, ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{1, 2}),
             std::make_tuple(modelType::TranspConvBcastAddMaxPoolTransp, ngraph::PartialShape{1, 16, 16, 128}, ngraph::Shape{5, 5}, ngraph::Strides{1, 1},
                 ngraph::Strides{1, 1}, ngraph::Shape{1, 4, 1, 1}, ngraph::Strides{1, 1}, ngraph::Shape{2, 2}),


### PR DESCRIPTION
### Details:
 - port padding and 2d convolution support from master branch
 - skip decomposition of convolutions supported on GNA 3.0
 - add some required fixes when backporting from master to releases/2021.4

### Tickets:
 - 63938
