### PR TITLE
Set scikit-image~=0.18.3 for python versions >=3.7

### DIFF
--- a/inference-engine/ie_bridges/python/wheel/meta/openvino-dev.requirements.txt
+++ b/inference-engine/ie_bridges/python/wheel/meta/openvino-dev.requirements.txt
@@ -11,8 +11,7 @@ texttable~=1.6.3
 py-cpuinfo>=7.0.0
 PyYAML>=5.4.1
 pillow>=8.1.2
-scikit-image~=0.17.2; python_version == '3.6'
-scikit-image~=0.18.3; python_version >= '3.7'
+scikit-image>=0.17.2
 scikit-learn>=0.24.1
 yamlloader>=0.5
 shapely>=1.7.1


### PR DESCRIPTION
### Details:
 - *Fix for openvino-dev wheel package installation for Python 3.9 on Linux & macOS*

https://github.com/openvinotoolkit/openvino/pull/7910