### PR TITLE
add default device value for ie.LoadNetwork

### DIFF
--- a/inference-engine/src/inference_engine/include/ie/ie_core.hpp
+++ b/inference-engine/src/inference_engine/include/ie/ie_core.hpp
@@ -107,7 +107,7 @@ public:
      * @return An executable network reference
      */
     ExecutableNetwork LoadNetwork(const CNNNetwork& network,
-                                  const std::string& deviceName,
+                                  const std::string& deviceName = "AUTO",
                                   const std::map<std::string, std::string>& config = {});
 
     /**
@@ -124,7 +124,7 @@ public:
      * @return An executable network reference
      */
     ExecutableNetwork LoadNetwork(const std::string& modelPath,
-                                  const std::string& deviceName,
+                                  const std::string& deviceName = "AUTO",
                                   const std::map<std::string, std::string>& config = {});
 
     /**

--- a/inference-engine/src/inference_engine/include/openvino/runtime/core.hpp
+++ b/inference-engine/src/inference_engine/include/openvino/runtime/core.hpp
@@ -116,7 +116,7 @@ public:
      * @return An executable network reference
      */
     ExecutableNetwork compile_model(const std::shared_ptr<const ov::Function>& network,
-                                    const std::string& deviceName,
+                                    const std::string& deviceName = "AUTO",
                                     const ConfigMap& config = {});
 
     /**
@@ -133,7 +133,7 @@ public:
      * @return An executable network reference
      */
     ExecutableNetwork compile_model(const std::string& modelPath,
-                                    const std::string& deviceName,
+                                    const std::string& deviceName = "AUTO",
                                     const ConfigMap& config = {});
 
     /**

--- a/inference-engine/tests/functional/plugin/shared/include/behavior/ov_executable_network/exec_network_base.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/behavior/ov_executable_network/exec_network_base.hpp
@@ -80,6 +80,10 @@ TEST_P(OVExecutableNetworkBaseTest, canLoadCorrectNetworkToGetExecutable) {
     EXPECT_NO_THROW(auto execNet = core->compile_model(function, targetDevice, configuration));
 }
 
+TEST_P(OVExecutableNetworkBaseTest, canLoadCorrectNetworkToDefaultDevice) {
+    EXPECT_NO_THROW(auto execNet = core->compile_model(function));
+}
+
 TEST_P(OVExecutableNetworkBaseTest, canLoadCorrectNetworkToGetExecutableWithIncorrectConfig) {
     std::map<std::string, std::string> incorrectConfig = {{"abc", "def"}};
     EXPECT_ANY_THROW(auto execNet = core->compile_model(function, targetDevice, configuration));

--- a/inference-engine/tests/functional/plugin/shared/include/behavior/plugin/core_integration.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/behavior/plugin/core_integration.hpp
@@ -879,6 +879,11 @@ TEST_P(IEClassQueryNetworkTest, QueryNetworkHETEROWithBigDeviceIDThrows) {
 //
 // LoadNetwork
 //
+TEST_P(IEClassNetworkTestP, LoadNetworkWithoutDeviceNameNoThrow) {
+  SKIP_IF_CURRENT_TEST_IS_DISABLED()
+  InferenceEngine::Core  ie = BehaviorTestsUtils::createIECoreWithTemplate();
+  ASSERT_NO_THROW(ie.LoadNetwork(actualCnnNetwork));
+}
 
 TEST_P(IEClassNetworkTestP, LoadNetworkActualNoThrow) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()


### PR DESCRIPTION
Signed-off-by: fishbell <bell.song@intel.com>

### Details:
 - change LoadNetwork api with default deviceName="AUTO". 
 - related test case added. For example, LoadNetwork(network).

### Tickets:
 - 57530
