### PR TITLE
Initial implementation for transformations accuracy checks

### DIFF
--- a/inference-engine/tests/functional/inference_engine/transformations/pruning/pruning_test_base.hpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/pruning/pruning_test_base.hpp
@@ -1,0 +1,76 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include "common_test_utils/test_common.hpp"
+#include <string>
+#include <sstream>
+#include <fstream>
+#include <memory>
+#include <queue>
+#include <map>
+
+#include <ngraph/function.hpp>
+#include <ngraph/opsets/opset8.hpp>
+#include <ngraph/coordinate_transform.hpp>
+
+#include <common_test_utils/ngraph_test_utils.hpp>
+#include <shared_test_classes/base/layer_test_utils.hpp>
+
+using namespace testing;
+using namespace ngraph;
+
+class PruningTestsCommon: public CommonTestUtils::TestsCommon {
+public:
+    void Run() {
+        try {
+            std::vector<std::vector<uint8_t>> input_data;
+            ngraph::element::TypeVector types;
+            for (auto param : function_ref->get_parameters()) {
+                types.push_back(param->get_element_type());
+
+                InferenceEngine::TensorDesc td(InferenceEngine::Precision::FP32, param->get_shape(), InferenceEngine::Layout::ANY);
+                const auto &input = FuncTestUtils::createAndFillBlob(td);
+                const auto &input_size = input->byteSize();
+
+                std::vector<uint8_t> data;
+                data.resize(input_size);
+
+                auto memory = InferenceEngine::as<InferenceEngine::MemoryBlob>(input);
+                IE_ASSERT(memory);
+
+                const auto lockedMemory = memory->wmap();
+                const auto buffer = lockedMemory.as<const std::uint8_t *>();
+                std::copy(buffer, buffer + input_size, data.data());
+
+                input_data.push_back(std::move(data));
+            }
+
+            auto ref_outputs = ngraph::helpers::interpreterFunction(function_ref, input_data, types);
+            auto outputs = ngraph::helpers::interpreterFunction(function, input_data, types);
+
+            IE_ASSERT(ref_outputs.size() == outputs.size());
+
+            for (size_t i = 0; i < ref_outputs.size(); ++i) {
+                IE_ASSERT(ref_outputs[i].second.size() == outputs[i].second.size());
+                auto * ref = reinterpret_cast<float *>(ref_outputs[i].second.data());
+                auto * out = reinterpret_cast<float *>(outputs[i].second.data());
+                IE_ASSERT(ref_outputs[i].second.size() / 8);
+                size_t size = ref_outputs[i].second.size() / sizeof(float);
+                LayerTestsUtils::LayerTestsCommon::Compare<float, float>(ref, out, size, 1e-5);
+            }
+        }
+        catch (const std::runtime_error &re) {
+            GTEST_FATAL_FAILURE_(re.what());
+        } catch (const std::exception &ex) {
+            GTEST_FATAL_FAILURE_(ex.what());
+        } catch (...) {
+            GTEST_FATAL_FAILURE_("Unknown failure occurred.");
+        }
+    }
+
+protected:
+    std::shared_ptr<ov::Function> function, function_ref;
+};

