### PR TITLE
[LPT] MatMulTransformation: canBeTransformed fix

### DIFF
--- a/inference-engine/src/low_precision_transformations/src/mat_mul.cpp
+++ b/inference-engine/src/low_precision_transformations/src/mat_mul.cpp
@@ -192,6 +192,8 @@ bool MatMulTransformation::canBeTransformed(const TransformationContext& context
         if (!NetworkHelper::checkZeroPoint(dequantization1.subtract)) {
             return false;
         }
+    } else {
+        return false;
     }
 
     const auto dequantization2 = NetworkHelper::getDequantization(layer, 1);


### PR DESCRIPTION
### Details:
 - *MatMulTransformation::canBeTransformed: added check for empty dequantization operations structure*

### Tickets:
 - *65837*
