### PR TITLE
[GPU] debug_config bug fix of not accepting multiple strings

### DIFF
--- a/inference-engine/thirdparty/clDNN/runtime/debug_configuration.cpp
+++ b/inference-engine/thirdparty/clDNN/runtime/debug_configuration.cpp
@@ -57,6 +57,11 @@ T convert_to(const std::string &str) {
     return res;
 }
 
+template <>
+std::string convert_to(const std::string &str) {
+    return str;
+}
+
 template<typename T>
 void get_debug_env_var(const std::string &var, T &val, std::vector<std::string> allowed_option_prefixes) {
     bool found = false;

--- a/inference-engine/thirdparty/clDNN/tests/test_cases/reorder_gpu_test.cpp
+++ b/inference-engine/thirdparty/clDNN/tests/test_cases/reorder_gpu_test.cpp
@@ -2398,7 +2398,6 @@ INSTANTIATE_TEST_SUITE_P(DISABLED_REORDER,
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
 TEST(reorder_onednn_gpu, basic_convert_int8) {
-
     auto& engine = get_onednn_test_engine();
     layout in_layout = { type_to_data_type<float>::value, format::byxf, { 1, 1, 3, 3 } };
     layout byte_layout = { type_to_data_type<int8_t>::value, format::bfyx, { 1, 1, 3, 3 } };


### PR DESCRIPTION
It receives space-separated parameter. Currently, only first argument is
received in case of string argument.

