### PR TITLE
[CPU] [TESTS] cpu tests improvements

### DIFF
--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
@@ -151,6 +151,10 @@ std::vector<std::string> disabledTestPatterns() {
         // bad accuracy
         R"(.*smoke_FakeQuantizeLayerCPUTest_Decompos.
             *IS=_TS=\(\(4\.5\.6\.7\)\)_RS=\(\(1\.1\.6\.1\)\)_\(\(1\.5\.6\.1\)\)_\(\(1\.1\.1\.1\)\)_\(\(1\.1\.6\.1\)\).*)",
+        // todo: [AV] issue
+        R"(.*GroupConvolutionLayerCPUTest.*PB\(1.*zp.*)",
+        // todo: [AV] issue
+        R"(.*MatMulLayerCPUTest.*outPRC=(U8|I8).*Fused=(fusingBiasFC|Relu|Multiply).*)",
     };
 
 #define FIX_62820 0

--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
@@ -152,6 +152,10 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*smoke_FakeQuantizeLayerCPUTest_Decompos.
             *IS=_TS=\(\(4\.5\.6\.7\)\)_RS=\(\(1\.1\.6\.1\)\)_\(\(1\.5\.6\.1\)\)_\(\(1\.1\.1\.1\)\)_\(\(1\.1\.6\.1\)\).*)",
         // todo: [AV] issue
+        R"(.*ConvolutionLayerCPUTest.*K\(1.*S\(2.*zp.*)",
+        // todo: [AV] issue 70622
+        R"(.*ConvolutionLayerCPUTest.*PB\(1\.1\.1.*jit_gemm.*zp.*)",
+        // todo: [AV] issue
         R"(.*GroupConvolutionLayerCPUTest.*PB\(1.*zp.*)",
         // todo: [AV] issue
         R"(.*MatMulLayerCPUTest.*outPRC=(U8|I8).*Fused=(fusingBiasFC|Relu|Multiply).*)",

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution.cpp
@@ -184,6 +184,13 @@ TEST_P(ConvolutionLayerCPUTest, CompareWithRefs) {
     }
 
     Run();
+//    auto memory = InferenceEngine::as<InferenceEngine::MemoryBlob>(inputs[0]);
+//    const auto lockedMemory = memory->wmap();
+//    const auto buffer = lockedMemory.as<const std::uint8_t *>();
+//    std::cout << "SRC" << std::endl;
+//    for (int i = 0; i < memory->size(); i++) {
+//        std::cout << i << ". " << (int32_t)buffer[i] << std::endl;
+//    }
 
     if (isBias) {
         checkBiasFusing(executableNetwork);

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution.cpp
@@ -21,6 +21,7 @@ typedef std::tuple<
         convLayerTestParamsSet,
         CPUSpecificParams,
         fusingSpecificParams,
+        bool,
         std::map<std::string, std::string> > convLayerCPUTestParamsSet;
 
 class ConvolutionLayerCPUTest : public testing::WithParamInterface<convLayerCPUTestParamsSet>,
@@ -30,8 +31,9 @@ public:
         convLayerTestParamsSet basicParamsSet;
         CPUSpecificParams cpuParams;
         fusingSpecificParams fusingParams;
+        bool withZeroPoints;
         std::map<std::string, std::string> additionalConfig;
-        std::tie(basicParamsSet, cpuParams, fusingParams, additionalConfig) = obj.param;
+        std::tie(basicParamsSet, cpuParams, fusingParams, withZeroPoints, additionalConfig) = obj.param;
 
         std::ostringstream result;
         result << LayerTestsDefinitions::ConvolutionLayerTest::getTestCaseName(testing::TestParamInfo<convLayerTestParamsSet>(
@@ -39,6 +41,8 @@ public:
 
         result << CPUTestsBase::getTestCaseName(cpuParams);
         result << CpuTestWithFusing::getTestCaseName(fusingParams);
+        if (withZeroPoints)
+            result << "_zp";
 
         if (!additionalConfig.empty()) {
             result << "_PluginConf";
@@ -51,6 +55,19 @@ public:
     }
 protected:
     bool isBias = false;
+
+    std::shared_ptr<ngraph::Node> insertZeroPoints(const ngraph::Output<ngraph::Node> &in) {
+        auto inShape = in.get_shape();
+        std::vector<uint8_t> zpData(inShape[1]);
+        for (int i = 0; i < zpData.size(); i++) {
+            zpData[i] = 128;
+        }
+        std::vector<size_t> zpShape(inShape.size(), 1);
+        zpShape[1] = inShape[1];
+        auto zpConstNode = ngraph::builder::makeConstant(in.get_element_type(), zpShape, zpData);
+        auto subtractNode = ngraph::builder::makeEltwise(in, zpConstNode, ngraph::helpers::EltwiseTypes::SUBTRACT);
+        return subtractNode;
+    }
 
     void checkBiasFusing(InferenceEngine::ExecutableNetwork &execNet) const {
         auto execGraph = execNet.GetExecGraphInfo().getFunction();
@@ -77,12 +94,23 @@ protected:
         ASSERT_TRUE(foundConv) << "Can't find Convolution node";
     }
 
+    int calculateQuantizeInHigh(const InferenceEngine::SizeVector& kernel, const int ic, const int maxIn0 = 10, const int maxIn1 = 10) const {
+        auto quantizeInHigh = maxIn0 * maxIn1;
+        quantizeInHigh *= ic;
+        for (int i = 0; i < kernel.size(); i++) {
+            quantizeInHigh *= kernel[i];
+        }
+        return quantizeInHigh;
+    }
+
     void SetUp() override {
+        using namespace ngraph;
         convLayerTestParamsSet basicParamsSet;
         CPUSpecificParams cpuParams;
         fusingSpecificParams fusingParams;
+        bool withZeroPoints;
         std::map<std::string, std::string> additionalConfig;
-        std::tie(basicParamsSet, cpuParams, fusingParams, additionalConfig) = this->GetParam();
+        std::tie(basicParamsSet, cpuParams, fusingParams, withZeroPoints, additionalConfig) = this->GetParam();
 
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
@@ -97,28 +125,48 @@ protected:
         auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
         std::tie(convParams, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, targetDevice) = basicParamsSet;
 
-        if (inPrc == Precision::UNSPECIFIED) {
-            selectedType += std::string("_") + Precision(Precision::FP32).name();
-        } else if (inPrc == Precision::BF16) {
-            selectedType += std::string("_") + inPrc.name();
+        if (inPrc == Precision::UNSPECIFIED)
+            inPrc = Precision::FP32;
+
+        if (inPrc == Precision::U8) {
+            selectedType += std::string("_") + Precision(Precision::I8).name();
         } else {
-            selectedType += std::string("_") + Precision(netPrecision).name();
+            selectedType += std::string("_") + inPrc.name();
         }
 
-        ngraph::op::PadType padType;
+        op::PadType padType;
         InferenceEngine::SizeVector kernel, stride, dilation;
         std::vector<ptrdiff_t> padBegin, padEnd;
         size_t convOutChannels;
         std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType) = convParams;
-        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+        auto ngPrc = (inPrc == Precision::BF16)
+                ? FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(Precision::FP32)
+                : FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrc);
 
-        auto inputParams = ngraph::builder::makeParams(ngraph::element::f32, { inputShape });
-        auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(inputParams));
+        auto inputParams = builder::makeParams(ngPrc, { inputShape });
+        auto paramOuts = helpers::convert2OutputVector(helpers::castOps2Nodes<op::Parameter>(inputParams));
 
-        auto convolutionNode = ngraph::builder::makeConvolution(paramOuts.front(), ngPrc, kernel, stride, padBegin,
-                                                                padEnd, dilation, padType, convOutChannels);
+        auto convInputNode = paramOuts.front();
+        if (withZeroPoints)
+            convInputNode = insertZeroPoints(convInputNode);
 
-        function = makeNgraphFunction(ngPrc, inputParams, convolutionNode, "Convolution");
+        auto weiPrc = (ngPrc == element::u8) ? element::i8 : ngPrc;
+        auto convolutionNode = builder::makeConvolutionRelaxed(convInputNode, weiPrc, kernel, stride, padBegin,
+            padEnd, dilation, padType, convOutChannels);
+
+        if (outPrc == Precision::U8 || outPrc == Precision::I8) {
+            threshold = 1.001f;
+            abs_threshold = 1.001f;
+            quantizeInHigh = calculateQuantizeInHigh(kernel, inputShape[1]);
+            outElemType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(outPrc);
+        }
+
+        if (inPrc == Precision::U8 || inPrc == Precision::I8) {
+            additionalPasses.push_back(std::make_shared<pass::ConvertPrecision<element::i8, element::f32>>());
+            additionalPasses.push_back(std::make_shared<pass::ConvertPrecision<element::u8, element::f32>>());
+        }
+
+        function = makeNgraphFunction(element::f32, inputParams, convolutionNode, "Convolution");
     }
 };
 
