### PR TITLE
[IE SAMPLE] Fixed inputs and outputs element type initialization

### DIFF
--- a/samples/cpp/speech_sample/main.cpp
+++ b/samples/cpp/speech_sample/main.cpp
@@ -89,6 +89,8 @@ int main(int argc, char* argv[]) {
         ov::preprocess::PrePostProcessor proc(model);
         for (int i = 0; i < model->inputs().size(); i++) {
             proc.input(i).tensor().set_element_type(ov::element::f32).set_layout(tensor_layout);
+        }
+        for (int i = 0; i < model->outputs().size(); i++) {
             proc.output(i).tensor().set_element_type(ov::element::f32);
         }
         model = proc.build();


### PR DESCRIPTION
### Details:
 - When initializing inputs and outputs element type it's expected that inputs number is equal to outputs number. But it's not always true, a separate index should be used for inputs and outputs

### Tickets:
74650