### PR TITLE
[GPU] dryrun bugfix

### DIFF
--- a/inference-engine/thirdparty/clDNN/src/program.cpp
+++ b/inference-engine/thirdparty/clDNN/src/program.cpp
@@ -428,7 +428,7 @@ void program::build_program(bool is_internal) {
 
     GPU_DEBUG_GET_INSTANCE(debug_config);
 #ifdef GPU_DEBUG_CONFIG
-    if (debug_config->dry_run_path.empty()) {
+    if (debug_config->dry_run_path.empty() || is_internal) {
 #else
     {
 #endif


### PR DESCRIPTION
dryrun failed in case nested graph is created.
(due to constant propagation)
For nested program, do not skip compile() to make outer program compiles OK.