### PR TITLE
Removed incorrect link from cnpy readme

### DIFF
--- a/thirdparty/cnpy/README.md
+++ b/thirdparty/cnpy/README.md
@@ -51,5 +51,3 @@ struct NpyArray {
     template<typename T> T* data();
 };
 ```
-
-See [example1.cpp](example1.cpp) for examples of how to use the library. example1 will also be build during cmake installation.


### PR DESCRIPTION
### Details:
 - Readme contained incorrect link to example1.cpp
