### PR TITLE
[OV2.0 Preprocessing] Python bindings for basic preprocess operations

### DIFF
--- a/ngraph/core/include/openvino/core/pre_post_process/input_info.hpp
+++ b/ngraph/core/include/openvino/core/pre_post_process/input_info.hpp
@@ -1,0 +1,73 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/core/core_visibility.hpp"
+#include "openvino/core/pre_post_process/input_tensor_info.hpp"
+#include "openvino/core/pre_post_process/preprocess_steps.hpp"
+
+namespace ov {
+namespace preprocess {
+
+class InputInfoImpl;
+
+/// \brief Class holding preprocessing information for one input
+/// API has Builder-like style to allow chaining calls in client's code, like
+/// \code{.cpp}
+/// auto proc = PrePostProcessor().input(InputInfo().tensor(...).preprocess(...);
+/// \endcode
+class OPENVINO_API InputInfo final {
+    std::unique_ptr<InputInfoImpl> m_impl;
+    friend class PrePostProcessor;
+
+public:
+    /// \brief Empty constructor. Should be used only if network will have only one input
+    InputInfo();
+
+    /// \brief Information about info for particular input index of model
+    ///
+    /// \param input_index Index to address specified input parameter of model
+    InputInfo(size_t input_index);
+
+    /// \brief Default move constructor
+    InputInfo(InputInfo&&) noexcept;
+
+    /// \brief Default move assignment operator
+    InputInfo& operator=(InputInfo&&) noexcept;
+
+    /// \brief Default destructor
+    ~InputInfo();
+
+    /// \brief Set input tensor information for input - Lvalue version
+    ///
+    /// \param builder Input tensor information.
+    ///
+    /// \return Reference to 'this' to allow chaining with other calls in a builder-like manner
+    InputInfo& tensor(InputTensorInfo&& builder) &;
+
+    /// \brief Set input tensor information for input - Rvalue version
+    ///
+    /// \param builder Input tensor information.
+    ///
+    /// \return Rvalue reference to 'this' to allow chaining with other calls in a builder-like manner
+    InputInfo&& tensor(InputTensorInfo&& builder) &&;
+
+    /// \brief Set preprocessing operations for input - Lvalue version
+    ///
+    /// \param builder Preprocessing operations.
+    ///
+    /// \return Reference to 'this' to allow chaining with other calls in a builder-like manner
+    InputInfo& preprocess(PreProcessSteps&& builder) &;
+
+    /// \brief Set preprocessing operations for input - Rvalue version
+    ///
+    /// \param builder Preprocessing operations.
+    ///
+    /// \return Rvalue reference to 'this' to allow chaining with other calls in a builder-like manner
+    InputInfo&& preprocess(PreProcessSteps&& builder) &&;
+};
+
+}  // namespace preprocess
+}  // namespace ov

--- a/ngraph/core/include/openvino/core/pre_post_process/input_tensor_info.hpp
+++ b/ngraph/core/include/openvino/core/pre_post_process/input_tensor_info.hpp
@@ -1,0 +1,63 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/core/core_visibility.hpp"
+#include "openvino/core/type/element_type.hpp"
+
+namespace ov {
+namespace preprocess {
+
+class InputTensorInfoImpl;
+
+/// \brief Information about user's input tensor. By default, it will be initialized to same data (type/shape/etc) as
+/// network's input parameter User application can override particular parameters (like 'element_type') according to
+/// application's data and specify appropriate conversions in pre-processing steps
+///
+/// \code{.cpp}
+/// auto proc =
+/// PrePostProcessor()
+///     .input(InputInfo()
+///            .tensor(InputTensorInfo()
+///                    .set_element_type(ov::element::u8))
+///            .preprocess(<add steps + conversion to network's input element type>)
+///     );
+/// \endcode
+class OPENVINO_API InputTensorInfo final {
+    std::unique_ptr<InputTensorInfoImpl> m_impl;
+    friend class InputInfo;
+
+public:
+    /// \brief Default empty constructor
+    InputTensorInfo();
+
+    /// \brief Default move constructor
+    InputTensorInfo(InputTensorInfo&&) noexcept;
+
+    /// \brief Default move assignment
+    InputTensorInfo& operator=(InputTensorInfo&&) noexcept;
+
+    /// \brief Default destructor
+    ~InputTensorInfo();
+
+    /// \brief Set element type for user's input tensor
+    /// This version allows chaining for Lvalue objects
+    ///
+    /// \param type Element type for user's input tensor.
+    ///
+    /// \return Reference to 'this' to allow chaining with other calls in a builder-like manner
+    InputTensorInfo& set_element_type(const ov::element::Type& type) &;
+
+    /// \brief Set element type for user's input tensor
+    /// This version allows chaining for Rvalue objects
+    ///
+    /// \param builder Pre-processing data for input tensor of model.
+    ///
+    /// \return Rvalue reference to 'this' to allow chaining with other calls in a builder-like manner
+    InputTensorInfo&& set_element_type(const ov::element::Type& type) &&;
+};
+
+}  // namespace preprocess
+}  // namespace ov

