### PR TITLE
Fix SmartReshape TransposeMatMul pass

### DIFF
--- a/src/core/src/pass/smart_reshape/matmul_sr.cpp
+++ b/src/core/src/pass/smart_reshape/matmul_sr.cpp
@@ -136,19 +136,19 @@ ngraph::pass::TransposeMatMul::TransposeMatMul() {
         };
 
         NodeVector fused_nodes;
-        auto input_A = matmul->get_input_node_shared_ptr(0);
+        auto input_A = matmul->input_value(0);
         bool transpose_A = matmul->get_transpose_a();
-        if (transpose_is_fusable(input_A)) {
-            fused_nodes.push_back(input_A);
-            input_A = input_A->get_input_node_shared_ptr(0);
+        if (transpose_is_fusable(input_A.get_node_shared_ptr())) {
+            fused_nodes.push_back(input_A.get_node_shared_ptr());
+            input_A = input_A.get_node()->input_value(0);
             transpose_A = !transpose_A;
         }
 
-        auto input_B = matmul->get_input_node_shared_ptr(1);
+        auto input_B = matmul->input_value(1);
         auto transpose_B = matmul->get_transpose_b();
-        if (transpose_is_fusable(input_B)) {
-            fused_nodes.push_back(input_B);
-            input_B = input_B->get_input_node_shared_ptr(0);
+        if (transpose_is_fusable(input_B.get_node_shared_ptr())) {
+            fused_nodes.push_back(input_B.get_node_shared_ptr());
+            input_B = input_B.get_node()->input_value(0);
             transpose_B = !transpose_B;
         }
 

--- a/src/tests/functional/inference_engine/cnn_network/matmul_sr_tests.cpp
+++ b/src/tests/functional/inference_engine/cnn_network/matmul_sr_tests.cpp
@@ -272,11 +272,17 @@ TEST(SmartReshapeTransposeMatMulTests, TransposeBothMatMulFuse) {
 TEST(SmartReshapeTransposeMatMulTests, TransposeBothMatMulWithAttrFuse) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
-        auto data_A = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 2});
-        auto data_B = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 5});
+        auto data_A = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f32, ngraph::Shape{2, 3, 2});
+        auto split_A = std::make_shared<ngraph::opset4::VariadicSplit>(data_A,
+                       ngraph::opset4::Constant::create(ngraph::element::i64, ngraph::Shape{}, {0}),
+                       ngraph::opset4::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {1, 1}));
+        auto data_B = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f32, ngraph::Shape{2, 3, 5});
+        auto split_B = std::make_shared<ngraph::opset4::VariadicSplit>(data_B,
+                                                                       ngraph::opset4::Constant::create(ngraph::element::i64, ngraph::Shape{}, {0}),
+                                                                       ngraph::opset4::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {1, 1}));
         auto order = ngraph::opset4::Constant::create(ngraph::element::i64, ngraph::Shape{3}, {0, 2, 1});
-        auto transpose_A = std::make_shared<ngraph::opset4::Transpose>(data_A, order);
-        auto transpose_B = std::make_shared<ngraph::opset4::Transpose>(data_B, order);
+        auto transpose_A = std::make_shared<ngraph::opset4::Transpose>(split_A->output(0), order);
+        auto transpose_B = std::make_shared<ngraph::opset4::Transpose>(split_B->output(1), order);
         auto matmul = std::make_shared<ngraph::opset4::MatMul>(transpose_A, transpose_B, false, true);
         f = std::make_shared<ngraph::Function>(ngraph::NodeVector{matmul}, ngraph::ParameterVector{data_A, data_B});
 
@@ -287,9 +293,15 @@ TEST(SmartReshapeTransposeMatMulTests, TransposeBothMatMulWithAttrFuse) {
         ASSERT_NO_THROW(check_rt_info(f));
     }
     {
-        auto data_A = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 2});
-        auto data_B = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 5});
-        auto matmul = std::make_shared<ngraph::opset4::MatMul>(data_A, data_B, true, false);
+        auto data_A = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f32, ngraph::Shape{2, 3, 2});
+        auto split_A = std::make_shared<ngraph::opset4::VariadicSplit>(data_A,
+                                                                       ngraph::opset4::Constant::create(ngraph::element::i64, ngraph::Shape{}, {0}),
+                                                                       ngraph::opset4::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {1, 1}));
+        auto data_B = std::make_shared<ngraph::opset4::Parameter>(ngraph::element::f32, ngraph::Shape{2, 3, 5});
+        auto split_B = std::make_shared<ngraph::opset4::VariadicSplit>(data_B,
+                                                                       ngraph::opset4::Constant::create(ngraph::element::i64, ngraph::Shape{}, {0}),
+                                                                       ngraph::opset4::Constant::create(ngraph::element::i64, ngraph::Shape{2}, {1, 1}));
+        auto matmul = std::make_shared<ngraph::opset4::MatMul>(split_A->output(0), split_B->output(1), true, false);
         f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{matmul}, ngraph::ParameterVector{data_A, data_B});
     }
 


### PR DESCRIPTION
### Description
Fix for TransposeMatMul  transformation for cases when Transpose on MatMul inputs has multi-output parent node.