### PR TITLE
[OV20] I420toRGB and I420toBGR operations specification

### DIFF
--- a/docs/doxygen/ie_docs.xml
+++ b/docs/doxygen/ie_docs.xml
@@ -177,6 +177,8 @@ limitations under the License.
                 <tab type="user" title="HardSigmoid-1" url="@ref openvino_docs_ops_activation_HardSigmoid_1"/>
                 <tab type="user" title="HSigmoid-5" url="@ref openvino_docs_ops_activation_HSigmoid_5"/>
                 <tab type="user" title="HSwish-4" url="@ref openvino_docs_ops_activation_HSwish_4"/>
+                <tab type="user" title="I420toBGR-8" url="@ref openvino_docs_ops_image_I420toBGR_8"/>
+                <tab type="user" title="I420toRGB-8" url="@ref openvino_docs_ops_image_I420toRGB_8"/>
                 <tab type="user" title="IDFT-7" url="@ref openvino_docs_ops_signals_IDFT_7"/>
                 <tab type="user" title="If-8" url="@ref openvino_docs_ops_condition_If_8"/>
                 <tab type="user" title="Interpolate-1" url="@ref openvino_docs_ops_image_Interpolate_1"/>

--- a/docs/ops/image/I420toBGR_8.md
+++ b/docs/ops/image/I420toBGR_8.md
@@ -1,0 +1,88 @@
+## I420toBGR <a name="I420toBGR"></a> {#openvino_docs_ops_image_I420toBGR_8}
+
+**Versioned name**: *I420toBGR-8*
+
+**Category**: *Image processing*
+
+**Short description**: *I420toBGR* performs image conversion from I420 to BGR format.
+
+**Detailed description**:
+
+Similar to *I420toRGB* but output channels for each pixel are reversed so that the first channel is `blue`, the second one is `green`, the last one is `red`.  See detailed conversion formulas in the [I420toRGB description](I420toRGB_8.md).
+
+**Inputs:**
+
+Same as specified for [I420toRGB](I420toRGB_8.md) operation.
+
+**Outputs:**
+
+* **1**: A tensor of type *T* representing an image converted in BGR format. Dimensions:
+  * `N` - batch dimension
+  * `H` - height dimension is the same as the image height
+  * `W` - width dimension is the same as the image width
+  * `C` - channels dimension is equal to 3. The first channel is Blue, the second one is Green, the last one is Red
+
+**Types:**
+
+* *T*: `uint8` or any supported floating-point type.
+
+
+**Examples:**
+
+*Example 1*
+
+```xml
+<layer ... type="I420toBGR">
+    <input>
+        <port id="0">
+            <dim>1</dim>
+            <dim>720</dim>
+            <dim>640</dim>
+            <dim>1</dim>
+        </port>
+    </input>
+    <output>
+        <port id="1">
+            <dim>1</dim>
+            <dim>480</dim>
+            <dim>640</dim>
+            <dim>3</dim>
+        </port>
+    </output>
+</layer>
+```
+
+*Example 2*
+
+```xml
+<layer ... type="I420toBGR">
+    <input>
+        <port id="0">  <!-- Y plane -->
+            <dim>1</dim>
+            <dim>480</dim>
+            <dim>640</dim>
+            <dim>1</dim>
+        </port>
+        <port id="1">  <!-- U plane -->
+            <dim>1</dim>
+            <dim>240</dim>
+            <dim>320</dim>
+            <dim>1</dim>
+        </port>
+        <port id="2">  <!-- V plane -->
+          <dim>1</dim>
+          <dim>240</dim>
+          <dim>320</dim>
+          <dim>1</dim>
+        </port>
+    </input>
+    <output>
+        <port id="1">
+            <dim>1</dim>
+            <dim>480</dim>
+            <dim>640</dim>
+            <dim>3</dim>
+        </port>
+    </output>
+</layer>
+```

