### PR TITLE
[PYTHON] Add python APIs for loadNetwork and compile_network without device name

### DIFF
--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pxd
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pxd
@@ -57,7 +57,7 @@ cdef class IECore:
     cpdef IENetwork read_network(self, model : [str, bytes, os.PathLike],
                                  weights : [str, bytes, os.PathLike] = ?, bool init_from_buffer = ?)
     cpdef ExecutableNetwork load_network(self, network: [IENetwork, str],
-                                         str device_name, config = ?, int num_requests = ?)
+                                         device_name: [str, NoneType], config = ?, int num_requests = ?)
     cpdef ExecutableNetwork import_network(self, str model_file, str device_name, config = ?, int num_requests = ?)
 
 

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pxd
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pxd
@@ -57,7 +57,7 @@ cdef class IECore:
     cpdef IENetwork read_network(self, model : [str, bytes, os.PathLike],
                                  weights : [str, bytes, os.PathLike] = ?, bool init_from_buffer = ?)
     cpdef ExecutableNetwork load_network(self, network: [IENetwork, str],
-                                         device_name: [str, NoneType], config = ?, int num_requests = ?)
+                                         device_name = ?, config = ?, int num_requests = ?)
     cpdef ExecutableNetwork import_network(self, str model_file, str device_name, config = ?, int num_requests = ?)
 
 

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pyx
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pyx
@@ -414,14 +414,14 @@ cdef class IECore:
                 net.impl = self.impl.readNetwork(model_, weights_)
         return net
 
-    cpdef ExecutableNetwork load_network(self, network: [IENetwork, str], str device_name, config=None, int num_requests=1):
+    cpdef ExecutableNetwork load_network(self, network: [IENetwork, str], device_name: [str, NoneType], config=None, int num_requests=1):
         """Loads a network that was read from the Intermediate Representation (IR) to the plugin with specified device name
         and creates an :class:`ExecutableNetwork` object of the :class:`IENetwork` class.
         You can create as many networks as you need and use them simultaneously (up to the limitation of the hardware
         resources).
         
         :param network: A valid :class:`IENetwork` instance. Model file name .xml, .onnx can also be passed as argument
-        :param device_name: A device name of a target plugin
+        :param device_name: A device name of a target plugin, if none it will use AUTO device.
         :param config: A dictionary of plugin configuration keys and their values
         :param num_requests: A positive integer value of infer requests to be created.
         Number of infer requests is limited by device capabilities. Value `0` indicates that optimal number of infer requests will be created.
@@ -445,14 +445,23 @@ cdef class IECore:
                              "or zero for auto detection")
         if config:
             c_config = dict_to_c_map(config)
-        c_device_name = device_name.encode()
+        if device_name:
+            c_device_name = device_name.encode()
         if isinstance(network, str):
             c_network_path = network.encode()
-            with nogil:
-                exec_net.impl = move(self.impl.loadNetworkFromFile(c_network_path, c_device_name, c_config, num_requests))
+            if device_name:
+                with nogil:
+                    exec_net.impl = move(self.impl.loadNetworkFromFile(c_network_path, c_device_name, c_config, num_requests))
+            else:
+                with nogil:
+                    exec_net.impl = move(self.impl.loadNetworkFromFile(c_network_path, c_config, num_requests))
         else:
-            with nogil:
-                exec_net.impl = move(self.impl.loadNetwork((<IENetwork>network).impl, c_device_name, c_config, num_requests))
+            if device_name:
+                with nogil:
+                    exec_net.impl = move(self.impl.loadNetwork((<IENetwork>network).impl, c_device_name, c_config, num_requests))
+            else:
+                with nogil:
+                    exec_net.impl = move(self.impl.loadNetwork((<IENetwork>network).impl, c_config, num_requests))
         return exec_net
 
     cpdef ExecutableNetwork import_network(self, str model_file, str device_name, config=None, int num_requests=1):

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pyx
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api.pyx
@@ -414,14 +414,14 @@ cdef class IECore:
                 net.impl = self.impl.readNetwork(model_, weights_)
         return net
 
-    cpdef ExecutableNetwork load_network(self, network: [IENetwork, str], device_name: [str, NoneType], config=None, int num_requests=1):
+    cpdef ExecutableNetwork load_network(self, network: [IENetwork, str], device_name=None, config=None, int num_requests=1):
         """Loads a network that was read from the Intermediate Representation (IR) to the plugin with specified device name
         and creates an :class:`ExecutableNetwork` object of the :class:`IENetwork` class.
         You can create as many networks as you need and use them simultaneously (up to the limitation of the hardware
         resources).
         
         :param network: A valid :class:`IENetwork` instance. Model file name .xml, .onnx can also be passed as argument
