### PR TITLE
gna version fix for deployment manager tool from 1377 to 1455

### DIFF
--- a/tools/deployment_manager/configs/linux.json
+++ b/tools/deployment_manager/configs/linux.json
@@ -72,7 +72,7 @@
       "files": [
         "runtime/lib/intel64/libgna.so",
         "runtime/lib/intel64/libgna.so.2",
-        "runtime/lib/intel64/libgna.so.3.0.0.1377",
+        "runtime/lib/intel64/libgna.so.3.0.0.1455",
         "runtime/lib/intel64/libov_intel_gna_plugin.so"
       ]
     },


### PR DESCRIPTION
 /openvino/cmake/dependencies.cmake  has GNA_VERSION "03.00.00.1455"
But in openvino/tools/deployment_manager/configs/linux.json
It is searching for libgna.so.3.0.0.1377
which is creating conflict
So fixing  this issue

Signed-off-by: aishwarya-manishi <aishwary.manishi@intel.com>

### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*
