### PR TITLE
Fix potential UNITY build failures (ENABLE_FASTER_BUILD)

### DIFF
--- a/ngraph/core/src/layout.cpp
+++ b/ngraph/core/src/layout.cpp
@@ -10,7 +10,7 @@
 #include "ngraph/except.hpp"
 #include "ngraph/util.hpp"
 
-using namespace ov;
+namespace ov {
 
 /////////////////////////////////////////////////////////////////////////////////
 
@@ -264,3 +264,5 @@ void AttributeAdapter<ov::Layout>::set(const std::string& value) {
 }
 
 constexpr VariantTypeInfo VariantWrapper<ov::Layout>::type_info;
+
+}  // namespace ov

--- a/ngraph/core/src/op/util/logical_reduction.cpp
+++ b/ngraph/core/src/op/util/logical_reduction.cpp
@@ -8,8 +8,9 @@
 #include "ngraph/op/constant.hpp"
 #include "ngraph/validation_util.hpp"
 
+namespace ov {
+
 using namespace std;
-using namespace ov;
 
 BWDCMP_RTTI_DEFINITION(op::util::LogicalReduction);
 
@@ -62,3 +63,5 @@ void op::util::LogicalReduction::validate_and_infer_types() {
     set_input_is_relevant_to_shape(1);
     set_output_type(0, data_et, result_shape);
 }
+
+}  // namespace ov

--- a/ngraph/core/src/preprocess/preprocess_steps_impl.cpp
+++ b/ngraph/core/src/preprocess/preprocess_steps_impl.cpp
@@ -8,8 +8,8 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/shape.hpp"
 
-using namespace ov;
-using namespace ov::preprocess;
+namespace ov {
+namespace preprocess {
 
 static Shape construct_mean_scale_shape(const std::shared_ptr<Node>& node,
                                         size_t values_size,
@@ -97,3 +97,6 @@ void PreProcessSteps::PreProcessStepsImpl::add_convert_impl(const ov::element::T
         },
         true));
 }
+
+}  // namespace preprocess
+}  // namespace ov


### PR DESCRIPTION
### Details:
- When ENABLE_FASTER_BUILD is ON, source files are combined to batch for faster compilation. However, when one source file uses "using namespace ngraph", and another has "using namespace ov" - then conflicts may occur depending on how sources were combined

- This fix removes usage of "using namespace ov" from ngraph code to avoid such potential issues. Old code still have "using namespace ngraph"
- Example of failed job due to this: https://github.com/openvinotoolkit/openvino/runs/3684741745

### Tickets:
 - N/A