-        :param device_name: A device name of a target plugin, if none it will use AUTO device.
+        :param device_name: A device name of a target plugin, if no device_name is set then it will use AUTO device as default.
         :param config: A dictionary of plugin configuration keys and their values
         :param num_requests: A positive integer value of infer requests to be created.
         Number of infer requests is limited by device capabilities. Value `0` indicates that optimal number of infer requests will be created.

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.cpp
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.cpp
@@ -617,7 +617,7 @@ std::unique_ptr<InferenceEnginePython::IEExecNetwork> InferenceEnginePython::IEC
     exec_network->createInferRequests(num_requests);
 
     return exec_network;
-    }
+}
 
 std::unique_ptr<InferenceEnginePython::IEExecNetwork> InferenceEnginePython::IECore::loadNetworkFromFile(
     const std::string& modelPath,
@@ -639,8 +639,7 @@ std::unique_ptr<InferenceEnginePython::IEExecNetwork> InferenceEnginePython::IEC
     int num_requests) {
     auto exec_network =
         InferenceEnginePython::make_unique<InferenceEnginePython::IEExecNetwork>(modelPath, num_requests);
-    exec_network->actual =
-        std::make_shared<InferenceEngine::ExecutableNetwork>(actual.LoadNetwork(modelPath, config));
+    exec_network->actual = std::make_shared<InferenceEngine::ExecutableNetwork>(actual.LoadNetwork(modelPath, config));
     exec_network->createInferRequests(num_requests);
 
     return exec_network;

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.cpp
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.cpp
@@ -606,6 +606,19 @@ std::unique_ptr<InferenceEnginePython::IEExecNetwork> InferenceEnginePython::IEC
     return exec_network;
 }
 
