### PR TITLE
[Snippets] Support decreasing output shapes

### DIFF
--- a/src/common/snippets/src/op/subgraph.cpp
+++ b/src/common/snippets/src/op/subgraph.cpp
@@ -264,8 +264,8 @@ snippets::Schedule snippets::op::Subgraph::generate(const BlockedShapeVector& ou
 
         for (size_t i = 0; i < work_size.size(); i++) {
             if (work_size[i] != shape[i]) {
-                if (work_size[i] == 1) {
-                    work_size[i] = shape[i];
+                if (work_size[i] == 1 || shape[i] == 1) {
+                    work_size[i] = max(work_size[i], shape[i]);
                 } else {
                     throw ngraph_error("incompatible shapes for output graphs");
                 }


### PR DESCRIPTION
### Details:
 - *Support decreasing output shapes in snippets. Was supported: [1,1,64,1] + [1,1,64,512]. Need to support: [1,1,64,512] + [1,1,64,1]*

### Tickets:
 - *74749*
