### PR TITLE
Fix output layout of tf yolo models converted with transformations config

### DIFF
--- a/tools/mo/openvino/tools/mo/front/YOLO.py
+++ b/tools/mo/openvino/tools/mo/front/YOLO.py
@@ -23,7 +23,7 @@ class YoloRegionAddon(FrontReplacementFromConfigFileGeneral):
         op_outputs = [n for n, d in graph.nodes(data=True) if 'op' in d and d['op'] == 'Result']
         for op_output in op_outputs:
             last_node = Node(graph, op_output).in_node(0)
-            op_params = dict(name=last_node.id + '/YoloRegion', axis=1, end_axis=-1)
+            op_params = dict(name=last_node.id + '/YoloRegion', axis=1, end_axis=-1, nchw_layout=True)
             op_params.update(replacement_descriptions)
             region_layer = RegionYoloOp(graph, op_params)
             region_layer_node = region_layer.create_node([last_node])
@@ -51,7 +51,7 @@ class YoloV3RegionAddon(FrontReplacementFromConfigFileGeneral):
                             'Refer to documentation about converting YOLO models for more information.'.format(
                     ', '.join(replacement_descriptions['entry_points']), input_node_name))
             last_node = Node(graph, input_node_name).in_node(0)
-            op_params = dict(name=last_node.id + '/YoloRegion', axis=1, end_axis=-1, do_softmax=0)
+            op_params = dict(name=last_node.id + '/YoloRegion', axis=1, end_axis=-1, do_softmax=0, nchw_layout=True)
             op_params.update(replacement_descriptions)
             if 'masks' in op_params:
                 op_params['mask'] = op_params['masks'][i]


### PR DESCRIPTION
Description:
RegionYOLO operation inserted with transformation enabled by transformation config is inserted in the correct layout, so it shouldn't be reverted by old API map

Ticket: 74941


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list
* [x]  Guide on how to convert the **public** model N/A: no new models were enabled
* [x]  User guide update N/A