--- a/ngraph/core/include/openvino/core/pre_post_process/pre_post_process.hpp
+++ b/ngraph/core/include/openvino/core/pre_post_process/pre_post_process.hpp
@@ -1,0 +1,62 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/core/core_visibility.hpp"
+#include "openvino/core/function.hpp"
+#include "openvino/core/pre_post_process/input_info.hpp"
+
+namespace ov {
+namespace preprocess {
+
+class PrePostProcessorImpl;
+
+/// \brief Main class for adding pre- and post- processing steps to existing ov::Function
+/// API has Builder-like style to allow chaining calls in client's code, like
+/// \code{.cpp}
+/// auto proc = PrePostProcessor().input(<for input1>).input(<input2>);
+/// \endcode
+class OPENVINO_API PrePostProcessor final {
+    std::unique_ptr<PrePostProcessorImpl> m_impl;
+
+public:
+    /// \brief Default constructor
+    PrePostProcessor();
+
+    /// \brief Default move constructor
+    PrePostProcessor(PrePostProcessor&&) noexcept;
+
+    /// \brief Default move assignment operator
+    PrePostProcessor& operator=(PrePostProcessor&&) noexcept;
+
+    /// \brief Default destructor
+    ~PrePostProcessor();
+
+    /// \brief Adds pre-processing information and steps to input of model. This method can be used only if ov::Function
+    /// passed on `build` has only one input
+    ///
+    /// \param builder Pre-processing data for input tensor of model.
+    ///
+    /// \return Reference to 'this' to allow chaining with other calls in a builder-like manner
+    PrePostProcessor& input(InputInfo&& builder) &;
+
+    /// \brief Adds pre-processing information and steps to input of model. This method can be used only if ov::Function
+    /// passed on `build` has only one input This version allows chaining if object represents Rvalue
+    ///
+    /// \param builder Pre-processing data for input tensor of model.
+    ///
+    /// \return Rvalue reference to 'this' to allow chaining with other calls in a builder-like manner
+    PrePostProcessor&& input(InputInfo&& builder) &&;
+
+    /// \brief Adds pre/post-processing operations to existing function
+    ///
+    /// \param function Existing function representing loaded model
+    ///
+    /// \return Function with added pre/post-processing operations
+    std::shared_ptr<Function> build(const std::shared_ptr<Function>& function);
+};
+
+}  // namespace preprocess
+}  // namespace ov

--- a/ngraph/core/include/openvino/core/pre_post_process/preprocess_steps.hpp
+++ b/ngraph/core/include/openvino/core/pre_post_process/preprocess_steps.hpp
@@ -1,0 +1,113 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/core/core_visibility.hpp"
+#include "openvino/core/type/element_type.hpp"
+
+namespace ov {
+namespace preprocess {
+
+class PreProcessStepsImpl;
+
+/// \brief Preprocessing steps. Each step typically intends adding of some operation to input parameter
+/// User application can specify sequence of preprocessing steps in a builder-like manner
+/// \code{.cpp}
+/// auto proc = PrePostProcessor()
+///     .input(InputInfo()
+///            .preprocess(PreProcessSteps()
+///                        .mean(0.2f)     // Subtract 0.2 from each element
+///                        .scale(2.3f))   // then divide each element to 2.3
+///     );
+/// \endcode
+class OPENVINO_API PreProcessSteps final {
+    std::unique_ptr<PreProcessStepsImpl> m_impl;
+    friend class InputInfo;
+
+public:
+    /// \brief Default empty constructor
+    PreProcessSteps();
+
+    /// \brief Default move constructor
+    PreProcessSteps(PreProcessSteps&&) noexcept;
+
+    /// \brief Default move assignment operator
+    PreProcessSteps& operator=(PreProcessSteps&&) noexcept;
+
+    /// \brief Default destructor
+    ~PreProcessSteps();
+
+    /// \brief Add convert element type preprocess operation - Lvalue version
+    ///
+    /// \param type Desired type of input.
+    ///
+    /// \return Reference to 'this' to allow chaining with other calls in a builder-like manner
+    PreProcessSteps& convert_element_type(const ov::element::Type& type) &;
+
+    /// \brief Add convert element type preprocess operation - Rvalue version
+    ///
+    /// \param type Desired type of input.
+    ///
+    /// \return Rvalue reference to 'this' to allow chaining with other calls in a builder-like manner
+    PreProcessSteps&& convert_element_type(const ov::element::Type& type) &&;
+
+    /// \brief Add scale preprocess operation - Lvalue version
+    /// Divide each element of input by specified value
+    ///
+    /// \param value Scaling value.
+    ///
+    /// \return Reference to 'this' to allow chaining with other calls in a builder-like manner
+    PreProcessSteps& scale(float value) &;
+
+    /// \brief Add scale preprocess operation - Rvalue version
+    /// Divide each element of input by specified value
+    ///
+    /// \param value Scaling value.
+    ///
+    /// \return Rvalue reference to 'this' to allow chaining with other calls in a builder-like manner
+    PreProcessSteps&& scale(float value) &&;
+
+    /// \brief Add mean preprocess operation - Lvalue version
+    /// Subtract specified value from each element of input
+    ///
+    /// \param value Value to subtract from each element.
+    ///
+    /// \return Reference to 'this' to allow chaining with other calls in a builder-like manner
+    PreProcessSteps& mean(float value) &;
+
+    /// \brief Add mean preprocess operation - Rvalue version
+    /// Subtract specified value from each element of input
+    ///
+    /// \param value Value to subtract from each element.
+    ///
+    /// \return Rvalue reference to 'this' to allow chaining with other calls in a builder-like manner
+    PreProcessSteps&& mean(float value) &&;
+
+    /// \brief Signature for custom preprocessing operation
+    ///
+    /// \param node Input node for custom preprocessing operation
+    ///
+    /// \return New node after applying custom preprocessing operation
+    using CustomPreprocessOp = std::function<std::shared_ptr<ov::Node>(const std::shared_ptr<ov::Node>& node)>;
+
+    /// \brief Add custom preprocess operation - Lvalue version
+    /// Client application can specify callback function for custom action
+    ///
+    /// \param preprocess_cb Client's custom preprocess operation.
+    ///
+    /// \return Reference to 'this' to allow chaining with other calls in a builder-like manner
+    PreProcessSteps& custom(const CustomPreprocessOp& preprocess_cb) &;
+
+    /// \brief Add custom preprocess operation - Rvalue version
+    /// Client application can specify callback function for custom action
+    ///
+    /// \param preprocess_cb Client's custom preprocess operation.
+    ///
+    /// \return Rvalue reference to 'this' to allow chaining with other calls in a builder-like manner
+    PreProcessSteps&& custom(const CustomPreprocessOp& preprocess_cb) &&;
+};
+
+}  // namespace preprocess
+}  // namespace ov

