### PR TITLE
Fix of ReverseInputChannels for NHWC layout.

### DIFF
--- a/model-optimizer/extensions/back/ReverseInputChannels.py
+++ b/model-optimizer/extensions/back/ReverseInputChannels.py
@@ -334,7 +334,7 @@ class ReverseChannelsPropagationUp(BackReplacementPattern):
         'Pow': lambda node, rc: ReverseChannelsPropagationUp.lift_up_through_eltwise(node, rc),
         'Convert': lambda node, rc: ReverseChannelsPropagationUp.lift_up_through_eltwise(node, rc),
         'Pad': lambda node, rc: ReverseChannelsPropagationUp.lift_up_through(node, rc),
-        'Transpose': lambda node, rc: ReverseChannelsPropagationUp.pass_rc_through_transpose(node, rc),
+        'Transpose': lambda node, rc: ReverseChannelsPropagationUp.lift_up_through_transpose(node, rc),
     }
 
     @staticmethod

--- a/model-optimizer/mo/utils/runtime_info.py
+++ b/model-optimizer/mo/utils/runtime_info.py
@@ -29,6 +29,17 @@ class RTInfo:
         """
         self.info = defaultdict(dict)
 
+    def contains(self, attribute_name: str):
+        attr_count = [key[0] for key in list(self.info.keys())].count(attribute_name)
+        assert attr_count <= 1, 'Incorrect rt_info attribute, got more than one {}.'.format(attribute_name)
+        return attr_count > 0
+
+    def get_attribute_version(self, attribute_name: str):
+        for name, version in list(self.info.keys()):
+            if name == attribute_name:
+                return version
+        raise Exception("rt_info does not contain attribute with name {}".format(attribute_name))
+
 
 class RTInfoElement:
     """

--- a/model-optimizer/unit_tests/extensions/back/ReverseInputChannels_test.py
+++ b/model-optimizer/unit_tests/extensions/back/ReverseInputChannels_test.py
@@ -3,16 +3,16 @@
 
 import unittest
 
-from extensions.back.ReverseInputChannels import ReverseChannelsPropagationUp, ReverseChannelsPropagationDown
+from extensions.back.ReverseInputChannels import ReverseChannelsPropagationUp, ReverseChannelsPropagationDown, \
+    InsertReverseChannels
 from mo.front.common.partial_infer.utils import int64_array, float32_array
 from mo.graph.graph import Node, Graph
-from mo.middle.passes.eliminate import shape_inference
 from mo.utils.ir_engine.compare_graphs import compare_graphs
