### PR TITLE
Support old import system in POT

### DIFF
--- a/tools/pot/compression/__init__.py
+++ b/tools/pot/compression/__init__.py
@@ -1,14 +1,17 @@
 import sys
+import warnings
+warnings.warn('Import compression is deprecated. Please use openvino.tools.pot instead', DeprecationWarning)
 
 import openvino.tools.pot.api
-import openvino.tools.pot.engines.ie_engine
+import openvino.tools.pot.engines
 import openvino.tools.pot.graph
-import openvino.tools.pot.graph.model_utils
-import openvino.tools.pot.pipeline.initializer
+import openvino.tools.pot.pipeline
 
 
 sys.modules["compression.api"] = openvino.tools.pot.api
+sys.modules["compression.engines"] = openvino.tools.pot.engines
 sys.modules["compression.engines.ie_engine"] = openvino.tools.pot.engines.ie_engine
 sys.modules["compression.graph"] = openvino.tools.pot.graph
 sys.modules["compression.graph.model_utils"] = openvino.tools.pot.graph.model_utils
+sys.modules["compression.pipeline"] = openvino.tools.pot.pipeline
 sys.modules["compression.pipeline.initializer"] = openvino.tools.pot.pipeline.initializer

--- a/tools/pot/compression/__init__.py
+++ b/tools/pot/compression/__init__.py
@@ -1,0 +1,14 @@
+import sys
+
+import openvino.tools.pot.api
+import openvino.tools.pot.engines.ie_engine
+import openvino.tools.pot.graph
+import openvino.tools.pot.graph.model_utils
+import openvino.tools.pot.pipeline.initializer
+
+
+sys.modules["compression.api"] = openvino.tools.pot.api
+sys.modules["compression.engines.ie_engine"] = openvino.tools.pot.engines.ie_engine
+sys.modules["compression.graph"] = openvino.tools.pot.graph
+sys.modules["compression.graph.model_utils"] = openvino.tools.pot.graph.model_utils
+sys.modules["compression.pipeline.initializer"] = openvino.tools.pot.pipeline.initializer

--- a/tools/pot/compression/__init__.py
+++ b/tools/pot/compression/__init__.py
@@ -1,12 +1,16 @@
+# Copyright (C) 2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import sys
 import warnings
-warnings.warn('Import compression is deprecated. Please use openvino.tools.pot instead', DeprecationWarning)
 
 import openvino.tools.pot.api
 import openvino.tools.pot.engines
 import openvino.tools.pot.graph
 import openvino.tools.pot.pipeline
 
+
+warnings.warn('Import compression is deprecated. Please use openvino.tools.pot instead', DeprecationWarning)
 
 sys.modules["compression.api"] = openvino.tools.pot.api
 sys.modules["compression.engines"] = openvino.tools.pot.engines

--- a/tools/pot/openvino/tools/pot/__init__.py
+++ b/tools/pot/openvino/tools/pot/__init__.py
@@ -33,6 +33,13 @@ from .algorithms.sparsity.default.base_algorithm import BaseWeightSparsity
 from .algorithms.quantization.overflow_correction.algorithm import OverflowCorrection
 from .algorithms.quantization.ranger.algorithm import Ranger
 
