### PR TITLE
Temporarily disable onnx_if_inside_if unit test on CPU

### DIFF
--- a/src/core/tests/runtime/interpreter/unit_test.manifest
+++ b/src/core/tests/runtime/interpreter/unit_test.manifest
@@ -73,6 +73,9 @@ INTERPRETER.onnx_model_dequantize_linear_1d_zero_scale_uint8_negative_axis
 INTERPRETER.onnx_if_inside_if
 INTERPRETER.onnx_if_inside_loop
 
+# Assertion failed: vector subscript out of range. Fails with Windows debug build only
+IE_CPU.onnx_if_inside_if
+
 # Legacy tests with unsupported features from opset4 LSTM/GRU/RNN
 # Peepholes input unsupported
 onnx_model_lstm_fwd_with_clip_peepholes


### PR DESCRIPTION
### Details:
 - Debug Windows build pipeline is broken on master because of "onnx_if_inside_if" failed test. Most likely the issue was introduced in https://github.com/openvinotoolkit/openvino/pull/9524
