### PR TITLE
[GNA] ActivationLayer tests enabled

### DIFF
--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/activation.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/activation.cpp
@@ -8,15 +8,59 @@
 
 namespace LayerTestsDefinitions {
 
-class ActivationLayerTestInteger : public ActivationLayerTest {
+class ActivationLayerGNATest : public ActivationLayerTest {
 protected:
     void SetUp() override {
-            ActivationLayerTest::SetUp();
+        ActivationLayerTest::SetUp();
+        // TODO: remove after integer inference output support
+        auto ngPrc = function->get_parameters()[0]->get_element_type().get_type_name();
+        if (ngPrc == "u8" || ngPrc == "i16") {
             threshold = 1.0;
+        }
+    }
+
+    InferenceEngine::Blob::Ptr GenerateInput(const InferenceEngine::InputInfo &info) const override {
+        bool inPrcSigned = function->get_parameters()[0]->get_element_type().is_signed();
+        int32_t data_start_from = -10;
+        uint32_t data_range = 20;
+        int32_t resolution = 32768;
+        switch (activationType) {
+            case ngraph::helpers::ActivationTypes::Log: {
+                data_start_from = 1;
+                data_range = 20;
+                resolution = 32768;
+                break;
+            }
+            case ngraph::helpers::ActivationTypes::Sign: {
+                data_start_from = -10;
+                data_range = 20;
+                resolution = 3072;
+                break;
+            }
+            case ngraph::helpers::ActivationTypes::Exp: {
+                const double max_result_on_GNA = 15.9;
+                const double exp_inverse = std::round(std::log(max_result_on_GNA));
+                if (inPrcSigned) {
+                    data_range = exp_inverse * 2.0;
+                    data_start_from = -exp_inverse;
+                } else {
+                    data_range = exp_inverse;
+                    data_start_from = 0;
+                }
+                break;
+            }
+        }
+        if (!inPrcSigned) {
+            data_range = 15;
+            data_start_from = 0;
+        }
+
+        return FuncTestUtils::createAndFillBlob(info.getTensorDesc(), data_range,
+                                                data_start_from, resolution);
     }
 };
 
-TEST_P(ActivationLayerTestInteger, CompareWithRefs) {
+TEST_P(ActivationLayerGNATest, CompareWithRefs) {
         Run();
 }
 
@@ -32,14 +76,12 @@ const std::vector<InferenceEngine::Precision> inputPrecisions = {
         InferenceEngine::Precision::U8
 };
 
-const std::vector<InferenceEngine::Precision> netPrecisionsIntegers = {
-        InferenceEngine::Precision::I16,
-        InferenceEngine::Precision::U8
-};
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
         InferenceEngine::Precision::FP32,
         InferenceEngine::Precision::FP16,
+        InferenceEngine::Precision::I16,
+        InferenceEngine::Precision::U8,
 };
 
 const std::map<ActivationTypes, std::vector<std::vector<float>>> activationTypes = {
@@ -78,21 +120,7 @@ const auto basicCases = ::testing::Combine(
         ::testing::Values(CommonTestUtils::DEVICE_GNA)
 );
 
-const auto integerCases = ::testing::Combine(
-        ::testing::ValuesIn(CommonTestUtils::combineParams(activationTypes)),
-        ::testing::ValuesIn(netPrecisionsIntegers),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Layout::ANY),
-        ::testing::Values(InferenceEngine::Layout::ANY),
-        ::testing::ValuesIn(CommonTestUtils::combineParams(basic)),
-        ::testing::Values(CommonTestUtils::DEVICE_GNA)
-);
 
-
-
-INSTANTIATE_TEST_SUITE_P(smoke_Activation_Basic, ActivationLayerTest, basicCases, ActivationLayerTest::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_Activation_Basic, ActivationLayerTestInteger, integerCases, ActivationLayerTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Activation_Basic, ActivationLayerGNATest, basicCases, ActivationLayerTest::getTestCaseName);
 
 }  // namespace

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/activation.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/activation.cpp
@@ -38,10 +38,8 @@ const std::vector<InferenceEngine::Precision> netPrecisionsIntegers = {
 };
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
-        // TODO: Issue:27391
-        // InferenceEngine::Precision::FP32,
-        // TODO: Issue:28036
-        // InferenceEngine::Precision::FP16,
+        InferenceEngine::Precision::FP32,
+        InferenceEngine::Precision::FP16,
 };
 
 const std::map<ActivationTypes, std::vector<std::vector<float>>> activationTypes = {

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/activation.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/activation.cpp
@@ -6,6 +6,22 @@
 #include "single_layer_tests/activation.hpp"
 #include "common_test_utils/test_constants.hpp"
 
+namespace LayerTestsDefinitions {
+
+class ActivationLayerTestInteger : public ActivationLayerTest {
+protected:
+    void SetUp() override {
+            ActivationLayerTest::SetUp();
+            threshold = 1.0;
+    }
+};
+
+TEST_P(ActivationLayerTestInteger, CompareWithRefs) {
+        Run();
+}
+
+}  //  namespace LayerTestsDefinitions
+
 using namespace LayerTestsDefinitions;
 using namespace ngraph::helpers;
 namespace {
@@ -16,13 +32,16 @@ const std::vector<InferenceEngine::Precision> inputPrecisions = {
         InferenceEngine::Precision::U8
 };
 
+const std::vector<InferenceEngine::Precision> netPrecisionsIntegers = {
+        InferenceEngine::Precision::I16,
+        InferenceEngine::Precision::U8
+};
+
 const std::vector<InferenceEngine::Precision> netPrecisions = {
         // TODO: Issue:27391
         // InferenceEngine::Precision::FP32,
         // TODO: Issue:28036
         // InferenceEngine::Precision::FP16,
-        InferenceEngine::Precision::I16,
-        InferenceEngine::Precision::U8
 };
 
 const std::map<ActivationTypes, std::vector<std::vector<float>>> activationTypes = {
@@ -61,7 +80,21 @@ const auto basicCases = ::testing::Combine(
         ::testing::Values(CommonTestUtils::DEVICE_GNA)
 );
 
+const auto integerCases = ::testing::Combine(
+        ::testing::ValuesIn(CommonTestUtils::combineParams(activationTypes)),
+        ::testing::ValuesIn(netPrecisionsIntegers),
+        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::ValuesIn(CommonTestUtils::combineParams(basic)),
+        ::testing::Values(CommonTestUtils::DEVICE_GNA)
+);
+
+
 
 INSTANTIATE_TEST_SUITE_P(smoke_Activation_Basic, ActivationLayerTest, basicCases, ActivationLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_Activation_Basic, ActivationLayerTestInteger, integerCases, ActivationLayerTest::getTestCaseName);
 
 }  // namespace

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/skip_tests_config.cpp
@@ -17,7 +17,6 @@ std::vector<std::string> disabledTestPatterns() {
         // TODO: FIX BUG 59041
         ".*Behavior.*CallbackThrowException.*",
         // TODO: FIX BUG 32210
-        R"(.*ActivationLayerTest.CompareWithRefs/(Sigmoid|Tanh|Exp|Log).*)",
         R"(.*ActivationFQSubgraph.*activation=(Exp|Log).*)",
         // TODO: Issue 68586
         R"(.*EltwiseActFqTest.*act=Log.*)",

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/skip_tests_config.cpp
@@ -75,5 +75,8 @@ std::vector<std::string> disabledTestPatterns() {
         // TODO: Issue: CVS-69639
         R"(.*EltwiseLayerTest.*OpType=Prod.*)",
         R"(.*EltwiseLayerTest.*OpType=Sum.*PARAMETER.*VECTOR.*)",
+        // TODO: Issue:27391
+        // TODO: Issue:28036
+        R"(.*ActivationLayerTest.*(Log|Exp).*netPRC=(FP16|FP32).*)",
     };
 }

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/skip_tests_config.cpp
@@ -77,6 +77,6 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*EltwiseLayerTest.*OpType=Sum.*PARAMETER.*VECTOR.*)",
         // TODO: Issue:27391
         // TODO: Issue:28036
-        R"(.*ActivationLayerTest.*(Log|Exp).*netPRC=(FP16|FP32).*)",
+        R"(.*ActivationLayerGNATest.*(Log|Exp).*netPRC=(FP16|FP32).*)",
     };
 }

