### PR TITLE
Add default device value for ie.LoadNetwork

### DIFF
--- a/src/inference/include/ie/ie_core.hpp
+++ b/src/inference/include/ie/ie_core.hpp
@@ -95,6 +95,19 @@ public:
     CNNNetwork ReadNetwork(const std::string& model, const Blob::CPtr& weights) const;
 
     /**
+     * @brief Creates an executable network from a network object and uses AUTO plugin as the default device to load
+     * executable network.
+     *
+     * Users can create as many networks as they need and use
+     *        them simultaneously (up to the limitation of the hardware resources)
+     *
+     * @param network CNNNetwork object acquired from Core::ReadNetwork
+     * operation
+     * @return An executable network reference
+     */
+    ExecutableNetwork LoadNetwork(const CNNNetwork& network);
+
+    /**
      * @brief Creates an executable network from a network object.
      *
      * Users can create as many networks as they need and use
@@ -109,6 +122,19 @@ public:
     ExecutableNetwork LoadNetwork(const CNNNetwork& network,
                                   const std::string& deviceName,
                                   const std::map<std::string, std::string>& config = {});
+
+    /**
+     * @brief Reads model and creates an executable network from IR or ONNX file and uses AUTO plugin as the default
+     * device to load executable network.
+     *
+     * This can be more efficient than using ReadNetwork + LoadNetwork(CNNNetwork) flow
+     *        especially for cases when caching is enabled and cached model is available
+     *
+     * @param modelPath path to model
+     *
+     * @return An executable network reference
+     */
+    ExecutableNetwork LoadNetwork(const std::string& modelPath);
 
     /**
      * @brief Reads model and creates an executable network from IR or ONNX file
@@ -154,6 +180,15 @@ public:
     void AddExtension(IExtensionPtr extension, const std::string& deviceName);
 
     /**
+     * @brief Creates an executable network from a previously exported network and uses AUTO plugin as the default
+     * device to load executable network.
+     *
+     * @param modelFileName Path to the location of the exported file
+     * @return An executable network reference
+     */
+    ExecutableNetwork ImportNetwork(const std::string& modelFileName);
+
+    /**
      * @brief Creates an executable network from a previously exported network
      *
      * @param modelFileName Path to the location of the exported file
@@ -167,6 +202,16 @@ public:
                                     const std::map<std::string, std::string>& config = {});
 
     /**
+     * @brief Creates an executable network from a previously exported network and uses AUTO plugin as the default
+     * device to load executable network.
+     *
+     * @param networkModel network model stream
+     * operation*
+     * @return An executable network reference
+     */
+    ExecutableNetwork ImportNetwork(std::istream& networkModel);
+
+    /**
      * @brief Creates an executable network from a previously exported network
      * @param networkModel network model stream
      * @param deviceName Name of device load executable network on
@@ -177,15 +222,6 @@ public:
     ExecutableNetwork ImportNetwork(std::istream& networkModel,
                                     const std::string& deviceName,
                                     const std::map<std::string, std::string>& config = {});
-
-    /**
-     * @deprecated Use Core::ImportNetwork with explicit device name
-     * @brief Creates an executable network from a previously exported network
-     * @param networkModel network model stream
-     * @return An executable network reference
-     */
-    INFERENCE_ENGINE_DEPRECATED("Use Core::ImportNetwork with explicit device name")
-    ExecutableNetwork ImportNetwork(std::istream& networkModel);
 
     /**
      * @brief Creates an executable network from a previously exported network within a specified

--- a/src/inference/include/ie/ie_core.hpp
+++ b/src/inference/include/ie/ie_core.hpp
@@ -105,7 +105,8 @@ public:
      * operation
      * @return An executable network reference
      */
-    ExecutableNetwork LoadNetwork(const CNNNetwork& network);
+    ExecutableNetwork LoadNetwork(const CNNNetwork& network,
+                                  const std::map<std::string, std::string>& config = {});
 
     /**
      * @brief Creates an executable network from a network object.
@@ -134,7 +135,8 @@ public:
      *
      * @return An executable network reference
      */
