### PR TITLE
[CPU][dynamism] MatMulToFullyConnected transformation temporary disabled

### DIFF
--- a/inference-engine/src/mkldnn_plugin/ngraph_transformations/convert_to_cpu_specific_opset.hpp
+++ b/inference-engine/src/mkldnn_plugin/ngraph_transformations/convert_to_cpu_specific_opset.hpp
@@ -48,6 +48,12 @@ inline void ConvertToCPUSpecificOpset(std::shared_ptr<ngraph::Function> &nGraphF
     }
     manager.register_pass<ngraph::pass::ConstantFolding>();
     manager.register_pass<ngraph::pass::ConvertPrecision>(precisions_array {{ ngraph::element::i64, ngraph::element::i32 }});
+
+    // TODO: remove after dynamic shapes support in FullyConnectedNode
+    manager.get_pass_config()->set_callback<ConvertMatMulToFC>([](const std::shared_ptr<const ngraph::Node>& node) -> bool {
+        return node->get_input_partial_shape(0).is_dynamic();
+    });
+
     manager.run_passes(nGraphFunc);
 }
 


### PR DESCRIPTION
### Details:
*ConvertMatMulToFC transformation is disabled for dynamic cases. This workaround will be removed after dynamic shapes support in FullyConnectedNode*