### PR TITLE
[GPU] Select impl_type after layout propagation

### DIFF
--- a/inference-engine/thirdparty/clDNN/src/graph_optimizer/reorder_inputs.cpp
+++ b/inference-engine/thirdparty/clDNN/src/graph_optimizer/reorder_inputs.cpp
@@ -516,4 +516,11 @@ void reorder_inputs::run(program& p, layout_optimizer& lo, reorder_factory& rf) 
             reorder_input_binary_convolution,
             reorder_input_deconvolution);
     }
+
+    for (auto n : p.get_processing_order()) {
+        if (n->is_in_data_flow() && fmt_map.count(n) != 0) {
+            auto preferred_impl = lo.get_preferred_impl_type(*n, fmt_map.at(n));
+            n->set_preferred_impl_type(preferred_impl);
+        }
+    }
 }


### PR DESCRIPTION
pooling layout is not chosen initially in reorder_inputs.
In that case, cldnn pooling is chosen instead of onednn.

### Tickets:
 - 65740
