### PR TITLE
[MO, OOB] Extend FIFOQueueDequeue replacer to support OOB case

### DIFF
--- a/tools/mo/unit_tests/mo/front/tf/fifo_replacer_test.py
+++ b/tools/mo/unit_tests/mo/front/tf/fifo_replacer_test.py
@@ -11,25 +11,43 @@ from openvino.tools.mo.utils.ir_engine.compare_graphs import compare_graphs
 from unit_tests.utils.graph import build_graph_with_edge_attrs
 
 
+def create_fifo_queue_graph(batch_size_shape: np.ndarray):
+    nodes = {
+        'placeholder': {'op': 'Parameter', 'data_type': np.int32, 'kind': 'op', 'shape': batch_size_shape},
+        'batch_join/fifo_queue': {'op': 'FIFOQueueV2', 'name': 'batch_join/fifo_queue',
+                                  'shapes': np.array([[1, 2, 3]]), 'types': np.array([np.float32]), 'kind': 'op'},
+        'batch_join': {'op': 'QueueDequeueUpToV2', 'kind': 'op'},
+        'image_batch': {'op': 'Identity', 'data_type': np.float32, 'kind': 'op'},
+        'label_batch': {'op': 'Identity', 'kind': 'op'},
+        'label_batch_op_output': {'op': 'Result', 'kind': 'op'},
+    }
+    edges = [
+        ('placeholder', 'batch_join', {'out': 0, 'in': 0}),
+        ('batch_join/fifo_queue', 'batch_join', {'out': 0, 'in': 1}),
+        ('batch_join', 'image_batch', {'out': 0, 'in': 0}),
+        ('batch_join', 'label_batch', {'out': 1, 'in': 0}),
+        ('label_batch', 'label_batch_op_output', {'out': 0, 'in': 0})
+    ]
+    graph = build_graph_with_edge_attrs(nodes, edges)
+    return graph
+
+
 class TestFIFOQueueReplacement(unittest.TestCase):
     def test_fifo_with_label_batch(self):
-        nodes = {
-            'placeholder': {'op': 'Parameter', 'data_type': np.int32, 'kind': 'op', 'shape': np.array(1)},
-            'batch_join/fifo_queue': {'op': 'FIFOQueueV2', 'name': 'batch_join/fifo_queue',
-                                      'shapes': np.array([[1, 2, 3]]), 'types': np.array([np.float32]), 'kind': 'op'},
-            'batch_join': {'op': 'QueueDequeueUpToV2', 'kind': 'op'},
-            'image_batch': {'op': 'Identity', 'data_type': np.float32, 'kind': 'op'},
-            'label_batch': {'op': 'Identity', 'kind': 'op'},
-            'label_batch_op_output': {'op': 'Result', 'kind': 'op'},
-        }
-        edges = [
-            ('placeholder', 'batch_join', {'out': 0, 'in': 0}),
-            ('batch_join/fifo_queue', 'batch_join', {'out': 0, 'in': 1}),
-            ('batch_join', 'image_batch', {'out': 0, 'in': 0}),
-            ('batch_join', 'label_batch', {'out': 1, 'in': 0}),
-            ('label_batch', 'label_batch_op_output', {'out': 0, 'in': 0})
-        ]
-        graph = build_graph_with_edge_attrs(nodes, edges)
+        graph = create_fifo_queue_graph(shape_array([1]))
+        tested_class = FIFOQueue()
+        tested_class.find_and_replace_pattern(graph=graph)
+        after_pattern = graph.nodes()
+        self.assertEqual(2, len(after_pattern))
+        try:
+            new_ph_dict = graph.node[[u for u, v in graph.in_edges('image_batch')][0]]
+        except Exception as e:
+            self.fail("Can't get new placeholder. Broken edge. Additional information: {}".format(e))
+        self.assertEqual(new_ph_dict['name'], 'batch_join/fifo_queue')
+        self.assertTrue(np.array_equal(new_ph_dict['shape'], [1, 2, 3]))
+
+    def test_fifo_with_undefined_batch_size(self):
+        graph = create_fifo_queue_graph(None)
         tested_class = FIFOQueue()
         tested_class.find_and_replace_pattern(graph=graph)
         after_pattern = graph.nodes()
@@ -128,7 +146,7 @@ class FIFOQueueDequeueCutTest(unittest.TestCase):
             {
                 'queue_dequeue': {'kind': 'op', 'op': 'QueueDequeue', 'shapes': [shape_array([2, 2]),
                                                                                  shape_array([1, 1])],
-                                 'types': [np.int32, np.float32]},
+                                  'types': [np.int32, np.float32]},
                 'sub': {'kind': 'op', 'op': 'Sub'},
                 'add': {'kind': 'op', 'op': 'Add'},
                 'concat': {'kind': 'op', 'op': 'Concat'}
@@ -167,7 +185,7 @@ class FIFOQueueDequeueCutTest(unittest.TestCase):
             {
                 'queue_dequeue': {'kind': 'op', 'op': 'QueueDequeueV2', 'shapes': [shape_array([2, 2]),
                                                                                    shape_array([1, 1])],
-                                 'types': [np.int32, np.float32]},
+                                  'types': [np.int32, np.float32]},
                 'sub': {'kind': 'op', 'op': 'Sub'},
                 'add': {'kind': 'op', 'op': 'Add'},
                 'concat': {'kind': 'op', 'op': 'Concat'}


### PR DESCRIPTION
**Root cause analysis:** Earlier the FIFOQueueDequeue transformation expects defined shape for batch_label placeholder. Due to this the transformation raises exception.

**Solution:** Now we can relax this requirement and convert with a shape specified in FIFOQueueV2 operation shape list attribute in case OOB conversion. For backward compatibility, I left legacy logic when batch_label shape is defined.

**Ticket:** 74143

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names

Validation:
* [x]  Unit tests
* [x]  Framework operation tests - N/A
* [x]  Transformation tests
* [ ]  Model Optimizer IR Reader check - now we have no opportunity to check it since ir_reader_test is outdated. Will be fixed in the scope of PR-9272

Documentation:
* [x]  Supported frameworks operations list - already updated, checked
* [x]  Guide on how to convert the **public** model - already updated OOB for FaceNet, checked
* [x]  User guide update - N/A
