### PR TITLE
[setupvars] Removed unnecessary double brackets

### DIFF
--- a/scripts/setupvars/setupvars.sh
+++ b/scripts/setupvars/setupvars.sh
@@ -8,7 +8,7 @@ INSTALLDIR="${SCRIPT_DIR}"
 export INTEL_OPENVINO_DIR="$INSTALLDIR"
 
 # parse command line options
-while [[ $# -gt 0 ]]
+while [ $# -gt 0 ]
 do
 key="$1"
 case $key in


### PR DESCRIPTION
they cause a problem on raspbianOS

### Details:
 - https://openvino-ci.intel.com/job/openvino/job/PV_checks/job/pv_check_linux/1035/consoleFull#:~:text=12%3A41%3A43%20%20/localdisk/jenkins/workspace/openvino/PV_checks/pv_check_linux/cvsdk-package-tests/dldt%40tmp/durable-dd1625d4/script.sh%3A%2016%3A%20/opt/intel/openvino_2021.4.684/bin/setupvars.sh%3A%20%5B%5B%3A%20not%20found

### Tickets:
 - CVS-58300
