### PR TITLE
[OV2.0] Preprocessing - remove manual assign of tensor names

### DIFF
--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
@@ -121,9 +121,8 @@ std::vector<std::string> disabledTestPatterns() {
         R"(smoke_PrePostProcess.*resize_linear_nhwc.*)",
         // Issue 67214
         R"(smoke_PrePostProcess.*resize_and_convert_layout_i8.*)",
-
-        // TODO:
-        R"(smoke_PrePostProcess.*two_inputs_basic_Device.*)"
+        // Issue 67910
+        R"(.*smoke_PrePostProcess.*two_inputs_trivial.*)",
     };
 
 #define FIX_62820 0

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/skip_tests_config.cpp
@@ -74,5 +74,7 @@ std::vector<std::string> disabledTestPatterns() {
             R"(.*smoke_PrePostProcess_GPU.*convert_element_type_and_mean.*)",
             // TODO: Issue 67408
             R"(.*smoke_LSTMSequenceCommonClip.*LSTMSequenceTest.*CompareWithRefs.*)",
+            // TODO: Issue 67910
+            R"(.*smoke_PrePostProcess_GPU.*two_inputs_trivial.*)",
     };
 }

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/subgraph_tests/preprocess.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/subgraph_tests/preprocess.cpp
@@ -17,6 +17,8 @@ inline std::vector<preprocess_func> GPU_smoke_preprocess_functions() {
             preprocess_func(mean_only, "mean_only", 0.01f),
             preprocess_func(scale_only, "scale_only", 0.01f),
             preprocess_func(convert_element_type_and_mean, "convert_element_type_and_mean", 0.01f),
+            preprocess_func(two_inputs_basic, "two_inputs_basic", 0.01f),
+            preprocess_func(two_inputs_trivial, "two_inputs_trivial", 0.01f),
     };
 }
 

--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/preprocess/preprocess_builders.hpp
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/preprocess/preprocess_builders.hpp
@@ -23,13 +23,15 @@ inline std::shared_ptr<Function> create_preprocess_1input(element::Type type,
     data1->set_friendly_name("input1");
     data1->output(0).get_tensor().set_names({"input1"});
     std::shared_ptr<op::v0::Result> res;
+    auto op1 = std::make_shared<op::v0::Abs>(data1);
     if (type == element::f32) {
-        res = std::make_shared<op::v0::Result>(data1);
+        res = std::make_shared<op::v0::Result>(op1);
     } else {
         auto convert = std::make_shared<op::v0::Convert>(data1, element::f32);
-        res = std::make_shared<op::v0::Result>(convert);
+        res = std::make_shared<op::v0::Result>(op1);
     }
-    res->set_friendly_name("Result");
+    res->set_friendly_name("Result1");
+    res->output(0).get_tensor().set_names({"Result1"});
     return std::make_shared<Function>(ResultVector{res}, ParameterVector{data1});
 }
 
