### PR TITLE
oneDNN: fixed build with mullti-config generators

### DIFF
--- a/inference-engine/thirdparty/clDNN/CMakeLists.txt
+++ b/inference-engine/thirdparty/clDNN/CMakeLists.txt
@@ -13,16 +13,7 @@ project("${CLDNN__PROJ_NAME}")
 # ======================================================================================================
 # ======================================================================================================
 if (ENABLE_ONEDNN_FOR_GPU)
-    get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
-    if (isMultiConfig)
-        ExternalProject_Get_property(onednn_gpu_build SOURCE_DIR)
-        ExternalProject_Get_property(onednn_gpu_build BINARY_DIR)
-
-        set(ONEDNN_INCLUDE_DIRS "${BINARY_DIR}/include/" "${SOURCE_DIR}/include/")
-        set(ONEDNN_LIBRARY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/$<CONFIG>/${CMAKE_STATIC_LIBRARY_PREFIX}onednn_gpu${CMAKE_STATIC_LIBRARY_SUFFIX}")
-    else()
-        set(ONEDNN_LIBRARY "onednn_gpu")
-    endif()
+    set(ONEDNN_LIBRARY onednn_gpu_tgt)
 endif()
 
 if(ENABLE_GPU_DEBUG_CAPS)

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -134,106 +134,54 @@ if(ENABLE_ONEDNN_FOR_GPU)
     function(build_onednn_gpu)
         include(ExternalProject)
         set(ONEDNN_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/onednn_gpu_build/")
-        set(ONEDNN_INSTALL_DIR "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
+        set(ONEDNN_INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/onednn_gpu_install/")
+        set(ONEDNN_PREFIX_DIR "${CMAKE_CURRENT_BINARY_DIR}/onednn_gpu_root")
         if(CMAKE_COMPILER_IS_GNUCXX)
             ie_add_compiler_flags(-Wno-undef)
         endif()
-
-        # Get processors count to limit number of threads spawned by make
-        include(ProcessorCount)
-        ProcessorCount(CORES_COUNT)
-        if(CORES_COUNT EQUAL 0)
-            set(CORES_COUNT "")
-        endif()
-        set (ONEDNN_CMAKE_ARGS "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
-                       "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
-                       "-DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}"
-                       "-DCMAKE_C_COMPILER_LAUNCHER=${CMAKE_C_COMPILER_LAUNCHER}"
-                       "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}"
-                       "-DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}"
-                       "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE=${ENABLE_LTO}"
-                       "-DCMAKE_POLICY_DEFAULT_CMP0069=NEW"
-                       "-DDNNL_CPU_RUNTIME=NONE"
-                       "-DDNNL_GPU_RUNTIME=OCL"
-                       "-DDNNL_LIBRARY_NAME=onednn_gpu"
-                       "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
-                       "-DCMAKE_RUNTIME_OUTPUT_DIRECTORY=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}"
-                       "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
-                       "-DDNNL_ENABLE_CONCURRENT_EXEC=ON"
-                       "-DDNNL_ENABLE_PRIMITIVE_CACHE=ON"
-                       "-DDNNL_ENABLE_JIT_PROFILING=${BUILD_SHARED_LIBS}"
-                       "-DDNNL_ENABLE_ITT_TASKS=${BUILD_SHARED_LIBS}"
-                       "-DDNNL_BUILD_TESTS=OFF"
-                       "-DDNNL_BUILD_EXAMPLES=OFF"
-                       "-DDNNL_BLAS_VENDOR=NONE"
-                       "-DDNNL_LIBRARY_TYPE=STATIC"
-                       "-DOpenCL_LIBRARY=${OpenCL_LIBRARY}"
-                       "-DOpenCL_INCLUDE_DIR=${OpenCL_INCLUDE_DIR}"
-                       "-DOPENCL_VERSION_2_2=${OPENCL_VERSION_2_2}")
-
-        get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
-        if (isMultiConfig)
-            set(DIR_PREFIX "/$<CONFIG>/")
-            set(ONEDNN_LIBRARY "${CMAKE_STATIC_LIBRARY_PREFIX}onednn_gpu${CMAKE_STATIC_LIBRARY_SUFFIX}")
-            set(ONEDNN_OUTPUT_LIBRARY "${ONEDNN_INSTALL_DIR}${DIR_PREFIX}${ONEDNN_LIBRARY}")
-            if (WIN32)
-                set(DNNL_COMMAND_SUFFIX "bat" )
-            else()
-                set(DNNL_COMMAND_SUFFIX "sh" )
-            endif()
-            set(DNNL_BUILD_TARGET_COMMAND "${ONEDNN_BUILD_DIR}/target_$<CONFIG>_build.${DNNL_COMMAND_SUFFIX}" )
-            set(DNNL_COPY_TARGET_COMMAND "${ONEDNN_BUILD_DIR}/target_$<CONFIG>_copy.${DNNL_COMMAND_SUFFIX}" )
-            file( GENERATE OUTPUT "${DNNL_BUILD_TARGET_COMMAND}" CONTENT "\"${CMAKE_COMMAND}\" --build . --config $<CONFIG> --target onednn_gpu --parallel ${CORES_COUNT}")
-            file( GENERATE OUTPUT "${DNNL_COPY_TARGET_COMMAND}" CONTENT "\"${CMAKE_COMMAND}\" -E copy ${ONEDNN_BUILD_DIR}src${DIR_PREFIX}${ONEDNN_LIBRARY} ${ONEDNN_OUTPUT_LIBRARY}" )
-            ExternalProject_Add(onednn_gpu_build
-                SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/onednn_gpu"
-                BINARY_DIR "${ONEDNN_BUILD_DIR}"
-                INSTALL_DIR "${ONEDNN_INSTALL_DIR}"
-                PREFIX onednn_gpu_build
-                EXCLUDE_FROM_ALL ON
-                CMAKE_ARGS ${ONEDNN_CMAKE_ARGS}
-                BUILD_COMMAND ${DNNL_BUILD_TARGET_COMMAND}
-                INSTALL_COMMAND ${DNNL_COPY_TARGET_COMMAND}
-                COMMAND ${CMAKE_COMMAND} -E echo "OneDNN build for GPU complete"
-            )
-        else()
-            set(ONEDNN_LIBRARY "${ONEDNN_BUILD_DIR}/src/${CMAKE_STATIC_LIBRARY_PREFIX}onednn_gpu${CMAKE_STATIC_LIBRARY_SUFFIX}")
-            set(ONEDNN_OUTPUT_LIBRARY "${ONEDNN_INSTALL_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}onednn_gpu${CMAKE_STATIC_LIBRARY_SUFFIX}")
-            ExternalProject_Add(onednn_gpu_build
-                SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/onednn_gpu"
-                BINARY_DIR "${ONEDNN_BUILD_DIR}"
-                INSTALL_DIR "${ONEDNN_INSTALL_DIR}"
-                PREFIX onednn_gpu_build
-                EXCLUDE_FROM_ALL ON
-                CMAKE_ARGS ${ONEDNN_CMAKE_ARGS}
-                BUILD_COMMAND ${CMAKE_COMMAND} --build . --config ${CMAKE_BUILD_TYPE} --target onednn_gpu --parallel ${CORES_COUNT}
-                INSTALL_COMMAND ${CMAKE_COMMAND} -E copy ${ONEDNN_LIBRARY} ${ONEDNN_OUTPUT_LIBRARY}
-                COMMAND ${CMAKE_COMMAND} -E echo "OneDNN $<CONFIG> build for GPU complete"
-                BUILD_BYPRODUCTS ${ONEDNN_OUTPUT_LIBRARY}
-            )
-            
-        endif()
-
-        ExternalProject_Get_property(onednn_gpu_build SOURCE_DIR)
-        ExternalProject_Get_property(onednn_gpu_build BINARY_DIR)
-
-        # WA: create temp 'include' directory
-        file(MAKE_DIRECTORY "${BINARY_DIR}/include")
-
-        if (NOT isMultiConfig)
-            add_library(onednn_gpu STATIC IMPORTED GLOBAL)
-            set_target_properties(onednn_gpu PROPERTIES
-                IMPORTED_LOCATION ${ONEDNN_OUTPUT_LIBRARY}
-                INTERFACE_INCLUDE_DIRECTORIES "$<BUILD_INTERFACE:${BINARY_DIR}/include>;$<BUILD_INTERFACE:${SOURCE_DIR}/include>"
-                INTERFACE_COMPILE_DEFINITIONS ENABLE_ONEDNN_FOR_GPU)
-            add_dependencies(onednn_gpu onednn_gpu_build)
-        endif()
-
-        # TODO: does not work for imported targets; need to import this target in
-        # OpenVINOConfig.cmake explicitly
-        # ov_install_static_lib(onednn_gpu gpu)
+        ExternalProject_Add(onednn_gpu_build
+            SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/onednn_gpu"
+            BINARY_DIR "${ONEDNN_BUILD_DIR}"
+            INSTALL_DIR "${ONEDNN_INSTALL_DIR}"
+            PREFIX "${ONEDNN_PREFIX_DIR}"
+            EXCLUDE_FROM_ALL ON
+            CMAKE_ARGS
+                "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
+                "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
+                "-DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}"
+                "-DCMAKE_C_COMPILER_LAUNCHER=${CMAKE_C_COMPILER_LAUNCHER}"
+                "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}"
+                "-DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}"
+                "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE=${ENABLE_LTO}"
+                "-DCMAKE_POLICY_DEFAULT_CMP0069=NEW"
+                "-DDNNL_CPU_RUNTIME=NONE"
+                "-DDNNL_GPU_RUNTIME=OCL"
+                "-DDNNL_LIBRARY_NAME=onednn_gpu"
+                "-DCMAKE_INSTALL_PREFIX=${ONEDNN_INSTALL_DIR}"
+                "-DCMAKE_INSTALL_LIBDIR=lib/$<CONFIG>"
+                "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+                "-DDNNL_ENABLE_CONCURRENT_EXEC=ON"
+                "-DDNNL_ENABLE_PRIMITIVE_CACHE=ON"
+                "-DDNNL_ENABLE_JIT_PROFILING=${BUILD_SHARED_LIBS}"
+                "-DDNNL_ENABLE_ITT_TASKS=${BUILD_SHARED_LIBS}"
+                "-DDNNL_BUILD_TESTS=OFF"
+                "-DDNNL_BUILD_EXAMPLES=OFF"
+                "-DDNNL_BLAS_VENDOR=NONE"
+                "-DDNNL_LIBRARY_TYPE=STATIC"
+                "-DOpenCL_LIBRARY=${OpenCL_LIBRARY}"
+                "-DOpenCL_INCLUDE_DIR=${OpenCL_INCLUDE_DIR}"
+                "-DOPENCL_VERSION_2_2=${OPENCL_VERSION_2_2}"
+        )
+        add_library(onednn_gpu_tgt INTERFACE)
+        set_target_properties(onednn_gpu_tgt PROPERTIES
+            INTERFACE_LINK_DIRECTORIES "${ONEDNN_INSTALL_DIR}/lib/$<CONFIG>"
+            INTERFACE_LINK_LIBRARIES "onednn_gpu"
+            INTERFACE_INCLUDE_DIRECTORIES "${ONEDNN_INSTALL_DIR}/include"
+            INTERFACE_COMPILE_DEFINITIONS ENABLE_ONEDNN_FOR_GPU
+        )
+        add_dependencies(onednn_gpu_tgt onednn_gpu_build)
+        # TODO: install onednn_gpu in static builds
     endfunction()
-
     build_onednn_gpu()
 endif()
 


### PR DESCRIPTION
replaces #8753, related #8757

### Details:
 - do not use custom configure/build/install steps - rely on `ExternalProject_Add`
 - use library and headers from install location
 - use link directory + library base name to point to library (instead of full library path), this method is not 100% reliable as the library with same name theoretically can replace ours, but the probability of such conflict should be small (can be avoided in future by renaming the library, generating full path to the file, etc.)
 - INTERFACE target `onednn_gpu_tgt` brings library and headers - I didn't mark it as IMPORTED because technically it is part of OpenVINO build process, maybe something should be changed here?
 
Checked:
* Linux with Ninja, Ninja Multi-Config, Makefiles generators in Release and Debug configurations
* Windows with MSVC 2019 generator

Not checked:
* XCode generator
* Static build