--- a/ngraph/core/src/pre_post_process/pre_post_process.cpp
+++ b/ngraph/core/src/pre_post_process/pre_post_process.cpp
@@ -1,0 +1,251 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/core/pre_post_process/pre_post_process.hpp"
+
+#include "ngraph/opsets/opset.hpp"
+#include "ngraph/opsets/opset7.hpp"
+
+namespace ov {
+namespace preprocess {
+
+/// \brief InputTensorInfoImpl - internal data structure
+struct InputTensorInfoImpl {
+    InputTensorInfoImpl() = default;
+    explicit InputTensorInfoImpl(const ov::element::Type& type) : m_type(type) {}
+
+    ov::element::Type m_type = ov::element::dynamic;
+};
+
+/// \brief PreProcessStepsImpl - internal data structure
+struct PreProcessStepsImpl {
+    void add_scale_impl(const std::vector<float>& values) {
+        m_actions.emplace_back([values](const std::shared_ptr<Node>& node) {
+            ngraph::Shape shape;
+            if (values.size() == 1) {
+                shape = ngraph::Shape{1};
+            } else {
+                // TODO: implement when Layout API is available
+            }
+            auto constant = ngraph::op::v0::Constant::create(ngraph::element::f32, shape, values);
+            constant->set_friendly_name(node->get_friendly_name() + "/scale/Divide_Factor");
+
+            auto new_op = std::make_shared<ngraph::op::v1::Divide>(node, constant);
+            new_op->set_friendly_name(node->get_friendly_name() + "/scale/Divide");
+            return new_op;
+        });
+    }
+
+    void add_mean_impl(const std::vector<float>& values) {
+        m_actions.emplace_back([values](const std::shared_ptr<Node>& node) {
+            ngraph::Shape shape;
+            if (values.size() == 1) {
+                shape = ngraph::Shape{1};
+            } else {
+                // TODO: implement when Layout API is available
+            }
+            auto constant = ngraph::op::v0::Constant::create(ngraph::element::f32, shape, values);
+            constant->set_friendly_name(node->get_friendly_name() + "/mean/Mean_Const");
+
+            auto new_op = std::make_shared<ngraph::op::v1::Subtract>(node, constant);
+            new_op->set_friendly_name(node->get_friendly_name() + "/mean/Subtract");
+            return new_op;
+        });
+    }
+
+    void add_convert_impl(const ov::element::Type& type) {
+        m_actions.emplace_back([type](const std::shared_ptr<Node>& node) {
+            if (node->get_element_type().is_dynamic()) {
+                throw ngraph::ngraph_error("Can't insert 'convert_element_type' for dynamic source tensor type.");
+            }
+            auto convert = std::make_shared<ngraph::op::v0::Convert>(node, type);
+            convert->set_friendly_name(node->get_friendly_name() + "/convert_element_type");
+            return convert;
+        });
+    }
+    std::vector<PreProcessSteps::CustomPreprocessOp> m_actions;
+};
+
+/// \brief InputInfoImpl - internal data structure
+struct InputInfoImpl {
+    InputInfoImpl() = default;
+    explicit InputInfoImpl(size_t idx) : m_has_index(true), m_index(idx) {}
+
+    bool has_index() const {
+        return m_has_index;
+    }
+
+    bool m_has_index = false;
+    size_t m_index = 0;
+    std::unique_ptr<InputTensorInfoImpl> m_tensor_data;
+    std::unique_ptr<PreProcessStepsImpl> m_preprocess;
+};
+
+//-------------- InputInfo ------------------
+InputInfo::InputInfo() : m_impl(std::unique_ptr<InputInfoImpl>(new InputInfoImpl)) {}
+InputInfo::InputInfo(size_t input_index) : m_impl(std::unique_ptr<InputInfoImpl>(new InputInfoImpl(input_index))) {}
+InputInfo::InputInfo(InputInfo&&) noexcept = default;
+InputInfo& InputInfo::operator=(InputInfo&&) noexcept = default;
+InputInfo::~InputInfo() = default;
+
+InputInfo& InputInfo::tensor(InputTensorInfo&& builder) & {
+    m_impl->m_tensor_data = std::move(builder.m_impl);
+    return *this;
+}
+
+InputInfo&& InputInfo::tensor(InputTensorInfo&& builder) && {
+    m_impl->m_tensor_data = std::move(builder.m_impl);
+    return std::move(*this);
+}
+
+InputInfo&& InputInfo::preprocess(PreProcessSteps&& builder) && {
+    m_impl->m_preprocess = std::move(builder.m_impl);
+    return std::move(*this);
+}
+
+InputInfo& InputInfo::preprocess(PreProcessSteps&& builder) & {
+    m_impl->m_preprocess = std::move(builder.m_impl);
+    return *this;
+}
+
+// ------------------------ PrePostProcessor --------------------
+struct PrePostProcessorImpl {
+public:
+    std::vector<std::unique_ptr<InputInfoImpl>> in_contexts;
+};
+
+PrePostProcessor::PrePostProcessor() : m_impl(std::unique_ptr<PrePostProcessorImpl>(new PrePostProcessorImpl())) {}
+PrePostProcessor::PrePostProcessor(PrePostProcessor&&) noexcept = default;
+PrePostProcessor& PrePostProcessor::operator=(PrePostProcessor&&) noexcept = default;
+PrePostProcessor::~PrePostProcessor() = default;
+
+PrePostProcessor& PrePostProcessor::input(InputInfo&& builder) & {
+    m_impl->in_contexts.push_back(std::move(builder.m_impl));
+    return *this;
+}
+
+PrePostProcessor&& PrePostProcessor::input(InputInfo&& builder) && {
+    m_impl->in_contexts.push_back(std::move(builder.m_impl));
+    return std::move(*this);
+}
+
+std::shared_ptr<Function> PrePostProcessor::build(const std::shared_ptr<Function>& function) {
+    for (const auto& input : m_impl->in_contexts) {
+        std::shared_ptr<ngraph::op::Parameter> param;
+        OV_CHECK(input, "Internal error: Invalid preprocessing input, please report a problem");
+        if (input->has_index()) {
+            param = function->get_parameters().at(input->m_index);
+        } else {
+            // Default case
+            OV_CHECK(function->get_parameters().size() == 1,
+                     std::string("Preprocessing info expects having 1 input, however function has ") +
+                         std::to_string(function->get_parameters().size()) +
+                         " inputs. Please use ov::preprocess::InputInfo constructor specifying "
+                         "particular input instead of default one");
+            param = function->get_parameters().front();
+        }
+        auto consumers = param->output(0).get_target_inputs();
+        if (!input->m_tensor_data) {
+            input->m_tensor_data =
+                std::unique_ptr<InputTensorInfoImpl>(new InputTensorInfoImpl(param->get_element_type()));
+        }
+        auto new_param_shape = param->get_partial_shape();
+        auto new_param = std::make_shared<ngraph::op::v0::Parameter>(input->m_tensor_data->m_type, new_param_shape);
+        // Old param will be removed, so friendly name can be reused
+        new_param->set_friendly_name(param->get_friendly_name());
+        std::shared_ptr<ngraph::Node> node = new_param;
+
+        // 2. Apply preprocessing
+        for (const auto& action : input->m_preprocess->m_actions) {
+            node = action(node);
+        }
+
+        // 3. Apply 'network()' data
+        // Check final type
+        if (node->get_element_type() != param->get_element_type()) {
+            throw ngraph::ngraph_error(
+                std::string("Element type after preprocessing {") + node->get_element_type().c_type_string() +
+                std::string("} doesn't match with network element type {") + param->get_element_type().c_type_string() +
+                "}. Please add 'convert_element_type' explicitly");
+        }
+
+        // Replace parameter
+        for (auto consumer : consumers) {
+            consumer.replace_source_output(node);
+        }
+        if (input->has_index()) {
+            function->replace_parameter(input->m_index, new_param);
+        } else {
+            function->replace_parameter(0, new_param);
+        }
+    }
+    function->validate_nodes_and_infer_types();
+    return function;
+}
+
+// --------------------- InputTensorInfo ------------------
+InputTensorInfo::InputTensorInfo() : m_impl(std::unique_ptr<InputTensorInfoImpl>(new InputTensorInfoImpl())) {}
+InputTensorInfo::InputTensorInfo(InputTensorInfo&&) noexcept = default;
+InputTensorInfo& InputTensorInfo::operator=(InputTensorInfo&&) noexcept = default;
+InputTensorInfo::~InputTensorInfo() = default;
+
+InputTensorInfo& InputTensorInfo::set_element_type(const ov::element::Type& type) & {
+    m_impl->m_type = type;
+    return *this;
+}
+
+InputTensorInfo&& InputTensorInfo::set_element_type(const ov::element::Type& type) && {
+    m_impl->m_type = type;
+    return std::move(*this);
+}
+
+// --------------------- PreProcessSteps ------------------
+
+PreProcessSteps::PreProcessSteps() : m_impl(std::unique_ptr<PreProcessStepsImpl>(new PreProcessStepsImpl())) {}
+PreProcessSteps::PreProcessSteps(PreProcessSteps&&) noexcept = default;
+PreProcessSteps& PreProcessSteps::operator=(PreProcessSteps&&) noexcept = default;
+PreProcessSteps::~PreProcessSteps() = default;
+
+PreProcessSteps& PreProcessSteps::scale(float value) & {
+    m_impl->add_scale_impl(std::vector<float>{value});
+    return *this;
+}
+
+PreProcessSteps&& PreProcessSteps::scale(float value) && {
+    m_impl->add_scale_impl(std::vector<float>{value});
+    return std::move(*this);
+}
+
+PreProcessSteps& PreProcessSteps::mean(float value) & {
+    m_impl->add_mean_impl(std::vector<float>{value});
+    return *this;
+}
+
+PreProcessSteps&& PreProcessSteps::mean(float value) && {
+    m_impl->add_mean_impl(std::vector<float>{value});
+    return std::move(*this);
+}
+
+PreProcessSteps& PreProcessSteps::convert_element_type(const ov::element::Type& type) & {
+    m_impl->add_convert_impl(type);
+    return *this;
+}
+
+PreProcessSteps&& PreProcessSteps::convert_element_type(const ov::element::Type& type) && {
+    m_impl->add_convert_impl(type);
+    return std::move(*this);
+}
+
+PreProcessSteps& PreProcessSteps::custom(const CustomPreprocessOp& preprocess_cb) & {
+    m_impl->m_actions.emplace_back(preprocess_cb);
+    return *this;
+}
+
+PreProcessSteps&& PreProcessSteps::custom(const CustomPreprocessOp& preprocess_cb) && {
+    m_impl->m_actions.emplace_back(preprocess_cb);
+    return std::move(*this);
+}
+
+}  // namespace preprocess
+}  // namespace ov

