### PR TITLE
[GPU] Fixed allocation type for optimized out outputs

### DIFF
--- a/inference-engine/thirdparty/clDNN/tests/test_cases/fusings_gpu_test.cpp
+++ b/inference-engine/thirdparty/clDNN/tests/test_cases/fusings_gpu_test.cpp
@@ -2315,7 +2315,7 @@ TEST_P(conv_int8_scale_activation_quantize_i8, basic) {
                  reorder("reorder_bfyx", "quantize", p.default_format, data_types::f32)
     );
 
-    tolerance = 1.f;
+    tolerance = 2.f;
     execute(p);
 }
 


### PR DESCRIPTION
### Details:
 - in reshape_gpu_f32.shrink_chain_partial test we had usm_device output which could lead to assertion fail in debug or crash in release build
