### PR TITLE
[LPT]Enable pushing dequantize operations through nodes with shape size more than 5  

### DIFF
--- a/inference-engine/tests/functional/inference_engine/lp_transformations/reshape_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/reshape_transformation.cpp
@@ -353,9 +353,9 @@ const std::vector<ReshapeTransformationTestValues> testValues = {
         },
         {
             ngraph::element::u8,
-            {{ngraph::element::f32}, {}, {{0.1f, 0.2f, 0.3f}, ngraph::element::f32, {1, 3, 1, 1}}},
-            ngraph::element::f32,
-            {}
+            {},
+            ngraph::element::u8,
+            {{ngraph::element::f32}, {}, {{0.1f, 0.2f, 0.3f}, ngraph::element::f32, {1, 3, 1, 1, 1, 1}}},
         }
     },
     // U8: no subtract 4D -> 6D: channels are not affected: with subtract
@@ -373,13 +373,13 @@ const std::vector<ReshapeTransformationTestValues> testValues = {
         },
         {
             ngraph::element::u8,
+            {},
+            ngraph::element::u8,
             {
                 { ngraph::element::f32 },
-                {{32, 64, 128}, ngraph::element::f32, {1, 3, 1, 1}},
-                {{0.1f, 0.2f, 0.3f}, ngraph::element::f32, {1, 3, 1, 1}}
-            },
-            ngraph::element::f32,
-            {}
+                {{32, 64, 128}, ngraph::element::f32, {1, 3, 1, 1, 1, 1}},
+                {{0.1f, 0.2f, 0.3f}, ngraph::element::f32, {1, 3, 1, 1, 1, 1}}
+            }
         }
     },
     // U8: no subtract 4D -> 2D: channels are affected: per tensor quantization
@@ -469,13 +469,13 @@ const std::vector<ReshapeTransformationTestValues> testValues = {
         LayerTransformation::createParamsU8I8(),
         {
             ngraph::element::u8,
-            {{ngraph::element::f32}, {}, {{0.1f, 0.2f, 0.3f}, ngraph::element::f32, {3, 1, 1}}}
+            {{ngraph::element::f32}, {}, {{0.1f, 0.2f, 0.3f}, ngraph::element::f32, {1, 3, 1, 1}}}
         },
         {
             ngraph::element::u8,
-            {{ngraph::element::f32}, {}, {{0.1f, 0.2f, 0.3f}, ngraph::element::f32, {3, 1, 1}}},
-            ngraph::element::f32,
-            {}
+            {},
+            ngraph::element::u8,
+            {{ngraph::element::f32}, {}, {{0.1f, 0.2f, 0.3f}, ngraph::element::f32, {1, 3, 1, 1, 1, 1}}},
         }
     },
     // U8: no subtract 4D -> 5D: channels are not affected: no subtract

--- a/inference-engine/tests/functional/inference_engine/lp_transformations/transpose_transformation.cpp
+++ b/inference-engine/tests/functional/inference_engine/lp_transformations/transpose_transformation.cpp
@@ -326,4 +326,35 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::ValuesIn(testValues)),
     TransposeTransformation::getTestCaseName);
 } // namespace testValues4
+namespace testValues5 {
+    const std::vector<ngraph::PartialShape> inputShapes6D = {
+        { Dimension::dynamic(), Dimension::dynamic(), Dimension::dynamic(),
+          Dimension::dynamic(), Dimension::dynamic(), Dimension::dynamic() }
+    };
+
+    const std::vector<TransposeTransformationTestValues> testValues = {
+        {
+            { 0, 1, 2, 3, 4, 5},
+            LayerTransformation::createParamsU8I8(),
+            {
+                ngraph::element::u8,
+                {{ngraph::element::f32}, {128}, {0.1f}}
+            },
+            {
+                ngraph::element::u8,
+                {{}, {}, {}},
+                ngraph::element::u8,
+                {{ngraph::element::f32}, {128}, {0.1f}}
+            }
+        },
+    };
+
+    INSTANTIATE_TEST_SUITE_P(
+        smoke_LPT,
+        TransposeTransformation,
+        ::testing::Combine(
+            ::testing::ValuesIn(inputShapes6D),
+            ::testing::ValuesIn(testValues)),
+        TransposeTransformation::getTestCaseName);
+} // namespace testValues5
 } // namespace

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/reshape_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/reshape_transformation.cpp
@@ -60,6 +60,14 @@ const std::vector<ReshapeTransformationParam> params = {
         "Reshape",
         "U8"
     },
