### PR TITLE
Fix PartialShape Iterators to reset cache

### DIFF
--- a/ngraph/core/include/openvino/core/partial_shape.hpp
+++ b/ngraph/core/include/openvino/core/partial_shape.hpp
@@ -224,6 +224,7 @@ public:
     ///        element in the shape. Iteration is done in ordinary
     ///        element order.
     iterator begin() noexcept {
+        m_shape_type = ShapeType::SHAPE_IS_UPDATED;
         return m_dimensions.begin();
     }
     /// \brief Returns a read-only (constant) iterator that points to the
@@ -236,6 +237,7 @@ public:
     ///        element in the shape. Iteration is done in ordinary
     ///        element order.
     iterator end() noexcept {
+        m_shape_type = ShapeType::SHAPE_IS_UPDATED;
         return m_dimensions.end();
     }
     /// \brief Returns a read-only (constant) iterator that points one past
@@ -248,6 +250,7 @@ public:
     ///        last element in the shape. Iteration is done in reverse
     ///        element order.
     reverse_iterator rbegin() noexcept {
+        m_shape_type = ShapeType::SHAPE_IS_UPDATED;
         return m_dimensions.rbegin();
     }
     /// \brief Returns a read-only (constant) reverse iterator that points
@@ -260,6 +263,7 @@ public:
     ///        before the first element in the shape. Iteration is done
     ///        in reverse element order.
     reverse_iterator rend() noexcept {
+        m_shape_type = ShapeType::SHAPE_IS_UPDATED;
         return m_dimensions.rend();
     }
     /// \brief Returns a read-only (constant) reverse iterator that points

--- a/ngraph/test/partial_shape.cpp
+++ b/ngraph/test/partial_shape.cpp
@@ -9,6 +9,44 @@
 
 using namespace ngraph;
 
+TEST(partial_shape, interators) {
+    const PartialShape ps({1, 2, 3});
+    ASSERT_TRUE(ps.is_static());
+    {
+        auto p = ps;
+        for (auto& d : p) {
+            d = Dimension::dynamic();
+        }
+        ASSERT_TRUE(p.is_dynamic());
+    }
+    {
+        auto p = ps;
+        auto it = p.begin();
+        *it = Dimension::dynamic();
+        ASSERT_TRUE(p.is_dynamic());
+    }
+    {
+        auto p = ps;
+        auto it = p.rbegin();
+        *it = Dimension::dynamic();
+        ASSERT_TRUE(p.is_dynamic());
+    }
+    {
+        auto p = ps;
+        auto it = p.end();
+        --it;
+        *it = Dimension::dynamic();
+        ASSERT_TRUE(p.is_dynamic());
+    }
+    {
+        auto p = ps;
+        auto it = p.rend();
+        --it;
+        *it = Dimension::dynamic();
+        ASSERT_TRUE(p.is_dynamic());
+    }
+}
+
 TEST(partial_shape, ps_construction_empty) {
     auto ps = PartialShape{};
     ASSERT_TRUE(ps.rank().is_static());


### PR DESCRIPTION
### Details
Fix PartialShape is_static method caching approach for case when non constant iterators are used.

### Ticket
XXX-62301
