### PR TITLE
[CPU][Tests] Decreased number of test cases for several ops

### DIFF
--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/deformable_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/deformable_convolution.cpp
@@ -226,6 +226,20 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32
 };
 
+const auto defConvSpecificParams_Smoke = ::testing::Combine(
+    ::testing::ValuesIn(std::vector<bool> {
+        true,
+        false
+    }),  // with_bilinear_interpolation_pad
+    ::testing::ValuesIn(std::vector<bool> {
+        true,
+        false
+    }),  // with_modulation
+    ::testing::ValuesIn(std::vector<OffsetType> {
+        OffsetType::REAL_MISC,
+    })  // offset type
+);
+
 const auto defConvSpecificParams = ::testing::Combine(
     ::testing::ValuesIn(std::vector<bool> {
         true,
@@ -251,8 +265,8 @@ std::vector<ngraph::op::PadType> padTypes = {
 
 const auto spParams1 = ::testing::Combine(
     ::testing::Values(1),  // batch
-    ::testing::Values(std::vector<size_t>({68, 68})),  // in. spat. shape
-    ::testing::Values(std::vector<size_t>({66, 66})),  // off. spat. shape
+    ::testing::Values(std::vector<size_t>({34, 34})),  // in. spat. shape
+    ::testing::Values(std::vector<size_t>({32, 32})),  // off. spat. shape
     ::testing::Values(std::vector<size_t>({3, 3})),  // ker. spat. shape
     ::testing::ValuesIn(padTypes),  // pad. type
     ::testing::Values(std::vector<ptrdiff_t>({0, 0})),  // pad. begin
@@ -308,6 +322,52 @@ const auto chParamsMulGr = ::testing::Combine(
         ::testing::ValuesIn(std::vector<size_t> {3, 7}),  // in. ch. per gr.
         ::testing::ValuesIn(std::vector<size_t> {3, 7}));  // out. ch. per gr.
 
+const auto params1_Smoke = ::testing::Combine(
+                             ::testing::Combine(
+                                 spParams1,
+                                 chParamsSingleGr,
+                                 defConvSpecificParams_Smoke,
+                                 ::testing::ValuesIn(netPrecisions),
+                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                             ::testing::ValuesIn(filterCPUInfoForDevice()));
+const auto params2_Smoke = ::testing::Combine(
+                             ::testing::Combine(
+                                 spParams2,
+                                 chParamsSingleGr,
+                                 defConvSpecificParams_Smoke,
+                                 ::testing::ValuesIn(netPrecisions),
+                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                             ::testing::ValuesIn(filterCPUInfoForDevice()));
+const auto params3_Smoke = ::testing::Combine(
+                             ::testing::Combine(
+                                 spParams3,
+                                 chParamsSingleGr,
+                                 defConvSpecificParams_Smoke,
+                                 ::testing::ValuesIn(netPrecisions),
+                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                             ::testing::ValuesIn(filterCPUInfoForDevice()));
+const auto params4_Smoke = ::testing::Combine(
+                             ::testing::Combine(
+                                 spParams4,
+                                 chParamsSingleGr,
+                                 defConvSpecificParams_Smoke,
+                                 ::testing::ValuesIn(netPrecisions),
+                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                             ::testing::ValuesIn(filterCPUInfoForDevice()));
+const auto params5_Smoke = ::testing::Combine(
+                             ::testing::Combine(
+                                 spParams4,
+                                 chParamsMulGr,
+                                 defConvSpecificParams_Smoke,
+                                 ::testing::ValuesIn(netPrecisions),
+                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                             ::testing::ValuesIn(filterCPUInfoForDevice(true)));
+INSTANTIATE_TEST_SUITE_P(smoke_DefConvLayoutTest1, DefConvLayerCPUTest, params1_Smoke, DefConvLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_DefConvLayoutTest2, DefConvLayerCPUTest, params2_Smoke, DefConvLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_DefConvLayoutTest3, DefConvLayerCPUTest, params3_Smoke, DefConvLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_DefConvLayoutTest4, DefConvLayerCPUTest, params4_Smoke, DefConvLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_DefConvLayoutTest5, DefConvLayerCPUTest, params5_Smoke, DefConvLayerCPUTest::getTestCaseName);
+
 const auto params1 = ::testing::Combine(
                          ::testing::Combine(
                              spParams1,
@@ -348,10 +408,11 @@ const auto params5 = ::testing::Combine(
                              ::testing::ValuesIn(netPrecisions),
                              ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                          ::testing::ValuesIn(filterCPUInfoForDevice(true)));
-INSTANTIATE_TEST_SUITE_P(smoke_DefConvLayoutTest1, DefConvLayerCPUTest, params1, DefConvLayerCPUTest::getTestCaseName);
-INSTANTIATE_TEST_SUITE_P(smoke_DefConvLayoutTest2, DefConvLayerCPUTest, params2, DefConvLayerCPUTest::getTestCaseName);
-INSTANTIATE_TEST_SUITE_P(smoke_DefConvLayoutTest3, DefConvLayerCPUTest, params3, DefConvLayerCPUTest::getTestCaseName);
-INSTANTIATE_TEST_SUITE_P(smoke_DefConvLayoutTest4, DefConvLayerCPUTest, params4, DefConvLayerCPUTest::getTestCaseName);
-INSTANTIATE_TEST_SUITE_P(smoke_DefConvLayoutTest5, DefConvLayerCPUTest, params5, DefConvLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(DefConvLayoutTest1, DefConvLayerCPUTest, params1, DefConvLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(DefConvLayoutTest2, DefConvLayerCPUTest, params2, DefConvLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(DefConvLayoutTest3, DefConvLayerCPUTest, params3, DefConvLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(DefConvLayoutTest4, DefConvLayerCPUTest, params4, DefConvLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(DefConvLayoutTest5, DefConvLayerCPUTest, params5, DefConvLayerCPUTest::getTestCaseName);
+
 } // namespace
 } // namespace CPULayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/interpolate.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/interpolate.cpp
@@ -289,7 +289,12 @@ std::vector<CPUSpecificParams> filterCPUInfoForDevice() {
     return resCPUParams;
 }
 /* ========== */
-const std::vector<ngraph::op::v4::Interpolate::CoordinateTransformMode> coordinateTransformModes = {
+const std::vector<ngraph::op::v4::Interpolate::CoordinateTransformMode> coordinateTransformModes_Smoke = {
+        ngraph::op::v4::Interpolate::CoordinateTransformMode::HALF_PIXEL,
+        ngraph::op::v4::Interpolate::CoordinateTransformMode::ASYMMETRIC,
+};
+
+const std::vector<ngraph::op::v4::Interpolate::CoordinateTransformMode> coordinateTransformModes_Full = {
         ngraph::op::v4::Interpolate::CoordinateTransformMode::TF_HALF_PIXEL_FOR_NN,
         ngraph::op::v4::Interpolate::CoordinateTransformMode::PYTORCH_HALF_PIXEL,
         ngraph::op::v4::Interpolate::CoordinateTransformMode::HALF_PIXEL,
@@ -297,12 +302,13 @@ const std::vector<ngraph::op::v4::Interpolate::CoordinateTransformMode> coordina
         ngraph::op::v4::Interpolate::CoordinateTransformMode::ALIGN_CORNERS,
 };
 
-const std::vector<ngraph::op::v4::Interpolate::ShapeCalcMode> shapeCalculationMode = {
-        ngraph::op::v4::Interpolate::ShapeCalcMode::SIZES,
-        ngraph::op::v4::Interpolate::ShapeCalcMode::SCALES,
+const std::vector<ngraph::op::v4::Interpolate::NearestMode> nearestModes_Smoke = {
+        ngraph::op::v4::Interpolate::NearestMode::SIMPLE,
+        ngraph::op::v4::Interpolate::NearestMode::ROUND_PREFER_FLOOR,
+        ngraph::op::v4::Interpolate::NearestMode::FLOOR,
 };
 
-const std::vector<ngraph::op::v4::Interpolate::NearestMode> nearestModes = {
+const std::vector<ngraph::op::v4::Interpolate::NearestMode> nearestModes_Full = {
         ngraph::op::v4::Interpolate::NearestMode::SIMPLE,
         ngraph::op::v4::Interpolate::NearestMode::ROUND_PREFER_FLOOR,
         ngraph::op::v4::Interpolate::NearestMode::FLOOR,
@@ -351,7 +357,7 @@ const std::vector<std::vector<int64_t>> defaultAxes4D = {
     {0, 1, 2, 3}
 };
 
-const std::vector<ShapeParams> shapeParams4D = {
+const std::vector<ShapeParams> shapeParams4D_Smoke = {
     ShapeParams{
         ngraph::op::v4::Interpolate::ShapeCalcMode::SCALES,
         InputShape{{}, {{1, 11, 4, 4}}},
@@ -362,20 +368,6 @@ const std::vector<ShapeParams> shapeParams4D = {
     ShapeParams{
         ngraph::op::v4::Interpolate::ShapeCalcMode::SIZES,
         InputShape{{}, {{1, 11, 4, 4}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {{1, 11, 5, 6}},
-        defaultAxes4D.front()
-    },
-    ShapeParams{
-        ngraph::op::v4::Interpolate::ShapeCalcMode::SCALES,
-        InputShape{{-1, {2, 20}, -1, -1}, {{1, 11, 4, 4}, {2, 7, 6, 5}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {{1.f, 1.f, 1.25f, 1.5f}},
-        defaultAxes4D.front()
-    },
-    ShapeParams{
-        ngraph::op::v4::Interpolate::ShapeCalcMode::SIZES,
-        InputShape{{-1, {2, 20}, -1, -1}, {{1, 11, 4, 4}, {1, 11, 5, 5}}},
         ngraph::helpers::InputLayerType::CONSTANT,
         {{1, 11, 5, 6}},
         defaultAxes4D.front()
@@ -396,10 +388,36 @@ const std::vector<ShapeParams> shapeParams4D = {
     }
 };
 
-const auto interpolateCasesNN = ::testing::Combine(
+const std::vector<ShapeParams> shapeParams4D_Full = {
+    ShapeParams{
+        ngraph::op::v4::Interpolate::ShapeCalcMode::SCALES,
+        InputShape{{-1, {2, 20}, -1, -1}, {{1, 11, 4, 4}, {2, 7, 6, 5}}},
+        ngraph::helpers::InputLayerType::CONSTANT,
+        {{1.f, 1.f, 1.25f, 1.5f}},
+        defaultAxes4D.front()
+    },
+    ShapeParams{
+        ngraph::op::v4::Interpolate::ShapeCalcMode::SIZES,
+        InputShape{{-1, {2, 20}, -1, -1}, {{1, 11, 4, 4}, {1, 11, 5, 5}}},
+        ngraph::helpers::InputLayerType::CONSTANT,
+        {{1, 11, 5, 6}},
+        defaultAxes4D.front()
+    }
+};
+
+const auto interpolateCasesNN_Smoke = ::testing::Combine(
         ::testing::Values(ngraph::op::v4::Interpolate::InterpolateMode::nearest),
-        ::testing::ValuesIn(coordinateTransformModes),
-        ::testing::ValuesIn(nearestModes),
+        ::testing::ValuesIn(coordinateTransformModes_Smoke),
+        ::testing::ValuesIn(nearestModes_Smoke),
+        ::testing::ValuesIn(antialias),
+        ::testing::ValuesIn(pads4D),
+        ::testing::ValuesIn(pads4D),
+        ::testing::ValuesIn(cubeCoefs));
+
+const auto interpolateCasesNN_Full = ::testing::Combine(
+        ::testing::Values(ngraph::op::v4::Interpolate::InterpolateMode::nearest),
+        ::testing::ValuesIn(coordinateTransformModes_Full),
+        ::testing::ValuesIn(nearestModes_Full),
         ::testing::ValuesIn(antialias),
         ::testing::ValuesIn(pads4D),
         ::testing::ValuesIn(pads4D),
@@ -407,13 +425,23 @@ const auto interpolateCasesNN = ::testing::Combine(
 
 INSTANTIATE_TEST_SUITE_P(smoke_InterpolateNN_Layout_Test, InterpolateLayerCPUTest,
         ::testing::Combine(
-            interpolateCasesNN,
-            ::testing::ValuesIn(shapeParams4D),
+             interpolateCasesNN_Smoke,
+            ::testing::ValuesIn(shapeParams4D_Smoke),
             ::testing::Values(ElementType::f32),
             ::testing::ValuesIn(filterCPUInfoForDevice()),
             ::testing::ValuesIn(interpolateFusingParamsSet),
             ::testing::ValuesIn(filterAdditionalConfig())),
     InterpolateLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(InterpolateNN_Layout_Test, InterpolateLayerCPUTest,
+         ::testing::Combine(
+             interpolateCasesNN_Full,
+             ::testing::ValuesIn(shapeParams4D_Full),
+             ::testing::Values(ElementType::f32),
+             ::testing::ValuesIn(filterCPUInfoForDevice()),
+             ::testing::ValuesIn(interpolateFusingParamsSet),
+             ::testing::ValuesIn(filterAdditionalConfig())),
+     InterpolateLayerCPUTest::getTestCaseName);
 
 const std::vector<ShapeParams> shapeParams4D_fixed_C = {
     ShapeParams{
@@ -434,7 +462,7 @@ const std::vector<ShapeParams> shapeParams4D_fixed_C = {
 
 INSTANTIATE_TEST_SUITE_P(smoke_InterpolateNN_Layout_PerChannelFuse_Test, InterpolateLayerCPUTest,
         ::testing::Combine(
-            interpolateCasesNN,
+            interpolateCasesNN_Smoke,
             ::testing::ValuesIn(shapeParams4D_fixed_C),
             ::testing::Values(ElementType::f32),
             ::testing::ValuesIn(filterCPUInfoForDevice()),
@@ -442,9 +470,28 @@ INSTANTIATE_TEST_SUITE_P(smoke_InterpolateNN_Layout_PerChannelFuse_Test, Interpo
             ::testing::ValuesIn(filterAdditionalConfig())),
     InterpolateLayerCPUTest::getTestCaseName);
 
-const auto interpolateCasesLinearOnnx = ::testing::Combine(
+INSTANTIATE_TEST_SUITE_P(InterpolateNN_Layout_PerChannelFuse_Test, InterpolateLayerCPUTest,
+        ::testing::Combine(
+            interpolateCasesNN_Full,
+            ::testing::ValuesIn(shapeParams4D_fixed_C),
+            ::testing::Values(ElementType::f32),
+            ::testing::ValuesIn(filterCPUInfoForDevice()),
+            ::testing::Values(fusingFakeQuantizePerChannelRelu),
+            ::testing::ValuesIn(filterAdditionalConfig())),
+    InterpolateLayerCPUTest::getTestCaseName);
+
+const auto interpolateCasesLinearOnnx_Smoke = ::testing::Combine(
         ::testing::Values(ngraph::op::v4::Interpolate::InterpolateMode::linear_onnx),
-        ::testing::ValuesIn(coordinateTransformModes),
+        ::testing::ValuesIn(coordinateTransformModes_Smoke),
+        ::testing::ValuesIn(defNearestModes),
+        ::testing::ValuesIn(antialias),
+        ::testing::ValuesIn(pads4D),
+        ::testing::ValuesIn(pads4D),
+        ::testing::ValuesIn(cubeCoefs));
+
+const auto interpolateCasesLinearOnnx_Full = ::testing::Combine(
+        ::testing::Values(ngraph::op::v4::Interpolate::InterpolateMode::linear_onnx),
+        ::testing::ValuesIn(coordinateTransformModes_Full),
         ::testing::ValuesIn(defNearestModes),
         ::testing::ValuesIn(antialias),
         ::testing::ValuesIn(pads4D),
@@ -453,17 +500,36 @@ const auto interpolateCasesLinearOnnx = ::testing::Combine(
 
 INSTANTIATE_TEST_SUITE_P(smoke_InterpolateLinearOnnx_Layout_Test, InterpolateLayerCPUTest,
         ::testing::Combine(
-            interpolateCasesLinearOnnx,
-            ::testing::ValuesIn(shapeParams4D),
+            interpolateCasesLinearOnnx_Smoke,
+            ::testing::ValuesIn(shapeParams4D_Smoke),
             ::testing::Values(ElementType::f32),
             ::testing::ValuesIn(filterCPUInfoForDevice()),
             ::testing::ValuesIn(interpolateFusingParamsSet),
             ::testing::ValuesIn(filterAdditionalConfig())),
     InterpolateLayerCPUTest::getTestCaseName);
 
-const auto interpolateCasesLinear = ::testing::Combine(
+INSTANTIATE_TEST_SUITE_P(InterpolateLinearOnnx_Layout_Test, InterpolateLayerCPUTest,
+        ::testing::Combine(
+            interpolateCasesLinearOnnx_Full,
+            ::testing::ValuesIn(shapeParams4D_Full),
+            ::testing::Values(ElementType::f32),
+            ::testing::ValuesIn(filterCPUInfoForDevice()),
+            ::testing::ValuesIn(interpolateFusingParamsSet),
+            ::testing::ValuesIn(filterAdditionalConfig())),
+    InterpolateLayerCPUTest::getTestCaseName);
+
+const auto interpolateCasesLinear_Smoke = ::testing::Combine(
         ::testing::Values(ngraph::op::v4::Interpolate::InterpolateMode::linear),
-        ::testing::ValuesIn(coordinateTransformModes),
+        ::testing::ValuesIn(coordinateTransformModes_Smoke),
+        ::testing::ValuesIn(defNearestModes),
+        ::testing::ValuesIn(antialias),
+        ::testing::ValuesIn(pads4D),
+        ::testing::ValuesIn(pads4D),
+        ::testing::ValuesIn(cubeCoefs));
+
+const auto interpolateCasesLinear_Full = ::testing::Combine(
+        ::testing::Values(ngraph::op::v4::Interpolate::InterpolateMode::linear),
+        ::testing::ValuesIn(coordinateTransformModes_Full),
         ::testing::ValuesIn(defNearestModes),
         ::testing::ValuesIn(antialias),
         ::testing::ValuesIn(pads4D),
@@ -472,17 +538,36 @@ const auto interpolateCasesLinear = ::testing::Combine(
 
 INSTANTIATE_TEST_SUITE_P(smoke_InterpolateLinear_Layout_Test, InterpolateLayerCPUTest,
         ::testing::Combine(
-            interpolateCasesLinear,
-            ::testing::ValuesIn(shapeParams4D),
+            interpolateCasesLinear_Smoke,
+            ::testing::ValuesIn(shapeParams4D_Smoke),
             ::testing::Values(ElementType::f32),
             ::testing::ValuesIn(filterCPUInfoForDevice()),
             ::testing::ValuesIn(interpolateFusingParamsSet),
             ::testing::ValuesIn(filterAdditionalConfig())),
     InterpolateLayerCPUTest::getTestCaseName);
 
-const auto interpolateCasesCubic = ::testing::Combine(
+INSTANTIATE_TEST_SUITE_P(InterpolateLinear_Layout_Test, InterpolateLayerCPUTest,
+        ::testing::Combine(
+            interpolateCasesLinear_Full,
+            ::testing::ValuesIn(shapeParams4D_Full),
+            ::testing::Values(ElementType::f32),
+            ::testing::ValuesIn(filterCPUInfoForDevice()),
+            ::testing::ValuesIn(interpolateFusingParamsSet),
+            ::testing::ValuesIn(filterAdditionalConfig())),
+    InterpolateLayerCPUTest::getTestCaseName);
+
+const auto interpolateCasesCubic_Smoke = ::testing::Combine(
         ::testing::Values(ngraph::op::v4::Interpolate::InterpolateMode::cubic),
-        ::testing::ValuesIn(coordinateTransformModes),
+        ::testing::ValuesIn(coordinateTransformModes_Smoke),
+        ::testing::ValuesIn(defNearestModes),
+        ::testing::ValuesIn(antialias),
+        ::testing::ValuesIn(pads4D),
+        ::testing::ValuesIn(pads4D),
+        ::testing::ValuesIn(cubeCoefs));
+
+const auto interpolateCasesCubic_Full = ::testing::Combine(
+        ::testing::Values(ngraph::op::v4::Interpolate::InterpolateMode::cubic),
+        ::testing::ValuesIn(coordinateTransformModes_Full),
         ::testing::ValuesIn(defNearestModes),
         ::testing::ValuesIn(antialias),
         ::testing::ValuesIn(pads4D),
@@ -491,8 +576,18 @@ const auto interpolateCasesCubic = ::testing::Combine(
 
 INSTANTIATE_TEST_SUITE_P(smoke_InterpolateCubic_Layout_Test, InterpolateLayerCPUTest,
         ::testing::Combine(
-            interpolateCasesCubic,
-            ::testing::ValuesIn(shapeParams4D),
+            interpolateCasesCubic_Smoke,
+            ::testing::ValuesIn(shapeParams4D_Smoke),
+            ::testing::Values(ElementType::f32),
+            ::testing::ValuesIn(filterCPUInfoForDevice()),
+            ::testing::ValuesIn(interpolateFusingParamsSet),
+            ::testing::ValuesIn(filterAdditionalConfig())),
+    InterpolateLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(InterpolateCubic_Layout_Test, InterpolateLayerCPUTest,
+        ::testing::Combine(
+            interpolateCasesCubic_Full,
+            ::testing::ValuesIn(shapeParams4D_Full),
             ::testing::Values(ElementType::f32),
             ::testing::ValuesIn(filterCPUInfoForDevice()),
             ::testing::ValuesIn(interpolateFusingParamsSet),
@@ -526,7 +621,7 @@ const std::vector<std::vector<int64_t>> defaultAxes5D = {
     {0, 1, 2, 3, 4}
 };
 
-const std::vector<ShapeParams> shapeParams5D = {
+const std::vector<ShapeParams> shapeParams5D_Smoke = {
     ShapeParams{
         ngraph::op::v4::Interpolate::ShapeCalcMode::SCALES,
         InputShape{{}, {{1, 11, 4, 4, 4}}},
@@ -539,20 +634,6 @@ const std::vector<ShapeParams> shapeParams5D = {
         InputShape{{}, {{1, 11, 4, 4, 4}}},
         ngraph::helpers::InputLayerType::CONSTANT,
         {{1, 11, 5, 6, 2}},
-        defaultAxes5D.front()
-    },
-    ShapeParams{
-        ngraph::op::v4::Interpolate::ShapeCalcMode::SCALES,
-        InputShape{{-1, {2, 20}, -1, -1, -1}, {{1, 11, 4, 4, 4}, {2, 7, 6, 5, 8}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {{1.f, 1.f, 1.25f, 1.5f, 0.5f}},
-        defaultAxes5D.front()
-    },
-    ShapeParams{
-        ngraph::op::v4::Interpolate::ShapeCalcMode::SIZES,
-        InputShape{{-1, {2, 20}, -1, -1, -1}, {{1, 11, 4, 4, 4}, {1, 11, 5, 5, 8}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {{1, 11, 5, 6, 4}},
         defaultAxes5D.front()
     },
     ShapeParams{
@@ -571,10 +652,35 @@ const std::vector<ShapeParams> shapeParams5D = {
     },
 };
 
-const auto interpolateCasesLinearOnnx5D = ::testing::Combine(
+const std::vector<ShapeParams> shapeParams5D_Full = {
+    ShapeParams{
+        ngraph::op::v4::Interpolate::ShapeCalcMode::SCALES,
+        InputShape{{-1, {2, 20}, -1, -1, -1}, {{1, 11, 4, 4, 4}, {2, 7, 6, 5, 8}}},
+        ngraph::helpers::InputLayerType::CONSTANT,
+        {{1.f, 1.f, 1.25f, 1.5f, 0.5f}},
+        defaultAxes5D.front()
+    },
+    ShapeParams{
+        ngraph::op::v4::Interpolate::ShapeCalcMode::SIZES,
+        InputShape{{-1, {2, 20}, -1, -1, -1}, {{1, 11, 4, 4, 4}, {1, 11, 5, 5, 8}}},
+        ngraph::helpers::InputLayerType::CONSTANT,
+        {{1, 11, 5, 6, 4}},
+        defaultAxes5D.front()
+    }
+};
+
+const auto interpolateCasesLinearOnnx5D_Smoke = ::testing::Combine(
         ::testing::Values(ngraph::op::v4::Interpolate::InterpolateMode::linear_onnx),
-        ::testing::ValuesIn(coordinateTransformModes),
-        ::testing::ValuesIn(nearestModes),
+        ::testing::ValuesIn(coordinateTransformModes_Smoke),
+        ::testing::ValuesIn(nearestModes_Smoke),
+        ::testing::ValuesIn(antialias),
+        ::testing::ValuesIn(pads5D),
+        ::testing::ValuesIn(pads5D),
+        ::testing::ValuesIn(cubeCoefs));
+const auto interpolateCasesLinearOnnx5D_Full = ::testing::Combine(
+        ::testing::Values(ngraph::op::v4::Interpolate::InterpolateMode::linear_onnx),
+        ::testing::ValuesIn(coordinateTransformModes_Smoke),
+        ::testing::ValuesIn(nearestModes_Full),
         ::testing::ValuesIn(antialias),
         ::testing::ValuesIn(pads5D),
         ::testing::ValuesIn(pads5D),
@@ -582,17 +688,36 @@ const auto interpolateCasesLinearOnnx5D = ::testing::Combine(
 
 INSTANTIATE_TEST_SUITE_P(smoke_InterpolateLinearOnnx5D_Layout_Test, InterpolateLayerCPUTest,
         ::testing::Combine(
-            interpolateCasesLinearOnnx5D,
-            ::testing::ValuesIn(shapeParams5D),
+            interpolateCasesLinearOnnx5D_Smoke,
+            ::testing::ValuesIn(shapeParams5D_Smoke),
             ::testing::Values(ElementType::f32),
             ::testing::ValuesIn(filterCPUInfoForDevice5D()),
             ::testing::ValuesIn(interpolateFusingParamsSet),
             ::testing::ValuesIn(filterAdditionalConfig())),
     InterpolateLayerCPUTest::getTestCaseName);
 
-const auto interpolateCasesNN5D = ::testing::Combine(
+INSTANTIATE_TEST_SUITE_P(InterpolateLinearOnnx5D_Layout_Test, InterpolateLayerCPUTest,
+        ::testing::Combine(
+            interpolateCasesLinearOnnx5D_Full,
+            ::testing::ValuesIn(shapeParams5D_Full),
+            ::testing::Values(ElementType::f32),
+            ::testing::ValuesIn(filterCPUInfoForDevice5D()),
+            ::testing::ValuesIn(interpolateFusingParamsSet),
+            ::testing::ValuesIn(filterAdditionalConfig())),
+    InterpolateLayerCPUTest::getTestCaseName);
+
+const auto interpolateCasesNN5D_Smoke = ::testing::Combine(
         ::testing::Values(ngraph::op::v4::Interpolate::InterpolateMode::nearest),
-        ::testing::ValuesIn(coordinateTransformModes),
+        ::testing::ValuesIn(coordinateTransformModes_Smoke),
+        ::testing::ValuesIn(defNearestModes),
+        ::testing::ValuesIn(antialias),
+        ::testing::ValuesIn(pads5D),
+        ::testing::ValuesIn(pads5D),
+        ::testing::ValuesIn(cubeCoefs));
+
+const auto interpolateCasesNN5D_Full = ::testing::Combine(
+        ::testing::Values(ngraph::op::v4::Interpolate::InterpolateMode::nearest),
+        ::testing::ValuesIn(coordinateTransformModes_Smoke),
         ::testing::ValuesIn(defNearestModes),
         ::testing::ValuesIn(antialias),
         ::testing::ValuesIn(pads5D),
@@ -601,8 +726,18 @@ const auto interpolateCasesNN5D = ::testing::Combine(
 
 INSTANTIATE_TEST_SUITE_P(smoke_InterpolateNN5D_Layout_Test, InterpolateLayerCPUTest,
         ::testing::Combine(
-            interpolateCasesNN5D,
-            ::testing::ValuesIn(shapeParams5D),
+            interpolateCasesNN5D_Smoke,
+            ::testing::ValuesIn(shapeParams5D_Smoke),
+            ::testing::Values(ElementType::f32),
+            ::testing::ValuesIn(filterCPUInfoForDevice5D()),
+            ::testing::ValuesIn(interpolateFusingParamsSet),
+            ::testing::ValuesIn(filterAdditionalConfig())),
+    InterpolateLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(InterpolateNN5D_Layout_Test, InterpolateLayerCPUTest,
+        ::testing::Combine(
+            interpolateCasesNN5D_Full,
+            ::testing::ValuesIn(shapeParams5D_Full),
             ::testing::Values(ElementType::f32),
             ::testing::ValuesIn(filterCPUInfoForDevice5D()),
             ::testing::ValuesIn(interpolateFusingParamsSet),
@@ -627,7 +762,16 @@ const std::vector<ShapeParams> shapeParams4D_corner = {
     }
 };
 
-const auto interpolateCornerCases = ::testing::Combine(
+const auto interpolateCornerCases_Smoke = ::testing::Combine(
+        ::testing::Values(ngraph::op::v4::Interpolate::InterpolateMode::nearest),
+        ::testing::Values(ngraph::op::v4::Interpolate::CoordinateTransformMode::ASYMMETRIC),
+        ::testing::Values(ngraph::op::v4::Interpolate::NearestMode::SIMPLE),
+        ::testing::ValuesIn(antialias),
+        ::testing::Values(std::vector<size_t>{0, 0, 0, 0}),
+        ::testing::Values(std::vector<size_t>{0, 0, 0, 0}),
+        ::testing::ValuesIn(cubeCoefs));
+
+const auto interpolateCornerCases_Full = ::testing::Combine(
         ::testing::Values(ngraph::op::v4::Interpolate::InterpolateMode::nearest),
         ::testing::Values(ngraph::op::v4::Interpolate::CoordinateTransformMode::ASYMMETRIC),
         ::testing::Values(ngraph::op::v4::Interpolate::NearestMode::SIMPLE),
@@ -638,7 +782,17 @@ const auto interpolateCornerCases = ::testing::Combine(
 
 INSTANTIATE_TEST_SUITE_P(smoke_Interpolate_corner_Layout_Test, InterpolateLayerCPUTest,
         ::testing::Combine(
-            interpolateCornerCases,
+            interpolateCornerCases_Smoke,
+            ::testing::ValuesIn(shapeParams4D_corner),
+            ::testing::Values(ElementType::f32),
+            ::testing::ValuesIn(filterCPUInfoForDevice()),
+            ::testing::ValuesIn(interpolateFusingParamsSet),
+            ::testing::ValuesIn(filterAdditionalConfig())),
+    InterpolateLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(Interpolate_corner_Layout_Test, InterpolateLayerCPUTest,
+        ::testing::Combine(
+            interpolateCornerCases_Full,
             ::testing::ValuesIn(shapeParams4D_corner),
             ::testing::Values(ElementType::f32),
             ::testing::ValuesIn(filterCPUInfoForDevice()),

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/interpolate.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/interpolate.cpp
@@ -672,15 +672,15 @@ const std::vector<ShapeParams> shapeParams5D_Full = {
 const auto interpolateCasesLinearOnnx5D_Smoke = ::testing::Combine(
         ::testing::Values(ngraph::op::v4::Interpolate::InterpolateMode::linear_onnx),
         ::testing::ValuesIn(coordinateTransformModes_Smoke),
-        ::testing::ValuesIn(nearestModes_Smoke),
+        ::testing::ValuesIn(defNearestModes),
         ::testing::ValuesIn(antialias),
         ::testing::ValuesIn(pads5D),
         ::testing::ValuesIn(pads5D),
         ::testing::ValuesIn(cubeCoefs));
 const auto interpolateCasesLinearOnnx5D_Full = ::testing::Combine(
         ::testing::Values(ngraph::op::v4::Interpolate::InterpolateMode::linear_onnx),
-        ::testing::ValuesIn(coordinateTransformModes_Smoke),
-        ::testing::ValuesIn(nearestModes_Full),
+        ::testing::ValuesIn(coordinateTransformModes_Full),
+        ::testing::ValuesIn(defNearestModes),
         ::testing::ValuesIn(antialias),
         ::testing::ValuesIn(pads5D),
         ::testing::ValuesIn(pads5D),
@@ -709,7 +709,7 @@ INSTANTIATE_TEST_SUITE_P(InterpolateLinearOnnx5D_Layout_Test, InterpolateLayerCP
 const auto interpolateCasesNN5D_Smoke = ::testing::Combine(
         ::testing::Values(ngraph::op::v4::Interpolate::InterpolateMode::nearest),
         ::testing::ValuesIn(coordinateTransformModes_Smoke),
-        ::testing::ValuesIn(defNearestModes),
+        ::testing::ValuesIn(nearestModes_Smoke),
         ::testing::ValuesIn(antialias),
         ::testing::ValuesIn(pads5D),
         ::testing::ValuesIn(pads5D),
@@ -717,8 +717,8 @@ const auto interpolateCasesNN5D_Smoke = ::testing::Combine(
 
 const auto interpolateCasesNN5D_Full = ::testing::Combine(
         ::testing::Values(ngraph::op::v4::Interpolate::InterpolateMode::nearest),
-        ::testing::ValuesIn(coordinateTransformModes_Smoke),
-        ::testing::ValuesIn(defNearestModes),
+        ::testing::ValuesIn(coordinateTransformModes_Full),
+        ::testing::ValuesIn(nearestModes_Full),
         ::testing::ValuesIn(antialias),
         ::testing::ValuesIn(pads5D),
         ::testing::ValuesIn(pads5D),
@@ -762,16 +762,7 @@ const std::vector<ShapeParams> shapeParams4D_corner = {
     }
 };
 
-const auto interpolateCornerCases_Smoke = ::testing::Combine(
-        ::testing::Values(ngraph::op::v4::Interpolate::InterpolateMode::nearest),
-        ::testing::Values(ngraph::op::v4::Interpolate::CoordinateTransformMode::ASYMMETRIC),
-        ::testing::Values(ngraph::op::v4::Interpolate::NearestMode::SIMPLE),
-        ::testing::ValuesIn(antialias),
-        ::testing::Values(std::vector<size_t>{0, 0, 0, 0}),
-        ::testing::Values(std::vector<size_t>{0, 0, 0, 0}),
-        ::testing::ValuesIn(cubeCoefs));
-
-const auto interpolateCornerCases_Full = ::testing::Combine(
+const auto interpolateCornerCases = ::testing::Combine(
         ::testing::Values(ngraph::op::v4::Interpolate::InterpolateMode::nearest),
         ::testing::Values(ngraph::op::v4::Interpolate::CoordinateTransformMode::ASYMMETRIC),
         ::testing::Values(ngraph::op::v4::Interpolate::NearestMode::SIMPLE),
@@ -782,17 +773,7 @@ const auto interpolateCornerCases_Full = ::testing::Combine(
 
 INSTANTIATE_TEST_SUITE_P(smoke_Interpolate_corner_Layout_Test, InterpolateLayerCPUTest,
         ::testing::Combine(
-            interpolateCornerCases_Smoke,
-            ::testing::ValuesIn(shapeParams4D_corner),
-            ::testing::Values(ElementType::f32),
-            ::testing::ValuesIn(filterCPUInfoForDevice()),
-            ::testing::ValuesIn(interpolateFusingParamsSet),
-            ::testing::ValuesIn(filterAdditionalConfig())),
-    InterpolateLayerCPUTest::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(Interpolate_corner_Layout_Test, InterpolateLayerCPUTest,
-        ::testing::Combine(
-            interpolateCornerCases_Full,
+            interpolateCornerCases,
             ::testing::ValuesIn(shapeParams4D_corner),
             ::testing::Values(ElementType::f32),
             ::testing::ValuesIn(filterCPUInfoForDevice()),

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/pad.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/pad.cpp
@@ -102,7 +102,7 @@ const std::vector<ElementType> inputPrecisions = {
         ElementType::i8
 };
 
-const std::vector<float> argPadValue = {0.f, 1.f, 2.5f, -1.f};
+const std::vector<float> argPadValue = {0.f, 2.5f, -1.f};
 
 const std::vector<ngraph::helpers::PadMode> padMode = {
         ngraph::helpers::PadMode::EDGE,
@@ -112,14 +112,23 @@ const std::vector<ngraph::helpers::PadMode> padMode = {
 
 /* *======================* Static Shapes Tests 4D *======================* */
 
-const std::vector<std::vector<int64_t>> padsBegin4DConstBlocked = {{0, 0, 0, 0}, {0, 0, 1, 3}, {2, 16, 1, 0}, {0, 0, 2, 0}};
-const std::vector<std::vector<int64_t>> padsEnd4DConstBlocked   = {{0, 0, 0, 0}, {0, 0, 2, 1}, {2, 0, 0, 1}, {1, 32, 2, 0}};
+const std::vector<std::vector<int64_t>> padsBegin4DConstBlocked_Smoke = {{0, 0, 1, 3}, {2, 16, 1, 0}};
+const std::vector<std::vector<int64_t>> padsEnd4DConstBlocked_Smoke   = {{0, 0, 2, 1}, {2, 0, 0, 1}};
 
-const std::vector<std::vector<int64_t>> padsBegin4DBlocked = {{0, 0, 0, 0}, {0, 0, 1, 3}, {2, 0, 1, 0}, {0, 0, 2, 0}};
-const std::vector<std::vector<int64_t>> padsEnd4DBlocked   = {{0, 0, 0, 0}, {0, 0, 2, 1}, {2, 0, 0, 1}, {1, 0, 2, 0}};
+const std::vector<std::vector<int64_t>> padsBegin4DBlocked_Smoke = {{0, 0, 1, 3}, {2, 0, 1, 0}};
+const std::vector<std::vector<int64_t>> padsEnd4DBlocked_Smoke   = {{0, 0, 2, 1}, {2, 0, 0, 1}};
 
-const std::vector<std::vector<int64_t>> padsBegin4D = {{0, 0, 0, 0}, {0, 1, 1, 1}, {0, 2, 1, 0}, {0, 0, 0, 1}};
-const std::vector<std::vector<int64_t>> padsEnd4D   = {{0, 0, 0, 0}, {0, 2, 1, 1}, {0, 0, 2, 0}, {1, 1, 0, 0}};
+const std::vector<std::vector<int64_t>> padsBegin4D_Smoke = {{0, 1, 1, 1}, {0, 2, 1, 0}};
+const std::vector<std::vector<int64_t>> padsEnd4D_Smoke   = {{0, 2, 1, 1}, {0, 0, 2, 0}};
+
+const std::vector<std::vector<int64_t>> padsBegin4DConstBlocked_Full = {{0, 0, 0, 0}, {0, 0, 1, 3}, {2, 16, 1, 0}, {0, 0, 2, 0}};
+const std::vector<std::vector<int64_t>> padsEnd4DConstBlocked_Full   = {{0, 0, 0, 0}, {0, 0, 2, 1}, {2, 0, 0, 1}, {1, 32, 2, 0}};
+
+const std::vector<std::vector<int64_t>> padsBegin4DBlocked_Full = {{0, 0, 0, 0}, {0, 0, 1, 3}, {2, 0, 1, 0}, {0, 0, 2, 0}};
+const std::vector<std::vector<int64_t>> padsEnd4DBlocked_Full   = {{0, 0, 0, 0}, {0, 0, 2, 1}, {2, 0, 0, 1}, {1, 0, 2, 0}};
+
+const std::vector<std::vector<int64_t>> padsBegin4D_Full = {{0, 0, 0, 0}, {0, 1, 1, 1}, {0, 2, 1, 0}, {0, 0, 0, 1}};
+const std::vector<std::vector<int64_t>> padsEnd4D_Full   = {{0, 0, 0, 0}, {0, 2, 1, 1}, {0, 0, 2, 0}, {1, 1, 0, 0}};
 
 const std::vector<CPUSpecificParams> CPUParams4DBlocked = {
         cpuParams_nChw16c,
@@ -132,8 +141,8 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Combine(
                 ::testing::ValuesIn(static_shapes_to_test_representation({{3, 16, 5, 5}})),
                 ::testing::ValuesIn(inputPrecisions),
-                ::testing::ValuesIn(padsBegin4DConstBlocked),
-                ::testing::ValuesIn(padsEnd4DConstBlocked),
+                ::testing::ValuesIn(padsBegin4DConstBlocked_Smoke),
+                ::testing::ValuesIn(padsEnd4DConstBlocked_Smoke),
                 ::testing::ValuesIn(argPadValue),
                 ::testing::Values(ngraph::helpers::PadMode::CONSTANT),
                 ::testing::ValuesIn(CPUParams4DBlocked)),
@@ -146,8 +155,8 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Combine(
                 ::testing::ValuesIn(static_shapes_to_test_representation({{3, 16, 5, 5}})),
                 ::testing::ValuesIn(inputPrecisions),
-                ::testing::ValuesIn(padsBegin4D),
-                ::testing::ValuesIn(padsEnd4D),
+                ::testing::ValuesIn(padsBegin4D_Smoke),
+                ::testing::ValuesIn(padsEnd4D_Smoke),
                 ::testing::ValuesIn(argPadValue),
                 ::testing::Values(ngraph::helpers::PadMode::CONSTANT),
                 ::testing::Values(cpuParams_nhwc)),
@@ -160,8 +169,8 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Combine(
                 ::testing::ValuesIn(static_shapes_to_test_representation({{3, 16, 10, 5}})),
                 ::testing::ValuesIn(inputPrecisions),
-                ::testing::ValuesIn(padsBegin4DBlocked),
-                ::testing::ValuesIn(padsEnd4DBlocked),
+                ::testing::ValuesIn(padsBegin4DBlocked_Smoke),
+                ::testing::ValuesIn(padsEnd4DBlocked_Smoke),
                 ::testing::Values(0),
                 ::testing::ValuesIn(padMode),
                 ::testing::ValuesIn(CPUParams4DBlocked)),
@@ -174,8 +183,64 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Combine(
                 ::testing::ValuesIn(static_shapes_to_test_representation({{3, 16, 10, 5}})),
                 ::testing::ValuesIn(inputPrecisions),
-                ::testing::ValuesIn(padsBegin4DBlocked),
-                ::testing::ValuesIn(padsEnd4DBlocked),
+                ::testing::ValuesIn(padsBegin4DBlocked_Smoke),
+                ::testing::ValuesIn(padsEnd4DBlocked_Smoke),
+                ::testing::Values(0),
+                ::testing::ValuesIn(padMode),
+                ::testing::Values(cpuParams_nhwc)),
+        PadLayerCPUTest::getTestCaseName
+);
+
+INSTANTIATE_TEST_SUITE_P(
+        CPUPad4DConstBlocked,
+        PadLayerCPUTest,
+        ::testing::Combine(
+                ::testing::ValuesIn(static_shapes_to_test_representation({{3, 16, 5, 5}})),
+                ::testing::ValuesIn(inputPrecisions),
+                ::testing::ValuesIn(padsBegin4DConstBlocked_Full),
+                ::testing::ValuesIn(padsEnd4DConstBlocked_Full),
+                ::testing::ValuesIn(argPadValue),
+                ::testing::Values(ngraph::helpers::PadMode::CONSTANT),
+                ::testing::ValuesIn(CPUParams4DBlocked)),
+        PadLayerCPUTest::getTestCaseName
+);
+
+INSTANTIATE_TEST_SUITE_P(
+        CPUPad4DConst,
+        PadLayerCPUTest,
+        ::testing::Combine(
+                ::testing::ValuesIn(static_shapes_to_test_representation({{3, 16, 5, 5}})),
+                ::testing::ValuesIn(inputPrecisions),
+                ::testing::ValuesIn(padsBegin4D_Full),
+                ::testing::ValuesIn(padsEnd4D_Full),
+                ::testing::ValuesIn(argPadValue),
+                ::testing::Values(ngraph::helpers::PadMode::CONSTANT),
+                ::testing::Values(cpuParams_nhwc)),
+        PadLayerCPUTest::getTestCaseName
+);
+
+INSTANTIATE_TEST_SUITE_P(
+        CPUPad4DBlocked,
+        PadLayerCPUTest,
+        ::testing::Combine(
+                ::testing::ValuesIn(static_shapes_to_test_representation({{3, 16, 10, 5}})),
+                ::testing::ValuesIn(inputPrecisions),
+                ::testing::ValuesIn(padsBegin4DBlocked_Full),
+                ::testing::ValuesIn(padsEnd4DBlocked_Full),
+                ::testing::Values(0),
+                ::testing::ValuesIn(padMode),
+                ::testing::ValuesIn(CPUParams4DBlocked)),
+        PadLayerCPUTest::getTestCaseName
+);
+
+INSTANTIATE_TEST_SUITE_P(
+        CPUPad4D,
+        PadLayerCPUTest,
+        ::testing::Combine(
+                ::testing::ValuesIn(static_shapes_to_test_representation({{3, 16, 10, 5}})),
+                ::testing::ValuesIn(inputPrecisions),
+                ::testing::ValuesIn(padsBegin4DBlocked_Full),
+                ::testing::ValuesIn(padsEnd4DBlocked_Full),
                 ::testing::Values(0),
                 ::testing::ValuesIn(padMode),
                 ::testing::Values(cpuParams_nhwc)),
@@ -208,8 +273,8 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Combine(
                 ::testing::ValuesIn(inputShapesDynamic4D),
                 ::testing::ValuesIn(inputPrecisions),
-                ::testing::ValuesIn(padsBegin4D),
-                ::testing::ValuesIn(padsEnd4D),
+                ::testing::ValuesIn(padsBegin4D_Smoke),
+                ::testing::ValuesIn(padsEnd4D_Smoke),
                 ::testing::ValuesIn(argPadValue),
                 ::testing::Values(ngraph::helpers::PadMode::CONSTANT),
                 ::testing::ValuesIn(CPUParams4DDynamic)),
@@ -222,8 +287,8 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Combine(
                 ::testing::Values(inputShapesDynamic4D[1]),
                 ::testing::ValuesIn(inputPrecisions),
-                ::testing::ValuesIn(padsBegin4DConstBlocked),
-                ::testing::ValuesIn(padsEnd4DConstBlocked),
+                ::testing::ValuesIn(padsBegin4DConstBlocked_Smoke),
+                ::testing::ValuesIn(padsEnd4DConstBlocked_Smoke),
                 ::testing::ValuesIn(argPadValue),
                 ::testing::Values(ngraph::helpers::PadMode::CONSTANT),
                 ::testing::ValuesIn(CPUParams4DBlocked)),
@@ -236,8 +301,8 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Combine(
                 ::testing::ValuesIn(inputShapesDynamic4D),
                 ::testing::ValuesIn(inputPrecisions),
-                ::testing::ValuesIn(padsBegin4D),
-                ::testing::ValuesIn(padsEnd4D),
+                ::testing::ValuesIn(padsBegin4D_Smoke),
+                ::testing::ValuesIn(padsEnd4D_Smoke),
                 ::testing::Values(0),
                 ::testing::ValuesIn(padMode),
                 ::testing::ValuesIn(CPUParams4DDynamic)),
@@ -250,8 +315,64 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Combine(
                 ::testing::Values(inputShapesDynamic4D[1]),
                 ::testing::ValuesIn(inputPrecisions),
-                ::testing::ValuesIn(padsBegin4DBlocked),
-                ::testing::ValuesIn(padsEnd4DBlocked),
+                ::testing::ValuesIn(padsBegin4DBlocked_Smoke),
+                ::testing::ValuesIn(padsEnd4DBlocked_Smoke),
+                ::testing::Values(0),
+                ::testing::ValuesIn(padMode),
+                ::testing::ValuesIn(CPUParams4DBlocked)),
+        PadLayerCPUTest::getTestCaseName
+);
+
+INSTANTIATE_TEST_SUITE_P(
+        CPUPadDynamic4DConst,
+        PadLayerCPUTest,
+        ::testing::Combine(
+                ::testing::ValuesIn(inputShapesDynamic4D),
+                ::testing::ValuesIn(inputPrecisions),
+                ::testing::ValuesIn(padsBegin4D_Full),
+                ::testing::ValuesIn(padsEnd4D_Full),
+                ::testing::ValuesIn(argPadValue),
+                ::testing::Values(ngraph::helpers::PadMode::CONSTANT),
+                ::testing::ValuesIn(CPUParams4DDynamic)),
+        PadLayerCPUTest::getTestCaseName
+);
+
+INSTANTIATE_TEST_SUITE_P(
+        CPUPadDynamic4DConstBlocked,
+        PadLayerCPUTest,
+        ::testing::Combine(
+                ::testing::Values(inputShapesDynamic4D[1]),
+                ::testing::ValuesIn(inputPrecisions),
+                ::testing::ValuesIn(padsBegin4DConstBlocked_Full),
+                ::testing::ValuesIn(padsEnd4DConstBlocked_Full),
+                ::testing::ValuesIn(argPadValue),
+                ::testing::Values(ngraph::helpers::PadMode::CONSTANT),
+                ::testing::ValuesIn(CPUParams4DBlocked)),
+        PadLayerCPUTest::getTestCaseName
+);
+
+INSTANTIATE_TEST_SUITE_P(
+        CPUPadDynamic4D,
+        PadLayerCPUTest,
+        ::testing::Combine(
+                ::testing::ValuesIn(inputShapesDynamic4D),
+                ::testing::ValuesIn(inputPrecisions),
+                ::testing::ValuesIn(padsBegin4D_Full),
+                ::testing::ValuesIn(padsEnd4D_Full),
+                ::testing::Values(0),
+                ::testing::ValuesIn(padMode),
+                ::testing::ValuesIn(CPUParams4DDynamic)),
+        PadLayerCPUTest::getTestCaseName
+);
+
+INSTANTIATE_TEST_SUITE_P(
+        CPUPadDynamic4DBlocked,
+        PadLayerCPUTest,
+        ::testing::Combine(
+                ::testing::Values(inputShapesDynamic4D[1]),
+                ::testing::ValuesIn(inputPrecisions),
+                ::testing::ValuesIn(padsBegin4DBlocked_Full),
+                ::testing::ValuesIn(padsEnd4DBlocked_Full),
                 ::testing::Values(0),
                 ::testing::ValuesIn(padMode),
                 ::testing::ValuesIn(CPUParams4DBlocked)),
@@ -262,14 +383,23 @@ INSTANTIATE_TEST_SUITE_P(
 
 /* *======================* Static Shapes Tests 5D *======================* */
 
-const std::vector<std::vector<int64_t>> padsBegin5DConstBlocked = {{0, 0, 0, 0, 0}, {0, 0, 1, 1, 0}, {2, 32, 1, 1, 0}, {0, 0, 1, 3, 1}, {0, 0, 0, 1, 0}};
-const std::vector<std::vector<int64_t>> padsEnd5DConstBlocked   = {{0, 0, 0, 0, 0}, {1, 16, 1, 1, 0}, {0, 0, 0, 1, 0}, {0, 0, 0, 1, 1}, {0, 0, 1, 0, 1}};
+const std::vector<std::vector<int64_t>> padsBegin5DConstBlocked_Smoke = {{0, 0, 1, 1, 0}, {2, 32, 1, 1, 0}};
+const std::vector<std::vector<int64_t>> padsEnd5DConstBlocked_Smoke   = {{1, 16, 1, 1, 0}, {0, 0, 0, 1, 0}};
 
-const std::vector<std::vector<int64_t>> padsBegin5DBlocked = {{0, 0, 0, 0, 0}, {0, 0, 1, 1, 0}, {2, 0, 1, 1, 0}, {0, 0, 1, 3, 1}, {0, 0, 0, 1, 0}};
-const std::vector<std::vector<int64_t>> padsEnd5DBlocked   = {{0, 0, 0, 0, 0}, {1, 0, 1, 1, 0}, {0, 0, 0, 1, 0}, {0, 0, 0, 1, 1}, {0, 0, 1, 0, 1}};
+const std::vector<std::vector<int64_t>> padsBegin5DBlocked_Smoke = {{0, 0, 1, 1, 0}, {2, 0, 1, 1, 0}};
+const std::vector<std::vector<int64_t>> padsEnd5DBlocked_Smoke   = {{1, 0, 1, 1, 0}, {0, 0, 0, 1, 0}};
 
-const std::vector<std::vector<int64_t>> padsBegin5D = {{0, 0, 0, 0, 0}, {0, 0, 2, 0, 0}, {1, 1, 1, 1, 0}, {2, 0, 1, 0, 1}, {0, 2, 1, 3, 1}};
-const std::vector<std::vector<int64_t>> padsEnd5D   = {{0, 0, 0, 0, 0}, {0, 0, 1, 0, 0}, {1, 0, 1, 1, 2}, {2, 2, 0, 1, 0}, {1, 1, 2, 0, 1}};
+const std::vector<std::vector<int64_t>> padsBegin5D_Smoke = {{0, 0, 2, 0, 0}, {1, 1, 1, 1, 0}};
+const std::vector<std::vector<int64_t>> padsEnd5D_Smoke   = {{0, 0, 1, 0, 0}, {1, 0, 1, 1, 2}};
+
+const std::vector<std::vector<int64_t>> padsBegin5DConstBlocked_Full = {{0, 0, 0, 0, 0}, {0, 0, 1, 1, 0}, {2, 32, 1, 1, 0}, {0, 0, 1, 3, 1}, {0, 0, 0, 1, 0}};
+const std::vector<std::vector<int64_t>> padsEnd5DConstBlocked_Full   = {{0, 0, 0, 0, 0}, {1, 16, 1, 1, 0}, {0, 0, 0, 1, 0}, {0, 0, 0, 1, 1}, {0, 0, 1, 0, 1}};
+
+const std::vector<std::vector<int64_t>> padsBegin5DBlocked_Full = {{0, 0, 0, 0, 0}, {0, 0, 1, 1, 0}, {2, 0, 1, 1, 0}, {0, 0, 1, 3, 1}, {0, 0, 0, 1, 0}};
+const std::vector<std::vector<int64_t>> padsEnd5DBlocked_Full   = {{0, 0, 0, 0, 0}, {1, 0, 1, 1, 0}, {0, 0, 0, 1, 0}, {0, 0, 0, 1, 1}, {0, 0, 1, 0, 1}};
+
+const std::vector<std::vector<int64_t>> padsBegin5D_Full = {{0, 0, 0, 0, 0}, {0, 0, 2, 0, 0}, {1, 1, 1, 1, 0}, {2, 0, 1, 0, 1}, {0, 2, 1, 3, 1}};
+const std::vector<std::vector<int64_t>> padsEnd5D_Full   = {{0, 0, 0, 0, 0}, {0, 0, 1, 0, 0}, {1, 0, 1, 1, 2}, {2, 2, 0, 1, 0}, {1, 1, 2, 0, 1}};
 
 const std::vector<CPUSpecificParams> CPUParams5DBlocked = {
         cpuParams_nCdhw16c,
@@ -282,8 +412,8 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Combine(
                 ::testing::ValuesIn(static_shapes_to_test_representation({{3, 16, 5, 5, 5}})),
                 ::testing::ValuesIn(inputPrecisions),
-                ::testing::ValuesIn(padsBegin5DConstBlocked),
-                ::testing::ValuesIn(padsEnd5DConstBlocked),
+                ::testing::ValuesIn(padsBegin5DConstBlocked_Smoke),
+                ::testing::ValuesIn(padsEnd5DConstBlocked_Smoke),
                 ::testing::ValuesIn(argPadValue),
                 ::testing::Values(ngraph::helpers::PadMode::CONSTANT),
                 ::testing::ValuesIn(CPUParams5DBlocked)),
@@ -296,8 +426,8 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Combine(
                 ::testing::ValuesIn(static_shapes_to_test_representation({{3, 16, 5, 5, 5}})),
                 ::testing::ValuesIn(inputPrecisions),
-                ::testing::ValuesIn(padsBegin5D),
-                ::testing::ValuesIn(padsEnd5D),
+                ::testing::ValuesIn(padsBegin5D_Smoke),
+                ::testing::ValuesIn(padsEnd5D_Smoke),
                 ::testing::ValuesIn(argPadValue),
                 ::testing::Values(ngraph::helpers::PadMode::CONSTANT),
                 ::testing::Values(cpuParams_ndhwc)),
@@ -310,8 +440,8 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Combine(
                 ::testing::ValuesIn(static_shapes_to_test_representation({{3, 16, 5, 5, 5}})),
                 ::testing::ValuesIn(inputPrecisions),
-                ::testing::ValuesIn(padsBegin5DBlocked),
-                ::testing::ValuesIn(padsEnd5DBlocked),
+                ::testing::ValuesIn(padsBegin5DBlocked_Smoke),
+                ::testing::ValuesIn(padsEnd5DBlocked_Smoke),
                 ::testing::Values(0),
                 ::testing::ValuesIn(padMode),
                 ::testing::ValuesIn(CPUParams5DBlocked)),
@@ -324,8 +454,64 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Combine(
                 ::testing::ValuesIn(static_shapes_to_test_representation({{3, 16, 5, 5, 5}})),
                 ::testing::ValuesIn(inputPrecisions),
-                ::testing::ValuesIn(padsBegin5D),
-                ::testing::ValuesIn(padsEnd5D),
+                ::testing::ValuesIn(padsBegin5D_Smoke),
+                ::testing::ValuesIn(padsEnd5D_Smoke),
+                ::testing::Values(0),
+                ::testing::ValuesIn(padMode),
+                ::testing::Values(cpuParams_ndhwc)),
+        PadLayerCPUTest::getTestCaseName
+);
+
+INSTANTIATE_TEST_SUITE_P(
+        CPUPad5DConstBlocked,
+        PadLayerCPUTest,
+        ::testing::Combine(
+                ::testing::ValuesIn(static_shapes_to_test_representation({{3, 16, 5, 5, 5}})),
+                ::testing::ValuesIn(inputPrecisions),
+                ::testing::ValuesIn(padsBegin5DConstBlocked_Full),
+                ::testing::ValuesIn(padsEnd5DConstBlocked_Full),
+                ::testing::ValuesIn(argPadValue),
+                ::testing::Values(ngraph::helpers::PadMode::CONSTANT),
+                ::testing::ValuesIn(CPUParams5DBlocked)),
+        PadLayerCPUTest::getTestCaseName
+);
+
+INSTANTIATE_TEST_SUITE_P(
+        CPUPad5DConst,
+        PadLayerCPUTest,
+        ::testing::Combine(
+                ::testing::ValuesIn(static_shapes_to_test_representation({{3, 16, 5, 5, 5}})),
+                ::testing::ValuesIn(inputPrecisions),
+                ::testing::ValuesIn(padsBegin5D_Full),
+                ::testing::ValuesIn(padsEnd5D_Full),
+                ::testing::ValuesIn(argPadValue),
+                ::testing::Values(ngraph::helpers::PadMode::CONSTANT),
+                ::testing::Values(cpuParams_ndhwc)),
+        PadLayerCPUTest::getTestCaseName
+);
+
+INSTANTIATE_TEST_SUITE_P(
+        CPUPad5DBlocked,
+        PadLayerCPUTest,
+        ::testing::Combine(
+                ::testing::ValuesIn(static_shapes_to_test_representation({{3, 16, 5, 5, 5}})),
+                ::testing::ValuesIn(inputPrecisions),
+                ::testing::ValuesIn(padsBegin5DBlocked_Full),
+                ::testing::ValuesIn(padsEnd5DBlocked_Full),
+                ::testing::Values(0),
+                ::testing::ValuesIn(padMode),
+                ::testing::ValuesIn(CPUParams5DBlocked)),
+        PadLayerCPUTest::getTestCaseName
+);
+
+INSTANTIATE_TEST_SUITE_P(
+        CPUPad5D,
+        PadLayerCPUTest,
+        ::testing::Combine(
+                ::testing::ValuesIn(static_shapes_to_test_representation({{3, 16, 5, 5, 5}})),
+                ::testing::ValuesIn(inputPrecisions),
+                ::testing::ValuesIn(padsBegin5D_Full),
+                ::testing::ValuesIn(padsEnd5D_Full),
                 ::testing::Values(0),
                 ::testing::ValuesIn(padMode),
                 ::testing::Values(cpuParams_ndhwc)),
@@ -358,8 +544,8 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Combine(
                 ::testing::ValuesIn(inputShapesDynamic5D),
                 ::testing::ValuesIn(inputPrecisions),
-                ::testing::ValuesIn(padsBegin5D),
-                ::testing::ValuesIn(padsEnd5D),
+                ::testing::ValuesIn(padsBegin5D_Smoke),
+                ::testing::ValuesIn(padsEnd5D_Smoke),
                 ::testing::ValuesIn(argPadValue),
                 ::testing::Values(ngraph::helpers::PadMode::CONSTANT),
                 ::testing::ValuesIn(CPUParams5DDynamic)),
@@ -372,8 +558,8 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Combine(
                 ::testing::Values(inputShapesDynamic5D[1]),
                 ::testing::ValuesIn(inputPrecisions),
-                ::testing::ValuesIn(padsBegin5DConstBlocked),
-                ::testing::ValuesIn(padsEnd5DConstBlocked),
+                ::testing::ValuesIn(padsBegin5DConstBlocked_Smoke),
+                ::testing::ValuesIn(padsEnd5DConstBlocked_Smoke),
                 ::testing::ValuesIn(argPadValue),
                 ::testing::Values(ngraph::helpers::PadMode::CONSTANT),
                 ::testing::ValuesIn(CPUParams5DBlocked)),
@@ -386,8 +572,8 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Combine(
                 ::testing::ValuesIn(inputShapesDynamic5D),
                 ::testing::ValuesIn(inputPrecisions),
-                ::testing::ValuesIn(padsBegin5D),
-                ::testing::ValuesIn(padsEnd5D),
+                ::testing::ValuesIn(padsBegin5D_Smoke),
+                ::testing::ValuesIn(padsEnd5D_Smoke),
                 ::testing::Values(0),
                 ::testing::ValuesIn(padMode),
                 ::testing::ValuesIn(CPUParams5DDynamic)),
@@ -400,8 +586,64 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Combine(
                 ::testing::Values(inputShapesDynamic5D[1]),
                 ::testing::ValuesIn(inputPrecisions),
-                ::testing::ValuesIn(padsBegin5DBlocked),
-                ::testing::ValuesIn(padsEnd5DBlocked),
+                ::testing::ValuesIn(padsBegin5DBlocked_Smoke),
+                ::testing::ValuesIn(padsEnd5DBlocked_Smoke),
+                ::testing::Values(0),
+                ::testing::ValuesIn(padMode),
+                ::testing::ValuesIn(CPUParams5DBlocked)),
+        PadLayerCPUTest::getTestCaseName
+);
+
+INSTANTIATE_TEST_SUITE_P(
+        CPUPadDynamic5DConst,
+        PadLayerCPUTest,
+        ::testing::Combine(
+                ::testing::ValuesIn(inputShapesDynamic5D),
+                ::testing::ValuesIn(inputPrecisions),
+                ::testing::ValuesIn(padsBegin5D_Full),
+                ::testing::ValuesIn(padsEnd5D_Full),
+                ::testing::ValuesIn(argPadValue),
+                ::testing::Values(ngraph::helpers::PadMode::CONSTANT),
+                ::testing::ValuesIn(CPUParams5DDynamic)),
+        PadLayerCPUTest::getTestCaseName
+);
+
+INSTANTIATE_TEST_SUITE_P(
+        CPUPadDynamic5DConstBlocked,
+        PadLayerCPUTest,
+        ::testing::Combine(
+                ::testing::Values(inputShapesDynamic5D[1]),
+                ::testing::ValuesIn(inputPrecisions),
+                ::testing::ValuesIn(padsBegin5DConstBlocked_Full),
+                ::testing::ValuesIn(padsEnd5DConstBlocked_Full),
+                ::testing::ValuesIn(argPadValue),
+                ::testing::Values(ngraph::helpers::PadMode::CONSTANT),
+                ::testing::ValuesIn(CPUParams5DBlocked)),
+        PadLayerCPUTest::getTestCaseName
+);
+
+INSTANTIATE_TEST_SUITE_P(
+        CPUPadDynamic5D,
+        PadLayerCPUTest,
+        ::testing::Combine(
+                ::testing::ValuesIn(inputShapesDynamic5D),
+                ::testing::ValuesIn(inputPrecisions),
+                ::testing::ValuesIn(padsBegin5D_Full),
+                ::testing::ValuesIn(padsEnd5D_Full),
+                ::testing::Values(0),
+                ::testing::ValuesIn(padMode),
+                ::testing::ValuesIn(CPUParams5DDynamic)),
+        PadLayerCPUTest::getTestCaseName
+);
+
+INSTANTIATE_TEST_SUITE_P(
+        CPUPadDynamic5DBlocked,
+        PadLayerCPUTest,
+        ::testing::Combine(
+                ::testing::Values(inputShapesDynamic5D[1]),
+                ::testing::ValuesIn(inputPrecisions),
+                ::testing::ValuesIn(padsBegin5DBlocked_Full),
+                ::testing::ValuesIn(padsEnd5DBlocked_Full),
                 ::testing::Values(0),
                 ::testing::ValuesIn(padMode),
                 ::testing::ValuesIn(CPUParams5DBlocked)),

--- a/inference-engine/tests/functional/plugin/cpu/single_layer_tests/reduce_ops.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/single_layer_tests/reduce_ops.cpp
@@ -258,6 +258,12 @@ const std::vector<ngraph::helpers::ReductionType> reductionTypes = {
         ngraph::helpers::ReductionType::L2,
 };
 
+const std::vector<ngraph::helpers::ReductionType> reductionTypesFusing = {
+        ngraph::helpers::ReductionType::Mean,
+        ngraph::helpers::ReductionType::Max,
+        ngraph::helpers::ReductionType::L2,
+};
+
 const std::vector<ngraph::helpers::ReductionType> reductionLogicalTypes = {
         ngraph::helpers::ReductionType::LogicalOr,
         ngraph::helpers::ReductionType::LogicalAnd
@@ -315,13 +321,9 @@ std::vector<CPUSpecificParams> cpuParams_HybridLayout_5D = {
 
 const std::vector<fusingSpecificParams> fusingParamsSet {
         /* activations */
-        fusingRelu,
-        fusingElu,
-        fusingTanh,
         fusingSwish,
 
         /* FQ */
-        fusingFakeQuantizePerChannel,
         fusingFakeQuantizePerChannelRelu,
         fusingFakeQuantizePerTensorRelu,
         /* another patterns */
@@ -576,7 +578,7 @@ const auto params_OneAxis_fusing = testing::Combine(
             testing::ValuesIn(axes),
             testing::ValuesIn(opTypes),
             testing::Values(true),
-            testing::ValuesIn(reductionTypes),
+            testing::ValuesIn(reductionTypesFusing),
             testing::ValuesIn(inpOutPrc),
             testing::Values(ElementType::undefined),
             testing::Values(ElementType::undefined),
@@ -589,7 +591,7 @@ const auto params_MultiAxis_4D_fusing = testing::Combine(
                 testing::ValuesIn(axesND),
                 testing::Values(CommonTestUtils::OpType::VECTOR),
                 testing::Values(true),
-                testing::ValuesIn(reductionTypes),
+                testing::ValuesIn(reductionTypesFusing),
                 testing::ValuesIn(inpOutPrc),
                 testing::Values(ElementType::undefined),
                 testing::Values(ElementType::undefined),
@@ -602,7 +604,7 @@ const auto params_MultiAxis_5D_fusing = testing::Combine(
                 testing::ValuesIn(axes5D),
                 testing::Values(CommonTestUtils::OpType::VECTOR),
                 testing::Values(true),
-                testing::ValuesIn(reductionTypes),
+                testing::ValuesIn(reductionTypesFusing),
                 testing::ValuesIn(inpOutPrc),
                 testing::Values(ElementType::undefined),
                 testing::Values(ElementType::undefined),
@@ -637,7 +639,7 @@ const auto params_OneAxis_fusing_KeepNoDims = testing::Combine(
             testing::ValuesIn(axes),
             testing::ValuesIn(opTypes),
             testing::Values(false),
-            testing::ValuesIn(reductionTypes),
+            testing::ValuesIn(reductionTypesFusing),
             testing::ValuesIn(inpOutPrc),
             testing::Values(ElementType::undefined),
             testing::Values(ElementType::undefined),
@@ -650,7 +652,7 @@ const auto params_MultiAxis_4D_Hybrid_fusing_KeepNoDims = testing::Combine(
             testing::ValuesIn(axesNDFusing),
             testing::Values(CommonTestUtils::OpType::VECTOR),
             testing::Values(false),
-            testing::ValuesIn(reductionTypes),
+            testing::ValuesIn(reductionTypesFusing),
             testing::ValuesIn(inpOutPrc),
             testing::Values(ElementType::undefined),
             testing::Values(ElementType::undefined),
@@ -663,7 +665,7 @@ const auto params_MultiAxis_5D_Hybrid_fusing_KeepNoDims = testing::Combine(
             testing::ValuesIn(axes5DFusing),
             testing::Values(CommonTestUtils::OpType::VECTOR),
             testing::Values(false),
-            testing::ValuesIn(reductionTypes),
+            testing::ValuesIn(reductionTypesFusing),
             testing::ValuesIn(inpOutPrc),
             testing::Values(ElementType::undefined),
             testing::Values(ElementType::undefined),


### PR DESCRIPTION
### Details:
 - Due to dynamism support on CPU number of functional test cases and as a consequence tests running time significantly increased. This may cause precommit jobs failures due to timeout. The PR desceases number of test cases for "bottleneck" operations by moving them in nightly scope or deleting non-important cases at all.
 - Tests running time decrease (measured locally):
 -- Interpolate: ~4x
 -- Reduce: ~2.5x
 -- Pad: ~7x
- How this PR affect cpuFuncTests execution time? 
-- WIP
