### PR TITLE
[MO] Fix axes in FusedBatchNorm -> MVN transformation

### DIFF
--- a/model-optimizer/extensions/middle/FusedBatchNormTraining.py
+++ b/model-optimizer/extensions/middle/FusedBatchNormTraining.py
@@ -58,7 +58,7 @@ class FusedBatchNormTraining(MiddleReplacementPattern):
 
         input_rank = len(node.in_port(0).data.get_shape())
         rng = create_op_with_const_inputs(graph, Range,
-                                          {0: int64_array(2), 1: int64_array(input_rank), 2: int64_array(1)},
+                                          {0: int64_array(1), 1: int64_array(input_rank - 1), 2: int64_array(1)},
                                           {'name': node_name + '/Range', 'output_type': np.int64})
         mvn = MVN(graph, {'name': node_name + '/mvn_', 'eps': node.soft_get('eps', 1e-6), 'eps_mode': 'outside_sqrt',
                           'normalize_variance': 1, 'override_output_shape': True}).create_node()


### PR DESCRIPTION
### Details:
 - *Root cause FusedBatchNorm to MVN MO transformation was creating MVN with wrong axes. It is triggered only for NHWC layout but was creating axes [2, ..., rank-1], for 4D cases it was [2, 3], while axes should be [1, 2]*

### Tickets:
 - *65264*
