### PR TITLE
[GNA] fixed failed to inserting transpose after matmul

### DIFF
--- a/inference-engine/tests/unit/gna/ngraph/transformations/handle_transposes_around_matmul.cpp
+++ b/inference-engine/tests/unit/gna/ngraph/transformations/handle_transposes_around_matmul.cpp
@@ -252,8 +252,8 @@ TEST(TransformationTests, InsertTransposeAfterMatmulTest) {
                 RunTest(
                     handle_transpose_after_matmul::CreateMatmulFunction(
                         {1, 256}, {256, 256}, {8, 32}, false, true, enable_add, matmul_on_left_side, enable_fq),
-                    handle_transpose_after_matmul::CreateMatmulTransposeFunction(
-                        {1, 256}, {256, 256}, {8, 32}, true, true, enable_add, matmul_on_left_side, enable_fq));
+                    handle_transpose_after_matmul::CreateMatmulFunction(
+                        {1, 256}, {256, 256}, {8, 32}, false, true, enable_add, matmul_on_left_side, enable_fq));
             }
         }
     }

--- a/inference-engine/tests/unit/gna/ngraph/transformations/handle_transposes_around_matmul.cpp
+++ b/inference-engine/tests/unit/gna/ngraph/transformations/handle_transposes_around_matmul.cpp
@@ -249,6 +249,11 @@ TEST(TransformationTests, InsertTransposeAfterMatmulTest) {
                         {4, 1}, {1, 8}, {2, 16}, false, true, enable_add, matmul_on_left_side, enable_fq),
                     handle_transpose_after_matmul::CreateMatmulTransposeFunction(
                         {4, 1}, {1, 8}, {2, 16}, true, true, enable_add, matmul_on_left_side, enable_fq));
+                RunTest(
+                    handle_transpose_after_matmul::CreateMatmulFunction(
+                        {1, 256}, {256, 256}, {8, 32}, false, true, enable_add, matmul_on_left_side, enable_fq),
+                    handle_transpose_after_matmul::CreateMatmulTransposeFunction(
+                        {1, 256}, {256, 256}, {8, 32}, true, true, enable_add, matmul_on_left_side, enable_fq));
             }
         }
     }


### PR DESCRIPTION
### Details:
 - Fixed failed to inserting transpose after matmul if output matmul tensor has only one dimension that more than one.

### Tickets:
 - CVS-66242
