### PR TITLE
[GNA] eltwise tests with GNA_SW_FP32

### DIFF
--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/eltwise.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/eltwise.cpp
@@ -41,10 +41,17 @@ std::vector<ngraph::helpers::EltwiseTypes> eltwiseOpTypes = {
         ngraph::helpers::EltwiseTypes::ADD
 };
 
-std::map<std::string, std::string> additional_config = {
-        {"GNA_DEVICE_MODE", "GNA_SW_EXACT"},
-        {"GNA_SCALE_FACTOR_0", "1638.4"},
-        {"GNA_SCALE_FACTOR_1", "1638.4"}
+std::vector<std::map<std::string, std::string>> additional_config = {
+        {
+                {"GNA_DEVICE_MODE", "GNA_SW_EXACT"},
+                {"GNA_SCALE_FACTOR_0", "1638.4"},
+                {"GNA_SCALE_FACTOR_1", "1638.4"}
+        },
+        {
+                {"GNA_DEVICE_MODE", "GNA_SW_FP32"},
+                {"GNA_SCALE_FACTOR_0", "1638.4"},
+                {"GNA_SCALE_FACTOR_1", "1638.4"}
+        }
 };
 
 const auto multiply_params = ::testing::Combine(
@@ -57,7 +64,7 @@ const auto multiply_params = ::testing::Combine(
         ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
         ::testing::Values(InferenceEngine::Layout::ANY),
         ::testing::Values(CommonTestUtils::DEVICE_GNA),
-        ::testing::Values(additional_config));
+        ::testing::ValuesIn(additional_config));
 
 INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs, EltwiseLayerTest, multiply_params, EltwiseLayerTest::getTestCaseName);
 }  // namespace

--- a/inference-engine/tests/functional/shared_test_classes/src/single_layer/eltwise.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/single_layer/eltwise.cpp
@@ -31,6 +31,9 @@ std::string EltwiseLayerTest::getTestCaseName(const testing::TestParamInfo<Eltwi
     results << "outPRC=" << outPrc.name() << "_";
     results << "inL=" << inLayout << "_";
     results << "trgDev=" << targetName;
+    for (auto const& configItem : additional_config) {
+        results << "_configItem=" << configItem.first << "_" << configItem.second;
+    }
     return results.str();
 }
 

--- a/inference-engine/tests_deprecated/unit/engines/gna/fp32_non_quantized_tests.cpp
+++ b/inference-engine/tests_deprecated/unit/engines/gna/fp32_non_quantized_tests.cpp
@@ -411,33 +411,6 @@ TEST_F(FP32NonQuantizedTest, TI2PropagateForward) {
             .called_with_input(input_data).equals_to(expected_result1).equals_to(expected_result2);
 }
 
-TEST_F(FP32NonQuantizedTest, EltwiseWithConstInputPropagatedForward) {
-    std::vector<float> input_data = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
-    std::vector<float> expected_result = {2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0};
-
-    assert_that().onInferModel(eltwiseSumModelWithConstLayer())
-        .inNotCompactMode().gna().propagate_forward().onCPU()
-        .called_with_input(input_data).equals_to(expected_result);
-}
-
-TEST_F(FP32NonQuantizedTest, EltwiseWithConstInputReorderPropagatedForward) {
-    std::vector<float> input_data = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
-    std::vector<float> expected_result = {2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0};
-
-    assert_that().onInferModel(eltwiseSumModelWithConstLayer2())
-        .inNotCompactMode().gna().propagate_forward().onCPU()
-        .called_with_input(input_data).equals_to(expected_result);
-}
-
-TEST_F(FP32NonQuantizedTest, EltwiseMulWithConstInputReorderPropagatedForward) {
-    std::vector<float> input_data = {3.0, 1.0, 3.0, 1.0, 3.0, 1.0, 3.0, 1.0, 3.0, 1.0};
-    std::vector<float> expected_result = {6.0, 2.0, 6.0, 2.0, 6.0, 2.0, 6.0, 2.0, 6.0, 2.0};
-
-    assert_that().onInferModel(eltwiseMulModelWithConstLayer())
-        .inNotCompactMode().withWeigthsPattern({2}).gna().propagate_forward().onCPU()
-        .called_with_input(input_data).equals_to(expected_result);
-}
-
 TEST_F(FP32NonQuantizedTest, PowerWithScaleFactorPropagateForward) {
     std::vector<float> input_data(10, 2.f);
     std::vector<float> expected_result(12, 21.f);


### PR DESCRIPTION
### Details:
 - added GNA_SW_FP32 mode for eltwise tests from tests_deprecated/fp32_non_quantized_tests

### Tickets:
 - 62542