--- a/inference-engine/tests/functional/shared_test_classes/src/single_layer/activation.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/single_layer/activation.cpp
@@ -148,6 +148,13 @@ InferenceEngine::Blob::Ptr ActivationLayerTest::GenerateInput(const InferenceEng
             data_start_from = 0;
         }
     }
+    // To avoid extremely small input values which lose sign during quantization
+    if (activationType == ngraph::helpers::ActivationTypes::Sign
+        && targetDevice == CommonTestUtils::DEVICE_GNA
+        && (info.getPrecision() == InferenceEngine::Precision::FP16 ||
+            info.getPrecision() == InferenceEngine::Precision::FP32)) {
+        resolution = 3072;
+    }
     return FuncTestUtils::createAndFillBlob(info.getTensorDesc(), data_range,
                                             data_start_from,
                                             resolution);

--- a/inference-engine/tests/functional/shared_test_classes/src/single_layer/activation.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/single_layer/activation.cpp
@@ -137,24 +137,7 @@ InferenceEngine::Blob::Ptr ActivationLayerTest::GenerateInput(const InferenceEng
         data_range = 15;
         data_start_from = 0;
     }
-    if (activationType == ngraph::helpers::ActivationTypes::Exp && targetDevice == CommonTestUtils::DEVICE_GNA) {
-        const double max_result_on_GNA = 15.9;
-        const double exp_inverse = std::round(std::log(max_result_on_GNA));
-        if (inPrcSigned) {
-            data_range = exp_inverse * 2.0;
-            data_start_from = -exp_inverse;
-        } else {
-            data_range = exp_inverse;
-            data_start_from = 0;
-        }
-    }
-    // To avoid extremely small input values which lose sign during quantization
-    if (activationType == ngraph::helpers::ActivationTypes::Sign
-        && targetDevice == CommonTestUtils::DEVICE_GNA
-        && (info.getPrecision() == InferenceEngine::Precision::FP16 ||
-            info.getPrecision() == InferenceEngine::Precision::FP32)) {
-        resolution = 3072;
-    }
+
     return FuncTestUtils::createAndFillBlob(info.getTensorDesc(), data_range,
                                             data_start_from,
                                             resolution);

