### PR TITLE
[CPU] Removed optimized out nodes from infer stage

### DIFF
--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph.h
@@ -235,9 +235,9 @@ protected:
     void Allocate();
     void AllocateWithReuse();
     void CreatePrimitives();
-    void ExtractConstantNodes();
+    void ExtractConstantAndExecutableNodes();
     void ExecuteNode(const MKLDNNNodePtr& node, const mkldnn::stream& stream) const;
-    void ExecuteConstantNodesOnly() const;
+    void ExecuteConstantNodesOnly();
 
     friend class MKLDNNInferRequest;
     friend class MKLDNNGraphlessInferRequest;
@@ -247,10 +247,12 @@ private:
     // TODO: change std::map to std::unordered_map
     std::map<std::string, MKLDNNNodePtr> inputNodesMap;
     std::map<std::string, MKLDNNNodePtr> outputNodesMap;
+
     // these node pointers (from graphNodes) are to avoid regular checking for
-    // constant node in ExecuteConstantNodesOnly and Infer methods
+    // constantness of nodes in ExecuteConstantNodesOnly, Infer methods and calls of
+    // non-executable (optimized out) nodes, such as Input, Reshape, etc.
     std::vector<MKLDNNNodePtr> constantGraphNodes;
-    std::vector<MKLDNNNodePtr> mutableGraphNodes;
+    std::vector<MKLDNNNodePtr> executableGraphNodes;
 
     void EnforceBF16();
 };

--- a/inference-engine/src/mkldnn_plugin/mkldnn_graph.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_graph.h
@@ -237,7 +237,7 @@ protected:
     void CreatePrimitives();
     void ExtractConstantAndExecutableNodes();
     void ExecuteNode(const MKLDNNNodePtr& node, const mkldnn::stream& stream) const;
-    void ExecuteConstantNodesOnly();
+    void ExecuteConstantNodesOnly() const;
 
     friend class MKLDNNInferRequest;
     friend class MKLDNNGraphlessInferRequest;

--- a/inference-engine/src/mkldnn_plugin/mkldnn_node.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_node.h
@@ -195,6 +195,11 @@ public:
         return engine;
     }
 
+    // must be called only after MKLDNNGraph::InitEdges()
+    virtual bool isExecutable() const {
+        return true;
+    }
+
     bool isConstant();
 
     bool isInplace() const;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_concat_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_concat_node.h
@@ -27,6 +27,9 @@ public:
     bool isOptimized() const;
 
     InferenceEngine::Precision getRuntimePrecision() const override;
+    bool isExecutable() const override {
+        return !isOptimized();
+    }
 
 private:
     size_t axis = 0;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_input_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_input_node.h
@@ -26,6 +26,9 @@ public:
     MKLDNNMemoryCPtr getMemoryPtr() const;
 
     void executeDynamicImpl(mkldnn::stream strm) override {}
+    bool isExecutable() const override {
+        return false;
+    }
 
     std::vector<VectorDims> shapeInfer() const override {
         return std::vector<VectorDims>();

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_memory_node.hpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_memory_node.hpp
@@ -89,6 +89,9 @@ public:
     bool created() const override {
         return getType() == MemoryInput;
     }
+    bool isExecutable() const override {
+        return true;
+    }
     void execute(mkldnn::stream strm) override;
 
     void createPrimitive() override;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reorder_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reorder_node.h
@@ -25,6 +25,10 @@ public:
     bool created() const override;
     const std::vector<impl_desc_type>& getPrimitivesPriority() override;
 
+    bool isExecutable() const override {
+        return !isOptimized;
+    }
+
     void setDescs(const MemoryDesc& input, const MemoryDesc& output) {
         this->input = input.clone();
         inputShapes.clear();

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reshape_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reshape_node.h
@@ -26,6 +26,9 @@ public:
     void initSupportedPrimitiveDescriptors() override;
     void createPrimitive() override;
     bool created() const override;
+    bool isExecutable() const override {
+        return false;
+    }
 
     static bool isSupportedOperation(const std::shared_ptr<const ngraph::Node>& op, std::string& errorMessage) noexcept;
 };

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.cpp
@@ -298,7 +298,7 @@ bool MKLDNNSplitNode::created() const {
     return getType() == Split;
 }
 
-bool MKLDNNSplitNode::isOptimized() {
+bool MKLDNNSplitNode::isOptimized() const {
     return getSelectedPrimitiveDescriptor() && getSelectedPrimitiveDescriptor()->getConfig().outConfs[0].inPlace >= 0;
 }
 

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_split_node.h
@@ -22,10 +22,13 @@ public:
     void execute(mkldnn::stream strm) override;
     bool created() const override;
 
-    bool isOptimized();
+    bool isOptimized() const;
     void initOptimalPrimitiveDescriptor() override;
 
     void setDynamicBatchLim(int lim) override;
+    bool isExecutable() const override {
+        return !isOptimized();
+    }
 
 private:
     void prepareOptimizedParams();


### PR DESCRIPTION
### Details:
 - *Added method `isExecutable()` to remove non-executable (optimized out) nodes from infer stage*

### Tickets:
 - *65291*
