### PR TITLE
Removed Output<Node>(shared_ptr) constructor

### DIFF
--- a/ngraph/core/include/openvino/core/node_output.hpp
+++ b/ngraph/core/include/openvino/core/node_output.hpp
@@ -33,13 +33,6 @@ public:
     /// \param index The index of the output.
     Output(Node* node, size_t index);
 
-    /// \brief Constructs a Output.
-    /// \param node A `shared_ptr` to the node for the output handle.
-    /// \param index The index of the output.
-    ///
-    /// TODO: Make a plan to deprecate this.
-    Output(const std::shared_ptr<Node>& node, size_t index);
-
     /// \brief Constructs a Output, referencing the zeroth output of the node.
     /// \param node A `shared_ptr` to the node for the output handle.
     template <typename T>
@@ -56,7 +49,6 @@ public:
     Node* get_node() const;
     /// \return A `shared_ptr` to the node referred to by this output handle.
     ///
-    /// TODO: Make a plan to deprecate this.
     std::shared_ptr<Node> get_node_shared_ptr() const;
 
     /// \return The index of the output referred to by this output handle.
@@ -110,13 +102,6 @@ public:
     /// \param index The index of the output.
     Output(const Node* node, size_t index);
 
-    /// \brief Constructs a Output.
-    /// \param node A `shared_ptr` to the node for the output handle.
-    /// \param index The index of the output.
-    ///
-    /// TODO: Make a plan to deprecate this.
-    Output(const std::shared_ptr<const Node>& node, size_t index);
-
     /// \brief Constructs a Output, referencing the zeroth output of the node.
     /// \param node A `shared_ptr` to the node for the output handle.
     template <typename T>
@@ -134,7 +119,6 @@ public:
     const Node* get_node() const;
     /// \return A `shared_ptr` to the node referred to by this output handle.
     ///
-    /// TODO: Make a plan to deprecate this.
     std::shared_ptr<const Node> get_node_shared_ptr() const;
     /// \return The index of the output referred to by this output handle.
     size_t get_index() const;

