### PR TITLE
[Python API] Add opset8 ops: i420toBGR-8, i420toRGB-8, NV12toBGR-8, NV12toRGB-8

### DIFF
--- a/src/bindings/python/src/compatibility/ngraph/__init__.py
+++ b/src/bindings/python/src/compatibility/ngraph/__init__.py
@@ -88,6 +88,8 @@ from ngraph.opset8 import hswish
 from ngraph.opset8 import idft
 from ngraph.opset8 import if_op
 from ngraph.opset8 import interpolate
+from ngraph.opset8 import i420_to_bgr
+from ngraph.opset8 import i420_to_rgb
 from ngraph.opset8 import less
 from ngraph.opset8 import less_equal
 from ngraph.opset8 import log
@@ -115,6 +117,8 @@ from ngraph.opset8 import non_max_suppression
 from ngraph.opset8 import non_zero
 from ngraph.opset8 import normalize_l2
 from ngraph.opset8 import not_equal
+from ngraph.opset8 import nv12_to_bgr
+from ngraph.opset8 import nv12_to_rgb
 from ngraph.opset8 import one_hot
 from ngraph.opset8 import pad
 from ngraph.opset8 import parameter

--- a/src/bindings/python/src/compatibility/ngraph/opset8/__init__.py
+++ b/src/bindings/python/src/compatibility/ngraph/opset8/__init__.py
@@ -71,6 +71,8 @@ from ngraph.opset4.ops import hswish
 from ngraph.opset7.ops import idft
 from ngraph.opset8.ops import if_op
 from ngraph.opset1.ops import interpolate
+from ngraph.opset8.ops import i420_to_bgr
+from ngraph.opset8.ops import i420_to_rgb
 from ngraph.opset1.ops import less
 from ngraph.opset1.ops import less_equal
 from ngraph.opset1.ops import log
@@ -98,6 +100,8 @@ from ngraph.opset5.ops import non_max_suppression
 from ngraph.opset3.ops import non_zero
 from ngraph.opset1.ops import normalize_l2
 from ngraph.opset1.ops import not_equal
+from ngraph.opset8.ops import nv12_to_bgr
+from ngraph.opset8.ops import nv12_to_rgb
 from ngraph.opset1.ops import one_hot
 from ngraph.opset1.ops import pad
 from ngraph.opset1.ops import parameter

--- a/src/bindings/python/src/compatibility/ngraph/opset8/ops.py
+++ b/src/bindings/python/src/compatibility/ngraph/opset8/ops.py
@@ -6,6 +6,7 @@ from functools import partial
 from typing import Callable, Iterable, List, Optional, Set, Union, Tuple
 
 import numpy as np
+from ngraph.exceptions import UserInputError
 from ngraph.impl import Node, Shape
 from ngraph.impl.op import Constant, Parameter
 from ngraph.opset_utils import _get_node_factory
