### PR TITLE
[tools] fix input parameters parsing in python benchmark app

### DIFF
--- a/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
@@ -134,10 +134,10 @@ def get_files_by_extensions(paths_to_input, extensions):
             check_files_exist(files)
             return files
 
-    return get_files_by_extensions_for_not_list_of_files(paths_to_input, extensions)
+    return get_files_by_extensions_for_directory_or_list_of_files(paths_to_input, extensions)
 
 
-def get_files_by_extensions_for_not_list_of_files(paths_to_input, extensions):
+def get_files_by_extensions_for_directory_or_list_of_files(paths_to_input, extensions):
     input_files = list()
 
     for path_to_input in paths_to_input:
@@ -150,8 +150,8 @@ def get_files_by_extensions_for_not_list_of_files(paths_to_input, extensions):
             file_extension = get_extension(file)
             if file_extension in extensions:
                 input_files.append(file)
-        input_files.sort()
-        return input_files
+    input_files.sort()
+    return input_files
 
 
 def get_extension(file_path):


### PR DESCRIPTION
### Details:
 - *Allows to use -i image1 -i image2 -i image3. Without this changes only first parameter is processed*