@@ -42,17 +44,37 @@ inline std::shared_ptr<Function> create_preprocess_2inputs(element::Type type,
     data2->set_friendly_name("input2");
     data2->output(0).get_tensor().set_names({"input2"});
     std::shared_ptr<op::v0::Result> res1, res2;
+    auto op1 = std::make_shared<op::v0::Abs>(data1);
+    auto op2 = std::make_shared<op::v0::Abs>(data2);
     if (type == element::f32) {
-        res1 = std::make_shared<op::v0::Result>(data1);
-        res2 = std::make_shared<op::v0::Result>(data2);
+        res1 = std::make_shared<op::v0::Result>(op1);
+        res2 = std::make_shared<op::v0::Result>(op2);
     } else {
-        auto convert1 = std::make_shared<op::v0::Convert>(data1, element::f32);
+        auto convert1 = std::make_shared<op::v0::Convert>(op1, element::f32);
         res1 = std::make_shared<op::v0::Result>(convert1);
-        auto convert2 = std::make_shared<op::v0::Convert>(data2, element::f32);
+        auto convert2 = std::make_shared<op::v0::Convert>(op2, element::f32);
         res2 = std::make_shared<op::v0::Result>(convert2);
     }
     res1->set_friendly_name("Result1");
+    res1->output(0).get_tensor().set_names({"Result1"});
     res2->set_friendly_name("Result2");
+    res2->output(0).get_tensor().set_names({"Result2"});
+    return std::make_shared<Function>(ResultVector{res1, res2}, ParameterVector{data1, data2});
+}
+
+inline std::shared_ptr<Function> create_preprocess_2inputs_trivial() {
+    auto data1 = std::make_shared<op::v0::Parameter>(element::f32, Shape{1, 3, 1, 1});
+    auto data2 = std::make_shared<op::v0::Parameter>(element::f32, Shape{1, 3, 1, 1});
+
+    data1->set_friendly_name("input1");
+    data1->output(0).get_tensor().set_names({"input1"});
+
+    data2->set_friendly_name("input2");
+    data2->output(0).get_tensor().set_names({"input2"});
+
+    auto res1 = std::make_shared<op::v0::Result>(data1);
+    auto res2 = std::make_shared<op::v0::Result>(data2);
+
     return std::make_shared<Function>(ResultVector{res1, res2}, ParameterVector{data1, data2});
 }
 
