### PR TITLE
'Convert': Fix for reference convert float->int8

### DIFF
--- a/docs/template_plugin/tests/functional/op_reference/convert.cpp
+++ b/docs/template_plugin/tests/functional/op_reference/convert.cpp
@@ -133,7 +133,7 @@ INSTANTIATE_TEST_SUITE_P(
                       std::vector<ngraph::float16> {-1, -2, 0, 3}, std::vector<int8_t> {-1, -2, 0, 3}),
         ConvertParams(ConversionTypes::CONVERT, ov::PartialShape {4}, ov::element::bf16, ov::element::i8,
                       std::vector<ngraph::bfloat16> {-1, -2, 0, 3}, std::vector<int8_t> {-1, -2, 0, 3}),
-        ConvertParams(ConversionTypes::CONVERT, ov::PartialShape {4}, ov::element::f32, ov::element::i8, std::vector<float> {-1, -2, 2, 3},
+        ConvertParams(ConversionTypes::CONVERT, ov::PartialShape {4}, ov::element::f32, ov::element::i8, std::vector<float> {-1, -2, 2.2, 3.8},
                       std::vector<int8_t> {-1, -2, 2, 3}),
         // destination i16
         ConvertParams(ConversionTypes::CONVERT, ov::PartialShape {8}, ov::element::u1, ov::element::i16, std::vector<uint8_t> {0x81},
@@ -162,7 +162,7 @@ INSTANTIATE_TEST_SUITE_P(
                       std::vector<ngraph::float16> {-1, -2, 0, 3}, std::vector<int16_t> {-1, -2, 0, 3}),
         ConvertParams(ConversionTypes::CONVERT, ov::PartialShape {4}, ov::element::bf16, ov::element::i16,
                       std::vector<ngraph::bfloat16> {-1, -2, 0, 3}, std::vector<int16_t> {-1, -2, 0, 3}),
-        ConvertParams(ConversionTypes::CONVERT, ov::PartialShape {4}, ov::element::f32, ov::element::i16, std::vector<float> {-1, -2, 2, 3},
+        ConvertParams(ConversionTypes::CONVERT, ov::PartialShape {4}, ov::element::f32, ov::element::i16, std::vector<float> {-1, -2, 2.2, 3.8},
                       std::vector<int16_t> {-1, -2, 2, 3}),
         // destination i32
         ConvertParams(ConversionTypes::CONVERT, ov::PartialShape {8}, ov::element::u1, ov::element::i32, std::vector<uint8_t> {0x81},
@@ -191,7 +191,7 @@ INSTANTIATE_TEST_SUITE_P(
                       std::vector<ngraph::float16> {-1, -2, 0, 3}, std::vector<int32_t> {-1, -2, 0, 3}),
         ConvertParams(ConversionTypes::CONVERT, ov::PartialShape {4}, ov::element::bf16, ov::element::i32,
                       std::vector<ngraph::bfloat16> {-1, -2, 0, 3}, std::vector<int32_t> {-1, -2, 0, 3}),
-        ConvertParams(ConversionTypes::CONVERT, ov::PartialShape {4}, ov::element::f32, ov::element::i32, std::vector<float> {-1, -2, 2, 3},
+        ConvertParams(ConversionTypes::CONVERT, ov::PartialShape {4}, ov::element::f32, ov::element::i32, std::vector<float> {-1, -2, 2.2, 3.8},
                       std::vector<int32_t> {-1, -2, 2, 3}),
         // destination i64
         ConvertParams(ConversionTypes::CONVERT, ov::PartialShape {8}, ov::element::u1, ov::element::i64, std::vector<uint8_t> {0x81},
@@ -220,7 +220,7 @@ INSTANTIATE_TEST_SUITE_P(
                       std::vector<ngraph::float16> {-1, -2, 0, 3}, std::vector<int64_t> {-1, -2, 0, 3}),
         ConvertParams(ConversionTypes::CONVERT, ov::PartialShape {4}, ov::element::bf16, ov::element::i64,
                       std::vector<ngraph::bfloat16> {-1, -2, 0, 3}, std::vector<int64_t> {-1, -2, 0, 3}),
-        ConvertParams(ConversionTypes::CONVERT, ov::PartialShape {4}, ov::element::f32, ov::element::i64, std::vector<float> {-1, -2, 2, 3},
+        ConvertParams(ConversionTypes::CONVERT, ov::PartialShape {4}, ov::element::f32, ov::element::i64, std::vector<float> {-1, -2, 2.2, 3.8},
                       std::vector<int64_t> {-1, -2, 2, 3}),
 
         // destination u1
@@ -310,7 +310,7 @@ INSTANTIATE_TEST_SUITE_P(
                       std::vector<uint8_t> {1, 2, 0, 3}),
         ConvertParams(ConversionTypes::CONVERT, ov::PartialShape {4}, ov::element::bf16, ov::element::u8,
                       std::vector<ngraph::bfloat16> {1, 2, 0, 3}, std::vector<uint8_t> {1, 2, 0, 3}),
-        ConvertParams(ConversionTypes::CONVERT, ov::PartialShape {4}, ov::element::f32, ov::element::u8, std::vector<float> {1, 2, 2, 3},
+        ConvertParams(ConversionTypes::CONVERT, ov::PartialShape {4}, ov::element::f32, ov::element::u8, std::vector<float> {1, 2, 2.2, 3.8},
                       std::vector<uint8_t> {1, 2, 2, 3}),
 
         // destination u16
@@ -340,7 +340,7 @@ INSTANTIATE_TEST_SUITE_P(
                       std::vector<uint16_t> {1, 2, 0, 3}),
         ConvertParams(ConversionTypes::CONVERT, ov::PartialShape {4}, ov::element::bf16, ov::element::u16,
                       std::vector<ngraph::bfloat16> {1, 2, 0, 3}, std::vector<uint16_t> {1, 2, 0, 3}),
-        ConvertParams(ConversionTypes::CONVERT, ov::PartialShape {4}, ov::element::f32, ov::element::u16, std::vector<float> {1, 2, 2, 3},
+        ConvertParams(ConversionTypes::CONVERT, ov::PartialShape {4}, ov::element::f32, ov::element::u16, std::vector<float> {1, 2, 2.2, 3.8},
                       std::vector<uint16_t> {1, 2, 2, 3}),
 
         // destination u32
@@ -370,7 +370,7 @@ INSTANTIATE_TEST_SUITE_P(
                       std::vector<uint32_t> {1, 2, 0, 3}),
         ConvertParams(ConversionTypes::CONVERT, ov::PartialShape {4}, ov::element::bf16, ov::element::u32,
                       std::vector<ngraph::bfloat16> {1, 2, 0, 3}, std::vector<uint32_t> {1, 2, 0, 3}),
-        ConvertParams(ConversionTypes::CONVERT, ov::PartialShape {4}, ov::element::f32, ov::element::u32, std::vector<float> {1, 2, 2, 3},
+        ConvertParams(ConversionTypes::CONVERT, ov::PartialShape {4}, ov::element::f32, ov::element::u32, std::vector<float> {1, 2, 2.2, 3.8},
                       std::vector<uint32_t> {1, 2, 2, 3}),
         // destination u64
         ConvertParams(ConversionTypes::CONVERT, ov::PartialShape {8}, ov::element::u1, ov::element::u64, std::vector<uint8_t> {0x81},
@@ -399,7 +399,7 @@ INSTANTIATE_TEST_SUITE_P(
                       std::vector<uint64_t> {1, 2, 0, 3}),
         ConvertParams(ConversionTypes::CONVERT, ov::PartialShape {4}, ov::element::bf16, ov::element::u64,
                       std::vector<ngraph::bfloat16> {1, 2, 0, 3}, std::vector<uint64_t> {1, 2, 0, 3}),
-        ConvertParams(ConversionTypes::CONVERT, ov::PartialShape {4}, ov::element::f32, ov::element::u64, std::vector<float> {1, 2, 2, 3},
+        ConvertParams(ConversionTypes::CONVERT, ov::PartialShape {4}, ov::element::f32, ov::element::u64, std::vector<float> {1, 2, 2.2, 3.8},
                       std::vector<uint64_t> {1, 2, 2, 3})),
     ReferenceConversionLayerTest::getTestCaseName);
 } // namespace

--- a/ngraph/core/reference/src/runtime/reference/convert.cpp
+++ b/ngraph/core/reference/src/runtime/reference/convert.cpp
@@ -60,7 +60,7 @@ void jit_convert_vec<float, int8_t>(jit::Generator& gen, const Xbyak::RegExp& sr
     auto p32vec_lo = gen.xmm2;
     auto p32vec_hi = gen.xmm3;
 
-    gen.vcvtps2dq(p32vec, gen.yword[src]);      // convert 8 floats to 8 ints
+    gen.vcvttps2dq(p32vec, gen.yword[src]);     // convert 8 floats to 8 ints
     gen.vpshufb(p32vec, p32vec, order);         // Shuffle the bytes according to the order
     gen.vextracti128(p32vec_hi, p32vec, 1);     // extract upper part of p32vec
     gen.vpor(p32vec_lo, p32vec_lo, p32vec_hi);  // p32vec_lo = p32vec_lo | p32vec_hi
@@ -80,7 +80,7 @@ void jit_convert_vec<float16, int8_t>(jit::Generator& gen, const Xbyak::RegExp& 
     auto p32vec_hi = gen.xmm3;
 
     gen.vcvtph2ps(p32vec, gen.xword[src]);      // convert 8 fp16's to 8 floats
-    gen.vcvtps2dq(p32vec, p32vec);              // convert 8 floats to 8 ints
+    gen.vcvttps2dq(p32vec, p32vec);             // convert 8 floats to 8 ints
     gen.vpshufb(p32vec, p32vec, order);         // Shuffle the bytes according to the order
     gen.vextracti128(p32vec_hi, p32vec, 1);     // extract upper part of p32vec
     gen.vpor(p32vec_lo, p32vec_lo, p32vec_hi);  // p32vec_lo = p32vec_lo | p32vec_hi


### PR DESCRIPTION
### Note
 - Same as PR #7713 but without changes in 'shared_tests' classes
 - There were discovered a lot of issues in 'CompareWithRefs' tests when generated float inputs are not rounded to 'int' (that's why I decided to create new PR and leave PR #7713 as draft for future references)

### Details:
 - Fix for convert float->int8 - reference implementation
 - Improved 'shared tests' for plugins to test conversion on non-round types (CPU is fine now, for GPU ticket is raised)

### Accuracy testing:
  - Accuracy testing has been performed. No deviations are observed
     - Code where 'convert' evaluate is called from LPT is here: https://github.com/openvinotoolkit/openvino/blob/b7ccdf4490d130573ba1a4e3c5325a765239e0b9/inference-engine/src/low_precision_transformations/src/network_helper.cpp#L494 - 'round' is already included there
     - On 'yolov5m' accuracy deviation is not happened due to fix, but due to other reasons. 

### Tickets:
 - 66520
