### PR TITLE
NMS: change back threshold for comparison

### DIFF
--- a/inference-engine/tests/functional/shared_test_classes/src/single_layer/non_max_suppression.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/single_layer/non_max_suppression.cpp
@@ -91,12 +91,12 @@ void NmsLayerTest::CompareBuffer(const std::vector<std::pair<ngraph::element::Ty
                     case ngraph::element::Type_t::f32:
                         LayerTestsUtils::LayerTestsCommon::Compare(
                                 reinterpret_cast<const float *>(expectedBuffer),
-                                reinterpret_cast<const float *>(actualBuffer), size, 0);
+                                reinterpret_cast<const float *>(actualBuffer), size, threshold);
                         break;
                     case ngraph::element::Type_t::f64:
                         LayerTestsUtils::LayerTestsCommon::Compare(
                                 reinterpret_cast<const double *>(expectedBuffer),
-                                reinterpret_cast<const float *>(actualBuffer), size, 0);
+                                reinterpret_cast<const float *>(actualBuffer), size, threshold);
                         break;
                     default:
                         break;


### PR DESCRIPTION
### Details:
 - In the functional tests of `NonMaxsuppression`, the section of `Compare` function for FP32 precision should have a tolerance of `threshold` in stead of zero.
 - Looks like this is accidentally changed by #5624 at [this line](https://github.com/openvinotoolkit/openvino/pull/5624/files#diff-5abce52af648507d0f01b0b16c11ded3e045fce945d64c497c622557e1ef8624L78).
 - This PR change it back to `threshold`.
