### PR TITLE
[GPU] Bugfix 1c redun reorder

### DIFF
--- a/inference-engine/thirdparty/clDNN/api/cldnn/primitives/convolution.hpp
+++ b/inference-engine/thirdparty/clDNN/api/cldnn/primitives/convolution.hpp
@@ -804,20 +804,6 @@ struct convolution : public primitive_base<convolution> {
     /// @brief On how many cards split the computation to.
     int32_t split() const { return static_cast<int32_t>(weights.size()); }
 
-    /// @brief Validates if this convolution satisfies condition to support mixed format execution from bfyx to blocked fsv16.
-    /// This validation is used by selecting onednn type as preferred impl and handling reorders at reorder_inputs and remove_redundant_reorders.
-    /// As an example, if a reorder has 2 reorder users that each reorder has a convolution user, then merge is not done when those 2 convolutions
-    /// have different result from this function.
-    /// Currently, if an input channel of the first onednn conv is 1, then ref kernel is selected.
-    bool needs_onednn_bfyx_to_fsv16(format fmt_prev, format fmt_next, layout& prev_output_layout, layout& next_output_layout) const {
-        if (fmt_prev == format::bfyx && (fmt_next == format::b_fs_yx_fsv16 || fmt_next == format::bs_fs_yx_bsv32_fsv16) &&
-            next_output_layout.size.feature[0] >= 16 && prev_output_layout.size.feature[0] <= 4 && prev_output_layout.size.feature[0] >= 2 &&
-            activations_zero_points.empty() && weights_zero_points.empty())
-            return true;
-
-        return false;
-    }
-
     std::vector<std::reference_wrapper<const primitive_id>> get_dependencies() const override {
         std::vector<std::reference_wrapper<const primitive_id>> ret;
         ret.reserve(weights.size() + bias.size() + weights_zero_points.size() +

--- a/inference-engine/thirdparty/clDNN/src/graph_optimizer/remove_redundant_reorders.cpp
+++ b/inference-engine/thirdparty/clDNN/src/graph_optimizer/remove_redundant_reorders.cpp
@@ -366,23 +366,26 @@ void remove_redundant_reorders::run(program& p) {
         p.remove_if_dangling(node);
     }
 
-    // Remove reorder for Convolution bfyx -> fs_b_yx_fsv32 (+ onednn: bfyx -> b_fs_yx_fsv32)
+    // Remove reorder for cldnn convolution bfyx -> fs_b_yx_fsv32.
+    //                for onednn convolution bfyx-> b_fs_yx_fsv32 (only shallow-depth input)
     auto try_fuse_reorder_bfyx_to_fsv32 = [&](reorder_node* node) -> bool {
         if (node->get_users().size() != 1)
             return false;
 
         auto& usr = node->get_users().front();
         auto& dep = node->get_dependency(0);
+        auto  dep_layout = dep.get_output_layout();
 
         if (!(usr->is_type<convolution>()) ||
-            node->get_output_layout().data_type != dep.get_output_layout().data_type ||
-            dep.get_output_layout().format != format::bfyx)
+            node->get_output_layout().data_type != dep_layout.data_type ||
+            dep_layout.format != format::bfyx)
             return false;
         if (usr->as<convolution>().get_preferred_impl_type() != impl_types::onednn &&
             usr->get_output_layout().format != format::fs_b_yx_fsv32)
             return false;
         if (usr->as<convolution>().get_preferred_impl_type() == impl_types::onednn &&
-            usr->get_output_layout().format != format::b_fs_yx_fsv32)
+            (usr->get_output_layout().format != format::b_fs_yx_fsv32 ||
+            !lo.needs_onednn_bfyx_to_blocked(dep_layout.format, usr->get_output_layout().format, dep_layout, usr->as<convolution>())))
             return false;
 
         if (dep.is_type<input_layout>())

--- a/inference-engine/thirdparty/clDNN/src/graph_optimizer/reorder_inputs.cpp
+++ b/inference-engine/thirdparty/clDNN/src/graph_optimizer/reorder_inputs.cpp
@@ -358,8 +358,7 @@ void insert_reorders_in_dir(program& p, const std::map<program_node*, format::ty
         bool needs_split_reorder = false;
         bool use_onednn_impls = lo.get_optimization_attributes().use_onednn_impls;
         if (node->is_type<convolution>() && use_onednn_impls)
-            needs_split_reorder = node->as<convolution>().get_primitive()->needs_onednn_bfyx_to_fsv16(in_layout.format, out_layout.format,
-                                                                                                      in_layout, current_layout);
+            needs_split_reorder = lo.needs_onednn_bfyx_to_blocked(in_layout.format, out_layout.format, in_layout, node->as<convolution>());
 
         auto reorder_pair = rf.get_reorder(travel_direction_wrapper<dir>::first(node, next)->id(),
                                            in_layout,

--- a/inference-engine/thirdparty/clDNN/src/include/layout_optimizer.h
+++ b/inference-engine/thirdparty/clDNN/src/include/layout_optimizer.h
@@ -202,5 +202,11 @@ public:
     size_t get_total_conv_count();
 
     bool should_select_b_fs_yx_fsv16_layout(convolution_node const& node, layout const& output_or_weights_layout);
+
+    /// @brief Validates if this convolution satisfies condition to support mixed format execution from bfyx to blocked fsv16 or fsv32.
+    /// This validation is used by selecting onednn type as preferred impl and handling reorders at reorder_inputs and remove_redundant_reorders.
+    /// As an example, if a reorder has 2 reorder users that each reorder has a convolution user, then merge is not done when those 2 convolutions
+    /// have different result from this function.
+    bool needs_onednn_bfyx_to_blocked(format fmt_prev, format fmt_next, layout& prev_output_layout, const convolution_node& node);
 };
 }  // namespace cldnn

--- a/inference-engine/thirdparty/clDNN/src/layout_optimizer.cpp
+++ b/inference-engine/thirdparty/clDNN/src/layout_optimizer.cpp
@@ -196,8 +196,7 @@ bool layout_optimizer::can_fuse_reorder(program_node& prev, program_node& next, 
             auto& conv = next.get_users().front()->as<convolution>();
             auto reorder_input_layout = next.get_dependencies().front()->get_output_layout();
             auto conv_output_layout = conv.get_output_layout();
-            if (conv.get_primitive()->needs_onednn_bfyx_to_fsv16(reorder_input_layout.format, conv_output_layout.format,
-                                                                 next_output_layout, conv_output_layout))
+            if (needs_onednn_bfyx_to_blocked(reorder_input_layout.format, conv_output_layout.format, next_output_layout, conv))
                 return false;
         }
 
@@ -259,7 +258,7 @@ bool layout_optimizer::can_fuse_reorder(program_node& prev, program_node& next, 
 
     // Fuse reorder if the following onednn convolution supports bfyx input
     if (next.is_type<convolution>() && use_onednn_impls && prev_dt == next_dt &&
-        next.as<convolution>().get_primitive()->needs_onednn_bfyx_to_fsv16(fmt_prev, fmt_next, prev_output_layout, next_output_layout))
+        needs_onednn_bfyx_to_blocked(fmt_prev, fmt_next, prev_output_layout, next.as<convolution>()))
         return true;
 
     // Support to avoid onednn first convolution selects ref kernel
@@ -299,6 +298,7 @@ bool layout_optimizer::can_fuse_reorder(program_node& prev, program_node& next, 
             prev.is_input() && (prev_dt == data_types::u8 || prev_dt == data_types::i8))
             return true;
 
+        // Remove Reorder to support mixed format convolutions of bsv32fsv16 or bsv32fsv32 output
         if (next.is_type<convolution>() && (prev.is_type<eltwise>() || prev.is_type<quantize>()) &&
             (fmt_prev == format::bfyx || fmt_prev == format::bs_fs_yx_bsv4_fsv2) &&
             ((fmt_next == format::bs_fs_yx_bsv32_fsv32 && (prev_output_layout.size.feature[0] == 3 || prev_output_layout.size.feature[0] == 4)) ||
@@ -692,6 +692,24 @@ bool layout_optimizer::deconvolution_b_fs_yx_fsv16_opt(layout const &input_layou
     if (input_layout.format.dimension() == 4 &&
         (input_layout.data_type == data_types::i8 || input_layout.data_type == data_types::u8) &&
         deconv->split() == 1)
+        return true;
+
+    return false;
+}
+
+bool layout_optimizer::needs_onednn_bfyx_to_blocked(format fmt_prev, format fmt_next, layout& prev_output_layout, const convolution_node& node) {
+    auto next_output_layout = node.get_output_layout();
+    if (prev_output_layout.data_type != next_output_layout.data_type)
+        return false;
+
+    // Target output_layout format
+    if (!(fmt_next == format::b_fs_yx_fsv16 || fmt_next == format::bs_fs_yx_bsv32_fsv16 ||
+        fmt_next == format::b_fs_yx_fsv32 || fmt_next == format::bs_fs_yx_bsv32_fsv32))
+        return false;
+
+    if (fmt_prev == format::bfyx &&
+        next_output_layout.size.feature[0] >= 16 && prev_output_layout.size.feature[0] <= 4 && prev_output_layout.size.feature[0] >= 2 &&
+        node.get_primitive()->activations_zero_points.empty() && node.get_primitive()->weights_zero_points.empty())
         return true;
 
     return false;
@@ -1206,7 +1224,7 @@ impl_types layout_optimizer::get_preferred_impl_type(program_node& node, format 
             bool enable_onednn_dw_fp16_conv = fp16_input && is_depthwise;
             if (((has_groups && !enable_onednn_dw_fp16_conv) || first_conv) &&
                 (output_layout.format == format::b_fs_yx_fsv16 || output_layout.format == format::bs_fs_yx_bsv32_fsv16) &&
-                (!conv.get_primitive()->needs_onednn_bfyx_to_fsv16(format::bfyx, output_layout.format, input_layout, output_layout)))
+                !needs_onednn_bfyx_to_blocked(format::bfyx, output_layout.format, input_layout, conv))
                 impl_candidate = impl_types::ocl;
         }
 
@@ -1338,7 +1356,7 @@ format layout_optimizer::get_preferred_format(program_node& node) {
         auto& input = node.get_dependency(0);
         if (use_onednn_impls && input.get_output_layout().size.feature[0] == 1 && input.is_in_data_flow() && !input.is_constant()) {
             auto in_layout = input.get_output_layout();
-            if (in_layout.format == format::bfyx && output_layout.size.feature[0] >= 16)
+            if (in_layout.format == format::bfyx && output_layout.size.feature[0] >= 16 && expected != format::bfyx)
                 expected = format::b_fs_yx_fsv16;
         }
     } else if (node.is_type<binary_convolution>()) {


### PR DESCRIPTION
### Details:
 - Minor bugfix in layout optimizer for conv (bfyx->bfyx)
 - modify logic of removing reorder for fsv32 (only shallow input)

### Tickets:
 - *ticket-id*