@@ -180,6 +202,13 @@ inline std::shared_ptr<Function> lvalues_multiple_ops() {
 inline std::shared_ptr<Function> two_inputs_basic() {
     using namespace ov::preprocess;
     auto function = create_preprocess_2inputs(element::f32, Shape{1, 3, 1, 1});
+    function = PrePostProcessor().input(InputInfo(1).preprocess(PreProcessSteps().mean(1.f).scale(2.0f))).build(function);
+    return function;
+}
+
+inline std::shared_ptr<Function> two_inputs_trivial() {
+    using namespace ov::preprocess;
+    auto function = create_preprocess_2inputs_trivial();
     function = PrePostProcessor().input(InputInfo(1).preprocess(PreProcessSteps().mean(1.f).scale(2.0f))).build(function);
     return function;
 }
@@ -340,6 +369,7 @@ inline std::vector<preprocess_func> generic_preprocess_functions() {
             preprocess_func(custom_preprocessing, "custom_preprocessing", 0.01f),
             preprocess_func(lvalues_multiple_ops, "lvalues_multiple_ops", 0.01f),
             preprocess_func(two_inputs_basic, "two_inputs_basic", 0.01f),
+            preprocess_func(two_inputs_trivial, "two_inputs_trivial", 0.01f),
             preprocess_func(reuse_network_layout, "reuse_network_layout", 0.01f),
             preprocess_func(tensor_layout, "tensor_layout", 0.01f),
             preprocess_func(resize_linear, "resize_linear", 0.01f),

--- a/ngraph/core/include/openvino/core/preprocess/color_format.hpp
+++ b/ngraph/core/include/openvino/core/preprocess/color_format.hpp
@@ -11,7 +11,8 @@ namespace preprocess {
 enum class ColorFormat {
     UNDEFINED,
     NV12_SINGLE_PLANE,  // Image in NV12 format as single tensor
-    NV12_TWO_PLANES,    // Image in NV12 format represented as separate tensors for Y and UV planes
+    /// \brief Image in NV12 format represented as separate tensors for Y and UV planes.
+    NV12_TWO_PLANES,
     RGB,
     BGR
 };

--- a/ngraph/core/include/openvino/core/preprocess/input_tensor_info.hpp
+++ b/ngraph/core/include/openvino/core/preprocess/input_tensor_info.hpp
@@ -123,16 +123,17 @@ public:
     ///
     /// In general way, some formats support multi-plane input, e.g. NV12 image can be represented as 2 separate tensors
     /// (planes): Y plane and UV plane. set_color_format API also allows to set sub_names for such parameters for
-    /// convenient usage of plane parameters.
+    /// convenient usage of plane parameters. During build stage, new parameters for each plane will be inserted to the
+    /// place of original parameter. This means that all parameters located after will shift their positions accordingly
+    /// (e.g. {param1, param2} will become {param1/Y, param1/UV, param2})
     ///
     /// This version allows chaining for Lvalue objects.
     ///
     /// \param format Color format of input image.
     ///
-    /// \param sub_names Optional list of sub-names assigned for each plane (e.g. {"Y", "UV"}). If not specified,
-    /// sub-names for plane parameters are auto-generated, exact names auto-generation rules depend on specific color
-    /// format, and client's code shall not rely on these rules. It is not allowed to specify sub-names for single-plane
-    /// inputs, also is specified, number of sub-names shall match with number of planes.
+    /// \param sub_names Optional list of sub-names assigned for each plane (e.g. {"Y", "UV"}). If specified, number of
+    /// sub-names shall match with number of planes. If not specified, friendly name and tensor name for plane
+    /// parameters will be empty. It is not allowed to specify sub-names for single-plane inputs.
     ///
     /// \return Reference to 'this' to allow chaining with other calls in a builder-like manner.
     InputTensorInfo& set_color_format(const ov::preprocess::ColorFormat& format,
@@ -142,16 +143,17 @@ public:
     ///
     /// In general way, some formats support multi-plane input, e.g. NV12 image can be represented as 2 separate tensors
     /// (planes): Y plane and UV plane. set_color_format API also allows to set sub_names for such parameters for
-    /// convenient usage of plane parameters.
+    /// convenient usage of plane parameters. During build stage, new parameters for each plane will be inserted to the
+    /// place of original parameter. This means that all parameters located after will shift their positions accordingly
+    /// (e.g. {param1, param2} will become {param1/Y, param1/UV, param2})
     ///
     /// This version allows chaining for Rvalue objects.
     ///
     /// \param format Color format of input image.
     ///
-    /// \param sub_names Optional list of sub-names assigned for each plane (e.g. {"Y", "UV"}). If not specified,
-    /// sub-names for plane parameters are auto-generated, exact names auto-generation rules depend on specific color
-    /// format, and client's code shall not rely on these rules. It is not allowed to specify sub-names for single-plane
-    /// inputs, also is specified, number of sub-names shall match with number of planes.
+    /// \param sub_names Optional list of sub-names assigned for each plane (e.g. {"Y", "UV"}). If specified, number of
+    /// sub-names shall match with number of planes. If not specified, friendly name and tensor name for plane
+    /// parameters will be empty. It is not allowed to specify sub-names for single-plane inputs.
     ///
     /// \return Rvalue reference to 'this' to allow chaining with other calls in a builder-like manner.
     InputTensorInfo&& set_color_format(const ov::preprocess::ColorFormat& format,

--- a/ngraph/core/src/preprocess/color_utils.hpp
+++ b/ngraph/core/src/preprocess/color_utils.hpp
@@ -60,19 +60,11 @@ public:
         return calculate_shape(plane_num, image_src_shape);
     }
 
-    std::string friendly_suffix(size_t plane_num) const {
-        OPENVINO_ASSERT(plane_num < planes_count(),
-                        "Internal error: incorrect plane number specified for color format");
-        return calc_name_suffix(plane_num);
-    }
-
 protected:
     virtual PartialShape calculate_shape(size_t plane_num, const PartialShape& image_shape) const {
         return image_shape;
     }
-    virtual std::string calc_name_suffix(size_t plane_num) const {
-        return {};
-    }
+
     explicit ColorFormatInfo(ColorFormat format) : m_format(format) {}
     ColorFormat m_format;
 };
@@ -126,12 +118,6 @@ protected:
             }
         }
         return result;
-    }
-    std::string calc_name_suffix(size_t plane_num) const override {
-        if (plane_num == 0) {
-            return "/Y";
-        }
-        return "/UV";
     }
 
     Layout default_layout() const override {

--- a/ngraph/core/src/preprocess/pre_post_process.cpp
+++ b/ngraph/core/src/preprocess/pre_post_process.cpp
@@ -324,6 +324,7 @@ PrePostProcessor&& PrePostProcessor::output(OutputInfo&& builder) && {
 
 std::shared_ptr<Function> PrePostProcessor::build(const std::shared_ptr<Function>& function) {
     FunctionGuard guard(function);
+    std::tuple<std::unordered_set<std::string>, bool> existing_names{std::unordered_set<std::string>{}, false};
     bool tensor_data_updated = false;
     for (const auto& input : m_impl->in_contexts) {
         std::shared_ptr<op::v0::Parameter> param;
@@ -344,7 +345,8 @@ std::shared_ptr<Function> PrePostProcessor::build(const std::shared_ptr<Function
         input->m_resolved_param = param;
     }
     auto results = function->get_results();
-    auto parameters = function->get_parameters();
+    auto parameters_list = std::list<std::shared_ptr<op::v0::Parameter>>(function->get_parameters().begin(),
+                                                                         function->get_parameters().end());
 
     for (const auto& input : m_impl->in_contexts) {
         auto param = input->m_resolved_param;
@@ -396,17 +398,33 @@ std::shared_ptr<Function> PrePostProcessor::build(const std::shared_ptr<Function
         std::vector<Output<Node>> nodes;
         std::vector<std::shared_ptr<op::v0::Parameter>> new_params;
 
-        // Create separate parameter for each plane. Shape and friendly name is based on color format
+        // Create separate parameter for each plane. Shape is based on color format
         for (size_t plane = 0; plane < color_info->planes_count(); plane++) {
             auto plane_shape = color_info->shape(plane, new_param_shape);
             auto plane_param =
                 std::make_shared<op::v0::Parameter>(input->m_tensor_data->get_element_type(), plane_shape);
             if (plane < input->m_tensor_data->planes_sub_names().size()) {
-                auto sub_name = std::string("/") + input->m_tensor_data->planes_sub_names()[plane];
-                inherit_friendly_names(function, param, plane_param, sub_name, false);
-            } else {
-                auto sub_name = color_info->friendly_suffix(plane);
-                inherit_friendly_names(function, param, plane_param, sub_name);
+                std::unordered_set<std::string> plane_tensor_names;
+                std::string sub_name;
+                sub_name = std::string("/") + input->m_tensor_data->planes_sub_names()[plane];
+                if (!std::get<1>(existing_names)) {
+                    existing_names = std::make_tuple(get_function_tensor_names(function), true);
+                }
+                for (const auto& tensor_name : param->get_default_output().get_tensor().get_names()) {
+                    auto new_name = tensor_name + sub_name;
+                    OPENVINO_ASSERT(
+                        std::get<0>(existing_names).count(new_name) == 0,
+                        "Error while trying to create plane input with name '",
+                        new_name,
+                        "' - name already exists in network. Please specify another sub-name for set_color_format");
+                    plane_tensor_names.insert(new_name);
+                }
+                plane_param->get_default_output().get_tensor().set_names(plane_tensor_names);
+                plane_param->set_friendly_name(param->get_friendly_name() + sub_name);
+            } else if (color_info->planes_count() == 1) {
+                plane_param->get_default_output().get_tensor().set_names(
+                    param->get_default_output().get_tensor().get_names());
+                plane_param->set_friendly_name(param->get_friendly_name());
             }
             if (!input->m_tensor_data->get_layout().empty()) {
                 plane_param->set_layout(input->m_tensor_data->get_layout());
@@ -466,22 +484,24 @@ std::shared_ptr<Function> PrePostProcessor::build(const std::shared_ptr<Function
         for (auto consumer : consumers) {
             consumer.replace_source_output(node);
         }
-        for (size_t i = 0; i < parameters.size(); i++) {
-            if (param == parameters[i]) {
-                parameters[i] = new_params[0];
-                break;
-            }
-        }
-        for (size_t i = 1; i < new_params.size(); i++) {
-            parameters.emplace_back(new_params[i]);
+        {
+            auto param_it = std::find(parameters_list.begin(), parameters_list.end(), param);
+            OPENVINO_ASSERT(param_it != parameters_list.end(),
+                            "Parameter to replace has been replaced by previous steps of preprocessing. Use only one "
+                            "InputInfo for one input parameter");
+            // Insert list of new parameters to the place of original parameter
+            param_it = parameters_list.erase(param_it);
+            parameters_list.insert(param_it, new_params.begin(), new_params.end());
         }
     }
 
     // Add parameters with right order
     {
-        while (!function->get_parameters().empty())
+        while (!function->get_parameters().empty()) {
             function->remove_parameter(*function->get_parameters().begin());
-        function->add_parameters(parameters);
+        }
+        auto parameters_vec = ParameterVector(parameters_list.begin(), parameters_list.end());
+        function->add_parameters(parameters_vec);
     }
     // Validate nodes after preprocessing if needed (no need to repeat it after post-processing)
     if (tensor_data_updated) {
@@ -501,6 +521,7 @@ std::shared_ptr<Function> PrePostProcessor::build(const std::shared_ptr<Function
             node = function->output();
         }
         auto start_out_node_names = node.get_tensor().get_names();
+        node.get_tensor().set_names({});
         result = std::dynamic_pointer_cast<op::v0::Result>(node.get_node_shared_ptr());
         // Set result layout from 'network' information
         if (output->m_network_data && output->m_network_data->is_layout_set() && result->get_layout().empty()) {
@@ -539,26 +560,28 @@ std::shared_ptr<Function> PrePostProcessor::build(const std::shared_ptr<Function
             auto action_result = action({node}, context);
             node = std::get<0>(action_result);
         }
+        node.get_node_shared_ptr()->set_friendly_name(
+            result->get_input_source_output(0).get_node_shared_ptr()->get_friendly_name());
 
         // Create result
         auto new_result = std::make_shared<ov::op::v0::Result>(node);
+        new_result->set_friendly_name(result->get_friendly_name());
         if (!context.layout().empty()) {
             new_result->set_layout(context.layout());
         }
         node.get_tensor().set_names(start_out_node_names);
-        for (size_t i = 0; i < results.size(); i++) {
-            if (result == results[i]) {
-                results[i] = new_result;
+
+        for (auto& old_result : results) {
+            if (result == old_result) {
+                old_result = new_result;
                 break;
             }
         }
     }
     // Add results with right order
-    {
-        while (!function->get_results().empty())
-            function->remove_result(*function->get_results().begin());
-        function->add_results(results);
-    }
+    while (!function->get_results().empty())
+        function->remove_result(*function->get_results().begin());
+    function->add_results(results);
 
     guard.reset();
     return function;

--- a/ngraph/core/src/preprocess/preprocess_steps_impl.cpp
+++ b/ngraph/core/src/preprocess/preprocess_steps_impl.cpp
@@ -46,10 +46,8 @@ void PreStepsList::add_scale_impl(const std::vector<float>& values) {
             shape = construct_mean_scale_shape(nodes[0].get_node_shared_ptr(), values.size(), context);
         }
         auto constant = op::v0::Constant::create(element::f32, shape, values);
-        // inherit_friendly_names(function, nodes[0].get_node_shared_ptr(), constant, "/scale/Divide_Factor");
 
         auto new_op = std::make_shared<op::v1::Divide>(nodes[0], constant);
-        // inherit_friendly_names(function, nodes[0].get_node_shared_ptr(), new_op, "/scale/Divide");
         return std::make_tuple(std::vector<Output<Node>>{new_op}, false);
     });
 }
@@ -69,10 +67,8 @@ void PreStepsList::add_mean_impl(const std::vector<float>& values) {
             shape = construct_mean_scale_shape(nodes[0], values.size(), context);
         }
         auto constant = op::v0::Constant::create(element::f32, shape, values);
-        // inherit_friendly_names(function, nodes[0], constant, "/mean/Mean_Const");
 
         auto new_op = std::make_shared<op::v1::Subtract>(nodes[0], constant);
-        // inherit_friendly_names(function, nodes[0], new_op, "/mean/Subtract");
         return std::make_tuple(std::vector<Output<Node>>{new_op}, false);
     });
 }
@@ -93,7 +89,6 @@ void PreStepsList::add_convert_impl(const element::Type& type) {
                             "Can't insert 'convert_element_type' for dynamic source tensor type.");
             if (t != node.get_element_type()) {
                 auto convert = std::make_shared<op::v0::Convert>(node, t);
-                // inherit_friendly_names(function, node, convert, "/convert_element_type");
                 res.emplace_back(convert);
                 convert_added = true;
             } else {
@@ -154,7 +149,6 @@ void PreStepsList::add_resize_impl(ResizeAlgorithm alg, int dst_height, int dst_
                                                     {0, 0});
 
         auto interp = std::make_shared<op::v4::Interpolate>(node, target_spatial_shape, scales, axes, attrs);
-        // inherit_friendly_names(function, nodes[0], interp, "/resize");
         return std::make_tuple(std::vector<Output<Node>>{interp}, true);
     });
 }
@@ -178,7 +172,6 @@ void PreStepsList::add_convert_layout_impl(const Layout& layout) {
         }
         auto perm_constant = op::v0::Constant::create<int64_t>(element::i64, Shape{permutation.size()}, permutation);
         auto transpose = std::make_shared<op::v1::Transpose>(nodes[0], perm_constant);
-        // inherit_friendly_names(function, nodes[0], transpose, "/convert_layout");
         context.layout() = dst_layout;  // Update context's current layout
         return std::make_tuple(std::vector<Output<Node>>{transpose}, true);
     });
@@ -207,7 +200,6 @@ void PreStepsList::add_convert_color_impl(const ColorFormat& dst_format) {
                                 color_format_name(dst_format),
                                 "' format:");
             }
-            // inherit_friendly_names(function, nodes[0], convert, "/convert_color_nv12_single");
             context.color_format() = dst_format;
             return std::make_tuple(std::vector<Output<Node>>{convert}, true);
         } else if (context.color_format() == ColorFormat::NV12_TWO_PLANES) {
@@ -226,7 +218,6 @@ void PreStepsList::add_convert_color_impl(const ColorFormat& dst_format) {
                                 color_format_name(dst_format),
                                 "' format:");
             }
