### PR TITLE
[GPU] Fix RapidJSON assertion failure during loading offline kernel

### DIFF
--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/auto_tuner.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/auto_tuner.cpp
@@ -317,6 +317,7 @@ void AutoTuner::RemoveKernel(const std::string& cacheFilePath,
 
 std::tuple<std::string, int> AutoTuner::LoadKernelOffline(TuningCache* deviceCache,
                                                           const Params& params) {
+    std::lock_guard<std::mutex> lock(mutex);
     static const uint32_t defaultComputeUnits = 24;
     if (!deviceCache)
         return {};


### PR DESCRIPTION
### Details:
 - Add mutex lock for thread safety during loading offline kernel

### Tickets:
 - 59937