### PR TITLE
Use one set of parentheses around gcc attribute deprecated arg

### DIFF
--- a/inference-engine/src/inference_engine/include/ie/ie_api.h
+++ b/inference-engine/src/inference_engine/include/ie/ie_api.h
@@ -39,7 +39,7 @@
 #elif defined __INTEL_COMPILER
 #    define INFERENCE_ENGINE_DEPRECATED(msg) __attribute__((deprecated(msg)))
 #elif defined(__GNUC__)
-#    define INFERENCE_ENGINE_DEPRECATED(msg) __attribute__((deprecated((msg))))
+#    define INFERENCE_ENGINE_DEPRECATED(msg) __attribute__((deprecated(msg)))
 #else
 #    define INFERENCE_ENGINE_DEPRECATED(msg)
 #endif

--- a/ngraph/core/include/openvino/core/deprecated.hpp
+++ b/ngraph/core/include/openvino/core/deprecated.hpp
@@ -25,7 +25,7 @@
 #    define OPENVINO_DEPRECATED(msg)      __attribute__((deprecated(msg)))
 #    define OPENVINO_ENUM_DEPRECATED(msg) OPENVINO_DEPRECATED(msg)
 #elif defined(__GNUC__)
-#    define OPENVINO_DEPRECATED(msg) __attribute__((deprecated((msg))))
+#    define OPENVINO_DEPRECATED(msg) __attribute__((deprecated(msg)))
 #    if __GNUC__ < 6 && !defined(__clang__)
 #        define OPENVINO_ENUM_DEPRECATED(msg)
 #    else


### PR DESCRIPTION
Double parentheses break some other compilers which pretend to be gcc.
Single set doesn't seem to break anything.