### PR TITLE
[OV2.0] 'set_memory_type' support for preprocessing input

### DIFF
--- a/inference-engine/src/transformations/include/transformations/rt_info/attributes.hpp
+++ b/inference-engine/src/transformations/include/transformations/rt_info/attributes.hpp
@@ -9,6 +9,7 @@
 #include <mutex>
 #include <ngraph/factory.hpp>
 #include <ngraph/node.hpp>
+#include <openvino/core/preprocess/input_tensor_info.hpp>
 #include <openvino/core/variant.hpp>
 #include <set>
 #include <transformations/rt_info/disable_constant_folding.hpp>

--- a/inference-engine/src/transformations/src/transformations/rt_info/attributes.cpp
+++ b/inference-engine/src/transformations/src/transformations/rt_info/attributes.cpp
@@ -15,6 +15,7 @@ ov::pass::Attributes::Attributes() {
     register_factory<OldApiMapElementType>();
     register_factory<LayoutAttribute>();
     register_factory<Decompression>();
+    register_factory<ov::preprocess::TensorInfoMemoryType>();
 }
 
 ov::Variant* ov::pass::Attributes::create_by_type_info(const ov::DiscreteTypeInfo& type_info) {

--- a/inference-engine/tests/functional/inference_engine/ir_serialization/rt_info_deserialization.cpp
+++ b/inference-engine/tests/functional/inference_engine/ir_serialization/rt_info_deserialization.cpp
@@ -27,6 +27,7 @@
 #include "ngraph/variant.hpp"
 #include "ngraph/pass/manager.hpp"
 #include "openvino/runtime/core.hpp"
+#include "openvino/core/preprocess/input_tensor_info.hpp"
 
 using namespace ngraph;
 
@@ -644,6 +645,7 @@ TEST_F(RTInfoDeserialization, InputAndOutputV11) {
                     <rt_info>
                         <attribute name="fused_names" version="0" value="test1,test2"/>
                         <attribute name="layout" version="0" layout="[N,C,H,W]" />
+                        <attribute name="memory_type" version="0" value="test_memory_type" />
                     </rt_info>
                     <dim>1</dim>
                     <dim>3</dim>
@@ -731,6 +733,9 @@ TEST_F(RTInfoDeserialization, InputAndOutputV11) {
     auto param = f->get_parameters()[0];
     check_fused_names(param->output(0).get_rt_info(), "test1,test2");
     EXPECT_EQ(param->get_layout(), "NCHW");
+    auto var0 = std::dynamic_pointer_cast<ov::preprocess::TensorInfoMemoryType>(
+            f->input(0).get_rt_info()[ov::preprocess::TensorInfoMemoryType::get_type_info_static()]);
+    EXPECT_EQ(var0->get(), "test_memory_type");
 
     auto result = f->get_result();
     check_fused_names(result->input(0).get_rt_info(), "test5,test6");

--- a/inference-engine/tests/functional/inference_engine/ir_serialization/rt_info_serialization.cpp
+++ b/inference-engine/tests/functional/inference_engine/ir_serialization/rt_info_serialization.cpp
@@ -12,6 +12,7 @@
 #include "ie_core.hpp"
 #include "ngraph/ngraph.hpp"
 #include "transformations/serialize.hpp"
+#include <openvino/core/preprocess/pre_post_process.hpp>
 #include <openvino/opsets/opset8.hpp>
 #include <transformations/rt_info/attributes.hpp>
 #include "frontend_manager/frontend_manager.hpp"
@@ -185,6 +186,9 @@ TEST_F(RTInfoSerializationTest, all_attributes_v11) {
         auto result = std::make_shared<ov::opset8::Result>(add);
         result->set_layout("????");
         function = std::make_shared<ngraph::Function>(ResultVector{result}, ParameterVector{data});
+        auto p = ov::preprocess::PrePostProcessor(function);
+        p.input().tensor().set_memory_type("test_memory_type");
+        function = p.build();
     }
 
     pass::Manager m;
@@ -210,6 +214,9 @@ TEST_F(RTInfoSerializationTest, all_attributes_v11) {
 
     auto add = f->get_results()[0]->get_input_node_ptr(0);
     EXPECT_EQ(f->get_parameters()[0]->get_layout(), "NCHW");
+    auto var0 = std::dynamic_pointer_cast<ov::preprocess::TensorInfoMemoryType>(
+            f->input(0).get_rt_info()[ov::preprocess::TensorInfoMemoryType::get_type_info_static()]);
+    EXPECT_EQ(var0->get(), "test_memory_type");
     EXPECT_EQ(f->get_results()[0]->get_layout(), "????");
     check_info(add->get_rt_info());
     check_info(add->input(0).get_rt_info());

--- a/ngraph/core/include/openvino/core/preprocess/input_tensor_info.hpp
+++ b/ngraph/core/include/openvino/core/preprocess/input_tensor_info.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "openvino/core/attribute_visitor.hpp"
 #include "openvino/core/core_visibility.hpp"
 #include "openvino/core/layout.hpp"
 #include "openvino/core/preprocess/color_format.hpp"
@@ -11,6 +12,20 @@
 
 namespace ov {
 namespace preprocess {
+
+class OPENVINO_API TensorInfoMemoryType : public VariantImpl<std::string> {
+public:
+    OPENVINO_RTTI("memory_type", "0");
+
+    TensorInfoMemoryType() = default;
+
+    explicit TensorInfoMemoryType(const std::string& value) : VariantImpl<std::string>(value) {}
+
+    bool visit_attributes(AttributeVisitor& visitor) override {
+        visitor.on_attribute("value", m_value);
+        return true;
+    }
+};
 
 /// \brief Information about user's input tensor. By default, it will be initialized to same data (type/shape/etc) as
 /// network's input parameter User application can override particular parameters (like 'element_type') according to
@@ -158,6 +173,14 @@ public:
     /// \return Rvalue reference to 'this' to allow chaining with other calls in a builder-like manner.
     InputTensorInfo&& set_color_format(const ov::preprocess::ColorFormat& format,
                                        const std::vector<std::string>& sub_names = {}) &&;
+
+    /// \brief Set memory type runtime information for user's input tensor
+    ///
+    /// \param memory_type Memory type. Refer to specific plugin's documentation for exact string format
+    ///
+    /// \return Reference to 'this' to allow chaining with other calls in a builder-like manner
+    InputTensorInfo& set_memory_type(const std::string& memory_type) &;
+    InputTensorInfo&& set_memory_type(const std::string& memory_type) &&;
 };
 
 }  // namespace preprocess


### PR DESCRIPTION
### Details:
 - Support 'set_memory_type(string)' for preprocessing input tensor info
 - It defines rt_info "memory_type" for parameter's output tensor
      - `<attribute name="memory_type" version="0" value="some_memory_type" />
 - Testing: unit tests + serialization/deserialization tests

### Tickets:
 - 66126
