### PR TITLE
[GPU] Fix of gws/lws inconsistency for some reorder cases

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/core/common/kernel_selector_utils.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/core/common/kernel_selector_utils.cpp
@@ -180,12 +180,23 @@ JitConstants GetTensorFriendlyWorkGroupsJit(const DataTensor& t) {
 
 std::vector<size_t> GetTensorFriendlyWorkGroups(const DataTensor& t) {
     std::vector<size_t> sizes;
+    auto x = DataTensor::Channelndex(t.GetLayout(), Tensor::DataChannelName::X);
     auto y = DataTensor::Channelndex(t.GetLayout(), Tensor::DataChannelName::Y);
     auto z = DataTensor::Channelndex(t.GetLayout(), Tensor::DataChannelName::Z);
     auto w = DataTensor::Channelndex(t.GetLayout(), Tensor::DataChannelName::W);
+
+    auto primary_spatial_axis = x;
+    if (y < primary_spatial_axis && y != -1) primary_spatial_axis = y;
+    if (z < primary_spatial_axis && z != -1) primary_spatial_axis = z;
+    if (w < primary_spatial_axis && w != -1) primary_spatial_axis = w;
+
     for (size_t i = 0; i < t.GetDims().size(); i++) {
         const auto& o = t.GetDims()[i];
-        if (y == static_cast<int>(i) || z == static_cast<int>(i) || w == static_cast<int>(i)) {
+        auto cur_axis_is_spatial = x == static_cast<int>(i) ||
+                                   y == static_cast<int>(i) ||
+                                   z == static_cast<int>(i) ||
+                                   w == static_cast<int>(i);
+        if (cur_axis_is_spatial && primary_spatial_axis != static_cast<int>(i)) {
             sizes.back() *= o.v;
         } else {
             sizes.push_back(o.v);


### PR DESCRIPTION
### Details:
 - Correction of an error related to gws / lws inconsistency inside reorder kernels for _fs_b_yx_fsv32_ format at input and _b_fs_yx_fsv32_ (or double blocked _bsv_fsv_ formats) at the output
 - Some changes in _GetTensorFriendlyWorkGroups_ function which can avoid potential issues for cases where X axis isn't the primary spatial axis

### Tickets:
 - 66180