-from unit_tests.utils.graph import build_graph, result, connect, regular_op_with_shaped_data, valued_const_with_data, \
-    regular_op_with_empty_data
+from mo.utils.runtime_info import OldAPIMap, RTInfo
+from unit_tests.utils.graph import build_graph, result, connect, regular_op_with_shaped_data, valued_const_with_data
 
 nodes = {
-    **regular_op_with_shaped_data('placeholder1', [1, 3, 10, 10], {'type': 'Parameter'}),
+    **regular_op_with_shaped_data('placeholder1', [1, 3, 10, 10], {'type': 'Parameter', 'rt_info': RTInfo()}),
     **regular_op_with_shaped_data('placeholder2', [1, 1, 1, 1], {'type': 'Parameter'}),
 
     **regular_op_with_shaped_data('mul', [1, 3, 10, 10], {'type': 'Multiply'}),
@@ -39,11 +39,11 @@ nodes2 = {
 }
 
 nodes3 = {
-    **regular_op_with_empty_data('placeholder', {'type': 'Parameter'}),
-    **regular_op_with_empty_data('transpose', {'type': 'Transpose'}),
+    **regular_op_with_shaped_data('placeholder', [1, 3, 10, 10], {'type': 'Parameter'}),
+    **regular_op_with_shaped_data('transpose', [1, 3, 10, 10], {'type': 'Transpose'}),
     **valued_const_with_data('transpose_order', int64_array([0, 3, 1, 2])),
-    **regular_op_with_empty_data('reverse_channels_up', {'type': 'ReverseChannels', 'axis': 3}),
-    **regular_op_with_empty_data('reverse_channels_down', {'type': 'ReverseChannels', 'axis': 1}),
+    **regular_op_with_shaped_data('reverse_channels_up', [1, 3, 10, 10], {'type': 'ReverseChannels', 'axis': 3}),
+    **regular_op_with_shaped_data('reverse_channels_down', [1, 3, 10, 10], {'type': 'ReverseChannels', 'axis': 1}),
     **result('result'),
     **result('result2'),
 }
@@ -89,7 +89,7 @@ class ReverseInputChannelsTest(unittest.TestCase):
         node = Node(graph, 'pad')
         reverse_channels = Node(graph, 'reverse_channels')
 
-        keep_moving_up, new_reverses = ReverseChannelsPropagationUp.lift_up_through(node, reverse_channels)
+        keep_moving_up, new_reverses = ReverseChannelsPropagationUp.lift_up_through_zero_port_only(node, reverse_channels)
         self.assertTrue(keep_moving_up is True)
         self.assertTrue(len(new_reverses) == 1)
         self.check_graph_attrs(graph, ['placeholder'])
@@ -104,7 +104,7 @@ class ReverseInputChannelsTest(unittest.TestCase):
         node = Node(graph, 'pad')
         reverse_channels = Node(graph, 'reverse_channels')
 
-        keep_moving_up, new_reverses = ReverseChannelsPropagationUp.lift_up_through(node, reverse_channels)
+        keep_moving_up, new_reverses = ReverseChannelsPropagationUp.lift_up_through_zero_port_only(node, reverse_channels)
         self.assertTrue(keep_moving_up is True)
         self.assertTrue(len(new_reverses) == 1)
         self.check_graph_attrs(graph, ['placeholder'])
@@ -119,7 +119,7 @@ class ReverseInputChannelsTest(unittest.TestCase):
         node = Node(graph, 'pad')
         reverse_channels = Node(graph, 'reverse_channels')
 
-        ReverseChannelsPropagationDown.pass_rc_through(node, reverse_channels)
+        ReverseChannelsPropagationDown.pass_rc_through_zero_port_only(node, reverse_channels)
         self.check_graph_attrs(graph, ['placeholder'])
 
     def test_lift_up_through_transpose(self):
@@ -161,7 +161,54 @@ class ReverseInputChannelsTest(unittest.TestCase):
 
         keep_moving_down = ReverseChannelsPropagationDown.pass_rc_through_transpose(node, reverse_channels)
 
-        shape_inference(graph)
+        self.assertTrue(keep_moving_down is True)
+        self.check_graph_attrs(graph, ['placeholder'])
+        (flag, resp) = compare_graphs(graph, graph_ref, 'result')
+        self.assertTrue(flag, resp)
+
+        reverse_channels = Node(graph, 'reverse_channels_down')
+        self.assertTrue(reverse_channels.axis == 1)
+
+    def test_lift_up_through_transpose_negative_axis(self):
+        graph = build_graph(nodes3, [*connect('placeholder', '0:transpose'), *connect('transpose_order', '1:transpose'),
+                                     *connect('transpose', 'reverse_channels_down'),
+                                     *connect('reverse_channels_down', 'result')])
+        graph_ref = build_graph(nodes3, [*connect('placeholder', 'reverse_channels_down'),
+                                         *connect('transpose_order', '1:transpose'),
+                                         *connect('reverse_channels_down', 'transpose'),
+                                         *connect('transpose', 'result')])
+        self.set_graph_attrs(graph, ['placeholder'])
+
+        node = Node(graph, 'transpose')
+        reverse_channels = Node(graph, 'reverse_channels_down')
+        reverse_channels.axis = -3
+
+        keep_moving_up, new_reverses = ReverseChannelsPropagationUp.lift_up_through_transpose(node, reverse_channels)
+        self.assertTrue(keep_moving_up is True)
+        self.assertTrue(len(new_reverses) == 1)
+        self.check_graph_attrs(graph, ['placeholder'])
+        (flag, resp) = compare_graphs(graph, graph_ref, 'result')
+        self.assertTrue(flag, resp)
+
+        reverse_channels = Node(graph, 'reverse_channels_down')
+        self.assertTrue(reverse_channels.axis == 3)
+
+    def test_lift_down_through_transpose_negative_axis(self):
+        graph = build_graph(nodes3, [*connect('placeholder', 'reverse_channels_up'),
+                                     *connect('transpose_order', '1:transpose'),
+                                     *connect('reverse_channels_up', '0:transpose'),
+                                     *connect('transpose', 'result')])
+        graph_ref = build_graph(nodes3, [*connect('placeholder', '0:transpose'),
+                                         *connect('transpose_order', '1:transpose'),
+                                         *connect('transpose', 'reverse_channels_up'),
+                                         *connect('reverse_channels_up', '0:result')])
+        self.set_graph_attrs(graph, ['placeholder'])
+
+        node = Node(graph, 'transpose')
+        reverse_channels = Node(graph, 'reverse_channels_up')
+        reverse_channels.axis = -1
+
+        keep_moving_down = ReverseChannelsPropagationDown.pass_rc_through_transpose(node, reverse_channels)
 
         self.assertTrue(keep_moving_down is True)
         self.check_graph_attrs(graph, ['placeholder'])
@@ -170,3 +217,16 @@ class ReverseInputChannelsTest(unittest.TestCase):
 
         reverse_channels = Node(graph, 'reverse_channels_down')
         self.assertTrue(reverse_channels.axis == 1)
+
+    def test_get_fw_index(self):
+        graph = build_graph(nodes, [*connect('placeholder1', 'result')])
+        node = Node(graph, 'placeholder1')
+        old_api_map = OldAPIMap(version=0)
+        node.rt_info.info[('old_api_map', old_api_map.get_version())] = old_api_map
+        node.rt_info.info[('old_api_map', old_api_map.get_version())].old_api_transpose_parameter([0, 2, 3, 1])
+        self.assertTrue(InsertReverseChannels.get_fw_index(node, 0) == 0)
+        self.assertTrue(InsertReverseChannels.get_fw_index(node, 1) == 3)
+        self.assertTrue(InsertReverseChannels.get_fw_index(node, 2) == 1)
+        self.assertTrue(InsertReverseChannels.get_fw_index(node, 3) == 2)
+        self.assertTrue(InsertReverseChannels.get_fw_index(node, -2) == 1)
+


### PR DESCRIPTION
Root cause analysis: 
In ReverseInputChannels index of dimension to reverse is constant equal to 1 as it was expected that layout of Parameter is always NCHW. But in API 2.0 layout can be NHWC which breaks the transformation.

Solution: 
Check if Parameter node has old_api_map and map channel index to new api.

Ticket: 70164


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests - N/A
* [x]  Transformation tests
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list - N/A
* [x]  Guide on how to convert the **public** model - N/A
* [x]  User guide update - N/A
