### PR TITLE
Sporadic IEClassBasicTest.smoke_LoadNetworkToDefaultDeviceNoThrow failure

### DIFF
--- a/src/tests/functional/plugin/shared/include/behavior/ov_executable_network/exec_network_base.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_executable_network/exec_network_base.hpp
@@ -77,10 +77,13 @@ TEST_P(OVExecutableNetworkBaseTest, canLoadCorrectNetworkToGetExecutable) {
     EXPECT_NO_THROW(auto execNet = core->compile_model(function, targetDevice, configuration));
 }
 
-TEST(OVExecutableNetworkBaseTest, smoke_LoadNetworkToDefaultDeviceNoThrow) {
-    std::shared_ptr<ov::runtime::Core> core = utils::PluginCache::get().core();
-    std::shared_ptr<ov::Model> function = ngraph::builder::subgraph::makeConvPoolRelu();
-    EXPECT_NO_THROW(auto execNet = core->compile_model(function));
+TEST_P(OVExecutableNetworkBaseTest, LoadNetworkToDefaultDeviceNoThrow) {
+    if (targetDevice == "CPU") {
+        std::map<std::string, std::string> cpuOnlyConfig = {{"MULTI_DEVICE_PRIORITIES", "CPU"}};
+        EXPECT_NO_THROW(auto execNet = core->compile_model(function, cpuOnlyConfig));
+    } else {
+        EXPECT_NO_THROW(auto execNet = core->compile_model(function));
+    }
 }
 
 TEST_P(OVExecutableNetworkBaseTest, canLoadCorrectNetworkToGetExecutableWithIncorrectConfig) {

--- a/src/tests/functional/plugin/shared/include/behavior/plugin/core_integration.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/plugin/core_integration.hpp
@@ -886,12 +886,14 @@ TEST_P(IEClassQueryNetworkTest, QueryNetworkHETEROWithBigDeviceIDThrows) {
 // LoadNetwork
 //
 
-TEST(IEClassBasicTest, smoke_LoadNetworkToDefaultDeviceNoThrow) {
-  InferenceEngine::CNNNetwork actualCnnNetwork;
-  std::shared_ptr<ngraph::Function> actualNetwork = ngraph::builder::subgraph::makeSplitConvConcat();
-  ASSERT_NO_THROW(actualCnnNetwork = InferenceEngine::CNNNetwork(actualNetwork));
-  InferenceEngine::Core  ie = BehaviorTestsUtils::createIECoreWithTemplate();
-  ASSERT_NO_THROW(ie.LoadNetwork(actualCnnNetwork));
+TEST_P(IEClassNetworkTestP, LoadNetworkToDefaultDeviceNoThrow) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+    InferenceEngine::Core  ie = BehaviorTestsUtils::createIECoreWithTemplate();
+    if (deviceName == "CPU") {
+        ASSERT_NO_THROW(ie.LoadNetwork(actualCnnNetwork, {{"MULTI_DEVICE_PRIORITIES", "CPU"}}));
+    } else {
+        ASSERT_NO_THROW(ie.LoadNetwork(actualCnnNetwork));
+    }
 }
 
 TEST_P(IEClassNetworkTestP, LoadNetworkActualNoThrow) {


### PR DESCRIPTION
In order to avoid this sporadic crash issue,  adding the logic of loading network to CPU device only when running CPU functional test on CI.

Signed-off-by: Wang, Yang <yang4.wang@intel.com>

### Details:
 - Update the test cases for both the LoadNetwork and compile_model API

### Tickets:
 - https://jira.devtools.intel.com/browse/CVS-75022
