### PR TITLE
Fix for benchmark_app: set model stream flags

### DIFF
--- a/samples/cpp/benchmark_app/main.cpp
+++ b/samples/cpp/benchmark_app/main.cpp
@@ -532,7 +532,7 @@ int main(int argc, char* argv[]) {
             next_step();
             auto startTime = Time::now();
 
-            std::ifstream modelStream(FLAGS_m);
+            std::ifstream modelStream(FLAGS_m, std::ios_base::binary | std::ios_base::in);
             if (!modelStream.is_open()) {
                 throw std::runtime_error("Cannot open model file " + FLAGS_m);
             }


### PR DESCRIPTION
### Details:
- It's needed to set flags for stream used for importing model
- https://github.com/intel-innersource/applications.ai.vpu-accelerators.vpux-plugin/pull/357 - benchmarkApp falls on Windows w/o these changes

### Tickets:
CVS-71021
