### PR TITLE
Extend coverage versions in requirements_dev.txt

### DIFF
--- a/model-optimizer/requirements_dev.txt
+++ b/model-optimizer/requirements_dev.txt
@@ -1,4 +1,4 @@
-coverage==4.4.2
+coverage>=4.4.2,<=5.5
 astroid==2.4.2
 pylint==2.5.0
 pyenchant==1.6.11


### PR DESCRIPTION
**Root cause analysis:** CI fails during installation of modules from `requirements_dev.txt` on Ubuntu 20 with python 3.8.

**Solution:** Extend coverage versions in `requirements_dev.txt`. Coverage 5.5 is the latest version for which I have successfully tested the MO unit-tests coverage.

Code:
* [x]  Comments - N/A
* [x]  Code style (PEP8) - N/A
* [x]  Transformation generates reshape-able IR - N/A
* [x]  Transformation preserves original framework node names - N/A

Validation:
* [x]  Unit tests - N/A
* [x]  Framework operation tests - N/A
* [x]  Transformation tests - N/A
* [x]  Model Optimizer IR Reader check - N/A

Documentation:
* [x]  Supported frameworks operations list - N/A
* [x]  Guide on how to convert the **public** model - N/A
* [x]  User guide update - N/A
