### PR TITLE
Fix ConvertPrecision for NMS5

### DIFF
--- a/inference-engine/src/transformations/include/ngraph_ops/nms_ie_internal.hpp
+++ b/inference-engine/src/transformations/include/ngraph_ops/nms_ie_internal.hpp
@@ -30,7 +30,8 @@ public:
                                 const Output<Node>& score_threshold,
                                 int center_point_box,
                                 bool sort_result_descending,
-                                const ngraph::element::Type& output_type = ngraph::element::i64);
+                                const ngraph::element::Type& output_type = ngraph::element::i64,
+                                const ngraph::element::Type& score_output_type = ngraph::element::f32);
 
     NonMaxSuppressionIEInternal(const Output<Node>& boxes,
                                 const Output<Node>& scores,
@@ -40,7 +41,8 @@ public:
                                 const Output<Node>& soft_nms_sigma,
                                 int center_point_box,
                                 bool sort_result_descending,
-                                const ngraph::element::Type& output_type = ngraph::element::i64);
+                                const ngraph::element::Type& output_type = ngraph::element::i64,
+                                const ngraph::element::Type& score_output_type = ngraph::element::f32);
 
     void validate_and_infer_types() override;
 
@@ -51,6 +53,7 @@ public:
     int m_center_point_box;
     bool m_sort_result_descending = true;
     element::Type m_output_type;
+    element::Type m_scores_output_type;
 
 private:
     int64_t max_boxes_output_from_input() const;

--- a/inference-engine/src/transformations/include/ngraph_ops/type_relaxed.hpp
+++ b/inference-engine/src/transformations/include/ngraph_ops/type_relaxed.hpp
@@ -116,7 +116,7 @@ protected:
         for (size_t i = 0; i < node.get_output_size(); ++i) {
             auto overridden_output_type = get_overridden_output_type(i);
             if (overridden_output_type != element::undefined) {
-                node.set_output_type(0, overridden_output_type, node.get_output_partial_shape(i));
+                node.set_output_type(i, overridden_output_type, node.get_output_partial_shape(i));
             }
         }
     }

--- a/inference-engine/src/transformations/src/ngraph_ops/nms_ie_internal.cpp
+++ b/inference-engine/src/transformations/src/ngraph_ops/nms_ie_internal.cpp
@@ -20,9 +20,11 @@ op::internal::NonMaxSuppressionIEInternal::NonMaxSuppressionIEInternal(const Out
                                                                        const Output<Node>& score_threshold,
                                                                        int center_point_box,
                                                                        bool sort_result_descending,
-                                                                       const ngraph::element::Type& output_type)
+                                                                       const ngraph::element::Type& output_type,
+                                                                       const ngraph::element::Type& score_output_type)
         : Op({boxes, scores, max_output_boxes_per_class, iou_threshold, score_threshold}),
-          m_center_point_box(center_point_box), m_sort_result_descending(sort_result_descending), m_output_type(output_type) {
+          m_center_point_box(center_point_box), m_sort_result_descending(sort_result_descending), m_output_type(output_type),
+          m_scores_output_type(score_output_type) {
     constructor_validate_and_infer_types();
 }
 
@@ -34,9 +36,11 @@ op::internal::NonMaxSuppressionIEInternal::NonMaxSuppressionIEInternal(const Out
                                                                        const Output<Node>& soft_nms_sigma,
                                                                        int center_point_box,
                                                                        bool sort_result_descending,
-                                                                       const ngraph::element::Type& output_type)
+                                                                       const ngraph::element::Type& output_type,
+                                                                       const ngraph::element::Type& score_output_type)
         : Op({boxes, scores, max_output_boxes_per_class, iou_threshold, score_threshold, soft_nms_sigma}),
-          m_center_point_box(center_point_box), m_sort_result_descending(sort_result_descending), m_output_type(output_type) {
+          m_center_point_box(center_point_box), m_sort_result_descending(sort_result_descending), m_output_type(output_type),
+          m_scores_output_type(score_output_type) {
     constructor_validate_and_infer_types();
 }
 
@@ -59,6 +63,7 @@ bool op::internal::NonMaxSuppressionIEInternal::visit_attributes(AttributeVisito
     visitor.on_attribute("center_point_box", m_center_point_box);
     visitor.on_attribute("sort_result_descending", m_sort_result_descending);
     visitor.on_attribute("output_type", m_output_type);
+    visitor.on_attribute("score_output_type", m_scores_output_type);
     return true;
 }
 
@@ -105,6 +110,6 @@ void op::internal::NonMaxSuppressionIEInternal::validate_and_infer_types() {
     }
 
     set_output_type(0, m_output_type, out_shape);
-    set_output_type(1, element::f32, out_shape);
+    set_output_type(1, m_scores_output_type, out_shape);
     set_output_type(2, m_output_type, Shape{1});
 }

--- a/inference-engine/src/transformations/src/transformations/op_conversions/convert_nms_to_nms_ie_internal.cpp
+++ b/inference-engine/src/transformations/src/transformations/op_conversions/convert_nms_to_nms_ie_internal.cpp
@@ -86,7 +86,8 @@ ngraph::pass::ConvertNMSToNMSIEInternal::ConvertNMSToNMSIEInternal() {
                     new_soft_nms_sigma,
                     center_point_box,
                     nms_5->get_sort_result_descending(),
-                    element::i32);
+                    element::i32,
+                    nms_5->get_output_element_type(1));
             new_ops.push_back(nms_legacy);
         } else {
             nms_legacy = std::make_shared<op::internal::NonMaxSuppressionIEInternal>(
@@ -97,7 +98,8 @@ ngraph::pass::ConvertNMSToNMSIEInternal::ConvertNMSToNMSIEInternal() {
                     new_score_threshold,
                     center_point_box,
                     nms_5->get_sort_result_descending(),
-                    element::i32);
+                    element::i32,
+                    nms_5->get_output_element_type(1));
             new_ops.push_back(nms_legacy);
         }
 

