### PR TITLE
[GPU] Exclude peak memory usage from the result of memory statistics

### DIFF
--- a/inference-engine/thirdparty/clDNN/api/intel_gpu/runtime/engine.hpp
+++ b/inference-engine/thirdparty/clDNN/api/intel_gpu/runtime/engine.hpp
@@ -110,7 +110,7 @@ public:
     uint64_t get_used_device_memory(allocation_type type) const;
 
     /// Returns statistics of GPU memory allocated by engine in current process for all allocation types.
-    /// @note It contains information about both current and peak memory usage
+    /// @note It contains information about current memory usage
     std::map<std::string, uint64_t> get_memory_statistics() const;
 
     /// Adds @p bytes count to currently used memory size of the specified allocation @p type

--- a/inference-engine/thirdparty/clDNN/runtime/engine.cpp
+++ b/inference-engine/thirdparty/clDNN/runtime/engine.cpp
@@ -164,12 +164,7 @@ std::map<std::string, uint64_t> engine::get_memory_statistics() const {
     std::map<std::string, uint64_t> statistics;
     for (auto const& m : _memory_usage_map) {
         std::ostringstream oss;
-        oss << m.first << "_current";
-        statistics[oss.str()] = m.second.load();
-    }
-    for (auto const& m : _peak_memory_usage_map) {
-        std::ostringstream oss;
-        oss << m.first << "_peak";
+        oss << m.first;
         statistics[oss.str()] = m.second.load();
     }
     return statistics;

--- a/src/inference/include/ie/gpu/gpu_config.hpp
+++ b/src/inference/include/ie/gpu/gpu_config.hpp
@@ -47,7 +47,7 @@ DECLARE_GPU_METRIC_KEY(EXECUTION_UNITS_COUNT, int);
 
 /**
  * @brief Metric to get statistics of GPU memory allocated by engine for each allocation type
- * It contains information about both current and peak memory usage
+ * It contains information about current memory usage
  */
 DECLARE_GPU_METRIC_KEY(MEMORY_STATISTICS, std::map<std::string, uint64_t>);
 


### PR DESCRIPTION
### Details:
 - Peak memory usage is excluded from the result of memory statistics in order to prevent unintentional misuse 
