### PR TITLE
Add parameter to get  RT_cache searched result  when value is

### DIFF
--- a/src/plugins/intel_cpu/src/cache/cache_entry.h
+++ b/src/plugins/intel_cpu/src/cache/cache_entry.h
@@ -54,8 +54,9 @@ public:
             return {builder(key), CacheEntryBase::LookUpStatus::Miss};
         }
         auto retStatus = LookUpStatus::Hit;
-        ValType retVal = _impl.get(key);
-        if (retVal == ValType()) {
+        bool found = false;
+        ValType retVal = _impl.get(key, found);
+        if (!found) {
             retStatus = LookUpStatus::Miss;
             retVal = builder(key);
             _impl.put(key, retVal);

--- a/src/plugins/intel_cpu/src/cache/lru_cache.h
+++ b/src/plugins/intel_cpu/src/cache/lru_cache.h
@@ -54,13 +54,14 @@ public:
      * @return Value associated with the key or default constructed instance of the Value type.
      */
 
-    Value get(const Key &key) {
+    Value get(const Key &key, bool& found) {
         auto itr = _cacheMapper.find(key);
         if (itr == _cacheMapper.end()) {
+            found = false;
             return Value();
         }
-
         touch(itr->second);
+        found = true;
         return _lruList.front().second;
     }
 


### PR DESCRIPTION
Add parameter found to get  RT_cache searched result  when building returned nullptr
### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*
