### PR TITLE
Removed IR version after reading

### DIFF
--- a/inference-engine/src/inference_engine/src/ie_network_reader.cpp
+++ b/inference-engine/src/inference_engine/src/ie_network_reader.cpp
@@ -319,9 +319,6 @@ CNNNetwork convert_to_cnnnetwork(std::shared_ptr<ngraph::Function>& function,
             }
 
             function = prepost.build(function);
-
-            // Set version to 10
-            rt_info["version"] = std::make_shared<ov::VariantWrapper<int64_t>>(10);
         } else if (ir_version == 11 && !newAPI) {
             const std::string& old_api_map_key = ov::OldApiMap::get_type_info_static();
 
@@ -363,9 +360,6 @@ CNNNetwork convert_to_cnnnetwork(std::shared_ptr<ngraph::Function>& function,
                             InputTensorInfo().set_element_type(old_api_type).set_layout(ov::Layout(tensorLayout.str())))
                         .preprocess(std::move(steps))
                         .network(InputNetworkInfo().set_layout(ov::Layout(networkLayout.str()))));
-
-                // Set version to 10
-                rt_info["version"] = std::make_shared<ov::VariantWrapper<int64_t>>(10);
             }
 
             auto& resuls = function->get_results();
@@ -417,6 +411,9 @@ CNNNetwork convert_to_cnnnetwork(std::shared_ptr<ngraph::Function>& function,
                 result->set_layout({});
             }
         }
+
+        // remove IR version
+        rt_info.erase(it);
     }
 
     OPENVINO_SUPPRESS_DEPRECATED_START

--- a/inference-engine/tests/functional/inference_engine/ir_serialization/rt_info_deserialization.cpp
+++ b/inference-engine/tests/functional/inference_engine/ir_serialization/rt_info_deserialization.cpp
@@ -181,7 +181,7 @@ TEST_F(RTInfoDeserialization, NodeV10) {
         auto f_10_core = core.read_model(model, ov::runtime::Tensor());
         ASSERT_NE(nullptr, f_10_core);
 
-        check_version(f_10_core, 10);
+        // check_version(f_10_core, 10);
 
         const auto fc = FunctionsComparator::with_default()
                             .enable(FunctionsComparator::ATTRIBUTES)
@@ -332,7 +332,7 @@ TEST_F(RTInfoDeserialization, InputAndOutputV10) {
         ov::runtime::Core core;
         auto f_10_core = core.read_model(model, ov::runtime::Tensor());
         ASSERT_NE(nullptr, f_10_core);
-        check_version(f_10_core, 10);
+        // check_version(f_10_core, 10);
 
         const auto fc = FunctionsComparator::with_default()
                             .enable(FunctionsComparator::ATTRIBUTES)
@@ -461,7 +461,7 @@ TEST_F(RTInfoDeserialization, NodeV11) {
         auto res = compare_functions(f, f_11);
         EXPECT_TRUE(res.first) << res.second;
 
-        check_version(f_11, 11);
+        // check_version(f_11, 11);
     }
 
     // read IR v11 with old API and check that old_api_map is applied
@@ -506,7 +506,7 @@ TEST_F(RTInfoDeserialization, NodeV11) {
         auto f_10_core = cnn_core.getFunction();
         ASSERT_NE(nullptr, f_10_core);
 
-        check_version(f_10_core, 10);
+        // check_version(f_10_core, 10);
 
         EXPECT_EQ(InferenceEngine::Precision::FP32, cnn_core.getInputsInfo()["in1"]->getPrecision());
         EXPECT_EQ(InferenceEngine::Precision::FP32, cnn_core.getOutputsInfo()["Round"]->getPrecision());
@@ -685,7 +685,7 @@ TEST_F(RTInfoDeserialization, InputAndOutputV11) {
         auto res = compare_functions(f, f_10);
         EXPECT_TRUE(res.first) << res.second;
 
-        check_version(f_10, 10);
+        // check_version(f_10, 10);
     }
 }
 


### PR DESCRIPTION
### Details:
 - Just to check if we remove `version` from `ov::Function::rt_info` - will it break something?
 - Side effect (currently seen as not desired behavior): It will allow to serialize old IR v10 from new API as IR v11 (but it will have operation names added as tensor names as well, precisions conversion from CNNNetwork are also applied as a part of the graph)