--- a/ngraph/core/include/openvino/pass/pattern/op/branch.hpp
+++ b/ngraph/core/include/openvino/pass/pattern/op/branch.hpp
@@ -36,9 +36,7 @@ public:
     }
 
     Output<Node> get_destination() const {
-        return m_destination_node == nullptr
-                   ? Output<Node>()
-                   : Output<Node>{m_destination_node->shared_from_this(), m_destination_index};
+        return m_destination_node == nullptr ? Output<Node>() : Output<Node>{m_destination_node, m_destination_index};
     }
 
     bool match_value(pattern::Matcher* matcher,

--- a/ngraph/core/src/node.cpp
+++ b/ngraph/core/src/node.cpp
@@ -748,7 +748,7 @@ vector<ov::Output<ov::Node>> ov::Node::outputs() {
     vector<Output<Node>> result;
 
     for (size_t i = 0; i < get_output_size(); i++) {
-        result.emplace_back(shared_from_this(), i);
+        result.emplace_back(this, i);
     }
 
     return result;
@@ -758,7 +758,7 @@ vector<ov::Output<const ov::Node>> ov::Node::outputs() const {
     vector<Output<const Node>> result;
 
     for (size_t i = 0; i < get_output_size(); i++) {
-        result.emplace_back(shared_from_this(), i);
+        result.emplace_back(this, i);
     }
 
     return result;

--- a/ngraph/core/src/node_input.cpp
+++ b/ngraph/core/src/node_input.cpp
@@ -28,7 +28,7 @@ const PartialShape& Input<Node>::get_partial_shape() const {
 
 Output<Node> Input<Node>::get_source_output() const {
     auto& output_descriptor = m_node->m_inputs.at(m_index).get_output();
-    return Output<Node>(output_descriptor.get_node(), output_descriptor.get_index());
+    return Output<Node>(output_descriptor.get_node().get(), output_descriptor.get_index());
 }
 
 descriptor::Tensor& Input<Node>::get_tensor() const {
@@ -104,7 +104,7 @@ const PartialShape& Input<const Node>::get_partial_shape() const {
 
 Output<Node> Input<const Node>::get_source_output() const {
     auto& output_descriptor = m_node->m_inputs.at(m_index).get_output();
-    return Output<Node>(output_descriptor.get_node(), output_descriptor.get_index());
+    return Output<Node>(output_descriptor.get_node().get(), output_descriptor.get_index());
 }
 
 descriptor::Tensor& Input<const Node>::get_tensor() const {

--- a/ngraph/core/src/node_output.cpp
+++ b/ngraph/core/src/node_output.cpp
@@ -11,16 +11,15 @@
 namespace ov {
 Output<Node>::Output(Node* node, size_t index) : m_node(node->shared_from_this()), m_index(index) {}
 
-Output<Node>::Output(const std::shared_ptr<Node>& node, size_t index) : m_node(node), m_index(index) {}
-
 void Output<Node>::reset() {
     m_node.reset();
     m_index = 0;
 }
 
 Output<Node> Output<Node>::for_node(const std::shared_ptr<Node>& node) {
-    return Output(node, m_index);
+    return Output(node.get(), m_index);
 }
+
 Node* Output<Node>::get_node() const {
     return m_node.get();
 }
@@ -99,15 +98,13 @@ bool Output<Node>::operator>=(const Output& other) const {
 }
 Output<const Node>::Output(const Node* node, size_t index) : m_node(node->shared_from_this()), m_index(index) {}
 
-Output<const Node>::Output(const std::shared_ptr<const Node>& node, size_t index) : m_node(node), m_index(index) {}
-
 void Output<const Node>::reset() {
     m_node.reset();
     m_index = 0;
 }
 
 Output<const Node> Output<const Node>::for_node(const std::shared_ptr<const Node>& node) {
-    return Output(node, m_index);
+    return Output(node.get(), m_index);
 }
 
 const Node* Output<const Node>::get_node() const {

--- a/ngraph/core/src/op/util/multi_subgraph_base.cpp
+++ b/ngraph/core/src/op/util/multi_subgraph_base.cpp
@@ -120,7 +120,7 @@ ov::op::util::MultiSubGraphOp::MultiSubGraphOp(const OutputVector& args, size_t 
 ov::Input<ov::Node> ov::op::util::MultiSubGraphOp::input_for_value(const Output<Node>& value) {
     auto input_index = get_input_size();
     set_argument(input_index, value);
-    return ov::Input<Node>(this, input_index);
+    return {this, input_index};
 }
 
 void ov::op::util::MultiSubGraphOp::set_invariant_inputs(const Output<Node>& value,
@@ -149,7 +149,7 @@ ov::Output<ov::Node> ov::op::util::MultiSubGraphOp::set_body_outputs(const Resul
         }
     }
     set_output_size(output_index + 1);
-    return Output<Node>(shared_from_this(), output_index);
+    return Output<Node>(this, output_index);
 }
 
 namespace ov {

--- a/ngraph/core/src/op/util/sub_graph_base.cpp
+++ b/ngraph/core/src/op/util/sub_graph_base.cpp
@@ -41,7 +41,7 @@ ov::Output<ov::Node> ov::op::util::SubGraphOp::get_iter_value(const Output<Node>
         std::make_shared<BodyOutputDescription>(body->get_result_index(body_value), output_index, iteration));
     set_output_size(output_index + 1);
     validate_and_infer_types();
-    return Output<Node>(shared_from_this(), output_index);
+    return Output<Node>(this, output_index);
 }
 
 ov::Output<ov::Node> ov::op::util::SubGraphOp::get_concatenated_slices(const Output<Node>& body_value,
@@ -61,7 +61,7 @@ ov::Output<ov::Node> ov::op::util::SubGraphOp::get_concatenated_slices(const Out
                                                                                  axis));
     set_output_size(output_index + 1);
     validate_and_infer_types();
-    return Output<Node>(shared_from_this(), output_index);
+    return Output<Node>(this, output_index);
 }
 
 void ov::op::util::SubGraphOp::set_sliced_input(const std::shared_ptr<ngraph::op::Parameter>& parameter,


### PR DESCRIPTION
### Details:
 - Removed Output constructor with shared pointer
