### PR TITLE
[GPU] Make cl_dump to distinguish program

### DIFF
--- a/src/plugins/intel_gpu/src/graph/kernel_runner.cpp
+++ b/src/plugins/intel_gpu/src/graph/kernel_runner.cpp
@@ -174,7 +174,7 @@ std::vector<std::chrono::nanoseconds> kernel_runner::run_kernels(const kernel_se
         batch_end = batch_start + current_compilation_batch;
 
         std::vector<kernel::ptr> kernels;
-        kernels_cache cache(_engine);
+        kernels_cache cache(_engine, program_id);
 
         for (auto it = batch_start; it < batch_end; it++) {
             auto kernel_id = cache.set_kernel_source(it->kernels[0].code.kernelString, false);

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -94,7 +94,6 @@ program::program(engine& engine_ref,
                  bool is_body_program)
     : _engine(engine_ref),
       _stream(_engine.create_stream()),
-      _kernels_cache(std::unique_ptr<kernels_cache>(new kernels_cache(_engine))),
       options(options),
       processing_order(),
       tuning_cache(nullptr),
@@ -103,7 +102,8 @@ program::program(engine& engine_ref,
     set_options();
     pm = std::unique_ptr<pass_manager>(new pass_manager(*this));
     prepare_nodes(topology);
-    _kernels_cache->set_batch_header_str(kernel_selector::KernelBase::get_db().get_batch_header_str());
+    _kernels_cache = std::unique_ptr<kernels_cache>(new kernels_cache(_engine, prog_id,
+                                                                      kernel_selector::KernelBase::get_db().get_batch_header_str()));
     if (no_optimizations) {
         init_graph();
     } else {
@@ -116,13 +116,13 @@ program::program(engine& engine_ref,
                  build_options const& options,
                  bool is_internal)
     : _engine(engine_ref),
-      _kernels_cache(std::unique_ptr<kernels_cache>(new kernels_cache(_engine))),
       options(options),
       processing_order(),
       tuning_cache(nullptr) {
     init_primitives();
     set_options();
-    _kernels_cache->set_batch_header_str(kernel_selector::KernelBase::get_db().get_batch_header_str());
+    _kernels_cache = std::unique_ptr<kernels_cache>(new kernels_cache(_engine, prog_id,
+                                                                      kernel_selector::KernelBase::get_db().get_batch_header_str()));
     pm = std::unique_ptr<pass_manager>(new pass_manager(*this));
     prepare_nodes(nodes);
     build_program(is_internal);
@@ -145,7 +145,7 @@ void program::init_primitives() {
 }
 
 void program::compile() {
-    _kernels_cache->build_all(prog_id);
+    _kernels_cache->build_all();
 }
 
 void program::init_kernels() {

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -145,7 +145,7 @@ void program::init_primitives() {
 }
 
 void program::compile() {
-    _kernels_cache->build_all();
+    _kernels_cache->build_all(prog_id);
 }
 
 void program::init_kernels() {

--- a/src/plugins/intel_gpu/src/runtime/kernels_cache.hpp
+++ b/src/plugins/intel_gpu/src/runtime/kernels_cache.hpp
@@ -73,20 +73,21 @@ public:
 private:
     static std::mutex _mutex;
     engine& _engine;
+    uint32_t _prog_id = 0;
     kernels_code _kernels_code;
     std::atomic<bool> _pending_compilation{false};
     std::map<const std::string, kernel::ptr> _kernels;
     std::vector<std::string> batch_header_str;
 
     void get_program_source(const kernels_code& kernels_source_code, std::vector<batch_program>*) const;
-    void build_batch(const engine& build_engine, const batch_program& batch, uint32_t prog_id = 0);
+    void build_batch(const engine& build_engine, const batch_program& batch);
 
     std::string get_cache_path() const;
     bool is_cache_enabled() const;
     size_t get_max_kernels_per_batch() const;
 
 public:
-    explicit kernels_cache(engine& engine);
+    explicit kernels_cache(engine& engine, uint32_t prog_id, const std::vector<std::string>& batch_header_str = {});
     kernel_id set_kernel_source(const std::shared_ptr<kernel_string>& kernel_string,
                                 bool dump_custom_program);
     kernel::ptr get_kernel(kernel_id id) const;
@@ -94,7 +95,7 @@ public:
         batch_header_str = std::move(batch_headers);
     }
     // forces compilation of all pending kernels/programs
-    void build_all(uint32_t prog_id = 0);
+    void build_all();
     void reset();
 };
 

--- a/src/plugins/intel_gpu/src/runtime/kernels_cache.hpp
+++ b/src/plugins/intel_gpu/src/runtime/kernels_cache.hpp
@@ -79,7 +79,7 @@ private:
     std::vector<std::string> batch_header_str;
 
     void get_program_source(const kernels_code& kernels_source_code, std::vector<batch_program>*) const;
-    void build_batch(const engine& build_engine, const batch_program& batch);
+    void build_batch(const engine& build_engine, const batch_program& batch, uint32_t prog_id = 0);
 
     std::string get_cache_path() const;
     bool is_cache_enabled() const;
@@ -94,7 +94,7 @@ public:
         batch_header_str = std::move(batch_headers);
     }
     // forces compilation of all pending kernels/programs
-    void build_all();
+    void build_all(uint32_t prog_id = 0);
     void reset();
 };
 


### PR DESCRIPTION
### Details:
 - Previously cl_dump was using same file name for all programs, so that the internal program and body programs are being overwritten. Fixt that issue.
 - Removed redundant copy of kernel string in kernel_cahce

### Tickets:

