### PR TITLE
[OV20] NV12toRGB and NV12toBGR operations specification

### DIFF
--- a/docs/doxygen/ie_docs.xml
+++ b/docs/doxygen/ie_docs.xml
@@ -211,6 +211,8 @@ limitations under the License.
                 <tab type="user" title="NonZero-3" url="@ref openvino_docs_ops_condition_NonZero_3"/>
                 <tab type="user" title="NormalizeL2-1" url="@ref openvino_docs_ops_normalization_NormalizeL2_1"/>
                 <tab type="user" title="NotEqual-1" url="@ref openvino_docs_ops_comparison_NotEqual_1"/>
+                <tab type="user" title="NV12toBGR-8" url="@ref openvino_docs_ops_image_NV12toBGR_8"/>
+                <tab type="user" title="NV12toRGB-8" url="@ref openvino_docs_ops_image_NV12toRGB_8"/>
                 <tab type="user" title="OneHot-1" url="@ref openvino_docs_ops_sequence_OneHot_1"/>
                 <tab type="user" title="PReLU-1" url="@ref openvino_docs_ops_activation_PReLU_1"/>
                 <tab type="user" title="PSROIPooling-1" url="@ref openvino_docs_ops_detection_PSROIPooling_1"/>

--- a/docs/ops/image/NV12toBGR_8.md
+++ b/docs/ops/image/NV12toBGR_8.md
@@ -24,7 +24,7 @@ Same as specified for [NV12toRGB](NV12toRGB_8.md) operation.
 
 **Types:**
 
-* *T*: `uint8` or `float32` type.
+* *T*: `uint8` or any supported floating-point type.
 
 
 **Examples:**

--- a/docs/ops/image/NV12toBGR_8.md
+++ b/docs/ops/image/NV12toBGR_8.md
@@ -1,0 +1,82 @@
+## NV12toBGR <a name="NV12toBGR"></a> {#openvino_docs_ops_image_NV12toBGR_8}
+
+**Versioned name**: *NV12toBGR-8*
+
+**Category**: *Image processing*
+
+**Short description**: *NV12toBGR* performs image conversion from NV12 format to BGR.
+
+**Detailed description**:
+
+Similar to *NV12toRGB* but output channels for each pixel are reversed so that: first channel is `blue`, second one is `green`, last one is `red`.  See detailed conversion formulas at [NV12toRGB](NV12toRGB_8.md)
+
+**Inputs:**
+
+Same as specified for [NV12toRGB](NV12toRGB_8.md) operation.
+
+**Outputs:**
+
+* **1**: A tensor of type *T* representing converted image in BGR format. Dimensions:
+  * `N` - batch dimension
+  * `H` - height dimension is same as image height
+  * `W` - width dimension is same as image width
+  * `C` - channels dimension equals to 3. First channel is Blue, second one is Green, last one is Red
+
+**Types:**
+
+* *T*: `uint8` or `float32` type.
+
+
+**Examples:**
+
+*Example 1*
+
+```xml
+<layer ... type="NV12toBGR">
+    <input>
+        <port id="0">
+            <dim>1</dim>
+            <dim>720</dim>
+            <dim>640</dim>
+            <dim>1</dim>
+        </port>
+    </input>
+    <output>
+        <port id="1">
+            <dim>1</dim>
+            <dim>480</dim>
+            <dim>640</dim>
+            <dim>3</dim>
+        </port>
+    </output>
+</layer>
+```
+
+*Example 2*
+
+```xml
+<layer ... type="NV12toBGR">
+    <input>
+        <port id="0">  <!-- Y plane -->
+            <dim>1</dim>
+            <dim>480</dim>
+            <dim>640</dim>
+            <dim>1</dim>
+        </port>
+        <port id="1">  <!-- UV plane -->
+            <dim>1</dim>
+            <dim>240</dim>
+            <dim>320</dim>
+            <dim>2</dim>
+        </port>
+    </input>
+    <output>
+        <port id="1">
+            <dim>1</dim>
+            <dim>480</dim>
+            <dim>640</dim>
+            <dim>3</dim>
+        </port>
+    </output>
+</layer>
+```

--- a/docs/ops/image/NV12toBGR_8.md
+++ b/docs/ops/image/NV12toBGR_8.md
@@ -4,11 +4,11 @@
 
 **Category**: *Image processing*
 
-**Short description**: *NV12toBGR* performs image conversion from NV12 format to BGR.
+**Short description**: *NV12toBGR* performs image conversion from NV12 to BGR format.
 
 **Detailed description**:
 
-Similar to *NV12toRGB* but output channels for each pixel are reversed so that: first channel is `blue`, second one is `green`, last one is `red`.  See detailed conversion formulas at [NV12toRGB](NV12toRGB_8.md)
+Similar to *NV12toRGB* but output channels for each pixel are reversed so that the first channel is `blue`, the second one is `green`, the last one is `red`.  See detailed conversion formulas in the [NV12toRGB description](NV12toRGB_8.md).
 
 **Inputs:**
 