-            // inherit_friendly_names(function, nodes[0], convert, "/convert_color_nv12_two_planes");
             context.color_format() = dst_format;
             return std::make_tuple(std::vector<Output<Node>>{convert}, true);
         }
@@ -251,7 +242,6 @@ void PostStepsList::add_convert_impl(const element::Type& type) {
             !t.is_dynamic() && t != element::undefined,
             "Can't convert to dynamic/unknown element type, consider using of InputTensorInfo::set_element_type");
         auto convert = std::make_shared<op::v0::Convert>(node, t);
-        inherit_friendly_names_postprocess(convert, node);
         return std::make_tuple(Output<Node>(convert), true);
     });
 }
@@ -269,7 +259,6 @@ void PostStepsList::add_convert_layout_impl(const Layout& layout) {
         }
         auto perm_constant = op::v0::Constant::create<int64_t>(element::i64, Shape{permutation.size()}, permutation);
         auto transpose = std::make_shared<op::v1::Transpose>(node, perm_constant);
-        inherit_friendly_names_postprocess(transpose, node);
         context.layout() = dst_layout;  // Update context's current layout
         return std::make_tuple(Output<Node>(transpose), true);
     });

--- a/ngraph/core/src/preprocess/preprocess_steps_impl.hpp
+++ b/ngraph/core/src/preprocess/preprocess_steps_impl.hpp
@@ -60,47 +60,6 @@ inline size_t get_and_check_channels_idx(const Layout& layout, const PartialShap
     return idx;
 }
 
