### PR TITLE
Added shared any and loadable parameter

### DIFF
--- a/inference-engine/src/inference_engine/include/ie/ie_parameter.hpp
+++ b/inference-engine/src/inference_engine/include/ie/ie_parameter.hpp
@@ -20,21 +20,346 @@
 #include <vector>
 
 #include "ie_blob.h"
-#include "openvino/runtime/parameter.hpp"
+#include "openvino/core/except.hpp"
 
 namespace InferenceEngine {
 
-using ov::runtime::Parameter;
-using ov::runtime::ParamMap;
+/**
+ * @brief This class represents an object to work with different parameters
+ *
+ */
+class INFERENCE_ENGINE_API_CLASS(Parameter) {
+public:
+    /**
+     * @brief Default constructor
+     */
+    Parameter() = default;
 
-}  // namespace InferenceEngine
+    /**
+     * @brief Move constructor
+     *
+     * @param parameter Parameter object
+     */
+    Parameter(Parameter&& parameter) noexcept {
+        std::swap(ptr, parameter.ptr);
+    }
 
-namespace ov {
-namespace runtime {
+    /**
+     * @brief Copy constructor
+     *
+     * @param parameter Parameter object
+     */
+    Parameter(const Parameter& parameter) {
+        *this = parameter;
+    }
 
+    /**
+     * @brief Constructor creates parameter with object
+     *
+     * @tparam T Parameter type
+     * @tparam U Identity type-transformation
+     * @param parameter object
+     */
+    template <class T,
+              typename = typename std::enable_if<!std::is_same<typename std::decay<T>::type, Parameter>::value &&
+                                                 !std::is_abstract<typename std::decay<T>::type>::value>::type>
+    Parameter(T&& parameter) {
+        static_assert(!std::is_same<typename std::decay<T>::type, Parameter>::value, "To prevent recursion");
+        ptr = new RealData<typename std::decay<T>::type>(std::forward<T>(parameter));
+    }
+
+    /**
+     * @brief Constructor creates string parameter from char *
+     *
+     * @param str char array
+     */
+    Parameter(const char* str) : Parameter(std::string(str)) {}
+
+    /**
+     * @brief Destructor
+     */
+    virtual ~Parameter();
+
+    /**
+     * Copy operator for Parameter
+     * @param parameter Parameter object
+     * @return Parameter
+     */
+    Parameter& operator=(const Parameter& parameter) {
+        if (this == &parameter) {
+            return *this;
+        }
+        clear();
+        if (!parameter.empty())
+            ptr = parameter.ptr->copy();
+        return *this;
+    }
+
+    /**
+     * Remove a value from parameter
+     */
+    void clear() {
+        delete ptr;
+        ptr = nullptr;
+    }
+
+    /**
+     * Checks that parameter contains a value
+     * @return false if parameter contains a value else false
+     */
+    bool empty() const noexcept {
+        return nullptr == ptr;
+    }
+
+    /**
+     * Checks the type of value
+     * @tparam T Type of value
+     * @return true if type of value is correct
+     */
+    template <class T>
+    bool is() const {
+        return empty() ? false : ptr->is(typeid(T));
+    }
+
+    /**
+     * Dynamic cast to specified type
+     * @tparam T type
+     * @return casted object
+     */
+    template <typename T>
+    T&& as() && {
+        return std::move(dyn_cast<T>(ptr));
+    }
+
+    /**
+     * Dynamic cast to specified type
+     * @tparam T type
+     * @return casted object
+     */
+    template <class T>
+    T& as() & {
+        return dyn_cast<T>(ptr);
+    }
+    /**
+     * Dynamic cast to specified type
+     * @tparam T type
+     * @return casted object
+     */
+    template <class T>
+    const T& as() const& {
+        return dyn_cast<T>(ptr);
+    }
+
+    /**
+     * Dynamic cast to specified type
+     * @tparam T type
+     * @return casted object
+     */
+    template <class T>
+    operator T &&() && {
+        return std::move(dyn_cast<typename std::remove_cv<T>::type>(ptr));
+    }
+
+    /**
+     * Dynamic cast to specified type
+     * @tparam T type
+     * @return casted object
+     */
+    template <class T>
+    operator T&() & {
+        return dyn_cast<typename std::remove_cv<T>::type>(ptr);
+    }
+
+    /**
+     * Dynamic cast to specified type
+     * @tparam T type
+     * @return casted object
+     */
+    template <class T>
+    operator const T&() const& {
+        return dyn_cast<typename std::remove_cv<T>::type>(ptr);
+    }
+
+    /**
+     * Dynamic cast to specified type
+     * @tparam T type
+     * @return casted object
+     */
+    template <class T>
+    operator T&() const& {
+        return dyn_cast<typename std::remove_cv<T>::type>(ptr);
+    }
+
+    /**
+     * @brief The comparison operator for the Parameter
+     *
+     * @param rhs object to compare
+     * @return true if objects are equal
+     */
+    bool operator==(const Parameter& rhs) const {
+        return *ptr == *(rhs.ptr);
+    }
+    /**
+     * @brief The comparison operator for the Parameter
+     *
+     * @param rhs object to compare
+     * @return true if objects aren't equal
+     */
+    bool operator!=(const Parameter& rhs) const {
+        return !(*this == rhs);
+    }
+
+    /**
+     * @brief Prints underlying object to the given output stream.
+     * Uses operator<< if it is defined, leaves stream unchanged otherwise.
+     * In case of empty parameter or nullptr stream immediately returns.
+     *
+     * @param object Object to be printed to the given output stream.
+     * @param stream Output stream object will be printed to.
+     */
+    friend void PrintTo(const Parameter& object, std::ostream* stream) {
+        if (object.empty() || !stream) {
+            return;
+        }
+        object.ptr->print(*stream);
+    }
+
+private:
+    template <class T, class EqualTo>
+    struct CheckOperatorEqual {
+        template <class U, class V>
+        static auto test(U*) -> decltype(std::declval<U>() == std::declval<V>()) {
+            return false;
+        }
+
+        template <typename, typename>
+        static auto test(...) -> std::false_type {
+            return {};
+        }
+
+        using type = typename std::is_same<bool, decltype(test<T, EqualTo>(nullptr))>::type;
+    };
+
+    template <class T, class EqualTo = T>
+    struct HasOperatorEqual : CheckOperatorEqual<T, EqualTo>::type {};
+
+    template <class T, class U>
+    struct CheckOutputStreamOperator {
+        template <class V, class W>
+        static auto test(W*) -> decltype(std::declval<V&>() << std::declval<W>(), std::true_type()) {
+            return {};
+        }
+
+        template <typename, typename>
+        static auto test(...) -> std::false_type {
+            return {};
+        }
+
+        using type = typename std::is_same<std::true_type, decltype(test<T, U>(nullptr))>::type;
+    };
+
+    template <class T>
+    struct HasOutputStreamOperator : CheckOutputStreamOperator<std::ostream, T>::type {};
+
+    struct Any {
+#ifdef __ANDROID__
+        virtual ~Any();
+#else
+        virtual ~Any() = default;
+#endif
+        virtual bool is(const std::type_info&) const = 0;
+        virtual Any* copy() const = 0;
+        virtual bool operator==(const Any& rhs) const = 0;
+        virtual void print(std::ostream&) const = 0;
+    };
+
+    template <class T>
+    struct RealData : Any, std::tuple<T> {
+        using std::tuple<T>::tuple;
+
+        bool is(const std::type_info& id) const override {
+            return id == typeid(T);
+        }
+        Any* copy() const override {
+            return new RealData{get()};
+        }
+
+        T& get() & {
+            return std::get<0>(*static_cast<std::tuple<T>*>(this));
+        }
+
+        const T& get() const& {
+            return std::get<0>(*static_cast<const std::tuple<T>*>(this));
+        }
+
+        template <class U>
+        typename std::enable_if<!HasOperatorEqual<U>::value, bool>::type equal(const Any& left, const Any& rhs) const {
+            throw ov::Exception("Parameter doesn't contain equal operator");
+        }
+
+        template <class U>
+        typename std::enable_if<HasOperatorEqual<U>::value, bool>::type equal(const Any& left, const Any& rhs) const {
+            return dyn_cast<U>(&left) == dyn_cast<U>(&rhs);
+        }
+
+        bool operator==(const Any& rhs) const override {
+            return rhs.is(typeid(T)) && equal<T>(*this, rhs);
+        }
+
+        template <class U, typename std::enable_if<!HasOutputStreamOperator<U>::value, bool>::type = true>
+        void print(std::ostream& stream, const U& object) const {}
+
+        template <class U, typename std::enable_if<HasOutputStreamOperator<U>::value, bool>::type = true>
+        void print(std::ostream& stream, const U& object) const {
+            stream << object;
+        }
+
+        void print(std::ostream& stream) const override {
+            print<T>(stream, get());
+        }
+    };
+
+    template <typename T>
+    static T& dyn_cast(Any* obj) {
+        OPENVINO_ASSERT(obj != nullptr, "Parameter is empty!");
+        return dynamic_cast<RealData<T>&>(*obj).get();
+    }
+
+    template <typename T>
+    static const T& dyn_cast(const Any* obj) {
+        OPENVINO_ASSERT(obj != nullptr, "Parameter is empty!");
+        return dynamic_cast<const RealData<T>&>(*obj).get();
+    }
+
+    Any* ptr = nullptr;
+};
+
+/**
+ * @brief An std::map object containing parameters
+ */
+using ParamMap = std::map<std::string, Parameter>;
+
+#ifdef __ANDROID__
+extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<int>);
+extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<bool>);
+extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<float>);
+extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<uint32_t>);
+extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<std::string>);
+extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<unsigned long>);
+extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<std::vector<int>>);
+extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<std::vector<std::string>>);
+extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<std::vector<unsigned long>>);
+extern template struct INFERENCE_ENGINE_API_CLASS(
+    InferenceEngine::Parameter::RealData<std::tuple<unsigned int, unsigned int>>);
+extern template struct INFERENCE_ENGINE_API_CLASS(
+    InferenceEngine::Parameter::RealData<std::tuple<unsigned int, unsigned int, unsigned int>>);
+#endif
 #ifdef __ANDROID__
 extern template struct INFERENCE_ENGINE_API_CLASS(InferenceEngine::Parameter::RealData<InferenceEngine::Blob::Ptr>);
 #endif
 
