### PR TITLE
[Slice-8] Output shape - Return dim(-1) if no upper bounds

### DIFF
--- a/src/core/tests/type_prop/slice.cpp
+++ b/src/core/tests/type_prop/slice.cpp
@@ -386,7 +386,7 @@ TEST(type_prop, slice_v8_basic_const_inputs_MAX_MIN_INT_dynamic_dimensions) {
                                     Dimension(10, 20),
                                     Dimension(30, 40),
                                     Dimension(0, 50),
-                                    Dimension(0, INT32_MAX)};
+                                    Dimension(-1)};
 
     std::vector<int32_t> start_val{2, 2, INT32_MIN, INT32_MIN, INT32_MIN, INT32_MIN, INT32_MIN, 0, 0};
     std::vector<int32_t> stop_val{10, INT32_MAX, 5, 10, 15, 25, INT32_MAX, 50, INT32_MAX};
@@ -428,7 +428,7 @@ TEST(type_prop, slice_v8_basic_const_inputs_MAX_MIN_INT_dynamic_dimensions_neg_s
                                     Dimension(20),
                                     Dimension(20),
                                     Dimension(0, 20),
-                                    Dimension(0, 21),
+                                    Dimension(-1),
                                     Dimension(-1)};
 
     std::vector<int32_t> start_val{9,
@@ -460,7 +460,7 @@ TEST(type_prop, slice_v8_basic_const_inputs_MAX_MIN_INT_dynamic_dimensions_neg_s
 
 TEST(type_prop, slice_v8_basic_const_inputs_data_full_dynamic_dims) {
     PartialShape data_shape{Dimension(-1), Dimension(-1), Dimension(-1)};
-    PartialShape expected_out_shape{Dimension(0, 6), Dimension(0, 15), Dimension(0, 5)};
+    PartialShape expected_out_shape{Dimension(-1), Dimension(-1), Dimension(-1)};
 
     std::vector<int32_t> start_val{2, 10, 35};
     std::vector<int32_t> stop_val{8, 25, 40};
@@ -479,7 +479,7 @@ TEST(type_prop, slice_v8_basic_const_inputs_data_full_dynamic_dims) {
 
 TEST(type_prop, slice_v8_basic_const_inputs_data_full_dynamic_dims_neg_ind) {
     PartialShape data_shape{Dimension(-1), Dimension(-1), Dimension(-1)};
-    PartialShape expected_out_shape{Dimension(0, 6), Dimension(0, 15), Dimension(0, 5)};
+    PartialShape expected_out_shape{Dimension(-1), Dimension(-1), Dimension(-1)};
 
     std::vector<int32_t> start_val{-8, -25, -40};
     std::vector<int32_t> stop_val{-2, -10, -35};
@@ -498,7 +498,7 @@ TEST(type_prop, slice_v8_basic_const_inputs_data_full_dynamic_dims_neg_ind) {
 
 TEST(type_prop, slice_v8_basic_const_inputs_data_full_dynamic_dims_neg_step) {
     PartialShape data_shape{Dimension(-1), Dimension(-1), Dimension(-1)};
-    PartialShape expected_out_shape{Dimension(0, 6), Dimension(0, 15), Dimension(0, 5)};
+    PartialShape expected_out_shape{Dimension(-1), Dimension(-1), Dimension(-1)};
 
     std::vector<int32_t> start_val{8, 25, 40};
     std::vector<int32_t> stop_val{2, 10, 35};
@@ -517,7 +517,7 @@ TEST(type_prop, slice_v8_basic_const_inputs_data_full_dynamic_dims_neg_step) {
 
 TEST(type_prop, slice_v8_basic_const_inputs_data_full_dynamic_dims_neg_step_neg_ind) {
     PartialShape data_shape{Dimension(-1), Dimension(-1), Dimension(-1)};
-    PartialShape expected_out_shape{Dimension(0, 6), Dimension(0, 15), Dimension(0, 5)};
+    PartialShape expected_out_shape{Dimension(-1), Dimension(-1), Dimension(-1)};
 
     std::vector<int32_t> start_val{-2, -10, -35};
     std::vector<int32_t> stop_val{-8, -25, -40};
@@ -536,11 +536,7 @@ TEST(type_prop, slice_v8_basic_const_inputs_data_full_dynamic_dims_neg_step_neg_
 
 TEST(type_prop, slice_v8_basic_const_inputs_data_full_dynamic_dims_neg_step_mix_ind) {
     PartialShape data_shape{Dimension(-1), Dimension(-1), Dimension(-1), Dimension(-1), Dimension(-1)};
-    PartialShape expected_out_shape{Dimension(0, 6),
-                                    Dimension(0, 6),
-                                    Dimension(-1),
-                                    Dimension(0, INT32_MAX - 5),
-                                    Dimension(-1)};
+    PartialShape expected_out_shape{Dimension(-1), Dimension(-1), Dimension(-1), Dimension(-1), Dimension(-1)};
 
     std::vector<int32_t> start_val{5, 5, -10, INT32_MAX, INT32_MAX};
     std::vector<int32_t> stop_val{-10, INT32_MIN, 5, 5, INT32_MIN};
@@ -551,6 +547,80 @@ TEST(type_prop, slice_v8_basic_const_inputs_data_full_dynamic_dims_neg_step_mix_
 
     element::Type_t et = element::i32;
     std::vector<std::vector<int32_t>> input_vals{start_val, stop_val, step_val, axes_val};
+    const auto op = make_slice_op_const_inputs(input_vals, data_shape, et);
+
+    EXPECT_EQ(op->get_element_type(), et);
+    EXPECT_EQ(op->get_output_partial_shape(0), expected_out_shape);
+}
+
+TEST(type_prop, slice_v8_basic_const_inputs_dynamic_dims_maxint32) {
+    PartialShape data_shape{Dimension(0, 2000), Dimension(-1), 4};
+    PartialShape expected_out_shape{Dimension(0, 2000), Dimension(-1), Dimension(4)};
+
+    std::vector<int32_t> start_val{0, 0, 0};
+    std::vector<int32_t> stop_val{INT32_MAX, INT32_MAX, INT32_MAX};
+    std::vector<int32_t> step_val{1, 1, 1};
+
+    std::vector<int32_t> axes_val(start_val.size());
+    std::iota(axes_val.begin(), axes_val.end(), 0);
+
+    element::Type_t et = element::i32;
+    std::vector<std::vector<int32_t>> input_vals{start_val, stop_val, step_val, axes_val};
+    const auto op = make_slice_op_const_inputs(input_vals, data_shape, et);
+
+    EXPECT_EQ(op->get_element_type(), et);
+    EXPECT_EQ(op->get_output_partial_shape(0), expected_out_shape);
+}
+
+TEST(type_prop, slice_v8_basic_const_inputs_dynamic_dims_maxint64) {
+    PartialShape data_shape{Dimension(0, 2000), Dimension(-1), 4};
+    PartialShape expected_out_shape{Dimension(0, 2000), Dimension(-1), Dimension(4)};
+
+    std::vector<int64_t> start_val{0, 0, 0};
+    std::vector<int64_t> stop_val{INT64_MAX, INT64_MAX, INT64_MAX};
+    std::vector<int64_t> step_val{1, 1, 1};
+
+    std::vector<int64_t> axes_val(start_val.size());
+    std::iota(axes_val.begin(), axes_val.end(), 0);
+
+    element::Type_t et = element::i64;
+    std::vector<std::vector<int64_t>> input_vals{start_val, stop_val, step_val, axes_val};
+    const auto op = make_slice_op_const_inputs(input_vals, data_shape, et);
+
+    EXPECT_EQ(op->get_element_type(), et);
+    EXPECT_EQ(op->get_output_partial_shape(0), expected_out_shape);
+}
+
+TEST(type_prop, slice_v8_basic_const_inputs_dynamic_dims_maxint32_start1) {
+    PartialShape data_shape{Dimension(0, 2000), Dimension(-1), 4};
+    PartialShape expected_out_shape{Dimension(0, 2000), Dimension(-1), Dimension(4)};
+
+    std::vector<int32_t> start_val{1};
+    std::vector<int32_t> stop_val{INT32_MAX};
+    std::vector<int32_t> step_val{1};
+
+    std::vector<int32_t> axes_val{1};
+
+    element::Type_t et = element::i32;
+    std::vector<std::vector<int32_t>> input_vals{start_val, stop_val, step_val, axes_val};
+    const auto op = make_slice_op_const_inputs(input_vals, data_shape, et);
+
+    EXPECT_EQ(op->get_element_type(), et);
+    EXPECT_EQ(op->get_output_partial_shape(0), expected_out_shape);
+}
+
+TEST(type_prop, slice_v8_basic_const_inputs_dynamic_dims_maxint64_start1) {
+    PartialShape data_shape{Dimension(0, 2000), Dimension(-1), 4};
+    PartialShape expected_out_shape{Dimension(0, 2000), Dimension(-1), Dimension(4)};
+
+    std::vector<int64_t> start_val{1};
+    std::vector<int64_t> stop_val{INT64_MAX};
+    std::vector<int64_t> step_val{1};
+
+    std::vector<int64_t> axes_val{1};
+
+    element::Type_t et = element::i64;
+    std::vector<std::vector<int64_t>> input_vals{start_val, stop_val, step_val, axes_val};
     const auto op = make_slice_op_const_inputs(input_vals, data_shape, et);
 
     EXPECT_EQ(op->get_element_type(), et);
@@ -582,7 +652,7 @@ TEST(type_prop, slice_v8_basic_const_inputs_MAX_MIN_INT_64_dynamic_dimensions_ne
                                     Dimension(20),
                                     Dimension(20),
                                     Dimension(0, 20),
-                                    Dimension(0, 21),
+                                    Dimension(-1),
                                     Dimension(-1)};
 
     std::vector<int64_t> start_val{9,


### PR DESCRIPTION
### Details:
 - Previously proposed Slice-8 `validate_and_infer_types` implementation calculated the upper bounds for the output dim based on `start/stop` even the input dimension hasn't got upper bound.
 To have alignment with StridedSlice-1  and avoid detection of max value of different size integers, 
 the proposed change is to always return dim(-1) if no upper bounds.

Corresponding StridedSlice shape_infer part:
https://github.com/openvinotoolkit/openvino/blob/7e0bf0dad5923dd3c0be1366f85ce85378ea3386/src/core/shape_inference/include/strided_slice_shape_inference.hpp#L209-L212

Draft PR with alternative solution: #9386 

### Tickets:
 - 74371
