### PR TITLE
Add include guard to file_utils.cpp

### DIFF
--- a/src/inference/src/file_utils.cpp
+++ b/src/inference/src/file_utils.cpp
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#ifndef FILE_UTILS_CPP
+#define FILE_UTILS_CPP
+
 #include <cstring>
 #include <fstream>
 #include <string>
@@ -130,3 +133,5 @@ std::string getIELibraryPath() {
 }
 
 }  // namespace InferenceEngine
+
+#endif


### PR DESCRIPTION
### Details:
Fix to successfully build master 

CMake keys:
```
  "-DENABLE_PROFILING_ITT=OFF",
        "-DENABLE_TESTS=ON",
        "-DNGRAPH_UNIT_TEST_BACKENDS_ENABLE=OFF",
        "-DENABLE_BEH_TESTS=ON",
        "-DENABLE_GNA=OFF",
        "-DENABLE_MKL_DNN=ON",
        "-DENABLE_CLDNN=ON",
        "-DENABLE_MYRIAD=OFF",
        "-DENABLE_SAMPLES=ON",
        "-DENABLE_MYRIAD_MVNC_TESTS=OFF",
        "-DENABLE_SANITIZER=OFF",
        "-DENABLE_DATA=OFF",
        "-DNGRAPH_ONNX_IMPORT_ENABLE=ON",
        "-DENABLE_FASTER_BUILD=OFF",
        "-DENABLE_TEMPLATE_PLUGIN=ON",
        "-DENABLE_PYTHON=ON",
        "-DPYTHON_EXECUTABLE=/home/dlyakhov/env/ov_dev/bin/python",
        "-DNGRAPH_PYTHON_BUILD_ENABLE=ON",
        "-DPYTHON_LIBRARY=/usr/lib/python3.6/config-3.6m-x86_64-linux-gnu/libpython3.6m.so",
        "-DPYTHON_INCLUDE_DIR=/usr/include/python3.6",
        "-DENABLE_CPPLINT=ON",
        "-DENABLE_OPENVINO_DEBUG=ON"
```

