### PR TITLE
remove DISABLED_ from conv_fusion_tests.cpp

### DIFF
--- a/inference-engine/tests/functional/inference_engine/transformations/conv_fusion_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/conv_fusion_test.cpp
@@ -177,7 +177,7 @@ INSTANTIATE_TEST_SUITE_P(DISABLED_ConvAddFusionNegative, ConvFusionTests,
                         std::make_tuple(InputShape{2, DYN, 64, 64, 64}, WeightsShape{9, 3, 2, 3, 1},
                                         add::get_type_info_static(), EltwiseShape{9, 1, 1, 1, 1}, true)));
 
-INSTANTIATE_TEST_SUITE_P(DISABLED_ConvMulFusion, ConvFusionTests,
+INSTANTIATE_TEST_SUITE_P(ConvMulFusion, ConvFusionTests,
         testing::Values(std::make_tuple(InputShape{DYN, DYN, DYN, DYN, DYN}, WeightsShape{8, 3, 1, 2, 3},
                                         mul::get_type_info_static(), EltwiseShape{8, 1, 1, 1}, false),
                         std::make_tuple(InputShape{DYN, 3, 64, 64, 64}, WeightsShape{8, 3, 1, 2, 3},


### PR DESCRIPTION
### Details:
 - *remove "DISABLED" from some tests. But if I try to remove all "DISABLED" - 6 tests start to fail*
 - *bug-ticket attached*
### Related-ticket:
- *70130*

