### PR TITLE
 Fix VariadicSplitLayerTest class to inherit virtually LayerTestsCommon

### DIFF
--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/variadic_split.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/variadic_split.hpp
@@ -27,7 +27,7 @@ typedef std::tuple<
 > VariadicSplitParams;
 
 class VariadicSplitLayerTest : public testing::WithParamInterface<VariadicSplitParams>,
-                           public LayerTestsUtils::LayerTestsCommon {
+                          virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<VariadicSplitParams> obj);
 


### PR DESCRIPTION
### Details:
 - *Fix VariadicSplitLayerTest class to inherit virtually LayerTestsCommon*

### Tickets:
 - *65144*