@@ -16,11 +16,11 @@ Same as specified for [NV12toRGB](NV12toRGB_8.md) operation.
 
 **Outputs:**
 
-* **1**: A tensor of type *T* representing converted image in BGR format. Dimensions:
+* **1**: A tensor of type *T* representing an image converted in BGR format. Dimensions:
   * `N` - batch dimension
-  * `H` - height dimension is same as image height
-  * `W` - width dimension is same as image width
-  * `C` - channels dimension equals to 3. First channel is Blue, second one is Green, last one is Red
+  * `H` - height dimension is the same as the image height
+  * `W` - width dimension is the same as the image width
+  * `C` - channels dimension is equal to 3. The first channel is Blue, the second one is Green, the last one is Red
 
 **Types:**
 

--- a/docs/ops/image/NV12toRGB_8.md
+++ b/docs/ops/image/NV12toRGB_8.md
@@ -4,11 +4,11 @@
 
 **Category**: *Image processing*
 
-**Short description**: *NV12toRGB* performs image conversion from NV12 format to RGB format.
+**Short description**: *NV12toRGB* performs image conversion from NV12 to RGB format.
 
 **Detailed description:**
 
-Conversion of each pixel from NV12 (YUV) to RGB space is represented by following formulas:
+Conversion of each pixel from NV12 (YUV) to RGB space is represented by the following formulas:
 
 \f[
 \begin{aligned}
@@ -18,36 +18,36 @@ Conversion of each pixel from NV12 (YUV) to RGB space is represented by followin
 \end{aligned}
 \f]
 
-Then R, G, B values are clipped to range (0, 255)
+Then R, G, B values are clipped to range (0, 255).
 
 **Inputs:**
 
-Input NV12 image tensor shall have `NHWC (a.k.a NYXC)` layout and can be represented in two ways:
+Input NV12 image tensor shall have `NHWC (also known as NYXC)` layout and can be represented in two ways:
 * *Single plane*:
   * **1**: Tensor of type *T*. **Required.** Dimensions:
     * `N` - batch dimension
-    * `H` - height dimension is 1.5x bigger than image height
-    * `W` - width dimension is same as image width
-    * `C` - channels dimension equals to 1 (one plane)
-* *Two separate planes: Y and UV*: In this way
+    * `H` - height dimension is 1.5x bigger than the image height
+    * `W` - width dimension is the same as the image width
+    * `C` - channels dimension is equal to 1 (one plane)
+* *Two separate planes - Y and UV*:
   * **1**: Tensor of type *T* representing Y plane. **Required.** Dimensions:
     * `N` - batch dimension
-    * `H` - height dimension is same as image height
-    * `W` - width dimension is same as image width
-    * `C` - channels dimension equals to 1 (only Y channel)
+    * `H` - height dimension is the same as the image height
+    * `W` - width dimension is the same as the image width
+    * `C` - channels dimension is equal to 1 (only Y channel)
   * **2**: Tensor of type *T* representing UV plane. **Required.** Dimensions:
-    * `N` - batch dimension. Shall be same as batch dimension for Y plane
-    * `H` - height dimension shall be half of image height (i.e. `image_height / 2`)
-    * `W` - width dimension shall be half of image width (i.e. `image_width / 2`)
+    * `N` - batch dimension. Shall be the same as the batch dimension for Y plane
+    * `H` - height dimension shall be half of the image height (for example, `image_height / 2`)
+    * `W` - width dimension shall be half of the image width (for example, `image_width / 2`)
     * `C` - channels dimension shall be equal to 2 (U channel and V channel)
 
 **Outputs:**
 
-* **1**: A tensor of type *T* representing converted image in RGB format. Dimensions:
+* **1**: A tensor of type *T* representing an image converted in RGB format. Dimensions:
   * `N` - batch dimension
-  * `H` - height dimension is same as image height
-  * `W` - width dimension is same as image width
-  * `C` - channels dimension equals to 3. First channel is Red, second one is Green, last one is Blue
+  * `H` - height dimension is the same as the image height
+  * `W` - width dimension is the same as the image width
+  * `C` - channels dimension is equal to 3. The first channel is Red, the second one is Green, the last one is Blue
 
 **Types:**
 

--- a/docs/ops/image/NV12toRGB_8.md
+++ b/docs/ops/image/NV12toRGB_8.md
@@ -51,7 +51,7 @@ Input NV12 image tensor shall have `NHWC (a.k.a NYXC)` layout and can be represe
 
 **Types:**
 
-* *T*: `uint8` or `float32` type.
+* *T*: `uint8` or any supported floating-point type.
 
 
 **Examples:**

