### PR TITLE
Introduce new evaluate API

### DIFF
--- a/ngraph/core/include/openvino/core/function.hpp
+++ b/ngraph/core/include/openvino/core/function.hpp
@@ -21,6 +21,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/rtti.hpp"
 #include "openvino/core/variant.hpp"
+#include "openvino/runtime/tensor.hpp"
 
 namespace ov {
 /// A user-defined function.
@@ -196,6 +197,15 @@ public:
     bool evaluate(const ngraph::HostTensorVector& output_tensors,
                   const ngraph::HostTensorVector& input_tensors,
                   ngraph::EvaluationContext evaluation_context = ngraph::EvaluationContext()) const;
+
+    /// \brief Evaluate the function on inputs, putting results in outputs.
+    /// \param output_tensors Tensors for the outputs to compute. One for each result
+    /// \param input_tensors Tensors for the inputs. One for each inputs.
+    /// \param evaluation_context Storage of additional settings and attributes that can be used
+    /// when evaluating the function. This additional information can be shared across nodes.
+    bool evaluate(const ov::runtime::TensorVector& output_tensors,
+                  const ov::runtime::TensorVector& input_tensors,
+                  ov::EvaluationContext evaluation_context = ov::EvaluationContext()) const;
 
     /// \brief Return a list of function's sinks.
     const ngraph::SinkVector& get_sinks() const {

--- a/ngraph/core/include/openvino/core/node.hpp
+++ b/ngraph/core/include/openvino/core/node.hpp
@@ -37,6 +37,7 @@
 #include "openvino/op/util/attr_types.hpp"
 #include "openvino/op/util/variable.hpp"
 #include "openvino/op/util/variable_value.hpp"
+#include "openvino/runtime/tensor.hpp"
 
 namespace ngraph {
 
@@ -220,6 +221,22 @@ public:
                           const EvaluationContext& evaluationContext) const;
     virtual bool evaluate_lower(const ov::HostTensorVector& output_values) const;
     virtual bool evaluate_upper(const ov::HostTensorVector& output_values) const;
+
+    /// \brief Evaluates the op on input_values putting results in output_values
+    /// \param output_values Tensors for the outputs to compute. One for each result
+    /// \param input_values Tensors for the inputs. One for each inputs.
+    /// \returns true if successful
+    virtual bool evaluate(const ov::runtime::TensorVector& output_values,
+                          const ov::runtime::TensorVector& input_values) const;
+    /// \brief Evaluates the op on input_values putting results in output_values
+    /// \param output_values Tensors for the outputs to compute. One for each result
+    /// \param input_values Tensors for the inputs. One for each inputs.
+    /// \param evaluation_context Storage of additional settings and attributes that can be used
+    /// when evaluating the op.
+    /// \returns true if successful
+    virtual bool evaluate(const ov::runtime::TensorVector& output_values,
+                          const ov::runtime::TensorVector& input_values,
+                          const ov::EvaluationContext& evaluationContext) const;
 
     virtual bool constant_fold(OutputVector& output_values, const OutputVector& inputs_values);
     /// \brief Decomposes the FusedOp into a sub-graph consisting of core ngraph ops

--- a/ngraph/core/include/openvino/runtime/tensor.hpp
+++ b/ngraph/core/include/openvino/runtime/tensor.hpp
@@ -50,10 +50,12 @@ protected:
     friend class ov::runtime::VariableState;
 
 public:
+    using Ptr = std::shared_ptr<Tensor>;
     /**
      * @brief Default constructor
      */
     Tensor() = default;
+    virtual ~Tensor() = default;
 
     /**
      * @brief Constructs Tensor using element type and shape. Allocate internal host storage using default allocator
@@ -149,5 +151,7 @@ public:
      */
     explicit operator bool() const noexcept;
 };
+
+using TensorVector = std::vector<Tensor::Ptr>;
 }  // namespace runtime
 }  // namespace ov

