### PR TITLE
[PYTHON API]: handle input normalization for tensor without name

### DIFF
--- a/src/bindings/python/src/openvino/runtime/ie_api.py
+++ b/src/bindings/python/src/openvino/runtime/ie_api.py
@@ -177,4 +177,3 @@ class Variant(VariantBase):
 
     def __len__(self) -> int:
         return len(self.value)
-

--- a/src/bindings/python/src/openvino/runtime/ie_api.py
+++ b/src/bindings/python/src/openvino/runtime/ie_api.py
@@ -25,13 +25,10 @@ def tensor_from_file(path: str) -> Tensor:
 def normalize_inputs(py_dict: dict, py_types: dict) -> dict:
     """Normalize a dictionary of inputs to Tensors."""
     for k, val in py_dict.items():
+        if not isinstance(k, (str, int)):
+            raise TypeError("Incompatible key type for tensor named: {}".format(k))
         try:
-            if isinstance(k, int):
-                ov_type = list(py_types.values())[k]
-            elif isinstance(k, str):
-                ov_type = py_types[k]
-            else:
-                raise TypeError("Incompatible key type for tensor named: {}".format(k))
+            ov_type = py_types[k]
         except KeyError:
             raise KeyError("Port for tensor named {} was not found!".format(k))
         py_dict[k] = (
@@ -49,8 +46,9 @@ def get_input_types(obj: Union[InferRequestBase, ExecutableNetworkBase]) -> dict
         return {n: input.get_element_type() for n in input.get_names()}
 
     input_types: dict = {}
-    for input in obj.inputs:
-        input_types = {**input_types, **map_tensor_names_to_types(input)}
+    for idx, input in enumerate(obj.inputs):
+        input_types.update(map_tensor_names_to_types(input))
+        input_types[idx] = input.get_element_type()
     return input_types
 
 
@@ -179,3 +177,4 @@ class Variant(VariantBase):
 
     def __len__(self) -> int:
         return len(self.value)
+


### PR DESCRIPTION
### Details:
 - solution from https://github.com/openvinotoolkit/openvino/pull/7691 handle case for multiple tensor names, but without respect to providing indexes instead of names
 - solution from https://github.com/openvinotoolkit/openvino/pull/9013 handle tensors without names, but incompatible with current API status and not cover case with multiple input names
 - My PR is attempt to get desired behaviour for both cases

### Tickets:
 - *ticket-id*
