### PR TITLE
[LPT] getDequantization: added precision limitation for mul/sub constants

### DIFF
--- a/inference-engine/src/low_precision_transformations/src/fake_quantize_dequantization.cpp
+++ b/inference-engine/src/low_precision_transformations/src/fake_quantize_dequantization.cpp
@@ -165,9 +165,13 @@ int FakeQuantizeDequantization::fillDequantizationParams(
         std::shared_ptr<ngraph::opset1::Constant>& constant) {
         convert = ov::as_type_ptr<opset1::Convert>(elementwise->get_input_node_shared_ptr(branchIndex));
         if (convert != nullptr) {
-            constant = ov::as_type_ptr<opset1::Constant>(convert->get_input_node_shared_ptr(0));
+            constant = convert->get_destination_type().is_real() ?
+                ov::as_type_ptr<opset1::Constant>(convert->get_input_node_shared_ptr(0)) :
+                nullptr;
         } else {
-            constant = ov::as_type_ptr<opset1::Constant>(elementwise->get_input_node_shared_ptr(branchIndex));
+            constant = elementwise->get_input_element_type(branchIndex).is_real() ?
+                ov::as_type_ptr<opset1::Constant>(elementwise->get_input_node_shared_ptr(branchIndex)) :
+                nullptr;
         }
     };
 
@@ -187,12 +191,18 @@ int FakeQuantizeDequantization::fillDequantizationParams(
 int FakeQuantizeDequantization::fillDequantizationParams(
     const std::shared_ptr<ngraph::Node>& elementwise,
     std::shared_ptr<ngraph::opset1::Constant>& constant) noexcept {
-    constant = ov::as_type_ptr<opset1::Constant>(elementwise->get_input_node_shared_ptr(1ul));
+    constant = elementwise->get_input_element_type(1ul).is_real() ?
+        ov::as_type_ptr<opset1::Constant>(elementwise->get_input_node_shared_ptr(1ul)) :
+        nullptr;
+
     if (constant != nullptr) {
         return 1;
     }
 
-    constant = ov::as_type_ptr<opset1::Constant>(elementwise->get_input_node_shared_ptr(0ul));
+    constant = elementwise->get_input_element_type(0ul).is_real() ?
+        ov::as_type_ptr<opset1::Constant>(elementwise->get_input_node_shared_ptr(0ul)) :
+        nullptr;
+
     if (constant != nullptr) {
         return 0;
     }

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/multiply_to_group_convolution_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/multiply_to_group_convolution_transformation.cpp
@@ -276,7 +276,7 @@ const std::vector<MultiplyToGroupConvolutionTransformationTestValues> testValues
             ngraph::element::u8,
             {
                 {},
-                {{1.f, 2.f, 3.f, 4.f}, ngraph::element::f32},
+                DequantizationOperations::Subtract{{1.f, 2.f, 3.f, 4.f}, element::f32}.setConstantPrecision(element::f32),
                 {{0.45f, 0.82f, 0.71f, 0.37f}}
             }
         },
@@ -301,7 +301,7 @@ const std::vector<MultiplyToGroupConvolutionTransformationTestValues> testValues
             ngraph::element::u8,
             {
                 {},
-                {{1.f, 2.f, 3.f, 4.f}, ngraph::element::f32},
+                DequantizationOperations::Subtract{{1.f, 2.f, 3.f, 4.f}, element::f32}.setConstantPrecision(element::f32),
                 {{0.45f, 0.82f, 0.71f, 0.37f}}
             }
         },

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/reshape_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/reshape_transformation.cpp
@@ -955,7 +955,23 @@ const std::vector<ReshapeTransformationTestValues> testValues = {
                 {{0.1f,  0.02f, 0.1f, 0.02f, 0.1f, 0.02f}, ngraph::element::f32, {1, 6}}
             }
         }
-    }
+    },
+    // Nondequantization multiply (I32 precision)
+    {
+        { 1, 384, 1024 },
+        { 1, 384, 16, 64 },
+        LayerTransformation::createParamsU8I8(),
+        {
+            ngraph::element::i32,
+            {{}, {}, {2}}
+        },
+        {
+            ngraph::element::i32,
+            {{}, {}, {2}},
+            ngraph::element::i32,
+            {}
+        }
+    },
 };
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
### Details:
 - *NetworkHelper::getDequantization: added precision limitation for mul/sub constants to avoid LPT running on the i32 subgraphs*

### Tickets:
 - *63658*
 - *64992*
 - *63344*
 - *Validation: 65812*
