### PR TITLE
Migrating to the new tbbbind library version 2.5

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -96,6 +96,12 @@ endif()
 if(THREADING STREQUAL "TBB" OR THREADING STREQUAL "TBB_AUTO")
     reset_deps_cache(TBBROOT TBB_DIR)
 
+    if(DEFINED ENV{THIRDPARTY_SERVER_PATH})
+        set(IE_PATH_TO_DEPS "$ENV{THIRDPARTY_SERVER_PATH}")
+    elseif(DEFINED THIRDPARTY_SERVER_PATH)
+        set(IE_PATH_TO_DEPS "${THIRDPARTY_SERVER_PATH}")
+    endif()
+
     if(WIN32 AND X86_64)
         #TODO: add target_path to be platform specific as well, to avoid following if
         RESOLVE_DEPENDENCY(TBB
@@ -103,11 +109,11 @@ if(THREADING STREQUAL "TBB" OR THREADING STREQUAL "TBB_AUTO")
                 TARGET_PATH "${TEMP}/tbb"
                 ENVIRONMENT "TBBROOT"
                 SHA256 "f1c9b9e2861efdaa01552bd25312ccbc5feeb45551e5f91ae61e29221c5c1479")
-        RESOLVE_DEPENDENCY(TBBBIND_2_4
-                ARCHIVE_WIN "tbbbind_2_4_static_win_v2.zip"
-                TARGET_PATH "${TEMP}/tbbbind_2_4"
-                ENVIRONMENT "TBBBIND_2_4_ROOT"
-                SHA256 "90dc165652f6ac2ed3014c71e57f797fcc4b11e1498a468e3d2c85deb2a4186a")
+        RESOLVE_DEPENDENCY(TBBBIND_2_5
+                ARCHIVE_WIN "tbbbind_2_5_static_win_v1.zip"
+                TARGET_PATH "${TEMP}/tbbbind_2_5"
+                ENVIRONMENT "TBBBIND_2_5_ROOT"
+                SHA256 "a67afeea8cf194f97968c800dab5b5459972908295242e282045d6b8953573c1")
     elseif(ANDROID)  # Should be before LINUX due LINUX is detected as well
         RESOLVE_DEPENDENCY(TBB
                 ARCHIVE_ANDROID "tbb2020_20200404_android.tgz"
@@ -120,11 +126,11 @@ if(THREADING STREQUAL "TBB" OR THREADING STREQUAL "TBB_AUTO")
                 TARGET_PATH "${TEMP}/tbb"
                 ENVIRONMENT "TBBROOT"
                 SHA256 "95b2f3b0b70c7376a0c7de351a355c2c514b42c4966e77e3e34271a599501008")
