### PR TITLE
Deprecated set_* methods in desctiption::Tensor

### DIFF
--- a/inference-engine/src/transformations/include/ngraph_ops/type_relaxed.hpp
+++ b/inference-engine/src/transformations/include/ngraph_ops/type_relaxed.hpp
@@ -92,7 +92,9 @@ protected:
         for (size_t i = 0; i < node.get_input_size(); ++i) {
             auto origin_input_type = get_origin_input_type(i);
             if (origin_input_type != element::undefined) {
+                OPENVINO_SUPPRESS_DEPRECATED_START
                 node.get_input_tensor(i).set_tensor_type(origin_input_type, node.get_input_partial_shape(i));
+                OPENVINO_SUPPRESS_DEPRECATED_END
             }
         }
     }
@@ -100,7 +102,9 @@ protected:
     void restore_input_data_types(Node &node, const element::TypeVector &old_input_types) {
         // Restore original input data types
         for (size_t i = 0; i < node.get_input_size(); ++i) {
+            OPENVINO_SUPPRESS_DEPRECATED_START
             node.get_input_tensor(i).set_tensor_type(old_input_types[i], node.get_input_partial_shape(i));
+            OPENVINO_SUPPRESS_DEPRECATED_END
         }
 
         if (m_original_output_data_types.empty()) {
@@ -158,7 +162,9 @@ public:
     TemporaryReplaceOutputType(Output<Node> output, element::Type tmp_type) : m_output(output) {
         // save original element type in order to restore it in the destructor
         orig_type = m_output.get_element_type();
+        OPENVINO_SUPPRESS_DEPRECATED_START
         m_output.get_tensor().set_element_type(tmp_type);
+        OPENVINO_SUPPRESS_DEPRECATED_END
     }
 
     /// Return the output port that was used in the constructor
@@ -168,7 +174,9 @@ public:
 
     /// Restores the original element type for the output
     ~TemporaryReplaceOutputType() {
+        OPENVINO_SUPPRESS_DEPRECATED_START
         m_output.get_tensor().set_element_type(orig_type);
+        OPENVINO_SUPPRESS_DEPRECATED_END
     }
 };
 

--- a/inference-engine/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
@@ -2,14 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include <fstream>
 #include <signal.h>
+#include <fstream>
 #include <transformations/utils/utils.hpp>
 
 #ifdef _WIN32
 #include <process.h>
 #endif
 
+#include "openvino/core/preprocess/pre_post_process.hpp"
 #include "openvino/pass/serialize.hpp"
 
 #include "graph_comparator.hpp"
@@ -27,16 +28,16 @@ namespace test {
 
 void SubgraphBaseTest::run() {
     auto crashHandler = [](int errCode) {
-        auto &s = LayerTestsUtils::Summary::getInstance();
+        auto& s = LayerTestsUtils::Summary::getInstance();
         s.saveReport();
         std::cerr << "Unexpected application crash with code: " << errCode << std::endl;
         std::abort();
     };
     signal(SIGSEGV, crashHandler);
 
-    LayerTestsUtils::PassRate::Statuses status =
-            FuncTestUtils::SkipTestsConfig::currentTestIsDisabled() ?
-            LayerTestsUtils::PassRate::Statuses::SKIPPED : LayerTestsUtils::PassRate::Statuses::CRASHED;
+    LayerTestsUtils::PassRate::Statuses status = FuncTestUtils::SkipTestsConfig::currentTestIsDisabled()
+                                                     ? LayerTestsUtils::PassRate::Statuses::SKIPPED
+                                                     : LayerTestsUtils::PassRate::Statuses::CRASHED;
     summary.setDeviceName(targetDevice);
     summary.updateOPsStats(function, status);
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
@@ -54,12 +55,13 @@ void SubgraphBaseTest::run() {
                 generate_inputs(targetStaticShapeVec);
                 infer();
                 validate();
-            } catch (const std::exception &ex) {
-                throw std::runtime_error("Incorrect target static shape: " + CommonTestUtils::vec2str(targetStaticShapeVec) + " " + ex.what());
+            } catch (const std::exception& ex) {
+                throw std::runtime_error("Incorrect target static shape: " +
+                                         CommonTestUtils::vec2str(targetStaticShapeVec) + " " + ex.what());
             }
         }
         status = LayerTestsUtils::PassRate::Statuses::PASSED;
-    } catch (const std::exception &ex) {
+    } catch (const std::exception& ex) {
         status = LayerTestsUtils::PassRate::Statuses::FAILED;
         errorMessage = ex.what();
     } catch (...) {
@@ -89,10 +91,13 @@ void SubgraphBaseTest::serialize() {
 
     bool success;
     std::string message;
-    std::tie(success, message) =
-            compare_functions(result, function, false, false, false,
-                              true,     // precision
-                              true);    // attributes
+    std::tie(success, message) = compare_functions(result,
+                                                   function,
+                                                   false,
+                                                   false,
+                                                   false,
+                                                   true,   // precision
+                                                   true);  // attributes
 
     EXPECT_TRUE(success) << message;
 
@@ -115,8 +120,8 @@ void SubgraphBaseTest::query_model() {
     ASSERT_EQ(expected, actual);
 }
 
-void SubgraphBaseTest::compare(const std::vector<ov::runtime::Tensor> &expected,
-                               const std::vector<ov::runtime::Tensor> &actual) {
+void SubgraphBaseTest::compare(const std::vector<ov::runtime::Tensor>& expected,
+                               const std::vector<ov::runtime::Tensor>& actual) {
     ASSERT_EQ(expected.size(), actual.size());
     for (size_t i = 0; i < expected.size(); i++) {
         ov::test::utils::compare(expected[i], actual[i], abs_threshold, rel_threshold);
@@ -125,11 +130,13 @@ void SubgraphBaseTest::compare(const std::vector<ov::runtime::Tensor> &expected,
 
 void SubgraphBaseTest::configure_model() {
     // configure input precision
+    ov::preprocess::PrePostProcessor p;
     {
         auto params = function->get_parameters();
         for (auto& param : params) {
             if (inType != ov::element::Type_t::undefined) {
-                param->get_output_tensor(0).set_element_type(inType);
+                p.input(ov::preprocess::InputInfo(param->get_output_tensor(0).get_any_name())
+                            .tensor(ov::preprocess::InputTensorInfo().set_element_type(inType)));
             }
         }
     }
@@ -139,10 +146,12 @@ void SubgraphBaseTest::configure_model() {
         auto results = function->get_results();
         for (auto& result : results) {
             if (outType != ov::element::Type_t::undefined) {
-                result->get_output_tensor(0).set_element_type(outType);
+                p.output(ov::preprocess::OutputInfo(result->get_output_tensor(0).get_any_name())
+                             .tensor(ov::preprocess::OutputTensorInfo().set_element_type(outType)));
             }
         }
     }
+    function = p.build(function);
 }
 
 void SubgraphBaseTest::compile_model() {
@@ -160,7 +169,8 @@ void SubgraphBaseTest::generate_inputs(const std::vector<ov::Shape>& targetInput
         const auto& funcInput = funcInputs[i];
         ov::runtime::Tensor tensor;
         if (funcInput.get_element_type().is_real()) {
-            tensor = ov::test::utils::create_and_fill_tensor(funcInput.get_element_type(), targetInputStaticShapes[i], 10, 0, 1000);
+            tensor = ov::test::utils::create_and_fill_tensor(
+                funcInput.get_element_type(), targetInputStaticShapes[i], 10, 0, 1000);
         } else {
             tensor = ov::test::utils::create_and_fill_tensor(funcInput.get_element_type(), targetInputStaticShapes[i]);
         }
@@ -197,8 +207,8 @@ void SubgraphBaseTest::validate() {
         return;
     }
 
-    ASSERT_EQ(actualOutputs.size(), expectedOutputs.size()) << "nGraph interpreter has "
-        << expectedOutputs.size() << " outputs, while IE " << actualOutputs.size();
+    ASSERT_EQ(actualOutputs.size(), expectedOutputs.size())
+        << "nGraph interpreter has " << expectedOutputs.size() << " outputs, while IE " << actualOutputs.size();
 
     compare(expectedOutputs, actualOutputs);
 }
@@ -213,7 +223,8 @@ void SubgraphBaseTest::init_input_shapes(const std::vector<InputShape>& shapes) 
             dynShape = shape.second.front();
         }
         inputDynamicShapes.push_back(dynShape);
-        ASSERT_EQ(shape.second.size(), targetStaticShapeSize) << "Target static count shapes should be the same for all inputs";
+        ASSERT_EQ(shape.second.size(), targetStaticShapeSize)
+            << "Target static count shapes should be the same for all inputs";
         for (size_t i = 0; i < shape.second.size(); ++i) {
             targetStaticShapes[i].push_back(shape.second.at(i));
         }

--- a/inference-engine/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
@@ -132,11 +132,11 @@ void SubgraphBaseTest::configure_model() {
     // configure input precision
     ov::preprocess::PrePostProcessor p;
     {
-        auto params = function->get_parameters();
-        for (auto& param : params) {
+        auto& params = function->get_parameters();
+        for (size_t i = 0; i < params.size(); i++) {
             if (inType != ov::element::Type_t::undefined) {
-                p.input(ov::preprocess::InputInfo(param->get_output_tensor(0).get_any_name())
-                            .tensor(ov::preprocess::InputTensorInfo().set_element_type(inType)));
+                p.input(ov::preprocess::InputInfo(i)
+                        .tensor(ov::preprocess::InputTensorInfo().set_element_type(inType)));
             }
         }
     }
@@ -144,9 +144,9 @@ void SubgraphBaseTest::configure_model() {
     // configure output precision
     {
         auto results = function->get_results();
-        for (auto& result : results) {
+        for (size_t i = 0; i < results.size(); i++) {
             if (outType != ov::element::Type_t::undefined) {
-                p.output(ov::preprocess::OutputInfo(result->get_output_tensor(0).get_any_name())
+                p.output(ov::preprocess::OutputInfo(i)
                              .tensor(ov::preprocess::OutputTensorInfo().set_element_type(outType)));
             }
         }

--- a/ngraph/core/include/openvino/core/descriptor/tensor.hpp
+++ b/ngraph/core/include/openvino/core/descriptor/tensor.hpp
@@ -45,8 +45,12 @@ public:
     const std::unordered_set<std::string>& get_names() const;
     void set_names(const std::unordered_set<std::string>& names);
     void add_names(const std::unordered_set<std::string>& names);
+
+    OPENVINO_DEPRECATED("set_tensor_type() is deprecated. To change Tensor type please change the Parameter type")
     void set_tensor_type(const element::Type& element_type, const PartialShape& pshape);
+    OPENVINO_DEPRECATED("set_element_type() is deprecated. To change Tensor element type please change the Parameter type")
     void set_element_type(const element::Type& elemenet_type);
+    OPENVINO_DEPRECATED("set_partial_shape() is deprecated. To change Tensor partial shape please change the Parameter partial shape")
     void set_partial_shape(const PartialShape& partial_shape);
 
     /// \brief sets lower bound value description

--- a/ngraph/core/include/openvino/core/descriptor/tensor.hpp
+++ b/ngraph/core/include/openvino/core/descriptor/tensor.hpp
@@ -48,9 +48,11 @@ public:
 
     OPENVINO_DEPRECATED("set_tensor_type() is deprecated. To change Tensor type please change the Parameter type")
     void set_tensor_type(const element::Type& element_type, const PartialShape& pshape);
-    OPENVINO_DEPRECATED("set_element_type() is deprecated. To change Tensor element type please change the Parameter type")
+    OPENVINO_DEPRECATED(
+        "set_element_type() is deprecated. To change Tensor element type please change the Parameter type")
     void set_element_type(const element::Type& elemenet_type);
-    OPENVINO_DEPRECATED("set_partial_shape() is deprecated. To change Tensor partial shape please change the Parameter partial shape")
+    OPENVINO_DEPRECATED(
+        "set_partial_shape() is deprecated. To change Tensor partial shape please change the Parameter partial shape")
     void set_partial_shape(const PartialShape& partial_shape);
 
     /// \brief sets lower bound value description

--- a/ngraph/core/src/descriptor/tensor.cpp
+++ b/ngraph/core/src/descriptor/tensor.cpp
@@ -23,6 +23,7 @@ ov::descriptor::Tensor::Tensor(const element::Type& element_type,
       m_partial_shape(pshape),
       m_shape_changed(true) {}
 
+OPENVINO_SUPPRESS_DEPRECATED_START
 void ov::descriptor::Tensor::set_tensor_type(const element::Type& element_type, const PartialShape& pshape) {
     set_element_type(element_type);
     set_partial_shape(pshape);
@@ -36,6 +37,7 @@ void ov::descriptor::Tensor::set_partial_shape(const PartialShape& partial_shape
     m_partial_shape = partial_shape;
     m_shape_changed = true;
 }
+OPENVINO_SUPPRESS_DEPRECATED_END
 
 void ov::descriptor::Tensor::invalidate_values() {
     m_upper_value = nullptr;

--- a/ngraph/core/src/node.cpp
+++ b/ngraph/core/src/node.cpp
@@ -222,7 +222,9 @@ void ov::Node::set_input_is_relevant_to_value(size_t i, bool relevant) {
 }
 
 void ov::Node::set_output_type(size_t i, const element::Type& element_type, const PartialShape& pshape) {
+    OPENVINO_SUPPRESS_DEPRECATED_START
     get_output_descriptor(i).get_tensor_ptr()->set_tensor_type(element_type, pshape);
+    OPENVINO_SUPPRESS_DEPRECATED_END
 }
 
 std::string ov::Node::description() const {

--- a/ngraph/core/src/runtime/host_tensor.cpp
+++ b/ngraph/core/src/runtime/host_tensor.cpp
@@ -130,9 +130,11 @@ bool runtime::HostTensor::get_is_allocated() const {
 }
 
 void runtime::HostTensor::set_element_type(const element::Type& element_type) {
+    OPENVINO_SUPPRESS_DEPRECATED_START
     NGRAPH_CHECK(get_element_type().is_dynamic() || get_element_type() == element_type,
                  "Can not change a static element type");
     m_descriptor->set_element_type(element_type);
+    OPENVINO_SUPPRESS_DEPRECATED_END
 }
 
 void runtime::HostTensor::set_shape(const Shape& shape) {
@@ -141,7 +143,9 @@ void runtime::HostTensor::set_shape(const Shape& shape) {
                  shape,
                  " must be compatible with the partial shape: ",
                  get_partial_shape());
+    OPENVINO_SUPPRESS_DEPRECATED_START
     m_descriptor->set_partial_shape(shape);
+    OPENVINO_SUPPRESS_DEPRECATED_END
 }
 
 void runtime::HostTensor::set_unary(const HostTensorPtr& arg) {


### PR DESCRIPTION
### Details:
 - Deprecated set_* method from `description::Tensor`

### Tickets:
 - 70361
 - 70301