### PR TITLE
[CPU] Added BF16 support for CumSum as well

### DIFF
--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_cum_sum_node.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_cum_sum_node.cpp
@@ -95,7 +95,7 @@ void MKLDNNCumSumNode::execute(mkldnn::stream strm) {
     if (inputShapes.size() == numOfInputs)
         axis = getAxis(getParentEdgeAt(AXIS)->getMemory(), getParentEdgeAt(CUM_SUM_DATA)->getMemory());
 
-    OV_SWITCH(MKLDNNPlugin, CumSumEmitter, this, dataPrecision,
+    OV_SWITCH(MKLDNNPlugin, CumSumExecute, this, dataPrecision,
               OV_CASE(Precision::I8, int8_t),
               OV_CASE(Precision::U8, uint8_t),
               OV_CASE(Precision::I16, int16_t),

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_cum_sum_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_cum_sum_node.h
@@ -47,6 +47,13 @@ private:
 
     InferenceEngine::Precision dataPrecision;
     std::string errorPrefix;
+
+    template<typename T>
+    struct CumSumEmitter {
+        void operator()(MKLDNNCumSumNode* node) {
+            node->exec<T>();
+        }
+    };
 };
 
 }  // namespace MKLDNNPlugin

--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_cum_sum_node.h
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_cum_sum_node.h
@@ -49,7 +49,7 @@ private:
     std::string errorPrefix;
 
     template<typename T>
-    struct CumSumEmitter {
+    struct CumSumExecute {
         void operator()(MKLDNNCumSumNode* node) {
             node->exec<T>();
         }


### PR DESCRIPTION
### Details:
 - *In `InitSupportedPrimitiveDescriptors` there is check for precision where bf16 is supported but in `execute` isn't supported (missing in switch case). This PR adds bf16 support for `execute`*
 - *CumSum uses template `execute` so I added `ConditionalCompilation` support*
 - *Updated CPU tests*

### Tickets:
 - *71595*
