### PR TITLE
[IE Transformations] Disable pull_transpose_through_fq transformation for activations path

### DIFF
--- a/inference-engine/src/transformations/src/transformations/common_optimizations/pull_transpose_through_fq.cpp
+++ b/inference-engine/src/transformations/src/transformations/common_optimizations/pull_transpose_through_fq.cpp
@@ -17,7 +17,8 @@ NGRAPH_RTTI_DEFINITION(ngraph::pass::PullTransposeThroughFQUp, "PullTransposeThr
 
 ngraph::pass::PullTransposeThroughFQUp::PullTransposeThroughFQUp() {
     MATCHER_SCOPE(PullTransposeThroughFQUp);
-    auto m_fq = pattern::wrap_type<opset1::FakeQuantize>({pattern::any_input(pattern::has_static_rank()),
+    const auto weights = ngraph::pattern::wrap_type<ngraph::opset1::Constant>();
+    auto m_fq = pattern::wrap_type<opset1::FakeQuantize>({weights,
                                                           pattern::any_input(pattern::has_static_shape()),
                                                           pattern::any_input(pattern::has_static_shape()),
                                                           pattern::any_input(pattern::has_static_shape()),

--- a/inference-engine/tests/functional/inference_engine/transformations/ngraph_fq_transpose_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/ngraph_fq_transpose_test.cpp
@@ -56,7 +56,7 @@ TEST_F(TransformationTestsF, FQTransposeTest1) {
     }
 }
 
-TEST(TransformationTests, FQTransposeNegativeCase) {
+TEST_F(TransformationTestsF, FQTransposeNegativeCase) {
     auto create_graph = []() -> std::shared_ptr<ngraph::Function> {
         auto data = std::make_shared<ngraph::op::Parameter>(ngraph::element::f32, ngraph::PartialShape{1, 3, 1});
         auto sigmoid = std::make_shared<ngraph::op::Sigmoid>(data);
@@ -85,7 +85,7 @@ TEST(TransformationTests, FQTransposeNegativeCase) {
     ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(TransformationTests, FQTransposeDynamic) {
+TEST_F(TransformationTestsF, FQTransposeDynamic) {
     auto data = std::make_shared<ngraph::op::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic());
     auto input_low = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {2});
     auto input_high = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {3});

--- a/inference-engine/tests/functional/inference_engine/transformations/ngraph_fq_transpose_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/ngraph_fq_transpose_test.cpp
@@ -56,6 +56,35 @@ TEST_F(TransformationTestsF, FQTransposeTest1) {
     }
 }
 
+TEST(TransformationTests, FQTransposeNegativeCase) {
+    auto create_graph = []() -> std::shared_ptr<ngraph::Function> {
+        auto data = std::make_shared<ngraph::op::Parameter>(ngraph::element::f32, ngraph::PartialShape{1, 3, 1});
+        auto sigmoid = std::make_shared<ngraph::op::Sigmoid>(data);
+        auto input_low = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {2});
+        auto input_high = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {3});
+        auto output_low = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {2});
+        auto output_high = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {3});
+        auto transpose_order = ngraph::op::Constant::create(ngraph::element::i64, ngraph::Shape{3}, {0, 2, 1});
+
+        auto fq = std::make_shared<ngraph::op::FakeQuantize>(sigmoid, input_low, input_high, output_low, output_high, 1);
+        auto transpose = std::make_shared<ngraph::op::Transpose>(fq, transpose_order);
+
+        return std::make_shared<ngraph::Function>(ngraph::NodeVector{transpose}, ngraph::ParameterVector{data});
+    };
+    auto f = create_graph();
+
+    ngraph::pass::Manager manager;
+    manager.register_pass<ngraph::pass::InitNodeInfo>();
+    manager.register_pass<ngraph::pass::PullTransposeThroughFQUp>();
+    manager.register_pass<ngraph::pass::InjectionPass>([](std::shared_ptr<ngraph::Function> f) {
+        check_rt_info(f);
+    });
+
+    auto f_ref = create_graph();
+    auto res = compare_functions(f, f_ref, true);
+    ASSERT_TRUE(res.first) << res.second;
+}
+
 TEST(TransformationTests, FQTransposeDynamic) {
     auto data = std::make_shared<ngraph::op::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic());
     auto input_low = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {2});


### PR DESCRIPTION
Root cause analysis: Using this operation on the activation path can prevent FQ and Conv (for example) fusing using a post op mechanism.

Ticket: 36833

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names

Validation:
* [x]  Unit tests: Updated;
* [x]  Framework operation tests: N/A - No new enabled operations;
* [x]  Transformation tests: N/A - No new implemented transformations;
* [x]  Model Optimizer IR Reader check: Done manually.

Documentation:
* [x]  Supported frameworks operations list: N/A - No new supported operations;
* [x]  Supported **public** models list: N/A - Nothing to add;
* [x]  User guide update: N/A - Nothing to update.