-}  // namespace runtime
+}  // namespace InferenceEngine
+
+namespace ov {
+namespace runtime {}  // namespace runtime
 }  // namespace ov

--- a/inference-engine/src/inference_engine/include/openvino/runtime/common.hpp
+++ b/inference-engine/src/inference_engine/include/openvino/runtime/common.hpp
@@ -9,8 +9,8 @@
  */
 #pragma once
 
-#include <chrono>
 #include <map>
+#include <openvino/core/shared_any.hpp>
 #include <string>
 
 #include "openvino/core/visibility.hpp"
@@ -45,9 +45,9 @@ namespace ov {
 namespace ie = InferenceEngine;
 namespace runtime {
 /**
- * @brief This type of map is commonly used to pass set of parameters
+ * @brief This type of map is commonly used to pass set of configuration values
  */
-using ConfigMap = std::map<std::string, std::string>;
+using ConfigMap = std::map<std::string, SharedAny>;
 
 /**
  * @brief This type of map is used for result of Core::query_model

--- a/inference-engine/src/inference_engine/include/openvino/runtime/core.hpp
+++ b/inference-engine/src/inference_engine/include/openvino/runtime/core.hpp
@@ -19,6 +19,7 @@
 #include "openvino/core/version.hpp"
 #include "openvino/runtime/common.hpp"
 #include "openvino/runtime/executable_network.hpp"
+#include "openvino/runtime/parameter.hpp"
 #include "openvino/runtime/remote_context.hpp"
 
 namespace InferenceEngine {
@@ -292,7 +293,7 @@ public:
      * @param params Map of device-specific shared context parameters.
      * @return A shared pointer to a created remote context.
      */
-    RemoteContext create_context(const std::string& deviceName, const ParamMap& params);
+    RemoteContext create_context(const std::string& deviceName, const ConfigMap& params);
 
     /**
      * @brief Get a pointer to default(plugin-supplied) shared context object for specified accelerator device.

--- a/inference-engine/src/inference_engine/include/openvino/runtime/executable_network.hpp
+++ b/inference-engine/src/inference_engine/include/openvino/runtime/executable_network.hpp
@@ -96,7 +96,7 @@ public:
      *
      * @param config Map of pairs: (config parameter name, config parameter value)
      */
-    void set_config(const ParamMap& config);
+    void set_config(const ConfigMap& config);
 
     /** @brief Gets configuration for current executable network.
      *

--- a/inference-engine/src/inference_engine/include/openvino/runtime/parameter.hpp
+++ b/inference-engine/src/inference_engine/include/openvino/runtime/parameter.hpp
@@ -8,353 +8,44 @@
  */
 #pragma once
 
-#include <algorithm>
-#include <cctype>
-#include <iterator>
-#include <map>
-#include <memory>
-#include <string>
-#include <tuple>
-#include <typeinfo>
-#include <utility>
-#include <vector>
-
 #include "openvino/core/except.hpp"
+#include "openvino/core/shared_any.hpp"
 #include "openvino/runtime/common.hpp"
 
 namespace ov {
 namespace runtime {
+class Core;
+class ExecutableNetwork;
+class RemoteContext;
 
 /**
- * @brief This class represents an object to work with different parameters
+ * @brief This class represents an object to work with different parameters loaded from inference plugins
  *
  */
-class OPENVINO_RUNTIME_API Parameter {
-public:
-    /**
-     * @brief Default constructor
-     */
-    Parameter() = default;
+class Parameter {
+    std::shared_ptr<void> _so;
+    SharedAny _impl;
 
-    /**
-     * @brief Move constructor
-     *
-     * @param parameter Parameter object
-     */
-    Parameter(Parameter&& parameter) noexcept {
-        std::swap(ptr, parameter.ptr);
-    }
+    Parameter(const std::shared_ptr<void>& so, const SharedAny& impl) : _so{so}, _impl{impl} {}
 
-    /**
-     * @brief Copy constructor
-     *
-     * @param parameter Parameter object
-     */
-    Parameter(const Parameter& parameter) {
-        *this = parameter;
-    }
+    friend class ov::runtime::Core;
+    friend class ov::runtime::ExecutableNetwork;
+    friend class ov::runtime::RemoteContext;
 
-    /**
-     * @brief Constructor creates parameter with object
-     *
-     * @tparam T Parameter type
-     * @tparam U Identity type-transformation
-     * @param parameter object
-     */
-    template <class T,
-              typename = typename std::enable_if<!std::is_same<typename std::decay<T>::type, Parameter>::value &&
-                                                 !std::is_abstract<typename std::decay<T>::type>::value>::type>
-    Parameter(T&& parameter) {
-        static_assert(!std::is_same<typename std::decay<T>::type, Parameter>::value, "To prevent recursion");
-        ptr = new RealData<typename std::decay<T>::type>(std::forward<T>(parameter));
-    }
-
-    /**
-     * @brief Constructor creates string parameter from char *
-     *
-     * @param str char array
-     */
-    Parameter(const char* str) : Parameter(std::string(str)) {}
-
-    /**
-     * @brief Destructor
-     */
-    virtual ~Parameter();
-
-    /**
-     * Copy operator for Parameter
-     * @param parameter Parameter object
-     * @return Parameter
-     */
-    Parameter& operator=(const Parameter& parameter) {
-        if (this == &parameter) {
-            return *this;
-        }
-        clear();
-        if (!parameter.empty())
-            ptr = parameter.ptr->copy();
-        return *this;
-    }
-
-    /**
-     * Remove a value from parameter
-     */
-    void clear() {
-        delete ptr;
-        ptr = nullptr;
-    }
-
-    /**
-     * Checks that parameter contains a value
-     * @return false if parameter contains a value else false
-     */
-    bool empty() const noexcept {
-        return nullptr == ptr;
-    }
-
-    /**
-     * Checks the type of value
-     * @tparam T Type of value
-     * @return true if type of value is correct
-     */
-    template <class T>
+    template <typename T>
     bool is() const {
-        return empty() ? false : ptr->is(typeid(T));
-    }
-
-    /**
-     * Dynamic cast to specified type
-     * @tparam T type
-     * @return casted object
-     */
-    template <typename T>
-    T&& as() && {
-        return std::move(dyn_cast<T>(ptr));
-    }
-
-    /**
-     * Dynamic cast to specified type
-     * @tparam T type
-     * @return casted object
-     */
-    template <class T>
-    T& as() & {
-        return dyn_cast<T>(ptr);
-    }
-    /**
-     * Dynamic cast to specified type
-     * @tparam T type
-     * @return casted object
-     */
-    template <class T>
-    const T& as() const& {
-        return dyn_cast<T>(ptr);
-    }
-
-    /**
-     * Dynamic cast to specified type
-     * @tparam T type
-     * @return casted object
-     */
-    template <class T>
-    operator T &&() && {
-        return std::move(dyn_cast<typename std::remove_cv<T>::type>(ptr));
-    }
-
-    /**
-     * Dynamic cast to specified type
-     * @tparam T type
-     * @return casted object
-     */
-    template <class T>
-    operator T&() & {
-        return dyn_cast<typename std::remove_cv<T>::type>(ptr);
-    }
-
-    /**
-     * Dynamic cast to specified type
-     * @tparam T type
-     * @return casted object
-     */
-    template <class T>
-    operator const T&() const& {
-        return dyn_cast<typename std::remove_cv<T>::type>(ptr);
-    }
-
-    /**
-     * Dynamic cast to specified type
-     * @tparam T type
-     * @return casted object
-     */
-    template <class T>
-    operator T&() const& {
-        return dyn_cast<typename std::remove_cv<T>::type>(ptr);
-    }
-
-    /**
-     * @brief The comparison operator for the Parameter
-     *
-     * @param rhs object to compare
-     * @return true if objects are equal
-     */
-    bool operator==(const Parameter& rhs) const {
-        return *ptr == *(rhs.ptr);
-    }
-    /**
-     * @brief The comparison operator for the Parameter
-     *
-     * @param rhs object to compare
-     * @return true if objects aren't equal
-     */
-    bool operator!=(const Parameter& rhs) const {
-        return !(*this == rhs);
-    }
-
-    /**
-     * @brief Prints underlying object to the given output stream.
-     * Uses operator<< if it is defined, leaves stream unchanged otherwise.
-     * In case of empty parameter or nullptr stream immediately returns.
-     *
-     * @param object Object to be printed to the given output stream.
-     * @param stream Output stream object will be printed to.
-     */
-    friend void PrintTo(const Parameter& object, std::ostream* stream) {
-        if (object.empty() || !stream) {
-            return;
-        }
-        object.ptr->print(*stream);
-    }
-
-private:
-    template <class T, class EqualTo>
-    struct CheckOperatorEqual {
-        template <class U, class V>
-        static auto test(U*) -> decltype(std::declval<U>() == std::declval<V>()) {
-            return false;
-        }
-
-        template <typename, typename>
-        static auto test(...) -> std::false_type {
-            return {};
-        }
-
-        using type = typename std::is_same<bool, decltype(test<T, EqualTo>(nullptr))>::type;
-    };
-
-    template <class T, class EqualTo = T>
-    struct HasOperatorEqual : CheckOperatorEqual<T, EqualTo>::type {};
-
-    template <class T, class U>
-    struct CheckOutputStreamOperator {
-        template <class V, class W>
-        static auto test(W*) -> decltype(std::declval<V&>() << std::declval<W>(), std::true_type()) {
-            return {};
-        }
-
-        template <typename, typename>
-        static auto test(...) -> std::false_type {
-            return {};
-        }
-
-        using type = typename std::is_same<std::true_type, decltype(test<T, U>(nullptr))>::type;
-    };
-
-    template <class T>
-    struct HasOutputStreamOperator : CheckOutputStreamOperator<std::ostream, T>::type {};
-
-    struct Any {
-#ifdef __ANDROID__
-        virtual ~Any();
-#else
-        virtual ~Any() = default;
-#endif
-        virtual bool is(const std::type_info&) const = 0;
-        virtual Any* copy() const = 0;
-        virtual bool operator==(const Any& rhs) const = 0;
-        virtual void print(std::ostream&) const = 0;
-    };
-
-    template <class T>
-    struct RealData : Any, std::tuple<T> {
-        using std::tuple<T>::tuple;
-
-        bool is(const std::type_info& id) const override {
-            return id == typeid(T);
-        }
-        Any* copy() const override {
-            return new RealData{get()};
-        }
-
-        T& get() & {
-            return std::get<0>(*static_cast<std::tuple<T>*>(this));
-        }
-
-        const T& get() const& {
-            return std::get<0>(*static_cast<const std::tuple<T>*>(this));
-        }
-
-        template <class U>
-        typename std::enable_if<!HasOperatorEqual<U>::value, bool>::type equal(const Any& left, const Any& rhs) const {
-            throw ov::Exception("Parameter doesn't contain equal operator");
-        }
-
-        template <class U>
-        typename std::enable_if<HasOperatorEqual<U>::value, bool>::type equal(const Any& left, const Any& rhs) const {
-            return dyn_cast<U>(&left) == dyn_cast<U>(&rhs);
-        }
-
-        bool operator==(const Any& rhs) const override {
-            return rhs.is(typeid(T)) && equal<T>(*this, rhs);
-        }
-
-        template <class U, typename std::enable_if<!HasOutputStreamOperator<U>::value, bool>::type = true>
-        void print(std::ostream& stream, const U& object) const {}
-
-        template <class U, typename std::enable_if<HasOutputStreamOperator<U>::value, bool>::type = true>
-        void print(std::ostream& stream, const U& object) const {
-            stream << object;
-        }
-
-        void print(std::ostream& stream) const override {
-            print<T>(stream, get());
-        }
-    };
-
-    template <typename T>
-    static T& dyn_cast(Any* obj) {
-        OPENVINO_ASSERT(obj != nullptr, "Parameter is empty!");
-        return dynamic_cast<RealData<T>&>(*obj).get();
+        return _impl.is<T>();
     }
 
     template <typename T>
-    static const T& dyn_cast(const Any* obj) {
-        OPENVINO_ASSERT(obj != nullptr, "Parameter is empty!");
-        return dynamic_cast<const RealData<T>&>(*obj).get();
+    T& as() const {
+        return _impl.as<T>();
     }
-
-    Any* ptr = nullptr;
 };
 
 /**
- * @brief An std::map object containing parameters
+ * @brief This type of map is commonly used to return set of loaded from inference plugin
  */
 using ParamMap = std::map<std::string, Parameter>;
-
-#ifdef __ANDROID__
-extern template struct OPENVINO_RUNTIME_API ov::runtime::Parameter::RealData<int>;
-extern template struct OPENVINO_RUNTIME_API ov::runtime::Parameter::RealData<bool>;
-extern template struct OPENVINO_RUNTIME_API ov::runtime::Parameter::RealData<float>;
-extern template struct OPENVINO_RUNTIME_API ov::runtime::Parameter::RealData<uint32_t>;
-extern template struct OPENVINO_RUNTIME_API ov::runtime::Parameter::RealData<std::string>;
-extern template struct OPENVINO_RUNTIME_API ov::runtime::Parameter::RealData<unsigned long>;
-extern template struct OPENVINO_RUNTIME_API ov::runtime::Parameter::RealData<std::vector<int>>;
-extern template struct OPENVINO_RUNTIME_API ov::runtime::Parameter::RealData<std::vector<std::string>>;
-extern template struct OPENVINO_RUNTIME_API ov::runtime::Parameter::RealData<std::vector<unsigned long>>;
-extern template struct OPENVINO_RUNTIME_API ov::runtime::Parameter::RealData<std::tuple<unsigned int, unsigned int>>;
-extern template struct OPENVINO_RUNTIME_API
-    ov::runtime::Parameter::RealData<std::tuple<unsigned int, unsigned int, unsigned int>>;
-#endif
-
 }  // namespace runtime
-
 }  // namespace ov

--- a/inference-engine/src/inference_engine/include/openvino/runtime/remote_context.hpp
+++ b/inference-engine/src/inference_engine/include/openvino/runtime/remote_context.hpp
@@ -119,11 +119,11 @@ public:
      * Returns a pointer to the object which implements RemoteTensor interface.
      * @param type Defines the element type of the tensor
      * @param shape Defines the shape of the tensor
-     * @param params Map of the low-level tensor object parameters.
+     * @param config Map of the low-level blob object parameters.
      * Abstract method.
      * @return A pointer to plugin object that implements RemoteTensor interface.
      */
-    RemoteTensor create_tensor(const element::Type& type, const Shape& shape, const ParamMap& params = {});
+    RemoteTensor create_tensor(const element::Type& type, const Shape& shape, const ConfigMap& config = {});
 
     /**
      * @brief Returns a map of device-specific parameters required for low-level

--- a/inference-engine/src/inference_engine/src/any_copy.cpp
+++ b/inference-engine/src/inference_engine/src/any_copy.cpp
@@ -1,0 +1,96 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "any_copy.hpp"
+
+namespace ov {
+
+ie::Parameter any_copy(const SharedAny& shared_any) {
+#define COPY_TYPE(...)                         \
+    if (shared_any.is<__VA_ARGS__>()) {        \
+        return {shared_any.is<__VA_ARGS__>()}; \
+    }
+    COPY_TYPE(ie::Blob::Ptr);
+    COPY_TYPE(int);
+    COPY_TYPE(bool);
+    COPY_TYPE(float);
+    COPY_TYPE(uint32_t);
+    COPY_TYPE(std::string);
+    COPY_TYPE(unsigned long);
+    COPY_TYPE(std::vector<int>);
+    COPY_TYPE(std::vector<std::string>);
+    COPY_TYPE(std::vector<unsigned long>);
+    COPY_TYPE(std::tuple<unsigned int, unsigned int>);
+    COPY_TYPE(std::tuple<unsigned int, unsigned int, unsigned int>);
+#undef COPY_TYPE
+    OPENVINO_UNREACHABLE("No type found ", shared_any.get_type_info().name());
+}
+
+ie::Parameter any_copy(const SharedAnyImpl::Ptr& shared_any_impl) {
+    return any_copy(SharedAny{shared_any_impl});
+}
+
+AnyCopyIEParamter::operator SharedAny() {
+#define COPY_TYPE(...)                        \
+    if (parameter.is<__VA_ARGS__>()) {        \
+        return {parameter.as<__VA_ARGS__>()}; \
+    }
+    COPY_TYPE(ie::Blob::Ptr);
+    COPY_TYPE(int);
+    COPY_TYPE(bool);
+    COPY_TYPE(float);
+    COPY_TYPE(uint32_t);
+    COPY_TYPE(std::string);
+    COPY_TYPE(unsigned long);
+    COPY_TYPE(std::vector<int>);
+    COPY_TYPE(std::vector<std::string>);
+    COPY_TYPE(std::vector<unsigned long>);
+    COPY_TYPE(std::tuple<unsigned int, unsigned int>);
+    COPY_TYPE(std::tuple<unsigned int, unsigned int, unsigned int>);
+#undef COPY_TYPE
+    OPENVINO_UNREACHABLE("No type found");
+}
+
+AnyCopyIEParamter::operator std::shared_ptr<SharedAnyImpl>() {
+    return operator SharedAny().get();
+}
+
+AnyCopyIEParamter any_copy(const ie::Parameter& parameter) {
+    return {parameter};
+}
+
+AnyCopyConfigMap::operator ie::ParamMap() {
+    ie::ParamMap result;
+    for (auto&& value : config_map) {
+        result.emplace(value.first, any_copy(value.second));
+    }
+    return result;
+}
+
+std::string AnyCopyConfigMap::to_string(const SharedAny& shared_any) {
+    std::stringstream strm;
+    shared_any.print(strm);
+    return strm.str();
+}
+
+AnyCopyConfigMap::operator std::map<std::string, std::string>() {
+    std::map<std::string, std::string> result;
+    for (auto&& value : config_map) {
+        result.emplace(value.first, to_string(value.second));
+    }
+    return result;
+}
+
+AnyCopyConfigMap any_copy(const runtime::ConfigMap& config_map) {
+    return {config_map};
+}
+
+runtime::ConfigMap any_copy(const std::map<std::string, std::string>& config_map) {
+    runtime::ConfigMap result;
+    for (auto&& value : config_map) {
+        result.emplace(value.first, SharedAny{value.second});
+    }
+    return result;
+}
+}  // namespace ov

--- a/inference-engine/src/inference_engine/src/any_copy.hpp
+++ b/inference-engine/src/inference_engine/src/any_copy.hpp
@@ -1,0 +1,37 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <ie_parameter.hpp>
+#include <istream>
+#include <map>
+#include <openvino/core/shared_any.hpp>
+#include <openvino/runtime/common.hpp>
+#include <openvino/runtime/parameter.hpp>
+#include <ostream>
+#include <string>
+
+namespace ov {
+
+ie::Parameter any_copy(const SharedAny& shared_any);
+ie::Parameter any_copy(const SharedAnyImpl::Ptr& shared_any_impl);
+runtime::ConfigMap any_copy(const std::map<std::string, std::string>& config_map);
+
+struct AnyCopyIEParamter {
+    operator SharedAny();
+    operator std::shared_ptr<SharedAnyImpl>();
+    const ie::Parameter& parameter;
+};
+AnyCopyIEParamter any_copy(const ie::Parameter& parameter);
+
+struct AnyCopyConfigMap {
+    operator ie::ParamMap();
+    std::string to_string(const SharedAny& shared_any);
+    operator std::map<std::string, std::string>();
+    const runtime::ConfigMap& config_map;
+};
+AnyCopyConfigMap any_copy(const runtime::ConfigMap& config_map);
+
+}  // namespace ov

--- a/inference-engine/src/inference_engine/src/cpp/ie_executable_network.cpp
+++ b/inference-engine/src/inference_engine/src/cpp/ie_executable_network.cpp
@@ -4,6 +4,7 @@
 
 #include "cpp/ie_executable_network.hpp"
 
+#include "any_copy.hpp"
 #include "cpp/exception2status.hpp"
 #include "cpp_interfaces/interface/ie_iexecutable_network_internal.hpp"
 #include "ie_common.h"
@@ -149,16 +150,16 @@ void ExecutableNetwork::export_model(std::ostream& networkModel) {
     OV_EXEC_NET_CALL_STATEMENT(_impl->Export(networkModel));
 }
 
-void ExecutableNetwork::set_config(const ie::ParamMap& config) {
-    OV_EXEC_NET_CALL_STATEMENT(_impl->SetConfig(config));
+void ExecutableNetwork::set_config(const ConfigMap& config) {
+    OV_EXEC_NET_CALL_STATEMENT(_impl->SetConfig(any_copy(config)));
 }
 
-ie::Parameter ExecutableNetwork::get_config(const std::string& name) const {
-    OV_EXEC_NET_CALL_STATEMENT(return _impl->GetConfig(name));
+Parameter ExecutableNetwork::get_config(const std::string& name) const {
+    OV_EXEC_NET_CALL_STATEMENT(return {_so, any_copy(_impl->GetConfig(name))});
 }
 
-ie::Parameter ExecutableNetwork::get_metric(const std::string& name) const {
-    OV_EXEC_NET_CALL_STATEMENT(return _impl->GetMetric(name));
+Parameter ExecutableNetwork::get_metric(const std::string& name) const {
+    OV_EXEC_NET_CALL_STATEMENT(return {_so, any_copy(_impl->GetMetric(name))});
 }
 
 std::shared_ptr<ie::RemoteContext> ExecutableNetwork::get_context() const {

--- a/inference-engine/src/inference_engine/src/cpp/ie_plugin.hpp
+++ b/inference-engine/src/inference_engine/src/cpp/ie_plugin.hpp
@@ -165,26 +165,26 @@ struct InferencePlugin {
         OV_PLUGIN_CALL_STATEMENT(_ptr->AddExtension(extension));
     }
 
-    void set_config(const ConfigMap& config) {
+    void set_config(const std::map<std::string, std::string>& config) {
         OV_PLUGIN_CALL_STATEMENT(_ptr->SetConfig(config));
     }
 
-    SoPtr<ie::IExecutableNetworkInternal> compile_model(const ie::CNNNetwork& network, const ConfigMap& config) {
+    SoPtr<ie::IExecutableNetworkInternal> compile_model(const ie::CNNNetwork& network, const std::map<std::string, std::string>& config) {
         OV_PLUGIN_CALL_STATEMENT(return {_so, _ptr->LoadNetwork(network, config)});
     }
 
     SoPtr<ie::IExecutableNetworkInternal> compile_model(const ie::CNNNetwork& network,
                                                         const std::shared_ptr<ie::RemoteContext>& context,
-                                                        const ConfigMap& config) {
+                                                        const std::map<std::string, std::string>& config) {
         OV_PLUGIN_CALL_STATEMENT(return {_so, _ptr->LoadNetwork(network, config, context)});
     }
 
-    SoPtr<ie::IExecutableNetworkInternal> compile_model(const std::string& modelPath, const ConfigMap& config) {
+    SoPtr<ie::IExecutableNetworkInternal> compile_model(const std::string& modelPath, const std::map<std::string, std::string>& config) {
         OV_PLUGIN_CALL_STATEMENT(return {_so, _ptr->LoadNetwork(modelPath, config)});
     }
 
     ie::QueryNetworkResult query_model(const ie::CNNNetwork& network,
-                                       const ConfigMap& config) const {
+                                       const std::map<std::string, std::string>& config) const {
         ie::QueryNetworkResult res;
         OV_PLUGIN_CALL_STATEMENT(res = _ptr->QueryNetwork(network, config));
         OPENVINO_ASSERT(res.rc == ie::OK, res.resp.msg);
@@ -192,18 +192,18 @@ struct InferencePlugin {
     }
 
     SoPtr<ie::IExecutableNetworkInternal> import_model(const std::string& modelFileName,
-                                                       const ConfigMap& config) {
+                                                       const std::map<std::string, std::string>& config) {
         OV_PLUGIN_CALL_STATEMENT(return {_so, _ptr->ImportNetwork(modelFileName, config)});
     }
 
     SoPtr<ie::IExecutableNetworkInternal> import_model(std::istream& networkModel,
-                                    const ConfigMap& config) {
+                                    const std::map<std::string, std::string>& config) {
         OV_PLUGIN_CALL_STATEMENT(return {_so, _ptr->ImportNetwork(networkModel, config)});
     }
 
     SoPtr<ie::IExecutableNetworkInternal> import_model(std::istream& networkModel,
                                                        const std::shared_ptr<ie::RemoteContext>& context,
-                                                       const ConfigMap& config) {
+                                                       const std::map<std::string, std::string>& config) {
         OV_PLUGIN_CALL_STATEMENT(return {_so, _ptr->ImportNetwork(networkModel, context, config)});
     }
 

--- a/inference-engine/src/inference_engine/src/ie_common.cpp
+++ b/inference-engine/src/inference_engine/src/ie_common.cpp
@@ -121,11 +121,6 @@ StatusCode InferenceEngineException::getStatus() const {
 }  // namespace details
 IE_SUPPRESS_DEPRECATED_END
 
-}  // namespace InferenceEngine
-
-namespace ov {
-
-namespace runtime {
 
 //
 // openvino/runtime/parameter.hpp
@@ -152,7 +147,4 @@ template struct Parameter::RealData<std::vector<unsigned long>>;
 template struct Parameter::RealData<std::tuple<unsigned int, unsigned int>>;
 template struct Parameter::RealData<std::tuple<unsigned int, unsigned int, unsigned int>>;
 #endif
-
-}  // namespace runtime
-
-}  // namespace ov
+}  // namespace InferenceEngine

--- a/ngraph/core/include/openvino/core/shared_any.hpp
+++ b/ngraph/core/include/openvino/core/shared_any.hpp
@@ -1,0 +1,189 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+#include <ostream>
+#include <typeinfo>
+
+#include "openvino/core/core_visibility.hpp"
+#include "openvino/core/except.hpp"
+#include "openvino/core/type.hpp"
+
+namespace ov {
+struct OPENVINO_API SharedAnyImpl : std::enable_shared_from_this<SharedAnyImpl> {
+    using Ptr = std::shared_ptr<SharedAnyImpl>;
+    virtual const std::type_info& get_type_info() const = 0;
+    virtual void print(std::ostream& os) const = 0;
+    virtual void* get() = 0;
+    const void* get() const {
+        return const_cast<SharedAnyImpl*>(this)->get();
+    }
+    virtual bool equal(const SharedAnyImpl& other) const = 0;
+
+protected:
+    ~SharedAnyImpl() = default;
+};
+
+class SharedAny {
+    template <typename...>
+    using void_t = void;
+
+    template <typename, typename = void>
+    struct ostreamable : std::false_type {};
+
+    // specialized as has_member< T , void > or discarded (sfinae)
+    template <typename T>
+    struct ostreamable<T, void_t<decltype(std::declval<std::ostream>() << std::declval<T>())>> : std::true_type {};
+
+    template <typename, typename = void>
+    struct equality_comparable : std::false_type {};
+
+    // specialized as has_member< T , void > or discarded (sfinae)
+    template <typename T>
+    struct equality_comparable<T, void_t<decltype(std::declval<T>() == std::declval<T>())>> : std::true_type {};
+
+    template <typename T>
+    struct Impl : public SharedAnyImpl {
+        template <typename... Args>
+        Impl(Args&&... args) : value{std::forward<Args>(args)...} {}
+
+        const std::type_info& get_type_info() const override {
+            return typeid(value);
+        }
+
+        template <class U>
+        static typename std::enable_if<ostreamable<U>::value>::type print(std::ostream& os, const U& value) {
+            os << value;
+        }
+
+        template <class U>
+        [[noreturn]] static typename std::enable_if<!ostreamable<U>::value>::type print(std::ostream&, const U&) {
+            OPENVINO_UNREACHABLE(typeid(T).name(), " has no output to std::ostream operator");
+        }
+        void print(std::ostream& os) const override {
+            print(os, value);
+        }
+        void* get() override {
+            return &value;
+        }
+
+        template <class U>
+        static typename std::enable_if<equality_comparable<U>::value, bool>::type equal(const U& rhs, const U& lhs) {
+            return rhs == lhs;
+        }
+        template <class U>
+        [[noreturn]] static typename std::enable_if<!equality_comparable<U>::value, bool>::type equal(const U&,
+                                                                                                      const U&) {
+            OPENVINO_UNREACHABLE(typeid(T).name(), " is not equality comparable");
+        }
+        bool equal(const SharedAnyImpl& other) const override {
+            if (get_type_info() == other.get_type_info()) {
+                return equal(this->value, *static_cast<const T*>(other.get()));
+            }
+            return false;
+        }
+        T value;
+    };
+
+public:
+    SharedAny() = default;
+
+    SharedAny(const SharedAnyImpl::Ptr& impl_) : impl{impl_} {}
+
+    template <
+        typename T,
+        typename DecayT = typename std::decay<T>::type,
+        typename Impl = Impl<DecayT>,
+        typename std::enable_if<std::is_copy_constructible<DecayT>::value && !std::is_same<DecayT, SharedAny>::value,
+                                bool>::type = true>
+    SharedAny(T&& value) : impl{std::make_shared<Impl>(std::forward<T>(value))} {}
+
+    template <typename T, typename... Args>
+    static SharedAny make(Args&&... args) {
+        return {std::make_shared<Impl<T>>(std::forward<Args>(args)...)};
+    }
+
+    const std::type_info& get_type_info() const {
+        OPENVINO_ASSERT(impl != nullptr, "SharedAny was not initialized");
+        return impl->get_type_info();
+    }
+
+    template <typename T>
+    bool is() const {
+        OPENVINO_ASSERT(impl != nullptr, "SharedAny was not initialized");
+        return impl->get_type_info() == typeid(T);
+    }
+
+    template <typename T>
+    T& as() & {
+        OPENVINO_ASSERT(is<T>(), "Bad cast from", impl->get_type_info().name(), " to ", typeid(T).name());
+        return *static_cast<T*>(impl->get());
+    }
+
+    template <typename T>
+    const T& as() const& {
+        OPENVINO_ASSERT(is<T>(), "Bad cast from", impl->get_type_info().name(), " to ", typeid(T).name());
+        return *static_cast<T*>(impl->get());
+    }
+
+    template <typename T>
+    T&& as() && {
+        OPENVINO_ASSERT(is<T>(), "Bad cast from", impl->get_type_info().name(), " to ", typeid(T).name());
+        return std::move(*static_cast<T*>(impl->get()));
+    }
+
+    template <typename T>
+    operator T&() & {
+        OPENVINO_ASSERT(is<T>(), "Bad cast from", impl->get_type_info().name(), " to ", typeid(T).name());
+        return *static_cast<T*>(impl->get());
+    }
+
+    template <typename T>
+    operator const T&() const& {
+        OPENVINO_ASSERT(is<T>(), "Bad cast from", impl->get_type_info().name(), " to ", typeid(T).name());
+        return *static_cast<T*>(impl->get());
+    }
+
+    template <typename T>
+    operator T &&() && {
+        OPENVINO_ASSERT(is<T>(), "Bad cast from", impl->get_type_info().name(), " to ", typeid(T).name());
+        return std::move(*static_cast<T*>(impl->get()));
+    }
+
+    void print(std::ostream& os) const {
+        OPENVINO_ASSERT(impl != nullptr, "SharedAny was not initialized");
+        impl->print(os);
+    }
+
+    bool operator==(const SharedAny& other) const {
+        OPENVINO_ASSERT(impl != nullptr && other.impl != nullptr, "Empty SharedAny is not comparable");
+        if (impl == other.impl)
+            return true;
+        return impl->equal(*other.impl);
+    }
+
+    bool operator!=(const SharedAny& other) const {
+        return !operator==(other);
+    }
+
+    SharedAnyImpl::Ptr get() const {
+        return impl;
+    }
+
+    operator SharedAnyImpl::Ptr() const {
+        return impl;
+    }
+
+    std::string to_string() {
+        std::stringstream strm;
+        impl->print(strm);
+        return strm.str();
+    }
+
+private:
+    SharedAnyImpl::Ptr impl;
+};
+}  // namespace ov

--- a/ngraph/test/CMakeLists.txt
+++ b/ngraph/test/CMakeLists.txt
@@ -89,6 +89,7 @@ set(SRC
     reshape_opt_kernel.cpp
     shape.cpp
     span.cpp
+    shared_any.cpp
     specialize_function.cpp
     tensor.cpp
     threading.cpp

--- a/ngraph/test/shared_any.cpp
+++ b/ngraph/test/shared_any.cpp
@@ -1,0 +1,58 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/core/shared_any.hpp"
+
+#include <string>
+
+#include "gtest/gtest.h"
+
+TEST(op, any_std_string) {
+    using namespace ov;
+    auto any = SharedAny{std::string{"My string"}};
+    ASSERT_TRUE(any.is<std::string>());
+    EXPECT_EQ(any.as<std::string>(), "My string");
+}
+
+TEST(op, any_int64_t) {
+    using namespace ov;
+    auto any = SharedAny{27ll};
+    ASSERT_TRUE(any.is<int64_t>());
+    EXPECT_FALSE(any.is<std::string>());
+    EXPECT_EQ(any.as<int64_t>(), 27);
+}
+
+struct Ship {
+    std::string name;
+    int16_t x;
+    int16_t y;
+};
+
+TEST(op, any_ship) {
+    using namespace ov;
+    {
+        auto any = SharedAny{Ship{"Lollipop", 3, 4}};
+        ASSERT_TRUE(any.is<Ship>());
+        Ship& ship = any.as<Ship>();
+        EXPECT_EQ(ship.name, "Lollipop");
+        EXPECT_EQ(ship.x, 3);
+        EXPECT_EQ(ship.y, 4);
+    }
+    {
+        auto any = SharedAny::make<Ship>("Lollipop", int16_t(3), int16_t(4));
+        ASSERT_TRUE(any.is<Ship>());
+        Ship& ship = any.as<Ship>();
+        EXPECT_EQ(ship.name, "Lollipop");
+        EXPECT_EQ(ship.x, 3);
+        EXPECT_EQ(ship.y, 4);
+    }
+    {
+        auto any = SharedAny::make<Ship>("Lollipop", int16_t(3), int16_t(4));
+        ASSERT_TRUE(any.is<Ship>());
+        Ship ship = any;
+        EXPECT_EQ(ship.name, "Lollipop");
+        EXPECT_EQ(ship.x, 3);
+        EXPECT_EQ(ship.y, 4);
+    }
+}


### PR DESCRIPTION
### Details:
 - Added `SharedAny` class 
 - Should replace `ie::Paramter` and `ngraph::Variant`
 - Can be split into `SharedAnyImpl` part that can be loaded from plugin and wrapper part that allows convenient work
 - Added thin `ov::runtime::Parameter`  class that wraps `SharedAny` and `so` reference and allows just read-only operations.
 - ov::runtime API changed to take maps of `SharedAny` instead of maps of `std::strings`
 - Added `any_copy()` internal functions that allows pass values betwin various `any` implementations used in OpenVINO