### PR TITLE
Add stale github action to automatically mark and close stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,18 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+
+jobs:
+  stale:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-pr-message: 'PR has been open 15 days with no activity. Remove stale label or comment or this will be closed in 15 days'
+          close-pr-message: 'Stale PR closed due to no activity for 15 days'
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          days-before-pr-stale: 15
+          days-before-pr-close: 15
+          operations-per-run: 5000


### PR DESCRIPTION
Sometimes CI restarts for old PRs that have no activity for a long time, this creates long CI queues. Thus, it is suggested to close stale PRs for 30 days of inactivity.

This action marks stale PR on 15 days of inactivity with "Stale" label, and closes marked PRs after extra 15 days if there are still no updates on the PR or Stale label is not removed