### PR TITLE
[GPU] Fixed NHWC interp. Added exec precision to impl name in perf counters

### DIFF
--- a/inference-engine/src/cldnn_engine/cldnn_graph.h
+++ b/inference-engine/src/cldnn_engine/cldnn_graph.h
@@ -88,7 +88,6 @@ protected:
     std::map<std::string, std::vector<cldnn::primitive_id>> prevPrimitiveIDs;
 
     std::map<cldnn::primitive_id, std::pair<std::string, PerfCounter>> perfMap;
-    std::map<cldnn::primitive_id, std::string> implementationsMap;
     std::vector<cldnn::primitive_id> profilingIDs;
 
     std::map<std::string, InferenceEngine::SizeVector> outputDims;
@@ -99,7 +98,6 @@ protected:
     std::shared_ptr<cldnn::network> BuildNetwork(std::shared_ptr<cldnn::program> program);
     void Build();
     void UpdateLayersMaps();
-    void UpdateImplementationsMap();
     std::shared_ptr<ngraph::Function> GetExecGraphInfoByPrimitivesInfo(std::vector<cldnn::primitive_info>& pi,
                                                                        bool filter_const_primitives = true);
 };

--- a/inference-engine/src/cldnn_engine/cldnn_transformations_pipeline.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_transformations_pipeline.cpp
@@ -35,6 +35,9 @@
 #include <transformations/common_optimizations/weights_dequantize_to_fake_quantize.hpp>
 #include "transformations/common_optimizations/convert_quantize_dequantize.hpp"
 #include "transformations/common_optimizations/convert_compression_only_to_legacy.hpp"
+#include <transformations/common_optimizations/wrap_interpolate_into_transposes.hpp>
+#include <transformations/common_optimizations/transpose_sinking.hpp>
+
 #include <transformations/op_conversions/convert_depth_to_space.hpp>
 #include <transformations/op_conversions/convert_space_to_depth.hpp>
 #include <transformations/op_conversions/convert_gelu.hpp>
