### PR TITLE
Check if argv has compress_fp16 attribute

### DIFF
--- a/model-optimizer/mo/main.py
+++ b/model-optimizer/mo/main.py
@@ -365,7 +365,7 @@ def emit_ir(graph: Graph, argv: argparse.Namespace):
                                          "--input_model", orig_model_name,
                                          "--framework", argv.framework,
                                          "--transform", argv.transform]
-                if argv.compress_fp16:
+                if "compress_fp16" in argv and argv.compress_fp16:
                     cmd += ["--compress_fp16"]
                     # restore data_type cmd parameter
                     argv.data_type = 'FP16'


### PR DESCRIPTION
### Details:
 - *Check if namespace argv has the "compress_fp16" attribute before accessing it. Fixes issue added by #7588*

### Tickets:
 - *None*
