### PR TITLE
[MO] Run MaxPool back stage transformation after FakeOutputResolver

### DIFF
--- a/tools/mo/openvino/tools/mo/back/MaxPool.py
+++ b/tools/mo/openvino/tools/mo/back/MaxPool.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2018-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
+from openvino.tools.mo.back.FakeOutputResolver import FakeOutputResolver
 from openvino.tools.mo.back.replacement import BackReplacementPattern
 from openvino.tools.mo.graph.graph import Graph
 from openvino.tools.mo.ops.result import Result
@@ -11,6 +11,9 @@ class MaxPool(BackReplacementPattern):
     Rename Pooling/max to MaxPool
     """
     enabled = True
+
+    def run_after(self):
+        return [FakeOutputResolver]
 
     def pattern(self):
         return dict(


### PR DESCRIPTION
Root cause analysis: Since `MaxPool-8` has 2 outputs, `FakeOutputResolver` transformation inserts extra `Add` operation between `MaxPool` and `Result`. It happens, because MO adds the missing output for `MaxPool` node before `FakeOutputResolver` executing. 

Solution: Arrange transformations so they work out in the right order.

Ticket: 73400


Code:
* [ ]  Comments N/A
* [ ]  Code style (PEP8) N/A
* [ ]  Transformation generates reshape-able IR N/A
* [ ]  Transformation preserves original framework node names N/A


Validation:
* [ ]  Unit tests N/A
* [ ]  Framework operation tests N/A
* [ ]  Transformation tests N/A
* [ ]  Model Optimizer IR Reader check N/A

Documentation:
* [ ]  Supported frameworks operations list N/A
* [ ]  Guide on how to convert the **public** model N/A
* [ ]  User guide update N/A
