### PR TITLE
[IE Samples] restored support for multiple -i args

### DIFF
--- a/samples/cpp/common/utils/src/args_helper.cpp
+++ b/samples/cpp/common/utils/src/args_helper.cpp
@@ -78,7 +78,7 @@ void parseInputFilesArguments(std::vector<std::string>& files) {
     while (args_it != args.end()) {
         const auto img_start = std::find_if(args_it, end(args), is_image_arg);
         if (img_start == end(args)) {
-            return;
+            break;
         }
         const auto img_begin = std::next(img_start);
         const auto img_end = std::find_if(img_begin, end(args), is_arg);
@@ -88,6 +88,9 @@ void parseInputFilesArguments(std::vector<std::string>& files) {
         args_it = img_end;
     }
 
+    if (files.empty()) {
+        return;
+    }
     size_t max_files = 20;
     if (files.size() < max_files) {
         slog::info << "Files were added: " << files.size() << slog::endl;

--- a/samples/cpp/common/utils/src/args_helper.cpp
+++ b/samples/cpp/common/utils/src/args_helper.cpp
@@ -67,20 +67,25 @@ void readInputFilesArguments(std::vector<std::string>& files, const std::string&
  */
 void parseInputFilesArguments(std::vector<std::string>& files) {
     std::vector<std::string> args = gflags::GetArgvs();
+    auto args_it = begin(args);
     const auto is_image_arg = [](const std::string& s) {
         return s == "-i" || s == "--images";
     };
     const auto is_arg = [](const std::string& s) {
         return s.front() == '-';
     };
-    const auto img_start = std::find_if(begin(args), end(args), is_image_arg);
-    if (img_start == end(args)) {
-        return;
-    }
-    const auto img_begin = std::next(img_start);
-    const auto img_end = std::find_if(img_begin, end(args), is_arg);
-    for (auto img = img_begin; img != img_end; ++img) {
-        readInputFilesArguments(files, *img);
+
+    while (args_it != args.end()) {
+        const auto img_start = std::find_if(args_it, end(args), is_image_arg);
+        if (img_start == end(args)) {
+            return;
+        }
+        const auto img_begin = std::next(img_start);
+        const auto img_end = std::find_if(img_begin, end(args), is_arg);
+        for (auto img = img_begin; img != img_end; ++img) {
+            readInputFilesArguments(files, *img);
+        }
+        args_it = img_end;
     }
 
     size_t max_files = 20;


### PR DESCRIPTION
In 2021.4 release input files parser in samples was changed in a not backward-compatible way (see how it was in 2021.3 https://github.com/openvinotoolkit/openvino/blob/c5f7ad383e654dfb4a5ac0805323cf8d43426b3f/inference-engine/samples/common/samples/args_helper.hpp#L74-L87), so support for multiple `-i ` arguments in command line was removed. 
It affected benchmark_app mostly. Thus if we now pass `-i file1 -i file2 -i file3` only `file1` will be read. 
In PR #7788 with modified benchmark we have restored multiple `-i `support and for correct comparison between master and our branch it's needed to fix inputs in master too.
