### PR TITLE
Added Import/Export functions to C_API #8353

### DIFF
--- a/inference-engine/ie_bridges/c/include/c_api/ie_c_api.h
+++ b/inference-engine/ie_bridges/c/include/c_api/ie_c_api.h
@@ -416,17 +416,18 @@ INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_import_network(ie_core
         const ie_config_t *config, ie_executable_network_t **exe_network);
 
 /**
-* @brief Creates an executable network from a network previously exported to blob. Users can create as many networks as they need and use
+* @brief Creates an executable network from a network previously exported to memory. Users can create as many networks as they need and use
 * them simultaneously (up to the limitation of the hardware resources). Use the ie_exec_network_free() method to free memory.
 * @ingroup Core
 * @param core A pointer to ie_core_t instance.
-* @param model_blob A pointer to ie_blob_t with exported network into blob.
+* @param content A pointer to content of exported network.
+* @param content_size Number of bytes in the exported network.
 * @param device_name Name of device to load network to.
 * @param config Device configuration.
 * @param exe_network A pointer to the newly created executable network.
 * @return Status code of the operation: OK(0) for success.
 */
-INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_import_network_from_memory(ie_core_t *core, const ie_blob_t *model_blob, \
+INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_import_network_from_memory(ie_core_t *core, const uint8_t *content, size_t content_size,
         const char *device_name, const ie_config_t *config, ie_executable_network_t **exe_network);
 
 /**
@@ -437,7 +438,7 @@ INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_import_network_from_me
 * @param exe_network A pointer to the newly created executable network.
 * @return Status code of the operation: OK(0) for success.
 */
-INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_export_network(ie_core_t *core, const char *file_name, \
+INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_export_network(ie_core_t *core, const char *file_name,
         ie_executable_network_t *exe_network);
 
 /**

--- a/inference-engine/ie_bridges/c/include/c_api/ie_c_api.h
+++ b/inference-engine/ie_bridges/c/include/c_api/ie_c_api.h
@@ -438,8 +438,7 @@ INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_import_network_from_me
 * @param exe_network A pointer to the newly created executable network.
 * @return Status code of the operation: OK(0) for success.
 */
-INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_export_network(ie_core_t *core, const char *file_name,
-        ie_executable_network_t *exe_network);
+INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_export_network(const char *file_name, ie_executable_network_t *exe_network);
 
 /**
  * @brief Creates an executable network from a given network object. Users can create as many networks as they need and use

--- a/inference-engine/ie_bridges/c/include/c_api/ie_c_api.h
+++ b/inference-engine/ie_bridges/c/include/c_api/ie_c_api.h
@@ -426,7 +426,8 @@ INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_import_network(ie_core
 * @param exe_network A pointer to the newly created executable network.
 * @return Status code of the operation: OK(0) for success.
 */
-INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_import_network_from_memory(ie_core_t *core, const ie_blob_t *model_blob, const char *device_name, const ie_config_t *config, ie_executable_network_t **exe_network);
+INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_import_network_from_memory(ie_core_t *core, const ie_blob_t *model_blob, \
+        const char *device_name, const ie_config_t *config, ie_executable_network_t **exe_network);
 
 /**
 * @brief Exports an executable network to bin file.
@@ -437,7 +438,7 @@ INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_import_network_from_me
 * @return Status code of the operation: OK(0) for success.
 */
 INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_export_network(ie_core_t *core, const char *file_name, \
-        ie_executable_network_t **exe_network);
+        ie_executable_network_t *exe_network);
 
 /**
  * @brief Creates an executable network from a network object. Users can create as many networks as they need and use

--- a/inference-engine/ie_bridges/c/include/c_api/ie_c_api.h
+++ b/inference-engine/ie_bridges/c/include/c_api/ie_c_api.h
@@ -426,11 +426,25 @@ INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_import_network_from_fi
 * @param exe_network A pointer to the newly created executable network.
 * @return Status code of the operation: OK(0) for success.
 */
-INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_import_network(ie_core_t *core, const char *net_model, const char *device_name, \
+INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_import_network(ie_core_t *core, const char *file_name, const char *device_name, \
         const ie_config_t *config, ie_executable_network_t **exe_network);
 
-INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_export_network(ie_core_t *core, ie_executable_network_t *network, char *str,\
+/**
+* @brief Creates an executable network from a previously exported network. Users can create as many networks as they need and use
+* them simultaneously (up to the limitation of the hardware resources). Use the ie_exec_network_free() method to free memory.
+* @ingroup Core
+* @param core A pointer to ie_core_t instance.
+* @param exported_blob A pointer to ie_blob_t with exported network into blob.
+* @param network A pointer to the newly created executable network.
+* @return Status code of the operation: OK(0) for success.
+*/
+INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_import_network_from_memory(ie_core_t *core, const ie_blob_t *exported_blob, \
         ie_executable_network_t **exe_network);
+
+INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_export_network(ie_core_t *core, const char *file_name, \
+        ie_executable_network_t **exe_network);
+
+INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_export_network_to_memory(ie_core_t *core, ie_blob_t **blob, ie_executable_network_t **exe_network);
 
 /**
  * @brief Creates an executable network from a network object. Users can create as many networks as they need and use

--- a/inference-engine/ie_bridges/c/include/c_api/ie_c_api.h
+++ b/inference-engine/ie_bridges/c/include/c_api/ie_c_api.h
@@ -402,6 +402,37 @@ INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_read_network_from_memo
     const ie_blob_t *weight_blob, ie_network_t **network);
 
 /**
+* @brief Creates an executable network from a previously exported network. Users can create as many networks as they need and use
+* them simultaneously (up to the limitation of the hardware resources). Use the ie_exec_network_free() method to free memory.
+* @ingroup Core
+* @param core A pointer to ie_core_t instance.
+* @param file_name Path to the location of the exported file.
+* @param device_name Name of device to load network to.
+* @param config Device configuration.
+* @param exe_network A pointer to the newly created executable network.
+* @return Status code of the operation: OK(0) for success.
+*/
+INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_import_network_from_file(ie_core_t *core, const char *file_name, const char *device_name, \
+        const ie_config_t *config, ie_executable_network_t **exe_network);
+
+/**
+* @brief Creates an executable network from a previously exported network. Users can create as many networks as they need and use
+* them simultaneously (up to the limitation of the hardware resources). Use the ie_exec_network_free() method to free memory.
+* @ingroup Core
+* @param core A pointer to ie_core_t instance.
+* @param file_name Path to the location of the exported file.
+* @param device_name Name of device to load network to.
+* @param config Device configuration.
+* @param exe_network A pointer to the newly created executable network.
+* @return Status code of the operation: OK(0) for success.
+*/
+INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_import_network(ie_core_t *core, const char *net_model, const char *device_name, \
+        const ie_config_t *config, ie_executable_network_t **exe_network);
+
+INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_export_network(ie_core_t *core, ie_executable_network_t *network, char *str,\
+        ie_executable_network_t **exe_network);
+
+/**
  * @brief Creates an executable network from a network object. Users can create as many networks as they need and use
  * them simultaneously (up to the limitation of the hardware resources). Use the ie_exec_network_free() method to free memory.
  * @ingroup Core

--- a/inference-engine/ie_bridges/c/include/c_api/ie_c_api.h
+++ b/inference-engine/ie_bridges/c/include/c_api/ie_c_api.h
@@ -379,7 +379,7 @@ INFERENCE_ENGINE_C_API(void) ie_core_versions_free(ie_core_versions_t *vers);
 /**
  * @brief Reads the model from the .xml and .bin files of the IR. Use the ie_network_free() method to free memory.
  * @ingroup Core
- * @param core A pointer to ie_core_t instance.
+ * @param core A pointer to the ie_core_t instance.
  * @param xml .xml file's path of the IR.
  * @param weights_file .bin file's path of the IR, if path is empty, will try to read bin file with the same name as xml and
  * if bin file with the same name was not found, will load IR without weights.
@@ -391,7 +391,7 @@ INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_read_network(ie_core_t
 /**
  * @brief Reads the model from an xml string and a blob of the bin part of the IR. Use the ie_network_free() method to free memory.
  * @ingroup Core
- * @param core A pointer to ie_core_t instance.
+ * @param core A pointer to the ie_core_t instance.
  * @param xml_content Xml content of the IR.
  * @param xml_content_size Number of bytes in the xml content of the IR.
  * @param weight_blob Blob containing the bin part of the IR.
@@ -402,12 +402,12 @@ INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_read_network_from_memo
     const ie_blob_t *weight_blob, ie_network_t **network);
 
 /**
-* @brief Creates an executable network from a network previously exported to file. Users can create as many networks as they need and use
+* @brief Creates an executable network from a network previously exported to a file. Users can create as many networks as they need and use
 * them simultaneously (up to the limitation of the hardware resources). Use the ie_exec_network_free() method to free memory.
 * @ingroup Core
-* @param core A pointer to ie_core_t instance.
-* @param file_name Path to the location of the exported file.
-* @param device_name Name of device to load network to.
+* @param core A pointer to the ie_core_t instance.
+* @param file_name A path to the location of the exported file.
+* @param device_name A name of the device to load the network to.
 * @param config Device configuration.
 * @param exe_network A pointer to the newly created executable network.
 * @return Status code of the operation: OK(0) for success.
@@ -419,10 +419,10 @@ INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_import_network(ie_core
 * @brief Creates an executable network from a network previously exported to memory. Users can create as many networks as they need and use
 * them simultaneously (up to the limitation of the hardware resources). Use the ie_exec_network_free() method to free memory.
 * @ingroup Core
-* @param core A pointer to ie_core_t instance.
-* @param content A pointer to content of exported network.
+* @param core A pointer to the ie_core_t instance.
+* @param content A pointer to content of the exported network.
 * @param content_size Number of bytes in the exported network.
-* @param device_name Name of device to load network to.
+* @param device_name A name of the device to load the network to.
 * @param config Device configuration.
 * @param exe_network A pointer to the newly created executable network.
 * @return Status code of the operation: OK(0) for success.
@@ -431,10 +431,10 @@ INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_import_network_from_me
         const char *device_name, const ie_config_t *config, ie_executable_network_t **exe_network);
 
 /**
-* @brief Exports an executable network to bin file.
+* @brief Exports an executable network to a .bin file.
 * @ingroup Core
-* @param core A pointer to ie_core_t instance.
-* @param file_name Path to the location of the file exporting to.
+* @param core A pointer to the ie_core_t instance.
+* @param file_name Path to the file to export the network to.
 * @param exe_network A pointer to the newly created executable network.
 * @return Status code of the operation: OK(0) for success.
 */
@@ -442,12 +442,12 @@ INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_export_network(ie_core
         ie_executable_network_t *exe_network);
 
 /**
- * @brief Creates an executable network from a network object. Users can create as many networks as they need and use
+ * @brief Creates an executable network from a given network object. Users can create as many networks as they need and use
  * them simultaneously (up to the limitation of the hardware resources). Use the ie_exec_network_free() method to free memory.
  * @ingroup Core
- * @param core A pointer to ie_core_t instance.
- * @param network A pointer to ie_network instance.
- * @param device_name Name of device to load network to.
+ * @param core A pointer to the ie_core_t instance.
+ * @param network A pointer to the input ie_network instance to create the executable network from.
+ * @param device_name Name of the device to load the network to.
  * @param config Device configuration.
  * @param exe_network A pointer to the newly created executable network.
  * @return Status code of the operation: OK(0) for success.
@@ -459,7 +459,7 @@ INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_load_network(ie_core_t
 * @brief Reads model and creates an executable network from IR or ONNX file. Users can create as many networks as they need and use
 * them simultaneously (up to the limitation of the hardware resources). Use the ie_exec_network_free() method to free memory.
 * @ingroup Core
-* @param core A pointer to ie_core_t instance.
+* @param core A pointer to the ie_core_t instance.
 * @param xml .xml file's path of the IR. Weights file name will be calculated automatically
 * @param device_name Name of device to load network to.
 * @param config Device configuration.

--- a/inference-engine/ie_bridges/c/include/c_api/ie_c_api.h
+++ b/inference-engine/ie_bridges/c/include/c_api/ie_c_api.h
@@ -412,20 +412,6 @@ INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_read_network_from_memo
 * @param exe_network A pointer to the newly created executable network.
 * @return Status code of the operation: OK(0) for success.
 */
-INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_import_network_from_file(ie_core_t *core, const char *file_name, const char *device_name, \
-        const ie_config_t *config, ie_executable_network_t **exe_network);
-
-/**
-* @brief Creates an executable network from a previously exported network. Users can create as many networks as they need and use
-* them simultaneously (up to the limitation of the hardware resources). Use the ie_exec_network_free() method to free memory.
-* @ingroup Core
-* @param core A pointer to ie_core_t instance.
-* @param file_name Path to the location of the exported file.
-* @param device_name Name of device to load network to.
-* @param config Device configuration.
-* @param exe_network A pointer to the newly created executable network.
-* @return Status code of the operation: OK(0) for success.
-*/
 INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_import_network(ie_core_t *core, const char *file_name, const char *device_name, \
         const ie_config_t *config, ie_executable_network_t **exe_network);
 
@@ -434,17 +420,24 @@ INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_import_network(ie_core
 * them simultaneously (up to the limitation of the hardware resources). Use the ie_exec_network_free() method to free memory.
 * @ingroup Core
 * @param core A pointer to ie_core_t instance.
-* @param exported_blob A pointer to ie_blob_t with exported network into blob.
-* @param network A pointer to the newly created executable network.
+* @param model_blob A pointer to ie_blob_t with exported network into blob.
+* @param device_name Name of device to load network to.
+* @param config Device configuration.
+* @param exe_network A pointer to the newly created executable network.
 * @return Status code of the operation: OK(0) for success.
 */
-INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_import_network_from_memory(ie_core_t *core, const ie_blob_t *exported_blob, \
-        ie_executable_network_t **exe_network);
+INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_import_network_from_memory(ie_core_t *core, const ie_blob_t *model_blob, const char *device_name, const ie_config_t *config, ie_executable_network_t **exe_network);
 
+/**
+* @brief Exports an executable network to bin file.
+* @ingroup Core
+* @param core A pointer to ie_core_t instance.
+* @param file_name Path to the location of the file exporting to.
+* @param exe_network A pointer to the newly created executable network.
+* @return Status code of the operation: OK(0) for success.
+*/
 INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_export_network(ie_core_t *core, const char *file_name, \
         ie_executable_network_t **exe_network);
-
-INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_export_network_to_memory(ie_core_t *core, ie_blob_t **blob, ie_executable_network_t **exe_network);
 
 /**
  * @brief Creates an executable network from a network object. Users can create as many networks as they need and use

--- a/inference-engine/ie_bridges/c/include/c_api/ie_c_api.h
+++ b/inference-engine/ie_bridges/c/include/c_api/ie_c_api.h
@@ -433,12 +433,11 @@ INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_import_network_from_me
 /**
 * @brief Exports an executable network to a .bin file.
 * @ingroup Core
-* @param core A pointer to the ie_core_t instance.
-* @param file_name Path to the file to export the network to.
 * @param exe_network A pointer to the newly created executable network.
+* @param file_name Path to the file to export the network to.
 * @return Status code of the operation: OK(0) for success.
 */
-INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_export_network(const char *file_name, ie_executable_network_t *exe_network);
+INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_export_network(ie_executable_network_t *exe_network, const char *file_name);
 
 /**
  * @brief Creates an executable network from a given network object. Users can create as many networks as they need and use

--- a/inference-engine/ie_bridges/c/include/c_api/ie_c_api.h
+++ b/inference-engine/ie_bridges/c/include/c_api/ie_c_api.h
@@ -402,7 +402,7 @@ INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_read_network_from_memo
     const ie_blob_t *weight_blob, ie_network_t **network);
 
 /**
-* @brief Creates an executable network from a previously exported network. Users can create as many networks as they need and use
+* @brief Creates an executable network from a network previously exported to file. Users can create as many networks as they need and use
 * them simultaneously (up to the limitation of the hardware resources). Use the ie_exec_network_free() method to free memory.
 * @ingroup Core
 * @param core A pointer to ie_core_t instance.
@@ -416,7 +416,7 @@ INFERENCE_ENGINE_C_API(IE_NODISCARD IEStatusCode) ie_core_import_network(ie_core
         const ie_config_t *config, ie_executable_network_t **exe_network);
 
 /**
-* @brief Creates an executable network from a previously exported network. Users can create as many networks as they need and use
+* @brief Creates an executable network from a network previously exported to blob. Users can create as many networks as they need and use
 * them simultaneously (up to the limitation of the hardware resources). Use the ie_exec_network_free() method to free memory.
 * @ingroup Core
 * @param core A pointer to ie_core_t instance.

--- a/inference-engine/ie_bridges/c/src/ie_c_api.cpp
+++ b/inference-engine/ie_bridges/c/src/ie_c_api.cpp
@@ -385,15 +385,15 @@ IEStatusCode ie_core_import_network_from_memory(ie_core_t *core, const uint8_t *
     }
 
     IEStatusCode status = IEStatusCode::OK;
-    // try {
-    mem_istream model_stream(reinterpret_cast<const char*>(content), content_size);
+    try {
+        mem_istream model_stream(reinterpret_cast<const char*>(content), content_size);
 
-    std::map<std::string, std::string> conf_map = config2Map(config);
-    std::unique_ptr<ie_executable_network_t> exe_net(new ie_executable_network_t);
+        std::map<std::string, std::string> conf_map = config2Map(config);
+        std::unique_ptr<ie_executable_network_t> exe_net(new ie_executable_network_t);
 
-    exe_net->object = core->object.ImportNetwork(model_stream, device_name, conf_map);
-    *exe_network = exe_net.release();
-    // } CATCH_IE_EXCEPTIONS
+        exe_net->object = core->object.ImportNetwork(model_stream, device_name, conf_map);
+        *exe_network = exe_net.release();
+    } CATCH_IE_EXCEPTIONS
 
     return status;
 }

--- a/inference-engine/ie_bridges/c/src/ie_c_api.cpp
+++ b/inference-engine/ie_bridges/c/src/ie_c_api.cpp
@@ -166,7 +166,6 @@ std::map<IE::ColorFormat, colorformat_e> colorformat_map = {{IE::ColorFormat::RA
 std::map<std::string, std::string> config2Map(const ie_config_t *config) {
     std::map<std::string, std::string> m;
     const ie_config_t *tmp = config;
-
     while (tmp && tmp->name && tmp->value) {
         m[tmp->name] = tmp->value;
         tmp = tmp->next;
@@ -369,9 +368,7 @@ IEStatusCode ie_core_import_network(ie_core_t *core, const char *file_name, cons
     }
 
     try {
-        std::map<std::string, std::string> conf_map;
-        if (config != nullptr)
-            conf_map = config2Map(config);
+        std::map<std::string, std::string> conf_map = config2Map(config);
         std::unique_ptr<ie_executable_network_t> exe_net(new ie_executable_network_t);
 
         exe_net->object = core->object.ImportNetwork(file_name, device_name, conf_map);
@@ -391,9 +388,7 @@ IEStatusCode ie_core_import_network_from_memory(ie_core_t *core, const uint8_t *
     try {
         mem_istream model_stream(reinterpret_cast<const char*>(content), content_size);
 
-        std::map<std::string, std::string> conf_map;
-        if (config != nullptr)
-            conf_map = config2Map(config);
+        std::map<std::string, std::string> conf_map = config2Map(config);
         std::unique_ptr<ie_executable_network_t> exe_net(new ie_executable_network_t);
 
         exe_net->object = core->object.ImportNetwork(model_stream, device_name, conf_map);
@@ -421,14 +416,13 @@ IEStatusCode ie_core_load_network(ie_core_t *core, const ie_network_t *network, 
         const ie_config_t *config, ie_executable_network_t **exe_network) {
     IEStatusCode status = IEStatusCode::OK;
 
-    if (core == nullptr || network == nullptr || device_name == nullptr || config == nullptr ||exe_network == nullptr) {
+    if (core == nullptr || network == nullptr || device_name == nullptr || exe_network == nullptr) {
         status = IEStatusCode::GENERAL_ERROR;
         return status;
     }
 
     try {
-        std::map<std::string, std::string> conf_map;
-        conf_map = config2Map(config);
+        std::map<std::string, std::string> conf_map = config2Map(config);
         std::unique_ptr<ie_executable_network_t> exe_net(new ie_executable_network_t);
 
         // create plugin in the registery and then create ExecutableNetwork.
@@ -443,14 +437,13 @@ IEStatusCode ie_core_load_network_from_file(ie_core_t *core, const char *xml, co
         const ie_config_t *config, ie_executable_network_t **exe_network) {
     IEStatusCode status = IEStatusCode::OK;
 
-    if (core == nullptr || xml == nullptr || device_name == nullptr || config == nullptr || exe_network == nullptr) {
+    if (core == nullptr || xml == nullptr || device_name == nullptr || exe_network == nullptr) {
         status = IEStatusCode::GENERAL_ERROR;
         return status;
     }
 
     try {
-        std::map<std::string, std::string> conf_map;
-        conf_map = config2Map(config);
+        std::map<std::string, std::string> conf_map = config2Map(config);
         std::unique_ptr<ie_executable_network_t> exe_net(new ie_executable_network_t);
 
         exe_net->object = core->object.LoadNetwork(xml, device_name, conf_map);

--- a/inference-engine/ie_bridges/c/src/ie_c_api.cpp
+++ b/inference-engine/ie_bridges/c/src/ie_c_api.cpp
@@ -347,8 +347,7 @@ IEStatusCode ie_core_import_network(ie_core_t *core, const char *file_name, cons
     }
 
     try {
-        std::map<std::string, std::string> conf_map;
-        conf_map = config2Map(config);
+        std::map<std::string, std::string> conf_map = config2Map(config);
         std::unique_ptr<ie_executable_network_t> exe_net(new ie_executable_network_t);
 
         exe_net->object = core->object.ImportNetwork(file_name, device_name, conf_map);
@@ -367,13 +366,12 @@ IEStatusCode ie_core_import_network_from_memory(ie_core_t *core, const ie_blob_t
     IEStatusCode status = IEStatusCode::OK;
     try {
         IE::MemoryBlob::Ptr mblob = IE::as<IE::MemoryBlob>(model_blob->object);
-        auto blob_data = mblob->rmap().as<char *>();
+        char *blob_data = mblob->rmap().as<char *>();
 
         size_t blob_size = model_blob->object->byteSize();
         std::stringstream network_model(std::string(blob_data, blob_size));
 
-        std::map<std::string, std::string> conf_map;
-        conf_map = config2Map(config);
+        std::map<std::string, std::string> conf_map = config2Map(config);
 
         std::unique_ptr<ie_executable_network_t> exe_net(new ie_executable_network_t);
         exe_net->object = core->object.ImportNetwork(network_model, device_name, conf_map);
@@ -391,50 +389,8 @@ IEStatusCode ie_core_export_network(ie_core_t *core, const char *file_name, ie_e
         return status;
     }
     try {
-        //std::fstream fs(file_name, fs.binary | fs.trunc | fs.out);
         (*exe_network)->object.Export(file_name);
     } CATCH_IE_EXCEPTIONS
-
-    return status;
-}
-
-IEStatusCode ie_core_export_network_to_memory(ie_core_t *core, ie_blob_t** blob, ie_executable_network_t **exe_network) {
-    IEStatusCode status = IEStatusCode::OK;
-
-    if (core == nullptr || blob == nullptr || exe_network == nullptr) {
-        status = IEStatusCode::GENERAL_ERROR;
-        return status;
-    }
-    // try {
-    std::ofstream ifs("exported_model.blob", ifs.out | ifs.binary);
-    (*exe_network)->object.Export(ifs);
-    // std::string model = ss.str();
-
-    std::ifstream ofs("exported_model.blob", ofs.in | ofs.binary);
-    auto eos = std::istream_iterator<int8_t>();
-    auto buffer = std::vector<int8_t>(std::istream_iterator<int8_t>(ofs), eos);
-
-
-    IE::SizeVector dims_vector = {1, buffer.size()};
-    IE::Precision prec = IE::Precision::BIN;
-    IE::TensorDesc tensor(prec, dims_vector, IE::Layout::ANY);
-
-    std::unique_ptr<ie_blob_t> model_blob(new ie_blob_t);
-    model_blob->object = std::make_shared<IE::TBlob<int8_t>>(tensor, &buffer[0], buffer.size());
-
-    // InferenceEngine::make_shared_blob<BlobType>(desc, reinterpret_cast<BlobType*>(ptr), size)
-    // char *p = const_cast<char*>(model.c_str());
-    // model_blob->object = IE::make_shared_blob(tensor, &buffer[0], buffer.size());
-
-    IE::MemoryBlob::Ptr mblob = IE::as<IE::MemoryBlob>(model_blob->object);
-
-    auto mblobHolder = mblob->wmap();
-    int8_t *blob_data = mblobHolder.as<int8_t*>();
-    for (size_t i = 0; i < buffer.size(); ++i) {
-        *(blob_data + i) = buffer[i];
-    }
-    *blob = model_blob.release();
-    // // } CATCH_IE_EXCEPTIONS
 
     return status;
 }

--- a/inference-engine/ie_bridges/c/src/ie_c_api.cpp
+++ b/inference-engine/ie_bridges/c/src/ie_c_api.cpp
@@ -379,18 +379,15 @@ IEStatusCode ie_core_import_network(ie_core_t *core, const char *file_name, cons
     return status;
 }
 
-IEStatusCode ie_core_import_network_from_memory(ie_core_t *core, const ie_blob_t *model_blob, const char *device_name,
+IEStatusCode ie_core_import_network_from_memory(ie_core_t *core, const uint8_t *content, size_t content_size, const char *device_name,
        const ie_config_t *config, ie_executable_network_t **exe_network) {
-    if (core == nullptr || model_blob == nullptr ||device_name == nullptr || config == nullptr || exe_network == nullptr) {
+    if (core == nullptr || content == nullptr || device_name == nullptr || config == nullptr || exe_network == nullptr) {
         return IEStatusCode::GENERAL_ERROR;
     }
 
     IEStatusCode status = IEStatusCode::OK;
     try {
-        IE::MemoryBlob::Ptr mblob = IE::as<IE::MemoryBlob>(model_blob->object);
-        const char *blob_data = mblob->rmap().as<const char *>();
-        size_t blob_size = model_blob->object->byteSize();
-        mem_istream model_stream(blob_data, blob_size);
+        mem_istream model_stream(reinterpret_cast<const char*>(content), content_size);
 
         std::map<std::string, std::string> conf_map = config2Map(config);
         std::unique_ptr<ie_executable_network_t> exe_net(new ie_executable_network_t);

--- a/inference-engine/ie_bridges/c/src/ie_c_api.cpp
+++ b/inference-engine/ie_bridges/c/src/ie_c_api.cpp
@@ -13,7 +13,6 @@
 #include <chrono>
 #include <tuple>
 #include <memory>
-#include <fstream>
 #include <ie_extension.h>
 #include "inference_engine.hpp"
 #include "ie_compound_blob.h"
@@ -337,7 +336,7 @@ IEStatusCode ie_core_read_network_from_memory(ie_core_t *core, const uint8_t *xm
     return status;
 }
 
-IEStatusCode ie_core_import_network(ie_core_t *core, const char *file_name, const char *device_name, \
+IEStatusCode ie_core_import_network(ie_core_t *core, const char *file_name, const char *device_name,
         const ie_config_t *config, ie_executable_network_t **exe_network) {
     IEStatusCode status = IEStatusCode::OK;
 
@@ -357,8 +356,8 @@ IEStatusCode ie_core_import_network(ie_core_t *core, const char *file_name, cons
     return status;
 }
 
-IEStatusCode ie_core_import_network_from_memory(ie_core_t *core, const ie_blob_t *model_blob, const char *device_name, \
-    const ie_config_t *config, ie_executable_network_t **exe_network) {
+IEStatusCode ie_core_import_network_from_memory(ie_core_t *core, const ie_blob_t *model_blob, const char *device_name,
+       const ie_config_t *config, ie_executable_network_t **exe_network) {
     if (core == nullptr || model_blob == nullptr ||device_name == nullptr || config == nullptr || exe_network == nullptr) {
         return IEStatusCode::GENERAL_ERROR;
     }
@@ -366,8 +365,7 @@ IEStatusCode ie_core_import_network_from_memory(ie_core_t *core, const ie_blob_t
     IEStatusCode status = IEStatusCode::OK;
     try {
         IE::MemoryBlob::Ptr mblob = IE::as<IE::MemoryBlob>(model_blob->object);
-        char *blob_data = mblob->rmap().as<char *>();
-
+        const char *blob_data = mblob->rmap().as<char *>();
         size_t blob_size = model_blob->object->byteSize();
         std::stringstream network_model(std::string(blob_data, blob_size));
 
@@ -381,7 +379,7 @@ IEStatusCode ie_core_import_network_from_memory(ie_core_t *core, const ie_blob_t
     return status;
 }
 
-IEStatusCode ie_core_export_network(ie_core_t *core, const char *file_name, ie_executable_network_t **exe_network) {
+IEStatusCode ie_core_export_network(ie_core_t *core, const char *file_name, ie_executable_network_t *exe_network) {
     IEStatusCode status = IEStatusCode::OK;
 
     if (core == nullptr || file_name == nullptr || exe_network == nullptr) {
@@ -389,7 +387,7 @@ IEStatusCode ie_core_export_network(ie_core_t *core, const char *file_name, ie_e
         return status;
     }
     try {
-        (*exe_network)->object.Export(file_name);
+        exe_network->object.Export(file_name);
     } CATCH_IE_EXCEPTIONS
 
     return status;

--- a/inference-engine/ie_bridges/c/src/ie_c_api.cpp
+++ b/inference-engine/ie_bridges/c/src/ie_c_api.cpp
@@ -398,10 +398,10 @@ IEStatusCode ie_core_import_network_from_memory(ie_core_t *core, const uint8_t *
     return status;
 }
 
-IEStatusCode ie_core_export_network(ie_core_t *core, const char *file_name, ie_executable_network_t *exe_network) {
+IEStatusCode ie_core_export_network(const char *file_name, ie_executable_network_t *exe_network) {
     IEStatusCode status = IEStatusCode::OK;
 
-    if (core == nullptr || file_name == nullptr || exe_network == nullptr) {
+    if (file_name == nullptr || exe_network == nullptr) {
         status = IEStatusCode::GENERAL_ERROR;
         return status;
     }

--- a/inference-engine/ie_bridges/c/src/ie_c_api.cpp
+++ b/inference-engine/ie_bridges/c/src/ie_c_api.cpp
@@ -421,7 +421,7 @@ IEStatusCode ie_core_load_network(ie_core_t *core, const ie_network_t *network, 
         const ie_config_t *config, ie_executable_network_t **exe_network) {
     IEStatusCode status = IEStatusCode::OK;
 
-    if (core == nullptr || network == nullptr || device_name == nullptr || exe_network == nullptr) {
+    if (core == nullptr || network == nullptr || device_name == nullptr || config == nullptr ||exe_network == nullptr) {
         status = IEStatusCode::GENERAL_ERROR;
         return status;
     }

--- a/inference-engine/ie_bridges/c/src/ie_c_api.cpp
+++ b/inference-engine/ie_bridges/c/src/ie_c_api.cpp
@@ -13,6 +13,7 @@
 #include <chrono>
 #include <tuple>
 #include <memory>
+#include <fstream>
 #include <ie_extension.h>
 #include "inference_engine.hpp"
 #include "ie_compound_blob.h"
@@ -331,6 +332,90 @@ IEStatusCode ie_core_read_network_from_memory(ie_core_t *core, const uint8_t *xm
         network_result->object = core->object.ReadNetwork(std::string(reinterpret_cast<const char *>(xml_content),
             reinterpret_cast<const char *>(xml_content + xml_content_size)), weight_blob->object);
         *network = network_result.release();
+    } CATCH_IE_EXCEPTIONS
+
+    return status;
+}
+
+IEStatusCode ie_core_import_network(ie_core_t *core, const char *file_name, const char *device_name, \
+        const ie_config_t *config, ie_executable_network_t **exe_network) {
+    IEStatusCode status = IEStatusCode::OK;
+
+    if (core == nullptr || file_name == nullptr || device_name == nullptr || config == nullptr || exe_network == nullptr) {
+        status = IEStatusCode::GENERAL_ERROR;
+        return status;
+    }
+
+    try {
+        std::map<std::string, std::string> conf_map;
+        conf_map = config2Map(config);
+        std::unique_ptr<ie_executable_network_t> exe_net(new ie_executable_network_t);
+
+        exe_net->object = core->object.ImportNetwork(file_name, device_name, conf_map);
+        *exe_network = exe_net.release();
+    } CATCH_IE_EXCEPTIONS
+
+    return status;
+}
+
+IEStatusCode ie_core_import_network_from_memory(ie_core_t *core, const ie_blob_t *exported_blob, \
+        ie_executable_network_t **exe_network) {
+    if (core == nullptr || exported_blob == nullptr || exe_network == nullptr) {
+        return IEStatusCode::GENERAL_ERROR;
+    }
+
+    IEStatusCode status = IEStatusCode::OK;
+    try {
+        std::stringstream network_model;
+        IE::TensorDesc tensor = exported_blob->object->getTensorDesc();
+
+        char* data = exported_blob->object->cbuffer().as<char*>();
+        network_model.write(data, sizeof(data));
+
+        std::unique_ptr<ie_executable_network_t> exe_net(new ie_executable_network_t);
+        exe_net->object = core->object.ImportNetwork(network_model);
+        *exe_network = exe_net.release();
+    } CATCH_IE_EXCEPTIONS
+
+    return status;
+}
+
+IEStatusCode ie_core_export_network(ie_core_t *core, const char *file_name, ie_executable_network_t **exe_network) {
+    IEStatusCode status = IEStatusCode::OK;
+
+    if (core == nullptr || file_name == nullptr || exe_network == nullptr) {
+        status = IEStatusCode::GENERAL_ERROR;
+        return status;
+    }
+    try {
+        std::fstream fs(file_name, fs.binary | fs.trunc | fs.out);
+        (*exe_network)->object.Export(fs);
+    } CATCH_IE_EXCEPTIONS
+
+    return status;
+}
+
+IEStatusCode ie_core_export_network_to_memory(ie_core_t *core, ie_blob_t** blob, ie_executable_network_t **exe_network) {
+    IEStatusCode status = IEStatusCode::OK;
+
+    if (core == nullptr || blob == nullptr || exe_network == nullptr) {
+        status = IEStatusCode::GENERAL_ERROR;
+        return status;
+    }
+    try {
+        std::stringstream stream;
+        (*exe_network)->object.Export(stream);
+        std::string model = stream.str();
+
+        IE::SizeVector dims_vector = {1, model.length()};
+        IE::Precision prec = IE::Precision::U8;
+        IE::TensorDesc tensor(prec, dims_vector, IE::Layout::ANY);
+
+        std::unique_ptr<ie_blob_t> model_blob(new ie_blob_t);
+        model_blob->object->buffer() = &model;
+        char *p = const_cast<char*>(model.c_str());
+        model_blob->object = IE::make_shared_blob(tensor, p, model.size());
+        *blob = model_blob.release();
     } CATCH_IE_EXCEPTIONS
 
     return status;

--- a/inference-engine/ie_bridges/c/src/ie_c_api.cpp
+++ b/inference-engine/ie_bridges/c/src/ie_c_api.cpp
@@ -385,20 +385,20 @@ IEStatusCode ie_core_import_network_from_memory(ie_core_t *core, const uint8_t *
     }
 
     IEStatusCode status = IEStatusCode::OK;
-    try {
-        mem_istream model_stream(reinterpret_cast<const char*>(content), content_size);
+    // try {
+    mem_istream model_stream(reinterpret_cast<const char*>(content), content_size);
 
-        std::map<std::string, std::string> conf_map = config2Map(config);
-        std::unique_ptr<ie_executable_network_t> exe_net(new ie_executable_network_t);
+    std::map<std::string, std::string> conf_map = config2Map(config);
+    std::unique_ptr<ie_executable_network_t> exe_net(new ie_executable_network_t);
 
-        exe_net->object = core->object.ImportNetwork(model_stream, device_name, conf_map);
-        *exe_network = exe_net.release();
-    } CATCH_IE_EXCEPTIONS
+    exe_net->object = core->object.ImportNetwork(model_stream, device_name, conf_map);
+    *exe_network = exe_net.release();
+    // } CATCH_IE_EXCEPTIONS
 
     return status;
 }
 
-IEStatusCode ie_core_export_network(const char *file_name, ie_executable_network_t *exe_network) {
+IEStatusCode ie_core_export_network(ie_executable_network_t *exe_network, const char *file_name) {
     IEStatusCode status = IEStatusCode::OK;
 
     if (file_name == nullptr || exe_network == nullptr) {

--- a/inference-engine/ie_bridges/c/src/ie_c_api.cpp
+++ b/inference-engine/ie_bridges/c/src/ie_c_api.cpp
@@ -369,8 +369,14 @@ IEStatusCode ie_core_import_network_from_memory(ie_core_t *core, const ie_blob_t
         std::stringstream network_model;
         IE::TensorDesc tensor = exported_blob->object->getTensorDesc();
 
-        char* data = exported_blob->object->cbuffer().as<char*>();
-        network_model.write(data, sizeof(data));
+        // char* data = exported_blob->object->cbuffer().as<char*>();
+        // network_model.write(data, sizeof(data));
+
+        InferenceEngine::MemoryBlob::Ptr mblob = InferenceEngine::as<InferenceEngine::MemoryBlob>(exported_blob->object);
+        auto mblobHolder = mblob->rmap();
+        char* blob_data = mblobHolder.as<char*>();
+        IE::TensorDesc desc = exported_blob->object->getTensorDesc();
+        network_model << blob_data;
 
         std::unique_ptr<ie_executable_network_t> exe_net(new ie_executable_network_t);
         exe_net->object = core->object.ImportNetwork(network_model);
@@ -388,8 +394,8 @@ IEStatusCode ie_core_export_network(ie_core_t *core, const char *file_name, ie_e
         return status;
     }
     try {
-        std::fstream fs(file_name, fs.binary | fs.trunc | fs.out);
-        (*exe_network)->object.Export(fs);
+        //std::fstream fs(file_name, fs.binary | fs.trunc | fs.out);
+        (*exe_network)->object.Export(file_name);
     } CATCH_IE_EXCEPTIONS
 
     return status;
@@ -402,21 +408,34 @@ IEStatusCode ie_core_export_network_to_memory(ie_core_t *core, ie_blob_t** blob,
         status = IEStatusCode::GENERAL_ERROR;
         return status;
     }
-    try {
-        std::stringstream stream;
-        (*exe_network)->object.Export(stream);
-        std::string model = stream.str();
+    // try {
+    std::ofstream ifs("exported_model.blob", ifs.out | ifs.binary);
+    (*exe_network)->object.Export(ifs);
+    // std::string model = ss.str();
 
-        IE::SizeVector dims_vector = {1, model.length()};
-        IE::Precision prec = IE::Precision::U8;
-        IE::TensorDesc tensor(prec, dims_vector, IE::Layout::ANY);
+    std::ifstream ofs("exported_model.blob", ofs.in | ofs.binary);
+    auto eos = std::istream_iterator<char>();
+    auto buffer = std::vector<char>(std::istream_iterator<char>(ofs), eos);
 
-        std::unique_ptr<ie_blob_t> model_blob(new ie_blob_t);
-        model_blob->object->buffer() = &model;
-        char *p = const_cast<char*>(model.c_str());
-        model_blob->object = IE::make_shared_blob(tensor, p, model.size());
-        *blob = model_blob.release();
-    } CATCH_IE_EXCEPTIONS
+
+    IE::SizeVector dims_vector = {1, buffer.size()};
+    IE::Precision prec = IE::Precision::BIN;
+    IE::TensorDesc tensor(prec, dims_vector, IE::Layout::ANY);
+
+    std::unique_ptr<ie_blob_t> model_blob(new ie_blob_t);
+
+    // InferenceEngine::make_shared_blob<BlobType>(desc, reinterpret_cast<BlobType*>(ptr), size)
+    // char *p = const_cast<char*>(model.c_str());
+    model_blob->object = IE::make_shared_blob(tensor, &buffer[0], buffer.size());
+
+    InferenceEngine::MemoryBlob::Ptr mblob = InferenceEngine::as<InferenceEngine::MemoryBlob>(model_blob->object);
+    auto mblobHolder = mblob->wmap();
+    char* blob_data = mblobHolder.as<char*>();
+    for (size_t i = 0; i < buffer.size(); ++i) {
+        *(blob_data + i) = buffer[i];
+    }
+    *blob = model_blob.release();
+    // // } CATCH_IE_EXCEPTIONS
 
     return status;
 }

--- a/inference-engine/ie_bridges/c/src/ie_c_api.cpp
+++ b/inference-engine/ie_bridges/c/src/ie_c_api.cpp
@@ -359,7 +359,7 @@ IEStatusCode ie_core_import_network(ie_core_t *core, const char *file_name, cons
 }
 
 IEStatusCode ie_core_import_network_from_memory(ie_core_t *core, const ie_blob_t *model_blob, const char *device_name, \
-    ie_config_t *config, ie_executable_network_t **exe_network) {
+    const ie_config_t *config, ie_executable_network_t **exe_network) {
     if (core == nullptr || model_blob == nullptr ||device_name == nullptr || config == nullptr || exe_network == nullptr) {
         return IEStatusCode::GENERAL_ERROR;
     }

--- a/inference-engine/ie_bridges/c/src/ie_c_api.cpp
+++ b/inference-engine/ie_bridges/c/src/ie_c_api.cpp
@@ -70,9 +70,8 @@ struct mem_stringbuf : std::streambuf {
         char * bptr(const_cast<char *>(buffer));
         setg(bptr, bptr, bptr + sz);
     }
-    
-    pos_type seekoff(off_type off, std::ios_base::seekdir dir, std::ios_base::openmode which = std::ios_base::in) override
-    {
+
+    pos_type seekoff(off_type off, std::ios_base::seekdir dir, std::ios_base::openmode which = std::ios_base::in) override {
         switch (dir) {
             case std::ios_base::beg:
                 setg(eback(), eback() + off, egptr());
@@ -86,11 +85,10 @@ struct mem_stringbuf : std::streambuf {
             default:
                 return pos_type(off_type(-1));
         }
-        return gptr() < eback() || gptr() > egptr() ? pos_type(off_type(-1)) : gptr() - eback();
+        return (gptr() < eback() || gptr() > egptr()) ? pos_type(off_type(-1)) : pos_type(gptr() - eback());
     }
 
-    pos_type seekpos(pos_type pos, std::ios_base::openmode which) override
-    {
+    pos_type seekpos(pos_type pos, std::ios_base::openmode which) override {
         return seekoff(pos, std::ios_base::beg, which);
     }
 };

--- a/inference-engine/ie_bridges/c/src/ie_c_api.cpp
+++ b/inference-engine/ie_bridges/c/src/ie_c_api.cpp
@@ -1374,37 +1374,37 @@ IEStatusCode ie_blob_make_memory(const tensor_desc_t *tensorDesc, ie_blob_t **bl
     }
 
     IEStatusCode status = IEStatusCode::OK;
-    // try {
-    std::unique_ptr<ie_blob_t> _blob(new ie_blob_t);
-    IE::TensorDesc tensor(prec, dims_vector, l);
+    try {
+        std::unique_ptr<ie_blob_t> _blob(new ie_blob_t);
+        IE::TensorDesc tensor(prec, dims_vector, l);
 
-    if (prec == IE::Precision::U8) {
-        _blob->object = IE::make_shared_blob<uint8_t>(tensor);
-    } else if (prec == IE::Precision::U16) {
-        _blob->object = IE::make_shared_blob<uint16_t>(tensor);
-    } else if (prec == IE::Precision::I8 || prec == IE::Precision::BIN || prec == IE::Precision::I4 || prec == IE::Precision::U4) {
-        _blob->object = IE::make_shared_blob<int8_t>(tensor);
-    } else if (prec == IE::Precision::I16 || prec == IE::Precision::FP16 || prec == IE::Precision::Q78) {
-        _blob->object = IE::make_shared_blob<int16_t>(tensor);
-    } else if (prec == IE::Precision::I32) {
-        _blob->object = IE::make_shared_blob<int32_t>(tensor);
-    } else if (prec == IE::Precision::U32) {
-        _blob->object = IE::make_shared_blob<uint32_t>(tensor);
-    } else if (prec == IE::Precision::I64) {
-        _blob->object = IE::make_shared_blob<int64_t>(tensor);
-    } else if (prec == IE::Precision::U64) {
-        _blob->object = IE::make_shared_blob<uint64_t>(tensor);
-    } else if  (prec == IE::Precision::FP32) {
-        _blob->object = IE::make_shared_blob<float>(tensor);
-    }  else if  (prec == IE::Precision::FP64) {
-        _blob->object = IE::make_shared_blob<double>(tensor);
-    } else {
-        _blob->object = IE::make_shared_blob<uint8_t>(tensor);
-    }
+        if (prec == IE::Precision::U8) {
+            _blob->object = IE::make_shared_blob<uint8_t>(tensor);
+        } else if (prec == IE::Precision::U16) {
+            _blob->object = IE::make_shared_blob<uint16_t>(tensor);
+        } else if (prec == IE::Precision::I8 || prec == IE::Precision::BIN || prec == IE::Precision::I4 || prec == IE::Precision::U4) {
+            _blob->object = IE::make_shared_blob<int8_t>(tensor);
+        } else if (prec == IE::Precision::I16 || prec == IE::Precision::FP16 || prec == IE::Precision::Q78) {
+            _blob->object = IE::make_shared_blob<int16_t>(tensor);
+        } else if (prec == IE::Precision::I32) {
+            _blob->object = IE::make_shared_blob<int32_t>(tensor);
+        } else if (prec == IE::Precision::U32) {
+            _blob->object = IE::make_shared_blob<uint32_t>(tensor);
+        } else if (prec == IE::Precision::I64) {
+            _blob->object = IE::make_shared_blob<int64_t>(tensor);
+        } else if (prec == IE::Precision::U64) {
+            _blob->object = IE::make_shared_blob<uint64_t>(tensor);
+        } else if  (prec == IE::Precision::FP32) {
+            _blob->object = IE::make_shared_blob<float>(tensor);
+        }  else if  (prec == IE::Precision::FP64) {
+            _blob->object = IE::make_shared_blob<double>(tensor);
+        } else {
+            _blob->object = IE::make_shared_blob<uint8_t>(tensor);
+        }
 
-    _blob->object->allocate();
-    *blob = _blob.release();
-    // } CATCH_IE_EXCEPTIONS
+        _blob->object->allocate();
+        *blob = _blob.release();
+    } CATCH_IE_EXCEPTIONS
 
     return status;
 }

--- a/inference-engine/ie_bridges/c/src/ie_c_api.cpp
+++ b/inference-engine/ie_bridges/c/src/ie_c_api.cpp
@@ -358,28 +358,25 @@ IEStatusCode ie_core_import_network(ie_core_t *core, const char *file_name, cons
     return status;
 }
 
-IEStatusCode ie_core_import_network_from_memory(ie_core_t *core, const ie_blob_t *exported_blob, \
-        ie_executable_network_t **exe_network) {
-    if (core == nullptr || exported_blob == nullptr || exe_network == nullptr) {
+IEStatusCode ie_core_import_network_from_memory(ie_core_t *core, const ie_blob_t *model_blob, const char *device_name, \
+    ie_config_t *config, ie_executable_network_t **exe_network) {
+    if (core == nullptr || model_blob == nullptr ||device_name == nullptr || config == nullptr || exe_network == nullptr) {
         return IEStatusCode::GENERAL_ERROR;
     }
 
     IEStatusCode status = IEStatusCode::OK;
     try {
-        std::stringstream network_model;
-        IE::TensorDesc tensor = exported_blob->object->getTensorDesc();
+        IE::MemoryBlob::Ptr mblob = IE::as<IE::MemoryBlob>(model_blob->object);
+        auto blob_data = mblob->rmap().as<char *>();
 
-        // char* data = exported_blob->object->cbuffer().as<char*>();
-        // network_model.write(data, sizeof(data));
+        size_t blob_size = model_blob->object->byteSize();
+        std::stringstream network_model(std::string(blob_data, blob_size));
 
-        InferenceEngine::MemoryBlob::Ptr mblob = InferenceEngine::as<InferenceEngine::MemoryBlob>(exported_blob->object);
-        auto mblobHolder = mblob->rmap();
-        char* blob_data = mblobHolder.as<char*>();
-        IE::TensorDesc desc = exported_blob->object->getTensorDesc();
-        network_model << blob_data;
+        std::map<std::string, std::string> conf_map;
+        conf_map = config2Map(config);
 
         std::unique_ptr<ie_executable_network_t> exe_net(new ie_executable_network_t);
-        exe_net->object = core->object.ImportNetwork(network_model);
+        exe_net->object = core->object.ImportNetwork(network_model, device_name, conf_map);
         *exe_network = exe_net.release();
     } CATCH_IE_EXCEPTIONS
 
@@ -414,8 +411,8 @@ IEStatusCode ie_core_export_network_to_memory(ie_core_t *core, ie_blob_t** blob,
     // std::string model = ss.str();
 
     std::ifstream ofs("exported_model.blob", ofs.in | ofs.binary);
-    auto eos = std::istream_iterator<char>();
-    auto buffer = std::vector<char>(std::istream_iterator<char>(ofs), eos);
+    auto eos = std::istream_iterator<int8_t>();
+    auto buffer = std::vector<int8_t>(std::istream_iterator<int8_t>(ofs), eos);
 
 
     IE::SizeVector dims_vector = {1, buffer.size()};
@@ -423,14 +420,16 @@ IEStatusCode ie_core_export_network_to_memory(ie_core_t *core, ie_blob_t** blob,
     IE::TensorDesc tensor(prec, dims_vector, IE::Layout::ANY);
 
     std::unique_ptr<ie_blob_t> model_blob(new ie_blob_t);
+    model_blob->object = std::make_shared<IE::TBlob<int8_t>>(tensor, &buffer[0], buffer.size());
 
     // InferenceEngine::make_shared_blob<BlobType>(desc, reinterpret_cast<BlobType*>(ptr), size)
     // char *p = const_cast<char*>(model.c_str());
-    model_blob->object = IE::make_shared_blob(tensor, &buffer[0], buffer.size());
+    // model_blob->object = IE::make_shared_blob(tensor, &buffer[0], buffer.size());
 
-    InferenceEngine::MemoryBlob::Ptr mblob = InferenceEngine::as<InferenceEngine::MemoryBlob>(model_blob->object);
+    IE::MemoryBlob::Ptr mblob = IE::as<IE::MemoryBlob>(model_blob->object);
+
     auto mblobHolder = mblob->wmap();
-    char* blob_data = mblobHolder.as<char*>();
+    int8_t *blob_data = mblobHolder.as<int8_t*>();
     for (size_t i = 0; i < buffer.size(); ++i) {
         *(blob_data + i) = buffer[i];
     }
@@ -1375,37 +1374,37 @@ IEStatusCode ie_blob_make_memory(const tensor_desc_t *tensorDesc, ie_blob_t **bl
     }
 
     IEStatusCode status = IEStatusCode::OK;
-    try {
-        std::unique_ptr<ie_blob_t> _blob(new ie_blob_t);
-        IE::TensorDesc tensor(prec, dims_vector, l);
+    // try {
+    std::unique_ptr<ie_blob_t> _blob(new ie_blob_t);
+    IE::TensorDesc tensor(prec, dims_vector, l);
 
-        if (prec == IE::Precision::U8) {
-            _blob->object = IE::make_shared_blob<uint8_t>(tensor);
-        } else if (prec == IE::Precision::U16) {
-            _blob->object = IE::make_shared_blob<uint16_t>(tensor);
-        } else if (prec == IE::Precision::I8 || prec == IE::Precision::BIN || prec == IE::Precision::I4 || prec == IE::Precision::U4) {
-            _blob->object = IE::make_shared_blob<int8_t>(tensor);
-        } else if (prec == IE::Precision::I16 || prec == IE::Precision::FP16 || prec == IE::Precision::Q78) {
-            _blob->object = IE::make_shared_blob<int16_t>(tensor);
-        } else if (prec == IE::Precision::I32) {
-            _blob->object = IE::make_shared_blob<int32_t>(tensor);
-        } else if (prec == IE::Precision::U32) {
-            _blob->object = IE::make_shared_blob<uint32_t>(tensor);
-        } else if (prec == IE::Precision::I64) {
-            _blob->object = IE::make_shared_blob<int64_t>(tensor);
-        } else if (prec == IE::Precision::U64) {
-            _blob->object = IE::make_shared_blob<uint64_t>(tensor);
-        } else if  (prec == IE::Precision::FP32) {
-            _blob->object = IE::make_shared_blob<float>(tensor);
-        }  else if  (prec == IE::Precision::FP64) {
-            _blob->object = IE::make_shared_blob<double>(tensor);
-        } else {
-            _blob->object = IE::make_shared_blob<uint8_t>(tensor);
-        }
+    if (prec == IE::Precision::U8) {
+        _blob->object = IE::make_shared_blob<uint8_t>(tensor);
+    } else if (prec == IE::Precision::U16) {
+        _blob->object = IE::make_shared_blob<uint16_t>(tensor);
+    } else if (prec == IE::Precision::I8 || prec == IE::Precision::BIN || prec == IE::Precision::I4 || prec == IE::Precision::U4) {
+        _blob->object = IE::make_shared_blob<int8_t>(tensor);
+    } else if (prec == IE::Precision::I16 || prec == IE::Precision::FP16 || prec == IE::Precision::Q78) {
+        _blob->object = IE::make_shared_blob<int16_t>(tensor);
+    } else if (prec == IE::Precision::I32) {
+        _blob->object = IE::make_shared_blob<int32_t>(tensor);
+    } else if (prec == IE::Precision::U32) {
+        _blob->object = IE::make_shared_blob<uint32_t>(tensor);
+    } else if (prec == IE::Precision::I64) {
+        _blob->object = IE::make_shared_blob<int64_t>(tensor);
+    } else if (prec == IE::Precision::U64) {
+        _blob->object = IE::make_shared_blob<uint64_t>(tensor);
+    } else if  (prec == IE::Precision::FP32) {
+        _blob->object = IE::make_shared_blob<float>(tensor);
+    }  else if  (prec == IE::Precision::FP64) {
+        _blob->object = IE::make_shared_blob<double>(tensor);
+    } else {
+        _blob->object = IE::make_shared_blob<uint8_t>(tensor);
+    }
 
-        _blob->object->allocate();
-        *blob = _blob.release();
-    } CATCH_IE_EXCEPTIONS
+    _blob->object->allocate();
+    *blob = _blob.release();
+    // } CATCH_IE_EXCEPTIONS
 
     return status;
 }

--- a/inference-engine/ie_bridges/c/src/ie_c_api.cpp
+++ b/inference-engine/ie_bridges/c/src/ie_c_api.cpp
@@ -363,13 +363,15 @@ IEStatusCode ie_core_import_network(ie_core_t *core, const char *file_name, cons
         const ie_config_t *config, ie_executable_network_t **exe_network) {
     IEStatusCode status = IEStatusCode::OK;
 
-    if (core == nullptr || file_name == nullptr || device_name == nullptr || config == nullptr || exe_network == nullptr) {
+    if (core == nullptr || file_name == nullptr || device_name == nullptr || exe_network == nullptr) {
         status = IEStatusCode::GENERAL_ERROR;
         return status;
     }
 
     try {
-        std::map<std::string, std::string> conf_map = config2Map(config);
+        std::map<std::string, std::string> conf_map;
+        if (config != nullptr)
+            conf_map = config2Map(config);
         std::unique_ptr<ie_executable_network_t> exe_net(new ie_executable_network_t);
 
         exe_net->object = core->object.ImportNetwork(file_name, device_name, conf_map);
@@ -381,7 +383,7 @@ IEStatusCode ie_core_import_network(ie_core_t *core, const char *file_name, cons
 
 IEStatusCode ie_core_import_network_from_memory(ie_core_t *core, const uint8_t *content, size_t content_size, const char *device_name,
        const ie_config_t *config, ie_executable_network_t **exe_network) {
-    if (core == nullptr || content == nullptr || device_name == nullptr || config == nullptr || exe_network == nullptr) {
+    if (core == nullptr || content == nullptr || device_name == nullptr || exe_network == nullptr) {
         return IEStatusCode::GENERAL_ERROR;
     }
 
@@ -389,7 +391,9 @@ IEStatusCode ie_core_import_network_from_memory(ie_core_t *core, const uint8_t *
     try {
         mem_istream model_stream(reinterpret_cast<const char*>(content), content_size);
 
-        std::map<std::string, std::string> conf_map = config2Map(config);
+        std::map<std::string, std::string> conf_map;
+        if (config != nullptr)
+            conf_map = config2Map(config);
         std::unique_ptr<ie_executable_network_t> exe_net(new ie_executable_network_t);
 
         exe_net->object = core->object.ImportNetwork(model_stream, device_name, conf_map);
@@ -417,7 +421,7 @@ IEStatusCode ie_core_load_network(ie_core_t *core, const ie_network_t *network, 
         const ie_config_t *config, ie_executable_network_t **exe_network) {
     IEStatusCode status = IEStatusCode::OK;
 
-    if (core == nullptr || network == nullptr || device_name == nullptr || config == nullptr || exe_network == nullptr) {
+    if (core == nullptr || network == nullptr || device_name == nullptr || exe_network == nullptr) {
         status = IEStatusCode::GENERAL_ERROR;
         return status;
     }

--- a/inference-engine/ie_bridges/c/tests/CMakeLists.txt
+++ b/inference-engine/ie_bridges/c/tests/CMakeLists.txt
@@ -22,9 +22,9 @@ target_link_libraries(${TARGET_NAME}
         )
 
 target_compile_definitions(${TARGET_NAME}
-        PUBLIC ${ARGV}
+        PUBLIC ${ARGV} ${GNA_LIBRARY_VERSION}
         DATA_PATH=\"${DATA_PATH}\"
-        MODELS_PATH=\"${MODELS_PATH}\" )
+        MODELS_PATH=\"${MODELS_PATH}\")
 
 add_dependencies(${TARGET_NAME} MultiDevicePlugin)
 
@@ -34,6 +34,10 @@ endif()
 
 if(ENABLE_CLDNN)
     add_dependencies(${TARGET_NAME} clDNNPlugin)
+endif()
+
+if(ENABLE_GNA)
+    add_dependencies(${TARGET_NAME} GNAPlugin)
 endif()
 
 add_cpplint_target(${TARGET_NAME}_cpplint FOR_TARGETS ${TARGET_NAME})

--- a/inference-engine/ie_bridges/c/tests/ie_c_api_test.cpp
+++ b/inference-engine/ie_bridges/c/tests/ie_c_api_test.cpp
@@ -355,6 +355,9 @@ TEST(ie_core_export_network_to_file, exportNetworktoFile) {
 }
 
 TEST(ie_core_import_network_from_memory, importNetworkFromMem) {
+    #ifndef GNA2
+        GTEST_SKIP_("GNA v1 doesn't support import");
+    #endif
     ie_core_t *core = nullptr;
     IE_ASSERT_OK(ie_core_create("", &core));
     ASSERT_NE(nullptr, core);
@@ -394,6 +397,9 @@ TEST(ie_core_import_network_from_memory, importNetworkFromMem) {
 }
 
 TEST(ie_core_import_network_from_file, importNetworkFromFile) {
+    #ifndef GNA2
+        GTEST_SKIP_("GNA v1 doesn't support import");
+    #endif
     ie_core_t *core = nullptr;
     IE_ASSERT_OK(ie_core_create("", &core));
     ASSERT_NE(nullptr, core);
@@ -426,6 +432,9 @@ TEST(ie_core_import_network_from_file, importNetworkFromFile) {
 }
 
 TEST(ie_core_import_network_from_file, importNetwork_errorHandling) {
+    #ifndef GNA2
+        GTEST_SKIP_("GNA v1 doesn't support import");
+    #endif
     ie_core_t *core = nullptr;
     IE_ASSERT_OK(ie_core_create("", &core));
     ASSERT_NE(nullptr, core);

--- a/inference-engine/ie_bridges/c/tests/ie_c_api_test.cpp
+++ b/inference-engine/ie_bridges/c/tests/ie_c_api_test.cpp
@@ -324,12 +324,17 @@ TEST(ie_core_read_network_from_memory, networkReadFromMemory) {
     ie_core_free(&core);
 }
 
-#ifdef ENABLE_GNA
-// The following tests should be performed on CPU when it supports import/export
 TEST(ie_core_export_network_to_file, exportNetworktoFile) {
     ie_core_t *core = nullptr;
     IE_ASSERT_OK(ie_core_create("", &core));
     ASSERT_NE(nullptr, core);
+
+    // Test should be performed on CPU when it supports import/export
+    ie_param_t param;
+    if (ie_core_get_metric(core, "GNA", "AVAILABLE_DEVICES", &param) != IEStatusCode::OK) {
+        ie_core_free(&core);
+        GTEST_SKIP();
+    }
 
     ie_config_t config = {nullptr, nullptr, nullptr};
     ie_executable_network_t *exe_network = nullptr;
@@ -353,6 +358,13 @@ TEST(ie_core_import_network_from_memory, importNetworkFromMem) {
     ie_core_t *core = nullptr;
     IE_ASSERT_OK(ie_core_create("", &core));
     ASSERT_NE(nullptr, core);
+
+    // Test should be performed on CPU when it supports import/export
+    ie_param_t param;
+    if (ie_core_get_metric(core, "GNA", "AVAILABLE_DEVICES", &param) != IEStatusCode::OK) {
+        ie_core_free(&core);
+        GTEST_SKIP();
+    }
 
     ie_config_t conf1 = {"GNA_DEVICE_MODE", "GNA_SW_EXACT", nullptr};
     ie_config_t conf2 = {"GNA_SCALE_FACTOR_0", "327.67", &conf1};
@@ -386,6 +398,13 @@ TEST(ie_core_import_network_from_file, importNetworkFromFile) {
     IE_ASSERT_OK(ie_core_create("", &core));
     ASSERT_NE(nullptr, core);
 
+    // Test should be performed on CPU when it supports import/export
+    ie_param_t param;
+    if (ie_core_get_metric(core, "GNA", "AVAILABLE_DEVICES", &param) != IEStatusCode::OK) {
+        ie_core_free(&core);
+        GTEST_SKIP();
+    }
+
     ie_config_t conf1 = {"GNA_DEVICE_MODE", "GNA_SW_EXACT", nullptr};
     ie_config_t conf2 = {"GNA_SCALE_FACTOR_0", "32767", &conf1};
 
@@ -410,6 +429,13 @@ TEST(ie_core_import_network_from_file, importNetwork_errorHandling) {
     ie_core_t *core = nullptr;
     IE_ASSERT_OK(ie_core_create("", &core));
     ASSERT_NE(nullptr, core);
+
+    // Test should be performed on CPU when it supports import/export
+    ie_param_t param;
+    if (ie_core_get_metric(core, "GNA", "AVAILABLE_DEVICES", &param) != IEStatusCode::OK) {
+        ie_core_free(&core);
+        GTEST_SKIP();
+    }
 
     ie_config_t config = {nullptr, nullptr, nullptr};
     ie_executable_network_t *exe_network = nullptr;
@@ -437,7 +463,6 @@ TEST(ie_core_import_network_from_file, importNetwork_errorHandling) {
 
     ie_core_free(&core);
 }
-#endif
 
 TEST(ie_core_load_network, loadNetwork) {
     ie_core_t *core = nullptr;

--- a/inference-engine/ie_bridges/c/tests/ie_c_api_test.cpp
+++ b/inference-engine/ie_bridges/c/tests/ie_c_api_test.cpp
@@ -331,11 +331,14 @@ TEST(ie_core_export_network_to_file, exportNetworktoFile) {
 
     ie_config_t config = {nullptr, nullptr, nullptr};
     ie_executable_network_t *exe_network = nullptr;
-    IE_EXPECT_OK(ie_core_load_network_from_file(core, xml, "GNA", &config, &exe_network));
+    std::string model_path_str = TestDataHelpers::generate_model_path("../gna", "gna_basic_fp32.xml");
+    const char *model_path = model_path_str.c_str();
+
+    IE_EXPECT_OK(ie_core_load_network_from_file(core, model_path, "GNA", &config, &exe_network));
     EXPECT_NE(nullptr, exe_network);
 
     const char* file_name = "exported_model.blob";
-    IE_EXPECT_OK(ie_core_export_network(core, file_name, &exe_network));
+    IE_EXPECT_OK(ie_core_export_network(core, file_name, exe_network));
     std::ifstream file(file_name);
     EXPECT_NE(file.peek(), std::ifstream::traits_type::eof());
 
@@ -348,18 +351,19 @@ TEST(ie_core_import_network_from_memory, importNetworkFromMem) {
     ie_core_t *core = nullptr;
     IE_ASSERT_OK(ie_core_create("", &core));
     ASSERT_NE(nullptr, core);
-    
+
     ie_config_t conf1 = {"GNA_DEVICE_MODE", "GNA_SW_EXACT", nullptr};
     ie_config_t conf2 = {"GNA_SCALE_FACTOR_0", "327.67", &conf1};
 
     ie_executable_network_t *exe_network = nullptr;
-    std::string model_path_str = TestDataHelpers::generate_model_path("../../models/google_cmd", "tf_speech_model_fp32.xml");
+    std::string model_path_str = TestDataHelpers::generate_model_path("../gna", "gna_basic_fp32.xml");
     const char *model_path = model_path_str.c_str();
+
     IE_EXPECT_OK(ie_core_load_network_from_file(core, model_path, "GNA", &conf2, &exe_network));
     EXPECT_NE(nullptr, exe_network);
-    
+
     const char* export_path = "exported_model.blob";
-    IE_EXPECT_OK(ie_core_export_network(core, export_path, &exe_network));
+    IE_EXPECT_OK(ie_core_export_network(core, export_path, exe_network));
 
     FILE *fileptr;
     fileptr = fopen(export_path, "rb");
@@ -377,9 +381,10 @@ TEST(ie_core_import_network_from_memory, importNetworkFromMem) {
     if (fread(input_data, 1, filelen, fileptr) != filelen) {
         fputs ("Reading error",stderr); exit (3);
     }
+
     fclose(fileptr);
     ie_executable_network_t *network = nullptr;
-    
+
     IE_EXPECT_OK(ie_core_import_network_from_memory(core, blob, "GNA", &conf2, &network));
     EXPECT_NE(nullptr, network);
     if (network != nullptr) {
@@ -401,13 +406,13 @@ TEST(ie_core_import_network_from_file, importNetworkFromFile) {
     ie_config_t conf2 = {"GNA_SCALE_FACTOR_0", "32767", &conf1};
 
     ie_executable_network_t *exe_network = nullptr;
-    std::string model_path_str = TestDataHelpers::generate_model_path("../../models/google_cmd", "tf_speech_model_fp32.xml");
+    std::string model_path_str = TestDataHelpers::generate_model_path("../gna", "gna_basic_fp32.xml");
     const char *model_path = model_path_str.c_str();
     IE_EXPECT_OK(ie_core_load_network_from_file(core, model_path, "GNA", &conf2, &exe_network));
     EXPECT_NE(nullptr, exe_network);
 
     const char* exported_model = "exported_model.blob";
-    IE_EXPECT_OK(ie_core_export_network(core, exported_model, &exe_network));
+    IE_EXPECT_OK(ie_core_export_network(core, exported_model, exe_network));
     std::ifstream file(exported_model);
     EXPECT_NE(file.peek(), std::ifstream::traits_type::eof());
 

--- a/inference-engine/ie_bridges/c/tests/ie_c_api_test.cpp
+++ b/inference-engine/ie_bridges/c/tests/ie_c_api_test.cpp
@@ -329,7 +329,6 @@ TEST(ie_core_export_network_to_file, exportNetworktoFile) {
     IE_ASSERT_OK(ie_core_create("", &core));
     ASSERT_NE(nullptr, core);
 
-    // ie_config_t config = {"CPU_THREADS_NUM", "3", nullptr};
     ie_config_t config = {nullptr, nullptr, nullptr};
     ie_executable_network_t *exe_network = nullptr;
     IE_EXPECT_OK(ie_core_load_network_from_file(core, xml, "GNA", &config, &exe_network));
@@ -354,7 +353,6 @@ TEST(ie_core_import_network_from_memory, importNetworkFromMem) {
     ie_config_t conf2 = {"GNA_SCALE_FACTOR_0", "327.67", &conf1};
 
     ie_executable_network_t *exe_network = nullptr;
-    // const char* model_path = "openvino/inference-engine/temp/models/src/models/google_cmd/tf_speech_model_fp32.xml";
     std::string model_path_str = TestDataHelpers::generate_model_path("../../models/google_cmd", "tf_speech_model_fp32.xml");
     const char *model_path = model_path_str.c_str();
     IE_EXPECT_OK(ie_core_load_network_from_file(core, model_path, "GNA", &conf2, &exe_network));

--- a/inference-engine/ie_bridges/c/tests/ie_c_api_test.cpp
+++ b/inference-engine/ie_bridges/c/tests/ie_c_api_test.cpp
@@ -331,7 +331,7 @@ TEST(ie_core_export_network_to_file, exportNetworktoFile) {
 
     ie_config_t config = {nullptr, nullptr, nullptr};
     ie_executable_network_t *exe_network = nullptr;
-    std::string model_path_str = TestDataHelpers::generate_model_path("../gna", "gna_basic_fp32.xml");
+    std::string model_path_str = TestDataHelpers::generate_gna_model_path("gna_basic_fp32.xml");
     const char *model_path = model_path_str.c_str();
 
     IE_EXPECT_OK(ie_core_load_network_from_file(core, model_path, "GNA", &config, &exe_network));
@@ -356,7 +356,7 @@ TEST(ie_core_import_network_from_memory, importNetworkFromMem) {
     ie_config_t conf2 = {"GNA_SCALE_FACTOR_0", "327.67", &conf1};
 
     ie_executable_network_t *exe_network = nullptr;
-    std::string model_path_str = TestDataHelpers::generate_model_path("../gna", "gna_basic_fp32.xml");
+    std::string model_path_str = TestDataHelpers::generate_gna_model_path("gna_basic_fp32.xml");
     const char *model_path = model_path_str.c_str();
 
     IE_EXPECT_OK(ie_core_load_network_from_file(core, model_path, "GNA", &conf2, &exe_network));
@@ -400,7 +400,7 @@ TEST(ie_core_import_network_from_file, importNetworkFromFile) {
     ie_config_t conf2 = {"GNA_SCALE_FACTOR_0", "32767", &conf1};
 
     ie_executable_network_t *exe_network = nullptr;
-    std::string model_path_str = TestDataHelpers::generate_model_path("../gna", "gna_basic_fp32.xml");
+    std::string model_path_str = TestDataHelpers::generate_gna_model_path("gna_basic_fp32.xml");
     const char *model_path = model_path_str.c_str();
     IE_EXPECT_OK(ie_core_load_network_from_file(core, model_path, "GNA", &conf2, &exe_network));
     EXPECT_NE(nullptr, exe_network);
@@ -424,7 +424,7 @@ TEST(ie_core_import_network_from_file, importNetwork_errorHandling) {
     ie_config_t config = {nullptr, nullptr, nullptr};
     ie_executable_network_t *exe_network = nullptr;
 
-    std::string file_name_str = TestDataHelpers::generate_model_path("../gna", "export2dot1.blob");
+    std::string file_name_str = TestDataHelpers::generate_gna_model_path("export2dot1.blob");
     const char* file_name = file_name_str.c_str();
 
     IE_EXPECT_NOT_OK(ie_core_import_network(nullptr, file_name, "GNA", &config, &exe_network));

--- a/inference-engine/ie_bridges/c/tests/ie_c_api_test.cpp
+++ b/inference-engine/ie_bridges/c/tests/ie_c_api_test.cpp
@@ -324,6 +324,8 @@ TEST(ie_core_read_network_from_memory, networkReadFromMemory) {
     ie_core_free(&core);
 }
 
+#ifdef ENABLE_GNA
+// The following tests should be performed on CPU when it supports import/export
 TEST(ie_core_export_network_to_file, exportNetworktoFile) {
     ie_core_t *core = nullptr;
     IE_ASSERT_OK(ie_core_create("", &core));
@@ -337,9 +339,9 @@ TEST(ie_core_export_network_to_file, exportNetworktoFile) {
     IE_EXPECT_OK(ie_core_load_network_from_file(core, model_path, "GNA", &config, &exe_network));
     EXPECT_NE(nullptr, exe_network);
 
-    const char* file_name = "exported_model.blob";
-    IE_EXPECT_OK(ie_core_export_network(exe_network, file_name));
-    std::ifstream file(file_name);
+    std::string export_path = TestDataHelpers::generate_gna_model_path("exported_model.blob");
+    IE_EXPECT_OK(ie_core_export_network(exe_network, export_path.c_str()));
+    std::ifstream file(export_path.c_str());
     EXPECT_NE(file.peek(), std::ifstream::traits_type::eof());
 
     EXPECT_NE(nullptr, exe_network);
@@ -393,12 +395,12 @@ TEST(ie_core_import_network_from_file, importNetworkFromFile) {
     IE_EXPECT_OK(ie_core_load_network_from_file(core, model_path, "GNA", &conf2, &exe_network));
     EXPECT_NE(nullptr, exe_network);
 
-    const char* exported_model = "exported_model.blob";
-    IE_EXPECT_OK(ie_core_export_network(exe_network, exported_model));
+    std::string exported_model = TestDataHelpers::generate_gna_model_path("exported_model.blob");
+    IE_EXPECT_OK(ie_core_export_network(exe_network, exported_model.c_str()));
     std::ifstream file(exported_model);
     EXPECT_NE(file.peek(), std::ifstream::traits_type::eof());
 
-    IE_EXPECT_OK(ie_core_import_network(core, exported_model, "GNA", &conf2, &exe_network));
+    IE_EXPECT_OK(ie_core_import_network(core, exported_model.c_str(), "GNA", &conf2, &exe_network));
     EXPECT_NE(nullptr, exe_network);
     ie_exec_network_free(&exe_network);
     ie_core_free(&core);
@@ -435,6 +437,7 @@ TEST(ie_core_import_network_from_file, importNetwork_errorHandling) {
 
     ie_core_free(&core);
 }
+#endif
 
 TEST(ie_core_load_network, loadNetwork) {
     ie_core_t *core = nullptr;

--- a/inference-engine/ie_bridges/c/tests/ie_c_api_test.cpp
+++ b/inference-engine/ie_bridges/c/tests/ie_c_api_test.cpp
@@ -338,7 +338,7 @@ TEST(ie_core_export_network_to_file, exportNetworktoFile) {
     EXPECT_NE(nullptr, exe_network);
 
     const char* file_name = "exported_model.blob";
-    IE_EXPECT_OK(ie_core_export_network(file_name, exe_network));
+    IE_EXPECT_OK(ie_core_export_network(exe_network, file_name));
     std::ifstream file(file_name);
     EXPECT_NE(file.peek(), std::ifstream::traits_type::eof());
 
@@ -363,7 +363,7 @@ TEST(ie_core_import_network_from_memory, importNetworkFromMem) {
     EXPECT_NE(nullptr, exe_network);
 
     const char* export_path = "exported_model.blob";
-    IE_EXPECT_OK(ie_core_export_network(export_path, exe_network));
+    IE_EXPECT_OK(ie_core_export_network(exe_network, export_path));
 
     FILE *fileptr;
     fileptr = fopen(export_path, "rb");
@@ -406,7 +406,7 @@ TEST(ie_core_import_network_from_file, importNetworkFromFile) {
     EXPECT_NE(nullptr, exe_network);
 
     const char* exported_model = "exported_model.blob";
-    IE_EXPECT_OK(ie_core_export_network(exported_model, exe_network));
+    IE_EXPECT_OK(ie_core_export_network(exe_network, exported_model));
     std::ifstream file(exported_model);
     EXPECT_NE(file.peek(), std::ifstream::traits_type::eof());
 

--- a/inference-engine/ie_bridges/c/tests/ie_c_api_test.cpp
+++ b/inference-engine/ie_bridges/c/tests/ie_c_api_test.cpp
@@ -489,6 +489,24 @@ TEST(ie_core_load_network, loadNetworkNoConfig) {
     ie_core_free(&core);
 }
 
+TEST(ie_core_load_network, loadNetworkNullConfig) {
+    ie_core_t *core = nullptr;
+    IE_ASSERT_OK(ie_core_create("", &core));
+    ASSERT_NE(nullptr, core);
+
+    ie_network_t *network = nullptr;
+    IE_EXPECT_OK(ie_core_read_network(core, xml, bin, &network));
+    EXPECT_NE(nullptr, network);
+
+    ie_executable_network_t *exe_network = nullptr;
+    IE_EXPECT_OK(ie_core_load_network(core, network, "CPU", nullptr, &exe_network));
+    EXPECT_NE(nullptr, exe_network);
+
+    ie_exec_network_free(&exe_network);
+    ie_network_free(&network);
+    ie_core_free(&core);
+}
+
 TEST(ie_core_load_network_from_file, loadNetworkNoConfig) {
     ie_core_t *core = nullptr;
     IE_ASSERT_OK(ie_core_create("", &core));
@@ -502,6 +520,20 @@ TEST(ie_core_load_network_from_file, loadNetworkNoConfig) {
     ie_exec_network_free(&exe_network);
     ie_core_free(&core);
 }
+
+TEST(ie_core_load_network_from_file, loadNetworkNullConfig) {
+    ie_core_t *core = nullptr;
+    IE_ASSERT_OK(ie_core_create("", &core));
+    ASSERT_NE(nullptr, core);
+
+    ie_executable_network_t *exe_network = nullptr;
+    IE_EXPECT_OK(ie_core_load_network_from_file(core, xml, "CPU", nullptr, &exe_network));
+    EXPECT_NE(nullptr, exe_network);
+
+    ie_exec_network_free(&exe_network);
+    ie_core_free(&core);
+}
+
 
 TEST(ie_core_load_network_from_file, loadNetwork_errorHandling) {
     ie_core_t *core = nullptr;
@@ -517,9 +549,6 @@ TEST(ie_core_load_network_from_file, loadNetwork_errorHandling) {
     EXPECT_EQ(nullptr, exe_network);
 
     IE_EXPECT_NOT_OK(ie_core_load_network_from_file(core, xml, nullptr, &config, &exe_network));
-    EXPECT_EQ(nullptr, exe_network);
-
-    IE_EXPECT_NOT_OK(ie_core_load_network_from_file(core, xml, "CPU", nullptr, &exe_network));
     EXPECT_EQ(nullptr, exe_network);
 
     IE_EXPECT_NOT_OK(ie_core_load_network_from_file(core, xml, "CPU", &config, nullptr));

--- a/inference-engine/ie_bridges/c/tests/ie_c_api_test.cpp
+++ b/inference-engine/ie_bridges/c/tests/ie_c_api_test.cpp
@@ -423,24 +423,27 @@ TEST(ie_core_import_network_from_file, importNetwork_errorHandling) {
 
     ie_config_t config = {nullptr, nullptr, nullptr};
     ie_executable_network_t *exe_network = nullptr;
-    const char *file_name = "exported_model.blob";
-    IE_EXPECT_NOT_OK(ie_core_import_network(nullptr, file_name, "CPU", &config, &exe_network));
+
+    std::string file_name_str = TestDataHelpers::generate_model_path("../gna", "export2dot1.blob");
+    const char* file_name = file_name_str.c_str();
+
+    IE_EXPECT_NOT_OK(ie_core_import_network(nullptr, file_name, "GNA", &config, &exe_network));
     EXPECT_EQ(nullptr, exe_network);
 
-    IE_EXPECT_NOT_OK(ie_core_import_network(core, nullptr, "CPU", &config, &exe_network));
+    IE_EXPECT_NOT_OK(ie_core_import_network(core, nullptr, "GNA", &config, &exe_network));
     EXPECT_EQ(nullptr, exe_network);
 
     IE_EXPECT_NOT_OK(ie_core_import_network(core, file_name, nullptr, &config, &exe_network));
     EXPECT_EQ(nullptr, exe_network);
 
-    IE_EXPECT_NOT_OK(ie_core_import_network(core, file_name, "CPU", nullptr, &exe_network));
-    EXPECT_EQ(nullptr, exe_network);
-
-    IE_EXPECT_NOT_OK(ie_core_import_network(core, file_name, "CPU", &config, nullptr));
+    IE_EXPECT_NOT_OK(ie_core_import_network(core, file_name, "GNA", &config, nullptr));
     EXPECT_EQ(nullptr, exe_network);
 
     IE_EXPECT_NOT_OK(ie_core_import_network(core, file_name, "UnregisteredDevice", &config, &exe_network));
     EXPECT_EQ(nullptr, exe_network);
+
+    IE_EXPECT_OK(ie_core_import_network(core, file_name, "GNA", nullptr, &exe_network));
+    EXPECT_NE(nullptr, exe_network);
 
     ie_core_free(&core);
 }

--- a/inference-engine/ie_bridges/c/tests/ie_c_api_test.cpp
+++ b/inference-engine/ie_bridges/c/tests/ie_c_api_test.cpp
@@ -338,7 +338,7 @@ TEST(ie_core_export_network_to_file, exportNetworktoFile) {
     EXPECT_NE(nullptr, exe_network);
 
     const char* file_name = "exported_model.blob";
-    IE_EXPECT_OK(ie_core_export_network(core, file_name, exe_network));
+    IE_EXPECT_OK(ie_core_export_network(file_name, exe_network));
     std::ifstream file(file_name);
     EXPECT_NE(file.peek(), std::ifstream::traits_type::eof());
 
@@ -363,7 +363,7 @@ TEST(ie_core_import_network_from_memory, importNetworkFromMem) {
     EXPECT_NE(nullptr, exe_network);
 
     const char* export_path = "exported_model.blob";
-    IE_EXPECT_OK(ie_core_export_network(core, export_path, exe_network));
+    IE_EXPECT_OK(ie_core_export_network(export_path, exe_network));
 
     FILE *fileptr;
     fileptr = fopen(export_path, "rb");
@@ -406,7 +406,7 @@ TEST(ie_core_import_network_from_file, importNetworkFromFile) {
     EXPECT_NE(nullptr, exe_network);
 
     const char* exported_model = "exported_model.blob";
-    IE_EXPECT_OK(ie_core_export_network(core, exported_model, exe_network));
+    IE_EXPECT_OK(ie_core_export_network(exported_model, exe_network));
     std::ifstream file(exported_model);
     EXPECT_NE(file.peek(), std::ifstream::traits_type::eof());
 

--- a/inference-engine/ie_bridges/c/tests/ie_c_api_test.cpp
+++ b/inference-engine/ie_bridges/c/tests/ie_c_api_test.cpp
@@ -338,7 +338,7 @@ TEST(ie_core_export_network_to_file, exportNetworktoFile) {
 
     ie_config_t config = {nullptr, nullptr, nullptr};
     ie_executable_network_t *exe_network = nullptr;
-    std::string model_path_str = TestDataHelpers::generate_gna_model_path("gna_basic_fp32.xml");
+    std::string model_path_str = TestDataHelpers::generate_model_path("test_model", "gna_basic_fp32.xml");
     const char *model_path = model_path_str.c_str();
 
     IE_EXPECT_OK(ie_core_load_network_from_file(core, model_path, "GNA", &config, &exe_network));
@@ -370,7 +370,7 @@ TEST(ie_core_import_network_from_memory, importNetworkFromMem) {
     ie_config_t conf2 = {"GNA_SCALE_FACTOR_0", "327.67", &conf1};
 
     ie_executable_network_t *exe_network = nullptr;
-    std::string model_path_str = TestDataHelpers::generate_gna_model_path("gna_basic_fp32.xml");
+    std::string model_path_str = TestDataHelpers::generate_model_path("test_model", "gna_basic_fp32.xml");
     const char *model_path = model_path_str.c_str();
 
     IE_EXPECT_OK(ie_core_load_network_from_file(core, model_path, "GNA", &conf2, &exe_network));
@@ -409,7 +409,7 @@ TEST(ie_core_import_network_from_file, importNetworkFromFile) {
     ie_config_t conf2 = {"GNA_SCALE_FACTOR_0", "32767", &conf1};
 
     ie_executable_network_t *exe_network = nullptr;
-    std::string model_path_str = TestDataHelpers::generate_gna_model_path("gna_basic_fp32.xml");
+    std::string model_path_str = TestDataHelpers::generate_model_path("test_model", "gna_basic_fp32.xml");
     const char *model_path = model_path_str.c_str();
     IE_EXPECT_OK(ie_core_load_network_from_file(core, model_path, "GNA", &conf2, &exe_network));
     EXPECT_NE(nullptr, exe_network);

--- a/inference-engine/ie_bridges/c/tests/test_model_repo.hpp
+++ b/inference-engine/ie_bridges/c/tests/test_model_repo.hpp
@@ -43,6 +43,10 @@ std::string generate_model_path(std::string dir, std::string filename) {
     return get_models_path() + kPathSeparator + dir + kPathSeparator + filename;
 }
 
+std::string generate_gna_model_path(std::string filename) {
+    return get_data_path() + kPathSeparator + std::string("gna") + kPathSeparator + filename;
+}
+
 std::string generate_image_path(std::string dir, std::string filename) {
     return get_data_path() + kPathSeparator + "validation_set" + kPathSeparator + dir + kPathSeparator + filename;
 }

--- a/inference-engine/tests/functional/plugin/gna/Import_export_tests/import_export_memory_layer.cpp
+++ b/inference-engine/tests/functional/plugin/gna/Import_export_tests/import_export_memory_layer.cpp
@@ -55,8 +55,7 @@ public:
         LoadNetwork();
         GenerateInputs();
         Infer();
-        const char *file_name = "exported_model.blob";
-        executableNetwork.Export(file_name);
+        executableNetwork.Export("exported_model.blob");
         for (auto const &configItem : importConfiguration) {
             configuration[configItem.first] = configItem.second;
         }
@@ -64,7 +63,7 @@ public:
         if (inputStream.fail()) {
             FAIL() << "Cannot open file to import model: exported_model.blob";
         }
-        auto importedNetwork = core->ImportNetwork(file_name, targetDevice, configuration);
+        auto importedNetwork = core->ImportNetwork(inputStream, targetDevice, configuration);
         std::vector<std::string> queryToState;
         IE_SUPPRESS_DEPRECATED_START
         for (const auto &query_state : executableNetwork.QueryState()) {

--- a/inference-engine/tests/functional/plugin/gna/Import_export_tests/import_export_memory_layer.cpp
+++ b/inference-engine/tests/functional/plugin/gna/Import_export_tests/import_export_memory_layer.cpp
@@ -55,7 +55,8 @@ public:
         LoadNetwork();
         GenerateInputs();
         Infer();
-        executableNetwork.Export("exported_model.blob");
+        const char *file_name = "exported_model.blob";
+        executableNetwork.Export(file_name);
         for (auto const &configItem : importConfiguration) {
             configuration[configItem.first] = configItem.second;
         }
@@ -63,7 +64,7 @@ public:
         if (inputStream.fail()) {
             FAIL() << "Cannot open file to import model: exported_model.blob";
         }
-        auto importedNetwork = core->ImportNetwork(inputStream, targetDevice, configuration);
+        auto importedNetwork = core->ImportNetwork(file_name, targetDevice, configuration);
         std::vector<std::string> queryToState;
         IE_SUPPRESS_DEPRECATED_START
         for (const auto &query_state : executableNetwork.QueryState()) {


### PR DESCRIPTION
Merge of #8353
### Details:
Added Import/Export functions to C API:

Creates an executable network from a network previously exported to file. Users can create as many networks as they
need and use them simultaneously (up to the limitation of the hardware resources). Use the ie_exec_network_free()
method to free
memory.
IEStatusCode ie_core_import_network(ie_core_t *core, const char *file_name, const char *device_name,
const ie_config_t *config, ie_executable_network_t **exe_network)

Creates an executable network from a network previously exported to blob. Users can create as many networks as they
need and use them simultaneously (up to the limitation of the hardware resources). Use the ie_exec_network_free()
method to free
memory.
IEStatusCode ie_core_import_network_from_memory(ie_core_t *core, const ie_blob_t *blob, const char *device_name,
const ie_config_t *config, ie_executable_network_t **exe_network)

Exports an executable network to bin file.
IEStatusCode ie_core_export_network(ie_core_t *core, const char *file_name, ie_executable_network_t **exe_network)

Added tests for these functions:
exportNetworktoFile, importNetworkFromMem, importNetworkFromFile

### Tickets:
 - 68136
