### PR TITLE
Remove  evaluate of `boolean` for ops inherited from `UnaryElementwiseArithmetic`

### DIFF
--- a/src/core/src/op/abs.cpp
+++ b/src/core/src/op/abs.cpp
@@ -36,7 +36,6 @@ bool evaluate_abs(const ngraph::HostTensorPtr& arg0, const ngraph::HostTensorPtr
     out->set_unary(arg0);
 
     switch (arg0->get_element_type()) {
-        NGRAPH_TYPE_CASE(evaluate_abs, boolean, arg0, out, count);
         NGRAPH_TYPE_CASE(evaluate_abs, i32, arg0, out, count);
         NGRAPH_TYPE_CASE(evaluate_abs, i64, arg0, out, count);
         NGRAPH_TYPE_CASE(evaluate_abs, u32, arg0, out, count);
@@ -68,7 +67,6 @@ bool ov::op::v0::Abs::has_evaluate() const {
     case ngraph::element::f16:
     case ngraph::element::f32:
     case ngraph::element::bf16:
-    case ngraph::element::boolean:
         return true;
     default:
         break;

--- a/src/core/src/op/ceiling.cpp
+++ b/src/core/src/op/ceiling.cpp
@@ -47,7 +47,6 @@ bool evaluate_ceiling(const HostTensorPtr& arg0, const HostTensorPtr& out, const
     out->set_unary(arg0);
 
     switch (arg0->get_element_type()) {
-        NGRAPH_COPY_TENSOR(evaluate_ceiling, boolean, arg0, out, count);
         NGRAPH_COPY_TENSOR(evaluate_ceiling, i8, arg0, out, count);
         NGRAPH_COPY_TENSOR(evaluate_ceiling, i16, arg0, out, count);
         NGRAPH_COPY_TENSOR(evaluate_ceiling, i32, arg0, out, count);
@@ -75,7 +74,6 @@ bool op::Ceiling::evaluate(const HostTensorVector& outputs, const HostTensorVect
 bool op::Ceiling::has_evaluate() const {
     NGRAPH_OP_SCOPE(v0_Ceiling_has_evaluate);
     switch (get_input_element_type(0)) {
-    case ngraph::element::boolean:
     case ngraph::element::i8:
     case ngraph::element::i16:
     case ngraph::element::i32:

--- a/src/core/src/op/floor.cpp
+++ b/src/core/src/op/floor.cpp
@@ -52,7 +52,6 @@ bool evaluate_floor(const HostTensorPtr& arg0, const HostTensorPtr& out, const s
     out->set_unary(arg0);
 
     switch (arg0->get_element_type()) {
-        NGRAPH_COPY_TENSOR(evaluate_floor, boolean, arg0, out, count);
         NGRAPH_COPY_TENSOR(evaluate_floor, i8, arg0, out, count);
         NGRAPH_COPY_TENSOR(evaluate_floor, i16, arg0, out, count);
         NGRAPH_COPY_TENSOR(evaluate_floor, i32, arg0, out, count);
@@ -80,7 +79,6 @@ bool op::Floor::evaluate(const HostTensorVector& outputs, const HostTensorVector
 bool op::Floor::has_evaluate() const {
     NGRAPH_OP_SCOPE(v0_Floor_has_evaluate);
     switch (get_input_element_type(0)) {
-    case ngraph::element::boolean:
     case ngraph::element::i8:
     case ngraph::element::i16:
     case ngraph::element::i32:

--- a/src/core/src/op/log.cpp
+++ b/src/core/src/op/log.cpp
@@ -43,7 +43,6 @@ bool evaluate_log(const HostTensorPtr& arg0, const HostTensorPtr& out, const siz
     out->set_unary(arg0);
 
     switch (arg0->get_element_type()) {
-        NGRAPH_TYPE_CASE(evaluate_log, boolean, arg0, out, count);
         NGRAPH_TYPE_CASE(evaluate_log, i32, arg0, out, count);
         NGRAPH_TYPE_CASE(evaluate_log, i64, arg0, out, count);
         NGRAPH_TYPE_CASE(evaluate_log, u32, arg0, out, count);
@@ -67,7 +66,6 @@ bool op::Log::evaluate(const HostTensorVector& outputs, const HostTensorVector& 
 bool op::Log::has_evaluate() const {
     NGRAPH_OP_SCOPE(v0_Log_has_evaluate);
     switch (get_input_element_type(0)) {
-    case ngraph::element::boolean:
     case ngraph::element::i32:
     case ngraph::element::i64:
     case ngraph::element::u32:

--- a/src/core/src/op/relu.cpp
+++ b/src/core/src/op/relu.cpp
@@ -41,7 +41,6 @@ bool evaluate_relu(const HostTensorPtr& arg0, const HostTensorPtr& out) {
     out->set_unary(arg0);
 
     switch (arg0->get_element_type()) {
-        NGRAPH_TYPE_CASE(evaluate_relu, boolean, arg0, out, count);
         NGRAPH_TYPE_CASE(evaluate_relu, i32, arg0, out, count);
         NGRAPH_TYPE_CASE(evaluate_relu, i64, arg0, out, count);
         NGRAPH_TYPE_CASE(evaluate_relu, u32, arg0, out, count);
@@ -66,7 +65,6 @@ bool op::Relu::evaluate(const HostTensorVector& outputs, const HostTensorVector&
 bool op::Relu::has_evaluate() const {
     NGRAPH_OP_SCOPE(v0_Relu_has_evaluate);
     switch (get_input_element_type(0)) {
-    case ngraph::element::boolean:
     case ngraph::element::i32:
     case ngraph::element::i64:
     case ngraph::element::u32:

--- a/src/core/src/op/sign.cpp
+++ b/src/core/src/op/sign.cpp
@@ -67,7 +67,6 @@ bool op::Sign::evaluate(const HostTensorVector& outputs, const HostTensorVector&
 bool op::Sign::has_evaluate() const {
     NGRAPH_OP_SCOPE(v0_Sign_has_evaluate);
     switch (get_input_element_type(0)) {
-    case ngraph::element::boolean:
     case ngraph::element::i32:
     case ngraph::element::i64:
     case ngraph::element::u32:


### PR DESCRIPTION
### Details:
Ops inherited from `UnaryElementwiseArithmetic` can't be created with input op type == boolean due https://github.com/openvinotoolkit/openvino/blob/master/ngraph/core/src/op/util/unary_elementwise_arithmetic.cpp#L21, but `evaluate` methods still supports it

### Tickets:
 - 59321
