### PR TITLE
fixed tensor shapes in Divide::evaluate_bound

### DIFF
--- a/src/core/tests/type_prop/reshape.cpp
+++ b/src/core/tests/type_prop/reshape.cpp
@@ -166,7 +166,7 @@ TEST(type_prop, interval_value_propagation_mul_div_rhs_scalar) {
     ASSERT_EQ(r->get_output_partial_shape(0), PartialShape({Dimension(2, 8), Dimension(8, 32), 4}));
 }
 
-TEST(type_prop, interval_value_propagation_mul_div_lhs_1D) {
+TEST(type_prop, interval_value_propagation_mul_lhs_1D_div) {
     auto param = make_shared<op::Parameter>(element::f32, PartialShape{Dimension(2, 8), Dimension(4, 16), 6});
     auto shape_of = make_shared<op::v3::ShapeOf>(param);
     auto cast_fp = make_shared<op::Convert>(shape_of, element::f32);
@@ -180,7 +180,7 @@ TEST(type_prop, interval_value_propagation_mul_div_lhs_1D) {
     ASSERT_EQ(r->get_output_partial_shape(0), PartialShape({Dimension(2, 8), Dimension(8, 32), 4}));
 }
 
-TEST(type_prop, interval_value_propagation_mul_div_rhs_1D) {
+TEST(type_prop, interval_value_propagation_mul_rhs_1D_div) {
     auto param = make_shared<op::Parameter>(element::f32, PartialShape{Dimension(2, 8), Dimension(4, 16), 6});
     auto shape_of = make_shared<op::v3::ShapeOf>(param);
     auto cast_fp = make_shared<op::Convert>(shape_of, element::f32);
@@ -192,6 +192,20 @@ TEST(type_prop, interval_value_propagation_mul_div_rhs_1D) {
 
     ASSERT_EQ(r->get_element_type(), element::f32);
     ASSERT_EQ(r->get_output_partial_shape(0), PartialShape({Dimension(2, 8), Dimension(8, 32), 4}));
+}
+
+TEST(type_prop, interval_value_propagation_mul_div_lhs_1D) {
+    auto param = make_shared<op::Parameter>(element::f32, PartialShape{Dimension(2, 8), Dimension(4, 16), 6});
+    auto shape_of = make_shared<op::v3::ShapeOf>(param);
+    auto cast_fp = make_shared<op::Convert>(shape_of, element::f32);
+    auto mul = make_shared<op::v1::Multiply>(cast_fp, op::Constant::create(element::f32, {1}, {2}));
+    auto div = make_shared<op::v1::Divide>(op::Constant::create(element::f32, {}, {192}), mul);
+    auto cast_int = make_shared<op::Convert>(div, element::i32);
+
+    auto r = make_shared<op::v1::Reshape>(param, cast_int, false);
+
+    ASSERT_EQ(r->get_element_type(), element::f32);
+    ASSERT_EQ(r->get_output_partial_shape(0), PartialShape({Dimension(12, 48), Dimension(6, 24), 16}));
 }
 
 TEST(type_prop, interval_value_propagation_reduce) {


### PR DESCRIPTION
Root cause analysis: Tensor shape was set according to shape of the first argument. This tensor was used in operation with both input arguments and result will have shape equal broadcast of 2 input shapes.

Solution: Set correct shape for tensor. Added unit test for such case.

Ticket: 73715