### PR TITLE
Update Transpose Sinking

### DIFF
--- a/inference-engine/src/transformations/include/transformations/common_optimizations/reshape_sequence_fusion.hpp
+++ b/inference-engine/src/transformations/include/transformations/common_optimizations/reshape_sequence_fusion.hpp
@@ -1,0 +1,28 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <transformations_visibility.hpp>
+
+#include <ngraph/pass/graph_rewrite.hpp>
+
+namespace ngraph {
+namespace pass {
+
+class TRANSFORMATIONS_API ReshapeSequenceFusion;
+
+}  // namespace pass
+}  // namespace ngraph
+
+/**
+ * @ingroup ie_transformation_common_api
+ * @brief ReshpaeSequenceFusion fuses sequence of Reshape operation into single Reshape
+ */
+
+class ngraph::pass::ReshapeSequenceFusion: public ngraph::pass::MatcherPass {
+public:
+    NGRAPH_RTTI_DECLARATION;
+    ReshapeSequenceFusion();
+};

--- a/inference-engine/src/transformations/include/transformations/common_optimizations/transpose_sinking.hpp
+++ b/inference-engine/src/transformations/include/transformations/common_optimizations/transpose_sinking.hpp
@@ -17,6 +17,7 @@ namespace ngraph {
 namespace pass {
 
 class TRANSFORMATIONS_API TransposeSinking;
+class TRANSFORMATIONS_API TransposeConvert;
 class TRANSFORMATIONS_API TransposeReduction;
 class TRANSFORMATIONS_API TransposeFQReduction;
 class TRANSFORMATIONS_API TransposeFuse;
@@ -46,6 +47,16 @@ public:
 
 /**
  * @ingroup ie_transformation_common_api
+ * @brief TransposeConvert transformation sinks Transpose through Convert
+ */
+class ngraph::pass::TransposeConvert : public ngraph::pass::MatcherPass {
+public:
+    NGRAPH_RTTI_DECLARATION;
+    TransposeConvert();
+};
+
+/**
+ * @ingroup ie_transformation_common_api
  * @brief TransposeFuse transformation eliminates 2 consequtive Transposes if they result in no changes to input or fuses them
  * to single Transpose if input gets changed
  */
@@ -65,6 +76,7 @@ public:
     TransposeSinking() {
         add_matcher<ngraph::pass::TransposeFQReduction>();
         add_matcher<ngraph::pass::TransposeReduction>();
+        add_matcher<ngraph::pass::TransposeConvert>();
         add_matcher<ngraph::pass::TransposeFuse>();
     }
 };

--- a/inference-engine/src/transformations/src/transformations/common_optimizations/common_optimizations.cpp
+++ b/inference-engine/src/transformations/src/transformations/common_optimizations/common_optimizations.cpp
@@ -114,7 +114,6 @@ bool ngraph::pass::CommonOptimizations::run_on_function(std::shared_ptr<ngraph::
     common_fusions->add_matcher<ngraph::pass::ShuffleChannelsFusion>(false);
     common_fusions->add_matcher<ngraph::pass::SpaceToBatchFusion>();
     common_fusions->add_matcher<ngraph::pass::BatchToSpaceFusion>();
-    common_fusions->add_matcher<ngraph::pass::TransposeToReshape>();
     common_fusions->set_name("ngraph::pass::CommonFusions");
 
     manager.register_pass<ngraph::pass::ConvertPadToGroupConvolution, false>();

--- a/inference-engine/src/transformations/src/transformations/common_optimizations/moc_transformations.cpp
+++ b/inference-engine/src/transformations/src/transformations/common_optimizations/moc_transformations.cpp
@@ -52,6 +52,7 @@
 #include <transformations/op_conversions/convert_divide.hpp>
 #include <transformations/common_optimizations/divide_fusion.hpp>
 #include <transformations/common_optimizations/subtract_fusion.hpp>
+#include <transformations/common_optimizations/reshape_sequence_fusion.hpp>
 
 NGRAPH_RTTI_DEFINITION(ngraph::pass::MOCTransformations, "MOCTransformations", 0);
 
@@ -134,6 +135,8 @@ bool ngraph::pass::MOCTransformations::run_on_function(std::shared_ptr<ngraph::F
     common_fusions->add_matcher<ngraph::pass::SplitConcatPairToInterpolateFusion>(m_use_shapes);
     common_fusions->add_matcher<ngraph::pass::DivideFusion>();
     common_fusions->add_matcher<ngraph::pass::SubtractFusion>();
+    common_fusions->add_matcher<ngraph::pass::TransposeToReshape>();
+    common_fusions->add_matcher<ngraph::pass::ReshapeSequenceFusion>();
     common_fusions->set_name("ngraph::pass::CommonFusions");
 
     manager.register_pass<ngraph::pass::BinarizeWeights>();

--- a/inference-engine/src/transformations/src/transformations/common_optimizations/reshape_sequence_fusion.cpp
+++ b/inference-engine/src/transformations/src/transformations/common_optimizations/reshape_sequence_fusion.cpp
@@ -1,0 +1,68 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/common_optimizations/reshape_sequence_fusion.hpp"
+#include "transformations/utils/utils.hpp"
+
+#include <memory>
+#include <vector>
+
+#include <ngraph/opsets/opset6.hpp>
+#include <ngraph/rt_info.hpp>
+#include <ngraph/pattern/op/wrap_type.hpp>
+#include "itt.hpp"
+
+
+NGRAPH_RTTI_DEFINITION(ngraph::pass::ReshapeSequenceFusion, "ReshapeSequenceFusion", 0);
+
+namespace {
+bool has_valid_pattern(const std::shared_ptr<ngraph::Node> & node) {
+    auto const_node = std::dynamic_pointer_cast<opset8::Constant>(node);
+    if (!const_node) return false;
+    const auto & values = const_node->cast_vector<int64_t>();
+    // We can not fuse Reshapes if their pattern values have special numbers like -1 and 0
+    return std::all_of(values.cbegin(), values.cend(), [](int64_t value) { return value > 0;});
+}
+}
+
+ngraph::pass::ReshapeSequenceFusion::ReshapeSequenceFusion() {
+    MATCHER_SCOPE(ReshapeSequenceFusion);
+    auto reshape_input = pattern::any_input();
+    auto reshape_a_pattern = pattern::wrap_type<opset8::Constant>();
+    auto reshape_a = pattern::wrap_type<opset8::Reshape>({reshape_input, reshape_a_pattern}, pattern::consumers_count(1));
+    auto reshape_b_pattern = pattern::wrap_type<opset8::Constant>();
+    auto reshape_b = pattern::wrap_type<opset8::Reshape>({reshape_a, reshape_b_pattern});
+
+    matcher_pass_callback callback = [=](pattern::Matcher& m) {
+        const auto & pattern_map = m.get_pattern_value_map();
+        auto input = pattern_map.at(reshape_input);
+        auto reshape = m.get_match_root();
+
+        auto pattern_a = pattern_map.at(reshape_a_pattern).get_node_shared_ptr();
+        auto pattern_b = pattern_map.at(reshape_a_pattern).get_node_shared_ptr();
+        // skip reshapes which patterns contain special numbers like -1 or 0
+        if (!has_valid_pattern(pattern_a) || !has_valid_pattern(pattern_b)) {
+            return false;
+        }
+
+        // vector of nodes which runtime info must be copied
+        NodeVector nodes{pattern_map.at(reshape_a).get_node_shared_ptr(), reshape};
+        while (std::dynamic_pointer_cast<opset8::Reshape>(input.get_node_shared_ptr())) {
+            auto node = input.get_node_shared_ptr();
+            if (!has_valid_pattern(node->get_input_node_shared_ptr(1)) ||
+                input.get_target_inputs().size() != 1) {
+                break;
+            }
+            nodes.push_back(node);
+            input = node->input_value(0);
+        }
+
+        reshape->input(0).replace_source_output(input);
+        copy_runtime_info(nodes, reshape);
+        return false;
+    };
+
+    auto m = std::make_shared<ngraph::pattern::Matcher>(reshape_b, matcher_name);
+    this->register_matcher(m, callback);
+}

--- a/inference-engine/src/transformations/src/transformations/common_optimizations/reshape_sequence_fusion.cpp
+++ b/inference-engine/src/transformations/src/transformations/common_optimizations/reshape_sequence_fusion.cpp
@@ -8,7 +8,7 @@
 #include <memory>
 #include <vector>
 
-#include <ngraph/opsets/opset6.hpp>
+#include <ngraph/opsets/opset8.hpp>
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include "itt.hpp"
@@ -18,7 +18,7 @@ NGRAPH_RTTI_DEFINITION(ngraph::pass::ReshapeSequenceFusion, "ReshapeSequenceFusi
 
 namespace {
 bool has_valid_pattern(const std::shared_ptr<ngraph::Node> & node) {
-    auto const_node = std::dynamic_pointer_cast<opset8::Constant>(node);
+    auto const_node = std::dynamic_pointer_cast<ngraph::opset8::Constant>(node);
     if (!const_node) return false;
     const auto & values = const_node->cast_vector<int64_t>();
     // We can not fuse Reshapes if their pattern values have special numbers like -1 and 0

--- a/inference-engine/src/transformations/src/transformations/common_optimizations/reshape_sequence_fusion.cpp
+++ b/inference-engine/src/transformations/src/transformations/common_optimizations/reshape_sequence_fusion.cpp
@@ -40,7 +40,7 @@ ngraph::pass::ReshapeSequenceFusion::ReshapeSequenceFusion() {
         auto reshape = m.get_match_root();
 
         auto pattern_a = pattern_map.at(reshape_a_pattern).get_node_shared_ptr();
-        auto pattern_b = pattern_map.at(reshape_a_pattern).get_node_shared_ptr();
+        auto pattern_b = pattern_map.at(reshape_b_pattern).get_node_shared_ptr();
         // skip reshapes which patterns contain special numbers like -1 or 0
         if (!has_valid_pattern(pattern_a) || !has_valid_pattern(pattern_b)) {
             return false;

--- a/inference-engine/src/transformations/src/transformations/common_optimizations/transpose_to_reshape.cpp
+++ b/inference-engine/src/transformations/src/transformations/common_optimizations/transpose_to_reshape.cpp
@@ -18,100 +18,93 @@ NGRAPH_RTTI_DEFINITION(ngraph::pass::TransposeToReshape, "TransposeToReshape", 0
 
 using namespace ngraph;
 
-namespace {
-
-bool replace_transpose_with_reshape(const std::shared_ptr<Node>& transpose) {
-    auto data = transpose->input_value(0);
-    const auto input_shape = transpose->input(0).get_partial_shape();
-
-    const size_t input_shape_rank = input_shape.rank().get_length();
-
-    auto order = ov::as_type_ptr<opset6::Constant>(transpose->input_value(1).get_node_shared_ptr());
-    if (!order || !ngraph::shape_size(order->get_shape())) {
-        return false;
-    }
-
-    const auto order_value = order->cast_vector<int64_t>();
-
-    // Check that transpose order without 1 dims has an ascending order
-    int64_t last_dim(-1);
-    for (size_t i = 0; i < input_shape_rank; ++i) {
-        if (input_shape[order_value[i]].is_dynamic() || input_shape[order_value[i]] != 1) {
-            if (order_value[i] < last_dim) {
-                return false;
-            }
-            last_dim = order_value[i];
-        }
-    }
-
-    // Transpose operation can be removed if original transpose order is sorted
-    // or dimension that changes their places equal to 1
-    using DimensionToPosition = struct {
-        Dimension dim;
-        size_t pos;
-    };
-    std::vector<DimensionToPosition> dims;
-    for (size_t i = 0; i < input_shape_rank; ++i) {
-        if (order_value[i] != static_cast<int64_t>(i)) {
-            dims.push_back({ input_shape[order_value[i]], i });
-        }
-    }
-
-    // If number of dimensions != 1 to move equal to 0 we can remove this Transpose
-    if (count_if(dims.begin(), dims.end(), [](const DimensionToPosition& item) {
-        return !(item.dim.is_static() && item.dim.get_length() == 1);
-        }) == 0) {
-        return replace_output_update_name(transpose->output(0), transpose->input_value(0));
-    }
-
-    // Transpose can be replaced with Reshape in two ways:
-    // 1. Reshape with dims as Constant
-    // 2. Reshape with dims as input (ShapeOf->Gather)
-    //
-    // The first case is possible only if one or less dynamic dimensions changes their position
-    // For example: input_shape {?, 3, 1, ?} and order {0, 1, 3, 2} can be replaced with Reshape
-    // with Constant {0, 3, -1, 1} but if input_shape {?, 1, 1, ?} and order {1, 0, 3, 2} transpose
-    // cannot be replaced int the same way and in this case its only possible to use Gather(ShapeOf,
-    // order)
-
-    Output<Node> reshape_dim;
-    NodeVector new_ops;
-
-    if (count_if(dims.begin(), dims.end(), [](const DimensionToPosition& item) {
-        return item.dim.is_dynamic();
-        }) < 2) {
-        std::vector<int64_t> reshape_value(input_shape_rank, 0);
-        for (const auto& item : dims) {
-            reshape_value[item.pos] = item.dim.is_dynamic() ? -1 : item.dim.get_length();
-        }
-        reshape_dim =
-            opset3::Constant::create(element::i64, Shape{ reshape_value.size() }, reshape_value);
-    } else {
-        auto shape_of = std::make_shared<opset3::ShapeOf>(data);
-        new_ops.push_back(shape_of);
-        reshape_dim = std::make_shared<opset3::Gather>(
-            shape_of, order, opset3::Constant::create(element::i64, Shape{ 1 }, { 0 }));
-        new_ops.push_back(reshape_dim.get_node_shared_ptr());
-    }
-
-    auto reshape_op = std::make_shared<opset3::Reshape>(data, reshape_dim, true);
-    new_ops.push_back(reshape_op);
-
-    reshape_op->set_friendly_name(transpose->get_friendly_name());
-    copy_runtime_info(transpose, new_ops);
-    replace_node(transpose, reshape_op);
-    return true;
-}
-
-} // namespace
-
 ngraph::pass::TransposeToReshape::TransposeToReshape() {
     MATCHER_SCOPE(TransposeToReshape);
 
     auto transpose_label = pattern::wrap_type<opset6::Transpose>(
         { pattern::any_input(pattern::has_static_rank()), pattern::wrap_type<opset6::Constant>() });
     ngraph::matcher_pass_callback matcher_pass_callback = [=](ngraph::pattern::Matcher& m) {
-        return replace_transpose_with_reshape(m.get_match_root());
+        auto transpose = m.get_match_root();
+        auto data = transpose->input_value(0);
+        const auto input_shape = transpose->input(0).get_partial_shape();
+
+        const size_t input_shape_rank = input_shape.rank().get_length();
+
+        auto order = ov::as_type_ptr<opset6::Constant>(transpose->input_value(1).get_node_shared_ptr());
+        if (!order || !ngraph::shape_size(order->get_shape())) {
+            return false;
+        }
+
+        const auto order_value = order->cast_vector<int64_t>();
+
+        // Check that transpose order without 1 dims has an ascending order
+        int64_t last_dim(-1);
+        for (size_t i = 0; i < input_shape_rank; ++i) {
+            if (input_shape[order_value[i]].is_dynamic() || input_shape[order_value[i]] != 1) {
+                if (order_value[i] < last_dim) {
+                    return false;
+                }
+                last_dim = order_value[i];
+            }
+        }
+
+        // Transpose operation can be removed if original transpose order is sorted
+        // or dimension that changes their places equal to 1
+        using DimensionToPosition = struct {
+            Dimension dim;
+            size_t pos;
+        };
+        std::vector<DimensionToPosition> dims;
+        for (size_t i = 0; i < input_shape_rank; ++i) {
+            if (order_value[i] != static_cast<int64_t>(i)) {
+                dims.push_back({ input_shape[order_value[i]], i });
+            }
+        }
+
+        // If number of dimensions != 1 to move equal to 0 we can remove this Transpose
+        if (count_if(dims.begin(), dims.end(), [](const DimensionToPosition& item) {
+            return !(item.dim.is_static() && item.dim.get_length() == 1);
+        }) == 0) {
+            return replace_output_update_name(transpose->output(0), transpose->input_value(0));
+        }
+
+        // Transpose can be replaced with Reshape in two ways:
+        // 1. Reshape with dims as Constant
+        // 2. Reshape with dims as input (ShapeOf->Gather)
+        //
+        // The first case is possible only if one or less dynamic dimensions changes their position
+        // For example: input_shape {?, 3, 1, ?} and order {0, 1, 3, 2} can be replaced with Reshape
+        // with Constant {0, 3, -1, 1} but if input_shape {?, 1, 1, ?} and order {1, 0, 3, 2} transpose
+        // cannot be replaced int the same way and in this case its only possible to use Gather(ShapeOf,
+        // order)
+
+        Output<Node> reshape_dim;
+        NodeVector new_ops;
+
+        if (count_if(dims.begin(), dims.end(), [](const DimensionToPosition& item) {
+            return item.dim.is_dynamic();
+        }) < 2) {
+            std::vector<int64_t> reshape_value(input_shape_rank, 0);
+            for (const auto& item : dims) {
+                reshape_value[item.pos] = item.dim.is_dynamic() ? -1 : item.dim.get_length();
+            }
+            reshape_dim =
+                    opset3::Constant::create(element::i64, Shape{ reshape_value.size() }, reshape_value);
+        } else {
+            auto shape_of = std::make_shared<opset3::ShapeOf>(data);
+            new_ops.push_back(shape_of);
+            reshape_dim = std::make_shared<opset3::Gather>(
+                    shape_of, order, opset3::Constant::create(element::i64, Shape{ 1 }, { 0 }));
+            new_ops.push_back(reshape_dim.get_node_shared_ptr());
+        }
+
+        auto reshape_op = register_new_node<opset3::Reshape>(data, reshape_dim, true);
+        new_ops.push_back(reshape_op);
+
+        reshape_op->set_friendly_name(transpose->get_friendly_name());
+        copy_runtime_info(transpose, new_ops);
+        replace_node(transpose, reshape_op);
+        return true;
     };
 
     auto m = std::make_shared<ngraph::pattern::Matcher>(transpose_label, matcher_name);

--- a/inference-engine/tests/functional/inference_engine/transformations/reshape_sequence_fusion.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/reshape_sequence_fusion.cpp
@@ -1,0 +1,94 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <memory>
+#include <queue>
+
+#include <ngraph/function.hpp>
+#include <ngraph/opsets/opset6.hpp>
+#include <transformations/common_optimizations/reshape_sequence_fusion.hpp>
+
+#include "common_test_utils/ngraph_test_utils.hpp"
+
+
+using namespace testing;
+using namespace ngraph;
+
+namespace {
+Output<Node> reshape(Output<Node> input, std::vector<int64_t> values, bool special_zero = true) {
+    return std::make_shared<opset6::Reshape>(input,
+                opset6::Constant::create(element::i64, Shape{values.size()}, values), special_zero);
+}
+}
+
+TEST_F(TransformationTestsF, ReshapeSequenceFusion1) {
+    {
+        auto data = std::make_shared<opset6::Parameter>(element::f32, Shape{1, 2, 3});
+        auto a = reshape(data, {3, 2});
+        auto b = reshape(a, {2, 3});
+        auto c = reshape(b, {6});
+        function = std::make_shared<Function>(OutputVector{c}, ParameterVector{data});
+
+        manager.register_pass<pass::ReshapeSequenceFusion>();
+    }
+
+    {
+        auto data = std::make_shared<opset6::Parameter>(element::f32, Shape{1, 2, 3});
+        auto c = reshape(data, {6});
+        function_ref = std::make_shared<Function>(OutputVector{c}, ParameterVector{data});
+    }
+}
+
+TEST_F(TransformationTestsF, ReshapeSequenceFusion2) {
+    {
+        auto data = std::make_shared<opset6::Parameter>(element::f32, Shape{1, 2, 3});
+        auto a = reshape(data, {3, 2});
+        auto b = reshape(a, {6});
+        function = std::make_shared<Function>(OutputVector{b}, ParameterVector{data});
+
+        manager.register_pass<pass::ReshapeSequenceFusion>();
+    }
+
+    {
+        auto data = std::make_shared<opset6::Parameter>(element::f32, Shape{1, 2, 3});
+        auto c = reshape(data, {6});
+        function_ref = std::make_shared<Function>(OutputVector{c}, ParameterVector{data});
+    }
+}
+
+TEST_F(TransformationTestsF, ReshapeSequenceFusionNeg1) {
+    {
+        auto data = std::make_shared<opset6::Parameter>(element::f32, Shape{1, 2, 3});
+        auto a = reshape(data, {-1, 2});
+        auto b = reshape(a, {6});
+        function = std::make_shared<Function>(OutputVector{b}, ParameterVector{data});
+
+        manager.register_pass<pass::ReshapeSequenceFusion>();
+    }
+}
+
+TEST_F(TransformationTestsF, ReshapeSequenceFusionNeg2) {
+    {
+        auto data = std::make_shared<opset6::Parameter>(element::f32, Shape{1, 2, 3});
+        auto a = reshape(data, {-1, 3});
+        auto b = reshape(a, {6});
+        function = std::make_shared<Function>(OutputVector{b}, ParameterVector{data});
+
+        manager.register_pass<pass::ReshapeSequenceFusion>();
+    }
+}
+
+TEST_F(TransformationTestsF, ReshapeSequenceFusionNeg3) {
+    {
+        auto data = std::make_shared<opset6::Parameter>(element::f32, Shape{1, 2, 3});
+        auto a = reshape(data, {2, 3});
+        auto b = reshape(a, {6});
+        function = std::make_shared<Function>(OutputVector{a, b}, ParameterVector{data});
+
+        manager.register_pass<pass::ReshapeSequenceFusion>();
+    }
+}

--- a/inference-engine/tests/functional/inference_engine/transformations/reshape_sequence_fusion.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/reshape_sequence_fusion.cpp
@@ -92,3 +92,14 @@ TEST_F(TransformationTestsF, ReshapeSequenceFusionNeg3) {
         manager.register_pass<pass::ReshapeSequenceFusion>();
     }
 }
+
+TEST_F(TransformationTestsF, ReshapeSequenceFusionNeg4) {
+    {
+        auto data = std::make_shared<opset6::Parameter>(element::f32, Shape{1, 2, 3});
+        auto a = reshape(data, {2, 3});
+        auto b = reshape(a, {0, 3});
+        function = std::make_shared<Function>(OutputVector{b}, ParameterVector{data});
+
+        manager.register_pass<pass::ReshapeSequenceFusion>();
+    }
+}


### PR DESCRIPTION
### Description
* Added new transformation ReshapeSequenceFusion which fuses sequence of Reshapes to single Reshape for simple cases when Reshapes takes Constants without special numbers like 0 or -1.
* Added TransposeConvert transformation which propagates Transpose through Convert. This becomes very useful for cases when PreProcessing was used and original model contained Transpose at the beginning. So now this transposes will be eliminated.
*  Move TransposeToReshape transformation into MOC pipeline as it is shape insensitive transformation.

### Tickets
XXX-71116
XXX-60458