### PR TITLE
[IE PYTHON] add new ngraph function for dynamic shape tests

### DIFF
--- a/inference-engine/ie_bridges/python/tests/conftest.py
+++ b/inference-engine/ie_bridges/python/tests/conftest.py
@@ -51,10 +51,44 @@ def pytest_configure(config):
     )
 
 
-def create_ngraph_function(inputShape):
+def create_encoder(input_shape, levels = 4):
     import ngraph as ng
-    inputShape = ng.impl.PartialShape(inputShape)
-    param = ng.parameter(inputShape, dtype=np.float32, name="data")
-    result = ng.relu(param, name='out')
+    # input
+    input_node = ng.parameter(input_shape, np.float32, name="data")
+
+    padding_begin = padding_end = [0, 0]
+    strides = [1, 1]
+    dilations = [1, 1]
+    input_channels = [input_shape[1]]
+    last_output = input_node
+
+    # convolution layers
+    for i in range(levels):
+        input_c = input_channels[-1]
+        output_c = input_c * 2
+        conv_w = np.random.uniform(0, 1, [output_c, input_c, 5, 5]).astype(np.float32)
+        conv_node = ng.convolution(last_output, conv_w, strides, padding_begin, padding_end, dilations)
+        input_channels.append(output_c)
+        last_output = conv_node
+
+    # deconvolution layers
+    for i in range(levels):
+        input_c = input_channels[-2]
+        output_c = input_channels.pop(-1)
+        deconv_w = np.random.uniform(0, 1, [output_c, input_c, 5, 5]).astype(np.float32)
+        deconv_node = ng.convolution_backprop_data(last_output, deconv_w, strides)
+        last_output = deconv_node
+
+    # result
+    last_output.set_friendly_name("out")
+    result_node = ng.result(last_output)
+    return ng.Function(result_node, [input_node], "Encoder")
+
+
+def create_relu(input_shape):
+    import ngraph as ng
+    input_shape = ng.impl.PartialShape(input_shape)
+    param = ng.parameter(input_shape, dtype=np.float32, name="data")
+    result = ng.relu(param, name="out")
     function  = ng.Function(result, [param], "TestFunction")
     return function

--- a/inference-engine/ie_bridges/python/tests/test_Blob.py
+++ b/inference-engine/ie_bridges/python/tests/test_Blob.py
@@ -140,10 +140,11 @@ def test_set_shape():
 @pytest.mark.ngraph_dependent_test
 @pytest.mark.template_plugin
 def test_blob_set_shape_after_async_infer():
-    from conftest import create_ngraph_function
+    from conftest import create_encoder
     import ngraph as ng
-    function = create_ngraph_function([ng.Dimension(0,5), ng.Dimension(4), ng.Dimension(20), ng.Dimension(20)])
+    function = create_encoder([1, 4, 20, 20])
     net = ng.function_to_cnn(function)
+    net.reshape({"data": [(1, 5), 4, 20, 20]})
     ie_core = IECore()
     ie_core.register_plugin("templatePlugin", "TEMPLATE")
     exec_net = ie_core.load_network(net, "TEMPLATE")
@@ -152,3 +153,4 @@ def test_blob_set_shape_after_async_infer():
     with pytest.raises(RuntimeError) as e:
         request.input_blobs['data'].set_shape([3, 4, 20, 20])
     assert "REQUEST_BUSY" in str(e.value)
+    request.wait()

--- a/inference-engine/ie_bridges/python/tests/test_CDataPtr.py
+++ b/inference-engine/ie_bridges/python/tests/test_CDataPtr.py
@@ -61,9 +61,9 @@ def test_initialized(device):
 @pytest.mark.ngraph_dependent_test
 @pytest.mark.template_plugin
 def test_is_dynamic():
-    from conftest import create_ngraph_function
+    from conftest import create_relu
     import ngraph as ng
-    function = create_ngraph_function([-1, 3, 20, 20])
+    function = create_relu([-1, 3, 20, 20])
     net = ng.function_to_cnn(function)
     ie = IECore()
     ie.register_plugin("templatePlugin", "TEMPLATE")

--- a/inference-engine/ie_bridges/python/tests/test_DataPtr.py
+++ b/inference-engine/ie_bridges/python/tests/test_DataPtr.py
@@ -48,9 +48,9 @@ def test_initialized():
 @pytest.mark.ngraph_dependent_test
 @pytest.mark.template_plugin
 def test_is_dynamic():