-    ExecutableNetwork LoadNetwork(const std::string& modelPath);
+    ExecutableNetwork LoadNetwork(const std::string& modelPath,
+                                  const std::map<std::string, std::string>& config = {});
 
     /**
      * @brief Reads model and creates an executable network from IR or ONNX file

--- a/src/inference/include/ie/ie_core.hpp
+++ b/src/inference/include/ie/ie_core.hpp
@@ -102,11 +102,11 @@ public:
      *        them simultaneously (up to the limitation of the hardware resources)
      *
      * @param network CNNNetwork object acquired from Core::ReadNetwork
+     * @param config Optional map of pairs: (config parameter name, config parameter value) relevant only for this load
      * operation
      * @return An executable network reference
      */
-    ExecutableNetwork LoadNetwork(const CNNNetwork& network,
-                                  const std::map<std::string, std::string>& config = {});
+    ExecutableNetwork LoadNetwork(const CNNNetwork& network, const std::map<std::string, std::string>& config = {});
 
     /**
      * @brief Creates an executable network from a network object.
@@ -132,11 +132,12 @@ public:
      *        especially for cases when caching is enabled and cached model is available
      *
      * @param modelPath path to model
+     * @param config Optional map of pairs: (config parameter name, config parameter value) relevant only for this load
+     * operation/
      *
      * @return An executable network reference
      */
-    ExecutableNetwork LoadNetwork(const std::string& modelPath,
-                                  const std::map<std::string, std::string>& config = {});
+    ExecutableNetwork LoadNetwork(const std::string& modelPath, const std::map<std::string, std::string>& config = {});
 
     /**
      * @brief Reads model and creates an executable network from IR or ONNX file

--- a/src/inference/include/ie/ie_core.hpp
+++ b/src/inference/include/ie/ie_core.hpp
@@ -180,15 +180,6 @@ public:
     void AddExtension(IExtensionPtr extension, const std::string& deviceName);
 
     /**
-     * @brief Creates an executable network from a previously exported network and uses AUTO plugin as the default
-     * device to load executable network.
-     *
-     * @param modelFileName Path to the location of the exported file
-     * @return An executable network reference
-     */
-    ExecutableNetwork ImportNetwork(const std::string& modelFileName);
-
-    /**
      * @brief Creates an executable network from a previously exported network
      *
      * @param modelFileName Path to the location of the exported file
@@ -202,16 +193,6 @@ public:
                                     const std::map<std::string, std::string>& config = {});
 
     /**
-     * @brief Creates an executable network from a previously exported network and uses AUTO plugin as the default
-     * device to load executable network.
-     *
-     * @param networkModel network model stream
-     * operation*
-     * @return An executable network reference
-     */
-    ExecutableNetwork ImportNetwork(std::istream& networkModel);
-
-    /**
      * @brief Creates an executable network from a previously exported network
      * @param networkModel network model stream
      * @param deviceName Name of device load executable network on
@@ -222,6 +203,15 @@ public:
     ExecutableNetwork ImportNetwork(std::istream& networkModel,
                                     const std::string& deviceName,
                                     const std::map<std::string, std::string>& config = {});
+
+    /**
+     * @deprecated Use Core::ImportNetwork with explicit device name
+     * @brief Creates an executable network from a previously exported network
+     * @param networkModel network model stream
+     * @return An executable network reference
+     */
+    INFERENCE_ENGINE_DEPRECATED("Use Core::ImportNetwork with explicit device name")
+    ExecutableNetwork ImportNetwork(std::istream& networkModel);
 
     /**
      * @brief Creates an executable network from a previously exported network within a specified

--- a/src/inference/include/openvino/runtime/core.hpp
+++ b/src/inference/include/openvino/runtime/core.hpp
@@ -102,6 +102,20 @@ public:
     std::shared_ptr<ov::Model> read_model(const std::string& model, const Tensor& weights) const;
 
     /**
+     * @brief Creates an executable network from a model object and loads model to default device.
+     *
+     * Users can create as many executable networks as they need and use
+     * them simultaneously (up to the limitation of the hardware resources)
+     *
+     * @param model Model object acquired from Core::read_model
+     * @param config Optional map of pairs: (config parameter name, config parameter value) relevant only for this load
+     * operation
+     * @return An executable network reference
+     */
+    ExecutableNetwork compile_model(const std::shared_ptr<const ov::Function>& model,
+                                    const ConfigMap& config = {});
+
+    /**
      * @brief Creates an executable network from a model object.
      *
      * Users can create as many executable networks as they need and use
@@ -118,6 +132,21 @@ public:
                                 const ConfigMap& config = {});
 
     /**
+     * @brief Reads model and creates an executable network from IR or ONNX file and load model to default device.
+     *
+     * This can be more efficient than using read_model + compile_model(Model) flow
+     * especially for cases when caching is enabled and cached model is available
+     *
+     * @param model_path path to model
+     * @param config Optional map of pairs: (config parameter name, config parameter value) relevant only for this load
+     * operation/
+     *
+     * @return An executable network reference
+     */
+    ExecutableNetwork compile_model(const std::string& model_path,
+                                    const ConfigMap& config = {});
+
+     /**
      * @brief Reads model and creates an executable network from IR or ONNX file
      *
      * This can be more efficient than using read_model + compile_model(Model) flow

--- a/src/inference/include/openvino/runtime/core.hpp
+++ b/src/inference/include/openvino/runtime/core.hpp
@@ -112,8 +112,7 @@ public:
      * operation
      * @return An executable network reference
      */