@@ -120,6 +123,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Function> func) {
 
         manager.register_pass<ngraph::pass::InitNodeInfo>();
         manager.register_pass<ngraph::pass::CommonOptimizations>();
+        manager.register_pass<ngraph::pass::WrapInterpolateIntoTransposes>();
+        manager.register_pass<ngraph::pass::TransposeSinking>();
 
         if (!config.enable_loop_unrolling) {
             manager.register_pass<ngraph::pass::BidirectionalLSTMSequenceDecomposition>();

--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/skip_tests_config.cpp
@@ -90,8 +90,6 @@ std::vector<std::string> disabledTestPatterns() {
             R"(.*(SoftMaxLayerTest).*)",
             // TODO: Issue: 68712
             R"(.*.MatMul.*CompareWithRefs.*IS0=\(1.5\)_IS1=\(1.5\).*transpose_a=0.*transpose_b=1.*CONSTANT.*FP16.*UNSPECIFIED.*UNSPECIFIED.*ANY.*)",
-            // TODO: Issue 66685
-            R"(smoke_PrePostProcess.*resize_linear_nhwc.*)",
             // TODO: Issue 69187
             R"(smoke_PrePostProcess.*cvt_color_nv12.*)",
             // TODO: Issue 71215

--- a/inference-engine/thirdparty/clDNN/api/cldnn/graph/network.hpp
+++ b/inference-engine/thirdparty/clDNN/api/cldnn/graph/network.hpp
@@ -160,6 +160,7 @@ public:
     // Implementation specific calls
     std::shared_ptr<primitive_inst> get_primitive(const primitive_id& id);
     std::string get_primitive_info(const primitive_id& id) const;
+    std::string get_implementation_info(const primitive_id& id) const;
     const event::ptr& get_primitive_event(const primitive_id& id) const { return _events.at(id); }
     bool has_event(const primitive_id& id) const { return _events.count(id); }
     std::vector<std::shared_ptr<primitive_inst>> get_primitives(const std::vector<primitive_id>& ids);

--- a/inference-engine/thirdparty/clDNN/api/cldnn/graph/program.hpp
+++ b/inference-engine/thirdparty/clDNN/api/cldnn/graph/program.hpp
@@ -206,6 +206,8 @@ public:
                       std::function<bool(program_node const&)> const& filter = nullptr) const;
 
     const primitives_info& get_primitives_info() const;
+    data_types get_inference_precision(const program_node& node) const;
+    std::string get_implementation_info(const primitive_id& id) const;
     const graph_optimizer_info& get_optimizer_passes_info() const;
     void save_pass_info(std::string pass_name);
 

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/resample/resample_kernel_base.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/resample/resample_kernel_base.cpp
@@ -107,6 +107,7 @@ bool ResampleKernelBase::Validate(const Params& p, const optional_params& o) con
     const auto& input = params.inputs[0];
     if ((input.GetDType() == Datatype::UINT8 || input.GetDType() == Datatype::INT8) &&
         params.resampleType != ResampleType::NEAREST_NEIGHBOR &&
+        params.resampleType != ResampleType::CAFFE_BILINEAR_INTERP &&
         params.resampleType != ResampleType::BILINEAR_INTERP)
         return false;
 

--- a/inference-engine/thirdparty/clDNN/src/graph_optimizer/compile_graph.cpp
+++ b/inference-engine/thirdparty/clDNN/src/graph_optimizer/compile_graph.cpp
@@ -54,5 +54,9 @@ void compile_graph::run(program& p) {
 
         task_executor->runAndWait(tasks);
         tasks.clear();
+
+        if (exception) {
+            std::rethrow_exception(exception);
+        }
     }
 }

--- a/inference-engine/thirdparty/clDNN/src/network.cpp
+++ b/inference-engine/thirdparty/clDNN/src/network.cpp
@@ -466,6 +466,10 @@ std::string network::get_primitive_info(const primitive_id& id) const {
     return node.type()->to_string(node);
 }
 
+std::string network::get_implementation_info(const primitive_id& id) const {
+    return _program->get_implementation_info(id);
+}
+
 memory::ptr network::get_output_memory(const primitive_id& output_id) {
     return get_primitive(output_id)->output_memory_ptr();
 }

--- a/inference-engine/thirdparty/clDNN/src/program.cpp
+++ b/inference-engine/thirdparty/clDNN/src/program.cpp
@@ -192,7 +192,7 @@ program_node& program::get_node(primitive_id const& id) {
     try {
         return *nodes_map.at(id);
     } catch (...) {
-        throw std::runtime_error("Program doesn't contain primtive node: " + id);
+        throw std::runtime_error("Program doesn't contain primitive node: " + id);
     }
 }
 
@@ -200,7 +200,7 @@ program_node const& program::get_node(primitive_id const& id) const {
     try {
         return *nodes_map.at(id);
     } catch (...) {
-        throw std::runtime_error("Program doesn't contain primtive node: " + id);
+        throw std::runtime_error("Program doesn't contain primitive node: " + id);
     }
 }
 
@@ -1122,46 +1122,56 @@ void program::dump_program(const char* stage,
     dump_graph_optimized(graph, *this);
 }
 
+data_types program::get_inference_precision(const program_node& node) const {
+    if (node.is_input()) {
+        return node.get_output_layout().data_type;
+    }
+    std::vector<data_types> input_dts;
+    for (auto& dep : node.get_dependencies()) {
+        input_dts.push_back(dep->get_output_layout().data_type);
+    }
+    data_types output_dt = node.get_output_layout().data_type;
+
+    assert(!input_dts.empty());
+    if (node.is_type<reorder>()) {
+        // If reorder has different input/output types - pick the max one as runtime precision
+        return data_type_traits::max_type(input_dts[0], output_dt);
+    } else if (node.is_type<quantize>()) {
+        if (data_type_traits::is_quantized(output_dt))
+            return output_dt;
+        return data_type_traits::max_type(input_dts[0], output_dt);
+    } else if (node.is_type<eltwise>()) {
+        auto max_dt = input_dts[0];
+        for (size_t i = 1; i < input_dts.size(); i++) {
+            max_dt = data_type_traits::max_type(max_dt, input_dts[i]);
+        }
+        return max_dt;
+    } else if (node.is_type<convolution>() || node.is_type<deconvolution>() || node.is_type<fully_connected>() || node.is_type<gemm>()) {
+        if (input_dts.size() < 2) {
+            throw std::runtime_error("[clDNN] Invalid inputs count in node " + node.id() + " during stage info collection. Expected >= 2 inputs");
+        }
+        if (data_type_traits::is_quantized(input_dts[0]) && data_type_traits::is_quantized(input_dts[1])) {
+            return input_dts[0];
+        } else {
+            return data_type_traits::max_type(input_dts[0], input_dts[1]);
+        }
+    }
+
+    return input_dts[0];
+}
+
+std::string program::get_implementation_info(const primitive_id& id) const {
+    try {
+        const auto& node = get_node(id);
+        auto impl = node.get_selected_impl();
+        return impl ? (impl->get_kernel_name() + "__" + dt_to_str(get_inference_precision(node))) : "undef";
+    } catch (...) { }
+
+    return "undef";
+}
+
 program::primitives_info program::get_current_stage_info() const {
     primitives_info info;
-
-    auto get_inference_precision = [](program_node& node) -> data_types {
-        if (node.is_input()) {
-            return node.get_output_layout().data_type;
-        }
-        std::vector<data_types> input_dts;
-        for (auto& dep : node.get_dependencies()) {
-            input_dts.push_back(dep->get_output_layout().data_type);
-        }
-        data_types output_dt = node.get_output_layout().data_type;
-
-        assert(!input_dts.empty());
-        if (node.is_type<reorder>()) {
-            // If reorder has different input/output types - pick the max one as runtime precision
-            return data_type_traits::max_type(input_dts[0], output_dt);
-        } else if (node.is_type<quantize>()) {
-            if (data_type_traits::is_quantized(output_dt))
-                return output_dt;
-            return data_type_traits::max_type(input_dts[0], output_dt);
-        } else if (node.is_type<eltwise>()) {
-            auto max_dt = input_dts[0];
-            for (size_t i = 1; i < input_dts.size(); i++) {
-                max_dt = data_type_traits::max_type(max_dt, input_dts[i]);
-            }
-            return max_dt;
-        } else if (node.is_type<convolution>() || node.is_type<deconvolution>() || node.is_type<fully_connected>() || node.is_type<gemm>()) {
-            if (input_dts.size() < 2) {
-                throw std::runtime_error("[clDNN] Invalid inputs count in node " + node.id() + " during stage info collection. Expected >= 2 inputs");
-            }
-            if (data_type_traits::is_quantized(input_dts[0]) && data_type_traits::is_quantized(input_dts[1])) {
-                return input_dts[0];
-            } else {
-                return data_type_traits::max_type(input_dts[0], input_dts[1]);
-            }
-        }
-
-        return input_dts[0];
-    };
 
     // Get info for actually executed graph nodes
     int exec_id = 0;
@@ -1191,7 +1201,7 @@ program::primitives_info program::get_current_stage_info() const {
                           fused,
                           p->get_output_layout(),
                           fmt_to_str(p->get_output_layout().format),
-                          p->selected_impl ? p->selected_impl->get_kernel_name() : "",
+                          get_implementation_info(p->id()),
                           get_inference_precision(*p),
                           p->selected_impl ? p->selected_impl->is_cpu() : false,
                           exec_id++);

--- a/inference-engine/thirdparty/clDNN/tests/test_cases/cache_test.cpp
+++ b/inference-engine/thirdparty/clDNN/tests/test_cases/cache_test.cpp
@@ -223,13 +223,10 @@ public:
         network.execute();
 
         if (compare_implementation.compare) {
-            std::string exec_impl;
-            for (auto& info : network.get_primitives_info()) {
-                if (info.original_id == "conv") {
-                    exec_impl = info.kernel_id;
-                    break;
-                }
-            }
+            std::string exec_impl = network.get_implementation_info("conv");
+            auto precision_pos = exec_impl.find("__");
+            exec_impl = exec_impl.substr(0, precision_pos);
+
             if (compare_implementation.not_equal) {
                 EXPECT_NE(exec_impl, compare_implementation.value);
             } else {


### PR DESCRIPTION
### Details:
 - Enabled NHWC -> NCHW Interpolate transformation
 - Added exception rethrow from compile_graph pass to avoid segfault
 - Added suffix with exec precision to impl name in PC and exec graph
 - Allow INT8 precision for caffe_bilinear mode

### Tickets:
 - *71331*
 - *71786*