-    from conftest import create_ngraph_function
+    from conftest import create_relu
     import ngraph as ng
-    function = create_ngraph_function([-1, 3, 20, 20])
+    function = create_relu([-1, 3, 20, 20])
     net = ng.function_to_cnn(function)
     assert net.input_info["data"].input_data.is_dynamic
     assert net.outputs["out"].is_dynamic

--- a/inference-engine/ie_bridges/python/tests/test_IENetwork.py
+++ b/inference-engine/ie_bridges/python/tests/test_IENetwork.py
@@ -166,9 +166,9 @@ def test_reshape():
     ([1, 3, -1, 25], [1, 3, 22, -1])
 ])
 def test_reshape_with_partial_shape(device, shape, p_shape):
-    from conftest import create_ngraph_function
+    from conftest import create_relu
     import ngraph as ng
-    function = create_ngraph_function(shape)
+    function = create_relu(shape)
     net = ng.function_to_cnn(function)
     net.reshape({"data": p_shape})
     changedFunction = ng.function_from_cnn(net)
@@ -185,9 +185,9 @@ def test_reshape_with_partial_shape(device, shape, p_shape):
 
 @pytest.mark.ngraph_dependent_test
 def test_incorrect_reshape(device):
-    from conftest import create_ngraph_function
+    from conftest import create_relu
     import ngraph as ng
-    function = create_ngraph_function([1, 3, 22, 22])
+    function = create_relu([1, 3, 22, 22])
     net = ng.function_to_cnn(function)
     with pytest.raises(ValueError) as e:
         net.reshape({"data": [(2, 4, 6), 3, 22, 22]})
@@ -287,9 +287,9 @@ def test_tensor_names():
 @pytest.mark.ngraph_dependent_test
 @pytest.mark.template_plugin
 def test_create_two_exec_net():
-    from conftest import create_ngraph_function
+    from conftest import create_relu
     import ngraph as ng
-    function = create_ngraph_function([ng.Dimension(0,5), ng.Dimension(4), ng.Dimension(20), ng.Dimension(20)])
+    function = create_relu([ng.Dimension(0,5), ng.Dimension(4), ng.Dimension(20), ng.Dimension(20)])
     net = ng.function_to_cnn(function)
     ie_core = IECore()
     ie_core.register_plugin("templatePlugin", "TEMPLATE")

--- a/inference-engine/ie_bridges/python/tests/test_InferRequest.py
+++ b/inference-engine/ie_bridges/python/tests/test_InferRequest.py
@@ -589,13 +589,13 @@ def test_query_state_write_buffer(device, input_shape, data_type, mode):
 @pytest.mark.parametrize("shape, p_shape, ref_shape", [
     ([1, 4, 20, 20], [-1, 4, 20, 20], [5, 4, 20, 20]),
     ([1, 4, 20, 20], [(0,5), 4, 20, 20], [3, 4, 20, 20]),
-    ([1, 4, 20, 20], [(3,5), 3, 20, 20], [2, 4, 20, 20]),
-    ([1, 4, 20, 20], [(3,5), 3, 20, 20], [6, 4, 20, 20]),
+    ([1, 4, 20, 20], [(3,5), 4, 20, 20], [2, 4, 20, 20]),
+    ([1, 4, 20, 20], [(3,5), 4, 20, 20], [6, 4, 20, 20]),
 ])
 def test_infer_dynamic_network_with_set_shape(shape, p_shape, ref_shape):
-    from conftest import create_ngraph_function
+    from conftest import create_encoder
     import ngraph as ng
-    function = create_ngraph_function(shape)
+    function = create_encoder(shape)
     net = ng.function_to_cnn(function)
     net.reshape({"data": p_shape})
     ie_core = ie.IECore()
@@ -616,13 +616,13 @@ def test_infer_dynamic_network_with_set_shape(shape, p_shape, ref_shape):
 @pytest.mark.parametrize("shape, p_shape, ref_shape", [
     ([1, 4, 20, 20], [-1, 4, 20, 20], [5, 4, 20, 20]),
     ([1, 4, 20, 20], [(0,5), 4, 20, 20], [3, 4, 20, 20]),
-    ([1, 4, 20, 20], [(3,5), 3, 20, 20], [2, 4, 20, 20]),
-    ([1, 4, 20, 20], [(3,5), 3, 20, 20], [6, 4, 20, 20]),
+    ([1, 4, 20, 20], [(3,5), 4, 20, 20], [2, 4, 20, 20]),
+    ([1, 4, 20, 20], [(3,5), 4, 20, 20], [6, 4, 20, 20]),
 ])
 def test_infer_dynamic_network_without_set_shape(shape, p_shape, ref_shape):
