### PR TITLE
Update convolution_kernel_bfyx_os_iyx_osv16.h

### DIFF
--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_kernel_bfyx_os_iyx_osv16.h
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/convolution/convolution_kernel_bfyx_os_iyx_osv16.h
@@ -41,7 +41,7 @@ protected:
             // In such case, using larger worksize will result in larger computational inefficiency
             // w.r.t the unalined output feature
             if (params.output.Feature().v > 8 || !IsSIMDSizeSupported(params.engineInfo, 8)
-               || (params.output.GetDType() == Datatype::F16) && params.output.Feature().v == 8) {
+               || (params.output.GetDType() == Datatype::F16) && (params.output.Feature().v == 8)) {
                 return 16;
             } else {
                 return 8;


### PR DESCRIPTION
Fixing '&&' within '||' [-Werror,-Wlogical-op-parentheses] error appeared earlier today on certain compilers