### PR TITLE
[CPU] Several CPU specific SL tests are extended with dynamic shapes

### DIFF
--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_matmul_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_matmul_node.cpp
@@ -73,13 +73,12 @@ bool MKLDNNMatMulNode::canFuse(const MKLDNNNodePtr& node) const {
                   EltwiseRoundHalfAwayFromZero, EltwiseAbs, EltwiseSqrt, EltwiseSoftRelu);
 }
 
-void MKLDNNMatMulNode::setPostOps(mkldnn::primitive_attr &attr, bool initWeights = false) const {
+void MKLDNNMatMulNode::setPostOps(mkldnn::primitive_attr &attr, const VectorDims& dims, bool initWeights = false) const {
     mkldnn::post_ops ops;
 
     for (auto &node : fusedWith) {
         if (auto* eltwiseNode = dynamic_cast<MKLDNNEltwiseNode *>(node.get())) {
-            // TODO [DS]: change to shape from memory
-            eltwiseNode->appendPostOps(ops, getOutputShapeAtPort(0).getStaticDims());
+            eltwiseNode->appendPostOps(ops, dims);
             continue;
         }
 
@@ -90,12 +89,16 @@ void MKLDNNMatMulNode::setPostOps(mkldnn::primitive_attr &attr, bool initWeights
 }
 
 
-MKLDNNNode::AttrPtr MKLDNNMatMulNode::initPrimitiveAttr() const {
+MKLDNNNode::AttrPtr MKLDNNMatMulNode::initPrimitiveAttr(const VectorDims &dims) const {
     auto attr = std::make_shared<mkldnn::primitive_attr>(mkldnn::primitive_attr());
 
-    setPostOps(*attr, true);
+    setPostOps(*attr, dims, true);
 
     return attr;
+}
+
+MKLDNNNode::AttrPtr MKLDNNMatMulNode::initPrimitiveAttr() const {
+    return initPrimitiveAttr(MemoryDescUtils::makeDummyShape(getInputShapeAtPort(0)).getStaticDims());
 }
 
 /* Example MatMul:
@@ -297,7 +300,7 @@ void MKLDNNMatMulNode::prepareParams() {
 
     if (isDynamicNode()) {
         if (!pAttr) {
-            pAttr = initPrimitiveAttr();
+            pAttr = initPrimitiveAttr(src0MemPtr->getStaticDims());
         }
         attr = pAttr;
 

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_matmul_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_matmul_node.cpp
@@ -98,7 +98,8 @@ MKLDNNNode::AttrPtr MKLDNNMatMulNode::initPrimitiveAttr(const VectorDims &dims) 
 }
 
 MKLDNNNode::AttrPtr MKLDNNMatMulNode::initPrimitiveAttr() const {
-    return initPrimitiveAttr(MemoryDescUtils::makeDummyShape(getInputShapeAtPort(0)).getStaticDims());
+    auto dummyShape = MemoryDescUtils::makeDummyShape(getInputShapeAtPort(0));
+    return initPrimitiveAttr(dummyShape.getStaticDims());
 }
 
 /* Example MatMul:

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_matmul_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_matmul_node.cpp
@@ -98,7 +98,7 @@ MKLDNNNode::AttrPtr MKLDNNMatMulNode::initPrimitiveAttr(const VectorDims &dims) 
 }
 
 MKLDNNNode::AttrPtr MKLDNNMatMulNode::initPrimitiveAttr() const {
-    auto dummyShape = MemoryDescUtils::makeDummyShape(getInputShapeAtPort(0));
+    auto dummyShape = MemoryDescUtils::makeDummyShape(getOutputShapeAtPort(0));
     return initPrimitiveAttr(dummyShape.getStaticDims());
 }
 

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_matmul_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_matmul_node.h
@@ -39,9 +39,10 @@ public:
 
 protected:
     AttrPtr initPrimitiveAttr() const override;
+    AttrPtr initPrimitiveAttr(const VectorDims& dims) const;
 
 private:
-    void setPostOps(mkldnn::primitive_attr &attr, bool initWeights) const;
+    void setPostOps(mkldnn::primitive_attr &attr, const VectorDims& dims, bool initWeights) const;
 
     std::string errorPrefix;
 

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution_backprop_data.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/convolution_backprop_data.cpp
@@ -102,15 +102,19 @@ protected:
 TEST_P(DeconvolutionLayerCPUTest, CompareWithRefs) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 
+    if (!fusedOps.empty()) {
+        bool isSupportedParams = stride[stride.size() - 1] <= kernel[kernel.size() - 1];
+        if (stride.size() > 1)
+            isSupportedParams &= stride[stride.size() - 2] <= kernel[kernel.size() - 2];
+        if (stride.size() > 2)
+            isSupportedParams &= stride[stride.size() - 3] <= kernel[kernel.size() - 3];
+        if (!isSupportedParams) {
+            GTEST_SKIP() << "Fusing with strides more than kernel size was disabled, because oneDNN deconvolution doesn't support it" << std::endl;
+        }
+    }
+
     Run();
-    CPUTestsBase::CheckPluginRelatedResults(executableNetwork, "Deconvolution");
-    bool isSupportedParams = stride[stride.size() - 1] <= kernel[kernel.size() - 1];
-    if (stride.size() > 1)
-        isSupportedParams &= stride[stride.size() - 2] <= kernel[kernel.size() - 2];
-    if (stride.size() > 2)
-        isSupportedParams &= stride[stride.size() - 3] <= kernel[kernel.size() - 3];
-    if (isSupportedParams)
-        CheckFusingResults(executableNetwork, "Deconvolution");
+    CheckPluginRelatedResults(executableNetwork, "Deconvolution");
 }
 
 namespace {

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution_backprop_data.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/group_convolution_backprop_data.cpp
@@ -101,15 +101,19 @@ protected:
 TEST_P(GroupDeconvolutionLayerCPUTest, CompareWithRefs) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 
+    if (!fusedOps.empty()) {
+        bool isSupportedParams = stride[stride.size() - 1] <= kernel[kernel.size() - 1];
+        if (stride.size() > 1)
+            isSupportedParams &= stride[stride.size() - 2] <= kernel[kernel.size() - 2];
+        if (stride.size() > 2)
+            isSupportedParams &= stride[stride.size() - 3] <= kernel[kernel.size() - 3];
+        if (!isSupportedParams) {
+            GTEST_SKIP() << "Fusing with strides more than kernel size was disabled, because oneDNN deconvolution doesn't support it" << std::endl;
+        }
+    }
+
     Run();
-    CPUTestsBase::CheckPluginRelatedResults(executableNetwork, "Deconvolution");
-    bool isSupportedParams = stride[stride.size() - 1] <= kernel[kernel.size() - 1];
-    if (stride.size() > 1)
-        isSupportedParams &= stride[stride.size() - 2] <= kernel[kernel.size() - 2];
-    if (stride.size() > 2)
-        isSupportedParams &= stride[stride.size() - 3] <= kernel[kernel.size() - 3];
-    if (isSupportedParams)
-        CheckFusingResults(executableNetwork, "Deconvolution");
+    CheckPluginRelatedResults(executableNetwork, "Deconvolution");
 }
 
 namespace {

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/mat_mul.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/mat_mul.cpp
@@ -18,6 +18,24 @@ enum class MatMulNodeType {
     FullyConnected
 };
 
+using ShapesDefenition = std::pair<std::vector<ngraph::PartialShape>, std::vector<std::vector<ngraph::Shape>>>;
+
+struct ShapeRelatedParams {
+    ShapesDefenition inputShapes;
+    std::pair<bool, bool> transpose;
+};
+
+typedef std::tuple<
+        ShapeRelatedParams,
+        InferenceEngine::Precision,        // Network precision
+        InferenceEngine::Precision,        // Input precision
+        InferenceEngine::Precision,        // Output precision
+        InferenceEngine::Layout,           // Input layout
+        ngraph::helpers::InputLayerType,   // Secondary input type
+        LayerTestsUtils::TargetDevice,     // Device name
+        std::map<std::string, std::string> // Additional network configuration
+> MatMulLayerTestParamsSet;
+
 using MatMulLayerCPUTestParamSet = std::tuple<MatMulLayerTestParamsSet,
                                               MatMulNodeType,
                                               fusingSpecificParams>;
@@ -32,10 +50,45 @@ public:
 
         std::tie(basicParamsSet, nodeType, fusingParams) = obj.param;
 
+        InferenceEngine::Precision netPrecision;
+        InferenceEngine::Precision inPrc, outPrc;
+        InferenceEngine::Layout inLayout;
+        ShapeRelatedParams shapeRelatedParams;
+        ngraph::helpers::InputLayerType secondaryInputType;
+        std::string targetDevice;
+        std::map<std::string, std::string> additionalConfig;
+        std::tie(shapeRelatedParams, netPrecision, inPrc, outPrc, inLayout, secondaryInputType, targetDevice, additionalConfig) =
+                basicParamsSet;
+
         std::ostringstream result;
         result << (nodeType == MatMulNodeType::MatMul ? "MatMul_" : "FullyConnected_");
-        result << LayerTestsDefinitions::MatMulTest::getTestCaseName(
-            testing::TestParamInfo<LayerTestsDefinitions::MatMulLayerTestParamsSet>(basicParamsSet, 0));
+        if (!shapeRelatedParams.inputShapes.first.empty()) {
+            result << "IS=" << CommonTestUtils::partialShape2str(shapeRelatedParams.inputShapes.first) << "_";
+        }
+        result << "TS=";
+        for (const auto& shape : shapeRelatedParams.inputShapes.second) {
+            result << "(";
+            if (!shape.empty()) {
+                auto itr = shape.begin();
+                do {
+                    result << CommonTestUtils::vec2str(*itr);
+                } while (++itr != shape.end() && result << "_");
+            }
+            result << ")_";
+        }
+        result << "transpose_a=" << shapeRelatedParams.transpose.first << "_";
+        result << "transpose_b=" << shapeRelatedParams.transpose.second << "_";
+        result << "secondaryInputType=" << secondaryInputType << "_";
+        result << "netPRC=" << netPrecision.name() << "_";
+        result << "inPRC=" << inPrc.name() << "_";
+        result << "outPRC=" << outPrc.name() << "_";
+        result << "inL=" << inLayout << "_";
+        result << "trgDev=" << targetDevice;
+        result << "config=(";
+        for (const auto configEntry : additionalConfig) {
+            result << configEntry.first << ", " << configEntry.second << ":";
+        }
+        result << ")";
         result << CpuTestWithFusing::getTestCaseName(fusingParams);
 
         return result.str();
@@ -58,10 +111,30 @@ protected:
 
         std::tie(shapeRelatedParams, netPrecision, inPrc, outPrc, inLayout, secondaryInputType, targetDevice, additionalConfig) = basicParamsSet;
 
-        SizeVector inShapeA = shapeRelatedParams.input1.first;
-        SizeVector inShapeB = shapeRelatedParams.input2.first;
-        bool transpA = shapeRelatedParams.input1.second;
-        bool transpB = shapeRelatedParams.input2.second;
+        bool transpA = shapeRelatedParams.transpose.first;
+        bool transpB = shapeRelatedParams.transpose.second;
+
+        auto transpose = [](ngraph::Shape& shape) {
+            IE_ASSERT(shape.size() > 1);
+            std::swap(*(shape.end() - 1), *(shape.end() - 2));
+        };
+
+        if (transpA) {
+            for (auto& item : shapeRelatedParams.inputShapes.second) {
+                transpose(item[0]);
+            }
+        }
+        if (transpB) {
+            for (auto& item : shapeRelatedParams.inputShapes.second) {
+                transpose(item[1]);
+            }
+        }
+
+        SizeVector inShapeA = shapeRelatedParams.inputShapes.second[0][0];
+        SizeVector inShapeB = shapeRelatedParams.inputShapes.second[0][1];
+
+        inputDynamicShapes = shapeRelatedParams.inputShapes.first;
+        targetStaticShapes = shapeRelatedParams.inputShapes.second;
 
         /* @todo
          * Currently nodes are not fused thought Reshape
@@ -78,14 +151,6 @@ protected:
             inPrc = outPrc = netPrecision;
 
         cpuNodeType = nodeType == MatMulNodeType::MatMul ? "MatMul" : "FullyConnected";
-
-        auto transpose = [](SizeVector& shape) {
-            IE_ASSERT(shape.size() > 1);
-            std::swap(*(shape.end() - 1), *(shape.end() - 2));
-        };
-
-        if (transpA) transpose(inShapeA);
-        if (transpB) transpose(inShapeB);
 
         auto ngPrec = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         auto params = builder::makeParams(ngPrec, {inShapeA});
@@ -110,10 +175,6 @@ TEST_P(MatMulLayerCPUTest, CompareWithRefs) {
 namespace {
 
 /* ============= Common params ============= */
-const std::vector<bool> transpose = {
-    true, false
-};
-
 std::vector<std::map<std::string, std::string>> additionalConfig {
     std::map<std::string, std::string>{/* empty config */},
     {{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES}}
@@ -133,26 +194,26 @@ const auto fusingBiasFC = fusingSpecificParams{std::make_shared<postNodesMgr>(st
                 return std::make_shared<opset1::Add>(inpNode, bias);
             }, "fusingBiasFC"}}), {"Add"}};
 
-const std::vector<ShapeRelatedParams> IS2D {
-    {{{59, 1}, false}, {{1, 120}, false}},
-    {{{59, 1}, true}, {{1, 120}, false}},
-    {{{59, 1}, false}, {{1, 120}, true}},
-    {{{59, 1}, true}, {{1, 120}, true}},
+const std::vector<ShapeRelatedParams> IS2D = {
+    {{{}, {{{59, 1}, {1, 120}}}}, {false, false}},
+    {{{}, {{{59, 1}, {1, 120}}}}, {true, false}},
+    {{{}, {{{59, 1}, {1, 120}}}}, {false, true}},
+    {{{}, {{{59, 1}, {1, 120}}}}, {true, true}},
 
-    {{{59, 120}, false}, {{120, 1}, false}},
-    {{{59, 120}, true}, {{120, 1}, false}},
-    {{{59, 120}, false}, {{120, 1}, true}},
-    {{{59, 120}, true}, {{120, 1}, true}},
+    {{{}, {{{59, 120}, {120, 1}}}}, {false, false}},
+    {{{}, {{{59, 120}, {120, 1}}}}, {true, false}},
+    {{{}, {{{59, 120}, {120, 1}}}}, {false, true}},
+    {{{}, {{{59, 120}, {120, 1}}}}, {true, true}},
 
-    {{{1, 120}, false}, {{120, 59}, false}},
-    {{{1, 120}, true}, {{120, 59}, false}},
-    {{{1, 120}, false}, {{120, 59}, true}},
-    {{{1, 120}, true}, {{120, 59}, true}},
+    {{{}, {{{1, 120}, {120, 59}}}}, {false, false}},
+    {{{}, {{{1, 120}, {120, 59}}}}, {true, false}},
+    {{{}, {{{1, 120}, {120, 59}}}}, {false, true}},
+    {{{}, {{{1, 120}, {120, 59}}}}, {true, true}},
 
-    {{{71, 128}, false}, {{128, 20}, false}},
-    {{{71, 128}, true}, {{128, 20}, false}},
-    {{{71, 128}, false}, {{128, 20}, true}},
-    {{{71, 128}, true}, {{128, 20}, true}},
+    {{{}, {{{71, 128}, {128, 20}}}}, {false, false}},
+    {{{}, {{{71, 128}, {128, 20}}}}, {true, false}},
+    {{{}, {{{71, 128}, {128, 20}}}}, {false, true}},
+    {{{}, {{{71, 128}, {128, 20}}}}, {true, true}},
 };
 
 std::vector<fusingSpecificParams> fusingParamsSet2D {
@@ -179,17 +240,17 @@ const auto testParams2D = ::testing::Combine(fullyConnectedParams2D,
 INSTANTIATE_TEST_SUITE_P(smoke_FC_2D, MatMulLayerCPUTest, testParams2D, MatMulLayerCPUTest::getTestCaseName);
 
 const std::vector<ShapeRelatedParams> IS3D = {
-    {{{1, 32, 120}, false}, {{120, 5}, false}},
-    {{{1, 32, 120}, true}, {{120, 5}, false}},
-    {{{1, 32, 120}, false}, {{120, 5}, true}},
-    {{{1, 32, 120}, true}, {{120, 5}, true}},
+    {{{}, {{{1, 32, 120}, {120, 5}}}}, {false, false}},
+    {{{}, {{{1, 32, 120}, {120, 5}}}}, {true, false}},
+    {{{}, {{{1, 32, 120}, {120, 5}}}}, {false, true}},
+    {{{}, {{{1, 32, 120}, {120, 5}}}}, {true, true}},
 
-    {{{7, 32, 120}, false}, {{120, 50}, false}},
-    {{{7, 32, 120}, true}, {{120, 50}, false}},
-    {{{7, 32, 120}, false}, {{120, 50}, true}},
-    {{{7, 32, 120}, true}, {{120, 50}, true}},
+    {{{}, {{{1, 32, 120}, {120, 50}}}}, {false, false}},
+    {{{}, {{{1, 32, 120}, {120, 50}}}}, {true, false}},
+    {{{}, {{{1, 32, 120}, {120, 50}}}}, {false, true}},
+    {{{}, {{{1, 32, 120}, {120, 50}}}}, {true, true}},
 
-    {{{1, 429}, false}, {{1, 429, 1}, true}},
+    {{{}, {{{1, 429}, {1, 429, 1}}}}, {true, true}}
 };
 
 std::vector<fusingSpecificParams> fusingParamsSet3D {
@@ -219,30 +280,56 @@ INSTANTIATE_TEST_SUITE_P(smoke_FC_3D, MatMulLayerCPUTest, testParams3D, MatMulLa
 namespace matmul {
 
 const std::vector<ShapeRelatedParams> IS = {
-    {{{1, 2, 32, 120}, false}, {{120, 5}, false}},
-    {{{1, 2, 32, 120}, true}, {{120, 5}, false}},
-    {{{1, 2, 32, 120}, false}, {{120, 5}, true}},
-    {{{1, 2, 32, 120}, true}, {{120, 5}, true}},
+    {{{}, {{{1, 2, 32, 120}, {120, 5}}}}, {false, false}},
+    {{{}, {{{1, 2, 32, 120}, {120, 5}}}}, {true, false}},
+    {{{}, {{{1, 2, 32, 120}, {120, 5}}}}, {false, true}},
+    {{{}, {{{1, 2, 32, 120}, {120, 5}}}}, {true, true}},
 
-    {{{7, 32, 120}, false}, {{3, 7, 120, 50}, false}},
-    {{{7, 32, 120}, true}, {{3, 7, 120, 50}, false}},
-    {{{7, 32, 120}, false}, {{3, 7, 120, 50}, true}},
-    {{{7, 32, 120}, true}, {{3, 7, 120, 50}, true}},
+    {{{}, {{{7, 32, 120}, {3, 7, 120, 50}}}}, {false, false}},
+    {{{}, {{{7, 32, 120}, {3, 7, 120, 50}}}}, {true, false}},
+    {{{}, {{{7, 32, 120}, {3, 7, 120, 50}}}}, {false, true}},
+    {{{}, {{{7, 32, 120}, {3, 7, 120, 50}}}}, {true, true}},
 
-    {{{10, 10, 10}, false}, {{10, 10, 10}, false}},
-    {{{10, 10, 10}, true}, {{10, 10, 10}, false}},
-    {{{10, 10, 10}, false}, {{10, 10, 10}, true}},
-    {{{10, 10, 10}, true}, {{10, 10, 10}, true}},
+    {{{}, {{{10, 10, 10}, {10, 10, 10}}}}, {false, false}},
+    {{{}, {{{10, 10, 10}, {10, 10, 10}}}}, {true, false}},
+    {{{}, {{{10, 10, 10}, {10, 10, 10}}}}, {false, true}},
+    {{{}, {{{10, 10, 10}, {10, 10, 10}}}}, {true, true}},
 
-    {{{55, 12}, false}, {{12, 55}, false}},
-    {{{55, 12}, true}, {{12, 55}, false}},
-    {{{55, 12}, false}, {{12, 55}, true}},
-    {{{55, 12}, true}, {{12, 55}, true}},
+    {{{}, {{{55, 12}, {12, 55}}}}, {false, false}},
+    {{{}, {{{55, 12}, {12, 55}}}}, {true, false}},
+    {{{}, {{{55, 12}, {12, 55}}}}, {false, true}},
+    {{{}, {{{55, 12}, {12, 55}}}}, {true, true}},
+
+    {{{{-1, -1}, {-1, -1}}, {{{55, 12}, {12, 55}}, {{33, 7}, {7, 33}}}}, {false, false}},
+    {{{{-1, -1}, {-1, -1}}, {{{55, 12}, {12, 55}}, {{33, 7}, {7, 33}}}}, {true, false}},
+    {{{{-1, -1}, {-1, -1}}, {{{55, 12}, {12, 55}}, {{33, 7}, {7, 33}}}}, {false, true}},
+    {{{{-1, -1}, {-1, -1}}, {{{55, 12}, {12, 55}}, {{33, 7}, {7, 33}}}}, {true, true}},
+
+    {{{{-1, -1, -1, -1}, {-1, -1}}, {{{1, 2, 32, 60}, {60, 5}}, {{1, 2, 32, 30}, {30, 5}}}}, {false, false}},
+    {{{{-1, -1, -1, -1}, {-1, -1}}, {{{1, 2, 32, 60}, {60, 5}}, {{1, 2, 32, 30}, {30, 5}}}}, {true, false}},
+    {{{{-1, -1, -1, -1}, {-1, -1}}, {{{1, 2, 32, 60}, {60, 5}}, {{1, 2, 32, 30}, {30, 5}}}}, {false, true}},
+    {{{{-1, -1, -1, -1}, {-1, -1}}, {{{1, 2, 32, 60}, {60, 5}}, {{1, 2, 32, 30}, {30, 5}}}}, {true, true}},
+
+    {{{{-1, -1, -1}, {-1, -1, -1, -1}}, {{{7, 32, 60}, {3, 7, 60, 25}}, {{7, 32, 30}, {3, 7, 30, 25}}}}, {false, false}},
+    {{{{-1, -1, -1}, {-1, -1, -1, -1}}, {{{7, 32, 60}, {3, 7, 60, 25}}, {{7, 32, 30}, {3, 7, 30, 25}}}}, {true, false}},
+    {{{{-1, -1, -1}, {-1, -1, -1, -1}}, {{{7, 32, 60}, {3, 7, 60, 25}}, {{7, 32, 30}, {3, 7, 30, 25}}}}, {false, true}},
+    {{{{-1, -1, -1}, {-1, -1, -1, -1}}, {{{7, 32, 60}, {3, 7, 60, 25}}, {{7, 32, 30}, {3, 7, 30, 25}}}}, {true, true}},
+
+    {{{{-1, -1, -1}, {-1, -1, -1}}, {{{10, 10, 10}, {10, 10, 10}}, {{5, 5, 5}, {5, 5, 5}}}}, {false, false}},
+    {{{{-1, -1, -1}, {-1, -1, -1}}, {{{10, 10, 10}, {10, 10, 10}}, {{5, 5, 5}, {5, 5, 5}}}}, {true, false}},
+    {{{{-1, -1, -1}, {-1, -1, -1}}, {{{10, 10, 10}, {10, 10, 10}}, {{5, 5, 5}, {5, 5, 5}}}}, {false, true}},
+    {{{{-1, -1, -1}, {-1, -1, -1}}, {{{10, 10, 10}, {10, 10, 10}}, {{5, 5, 5}, {5, 5, 5}}}}, {true, true}},
+
+    {{{{{1, 15}, {1, 15}, {1, 15}}, {{1, 15}, {1, 15}, {1, 15}}}, {{{10, 10, 10}, {10, 10, 10}}, {{5, 5, 5}, {5, 5, 5}}}}, {false, false}},
+    {{{{{1, 15}, {1, 15}, {1, 15}}, {{1, 15}, {1, 15}, {1, 15}}}, {{{10, 10, 10}, {10, 10, 10}}, {{5, 5, 5}, {5, 5, 5}}}}, {true, false}},
+    {{{{{1, 15}, {1, 15}, {1, 15}}, {{1, 15}, {1, 15}, {1, 15}}}, {{{10, 10, 10}, {10, 10, 10}}, {{5, 5, 5}, {5, 5, 5}}}}, {false, true}},
+    {{{{{1, 15}, {1, 15}, {1, 15}}, {{1, 15}, {1, 15}, {1, 15}}}, {{{10, 10, 10}, {10, 10, 10}}, {{5, 5, 5}, {5, 5, 5}}}}, {true, true}},
 };
 
 std::vector<fusingSpecificParams> matmulFusingParams {
         emptyFusingSpec,
         fusingElu,
+        fusingSqrt
 };
 
 const auto matMulParams = ::testing::Combine(::testing::ValuesIn(IS),

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/mat_mul.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/mat_mul.cpp
@@ -29,7 +29,7 @@ typedef std::tuple<
         ElementType,        // Input precision
         ElementType,        // Output precision
         ngraph::helpers::InputLayerType,   // Secondary input type
-        LayerTestsUtils::TargetDevice,     // Device name
+        TargetDevice,     // Device name
         std::map<std::string, std::string> // Additional network configuration
 > MatMulLayerTestParamsSet;
 
@@ -51,7 +51,7 @@ public:
         ElementType inType, outType;
         ShapeRelatedParams shapeRelatedParams;
         ngraph::helpers::InputLayerType secondaryInputType;
-        std::string targetDevice;
+        TargetDevice targetDevice;
         std::map<std::string, std::string> additionalConfig;
         std::tie(shapeRelatedParams, netType, inType, outType, secondaryInputType, targetDevice, additionalConfig) =
                 basicParamsSet;

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/mat_mul.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/mat_mul.cpp
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "shared_test_classes/single_layer/mat_mul.hpp"
+#include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/fusing_test_utils.hpp"
 #include "ngraph_functions/builders.hpp"
 
 using namespace ngraph;
 using namespace InferenceEngine;
 using namespace CPUTestUtils;
-using namespace LayerTestsDefinitions;
+using namespace ov::test;
 
 namespace CPULayerTestsDefinitions {
 
@@ -18,19 +18,16 @@ enum class MatMulNodeType {
     FullyConnected
 };
 
-using ShapesDefenition = std::pair<std::vector<ngraph::PartialShape>, std::vector<std::vector<ngraph::Shape>>>;
-
 struct ShapeRelatedParams {
-    ShapesDefenition inputShapes;
+    std::vector<InputShape> inputShapes;
     std::pair<bool, bool> transpose;
 };
 
 typedef std::tuple<
         ShapeRelatedParams,
-        InferenceEngine::Precision,        // Network precision
-        InferenceEngine::Precision,        // Input precision
-        InferenceEngine::Precision,        // Output precision
-        InferenceEngine::Layout,           // Input layout
+        ElementType,        // Network precision
+        ElementType,        // Input precision
+        ElementType,        // Output precision
         ngraph::helpers::InputLayerType,   // Secondary input type
         LayerTestsUtils::TargetDevice,     // Device name
         std::map<std::string, std::string> // Additional network configuration
@@ -41,7 +38,7 @@ using MatMulLayerCPUTestParamSet = std::tuple<MatMulLayerTestParamsSet,
                                               fusingSpecificParams>;
 
 class MatMulLayerCPUTest : public testing::WithParamInterface<MatMulLayerCPUTestParamSet>,
-                                virtual public LayerTestsUtils::LayerTestsCommon, public CpuTestWithFusing {
+                           virtual public SubgraphBaseTest, public CpuTestWithFusing {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<MatMulLayerCPUTestParamSet>& obj) {
         MatMulLayerTestParamsSet basicParamsSet;
@@ -50,39 +47,38 @@ public:
 
         std::tie(basicParamsSet, nodeType, fusingParams) = obj.param;
 
-        InferenceEngine::Precision netPrecision;
-        InferenceEngine::Precision inPrc, outPrc;
-        InferenceEngine::Layout inLayout;
+        ElementType netType;
+        ElementType inType, outType;
         ShapeRelatedParams shapeRelatedParams;
         ngraph::helpers::InputLayerType secondaryInputType;
         std::string targetDevice;
         std::map<std::string, std::string> additionalConfig;
-        std::tie(shapeRelatedParams, netPrecision, inPrc, outPrc, inLayout, secondaryInputType, targetDevice, additionalConfig) =
+        std::tie(shapeRelatedParams, netType, inType, outType, secondaryInputType, targetDevice, additionalConfig) =
                 basicParamsSet;
 
         std::ostringstream result;
         result << (nodeType == MatMulNodeType::MatMul ? "MatMul_" : "FullyConnected_");
-        if (!shapeRelatedParams.inputShapes.first.empty()) {
-            result << "IS=" << CommonTestUtils::partialShape2str(shapeRelatedParams.inputShapes.first) << "_";
+        result << "IS=";
+        for (const auto& shape : shapeRelatedParams.inputShapes) {
+            result << CommonTestUtils::partialShape2str({shape.first}) << "_";
         }
         result << "TS=";
-        for (const auto& shape : shapeRelatedParams.inputShapes.second) {
+        for (const auto& shape : shapeRelatedParams.inputShapes) {
             result << "(";
-            if (!shape.empty()) {
-                auto itr = shape.begin();
+            if (!shape.second.empty()) {
+                auto itr = shape.second.begin();
                 do {
                     result << CommonTestUtils::vec2str(*itr);
-                } while (++itr != shape.end() && result << "_");
+                } while (++itr != shape.second.end() && result << "_");
             }
             result << ")_";
         }
         result << "transpose_a=" << shapeRelatedParams.transpose.first << "_";
         result << "transpose_b=" << shapeRelatedParams.transpose.second << "_";
         result << "secondaryInputType=" << secondaryInputType << "_";
-        result << "netPRC=" << netPrecision.name() << "_";
-        result << "inPRC=" << inPrc.name() << "_";
-        result << "outPRC=" << outPrc.name() << "_";
-        result << "inL=" << inLayout << "_";
+        result << "netPRC=" << netType << "_";
+        result << "inPRC=" << inType << "_";
+        result << "outPRC=" << outType << "_";
         result << "trgDev=" << targetDevice;
         result << "config=(";
         for (const auto configEntry : additionalConfig) {
@@ -97,6 +93,12 @@ public:
 protected:
      std::string cpuNodeType;
 
+    template<typename T>
+    void transpose(T& shape) {
+        IE_ASSERT(shape.size() > 1);
+        std::swap(*(shape.end() - 1), *(shape.end() - 2));
+    }
+
     void SetUp() override {
         MatMulLayerTestParamsSet basicParamsSet;
         MatMulNodeType nodeType;
@@ -105,36 +107,32 @@ protected:
         std::tie(basicParamsSet, nodeType, fusingParams) = this->GetParam();
 
         ShapeRelatedParams shapeRelatedParams;
-        Precision netPrecision;
+        ElementType netType;
         helpers::InputLayerType secondaryInputType;
         std::map<std::string, std::string> additionalConfig;
 
-        std::tie(shapeRelatedParams, netPrecision, inPrc, outPrc, inLayout, secondaryInputType, targetDevice, additionalConfig) = basicParamsSet;
+        std::tie(shapeRelatedParams, netType, inType, outType, secondaryInputType, targetDevice, additionalConfig) = basicParamsSet;
+
+        init_input_shapes(shapeRelatedParams.inputShapes);
 
         bool transpA = shapeRelatedParams.transpose.first;
         bool transpB = shapeRelatedParams.transpose.second;
 
-        auto transpose = [](ngraph::Shape& shape) {
-            IE_ASSERT(shape.size() > 1);
-            std::swap(*(shape.end() - 1), *(shape.end() - 2));
-        };
-
         if (transpA) {
-            for (auto& item : shapeRelatedParams.inputShapes.second) {
-                transpose(item[0]);
+            transpose(inputDynamicShapes[0]);
+            for (auto& shapes : targetStaticShapes) {
+                transpose(shapes[0]);
             }
         }
         if (transpB) {
-            for (auto& item : shapeRelatedParams.inputShapes.second) {
-                transpose(item[1]);
+            transpose(inputDynamicShapes[1]);
+            for (auto& shapes : targetStaticShapes) {
+                transpose(shapes[1]);
             }
         }
 
-        SizeVector inShapeA = shapeRelatedParams.inputShapes.second[0][0];
-        SizeVector inShapeB = shapeRelatedParams.inputShapes.second[0][1];
-
-        inputDynamicShapes = shapeRelatedParams.inputShapes.first;
-        targetStaticShapes = shapeRelatedParams.inputShapes.second;
+        const auto& inShapeA = inputDynamicShapes[0];
+        const auto& inShapeB = inputDynamicShapes[1];
 
         /* @todo
          * Currently nodes are not fused thought Reshape
@@ -146,21 +144,22 @@ protected:
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
         if (additionalConfig[PluginConfigParams::KEY_ENFORCE_BF16] == PluginConfigParams::YES)
-            inPrc = outPrc = netPrecision = Precision::BF16;
+            inType = outType = netType = ElementType::bf16;
         else
-            inPrc = outPrc = netPrecision;
+            inType = outType = netType;
 
         cpuNodeType = nodeType == MatMulNodeType::MatMul ? "MatMul" : "FullyConnected";
+        selectedType = makeSelectedTypeStr("jit_gemm", outType);
 
-        auto ngPrec = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
-        auto params = builder::makeParams(ngPrec, {inShapeA});
-        auto matrixB = builder::makeInputLayer(ngPrec, secondaryInputType, inShapeB);
+        auto params = builder::makeDynamicParams(netType, {inShapeA});
+
+        auto matrixB = builder::makeDynamicInputLayer(netType, secondaryInputType, inShapeB);
         if (secondaryInputType == helpers::InputLayerType::PARAMETER) {
             params.push_back(std::dynamic_pointer_cast<opset1::Parameter>(matrixB));
         }
         auto paramOuts = helpers::convert2OutputVector(helpers::castOps2Nodes<opset1::Parameter>(params));
         auto matMul = builder::makeMatMul(paramOuts[0], matrixB, transpA, transpB);
-        function = makeNgraphFunction(ngPrec, params, matMul, cpuNodeType);
+        function = makeNgraphFunction(netType, params, matMul, cpuNodeType);
         checkFusingPosition = false;
     }
 };
@@ -168,8 +167,8 @@ protected:
 TEST_P(MatMulLayerCPUTest, CompareWithRefs) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 
-    Run();
-    CheckFusingResults(executableNetwork, cpuNodeType);
+    run();
+    CheckPluginRelatedResults(executableNetwork, cpuNodeType);
 }
 
 namespace {
@@ -180,9 +179,9 @@ std::vector<std::map<std::string, std::string>> additionalConfig {
     {{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES}}
 };
 
-const std::vector<Precision> netPRCs {
-    Precision::FP32,
-    Precision::BF16
+const std::vector<ElementType> netPRCs {
+    ElementType::f32,
+    ElementType::bf16
 };
 
 /* ============= FullyConnected ============= */
@@ -195,25 +194,25 @@ const auto fusingBiasFC = fusingSpecificParams{std::make_shared<postNodesMgr>(st
             }, "fusingBiasFC"}}), {"Add"}};
 
 const std::vector<ShapeRelatedParams> IS2D = {
-    {{{}, {{{59, 1}, {1, 120}}}}, {false, false}},
-    {{{}, {{{59, 1}, {1, 120}}}}, {true, false}},
-    {{{}, {{{59, 1}, {1, 120}}}}, {false, true}},
-    {{{}, {{{59, 1}, {1, 120}}}}, {true, true}},
+    {static_shapes_to_test_representation({{59, 1}, {1, 120}}), {false, false}},
+    {static_shapes_to_test_representation({{59, 1}, {1, 120}}), {true, false}},
+    {static_shapes_to_test_representation({{59, 1}, {1, 120}}), {false, true}},
+    {static_shapes_to_test_representation({{59, 1}, {1, 120}}), {true, true}},
 
-    {{{}, {{{59, 120}, {120, 1}}}}, {false, false}},
-    {{{}, {{{59, 120}, {120, 1}}}}, {true, false}},
-    {{{}, {{{59, 120}, {120, 1}}}}, {false, true}},
-    {{{}, {{{59, 120}, {120, 1}}}}, {true, true}},
+    {static_shapes_to_test_representation({{59, 120}, {120, 1}}), {false, false}},
+    {static_shapes_to_test_representation({{59, 120}, {120, 1}}), {true, false}},
+    {static_shapes_to_test_representation({{59, 120}, {120, 1}}), {false, true}},
+    {static_shapes_to_test_representation({{59, 120}, {120, 1}}), {true, true}},
 
-    {{{}, {{{1, 120}, {120, 59}}}}, {false, false}},
-    {{{}, {{{1, 120}, {120, 59}}}}, {true, false}},
-    {{{}, {{{1, 120}, {120, 59}}}}, {false, true}},
-    {{{}, {{{1, 120}, {120, 59}}}}, {true, true}},
+    {static_shapes_to_test_representation({{1, 120}, {120, 59}}), {false, false}},
+    {static_shapes_to_test_representation({{1, 120}, {120, 59}}), {true, false}},
+    {static_shapes_to_test_representation({{1, 120}, {120, 59}}), {false, true}},
+    {static_shapes_to_test_representation({{1, 120}, {120, 59}}), {true, true}},
 
-    {{{}, {{{71, 128}, {128, 20}}}}, {false, false}},
-    {{{}, {{{71, 128}, {128, 20}}}}, {true, false}},
-    {{{}, {{{71, 128}, {128, 20}}}}, {false, true}},
-    {{{}, {{{71, 128}, {128, 20}}}}, {true, true}},
+    {static_shapes_to_test_representation({{71, 128}, {128, 20}}), {false, false}},
+    {static_shapes_to_test_representation({{71, 128}, {128, 20}}), {true, false}},
+    {static_shapes_to_test_representation({{71, 128}, {128, 20}}), {false, true}},
+    {static_shapes_to_test_representation({{71, 128}, {128, 20}}), {true, true}},
 };
 
 std::vector<fusingSpecificParams> fusingParamsSet2D {
@@ -226,9 +225,8 @@ std::vector<fusingSpecificParams> fusingParamsSet2D {
 
 const auto fullyConnectedParams2D = ::testing::Combine(::testing::ValuesIn(IS2D),
                                                        ::testing::ValuesIn(netPRCs),
-                                                       ::testing::Values(Precision::UNSPECIFIED),
-                                                       ::testing::Values(Precision::UNSPECIFIED),
-                                                       ::testing::Values(Layout::ANY),
+                                                       ::testing::Values(ElementType::undefined),
+                                                       ::testing::Values(ElementType::undefined),
                                                        ::testing::Values(helpers::InputLayerType::CONSTANT),
                                                        ::testing::Values(CommonTestUtils::DEVICE_CPU),
                                                        ::testing::ValuesIn(additionalConfig));
@@ -240,17 +238,17 @@ const auto testParams2D = ::testing::Combine(fullyConnectedParams2D,
 INSTANTIATE_TEST_SUITE_P(smoke_FC_2D, MatMulLayerCPUTest, testParams2D, MatMulLayerCPUTest::getTestCaseName);
 
 const std::vector<ShapeRelatedParams> IS3D = {
-    {{{}, {{{1, 32, 120}, {120, 5}}}}, {false, false}},
-    {{{}, {{{1, 32, 120}, {120, 5}}}}, {true, false}},
-    {{{}, {{{1, 32, 120}, {120, 5}}}}, {false, true}},
-    {{{}, {{{1, 32, 120}, {120, 5}}}}, {true, true}},
+    {static_shapes_to_test_representation({{1, 32, 120}, {120, 5}}), {false, false}},
+    {static_shapes_to_test_representation({{1, 32, 120}, {120, 5}}), {true, false}},
+    {static_shapes_to_test_representation({{1, 32, 120}, {120, 5}}), {false, true}},
+    {static_shapes_to_test_representation({{1, 32, 120}, {120, 5}}), {true, true}},
 
-    {{{}, {{{1, 32, 120}, {120, 50}}}}, {false, false}},
-    {{{}, {{{1, 32, 120}, {120, 50}}}}, {true, false}},
-    {{{}, {{{1, 32, 120}, {120, 50}}}}, {false, true}},
-    {{{}, {{{1, 32, 120}, {120, 50}}}}, {true, true}},
+    {static_shapes_to_test_representation({{1, 32, 120}, {120, 50}}), {false, false}},
+    {static_shapes_to_test_representation({{1, 32, 120}, {120, 50}}), {true, false}},
+    {static_shapes_to_test_representation({{1, 32, 120}, {120, 50}}), {false, true}},
+    {static_shapes_to_test_representation({{1, 32, 120}, {120, 50}}), {true, true}},
 
-    {{{}, {{{1, 429}, {1, 429, 1}}}}, {true, true}}
+    {static_shapes_to_test_representation({{1, 429}, {1, 429, 1}}), {true, true}}
 };
 
 std::vector<fusingSpecificParams> fusingParamsSet3D {
@@ -260,9 +258,8 @@ std::vector<fusingSpecificParams> fusingParamsSet3D {
 
 const auto fullyConnectedParams3D = ::testing::Combine(::testing::ValuesIn(IS3D),
                                                        ::testing::ValuesIn(netPRCs),
-                                                       ::testing::Values(Precision::UNSPECIFIED),
-                                                       ::testing::Values(Precision::UNSPECIFIED),
-                                                       ::testing::Values(Layout::ANY),
+                                                       ::testing::Values(ElementType::undefined),
+                                                       ::testing::Values(ElementType::undefined),
                                                        ::testing::Values(helpers::InputLayerType::CONSTANT),
                                                        ::testing::Values(CommonTestUtils::DEVICE_CPU),
                                                        ::testing::ValuesIn(additionalConfig));
@@ -273,57 +270,177 @@ const auto testParams3D = ::testing::Combine(fullyConnectedParams3D,
 
 INSTANTIATE_TEST_SUITE_P(smoke_FC_3D, MatMulLayerCPUTest, testParams3D, MatMulLayerCPUTest::getTestCaseName);
 
-}; // namespace fullyConnected
+} // namespace fullyConnected
 
 
 /* ============= MatMul ============= */
 namespace matmul {
 
 const std::vector<ShapeRelatedParams> IS = {
-    {{{}, {{{1, 2, 32, 120}, {120, 5}}}}, {false, false}},
-    {{{}, {{{1, 2, 32, 120}, {120, 5}}}}, {true, false}},
-    {{{}, {{{1, 2, 32, 120}, {120, 5}}}}, {false, true}},
-    {{{}, {{{1, 2, 32, 120}, {120, 5}}}}, {true, true}},
+    {static_shapes_to_test_representation({{1, 2, 32, 120}, {120, 5}}), {false, false}},
+    {static_shapes_to_test_representation({{1, 2, 32, 120}, {120, 5}}), {true, false}},
+    {static_shapes_to_test_representation({{1, 2, 32, 120}, {120, 5}}), {false, true}},
+    {static_shapes_to_test_representation({{1, 2, 32, 120}, {120, 5}}), {true, true}},
 
-    {{{}, {{{7, 32, 120}, {3, 7, 120, 50}}}}, {false, false}},
-    {{{}, {{{7, 32, 120}, {3, 7, 120, 50}}}}, {true, false}},
-    {{{}, {{{7, 32, 120}, {3, 7, 120, 50}}}}, {false, true}},
-    {{{}, {{{7, 32, 120}, {3, 7, 120, 50}}}}, {true, true}},
+    {static_shapes_to_test_representation({{7, 32, 120}, {3, 7, 120, 50}}), {false, false}},
+    {static_shapes_to_test_representation({{7, 32, 120}, {3, 7, 120, 50}}), {true, false}},
+    {static_shapes_to_test_representation({{7, 32, 120}, {3, 7, 120, 50}}), {false, true}},
+    {static_shapes_to_test_representation({{7, 32, 120}, {3, 7, 120, 50}}), {true, true}},
 
-    {{{}, {{{10, 10, 10}, {10, 10, 10}}}}, {false, false}},
-    {{{}, {{{10, 10, 10}, {10, 10, 10}}}}, {true, false}},
-    {{{}, {{{10, 10, 10}, {10, 10, 10}}}}, {false, true}},
-    {{{}, {{{10, 10, 10}, {10, 10, 10}}}}, {true, true}},
+    {static_shapes_to_test_representation({{10, 10, 10}, {10, 10, 10}}), {false, false}},
+    {static_shapes_to_test_representation({{10, 10, 10}, {10, 10, 10}}), {true, false}},
+    {static_shapes_to_test_representation({{10, 10, 10}, {10, 10, 10}}), {false, true}},
+    {static_shapes_to_test_representation({{10, 10, 10}, {10, 10, 10}}), {true, true}},
 
-    {{{}, {{{55, 12}, {12, 55}}}}, {false, false}},
-    {{{}, {{{55, 12}, {12, 55}}}}, {true, false}},
-    {{{}, {{{55, 12}, {12, 55}}}}, {false, true}},
-    {{{}, {{{55, 12}, {12, 55}}}}, {true, true}},
+    {static_shapes_to_test_representation({{55, 12}, {12, 55}}), {false, false}},
+    {static_shapes_to_test_representation({{55, 12}, {12, 55}}), {true, false}},
+    {static_shapes_to_test_representation({{55, 12}, {12, 55}}), {false, true}},
+    {static_shapes_to_test_representation({{55, 12}, {12, 55}}), {true, true}},
 
-    {{{{-1, -1}, {-1, -1}}, {{{55, 12}, {12, 55}}, {{33, 7}, {7, 33}}}}, {false, false}},
-    {{{{-1, -1}, {-1, -1}}, {{{55, 12}, {12, 55}}, {{33, 7}, {7, 33}}}}, {true, false}},
-    {{{{-1, -1}, {-1, -1}}, {{{55, 12}, {12, 55}}, {{33, 7}, {7, 33}}}}, {false, true}},
-    {{{{-1, -1}, {-1, -1}}, {{{55, 12}, {12, 55}}, {{33, 7}, {7, 33}}}}, {true, true}},
+    {
+        { //dynamic case description each pair per each input has {{dynamic shape}, {{static shape case1}, {static shape case2}, ...}
+            {{-1, -1}, {{55, 12}, {33, 7}}}, // input 0
+            {{-1, -1}, {{12, 55}, {7, 33}}}  // input 1
+        },
+        {false, false}
+    },
+    {
+        { //dynamic case description each pair per each input has {{dynamic shape}, {{static shape case1}, {static shape case2}, ...}
+            {{-1, -1}, {{55, 12}, {33, 7}}}, // input 0
+            {{-1, -1}, {{12, 55}, {7, 33}}} // input 1
+        },
+        {true, false}
+    },
+    {
+        { //dynamic case description each pair per each input has {{dynamic shape}, {{static shape case1}, {static shape case2}, ...}
+            {{-1, -1}, {{55, 12}, {33, 7}}}, // input 0
+            {{-1, -1}, {{12, 55}, {7, 33}}} // input 1
+        },
+        {false, true}
+    },
+    {
+        { //dynamic case description each pair per each input has {{dynamic shape}, {{static shape case1}, {static shape case2}, ...}
+            {{-1, -1}, {{55, 12}, {33, 7}}}, // input 0
+            {{-1, -1}, {{12, 55}, {7, 33}}} // input 1
+        },
+        {true, true}
+    },
 
-    {{{{-1, -1, -1, -1}, {-1, -1}}, {{{1, 2, 32, 60}, {60, 5}}, {{1, 2, 32, 30}, {30, 5}}}}, {false, false}},
-    {{{{-1, -1, -1, -1}, {-1, -1}}, {{{1, 2, 32, 60}, {60, 5}}, {{1, 2, 32, 30}, {30, 5}}}}, {true, false}},
-    {{{{-1, -1, -1, -1}, {-1, -1}}, {{{1, 2, 32, 60}, {60, 5}}, {{1, 2, 32, 30}, {30, 5}}}}, {false, true}},
-    {{{{-1, -1, -1, -1}, {-1, -1}}, {{{1, 2, 32, 60}, {60, 5}}, {{1, 2, 32, 30}, {30, 5}}}}, {true, true}},
+    {
+        { //dynamic case description each pair per each input has {{dynamic shape}, {{static shape case1}, {static shape case2}, ...}
+            {{-1, -1, -1, -1}, {{1, 2, 32, 60}, {1, 2, 32, 30}}}, // input 0
+            {{-1, -1}, {{60, 5}, {30, 5}}}  // input 1
+        },
+        {false, false}
+    },
+    {
+        { //dynamic case description each pair per each input has {{dynamic shape}, {{static shape case1}, {static shape case2}, ...}
+            {{-1, -1, -1, -1}, {{1, 2, 32, 60}, {1, 2, 32, 30}}}, // input 0
+            {{-1, -1}, {{60, 5}, {30, 5}}} // input 1
+        },
+        {true, false}
+    },
+    {
+        { //dynamic case description each pair per each input has {{dynamic shape}, {{static shape case1}, {static shape case2}, ...}
+            {{-1, -1, -1, -1}, {{1, 2, 32, 60}, {1, 2, 32, 30}}}, // input 0
+            {{-1, -1}, {{60, 5}, {30, 5}}} // input 1
+        },
+        {false, true}
+    },
+    {
+        { //dynamic case description each pair per each input has {{dynamic shape}, {{static shape case1}, {static shape case2}, ...}
+            {{-1, -1, -1, -1}, {{1, 2, 32, 60}, {1, 2, 32, 30}}}, // input 0
+            {{-1, -1}, {{60, 5}, {30, 5}}} // input 1
+        },
+        {true, true}
+    },
 
-    {{{{-1, -1, -1}, {-1, -1, -1, -1}}, {{{7, 32, 60}, {3, 7, 60, 25}}, {{7, 32, 30}, {3, 7, 30, 25}}}}, {false, false}},
-    {{{{-1, -1, -1}, {-1, -1, -1, -1}}, {{{7, 32, 60}, {3, 7, 60, 25}}, {{7, 32, 30}, {3, 7, 30, 25}}}}, {true, false}},
-    {{{{-1, -1, -1}, {-1, -1, -1, -1}}, {{{7, 32, 60}, {3, 7, 60, 25}}, {{7, 32, 30}, {3, 7, 30, 25}}}}, {false, true}},
-    {{{{-1, -1, -1}, {-1, -1, -1, -1}}, {{{7, 32, 60}, {3, 7, 60, 25}}, {{7, 32, 30}, {3, 7, 30, 25}}}}, {true, true}},
+    {
+        { //dynamic case description each pair per each input has {{dynamic shape}, {{static shape case1}, {static shape case2}, ...}
+            {{-1, -1, -1}, {{7, 32, 60}, {7, 32, 30}}}, // input 0
+            {{-1, -1, -1, -1}, {{3, 7, 60, 25}, {3, 7, 30, 25}}}  // input 1
+        },
+        {false, false}
+    },
+    {
+        { //dynamic case description each pair per each input has {{dynamic shape}, {{static shape case1}, {static shape case2}, ...}
+            {{-1, -1, -1}, {{7, 32, 60}, {7, 32, 30}}}, // input 0
+            {{-1, -1, -1, -1}, {{3, 7, 60, 25}, {3, 7, 30, 25}}} // input 1
+        },
+        {true, false}
+    },
+    {
+        { //dynamic case description each pair per each input has {{dynamic shape}, {{static shape case1}, {static shape case2}, ...}
+            {{-1, -1, -1}, {{7, 32, 60}, {7, 32, 30}}}, // input 0
+            {{-1, -1, -1, -1}, {{3, 7, 60, 25}, {3, 7, 30, 25}}} // input 1
+        },
+        {false, true}
+    },
+    {
+        { //dynamic case description each pair per each input has {{dynamic shape}, {{static shape case1}, {static shape case2}, ...}
+            {{-1, -1, -1}, {{7, 32, 60}, {7, 32, 30}}}, // input 0
+            {{-1, -1, -1, -1}, {{3, 7, 60, 25}, {3, 7, 30, 25}}} // input 1
+        },
+        {true, true}
+    },
 
-    {{{{-1, -1, -1}, {-1, -1, -1}}, {{{10, 10, 10}, {10, 10, 10}}, {{5, 5, 5}, {5, 5, 5}}}}, {false, false}},
-    {{{{-1, -1, -1}, {-1, -1, -1}}, {{{10, 10, 10}, {10, 10, 10}}, {{5, 5, 5}, {5, 5, 5}}}}, {true, false}},
-    {{{{-1, -1, -1}, {-1, -1, -1}}, {{{10, 10, 10}, {10, 10, 10}}, {{5, 5, 5}, {5, 5, 5}}}}, {false, true}},
-    {{{{-1, -1, -1}, {-1, -1, -1}}, {{{10, 10, 10}, {10, 10, 10}}, {{5, 5, 5}, {5, 5, 5}}}}, {true, true}},
+    {
+        { //dynamic case description each pair per each input has {{dynamic shape}, {{static shape case1}, {static shape case2}, ...}
+            {{-1, -1, -1}, {{10, 10, 10}, {5, 5, 5}}}, // input 0
+            {{-1, -1, -1}, {{10, 10, 10}, {5, 5, 5}}}  // input 1
+        },
+        {false, false}
+    },
+    {
+        { //dynamic case description each pair per each input has {{dynamic shape}, {{static shape case1}, {static shape case2}, ...}
+            {{-1, -1, -1}, {{10, 10, 10}, {5, 5, 5}}}, // input 0
+            {{-1, -1, -1}, {{10, 10, 10}, {5, 5, 5}}} // input 1
+        },
+        {true, false}
+    },
+    {
+        { //dynamic case description each pair per each input has {{dynamic shape}, {{static shape case1}, {static shape case2}, ...}
+            {{-1, -1, -1}, {{10, 10, 10}, {5, 5, 5}}}, // input 0
+            {{-1, -1, -1}, {{10, 10, 10}, {5, 5, 5}}} // input 1
+        },
+        {false, true}
+    },
+    {
+        { //dynamic case description each pair per each input has {{dynamic shape}, {{static shape case1}, {static shape case2}, ...}
+            {{-1, -1, -1}, {{10, 10, 10}, {5, 5, 5}}}, // input 0
+            {{-1, -1, -1}, {{10, 10, 10}, {5, 5, 5}}} // input 1
+        },
+        {true, true}
+    },
 
-    {{{{{1, 15}, {1, 15}, {1, 15}}, {{1, 15}, {1, 15}, {1, 15}}}, {{{10, 10, 10}, {10, 10, 10}}, {{5, 5, 5}, {5, 5, 5}}}}, {false, false}},
-    {{{{{1, 15}, {1, 15}, {1, 15}}, {{1, 15}, {1, 15}, {1, 15}}}, {{{10, 10, 10}, {10, 10, 10}}, {{5, 5, 5}, {5, 5, 5}}}}, {true, false}},
-    {{{{{1, 15}, {1, 15}, {1, 15}}, {{1, 15}, {1, 15}, {1, 15}}}, {{{10, 10, 10}, {10, 10, 10}}, {{5, 5, 5}, {5, 5, 5}}}}, {false, true}},
-    {{{{{1, 15}, {1, 15}, {1, 15}}, {{1, 15}, {1, 15}, {1, 15}}}, {{{10, 10, 10}, {10, 10, 10}}, {{5, 5, 5}, {5, 5, 5}}}}, {true, true}},
+    {
+        { //dynamic case description each pair per each input has {{dynamic shape}, {{static shape case1}, {static shape case2}, ...}
+            {{{1, 15}, {1, 15}, {1, 15}}, {{10, 10, 10}, {5, 5, 5}}}, // input 0
+            {{{1, 15}, {1, 15}, {1, 15}}, {{10, 10, 10}, {5, 5, 5}}}  // input 1
+        },
+        {false, false}
+    },
+    {
+        { //dynamic case description each pair per each input has {{dynamic shape}, {{static shape case1}, {static shape case2}, ...}
+            {{{1, 15}, {1, 15}, {1, 15}}, {{10, 10, 10}, {5, 5, 5}}}, // input 0
+            {{{1, 15}, {1, 15}, {1, 15}}, {{10, 10, 10}, {5, 5, 5}}} // input 1
+        },
+        {true, false}
+    },
+    {
+        { //dynamic case description each pair per each input has {{dynamic shape}, {{static shape case1}, {static shape case2}, ...}
+            {{{1, 15}, {1, 15}, {1, 15}}, {{10, 10, 10}, {5, 5, 5}}}, // input 0
+            {{{1, 15}, {1, 15}, {1, 15}}, {{10, 10, 10}, {5, 5, 5}}} // input 1
+        },
+        {false, true}
+    },
+    {
+        { //dynamic case description each pair per each input has {{dynamic shape}, {{static shape case1}, {static shape case2}, ...}
+            {{{1, 15}, {1, 15}, {1, 15}}, {{10, 10, 10}, {5, 5, 5}}}, // input 0
+            {{{1, 15}, {1, 15}, {1, 15}}, {{10, 10, 10}, {5, 5, 5}}} // input 1
+        },
+        {true, true}
+    },
 };
 
 std::vector<fusingSpecificParams> matmulFusingParams {
@@ -334,9 +451,8 @@ std::vector<fusingSpecificParams> matmulFusingParams {
 
 const auto matMulParams = ::testing::Combine(::testing::ValuesIn(IS),
                                              ::testing::ValuesIn(netPRCs),
-                                             ::testing::Values(Precision::UNSPECIFIED),
-                                             ::testing::Values(Precision::UNSPECIFIED),
-                                             ::testing::Values(Layout::ANY),
+                                             ::testing::Values(ElementType::undefined),
+                                             ::testing::Values(ElementType::undefined),
                                              ::testing::Values(helpers::InputLayerType::PARAMETER),
                                              ::testing::Values(CommonTestUtils::DEVICE_CPU),
                                              ::testing::ValuesIn(additionalConfig));
@@ -347,7 +463,7 @@ const auto testParams = ::testing::Combine(matMulParams,
 
 INSTANTIATE_TEST_SUITE_P(smoke_MM, MatMulLayerCPUTest, testParams, MatMulLayerCPUTest::getTestCaseName);
 
-}; // namespace matmul
+} // namespace matmul
 
 } // namespace
 

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/nonzero.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/nonzero.cpp
@@ -1,0 +1,166 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/base/ov_subgraph.hpp"
+#include "test_utils/cpu_test_utils.hpp"
+
+#include "ngraph_functions/builders.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+using namespace InferenceEngine;
+using namespace CPUTestUtils;
+using namespace ov::test;
+
+namespace CPULayerTestsDefinitions {
+
+typedef std::tuple<
+        InputShape,     // Input shape definition
+        ElementType     // Net precision
+> NonZeroLayerTestParams;
+
+typedef std::tuple<
+        NonZeroLayerTestParams,
+        CPUSpecificParams> NonZeroLayerCPUTestParamsSet;
+
+class NonZeroLayerCPUTest : public testing::WithParamInterface<NonZeroLayerCPUTestParamsSet>,
+                          virtual public SubgraphBaseTest, public CPUTestsBase {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<NonZeroLayerCPUTestParamsSet> obj) {
+        NonZeroLayerTestParams basicParamsSet;
+        CPUSpecificParams cpuParams;
+        std::tie(basicParamsSet, cpuParams) = obj.param;
+        std::string td;
+        ElementType netType = ElementType::undefined;
+        InputShape inputShape;
+
+        std::tie(inputShape, netType) = basicParamsSet;
+
+        std::ostringstream result;
+        result << "IS=";
+        result  << CommonTestUtils::partialShape2str({inputShape.first}) << "_";
+        result << "TS=(";
+        for (const auto& shape : inputShape.second) {
+            result << CommonTestUtils::vec2str(shape) << "_";
+        }
+        result << ")_";
+        result << "netPRC=" << netType;
+        result << CPUTestsBase::getTestCaseName(cpuParams);
+        return result.str();
+    }
+protected:
+    void SetUp() override {
+        targetDevice = CommonTestUtils::DEVICE_CPU;
+        NonZeroLayerTestParams basicParamsSet;
+        CPUSpecificParams cpuParams;
+        std::tie(basicParamsSet, cpuParams) = this->GetParam();
+        std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
+        ElementType netType = ElementType::undefined;
+        InputShape inputShape;
+        std::tie(inputShape, netType) = basicParamsSet;
+
+        init_input_shapes({inputShape});
+        auto inputParams = ngraph::builder::makeDynamicParams(netType, inputDynamicShapes);
+
+        auto nonZero = std::make_shared<ngraph::opset3::NonZero>(inputParams[0]);
+        // I8 was used as a special placeholder during calculating of primitive type if input was U8,
+        // real runtime precision is still U8
+        selectedType = makeSelectedTypeStr("ref_", netType == ElementType::u8 ? ElementType::i8 : netType);
+        inputParams[0]->set_friendly_name("input");
+        function = makeNgraphFunction(netType, inputParams, nonZero, "NonZero");
+    }
+};
+
+TEST_P(NonZeroLayerCPUTest, CompareWithRefs) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+    run();
+    CheckPluginRelatedResults(executableNetwork, "NonZero");
+}
+
+namespace {
+
+/* CPU PARAMS */
+std::vector<CPUSpecificParams> filterCPUInfoForDevice() {
+    return std::vector<CPUSpecificParams> {CPUSpecificParams{{}, {nc}, {}, {}}};;
+}
+
+const std::vector<ElementType> netPrecisions = {
+        ElementType::f32,
+        ElementType::bf16,
+        ElementType::i32,
+        ElementType::i8,
+        ElementType::u8
+};
+
+std::vector<InputShape> inShapesDynamic = {
+        {
+            //dynamic shape
+            {-1},
+            { //target static shapes
+                {100},
+                {200},
+                {300}
+            }
+        },
+        {
+            //dynamic shape
+            {-1, -1},
+            { //target static shapes
+                {4, 100},
+                {4, 200},
+                {4, 300}
+            }
+        },
+        {
+            //dynamic shape
+            {-1, -1, -1},
+            { //target static shapes
+                {4, 4, 100},
+                {4, 4, 200},
+                {4, 4, 300}
+            }
+        },
+        {
+            //dynamic shape
+            {-1, -1, -1, -1},
+            { //target static shapes
+                {4, 4, 4, 100},
+                {4, 4, 4, 200},
+                {4, 4, 4, 300}
+            }
+        },
+        {
+            //dynamic shape
+            {-1, {1, 10}, -1, {1, 500}},
+            { //target static shapes
+                {4, 4, 4, 100},
+                {4, 4, 4, 200},
+                {4, 4, 4, 300}
+            }
+        }
+};
+std::vector<ngraph::Shape> inShapesStatic = {
+        { 100 },
+        { 4, 100 },
+        { 4, 2, 100 },
+        { 4, 4, 2, 100 },
+        { 4, 4, 4, 2, 100 }
+};
+
+const auto paramsStatic = ::testing::Combine(
+        ::testing::Combine(
+                ::testing::ValuesIn(static_shapes_to_test_representation(inShapesStatic)),
+                ::testing::ValuesIn(netPrecisions)),
+        ::testing::ValuesIn(filterCPUInfoForDevice()));
+const auto paramsDynamic = ::testing::Combine(
+        ::testing::Combine(
+                ::testing::ValuesIn(inShapesDynamic),
+                ::testing::ValuesIn(netPrecisions)),
+        ::testing::ValuesIn(filterCPUInfoForDevice()));
+
+INSTANTIATE_TEST_SUITE_P(smoke_NonZeroStaticCPUTest, NonZeroLayerCPUTest,
+                         paramsStatic, NonZeroLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_NonZeroDynamicCPUTest, NonZeroLayerCPUTest,
+                         paramsDynamic, NonZeroLayerCPUTest::getTestCaseName);
+} // namespace
+} // namespace CPULayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/nonzero.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/nonzero.cpp
@@ -137,6 +137,15 @@ std::vector<InputShape> inShapesDynamic = {
                 {4, 4, 4, 200},
                 {4, 4, 4, 300}
             }
+        },
+        {
+            //dynamic shape
+            {{1, 10}, {1, 10}, {1, 10}, {1, 500}},
+            { //target static shapes
+                {4, 4, 4, 100},
+                {4, 4, 4, 200},
+                {4, 4, 4, 300}
+            }
         }
 };
 std::vector<ngraph::Shape> inShapesStatic = {

--- a/inference-engine/tests/functional/plugin/cpu/subgraph_tests/src/align_matmul_input_ranks.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/subgraph_tests/src/align_matmul_input_ranks.cpp
@@ -58,6 +58,8 @@ protected:
         const auto outputNodes = helpers::convert2OutputVector(helpers::castOps2Nodes<op::Parameter>(inputParams));
         const auto matMul = builder::makeMatMul(outputNodes[0], outputNodes[1], false, false);
 
+        selectedType = makeSelectedTypeStr("jit_gemm", ngPrec);
+
         function = makeNgraphFunction(ngPrec, inputParams, matMul, "AlignMatMulInputRanks");
     }
 
@@ -69,7 +71,7 @@ TEST_P(AlignMatMulInputRanksTest, CompareWithRefs) {
 
     Run();
     CheckNodeOfTypeCount(executableNetwork, "Reshape", expectedNumOfReshapes); // Squeeze / Unsqueeze turns into Reshape
-    CheckFusingResults(executableNetwork, "MatMul");
+    CheckPluginRelatedResults(executableNetwork, "MatMul");
 }
 
 namespace {

--- a/inference-engine/tests/functional/plugin/cpu/subgraph_tests/src/conv_maxpool_activ.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/subgraph_tests/src/conv_maxpool_activ.cpp
@@ -58,23 +58,7 @@ protected:
             pooling = builder::makePooling(conv, strides, padBegin, padEnd, kernelSize, roundingType, paddingType, false, poolType);
         }
 
-        auto makeImplStr = []() {
-            if (InferenceEngine::with_cpu_x86_avx512f()) {
-                return "jit_avx512";
-            }
-            if (InferenceEngine::with_cpu_x86_avx2()) {
-                return "jit_avx2";
-            }
-            if (InferenceEngine::with_cpu_x86_avx()) {
-                return "jit_avx";
-            }
-            if (InferenceEngine::with_cpu_x86_sse42()) {
-                return "jit_sse42";
-            }
-            return "ref";
-        };
-
-        selectedType = makeSelectedTypeStr(makeImplStr(), element::f32);
+        selectedType = makeSelectedTypeStr(getPrimitiveType(), element::f32);
 
         function = makeNgraphFunction(element::f32, inputParams, pooling, "ConvPoolActiv");
     }

--- a/inference-engine/tests/functional/plugin/cpu/subgraph_tests/src/conv_maxpool_activ.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/subgraph_tests/src/conv_maxpool_activ.cpp
@@ -58,6 +58,24 @@ protected:
             pooling = builder::makePooling(conv, strides, padBegin, padEnd, kernelSize, roundingType, paddingType, false, poolType);
         }
 
+        auto makeImplStr = []() {
+            if (InferenceEngine::with_cpu_x86_avx512f()) {
+                return "jit_avx512";
+            }
+            if (InferenceEngine::with_cpu_x86_avx2()) {
+                return "jit_avx2";
+            }
+            if (InferenceEngine::with_cpu_x86_avx()) {
+                return "jit_avx";
+            }
+            if (InferenceEngine::with_cpu_x86_sse42()) {
+                return "jit_sse42";
+            }
+            return "ref";
+        };
+
+        selectedType = makeSelectedTypeStr(makeImplStr(), element::f32);
+
         function = makeNgraphFunction(element::f32, inputParams, pooling, "ConvPoolActiv");
     }
 };
@@ -66,7 +84,7 @@ TEST_P(ConvPoolActivTest, CompareWithRefs) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 
     Run();
-    CheckFusingResults(executableNetwork, "Convolution");
+    CheckPluginRelatedResults(executableNetwork, "Convolution");
 }
 
 namespace {

--- a/inference-engine/tests/functional/plugin/cpu/subgraph_tests/src/reshape_fc.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/subgraph_tests/src/reshape_fc.cpp
@@ -59,6 +59,8 @@ protected:
         auto matrixB = builder::makeConstant<float>(element::f32, isB, {}, true);
         auto matMul = builder::makeMatMul(reshape, matrixB, false, transpB);
 
+        selectedType = makeSelectedTypeStr("jit_gemm", element::f32);
+
         function = makeNgraphFunction(element::f32, inputParams, matMul, "ReshapeFC");
     }
 };
@@ -68,7 +70,7 @@ TEST_P(ReshapeFCTest, CompareWithRefs) {
 
     Run();
     CheckNodeOfTypeCount(executableNetwork, "Reshape", 0);
-    CheckFusingResults(executableNetwork, "FullyConnected");
+    CheckPluginRelatedResults(executableNetwork, "FullyConnected");
 }
 
 namespace {

--- a/inference-engine/tests/functional/plugin/cpu/subgraph_tests/src/reshape_fc.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/subgraph_tests/src/reshape_fc.cpp
@@ -59,9 +59,10 @@ protected:
         auto matrixB = builder::makeConstant<float>(element::f32, isB, {}, true);
         auto matMul = builder::makeMatMul(reshape, matrixB, false, transpB);
 
-        selectedType = makeSelectedTypeStr("jit_gemm", element::f32);
+        const auto netType = element::f32;
+        selectedType = makeSelectedTypeStr("jit_gemm", netType);
 
-        function = makeNgraphFunction(element::f32, inputParams, matMul, "ReshapeFC");
+        function = makeNgraphFunction(netType, inputParams, matMul, "ReshapeFC");
     }
 };
 

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.cpp
@@ -119,6 +119,18 @@ void CPUTestsBase::CheckPluginRelatedResults(InferenceEngine::ExecutableNetwork 
     ASSERT_TRUE(!selectedType.empty()) << "Node type is not defined.";
     InferenceEngine::CNNNetwork execGraphInfo = execNet.GetExecGraphInfo();
     auto function = execGraphInfo.getFunction();
+    CheckPluginRelatedResultsImpl(function, std::move(nodeType));
+}
+
+void CPUTestsBase::CheckPluginRelatedResults(ov::runtime::ExecutableNetwork &execNet, std::string nodeType) const {
+    if (nodeType.empty()) return;
+
+    ASSERT_TRUE(!selectedType.empty()) << "Node type is not defined.";
+    auto function = execNet.get_runtime_function();
+    CheckPluginRelatedResultsImpl(function, std::move(nodeType));
+}
+
+void CPUTestsBase::CheckPluginRelatedResultsImpl(std::shared_ptr<const ov::Function> function, std::string nodeType) const {
     ASSERT_NE(nullptr, function);
     for (const auto &node : function->get_ops()) {
         const auto & rtInfo = node->get_rt_info();

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "cpu_test_utils.hpp"
+#include "ie_ngraph_utils.hpp"
 #include "utils/rt_info/memory_formats_attribute.hpp"
 #include <cstdint>
 
@@ -291,6 +292,12 @@ std::shared_ptr<ngraph::Node>
 CPUTestsBase::modifyGraph(const ngraph::element::Type &ngPrc, ngraph::ParameterVector &params, const std::shared_ptr<ngraph::Node> &lastNode) const {
     lastNode->get_rt_info() = getCPUInfo();
     return lastNode;
+}
+
+std::string CPUTestsBase::makeSelectedTypeStr(std::string implString, ngraph::element::Type_t elType) {
+    implString.push_back('_');
+    implString += InferenceEngine::details::convertPrecision(elType).name();
+    return implString;
 }
 
 std::vector<CPUSpecificParams> filterCPUSpecificParams(std::vector<CPUSpecificParams> &paramsVector) {

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
@@ -9,6 +9,7 @@
 #include "ie_system_conf.h"
 #include "shared_test_classes/base/layer_test_utils.hpp"
 #include <exec_graph_info.hpp>
+#include <openvino/runtime/executable_network.hpp>
 #include "ie_system_conf.h"
 
 namespace CPUTestUtils {
@@ -133,8 +134,11 @@ public:
                                                          const std::shared_ptr<ngraph::Node> &lastNode,
                                                          std::string name) const;
 
+    void CheckPluginRelatedResults(InferenceEngine::ExecutableNetwork &execNet, std::string nodeType) const;
+    void CheckPluginRelatedResults(ov::runtime::ExecutableNetwork &execNet, std::string nodeType) const;
+
 protected:
-    virtual void CheckPluginRelatedResults(InferenceEngine::ExecutableNetwork &execNet, std::string nodeType) const;
+    virtual void CheckPluginRelatedResultsImpl(std::shared_ptr<const ov::Function> function, std::string nodeType) const;
     /**
      * @brief This function modifies the initial single layer test graph to add any necessary modifications that are specific to the cpu test scope.
      * @param ngPrc Graph precision.

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
@@ -127,6 +127,7 @@ public:
     static CPUInfo makeCPUInfo(std::vector<cpu_memory_format_t> inFmts,
                                std::vector<cpu_memory_format_t> outFmts,
                                std::vector<std::string> priority);
+    static std::string makeSelectedTypeStr(std::string implString, ngraph::element::Type_t elType);
 
     CPUInfo getCPUInfo() const;
     std::shared_ptr<ngraph::Function> makeNgraphFunction(const ngraph::element::Type &ngPrc,

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/fusing_test_utils.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/fusing_test_utils.cpp
@@ -36,9 +36,7 @@ CpuTestWithFusing::modifyGraph(const ngraph::element::Type &ngPrc, ngraph::Param
     return retNode;
 }
 
-void CpuTestWithFusing::CheckFusingResults(InferenceEngine::ExecutableNetwork &execNet, std::string nodeType) const {
-    InferenceEngine::CNNNetwork execGraphInfo = execNet.GetExecGraphInfo();
-    auto function = execGraphInfo.getFunction();
+void CpuTestWithFusing::CheckFusingResults(std::shared_ptr<const ov::Function> function, std::string nodeType) const {
     ASSERT_NE(nullptr, function);
     bool isNodeFound = false;
     for (const auto & op : function->get_ops()) {
@@ -69,9 +67,9 @@ void CpuTestWithFusing::CheckFusingResults(InferenceEngine::ExecutableNetwork &e
     ASSERT_TRUE(isNodeFound) << "Node type name: \"" << nodeType << "\" has not been found.";
 }
 
-void CpuTestWithFusing::CheckPluginRelatedResults(InferenceEngine::ExecutableNetwork &execNet, std::string nodeType) const {
-    CPUTestsBase::CheckPluginRelatedResults(execNet, nodeType);
-    CheckFusingResults(execNet, nodeType);
+void CpuTestWithFusing::CheckPluginRelatedResultsImpl(std::shared_ptr<const ov::Function> function, std::string nodeType) const {
+    CPUTestsBase::CheckPluginRelatedResultsImpl(function, nodeType);
+    CheckFusingResults(function, nodeType);
 }
 
 std::shared_ptr<ngraph::Node>

--- a/inference-engine/tests/functional/plugin/cpu/test_utils/fusing_test_utils.hpp
+++ b/inference-engine/tests/functional/plugin/cpu/test_utils/fusing_test_utils.hpp
@@ -64,8 +64,10 @@ protected:
                                               ngraph::ParameterVector &params,
                                               const std::shared_ptr<ngraph::Node> &lastNode) const override;
 
-    void CheckPluginRelatedResults(InferenceEngine::ExecutableNetwork &execNet, std::string nodeType) const override;
-    void CheckFusingResults(InferenceEngine::ExecutableNetwork &execNet, std::string nodeType) const;
+    void CheckPluginRelatedResultsImpl(std::shared_ptr<const ov::Function> function, std::string nodeType) const override;
+
+private:
+    void CheckFusingResults(std::shared_ptr<const ov::Function> function, std::string nodeType) const;
 
 protected:
     std::shared_ptr<postOpMgr> postOpMgrPtr;

--- a/inference-engine/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
@@ -201,7 +201,7 @@ std::vector<ov::runtime::Tensor> SubgraphBaseTest::calculate_refs() {
     manager.run_passes(functionToProcess);
     functionToProcess->validate_nodes_and_infer_types();
 
-    ov::preprocess::PrePostProcessor prePostProc;
+    ov::preprocess::PrePostProcessor p(functionToProcess);
     const auto& inputNodes = functionToProcess->inputs();
     for (size_t i = 0; i < inputNodes.size(); ++i) {
         auto itr = std::find_if(inputs.begin(), inputs.end(),
@@ -211,7 +211,7 @@ std::vector<ov::runtime::Tensor> SubgraphBaseTest::calculate_refs() {
         if (itr != inputs.end()) {
             auto elementType = itr->second.get_element_type();
             if (inputNodes[i].get_element_type() != elementType) {
-                prePostProc.input(ov::preprocess::InputInfo(i).tensor(ov::preprocess::InputTensorInfo().set_element_type(elementType)));
+                p.input(ov::preprocess::InputInfo(i).tensor(ov::preprocess::InputTensorInfo().set_element_type(elementType)));
             }
         } else {
             std::stringstream errMsg;
@@ -224,11 +224,11 @@ std::vector<ov::runtime::Tensor> SubgraphBaseTest::calculate_refs() {
     const auto& outputs = functionToProcess->outputs();
     for (size_t i = 0; i < outputs.size(); ++i) {
         if (outType != ElementType::undefined && outType != outputs[i].get_element_type()) {
-            prePostProc.output(ov::preprocess::OutputInfo(i).tensor(ov::preprocess::OutputTensorInfo().set_element_type(outType)));
+            p.output(ov::preprocess::OutputInfo(i).tensor(ov::preprocess::OutputTensorInfo().set_element_type(outType)));
         }
     }
 
-    functionToProcess = prePostProc.build(functionToProcess);
+    functionToProcess = p.build();
 
     return ngraph::helpers::interpretFunction(functionToProcess, inputs);
 }

--- a/inference-engine/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
@@ -193,10 +193,10 @@ std::vector<ov::runtime::Tensor> SubgraphBaseTest::calculate_refs() {
     functionRefs->validate_nodes_and_infer_types();
 
     auto convertTensorPrc = [](const ov::runtime::Tensor& srcTensor, const ov::runtime::Tensor& dstTensor) {
-        static ngraph::op::Convert covert;
+        static ngraph::op::Convert convert;
         auto src = std::make_shared<ov::HostTensor>(srcTensor.get_element_type(), srcTensor.get_shape(), srcTensor.data());
         auto dst = std::make_shared<ov::HostTensor>(dstTensor.get_element_type(), dstTensor.get_shape(), dstTensor.data());
-        covert.evaluate({dst}, {src});
+        convert.evaluate({dst}, {src});
     };
 
     InputsMap referenceFuncInputs;

--- a/inference-engine/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
@@ -12,8 +12,6 @@
 
 #include "openvino/core/preprocess/pre_post_process.hpp"
 #include "openvino/pass/serialize.hpp"
-#include "openvino/core/preprocess/pre_post_process.hpp"
-#include "ngraph/op/convert.hpp"
 
 #include "graph_comparator.hpp"
 
@@ -131,7 +129,6 @@ void SubgraphBaseTest::compare(const std::vector<ov::runtime::Tensor>& expected,
 }
 
 void SubgraphBaseTest::configure_model() {
-    // Caution!!! This parameters work properly only for test cases with static shapes, see issue: CVS-70301
     // configure input precision
     ov::preprocess::PrePostProcessor p(function);
     {

--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/src/input_layer.cpp
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/src/input_layer.cpp
@@ -28,5 +28,18 @@ std::shared_ptr<ngraph::Node> makeInputLayer(const element::Type &type, ngraph::
     }
     return input;
 }
+
+std::shared_ptr<ngraph::Node> makeDynamicInputLayer(const element::Type &type, ngraph::helpers::InputLayerType inputType,
+                                                    const PartialShape& shape) {
+    if (shape.is_static()) {
+        return makeInputLayer(type, inputType, shape.get_shape());
+    }
+
+    if (inputType == ngraph::helpers::InputLayerType::PARAMETER) {
+        return ngraph::builder::makeDynamicParams(type, {shape}).front();
+    }
+
+    throw std::runtime_error("Could not make input layer. Unsupported inputType for dynamic shape");
+}
 }  // namespace builder
 }  // namespace ngraph


### PR DESCRIPTION
### Details:
MatMul, NonZero nodes CPU specific single layer (SL) tests are extended with dynamic shapes. The SL tests now use the new common single layer test infrastructure that contains all the latest OpenVINO API changes, especially with regard to support dynamic shapes.

### Tickets:
 - *ticket-id*
