### PR TITLE
fix to pass sr_stridedslice_squeeze

### DIFF
--- a/inference-engine/tests/functional/inference_engine/transformations/sr_strided_slice_squeeze.cpp
+++ b/inference-engine/tests/functional/inference_engine/transformations/sr_strided_slice_squeeze.cpp
@@ -37,6 +37,64 @@ TEST(SmartReshapeTests, SS_Squeeze) {
     ASSERT_TRUE(network.getFunction()->get_parameters()[0]->get_partial_shape().compatible({2, 3}));
 }
 
+TEST(SmartReshapeTests, SS_Squeeze_partial_begin_end_mask) {
+    std::shared_ptr<ngraph::Function> f(nullptr);
+    {
+        auto input = std::make_shared<ngraph::opset5::Parameter>(ngraph::element::f32, ngraph::Shape{1, 128, 768});
+        auto ss = std::make_shared<ngraph::opset5::StridedSlice>(
+                input,
+                ngraph::opset5::Constant::create(ngraph::element::i64, {3}, {0, 1, 0}),
+                ngraph::opset5::Constant::create(ngraph::element::i64, {3}, {0, 2, 768}),
+                ngraph::opset5::Constant::create(ngraph::element::i64, {3}, {1, 1, 1}),
+                std::vector<int64_t>{0}, std::vector<int64_t>{1});  // begin_mask.size() is no larger than axis that is going to be squeezed.
+        auto squeeze = std::make_shared<ngraph::opset5::Squeeze>(ss, ngraph::opset5::Constant::create(ngraph::element::i64, {1}, {1}));
+
+        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{squeeze}, ngraph::ParameterVector{input});
+    }
+
+    InferenceEngine::CNNNetwork network(f);
+
+    ASSERT_TRUE(network.getFunction()->get_results()[0]->get_output_partial_shape(0).compatible({1, 768})) <<
+        network.getFunction()->get_results()[0]->get_output_partial_shape(0);
+    ASSERT_TRUE(network.getFunction()->get_parameters()[0]->get_partial_shape().compatible({1, 128, 768}));
+
+    auto inputname = network.getFunction()->get_parameters()[0]->get_friendly_name();
+    ASSERT_NO_THROW(network.reshape(InferenceEngine::ICNNNetwork::InputShapes{{inputname, {2, 128, 768}}}));
+
+    ASSERT_TRUE(network.getFunction()->get_results()[0]->get_output_partial_shape(0).compatible({2, 768})) <<
+        network.getFunction()->get_results()[0]->get_output_partial_shape(0);
+    ASSERT_TRUE(network.getFunction()->get_parameters()[0]->get_partial_shape().compatible({2, 128, 768}));
+}
+
+
+TEST(SmartReshapeTests, SS_Squeeze_partial_begin_end) {
+    std::shared_ptr<ngraph::Function> f(nullptr);
+    {
+        auto input = std::make_shared<ngraph::opset5::Parameter>(ngraph::element::f32, ngraph::Shape{1, 1, 768});
+        auto ss = std::make_shared<ngraph::opset5::StridedSlice>(
+                input,
+                ngraph::opset5::Constant::create(ngraph::element::i64, {1}, {0}),  // begin.size() is no larger than axis that is going to be squeezed.
+                ngraph::opset5::Constant::create(ngraph::element::i64, {1}, {0}),
+                ngraph::opset5::Constant::create(ngraph::element::i64, {1}, {1}),
+                std::vector<int64_t>{1, 1, 1}, std::vector<int64_t>{1, 1, 1});
+        auto squeeze = std::make_shared<ngraph::opset5::Squeeze>(ss, ngraph::opset5::Constant::create(ngraph::element::i64, {1}, {1}));
+
+        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{squeeze}, ngraph::ParameterVector{input});
+    }
+
+    InferenceEngine::CNNNetwork network(f);
+
+    ASSERT_TRUE(network.getFunction()->get_results()[0]->get_output_partial_shape(0).compatible({1, 768})) <<
+        network.getFunction()->get_results()[0]->get_output_partial_shape(0);
+    ASSERT_TRUE(network.getFunction()->get_parameters()[0]->get_partial_shape().compatible({1, 1, 768}));
+
+    auto inputname = network.getFunction()->get_parameters()[0]->get_friendly_name();
+    ASSERT_NO_THROW(network.reshape(InferenceEngine::ICNNNetwork::InputShapes{{inputname, {2, 1, 768}}}));
+
+    ASSERT_TRUE(network.getFunction()->get_results()[0]->get_output_partial_shape(0).compatible({2, 768})) <<
+        network.getFunction()->get_results()[0]->get_output_partial_shape(0);
+    ASSERT_TRUE(network.getFunction()->get_parameters()[0]->get_partial_shape().compatible({2, 1, 768}));
+}
 
 TEST(SmartReshapeTests, SS_Squeeze_mask_use_negative) {
     std::shared_ptr<ngraph::Function> f(nullptr);

--- a/src/core/src/pass/smart_reshape/strided_slice_squeeze.cpp
+++ b/src/core/src/pass/smart_reshape/strided_slice_squeeze.cpp
@@ -56,11 +56,9 @@ ngraph::pass::StridedSliceSqueeze::StridedSliceSqueeze() {
             }))
             return false;
 
-        auto const_axes_tmp = const_axes->cast_vector<int64_t>();
-
         const auto& axes = normalize_axes(squeeze->description(),
-                                          const_axes->cast_vector<int64_t>(),           // [1]
-                                          squeeze->get_input_partial_shape(0).rank());  // 3
+                                          const_axes->cast_vector<int64_t>(),
+                                          squeeze->get_input_partial_shape(0).rank());
 
         // Here squeeze input shape is equal to stridedslice input shape,
         // since new_axis_mask, shrink_axis_mask and ellipsis_mask are all zeros.
@@ -84,7 +82,6 @@ ngraph::pass::StridedSliceSqueeze::StridedSliceSqueeze() {
             if (begin_mask[axis]) {  // corresponding dimension of the begin input is ignored. starting from 0
                 begin_vec[axis] = 0;
                 end_vec[axis] = 1;
-                ;
                 begin_mask[axis] = 0;
                 end_mask[axis] = 0;
             } else {                          // corresponding dimension of the begin input is used for slicing start


### PR DESCRIPTION
### Details:
 - *fix to pass sr_stridedslice_squeeze when begin_masks.size() is no larger than axis that is going to be squeezed..*
 - *corresponding unit test case.*

### Tickets:
 - *CVS-71981*
