### PR TITLE
[GNA] Allow networks with FP64 weights

### DIFF
--- a/inference-engine/src/gna_plugin/gna_plugin.cpp
+++ b/inference-engine/src/gna_plugin/gna_plugin.cpp
@@ -751,6 +751,7 @@ void GNAPlugin::LoadNetwork(CNNNetwork & _network) {
     NetPass::ConvertPrecision(network, Precision::I64, Precision::I32);
     NetPass::ConvertPrecision(network, Precision::U64, Precision::I32);
     NetPass::ConvertPrecision(network, Precision::U32, Precision::I32);
+    NetPass::ConvertPrecision(network, Precision::FP64, Precision::FP32);
 
     //  Check the input network
     std::string error;


### PR DESCRIPTION
### Details:
 - After openvino2.0 changes merge model weights can have FP64 precision, for example such weights can be created in POT produced IRs, GNA plugin throws an error in this case
 - Allow handling of networks with FP64 data type

### Tickets:
