### PR TITLE
Optimize Function Topological Sort

### DIFF
--- a/ngraph/core/include/openvino/core/function.hpp
+++ b/ngraph/core/include/openvino/core/function.hpp
@@ -25,12 +25,7 @@
 #include "openvino/runtime/tensor.hpp"
 
 namespace ov {
-#ifdef NGRAPH_UNIT_TEST_ENABLE
 class FunctionAccessor;
-#    define FUNCTION_TEST_FRIENDS friend class ov::FunctionAccessor
-#else
-#    define FUNCTION_TEST_FRIENDS
-#endif
 /// A user-defined function.
 class OPENVINO_API Function : public std::enable_shared_from_this<Function> {
 public:
@@ -44,7 +39,7 @@ public:
     OPENVINO_DEPRECATED("This member was deprecated. Please use ::get_type_info_static() instead.")
     static const ov::DiscreteTypeInfo type_info;
 
-    FUNCTION_TEST_FRIENDS;
+    friend class ov::FunctionAccessor;
 
     Function(const ov::NodeVector& results, const ov::ParameterVector& parameters, const std::string& name = "");
 

--- a/ngraph/core/include/openvino/core/function.hpp
+++ b/ngraph/core/include/openvino/core/function.hpp
@@ -39,8 +39,6 @@ public:
     OPENVINO_DEPRECATED("This member was deprecated. Please use ::get_type_info_static() instead.")
     static const ov::DiscreteTypeInfo type_info;
 
-    friend class ov::FunctionAccessor;
-
     Function(const ov::NodeVector& results, const ov::ParameterVector& parameters, const std::string& name = "");
 
     Function(const ov::OutputVector& results, const ov::ParameterVector& parameters, const std::string& name = "");
@@ -298,6 +296,8 @@ public:
     Function& operator=(Function&&) = delete;
 
 private:
+    friend class ov::FunctionAccessor;
+
     /// \brief Depending on the options selected,
     /// checks all the Parameter/Variables are registered in the list of Function
     /// parameters/variables or finds all Parameters/Variables in a function and registers them.

--- a/ngraph/core/include/openvino/core/function.hpp
+++ b/ngraph/core/include/openvino/core/function.hpp
@@ -8,6 +8,7 @@
 #include <initializer_list>
 #include <list>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -333,6 +334,8 @@ private:
     // Private runtime info which is shared across nodes and used only
     // for internal purposes.
     std::shared_ptr<SharedRTInfo> m_shared_rt_info;
+
+    mutable std::mutex m_topological_sort_mutex;
 };
 
 OPENVINO_API

--- a/ngraph/core/include/openvino/core/function.hpp
+++ b/ngraph/core/include/openvino/core/function.hpp
@@ -24,12 +24,12 @@
 #include "openvino/runtime/tensor.hpp"
 
 namespace ov {
-//#ifdef ENABLE_TESTS
+#ifdef NGRAPH_UNIT_TEST_ENABLE
 class FunctionAccessor;
-#define FUNCTION_TEST_FRIENDS friend class ov::FunctionAccessor
-//#else
-//#define FUNCTION_TEST_FRIENDS
-//#endif
+#    define FUNCTION_TEST_FRIENDS friend class ov::FunctionAccessor
+#else
+#    define FUNCTION_TEST_FRIENDS
+#endif
 /// A user-defined function.
 class OPENVINO_API Function : public std::enable_shared_from_this<Function> {
 public:

--- a/ngraph/core/include/openvino/core/node.hpp
+++ b/ngraph/core/include/openvino/core/node.hpp
@@ -104,6 +104,9 @@ std::string node_validation_failure_loc_string(const Node* node);
     case element::Type_t::a: \
         rc = evaluate<element::Type_t::a>
 
+class NodeAccessor;
+#define NODE_TEST_FRIENDS friend class ov::NodeAccessor
+
 /// Nodes are the backbone of the graph of Value dataflow. Every node has
 /// zero or more nodes as arguments and one value, which is either a tensor
 /// or a (possibly empty) tuple of values.
@@ -120,6 +123,8 @@ class OPENVINO_API Node : public std::enable_shared_from_this<Node> {
     friend class Output;
 
     friend class Function;
+
+    NODE_TEST_FRIENDS;
 
 protected:
     descriptor::Input& get_input_descriptor(size_t position);

--- a/ngraph/core/include/openvino/core/node.hpp
+++ b/ngraph/core/include/openvino/core/node.hpp
@@ -104,12 +104,7 @@ std::string node_validation_failure_loc_string(const Node* node);
     case element::Type_t::a: \
         rc = evaluate<element::Type_t::a>
 
-#ifdef NGRAPH_UNIT_TEST_ENABLE
 class NodeAccessor;
-#    define NODE_TEST_FRIENDS friend class ov::NodeAccessor
-#else
-#    define NODE_TEST_FRIENDS
-#endif
 
 /// Nodes are the backbone of the graph of Value dataflow. Every node has
 /// zero or more nodes as arguments and one value, which is either a tensor
@@ -128,7 +123,7 @@ class OPENVINO_API Node : public std::enable_shared_from_this<Node> {
 
     friend class Function;
 
-    NODE_TEST_FRIENDS;
+    friend class ov::NodeAccessor;
 
 protected:
     descriptor::Input& get_input_descriptor(size_t position);

--- a/ngraph/core/include/openvino/core/node.hpp
+++ b/ngraph/core/include/openvino/core/node.hpp
@@ -123,8 +123,6 @@ class OPENVINO_API Node : public std::enable_shared_from_this<Node> {
 
     friend class Function;
 
-    friend class ov::NodeAccessor;
-
 protected:
     descriptor::Input& get_input_descriptor(size_t position);
     descriptor::Output& get_output_descriptor(size_t position);
@@ -485,6 +483,7 @@ public:
     virtual bool match_node(ov::pass::pattern::Matcher* matcher, const Output<Node>& graph_value);
 
 private:
+    friend class ov::NodeAccessor;
     std::vector<Node*> m_control_dependents;
     std::vector<std::shared_ptr<Node>> m_control_dependencies;
     size_t m_instance_id{m_next_instance_id.fetch_add(1)};

--- a/ngraph/core/include/openvino/core/node.hpp
+++ b/ngraph/core/include/openvino/core/node.hpp
@@ -71,6 +71,10 @@ class Output;
 
 class Node;
 
+class Function;
+
+class SharedRTInfo;
+
 /// EvaluationContext stores and manages a context (additional parameters, values and
 /// environment) for evaluating ov::Function.
 using EvaluationContext = std::map<std::string, std::shared_ptr<Variant>>;
@@ -115,18 +119,20 @@ class OPENVINO_API Node : public std::enable_shared_from_this<Node> {
     template <typename NodeType>
     friend class Output;
 
+    friend class Function;
+
 protected:
     descriptor::Input& get_input_descriptor(size_t position);
     descriptor::Output& get_output_descriptor(size_t position);
 
-    /// \brief Construct an unitialized Node
+    /// \brief Construct an uninitialized Node
     Node() = default;
     /// \brief Copying a node
     Node(const Node&);
     /// \brief Assignment operator
     Node& operator=(const Node&);
 
-    /// \brief Construct an unitialized Node
+    /// \brief Construct an uninitialized Node
     /// \param output_size Number of outputs for this node
     Node(size_t output_size);
 
@@ -383,9 +389,6 @@ public:
     OPENVINO_DEPRECATED("The tensor name was deprecated. Use get_input_tensor(i).get_names() instead.")
     const std::string& get_input_tensor_name(size_t i) const;
 
-    std::unordered_set<descriptor::Tensor*> liveness_new_list;
-    std::unordered_set<descriptor::Tensor*> liveness_free_list;
-
     Node* get_input_node_ptr(size_t index) const;
     std::shared_ptr<Node> get_input_node_shared_ptr(size_t index) const;
     Output<Node> get_input_source_output(size_t i) const;
@@ -480,7 +483,6 @@ public:
 private:
     std::vector<Node*> m_control_dependents;
     std::vector<std::shared_ptr<Node>> m_control_dependencies;
-    std::string m_node_type;
     size_t m_instance_id{m_next_instance_id.fetch_add(1)};
     std::string m_friendly_name;
     mutable std::string m_unique_name;
@@ -491,7 +493,13 @@ private:
     OPENVINO_SUPPRESS_DEPRECATED_START
     std::shared_ptr<ngraph::op::util::OpAnnotations> m_op_annotations;
     OPENVINO_SUPPRESS_DEPRECATED_END
-    std::map<std::string, std::shared_ptr<Variant>> m_rt_info;
+    RTMap m_rt_info;
+
+    // The vector of SharedRTInfo attributes associated to Functions
+    // where this node belongs to. SharedRTInfo is private field which
+    // is used for internal purposes. For example: tracking changes
+    // during graph transformations.
+    std::set<std::shared_ptr<SharedRTInfo>> m_shared_rt_info;
 };
 
 using NodeTypeInfo = Node::type_info_t;

--- a/ngraph/core/include/openvino/core/node.hpp
+++ b/ngraph/core/include/openvino/core/node.hpp
@@ -104,8 +104,12 @@ std::string node_validation_failure_loc_string(const Node* node);
     case element::Type_t::a: \
         rc = evaluate<element::Type_t::a>
 
+#ifdef NGRAPH_UNIT_TEST_ENABLE
 class NodeAccessor;
-#define NODE_TEST_FRIENDS friend class ov::NodeAccessor
+#    define NODE_TEST_FRIENDS friend class ov::NodeAccessor
+#else
+#    define NODE_TEST_FRIENDS
+#endif
 
 /// Nodes are the backbone of the graph of Value dataflow. Every node has
 /// zero or more nodes as arguments and one value, which is either a tensor

--- a/ngraph/core/include/openvino/core/node.hpp
+++ b/ngraph/core/include/openvino/core/node.hpp
@@ -503,6 +503,13 @@ private:
     // is used for internal purposes. For example: tracking changes
     // during graph transformations.
     std::set<std::shared_ptr<SharedRTInfo>> m_shared_rt_info;
+
+    // As node can be included into different Functions which
+    // can be executed into multiple threads means that m_shared_rt_info
+    // can be updated simultaneously, so we have to guaranty exclusive
+    // update of this field by having specific method with mutex.
+    void insert_info(std::shared_ptr<SharedRTInfo> info);
+    std::mutex m_insert_mutex;
 };
 
 using NodeTypeInfo = Node::type_info_t;

--- a/ngraph/core/src/descriptor/input.cpp
+++ b/ngraph/core/src/descriptor/input.cpp
@@ -50,7 +50,7 @@ void ov::descriptor::Input::replace_output(Output& new_output) {
     // so we have to reset cache by setting a flag into shared node info.
     for_each(m_node->m_shared_rt_info.cbegin(),
              m_node->m_shared_rt_info.cend(),
-             [](std::shared_ptr<SharedRTInfo> info) {
+             [](const std::shared_ptr<SharedRTInfo>& info) {
                  info->set_use_topological_cache(false);
              });
 }

--- a/ngraph/core/src/descriptor/input.cpp
+++ b/ngraph/core/src/descriptor/input.cpp
@@ -4,6 +4,7 @@
 
 #include "openvino/core/descriptor/input.hpp"
 
+#include "shared_node_info.hpp"
 #include "ngraph/env_util.hpp"
 #include "openvino/core/descriptor/output.hpp"
 #include "openvino/core/node.hpp"
@@ -44,6 +45,12 @@ void ov::descriptor::Input::replace_output(Output& new_output) {
         // if a new input violates one of the type checks in the c-tor.
         m_node->clone_with_new_inputs(m_node->input_values());
     }
+
+    // Output replacement may change the topological order of nodes,
+    // so we have to reset cache by setting a flag into shared node info.
+    for_each(m_node->m_shared_rt_info.cbegin(), m_node->m_shared_rt_info.cend(), [](std::shared_ptr<SharedRTInfo> info) {
+        info->set_use_topological_cache(false);
+    });
 }
 
 void ov::descriptor::Input::replace_output(const std::shared_ptr<ov::Node>& node, size_t i) {

--- a/ngraph/core/src/descriptor/input.cpp
+++ b/ngraph/core/src/descriptor/input.cpp
@@ -4,11 +4,11 @@
 
 #include "openvino/core/descriptor/input.hpp"
 
-#include "shared_node_info.hpp"
 #include "ngraph/env_util.hpp"
 #include "openvino/core/descriptor/output.hpp"
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "shared_node_info.hpp"
 
 ov::descriptor::Input::Input(ov::Node* node, size_t index, Output& output)
     : m_node(node),
@@ -48,9 +48,11 @@ void ov::descriptor::Input::replace_output(Output& new_output) {
 
     // Output replacement may change the topological order of nodes,
     // so we have to reset cache by setting a flag into shared node info.
-    for_each(m_node->m_shared_rt_info.cbegin(), m_node->m_shared_rt_info.cend(), [](std::shared_ptr<SharedRTInfo> info) {
-        info->set_use_topological_cache(false);
-    });
+    for_each(m_node->m_shared_rt_info.cbegin(),
+             m_node->m_shared_rt_info.cend(),
+             [](std::shared_ptr<SharedRTInfo> info) {
+                 info->set_use_topological_cache(false);
+             });
 }
 
 void ov::descriptor::Input::replace_output(const std::shared_ptr<ov::Node>& node, size_t i) {

--- a/ngraph/core/src/function.cpp
+++ b/ngraph/core/src/function.cpp
@@ -204,11 +204,6 @@ void ov::Function::prerequirements(bool detect_variables, bool detect_parameters
         m_variables = auto_detect_variables(ordered_ops);
     else
         check_all_variables_registered(ordered_ops, m_variables);
-
-    // Initialize shared rt info for all nodes related to Function
-    for_each(ordered_ops.cbegin(), ordered_ops.cend(), [this](const std::shared_ptr<ov::Node>& node) {
-        node->m_shared_rt_info.insert(m_shared_rt_info);
-    });
 }
 
 void ov::Function::validate_nodes_and_infer_types() const {
@@ -291,7 +286,7 @@ std::vector<shared_ptr<ov::Node>> ov::Function::get_ordered_ops() const {
     m_cached_ordered_ops.clear();
     for_each(order.cbegin(), order.cend(), [this](const shared_ptr<Node>& node) {
         m_cached_ordered_ops.push_back(node);
-        node->m_shared_rt_info.insert(m_shared_rt_info);
+        node->insert_info(m_shared_rt_info);
     });
     m_shared_rt_info->set_use_topological_cache(true);
 

--- a/ngraph/core/src/function.cpp
+++ b/ngraph/core/src/function.cpp
@@ -266,8 +266,8 @@ std::vector<shared_ptr<ov::Node>> ov::Function::get_ordered_ops() const {
     NodeVector nodes;
     if (m_shared_rt_info->get_use_topological_cache()) {
         for (const auto& node : m_cached_ordered_ops) {
-            if (node.lock()) {
-                nodes.emplace_back(node);
+            if (auto locked_node = node.lock()) {
+                nodes.emplace_back(locked_node);
             }
         }
         return nodes;

--- a/ngraph/core/src/function.cpp
+++ b/ngraph/core/src/function.cpp
@@ -262,7 +262,7 @@ void ov::Function::validate_nodes_and_infer_types() const {
 
 std::vector<shared_ptr<ov::Node>> ov::Function::get_ordered_ops() const {
     OV_ITT_SCOPED_TASK(ov::itt::domains::nGraph, "Function::get_ordered_ops");
-    const lock_guard<mutex> lock(m_topological_sort_mutex);
+    lock_guard<mutex> lock(m_topological_sort_mutex);
 
     NodeVector nodes;
     if (m_shared_rt_info->get_use_topological_cache()) {

--- a/ngraph/core/src/function.cpp
+++ b/ngraph/core/src/function.cpp
@@ -206,7 +206,7 @@ void ov::Function::prerequirements(bool detect_variables, bool detect_parameters
         check_all_variables_registered(ordered_ops, m_variables);
 
     // Initialize shared rt info for all nodes related to Function
-    for_each(ordered_ops.cbegin(), ordered_ops.cend(), [this](std::shared_ptr<ov::Node> node) {
+    for_each(ordered_ops.cbegin(), ordered_ops.cend(), [this](const std::shared_ptr<ov::Node>& node) {
         node->m_shared_rt_info.insert(m_shared_rt_info);
     });
 }
@@ -290,7 +290,7 @@ std::vector<shared_ptr<ov::Node>> ov::Function::get_ordered_ops() const {
     // Update nodes cache and update all nodes to have shared rt info
     // which belongs to the current Function.
     m_cached_ordered_ops.clear();
-    for_each(order.cbegin(), order.cend(), [this](shared_ptr<Node> node) {
+    for_each(order.cbegin(), order.cend(), [this](const shared_ptr<Node>& node) {
         m_cached_ordered_ops.push_back(node);
         node->m_shared_rt_info.insert(m_shared_rt_info);
     });

--- a/ngraph/core/src/function.cpp
+++ b/ngraph/core/src/function.cpp
@@ -285,8 +285,7 @@ std::vector<shared_ptr<ov::Node>> ov::Function::get_ordered_ops() const {
 
     auto order = m_topological_sorter(nodes);
 
-    static mutex cache_mutex;
-    const lock_guard<mutex> lock(cache_mutex);
+    const lock_guard<mutex> lock(m_topological_sort_mutex);
 
     // Update nodes cache and update all nodes to have shared rt info
     // which belongs to the current Function.

--- a/ngraph/core/src/function.cpp
+++ b/ngraph/core/src/function.cpp
@@ -11,7 +11,6 @@
 #include <unordered_map>
 
 #include "itt.hpp"
-#include "shared_node_info.hpp"
 #include "ngraph/evaluator.hpp"
 #include "ngraph/graph_util.hpp"
 #include "ngraph/log.hpp"
@@ -26,6 +25,7 @@
 #include "openvino/op/util/variable_context.hpp"
 #include "openvino/op/util/variable_extension.hpp"
 #include "openvino/pass/manager.hpp"
+#include "shared_node_info.hpp"
 #include "transformations/smart_reshape/smart_reshape.hpp"
 
 using namespace std;
@@ -265,12 +265,11 @@ std::vector<shared_ptr<ov::Node>> ov::Function::get_ordered_ops() const {
 
     NodeVector nodes;
     if (m_shared_rt_info->get_use_topological_cache()) {
-        for (const auto & node : m_cached_ordered_ops)  {
+        for (const auto& node : m_cached_ordered_ops) {
             if (node.lock()) {
                 nodes.emplace_back(node);
             }
         }
-        std::cout << "cache is used" << std::endl;
         return nodes;
     }
 
@@ -284,7 +283,6 @@ std::vector<shared_ptr<ov::Node>> ov::Function::get_ordered_ops() const {
         nodes.push_back(param);
     }
 
-    std::cout << "cache miss" << std::endl;
     auto order = m_topological_sorter(nodes);
 
     static mutex cache_mutex;

--- a/ngraph/core/src/function.cpp
+++ b/ngraph/core/src/function.cpp
@@ -262,6 +262,7 @@ void ov::Function::validate_nodes_and_infer_types() const {
 
 std::vector<shared_ptr<ov::Node>> ov::Function::get_ordered_ops() const {
     OV_ITT_SCOPED_TASK(ov::itt::domains::nGraph, "Function::get_ordered_ops");
+    const lock_guard<mutex> lock(m_topological_sort_mutex);
 
     NodeVector nodes;
     if (m_shared_rt_info->get_use_topological_cache()) {
@@ -284,8 +285,6 @@ std::vector<shared_ptr<ov::Node>> ov::Function::get_ordered_ops() const {
     }
 
     auto order = m_topological_sorter(nodes);
-
-    const lock_guard<mutex> lock(m_topological_sort_mutex);
 
     // Update nodes cache and update all nodes to have shared rt info
     // which belongs to the current Function.

--- a/ngraph/core/src/node.cpp
+++ b/ngraph/core/src/node.cpp
@@ -51,13 +51,17 @@ ov::Node& ov::Node::operator=(const Node& node) {
     this->m_inputs = node.m_inputs;
     this->m_op_annotations = node.m_op_annotations;
     this->m_rt_info = node.m_rt_info;
-    this->m_shared_rt_info = node.m_shared_rt_info;
     // cannot do it without copying node.m_inputs first due to too limiting const qualifiers
     for (auto& input : m_inputs) {
         input = descriptor::Input(this, input.get_index(), input.get_output());
         input.get_output().add_input(&input);
     }
     return *this;
+}
+
+void ov::Node::insert_info(std::shared_ptr<SharedRTInfo> info) {
+    std::lock_guard<std::mutex> lock(m_insert_mutex);
+    m_shared_rt_info.insert(std::move(info));
 }
 
 ov::Node::Node(size_t output_size) : Node() {

--- a/ngraph/core/src/node.cpp
+++ b/ngraph/core/src/node.cpp
@@ -35,8 +35,7 @@ ov::Node::Node(const Node& node)
       // skip m_outputs -- should be initialized outside
       ,
       m_op_annotations(node.m_op_annotations),
-      m_rt_info(node.m_rt_info),
-      m_shared_rt_info(node.m_shared_rt_info) {
+      m_rt_info(node.m_rt_info) {
     // cannot do it without copying node.m_inputs first due to too limiting const qualifiers
     for (auto& input : m_inputs) {
         input = descriptor::Input(this, input.get_index(), input.get_output());

--- a/ngraph/core/src/node.cpp
+++ b/ngraph/core/src/node.cpp
@@ -169,7 +169,7 @@ void ov::Node::set_arguments(const OutputVector& arguments) {
         m_inputs.emplace_back(this, i++, output_descriptor);
     }
 
-    // set_arguments doesn't use replace_output method so we have to
+    // set_arguments doesn't use replace_output method, so we have to reset cache manually here
     for_each(this->m_shared_rt_info.cbegin(), this->m_shared_rt_info.cend(), [](std::shared_ptr<SharedRTInfo> info) {
         info->set_use_topological_cache(false);
     });

--- a/ngraph/core/src/node.cpp
+++ b/ngraph/core/src/node.cpp
@@ -72,7 +72,7 @@ ov::Node::Node(const OutputVector& arguments, size_t output_size) : Node() {
 
 ov::Node::~Node() {
     // raise a flag to reset nodes cache
-    for_each(m_shared_rt_info.cbegin(), m_shared_rt_info.cend(), [](std::shared_ptr<SharedRTInfo> info) {
+    for_each(m_shared_rt_info.cbegin(), m_shared_rt_info.cend(), [](const std::shared_ptr<SharedRTInfo>& info) {
         info->set_use_topological_cache(false);
     });
 

--- a/ngraph/core/src/shared_node_info.hpp
+++ b/ngraph/core/src/shared_node_info.hpp
@@ -5,9 +5,8 @@
 #pragma once
 
 #include <memory>
-
-#include <openvino/core/node.hpp>
 #include <openvino/core/except.hpp>
+#include <openvino/core/node.hpp>
 #include <openvino/core/variant.hpp>
 
 namespace ov {
@@ -17,7 +16,7 @@ public:
         set_use_topological_cache(false);
     }
 
-    const RTMap & get_rt_info() const {
+    const RTMap& get_rt_info() const {
         return m_rt_info;
     }
 
@@ -26,12 +25,12 @@ public:
     }
 
     void set_use_topological_cache(bool status) {
-        auto & info = get_rt_info();
+        auto& info = get_rt_info();
         info["use_topological_cache"] = std::make_shared<VariantWrapper<int64_t>>(status);
     }
 
     bool get_use_topological_cache() const {
-        const auto & info = get_rt_info();
+        const auto& info = get_rt_info();
         if (info.count("use_topological_cache") == 0) {
             throw Exception("use_topological_cache is not set");
         }

--- a/ngraph/core/src/shared_node_info.hpp
+++ b/ngraph/core/src/shared_node_info.hpp
@@ -12,32 +12,17 @@
 namespace ov {
 class SharedRTInfo {
 public:
-    SharedRTInfo() {
-        set_use_topological_cache(false);
-    }
-
-    const RTMap& get_rt_info() const {
-        return m_rt_info;
-    }
-
-    RTMap& get_rt_info() {
-        return m_rt_info;
-    }
+    SharedRTInfo() : m_use_topological_cache(false) {}
 
     void set_use_topological_cache(bool status) {
-        auto& info = get_rt_info();
-        info["use_topological_cache"] = std::make_shared<VariantWrapper<int64_t>>(status);
+        m_use_topological_cache = status;
     }
 
     bool get_use_topological_cache() const {
-        const auto& info = get_rt_info();
-        if (info.count("use_topological_cache") == 0) {
-            throw Exception("use_topological_cache is not set");
-        }
-        return std::dynamic_pointer_cast<VariantWrapper<int64_t>>(info.at("use_topological_cache"))->get();
+        return m_use_topological_cache;
     }
 
 private:
-    RTMap m_rt_info;
+    bool m_use_topological_cache;
 };
 }  // namespace ov

--- a/ngraph/core/src/shared_node_info.hpp
+++ b/ngraph/core/src/shared_node_info.hpp
@@ -1,0 +1,44 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+
+#include <openvino/core/node.hpp>
+#include <openvino/core/except.hpp>
+#include <openvino/core/variant.hpp>
+
+namespace ov {
+class SharedRTInfo {
+public:
+    SharedRTInfo() {
+        set_use_topological_cache(false);
+    }
+
+    const RTMap & get_rt_info() const {
+        return m_rt_info;
+    }
+
+    RTMap& get_rt_info() {
+        return m_rt_info;
+    }
+
+    void set_use_topological_cache(bool status) {
+        auto & info = get_rt_info();
+        info["use_topological_cache"] = std::make_shared<VariantWrapper<int64_t>>(status);
+    }
+
+    bool get_use_topological_cache() const {
+        const auto & info = get_rt_info();
+        if (info.count("use_topological_cache") == 0) {
+            throw Exception("use_topological_cache is not set");
+        }
+        return std::dynamic_pointer_cast<VariantWrapper<int64_t>>(info.at("use_topological_cache"))->get();
+    }
+
+private:
+    RTMap m_rt_info;
+};
+}  // namespace ov

--- a/ngraph/test/function.cpp
+++ b/ngraph/test/function.cpp
@@ -971,7 +971,7 @@ TEST(function, add_output_port_to_result) {
 }
 
 namespace {
-bool all_ops_have_same_info(std::shared_ptr<ov::Function> f) {
+bool all_ops_have_same_info(const std::shared_ptr<ov::Function>& f) {
     auto shared_info = ov::FunctionAccessor(f).get_shared_info();
     for (auto&& op : f->get_ordered_ops()) {
         if (std::set<std::shared_ptr<ov::SharedRTInfo>>({shared_info}) != ov::NodeAccessor(op).get_shared_info()) {

--- a/ngraph/test/function.cpp
+++ b/ngraph/test/function.cpp
@@ -6,6 +6,9 @@
 
 #include <gtest/gtest.h>
 
+#include <shared_node_info.hpp>
+#include <test_common.hpp>
+
 #include "openvino/core/partial_shape.hpp"
 #include "openvino/opsets/opset8.hpp"
 
@@ -967,12 +970,261 @@ TEST(function, add_output_port_to_result) {
     EXPECT_EQ(f->get_results().size(), 1);
 }
 
+namespace {
+bool all_ops_have_same_info(std::shared_ptr<ov::Function> f) {
+    auto shared_info = ov::FunctionAccessor(f).get_shared_info();
+    for (auto&& op : f->get_ordered_ops()) {
+        if (std::set<std::shared_ptr<ov::SharedRTInfo>>({shared_info}) != ov::NodeAccessor(op).get_shared_info()) {
+            return false;
+        }
+    }
+    return true;
+}
+}  // namespace
 
-// TODO: add tests to check that topological sort is correct
-// ReplaceNode, replace_source_output, output.replace, set_argument/arguments
-// Add CF
-// Add/Remove - Parameter/Result/Sink
-// Test multiple components
-// Test shared nodes between Functions
-// + topological sorter change
-// Negative: add consumer,
+TEST(function, topological_sort_caching_basic) {
+    auto arg0 = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::PartialShape{1});
+    auto relu1 = std::make_shared<ov::opset8::Relu>(arg0);
+    auto relu2 = std::make_shared<ov::opset8::Relu>(relu1);
+    auto result = std::make_shared<ov::opset8::Result>(relu2);
+    auto f = std::make_shared<ov::Function>(ov::ResultVector{result}, ov::ParameterVector{arg0});
+
+    auto shared_info = ov::FunctionAccessor(f).get_shared_info();
+    // Check that after function creation which call get_ordered_ops
+    // cache is set to true value
+    ASSERT_TRUE(shared_info->get_use_topological_cache());
+
+    // Check that nodes contains the same shared info after function creation
+    ASSERT_EQ(ov::NodeAccessor(arg0).get_shared_info().size(), 1);
+    ASSERT_TRUE(ov::NodeAccessor(arg0).get_shared_info().count(shared_info));
+
+    ASSERT_EQ(ov::NodeAccessor(relu1).get_shared_info().size(), 1);
+    ASSERT_TRUE(ov::NodeAccessor(relu1).get_shared_info().count(shared_info));
+
+    ASSERT_EQ(ov::NodeAccessor(relu2).get_shared_info().size(), 1);
+    ASSERT_TRUE(ov::NodeAccessor(relu2).get_shared_info().count(shared_info));
+
+    ASSERT_EQ(ov::NodeAccessor(result).get_shared_info().size(), 1);
+    ASSERT_TRUE(ov::NodeAccessor(result).get_shared_info().count(shared_info));
+
+    ASSERT_EQ(f->get_ordered_ops().size(), 4);
+}
+
+TEST(function, topological_sort_caching_replace_node) {
+    auto arg0 = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::PartialShape{1});
+    auto relu1 = std::make_shared<ov::opset8::Relu>(arg0);
+    auto relu2 = std::make_shared<ov::opset8::Relu>(relu1);
+    auto result = std::make_shared<ov::opset8::Result>(relu2);
+    auto f = std::make_shared<ov::Function>(ov::ResultVector{result}, ov::ParameterVector{arg0});
+
+    auto shared_info = ov::FunctionAccessor(f).get_shared_info();
+    ASSERT_TRUE(shared_info->get_use_topological_cache());
+
+    auto new_relu = std::make_shared<ov::opset8::Relu>(relu1);
+    ov::replace_node(relu2, new_relu);
+
+    // Function has changed so cache must be updated
+    ASSERT_FALSE(shared_info->get_use_topological_cache());
+
+    // Before get_ordered_ops, new_node shouldn't have shared_info, but after
+    // it will be set to the function shared_info and cache will be used.
+    ASSERT_FALSE(ov::NodeAccessor(new_relu).get_shared_info().count(shared_info));
+    ASSERT_EQ(f->get_ordered_ops().size(), 4);
+    ASSERT_TRUE(ov::NodeAccessor(new_relu).get_shared_info().count(shared_info));
+    ASSERT_TRUE(shared_info->get_use_topological_cache());
+    ASSERT_TRUE(all_ops_have_same_info(f));
+}
+
+TEST(function, topological_sort_caching_replace_source_output) {
+    auto arg0 = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::PartialShape{1});
+    auto relu1 = std::make_shared<ov::opset8::Relu>(arg0);
+    auto relu2 = std::make_shared<ov::opset8::Relu>(relu1);
+    auto result = std::make_shared<ov::opset8::Result>(relu2);
+    auto f = std::make_shared<ov::Function>(ov::ResultVector{result}, ov::ParameterVector{arg0});
+
+    auto shared_info = ov::FunctionAccessor(f).get_shared_info();
+    ASSERT_TRUE(shared_info->get_use_topological_cache());
+
+    relu2->input(0).replace_source_output(relu1);
+
+    // Function has changed so cache must be updated
+    ASSERT_FALSE(shared_info->get_use_topological_cache());
+
+    ASSERT_EQ(f->get_ordered_ops().size(), 4);
+    ASSERT_TRUE(shared_info->get_use_topological_cache());
+    ASSERT_TRUE(all_ops_have_same_info(f));
+}
+
+TEST(function, topological_sort_caching_dangling_node) {
+    auto arg0 = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::PartialShape{1});
+    auto relu1 = std::make_shared<ov::opset8::Relu>(arg0);
+    auto relu2 = std::make_shared<ov::opset8::Relu>(relu1);
+    auto result = std::make_shared<ov::opset8::Result>(relu2);
+    auto f = std::make_shared<ov::Function>(ov::ResultVector{result}, ov::ParameterVector{arg0});
+
+    auto shared_info = ov::FunctionAccessor(f).get_shared_info();
+    ASSERT_TRUE(shared_info->get_use_topological_cache());
+
+    auto new_relu = std::make_shared<ov::opset8::Relu>(relu1);
+
+    // Function has not changed so cache mustn't be updated
+    ASSERT_TRUE(shared_info->get_use_topological_cache());
+    // Dangling node is not in Function
+    ASSERT_EQ(f->get_ordered_ops().size(), 4);
+}
+
+TEST(function, topological_sort_caching_replace_output) {
+    auto arg0 = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::PartialShape{1});
+    auto relu1 = std::make_shared<ov::opset8::Relu>(arg0);
+    auto relu2 = std::make_shared<ov::opset8::Relu>(relu1);
+    auto result = std::make_shared<ov::opset8::Result>(relu2);
+    auto f = std::make_shared<ov::Function>(ov::ResultVector{result}, ov::ParameterVector{arg0});
+
+    auto shared_info = ov::FunctionAccessor(f).get_shared_info();
+    ASSERT_TRUE(shared_info->get_use_topological_cache());
+
+    auto new_relu = std::make_shared<ov::opset8::Relu>(relu1);
+    relu2->output(0).replace(new_relu);
+
+    // Function has changed so cache must be updated
+    ASSERT_FALSE(shared_info->get_use_topological_cache());
+    ASSERT_EQ(f->get_ordered_ops().size(), 4);
+    ASSERT_TRUE(shared_info->get_use_topological_cache());
+    ASSERT_TRUE(all_ops_have_same_info(f));
+}
+
+TEST(function, topological_sort_caching_set_argument) {
+    auto arg0 = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::PartialShape{1});
+    auto relu1 = std::make_shared<ov::opset8::Relu>(arg0);
+    auto relu2 = std::make_shared<ov::opset8::Relu>(relu1);
+    auto result = std::make_shared<ov::opset8::Result>(relu2);
+    auto f = std::make_shared<ov::Function>(ov::ResultVector{result}, ov::ParameterVector{arg0});
+
+    auto shared_info = ov::FunctionAccessor(f).get_shared_info();
+    ASSERT_TRUE(shared_info->get_use_topological_cache());
+
+    relu2->set_argument(0, arg0);
+
+    // Function has changed so cache must be updated
+    ASSERT_FALSE(shared_info->get_use_topological_cache());
+    ASSERT_EQ(f->get_ordered_ops().size(), 3);
+    ASSERT_TRUE(shared_info->get_use_topological_cache());
+    ASSERT_TRUE(all_ops_have_same_info(f));
+}
+
+TEST(function, topological_sort_caching_set_arguments) {
+    auto arg0 = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::PartialShape{1});
+    auto relu1 = std::make_shared<ov::opset8::Relu>(arg0);
+    auto relu2 = std::make_shared<ov::opset8::Relu>(relu1);
+    auto result = std::make_shared<ov::opset8::Result>(relu2);
+    auto f = std::make_shared<ov::Function>(ov::ResultVector{result}, ov::ParameterVector{arg0});
+
+    auto shared_info = ov::FunctionAccessor(f).get_shared_info();
+    ASSERT_TRUE(shared_info->get_use_topological_cache());
+
+    relu2->set_arguments({arg0->output(0)});
+
+    // Function has changed so cache must be updated
+    ASSERT_FALSE(shared_info->get_use_topological_cache());
+    ASSERT_EQ(f->get_ordered_ops().size(), 3);
+    ASSERT_TRUE(shared_info->get_use_topological_cache());
+    ASSERT_TRUE(all_ops_have_same_info(f));
+}
+
+TEST(function, topological_sort_caching_add_cf) {
+    auto arg0 = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::PartialShape{1});
+    auto relu1 = std::make_shared<ov::opset8::Relu>(arg0);
+    auto relu2 = std::make_shared<ov::opset8::Relu>(relu1);
+    auto result = std::make_shared<ov::opset8::Result>(relu2);
+    auto f = std::make_shared<ov::Function>(ov::ResultVector{result}, ov::ParameterVector{arg0});
+
+    auto shared_info = ov::FunctionAccessor(f).get_shared_info();
+    ASSERT_TRUE(shared_info->get_use_topological_cache());
+
+    relu2->add_control_dependency(arg0);
+
+    // Function has changed so cache must be updated
+    ASSERT_FALSE(shared_info->get_use_topological_cache());
+    ASSERT_EQ(f->get_ordered_ops().size(), 4);
+    ASSERT_TRUE(shared_info->get_use_topological_cache());
+    ASSERT_TRUE(all_ops_have_same_info(f));
+}
+
+TEST(function, topological_sort_caching_result_parameter_sink) {
+    auto arg0 = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::PartialShape{1});
+    auto relu1 = std::make_shared<ov::opset8::Relu>(arg0);
+    auto relu2 = std::make_shared<ov::opset8::Relu>(relu1);
+    auto result = std::make_shared<ov::opset8::Result>(relu2);
+    auto f = std::make_shared<ov::Function>(ov::ResultVector{result}, ov::ParameterVector{arg0});
+
+    auto shared_info = ov::FunctionAccessor(f).get_shared_info();
+    ASSERT_TRUE(shared_info->get_use_topological_cache());
+
+    auto check_caching_status = [=](int64_t expected_number_of_ops) {
+        ASSERT_FALSE(shared_info->get_use_topological_cache());
+        ASSERT_EQ(f->get_ordered_ops().size(), expected_number_of_ops);
+        ASSERT_TRUE(shared_info->get_use_topological_cache());
+        ASSERT_TRUE(all_ops_have_same_info(f));
+    };
+
+    auto result2 = std::make_shared<ov::opset8::Result>(relu2);
+    f->add_results({result2});
+    check_caching_status(5);
+
+    f->remove_result(result2);
+    check_caching_status(4);
+
+    auto arg1 = std::make_shared<ov::opset8::Parameter>();
+    f->add_parameters({arg1});
+    check_caching_status(5);
+
+    f->remove_parameter(arg1);
+    check_caching_status(4);
+
+    auto assign = std::make_shared<ov::opset8::Assign>();
+    f->add_sinks({assign});
+    check_caching_status(5);
+
+    f->remove_sink(assign);
+    check_caching_status(4);
+}
+
+TEST(function, topological_sort_caching_multiple_components) {
+    auto arg0 = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::PartialShape{1});
+    auto relu0 = std::make_shared<ov::opset8::Relu>(arg0);
+    auto result0 = std::make_shared<ov::opset8::Result>(relu0);
+
+    auto arg1 = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::PartialShape{1});
+    auto relu1 = std::make_shared<ov::opset8::Relu>(arg1);
+    auto result1 = std::make_shared<ov::opset8::Result>(relu1);
+
+    auto f = std::make_shared<ov::Function>(ov::ResultVector{result0, result1}, ov::ParameterVector{arg0, arg1});
+
+    auto shared_info = ov::FunctionAccessor(f).get_shared_info();
+    ASSERT_TRUE(shared_info->get_use_topological_cache());
+    ASSERT_TRUE(all_ops_have_same_info(f));
+}
+
+TEST(function, topological_sort_caching_shared_nodes) {
+    auto arg0 = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::PartialShape{1});
+    auto relu0 = std::make_shared<ov::opset8::Relu>(arg0);
+    auto result0 = std::make_shared<ov::opset8::Result>(relu0);
+
+    auto f1 = std::make_shared<ov::Function>(ov::ResultVector{result0}, ov::ParameterVector{arg0});
+    auto f2 = std::make_shared<ov::Function>(ov::ResultVector{result0}, ov::ParameterVector{arg0});
+
+    auto f1_shared_info = ov::FunctionAccessor(f1).get_shared_info();
+    auto f2_shared_info = ov::FunctionAccessor(f2).get_shared_info();
+
+    for (auto&& node : f1->get_ordered_ops()) {
+        auto node_info = ov::NodeAccessor(node).get_shared_info();
+        // As two Functions owns the same node so node will have two shared_info objects
+        ASSERT_EQ(node_info.size(), 2);
+        ASSERT_TRUE(node_info.count(f1_shared_info));
+        ASSERT_TRUE(node_info.count(f2_shared_info));
+    }
+
+    relu0->add_control_dependency(arg0);  // simply drop cache
+    ASSERT_FALSE(f1_shared_info->get_use_topological_cache());
+    ASSERT_FALSE(f2_shared_info->get_use_topological_cache());
+}

--- a/ngraph/test/function.cpp
+++ b/ngraph/test/function.cpp
@@ -966,3 +966,13 @@ TEST(function, add_output_port_to_result) {
     EXPECT_NO_THROW(f->add_output(result->output(0)));
     EXPECT_EQ(f->get_results().size(), 1);
 }
+
+
+// TODO: add tests to check that topological sort is correct
+// ReplaceNode, replace_source_output, output.replace, set_argument/arguments
+// Add CF
+// Add/Remove - Parameter/Result/Sink
+// Test multiple components
+// Test shared nodes between Functions
+// + topological sorter change
+// Negative: add consumer,

--- a/ngraph/test/util/CMakeLists.txt
+++ b/ngraph/test/util/CMakeLists.txt
@@ -11,7 +11,7 @@ if(COMMAND ie_faster_build)
 endif()
 
 target_link_libraries(ngraph_test_util PUBLIC ngraph gtest gmock)
-target_include_directories(ngraph_test_util PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(ngraph_test_util PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../../core/src/)
 
 file(GLOB_RECURSE all_util_src "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/*.hpp")
 add_clang_format_target(ngraph_test_util_clang FOR_SOURCES ${all_util_src})

--- a/ngraph/test/util/CMakeLists.txt
+++ b/ngraph/test/util/CMakeLists.txt
@@ -10,13 +10,13 @@ if(COMMAND ie_faster_build)
     ie_faster_build(ngraph_test_util UNITY)
 endif()
 
-add_definitions(-DNGRAPH_UNIT_TEST_ENABLE)
-
 target_link_libraries(ngraph_test_util PUBLIC ngraph gtest gmock)
-target_include_directories(ngraph_test_util PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../../core/src/)
+target_include_directories(ngraph_test_util PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 file(GLOB_RECURSE all_util_src "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/*.hpp")
 add_clang_format_target(ngraph_test_util_clang FOR_SOURCES ${all_util_src})
+
+set_source_files_properties(${all_util_src} PROPERTIES INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/../../core/src/)
 
 # developer package
 openvino_developer_export_targets(COMPONENT ngraph TARGETS ngraph_test_util)

--- a/ngraph/test/util/CMakeLists.txt
+++ b/ngraph/test/util/CMakeLists.txt
@@ -10,6 +10,8 @@ if(COMMAND ie_faster_build)
     ie_faster_build(ngraph_test_util UNITY)
 endif()
 
+add_definitions(-DNGRAPH_UNIT_TEST_ENABLE)
+
 target_link_libraries(ngraph_test_util PUBLIC ngraph gtest gmock)
 target_include_directories(ngraph_test_util PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../../core/src/)
 

--- a/ngraph/test/util/test_common.cpp
+++ b/ngraph/test/util/test_common.cpp
@@ -86,4 +86,17 @@ std::string TestsCommon::GetTestName() const {
 }
 
 }  // namespace test
+std::shared_ptr<SharedRTInfo> FunctionAccessor::get_shared_info() const {
+    if (auto f = m_function.lock()) {
+        return f->m_shared_rt_info;
+    }
+    throw ngraph::ngraph_error("Original function is not available");
+}
+
+std::set<std::shared_ptr<SharedRTInfo>> NodeAccessor::get_shared_info() const {
+    if (auto node = m_node.lock()) {
+        return node->m_shared_rt_info;
+    }
+    throw ngraph::ngraph_error("Original node is not available");
+}
 }  // namespace ov

--- a/ngraph/test/util/test_common.hpp
+++ b/ngraph/test/util/test_common.hpp
@@ -5,10 +5,10 @@
 #pragma once
 
 #include <gtest/gtest.h>
-#include <openvino/core/function.hpp>
-#include <shared_node_info.hpp>
 
 #include <memory>
+#include <openvino/core/function.hpp>
+#include <shared_node_info.hpp>
 #include <string>
 #include <utility>
 
@@ -27,12 +27,37 @@ protected:
 }  // namespace test
 
 class FunctionAccessor {
-     std::shared_ptr<Function> m_function;
-public:
-     FunctionAccessor(std::shared_ptr<Function> f) : m_function(std::move(f)) {}
+    std::weak_ptr<Function> m_function;
 
-     bool get_cache_flag() const {
-         return m_function->m_shared_rt_info->get_use_topological_cache();
-     }
+public:
+    FunctionAccessor(std::weak_ptr<Function> f) : m_function(std::move(f)) {}
+
+    bool get_cache_flag() const {
+        if (auto f = m_function.lock()) {
+            return f->m_shared_rt_info->get_use_topological_cache();
+        }
+        throw ngraph::ngraph_error("Original function is not available");
+    }
+
+    std::shared_ptr<SharedRTInfo> get_shared_info() const {
+        if (auto f = m_function.lock()) {
+            return f->m_shared_rt_info;
+        }
+        throw ngraph::ngraph_error("Original function is not available");
+    }
+};
+
+class NodeAccessor {
+    std::weak_ptr<Node> m_node;
+
+public:
+    NodeAccessor(std::weak_ptr<Node> node) : m_node(std::move(node)) {}
+
+    std::set<std::shared_ptr<SharedRTInfo>> get_shared_info() const {
+        if (auto node = m_node.lock()) {
+            return node->m_shared_rt_info;
+        }
+        throw ngraph::ngraph_error("Original node is not available");
+    }
 };
 }  // namespace ov

--- a/ngraph/test/util/test_common.hpp
+++ b/ngraph/test/util/test_common.hpp
@@ -32,19 +32,7 @@ class FunctionAccessor {
 public:
     FunctionAccessor(std::weak_ptr<Function> f) : m_function(std::move(f)) {}
 
-    bool get_cache_flag() const {
-        if (auto f = m_function.lock()) {
-            return f->m_shared_rt_info->get_use_topological_cache();
-        }
-        throw ngraph::ngraph_error("Original function is not available");
-    }
-
-    std::shared_ptr<SharedRTInfo> get_shared_info() const {
-        if (auto f = m_function.lock()) {
-            return f->m_shared_rt_info;
-        }
-        throw ngraph::ngraph_error("Original function is not available");
-    }
+    std::shared_ptr<SharedRTInfo> get_shared_info() const;
 };
 
 class NodeAccessor {
@@ -53,11 +41,6 @@ class NodeAccessor {
 public:
     NodeAccessor(std::weak_ptr<Node> node) : m_node(std::move(node)) {}
 
-    std::set<std::shared_ptr<SharedRTInfo>> get_shared_info() const {
-        if (auto node = m_node.lock()) {
-            return node->m_shared_rt_info;
-        }
-        throw ngraph::ngraph_error("Original node is not available");
-    }
+    std::set<std::shared_ptr<SharedRTInfo>> get_shared_info() const;
 };
 }  // namespace ov

--- a/ngraph/test/util/test_common.hpp
+++ b/ngraph/test/util/test_common.hpp
@@ -5,9 +5,12 @@
 #pragma once
 
 #include <gtest/gtest.h>
+#include <openvino/core/function.hpp>
+#include <shared_node_info.hpp>
 
 #include <memory>
 #include <string>
+#include <utility>
 
 namespace ov {
 namespace test {
@@ -22,4 +25,14 @@ protected:
 };
 
 }  // namespace test
+
+class FunctionAccessor {
+     std::shared_ptr<Function> m_function;
+public:
+     FunctionAccessor(std::shared_ptr<Function> f) : m_function(std::move(f)) {}
+
+     bool get_cache_flag() const {
+         return m_function->m_shared_rt_info->get_use_topological_cache();
+     }
+};
 }  // namespace ov


### PR DESCRIPTION
### Description
get_ordered_ops is a highly used method across transformations pipeline and common infrastructure. Unfortunately the cost of get_ordered_ops call is not zero and for huge models topological sort takes significant time. But we have an opportunity to optimize this by caching an order and change it we change Function. The number of methods that affect resulting topological order is next ->

**Function methods:**
* ov::Function::set_topological_sort
* ov::Function::add_sinks
* ov::Function::remove_sink 
* ov::Function::add_results
* ov::Function::remove_result
* ov::Function::add_parameters
* ov::Function::remove_parameter

**Node methods:**
* ov::Node::add_control_dependency
* ov::Node::set_argument (based on replace_output)
* ov::Node::set_arguments
*  ov::descriptor::Input::replace_output - basic method for all kind of replacements

_Note: all this methods are covered with unit-tests tests which rely on the shared objects cache state which is more robust than just relying on nodes order of complex graphs._

To control changes in Functions we have to keep some shared object inside Nodes which we update if one of this methods above is used. This object is used inside get_ordered_ops to control cache updates. The only tricky thing here is that nodes can belong to multiple Functions so in each Node we store a set of this shared objects.

### Ticket
XXX-44330

### Validation
DL Benchmark validation and official validation show no regressions. See full report in ticket.