### PR TITLE
[GPU] Fix bfyx conv degradation for gen9 

### DIFF
--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_kernel_bfyx_os_iyx_osv16.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_kernel_bfyx_os_iyx_osv16.h
@@ -40,7 +40,12 @@ protected:
             // Smaller # EU tends to be computation bounds.
             // In such case, using larger worksize will result in larger computational inefficiency
             // w.r.t the unalined output feature
-            return (params.output.Feature().v >= 8 || !IsSIMDSizeSupported(params.engineInfo, 8)) ? 16 : 8;
+            if (params.output.Feature().v > 8 || !IsSIMDSizeSupported(params.engineInfo, 8)
+               || (params.output.GetDType() == Datatype::F16) && params.output.Feature().v == 8) {
+                return 16;
+            } else {
+                return 8;
+            }
         } else {
             return 16;
         }

--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_kernel_bfyx_os_iyx_osv16.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_kernel_bfyx_os_iyx_osv16.h
@@ -40,7 +40,7 @@ protected:
             // Smaller # EU tends to be computation bounds.
             // In such case, using larger worksize will result in larger computational inefficiency
             // w.r.t the unalined output feature
-            return (params.output.Feature().v > 8 || !IsSIMDSizeSupported(params.engineInfo, 8)) ? 16 : 8;
+            return (params.output.Feature().v >= 8 || !IsSIMDSizeSupported(params.engineInfo, 8)) ? 16 : 8;
         } else {
             return 16;
         }


### PR DESCRIPTION
### Details:
 - Two fixes 
 1. apply align(2) of output block size only when the feature width is enoughly big
 2. set subgroup size as 16 when fp16 && out_feature_size == 8

### Tickets:
 - 61739
