### PR TITLE
Improved ov::Tensor behavior

### DIFF
--- a/inference-engine/ie_bridges/python/tests/test_Blob.py
+++ b/inference-engine/ie_bridges/python/tests/test_Blob.py
@@ -132,9 +132,9 @@ def test_set_shape():
 
     array = np.ones([1, 3, 127, 127], dtype=np.float32)
     blob = Blob(tensor_desc, array)
-    blob.set_shape([1, 4, 128, 128])
-    assert blob.tensor_desc.dims == [1, 4, 128, 128]
-    assert blob.buffer.shape == (1, 4, 128, 128)
+    with pytest.raises(ValueError) as e:
+        blob.set_shape([1, 4, 128, 128])
+    assert "Cannot call setShape for Blobs created on top of preallocated memory." in str(e.value)
 
 
 @pytest.mark.ngraph_dependent_test

--- a/inference-engine/ie_bridges/python/tests/test_Blob.py
+++ b/inference-engine/ie_bridges/python/tests/test_Blob.py
@@ -130,11 +130,14 @@ def test_set_shape():
     assert blob.tensor_desc.dims == [1, 4, 128, 128]
     assert blob.buffer.shape == (1, 4, 128, 128)
 
+
+def test_cannot_set_shape_preallocated_memory():
+    tensor_desc = TensorDesc("FP32", [1, 3, 127, 127], "NHWC")
     array = np.ones([1, 3, 127, 127], dtype=np.float32)
     blob = Blob(tensor_desc, array)
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(RuntimeError) as e:
         blob.set_shape([1, 4, 128, 128])
-    assert "Cannot call setShape for Blobs created on top of preallocated memory." in str(e.value)
+    assert "Cannot call setShape for Blobs created on top of preallocated memory" in str(e.value)
 
 
 @pytest.mark.ngraph_dependent_test

--- a/inference-engine/src/inference_engine/include/ie/ie_blob.h
+++ b/inference-engine/src/inference_engine/include/ie/ie_blob.h
@@ -192,22 +192,7 @@ public:
      *
      * @param dims new shape
      */
