### PR TITLE
[GPU] Fix incorrect reusage of OneDNN postops configurations

### DIFF
--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/include/batch_headers/fetch_data.cl
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/cl_kernels/include/batch_headers/fetch_data.cl
@@ -459,7 +459,7 @@ inline uint get_bs_fs_zyx_bsv_fsv_index(uint b, uint f,  uint z, uint y, uint x,
 }
 
 #define GET_DATA_BS_FS_YX_BSV16_FSV16_INDEX(prefix, b, f, y, x)     \
-    get_bs_fs_zyx_bsv_fsv_index(                         \
+    get_bs_fs_zyx_bsv_fsv_index(                                    \
         b, f, 0, y, x,                                              \
         CAT(prefix, _SIZE_X),                                       \
         CAT(prefix, _SIZE_Y),                                       \
@@ -475,7 +475,7 @@ inline uint get_bs_fs_zyx_bsv_fsv_index(uint b, uint f,  uint z, uint y, uint x,
         CAT(prefix, _PAD_AFTER_SIZE_X), 16, 16)
 
 #define GET_DATA_BS_FS_YX_BSV32_FSV32_INDEX(prefix, b, f, y, x)     \
-    get_bs_fs_zyx_bsv_fsv_index(                         \
+    get_bs_fs_zyx_bsv_fsv_index(                                    \
         b, f, 0, y, x,                                              \
         CAT(prefix, _SIZE_X),                                       \
         CAT(prefix, _SIZE_Y),                                       \
@@ -491,7 +491,7 @@ inline uint get_bs_fs_zyx_bsv_fsv_index(uint b, uint f,  uint z, uint y, uint x,
         CAT(prefix, _PAD_AFTER_SIZE_X), 32, 32)
 
 #define GET_DATA_BS_FS_YX_BSV4_FSV4_INDEX(prefix, b, f, y, x)       \
-    get_bs_fs_zyx_bsv_fsv_index(                         \
+    get_bs_fs_zyx_bsv_fsv_index(                                    \
         b, f, 0, y, x,                                              \
         CAT(prefix, _SIZE_X),                                       \
         CAT(prefix, _SIZE_Y),                                       \
@@ -507,7 +507,7 @@ inline uint get_bs_fs_zyx_bsv_fsv_index(uint b, uint f,  uint z, uint y, uint x,
         CAT(prefix, _PAD_AFTER_SIZE_X), 4, 4)
 
 #define GET_DATA_BS_FS_YX_BSV4_FSV2_INDEX(prefix, b, f, y, x)       \
-    get_bs_fs_zyx_bsv_fsv_index(                         \
+    get_bs_fs_zyx_bsv_fsv_index(                                    \
         b, f, 0, y, x,                                              \
         CAT(prefix, _SIZE_X),                                       \
         CAT(prefix, _SIZE_Y),                                       \
@@ -523,7 +523,7 @@ inline uint get_bs_fs_zyx_bsv_fsv_index(uint b, uint f,  uint z, uint y, uint x,
         CAT(prefix, _PAD_AFTER_SIZE_X), 4, 2)
 
 #define GET_DATA_BS_FS_YX_BSV32_FSV16_INDEX(prefix, b, f, y, x)     \
-    get_bs_fs_zyx_bsv_fsv_index(                         \
+    get_bs_fs_zyx_bsv_fsv_index(                                    \
         b, f, 0, y, x,                                              \
         CAT(prefix, _SIZE_X),                                       \
         CAT(prefix, _SIZE_Y),                                       \
@@ -539,7 +539,7 @@ inline uint get_bs_fs_zyx_bsv_fsv_index(uint b, uint f,  uint z, uint y, uint x,
         CAT(prefix, _PAD_AFTER_SIZE_X), 32, 16)
 
 #define GET_DATA_BS_FS_ZYX_BSV16_FSV16_INDEX(prefix, b, f, z, y, x) \
-    get_bs_fs_zyx_bsv_fsv_index(                         \
+    get_bs_fs_zyx_bsv_fsv_index(                                    \
         b, f, z, y, x,                                              \
         CAT(prefix, _SIZE_X),                                       \
         CAT(prefix, _SIZE_Y),                                       \
@@ -555,7 +555,7 @@ inline uint get_bs_fs_zyx_bsv_fsv_index(uint b, uint f,  uint z, uint y, uint x,
         CAT(prefix, _PAD_AFTER_SIZE_X), 16, 16)
 
 #define GET_DATA_BS_FS_YX_BSV16_FSV16_INDEX_SAFE(prefix, b, f, y, x) \
-    get_bs_fs_zyx_bsv_fsv_index_safe(                     \
+    get_bs_fs_zyx_bsv_fsv_index_safe(                                \
         b, f, 0, y, x,                                               \
         CAT(prefix, _SIZE_X),                                        \
         CAT(prefix, _SIZE_Y),                                        \
@@ -572,7 +572,7 @@ inline uint get_bs_fs_zyx_bsv_fsv_index(uint b, uint f,  uint z, uint y, uint x,
         CAT(prefix, _PAD_AFTER_SIZE_X), 16, 16)
 
 #define GET_DATA_BS_FS_YX_BSV32_FSV32_INDEX_SAFE(prefix, b, f, y, x) \
-    FUNC_CALL(get_bs_fs_zyx_bsv_fsv_index_safe)(                     \
+    get_bs_fs_zyx_bsv_fsv_index_safe(                                \
         b, f, 0, y, x,                                               \
         CAT(prefix, _SIZE_X),                                        \
         CAT(prefix, _SIZE_Y),                                        \
@@ -589,7 +589,7 @@ inline uint get_bs_fs_zyx_bsv_fsv_index(uint b, uint f,  uint z, uint y, uint x,
         CAT(prefix, _PAD_AFTER_SIZE_X), 32, 32)
 
 #define GET_DATA_BS_FS_YX_BSV4_FSV4_INDEX_SAFE(prefix, b, f, y, x)   \
-    FUNC_CALL(get_bs_fs_zyx_bsv_fsv_index_safe)(                     \
+    get_bs_fs_zyx_bsv_fsv_index_safe(                                \
         b, f, 0, y, x,                                               \
         CAT(prefix, _SIZE_X),                                        \
         CAT(prefix, _SIZE_Y),                                        \
@@ -606,7 +606,7 @@ inline uint get_bs_fs_zyx_bsv_fsv_index(uint b, uint f,  uint z, uint y, uint x,
         CAT(prefix, _PAD_AFTER_SIZE_X), 4, 4)
 
 #define GET_DATA_BS_FS_YX_BSV4_FSV2_INDEX_SAFE(prefix, b, f, y, x)   \
-    FUNC_CALL(get_bs_fs_zyx_bsv_fsv_index_safe)(                     \
+    get_bs_fs_zyx_bsv_fsv_index_safe(                                \
         b, f, 0, y, x,                                               \
         CAT(prefix, _SIZE_X),                                        \
         CAT(prefix, _SIZE_Y),                                        \
@@ -623,7 +623,7 @@ inline uint get_bs_fs_zyx_bsv_fsv_index(uint b, uint f,  uint z, uint y, uint x,
         CAT(prefix, _PAD_AFTER_SIZE_X), 4, 2)
 
 #define GET_DATA_BS_FS_YX_BSV32_FSV16_INDEX_SAFE(prefix, b, f, y, x) \
-    FUNC_CALL(get_bs_fs_zyx_bsv_fsv_index_safe)(                     \
+    get_bs_fs_zyx_bsv_fsv_index_safe(                                \
         b, f, 0, y, x,                                               \
         CAT(prefix, _SIZE_X),                                        \
         CAT(prefix, _SIZE_Y),                                        \
@@ -640,7 +640,7 @@ inline uint get_bs_fs_zyx_bsv_fsv_index(uint b, uint f,  uint z, uint y, uint x,
         CAT(prefix, _PAD_AFTER_SIZE_X), 32, 16)
 
 #define GET_DATA_BS_FS_ZYX_BSV16_FSV16_INDEX_SAFE(prefix, b, f, z, y, x) \
-    get_bs_fs_zyx_bsv_fsv_index_safe(                         \
+    get_bs_fs_zyx_bsv_fsv_index_safe(                                    \
         b, f, z, y, x,                                                   \
         CAT(prefix, _SIZE_X ),                                           \
         CAT(prefix, _SIZE_Y),                                            \

--- a/inference-engine/thirdparty/clDNN/src/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/inference-engine/thirdparty/clDNN/src/graph_optimizer/prepare_primitive_fusing.cpp
@@ -295,10 +295,56 @@ void prepare_primitive_fusing::fuse_bias(program &p) {
             new_node.recalc_output_layout();
         };
 
+        auto recalculate_biases = [&](data_node& original_node, data_node& new_node) -> bool {
+            auto original_mem = original_node.get_attached_memory_ptr();
+            auto new_mem = new_node.get_attached_memory_ptr();
+            if (original_mem->count() != new_mem->count() || original_mem->get_layout().data_type != new_mem->get_layout().data_type)
+                return false;
+
+            switch (original_mem->get_layout().data_type) {
+                case data_types::f32: {
+                    mem_lock<float, mem_lock_type::write> original_bias_mem(original_mem, p.get_stream());
+                    mem_lock<float, mem_lock_type::read> new_bias_mem(new_mem, p.get_stream());
+                    float* original_data = original_bias_mem.data();
+                    float* new_data = new_bias_mem.data();
+                    for (size_t i = 0; i < original_bias_mem.size(); i++)
+                        original_data[i] += new_data[i];
+                    break;
+                }
+                case data_types::f16: {
+                    mem_lock<uint16_t, mem_lock_type::write> original_bias_mem(original_mem, p.get_stream());
+                    mem_lock<uint16_t, mem_lock_type::read> new_bias_mem(new_mem, p.get_stream());
+                    uint16_t* original_data = original_bias_mem.data();
+                    uint16_t* new_data = new_bias_mem.data();
+                    for (size_t i = 0; i < original_bias_mem.size(); i++) {
+                        float new_val = half_to_float(original_data[i]) + half_to_float(new_data[i]);
+                        original_data[i] = float_to_half(new_val);
+                    }
+                    break;
+                }
+                default:
+                    return false;
+            }
+            return true;
+        };
+
         if (replace_candidate.is_type<convolution>()) {
             auto& conv = replace_candidate.as<convolution>();
             auto desc = conv.get_primitive();
             std::vector<primitive_id> biases = {bias_name};
+
+            // If the primitive has biases, then we try to combine the values, or do nothing and keep as fused sum.
+            if (conv.bias_term()) {
+                if (conv.bias().is_type<data>() && bias_node.is_type<data>()) {
+                    if (recalculate_biases(conv.bias().as<data>(), bias_node.as<data>())) {
+                        p.replace_all_usages(eltw_node, conv);
+                        p.add_optimized_primitive_info(eltw_node.id(), {conv.id()});
+                        p.remove_all_connections(eltw_node);
+                        p.remove_if_dangling(eltw_node);
+                    }
+                }
+                continue;
+            }
 
             auto conv_with_bias_prim = std::make_shared<convolution>(desc->id + "_tmp",
                                                                      desc->input[0],
@@ -325,6 +371,19 @@ void prepare_primitive_fusing::fuse_bias(program &p) {
             auto desc = deconv.get_primitive();
             std::vector<primitive_id> biases = {bias_name};
 
+            // If the primitive has biases, then we try to combine the values, or do nothing and keep as fused sum.
+            if (deconv.bias_term()) {
+                if (deconv.bias().is_type<data>() && bias_node.is_type<data>()) {
+                    if (recalculate_biases(deconv.bias().as<data>(), bias_node.as<data>())) {
+                        p.replace_all_usages(eltw_node, deconv);
+                        p.add_optimized_primitive_info(eltw_node.id(), {deconv.id()});
+                        p.remove_all_connections(eltw_node);
+                        p.remove_if_dangling(eltw_node);
+                    }
+                }
+                continue;
+            }
+
             auto deconv_with_bias_prim = std::make_shared<deconvolution>(desc->id + "_tmp",
                                                                          desc->input[0],
                                                                          desc->weights,
@@ -340,6 +399,20 @@ void prepare_primitive_fusing::fuse_bias(program &p) {
         } else if (replace_candidate.is_type<fully_connected>()) {
             auto& fc = replace_candidate.as<fully_connected>();
             auto desc = fc.get_primitive();
+
+            // If the primitive has biases, then we try to combine the values, or do nothing and keep as fused sum.
+            if (fc.bias_term()) {
+                if (fc.bias().is_type<data>() && bias_node.is_type<data>()) {
+                    if (recalculate_biases(fc.bias().as<data>(), bias_node.as<data>())) {
+                        p.replace_all_usages(eltw_node, fc);
+                        p.add_optimized_primitive_info(eltw_node.id(), {fc.id()});
+                        p.remove_all_connections(eltw_node);
+                        p.remove_if_dangling(eltw_node);
+                    }
+                }
+                continue;
+            }
+
             auto fc_with_bias_prim = std::make_shared<fully_connected>(desc->id + "_tmp",
                                                                        desc->input[0],
                                                                        desc->weights,

--- a/inference-engine/thirdparty/clDNN/tests/test_cases/fusings_gpu_test.cpp
+++ b/inference-engine/thirdparty/clDNN/tests/test_cases/fusings_gpu_test.cpp
@@ -771,6 +771,29 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, conv_fp32_bias,
                                              bc_test_params{CASE_CONV_FP16_10, 2, 3},
                                              }));
 
+class conv_fp32_double_bias : public ConvFusingTest {};
+TEST_P(conv_fp32_double_bias, basic) {
+    auto p = GetParam();
+    create_topologies(input_layout("input", get_input_layout(p)),
+                 data("weights", get_mem(get_weights_layout(p))),
+                 data("bias1", get_mem(get_bias_layout(p))),
+                 data("bias2", get_mem(get_bias_layout(p))),
+                 convolution("conv_prim", "input", {"weights"}, std::vector<primitive_id>{}, p.groups, p.stride, p.pad, p.dilation),
+                 eltwise("add_bias1", {"conv_prim", "bias1"}, eltwise_mode::sum),
+                 eltwise("add_bias2", {"add_bias1", "bias2"}, eltwise_mode::sum),
+                 reorder("reorder_bfyx", "add_bias2", p.default_format, data_types::f32)
+    );
+
+    tolerance = 1e-5f;
+    execute(p);
+}
+
+INSTANTIATE_TEST_SUITE_P(fusings_gpu, conv_fp32_double_bias,
+                        ::testing::ValuesIn(std::vector<bc_test_params>{
+                                            bc_test_params{CASE_CONV_U8S8_1, 2, 4},
+                                            bc_test_params{CASE_CONV_S8S8_1, 2, 4},
+                                            }));
+
 class conv_fp32_prelu_eltwise : public ConvFusingTest {};
 TEST_P(conv_fp32_prelu_eltwise, basic_sum) {
     auto p = GetParam();
@@ -4864,7 +4887,7 @@ TEST_P(deconv_scale_actv_quant_u8_eltw_scale_actv_quant_i8, basic) {
         reorder("out", "quant2", p.default_format, data_types::f32)
     );
 
-    tolerance = 1.0f;
+    tolerance = 2.0f;
     execute(p);
 }
 


### PR DESCRIPTION
This PR fixes three issues:
- Incorrect oneDNN post_ops reusage across program for primitives with same names
- Incorrect biases replacement in case if node already has biases
- Kernels compilations fails for some blocked formats