--- a/docs/ops/image/I420toRGB_8.md
+++ b/docs/ops/image/I420toRGB_8.md
@@ -1,0 +1,120 @@
+## I420toRGB <a name="I420toRGB"></a> {#openvino_docs_ops_image_I420toRGB_8}
+
+**Versioned name**: *I420toRGB-8*
+
+**Category**: *Image processing*
+
+**Short description**: *I420toRGB* performs image conversion from I420 to RGB format.
+
+**Detailed description:**
+
+Conversion of each pixel from I420 (YUV) to RGB space is represented by the following formulas (same as in [NV12toRGB](NV12toRGB_8.md)):
+
+\f[
+\begin{aligned}
+& R = 1.164 \cdot (Y - 16) + 1.596 \cdot (V - 128) \\
+& G = 1.164 \cdot (Y - 16) - 0.813 \cdot (V - 128) - 0.391 \cdot (U - 128) \\
+& B = 1.164 \cdot (Y - 16) + 2.018 \cdot (U - 128)
+\end{aligned}
+\f]
+
+Then R, G, B values are clipped to range (0, 255).
+
+**Inputs:**
+
+Input I420 image tensor shall have `NHWC (also known as NYXC)` layout and can be represented in two ways:
+* *Single plane*:
+  * **1**: Tensor of type *T*. **Required.** Dimensions:
+    * `N` - batch dimension
+    * `H` - height dimension is 1.5x bigger than the image height
+    * `W` - width dimension is the same as the image width
+    * `C` - channels dimension is equal to 1 (one plane)
+* *Three separate planes - Y, U and V*:
+  * **1**: Tensor of type *T* representing Y plane. **Required.** Dimensions:
+    * `N` - batch dimension
+    * `H` - height dimension is the same as the image height
+    * `W` - width dimension is the same as the image width
+    * `C` - channels dimension is equal to 1 (only Y channel)
+  * **2**: Tensor of type *T* representing U plane. **Required.** Dimensions:
+    * `N` - batch dimension. Shall be the same as the batch dimension for Y plane
+    * `H` - height dimension shall be half of the image height (for example, `image_height / 2`)
+    * `W` - width dimension shall be half of the image width (for example, `image_width / 2`)
+    * `C` - channels dimension shall be equal to 1 (U channel)
+  * **3**: Tensor of type *T* representing V plane. **Required.** Dimensions:
+    * `N` - batch dimension. Shall be the same as the batch dimension for Y plane
+    * `H` - height dimension shall be half of the image height (for example, `image_height / 2`)
+    * `W` - width dimension shall be half of the image width (for example, `image_width / 2`)
+    * `C` - channels dimension shall be equal to 1 (V channel)
+
+**Outputs:**
+
+* **1**: A tensor of type *T* representing an image converted in RGB format. Dimensions:
+  * `N` - batch dimension
+  * `H` - height dimension is the same as the image height
+  * `W` - width dimension is the same as the image width
+  * `C` - channels dimension is equal to 3. The first channel is Red, the second one is Green, the last one is Blue
+
+**Types:**
+
+* *T*: `uint8` or any supported floating-point type.
+
+
+**Examples:**
+
+*Example 1*
+
+```xml
+<layer ... type="I420toRGB">
+    <input>
+        <port id="0">
+            <dim>1</dim>
+            <dim>720</dim>
+            <dim>640</dim>
+            <dim>1</dim>
+        </port>
+    </input>
+    <output>
+        <port id="1">
+            <dim>1</dim>
+            <dim>480</dim>
+            <dim>640</dim>
+            <dim>3</dim>
+        </port>
+    </output>
+</layer>
+```
+
+*Example 2*
+
+```xml
+<layer ... type="I420toRGB">
+    <input>
+        <port id="0">  <!-- Y plane -->
+            <dim>1</dim>
+            <dim>480</dim>
+            <dim>640</dim>
+            <dim>1</dim>
+        </port>
+        <port id="1">  <!-- U plane -->
+            <dim>1</dim>
+            <dim>240</dim>
+            <dim>320</dim>
+            <dim>2</dim>
+        </port>
+        <port id="2">  <!-- V plane -->
+          <dim>1</dim>
+          <dim>240</dim>
+          <dim>320</dim>
+          <dim>2</dim>
+        </port>
+    </input>
+    <output>
+        <port id="1">
+            <dim>1</dim>
+            <dim>480</dim>
+            <dim>640</dim>
+            <dim>3</dim>
+        </port>
+    </output>
+</layer>
+```

--- a/docs/ops/opset8.md
+++ b/docs/ops/opset8.md
@@ -79,6 +79,8 @@ declared in `namespace opset8`.
 * [HSigmoid](activation/HSigmoid_5.md)
 * [HSwish](activation/HSwish_4.md)
 * [IDFT](signals/IDFT_7.md)
+* [I420toBGR](image/I420toBGR_8.md)
+* [I420toRGB](image/I420toRGB_8.md)
 * [If](condition/If_8.md)
 * [Interpolate](image/Interpolate_4.md)
 * [Less](comparison/Less_1.md)


### PR DESCRIPTION
### Details:
 - I420toRGB and I420toBGR operations specification
 - Similar to NV12toRGB/BGR (PR #7595), but with 3 planes mode support (instead of 3 planes). Splitted into 2 separate operations to be able to maintain their behavior separately.

### Tickets:
 - 62175
 - 71208