### PR TITLE
Fix UnicodeEncodeError exception in MO help

### DIFF
--- a/tools/mo/openvino/tools/mo/utils/cli_parser.py
+++ b/tools/mo/openvino/tools/mo/utils/cli_parser.py
@@ -351,7 +351,7 @@ def get_common_cli_parser(parser: argparse.ArgumentParser = None):
                                    ' for example: --layout name1(nchw),name2(nc). It is possible to instruct '
                                    'ModelOptimizer to change layout, for example: '
                                    '--layout name1(nhwc->nchw),name2(cn->nc). Also "*" in long layout form can be used'
-                                   ' to fuse dimensions, for example [n,c,...]->[n*c,…].',
+                                   ' to fuse dimensions, for example [n,c,...]->[n*c,...].',
                               default=())
     # TODO: isn't it a weights precision type
     common_group.add_argument('--data_type',


### PR DESCRIPTION
### Details:
`mo --help` raises UnicodeEncodeError exception on Ubuntu 18 and Python 3.6.9.

Root cause is single Unicode ellipsis character (U+2026) in this line:
https://github.com/openvinotoolkit/openvino/blob/59fca61dd58ae403eb6793228ab910d8f2eae35a/tools/mo/openvino/tools/mo/utils/cli_parser.py#L336

```
$ mo --help
[ ERROR ]  -------------------------------------------------
[ ERROR ]  ----------------- INTERNAL ERROR ----------------
[ ERROR ]  Unexpected exception happened.
[ ERROR ]  Please contact Model Optimizer developers and forward the following information:
[ ERROR ]  'ascii' codec can't encode character '\u2026' in position 7689: ordinal not in range(128)
[ ERROR ]  Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/openvino/tools/mo/main.py", line 445, in main
    argv = cli_parser.parse_args()
  File "/usr/lib/python3.6/argparse.py", line 1743, in parse_args
    args, argv = self.parse_known_args(args, namespace)
  File "/usr/lib/python3.6/argparse.py", line 1775, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/usr/lib/python3.6/argparse.py", line 1981, in _parse_known_args
    start_index = consume_optional(start_index)
  File "/usr/lib/python3.6/argparse.py", line 1921, in consume_optional
    take_action(action, args, option_string)
  File "/usr/lib/python3.6/argparse.py", line 1849, in take_action
    action(self, namespace, argument_values, option_string)
  File "/usr/lib/python3.6/argparse.py", line 1033, in __call__
    parser.print_help()
  File "/usr/lib/python3.6/argparse.py", line 2375, in print_help
    self._print_message(self.format_help(), file)
  File "/usr/lib/python3.6/argparse.py", line 2381, in _print_message
    file.write(message)
UnicodeEncodeError: 'ascii' codec can't encode character '\u2026' in position 7689: ordinal not in range(128)

[ ERROR ]  ---------------- END OF BUG REPORT --------------
[ ERROR ]  -------------------------------------------------
```
