### PR TITLE
[CPU] Port descriptor

### DIFF
--- a/src/plugins/intel_cpu/src/memory_desc/blocked_memory_desc.cpp
+++ b/src/plugins/intel_cpu/src/memory_desc/blocked_memory_desc.cpp
@@ -19,10 +19,6 @@ bool BlockedMemoryDesc::isCompatibleInternal(const BlockedMemoryDesc &rhs, uint3
         return false;
     }
 
-    if (!dimsEqualWeak(this->getStrides(), rhs.getStrides())) {
-        return false;
-    }
-
     auto& thisStrides = this->getStrides();
     auto& rhsStrides = rhs.getStrides();
 

--- a/src/plugins/intel_cpu/src/memory_desc/blocked_memory_desc.cpp
+++ b/src/plugins/intel_cpu/src/memory_desc/blocked_memory_desc.cpp
@@ -7,7 +7,7 @@
 
 using namespace MKLDNNPlugin;
 
-bool BlockedMemoryDesc::isCompatibleInternal(const BlockedMemoryDesc &rhs, uint32_t cmpMask) const {
+bool BlockedMemoryDesc::isCompatibleInternal(const BlockedMemoryDesc &rhs, CmpMask cmpMask) const {
     if (this->getShape() != rhs.getShape() || this->getPrecision() != rhs.getPrecision())
         return false;
 
@@ -26,7 +26,7 @@ bool BlockedMemoryDesc::isCompatibleInternal(const BlockedMemoryDesc &rhs, uint3
         return false;
 
     for (size_t i = 0; i < thisStrides.size(); i++) {
-        if ((cmpMask & (1u << i)) && !dimsEqualWeak(thisStrides[i], rhsStrides[i]))
+        if (cmpMask.test(i) && !dimsEqualWeak(thisStrides[i], rhsStrides[i]))
             return false;
     }
 
@@ -34,8 +34,7 @@ bool BlockedMemoryDesc::isCompatibleInternal(const BlockedMemoryDesc &rhs, uint3
         return false;
     }
 
-    constexpr uint32_t offsetMask = 0x80000000u;
-    if (cmpMask & offsetMask) {
+    if (cmpMask.test(BLOCKED_DESC_OFFSET_MASK_POS)) {
         return dimsEqualWeak(this->getOffsetPadding(), rhs.getOffsetPadding());
     }
 

--- a/src/plugins/intel_cpu/src/memory_desc/blocked_memory_desc.h
+++ b/src/plugins/intel_cpu/src/memory_desc/blocked_memory_desc.h
@@ -4,11 +4,21 @@
 
 #pragma once
 
+#include <bitset>
+
 #include "cpu_memory_desc.h"
 
 namespace MKLDNNPlugin {
 
+#define BLOCKED_DESC_FULL_MASK 0xffffffff
+#define BLOCKED_DESC_EMPTY_MASK 0x0
+#define BLOCKED_DESC_SKIP_OFFSET_MASK 0x7fffffff
+#define BLOCKED_DESC_OFFSET_MASK_POS 31
+
 class BlockedMemoryDesc : public virtual MemoryDesc {
+public:
+    using CmpMask = std::bitset<32>;
+
 public:
     BlockedMemoryDesc() {}
 
@@ -69,7 +79,7 @@ public:
      *
      * @return the result of the compatibility check
      */
-    virtual bool isCompatible(const BlockedMemoryDesc &rhs, uint32_t cmpMask) const = 0;
+    virtual bool isCompatible(const BlockedMemoryDesc &rhs, CmpMask cmpMask) const = 0;
 
     virtual ~BlockedMemoryDesc() = default;
 
@@ -83,7 +93,7 @@ protected:
      * Doesn't perform descs specific attributes check
      * @return true if compatible, otherwise false
      */
-    bool isCompatibleInternal(const BlockedMemoryDesc &rhs, uint32_t compMask = 0xffffffff) const;
+    bool isCompatibleInternal(const BlockedMemoryDesc &rhs, CmpMask cmpMask = BLOCKED_DESC_FULL_MASK) const;
 
     mutable VectorDims blockedDims;
     mutable VectorDims strides;

--- a/src/plugins/intel_cpu/src/memory_desc/blocked_memory_desc.h
+++ b/src/plugins/intel_cpu/src/memory_desc/blocked_memory_desc.h
@@ -62,20 +62,14 @@ public:
     virtual size_t getPaddedElementsCount() const = 0;
 
     /**
-     * @brief Creates MemoryDesc with offsetPadding and strides of UNDEFINED_DIM size
+     * @brief Performs masked compatibility check, where the mask defines which strides to check,
+     * the most significant bit defines whether to check offset compatibility.
+     * @param rhs - desc to compare to
+     * @param cmpMask - a bit mask that defines compatibility check rules
      *
-     * @return pointer to the new MemoryDesc
+     * @return the result of the compatibility check
      */
-    virtual MemoryDescPtr cloneWithUndefStridesAndOffset() const = 0;
-
-    /**
-     * @brief Creates MemoryDesc with offsetPadding of 0 size and default strides
-     *
-     * @return pointer to the new MemoryDesc
-     */
-    virtual MemoryDescPtr cloneWithDefaultStridesAndOffset() const = 0;
-
-    virtual bool isCompatible(const BlockedMemoryDesc &rhs, uint32_t compMask) const = 0;
+    virtual bool isCompatible(const BlockedMemoryDesc &rhs, uint32_t cmpMask) const = 0;
 
     virtual ~BlockedMemoryDesc() = default;
 

--- a/src/plugins/intel_cpu/src/memory_desc/blocked_memory_desc.h
+++ b/src/plugins/intel_cpu/src/memory_desc/blocked_memory_desc.h
@@ -75,6 +75,10 @@ public:
      */
     virtual MemoryDescPtr cloneWithDefaultStridesAndOffset() const = 0;
 
+    virtual bool isCompatible(const BlockedMemoryDesc &rhs, uint32_t compMask) const = 0;
+
+    virtual ~BlockedMemoryDesc() = default;
+
     std::string serializeFormat() const override;
 
 protected:
@@ -85,7 +89,7 @@ protected:
      * Doesn't perform descs specific attributes check
      * @return true if compatible, otherwise false
      */
-    bool isCompatible(const BlockedMemoryDesc &rhs) const;
+    bool isCompatibleInternal(const BlockedMemoryDesc &rhs, uint32_t compMask = 0xffffffff) const;
 
     mutable VectorDims blockedDims;
     mutable VectorDims strides;

--- a/src/plugins/intel_cpu/src/memory_desc/cpu_blocked_memory_desc.cpp
+++ b/src/plugins/intel_cpu/src/memory_desc/cpu_blocked_memory_desc.cpp
@@ -309,20 +309,6 @@ size_t CpuBlockedMemoryDesc::getPaddedElementsCount() const {
     return std::accumulate(blockedDims.begin(), blockedDims.end(), size_t{1}, std::multiplies<size_t>());
 }
 
-MemoryDescPtr CpuBlockedMemoryDesc::cloneWithUndefStridesAndOffset() const {
-    const auto orderSize = getOrder().size();
-    CpuBlockedMemoryDescPtr newDesc = std::make_shared<CpuBlockedMemoryDesc>(*this);
-    newDesc->strides = VectorDims(orderSize, Shape::UNDEFINED_DIM);
-    newDesc->offsetPadding = Shape::UNDEFINED_DIM;
-    newDesc->offsetPaddingToData =  VectorDims(orderSize, 0);
-    newDesc->status = descStatus::Undefined;
-    return newDesc;
-}
-
-MemoryDescPtr CpuBlockedMemoryDesc::cloneWithDefaultStridesAndOffset() const {
-    return std::make_shared<CpuBlockedMemoryDesc>(getPrecision(), getShape(), getBlockDims(), getOrder());
-}
-
 MemoryDescPtr CpuBlockedMemoryDesc::cloneWithNewPrecision(const InferenceEngine::Precision prec) const {
     auto newDesc = std::make_shared<CpuBlockedMemoryDesc>(*this);
     newDesc->setPrecision(prec);

--- a/src/plugins/intel_cpu/src/memory_desc/cpu_blocked_memory_desc.cpp
+++ b/src/plugins/intel_cpu/src/memory_desc/cpu_blocked_memory_desc.cpp
@@ -99,12 +99,23 @@ bool CpuBlockedMemoryDesc::isCompatible(const MemoryDesc& rhs) const {
     }
 }
 
-bool CpuBlockedMemoryDesc::isCompatible(const CpuBlockedMemoryDesc &rhs) const {
-    return BlockedMemoryDesc::isCompatible(rhs);
+bool CpuBlockedMemoryDesc::isCompatible(const CpuBlockedMemoryDesc &rhs, uint32_t cmpMask) const {
+    return BlockedMemoryDesc::isCompatibleInternal(rhs, cmpMask);
 }
 
-bool CpuBlockedMemoryDesc::isCompatible(const DnnlBlockedMemoryDesc &rhs) const {
-    return rhs.isCompatible(*this);
+bool CpuBlockedMemoryDesc::isCompatible(const DnnlBlockedMemoryDesc &rhs, uint32_t cmpMask) const {
+    return rhs.isCompatible(*this, cmpMask);
+}
+
+bool CpuBlockedMemoryDesc::isCompatible(const BlockedMemoryDesc &rhs, uint32_t cmpMask) const {
+    const BlockedMemoryDesc* pRhs = &rhs;
+    if (auto cpuBlkDesc = dynamic_cast<const CpuBlockedMemoryDesc*>(pRhs)) {
+        return isCompatible(*cpuBlkDesc, cmpMask);
+    } else if (auto dnnlBlkDesc = dynamic_cast<const DnnlBlockedMemoryDesc*>(pRhs)) {
+        return isCompatible(*dnnlBlkDesc, cmpMask);
+    } else {
+        return false;
+    }
 }
 
 bool CpuBlockedMemoryDesc::canComputeMemSizeZeroDims() const {

--- a/src/plugins/intel_cpu/src/memory_desc/cpu_blocked_memory_desc.cpp
+++ b/src/plugins/intel_cpu/src/memory_desc/cpu_blocked_memory_desc.cpp
@@ -99,15 +99,15 @@ bool CpuBlockedMemoryDesc::isCompatible(const MemoryDesc& rhs) const {
     }
 }
 
-bool CpuBlockedMemoryDesc::isCompatible(const CpuBlockedMemoryDesc &rhs, uint32_t cmpMask) const {
+bool CpuBlockedMemoryDesc::isCompatible(const CpuBlockedMemoryDesc &rhs, CmpMask cmpMask) const {
     return BlockedMemoryDesc::isCompatibleInternal(rhs, cmpMask);
 }
 
-bool CpuBlockedMemoryDesc::isCompatible(const DnnlBlockedMemoryDesc &rhs, uint32_t cmpMask) const {
+bool CpuBlockedMemoryDesc::isCompatible(const DnnlBlockedMemoryDesc &rhs, CmpMask cmpMask) const {
     return rhs.isCompatible(*this, cmpMask);
 }
 
-bool CpuBlockedMemoryDesc::isCompatible(const BlockedMemoryDesc &rhs, uint32_t cmpMask) const {
+bool CpuBlockedMemoryDesc::isCompatible(const BlockedMemoryDesc &rhs, CmpMask cmpMask) const {
     const BlockedMemoryDesc* pRhs = &rhs;
     if (auto cpuBlkDesc = dynamic_cast<const CpuBlockedMemoryDesc*>(pRhs)) {
         return isCompatible(*cpuBlkDesc, cmpMask);

--- a/src/plugins/intel_cpu/src/memory_desc/cpu_blocked_memory_desc.h
+++ b/src/plugins/intel_cpu/src/memory_desc/cpu_blocked_memory_desc.h
@@ -77,10 +77,6 @@ public:
 
     size_t getPaddedElementsCount() const override;
 
-    MemoryDescPtr cloneWithUndefStridesAndOffset() const override;
-
-    MemoryDescPtr cloneWithDefaultStridesAndOffset() const override;
-
     MemoryDescPtr cloneWithNewPrecision(const InferenceEngine::Precision prec) const override;
 
 private:

--- a/src/plugins/intel_cpu/src/memory_desc/cpu_blocked_memory_desc.h
+++ b/src/plugins/intel_cpu/src/memory_desc/cpu_blocked_memory_desc.h
@@ -22,9 +22,9 @@ public:
     }
 
     bool isCompatible(const MemoryDesc& rhs) const override;
-    bool isCompatible(const BlockedMemoryDesc& rhs, uint32_t cmpMask) const override;
-    bool isCompatible(const CpuBlockedMemoryDesc &rhs, uint32_t cmpMask = 0xffffffff) const;
-    bool isCompatible(const DnnlBlockedMemoryDesc &rhs, uint32_t cmpMask = 0xffffffff) const;
+    bool isCompatible(const BlockedMemoryDesc& rhs, CmpMask cmpMask) const override;
+    bool isCompatible(const CpuBlockedMemoryDesc &rhs, CmpMask cmpMask = BLOCKED_DESC_FULL_MASK) const;
+    bool isCompatible(const DnnlBlockedMemoryDesc &rhs, CmpMask cmpMask = BLOCKED_DESC_FULL_MASK) const;
 
     InferenceEngine::Precision getPrecision() const override {
         return precision;

--- a/src/plugins/intel_cpu/src/memory_desc/cpu_blocked_memory_desc.h
+++ b/src/plugins/intel_cpu/src/memory_desc/cpu_blocked_memory_desc.h
@@ -22,8 +22,9 @@ public:
     }
 
     bool isCompatible(const MemoryDesc& rhs) const override;
-    bool isCompatible(const CpuBlockedMemoryDesc &rhs) const;
-    bool isCompatible(const DnnlBlockedMemoryDesc &rhs) const;
+    bool isCompatible(const BlockedMemoryDesc& rhs, uint32_t cmpMask) const override;
+    bool isCompatible(const CpuBlockedMemoryDesc &rhs, uint32_t cmpMask = 0xffffffff) const;
+    bool isCompatible(const DnnlBlockedMemoryDesc &rhs, uint32_t cmpMask = 0xffffffff) const;
 
     InferenceEngine::Precision getPrecision() const override {
         return precision;

--- a/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.cpp
+++ b/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.cpp
@@ -263,7 +263,8 @@ bool DnnlBlockedMemoryDesc::isCompatible(const DnnlBlockedMemoryDesc& rhs, uint3
         return false;
 
     int stride_start = 0;
-    while ((cmpMask & (1u << stride_start)) && stride_start < wrappedThis.ndims()) {
+    auto invertCmpMask = ~cmpMask;
+    while ((invertCmpMask & (1u << stride_start)) && stride_start <= wrappedThis.ndims()) {
         ++stride_start;
     }
 

--- a/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.cpp
+++ b/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.cpp
@@ -262,17 +262,13 @@ bool DnnlBlockedMemoryDesc::isCompatible(const DnnlBlockedMemoryDesc& rhs, CmpMa
     if (one_of(wrappedThis.format_kind(), format_kind::undef, format_kind::any))
         return false;
 
-    int stride_start = 0;
-    while (!cmpMask.test(stride_start) && stride_start <= wrappedThis.ndims()) {
-        ++stride_start;
-    }
-
-    bool checkOffset = cmpMask.test(BLOCKED_DESC_OFFSET_MASK_POS);
+    const uint64_t stride_mask = (0xffffffffffffffff << cmpMask.size()) | cmpMask.to_ullong();
+    const bool checkOffset = cmpMask.test(BLOCKED_DESC_OFFSET_MASK_POS);
 
     const auto thisExtra = this->desc.data.extra;
     const auto rhsExtra = rhs.desc.data.extra;
     return this->getOrder() == rhs.getOrder() && (thisExtra.flags == rhsExtra.flags && thisExtra.compensation_mask == rhsExtra.compensation_mask &&
-           thisExtra.scale_adjust == rhsExtra.scale_adjust) && wrappedThis.similar_to(wrappedRhs, true, true, 0, stride_start, true, checkOffset);
+           thisExtra.scale_adjust == rhsExtra.scale_adjust) && wrappedThis.similar_to(wrappedRhs, true, true, 0, true, checkOffset, stride_mask);
 }
 
 static VectorDims extractOrder(const mkldnn::memory::desc& desc) {

--- a/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.cpp
+++ b/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.cpp
@@ -617,24 +617,6 @@ void DnnlBlockedMemoryDesc::initOffsetPadding() {
     offsetPaddingToData = VectorDims(std::begin(desc.data.padded_offsets), std::begin(desc.data.padded_offsets) + getOrder().size());
 }
 
-MemoryDescPtr DnnlBlockedMemoryDesc::cloneWithUndefStridesAndOffset() const {
-    DnnlBlockedMemoryDescPtr newDesc = std::make_shared<DnnlBlockedMemoryDesc>(*this);
-    auto &dnnlBlkDesc = newDesc->desc.data.format_desc.blocking;
-    std::fill(std::begin(dnnlBlkDesc.strides), std::begin(dnnlBlkDesc.strides) + getShape().getRank(), DNNL_RUNTIME_DIM_VAL);
-    newDesc->initStrides();
-    newDesc->desc.data.offset0 = DNNL_RUNTIME_DIM_VAL;
-    newDesc->status = descStatus::Undefined;
-    return newDesc;
-}
-
-MemoryDescPtr DnnlBlockedMemoryDesc::cloneWithDefaultStridesAndOffset() const {
-    DnnlBlockedMemoryDescPtr newDesc = std::make_shared<DnnlBlockedMemoryDesc>(*this);
-    newDesc->recomputeDefaultStrides();
-    newDesc->desc.data.offset0 = 0;
-    newDesc->status = descStatus::Unknown;
-    return newDesc;
-}
-
 MemoryDescPtr DnnlBlockedMemoryDesc::cloneWithNewPrecision(const InferenceEngine::Precision prec) const {
     auto newDesc = std::make_shared<DnnlBlockedMemoryDesc>(*this);
     newDesc->setPrecision(prec);

--- a/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.h
+++ b/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.h
@@ -58,10 +58,6 @@ public:
 
     size_t getPaddedElementsCount() const override;
 
-    MemoryDescPtr cloneWithUndefStridesAndOffset() const override;
-
-    MemoryDescPtr cloneWithDefaultStridesAndOffset() const override;
-
     MemoryDescPtr cloneWithNewPrecision(const InferenceEngine::Precision prec) const override;
 
 private:

--- a/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.h
+++ b/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.h
@@ -22,9 +22,9 @@ public:
     }
 
     bool isCompatible(const MemoryDesc& rhs) const override;
-    bool isCompatible(const BlockedMemoryDesc& rhs, uint32_t cmpMask) const override;
-    bool isCompatible(const CpuBlockedMemoryDesc &rhs, uint32_t cmpMask = 0xffffffff) const;
-    bool isCompatible(const DnnlBlockedMemoryDesc &rhs, uint32_t cmpMask = 0xffffffff) const;
+    bool isCompatible(const BlockedMemoryDesc& rhs, CmpMask cmpMask) const override;
+    bool isCompatible(const CpuBlockedMemoryDesc &rhs, CmpMask cmpMask = BLOCKED_DESC_FULL_MASK) const;
+    bool isCompatible(const DnnlBlockedMemoryDesc &rhs, CmpMask cmpMask = BLOCKED_DESC_FULL_MASK) const;
 
     const VectorDims& getBlockDims() const override {
         return blockedDims;

--- a/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.h
+++ b/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.h
@@ -22,8 +22,9 @@ public:
     }
 
     bool isCompatible(const MemoryDesc& rhs) const override;
-    bool isCompatible(const DnnlBlockedMemoryDesc& rhs) const;
-    bool isCompatible(const CpuBlockedMemoryDesc& rhs) const;
+    bool isCompatible(const BlockedMemoryDesc& rhs, uint32_t cmpMask) const override;
+    bool isCompatible(const CpuBlockedMemoryDesc &rhs, uint32_t cmpMask = 0xffffffff) const;
+    bool isCompatible(const DnnlBlockedMemoryDesc &rhs, uint32_t cmpMask = 0xffffffff) const;
 
     const VectorDims& getBlockDims() const override {
         return blockedDims;

--- a/src/plugins/intel_cpu/src/mkldnn_edge.cpp
+++ b/src/plugins/intel_cpu/src/mkldnn_edge.cpp
@@ -220,7 +220,7 @@ MKLDNNEdge::ReorderStatus MKLDNNEdge::needReorder() {
     bool optimized = false;
     auto inputPortDesc = getInputPortDesc();
     auto outPortDesc = getOutputPortDesc();
-    if (!outPortDesc->compare(*inputPortDesc)) {
+    if (!outPortDesc->isCompatible(*inputPortDesc)) {
         if (isPhycicalMemCompatible(*inputPortDesc->getMemDesc(), *outPortDesc->getMemDesc()) && !getParent()->isConstant()) {
             optimized = true;
         } else {

--- a/src/plugins/intel_cpu/src/mkldnn_edge.h
+++ b/src/plugins/intel_cpu/src/mkldnn_edge.h
@@ -7,6 +7,7 @@
 #include <ie_blob.h>
 #include "cpu_shape.h"
 #include "memory_desc/cpu_memory_desc.h"
+#include "nodes/node_config.h"
 #include "mkldnn_weights_cache.hpp"
 
 #include <map>
@@ -92,6 +93,9 @@ private:
 
     const MemoryDesc& getInputDesc() const;
     const MemoryDesc& getOutputDesc() const;
+    PortDescBaseCPtr getInputPortDesc() const;
+    PortDescBaseCPtr getOutputPortDesc() const;
+
     const MemoryDesc& getDesc() const;
     bool enforceReorder();
 

--- a/src/plugins/intel_cpu/src/mkldnn_graph_dumper.cpp
+++ b/src/plugins/intel_cpu/src/mkldnn_graph_dumper.cpp
@@ -76,11 +76,11 @@ std::map<std::string, std::string> extract_node_metadata(const MKLDNNNodePtr &no
     auto outDescs = node->getSelectedPrimitiveDescriptor()->getConfig().outConfs;
 
     if (!outDescs.empty()) {
-        outputLayoutsStr = outDescs[0].desc->serializeFormat();
+        outputLayoutsStr = outDescs[0].getMemDesc()->serializeFormat();
 
         bool isAllEqual = true;
         for (size_t i = 1; i < outDescs.size(); i++) {
-            if (outDescs[i - 1].desc->serializeFormat() != outDescs[i].desc->serializeFormat()) {
+            if (outDescs[i - 1].getMemDesc()->serializeFormat() != outDescs[i].getMemDesc()->serializeFormat()) {
                 isAllEqual = false;
                 break;
             }
@@ -89,7 +89,7 @@ std::map<std::string, std::string> extract_node_metadata(const MKLDNNNodePtr &no
         // If all output layouts are the same, we store the name only once
         if (!isAllEqual) {
             for (size_t i = 1; i < outDescs.size(); i++) {
-                outputLayoutsStr += "," + outDescs[i].desc->serializeFormat();
+                outputLayoutsStr += "," + outDescs[i].getMemDesc()->serializeFormat();
             }
         }
     } else {
@@ -241,14 +241,14 @@ void serializeToCout(const MKLDNNGraph &graph) {
         if (nodeDesc) {
             auto& inConfs = nodeDesc->getConfig().inConfs;
             if (!inConfs.empty()) {
-                std::cout << "in: " << inConfs.front().desc->getPrecision().name()
-                          << "/l=" << inConfs.front().desc->serializeFormat()
+                std::cout << "in: " << inConfs.front().getMemDesc()->getPrecision().name()
+                          << "/l=" << inConfs.front().getMemDesc()->serializeFormat()
                           << "; ";
             }
             auto& outConfs = nodeDesc->getConfig().outConfs;
             if (!outConfs.empty()) {
-                std::cout << "out: " << outConfs.front().desc->getPrecision().name()
-                          << "/l=" << outConfs.front().desc->serializeFormat();
+                std::cout << "out: " << outConfs.front().getMemDesc()->getPrecision().name()
+                          << "/l=" << outConfs.front().getMemDesc()->serializeFormat();
             }
         }
         std::cout << " ]"  << std::endl;

--- a/src/plugins/intel_cpu/src/mkldnn_graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/mkldnn_graph_optimizer.cpp
@@ -1889,10 +1889,10 @@ void MKLDNNGraphOptimizer::MergeTransposeAndReorder(MKLDNNGraph &graph) {
         }
 
         auto& transposeOrder = transposeNode->getOrder();
-        auto layoutOrder = transposeNode->getSelectedPrimitiveDescriptor()->getConfig().outConfs[0].desc->as<BlockedMemoryDesc>()->getOrder();
+        auto layoutOrder = transposeNode->getSelectedPrimitiveDescriptor()->getConfig().outConfs[0].getMemDesc()->as<BlockedMemoryDesc>()->getOrder();
 
-        auto inBlockedDesc = reorderNode->getSelectedPrimitiveDescriptor()->getConfig().inConfs[0].desc->as<BlockedMemoryDesc>();
-        auto outBlockedDesc = reorderNode->getSelectedPrimitiveDescriptor()->getConfig().outConfs[0].desc->as<BlockedMemoryDesc>();
+        auto inBlockedDesc = reorderNode->getSelectedPrimitiveDescriptor()->getConfig().inConfs[0].getMemDesc()->as<BlockedMemoryDesc>();
+        auto outBlockedDesc = reorderNode->getSelectedPrimitiveDescriptor()->getConfig().outConfs[0].getMemDesc()->as<BlockedMemoryDesc>();
 
         auto& inOrder = inBlockedDesc->getOrder();
         auto& outOrder = outBlockedDesc->getOrder();
@@ -1971,8 +1971,8 @@ void MKLDNNGraphOptimizer::MergeTransposeAndReorder(MKLDNNGraph &graph) {
         graph.DropNode(parentNode);
         graph.DropNode(childNode);
 
-        auto& inDesc = parentNode->getSelectedPrimitiveDescriptor()->getConfig().inConfs[0].desc;
-        auto& outDesc = childNode->getSelectedPrimitiveDescriptor()->getConfig().outConfs[0].desc;
+        auto inDesc = parentNode->getSelectedPrimitiveDescriptor()->getConfig().inConfs[0].getMemDesc();
+        auto outDesc = childNode->getSelectedPrimitiveDescriptor()->getConfig().outConfs[0].getMemDesc();
 
         auto inPrec = inDesc->getPrecision();
         auto outPrec = outDesc->getPrecision();

--- a/src/plugins/intel_cpu/src/mkldnn_node.cpp
+++ b/src/plugins/intel_cpu/src/mkldnn_node.cpp
@@ -927,9 +927,12 @@ MemoryDescPtr MKLDNNNode::getDefinedInputDesc(const NodeConfig &config, size_t i
 //        return config.inConfs[idx].getMemDesc();
 //    }
 //
-//    if (config.inConfs[idx].inPlace() >= 0) {
-//        return getDefinedOutputDesc(config, static_cast<size_t>(config.inConfs[idx].inPlace()));
-//    }
+    if (config.inConfs[idx].inPlace() >= 0) {
+        auto outPortDesc = config.outConfs[static_cast<size_t>(config.inConfs[idx].inPlace())].getPortDesc();
+        if (config.inConfs[idx].getPortDesc()->compare(*outPortDesc)) {
+            return outPortDesc->getMemDesc();
+        }
+    }
 
     if (num >= 0) {
         auto parentConf = selectedPD->getConfig().outConfs[num];
@@ -956,9 +959,12 @@ MemoryDescPtr MKLDNNNode::getDefinedOutputDesc(const NodeConfig &config, size_t 
 //        return config.outConfs[idx].getMemDesc();
 //    }
 //
-//    if (config.outConfs[idx].inPlace() >= 0) {
-//        return getDefinedInputDesc(config, static_cast<size_t>(config.outConfs[idx].inPlace()));
-//    }
+    if (config.outConfs[idx].inPlace() >= 0) {
+        auto inpPortDesc = config.inConfs[static_cast<size_t>(config.outConfs[idx].inPlace())].getPortDesc();
+        if (config.outConfs[idx].getPortDesc()->compare(*inpPortDesc)) {
+            return inpPortDesc->getMemDesc();
+        }
+    }
 
     if (num >= 0) {
         auto childConf = selectedPD->getConfig().inConfs[num];

--- a/src/plugins/intel_cpu/src/mkldnn_node.cpp
+++ b/src/plugins/intel_cpu/src/mkldnn_node.cpp
@@ -716,13 +716,13 @@ void MKLDNNNode::initDescriptor(const NodeConfig& config) {
 
         for (size_t i = 0; i < selectedConfig.inConfs.size(); i++) {
             //if (!selectedConfig.inConfs[i].getMemDesc()->isCompatible(*config.inConfs[i].getMemDesc()))
-            if (!selectedConfig.inConfs[i].getPortDesc()->compare(*config.inConfs[i].getPortDesc()))
+            if (!selectedConfig.inConfs[i].getPortDesc()->isCompatible(*config.inConfs[i].getPortDesc()))
                 IE_THROW() << "Incorrect descriptor for node: " << getName() << " on " << i << " intput port";
         }
 
         for (size_t i = 0; i < selectedConfig.outConfs.size(); i++) {
             //if (!selectedConfig.outConfs[i].getMemDesc()->isCompatible(*config.outConfs[i].getMemDesc()))
-            if (!selectedConfig.outConfs[i].getPortDesc()->compare(*config.outConfs[i].getPortDesc()))
+            if (!selectedConfig.outConfs[i].getPortDesc()->isCompatible(*config.outConfs[i].getPortDesc()))
                 IE_THROW() << "Incorrect descriptor for node: " << getName() << " on " << i << " output port";
         }
         rightConfig = config;
@@ -925,7 +925,7 @@ MemoryDescPtr MKLDNNNode::getConsistentInputDesc(const NodeConfig &config, size_
 
     if (config.inConfs[idx].inPlace() >= 0) {
         auto outPortDesc = config.outConfs[static_cast<size_t>(config.inConfs[idx].inPlace())].getPortDesc();
-        if (config.inConfs[idx].getPortDesc()->compare(*outPortDesc)) {
+        if (config.inConfs[idx].getPortDesc()->isCompatible(*outPortDesc)) {
             return outPortDesc->getMemDesc();
         }
     }
@@ -936,7 +936,7 @@ MemoryDescPtr MKLDNNNode::getConsistentInputDesc(const NodeConfig &config, size_
         if (!parentConf.getMemDesc()->isDefined() && parentConf.inPlace() >= 0)
             getParentEdgeAt(idx)->getParent()->initOptimalPrimitiveDescriptor();
         parentConf = getParentEdgeAt(idx)->getParent()->getSelectedPrimitiveDescriptor()->getConfig().outConfs[num];
-        if (parentConf.getMemDesc()->isDefined() && config.inConfs[idx].getPortDesc()->compare(*parentConf.getPortDesc())) {
+        if (parentConf.getMemDesc()->isDefined() && config.inConfs[idx].getPortDesc()->isCompatible(*parentConf.getPortDesc())) {
             return parentConf.getMemDesc();
         }
     }
@@ -952,7 +952,7 @@ MemoryDescPtr MKLDNNNode::getConsistentOutputDesc(const NodeConfig &config, size
 
     if (config.outConfs[idx].inPlace() >= 0) {
         auto inpPortDesc = config.inConfs[static_cast<size_t>(config.outConfs[idx].inPlace())].getPortDesc();
-        if (config.outConfs[idx].getPortDesc()->compare(*inpPortDesc)) {
+        if (config.outConfs[idx].getPortDesc()->isCompatible(*inpPortDesc)) {
             return inpPortDesc->getMemDesc();
         }
     }
@@ -963,7 +963,7 @@ MemoryDescPtr MKLDNNNode::getConsistentOutputDesc(const NodeConfig &config, size
         if (!childConf.getMemDesc()->isDefined() && childConf.inPlace() >= 0)
             getChildEdgeAt(idx)->getChild()->initOptimalPrimitiveDescriptor();
         childConf = getChildEdgeAt(idx)->getChild()->getSelectedPrimitiveDescriptor()->getConfig().inConfs[num];
-        if (childConf.getMemDesc()->isDefined() && config.outConfs[idx].getPortDesc()->compare(*childConf.getPortDesc())) {
+        if (childConf.getMemDesc()->isDefined() && config.outConfs[idx].getPortDesc()->isCompatible(*childConf.getPortDesc())) {
             return childConf.getMemDesc();
         }
     }

--- a/src/plugins/intel_cpu/src/mkldnn_node.cpp
+++ b/src/plugins/intel_cpu/src/mkldnn_node.cpp
@@ -586,7 +586,7 @@ void MKLDNNNode::initSupportedPrimitiveDescriptors() {
                 portConfig.constant(false);
                 auto desc = getSrcMemDesc(itpd, i);
                 if (desc->getType() & MemoryDescType::Blocked) {
-                    portConfig.setMemDesc(std::dynamic_pointer_cast<BlockedMemoryDesc>(desc), 0x0);
+                    portConfig.setMemDesc(std::dynamic_pointer_cast<BlockedMemoryDesc>(desc), BLOCKED_DESC_EMPTY_MASK);
                 } else {
                     portConfig.setMemDesc(std::move(desc));
                 }
@@ -599,7 +599,7 @@ void MKLDNNNode::initSupportedPrimitiveDescriptors() {
                 portConfig.constant(false);
                 auto desc = getDstMemDesc(itpd, i);
                 if (desc->getType() & MemoryDescType::Blocked) {
-                    portConfig.setMemDesc(std::dynamic_pointer_cast<BlockedMemoryDesc>(desc), 0x0);
+                    portConfig.setMemDesc(std::dynamic_pointer_cast<BlockedMemoryDesc>(desc), BLOCKED_DESC_EMPTY_MASK);
                 } else {
                     portConfig.setMemDesc(std::move(desc));
                 }
@@ -618,8 +618,8 @@ void MKLDNNNode::filterSupportedPrimitiveDescriptors() {
     // Compare by format tag
     auto areCompatible = [](const MemoryDesc& desc, mkldnn::memory::format_tag fmt) -> bool {
         auto fmt_tdesc = DnnlBlockedMemoryDesc(desc.getShape(),
-                                                 MKLDNNExtensionUtils::IEPrecisionToDataType(desc.getPrecision()),
-                                                 fmt);
+                                               MKLDNNExtensionUtils::IEPrecisionToDataType(desc.getPrecision()),
+                                               fmt);
         return desc.isCompatible(fmt_tdesc);
     };
 
@@ -715,13 +715,11 @@ void MKLDNNNode::initDescriptor(const NodeConfig& config) {
             return;
 
         for (size_t i = 0; i < selectedConfig.inConfs.size(); i++) {
-            //if (!selectedConfig.inConfs[i].getMemDesc()->isCompatible(*config.inConfs[i].getMemDesc()))
             if (!selectedConfig.inConfs[i].getPortDesc()->isCompatible(*config.inConfs[i].getPortDesc()))
                 IE_THROW() << "Incorrect descriptor for node: " << getName() << " on " << i << " intput port";
         }
 
         for (size_t i = 0; i < selectedConfig.outConfs.size(); i++) {
-            //if (!selectedConfig.outConfs[i].getMemDesc()->isCompatible(*config.outConfs[i].getMemDesc()))
             if (!selectedConfig.outConfs[i].getPortDesc()->isCompatible(*config.outConfs[i].getPortDesc()))
                 IE_THROW() << "Incorrect descriptor for node: " << getName() << " on " << i << " output port";
         }
@@ -982,7 +980,7 @@ void MKLDNNNode::initOptimalPrimitiveDescriptor() {
         for (size_t i = 0; i < config.outConfs.size(); i++) {
             auto outMemDesc = config.outConfs[i].getMemDesc();
             if (outMemDesc && (outMemDesc->getType() & Blocked)) {
-                config.outConfs[i].setMemDesc(std::dynamic_pointer_cast<BlockedMemoryDesc>(outMemDesc), 0xffffffff);
+                config.outConfs[i].setMemDesc(std::dynamic_pointer_cast<BlockedMemoryDesc>(outMemDesc), BLOCKED_DESC_FULL_MASK);
             }
         }
     } else {

--- a/src/plugins/intel_cpu/src/mkldnn_node.cpp
+++ b/src/plugins/intel_cpu/src/mkldnn_node.cpp
@@ -994,9 +994,8 @@ void MKLDNNNode::initOptimalPrimitiveDescriptor() {
         for (size_t i = 0; i < config.outConfs.size(); i++) {
             config.outConfs[i].setMemDesc(getDefinedOutputDesc(config, i));
         }
-
-        initDescriptor(config);
-    } else if (getType() != RNNSeq && getType() != RNNCell) {
+    }
+    if (getType() != RNNSeq && getType() != RNNCell) {
         initDescriptor(config);
     }
 }

--- a/src/plugins/intel_cpu/src/mkldnn_node.h
+++ b/src/plugins/intel_cpu/src/mkldnn_node.h
@@ -28,7 +28,7 @@
 #include <nodes/common/blocked_desc_creator.h>
 #include "cpu_types.h"
 #include "cpu_shape.h"
-#include "memory_desc/cpu_memory_desc.h"
+#include "nodes/node_config.h"
 #include "cache/multi_cache.h"
 
 #include <utils/shape_inference/static_shape.hpp>
@@ -64,41 +64,6 @@ private:
         }
         return creators.at(blockedDescType);
     }
-};
-
-struct PortConfig {
-    PortConfig() = default;
-
-    PortConfig(const PortConfig& rhs) {
-        this->constant = rhs.constant;
-        this->inPlace = rhs.inPlace;
-        if (rhs.desc) {
-            this->desc = rhs.desc;
-        }
-    }
-
-    PortConfig& operator=(const PortConfig& rhs) {
-        this->constant = rhs.constant;
-        this->inPlace = rhs.inPlace;
-        if (rhs.desc) {
-            this->desc = rhs.desc;
-        }
-        return *this;
-    }
-
-    PortConfig(PortConfig&& rhs) = default;
-    PortConfig& operator=(PortConfig&& rhs) = default;
-
-    // TODO [DS]: better to make private and const
-    bool constant = false;
-    int inPlace = -1;
-    MemoryDescPtr desc;
-};
-
-struct NodeConfig {
-    bool dynBatchSupport = false;
-    std::vector<PortConfig> inConfs;
-    std::vector<PortConfig> outConfs;
 };
 
 class NodeDesc {
@@ -407,7 +372,7 @@ public:
             if (srcDescs.empty() || selectedDescs.empty())
                 return false;
             for (size_t i = 0; i < srcDescs.size() && i < selectedDescs.size(); i++) {
-                if (!srcDescs[i]->isCompatible(*selectedDescs[i].desc))
+                if (!srcDescs[i]->isCompatible(*selectedDescs[i].getMemDesc()))
                     return false;
             }
             return true;
@@ -711,9 +676,9 @@ protected:
                 return false;
 
             PortConfig portConfig;
-            portConfig.inPlace = portConfigurator.inPlace;
-            portConfig.constant = portConfigurator.constant;
-            portConfig.desc = portConfigurator.blockedDescCreator->createSharedDesc(prc, shape);
+            portConfig.inPlace(portConfigurator.inPlace);
+            portConfig.constant(portConfigurator.constant);
+            portConfig.setMemDesc(portConfigurator.blockedDescCreator->createSharedDesc(prc, shape));
 
             port.push_back(std::move(portConfig));
 

--- a/src/plugins/intel_cpu/src/mkldnn_node.h
+++ b/src/plugins/intel_cpu/src/mkldnn_node.h
@@ -581,8 +581,8 @@ protected:
     virtual size_t getMaxBatch() const;
 
 
-    virtual MemoryDescPtr getDefinedInputDesc(const NodeConfig &config, size_t idx) const;
-    virtual MemoryDescPtr getDefinedOutputDesc(const NodeConfig &config, size_t idx) const;
+    virtual MemoryDescPtr getConsistentInputDesc(const NodeConfig &config, size_t idx) const;
+    virtual MemoryDescPtr getConsistentOutputDesc(const NodeConfig &config, size_t idx) const;
     virtual MemoryDescPtr getSrcMemDesc(mkldnn::primitive_desc_iterator &primitive_desc_it, size_t idx);
     virtual MemoryDescPtr getDstMemDesc(mkldnn::primitive_desc_iterator &primitive_desc_it, size_t idx);
 

--- a/src/plugins/intel_cpu/src/mkldnn_node.h
+++ b/src/plugins/intel_cpu/src/mkldnn_node.h
@@ -581,8 +581,8 @@ protected:
     virtual size_t getMaxBatch() const;
 
 
-    virtual MemoryDescPtr getConsistentInputDesc(const NodeConfig &config, size_t idx) const;
-    virtual MemoryDescPtr getConsistentOutputDesc(const NodeConfig &config, size_t idx) const;
+    virtual PortDescBasePtr getConsistentInputDesc(const NodeConfig &config, size_t idx) const;
+    virtual PortDescBasePtr getConsistentOutputDesc(const NodeConfig &config, size_t idx) const;
     virtual MemoryDescPtr getSrcMemDesc(mkldnn::primitive_desc_iterator &primitive_desc_it, size_t idx);
     virtual MemoryDescPtr getDstMemDesc(mkldnn::primitive_desc_iterator &primitive_desc_it, size_t idx);
 

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_bin_conv_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_bin_conv_node.cpp
@@ -970,14 +970,14 @@ void MKLDNNBinaryConvolutionNode::initSupportedPrimitiveDescriptors() {
     NodeConfig config;
     config.dynBatchSupport = false;
     config.inConfs.resize(2);
-    config.inConfs[0].constant = false;
-    config.inConfs[0].inPlace = -1;
-    config.inConfs[1].constant = false;
-    config.inConfs[1].inPlace = -1;
+    config.inConfs[0].constant(false);
+    config.inConfs[0].inPlace(-1);
+    config.inConfs[1].constant(false);
+    config.inConfs[1].inPlace(-1);
 
     config.outConfs.resize(1);
-    config.outConfs[0].constant = false;
-    config.outConfs[0].inPlace = -1;
+    config.outConfs[0].constant(false);
+    config.outConfs[0].inPlace(-1);
 
     if (implType != impl_desc_type::ref) {
         // optimzed implementation
@@ -985,7 +985,7 @@ void MKLDNNBinaryConvolutionNode::initSupportedPrimitiveDescriptors() {
 
         //activation
         auto nspcCreator = BlockedDescCreator::getCommonCreators().at(LayoutType::nspc);
-        config.inConfs[0].desc = nspcCreator->createSharedDesc(Precision::BIN, getInputShapeAtPort(0));
+        config.inConfs[0].setMemDesc(nspcCreator->createSharedDesc(Precision::BIN, getInputShapeAtPort(0)));
 
         //weights
         size_t weiFirstDimBlockSize = implType == impl_desc_type::jit_avx512 ? 16 : 8; //memory::format_tag::OIhw16o32i : memory::format_tag::OIhw8o32i;
@@ -994,14 +994,14 @@ void MKLDNNBinaryConvolutionNode::initSupportedPrimitiveDescriptors() {
                                             weiDims[2], weiDims[3], weiFirstDimBlockSize, 32};
         std::vector<size_t> weiOrder = {0, 1, 2, 3, 0, 1};
 
-        config.inConfs[1].desc = std::make_shared<CpuBlockedMemoryDesc>(Precision::BIN, Shape(weiDims), weiBlockDims, weiOrder);
+        config.inConfs[1].setMemDesc(std::make_shared<CpuBlockedMemoryDesc>(Precision::BIN, Shape(weiDims), weiBlockDims, weiOrder));
 
         //result
         auto outputPrecision = withBinarization ? Precision::BIN : Precision::FP32;
-        config.outConfs[0].desc = nspcCreator->createSharedDesc(outputPrecision, getOutputShapeAtPort(0));
+        config.outConfs[0].setMemDesc(nspcCreator->createSharedDesc(outputPrecision, getOutputShapeAtPort(0)));
         if (withSum) {
             config.inConfs.push_back(config.outConfs[0]);
-            config.outConfs[0].inPlace = 2;
+            config.outConfs[0].inPlace(2);
         }
         supportedPrimitiveDescriptors.push_back({config, implType});
     } else {
@@ -1009,9 +1009,9 @@ void MKLDNNBinaryConvolutionNode::initSupportedPrimitiveDescriptors() {
         auto weiCreator = BlockedDescCreator::getCommonCreators().at(LayoutType::ncsp);
         auto nspcCreator = BlockedDescCreator::getCommonCreators().at(LayoutType::nspc);
 
-        config.inConfs[0].desc = nspcCreator->createSharedDesc(Precision::BIN, getInputShapeAtPort(0));
-        config.inConfs[1].desc = weiCreator->createSharedDesc(Precision::BIN, getInputShapeAtPort(1));
-        config.outConfs[0].desc = nspcCreator->createSharedDesc(Precision::FP32, getOutputShapeAtPort(0));
+        config.inConfs[0].setMemDesc(nspcCreator->createSharedDesc(Precision::BIN, getInputShapeAtPort(0)));
+        config.inConfs[1].setMemDesc(weiCreator->createSharedDesc(Precision::BIN, getInputShapeAtPort(1)));
+        config.outConfs[0].setMemDesc(nspcCreator->createSharedDesc(Precision::FP32, getOutputShapeAtPort(0)));
         supportedPrimitiveDescriptors.push_back({config, implType});
     }
 }

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_color_convert_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_color_convert_node.cpp
@@ -617,7 +617,7 @@ void MKLDNNColorConvertNode::createPrimitive() {
 
     if (!_impl) {
         const auto & cfg = desc->getConfig();
-        const auto precision = cfg.inConfs[0].desc->getPrecision();
+        const auto precision = cfg.inConfs[0].getMemDesc()->getPrecision();
         const bool isSinglePlane = cfg.inConfs.size() == 1;
 
         _impl = std::unique_ptr<Converter>(_supportedImpls

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_concat_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_concat_node.cpp
@@ -415,11 +415,11 @@ void MKLDNNConcatNode::initOptimalPrimitiveDescriptor() {
         if (!isConfigDefined(config)) {
             for (size_t i = 0; i < config.inConfs.size(); i++) {
                 // Concat doesn't support different precision on inputs
-                config.inConfs[i].setMemDesc(getDefinedInputDesc(config, i)->cloneWithNewPrecision(inputPrecision));
+                config.inConfs[i].setMemDesc(getConsistentInputDesc(config, i)->cloneWithNewPrecision(inputPrecision));
             }
 
             for (size_t i = 0; i < config.outConfs.size(); i++) {
-                config.outConfs[i].setMemDesc(getDefinedOutputDesc(config, i)->cloneWithNewPrecision(outputPrecision));
+                config.outConfs[i].setMemDesc(getConsistentOutputDesc(config, i)->cloneWithNewPrecision(outputPrecision));
             }
 
             initDescriptor(config);

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_concat_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_concat_node.cpp
@@ -415,11 +415,11 @@ void MKLDNNConcatNode::initOptimalPrimitiveDescriptor() {
         if (!isConfigDefined(config)) {
             for (size_t i = 0; i < config.inConfs.size(); i++) {
                 // Concat doesn't support different precision on inputs
-                config.inConfs[i].setMemDesc(getConsistentInputDesc(config, i)->cloneWithNewPrecision(inputPrecision));
+                config.inConfs[i].setMemDesc(getConsistentInputDesc(config, i)->getMemDesc()->cloneWithNewPrecision(inputPrecision));
             }
 
             for (size_t i = 0; i < config.outConfs.size(); i++) {
-                config.outConfs[i].setMemDesc(getConsistentOutputDesc(config, i)->cloneWithNewPrecision(outputPrecision));
+                config.outConfs[i].setMemDesc(getConsistentOutputDesc(config, i)->getMemDesc()->cloneWithNewPrecision(outputPrecision));
             }
 
             initDescriptor(config);

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_concat_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_concat_node.cpp
@@ -441,7 +441,7 @@ void MKLDNNConcatNode::initOptimalPrimitiveDescriptor() {
                     if (!childConf.getMemDesc()->isDefined() && childConf.inPlace() >= 0)
                         getChildEdgeAt(i)->getChild()->initOptimalPrimitiveDescriptor();
 
-                    if (childConf.getMemDesc()->isDefined() && config.outConfs[i].getPortDesc()->compare(*childConf.getPortDesc())) {
+                    if (childConf.getMemDesc()->isDefined() && config.outConfs[i].getPortDesc()->isCompatible(*childConf.getPortDesc())) {
                         config.outConfs[i].setMemDesc(childConf.getMemDesc());
                         continue;
                     }

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_conv_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_conv_node.cpp
@@ -427,7 +427,7 @@ void MKLDNNConvolutionNode::initSupportedPrimitiveDescriptors() {
                     dataConfig.constant(false);
                     auto desc = getSrcMemDesc(itpd, i);
                     if (desc->getType() & MemoryDescType::Blocked && !isGrouped) {
-                        dataConfig.setMemDesc(desc->as<BlockedMemoryDesc>()->cloneWithUndefStridesAndOffset());
+                        dataConfig.setMemDesc(std::dynamic_pointer_cast<BlockedMemoryDesc>(desc), 0x0);
                     } else {
                         dataConfig.setMemDesc(std::move(desc));
                     }
@@ -461,7 +461,7 @@ void MKLDNNConvolutionNode::initSupportedPrimitiveDescriptors() {
                     dataConfig.constant(false);
                     auto desc = getDstMemDesc(itpd, i);
                     if (desc->getType() & MemoryDescType::Blocked && !isGrouped) {
-                        dataConfig.setMemDesc(desc->as<BlockedMemoryDesc>()->cloneWithUndefStridesAndOffset());
+                        dataConfig.setMemDesc(std::dynamic_pointer_cast<BlockedMemoryDesc>(desc), 0x0);
                     } else {
                         dataConfig.setMemDesc(std::move(desc));
                     }

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_conv_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_conv_node.cpp
@@ -427,7 +427,7 @@ void MKLDNNConvolutionNode::initSupportedPrimitiveDescriptors() {
                     dataConfig.constant(false);
                     auto desc = getSrcMemDesc(itpd, i);
                     if (desc->getType() & MemoryDescType::Blocked && !isGrouped) {
-                        dataConfig.setMemDesc(std::dynamic_pointer_cast<BlockedMemoryDesc>(desc), 0x0);
+                        dataConfig.setMemDesc(std::dynamic_pointer_cast<BlockedMemoryDesc>(desc), BLOCKED_DESC_EMPTY_MASK);
                     } else {
                         dataConfig.setMemDesc(std::move(desc));
                     }
@@ -461,7 +461,7 @@ void MKLDNNConvolutionNode::initSupportedPrimitiveDescriptors() {
                     dataConfig.constant(false);
                     auto desc = getDstMemDesc(itpd, i);
                     if (desc->getType() & MemoryDescType::Blocked && !isGrouped) {
-                        dataConfig.setMemDesc(std::dynamic_pointer_cast<BlockedMemoryDesc>(desc), 0x0);
+                        dataConfig.setMemDesc(std::dynamic_pointer_cast<BlockedMemoryDesc>(desc), BLOCKED_DESC_EMPTY_MASK);
                     } else {
                         dataConfig.setMemDesc(std::move(desc));
                     }

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_convert_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_convert_node.cpp
@@ -98,12 +98,12 @@ void MKLDNNConvertNode::initSupportedPrimitiveDescriptors() {
     // if input and output pointers are not null and not contain extra data, then the inp/output tensor descriptors were set using setDescs method, so
     // they should be used as the actual descriptors.
     if (canInitExternalDesc) {
-        dataIn.desc = input;
+        dataIn.setMemDesc(input);
         config.inConfs.push_back(dataIn);
 
         // inp/out layouts must be the same
-        dataConfigOut.desc = config.inConfs[0].desc;
-        dataConfigOut.desc = dataConfigOut.desc->cloneWithNewPrecision(output->getPrecision());
+        dataConfigOut.setMemDesc(config.inConfs[0].getMemDesc());
+        dataConfigOut.setMemDesc(dataConfigOut.getMemDesc()->cloneWithNewPrecision(output->getPrecision()));
         config.outConfs.push_back(dataConfigOut);
         supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::unknown);
     } else if (inputShapes.size() == 1 && outputShapes.size() == 1) {
@@ -119,8 +119,8 @@ void MKLDNNConvertNode::initSupportedPrimitiveDescriptors() {
         auto range = BlockedDescCreator::makeFilteredRange(creators, insShape.getRank());
 
         for (auto itr = range.first; itr != range.second; ++itr) {
-            config.inConfs[0].desc = std::make_shared<CpuBlockedMemoryDesc>(itr->second->createDesc(insPrecision, insShape));
-            config.outConfs[0].desc = std::make_shared<CpuBlockedMemoryDesc>(itr->second->createDesc(outPrecision, outputShape));
+            config.inConfs[0].setMemDesc(std::make_shared<CpuBlockedMemoryDesc>(itr->second->createDesc(insPrecision, insShape)));
+            config.outConfs[0].setMemDesc(std::make_shared<CpuBlockedMemoryDesc>(itr->second->createDesc(outPrecision, outputShape)));
 
             supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::unknown);
         }

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_def_conv_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_def_conv_node.cpp
@@ -654,20 +654,20 @@ void MKLDNNDeformableConvolutionNode::initSupportedPrimitiveDescriptors() {
     NodeConfig config;
     config.dynBatchSupport = false;
     config.inConfs.resize(inputsNumber);
-    config.inConfs[0].constant = false;
-    config.inConfs[0].inPlace = -1;
-    config.inConfs[1].constant = false;
-    config.inConfs[1].inPlace = -1;
-    config.inConfs[2].constant = false;
-    config.inConfs[2].inPlace = -1;
+    config.inConfs[0].constant(false);
+    config.inConfs[0].inPlace(-1);
+    config.inConfs[1].constant(false);
+    config.inConfs[1].inPlace(-1);
+    config.inConfs[2].constant(false);
+    config.inConfs[2].inPlace(-1);
     if (inputsNumber > 3) {
-        config.inConfs[3].constant = false;
-        config.inConfs[3].inPlace = -1;
+        config.inConfs[3].constant(false);
+        config.inConfs[3].inPlace(-1);
     }
 
     config.outConfs.resize(1);
-    config.outConfs[0].constant = false;
-    config.outConfs[0].inPlace = -1;
+    config.outConfs[0].constant(false);
+    config.outConfs[0].inPlace(-1);
 
     impl_desc_type impl_type;
     const int simd_w = mayiuse(cpu::x64::avx512_common) ? 16 : 8;
@@ -698,35 +698,35 @@ void MKLDNNDeformableConvolutionNode::initSupportedPrimitiveDescriptors() {
         auto dataFormat = memory::format_tag::nhwc;
         auto offFormat = memory::format_tag::nchw;
         auto weiFormat = mayiuse(avx512_common) ? memory::format_tag::OIhw16i16o : memory::format_tag::OIhw8i8o;
-        config.inConfs[DATA_ID].desc = std::make_shared<DnnlBlockedMemoryDesc>(getInputShapeAtPort(DATA_ID),
-                                                                              memory::data_type::f32, dataFormat);
-        config.inConfs[OFF_ID].desc = std::make_shared<DnnlBlockedMemoryDesc>(getInputShapeAtPort(OFF_ID),
-                                                                              memory::data_type::f32, offFormat);
+        config.inConfs[DATA_ID].setMemDesc(std::make_shared<DnnlBlockedMemoryDesc>(getInputShapeAtPort(DATA_ID),
+                                                                                   memory::data_type::f32, dataFormat));
+        config.inConfs[OFF_ID].setMemDesc(std::make_shared<DnnlBlockedMemoryDesc>(getInputShapeAtPort(OFF_ID),
+                                                                                  memory::data_type::f32, offFormat));
 
-        config.inConfs[WEI_ID].desc = std::make_shared<DnnlBlockedMemoryDesc>(getInputShapeAtPort(WEI_ID),
-                                                                                memory::data_type::f32, weiFormat);
+        config.inConfs[WEI_ID].setMemDesc(std::make_shared<DnnlBlockedMemoryDesc>(getInputShapeAtPort(WEI_ID),
+                                                                                  memory::data_type::f32, weiFormat));
 
         if (inputsNumber > 3) {
-            config.inConfs[MOD_ID].desc = std::make_shared<DnnlBlockedMemoryDesc>(getInputShapeAtPort(MOD_ID),
-                                                                                 memory::data_type::f32, memory::format_tag::nchw);
+            config.inConfs[MOD_ID].setMemDesc(std::make_shared<DnnlBlockedMemoryDesc>(getInputShapeAtPort(MOD_ID),
+                                                                                      memory::data_type::f32, memory::format_tag::nchw));
         }
-        config.outConfs[0].desc = std::make_shared<DnnlBlockedMemoryDesc>(getOutputShapeAtPort(DATA_ID),
-                                                                              memory::data_type::f32, dataFormat);
+        config.outConfs[0].setMemDesc(std::make_shared<DnnlBlockedMemoryDesc>(getOutputShapeAtPort(DATA_ID),
+                                                                              memory::data_type::f32, dataFormat));
         supportedPrimitiveDescriptors.push_back({config, impl_type});
     } else {
         // reference implementation
-        config.inConfs[DATA_ID].desc = std::make_shared<DnnlBlockedMemoryDesc>(getInputShapeAtPort(DATA_ID), memory::data_type::f32,
-                                                               memory::format_tag::nchw);
-        config.inConfs[OFF_ID].desc = std::make_shared<DnnlBlockedMemoryDesc>(getInputShapeAtPort(OFF_ID), memory::data_type::f32,
-                                                               memory::format_tag::nchw);
-        config.inConfs[WEI_ID].desc = std::make_shared<DnnlBlockedMemoryDesc>(getInputShapeAtPort(WEI_ID), memory::data_type::f32,
-                                                               memory::format_tag::oihw);
+        config.inConfs[DATA_ID].setMemDesc(std::make_shared<DnnlBlockedMemoryDesc>(getInputShapeAtPort(DATA_ID), memory::data_type::f32,
+                                                                                   memory::format_tag::nchw));
+        config.inConfs[OFF_ID].setMemDesc(std::make_shared<DnnlBlockedMemoryDesc>(getInputShapeAtPort(OFF_ID), memory::data_type::f32,
+                                                                                  memory::format_tag::nchw));
+        config.inConfs[WEI_ID].setMemDesc(std::make_shared<DnnlBlockedMemoryDesc>(getInputShapeAtPort(WEI_ID), memory::data_type::f32,
+                                                                                  memory::format_tag::oihw));
         if (inputsNumber > 3) {
-            config.inConfs[MOD_ID].desc = std::make_shared<DnnlBlockedMemoryDesc>(getInputShapeAtPort(MOD_ID), memory::data_type::f32,
-                                                                                 memory::format_tag::nchw);
+            config.inConfs[MOD_ID].setMemDesc(std::make_shared<DnnlBlockedMemoryDesc>(getInputShapeAtPort(MOD_ID), memory::data_type::f32,
+                                                                                      memory::format_tag::nchw));
         }
-        config.outConfs[0].desc = std::make_shared<DnnlBlockedMemoryDesc>(getOutputShapeAtPort(DATA_ID), memory::data_type::f32,
-                                                                memory::format_tag::nchw);
+        config.outConfs[0].setMemDesc(std::make_shared<DnnlBlockedMemoryDesc>(getOutputShapeAtPort(DATA_ID), memory::data_type::f32,
+                                                                              memory::format_tag::nchw));
         supportedPrimitiveDescriptors.push_back({config, impl_type});
     }
 }
@@ -1016,18 +1016,18 @@ void MKLDNNDeformableConvolutionNode::prepareParams() {
     auto& offMemPtr = getParentEdgeAt(OFF_ID)->getMemoryPtr();
     auto& weiMemPtr = getParentEdgeAt(WEI_ID)->getMemoryPtr();
 
-    if (!dstMemPtr || !dstMemPtr->GetPrimitivePtr())
+    if (!dstMemPtr || !dstMemPtr->isAllocated())
         IE_THROW() << errorPrefix << " did not allocate destination memory";
-    if (!srcMemPtr || !srcMemPtr->GetPrimitivePtr())
+    if (!srcMemPtr || !srcMemPtr->isAllocated())
         IE_THROW() << errorPrefix << " did not allocate input memory";
-    if (!offMemPtr || !offMemPtr->GetPrimitivePtr())
+    if (!offMemPtr || !offMemPtr->isAllocated())
         IE_THROW() << errorPrefix << " did not allocate offsets shape memory";
-    if (!weiMemPtr || !weiMemPtr->GetPrimitivePtr())
+    if (!weiMemPtr || !weiMemPtr->isAllocated())
         IE_THROW() << errorPrefix << " did not allocate weights memory";
 
     if (getOriginalInputsNumber() > 3) {
         auto& modMemPtr = getParentEdgeAt(MOD_ID)->getMemoryPtr();
-        if (!modMemPtr || !modMemPtr->GetPrimitivePtr())
+        if (!modMemPtr || !modMemPtr->isAllocated())
             IE_THROW() << errorPrefix << " did not allocate modulations memory";
     }
 

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_def_conv_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_def_conv_node.cpp
@@ -1016,18 +1016,18 @@ void MKLDNNDeformableConvolutionNode::prepareParams() {
     auto& offMemPtr = getParentEdgeAt(OFF_ID)->getMemoryPtr();
     auto& weiMemPtr = getParentEdgeAt(WEI_ID)->getMemoryPtr();
 
-    if (!dstMemPtr || !dstMemPtr->isAllocated())
+    if (!dstMemPtr || !dstMemPtr->GetPrimitivePtr())
         IE_THROW() << errorPrefix << " did not allocate destination memory";
-    if (!srcMemPtr || !srcMemPtr->isAllocated())
+    if (!srcMemPtr || !srcMemPtr->GetPrimitivePtr())
         IE_THROW() << errorPrefix << " did not allocate input memory";
-    if (!offMemPtr || !offMemPtr->isAllocated())
+    if (!offMemPtr || !offMemPtr->GetPrimitivePtr())
         IE_THROW() << errorPrefix << " did not allocate offsets shape memory";
-    if (!weiMemPtr || !weiMemPtr->isAllocated())
+    if (!weiMemPtr || !weiMemPtr->GetPrimitivePtr())
         IE_THROW() << errorPrefix << " did not allocate weights memory";
 
     if (getOriginalInputsNumber() > 3) {
         auto& modMemPtr = getParentEdgeAt(MOD_ID)->getMemoryPtr();
-        if (!modMemPtr || !modMemPtr->isAllocated())
+        if (!modMemPtr || !modMemPtr->GetPrimitivePtr())
             IE_THROW() << errorPrefix << " did not allocate modulations memory";
     }
 

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_depth_to_space_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_depth_to_space_node.cpp
@@ -125,10 +125,10 @@ void MKLDNNDepthToSpaceNode::initSupportedPrimitiveDescriptors() {
     config.dynBatchSupport = true;
     config.inConfs.resize(1);
     config.outConfs.resize(1);
-    config.inConfs[0].inPlace = -1;
-    config.inConfs[0].constant = false;
-    config.outConfs[0].inPlace = -1;
-    config.outConfs[0].constant = false;
+    config.inConfs[0].inPlace(-1);
+    config.inConfs[0].constant(false);
+    config.outConfs[0].inPlace(-1);
+    config.outConfs[0].constant(false);
 
     const auto& inputDataShape = getInputShapeAtPort(0);
     const auto& outputDataShape = getOutputShapeAtPort(0);
@@ -152,8 +152,8 @@ void MKLDNNDepthToSpaceNode::initSupportedPrimitiveDescriptors() {
     auto range = BlockedDescCreator::makeFilteredRange(creators, inputDataShape.getRank(), supportedTypes);
 
     for (auto itr = range.first; itr != range.second; ++itr) {
-        config.inConfs[0].desc = itr->second->createSharedDesc(precision, inputDataShape);
-        config.outConfs[0].desc = itr->second->createSharedDesc(precision, outputDataShape);
+        config.inConfs[0].setMemDesc(itr->second->createSharedDesc(precision, inputDataShape));
+        config.outConfs[0].setMemDesc(itr->second->createSharedDesc(precision, outputDataShape));
         supportedPrimitiveDescriptors.emplace_back(config, impl_type);
     }
 }

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_eltwise_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_eltwise_node.cpp
@@ -1951,11 +1951,11 @@ void MKLDNNEltwiseNode::initOptimalPrimitiveDescriptor() {
     auto config = selected_pd->getConfig();
     if (!isDynamicNode()) { //isConfigDefined(config)
         for (size_t i = 0; i < config.inConfs.size(); i++) {
-            config.inConfs[i].setMemDesc(getDefinedInputDesc(config, i));
+            config.inConfs[i].setMemDesc(getConsistentInputDesc(config, i));
         }
 
         for (size_t i = 0; i < config.outConfs.size(); i++) {
-            config.outConfs[i].setMemDesc(getDefinedOutputDesc(config, i));
+            config.outConfs[i].setMemDesc(getConsistentOutputDesc(config, i));
         }
 
         initDescriptor(config);

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_eltwise_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_eltwise_node.cpp
@@ -1760,44 +1760,44 @@ void MKLDNNEltwiseNode::initSupportedPrimitiveDescriptors() {
             PortConfig portConfig;
             // TODO [DS]: inplace
             if (!isDynamicNode())
-                portConfig.inPlace = (!i && canBeInPlace() && inputPrecisions[i] == outputPrecision) ? 0 : -1;
-            portConfig.constant = false;
+                portConfig.inPlace((!i && canBeInPlace() && inputPrecisions[i] == outputPrecision) ? 0 : -1);
+            portConfig.constant(false);
 
             const auto &srcShape = getInputShapeAtPort(i);
-            portConfig.desc = createMemoryDesc(srcShape, inputPrecisions[i], offset);
+            portConfig.setMemDesc(createMemoryDesc(srcShape, inputPrecisions[i], offset));
             if (!isDynamicNode() && srcShape.getDims()[0] == 1) {
-                const auto denseDesc = portConfig.desc->as<BlockedMemoryDesc>();
+                const auto denseDesc = portConfig.getMemDesc()->as<BlockedMemoryDesc>();
                 auto strides = denseDesc->getStrides();
                 strides[0] = Shape::UNDEFINED_DIM;
-                portConfig.desc = std::make_shared<CpuBlockedMemoryDesc>(denseDesc->getPrecision(),
+                portConfig.setMemDesc(std::make_shared<CpuBlockedMemoryDesc>(denseDesc->getPrecision(),
                                                                          denseDesc->getShape(),
                                                                          denseDesc->getBlockDims(),
                                                                          denseDesc->getOrder(),
                                                                          denseDesc->getOffsetPadding(),
                                                                          denseDesc->getOffsetPaddingToData(),
-                                                                         strides);
+                                                                         strides));
             }
 
             config.inConfs.push_back(portConfig);
         }
 
         PortConfig portConfig;
-        portConfig.inPlace = -1;
-        portConfig.constant = false;
+        portConfig.inPlace(-1);
+        portConfig.constant(false);
 
         const auto &dstShape = getOutputShapeAtPort(0);
-        portConfig.desc = createMemoryDesc(dstShape, outputPrecision, offset);
+        portConfig.setMemDesc(createMemoryDesc(dstShape, outputPrecision, offset));
         if (!isDynamicNode() && dstShape.getDims()[0] == 1) {
-            const auto denseDesc = portConfig.desc->as<BlockedMemoryDesc>();
+            const auto denseDesc = portConfig.getMemDesc()->as<BlockedMemoryDesc>();
             auto strides = denseDesc->getStrides();
             strides[0] = Shape::UNDEFINED_DIM;
-            portConfig.desc = std::make_shared<CpuBlockedMemoryDesc>(denseDesc->getPrecision(),
+            portConfig.setMemDesc(std::make_shared<CpuBlockedMemoryDesc>(denseDesc->getPrecision(),
                                                                      denseDesc->getShape(),
                                                                      denseDesc->getBlockDims(),
                                                                      denseDesc->getOrder(),
                                                                      denseDesc->getOffsetPadding(),
                                                                      denseDesc->getOffsetPaddingToData(),
-                                                                     strides);
+                                                                     strides));
         }
 
         config.outConfs.push_back(portConfig);
@@ -1966,11 +1966,11 @@ void MKLDNNEltwiseNode::initOptimalPrimitiveDescriptor() {
     auto config = selected_pd->getConfig();
     if (!isConfigDefined(config)) {
         for (size_t i = 0; i < config.inConfs.size(); i++) {
-            config.inConfs[i].desc = getDefinedInputDesc(config, i);
+            config.inConfs[i].setMemDesc(getDefinedInputDesc(config, i));
         }
 
         for (size_t i = 0; i < config.outConfs.size(); i++) {
-            config.outConfs[i].desc = getDefinedOutputDesc(config, i);
+            config.outConfs[i].setMemDesc(getDefinedOutputDesc(config, i));
         }
 
         initDescriptor(config);

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_eltwise_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_eltwise_node.cpp
@@ -1944,26 +1944,6 @@ void MKLDNNEltwiseNode::selectOptimalPrimitiveDescriptor() {
     selectPreferPrimitiveDescriptor(getPrimitivesPriority(), true);
 }
 
-void MKLDNNEltwiseNode::initOptimalPrimitiveDescriptor() {
-    auto selected_pd = getSelectedPrimitiveDescriptor();
-    if (selected_pd == nullptr)
-        IE_THROW() << "Preferable primitive descriptor is not set.";
-    auto config = selected_pd->getConfig();
-    if (!isDynamicNode()) { //isConfigDefined(config)
-        for (size_t i = 0; i < config.inConfs.size(); i++) {
-            config.inConfs[i].setMemDesc(getConsistentInputDesc(config, i));
-        }
-
-        for (size_t i = 0; i < config.outConfs.size(); i++) {
-            config.outConfs[i].setMemDesc(getConsistentOutputDesc(config, i));
-        }
-
-        initDescriptor(config);
-    } else {
-        initDescriptor(config);
-    }
-}
-
 void MKLDNNEltwiseNode::execute(mkldnn::stream strm) {
     if (execPtr) {
         jit_eltwise_call_args_ptrs args_ptrs = {};

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_eltwise_node.h
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_eltwise_node.h
@@ -93,7 +93,6 @@ public:
     void getSupportedDescriptors() override;
     void initSupportedPrimitiveDescriptors() override;
     void selectOptimalPrimitiveDescriptor() override;
-    void initOptimalPrimitiveDescriptor() override;
     void execute(mkldnn::stream strm) override;
     bool created() const override;
     bool canBeInPlace() const override;

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_fake_quantize_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_fake_quantize_node.cpp
@@ -1260,24 +1260,24 @@ void MKLDNNFakeQuantizeNode::initSupportedPrimitiveDescriptors() {
         config.dynBatchSupport = true;
         for (size_t i = 0; i < getParentEdges().size(); i++) {
             PortConfig dataConfig;
-            dataConfig.inPlace = -1;
-            dataConfig.constant = false;
+            dataConfig.inPlace(-1);
+            dataConfig.constant(false);
 
             if (i == 0) {
                 auto descCreator = BlockedDescCreator::getCommonCreators().at(fmt);
-                dataConfig.desc = descCreator->createSharedDesc(getInputPrecision(), getInputShapeAtPort(i));
+                dataConfig.setMemDesc(descCreator->createSharedDesc(getInputPrecision(), getInputShapeAtPort(i)));
             } else {
                 auto descCreator = BlockedDescCreator::getCommonCreators().at(LayoutType::ncsp);
-                dataConfig.desc = descCreator->createSharedDesc(Precision::FP32, getInputShapeAtPort(i));
+                dataConfig.setMemDesc(descCreator->createSharedDesc(Precision::FP32, getInputShapeAtPort(i)));
             }
             config.inConfs.push_back(dataConfig);
         }
 
         PortConfig dataConfig;
-        dataConfig.inPlace = -1;
-        dataConfig.constant = false;
+        dataConfig.inPlace(-1);
+        dataConfig.constant(false);
         auto descCreator = BlockedDescCreator::getCommonCreators().at(fmt);
-        dataConfig.desc = descCreator->createSharedDesc(getOutputPrecision(), getOutputShapeAtPort(0));
+        dataConfig.setMemDesc(descCreator->createSharedDesc(getOutputPrecision(), getOutputShapeAtPort(0)));
         config.outConfs.push_back(dataConfig);
 
         supportedPrimitiveDescriptors.push_back({config, impl_type});
@@ -1393,9 +1393,9 @@ void MKLDNNFakeQuantizeNode::prepareParams() {
         //Form FakeQuanKey
         FakeQuantKey key = {};
         key.jqp.c = inDims.size() > 1 ? inDims[1] : 1;
-        key.jqp.src_prc = config.inConfs[0].desc->getPrecision();
+        key.jqp.src_prc = config.inConfs[0].getMemDesc()->getPrecision();
         key.jqp.wei_prc = Precision::FP32;
-        key.jqp.dst_prc = config.outConfs[0].desc->getPrecision();
+        key.jqp.dst_prc = config.outConfs[0].getMemDesc()->getPrecision();
 
         auto srcDesc = getParentEdgeAt(0)->getMemory().GetDescWithType<BlockedMemoryDesc>();
         key.jqp.s_str = srcDesc->getStrides();

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_fullyconnected_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_fullyconnected_node.cpp
@@ -532,26 +532,26 @@ void MKLDNNFullyConnectedNode::initSupportedPrimitiveDescriptors() {
             config.dynBatchSupport = true;
             for (size_t i = 0; i < descInputNumbers(desc); i++) {
                 PortConfig portConfig;
-                portConfig.inPlace = -1;
-                portConfig.constant = false;
+                portConfig.inPlace(-1);
+                portConfig.constant(false);
                 auto desc = getSrcMemDesc(itpd, i);
                 if (supportsUndefStridesAndOffset()) {
-                    portConfig.desc = desc->as<BlockedMemoryDesc>()->cloneWithUndefStridesAndOffset();
+                    portConfig.setMemDesc(std::dynamic_pointer_cast<BlockedMemoryDesc>(desc), BLOCKED_DESC_EMPTY_MASK);
                 } else {
-                    portConfig.desc = std::move(desc);
+                    portConfig.setMemDesc(desc);
                 }
                 config.inConfs.push_back(portConfig);
             }
 
             for (size_t i = 0; i < descOutputNumbers(desc); i++) {
                 PortConfig portConfig;
-                portConfig.inPlace = canBeInPlace() ? 0 : -1;
-                portConfig.constant = false;
+                portConfig.inPlace(canBeInPlace() ? 0 : -1);
+                portConfig.constant(false);
                 auto desc = getDstMemDesc(itpd, i);
                 if (supportsUndefStridesAndOffset()) {
-                    portConfig.desc = desc->as<BlockedMemoryDesc>()->cloneWithUndefStridesAndOffset();
+                    portConfig.setMemDesc(std::dynamic_pointer_cast<BlockedMemoryDesc>(desc), BLOCKED_DESC_EMPTY_MASK);
                 } else {
-                    portConfig.desc = std::move(desc);
+                    portConfig.setMemDesc(desc);
                 }
                 config.outConfs.push_back(portConfig);
             }

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_if_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_if_node.cpp
@@ -171,14 +171,14 @@ void MKLDNNIfNode::initSupportedPrimitiveDescriptors() {
     for (size_t i = 0; i < inputShapes.size(); i++) {
         PortConfig dataConf {};
         auto descCreator = BlockedDescCreator::getCommonCreators().at(LayoutType::ncsp);
-        dataConf.desc = descCreator->createSharedDesc(getOriginalInputPrecisionAtPort(i), getInputShapeAtPort(i));
+        dataConf.setMemDesc(descCreator->createSharedDesc(getOriginalInputPrecisionAtPort(i), getInputShapeAtPort(i)));
         config.inConfs.emplace_back(dataConf);
     }
 
     for (size_t i = 0; i < outputShapes.size(); i++) {
         PortConfig dataConf {};
         auto descCreator = BlockedDescCreator::getCommonCreators().at(LayoutType::ncsp);
-        dataConf.desc = descCreator->createSharedDesc(getOriginalOutputPrecisionAtPort(i), getOutputShapeAtPort(i));
+        dataConf.setMemDesc(descCreator->createSharedDesc(getOriginalOutputPrecisionAtPort(i), getOutputShapeAtPort(i)));
         config.outConfs.push_back(dataConf);
     }
 

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_interpolate_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_interpolate_node.cpp
@@ -1974,14 +1974,14 @@ void MKLDNNInterpolateNode::initSupportedPrimitiveDescriptors() {
 
     auto& creatorsMap = BlockedDescCreator::getCommonCreators();
     auto pushDesc = [&](LayoutType dataFormat, impl_desc_type implDetail) {
-        config.inConfs[DATA_ID].desc = creatorsMap.at(dataFormat)->createSharedDesc(inputPrecision, getInputShapeAtPort(DATA_ID));
-        config.inConfs[TARGET_SHAPE_ID].desc = creatorsMap.at(LayoutType::ncsp)->createSharedDesc(targetShapeType, getInputShapeAtPort(TARGET_SHAPE_ID));
-        config.inConfs[SCALES_ID].desc = creatorsMap.at(LayoutType::ncsp)->createSharedDesc(scalesType, getInputShapeAtPort(SCALES_ID));
+        config.inConfs[DATA_ID].setMemDesc(creatorsMap.at(dataFormat)->createSharedDesc(inputPrecision, getInputShapeAtPort(DATA_ID)));
+        config.inConfs[TARGET_SHAPE_ID].setMemDesc(creatorsMap.at(LayoutType::ncsp)->createSharedDesc(targetShapeType, getInputShapeAtPort(TARGET_SHAPE_ID)));
+        config.inConfs[SCALES_ID].setMemDesc(creatorsMap.at(LayoutType::ncsp)->createSharedDesc(scalesType, getInputShapeAtPort(SCALES_ID)));
 
         if (isAxesSpecified)
-            config.inConfs[AXES_ID].desc = creatorsMap.at(LayoutType::ncsp)->createSharedDesc(axesType, getInputShapeAtPort(AXES_ID));
+            config.inConfs[AXES_ID].setMemDesc(creatorsMap.at(LayoutType::ncsp)->createSharedDesc(axesType, getInputShapeAtPort(AXES_ID)));
 
-        config.outConfs[0].desc = creatorsMap.at(dataFormat)->createSharedDesc(outputPrecision, getOutputShapeAtPort(0));
+        config.outConfs[0].setMemDesc(creatorsMap.at(dataFormat)->createSharedDesc(outputPrecision, getOutputShapeAtPort(0)));
         supportedPrimitiveDescriptors.push_back({config, implDetail});
     };
 

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_matmul_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_matmul_node.cpp
@@ -412,18 +412,18 @@ void MKLDNNMatMulNode::initSupportedPrimitiveDescriptors() {
             config.dynBatchSupport = true;
             for (size_t i = 0; i < descInputNumbers(desc); i++) {
                 PortConfig portConfig;
-                portConfig.inPlace = -1;
-                portConfig.constant = false;
-                portConfig.desc = getSrcMemDesc(itpd, i);
+                portConfig.inPlace(-1);
+                portConfig.constant(false);
+                portConfig.setMemDesc(getSrcMemDesc(itpd, i));
 
                 config.inConfs.push_back(portConfig);
             }
 
             for (size_t i = 0; i < descOutputNumbers(desc); i++) {
                 PortConfig portConfig;
-                portConfig.inPlace = canBeInPlace() ? 0 : -1;
-                portConfig.constant = false;
-                portConfig.desc = getDstMemDesc(itpd, i);
+                portConfig.inPlace(canBeInPlace() ? 0 : -1);
+                portConfig.constant(false);
+                portConfig.setMemDesc(getDstMemDesc(itpd, i));
 
                 config.outConfs.push_back(portConfig);
             }

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_memory_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_memory_node.cpp
@@ -69,9 +69,9 @@ void MKLDNNMemoryOutputNode::initSupportedPrimitiveDescriptors() {
     NodeConfig config;
     config.dynBatchSupport = true;
     config.inConfs.resize(1);
-    config.inConfs[0].inPlace = -1;
-    config.inConfs[0].constant = false;
-    config.inConfs[0].desc = std::make_shared<CpuBlockedMemoryDesc>(precision, getInputShapeAtPort(0));
+    config.inConfs[0].inPlace(-1);
+    config.inConfs[0].constant(false);
+    config.inConfs[0].setMemDesc(std::make_shared<CpuBlockedMemoryDesc>(precision, getInputShapeAtPort(0)));
     supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::unknown);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_normalize_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_normalize_node.cpp
@@ -815,16 +815,16 @@ void MKLDNNNormalizeL2Node::initSupportedPrimitiveDescriptors() {
     config.dynBatchSupport = false;
     config.inConfs.resize(2);
     config.outConfs.resize(1);
-    config.outConfs[0].inPlace = canBeInplace ? 0 : -1;
+    config.outConfs[0].inPlace(canBeInplace ? 0 : -1);
 
     auto& creatorsMap = BlockedDescCreator::getCommonCreators();
     auto pushDesc = [&](LayoutType format, impl_desc_type impl_type) {
         auto a = creatorsMap.at(format)->createSharedDesc(inputPrecision, getInputShapeAtPort(DATA));
-        config.inConfs[0].desc = std::move(a);
+        config.inConfs[0].setMemDesc(std::move(a));
         a = creatorsMap.at(LayoutType::ncsp)->createSharedDesc(InferenceEngine::Precision::I32, getInputShapeAtPort(AXES));
-        config.inConfs[1].desc = std::move(a);
+        config.inConfs[1].setMemDesc(std::move(a));
         a = creatorsMap.at(format)->createSharedDesc(outputPrecision, getOutputShapeAtPort(DATA));
-        config.outConfs[0].desc = std::move(a);
+        config.outConfs[0].setMemDesc(std::move(a));
         supportedPrimitiveDescriptors.push_back({config, impl_type});
     };
 
@@ -842,7 +842,7 @@ void MKLDNNNormalizeL2Node::initSupportedPrimitiveDescriptors() {
         }
     }
     if (canBeInplace)
-        config.inConfs[0].inPlace = 0;
+        config.inConfs[0].inPlace(0);
     pushDesc(LayoutType::ncsp, impl_type);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_pad_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_pad_node.cpp
@@ -136,13 +136,13 @@ void MKLDNNPadNode::initSupportedPrimitiveDescriptors() {
 
     auto& creatorsMap = BlockedDescCreator::getCommonCreators();
     auto pushSupportedPrimitiveDescriptor = [&](LayoutType memoryFormat) {
-        config.inConfs[0].desc = creatorsMap.at(memoryFormat)->createSharedDesc(precision, getInputShapeAtPort(DATA_ID));
-        config.inConfs[1].desc = creatorsMap.at(LayoutType::ncsp)->createSharedDesc(InferenceEngine::Precision::I32, getInputShapeAtPort(PADS_BEGIN_ID));
-        config.inConfs[2].desc = creatorsMap.at(LayoutType::ncsp)->createSharedDesc(InferenceEngine::Precision::I32, getInputShapeAtPort(PADS_END_ID));
+        config.inConfs[0].setMemDesc(creatorsMap.at(memoryFormat)->createSharedDesc(precision, getInputShapeAtPort(DATA_ID)));
+        config.inConfs[1].setMemDesc(creatorsMap.at(LayoutType::ncsp)->createSharedDesc(Precision::I32, getInputShapeAtPort(PADS_BEGIN_ID)));
+        config.inConfs[2].setMemDesc(creatorsMap.at(LayoutType::ncsp)->createSharedDesc(Precision::I32, getInputShapeAtPort(PADS_END_ID)));
         if (isPadValueSpecified)
-            config.inConfs[3].desc = creatorsMap.at(LayoutType::ncsp)->createSharedDesc(InferenceEngine::Precision::FP32, getInputShapeAtPort(PAD_VALUE_ID));
+            config.inConfs[3].setMemDesc(creatorsMap.at(LayoutType::ncsp)->createSharedDesc(Precision::FP32, getInputShapeAtPort(PAD_VALUE_ID)));
 
-        config.outConfs[0].desc = creatorsMap.at(memoryFormat)->createSharedDesc(precision, getOutputShapeAtPort(DATA_ID));
+        config.outConfs[0].setMemDesc(creatorsMap.at(memoryFormat)->createSharedDesc(precision, getOutputShapeAtPort(DATA_ID)));
         supportedPrimitiveDescriptors.push_back({config, impl_desc_type::ref});
     };
 

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_pooling_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_pooling_node.cpp
@@ -580,13 +580,13 @@ void MKLDNNPoolingNode::initDescriptor(const NodeConfig& config) {
 
         for (size_t i = 0; i < selectedConfig.inConfs.size(); i++) {
             //if (!selectedConfig.inConfs[i].getMemDesc()->isCompatible(*config.inConfs[i].getMemDesc()))
-            if (!selectedConfig.inConfs[i].getPortDesc()->compare(*config.inConfs[i].getPortDesc()))
+            if (!selectedConfig.inConfs[i].getPortDesc()->isCompatible(*config.inConfs[i].getPortDesc()))
                 IE_THROW() << "Incorrect descriptor for node: " << getName();
         }
 
         for (size_t i = 0; i < selectedConfig.outConfs.size(); i++) {
             //if (!selectedConfig.outConfs[i].getMemDesc()->isCompatible(*config.outConfs[i].getMemDesc()))
-            if (!selectedConfig.outConfs[i].getPortDesc()->compare(*config.outConfs[i].getPortDesc()))
+            if (!selectedConfig.outConfs[i].getPortDesc()->isCompatible(*config.outConfs[i].getPortDesc()))
                 IE_THROW() << "Incorrect descriptor for node: " << getName();
         }
         rightConfig = config;

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_pooling_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_pooling_node.cpp
@@ -463,18 +463,18 @@ void MKLDNNPoolingNode::initSupportedPrimitiveDescriptors() {
             config.dynBatchSupport = true;
             for (size_t i = 0; i < descInputNumbers(desc); i++) {
                 PortConfig dataConfig;
-                dataConfig.inPlace = -1;
-                dataConfig.constant = false;
-                dataConfig.desc = getSrcMemDesc(itpd, i);
+                dataConfig.inPlace(-1);
+                dataConfig.constant(false);
+                dataConfig.setMemDesc(getSrcMemDesc(itpd, i));
 
                 config.inConfs.push_back(dataConfig);
             }
 
             for (size_t i = 0; i < descOutputNumbers(desc); i++) {
                 PortConfig dataConfig;
-                dataConfig.inPlace = canBeInPlace() ? 0 : -1;
-                dataConfig.constant = false;
-                dataConfig.desc = getDstMemDesc(itpd, i);
+                dataConfig.inPlace(canBeInPlace() ? 0 : -1);
+                dataConfig.constant(false);
+                dataConfig.setMemDesc(getDstMemDesc(itpd, i));
 
                 config.outConfs.push_back(dataConfig);
             }
@@ -483,9 +483,10 @@ void MKLDNNPoolingNode::initSupportedPrimitiveDescriptors() {
             if (isMaxPool8) {
                 auto& creatorsMap = BlockedDescCreator::getCommonCreators();
                 PortConfig dataConfig;
-                dataConfig.inPlace = -1;
-                dataConfig.constant = false;
-                dataConfig.desc = creatorsMap.at(LayoutType::ncsp)->createSharedDesc(config.outConfs.front().desc->getPrecision(), getOutputShapeAtPort(1));
+                dataConfig.inPlace(-1);
+                dataConfig.constant(false);
+                dataConfig.setMemDesc(creatorsMap.at(LayoutType::ncsp)->createSharedDesc(config.outConfs.front().getMemDesc()->getPrecision(),
+                                                                                         getOutputShapeAtPort(1)));
 
                 config.outConfs.push_back(dataConfig);
             }
@@ -506,10 +507,10 @@ void MKLDNNPoolingNode::initDescriptor(const NodeConfig& config) {
     }
     std::vector<MemoryDescPtr> inDescs;
     for (const auto& inConf : config.inConfs)
-        inDescs.push_back(inConf.desc);
+        inDescs.push_back(inConf.getMemDesc());
     std::vector<MemoryDescPtr> outDescs;
     for (const auto& outConf : config.outConfs)
-        outDescs.push_back(outConf.desc);
+        outDescs.push_back(outConf.getMemDesc());
     createDescriptor(inDescs, outDescs);
 
     mkldnn::primitive_attr attr;
@@ -528,17 +529,17 @@ void MKLDNNPoolingNode::initDescriptor(const NodeConfig& config) {
             cfg.dynBatchSupport = true;
             for (size_t i = 0; i < descInputNumbers(desc); i++) {
                 PortConfig dataConfig;
-                dataConfig.inPlace = canBeInPlace() ? 0 : -1;
-                dataConfig.constant = false;
-                dataConfig.desc = getSrcMemDesc(itpd, i);
+                dataConfig.inPlace(canBeInPlace() ? 0 : -1);
+                dataConfig.constant(false);
+                dataConfig.setMemDesc(getSrcMemDesc(itpd, i));
                 cfg.inConfs.push_back(dataConfig);
             }
 
             for (size_t i = 0; i < descOutputNumbers(desc); i++) {
                 PortConfig dataConfig;
-                dataConfig.inPlace = -1;
-                dataConfig.constant = false;
-                dataConfig.desc = getDstMemDesc(itpd, i);
+                dataConfig.inPlace(-1);
+                dataConfig.constant(false);
+                dataConfig.setMemDesc(getDstMemDesc(itpd, i));
                 cfg.outConfs.push_back(dataConfig);
             }
 
@@ -546,9 +547,10 @@ void MKLDNNPoolingNode::initDescriptor(const NodeConfig& config) {
             if (isMaxPool8) {
                 auto& creatorsMap = BlockedDescCreator::getCommonCreators();
                 PortConfig dataConfig;
-                dataConfig.inPlace = -1;
-                dataConfig.constant = false;
-                dataConfig.desc = creatorsMap.at(LayoutType::ncsp)->createSharedDesc(cfg.outConfs.front().desc->getPrecision(), getOutputShapeAtPort(1));
+                dataConfig.inPlace(-1);
+                dataConfig.constant(false);
+                dataConfig.setMemDesc(creatorsMap.at(LayoutType::ncsp)->createSharedDesc(cfg.outConfs.front().getMemDesc()->getPrecision(),
+                                                                                         getOutputShapeAtPort(1)));
 
                 cfg.outConfs.push_back(dataConfig);
             }
@@ -577,12 +579,12 @@ void MKLDNNPoolingNode::initDescriptor(const NodeConfig& config) {
             return;
 
         for (size_t i = 0; i < selectedConfig.inConfs.size(); i++) {
-            if (!selectedConfig.inConfs[i].desc->isCompatible(*config.inConfs[i].desc))
+            if (!selectedConfig.inConfs[i].getMemDesc()->isCompatible(*config.inConfs[i].getMemDesc()))
                 IE_THROW() << "Incorrect descriptor for node: " << getName();
         }
 
         for (size_t i = 0; i < selectedConfig.outConfs.size(); i++) {
-            if (!selectedConfig.outConfs[i].desc->isCompatible(*config.outConfs[i].desc))
+            if (!selectedConfig.outConfs[i].getMemDesc()->isCompatible(*config.outConfs[i].getMemDesc()))
                 IE_THROW() << "Incorrect descriptor for node: " << getName();
         }
         rightConfig = config;

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_pooling_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_pooling_node.cpp
@@ -579,12 +579,14 @@ void MKLDNNPoolingNode::initDescriptor(const NodeConfig& config) {
             return;
 
         for (size_t i = 0; i < selectedConfig.inConfs.size(); i++) {
-            if (!selectedConfig.inConfs[i].getMemDesc()->isCompatible(*config.inConfs[i].getMemDesc()))
+            //if (!selectedConfig.inConfs[i].getMemDesc()->isCompatible(*config.inConfs[i].getMemDesc()))
+            if (!selectedConfig.inConfs[i].getPortDesc()->compare(*config.inConfs[i].getPortDesc()))
                 IE_THROW() << "Incorrect descriptor for node: " << getName();
         }
 
         for (size_t i = 0; i < selectedConfig.outConfs.size(); i++) {
-            if (!selectedConfig.outConfs[i].getMemDesc()->isCompatible(*config.outConfs[i].getMemDesc()))
+            //if (!selectedConfig.outConfs[i].getMemDesc()->isCompatible(*config.outConfs[i].getMemDesc()))
+            if (!selectedConfig.outConfs[i].getPortDesc()->compare(*config.outConfs[i].getPortDesc()))
                 IE_THROW() << "Incorrect descriptor for node: " << getName();
         }
         rightConfig = config;

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_pooling_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_pooling_node.cpp
@@ -579,13 +579,11 @@ void MKLDNNPoolingNode::initDescriptor(const NodeConfig& config) {
             return;
 
         for (size_t i = 0; i < selectedConfig.inConfs.size(); i++) {
-            //if (!selectedConfig.inConfs[i].getMemDesc()->isCompatible(*config.inConfs[i].getMemDesc()))
             if (!selectedConfig.inConfs[i].getPortDesc()->isCompatible(*config.inConfs[i].getPortDesc()))
                 IE_THROW() << "Incorrect descriptor for node: " << getName();
         }
 
         for (size_t i = 0; i < selectedConfig.outConfs.size(); i++) {
-            //if (!selectedConfig.outConfs[i].getMemDesc()->isCompatible(*config.outConfs[i].getMemDesc()))
             if (!selectedConfig.outConfs[i].getPortDesc()->isCompatible(*config.outConfs[i].getPortDesc()))
                 IE_THROW() << "Incorrect descriptor for node: " << getName();
         }

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_reduce_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_reduce_node.cpp
@@ -1815,21 +1815,21 @@ void MKLDNNReduceNode::initSupportedPrimitiveDescriptors() {
     config.dynBatchSupport = false;
     config.inConfs.resize(2);
     config.outConfs.resize(1);
-    config.inConfs[REDUCE_DATA].constant = false;
-    config.inConfs[REDUCE_INDEXES].constant = false;
-    config.outConfs[0].constant = false;
-    config.inConfs[REDUCE_DATA].inPlace = -1;
-    config.inConfs[REDUCE_INDEXES].inPlace = -1;
-    config.outConfs[0].inPlace = -1;
+    config.inConfs[REDUCE_DATA].constant(false);
+    config.inConfs[REDUCE_INDEXES].constant(false);
+    config.outConfs[0].constant(false);
+    config.inConfs[REDUCE_DATA].inPlace(-1);
+    config.inConfs[REDUCE_INDEXES].inPlace(-1);
+    config.outConfs[0].inPlace(-1);
 
     auto& creatorsMap = BlockedDescCreator::getCommonCreators();
 
     auto pushDesc = [&](LayoutType inFormat, LayoutType outFormat, InferenceEngine::Precision inPrecision,
             InferenceEngine::Precision outPrecision, impl_desc_type impl_type) {
-        config.inConfs[REDUCE_DATA].desc = creatorsMap.at(inFormat)->createSharedDesc(inPrecision, getInputShapeAtPort(REDUCE_DATA));
-        config.inConfs[REDUCE_INDEXES].desc = creatorsMap.at(LayoutType::ncsp)->createSharedDesc(InferenceEngine::Precision::I32,
-                                                                                                 getInputShapeAtPort(REDUCE_INDEXES));
-        config.outConfs[0].desc = creatorsMap.at(outFormat)->createSharedDesc(outPrecision, getOutputShapeAtPort(0));
+        config.inConfs[REDUCE_DATA].setMemDesc(creatorsMap.at(inFormat)->createSharedDesc(inPrecision, getInputShapeAtPort(REDUCE_DATA)));
+        config.inConfs[REDUCE_INDEXES].setMemDesc(creatorsMap.at(LayoutType::ncsp)->createSharedDesc(InferenceEngine::Precision::I32,
+                                                                                                 getInputShapeAtPort(REDUCE_INDEXES)));
+        config.outConfs[0].setMemDesc(creatorsMap.at(outFormat)->createSharedDesc(outPrecision, getOutputShapeAtPort(0)));
         supportedPrimitiveDescriptors.push_back({config, impl_type});
     };
 
@@ -1956,8 +1956,8 @@ void MKLDNNReduceNode::createPrimitive() {
 
     auto selectedPD = getSelectedPrimitiveDescriptor();
     jcp = jit_reduce_config_params();
-    jcp.src_dt = MKLDNNExtensionUtils::IEPrecisionToDataType(selectedPD->getConfig().inConfs[REDUCE_DATA].desc->getPrecision());
-    jcp.dst_dt = MKLDNNExtensionUtils::IEPrecisionToDataType(selectedPD->getConfig().outConfs[0].desc->getPrecision());
+    jcp.src_dt = MKLDNNExtensionUtils::IEPrecisionToDataType(selectedPD->getConfig().inConfs[REDUCE_DATA].getMemDesc()->getPrecision());
+    jcp.dst_dt = MKLDNNExtensionUtils::IEPrecisionToDataType(selectedPD->getConfig().outConfs[0].getMemDesc()->getPrecision());
     jcp.src_data_size = MKLDNNExtensionUtils::sizeOfDataType(jcp.src_dt);
     jcp.dst_data_size = MKLDNNExtensionUtils::sizeOfDataType(jcp.dst_dt);
     jcp.layout = layout;

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_reshape_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_reshape_node.cpp
@@ -113,15 +113,15 @@ void MKLDNNReshapeNode::initSupportedPrimitiveDescriptors() {
     config.inConfs.resize(getParentEdges().size());
     auto& creatorsMap = BlockedDescCreator::getCommonCreators();
     for (size_t i = 0; i < getParentEdges().size(); i++) {
-        config.inConfs[i].inPlace = -1;
-        config.inConfs[i].constant = false;
-        config.inConfs[i].desc = creatorsMap.at(LayoutType::ncsp)->createSharedDesc((i > 0 ? secondInPrc : inPrec), getInputShapeAtPort(i));
+        config.inConfs[i].inPlace(-1);
+        config.inConfs[i].constant(false);
+        config.inConfs[i].setMemDesc(creatorsMap.at(LayoutType::ncsp)->createSharedDesc((i > 0 ? secondInPrc : inPrec), getInputShapeAtPort(i)));
     }
     config.outConfs.resize(1);
     // TODO [DS]: inplace
-    config.outConfs[0].inPlace = isDynamicNode() ? -1 : 0;
-    config.outConfs[0].constant = false;
-    config.outConfs[0].desc = creatorsMap.at(LayoutType::ncsp)->createSharedDesc(outPrec, getOutputShapeAtPort(0));
+    config.outConfs[0].inPlace(isDynamicNode() ? -1 : 0);
+    config.outConfs[0].constant(false);
+    config.outConfs[0].setMemDesc(creatorsMap.at(LayoutType::ncsp)->createSharedDesc(outPrec, getOutputShapeAtPort(0)));
     supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::unknown);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_rnn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_rnn.cpp
@@ -763,17 +763,17 @@ void MKLDNNRNN::createDescriptor(const std::vector<MemoryDescPtr> &inputDesc,
     config.dynBatchSupport = false;
     for (size_t i = 0; i < inputDesc.size(); i++) {
         PortConfig dataConfig;
-        dataConfig.inPlace = -1;
-        dataConfig.constant = false;
-        dataConfig.desc = inputDesc[i];
+        dataConfig.inPlace(-1);
+        dataConfig.constant(false);
+        dataConfig.setMemDesc(inputDesc[i]);
         config.inConfs.push_back(dataConfig);
     }
 
     for (size_t i = 0; i < outputDesc.size(); i++) {
         PortConfig dataConfig;
-        dataConfig.inPlace = -1;
-        dataConfig.constant = false;
-        dataConfig.desc = outputDesc[i];
+        dataConfig.inPlace(-1);
+        dataConfig.constant(false);
+        dataConfig.setMemDesc(outputDesc[i]);
         config.outConfs.push_back(dataConfig);
     }
 
@@ -865,12 +865,12 @@ void MKLDNNRNN::prepareParams() {
 }
 
 std::shared_ptr<MemoryDesc> MKLDNNRNN::getSrcMemDesc(mkldnn::primitive_desc_iterator& primitive_desc_it, size_t idx) {
-    auto desc = supportedPrimitiveDescriptors[0].getConfig().inConfs[idx].desc;
+    auto desc = supportedPrimitiveDescriptors[0].getConfig().inConfs[idx].getMemDesc();
     return desc->as<BlockedMemoryDesc>()->cloneWithUndefStridesAndOffset();
 }
 
 std::shared_ptr<MemoryDesc> MKLDNNRNN::getDstMemDesc(mkldnn::primitive_desc_iterator& primitive_desc_it, size_t idx) {
-    auto desc = supportedPrimitiveDescriptors[0].getConfig().outConfs[idx].desc;
+    auto desc = supportedPrimitiveDescriptors[0].getConfig().outConfs[idx].getMemDesc();
     return desc->as<BlockedMemoryDesc>()->cloneWithUndefStridesAndOffset();
 }
 

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_rnn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_rnn.cpp
@@ -865,13 +865,11 @@ void MKLDNNRNN::prepareParams() {
 }
 
 std::shared_ptr<MemoryDesc> MKLDNNRNN::getSrcMemDesc(mkldnn::primitive_desc_iterator& primitive_desc_it, size_t idx) {
-    auto desc = supportedPrimitiveDescriptors[0].getConfig().inConfs[idx].getMemDesc();
-    return desc->as<BlockedMemoryDesc>()->cloneWithUndefStridesAndOffset();
+    return supportedPrimitiveDescriptors[0].getConfig().inConfs[idx].getMemDesc();
 }
 
 std::shared_ptr<MemoryDesc> MKLDNNRNN::getDstMemDesc(mkldnn::primitive_desc_iterator& primitive_desc_it, size_t idx) {
-    auto desc = supportedPrimitiveDescriptors[0].getConfig().outConfs[idx].getMemDesc();
-    return desc->as<BlockedMemoryDesc>()->cloneWithUndefStridesAndOffset();
+    return supportedPrimitiveDescriptors[0].getConfig().outConfs[idx].getMemDesc();
 }
 
 void MKLDNNRNN::execute(mkldnn::stream strm) {

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_roi_pooling_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_roi_pooling_node.cpp
@@ -468,8 +468,8 @@ void MKLDNNROIPoolingNode::createPrimitive() {
     refParams.alg = getAlgorithm();
 
     const auto& config = selectedPD->getConfig();
-    refParams.src_prc = config.inConfs[0].desc->getPrecision();
-    refParams.dst_prc = config.outConfs[0].desc->getPrecision();
+    refParams.src_prc = config.inConfs[0].getMemDesc()->getPrecision();
+    refParams.dst_prc = config.outConfs[0].getMemDesc()->getPrecision();
 
     if (inputShapesDefined()) {
         if (needPrepareParams() && isExecutable())

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_scatter_update_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_scatter_update_node.cpp
@@ -194,17 +194,17 @@ void MKLDNNScatterUpdateNode::initSupportedPrimitiveDescriptors() {
         config.inConfs.resize(3);
     }
     config.outConfs.resize(1);
-    config.inConfs[DATA_ID].constant = false;
-    config.inConfs[INDICES_ID].constant = false;
-    config.inConfs[UPDATE_ID].constant = false;
-    config.outConfs[0].constant = false;
-    config.inConfs[DATA_ID].inPlace = canBeInplace ? 0 : -1;
-    config.inConfs[INDICES_ID].inPlace = -1;
-    config.inConfs[UPDATE_ID].inPlace = -1;
-    config.outConfs[0].inPlace = canBeInplace ? 0 : -1;
+    config.inConfs[DATA_ID].constant(false);
+    config.inConfs[INDICES_ID].constant(false);
+    config.inConfs[UPDATE_ID].constant(false);
+    config.outConfs[0].constant(false);
+    config.inConfs[DATA_ID].inPlace(canBeInplace ? 0 : -1);
+    config.inConfs[INDICES_ID].inPlace(-1);
+    config.inConfs[UPDATE_ID].inPlace(-1);
+    config.outConfs[0].inPlace(canBeInplace ? 0 : -1);
     if (axisRelaxed) {
-        config.inConfs[AXIS_ID].constant = false;
-        config.inConfs[AXIS_ID].inPlace = -1;
+        config.inConfs[AXIS_ID].constant(false);
+        config.inConfs[AXIS_ID].inPlace(-1);
     }
 
     std::vector<PortConfigurator> inPortConfig{{LayoutType::ncsp, dataPrec}, {LayoutType::ncsp, indicesPrec}, {LayoutType::ncsp, dataPrec}};

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_softmax_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_softmax_node.cpp
@@ -109,22 +109,22 @@ void MKLDNNSoftMaxNode::initOptimalPrimitiveDescriptor() {
     if (selected_pd == nullptr)
         IE_THROW() << "Preferable primitive descriptor is not set.";
     auto config = selected_pd->getConfig();
-    if (isConfigDefined(config))
+    if (isDynamicNode()) //isConfigDefined(config)
         return;
 
     if (config.inConfs.size() != 1 || config.outConfs.size() != 1 ||
             (config.inConfs[0].getMemDesc()->isDefined() &&
-                    config.outConfs[0].getMemDesc()->isDefined() && !config.inConfs[0].getMemDesc()->isCompatible(*config.outConfs[0].getMemDesc())))
+                    config.outConfs[0].getMemDesc()->isDefined() && !config.outConfs[0].getPortDesc()->compare(*config.inConfs[0].getPortDesc())))
         IE_THROW() << "Layer " << getName() << " has incorrect selected config!";
 
-    if (config.inConfs[0].getMemDesc()->isDefined()) {
-        config.outConfs[0].setMemDesc(config.inConfs[0].getMemDesc());
-    } else if (config.outConfs[0].getMemDesc()->isDefined()) {
-        config.inConfs[0].setMemDesc(config.outConfs[0].getMemDesc());
-    } else {
+//    if (config.inConfs[0].getMemDesc()->isDefined()) {
+//        config.outConfs[0].setMemDesc(config.inConfs[0].getMemDesc());
+//    } else if (config.outConfs[0].getMemDesc()->isDefined()) {
+//        config.inConfs[0].setMemDesc(config.outConfs[0].getMemDesc());
+//    } else {
         config.inConfs[0].setMemDesc(getDefinedInputDesc(config, 0));
         config.outConfs[0].setMemDesc(config.inConfs[0].getMemDesc());
-    }
+//    }
 
     initDescriptor(config);
 }

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_softmax_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_softmax_node.cpp
@@ -111,7 +111,7 @@ void MKLDNNSoftMaxNode::initOptimalPrimitiveDescriptor() {
     auto config = selected_pd->getConfig();
     if (isDynamicNode()) {
         auto outMemDesc = config.outConfs[0].getMemDesc();
-        config.outConfs[0].setMemDesc(std::dynamic_pointer_cast<BlockedMemoryDesc>(outMemDesc), 0xffffffff);
+        config.outConfs[0].setMemDesc(std::dynamic_pointer_cast<BlockedMemoryDesc>(outMemDesc), BLOCKED_DESC_FULL_MASK);
     } else {
         if (config.inConfs.size() != 1 || config.outConfs.size() != 1 ||
             (config.inConfs[0].getMemDesc()->isDefined() &&

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_softmax_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_softmax_node.cpp
@@ -118,7 +118,7 @@ void MKLDNNSoftMaxNode::initOptimalPrimitiveDescriptor() {
              config.outConfs[0].getMemDesc()->isDefined() && !config.outConfs[0].getPortDesc()->isCompatible(*config.inConfs[0].getPortDesc())))
             IE_THROW() << "Layer " << getName() << " has incorrect selected config!";
 
-        config.inConfs[0].setMemDesc(getConsistentInputDesc(config, 0));
+        config.inConfs[0].setMemDesc(getConsistentInputDesc(config, 0)->getMemDesc());
         config.outConfs[0].setMemDesc(config.inConfs[0].getMemDesc());
     }
     initDescriptor(config);

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_softmax_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_softmax_node.cpp
@@ -114,7 +114,7 @@ void MKLDNNSoftMaxNode::initOptimalPrimitiveDescriptor() {
 
     if (config.inConfs.size() != 1 || config.outConfs.size() != 1 ||
             (config.inConfs[0].getMemDesc()->isDefined() &&
-                    config.outConfs[0].getMemDesc()->isDefined() && !config.outConfs[0].getPortDesc()->compare(*config.inConfs[0].getPortDesc())))
+                    config.outConfs[0].getMemDesc()->isDefined() && !config.outConfs[0].getPortDesc()->isCompatible(*config.inConfs[0].getPortDesc())))
         IE_THROW() << "Layer " << getName() << " has incorrect selected config!";
 
 //    if (config.inConfs[0].getMemDesc()->isDefined()) {

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_softmax_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_softmax_node.cpp
@@ -122,7 +122,7 @@ void MKLDNNSoftMaxNode::initOptimalPrimitiveDescriptor() {
 //    } else if (config.outConfs[0].getMemDesc()->isDefined()) {
 //        config.inConfs[0].setMemDesc(config.outConfs[0].getMemDesc());
 //    } else {
-        config.inConfs[0].setMemDesc(getDefinedInputDesc(config, 0));
+        config.inConfs[0].setMemDesc(getConsistentInputDesc(config, 0));
         config.outConfs[0].setMemDesc(config.inConfs[0].getMemDesc());
 //    }
 

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_softmax_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_softmax_node.cpp
@@ -113,17 +113,17 @@ void MKLDNNSoftMaxNode::initOptimalPrimitiveDescriptor() {
         return;
 
     if (config.inConfs.size() != 1 || config.outConfs.size() != 1 ||
-            (config.inConfs[0].desc->isDefined() &&
-                    config.outConfs[0].desc->isDefined() && !config.inConfs[0].desc->isCompatible(*config.outConfs[0].desc)))
+            (config.inConfs[0].getMemDesc()->isDefined() &&
+                    config.outConfs[0].getMemDesc()->isDefined() && !config.inConfs[0].getMemDesc()->isCompatible(*config.outConfs[0].getMemDesc())))
         IE_THROW() << "Layer " << getName() << " has incorrect selected config!";
 
-    if (config.inConfs[0].desc->isDefined()) {
-        config.outConfs[0].desc = config.inConfs[0].desc;
-    } else if (config.outConfs[0].desc->isDefined()) {
-        config.inConfs[0].desc = config.outConfs[0].desc;
+    if (config.inConfs[0].getMemDesc()->isDefined()) {
+        config.outConfs[0].setMemDesc(config.inConfs[0].getMemDesc());
+    } else if (config.outConfs[0].getMemDesc()->isDefined()) {
+        config.inConfs[0].setMemDesc(config.outConfs[0].getMemDesc());
     } else {
-        config.inConfs[0].desc = getDefinedInputDesc(config, 0);
-        config.outConfs[0].desc = config.inConfs[0].desc;
+        config.inConfs[0].setMemDesc(getDefinedInputDesc(config, 0));
+        config.outConfs[0].setMemDesc(config.inConfs[0].getMemDesc());
     }
 
     initDescriptor(config);

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_space_to_depth_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_space_to_depth_node.cpp
@@ -130,10 +130,10 @@ void MKLDNNSpaceToDepthNode::initSupportedPrimitiveDescriptors() {
     config.dynBatchSupport = true;
     config.inConfs.resize(1);
     config.outConfs.resize(1);
-    config.inConfs[0].inPlace = -1;
-    config.inConfs[0].constant = false;
-    config.outConfs[0].inPlace = -1;
-    config.outConfs[0].constant = false;
+    config.inConfs[0].inPlace(-1);
+    config.inConfs[0].constant(false);
+    config.outConfs[0].inPlace(-1);
+    config.outConfs[0].constant(false);
 
     const auto& inputDataShape = getInputShapeAtPort(0);
     const auto& outputDataShape = getOutputShapeAtPort(0);
@@ -157,8 +157,8 @@ void MKLDNNSpaceToDepthNode::initSupportedPrimitiveDescriptors() {
     auto range = BlockedDescCreator::makeFilteredRange(creators, inputDataShape.getRank(), supportedTypes);
 
     for (auto itr = range.first; itr != range.second; ++itr) {
-        config.inConfs[0].desc = itr->second->createSharedDesc(precision, inputDataShape);
-        config.outConfs[0].desc = itr->second->createSharedDesc(precision, outputDataShape);
+        config.inConfs[0].setMemDesc(itr->second->createSharedDesc(precision, inputDataShape));
+        config.outConfs[0].setMemDesc(itr->second->createSharedDesc(precision, outputDataShape));
         supportedPrimitiveDescriptors.emplace_back(config, impl_type);
     }
 }

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_split_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_split_node.cpp
@@ -180,12 +180,12 @@ void MKLDNNSplitNode::initSupportedPrimitiveDescriptors() {
             SizeVector strides(numOfDim);
             strides.back() = 1lu;
             size_t offset = Shape::UNDEFINED_DIM;
-            uint32_t mask = 0xffffffff ^ (1 << 31); // accepts any offset
+            BlockedMemoryDesc::CmpMask mask = BLOCKED_DESC_SKIP_OFFSET_MASK; // accepts any offset
 
             for (size_t i = 2; i <= numOfDim; i++) {
                 if (numOfDim - i < axis) {
                     strides[numOfDim - i] = Shape::UNDEFINED_DIM;
-                    mask ^= (1 << (numOfDim - i)); // accepts any strides on axis
+                    mask.reset(numOfDim - i); // accepts any strides on axis
                 } else {
                     strides[numOfDim - i] = strides[numOfDim - i + 1] * blkDims[numOfDim - i + 1];
                 }
@@ -360,7 +360,7 @@ void MKLDNNSplitNode::initOptimalPrimitiveDescriptor() {
                                                                              firstInBlockingDesc->getOffsetPadding() + offset,
                                                                              firstInBlockingDesc->getOffsetPaddingToData(),
                                                                              (shape.hasZeroDims() ? VectorDims(blkDims.size(), 0) :
-                                                                              firstInBlockingDesc->getStrides())), 0xffffffff);
+                                                                              firstInBlockingDesc->getStrides())), BLOCKED_DESC_FULL_MASK);
 
             size_t axisSize = 1;
             for (size_t j = axis; j < outBlockingDesc->getBlockDims().size(); j++) {

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_split_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_split_node.cpp
@@ -333,7 +333,7 @@ void MKLDNNSplitNode::initOptimalPrimitiveDescriptor() {
                     const auto& parentConfig = getParentEdgeAt(i)->getParent()->getSelectedPrimitiveDescriptor()->getConfig().outConfs[num];
                     if (!parentConfig.getMemDesc()->isDefined() && parentConfig.inPlace() >= 0)
                         getParentEdgeAt(i)->getParent()->initOptimalPrimitiveDescriptor();
-                    if (parentConfig.getMemDesc()->isDefined() && config.inConfs[i].getPortDesc()->compare(*parentConfig.getPortDesc())) {
+                    if (parentConfig.getMemDesc()->isDefined() && config.inConfs[i].getPortDesc()->isCompatible(*parentConfig.getPortDesc())) {
                         config.inConfs[i].setMemDesc(parentConfig.getMemDesc());
                         continue;
                     }

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_split_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_split_node.cpp
@@ -327,7 +327,7 @@ void MKLDNNSplitNode::initOptimalPrimitiveDescriptor() {
 //            if (config.inConfs[i].getMemDesc()->isDefined())
 //                continue;
 
-            int num = getParentEdgeAt(i)->getOutputNum();
+            int num = getParentEdgeAt(i)->getInputNum();
             if (getParentEdgeAt(i)->getParent()->getSelectedPrimitiveDescriptor()) {
                 if (num >= 0) {
                     const auto& parentConfig = getParentEdgeAt(i)->getParent()->getSelectedPrimitiveDescriptor()->getConfig().outConfs[num];

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_split_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_split_node.cpp
@@ -135,23 +135,23 @@ void MKLDNNSplitNode::initSupportedPrimitiveDescriptors() {
 
         config.dynBatchSupport = dynBatchSupport;
         config.inConfs.resize(INPUTS_NUM);
-        config.inConfs[0].inPlace = -1;
-        config.inConfs[0].constant = false;
-        config.inConfs[0].desc = std::make_shared<CpuBlockedMemoryDesc>(itr->second->createDesc(inpPrecision, srcShape));
-        config.inConfs[1].inPlace = -1;
-        config.inConfs[1].constant = true;
-        config.inConfs[1].desc = std::make_shared<CpuBlockedMemoryDesc>(axisPrecision, Shape(VectorDims{1}));
+        config.inConfs[0].inPlace(-1);
+        config.inConfs[0].constant(false);
+        config.inConfs[0].setMemDesc(std::make_shared<CpuBlockedMemoryDesc>(itr->second->createDesc(inpPrecision, srcShape)));
+        config.inConfs[1].inPlace(-1);
+        config.inConfs[1].constant(true);
+        config.inConfs[1].setMemDesc(std::make_shared<CpuBlockedMemoryDesc>(axisPrecision, Shape(VectorDims{1})));
         if (INPUTS_NUM == 3) {
-            config.inConfs[2].desc = std::make_shared<CpuBlockedMemoryDesc>(axisPrecision, Shape(VectorDims{outputShapes.size()}));
-            config.inConfs[2].constant = true;
+            config.inConfs[2].setMemDesc(std::make_shared<CpuBlockedMemoryDesc>(axisPrecision, Shape(VectorDims{outputShapes.size()})));
+            config.inConfs[2].constant(true);
         }
 
         config.outConfs.resize(outputShapes.size());
 
         for (size_t i = 0; i < outputShapes.size(); i++) {
-            config.outConfs[i].inPlace = -1;
-            config.outConfs[i].constant = false;
-            config.outConfs[i].desc = std::make_shared<CpuBlockedMemoryDesc>(itr->second->createDesc(inpPrecision, outputShapes[i]));
+            config.outConfs[i].inPlace(-1);
+            config.outConfs[i].constant(false);
+            config.outConfs[i].setMemDesc(std::make_shared<CpuBlockedMemoryDesc>(itr->second->createDesc(inpPrecision, outputShapes[i])));
         }
         supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::ref);
 
@@ -171,7 +171,7 @@ void MKLDNNSplitNode::initSupportedPrimitiveDescriptors() {
         for (auto refPdIndex : pdIndexesToReuse) {
             const auto& refConfig = supportedPrimitiveDescriptors[refPdIndex].getConfig();
             auto config = refConfig;
-            const auto inBlockingDesc = refConfig.inConfs[0].desc->as<CpuBlockedMemoryDesc>();
+            const auto inBlockingDesc = refConfig.inConfs[0].getMemDesc()->as<CpuBlockedMemoryDesc>();
             const auto& order = inBlockingDesc->getOrder();
             const auto& blkDims = inBlockingDesc->getBlockDims();
             auto numOfDim = blkDims.size();
@@ -189,17 +189,17 @@ void MKLDNNSplitNode::initSupportedPrimitiveDescriptors() {
                 }
             }
 
-            config.inConfs[0].desc = std::make_shared<CpuBlockedMemoryDesc>(inpPrecision, srcShape, blkDims, order, offset, offsets, strides);
+            config.inConfs[0].setMemDesc(std::make_shared<CpuBlockedMemoryDesc>(inpPrecision, srcShape, blkDims, order, offset, offsets, strides));
 
             for (size_t i = 0; i < outputShapes.size(); i++) {
-                auto outBlockingDesc = refConfig.outConfs[i].desc->as<CpuBlockedMemoryDesc>();
+                auto outBlockingDesc = refConfig.outConfs[i].getMemDesc()->as<CpuBlockedMemoryDesc>();
                 const auto& outBlkDims = outBlockingDesc->getBlockDims();
                 const auto& shape = outBlockingDesc->getShape();
                 const auto& dims = shape.getStaticDims();
 
-                config.outConfs[i].inPlace = 0;
-                config.outConfs[i].desc = std::make_shared<CpuBlockedMemoryDesc>(outPrecision, Shape(dims), outBlkDims, order, offset, offsets,
-                                                                                 shape.hasZeroDims() ? SizeVector(numOfDim, 0) : strides);
+                config.outConfs[i].inPlace(0);
+                config.outConfs[i].setMemDesc(std::make_shared<CpuBlockedMemoryDesc>(outPrecision, Shape(dims), outBlkDims, order, offset, offsets,
+                                                                                 shape.hasZeroDims() ? SizeVector(numOfDim, 0) : strides));
             }
             supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::unknown);
         }
@@ -211,22 +211,22 @@ void MKLDNNSplitNode::initSupportedPrimitiveDescriptors() {
 
         config.dynBatchSupport = dynBatchSupport;
         config.inConfs.resize(INPUTS_NUM);
-        config.inConfs[0].inPlace = -1;
-        config.inConfs[0].constant = false;
-        config.inConfs[0].desc = creatorsMap.at(LayoutType::nspc)->createSharedDesc(inpPrecision, srcShape);
-        config.inConfs[1].inPlace = -1;
-        config.inConfs[1].constant = true;
-        config.inConfs[1].desc = std::make_shared<CpuBlockedMemoryDesc>(axisPrecision, Shape(VectorDims{1}));
+        config.inConfs[0].inPlace(-1);
+        config.inConfs[0].constant(false);
+        config.inConfs[0].setMemDesc(creatorsMap.at(LayoutType::nspc)->createSharedDesc(inpPrecision, srcShape));
+        config.inConfs[1].inPlace(-1);
+        config.inConfs[1].constant(true);
+        config.inConfs[1].setMemDesc(std::make_shared<CpuBlockedMemoryDesc>(axisPrecision, Shape(VectorDims{1})));
         if (INPUTS_NUM == 3) {
-            config.inConfs[2].desc = std::make_shared<CpuBlockedMemoryDesc>(axisPrecision, Shape(VectorDims{outputShapes.size()}));
-            config.inConfs[2].constant = true;
+            config.inConfs[2].setMemDesc(std::make_shared<CpuBlockedMemoryDesc>(axisPrecision, Shape(VectorDims{outputShapes.size()})));
+            config.inConfs[2].constant(true);
         }
         config.outConfs.resize(outputShapes.size());
 
         for (size_t i = 0; i < outputShapes.size(); i++) {
-            config.outConfs[i].inPlace = -1;
-            config.outConfs[i].constant = false;
-            config.outConfs[i].desc = creatorsMap.at(LayoutType::ncsp)->createSharedDesc(inpPrecision, outputShapes[i]);
+            config.outConfs[i].inPlace(-1);
+            config.outConfs[i].constant(false);
+            config.outConfs[i].setMemDesc(creatorsMap.at(LayoutType::ncsp)->createSharedDesc(inpPrecision, outputShapes[i]));
         }
         supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::ref);
     }
@@ -309,7 +309,7 @@ bool MKLDNNSplitNode::created() const {
 }
 
 bool MKLDNNSplitNode::isOptimized() const {
-    return getSelectedPrimitiveDescriptor() && getSelectedPrimitiveDescriptor()->getConfig().outConfs[0].inPlace >= 0;
+    return getSelectedPrimitiveDescriptor() && getSelectedPrimitiveDescriptor()->getConfig().outConfs[0].inPlace() >= 0;
 }
 
 void MKLDNNSplitNode::initOptimalPrimitiveDescriptor() {
@@ -322,43 +322,43 @@ void MKLDNNSplitNode::initOptimalPrimitiveDescriptor() {
         MKLDNNNode::initOptimalPrimitiveDescriptor();
     } else if (!isConfigDefined(config)) {
         for (size_t i = 0; i < config.inConfs.size(); i++) {
-            if (config.inConfs[i].desc->isDefined())
+            if (config.inConfs[i].getMemDesc()->isDefined())
                 continue;
 
             int num = getParentEdgeAt(i)->getOutputNum();
             if (getParentEdgeAt(i)->getParent()->getSelectedPrimitiveDescriptor()) {
                 if (num >= 0) {
                     const auto& parentConfig = getParentEdgeAt(i)->getParent()->getSelectedPrimitiveDescriptor()->getConfig().outConfs[num];
-                    if (!parentConfig.desc->isDefined() && parentConfig.inPlace >= 0)
+                    if (!parentConfig.getMemDesc()->isDefined() && parentConfig.inPlace() >= 0)
                         getParentEdgeAt(i)->getParent()->initOptimalPrimitiveDescriptor();
-                    if (parentConfig.desc->isDefined() && parentConfig.desc->isCompatible(*config.inConfs[i].desc)) {
-                        config.inConfs[i].desc = parentConfig.desc;
+                    if (parentConfig.getMemDesc()->isDefined() && parentConfig.getMemDesc()->isCompatible(*config.inConfs[i].getMemDesc())) {
+                        config.inConfs[i].setMemDesc(parentConfig.getMemDesc());
                         continue;
                     }
                 }
             }
 
             // reset undefined offsets
-            config.inConfs[i].desc = config.inConfs[i].desc->as<BlockedMemoryDesc>()->cloneWithDefaultStridesAndOffset();
+            config.inConfs[i].setMemDesc(config.inConfs[i].getMemDesc()->as<BlockedMemoryDesc>()->cloneWithDefaultStridesAndOffset());
         }
         if (config.outConfs.size() != outputShapes.size())
             THROW_ERROR << "has invalid config";
 
-        auto firstInBlockingDesc = config.inConfs[0].desc->as<BlockedMemoryDesc>();
+        auto firstInBlockingDesc = config.inConfs[0].getMemDesc()->as<BlockedMemoryDesc>();
         size_t offset = 0;
         for (size_t i = 0; i < outputShapes.size(); i++) {
-            auto oldDesc = config.outConfs[i].desc;
+            auto oldDesc = config.outConfs[i].getMemDesc();
             auto outBlockingDesc = oldDesc->as<BlockedMemoryDesc>();
             const auto& shape = outBlockingDesc->getShape();
             const auto& blkDims = outBlockingDesc->getBlockDims();
-            config.outConfs[i].desc = std::make_shared<CpuBlockedMemoryDesc>(outBlockingDesc->getPrecision(),
+            config.outConfs[i].setMemDesc(std::make_shared<CpuBlockedMemoryDesc>(outBlockingDesc->getPrecision(),
                                                                              shape,
                                                                              blkDims,
                                                                              outBlockingDesc->getOrder(),
                                                                              firstInBlockingDesc->getOffsetPadding() + offset,
                                                                              firstInBlockingDesc->getOffsetPaddingToData(),
                                                                              (shape.hasZeroDims() ? VectorDims(blkDims.size(), 0) :
-                                                                              firstInBlockingDesc->getStrides()));
+                                                                              firstInBlockingDesc->getStrides())));
 
             size_t axisSize = 1;
             for (size_t j = axis; j < outBlockingDesc->getBlockDims().size(); j++) {
@@ -372,11 +372,11 @@ void MKLDNNSplitNode::initOptimalPrimitiveDescriptor() {
     config = selected_pd->getConfig();
     canUseOptimizedNspc2Ncsp = false;
     IE_ASSERT(config.inConfs.size() > 0);
-    const auto inConfDesc = config.inConfs[0].desc;
+    const auto inConfDesc = config.inConfs[0].getMemDesc();
     if (axis == 1 && one_of(inConfDesc->getShape().getRank(), 4, 5) && inConfDesc->hasLayoutType(LayoutType::nspc)) {
         canUseOptimizedNspc2Ncsp = true;
         for (size_t i = 0; i < config.outConfs.size(); i++) {
-            if (!config.outConfs[i].desc->hasLayoutType(LayoutType::ncsp))
+            if (!config.outConfs[i].getMemDesc()->hasLayoutType(LayoutType::ncsp))
                 canUseOptimizedNspc2Ncsp = false;
         }
     }
@@ -389,7 +389,7 @@ void MKLDNNSplitNode::selectOptimalPrimitiveDescriptor() {
     if (!implPriorities.empty() && implPriorities[0] == impl_desc_type::ref) {
         for (size_t i = 0; i < supportedPrimitiveDescriptors.size(); ++i) {
             auto& pd = supportedPrimitiveDescriptors[i];
-            if (pd.getConfig().inConfs[0].desc->hasLayoutType(LayoutType::ncsp) &&
+            if (pd.getConfig().inConfs[0].getMemDesc()->hasLayoutType(LayoutType::ncsp) &&
                 impl_desc_type::ref == pd.getImplementationType()) {
                     selectPrimitiveDescriptorByIndex(static_cast<int>(i));
                 return;
@@ -409,7 +409,7 @@ void MKLDNNSplitNode::selectOptimalPrimitiveDescriptor() {
             if (inNum < 0 || inNum >= parent_spd->getConfig().outConfs.size()) {
                 inNum = 0;
             }
-            if (supportedPrimitiveDescriptors[i].getConfig().inConfs[0].desc->isCompatible(*parent_spd->getConfig().outConfs[inNum].desc)) {
+            if (supportedPrimitiveDescriptors[i].getConfig().inConfs[0].getMemDesc()->isCompatible(*parent_spd->getConfig().outConfs[inNum].getMemDesc())) {
                 canSelectPrimitive.push_back(i);
             }
         }
@@ -434,7 +434,7 @@ void MKLDNNSplitNode::selectOptimalPrimitiveDescriptor() {
             auto childEdge = getChildEdgeAt(i);
             auto childPtr = childEdge->getChild();
             auto& vecChildSpd = childPtr->getSupportedPrimitiveDescriptors();
-            const auto& outputDesc = supportedPrimitiveDescriptors[indx].getConfig().outConfs[childEdge->getInputNum()].desc;
+            const auto& outputDesc = supportedPrimitiveDescriptors[indx].getConfig().outConfs[childEdge->getInputNum()].getMemDesc();
 
             if (!vecChildSpd.empty()) {
                 int inNum = childEdge->getOutputNum();
@@ -446,7 +446,7 @@ void MKLDNNSplitNode::selectOptimalPrimitiveDescriptor() {
                     if (inNum >= childSpd.getConfig().inConfs.size()) {
                         inNum = 0;
                     }
-                    if (outputDesc->isCompatible(*childSpd.getConfig().inConfs[inNum].desc)) {
+                    if (outputDesc->isCompatible(*childSpd.getConfig().inConfs[inNum].getMemDesc())) {
                         hasMatchDesc = true;
                         break;
                     }

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_strided_slice_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_strided_slice_node.cpp
@@ -249,19 +249,19 @@ void MKLDNNStridedSliceNode::initSupportedPrimitiveDescriptors() {
     NodeConfig config;
     config.dynBatchSupport = false;
     config.inConfs.resize(getParentEdges().size());
-    config.inConfs[DATA_ID].inPlace = -1;
-    config.inConfs[BEGIN_ID].inPlace = -1;
-    config.inConfs[END_ID].inPlace = -1;
-    config.inConfs[DATA_ID].constant = isConstantInput[DATA_ID];
-    config.inConfs[BEGIN_ID].constant = isConstantInput[BEGIN_ID];
-    config.inConfs[END_ID].constant = isConstantInput[END_ID];
+    config.inConfs[DATA_ID].inPlace(-1);
+    config.inConfs[BEGIN_ID].inPlace(-1);
+    config.inConfs[END_ID].inPlace(-1);
+    config.inConfs[DATA_ID].constant(isConstantInput[DATA_ID]);
+    config.inConfs[BEGIN_ID].constant(isConstantInput[BEGIN_ID]);
+    config.inConfs[END_ID].constant(isConstantInput[END_ID]);
     if (isStrideSpecified) {
-        config.inConfs[STRIDE_ID].inPlace = -1;
-        config.inConfs[STRIDE_ID].constant = isConstantInput[STRIDE_ID];
+        config.inConfs[STRIDE_ID].inPlace(-1);
+        config.inConfs[STRIDE_ID].constant(isConstantInput[STRIDE_ID]);
     }
     if (isAxesSpecified) {
-        config.inConfs[AXES_ID].inPlace = -1;
-        config.inConfs[AXES_ID].constant = isConstantInput[AXES_ID];
+        config.inConfs[AXES_ID].inPlace(-1);
+        config.inConfs[AXES_ID].constant(isConstantInput[AXES_ID]);
     }
     config.outConfs.resize(1);
 
@@ -287,15 +287,15 @@ void MKLDNNStridedSliceNode::initSupportedPrimitiveDescriptors() {
     auto range = BlockedDescCreator::makeFilteredRange(creators, nDims, supportedTypes);
 
     for (auto itr = range.first; itr != range.second; ++itr) {
-        config.inConfs[DATA_ID].desc = itr->second->createSharedDesc(dataPrecision, getInputShapeAtPort(DATA_ID));
-        config.inConfs[BEGIN_ID].desc = creators.at(LayoutType::ncsp)->createSharedDesc(iPrecision, getInputShapeAtPort(BEGIN_ID));
-        config.inConfs[END_ID].desc = creators.at(LayoutType::ncsp)->createSharedDesc(iPrecision, getInputShapeAtPort(END_ID));
+        config.inConfs[DATA_ID].setMemDesc(itr->second->createSharedDesc(dataPrecision, getInputShapeAtPort(DATA_ID)));
+        config.inConfs[BEGIN_ID].setMemDesc(creators.at(LayoutType::ncsp)->createSharedDesc(iPrecision, getInputShapeAtPort(BEGIN_ID)));
+        config.inConfs[END_ID].setMemDesc(creators.at(LayoutType::ncsp)->createSharedDesc(iPrecision, getInputShapeAtPort(END_ID)));
         if (isStrideSpecified)
-            config.inConfs[STRIDE_ID].desc = creators.at(LayoutType::ncsp)->createSharedDesc(iPrecision, getInputShapeAtPort(STRIDE_ID));
+            config.inConfs[STRIDE_ID].setMemDesc(creators.at(LayoutType::ncsp)->createSharedDesc(iPrecision, getInputShapeAtPort(STRIDE_ID)));
         if (isAxesSpecified)
-            config.inConfs[AXES_ID].desc = creators.at(LayoutType::ncsp)->createSharedDesc(iPrecision, getInputShapeAtPort(AXES_ID));
+            config.inConfs[AXES_ID].setMemDesc(creators.at(LayoutType::ncsp)->createSharedDesc(iPrecision, getInputShapeAtPort(AXES_ID)));
 
-        config.outConfs[0].desc = itr->second->createSharedDesc(dataPrecision, getOutputShapeAtPort(DATA_ID));
+        config.outConfs[0].setMemDesc(itr->second->createSharedDesc(dataPrecision, getOutputShapeAtPort(DATA_ID)));
         supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::ref);
     }
 }

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_tensoriterator_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_tensoriterator_node.cpp
@@ -33,7 +33,7 @@ static NodeConfig make_plain_config(const std::shared_ptr<ov::Node>& op) {
 
         PortConfig data_conf {};
         auto descCreator = BlockedDescCreator::getCommonCreators().at(LayoutType::ncsp);
-        data_conf.desc = descCreator->createSharedDesc(prec, shape);
+        data_conf.setMemDesc(descCreator->createSharedDesc(prec, shape));
         config.inConfs.push_back(data_conf);
     }
 
@@ -44,7 +44,7 @@ static NodeConfig make_plain_config(const std::shared_ptr<ov::Node>& op) {
 
         PortConfig data_conf {};
         auto descCreator = BlockedDescCreator::getCommonCreators().at(LayoutType::ncsp);
-        data_conf.desc = descCreator->createSharedDesc(prec, shape);
+        data_conf.setMemDesc(descCreator->createSharedDesc(prec, shape));
         config.outConfs.push_back(data_conf);
     }
 

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_topk_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_topk_node.cpp
@@ -1946,7 +1946,7 @@ void MKLDNNTopKNode::preset_params() {
     }
 
     auto selectedPD = getSelectedPrimitiveDescriptor();
-    auto data_type = MKLDNNExtensionUtils::IEPrecisionToDataType(selectedPD->getConfig().inConfs[TOPK_DATA].desc->getPrecision());
+    auto data_type = MKLDNNExtensionUtils::IEPrecisionToDataType(selectedPD->getConfig().inConfs[TOPK_DATA].getMemDesc()->getPrecision());
     data_size = MKLDNNExtensionUtils::sizeOfDataType(data_type);
 
     topk_innermost = (layout == TopKLayoutType::topk_ncsp && axis == static_cast<int>(getOutputShapeAtPort(TOPK_DATA).getRank() - 1)) ||

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_topk_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_topk_node.cpp
@@ -2063,7 +2063,7 @@ void MKLDNNTopKNode::createPrimitive() {
         // will be used. These params are: top_k, axis_dim, sort_stride, work_amount
         auto jcp = jit_topk_config_params();
         auto selectedPD = getSelectedPrimitiveDescriptor();
-        jcp.precision = selectedPD->getConfig().inConfs[TOPK_DATA].desc->getPrecision();
+        jcp.precision = selectedPD->getConfig().inConfs[TOPK_DATA].getMemDesc()->getPrecision();
         jcp.data_size = data_size;
         jcp.blk_size = blk_size;
         jcp.layout = layout;

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_transpose_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_transpose_node.cpp
@@ -68,41 +68,41 @@ void MKLDNNTransposeNode::initSupportedPrimitiveDescriptors() {
     config.dynBatchSupport = true;
     config.inConfs.resize(2);
     config.outConfs.resize(1);
-    config.inConfs[INPUT_DATA_IDX].inPlace = -1;
-    config.inConfs[INPUT_DATA_IDX].constant = false;
-    config.inConfs[INPUT_ORDER_IDX].constant = isInputOrderConst;
-    config.inConfs[INPUT_ORDER_IDX].desc = creatorsMap.at(LayoutType::ncsp)->createSharedDesc(
-            Precision::I32, getInputShapeAtPort(INPUT_ORDER_IDX));
-    config.outConfs[0].inPlace = -1;
-    config.outConfs[0].constant = false;
+    config.inConfs[INPUT_DATA_IDX].inPlace(-1);
+    config.inConfs[INPUT_DATA_IDX].constant(false);
+    config.inConfs[INPUT_ORDER_IDX].constant(isInputOrderConst);
+    config.inConfs[INPUT_ORDER_IDX].setMemDesc(creatorsMap.at(LayoutType::ncsp)->createSharedDesc(
+            Precision::I32, getInputShapeAtPort(INPUT_ORDER_IDX)));
+    config.outConfs[0].inPlace(-1);
+    config.outConfs[0].constant(false);
 
     const auto& inputDataShape = getInputShapeAtPort(INPUT_DATA_IDX);
     const auto& outputDataShape = getOutputShapeAtPort(0);
     if (inputDataShape.getRank() == 4 || inputDataShape.getRank() == 5) {
-        config.inConfs[0].desc = creatorsMap.at(LayoutType::ncsp)->createSharedDesc(prec, inputDataShape);
-        config.outConfs[0].desc = creatorsMap.at(LayoutType::ncsp)->createSharedDesc(prec, outputDataShape);
+        config.inConfs[0].setMemDesc(creatorsMap.at(LayoutType::ncsp)->createSharedDesc(prec, inputDataShape));
+        config.outConfs[0].setMemDesc(creatorsMap.at(LayoutType::ncsp)->createSharedDesc(prec, outputDataShape));
         supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown});
 
         const auto& srcDims = inputDataShape.getDims();
         if (srcDims[1] != Shape::UNDEFINED_DIM && srcDims[1] % 8 == 0) {
-            config.inConfs[0].desc = creatorsMap.at(LayoutType::nCsp8c)->createSharedDesc(prec, inputDataShape);
+            config.inConfs[0].setMemDesc(creatorsMap.at(LayoutType::nCsp8c)->createSharedDesc(prec, inputDataShape));
             supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown});
         }
 
         if (srcDims[1] != Shape::UNDEFINED_DIM && srcDims[1] % 16 == 0) {
-            config.inConfs[0].desc = creatorsMap.at(LayoutType::nCsp16c)->createSharedDesc(prec, inputDataShape);
+            config.inConfs[0].setMemDesc(creatorsMap.at(LayoutType::nCsp16c)->createSharedDesc(prec, inputDataShape));
             supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown});
         }
 
         if (prec == Precision::FP32 || prec == Precision::I8 || prec == Precision::U8) {
-            config.inConfs[0].desc = creatorsMap.at(LayoutType::nspc)->createSharedDesc(prec, inputDataShape);
-            config.outConfs[0].desc = creatorsMap.at(LayoutType::nspc)->createSharedDesc(prec, outputDataShape);
+            config.inConfs[0].setMemDesc(creatorsMap.at(LayoutType::nspc)->createSharedDesc(prec, inputDataShape));
+            config.outConfs[0].setMemDesc(creatorsMap.at(LayoutType::nspc)->createSharedDesc(prec, outputDataShape));
             supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown});
         }
     } else {
         // general plain case
-        config.inConfs[0].desc = creatorsMap.at(LayoutType::ncsp)->createSharedDesc(prec, inputDataShape);
-        config.outConfs[0].desc = creatorsMap.at(LayoutType::ncsp)->createSharedDesc(prec, outputDataShape);
+        config.inConfs[0].setMemDesc(creatorsMap.at(LayoutType::ncsp)->createSharedDesc(prec, inputDataShape));
+        config.outConfs[0].setMemDesc(creatorsMap.at(LayoutType::ncsp)->createSharedDesc(prec, outputDataShape));
         supportedPrimitiveDescriptors.push_back({config, impl_desc_type::unknown});
     }
 }
@@ -160,7 +160,7 @@ void MKLDNNTransposeNode::createPrimitive() {
         return;
     }
 
-    params.data_size = getSelectedPrimitiveDescriptor()->getConfig().inConfs[0].desc->getPrecision().size();
+    params.data_size = getSelectedPrimitiveDescriptor()->getConfig().inConfs[0].getMemDesc()->getPrecision().size();
     if (isInputOrderConst)
         params.order = order;
     auto srcDesc = getParentEdgeAt(INPUT_DATA_IDX)->getMemory().GetDescWithType<BlockedMemoryDesc>();

--- a/src/plugins/intel_cpu/src/nodes/node_config.h
+++ b/src/plugins/intel_cpu/src/nodes/node_config.h
@@ -15,11 +15,11 @@ public:
     /**
      * @brief Check if the port desc can be accepted.
      *
-     * @warning This operation is not commutative desc1.compare(desc2) != desc2.compare(desc1) in general case
+     * @warning This operation is not commutative desc1.isCompatible(desc2) != desc2.isCompatible(desc1) in general case
      *
      * @return True if the port desc may be accepted false otherwise
      */
-    bool compare(const PortDescBase& rhs) const {
+    bool isCompatible(const PortDescBase& rhs) const {
         return typeid(*this) == typeid(rhs) && this->compareImpl(rhs);
     }
     virtual MemoryDescPtr getMemDesc() const = 0;
@@ -35,7 +35,7 @@ class PortDescBase_ : public PortDescBase {
 protected:
     PortDescBase_() = default;
     bool compareImpl(const PortDescBase& rhs) const override /*final*/ {
-        return static_cast<const T&>(*this).compare(static_cast<const T&>(rhs));
+        return static_cast<const T&>(*this).isCompatible(static_cast<const T&>(rhs));
     }
 };
 
@@ -46,7 +46,7 @@ public:
             IE_THROW(ParameterMismatch) << "PortDescGeneric constructor got nullptr";
         }
     }
-    bool compare(const PortDescGeneric& rhs) const {
+    bool isCompatible(const PortDescGeneric& rhs) const {
         return _memDesc->isCompatible(*rhs._memDesc);
     }
     MemoryDescPtr getMemDesc() const override {
@@ -64,7 +64,7 @@ public:
             IE_THROW(ParameterMismatch) << "PortDescBlocked constructor got nullptr";
         }
     }
-    bool compare(const PortDescBlocked& rhs) const {
+    bool isCompatible(const PortDescBlocked& rhs) const {
         return _memDesc->isCompatible(*rhs._memDesc, _cmpMask) /*&& mask comparison*/;
     }
     MemoryDescPtr getMemDesc() const override {

--- a/src/plugins/intel_cpu/src/nodes/node_config.h
+++ b/src/plugins/intel_cpu/src/nodes/node_config.h
@@ -65,7 +65,7 @@ public:
         }
     }
     bool isCompatible(const PortDescBlocked& rhs) const {
-        return _memDesc->isCompatible(*rhs._memDesc, _cmpMask) /*&& mask comparison*/;
+        return _memDesc->isCompatible(*rhs._memDesc, _cmpMask) && (~((~_cmpMask) | rhs._cmpMask) == 0x0);
     }
     MemoryDescPtr getMemDesc() const override {
         return _memDesc;

--- a/src/plugins/intel_cpu/src/nodes/node_config.h
+++ b/src/plugins/intel_cpu/src/nodes/node_config.h
@@ -1,0 +1,69 @@
+// Copyright (C) 2018-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "memory_desc/cpu_memory_desc.h"
+
+namespace MKLDNNPlugin {
+class PortConfig {
+public:
+    PortConfig() = default;
+
+    PortConfig(const PortConfig& rhs) {
+        this->_constant = rhs._constant;
+        this->_inPlacePort = rhs._inPlacePort;
+        if (rhs._desc) {
+            this->_desc = rhs._desc;
+        }
+    }
+
+    PortConfig& operator=(const PortConfig& rhs) {
+        this->_constant = rhs._constant;
+        this->_inPlacePort = rhs._inPlacePort;
+        if (rhs._desc) {
+            this->_desc = rhs._desc;
+        }
+        return *this;
+    }
+
+    PortConfig(PortConfig&& rhs) = default;
+    PortConfig& operator=(PortConfig&& rhs) = default;
+
+    int inPlace() const {
+        return _inPlacePort;
+    }
+
+    void inPlace(int port) {
+        _inPlacePort = port;
+    }
+
+    bool constant() const {
+        return _constant;
+    }
+
+    void constant(bool constant) {
+        _constant = constant;
+    }
+
+    MemoryDescPtr getMemDesc() const {
+        return _desc;
+    }
+
+    void setMemDesc(MemoryDescPtr desc) {
+        _desc = desc;
+    }
+
+private:
+    bool _constant = false;
+    int _inPlacePort = -1;
+    MemoryDescPtr _desc;
+};
+
+struct NodeConfig {
+    bool dynBatchSupport = false;
+    std::vector<PortConfig> inConfs;
+    std::vector<PortConfig> outConfs;
+};
+} // namespace MKLDNNPlugin

--- a/src/plugins/intel_cpu/src/nodes/node_config.h
+++ b/src/plugins/intel_cpu/src/nodes/node_config.h
@@ -34,7 +34,7 @@ template<class T>
 class PortDescBase_ : public PortDescBase {
 protected:
     PortDescBase_() = default;
-    bool compareImpl(const PortDescBase& rhs) const override final {
+    bool compareImpl(const PortDescBase& rhs) const override /*final*/ {
         return static_cast<const T&>(*this).compare(static_cast<const T&>(rhs));
     }
 };

--- a/src/plugins/intel_cpu/src/nodes/node_config.h
+++ b/src/plugins/intel_cpu/src/nodes/node_config.h
@@ -65,7 +65,7 @@ public:
         }
     }
     bool compare(const PortDescBlocked& rhs) const {
-        return _memDesc->isCompatible(*rhs._memDesc, _cmpMask & rhs._cmpMask);
+        return _memDesc->isCompatible(*rhs._memDesc, _cmpMask) /*&& mask comparison*/;
     }
     MemoryDescPtr getMemDesc() const override {
         return _memDesc;

--- a/src/plugins/intel_cpu/src/nodes/subgraph.cpp
+++ b/src/plugins/intel_cpu/src/nodes/subgraph.cpp
@@ -143,40 +143,40 @@ void MKLDNNSnippetNode::initSupportedPrimitiveDescriptors() {
         config.inConfs.resize(inputShapes.size());
         for (size_t i = 0; i < inputShapes.size(); i++) {
             PortConfig portConfig;
-            portConfig.inPlace = (!i && canBeInPlace()) ? 0 : -1;
-            portConfig.constant = false;
-            portConfig.desc = createMemoryDesc(inputShapes[i], supportedPrecision, offset);
+            portConfig.inPlace((!i && canBeInPlace()) ? 0 : -1);
+            portConfig.constant(false);
+            portConfig.setMemDesc(createMemoryDesc(inputShapes[i], supportedPrecision, offset));
             if (inputShapes[i].getDims()[0] == 1) {
-                const auto denseDesc = portConfig.desc->as<BlockedMemoryDesc>();
+                const auto denseDesc = portConfig.getMemDesc()->as<BlockedMemoryDesc>();
                 auto strides = denseDesc->getStrides();
                 strides[0] = Shape::UNDEFINED_DIM;
-                portConfig.desc = std::make_shared<CpuBlockedMemoryDesc>(denseDesc->getPrecision(),
-                                                                         denseDesc->getShape(),
-                                                                         denseDesc->getBlockDims(),
-                                                                         denseDesc->getOrder(),
-                                                                         denseDesc->getOffsetPadding(),
-                                                                         denseDesc->getOffsetPaddingToData(),
-                                                                         strides);
+                portConfig.setMemDesc(std::make_shared<CpuBlockedMemoryDesc>(denseDesc->getPrecision(),
+                                                                             denseDesc->getShape(),
+                                                                             denseDesc->getBlockDims(),
+                                                                             denseDesc->getOrder(),
+                                                                             denseDesc->getOffsetPadding(),
+                                                                             denseDesc->getOffsetPaddingToData(),
+                                                                             strides));
             }
             config.inConfs[i] = portConfig;
         }
         config.outConfs.resize(outputShapes.size());
         for (size_t i = 0; i < outputShapes.size(); i++) {
             PortConfig portConfig;
-            portConfig.inPlace = -1;
-            portConfig.constant = false;
-            portConfig.desc = createMemoryDesc(outputShapes[i], supportedPrecision, offset);
+            portConfig.inPlace(-1);
+            portConfig.constant(false);
+            portConfig.setMemDesc(createMemoryDesc(outputShapes[i], supportedPrecision, offset));
             if (outputShapes[i].getDims()[0] == 1) {
-                const auto denseDesc = portConfig.desc->as<BlockedMemoryDesc>();
+                const auto denseDesc = portConfig.getMemDesc()->as<BlockedMemoryDesc>();
                 auto strides = denseDesc->getStrides();
                 strides[0] = Shape::UNDEFINED_DIM;
-                portConfig.desc = std::make_shared<CpuBlockedMemoryDesc>(denseDesc->getPrecision(),
-                                                                         denseDesc->getShape(),
-                                                                         denseDesc->getBlockDims(),
-                                                                         denseDesc->getOrder(),
-                                                                         denseDesc->getOffsetPadding(),
-                                                                         denseDesc->getOffsetPaddingToData(),
-                                                                         strides);
+                portConfig.setMemDesc(std::make_shared<CpuBlockedMemoryDesc>(denseDesc->getPrecision(),
+                                                                             denseDesc->getShape(),
+                                                                             denseDesc->getBlockDims(),
+                                                                             denseDesc->getOrder(),
+                                                                             denseDesc->getOffsetPadding(),
+                                                                             denseDesc->getOffsetPaddingToData(),
+                                                                             strides));
             }
             config.outConfs[i] = portConfig;
         }
@@ -295,7 +295,7 @@ static auto collapseLastDims(std::vector<int64_t>& dims, int dimsToCollapse) -> 
 
 void MKLDNNSnippetNode::define_schedule() {
     const auto config = getSelectedPrimitiveDescriptor()->getConfig();
-    const auto dataSize = config.inConfs[0].desc->getPrecision().size();
+    const auto dataSize = config.inConfs[0].getMemDesc()->getPrecision().size();
     // store to use as an execution domain
     max_rank_out_desc_idx = argmax_rank(getChildEdges());
     const auto outBlockingDesc_maxRank = getChildEdgeAt(max_rank_out_desc_idx)->getMemory().GetDescWithType<BlockedMemoryDesc>();

--- a/src/plugins/intel_cpu/src/nodes/subgraph.cpp
+++ b/src/plugins/intel_cpu/src/nodes/subgraph.cpp
@@ -138,29 +138,28 @@ void MKLDNNSnippetNode::initSupportedPrimitiveDescriptors() {
         };
 
         size_t offset = 0;
-        constexpr uint32_t anyOffsetMask = 0xffffffff ^ (1 << 31); // accepts any offset
         NodeConfig config;
         config.dynBatchSupport = false;
         config.inConfs.resize(inputShapes.size());
         for (size_t i = 0; i < inputShapes.size(); i++) {
-            uint32_t inputMask = anyOffsetMask;
+            BlockedMemoryDesc::CmpMask inputMask = BLOCKED_DESC_SKIP_OFFSET_MASK;
             PortConfig portConfig;
             portConfig.inPlace((!i && canBeInPlace()) ? 0 : -1);
             portConfig.constant(false);
             if (inputShapes[i].getDims()[0] == 1) {
-                inputMask ^= 0x1; // accepts any stride on batch axis
+                inputMask.reset(0); // accepts any stride on batch axis
             }
             portConfig.setMemDesc(createMemoryDesc(inputShapes[i], supportedPrecision, offset), inputMask);
             config.inConfs[i] = portConfig;
         }
         config.outConfs.resize(outputShapes.size());
         for (size_t i = 0; i < outputShapes.size(); i++) {
-            uint32_t outputMask = anyOffsetMask;
+            BlockedMemoryDesc::CmpMask outputMask = BLOCKED_DESC_SKIP_OFFSET_MASK;
             PortConfig portConfig;
             portConfig.inPlace(-1);
             portConfig.constant(false);
             if (outputShapes[i].getDims()[0] == 1) {
-                outputMask ^= 0x1; // accepts any stride on batch axis
+                outputMask.reset(0); // accepts any stride on batch axis
             }
             portConfig.setMemDesc(createMemoryDesc(outputShapes[i], supportedPrecision, offset), outputMask);
             config.outConfs[i] = portConfig;

--- a/src/tests/unit/cpu/mkldnn_zero_dims_test.cpp
+++ b/src/tests/unit/cpu/mkldnn_zero_dims_test.cpp
@@ -77,24 +77,6 @@ protected:
 
         ASSERT_TRUE(descDnnl.isCompatible(descCpu));
         ASSERT_TRUE(descCpu.isCompatible(descDnnl));
-
-        // undefined
-        VectorDims undefDnnlStrides(descDnnl.getBlockDims().size(), Shape::UNDEFINED_DIM);
-        std::fill(undefDnnlStrides.begin() + descDnnl.getShape().getRank(), undefDnnlStrides.end(), 0);
-        const auto undefDnnl = descDnnl.cloneWithUndefStridesAndOffset();
-        validate(*undefDnnl->as<BlockedMemoryDesc>(), undefDnnlStrides, Shape::UNDEFINED_DIM, offsetPadding, Shape::UNDEFINED_DIM);
-
-        VectorDims undefCpuStrides(descCpu.getBlockDims().size(), Shape::UNDEFINED_DIM);
-        const auto undefCpu = descCpu.cloneWithUndefStridesAndOffset();
-        validate(*undefCpu->as<BlockedMemoryDesc>(), undefCpuStrides, Shape::UNDEFINED_DIM, offsetPadding,
-                  Shape::UNDEFINED_DIM);
-
-        // defined
-        const auto definedDnnl = descDnnl.cloneWithDefaultStridesAndOffset();
-        validate(*definedDnnl->as<BlockedMemoryDesc>(), zeroStrides, offset, offsetPadding, 0);
-
-        const auto definedCpu = descCpu.cloneWithDefaultStridesAndOffset();
-        validate(*definedCpu->as<BlockedMemoryDesc>(), zeroStrides, offset, offsetPadding, 0);
     }
 };
 

--- a/src/tests/unit/cpu/nodes/mkldnn_reorder_node.cpp
+++ b/src/tests/unit/cpu/nodes/mkldnn_reorder_node.cpp
@@ -108,7 +108,7 @@ protected:
         }
         auto config = outputNode->getSelectedPrimitiveDescriptor()->getConfig();
         config.inConfs.resize(1);
-        config.inConfs[0].inPlace = forceInplace ? 0 : -1;
+        config.inConfs[0].inPlace(forceInplace ? 0 : -1);
         outputNode->getSelectedPrimitiveDescriptor()->setConfig(config);
         reorderNode->createPrimitive();
 


### PR DESCRIPTION
### Details:
The main reason of this PR is a separation of undefined tensor state meaning in dynamic and static context. In this PR additional port config class is used to provide an additional info about what degrees of freedom the implementation have in the sense of blocked tensor reading and writing.
OneDNN fork PR: https://github.com/openvinotoolkit/oneDNN/pull/114

### Tickets:
 - *ticket-id*
