### PR TITLE
Add missing spaces between words in string literals

### DIFF
--- a/.ci/openvino-onnx/watchdog/src/watchdog.py
+++ b/.ci/openvino-onnx/watchdog/src/watchdog.py
@@ -486,7 +486,7 @@ class Watchdog:
             self._queue_message(message, message_severity='warning', pr=pr)
         elif build_delta > _BUILD_DURATION_THRESHOLD:
             # CI job take too long, possibly froze - communicate failure
-            message = ('ONNX CI job build #{}, for PR #{} started,'
+            message = ('ONNX CI job build #{}, for PR #{} started, '
                        'but did not finish in designated time of {} '
                        'minutes!'.format(build_number, pr_number,
                                          str(_BUILD_DURATION_THRESHOLD.seconds / 60)))

--- a/model-optimizer/extensions/front/tf/non_max_suppression_ext.py
+++ b/model-optimizer/extensions/front/tf/non_max_suppression_ext.py
@@ -39,7 +39,7 @@ class NonMaxSuppressionV4Extractor(FrontExtractorOp):
     def extract(cls, node):
         pad_to_max_output_size = node.pb.attr["pad_to_max_output_size:"].b
         if not pad_to_max_output_size:
-            log.warning('The attribute "pad_to_max_output_size" of node {} is equal to False which is not supported.'
+            log.warning('The attribute "pad_to_max_output_size" of node {} is equal to False which is not supported. '
                         'Forcing it to be equal to True'.format(node.soft_get('name')))
         attrs = {'sort_result_descending': 1, 'box_encoding': 'corner', 'output_type': np.int32}
         NonMaxSuppression.update_node_stat(node, attrs)
@@ -54,7 +54,7 @@ class NonMaxSuppressionV5Extractor(FrontExtractorOp):
     def extract(cls, node):
         pad_to_max_output_size = node.pb.attr["pad_to_max_output_size:"].b
         if not pad_to_max_output_size:
-            log.warning('The attribute "pad_to_max_output_size" of node {} is equal to False which is not supported.'
+            log.warning('The attribute "pad_to_max_output_size" of node {} is equal to False which is not supported. '
                         'Forcing it to be equal to True'.format(node.soft_get('name')))
         attrs = {'sort_result_descending': 1, 'box_encoding': 'corner', 'output_type': np.int32}
         NonMaxSuppression.update_node_stat(node, attrs)

--- a/model-optimizer/extensions/load/tf/loader.py
+++ b/model-optimizer/extensions/load/tf/loader.py
@@ -55,7 +55,7 @@ class TFLoader(Loader):
         except:
             log.warning("TensorFlow post-processing of loaded model was unsuccessful. "
                         "This is an optional step that Model Optimizer performs for any input model but it is not usually "
-                        "required for all models."
+                        "required for all models. "
                         "It likely means that the original model is ill-formed. "
                         "Model Optimizer will continue converting this model.")
 

--- a/model-optimizer/extensions/middle/StridedSliceNormalizer.py
+++ b/model-optimizer/extensions/middle/StridedSliceNormalizer.py
@@ -198,7 +198,7 @@ class StridedSliceNormalizer(MiddleReplacementPattern):
                 # concat already exists
                 concat = node.in_port(i).get_source().node
                 last_in_port = max(concat.in_ports().keys())
-                assert not concat.in_port(last_in_port).disconnected(), 'The last in_port of Concat node {}' \
+                assert not concat.in_port(last_in_port).disconnected(), 'The last in_port of Concat node {} ' \
                                                                         'should be connected'. \
                     format(concat.soft_get('name', node.id))
 

--- a/model-optimizer/extensions/middle/TensorIteratorInput.py
+++ b/model-optimizer/extensions/middle/TensorIteratorInput.py
@@ -131,7 +131,7 @@ class SmartInputMatcher(MiddleReplacementPattern):
             if shape['kind'] == 'op' and shape['op'] == 'Const':
                 start = 0
                 end = shape.value[0]
-                log.warning("Your network cannot be reshaped since shapes of placeholders are constants."
+                log.warning("Your network cannot be reshaped since shapes of placeholders are constants. "
                             "Please, provide non-constant shapes. ")
 
         # Create input node with params

--- a/model-optimizer/extensions/ops/If.py
+++ b/model-optimizer/extensions/ops/If.py
@@ -232,10 +232,10 @@ class If(Op):
         else_outputs = [node for node in if_node.else_graph.get_op_nodes() if node.has('output_id')]
         outputs_mapping = {}
         outputs_number = len(if_node.out_ports())
-        assert outputs_number == len(then_outputs), 'Incorrect number outputs in then_graph of If with"' \
+        assert outputs_number == len(then_outputs), 'Incorrect number outputs in then_graph of If with ' \
                                                     'name {0}! then_graph must has {1} outputs' \
             .format(if_node.name, outputs_number)
-        assert outputs_number == len(else_outputs), 'Incorrect number outputs in else_graph of If with"' \
+        assert outputs_number == len(else_outputs), 'Incorrect number outputs in else_graph of If with ' \
                                                     'name {0}! else_graph must has {1} outputs' \
             .format(if_node.name, outputs_number)
         for port_id in if_node.out_ports().keys():

--- a/model-optimizer/mo/front/caffe/extractor.py
+++ b/model-optimizer/mo/front/caffe/extractor.py
@@ -87,7 +87,7 @@ def register_caffe_python_extractor(op: Op, name: str = None):
     if not name and hasattr(op, 'op'):
         name = op.op
     if not name:
-        raise Error("Can not register Op {}. Please, call function 'register_caffe_python_extractor'"
+        raise Error("Can not register Op {}. Please, call function 'register_caffe_python_extractor' "
                     "with parameter 'name' .".format(op),
                     refer_to_faq_msg(87))
     CaffePythonFrontExtractorOp.registered_ops[name] = lambda node: extension_op_extractor(node, op)

--- a/model-optimizer/mo/front/caffe/loader.py
+++ b/model-optimizer/mo/front/caffe/loader.py
@@ -93,7 +93,7 @@ def load_caffe_proto_model(caffe_pb2, proto_path: str, model_path: [str, None] =
                            'Run: set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=cpp \n'
         except ImportError:
             # 3. cpp implementation is not available
-            message += 'However you can use the C++ protobuf implementation that is supplied with the OpenVINO toolkit' \
+            message += 'However you can use the C++ protobuf implementation that is supplied with the OpenVINO toolkit ' \
                        'or build protobuf library from sources. \n' \
                        'Navigate to "install_prerequisites" folder and run: ' \
                        'python -m easy_install protobuf-3.5.1-py($your_python_version)-win-amd64.egg \n' \

--- a/model-optimizer/mo/utils/cli_parser.py
+++ b/model-optimizer/mo/utils/cli_parser.py
@@ -528,7 +528,7 @@ def get_tf_cli_parser(parser: argparse.ArgumentParser = None):
                           action=CanonicalizePathCheckExistenceAction,
                           type=readable_file)
     tf_group.add_argument('--saved_model_dir', default=None,
-                          help='TensorFlow*: directory with a model in SavedModel format'
+                          help='TensorFlow*: directory with a model in SavedModel format '
                                'of TensorFlow 1.x or 2.x version.',
                           action=CanonicalizePathCheckExistenceAction,
                           type=readable_dirs)
@@ -949,7 +949,7 @@ def parse_tuple_pairs(argv_values: str):
 
     matches = [m for m in re.finditer(r'[(\[]([0-9., -]+)[)\]]', argv_values, re.IGNORECASE)]
 
-    error_msg = 'Mean/scale values should consist of name and values specified in round or square brackets' \
+    error_msg = 'Mean/scale values should consist of name and values specified in round or square brackets ' \
                 'separated by comma, e.g. data(1,2,3),info[2,3,4],egg[255] or data(1,2,3). Or just plain set of ' \
                 'values without names: (1,2,3),(2,3,4) or [1,2,3],[2,3,4].' + refer_to_faq_msg(101)
     if not matches:

--- a/model-optimizer/unit_tests/mo/front/caffe/loader_test.py
+++ b/model-optimizer/unit_tests/mo/front/caffe/loader_test.py
@@ -32,7 +32,7 @@ proto_str_old_styled_multi_input = 'name: "network" ' \
                                    'input_dim: 3 ' \
                                    'input_dim: 224 ' \
                                    'input_dim: 224 ' \
-                                   'input: "data"' \
+                                   'input: "data" ' \
                                    'input_dim: 1 ' \
                                    'input_dim: 3 '
 
@@ -55,7 +55,7 @@ proto_str_multi_input = 'name: "network" ' \
                         'dim: 224 ' \
                         'dim: 224 ' \
                         '} ' \
-                        'input: "data1"' \
+                        'input: "data1" ' \
                         'input_shape ' \
                         '{ ' \
                         'dim: 1 ' \
@@ -81,7 +81,7 @@ proto_same_name_layers = 'layer { ' \
                          'type: "Convolution" ' \
                          'bottom: "data" ' \
                          'top: "conv1" ' \
-                         '}' \
+                         '} ' \
                          'layer { ' \
                          'name: "conv1" ' \
                          'type: "Convolution" ' \

--- a/model-optimizer/unit_tests/mo/frontend_ngraph_test_actual.py
+++ b/model-optimizer/unit_tests/mo/frontend_ngraph_test_actual.py
@@ -29,7 +29,7 @@ try:
     from ngraph.utils.types import get_element_type
 
 except Exception:
-    print("No mock frontend API available,"
+    print("No mock frontend API available, "
           "ensure to use -DENABLE_TESTS=ON option when running these tests")
     mock_available = False
 

--- a/model-optimizer/unit_tests/mo/moc_frontend/moc_extractor_test_actual.py
+++ b/model-optimizer/unit_tests/mo/moc_frontend/moc_extractor_test_actual.py
@@ -21,7 +21,7 @@ try:
     from ngraph.frontend import FrontEndManager
 
 except Exception:
-    print("No mock frontend API available,"
+    print("No mock frontend API available, "
           "ensure to use -DENABLE_TESTS=ON option when running these tests")
     mock_available = False
 

--- a/runtime/bindings/python/tests/__init__.py
+++ b/runtime/bindings/python/tests/__init__.py
@@ -23,65 +23,65 @@ def xfail_test(reason="Mark the test as expected to fail", strict=True):
 
 
 skip_segfault = pytest.mark.skip(reason="Segmentation fault error")
-xfail_issue_33488 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations:"
+xfail_issue_33488 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations: "
                                       "MaxUnpool")
-xfail_issue_33538 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations:"
+xfail_issue_33538 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations: "
                                       "Scan")
 skip_issue_38084 = pytest.mark.skip(reason="Aborted (core dumped) Assertion "
                                            "`(layer->get_output_partial_shape(i).is_static())' failed.")
-xfail_issue_33589 = xfail_test(reason="nGraph does not support the following ONNX operations:"
+xfail_issue_33589 = xfail_test(reason="nGraph does not support the following ONNX operations: "
                                       "IsNaN and isInf")
-xfail_issue_33595 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations:"
+xfail_issue_33595 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations: "
                                       "Unique")
-xfail_issue_33596 = xfail_test(reason="RuntimeError: nGraph does not support different sequence operations:"
-                                      "ConcatFromSequence, SequenceConstruct, SequenceAt, SplitToSequence,"
+xfail_issue_33596 = xfail_test(reason="RuntimeError: nGraph does not support different sequence operations: "
+                                      "ConcatFromSequence, SequenceConstruct, SequenceAt, SplitToSequence, "
                                       "SequenceEmpty, SequenceInsert, SequenceErase, SequenceLength ")
-xfail_issue_33606 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations:"
+xfail_issue_33606 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations: "
                                       "Det")
-xfail_issue_33651 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations:"
+xfail_issue_33651 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations: "
                                       "TfIdfVectorizer")
-xfail_issue_33581 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations:"
+xfail_issue_33581 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations: "
                                       "GatherElements")
 xfail_issue_33633 = xfail_test(reason="MaxPool: dilations unsupported")
 xfail_issue_35923 = xfail_test(reason="RuntimeError: PReLU without weights is not supported")
 xfail_issue_35927 = xfail_test(reason="RuntimeError: B has zero dimension that is not allowable")
 xfail_issue_36486 = xfail_test(reason="RuntimeError: HardSigmoid operation should be converted "
                                       "to HardSigmoid_IE")
-xfail_issue_38084 = xfail_test(reason="RuntimeError: AssertionFailed: layer->get_output_partial_shape(i)"
-                                      "is_static() nGraph <value> operation with name: <value> cannot be"
-                                      "converted to <value> layer with name: <value> because output"
+xfail_issue_38084 = xfail_test(reason="RuntimeError: AssertionFailed: layer->get_output_partial_shape(i)."
+                                      "is_static() nGraph <value> operation with name: <value> cannot be "
+                                      "converted to <value> layer with name: <value> because output "
                                       "with index 0 contains dynamic shapes: {<value>}. Try to use "
                                       "CNNNetwork::reshape() method in order to specialize shapes "
                                       "before the conversion.")
 xfail_issue_38091 = xfail_test(reason="AssertionError: Mismatched elements")
-xfail_issue_38699 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations:"
+xfail_issue_38699 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations: "
                                       "ai.onnx.preview.training.Gradient")
 xfail_issue_38701 = xfail_test(reason="RuntimeError: unsupported element type: STRING")
 xfail_issue_38706 = xfail_test(reason="RuntimeError: output_3.0 has zero dimension which is not allowed")
 xfail_issue_38708 = xfail_test(reason="RuntimeError: While validating ONNX node '<Node(Slice): y>': "
                                       "Axes input must be constant")
 xfail_issue_38710 = xfail_test(reason="RuntimeError: data has zero dimension which is not allowed")
-xfail_issue_38713 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations:"
+xfail_issue_38713 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations: "
                                       "ai.onnx.preview.training.Momentum")
-xfail_issue_45457 = xfail_test(reason="RuntimeError: Unsupported dynamic ops: v5::Loop"
+xfail_issue_45457 = xfail_test(reason="RuntimeError: Unsupported dynamic ops: v5::Loop "
                                       "Not constant termination condition body output is not supported")
-xfail_issue_38722 = xfail_test(reason="RuntimeError: While validating ONNX nodes MatMulInteger"
-                                      "and QLinearMatMul"
+xfail_issue_38722 = xfail_test(reason="RuntimeError: While validating ONNX nodes MatMulInteger "
+                                      "and QLinearMatMul "
                                       "Input0 scale and input0 zero point shape must be same and 1")
-xfail_issue_38724 = xfail_test(reason="RuntimeError: While validating ONNX node '<Node(Resize): Y>':"
-                                      "tf_crop_and_resize - this type of coordinate transformation mode"
-                                      "is not supported. Choose one of the following modes:"
-                                      "tf_half_pixel_for_nn, asymmetric, align_corners, pytorch_half_pixel,"
+xfail_issue_38724 = xfail_test(reason="RuntimeError: While validating ONNX node '<Node(Resize): Y>': "
+                                      "tf_crop_and_resize - this type of coordinate transformation mode "
+                                      "is not supported. Choose one of the following modes: "
+                                      "tf_half_pixel_for_nn, asymmetric, align_corners, pytorch_half_pixel, "
                                       "half_pixel")
-xfail_issue_38725 = xfail_test(reason="RuntimeError: While validating ONNX node '<Node(Loop):"
+xfail_issue_38725 = xfail_test(reason="RuntimeError: While validating ONNX node '<Node(Loop): "
                                       "value info has no element type specified")
-xfail_issue_38726 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations:"
+xfail_issue_38726 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations: "
                                       "LessOrEqual")
-xfail_issue_38732 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations:"
+xfail_issue_38732 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations: "
                                       "ConvInteger")
-xfail_issue_38734 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations:"
+xfail_issue_38734 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations: "
                                       "ai.onnx.preview.training.Adam")
-xfail_issue_38735 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations:"
+xfail_issue_38735 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations: "
                                       "ai.onnx.preview.training.Adagrad")
 xfail_issue_48052 = xfail_test(reason="Dropout op is not supported in traning mode")
 xfail_issue_45180 = xfail_test(reason="RuntimeError: Unsupported dynamic op: ReduceSum")
@@ -100,8 +100,8 @@ xfail_issue_33593 = xfail_test(reason="Current implementation of MaxPool doesn't
 xfail_issue_55760 = xfail_test(reason="RuntimeError: Reversed axis have axes above the source space shape")
 
 # Model MSFT issues:
-xfail_issue_37957 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations:"
-                                      "com.microsoft.CropAndResize, com.microsoft.GatherND,"
+xfail_issue_37957 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations: "
+                                      "com.microsoft.CropAndResize, com.microsoft.GatherND, "
                                       "com.microsoft.Pad, com.microsoft.Range")
 xfail_issue_39669 = xfail_test(reason="AssertionError: This model has no test data")
 xfail_issue_36534 = xfail_test(reason="RuntimeError: node input index is out of range")

--- a/tests/stress_tests/scripts/run_memcheck.py
+++ b/tests/stress_tests/scripts/run_memcheck.py
@@ -140,7 +140,7 @@ def main():
         else:
             if list(glob(os.path.join(args.output_dir, '**', '*.log'), recursive=True)):
                 logging.error(
-                    'Output directory %s already has test logs.'
+                    'Output directory %s already has test logs. '
                     'Please specify an empty directory for output logs',
                     args.output_dir)
                 sys.exit(1)

--- a/tools/benchmark_tool/openvino/tools/benchmark/main.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/main.py
@@ -126,7 +126,7 @@ def run(args):
                 elif key not in config[device].keys() and args.api_type == "async" and not is_flag_set_in_command_line('hint'):
                     ## set the _AUTO value for the #streams
                     logger.warning(f"-nstreams default value is determined automatically for {device} device. " +
-                                   "Although the automatic selection usually provides a reasonable performance,"
+                                   "Although the automatic selection usually provides a reasonable performance, "
                                    "but it still may be non-optimal for some cases, for more information look at README.")
                     if device != MYRIAD_DEVICE_NAME:  ## MYRIAD sets the default number of streams implicitly
                         config[device][key] = device + "_THROUGHPUT_AUTO"

--- a/tools/benchmark_tool/openvino/tools/benchmark/parameters.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/parameters.py
@@ -49,9 +49,9 @@ def parse_args():
                       help='Optional. Required for GPU custom kernels. Absolute path to an .xml file with the '
                            'kernels description.')
     args.add_argument('-hint', '--perf_hint', type=str, required=False, default='', choices=['throughput', 'latency'],
-                      help='Optional. Performance hint (optimize for latency or throughput).'
-                            'The hint allows the OpenVINO device to select the right network-specific settings,'
-                            'as opposite to accepting specific values like  \'nstreams\' from the command line.'
+                      help='Optional. Performance hint (optimize for latency or throughput). '
+                            'The hint allows the OpenVINO device to select the right network-specific settings, '
+                            'as opposite to accepting specific values like  \'nstreams\' from the command line. '
                             'So you can specify just the hint without adding explicit device-specific options')
     args.add_argument('-api', '--api_type', type=str, required=False, default='async', choices=['sync', 'async'],
                       help='Optional. Enable using sync/async API. Default value is async.')
@@ -101,8 +101,8 @@ def parse_args():
     args.add_argument('-pin', '--infer_threads_pinning', type=str, required=False,  choices=['YES', 'NO', 'NUMA', 'HYBRID_AWARE'],
                       help='Optional. Enable  threads->cores (\'YES\' which is OpenVINO runtime\'s default for conventional CPUs), '
                            'threads->(NUMA)nodes (\'NUMA\'), '
-                           'threads->appropriate core types (\'HYBRID_AWARE\', which is OpenVINO runtime\'s default for Hybrid CPUs)'
-                           'or completely disable (\'NO\')'
+                           'threads->appropriate core types (\'HYBRID_AWARE\', which is OpenVINO runtime\'s default for Hybrid CPUs) '
+                           'or completely disable (\'NO\') '
                            'CPU threads pinning for CPU-involved inference.')
     args.add_argument('-exec_graph_path', '--exec_graph_path', type=str, required=False,
                       help='Optional. Path to a file where to store executable graph information serialized.')

--- a/tools/deployment_manager/deployman/main.py
+++ b/tools/deployment_manager/deployman/main.py
@@ -183,7 +183,7 @@ def main():
 
     parser = argparse.ArgumentParser(description="", formatter_class=argparse.RawTextHelpFormatter)
 
-    parser.add_argument("--targets", nargs="+", help="List of targets."
+    parser.add_argument("--targets", nargs="+", help="List of targets. "
                                                      "Possible values: \n{}".format(help_msg))
     parser.add_argument("--user_data", type=str, help="Path to user data that will be added to "
                                                       "the deployment package", default=None)


### PR DESCRIPTION
### Details:
When breaking up long sentences into multiple consecutive string literals, it's easy to forget to add a space at the end of the first literal (or at the beginning of the second literal), which results in words being jammed together in the final sentence. This fixes a bunch of such errors.

I found these by using the following script:

```python
#!/usr/bin/env python3

import ast
import token
import tokenize
import sys

def main():
    for path in sys.argv[1:]:
        with open(path, 'rb') as f:
            previous_had_no_space = False

            for t in tokenize.tokenize(f.readline):
                if t.type == tokenize.NL: continue

                current_has_no_space = False

                if t.type == token.STRING:
                    try:
                        string_value = ast.literal_eval(t.string)
                    except ValueError:
                        pass
                    else:
                        if isinstance(string_value, str) and string_value:
                            if previous_had_no_space and not string_value[0].isspace():
                                print(f"{path}:{t.start[0]}:{t.start[1]+1}")
                            if not string_value[-1].isspace():
                                current_has_no_space = True

                previous_had_no_space = current_has_no_space

if __name__ == '__main__':
    main()
```

In one of the cases, a period was more appropriate than a space, so I added that instead.

### Tickets:
N/A