-    void setShape(const SizeVector& dims) {
-        if (properProduct(dims) > properProduct(getTensorDesc().getDims())) {
-            // New blob shape requires more memory than old one -- reallocate
-            if (!deallocate())
-                IE_THROW() << "Cannot deallocate blob while an attempt to enlarge blob area in setShape.";
-
-            // Old and new ranks should match as well as layouts
-            getTensorDesc().setDims(dims);
-
-            allocate();
-            // no way to detect if allocation is successful other than map/unmap that we wouldn't like to do here
-        } else {
-            // Don't shrink area when new size fit the existing area
-            getTensorDesc().setDims(dims);
-        }
-    }
+    void setShape(const SizeVector& dims);
 
     /**
      * @deprecated Cast to MemoryBlob and use new wlock/rwlock API instead.

--- a/inference-engine/src/inference_engine/include/ie/ie_layouts.h
+++ b/inference-engine/src/inference_engine/include/ie/ie_layouts.h
@@ -84,7 +84,7 @@ public:
     /**
      * @brief Returns the vector of order
      *
-     * @return order
+     * @return order of dimensions
      */
     const SizeVector& getOrder() const {
         return order;
@@ -93,7 +93,7 @@ public:
     /**
      * @brief Returns the per-dimension offset vector
      *
-     * @return offsets
+     * @return offsets in elements
      */
     const SizeVector& getOffsetPaddingToData() const {
         return offsetPaddingToData;
@@ -102,7 +102,7 @@ public:
     /**
      * @brief Returns the offset to the current memory block
      *
-     * @return offset
+     * @return offset in elements
      */
     size_t getOffsetPadding() const {
         return offsetPadding;
@@ -111,7 +111,7 @@ public:
     /**
      * @brief Returns strides for each dimension
      *
-     * @return strides
+     * @return strides in elements
      */
     const SizeVector& getStrides() const {
         return strides;

--- a/inference-engine/src/inference_engine/src/ie_blob_common.cpp
+++ b/inference-engine/src/inference_engine/src/ie_blob_common.cpp
@@ -7,8 +7,55 @@
 #include <vector>
 
 #include "ie_blob.h"
+#include "system_allocator.hpp"
 
 namespace InferenceEngine {
+
+void Blob::setShape(const SizeVector& dims) {
+    // we don't want to allow setShape for:
+    // 1. ROI cases
+    {
+        size_t denseStride = 1;
+        const auto& blockedDims = getTensorDesc().getBlockingDesc().getBlockDims();
+        const auto& strides = getTensorDesc().getBlockingDesc().getStrides();
+
+        for (size_t i = 1; i <= strides.size(); i++) {
+            if (denseStride != strides[strides.size() - i]) {
+                IE_THROW() << "Blob::setShape requires dense blob";
+            }
+            denseStride *= blockedDims[blockedDims.size() - i];
+        }
+    }
+
+    // 2. Blobs created on top of preallocated memory
+    if (std::dynamic_pointer_cast<InferenceEngine::details::PreAllocator>(getAllocator())) {
+        IE_THROW() << "Cannot call setShape for Blobs created on top of preallocated memory.";
+    }
+
+    if (properProduct(dims) > properProduct(getTensorDesc().getDims())) {
+        // New blob shape requires more memory than old one -- reallocate
+        if (!deallocate()) {
+            IE_THROW() << "Cannot deallocate blob while an attempt to enlarge blob area in setShape.";
+        }
+
+        // Old and new ranks should match as well as layouts
+        getTensorDesc().setDims(dims);
+
+        allocate();
+        // no way to detect if allocation is successful other than map/unmap
+        // that we wouldn't like to do here; but for cases when we use SystemMemoryAllocator
+        // we can do it
+        if (std::dynamic_pointer_cast<InferenceEngine::SystemMemoryAllocator>(getAllocator())) {
+            if (buffer() == nullptr) {
+                IE_THROW() << "Failed to allocate memory in Blob::setShape";
+            }
+        }
+    } else {
+        // Don't shrink area when new size fit the existing area
+        getTensorDesc().setDims(dims);
+    }
+}
+
 Blob::Ptr Blob::createROI(const ROI& roi) const {
     if (getTensorDesc().getLayout() == Layout::NCHW || getTensorDesc().getLayout() == Layout::NHWC) {
         return createROI({roi.id, 0, roi.posY, roi.posX},

--- a/inference-engine/src/inference_engine/src/ie_layouts.cpp
+++ b/inference-engine/src/inference_engine/src/ie_layouts.cpp
@@ -288,6 +288,21 @@ BlockingDesc::BlockingDesc(const SizeVector& blocked_dims,
     if (blocked_dims.size() != dimOffsets.size())
         IE_THROW() << "Offsets are not initialized for all dimensions.";
     this->offsetPaddingToData = dimOffsets;
+
+    // check that strides are valid
+    {
+        size_t denseStride = 1;
+
+        for (size_t i = 1; i <= strides.size(); i++) {
+            if (denseStride > strides[strides.size() - i]) {
+                IE_THROW() << "Stride in " << (strides.size() - i)
+                           << "-th dimension "
+                              "is not valid; actual "
+                           << strides[strides.size() - i] << ", should be >= " << denseStride << std::endl;
+            }
+            denseStride = std::max(strides[strides.size() - i], denseStride) * blocked_dims[blocked_dims.size() - i];
+        }
+    }
 }
 
 BlockingDesc::BlockingDesc(const SizeVector& dims, Layout layout) : offsetPadding(0) {

--- a/ngraph/core/CMakeLists.txt
+++ b/ngraph/core/CMakeLists.txt
@@ -18,6 +18,7 @@ set(IE_SHARED_SRCS
     "${IE_SRC_ROOT}/system_allocator.cpp"
     "${IE_SRC_ROOT}/blob_factory.cpp"
     "${IE_SRC_ROOT}/ie_blob_common.cpp"
+    "${IE_SRC_ROOT}/system_allocator.cpp"
     "${IE_SRC_ROOT}/ie_layouts.cpp")
 set(MIXED_SRC ${IE_SHARED_SRCS}
     "${CMAKE_CURRENT_SOURCE_DIR}/src/runtime/allocator.cpp"

--- a/ngraph/core/include/openvino/runtime/tensor.hpp
+++ b/ngraph/core/include/openvino/runtime/tensor.hpp
@@ -70,10 +70,7 @@ public:
      * @param strides Optional strides parameters in elements. Strides are supposed to be equal to shape if they are not
      * set
      */
-    Tensor(const element::Type type,
-           const Shape& shape,
-           void* host_ptr,
-           const Strides& strides = {});
+    Tensor(const element::Type type, const Shape& shape, void* host_ptr, const Strides& strides = {});
 
     /**
      * @brief Constructs region of interest (ROI) tensor form another tensor.

--- a/ngraph/core/include/openvino/runtime/tensor.hpp
+++ b/ngraph/core/include/openvino/runtime/tensor.hpp
@@ -67,15 +67,12 @@ public:
      * @param type Tensor element type
      * @param shape Tensor shape
      * @param host_ptr Pointer to pre-allocated host memory
-     * @param size Optional size of allocated host memory in elements. If it is not set (default is `0`), the size of
-     * memory supposed to be not less then ov::shape_size(shape) * type.size() in bytes.
      * @param strides Optional strides parameters in elements. Strides are supposed to be equal to shape if they are not
      * set
      */
     Tensor(const element::Type type,
            const Shape& shape,
            void* host_ptr,
-           const size_t size = 0,
            const Strides& strides = {});
 
     /**

--- a/ngraph/core/src/runtime/ov_tensor.cpp
+++ b/ngraph/core/src/runtime/ov_tensor.cpp
@@ -41,7 +41,6 @@ Tensor::Tensor(const element::Type element_type, const Shape& shape, const Alloc
 Tensor::Tensor(const element::Type element_type,
                const Shape& shape,
                void* host_ptr,
-               const size_t size,
                const Strides& strides) {
     ie::SizeVector blk_order(shape.size());
     std::iota(blk_order.begin(), blk_order.end(), 0);
@@ -50,12 +49,6 @@ Tensor::Tensor(const element::Type element_type,
     if (strides.empty()) {
         blk_strides = ov::row_major_strides(shape);
     } else {
-        OPENVINO_ASSERT(shape.size() == strides.size(),
-                        "shape.size() (",
-                        shape.size(),
-                        ") must be equal to strides.size() (",
-                        strides.size(),
-                        ")");
         blk_strides.assign(strides.begin(), strides.end());
     }
 
@@ -64,8 +57,7 @@ Tensor::Tensor(const element::Type element_type,
                                          ie::TensorDesc{ie::details::convertPrecision(element_type),
                                                         shape,
                                                         ie::BlockingDesc{shape, blk_order, 0, dim_offset, blk_strides}},
-                                         host_ptr,
-                                         size);
+                                         host_ptr);
     } catch (const std::exception& ex) {
         throw ov::Exception(ex.what());
     } catch (...) {

--- a/ngraph/core/src/runtime/ov_tensor.cpp
+++ b/ngraph/core/src/runtime/ov_tensor.cpp
@@ -38,10 +38,7 @@ Tensor::Tensor(const element::Type element_type, const Shape& shape, const Alloc
     _impl->allocate();
 }
 
-Tensor::Tensor(const element::Type element_type,
-               const Shape& shape,
-               void* host_ptr,
-               const Strides& strides) {
+Tensor::Tensor(const element::Type element_type, const Shape& shape, void* host_ptr, const Strides& strides) {
     ie::SizeVector blk_order(shape.size());
     std::iota(blk_order.begin(), blk_order.end(), 0);
     ie::SizeVector dim_offset(shape.size(), 0);


### PR DESCRIPTION
### Details:
 - Check that `Tensor` strides are valid
 - Fixed behavior for `Blob::setShape` - throw exception in case of ROI blob or external memory
 - Removed `size` from ctor with external memory

### Tickets:
 - CVS-33206
 - CVS-66390
