### PR TITLE
[CPU][INT8][Intel OMZ / Public] Third dimension issue in FuseConvolut…

### DIFF
--- a/src/plugins/intel_cpu/src/mkldnn_graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/mkldnn_graph_optimizer.cpp
@@ -578,7 +578,7 @@ void MKLDNNGraphOptimizer::FuseConvolutionAndZeroPoints(MKLDNNGraph &graph) {
         ptrdiff_t OC = weightsConstantDims[0 + groupOffset];
         ptrdiff_t IC = weightsConstantDims[1 + groupOffset];
         ptrdiff_t KD = weightsConstantDims.size() == (5 + groupOffset) ? weightsConstantDims[weightsConstantDims.size() - 3] : 1;
-        ptrdiff_t KH = node->getInputShapeAtPort(0).getRank() > (3 + groupOffset) ? weightsConstantDims[weightsConstantDims.size() - 2] : 1;
+        ptrdiff_t KH = weightsConstantDims.size() == (3 + groupOffset) ? 1 : weightsConstantDims[weightsConstantDims.size() - 2];
         ptrdiff_t KW = weightsConstantDims[weightsConstantDims.size() - 1];
 
         for (size_t g = 0; g < G; g++) {


### PR DESCRIPTION
…ionAndZeroPoints

### Details:
 *Height dimension for output compensation was wrongly detected*


### Tickets:
 - *73800*
 - *73827*
