### PR TITLE
ClDNN: Add OPENCL extension d3d11 sharing checking

### DIFF
--- a/inference-engine/thirdparty/clDNN/runtime/ocl/ocl_device_detector.cpp
+++ b/inference-engine/thirdparty/clDNN/runtime/ocl/ocl_device_detector.cpp
@@ -206,6 +206,13 @@ std::vector<device::ptr>  ocl_device_detector::create_device_list_from_user_devi
 
         std::vector<cl::Device> devices;
 #ifdef _WIN32
+        // From OpenCL Docs:
+        // A non-NULL return value for clGetExtensionFunctionAddressForPlatform
+        // does not guarantee that an extension function is actually supported
+        // by the platform. The application must also make a corresponding query
+        // using clGetPlatformInfo (platform, CL_PLATFORM_EXTENSIONS, …​ ) or
+        // clGetDeviceInfo (device,CL_DEVICE_EXTENSIONS, …​ )
+        // to determine if an extension is supported by the OpenCL implementation.
         const std::string& ext = platform.getInfo<CL_PLATFORM_EXTENSIONS>();
         if (ext.empty() || ext.find(INTEL_D3D11_SHARING_EXT_NAME) == std::string::npos) {
             continue;

--- a/inference-engine/thirdparty/clDNN/runtime/ocl/ocl_device_detector.cpp
+++ b/inference-engine/thirdparty/clDNN/runtime/ocl/ocl_device_detector.cpp
@@ -44,6 +44,7 @@ return true;
 namespace cldnn {
 namespace ocl {
 static constexpr auto INTEL_PLATFORM_VENDOR = "Intel(R) Corporation";
+static constexpr auto INTEL_D3D11_SHARING_EXT_NAME = "cl_khr_d3d11_sharing";
 
 static std::vector<cl::Device> getSubDevices(cl::Device& rootDevice) {
     cl_uint maxSubDevices;
@@ -205,6 +206,11 @@ std::vector<device::ptr>  ocl_device_detector::create_device_list_from_user_devi
 
         std::vector<cl::Device> devices;
 #ifdef _WIN32
+        const std::string& ext = platform.getInfo<CL_PLATFORM_EXTENSIONS>();
+        if (ext.empty() || ext.find(INTEL_D3D11_SHARING_EXT_NAME) == std::string::npos) {
+            continue;
+        }
+
         platform.getDevices(CL_D3D11_DEVICE_KHR,
             user_device,
             CL_PREFERRED_DEVICES_FOR_D3D11_KHR,


### PR DESCRIPTION
### Crash in clDNN when gpu::make_shared_context is called:
Cannot create remote GPU context using ` make_shared_context` with DX11 device.
Windows 10 system on Intel Cote i7 10610U has 2 OPENCL contexts:
- Platform name: Intel(R) OpenCL HD Graphics
- Platform name: Intel(R) OpenCL

DX11Device had created  using Intel HD Graphics and passed into  `gpu::make_shared_context ` and crash happened.
ClDNNPlugin uses  iteration over both contexts (GPU & CPU) and call INTEL extension  request `pfn_clGetDeviceIDsFromMediaAdapterINTEL` 
 for getting interoperability devices from initial Dx11 device. This is extension external call happened successfully for the first (Intel GPU platform) which  definitely support DX11 sharing extension but has crash with AccessViolation message for the second CPU context

OpenCL said https://www.khronos.org/registry/OpenCL/sdk/2.2/docs/man/html/clGetExtensionFunctionAddressForPlatform.html
that user must check extension explicitly with before invoke external extension function by obtained address by ICD, because

```
A return value of NULL indicates that the specified function does not exist for the implementation or platform is not a valid platform. A non-NULL return value for clGetExtensionFunctionAddressForPlatform **does not guarantee** that an extension function is actually supported by the platform. The application must also make a corresponding query using clGetPlatformInfo (platform, CL_PLATFORM_EXTENSIONS, …​ ) or clGetDeviceInfo (device,CL_DEVICE_EXTENSIONS, …​ ) to determine if an extension is supported by the OpenCL implementation.
```

PR provided string extension matching on "cl_khr_d3d11_sharing" straight before invoke interop ext function to prevent crash with AccessViolation

### Tickets:
 - CVS-66895
