### PR TITLE
[MO] changed input node_names postfix after cutting

### DIFF
--- a/model-optimizer/mo/front/extractor.py
+++ b/model-optimizer/mo/front/extractor.py
@@ -521,8 +521,8 @@ def get_new_placeholder_name(node_id: str, is_out_port: bool = False, port: int 
     :param port: a port number
     :return: a name of new placeholder created by cutting a graph
     """
-    port_type = '_out' if is_out_port else ''
-    return '{}/placeholder{}_port_{}'.format(node_id, port_type, port)
+    name_postfix = ':' if is_out_port else '/placeholder_port_'
+    return '{}{}{}'.format(node_id, name_postfix, port)
 
 
 def input_user_data_repack(graph: Graph, input_user_shapes: [None, list, dict, np.ndarray],

--- a/model-optimizer/unit_tests/mo/front/extractor_test.py
+++ b/model-optimizer/unit_tests/mo/front/extractor_test.py
@@ -386,8 +386,8 @@ class TestInputAddition(unittest.TestCase):
         self.assertTrue(flag, resp)
 
         # Checks for new input and edges
-        self.assertTrue('conv_1/placeholder_out_port_0' in graph.nodes())
-        new_input = 'conv_1/placeholder_out_port_0'
+        self.assertTrue('conv_1:0' in graph.nodes())
+        new_input = 'conv_1:0'
         self.assertTrue(graph.node[new_input]['is_input'])
         self.assertTrue((new_input, 'relu_1') in graph.edges())
         self.assertTrue(('old_input', 'relu_1') not in graph.edges())
@@ -428,8 +428,8 @@ class TestInputAddition(unittest.TestCase):
         self.assertTrue(flag, resp)
 
         # Checks for new input and edges
-        self.assertTrue('conv_1/placeholder_out_port_0' in graph.nodes())
-        new_input = 'conv_1/placeholder_out_port_0'
+        self.assertTrue('conv_1:0' in graph.nodes())
+        new_input = 'conv_1:0'
 
         self.assertTrue(graph.node[new_input]['is_input'])
 
@@ -561,7 +561,7 @@ class TestUserDataRepack(unittest.TestCase):
         shape_2 = np.array([5])
         input, freeze_placeholder = input_user_data_repack(graph, {'Aa:0': shape_1, 'Cc:0' : shape_2}, {'Bb': False, 'Cc:0' : [1.0, 1.0, 2.0, 3.0, 5.0]})
         self.assertDictEqual(input, {'A' : [{'shape' : shape_1, 'out' : 0}], 'B' : [{'shape' : None, 'port' : None}], 'C' : [{'shape' : shape_2, 'out' : 0}]})
-        self.assertEqual(freeze_placeholder, {'B' : False, 'C/placeholder_out_port_0' : [1.0, 1.0, 2.0, 3.0, 5.0]})
+        self.assertEqual(freeze_placeholder, {'B' : False, 'C:0' : [1.0, 1.0, 2.0, 3.0, 5.0]})
 
     def test_freeze_new_placeholder_2(self):
         # create a new placeholder Ee by cutting input port with shape_2 = [2, 2] and freeze a value [[1.0, 1.0], [2.0, 3.0]]


### PR DESCRIPTION
### Details:
Currently if `--input node_name:0[1 3 100 100], ...` is specified the node is being cut and replaced with `Parameter` with a name `node_name/placeholder_out_port_0`.

In this PR we change  `node_name/placeholder_out_port_0` -> `node_name:0` to match original FW syntax so that we can refer to the nodes keeping original dictionary with inputs.

### Tickets:
 - *ticket-id*
