### PR TITLE
[GPU] Don't optimize crop if its user is a reshape that can be optimized

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -269,6 +269,10 @@ void concat_in_place_optimization::optimize_cascade(concatenation_node& node, st
 
 }  // namespace
 
+static bool can_reshape_be_optimized(const reshape_node& node) {
+    return node.is_in_place() && node.get_fused_activations_funcs().empty();
+}
+
 // ToDo remove friendship relation from  program_node
 void prepare_buffer_fusing::run(program& p) {
     bool is_debug = p.get_options().get<build_option_type::debug>()->enabled();
@@ -310,6 +314,11 @@ void prepare_buffer_fusing::run(program& p) {
                     return;
                 if (user->is_type<loop>() || user->is_type<non_max_suppression>())
                     return;
+                if (user->is_type<reshape>()) {
+                    auto& reshape_node = user->as<reshape>();
+                    if (can_reshape_be_optimized(reshape_node))
+                        return;
+                }
             }
 
             if (node.get_dependencies().size() == 1 && node.get_users().size() > 0) {
@@ -387,10 +396,7 @@ void prepare_buffer_fusing::run(program& p) {
             continue;
         program_helpers::do_for_types<reshape>(*node, [&p](reshape_node& node) {
             node.get_output_layout();
-            if (node.is_in_place() && node.get_fused_activations_funcs().empty())
-                node.can_be_optimized(true);
-            else
-                node.can_be_optimized(false);
+            node.can_be_optimized(can_reshape_be_optimized(node));
         });
     }
 }


### PR DESCRIPTION
Crop uses more eltwise assign kernel which yields better performance than reshape_ref.
