### PR TITLE
[MO] allow zero size dimensions in Slice output

### DIFF
--- a/model-optimizer/mo/ops/slice.py
+++ b/model-optimizer/mo/ops/slice.py
@@ -142,8 +142,6 @@ class Slice(Op):
             slice_idx[axes[i]] = slice(starts[i], ends[i], steps[i])
         if input_value is None or any(is_dynamic_slice(s) for s in slice_idx):
             output_shape = get_shape_from_slice(input_shape, slice_idx)
-            if np.ma.any(output_shape <= 0):
-                raise Error('Output shape: {} of node "{}" contains non-positive values'.format(output_shape, node.name))
             node.out_port(0).data.set_shape(output_shape)
         else:
             node.out_port(0).data.set_value(input_value[tuple(slice_idx)])


### PR DESCRIPTION
#### Root cause analysis:
in MO if Slice returns tensors with zero dimension sizes are prohibited, this is not true since ONNX Slice and numpy allow such shapes.
**ONNX** 
![image](https://user-images.githubusercontent.com/5703039/135590657-6ee0206a-96ba-47c1-ad9e-5a5ba7029411.png)
**Numpy**
![image](https://user-images.githubusercontent.com/5703039/135591170-ab569d12-422d-4c63-a3a1-eaab493224ee.png)


#### Solution:
- removed such restriction
- moved negative unit-tests for such cases into positive tests

#### Tickets:
 - xxx-65194