--- a/inference-engine/tests/functional/inference_engine/transformations/pruning/test_example.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/pruning/test_example.cpp
@@ -1,0 +1,96 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <sstream>
+#include <memory>
+
+#include <ngraph/function.hpp>
+#include <ngraph/opsets/opset8.hpp>
+
+#include <ngraph/pass/manager.hpp>
+
+#include <pruning.hpp>
+#include <mask_attribute.hpp>
+#include "pruning_test_base.hpp"
+
+using namespace testing;
+using namespace ngraph;
+
+using InputShape = ngraph::PartialShape;
+using WeightsShape = ngraph::Shape;
+
+namespace {
+Output<Node> create_constant_with_zeros(const Shape & shape, const Mask & mask) {
+    std::vector<double> values(shape_size(shape), 1);
+    for (size_t dim = 0; dim < mask.size(); ++dim) {
+        for (const auto & dim_value : mask.at(dim)) {
+            Coordinate coord_begin(shape.size(), 0);
+            coord_begin[dim] = dim_value;
+
+            Coordinate coord_end(shape);
+            coord_end[dim] = dim_value + 1;
+
+            NGRAPH_SUPPRESS_DEPRECATED_START
+            CoordinateTransform iter(shape, coord_begin, coord_end);
+            for (const Coordinate & coord : iter) {
+                values[iter.index(coord)] = 0;
+            }
+            NGRAPH_SUPPRESS_DEPRECATED_END
+        }
+    }
+    return std::make_shared<opset8::Constant>(element::f32, shape, values);
+}
+}// namespace
+
+class PruneSingleConvolutionTest: public testing::WithParamInterface<std::tuple<InputShape, WeightsShape>>,
+                                  virtual public PruningTestsCommon {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<std::tuple<InputShape, WeightsShape>>& obj) {
+        InputShape inputShapes;
+        WeightsShape weightsShape;
+        std::tie(inputShapes, weightsShape) = obj.param;
+        std::ostringstream result;
+        result << "IS=" << CommonTestUtils::partialShape2str({inputShapes}) << "_";
+        result << "WS=" << CommonTestUtils::vec2str(weightsShape);
+        return result.str();
+    }
+protected:
+    void SetUp() override {
+        InputShape inputShapes;
+        WeightsShape weightsShape;
+        std::tie(inputShapes, weightsShape) = this->GetParam();
+
+        auto param = std::make_shared<opset8::Parameter>(element::f32, inputShapes);
+        auto weights = create_constant_with_zeros(weightsShape, {{1, 2, 3}, {}, {}, {}});
+        auto conv = std::make_shared<opset8::Convolution>(param, weights, Strides(2, 1),
+                                                                          CoordinateDiff(2, 0),
+                                                                          CoordinateDiff(2, 0),
+                                                                          Strides(2, 1));
+
+        // reference function to get reference accuracy results
+        function_ref = std::make_shared<ngraph::Function>(OutputVector{conv}, ParameterVector{param}, "Convolution");
+
+        // function which is processed by Pruning transformation
+        function = ov::clone_function(*function_ref);
+
+        pass::Manager m;
+        m.register_pass<pass::Pruning>();
+        m.run_passes(function);
+
+        // Here we can check the results of Pruning (like number of shrinked elements returned somehow by Pruning)
+    }
+};
+
+TEST_P(PruneSingleConvolutionTest, AccuracyCheck) {
+    Run();
+}
+
+INSTANTIATE_TEST_SUITE_P(PruneConvolution, PruneSingleConvolutionTest,
+                         ::testing::Combine(
+                                 ::testing::Values(PartialShape{1, 6, 16, 16}),
+                                 ::testing::ValuesIn({Shape{6, 6, 1, 1}, Shape{12, 6, 1, 2}})),
+                         PruneSingleConvolutionTest::getTestCaseName);

--- a/inference-engine/tests/functional/inference_engine/transformations/pruning_test.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/pruning_test.cpp
@@ -20,6 +20,7 @@
 using namespace testing;
 using namespace ngraph;
 
+namespace {
 void compare_masks(const Mask & mask, const Mask & ref_mask) {
     ASSERT_EQ(mask.size(), ref_mask.size());
     ASSERT_EQ(mask, ref_mask);
@@ -45,6 +46,7 @@ Output<Node> create_constant_with_zeros(const Shape & shape, const Mask & mask) 
     }
     return std::make_shared<opset5::Constant>(element::f32, shape, values);
 }
+}// namespace
 
 TEST(TransformationTests, InitMasksOI) {
     Shape weights_shape{6, 3, 3, 3};


### PR DESCRIPTION
### Description
This is a draft for cases when accuracy validation is needed by transformations. As an example Pruning transformation was used to tests it. Accuracy validation for transformation doesn't require plugins so LayerTestClass doesn't suit this requirement as it fully depends on target device. So I've created an initial version for accuracy check based on Interpreter which must be productized for common use.
