### PR TITLE
Add support of pkgutil-style namespace packages

### DIFF
--- a/inference-engine/ie_bridges/python/src/openvino/__init__.py
+++ b/inference-engine/ie_bridges/python/src/openvino/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2018-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+from typing import Iterable
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: Iterable[str]

--- a/inference-engine/ie_bridges/python/src/openvino/__init__.py
+++ b/inference-engine/ie_bridges/python/src/openvino/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2018-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-__path__ = __import__('pkgutil').extend_path(__path__, __name__) # type: ignore  # mypy issue #1422
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore  # mypy issue #1422

--- a/inference-engine/ie_bridges/python/src/openvino/__init__.py
+++ b/inference-engine/ie_bridges/python/src/openvino/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2018-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: Iterable[str]

--- a/inference-engine/ie_bridges/python/src/openvino/__init__.py
+++ b/inference-engine/ie_bridges/python/src/openvino/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2018-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/inference-engine/ie_bridges/python/src/openvino/__init__.py
+++ b/inference-engine/ie_bridges/python/src/openvino/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2018-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-from typing import Iterable
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: Iterable[str]
+__path__ = __import__('pkgutil').extend_path(__path__, __name__) # type: ignore  # mypy issue #1422


### PR DESCRIPTION
### Details:
 - *According to packaging [guides](https://packaging.python.org/guides/packaging-namespace-packages/#pkgutil-style-namespace-packages) every distribution that uses the namespace package must include an identical __init__.py:*
`__path__ = __import__('pkgutil').extend_path(__path__, __name__)`

### Tickets:
 - *60366*