@@ -151,6 +199,7 @@ const std::vector<fusingSpecificParams> fusingParamsSet{
         // eltwise
         fusingRelu,
         fusingPRelu1D,
+        fusingPReluPerChannel,
         // depthwise
         fusingReluScaleShift,
         // fake quantize
@@ -169,6 +218,7 @@ const std::vector<fusingSpecificParams> fusingParamsSetBF16{
         fusingRelu,
         // depthwise
         fusingReluScaleShift,
+        fusingPReluPerChannel,
         // sum
         fusingSum,
         // bias
@@ -179,7 +229,7 @@ const std::map<std::string, std::string> cpuEmptyPluginConfig;
 const std::map<std::string, std::string> cpuBF16PluginConfig = { { PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES } };
 
 /* ============= Convolution params (GEMM layout) ============= */
-const SizeVector numOutChannels_Gemm = {6 };
+const SizeVector numOutChannels_Gemm = { 6, 33 };
 
 /* ============= Convolution params (blocked and nspc layout) ============= */
 const SizeVector numOutChannels = { 64, 63 };
@@ -221,20 +271,21 @@ const std::vector<CPUSpecificParams> CPUParams_GEMM_2D = {
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_Conv_2D_GEMM_FP32, ConvolutionLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::Combine(
-                                         convParams_ExplicitPadding_GEMM_2D,
-                                         ::testing::Values(Precision::FP32),
-                                         ::testing::Values(Precision::UNSPECIFIED),
-                                         ::testing::Values(Precision::UNSPECIFIED),
-                                         ::testing::Values(Layout::ANY),
-                                         ::testing::Values(Layout::ANY),
-                                         ::testing::Values(std::vector<size_t >({ 2, 12, 7, 7 })),
-                                         ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                 ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_GEMM_2D)),
-                                 ::testing::ValuesIn(fusingParamsSet),
-                                 ::testing::Values(cpuEmptyPluginConfig)),
-                         ConvolutionLayerCPUTest::getTestCaseName);
+    ::testing::Combine(
+        ::testing::Combine(
+            convParams_ExplicitPadding_GEMM_2D,
+            ::testing::Values(Precision::FP32),
+            ::testing::Values(Precision::UNSPECIFIED),
+            ::testing::Values(Precision::UNSPECIFIED),
+            ::testing::Values(Layout::ANY),
+            ::testing::Values(Layout::ANY),
+            ::testing::Values(std::vector<size_t >({ 2, 12, 7, 7 })),
+            ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+        ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_GEMM_2D)),
+        ::testing::ValuesIn(fusingParamsSet),
+        ::testing::Values(false),
+        ::testing::Values(cpuEmptyPluginConfig)),
+    ConvolutionLayerCPUTest::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(smoke_Conv_2D_GEMM_BF16, ConvolutionLayerCPUTest,
                          ::testing::Combine(
@@ -249,24 +300,10 @@ INSTANTIATE_TEST_SUITE_P(smoke_Conv_2D_GEMM_BF16, ConvolutionLayerCPUTest,
                                          ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                                  ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_GEMM_2D)),
                                  ::testing::ValuesIn(fusingParamsSetBF16),
+                                 ::testing::Values(false),
                                  ::testing::Values(cpuBF16PluginConfig)),
                          ConvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Conv_2D_GEMM_I8, ConvolutionLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::Combine(
-                                         convParams_ExplicitPadding_GEMM_2D,
-                                         ::testing::Values(Precision::FP32),
-                                         ::testing::Values(Precision::I8),
-                                         ::testing::Values(Precision::UNSPECIFIED),
-                                         ::testing::Values(Layout::ANY),
-                                         ::testing::Values(Layout::ANY),
-                                         ::testing::Values(std::vector<size_t >({ 2, 12, 7, 7 })),
-                                         ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                 ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_GEMM_2D)),
-                                 ::testing::Values(fusingSum),
-                                 ::testing::Values(cpuEmptyPluginConfig)),
-                         ConvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= Convolution (GEMM 3D) ============= */
 const auto convParams_ExplicitPadding_GEMM_3D = ::testing::Combine(
@@ -297,6 +334,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Conv_3D_GEMM_FP32, ConvolutionLayerCPUTest,
                                          ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                                  ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_GEMM_3D)),
                                  ::testing::ValuesIn(fusingParamsSet),
+                                 ::testing::Values(false),
                                  ::testing::Values(cpuEmptyPluginConfig)),
                          ConvolutionLayerCPUTest::getTestCaseName);
 
@@ -313,23 +351,8 @@ INSTANTIATE_TEST_SUITE_P(smoke_Conv_3D_GEMM_BF16, ConvolutionLayerCPUTest,
                                          ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                                  ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_GEMM_3D)),
                                  ::testing::ValuesIn(fusingParamsSetBF16),
+                                 ::testing::Values(false),
                                  ::testing::Values(cpuBF16PluginConfig)),
-                         ConvolutionLayerCPUTest::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_Conv_3D_GEMM_I8, ConvolutionLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::Combine(
-                                         convParams_ExplicitPadding_GEMM_3D,
-                                         ::testing::Values(Precision::FP32),
-                                         ::testing::Values(Precision::I8),
-                                         ::testing::Values(Precision::UNSPECIFIED),
-                                         ::testing::Values(Layout::ANY),
-                                         ::testing::Values(Layout::ANY),
-                                         ::testing::Values(std::vector<size_t >({ 2, 12, 7, 7, 7 })),
-                                         ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                 ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_GEMM_3D)),
-                                 ::testing::Values(fusingSum),
-                                 ::testing::Values(cpuEmptyPluginConfig)),
                          ConvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= Convolution (2D) ============= */
@@ -345,9 +368,9 @@ const auto convParams_ExplicitPadding_2D = ::testing::Combine(
 
 const std::vector<CPUSpecificParams> CPUParams_2D = {
         conv_sse42_2D,
+        conv_sse42_2D_nspc,
         conv_avx2_2D,
         conv_avx512_2D,
-        conv_sse42_2D_nspc,
         conv_avx2_2D_nspc,
         conv_avx512_2D_nspc
 };
@@ -365,6 +388,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Conv_2D_FP32, ConvolutionLayerCPUTest,
                                          ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                                  ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_2D)),
                                  ::testing::ValuesIn(fusingParamsSet),
+                                 ::testing::Values(false),
                                  ::testing::Values(cpuEmptyPluginConfig)),
                          ConvolutionLayerCPUTest::getTestCaseName);
 
@@ -381,24 +405,10 @@ INSTANTIATE_TEST_SUITE_P(smoke_Conv_2D_BF16, ConvolutionLayerCPUTest,
                                          ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                                  ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D, conv_avx512_2D_nspc})),
                                  ::testing::ValuesIn(fusingParamsSetBF16),
+                                 ::testing::Values(false),
                                  ::testing::Values(cpuBF16PluginConfig)),
                          ConvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Conv_2D_I8, ConvolutionLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::Combine(
-                                         convParams_ExplicitPadding_2D,
-                                         ::testing::Values(Precision::FP32),
-                                         ::testing::Values(Precision::I8),
-                                         ::testing::Values(Precision::UNSPECIFIED),
-                                         ::testing::Values(Layout::ANY),
-                                         ::testing::Values(Layout::ANY),
-                                         ::testing::ValuesIn(inputShapes2d),
-                                         ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                 ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_2D)),
-                                 ::testing::Values(fusingSum),
-                                 ::testing::Values(cpuEmptyPluginConfig)),
-                         ConvolutionLayerCPUTest::getTestCaseName);
 
 const std::vector<CPUSpecificParams> CPUParams_2D_plain_to_blocked = {
         conv_sse42_plain_to_blocked_2D,
@@ -419,6 +429,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Conv_PlainToBlocked_2D_FP32, ConvolutionLayerCPUT
                                          ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                                  ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_2D_plain_to_blocked)),
                                  ::testing::Values(emptyFusingSpec),
+                                 ::testing::Values(false),
                                  ::testing::Values(cpuEmptyPluginConfig)),
                          ConvolutionLayerCPUTest::getTestCaseName);
 
@@ -435,6 +446,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Conv_PlainToBlocked_2D_BF16, ConvolutionLayerCPUT
                                          ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                                  ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_plain_to_blocked_2D})),
                                  ::testing::Values(emptyFusingSpec),
+                                 ::testing::Values(false),
                                  ::testing::Values(cpuEmptyPluginConfig)),
                          ConvolutionLayerCPUTest::getTestCaseName);
 