--- a/ngraph/test/runtime/interpreter/evaluates_map.cpp
+++ b/ngraph/test/runtime/interpreter/evaluates_map.cpp
@@ -27,6 +27,7 @@
 #include <ngraph/runtime/reference/embedding_bag_offsets_sum.hpp>
 #include <ngraph/runtime/reference/embedding_bag_packed_sum.hpp>
 #include <ngraph/runtime/reference/embedding_segments_sum.hpp>
+#include <ngraph/runtime/reference/exp.hpp>
 #include <ngraph/runtime/reference/experimental_detectron_detection_output.hpp>
 #include <ngraph/runtime/reference/experimental_detectron_prior_grid_generator.hpp>
 #include <ngraph/runtime/reference/experimental_detectron_proposal_single_image.hpp>
@@ -44,7 +45,11 @@
 #include <ngraph/runtime/reference/group_convolution_backprop_data.hpp>
 #include <ngraph/runtime/reference/gru_cell.hpp>
 #include <ngraph/runtime/reference/hard_sigmoid.hpp>
+<<<<<<< HEAD
 #include <ngraph/runtime/reference/if.hpp>
+=======
+#include <ngraph/runtime/reference/log.hpp>
+>>>>>>> [GNA] ActivationLayer tests in integer precision enabled
 #include <ngraph/runtime/reference/log_softmax.hpp>
 #include <ngraph/runtime/reference/lrn.hpp>
 #include <ngraph/runtime/reference/lstm_cell.hpp>
@@ -67,9 +72,11 @@
 #include <ngraph/runtime/reference/scatter_nd_update.hpp>
 #include <ngraph/runtime/reference/selu.hpp>
 #include <ngraph/runtime/reference/sequences.hpp>
+#include <ngraph/runtime/reference/sigmoid.hpp>
 #include <ngraph/runtime/reference/sign.hpp>
 #include <ngraph/runtime/reference/slice.hpp>
 #include <ngraph/runtime/reference/squared_difference.hpp>
+#include <ngraph/runtime/reference/tanh.hpp>
 #include <ngraph/runtime/reference/tensor_iterator.hpp>
 #include <ngraph/runtime/reference/utils/nms_common.hpp>
 