--- a/ngraph/core/src/op/if.cpp
+++ b/ngraph/core/src/op/if.cpp
@@ -224,7 +224,7 @@ op::v8::If::OutputMap op::v8::If::get_mapping_outputs_on_body_description(
 
 bool op::v8::If::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const {
     NGRAPH_OP_SCOPE(v8_If_evaluate);
-    runtime::reference::if_reference(m_bodies, m_output_descriptions, m_input_descriptions, outputs, inputs);
+    ngraph::runtime::reference::if_reference(m_bodies, m_output_descriptions, m_input_descriptions, outputs, inputs);
     return true;
 }
 

--- a/ngraph/core/src/op/interpolate.cpp
+++ b/ngraph/core/src/op/interpolate.cpp
@@ -429,31 +429,31 @@ bool op::v4::Interpolate::evaluate_interpolate(const HostTensorVector& outputs, 
 
     switch (input_et) {
     case element::Type_t::f32:
-        runtime::reference::interpolate<float>(reinterpret_cast<float*>(padded_data_ptr),
-                                               padded_input_shape,
-                                               scales,
-                                               axes,
-                                               outputs[0]->get_data_ptr<float>(),
-                                               out_shape,
-                                               m_attrs);
+        ngraph::runtime::reference::interpolate<float>(reinterpret_cast<float*>(padded_data_ptr),
+                                                       padded_input_shape,
+                                                       scales,
+                                                       axes,
+                                                       outputs[0]->get_data_ptr<float>(),
+                                                       out_shape,
+                                                       m_attrs);
         break;
     case element::Type_t::f16:
-        runtime::reference::interpolate<float16>(reinterpret_cast<float16*>(padded_data_ptr),
-                                                 padded_input_shape,
-                                                 scales,
-                                                 axes,
-                                                 outputs[0]->get_data_ptr<float16>(),
-                                                 out_shape,
-                                                 m_attrs);
+        ngraph::runtime::reference::interpolate<float16>(reinterpret_cast<float16*>(padded_data_ptr),
+                                                         padded_input_shape,
+                                                         scales,
+                                                         axes,
+                                                         outputs[0]->get_data_ptr<float16>(),
+                                                         out_shape,
+                                                         m_attrs);
         break;
     case element::Type_t::i8:
-        runtime::reference::interpolate<int8_t>(reinterpret_cast<int8_t*>(padded_data_ptr),
-                                                padded_input_shape,
-                                                scales,
-                                                axes,
-                                                outputs[0]->get_data_ptr<int8_t>(),
-                                                out_shape,
-                                                m_attrs);
+        ngraph::runtime::reference::interpolate<int8_t>(reinterpret_cast<int8_t*>(padded_data_ptr),
+                                                        padded_input_shape,
+                                                        scales,
+                                                        axes,
+                                                        outputs[0]->get_data_ptr<int8_t>(),
+                                                        out_shape,
+                                                        m_attrs);
         break;
     default:;
     }

--- a/ngraph/core/src/op/loop.cpp
+++ b/ngraph/core/src/op/loop.cpp
@@ -263,12 +263,12 @@ Output<Node> op::v5::Loop::get_concatenated_slices(const Output<Node>& value,
 
 bool op::v5::Loop::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const {
     NGRAPH_OP_SCOPE(v5_Loop_evaluate);
-    runtime::reference::loop(m_bodies[0],
-                             m_output_descriptions[0],
-                             m_input_descriptions[0],
-                             m_special_body_ports,
-                             outputs,
-                             inputs);
+    ngraph::runtime::reference::loop(m_bodies[0],
+                                     m_output_descriptions[0],
+                                     m_input_descriptions[0],
+                                     m_special_body_ports,
+                                     outputs,
+                                     inputs);
     return true;
 }
 

--- a/ngraph/core/src/op/random_uniform.cpp
+++ b/ngraph/core/src/op/random_uniform.cpp
@@ -180,15 +180,15 @@ bool op::v8::RandomUniform::evaluate(const HostTensorVector& outputs, const Host
         throw ngraph_error("Unsupported type of RandomUniform: " + get_out_type().get_type_name());
     }
 
-    auto state = runtime::reference::random_uniform(out_shape,
-                                                    inputs[1]->get_data_ptr<const char>(),
-                                                    inputs[2]->get_data_ptr<const char>(),
-                                                    out,
-                                                    inputs[0]->get_shape(),
-                                                    get_out_type(),
-                                                    get_global_seed(),
-                                                    get_op_seed(),
-                                                    m_state);
+    auto state = ngraph::runtime::reference::random_uniform(out_shape,
+                                                            inputs[1]->get_data_ptr<const char>(),
+                                                            inputs[2]->get_data_ptr<const char>(),
+                                                            out,
+                                                            inputs[0]->get_shape(),
+                                                            get_out_type(),
+                                                            get_global_seed(),
+                                                            get_op_seed(),
+                                                            m_state);
 
     // Update RandomUniform state
     std::lock_guard<std::mutex> guard(m_state_mutex);

--- a/ngraph/core/src/op/reverse.cpp
+++ b/ngraph/core/src/op/reverse.cpp
@@ -160,12 +160,12 @@ bool op::v1::Reverse::evaluate_reverse(const HostTensorVector& outputs, const Ho
             }
         }
     }
-    runtime::reference::reverse(inputs[0]->get_data_ptr<const char>(),
-                                outputs[0]->get_data_ptr<char>(),
-                                inputs[0]->get_shape(),
-                                outputs[0]->get_shape(),
-                                axes,
-                                inputs[0]->get_element_type().size());
+    ngraph::runtime::reference::reverse(inputs[0]->get_data_ptr<const char>(),
+                                        outputs[0]->get_data_ptr<char>(),
+                                        inputs[0]->get_shape(),
+                                        outputs[0]->get_shape(),
+                                        axes,
+                                        inputs[0]->get_element_type().size());
     return true;
 }
 

