### PR TITLE
[CPU] Migration on oneDNN v2.3.2

### DIFF
--- a/inference-engine/src/mkldnn_plugin/emitters/jit_eltwise_emitters.cpp
+++ b/inference-engine/src/mkldnn_plugin/emitters/jit_eltwise_emitters.cpp
@@ -1297,7 +1297,7 @@ jit_power_static_emitter::jit_power_static_emitter(jit_generator *host, cpu_isa_
     power = ngraph::as_type_ptr<ngraph::op::Constant>(parent)->get_data_ptr<float>()[0];
     scale = 1.f;
     shift = 0.f;
-    push_arg_entry_of("power", float2int(power), true);
+    push_arg_entry_of("power", cpu::x64::float2int(power), true);
     push_arg_entry_of("scale", 0x3f800000, true);
     push_arg_entry_of("shift", 0x00000000, true);
     push_arg_entry_of("one",   0x3f800000, true);
@@ -1475,10 +1475,10 @@ void jit_power_static_emitter::emit_isa(const std::vector<size_t> &in_vec_idxs, 
 }
 
 void jit_power_static_emitter::register_table_entries() {
-    push_arg_entry_of("power", float2int(power), true);
-    push_arg_entry_of("scale", float2int(scale), true);
-    push_arg_entry_of("shift", float2int(shift), true);
-    push_arg_entry_of("one",   float2int(1.f), true);
+    push_arg_entry_of("power", cpu::x64::float2int(power), true);
+    push_arg_entry_of("scale", cpu::x64::float2int(scale), true);
+    push_arg_entry_of("shift", cpu::x64::float2int(shift), true);
+    push_arg_entry_of("one",   cpu::x64::float2int(1.f), true);
 }
 
 size_t jit_power_static_emitter::aux_vecs_count() const {

--- a/inference-engine/src/mkldnn_plugin/emitters/jit_mkldnn_emitters.hpp
+++ b/inference-engine/src/mkldnn_plugin/emitters/jit_mkldnn_emitters.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <cpu/x64/jit_generator.hpp>
-#include <cpu/x64/jit_uni_eltwise_injector.hpp>
+#include <cpu/x64/injectors/jit_uni_eltwise_injector.hpp>
 #include "jit_emitter.hpp"
 #include "mkldnn_node.h"
 

--- a/inference-engine/src/mkldnn_plugin/mkldnn_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_node.cpp
@@ -1024,7 +1024,7 @@ Layout MKLDNNNode::getWeightsLayoutByDims(SizeVector dims, bool isGrouped) {
     }
 }
 
-void MKLDNNNode::appendPostOps(mkldnn::post_ops& ops) {
+void MKLDNNNode::appendPostOps(mkldnn::post_ops& ops, bool initAsBinary, bool initBinaryMemory) {
     IE_THROW() << "Fusing of " << this->getType() << " operation is not implemented";
 }
 

--- a/inference-engine/src/mkldnn_plugin/mkldnn_node.h
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_node.h
@@ -578,7 +578,7 @@ protected:
      * Seed node should call this routine and pass its post operations list as parameter.
      * @param ops List of fused post operations
      */
-    virtual void appendPostOps(mkldnn::post_ops& ops);
+    virtual void appendPostOps(mkldnn::post_ops& ops, bool initAsBinary = false, bool initBinaryMemory = false);
     virtual std::shared_ptr<mkldnn::primitive_attr> initPrimitiveAttr() const { return nullptr; }
 
     typedef std::function<DnnlMemoryDescPtr (mkldnn::primitive_desc_iterator &primitive_desc_it, size_t idx)>
@@ -613,6 +613,7 @@ protected:
     std::vector<MKLDNNMemoryPtr> internalBlobMemory;
     std::vector<NodeDesc> supportedPrimitiveDescriptors;
     std::unordered_map<int, mkldnn::memory> primArgs;
+    std::vector<mkldnn::memory> binaryPostOpsArgs;
     MKLDNNPrimitive prim;
     std::vector<MKLDNNDescriptor> descs;
 

--- a/inference-engine/src/mkldnn_plugin/nodes/common/softmax.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/common/softmax.cpp
@@ -6,7 +6,7 @@
 
 #include <ie_parallel.hpp>
 #include <cpu/x64/jit_generator.hpp>
-#include <cpu/x64/jit_uni_eltwise_injector.hpp>
+#include <cpu/x64/injectors/jit_uni_eltwise_injector.hpp>
 #include <mkldnn.hpp>  // TODO: just to replace mkldnn->dnnl via macros
 #include "utils/bfloat16.hpp"
 #include "emitters/jit_bf16_emitters.hpp"

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_bin_conv_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_bin_conv_node.cpp
@@ -14,8 +14,8 @@
 #include <mkldnn_extension_utils.h>
 #include "ie_parallel.hpp"
 #include "cpu/x64/jit_generator.hpp"
-#include "cpu/x64/jit_uni_eltwise_injector.hpp"
-#include "cpu/x64/jit_uni_depthwise_injector.hpp"
+#include "cpu/x64/injectors/jit_uni_eltwise_injector.hpp"
+#include "cpu/x64/injectors/jit_uni_depthwise_injector.hpp"
 #include "cpu/x64/cpu_isa_traits.hpp"
 #include "utils/general_utils.h"
 #include <ngraph/opsets/opset1.hpp>
@@ -848,7 +848,7 @@ private:
 
         // offset = 4
         for (size_t d = 0; d < simd_w; ++d) {
-            dd(float2int(jcp_.ic * jcp_.kw * jcp_.kh));
+            dd(x64::float2int(jcp_.ic * jcp_.kw * jcp_.kh));
         }
 
         // offset = 5

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.cpp
@@ -325,7 +325,8 @@ void MKLDNNConvolutionNode::getSupportedDescriptors() {
     }
 }
 
-void MKLDNNConvolutionNode::setPostOps(mkldnn::primitive_attr &attr, bool initWeights = false) const {
+void MKLDNNConvolutionNode::setPostOps(mkldnn::primitive_attr &attr, bool initWeights = false, bool initAsBinary = false) {
+    bool initBinaryMemory = initWeights;
     mkldnn::post_ops ops;
 
     for (auto &node : fusedWith) {
@@ -334,16 +335,37 @@ void MKLDNNConvolutionNode::setPostOps(mkldnn::primitive_attr &attr, bool initWe
 
         auto* eltwiseNode = dynamic_cast<MKLDNNEltwiseNode *>(node.get());
         if (eltwiseNode) {
-            if (eltwiseNode->isSpecialConvolutionAddFusing())
+            if (eltwiseNode->isSpecialConvolutionAddFusing()) {
                 ops.append_sum(1.0, MKLDNNExtensionUtils::IEPrecisionToDataType(eltwisePrecision));
-            else
-                eltwiseNode->appendPostOps(ops);
+            } else {
+                eltwiseNode->appendPostOps(ops, initAsBinary, initBinaryMemory);
+                if (initBinaryMemory) {
+                    if (eltwiseNode->scalesMemory)
+                        binaryPostOpsArgs.push_back(eltwiseNode->scalesMemory->GetPrimitive());
+                    if (eltwiseNode->shiftsMemory)
+                        binaryPostOpsArgs.push_back(eltwiseNode->shiftsMemory->GetPrimitive());
+                }
+            }
             continue;
         }
 
         auto* fakeQuantizeNode = dynamic_cast<MKLDNNFakeQuantizeNode *>(node.get());
         if (fakeQuantizeNode) {
-            fakeQuantizeNode->appendPostOps(ops);
+            fakeQuantizeNode->appendPostOps(ops, initAsBinary, initBinaryMemory);
+            if (initBinaryMemory) {
+                if (fakeQuantizeNode->cropHighMemory)
+                    binaryPostOpsArgs.push_back(fakeQuantizeNode->cropHighMemory->GetPrimitive());
+                if (fakeQuantizeNode->cropLowMemory)
+                    binaryPostOpsArgs.push_back(fakeQuantizeNode->cropLowMemory->GetPrimitive());
+                if (fakeQuantizeNode->inputScaleMemory)
+                    binaryPostOpsArgs.push_back(fakeQuantizeNode->inputScaleMemory->GetPrimitive());
+                if (fakeQuantizeNode->inputShiftMemory)
+                    binaryPostOpsArgs.push_back(fakeQuantizeNode->inputShiftMemory->GetPrimitive());
+                if (fakeQuantizeNode->outputScaleMemory)
+                    binaryPostOpsArgs.push_back(fakeQuantizeNode->outputScaleMemory->GetPrimitive());
+                if (fakeQuantizeNode->outputShiftMemory)
+                    binaryPostOpsArgs.push_back(fakeQuantizeNode->outputShiftMemory->GetPrimitive());
+            }
             continue;
         }
 
@@ -383,79 +405,84 @@ void MKLDNNConvolutionNode::initSupportedPrimitiveDescriptors() {
     if (!supportedPrimitiveDescriptors.empty())
         return;
 
-    mkldnn::primitive_attr attr;
-    addZeroPoints(attr);
-    setPostOps(attr);
+    // attr[0] - depthwise, quantize
+    // attr[1] - binary
+    mkldnn::primitive_attr attrs[1];
+    setPostOps(attrs[0]);
+//    setPostOps(attrs[1], false, true);
 
     bool containJitImpl = false;
 
     for (auto& desc : descs) {
         if (containJitImpl && isPossibleToSkipInitConfig(desc))
             continue;
-        auto itpd = desc.createPrimitiveDescriptorIterator(getEngine(), attr);
-        while (static_cast<bool>(itpd)) {
-            NodeConfig config;
-            config.dynBatchSupport = true;
-            for (size_t i = 0; i < descInputNumbers(desc); i++) {
-                PortConfig dataConfig;
-                dataConfig.inPlace = -1;
-                dataConfig.constant = false;
-                auto desc = getSrcMemDesc(itpd, i);
-                if (desc->getType() & MemoryDescType::Blocked && !isGrouped) {
-                    dataConfig.desc = desc->as<BlockedMemoryDesc>()->cloneWithUndefStridesAndOffset();
-                } else {
-                    dataConfig.desc = std::move(desc);
-                }
-
-                config.inConfs.push_back(dataConfig);
-            }
-
-            if (withDWConv) {
-                auto weightsPrc = MKLDNNExtensionUtils::IEPrecisionToDataType(dw_conv_in_dt == mkldnn_u8 ? Precision::I8 : Precision::FP32);
-                auto biasPrc = memory::data_type::f32;
-
-                std::vector<size_t> dwWeightsDims({dw_conv_oc, 1, 1, dw_conv_kernel[Y_AXIS], dw_conv_kernel[X_AXIS]});
-                std::vector<size_t> dwBiasesDims({dw_conv_oc});
-
-                PortConfig dataConfig;
-                dataConfig.inPlace = -1;
-                dataConfig.constant = false;
-                dataConfig.desc = std::make_shared<DnnlBlockedMemoryDesc>(Shape(dwWeightsDims), weightsPrc, memory::format_tag::Goihw8g);
-                config.inConfs.push_back(dataConfig);
-
-                dataConfig.desc = std::make_shared<DnnlBlockedMemoryDesc>(Shape(dwBiasesDims), biasPrc, memory::format_tag::x);
-                config.inConfs.push_back(dataConfig);
-            }
-
-            for (size_t i = 0; i < descOutputNumbers(desc); i++) {
-                PortConfig dataConfig;
-                if (withSum) {
-                    dataConfig.inPlace = getParentEdges().size() - 1;
-                }
-
-                dataConfig.constant = false;
-                auto desc = getDstMemDesc(itpd, i);
-                if (desc->getType() & MemoryDescType::Blocked && !isGrouped) {
-                    dataConfig.desc = desc->as<BlockedMemoryDesc>()->cloneWithUndefStridesAndOffset();
-                } else {
-                    dataConfig.desc = std::move(desc);
-                }
-
-                config.outConfs.push_back(dataConfig);
-
-                if (withSum) {
+        for (auto &attr : attrs) {
+            addZeroPoints(attr);
+            auto itpd = desc.createPrimitiveDescriptorIterator(getEngine(), attr);
+            while (static_cast<bool>(itpd)) {
+                NodeConfig config;
+                config.dynBatchSupport = true;
+                for (size_t i = 0; i < descInputNumbers(desc); i++) {
+                    PortConfig dataConfig;
                     dataConfig.inPlace = -1;
-                    dataConfig.desc = dataConfig.desc->cloneWithNewPrecision(dataConfig.desc->getPrecision());
+                    dataConfig.constant = false;
+                    auto desc = getSrcMemDesc(itpd, i);
+                    if (desc->getType() & MemoryDescType::Blocked && !isGrouped) {
+                        dataConfig.desc = desc->as<BlockedMemoryDesc>()->cloneWithUndefStridesAndOffset();
+                    } else {
+                        dataConfig.desc = std::move(desc);
+                    }
+
                     config.inConfs.push_back(dataConfig);
                 }
-            }
-            impl_desc_type impl_type = parse_impl_name(itpd.impl_info_str());
-            if (impl_type & jit)
-                containJitImpl = true;
 
-            supportedPrimitiveDescriptors.emplace_back(config, impl_type);
-            if (!itpd.next_impl())
-                break;
+                if (withDWConv) {
+                    auto weightsPrc = MKLDNNExtensionUtils::IEPrecisionToDataType(dw_conv_in_dt == mkldnn_u8 ? Precision::I8 : Precision::FP32);
+                    auto biasPrc = memory::data_type::f32;
+
+                    std::vector<size_t> dwWeightsDims({dw_conv_oc, 1, 1, dw_conv_kernel[Y_AXIS], dw_conv_kernel[X_AXIS]});
+                    std::vector<size_t> dwBiasesDims({dw_conv_oc});
+
+                    PortConfig dataConfig;
+                    dataConfig.inPlace = -1;
+                    dataConfig.constant = false;
+                    dataConfig.desc = std::make_shared<DnnlBlockedMemoryDesc>(Shape(dwWeightsDims), weightsPrc, memory::format_tag::Goihw8g);
+                    config.inConfs.push_back(dataConfig);
+
+                    dataConfig.desc = std::make_shared<DnnlBlockedMemoryDesc>(Shape(dwBiasesDims), biasPrc, memory::format_tag::x);
+                    config.inConfs.push_back(dataConfig);
+                 }
+
+                for (size_t i = 0; i < descOutputNumbers(desc); i++) {
+                    PortConfig dataConfig;
+                    if (withSum) {
+                        dataConfig.inPlace = getParentEdges().size() - 1;
+                    }
+
+                    dataConfig.constant = false;
+                    auto desc = getDstMemDesc(itpd, i);
+                    if (desc->getType() & MemoryDescType::Blocked && !isGrouped) {
+                        dataConfig.desc = desc->as<BlockedMemoryDesc>()->cloneWithUndefStridesAndOffset();
+                    } else {
+                        dataConfig.desc = std::move(desc);
+                    }
+
+                    config.outConfs.push_back(dataConfig);
+
+                    if (withSum) {
+                        dataConfig.inPlace = -1;
+                        dataConfig.desc = dataConfig.desc->cloneWithNewPrecision(dataConfig.desc->getPrecision());
+                        config.inConfs.push_back(dataConfig);
+                    }
+                }
+                impl_desc_type impl_type = parse_impl_name(itpd.impl_info_str());
+                if (impl_type & jit)
+                    containJitImpl = true;
+
+                supportedPrimitiveDescriptors.emplace_back(config, impl_type);
+                if (!itpd.next_impl())
+                    break;
+            }
         }
     }
 }
@@ -467,7 +494,11 @@ void MKLDNNConvolutionNode::createPrimitive() {
 
     mkldnn::primitive_attr attr;
     addZeroPoints(attr);
-    setPostOps(attr, true);
+    if (false && getSelectedPrimitiveDescriptor()->getImplementationType() == jit_gemm) {
+        setPostOps(attr, true, true);
+    } else {
+        setPostOps(attr, true);
+    }
 
     auto prim_desc = createPrimitiveDescriptor<convolution_forward::primitive_desc,
             convolution_forward::desc>(attr);
@@ -480,6 +511,14 @@ void MKLDNNConvolutionNode::createPrimitive() {
         primArgs = {{DNNL_ARG_SRC, src}, {DNNL_ARG_WEIGHTS, getWeights()}, {DNNL_ARG_BIAS, getBias()}, {DNNL_ARG_DST, dst}};
     else
         primArgs = {{DNNL_ARG_SRC, src}, {DNNL_ARG_WEIGHTS, getWeights()}, {DNNL_ARG_DST, dst}};
+
+//    auto post_ops = attr.get_post_ops();
+//    int idx = 0;
+//    for (int i = 0; i < post_ops.len(); i++) {
+//        if (post_ops.kind(i) == mkldnn::primitive::kind::binary) {
+//            primArgs.insert({DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1, binaryPostOpsArgs[idx++]});
+//        }
+//    }
 }
 
 bool MKLDNNConvolutionNode::created() const {
@@ -547,7 +586,7 @@ void MKLDNNConvolutionNode::addZeroPoints(mkldnn::primitive_attr& attr) const {
 }
 
 void MKLDNNConvolutionNode::initDescriptor(const NodeConfig& config) {
-    auto* selectedPD = getSelectedPrimitiveDescriptor();
+    auto *selectedPD = getSelectedPrimitiveDescriptor();
     if (!selectedPD) {
         return;
     }
@@ -564,10 +603,11 @@ void MKLDNNConvolutionNode::initDescriptor(const NodeConfig& config) {
     if (isStridedBlobsSupported) {
         createDescriptor({config.inConfs[0].desc}, {config.outConfs[0].desc});
     }
-
-    mkldnn::primitive_attr attr;
-    addZeroPoints(attr);
-    setPostOps(attr);
+    // attr[0] - depthwise, quantize
+    // attr[1] - binary
+    mkldnn::primitive_attr attrs[1];
+    setPostOps(attrs[0]);
+//    setPostOps(attrs[1], false, true);
 
     auto rightConfig = selectedPD->getConfig();
     size_t selected_count = 0;
@@ -578,67 +618,70 @@ void MKLDNNConvolutionNode::initDescriptor(const NodeConfig& config) {
         auto& desc = descs[i];
         if (containJitImpl && isPossibleToSkipInitConfig(desc))
             continue;
-        auto itpd = desc.createPrimitiveDescriptorIterator(getEngine(), attr);
-        while (static_cast<bool>(itpd)) {
-            NodeConfig cfg;
-            cfg.dynBatchSupport = true;
-            for (size_t j = 0; j < descInputNumbers(desc); j++) {
-                PortConfig dataConfig;
-                dataConfig.inPlace = -1;
-                dataConfig.constant = false;
-                dataConfig.desc = getSrcMemDesc(itpd, j);
-                cfg.inConfs.push_back(dataConfig);
-            }
-
-            if (withDWConv) {
-                auto weightsPrc = MKLDNNExtensionUtils::IEPrecisionToDataType(dw_conv_in_dt == mkldnn_u8 ? Precision::I8 : Precision::FP32);
-                auto biasPrc = memory::data_type::f32;
-
-                std::vector<size_t> dwWeightsDims({dw_conv_oc, 1, 1, dw_conv_kernel[Y_AXIS], dw_conv_kernel[X_AXIS]});
-                std::vector<size_t> dwBiasesDims({dw_conv_oc});
-
-                PortConfig dataConfig;
-                dataConfig.inPlace = -1;
-                dataConfig.constant = false;
-                dataConfig.desc = std::make_shared<DnnlBlockedMemoryDesc>(Shape(dwWeightsDims), weightsPrc, memory::format_tag::Goihw8g);
-                cfg.inConfs.push_back(dataConfig);
-
-                dataConfig.desc = std::make_shared<DnnlBlockedMemoryDesc>(Shape(dwBiasesDims), biasPrc, memory::format_tag::x);
-                cfg.inConfs.push_back(dataConfig);
-            }
-
-            for (size_t j = 0; j < descOutputNumbers(desc); j++) {
-                PortConfig dataConfig;
-                dataConfig.inPlace = -1;
-                dataConfig.constant = false;
-                dataConfig.desc = getDstMemDesc(itpd, j);
-                if (withSum) {
-                    auto eltwiseConfig = dataConfig;
-                    eltwiseConfig.desc = eltwiseConfig.desc->cloneWithNewPrecision(eltwisePrecision);
-                    cfg.inConfs.push_back(eltwiseConfig);
-                    dataConfig.inPlace = getParentEdges().size() - 1;
+        for (auto &attr : attrs) {
+            addZeroPoints(attr);
+            auto itpd = desc.createPrimitiveDescriptorIterator(getEngine(), attr);
+            while (static_cast<bool>(itpd)) {
+                NodeConfig cfg;
+                cfg.dynBatchSupport = true;
+                for (size_t j = 0; j < descInputNumbers(desc); j++) {
+                    PortConfig dataConfig;
+                    dataConfig.inPlace = -1;
+                    dataConfig.constant = false;
+                    dataConfig.desc = getSrcMemDesc(itpd, j);
+                    cfg.inConfs.push_back(dataConfig);
                 }
 
-                cfg.outConfs.push_back(dataConfig);
-            }
-            impl_desc_type impl_type = parse_impl_name(itpd.impl_info_str());
-            if (impl_type & jit)
-                containJitImpl = true;
+                if (withDWConv) {
+                    auto weightsPrc = MKLDNNExtensionUtils::IEPrecisionToDataType(dw_conv_in_dt == mkldnn_u8 ? Precision::I8 : Precision::FP32);
+                    auto biasPrc = memory::data_type::f32;
 
-            if (selected_count == selectedPrimitiveDescriptorIndex) {
-                if (impl_type != selectedPD->getImplementationType()) {
-                    IE_THROW() << "Cannot get the original layer configuration!";
+                    std::vector <size_t> dwWeightsDims({dw_conv_oc, 1, 1, dw_conv_kernel[Y_AXIS], dw_conv_kernel[X_AXIS]});
+                    std::vector <size_t> dwBiasesDims({dw_conv_oc});
+
+                    PortConfig dataConfig;
+                    dataConfig.inPlace = -1;
+                    dataConfig.constant = false;
+                    dataConfig.desc = std::make_shared<DnnlBlockedMemoryDesc>(Shape(dwWeightsDims), weightsPrc, memory::format_tag::Goihw8g);
+                    cfg.inConfs.push_back(dataConfig);
+
+                    dataConfig.desc = std::make_shared<DnnlBlockedMemoryDesc>(Shape(dwBiasesDims), biasPrc, memory::format_tag::x);
+                    cfg.inConfs.push_back(dataConfig);
                 }
-                rightConfig = cfg;
-            }
-            if (i == descs.size() - 1 && isStridedBlobsSupported) {
-                if (impl_type == selectedPD->getImplementationType()) {
-                    rightConfig = config;
+
+                for (size_t j = 0; j < descOutputNumbers(desc); j++) {
+                    PortConfig dataConfig;
+                    dataConfig.inPlace = -1;
+                    dataConfig.constant = false;
+                    dataConfig.desc = getDstMemDesc(itpd, j);
+                    if (withSum) {
+                        auto eltwiseConfig = dataConfig;
+                        eltwiseConfig.desc = eltwiseConfig.desc->cloneWithNewPrecision(eltwisePrecision);
+                        cfg.inConfs.push_back(eltwiseConfig);
+                        dataConfig.inPlace = getParentEdges().size() - 1;
+                    }
+
+                    cfg.outConfs.push_back(dataConfig);
                 }
+                impl_desc_type impl_type = parse_impl_name(itpd.impl_info_str());
+                if (impl_type & jit)
+                    containJitImpl = true;
+
+                if (selected_count == selectedPrimitiveDescriptorIndex) {
+                    if (impl_type != selectedPD->getImplementationType()) {
+                        IE_THROW() << "Cannot get the original layer configuration!";
+                    }
+                    rightConfig = cfg;
+                }
+                if (i == descs.size() - 1 && isStridedBlobsSupported) {
+                    if (impl_type == selectedPD->getImplementationType()) {
+                        rightConfig = config;
+                    }
+                }
+                selected_count++;
+                if (!itpd.next_impl())
+                    break;
             }
-            selected_count++;
-            if (!itpd.next_impl())
-                break;
         }
     }
     selectedPD->setConfig(rightConfig);

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_conv_node.h
@@ -66,7 +66,7 @@ protected:
 
 private:
     void addZeroPoints(mkldnn::primitive_attr& attr) const;
-    void setPostOps(mkldnn::primitive_attr &attr, bool initWeights) const;
+    void setPostOps(mkldnn::primitive_attr &attr, bool initWeights, bool initAsBinary);
     void filterSupportedDescriptors();
     bool isPossibleToSkipInitConfig(MKLDNNDescriptor &desc) const;
     bool isNspcAvailable() const;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_def_conv_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_def_conv_node.cpp
@@ -140,11 +140,11 @@ private:
         }
 
         for (size_t d = 0; d < vlen / sizeof(int32_t); ++d) {
-            dd(float2int(static_cast<float>(jcp_.ih)));
+            dd(cpu::x64::float2int(static_cast<float>(jcp_.ih)));
         }
 
         for (size_t d = 0; d < vlen / sizeof(int32_t); ++d) {
-            dd(float2int(static_cast<float>(jcp_.iw)));
+            dd(cpu::x64::float2int(static_cast<float>(jcp_.iw)));
         }
 
         for (size_t d = 0; d < vlen / sizeof(int32_t); ++d) {
@@ -331,7 +331,7 @@ private:
                         size_t def_off_h = ((2 * (kh * jcp_.kw + kw) + 0) * jcp_.oh * jcp_.ow) + ow;
                         mov(reg_tmp_32, ptr[aux_reg_def_off + def_off_h * jcp_.typesize_off]);
                         movq(xmm_tmp, reg_tmp_64);
-                        mov(reg_tmp_32, float2int(static_cast<float>((kh * (jcp_.dilate_h + 1)))));
+                        mov(reg_tmp_32, cpu::x64::float2int(static_cast<float>((kh * (jcp_.dilate_h + 1)))));
                         movq(xmm_map_h, reg_tmp_64);
                         addss(xmm_map_h, xmm_tmp);
 
@@ -358,7 +358,7 @@ private:
                         size_t def_off_w = ((2 * (kh * jcp_.kw + kw) + 1) * jcp_.oh * jcp_.ow) + ow;
                         mov(reg_tmp_32, ptr[aux_reg_def_off + def_off_w * jcp_.typesize_off]);
                         movq(xmm_tmp, reg_tmp_64);
-                        mov(reg_tmp_32, float2int(static_cast<float>((kw * (jcp_.dilate_w + 1)))));
+                        mov(reg_tmp_32, cpu::x64::float2int(static_cast<float>((kw * (jcp_.dilate_w + 1)))));
                         movq(xmm_map_w, reg_tmp_64);
                         addss(xmm_map_w, xmm_tmp);
 

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_eltwise_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_eltwise_node.cpp
@@ -8,7 +8,7 @@
 
 #include <mkldnn_types.h>
 #include "utils/bfloat16.hpp"
-#include <cpu/x64/jit_uni_quantization_injector.hpp>
+#include <cpu/x64/injectors/jit_uni_quantization_injector.hpp>
 #include <cpu/ref_eltwise.hpp>
 
 #include "mkldnn_extension_utils.h"
@@ -923,7 +923,7 @@ std::map<const ngraph::DiscreteTypeInfo, std::function<void(const std::shared_pt
     }},
     {ngraph::op::v4::HSwish::type_info, [](const std::shared_ptr<ngraph::Node>& op, MKLDNNEltwiseNode& node) {
         node.algorithm = EltwiseHswish;
-        node.mkldnnAlgorithm = mkldnn::algorithm::eltwise_hswish;
+        node.mkldnnAlgorithm = mkldnn::algorithm::eltwise_hardswish;
     }},
     {ngraph::op::v4::Mish::type_info, [](const std::shared_ptr<ngraph::Node>& op, MKLDNNEltwiseNode& node) {
         node.algorithm = EltwiseMish;
@@ -1673,13 +1673,19 @@ void MKLDNNEltwiseNode::fuseInto(MKLDNNNodePtr& parentNode) {
     // TODO [DS]: at this moment this transformation prohibit for dynamic case
     specialConvolutionAddFusing = (parentNode->getType() == Convolution || parentNode->getType() == BinaryConvolution) && getAlgorithm() == EltwiseAdd &&
             getInputShapeAtPort(0) == getInputShapeAtPort(1);
-    if (!specialConvolutionAddFusing && parentNode->getType() != Eltwise && canBePerformedAsScaleShift(parentNode.get())) {
-        fillScalesAndShifts(parentNode.get(), scales, shifts, 16);
+    if (!specialConvolutionAddFusing && canBePerformedAsScaleShift(parentNode.get())) {
+        if ((parentNode->getType() == FullyConnected) && one_of(getAlgorithm(), EltwiseAdd, EltwiseSubtract,
+                EltwiseMultiply, EltwiseDivide, EltwiseMulAdd, EltwisePowerStatic, EltwisePrelu)) {
+            fillScalesAndShifts(parentNode.get(), scales, shifts);
+        } else {
+            fillScalesAndShifts(parentNode.get(), scales, shifts, 16);
+        }
+        scalesSize = static_cast<size_t>(outputShapes[0].getStaticDims()[outputShapes[0].getRank() > 1 ? 1 : 0]);
     }
     MKLDNNNode::fuseInto(parentNode);
 }
 
-void MKLDNNEltwiseNode::appendPostOps(mkldnn::post_ops& ops) {
+void MKLDNNEltwiseNode::appendPostOps(mkldnn::post_ops& ops, bool initAsBinary, bool initBinaryMemory) {
     const std::string errorPrefix = "Appending Eltwise node with name '" + getName() + "' ";
     if (getMKLDNNAlgorithm() != mkldnn::algorithm::undef) {
         switch (getMKLDNNAlgorithm()) {
@@ -1698,7 +1704,7 @@ void MKLDNNEltwiseNode::appendPostOps(mkldnn::post_ops& ops) {
             case mkldnn::algorithm::eltwise_gelu_tanh:
             case mkldnn::algorithm::eltwise_clip:
             case mkldnn::algorithm::eltwise_swish:
-            case mkldnn::algorithm::eltwise_hswish:
+            case mkldnn::algorithm::eltwise_hardswish:
             case mkldnn::algorithm::eltwise_mish:
             case mkldnn::algorithm::eltwise_hsigmoid:
             case mkldnn::algorithm::eltwise_round_half_to_even:
@@ -1708,23 +1714,71 @@ void MKLDNNEltwiseNode::appendPostOps(mkldnn::post_ops& ops) {
             default: IE_THROW() << errorPrefix << "as post operation is not supported";
         }
     } else {
-        switch (getAlgorithm()) {
-            case EltwiseAdd:
-            case EltwiseSubtract:
-            case EltwiseMultiply:
-            case EltwiseDivide:
-            case EltwiseMulAdd:
-            case EltwisePowerStatic:
-                if (scales.empty() || shifts.empty())
+        if (initAsBinary) {
+            auto appendBinary = [&](const mkldnn::algorithm alg, MKLDNNMemoryPtr &memPtr, const std::vector<float> &data) {
+                if (data.empty())
                     IE_THROW() << errorPrefix << "cannot be performed since buffers are not allocated";
-                ops.append_depthwise(mkldnn::algorithm::depthwise_scale_shift, &scales[0], &shifts[0]);
-                break;
-            case EltwisePrelu:
-                if (scales.empty())
-                    IE_THROW() << errorPrefix << "cannot be performed since buffers are not allocated";
-                ops.append_depthwise(mkldnn::algorithm::depthwise_prelu, &scales[0], nullptr);
-                break;
-            default: IE_THROW() << errorPrefix << "as post operation is not supported";
+
+                auto outShape = outputShapes[0].getStaticDims();
+                auto chIdx = outputShapes[0].getRank() > 1 ? 1 : 0;
+
+                std::vector<size_t> binaryShape(outShape.size(), 1);
+                binaryShape[chIdx] = outShape[chIdx];
+
+                DnnlBlockedMemoryDesc memoryDesc(Precision::FP32, Shape(binaryShape));
+                ops.append_binary(alg, memoryDesc.getDnnlDesc());
+
+                if (initBinaryMemory) {
+                    memPtr.reset(new MKLDNNMemory(getEngine()));
+                    memPtr->Create(memoryDesc, &data[0]);
+                }
+            };
+            switch (getAlgorithm()) {
+                case EltwiseAdd:
+                case EltwiseSubtract:
+                    appendBinary(mkldnn::algorithm::binary_add, shiftsMemory, shifts);
+                    break;
+//
+//                    appendBinary(mkldnn::algorithm::binary_sub, shiftsMemory, shifts);
+//                    break;
+                case EltwiseMultiply:
+                case EltwiseDivide:
+                    appendBinary(mkldnn::algorithm::binary_mul, scalesMemory, scales);
+                    break;
+//
+//                    appendBinary(mkldnn::algorithm::binary_div, scalesMemory, scales);
+//                    break;
+                case EltwiseMulAdd:
+                case EltwisePowerStatic:
+                    appendBinary(mkldnn::algorithm::binary_mul, scalesMemory, scales);
+                    appendBinary(mkldnn::algorithm::binary_add, shiftsMemory, shifts);
+                    break;
+                case EltwisePrelu:
+                    appendBinary(mkldnn::algorithm::binary_prelu, scalesMemory, scales);
+                    break;
+                default:
+                    IE_THROW() << errorPrefix << "as post operation is not supported";
+            }
+        } else {
+            switch (getAlgorithm()) {
+                case EltwiseAdd:
+                case EltwiseSubtract:
+                case EltwiseMultiply:
+                case EltwiseDivide:
+                case EltwiseMulAdd:
+                case EltwisePowerStatic:
+                    if (scales.empty() || shifts.empty())
+                        IE_THROW() << errorPrefix << "cannot be performed since buffers are not allocated";
+                    ops.append_depthwise(mkldnn::algorithm::depthwise_scale_shift, &scales[0], &shifts[0]);
+                    break;
+                case EltwisePrelu:
+                    if (scales.empty())
+                        IE_THROW() << errorPrefix << "cannot be performed since buffers are not allocated";
+                    ops.append_depthwise(mkldnn::algorithm::depthwise_prelu, &scales[0], nullptr);
+                    break;
+                default:
+                    IE_THROW() << errorPrefix << "as post operation is not supported";
+            }
         }
     }
 }

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_eltwise_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_eltwise_node.h
@@ -75,13 +75,15 @@ public:
     bool created() const override;
     bool canBeInPlace() const override;
     bool canFuse(const MKLDNNNodePtr& node) const override;
-    void appendPostOps(mkldnn::post_ops& ops) override;
+    void appendPostOps(mkldnn::post_ops& ops, bool initAsBinary = false, bool initBinaryMemory = false) override;
     void fuseInto(MKLDNNNodePtr& parentNode) override;
     InferenceEngine::Precision getRuntimePrecision() const override;
 
     float getAlpha() const { return alpha; }
     float getBeta() const { return beta; }
     float getGamma() const { return gamma; }
+    MKLDNNMemoryPtr scalesMemory;
+    MKLDNNMemoryPtr shiftsMemory;
     mkldnn::algorithm getMKLDNNAlgorithm() const { return mkldnnAlgorithm; }
 
     bool isWithBroadcast();
@@ -146,6 +148,7 @@ private:
 
     std::vector<float> scales = {};
     std::vector<float> shifts = {};
+    size_t scalesSize = 0;
 
     std::vector<MKLDNNMemoryPtr> memPtrs = {};
 

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_fake_quantize_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_fake_quantize_node.h
@@ -90,12 +90,24 @@ public:
     const std::vector<float>& getOutputScale() const { return outputScale; }
     const std::vector<float>& getOutputShift() const { return outputShift; }
 
-    void setCropLow(std::vector<float> newCropLow) { cropLow = std::move(newCropLow); isPostOpDataInitialized = false; }
-    void setCropHigh(std::vector<float> newCropHigh) { cropHigh = std::move(newCropHigh); isPostOpDataInitialized = false; }
-    void setInputScale(std::vector<float> newInputScale) { inputScale = std::move(newInputScale); isPostOpDataInitialized = false; }
-    void setInputShift(std::vector<float> newInputShift) { inputShift = std::move(newInputShift); isPostOpDataInitialized = false; }
-    void setOutputScale(std::vector<float> newOutputScale) { outputScale = std::move(newOutputScale); isPostOpDataInitialized = false;}
-    void setOutputShift(std::vector<float> newOutputShift) { outputShift = std::move(newOutputShift); isPostOpDataInitialized = false; }
+    void setCropLow(std::vector<float> newCropLow) {
+        cropLow = std::move(newCropLow); cropLowSize = cropLow.size(); isPostOpDataInitialized = false;
+    }
+    void setCropHigh(std::vector<float> newCropHigh) {
+        cropHigh = std::move(newCropHigh); cropHighSize = cropHigh.size(); isPostOpDataInitialized = false;
+    }
+    void setInputScale(std::vector<float> newInputScale) {
+        inputScale = std::move(newInputScale); inputScaleSize = inputScale.size(); isPostOpDataInitialized = false;
+    }
+    void setInputShift(std::vector<float> newInputShift) {
+        inputShift = std::move(newInputShift); inputShiftSize = inputShift.size(); isPostOpDataInitialized = false;
+    }
+    void setOutputScale(std::vector<float> newOutputScale) {
+        outputScale = std::move(newOutputScale); outputScaleSize = outputScale.size(); isPostOpDataInitialized = false;
+    }
+    void setOutputShift(std::vector<float> newOutputShift) {
+        outputShift = std::move(newOutputShift); outputShiftSize = outputShift.size(); isPostOpDataInitialized = false;
+    }
 
     bool isInputLowBroadcast() const { return isInputLowBroadcasted; }
     bool isInputHighBroadcast() const { return isInputHighBroadcasted; }
@@ -105,9 +117,16 @@ public:
     InferenceEngine::Precision getInputPrecision() const { return inputPrecision; }
     InferenceEngine::Precision getOutputPrecision() const { return outputPrecision; }
 
-    void appendPostOps(mkldnn::post_ops& ops) override;
+    void appendPostOps(mkldnn::post_ops& ops, bool initAsBinary = false, bool initBinaryMemory = false) override;
 
     static bool isSupportedOperation(const std::shared_ptr<const ngraph::Node>& op, std::string& errorMessage) noexcept;
+
+    MKLDNNMemoryPtr cropLowMemory;
+    MKLDNNMemoryPtr cropHighMemory;
+    MKLDNNMemoryPtr inputScaleMemory;
+    MKLDNNMemoryPtr inputShiftMemory;
+    MKLDNNMemoryPtr outputScaleMemory;
+    MKLDNNMemoryPtr outputShiftMemory;
 
 private:
     void init() override;
@@ -129,6 +148,13 @@ private:
     std::vector<float> inputShift;
     std::vector<float> outputScale;
     std::vector<float> outputShift;
+
+    size_t cropLowSize;
+    size_t cropHighSize;
+    size_t inputScaleSize;
+    size_t inputShiftSize;
+    size_t outputScaleSize;
+    size_t outputShiftSize;
 
     // mkldnn style post ops data representation
     bool isPostOpDataInitialized = false;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_fullyconnected_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_fullyconnected_node.h
@@ -54,7 +54,7 @@ private:
     InferenceEngine::SizeVector biasesDims;
 
     std::vector<MKLDNNMemoryPtr> PostOpsIntBlobMemory;
-    void setPostOps(mkldnn::primitive_attr &attr, bool initWeights);
+    void setPostOps(mkldnn::primitive_attr &attr, bool initWeights, bool initAsBinary);
 
     bool withBiases = false;
 

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_interpolate_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_interpolate_node.cpp
@@ -16,9 +16,9 @@
 
 #include <cpu/x64/jit_generator.hpp>
 #include <cpu/x64/jit_uni_eltwise.hpp>
-#include <cpu/x64/jit_uni_depthwise_injector.hpp>
-#include <cpu/x64/jit_uni_quantization_injector.hpp>
-#include <cpu/x64/jit_uni_eltwise_injector.hpp>
+#include <cpu/x64/injectors/jit_uni_depthwise_injector.hpp>
+#include <cpu/x64/injectors/jit_uni_quantization_injector.hpp>
+#include <cpu/x64/injectors/jit_uni_eltwise_injector.hpp>
 #include "common/cpu_memcpy.h"
 #include "utils/bfloat16.hpp"
 #include "emitters/jit_bf16_emitters.hpp"

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_mvn_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_mvn_node.cpp
@@ -18,9 +18,9 @@
 
 #include <cpu/x64/jit_generator.hpp>
 #include <cpu/x64/jit_uni_eltwise.hpp>
-#include <cpu/x64/jit_uni_depthwise_injector.hpp>
-#include <cpu/x64/jit_uni_quantization_injector.hpp>
-#include <cpu/x64/jit_uni_eltwise_injector.hpp>
+#include <cpu/x64/injectors/jit_uni_depthwise_injector.hpp>
+#include <cpu/x64/injectors/jit_uni_quantization_injector.hpp>
+#include <cpu/x64/injectors/jit_uni_eltwise_injector.hpp>
 
 #include <ngraph/opsets/opset6.hpp>
 #include "memory_desc/dnnl_blocked_memory_desc.h"

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_normalize_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_normalize_node.cpp
@@ -13,9 +13,9 @@
 #include <mkldnn_extension_utils.h>
 #include "emitters/jit_bf16_emitters.hpp"
 #include "mkldnn_extension_utils.h"
-#include <cpu/x64/jit_uni_eltwise_injector.hpp>
-#include <cpu/x64/jit_uni_depthwise_injector.hpp>
-#include <cpu/x64/jit_uni_quantization_injector.hpp>
+#include <cpu/x64/injectors/jit_uni_eltwise_injector.hpp>
+#include <cpu/x64/injectors/jit_uni_depthwise_injector.hpp>
+#include <cpu/x64/injectors/jit_uni_quantization_injector.hpp>
 #include "common/cpu_memcpy.h"
 #include "nodes/common/cpu_convert.h"
 #include <mkldnn_selective_build.h>

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reduce_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reduce_node.cpp
@@ -18,9 +18,9 @@
 
 #include <cpu/x64/jit_generator.hpp>
 #include <cpu/x64/jit_uni_eltwise.hpp>
-#include <cpu/x64/jit_uni_depthwise_injector.hpp>
-#include <cpu/x64/jit_uni_quantization_injector.hpp>
-#include <cpu/x64/jit_uni_eltwise_injector.hpp>
+#include <cpu/x64/injectors/jit_uni_depthwise_injector.hpp>
+#include <cpu/x64/injectors/jit_uni_quantization_injector.hpp>
+#include <cpu/x64/injectors/jit_uni_eltwise_injector.hpp>
 #include <ngraph/opsets/opset1.hpp>
 #include <ngraph/opsets/opset4.hpp>
 

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_region_yolo_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_region_yolo_node.cpp
@@ -13,7 +13,7 @@
 #include "common/cpu_convert.h"
 #include <cpu/x64/jit_generator.hpp>
 #include <emitters/jit_bf16_emitters.hpp>
-#include <cpu/x64/jit_uni_eltwise_injector.hpp>
+#include <cpu/x64/injectors/jit_uni_eltwise_injector.hpp>
 #include "utils/bfloat16.hpp"
 
 using namespace MKLDNNPlugin;

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reorder_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reorder_node.cpp
@@ -356,7 +356,7 @@ void MKLDNNReorderNode::reorderData(const MKLDNNMemory &input, const MKLDNNMemor
             }
         }
         if (pReorder) {
-            mkldnn::stream loc_stream(output.getEngine(), mkldnn::stream::flags::default_order);
+            mkldnn::stream loc_stream(output.getEngine(), mkldnn::stream::flags::in_order);
             pReorder->execute(loc_stream, *srcMemoryPtr, *output.GetPrimitivePtr());
         } else {
             IE_THROW() << "Could not make mkldnn reorder.";


### PR DESCRIPTION
What's new:
- binary post
- binary post ops support for gemm convolution and gemm inner product
- plugin fixes
- mkldnn: avx512: fixed prelu post op

Known issues:
- Binary post ops are temporarily disabled for convolution due to performance issues
- Issues with RNN nodes performance
-------

### Details:
- Old PR https://github.com/openvinotoolkit/openvino/pull/7212
- https://github.com/openvinotoolkit/oneDNN/pull/76

### Tickets:
- 66455