### PR TITLE
TMP: export_model renamed to old-good export

### DIFF
--- a/inference-engine/src/inference_engine/include/openvino/runtime/executable_network.hpp
+++ b/inference-engine/src/inference_engine/include/openvino/runtime/executable_network.hpp
@@ -129,7 +129,7 @@ public:
      *
      * @param networkModel Network model output stream
      */
-    void export_model(std::ostream& networkModel);
+    void export(std::ostream& networkModel);
 
     /**
      * @brief Sets configuration for current executable network

--- a/inference-engine/src/inference_engine/src/cpp/ie_executable_network.cpp
+++ b/inference-engine/src/inference_engine/src/cpp/ie_executable_network.cpp
@@ -204,7 +204,7 @@ InferRequest ExecutableNetwork::create_infer_request() {
     OV_EXEC_NET_CALL_STATEMENT(return {_so, _impl->CreateInferRequest()});
 }
 
-void ExecutableNetwork::export_model(std::ostream& networkModel) {
+void ExecutableNetwork::export(std::ostream& networkModel) {
     OV_EXEC_NET_CALL_STATEMENT(_impl->Export(networkModel));
 }
 

--- a/inference-engine/tests/functional/inference_engine/ov_executable_network_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/ov_executable_network_test.cpp
@@ -11,7 +11,7 @@ using namespace std;
 
 TEST(ExecutableNetworkOVTests, throwsOnUninitializedExportStream) {
     ov::runtime::ExecutableNetwork exec;
-    ASSERT_THROW(exec.export_model(std::cout), ov::Exception);
+    ASSERT_THROW(exec.export(std::cout), ov::Exception);
 }
 
 TEST(ExecutableNetworkOVTests, throwsOnUninitializedGetFunction) {

--- a/inference-engine/tests/functional/plugin/shared/include/behavior/ov_core_integration.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/behavior/ov_core_integration.hpp
@@ -480,7 +480,7 @@ TEST_P(OVClassImportExportTestP, smoke_ImportNetworkNoThrowWithDeviceName) {
     std::stringstream strm;
     ov::runtime::ExecutableNetwork executableNetwork;
     ASSERT_NO_THROW(executableNetwork = ie.compile_model(actualNetwork, deviceName));
-    ASSERT_NO_THROW(executableNetwork.export_model(strm));
+    ASSERT_NO_THROW(executableNetwork.export(strm));
     ASSERT_NO_THROW(executableNetwork = ie.import_model(strm, deviceName));
     ASSERT_NO_THROW(executableNetwork.create_infer_request());
 }

--- a/inference-engine/tests/functional/plugin/shared/include/behavior/ov_exec_network.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/behavior/ov_exec_network.hpp
@@ -223,7 +223,7 @@ TEST_P(OVExecNetwork, importExportedFunction) {
     execNet = ie->compile_model(function, targetDevice, configuration);
 
     std::stringstream strm;
-    execNet.export_model(strm);
+    execNet.export(strm);
 
     ov::runtime::ExecutableNetwork importedExecNet = ie->import_model(strm, targetDevice, configuration);
     ASSERT_EQ(function->inputs().size(), 2);
@@ -337,7 +337,7 @@ TEST_P(OVExecNetwork, readFromV10IR) {
     }
 
     std::stringstream strm;
-    execNet.export_model(strm);
+    execNet.export(strm);
 
     ov::runtime::ExecutableNetwork importedExecNet = ie->import_model(strm, targetDevice, configuration);
     EXPECT_EQ(importedExecNet.inputs().size(), 1);
@@ -452,7 +452,7 @@ TEST_P(OVExecNetwork, ieImportExportedFunction) {
     execNet = ie->compile_model(function, targetDevice, configuration);
 
     std::stringstream strm;
-    execNet.export_model(strm);
+    execNet.export(strm);
 
     InferenceEngine::ExecutableNetwork importedExecNet = core->ImportNetwork(strm, targetDevice, configuration);
     ASSERT_EQ(function->inputs().size(), 2);


### PR DESCRIPTION
@vinograd47 @ilyachur @apankratovantonp how do you think? I think people can be confused that `export_model` can result in exporting of original model, while generic `export` does not guarantee it

Currently we have:
- `import_model` from compiled blob
- `compile_model` from source representation
- `export_model` to compiled blob. Do we need to keep as is? or name to old-good `export`?