### PR TITLE
[Python API] remove requirements installation to common python

### DIFF
--- a/inference-engine/ie_bridges/python/CMakeLists.txt
+++ b/inference-engine/ie_bridges/python/CMakeLists.txt
@@ -88,10 +88,6 @@ install(FILES requirements.txt
         DESTINATION ${PYTHON_BRIDGE_CPACK_PATH}/${PYTHON_VERSION}
         COMPONENT ${PYTHON_COMPONENT})
 
-install(FILES requirements.txt
-        DESTINATION ${PYTHON_BRIDGE_CPACK_PATH}
-        COMPONENT ${PYTHON_COMPONENT})
-
 install(PROGRAMS src/openvino/__init__.py
         DESTINATION ${PYTHON_BRIDGE_CPACK_PATH}/${PYTHON_VERSION}/openvino
         COMPONENT ${PYTHON_COMPONENT})


### PR DESCRIPTION
It's overwrote by each python. It also installs in each python dir (python3.6, python3.8...)
