### PR TITLE
Reduce number of Function Validations

### DIFF
--- a/inference-engine/src/cldnn_engine/cldnn_transformations_pipeline.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_transformations_pipeline.cpp
@@ -110,6 +110,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Function> func) {
     bool enableInt8;
     {
         ngraph::pass::Manager manager;
+        manager.set_per_pass_validation(false);
+
         enableInt8 = config.enableInt8 && ngraph::pass::low_precision::LowPrecision::isFunctionQuantized(func);
         if (enableInt8) {
             manager.register_pass<ngraph::pass::DisableConvertConstantFoldingOnConstPath>(
@@ -160,6 +162,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Function> func) {
                 {ngraph::element::u4, ngraph::element::u8},
         };
 
+        manager.register_pass<ngraph::pass::Validate>();
         manager.register_pass<ngraph::pass::ConvertPrecision>(convert_precision_list);
 
         auto pass_config = manager.get_pass_config();

--- a/inference-engine/src/mkldnn_plugin/mkldnn_plugin.cpp
+++ b/inference-engine/src/mkldnn_plugin/mkldnn_plugin.cpp
@@ -127,6 +127,7 @@ Engine::~Engine() {
 
 static void TransformationUpToCPUSpecificOpSet(std::shared_ptr<ngraph::Function> nGraphFunc, const bool _enableLPT) {
     ngraph::pass::Manager manager;
+    manager.set_per_pass_validation(false);
     manager.register_pass<ngraph::pass::InitNodeInfo>();
 
     const bool useLpt =
@@ -184,6 +185,7 @@ static void TransformationUpToCPUSpecificOpSet(std::shared_ptr<ngraph::Function>
         manager.register_pass<ngraph::pass::low_precision::ConvertSubtractConstant>(
             std::vector<ngraph::element::Type>{ ngraph::element::i8, ngraph::element::u8, ngraph::element::i4, ngraph::element::u4 });
     }
+    manager.register_pass<ngraph::pass::Validate>();
     manager.register_pass<ngraph::pass::ConvertPrecision>(precisions);
     manager.register_pass<ngraph::pass::EliminateConvert>();
 

--- a/inference-engine/src/transformations/src/transformations/common_optimizations/common_optimizations.cpp
+++ b/inference-engine/src/transformations/src/transformations/common_optimizations/common_optimizations.cpp
@@ -96,6 +96,7 @@ NGRAPH_RTTI_DEFINITION(ngraph::pass::CommonOptimizations, "CommonOptimizations",
 bool ngraph::pass::CommonOptimizations::run_on_function(std::shared_ptr<ngraph::Function> f) {
     RUN_ON_FUNCTION_SCOPE(CommonOptimizations);
     ngraph::pass::Manager manager(get_pass_config());
+    manager.set_per_pass_validation(false);
 
     manager.register_pass<ov::pass::DisableDecompressionConvertConstantFolding>();
 
@@ -186,6 +187,7 @@ bool ngraph::pass::CommonOptimizations::run_on_function(std::shared_ptr<ngraph::
     // because we cannot insert any MaxPools since they may prevent
     // other optimizations
     manager.register_pass<ngraph::pass::StridesOptimization>();
+    manager.register_pass<ngraph::pass::Validate>();
 
     manager.run_passes(f);
 

--- a/inference-engine/src/transformations/src/transformations/common_optimizations/moc_transformations.cpp
+++ b/inference-engine/src/transformations/src/transformations/common_optimizations/moc_transformations.cpp
@@ -68,6 +68,7 @@ bool ngraph::pass::MOCTransformations::run_on_function(std::shared_ptr<ngraph::F
     }
 
     ngraph::pass::Manager manager(get_pass_config());
+    manager.set_per_pass_validation(false);
 
     manager.register_pass<ngraph::pass::InitNodeInfo>();
     if (m_low_precision_enabled) {
@@ -79,10 +80,15 @@ bool ngraph::pass::MOCTransformations::run_on_function(std::shared_ptr<ngraph::F
     }
     manager.register_pass<ngraph::pass::DisableRandomUniformConstantFolding>();
     manager.register_pass<ngraph::pass::ConstantFolding>();
+    manager.register_pass<ngraph::pass::Validate>();
+
     // FusedFilteringBoxesBySize transformation has the complex pattern
     // which can be affected by further transformations. So we have to
-    // execute it at the beginning of the pipeline.
+    // execute it at the beginning of the pipeline. Also, this pass resolves
+    // dynamism, so we have to execute type/shape propagation after.
     manager.register_pass<ngraph::pass::FuseFilteringBoxesBySize>();
+    manager.register_pass<ngraph::pass::Validate>();
+
     manager.register_pass<ngraph::pass::ConvertQuantizeDequantize>();
     manager.register_pass<ngraph::pass::SimplifyShapeOfSubGraph>();
     if (!m_use_shapes) {

--- a/inference-engine/src/transformations/src/transformations/opset_conversions/convert_opset2_to_opset1.cpp
+++ b/inference-engine/src/transformations/src/transformations/opset_conversions/convert_opset2_to_opset1.cpp
@@ -18,6 +18,7 @@ NGRAPH_RTTI_DEFINITION(ngraph::pass::ConvertOpSet2ToOpSet1, "ConvertOpSet2ToOpSe
 bool ngraph::pass::ConvertOpSet2ToOpSet1::run_on_function(std::shared_ptr<ngraph::Function> f) {
     RUN_ON_FUNCTION_SCOPE(ConvertOpSet2ToOpSet1);
     ngraph::pass::Manager manager(get_pass_config());
+    manager.set_per_pass_validation(false);
 
     manager.register_pass<ngraph::pass::ConvertSpaceToBatch>();
     manager.register_pass<ngraph::pass::ConvertBatchToSpace>();

--- a/inference-engine/src/transformations/src/transformations/opset_conversions/convert_opset3_to_opset2.cpp
+++ b/inference-engine/src/transformations/src/transformations/opset_conversions/convert_opset3_to_opset2.cpp
@@ -21,6 +21,7 @@ NGRAPH_RTTI_DEFINITION(ngraph::pass::ConvertOpSet3ToOpSet2, "ConvertOpSet3ToOpSe
 bool ngraph::pass::ConvertOpSet3ToOpSet2::run_on_function(std::shared_ptr<ngraph::Function> f) {
     RUN_ON_FUNCTION_SCOPE(ConvertOpSet3ToOpSet2);
     ngraph::pass::Manager manager(get_pass_config());
+    manager.set_per_pass_validation(false);
 
     manager.register_pass<ngraph::pass::ConvertBroadcast3>();
     manager.register_pass<ngraph::pass::ConvertShapeOf3>();

--- a/ngraph/core/include/openvino/pass/manager.hpp
+++ b/ngraph/core/include/openvino/pass/manager.hpp
@@ -55,9 +55,8 @@ public:
     /// \brief Set flag to enable/disable running Validate pass after executing
     /// each registered pass
     /// \param new_state Value "true" enables Validate pass run; "false", otherwise
-    void set_per_pass_validation(bool new_state) {
-        m_per_pass_validation = new_state;
-    }
+    void set_per_pass_validation(bool new_state);
+
     /// \brief Callback is a lambda function that can be used by registered transformations.
     /// The main purpose of this callback is to provide a way for plugins to disable/enable
     /// transformations based on some conditions. In some cases plugins may want not to

--- a/ngraph/core/src/pass/manager.cpp
+++ b/ngraph/core/src/pass/manager.cpp
@@ -44,6 +44,10 @@ ov::pass::Manager::~Manager() = default;
 
 ov::pass::Manager::Manager(std::shared_ptr<ov::pass::PassConfig> pass_config) : m_pass_config(std::move(pass_config)) {}
 
+void ov::pass::Manager::set_per_pass_validation(bool new_state) {
+    m_per_pass_validation = new_state;
+}
+
 void ov::pass::Manager::run_passes(shared_ptr<ov::Function> func) {
     NGRAPH_SUPPRESS_DEPRECATED_START
     OV_ITT_SCOPED_TASK(ov::itt::domains::nGraph, "pass::Manager::run_passes");


### PR DESCRIPTION
### Description
Validation of the Function is a very time consuming process and as it takes significant part of LoadTime we have to minimize its usage inside our transformation pipelines. In this PR MOCTransformations, CommonOptimizations, CPU and GPU common pipelines before LPT were updated and the average number of Validations in this pipelines is ~2-3.
The only disadvantage of this approach is that now we have to care which passes can change model type/shape and in such cases we have to enable Validation manually. But on practice the number of such transformations is really low, so for most cases validation is not required.

_Note: there are still some additional validation that potentially can be removed but their removal requires additional investigation and will be done separately._

### Validation
Two GPU and CPU internal cycles passed successfully without functional and LoadTime regressions.

### Ticket
XXX-44329