### PR TITLE
[CPU] Reference node forced to perform shape inference for each infer request

### DIFF
--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reference_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reference_node.cpp
@@ -105,3 +105,7 @@ void MKLDNNReferenceNode::executeDynamicImpl(mkldnn::stream strm) {
 bool MKLDNNReferenceNode::created() const {
     return getType() == Reference;
 }
+
+bool MKLDNNReferenceNode::needShapeInfer() const {
+    return true;
+}

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reference_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_reference_node.h
@@ -19,6 +19,7 @@ public:
     bool created() const override;
 
     std::vector<VectorDims> shapeInfer() const override;
+    bool needShapeInfer() const override;
     bool needPrepareParams() const override { return false; }
     void executeDynamicImpl(mkldnn::stream strm) override;
 


### PR DESCRIPTION
### Details:
Shape inference is now called each infer request for MKLDNNReference regardless of whether the input shape was changed or not. It is important for operations which output shape depends not only on the input shapes but also on input parameters values (e.g. broadcast has target shape parameter on its second input).

### Tickets:
 - 70330
