### PR TITLE
Failure of quantization for some models due to absence ShuffleChannels operation in some set

### DIFF
--- a/model-optimizer/extensions/back/op_versioning.py
+++ b/model-optimizer/extensions/back/op_versioning.py
@@ -101,6 +101,7 @@ class OpVersioning(BackReplacementPattern):
         "Select",
         "Selu",
         "ShapeOf",
+        "ShuffleChannels",
         "Sigmoid",
         "Sign",
         "Sin",


### PR DESCRIPTION
Root cause analysis: 
When Caffe model contains the operation `ShuffleChannel` (this Caffe operation is converted to OV `ShuffleChannels` operation) or ONNX model contains a pattern that can be converted in OV `ShuffleChannels` operation, we have a failure of quantization, because there are no  `ShuffleChannels` operation into `OpVersioning.opset_1_types` set, although there is an operation  `ShuffleChannels` in OV opset1.

Solution:
Add `ShuffleChannels` operation into `OpVersioning.opset_1_types` set.

Ticket: CVS 72264

Code:
* [x]  Comments
* [x]  Code style
* [x]  Transformation generates reshape-able IR - N/A
* [x]  Transformation preserves original framework node names - N/A


Validation:
* [x]  Unit tests
* [x]  Framework operation tests  - N/A
* [x]  Transformation tests - N/A
* [x]  Model Optimizer IR Reader check - N/A

Documentation:
* [x]  Supported frameworks operations list - N/A
* [x]  Guide on how to convert the **public** model - N/A
* [x]  User guide update - N/A