+from .api.data_loader import DataLoader
+from .api.metric import Metric
+from .engines.ie_engine import IEEngine
+from .graph import load_model, save_model
+from .graph.model_utils import compress_model_weights
+from .pipeline.initializer import create_pipeline
+
 QUANTIZATION_ALGORITHMS = [
     'MinMaxQuantization',
     'RangeOptimization',

--- a/tools/pot/openvino/tools/pot/__init__.py
+++ b/tools/pot/openvino/tools/pot/__init__.py
@@ -35,6 +35,7 @@ from .algorithms.quantization.ranger.algorithm import Ranger
 
 from .api.data_loader import DataLoader
 from .api.metric import Metric
+from .api.engine import Engine
 from .engines.ie_engine import IEEngine
 from .graph import load_model, save_model
 from .graph.model_utils import compress_model_weights

--- a/tools/pot/openvino/tools/pot/api/README.md
+++ b/tools/pot/openvino/tools/pot/api/README.md
@@ -51,7 +51,7 @@ pipeline.
 ### DataLoader
 
 ```
-class compression.api.DataLoader(config)
+class openvino.tools.pot.api.DataLoader(config)
 ```
 The base class for all DataLoaders.
 
@@ -64,7 +64,7 @@ which supports integer indexing in range of 0 to `len(self)`
 ### Metric
 
 ```
-class compression.api.Metric()
+class openvino.tools.pot.api.Metric()
 ```
 An abstract class representing an accuracy metric.
 
@@ -87,7 +87,7 @@ All subclasses should override the following methods:
 ### Engine
 
 ```
-class compression.api.Engine(config, data_loader=None, metric=None)
+class openvino.tools.pot.api.Engine(config, data_loader=None, metric=None)
 ```
 Base class for all Engines.
 
@@ -153,7 +153,7 @@ describe internal representation of the DL model and how to work with it.
 ### IEEngine
 
 ```
-class compression.engines.IEEngine(config, data_loader=None, metric=None)
+class openvino.tools.pot.engines.ie_engine.IEEngine(config, data_loader=None, metric=None)
 ```
 IEEngine is a helper which implements Engine class based on [OpenVINO&trade; Inference Engine Python* API](@ref openvino_inference_engine_ie_bridges_python_docs_api_overview).
 This class support inference in synchronous and asynchronous modes and can be reused as-is in the custom pipeline or 
@@ -196,7 +196,7 @@ The Python* POT API provides the `NXModel` class as one interface for working wi
 It is used to load, save and access the model, in case of the cascaded model, access each model of the cascaded model.
 
 ```
-class compression.graph.nx_wrapper.NXModel(**kwargs)
+class openvino.tools.pot.graph.nx_model.NXModel(**kwargs)
 ```
 The NXModel class provides a representation of the DL model. A single model and cascaded model can be 
 represented as an instance of this class. The cascaded model is stored as a list of models.
@@ -209,7 +209,7 @@ represented as an instance of this class. The cascaded model is stored as a list
 
 The Python* POT API provides the utility function to load model from the OpenVINO&trade; Intermediate Representation (IR):
 ```
-compression.graph.model_utils.load_model(model_config)
+openvino.tools.pot.graph.model_utils.load_model(model_config)
 ```
 *Parameters*
 - `model_config` - dictionary describing a model that includes the following attributes:
@@ -255,7 +255,7 @@ compression.graph.model_utils.load_model(model_config)
 #### Saving model to IR
 The Python* POT API provides the utility function to save model in the OpenVINO&trade; Intermediate Representation (IR):
 ```
-compression.graph.model_utils.save_model(model, save_path, model_name=None, for_stat_collection=False)
+openvino.tools.pot.graph.model_utils.save_model(model, save_path, model_name=None, for_stat_collection=False)
 ```
 *Parameters*
 - `model` - `NXModel` instance.
@@ -280,7 +280,7 @@ compression.graph.model_utils.save_model(model, save_path, model_name=None, for_
 ### Sampler
 
 ```
-class compression.samplers.Sampler(data_loader=None, batch_size=1, subset_indices=None)
+class openvino.tools.pot.samplers.Sampler(data_loader=None, batch_size=1, subset_indices=None)
 ```
 Base class for all Samplers.
 
@@ -298,7 +298,7 @@ that returns the length of the returned iterators.
 ### BatchSampler
 
 ```
-class  compression.samplers.batch_sampler.BatchSampler(data_loader, batch_size=1, subset_indices=None):
+class openvino.tools.pot.samplers.batch_sampler.BatchSampler(data_loader, batch_size=1, subset_indices=None):
 ```
 Sampler provides an iterable over the dataset subset if `subset_indices` is specified or over the whole dataset with 
 given `batch_size`. Returns a list of data items.
@@ -306,7 +306,7 @@ given `batch_size`. Returns a list of data items.
 ## Pipeline
 
 ```
-class compression.pipeline.pipeline.Pipeline(engine)
+class openvino.tools.pot.pipeline.pipeline.Pipeline(engine)
 ```
 Pipeline class represents the optimization pipeline.
 
@@ -319,7 +319,7 @@ The pipeline can be applied to the DL model by calling `run(model)` method where
 
 The POT Python* API provides the utility function to create and configure the pipeline:
 ```
-compression.pipeline.initializer.create_pipeline(algo_config, engine)
+openvino.tools.pot.pipeline.initializer.create_pipeline(algo_config, engine)
 ```
 *Parameters* 
 - `algo_config` - a list defining optimization algorithms and their parameters included in the optimization pipeline. 

--- a/tools/pot/openvino/tools/pot/api/samples/3d_segmentation/3d_segmentation_sample.py
+++ b/tools/pot/openvino/tools/pot/api/samples/3d_segmentation/3d_segmentation_sample.py
@@ -8,11 +8,8 @@ import numpy as np
 from scipy.ndimage import interpolation
 from addict import Dict
 
-from openvino.tools.pot.api import Metric, DataLoader
-from openvino.tools.pot.engines.ie_engine import IEEngine
-from openvino.tools.pot.graph import load_model, save_model
-from openvino.tools.pot.graph.model_utils import compress_model_weights
-from openvino.tools.pot.pipeline.initializer import create_pipeline
+from openvino.tools.pot import Metric, DataLoader, IEEngine, \
+    load_model, save_model, compress_model_weights, create_pipeline
 from openvino.tools.pot.utils.logger import init_logger
 from openvino.tools.pot.api.samples.utils.argument_parser import get_common_argparser
 

--- a/tools/pot/openvino/tools/pot/api/samples/classification/classification_sample.py
+++ b/tools/pot/openvino/tools/pot/api/samples/classification/classification_sample.py
@@ -6,11 +6,8 @@ import numpy as np
 from addict import Dict
 from cv2 import imread, resize as cv2_resize
 
-from openvino.tools.pot.api import Metric, DataLoader
-from openvino.tools.pot.graph import load_model, save_model
-from openvino.tools.pot.graph.model_utils import compress_model_weights
-from openvino.tools.pot.engines.ie_engine import IEEngine
-from openvino.tools.pot.pipeline.initializer import create_pipeline
+from openvino.tools.pot import Metric, DataLoader, IEEngine, \
+    load_model, save_model, compress_model_weights, create_pipeline
 from openvino.tools.pot.utils.logger import init_logger
 from openvino.tools.pot.api.samples.utils.argument_parser import get_common_argparser
 

--- a/tools/pot/openvino/tools/pot/api/samples/face_detection/face_detection_sample.py
+++ b/tools/pot/openvino/tools/pot/api/samples/face_detection/face_detection_sample.py
@@ -10,11 +10,9 @@ from addict import Dict
 import cv2
 import numpy as np
 
-from openvino.tools.pot.api import Metric, DataLoader
-from openvino.tools.pot.engines.ie_engine import IEEngine
-from openvino.tools.pot.graph import load_model
-from openvino.tools.pot.graph.model_utils import compress_model_weights, add_outputs
-from openvino.tools.pot.pipeline.initializer import create_pipeline
+from openvino.tools.pot import Metric, DataLoader, IEEngine, \
+    load_model, compress_model_weights, create_pipeline
+from openvino.tools.pot.graph.model_utils import add_outputs
 from openvino.tools.pot.utils.logger import init_logger, get_logger
 from openvino.tools.pot.api.samples.face_detection import utils
 

--- a/tools/pot/openvino/tools/pot/api/samples/object_detection/data_loader.py
+++ b/tools/pot/openvino/tools/pot/api/samples/object_detection/data_loader.py
@@ -6,7 +6,7 @@ import json
 import cv2
 import numpy as np
 
-from openvino.tools.pot.api import DataLoader
+from openvino.tools.pot import DataLoader
 
 
 class COCOLoader(DataLoader):

--- a/tools/pot/openvino/tools/pot/api/samples/object_detection/metric.py
+++ b/tools/pot/openvino/tools/pot/api/samples/object_detection/metric.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 
-from openvino.tools.pot.api import Metric
+from openvino.tools.pot import Metric
 
 
 class MAP(Metric):

--- a/tools/pot/openvino/tools/pot/api/samples/object_detection/obejct_detection_sample.py
+++ b/tools/pot/openvino/tools/pot/api/samples/object_detection/obejct_detection_sample.py
@@ -5,10 +5,7 @@ import os
 
 from addict import Dict
 
-from openvino.tools.pot.engines.ie_engine import IEEngine
-from openvino.tools.pot.graph import load_model, save_model
-from openvino.tools.pot.graph.model_utils import compress_model_weights
-from openvino.tools.pot.pipeline.initializer import create_pipeline
+from openvino.tools.pot import IEEngine, load_model, save_model, compress_model_weights, create_pipeline
 from openvino.tools.pot.utils.logger import init_logger
 from openvino.tools.pot.api.samples.utils.argument_parser import get_common_argparser
 from openvino.tools.pot.api.samples.object_detection.metric import MAP

--- a/tools/pot/openvino/tools/pot/api/samples/segmentation/segmentation_sample.py
+++ b/tools/pot/openvino/tools/pot/api/samples/segmentation/segmentation_sample.py
@@ -8,11 +8,8 @@ import cv2
 import numpy as np
 from addict import Dict
 
-from openvino.tools.pot.api import Metric, DataLoader
-from openvino.tools.pot.engines.ie_engine import IEEngine
-from openvino.tools.pot.graph import load_model, save_model
-from openvino.tools.pot.graph.model_utils import compress_model_weights
-from openvino.tools.pot.pipeline.initializer import create_pipeline
+from openvino.tools.pot import Metric, DataLoader, IEEngine, \
+    load_model, save_model, compress_model_weights, create_pipeline
 from openvino.tools.pot.utils.logger import init_logger
 from openvino.tools.pot.api.samples.utils.argument_parser import get_common_argparser
 

--- a/tools/pot/openvino/tools/pot/api/samples/speech/data_loader.py
+++ b/tools/pot/openvino/tools/pot/api/samples/speech/data_loader.py
@@ -5,7 +5,7 @@ import os
 import struct
 import numpy as np
 
-from openvino.tools.pot.api.data_loader import DataLoader
+from openvino.tools.pot import DataLoader
 
 
 class ArkDataLoader(DataLoader):

--- a/tools/pot/openvino/tools/pot/api/samples/speech/gna_sample.py
+++ b/tools/pot/openvino/tools/pot/api/samples/speech/gna_sample.py
@@ -5,8 +5,7 @@ import json
 import os
 from addict import Dict
 
-from openvino.tools.pot.graph import load_model, save_model
-from openvino.tools.pot.pipeline.initializer import create_pipeline
+from openvino.tools.pot import load_model, save_model, create_pipeline
 from openvino.tools.pot.utils.logger import init_logger
 from openvino.tools.pot.api.samples.utils.argument_parser import get_common_argparser
 from openvino.tools.pot.api.samples.speech.data_loader import ArkDataLoader


### PR DESCRIPTION
### Details:
 - *Added support for legacy imports*
```python
from compression.api import DataLoader as POTDataLoader
from compression.api import Metric
from compression.engines.ie_engine import IEEngine
from compression.graph import load_model, save_model
from compression.graph.model_utils import compress_model_weights
from compression.pipeline.initializer import create_pipeline
```
 - *Enabled import  `DataLoader, Metric, IEEngine, load_model, save_model, compress_model_weights, create_pipeline` without `api` dir*
 ```python
from openvino.tools.pot import DataLoader, Metric, IEEngine, load_model, save_model, compress_model_weights, create_pipeline
```

### Tickets:
 - *74012*
