### PR TITLE
[GPU] Fixed invalid vector element access in reduce test

### DIFF
--- a/src/tests/functional/shared_test_classes/src/subgraph/reduce_eltwise.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/reduce_eltwise.cpp
@@ -56,7 +56,8 @@ void ReduceEltwiseTest::SetUp() {
 
     auto reduce = std::make_shared<ngraph::opset3::ReduceSum>(paramOuts[0], reductionAxesNode, keepDims);
 
-    std::vector<size_t> constShape(reduce.get()->get_output_size(), 1);
+    std::vector<size_t> constShape(reduce.get()->get_output_partial_shape(0).rank().get_length(), 1);
+    ASSERT_GT(constShape.size(), 2);
     constShape[2] = inputShape.back();
     auto constant = ngraph::builder::makeConstant<float>(ngPrc, constShape, {}, true);
     auto eltw = ngraph::builder::makeEltwise(reduce, constant, ngraph::helpers::EltwiseTypes::MULTIPLY);


### PR DESCRIPTION
### Details:
- `get_output_size()` usage seems to be incorrect here as it return count of outputs, not output shape.

### Tickets:
 - 74362
