### PR TITLE
Update existing functional tests to use pass::Manager

### DIFF
--- a/inference-engine/tests/functional/inference_engine/transformations/const_folding_for_if.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/const_folding_for_if.cpp
@@ -48,7 +48,9 @@ TEST(TransformationTests, if_constant_folding) {
         auto add = make_shared<op::v1::Add>(if_res, param_add);
         auto add_res = make_shared<op::Result>(add);
         fun = make_shared<Function>(OutputVector{ add_res }, ParameterVector{ param_add });
-        ngraph::pass::ConstantFolding().run_on_function(fun);
+        ngraph::pass::Manager manager;
+        manager.register_pass<ngraph::pass::ConstantFolding>();
+        manager.run_passes(fun);
     }
     std::shared_ptr<ngraph::Function> f_ref(nullptr);
     {

--- a/inference-engine/tests/functional/inference_engine/transformations/const_folding_for_if.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/const_folding_for_if.cpp
@@ -14,6 +14,7 @@
 #include "ngraph/opsets/opset8.hpp"
 #include <ngraph/pass/constant_folding.hpp>
 
+#include "../../../ngraph/core/include/ngraph/pass/manager.hpp"
 using namespace testing;
 using namespace std;
 using namespace ngraph;

--- a/inference-engine/tests/functional/inference_engine/transformations/const_folding_for_if.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/const_folding_for_if.cpp
@@ -14,7 +14,7 @@
 #include "ngraph/opsets/opset8.hpp"
 #include <ngraph/pass/constant_folding.hpp>
 
-#include "../../../ngraph/core/include/ngraph/pass/manager.hpp"
+#include <ngraph/pass/manager.hpp>
 using namespace testing;
 using namespace std;
 using namespace ngraph;

--- a/inference-engine/tests/functional/inference_engine/transformations/const_folding_prior_box.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/const_folding_prior_box.cpp
@@ -15,6 +15,7 @@
 #include <ngraph/pass/constant_folding.hpp>
 #include <ngraph/ops.hpp>
 #include "common_test_utils/ngraph_test_utils.hpp"
+#include "../../../ngraph/core/include/ngraph/pass/manager.hpp"
 
 using namespace testing;
 

--- a/inference-engine/tests/functional/inference_engine/transformations/const_folding_prior_box.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/const_folding_prior_box.cpp
@@ -15,7 +15,7 @@
 #include <ngraph/pass/constant_folding.hpp>
 #include <ngraph/ops.hpp>
 #include "common_test_utils/ngraph_test_utils.hpp"
-#include "../../../ngraph/core/include/ngraph/pass/manager.hpp"
+#include <ngraph/pass/manager.hpp>
 
 using namespace testing;
 

--- a/inference-engine/tests/functional/inference_engine/transformations/const_folding_prior_box.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/const_folding_prior_box.cpp
@@ -36,8 +36,10 @@ TEST(TransformationTests, ConstFoldingPriorBox) {
         auto pb = std::make_shared<ngraph::opset3::PriorBox>(layer_shape, image_shape, attrs);
         auto res = std::make_shared<ngraph::opset3::Result>(pb);
         f = std::make_shared<ngraph::Function>(ngraph::NodeVector{res}, ngraph::ParameterVector{in});
-        ngraph::pass::InitNodeInfo().run_on_function(f);
-        ngraph::pass::ConstantFolding().run_on_function(f);
+        ngraph::pass::Manager manager;
+        manager.register_pass<ngraph::pass::InitNodeInfo>();
+        manager.register_pass<ngraph::pass::ConstantFolding>();
+        manager.run_passes(f);
         ASSERT_NO_THROW(check_rt_info(f));
     }
 
@@ -78,8 +80,10 @@ TEST(TransformationTests, ConstFoldingPriorBoxClustered) {
         auto pb = std::make_shared<ngraph::opset3::PriorBoxClustered>(layer_shape, image_shape, attrs);
         auto res = std::make_shared<ngraph::opset3::Result>(pb);
         f = std::make_shared<ngraph::Function>(ngraph::NodeVector{res}, ngraph::ParameterVector{in});
-        ngraph::pass::InitNodeInfo().run_on_function(f);
-        ngraph::pass::ConstantFolding().run_on_function(f);
+        ngraph::pass::Manager manager;
+        manager.register_pass<ngraph::pass::InitNodeInfo>();
+        manager.register_pass<ngraph::pass::ConstantFolding>();
+        manager.run_passes(f);
         ASSERT_NO_THROW(check_rt_info(f));
     }
 
@@ -138,8 +142,10 @@ TEST(TransformationTests, ConstFoldingPriorBoxSubgraph) {
         auto pb = std::make_shared<ngraph::opset3::PriorBox>(ss_data, ss_image, attrs);
         auto res = std::make_shared<ngraph::opset3::Result>(pb);
         f = std::make_shared<ngraph::Function>(ngraph::NodeVector{res}, ngraph::ParameterVector{in, in_2});
-        ngraph::pass::InitNodeInfo().run_on_function(f);
-        ngraph::pass::ConstantFolding().run_on_function(f);
+        ngraph::pass::Manager manager;
+        manager.register_pass<ngraph::pass::InitNodeInfo>();
+        manager.register_pass<ngraph::pass::ConstantFolding>();
+        manager.run_passes(f);
         ASSERT_NO_THROW(check_rt_info(f));
     }
 
@@ -189,8 +195,10 @@ TEST(TransformationTests, ConstFoldingPriorBoxClusteredSubgraph) {
         auto pb = std::make_shared<ngraph::opset3::PriorBoxClustered>(ss_data, ss_image, attrs);
         auto res = std::make_shared<ngraph::opset3::Result>(pb);
         f = std::make_shared<ngraph::Function>(ngraph::NodeVector{res}, ngraph::ParameterVector{in, in_2});
-        ngraph::pass::InitNodeInfo().run_on_function(f);
-        ngraph::pass::ConstantFolding().run_on_function(f);
+        ngraph::pass::Manager manager;
+        manager.register_pass<ngraph::pass::InitNodeInfo>();
+        manager.register_pass<ngraph::pass::ConstantFolding>();
+        manager.run_passes(f);
         ASSERT_NO_THROW(check_rt_info(f));
     }
 

--- a/inference-engine/tests/functional/inference_engine/transformations/conv_fusion_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/conv_fusion_test.cpp
@@ -50,7 +50,9 @@ public:
             f_ref = get_initial_function(input_shape, weights_shape, eltwise_type, eltwise_shape);
         } else {
             f_ref = get_reference_function(input_shape, weights_shape, eltwise_type, eltwise_shape);
-            ngraph::pass::ConstantFolding().run_on_function(f_ref);
+            ngraph::pass::Manager manager;
+            manager.register_pass<ngraph::pass::ConstantFolding>();
+            manager.run_passes(f_ref);
         }
     }
 

