### PR TITLE
[GPU] Limit number of threads used for onednn build

### DIFF
--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -135,6 +135,13 @@ if(ENABLE_ONEDNN_FOR_GPU)
         set(ONEDNN_INSTALL_DIR "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
         set(ONEDNN_LIBRARY "${ONEDNN_BUILD_DIR}/src/${CMAKE_STATIC_LIBRARY_PREFIX}onednn_gpu${CMAKE_STATIC_LIBRARY_SUFFIX}")
         set(ONEDNN_OUTPUT_LIBRARY "${ONEDNN_INSTALL_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}onednn_gpu${CMAKE_STATIC_LIBRARY_SUFFIX}")
+
+        # Get processors count to limit number of threads spawned by make
+        include(ProcessorCount)
+        ProcessorCount(CORES_COUNT)
+        if(CORES_COUNT EQUAL 0)
+            set(CORES_COUNT "")
+        endif()
         ExternalProject_Add(onednn_gpu_build
             SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/onednn_gpu"
             BINARY_DIR "${ONEDNN_BUILD_DIR}"
@@ -159,7 +166,7 @@ if(ENABLE_ONEDNN_FOR_GPU)
                        "-DOpenCL_LIBRARY=${OpenCL_LIBRARY}"
                        "-DOpenCL_INCLUDE_DIR=${OpenCL_INCLUDE_DIR}"
                        "-DOPENCL_VERSION_2_2=${OPENCL_VERSION_2_2}"
-            BUILD_COMMAND ${CMAKE_COMMAND} --build . --config ${CMAKE_BUILD_TYPE} --target onednn_gpu --parallel
+            BUILD_COMMAND ${CMAKE_COMMAND} --build . --config ${CMAKE_BUILD_TYPE} --target onednn_gpu --parallel ${CORES_COUNT}
             INSTALL_COMMAND ${CMAKE_COMMAND} -E copy ${ONEDNN_LIBRARY} ${ONEDNN_OUTPUT_LIBRARY}
             COMMAND ${CMAKE_COMMAND} -E echo "OneDNN $<CONFIG> build for GPU complete"
             BUILD_BYPRODUCTS ${ONEDNN_OUTPUT_LIBRARY}


### PR DESCRIPTION
### Details:
 - make may spawn to many threads and fail with out of memory error. Limit number of threads used for onednn build by cores count to avoid such error.

### Ticket:
 - 69684