### PR TITLE
stick to default memory if userrequest exceed the optimal number

### DIFF
--- a/inference-engine/src/multi_device/multi_device_exec_network.cpp
+++ b/inference-engine/src/multi_device/multi_device_exec_network.cpp
@@ -385,7 +385,7 @@ InferenceEngine::IInferRequestInternal::Ptr MultiDeviceExecutableNetwork::Create
     if (_workModeIsAUTO) {
         if (!_networkFirstReady && _networkActualNeeded) {
             auto& dev_requests = _workerRequests[_acceleratorDevice.deviceName];
-            if ( num < dev_requests.size()) {
+            if (num < dev_requests.size()) {
                 request_to_share_blobs_with = dev_requests.at(num)._inferRequest;
             }
         }
@@ -415,7 +415,7 @@ InferenceEngine::IInferRequestInternal::Ptr MultiDeviceExecutableNetwork::Create
     if (_workModeIsAUTO) {
         if (!_networkFirstReady && _networkActualNeeded) {
             auto& dev_requests = _workerRequests[_acceleratorDevice.deviceName];
-            if ( num < dev_requests.size()) {
+            if (num < dev_requests.size()) {
                 request_to_share_blobs_with = dev_requests.at(num)._inferRequest;
             }
         }

--- a/inference-engine/src/multi_device/multi_device_exec_network.cpp
+++ b/inference-engine/src/multi_device/multi_device_exec_network.cpp
@@ -385,9 +385,11 @@ InferenceEngine::IInferRequestInternal::Ptr MultiDeviceExecutableNetwork::Create
     if (_workModeIsAUTO) {
         if (!_networkFirstReady && _networkActualNeeded) {
             auto& dev_requests = _workerRequests[_acceleratorDevice.deviceName];
-            auto index = num % dev_requests.size();
-            request_to_share_blobs_with = dev_requests.at(index)._inferRequest;
+            if ( num < dev_requests.size()) {
+                request_to_share_blobs_with = dev_requests.at(num)._inferRequest;
+            }
         }
+        // if user creates more infer request than the device optimal value, fall back to default memory
         return std::make_shared<MultiDeviceInferRequest>(inputs, outputs, request_to_share_blobs_with);
     }
 
@@ -413,9 +415,11 @@ InferenceEngine::IInferRequestInternal::Ptr MultiDeviceExecutableNetwork::Create
     if (_workModeIsAUTO) {
         if (!_networkFirstReady && _networkActualNeeded) {
             auto& dev_requests = _workerRequests[_acceleratorDevice.deviceName];
-            auto index = num % dev_requests.size();
-            request_to_share_blobs_with = dev_requests.at(index)._inferRequest;
+            if ( num < dev_requests.size()) {
+                request_to_share_blobs_with = dev_requests.at(num)._inferRequest;
+            }
         }
+        // if user creates more infer request than the device optimal value, fall back to default memory
         return std::make_shared<MultiDeviceInferRequest>(networkInputs, networkOutputs, request_to_share_blobs_with);
     }
 


### PR DESCRIPTION
Signed-off-by: fishbell <bell.song@intel.com>

### Details:
 - when user create more auto requests than the optimal value, fall back to use default memory
 - *...*

### Tickets:
 - *ticket-id*
