### PR TITLE
eliminate odd memory copy

### DIFF
--- a/inference-engine/samples/common/format_reader/opencv_wrapper.cpp
+++ b/inference-engine/samples/common/format_reader/opencv_wrapper.cpp
@@ -39,8 +39,8 @@ std::shared_ptr<unsigned char> OCVReader::getData(size_t width = 0, size_t heigh
     cv::Mat resized(width, height, img.type(), _data.get());
 
     if (width != img.cols || height != img.rows) {
-        slog::warn << "Image is resized from (" << img.cols << ", " << img.rows << ") to (" << width << ", " << height << ")"
-                   << slog::endl;
+        slog::warn << "Image is resized from (" << img.cols << ", " << img.rows << ") to (" << width << ", " << height
+                   << ")" << slog::endl;
     }
     // cv::resize() just copy data to output image if sizes are the same
     cv::resize(img, resized, cv::Size(width, height));


### PR DESCRIPTION
### Details:
 - *refresh PR #414* which intended to eliminate unnecessary data copy, when image is resized to match network input size. Note, it might be improved even further, if handle case when input image already corresponds to network size, but it seems to less probable case, so not implemented in favor of sample simplicity.