@@ -458,52 +470,38 @@ const std::vector<CPUSpecificParams> CPUParams_3D = {
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_Conv_3D_FP32, ConvolutionLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::Combine(
-                                         convParams_ExplicitPadding_3D,
-                                         ::testing::Values(Precision::FP32),
-                                         ::testing::Values(Precision::UNSPECIFIED),
-                                         ::testing::Values(Precision::UNSPECIFIED),
-                                         ::testing::Values(Layout::ANY),
-                                         ::testing::Values(Layout::ANY),
-                                         ::testing::ValuesIn(inputShapes3d),
-                                         ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                 ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_3D)),
-                                 ::testing::ValuesIn(fusingParamsSet),
-                                 ::testing::Values(cpuEmptyPluginConfig)),
-                         ConvolutionLayerCPUTest::getTestCaseName);
+    ::testing::Combine(
+        ::testing::Combine(
+            convParams_ExplicitPadding_3D,
+            ::testing::Values(Precision::FP32),
+            ::testing::Values(Precision::UNSPECIFIED),
+            ::testing::Values(Precision::UNSPECIFIED),
+            ::testing::Values(Layout::ANY),
+            ::testing::Values(Layout::ANY),
+            ::testing::ValuesIn(inputShapes3d),
+            ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+        ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_3D)),
+        ::testing::ValuesIn(fusingParamsSet),
+        ::testing::Values(false),
+        ::testing::Values(cpuEmptyPluginConfig)),
+    ConvolutionLayerCPUTest::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(smoke_Conv_3D_BF16, ConvolutionLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::Combine(
-                                         convParams_ExplicitPadding_3D,
-                                         ::testing::Values(Precision::FP32),
-                                         ::testing::Values(Precision::BF16),
-                                         ::testing::Values(Precision::BF16),
-                                         ::testing::Values(Layout::ANY),
-                                         ::testing::Values(Layout::ANY),
-                                         ::testing::ValuesIn(inputShapes3d),
-                                         ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                 ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_3D, conv_avx512_3D_nspc})),
-                                 ::testing::ValuesIn(fusingParamsSetBF16),
-                                 ::testing::Values(cpuBF16PluginConfig)),
-                         ConvolutionLayerCPUTest::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_Conv_3D_I8, ConvolutionLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::Combine(
-                                         convParams_ExplicitPadding_3D,
-                                         ::testing::Values(Precision::FP32),
-                                         ::testing::Values(Precision::I8),
-                                         ::testing::Values(Precision::UNSPECIFIED),
-                                         ::testing::Values(Layout::ANY),
-                                         ::testing::Values(Layout::ANY),
-                                         ::testing::ValuesIn(inputShapes3d),
-                                         ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                 ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_3D)),
-                                 ::testing::Values(fusingSum),
-                                 ::testing::Values(cpuEmptyPluginConfig)),
-                         ConvolutionLayerCPUTest::getTestCaseName);
+    ::testing::Combine(
+        ::testing::Combine(
+            convParams_ExplicitPadding_3D,
+            ::testing::Values(Precision::FP32),
+            ::testing::Values(Precision::BF16),
+            ::testing::Values(Precision::BF16),
+            ::testing::Values(Layout::ANY),
+            ::testing::Values(Layout::ANY),
+            ::testing::ValuesIn(inputShapes3d),
+            ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_3D, conv_avx512_3D_nspc})),
+        ::testing::ValuesIn(fusingParamsSetBF16),
+        ::testing::Values(false),
+        ::testing::Values(cpuBF16PluginConfig)),
+    ConvolutionLayerCPUTest::getTestCaseName);
 
 const std::vector<CPUSpecificParams> CPUParams_3D_plain_to_blocked = {
         conv_avx2_plain_to_blocked_3D,
@@ -511,36 +509,38 @@ const std::vector<CPUSpecificParams> CPUParams_3D_plain_to_blocked = {
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_Conv_PlainToBlocked_3D_FP32, ConvolutionLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::Combine(
-                                         convParams_ExplicitPadding_3D,
-                                         ::testing::Values(Precision::FP32),
-                                         ::testing::Values(Precision::UNSPECIFIED),
-                                         ::testing::Values(Precision::UNSPECIFIED),
-                                         ::testing::Values(Layout::ANY),
-                                         ::testing::Values(Layout::ANY),
-                                         ::testing::ValuesIn(inputShapesPlain2Blocked3d),
-                                         ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                 ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_3D_plain_to_blocked)),
-                                 ::testing::Values(emptyFusingSpec),
-                                 ::testing::Values(cpuEmptyPluginConfig)),
-                         ConvolutionLayerCPUTest::getTestCaseName);
+    ::testing::Combine(
+        ::testing::Combine(
+            convParams_ExplicitPadding_3D,
+            ::testing::Values(Precision::FP32),
+            ::testing::Values(Precision::UNSPECIFIED),
+            ::testing::Values(Precision::UNSPECIFIED),
+            ::testing::Values(Layout::ANY),
+            ::testing::Values(Layout::ANY),
+            ::testing::ValuesIn(inputShapesPlain2Blocked3d),
+            ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+        ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_3D_plain_to_blocked)),
+        ::testing::Values(emptyFusingSpec),
+        ::testing::Values(false),
+        ::testing::Values(cpuEmptyPluginConfig)),
+    ConvolutionLayerCPUTest::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(smoke_Conv_PlainToBlocked_3D_BF16, ConvolutionLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::Combine(
-                                         convParams_ExplicitPadding_3D,
-                                         ::testing::Values(Precision::FP32),
-                                         ::testing::Values(Precision::BF16),
-                                         ::testing::Values(Precision::BF16, Precision::FP32),
-                                         ::testing::Values(Layout::ANY),
-                                         ::testing::Values(Layout::ANY),
-                                         ::testing::ValuesIn(inputShapesPlain2Blocked3d),
-                                         ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                 ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_plain_to_blocked_3D})),
-                                 ::testing::Values(emptyFusingSpec),
-                                 ::testing::Values(cpuEmptyPluginConfig)),
-                         ConvolutionLayerCPUTest::getTestCaseName);
+    ::testing::Combine(
+        ::testing::Combine(
+            convParams_ExplicitPadding_3D,
+            ::testing::Values(Precision::FP32),
+            ::testing::Values(Precision::BF16),
+            ::testing::Values(Precision::BF16, Precision::FP32),
+            ::testing::Values(Layout::ANY),
+            ::testing::Values(Layout::ANY),
+            ::testing::ValuesIn(inputShapesPlain2Blocked3d),
+            ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_plain_to_blocked_3D})),
+        ::testing::Values(emptyFusingSpec),
+        ::testing::Values(false),
+        ::testing::Values(cpuEmptyPluginConfig)),
+    ConvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= Kernel_1x1 (2D) ============= */
 
@@ -576,6 +576,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Conv_2D_1x1_FP32, ConvolutionLayerCPUTest,
                                          ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                                  ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_1x1_2D)),
                                  ::testing::ValuesIn(fusingParamsSet),
+                                 ::testing::Values(false),
                                  ::testing::Values(cpuEmptyPluginConfig)),
                          ConvolutionLayerCPUTest::getTestCaseName);
 
@@ -592,23 +593,8 @@ INSTANTIATE_TEST_SUITE_P(smoke_Conv_2D_1x1_BF16, ConvolutionLayerCPUTest,
                                          ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                                  ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D_1x1, conv_avx512_2D_1x1_nspc})),
                                  ::testing::ValuesIn(fusingParamsSetBF16),
+                                 ::testing::Values(false),
                                  ::testing::Values(cpuBF16PluginConfig)),
-                         ConvolutionLayerCPUTest::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_Conv_2D_1x1_I8, ConvolutionLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::Combine(
-                                         convParams_ExplicitPadding_1x1_2D,
-                                         ::testing::Values(Precision::FP32),
-                                         ::testing::Values(Precision::I8),
-                                         ::testing::Values(Precision::UNSPECIFIED),
-                                         ::testing::Values(Layout::ANY),
-                                         ::testing::Values(Layout::ANY),
-                                         ::testing::ValuesIn(inputShapes2d),
-                                         ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                 ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_1x1_2D)),
-                                 ::testing::Values(fusingSum),
-                                 ::testing::Values(cpuEmptyPluginConfig)),
                          ConvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= Convolution (1D) ============= */
@@ -648,6 +634,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Conv_1D, ConvolutionLayerCPUTest,
                                          ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                                  ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_1D)),
                                  ::testing::Values(fusingAddPerChannel),
+                                 ::testing::Values(false),
                                  ::testing::Values(cpuEmptyPluginConfig)),
                          ConvolutionLayerCPUTest::getTestCaseName);
 
@@ -683,6 +670,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Conv_Jit_Planar_2D_FP32, ConvolutionLayerCPUTest,
                                          ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                                  ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Jit_Planar_2D)),
                                  ::testing::Values(emptyFusingSpec, fusingRelu),
+                                 ::testing::Values(false),
                                  ::testing::Values(cpuEmptyPluginConfig)),
                          ConvolutionLayerCPUTest::getTestCaseName);
 
@@ -704,20 +692,21 @@ const auto convParams_Planar_ExplicitPadding_3D = ::testing::Combine(
 );
 
 INSTANTIATE_TEST_SUITE_P(smoke_Conv_Jit_Planar_3D_FP32, ConvolutionLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::Combine(
-                                         convParams_Planar_ExplicitPadding_3D,
-                                         ::testing::Values(Precision::FP32),
-                                         ::testing::Values(Precision::UNSPECIFIED),
-                                         ::testing::Values(Precision::UNSPECIFIED),
-                                         ::testing::Values(Layout::ANY),
-                                         ::testing::Values(Layout::ANY),
-                                         ::testing::ValuesIn(inputShapes3d),
-                                         ::testing::Values(CommonTestUtils::DEVICE_CPU)),
-                                 ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Jit_Planar_3D)),
-                                 ::testing::Values(emptyFusingSpec, fusingRelu),
-                                 ::testing::Values(cpuEmptyPluginConfig)),
-                         ConvolutionLayerCPUTest::getTestCaseName);
+    ::testing::Combine(
+        ::testing::Combine(
+            convParams_Planar_ExplicitPadding_3D,
+            ::testing::Values(Precision::FP32),
+            ::testing::Values(Precision::UNSPECIFIED),
+            ::testing::Values(Precision::UNSPECIFIED),
+            ::testing::Values(Layout::ANY),
+            ::testing::Values(Layout::ANY),
+            ::testing::ValuesIn(inputShapes3d),
+            ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+        ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Jit_Planar_3D)),
+        ::testing::Values(emptyFusingSpec, fusingRelu),
+        ::testing::Values(false),
+        ::testing::Values(cpuEmptyPluginConfig)),
+    ConvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= */
 
@@ -765,9 +754,100 @@ INSTANTIATE_TEST_SUITE_P(smoke_Conv_winograd, ConvolutionLayerCPUTest,
                                          ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                                  ::testing::ValuesIn(filterCPUInfoForDevice(std::vector<CPUSpecificParams>{conv_winograd})),
                                  ::testing::ValuesIn(fusingParamsSet),
+                                 ::testing::Values(false),
                                  ::testing::Values(cpuEmptyPluginConfig)),
                          ConvolutionLayerCPUTest::getTestCaseName);
 
 } // namespace winograd
