### PR TITLE
[GNA] Fix permute precision handling

### DIFF
--- a/inference-engine/src/gna_plugin/layers/gna_layer_info.hpp
+++ b/inference-engine/src/gna_plugin/layers/gna_layer_info.hpp
@@ -61,8 +61,9 @@ class LayerInfo {
         IS_VALID();
         static InferenceEngine::details::caseless_set<std::string> layersWith8BOr16BOutputs = {"memory", "input", "split", "slice", "concat", "copy", "const"};
         return layersWith8BOr16BOutputs.find(layer->type) != layersWith8BOr16BOutputs.end() ||
-                                                                        isActivation() ||
-                                                            (isCrop() && !isCropAffined());
+               isActivation() ||
+               (isCrop() && !isCropAffined()) ||
+               isPermute();
     }
     bool has32BOutput() const noexcept {
         IS_VALID();

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/transpose_add.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/transpose_add.cpp
@@ -8,7 +8,9 @@
 namespace {
 std::vector<std::vector<size_t>> input_shapes {
     {1, 4, 32},
-    {1, 8, 8}
+    {1, 8, 8},
+    {1, 7, 8},
+    {1, 40, 3}
 };
 
 std::vector<InferenceEngine::Precision> netPrecisions = {

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/transpose_add.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/transpose_add.cpp
@@ -1,0 +1,32 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+#include "subgraph_tests/transpose_add.hpp"
+#include "common_test_utils/test_constants.hpp"
+namespace {
+std::vector<std::vector<size_t>> input_shapes {
+    {1, 4, 32},
+    {1, 8, 8}
+};
+
+std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16,
+};
+
+std::map<std::string, std::string> additional_config = {
+    {"GNA_DEVICE_MODE", "GNA_SW_EXACT"},
+};
+} // namespace
+
+namespace SubgraphTestsDefinitions {
+    INSTANTIATE_TEST_SUITE_P(smoke_basic, TransposeAdd,
+        ::testing::Combine(
+            ::testing::ValuesIn(netPrecisions),
+            ::testing::Values(CommonTestUtils::DEVICE_GNA),
+            ::testing::ValuesIn(input_shapes),
+            ::testing::Values(additional_config)),
+        TransposeAdd::getTestCaseName);
+} // namespace SubgraphTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/transpose_add.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/subgraph_tests/transpose_add.hpp
@@ -1,0 +1,15 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "shared_test_classes/subgraph/transpose_add.hpp"
+
+namespace SubgraphTestsDefinitions {
+
+TEST_P(TransposeAdd, CompareWithRefImpl) {
+    Run();
+};
+
+}  // namespace SubgraphTestsDefinitions

--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/transpose_add.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/transpose_add.hpp
@@ -1,0 +1,32 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <vector>
+#include <string>
+#include <memory>
+
+#include "shared_test_classes/base/layer_test_utils.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+#include "ngraph_functions/builders.hpp"
+
+namespace SubgraphTestsDefinitions {
+typedef std::tuple<
+    InferenceEngine::Precision,         // Network Precision
+    std::string,                        // Target Device
+    std::vector<size_t>,                // Input shape
+    std::map<std::string, std::string>  // Configuration
+> TransposeAddParams;
+
+class TransposeAdd : public testing::WithParamInterface<TransposeAddParams>,
+    virtual public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<TransposeAddParams> obj);
+
+protected:
+    void SetUp() override;
+};
+}  // namespace SubgraphTestsDefinitions

--- a/inference-engine/tests/functional/shared_test_classes/src/subgraph/transpose_add.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/subgraph/transpose_add.cpp
@@ -11,7 +11,6 @@ std::string TransposeAdd::getTestCaseName(testing::TestParamInfo<TransposeAddPar
     std::vector<size_t> input_shape;
     std::map<std::string, std::string> configuration;
 
-
     std::tie(netPrecision, targetName, input_shape, configuration) = obj.param;
     std::ostringstream results;
 
@@ -27,6 +26,7 @@ void TransposeAdd::SetUp() {
     std::map<std::string, std::string> additional_config;
 
     std::tie(netPrecision, targetDevice, input_shape, additional_config) = this->GetParam();
+    GTEST_ASSERT_GE(input_shape.size(), 2);
 
     configuration.insert(additional_config.begin(), additional_config.end());
 

--- a/inference-engine/tests/functional/shared_test_classes/src/subgraph/transpose_add.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/subgraph/transpose_add.cpp
@@ -1,0 +1,49 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/subgraph/transpose_add.hpp"
+
+namespace SubgraphTestsDefinitions {
+std::string TransposeAdd::getTestCaseName(testing::TestParamInfo<TransposeAddParams> obj) {
+    InferenceEngine::Precision netPrecision;
+    std::string targetName;
+    std::vector<size_t> input_shape;
+    std::map<std::string, std::string> configuration;
+
+
+    std::tie(netPrecision, targetName, input_shape, configuration) = obj.param;
+    std::ostringstream results;
+
+    results << "IS=" << CommonTestUtils::vec2str(std::vector<size_t>(input_shape.begin(), input_shape.end())) << "_";
+    results << "netPRC=" << netPrecision.name() << "_";
+    results << "targetDevice=" << targetName;
+    return results.str();
+}
+
+void TransposeAdd::SetUp() {
+    InferenceEngine::Precision netPrecision;
+    std::vector<size_t> input_shape;
+    std::map<std::string, std::string> additional_config;
+
+    std::tie(netPrecision, targetDevice, input_shape, additional_config) = this->GetParam();
+
+    configuration.insert(additional_config.begin(), additional_config.end());
+
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+    auto params = ngraph::builder::makeParams(ngPrc, {input_shape});
+
+    ngraph::Shape permute_order(input_shape.size());
+    std::iota(std::begin(permute_order), std::end(permute_order), 0);
+    std::iter_swap(std::end(permute_order) - 2, std::end(permute_order) - 1);
+    auto transpose_in_params = std::make_shared<ngraph::opset8::Constant>(ngraph::element::i64,
+        ngraph::Shape{permute_order.size()}, permute_order);
+    auto transpose_in = std::make_shared<ngraph::opset8::Transpose>(params[0], transpose_in_params);
+
+    auto add_const = ngraph::builder::makeConstant<float>(ngPrc, transpose_in->get_output_shape(0), {}, true);
+    auto add = std::make_shared<ngraph::opset8::Add>(transpose_in, add_const);
+
+    function = std::make_shared<ngraph::Function>(add, params, "transpose_add");
+}
+
+} // namespace SubgraphTestsDefinitions


### PR DESCRIPTION
### Details:
 - Permute output precision isn't specified in LayerInfo functions, as a result a diagonal layer isn't inserted between it and Eltwise layer.
 - Permute output precision should be marked as int16.
 - Functional test is added.

### Tickets:
65238
