### PR TITLE
Fix error due to max macro interference from windows.h

### DIFF
--- a/src/core/include/openvino/op/gather.hpp
+++ b/src/core/include/openvino/op/gather.hpp
@@ -14,7 +14,7 @@ class OPENVINO_API Gather : public op::util::GatherBase {
 public:
     OPENVINO_OP("Gather", "opset1", op::util::GatherBase, 1);
     BWDCMP_RTTI_DECLARATION;
-    static constexpr int64_t AXIS_NOT_SET_VALUE = std::numeric_limits<int64_t>::max();
+    static constexpr int64_t AXIS_NOT_SET_VALUE = (std::numeric_limits<int64_t>::max)();
     Gather() = default;
     /// \param data The tensor from which slices are gathered
     /// \param indices Tensor with indexes to gather

--- a/src/plugins/auto/executable_network.cpp
+++ b/src/plugins/auto/executable_network.cpp
@@ -655,7 +655,7 @@ InferenceEngine::Parameter MultiDeviceExecutableNetwork::GetMetric(const std::st
                 real = _loadContext[CPU].
                     executableNetwork->GetMetric(name).as<unsigned int>();
             }
-            unsigned int res = std::max(8u, real);
+            unsigned int res = (std::max)(8u, real);
             IE_SET_METRIC_RETURN(OPTIMAL_NUMBER_OF_INFER_REQUESTS, res);
         }
 


### PR DESCRIPTION
### Details:
 - *This is to fix build error in Windows OS with seq threading mode due to max macro interference from windows.h*
 - *The including is in src/plugins/auto/utils/thread_utils.hpp line 20*
To reproduce, cmake command:
```
cmake -D ENABLE_VPU=ON -D ENABLE_CLDNN=OFF -D ENABLE_GNA=OFF -D ENABLE_MYRIAD=OFF -D ENABLE_HETERO=OFF -D ENABLE_MULTI=OFF -D ENABLE_TEMPLATE=OFF -D ENABLE_IR_V7_READER=OFF -D NGRAPH_ONNX_FRONTEND_ENABLE=OFF -D NGRAPH_PDPD_FRONTEND_ENABLE=OFF -D NGRAPH_TF_FRONTEND_ENABLE=OFF -D ENABLE_GAPI_PREPROCESSING=OFF -D ENABLE_MKL_DNN=OFF -D NGRAPH_IR_FRONTEND_ENABLE=ON -D IE_EXTRA_MODULES=$KMB_PLUGIN_HOME -D BUILD_SHARED_LIBS=OFF -D CMAKE_BUILD_TYPE=Release -D THREADING=SEQ -G "Visual Studio 16 2019" -A x64 -D CMAKE_CXX_FLAGS_RELEASE= /Zi -D CMAKE_EXE_LINKER_FLAGS_RELEASE= /DEBUG /OPT:REF /OPT:ICF -D CMAKE_SHARED_LINKER_FLAGS_RELEASE= /DEBUG /OPT:REF /OPT:ICF -D CMAKE_STATIC_LINKER_FLAGS_RELEASE= /DEBUG /OPT:REF /OPT:ICF  -D CMAKE_TOOLCHAIN_FILE=$OPENVINO_HOME/cmake/toolchains/onecoreuap.toolchain.cmake ..
```
Error log:
```
         C:\umd\openvino\src\core\include\openvino/op/gather.hpp(17,81): error C2589: '(': illegal token on right side of '::' (compiling source file C:\umd\openvino\src\plugins\auto\executable_network.cpp) [C:\umd\openvino\build-R-OC\src\plugins\auto\ov_auto_plugin.vcxproj]
         C:\umd\openvino\src\core\include\openvino/op/gather.hpp(17): error C2062: type 'unknown-type' unexpected (compiling source file C:\umd\openvino\src\plugins\auto\executable_network.cpp) [C:\umd\openvino\build-R-OC\src\plugins\auto\ov_auto_plugin.vcxproj]
         C:\umd\openvino\src\core\include\openvino/op/gather.hpp(17,81): error C2737: 'public: static __int64 const ov::op::v1::Gather::AXIS_NOT_SET_VALUE': constexpr object must be initialized (compiling source file C:\umd\openvino\src\plugins\auto\executable_network.cpp) [C:\umd\openvino\build-R-OC\src\plugins\auto\ov_auto_plugin.vcxproj]
         C:\umd\openvino\src\core\include\openvino/op/gather.hpp(17,81): error C2059: syntax error: ')' (compiling source file C:\umd\openvino\src\plugins\auto\executable_network.cpp) [C:\umd\openvino\build-R-OC\src\plugins\auto\ov_auto_plugin.vcxproj]
         C:\umd\openvino\src\plugins\auto\executable_network.cpp(658,37): error C2589: '(': illegal token on right side of '::' [C:\umd\openvino\build-R-OC\src\plugins\auto\ov_auto_plugin.vcxproj]
         C:\umd\openvino\src\plugins\auto\executable_network.cpp(658): error C2062: type 'unknown-type' unexpected [C:\umd\openvino\build-R-OC\src\plugins\auto\ov_auto_plugin.vcxproj]
         C:\umd\openvino\src\plugins\auto\executable_network.cpp(658,37): error C2059: syntax error: ')' [C:\umd\openvino\build-R-OC\src\plugins\auto\ov_auto_plugin.vcxproj]

```
### Tickets:
 - *ticket-id*