--- a/docs/ops/image/NV12toRGB_8.md
+++ b/docs/ops/image/NV12toRGB_8.md
@@ -1,0 +1,109 @@
+## NV12toRGB <a name="NV12toRGB"></a> {#openvino_docs_ops_image_NV12toRGB_8}
+
+**Versioned name**: *NV12toRGB-8*
+
+**Category**: *Image processing*
+
+**Short description**: *NV12toRGB* performs image conversion from NV12 format to RGB format.
+
+**Detailed description:**
+
+Conversion of each pixel from NV12 (YUV) to RGB space is represented by following formulas:
+
+\f[
+\begin{aligned}
+& R = 1.164 \cdot (Y - 16) + 1.596 \cdot (V - 128) \\
+& G = 1.164 \cdot (Y - 16) - 0.813 \cdot (V - 128) - 0.391 \cdot (U - 128) \\
+& B = 1.164 \cdot (Y - 16) + 2.018 \cdot (U - 128)
+\end{aligned}
+\f]
+
+Then R, G, B values are clipped to range (0, 255)
+
+**Inputs:**
+
+Input NV12 image tensor shall have `NHWC (a.k.a NYXC)` layout and can be represented in two ways:
+* *Single plane*:
+  * **1**: Tensor of type *T*. **Required.** Dimensions:
+    * `N` - batch dimension
+    * `H` - height dimension is 1.5x bigger than image height
+    * `W` - width dimension is same as image width
+    * `C` - channels dimension equals to 1 (one plane)
+* *Two separate planes: Y and UV*: In this way
+  * **1**: Tensor of type *T* representing Y plane. **Required.** Dimensions:
+    * `N` - batch dimension
+    * `H` - height dimension is same as image height
+    * `W` - width dimension is same as image width
+    * `C` - channels dimension equals to 1 (only Y channel)
+  * **2**: Tensor of type *T* representing UV plane. **Required.** Dimensions:
+    * `N` - batch dimension. Shall be same as batch dimension for Y plane
+    * `H` - height dimension shall be half of image height (i.e. `image_height / 2`)
+    * `W` - width dimension shall be half of image width (i.e. `image_width / 2`)
+    * `C` - channels dimension shall be equal to 2 (U channel and V channel)
+
+**Outputs:**
+
+* **1**: A tensor of type *T* representing converted image in RGB format. Dimensions:
+  * `N` - batch dimension
+  * `H` - height dimension is same as image height
+  * `W` - width dimension is same as image width
+  * `C` - channels dimension equals to 3. First channel is Red, second one is Green, last one is Blue
+
+**Types:**
+
+* *T*: `uint8` or `float32` type.
+
+
+**Examples:**
+
+*Example 1*
+
+```xml
+<layer ... type="NV12toRGB">
+    <input>
+        <port id="0">
+            <dim>1</dim>
+            <dim>720</dim>
+            <dim>640</dim>
+            <dim>1</dim>
+        </port>
+    </input>
+    <output>
+        <port id="1">
+            <dim>1</dim>
+            <dim>480</dim>
+            <dim>640</dim>
+            <dim>3</dim>
+        </port>
+    </output>
+</layer>
+```
+
+*Example 2*
+
+```xml
+<layer ... type="NV12toRGB">
+    <input>
+        <port id="0">  <!-- Y plane -->
+            <dim>1</dim>
+            <dim>480</dim>
+            <dim>640</dim>
+            <dim>1</dim>
+        </port>
+        <port id="1">  <!-- UV plane -->
+            <dim>1</dim>
+            <dim>240</dim>
+            <dim>320</dim>
+            <dim>2</dim>
+        </port>
+    </input>
+    <output>
+        <port id="1">
+            <dim>1</dim>
+            <dim>480</dim>
+            <dim>640</dim>
+            <dim>3</dim>
+        </port>
+    </output>
+</layer>
+```

--- a/docs/ops/opset8.md
+++ b/docs/ops/opset8.md
@@ -106,6 +106,8 @@ declared in `namespace opset8`.
 * [NonZero](condition/NonZero_3.md)
 * [NormalizeL2](normalization/NormalizeL2_1.md)
 * [NotEqual](comparison/NotEqual_1.md)
+* [NV12toBGR](image/NV12toBGR_8.md)
+* [NV12toRGB](image/NV12toRGB_8.md)
 * [OneHot](sequence/OneHot_1.md)
 * [Pad](movement/Pad_1.md)
 * [Parameter](infrastructure/Parameter_1.md)


### PR DESCRIPTION
### Details:
 - NV12toRGB and NV12toBGR operations specification
 - It was decided to split this into 2 separate operations to be able to maintain their behavior separately. Also in futurethere may be needed to perform conversion from NV21, and this extension shall not affect users which use old operations (e.g. NV12toRGB-8 will be the same even if there is new NV21toRGB operation is introduced)

### Tickets:
 - 62174