+
+/* ============= U8/I8 Convolution ============= */
+namespace int8 {
+
+const std::vector<fusingSpecificParams> fusingParamsSetI8{
+        emptyFusingSpec,
+        // activations
+        fusingElu,
+        fusingSigmoid,
+        fusingPReluPerChannel,
+        fusingSwish,
+        fusingMish,
+//        // other patterns
+        fusingSumEluFQ,
+        fusingSum,
+        fusingAddPerChannel
+};
+
+const std::vector<CPUSpecificParams> CPUParams_2D_I8 = {
+        conv_gemm_2D_nspc,
+        conv_sse42_2D_nspc,
+        conv_avx2_2D_nspc,
+        conv_avx512_2D_nspc
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_Conv_2D_I8, ConvolutionLayerCPUTest,
+        ::testing::Combine(
+                ::testing::Combine(
+                        convParams_ExplicitPadding_GEMM_2D,
+                        ::testing::Values(Precision::FP32),
+                        ::testing::Values(Precision::U8 /*, Precision::I8*/), // i8 primitives are disabled in oneDNN fork
+                        ::testing::Values(Precision::FP32, Precision::U8, Precision::I8),
+                        ::testing::Values(Layout::ANY),
+                        ::testing::Values(Layout::ANY),
+                        ::testing::Values(std::vector<size_t >({ 2, 12, 10, 11 })),
+                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_2D_I8)),
+                ::testing::ValuesIn(fusingParamsSetI8),
+                ::testing::Values(false, true),
+                ::testing::Values(cpuEmptyPluginConfig)),
+         ConvolutionLayerCPUTest::getTestCaseName);
+
+const std::vector<CPUSpecificParams> CPUParams_3D_I8 = {
+        conv_gemm_3D_nspc,
+        conv_sse42_3D_nspc,
+        conv_avx2_3D_nspc,
+        conv_avx512_3D_nspc
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_Conv_3D_I8, ConvolutionLayerCPUTest,
+        ::testing::Combine(
+                ::testing::Combine(
+                        convParams_ExplicitPadding_GEMM_3D,
+                        ::testing::Values(Precision::FP32),
+                        ::testing::Values(Precision::U8 /*, Precision::I8*/), // i8 primitives are disabled in oneDNN fork
+                        ::testing::Values(Precision::FP32, Precision::U8, Precision::I8),
+                        ::testing::Values(Layout::ANY),
+                        ::testing::Values(Layout::ANY),
+                        ::testing::Values(std::vector<size_t >({ 1, 12, 6, 10, 11 })),
+                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_3D_I8)),
+                ::testing::ValuesIn(fusingParamsSetI8),
+                ::testing::Values(false, true),
+                ::testing::Values(cpuEmptyPluginConfig)),
+        ConvolutionLayerCPUTest::getTestCaseName);
+
+const std::vector<CPUSpecificParams> CPUParams_1x1_2D_I8 = {
+        conv_sse42_2D_1x1_nspc,
+        conv_avx2_2D_1x1_nspc,
+        conv_avx512_2D_1x1_nspc
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_Conv_2D_1x1_I8, ConvolutionLayerCPUTest,
+        ::testing::Combine(
+                ::testing::Combine(
+                        convParams_ExplicitPadding_1x1_2D,
+                        ::testing::Values(Precision::FP32),
+                        ::testing::Values(Precision::U8 /*, Precision::I8*/), // i8 primitives are disabled in oneDNN fork
+                        ::testing::Values(Precision::FP32, Precision::U8, Precision::I8),
+                        ::testing::Values(Layout::ANY),
+                        ::testing::Values(Layout::ANY),
+                        ::testing::Values(std::vector<size_t >({ 2, 12, 10, 11 })),
+                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_1x1_2D_I8)),
+                ::testing::ValuesIn(fusingParamsSetI8),
+                ::testing::Values(false, true),
+                ::testing::Values(cpuEmptyPluginConfig)),
+        ConvolutionLayerCPUTest::getTestCaseName);
+
+} // namespace int8
 
 } // namespace CPULayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution_backprop_data.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution_backprop_data.cpp
@@ -52,7 +52,18 @@ public:
     }
 protected:
     InferenceEngine::SizeVector kernel, stride;
+
+    int calculateQuantizeInHigh(const InferenceEngine::SizeVector& kernel, const int ic, const int maxIn0 = 10, const int maxIn1 = 10) const {
+        auto quantizeInHigh = maxIn0 * maxIn1;
+        quantizeInHigh *= ic;
+        for (int i = 0; i < kernel.size(); i++) {
+            quantizeInHigh *= kernel[i];
+        }
+        return quantizeInHigh;
+    }
+
     void SetUp() override {
+        using namespace ngraph;
         convBackpropDataLayerTestParamsSet basicParamsSet;
         CPUSpecificParams cpuParams;
         fusingSpecificParams fusingParams;
@@ -70,32 +81,50 @@ protected:
         auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
         std::tie(convParams, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, outputShape, targetDevice) = basicParamsSet;
 
-        if (inPrc == Precision::UNSPECIFIED) {
-            selectedType += std::string("_") + Precision(Precision::FP32).name();
+        if (inPrc == Precision::UNSPECIFIED)
+            inPrc = Precision::FP32;
+        if (outPrc == Precision::UNSPECIFIED)
+            outPrc = Precision::FP32;
+
+        if (inPrc == Precision::U8) {
+            selectedType += std::string("_") + Precision(Precision::I8).name();
         } else {
             selectedType += std::string("_") + inPrc.name();
         }
 
-        ngraph::op::PadType padType;
+        op::PadType padType;
         InferenceEngine::SizeVector dilation;
         std::vector<ptrdiff_t> padBegin, padEnd, outPadding;
         size_t convOutChannels;
         std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType, outPadding) = convParams;
-        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+        auto inElementType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrc);
+        auto outElementType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(outPrc);
+        if (inPrc == Precision::BF16)
+            inElementType = element::f32;
+        if (outPrc == Precision::BF16)
+            outElementType = element::f32;
 
-        auto inputParams = ngraph::builder::makeParams(ngraph::element::f32, { inputShape });
-        auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(inputParams));
+        auto inputParams = builder::makeParams(inElementType, { inputShape });
+        auto paramOuts = helpers::convert2OutputVector(helpers::castOps2Nodes<op::Parameter>(inputParams));
 
-        auto deconvolutionNode = ngraph::builder::makeConvolutionBackpropData(paramOuts.front(), ngPrc, kernel, stride, padBegin,
-                padEnd, dilation, padType, convOutChannels, false, outPadding);
+        auto weiPrc = (inElementType == element::u8) ? element::i8 : inElementType;
 
-        if (!outputShape.empty()) {
-            auto outShape = ngraph::opset3::Constant::create(ngraph::element::i64, {outputShape.size()}, outputShape);
-            deconvolutionNode = ngraph::builder::makeConvolutionBackpropData(paramOuts.front(), outShape, ngPrc, kernel, stride, padBegin,
-                padEnd, dilation, padType, convOutChannels);
+        auto deconvolutionNode = builder::makeConvolutionBackpropDataRelaxed(paramOuts.front(), weiPrc,
+                kernel, stride, padBegin, padEnd, dilation, padType, convOutChannels);
+
+        if (outPrc == Precision::U8 || outPrc == Precision::I8) {
+            threshold = 1.001f;
+            abs_threshold = 1.001f;
+            quantizeInHigh = calculateQuantizeInHigh(kernel, inputShape[1]);
+            outElemType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(outPrc);
         }
 
-        function = makeNgraphFunction(ngPrc, inputParams, deconvolutionNode, "convolutionBackpropData");
+        if (inPrc == Precision::U8 || inPrc == Precision::I8) {
+            additionalPasses.push_back(std::make_shared<pass::ConvertPrecision<element::i8, element::f32>>());
+            additionalPasses.push_back(std::make_shared<pass::ConvertPrecision<element::u8, element::f32>>());
+        }
+
+        function = makeNgraphFunction(element::f32, inputParams, deconvolutionNode, "convolutionBackpropData");
     }
 };
 
@@ -127,7 +156,7 @@ const std::vector<SizeVector> emptyOutputShape = { {} };
 const std::vector<std::vector<ptrdiff_t>> emptyOutputPadding = { {} };
 
 /* ============= Deconvolution params (planar layout) ============= */
-const SizeVector numOutChannels_Planar = { 6 };
+const SizeVector numOutChannels_Planar = { 6, 33 };
 
 /* ============= Deconvolution params (blocked layout) ============= */
 const SizeVector numOutChannels_Blocked = { 64 };
@@ -194,7 +223,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Deconv_2D_Planar_BF16, DeconvolutionLayerCPUTest,
         ::testing::Values(cpuBF16PluginConfig)),
     DeconvolutionLayerCPUTest::getTestCaseName);
 
