### PR TITLE
benchmark_app bugfix for filling input

### DIFF
--- a/inference-engine/samples/common/format_reader/opencv_wrapper.cpp
+++ b/inference-engine/samples/common/format_reader/opencv_wrapper.cpp
@@ -36,7 +36,7 @@ std::shared_ptr<unsigned char> OCVReader::getData(size_t width = 0, size_t heigh
     size_t size = width * height * img.channels();
     _data.reset(new unsigned char[size], std::default_delete<unsigned char[]>());
 
-    cv::Mat resized(width, height, img.type(), _data.get());
+    cv::Mat resized(cv::Size(width, height), img.type(), _data.get());
 
     if (width != img.cols || height != img.rows) {
         slog::warn << "Image is resized from (" << img.cols << ", " << img.rows << ") to (" << width << ", " << height


### PR DESCRIPTION
Benchmark_app created mismatching buffer because of transposition of
width/height. Input was not fed into network in case of non-square form.

### Details:
 - The issue was introduced from PR-8093