@@ -558,3 +559,99 @@ def prior_box(
     check_valid_attributes("PriorBox", attrs, requirements)
 
     return _get_node_factory_opset8().create("PriorBox", [layer_shape, as_node(image_shape)], attrs)
+
+
+@nameable_op
+def i420_to_bgr(
+        arg: NodeInput,
+        arg_u: NodeInput = None,
+        arg_v: NodeInput = None,
+        name: Optional[str] = None,
+) -> Node:
+    """Return a node which performs I420toBGR operation.
+
+    @param  arg: The node providing single or Y plane data.
+    @param  arg_u: The node providing U plane data. Required for separate planes.
+    @param  arg_v: The node providing V plane data. Required for separate planes.
+    @param  name: The optional name for the created output node.
+    @return The new node performing I420toBGR operation.
+    """
+    if arg_u is None and arg_v is None:
+        inputs = as_nodes(arg)
+    elif arg_u is not None and arg_v is not None:
+        inputs = as_nodes(arg, arg_u, arg_v)
+    else:
+        raise UserInputError(
+            "Operation I420toBGR must have one (single plane) or three (separate planes) inputs provided."
+        )
+
+    return _get_node_factory_opset8().create("I420toBGR", inputs)
+
+
+@nameable_op
+def i420_to_rgb(
+        arg: NodeInput,
+        arg_u: NodeInput = None,
+        arg_v: NodeInput = None,
+        name: Optional[str] = None,
+) -> Node:
+    """Return a node which performs I420toRGB operation.
+
+    @param  arg: The node providing single or Y plane data.
+    @param  arg_u: The node providing U plane data. Required for separate planes.
+    @param  arg_v: The node providing V plane data. Required for separate planes.
+    @param  name: The optional name for the created output node.
+    @return The new node performing I420toRGB operation.
+    """
+    if arg_u is None and arg_v is None:
+        inputs = as_nodes(arg)
+    elif arg_u is not None and arg_v is not None:
+        inputs = as_nodes(arg, arg_u, arg_v)
+    else:
+        raise UserInputError(
+            "Operation I420toRGB must have one (single plane) or three (separate planes) inputs provided."
+        )
+
+    return _get_node_factory_opset8().create("I420toRGB", inputs)
+
+
+@nameable_op
+def nv12_to_bgr(
+        arg: NodeInput,
+        arg_uv: NodeInput = None,
+        name: Optional[str] = None,
+) -> Node:
+    """Return a node which performs NV12toBGR operation.
+
+    @param  arg: The node providing single or Y plane data.
+    @param  arg_uv: The node providing UV plane data. Required for separate planes.
+    @param  name: The optional name for the created output node.
+    @return The new node performing NV12toBGR operation.
+    """
+    if arg_uv is None:
+        inputs = as_nodes(arg)
+    else:
+        inputs = as_nodes(arg, arg_uv)
+
+    return _get_node_factory_opset8().create("NV12toBGR", inputs)
+
+
+@nameable_op
+def nv12_to_rgb(
+        arg: NodeInput,
+        arg_uv: NodeInput = None,
+        name: Optional[str] = None,
+) -> Node:
+    """Return a node which performs NV12toRGB operation.
+
+    @param  arg: The node providing single or Y plane data.
+    @param  arg_uv: The node providing UV plane data. Required for separate planes.
+    @param  name: The optional name for the created output node.
+    @return The new node performing NV12toRGB operation.
+    """
+    if arg_uv is None:
+        inputs = as_nodes(arg)
+    else:
+        inputs = as_nodes(arg, arg_uv)
+
+    return _get_node_factory_opset8().create("NV12toRGB", inputs)

--- a/src/bindings/python/src/compatibility/ngraph/opset8/ops.py
+++ b/src/bindings/python/src/compatibility/ngraph/opset8/ops.py
@@ -564,8 +564,8 @@ def prior_box(
 @nameable_op
 def i420_to_bgr(
         arg: NodeInput,
-        arg_u: NodeInput = None,
-        arg_v: NodeInput = None,
+        arg_u: Optional[NodeInput] = None,
+        arg_v: Optional[NodeInput] = None,
         name: Optional[str] = None,
 ) -> Node:
     """Return a node which performs I420toBGR operation.
@@ -591,8 +591,8 @@ def i420_to_bgr(
 @nameable_op
 def i420_to_rgb(
         arg: NodeInput,
-        arg_u: NodeInput = None,
-        arg_v: NodeInput = None,
+        arg_u: Optional[NodeInput] = None,
+        arg_v: Optional[NodeInput] = None,
         name: Optional[str] = None,
 ) -> Node:
     """Return a node which performs I420toRGB operation.
@@ -618,7 +618,7 @@ def i420_to_rgb(
 @nameable_op
 def nv12_to_bgr(
         arg: NodeInput,
-        arg_uv: NodeInput = None,
+        arg_uv: Optional[NodeInput] = None,
         name: Optional[str] = None,
 ) -> Node:
     """Return a node which performs NV12toBGR operation.
@@ -639,7 +639,7 @@ def nv12_to_bgr(
 @nameable_op
 def nv12_to_rgb(
         arg: NodeInput,
-        arg_uv: NodeInput = None,
+        arg_uv: Optional[NodeInput] = None,
         name: Optional[str] = None,
 ) -> Node:
     """Return a node which performs NV12toRGB operation.

--- a/src/bindings/python/src/openvino/runtime/opset8/__init__.py
+++ b/src/bindings/python/src/openvino/runtime/opset8/__init__.py
@@ -100,6 +100,8 @@ from openvino.runtime.opset5.ops import non_max_suppression
 from openvino.runtime.opset3.ops import non_zero
 from openvino.runtime.opset1.ops import normalize_l2
 from openvino.runtime.opset1.ops import not_equal
+from openvino.runtime.opset8.ops import nv12_to_bgr
+from openvino.runtime.opset8.ops import nv12_to_rgb
 from openvino.runtime.opset1.ops import one_hot
 from openvino.runtime.opset1.ops import pad
 from openvino.runtime.opset1.ops import parameter

--- a/src/bindings/python/src/openvino/runtime/opset8/__init__.py
+++ b/src/bindings/python/src/openvino/runtime/opset8/__init__.py
@@ -71,6 +71,7 @@ from openvino.runtime.opset4.ops import hswish
 from openvino.runtime.opset7.ops import idft
 from openvino.runtime.opset8.ops import if_op
 from openvino.runtime.opset1.ops import interpolate
+from openvino.runtime.opset8.ops import i420_to_bgr
 from openvino.runtime.opset1.ops import less
 from openvino.runtime.opset1.ops import less_equal
 from openvino.runtime.opset1.ops import log

--- a/src/bindings/python/src/openvino/runtime/opset8/__init__.py
+++ b/src/bindings/python/src/openvino/runtime/opset8/__init__.py
@@ -72,6 +72,7 @@ from openvino.runtime.opset7.ops import idft
 from openvino.runtime.opset8.ops import if_op
 from openvino.runtime.opset1.ops import interpolate
 from openvino.runtime.opset8.ops import i420_to_bgr
+from openvino.runtime.opset8.ops import i420_to_rgb
 from openvino.runtime.opset1.ops import less
 from openvino.runtime.opset1.ops import less_equal
 from openvino.runtime.opset1.ops import log

--- a/src/bindings/python/src/openvino/runtime/opset8/ops.py
+++ b/src/bindings/python/src/openvino/runtime/opset8/ops.py
@@ -559,3 +559,37 @@ def prior_box(
     check_valid_attributes("PriorBox", attrs, requirements)
 
     return _get_node_factory_opset8().create("PriorBox", [layer_shape, as_node(image_shape)], attrs)
+
+
+# @nameable_op
+# def i420_to_bgr(
+#         arg: NodeInput,
+#         name: Optional[str] = None,
+# ) -> Node:
+#     """Return a node which performs I420toRGB operation.
+
+#     @param  arg: The node providing input image data (single plane).
+#     @param  name:  The optional name for the created output node.
+#     @return The new node performing I420toRGB operation.
+#     """
+#     inputs = as_nodes(arg)
+#     return _get_node_factory_opset8().create("I420toRGB", inputs)
+
+
+@nameable_op
+def i420_to_bgr(
+        arg_y: NodeInput,
+        arg_u: NodeInput,
+        arg_v: NodeInput,
+        name: Optional[str] = None,
+) -> Node:
+    """Return a node which performs I420toRGB operation.
+
+    @param  arg_y: The node providing input image data (Y plane).
+    @param  arg_u: The node providing input image data (U plane).
+    @param  arg_v: The node providing input image data (V plane).
+    @param  name:  The optional name for the created output node.
+    @return The new node performing I420toRGB operation.
+    """
+    inputs = as_nodes(arg_y, arg_u, arg_v)
+    return _get_node_factory_opset8().create("I420toRGB", inputs)

--- a/src/bindings/python/src/openvino/runtime/opset8/ops.py
+++ b/src/bindings/python/src/openvino/runtime/opset8/ops.py
@@ -578,18 +578,53 @@ def prior_box(
 
 @nameable_op
 def i420_to_bgr(
-        arg_y: NodeInput,
-        arg_u: NodeInput,
-        arg_v: NodeInput,
+        arg: NodeInput,
+        arg_u: NodeInput = None,
+        arg_v: NodeInput = None,
+        name: Optional[str] = None,
+) -> Node:
+    """Return a node which performs I420toBGR operation.
+
+    @param  arg: The node providing single or Y plane data.
+    @param  arg_u: The node providing U plane data. Required for separate planes.
+    @param  arg_v: The node providing V plane data. Required for separate planes.
+    @param  name:  The optional name for the created output node.
+    @return The new node performing I420toBGR operation.
+    """
+    if arg_u is None and arg_v is None:
+        inputs = as_nodes(arg)
+    elif arg_u is not None and arg_v is not None:
+        inputs = as_nodes(arg, arg_u, arg_v)
+    else:
+        raise UserInputError(
+            'Operation I420toBGR must have one (single plane) or three (separate planes) inputs provided'
+        )
+
+    return _get_node_factory_opset8().create("I420toBGR", inputs)
+
+
+@nameable_op
+def i420_to_rgb(
+        arg: NodeInput,
+        arg_u: NodeInput = None,
+        arg_v: NodeInput = None,
         name: Optional[str] = None,
 ) -> Node:
     """Return a node which performs I420toRGB operation.
 
-    @param  arg_y: The node providing input image data (Y plane).
-    @param  arg_u: The node providing input image data (U plane).
-    @param  arg_v: The node providing input image data (V plane).
+    @param  arg: The node providing single or Y plane data.
+    @param  arg_u: The node providing U plane data. Required for separate planes.
+    @param  arg_v: The node providing V plane data. Required for separate planes.
     @param  name:  The optional name for the created output node.
     @return The new node performing I420toRGB operation.
     """
-    inputs = as_nodes(arg_y, arg_u, arg_v)
+    if arg_u is None and arg_v is None:
+        inputs = as_nodes(arg)
+    elif arg_u is not None and arg_v is not None:
+        inputs = as_nodes(arg, arg_u, arg_v)
+    else:
+        raise UserInputError(
+            'Operation I420toRGB must have one (single plane) or three (separate planes) inputs provided'
+        )
+
     return _get_node_factory_opset8().create("I420toRGB", inputs)

--- a/src/bindings/python/src/openvino/runtime/opset8/ops.py
+++ b/src/bindings/python/src/openvino/runtime/opset8/ops.py
@@ -574,7 +574,7 @@ def i420_to_bgr(
     @param  arg: The node providing single or Y plane data.
     @param  arg_u: The node providing U plane data. Required for separate planes.
     @param  arg_v: The node providing V plane data. Required for separate planes.
-    @param  name:  The optional name for the created output node.
+    @param  name: The optional name for the created output node.
     @return The new node performing I420toBGR operation.
     """
     if arg_u is None and arg_v is None:
@@ -601,7 +601,7 @@ def i420_to_rgb(
     @param  arg: The node providing single or Y plane data.
     @param  arg_u: The node providing U plane data. Required for separate planes.
     @param  arg_v: The node providing V plane data. Required for separate planes.
-    @param  name:  The optional name for the created output node.
+    @param  name: The optional name for the created output node.
     @return The new node performing I420toRGB operation.
     """
     if arg_u is None and arg_v is None:
@@ -626,7 +626,7 @@ def nv12_to_bgr(
 
     @param  arg: The node providing single or Y plane data.
     @param  arg_uv: The node providing UV plane data. Required for separate planes.
-    @param  name:  The optional name for the created output node.
+    @param  name: The optional name for the created output node.
     @return The new node performing NV12toBGR operation.
     """
     if arg_uv is None:
@@ -647,7 +647,7 @@ def nv12_to_rgb(
 
     @param  arg: The node providing single or Y plane data.
     @param  arg_uv: The node providing UV plane data. Required for separate planes.
-    @param  name:  The optional name for the created output node.
+    @param  name: The optional name for the created output node.
     @return The new node performing NV12toRGB operation.
     """
     if arg_uv is None:

--- a/src/bindings/python/src/openvino/runtime/opset8/ops.py
+++ b/src/bindings/python/src/openvino/runtime/opset8/ops.py
@@ -565,8 +565,8 @@ def prior_box(
 @nameable_op
 def i420_to_bgr(
         arg: NodeInput,
-        arg_u: NodeInput = None,
-        arg_v: NodeInput = None,
+        arg_u: Optional[NodeInput] = None,
+        arg_v: Optional[NodeInput] = None,
         name: Optional[str] = None,
 ) -> Node:
     """Return a node which performs I420toBGR operation.
@@ -592,8 +592,8 @@ def i420_to_bgr(
 @nameable_op
 def i420_to_rgb(
         arg: NodeInput,
-        arg_u: NodeInput = None,
-        arg_v: NodeInput = None,
+        arg_u: Optional[NodeInput] = None,
+        arg_v: Optional[NodeInput] = None,
         name: Optional[str] = None,
 ) -> Node:
     """Return a node which performs I420toRGB operation.
@@ -619,7 +619,7 @@ def i420_to_rgb(
 @nameable_op
 def nv12_to_bgr(
         arg: NodeInput,
-        arg_uv: NodeInput = None,
+        arg_uv: Optional[NodeInput] = None,
         name: Optional[str] = None,
 ) -> Node:
     """Return a node which performs NV12toBGR operation.
@@ -640,7 +640,7 @@ def nv12_to_bgr(
 @nameable_op
 def nv12_to_rgb(
         arg: NodeInput,
-        arg_uv: NodeInput = None,
+        arg_uv: Optional[NodeInput] = None,
         name: Optional[str] = None,
 ) -> Node:
     """Return a node which performs NV12toRGB operation.

--- a/src/bindings/python/src/openvino/runtime/opset8/ops.py
+++ b/src/bindings/python/src/openvino/runtime/opset8/ops.py
@@ -562,21 +562,6 @@ def prior_box(
     return _get_node_factory_opset8().create("PriorBox", [layer_shape, as_node(image_shape)], attrs)
 
 
-# @nameable_op
-# def i420_to_bgr(
-#         arg: NodeInput,
-#         name: Optional[str] = None,
-# ) -> Node:
-#     """Return a node which performs I420toRGB operation.
-
-#     @param  arg: The node providing input image data (single plane).
-#     @param  name:  The optional name for the created output node.
-#     @return The new node performing I420toRGB operation.
-#     """
-#     inputs = as_nodes(arg)
-#     return _get_node_factory_opset8().create("I420toRGB", inputs)
-
-
 @nameable_op
 def i420_to_bgr(
         arg: NodeInput,

--- a/src/bindings/python/src/openvino/runtime/opset8/ops.py
+++ b/src/bindings/python/src/openvino/runtime/opset8/ops.py
@@ -6,6 +6,7 @@ from functools import partial
 from typing import Callable, Iterable, List, Optional, Set, Union, Tuple
 
 import numpy as np
+from openvino.runtime.exceptions import UserInputError
 from openvino.runtime.impl import Node, Shape
 from openvino.runtime.impl.op import Constant, Parameter
 from openvino.runtime.opset_utils import _get_node_factory
@@ -597,7 +598,7 @@ def i420_to_bgr(
         inputs = as_nodes(arg, arg_u, arg_v)
     else:
         raise UserInputError(
-            'Operation I420toBGR must have one (single plane) or three (separate planes) inputs provided'
+            "Operation I420toBGR must have one (single plane) or three (separate planes) inputs provided."
         )
 
     return _get_node_factory_opset8().create("I420toBGR", inputs)
@@ -624,7 +625,7 @@ def i420_to_rgb(
         inputs = as_nodes(arg, arg_u, arg_v)
     else:
         raise UserInputError(
-            'Operation I420toRGB must have one (single plane) or three (separate planes) inputs provided'
+            "Operation I420toRGB must have one (single plane) or three (separate planes) inputs provided."
         )
 
     return _get_node_factory_opset8().create("I420toRGB", inputs)

--- a/src/bindings/python/src/openvino/runtime/opset8/ops.py
+++ b/src/bindings/python/src/openvino/runtime/opset8/ops.py
@@ -614,3 +614,45 @@ def i420_to_rgb(
         )
 
     return _get_node_factory_opset8().create("I420toRGB", inputs)
+
+
+@nameable_op
+def nv12_to_bgr(
+        arg: NodeInput,
+        arg_uv: NodeInput = None,
+        name: Optional[str] = None,
+) -> Node:
+    """Return a node which performs NV12toBGR operation.
+
+    @param  arg: The node providing single or Y plane data.
+    @param  arg_uv: The node providing UV plane data. Required for separate planes.
+    @param  name:  The optional name for the created output node.
+    @return The new node performing NV12toBGR operation.
+    """
+    if arg_uv is None:
+        inputs = as_nodes(arg)
+    else:
+        inputs = as_nodes(arg, arg_uv)
+
+    return _get_node_factory_opset8().create("NV12toBGR", inputs)
+
+
+@nameable_op
+def nv12_to_rgb(
+        arg: NodeInput,
+        arg_uv: NodeInput = None,
+        name: Optional[str] = None,
+) -> Node:
+    """Return a node which performs NV12toRGB operation.
+
+    @param  arg: The node providing single or Y plane data.
+    @param  arg_uv: The node providing UV plane data. Required for separate planes.
+    @param  name:  The optional name for the created output node.
+    @return The new node performing NV12toRGB operation.
+    """
+    if arg_uv is None:
+        inputs = as_nodes(arg)
+    else:
+        inputs = as_nodes(arg, arg_uv)
+
+    return _get_node_factory_opset8().create("NV12toRGB", inputs)

--- a/src/bindings/python/tests/test_ngraph/test_create_op.py
+++ b/src/bindings/python/tests/test_ngraph/test_create_op.py
@@ -4,6 +4,7 @@
 import numpy as np
 import pytest
 from openvino.runtime import PartialShape, Dimension
+from openvino.runtime.exceptions import UserInputError
 
 import openvino.runtime.opset8 as ov
 import openvino.runtime.opset1 as ov_opset1
@@ -1977,6 +1978,13 @@ def test_i420_to_bgr():
     assert node_separate_planes.get_output_element_type(0) == Type.f32
     assert list(node_separate_planes.get_output_shape(0)) == expected_output_shape
 
+    # Incorrect inputs number
+    with pytest.raises(UserInputError, match=r".*Operation I420toBGR*."):
+        node_separate_planes = ov.i420_to_bgr(arg_y, arg_v)
+
+    with pytest.raises(UserInputError, match=r".*Operation I420toBGR*."):
+        node_separate_planes = ov.i420_to_bgr(arg_single_plane, None, arg_v)
+
 
 def test_i420_to_rgb():
     expected_output_shape = [1, 480, 640, 3]
@@ -2001,3 +2009,9 @@ def test_i420_to_rgb():
     assert node_separate_planes.get_output_size() == 1
     assert node_separate_planes.get_output_element_type(0) == Type.f32
     assert list(node_separate_planes.get_output_shape(0)) == expected_output_shape
+
+    with pytest.raises(UserInputError, match=r".*Operation I420toRGB*."):
+        node_separate_planes = ov.i420_to_rgb(arg_y, arg_v)
+
+    with pytest.raises(UserInputError, match=r".*Operation I420toRGB*."):
+        node_separate_planes = ov.i420_to_rgb(arg_single_plane, None, arg_v)

--- a/src/bindings/python/tests/test_ngraph/test_create_op.py
+++ b/src/bindings/python/tests/test_ngraph/test_create_op.py
@@ -2015,3 +2015,51 @@ def test_i420_to_rgb():
 
     with pytest.raises(UserInputError, match=r".*Operation I420toRGB*."):
         node_separate_planes = ov.i420_to_rgb(arg_single_plane, None, arg_v)
+
+
+def test_nv12_to_bgr():
+    expected_output_shape = [1, 480, 640, 3]
+
+    # # Single plane (one arg)
+    arg_single_plane = ov.parameter([1, 720, 640, 1], name="input", dtype=np.float32)
+    node_single_plane = ov.nv12_to_bgr(arg_single_plane)
+
+    assert node_single_plane.get_type_name() == "NV12toBGR"
+    assert node_single_plane.get_output_size() == 1
+    assert node_single_plane.get_output_element_type(0) == Type.f32
+    assert list(node_single_plane.get_output_shape(0)) == expected_output_shape
+
+    # Separate planes (two args)
+    arg_y = ov.parameter([1, 480, 640, 1], name="input_y", dtype=np.float32)
+    arg_uv = ov.parameter([1, 240, 320, 2], name="input_uv", dtype=np.float32)
+
+    node_separate_planes = ov.nv12_to_bgr(arg_y, arg_uv)
+
+    assert node_separate_planes.get_type_name() == "NV12toBGR"
+    assert node_separate_planes.get_output_size() == 1
+    assert node_separate_planes.get_output_element_type(0) == Type.f32
+    assert list(node_separate_planes.get_output_shape(0)) == expected_output_shape
+
+
+def test_nv12_to_rgb():
+    expected_output_shape = [1, 480, 640, 3]
+
+    # # Single plane (one arg)
+    arg_single_plane = ov.parameter([1, 720, 640, 1], name="input", dtype=np.float32)
+    node_single_plane = ov.nv12_to_rgb(arg_single_plane)
+
+    assert node_single_plane.get_type_name() == "NV12toRGB"
+    assert node_single_plane.get_output_size() == 1
+    assert node_single_plane.get_output_element_type(0) == Type.f32
+    assert list(node_single_plane.get_output_shape(0)) == expected_output_shape
+
+    # Separate planes (two args)
+    arg_y = ov.parameter([1, 480, 640, 1], name="input_y", dtype=np.float32)
+    arg_uv = ov.parameter([1, 240, 320, 2], name="input_uv", dtype=np.float32)
+
+    node_separate_planes = ov.nv12_to_rgb(arg_y, arg_uv)
+
+    assert node_separate_planes.get_type_name() == "NV12toRGB"
+    assert node_separate_planes.get_output_size() == 1
+    assert node_separate_planes.get_output_element_type(0) == Type.f32
+    assert list(node_separate_planes.get_output_shape(0)) == expected_output_shape

--- a/src/bindings/python/tests/test_ngraph/test_create_op.py
+++ b/src/bindings/python/tests/test_ngraph/test_create_op.py
@@ -1951,3 +1951,28 @@ def test_slice():
     assert node.get_output_size() == 1
     assert node.get_output_element_type(0) == Type.f32
     assert tuple(node.get_output_shape(0)) == np.zeros(data_shape)[2:9:2, ::, 0:2:1].shape
+
+
+def test_i420_to_bgr():
+    expected_output_shape = [1, 480, 640, 3]
+
+    # # Single plane (one arg)
+    # arg_single_plane = ov.parameter([1, 720, 640, 1], name="input", dtype=np.float32)
+    # node_single_plane = ov.i420_to_bgr(arg_single_plane)
+
+    # assert node_single_plane.get_type_name() == "I420toRGB"
+    # assert node_single_plane.get_output_size() == 1
+    # assert node_single_plane.get_output_element_type(0) == Type.f32
+    # assert node_single_plane.get_output_shape(0) == expected_output_shape
+
+    # Separate planes (three args)
+    arg_y = ov.parameter([1, 480, 640, 1], name="input_y", dtype=np.float32)
+    arg_u = ov.parameter([1, 240, 320, 1], name="input_u", dtype=np.float32)
+    arg_v = ov.parameter([1, 240, 320, 1], name="input_v", dtype=np.float32)
+
+    node_separate_planes = ov.i420_to_bgr(arg_y, arg_u, arg_v)
+
+    assert node_separate_planes.get_type_name() == "I420toRGB"
+    assert node_separate_planes.get_output_size() == 1
+    assert node_separate_planes.get_output_element_type(0) == Type.f32
+    assert list(node_separate_planes.get_output_shape(0)) == expected_output_shape

--- a/src/bindings/python/tests/test_ngraph/test_create_op.py
+++ b/src/bindings/python/tests/test_ngraph/test_create_op.py
@@ -1957,13 +1957,13 @@ def test_i420_to_bgr():
     expected_output_shape = [1, 480, 640, 3]
 
     # # Single plane (one arg)
-    # arg_single_plane = ov.parameter([1, 720, 640, 1], name="input", dtype=np.float32)
-    # node_single_plane = ov.i420_to_bgr(arg_single_plane)
+    arg_single_plane = ov.parameter([1, 720, 640, 1], name="input", dtype=np.float32)
+    node_single_plane = ov.i420_to_bgr(arg_single_plane)
 
-    # assert node_single_plane.get_type_name() == "I420toRGB"
-    # assert node_single_plane.get_output_size() == 1
-    # assert node_single_plane.get_output_element_type(0) == Type.f32
-    # assert node_single_plane.get_output_shape(0) == expected_output_shape
+    assert node_single_plane.get_type_name() == "I420toBGR"
+    assert node_single_plane.get_output_size() == 1
+    assert node_single_plane.get_output_element_type(0) == Type.f32
+    assert list(node_single_plane.get_output_shape(0)) == expected_output_shape
 
     # Separate planes (three args)
     arg_y = ov.parameter([1, 480, 640, 1], name="input_y", dtype=np.float32)
@@ -1971,6 +1971,31 @@ def test_i420_to_bgr():
     arg_v = ov.parameter([1, 240, 320, 1], name="input_v", dtype=np.float32)
 
     node_separate_planes = ov.i420_to_bgr(arg_y, arg_u, arg_v)
+
+    assert node_separate_planes.get_type_name() == "I420toBGR"
+    assert node_separate_planes.get_output_size() == 1
+    assert node_separate_planes.get_output_element_type(0) == Type.f32
+    assert list(node_separate_planes.get_output_shape(0)) == expected_output_shape
+
+
+def test_i420_to_rgb():
+    expected_output_shape = [1, 480, 640, 3]
+
+    # # Single plane (one arg)
+    arg_single_plane = ov.parameter([1, 720, 640, 1], name="input", dtype=np.float32)
+    node_single_plane = ov.i420_to_rgb(arg_single_plane)
+
+    assert node_single_plane.get_type_name() == "I420toRGB"
+    assert node_single_plane.get_output_size() == 1
+    assert node_single_plane.get_output_element_type(0) == Type.f32
+    assert list(node_single_plane.get_output_shape(0)) == expected_output_shape
+
+    # Separate planes (three args)
+    arg_y = ov.parameter([1, 480, 640, 1], name="input_y", dtype=np.float32)
+    arg_u = ov.parameter([1, 240, 320, 1], name="input_u", dtype=np.float32)
+    arg_v = ov.parameter([1, 240, 320, 1], name="input_v", dtype=np.float32)
+
+    node_separate_planes = ov.i420_to_rgb(arg_y, arg_u, arg_v)
 
     assert node_separate_planes.get_type_name() == "I420toRGB"
     assert node_separate_planes.get_output_size() == 1

--- a/src/bindings/python/tests_compatibility/test_ngraph/test_create_op.py
+++ b/src/bindings/python/tests_compatibility/test_ngraph/test_create_op.py
@@ -8,6 +8,7 @@ from _pyngraph import PartialShape, Dimension
 import ngraph as ng
 import ngraph.opset1 as ng_opset1
 import ngraph.opset5 as ng_opset5
+from ngraph.exceptions import UserInputError
 from ngraph.impl import Type
 
 np_types = [np.float32, np.int32]
@@ -1951,3 +1952,114 @@ def test_slice():
     assert node.get_output_size() == 1
     assert node.get_output_element_type(0) == Type.f32
     assert tuple(node.get_output_shape(0)) == np.zeros(data_shape)[2:9:2, ::, 0:2:1].shape
+
+
+def test_i420_to_bgr():
+    expected_output_shape = [1, 480, 640, 3]
+
+    # # Single plane (one arg)
+    arg_single_plane = ng.parameter([1, 720, 640, 1], name="input", dtype=np.float32)
+    node_single_plane = ng.i420_to_bgr(arg_single_plane)
+
+    assert node_single_plane.get_type_name() == "I420toBGR"
+    assert node_single_plane.get_output_size() == 1
+    assert node_single_plane.get_output_element_type(0) == Type.f32
+    assert list(node_single_plane.get_output_shape(0)) == expected_output_shape
+
+    # Separate planes (three args)
+    arg_y = ng.parameter([1, 480, 640, 1], name="input_y", dtype=np.float32)
+    arg_u = ng.parameter([1, 240, 320, 1], name="input_u", dtype=np.float32)
+    arg_v = ng.parameter([1, 240, 320, 1], name="input_v", dtype=np.float32)
+
+    node_separate_planes = ng.i420_to_bgr(arg_y, arg_u, arg_v)
+
+    assert node_separate_planes.get_type_name() == "I420toBGR"
+    assert node_separate_planes.get_output_size() == 1
+    assert node_separate_planes.get_output_element_type(0) == Type.f32
+    assert list(node_separate_planes.get_output_shape(0)) == expected_output_shape
+
+    # Incorrect inputs number
+    with pytest.raises(UserInputError, match=r".*Operation I420toBGR*."):
+        node_separate_planes = ng.i420_to_bgr(arg_y, arg_v)
+
+    with pytest.raises(UserInputError, match=r".*Operation I420toBGR*."):
+        node_separate_planes = ng.i420_to_bgr(arg_single_plane, None, arg_v)
+
+
+def test_i420_to_rgb():
+    expected_output_shape = [1, 480, 640, 3]
+
+    # # Single plane (one arg)
+    arg_single_plane = ng.parameter([1, 720, 640, 1], name="input", dtype=np.float32)
+    node_single_plane = ng.i420_to_rgb(arg_single_plane)
+
+    assert node_single_plane.get_type_name() == "I420toRGB"
+    assert node_single_plane.get_output_size() == 1
+    assert node_single_plane.get_output_element_type(0) == Type.f32
+    assert list(node_single_plane.get_output_shape(0)) == expected_output_shape
+
+    # Separate planes (three args)
+    arg_y = ng.parameter([1, 480, 640, 1], name="input_y", dtype=np.float32)
+    arg_u = ng.parameter([1, 240, 320, 1], name="input_u", dtype=np.float32)
+    arg_v = ng.parameter([1, 240, 320, 1], name="input_v", dtype=np.float32)
+
+    node_separate_planes = ng.i420_to_rgb(arg_y, arg_u, arg_v)
+
+    assert node_separate_planes.get_type_name() == "I420toRGB"
+    assert node_separate_planes.get_output_size() == 1
+    assert node_separate_planes.get_output_element_type(0) == Type.f32
+    assert list(node_separate_planes.get_output_shape(0)) == expected_output_shape
+
+    with pytest.raises(UserInputError, match=r".*Operation I420toRGB*."):
+        node_separate_planes = ng.i420_to_rgb(arg_y, arg_v)
+
+    with pytest.raises(UserInputError, match=r".*Operation I420toRGB*."):
+        node_separate_planes = ng.i420_to_rgb(arg_single_plane, None, arg_v)
+
+
+def test_nv12_to_bgr():
+    expected_output_shape = [1, 480, 640, 3]
+
+    # # Single plane (one arg)
+    arg_single_plane = ng.parameter([1, 720, 640, 1], name="input", dtype=np.float32)
+    node_single_plane = ng.nv12_to_bgr(arg_single_plane)
+
+    assert node_single_plane.get_type_name() == "NV12toBGR"
+    assert node_single_plane.get_output_size() == 1
+    assert node_single_plane.get_output_element_type(0) == Type.f32
+    assert list(node_single_plane.get_output_shape(0)) == expected_output_shape
+
+    # Separate planes (two args)
+    arg_y = ng.parameter([1, 480, 640, 1], name="input_y", dtype=np.float32)
+    arg_uv = ng.parameter([1, 240, 320, 2], name="input_uv", dtype=np.float32)
+
+    node_separate_planes = ng.nv12_to_bgr(arg_y, arg_uv)
+
+    assert node_separate_planes.get_type_name() == "NV12toBGR"
+    assert node_separate_planes.get_output_size() == 1
+    assert node_separate_planes.get_output_element_type(0) == Type.f32
+    assert list(node_separate_planes.get_output_shape(0)) == expected_output_shape
+
+
+def test_nv12_to_rgb():
+    expected_output_shape = [1, 480, 640, 3]
+
+    # # Single plane (one arg)
+    arg_single_plane = ng.parameter([1, 720, 640, 1], name="input", dtype=np.float32)
+    node_single_plane = ng.nv12_to_rgb(arg_single_plane)
+
+    assert node_single_plane.get_type_name() == "NV12toRGB"
+    assert node_single_plane.get_output_size() == 1
+    assert node_single_plane.get_output_element_type(0) == Type.f32
+    assert list(node_single_plane.get_output_shape(0)) == expected_output_shape
+
+    # Separate planes (two args)
+    arg_y = ng.parameter([1, 480, 640, 1], name="input_y", dtype=np.float32)
+    arg_uv = ng.parameter([1, 240, 320, 2], name="input_uv", dtype=np.float32)
+
+    node_separate_planes = ng.nv12_to_rgb(arg_y, arg_uv)
+
+    assert node_separate_planes.get_type_name() == "NV12toRGB"
+    assert node_separate_planes.get_output_size() == 1
+    assert node_separate_planes.get_output_element_type(0) == Type.f32
+    assert list(node_separate_planes.get_output_shape(0)) == expected_output_shape


### PR DESCRIPTION
### Details:
Add opset8 ops to the PythonAPI:

- [x] i420toBGR-8
- [x] i420toRGB-8
- [x] NV12toBGR-8
- [x] NV12toRGB-8

- [x] Add copy of the ops to the compatibility API

### Tickets:
 - 71220, 71207
