### PR TITLE
Avoid ambiguous combination of --use_X_frontend flags

### DIFF
--- a/model-optimizer/mo/main.py
+++ b/model-optimizer/mo/main.py
@@ -103,6 +103,10 @@ def get_moc_frontends(argv: argparse.Namespace):
     use_legacy_frontend = argv.use_legacy_frontend
     use_new_frontend = argv.use_new_frontend
 
+    if use_legacy_frontend and use_new_frontend:
+        raise Error('Ambiguous arguments provided. Please do not use --use_legacy_frontend and  '
+                    '--use_new_frontend flags at the same time.')
+
     if not fem or use_legacy_frontend:
         return None, []
 

--- a/model-optimizer/mo/main.py
+++ b/model-optimizer/mo/main.py
@@ -104,7 +104,7 @@ def get_moc_frontends(argv: argparse.Namespace):
     use_new_frontend = argv.use_new_frontend
 
     if use_legacy_frontend and use_new_frontend:
-        raise Error('Ambiguous arguments provided. Please do not use --use_legacy_frontend and  '
+        raise Error('Ambiguous arguments provided. Please do not use --use_legacy_frontend and '
                     '--use_new_frontend flags at the same time.')
 
     if not fem or use_legacy_frontend:


### PR DESCRIPTION
Raise an error when user specifies ambiguous combination of `--use_legacy_frontend` and `--use_new_frontend` flags
