### PR TITLE
fix typo in `NC` layout description

### DIFF
--- a/inference-engine/src/inference_engine/include/ie/ie_common.h
+++ b/inference-engine/src/inference_engine/include/ie/ie_common.h
@@ -95,7 +95,7 @@ enum Layout : uint8_t {
 
     // 2D
     HW = 192,  //!< HW 2D layout
-    NC = 193,  //!< HC 2D layout
+    NC = 193,  //!< NC 2D layout
     CN = 194,  //!< CN 2D layout
 
     BLOCKED = 200,  //!< A blocked layout


### PR DESCRIPTION
### Details:
 - *typo in NC Layout description*

`NC` layout described as `HC`