@@ -1679,6 +1686,42 @@ template <element::Type_t ET>
 bool evaluate(const shared_ptr<op::v0::Abs>& op, const HostTensorVector& outputs, const HostTensorVector& inputs) {
     using T = typename element_type_traits<ET>::value_type;
     runtime::reference::abs<T>(inputs[0]->get_data_ptr<T>(),
+                               outputs[0]->get_data_ptr<T>(),
+                               shape_size(inputs[0]->get_shape()));
+    return true;
+}
+
+template <element::Type_t ET>
+bool evaluate(const shared_ptr<op::v0::Sigmoid>& op, const HostTensorVector& outputs, const HostTensorVector& inputs) {
+    using T = typename element_type_traits<ET>::value_type;
+    runtime::reference::sigmoid<T>(inputs[0]->get_data_ptr<T>(),
+                                   outputs[0]->get_data_ptr<T>(),
+                                   shape_size(inputs[0]->get_shape()));
+    return true;
+}
+
+template <element::Type_t ET>
+bool evaluate(const shared_ptr<op::v0::Exp>& op, const HostTensorVector& outputs, const HostTensorVector& inputs) {
+    using T = typename element_type_traits<ET>::value_type;
+    runtime::reference::exp<T>(inputs[0]->get_data_ptr<T>(),
+                               outputs[0]->get_data_ptr<T>(),
+                               shape_size(inputs[0]->get_shape()));
+    return true;
+}
+
+template <element::Type_t ET>
+bool evaluate(const shared_ptr<op::v0::Tanh>& op, const HostTensorVector& outputs, const HostTensorVector& inputs) {
+    using T = typename element_type_traits<ET>::value_type;
+    runtime::reference::tanh<T>(inputs[0]->get_data_ptr<T>(),
+                                outputs[0]->get_data_ptr<T>(),
+                                shape_size(inputs[0]->get_shape()));
+    return true;
+}
+
+template <element::Type_t ET>
+bool evaluate(const shared_ptr<op::v0::Log>& op, const HostTensorVector& outputs, const HostTensorVector& inputs) {
+    using T = typename element_type_traits<ET>::value_type;
+    runtime::reference::log<T>(inputs[0]->get_data_ptr<T>(),
                                outputs[0]->get_data_ptr<T>(),
                                shape_size(inputs[0]->get_shape()));
     return true;

--- a/ngraph/test/runtime/interpreter/evaluates_map.cpp
+++ b/ngraph/test/runtime/interpreter/evaluates_map.cpp
@@ -45,11 +45,8 @@
 #include <ngraph/runtime/reference/group_convolution_backprop_data.hpp>
 #include <ngraph/runtime/reference/gru_cell.hpp>
 #include <ngraph/runtime/reference/hard_sigmoid.hpp>
-<<<<<<< HEAD
 #include <ngraph/runtime/reference/if.hpp>
-=======
 #include <ngraph/runtime/reference/log.hpp>
->>>>>>> [GNA] ActivationLayer tests in integer precision enabled
 #include <ngraph/runtime/reference/log_softmax.hpp>
 #include <ngraph/runtime/reference/lrn.hpp>
 #include <ngraph/runtime/reference/lstm_cell.hpp>

--- a/ngraph/test/runtime/interpreter/opset_int_tbl.hpp
+++ b/ngraph/test/runtime/interpreter/opset_int_tbl.hpp
@@ -106,3 +106,8 @@ NGRAPH_OP(MulticlassNms, op::v8)
 NGRAPH_OP(Slice, op::v8)
 NGRAPH_OP(DeformableConvolution, ngraph::op::v8)
 NGRAPH_OP(If, ngraph::op::v8)
+
+NGRAPH_OP(Sigmoid, op::v0)
+NGRAPH_OP(Tanh, op::v0)
+NGRAPH_OP(Exp, op::v0)
+NGRAPH_OP(Log, op::v0)


### PR DESCRIPTION
### Details:
 - Enabling **integer precision** tests:
   - Threshold for integer networks changed to 1 until the capability of returning actual values in integers
   - Separate test suite
 - Enabling **floating point** precision tests:
   - Returning FP32 and FP16 precisions into the test configuration
   - Limiting small input values for `Sign` activation
   - Adding `Exp` and `Log` activations in skip list

### Tickets:
 - *32210*
 - *61379*
