### PR TITLE
[GNA] Color conversion operations negative tests

### DIFF
--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/convert_color_i420.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/convert_color_i420.cpp
@@ -1,0 +1,35 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "single_layer_tests/convert_color_i420.hpp"
+#include "common_test_utils/test_constants.hpp"
+#include "negative_layer_support_test.hpp"
+
+using namespace LayerTestsDefinitions;
+
+namespace {
+
+const std::vector<ov::Shape> inShapes_nhwc = {
+        {1, 10, 10, 1}
+};
+
+const std::vector<ov::element::Type> inTypes = {
+        ov::element::u8,
+        ov::element::f32
+};
+
+const auto testCase_values = ::testing::Combine(
+        ::testing::ValuesIn(inShapes_nhwc),
+        ::testing::ValuesIn(inTypes),
+        ::testing::Bool(),
+        ::testing::Bool(),
+        ::testing::Values(CommonTestUtils::DEVICE_GNA)
+);
+
+
+GNA_UNSUPPPORTED_LAYER_NEG_TEST(ConvertColorI420LayerTest, "The plugin does not support layer", testCase_values)
+
+}  // namespace

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/convert_color_nv12.cpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/convert_color_nv12.cpp
@@ -1,0 +1,35 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "single_layer_tests/convert_color_nv12.hpp"
+#include "common_test_utils/test_constants.hpp"
+#include "negative_layer_support_test.hpp"
+
+using namespace LayerTestsDefinitions;
+
+namespace {
+
+const std::vector<ov::Shape> inShapes_nhwc = {
+    {1, 10, 10, 1}
+};
+
+const std::vector<ov::element::Type> inTypes = {
+        ov::element::u8,
+        ov::element::f32
+};
+
+const auto testCase_values = ::testing::Combine(
+    ::testing::ValuesIn(inShapes_nhwc),
+    ::testing::ValuesIn(inTypes),
+    ::testing::Bool(),
+    ::testing::Bool(),
+    ::testing::Values(CommonTestUtils::DEVICE_GNA)
+);
+
+
+GNA_UNSUPPPORTED_LAYER_NEG_TEST(ConvertColorNV12LayerTest, "The plugin does not support layer", testCase_values)
+
+}  // namespace

--- a/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/negative_layer_support_test.hpp
+++ b/inference-engine/tests/functional/plugin/gna/shared_tests_instances/single_layer_tests/negative_layer_support_test.hpp
@@ -1,0 +1,33 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+namespace LayerTestsDefinitions {
+
+#define GNA_UNSUPPPORTED_LAYER_NEG_TEST(test_class, expected_error_substring, test_configuration)       \
+class Negative##test_class : public test_class {                                                        \
+public:                                                                                                 \
+        void Run() override {                                                                           \
+                try {                                                                                   \
+                        test_class::LoadNetwork();                                                      \
+                        FAIL() << "GNA's unsupported layers were not detected during LoadNetwork()";    \
+                }                                                                                       \
+                catch (std::runtime_error& e) {                                                         \
+                        const std::string errorMsg = e.what();                                          \
+                        const auto expectedMsg = expected_error_substring;                              \
+                        ASSERT_STR_CONTAINS(errorMsg, expectedMsg);                                     \
+                        EXPECT_TRUE(errorMsg.find(expectedMsg) != std::string::npos)                    \
+                        << "Wrong error message, actual error message: " << errorMsg                    \
+                        << ", expected: " << expectedMsg;                                               \
+                }                                                                                       \
+        }                                                                                               \
+};                                                                                                      \
+                                                                                                        \
+TEST_P(Negative##test_class, ThrowAsNotSupported) {                                                     \
+    Run();                                                                                              \
+}                                                                                                       \
+                                                                                                        \
+INSTANTIATE_TEST_SUITE_P(smoke_NegativeTestsUnsupportedLayer, Negative##test_class,                     \
+                         test_configuration, Negative##test_class::getTestCaseName);
+
+}  // namespace LayerTestsDefinitions


### PR DESCRIPTION
### Details:
 - Template for creation of negative single layer tests which expects certain fail on `LoadNetwork()` call
 - Negative tests added (using template) for color conversion operations: 
 `i420toBGR-8` and `i420toRGB-8`
 `NV12toBGR-8` and `NV12toRGB-8`

### Tickets:
 - *71205*
 - *71218*
