### PR TITLE
Dragan: random uniform fix

### DIFF
--- a/model-optimizer/extensions/ops/random_uniform.py
+++ b/model-optimizer/extensions/ops/random_uniform.py
@@ -4,6 +4,7 @@
 import numpy as np
 
 from mo.graph.graph import Graph, Node
+from mo.graph.perm_inputs import PermuteInputs
 from mo.middle.passes.convert_data_type import np_data_type_to_destination_type
 from mo.ops.op import Op
 
@@ -50,6 +51,8 @@ class RandomUniform(Op):
         # ir data type is not equal to data node type.
         node.in_node(1)['correct_data_type'] = True
         node.in_node(2)['correct_data_type'] = True
+
+        PermuteInputs().set_input_permutation(node.in_node(0), node, 'output:0', 'shape')
 
 
 class AttributedRandomUniform(Op):

--- a/tests/layer_tests/tensorflow_tests/test_tf_RandomUniform.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_RandomUniform.py
@@ -26,7 +26,7 @@ class TestTFRandomUniform(CommonTFLayerTest):
             x = tf.compat.v1.placeholder(input_type, tf_x_shape, 'Input')
             if global_seed is not None:
                 tf.compat.v1.random.set_random_seed(global_seed)
-            random_uniform = tf.random.uniform(x_shape, seed=op_seed, dtype=input_type, minval=min_val,
+            random_uniform = tf.random.uniform(tf_x_shape, seed=op_seed, dtype=input_type, minval=min_val,
                                                maxval=max_val) + x
 
             tf.compat.v1.global_variables_initializer()
@@ -80,6 +80,7 @@ class TestTFRandomUniform(CommonTFLayerTest):
         dict(global_seed=32465, op_seed=48971, min_val=0.0, max_val=1.0, x_shape=[3, 7], input_type=tf.float32),
         marks=pytest.mark.precommit),
         dict(global_seed=None, op_seed=56197, min_val=-100, max_val=100, x_shape=[6], input_type=tf.float32),
+        dict(global_seed=None, op_seed=56197, min_val=-100, max_val=100, x_shape=[1, 2, 1, 1], input_type=tf.float32),
         dict(global_seed=78132, op_seed=None, min_val=-200, max_val=-50, x_shape=[5, 8], input_type=tf.int32),
         dict(global_seed=4571, op_seed=48971, min_val=1.5, max_val=2.3, x_shape=[7], input_type=tf.float32),
         dict(global_seed=32465, op_seed=12335, min_val=-150, max_val=-100, x_shape=[18], input_type=tf.int32)]


### PR DESCRIPTION
Root cause analysis: Shape for RandomUniform send as input constant. If it is 4D then it should be permuted.

Ticket: 65858


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR **NA**
* [x]  Transformation preserves original framework node names **NA**


Validation:
* [x]  Unit tests 
* [x]  Framework operation tests **NA**
* [x]  Transformation tests **NA**
* [x]  Model Optimizer IR Reader check **NA**

Documentation:
* [x]  Supported frameworks operations list **NA**
* [x]  Guide on how to convert the **public** model **NA**
* [x]  User guide update **NA**