### PR TITLE
Temporarily disable some paddle test case which sporadically fail dur…

### DIFF
--- a/ngraph/test/frontend/paddlepaddle/op_fuzzy.cpp
+++ b/ngraph/test/frontend/paddlepaddle/op_fuzzy.cpp
@@ -196,9 +196,11 @@ static const std::vector<std::string> models{std::string("argmax"),
                                              std::string("squeeze_null_axes"),
                                              std::string("tanh"),
                                              std::string("unsqueeze"),
-                                             std::string("yolo_box_clip_box"),
-                                             std::string("yolo_box_default"),
-                                             std::string("yolo_box_scale_xy"),
+                                             // Temporily disable them until root caused to secure CI stable.
+                                             // CVS-66703 to track this.
+                                             // std::string("yolo_box_clip_box"),
+                                             // std::string("yolo_box_default"),
+                                             // std::string("yolo_box_scale_xy"),
                                              std::string("yolo_box_uneven_wh")};
 
 INSTANTIATE_TEST_SUITE_P(PDPDFuzzyOpTest,


### PR DESCRIPTION
Temporarily disable some paddle frontend test cases to make CI stable.
Further investigation required. JIRA tracking.

### Details:
 - Some failure case appears sporadically during CI recently. 
 - They are not easy to reproduce.
 - Team agrees to temporarily disable them to make CI stable, and track them with a ticket for further investigation.

[Yesterday 8:12 PM] Nosov, Mikhail
[ PASSED ] 254 tests. [ FAILED ] 3 tests, listed below: [ FAILED ] PDPDFuzzyOpTest/FrontEndFuzzyOpTest.testOpFuzzy/paddle_yolo_box_clip_box, where GetParam() = ("paddle", "test_model_zoo/paddle_test_models/", "yolo_box_clip_box") [ FAILED ] PDPDFuzzyOpTest/FrontEndFuzzyOpTest.testOpFuzzy/paddle_yolo_box_default, where GetParam() = ("paddle", "test_model_zoo/paddle_test_models/", "yolo_box_default") [ FAILED ] PDPDFuzzyOpTest/FrontEndFuzzyOpTest.testOpFuzzy/paddle_yolo_box_scale_xy, where GetParam() = ("paddle", "test_model_zoo/paddle_test_models/", "yolo_box_scale_xy")  


### Tickets:
 - *CVS-66703*
