### PR TITLE
[GNA] Fix KEY_EXEC_TARGET

### DIFF
--- a/inference-engine/src/gna_plugin/gna_device.hpp
+++ b/inference-engine/src/gna_plugin/gna_device.hpp
@@ -202,6 +202,7 @@ public:
 
     static void enforceLegacyCnns(Gna2Model& gnaModel);
     static void enforceLegacyCnnsWhenNeeded(Gna2Model& gnaModel);
+    static Gna2DeviceVersion parseTarget(std::string target);
     Gna2DeviceVersion parseDeclaredTarget(std::string target, const bool execTarget) const;
     Gna2DeviceVersion getDefaultTarget() const;
     Gna2DeviceVersion getTargetDevice(bool execTarget) const;

--- a/inference-engine/src/gna_plugin/gna_device.hpp
+++ b/inference-engine/src/gna_plugin/gna_device.hpp
@@ -206,6 +206,9 @@ public:
     Gna2DeviceVersion parseDeclaredTarget(std::string target, const bool execTarget) const;
     Gna2DeviceVersion getDefaultTarget() const;
     Gna2DeviceVersion getTargetDevice(bool execTarget) const;
+
+    void createVirtualDevice(Gna2DeviceVersion devVersion, std::string purpose);
+    void detectGnaDeviceVersion();
 #endif
     void setOMPThreads(uint8_t const n_threads);
 

--- a/inference-engine/src/gna_plugin/gna_device.hpp
+++ b/inference-engine/src/gna_plugin/gna_device.hpp
@@ -202,13 +202,13 @@ public:
 
     static void enforceLegacyCnns(Gna2Model& gnaModel);
     static void enforceLegacyCnnsWhenNeeded(Gna2Model& gnaModel);
-    static Gna2DeviceVersion parseTarget(std::string target);
+    static Gna2DeviceVersion parseTarget(const std::string& target);
     Gna2DeviceVersion parseDeclaredTarget(std::string target, const bool execTarget) const;
     Gna2DeviceVersion getDefaultTarget() const;
     Gna2DeviceVersion getTargetDevice(bool execTarget) const;
 
-    void createVirtualDevice(Gna2DeviceVersion devVersion, std::string purpose);
-    void detectGnaDeviceVersion();
+    void createVirtualDevice(Gna2DeviceVersion devVersion, std::string purpose = "");
+    void updateGnaDeviceVersion();
 #endif
     void setOMPThreads(uint8_t const n_threads);
 


### PR DESCRIPTION
### Details:
 - When user specifies value for `InferenceEngine::GNAConfigParams::KEY_GNA_EXEC_TARGET` and it's different than the detected GNA device, then use `Gna2DeviceCreateForExport()` to create GNA 'virtual device' compliant with the specified one.

### Tickets:
 - 66309
