### PR TITLE
Set throughput as defaule value of -hint for AUTO

### DIFF
--- a/samples/cpp/benchmark_app/main.cpp
+++ b/samples/cpp/benchmark_app/main.cpp
@@ -193,6 +193,9 @@ int main(int argc, char* argv[]) {
         }
         // Set throughput when loading AUTO device if hint is empty.
         if (FLAGS_d == "AUTO" && FLAGS_hint.empty()) {
+            slog::warn << "-hint default value is determined as \'THROUGHPUT\' automatically for AUTO device. For more "
+                          "detailed information look at README."
+                       << slog::endl;
             FLAGS_hint = "throughput";
         }
 

--- a/samples/cpp/benchmark_app/main.cpp
+++ b/samples/cpp/benchmark_app/main.cpp
@@ -191,6 +191,10 @@ int main(int argc, char* argv[]) {
             ie.AddExtension(extension_ptr);
             slog::info << "CPU (MKLDNN) extensions is loaded " << FLAGS_l << slog::endl;
         }
+        // Set throughput when loading AUTO device if hint is empty.
+        if (FLAGS_d == "AUTO" && FLAGS_hint.empty()) {
+            FLAGS_hint = "throughput";
+        }
 
         // Load clDNN Extensions
         if ((FLAGS_d.find("GPU") != std::string::npos) && !FLAGS_c.empty()) {

--- a/tools/benchmark_tool/openvino/tools/benchmark/main.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/main.py
@@ -130,6 +130,10 @@ def run(args):
                 config[device]['PERFORMANCE_HINT'] = args.perf_hint.upper()
                 if is_flag_set_in_command_line('nireq'):
                     config[device]['PERFORMANCE_HINT_NUM_REQUESTS'] = str(args.number_infer_requests)
+            elif "AUTO" == device_name:
+                config[device]['PERFORMANCE_HINT'] = "THROUGHPUT"
+                if is_flag_set_in_command_line('nireq'):
+                    config[device]['PERFORMANCE_HINT_NUM_REQUESTS'] = str(args.number_infer_requests)
             ## the rest are individual per-device settings (overriding the values the device will deduce from perf hint)
             def set_throughput_streams():
                 key = get_device_type_from_name(device) + "_THROUGHPUT_STREAMS"
@@ -314,13 +318,16 @@ def run(args):
 
         # --------------------- 8. Querying optimal runtime parameters --------------------------------------------------
         next_step()
-        if is_flag_set_in_command_line('hint'):
+        if is_flag_set_in_command_line('hint') or "AUTO" == device_name:
             ## actual device-deduced settings for the hint
             for device in devices:
                 keys = benchmark.core.get_metric(device, 'SUPPORTED_CONFIG_KEYS')
                 logger.info(f'DEVICE: {device}')
                 for k in keys:
-                    logger.info(f'  {k}  , {exe_network.get_config(k)}')
+                    try:
+                        logger.info(f'  {k}  , {exe_network.get_config(k)}')
+                    except:
+                        pass
 
         # Update number of streams
         for device in device_number_streams.keys():


### PR DESCRIPTION
Set throughput as defaule value of -hint for AUTO when device is AUTO and -hint is not set, then set it as throughput.

Signed-off-by: Wang, Yang <yang4.wang@intel.com>

### Details:
 - Update  benchmark app both C++ version and Python version.
 - Fix the key not found within benchmark app Python version.

### Tickets:
 -https://jira.devtools.intel.com/browse/CVS-69022
