### PR TITLE
[GPU] Modify reorder handling

### DIFF
--- a/inference-engine/thirdparty/clDNN/src/graph_optimizer/remove_redundant_reorders.cpp
+++ b/inference-engine/thirdparty/clDNN/src/graph_optimizer/remove_redundant_reorders.cpp
@@ -232,6 +232,9 @@ void remove_redundant_reorders::run(program& p) {
         if (!ident.second)
             continue;
 
+        if (r_node.is_output() && i_layout.get_linear_size() != o_layout.get_linear_size())
+            continue;
+
         // mark as optimized
         r_node.can_be_optimized(true);
         r_node.requires_reinterpret(!ident.first);

--- a/inference-engine/thirdparty/clDNN/src/layout_optimizer.cpp
+++ b/inference-engine/thirdparty/clDNN/src/layout_optimizer.cpp
@@ -327,7 +327,7 @@ bool layout_optimizer::can_fuse_reorder(program_node& prev, program_node& next, 
             !data_type_traits::is_floating_point(prev_dt) && data_type_traits::is_floating_point(next_dt)) {
             auto& node = prev.get_users().front();
             // Avoid to fuse padding reorder to previous onednn convolution
-            if (prev.is_type<convolution>() && prev.as<convolution>().get_preferred_impl_type() == impl_types::onednn &&
+            if (prev.get_preferred_impl_type() == impl_types::onednn &&
                 (node->get_output_layout().data_padding != prev.get_output_layout().data_padding))
                 return false;
             else

--- a/inference-engine/thirdparty/clDNN/src/program_helpers.cpp
+++ b/inference-engine/thirdparty/clDNN/src/program_helpers.cpp
@@ -117,8 +117,16 @@ layout program_helpers::get_weights_layout(typed_program_node<cldnn::data>& data
 std::pair<bool, bool> program_helpers::are_layouts_identical(layout const& l1, layout const& l2) {
     const auto& l1_pad = l1.data_padding;
     const auto& l2_pad = l2.data_padding;
+    auto offset_last_element_l1 = l1.get_linear_offset(l1.size - tensor{1});
+    auto offset_last_element_l2 = l2.get_linear_offset(l2.size - tensor{1});
     if (l1 == l2)
         return {true, true};
+    // If data is actually 1d along f and dense, the layouts are identical
+    if (l1.data_type == l2.data_type && l1.size == l2.size && !l1_pad && !l2_pad && l1.size.batch[0] == 1 &&
+        ((l1.format.spatial_num() == 2 && l1.size.spatial[0] == 1 && l1.size.spatial[1] == 1) ||
+        ((l1.format.spatial_num() == 3 && l1.size.spatial[0] == 1 && l1.size.spatial[1] == 1 && l1.size.spatial[2] == 1))) &&
+        (offset_last_element_l1 + 1 == l1.size.feature[0] && offset_last_element_l2 + 1 == l2.size.feature[0]))
+        return {false, true};
     if (l1.data_type != l2.data_type)
         return {false, false};
     // Reorders between bfyx, bfzyx, bfwzyx can pe reinterpeted as reshape when


### PR DESCRIPTION
+ Remove redundant reorder for meta-only reorder
+ Modify reorder removal logic for conv from fsv32 to fsv16

Signed-off-by: Min, Byungil <byungil.min@intel.com>

### Details:
 - *Remove redundant reorder for meta-only reorder*
 - *Modify reorder removal logic for conv from fsv32 to fsv16*

### Tickets:
 - *ticket-id*
