### PR TITLE
Overwrite 'model' layout with preprocessing when layout is already set

### DIFF
--- a/src/core/src/preprocess/pre_post_process.cpp
+++ b/src/core/src/preprocess/pre_post_process.cpp
@@ -367,7 +367,8 @@ std::shared_ptr<Model> PrePostProcessor::build() {
     for (const auto& input_info : m_impl->m_inputs) {
         auto& input = input_info.m_impl;
         // Set parameter layout from 'model' information
-        if (input->get_model()->is_layout_set() && input->m_resolved_param->get_layout().empty()) {
+        if (input->get_model()->is_layout_set()) {
+            // Overwrite existing model's layout here (fix 74065)
             input->m_resolved_param->set_layout(input->get_model()->get_layout());
         }
     }
@@ -563,7 +564,8 @@ std::shared_ptr<Model> PrePostProcessor::build() {
         node.get_tensor().set_names({});
         result = std::dynamic_pointer_cast<op::v0::Result>(node.get_node_shared_ptr());
         // Set result layout from 'model' information
-        if (output->get_model_data()->is_layout_set() && result->get_layout().empty()) {
+        if (output->get_model_data()->is_layout_set()) {
+            // Overwrite existing model's layout here (fix 74065)
             result->set_layout(output->get_model_data()->get_layout());
         }
         auto parent = result->get_input_source_output(0);

--- a/src/core/tests/preprocess.cpp
+++ b/src/core/tests/preprocess.cpp
@@ -545,7 +545,7 @@ TEST(pre_post_process, set_model_layout_when_already_exists) {
     {
         auto p = PrePostProcessor(m);
         p.input().tensor().set_layout("NHWC");
-        p.input().model().set_layout("NCHW"); // Expect "N???" will be overwritten by "NCHW"
+        p.input().model().set_layout("NCHW");  // Expect "N???" will be overwritten by "NCHW"
         m = p.build();
     }
     EXPECT_EQ(m->input().get_partial_shape(), (PartialShape{Dimension::dynamic(), 2, 1, 3}));
@@ -1173,7 +1173,7 @@ TEST(pre_post_process, postprocess_set_model_layout_when_already_exists) {
     EXPECT_EQ(m->output().get_partial_shape(), (PartialShape{Dimension::dynamic(), 3, 2, 1}));
     {
         auto p = PrePostProcessor(m);
-        p.output().model().set_layout("NCHW"); // Expect "N???" will be overwritten by "NCHW"
+        p.output().model().set_layout("NCHW");  // Expect "N???" will be overwritten by "NCHW"
         p.output().tensor().set_layout("NHWC");
         m = p.build();
     }

--- a/src/core/tests/preprocess.cpp
+++ b/src/core/tests/preprocess.cpp
@@ -534,6 +534,23 @@ TEST(pre_post_process, reuse_model_layout_no_tensor_info) {
     EXPECT_EQ(f->get_parameters().front()->get_layout(), "NC??");
 }
 
+TEST(pre_post_process, set_model_layout_when_already_exists) {
+    auto m = create_simple_function(element::f32, PartialShape{Dimension::dynamic(), 3, 2, 1});
+    {
+        auto p = PrePostProcessor(m);
+        p.input().model().set_layout("N???");
+        m = p.build();
+    }
+    EXPECT_EQ(m->input().get_partial_shape(), (PartialShape{Dimension::dynamic(), 3, 2, 1}));
+    {
+        auto p = PrePostProcessor(m);
+        p.input().tensor().set_layout("NHWC");
+        p.input().model().set_layout("NCHW"); // Expect "N???" will be overwritten by "NCHW"
+        m = p.build();
+    }
+    EXPECT_EQ(m->input().get_partial_shape(), (PartialShape{Dimension::dynamic(), 2, 1, 3}));
+}
+
 TEST(pre_post_process, set_layout_out_of_bounds) {
     auto shape = PartialShape{1, 2};
     std::stringstream shape_str;
@@ -1144,6 +1161,23 @@ TEST(pre_post_process, postprocess_convert_layout_implicit) {
     p.build();
     EXPECT_EQ(f->get_results()[0]->get_layout(), "NHWC");
     EXPECT_EQ(f->get_results()[0]->get_output_tensor(0).get_partial_shape(), (PartialShape{1, 2, 2, 3}));
+}
+
+TEST(pre_post_process, postprocess_set_model_layout_when_already_exists) {
+    auto m = create_simple_function(element::f32, PartialShape{Dimension::dynamic(), 3, 2, 1});
+    {
+        auto p = PrePostProcessor(m);
+        p.output().model().set_layout("N???");
+        m = p.build();
+    }
+    EXPECT_EQ(m->output().get_partial_shape(), (PartialShape{Dimension::dynamic(), 3, 2, 1}));
+    {
+        auto p = PrePostProcessor(m);
+        p.output().model().set_layout("NCHW"); // Expect "N???" will be overwritten by "NCHW"
+        p.output().tensor().set_layout("NHWC");
+        m = p.build();
+    }
+    EXPECT_EQ(m->output().get_partial_shape(), (PartialShape{Dimension::dynamic(), 2, 1, 3}));
 }
 
 TEST(pre_post_process, postprocess_convert_layout_explicit_no_target) {


### PR DESCRIPTION
### Details:
 - When user specifies `input/output().model().set_layout("NCHW")` - preprocessing will overwrite existing layout information of parameter/result

### Tickets:
 - 74065