-inline void inherit_friendly_names(const std::shared_ptr<ov::Function>& function,
-                                   const Output<ov::Node>& src_node,
-                                   const Output<ov::Node>& dst_node,
-                                   const std::string& suffix,
-                                   bool search_for_available_name = true) {
-    dst_node.get_node_shared_ptr()->set_friendly_name(src_node.get_node_shared_ptr()->get_friendly_name() + suffix);
-    std::unordered_set<std::string> new_names;
-    for (const auto& tensor_name : src_node.get_tensor().get_names()) {
-        auto new_tensor_name = tensor_name + suffix;
-        if (!suffix.empty()) {
-            // Verify that new names are unique for a function
-            if (!is_tensor_name_available(new_tensor_name, function) && search_for_available_name) {
-                // Search for available name
-                size_t idx = 0;
-                do {
-                    new_tensor_name = tensor_name + suffix + std::to_string(idx++);
-                } while (!is_tensor_name_available(new_tensor_name, function));
-            }
-        }
-        new_names.emplace(new_tensor_name);
-    }
-    dst_node.get_tensor().set_names(new_names);
-}
-
-// TODO: add uniqueness check like for preprocessing (or remove from pre-processing)
-inline void inherit_friendly_names_postprocess(const Output<ov::Node>& inserted_output,
-                                               const Output<ov::Node>& previous_output) {
-    inserted_output.get_node_shared_ptr()->set_friendly_name(
-        previous_output.get_node_shared_ptr()->get_friendly_name());
-    std::unordered_set<std::string> new_names;  // New name for previous node
-    for (const auto& tensor_name : previous_output.get_tensor().get_names()) {
-        auto new_tensor_name = tensor_name;
-        new_names.emplace(new_tensor_name);
-    }
-    previous_output.get_tensor().set_names(new_names);
-
-    // reset names for original node
-    previous_output.get_node_shared_ptr()->set_friendly_name({});
-    previous_output.get_tensor().set_names({});
-}
-
 /// \brief Context passed to each pre/post-processing operation.
 /// This is internal structure which is not shared to custom operations yet.
 class PrePostProcessingContextBase {

--- a/ngraph/core/src/tensor_name_util.hpp
+++ b/ngraph/core/src/tensor_name_util.hpp
@@ -9,21 +9,15 @@
 
 namespace ov {
 
-/// \brief Check that specified tensor name is unique for a given function.
-///
-/// \param tensor_name Name to check across all tensors in a function.
-/// \param function Function.
-/// \return False if tensor name is already used in some function's node, True otherwise
-inline bool is_tensor_name_available(const std::string& tensor_name, const std::shared_ptr<Function>& function) {
+inline std::unordered_set<std::string> get_function_tensor_names(const std::shared_ptr<Function>& function) {
+    std::unordered_set<std::string> set;
     for (const auto& node : function->get_ordered_ops()) {
         for (const auto& output : node->outputs()) {
-            const auto& tensor = output.get_tensor();
-            if (tensor.get_names().count(tensor_name)) {
-                return false;
-            }
+            const auto& names = output.get_tensor().get_names();
+            set.insert(names.begin(), names.end());
         }
     }
-    return true;
+    return set;
 }
 
 }  // namespace ov


### PR DESCRIPTION
### Details:
Follow up with recently discussed comments:
 - For new added pre/post-processing operations, remove assignment to friendly name and output tensor names
 - For multi-plane (NV12)
   - If user manually specified suffixes - check for conflicts with existing one and throw
   - If suffixes were not specified - tensor names and friendly names are not set for new plane parameters
 - IE network reader: apply 67cfc9beb5bb0c66916c91ab5820dc25ad164a70 to use implicit layout and element_type pre/post-processing conversions
 - Ensure order of parameters and results are kept the same after pre/post-processing.
 - Updated tests

### Other:
   - Exception safety: add restoring of partially changed Results if exception occurs
   - Find an issue in CompareWithRefs tests - on CPU/GPU trivial functions with preprocessing cause reordering of outputs

### Tickets:
 - 67910 (created)
