### PR TITLE
[GNA] Enable 2D convolution decomposition on GNA 3.0

### DIFF
--- a/inference-engine/src/gna_plugin/backend/dnn_types.h
+++ b/inference-engine/src/gna_plugin/backend/dnn_types.h
@@ -201,18 +201,6 @@ enum OvGnaType {
     OvGnaTypePwl = 8,
 };
 
-#if GNA_LIB_VER == 2
-enum OvGnaMode {
-    OvGnaModeDefault = 0,
-    OvGnaModeDisabled = -1
-};
-
-struct OvGnaTensor {
-    std::vector<uint32_t> dimensions;
-    OvGnaType type;
-    OvGnaMode mode;
-};
-
 template <class T>
 OvGnaType OvGnaTypeIntFromBytes(T bytesPerElement) {
     static const std::map<T, OvGnaType> m = {
@@ -226,6 +214,18 @@ OvGnaType OvGnaTypeIntFromBytes(T bytesPerElement) {
     }
     return r->second;
 }
+
+#if GNA_LIB_VER == 2
+enum OvGnaMode {
+    OvGnaModeDefault = 0,
+    OvGnaModeDisabled = -1
+};
+
+struct OvGnaTensor {
+    std::vector<uint32_t> dimensions;
+    OvGnaType type;
+    OvGnaMode mode;
+};
 
 inline std::string OvGnaTypeToString(OvGnaType type) {
     static const std::map<OvGnaType, std::string> typeToString = {

--- a/inference-engine/src/gna_plugin/backend/gna_limitations.cpp
+++ b/inference-engine/src/gna_plugin/backend/gna_limitations.cpp
@@ -94,23 +94,36 @@ std::string VectorOrSquareLimitByChannelsAndPrecision::GetErrorOrEmpty(const uin
     return GetByPrecision(precision).GetErrorOrEmpty(h, w, channels, what);
 }
 
-void Validator::ValidateCnn2D(std::string name, const uint32_t inHeight, const uint32_t inWidth,
-    const uint32_t inChannels, const uint32_t kH, const uint32_t kW, const uint32_t kN,
-    const uint32_t strideH, const uint32_t strideW, OvGnaType inPrecision) const {
+bool Validator::ValidateCnn2D(std::string name, const uint32_t inHeight, const uint32_t inWidth,
+    const uint32_t inChannels, const uint32_t kernelH, const uint32_t kernelW, const uint32_t kernelN,
+    const uint32_t strideH, const uint32_t strideW, const uint32_t dilationH, const uint32_t dilationW,
+    OvGnaType inPrecision, bool exception) const {
     const std::string prefix = "Layer Convolution2D: " + name + ":";
     auto error = inputHWLimit.GetErrorOrEmpty(inHeight, inWidth);
 
-    error += kernelNumberLimit.GetErrorOrEmpty(kN);
-
+    error += kernelNumberLimit.GetErrorOrEmpty(kernelN);
     error += inputChannelsNumberLimit.GetErrorOrEmpty(inChannels);
-    error += kernelLimit.GetErrorOrEmpty(kH, kW, inPrecision, inChannels, "kernel");
+    error += kernelLimit.GetErrorOrEmpty(kernelH, kernelW, inPrecision, inChannels, "kernel");
     error += strideLimit.GetErrorOrEmpty(strideH, strideW, inPrecision, inChannels, "convolution stride");
-    ThrowIfNotEmpty(prefix, error);
+
+    const RangeLimit kernelStrideHLimit{1, kernelH, "kernel stride height (must be up to kernel height)"};
+    const RangeLimit kernelStrideWLimit{1, kernelW, "kernel stride width (must be up to kernel width)"};
+
+    error += kernelStrideHLimit.GetErrorOrEmpty(strideH);
+    error += kernelStrideWLimit.GetErrorOrEmpty(strideW);
+
+    error += dilationLimit.GetErrorOrEmpty(dilationH, dilationW);
+
+    if (exception)
+        ThrowIfNotEmpty(prefix, error);
+
+    return error.empty() ? true : false;
 }
 
-void Validator::ValidatePooling2D(std::string name,
+bool Validator::ValidatePooling2D(std::string name,
     const uint32_t windowH, const uint32_t windowW,
-    const uint32_t strideH, const uint32_t strideW) const {
+    const uint32_t strideH, const uint32_t strideW,
+    bool exception) const {
     const std::string prefix = "Layer Pooling2D: " + name + ":";
 
     auto error = poolingWindowLimit.GetErrorOrEmpty(windowH, windowW, "pooling window");
@@ -120,7 +133,10 @@ void Validator::ValidatePooling2D(std::string name,
     error += poolingStrideHLimit.GetErrorOrEmpty(strideH);
     error += poolingStrideWLimit.GetErrorOrEmpty(strideW);
 
-    ThrowIfNotEmpty(prefix, error);
+    if (exception)
+        ThrowIfNotEmpty(prefix, error);
+
+    return error.empty() ? true : false;
 }
 
 void Validator::ThrowIfNotEmpty(const std::string prefix, const std::string error) {

--- a/inference-engine/src/gna_plugin/backend/gna_limitations.hpp
+++ b/inference-engine/src/gna_plugin/backend/gna_limitations.hpp
@@ -16,6 +16,8 @@ constexpr uint32_t bufferMaxSize = 65528;
 
 constexpr uint32_t convMinFiltersNum = 4;
 constexpr uint32_t convMaxFiltersNum = 65532;
+constexpr uint32_t convDilationHeight = 1;
+constexpr uint32_t convDilationWidth = 1;
 constexpr uint32_t convFiltersNumDivider = 4;
 constexpr uint32_t convFilterSizeDivider = 8;
 constexpr uint32_t convFilterMaxSize = 768;
@@ -97,19 +99,24 @@ class Validator {
         { 240, { 3, 7, 3 }, { 2, 7, 2 } },
         { 120, { 3, 7, 3 }, { 1, 7, 1 } } };
     VectorOrSquareLimitByChannelsAndPrecision& strideLimit = kernelLimit;
+    RangeLimit2D dilationLimit{ {convDilationHeight, convDilationHeight, "dilation height" },
+        { convDilationWidth, convDilationWidth, "dilation width" } };
     const VectorOrSquareLimit poolingWindowLimit{ 3, 1, 1 };
 
     static void ThrowIfNotEmpty(const std::string prefix, const std::string error);
+
 public:
     Validator() = default;
 
-    void ValidateCnn2D(std::string name, const uint32_t inHeight, const uint32_t inWidth,
-        const uint32_t inChannels, const uint32_t kH, const uint32_t kW, const uint32_t kN,
-        const uint32_t strideH, const uint32_t strideW, OvGnaType inPrecision) const;
+    bool ValidateCnn2D(std::string name, const uint32_t inHeight, const uint32_t inWidth,
+        const uint32_t inChannels, const uint32_t kernelH, const uint32_t kernelW, const uint32_t kernelN,
+        const uint32_t strideH, const uint32_t strideW, const uint32_t dilationH, const uint32_t dilationW,
+        OvGnaType inPrecision, bool exception = true) const;
 
-    void ValidatePooling2D(std::string name,
+    bool ValidatePooling2D(std::string name,
         const uint32_t windowH, const uint32_t windowW,
-        const uint32_t strideH, const uint32_t strideW) const;
+        const uint32_t strideH, const uint32_t strideW,
+        bool exception = true) const;
 };
 } // namespace Cnn2D
 

--- a/inference-engine/src/gna_plugin/gna_graph_compiler.cpp
+++ b/inference-engine/src/gna_plugin/gna_graph_compiler.cpp
@@ -580,7 +580,8 @@ void GNAGraphCompiler::finalizeConvolution2DPrimitive(InferenceEngine::CNNLayerP
 
     cnn2dValidator.ValidateCnn2D(layer->name,
         in_height, in_width, in_channels,
-        convolution._kernel_y, convolution._kernel_x, filter_n, convolution._stride_y, convolution._stride_x, inputPrec);
+        convolution._kernel_y, convolution._kernel_x, filter_n, convolution._stride_y, convolution._stride_x,
+        convolution._dilation_y, convolution._dilation_x, inputPrec);
 
     float weight_scale_factor = getScaleFactor(layer, QuantizedDataType::weights);
     float output_scale_factor = getScaleFactor(layer, QuantizedDataType::output);

--- a/inference-engine/src/gna_plugin/transformations/convert_padded_to_valid_convolution.cpp
+++ b/inference-engine/src/gna_plugin/transformations/convert_padded_to_valid_convolution.cpp
@@ -201,20 +201,25 @@ ConvertPaddedToValidConv::ConvertPaddedToValidConv() {
         ngraph::pattern::consumers_count(1));
     auto af1 = ngraph::pattern::wrap_type<ngraph::opset7::Relu, ngraph::opset7::Sigmoid,
         ngraph::opset7::Tanh, ngraph::opset7::Abs, ngraph::opset7::Log, ngraph::opset7::Exp,
-        ngraph::opset7::Sign, ngraph::opset7::Clamp>({bias}, ngraph::pattern::consumers_count(1));
+        ngraph::opset7::Sign, ngraph::opset7::Clamp>({conv}, ngraph::pattern::consumers_count(1));
     auto af2 = ngraph::pattern::wrap_type<ngraph::opset7::Relu, ngraph::opset7::Sigmoid,
         ngraph::opset7::Tanh, ngraph::opset7::Abs, ngraph::opset7::Log, ngraph::opset7::Exp,
-        ngraph::opset7::Sign, ngraph::opset7::Clamp>({fq_bias}, ngraph::pattern::consumers_count(1));
+        ngraph::opset7::Sign, ngraph::opset7::Clamp>({bias}, ngraph::pattern::consumers_count(1));
     auto af3 = ngraph::pattern::wrap_type<ngraph::opset7::Relu, ngraph::opset7::Sigmoid,
         ngraph::opset7::Tanh, ngraph::opset7::Abs, ngraph::opset7::Log, ngraph::opset7::Exp,
-        ngraph::opset7::Sign, ngraph::opset7::Clamp>({max_pool1}, ngraph::pattern::consumers_count(1));
+        ngraph::opset7::Sign, ngraph::opset7::Clamp>({fq_bias}, ngraph::pattern::consumers_count(1));
     auto af4 = ngraph::pattern::wrap_type<ngraph::opset7::Relu, ngraph::opset7::Sigmoid,
         ngraph::opset7::Tanh, ngraph::opset7::Abs, ngraph::opset7::Log, ngraph::opset7::Exp,
+        ngraph::opset7::Sign, ngraph::opset7::Clamp>({max_pool1}, ngraph::pattern::consumers_count(1));
+    auto af5 = ngraph::pattern::wrap_type<ngraph::opset7::Relu, ngraph::opset7::Sigmoid,
+        ngraph::opset7::Tanh, ngraph::opset7::Abs, ngraph::opset7::Log, ngraph::opset7::Exp,
         ngraph::opset7::Sign, ngraph::opset7::Clamp>({max_pool2}, ngraph::pattern::consumers_count(1));
-    auto fq_af = ngraph::pattern::wrap_type<ngraph::opset7::FakeQuantize>({af4, const_input, const_input, const_input, const_input},
+    auto fq_af1 = ngraph::pattern::wrap_type<ngraph::opset7::FakeQuantize>({af3, const_input, const_input, const_input, const_input},
+        ngraph::pattern::consumers_count(1));
+    auto fq_af2 = ngraph::pattern::wrap_type<ngraph::opset7::FakeQuantize>({af5, const_input, const_input, const_input, const_input},
         ngraph::pattern::consumers_count(1));
     auto transpose_input =
-        std::make_shared<ngraph::pattern::op::Or>(ngraph::OutputVector{conv, bias, max_pool1, max_pool2, fq_bias, af1, af2, af3, af4, fq_af});
+        std::make_shared<ngraph::pattern::op::Or>(ngraph::OutputVector{conv, bias, max_pool1, max_pool2, fq_bias, af1, af2, af3, af4, af5, fq_af1, fq_af2});
     auto trailing_transpose = ngraph::pattern::wrap_type<ngraph::opset7::Transpose>({transpose_input, const_input},
         consumers_and_rank(1, 4));
 

--- a/inference-engine/src/gna_plugin/transformations/decompose_2d_convolution.hpp
+++ b/inference-engine/src/gna_plugin/transformations/decompose_2d_convolution.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <ngraph/pass/graph_rewrite.hpp>
+#include <ie_precision.hpp>
 
 namespace GNAPluginNS {
 
@@ -30,7 +31,7 @@ namespace GNAPluginNS {
 class Decompose2DConv : public ngraph::pass::MatcherPass {
 public:
     NGRAPH_RTTI_DECLARATION;
-    Decompose2DConv();
+    Decompose2DConv(const std::string& gnaCompileTarget, const InferenceEngine::Precision& gnaPrecision);
 };
 
 /**
@@ -51,7 +52,7 @@ public:
 class Decompose2DConvTransposedWithBias : public ngraph::pass::MatcherPass {
 public:
     NGRAPH_RTTI_DECLARATION;
-    Decompose2DConvTransposedWithBias();
+    Decompose2DConvTransposedWithBias(const std::string& gnaCompileTarget, const InferenceEngine::Precision& gnaPrecision);
 };
 
 /**
@@ -74,7 +75,7 @@ public:
 class Decompose2DConvTransposedWithBiasAF : public ngraph::pass::MatcherPass {
 public:
     NGRAPH_RTTI_DECLARATION;
-    Decompose2DConvTransposedWithBiasAF();
+    Decompose2DConvTransposedWithBiasAF(const std::string& gnaCompileTarget, const InferenceEngine::Precision& gnaPrecision);
 };
 
 } // namespace GNAPluginNS

--- a/inference-engine/src/gna_plugin/transformations/utils/transformation_helper.cpp
+++ b/inference-engine/src/gna_plugin/transformations/utils/transformation_helper.cpp
@@ -73,8 +73,8 @@ std::shared_ptr<ngraph::opset7::StridedSlice> FlatCrop(ngraph::Output<ngraph::No
         std::vector<int64_t>{1, 0});                                                                            // end mask
 }
 
-std::shared_ptr<ngraph::Node> VerifyBiasGetConst(std::shared_ptr<ngraph::Node> conv, std::shared_ptr<ngraph::Node> bias) {
-    auto add_const = std::dynamic_pointer_cast<ngraph::opset7::Constant>(bias->input_value(1).get_node_shared_ptr());
+std::shared_ptr<ngraph::Node> VerifyBiasGetConst(std::shared_ptr<ngraph::Node> conv, std::shared_ptr<ngraph::Node> add) {
+    auto add_const = std::dynamic_pointer_cast<ngraph::opset7::Constant>(add->input_value(1).get_node_shared_ptr());
 
     // Check if it's really a bias and not just addition
     if (add_const) {

--- a/inference-engine/src/gna_plugin/transformations/utils/transformation_helper.hpp
+++ b/inference-engine/src/gna_plugin/transformations/utils/transformation_helper.hpp
@@ -65,13 +65,13 @@ std::shared_ptr<ngraph::opset7::StridedSlice> FlatCrop(ngraph::Output<ngraph::No
 /**
  * @brief checks whether an add present after convolution is a bias and gets its const input
  * @param conv convolution layer preceding potential bias
- * @param bias potential bias layer passed from ngraph matcher
+ * @param add potential bias layer passed from ngraph matcher
  * @return bias const if the add layer present after convolution is a bias, nullptr otherwise
  */
-std::shared_ptr<ngraph::Node> VerifyBiasGetConst(std::shared_ptr<ngraph::Node> conv, std::shared_ptr<ngraph::Node> bias);
+std::shared_ptr<ngraph::Node> VerifyBiasGetConst(std::shared_ptr<ngraph::Node> conv, std::shared_ptr<ngraph::Node> add);
 
 /**
- * @brief inserts a new fake quantize layer (if it exists) copied from an existing fake quantize layer and conncts it to the output of a given layer
+ * @brief inserts a new fake quantize layer copied from an existing one and connects it to the output of a given layer
  * @param fq_layer existing fake quantize layer to be copied
  * @param last_node the node to which output the new fake quantize layer will be connected
  * @return new fake quantize layer or the last node

--- a/inference-engine/tests/functional/plugin/gna/pass_tests/convert_padded_to_valid_conv.cpp
+++ b/inference-engine/tests/functional/plugin/gna/pass_tests/convert_padded_to_valid_conv.cpp
@@ -25,10 +25,11 @@ namespace LayerTestsDefinitions {
 enum class modelType {
     TranspConvTransp = 0,               /* Transpose(NHWC->NCHW) => Conv => Transpose(NCHW->NHWC) */
     TranspConvBcastAddTransp,           /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => Transpose(NCHW->NHWC) */
+    TranspConvActTransp,                /* Transpose(NHWC->NCHW) => Conv => Activation Function => Transpose(NCHW->NHWC) */
     TranspConvBcastAddMaxPoolTransp,    /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => MaxPooling => Transpose(NCHW->NHWC) (2D Max Pool case) */
     TranspConvBcastAddActTransp,        /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => Activation Function => Transpose(NCHW->NHWC) */
     TranspConvBcastAddMaxPoolActTransp, /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => MaxPool => Activation Function => Transpose(NCHW->NHWC) */
-    TranspConvTranspBcastAdd,           /* Transpose(NHWC->NCHW) => conv => Transpose(NCHW->NHWC) => Bias */
+    TranspConvTranspBcastAdd,           /* Transpose(NHWC->NCHW) => Conv => Transpose(NCHW->NHWC) => Bias */
     TranspConvTranspBcastAddAct         /* Transpose(NHWC->NCHW) => Conv => Transpose(NCHW->NHWC) => Bias => Activation Function */
 };
 
@@ -139,6 +140,13 @@ protected:
         {
             auto bias = std::make_shared<Add>(conv, biasConst);
             lastOp = std::make_shared<Transpose>(bias, transposeOutOrder);
+        }
+        break;
+
+        case modelType::TranspConvActTransp:
+        {
+            auto activation = std::make_shared<Relu>(conv);
+            lastOp = std::make_shared<Transpose>(activation, transposeOutOrder);
         }
         break;
 
@@ -257,6 +265,7 @@ const std::vector<op::PadType> padTypes = {
 const std::vector<modelType> models = {
     modelType::TranspConvTransp,
     modelType::TranspConvBcastAddTransp,
+    modelType::TranspConvActTransp,
     modelType::TranspConvBcastAddActTransp,
     modelType::TranspConvTranspBcastAdd,
     modelType::TranspConvTranspBcastAddAct,
@@ -277,8 +286,8 @@ const std::vector<std::vector<size_t >> maxpool1DPools = {{1, 2}};
 const std::vector<std::vector<size_t >> maxpool1DStrides = {{1, 1}};
 
 const std::vector<std::vector<size_t>> input2DNHWC = {{1, 16, 16, 32}};
-const std::vector<std::vector<size_t >> kernels2D = {{2, 2}, {4, 1}, {1, 3}};
-const std::vector<std::vector<size_t >> strides2D = {{1, 1}, {1, 2}, {2, 1}, {2, 2}};
+const std::vector<std::vector<size_t >> kernels2D = {{2, 2}, {4, 1}};
+const std::vector<std::vector<size_t >> strides2D = {{1, 1}, {2, 1}};
 const std::vector<std::vector<ptrdiff_t>> padBegins2D = {{1, 2}};
 const std::vector<std::vector<ptrdiff_t>> padEnds2D = {{3, 1}};
 const std::vector<std::vector<size_t >> dilations2D = {{1, 1}};

--- a/inference-engine/tests/functional/plugin/gna/pass_tests/decompose_2d_conv.cpp
+++ b/inference-engine/tests/functional/plugin/gna/pass_tests/decompose_2d_conv.cpp
@@ -24,6 +24,7 @@ namespace LayerTestsDefinitions {
 enum class modelType {
     TranspConvTransp = 0,               /* Transpose(NHWC->NCHW) => Conv => Transpose(NCHW->NHWC) */
     TranspConvBcastAddTransp,           /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => Transpose(NCHW->NHWC) */
+    TranspConvActTransp,                /* Transpose(NHWC->NCHW) => Conv => Activation Function => Transpose(NCHW->NHWC) */
     TranspConvBcastAddMaxPoolTransp,    /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => MaxPooling => Transpose(NCHW->NHWC) (2D Max Pool case) */
     TranspConvBcastAddActTransp,        /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => Activation Function => Transpose(NCHW->NHWC) */
     TranspConvBcastAddMaxPoolActTransp, /* Transpose(NHWC->NCHW) => Conv => Broadcasted Add (Bias) => MaxPool => Activation Function => Transpose(NCHW->NHWC) */
@@ -141,13 +142,20 @@ protected:
         }
         break;
 
+        case modelType::TranspConvActTransp:
+        {
+            auto activation = std::make_shared<Relu>(conv);
+            lastOp = std::make_shared<Transpose>(activation, transposeOutOrder);
+        }
+        break;
+
         case modelType::TranspConvBcastAddMaxPoolTransp:
         {
             auto bcastAdd = std::make_shared<Add>(conv, biasConst);
             auto maxpool = std::make_shared<MaxPool>(bcastAdd, maxpoolStrides, Shape{0, 0}, Shape{0, 0}, maxpoolShape,
                 op::RoundingType::FLOOR, op::PadType::VALID);
             auto transpose = std::make_shared<Transpose>(maxpool, transposeOutOrder);
-            auto lastOp = std::make_shared<Relu>(transpose);
+            lastOp = std::make_shared<Relu>(transpose);
         }
         break;
 
@@ -221,6 +229,7 @@ const std::vector<op::PadType> padTypes = {
 const std::vector<modelType> models = {
     modelType::TranspConvTransp,
     modelType::TranspConvBcastAddTransp,
+    modelType::TranspConvActTransp,
     modelType::TranspConvBcastAddActTransp,
     modelType::TranspConvTranspBcastAdd,
     modelType::TranspConvTranspBcastAddAct,
@@ -236,9 +245,9 @@ const std::vector<std::vector<ptrdiff_t>> padEnds2D = {{3, 1}};
 const std::vector<std::vector<size_t >> dilations2D = {{1, 1}, {1, 2}, {2, 1}, {2, 2}};
 const std::vector<size_t> numOutChannels2D = {4};
 const std::vector<std::vector<size_t >> biases2D = {{1, 4, 1, 1}};
-const std::vector<std::vector<size_t >> transp_biases2D = {{1, 1, 1, 4}};
-const std::vector<std::vector<size_t >> maxpool1D_pools = {{1, 2}};
-const std::vector<std::vector<size_t >> maxpool1D_strides = {{1, 1}};
+const std::vector<std::vector<size_t >> transpBiases2D = {{1, 1, 1, 4}};
+const std::vector<std::vector<size_t >> maxpool1DPools = {{1, 2}};
+const std::vector<std::vector<size_t >> maxpool1DStrides = {{1, 1}};
 
 const auto conv2DParams = ::testing::Combine(
     ::testing::ValuesIn(kernels2D),
@@ -252,9 +261,9 @@ const auto conv2DParams = ::testing::Combine(
 
 const auto miscParams = ::testing::Combine(
     ::testing::ValuesIn(biases2D),
-    ::testing::ValuesIn(transp_biases2D),
-    ::testing::ValuesIn(maxpool1D_pools),
-    ::testing::ValuesIn(maxpool1D_strides)
+    ::testing::ValuesIn(transpBiases2D),
+    ::testing::ValuesIn(maxpool1DPools),
+    ::testing::ValuesIn(maxpool1DStrides)
 );
 
 INSTANTIATE_TEST_CASE_P(smoke_Decompose2DConv, Decompose2DConvTest,
@@ -311,6 +320,62 @@ INSTANTIATE_TEST_CASE_P(smoke_Decompose2DConvStridesDilations, Decompose2DConvTe
         ::testing::ValuesIn(configsStrides),
         ::testing::ValuesIn(input2DNHWCStrides),
         ::testing::ValuesIn(modelsStrides)),
+    Decompose2DConvTest::getTestCaseName);
+
+/* ============= GNA 3.0 Supported Convolutions Combination ============= */
+
+const std::vector<std::map<std::string, std::string>> configsGNA30 = {
+    {
+        {"GNA_DEVICE_MODE", "GNA_SW_EXACT"},
+        {"GNA_SCALE_FACTOR_0", "1"},
+        {"GNA_EXEC_TARGET", "GNA_TARGET_3_0"}
+    }
+};
+
+const std::vector<op::PadType> padTypesGNA30 = {
+    op::PadType::VALID,
+};
+
+const std::vector<modelType> modelsGNA30 = {
+    modelType::TranspConvBcastAddMaxPoolTransp,
+};
+
+const std::vector<std::vector<size_t>> input2DNHWCGNA30 = {{1, 16, 16, 32}};
+const std::vector<std::vector<size_t >> kernels2DGNA30 = {{1, 2}, {1, 4}};
+const std::vector<std::vector<size_t >> strides2DGNA30 = {{1, 1}};
+const std::vector<std::vector<size_t >> dilations2DGNA30 = {{1, 1}, {1, 2}};
+const std::vector<size_t> numOutChannels2DGNA30 = {8};
+const std::vector<std::vector<size_t >> biases2DGNA30 = {{1, 8, 1, 1}};
+const std::vector<std::vector<size_t >> transpBiases2DGNA30 = {{1, 1, 1, 8}};
+const std::vector<std::vector<size_t >> maxpool2DPoolsGNA30 = {{1, 1}, {1, 2}};
+const std::vector<std::vector<size_t >> maxpoo2DStridesGNA30 = {{1, 1}};
+
+const auto conv2DParamsGNA30 = ::testing::Combine(
+    ::testing::ValuesIn(kernels2DGNA30),
+    ::testing::ValuesIn(strides2DGNA30),
+    ::testing::ValuesIn(padBegins2D),
+    ::testing::ValuesIn(padEnds2D),
+    ::testing::ValuesIn(dilations2DGNA30),
+    ::testing::ValuesIn(numOutChannels2DGNA30),
+    ::testing::ValuesIn(padTypesGNA30)
+);
+
+const auto miscParamsGNA30 = ::testing::Combine(
+    ::testing::ValuesIn(biases2DGNA30),
+    ::testing::ValuesIn(transpBiases2DGNA30),
+    ::testing::ValuesIn(maxpool2DPoolsGNA30),
+    ::testing::ValuesIn(maxpoo2DStridesGNA30)
+);
+
+INSTANTIATE_TEST_CASE_P(smoke_Decompose2DConvGNA30, Decompose2DConvTest,
+    ::testing::Combine(
+        conv2DParamsGNA30,
+        miscParamsGNA30,
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(CommonTestUtils::DEVICE_GNA),
+        ::testing::ValuesIn(configsGNA30),
+        ::testing::ValuesIn(input2DNHWCGNA30),
+        ::testing::ValuesIn(modelsGNA30)),
     Decompose2DConvTest::getTestCaseName);
 
 } // namespace LayerTestsDefinitions


### PR DESCRIPTION
### Details:
 - enable 2D convolution decomposition also on GNA 3.0 platforms
 - 2D convolution supported by GNA 3.0 HW will not be decomposed by OV
 - support detection of subgraphs containing activation without bias
 - changes ported back from the releases/2021/4 branch.

### Tickets:
 - 63938.
