### PR TITLE
Fix wheel install for Python 3.6 and 3.7

### DIFF
--- a/inference-engine/ie_bridges/python/wheel/CMakeLists.txt
+++ b/inference-engine/ie_bridges/python/wheel/CMakeLists.txt
@@ -54,7 +54,11 @@ foreach(_target ov_runtime_libraries ie_plugins _pyngraph pyopenvino)
 endforeach()
 
 set(cp_python "cp${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")
-set(openvino_wheel_name "openvino-${WHEEL_VERSION}-${WHEEL_BUILD}-${cp_python}-${cp_python}-${WHEEL_PLATFORM}.whl")
+set(cp_python_m "${cp_python}")
+if(cp_python MATCHES "^cp3(6|7)$")
+    set(cp_python_m "${cp_python}m")
+endif()
+set(openvino_wheel_name "openvino-${WHEEL_VERSION}-${WHEEL_BUILD}-${cp_python}-${cp_python_m}-${WHEEL_PLATFORM}.whl")
 set(openvino_wheels_output_dir "${CMAKE_BINARY_DIR}/wheels")
 set(openvino_wheel_path "${openvino_wheels_output_dir}/${openvino_wheel_name}")
 


### PR DESCRIPTION
### Details:
For Python 3.6 and 3.7 wheels have suffixes `cp36-cp36m` and `cp37-cp37m` correspondingly. For 3.8+ there is no "m" suffix.

Problem is reproduced at install step:
```
CMake Error at inference-engine/ie_bridges/python/wheel/cmake_install.cmake:46 (file):
  file INSTALL cannot find
  "/home/dkurt/openvino/build/wheels/openvino-2022.1.0-000-cp36-cp36-manylinux2014_x86_64.whl":
  No such file or directory.
Call Stack (most recent call first):
  inference-engine/ie_bridges/python/cmake_install.cmake:57 (include)
  inference-engine/cmake_install.cmake:47 (include)
  cmake_install.cmake:60 (include)
```
