### PR TITLE
Python bindings: expose InputTensorInfo::set_memory_type

### DIFF
--- a/src/bindings/python/src/pyopenvino/graph/preprocess/pre_post_process.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/preprocess/pre_post_process.cpp
@@ -269,6 +269,9 @@ static void regclass_graph_InputTensorInfo(py::module m) {
                 const std::vector<std::string>& sub_names = {}) {
                  return &me.set_color_format(format, sub_names);
              });
+    info.def("set_memory_type", [](ov::preprocess::InputTensorInfo& me, const std::string& memory_type) {
+        return &me.set_memory_type(memory_type);
+    });
 }
 
 static void regclass_graph_OutputTensorInfo(py::module m) {

--- a/src/bindings/python/tests/test_ngraph/test_preprocess.py
+++ b/src/bindings/python/tests/test_ngraph/test_preprocess.py
@@ -243,7 +243,7 @@ def test_ngraph_preprocess_set_memory_type():
     p.input().tensor().set_memory_type("some_memory_type")
     function = p.build()
 
-    assert any(key for key in function.input().rt_info if 'memory_type' in key)
+    assert any(key for key in function.input().rt_info if "memory_type" in key)
 
 
 @pytest.mark.parametrize(

--- a/src/bindings/python/tests/test_ngraph/test_preprocess.py
+++ b/src/bindings/python/tests/test_ngraph/test_preprocess.py
@@ -232,6 +232,20 @@ def test_ngraph_preprocess_set_shape():
     assert np.equal(output, expected_output).all()
 
 
+def test_ngraph_preprocess_set_memory_type():
+    shape = [1, 1, 1]
+    parameter_a = ops.parameter(shape, dtype=np.int32, name="A")
+    op = ops.relu(parameter_a)
+    model = op
+    function = Model(model, [parameter_a], "TestFunction")
+
+    p = PrePostProcessor(function)
+    p.input().tensor().set_memory_type("some_memory_type")
+    function = p.build()
+
+    assert any(key for key in function.input().rt_info if 'memory_type' in key)
+
+
 @pytest.mark.parametrize(
     "algorithm, color_format1, color_format2, is_failing",
     [(ResizeAlgorithm.RESIZE_LINEAR, ColorFormat.UNDEFINED, ColorFormat.BGR, True),


### PR DESCRIPTION
### Details:
 - Python bindings: expose InputTensorInfo::set_memory_type
 - This method can be used when 'GPU' is a target inference device

### Tickets:
 - 75713
