### PR TITLE
Atomic guard impromenents

### DIFF
--- a/src/core/src/atomic_guard.hpp
+++ b/src/core/src/atomic_guard.hpp
@@ -12,7 +12,8 @@ class AtomicGuard {
 public:
     AtomicGuard(std::atomic_bool& b) : m_atomic(b) {
         bool exp = false;
-        while (!m_atomic.compare_exchange_strong(exp, true)) {
+        while (m_atomic.load(std::memory_order::relaxed) ||
+               !m_atomic.compare_exchange_strong(exp, true)) {
             exp = false;
         }
     }

--- a/src/core/src/atomic_guard.hpp
+++ b/src/core/src/atomic_guard.hpp
@@ -12,7 +12,7 @@ class AtomicGuard {
 public:
     AtomicGuard(std::atomic_bool& b) : m_atomic(b) {
         bool exp = false;
-        while (m_atomic.load(std::memory_order::relaxed) ||
+        while (m_atomic.load(std::memory_order_relaxed) ||
                !m_atomic.compare_exchange_strong(exp, true)) {
             exp = false;
         }

--- a/src/core/src/atomic_guard.hpp
+++ b/src/core/src/atomic_guard.hpp
@@ -12,8 +12,7 @@ class AtomicGuard {
 public:
     AtomicGuard(std::atomic_bool& b) : m_atomic(b) {
         bool exp = false;
-        while (m_atomic.load(std::memory_order_relaxed) ||
-               !m_atomic.compare_exchange_strong(exp, true)) {
+        while (m_atomic.load(std::memory_order_relaxed) || !m_atomic.compare_exchange_strong(exp, true)) {
             exp = false;
         }
     }


### PR DESCRIPTION
For _compare_exchange_strong_ the compiler most likely will generate the _lock cmpxchg_. 

The Intel reference says: 
_This instruction can be used with a LOCK prefix to allow the instruction to be executed atomically. To simplify the
interface to the processor’s bus, the destination operand receives a write cycle without regard to the result of the
comparison. The destination operand is written back if the comparison fails; otherwise, the source operand is
written into the destination. (The processor never produces a locked read without also producing a locked write.)_

So, to make it a bit faster we can first read the value, and only if the value is false do the CAS.  