### PR TITLE
[benchmark_app] remove the device restriction when loading extension library

### DIFF
--- a/samples/cpp/benchmark_app/main.cpp
+++ b/samples/cpp/benchmark_app/main.cpp
@@ -209,7 +209,7 @@ int main(int argc, char* argv[]) {
 
         ov::Core core;
 
-        if (FLAGS_d.find("CPU") != std::string::npos && !FLAGS_l.empty()) {
+        if (!FLAGS_l.empty()) {
             // CPU (MKLDNN) extensions is loaded as a shared library
             core.add_extension(FLAGS_l);
             slog::info << "CPU (MKLDNN) extensions is loaded " << FLAGS_l << slog::endl;

--- a/tools/benchmark_tool/openvino/tools/benchmark/main.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/main.py
@@ -67,7 +67,7 @@ def run(args):
                               args.number_iterations, args.time, args.api_type, args.inference_only)
 
         ## CPU (MKLDNN) extensions
-        if CPU_DEVICE_NAME in device_name and args.path_to_extension:
+        if args.path_to_extension:
             benchmark.add_extension(path_to_extension=args.path_to_extension)
 
         ## GPU (clDNN) Extensions


### PR DESCRIPTION
Details:
As for custom GPU operation, user need the ngraph register library(can be loaded via -l xxx.dll) and the GPU config xml (can be loaded via -c xxx.xml).
But, currently if user choose -d GPU, extension library will not be loaded, which casue the readnetwork() fail.
Therefore, user have to use the -d HETERO:GPU,CPU to enable extension library loading, but this heteroplugin indeed has different behavior with -d GPU.