### PR TITLE
[MO] fixed dealing with None in then/else branches of Select

### DIFF
--- a/model-optimizer/extensions/ops/select.py
+++ b/model-optimizer/extensions/ops/select.py
@@ -64,7 +64,8 @@ class Select(Op):
                 # if we use np.where for such cases then dtype of output_value will be object (non numeric type)
                 # and subsequent numpy operation on a such tensors will fail
                 output_value = resulting_tensors[not np.bool(condition_value.item(0))]
-
+                if output_value is None:
+                    return
                 if broadcast_rule == 'numpy':
                     output_value = bi_directional_broadcasting(output_value, output_shape)
                 elif broadcast_rule == 'pdpd':
@@ -72,7 +73,6 @@ class Select(Op):
                     raise Error("PDPD broadcasting rule is not implemented yet")
 
                 node.out_port(0).data.set_value(output_value)
-                return
             else:
                 output_value = np.ma.where(condition_value, resulting_tensors[0], resulting_tensors[1])
                 # If any element of output value is None that means that we use the value from the 'then' or the


### PR DESCRIPTION
### Details:
 **root cause analysis:** In some cases `Select` condition is True[False] for all elements while one of the branches is None (which is not selected). 
During shape inference of `Select` `np.where` is called and in the above case output_value `dtype` is set to `object`. Which is not compatible with numerical int and float types. 
![image](https://user-images.githubusercontent.com/5703039/132849128-fa093074-e535-444d-8dcb-b8470de73fec.png)
And subsequently numpy operations were failed without proper error message and explanation.

**solution**: process cases when there is `None` in one the branches manually without using `np.where` so that `dtype` will not be corrupted
![image](https://user-images.githubusercontent.com/5703039/132848658-2132ba66-5b3a-40be-97e7-f15094e4b170.png)

### Tickets:
 - xxx-62426, xxx-64129
 
Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names

Validation:
* [x]  Unit tests: done
* [x]  Framework operation tests: no new operation were added
* [x]  Transformation tests: no new transformation were added
* [x]  Model Optimizer IR Reader check: done

Documentation:
* [x]  Supported frameworks operations list n/a
* [x]  Guide on how to convert the **public** model n/a
* [x]  User guide update: a/a