-/* ============= GroupDeconvolution (Planar 3D) ============= */
+/* ============= Deconvolution (Planar 3D) ============= */
 const auto convParams_ExplicitPadding_Planar_3D = ::testing::Combine(
     ::testing::ValuesIn(kernels3d),
     ::testing::ValuesIn(strides3d),
@@ -382,4 +411,128 @@ INSTANTIATE_TEST_SUITE_P(smoke_Deconv_2D_1x1_BF16, DeconvolutionLayerCPUTest,
 /* ========= */
 
 } // namespace
+
+/* ============= U8/I8 Deconvolution ============= */
+namespace int8 {
+
+/* ============= Deconvolution params I8 (2D) ============= */
+const std::vector<SizeVector> kernels2di8 = { {3, 3} };
+const std::vector<SizeVector> strides2di8 = { {1, 1}, {2, 2} };
+const std::vector<std::vector<ptrdiff_t>> padBegins2di8 = { {0, 0}, {1, 1} };
+const std::vector<std::vector<ptrdiff_t>> padEnds2di8 = { {0, 0}, {1, 1} };
+const std::vector<SizeVector> dilations2di8 = { {1, 1}/*, {2, 2}*/ };
+
+const auto deconvParams_2D_I8 = ::testing::Combine(
+        ::testing::ValuesIn(kernels2di8),
+        ::testing::ValuesIn(strides2di8),
+        ::testing::ValuesIn(padBegins2di8),
+        ::testing::ValuesIn(padEnds2di8),
+        ::testing::ValuesIn(dilations2di8),
+        ::testing::ValuesIn(numOutChannels_Planar),
+        ::testing::Values(ngraph::op::PadType::EXPLICIT),
+        ::testing::ValuesIn(emptyOutputPadding)
+);
+
+const std::vector<fusingSpecificParams> fusingParamsSetI8{
+        emptyFusingSpec,
+        // activations
+        fusingElu,
+        fusingSigmoid,
+        fusingPReluPerChannel,
+//        fusingReluScaleShift,
+        fusingSwish,
+        fusingMish,
+        // other patterns
+        fusingAddPerChannel
+};
+
+const std::vector<CPUSpecificParams> CPUParams_2D_I8 = {
+        conv_sse42_2D_nspc,
+        conv_avx2_2D_nspc,
+        conv_avx512_2D_nspc
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_Deconv_2D_I8, DeconvolutionLayerCPUTest,
+        ::testing::Combine(
+                ::testing::Combine(
+                        deconvParams_2D_I8,
+                        ::testing::Values(Precision::FP32),
+                        ::testing::Values(Precision::U8, Precision::I8),
+                        ::testing::Values(Precision::FP32, Precision::U8, Precision::I8),
+                        ::testing::Values(Layout::ANY),
+                        ::testing::Values(Layout::ANY),
+                        ::testing::Values(std::vector<size_t >({ 2, 12, 7, 7 })),
+                        ::testing::ValuesIn(emptyOutputShape),
+                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_2D_I8)),
+                ::testing::ValuesIn(fusingParamsSetI8),
+                ::testing::Values(cpuEmptyPluginConfig)),
+        DeconvolutionLayerCPUTest::getTestCaseName);
+
+// temporarily disabled support for 3D cases in the plug-in
+/* ============= Deconvolution params I8 (3D) ============= */
+//const std::vector<SizeVector> kernels3di8 = { {3, 3, 3} };
+//const std::vector<SizeVector> strides3di8 = { {1, 1, 1}, {2, 2, 2} };
+//const std::vector<std::vector<ptrdiff_t>> padBegins3di8 = { {0, 0, 0}, {1, 1, 1} };
+//const std::vector<std::vector<ptrdiff_t>> padEnds3di8 = { {0, 0, 0}, {1, 1, 1} };
+//const std::vector<SizeVector> dilations3di8 = { {1, 1, 1}/*, {2, 2, 2}*/ };
+//
+//const auto deconvParams_3D_I8 = ::testing::Combine(
+//        ::testing::ValuesIn(kernels3di8),
+//        ::testing::ValuesIn(strides3di8),
+//        ::testing::ValuesIn(padBegins3di8),
+//        ::testing::ValuesIn(padEnds3di8),
+//        ::testing::ValuesIn(dilations3di8),
+//        ::testing::ValuesIn(numOutChannels_Planar),
+//        ::testing::Values(ngraph::op::PadType::EXPLICIT),
+//        ::testing::ValuesIn(emptyOutputPadding)
+//);
+//
+//const std::vector<CPUSpecificParams> CPUParams_3D_I8 = {
+//        conv_sse42_3D_nspc,
+//        conv_avx2_3D_nspc,
+//        conv_avx512_3D_nspc
+//};
+//
+//INSTANTIATE_TEST_CASE_P(smoke_Deconv_3D_I8, DeconvolutionLayerCPUTest,
+//        ::testing::Combine(
+//                ::testing::Combine(
+//                        deconvParams_3D_I8,
+//                        ::testing::Values(Precision::FP32),
+//                        ::testing::Values(Precision::U8, Precision::I8),
+//                        ::testing::Values(Precision::FP32, Precision::U8, Precision::I8),
+//                        ::testing::Values(Layout::ANY),
+//                        ::testing::Values(Layout::ANY),
+//                        ::testing::Values(std::vector<size_t >({ 2, 12, 7, 7, 7 })),
+//                        ::testing::ValuesIn(emptyOutputShape),
+//                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+//                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_3D_I8)),
+//                ::testing::ValuesIn(fusingParamsSetI8),
+//                ::testing::Values(cpuEmptyPluginConfig)),
+//        DeconvolutionLayerCPUTest::getTestCaseName);
+
+const std::vector<CPUSpecificParams> CPUParams_2D_1x1_I8 = {
+        conv_sse42_2D_1x1_nspc,
+        conv_avx2_2D_1x1_nspc,
+        conv_avx512_2D_1x1_nspc
+};
+
+INSTANTIATE_TEST_CASE_P(smoke_Deconv_2D_1x1_I8, DeconvolutionLayerCPUTest,
+        ::testing::Combine(
+                ::testing::Combine(
+                        convParams_ExplicitPadding_1x1_2D,
+                        ::testing::Values(Precision::FP32),
+                        ::testing::Values(Precision::U8/*, Precision::I8*/), // todo: [AV] turn on I8
+                        ::testing::Values(Precision::FP32, Precision::U8, Precision::I8),
+                        ::testing::Values(Layout::ANY),
+                        ::testing::Values(Layout::ANY),
+                        ::testing::Values(std::vector<size_t >({ 2, 12, 7, 7 })),
+                        ::testing::ValuesIn(emptyOutputShape),
+                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_2D_1x1_I8)),
+                ::testing::ValuesIn(fusingParamsSetI8),
+                ::testing::Values(cpuEmptyPluginConfig)),
+        DeconvolutionLayerCPUTest::getTestCaseName);
+
+} // namespace int8
 } // namespace CPULayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution_backprop_data.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution_backprop_data.cpp
@@ -50,7 +50,19 @@ public:
 
 protected:
     InferenceEngine::SizeVector kernel, stride;
+
+    int calculateQuantizeInHigh(const InferenceEngine::SizeVector& kernel, const int ic, const int groups,
+            const int maxIn0 = 10, const int maxIn1 = 10) const {
+        auto quantizeInHigh = maxIn0 * maxIn1;
+        quantizeInHigh *= (ic / groups);
+        for (int i = 0; i < kernel.size(); i++) {
+            quantizeInHigh *= kernel[i];
+        }
+        return quantizeInHigh;
+    }
+
     void SetUp() override {
+        using namespace ngraph;
         groupConvBackpropDataLayerTestParamsSet basicParamsSet;
         CPUSpecificParams cpuParams;
         fusingSpecificParams fusingParams;
@@ -67,34 +79,50 @@ protected:
         auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
         std::tie(groupConvParams, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, outputShape, targetDevice) = basicParamsSet;
 
-        if (inPrc == Precision::UNSPECIFIED) {
-            selectedType += std::string("_") + Precision(Precision::FP32).name();
+        if (inPrc == Precision::UNSPECIFIED)
+            inPrc = Precision::FP32;
+        if (outPrc == Precision::UNSPECIFIED)
+            outPrc = Precision::FP32;
+
+        if (inPrc == Precision::U8) {
+            selectedType += std::string("_") + Precision(Precision::I8).name();
         } else {
             selectedType += std::string("_") + inPrc.name();
         }
 
-        ngraph::op::PadType padType;
+        op::PadType padType;
         InferenceEngine::SizeVector dilation;
         std::vector<ptrdiff_t> padBegin, padEnd, outputPadding;
         size_t convOutChannels, numGroups;
         std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, numGroups, padType, outputPadding) = groupConvParams;
+        auto inElementType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrc);
+        auto outElementType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(outPrc);
+        if (inPrc == Precision::BF16)
+            inElementType = element::f32;
+        if (outPrc == Precision::BF16)
+            outElementType = element::f32;
 
-        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
-        auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
-        auto paramOuts = ngraph::helpers::convert2OutputVector(
-                ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
-        std::shared_ptr<ngraph::op::v1::GroupConvolutionBackpropData> groupConv;
-        if (!outputShape.empty()) {
-            auto outShape = ngraph::opset3::Constant::create(ngraph::element::i64, {outputShape.size()}, outputShape);
-            groupConv = std::dynamic_pointer_cast<ngraph::opset1::GroupConvolutionBackpropData>(
-            ngraph::builder::makeGroupConvolutionBackpropData(paramOuts[0], outShape, ngPrc, kernel, stride, padBegin,
-                                                            padEnd, dilation, padType, convOutChannels, numGroups, false, outputPadding));
-        } else {
-            groupConv = std::dynamic_pointer_cast<ngraph::opset1::GroupConvolutionBackpropData>(
-            ngraph::builder::makeGroupConvolutionBackpropData(paramOuts[0], ngPrc, kernel, stride, padBegin,
-                                                padEnd, dilation, padType, convOutChannels, numGroups, false, outputPadding));
+        auto inputParams = builder::makeParams(inElementType, { inputShape });
+        auto paramOuts = helpers::convert2OutputVector(helpers::castOps2Nodes<op::Parameter>(inputParams));
+
+        auto weiPrc = (inElementType == element::u8) ? element::i8 : inElementType;
+
+        auto groupConv = ngraph::builder::makeGroupConvolutionBackpropDataRelaxed(paramOuts[0], weiPrc, kernel,
+                    stride, padBegin, padEnd, dilation, padType, convOutChannels, numGroups);
+
+        if (outPrc == Precision::U8 || outPrc == Precision::I8) {
+            threshold = 1.001f;
+            abs_threshold = 1.001f;
+            quantizeInHigh = calculateQuantizeInHigh(kernel, inputShape[1], numGroups);
+            outElemType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(outPrc);
         }
-        function = makeNgraphFunction(ngPrc, params, groupConv, "groupConvolutionBackpropData");
+
+        if (inPrc == Precision::U8 || inPrc == Precision::I8) {
+            additionalPasses.push_back(std::make_shared<pass::ConvertPrecision<element::i8, element::f32>>());
+            additionalPasses.push_back(std::make_shared<pass::ConvertPrecision<element::u8, element::f32>>());
+        }
+
+        function = makeNgraphFunction(element::f32, inputParams, groupConv, "groupConvolutionBackpropData");
     }
 };
 
@@ -113,28 +141,6 @@ TEST_P(GroupDeconvolutionLayerCPUTest, CompareWithRefs) {
 }
 
 namespace {
-
-/* GROUP CONV TEST UTILS */
-std::vector<groupDeconvLayerCPUTestParamsSet> filterParamsSetForDevice(std::vector<groupDeconvLayerCPUTestParamsSet> paramsSet) {
-    std::vector<groupDeconvLayerCPUTestParamsSet> resParamsSet;
-    const int cpuParamsIndex = 1;
-    const int selectedTypeIndex = 3;
-
-    for (auto param : paramsSet) {
-        auto cpuParams = std::get<cpuParamsIndex>(param);
-        auto selectedTypeStr = std::get<selectedTypeIndex>(cpuParams);
-
-        if (selectedTypeStr.find("jit") != std::string::npos && !with_cpu_x86_sse42())
-            continue;
-        if (selectedTypeStr.find("avx512") != std::string::npos && !with_cpu_x86_avx512f())
-            continue;
-
-        resParamsSet.push_back(param);
-    }
-
-    return resParamsSet;
-}
-/* ===================== */
 
 /* COMMON PARAMS */
 std::vector<fusingSpecificParams> fusingParamsSet {
@@ -411,5 +417,211 @@ INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_2D_DW_BF16, GroupDeconvolutionLayerCP
         ::testing::Values(cpuBF16PluginConfig)),
     GroupDeconvolutionLayerCPUTest::getTestCaseName);
 } // namespace
