### PR TITLE
[GNA] Update split components overal size computation

### DIFF
--- a/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.cpp
+++ b/inference-engine/src/gna_plugin/optimizer/gna_pass_manager.cpp
@@ -1265,7 +1265,7 @@ void InsertSplitAligningFilterPass::run() {
         size_t currentOffset = 0;
         int splitOutIndex = 0;
         for (auto &&splitOutput  : l->outData) {
-            auto outputSize = product(++begin(splitOutput->getDims()), end(splitOutput->getDims()));
+            auto outputSize = product(begin(splitOutput->getDims()), end(splitOutput->getDims()));
 
             if ((currentOffset != ALIGN64(currentOffset)) || (padding != 0)) {
                 // check that this split output actually connected to further layers


### PR DESCRIPTION
### Details:
 - Fix transformation inserting constitutional copy filter to handle unaligned split operation

### Tickets:
 - *ticket-id*