-        RESOLVE_DEPENDENCY(TBBBIND_2_4
-                ARCHIVE_LIN "tbbbind_2_4_static_lin_v2.tgz"
-                TARGET_PATH "${TEMP}/tbbbind_2_4"
-                ENVIRONMENT "TBBBIND_2_4_ROOT"
-                SHA256 "6dc926258c6cd3cba0f5c2cc672fd2ad599a1650fe95ab11122e8f361a726cb6")
+        RESOLVE_DEPENDENCY(TBBBIND_2_5
+                ARCHIVE_LIN "tbbbind_2_5_static_lin_v2.tgz"
+                TARGET_PATH "${TEMP}/tbbbind_2_5"
+                ENVIRONMENT "TBBBIND_2_5_ROOT"
+                SHA256 "865e7894c58402233caf0d1b288056e0e6ab2bf7c9d00c9dc60561c484bc90f4")
     elseif(LINUX AND AARCH64)
         RESOLVE_DEPENDENCY(TBB
                 ARCHIVE_LIN "keembay/tbb2020_38404_kmb_lic.tgz"
@@ -144,8 +150,12 @@ if(THREADING STREQUAL "TBB" OR THREADING STREQUAL "TBB_AUTO")
     update_deps_cache(TBBROOT "${TBB}" "Path to TBB root folder")
     update_deps_cache(TBB_DIR "${TBB}/cmake" "Path to TBB cmake folder")
 
-    update_deps_cache(TBBBIND_2_4_DIR "${TBBBIND_2_4}/cmake" "Path to TBBBIND_2_4 cmake folder")
+    update_deps_cache(TBBBIND_2_5_DIR "${TBBBIND_2_5}/cmake" "Path to TBBBIND_2_5 cmake folder")
     debug_message(STATUS "tbb=" ${TBB})
+
+    if(DEFINED IE_PATH_TO_DEPS)
+        unset(IE_PATH_TO_DEPS)
+    endif()
 endif()
 
 ## OpenCV

--- a/inference-engine/src/inference_engine/CMakeLists.txt
+++ b/inference-engine/src/inference_engine/CMakeLists.txt
@@ -5,9 +5,9 @@
 set (TARGET_NAME "inference_engine")
 
 if(THREADING STREQUAL "TBB" OR THREADING STREQUAL "TBB_AUTO")
-    find_package(TBBBIND_2_4 QUIET)
-    if (TBBBIND_2_4_FOUND)
-        message(STATUS "Static tbbbind_2_4 package was found")
+    find_package(TBBBIND_2_5 QUIET)
+    if (TBBBIND_2_5_FOUND)
+        message(STATUS "Static tbbbind_2_5 package was found")
     endif()
 endif()
 
@@ -141,9 +141,9 @@ target_include_directories(${TARGET_NAME}_obj PRIVATE "${CMAKE_CURRENT_SOURCE_DI
 target_link_libraries(${TARGET_NAME}_obj PRIVATE ${TARGET_NAME}_reader_api openvino::itt openvino::util)
 
 set_ie_threading_interface_for(${TARGET_NAME}_obj)
-if (TBBBIND_2_4_FOUND)
-    target_compile_definitions(${TARGET_NAME}_obj PRIVATE -DTBBBIND_2_4_AVAILABLE)
-    target_link_libraries(${TARGET_NAME}_obj PRIVATE ${TBBBIND_2_4_IMPORTED_TARGETS})
+if (TBBBIND_2_5_FOUND)
+    target_compile_definitions(${TARGET_NAME}_obj PRIVATE -DTBBBIND_2_5_AVAILABLE)
+    target_link_libraries(${TARGET_NAME}_obj PRIVATE ${TBBBIND_2_5_IMPORTED_TARGETS})
 endif()
 
 # Create library file from object library
@@ -166,9 +166,9 @@ ie_add_vs_version_file(NAME ${TARGET_NAME}
                        FILEDESCRIPTION "Inference Engine Core Runtime library")
 
 set_ie_threading_interface_for(${TARGET_NAME})
-if (TBBBIND_2_4_FOUND)
-    target_compile_definitions(${TARGET_NAME} PRIVATE -DTBBBIND_2_4_AVAILABLE)
-    target_link_libraries(${TARGET_NAME} PRIVATE ${TBBBIND_2_4_IMPORTED_TARGETS})
+if (TBBBIND_2_5_FOUND)
+    target_compile_definitions(${TARGET_NAME} PRIVATE -DTBBBIND_2_5_AVAILABLE)
+    target_link_libraries(${TARGET_NAME} PRIVATE ${TBBBIND_2_5_IMPORTED_TARGETS})
 endif()
 
 target_link_libraries(${TARGET_NAME} PRIVATE pugixml::static openvino::itt openvino::util ${CMAKE_DL_LIBS} Threads::Threads
@@ -201,9 +201,9 @@ if(BUILD_SHARED_LIBS)
                 ${IE_STATIC_DEPENDENT_FILES})
 
     set_ie_threading_interface_for(${TARGET_NAME}_s)
-    if (TBBBIND_2_4_FOUND)
-        target_compile_definitions(${TARGET_NAME}_s PRIVATE -DTBBBIND_2_4_AVAILABLE)
-        target_link_libraries(${TARGET_NAME}_s PRIVATE ${TBBBIND_2_4_IMPORTED_TARGETS})
+    if (TBBBIND_2_5_FOUND)
+        target_compile_definitions(${TARGET_NAME}_s PRIVATE -DTBBBIND_2_5_AVAILABLE)
+        target_link_libraries(${TARGET_NAME}_s PRIVATE ${TBBBIND_2_5_IMPORTED_TARGETS})
     endif()
 
     target_include_directories(${TARGET_NAME}_s PUBLIC

--- a/inference-engine/src/inference_engine/src/threading/ie_parallel_custom_arena.cpp
+++ b/inference-engine/src/inference_engine/src/threading/ie_parallel_custom_arena.cpp
@@ -6,11 +6,11 @@
 
 #if IE_THREAD == IE_THREAD_TBB || IE_THREAD == IE_THREAD_TBB_AUTO
 
-#    ifndef TBBBIND_2_4_AVAILABLE
-#        define TBBBIND_2_4_AVAILABLE 0
+#    ifndef TBBBIND_2_5_AVAILABLE
+#        define TBBBIND_2_5_AVAILABLE 0
 #    endif
 
-#    define USE_TBBBIND_2_4                 (TBBBIND_2_4_AVAILABLE && TBB_INTERFACE_VERSION < 12020)
+#    define USE_TBBBIND_2_5                 (TBBBIND_2_5_AVAILABLE && TBB_INTERFACE_VERSION < 12020)
 #    define TBB_NUMA_SUPPORT_PRESENT        (TBB_INTERFACE_VERSION >= 11100)
 #    define TBB_HYBRID_CPUS_SUPPORT_PRESENT (TBB_INTERFACE_VERSION >= 12020)
 
@@ -21,7 +21,7 @@
 namespace custom {
 namespace detail {
 
-#    if USE_TBBBIND_2_4
+#    if USE_TBBBIND_2_5
 extern "C" {
 void __TBB_internal_initialize_system_topology(std::size_t groups_num,
                                                int& numa_nodes_count,
@@ -152,7 +152,7 @@ task_arena::task_arena(int max_concurrency_, unsigned reserved_for_masters)
       my_binding_observer{} {}
 
 task_arena::task_arena(const constraints& constraints_, unsigned reserved_for_masters)
-#    if USE_TBBBIND_2_4
+#    if USE_TBBBIND_2_5
     : my_task_arena {
     info::default_concurrency(constraints_), reserved_for_masters
 }
@@ -175,7 +175,7 @@ task_arena::task_arena(const task_arena& s)
 
 void task_arena::initialize() {
     my_task_arena.initialize();
-#    if USE_TBBBIND_2_4
+#    if USE_TBBBIND_2_5
     std::call_once(my_initialization_state, [this] {
         my_binding_observer =
             detail::construct_binding_observer(my_task_arena, my_task_arena.max_concurrency(), my_constraints);
@@ -185,7 +185,7 @@ void task_arena::initialize() {
 
 void task_arena::initialize(int max_concurrency_, unsigned reserved_for_masters) {
     my_task_arena.initialize(max_concurrency_, reserved_for_masters);
-#    if USE_TBBBIND_2_4
+#    if USE_TBBBIND_2_5
     std::call_once(my_initialization_state, [this] {
         my_binding_observer =
             detail::construct_binding_observer(my_task_arena, my_task_arena.max_concurrency(), my_constraints);
@@ -195,7 +195,7 @@ void task_arena::initialize(int max_concurrency_, unsigned reserved_for_masters)
 
 void task_arena::initialize(constraints constraints_, unsigned reserved_for_masters) {
     my_constraints = constraints_;
-#    if USE_TBBBIND_2_4
+#    if USE_TBBBIND_2_5
     my_task_arena.initialize(info::default_concurrency(constraints_), reserved_for_masters);
     std::call_once(my_initialization_state, [this] {
         my_binding_observer =
@@ -219,7 +219,7 @@ int task_arena::max_concurrency() {
 
 namespace info {
 std::vector<numa_node_id> numa_nodes() {
-#    if USE_TBBBIND_2_4
+#    if USE_TBBBIND_2_5
     detail::initialize_system_topology();
     std::vector<numa_node_id> node_indexes(detail::numa_nodes_count);
     std::memcpy(node_indexes.data(), detail::numa_nodes_indexes, detail::numa_nodes_count * sizeof(int));
@@ -232,7 +232,7 @@ std::vector<numa_node_id> numa_nodes() {
 }
 
 std::vector<core_type_id> core_types() {
-#    if USE_TBBBIND_2_4
+#    if USE_TBBBIND_2_5
     detail::initialize_system_topology();
     std::vector<numa_node_id> core_type_indexes(detail::core_types_count);
     std::memcpy(core_type_indexes.data(), detail::core_types_indexes, detail::core_types_count * sizeof(int));
@@ -248,7 +248,7 @@ int default_concurrency(task_arena::constraints c) {
     if (c.max_concurrency > 0) {
         return c.max_concurrency;
     }
-#    if USE_TBBBIND_2_4
+#    if USE_TBBBIND_2_5
     if (detail::is_binding_environment_valid()) {
         detail::initialize_system_topology();
         return detail::__TBB_internal_get_default_concurrency(c.numa_id, c.core_type, c.max_threads_per_core);


### PR DESCRIPTION
### Details:
 - Migrating to the new tbbbind library version 2.5 due to memory leak in hwloc library

### Tickets:
 - CVS-60860