+
+/* ============= U8/I8 Deconvolution ============= */
+namespace int8 {
+
+const std::vector<SizeVector> kernels2di8 = { {3, 3} };
+const std::vector<SizeVector> strides2di8 = { {1, 1}, {2, 2} };
+const std::vector<std::vector<ptrdiff_t>> padBegins2di8 = { {0, 0}, {1, 1} };
+const std::vector<std::vector<ptrdiff_t>> padEnds2di8 = { {0, 0}, {1, 1} };
+const std::vector<SizeVector> dilations2di8 = { {1, 1}/*, {2, 2}*/ };
+
+const auto groupDeconvParams_2D_I8 = ::testing::Combine(
+        ::testing::ValuesIn(kernels2di8),
+        ::testing::ValuesIn(strides2di8),
+        ::testing::ValuesIn(padBegins2di8),
+        ::testing::ValuesIn(padEnds2di8),
+        ::testing::ValuesIn(dilations2di8),
+        ::testing::ValuesIn(numOutChannels_Blocked),
+        ::testing::ValuesIn(numGroups_Blocked),
+        ::testing::Values(ngraph::op::PadType::EXPLICIT),
+        ::testing::ValuesIn(emptyOutputPadding)
+);
+
+const std::vector<fusingSpecificParams> fusingParamsSetI8{
+        emptyFusingSpec,
+//        // activations
+        fusingElu,
+        fusingSigmoid,
+        fusingPReluPerChannel,
+        fusingSwish,
+        fusingMish,
+//        // other patterns
+        fusingAddPerChannel
+};
+
+const std::vector<CPUSpecificParams> CPUParams_2D_I8 = {
+        conv_sse42_2D_nspc,
+        conv_avx2_2D_nspc,
+        conv_avx512_2D_nspc
+};
+
+INSTANTIATE_TEST_CASE_P(smoke_GroupDeconv_2D_I8, GroupDeconvolutionLayerCPUTest,
+        ::testing::Combine(
+                ::testing::Combine(
+                        groupDeconvParams_2D_I8,
+                        ::testing::Values(Precision::FP32),
+                        ::testing::Values(Precision::U8, Precision::I8),
+                        ::testing::Values(Precision::FP32, Precision::U8, Precision::I8),
+                        ::testing::Values(Layout::ANY),
+                        ::testing::Values(Layout::ANY),
+                        ::testing::Values(std::vector<size_t >({ 2, 64, 7, 7 })),
+                        ::testing::ValuesIn(emptyOutputShape),
+                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_2D_I8)),
+                ::testing::ValuesIn(fusingParamsSetI8),
+                ::testing::Values(cpuEmptyPluginConfig)),
+        GroupDeconvolutionLayerCPUTest::getTestCaseName);
+
+// temporarily disabled support for 3D cases in the plug-in
+/* ============= GroupDeconvolution params I8 (3D) ============= */
+//const std::vector<SizeVector> kernels3di8 = { {3, 3, 3} };
+//const std::vector<SizeVector> strides3di8 = { {1, 1, 1}, {2, 2, 2} };
+//const std::vector<std::vector<ptrdiff_t>> padBegins3di8 = { {0, 0, 0}, {1, 1, 1} };
+//const std::vector<std::vector<ptrdiff_t>> padEnds3di8 = { {0, 0, 0}, {1, 1, 1} };
+//const std::vector<SizeVector> dilations3di8 = { {1, 1, 1}/*, {2, 2, 2}*/ };
+//
+//const auto groupDeconvParams_3D_I8 = ::testing::Combine(
+//        ::testing::ValuesIn(kernels3di8),
+//        ::testing::ValuesIn(strides3di8),
+//        ::testing::ValuesIn(padBegins3di8),
+//        ::testing::ValuesIn(padEnds3di8),
+//        ::testing::ValuesIn(dilations3di8),
+//        ::testing::ValuesIn(numOutChannels_Blocked),
+//        ::testing::ValuesIn(numGroups_Blocked),
+//        ::testing::Values(ngraph::op::PadType::EXPLICIT),
+//        ::testing::ValuesIn(emptyOutputPadding)
+//);
+//
+//const std::vector<CPUSpecificParams> CPUParams_3D_I8 = {
+//        conv_sse42_3D_nspc,
+//        conv_avx2_3D_nspc,
+//        conv_avx512_3D_nspc
+//};
+//
+//INSTANTIATE_TEST_CASE_P(smoke_GroupDeconv_3D_I8, GroupDeconvolutionLayerCPUTest,
+//        ::testing::Combine(
+//                ::testing::Combine(
+//                        groupDeconvParams_3D_I8,
+//                        ::testing::Values(Precision::FP32),
+//                        ::testing::Values(Precision::U8, Precision::I8),
+//                        ::testing::Values(Precision::FP32, Precision::U8, Precision::I8),
+//                        ::testing::Values(Layout::ANY),
+//                        ::testing::Values(Layout::ANY),
+//                        ::testing::Values(std::vector<size_t >({ 2, 64, 7, 7, 7 })),
+//                        ::testing::ValuesIn(emptyOutputShape),
+//                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+//                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_3D_I8)),
+//                ::testing::ValuesIn(fusingParamsSetI8),
+//                ::testing::Values(cpuEmptyPluginConfig)),
+//        GroupDeconvolutionLayerCPUTest::getTestCaseName);
+
+/* ============= GroupDeconvolution params 1x1 I8 (2D) ============= */
+const auto groupDeconvParams_1x1_2D_I8 = ::testing::Combine(
+        ::testing::Values(SizeVector({1, 1})),
+        ::testing::Values(SizeVector({1, 1})),
+        ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
+        ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
+        ::testing::Values(SizeVector({1, 1})),
+        ::testing::ValuesIn(numOutChannels_Blocked),
+        ::testing::ValuesIn(numGroups_Blocked),
+        ::testing::Values(ngraph::op::PadType::EXPLICIT),
+        ::testing::ValuesIn(emptyOutputPadding)
+);
+
+const std::vector<CPUSpecificParams> CPUParams_2D_1x1_I8 = {
+        // not supported 1x1 grouped conv for avx2/sse41 isa
+        // conv_sse42_2D_1x1_I8,
+        // conv_avx2_2D_1x1_I8,
+        conv_avx512_2D_1x1_nspc
+};
+
+INSTANTIATE_TEST_CASE_P(smoke_GroupDeconv_1x1_2D_I8, GroupDeconvolutionLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Combine(
+                                        groupDeconvParams_1x1_2D_I8,
+                                        ::testing::Values(Precision::FP32),
+                                        ::testing::Values(Precision::U8/*, Precision::I8*/), // todo: [AV] turn on I8
+                                        ::testing::Values(Precision::FP32, Precision::U8, Precision::I8),
+                                        ::testing::Values(Layout::ANY),
+                                        ::testing::Values(Layout::ANY),
+                                        ::testing::Values(std::vector<size_t >({ 2, 64, 7, 7 })),
+                                        ::testing::ValuesIn(emptyOutputShape),
+                                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_2D_1x1_I8)),
+                                ::testing::ValuesIn(fusingParamsSetI8),
+                                ::testing::Values(cpuEmptyPluginConfig)),
+                        GroupDeconvolutionLayerCPUTest::getTestCaseName);
+
+// temporarily disabled support for 3D cases in the plug-in
+/* ============= GroupDeconvolution params 1x1 I8 (3D) ============= */
+//const auto groupDeconvParams_1x1_3D_I8 = ::testing::Combine(
+//        ::testing::Values(SizeVector({1, 1, 1})),
+//        ::testing::Values(SizeVector({1, 1, 1})),
+//        ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),
+//        ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),
+//        ::testing::Values(SizeVector({1, 1, 1})),
+//        ::testing::ValuesIn(numOutChannels_Blocked),
+//        ::testing::ValuesIn(numGroups_Blocked),
+//        ::testing::Values(ngraph::op::PadType::EXPLICIT),
+//        ::testing::ValuesIn(emptyOutputPadding)
+//);
+//
+//const std::vector<CPUSpecificParams> CPUParams_3D_1x1_I8 = {
+//        // not supported 1x1 grouped conv for avx2/sse41 isa
+//        // conv_sse42_3D_1x1_I8,
+//        // conv_avx2_3D_1x1_I8,
+//        conv_avx512_3D_1x1_nspc
+//};
+//
+//INSTANTIATE_TEST_CASE_P(smoke_GroupDeconv_1x1_3D_I8, GroupDeconvolutionLayerCPUTest,
+//                        ::testing::Combine(
+//                                ::testing::Combine(
+//                                        groupDeconvParams_1x1_3D_I8,
+//                                        ::testing::Values(Precision::FP32),
+//                                        ::testing::Values(Precision::U8, Precision::I8),
+//                                        ::testing::Values(Precision::FP32, Precision::U8, Precision::I8),
+//                                        ::testing::Values(Layout::ANY),
+//                                        ::testing::Values(Layout::ANY),
+//                                        ::testing::Values(std::vector<size_t >({ 2, 64, 7, 7, 7 })),
+//                                        ::testing::ValuesIn(emptyOutputShape),
+//                                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+//                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_3D_1x1_I8)),
+//                                ::testing::ValuesIn(fusingParamsSetI8),
+//                                ::testing::Values(cpuEmptyPluginConfig)),
+//                        GroupDeconvolutionLayerCPUTest::getTestCaseName);
+
+/* ============= GroupDeconvolution params I8 (DW 2D) ============= */
+const auto groupDeconvParams_DW_2D_I8 = ::testing::Combine(
+        ::testing::ValuesIn(kernels2di8),
+        ::testing::ValuesIn(strides2di8),
+        ::testing::ValuesIn(padBegins2di8),
+        ::testing::ValuesIn(padEnds2di8),
+        ::testing::ValuesIn(dilations2di8),
+        ::testing::ValuesIn(numOutChannels_DW),
+        ::testing::ValuesIn(numGroups_DW),
+        ::testing::Values(ngraph::op::PadType::EXPLICIT),
+        ::testing::ValuesIn(emptyOutputPadding)
+);
+
+INSTANTIATE_TEST_CASE_P(smoke_GroupDeconv_2D_DW_I8, GroupDeconvolutionLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Combine(
+                                        groupDeconvParams_DW_2D_I8,
+                                        ::testing::Values(Precision::FP32),
+                                        ::testing::Values(Precision::U8), // I8 and 3D DW deconvolution not supported in oneDNN
+                                        ::testing::Values(Precision::FP32, Precision::U8, Precision::I8),
+                                        ::testing::Values(Layout::ANY),
+                                        ::testing::Values(Layout::ANY),
+                                        ::testing::Values(std::vector<size_t >({ 2, 32, 7, 7 })),
+                                        ::testing::ValuesIn(emptyOutputShape),
+                                        ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_2D_I8)),
+                                ::testing::ValuesIn(fusingParamsSetI8),
+                                ::testing::Values(cpuEmptyPluginConfig)),
+                        GroupDeconvolutionLayerCPUTest::getTestCaseName);
+
+} // namespace int8
 
 } // namespace CPULayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/mat_mul.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/mat_mul.cpp