--- a/ngraph/core/src/op/scatter_update.cpp
+++ b/ngraph/core/src/op/scatter_update.cpp
@@ -74,15 +74,15 @@ bool op::v3::ScatterUpdate::evaluate_scatter_update(const HostTensorVector& outp
         return false;
     }
 
-    runtime::reference::scatter_update(data->get_data_ptr<char>(),
-                                       indices_casted_vector.data(),
-                                       updates->get_data_ptr<char>(),
-                                       axis_val,
-                                       out->get_data_ptr<char>(),
-                                       elem_size,
-                                       data->get_shape(),
-                                       indices->get_shape(),
-                                       updates->get_shape());
+    ngraph::runtime::reference::scatter_update(data->get_data_ptr<char>(),
+                                               indices_casted_vector.data(),
+                                               updates->get_data_ptr<char>(),
+                                               axis_val,
+                                               out->get_data_ptr<char>(),
+                                               elem_size,
+                                               data->get_shape(),
+                                               indices->get_shape(),
+                                               updates->get_shape());
 
     return true;
 }

--- a/ngraph/core/src/op/shuffle_channels.cpp
+++ b/ngraph/core/src/op/shuffle_channels.cpp
@@ -89,7 +89,7 @@ bool op::ShuffleChannels::evaluate_shuffle_channels(const HostTensorVector& outp
     outputs[0]->set_element_type(inputs[0]->get_element_type());
     outputs[0]->set_shape(data_shape);
 
-    runtime::reference::shuffle_channels(arg, out, data_shape, elem_size, m_axis, m_group);
+    ngraph::runtime::reference::shuffle_channels(arg, out, data_shape, elem_size, m_axis, m_group);
 
     return true;
 }

--- a/ngraph/core/src/op/space_to_batch.cpp
+++ b/ngraph/core/src/op/space_to_batch.cpp
@@ -196,32 +196,32 @@ bool ngraph::op::v1::SpaceToBatch::evaluate_space_to_batch(const HostTensorVecto
             }
         }
 
