### PR TITLE
Compilation error fix in pyopenvino.cpp

### DIFF
--- a/src/bindings/python/src/pyopenvino/pyopenvino.cpp
+++ b/src/bindings/python/src/pyopenvino/pyopenvino.cpp
@@ -3,7 +3,7 @@
 
 #include <pybind11/pybind11.h>
 
-#include <openvino/core/function.hpp>
+#include <openvino/core/model.hpp>
 #include <openvino/core/node.hpp>
 #include <openvino/core/version.hpp>
 #include <string>


### PR DESCRIPTION
Fixes a problem coming from a recent merge of 2 PRs.