### PR TITLE
Bump nx requirement based on python version

### DIFF
--- a/tools/mo/requirements.txt
+++ b/tools/mo/requirements.txt
@@ -1,7 +1,8 @@
 tensorflow~=2.5.0
 mxnet~=1.2.0; sys_platform == 'win32'
 mxnet~=1.7.0.post2; sys_platform != 'win32'
-networkx~=2.5
+networkx~=2.5; python_version < "3.7"
+networkx~=2.6; python_version >= "3.7"
 numpy>=1.16.6,<1.20
 protobuf>=3.15.6
 onnx>=1.8.1

--- a/tools/mo/requirements_caffe.txt
+++ b/tools/mo/requirements_caffe.txt
@@ -1,4 +1,5 @@
-networkx~=2.5
+networkx~=2.5; python_version < "3.7"
+networkx~=2.6; python_version >= "3.7"
 numpy>=1.16.6,<1.20
 protobuf>=3.15.6
 defusedxml>=0.7.1

--- a/tools/mo/requirements_kaldi.txt
+++ b/tools/mo/requirements_kaldi.txt
@@ -1,4 +1,5 @@
-networkx~=2.5
+networkx~=2.5; python_version < "3.7"
+networkx~=2.6; python_version >= "3.7"
 numpy>=1.16.6,<1.20
 defusedxml>=0.7.1
 requests>=2.25.1

--- a/tools/mo/requirements_mxnet.txt
+++ b/tools/mo/requirements_mxnet.txt
@@ -1,6 +1,7 @@
 mxnet~=1.2.0; sys_platform == 'win32'
 mxnet~=1.7.0.post2; sys_platform != 'win32'
-networkx~=2.5
+networkx~=2.5; python_version < "3.7"
+networkx~=2.6; python_version >= "3.7"
 numpy>=1.16.6,<1.20
 defusedxml>=0.7.1
 urllib3>=1.26.4

--- a/tools/mo/requirements_onnx.txt
+++ b/tools/mo/requirements_onnx.txt
@@ -1,5 +1,6 @@
 onnx>=1.8.1
-networkx~=2.5
+networkx~=2.5; python_version < "3.7"
+networkx~=2.6; python_version >= "3.7"
 numpy>=1.16.6,<1.20
 defusedxml>=0.7.1
 requests>=2.25.1

--- a/tools/mo/requirements_tf.txt
+++ b/tools/mo/requirements_tf.txt
@@ -1,6 +1,7 @@
 # TensorFlow 1.x and 2.x are incompatible, use separate virtual environments for each version
 tensorflow~=1.15.5
-networkx~=2.5
+networkx~=2.5; python_version < "3.7"
+networkx~=2.6; python_version >= "3.7"
 numpy>=1.16.6,<1.19
 defusedxml>=0.7.1
 requests>=2.25.1

--- a/tools/mo/requirements_tf2.txt
+++ b/tools/mo/requirements_tf2.txt
@@ -1,5 +1,6 @@
 tensorflow~=2.5.0
-networkx~=2.5
+networkx~=2.5; python_version < "3.7"
+networkx~=2.6; python_version >= "3.7"
 numpy>=1.16.6,<1.20
 defusedxml>=0.7.1
 requests>=2.25.1


### PR DESCRIPTION
networkX 2.5 has vulnerability due to yml_load which is not used in our product
just to make our scans clean we bumb the version of this module
but networkX 2.6 dropped python 3.6 support that is why we have conditional versioning in our requirements