### PR TITLE
[IE TESTS] Fix fill blob with random data for precision U4/I4/BIN

### DIFF
--- a/src/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
+++ b/src/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
@@ -138,11 +138,6 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*smoke_PrePostProcess.*two_inputs_trivial.*)",
         // TODO: CVS-67255
         R"(smoke_If.*SimpleIf2OutTest.*)",
-        // TODO: CVS-68525
-        R"(.*CanSetInBlobWithDifferentPrecision/netPRC=(I4|U4).*)",
-        R"(.*CanSetInBlobWithDifferentPrecision/netPRC=BIN.*)",
-        R"(.*CanSetOutBlobWithDifferentPrecision/netPRC=(I4|U4).*)",
-        R"(.*CanSetOutBlobWithDifferentPrecision/netPRC=BIN.*)",
 
         // Issue: 69086
         // need to add support convert BIN -> FP32

--- a/src/tests/functional/plugin/gpu/shared_tests_instances/skip_tests_config.cpp
+++ b/src/tests/functional/plugin/gpu/shared_tests_instances/skip_tests_config.cpp
@@ -79,11 +79,6 @@ std::vector<std::string> disabledTestPatterns() {
             R"(.*EltwiseLayerTest.*OpType=Pow.*NetType=i64.*)",
             // TODO: Issue 67910
             R"(.*smoke_PrePostProcess_GPU.*two_inputs_trivial.*)",
-            // TODO: 68525
-            R"(.*CanSetInBlobWithDifferentPrecision/netPRC=(I4|U4).*)",
-            R"(.*CanSetInBlobWithDifferentPrecision/netPRC=BIN.*)",
-            R"(.*CanSetOutBlobWithDifferentPrecision/netPRC=(I4|U4).*)",
-            R"(.*CanSetOutBlobWithDifferentPrecision/netPRC=BIN.*)",
             // TODO: Issue: 67486
             R"(.*(SoftMaxLayerTest).*)",
             // TODO: Issue: 68712

--- a/src/tests/functional/plugin/shared/include/behavior/infer_request/io_blob.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/infer_request/io_blob.hpp
@@ -346,7 +346,7 @@ protected:
 };
 
 
-TEST_P(InferRequestIOBBlobSetPrecisionTest, CanSetInBlobWithDifferentPrecision) {
+TEST_P(InferRequestIOBBlobSetPrecisionTest, CanSetOutBlobWithDifferentPrecision) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
     // Create InferRequest
     InferenceEngine::InferRequest req;
@@ -362,7 +362,7 @@ TEST_P(InferRequestIOBBlobSetPrecisionTest, CanSetInBlobWithDifferentPrecision) 
     }
 }
 
-TEST_P(InferRequestIOBBlobSetPrecisionTest, CanSetOutBlobWithDifferentPrecision) {
+TEST_P(InferRequestIOBBlobSetPrecisionTest, CanSetInBlobWithDifferentPrecision) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
     // Create InferRequest
     InferenceEngine::InferRequest req;

--- a/src/tests/ie_test_utils/common_test_utils/data_utils.hpp
+++ b/src/tests/ie_test_utils/common_test_utils/data_utils.hpp
@@ -262,7 +262,12 @@ void inline fill_data_random(InferenceEngine::Blob::Ptr &blob, const uint32_t ra
                              const int32_t k = 1, const int seed = 1) {
     using dataType = typename InferenceEngine::PrecisionTrait<PRC>::value_type;
     auto *rawBlobDataPtr = blob->buffer().as<dataType *>();
-    fill_data_random(rawBlobDataPtr, blob->size(), range, start_from, k, seed);
+    if (PRC == InferenceEngine::Precision::U4 || PRC == InferenceEngine::Precision::I4 ||
+        PRC == InferenceEngine::Precision::BIN) {
+        fill_data_random(rawBlobDataPtr, blob->byteSize(), range, start_from, k, seed);
+    } else {
+        fill_data_random(rawBlobDataPtr, blob->size(), range, start_from, k, seed);
+    }
 }
 
 /** @brief Fill blob with a sorted sequence of unique elements randomly generated.


### PR DESCRIPTION
### Details:
 - Make use of byteSize for filling blob for precision U4/I4/BIN
 - Swap name CanSet[In/Out]BlobWithDifferentLayouts
 - Remove CanSet[In/Out]BlobWithDifferentLayouts for precision U4/I4/BIN from skip config

### Tickets:
 - CVS-68525
