### PR TITLE
[GPU] Keep `-Os` optimize option only for Release build

### DIFF
--- a/inference-engine/src/cldnn_engine/CMakeLists.txt
+++ b/inference-engine/src/cldnn_engine/CMakeLists.txt
@@ -26,7 +26,9 @@ ie_add_plugin(NAME ${TARGET_NAME}
               SOURCES ${MAIN_SRC} ${LIBRARY_HEADERS}
               VERSION_DEFINES_FOR cldnn_engine.cpp)
 
-target_compile_options(${TARGET_NAME} PRIVATE -Os)
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+  target_compile_options(${TARGET_NAME} PRIVATE -Os)
+endif()
 
 target_link_libraries(${TARGET_NAME} PRIVATE clDNN_lib pugixml::static
                                              inference_engine

--- a/inference-engine/thirdparty/clDNN/kernel_selector/CMakeLists.txt
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/CMakeLists.txt
@@ -125,7 +125,9 @@ add_library("${CLDNN_BUILD__PROJ}" STATIC
     ${__CLDNN_AllSources}
   )
 
-target_compile_options(${CLDNN_BUILD__PROJ} PRIVATE -Os)
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+  target_compile_options(${CLDNN_BUILD__PROJ} PRIVATE -Os)
+endif()
 
 set_property(TARGET "${CLDNN_BUILD__PROJ}" PROPERTY PROJECT_LABEL "${CLDNN_BUILD__PROJ_LABEL}")
 

--- a/inference-engine/thirdparty/clDNN/runtime/CMakeLists.txt
+++ b/inference-engine/thirdparty/clDNN/runtime/CMakeLists.txt
@@ -46,7 +46,9 @@ add_library("${CLDNN_BUILD__PROJ}" STATIC
     ${__CLDNN_AllSources}
   )
 
-target_compile_options(${CLDNN_BUILD__PROJ} PRIVATE -Os)
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+  target_compile_options(${CLDNN_BUILD__PROJ} PRIVATE -Os)
+endif()
 
 set_property(TARGET "${CLDNN_BUILD__PROJ}" PROPERTY PROJECT_LABEL "${CLDNN_BUILD__PROJ_LABEL}")
 

--- a/inference-engine/thirdparty/clDNN/src/CMakeLists.txt
+++ b/inference-engine/thirdparty/clDNN/src/CMakeLists.txt
@@ -111,7 +111,9 @@ add_library("${CLDNN_BUILD__PROJ}" STATIC
     ${__CLDNN_AllSources}
   )
 
-target_compile_options(${CLDNN_BUILD__PROJ} PRIVATE -Os)
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+  target_compile_options(${CLDNN_BUILD__PROJ} PRIVATE -Os)
+endif()
 
 set_property(TARGET "${CLDNN_BUILD__PROJ}" PROPERTY PROJECT_LABEL "${CLDNN_BUILD__PROJ_LABEL}")
 


### PR DESCRIPTION
These changes exclude -Os optimization option for Debug and RelWithDebInfo builds
