### PR TITLE
[GPU] Enable unet2d enable on DG2

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/tensor.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/tensor.hpp
@@ -162,6 +162,7 @@ struct format {
         os_is_yx_osa2_isa8_osv8_isv2,
         os_is_yx_osa2_isa8_osv16_isv2,
         os_is_yx_osa2_isa8_osv16_isv4,
+        is_os_yx_isa2_osa8_isv8_osv2,
         is_o_yx_isv32,                                ///< format for weights for 1x1 MMAD convolutions
         is_o32_yx_isv32_swizzled_by_4,                ///< format for weights for 1x1 MMAD convolutions
         os_is_y_x8_osv8_isv4,                         ///< format for weights for 1x1 MMAD convolutions
@@ -301,6 +302,7 @@ struct format {
                 { os_is_zyx_isa8_osv16_isv4,                   { 1, 1, 3, 0, "oizyx",  "oixyz",      {{1, 8}, {0, 16}, {1, 4}}}},
                 { os_is_yx_osa4_isa8_osv8_isv4_swizzled_by_4,  { 1, 1, 2, 0, "oiyx",   "oixy?",      {{0, 32}, {1, 32}}}},
                 { os_is_zyx_osa4_isa8_osv8_isv4_swizzled_by_4, { 1, 1, 3, 0, "oizyx",  "oixyz",      {{0, 32}, {1, 32}}}},
+                { is_os_yx_isa2_osa8_isv8_osv2,                { 1, 1, 2, 0, "ioyx",   "ioxy?",      {{1, 16}, {0, 16}}}},
                 { is_o_yx_isv32,                               { 1, 1, 2, 0, "oyxi",   "oixy?",      {{1, 32}}}},
                 { is_o32_yx_isv32_swizzled_by_4,               { 1, 1, 2, 0, "oyxi",   "oixy?",      {}}},
                 { os_is_y_x8_osv8_isv4,                        { 1, 1, 2, 0, "oyxi",   "oixy?",      {}}},

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.cpp
@@ -117,9 +117,7 @@ protected:
         auto cldnn_prim = arg.get_primitive();
         auto weights_layout = arg.get_dependency(1).get_output_layout();
         auto grouped_weights = format::is_grouped(weights_layout.format) || arg.get_primitive()->grouped_weights_shape;
-        auto onednn_desc = onednn::get_format_by_desc(pd.weights_desc(0));
-        cldnn::format out_fmt = (onednn_desc != dnnl::memory::format_tag::undef) ? onednn::convert_format(onednn_desc, grouped_weights)
-                                                                                    : onednn::find_format(pd.weights_desc(0), grouped_weights);
+        cldnn::format out_fmt = onednn::find_format(pd.weights_desc(0), grouped_weights);
         kernel_selector::WeightsLayout reqLayout = to_weights_layout(out_fmt, cldnn_prim->grouped_weights_shape);
 
         set_params(arg, r_params);

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.cpp
@@ -117,7 +117,9 @@ protected:
         auto cldnn_prim = arg.get_primitive();
         auto weights_layout = arg.get_dependency(1).get_output_layout();
         auto grouped_weights = format::is_grouped(weights_layout.format) || arg.get_primitive()->grouped_weights_shape;
-        cldnn::format out_fmt = onednn::convert_format(onednn::get_format_by_desc(pd.weights_desc(0)), grouped_weights);
+        auto onednn_desc = onednn::get_format_by_desc(pd.weights_desc(0));
+        cldnn::format out_fmt = (onednn_desc != dnnl::memory::format_tag::undef) ? onednn::convert_format(onednn_desc, grouped_weights)
+                                                                                    : onednn::find_format(pd.weights_desc(0), grouped_weights);
         kernel_selector::WeightsLayout reqLayout = to_weights_layout(out_fmt, cldnn_prim->grouped_weights_shape);
 
         set_params(arg, r_params);

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.cpp
@@ -75,9 +75,7 @@ protected:
         auto cldnn_prim = arg.get_primitive();
         auto weights_layout = arg.get_dependency(1).get_output_layout();
         auto grouped_weights = format::is_grouped(weights_layout.format) || arg.get_primitive()->grouped_weights_shape;
-        auto onednn_desc = onednn::get_format_by_desc(pd.weights_desc(0));
-        cldnn::format out_fmt = (onednn_desc != dnnl::memory::format_tag::undef) ? onednn::convert_format(onednn_desc, grouped_weights)
-                                                                                    : onednn::find_format(pd.weights_desc(0), grouped_weights);
+        cldnn::format out_fmt = onednn::find_format(pd.weights_desc(0), grouped_weights);
         kernel_selector::WeightsLayout reqLayout = to_weights_layout(out_fmt, cldnn_prim->grouped_weights_shape);
 
         set_params(arg, r_params);

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.cpp
@@ -75,7 +75,9 @@ protected:
         auto cldnn_prim = arg.get_primitive();
         auto weights_layout = arg.get_dependency(1).get_output_layout();
         auto grouped_weights = format::is_grouped(weights_layout.format) || arg.get_primitive()->grouped_weights_shape;
-        cldnn::format out_fmt = onednn::convert_format(onednn::get_format_by_desc(pd.weights_desc(0)), grouped_weights);
+        auto onednn_desc = onednn::get_format_by_desc(pd.weights_desc(0));
+        cldnn::format out_fmt = (onednn_desc != dnnl::memory::format_tag::undef) ? onednn::convert_format(onednn_desc, grouped_weights)
+                                                                                    : onednn::find_format(pd.weights_desc(0), grouped_weights);
         kernel_selector::WeightsLayout reqLayout = to_weights_layout(out_fmt, cldnn_prim->grouped_weights_shape);
 
         set_params(arg, r_params);

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -64,9 +64,7 @@ protected:
 
         auto cldnn_prim = arg.get_primitive();
         auto weights_layout = arg.get_dependency(1).get_output_layout();
-        auto onednn_desc = onednn::get_format_by_desc(pd.weights_desc(0));
-        cldnn::format out_fmt = (onednn_desc != dnnl::memory::format_tag::undef) ? onednn::convert_format(onednn_desc)
-                                                                                    : onednn::find_format(pd.weights_desc(0));
+        cldnn::format out_fmt = onednn::find_format(pd.weights_desc(0));
         kernel_selector::WeightsLayout req_layout = to_weights_layout(out_fmt, false);
 
         // set engine info & forcing

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -64,7 +64,9 @@ protected:
 
         auto cldnn_prim = arg.get_primitive();
         auto weights_layout = arg.get_dependency(1).get_output_layout();
-        cldnn::format out_fmt = onednn::convert_format(onednn::get_format_by_desc(pd.weights_desc(0)));
+        auto onednn_desc = onednn::get_format_by_desc(pd.weights_desc(0));
+        cldnn::format out_fmt = (onednn_desc != dnnl::memory::format_tag::undef) ? onednn::convert_format(onednn_desc)
+                                                                                    : onednn::find_format(pd.weights_desc(0));
         kernel_selector::WeightsLayout req_layout = to_weights_layout(out_fmt, false);
 
         // set engine info & forcing

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
@@ -278,7 +278,7 @@ cldnn::format convert_format(dnnl::memory::format_tag fmt, bool is_grouped) {
         switch (fmt) {
         case dnnl::memory::format_tag::ab: return cldnn::format::oiyx;
         case dnnl::memory::format_tag::abcd: return cldnn::format::oiyx;
-        case dnnl::memory::format_tag::bacd: return cldnn::format::oiyx;
+        case dnnl::memory::format_tag::bacd: return cldnn::format::ioyx;
         case dnnl::memory::format_tag::BAcd16b16a: return cldnn::format::is_os_yx_isv16_osv16;
         case dnnl::memory::format_tag::ABcd16b16a: return cldnn::format::os_is_yx_isv16_osv16;
         case dnnl::memory::format_tag::abcde: return cldnn::format::oizyx;
@@ -295,6 +295,22 @@ cldnn::format convert_format(dnnl::memory::format_tag fmt, bool is_grouped) {
         case dnnl::memory::format_tag::ABcd2a8b16a4b: return cldnn::format::os_is_yx_osa2_isa8_osv16_isv4;
         case dnnl::memory::format_tag::ABcd2a8b16a2b: return cldnn::format::os_is_yx_osa2_isa8_osv16_isv2;
         default: throw std::runtime_error(std::string("Unsupported onednn fmt ") + dnnl_fmt_tag2str((dnnl_format_tag_t)fmt));
+        }
+    }
+}
+
+cldnn::format find_format(dnnl::memory::desc desc, bool is_grouped) {
+    if (is_grouped) {
+        throw std::runtime_error(std::string("Unsupported grouped onednn dnnl::memory::desc find_format"));
+    } else {
+        auto blk = desc.data.format_desc.blocking;
+
+        if (desc.data.ndims == 4 && desc.data.format_desc.blocking.inner_nblks == 4
+            && blk.inner_blks[0] == 2 && blk.inner_blks[1] == 8 && blk.inner_blks[2] == 8 && blk.inner_blks[3] == 2
+            && blk.inner_idxs[0] == 1 && blk.inner_idxs[1] == 0 && blk.inner_idxs[2] == 1 && blk.inner_idxs[3] == 0) {
+            return cldnn::format::is_os_yx_isa2_osa8_isv8_osv2;
+        } else {
+            throw std::runtime_error(std::string("Unsupported onednn dnnl::memory::desc find_format"));
         }
     }
 }

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
@@ -222,7 +222,7 @@ static bool isSame(dnnl::memory::desc desc, dnnl::memory::format_tag fmt) {
     return true;
 }
 
-dnnl::memory::format_tag get_format_by_desc(dnnl::memory::desc desc) {
+static dnnl::memory::format_tag get_format_by_desc(dnnl::memory::desc desc) {
     // TODO [OneDNN]: Previously it was a field of tdesc, but now the brute
     //                force search here. Please avoid of using this method.
     const auto ndims = desc.dims().size();
@@ -239,25 +239,8 @@ dnnl::memory::format_tag get_format_by_desc(dnnl::memory::desc desc) {
     return dnnl::memory::format_tag::undef;
 }
 
-dnnl::algorithm convert_activation_func(cldnn::activation_func func) {
-    switch (func) {
-        case cldnn::activation_func::relu: return dnnl::algorithm::eltwise_relu;
-        case cldnn::activation_func::relu_negative_slope: return dnnl::algorithm::eltwise_relu;
-        case cldnn::activation_func::gelu: return dnnl::algorithm::eltwise_gelu;
-        case cldnn::activation_func::elu: return dnnl::algorithm::eltwise_elu;
-        case cldnn::activation_func::mish: return dnnl::algorithm::eltwise_mish;
-        case cldnn::activation_func::swish: return dnnl::algorithm::eltwise_swish;
-        case cldnn::activation_func::hswish: return dnnl::algorithm::eltwise_hardswish;
-        case cldnn::activation_func::abs: return dnnl::algorithm::eltwise_abs;
-        case cldnn::activation_func::exp: return dnnl::algorithm::eltwise_exp;
-        case cldnn::activation_func::logistic: return dnnl::algorithm::eltwise_logistic;
-        case cldnn::activation_func::clamp: return dnnl::algorithm::eltwise_clip;
-        case cldnn::activation_func::hyperbolic_tan: return dnnl::algorithm::eltwise_tanh;
-        default: throw std::runtime_error("Unsupported activation func for onednn primitive " + std::to_string(static_cast<int>(func)));
-    }
-}
-
-cldnn::format convert_format(dnnl::memory::format_tag fmt, bool is_grouped) {
+// onednn -> cldnn
+static cldnn::format convert_format(dnnl::memory::format_tag fmt, bool is_grouped) {
     if (is_grouped) {
         switch (fmt) {
         case dnnl::memory::format_tag::abcde: return cldnn::format::goiyx;
@@ -300,18 +283,42 @@ cldnn::format convert_format(dnnl::memory::format_tag fmt, bool is_grouped) {
 }
 
 cldnn::format find_format(dnnl::memory::desc desc, bool is_grouped) {
-    if (is_grouped) {
-        throw std::runtime_error(std::string("Unsupported grouped onednn dnnl::memory::desc find_format"));
-    } else {
-        auto blk = desc.data.format_desc.blocking;
+    auto onednn_desc = get_format_by_desc(desc);
 
-        if (desc.data.ndims == 4 && desc.data.format_desc.blocking.inner_nblks == 4
-            && blk.inner_blks[0] == 2 && blk.inner_blks[1] == 8 && blk.inner_blks[2] == 8 && blk.inner_blks[3] == 2
-            && blk.inner_idxs[0] == 1 && blk.inner_idxs[1] == 0 && blk.inner_idxs[2] == 1 && blk.inner_idxs[3] == 0) {
-            return cldnn::format::is_os_yx_isa2_osa8_isv8_osv2;
+    if (onednn_desc != dnnl::memory::format_tag::undef) {
+        return convert_format(onednn_desc, is_grouped);
+    } else {
+        if (is_grouped) {
+            throw std::runtime_error(std::string("Unsupported grouped onednn dnnl::memory::desc find_format"));
         } else {
-            throw std::runtime_error(std::string("Unsupported onednn dnnl::memory::desc find_format"));
+            auto blk = desc.data.format_desc.blocking;
+
+            if (desc.data.ndims == 4 && desc.data.format_desc.blocking.inner_nblks == 4
+                && blk.inner_blks[0] == 2 && blk.inner_blks[1] == 8 && blk.inner_blks[2] == 8 && blk.inner_blks[3] == 2
+                && blk.inner_idxs[0] == 1 && blk.inner_idxs[1] == 0 && blk.inner_idxs[2] == 1 && blk.inner_idxs[3] == 0) {
+                return cldnn::format::is_os_yx_isa2_osa8_isv8_osv2;
+            } else {
+                throw std::runtime_error(std::string("Unsupported onednn dnnl::memory::desc find_format"));
+            }
         }
+    }
+}
+
+dnnl::algorithm convert_activation_func(cldnn::activation_func func) {
+    switch (func) {
+        case cldnn::activation_func::relu: return dnnl::algorithm::eltwise_relu;
+        case cldnn::activation_func::relu_negative_slope: return dnnl::algorithm::eltwise_relu;
+        case cldnn::activation_func::gelu: return dnnl::algorithm::eltwise_gelu;
+        case cldnn::activation_func::elu: return dnnl::algorithm::eltwise_elu;
+        case cldnn::activation_func::mish: return dnnl::algorithm::eltwise_mish;
+        case cldnn::activation_func::swish: return dnnl::algorithm::eltwise_swish;
+        case cldnn::activation_func::hswish: return dnnl::algorithm::eltwise_hardswish;
+        case cldnn::activation_func::abs: return dnnl::algorithm::eltwise_abs;
+        case cldnn::activation_func::exp: return dnnl::algorithm::eltwise_exp;
+        case cldnn::activation_func::logistic: return dnnl::algorithm::eltwise_logistic;
+        case cldnn::activation_func::clamp: return dnnl::algorithm::eltwise_clip;
+        case cldnn::activation_func::hyperbolic_tan: return dnnl::algorithm::eltwise_tanh;
+        default: throw std::runtime_error("Unsupported activation func for onednn primitive " + std::to_string(static_cast<int>(func)));
     }
 }
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/utils.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/utils.hpp
@@ -33,6 +33,7 @@ dnnl::algorithm convert_activation_func(cldnn::activation_func func);
 
 // onednn -> cldnn
 cldnn::format convert_format(dnnl::memory::format_tag fmt, bool is_grouped = false);
+cldnn::format find_format(dnnl::memory::desc desc, bool is_grouped = false);
 
 int64_t get_offset(dnnl::memory::desc desc);
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/utils.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/utils.hpp
@@ -28,11 +28,7 @@ dnnl::memory::dims flatten_tensor(cldnn::tensor t);
 dnnl::memory::data_type convert_data_type(cldnn::data_types dt);
 dnnl::memory::format_tag convert_data_format(cldnn::format fmt);
 dnnl::memory::desc layout_to_memory_desc(cldnn::layout l, dnnl::memory::format_tag target_fmt = dnnl::memory::format_tag::undef, bool flatten = false);
-dnnl::memory::format_tag get_format_by_desc(dnnl::memory::desc desc);
 dnnl::algorithm convert_activation_func(cldnn::activation_func func);
-
-// onednn -> cldnn
-cldnn::format convert_format(dnnl::memory::format_tag fmt, bool is_grouped = false);
 cldnn::format find_format(dnnl::memory::desc desc, bool is_grouped = false);
 
 int64_t get_offset(dnnl::memory::desc desc);

--- a/src/plugins/intel_gpu/src/graph/kernel_selector_helper.cpp
+++ b/src/plugins/intel_gpu/src/graph/kernel_selector_helper.cpp
@@ -389,6 +389,8 @@ kernel_selector::weights_layout to_weights_layout(format f, bool is_grouped) {
             return kernel_selector::weights_layout::g_os_zyx_is_osv32_isv16;
         case format::g_os_zyx_is_osv32_isv32:
             return kernel_selector::weights_layout::g_os_zyx_is_osv32_isv32;
+        case format::is_os_yx_isa2_osa8_isv8_osv2:
+            return kernel_selector::weights_layout::is_os_yx_isa2_osa8_isv8_osv2;
         default:
             throw std::invalid_argument("Unable to convert tensor layout " + fmt_to_str(f) + " to weights layout");
     }
@@ -506,6 +508,8 @@ cldnn::format::type from_weights_layout(kernel_selector::weights_layout l) {
             return cldnn::format::is_os_zyx_isv16_osv16;
         case kernel_selector::weights_layout::is_os_yx_isv16_osv16:
             return cldnn::format::is_os_yx_isv16_osv16;
+        case kernel_selector::weights_layout::is_os_yx_isa2_osa8_isv8_osv2:
+            return cldnn::format::is_os_yx_isa2_osa8_isv8_osv2;
         case kernel_selector::weights_layout::os_is_yx_osv8_isv2:
             return cldnn::format::os_is_yx_osv8_isv2;
         case kernel_selector::weights_layout::os_is_yx_osv8_isv4:

--- a/src/plugins/intel_gpu/src/kernel_selector/common/tensor_type.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/common/tensor_type.cpp
@@ -117,6 +117,7 @@ WeightsTensor::WeightsChannelArray WeightsTensor::weightsChannelArray {{
     { WeightsLayout::os_is_yx_isv16_osv16,                        {  0,  1, -1,   2,   3, -1 } },
     { WeightsLayout::is_os_zyx_isv16_osv16,                       {  0,  1,  2,   4,   3, -1 } },
     { WeightsLayout::is_os_yx_isv16_osv16,                        {  0,  1, -1,   3,   2, -1 } },
+    { WeightsLayout::is_os_yx_isa2_osa8_isv8_osv2,                {  0,  1, -1,   3,   2, -1 } },
     { WeightsLayout::os_is_osv32_isv32_swizzled_by_4,             { -1, -1, -1,   0,   1, -1 } },
     { WeightsLayout::os_is_zyx_isv8_osv16_isv2,                   {  0,  1,  2,   3,   4, -1 } },
     { WeightsLayout::os_is_yx_isv8_osv16_isv2,                    {  0,  1, -1,   2,   3, -1 } },
@@ -534,6 +535,7 @@ NDims WeightsTensor::GetSimpleDims(const std::vector<size_t>& d, WeightsLayout l
             newDims[3] = RoundUp(newDims[3], 32);
             break;
         case os_is_yx_osa2_isa8_osv8_isv2:
+        case is_os_yx_isa2_osa8_isv8_osv2:
             newDims[2] = RoundUp(newDims[2], 16);
             newDims[3] = RoundUp(newDims[3], 16);
             break;

--- a/src/plugins/intel_gpu/src/kernel_selector/common/tensor_type.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/common/tensor_type.h
@@ -116,6 +116,7 @@ enum WeightsLayout {
     os_is_yx_osa2_isa8_osv8_isv2,
     os_is_yx_osa2_isa8_osv16_isv4,
     os_is_yx_osa2_isa8_osv16_isv2,
+    is_os_yx_isa2_osa8_isv8_osv2,
     g_os_is_yx_osa2_isa8_osv16_isv4,
     g_os_is_yx_osa2_isa8_osv16_isv2,
     os_is_yx_osa4_isa8_osv8_isv4_swizzled_by_4,  // for MMAD convolution swizzled from ofm 0..7 to 0,4,8,12,16,20,24,28,

--- a/src/plugins/intel_gpu/src/kernel_selector/core/cl_kernels/include/batch_headers/fetch_weights.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/core/cl_kernels/include/batch_headers/fetch_weights.cl
@@ -745,29 +745,7 @@ inline uint get_g_os_is_yx_osa2_isa8_osv16_isv2(uint g, uint o, uint i, uint y, 
 inline uint get_g_is_os_yx_isa2_osa8_isv8_osv2(uint g, uint o, uint i, uint z, uint y, uint x,
                                                uint size_x, uint size_y,  uint size_z, uint size_ifm, uint size_ofm, uint offset)
 {
-    const uint isv_idx = i % 8;
-    const uint isa_idx = (i / 8) % 2;
-    const uint is_idx = (i / 16);
-    const uint osv_idx = o % 2;
-    const uint osa_idx = (o / 2) % 8;
-    const uint os_idx = (o / 16);
-
-    const uint ifm_16_aligned = ((size_ifm + 15)/16);
-    const uint ofm_16_aligned = ((size_ofm + 15)/16);
-
-    size_t idx = offset +
-                 osv_idx +
-                 isv_idx * 2 +
-                 osa_idx * 8 * 2 +
-                 isa_idx * 8 * 16 +
-                 x * 16 * 16 +
-                 y * size_x * 16 * 16 +
-                 z * size_y * size_x * 16 * 16 +
-                 os_idx * 16 * 16 * size_x * size_y * size_z +
-                 is_idx * 16 * 16 * ofm_16_aligned * size_x * size_y * size_z +
-                 g * 16 * 16 * ifm_16_aligned * ofm_16_aligned * size_x * size_y * size_z;
-
-    return idx;
+    return get_g_os_is_yx_osa2_isa8_osv8_isv2(g, i, o, z, y, x, size_x, size_y, size_z, size_ofm, size_ifm, offset);
 }
 
 #define GET_FILTER_OS_IS_YX_OSA4_ISA8_OSV8_ISV4_INDEX(prefix, o, i, y, x) \

--- a/src/plugins/intel_gpu/src/kernel_selector/core/cl_kernels/include/batch_headers/fetch_weights.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/core/cl_kernels/include/batch_headers/fetch_weights.cl
@@ -742,6 +742,34 @@ inline uint get_g_os_is_yx_osa2_isa8_osv16_isv2(uint g, uint o, uint i, uint y, 
     return idx;
 }
 
+inline uint get_g_is_os_yx_isa2_osa8_isv8_osv2(uint g, uint o, uint i, uint z, uint y, uint x,
+                                               uint size_x, uint size_y,  uint size_z, uint size_ifm, uint size_ofm, uint offset)
+{
+    const uint isv_idx = i % 8;
+    const uint isa_idx = (i / 8) % 2;
+    const uint is_idx = (i / 16);
+    const uint osv_idx = o % 2;
+    const uint osa_idx = (o / 2) % 8;
+    const uint os_idx = (o / 16);
+
+    const uint ifm_16_aligned = ((size_ifm + 15)/16);
+    const uint ofm_16_aligned = ((size_ofm + 15)/16);
+
+    size_t idx = offset +
+                 osv_idx +
+                 isv_idx * 2 +
+                 osa_idx * 8 * 2 +
+                 isa_idx * 8 * 16 +
+                 x * 16 * 16 +
+                 y * size_x * 16 * 16 +
+                 z * size_y * size_x * 16 * 16 +
+                 os_idx * 16 * 16 * size_x * size_y * size_z +
+                 is_idx * 16 * 16 * ofm_16_aligned * size_x * size_y * size_z +
+                 g * 16 * 16 * ifm_16_aligned * ofm_16_aligned * size_x * size_y * size_z;
+
+    return idx;
+}
+
 #define GET_FILTER_OS_IS_YX_OSA4_ISA8_OSV8_ISV4_INDEX(prefix, o, i, y, x) \
     get_g_os_is_yx_osa4_isa8_osv8_isv4(                        \
         0, o, i, 0, y, x,                                                 \
@@ -893,6 +921,16 @@ inline uint get_g_os_is_yx_osa2_isa8_osv16_isv2(uint g, uint o, uint i, uint y, 
         CAT(prefix, _SIZE_Z),                                                               \
         CAT(prefix, _IFM_NUM),                                                              \
         CAT(prefix, _OFM_NUM),                                                              \
+        CAT(prefix, _OFFSET))
+
+#define GET_FILTER_IS_OS_YX_ISA2_OSA8_ISV8_OSV2_INDEX(prefix, o, i, y, x) \
+    get_g_is_os_yx_isa2_osa8_isv8_osv2(                        \
+        0, o, i, 0, y, x,                                                 \
+        CAT(prefix, _SIZE_X),                                             \
+        CAT(prefix, _SIZE_Y),                                             \
+        1,                                                                \
+        CAT(prefix, _IFM_NUM),                                            \
+        CAT(prefix, _OFM_NUM),                                            \
         CAT(prefix, _OFFSET))
 
 

--- a/src/plugins/intel_gpu/src/kernel_selector/core/cl_kernels/reorder_weights.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/core/cl_kernels/reorder_weights.cl
@@ -203,6 +203,8 @@ inline uint FUNC(get_output_index)(uint g, uint o, uint i, uint z, uint y, uint 
     return GET_FILTER_OS_IS_YX_ISA8_OSV8_ISV4_SWIZZLED_BY_4_INDEX(OUTPUT, g, o, i, y, x);
 #elif defined OUTPUT_LAYOUT_OS_IS_YX_OSA2_ISA8_OSV8_ISV2
     return GET_FILTER_OS_IS_YX_OSA2_ISA8_OSV8_ISV2_INDEX(OUTPUT, o, i, y, x);
+#elif defined OUTPUT_LAYOUT_IS_OS_YX_ISA2_OSA8_ISV8_OSV2
+    return GET_FILTER_IS_OS_YX_ISA2_OSA8_ISV8_OSV2_INDEX(OUTPUT, o, i, y, x);
 #elif defined OUTPUT_LAYOUT_OS_IS_YX_OSA4_ISA8_OSV8_ISV2
     return GET_FILTER_OS_IS_YX_OSA4_ISA8_OSV8_ISV2_INDEX(OUTPUT, o, i, y, x);
 #elif defined OUTPUT_LAYOUT_OS_IS_ZYX_OSA4_ISA8_OSV8_ISV2

--- a/src/plugins/intel_gpu/src/kernel_selector/core/kernel_selector_common.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/core/kernel_selector_common.cpp
@@ -395,6 +395,7 @@ std::string toString(WeightsLayout layout) {
         case WeightsLayout::os_is_yx_osa2_isa8_osv16_isv2:               return "OS_IS_YX_OSA2_ISA8_OSV16_ISV2";
         case WeightsLayout::g_os_is_yx_osa2_isa8_osv16_isv2:             return "G_OS_IS_YX_OSA2_ISA8_OSV16_ISV2";
         case WeightsLayout::os_is_yx_osa2_isa8_osv8_isv2:                return "OS_IS_YX_OSA2_ISA8_OSV8_ISV2";
+        case WeightsLayout::is_os_yx_isa2_osa8_isv8_osv2:                return "IS_OS_YX_ISA2_OSA8_ISV8_OSV2";
         case WeightsLayout::g_os_is_yx_isv16_osv16:                      return "G_OS_IS_YX_ISV16_OSV16";
         case WeightsLayout::g_os_is_yx_osv16_isv4:                       return "G_OS_IS_YX_OSV16_ISV4";
         case WeightsLayout::g_os_is_zyx_osv16_isv16:                     return "G_OS_IS_ZYX_OSV16_ISV16";


### PR DESCRIPTION
Because unsupported oneDNN tag issue, one of target network fails on DG2.
Add is_os_yx_isa2_osa8_isv8_osv2 format, which is used in
weight reorder, Fix issue.

Signed-off-by: hyunback <hyunback.kim@intel.com>


