### PR TITLE
[OV20] ov::Layout improvements

### DIFF
--- a/ngraph/core/include/openvino/core/descriptor/tensor.hpp
+++ b/ngraph/core/include/openvino/core/descriptor/tensor.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <atomic>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -14,6 +15,7 @@
 #include "openvino/core/partial_shape.hpp"
 #include "openvino/core/shape.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/core/variant.hpp"
 
 namespace ngraph {
 namespace runtime {
@@ -74,6 +76,15 @@ public:
     }
     size_t size() const;
 
+    using RTMap = std::map<std::string, std::shared_ptr<Variant>>;
+
+    RTMap& get_rt_info() {
+        return m_rt_info;
+    }
+    const RTMap& get_rt_info() const {
+        return m_rt_info;
+    }
+
 protected:
     element::Type m_element_type;
 
@@ -97,6 +108,7 @@ protected:
     ngraph::HostTensorPtr m_lower_value, m_upper_value;
     std::string m_name;
     std::unordered_set<std::string> m_names;
+    std::map<std::string, std::shared_ptr<Variant>> m_rt_info;
 };
 
 OPENVINO_API

--- a/ngraph/core/include/openvino/op/parameter.hpp
+++ b/ngraph/core/include/openvino/op/parameter.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "openvino/core/layout.hpp"
 #include "openvino/op/op.hpp"
 
 namespace ov {
@@ -49,6 +50,12 @@ public:
     void set_element_type(const element::Type& element_type) {
         m_element_type = element_type;
     }
+
+    bool has_layout() const;
+
+    Layout get_layout() const;
+
+    void set_layout(const Layout& layout);
 
 protected:
     PartialShape m_partial_shape;

--- a/ngraph/core/src/op/parameter.cpp
+++ b/ngraph/core/src/op/parameter.cpp
@@ -48,6 +48,22 @@ void op::Parameter::set_is_relevant_to_shapes(bool is_relevant) {
     m_is_relevant_to_shapes = is_relevant;
 }
 
+bool op::Parameter::has_layout() const {
+    return get_output_tensor(0).get_rt_info().find("LAYOUT") != get_output_tensor(0).get_rt_info().end();
+}
+
+ov::Layout op::Parameter::get_layout() const {
+    auto it = get_output_tensor(0).get_rt_info().find("LAYOUT");
+    OPENVINO_ASSERT(it != get_output_tensor(0).get_rt_info().end(), "Layout for parameter is not set");
+    auto layout = std::dynamic_pointer_cast<VariantWrapper<Layout>>(it->second);
+    OPENVINO_ASSERT(layout, "Layout runtime info for node is invalid");
+    return layout->get();
+}
+
+void op::Parameter::set_layout(const Layout& layout) {
+    get_output_tensor(0).get_rt_info()["LAYOUT"] = std::make_shared<VariantWrapper<Layout>>(layout);
+}
+
 constexpr DiscreteTypeInfo ov::AttributeAdapter<ParameterVector>::type_info;
 
 ov::AttributeAdapter<ParameterVector>::AttributeAdapter(ParameterVector& ref) : m_ref(ref) {}

--- a/ngraph/core/src/preprocess/pre_post_process.cpp
+++ b/ngraph/core/src/preprocess/pre_post_process.cpp
@@ -6,6 +6,7 @@
 
 #include "ngraph/opsets/opset1.hpp"
 #include "openvino/core/function.hpp"
+#include "preprocess_steps_impl.hpp"
 
 namespace ov {
 namespace preprocess {
@@ -17,97 +18,6 @@ struct InputTensorInfo::InputTensorInfoImpl {
 
     element::Type m_type = element::dynamic;
     Layout m_layout = Layout();
-};
-
-static int64_t get_channels_helper(const std::shared_ptr<Node>& node) {
-    auto it = node->get_rt_info().find("LAYOUT");
-    if (it == node->get_rt_info().end()) {
-        return -1;
-    }
-    auto layout = std::dynamic_pointer_cast<VariantWrapper<Layout>>(it->second);
-    OPENVINO_ASSERT(layout, "Layout runtime info for node is invalid");
-    if (!layout::has_channels(layout->get())) {
-        return -1;
-    }
-    return layout::channels(layout->get());
-}
-
-static Shape construct_mean_scale_shape(const std::shared_ptr<Node>& node, size_t values_size) {
-    // TODO: support also Mean/Scale image case
-    auto channels = get_channels_helper(node);
-    OPENVINO_ASSERT(channels >= 0, "Channels dimension is not specified in layout");
-    auto node_shape = node->get_output_partial_shape(0);
-    auto node_rank = node->get_output_partial_shape(0).rank();
-    OPENVINO_ASSERT(node_rank.is_static(), "Mean/scale vector operation is not supported for fully dynamic shape");
-    OPENVINO_ASSERT(node_rank.get_length() > channels, "Channels dimension is out of bounds");
-    OPENVINO_ASSERT(node_shape[channels] == values_size, "Number of channels and mean/values size mismatch");
-    std::vector<std::size_t> v(node_rank.get_length(), 1);
-    v[channels] = values_size;
-    return {v};
-}
-
-static void propagate_layout(const std::shared_ptr<Node>& src, const std::shared_ptr<Node>& dst) {
-    if (src->get_rt_info().count("LAYOUT")) {
-        dst->get_rt_info()["LAYOUT"] = src->get_rt_info()["LAYOUT"];
-    }
-}
-
-/// \brief PreProcessStepsImpl - internal data structure
-struct PreProcessSteps::PreProcessStepsImpl {
-    void add_scale_impl(const std::vector<float>& values) {
-        m_actions.emplace_back(std::make_tuple(
-            [values](const std::shared_ptr<Node>& node) {
-                Shape shape;
-                if (values.size() == 1) {
-                    shape = Shape{1};
-                } else {
-                    shape = construct_mean_scale_shape(node, values.size());
-                }
-                auto constant = op::v0::Constant::create(element::f32, shape, values);
-                constant->set_friendly_name(node->get_friendly_name() + "/scale/Divide_Factor");
-
-                auto new_op = std::make_shared<op::v1::Divide>(node, constant);
-                new_op->set_friendly_name(node->get_friendly_name() + "/scale/Divide");
-                propagate_layout(node, new_op);
-                return new_op;
-            },
-            false));
-    }
-
-    void add_mean_impl(const std::vector<float>& values) {
-        m_actions.emplace_back(std::make_tuple(
-            [values](const std::shared_ptr<Node>& node) {
-                Shape shape;
-                if (values.size() == 1) {
-                    shape = Shape{1};
-                } else {
-                    shape = construct_mean_scale_shape(node, values.size());
-                }
-                auto constant = op::v0::Constant::create(element::f32, shape, values);
-                constant->set_friendly_name(node->get_friendly_name() + "/mean/Mean_Const");
-
-                auto new_op = std::make_shared<op::v1::Subtract>(node, constant);
-                new_op->set_friendly_name(node->get_friendly_name() + "/mean/Subtract");
-                propagate_layout(node, new_op);
-                return new_op;
-            },
-            false));
-    }
-
-    void add_convert_impl(const element::Type& type) {
-        m_actions.emplace_back(std::make_tuple(
-            [type](const std::shared_ptr<Node>& node) {
-                if (node->get_element_type().is_dynamic()) {
-                    throw ngraph::ngraph_error("Can't insert 'convert_element_type' for dynamic source tensor type.");
-                }
-                auto convert = std::make_shared<op::v0::Convert>(node, type);
-                convert->set_friendly_name(node->get_friendly_name() + "/convert_element_type");
-                propagate_layout(node, convert);
-                return convert;
-            },
-            true));
-    }
-    std::list<std::tuple<PreProcessSteps::CustomPreprocessOp, bool>> m_actions;
 };
 
 /// \brief InputInfoImpl - internal data structure
@@ -201,36 +111,36 @@ std::shared_ptr<Function> PrePostProcessor::build(const std::shared_ptr<Function
         auto new_param_shape = param->get_partial_shape();
         auto new_param = std::make_shared<op::v0::Parameter>(input->m_tensor_data->m_type, new_param_shape);
         if (input->m_tensor_data->m_layout != Layout()) {
-            new_param->get_rt_info()["LAYOUT"] =
-                std::make_shared<VariantWrapper<Layout>>(input->m_tensor_data->m_layout);
+            new_param->set_layout(input->m_tensor_data->m_layout);
         }
         // Old param will be removed, so friendly name can be reused
         new_param->set_friendly_name(param->get_friendly_name());
-        std::shared_ptr<Node> node = new_param;
 
+        // Also reuse names of original tensor
+        new_param->get_output_tensor(0).set_names(param->get_output_tensor(0).get_names());
+
+        std::shared_ptr<Node> node = new_param;
+        PreprocessingContext context(input->m_tensor_data->m_layout);
         // 2. Apply preprocessing
-        for (const auto& action : input->m_preprocess->m_actions) {
-            node = std::get<0>(action)(node);
+        for (const auto& action : input->m_preprocess->actions()) {
+            node = std::get<0>(action)({node}, context);
             tensor_data_updated |= std::get<1>(action);
         }
 
         // Check final type
-        if (node->get_element_type() != param->get_element_type()) {
-            throw ngraph::ngraph_error(
-                std::string("Element type after preprocessing {") + node->get_element_type().c_type_string() +
-                std::string("} doesn't match with network element type {") + param->get_element_type().c_type_string() +
-                "}. Please add 'convert_element_type' explicitly");
-        }
+        OPENVINO_ASSERT(node->get_element_type() == param->get_element_type(),
+                        std::string("Element type after preprocessing {") + node->get_element_type().c_type_string() +
+                            std::string("} doesn't match with network element type {") +
+                            param->get_element_type().c_type_string() +
+                            "}. Please add 'convert_element_type' explicitly");
 
         // Replace parameter
         for (auto consumer : consumers) {
             consumer.replace_source_output(node);
         }
-        if (input->has_index()) {
-            function->replace_parameter(input->m_index, new_param);
-        } else {
-            function->replace_parameter(0, new_param);
-        }
+        function->add_parameters({new_param});
+        // remove old parameter
+        function->remove_parameter(param);
     }
     if (tensor_data_updated) {
         function->validate_nodes_and_infer_types();
@@ -323,13 +233,27 @@ PreProcessSteps&& PreProcessSteps::convert_element_type(const element::Type& typ
 
 PreProcessSteps& PreProcessSteps::custom(const CustomPreprocessOp& preprocess_cb) & {
     // 'true' indicates that custom preprocessing step will trigger validate_and_infer_types
-    m_impl->m_actions.emplace_back(std::make_tuple(preprocess_cb, true));
+    m_impl->actions().emplace_back(std::make_tuple(
+        [preprocess_cb](const std::vector<std::shared_ptr<ov::Node>>& nodes, PreprocessingContext&) {
+            OPENVINO_ASSERT(nodes.size() == 1,
+                            "Can't apply custom preprocessing step for multi-plane input. Suggesting to convert "
+                            "current image to RGB/BGR color format using 'convert_color'");
+            return preprocess_cb(nodes[0]);
+        },
+        true));
     return *this;
 }
 
 PreProcessSteps&& PreProcessSteps::custom(const CustomPreprocessOp& preprocess_cb) && {
     // 'true' indicates that custom preprocessing step will trigger validate_and_infer_types
-    m_impl->m_actions.emplace_back(std::make_tuple(preprocess_cb, true));
+    m_impl->actions().emplace_back(std::make_tuple(
+        [preprocess_cb](const std::vector<std::shared_ptr<ov::Node>>& nodes, PreprocessingContext&) {
+            OPENVINO_ASSERT(nodes.size() == 1,
+                            "Can't apply custom preprocessing step for multi-plane input. Suggesting to convert "
+                            "current image to RGB/BGR color format using 'convert_color'");
+            return preprocess_cb(nodes[0]);
+        },
+        true));
     return std::move(*this);
 }
 

--- a/ngraph/core/src/preprocess/preprocess_steps_impl.cpp
+++ b/ngraph/core/src/preprocess/preprocess_steps_impl.cpp
@@ -1,0 +1,94 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "preprocess_steps_impl.hpp"
+
+#include "ngraph/opsets/opset1.hpp"
+#include "openvino/core/node.hpp"
+#include "openvino/core/shape.hpp"
+
+using namespace ov;
+using namespace ov::preprocess;
+
+static Shape construct_mean_scale_shape(const std::shared_ptr<Node>& node,
+                                        size_t values_size,
+                                        const PreprocessingContext& context) {
+    // TODO: support also Mean/Scale image case
+    OPENVINO_ASSERT(layout::has_channels(context.layout()), "Channels dimension is not specified in layout");
+    auto channels_index = layout::channels(context.layout());
+    auto node_shape = node->get_output_partial_shape(0);
+    auto node_rank = node->get_output_partial_shape(0).rank();
+    OPENVINO_ASSERT(node_rank.is_static(), "Mean/scale vector operation is not supported for fully dynamic shape");
+    std::vector<std::size_t> v(node_rank.get_length(), 1);
+    if (channels_index < 0) {
+        // E.g. channels_index = -1 means last dimension
+        channels_index = node_rank.get_length() + channels_index;
+    }
+    OPENVINO_ASSERT(node_rank.get_length() > channels_index, "Channels dimension is out of bounds");
+    OPENVINO_ASSERT(node_shape[channels_index] == values_size, "Number of channels and mean/values size mismatch");
+    v[channels_index] = values_size;
+    return {v};
+}
+
+void PreProcessSteps::PreProcessStepsImpl::add_scale_impl(const std::vector<float>& values) {
+    m_actions.emplace_back(std::make_tuple(
+        [values](const std::vector<std::shared_ptr<Node>>& nodes, PreprocessingContext& context) {
+            OPENVINO_ASSERT(!nodes.empty(), "Internal error: Can't apply scale preprocessing for empty input.");
+            OPENVINO_ASSERT(nodes.size() == 1,
+                            "Can't apply scale preprocessing for multi-plane input. Suggesting to convert current "
+                            "image to RGB/BGR color format using 'convert_color'");
+            Shape shape;
+            if (values.size() == 1) {
+                shape = Shape{1};
+            } else {
+                shape = construct_mean_scale_shape(nodes[0], values.size(), context);
+            }
+            auto constant = op::v0::Constant::create(element::f32, shape, values);
+            constant->set_friendly_name(nodes[0]->get_friendly_name() + "/scale/Divide_Factor");
+
+            auto new_op = std::make_shared<op::v1::Divide>(nodes[0], constant);
+            new_op->set_friendly_name(nodes[0]->get_friendly_name() + "/scale/Divide");
+            return new_op;
+        },
+        false));
+}
+
+void PreProcessSteps::PreProcessStepsImpl::add_mean_impl(const std::vector<float>& values) {
+    m_actions.emplace_back(std::make_tuple(
+        [values](const std::vector<std::shared_ptr<Node>>& nodes, PreprocessingContext& context) {
+            OPENVINO_ASSERT(!nodes.empty(), "Internal error: Can't apply mean preprocessing for empty input.");
+            OPENVINO_ASSERT(nodes.size() == 1,
+                            "Can't apply scale preprocessing for multi-plane input. Suggesting to convert current "
+                            "image to RGB/BGR color format using 'convert_color'");
+            Shape shape;
+            if (values.size() == 1) {
+                shape = Shape{1};
+            } else {
+                shape = construct_mean_scale_shape(nodes[0], values.size(), context);
+            }
+            auto constant = op::v0::Constant::create(element::f32, shape, values);
+            constant->set_friendly_name(nodes[0]->get_friendly_name() + "/mean/Mean_Const");
+
+            auto new_op = std::make_shared<op::v1::Subtract>(nodes[0], constant);
+            new_op->set_friendly_name(nodes[0]->get_friendly_name() + "/mean/Subtract");
+            return new_op;
+        },
+        false));
+}
+
+void PreProcessSteps::PreProcessStepsImpl::add_convert_impl(const element::Type& type) {
+    m_actions.emplace_back(std::make_tuple(
+        [type](const std::vector<std::shared_ptr<Node>>& nodes, PreprocessingContext&) {
+            OPENVINO_ASSERT(!nodes.empty(), "Internal error: Can't set element type for empty input.");
+            OPENVINO_ASSERT(nodes.size() == 1,
+                            "Can't set element type for multi-plane input. Suggesting to convert current image to "
+                            "RGB/BGR color format using 'convert_color'");
+            OPENVINO_ASSERT(nodes[0]->get_element_type().is_static(),
+                            "Can't insert 'convert_element_type' for dynamic source tensor type.");
+            auto convert = std::make_shared<op::v0::Convert>(nodes[0], type);
+            convert->set_friendly_name(nodes[0]->get_friendly_name() + "/convert_element_type");
+            return convert;
+        },
+        true));
+}

--- a/ngraph/core/src/preprocess/preprocess_steps_impl.hpp
+++ b/ngraph/core/src/preprocess/preprocess_steps_impl.hpp
@@ -1,0 +1,56 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <list>
+
+#include "openvino/core/layout.hpp"
+#include "openvino/core/preprocess/preprocess_steps.hpp"
+
+namespace ov {
+namespace preprocess {
+
+/// \brief Preprocessing context passed to each preprocessing operation.
+/// This is internal structure which is not shared to custom operations yet.
+class PreprocessingContext {
+public:
+    explicit PreprocessingContext(const Layout& layout) : m_layout(layout) {}
+
+    const Layout& layout() const {
+        return m_layout;
+    }
+
+    Layout& layout() {
+        return m_layout;
+    }
+
+private:
+    Layout m_layout;
+};
+
+using InternalPreprocessOp =
+    std::function<std::shared_ptr<ov::Node>(const std::vector<std::shared_ptr<ov::Node>>& nodes,
+                                            PreprocessingContext& context)>;
+
+/// \brief PreProcessStepsImpl - internal data structure
+class PreProcessSteps::PreProcessStepsImpl {
+public:
+    void add_scale_impl(const std::vector<float>& values);
+    void add_mean_impl(const std::vector<float>& values);
+    void add_convert_impl(const element::Type& type);
+
+    const std::list<std::tuple<InternalPreprocessOp, bool>>& actions() const {
+        return m_actions;
+    }
+    std::list<std::tuple<InternalPreprocessOp, bool>>& actions() {
+        return m_actions;
+    }
+
+private:
+    std::list<std::tuple<InternalPreprocessOp, bool>> m_actions;
+};
+
+}  // namespace preprocess
+}  // namespace ov

--- a/ngraph/test/preprocess.cpp
+++ b/ngraph/test/preprocess.cpp
@@ -17,6 +17,7 @@ using namespace ngraph::test;
 static std::shared_ptr<Function> create_simple_function(element::Type type, const PartialShape& shape) {
     auto data1 = std::make_shared<op::v0::Parameter>(type, shape);
     data1->set_friendly_name("input1");
+    data1->get_output_tensor(0).set_names({"tensor_input1"});
     auto res = std::make_shared<op::v0::Result>(data1);
     res->set_friendly_name("Result");
     return std::make_shared<Function>(ResultVector{res}, ParameterVector{data1});
@@ -25,12 +26,14 @@ static std::shared_ptr<Function> create_simple_function(element::Type type, cons
 static std::shared_ptr<Function> create_2inputs(element::Type type, const PartialShape& shape) {
     auto data1 = std::make_shared<op::v0::Parameter>(type, shape);
     data1->set_friendly_name("input1");
+    data1->get_output_tensor(0).set_names({"tensor_input1"});
     auto data2 = std::make_shared<op::v0::Parameter>(type, shape);
     data2->set_friendly_name("input2");
+    data1->get_output_tensor(0).set_names({"tensor_input2"});
     auto res1 = std::make_shared<op::v0::Result>(data1);
-    res1->set_friendly_name("Result");
+    res1->set_friendly_name("Result1");
     auto res2 = std::make_shared<op::v0::Result>(data2);
-    res2->set_friendly_name("Result");
+    res2->set_friendly_name("Result2");
     return std::make_shared<Function>(ResultVector{res1, res2}, ParameterVector{data1, data2});
 }
 
@@ -68,49 +71,52 @@ TEST(pre_post_process, convert_element_type_and_scale) {
                                        .scale(2.f)
                                        .convert_element_type(element::i8)))
             .build(f);
+    EXPECT_EQ(f->get_parameters().front()->get_element_type(), element::i16);
+    EXPECT_FALSE(f->get_parameters().front()->has_layout());
+    EXPECT_EQ(f->get_output_element_type(0), element::i8);
 
     auto result = std::make_shared<HostTensor>();
     f->evaluate({result},
                 {make_host_tensor<element::i16>(Shape{1, 3, 2, 2}, {2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 10000, 200})});
     auto result_val = read_vector<int8_t>(result);
     EXPECT_TRUE(all_close(std::vector<int8_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, (int8_t)5000, 100}, result_val));
-    EXPECT_EQ(f->get_parameters().front()->get_element_type(), element::i16);
-
-    ASSERT_EQ(f->get_output_element_type(0), element::i8);
 }
 
 TEST(pre_post_process, convert_element_type_from_unknown) {
     auto f = create_simple_function(element::i32, Shape{1, 3, 224, 224});
-    ASSERT_ANY_THROW(
+    ASSERT_THROW(
         f = PrePostProcessor()
                 .input(InputInfo().preprocess(
                     PreProcessSteps().convert_element_type(element::dynamic).convert_element_type(element::i32)))
-                .build(f));
+                .build(f),
+        ov::AssertFailure);
 }
 
 TEST(pre_post_process, convert_element_type_no_match) {
     auto f = create_simple_function(element::i32, Shape{1, 3, 224, 224});
-    ASSERT_ANY_THROW(f = PrePostProcessor()
-                             .input(InputInfo()
-                                        .tensor(InputTensorInfo().set_element_type(element::i32))
-                                        .preprocess(PreProcessSteps().convert_element_type(element::f32).scale(2.0f)))
-                             .build(f));
+    ASSERT_THROW(f = PrePostProcessor()
+                         .input(InputInfo()
+                                    .tensor(InputTensorInfo().set_element_type(element::i32))
+                                    .preprocess(PreProcessSteps().convert_element_type(element::f32).scale(2.0f)))
+                         .build(f),
+                 ov::AssertFailure);
 }
 
 TEST(pre_post_process, scale_not_float) {
     auto f = create_simple_function(element::i32, Shape{1, 3, 224, 224});
-    ASSERT_ANY_THROW(
+    ASSERT_THROW(
         f = PrePostProcessor()
                 .input(InputInfo().preprocess(PreProcessSteps().convert_element_type(element::f32).scale(2.0f)))
-                .build(f));
+                .build(f),
+        ov::AssertFailure);
 }
 
 TEST(pre_post_process, mean_not_float) {
     auto f = create_simple_function(element::i32, Shape{1, 3, 224, 224});
-    ASSERT_ANY_THROW(
-        f = PrePostProcessor()
-                .input(InputInfo().preprocess(PreProcessSteps().convert_element_type(element::f32).mean(2.0f)))
-                .build(f));
+    ASSERT_THROW(f = PrePostProcessor()
+                         .input(InputInfo().preprocess(PreProcessSteps().convert_element_type(element::f32).mean(2.0f)))
+                         .build(f),
+                 ov::AssertFailure);
 }
 
 TEST(pre_post_process, tensor_element_type_and_scale) {
@@ -121,13 +127,15 @@ TEST(pre_post_process, tensor_element_type_and_scale) {
                        .preprocess(PreProcessSteps().scale(2.0f).convert_element_type(element::i8)))
             .build(f);
 
+    EXPECT_EQ(f->get_parameters().front()->get_element_type(), element::f32);
+    EXPECT_EQ(f->get_output_element_type(0), element::i8);
+    EXPECT_FALSE(f->get_parameters().front()->has_layout());
+    EXPECT_THROW(f->get_parameters().front()->get_layout(), ov::AssertFailure);
+
     auto result = std::make_shared<HostTensor>();
     f->evaluate({result}, {make_host_tensor<element::f32>(Shape{1, 3, 1, 1}, {2., 4., 6.})});
     auto result_val = read_vector<int8_t>(result);
     EXPECT_TRUE(all_close(std::vector<int8_t>{1, 2, 3}, result_val));
-    EXPECT_EQ(f->get_parameters().front()->get_element_type(), element::f32);
-
-    ASSERT_EQ(f->get_output_element_type(0), element::i8);
 }
 
 TEST(pre_post_process, custom_preprocessing) {
@@ -148,6 +156,8 @@ TEST(pre_post_process, custom_preprocessing) {
 
 TEST(pre_post_process, test_lvalue) {
     auto f = create_simple_function(element::i8, Shape{1, 3, 1, 1});
+    auto name = f->get_parameters()[0]->get_friendly_name();
+    auto tensor_names = f->get_parameters().front()->get_output_tensor(0).get_names();
     auto p = PrePostProcessor();
     auto p1 = std::move(p);
     p = std::move(p1);
@@ -180,14 +190,17 @@ TEST(pre_post_process, test_lvalue) {
     }
     p.input(std::move(inputInfo));
     f = p.build(f);
+    EXPECT_EQ(f->get_parameters().front()->get_element_type(), element::f32);
+    EXPECT_EQ(f->get_parameters().front()->get_friendly_name(), name);
+    EXPECT_TRUE(f->get_parameters().front()->has_layout());
+    EXPECT_EQ(f->get_parameters().front()->get_layout(), "?CHW");
+    EXPECT_EQ(f->get_parameters().front()->get_output_tensor(0).get_names(), tensor_names);
+    EXPECT_EQ(f->get_output_element_type(0), element::i8);
 
     auto result = std::make_shared<HostTensor>();
     f->evaluate({result}, {make_host_tensor<element::f32>(Shape{1, 3, 1, 1}, {-9., 17., -1.})});
     auto result_val = read_vector<int8_t>(result);
     EXPECT_TRUE(all_close(std::vector<int8_t>{3, 2, 1}, result_val));
-    EXPECT_EQ(f->get_parameters().front()->get_element_type(), element::f32);
-
-    ASSERT_EQ(f->get_output_element_type(0), element::i8);
 }
 
 TEST(pre_post_process, test_2_inputs_basic) {
@@ -208,12 +221,18 @@ TEST(pre_post_process, test_2_inputs_basic) {
 
 TEST(pre_post_process, mean_scale_vector_tensor_layout) {
     auto f = create_simple_function(element::f32, PartialShape{Dimension::dynamic(), 3, 2, 1});
+    auto name = f->get_parameters().front()->get_friendly_name();
+    auto tensor_names = f->get_parameters().front()->get_output_tensor(0).get_names();
     ASSERT_EQ(f->get_output_element_type(0), element::f32);
     f = PrePostProcessor()
             .input(InputInfo()
                        .tensor(InputTensorInfo().set_layout("NC??"))
                        .preprocess(PreProcessSteps().mean({1.f, 2.f, 3.f}).scale({2.f, 3.f, 4.f})))
             .build(f);
+    EXPECT_EQ(f->get_parameters().front()->get_friendly_name(), name);
+    EXPECT_TRUE(f->get_parameters().front()->has_layout());
+    EXPECT_EQ(f->get_parameters().front()->get_layout(), "NC??");
+    EXPECT_EQ(f->get_parameters().front()->get_output_tensor(0).get_names(), tensor_names);
 
     auto result = std::make_shared<HostTensor>();
     f->evaluate({result}, {make_host_tensor<ngraph::element::f32>(Shape{1, 3, 2, 1}, {5., 1., 5., 11., 11., -1.})});
@@ -221,19 +240,68 @@ TEST(pre_post_process, mean_scale_vector_tensor_layout) {
     EXPECT_TRUE(all_close_f(std::vector<float>{2., 0., 1., 3., 2., -1.}, result_val));
 }
 
+TEST(pre_post_process, mean_scale_dynamic_layout) {
+    auto f = create_simple_function(element::f32,
+                                    PartialShape{Dimension::dynamic(), Dimension::dynamic(), Dimension::dynamic(), 3});
+    auto name = f->get_parameters().front()->get_friendly_name();
+    auto tensor_names = f->get_parameters().front()->get_output_tensor(0).get_names();
+    ASSERT_EQ(f->get_output_element_type(0), element::f32);
+    f = PrePostProcessor()
+            .input(InputInfo()
+                       .tensor(InputTensorInfo().set_layout("N...C"))
+                       .preprocess(PreProcessSteps().mean({1.f, 2.f, 3.f}).scale({2.f, 3.f, 4.f})))
+            .build(f);
+
+    EXPECT_EQ(f->get_parameters().front()->get_friendly_name(), name);
+    EXPECT_TRUE(f->get_parameters().front()->has_layout());
+    EXPECT_EQ(f->get_parameters().front()->get_layout(), "N...C");
+    EXPECT_EQ(f->get_parameters().front()->get_output_tensor(0).get_names(), tensor_names);
+
+    auto result = std::make_shared<HostTensor>();
+    f->evaluate({result}, {make_host_tensor<ngraph::element::f32>(Shape{1, 2, 1, 3}, {5., 2., 7., 7., 8., -1.})});
+    auto result_val = read_vector<float>(result);
+    EXPECT_TRUE(all_close_f(std::vector<float>{2., 0., 1., 3., 2., -1.}, result_val));
+}
+
 TEST(pre_post_process, scale_vector_no_channels_layout) {
     auto f = create_simple_function(element::f32, Shape{1, 3, 224, 224});
     ASSERT_EQ(f->get_output_element_type(0), element::f32);
-    ASSERT_ANY_THROW(f = PrePostProcessor()
-                             .input(InputInfo()
-                                        .tensor(InputTensorInfo().set_layout("N?HW"))
-                                        .preprocess(PreProcessSteps().scale({0.1f, 0.2f, 0.3f})))
-                             .build(f));
+    ASSERT_THROW(f = PrePostProcessor()
+                         .input(InputInfo()
+                                    .tensor(InputTensorInfo().set_layout("N?HW"))
+                                    .preprocess(PreProcessSteps().scale({0.1f, 0.2f, 0.3f})))
+                         .build(f),
+                 ov::AssertFailure);
+}
+
+TEST(pre_post_process, scale_vector_channels_out_of_range) {
+    auto f = create_simple_function(element::f32, Shape{1, 3, 224, 224});
+    ASSERT_EQ(f->get_output_element_type(0), element::f32);
+    ASSERT_THROW(f = PrePostProcessor()
+                         .input(InputInfo()
+                                    .tensor(InputTensorInfo().set_layout("0123C"))
+                                    .preprocess(PreProcessSteps().scale({0.1f, 0.2f, 0.3f})))
+                         .build(f),
+                 ov::AssertFailure);
 }
 
 TEST(pre_post_process, mean_vector_no_layout) {
     auto f = create_simple_function(element::f32, PartialShape{Dimension::dynamic(), 3, 224, 224});
     ASSERT_EQ(f->get_output_element_type(0), element::f32);
-    ASSERT_ANY_THROW(
-        f = PrePostProcessor().input(InputInfo().preprocess(PreProcessSteps().mean({0.1f, 0.2f, 0.3f}))).build(f));
+    ASSERT_THROW(
+        f = PrePostProcessor().input(InputInfo().preprocess(PreProcessSteps().mean({0.1f, 0.2f, 0.3f}))).build(f),
+        ov::AssertFailure);
+}
+
+TEST(pre_post_process, mean_vector_dynamic_channels_shape) {
+    auto f = create_simple_function(
+        element::f32,
+        PartialShape{Dimension::dynamic(), Dimension::dynamic(), Dimension::dynamic(), Dimension::dynamic()});
+    ASSERT_EQ(f->get_output_element_type(0), element::f32);
+    ASSERT_THROW(f = PrePostProcessor()
+                         .input(InputInfo()
+                                    .tensor(InputTensorInfo().set_layout("NCHW"))
+                                    .preprocess(PreProcessSteps().mean({0.1f, 0.2f, 0.3f})))
+                         .build(f),
+                 ov::AssertFailure);
 }


### PR DESCRIPTION
### Details:
 - Fix leftovers for ov::Layout:
 - Mean/Scale: work with dynamic layout, like "N...C" where 'C' index is negative
 - Added runtime info to Tensor, use it for 'Layout' property
 - Add get_layout/set_layout/has_layout methods for parameter
 - Moved preprocess steps code to separate .cpp file for better readability
 - Preprocess: copy output tensor names of original parameter to new parameter (before preprocessing)
 - Test code coverage = 100%

### Tickets:
 - 65416
