### PR TITLE
Update RIC Fusion for known Gathers

### DIFF
--- a/src/common/transformations/include/transformations/rt_info/attributes.hpp
+++ b/src/common/transformations/include/transformations/rt_info/attributes.hpp
@@ -20,6 +20,7 @@
 #include <transformations/rt_info/old_api_map_order_attribute.hpp>
 #include <transformations/rt_info/primitives_priority_attribute.hpp>
 #include <transformations/rt_info/strides_property.hpp>
+#include <transformations/rt_info/reverse_input_channels.hpp>
 #include <transformations/rt_info/decompression.hpp>
 #include <transformations_visibility.hpp>
 #include <utility>

--- a/src/common/transformations/include/transformations/rt_info/reverse_input_channels.hpp
+++ b/src/common/transformations/include/transformations/rt_info/reverse_input_channels.hpp
@@ -1,0 +1,27 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <ngraph/node.hpp>
+#include <ngraph/variant.hpp>
+#include <openvino/core/rtti.hpp>
+#include <openvino/core/runtime_attribute.hpp>
+
+namespace ov {
+NGRAPH_API bool is_reverse_input_channels(const std::shared_ptr<ngraph::Node>& node);
+
+NGRAPH_API void set_is_reverse_input_channels(std::shared_ptr<ngraph::Node> node);
+
+/*
+ * ReverseInputChannels attribute indicates that operation can be fused
+ * by ReverseInputChannels fusion transformation for cases when shape is dynamic.
+ */
+class NGRAPH_API ReverseInputChannels : public ov::RuntimeAttribute {
+public:
+    OPENVINO_RTTI("reverse_input_channels", "0");
+    ReverseInputChannels() = default;
+    bool visit_attributes(AttributeVisitor& visitor) override { return true; };
+};
+} // namespace ov

--- a/src/common/transformations/src/transformations/common_optimizations/ric_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/ric_fusion.cpp
@@ -77,7 +77,7 @@ public:
     // we have to merge RIC attrs from all inputs. To check that given attr be merged with
     // current we check the order and axis which must be the same.
     bool can_be_merged_with(const Attribute & other) {
-        return m_order == other.m_order && m_axis == other.m_axis;
+        return (m_order.empty() || other.m_order.empty() || m_order == other.m_order) && m_axis == other.m_axis;
     }
 
     // When merging two and more attrs for further propagation we have to keep can_be_fused references
@@ -101,6 +101,8 @@ public:
     bool is_initial() const { return m_is_initial; }
 
 private:
+    // empty order means that the order is default and must be n, n-1, ..., 0
+    // according to the dimension values specified by m_axis
     std::vector<int64_t> m_order;
     int64_t m_axis;
 
@@ -227,18 +229,23 @@ public:
             const auto & pattern_map = m.get_pattern_value_map();
             const auto & output = pattern_map.at(pattern_root);
 
-            auto order = ov::get_constant_from_source(pattern_map.at(indices_p));
             auto axis = ov::get_constant_from_source(pattern_map.at(axis_p));
-            if (!order || !axis) {
-                return false;
+            if (!axis) return false;
+
+            const auto axis_value = axis->cast_vector<int64_t>().at(0);
+
+            if (ov::is_reverse_input_channels(output.get_node_shared_ptr())) {
+                ric_attr::init(output, {}, axis_value);
+                return true;
             }
+
+            auto order = ov::get_constant_from_source(pattern_map.at(indices_p));
+            if (!order) return false;
 
             // Avoid cases with two consecutive Gathers
             if (ric_attr::has(pattern_map.at(input_p))) {
                 return false;
             }
-
-            const auto axis_value = axis->cast_vector<int64_t>().at(0);
 
             // This constraint helps to avoid detection of other Gathers that do not perform RIC
             const auto & data_shape = m.get_match_root()->input(0).get_partial_shape();
@@ -333,7 +340,8 @@ public:
                 }
 
                 const int64_t & new_axis = ric.get_axis() - (data_rank - shape_rank);
