### PR TITLE
Change PowerIE to ops chain

### DIFF
--- a/inference-engine/tests/functional/shared_test_classes/src/subgraph/softsign.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/subgraph/softsign.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include <legacy/ngraph_ops/power.hpp>
+#include <ngraph/opsets/opset6.hpp>
 #include "shared_test_classes/subgraph/softsign.hpp"
 #include "ngraph_functions/builders.hpp"
 
@@ -37,8 +37,13 @@ void SoftsignTest::SetUp() {
     auto params = ngraph::builder::makeParams(ngPrc, { inputShape });
 
     auto abs = std::make_shared<ngraph::op::Abs>(params[0]);
-    auto add = std::make_shared<ngraph::op::PowerIE>(abs, 1, 1, 1);
-    auto power = std::make_shared<ngraph::op::PowerIE>(add, -1, 1, 0);
+
+    auto const_1 = ngraph::opset1::Constant::create(ngPrc, ngraph::Shape{}, {1});
+    auto const_neg_1 = ngraph::opset1::Constant::create(ngPrc, ngraph::Shape{}, {-1});
+
+    auto add = std::make_shared<ngraph::opset6::Add>(abs, const_1);
+    auto power = std::make_shared<ngraph::opset6::Power>(add, const_neg_1);
+
     auto mul = std::make_shared<ngraph::op::v1::Multiply>(power, params[0]);
     ngraph::ResultVector results{ std::make_shared<ngraph::op::Result>(mul) };
     function = std::make_shared<ngraph::Function>(results, params, "SoftSignTest");


### PR DESCRIPTION
### Details:
 - PowerIE has considered as legacy op type, it was changed to ops from pset6

### RSA
- change legacy types of ops

### Tickets:
 - XXX-55373
