### PR TITLE
Disable smoke_LoadNetworkToDefaultDeviceNoThrow test case in CPU plugin

### DIFF
--- a/src/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
+++ b/src/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
@@ -174,6 +174,8 @@ std::vector<std::string> disabledTestPatterns() {
         R"(smoke_ConversionLayerTest/ConversionLayerTest.CompareWithRefs.*UNSPECIFIED.*)",
         // Issue:
         R"(.*smoke_VariadicSplit4D_CPU_zero_dims.*)",
+        // Issue: encounter the sporadic crash in CI
+        R"(.*smoke_LoadNetworkToDefaultDeviceNoThrow*)"
     };
 
 #define FIX_62820 0

--- a/src/tests/functional/plugin/shared/include/behavior/ov_executable_network/exec_network_base.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_executable_network/exec_network_base.hpp
@@ -78,6 +78,7 @@ TEST_P(OVExecutableNetworkBaseTest, canLoadCorrectNetworkToGetExecutable) {
 }
 
 TEST(OVExecutableNetworkBaseTest, smoke_LoadNetworkToDefaultDeviceNoThrow) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     std::shared_ptr<ov::runtime::Core> core = utils::PluginCache::get().core();
     std::shared_ptr<ov::Model> function = ngraph::builder::subgraph::makeConvPoolRelu();
     EXPECT_NO_THROW(auto execNet = core->compile_model(function));

--- a/src/tests/functional/plugin/shared/include/behavior/plugin/core_integration.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/plugin/core_integration.hpp
@@ -887,11 +887,12 @@ TEST_P(IEClassQueryNetworkTest, QueryNetworkHETEROWithBigDeviceIDThrows) {
 //
 
 TEST(IEClassBasicTest, smoke_LoadNetworkToDefaultDeviceNoThrow) {
-  InferenceEngine::CNNNetwork actualCnnNetwork;
-  std::shared_ptr<ngraph::Function> actualNetwork = ngraph::builder::subgraph::makeSplitConvConcat();
-  ASSERT_NO_THROW(actualCnnNetwork = InferenceEngine::CNNNetwork(actualNetwork));
-  InferenceEngine::Core  ie = BehaviorTestsUtils::createIECoreWithTemplate();
-  ASSERT_NO_THROW(ie.LoadNetwork(actualCnnNetwork));
+    SKIP_IF_CURRENT_TEST_IS_DISABLED();
+    InferenceEngine::CNNNetwork actualCnnNetwork;
+    std::shared_ptr<ngraph::Function> actualNetwork = ngraph::builder::subgraph::makeSplitConvConcat();
+    ASSERT_NO_THROW(actualCnnNetwork = InferenceEngine::CNNNetwork(actualNetwork));
+    InferenceEngine::Core  ie = BehaviorTestsUtils::createIECoreWithTemplate();
+    ASSERT_NO_THROW(ie.LoadNetwork(actualCnnNetwork));
 }
 
 TEST_P(IEClassNetworkTestP, LoadNetworkActualNoThrow) {


### PR DESCRIPTION
Disable the test case  named `smoke_LoadNetworkToDefaultDeviceNoThrow`  that may cause the sporadic crash issue when CPU plugin executes this test case.

Signed-off-by: Wang, Yang <yang4.wang@intel.com>

### Details:
 - Add macro SKIP_IF_CURRENT_TEST_IS_DISABLED() in those 2 test cases.
 - Disable this test case in CPU plugin to fix sporadic crash issue in CI

### Tickets:
 - https://jira.devtools.intel.com/browse/CVS-75022
 - https://jira.devtools.intel.com/browse/CVS-75560
