### PR TITLE
Paddle 'slice' should set correct beg_mask and end_mask paramters

### DIFF
--- a/ngraph/frontend/paddlepaddle/src/op/slice.cpp
+++ b/ngraph/frontend/paddlepaddle/src/op/slice.cpp
@@ -35,24 +35,42 @@ NamedOutputs slice(const NodeContext& node) {
         end_idx_node = opset6::Constant::create(element::i32, {ends.size()}, ends);
     }
 
-    // the shape of input, such as [1, 1, 3, 3]
+    // The following process is:
+    // Given:
+    // data = [ [1, 2, 3, 4], [5, 6, 7, 8], ] // shape is: [2, 4]
+    // axes = [0]
+    // starts = [1]
+    // ends = [2]
+    // Our process is:
+    //  1. Get 'axes': [0, 1], 'starts', 'ends'
+    //  2. Get data shape: [2,4] and dims: 2
+    //  3. Create two tensor t1 and t2, shape is the dims from step2: 2. t1: [0, 0], t2: [INT_MAX, INT_MAX]
+    //  4. Use 'ScatterNDUpdate' to update some elements in t1, the updated indexes are coming from 'axes', the contents
+    //  are coming from 'starts', t1: [1, 0]; apply the similar process to t2
+    //  5. Call 'StrideSlice' with t1 and t2
+    // Why using ScatterNDUpdate is that 'axes' may be discontinuous.
+
+    // the shape of input, such as [2, 4]
     auto shape_node = std::make_shared<opset6::ShapeOf>(data, element::Type_t::i32);
-    // the input dim, such as [4]
+    // the input dim, such as [2]
     auto shape_shape_node = std::make_shared<opset6::ShapeOf>(shape_node, element::i32);
     auto const_0_node = opset6::Constant::create(element::i32, {}, {0});
     auto const_max_node = opset6::Constant::create(element::i32, {}, {INT_MAX});
-    // array [0:max)
+    // t1: [0, 0]
     auto start_node = std::make_shared<opset6::Broadcast>(const_0_node, shape_shape_node);
+    // t2: [INT_MAX, INT_MAX]
     auto end_node = std::make_shared<opset6::Broadcast>(const_max_node, shape_shape_node);
     auto axes_node = opset6::Constant::create(element::i32, {axes.size(), 1}, axes);
+    // update t1
     auto fixed_start_node = std::make_shared<opset6::ScatterNDUpdate>(start_node, axes_node, start_idx_node);
+    // update t2
     auto fixed_end_node = std::make_shared<opset6::ScatterNDUpdate>(end_node, axes_node, end_idx_node);
 
     return node.default_single_output_mapping({std::make_shared<ngraph::opset6::StridedSlice>(data,
                                                                                               fixed_start_node,
                                                                                               fixed_end_node,
-                                                                                              std::vector<int64_t>{},
-                                                                                              std::vector<int64_t>{})},
+                                                                                              std::vector<int64_t>{0},
+                                                                                              std::vector<int64_t>{0})},
                                               {"Out"});
 }
 }  // namespace op


### PR DESCRIPTION
### Details:
 - *StridedSlice should set beg/end_mask to {0} instead of {}*. If beg/end_mask={} will generate incorrect IR: \<data begin_mask="" ellipsis_mask="" end_mask="" new_axis_mask="" shrink_axis_mask=""/\>, which cause MO assertion error on the IR.
 - *add [review comment](https://github.com/openvinotoolkit/openvino/pull/6636#discussion_r681797059) to the slice source code*

### Tickets:
 - *62791*
