### PR TITLE
[GPU] Resolve performance regression by selecting ref kernel

### DIFF
--- a/inference-engine/thirdparty/clDNN/src/layout_optimizer.cpp
+++ b/inference-engine/thirdparty/clDNN/src/layout_optimizer.cpp
@@ -859,10 +859,7 @@ layout layout_optimizer::get_expected_layout(layout const& current_layout,
                 if (input_layout.size.batch[0] % 16 == 0) {
                     expected_format = cldnn::format::bs_fs_yx_bsv32_fsv32;
                 } else {
-                    if (data_type_traits::is_floating_point(output_layout.data_type))
-                        expected_format = cldnn::format::b_fs_yx_fsv16;
-                    else
-                        expected_format = cldnn::format::b_fs_yx_fsv32;
+                    expected_format = cldnn::format::b_fs_yx_fsv32;
                 }
             } else if ((_optimization_attributes.b_fs_yx_fsv16_network &&
                        convolution_b_fs_yx_fsv16_opt(input_layout, output_layout, weights_layout, prim)) && is_2d) {


### PR DESCRIPTION
- Not to select fsv16 for u8 to fp32 conv

Signed-off-by: Min, Byungil <byungil.min@intel.com>

### Details:
 - Modified layout optimizer  not to select fsv16 for conv from u8 to fp32

### Tickets:
 - *ticket-id*