-                if (shape[new_axis] == 1) {
+                const auto & axis_dim = shape[new_axis];
+                if (axis_dim == 1) {
                     // we don't have to insert RIC for constant, so we keep propagating
                     ric_attr::set(m.get_match_value(), ric);
                     continue;
@@ -343,9 +351,15 @@ public:
                 auto ric_const = ric;
                 ric_const.set_axis(new_axis);
                 ric_const.set_is_final(true);
-                ric_const.set_callback([](Input<Node> input, const ric_attr::Attribute & attr) {
+                ric_const.set_callback([axis_dim](Input<Node> input, const ric_attr::Attribute & attr) {
                     auto output = input.get_source_output();
-                    auto gather = std::make_shared<opset8::Gather>(output, create_const(attr.get_order()),
+                    // Handle case when the RIC order is default
+                    auto order = attr.get_order();
+                    if (order.empty()) {
+                        order.resize(axis_dim);
+                        std::iota(order.rbegin(), order.rend(), 0);
+                    }
+                    auto gather = std::make_shared<opset8::Gather>(output, create_const(order),
                                                                    create_const({attr.get_axis()}));
                     input.replace_source_output(gather);
                     // TODO: copy runtime info from RIC sub-graph
@@ -372,7 +386,7 @@ public:
         auto input_p = pattern::any_input(ric_attr::has<Output<Node>>);
         auto pattern_root = pattern::wrap_type<opset8::Convolution>({input_p,
                                                                      pattern::wrap_type<opset8::Constant,
-                                                                                        opset8::FakeQuantize>()});
+                                                                                        opset8::FakeQuantize>(pattern::has_static_dim(1/*output channel*/))});
         auto callback = [=](pattern::Matcher& m) {
             auto conv = m.get_match_root();
             auto ric = ric_attr::get(conv->input_value(0)).propagate();
@@ -380,9 +394,16 @@ public:
 
             ric.set_is_final(true);
             ric.set_callback([](Input<Node> input, const ric_attr::Attribute & attr) {
+                const auto output_channel_index = 1;
+                auto order = attr.get_order();
+                // Handle case when the RIC order is default
+                if (order.empty()) {
+                    order.resize(input.get_partial_shape()[output_channel_index].get_length());
+                    std::iota(order.rbegin(), order.rend(), 0);
+                }
                 auto weights = input.get_source_output();
-                auto gather = std::make_shared<opset8::Gather>(weights, create_const(attr.get_order()),
-                                                               create_const({1} /* output channel */));
+                auto gather = std::make_shared<opset8::Gather>(weights, create_const(order),
+                                                               create_const({output_channel_index}));
                 input.replace_source_output(gather);
                 // TODO: copy runtime info from RIC sub-graph
             });
@@ -419,9 +440,18 @@ public:
             const auto & weights_shape = conv->input_value(1).get_shape();
             const int64_t & group = static_cast<int64_t>(weights_shape.at(0));
             const int64_t & channels = static_cast<int64_t>(weights_shape.at(1));
+            const int64_t & in_channels = static_cast<int64_t>(weights_shape.at(2));
 
             auto ric = ric_attr::get(conv->input_value(0)).propagate();
-            if (ric.get_order().size() != static_cast<size_t>(group) || ric.get_axis() != 1) {
+            auto order = ric.get_order();
+            // Handle case when the RIC order is default
+            if (order.empty()) {
+                order.resize(group);
+                std::iota(order.rbegin(), order.rend(), 0);
+                ric.set_order(order);
+            }
+
+            if (in_channels != 1 || ric.get_order().size() != static_cast<size_t>(group) || ric.get_axis() != 1) {
                 // TODO: insert RIC when group == 1
                 return false;
             }

--- a/src/common/transformations/src/transformations/rt_info/attributes.cpp
+++ b/src/common/transformations/src/transformations/rt_info/attributes.cpp
@@ -16,6 +16,7 @@ ov::pass::Attributes::Attributes() {
     register_factory<Decompression>();
     register_factory<ov::preprocess::TensorInfoMemoryType>();
     register_factory<StridesPropagation>();
+    register_factory<ReverseInputChannels>();
 }
 
 ov::Any ov::pass::Attributes::create_by_type_info(const ov::DiscreteTypeInfo& type_info) {

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -101,6 +101,7 @@ set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/src/pass/convert_precis
                             "${CMAKE_CURRENT_SOURCE_DIR}/src/pass/init_node_info.cpp"
                             "${CMAKE_CURRENT_SOURCE_DIR}/src/pass/serialize.cpp"
                             "${CMAKE_CURRENT_SOURCE_DIR}/src/op/type_relaxed.cpp"
+                            "${CMAKE_CURRENT_SOURCE_DIR}/src/preprocess/preprocess_steps_impl.cpp"
                             "${CMAKE_CURRENT_SOURCE_DIR}/src/model.cpp" # for SmartReshape
                             ${smart_reshape_srcs} ${rt_info_srcs}
         PROPERTIES INCLUDE_DIRECTORIES $<TARGET_PROPERTY:inference_engine_transformations,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/src/core/src/pass/rt_info/reverse_input_channels.cpp
+++ b/src/core/src/pass/rt_info/reverse_input_channels.cpp
@@ -1,0 +1,14 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/rt_info/reverse_input_channels.hpp"
+#include "ngraph/node.hpp"
+
+bool ov::is_reverse_input_channels(const std::shared_ptr<ngraph::Node> &node) {
+    return node->get_rt_info().count(ReverseInputChannels::get_type_info_static());
+}
+
+void ov::set_is_reverse_input_channels(std::shared_ptr<ngraph::Node> node) {
+    node->get_rt_info().emplace(ReverseInputChannels::get_type_info_static(), ReverseInputChannels{});
+}

--- a/src/core/src/pass/rt_info/reverse_input_channels.cpp
+++ b/src/core/src/pass/rt_info/reverse_input_channels.cpp
@@ -3,9 +3,10 @@
 //
 
 #include "transformations/rt_info/reverse_input_channels.hpp"
+
 #include "ngraph/node.hpp"
 
-bool ov::is_reverse_input_channels(const std::shared_ptr<ngraph::Node> &node) {
+bool ov::is_reverse_input_channels(const std::shared_ptr<ngraph::Node>& node) {
     return node->get_rt_info().count(ReverseInputChannels::get_type_info_static());
 }
 

--- a/src/core/src/preprocess/preprocess_steps_impl.cpp
+++ b/src/core/src/preprocess/preprocess_steps_impl.cpp
@@ -12,6 +12,8 @@
 #include "openvino/op/nv12_to_rgb.hpp"
 #include "openvino/opsets/opset8.hpp"
 
+#include "transformations/rt_info/reverse_input_channels.hpp"
+
 namespace ov {
 namespace preprocess {
 
@@ -362,7 +364,11 @@ void PreStepsList::add_reverse_channels() {
     m_actions.emplace_back([](const std::vector<Output<Node>>& nodes,
                               const std::shared_ptr<Model>& function,
                               PreprocessingContext& context) {
-        return reverse_channels(nodes, function, context);
+        auto resp = reverse_channels(nodes, function, context);
+        auto outputs = std::get<0>(resp);
+        OPENVINO_ASSERT(outputs.size() == 1, "Internal error: reverse_channels returned unexpected number of outputs");
+        set_is_reverse_input_channels(outputs.at(0).get_node_shared_ptr());
+        return resp;
     });
 }
 
@@ -413,8 +419,8 @@ std::tuple<std::vector<Output<Node>>, bool> PreStepsList::reverse_channels(const
 
     // Gather slices in reverse order (indexes are specified by 'range' operation)
     auto constant_axis = op::v0::Constant::create(element::i32, {1}, {channels_idx});
-    auto convert = std::make_shared<op::v8::Gather>(nodes[0], range, constant_axis);
-    return std::make_tuple(std::vector<Output<Node>>{convert}, false);
+    auto gather = std::make_shared<op::v8::Gather>(nodes[0], range, constant_axis);
+    return std::make_tuple(std::vector<Output<Node>>{gather}, false);
 }
 
 std::tuple<std::vector<Output<Node>>, bool> PreStepsList::cut_last_channel(const std::vector<Output<Node>>& nodes,

--- a/src/core/src/preprocess/preprocess_steps_impl.cpp
+++ b/src/core/src/preprocess/preprocess_steps_impl.cpp
@@ -11,7 +11,6 @@
 #include "openvino/op/nv12_to_bgr.hpp"
 #include "openvino/op/nv12_to_rgb.hpp"
 #include "openvino/opsets/opset8.hpp"
-
 #include "transformations/rt_info/reverse_input_channels.hpp"
 
 namespace ov {


### PR DESCRIPTION
### Description
RIC fusion was updated to fuse Gathers (RIC) for cases when order is unknown. This cases appears when we apply RIC preprocessing for dynamic inputs, so this Gather (RIC) operation are marked with special flag which indicates that this operation is RIC operation and can be fused without any bad consequences.