### PR TITLE
Add NopElimination pass to remove unnecessary convert layers

### DIFF
--- a/inference-engine/src/mkldnn_plugin/mkldnn_plugin.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_plugin.cpp
@@ -29,6 +29,7 @@
 #include <transformations/common_optimizations/weights_dequantize_to_fake_quantize.hpp>
 #include "transformations/common_optimizations/convert_quantize_dequantize.hpp"
 #include <transformations/common_optimizations/softmax_fusion.hpp>
+#include <transformations/common_optimizations/nop_elimination.hpp>
 #include <transformations/op_conversions/convert_depth_to_space.hpp>
 #include <transformations/op_conversions/convert_shuffle_channels3.hpp>
 #include <transformations/op_conversions/convert_space_to_depth.hpp>
@@ -182,6 +183,7 @@ static void TransformationUpToCPUSpecificOpSet(std::shared_ptr<ngraph::Function>
             std::vector<ngraph::element::Type>{ ngraph::element::i8, ngraph::element::u8, ngraph::element::i4, ngraph::element::u4 });
     }
     manager.register_pass<ngraph::pass::ConvertPrecision>(precisions);
+    manager.register_pass<ngraph::pass::NopElimination>();
 
     auto pass_config = manager.get_pass_config();
 


### PR DESCRIPTION
### Details:
 - *ConvertPrecision  ngraph pass produces some unnecessary conversions such as int32 -> int32. Add NopElimination pass after ConvertPrecision ngraph pass to remove unnecessary convert layers*.

### Tickets:
 - *CVS-62344*
