### PR TITLE
[GPU] Align queue type in engine config

### DIFF
--- a/inference-engine/src/cldnn_engine/cldnn_remote_context.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_remote_context.cpp
@@ -243,10 +243,13 @@ CLDNNExecutionContextImpl::CLDNNExecutionContextImpl(const std::shared_ptr<IInfe
                 (m_config.tuningConfig.mode == cldnn::tuning_mode::tuning_tune_and_cache) ||
                 (m_config.tuningConfig.mode == cldnn::tuning_mode::tuning_retune_and_cache));
         cldnn::queue_types queue_type;
-        if (dev->get_info().supports_immad)
+        if (m_external_queue) {
+            queue_type = cldnn::stream::detect_queue_type(engine_type, m_external_queue);
+        } else if (dev->get_info().supports_immad) {
             queue_type = cldnn::queue_types::in_order;
-        else
+        } else {
             queue_type = cldnn::queue_types::out_of_order;
+        }
 
         bool use_unified_shared_memory = true;
         m_engine = cldnn::engine::create(engine_type, runtime_type, dev, cldnn::engine_configuration(enable_profiling,

--- a/inference-engine/thirdparty/clDNN/api/cldnn/runtime/stream.hpp
+++ b/inference-engine/thirdparty/clDNN/api/cldnn/runtime/stream.hpp
@@ -41,6 +41,7 @@ public:
 
     queue_types get_queue_type() const { return queue_type; }
 
+    static queue_types detect_queue_type(engine_types engine_type, void* queue_handle);
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
     virtual dnnl::stream& get_onednn_stream() = 0;

--- a/inference-engine/thirdparty/clDNN/runtime/ocl/ocl_device_detector.cpp
+++ b/inference-engine/thirdparty/clDNN/runtime/ocl/ocl_device_detector.cpp
@@ -179,7 +179,7 @@ std::vector<device::ptr>  ocl_device_detector::create_device_list_from_user_cont
     for (auto& device : all_devices) {
         if (!does_device_match_config(out_out_order, device))
             continue;
-        ret.emplace_back(std::make_shared<ocl_device>(device, cl::Context(device), device.getInfo<CL_DEVICE_PLATFORM>()));
+        ret.emplace_back(std::make_shared<ocl_device>(device, ctx, device.getInfo<CL_DEVICE_PLATFORM>()));
     }
 
     if (ret.empty()) {

--- a/inference-engine/thirdparty/clDNN/runtime/ocl/ocl_stream.hpp
+++ b/inference-engine/thirdparty/clDNN/runtime/ocl/ocl_stream.hpp
@@ -80,6 +80,8 @@ public:
 
     const cl::UsmHelper& get_usm_helper() const { return _engine.get_usm_helper(); }
 
+    static queue_types detect_queue_type(void* queue_handle);
+
 #ifdef ENABLE_ONEDNN_FOR_GPU
     dnnl::stream& get_onednn_stream() override;
 #endif

--- a/inference-engine/thirdparty/clDNN/runtime/stream.cpp
+++ b/inference-engine/thirdparty/clDNN/runtime/stream.cpp
@@ -1,0 +1,20 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "cldnn/runtime/stream.hpp"
+
+#include "ocl/ocl_stream.hpp"
+
+#include <stdexcept>
+
+namespace cldnn {
+
+queue_types stream::detect_queue_type(engine_types engine_type, void* queue_handle) {
+    switch (engine_type) {
+        case engine_types::ocl: return ocl::ocl_stream::detect_queue_type(queue_handle);
+        default: throw std::runtime_error("Invalid engine type");
+    }
+}
+
+}  // namespace cldnn


### PR DESCRIPTION
### Details:
 - engine_configuration now uses queue_type extracted from user handle in case of queue sharing
 - context handle is not re-created in ocl_device_detector to allow sharing with onednn
 - follow up of comments for #6235
