### PR TITLE
[IE] Add new API to return the number of logical cores

### DIFF
--- a/inference-engine/src/inference_engine/src/ie_system_conf.cpp
+++ b/inference-engine/src/inference_engine/src/ie_system_conf.cpp
@@ -95,6 +95,21 @@ std::vector<int> getAvailableNUMANodes() {
     return {-1};
 }
 #    endif
+int getNumberOfLogicalCPUCores(bool) {
+    return parallel_get_max_threads();
+}
+#else
+int getNumberOfLogicalCPUCores(bool bigCoresOnly) {
+    int logical_cores = parallel_get_max_threads();
+#    if (IE_THREAD == IE_THREAD_TBB || IE_THREAD == IE_THREAD_TBB_AUTO)
+    auto core_types = custom::info::core_types();
+    if (bigCoresOnly && core_types.size() > 1) /*Hybrid CPU*/ {
+        logical_cores = custom::info::default_concurrency(
+            custom::task_arena::constraints{}.set_core_type(core_types.back()).set_max_threads_per_core(-1));
+    }
+#    endif
+    return logical_cores;
+}
 #endif
 
 #if ((IE_THREAD == IE_THREAD_TBB) || (IE_THREAD == IE_THREAD_TBB_AUTO))

--- a/inference-engine/src/plugin_api/ie_system_conf.h
+++ b/inference-engine/src/plugin_api/ie_system_conf.h
@@ -53,6 +53,16 @@ INFERENCE_ENGINE_API_CPP(std::vector<int>) getAvailableCoresTypes();
 INFERENCE_ENGINE_API_CPP(int) getNumberOfCPUCores(bool bigCoresOnly = false);
 
 /**
+ * @brief      Returns number of CPU logical cores on Linux/Windows (on other OSes it simply relies on the original
+ * parallel API of choice, which uses the 'all' logical cores). call function with 'false' to get #logical cores of
+ * all types call function with 'true' to get #logical 'Big' cores number of 'Little' = 'all' - 'Big'
+ * @ingroup    ie_dev_api_system_conf
+ * @param[in]  bigCoresOnly Additionally limits the number of reported cores to the 'Big' cores only.
+ * @return     Number of logical CPU cores.
+ */
+INFERENCE_ENGINE_API_CPP(int) getNumberOfLogicalCPUCores(bool bigCoresOnly = false);
+
+/**
  * @brief      Checks whether CPU supports SSE 4.2 capability
  * @ingroup    ie_dev_api_system_conf
  * @return     `True` is SSE 4.2 instructions are available, `false` otherwise

--- a/inference-engine/tests/functional/inference_engine/task_executor_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/task_executor_tests.cpp
@@ -206,6 +206,18 @@ static auto Executors = ::testing::Values(
                                                streams, threads/streams, IStreamsExecutor::ThreadBindingType::NONE});
     },
     [] {
+        auto streams = getNumberOfLogicalCPUCores(true);
+        auto threads = parallel_get_max_threads();
+        return std::make_shared<CPUStreamsExecutor>(IStreamsExecutor::Config{"TestCPUStreamsExecutor",
+                                               streams, threads/streams, IStreamsExecutor::ThreadBindingType::NONE});
+    },
+    [] {
+        auto streams = getNumberOfLogicalCPUCores(false);
+        auto threads = parallel_get_max_threads();
+        return std::make_shared<CPUStreamsExecutor>(IStreamsExecutor::Config{"TestCPUStreamsExecutor",
+                                               streams, threads/streams, IStreamsExecutor::ThreadBindingType::NONE});
+    },
+    [] {
         return std::make_shared<ImmediateExecutor>();
     }
 );
@@ -215,6 +227,18 @@ INSTANTIATE_TEST_SUITE_P(TaskExecutorTests, TaskExecutorTests, Executors);
 static auto AsyncExecutors = ::testing::Values(
     [] {
         auto streams = getNumberOfCPUCores();
+        auto threads = parallel_get_max_threads();
+        return std::make_shared<CPUStreamsExecutor>(IStreamsExecutor::Config{"TestCPUStreamsExecutor",
+                                               streams, threads/streams, IStreamsExecutor::ThreadBindingType::NONE});
+    },
+    [] {
+        auto streams = getNumberOfLogicalCPUCores(true);
+        auto threads = parallel_get_max_threads();
+        return std::make_shared<CPUStreamsExecutor>(IStreamsExecutor::Config{"TestCPUStreamsExecutor",
+                                               streams, threads/streams, IStreamsExecutor::ThreadBindingType::NONE});
+    },
+    [] {
+        auto streams = getNumberOfLogicalCPUCores(false);
         auto threads = parallel_get_max_threads();
         return std::make_shared<CPUStreamsExecutor>(IStreamsExecutor::Config{"TestCPUStreamsExecutor",
                                                streams, threads/streams, IStreamsExecutor::ThreadBindingType::NONE});


### PR DESCRIPTION
### Details:
 - *Create new API to return the number of logical cores for BIG and All cores*
 - *This is needed for gpu plugin's cpu affinity control*


### Tickets:
 - *63585*
