### PR TITLE
[POT] Add Jenkinsfile for POT

### DIFF
--- a/.ci/pot/Jenkinsfile
+++ b/.ci/pot/Jenkinsfile
@@ -1,0 +1,14 @@
+#!groovy
+
+
+properties([
+    parameters([
+        string(defaultValue: '',
+               description: 'Pipeline shared library version (branch/tag/commit). Determined automatically if empty',
+               name: 'library_version')
+    ])
+])
+
+loadOpenVinoLibrary {
+    potEntrypoint(this)
+}


### PR DESCRIPTION
### Details:
 - This will trigger traditional POT pre-commit pipeline if a PR contains changes inside `tools/pot` directory of the repository. In other cases pipeline will exit sending success `ci/pot` commit status.
![image](https://user-images.githubusercontent.com/7278796/138472875-9d5542e0-ee71-4ce1-ac50-7e5d9e7cbfe1.png)

### Tickets:
 - *66116*
