### PR TITLE
[MO] add uint32/uint8 into list of supported data types

### DIFF
--- a/model-optimizer/mo/middle/passes/convert_data_type.py
+++ b/model-optimizer/mo/middle/passes/convert_data_type.py
@@ -38,10 +38,11 @@ SUPPORTED_DATA_TYPES = {
     'I32': (np.int32, 'I32', 'i32'),
     'I64': (np.int64, 'I64', 'i64'),
     'int8': (np.int8, 'I8', 'i8'),
-    'uint8': (np.uint8, 'U8', 'u8'),
     'int32': (np.int32, 'I32', 'i32'),
     'int64': (np.int64, 'I64', 'i64'),
     'bool': (np.bool, 'BOOL', 'boolean'),
+    'uint8': (np.uint8, 'U8', 'u8'),
+    'uint32': (np.uint32, 'U32', 'u32'),
     'uint64': (np.uint64, 'U64', 'u64'),
 
     # custom types


### PR DESCRIPTION
### Details:
 **Root cause analysis:** during quantization MO was failing with the error `mo.utils.error.Error: Destination type "u32" is not supported`. This was happening because of the introduced transformation which marks gather-NMS path to be unsigned (#6474) while uint32 was not mentioned in `SUPPORTED_DATA_TYPES` of MO

**Solution**: Add  uint32 into `SUPPORTED_DATA_TYPES`

### Tickets:
 - xxx-63537
