### PR TITLE
[GNA] Fix KEY_EXEC_TARGET (cherry pick #7671)

### DIFF
--- a/inference-engine/src/gna_plugin/gna_device.hpp
+++ b/inference-engine/src/gna_plugin/gna_device.hpp
@@ -202,9 +202,13 @@ public:
 
     static void enforceLegacyCnns(Gna2Model& gnaModel);
     static void enforceLegacyCnnsWhenNeeded(Gna2Model& gnaModel);
+    static Gna2DeviceVersion parseTarget(const std::string& target);
     Gna2DeviceVersion parseDeclaredTarget(std::string target, const bool execTarget) const;
     Gna2DeviceVersion getDefaultTarget() const;
     Gna2DeviceVersion getTargetDevice(bool execTarget) const;
+
+    void createVirtualDevice(Gna2DeviceVersion devVersion, std::string purpose = "");
+    void updateGnaDeviceVersion();
 #endif
     void setOMPThreads(uint8_t const n_threads);
 


### PR DESCRIPTION
### Details:
 - When user specifies value for `InferenceEngine::GNAConfigParams::KEY_GNA_EXEC_TARGET` and it's different than the detected GNA device, then use `Gna2DeviceCreateForExport()` to create GNA 'virtual device' compliant with the specified one.
 - Update detected GNA device version field in GNA Device helper
 - Use EXEC instead of COMPILE TARGET condition to append CNN Legacy enforcement (GNA1)

### Tickets:
 - 66309