### PR TITLE
[TemplateFuncTests] RGBX->RGB: Increase image size to avoid test failures on some platforms

### DIFF
--- a/docs/template_plugin/tests/functional/subgraph_reference/preprocess_legacy.cpp
+++ b/docs/template_plugin/tests/functional/subgraph_reference/preprocess_legacy.cpp
@@ -108,8 +108,8 @@ TEST_F(ReferencePreprocessLegacyTest, resize) {
 }
 
 TEST_F(ReferencePreprocessLegacyTest, bgrx_to_bgr) {
-    const int h = 32;
-    const int w = 32;
+    const int h = 320;
+    const int w = 320;
     auto rgbx_input = std::vector<uint8_t>(h * w * 4, 0);
     for (auto i = 0; i < h * w * 4; i++) {
         rgbx_input[i] = i % 256;
@@ -138,8 +138,8 @@ TEST_F(ReferencePreprocessLegacyTest, bgrx_to_bgr) {
 }
 
 TEST_F(ReferencePreprocessLegacyTest, rgbx_to_bgr) {
-    const int h = 32;
-    const int w = 32;
+    const int h = 320;
+    const int w = 320;
     auto rgbx_input = std::vector<uint8_t>(h * w * 4, 0);
     for (auto i = 0; i < h * w * 4; i++) {
         rgbx_input[i] = i % 256;

--- a/docs/template_plugin/tests/functional/subgraph_reference/preprocess_legacy.cpp
+++ b/docs/template_plugin/tests/functional/subgraph_reference/preprocess_legacy.cpp
@@ -108,8 +108,8 @@ TEST_F(ReferencePreprocessLegacyTest, resize) {
 }
 
 TEST_F(ReferencePreprocessLegacyTest, bgrx_to_bgr) {
-    const int h = 320;
-    const int w = 320;
+    const int h = 160;
+    const int w = 160;
     auto rgbx_input = std::vector<uint8_t>(h * w * 4, 0);
     for (auto i = 0; i < h * w * 4; i++) {
         rgbx_input[i] = i % 256;
@@ -138,8 +138,8 @@ TEST_F(ReferencePreprocessLegacyTest, bgrx_to_bgr) {
 }
 
 TEST_F(ReferencePreprocessLegacyTest, rgbx_to_bgr) {
-    const int h = 320;
-    const int w = 320;
+    const int h = 160;
+    const int w = 160;
     auto rgbx_input = std::vector<uint8_t>(h * w * 4, 0);
     for (auto i = 0; i < h * w * 4; i++) {
         rgbx_input[i] = i % 256;

--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/preprocess/preprocess_builders.hpp
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/preprocess/preprocess_builders.hpp
@@ -387,7 +387,7 @@ inline std::shared_ptr<Function> cvt_color_i420_to_bgr_three_planes() {
 
 inline std::shared_ptr<Function> cvt_color_bgrx_to_bgr() {
     using namespace ov::preprocess;
-    auto function = create_preprocess_2inputs(element::f32, PartialShape{1, 32, 32, 3});
+    auto function = create_preprocess_2inputs(element::f32, PartialShape{1, 160, 160, 3});
     auto p = PrePostProcessor(function);
     p.input(0).tensor().set_color_format(ColorFormat::BGRX);
     p.input(0).preprocess().convert_color(ColorFormat::BGR);


### PR DESCRIPTION
### Details:
- Increase image size to avoid test failures on some platforms
- In legacy preprocessing, there is an assert 'length >= nlanes' and 'nlanes' value depends on machine architecture
- Set 160x160 test image to guarantee that image size >= nlanes

- Also increased image size for 'plugin shared tests' to ensure the same (even though tests do not work with legacy preprocessing)


### Tickets:
 - 71390
