### PR TITLE
Support NonConst pads_begin and pads_end in Pad op

### DIFF
--- a/docs/template_plugin/tests/functional/op_reference/pad.cpp
+++ b/docs/template_plugin/tests/functional/op_reference/pad.cpp
@@ -116,6 +116,64 @@ TEST_P(ReferencePadTestParamsOk, CompareWithRefs) {
     EXPECT_NO_THROW(Exec());
 }
 
+class ReferencePadTestNonConstPadBeginPadEnd : public ReferencePadTest {
+public:
+    void SetUp() override {
+        SKIP_IF_CURRENT_TEST_IS_DISABLED();
+        auto params = GetParam();
+        function = CreateFunction(params);
+        inputData = {params.inputData.data, params.padsBegin.data, params.padsEnd.data};
+        refOutData = {params.expectedOutput.data};
+    }
+
+private:
+    static std::shared_ptr<Function> CreateFunction(const PadParams& params) {
+        const auto data = std::make_shared<op::v0::Parameter>(params.inputData.type,
+                                                              params.inputData.shape);
+        const auto padsBegin = std::make_shared<op::v0::Parameter>(params.padsBegin.type,
+                                                                   params.padsBegin.shape);
+        const auto padsEnd = std::make_shared<op::v0::Parameter>(params.padsEnd.type,
+                                                                 params.padsEnd.shape);
+        const auto f = [&] {
+            if (params.useConstValue) {
+                // pad_value should be used only in CONSTANT mode
+                const auto padVal = op::v0::Constant::create(params.constantValue.type,
+                                                             params.constantValue.shape,
+                                                             params.constantValue.data.data());
+                return std::make_shared<Function>(std::make_shared<op::v1::Pad>(data,
+                                                                                padsBegin,
+                                                                                padsEnd,
+                                                                                padVal,
+                                                                                params.padMode),
+                                                  ParameterVector{data, padsBegin, padsEnd});
+            }
+
+            return std::make_shared<Function>(std::make_shared<op::v1::Pad>(data,
+                                                                            padsBegin,
+                                                                            padsEnd,
+                                                                            params.padMode),
+                                              ParameterVector{data, padsBegin, padsEnd});
+        }();
+        return f;
+    }
+};
+
+TEST_P(ReferencePadTestNonConstPadBeginPadEnd, CompareWithRefs) {
+    Exec();
+}
+
+class ReferencePadTestNonConstPadBeginPadEndTooLarge : public ReferencePadTestNonConstPadBeginPadEnd {};
+
+TEST_P(ReferencePadTestNonConstPadBeginPadEndTooLarge, CompareWithRefs) {
+    EXPECT_ANY_THROW(Exec());
+}
+
+class ReferencePadTestNonConstPadBeginPadEndParamsOk : public ReferencePadTestNonConstPadBeginPadEnd {};
+
+TEST_P(ReferencePadTestNonConstPadBeginPadEndParamsOk, CompareWithRefs) {
+    EXPECT_NO_THROW(Exec());
+}
+
 template <element::Type_t ET, element::Type_t ET_INT>
 std::vector<PadParams> generateParams() {
     using T = typename element_type_traits<ET>::value_type;
@@ -1005,6 +1063,9 @@ std::vector<PadParams> generateCombinedParams() {
 INSTANTIATE_TEST_SUITE_P(smoke_Pad_With_Hardcoded_Refs, ReferencePadTest,
     testing::ValuesIn(generateCombinedParams()), ReferencePadTest::getTestCaseName);
 
+INSTANTIATE_TEST_SUITE_P(smoke_Pad_With_Hardcoded_Refs, ReferencePadTestNonConstPadBeginPadEnd,
+    testing::ValuesIn(generateCombinedParams()), ReferencePadTest::getTestCaseName);
+
 template <element::Type_t ET, element::Type_t ET_INT>
 std::vector<PadParams> generateParamsTooLarge() {
     using T = typename element_type_traits<ET>::value_type;
@@ -1052,6 +1113,9 @@ std::vector<PadParams> generateCombinedParamsTooLarge() {
 INSTANTIATE_TEST_SUITE_P(smoke_Pad_With_Hardcoded_Refs, ReferencePadTestParamsTooLarge,
     testing::ValuesIn(generateCombinedParamsTooLarge()), ReferencePadTest::getTestCaseName);
 
+INSTANTIATE_TEST_SUITE_P(smoke_Pad_With_Hardcoded_Refs, ReferencePadTestNonConstPadBeginPadEndTooLarge,
+    testing::ValuesIn(generateCombinedParamsTooLarge()), ReferencePadTest::getTestCaseName);
+
 template <element::Type_t ET, element::Type_t ET_INT>
 std::vector<PadParams> generateParamsOk() {
     using T = typename element_type_traits<ET>::value_type;
@@ -1097,5 +1161,8 @@ std::vector<PadParams> generateCombinedParamsOk() {
 }
 
 INSTANTIATE_TEST_SUITE_P(smoke_Pad_With_Hardcoded_Refs, ReferencePadTestParamsOk,
+    testing::ValuesIn(generateCombinedParamsOk()), ReferencePadTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_Pad_With_Hardcoded_Refs, ReferencePadTestNonConstPadBeginPadEndParamsOk,
     testing::ValuesIn(generateCombinedParamsOk()), ReferencePadTest::getTestCaseName);
 } // namespace

--- a/ngraph/core/src/op/pad.cpp
+++ b/ngraph/core/src/op/pad.cpp
@@ -200,7 +200,26 @@ bool op::v1::Pad::evaluate_pad(const HostTensorVector& outputs, const HostTensor
     } else {
         pad_value = pad_zero_value.data();
     }
+
+    // compute pads_begin and pads_end CoordinateDiffs from pads_begin 
+    // and pads_end shapes and reshape output to determine shape
+    // (in case pads_begin and pads_end are Parameters, output is dynamic with static rank).
+    const auto* pads_begin = inputs[1]->get_data_ptr<int64_t>();
+    const auto* pads_end = inputs[2]->get_data_ptr<int64_t>();
+
+    CoordinateDiff pads_begin_coord(shape_size(inputs[1]->get_shape()));
+    pads_begin_coord.assign(pads_begin, pads_begin + shape_size(inputs[1]->get_shape()));
+    CoordinateDiff pads_end_coord(shape_size(inputs[2]->get_shape()));
+    pads_end_coord.assign(pads_end, pads_end + shape_size(inputs[2]->get_shape()));
+
+    auto data_shape = data->get_shape();
+    ov::Shape padded_shape(data_shape.size());
+    for (size_t i = 0; i < data_shape.size(); ++i) {
+        padded_shape[i] = data_shape[i] + pads_begin_coord[i] + pads_end_coord[i];
+    }
+
     const auto& out = outputs[0];
+    out->set_shape(padded_shape);
 
     ngraph::runtime::reference::pad(data->get_data_ptr<char>(),
                                     pad_value,
@@ -208,8 +227,8 @@ bool op::v1::Pad::evaluate_pad(const HostTensorVector& outputs, const HostTensor
                                     elem_size,
                                     data->get_shape(),
                                     out->get_shape(),
-                                    get_pads_begin(),
-                                    get_pads_end(),
+                                    pads_begin_coord,
+                                    pads_end_coord,
                                     get_pad_mode());
 
     return true;


### PR DESCRIPTION
### Details:
Previous implementation of Pad op doesn't support NonConst pads_begin and pads_end, which is lead to out of bounds exception

### Tickets:
 - 69443
