### PR TITLE
[Offline Transformations] Reshape Layer Pruning Transformation Support

### DIFF
--- a/src/common/offline_transformations/include/mask_attribute.hpp
+++ b/src/common/offline_transformations/include/mask_attribute.hpp
@@ -44,6 +44,11 @@ public:
             : std::vector<value_type>(size) {
     }
 
+    explicit Mask(const size_t & size, const bool adjust_value)
+            : std::vector<value_type>(size),
+              m_adjust_value(adjust_value) {
+    }
+
     Mask(std::initializer_list<std::initializer_list<uint64_t>> list)
             : std::vector<value_type>() {
         for (const auto & dim_values : list) {
@@ -196,8 +201,17 @@ public:
         m_need_initialization = true;
     }
 
+    bool adjust_value() const {
+        return m_adjust_value;
+    }
+
 private:
     bool m_is_shape_like{false};
+    // Flag - if constant this mask is related to should be pruned
+    // by value. Means shape of the constant remains the same
+    // but correspondent dimensions values decreased by
+    // count of channels which should be pruned.
+    bool m_adjust_value{false};
 
     // Masks dependent on this mask vs methods, specifying how
     // this mask will be modifed by correspondent dependent mask

--- a/src/common/offline_transformations/include/mask_attribute.hpp
+++ b/src/common/offline_transformations/include/mask_attribute.hpp
@@ -207,10 +207,13 @@ public:
 
 private:
     bool m_is_shape_like{false};
-    // Flag - if constant this mask is related to should be pruned
-    // by value. Means shape of the constant remains the same
-    // but correspondent dimensions values decreased by
-    // count of channels which should be pruned.
+    // Flag - if a constant this mask is related to should be pruned
+    // by value. Only 1D constants could be pruned by value and
+    // number of mask dimensions should be equal to number of elements
+    // in the constant. Each value of the constant at index i
+    // decreasing by number of elements in i'th mask dimension.
+    // The constant is typically interpetated as a shape
+    // of some operation.
     bool m_adjust_value{false};
 
     // Masks dependent on this mask vs methods, specifying how

--- a/src/common/offline_transformations/include/mask_attribute.hpp
+++ b/src/common/offline_transformations/include/mask_attribute.hpp
@@ -207,12 +207,12 @@ public:
 
 private:
     bool m_is_shape_like{false};
-    // Flag - if a constant this mask is related to should be pruned
-    // by value. Only 1D constants could be pruned by value and
-    // number of mask dimensions should be equal to number of elements
-    // in the constant. Each value of the constant at index i
-    // decreasing by number of elements in i'th mask dimension.
-    // The constant is typically interpetated as a shape
+    // Flag is true if this mask should be interpretated in special way:
+    // Each value of the constant at index i decreasing by a number
+    // of elements in i'th mask dimension during weights shrinking pass.
+    // Only a 1D constants could be pruned in this way and
+    // the number of mask dimensions should be equal to the number of elements
+    // in the constant. The constant is typically interpetated as a shape
     // of some operation.
     bool m_adjust_value{false};
 

--- a/src/common/offline_transformations/src/pruning/shrink_weights.cpp
+++ b/src/common/offline_transformations/src/pruning/shrink_weights.cpp
@@ -21,7 +21,7 @@ bool ngraph::pass::ShrinkWeights::run_on_model(const std::shared_ptr<ngraph::Fun
     for (const auto & node : f->get_ordered_ops()) {
         // calculate shape for every node in graph as the input shape may change
         // during Constant shrinking
-        node->validate_and_infer_types();
+        node->revalidate_and_infer_types();
 
         // TODO: constant can be shared across functions so we need to avoid consumers from other function
         auto const_node = std::dynamic_pointer_cast<opset6::Constant>(node);

--- a/src/tests/functional/inference_engine/transformations/offline_transformations/pruning_test.cpp
+++ b/src/tests/functional/inference_engine/transformations/offline_transformations/pruning_test.cpp
@@ -19,7 +19,6 @@
 #include <inference_engine.hpp>
 #include <openvino/util/env_util.hpp>
 
-
 #include "common_test_utils/ngraph_test_utils.hpp"
 
 #define VISUALIZE_TESTS_TREE false
@@ -60,6 +59,9 @@ TEST(TransformationTests, PruneIRTest) {
     InferenceEngine::Core core;
 
     const std::string input_model = ov::util::getenv_string("PRUNING_TARGET_IR_PATH");
+    if (input_model == "")
+        return;
+
     auto function = core.ReadNetwork(input_model).getFunction();
 
     pass::Manager m;
@@ -633,7 +635,16 @@ TEST_F(TransformationTestsF, PropagateMasksQuantizedGroupConvolution) {
         auto mul_const = create_constant_with_zeros(Shape{4, 1, 1, 1}, {{}, {}, {}, {}});
         auto mul = std::make_shared<opset5::Multiply>(sub, mul_const);
 
-        auto reshape = std::make_shared<opset5::Reshape>(mul, opset5::Constant::create(element::i64, Shape{5}, {4, 1, 1, 3, 3}), false);
+
+        auto reshape_const = opset5::Constant::create(element::i64, Shape{5}, {8, 1, 1, 3, 3});
+
+        const auto axis = opset6::Constant::create(ov::element::i8, {}, {0});
+        auto dims_to_keep_vec = std::vector<size_t>{2, 3, 4};
+        const auto dims_to_keep = opset6::Constant::create(reshape_const->get_element_type(), {dims_to_keep_vec.size()}, dims_to_keep_vec);
+        const auto reshape_gather = std::make_shared<opset6::Gather>(reshape_const, dims_to_keep, axis);
+        const auto reshape_concat = std::make_shared<opset6::Concat>(
+            NodeVector{opset6::Constant::create(reshape_const->get_element_type(), {2}, {-1, 1}), reshape_gather}, 0);
+        auto reshape = std::make_shared<opset5::Reshape>(mul, reshape_concat, false);
 
         auto conv_group = std::make_shared<opset5::GroupConvolution>(conv1, reshape, Strides(2, 1),
                                                            CoordinateDiff(2, 0), CoordinateDiff(2, 0), Strides(2, 1));
@@ -648,6 +659,144 @@ TEST_F(TransformationTestsF, PropagateMasksQuantizedGroupConvolution) {
     }
     if (VISUALIZE_TESTS_TREE)
         ngraph::pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PropagateMasksQuantizedGroupConvolution.svg").run_on_function(function);
+    {
+        pass::Manager m;
+        m.register_pass<pass::InitMasks>();
+        m.register_pass<pass::PropagateMasks>();
+        m.run_passes(function);
+    }
+
+    compare_masks(*getMask(weights1.get_node_shared_ptr()->output(0)), Mask({{0, 1, 2, 3}, {}, {}, {}}));
+    compare_masks(*getMask(conv1->output(0)),  Mask({{}, {0 , 1, 2, 3}, {}, {}}));
+
+    compare_masks(*getMask(weights_group->output(0)), Mask({{0, 1, 2, 3}, {}, {}, {}}));
+    compare_masks(*getMask(sub->output(0)), Mask({{0, 1, 2, 3}, {}, {}, {}}));
+    compare_masks(*getMask(sub_const.get_node_shared_ptr()->output(0)), Mask({{0, 1, 2, 3}, {}, {}, {}}));
+    compare_masks(*getMask(mul->output(0)), Mask({{0, 1, 2, 3}, {}, {}, {}}));
+    compare_masks(*getMask(mul_const.get_node_shared_ptr()->output(0)), Mask({{0, 1, 2, 3}, {}, {}, {}}));
+
+    compare_masks(*getMask(reshape->output(0)), Mask({{0, 1, 2, 3}, {}, {}, {}, {}}));
+
+    compare_masks(*getMask(conv_group->output(0)),  Mask({{}, {0, 1, 2, 3}, {}, {}}));
+
+    compare_masks(*getMask(conv2->output(0)),  Mask({{}, {}, {}, {}}));
+
+    compare_masks(*getMask(weights_2->output(0)),  Mask({{}, {0, 1, 2, 3}, {}, {}}));
+    {
+        pass::Manager m;
+        m.register_pass<pass::ShrinkWeights>();
+        m.run_passes(function);
+    }
+    disable_rt_info_check();
+    enable_accuracy_check();
+}
+
+
+TEST_F(TransformationTestsF, PropagateMasksQuantizedGroupConvolutionWithShapeOf) {
+    Shape input_shape{1, 3, 64, 64};
+    Shape weights_shape{8, 3, 3, 3};
+    Shape weights_group_shape{8, 1, 3, 3};
+    Shape weight_shape2{3, 8, 3, 3};
+    auto input = std::make_shared<opset5::Parameter>(element::f32, input_shape);
+    input->set_friendly_name("input");
+
+    auto weights1 = create_constant_with_zeros(weights_shape, {{0, 1, 2, 3}, {}, {}, {}});
+    auto conv1 = std::make_shared<opset5::Convolution>(input, weights1, Strides(2, 1),
+                                                      CoordinateDiff(2, 0), CoordinateDiff(2, 0), Strides(2, 1));
+    auto weights_group = opset5::Constant::create(element::i8, weights_group_shape, {0});
+    weights_group->set_friendly_name("weights_group");
+
+    auto convert = std::make_shared<opset5::Convert>(weights_group, element::f32);
+    convert->set_friendly_name("convert");
+
+    auto sub_const = create_constant_with_zeros(Shape{8, 1, 1, 1}, {{0, 1, 2, 3}, {}, {}, {}});
+
+    auto sub = std::make_shared<opset5::Subtract>(convert, sub_const);
+    sub->set_friendly_name("sub");
+
+    auto mul_const = create_constant_with_zeros(Shape{8, 1, 1, 1}, {{0, 1, 2, 3, 4}, {}, {}, {}});
+    auto mul = std::make_shared<opset5::Multiply>(sub, mul_const);
+    mul->set_friendly_name("mul");
+
+    auto shape_of = std::make_shared<opset6::ShapeOf>(mul);
+    auto axis = opset6::Constant::create(ov::element::i8, {}, {0});
+    auto split_lenghts = opset6::Constant::create(ov::element::i8, {2}, {1, -1});
+    auto variadic_split = std::make_shared<opset6::VariadicSplit>(shape_of, axis, split_lenghts);
+    auto div_const = opset6::Constant::create(ov::element::i64, {1}, {8});
+    auto div = std::make_shared<opset6::Divide>(variadic_split->output(0), div_const);
+    auto reshape_concat = std::make_shared<opset6::Concat>(
+        OutputVector{opset6::Constant::create(shape_of->get_element_type(), {1}, {8})->output(0),
+                  div->output(0), variadic_split->output(1)}, 0);
+
+    auto reshape = std::make_shared<opset5::Reshape>(mul, reshape_concat, false);
+
+    auto conv_group = std::make_shared<opset5::GroupConvolution>(conv1, reshape, Strides(2, 1),
+                                                       CoordinateDiff(2, 0), CoordinateDiff(2, 0), Strides(2, 1));
+
+    auto add_const = create_constant_with_zeros(Shape{1, 8, 1, 1}, {{}, {0, 1, 2, 3, 4}, {}, {}});;
+    auto add = std::make_shared<opset5::Add>(conv_group, add_const);
+    add->set_friendly_name("add");
+
+    auto weights_2 = opset5::Constant::create(element::f32, weight_shape2, {0});
+    auto conv2 = std::make_shared<opset5::Convolution>(add, weights_2, Strides(2, 1),
+                                                       CoordinateDiff(2, 0), CoordinateDiff(2, 0), Strides(2, 1));
+    function = std::make_shared<Function>(NodeVector{conv2}, ParameterVector{input});
+    {
+        auto input = std::make_shared<opset5::Parameter>(element::f32, input_shape);
+
+        auto weights1 = create_constant_with_zeros({weights_shape[0] - 4, weights_shape[1], weights_shape[2], weights_shape[3]}, {{}, {}, {}, {}});
+        auto conv1 = std::make_shared<opset5::Convolution>(input, weights1, Strides(2, 1),
+                                                          CoordinateDiff(2, 0), CoordinateDiff(2, 0), Strides(2, 1));
+        auto weights_group = opset5::Constant::create(element::i8,
+                                                      {
+                                                          weights_group_shape[0] - 4,
+                                                          weights_group_shape[1],
+                                                          weights_group_shape[2],
+                                                          weights_group_shape[3]
+                                                      }, {0});
+
+        auto convert = std::make_shared<opset5::Convert>(weights_group, element::f32);
+
+        auto sub_const = create_constant_with_zeros(Shape{4, 1, 1, 1}, {{}, {}, {}, {}});
+
+        auto sub = std::make_shared<opset5::Subtract>(convert, sub_const);
+
+        auto mul_const = create_constant_with_zeros(Shape{4, 1, 1, 1}, {{}, {}, {}, {}});
+        auto mul = std::make_shared<opset5::Multiply>(sub, mul_const);
+
+
+        auto shape_of = std::make_shared<opset6::ShapeOf>(mul);
+        auto axis = opset6::Constant::create(ov::element::i8, {}, {0});
+        auto split_lenghts = opset6::Constant::create(ov::element::i8, {2}, {1, -1});
+        auto variadic_split = std::make_shared<opset6::VariadicSplit>(shape_of, axis, split_lenghts);
+        auto div_const = opset6::Constant::create(ov::element::i64, {1}, {8});
+        auto div = std::make_shared<opset6::Divide>(variadic_split->output(0), div_const);
+
+        auto reshape_concat = std::make_shared<opset6::Concat>(
+            OutputVector{opset6::Constant::create(shape_of->get_element_type(), {1}, {1})->output(0),
+                         div->output(0), variadic_split->output(1)}, 0);
+
+        const auto axis_1 = opset6::Constant::create(ov::element::i8, {}, {0});
+        auto dims_to_keep_vec = std::vector<size_t>{2, 3, 4};
+        const auto dims_to_keep = opset6::Constant::create(reshape_concat->get_element_type(), {dims_to_keep_vec.size()}, dims_to_keep_vec);
+        const auto new_reshape_gather = std::make_shared<opset6::Gather>(reshape_concat, dims_to_keep, axis_1);
+        const auto new_reshape_concat = std::make_shared<opset6::Concat>(
+            NodeVector{opset6::Constant::create(reshape_concat->get_element_type(), {2}, {-1, 1}), new_reshape_gather}, 0);
+        auto reshape = std::make_shared<opset5::Reshape>(mul, new_reshape_concat, false);
+
+        auto conv_group = std::make_shared<opset5::GroupConvolution>(conv1, reshape, Strides(2, 1),
+                                                           CoordinateDiff(2, 0), CoordinateDiff(2, 0), Strides(2, 1));
+
+        auto add_const = create_constant_with_zeros(Shape{1, 4, 1, 1}, {{}, {}, {}, {}});;
+        auto add = std::make_shared<opset5::Add>(conv_group, add_const);
+
+        auto weights_2 = opset5::Constant::create(element::f32, {weight_shape2[0], weight_shape2[1] - 4, weight_shape2[2], weight_shape2[3]}, {0});
+        auto conv2 = std::make_shared<opset5::Convolution>(add, weights_2, Strides(2, 1),
+                                                           CoordinateDiff(2, 0), CoordinateDiff(2, 0), Strides(2, 1));
+        function_ref = std::make_shared<Function>(NodeVector{conv2}, ParameterVector{input});
+    }
+    if (VISUALIZE_TESTS_TREE)
+        ngraph::pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PropagateMasksQuantizedGroupConvolutionWithShapeOf.svg").run_on_function(function);
     {
         pass::Manager m;
         m.register_pass<pass::InitMasks>();
@@ -1206,7 +1355,7 @@ TEST_F(TransformationTestsF, PruneConvIsClosingAndInGroup) {
                                                                                  CoordinateDiff(2, 0),
                                                                                  Strides(2, 1));
 
-    function = std::make_shared<ngraph::Function>(OutputVector{end_conv}, ParameterVector{input}, "ReshapeMulBranching");
+    function = std::make_shared<ngraph::Function>(OutputVector{end_conv}, ParameterVector{input});
 
     if (VISUALIZE_TESTS_TREE)
         ngraph::pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PruneConvIsClosingAndInGroup.svg").run_on_function(function);
@@ -1242,7 +1391,7 @@ TEST_F(TransformationTestsF, PruneConvIsClosingAndInGroup) {
                                                                                      CoordinateDiff(2, 0),
                                                                                      CoordinateDiff(2, 0),
                                                                                      Strides(2, 1));
-        function_ref = std::make_shared<ngraph::Function>(OutputVector{end_conv}, ParameterVector{input}, "ReshapeMulBranching");
+        function_ref = std::make_shared<ngraph::Function>(OutputVector{end_conv}, ParameterVector{input});
     }
     {
         pass::Manager m;
@@ -1393,7 +1542,7 @@ TEST_F(TransformationTestsF, PruneReducelayerUp) {
                                                                                  CoordinateDiff(2, 0),
                                                                                  Strides(2, 1));
 
-    function = std::make_shared<ngraph::Function>(OutputVector{conv_1}, ParameterVector{input}, "GoodReshapeModel");
+    function = std::make_shared<ngraph::Function>(OutputVector{conv_1}, ParameterVector{input});
     {
         auto input = std::make_shared<opset5::Parameter>(element::f32, inputShapes);
         auto weights = create_constant_with_zeros({
@@ -1421,7 +1570,7 @@ TEST_F(TransformationTestsF, PruneReducelayerUp) {
                                                            CoordinateDiff(2, 0),
                                                            CoordinateDiff(2, 0),
                                                            Strides(2, 1));
-        function_ref = std::make_shared<ngraph::Function>(OutputVector{conv_1}, ParameterVector{input}, "GoodReshapeModel");
+        function_ref = std::make_shared<ngraph::Function>(OutputVector{conv_1}, ParameterVector{input});
     }
     if (VISUALIZE_TESTS_TREE)
         ngraph::pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PruneReducelayerUp.svg").run_on_function(function);
@@ -1468,7 +1617,7 @@ TEST_F(TransformationTestsF, PruneReduceLayerDown) {
                                                                                  CoordinateDiff(2, 0),
                                                                                  Strides(2, 1));
 
-    function = std::make_shared<ngraph::Function>(OutputVector{end_conv}, ParameterVector{input}, "GoodReshapeDonw");
+    function = std::make_shared<ngraph::Function>(OutputVector{end_conv}, ParameterVector{input});
     {
         auto input = std::make_shared<opset5::Parameter>(element::f32, inputShapes);
         auto weights = create_constant_with_zeros({
@@ -1501,7 +1650,7 @@ TEST_F(TransformationTestsF, PruneReduceLayerDown) {
                                                                                      CoordinateDiff(2, 0),
                                                                                      CoordinateDiff(2, 0),
                                                                                      Strides(2, 1));
-        function_ref = std::make_shared<ngraph::Function>(OutputVector{end_conv}, ParameterVector{input}, "GoodReshapeDown");
+        function_ref = std::make_shared<ngraph::Function>(OutputVector{end_conv}, ParameterVector{input});
     }
     if (VISUALIZE_TESTS_TREE)
         ngraph::pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PruneReduceLayerDown.svg").run_on_function(function);
@@ -1553,7 +1702,7 @@ TEST(TransformationTests, PruneStopReducelayerUp) {
                                                         CoordinateDiff(2, 0),
                                                         Strides(2, 1));
 
-    auto function = std::make_shared<ngraph::Function>(OutputVector{conv_1}, ParameterVector{input}, "BadReshapeModel");
+    auto function = std::make_shared<ngraph::Function>(OutputVector{conv_1}, ParameterVector{input});
 
     if (VISUALIZE_TESTS_TREE)
         ngraph::pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PruneStopReducelayerUp.svg").run_on_function(function);
@@ -1644,7 +1793,7 @@ TEST_F(TransformationTestsF, MaskPropagationReshapeUp) {
                                                         CoordinateDiff(2, 0),
                                                         Strides(2, 1));
 
-    function = std::make_shared<ngraph::Function>(OutputVector{conv_1}, ParameterVector{input}, "GoodReshapeUp");
+    function = std::make_shared<ngraph::Function>(OutputVector{conv_1}, ParameterVector{input});
     {
         auto input = std::make_shared<opset5::Parameter>(element::f32, inputShapes);
         auto weights = create_constant_with_zeros({
@@ -1668,10 +1817,80 @@ TEST_F(TransformationTestsF, MaskPropagationReshapeUp) {
                                                             CoordinateDiff(2, 0),
                                                             Strides(2, 1));
 
-        function_ref = std::make_shared<ngraph::Function>(OutputVector{conv_1}, ParameterVector{input}, "GoodReshapeUp");
+        function_ref = std::make_shared<ngraph::Function>(OutputVector{conv_1}, ParameterVector{input});
     }
     if (VISUALIZE_TESTS_TREE)
         ngraph::pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "MaskPropagationReshapeUp.svg").run_on_function(function);
+    {
+        pass::Manager m;
+        m.register_pass<pass::InitMasks>();
+        m.register_pass<pass::PropagateMasks>();
+        m.run_passes(function);
+    }
+    compare_masks(*getMask(weights.get_node_shared_ptr()->output(0)),  Mask({{1, 2, 3}, {}, {}, {}}));
+    compare_masks(*getMask(conv->output(0)),  Mask({{}, {1, 2, 3}, {}, {}}));
+
+    compare_masks(*getMask(conv_1_weights.get_node_shared_ptr()->output(0)),  Mask({{}, {1, 2, 3}, {}, {}}));
+    compare_masks(*getMask(conv_1->output(0)),  Mask({{}, {}, {}, {}}));
+    {
+        pass::Manager m;
+        m.register_pass<pass::ShrinkWeights>();
+        m.run_passes(function);
+    }
+    disable_rt_info_check();
+    enable_accuracy_check();
+}
+
+
+TEST_F(TransformationTestsF, MaskPropagationReshapeUpWithShapeOf) {
+    auto inputShapes = PartialShape{1, 6, 8, 8};
+    auto weightsShape = Shape{6, 6, 1, 1};
+
+    auto input = std::make_shared<opset5::Parameter>(element::f32, inputShapes);
+    auto weights = create_constant_with_zeros(weightsShape, {{1, 2, 3}, {}, {}, {}});
+    auto conv = std::make_shared<opset5::Convolution>(input, weights, Strides(2, 1),
+                                                      CoordinateDiff(2, 0),
+                                                      CoordinateDiff(2, 0),
+                                                      Strides(2, 1));
+
+    auto shape_of_conv = std::make_shared<opset5::ShapeOf>(conv);
+    auto reshape = std::make_shared<opset5::Reshape>(conv, shape_of_conv, true);
+
+    auto conv_1_shape = Shape{6, 6, 1, 1};
+    auto conv_1_weights = create_constant_with_zeros(conv_1_shape, {{1, 2, 3}, {}, {}, {}});
+    auto conv_1 = std::make_shared<opset5::Convolution>(reshape, conv_1_weights, Strides(2, 1),
+                                                        CoordinateDiff(2, 0),
+                                                        CoordinateDiff(2, 0),
+                                                        Strides(2, 1));
+
+    function = std::make_shared<ngraph::Function>(OutputVector{conv_1}, ParameterVector{input});
+    {
+        auto input = std::make_shared<opset5::Parameter>(element::f32, inputShapes);
+        auto weights = create_constant_with_zeros({
+                                                   weightsShape[0] - 3,
+                                                   weightsShape[1],
+                                                   weightsShape[2],
+                                                   weightsShape[3],
+                                                  }, {{}, {}, {}, {}});
+        auto conv = std::make_shared<opset5::Convolution>(input, weights, Strides(2, 1),
+                                                          CoordinateDiff(2, 0),
+                                                          CoordinateDiff(2, 0),
+                                                          Strides(2, 1));
+
+        auto shape_of_conv = std::make_shared<opset5::ShapeOf>(conv);
+        auto reshape = std::make_shared<opset5::Reshape>(conv, shape_of_conv, true);
+
+        auto conv_1_shape = Shape{6, 3, 1, 1};
+        auto conv_1_weights = create_constant_with_zeros(conv_1_shape, {{1, 2, 3}, {}, {}, {}});
+        auto conv_1 = std::make_shared<opset5::Convolution>(reshape, conv_1_weights, Strides(2, 1),
+                                                            CoordinateDiff(2, 0),
+                                                            CoordinateDiff(2, 0),
+                                                            Strides(2, 1));
+
+        function_ref = std::make_shared<ngraph::Function>(OutputVector{conv_1}, ParameterVector{input});
+    }
+    if (VISUALIZE_TESTS_TREE)
+        ngraph::pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "MaskPropagationReshapeUpWithShapeOf.svg").run_on_function(function);
     {
         pass::Manager m;
         m.register_pass<pass::InitMasks>();
@@ -1728,7 +1947,7 @@ TEST_F(TransformationTestsF, MaskPropagationReshapeDown) {
                                                            CoordinateDiff(2, 0),
                                                            Strides(2, 1));
 
-    function = std::make_shared<ngraph::Function>(OutputVector{last_conv}, ParameterVector{input}, "GoodReshapeDown");
+    function = std::make_shared<ngraph::Function>(OutputVector{last_conv}, ParameterVector{input});
     {
         auto input = std::make_shared<opset5::Parameter>(element::f32, inputShapes);
         auto weights = create_constant_with_zeros({
@@ -1764,7 +1983,7 @@ TEST_F(TransformationTestsF, MaskPropagationReshapeDown) {
                                                                CoordinateDiff(2, 0),
                                                                Strides(2, 1));
 
-        function_ref = std::make_shared<ngraph::Function>(OutputVector{last_conv}, ParameterVector{input}, "GoodReshapeDown");
+        function_ref = std::make_shared<ngraph::Function>(OutputVector{last_conv}, ParameterVector{input});
     }
     if (VISUALIZE_TESTS_TREE)
         ngraph::pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "MaskPropagationReshapeDown.svg").run_on_function(function);

--- a/src/tests/functional/inference_engine/transformations/offline_transformations/pruning_test.cpp
+++ b/src/tests/functional/inference_engine/transformations/offline_transformations/pruning_test.cpp
@@ -17,7 +17,6 @@
 #include <ngraph/coordinate_transform.hpp>
 #include <ngraph/pass/manager.hpp>
 #include <inference_engine.hpp>
-#include <openvino/util/env_util.hpp>
 
 #include "common_test_utils/ngraph_test_utils.hpp"
 
@@ -55,52 +54,52 @@ Output<Node> create_constant_with_zeros(const Shape & shape, const Mask & mask) 
 
 // Uncomment, specify PRUNING_TARGET_IR_PATH var and
 // include <openvino/util/env_util.hpp> to check pruning on given IR
-TEST(TransformationTests, PruneIRTest) {
-    InferenceEngine::Core core;
-
-    const std::string input_model = ov::util::getenv_string("PRUNING_TARGET_IR_PATH");
-    if (input_model == "")
-        return;
-
-    auto function = core.ReadNetwork(input_model).getFunction();
-
-    pass::Manager m;
-    m.register_pass<pass::InitMasks>();
-    m.register_pass<pass::PropagateMasks>();
-
-    // VisualizeTree modifier helps to print Masks and mark nodes with masks
-    auto modifier = [](const Node& node, std::vector<std::string>& attributes) {
-        std::stringstream ss;
-        size_t index{0};
-        for (const auto & output : node.outputs()) {
-            if (const auto & mask = getMask(output)) {
-                if (!mask->all_dims_are_empty()) {
-                    attributes.emplace_back("color=green");
-                    attributes.emplace_back("penwidth=2");
-                }
-                ss << "Mask(" << index << ") : " << *mask << "\\n";
-            }
-            index++;
-        }
-        if (!ss.str().empty()) {
-            auto label = std::find_if(attributes.begin(), attributes.end(),
-                                   [](const std::string & value) { return value.find("label=") != std::string::npos; });
-            if (label != attributes.end()) {
-                label->pop_back();
-                *label += "\n" + ss.str() + "\"";
-            } else {
-                attributes.push_back("label=\"" + ss.str() + "\"");
-            }
-        }
-    };
-
-    m.register_pass<ngraph::pass::VisualizeTree>(std::string(VISUALIZE_TREE_ROOT) + "PruneIRTest_with_masks.svg", modifier);
-    m.register_pass<pass::ShrinkWeights>();
-
-    if (VISUALIZE_TESTS_TREE)
-        ngraph::pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PruneIRTest.svg").run_on_function(function);
-    m.run_passes(function);
-}
+//TEST(TransformationTests, PruneIRTest) {
+//    InferenceEngine::Core core;
+//
+//    const std::string input_model = ov::util::getenv_string("PRUNING_TARGET_IR_PATH");
+//    if (input_model == "")
+//        return;
+//
+//    auto function = core.ReadNetwork(input_model).getFunction();
+//
+//    pass::Manager m;
+//    m.register_pass<pass::InitMasks>();
+//    m.register_pass<pass::PropagateMasks>();
+//
+//    // VisualizeTree modifier helps to print Masks and mark nodes with masks
+//    auto modifier = [](const Node& node, std::vector<std::string>& attributes) {
+//        std::stringstream ss;
+//        size_t index{0};
+//        for (const auto & output : node.outputs()) {
+//            if (const auto & mask = getMask(output)) {
+//                if (!mask->all_dims_are_empty()) {
+//                    attributes.emplace_back("color=green");
+//                    attributes.emplace_back("penwidth=2");
+//                }
+//                ss << "Mask(" << index << ") : " << *mask << "\\n";
+//            }
+//            index++;
+//        }
+//        if (!ss.str().empty()) {
+//            auto label = std::find_if(attributes.begin(), attributes.end(),
+//                                   [](const std::string & value) { return value.find("label=") != std::string::npos; });
+//            if (label != attributes.end()) {
+//                label->pop_back();
+//                *label += "\n" + ss.str() + "\"";
+//            } else {
+//                attributes.push_back("label=\"" + ss.str() + "\"");
+//            }
+//        }
+//    };
+//
+//    m.register_pass<ngraph::pass::VisualizeTree>(std::string(VISUALIZE_TREE_ROOT) + "PruneIRTest_with_masks.svg", modifier);
+//    m.register_pass<pass::ShrinkWeights>();
+//
+//    if (VISUALIZE_TESTS_TREE)
+//        ngraph::pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PruneIRTest.svg").run_on_function(function);
+//    m.run_passes(function);
+//}
 
 
 TEST(TransformationTests, InitMasksOI) {

--- a/src/tests/functional/inference_engine/transformations/offline_transformations/pruning_test.cpp
+++ b/src/tests/functional/inference_engine/transformations/offline_transformations/pruning_test.cpp
@@ -17,6 +17,7 @@
 #include <ngraph/coordinate_transform.hpp>
 #include <ngraph/pass/manager.hpp>
 #include <inference_engine.hpp>
+#include <openvino/util/env_util.hpp>
 
 
 #include "common_test_utils/ngraph_test_utils.hpp"
@@ -51,6 +52,52 @@ Output<Node> create_constant_with_zeros(const Shape & shape, const Mask & mask) 
         }
     }
     return std::make_shared<opset5::Constant>(element::f32, shape, values);
+}
+
+// Uncomment, specify PRUNING_TARGET_IR_PATH var and
+// include <openvino/util/env_util.hpp> to check pruning on given IR
+TEST(TransformationTests, PruneIRTest) {
+    InferenceEngine::Core core;
+
+    const std::string input_model = ov::util::getenv_string("PRUNING_TARGET_IR_PATH");
+    auto function = core.ReadNetwork(input_model).getFunction();
+
+    pass::Manager m;
+    m.register_pass<pass::InitMasks>();
+    m.register_pass<pass::PropagateMasks>();
+
+    // VisualizeTree modifier helps to print Masks and mark nodes with masks
+    auto modifier = [](const Node& node, std::vector<std::string>& attributes) {
+        std::stringstream ss;
+        size_t index{0};
+        for (const auto & output : node.outputs()) {
+            if (const auto & mask = getMask(output)) {
+                if (!mask->all_dims_are_empty()) {
+                    attributes.emplace_back("color=green");
+                    attributes.emplace_back("penwidth=2");
+                }
+                ss << "Mask(" << index << ") : " << *mask << "\\n";
+            }
+            index++;
+        }
+        if (!ss.str().empty()) {
+            auto label = std::find_if(attributes.begin(), attributes.end(),
+                                   [](const std::string & value) { return value.find("label=") != std::string::npos; });
+            if (label != attributes.end()) {
+                label->pop_back();
+                *label += "\n" + ss.str() + "\"";
+            } else {
+                attributes.push_back("label=\"" + ss.str() + "\"");
+            }
+        }
+    };
+
+    m.register_pass<ngraph::pass::VisualizeTree>(std::string(VISUALIZE_TREE_ROOT) + "PruneIRTest_with_masks.svg", modifier);
+    m.register_pass<pass::ShrinkWeights>();
+
+    if (VISUALIZE_TESTS_TREE)
+        ngraph::pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PruneIRTest.svg").run_on_function(function);
+    m.run_passes(function);
 }
 
 
@@ -264,6 +311,39 @@ TEST_F(TransformationTestsF, PropagateMasksDynamicConvolution) {
     }
     disable_rt_info_check();
     enable_accuracy_check();
+}
+
+
+TEST(TransformationTests, PropagateMasksDynamicReshape) {
+    PartialShape input_shape{Dimension::dynamic(), 3, 64, 64};
+    Shape weights_shape{6, 3, 3, 3};
+    Shape weights_shape2{6, 6, 3, 3};
+    auto input = std::make_shared<opset5::Parameter>(element::f32, input_shape);
+    auto weights = opset5::Constant::create(element::f32, weights_shape, {0});
+    auto conv = std::make_shared<opset5::Convolution>(input, weights, Strides(2, 1),
+                                                      CoordinateDiff(2, 0), CoordinateDiff(2, 0), Strides(2, 1));
+    auto relu = std::make_shared<opset5::Relu>(conv);
+
+    auto reshape = std::make_shared<opset5::Reshape>(relu, opset5::Constant::create(element::i64, Shape{4}, {-1, 6, 64, 64}), true);
+
+    auto weights2 = opset5::Constant::create(element::f32, weights_shape2, {0});
+    auto conv2 = std::make_shared<opset5::Convolution>(reshape, weights2, Strides(2, 1),
+                                                       CoordinateDiff(2, 0), CoordinateDiff(2, 0), Strides(2, 1));
+
+    auto function = std::make_shared<Function>(NodeVector{conv2}, ParameterVector{input});
+    if (VISUALIZE_TESTS_TREE)
+        ngraph::pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PropagateMasksDynamicReshape.svg").run_on_function(function);
+
+    pass::Manager m;
+    m.register_pass<pass::Pruning>();
+    m.run_passes(function);
+
+    compare_masks(*getMask(weights->output(0)),  Mask({{}, {}, {}, {}}));
+    compare_masks(*getMask(conv->output(0)),     Mask({{}, {}, {}, {}}));
+    compare_masks(*getMask(relu->output(0)),     Mask({{}, {}, {}, {}}));
+    compare_masks(*getMask(reshape), Mask({{}, {}, {}, {}}));
+    compare_masks(*getMask(weights2->output(0)),  Mask({{}, {}, {}, {}}));
+    compare_masks(*getMask(conv2->output(0)),     Mask({{}, {}, {}, {}}));
 }
 
 
@@ -1247,6 +1327,51 @@ TEST(TransformationTests, PruneBranchingStopOp) {
 }
 
 
+TEST(TransformationTests, PruneStopOpUp) {
+    // Checks case of branching with stop op
+    auto inputShapes = PartialShape{1, 6, 16, 16};
+    auto weightsShape = Shape{6, 6, 1, 1};
+
+    auto input = std::make_shared<opset5::Parameter>(element::f32, inputShapes);
+    auto weights = create_constant_with_zeros(weightsShape, {{1, 2, 3}, {}, {}, {}});
+    auto conv = std::make_shared<opset5::Convolution>(input, weights, Strides(2, 1),
+                                                      CoordinateDiff(2, 0),
+                                                      CoordinateDiff(2, 0),
+                                                      Strides(2, 1));
+    // Branching stop op
+    Shape group_conv_weights_shape{3, 2, 2, 1, 1};
+    auto group_conv_weights = opset5::Constant::create(element::f32, group_conv_weights_shape, {0});
+    auto group_conv = std::make_shared<opset5::GroupConvolution>(conv, group_conv_weights, Strides(2, 1),
+                                                           CoordinateDiff(2, 0), CoordinateDiff(2, 0), Strides(2, 1));
+
+    auto conv_1_shape = Shape{weightsShape[0], 6, 1, 1};
+
+    auto mul_const = create_constant_with_zeros(Shape{1, 6, 16, 16}, {{}, {1, 2, 3}, {}, {}});
+    auto mul = std::make_shared<opset5::Multiply>(group_conv, mul_const);
+
+    auto end_conv_shape = Shape{weightsShape[1], weightsShape[0], 1, 1};
+    auto weights_end_conv = create_constant_with_zeros(end_conv_shape, {{1, 2, 3}, {}, {}, {}});
+    auto end_conv = std::make_shared<opset5::Convolution>(mul, weights_end_conv, Strides(2, 1),
+                                                          CoordinateDiff(2, 0),
+                                                          CoordinateDiff(2, 0),
+                                                          Strides(2, 1));
+    auto function = std::make_shared<ngraph::Function>(OutputVector{end_conv}, ParameterVector{input}, "StopOpUp");
+
+    if (VISUALIZE_TESTS_TREE)
+        ngraph::pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PruneStopOpUp.svg").run_on_function(function);
+
+    pass::Manager m;
+    m.register_pass<pass::Pruning>();
+    m.run_passes(function);
+
+    compare_masks(*getMask(weights.get_node_shared_ptr()->output(0)),  Mask({{}, {}, {}, {}}));
+    compare_masks(*getMask(conv->output(0)),  Mask({{}, {}, {}, {}}));
+
+    compare_masks(*getMask(weights_end_conv.get_node_shared_ptr()->output(0)),  Mask({{}, {}, {}, {}}));
+    compare_masks(*getMask(end_conv->output(0)),  Mask({{}, {}, {}, {}}));
+}
+
+
 TEST_F(TransformationTestsF, PruneReducelayerUp) {
     auto inputShapes = PartialShape{1, 6, 16, 16};
     auto weightsShape = Shape{6, 6, 1, 1};
@@ -1495,4 +1620,427 @@ TEST(TransformationTests, PruneStopReduceLayerDown) {
 
     compare_masks(*getMask(weights_end_conv.get_node_shared_ptr()->output(0)),  Mask({{}, {}, {}, {}}));
     compare_masks(*getMask(end_conv->output(0)),  Mask({{}, {}, {}, {}}));
+}
+
+
+TEST_F(TransformationTestsF, MaskPropagationReshapeUp) {
+    auto inputShapes = PartialShape{1, 6, 8, 8};
+    auto weightsShape = Shape{6, 6, 1, 1};
+
+    auto input = std::make_shared<opset5::Parameter>(element::f32, inputShapes);
+    auto weights = create_constant_with_zeros(weightsShape, {{1, 2, 3}, {}, {}, {}});
+    auto conv = std::make_shared<opset5::Convolution>(input, weights, Strides(2, 1),
+                                                      CoordinateDiff(2, 0),
+                                                      CoordinateDiff(2, 0),
+                                                      Strides(2, 1));
+
+    auto reshape_const = opset5::Constant::create(element::i64, Shape{4}, {1, 6, 64, 1});
+    auto reshape = std::make_shared<opset5::Reshape>(conv, reshape_const, true);
+
+    auto conv_1_shape = Shape{6, 6, 1, 1};
+    auto conv_1_weights = create_constant_with_zeros(conv_1_shape, {{1, 2, 3}, {}, {}, {}});
+    auto conv_1 = std::make_shared<opset5::Convolution>(reshape, conv_1_weights, Strides(2, 1),
+                                                        CoordinateDiff(2, 0),
+                                                        CoordinateDiff(2, 0),
+                                                        Strides(2, 1));
+
+    function = std::make_shared<ngraph::Function>(OutputVector{conv_1}, ParameterVector{input}, "GoodReshapeUp");
+    {
+        auto input = std::make_shared<opset5::Parameter>(element::f32, inputShapes);
+        auto weights = create_constant_with_zeros({
+                                                   weightsShape[0] - 3,
+                                                   weightsShape[1],
+                                                   weightsShape[2],
+                                                   weightsShape[3],
+                                                  }, {{}, {}, {}, {}});
+        auto conv = std::make_shared<opset5::Convolution>(input, weights, Strides(2, 1),
+                                                          CoordinateDiff(2, 0),
+                                                          CoordinateDiff(2, 0),
+                                                          Strides(2, 1));
+
+        auto reshape_const = opset5::Constant::create(element::i64, Shape{4}, {1, 3, 64, 1});
+        auto reshape = std::make_shared<opset5::Reshape>(conv, reshape_const, true);
+
+        auto conv_1_shape = Shape{6, 3, 1, 1};
+        auto conv_1_weights = create_constant_with_zeros(conv_1_shape, {{1, 2, 3}, {}, {}, {}});
+        auto conv_1 = std::make_shared<opset5::Convolution>(reshape, conv_1_weights, Strides(2, 1),
+                                                            CoordinateDiff(2, 0),
+                                                            CoordinateDiff(2, 0),
+                                                            Strides(2, 1));
+
+        function_ref = std::make_shared<ngraph::Function>(OutputVector{conv_1}, ParameterVector{input}, "GoodReshapeUp");
+    }
+    if (VISUALIZE_TESTS_TREE)
+        ngraph::pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "MaskPropagationReshapeUp.svg").run_on_function(function);
+    {
+        pass::Manager m;
+        m.register_pass<pass::InitMasks>();
+        m.register_pass<pass::PropagateMasks>();
+        m.run_passes(function);
+    }
+    compare_masks(*getMask(weights.get_node_shared_ptr()->output(0)),  Mask({{1, 2, 3}, {}, {}, {}}));
+    compare_masks(*getMask(conv->output(0)),  Mask({{}, {1, 2, 3}, {}, {}}));
+
+    compare_masks(*getMask(conv_1_weights.get_node_shared_ptr()->output(0)),  Mask({{}, {1, 2, 3}, {}, {}}));
+    compare_masks(*getMask(conv_1->output(0)),  Mask({{}, {}, {}, {}}));
+    {
+        pass::Manager m;
+        m.register_pass<pass::ShrinkWeights>();
+        m.run_passes(function);
+    }
+    disable_rt_info_check();
+    enable_accuracy_check();
+}
+
+
+TEST_F(TransformationTestsF, MaskPropagationReshapeDown) {
+    auto inputShapes = PartialShape{1, 1, 24, 24};
+    auto weightsShape = Shape{8, 1, 1, 1};
+
+    auto input = std::make_shared<opset5::Parameter>(element::f32, inputShapes);
+    auto weights = create_constant_with_zeros(weightsShape, {{}, {}, {}, {}});
+    auto first_conv = std::make_shared<opset5::Convolution>(input, weights, Strides(2, 1),
+                                                            CoordinateDiff(2, 0),
+                                                            CoordinateDiff(2, 0),
+                                                            Strides(2, 1));
+
+
+
+    auto reshape_const = opset5::Constant::create(element::i64, Shape{4}, {1, 8, 576, 1});
+    auto reshape = std::make_shared<opset5::Reshape>(first_conv, reshape_const, true);
+
+    auto reshape_conv_weights = create_constant_with_zeros({8, 8, 1, 1}, {{1, 2, 3}, {}, {}, {}});
+    auto reshape_conv = std::make_shared<opset5::Convolution>(reshape, reshape_conv_weights,
+                                                             Strides(2, 1),
+                                                             CoordinateDiff(2, 0),
+                                                             CoordinateDiff(2, 0),
+                                                             Strides(2, 1));
+
+    auto reshape_const_1 = opset5::Constant::create(element::i64, Shape{4}, {1, 8, 24, 24});
+    auto reshape_1 = std::make_shared<opset5::Reshape>(reshape_conv, reshape_const_1, true);
+
+    auto mul = std::make_shared<opset5::Multiply>(first_conv, reshape_1);
+
+    auto last_conv_weights = create_constant_with_zeros({8, 8, 8, 8}, {{1, 2, 3}, {}, {}, {}});
+    auto last_conv = std::make_shared<opset5::Convolution>(mul, last_conv_weights,
+                                                           Strides(2, 1),
+                                                           CoordinateDiff(2, 0),
+                                                           CoordinateDiff(2, 0),
+                                                           Strides(2, 1));
+
+    function = std::make_shared<ngraph::Function>(OutputVector{last_conv}, ParameterVector{input}, "GoodReshapeDown");
+    {
+        auto input = std::make_shared<opset5::Parameter>(element::f32, inputShapes);
+        auto weights = create_constant_with_zeros({
+                                                    weightsShape[0] - 3,
+                                                    weightsShape[1],
+                                                    weightsShape[2],
+                                                    weightsShape[3],
+                                                   }, {{}, {}, {}, {}});
+        auto first_conv = std::make_shared<opset5::Convolution>(input, weights, Strides(2, 1),
+                                                                CoordinateDiff(2, 0),
+                                                                CoordinateDiff(2, 0),
+                                                                Strides(2, 1));
+
+        auto reshape_const = opset5::Constant::create(element::i64, Shape{4}, {1, 5, 576, 1});
+        auto reshape = std::make_shared<opset5::Reshape>(first_conv, reshape_const, true);
+
+        auto reshape_conv_weights = create_constant_with_zeros({5, 5, 1, 1}, {{}, {}, {}, {}});
+        auto reshape_conv = std::make_shared<opset5::Convolution>(reshape, reshape_conv_weights,
+                                                                 Strides(2, 1),
+                                                                 CoordinateDiff(2, 0),
+                                                                 CoordinateDiff(2, 0),
+                                                                 Strides(2, 1));
+
+        auto reshape_const_1 = opset5::Constant::create(element::i64, Shape{4}, {1, 5, 24, 24});
+        auto reshape_1 = std::make_shared<opset5::Reshape>(reshape_conv, reshape_const_1, true);
+
+        auto mul = std::make_shared<opset5::Multiply>(first_conv, reshape_1);
+
+        auto last_conv_weights = create_constant_with_zeros({8, 5, 8, 8}, {{1, 2, 3}, {}, {}, {}});
+        auto last_conv = std::make_shared<opset5::Convolution>(mul, last_conv_weights,
+                                                               Strides(2, 1),
+                                                               CoordinateDiff(2, 0),
+                                                               CoordinateDiff(2, 0),
+                                                               Strides(2, 1));
+
+        function_ref = std::make_shared<ngraph::Function>(OutputVector{last_conv}, ParameterVector{input}, "GoodReshapeDown");
+    }
+    if (VISUALIZE_TESTS_TREE)
+        ngraph::pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "MaskPropagationReshapeDown.svg").run_on_function(function);
+    {
+        pass::Manager m;
+        m.register_pass<pass::InitMasks>();
+        m.register_pass<pass::PropagateMasks>();
+        m.run_passes(function);
+    }
+    compare_masks(*getMask(weights.get_node_shared_ptr()->output(0)),  Mask({{1, 2, 3}, {}, {}, {}}));
+    compare_masks(*getMask(first_conv->output(0)),  Mask({{}, {1, 2, 3}, {}, {}}));
+
+    compare_masks(*getMask(reshape_conv_weights.get_node_shared_ptr()->output(0)),  Mask({{1, 2, 3}, {1, 2, 3}, {}, {}}));
+    compare_masks(*getMask(reshape_conv->output(0)),  Mask({{}, {1, 2, 3}, {}, {}}));
+
+    compare_masks(*getMask(last_conv_weights.get_node_shared_ptr()->output(0)),  Mask({{}, {1, 2, 3}, {}, {}}));
+    compare_masks(*getMask(last_conv->output(0)),  Mask({{}, {}, {}, {}}));
+    {
+        pass::Manager m;
+        m.register_pass<pass::ShrinkWeights>();
+        m.run_passes(function);
+    }
+    disable_rt_info_check();
+    enable_accuracy_check();
+}
+
+
+TEST(TransformationTests, MaskPropagationStopReshapeUp) {
+    auto inputShapes = PartialShape{1, 6, 8, 8};
+    auto weightsShape = Shape{6, 6, 1, 1};
+
+    auto input = std::make_shared<opset5::Parameter>(element::f32, inputShapes);
+    auto weights = create_constant_with_zeros(weightsShape, {{1, 2, 3}, {}, {}, {}});
+    auto conv = std::make_shared<opset5::Convolution>(input, weights, Strides(2, 1),
+                                                      CoordinateDiff(2, 0),
+                                                      CoordinateDiff(2, 0),
+                                                      Strides(2, 1));
+
+    auto reshape_const = opset5::Constant::create(element::i64, Shape{4}, {1, 3, 128, 1});
+    auto reshape = std::make_shared<opset5::Reshape>(conv, reshape_const, true);
+
+    auto conv_1_shape = Shape{6, 3, 1, 1};
+    auto conv_1_weights = create_constant_with_zeros(conv_1_shape, {{1, 2, 3}, {}, {}, {}});
+    auto conv_1 = std::make_shared<opset5::Convolution>(reshape, conv_1_weights, Strides(2, 1),
+                                                        CoordinateDiff(2, 0),
+                                                        CoordinateDiff(2, 0),
+                                                        Strides(2, 1));
+
+    auto function = std::make_shared<ngraph::Function>(OutputVector{conv_1}, ParameterVector{input}, "GoodReshapeUp");
+    if (VISUALIZE_TESTS_TREE)
+        ngraph::pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "MaskPropagationStopReshapeUp.svg").run_on_function(function);
+    {
+        pass::Manager m;
+        m.register_pass<pass::InitMasks>();
+        m.register_pass<pass::PropagateMasks>();
+        m.run_passes(function);
+    }
+    compare_masks(*getMask(weights.get_node_shared_ptr()->output(0)),  Mask({{}, {}, {}, {}}));
+    compare_masks(*getMask(conv->output(0)),  Mask({{}, {}, {}, {}}));
+
+    compare_masks(*getMask(conv_1_weights.get_node_shared_ptr()->output(0)),  Mask({{}, {}, {}, {}}));
+    compare_masks(*getMask(conv_1->output(0)),  Mask({{}, {}, {}, {}}));
+}
+
+
+TEST(TransformationTests, MaskPropagationStopReshapeDown) {
+    auto inputShapes = PartialShape{1, 1, 24, 24};
+    auto weightsShape = Shape{8, 1, 1, 1};
+
+    auto input = std::make_shared<opset5::Parameter>(element::f32, inputShapes);
+    auto weights = create_constant_with_zeros(weightsShape, {{1, 2, 3}, {}, {}, {}});
+    auto first_conv = std::make_shared<opset5::Convolution>(input, weights, Strides(2, 1),
+                                                            CoordinateDiff(2, 0),
+                                                            CoordinateDiff(2, 0),
+                                                            Strides(2, 1));
+
+
+
+    auto reshape_const = opset5::Constant::create(element::i64, Shape{4}, {1, 32, 12, 12});
+    auto reshape = std::make_shared<opset5::Reshape>(first_conv, reshape_const, true);
+
+    auto reshape_conv_weights = create_constant_with_zeros({8, 32, 13, 13}, {{1, 2, 3}, {}, {}, {}});
+    auto reshape_conv = std::make_shared<opset5::Convolution>(reshape, reshape_conv_weights,
+                                                             Strides(2, 1),
+                                                             CoordinateDiff(2, 12),
+                                                             CoordinateDiff(2, 12),
+                                                             Strides(2, 1));
+
+
+    auto mul = std::make_shared<opset5::Multiply>(first_conv, reshape_conv);
+
+    auto last_conv_weights = create_constant_with_zeros({8, 8, 8, 8}, {{1, 2, 3}, {}, {}, {}});
+    auto last_conv = std::make_shared<opset5::Convolution>(mul, last_conv_weights,
+                                                           Strides(2, 1),
+                                                           CoordinateDiff(2, 0),
+                                                           CoordinateDiff(2, 0),
+                                                           Strides(2, 1));
+
+    auto function = std::make_shared<ngraph::Function>(OutputVector{last_conv}, ParameterVector{input}, "BadReshapeElementwiseModel");
+
+    if (VISUALIZE_TESTS_TREE)
+        ngraph::pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "MaskPropagationStopReshapeDown.svg").run_on_function(function);
+    {
+        pass::Manager m;
+        m.register_pass<pass::InitMasks>();
+        m.register_pass<pass::PropagateMasks>();
+        m.run_passes(function);
+    }
+    compare_masks(*getMask(weights.get_node_shared_ptr()->output(0)),  Mask({{}, {}, {}, {}}));
+    compare_masks(*getMask(first_conv->output(0)),  Mask({{}, {}, {}, {}}));
+
+    compare_masks(*getMask(reshape_conv_weights.get_node_shared_ptr()->output(0)),  Mask({{}, {}, {}, {}}));
+    compare_masks(*getMask(reshape_conv->output(0)),  Mask({{}, {}, {}, {}}));
+
+    compare_masks(*getMask(last_conv_weights.get_node_shared_ptr()->output(0)),  Mask({{}, {}, {}, {}}));
+    compare_masks(*getMask(last_conv->output(0)),  Mask({{}, {}, {}, {}}));
+}
+
+
+TEST(TransformationTests, MaskPropagationWrongDimsElementwise) {
+    auto inputShapes = PartialShape{1, 1, 24, 24};
+    auto weightsShape = Shape{8, 1, 1, 1};
+
+    auto input = std::make_shared<opset5::Parameter>(element::f32, inputShapes);
+    auto weights = create_constant_with_zeros(weightsShape, {{1, 2, 3}, {}, {}, {}});
+    auto first_conv = std::make_shared<opset5::Convolution>(input, weights, Strides(2, 1),
+                                                            CoordinateDiff(2, 0),
+                                                            CoordinateDiff(2, 0),
+                                                            Strides(2, 1));
+
+
+    auto branch_conv_weights = create_constant_with_zeros({32, 8, 2, 2}, {{1, 2, 3}, {}, {}, {}});
+    auto branch_conv = std::make_shared<opset5::Convolution>(first_conv, branch_conv_weights,
+                                                             Strides(2, 2),
+                                                             CoordinateDiff(2, 0),
+                                                             CoordinateDiff(2, 0),
+                                                             Strides(2, 1));
+
+    auto reshape_const = opset5::Constant::create(element::i64, Shape{4}, {1, 32, 12, 12});
+    auto reshape = std::make_shared<opset5::Reshape>(first_conv, reshape_const, true);
+
+    auto mul = std::make_shared<opset5::Multiply>(branch_conv, reshape);
+
+    auto last_conv_weights = create_constant_with_zeros({8, 32, 8, 8}, {{1, 2, 3}, {}, {}, {}});
+    auto last_conv = std::make_shared<opset5::Convolution>(mul, last_conv_weights,
+                                                           Strides(2, 1),
+                                                           CoordinateDiff(2, 0),
+                                                           CoordinateDiff(2, 0),
+                                                           Strides(2, 1));
+
+    auto function = std::make_shared<ngraph::Function>(OutputVector{last_conv}, ParameterVector{input}, "BadReshapeElementwiseModel");
+
+    if (VISUALIZE_TESTS_TREE)
+        ngraph::pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "MaskPropagationWrongDimsElementwise.svg").run_on_function(function);
+
+    pass::Manager m;
+    m.register_pass<pass::Pruning>();
+    m.run_passes(function);
+
+    compare_masks(*getMask(weights.get_node_shared_ptr()->output(0)),  Mask({{}, {}, {}, {}}));
+    compare_masks(*getMask(first_conv->output(0)),  Mask({{}, {}, {}, {}}));
+
+    compare_masks(*getMask(branch_conv_weights.get_node_shared_ptr()->output(0)),  Mask({{}, {}, {}, {}}));
+    compare_masks(*getMask(branch_conv->output(0)),  Mask({{}, {}, {}, {}}));
+
+    compare_masks(*getMask(last_conv_weights.get_node_shared_ptr()->output(0)),  Mask({{}, {}, {}, {}}));
+    compare_masks(*getMask(last_conv->output(0)),  Mask({{}, {}, {}, {}}));
+}
+
+
+TEST_F(TransformationTestsF, PruneSEBlock) {
+    auto inputShapes = PartialShape{1, 6, 16, 16};
+    auto weightsShape = Shape{6, 6, 1, 1};
+
+    auto input = std::make_shared<opset5::Parameter>(element::f32, inputShapes);
+    auto first_conv_weights = create_constant_with_zeros(weightsShape, {{1, 2, 3}, {}, {}, {}});
+    auto first_conv = std::make_shared<opset5::Convolution>(input, first_conv_weights, Strides(2, 1),
+                                                            CoordinateDiff(2, 0),
+                                                            CoordinateDiff(2, 0),
+                                                            Strides(2, 1));
+    auto reduce_const = opset5::Constant::create(element::i64, Shape{2}, {2, 3});
+    auto reduce_mean = std::make_shared<opset5::ReduceMean>(first_conv, reduce_const, false);
+
+
+    auto reshape_const = opset5::Constant::create(element::i64, Shape{4}, {1, 6, 1, 1});
+    auto reshape = std::make_shared<opset5::Reshape>(reduce_mean, reshape_const, true);
+
+    auto se_conv_0_shape = Shape{weightsShape[0], weightsShape[0], 1, 1};
+    auto se_conv_0_weights = create_constant_with_zeros(se_conv_0_shape, {{1, 2, 3}, {}, {}, {}});
+    auto se_conv_0 = std::make_shared<opset5::Convolution>(reshape, se_conv_0_weights, Strides(2, 1),
+                                                           CoordinateDiff(2, 0),
+                                                           CoordinateDiff(2, 0),
+                                                           Strides(2, 1));
+    auto se_conv_1_shape = Shape{weightsShape[0], weightsShape[0], 1, 1};
+    auto se_conv_1_weights = create_constant_with_zeros(se_conv_0_shape, {{1, 2, 3}, {}, {}, {}});
+    auto se_conv_1 = std::make_shared<opset5::Convolution>(se_conv_0, se_conv_1_weights, Strides(2, 1),
+                                                           CoordinateDiff(2, 0),
+                                                           CoordinateDiff(2, 0),
+                                                           Strides(2, 1));
+
+    auto mul = std::make_shared<opset5::Multiply>(se_conv_1, first_conv);
+
+    auto end_conv_shape = Shape{weightsShape[1], weightsShape[0], 1, 1};
+    auto weights_end_conv = create_constant_with_zeros(end_conv_shape, {{1, 2, 3}, {}, {}, {}});
+    auto end_conv = std::make_shared<opset5::Convolution>(mul, weights_end_conv, Strides(2, 1),
+                                                                                 CoordinateDiff(2, 0),
+                                                                                 CoordinateDiff(2, 0),
+                                                                                 Strides(2, 1));
+
+    function = std::make_shared<ngraph::Function>(OutputVector{end_conv}, ParameterVector{input}, "SEBlock");
+    {
+        auto input = std::make_shared<opset5::Parameter>(element::f32, inputShapes);
+        auto first_conv_weights = create_constant_with_zeros({
+                                                              weightsShape[0] - 3,
+                                                              weightsShape[1],
+                                                              weightsShape[2],
+                                                              weightsShape[3]
+                                                             }, {{}, {}, {}, {}});
+        auto first_conv = std::make_shared<opset5::Convolution>(input, first_conv_weights, Strides(2, 1),
+                                                                CoordinateDiff(2, 0),
+                                                                CoordinateDiff(2, 0),
+                                                                Strides(2, 1));
+        auto reduce_const = opset5::Constant::create(element::i64, Shape{2}, {2, 3});
+        auto reduce_mean = std::make_shared<opset5::ReduceMean>(first_conv, reduce_const, false);
+
+        auto reshape_const = opset5::Constant::create(element::i64, Shape{4}, {1, 3, 1, 1});
+        auto reshape = std::make_shared<opset5::Reshape>(reduce_mean, reshape_const, true);
+
+        auto se_conv_0_shape = Shape{weightsShape[0] - 3, weightsShape[0] -3, 1, 1};
+        auto se_conv_0_weights = create_constant_with_zeros(se_conv_0_shape, {{}, {}, {}, {}});
+        auto se_conv_0 = std::make_shared<opset5::Convolution>(reshape, se_conv_0_weights, Strides(2, 1),
+                                                               CoordinateDiff(2, 0),
+                                                               CoordinateDiff(2, 0),
+                                                               Strides(2, 1));
+        auto se_conv_1_shape = Shape{weightsShape[0] - 3, weightsShape[0] - 3, 1, 1};
+        auto se_conv_1_weights = create_constant_with_zeros(se_conv_0_shape, {{}, {}, {}, {}});
+        auto se_conv_1 = std::make_shared<opset5::Convolution>(se_conv_0, se_conv_1_weights, Strides(2, 1),
+                                                               CoordinateDiff(2, 0),
+                                                               CoordinateDiff(2, 0),
+                                                               Strides(2, 1));
+
+        auto mul = std::make_shared<opset5::Multiply>(se_conv_1, first_conv);
+
+        auto end_conv_shape = Shape{weightsShape[1], weightsShape[0] - 3, 1, 1};
+        auto weights_end_conv = create_constant_with_zeros(end_conv_shape, {{}, {}, {}, {}});
+        auto end_conv = std::make_shared<opset5::Convolution>(mul, weights_end_conv, Strides(2, 1),
+                                                                                     CoordinateDiff(2, 0),
+                                                                                     CoordinateDiff(2, 0),
+                                                                                     Strides(2, 1));
+
+        function_ref = std::make_shared<ngraph::Function>(OutputVector{end_conv}, ParameterVector{input}, "SEBlock");
+    }
+    if (VISUALIZE_TESTS_TREE)
+        ngraph::pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PruneSEBlock.svg").run_on_function(function);
+    {
+        pass::Manager m;
+        m.register_pass<pass::InitMasks>();
+        m.register_pass<pass::PropagateMasks>();
+        m.run_passes(function);
+    }
+    compare_masks(*getMask(first_conv_weights.get_node_shared_ptr()->output(0)),  Mask({{1, 2, 3}, {}, {}, {}}));
+    compare_masks(*getMask(first_conv->output(0)),  Mask({{}, {1, 2, 3}, {}, {}}));
+
+    compare_masks(*getMask(se_conv_0_weights.get_node_shared_ptr()->output(0)),  Mask({{1, 2, 3}, {1, 2, 3}, {}, {}}));
+    compare_masks(*getMask(se_conv_0->output(0)),  Mask({{}, {1, 2, 3}, {}, {}}));
+
+    compare_masks(*getMask(se_conv_1_weights.get_node_shared_ptr()->output(0)),  Mask({{1, 2, 3}, {1, 2, 3}, {}, {}}));
+    compare_masks(*getMask(se_conv_1->output(0)),  Mask({{}, {1, 2, 3}, {}, {}}));
+
+    compare_masks(*getMask(weights_end_conv.get_node_shared_ptr()->output(0)),  Mask({{}, {1, 2, 3}, {}, {}}));
+    compare_masks(*getMask(end_conv->output(0)),  Mask({{}, {}, {}, {}}));
+    {
+        pass::Manager m;
+        m.register_pass<pass::ShrinkWeights>();
+        m.run_passes(function);
+    }
+    disable_rt_info_check();
+    enable_accuracy_check();
 }


### PR DESCRIPTION
### Details:
Valid reshape operation pruning mask propagation support. 

Reshape mask propagator checks input and output dimensions from the beginning till first shape differences or min sizes of in/out shapes and propagate mask only for dimensions which are completely the same from the beginning of the shapes.
Such way to propagate masks through reshape keeps callback connections in valid state

### Tickets:
 - 67418

TODO:

- [x] Tests
- [x] Beautiful illustration
