### PR TITLE
[OV2.0] Preprocessing API changes

### DIFF
--- a/docs/template_plugin/tests/functional/subgraph_reference/preprocess.cpp
+++ b/docs/template_plugin/tests/functional/subgraph_reference/preprocess.cpp
@@ -97,7 +97,7 @@ static RefPreprocessParams simple_mean_scale() {
     RefPreprocessParams res("simple_mean_scale");
     res.function = []() {
         auto f = create_simple_function(element::f32, Shape{1, 3, 2, 2});
-        f = PrePostProcessor().input(InputInfo().preprocess(PreProcessSteps().mean(1.f).scale(2.f))).build(f);
+        f = PrePostProcessor(f).input(InputInfo().preprocess(PreProcessSteps().mean(1.f).scale(2.f))).build();
         return f;
     };
     res.inputs.emplace_back(Shape{1, 3, 2, 2}, element::f32, std::vector<float>{1., 3., 5., 7., 9., 11., 13., 15., 17., 19., 21., 23.});
@@ -109,7 +109,7 @@ static RefPreprocessParams scale_then_mean() {
     RefPreprocessParams res("scale_then_mean");
     res.function = []() {
         auto f = create_simple_function(element::f32, Shape{1, 3, 2, 2});
-        f = PrePostProcessor().input(InputInfo().preprocess(PreProcessSteps().scale(2.0f).mean(2.0f))).build(f);
+        f = PrePostProcessor(f).input(InputInfo().preprocess(PreProcessSteps().scale(2.0f).mean(2.0f))).build();
         return f;
     };
 
@@ -122,14 +122,14 @@ static RefPreprocessParams convert_only() {
     RefPreprocessParams res("convert_only");
     res.function = []() {
         auto f = create_simple_function(element::f32, Shape{1, 1, 2, 2});
-        f = PrePostProcessor().input(InputInfo()
+        f = PrePostProcessor(f).input(InputInfo()
                 .tensor(InputTensorInfo().set_element_type(element::i16))
                 .preprocess(PreProcessSteps()
                 .convert_element_type(element::f32)
                 .scale(3.f)
                 .convert_element_type(element::u8)
                 .convert_element_type(element::f32)))
-                        .build(f);
+                        .build();
         return f;
     };
     res.inputs.emplace_back(Shape{1, 1, 2, 2}, element::i16, std::vector<int16_t>{2, 3, 4, 5});
@@ -141,14 +141,14 @@ static RefPreprocessParams convert_element_type_and_scale() {
     RefPreprocessParams res("convert_element_type_and_scale");
     res.function = []() {
         auto f = create_simple_function(element::u8, Shape{1, 3, 2, 2});
-        f = PrePostProcessor()
+        f = PrePostProcessor(f)
                 .input(InputInfo()
                                .tensor(InputTensorInfo().set_element_type(element::i16))
                                .preprocess(PreProcessSteps()
                                                    .convert_element_type(element::f32)
                                                    .scale(2.f)
                                                    .convert_element_type(element::u8)))
-                .build(f);
+                .build();
         return f;
     };
 
@@ -163,11 +163,11 @@ static RefPreprocessParams tensor_element_type_and_scale() {
     RefPreprocessParams res("tensor_element_type_and_scale");
     res.function = []() {
         auto f = create_simple_function(element::i8, Shape{1, 3, 1, 1});
-        f = PrePostProcessor()
+        f = PrePostProcessor(f)
             .input(InputInfo()
                            .tensor(InputTensorInfo().set_element_type(element::f32))
                            .preprocess(PreProcessSteps().scale(2.0f).convert_element_type(element::i8)))
-            .build(f);
+            .build();
         return f;
     };
 
@@ -180,13 +180,13 @@ static RefPreprocessParams custom_preprocessing() {
     RefPreprocessParams res("custom_preprocessing");
     res.function = []() {
         auto f = create_simple_function(element::i32, Shape{1, 3, 1, 1});
-        f = PrePostProcessor()
+        f = PrePostProcessor(f)
             .input(InputInfo().preprocess(PreProcessSteps().custom([](const Output<Node>& node) {
                 auto abs = std::make_shared<op::v0::Abs>(node);
                 abs->set_friendly_name(node.get_node_shared_ptr()->get_friendly_name() + "/abs");
                 return abs;
             })))
-            .build(f);
+            .build();
         return f;
     };
 
@@ -199,7 +199,7 @@ static RefPreprocessParams test_lvalue() {
     RefPreprocessParams res("test_lvalue");
     res.function = []() {
         auto f = create_simple_function(element::i8, Shape{1, 3, 1, 1});
-        auto p = PrePostProcessor();
+        auto p = PrePostProcessor(f);
         auto p1 = std::move(p);
         p = std::move(p1);
         auto inputInfo = InputInfo();
@@ -230,7 +230,7 @@ static RefPreprocessParams test_lvalue() {
             inputInfo.preprocess(std::move(same));
         }
         p.input(std::move(inputInfo));
-        f = p.build(f);
+        f = p.build();
         return f;
     };
 
@@ -243,7 +243,7 @@ static RefPreprocessParams test_2_inputs_basic() {
     RefPreprocessParams res("test_2_inputs_basic");
     res.function = []() {
         auto f = create_2inputs(element::f32, Shape{1, 3, 1, 1});
-        f = PrePostProcessor().input(InputInfo(0)
+        f = PrePostProcessor(f).input(InputInfo(0)
                                              .preprocess(
                                                      PreProcessSteps()
                                                              .mean(1.f)))
@@ -252,7 +252,7 @@ static RefPreprocessParams test_2_inputs_basic() {
                                 .preprocess(PreProcessSteps()
                                                     .mean(1.f)
                                                     .scale(2.0f)))
-                .build(f);
+                .build();
         return f;
     };
 
@@ -267,11 +267,11 @@ static RefPreprocessParams mean_scale_vector_tensor_layout() {
     RefPreprocessParams res("mean_scale_vector_tensor_layout");
     res.function = []() {
         auto f = create_simple_function(element::f32, PartialShape{1, 3, 2, 1});
-        f = PrePostProcessor()
+        f = PrePostProcessor(f)
                 .input(InputInfo()
                                .tensor(InputTensorInfo().set_layout("NC??"))
                                .preprocess(PreProcessSteps().mean({1.f, 2.f, 3.f}).scale({2.f, 3.f, 4.f})))
-                .build(f);
+                .build();
         return f;
     };
 
@@ -284,11 +284,11 @@ static RefPreprocessParams mean_scale_dynamic_layout() {
     RefPreprocessParams res("mean_scale_dynamic_layout");
     res.function = []() {
         auto f = create_simple_function(element::f32, PartialShape{1, 2, 1, 3});
-        f = PrePostProcessor()
+        f = PrePostProcessor(f)
                 .input(InputInfo()
                                .tensor(InputTensorInfo().set_layout("N...C"))
                                .preprocess(PreProcessSteps().mean({1.f, 2.f, 3.f}).scale({2.f, 3.f, 4.f})))
-                .build(f);
+                .build();
         return f;
     };
 
@@ -301,13 +301,13 @@ static RefPreprocessParams resize_to_network_height() {
     RefPreprocessParams res("resize_to_network_height");
     res.function = []() {
         auto f = create_simple_function(element::f32, PartialShape{1, 2, 1, 1});
-        f = PrePostProcessor()
+        f = PrePostProcessor(f)
                 .input(InputInfo()
                                .tensor(InputTensorInfo().set_spatial_dynamic_shape())
                                .preprocess(PreProcessSteps().resize(ResizeAlgorithm::RESIZE_LINEAR))
                                .network(InputNetworkInfo().set_layout("NHWC"))
                 )
-                .build(f);
+                .build();
         return f;
     };
     res.inputs.emplace_back(element::f32, Shape{1, 4, 1, 1}, std::vector<float>{0., 2., 4., 6.});
@@ -319,12 +319,12 @@ static RefPreprocessParams resize_to_network_width() {
     RefPreprocessParams res("resize_to_network_width");
     res.function = []() {
         auto f = create_simple_function(element::f32, PartialShape{Dimension::dynamic(), 1, 2, 2});
-        f = PrePostProcessor()
+        f = PrePostProcessor(f)
                 .input(InputInfo()
                                .tensor(InputTensorInfo().set_spatial_dynamic_shape())
                                .preprocess(PreProcessSteps().resize(ResizeAlgorithm::RESIZE_LINEAR))
                                .network(InputNetworkInfo().set_layout("NCHW")))
-                .build(f);
+                .build();
         return f;
     };
     res.inputs.emplace_back(element::f32, Shape{1, 1, 2, 6}, std::vector<float>{0., 1., 2., 3., 4., 5.,
@@ -339,12 +339,12 @@ static RefPreprocessParams resize_from_spatial_dims() {
         auto f = create_simple_function(element::f32, PartialShape{Dimension::dynamic(), 1, 1, 1});
         auto t = InputTensorInfo();
         t.set_spatial_static_shape(1, 4);
-        f = PrePostProcessor()
+        f = PrePostProcessor(f)
                 .input(InputInfo()
                                .tensor(std::move(t))
                                .preprocess(PreProcessSteps().resize(ResizeAlgorithm::RESIZE_CUBIC))
                                .network(InputNetworkInfo().set_layout("NCHW")))
-                .build(f);
+                .build();
         return f;
     };
     res.inputs.emplace_back(element::f32, Shape{1, 1, 1, 7}, std::vector<float>{0., 0.25, 1., 2.25, 4., 6.25, 9});
@@ -356,13 +356,13 @@ static RefPreprocessParams resize_i8() {
     RefPreprocessParams res("resize_i8");
     res.function = []() {
         auto f = create_simple_function(element::i8, PartialShape{1, 3, 1, 1});
-        f = PrePostProcessor()
+        f = PrePostProcessor(f)
                 .input(InputInfo()
                                .tensor(InputTensorInfo()
                                     .set_spatial_dynamic_shape())
                                .preprocess(PreProcessSteps().resize(ResizeAlgorithm::RESIZE_LINEAR))
                                .network(InputNetworkInfo().set_layout("NCHW")))
-                .build(f);
+                .build();
         return f;
     };
     res.inputs.emplace_back(element::i8, Shape{1, 3, 2, 2}, std::vector<int8_t>{0, 0, 0, 0,
@@ -376,12 +376,12 @@ static RefPreprocessParams resize_to_network_width_height() {
     RefPreprocessParams res("resize_to_network_width_height");
     res.function = []() {
         auto f = create_simple_function(element::f32, PartialShape{1, 1, 4, 4});
-        f = PrePostProcessor()
+        f = PrePostProcessor(f)
                 .input(InputInfo()
                                .tensor(InputTensorInfo().set_spatial_static_shape(5, 5))
                                .preprocess(PreProcessSteps().resize(ResizeAlgorithm::RESIZE_NEAREST))
                                .network(InputNetworkInfo().set_layout("...HW")))
-                .build(f);
+                .build();
         return f;
     };
 
@@ -406,12 +406,12 @@ static RefPreprocessParams resize_to_specified_width_height() {
     RefPreprocessParams res("resize_to_specified_width_height");
     res.function = []() {
         auto f = create_simple_function(element::f32, PartialShape{1, 1, Dimension::dynamic(), Dimension::dynamic()});
-        f = PrePostProcessor()
+        f = PrePostProcessor(f)
                 .input(InputInfo()
                                .tensor(InputTensorInfo().set_spatial_dynamic_shape())
                                .preprocess(PreProcessSteps().resize(ResizeAlgorithm::RESIZE_NEAREST, 4, 4))
                                .network(InputNetworkInfo().set_layout("...HW")))
-                .build(f);
+                .build();
         return f;
     };
 
@@ -448,9 +448,9 @@ static RefPreprocessParams resize_lvalues() {
         i.tensor(std::move(t));
         i.preprocess(std::move(s));
         i.network(std::move(n));
-        f = PrePostProcessor()
+        f = PrePostProcessor(f)
                 .input(std::move(i))
-                .build(f);
+                .build();
         return f;
     };
     // clang-format off
@@ -473,11 +473,11 @@ static RefPreprocessParams convert_layout_nhwc_to_nchw_lvalue() {
         auto p = PreProcessSteps();
         p.convert_layout("NCHW");
 
-        f = PrePostProcessor()
+        f = PrePostProcessor(f)
                 .input(InputInfo()
                                .tensor(InputTensorInfo().set_layout("NHWC"))
                                .preprocess(std::move(p)))
-                .build(f);
+                .build();
         return f;
     };
     res.inputs.emplace_back(Shape{1, 2, 2, 3}, element::u8, std::vector<uint8_t>{1,  2,  3,       // [H=0, W=0, RGB]
@@ -497,11 +497,11 @@ static RefPreprocessParams convert_layout_nhwc_to_net_no_tensor_shape() {
         f->get_parameters()[0]->set_layout("NCHW");
         auto p = PreProcessSteps();
         p.convert_layout();
-        f = PrePostProcessor()
+        f = PrePostProcessor(f)
                 .input(InputInfo()
                                .tensor(InputTensorInfo().set_layout("NHWC"))
                                .preprocess(std::move(p)))
-                .build(f);
+                .build();
         return f;
     };
     res.inputs.emplace_back(Shape{1, 2, 2, 3}, element::u8, std::vector<uint8_t>{1,  2,  3,       // [H=0, W=0, RGB]
@@ -518,10 +518,10 @@ static RefPreprocessParams convert_layout_by_dims() {
     RefPreprocessParams res("convert_layout_by_dims");
     res.function = []() {
         auto f = create_simple_function(element::u8, {1, 3, 2, 2});
-        f = PrePostProcessor()
+        f = PrePostProcessor(f)
                 .input(InputInfo()
                                .preprocess(PreProcessSteps().convert_layout({0, 3, 1, 2})))
-                .build(f);
+                .build();
         return f;
     };
     res.inputs.emplace_back(Shape{1, 2, 2, 3}, element::u8, std::vector<uint8_t>{1,  2,  3,       // [H=0, W=0, RGB]
@@ -541,9 +541,9 @@ static RefPreprocessParams convert_layout_by_dims_multi() {
         auto p = PreProcessSteps();
         p.convert_layout({0, 1, 3, 2}); // NHWC->NHCW
         p.convert_layout({0, 2, 1, 3}); // NHCW->NCHW
-        f = PrePostProcessor()
+        f = PrePostProcessor(f)
                 .input(InputInfo().preprocess(std::move(p)))
-                .build(f);
+                .build();
         return f;
     };
     res.inputs.emplace_back(Shape{1, 2, 2, 3}, element::f32, std::vector<float>{1,  2,  3,       // [H=0, W=0]
@@ -564,10 +564,10 @@ static RefPreprocessParams convert_layout_by_dims_multi_layout() {
         p.convert_layout({0, 1, 3, 2}); // NHWC->NHCW
         p.mean({1, 2, 2});              // Apply means to 'C' channel
         p.convert_layout({0, 2, 1, 3}); // NHCW->NCHW
-        f = PrePostProcessor()
+        f = PrePostProcessor(f)
                 .input(InputInfo().tensor(InputTensorInfo().set_layout("N??C"))
                                .preprocess(std::move(p)))
-                .build(f);
+                .build();
         return f;
     };
     res.inputs.emplace_back(Shape{1, 2, 2, 3}, element::f32, std::vector<float>{1,  2,  3,       // [H=0, W=0, RGB]
@@ -584,7 +584,7 @@ static RefPreprocessParams resize_and_convert_layout() {
     RefPreprocessParams res("resize_and_convert_layout");
     res.function = []() {
         auto f = create_simple_function(element::f32, PartialShape{1, 2, 2, 2});
-        f = PrePostProcessor()
+        f = PrePostProcessor(f)
                 .input(InputInfo()
                                .tensor(InputTensorInfo()
                                                .set_layout("NCHW")
@@ -593,7 +593,7 @@ static RefPreprocessParams resize_and_convert_layout() {
                                                    .resize(ResizeAlgorithm::RESIZE_LINEAR)
                                                    .convert_layout())
                                .network(InputNetworkInfo().set_layout("NHWC")))
-                .build(f);
+                .build();
         return f;
     };
 
@@ -622,13 +622,13 @@ static RefPreprocessParams convert_color_nv12_to_bgr_two_planes() {
     res.rel_threshold = 1.f; // Ignore relative pixel values comparison (100%)
     res.function = []() {
         auto f = create_simple_function(element::u8, PartialShape{1, 4, 4, 3});
-        f = PrePostProcessor()
+        f = PrePostProcessor(f)
                 .input(InputInfo()
                                .tensor(InputTensorInfo()
                                                .set_color_format(ColorFormat::NV12_TWO_PLANES))
                                .preprocess(PreProcessSteps()
                                                    .convert_color(ColorFormat::BGR)))
-                .build(f);
+                .build();
         return f;
     };
 
@@ -661,13 +661,13 @@ static RefPreprocessParams convert_color_nv12_single_plane() {
     res.rel_threshold = 1.f; // Ignore relative pixel values comparison (100%)
     res.function = []() {
         auto f = create_simple_function(element::f32, PartialShape{1, 4, 4, 3});
-        f = PrePostProcessor()
+        f = PrePostProcessor(f)
                 .input(InputInfo()
                                .tensor(InputTensorInfo()
                                                .set_color_format(ColorFormat::NV12_SINGLE_PLANE))
                                .preprocess(PreProcessSteps()
                                                    .convert_color(ColorFormat::RGB)))
-                .build(f);
+                .build();
         return f;
     };
 
@@ -696,7 +696,7 @@ static RefPreprocessParams convert_color_nv12_layout_resize() {
     res.rel_threshold = 1.f; // Ignore relative pixel values comparison (100%)
     res.function = []() {
         auto f = create_simple_function(element::f32, PartialShape{1, 3, 2, 2});
-        f = PrePostProcessor()
+        f = PrePostProcessor(f)
                 .input(InputInfo()
                                .tensor(InputTensorInfo()
                                                .set_color_format(ColorFormat::NV12_SINGLE_PLANE)
@@ -708,7 +708,7 @@ static RefPreprocessParams convert_color_nv12_layout_resize() {
                                                    .convert_element_type(element::f32)
                                                    .resize(ResizeAlgorithm::RESIZE_NEAREST))
                                .network(InputNetworkInfo().set_layout("NCHW")))
-                .build(f);
+                .build();
         return f;
     };
 
@@ -736,7 +736,7 @@ static RefPreprocessParams element_type_before_convert_color_nv12() {
     res.rel_threshold = 1.f; // Ignore relative pixel values comparison (100%)
     res.function = []() {
         auto f = create_simple_function(element::f32, PartialShape{1, 2, 2, 3});
-        f = PrePostProcessor()
+        f = PrePostProcessor(f)
                 .input(InputInfo()
                                .tensor(InputTensorInfo()
                                                .set_element_type(element::u8)
@@ -745,7 +745,7 @@ static RefPreprocessParams element_type_before_convert_color_nv12() {
                                                    .convert_element_type(element::f32)
                                                    .convert_color(ColorFormat::RGB))
                                .network(InputNetworkInfo().set_layout("NHWC")))
-                .build(f);
+                .build();
         return f;
     };
 
@@ -767,7 +767,7 @@ static RefPreprocessParams postprocess_2_inputs_basic() {
     RefPreprocessParams res("postprocess_2_inputs_basic");
     res.function = []() {
         auto f = create_2inputs(element::f32, Shape{1, 3, 1, 2});
-        f = PrePostProcessor()
+        f = PrePostProcessor(f)
                 .output(OutputInfo("tensor_output1")
                                 .network(OutputNetworkInfo().set_layout("NCHW"))
                                 .postprocess(PostProcessSteps().convert_layout())
@@ -775,7 +775,7 @@ static RefPreprocessParams postprocess_2_inputs_basic() {
                 .output(OutputInfo("tensor_output2")
                                 .postprocess(PostProcessSteps().convert_element_type())
                                 .tensor(OutputTensorInfo().set_element_type(element::u8)))
-                .build(f);
+                .build();
         return f;
     };
     res.inputs.emplace_back(Shape{1, 3, 1, 2}, element::f32, std::vector<float>{1.1, 2.1, 3.1, 4.1, 5.1, 6.1});
@@ -789,10 +789,10 @@ static RefPreprocessParams post_convert_layout_by_dims() {
     RefPreprocessParams res("post_convert_layout_by_dims");
     res.function = []() {
         auto f = create_simple_function(element::u8, {1, 2, 2, 3});
-        f = PrePostProcessor()
+        f = PrePostProcessor(f)
                 .output(OutputInfo()
                                .postprocess(PostProcessSteps().convert_layout({0, 3, 1, 2})))
-                .build(f);
+                .build();
         return f;
     };
     res.inputs.emplace_back(Shape{1, 2, 2, 3}, element::u8, std::vector<uint8_t>{1,  2,  3,       // [H=0, W=0, RGB]
@@ -812,9 +812,9 @@ static RefPreprocessParams post_convert_layout_by_dims_multi() {
         auto p = PostProcessSteps();
         p.convert_layout({0, 1, 3, 2}); // NHWC->NHCW
         p.convert_layout({0, 2, 1, 3}); // NHCW->NCHW
-        f = PrePostProcessor()
+        f = PrePostProcessor(f)
                 .output(OutputInfo().postprocess(std::move(p)))
-                .build(f);
+                .build();
         return f;
     };
     res.inputs.emplace_back(Shape{1, 2, 2, 3}, element::f32, std::vector<float>{1,  2,  3,       // [H=0, W=0]
@@ -831,7 +831,7 @@ static RefPreprocessParams pre_and_post_processing() {
     RefPreprocessParams res("pre_and_post_processing");
     res.function = []() {
         auto f = create_2inputs(element::f32, Shape{1, 3, 1, 2});
-        f = PrePostProcessor()
+        f = PrePostProcessor(f)
                 .input(InputInfo(0)
                                 .tensor(InputTensorInfo().set_element_type(element::u8))
                                 .preprocess(PreProcessSteps().convert_element_type(element::f32).mean(1.f)))
@@ -844,7 +844,7 @@ static RefPreprocessParams pre_and_post_processing() {
                 .output(OutputInfo("tensor_output2")
                                 .postprocess(PostProcessSteps().convert_element_type())
                                 .tensor(OutputTensorInfo().set_element_type(element::u8)))
-                .build(f);
+                .build();
         return f;
     };
     res.inputs.emplace_back(Shape{1, 3, 1, 2}, element::u8, std::vector<uint8_t>{1, 2, 3, 4, 5, 6});
@@ -858,9 +858,9 @@ static RefPreprocessParams rgb_to_bgr() {
     RefPreprocessParams res("rgb_to_bgr");
     res.function = []() {
         auto f = create_simple_function(element::f32, Shape{2, 1, 1, 3});
-        f = PrePostProcessor().input(InputInfo()
+        f = PrePostProcessor(f).input(InputInfo()
                                              .tensor(InputTensorInfo().set_color_format(ColorFormat::RGB))
-                                             .preprocess(PreProcessSteps().convert_color(ColorFormat::BGR))).build(f);
+                                             .preprocess(PreProcessSteps().convert_color(ColorFormat::BGR))).build();
         return f;
     };
 
@@ -873,9 +873,9 @@ static RefPreprocessParams bgr_to_rgb() {
     RefPreprocessParams res("bgr_to_rgb");
     res.function = []() {
         auto f = create_simple_function(element::f32, Shape{2, 1, 1, 3});
-        f = PrePostProcessor().input(InputInfo()
+        f = PrePostProcessor(f).input(InputInfo()
                 .tensor(InputTensorInfo().set_color_format(ColorFormat::BGR))
-                .preprocess(PreProcessSteps().convert_color(ColorFormat::RGB))).build(f);
+                .preprocess(PreProcessSteps().convert_color(ColorFormat::RGB))).build();
         return f;
     };
 
@@ -888,9 +888,9 @@ static RefPreprocessParams reverse_channels_nchw() {
     RefPreprocessParams res("reverse_channels_nchw");
     res.function = []() {
         auto f = create_simple_function(element::f32, PartialShape{1, 2, 2, 2});
-        f = PrePostProcessor().input(InputInfo()
+        f = PrePostProcessor(f).input(InputInfo()
                                              .tensor(InputTensorInfo().set_layout("NCHW"))
-                                             .preprocess(PreProcessSteps().reverse_channels())).build(f);
+                                             .preprocess(PreProcessSteps().reverse_channels())).build();
         return f;
     };
 
@@ -903,9 +903,9 @@ static RefPreprocessParams reverse_channels_dyn_layout() {
     RefPreprocessParams res("reverse_channels_dyn_layout");
     res.function = []() {
         auto f = create_simple_function(element::f32, PartialShape{1, 1, 3, 2});
-        f = PrePostProcessor().input(InputInfo()
+        f = PrePostProcessor(f).input(InputInfo()
                 .tensor(InputTensorInfo().set_color_format(ColorFormat::BGR).set_layout("...CN"))
-                .preprocess(PreProcessSteps().convert_color(ColorFormat::RGB))).build(f);
+                .preprocess(PreProcessSteps().convert_color(ColorFormat::RGB))).build();
         return f;
     };
 
@@ -921,9 +921,9 @@ static RefPreprocessParams reverse_dyn_shape() {
                                                                    Dimension::dynamic(),
                                                                    Dimension::dynamic(),
                                                                    Dimension::dynamic()});
-        f = PrePostProcessor().input(InputInfo()
+        f = PrePostProcessor(f).input(InputInfo()
                                              .tensor(InputTensorInfo().set_layout("NCHW"))
-                                             .preprocess(PreProcessSteps().reverse_channels())).build(f);
+                                             .preprocess(PreProcessSteps().reverse_channels())).build();
         return f;
     };
 
@@ -938,9 +938,9 @@ static RefPreprocessParams reverse_fully_dyn_shape() {
         auto f = create_simple_function(element::u8, PartialShape::dynamic());
         auto p = PreProcessSteps();
         p.reverse_channels();
-        f = PrePostProcessor().input(InputInfo()
+        f = PrePostProcessor(f).input(InputInfo()
                                              .tensor(InputTensorInfo().set_layout("...C??"))
-                                             .preprocess(std::move(p))).build(f);
+                                             .preprocess(std::move(p))).build();
         return f;
     };
 

--- a/docs/template_plugin/tests/functional/subgraph_reference/preprocess_legacy.cpp
+++ b/docs/template_plugin/tests/functional/subgraph_reference/preprocess_legacy.cpp
@@ -54,7 +54,7 @@ static std::shared_ptr<Function> create_simple_function_nv12(const PartialShape&
 
 TEST_F(ReferencePreprocessLegacyTest, mean) {
     function = create_simple_function(element::f32, Shape{1, 3, 2, 2});
-    function = PrePostProcessor().input(InputInfo().preprocess(PreProcessSteps().mean(1.f))).build(function);
+    function = PrePostProcessor(function).input(InputInfo().preprocess(PreProcessSteps().mean(1.f))).build();
 
     auto f2 = create_simple_function(element::f32, Shape{1, 3, 2, 2});
     legacy_network = InferenceEngine::CNNNetwork(f2);
@@ -72,7 +72,7 @@ TEST_F(ReferencePreprocessLegacyTest, mean) {
 
 TEST_F(ReferencePreprocessLegacyTest, mean_scale) {
     function = create_simple_function(element::f32, Shape{1, 3, 20, 20});
-    function = PrePostProcessor().input(InputInfo().preprocess(PreProcessSteps().scale(2.f))).build(function);
+    function = PrePostProcessor(function).input(InputInfo().preprocess(PreProcessSteps().scale(2.f))).build();
 
     auto f2 = create_simple_function(element::f32, Shape{1, 3, 20, 20});
     legacy_network = InferenceEngine::CNNNetwork(f2);
@@ -93,11 +93,11 @@ TEST_F(ReferencePreprocessLegacyTest, resize) {
     auto f2 = create_simple_function(element::f32, Shape{1, 3, 5, 5});
     legacy_network = InferenceEngine::CNNNetwork(f2);
 
-    function = PrePostProcessor().input(InputInfo()
+    function = PrePostProcessor(function).input(InputInfo()
             .tensor(InputTensorInfo().set_layout("NCHW").set_spatial_static_shape(42, 30))
             .preprocess(PreProcessSteps().resize(ResizeAlgorithm::RESIZE_LINEAR))
             .network(InputNetworkInfo().set_layout("NCHW")))
-                    .build(function);
+                    .build();
 
     auto &preProcess = legacy_network.getInputsInfo().begin()->second->getPreProcess();
     preProcess.setResizeAlgorithm(InferenceEngine::ResizeAlgorithm::RESIZE_BILINEAR);
@@ -114,12 +114,12 @@ public:
         inputData.clear();
         legacy_input_blobs.clear();
 
-        function = PrePostProcessor().input(InputInfo()
+        function = PrePostProcessor(function).input(InputInfo()
                                                     .tensor(InputTensorInfo().set_color_format(
                                                             ColorFormat::NV12_SINGLE_PLANE))
                                                     .preprocess(PreProcessSteps().convert_color(ColorFormat::BGR))
                                                     .network(InputNetworkInfo().set_layout("NCHW")))
-                .build(function);
+                .build();
 
         const auto &param = function->get_parameters()[0];
         inputData.emplace_back(param->get_element_type(), param->get_shape(), ov20_input_yuv.data());

--- a/docs/template_plugin/tests/functional/subgraph_reference/preprocess_opencv.cpp
+++ b/docs/template_plugin/tests/functional/subgraph_reference/preprocess_opencv.cpp
@@ -72,11 +72,11 @@ TEST_F(PreprocessOpenCVReferenceTest_NV12, convert_nv12_full_color_range) {
 
     inputData.clear();
 
-    function = PrePostProcessor().input(InputInfo()
+    function = PrePostProcessor(function).input(InputInfo()
                                                 .tensor(InputTensorInfo().set_color_format(
                                                         ColorFormat::NV12_SINGLE_PLANE))
                                                 .preprocess(PreProcessSteps().convert_color(ColorFormat::BGR)))
-            .build(function);
+            .build();
 
     const auto &param = function->get_parameters()[0];
     inputData.emplace_back(param->get_element_type(), param->get_shape(), ov20_input_yuv.data());
@@ -101,12 +101,12 @@ TEST_F(PreprocessOpenCVReferenceTest_NV12, convert_nv12_colored) {
 
     inputData.clear();
 
-    function = PrePostProcessor().input(InputInfo()
+    function = PrePostProcessor(function).input(InputInfo()
                                                 .tensor(InputTensorInfo().set_color_format(
                                                         ColorFormat::NV12_SINGLE_PLANE))
                                                 .preprocess(PreProcessSteps().convert_color(ColorFormat::BGR))
                                                 )
-            .build(function);
+            .build();
 
     const auto &param = function->get_parameters()[0];
     inputData.emplace_back(param->get_element_type(), param->get_shape(), input_yuv.data());
@@ -128,12 +128,12 @@ TEST_F(PreprocessOpenCVReferenceTest, resize_u8_simple_linear) {
 
     inputData.clear();
 
-    function = PrePostProcessor().input(InputInfo()
+    function = PrePostProcessor(function).input(InputInfo()
                                                 .tensor(InputTensorInfo().set_spatial_static_shape(2, 2))
                                                 .preprocess(PreProcessSteps().resize(ResizeAlgorithm::RESIZE_LINEAR))
                                                 .network(InputNetworkInfo().set_layout("NCHW"))
             )
-            .build(function);
+            .build();
 
     const auto &param = function->get_parameters()[0];
     inputData.emplace_back(param->get_element_type(), param->get_shape(), input_img.data());
@@ -167,12 +167,12 @@ TEST_F(PreprocessOpenCVReferenceTest, resize_u8_large_picture_linear) {
 
     inputData.clear();
 
-    function = PrePostProcessor().input(InputInfo()
+    function = PrePostProcessor(function).input(InputInfo()
                                                 .tensor(InputTensorInfo().set_spatial_static_shape(input_height, input_width))
                                                 .preprocess(PreProcessSteps().resize(ResizeAlgorithm::RESIZE_LINEAR))
                                                 .network(InputNetworkInfo().set_layout("NCHW"))
             )
-            .build(function);
+            .build();
 
     const auto &param = function->get_parameters()[0];
     inputData.emplace_back(param->get_element_type(), param->get_shape(), input_img.data());
@@ -205,12 +205,12 @@ TEST_F(PreprocessOpenCVReferenceTest, resize_f32_large_picture_linear) {
 
     inputData.clear();
 
-    function = PrePostProcessor().input(InputInfo()
+    function = PrePostProcessor(function).input(InputInfo()
                                                 .tensor(InputTensorInfo().set_spatial_static_shape(input_height, input_width))
                                                 .preprocess(PreProcessSteps().resize(ResizeAlgorithm::RESIZE_LINEAR))
                                                 .network(InputNetworkInfo().set_layout("NCHW"))
             )
-            .build(function);
+            .build();
 
     const auto &param = function->get_parameters()[0];
     inputData.emplace_back(param->get_element_type(), param->get_shape(), input_img.data());
@@ -234,12 +234,12 @@ TEST_F(PreprocessOpenCVReferenceTest, DISABLED_resize_f32_large_picture_cubic_sm
     auto element_type = element::f32;
     auto input_img = std::vector<float> {1.f, 2.f, 3.f, 4.f, 4.f, 3.f, 2.f, 1.f, 1.f, 2.f, 3.f, 4.f, 4.f, 3.f, 2.f, 1.f};
     function = create_simple_function(element_type, func_shape);
-    function = PrePostProcessor().input(InputInfo()
+    function = PrePostProcessor(function).input(InputInfo()
                                                 .tensor(InputTensorInfo().set_spatial_static_shape(input_height, input_width))
                                                 .preprocess(PreProcessSteps().resize(ResizeAlgorithm::RESIZE_CUBIC))
                                                 .network(InputNetworkInfo().set_layout("NCHW"))
             )
-            .build(function);
+            .build();
 
     inputData.emplace_back(element_type, input_shape, input_img.data());
 

--- a/inference-engine/samples/classification_sample_async/main.cpp
+++ b/inference-engine/samples/classification_sample_async/main.cpp
@@ -104,28 +104,22 @@ int main(int argc, char* argv[]) {
         // -------- Step 3. Apply preprocessing --------
         const ov::Layout tensor_layout{"NHWC"};
 
-        // clang-format off
-        model = PrePostProcessor().
-            // 1) InputInfo() with no args assumes a model has a single input
-            input(InputInfo().
-                // 2) Set input tensor information:
-                // - precision of tensor is supposed to be 'u8'
-                // - layout of data is 'NHWC'
-                tensor(InputTensorInfo().
-                    set_element_type(ov::element::u8).
-                    set_layout(tensor_layout)).
-                // 3) Here we suppose model has 'NCHW' layout for input
-                network(InputNetworkInfo().
-                    set_layout("NCHW"))).
-            output(OutputInfo().
-                // 4) Set output tensor information:
-                // - precision of tensor is supposed to be 'f32'
-                tensor(OutputTensorInfo().
-                    set_element_type(ov::element::f32))).
-            // 5) Once the build() method is called, the preprocessing steps
-            // for layout and precision conversions are inserted automatically
-        build(model);
-        // clang-format on
+        PrePostProcessor proc(model);
+        // 1) input() with no args assumes a model has a single input
+        InputInfo& input_info = proc.input();
+        // 2) Set input tensor information:
+        // - precision of tensor is supposed to be 'u8'
+        // - layout of data is 'NHWC'
+        input_info.tensor().set_element_type(ov::element::u8).set_layout(tensor_layout);
+        // 3) Here we suppose model has 'NCHW' layout for input
+        input_info.network().set_layout("NCHW");
+        // 4) output() with no args assumes a model has a single result
+        // - output() with no args assumes a model has a single result
+        // - precision of tensor is supposed to be 'f32'
+        proc.output().tensor().set_element_type(ov::element::f32);
+        // 5) Once the build() method is called, the pre(post)processing steps
+        // for layout and precision conversions are inserted automatically
+        model = proc.build();
 
         // -------- Step 4. read input images --------
         slog::info << "Read input images" << slog::endl;

--- a/inference-engine/samples/hello_classification/main.cpp
+++ b/inference-engine/samples/hello_classification/main.cpp
@@ -72,7 +72,7 @@ int tmain(int argc, tchar* argv[]) {
         // -------- Step 4. Apply preprocessing --------
 
         // clang-format off
-        model = PrePostProcessor().
+        model = PrePostProcessor(model).
             // 1) InputInfo() with no args assumes a model has a single input
             input(InputInfo().
                 // 2) Set input tensor information:
@@ -101,7 +101,7 @@ int tmain(int argc, tchar* argv[]) {
                 tensor(OutputTensorInfo().
                     set_element_type(ov::element::f32))).
             // 6) Apply preprocessing modifing the original 'model'
-            build(model);
+            build();
         // clang-format on
 
         // -------- Step 5. Loading a model to the device --------

--- a/inference-engine/samples/ngraph_function_creation_sample/main.cpp
+++ b/inference-engine/samples/ngraph_function_creation_sample/main.cpp
@@ -278,7 +278,7 @@ int main(int argc, char* argv[]) {
         // apply preprocessing
         // clang-format off
         using namespace ov::preprocess;
-        model = PrePostProcessor()
+        model = PrePostProcessor(model)
             // 1) InputInfo() with no args assumes a model has a single input
             .input(InputInfo()
                 // 2) Set input tensor information:
@@ -292,7 +292,7 @@ int main(int argc, char* argv[]) {
                     .set_layout("NCHW")))
         // 4) Once the build() method is called, the preprocessing steps
         // for layout and precision conversions are inserted automatically
-        .build(model);
+        .build();
         // clang-format on
 
         // -------- Step 4. Read input images --------

--- a/inference-engine/tests/functional/plugin/gpu/remote_blob_tests/gpu_remote_tensor_tests.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/remote_blob_tests/gpu_remote_tensor_tests.cpp
@@ -37,11 +37,11 @@ TEST_F(OVRemoteTensor_Test, smoke_canInputUserTensor) {
     auto ie = ov::runtime::Core();
 
     using namespace ov::preprocess;
-    auto function = PrePostProcessor()
+    auto function = PrePostProcessor(fn_ptr)
             .input(InputInfo()
                            .tensor(InputTensorInfo().set_element_type(ov::element::i8))
                            .preprocess(PreProcessSteps().convert_element_type(ov::element::f32)))
-            .build(fn_ptr);
+            .build();
 
     auto exec_net = ie.compile_model(function, CommonTestUtils::DEVICE_GPU);
 
@@ -92,11 +92,11 @@ TEST_F(OVRemoteTensor_Test, smoke_canInferOnUserContext) {
     auto ie = ov::runtime::Core();
 
     using namespace ov::preprocess;
-    auto function = PrePostProcessor()
+    auto function = PrePostProcessor(fn_ptr)
             .input(InputInfo()
                            .tensor(InputTensorInfo().set_element_type(ov::element::i8))
                            .preprocess(PreProcessSteps().convert_element_type(ov::element::f32)))
-            .build(fn_ptr);
+            .build();
 
     auto exec_net_regular = ie.compile_model(function, CommonTestUtils::DEVICE_GPU);
     auto input = function->get_parameters().at(0);
@@ -136,11 +136,11 @@ TEST_F(OVRemoteTensor_Test, smoke_canInferOnUserContextWithMultipleDevices) {
     auto ie = ov::runtime::Core();
 
     using namespace ov::preprocess;
-    auto function = PrePostProcessor()
+    auto function = PrePostProcessor(fn_ptr)
             .input(InputInfo()
                            .tensor(InputTensorInfo().set_element_type(ov::element::i8))
                            .preprocess(PreProcessSteps().convert_element_type(ov::element::f32)))
-            .build(fn_ptr);
+            .build();
 
     auto exec_net_regular = ie.compile_model(function, CommonTestUtils::DEVICE_GPU);
     auto input = function->get_parameters().at(0);
@@ -185,11 +185,11 @@ TEST_F(OVRemoteTensor_Test, smoke_canInferOnUserQueue_out_of_order) {
     auto ie = ov::runtime::Core();
 
     using namespace ov::preprocess;
-    auto function = PrePostProcessor()
+    auto function = PrePostProcessor(fn_ptr)
             .input(InputInfo()
                            .tensor(InputTensorInfo().set_element_type(ov::element::i8))
                            .preprocess(PreProcessSteps().convert_element_type(ov::element::f32)))
-            .build(fn_ptr);
+            .build();
 
     auto exec_net_regular = ie.compile_model(function, CommonTestUtils::DEVICE_GPU);
     auto input = function->get_parameters().at(0);
@@ -265,11 +265,11 @@ TEST_F(OVRemoteTensor_Test, smoke_canInferOnUserQueue_in_order) {
     auto ie = ov::runtime::Core();
 
     using namespace ov::preprocess;
-    auto function = PrePostProcessor()
+    auto function = PrePostProcessor(fn_ptr)
             .input(InputInfo()
                            .tensor(InputTensorInfo().set_element_type(ov::element::i8))
                            .preprocess(PreProcessSteps().convert_element_type(ov::element::f32)))
-            .build(fn_ptr);
+            .build();
 
     auto exec_net_regular = ie.compile_model(function, CommonTestUtils::DEVICE_GPU);
     auto input = function->get_parameters().at(0);
@@ -375,11 +375,11 @@ TEST_P(OVRemoteTensorBatched_Test, DISABLED_canInputNV12) {
     auto fn_ptr_remote = ngraph::builder::subgraph::makeConvPoolRelu({num_batch, 3, height, width});
 
     using namespace ov::preprocess;
-    auto function = PrePostProcessor()
+    auto function = PrePostProcessor(fn_ptr_remote)
             .input(InputInfo()
                            .tensor(InputTensorInfo().set_element_type(ov::element::i8).set_color_format(ov::preprocess::ColorFormat::NV12_TWO_PLANES))
                            .preprocess(PreProcessSteps().convert_element_type(ov::element::f32)))
-            .build(fn_ptr_remote);
+            .build();
 
     auto exec_net_b = ie.compile_model(fn_ptr_remote, CommonTestUtils::DEVICE_GPU);
     auto inf_req_remote = exec_net_b.create_infer_request();

--- a/inference-engine/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
@@ -130,7 +130,7 @@ void SubgraphBaseTest::compare(const std::vector<ov::runtime::Tensor>& expected,
 
 void SubgraphBaseTest::configure_model() {
     // configure input precision
-    ov::preprocess::PrePostProcessor p;
+    ov::preprocess::PrePostProcessor p(function);
     {
         auto& params = function->get_parameters();
         for (size_t i = 0; i < params.size(); i++) {
@@ -151,7 +151,7 @@ void SubgraphBaseTest::configure_model() {
             }
         }
     }
-    function = p.build(function);
+    function = p.build();
 }
 
 void SubgraphBaseTest::compile_model() {

--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/preprocess/preprocess_builders.hpp
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/preprocess/preprocess_builders.hpp
@@ -81,90 +81,90 @@ inline std::shared_ptr<Function> create_preprocess_2inputs_trivial() {
 inline std::shared_ptr<Function> mean_only() {
     using namespace ov::preprocess;
     auto function = create_preprocess_1input(element::f32, Shape{1, 3, 24, 24});
-    function = PrePostProcessor().input(InputInfo().preprocess(PreProcessSteps().mean(1.1f))).build(function);
+    function = PrePostProcessor(function).input(InputInfo().preprocess(PreProcessSteps().mean(1.1f))).build();
     return function;
 }
 
 inline std::shared_ptr<Function> scale_only() {
     using namespace ov::preprocess;
     auto function = create_preprocess_1input(element::f32, Shape{1, 3, 24, 24});
-    function = PrePostProcessor().input(InputInfo().preprocess(PreProcessSteps().scale(2.1f))).build(function);
+    function = PrePostProcessor(function).input(InputInfo().preprocess(PreProcessSteps().scale(2.1f))).build();
     return function;
 }
 
 inline std::shared_ptr<Function> mean_scale() {
     using namespace ov::preprocess;
     auto function = create_preprocess_1input(element::f32, Shape{1, 3, 24, 24});
-    function = PrePostProcessor().input(InputInfo().preprocess(PreProcessSteps().mean(1.1f).scale(2.1f))).build(function);
+    function = PrePostProcessor(function).input(InputInfo().preprocess(PreProcessSteps().mean(1.1f).scale(2.1f))).build();
     return function;
 }
 
 inline std::shared_ptr<Function> scale_mean() {
     using namespace ov::preprocess;
     auto function = create_preprocess_1input(element::f32, Shape{1, 3, 24, 24});
-    function = PrePostProcessor().input(InputInfo().preprocess(PreProcessSteps().scale(2.1f).mean(1.1f))).build(function);
+    function = PrePostProcessor(function).input(InputInfo().preprocess(PreProcessSteps().scale(2.1f).mean(1.1f))).build();
     return function;
 }
 
 inline std::shared_ptr<Function> mean_vector() {
     using namespace ov::preprocess;
     auto function = create_preprocess_1input(element::f32, Shape{1, 3, 24, 24});
-    function = PrePostProcessor().input(InputInfo()
+    function = PrePostProcessor(function).input(InputInfo()
                                                 .tensor(InputTensorInfo().set_layout("NCHW"))
-                                                .preprocess(PreProcessSteps().mean({2.2f, 3.3f, 4.4f}))).build(function);
+                                                .preprocess(PreProcessSteps().mean({2.2f, 3.3f, 4.4f}))).build();
     return function;
 }
 
 inline std::shared_ptr<Function> scale_vector() {
     using namespace ov::preprocess;
     auto function = create_preprocess_1input(element::f32, Shape{1, 3, 24, 24});
-    function = PrePostProcessor().input(InputInfo()
+    function = PrePostProcessor(function).input(InputInfo()
                                                 .tensor(InputTensorInfo().set_layout("NCHW"))
-                                                .preprocess(PreProcessSteps().scale({2.2f, 3.3f, 4.4f}))).build(function);
+                                                .preprocess(PreProcessSteps().scale({2.2f, 3.3f, 4.4f}))).build();
     return function;
 }
 
 inline std::shared_ptr<Function> convert_element_type_and_mean() {
     using namespace ov::preprocess;
     auto function = create_preprocess_1input(element::u8, Shape{1, 3, 24, 24});
-    function = PrePostProcessor()
+    function = PrePostProcessor(function)
             .input(InputInfo()
                            .preprocess(PreProcessSteps()
                                                .convert_element_type(element::f32)
                                                .mean(0.2f)
                                                .convert_element_type(element::u8)))
-            .build(function);
+            .build();
     return function;
 }
 
 inline std::shared_ptr<Function> tensor_element_type_and_mean() {
     using namespace ov::preprocess;
     auto function = create_preprocess_1input(element::u8, Shape{1, 3, 12, 12});
-    function = PrePostProcessor()
+    function = PrePostProcessor(function)
             .input(InputInfo()
                            .tensor(InputTensorInfo().set_element_type(element::f32))
                            .preprocess(PreProcessSteps().mean(0.1f).convert_element_type(element::u8)))
-            .build(function);
+            .build();
     return function;
 }
 
 inline std::shared_ptr<Function> custom_preprocessing() {
     using namespace ov::preprocess;
     auto function = create_preprocess_1input(element::i32, Shape{3, 4, 10, 20});
-    function = PrePostProcessor()
+    function = PrePostProcessor(function)
             .input(InputInfo().preprocess(PreProcessSteps().custom([](const Output<Node>& node) {
                 auto abs = std::make_shared<op::v0::Abs>(node);
                 abs->set_friendly_name(node.get_node_shared_ptr()->get_friendly_name() + "/abs");
                 return abs;
             })))
-            .build(function);
+            .build();
     return function;
 }
 
 inline std::shared_ptr<Function> lvalues_multiple_ops() {
     using namespace ov::preprocess;
     auto function = create_preprocess_1input(element::u8, Shape{1, 3, 3, 3});
-    auto p = PrePostProcessor();
+    auto p = PrePostProcessor(function);
     auto p1 = std::move(p);
     p = std::move(p1);
     auto inputInfo = InputInfo();
@@ -195,21 +195,21 @@ inline std::shared_ptr<Function> lvalues_multiple_ops() {
         inputInfo.preprocess(std::move(same));
     }
     p.input(std::move(inputInfo));
-    function = p.build(function);
+    function = p.build();
     return function;
 }
 
 inline std::shared_ptr<Function> two_inputs_basic() {
     using namespace ov::preprocess;
     auto function = create_preprocess_2inputs(element::f32, Shape{1, 3, 1, 1});
-    function = PrePostProcessor().input(InputInfo(1).preprocess(PreProcessSteps().mean(1.f).scale(2.0f))).build(function);
+    function = PrePostProcessor(function).input(InputInfo(1).preprocess(PreProcessSteps().mean(1.f).scale(2.0f))).build();
     return function;
 }
 
 inline std::shared_ptr<Function> two_inputs_trivial() {
     using namespace ov::preprocess;
     auto function = create_preprocess_2inputs_trivial();
-    function = PrePostProcessor().input(InputInfo(1).preprocess(PreProcessSteps().mean(1.f).scale(2.0f))).build(function);
+    function = PrePostProcessor(function).input(InputInfo(1).preprocess(PreProcessSteps().mean(1.f).scale(2.0f))).build();
     return function;
 }
 
@@ -217,9 +217,9 @@ inline std::shared_ptr<Function> reuse_network_layout() {
     using namespace ov::preprocess;
     auto function = create_preprocess_1input(element::f32, PartialShape{4, 3, 2, 1});
     function->get_parameters().front()->set_layout("NC??");
-    function = PrePostProcessor()
+    function = PrePostProcessor(function)
             .input(InputInfo().preprocess(PreProcessSteps().mean({1.1f, 2.2f, 3.3f}).scale({2.f, 3.f, 4.f})))
-            .build(function);
+            .build();
     return function;
 }
 
@@ -227,66 +227,66 @@ inline std::shared_ptr<Function> tensor_layout() {
     using namespace ov::preprocess;
     auto function = create_preprocess_1input(element::f32, PartialShape{4, 3, 2, 1});
     function->get_parameters().front()->set_layout("NC??");
-    function = PrePostProcessor()
+    function = PrePostProcessor(function)
             .input(InputInfo()
                            .tensor(InputTensorInfo().set_layout("NC??"))
                            .preprocess(PreProcessSteps().mean({1.1f, 2.2f, 3.3f}).scale({2.f, 3.f, 4.f})))
-            .build(function);
+            .build();
     return function;
 }
 
 inline std::shared_ptr<Function> resize_linear() {
     using namespace ov::preprocess;
     auto function = create_preprocess_1input(element::f32, PartialShape{1, 3, 10, 10});
-    function = PrePostProcessor()
+    function = PrePostProcessor(function)
             .input(InputInfo()
                            .tensor(InputTensorInfo().set_spatial_static_shape(20, 20))
                            .preprocess(PreProcessSteps().resize(ResizeAlgorithm::RESIZE_LINEAR))
                            .network(InputNetworkInfo().set_layout("NCHW")))
-            .build(function);
+            .build();
     return function;
 }
 
 inline std::shared_ptr<Function> resize_nearest() {
     using namespace ov::preprocess;
     auto function = create_preprocess_1input(element::f32, PartialShape{1, 3, 10, 10});
-    function = PrePostProcessor()
+    function = PrePostProcessor(function)
             .input(InputInfo()
                            .tensor(InputTensorInfo().set_spatial_static_shape(20, 20))
                            .preprocess(PreProcessSteps().resize(ResizeAlgorithm::RESIZE_NEAREST))
                            .network(InputNetworkInfo().set_layout("NCHW")))
-            .build(function);
+            .build();
     return function;
 }
 
 inline std::shared_ptr<Function> resize_linear_nhwc() {
     using namespace ov::preprocess;
     auto function = create_preprocess_1input(element::f32, PartialShape{1, 10, 10, 3});
-    function = PrePostProcessor()
+    function = PrePostProcessor(function)
             .input(InputInfo()
                            .tensor(InputTensorInfo().set_spatial_static_shape(20, 20))
                            .preprocess(PreProcessSteps().resize(ResizeAlgorithm::RESIZE_LINEAR))
                            .network(InputNetworkInfo().set_layout("NHWC")))
-            .build(function);
+            .build();
     return function;
 }
 
 inline std::shared_ptr<Function> resize_cubic() {
     using namespace ov::preprocess;
     auto function = create_preprocess_1input(element::f32, PartialShape{1, 3, 20, 20});
-    function = PrePostProcessor()
+    function = PrePostProcessor(function)
             .input(InputInfo()
                            .tensor(InputTensorInfo().set_spatial_static_shape(10, 10))
                            .preprocess(PreProcessSteps().resize(ResizeAlgorithm::RESIZE_CUBIC))
                            .network(InputNetworkInfo().set_layout("NCHW")))
-            .build(function);
+            .build();
     return function;
 }
 
 inline std::shared_ptr<Function> resize_and_convert_layout() {
     using namespace ov::preprocess;
     auto function = create_preprocess_1input(element::f32, PartialShape{1, 30, 20, 3});
-    function = PrePostProcessor()
+    function = PrePostProcessor(function)
             .input(InputInfo()
                            .tensor(InputTensorInfo()
                                            .set_layout("NHWC")
@@ -295,25 +295,25 @@ inline std::shared_ptr<Function> resize_and_convert_layout() {
                                                .convert_layout()
                                                .resize(ResizeAlgorithm::RESIZE_LINEAR))
                            .network(InputNetworkInfo().set_layout("NCHW")))
-            .build(function);
+            .build();
     return function;
 }
 
 inline std::shared_ptr<Function> convert_layout_by_dims() {
     using namespace ov::preprocess;
     auto function = create_preprocess_1input(element::f32, PartialShape{1, 30, 20, 3});
-    function = PrePostProcessor()
+    function = PrePostProcessor(function)
             .input(InputInfo()
                            .preprocess(PreProcessSteps()
                                                .convert_layout({0, 3, 1, 2})))
-            .build(function);
+            .build();
     return function;
 }
 
 inline std::shared_ptr<Function> resize_and_convert_layout_i8() {
     using namespace ov::preprocess;
     auto function = create_preprocess_1input(element::i8, PartialShape{1, 30, 20, 3});
-    function = PrePostProcessor()
+    function = PrePostProcessor(function)
             .input(InputInfo()
                            .tensor(InputTensorInfo()
                                            .set_layout("NHWC")
@@ -322,36 +322,36 @@ inline std::shared_ptr<Function> resize_and_convert_layout_i8() {
                                                .convert_layout()
                                                .resize(ResizeAlgorithm::RESIZE_LINEAR))
                            .network(InputNetworkInfo().set_layout("NCHW")))
-            .build(function);
+            .build();
     return function;
 }
 
 inline std::shared_ptr<Function> cvt_color_nv12_to_rgb_single_plane() {
     using namespace ov::preprocess;
     auto function = create_preprocess_1input(element::f32, PartialShape{1, 20, 20, 3});
-    function = PrePostProcessor()
+    function = PrePostProcessor(function)
             .input(InputInfo()
                            .tensor(InputTensorInfo().set_color_format(ColorFormat::NV12_SINGLE_PLANE))
                            .preprocess(PreProcessSteps().convert_color(ColorFormat::RGB)))
-            .build(function);
+            .build();
     return function;
 }
 
 inline std::shared_ptr<Function> cvt_color_nv12_to_bgr_two_planes() {
     using namespace ov::preprocess;
     auto function = create_preprocess_1input(element::f32, PartialShape{1, 20, 20, 3});
-    function = PrePostProcessor()
+    function = PrePostProcessor(function)
             .input(InputInfo()
                            .tensor(InputTensorInfo().set_color_format(ColorFormat::NV12_TWO_PLANES))
                            .preprocess(PreProcessSteps().convert_color(ColorFormat::BGR)))
-            .build(function);
+            .build();
     return function;
 }
 
 inline std::shared_ptr<Function> cvt_color_nv12_cvt_layout_resize() {
     using namespace ov::preprocess;
     auto function = create_preprocess_1input(element::f32, PartialShape{1, 3, 10, 10});
-    function = PrePostProcessor()
+    function = PrePostProcessor(function)
             .input(InputInfo()
                            .tensor(InputTensorInfo()
                                 .set_color_format(ColorFormat::NV12_TWO_PLANES)
@@ -363,7 +363,7 @@ inline std::shared_ptr<Function> cvt_color_nv12_cvt_layout_resize() {
                                 .convert_element_type(element::f32)
                                 .resize(ResizeAlgorithm::RESIZE_LINEAR))
                            .network(InputNetworkInfo().set_layout("NCHW")))
-            .build(function);
+            .build();
     return function;
 }
 

--- a/ngraph/core/include/openvino/core/preprocess/input_info.hpp
+++ b/ngraph/core/include/openvino/core/preprocess/input_info.hpp
@@ -18,10 +18,6 @@ namespace preprocess {
 ///    - Preprocessing steps applied to user's input (InputInfo::preprocess)
 ///    - Network's input info, which is a final info after preprocessing (InputInfo::network)
 ///
-/// API has Builder-like style to allow chaining calls in client's code, like
-/// \code{.cpp}
-/// auto proc = PrePostProcessor().input(InputInfo().tensor(...).preprocess(...).network(...);
-/// \endcode
 class OPENVINO_API InputInfo final {
     class InputInfoImpl;
     std::unique_ptr<InputInfoImpl> m_impl;
@@ -29,14 +25,20 @@ class OPENVINO_API InputInfo final {
 
 public:
     /// \brief Empty constructor. Should be used only if network will have only one input
+    ///
+    /// \todo Consider remove it (don't allow user to create standalone objects)
     InputInfo();
 
     /// \brief Constructor for particular input index of model
+    ///
+    /// \todo Consider remove it (don't allow user to create standalone objects)
     ///
     /// \param input_index Index to address specified input parameter of model
     explicit InputInfo(size_t input_index);
 
     /// \brief Constructor for particular output of model addressed by it's input name
+    ///
+    /// \todo Consider remove it (don't allow user to create standalone objects)
     ///
     /// \param input_tensor_name Name of input tensor name
     explicit InputInfo(const std::string& input_tensor_name);
@@ -50,7 +52,24 @@ public:
     /// \brief Default destructor
     ~InputInfo();
 
+    /// \brief Get current input tensor information with ability to change specific data
+    ///
+    /// \return Reference to current input tensor structure
+    InputTensorInfo& tensor();
+
+    /// \brief Get current input preprocess information with ability to add more preprocessing steps
+    ///
+    /// \return Reference to current preprocess steps structure
+    PreProcessSteps& preprocess();
+
+    /// \brief Get current input network/model information with ability to change original network's input data
+    ///
+    /// \return Reference to current network's input information structure
+    InputNetworkInfo& network();
+
     /// \brief Set input tensor information for input - Lvalue version
+    ///
+    /// \todo Consider removing it in future
     ///
     /// \param builder Input tensor information.
     ///
@@ -59,6 +78,8 @@ public:
 
     /// \brief Set input tensor information for input - Rvalue version
     ///
+    /// \todo Consider removing it in future
+    ///
     /// \param builder Input tensor information.
     ///
     /// \return Rvalue reference to 'this' to allow chaining with other calls in a builder-like manner
@@ -66,12 +87,16 @@ public:
 
     /// \brief Set preprocessing operations for input - Lvalue version
     ///
+    /// \todo Consider removing it in future
+    ///
     /// \param builder Preprocessing operations.
     ///
     /// \return Reference to 'this' to allow chaining with other calls in a builder-like manner
     InputInfo& preprocess(PreProcessSteps&& builder) &;
 
     /// \brief Set preprocessing operations for input - Rvalue version
+    ///
+    /// \todo Consider removing it in future
     ///
     /// \param builder Preprocessing operations.
     ///
@@ -81,12 +106,16 @@ public:
 
     /// \brief Set network's tensor information for input - Lvalue version
     ///
+    /// \todo Consider removing it in future
+    ///
     /// \param builder Input network tensor information.
     ///
     /// \return Reference to 'this' to allow chaining with other calls in a builder-like manner
     InputInfo& network(InputNetworkInfo&& builder) &;
 
     /// \brief Set input tensor information for input - Rvalue version
+    ///
+    /// \todo Consider removing it in future
     ///
     /// \param builder Input network tensor information.
     ///

--- a/ngraph/core/include/openvino/core/preprocess/input_network_info.hpp
+++ b/ngraph/core/include/openvino/core/preprocess/input_network_info.hpp
@@ -21,7 +21,7 @@ namespace preprocess {
 /// \code{.cpp}
 /// <network has input parameter with shape {1, 3, 224, 224}>
 /// auto proc =
-/// PrePostProcessor()
+/// PrePostProcessor(function)
 ///     .input(InputInfo()
 ///            .tensor(<input tensor info>)
 ///            .preprocess(PreProcessSteps().resize(ResizeAlgorithm::RESIZE_LINEAR))

--- a/ngraph/core/include/openvino/core/preprocess/input_tensor_info.hpp
+++ b/ngraph/core/include/openvino/core/preprocess/input_tensor_info.hpp
@@ -18,7 +18,7 @@ namespace preprocess {
 ///
 /// \code{.cpp}
 /// auto proc =
-/// PrePostProcessor()
+/// PrePostProcessor(function)
 ///     .input(InputInfo()
 ///            .tensor(InputTensorInfo()
 ///                    .set_element_type(ov::element::u8))

--- a/ngraph/core/include/openvino/core/preprocess/output_info.hpp
+++ b/ngraph/core/include/openvino/core/preprocess/output_info.hpp
@@ -17,11 +17,6 @@ namespace preprocess {
 ///    - Network's output info,  (OutputInfo::network)
 ///    - Postprocessing steps applied to user's input (OutputInfo::postprocess)
 ///    - User's desired output parameter information, which is a final one after preprocessing (OutputInfo::tensor)
-///
-/// API has Builder-like style to allow chaining calls in client's code, like
-/// \code{.cpp}
-/// auto proc = PrePostProcessor().output(InputInfo().network(...).preprocess(...).tensor(...);
-/// \endcode
 class OPENVINO_API OutputInfo final {
     class OutputInfoImpl;
     std::unique_ptr<OutputInfoImpl> m_impl;
@@ -29,14 +24,20 @@ class OPENVINO_API OutputInfo final {
 
 public:
     /// \brief Empty constructor. Should be used only if network has exactly one output
+    ///
+    /// \todo Consider making this private to not allow user to create standalone object
     OutputInfo();
 
     /// \brief Constructor for particular output index of model
+    ///
+    /// \todo Consider remove it (don't allow user to create standalone objects)
     ///
     /// \param output_index Index to address specified output parameter of model
     explicit OutputInfo(size_t output_index);
 
     /// \brief Constructor for particular output of model addressed by it's output name
+    ///
+    /// \todo Consider remove it (don't allow user to create standalone objects)
     ///
     /// \param output_tensor_name Name of output tensor name
     explicit OutputInfo(const std::string& output_tensor_name);
@@ -50,7 +51,24 @@ public:
     /// \brief Default destructor
     ~OutputInfo();
 
+    /// \brief Get current output network/model information with ability to change original network's output data
+    ///
+    /// \return Reference to current network's output information structure
+    OutputNetworkInfo& network();
+
+    /// \brief Get current output post-process information with ability to add more post-processing steps
+    ///
+    /// \return Reference to current preprocess steps structure
+    PostProcessSteps& postprocess();
+
+    /// \brief Get current output tensor information with ability to change specific data
+    ///
+    /// \return Reference to current output tensor structure
+    OutputTensorInfo& tensor();
+
     /// \brief Set network's tensor information for output - Lvalue version
+    ///
+    /// \todo Consider removing it in future
     ///
     /// \param builder Output network tensor information.
     ///
@@ -59,6 +77,8 @@ public:
 
     /// \brief Set network's tensor information for output - Rvalue version
     ///
+    /// \todo Consider removing it in future
+    ///
     /// \param builder Output network tensor information.
     ///
     /// \return Rvalue reference to 'this' to allow chaining with other calls in a builder-like manner
@@ -66,12 +86,16 @@ public:
 
     /// \brief Set postprocessing operations for output - Lvalue version
     ///
+    /// \todo Consider removing it in future
+    ///
     /// \param builder Postprocessing operations.
     ///
     /// \return Reference to 'this' to allow chaining with other calls in a builder-like manner
     OutputInfo& postprocess(PostProcessSteps&& builder) &;
 
     /// \brief Set postprocessing operations for output - Rvalue version
+    ///
+    /// \todo Consider removing it in future
     ///
     /// \param builder Postprocessing operations.
     ///
@@ -81,12 +105,16 @@ public:
 
     /// \brief Set final output tensor information for output after postprocessing - Lvalue version
     ///
+    /// \todo Consider removing it in future
+    ///
     /// \param builder Output tensor information.
     ///
     /// \return Reference to 'this' to allow chaining with other calls in a builder-like manner
     OutputInfo& tensor(OutputTensorInfo&& builder) &;
 
     /// \brief Set final output tensor information for output after postprocessing - Rvalue version
+    ///
+    /// \todo Consider removing it in future
     ///
     /// \param builder Output tensor information.
     ///

--- a/ngraph/core/include/openvino/core/preprocess/output_network_info.hpp
+++ b/ngraph/core/include/openvino/core/preprocess/output_network_info.hpp
@@ -14,17 +14,15 @@ namespace preprocess {
 /// info may not be needed. However it can be set to specify additional information about network, like 'layout'.
 ///
 /// Example of usage of network 'layout':
-/// Support network has output parameter with shape {1, 3, 224, 224} and `NHWC` layout. User may need to transpose
+/// Support network has output result with shape {1, 3, 224, 224} and `NHWC` layout. User may need to transpose
 /// output picture to interleaved format {1, 224, 224, 3}. This can be done with the following code
 ///
 /// \code{.cpp}
-/// <network has output parameter with shape {1, 3, 224, 224}>
-/// auto proc =
-/// PrePostProcessor()
-///     .output(OutputInfo()
-///            .network(OutputNetworkInfo().set_layout("NCHW")
-///            .preprocess(PostProcessSteps().convert_layout("NHWC")))
-///     );
+///     <network has output result with shape {1, 3, 224, 224}>
+///     auto proc = PrePostProcessor(function);
+///     proc.output().network().set_layout("NCHW");
+///     proc.output().postprocess().convert_layout("NHWC");
+///     function = proc.build();
 /// \endcode
 class OPENVINO_API OutputNetworkInfo final {
     class OutputNetworkInfoImpl;

--- a/ngraph/core/include/openvino/core/preprocess/output_tensor_info.hpp
+++ b/ngraph/core/include/openvino/core/preprocess/output_tensor_info.hpp
@@ -16,13 +16,11 @@ namespace preprocess {
 /// 'element_type') according to application's data and specify appropriate conversions in post-processing steps
 ///
 /// \code{.cpp}
-/// auto proc =
-/// PrePostProcessor()
-///     .output(OutputInfo()
-///            .postprocess(<add steps + conversion to user's output element type>)
-///            .tensor(OutputTensorInfo()
-///                    .set_element_type(ov::element::u8))
-///     );
+///     auto proc = PrePostProcessor(function);
+///     auto& output = proc.output();
+///     output.postprocess().<add steps + conversion to user's output element type>;
+///     output.tensor().set_element_type(ov::element::u8);
+///     function = proc.build();
 /// \endcode
 class OPENVINO_API OutputTensorInfo final {
     class OutputTensorInfoImpl;
@@ -31,6 +29,8 @@ class OPENVINO_API OutputTensorInfo final {
 
 public:
     /// \brief Default empty constructor
+    ///
+    /// \todo Consider making this private to not allow user to create standalone object
     OutputTensorInfo();
 
     /// \brief Default move constructor

--- a/ngraph/core/include/openvino/core/preprocess/postprocess_steps.hpp
+++ b/ngraph/core/include/openvino/core/preprocess/postprocess_steps.hpp
@@ -17,11 +17,9 @@ namespace preprocess {
 /// \brief Postprocessing steps. Each step typically intends adding of some operation to output parameter
 /// User application can specify sequence of postprocessing steps in a builder-like manner
 /// \code{.cpp}
-/// auto proc = PrePostProcessor()
-///     .output(OutputInfo()
-///             .postprocess(PostProcessSteps()
-///                        .convert_element_type(element::u8)))
-///     );
+///     auto proc = PrePostProcessor(function);
+///     proc.output().postprocess().convert_element_type(element::u8);
+///     function = proc.build();
 /// \endcode
 class OPENVINO_API PostProcessSteps final {
     class PostProcessStepsImpl;
@@ -30,6 +28,8 @@ class OPENVINO_API PostProcessSteps final {
 
 public:
     /// \brief Default empty constructor
+    ///
+    /// \todo Consider remove it (don't allow user to create standalone objects)
     PostProcessSteps();
 
     /// \brief Default move constructor
@@ -64,7 +64,7 @@ public:
     /// interleaved output image ('NHWC', [1, 224, 224, 3]). Post-processing may look like this:
     ///
     /// \code{.cpp} auto proc =
-    /// PrePostProcessor()
+    /// PrePostProcessor(function)
     ///     .output(OutputInfo()
     ///            .network(OutputTensorInfo().set_layout("NCHW")) // Network output is NCHW
     ///            .postprocess(PostProcessSteps()
@@ -92,7 +92,7 @@ public:
     /// interleaved output image [1, 480, 640, 3]. Post-processing may look like this:
     ///
     /// \code{.cpp} auto proc =
-    /// PrePostProcessor()
+    /// PrePostProcessor(function)
     ///     .output(OutputInfo()
     ///            .postprocess(PostProcessSteps()
     ///                        .convert_layout({0, 2, 3, 1})

--- a/ngraph/core/include/openvino/core/preprocess/pre_post_process.hpp
+++ b/ngraph/core/include/openvino/core/preprocess/pre_post_process.hpp
@@ -17,7 +17,7 @@ namespace preprocess {
 /// \brief Main class for adding pre- and post- processing steps to existing ov::Function
 /// API has Builder-like style to allow chaining calls in client's code, like
 /// \code{.cpp}
-/// auto proc = PrePostProcessor().input(<for input1>).input(<input2>);
+/// auto proc = PrePostProcessor(function).input(<for input1>).input(<input2>);
 /// \endcode
 ///
 /// This is a helper class for writing easy pre- and post- processing operations on ov::Function object assuming that
@@ -32,7 +32,9 @@ class OPENVINO_API PrePostProcessor final {
 
 public:
     /// \brief Default constructor
-    PrePostProcessor();
+    ///
+    /// \param function Existing function representing loaded model
+    explicit PrePostProcessor(const std::shared_ptr<Function>& function);
 
     /// \brief Default move constructor
     PrePostProcessor(PrePostProcessor&&) noexcept;
@@ -43,7 +45,61 @@ public:
     /// \brief Default destructor
     ~PrePostProcessor();
 
+    /// \brief Gets input pre-processing data structure. Should be used only if network/function has only one input
+    /// Using returned structure application's code is able to set user's tensor data (e.g layout), preprocess steps,
+    /// target model's data
+    ///
+    /// \return Reference to network's input information structure
+    InputInfo& input();
+
+    /// \brief Gets input pre-processing data structure for input identified by it's tensor name
+    ///
+    /// \param tensor_name Tensor name of specific input. Throws if tensor name is not associated with any input in a
+    /// model
+    ///
+    /// \return Reference to network's input information structure
+    InputInfo& input(const std::string& tensor_name);
+
+    /// \brief Gets input pre-processing data structure for input identified by it's order in a model
+    ///
+    /// \param input_index Input index of specific input. Throws if input index is out of range for associated function
+    ///
+    /// \return Reference to network's input information structure
+    InputInfo& input(size_t input_index);
+
+    /// \brief Gets output post-processing data structure. Should be used only if network/function has only one output
+    /// Using returned structure application's code is able to set model's output data, post-process steps, user's
+    /// tensor data (e.g layout)
+    ///
+    /// \return Reference to network's output information structure
+    OutputInfo& output();
+
+    /// \brief Gets output post-processing data structure for output identified by it's tensor name
+    ///
+    /// \param tensor_name Tensor name of specific output. Throws if tensor name is not associated with any input in a
+    /// model
+    ///
+    /// \return Reference to network's output information structure
+    OutputInfo& output(const std::string& tensor_name);
+
+    /// \brief Gets output post-processing data structure for output identified by it's order in a model
+    ///
+    /// \param output_index Output index of specific output. Throws if output index is out of range for associated
+    /// function
+    ///
+    /// \return Reference to network's output information structure
+    OutputInfo& output(size_t output_index);
+
+    /// \brief Adds pre/post-processing operations to function passed in constructor
+    ///
+    /// \return Function with added pre/post-processing operations
+    std::shared_ptr<Function> build();
+
+    //------------------ TODO: consider removal of rest --------
+
     /// \brief Adds pre-processing information and steps to input of model.
+    ///
+    /// \todo TODO: Consider remove this in sake of `InputInfo& input(...)` version
     ///
     /// \param builder Pre-processing data for input tensor of model.
     ///
@@ -52,12 +108,16 @@ public:
 
     /// \brief Adds pre-processing information and steps to input of model - Rvalue version.
     ///
+    /// \todo TODO: Consider remove this in sake of `InputInfo& input(...)` version
+    ///
     /// \param builder Pre-processing data for input tensor of model.
     ///
     /// \return Rvalue reference to 'this' to allow chaining with other calls in a builder-like manner
     PrePostProcessor&& input(InputInfo&& builder) &&;
 
     /// \brief Adds post-processing information and steps to output of model.
+    ///
+    /// \todo TODO: Consider remove this in sake of `OutputInfo& output(...)` version
     ///
     /// \param builder Post-processing data for output tensor of model.
     ///
@@ -66,17 +126,12 @@ public:
 
     /// \brief Adds pre-processing information and steps to input of model - Rvalue version.
     ///
+    /// \todo TODO: Consider remove this in sake of `OutputInfo& output(...)` version
+    ///
     /// \param builder Post-processing data for output tensor of model.
     ///
     /// \return Rvalue reference to 'this' to allow chaining with other calls in a builder-like manner
     PrePostProcessor&& output(OutputInfo&& builder) &&;
-
-    /// \brief Adds pre/post-processing operations to existing function
-    ///
-    /// \param function Existing function representing loaded model
-    ///
-    /// \return Function with added pre/post-processing operations
-    std::shared_ptr<Function> build(const std::shared_ptr<Function>& function);
 };
 
 }  // namespace preprocess

--- a/ngraph/core/include/openvino/core/preprocess/preprocess_steps.hpp
+++ b/ngraph/core/include/openvino/core/preprocess/preprocess_steps.hpp
@@ -18,7 +18,7 @@ namespace preprocess {
 /// \brief Preprocessing steps. Each step typically intends adding of some operation to input parameter
 /// User application can specify sequence of preprocessing steps in a builder-like manner
 /// \code{.cpp}
-/// auto proc = PrePostProcessor()
+/// auto proc = PrePostProcessor(function)
 ///     .input(InputInfo()
 ///            .preprocess(PreProcessSteps()
 ///                        .mean(0.2f)     // Subtract 0.2 from each element
@@ -207,7 +207,7 @@ public:
     /// planar input image ('NCHW', [1, 3, 224, 224]). Preprocessing may look like this:
     ///
     /// \code{.cpp} auto proc =
-    /// PrePostProcessor()
+    /// PrePostProcessor(function)
     ///     .input(InputInfo()
     ///            .tensor(InputTensorInfo().set_layout("NHWC")) // User data is NHWC
     ///            .preprocess(PreProcessSteps()
@@ -228,7 +228,7 @@ public:
     /// planar input image ('NCHW', [1, 3, 480, 640]). Preprocessing may look like this:
     ///
     /// \code{.cpp} auto proc =
-    /// PrePostProcessor()
+    /// PrePostProcessor(function)
     ///     .input(InputInfo()
     ///            .preprocess(PreProcessSteps()
     ///                        .convert_layout({0, 3, 1, 2})
@@ -249,7 +249,7 @@ public:
     /// BGR planes order. Preprocessing may look like this:
     ///
     /// \code{.cpp} auto proc =
-    /// PrePostProcessor()
+    /// PrePostProcessor(function)
     ///     .input(InputInfo()
     ///            .tensor(InputTensorInfo().set_layout("NCHW")) // User data is NCHW
     ///            .preprocess(PreProcessSteps()

--- a/ngraph/core/src/preprocess/pre_post_process.cpp
+++ b/ngraph/core/src/preprocess/pre_post_process.cpp
@@ -165,20 +165,25 @@ struct InputInfo::InputInfoImpl {
         return m_has_name;
     }
 
-    void create_tensor_data(const element::Type& type, const Layout& layout) {
-        auto data = std::unique_ptr<InputTensorInfo::InputTensorInfoImpl>(new InputTensorInfo::InputTensorInfoImpl());
-        data->set_layout(layout);
-        data->set_element_type(type);
-        m_tensor_data = std::move(data);
+    std::unique_ptr<InputTensorInfo::InputTensorInfoImpl>& get_tensor_data() {
+        return m_tensor_info.m_impl;
+    }
+
+    std::unique_ptr<PreProcessSteps::PreProcessStepsImpl>& get_preprocess() {
+        return m_preprocess.m_impl;
+    }
+
+    std::unique_ptr<InputNetworkInfo::InputNetworkInfoImpl>& get_network() {
+        return m_network_data.m_impl;
     }
 
     bool m_has_index = false;
     size_t m_index = 0;
     bool m_has_name = false;
     std::string m_name;
-    std::unique_ptr<InputTensorInfo::InputTensorInfoImpl> m_tensor_data;
-    std::unique_ptr<PreProcessSteps::PreProcessStepsImpl> m_preprocess;
-    std::unique_ptr<InputNetworkInfo::InputNetworkInfoImpl> m_network_data;
+    InputTensorInfo m_tensor_info;
+    PreProcessSteps m_preprocess;
+    InputNetworkInfo m_network_data;
     std::shared_ptr<op::v0::Parameter> m_resolved_param;
 };
 
@@ -196,18 +201,25 @@ struct OutputInfo::OutputInfoImpl {
         return m_has_name;
     }
 
-    void create_tensor_data() {
-        m_tensor_data =
-            std::unique_ptr<OutputTensorInfo::OutputTensorInfoImpl>(new OutputTensorInfo::OutputTensorInfoImpl());
+    std::unique_ptr<OutputTensorInfo::OutputTensorInfoImpl>& get_tensor_data() {
+        return m_tensor_info.m_impl;
+    }
+
+    std::unique_ptr<PostProcessSteps::PostProcessStepsImpl>& get_postprocess() {
+        return m_postprocess.m_impl;
+    }
+
+    std::unique_ptr<OutputNetworkInfo::OutputNetworkInfoImpl>& get_network_data() {
+        return m_network_info.m_impl;
     }
 
     bool m_has_index = false;
     size_t m_index = 0;
     bool m_has_name = false;
     std::string m_name;
-    std::unique_ptr<OutputTensorInfo::OutputTensorInfoImpl> m_tensor_data;
-    std::unique_ptr<PostProcessSteps::PostProcessStepsImpl> m_postprocess;
-    std::unique_ptr<OutputNetworkInfo::OutputNetworkInfoImpl> m_network_data;
+    OutputTensorInfo m_tensor_info;
+    PostProcessSteps m_postprocess;
+    OutputNetworkInfo m_network_info;
 };
 
 //-------------- InputInfo ------------------
@@ -220,32 +232,44 @@ InputInfo& InputInfo::operator=(InputInfo&&) noexcept = default;
 InputInfo::~InputInfo() = default;
 
 InputInfo& InputInfo::tensor(InputTensorInfo&& builder) & {
-    m_impl->m_tensor_data = std::move(builder.m_impl);
+    m_impl->m_tensor_info = std::move(builder);
     return *this;
 }
 
+InputTensorInfo& InputInfo::tensor() {
+    return m_impl->m_tensor_info;
+}
+
+PreProcessSteps& InputInfo::preprocess() {
+    return m_impl->m_preprocess;
+}
+
+InputNetworkInfo& InputInfo::network() {
+    return m_impl->m_network_data;
+}
+
 InputInfo&& InputInfo::tensor(InputTensorInfo&& builder) && {
-    m_impl->m_tensor_data = std::move(builder.m_impl);
+    m_impl->m_tensor_info = std::move(builder);
     return std::move(*this);
 }
 
 InputInfo&& InputInfo::preprocess(PreProcessSteps&& builder) && {
-    m_impl->m_preprocess = std::move(builder.m_impl);
+    m_impl->m_preprocess = std::move(builder);
     return std::move(*this);
 }
 
 InputInfo& InputInfo::preprocess(PreProcessSteps&& builder) & {
-    m_impl->m_preprocess = std::move(builder.m_impl);
+    m_impl->m_preprocess = std::move(builder);
     return *this;
 }
 
 InputInfo& InputInfo::network(InputNetworkInfo&& builder) & {
-    m_impl->m_network_data = std::move(builder.m_impl);
+    m_impl->m_network_data = std::move(builder);
     return *this;
 }
 
 InputInfo&& InputInfo::network(InputNetworkInfo&& builder) && {
-    m_impl->m_network_data = std::move(builder.m_impl);
+    m_impl->m_network_data = std::move(builder);
     return std::move(*this);
 }
 
@@ -260,73 +284,202 @@ OutputInfo::OutputInfo(OutputInfo&&) noexcept = default;
 OutputInfo& OutputInfo::operator=(OutputInfo&&) noexcept = default;
 OutputInfo::~OutputInfo() = default;
 
+OutputNetworkInfo& OutputInfo::network() {
+    return m_impl->m_network_info;
+}
+
+PostProcessSteps& OutputInfo::postprocess() {
+    return m_impl->m_postprocess;
+}
+
+OutputTensorInfo& OutputInfo::tensor() {
+    return m_impl->m_tensor_info;
+}
+
+// TODO: remove this in future
 OutputInfo& OutputInfo::tensor(OutputTensorInfo&& builder) & {
-    m_impl->m_tensor_data = std::move(builder.m_impl);
+    m_impl->m_tensor_info = std::move(builder);
     return *this;
 }
 
+// TODO: remove this in future
 OutputInfo&& OutputInfo::tensor(OutputTensorInfo&& builder) && {
-    m_impl->m_tensor_data = std::move(builder.m_impl);
+    m_impl->m_tensor_info = std::move(builder);
     return std::move(*this);
 }
 
+// TODO: remove this in future
 OutputInfo&& OutputInfo::postprocess(PostProcessSteps&& builder) && {
-    m_impl->m_postprocess = std::move(builder.m_impl);
+    m_impl->m_postprocess = std::move(builder);
     return std::move(*this);
 }
 
+// TODO: remove this in future
 OutputInfo& OutputInfo::postprocess(PostProcessSteps&& builder) & {
-    m_impl->m_postprocess = std::move(builder.m_impl);
+    m_impl->m_postprocess = std::move(builder);
     return *this;
 }
 
+// TODO: remove this in future
 OutputInfo& OutputInfo::network(OutputNetworkInfo&& builder) & {
-    m_impl->m_network_data = std::move(builder.m_impl);
+    m_impl->m_network_info = std::move(builder);
     return *this;
 }
 
+// TODO: remove this in future
 OutputInfo&& OutputInfo::network(OutputNetworkInfo&& builder) && {
-    m_impl->m_network_data = std::move(builder.m_impl);
+    m_impl->m_network_info = std::move(builder);
     return std::move(*this);
 }
 
 // ------------------------ PrePostProcessor --------------------
 struct PrePostProcessor::PrePostProcessorImpl {
 public:
-    std::list<std::unique_ptr<InputInfo::InputInfoImpl>> in_contexts;
-    std::list<std::unique_ptr<OutputInfo::OutputInfoImpl>> out_contexts;
+    PrePostProcessorImpl() = default;
+    explicit PrePostProcessorImpl(const std::shared_ptr<ov::Function>& f) : m_function(f) {
+        OPENVINO_ASSERT(f, "Function can't be nullptr for PrePostProcessor");
+        m_inputs.reserve(m_function->inputs().size());
+        for (size_t i = 0; i < m_function->inputs().size(); i++) {
+            m_inputs.emplace_back(i);
+        }
+
+        m_outputs.reserve(m_function->outputs().size());
+        for (size_t i = 0; i < m_function->outputs().size(); i++) {
+            m_outputs.emplace_back(i);
+        }
+    }
+    size_t find_input_index(const std::string& tensor_name) {
+        size_t index;
+        for (index = 0; index < m_function->inputs().size(); index++) {
+            if (m_function->input(index).get_names().count(tensor_name)) {
+                break;
+            }
+        }
+        OPENVINO_ASSERT(index < m_inputs.size(), "Function doesn't have input with name ", tensor_name);
+        return index;
+    }
+    size_t find_output_index(const std::string& tensor_name) {
+        size_t index;
+        for (index = 0; index < m_function->outputs().size(); index++) {
+            if (m_function->output(index).get_names().count(tensor_name)) {
+                break;
+            }
+        }
+        OPENVINO_ASSERT(index < m_outputs.size(), "Function doesn't have output with name ", tensor_name);
+        return index;
+    }
+
+    // TODO: this is created for compatibility, consider to remove
+    void add_input_info(InputInfo&& builder) {
+        if (builder.m_impl->m_has_index) {
+            OPENVINO_ASSERT(builder.m_impl->m_index < m_inputs.size(), "Index is out of range");
+            m_inputs[builder.m_impl->m_index] = std::move(builder);
+        } else if (builder.m_impl->m_has_name) {
+            size_t index = find_input_index(builder.m_impl->m_name);
+            m_inputs[index] = std::move(builder);
+        } else {
+            OPENVINO_ASSERT(1 == m_inputs.size(), "Function shall have only one input");
+            m_inputs[0] = std::move(builder);
+        }
+    }
+
+    // TODO: this is created for compatibility, consider to remove
+    void add_output_info(OutputInfo&& builder) {
+        if (builder.m_impl->m_has_index) {
+            OPENVINO_ASSERT(builder.m_impl->m_index < m_inputs.size(), "Output index is out of range");
+            m_outputs[builder.m_impl->m_index] = std::move(builder);
+        } else if (builder.m_impl->m_has_name) {
+            size_t index = find_output_index(builder.m_impl->m_name);
+            m_outputs[index] = std::move(builder);
+        } else {
+            OPENVINO_ASSERT(1 == m_inputs.size(), "Function shall have only one output");
+            m_outputs[0] = std::move(builder);
+        }
+    }
+    std::vector<InputInfo> m_inputs;
+    std::vector<OutputInfo> m_outputs;
+    std::shared_ptr<Function> m_function = nullptr;
 };
 
-PrePostProcessor::PrePostProcessor() : m_impl(std::unique_ptr<PrePostProcessorImpl>(new PrePostProcessorImpl())) {}
+PrePostProcessor::PrePostProcessor(const std::shared_ptr<Function>& function)
+    : m_impl(std::unique_ptr<PrePostProcessorImpl>(new PrePostProcessorImpl(function))) {}
 PrePostProcessor::PrePostProcessor(PrePostProcessor&&) noexcept = default;
 PrePostProcessor& PrePostProcessor::operator=(PrePostProcessor&&) noexcept = default;
 PrePostProcessor::~PrePostProcessor() = default;
 
+InputInfo& PrePostProcessor::input() {
+    OPENVINO_ASSERT(m_impl->m_inputs.size() == 1,
+                    "PrePostProcessor::input() - function must have exactly one input, got ",
+                    m_impl->m_inputs.size());
+    return m_impl->m_inputs.front();
+}
+
+InputInfo& PrePostProcessor::input(size_t input_index) {
+    OPENVINO_ASSERT(m_impl->m_inputs.size() > input_index,
+                    "PrePostProcessor::input(size_t) - function doesn't have input with index ",
+                    input_index,
+                    ". Total number of inputs is ",
+                    m_impl->m_inputs.size());
+    return m_impl->m_inputs[input_index];
+}
+
+InputInfo& PrePostProcessor::input(const std::string& tensor_name) {
+    size_t index = m_impl->find_input_index(tensor_name);
+    return m_impl->m_inputs[index];
+}
+
+OutputInfo& PrePostProcessor::output() {
+    OPENVINO_ASSERT(m_impl->m_outputs.size() == 1,
+                    "PrePostProcessor::output() - function must have exactly one output, got ",
+                    m_impl->m_outputs.size());
+    return m_impl->m_outputs.front();
+}
+
+OutputInfo& PrePostProcessor::output(size_t output_index) {
+    OPENVINO_ASSERT(m_impl->m_outputs.size() > output_index,
+                    "PrePostProcessor::output(size_t) - function doesn't have input with index ",
+                    output_index,
+                    ". Total number of inputs is ",
+                    m_impl->m_inputs.size());
+    return m_impl->m_outputs[output_index];
+}
+
+OutputInfo& PrePostProcessor::output(const std::string& tensor_name) {
+    size_t index = m_impl->find_output_index(tensor_name);
+    return m_impl->m_outputs[index];
+}
+
+// TODO: consider to remove
 PrePostProcessor& PrePostProcessor::input(InputInfo&& builder) & {
-    m_impl->in_contexts.push_back(std::move(builder.m_impl));
+    m_impl->add_input_info(std::move(builder));
     return *this;
 }
 
+// TODO: consider to remove
 PrePostProcessor&& PrePostProcessor::input(InputInfo&& builder) && {
-    m_impl->in_contexts.push_back(std::move(builder.m_impl));
+    m_impl->add_input_info(std::move(builder));
     return std::move(*this);
 }
 
+// TODO: consider remove
 PrePostProcessor& PrePostProcessor::output(OutputInfo&& builder) & {
-    m_impl->out_contexts.push_back(std::move(builder.m_impl));
+    m_impl->add_output_info(std::move(builder));
     return *this;
 }
 
+// TODO: consider remove
 PrePostProcessor&& PrePostProcessor::output(OutputInfo&& builder) && {
-    m_impl->out_contexts.push_back(std::move(builder.m_impl));
+    m_impl->add_output_info(std::move(builder));
     return std::move(*this);
 }
 
-std::shared_ptr<Function> PrePostProcessor::build(const std::shared_ptr<Function>& function) {
+std::shared_ptr<Function> PrePostProcessor::build() {
+    auto function = m_impl->m_function;
     FunctionGuard guard(function);
     std::tuple<std::unordered_set<std::string>, bool> existing_names{std::unordered_set<std::string>{}, false};
     bool tensor_data_updated = false;
-    for (const auto& input : m_impl->in_contexts) {
+    for (const auto& input_info : m_impl->m_inputs) {
+        auto& input = input_info.m_impl;
         std::shared_ptr<op::v0::Parameter> param;
         Output<Node> node;
         OPENVINO_ASSERT(input, "Internal error: Invalid preprocessing input, please report a problem");
@@ -339,8 +492,8 @@ std::shared_ptr<Function> PrePostProcessor::build(const std::shared_ptr<Function
         }
         param = std::dynamic_pointer_cast<op::v0::Parameter>(node.get_node_shared_ptr());
         // Set parameter layout from 'network' information
-        if (input->m_network_data && input->m_network_data->is_layout_set() && param->get_layout().empty()) {
-            param->set_layout(input->m_network_data->get_layout());
+        if (input->get_network()->is_layout_set() && param->get_layout().empty()) {
+            param->set_layout(input->get_network()->get_layout());
         }
         input->m_resolved_param = param;
     }
@@ -348,31 +501,29 @@ std::shared_ptr<Function> PrePostProcessor::build(const std::shared_ptr<Function
     auto parameters_list = std::list<std::shared_ptr<op::v0::Parameter>>(function->get_parameters().begin(),
                                                                          function->get_parameters().end());
 
-    for (const auto& input : m_impl->in_contexts) {
+    for (const auto& input_info : m_impl->m_inputs) {
+        const auto& input = input_info.m_impl;
         auto param = input->m_resolved_param;
         auto consumers = param->output(0).get_target_inputs();
-        if (!input->m_tensor_data) {
-            input->create_tensor_data(param->get_element_type(), param->get_layout());
+        if (!input->get_tensor_data()->is_element_type_set()) {
+            input->get_tensor_data()->set_element_type(param->get_element_type());
         }
-        if (!input->m_tensor_data->is_element_type_set()) {
-            input->m_tensor_data->set_element_type(param->get_element_type());
-        }
-        auto color_info = ColorFormatInfo::get(input->m_tensor_data->get_color_format());
-        if (!input->m_tensor_data->is_layout_set()) {
+        auto color_info = ColorFormatInfo::get(input->get_tensor_data()->get_color_format());
+        if (!input->get_tensor_data()->is_layout_set()) {
             if (!color_info->default_layout().empty()) {
-                input->m_tensor_data->set_layout(color_info->default_layout());
+                input->get_tensor_data()->set_layout(color_info->default_layout());
             } else if (!param->get_layout().empty()) {
-                input->m_tensor_data->set_layout(param->get_layout());
+                input->get_tensor_data()->set_layout(param->get_layout());
             }
         }
 
         auto net_shape = param->get_partial_shape();
         auto new_param_shape = net_shape;
-        if (input->m_tensor_data->is_layout_set() && !param->get_layout().empty() &&
-            param->get_layout() != input->m_tensor_data->get_layout()) {
+        if (input->get_tensor_data()->is_layout_set() && !param->get_layout().empty() &&
+            param->get_layout() != input->get_tensor_data()->get_layout()) {
             // Find transpose between network and tensor layouts and update tensor shape
             auto net_to_tensor =
-                layout::find_permutation(param->get_layout(), net_shape.rank(), input->m_tensor_data->get_layout());
+                layout::find_permutation(param->get_layout(), net_shape.rank(), input->get_tensor_data()->get_layout());
             if (!net_to_tensor.empty()) {
                 std::vector<ov::Dimension> dims(new_param_shape.size());
                 std::transform(net_to_tensor.begin(), net_to_tensor.end(), dims.begin(), [&](int64_t v) {
@@ -380,20 +531,20 @@ std::shared_ptr<Function> PrePostProcessor::build(const std::shared_ptr<Function
                 });
                 new_param_shape = PartialShape(dims);
             }
-        } else if (input->m_preprocess) {
-            new_param_shape = input->m_preprocess->calculate_param_shape(new_param_shape);
+        } else {
+            new_param_shape = input->get_preprocess()->calculate_param_shape(new_param_shape);
         }
-        if (input->m_tensor_data->is_spatial_shape_set()) {
-            auto height_idx = get_and_check_height_idx(input->m_tensor_data->get_layout(), new_param_shape);
-            auto width_idx = get_and_check_width_idx(input->m_tensor_data->get_layout(), new_param_shape);
-            if (input->m_tensor_data->is_spatial_shape_dynamic()) {
+        if (input->get_tensor_data()->is_spatial_shape_set()) {
+            auto height_idx = get_and_check_height_idx(input->get_tensor_data()->get_layout(), new_param_shape);
+            auto width_idx = get_and_check_width_idx(input->get_tensor_data()->get_layout(), new_param_shape);
+            if (input->get_tensor_data()->is_spatial_shape_dynamic()) {
                 // Use dynamic spatial dimensions
                 new_param_shape[height_idx] = Dimension::dynamic();
                 new_param_shape[width_idx] = Dimension::dynamic();
             } else {
                 // Use static spatial dimensions
-                new_param_shape[height_idx] = input->m_tensor_data->get_spatial_height();
-                new_param_shape[width_idx] = input->m_tensor_data->get_spatial_width();
+                new_param_shape[height_idx] = input->get_tensor_data()->get_spatial_height();
+                new_param_shape[width_idx] = input->get_tensor_data()->get_spatial_width();
             }
         }
 
@@ -404,11 +555,11 @@ std::shared_ptr<Function> PrePostProcessor::build(const std::shared_ptr<Function
         for (size_t plane = 0; plane < color_info->planes_count(); plane++) {
             auto plane_shape = color_info->shape(plane, new_param_shape);
             auto plane_param =
-                std::make_shared<op::v0::Parameter>(input->m_tensor_data->get_element_type(), plane_shape);
-            if (plane < input->m_tensor_data->planes_sub_names().size()) {
+                std::make_shared<op::v0::Parameter>(input->get_tensor_data()->get_element_type(), plane_shape);
+            if (plane < input->get_tensor_data()->planes_sub_names().size()) {
                 std::unordered_set<std::string> plane_tensor_names;
                 std::string sub_name;
-                sub_name = std::string("/") + input->m_tensor_data->planes_sub_names()[plane];
+                sub_name = std::string("/") + input->get_tensor_data()->planes_sub_names()[plane];
                 if (!std::get<1>(existing_names)) {
                     existing_names = std::make_tuple(get_function_tensor_names(function), true);
                 }
@@ -428,26 +579,24 @@ std::shared_ptr<Function> PrePostProcessor::build(const std::shared_ptr<Function
                     param->get_default_output().get_tensor().get_names());
                 plane_param->set_friendly_name(param->get_friendly_name());
             }
-            if (!input->m_tensor_data->get_layout().empty()) {
-                plane_param->set_layout(input->m_tensor_data->get_layout());
+            if (!input->get_tensor_data()->get_layout().empty()) {
+                plane_param->set_layout(input->get_tensor_data()->get_layout());
             }
             new_params.push_back(plane_param);
             nodes.emplace_back(plane_param);
         }
 
-        PreprocessingContext context(input->m_tensor_data->get_layout());
-        context.color_format() = input->m_tensor_data->get_color_format();
+        PreprocessingContext context(input->get_tensor_data()->get_layout());
+        context.color_format() = input->get_tensor_data()->get_color_format();
         context.target_layout() = param->get_layout();
         context.network_shape() = param->get_partial_shape();
         context.target_element_type() = param->get_element_type();
 
         // 2. Apply preprocessing
-        if (input->m_preprocess) {
-            for (const auto& action : input->m_preprocess->actions()) {
-                auto action_result = action(nodes, function, context);
-                nodes = std::get<0>(action_result);
-                tensor_data_updated |= std::get<1>(action_result);
-            }
+        for (const auto& action : input->get_preprocess()->actions()) {
+            auto action_result = action(nodes, function, context);
+            nodes = std::get<0>(action_result);
+            tensor_data_updated |= std::get<1>(action_result);
         }
 
         OPENVINO_ASSERT(nodes.size() == 1,
@@ -511,7 +660,8 @@ std::shared_ptr<Function> PrePostProcessor::build(const std::shared_ptr<Function
     }
 
     // Post processing
-    for (const auto& output : m_impl->out_contexts) {
+    for (const auto& output_info : m_impl->m_outputs) {
+        const auto& output = output_info.m_impl;
         std::shared_ptr<op::v0::Result> result;
         Output<Node> node;
         OPENVINO_ASSERT(output, "Internal error: Invalid postprocessing output, please report a problem");
@@ -526,35 +676,30 @@ std::shared_ptr<Function> PrePostProcessor::build(const std::shared_ptr<Function
         node.get_tensor().set_names({});
         result = std::dynamic_pointer_cast<op::v0::Result>(node.get_node_shared_ptr());
         // Set result layout from 'network' information
-        if (output->m_network_data && output->m_network_data->is_layout_set() && result->get_layout().empty()) {
-            result->set_layout(output->m_network_data->get_layout());
+        if (output->get_network_data()->is_layout_set() && result->get_layout().empty()) {
+            result->set_layout(output->get_network_data()->get_layout());
         }
         auto parent = result->get_input_source_output(0);
-        if (!output->m_tensor_data) {
-            output->create_tensor_data();
-        }
         PostprocessingContext context(result->get_layout());
-        if (output->m_tensor_data->is_layout_set()) {
-            context.target_layout() = output->m_tensor_data->get_layout();
+        if (output->get_tensor_data()->is_layout_set()) {
+            context.target_layout() = output->get_tensor_data()->get_layout();
         }
-        if (output->m_tensor_data->is_element_type_set()) {
-            context.target_element_type() = output->m_tensor_data->get_element_type();
+        if (output->get_tensor_data()->is_element_type_set()) {
+            context.target_element_type() = output->get_tensor_data()->get_element_type();
         }
         // Apply post-processing
         node = result->get_input_source_output(0);
         bool post_processing_applied = false;
-        if (output->m_postprocess) {
-            for (const auto& action : output->m_postprocess->actions()) {
-                auto action_result = action({node}, context);
-                node = std::get<0>(action_result);
-                post_processing_applied = true;
-            }
+        for (const auto& action : output->get_postprocess()->actions()) {
+            auto action_result = action({node}, context);
+            node = std::get<0>(action_result);
+            post_processing_applied = true;
         }
         // Implicit: Convert element type + layout to user's tensor implicitly
         PostStepsList implicit_steps;
-        if (node.get_element_type() != output->m_tensor_data->get_element_type() &&
-            output->m_tensor_data->is_element_type_set() && node.get_element_type() != element::dynamic) {
-            implicit_steps.add_convert_impl(output->m_tensor_data->get_element_type());
+        if (node.get_element_type() != output->get_tensor_data()->get_element_type() &&
+            output->get_tensor_data()->is_element_type_set() && node.get_element_type() != element::dynamic) {
+            implicit_steps.add_convert_impl(output->get_tensor_data()->get_element_type());
         }
 
         if (!context.target_layout().empty() && context.target_layout() != context.layout()) {


### PR DESCRIPTION
### Details:
- PreProcess API change:
   - PrePostProcessor takes 'function' argument in constructor
   - PrePostProcessor::build() doesn't take any function anymore
   - PrePostProcessor::input() method to get reference to input
   - PrePostProcessor::output() method to get reference to output
   - InputInfo - add getters of tensor, preprocess, network
   - OutputInfo - add getters of tensor, preprocess, network

- Samples:
   - ClassificationSampleAsync - use new getters

- Inference engine:
   - Use new getters in ie_network_reader.cpp

- TODO
    - Consider removal of builder-like API in PrePostProcessor, InputInfo, OutputInfo
    - 
### Tickets:
 - 70404
