### PR TITLE
[LPT] Fix not thread safe function setDefaultPrecisions

### DIFF
--- a/src/common/low_precision_transformations/include/low_precision/layer_transformation.hpp
+++ b/src/common/low_precision_transformations/include/low_precision/layer_transformation.hpp
@@ -196,6 +196,7 @@ inline std::ostream &operator << (std::ostream &os, const DataPrecision& value) 
 class LP_TRANSFORMATIONS_API LayerTransformation : public ngraph::pass::MatcherPass {
     static std::vector<ngraph::element::Type> defaultPrecisions;
     static std::mutex defaultPrecisionsMutex;
+
 public:
     class Params {
     public:

--- a/src/common/low_precision_transformations/include/low_precision/layer_transformation.hpp
+++ b/src/common/low_precision_transformations/include/low_precision/layer_transformation.hpp
@@ -194,6 +194,8 @@ inline std::ostream &operator << (std::ostream &os, const DataPrecision& value) 
 
 // Base class for all LP transformations, holds some common data structures
 class LP_TRANSFORMATIONS_API LayerTransformation : public ngraph::pass::MatcherPass {
+    static std::vector<ngraph::element::Type> defaultPrecisions;
+    static std::mutex defaultPrecisionsMutex;
 public:
     class Params {
     public:
@@ -267,6 +269,9 @@ public:
             const std::shared_ptr<Node>& layer,
             const QuantizationDetails& quantizationDetails,
             const std::vector<element::Type>& precisions);
+
+    static void setDefaultPrecisions(const std::vector<ngraph::element::Type>& precisions);
+    static std::vector<ngraph::element::Type> getDefaultPrecisions();
 
 protected:
 #ifdef LPT_PRINT_DEQUANTIZATION_INFO

--- a/src/common/low_precision_transformations/include/low_precision/rt_info/precisions_attribute.hpp
+++ b/src/common/low_precision_transformations/include/low_precision/rt_info/precisions_attribute.hpp
@@ -23,8 +23,8 @@ namespace ngraph {
 class LP_TRANSFORMATIONS_API PrecisionsAttribute : public SharedAttribute<std::vector<ngraph::element::Type>> {
 public:
     OPENVINO_RTTI("LowPrecision::Precisions", "", ov::RuntimeAttribute, 0);
-    static std::vector<ngraph::element::Type> defaultPrecisions;
-    static std::mutex defaultPrecisions_guard;
+    static void setDefaultPrecisions(const std::vector<ngraph::element::Type>& precisions);
+    static std::vector<ngraph::element::Type> getDefaultPrecisions();
     PrecisionsAttribute(const std::vector<ngraph::element::Type>& precisions = defaultPrecisions);
 
     static ov::Any create(

--- a/src/common/low_precision_transformations/include/low_precision/rt_info/precisions_attribute.hpp
+++ b/src/common/low_precision_transformations/include/low_precision/rt_info/precisions_attribute.hpp
@@ -22,8 +22,6 @@ namespace ngraph {
 class LP_TRANSFORMATIONS_API PrecisionsAttribute : public SharedAttribute<std::vector<ngraph::element::Type>> {
 public:
     OPENVINO_RTTI("LowPrecision::Precisions", "", ov::RuntimeAttribute, 0);
-    static void setDefaultPrecisions(const std::vector<ngraph::element::Type>& precisions);
-    static std::vector<ngraph::element::Type> getDefaultPrecisions();
     PrecisionsAttribute(const std::vector<ngraph::element::Type>& precisions);
 
     static ov::Any create(

--- a/src/common/low_precision_transformations/include/low_precision/rt_info/precisions_attribute.hpp
+++ b/src/common/low_precision_transformations/include/low_precision/rt_info/precisions_attribute.hpp
@@ -13,7 +13,6 @@
 #include <ngraph/pass/graph_rewrite.hpp>
 #include <ngraph/variant.hpp>
 
-#include "low_precision/layer_transformation.hpp"
 #include "low_precision/lpt_visibility.hpp"
 #include "low_precision/rt_info/attribute_parameters.hpp"
 #include "low_precision/rt_info/shared_value_attribute.hpp"
@@ -25,7 +24,7 @@ public:
     OPENVINO_RTTI("LowPrecision::Precisions", "", ov::RuntimeAttribute, 0);
     static void setDefaultPrecisions(const std::vector<ngraph::element::Type>& precisions);
     static std::vector<ngraph::element::Type> getDefaultPrecisions();
-    PrecisionsAttribute(const std::vector<ngraph::element::Type>& precisions = defaultPrecisions);
+    PrecisionsAttribute(const std::vector<ngraph::element::Type>& precisions);
 
     static ov::Any create(
         const std::shared_ptr<ngraph::Node>& node,

--- a/src/common/low_precision_transformations/include/low_precision/rt_info/precisions_attribute.hpp
+++ b/src/common/low_precision_transformations/include/low_precision/rt_info/precisions_attribute.hpp
@@ -24,6 +24,7 @@ class LP_TRANSFORMATIONS_API PrecisionsAttribute : public SharedAttribute<std::v
 public:
     OPENVINO_RTTI("LowPrecision::Precisions", "", ov::RuntimeAttribute, 0);
     static std::vector<ngraph::element::Type> defaultPrecisions;
+    static std::mutex defaultPrecisions_guard;
     PrecisionsAttribute(const std::vector<ngraph::element::Type>& precisions = defaultPrecisions);
 
     static ov::Any create(

--- a/src/common/low_precision_transformations/src/fake_quantize_decomposition.cpp
+++ b/src/common/low_precision_transformations/src/fake_quantize_decomposition.cpp
@@ -320,7 +320,7 @@ bool FakeQuantizeDecompositionTransformation::transform(TransformationContext& c
 
     DataPrecision dataPrecision = fq_decomposition::getDataPrecisionByOutputPort(layer);
 
-    PrecisionsAttribute precisionsAttribute;
+    PrecisionsAttribute precisionsAttribute(getDefaultPrecisions());
     {
         // TODO: LPT: return attribute (not wrapper)
         auto attributeWrapper = getAttributeFromOutput<PrecisionsAttribute>(layer->output(0));

--- a/src/common/low_precision_transformations/src/layer_transformation.cpp
+++ b/src/common/low_precision_transformations/src/layer_transformation.cpp
@@ -23,6 +23,10 @@ namespace low_precision {
 
 constexpr char LayerTransformation::originalLayerPostfix[];
 
+// order defines default precision
+std::vector<ngraph::element::Type> LayerTransformation::defaultPrecisions = { ngraph::element::u8,  ngraph::element::i8 };
+std::mutex LayerTransformation::defaultPrecisionsMutex;
+
 LayerTransformation::LayerTransformation(const Params& params) :
     updatePrecisions(params.updatePrecisions),
     deqPrecision(params.deqPrecision),
@@ -440,6 +444,16 @@ void LayerTransformation::addPattern(ngraph::pass::GraphRewrite& pass, Transform
     NGRAPH_SUPPRESS_DEPRECATED_START
     pass.add_matcher(m, internal_callback, ngraph::pass::PassProperty::CHANGE_DYNAMIC_STATE);
     NGRAPH_SUPPRESS_DEPRECATED_END
+}
+
+void LayerTransformation::setDefaultPrecisions(const std::vector<ngraph::element::Type>& precisions) {
+    std::lock_guard<std::mutex> lock(defaultPrecisionsMutex);
+    defaultPrecisions = precisions;
+}
+
+std::vector<ngraph::element::Type> LayerTransformation::getDefaultPrecisions() {
+    std::lock_guard<std::mutex> lock(defaultPrecisionsMutex);
+    return defaultPrecisions;
 }
 
 }  // namespace low_precision

--- a/src/common/low_precision_transformations/src/low_precision.cpp
+++ b/src/common/low_precision_transformations/src/low_precision.cpp
@@ -303,5 +303,6 @@ bool ngraph::pass::low_precision::LowPrecision::isFQLevelsPresent(
 }
 
 void ngraph::pass::low_precision::LowPrecision::setDefaultPrecisions(const std::vector<element::Type>& precisions) {
+    std::lock_guard<std::mutex> lock(PrecisionsAttribute::defaultPrecisions_guard);
     ngraph::PrecisionsAttribute::defaultPrecisions = precisions;
 }

--- a/src/common/low_precision_transformations/src/low_precision.cpp
+++ b/src/common/low_precision_transformations/src/low_precision.cpp
@@ -303,6 +303,5 @@ bool ngraph::pass::low_precision::LowPrecision::isFQLevelsPresent(
 }
 
 void ngraph::pass::low_precision::LowPrecision::setDefaultPrecisions(const std::vector<element::Type>& precisions) {
-    std::lock_guard<std::mutex> lock(PrecisionsAttribute::defaultPrecisions_guard);
-    ngraph::PrecisionsAttribute::defaultPrecisions = precisions;
+    ngraph::PrecisionsAttribute::setDefaultPrecisions(precisions);
 }

--- a/src/common/low_precision_transformations/src/low_precision.cpp
+++ b/src/common/low_precision_transformations/src/low_precision.cpp
@@ -303,5 +303,5 @@ bool ngraph::pass::low_precision::LowPrecision::isFQLevelsPresent(
 }
 
 void ngraph::pass::low_precision::LowPrecision::setDefaultPrecisions(const std::vector<element::Type>& precisions) {
-    ngraph::PrecisionsAttribute::setDefaultPrecisions(precisions);
+    LayerTransformation::setDefaultPrecisions(precisions);
 }

--- a/src/common/low_precision_transformations/src/mat_mul.cpp
+++ b/src/common/low_precision_transformations/src/mat_mul.cpp
@@ -56,7 +56,7 @@ bool MatMulTransformation::transform(TransformationContext &context, ngraph::pat
 
             const auto precisionsAttribute = getAttributeFromOutput<PrecisionsAttribute>(fakeQuantize);
             const auto precisions = precisionsAttribute.empty() ?
-                PrecisionsAttribute::defaultPrecisions :
+                getDefaultPrecisions() :
                 precisionsAttribute.as<PrecisionsAttribute>().value();
             const DataPrecision dataPrecision = getDataPrecision(fakeQuantize, quantizationDetails, precisions);
 
@@ -261,7 +261,7 @@ bool MatMulTransformation::canBeTransformed(const TransformationContext& context
 
         const auto precisionsAttribute = getAttribute<PrecisionsAttribute>(matMul->input(1));
         const auto precisions = precisionsAttribute.empty() ?
-            PrecisionsAttribute::defaultPrecisions :
+            getDefaultPrecisions() :
             precisionsAttribute.as<PrecisionsAttribute>().value();
 
         const DataPrecision dataPrecision = getDataPrecision(fakeQuantize, quantizationDetails, precisions);

--- a/src/common/low_precision_transformations/src/multiply_to_group_convolution.cpp
+++ b/src/common/low_precision_transformations/src/multiply_to_group_convolution.cpp
@@ -68,7 +68,7 @@ bool MultiplyToGroupConvolutionTransformation::transform(TransformationContext& 
         if (weightsPrecision == element::undefined) {
             const auto precisionsAttribute = getAttribute<PrecisionsAttribute>(multiply->input(inputIndex == 0ul ? 1ul : 0ul));
             const auto precisions = precisionsAttribute == nullptr ?
-                PrecisionsAttribute::defaultPrecisions :
+                getDefaultPrecisions() :
                 precisionsAttribute.as<PrecisionsAttribute>().value();
             weightsPrecision = precisions[0];
         }

--- a/src/common/low_precision_transformations/src/rt_info/precisions_attribute.cpp
+++ b/src/common/low_precision_transformations/src/rt_info/precisions_attribute.cpp
@@ -18,6 +18,7 @@ using namespace ov;
 
 // order defines default precision
 std::vector<ngraph::element::Type> PrecisionsAttribute::defaultPrecisions = {ngraph::element::u8,  ngraph::element::i8};
+std::mutex PrecisionsAttribute::defaultPrecisions_guard;
 
 PrecisionsAttribute::PrecisionsAttribute(const std::vector<ngraph::element::Type>& precisions) :
     SharedAttribute(precisions) {

--- a/src/common/low_precision_transformations/src/rt_info/precisions_attribute.cpp
+++ b/src/common/low_precision_transformations/src/rt_info/precisions_attribute.cpp
@@ -12,23 +12,10 @@
 
 #include <ngraph/opsets/opset1.hpp>
 #include "low_precision/network_helper.hpp"
+#include "low_precision/layer_transformation.hpp"
 
 using namespace ngraph;
 using namespace ov;
-
-// order defines default precision
-std::vector<ngraph::element::Type> PrecisionsAttribute::defaultPrecisions = { ngraph::element::u8,  ngraph::element::i8 };
-std::mutex PrecisionsAttribute::defaultPrecisionsMutex;
-
-void PrecisionsAttribute::setDefaultPrecisions(const std::vector<ngraph::element::Type>& precisions) {
-    std::lock_guard<std::mutex> lock(PrecisionsAttribute::defaultPrecisionsMutex);
-    PrecisionsAttribute::defaultPrecisions = precisions;
-}
-
-std::vector<ngraph::element::Type> PrecisionsAttribute::getDefaultPrecisions() {
-    std::lock_guard<std::mutex> lock(PrecisionsAttribute::defaultPrecisionsMutex);
-    return PrecisionsAttribute::defaultPrecisions;
-}
 
 PrecisionsAttribute::PrecisionsAttribute(const std::vector<ngraph::element::Type>& precisions) :
     SharedAttribute(precisions) {
@@ -38,7 +25,8 @@ ov::Any PrecisionsAttribute::create(
     const std::shared_ptr<ngraph::Node>& node,
     const AttributeParameters& params) {
     auto& rt = ov::is_type<opset1::FakeQuantize>(node) ? node->output(0).get_rt_info() : node->get_rt_info();
-    return (rt[PrecisionsAttribute::get_type_info_static()] = PrecisionsAttribute());
+    return (rt[PrecisionsAttribute::get_type_info_static()] = PrecisionsAttribute(
+        ngraph::pass::low_precision::LayerTransformation::getDefaultPrecisions()));
 }
 
 void PrecisionsAttribute::merge(std::vector<ov::Any>& attributes) {

--- a/src/common/low_precision_transformations/src/rt_info/precisions_attribute.cpp
+++ b/src/common/low_precision_transformations/src/rt_info/precisions_attribute.cpp
@@ -17,8 +17,18 @@ using namespace ngraph;
 using namespace ov;
 
 // order defines default precision
-std::vector<ngraph::element::Type> PrecisionsAttribute::defaultPrecisions = {ngraph::element::u8,  ngraph::element::i8};
-std::mutex PrecisionsAttribute::defaultPrecisions_guard;
+std::vector<ngraph::element::Type> PrecisionsAttribute::defaultPrecisions = { ngraph::element::u8,  ngraph::element::i8 };
+std::mutex PrecisionsAttribute::defaultPrecisionsMutex;
+
+void PrecisionsAttribute::setDefaultPrecisions(const std::vector<ngraph::element::Type>& precisions) {
+    std::lock_guard<std::mutex> lock(PrecisionsAttribute::defaultPrecisionsMutex);
+    PrecisionsAttribute::defaultPrecisions = precisions;
+}
+
+std::vector<ngraph::element::Type> PrecisionsAttribute::getDefaultPrecisions() {
+    std::lock_guard<std::mutex> lock(PrecisionsAttribute::defaultPrecisionsMutex);
+    return PrecisionsAttribute::defaultPrecisions;
+}
 
 PrecisionsAttribute::PrecisionsAttribute(const std::vector<ngraph::element::Type>& precisions) :
     SharedAttribute(precisions) {

--- a/src/common/low_precision_transformations/src/weightable_layer_transformation.cpp
+++ b/src/common/low_precision_transformations/src/weightable_layer_transformation.cpp
@@ -300,7 +300,7 @@ bool WeightableLayerTransformation::decomposeFakeQuantizeForWeightsPath(const st
     const QuantizationDetails quantizationDetails = QuantizationDetails::getDetails(fq);
     const auto precisionsAttribute = getAttributeFromOutput<PrecisionsAttribute>(fq);
     const auto precisions = precisionsAttribute.empty() ?
-        PrecisionsAttribute::defaultPrecisions :
+        getDefaultPrecisions() :
         precisionsAttribute.as<PrecisionsAttribute>().value();
 
     const DataPrecision dataPrecision = getDataPrecision(fq, quantizationDetails, precisions);
@@ -367,7 +367,7 @@ DataPrecision WeightableLayerTransformation::getDataPrecisionOnWeights(const std
 
     const auto precisionsAttribute = getAttributeFromOutput<PrecisionsAttribute>(fq);
     const auto precisions = precisionsAttribute.empty() ?
-        PrecisionsAttribute::defaultPrecisions :
+        getDefaultPrecisions() :
         precisionsAttribute.as<PrecisionsAttribute>().value();
 
     return getDataPrecision(fq, quantizationDetails, precisions);


### PR DESCRIPTION
### Details:
LPT has defaultPrecisions global non-const variable

### Tickets:
55743
