### PR TITLE
[frontend][paddle] It is possible that get_output_partial_shape retur…

### DIFF
--- a/ngraph/frontend/paddlepaddle/src/op/slice.cpp
+++ b/ngraph/frontend/paddlepaddle/src/op/slice.cpp
@@ -77,13 +77,6 @@ NamedOutputs slice(const NodeContext& node) {
     auto decrease_axis = node.get_attribute<std::vector<int32_t>>("decrease_axis");
 
     if (decrease_axis.size() > 0) {
-        auto stride_slice_output_shape = stride_slice_node->get_output_partial_shape(0);
-
-        for (size_t i = 0; i < decrease_axis.size(); ++i)
-            PDPD_OP_VALIDATION_CHECK(node,
-                                     stride_slice_output_shape[decrease_axis[i]] == 1,
-                                     "decrease dim should be 1!");
-
         auto squeeze_index_node = Constant::create(element::i32, {}, decrease_axis);
         auto decreased_node = std::make_shared<Squeeze>(stride_slice_node, squeeze_index_node);
 


### PR DESCRIPTION
…ns dynamic shape. Then we cannot simply check if it is 1. In case of BERT which input shape is dynamic, this check will absolutely fail.

### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*
