### PR TITLE
Fix for warning C4297 in CPP plugin interface

### DIFF
--- a/inference-engine/src/plugin_api/cpp_interfaces/interface/ie_iplugin_internal.hpp
+++ b/inference-engine/src/plugin_api/cpp_interfaces/interface/ie_iplugin_internal.hpp
@@ -337,16 +337,17 @@ public:
  * @brief Defines the exported `CreatePluginEngine` function which is used to create a plugin instance
  * @ingroup ie_dev_api_plugin_api
  */
-#define IE_DEFINE_PLUGIN_CREATE_FUNCTION(PluginType, version, ...)                                                \
-    INFERENCE_PLUGIN_API(void) IE_CREATE_PLUGIN(::std::shared_ptr<::InferenceEngine::IInferencePlugin>& plugin) { \
-        try {                                                                                                     \
-            plugin = ::std::make_shared<PluginType>(__VA_ARGS__);                                                 \
-        } catch (const InferenceEngine::Exception&) {                                                             \
-            throw;                                                                                                \
-        } catch (const std::exception& ex) {                                                                      \
-            IE_THROW() << ex.what();                                                                              \
-        } catch (...) {                                                                                           \
-            IE_THROW(Unexpected);                                                                                 \
-        }                                                                                                         \
-        plugin->SetVersion(version);                                                                              \
+#define IE_DEFINE_PLUGIN_CREATE_FUNCTION(PluginType, version, ...)                                     \
+    INFERENCE_PLUGIN_API(void)                                                                         \
+    IE_CREATE_PLUGIN(::std::shared_ptr<::InferenceEngine::IInferencePlugin>& plugin) noexcept(false) { \
+        try {                                                                                          \
+            plugin = ::std::make_shared<PluginType>(__VA_ARGS__);                                      \
+        } catch (const InferenceEngine::Exception&) {                                                  \
+            throw;                                                                                     \
+        } catch (const std::exception& ex) {                                                           \
+            IE_THROW() << ex.what();                                                                   \
+        } catch (...) {                                                                                \
+            IE_THROW(Unexpected);                                                                      \
+        }                                                                                              \
+        plugin->SetVersion(version);                                                                   \
     }


### PR DESCRIPTION
### Details:
 - On Windows `INFERENCE_PLUGIN_API` macro defined as `extern "C"`, and if use `IE_DEFINE_PLUGIN_CREATE_FUNCTION` macro in a plugin with /EHc compiler key, you will get 'warning C4297: function assumed not to throw an exception but does. The function is extern "C" and /EHc was specified". So we should explicitly specify it as throw function.

https://docs.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model?redirectedfrom=MSDN&view=msvc-160