### PR TITLE
Workaround no tensor names in Parameter for preprocessing

### DIFF
--- a/tools/mo/openvino/tools/mo/back/preprocessing.py
+++ b/tools/mo/openvino/tools/mo/back/preprocessing.py
@@ -447,5 +447,15 @@ def apply_preprocessing(ov_function: Model, argv: argparse.Namespace):
                 ov_function.get_parameters()[idx].layout = Layout()
 
     # Remove inserted tensor names
+    names_to_delete = []
     for tensor in nameless_tensors:
-        tensor.set_names(set())
+        names_to_delete.extend(tensor.get_names())
+    if len(names_to_delete) > 0:
+        tensors = [ov_node.get_tensor() for ov_node in ov_function.inputs + ov_function.outputs]
+        for tensor in tensors:
+            names = tensor.get_names()
+            new_names = set()
+            for name in names:
+                if name not in names_to_delete:
+                    new_names.add(name)
+            tensor.set_names(new_names)

--- a/tools/mo/unit_tests/mo/back/moc_preprocessing_test_actual.py
+++ b/tools/mo/unit_tests/mo/back/moc_preprocessing_test_actual.py
@@ -264,6 +264,10 @@ class TestPreprocessingMOC(UnitTestWithMockedTelemetry):
         # Verify that layout presents in function after preprocessing
         self.assertEqual(function.get_parameters()[1].layout, Layout("NHWC"))
 
+        # Checking that tensor names weren't added
+        for param in function.get_parameters():
+            self.assertTrue(len(param.get_output_tensor(0).get_names()) == 0)
+
     def test_mean_scale_with_layout_dynamic(self):
         argv = Namespace(mean_scale_values={'input2a': {'mean': np.array([1., 2., 3., 4.]),
                                                         'scale': np.array([2., 4., 8., 9.])}},


### PR DESCRIPTION
### Details:
 - *Some models may not have tensor names of some Parameters. This workaround uses the friendly name in preprocessing to set tensor name if user used friendly_name to apply preprocessing*

### Tickets:
 - *None*