-    from conftest import create_ngraph_function
+    from conftest import create_encoder
     import ngraph as ng
-    function = create_ngraph_function(shape)
+    function = create_encoder(shape)
     net = ng.function_to_cnn(function)
     net.reshape({"data": p_shape})
     ie_core = ie.IECore()
@@ -642,13 +642,13 @@ def test_infer_dynamic_network_without_set_shape(shape, p_shape, ref_shape):
 @pytest.mark.parametrize("shape, p_shape, ref_shape", [
     ([1, 4, 20, 20], [-1, 4, 20, 20], [5, 4, 20, 20]),
     ([1, 4, 20, 20], [(0,5), 4, 20, 20], [3, 4, 20, 20]),
-    ([1, 4, 20, 20], [(3,5), 3, 20, 20], [2, 4, 20, 20]),
-    ([1, 4, 20, 20], [(3,5), 3, 20, 20], [6, 4, 20, 20]),
+    ([1, 4, 20, 20], [(3,5), 4, 20, 20], [2, 4, 20, 20]),
+    ([1, 4, 20, 20], [(3,5), 4, 20, 20], [6, 4, 20, 20]),
 ])
 def test_infer_dynamic_network_with_set_blob(shape, p_shape, ref_shape):
-    from conftest import create_ngraph_function
+    from conftest import create_encoder
     import ngraph as ng
-    function = create_ngraph_function(shape)
+    function = create_encoder(shape)
     net = ng.function_to_cnn(function)
     net.reshape({"data": p_shape})
     ie_core = ie.IECore()
@@ -670,11 +670,11 @@ def test_infer_dynamic_network_with_set_blob(shape, p_shape, ref_shape):
 @pytest.mark.ngraph_dependent_test
 @pytest.mark.template_plugin
 def test_infer_dynamic_network_twice():
-    from conftest import create_ngraph_function
+    from conftest import create_encoder
     import ngraph as ng
     shape, p_shape = [1, 4, 20, 20], [(0,5), 4, 20, 20]
     ref_shape1, ref_shape2 = [2, 4, 20, 20], [3, 4, 20, 20]
-    function = create_ngraph_function(shape)
+    function = create_encoder(shape)
     net = ng.function_to_cnn(function)
     net.reshape({"data": p_shape})
     ie_core = ie.IECore()
@@ -692,11 +692,11 @@ def test_infer_dynamic_network_twice():
 @pytest.mark.ngraph_dependent_test
 @pytest.mark.template_plugin
 def test_infer_dynamic_network_with_set_blob_twice():
-    from conftest import create_ngraph_function
+    from conftest import create_encoder
     import ngraph as ng
     shape, p_shape = [1, 4, 20, 20], [(0,5), 4, 20, 20]
     ref_shape1, ref_shape2 = [2, 4, 20, 20], [3, 4, 20, 20]
-    function = create_ngraph_function(shape)
+    function = create_encoder(shape)
     net = ng.function_to_cnn(function)
     net.reshape({"data": p_shape})
     ie_core = ie.IECore()
@@ -723,14 +723,14 @@ def test_infer_dynamic_network_with_set_blob_twice():
 @pytest.mark.template_plugin
 @pytest.mark.parametrize("shapes", [
     ([3, 4, 20, 20], [3, 4, 20, 20], [3, 4, 20, 20]),
-    ([3, 4, 20, 20], [3, 6, 20, 20], [3, 8, 20, 20]),
+    ([3, 4, 20, 20], [3, 4, 28, 28], [3, 4, 45, 45]),
 ])
 def test_async_infer_dynamic_network_3_requests(shapes):
-    from conftest import create_ngraph_function
+    from conftest import create_encoder
     import ngraph as ng
-    function = create_ngraph_function([3, 4, 20, 20])
+    function = create_encoder([3, 4, 20, 20])
     net = ng.function_to_cnn(function)
-    net.reshape({"data": [3, (2, 10), 20, 20]})
+    net.reshape({"data": [3, 4, (20, 50), (20, 50)]})
     ie_core = ie.IECore()
     ie_core.register_plugin("templatePlugin", "TEMPLATE")
     exec_net = ie_core.load_network(net, "TEMPLATE", num_requests=3)