-        runtime::opt_kernel::reshape(flat_data.data(),
-                                     dispersed_data.data(),
-                                     data_shape,
-                                     plain_axes_order,
-                                     dispersed_shape,
-                                     elem_size);
+        ngraph::runtime::opt_kernel::reshape(flat_data.data(),
+                                             dispersed_data.data(),
+                                             data_shape,
+                                             plain_axes_order,
+                                             dispersed_shape,
+                                             elem_size);
         ov::Shape post_transpose_shape(axes_order.size());
         for (size_t i = 0; i < axes_order.size(); ++i) {
             post_transpose_shape[i] = dispersed_shape[axes_order[i]];
         }
 
-        runtime::opt_kernel::reshape(dispersed_data.data(),
-                                     post_transpose_data.data(),
-                                     dispersed_shape,
-                                     axes_order,
-                                     post_transpose_shape,
-                                     elem_size);
+        ngraph::runtime::opt_kernel::reshape(dispersed_data.data(),
+                                             post_transpose_data.data(),
+                                             dispersed_shape,
+                                             axes_order,
+                                             post_transpose_shape,
+                                             elem_size);
         squeezed_shape[0] *= block_values[block_idx];
         squeezed_shape[block_idx] /= block_values[block_idx];
 
-        runtime::opt_kernel::reshape(post_transpose_data.data(),
-                                     flat_data.data(),
-                                     post_transpose_shape,
-                                     plain_axes_order,
-                                     squeezed_shape,
-                                     elem_size);
+        ngraph::runtime::opt_kernel::reshape(post_transpose_data.data(),
+                                             flat_data.data(),
+                                             post_transpose_shape,
+                                             plain_axes_order,
+                                             squeezed_shape,
+                                             elem_size);
         data_shape = squeezed_shape;
     }
 

--- a/ngraph/core/src/op/tile.cpp
+++ b/ngraph/core/src/op/tile.cpp
@@ -92,12 +92,12 @@ bool op::v0::Tile::evaluate_tile(const HostTensorVector& outputs, const HostTens
         output->set_shape(output_shape);
     }
 
-    runtime::reference::tile(data->get_data_ptr<const char>(),
-                             output->get_data_ptr<char>(),
-                             data->get_shape(),
-                             output_shape,
-                             data->get_element_type().size(),
-                             repeats_val);
+    ngraph::runtime::reference::tile(data->get_data_ptr<const char>(),
+                                     output->get_data_ptr<char>(),
+                                     data->get_shape(),
+                                     output_shape,
+                                     data->get_element_type().size(),
+                                     repeats_val);
 
     return true;
 }

--- a/ngraph/core/src/runtime/aligned_buffer.cpp
+++ b/ngraph/core/src/runtime/aligned_buffer.cpp
@@ -59,8 +59,9 @@ runtime::AlignedBuffer& runtime::AlignedBuffer::operator=(AlignedBuffer&& other)
 }
 
 namespace ov {
-BWDCMP_RTTI_DEFINITION(AttributeAdapter<std::shared_ptr<runtime::AlignedBuffer>>);
+BWDCMP_RTTI_DEFINITION(AttributeAdapter<std::shared_ptr<ngraph::runtime::AlignedBuffer>>);
 
-AttributeAdapter<shared_ptr<runtime::AlignedBuffer>>::AttributeAdapter(shared_ptr<runtime::AlignedBuffer>& value)
-    : DirectValueAccessor<shared_ptr<runtime::AlignedBuffer>>(value) {}
+AttributeAdapter<shared_ptr<ngraph::runtime::AlignedBuffer>>::AttributeAdapter(
+    shared_ptr<ngraph::runtime::AlignedBuffer>& value)
+    : DirectValueAccessor<shared_ptr<ngraph::runtime::AlignedBuffer>>(value) {}
 }  // namespace ov


### PR DESCRIPTION
### Details:
 - Introduce new evaluate methods which work with `ov::runtime::Tensor`
 - `ov::Function::evaluate(HostTensorVector ...)` calls `ov::Function::evaluate(ov::runtime::TensorVector ...)` inside
 - `ov::Node::evaluate(ov::runtime::TensorVector ...) by default calls `ov::Node::evaluate(HostTensorVector ...)`
 - new operations can implement only evaluate methods with `ov::runtime::Tensor`s