--- a/ngraph/core/src/pass/convert_precision.cpp
+++ b/ngraph/core/src/pass/convert_precision.cpp
@@ -331,7 +331,11 @@ bool fuse_type_to_convert(const std::shared_ptr<ngraph::Node>& node, element::Ty
 
 bool fuse_type_to_nms3(const std::shared_ptr<ngraph::Node>& node, ngraph::element::Type to, size_t idx) {
     if (auto nms = ov::as_type_ptr<opset3::NonMaxSuppression>(node)) {
-        nms->set_output_type(to);
+        if (to == element::i32 || to == element::i64) {
+            nms->set_output_type(to);
+        } else {
+            throw ngraph_error("Type: " + to.get_type_name() + " is not supported for NMS3");
+        }
         return true;
     }
     return false;
@@ -339,7 +343,11 @@ bool fuse_type_to_nms3(const std::shared_ptr<ngraph::Node>& node, ngraph::elemen
 
 bool fuse_type_to_nms4(const std::shared_ptr<ngraph::Node>& node, ngraph::element::Type to, size_t idx) {
     if (auto nms = ov::as_type_ptr<opset4::NonMaxSuppression>(node)) {
-        nms->set_output_type(to);
+        if (to == element::i32 || to == element::i64) {
+            nms->set_output_type(to);
+        } else {
+            throw ngraph_error("Type: " + to.get_type_name() + " is not supported for NMS4");
+        }
         return true;
     }
     return false;

--- a/ngraph/core/src/pass/convert_precision.cpp
+++ b/ngraph/core/src/pass/convert_precision.cpp
@@ -363,12 +363,14 @@ bool fuse_type_to_nms5(const std::shared_ptr<ngraph::Node>& node, ngraph::elemen
                 return true;
             } else {
                 element::TypeVector output_types;
-                for (const auto & output : nms->outputs()) {
+                for (const auto& output : nms->outputs()) {
                     output_types.emplace_back(output.get_element_type());
                 }
                 output_types[idx] = to;
                 auto relaxed_op =
-                        std::make_shared<ngraph::op::TypeRelaxed<opset5::NonMaxSuppression>>(*nms, element::TypeVector{}, output_types);
+                    std::make_shared<ngraph::op::TypeRelaxed<opset5::NonMaxSuppression>>(*nms,
+                                                                                         element::TypeVector{},
+                                                                                         output_types);
                 replace_node(node, relaxed_op);
                 return true;
             }

--- a/ngraph/core/src/pass/convert_precision.cpp
+++ b/ngraph/core/src/pass/convert_precision.cpp
@@ -354,30 +354,30 @@ bool fuse_type_to_nms4(const std::shared_ptr<ngraph::Node>& node, ngraph::elemen
 }
 
 bool fuse_type_to_nms5(const std::shared_ptr<ngraph::Node>& node, ngraph::element::Type to, size_t idx) {
-    if (auto nms = ov::as_type_ptr<opset5::NonMaxSuppression>(node)) {
-        if ((idx == 0 || idx == 2) && (to == element::i32 || to == element::i64)) {
-            nms->set_output_type(to);
-        } else {
-            if (auto type_relaxed = std::dynamic_pointer_cast<op::TypeRelaxedBase>(node)) {
-                type_relaxed->set_overridden_output_type(to, idx);
-                return true;
-            } else {
-                element::TypeVector output_types;
-                for (const auto& output : nms->outputs()) {
-                    output_types.emplace_back(output.get_element_type());
-                }
-                output_types[idx] = to;
-                auto relaxed_op =
-                    std::make_shared<ngraph::op::TypeRelaxed<opset5::NonMaxSuppression>>(*nms,
-                                                                                         element::TypeVector{},
-                                                                                         output_types);
-                replace_node(node, relaxed_op);
-                return true;
-            }
-        }
+    auto nms = ov::as_type_ptr<opset5::NonMaxSuppression>(node);
+    if (!nms) {
+        return false;
+    }
+
+    if ((idx == 0 || idx == 2) && (to == element::i32 || to == element::i64)) {
+        nms->set_output_type(to);
         return true;
     }
-    return false;
+
+    if (auto type_relaxed = std::dynamic_pointer_cast<op::TypeRelaxedBase>(node)) {
+        type_relaxed->set_overridden_output_type(to, idx);
+        return true;
+    }
+
+    element::TypeVector output_types;
+    for (const auto& output : nms->outputs()) {
+        output_types.emplace_back(output.get_element_type());
+    }
+    output_types[idx] = to;
+    auto relaxed_op =
+        std::make_shared<ngraph::op::TypeRelaxed<opset5::NonMaxSuppression>>(*nms, element::TypeVector{}, output_types);
+    replace_node(node, relaxed_op);
+    return true;
 }
 
 bool fuse_type_to_topk(const std::shared_ptr<ngraph::Node>& node, ngraph::element::Type to, size_t idx) {


### PR DESCRIPTION
### Description
* Fixed ConvertPrecision transformation for NMS5
* Added score_output_type attribute for NMSIE operation to have valid conversion from TypeRelaxed NMS5 to NMSIE
* Fixed an issue with TypeRelax with wrong indexing when setting output type

### Ticket
XXX-62983