### PR TITLE
Move back temp frolder to the CMAKE_SOURCE_DIR

### DIFF
--- a/.ci/azure/linux.yml
+++ b/.ci/azure/linux.yml
@@ -162,7 +162,7 @@ jobs:
         $(REPO_DIR)
       workingDirectory: $(BUILD_DIR)
 
-  - script: ls -alR $(BUILD_DIR)/temp/
+  - script: ls -alR $(REPO_DIR)/temp/
     displayName: 'List temp SDKs'
 
   - script: ccache --zero-stats --max-size=1T --show-config
@@ -207,7 +207,7 @@ jobs:
       set -e
       mkdir $(INSTALL_DIR)/opencv/
       cmake -DCMAKE_INSTALL_PREFIX=$(INSTALL_DIR) -DCOMPONENT=tests -P cmake_install.cmake
-      cp -R $(BUILD_DIR)/temp/opencv_4.5.2_ubuntu20/opencv/* $(INSTALL_DIR)/opencv/
+      cp -R $(REPO_DIR)/temp/opencv_4.5.2_ubuntu20/opencv/* $(INSTALL_DIR)/opencv/
     workingDirectory: $(BUILD_DIR)
     displayName: 'Install tests'
 

--- a/.ci/azure/linux_coverity.yml
+++ b/.ci/azure/linux_coverity.yml
@@ -73,7 +73,7 @@ jobs:
         $(REPO_DIR)
       workingDirectory: $(BUILD_DIR)
 
-  - script: ls -alR $(BUILD_DIR)/temp/
+  - script: ls -alR $(REPO_DIR)/temp/
     displayName: 'List temp SDKs'
 
   - script: |

--- a/.ci/azure/linux_lohika.yml
+++ b/.ci/azure/linux_lohika.yml
@@ -126,7 +126,7 @@ jobs:
         $(REPO_DIR)
       workingDirectory: $(BUILD_DIR)
 
-  - script: ls -alR $(BUILD_DIR)/temp/
+  - script: ls -alR $(REPO_DIR)/temp/
     displayName: 'List temp SDKs'
 
   - script: ninja
@@ -147,7 +147,7 @@ jobs:
       set -e
       mkdir $(INSTALL_DIR)/opencv/
       cmake -DCMAKE_INSTALL_PREFIX=$(INSTALL_DIR) -DCOMPONENT=tests -P cmake_install.cmake
-      cp -R $(BUILD_DIR)/temp/opencv_4.5.2_ubuntu20/opencv/* $(INSTALL_DIR)/opencv/
+      cp -R $(REPO_DIR)/temp/opencv_4.5.2_ubuntu20/opencv/* $(INSTALL_DIR)/opencv/
     workingDirectory: $(BUILD_DIR)
     displayName: 'Install tests'
 

--- a/.ci/azure/mac.yml
+++ b/.ci/azure/mac.yml
@@ -100,7 +100,7 @@ jobs:
     workingDirectory: $(BUILD_DIR)
     displayName: 'CMake'
 
-  - script: ls -alR $(BUILD_DIR)/temp/
+  - script: ls -alR $(REPO_DIR)/temp/
     displayName: 'List temp SDKs'
 
   - script: ninja
@@ -121,7 +121,7 @@ jobs:
       set -e
       mkdir $(INSTALL_DIR)/opencv/
       cmake -DCMAKE_INSTALL_PREFIX=$(INSTALL_DIR) -DCOMPONENT=tests -P cmake_install.cmake
-      cp -R $(BUILD_DIR)/temp/opencv_4.5.2_osx/opencv/* $(INSTALL_DIR)/opencv/
+      cp -R $(REPO_DIR)/temp/opencv_4.5.2_osx/opencv/* $(INSTALL_DIR)/opencv/
     workingDirectory: $(BUILD_DIR)
     displayName: 'Install tests'
 

--- a/.ci/azure/windows.yml
+++ b/.ci/azure/windows.yml
@@ -136,7 +136,7 @@ jobs:
     workingDirectory: $(BUILD_DIR)
     displayName: 'CMake'
 
-  - script: dir $(BUILD_DIR)\temp\ /s
+  - script: dir $(REPO_DIR)\temp\ /s
     displayName: 'List temp SDKs'
 
   - script: |

--- a/.ci/azure/windows_conditional_compilation.yml
+++ b/.ci/azure/windows_conditional_compilation.yml
@@ -70,7 +70,7 @@ jobs:
     workingDirectory: $(BUILD_DIR)
     displayName: 'CMake'
 
-  - script: dir $(BUILD_DIR)\temp\ /s
+  - script: dir $(REPO_DIR)\temp\ /s
     displayName: 'List temp SDKs'
 
   - script: call "$(MSVS_VARS_PATH)" && $(WORK_DIR)\ninja-win\ninja

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -5,7 +5,7 @@
 cmake_policy(SET CMP0054 NEW)
 
 # TODO: fix it
-set_temp_directory(TEMP "${CMAKE_BINARY_DIR}")
+set_temp_directory(TEMP "${CMAKE_SOURCE_DIR}")
 
 if(ENABLE_SAME_BRANCH_FOR_MODELS)
     branchName(MODELS_BRANCH)

--- a/model-optimizer/mo/utils/find_ie_version.py
+++ b/model-optimizer/mo/utils/find_ie_version.py
@@ -106,7 +106,7 @@ def find_ie_version(silent=False):
             "libs": [
                 os.path.join(script_path, '../../../bin/intel64'),
                 os.path.join(script_path, '../../../bin/intel64/Release'),
-                os.path.join(script_path, '../../../inference-engine/temp/tbb/bin'),
+                os.path.join(script_path, '../../../temp/tbb/bin'),
             ]
         },
         {
@@ -114,7 +114,7 @@ def find_ie_version(silent=False):
             "libs": [
                 os.path.join(script_path, '../../../bin/intel64'),
                 os.path.join(script_path, '../../../bin/intel64/Debug'),
-                os.path.join(script_path, '../../../inference-engine/temp/tbb/bin'),
+                os.path.join(script_path, '../../../temp/tbb/bin'),
             ]
         },
     ]

--- a/model-optimizer/mo/utils/find_ie_version.py
+++ b/model-optimizer/mo/utils/find_ie_version.py
@@ -92,14 +92,6 @@ def find_ie_version(silent=False):
 
     # Windows
     bindings_paths_windows = [
-        # Package
-        {
-            "module": os.path.join(script_path, '../../../../python/', python_version),
-            "libs": [
-                os.path.join(script_path, '../../../../runtime/bin/intel64/Release'),
-                os.path.join(script_path, '../../../../runtime/3rdparty/tbb/bin'),
-            ],
-        },
         # Local builds
         {
             "module": os.path.join(script_path, '../../../bin/intel64/Release/python_api/', python_version),
@@ -121,14 +113,6 @@ def find_ie_version(silent=False):
 
     # Linux / Darwin
     bindings_paths_linux = [
-        # Package
-        {
-            "module": os.path.join(script_path, '../../../../python/', python_version),
-            "libs": [
-                os.path.join(script_path, '../../../../runtime/lib/intel64'),
-                os.path.join(script_path, '../../../../runtime/3rdparty/tbb/lib'),
-            ],
-        },
         # Local builds
         {
             "module": os.path.join(script_path, '../../../bin/intel64/Release/lib/python_api/', python_version),


### PR DESCRIPTION
### Description
Move back temp folder with 3rd party components to the CMAKE_SOURCE_DIR so MO will be able to determine where to find libraries when it is used with local build.
CVS-71761
