### PR TITLE
Disabled ROIAlign tests with bf16

### DIFF
--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
@@ -155,6 +155,8 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*GroupConvolutionLayerCPUTest.*IS=\{.+\}.*_Fused=.*Add\(Parameters\).*)",
         // Issue: 71968
         R"(.*LSTMSequenceCommonZeroClip.*PURE.*CONST.*hidden_size=10.*sigmoid.sigmoid.sigmoid.*reverse.*FP32_targetDevice=CPU.*)",
+        // Issue: 72151
+        R"(.*smoke_ROIAlignLayoutTest.*bf16.*)",
     };
 
 #define FIX_62820 0


### PR DESCRIPTION
### Details:
 - *After [PR#8571](https://github.com/openvinotoolkit/openvino/pull/8571) ROIALign CPU tests are failed for bf16. This PR disables these tests*

### Tickets:
 - *N/A*