+    // 4D -> 6D
+    {
+        { 1, 3, 4, 8 },
+        { 1, 3, 4, 8, 1, 1 },
+        { 256ul, ngraph::Shape{ 1, 1, 1, 1}, { 0.f }, { 255.f }, { 0.f }, { 25.5f } },
+        "Reshape",
+        "U8"
+    },
     // 4D -> 2D
     {
         { 1, 3, 4, 8 },

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/transpose_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/transpose_transformation.cpp
@@ -38,7 +38,15 @@ const std::vector<TransposeTransformationTestValues> testValues = {
             {0.f, 12.5f, 25.5f},
             {25.5f, 25.5f + 12.5f * 2, 25.5f + 12.5f * 4}
         }
-    }
+    },
+    // 6D
+    {
+        { 1, 1000, 1, 1, 3, 4},
+        { 0, 2, 1, 3, 5, 4},
+        LayerTestsUtils::LayerTransformationParamsNGraphFactory::createParamsU8I8(),
+        ngraph::element::f32,
+        {256, {}, {0.f}, {25.5f}, {12.5f}, {25.5f + 12.5f}}
+    },
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_LPT, TransposeTransformation,

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/reshape_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/reshape_transformation.cpp
@@ -60,6 +60,14 @@ const std::vector<ReshapeTransformationParam> params = {
         "Reshape",
         "U8"
     },
+    // 4D -> 6D
+    {
+        { 1, 3, 4, 8 },
+        { 1, 3, 4, 8, 1, 1 },
+        { 256ul, ngraph::Shape{ 1, 1, 1, 1}, { 0.f }, { 255.f }, { 0.f }, { 25.5f } },
+        "Reshape",
+        "U8"
+    },
     // 4D -> 2D
     {
         { 1, 3, 4, 8 },

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/transpose_transformation.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/low_precision_transformations/transpose_transformation.cpp
@@ -38,7 +38,15 @@ const std::vector<TransposeTransformationTestValues> testValues = {
             {0.f, 12.5f, 25.5f},
             {25.5f, 25.5f + 12.5f * 2, 25.5f + 12.5f * 4}
         }
-    }
+    },
+    // 6D
+    {
+        { 1, 1000, 1, 1, 3, 4},
+        { 0, 2, 1, 3, 5, 4},
+        LayerTestsUtils::LayerTransformationParamsNGraphFactory::createParamsU8I8(),
+        ngraph::element::f32,
+        {256, {}, {0.f}, {25.5f}, {12.5f}, {25.5f + 12.5f}}
+    },
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_LPT, TransposeTransformation,

--- a/src/common/low_precision_transformations/src/layer_transformation.cpp
+++ b/src/common/low_precision_transformations/src/layer_transformation.cpp
@@ -51,11 +51,7 @@ bool LayerTransformation::canBeTransformed(const TransformationContext& context,
 bool LayerTransformation::canBeTransformedStatic(const std::shared_ptr<Node>& layer) {
     for (const auto& output : layer->outputs()) {
         const auto rank = output.get_partial_shape().rank();
-        if (rank.is_dynamic()) {
-            return false;
-        }
-        auto size = rank.get_length();
-        if ((size < 2) || (size > 5)) {
+        if (rank.is_dynamic() || rank.get_length() < 2) {
             return false;
         }
     }


### PR DESCRIPTION
### Details:
 - Push dequantize through Transpose->Reshape->Transpose->avgPool pattern
 - Disable pull_transpose_through_fq transformation for activations path
 - [CPU] 5D & 6D element-wise operations performance degradation

### Tickets:
 - 51790
 - 36833 - merged
 - 68856 - merged