@@ -94,7 +94,6 @@ protected:
         if (transpA) transpose(inShapeA);
         if (transpB) transpose(inShapeB);
 
-        auto ngPrec = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         auto elemTypeA = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrc);
         auto elemTypeB = (elemTypeA == element::u8) ? element::i8 : elemTypeA;
 

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/convolution_params.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/convolution_params.hpp
@@ -71,5 +71,9 @@ namespace CPUTestUtils {
     const auto conv_avx2_2D_1x1_nspc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_avx2_1x1"}, "jit_avx2_1x1"};
     const auto conv_avx512_2D_1x1_nspc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_avx512_1x1"}, "jit_avx512_1x1"};
 
+    const auto conv_sse42_3D_1x1_nspc = CPUSpecificParams{{ndhwc}, {ndhwc}, {"jit_sse42_1x1"}, "jit_sse42_1x1"};
+    const auto conv_avx2_3D_1x1_nspc = CPUSpecificParams{{ndhwc}, {ndhwc}, {"jit_avx2_1x1"}, "jit_avx2_1x1"};
+    const auto conv_avx512_3D_1x1_nspc = CPUSpecificParams{{ndhwc}, {ndhwc}, {"jit_avx512_1x1"}, "jit_avx512_1x1"};
+
     const auto conv_winograd = CPUSpecificParams{{nChw16c}, {nChw16c}, {"jit_avx512_winograd"}, "jit_avx512_winograd"};
 } // namespace CPUTestUtils

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.cpp
@@ -5,6 +5,7 @@
 #include "cpu_test_utils.hpp"
 #include "utils/rt_info/memory_formats_attribute.hpp"
 #include <cstdint>
