### PR TITLE
[IE PYTHON] Custom Python layers

### DIFF
--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pyx
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pyx
@@ -509,6 +509,9 @@ cdef class IECore:
     def add_extension(self, extension_path: str, device_name: str):
         self.impl.addExtension(extension_path.encode(), device_name.encode())
 
+    def add_py_extension(self, obj : int):
+        self.impl.addExtension(obj)
+
     ## Gets a general runtime metric for dedicated hardware. Enables to request common device properties,
     #  which are `ExecutableNetwork` agnostic, such as device name, temperature, and other devices-specific values.
     #  @param device_name: A name of a device to get a metric value.

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pyx
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pyx
@@ -509,7 +509,7 @@ cdef class IECore:
     def add_extension(self, extension_path: str, device_name: str):
         self.impl.addExtension(extension_path.encode(), device_name.encode())
 
-    def add_py_extension(self, obj : int):
+    def add_py_extension(self, obj):
         self.impl.addExtension(obj)
 
     ## Gets a general runtime metric for dedicated hardware. Enables to request common device properties,

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.cpp
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.cpp
@@ -790,22 +790,17 @@ public:
     }
 
     std::vector<std::string> getImplTypes(const std::shared_ptr<ngraph::Node>& node) override {
-        // auto castedNode = std::dynamic_pointer_cast<ov::op::util::FrameworkNode>(node);
-        // if (castedNode) {
-        //     std::cout << castedNode->get_attrs().get_type_name() << " | " << opName << std::endl;
-        //     for (auto it : castedNode->get_attrs()) {
-        //         std::cout << it.first << " " << it.second << std::endl;
-        //     }
-        // }
-        // TODO: check layer op name.
-        if (std::dynamic_pointer_cast<ov::op::util::FrameworkNode>(node)) {
+        auto castedNode = std::dynamic_pointer_cast<ov::op::util::FrameworkNode>(node);
+        if (castedNode && castedNode->get_attrs().get_type_name() == opName) {
             return {"CPU"};
         }
         return {};
     }
 
     InferenceEngine::ILayerImpl::Ptr getImplementation(const std::shared_ptr<ngraph::Node>& node, const std::string& implType) override {
-        if (std::dynamic_pointer_cast<ov::op::util::FrameworkNode>(node) && implType == "CPU") {
+        auto castedNode = std::dynamic_pointer_cast<ov::op::util::FrameworkNode>(node);
+        if (castedNode && implType == "CPU" &&
+            castedNode->get_attrs().get_type_name() == opName) {
             return std::make_shared<PyLayerImpl>(node, impl);
         }
         return nullptr;

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.cpp
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.cpp
@@ -665,6 +665,25 @@ void InferenceEnginePython::IECore::addExtension(const std::string& ext_lib_path
     actual.AddExtension(extension, deviceName);
 }
 
+// class PyExtension : public ov::op::Op {
+// public:
+//     OPENVINO_OP("Identity");
+
+//     Identity() = default;
+//     Identity(const ov::Output<ov::Node>& arg);
+//     void validate_and_infer_types() override;
+//     std::shared_ptr<ov::Node> clone_with_new_inputs(const ov::OutputVector& new_args) const override;
+//     bool visit_attributes(ov::AttributeVisitor& visitor) override;
+
+//     bool evaluate(ov::runtime::TensorVector& outputs, const ov::runtime::TensorVector& inputs) const override;
+//     bool has_evaluate() const override;
+// };
+
+
+void InferenceEnginePython::IECore::addExtension(PyObject* cls) {
+    std::cout << " Helo" << std::endl;
+}
+
 std::vector<std::string> InferenceEnginePython::IECore::getAvailableDevices() {
     return actual.GetAvailableDevices();
 }

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.hpp
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.hpp
@@ -185,6 +185,7 @@ struct IECore {
     void unregisterPlugin(const std::string& deviceName);
     void registerPlugins(const std::string& xmlConfigFile);
     void addExtension(const std::string& ext_lib_path, const std::string& deviceName);
+    void addExtension(PyObject* cls);
     std::vector<std::string> getAvailableDevices();
     PyObject* getMetric(const std::string& deviceName, const std::string& name);
     PyObject* getConfig(const std::string& deviceName, const std::string& name);

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl_defs.pxd
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl_defs.pxd
@@ -220,6 +220,7 @@ cdef extern from "ie_api_impl.hpp" namespace "InferenceEnginePython":
         void unregisterPlugin(const string & deviceName) except +
         void registerPlugins(const string & xmlConfigFile) except +
         void addExtension(const string & ext_lib_path, const string & deviceName) except +
+        void addExtension(object) except +
         vector[string] getAvailableDevices() except +
         object getMetric(const string & deviceName, const string & name) except +
         object getConfig(const string & deviceName, const string & name) except +
@@ -233,3 +234,5 @@ cdef extern from "ie_api_impl.hpp" namespace "InferenceEnginePython":
     cdef object getPartialShape_capsule(DataPtr)
 
     cdef const size_t product(const SizeVector& dims)
+
+    cdef IENetwork read_network(string path_to_xml, string path_to_bin)

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl_defs.pxd
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl_defs.pxd
@@ -234,5 +234,3 @@ cdef extern from "ie_api_impl.hpp" namespace "InferenceEnginePython":
     cdef object getPartialShape_capsule(DataPtr)
 
     cdef const size_t product(const SizeVector& dims)
-
-    cdef IENetwork read_network(string path_to_xml, string path_to_bin)

--- a/ngraph/core/src/op/util/framework_node.cpp
+++ b/ngraph/core/src/op/util/framework_node.cpp
@@ -20,6 +20,7 @@ std::shared_ptr<ov::Node> ov::op::util::FrameworkNode::clone_with_new_inputs(con
     for (size_t i = 0; i < get_output_size(); ++i) {
         node->set_output_type(i, get_output_element_type(i), get_output_partial_shape(i));
     }
+    node->set_attrs(get_attrs());
     return node;
 }
 

--- a/runtime/bindings/python/tests/test_inference_engine/test_core.py
+++ b/runtime/bindings/python/tests/test_inference_engine/test_core.py
@@ -333,6 +333,7 @@ def test_py_extension(device):
             </output>
         </layer>
         <layer name="operation" id="1" type="CustomAdd" version="util">
+            <data  add="11"/>
             <input>
                 <port id="1" precision="FP32">
                     <dim>2</dim>
@@ -370,8 +371,11 @@ def test_py_extension(device):
     class CustomAdd:
         op = "CustomAdd"
 
+        def __init__(self, data):
+            self.add = float(data.get("add", 0))
+
         def execute(self, inputs):
-            return inputs[0] + 11
+            return inputs[0] + self.add
 
     from openvino.inference_engine import IECore
 


### PR DESCRIPTION
### Details:
 - Custom layers support in Python
 - Uses `FrameworkNode` so layer should belong to `"util"` opset.
 - Introduced for old Python API for now
