### PR TITLE
Update setupvars.bat with CMAKE_BUILD_TYPE

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -33,11 +33,14 @@ if(UNIX)
     set(_setupvars_file setupvars/setupvars.sh)
 elseif(WIN32)
     set(_setupvars_file setupvars/setupvars.bat)
-    # Update setupvars.bat to support non "Release" build types
-    file(READ "${_setupvars_file}" _setupvars_content)
-    string(REPLACE "Release" ${CMAKE_BUILD_TYPE} _setupvars_content ${_setupvars_content})
-    set(_setupvars_file "${CMAKE_BINARY_DIR}/${_setupvars_file}")
-    file(WRITE "${_setupvars_file}" ${_setupvars_content})
+    if (USE_BUILD_TYPE_SUBFOLDER AND CMAKE_BUILD_TYPE AND NOT CMAKE_BUILD_TYPE EQUAL "Debug")
+        # Patch primary configuration in setupvars.bat which is "Release" by default.
+        # Note setupvars secondary configuration is always "Debug".
+        file(READ "${_setupvars_file}" _setupvars_content)
+        string(REPLACE "Release" ${CMAKE_BUILD_TYPE} _setupvars_content ${_setupvars_content})
+        set(_setupvars_file "${CMAKE_BINARY_DIR}/${_setupvars_file}")
+        file(WRITE "${_setupvars_file}" ${_setupvars_content})
+    endif()
 endif()
 install(PROGRAMS "${_setupvars_file}"
         DESTINATION .

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -37,9 +37,9 @@ elseif(WIN32)
         # Patch primary configuration in setupvars.bat which is "Release" by default.
         # Note setupvars secondary configuration is always "Debug".
         file(READ "${_setupvars_file}" _setupvars_content)
-        string(REPLACE "Release" ${CMAKE_BUILD_TYPE} _setupvars_content ${_setupvars_content})
+        string(REPLACE "Release" ${CMAKE_BUILD_TYPE} _setupvars_content "${_setupvars_content}")
         set(_setupvars_file "${CMAKE_BINARY_DIR}/${_setupvars_file}")
-        file(WRITE "${_setupvars_file}" ${_setupvars_content})
+        file(WRITE "${_setupvars_file}" "${_setupvars_content}")
     endif()
 endif()
 install(PROGRAMS "${_setupvars_file}"

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -30,14 +30,18 @@ ie_shellcheck_process(DIRECTORY "${OpenVINO_SOURCE_DIR}"
 ie_cpack_add_component(setupvars REQUIRED)
 
 if(UNIX)
-    install(PROGRAMS setupvars/setupvars.sh
-            DESTINATION .
-            COMPONENT setupvars)
+    set(_setupvars_file setupvars/setupvars.sh)
 elseif(WIN32)
-    install(PROGRAMS setupvars/setupvars.bat
-            DESTINATION .
-            COMPONENT setupvars)
+    set(_setupvars_file setupvars/setupvars.bat)
+    # Update setupvars.bat to support non "Release" build types
+    file(READ "${_setupvars_file}" _setupvars_content)
+    string(REPLACE "Release" ${CMAKE_BUILD_TYPE} _setupvars_content ${_setupvars_content})
+    set(_setupvars_file "${CMAKE_BINARY_DIR}/${_setupvars_file}")
+    file(WRITE "${_setupvars_file}" ${_setupvars_content})
 endif()
+install(PROGRAMS "${_setupvars_file}"
+        DESTINATION .
+        COMPONENT setupvars)
 
 # install install_dependencies
 


### PR DESCRIPTION
 setupvars.bat paths set depends on CMAKE_BUILD_TYPE.
 RelWithDebInfo didn't work correctly.