### PR TITLE
[DON'T MERGE] 'Convert op': check rounding behavior

### DIFF
--- a/inference-engine/tests/functional/shared_test_classes/src/single_layer/conversion.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/single_layer/conversion.cpp
@@ -5,6 +5,7 @@
 #include "shared_test_classes/single_layer/conversion.hpp"
 
 #include "ngraph_functions/builders.hpp"
+#include <ie_ngraph_utils.hpp>
 
 namespace LayerTestsDefinitions {
 
@@ -41,5 +42,6 @@ void ConversionLayerTest::SetUp() {
 
     ngraph::ResultVector results{std::make_shared<ngraph::opset3::Result>(conversion)};
     function = std::make_shared<ngraph::Function>(results, params, "Conversion");
+    outPrc = InferenceEngine::details::convertPrecision(function->get_output_element_type(0));
 }
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/src/conversion.cpp
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/src/conversion.cpp
@@ -13,7 +13,29 @@ std::shared_ptr<ngraph::Node> makeConversion(const ngraph::Output<Node>& in,
                                              const element::Type& output_type,
                                              const ngraph::helpers::ConversionTypes& conversionType) {
     if (conversionType == ngraph::helpers::ConversionTypes::CONVERT) {
-        return std::make_shared<ngraph::opset1::Convert>(in, output_type);
+        if (in.get_element_type() == ov::element::f32) {
+            auto add_const = std::make_shared<ngraph::opset1::Constant>(ov::element::f32, Shape{1},
+                                                                        std::vector<float>{0.8});
+            auto add = std::make_shared<ngraph::opset1::Add>(in, add_const);
+            return std::make_shared<ngraph::opset1::Convert>(add, output_type);
+        } else if (in.get_element_type() == ov::element::f16) {
+            auto add_const = std::make_shared<ngraph::opset1::Constant>(ov::element::f16, Shape{1},
+                                                                        std::vector<float>{0.8});
+            auto add = std::make_shared<ngraph::opset1::Add>(in, add_const);
+            return std::make_shared<ngraph::opset1::Convert>(add, output_type);
+        } else if (in.get_element_type() == ov::element::f64) {
+            auto add_const = std::make_shared<ngraph::opset1::Constant>(ov::element::f64, Shape{1},
+                                                                        std::vector<float>{0.8});
+            auto add = std::make_shared<ngraph::opset1::Add>(in, add_const);
+            return std::make_shared<ngraph::opset1::Convert>(add, output_type);
+        } else if (in.get_element_type() == ov::element::bf16) {
+            auto add_const = std::make_shared<ngraph::opset1::Constant>(ov::element::bf16, Shape{1},
+                                                                        std::vector<float>{0.8});
+            auto add = std::make_shared<ngraph::opset1::Add>(in, add_const);
+            return std::make_shared<ngraph::opset1::Convert>(add, output_type);
+        } else {
+            return std::make_shared<ngraph::opset1::Convert>(in, output_type);
+        }
     } else if (conversionType == ngraph::helpers::ConversionTypes::CONVERT_LIKE) {
         const auto like = std::make_shared<op::Constant>(output_type, ngraph::Shape{1});
         return std::make_shared<ngraph::opset1::ConvertLike>(in, like);


### PR DESCRIPTION
### Details:
 - Modified 'conversion' test to check how plugins actually do roundings to uint8, e.g. if 3.8f -> uint8 is converted to 3 or 4
 - *...*

### Tickets:
 - 65862
