### PR TITLE
DRAGAN: fix random uniform input constant layout

### DIFF
--- a/model-optimizer/extensions/ops/random_uniform.py
+++ b/model-optimizer/extensions/ops/random_uniform.py
@@ -4,6 +4,7 @@
 import numpy as np
 
 from mo.graph.graph import Graph, Node
+from mo.graph.perm_inputs import PermuteInputs
 from mo.middle.passes.convert_data_type import np_data_type_to_destination_type
 from mo.ops.op import Op
 
@@ -50,6 +51,8 @@ class RandomUniform(Op):
         # ir data type is not equal to data node type.
         node.in_node(1)['correct_data_type'] = True
         node.in_node(2)['correct_data_type'] = True
+
+        PermuteInputs().set_input_permutation(node.in_node(0), node, 'output:0', 'shape')
 
 
 class AttributedRandomUniform(Op):


### PR DESCRIPTION
Root cause analysis: Shape for RandomUniform send as input constant. If it is 4D then it should be permuted.

Ticket: 65858


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR **NA**
* [x]  Transformation preserves original framework node names **NA**


Validation:
* [x]  Unit tests 
* [x]  Framework operation tests **NA**
* [x]  Transformation tests **NA**
* [x]  Model Optimizer IR Reader check **NA**

Documentation:
* [x]  Supported frameworks operations list **NA**
* [x]  Guide on how to convert the **public** model **NA**
* [x]  User guide update **NA**