--- a/ngraph/python/src/ngraph/__init__.py
+++ b/ngraph/python/src/ngraph/__init__.py
@@ -16,6 +16,7 @@ from ngraph.impl import Dimension
 from ngraph.impl import Function
 from ngraph.impl import Node
 from ngraph.impl import PartialShape
+from ngraph.impl import Type
 from ngraph.frontend import FrontEnd
 from ngraph.frontend import FrontEndManager
 from ngraph.frontend import GeneralFailure

--- a/ngraph/python/src/ngraph/preprocess/__init__.py
+++ b/ngraph/python/src/ngraph/preprocess/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (C) 2018-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Package: ngraph
+Low level wrappers for the PrePostProcessing c++ api.
+"""
+
+# flake8: noqa
+
+# main classes
+from _pyngraph.preprocess import InputInfo
+from _pyngraph.preprocess import InputTensorInfo
+from _pyngraph.preprocess import PrePostProcessor
+from _pyngraph.preprocess import PreProcessSteps

--- a/ngraph/python/src/pyngraph/pre_post_process.cpp
+++ b/ngraph/python/src/pyngraph/pre_post_process.cpp
@@ -1,0 +1,236 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/core/pre_post_process/pre_post_process.hpp"
+
+#include <pybind11/functional.h>
+#include <pybind11/pybind11.h>
+
+#include "pyngraph/pre_post_process.hpp"
+
+namespace py = pybind11;
+
+static void regclass_pyngraph_PreProcessSteps(py::module m) {
+    py::class_<ov::preprocess::PreProcessSteps, std::shared_ptr<ov::preprocess::PreProcessSteps>> steps(
+        m,
+        "PreProcessSteps");
+    steps.doc() = "ngraph.impl.preprocess.PreProcessSteps wraps ov::preprocess::PreProcessSteps";
+
+    steps.def(py::init<>());
+    steps.def(
+        "mean",
+        [](const std::shared_ptr<ov::preprocess::PreProcessSteps>& me, float value) {
+            me->mean(value);
+            return me;
+        },
+        py::arg("value"),
+        R"(
+                Subtracts single float value from each element in input tensor.
+                Input tensor must have ngraph.Type.f32 data type.
+
+                Parameters
+                ----------
+                value : float
+                    Value to subtract.
+
+                Returns
+                ----------
+                mean : PreProcessSteps
+                    Reference to itself to allow chaining of calls in client's code in a builder-like manner.
+              )");
+    steps.def(
+        "scale",
+        [](const std::shared_ptr<ov::preprocess::PreProcessSteps>& me, float value) {
+            me->scale(value);
+            return me;
+        },
+        py::arg("value"),
+        R"(
+                Divides each element in input tensor to specified constant float value.
+                Input tensor must have ngraph.Type.f32 data type.
+
+                Parameters
+                ----------
+                value : float
+                    Value to divide.
+
+                Returns
+                ----------
+                scale : PreProcessSteps
+                    Reference to itself to allow chaining of calls in client's code in a builder-like manner.
+              )");
+    steps.def(
+        "convert_element_type",
+        [](const std::shared_ptr<ov::preprocess::PreProcessSteps>& me, ov::element::Type type) {
+            me->convert_element_type(type);
+            return me;
+        },
+        py::arg("type"),
+        R"(
+                Converts input tensor element type to specified type.
+                Input tensor must have ngraph.Type.f32 data type.
+
+                Parameters
+                ----------
+                type : Type
+                    Destination type.
+
+                Returns
+                ----------
+                convert_element_type : PreProcessSteps
+                    Reference to itself to allow chaining of calls in client's code in a builder-like manner.
+              )");
+    steps.def(
+        "custom",
+        [](const std::shared_ptr<ov::preprocess::PreProcessSteps>& me,
+           const ov::preprocess::PreProcessSteps::CustomPreprocessOp& op) {
+            me->custom(op);
+            return me;
+        },
+        py::arg("operation"),
+        R"(
+                Adds custom preprocessing operation.
+
+                Parameters
+                ----------
+                operation : function taking Node as input argument and returning Node after preprocessing.
+
+                Returns
+                ----------
+                custom : PreProcessSteps
+                    Reference to itself to allow chaining of calls in client's code in a builder-like manner.
+              )");
+}
+
+static void regclass_pyngraph_InputTensorInfo(py::module m) {
+    py::class_<ov::preprocess::InputTensorInfo, std::shared_ptr<ov::preprocess::InputTensorInfo>> info(
+        m,
+        "InputTensorInfo");
+    info.doc() = "ngraph.impl.preprocess.InputTensorInfo wraps ov::preprocess::InputTensorInfo";
+
+    info.def(py::init<>());
+    info.def(
+        "set_element_type",
+        [](const std::shared_ptr<ov::preprocess::InputTensorInfo>& me, const ov::element::Type& type) {
+            me->set_element_type(type);
+            return me;
+        },
+        py::arg("type"),
+        R"(
+                Set initial client's tensor element type. If type is not the same as network's element type, user must
+                add appropriate type conversion manually.
+
+                Parameters
+                ----------
+                type : Type
+                    Client's input tensor element type.
+
+                Returns
+                ----------
+                tensor : InputTensorInfo
+                    Reference to itself to allow chaining of calls in client's code in a builder-like manner.
+              )");
+}
+
+static void regclass_pyngraph_InputInfo(py::module m) {
+    py::class_<ov::preprocess::InputInfo, std::shared_ptr<ov::preprocess::InputInfo>> inp(m, "InputInfo");
+    inp.doc() = "ngraph.impl.preprocess.InputInfo wraps ov::preprocess::InputInfo";
+
+    inp.def(py::init<>(), R"(Default constructor, can be used only for networks with exactly one input)");
+    inp.def(py::init<size_t>(), R"(Constructor with parameter index as argument)");
+    inp.def(
+        "tensor",
+        [](const std::shared_ptr<ov::preprocess::InputInfo>& me,
+           const std::shared_ptr<ov::preprocess::InputTensorInfo>& inputTensorInfo) {
+            me->tensor(std::move(*inputTensorInfo));
+            return me;
+        },
+        py::arg("tensor"),
+        R"(
+                Adds builder for actual tensor information of client's input.
+
+                Parameters
+                ----------
+                tensor : InputTensorInfo
+                    Client's input tensor information. It's internal data will be moved to parent InputInfo object.
+
+                Returns
+                ----------
+                tensor : InputInfo
+                    Reference to itself to allow chaining of calls in client's code in a builder-like manner.
+              )");
+    inp.def(
+        "preprocess",
+        [](const std::shared_ptr<ov::preprocess::InputInfo>& me,
+           const std::shared_ptr<ov::preprocess::PreProcessSteps>& preProcessSteps) {
+            me->preprocess(std::move(*preProcessSteps));
+            return me;
+        },
+        py::arg("pre_process_steps"),
+        R"(
+                Adds builder for actual preprocessing steps for input parameter.
+                Steps can specify various actions, like 'mean', 'scale' and others.
+
+                Parameters
+                ----------
+                pre_process_steps : PreProcessSteps
+                    Preprocessing steps. It's internal data will be moved to parent InputInfo object.
+
+                Returns
+                ----------
+                preprocess : InputInfo
+                    Reference to itself to allow chaining of calls in client's code in a builder-like manner.
+              )");
+}
+
+void regclass_pyngraph_PrePostProcessor(py::module m) {
+    regclass_pyngraph_PreProcessSteps(m);
+    regclass_pyngraph_InputInfo(m);
+    regclass_pyngraph_InputTensorInfo(m);
+    py::class_<ov::preprocess::PrePostProcessor, std::shared_ptr<ov::preprocess::PrePostProcessor>> proc(
+        m,
+        "PrePostProcessor");
+    proc.doc() = "ngraph.impl.preprocess.PrePostProcessor wraps ov::preprocess::PrePostProcessor";
+
+    proc.def(py::init<>());
+    proc.def(
+        "input",
+        [](const std::shared_ptr<ov::preprocess::PrePostProcessor>& me,
+           const std::shared_ptr<ov::preprocess::InputInfo>& info) {
+            me->input(std::move(*info));
+            return me;
+        },
+        py::arg("input_info"),
+        R"(
+                Adds builder for preprocessing info for input parameter.
+
+                Parameters
+                ----------
+                input_info : InputInfo
+                    Preprocessing info for input parameter. It's internal data will be moved to PreProcessing object.
+
+                Returns
+                ----------
+                in : PrePostProcessor
+                    Reference to itself to allow chaining of calls in client's code.
+              )");
+    proc.def("build",
+             &ov::preprocess::PrePostProcessor::build,
+             py::arg("function"),
+             R"(
+                Apply pre- and post-processing steps to specified model represented by `function` object.
+                Parameters specified for inputs and outputs are validated on this stage
+                and exception is raised if some data is invalid or inconsistent.
+
+                Parameters
+                ----------
+                function : Function
+                    Function representing existing model without pre-post-processing steps.
+
+                Returns
+                ----------
+                build : Function
+                    Same function object with applied pre(post)processing steps.
+              )");
+}

--- a/ngraph/python/src/pyngraph/pre_post_process.hpp
+++ b/ngraph/python/src/pyngraph/pre_post_process.hpp
@@ -1,0 +1,11 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+void regclass_pyngraph_PrePostProcessor(py::module m);

--- a/ngraph/python/src/pyngraph/pyngraph.cpp
+++ b/ngraph/python/src/pyngraph/pyngraph.cpp
@@ -27,6 +27,7 @@
 #include "pyngraph/ops/util/regmodule_pyngraph_op_util.hpp"
 #include "pyngraph/partial_shape.hpp"
 #include "pyngraph/passes/regmodule_pyngraph_passes.hpp"
+#include "pyngraph/pre_post_process.hpp"
 #include "pyngraph/rt_map.hpp"
 #include "pyngraph/shape.hpp"
 #include "pyngraph/strides.hpp"
@@ -75,4 +76,7 @@ PYBIND11_MODULE(_pyngraph, m) {
     regclass_pyngraph_Variant(m);
     regclass_pyngraph_VariantWrapper<std::string>(m, std::string("String"));
     regclass_pyngraph_VariantWrapper<int64_t>(m, std::string("Int"));
+    py::module m_preprocess =
+        m.def_submodule("preprocess", "Package ngraph.impl.preprocess that wraps ngraph::preprocess");
+    regclass_pyngraph_PrePostProcessor(m_preprocess);
 }

--- a/ngraph/python/tests/test_ngraph/test_preprocess.py
+++ b/ngraph/python/tests/test_ngraph/test_preprocess.py
@@ -1,0 +1,89 @@
+# Copyright (C) 2018-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import numpy as np
+import pytest
+
+import ngraph as ng
+from ngraph.preprocess import PrePostProcessor, InputInfo, PreProcessSteps, InputTensorInfo
+from ngraph import Function, Node, Type
+from tests.runtime import get_runtime
+from tests.test_ngraph.util import run_op_node
+
+
+def test_ngraph_preprocess_mean():
+    shape = [2, 2]
+    parameter_a = ng.parameter(shape, dtype=np.float32, name="A")
+    model = parameter_a
+    function = Function(model, [parameter_a], "TestFunction")
+
+    function = PrePostProcessor()\
+        .input(InputInfo()
+               .preprocess(PreProcessSteps()
+                           .mean(1.)
+                           )
+               )\
+        .build(function)
+
+    input_data = np.array([[1,2], [3,4]]).astype(np.float32)
+    expected_output = np.array([[0,1], [2,3]]).astype(np.float32)
+
+    runtime = get_runtime()
+    computation = runtime.computation(function)
+    output = computation(input_data)
+    assert np.equal(output, expected_output).all()
+
+
+def test_ngraph_preprocess_mean_scale_convert():
+    shape = [2, 2]
+    param1 = ng.parameter(shape, dtype=np.float32, name="A")
+    param2 = ng.parameter(shape, dtype=np.float32, name="B")
+    function = Function([param1, param2], [param1, param2], "TestFunction")
+
+    def custom_preprocess(node: Node):
+        return ng.abs(node)
+
+    function = PrePostProcessor() \
+        .input(InputInfo(1)
+               .tensor(InputTensorInfo()
+                       .set_element_type(Type.i32))
+               .preprocess(PreProcessSteps()
+                           .convert_element_type(Type.f32)
+                           .mean(1.)
+                           .scale(2.)
+                           )
+               ) \
+        .input(InputInfo(0)
+               .preprocess(PreProcessSteps()
+                           .mean(1.)
+                           .custom(custom_preprocess)
+                           )
+               ) \
+        .build(function)
+
+    input_data1 = np.array([[0,1], [2,-2]]).astype(np.int32)
+    input_data2 = np.array([[1,3], [5,7]]).astype(np.int32)
+    expected_output1 = np.array([[1,0], [1,3]]).astype(np.float32)
+    expected_output2 = np.array([[0,1], [2,3]]).astype(np.float32)
+
+    runtime = get_runtime()
+    computation = runtime.computation(function)
+    [output1, output2] = computation(input_data1, input_data2)
+    assert np.equal(output1, expected_output1).all()
+    assert np.equal(output2, expected_output2).all()
+
+
+def test_ngraph_invalid_element_type():
+    shape = [2, 2]
+    param1 = ng.parameter(shape, dtype=np.float32, name="A")
+    function = Function([param1], [param1], "TestFunction")
+    with pytest.raises(Exception):
+        function = PrePostProcessor() \
+            .input(InputInfo()
+                   .preprocess(PreProcessSteps()
+                               .convert_element_type(Type.i32)
+                               )
+                   ) \
+            .build(function)

--- a/ngraph/test/CMakeLists.txt
+++ b/ngraph/test/CMakeLists.txt
@@ -76,6 +76,7 @@ set(SRC
     pass_config.cpp
     pass_manager.cpp
     pattern.cpp
+    pre_post_process.cpp
     provenance.cpp
     replace_node.cpp
     reshape_opt_kernel.cpp

--- a/ngraph/test/pre_post_process.cpp
+++ b/ngraph/test/pre_post_process.cpp
@@ -1,0 +1,192 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/core/pre_post_process/pre_post_process.hpp"
+
+#include <ngraph/pass/visualize_tree.hpp>
+
+#include "gtest/gtest.h"
+#include "ngraph/ngraph.hpp"
+#include "ngraph/ops.hpp"
+#include "util/all_close.hpp"
+#include "util/all_close_f.hpp"
+#include "util/test_tools.hpp"
+
+using namespace ov;
+using namespace ov::preprocess;
+using namespace ngraph::test;
+
+static std::shared_ptr<Function> create_simple_function(element::Type type, const PartialShape& shape) {
+    auto data1 = std::make_shared<ngraph::op::v0::Parameter>(type, shape);
+    data1->set_friendly_name("input1");
+    auto res = std::make_shared<ngraph::op::v0::Result>(data1);
+    res->set_friendly_name("Result");
+    return std::make_shared<ngraph::Function>(ngraph::ResultVector{res}, ngraph::ParameterVector{data1});
+}
+
+static std::shared_ptr<Function> create_2inputs(element::Type type, const PartialShape& shape) {
+    auto data1 = std::make_shared<ngraph::op::v0::Parameter>(type, shape);
+    data1->set_friendly_name("input1");
+    auto data2 = std::make_shared<ngraph::op::v0::Parameter>(type, shape);
+    data2->set_friendly_name("input2");
+    auto res1 = std::make_shared<ngraph::op::v0::Result>(data1);
+    res1->set_friendly_name("Result");
+    auto res2 = std::make_shared<ngraph::op::v0::Result>(data2);
+    res2->set_friendly_name("Result");
+    return std::make_shared<ngraph::Function>(ngraph::ResultVector{res1, res2}, ngraph::ParameterVector{data1, data2});
+}
+
+TEST(pre_post_process, simple_mean_scale) {
+    auto f = create_simple_function(ngraph::element::f32, ngraph::Shape{1, 3, 2, 2});
+    f = PrePostProcessor().input(InputInfo().preprocess(PreProcessSteps().mean(1.f).scale(2.f))).build(f);
+
+    auto result = std::make_shared<HostTensor>();
+    f->evaluate({result},
+                {make_host_tensor<ngraph::element::f32>(ngraph::Shape{1, 3, 2, 2},
+                                                        {1., 3., 5., 7., 9., 11., 13., 15., 17., 19., 21., 23.})});
+    auto result_val = read_vector<float>(result);
+    EXPECT_TRUE(all_close_f(std::vector<float>{0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11.}, result_val));
+}
+
+TEST(pre_post_process, scale_then_mean) {
+    auto f = create_simple_function(ngraph::element::f32, ngraph::Shape{1, 3, 2, 2});
+    f = PrePostProcessor().input(InputInfo().preprocess(PreProcessSteps().scale(2.0f).mean(1.0f))).build(f);
+
+    auto result = std::make_shared<HostTensor>();
+    f->evaluate({result},
+                {make_host_tensor<ngraph::element::f32>(ngraph::Shape{1, 3, 2, 2},
+                                                        {2., 4., 6., 8., 10., 12., 14., 16., 18., 20., 100., 200.})});
+    auto result_val = read_vector<float>(result);
+    EXPECT_TRUE(all_close_f(std::vector<float>{0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 49., 99.}, result_val));
+}
+
+TEST(pre_post_process, convert_element_type_and_scale) {
+    auto f = create_simple_function(element::i8, ngraph::Shape{1, 3, 2, 2});
+    f = PrePostProcessor()
+            .input(InputInfo()
+                       .tensor(InputTensorInfo().set_element_type(element::i16))
+                       .preprocess(PreProcessSteps()
+                                       .convert_element_type(element::f32)
+                                       .scale(2.f)
+                                       .convert_element_type(element::i8)))
+            .build(f);
+
+    auto result = std::make_shared<HostTensor>();
+    f->evaluate({result},
+                {make_host_tensor<ngraph::element::i32>(ngraph::Shape{1, 3, 2, 2},
+                                                        {2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 1000000, 200})});
+    auto result_val = read_vector<int8_t>(result);
+    EXPECT_TRUE(all_close(std::vector<int8_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, (int8_t)500000, 100}, result_val));
+    EXPECT_EQ(f->get_parameters().front()->get_element_type(), element::i16);
+
+    ASSERT_EQ(f->get_output_element_type(0), element::i8);
+}
+
+TEST(pre_post_process, convert_element_type_from_unknown) {
+    auto f = create_simple_function(element::i32, ngraph::Shape{1, 3, 224, 224});
+    ASSERT_ANY_THROW(
+        f = PrePostProcessor()
+                .input(InputInfo().preprocess(
+                    PreProcessSteps().convert_element_type(element::dynamic).convert_element_type(element::i32)))
+                .build(f););
+}
+
+TEST(pre_post_process, convert_element_type_no_match) {
+    auto f = create_simple_function(element::i32, ngraph::Shape{1, 3, 224, 224});
+    ASSERT_ANY_THROW(f = PrePostProcessor()
+                             .input(InputInfo()
+                                        .tensor(InputTensorInfo().set_element_type(element::i32))
+                                        .preprocess(PreProcessSteps().convert_element_type(element::f32).scale(2.0f)))
+                             .build(f););
+}
+
+TEST(pre_post_process, tensor_element_type_and_scale) {
+    auto f = create_simple_function(element::i8, ngraph::Shape{1, 3, 1, 1});
+    f = PrePostProcessor()
+            .input(InputInfo()
+                       .tensor(InputTensorInfo().set_element_type(element::f32))
+                       .preprocess(PreProcessSteps().scale(2.0f).convert_element_type(element::i8)))
+            .build(f);
+
+    auto result = std::make_shared<HostTensor>();
+    f->evaluate({result}, {make_host_tensor<ngraph::element::f32>(ngraph::Shape{1, 3, 1, 1}, {2., 4., 6.})});
+    auto result_val = read_vector<int8_t>(result);
+    EXPECT_TRUE(all_close(std::vector<int8_t>{1, 2, 3}, result_val));
+    EXPECT_EQ(f->get_parameters().front()->get_element_type(), element::f32);
+
+    ASSERT_EQ(f->get_output_element_type(0), element::i8);
+}
+
+TEST(pre_post_process, custom_preprocessing) {
+    auto f = create_simple_function(element::i32, ngraph::Shape{1, 3, 1, 1});
+    f = PrePostProcessor()
+            .input(InputInfo().preprocess(PreProcessSteps().custom([](const std::shared_ptr<Node>& node) {
+                auto abs = std::make_shared<ngraph::op::v0::Abs>(node);
+                abs->set_friendly_name(node->get_friendly_name() + "/abs");
+                return abs;
+            })))
+            .build(f);
+
+    auto result = std::make_shared<HostTensor>();
+    f->evaluate({result}, {make_host_tensor<ngraph::element::i32>(ngraph::Shape{1, 3, 1, 1}, {0, 4, -6})});
+    auto result_val = read_vector<int32_t>(result);
+    EXPECT_TRUE(all_close(std::vector<int32_t>{0, 4, 6}, result_val));
+}
+
+TEST(pre_post_process, test_lvalue) {
+    auto f = create_simple_function(element::i8, ngraph::Shape{1, 3, 1, 1});
+    auto p = PrePostProcessor();
+    auto p1 = std::move(p);
+    p = std::move(p1);
+    auto inputInfo = InputInfo();
+    auto inputInfo2 = std::move(inputInfo);
+    inputInfo = std::move(inputInfo2);
+    {
+        auto inputTensorInfo = InputTensorInfo();
+        auto inputTensorInfo2 = std::move(inputTensorInfo);
+        inputTensorInfo = std::move(inputTensorInfo2);
+        auto& same = inputTensorInfo.set_element_type(element::f32);
+        inputInfo.tensor(std::move(same));
+    }
+    {
+        auto preprocessSteps = PreProcessSteps();
+        auto preprocessSteps2 = std::move(preprocessSteps);
+        preprocessSteps = std::move(preprocessSteps2);
+        preprocessSteps.mean(1.f);
+        preprocessSteps.scale(2.f);
+        preprocessSteps.custom([](const std::shared_ptr<Node>& node) {
+            auto abs = std::make_shared<ngraph::op::v0::Abs>(node);
+            abs->set_friendly_name(node->get_friendly_name() + "/abs");
+            return abs;
+        });
+        auto& same = preprocessSteps.convert_element_type(element::i8);
+        inputInfo.preprocess(std::move(same));
+    }
+    p.input(std::move(inputInfo));
+    f = p.build(f);
+
+    auto result = std::make_shared<HostTensor>();
+    f->evaluate({result}, {make_host_tensor<ngraph::element::f32>(ngraph::Shape{1, 3, 1, 1}, {-3., 5., 7.})});
+    auto result_val = read_vector<int8_t>(result);
+    EXPECT_TRUE(all_close(std::vector<int8_t>{2, 2, 3}, result_val));
+    EXPECT_EQ(f->get_parameters().front()->get_element_type(), element::f32);
+
+    ASSERT_EQ(f->get_output_element_type(0), element::i8);
+}
+
+TEST(pre_post_process, test_2_inputs_basic) {
+    auto f = create_2inputs(element::f32, ngraph::Shape{1, 3, 1, 1});
+    { f = PrePostProcessor().input(InputInfo(1).preprocess(PreProcessSteps().mean(1.f).scale(2.0f))).build(f); }
+    auto result1 = std::make_shared<HostTensor>();
+    auto result2 = std::make_shared<HostTensor>();
+    auto input1 = make_host_tensor<ngraph::element::f32>(ngraph::Shape{1, 3, 1, 1}, {3., 5., 7.});
+    auto input2 = make_host_tensor<ngraph::element::f32>(ngraph::Shape{1, 3, 1, 1}, {3., 5., 7.});
+    f->evaluate({result1, result2}, {input1, input2});
+
+    auto result1_val = read_vector<float>(result1);
+    EXPECT_TRUE(all_close_f(std::vector<float>{3, 5, 7}, result1_val));
+
+    auto result2_val = read_vector<float>(result2);
+    EXPECT_TRUE(all_close_f(std::vector<float>{1, 2, 3}, result2_val));
+}


### PR DESCRIPTION
### Details:
 - Depends on PR #7391 
 - See code related to 'ngraph/python' only
 - Tensor: set_element_type
 - Steps: mean/scale/convert_element_type/custom

### Tickets:
 - 62183