@@ -745,9 +745,9 @@ def test_async_infer_dynamic_network_3_requests(shapes):
 @pytest.mark.ngraph_dependent_test
 @pytest.mark.template_plugin
 def test_set_blob_with_incorrect_name():
-    from conftest import create_ngraph_function
+    from conftest import create_encoder
     import ngraph as ng
-    function = create_ngraph_function([4, 4, 20, 20])
+    function = create_encoder([4, 4, 20, 20])
     net = ng.function_to_cnn(function)
     ie_core = ie.IECore()
     ie_core.register_plugin("templatePlugin", "TEMPLATE")
@@ -763,9 +763,9 @@ def test_set_blob_with_incorrect_name():
 @pytest.mark.ngraph_dependent_test
 @pytest.mark.template_plugin
 def test_set_blob_with_incorrect_size():
-    from conftest import create_ngraph_function
+    from conftest import create_encoder
     import ngraph as ng
-    function = create_ngraph_function([4, 4, 20, 20])
+    function = create_encoder([4, 4, 20, 20])
     net = ng.function_to_cnn(function)
     ie_core = ie.IECore()
     ie_core.register_plugin("templatePlugin", "TEMPLATE")
@@ -773,6 +773,7 @@ def test_set_blob_with_incorrect_size():
     tensor_desc = exec_net.requests[0].input_blobs["data"].tensor_desc
     tensor_desc.dims = [tensor_desc.dims[0]*2, 4, 20, 20]
     blob = ie.Blob(tensor_desc)
+    print(exec_net.requests[0].output_blobs)
     with pytest.raises(RuntimeError) as e:
         exec_net.requests[0].set_blob("data", blob)
     assert f"Input blob size is not equal network input size" in str(e.value)
@@ -784,10 +785,11 @@ def test_set_blob_with_incorrect_size():
 @pytest.mark.ngraph_dependent_test
 @pytest.mark.template_plugin
 def test_set_blob_after_async_infer():
-    from conftest import create_ngraph_function
+    from conftest import create_encoder
     import ngraph as ng
-    function = create_ngraph_function([ng.Dimension(0,5), ng.Dimension(4), ng.Dimension(20), ng.Dimension(20)])
+    function = create_encoder([1, 4, 20, 20])
     net = ng.function_to_cnn(function)
+    net.reshape({"data": [(0, 5), 4, 20, 20]})
     ie_core = ie.IECore()
     ie_core.register_plugin("templatePlugin", "TEMPLATE")
     exec_net = ie_core.load_network(net, "TEMPLATE")
@@ -799,3 +801,4 @@ def test_set_blob_after_async_infer():
     with pytest.raises(RuntimeError) as e:
         request.set_blob("data", blob)
     assert "REQUEST_BUSY" in str(e.value)
+    request.wait()

--- a/inference-engine/ie_bridges/python/tests/test_NGraph.py
+++ b/inference-engine/ie_bridges/python/tests/test_NGraph.py
@@ -6,14 +6,14 @@ import ngraph as ng
 from ngraph.impl.op import Parameter
 from ngraph.impl import Function, Shape, Type
 
-from conftest import model_path, create_ngraph_function
+from conftest import model_path, create_relu
 
 
 test_net_xml, test_net_bin = model_path()
 
 
 def test_create_IENetwork_from_nGraph():
-    func = create_ngraph_function([1, 3, 22, 22])
+    func = create_relu([1, 3, 22, 22])
     caps = Function.to_capsule(func)
     cnnNetwork = IENetwork(caps)
     assert cnnNetwork != None
@@ -23,7 +23,7 @@ def test_create_IENetwork_from_nGraph():
 
 
 def test_get_IENetwork_from_nGraph():
-    func = create_ngraph_function([1, 3, 22, 22])
+    func = create_relu([1, 3, 22, 22])
     caps = Function.to_capsule(func)
     cnnNetwork = IENetwork(caps)
     assert cnnNetwork != None


### PR DESCRIPTION
### Details:
 - *[test_blob_set_shape_after_async_infer](https://github.com/openvinotoolkit/openvino/blob/master/inference-engine/ie_bridges/python/tests/test_Blob.py#L142) and [test_set_blob_after_async_infer](https://github.com/openvinotoolkit/openvino/blob/master/inference-engine/ie_bridges/python/tests/test_InferRequest.py#L786) fail sporadic due to very simple model for inference, because inference finish too fast and exception don't throw*
 - *Adding a more complex ngraph function for these tests can solve it*

### Tickets:
 - *65553*
