### PR TITLE
[IE PYTHON] Fix memory leak for python3.9

### DIFF
--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.cpp
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.cpp
@@ -96,7 +96,7 @@ PyObject* parse_parameter(const InferenceEngine::Parameter& param) {
         auto val = param.as<std::vector<std::string>>();
         PyObject* list = PyList_New(0);
         for (const auto& it : val) {
-            PyObject* str_val = PyUnicode_FromString(it.c_str());
+            PyObject* str_val = PyUnicode_InternFromString(it.c_str());
             PyList_Append(list, str_val);
         }
         return list;


### PR DESCRIPTION
### Details:
 - *The problem is python3.9 specific only*
 - *Replacing PyUnicode_FromString with PyUnicode_InternFromString fixes memory leak*

### Tickets:
 - *65443*
