### PR TITLE
Replace 'quantized' with 'compressed' in MO help

### DIFF
--- a/docs/MO_DG/prepare_model/convert_model/Converting_Model_General.md
+++ b/docs/MO_DG/prepare_model/convert_model/Converting_Model_General.md
@@ -99,7 +99,7 @@ Framework-agnostic parameters:
   --data_type {FP16,FP32,half,float}
                         Data type for all intermediate tensors and weights. If
                         original model is in FP32 and --data_type=FP16 is
-                        specified, all model weights and biases are quantized
+                        specified, all model weights and biases are compressed
                         to FP16.
   --disable_fusing      Turn off fusing of linear operations to Convolution
   --disable_resnet_optimization

--- a/model-optimizer/mo/utils/cli_parser.py
+++ b/model-optimizer/mo/utils/cli_parser.py
@@ -275,7 +275,7 @@ def get_common_cli_parser(parser: argparse.ArgumentParser = None):
     common_group.add_argument('--data_type',
                               help='Data type for all intermediate tensors and weights. ' +
                                    'If original model is in FP32 and --data_type=FP16 is specified, all model weights ' +
-                                   'and biases are quantized to FP16.',
+                                   'and biases are compressed to FP16.',
                               choices=["FP16", "FP32", "half", "float"],
                               default='float')
     common_group.add_argument('--transform',


### PR DESCRIPTION
Signed-off-by: Andrei Kochin <andrei.kochin@intel.com>

### Details:

Solution: Replace word 'quantized' with 'compressed' in --data_type help description to avoid confusions.

Code:
* [x]  Comments **NA no functional code change**
* [x]  Code style (PEP8) **NA no functional code change**
* [x]  Transformation generates reshape-able IR **NA no functional code change**
* [x]  Transformation preserves original framework node names **NA no functional code change**


Validation:
* [x]  Unit tests **NA no functional code change**
* [x]  Framework operation tests **NA no functional code change**
* [x]  Transformation tests **NA no functional code change**
* [x]  Model Optimizer IR Reader check **NA no functional code change**

Documentation:
* [x]  Supported frameworks operations list **NA no functional code change**
* [x]  Guide on how to convert the **public** model **NA no functional code change**
* [x]  User guide update

### Tickets:
 - None