+#include "ngraph_functions/builders.hpp"
 
 namespace CPUTestUtils {
 
@@ -268,6 +269,12 @@ CPUTestsBase::makeNgraphFunction(const ngraph::element::Type &ngPrc, ngraph::Par
                                  const std::shared_ptr<ngraph::Node> &lastNode, std::string name) const {
    auto newLastNode = modifyGraph(ngPrc, params, lastNode);
    ngraph::ResultVector results;
+
+   if (outElemType == ngraph::element::u8) {
+       newLastNode = ngraph::builder::makeFakeQuantize(newLastNode, ngPrc, 256, {1, 1, 1, 1}, {0}, {static_cast<float>(quantizeInHigh)}, {0}, {255});
+   } else if (outElemType == ngraph::element::i8) {
+       newLastNode = ngraph::builder::makeFakeQuantize(newLastNode, ngPrc, 255, {1, 1, 1, 1}, {0}, {static_cast<float>(quantizeInHigh)}, {-127}, {127});
+   }
 
    for (int i = 0; i < newLastNode->get_output_size(); i++)
         results.push_back(std::make_shared<ngraph::opset1::Result>(newLastNode->output(i)));

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
@@ -10,6 +10,7 @@
 #include "shared_test_classes/base/layer_test_utils.hpp"
 #include <exec_graph_info.hpp>
 #include "ie_system_conf.h"
+#include "ngraph_ops/type_relaxed.hpp"
 
 namespace CPUTestUtils {
     typedef enum {
@@ -151,6 +152,10 @@ protected:
     std::vector<cpu_memory_format_t> inFmts, outFmts;
     std::vector<std::string> priority;
     std::string selectedType;
+
+    ngraph::element::Type outElemType = ngraph::element::f32;
+    // only for int8 testing
+    int quantizeInHigh = 1;
 };
 
 const auto emptyCPUSpec = CPUSpecificParams{{}, {}, {}, {}};

--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
@@ -153,7 +153,7 @@ protected:
     InferenceEngine::ExecutableNetwork executableNetwork;
     std::vector<InferenceEngine::Blob::Ptr> inputs;
     float threshold;
-    float abs_threshold;
+    float abs_threshold = -1;
     InferenceEngine::CNNNetwork cnnNetwork;
     std::shared_ptr<InferenceEngine::Core> core;
 
@@ -164,6 +164,8 @@ protected:
     virtual std::vector<InferenceEngine::Blob::Ptr> GetOutputs();
 
     InferenceEngine::InferRequest inferRequest;
+
+    std::vector<std::shared_ptr<ngraph::pass::GraphRewrite>> additionalPasses;
 
 private:
     RefMode refMode = RefMode::INTERPRETER;

--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
@@ -94,6 +94,12 @@ public:
 
     template<class T_IE, class T_NGRAPH>
     static void Compare(const T_NGRAPH *expected, const T_IE *actual, std::size_t size, float threshold, float abs_threshold = -1.f) {
+//        std::cout << "REF vs RES" << std::endl;
+//        for (std::size_t i = 0; i < size; ++i) {
+//            const T_NGRAPH &ref = expected[i];
+//            const auto &res = actual[i];
+//            std::cout << i << ". ref = " << ref << ", res = " << res << std::endl;
+//        }
         for (std::size_t i = 0; i < size; ++i) {
             const T_NGRAPH &ref = expected[i];
             const auto &res = actual[i];

--- a/inference-engine/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
@@ -386,6 +386,9 @@ std::vector<std::pair<ngraph::element::Type, std::vector<std::uint8_t>>> LayerTe
     ngraph::pass::ConvertPrecision<ngraph::element::Type_t::f16, ngraph::element::Type_t::f32>().run_on_function(functionRefs);
     ngraph::pass::ConvertPrecision<ngraph::element::Type_t::bf16, ngraph::element::Type_t::f32>().run_on_function(functionRefs);
 
+    for (const auto pass : additionalPasses)
+        pass->run_on_function(functionRefs);
+
     functionRefs->validate_nodes_and_infer_types();
 
     auto referenceInputs = std::vector<std::vector<uint8_t>>(inputs.size());
@@ -446,7 +449,7 @@ std::vector<InferenceEngine::Blob::Ptr> LayerTestsCommon::GetOutputs() {
 
 void LayerTestsCommon::Compare(const std::vector<std::pair<ngraph::element::Type, std::vector<std::uint8_t>>> &expectedOutputs,
                                const std::vector<InferenceEngine::Blob::Ptr> &actualOutputs) {
-    Compare(expectedOutputs, actualOutputs, threshold);
+    Compare(expectedOutputs, actualOutputs, threshold, abs_threshold);
 }
 
 void LayerTestsCommon::Validate() {

--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/CMakeLists.txt
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/CMakeLists.txt
@@ -13,6 +13,7 @@ addIeTarget(
         INCLUDES
             PUBLIC
                 ${PUBLIC_HEADERS_DIR}
+                ${IE_MAIN_SOURCE_DIR}/src/transformations/include
         ADDITIONAL_SOURCE_DIRS
             ${CMAKE_CURRENT_SOURCE_DIR}/src
         LINK_LIBRARIES

--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/builders.hpp
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/builders.hpp
@@ -18,6 +18,7 @@
 
 #include "ngraph_functions/utils/data_utils.hpp"
 #include "openvino/core/partial_shape.hpp"
+#include "ngraph_ops/type_relaxed.hpp"
 
 namespace ngraph {
 namespace builder {
@@ -97,6 +98,17 @@ std::shared_ptr<ngraph::Node> makeConvolution(const ngraph::Output<Node> &in,
                                               const std::vector<float> &filterWeights = {},
                                               const std::vector<float> &biasesWeights = {});
 
+std::shared_ptr<ngraph::Node> makeConvolutionRelaxed(const ngraph::Output<Node> &in,
+                                              const element::Type &type,
+                                              const std::vector<size_t> &filterSize,
+                                              const std::vector<size_t> &strides,
+                                              const std::vector<ptrdiff_t> &padsBegin,
+                                              const std::vector<ptrdiff_t> &padsEnd,
+                                              const std::vector<size_t> &dilations,
+                                              const op::PadType &autoPad,
+                                              size_t numOutChannels,
+                                              const std::vector<float> &filterWeights = {});
+
 std::shared_ptr<ngraph::Node> makeGroupConvolution(const ngraph::Output<Node> &in,
                                                    const element::Type &type,
                                                    const std::vector<size_t> &filterSize,
@@ -121,6 +133,18 @@ std::shared_ptr<ngraph::Node> makeGroupConvolution(const ngraph::Output<Node> &i
                                                    const op::PadType &autoPad,
                                                    bool addBiases = false,
                                                    const std::vector<float> &biasesWeights = {});
+
+std::shared_ptr<Node> makeGroupConvolutionRelaxed(const ngraph::Output<Node> &in,
+                                                  const element::Type &type,
+                                                  const std::vector<size_t> &filterSize,
+                                                  const std::vector<size_t> &strides,
+                                                  const std::vector<ptrdiff_t> &padsBegin,
+                                                  const std::vector<ptrdiff_t> &padsEnd,
+                                                  const std::vector<size_t> &dilations,
+                                                  const op::PadType &autoPad,
+                                                  size_t numOutChannels,
+                                                  size_t numGroups,
+                                                  const std::vector<float> &filterWeights = {});
 
 std::shared_ptr<ngraph::Node> makeConvolutionBackpropData(const ngraph::Output<Node> &in,
                                                           const element::Type &type,
@@ -162,6 +186,17 @@ std::shared_ptr<ngraph::Node> makeConvolutionBackpropData(const ngraph::Output<N
                                                           const std::vector<ptrdiff_t> &outputPadding = {},
                                                           const std::vector<float> &filterWeights = {},
                                                           const std::vector<float> &biasesWeights = {});
+
+std::shared_ptr<ngraph::Node> makeConvolutionBackpropDataRelaxed(const ngraph::Output<Node> &in,
+                                                          const element::Type &weiType,
+                                                          const std::vector<size_t> &filterSize,
+                                                          const std::vector<size_t> &strides,
+                                                          const std::vector<ptrdiff_t> &padsBegin,
+                                                          const std::vector<ptrdiff_t> &padsEnd,
+                                                          const std::vector<size_t> &dilations,
+                                                          const op::PadType &autoPad,
+                                                          size_t numOutChannels,
+                                                          const std::vector<float> &filterWeights = {});
 
 std::shared_ptr<ngraph::Node> makeCTCGreedyDecoder(
         const ngraph::Output<Node>& inputData,
@@ -234,6 +269,18 @@ std::shared_ptr<ngraph::Node> makeGroupConvolutionBackpropData(const ngraph::Out
                                                                const std::vector<ptrdiff_t> &outputPadding = {},
                                                                const std::vector<float> &filterWeights = {},
                                                                const std::vector<float> &biasesWeights = {});
+
+std::shared_ptr<Node> makeGroupConvolutionBackpropDataRelaxed(const ngraph::Output<Node> &in,
+                                                              const element::Type &weiType,
+                                                              const std::vector<size_t> &filterSize,
+                                                              const std::vector<size_t> &strides,
+                                                              const std::vector<ptrdiff_t> &padsBegin,
+                                                              const std::vector<ptrdiff_t> &padsEnd,
+                                                              const std::vector<size_t> &dilations,
+                                                              const op::PadType &autoPad,
+                                                              size_t numOutChannels,
+                                                              size_t numGroups,
+                                                              const std::vector<float> &filterWeights = {});
 
 std::shared_ptr<ngraph::Node> makeBinaryConvolution(const ngraph::Output<Node> &in,
                                                     const std::vector<size_t> &filterSize,
@@ -403,6 +450,11 @@ std::shared_ptr<Node> makeMatMul(const Output<Node> &A,
                                  const Output<Node> &B,
                                  bool transpose_a = false,
                                  bool transpose_b = false);
+
+std::shared_ptr<Node> makeFullyConnectedRelaxed(const Output<Node> &A,
+                                                const Output<Node>& B,
+                                                bool transpose_a = false,
+                                                bool transpose_b = false);
 
 std::shared_ptr<ngraph::Node> makeReduce(const ngraph::Output<Node>& data,
                                          const ngraph::Output<Node>& axes,

--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/src/convolution.cpp
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/src/convolution.cpp
@@ -39,5 +39,34 @@ std::shared_ptr<Node> makeConvolution(const ngraph::Output<Node> &in,
     }
 }
 
+std::shared_ptr<Node> makeConvolutionRelaxed(const ngraph::Output<Node> &in,
+                                      const element::Type &type,
+                                      const std::vector<size_t> &filterSize,
+                                      const std::vector<size_t> &strides,
+                                      const std::vector<ptrdiff_t> &padsBegin,
+                                      const std::vector<ptrdiff_t> &padsEnd,
+                                      const std::vector<size_t> &dilations,
+                                      const op::PadType &autoPad,
+                                      size_t numOutChannels,
+                                      const std::vector<float> &filterWeights) {
+    auto inputParamsFP32 = ngraph::builder::makeParams(ngraph::element::f32, { in.get_shape() });
+    auto paramOutsFP32 = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(inputParamsFP32));
+
+    auto convolutionNodeRelaxed = std::make_shared<op::TypeRelaxed<opset1::Convolution>>(
+            *as_type_ptr<opset1::Convolution>(ngraph::builder::makeConvolution(
+                    paramOutsFP32.front(), ngraph::element::f32, filterSize, strides, padsBegin, padsEnd, dilations, autoPad, numOutChannels)),
+            element::f32);
+
+    bool randomFilterWeights = filterWeights.empty();
+    auto shape = in.get_shape();
+    std::vector<size_t> filterWeightsShape = {numOutChannels, shape[1]};
+    filterWeightsShape.insert(filterWeightsShape.end(), filterSize.begin(), filterSize.end());
+    auto filterWeightsNode = makeConstant(type, filterWeightsShape, filterWeights, randomFilterWeights);
+
+    auto newConvolution = convolutionNodeRelaxed->copy_with_new_inputs({in, filterWeightsNode});
+
+    return newConvolution;
+}
+
 }  // namespace builder
 }  // namespace ngraph

--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/src/convolution.cpp
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/src/convolution.cpp
@@ -63,6 +63,16 @@ std::shared_ptr<Node> makeConvolutionRelaxed(const ngraph::Output<Node> &in,
     filterWeightsShape.insert(filterWeightsShape.end(), filterSize.begin(), filterSize.end());
     auto filterWeightsNode = makeConstant(type, filterWeightsShape, filterWeights, randomFilterWeights);
 
+//    auto constNode = std::dynamic_pointer_cast<ngraph::op::Constant>(filterWeightsNode);
+//    std::cout << "WEI" << std::endl;
+//    auto dataSize = 1;
+//    for (int i = 0; i < constNode->get_output_shape(0).size(); i++)
+//        dataSize *= constNode->get_output_shape(0)[i];
+//    auto *dataPtr = (const int8_t *)constNode->get_data_ptr();
+//    for (int i = 0; i < dataSize; i++) {
+//        std::cout << i << ". " << (int32_t)(dataPtr[i]) << std::endl;
+//    }
+
     auto newConvolution = convolutionNodeRelaxed->copy_with_new_inputs({in, filterWeightsNode});
 
     return newConvolution;

--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/src/convolution_backprop_data.cpp
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/src/convolution_backprop_data.cpp
@@ -96,5 +96,34 @@ std::shared_ptr<Node> makeConvolutionBackpropData(const ngraph::Output<Node> &in
     }
 }
 
+std::shared_ptr<Node> makeConvolutionBackpropDataRelaxed(const ngraph::Output<Node> &in,
+                                                  const element::Type &weiType,
+                                                  const std::vector<size_t> &filterSize,
+                                                  const std::vector<size_t> &strides,
+                                                  const std::vector<ptrdiff_t> &padsBegin,
+                                                  const std::vector<ptrdiff_t> &padsEnd,
+                                                  const std::vector<size_t> &dilations,
+                                                  const op::PadType &autoPad,
+                                                  size_t numOutChannels,
+                                                  const std::vector<float> &filterWeights) {
+    auto inputParamsFP32 = ngraph::builder::makeParams(ngraph::element::f32, { in.get_shape() });
+    auto paramOutsFP32 = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(inputParamsFP32));
+
+    auto deconvolutionNodeRelaxed = std::make_shared<op::TypeRelaxed<opset1::ConvolutionBackpropData>>(
+            *as_type_ptr<opset1::ConvolutionBackpropData>(ngraph::builder::makeConvolutionBackpropData(
+                    paramOutsFP32.front(), ngraph::element::f32, filterSize, strides, padsBegin, padsEnd, dilations, autoPad, numOutChannels)),
+            element::f32);
+
+    bool randomFilterWeights = filterWeights.empty();
+    auto shape = in.get_shape();
+    std::vector<size_t> filterWeightsShape = {shape[1], numOutChannels};
+    filterWeightsShape.insert(filterWeightsShape.end(), filterSize.begin(), filterSize.end());
+    auto filterWeightsNode = makeConstant(weiType, filterWeightsShape, filterWeights, randomFilterWeights);
+
+    auto newDeconvolution = deconvolutionNodeRelaxed->copy_with_new_inputs({in, filterWeightsNode});
+
+    return newDeconvolution;
+}
+
 }  // namespace builder
 }  // namespace ngraph

--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/src/group_convolution_backprop_data.cpp
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/src/group_convolution_backprop_data.cpp
@@ -108,5 +108,39 @@ std::shared_ptr<Node> makeGroupConvolutionBackpropData(const ngraph::Output<Node
     }
 }
 
+std::shared_ptr<Node> makeGroupConvolutionBackpropDataRelaxed(const ngraph::Output<Node> &in,
+                                                         const element::Type &weiType,
+                                                         const std::vector<size_t> &filterSize,
+                                                         const std::vector<size_t> &strides,
+                                                         const std::vector<ptrdiff_t> &padsBegin,
+                                                         const std::vector<ptrdiff_t> &padsEnd,
+                                                         const std::vector<size_t> &dilations,
+                                                         const op::PadType &autoPad,
+                                                         size_t numOutChannels,
+                                                         size_t numGroups,
+                                                         const std::vector<float> &filterWeights) {
+    auto inputParamsFP32 = ngraph::builder::makeParams(ngraph::element::f32, { in.get_shape() });
+    auto paramOutsFP32 = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(inputParamsFP32));
+
+    auto groupDeconvolutionNodeRelaxed = std::make_shared<op::TypeRelaxed<opset1::GroupConvolutionBackpropData>>(
+            *as_type_ptr<opset1::GroupConvolutionBackpropData>(ngraph::builder::makeGroupConvolutionBackpropData(
+                    paramOutsFP32.front(), ngraph::element::f32, filterSize, strides, padsBegin, padsEnd, dilations, autoPad,
+                    numOutChannels, numGroups)),
+            element::f32);
+
+    bool randomFilterWeights = filterWeights.empty();
+    auto shape = in.get_shape();
+    std::vector<size_t> filterWeightsShape = {shape[1], numOutChannels};
+    filterWeightsShape[0] /= numGroups;
+    filterWeightsShape[1] /= numGroups;
+    filterWeightsShape.insert(filterWeightsShape.begin(), numGroups);
+    filterWeightsShape.insert(filterWeightsShape.end(), filterSize.begin(), filterSize.end());
+    auto filterWeightsNode = makeConstant(weiType, filterWeightsShape, filterWeights, randomFilterWeights);
+
+    auto newGroupDeconvolution = groupDeconvolutionNodeRelaxed->copy_with_new_inputs({in, filterWeightsNode});
+
+    return newGroupDeconvolution;
+}
+
 }  // namespace builder
 }  // namespace ngraph


### PR DESCRIPTION
	1. extended cpu specific tests to support int8 presision

	2. added int8 fusing tests : convolution, deconvolution, fullyconnected

	3. added zeroPoints convolution tests

**TODO**
- [x] fill Convolution and GroupConvolution tests
- [x] fill ConvolutionBackpropData and GroupConvolutionBackpropData tests
- [ ] split tests into files depending on the precision (fp32, bf16, int8)
- [ ] add dw conv fusing tests for https://github.com/openvinotoolkit/openvino/pull/6333
- [ ] add tests for issue 63021
- [ ] add tests for issue 62549
- [ ] apply comments from PR https://github.com/openvinotoolkit/openvino/pull/6546