-    ExecutableNetwork compile_model(const std::shared_ptr<const ov::Function>& model,
-                                    const ConfigMap& config = {});
+    CompiledModel compile_model(const std::shared_ptr<const ov::Model>& model, const ConfigMap& config = {});
 
     /**
      * @brief Creates an executable network from a model object.
@@ -143,10 +142,9 @@ public:
      *
      * @return An executable network reference
      */
-    ExecutableNetwork compile_model(const std::string& model_path,
-                                    const ConfigMap& config = {});
+    CompiledModel compile_model(const std::string& model_path, const ConfigMap& config = {});
 
-     /**
+    /**
      * @brief Reads model and creates an executable network from IR or ONNX file
      *
      * This can be more efficient than using read_model + compile_model(Model) flow

--- a/src/inference/src/ie_core.cpp
+++ b/src/inference/src/ie_core.cpp
@@ -51,7 +51,7 @@ using namespace std::placeholders;
 namespace ov {
 
 // Specify the default device when no device name is provided.
-static const char* DEFAULT_DEVICE_NAME = "DEFAULT_DEVICE";
+static const std::string DEFAULT_DEVICE_NAME = "DEFAULT_DEVICE";
 
 namespace runtime {
 

--- a/src/inference/src/ie_core.cpp
+++ b/src/inference/src/ie_core.cpp
@@ -1248,11 +1248,6 @@ void Core::AddExtension(const IExtensionPtr& extension) {
     _impl->AddExtension(extension);
 }
 
-ExecutableNetwork Core::ImportNetwork(const std::string& modelFileName) {
-    OV_ITT_SCOPED_TASK(ov::itt::domains::IE, "Core::ImportNetwork");
-    return ImportNetwork(modelFileName, DEFAULT_DEVICE_NAME);
-}
-
 ExecutableNetwork Core::ImportNetwork(const std::string& modelFileName,
                                       const std::string& deviceName,
                                       const std::map<std::string, std::string>& config) {

--- a/src/inference/src/ie_core.cpp
+++ b/src/inference/src/ie_core.cpp
@@ -1171,8 +1171,9 @@ CNNNetwork Core::ReadNetwork(const std::string& model, const Blob::CPtr& weights
     return _impl->ReadNetwork(model, weights);
 }
 
-ExecutableNetwork Core::LoadNetwork(const CNNNetwork& network) {
-    return LoadNetwork(network, DEFAULT_DEVICE_NAME);
+ExecutableNetwork Core::LoadNetwork(const CNNNetwork& network,
+                                    const std::map<std::string, std::string>& config) {
+    return LoadNetwork(network, DEFAULT_DEVICE_NAME, config);
 }
 
 ExecutableNetwork Core::LoadNetwork(const CNNNetwork& network,
@@ -1196,8 +1197,9 @@ ExecutableNetwork Core::LoadNetwork(const std::string& modelPath,
     return {exec._so, exec._ptr};
 }
 
-ExecutableNetwork Core::LoadNetwork(const std::string& modelPath) {
-    return LoadNetwork(modelPath, DEFAULT_DEVICE_NAME);
+ExecutableNetwork Core::LoadNetwork(const std::string& modelPath,
+                                    const std::map<std::string, std::string>& config) {
+    return LoadNetwork(modelPath, DEFAULT_DEVICE_NAME,config);
 }
 
 RemoteContext::Ptr Core::CreateContext(const std::string& deviceName, const ParamMap& params) {

--- a/src/inference/src/ie_core.cpp
+++ b/src/inference/src/ie_core.cpp
@@ -1460,18 +1460,28 @@ ie::CNNNetwork toCNN(const std::shared_ptr<const ngraph::Function>& model) {
 
 }  // namespace
 
-CompiledModel Core::compile_model(const std::shared_ptr<const ov::Model>& model,
-                                  const std::string& deviceName,
-                                  const ConfigMap& config) {
+ExecutableNetwork Core::compile_model(const std::shared_ptr<const ov::Function>& model,
+                                      const ConfigMap& config) {
+    return compile_model(model, DEFAULT_DEVICE_NAME, config);
+}
+
+ExecutableNetwork Core::compile_model(const std::shared_ptr<const ov::Function>& model,
+                                      const std::string& deviceName,
+                                      const ConfigMap& config) {
     OV_CORE_CALL_STATEMENT({
         auto exec = _impl->LoadNetwork(toCNN(model), deviceName, config);
         return {exec._so, exec._ptr};
     });
 }
 
-CompiledModel Core::compile_model(const std::string& modelPath,
-                                  const std::string& deviceName,
-                                  const ConfigMap& config) {
+ExecutableNetwork Core::compile_model(const std::string& modelPath,
+                                      const ConfigMap& config) {
+    return compile_model(modelPath, DEFAULT_DEVICE_NAME, config);
+}
+
+ExecutableNetwork Core::compile_model(const std::string& modelPath,
+                                      const std::string& deviceName,
+                                      const ConfigMap& config) {
     OV_CORE_CALL_STATEMENT({
         auto exec = _impl->LoadNetwork(modelPath, deviceName, config);
         return {exec._so, exec._ptr};

--- a/src/inference/src/ie_core.cpp
+++ b/src/inference/src/ie_core.cpp
@@ -51,7 +51,7 @@ using namespace std::placeholders;
 namespace ov {
 
 // Specify the default device when no device name is provided.
-static const std::string DEFAULT_DEVICE_NAME = "DEFAULT_DEVICE";
+const std::string DEFAULT_DEVICE_NAME = "DEFAULT_DEVICE";
 
 namespace runtime {
 

--- a/src/inference/src/ie_core.cpp
+++ b/src/inference/src/ie_core.cpp
@@ -45,13 +45,14 @@
 #    include "ie_plugins.hpp"
 #endif
 
-// Specify the default device when no device name is provided.
-const char* DEFAULT_DEVICE_NAME = "DEFAULT_DEVICE";
-
 using namespace InferenceEngine::PluginConfigParams;
 using namespace std::placeholders;
 
 namespace ov {
+
+// Specify the default device when no device name is provided.
+static const char* DEFAULT_DEVICE_NAME = "DEFAULT_DEVICE";
+
 namespace runtime {
 
 namespace {
@@ -735,13 +736,12 @@ public:
 
         std::lock_guard<std::mutex> lock(pluginsMutex);
         auto deviceName = pluginName;
-        if (deviceName == DEFAULT_DEVICE_NAME)
+        if (deviceName == ov::DEFAULT_DEVICE_NAME)
             deviceName = "AUTO";
         auto it = pluginRegistry.find(deviceName);
         if (it == pluginRegistry.end()) {
-            if (pluginName == DEFAULT_DEVICE_NAME)
-                IE_THROW() << "No device is provided, so AUTO device is used by default, which failed loading. Should "
-                              "you rebuild OpenVINO with the AUTO enabled or re-install accordingly?";
+            if (pluginName == ov::DEFAULT_DEVICE_NAME)
+                IE_THROW() << "No device is provided, so AUTO device is used by default, which failed loading.";
             else
                 IE_THROW() << "Device with \"" << deviceName << "\" name is not registered in the InferenceEngine";
         }
@@ -1171,9 +1171,8 @@ CNNNetwork Core::ReadNetwork(const std::string& model, const Blob::CPtr& weights
     return _impl->ReadNetwork(model, weights);
 }
 
-ExecutableNetwork Core::LoadNetwork(const CNNNetwork& network,
-                                    const std::map<std::string, std::string>& config) {
-    return LoadNetwork(network, DEFAULT_DEVICE_NAME, config);
+ExecutableNetwork Core::LoadNetwork(const CNNNetwork& network, const std::map<std::string, std::string>& config) {
+    return LoadNetwork(network, ov::DEFAULT_DEVICE_NAME, config);
 }
 
 ExecutableNetwork Core::LoadNetwork(const CNNNetwork& network,
@@ -1197,9 +1196,8 @@ ExecutableNetwork Core::LoadNetwork(const std::string& modelPath,
     return {exec._so, exec._ptr};
 }
 
-ExecutableNetwork Core::LoadNetwork(const std::string& modelPath,
-                                    const std::map<std::string, std::string>& config) {
-    return LoadNetwork(modelPath, DEFAULT_DEVICE_NAME,config);
+ExecutableNetwork Core::LoadNetwork(const std::string& modelPath, const std::map<std::string, std::string>& config) {
+    return LoadNetwork(modelPath, ov::DEFAULT_DEVICE_NAME, config);
 }
 
 RemoteContext::Ptr Core::CreateContext(const std::string& deviceName, const ParamMap& params) {
@@ -1460,28 +1458,26 @@ ie::CNNNetwork toCNN(const std::shared_ptr<const ngraph::Function>& model) {
 
 }  // namespace
 
-ExecutableNetwork Core::compile_model(const std::shared_ptr<const ov::Function>& model,
-                                      const ConfigMap& config) {
-    return compile_model(model, DEFAULT_DEVICE_NAME, config);
+CompiledModel Core::compile_model(const std::shared_ptr<const ov::Model>& model, const ConfigMap& config) {
+    return compile_model(model, ov::DEFAULT_DEVICE_NAME, config);
 }
 
-ExecutableNetwork Core::compile_model(const std::shared_ptr<const ov::Function>& model,
-                                      const std::string& deviceName,
-                                      const ConfigMap& config) {
+CompiledModel Core::compile_model(const std::shared_ptr<const ov::Model>& model,
+                                  const std::string& deviceName,
+                                  const ConfigMap& config) {
     OV_CORE_CALL_STATEMENT({
         auto exec = _impl->LoadNetwork(toCNN(model), deviceName, config);
         return {exec._so, exec._ptr};
     });
 }
 
-ExecutableNetwork Core::compile_model(const std::string& modelPath,
-                                      const ConfigMap& config) {
-    return compile_model(modelPath, DEFAULT_DEVICE_NAME, config);
+CompiledModel Core::compile_model(const std::string& modelPath, const ConfigMap& config) {
+    return compile_model(modelPath, ov::DEFAULT_DEVICE_NAME, config);
 }
 
-ExecutableNetwork Core::compile_model(const std::string& modelPath,
-                                      const std::string& deviceName,
-                                      const ConfigMap& config) {
+CompiledModel Core::compile_model(const std::string& modelPath,
+                                  const std::string& deviceName,
+                                  const ConfigMap& config) {
     OV_CORE_CALL_STATEMENT({
         auto exec = _impl->LoadNetwork(modelPath, deviceName, config);
         return {exec._so, exec._ptr};

--- a/src/tests/functional/plugin/shared/include/behavior/ov_executable_network/exec_network_base.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_executable_network/exec_network_base.hpp
@@ -61,12 +61,9 @@ public:
             // Remote tensor
             data2 = nullptr;
         }
-        return t1.get_element_type() == t2.get_element_type() &&
-            t1.get_shape() == t2.get_shape() &&
-            t1.get_byte_size() == t2.get_byte_size() &&
-            t1.get_size() == t2.get_size() &&
-            t1.get_strides() == t2.get_strides() &&
-            data1 == data2;
+        return t1.get_element_type() == t2.get_element_type() && t1.get_shape() == t2.get_shape() &&
+               t1.get_byte_size() == t2.get_byte_size() && t1.get_size() == t2.get_size() &&
+               t1.get_strides() == t2.get_strides() && data1 == data2;
     }
 
 protected:
@@ -80,7 +77,9 @@ TEST_P(OVExecutableNetworkBaseTest, canLoadCorrectNetworkToGetExecutable) {
     EXPECT_NO_THROW(auto execNet = core->compile_model(function, targetDevice, configuration));
 }
 
-TEST_P(OVExecutableNetworkBaseTest, canLoadCorrectNetworkToDefaultDevice) {
+TEST(OVLoadNetworkToDefaultDevice, canLoadCorrectNetworkToDefaultDevice) {
+    std::shared_ptr<ov::runtime::Core> core = utils::PluginCache::get().core();
+    std::shared_ptr<ov::Model> function = ngraph::builder::subgraph::makeConvPoolRelu();
     EXPECT_NO_THROW(auto execNet = core->compile_model(function));
 }
 
@@ -546,8 +545,8 @@ TEST_P(OVExecutableNetworkBaseTest, getOutputsFromSplitFunctionWithSeveralOutput
         result1->set_friendly_name("result1");
         auto result2 = std::make_shared<ov::opset8::Result>(split->output(1));
         result2->set_friendly_name("result2");
-        function = std::make_shared<ngraph::Function>(ngraph::ResultVector{result1, result2},
-                                                      ngraph::ParameterVector{param1});
+        function =
+            std::make_shared<ngraph::Function>(ngraph::ResultVector{result1, result2}, ngraph::ParameterVector{param1});
         function->set_friendly_name("SingleSplit");
     }
     execNet = core->compile_model(function, targetDevice, configuration);

--- a/src/tests/functional/plugin/shared/include/behavior/ov_executable_network/exec_network_base.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_executable_network/exec_network_base.hpp
@@ -80,6 +80,10 @@ TEST_P(OVExecutableNetworkBaseTest, canLoadCorrectNetworkToGetExecutable) {
     EXPECT_NO_THROW(auto execNet = core->compile_model(function, targetDevice, configuration));
 }
 
+TEST_P(OVExecutableNetworkBaseTest, canLoadCorrectNetworkToDefaultDevice) {
+    EXPECT_NO_THROW(auto execNet = core->compile_model(function, configuration));
+}
+
 TEST_P(OVExecutableNetworkBaseTest, canLoadCorrectNetworkToGetExecutableWithIncorrectConfig) {
     std::map<std::string, std::string> incorrectConfig = {{"abc", "def"}};
     EXPECT_ANY_THROW(auto execNet = core->compile_model(function, targetDevice, incorrectConfig));

--- a/src/tests/functional/plugin/shared/include/behavior/ov_executable_network/exec_network_base.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_executable_network/exec_network_base.hpp
@@ -77,7 +77,7 @@ TEST_P(OVExecutableNetworkBaseTest, canLoadCorrectNetworkToGetExecutable) {
     EXPECT_NO_THROW(auto execNet = core->compile_model(function, targetDevice, configuration));
 }
 
-TEST(OVLoadNetworkToDefaultDevice, canLoadCorrectNetworkToDefaultDevice) {
+TEST(OVExecutableNetworkBaseTest, smoke_LoadNetworkToDefaultDeviceNoThrow) {
     std::shared_ptr<ov::runtime::Core> core = utils::PluginCache::get().core();
     std::shared_ptr<ov::Model> function = ngraph::builder::subgraph::makeConvPoolRelu();
     EXPECT_NO_THROW(auto execNet = core->compile_model(function));

--- a/src/tests/functional/plugin/shared/include/behavior/ov_executable_network/exec_network_base.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_executable_network/exec_network_base.hpp
@@ -81,7 +81,7 @@ TEST_P(OVExecutableNetworkBaseTest, canLoadCorrectNetworkToGetExecutable) {
 }
 
 TEST_P(OVExecutableNetworkBaseTest, canLoadCorrectNetworkToDefaultDevice) {
-    EXPECT_NO_THROW(auto execNet = core->compile_model(function, configuration));
+    EXPECT_NO_THROW(auto execNet = core->compile_model(function));
 }
 
 TEST_P(OVExecutableNetworkBaseTest, canLoadCorrectNetworkToGetExecutableWithIncorrectConfig) {

--- a/src/tests/functional/plugin/shared/include/behavior/plugin/core_integration.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/plugin/core_integration.hpp
@@ -886,8 +886,11 @@ TEST_P(IEClassQueryNetworkTest, QueryNetworkHETEROWithBigDeviceIDThrows) {
 // LoadNetwork
 //
 
-TEST_P(IEClassNetworkTestP, LoadNetworkWithoutDeviceNameNoThrow) {
+TEST(IEClassNetworkTestToDefaultDevice, LoadNetworkWithoutDeviceNameNoThrow) {
   SKIP_IF_CURRENT_TEST_IS_DISABLED()
+  InferenceEngine::CNNNetwork actualCnnNetwork;
+  std::shared_ptr<ngraph::Function> actualNetwork = ngraph::builder::subgraph::makeSplitConvConcat();
+  ASSERT_NO_THROW(actualCnnNetwork = InferenceEngine::CNNNetwork(actualNetwork));
   InferenceEngine::Core  ie = BehaviorTestsUtils::createIECoreWithTemplate();
   ASSERT_NO_THROW(ie.LoadNetwork(actualCnnNetwork));
 }

--- a/src/tests/functional/plugin/shared/include/behavior/plugin/core_integration.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/plugin/core_integration.hpp
@@ -357,6 +357,11 @@ TEST(IEClassBasicTest, smoke_ImportNetworkMultiThrows) {
     ASSERT_THROW(ie.ImportNetwork("model", CommonTestUtils::DEVICE_MULTI), InferenceEngine::NetworkNotRead);
 }
 
+TEST(IEClassBasicTest, smoke_ImportNetworkDefaultThrows) {
+    InferenceEngine::Core ie = BehaviorTestsUtils::createIECoreWithTemplate();
+    ASSERT_THROW(ie.ImportNetwork("model"), InferenceEngine::NetworkNotRead);
+}
+
 TEST_P(IEClassBasicTestP, ImportNetworkWithNullContextThrows) {
     InferenceEngine::Core  ie = BehaviorTestsUtils::createIECoreWithTemplate();
     InferenceEngine::RemoteContext::Ptr context = nullptr;
@@ -885,6 +890,12 @@ TEST_P(IEClassQueryNetworkTest, QueryNetworkHETEROWithBigDeviceIDThrows) {
 //
 // LoadNetwork
 //
+
+TEST_P(IEClassNetworkTestP, LoadNetworkWithoutDeviceNameNoThrow) {
+  SKIP_IF_CURRENT_TEST_IS_DISABLED()
+  InferenceEngine::Core  ie = BehaviorTestsUtils::createIECoreWithTemplate();
+  ASSERT_NO_THROW(ie.LoadNetwork(actualCnnNetwork));
+}
 
 TEST_P(IEClassNetworkTestP, LoadNetworkActualNoThrow) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()

--- a/src/tests/functional/plugin/shared/include/behavior/plugin/core_integration.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/plugin/core_integration.hpp
@@ -886,8 +886,7 @@ TEST_P(IEClassQueryNetworkTest, QueryNetworkHETEROWithBigDeviceIDThrows) {
 // LoadNetwork
 //
 
-TEST(IEClassNetworkTestToDefaultDevice, LoadNetworkWithoutDeviceNameNoThrow) {
-  SKIP_IF_CURRENT_TEST_IS_DISABLED()
+TEST(IEClassBasicTest, smoke_LoadNetworkToDefaultDeviceNoThrow) {
   InferenceEngine::CNNNetwork actualCnnNetwork;
   std::shared_ptr<ngraph::Function> actualNetwork = ngraph::builder::subgraph::makeSplitConvConcat();
   ASSERT_NO_THROW(actualCnnNetwork = InferenceEngine::CNNNetwork(actualNetwork));

--- a/src/tests/functional/plugin/shared/include/behavior/plugin/core_integration.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/plugin/core_integration.hpp
@@ -357,11 +357,6 @@ TEST(IEClassBasicTest, smoke_ImportNetworkMultiThrows) {
     ASSERT_THROW(ie.ImportNetwork("model", CommonTestUtils::DEVICE_MULTI), InferenceEngine::NetworkNotRead);
 }
 
-TEST(IEClassBasicTest, smoke_ImportNetworkDefaultThrows) {
-    InferenceEngine::Core ie = BehaviorTestsUtils::createIECoreWithTemplate();
-    ASSERT_THROW(ie.ImportNetwork("model"), InferenceEngine::NetworkNotRead);
-}
-
 TEST_P(IEClassBasicTestP, ImportNetworkWithNullContextThrows) {
     InferenceEngine::Core  ie = BehaviorTestsUtils::createIECoreWithTemplate();
     InferenceEngine::RemoteContext::Ptr context = nullptr;


### PR DESCRIPTION
Signed-off-by: Wang, Yang <yang4.wang@intel.com>

### Details:
 - Add LoadNetwork API using AUTO as the default device to load executable network.
 - Add related test cases.

### Tickets:
 - https://jira.devtools.intel.com/browse/CVS-57530
