### PR TITLE
[PYTHON] Fix Tensor creation from numpy arrays

### DIFF
--- a/runtime/bindings/python/src/openvino/ie_api.py
+++ b/runtime/bindings/python/src/openvino/ie_api.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+import numpy as np
+
 from openvino.pyopenvino import TBlobFloat32
 from openvino.pyopenvino import TBlobFloat64
 from openvino.pyopenvino import TBlobInt64
@@ -13,8 +15,6 @@ from openvino.pyopenvino import TBlobInt8
 from openvino.pyopenvino import TBlobUint8
 from openvino.pyopenvino import TensorDesc
 from openvino.pyopenvino import InferRequest
-
-import numpy as np
 
 
 precision_map = {"FP32": np.float32,

--- a/runtime/bindings/python/src/pyopenvino/core/tensor.cpp
+++ b/runtime/bindings/python/src/pyopenvino/core/tensor.cpp
@@ -10,18 +10,31 @@
 #include "openvino/runtime/tensor.hpp"
 #include "pyopenvino/core/common.hpp"
 
+#define C_CONTIGUOUS py::detail::npy_api::constants::NPY_ARRAY_C_CONTIGUOUS_
+
 namespace py = pybind11;
 
 void regclass_Tensor(py::module m) {
     py::class_<ov::runtime::Tensor, std::shared_ptr<ov::runtime::Tensor>> cls(m, "Tensor");
 
-    cls.def(py::init([](py::array& array) {
+    cls.def(py::init([](py::array& array, bool shared_memory) {
+                auto type = Common::dtype_to_ov_type().at(py::str(array.dtype()));
                 std::vector<size_t> shape(array.shape(), array.shape() + array.ndim());
-                return ov::runtime::Tensor(Common::dtype_to_ov_type().at(py::str(array.dtype())),
-                                           shape,
-                                           (void*)array.data());
+                if (shared_memory) {
+                    if (C_CONTIGUOUS == (array.flags() & C_CONTIGUOUS)) {
+                        std::vector<size_t> strides(array.strides(), array.strides() + array.ndim());
+                        return ov::runtime::Tensor(type, shape, const_cast<void*>(array.data(0)), strides);
+                    } else {
+                        IE_THROW() << "Tensor with shared memory must be C contiguous!";
+                    }
+                }
+                array = py::module::import("numpy").attr("ascontiguousarray")(array).cast<py::array>();
+                auto tensor = ov::runtime::Tensor(type, shape);
+                std::memcpy(tensor.data(), array.data(0), array.nbytes());
+                return tensor;
             }),
-            py::arg("array"));
+            py::arg("array"),
+            py::arg("shared_memory") = false);
 
     cls.def(py::init<const ov::element::Type, const ov::Shape>(), py::arg("type"), py::arg("shape"));
 
@@ -30,27 +43,27 @@ void regclass_Tensor(py::module m) {
     cls.def(py::init([](py::dtype& np_dtype, std::vector<size_t>& shape) {
                 return ov::runtime::Tensor(Common::dtype_to_ov_type().at(py::str(np_dtype)), shape);
             }),
-            py::arg("dtype"),
+            py::arg("type"),
             py::arg("shape"));
 
     cls.def(py::init([](py::object& np_literal, std::vector<size_t>& shape) {
                 return ov::runtime::Tensor(Common::dtype_to_ov_type().at(py::str(py::dtype::from_args(np_literal))),
                                            shape);
             }),
-            py::arg("dtype"),
+            py::arg("type"),
             py::arg("shape"));
 
     cls.def(py::init([](py::dtype& np_dtype, const ov::Shape& shape) {
                 return ov::runtime::Tensor(Common::dtype_to_ov_type().at(py::str(np_dtype)), shape);
             }),
-            py::arg("dtype"),
+            py::arg("type"),
             py::arg("shape"));
 
     cls.def(py::init([](py::object& np_literal, const ov::Shape& shape) {
                 return ov::runtime::Tensor(Common::dtype_to_ov_type().at(py::str(py::dtype::from_args(np_literal))),
                                            shape);
             }),
-            py::arg("dtype"),
+            py::arg("type"),
             py::arg("shape"));
 
     cls.def(py::init<ov::runtime::Tensor, ov::Coordinate, ov::Coordinate>(),

--- a/runtime/bindings/python/tests/test_inference_engine/helpers.py
+++ b/runtime/bindings/python/tests/test_inference_engine/helpers.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import cv2
+import os
+
+
+def image_path():
+    path_to_repo = os.environ["DATA_PATH"]
+    path_to_img = os.path.join(path_to_repo, "validation_set", "224x224", "dog.bmp")
+    return path_to_img
+
+
+def model_path(is_myriad=False):
+    path_to_repo = os.environ["MODELS_PATH"]
+    if not is_myriad:
+        test_xml = os.path.join(path_to_repo, "models", "test_model", "test_model_fp32.xml")
+        test_bin = os.path.join(path_to_repo, "models", "test_model", "test_model_fp32.bin")
+    else:
+        test_xml = os.path.join(path_to_repo, "models", "test_model", "test_model_fp16.xml")
+        test_bin = os.path.join(path_to_repo, "models", "test_model", "test_model_fp16.bin")
+    return (test_xml, test_bin)
+
+
+def read_image():
+    n, c, h, w = (1, 3, 32, 32)
+    image = cv2.imread(image_path())
+    if image is None:
+        raise FileNotFoundError("Input image not found")
+
+    image = cv2.resize(image, (h, w)) / 255
+    image = image.transpose((2, 0, 1)).astype(np.float32)
+    image = image.reshape((n, c, h, w))
+    return image

--- a/runtime/bindings/python/tests/test_inference_engine/test_infer_request.py
+++ b/runtime/bindings/python/tests/test_inference_engine/test_infer_request.py
@@ -5,42 +5,12 @@ import numpy as np
 import os
 import pytest
 
+from tests.test_inference_engine.helpers import model_path, read_image
 from openvino import Core, Blob, TensorDesc, StatusCode
-
-
-def image_path():
-    path_to_repo = os.environ["DATA_PATH"]
-    path_to_img = os.path.join(path_to_repo, "validation_set", "224x224", "dog.bmp")
-    return path_to_img
-
-
-def model_path(is_myriad=False):
-    path_to_repo = os.environ["MODELS_PATH"]
-    if not is_myriad:
-        test_xml = os.path.join(path_to_repo, "models", "test_model", "test_model_fp32.xml")
-        test_bin = os.path.join(path_to_repo, "models", "test_model", "test_model_fp32.bin")
-    else:
-        test_xml = os.path.join(path_to_repo, "models", "test_model", "test_model_fp16.xml")
-        test_bin = os.path.join(path_to_repo, "models", "test_model", "test_model_fp16.bin")
-    return (test_xml, test_bin)
-
-
-def read_image():
-    import cv2
-    n, c, h, w = (1, 3, 32, 32)
-    image = cv2.imread(path_to_img)
-    if image is None:
-        raise FileNotFoundError("Input image not found")
-
-    image = cv2.resize(image, (h, w)) / 255
-    image = image.transpose((2, 0, 1)).astype(np.float32)
-    image = image.reshape((n, c, h, w))
-    return image
 
 
 is_myriad = os.environ.get("TEST_DEVICE") == "MYRIAD"
 test_net_xml, test_net_bin = model_path(is_myriad)
-path_to_img = image_path()
 
 
 def test_get_perf_counts(device):

--- a/runtime/bindings/python/tests/test_inference_engine/test_tensor.py
+++ b/runtime/bindings/python/tests/test_inference_engine/test_tensor.py
@@ -3,6 +3,8 @@
 
 import numpy as np
 import pytest
+
+from tests.test_inference_engine.helpers import read_image
 from openvino import Tensor
 import openvino as ov
 
@@ -47,27 +49,86 @@ def test_init_with_ngraph(ov_type, numpy_dtype):
     (ov.impl.Type.u64, np.uint64),
     (ov.impl.Type.boolean, np.bool)
 ])
-def test_init_with_numpy(ov_type, numpy_dtype):
+def test_init_with_numpy_dtype(ov_type, numpy_dtype):
     shape = (1, 3, 127, 127)
     ov_shape = ov.impl.Shape(shape)
-    ones_arr = np.ones(shape, numpy_dtype)
-    ones_ov_tensor = Tensor(array=ones_arr)
     ov_tensors = []
-    ov_tensors.append(Tensor(dtype=numpy_dtype, shape=shape))
-    ov_tensors.append(Tensor(dtype=np.dtype(numpy_dtype), shape=shape))
-    ov_tensors.append(Tensor(dtype=np.dtype(numpy_dtype), shape=np.array(shape)))
-    ov_tensors.append(ones_ov_tensor)
-    ov_tensors.append(Tensor(dtype=numpy_dtype, shape=ov_shape))
-    ov_tensors.append(Tensor(dtype=np.dtype(numpy_dtype), shape=ov_shape))
+    ov_tensors.append(Tensor(type=numpy_dtype, shape=shape))
+    ov_tensors.append(Tensor(type=np.dtype(numpy_dtype), shape=shape))
+    ov_tensors.append(Tensor(type=np.dtype(numpy_dtype), shape=np.array(shape)))
+    ov_tensors.append(Tensor(type=numpy_dtype, shape=ov_shape))
+    ov_tensors.append(Tensor(type=np.dtype(numpy_dtype), shape=ov_shape))
     assert np.all(tuple(ov_tensor.shape) == shape for ov_tensor in ov_tensors)
     assert np.all(ov_tensor.element_type == ov_type for ov_tensor in ov_tensors)
     assert np.all(isinstance(ov_tensor.data, np.ndarray) for ov_tensor in ov_tensors)
     assert np.all(ov_tensor.data.dtype == numpy_dtype for ov_tensor in ov_tensors)
     assert np.all(ov_tensor.data.shape == shape for ov_tensor in ov_tensors)
-    assert np.shares_memory(ones_arr, ones_ov_tensor.data)
-    assert np.array_equal(ones_ov_tensor.data, ones_arr)
-    assert ones_ov_tensor.size == ones_arr.size
-    assert ones_ov_tensor.byte_size == ones_arr.nbytes
+
+
+@pytest.mark.parametrize("ov_type, numpy_dtype", [
+    (ov.impl.Type.f32, np.float32),
+    (ov.impl.Type.f64, np.float64),
+    (ov.impl.Type.f16, np.float16),
+    (ov.impl.Type.i8, np.int8),
+    (ov.impl.Type.u8, np.uint8),
+    (ov.impl.Type.i32, np.int32),
+    (ov.impl.Type.u32, np.uint32),
+    (ov.impl.Type.i16, np.int16),
+    (ov.impl.Type.u16, np.uint16),
+    (ov.impl.Type.i64, np.int64),
+    (ov.impl.Type.u64, np.uint64),
+    (ov.impl.Type.boolean, np.bool)
+])
+def test_init_with_numpy_shared_memory(ov_type, numpy_dtype):
+    arr = read_image().astype(numpy_dtype)
+    shape = arr.shape
+    arr = np.ascontiguousarray(arr)
+    ov_tensor = Tensor(array=arr, shared_memory=True)
+    assert tuple(ov_tensor.shape) == shape
+    assert ov_tensor.element_type == ov_type
+    assert isinstance(ov_tensor.data, np.ndarray)
+    assert ov_tensor.data.dtype == numpy_dtype
+    assert ov_tensor.data.shape == shape
+    assert np.shares_memory(arr, ov_tensor.data)
+    assert np.array_equal(ov_tensor.data, arr)
+    assert ov_tensor.size == arr.size
+    assert ov_tensor.byte_size == arr.nbytes
+
+
+@pytest.mark.parametrize("ov_type, numpy_dtype", [
+    (ov.impl.Type.f32, np.float32),
+    (ov.impl.Type.f64, np.float64),
+    (ov.impl.Type.f16, np.float16),
+    (ov.impl.Type.i8, np.int8),
+    (ov.impl.Type.u8, np.uint8),
+    (ov.impl.Type.i32, np.int32),
+    (ov.impl.Type.u32, np.uint32),
+    (ov.impl.Type.i16, np.int16),
+    (ov.impl.Type.u16, np.uint16),
+    (ov.impl.Type.i64, np.int64),
+    (ov.impl.Type.u64, np.uint64),
+    (ov.impl.Type.boolean, np.bool)
+])
+def test_init_with_numpy_copy_memory(ov_type, numpy_dtype):
+    arr = read_image().astype(numpy_dtype)
+    shape = arr.shape
+    ov_tensor = Tensor(array=arr, shared_memory=False)
+    assert tuple(ov_tensor.shape) == shape
+    assert ov_tensor.element_type == ov_type
+    assert isinstance(ov_tensor.data, np.ndarray)
+    assert ov_tensor.data.dtype == numpy_dtype
+    assert ov_tensor.data.shape == shape
+    assert not(np.shares_memory(arr, ov_tensor.data))
+    assert np.array_equal(ov_tensor.data, arr)
+    assert ov_tensor.size == arr.size
+    assert ov_tensor.byte_size == arr.nbytes
+
+
+def test_init_with_numpy_fail():
+    arr = read_image()
+    with pytest.raises(RuntimeError) as e:
+        _ = Tensor(array=arr, shared_memory=True)
+    assert "Tensor with shared memory must be C contiguous" in str(e.value)
 
 
 def test_init_with_roi_tensor():
@@ -143,7 +204,9 @@ def test_set_shape(ov_type, numpy_dtype):
 ])
 def test_cannot_set_shape_on_preallocated_memory(ref_shape):
     ones_arr = np.ones(shape=(1, 3, 32, 32), dtype=np.float32)
-    ov_tensor = Tensor(ones_arr)
+    ones_arr = np.ascontiguousarray(ones_arr)
+    ov_tensor = Tensor(ones_arr, shared_memory=True)
+    assert np.shares_memory(ones_arr, ov_tensor.data)
     with pytest.raises(RuntimeError) as e:
         ov_tensor.shape = ref_shape
     assert "Cannot call setShape for Blobs created on top of preallocated memory" in str(e.value)


### PR DESCRIPTION
### Details:
 - Re-do constructor for Tensor Python API
 - Allow user to decide if memory is shared or not between original numpy array. In case memory is not shared, memory copy is performed (with additional step of moving an array's memory layout to C-style row major).
 - Add new tests

### Tickets:
 - *...*
