### PR TITLE
Fix build failure for inference_engine when using higher version TBB

### DIFF
--- a/src/inference/src/threading/ie_parallel_custom_arena.cpp
+++ b/src/inference/src/threading/ie_parallel_custom_arena.cpp
@@ -21,10 +21,6 @@
 namespace custom {
 namespace detail {
 
-#    if TBB_NUMA_SUPPORT_PRESENT
-static tbb::task_arena::constraints convert_constraints(const custom::task_arena::constraints& c);
-#    endif
-
 #    if USE_TBBBIND_2_5
 extern "C" {
 void __TBB_internal_initialize_system_topology(std::size_t groups_num,
@@ -59,6 +55,8 @@ static bool is_binding_environment_valid() {
 #        endif /* _WIN32 && !_WIN64 */
 }
 
+#    elif TBB_NUMA_SUPPORT_PRESENT
+static tbb::task_arena::constraints convert_constraints(const custom::task_arena::constraints& c);
 #    endif
 
 class TBBbindSystemTopology {

--- a/src/inference/src/threading/ie_parallel_custom_arena.cpp
+++ b/src/inference/src/threading/ie_parallel_custom_arena.cpp
@@ -21,6 +21,10 @@
 namespace custom {
 namespace detail {
 
+#    if TBB_NUMA_SUPPORT_PRESENT
+static tbb::task_arena::constraints convert_constraints(const custom::task_arena::constraints& c);
+#    endif
+
 #    if USE_TBBBIND_2_5
 extern "C" {
 void __TBB_internal_initialize_system_topology(std::size_t groups_num,


### PR DESCRIPTION
### Details:
 - Problem Statement: 
When we build openvino with `-D THREADING=TBB` using higher version of manually built TBB libraries from [oneTBB](https://github.com/oneapi-src/oneTBB), where the TBB version is `TBB_INTERFACE_VERSION=12060`, we get the following error
`src\inference\src\threading\ie_parallel_custom_arena.cpp(116,47): error C3861: 'convert_constraints': identifier not found [C:\Users\Local_Admin\Workspace\hongyu1\ov\ov\build-R-OC\src\inference\inference_engine_obj.vcxproj]`
The reason is that the definition of function `convert_constraints` is behind line 116.
 - Fix:
After adding the declaration of `convert_constraints` at the beginning of the namespace, inference_engine target can be built correctly.

