### PR TITLE
[TESTS] Disable  ReferencePadTestParamsTooLarge in reference tests

### DIFF
--- a/docs/template_plugin/tests/functional/op_reference/pad.cpp
+++ b/docs/template_plugin/tests/functional/op_reference/pad.cpp
@@ -3,6 +3,7 @@
 //
 
 #include <gtest/gtest.h>
+#include <functional_test_utils/skip_tests_config.hpp>
 
 #include "openvino/op/pad.hpp"
 #include "openvino/op/constant.hpp"
@@ -43,6 +44,7 @@ struct PadParams {
 class ReferencePadTest : public testing::TestWithParam<PadParams>, public CommonReferenceTest {
 public:
     void SetUp() override {
+        SKIP_IF_CURRENT_TEST_IS_DISABLED();
         auto params = GetParam();
         function = CreateFunction(params);
         inputData = {params.inputData.data};

--- a/docs/template_plugin/tests/functional/skip_tests_config.cpp
+++ b/docs/template_plugin/tests/functional/skip_tests_config.cpp
@@ -75,6 +75,8 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*ReferencePadTest.*pad_exterior_2d_0x0)",
         R"(.*ReferencePadTest.*pad_exterior_2d_0x3)",
         R"(.*ReferencePadTest.*pad_exterior_2d_3x0)",
+        // CVS-70975
+        R"(.*ReferencePadTestParamsTooLarge.*)",
     };
 
 #ifdef _WIN32


### PR DESCRIPTION
### Details:
 - *Disabled ReferencePadTestParamsTooLarge in reference tests*
 - *Conflict are between PR#8396 and PR#8414*
 - *Now exceptions are thrown from SetUp() not from Exec() because some checks were moved to ngraph from CPU plugin*
 - *Created ticket 70975 for this case*

### Tickets:
 - *N/A*