+std::unique_ptr<InferenceEnginePython::IEExecNetwork> InferenceEnginePython::IECore::loadNetwork(
+    IENetwork network,
+    const std::map<std::string, std::string>& config,
+    int num_requests) {
+    auto exec_network =
+        InferenceEnginePython::make_unique<InferenceEnginePython::IEExecNetwork>(network.name, num_requests);
+    exec_network->actual =
+        std::make_shared<InferenceEngine::ExecutableNetwork>(actual.LoadNetwork(*network.actual, config));
+    exec_network->createInferRequests(num_requests);
+
+    return exec_network;
+    }
+
 std::unique_ptr<InferenceEnginePython::IEExecNetwork> InferenceEnginePython::IECore::loadNetworkFromFile(
     const std::string& modelPath,
     const std::string& deviceName,
@@ -615,6 +628,19 @@ std::unique_ptr<InferenceEnginePython::IEExecNetwork> InferenceEnginePython::IEC
         InferenceEnginePython::make_unique<InferenceEnginePython::IEExecNetwork>(modelPath, num_requests);
     exec_network->actual =
         std::make_shared<InferenceEngine::ExecutableNetwork>(actual.LoadNetwork(modelPath, deviceName, config));
+    exec_network->createInferRequests(num_requests);
+
+    return exec_network;
+}
+
+std::unique_ptr<InferenceEnginePython::IEExecNetwork> InferenceEnginePython::IECore::loadNetworkFromFile(
+    const std::string& modelPath,
+    const std::map<std::string, std::string>& config,
+    int num_requests) {
+    auto exec_network =
+        InferenceEnginePython::make_unique<InferenceEnginePython::IEExecNetwork>(modelPath, num_requests);
+    exec_network->actual =
+        std::make_shared<InferenceEngine::ExecutableNetwork>(actual.LoadNetwork(modelPath, config));
     exec_network->createInferRequests(num_requests);
 
     return exec_network;

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.hpp
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl.hpp
@@ -167,9 +167,16 @@ struct IECore {
                                                                       const std::string& deviceName,
                                                                       const std::map<std::string, std::string>& config,
                                                                       int num_requests);
+    std::unique_ptr<InferenceEnginePython::IEExecNetwork> loadNetwork(IENetwork network,
+                                                                      const std::map<std::string, std::string>& config,
+                                                                      int num_requests);
     std::unique_ptr<InferenceEnginePython::IEExecNetwork> loadNetworkFromFile(
         const std::string& modelPath,
         const std::string& deviceName,
+        const std::map<std::string, std::string>& config,
+        int num_requests);
+    std::unique_ptr<InferenceEnginePython::IEExecNetwork> loadNetworkFromFile(
+        const std::string& modelPath,
         const std::map<std::string, std::string>& config,
         int num_requests);
     std::unique_ptr<InferenceEnginePython::IEExecNetwork> importNetwork(

--- a/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl_defs.pxd
+++ b/inference-engine/ie_bridges/python/src/openvino/inference_engine/ie_api_impl_defs.pxd
@@ -209,7 +209,11 @@ cdef extern from "ie_api_impl.hpp" namespace "InferenceEnginePython":
         IENetwork readNetwork(const string& modelPath,uint8_t*bin, size_t bin_size) nogil except +
         unique_ptr[IEExecNetwork] loadNetwork(IENetwork network, const string deviceName,
                                               const map[string, string] & config, int num_requests) nogil except +
+        unique_ptr[IEExecNetwork] loadNetwork(IENetwork network,
+                                              const map[string, string] & config, int num_requests) nogil except +
         unique_ptr[IEExecNetwork] loadNetworkFromFile(const string & modelPath, const string & deviceName,
+                                              const map[string, string] & config, int num_requests) nogil except +
+        unique_ptr[IEExecNetwork] loadNetworkFromFile(const string & modelPath,
                                               const map[string, string] & config, int num_requests) nogil except +
         unique_ptr[IEExecNetwork] importNetwork(const string & modelFIle, const string & deviceName,
                                                 const map[string, string] & config, int num_requests) except +

--- a/inference-engine/ie_bridges/python/tests/test_IECore.py
+++ b/inference-engine/ie_bridges/python/tests/test_IECore.py
@@ -47,12 +47,21 @@ def test_load_network(device):
     exec_net = ie.load_network(net, device)
     assert isinstance(exec_net, ExecutableNetwork)
 
+def test_load_network_without_device():
+    ie = IECore()
+    net = ie.read_network(model=test_net_xml, weights=test_net_bin)
+    exec_net = ie.load_network(net, None)
+    assert isinstance(exec_net, ExecutableNetwork)
 
 def test_load_network_from_file(device):
     ie = IECore()
     exec_net = ie.load_network(test_net_xml, device)
     assert isinstance(exec_net, ExecutableNetwork)
 
+def test_load_network_from_file_without_device():
+    ie = IECore()
+    exec_net = ie.load_network(test_net_xml, None)
+    assert isinstance(exec_net, ExecutableNetwork)
 
 @pytest.mark.skipif(os.environ.get("TEST_DEVICE", "CPU") != "CPU", reason="Device independent test")
 def test_load_network_wrong_device():

--- a/inference-engine/ie_bridges/python/tests/test_IECore.py
+++ b/inference-engine/ie_bridges/python/tests/test_IECore.py
@@ -50,7 +50,7 @@ def test_load_network(device):
 def test_load_network_without_device():
     ie = IECore()
     net = ie.read_network(model=test_net_xml, weights=test_net_bin)
-    exec_net = ie.load_network(net, None)
+    exec_net = ie.load_network(net)
     assert isinstance(exec_net, ExecutableNetwork)
 
 def test_load_network_from_file(device):
@@ -60,7 +60,7 @@ def test_load_network_from_file(device):
 
 def test_load_network_from_file_without_device():
     ie = IECore()
-    exec_net = ie.load_network(test_net_xml, None)
+    exec_net = ie.load_network(test_net_xml)
     assert isinstance(exec_net, ExecutableNetwork)
 
 @pytest.mark.skipif(os.environ.get("TEST_DEVICE", "CPU") != "CPU", reason="Device independent test")

--- a/src/bindings/python/src/openvino/runtime/ie_api.py
+++ b/src/bindings/python/src/openvino/runtime/ie_api.py
@@ -115,6 +115,14 @@ class Core(CoreBase):
             super().compile_model(model, device_name, {} if config is None else config)
         )
 
+    def compile_model(
+        self, model: Union[Model, str], config: dict = None
+    ) -> CompiledModel:
+        """Compile a model from given Model with AUTO plugin as device device."""
+        return CompiledModel(
+            super().compile_model(model, {} if config is None else config)
+        )
+
     def import_model(
         self, model_file: str, device_name: str, config: dict = None
     ) -> CompiledModel:

--- a/src/bindings/python/src/openvino/runtime/ie_api.py
+++ b/src/bindings/python/src/openvino/runtime/ie_api.py
@@ -108,20 +108,17 @@ class Core(CoreBase):
     """Core wrapper."""
 
     def compile_model(
-        self, model: Union[Model, str], device_name: str, config: dict = None
+        self, model: Union[Model, str], device_name: str = None, config: dict = None
     ) -> CompiledModel:
         """Compile a model from given Model."""
-        return CompiledModel(
-            super().compile_model(model, device_name, {} if config is None else config)
-        )
-
-    def compile_model(
-        self, model: Union[Model, str], config: dict = None
-    ) -> CompiledModel:
-        """Compile a model from given Model with AUTO plugin as device device."""
-        return CompiledModel(
-            super().compile_model(model, {} if config is None else config)
-        )
+        if device_name is None:
+            return CompiledModel(
+                super().compile_model(model, {} if config is None else config)
+            )
+        else:
+            return CompiledModel(
+                super().compile_model(model, device_name, {} if config is None else config)
+            )
 
     def import_model(
         self, model_file: str, device_name: str, config: dict = None

--- a/src/bindings/python/src/openvino/runtime/ie_api.py
+++ b/src/bindings/python/src/openvino/runtime/ie_api.py
@@ -115,10 +115,10 @@ class Core(CoreBase):
             return CompiledModel(
                 super().compile_model(model, {} if config is None else config)
             )
-        else:
-            return CompiledModel(
-                super().compile_model(model, device_name, {} if config is None else config)
-            )
+
+        return CompiledModel(
+            super().compile_model(model, device_name, {} if config is None else config)
+        )
 
     def import_model(
         self, model_file: str, device_name: str, config: dict = None

--- a/src/bindings/python/src/pyopenvino/core/core.cpp
+++ b/src/bindings/python/src/pyopenvino/core/core.cpp
@@ -40,12 +40,12 @@ void regclass_Core(py::module m) {
             py::arg("device_name"),
             py::arg("config") = py::dict());
 
-    cls.def("compile_model",
-            (ov::runtime::CompiledModel(
-                ov::runtime::Core::*)(const std::shared_ptr<const ov::Model>&, const ConfigMap&)) &
-                ov::runtime::Core::compile_model,
-            py::arg("model"),
-            py::arg("config") = py::dict());
+    cls.def(
+        "compile_model",
+        (ov::runtime::CompiledModel(ov::runtime::Core::*)(const std::shared_ptr<const ov::Model>&, const ConfigMap&)) &
+            ov::runtime::Core::compile_model,
+        py::arg("model"),
+        py::arg("config") = py::dict());
 
     cls.def(
         "compile_model",
@@ -55,12 +55,11 @@ void regclass_Core(py::module m) {
         py::arg("device_name"),
         py::arg("config") = py::dict());
 
-    cls.def(
-        "compile_model",
-        (ov::runtime::CompiledModel(ov::runtime::Core::*)(const std::string&, const ConfigMap&)) &
-            ov::runtime::Core::compile_model,
-        py::arg("model_path"),
-        py::arg("config") = py::dict());
+    cls.def("compile_model",
+            (ov::runtime::CompiledModel(ov::runtime::Core::*)(const std::string&, const ConfigMap&)) &
+                ov::runtime::Core::compile_model,
+            py::arg("model_path"),
+            py::arg("config") = py::dict());
 
     cls.def("get_versions", &ov::runtime::Core::get_versions, py::arg("device_name"));
 

--- a/src/bindings/python/src/pyopenvino/core/core.cpp
+++ b/src/bindings/python/src/pyopenvino/core/core.cpp
@@ -40,12 +40,26 @@ void regclass_Core(py::module m) {
             py::arg("device_name"),
             py::arg("config") = py::dict());
 
+    cls.def("compile_model",
+            (ov::runtime::CompiledModel(
+                ov::runtime::Core::*)(const std::shared_ptr<const ov::Model>&, const ConfigMap&)) &
+                ov::runtime::Core::compile_model,
+            py::arg("model"),
+            py::arg("config") = py::dict());
+
     cls.def(
         "compile_model",
         (ov::runtime::CompiledModel(ov::runtime::Core::*)(const std::string&, const std::string&, const ConfigMap&)) &
             ov::runtime::Core::compile_model,
         py::arg("model_path"),
         py::arg("device_name"),
+        py::arg("config") = py::dict());
+
+    cls.def(
+        "compile_model",
+        (ov::runtime::CompiledModel(ov::runtime::Core::*)(const std::string&, const ConfigMap&)) &
+            ov::runtime::Core::compile_model,
+        py::arg("model_path"),
         py::arg("config") = py::dict());
 
     cls.def("get_versions", &ov::runtime::Core::get_versions, py::arg("device_name"));

--- a/src/bindings/python/tests/test_inference_engine/test_core.py
+++ b/src/bindings/python/tests/test_inference_engine/test_core.py
@@ -63,6 +63,11 @@ def test_compile_model(device):
     exec_net = ie.compile_model(func, device)
     assert isinstance(exec_net, CompiledModel)
 
+def test_compile_model_without_device():
+    ie = Core()
+    func = ie.read_model(model=test_net_xml, weights=test_net_bin)
+    exec_net = ie.compile_model(func)
+    assert isinstance(exec_net, CompiledModel)
 
 def test_read_model_from_ir():
     core = Core()

--- a/src/bindings/python/tests/test_inference_engine/test_core.py
+++ b/src/bindings/python/tests/test_inference_engine/test_core.py
@@ -65,10 +65,10 @@ def test_compile_model(device):
 
 
 def test_compile_model_without_device():
-    ie = Core()
-    func = ie.read_model(model=test_net_xml, weights=test_net_bin)
-    exec_net = ie.compile_model(func)
-    assert isinstance(exec_net, CompiledModel)
+    core = Core()
+    model = core.read_model(model=test_net_xml, weights=test_net_bin)
+    compiled_model = core.compile_model(model)
+    assert isinstance(compiled_model, CompiledModel)
 
 
 def test_read_model_from_ir():

--- a/src/bindings/python/tests/test_inference_engine/test_core.py
+++ b/src/bindings/python/tests/test_inference_engine/test_core.py
@@ -63,11 +63,13 @@ def test_compile_model(device):
     exec_net = ie.compile_model(func, device)
     assert isinstance(exec_net, CompiledModel)
 
+
 def test_compile_model_without_device():
     ie = Core()
     func = ie.read_model(model=test_net_xml, weights=test_net_bin)
     exec_net = ie.compile_model(func)
     assert isinstance(exec_net, CompiledModel)
+
 
 def test_read_model_from_ir():
     core = Core()


### PR DESCRIPTION
Details:
       Add Python APIs for loadNetwork and compile_network without device name

Tickets:
      https://jira.devtools.intel.com/browse/CVS-75249
