### PR TITLE
[GPU] Merge minor updates

### DIFF
--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/eltwise/eltwise_kernel_base.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/eltwise/eltwise_kernel_base.cpp
@@ -41,7 +41,7 @@ static uint32_t GetNumberOfInputs(EltwiseMode m) {
 
 std::vector<size_t> GetLimitedOptimalLocalWorkGroupSizes(std::vector<size_t> gws, const EngineInfo& info, std::vector<size_t> limited_size_lws) {
     const size_t lws_max = info.maxWorkGroupSize;
-    const size_t optimal_lws_values[] = {256, 227, 224, 192, 160, 128, 96, 64, 32, 16, 8, 7, 6, 5, 4, 2, 1};
+    const size_t optimal_lws_values[] = {256, 227, 224, 192, 160, 128, 96, 64, 32, 16, 8, 7, 6, 5, 4, 3, 2, 1};
     size_t total_lws = 1;
     std::vector<size_t> lws;
     for (size_t i = 0; i < gws.size(); ++i) {

--- a/inference-engine/thirdparty/clDNN/src/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/inference-engine/thirdparty/clDNN/src/graph_optimizer/prepare_primitive_fusing.cpp
@@ -587,6 +587,10 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
             if (!input_data_supports_fusings(input_data, activation_node.id()))
                 return;
 
+            if ((input_data.get_users().size() != 1 || activation_node.get_dependencies().size() != 1) &&
+                _lo.get_optimization_attributes().use_onednn_impls == 1)
+                return;
+
             bool should_fuse = input_data.is_type<binary_convolution>();
 
             should_fuse |= input_data.is_type<convolution>() && conv_supports_fusings(input_data.as<convolution>());

--- a/inference-engine/thirdparty/clDNN/src/graph_optimizer/remove_redundant_reorders.cpp
+++ b/inference-engine/thirdparty/clDNN/src/graph_optimizer/remove_redundant_reorders.cpp
@@ -350,7 +350,7 @@ void remove_redundant_reorders::run(program& p) {
             usr->get_output_layout().data_type != dep.get_output_layout().data_type ||
             dep.get_output_layout().format != format::bfyx)
             return;
-        if (usr->as<convolution>().get_preferred_impl_type() == impl_types::ocl &&
+        if (usr->as<convolution>().get_preferred_impl_type() != impl_types::onednn &&
             usr->get_output_layout().format != format::fs_b_yx_fsv32)
             return;
         if (usr->as<convolution>().get_preferred_impl_type() == impl_types::onednn &&

--- a/inference-engine/thirdparty/clDNN/src/layout_optimizer.cpp
+++ b/inference-engine/thirdparty/clDNN/src/layout_optimizer.cpp
@@ -221,8 +221,9 @@ bool layout_optimizer::can_fuse_reorder(program_node& prev, program_node& next, 
         prev.is_input() && (prev_dt == data_types::u8 || prev_dt == data_types::i8))
         return true;
 
+    // Additional check: fmt_prev == fmt_next is added only when onednn is enabled.
     if (next.is_type<convolution>() &&
-        fmt_prev == format::bfyx &&
+        fmt_prev == format::bfyx && (!get_optimization_attributes().use_onednn_impls || fmt_prev == fmt_next) &&
         ((fmt_next == format::fs_b_yx_fsv32 && next.as<convolution>().get_primitive()->groups == 1) ||
         (fmt_next == format::b_fs_yx_fsv32 && (prev_output_layout.size.feature[0] == 3 || prev_output_layout.size.feature[0] == 4)) ||
         (fmt_next == format::bs_fs_yx_bsv16_fsv16 && next_output_layout.size.feature[0] % 16 == 0 && prev_output_layout.size.feature[0] == 3) ||


### PR DESCRIPTION
+ Prevent to fuse PRelu if convolution is onednn impl.
+ Prevent to remove input reorder if onednn conv converts format from bfyx to b_fs_yx_fsv32.
+ Add a value to optimal lws values for eltwise kernel selector.
+ Fix a condition of remove redundant reorder. (try_fuse_reorder_bfyx_to_fsv32)