--- a/inference-engine/tests/functional/inference_engine/transformations/conv_fusion_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/conv_fusion_test.cpp
@@ -23,6 +23,8 @@
 
 #include "common_test_utils/ngraph_test_utils.hpp"
 
+#include "../../../ngraph/core/include/ngraph/pass/manager.hpp"
+
 using namespace ngraph;
 using namespace testing;
 

--- a/inference-engine/tests/functional/inference_engine/transformations/conv_fusion_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/conv_fusion_test.cpp
@@ -23,7 +23,7 @@
 
 #include "common_test_utils/ngraph_test_utils.hpp"
 
-#include "../../../ngraph/core/include/ngraph/pass/manager.hpp"
+#include <ngraph/pass/manager.hpp>
 
 using namespace ngraph;
 using namespace testing;

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_convolution_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_convolution_test.cpp
@@ -71,7 +71,7 @@ private:
 };
 
 TEST_P(ConvertConvolutionTest, CompareFunctions) {
-    const auto & orig_shape = f->get_output_partial_shape(0);
+    const auto orig_shape = f->get_output_partial_shape(0);
     pass::Manager manager;
     manager.register_pass<pass::InitNodeInfo>();
     manager.register_pass<pass::ConvertConvolutions>();

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_convolution_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_convolution_test.cpp
@@ -24,6 +24,8 @@
 
 #include "common_test_utils/ngraph_test_utils.hpp"
 
+#include "../../../ngraph/core/include/ngraph/pass/manager.hpp"
+
 using namespace testing;
 using namespace ngraph;
 using namespace ngraph::opset1;

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_convolution_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_convolution_test.cpp
@@ -72,8 +72,11 @@ private:
 
 TEST_P(ConvertConvolutionTest, CompareFunctions) {
     const auto & orig_shape = f->get_output_partial_shape(0);
-    pass::InitNodeInfo().run_on_function(f);
-    pass::ConvertConvolutions().run_on_function(f);
+    pass::Manager manager;
+    manager.register_pass<pass::InitNodeInfo>();
+    manager.register_pass<pass::ConvertConvolutions>();
+    manager.run_passes(f);
+
     ASSERT_NO_THROW(check_rt_info(f));
     auto res = compare_functions(f, f_ref);
     ASSERT_TRUE(res.first) << res.second;

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_convolution_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_convolution_test.cpp
@@ -24,7 +24,7 @@
 
 #include "common_test_utils/ngraph_test_utils.hpp"
 
-#include "../../../ngraph/core/include/ngraph/pass/manager.hpp"
+#include <ngraph/pass/manager.hpp>
 
 using namespace testing;
 using namespace ngraph;

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_deconvolution_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_deconvolution_test.cpp
@@ -67,7 +67,7 @@ private:
 };
 
 TEST_P(ConvertDeconvolutionTest, CompareFunctions) {
-    const auto & orig_shape = f->get_output_partial_shape(0);
+    const auto orig_shape = f->get_output_partial_shape(0);
     ngraph::pass::Manager manager;
     manager.register_pass<ngraph::pass::InitNodeInfo>();
     manager.register_pass<ngraph::pass::ConvertConvolutions>();

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_deconvolution_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_deconvolution_test.cpp
@@ -24,6 +24,8 @@
 
 #include "common_test_utils/ngraph_test_utils.hpp"
 
+#include "../../../ngraph/core/include/ngraph/pass/manager.hpp"
+
 using namespace testing;
 
 using InputShape = ngraph::PartialShape;

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_deconvolution_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_deconvolution_test.cpp
@@ -68,8 +68,10 @@ private:
 
 TEST_P(ConvertDeconvolutionTest, CompareFunctions) {
     const auto & orig_shape = f->get_output_partial_shape(0);
-    ngraph::pass::InitNodeInfo().run_on_function(f);
-    ngraph::pass::ConvertConvolutions().run_on_function(f);
+    ngraph::pass::Manager manager;
+    manager.register_pass<ngraph::pass::InitNodeInfo>();
+    manager.register_pass<ngraph::pass::ConvertConvolutions>();
+    manager.run_passes(f);
     ASSERT_NO_THROW(check_rt_info(f));
     auto res = compare_functions(f, f_ref);
     ASSERT_TRUE(res.first) << res.second;

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_deconvolution_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_deconvolution_test.cpp
@@ -24,7 +24,7 @@
 
 #include "common_test_utils/ngraph_test_utils.hpp"
 
-#include "../../../ngraph/core/include/ngraph/pass/manager.hpp"
+#include <ngraph/pass/manager.hpp>
 
 using namespace testing;
 

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_ngraph_to_cnn_network_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_ngraph_to_cnn_network_tests.cpp
@@ -38,7 +38,9 @@ TEST(ConvertFunctionToCNNNetworkTests, ConvertPReLUNetwork) {
 
         f = std::make_shared<ngraph::Function>(ngraph::ResultVector{result},
                                                ngraph::ParameterVector{param1, param2});
-        ngraph::pass::InitNodeInfo().run_on_function(f);
+        ngraph::pass::Manager manager;
+        manager.register_pass<ngraph::pass::InitNodeInfo>();
+        manager.run_passes(f);
     }
 
     InferenceEngine::CNNNetwork nGraphImpl(f);
@@ -67,7 +69,9 @@ TEST(ConvertFunctionToCNNNetworkTests, ConvertConvolutionNetwork) {
 
         f = std::make_shared<ngraph::Function>(ngraph::ResultVector{result},
                                                ngraph::ParameterVector{param1, param2});
-        ngraph::pass::InitNodeInfo().run_on_function(f);
+        ngraph::pass::Manager manager;
+        manager.register_pass<ngraph::pass::InitNodeInfo>();
+        manager.run_passes(f);
     }
 
     InferenceEngine::CNNNetwork nGraphImpl(f);
@@ -163,7 +167,9 @@ TEST(ConvertFunctionToCNNNetworkTests, ConvertTopKWithOneInput) {
 
         f = std::make_shared<ngraph::Function>(ngraph::ResultVector{result},
                                                ngraph::ParameterVector{param});
-        ngraph::pass::InitNodeInfo().run_on_function(f);
+        ngraph::pass::Manager manager;
+        manager.register_pass<ngraph::pass::InitNodeInfo>();
+        manager.run_passes(f);
     }
 
     ngraph::pass::Manager manager;

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_ngraph_to_cnn_network_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_ngraph_to_cnn_network_tests.cpp
@@ -24,7 +24,7 @@
 #include <transformations/init_node_info.hpp>
 #include <legacy/convert_function_to_cnn_network.hpp>
 
-#include "../../../ngraph/core/include/ngraph/pass/manager.hpp"
+#include <ngraph/pass/manager.hpp>
 
 using namespace testing;
 using namespace InferenceEngine;

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_ngraph_to_cnn_network_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_ngraph_to_cnn_network_tests.cpp
@@ -24,6 +24,8 @@
 #include <transformations/init_node_info.hpp>
 #include <legacy/convert_function_to_cnn_network.hpp>
 
+#include "../../../ngraph/core/include/ngraph/pass/manager.hpp"
+
 using namespace testing;
 using namespace InferenceEngine;
 

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_reduce_to_pooling_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_reduce_to_pooling_test.cpp
@@ -149,7 +149,9 @@ INSTANTIATE_TEST_SUITE_P(ReduceToReshapePoolReshape, ConvertReduceToPoolingTests
 
 TEST(ConvertReduceToPooling, Negative) {
     auto f = ConvertReduceToPoolingTests::get_initial_function(ngraph::PartialShape::dynamic(), {3}, MAX, true);
-    ASSERT_NO_THROW(ngraph::pass::ConvertReduceToPooling().run_on_function(f));
+    ngraph::pass::Manager manager;
+    manager.register_pass<ngraph::pass::ConvertReduceToPooling>();
+    ASSERT_NO_THROW(manager.run_passes(f));
 }
 
 #undef MAX

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_reduce_to_pooling_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_reduce_to_pooling_test.cpp
@@ -21,6 +21,8 @@
 
 #include "common_test_utils/ngraph_test_utils.hpp"
 
+#include "../../../ngraph/core/include/ngraph/pass/manager.hpp"
+
 using namespace testing;
 
 using InputShape = ngraph::PartialShape;

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_reduce_to_pooling_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_reduce_to_pooling_test.cpp
@@ -21,7 +21,7 @@
 
 #include "common_test_utils/ngraph_test_utils.hpp"
 
-#include "../../../ngraph/core/include/ngraph/pass/manager.hpp"
+#include <ngraph/pass/manager.hpp>
 
 using namespace testing;
 

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_scatter_elements_to_scatter_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_scatter_elements_to_scatter_test.cpp
@@ -22,6 +22,8 @@
 
 #include "common_test_utils/ngraph_test_utils.hpp"
 
+#include "../../../ngraph/core/include/ngraph/pass/manager.hpp"
+
 using namespace testing;
 
 std::shared_ptr<ngraph::Function> get_initial_function(const ngraph::PartialShape & data_shape,

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_scatter_elements_to_scatter_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_scatter_elements_to_scatter_test.cpp
@@ -82,9 +82,11 @@ void test(std::shared_ptr<ngraph::Function> f, std::shared_ptr<ngraph::Function>
     manager.register_pass<ngraph::pass::InitNodeInfo>();
     manager.register_pass<ngraph::pass::ConvertScatterElementsToScatter>();
     manager.register_pass<ngraph::pass::CheckUniqueNames>(unh);
-    manager.run_passes(f);
-    ASSERT_NO_THROW(check_rt_info(f));
-    ngraph::pass::ConstantFolding().run_on_function(f);
+    manager.register_pass<ngraph::pass::InjectionPass>([](std::shared_ptr<ngraph::Function> f) {
+        check_rt_info(f);
+    });
+    manager.register_pass<ngraph::pass::ConstantFolding>();
+    ASSERT_NO_THROW(manager.run_passes(f));
 
     auto fc = FunctionsComparator::no_default().enable(FunctionsComparator::PRECISIONS);
     auto res = fc.compare(f, f_ref);

--- a/inference-engine/tests/functional/inference_engine/transformations/convert_scatter_elements_to_scatter_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/convert_scatter_elements_to_scatter_test.cpp
@@ -22,7 +22,7 @@
 
 #include "common_test_utils/ngraph_test_utils.hpp"
 
-#include "../../../ngraph/core/include/ngraph/pass/manager.hpp"
+#include <ngraph/pass/manager.hpp>
 
 using namespace testing;
 

--- a/inference-engine/tests/functional/inference_engine/transformations/keep_constant_inputs_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/keep_constant_inputs_tests.cpp
@@ -23,6 +23,8 @@
 #include <transformations/opset_conversions/convert_opset3_to_opset2.hpp>
 #include "shared_test_classes/base/low_precision_transformations/layer_transformation.hpp"
 
+#include "../../../ngraph/core/include/ngraph/pass/manager.hpp"
+
 using namespace testing;
 using namespace InferenceEngine;
 

--- a/inference-engine/tests/functional/inference_engine/transformations/keep_constant_inputs_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/keep_constant_inputs_tests.cpp
@@ -44,10 +44,12 @@ int numberOfInputsForLayerInCNNNetwork(const InferenceEngine::CNNNetwork & netwo
 void transformNetwork(InferenceEngine::CNNNetwork & clonedNetwork, bool keep_constant_inputs) {
     if (clonedNetwork.getFunction()) {
         auto nGraphFunc = clonedNetwork.getFunction();
-        ngraph::pass::CommonOptimizations().run_on_function(nGraphFunc);
-        ngraph::pass::ConvertOpSet3ToOpSet2().run_on_function(nGraphFunc);
-        ngraph::pass::ConvertOpSet2ToOpSet1().run_on_function(nGraphFunc);
-        ngraph::pass::ConvertOpSet1ToLegacy().run_on_function(nGraphFunc);
+        ngraph::pass::Manager manager;
+        manager.register_pass<ngraph::pass::CommonOptimizations>();
+        manager.register_pass<ngraph::pass::ConvertOpSet3ToOpSet2>();
+        manager.register_pass<ngraph::pass::ConvertOpSet2ToOpSet1>();
+        manager.register_pass<ngraph::pass::ConvertOpSet1ToLegacy>();
+        manager.run_passes(nGraphFunc);
         IE_SUPPRESS_DEPRECATED_START
         clonedNetwork = InferenceEngine::CNNNetwork(
             InferenceEngine::details::convertFunctionToICNNNetwork(nGraphFunc, clonedNetwork, keep_constant_inputs));

--- a/inference-engine/tests/functional/inference_engine/transformations/keep_constant_inputs_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/keep_constant_inputs_tests.cpp
@@ -23,7 +23,7 @@
 #include <transformations/opset_conversions/convert_opset3_to_opset2.hpp>
 #include "shared_test_classes/base/low_precision_transformations/layer_transformation.hpp"
 
-#include "../../../ngraph/core/include/ngraph/pass/manager.hpp"
+#include <ngraph/pass/manager.hpp>
 
 using namespace testing;
 using namespace InferenceEngine;

--- a/inference-engine/tests/functional/inference_engine/transformations/mul_add_conversion_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/mul_add_conversion_test.cpp
@@ -148,9 +148,11 @@ TEST_P(MulAddConversionTests, CompareFunctions) {
     manager.register_pass<ngraph::pass::InitNodeInfo>();
     manager.register_pass<ngraph::pass::ConvertMulAddToScaleShiftOrPower>();
     manager.register_pass<ngraph::pass::CheckUniqueNames>(unh);
-    manager.run_passes(f);
-    ASSERT_NO_THROW(check_rt_info(f));
-    ngraph::pass::ConstantFolding().run_on_function(f);
+    manager.register_pass<ngraph::pass::InjectionPass>([](std::shared_ptr<ngraph::Function> f) {
+        check_rt_info(f);
+    });
+    manager.register_pass<ngraph::pass::ConstantFolding>();
+    ASSERT_NO_THROW(manager.run_passes(f));
     f->validate_nodes_and_infer_types();
 
     auto fc = FunctionsComparator::no_default().enable(FunctionsComparator::PRECISIONS);
@@ -166,9 +168,12 @@ TEST_P(MulOrAddConversionTests, CompareFunctions) {
     manager.register_pass<ngraph::pass::InitNodeInfo>();
     manager.register_pass<ngraph::pass::ConvertMulOrAddFinally>();
     manager.register_pass<ngraph::pass::CheckUniqueNames>(unh);
-    manager.run_passes(f);
-    ASSERT_NO_THROW(check_rt_info(f));
-    ngraph::pass::ConstantFolding().run_on_function(f);
+    manager.register_pass<ngraph::pass::InjectionPass>([](std::shared_ptr<ngraph::Function> f) {
+        check_rt_info(f);
+    });
+    manager.register_pass<ngraph::pass::ConstantFolding>();
+    ASSERT_NO_THROW(manager.run_passes(f));
+
     f->validate_nodes_and_infer_types();
 
     auto fc = FunctionsComparator::no_default().enable(FunctionsComparator::PRECISIONS);

--- a/inference-engine/tests/functional/inference_engine/transformations/mul_add_conversion_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/mul_add_conversion_test.cpp
@@ -28,6 +28,8 @@
 #include "common_test_utils/ngraph_test_utils.hpp"
 #include "lpt_ngraph_functions/common/builders.hpp"
 
+#include "../../../ngraph/core/include/ngraph/pass/manager.hpp"
+
 using namespace testing;
 
 using InputShape = ngraph::PartialShape;

--- a/inference-engine/tests/functional/inference_engine/transformations/mul_add_conversion_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/mul_add_conversion_test.cpp
@@ -28,7 +28,7 @@
 #include "common_test_utils/ngraph_test_utils.hpp"
 #include "lpt_ngraph_functions/common/builders.hpp"
 
-#include "../../../ngraph/core/include/ngraph/pass/manager.hpp"
+#include <ngraph/pass/manager.hpp>
 
 using namespace testing;
 

--- a/inference-engine/tests/functional/inference_engine/transformations/ngraph_1d_ops_reshape_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/ngraph_1d_ops_reshape_test.cpp
@@ -36,10 +36,14 @@ TEST(TransformationTests, ConvReshapeTest1) {
         auto conv = std::make_shared<ngraph::op::ConvolutionIE>(input, w, strides, dilations, pads_begin, pads_end, ngraph::element::f32, 1);
 
         f = std::make_shared<ngraph::Function>(ngraph::NodeVector{conv}, ngraph::ParameterVector{});
-        ngraph::pass::InitNodeInfo().run_on_function(f);
-        ngraph::pass::Reshape1DOps().run_on_function(f);
-        ASSERT_NO_THROW(check_rt_info(f));
-        ngraph::pass::ConstantFolding().run_on_function(f);
+        ngraph::pass::Manager manager;
+        manager.register_pass<ngraph::pass::InitNodeInfo>();
+        manager.register_pass<ngraph::pass::Reshape1DOps>();
+        manager.register_pass<ngraph::pass::InjectionPass>([](std::shared_ptr<ngraph::Function> f) {
+            check_rt_info(f);
+        });
+        manager.register_pass<ngraph::pass::ConstantFolding>();
+        ASSERT_NO_THROW(manager.run_passes(f));
     }
 
     std::vector<size_t> ref_shape{1, 6, 1, 62};
@@ -69,10 +73,14 @@ TEST(TransformationTests, ConvBiasReshapeTest1) {
         auto conv = std::make_shared<ngraph::op::ConvolutionIE>(input, w, b, strides, dilations, pads_begin, pads_end, ngraph::element::f32, 1);
 
         f = std::make_shared<ngraph::Function>(ngraph::NodeVector{conv}, ngraph::ParameterVector{});
-        ngraph::pass::InitNodeInfo().run_on_function(f);
-        ngraph::pass::Reshape1DOps().run_on_function(f);
-        ASSERT_NO_THROW(check_rt_info(f));
-        ngraph::pass::ConstantFolding().run_on_function(f);
+        ngraph::pass::Manager manager;
+        manager.register_pass<ngraph::pass::InitNodeInfo>();
+        manager.register_pass<ngraph::pass::Reshape1DOps>();
+        manager.register_pass<ngraph::pass::InjectionPass>([](std::shared_ptr<ngraph::Function> f) {
+            check_rt_info(f);
+        });
+        manager.register_pass<ngraph::pass::ConstantFolding>();
+        ASSERT_NO_THROW(manager.run_passes(f));
     }
 
     std::vector<size_t> ref_shape{1, 6, 1, 62};

--- a/inference-engine/tests/functional/inference_engine/transformations/ngraph_1d_ops_reshape_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/ngraph_1d_ops_reshape_test.cpp
@@ -21,6 +21,8 @@
 #include <ngraph/pass/manager.hpp>
 #include "common_test_utils/ngraph_test_utils.hpp"
 
+#include "../../../ngraph/core/include/ngraph/pass/manager.hpp"
+
 using namespace testing;
 using namespace ngraph;
 

--- a/inference-engine/tests/functional/inference_engine/transformations/ngraph_1d_ops_reshape_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/ngraph_1d_ops_reshape_test.cpp
@@ -21,7 +21,7 @@
 #include <ngraph/pass/manager.hpp>
 #include "common_test_utils/ngraph_test_utils.hpp"
 
-#include "../../../ngraph/core/include/ngraph/pass/manager.hpp"
+#include <ngraph/pass/manager.hpp>
 
 using namespace testing;
 using namespace ngraph;

--- a/inference-engine/tests/functional/inference_engine/transformations/nop_elimination.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/nop_elimination.cpp
@@ -21,6 +21,8 @@
 
 #include "common_test_utils/ngraph_test_utils.hpp"
 
+#include "../../../ngraph/core/include/ngraph/pass/manager.hpp"
+
 using namespace ngraph;
 using namespace std;
 

--- a/inference-engine/tests/functional/inference_engine/transformations/nop_elimination.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/nop_elimination.cpp
@@ -559,7 +559,9 @@ TEST(nop_elimination, unsqueeze_squeeze_elimination) {
     auto check_usecase = [&](const Shape& shape, const std::vector<int64_t>& axes_val) {
         auto baseline_f = generate_func(shape, axes_val);
         auto optimized_f = generate_func(shape, axes_val);
-        pass::NopElimination().run_on_function(optimized_f);
+        ngraph::pass::Manager manager;
+        manager.register_pass<ngraph::pass::NopElimination>();
+        manager.run_passes(optimized_f);
 
         ASSERT_EQ(count_ops_of_type<op::v0::Squeeze>(baseline_f), 1);
         ASSERT_EQ(count_ops_of_type<op::v0::Unsqueeze>(baseline_f), 1);
@@ -589,7 +591,9 @@ TEST(nop_elimination, reshape_unsqueeze_elimination) {
         auto B1 = make_shared<op::v0::Unsqueeze>(B, axes);
         auto baseline_f = make_shared<Function>(make_shared<op::v0::Abs>(B1), ParameterVector{A});
         auto optimized_f = clone_function(*baseline_f);
-        pass::NopElimination().run_on_function(optimized_f);
+        ngraph::pass::Manager manager;
+        manager.register_pass<ngraph::pass::NopElimination>();
+        manager.run_passes(optimized_f);
 
         ASSERT_EQ(count_ops_of_type<op::v1::Reshape>(baseline_f), 1);
         ASSERT_EQ(count_ops_of_type<op::v0::Unsqueeze>(baseline_f), 1);
@@ -618,7 +622,9 @@ TEST(nop_elimination, reshape_squeeze_elimination) {
         auto B1 = make_shared<op::v0::Squeeze>(B, axes);
         auto baseline_f = make_shared<Function>(make_shared<op::v0::Abs>(B1), ParameterVector{A});
         auto optimized_f = clone_function(*baseline_f);
-        pass::NopElimination().run_on_function(optimized_f);
+        ngraph::pass::Manager manager;
+        manager.register_pass<ngraph::pass::NopElimination>();
+        manager.run_passes(optimized_f);
 
         ASSERT_EQ(count_ops_of_type<op::v1::Reshape>(baseline_f), 1);
         ASSERT_EQ(count_ops_of_type<op::v0::Squeeze>(baseline_f), 1);
@@ -644,7 +650,9 @@ TEST(nop_elimination, reshape_reshape_elimination) {
         auto B1 = make_shared<op::v1::Reshape>(B, pat2, true);
         auto baseline_f = make_shared<Function>(make_shared<op::v0::Abs>(B1), ParameterVector{A});
         auto optimized_f = clone_function(*baseline_f);
-        pass::NopElimination().run_on_function(optimized_f);
+        ngraph::pass::Manager manager;
+        manager.register_pass<ngraph::pass::NopElimination>();
+        manager.run_passes(optimized_f);
 
         ASSERT_EQ(count_ops_of_type<op::v1::Reshape>(baseline_f), 2);
         ASSERT_EQ(count_ops_of_type<op::v1::Reshape>(optimized_f), 1);
@@ -669,7 +677,9 @@ TEST(nop_elimination, squeeze_reshape_elimination) {
         auto B1 = make_shared<op::v1::Reshape>(B, pat2, false);
         auto baseline_f = make_shared<Function>(make_shared<op::v0::Abs>(B1), ParameterVector{A});
         auto optimized_f = clone_function(*baseline_f);
-        pass::NopElimination().run_on_function(optimized_f);
+        ngraph::pass::Manager manager;
+        manager.register_pass<ngraph::pass::NopElimination>();
+        manager.run_passes(optimized_f);
 
         ASSERT_EQ(count_ops_of_type<op::v1::Reshape>(baseline_f), 1);
         ASSERT_EQ(count_ops_of_type<op::v0::Squeeze>(baseline_f), 1);
@@ -695,7 +705,9 @@ TEST(nop_elimination, unsqueeze_reshape_elimination) {
         auto B1 = make_shared<op::v1::Reshape>(B, pat2, false);
         auto baseline_f = make_shared<Function>(make_shared<op::v0::Abs>(B1), ParameterVector{A});
         auto optimized_f = clone_function(*baseline_f);
-        pass::NopElimination().run_on_function(optimized_f);
+        ngraph::pass::Manager manager;
+        manager.register_pass<ngraph::pass::NopElimination>();
+        manager.run_passes(optimized_f);
 
         ASSERT_EQ(count_ops_of_type<op::v1::Reshape>(baseline_f), 1);
         ASSERT_EQ(count_ops_of_type<op::v0::Unsqueeze>(baseline_f), 1);
@@ -716,8 +728,9 @@ TEST(nop_elimination, squeeze_unsqueeze_elimination_negative) {
         auto squeeze = make_shared<ngraph::opset1::Squeeze>(input, indices);
         auto baseline_f = make_shared<Function>(squeeze, ParameterVector{input});
         auto optimized_f = clone_function(*baseline_f);
-        pass::NopElimination().run_on_function(optimized_f);
-
+        ngraph::pass::Manager manager;
+        manager.register_pass<ngraph::pass::NopElimination>();
+        manager.run_passes(optimized_f);
         ASSERT_EQ(count_ops_of_type<ngraph::opset1::Squeeze>(baseline_f), 1);
         ASSERT_EQ(count_ops_of_type<ngraph::opset1::Squeeze>(optimized_f), 1);
     };
@@ -733,7 +746,9 @@ TEST(nop_elimination, topk_convert_elimination) {
         auto C = make_shared<op::Convert>(B->output(0), B->output(0).get_element_type());
         auto baseline_f = make_shared<Function>(make_shared<op::v0::Abs>(C), ParameterVector{A});
         auto optimized_f = clone_function(*baseline_f);
-        pass::NopElimination().run_on_function(optimized_f);
+        ngraph::pass::Manager manager;
+        manager.register_pass<ngraph::pass::NopElimination>();
+        manager.run_passes(optimized_f);
 
         ASSERT_EQ(count_ops_of_type<op::Convert>(baseline_f), 1);
         ASSERT_EQ(count_ops_of_type<op::Convert>(optimized_f), 0);

--- a/inference-engine/tests/functional/inference_engine/transformations/nop_elimination.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/nop_elimination.cpp
@@ -21,7 +21,7 @@
 
 #include "common_test_utils/ngraph_test_utils.hpp"
 
-#include "../../../ngraph/core/include/ngraph/pass/manager.hpp"
+#include <ngraph/pass/manager.hpp>
 
 using namespace ngraph;
 using namespace std;

--- a/inference-engine/tests/functional/inference_engine/transformations/type_relaxed_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/type_relaxed_tests.cpp
@@ -8,6 +8,7 @@
 #include <ngraph/pass/constant_folding.hpp>
 #include <ngraph_ops/type_relaxed.hpp>
 
+#include "../../../ngraph/core/include/ngraph/pass/manager.hpp"
 
 namespace element = ngraph::element;
 using std::make_shared;

--- a/inference-engine/tests/functional/inference_engine/transformations/type_relaxed_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/type_relaxed_tests.cpp
@@ -328,8 +328,9 @@ TEST_F(TypeRelaxedTests, ConstantFoldingCheck) {
         auto relaxed_equal = make_shared<ngraph::op::TypeRelaxed<ngraph::opset1::Equal>>(equal, TypeVector{}, TypeVector{ element::u8 });
 
         f = make_shared<ngraph::Function>(ngraph::OutputVector{ relaxed_equal }, ngraph::ParameterVector{});
-
-        ASSERT_NO_THROW(ngraph::pass::ConstantFolding().run_on_function(f));
+        ngraph::pass::Manager manager;
+        manager.register_pass<ngraph::pass::ConstantFolding>();
+        ASSERT_NO_THROW(manager.run_passes(f));
         auto layer_before_result = f->get_result()->get_input_node_shared_ptr(0);
         ASSERT_TRUE(ngraph::is_type<ngraph::opset1::Constant>(layer_before_result));
     }
@@ -344,8 +345,9 @@ TEST_F(TypeRelaxedTests, ConstantFoldingCheck1) {
         auto relaxed_equal = make_shared<ngraph::op::TypeRelaxed<ngraph::opset1::Equal>>(equal, TypeVector{}, TypeVector{ element::boolean });
 
         f = make_shared<ngraph::Function>(ngraph::OutputVector{ relaxed_equal }, ngraph::ParameterVector{});
-
-        ASSERT_NO_THROW(ngraph::pass::ConstantFolding().run_on_function(f));
+        ngraph::pass::Manager manager;
+        manager.register_pass<ngraph::pass::ConstantFolding>();
+        ASSERT_NO_THROW(manager.run_passes(f));
         auto layer_before_result = f->get_result()->get_input_node_shared_ptr(0);
         ASSERT_TRUE(ngraph::is_type<ngraph::opset1::Constant>(layer_before_result));
     }
@@ -365,8 +367,9 @@ TEST_F(TypeRelaxedTests, ConstantFoldingCheck2) {
             ngraph::op::TemporaryReplaceOutputType(const2, element::i32).get());
 
         f = make_shared<ngraph::Function>(ngraph::OutputVector{ relaxed_equal }, ngraph::ParameterVector{});
-
-        ASSERT_NO_THROW(ngraph::pass::ConstantFolding().run_on_function(f));
+        ngraph::pass::Manager manager;
+        manager.register_pass<ngraph::pass::ConstantFolding>();
+        ASSERT_NO_THROW(manager.run_passes(f));
         auto layer_before_result = f->get_result()->get_input_node_shared_ptr(0);
         ASSERT_TRUE(ngraph::is_type<ngraph::opset1::Constant>(layer_before_result));
     }
@@ -383,8 +386,9 @@ TEST_F(TypeRelaxedTests, ConstantFoldingCheck3) {
         auto relaxed_equal = make_shared<ngraph::op::TypeRelaxed<ngraph::opset1::Equal>>(equal, original_input_types, TypeVector{ element::u8 });
 
         f = make_shared<ngraph::Function>(ngraph::OutputVector{ relaxed_equal }, ngraph::ParameterVector{});
-
-        ASSERT_NO_THROW(ngraph::pass::ConstantFolding().run_on_function(f));
+        ngraph::pass::Manager manager;
+        manager.register_pass<ngraph::pass::ConstantFolding>();
+        ASSERT_NO_THROW(manager.run_passes(f));
         auto layer_before_result = f->get_result()->get_input_node_shared_ptr(0);
         ASSERT_TRUE(ngraph::is_type<ngraph::opset1::Constant>(layer_before_result));
     }

--- a/inference-engine/tests/functional/inference_engine/transformations/type_relaxed_tests.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/type_relaxed_tests.cpp
@@ -8,7 +8,7 @@
 #include <ngraph/pass/constant_folding.hpp>
 #include <ngraph_ops/type_relaxed.hpp>
 
-#include "../../../ngraph/core/include/ngraph/pass/manager.hpp"
+#include <ngraph/pass/manager.hpp>
 
 namespace element = ngraph::element;
 using std::make_shared;


### PR DESCRIPTION
### Details:
 - updated tests in "inference-engine/tests/functional/inference_engine/transformations/" directory 
 - change all run_on_function execution to execution with pass::Manager
 - 14/18 test failed in "convert_convolution_test.cpp" probably because validation in pass::Manager 
 - 10/16 test failed in "convert_deconvolution_test.cpp" probably because validation in pass::Manager

### Tickets:
 - 68833
