### PR TITLE
bell/hotswap: optimize the memory copy in AUTO:CPU,GPU case

### DIFF
--- a/src/plugins/auto/async_infer_request.cpp
+++ b/src/plugins/auto/async_infer_request.cpp
@@ -70,7 +70,7 @@ MultiDeviceAsyncInferRequest::MultiDeviceAsyncInferRequest(
         {
          /*TaskExecutor*/ _multiDeviceExecutableNetwork, /*task*/ [this] {
                _workerInferRequest = MultiDeviceExecutableNetwork::_thisWorkerInferRequest;
-               _inferRequest->SetBlobsToAnotherRequest(_workerInferRequest->_inferRequest);
+               _inferRequest->SetBlobsToAnotherRequest(_workerInferRequest->_inferRequest, _workerInferRequest->_eligibleForBlobSharing);
         }},
         // final task in the pipeline:
         { /*TaskExecutor*/std::make_shared<ThisRequestExecutor>(this), /*task*/ [this] {

--- a/src/plugins/auto/executable_network.hpp
+++ b/src/plugins/auto/executable_network.hpp
@@ -132,10 +132,12 @@ class MultiDeviceExecutableNetwork : public InferenceEngine::ExecutableNetworkTh
                                      public InferenceEngine::ITaskExecutor {
 public:
     using Ptr = std::shared_ptr<MultiDeviceExecutableNetwork>;
+    friend class MultiDeviceInferRequest;
     struct WorkerInferRequest {
         InferenceEngine::SoIInferRequestInternal  _inferRequest;
         InferenceEngine::Task                     _task;
         std::exception_ptr                        _exceptionPtr = nullptr;
+        bool                                      _eligibleForBlobSharing = true;
     };
     using NotBusyWorkerRequests = ThreadSafeBoundedQueue<WorkerInferRequest*>;
 
@@ -192,6 +194,7 @@ private:
     void TryToLoadNetWork(AutoLoadContext& context,
                           const std::string& modelPath,
                           const InferenceEngine::CNNNetwork& network);
+    bool NeedHotSwap() { return _loadContext[CPU].isEnabled && _loadContext[ACTUALDEVICE].isAlready; }
 
 private:
     std::shared_ptr<InferenceEngine::ICore>                             _core;

--- a/src/plugins/auto/infer_request.cpp
+++ b/src/plugins/auto/infer_request.cpp
@@ -78,7 +78,7 @@ void MultiDeviceInferRequest::SetBlobsToAnotherRequest(const SoIInferRequestInte
         auto blob = GetBlob(name);
         if (req->GetBlob(name) != blob) {
             auto exeNetwork = _exeNetwork.get();
-            if (eligbleForBlobShaing && dynamic_cast<MultiDeviceExecutableNetwork*>(exeNetwork)->NeedHotSwap() && !blob->is<RemoteBlob>()) {
+            if (eligbleForBlobShaing && dynamic_cast<MultiDeviceExecutableNetwork*>(exeNetwork)->NeedHotSwap()) {
                 //if pre-proc involved, stick to system blob, same as GPU plugin
                 auto it = _preProcData.find(name);
                 if (it != _preProcData.end()) {

--- a/src/plugins/auto/infer_request.cpp
+++ b/src/plugins/auto/infer_request.cpp
@@ -9,6 +9,19 @@
 #include <cpp_interfaces/interface/ie_iinfer_request_internal.hpp>
 #include <blob_factory.hpp>
 
+namespace {
+void CopyBlob(InferenceEngine::Blob::CPtr src, InferenceEngine::Blob::Ptr dst) {
+    auto bufferDst = dst->buffer();
+    auto ptrDst = bufferDst.as<char*>();
+    auto bufferSrc = src->cbuffer();
+    auto ptrSrc = bufferSrc.as<const char*>();
+    ptrdiff_t szDst = dst->byteSize();
+    if (ptrDst - ptrSrc < szDst)
+        return;
+    else
+        memcpy(ptrDst, ptrSrc, src->byteSize());
+}
+} // namespace
 namespace MultiDevicePlugin {
 
 using namespace InferenceEngine;
@@ -58,20 +71,44 @@ void MultiDeviceInferRequest::CreateInferRequest(const InferenceEngine::SoIInfer
         _outputs[it.first]->allocate();
     }
 }
-void MultiDeviceInferRequest::SetBlobsToAnotherRequest(const SoIInferRequestInternal& req) {
+void MultiDeviceInferRequest::SetBlobsToAnotherRequest(const SoIInferRequestInternal& req, bool& eligbleForBlobShaing) {
     for (const auto &it : _networkInputs) {
         auto &name = it.first;
         // this request is already in BUSY state, so using the internal functions safely
         auto blob = GetBlob(name);
-        if (req->GetBlob(name) != blob)
+        if (req->GetBlob(name) != blob) {
+            //TODO: check the current hw ready status, and update the input to reuse the hw input if applicable
+            auto exeNetwork = _exeNetwork.get();
+            if (eligbleForBlobShaing && dynamic_cast<MultiDeviceExecutableNetwork*>(exeNetwork)->NeedHotSwap() && !blob->is<RemoteBlob>()) {
+                //if pre-proc involved, stick to system blob, same as GPU plugin
+                auto it = _preProcData.find(name);
+                if (it != _preProcData.end()) {
+                    req->SetBlob(name, blob);
+                } else {
+                    //otherwise, copy the current auto input data to the hw request
+                    //use the hw device blob thread-safely,
+                    //as this hw request is binded to current auto request
+                    CopyBlob(blob, req->GetBlob(name));
+                    SetBlob(name, req->GetBlob(name));
+                    eligbleForBlobShaing = false;
+                }
+            } else {
             req->SetBlob(name, blob);
+            }
+        }
     }
     for (const auto &it : _networkOutputs) {
         auto &name = it.first;
         // this request is already in BUSY state, so using the internal functions safely
         auto blob = GetBlob(name);
-        if (req->GetBlob(name) != blob)
-            req->SetBlob(name, blob);
+        if (req->GetBlob(name) != blob) {
+            auto exeNetwork = _exeNetwork.get();
+            if (eligbleForBlobShaing && dynamic_cast<MultiDeviceExecutableNetwork*>(exeNetwork)->NeedHotSwap() && !blob->is<RemoteBlob>()) {
+                SetBlob(name, req->GetBlob(name));
+            } else {
+                req->SetBlob(name, blob);
+            }
+        }
     }
 }
 

--- a/src/plugins/auto/infer_request.cpp
+++ b/src/plugins/auto/infer_request.cpp
@@ -77,7 +77,6 @@ void MultiDeviceInferRequest::SetBlobsToAnotherRequest(const SoIInferRequestInte
         // this request is already in BUSY state, so using the internal functions safely
         auto blob = GetBlob(name);
         if (req->GetBlob(name) != blob) {
-            //TODO: check the current hw ready status, and update the input to reuse the hw input if applicable
             auto exeNetwork = _exeNetwork.get();
             if (eligbleForBlobShaing && dynamic_cast<MultiDeviceExecutableNetwork*>(exeNetwork)->NeedHotSwap() && !blob->is<RemoteBlob>()) {
                 //if pre-proc involved, stick to system blob, same as GPU plugin
@@ -85,9 +84,9 @@ void MultiDeviceInferRequest::SetBlobsToAnotherRequest(const SoIInferRequestInte
                 if (it != _preProcData.end()) {
                     req->SetBlob(name, blob);
                 } else {
-                    //otherwise, copy the current auto input data to the hw request
-                    //use the hw device blob thread-safely,
-                    //as this hw request is binded to current auto request
+                    // otherwise, copy the current auto input data to the hw request
+                    // use the hw device blob thread-safely
+                    // as this hw device blob has not been shared before
                     CopyBlob(blob, req->GetBlob(name));
                     SetBlob(name, req->GetBlob(name));
                     eligbleForBlobShaing = false;

--- a/src/plugins/auto/infer_request.hpp
+++ b/src/plugins/auto/infer_request.hpp
@@ -15,6 +15,7 @@
 #include <memory>
 #include <string>
 #include <cpp_interfaces/interface/ie_iinfer_request_internal.hpp>
+#include "executable_network.hpp"
 
 #ifdef  MULTIUNITTEST
 #define MOCKTESTMACRO virtual
@@ -37,7 +38,7 @@ public:
     std::map<std::string, InferenceEngine::InferenceEngineProfileInfo> GetPerformanceCounts() const override;
     void InferImpl() override;
     // Multi-Device impl specific: sets the data (blobs from the device-less requests to the specific device request)
-    void SetBlobsToAnotherRequest(const InferenceEngine::SoIInferRequestInternal& req);
+    void SetBlobsToAnotherRequest(const InferenceEngine::SoIInferRequestInternal& req, bool& eligbleForBlobShaing);
 
 private:
     void CreateInferRequest(const InferenceEngine::SoIInferRequestInternal& request_to_share_blobs_with);


### PR DESCRIPTION
Signed-off-by: fishbell <bell.song@intel.com>

### Details:
 - optimize the memory copy in AUTO:CPU,GPU, do the hot swapping when GPU is ready
 - if user request# is more than GPU optimal requests, additional memcpy will still be in place
 - potential copy may happen depending on scheduling results

### Tickets:
 - 69730
