### PR TITLE
[ MO ][ IR READER ] GroupConvolutionBackpropData extender update

### DIFF
--- a/model-optimizer/mo/utils/ir_reader/extenders/deconvolution_extender.py
+++ b/model-optimizer/mo/utils/ir_reader/extenders/deconvolution_extender.py
@@ -25,6 +25,9 @@ class GroupConvolutionBackpropData_extender(Extender):
 
 
 def common_backpropdata_extender(op: Node):
+    for attr in ['strides', 'output_padding', 'pads_begin', 'pads_end', 'dilations']:
+        Extender.attr_to_list(op, attr)
+
     if op.has_valid('output_padding'):
         op.output_padding = int64_array([0, 0] + op.output_padding)
 


### PR DESCRIPTION
Root cause analysis: IR Reader fails with error if one of `GroupConvolutionBackpropData` attributes (`strides`, `output_padding`, `pads_begin`, `pads_end` or `dilations`) has a scalar value.

Solution: Update `GroupConvolutionBackpropData` extender to read these attributes as `list`

Ticket: 65391


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR N/A
* [x]  Transformation preserves original framework node names N/A


Validation:
* [x]  Unit tests N/A
* [x]  Framework operation tests N/A
* [x]  Transformation tests N/A
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list N/A
* [x]  Guide on how to convert the **public** model N/A
* [x]  User guide update N/A
