### PR TITLE
[MO] Skip `rt_info` in old graph comparator

### DIFF
--- a/tools/mo/openvino/tools/mo/utils/ir_engine/compare_graphs.py
+++ b/tools/mo/openvino/tools/mo/utils/ir_engine/compare_graphs.py
@@ -109,7 +109,7 @@ def compare_graphs(graph: Graph, graph_ref: Graph, last_node: str, last_node_ref
                 for attr in graph_ref.node[node_ref.id]:
                     if graph_ref.node[node_ref.id][attr] is None or attr in \
                             ['name', 'id', '_in_ports', '_out_ports', 'infer', 'IE', 'biases', 'weights', 'custom',
-                             'offset', 'ir_data_attrs']:
+                             'offset', 'ir_data_attrs', 'rt_info']:
                         continue
                     if attr not in graph.node[node.id]:
                         stderr.append('Current node "{}" with type {} has missing attribute {}'

--- a/tools/mo/openvino/tools/mo/utils/ir_engine/compare_graphs.py
+++ b/tools/mo/openvino/tools/mo/utils/ir_engine/compare_graphs.py
@@ -122,12 +122,6 @@ def compare_graphs(graph: Graph, graph_ref: Graph, last_node: str, last_node_ref
                                           'different values \n{} \nand \n{}'.format(
                                 node.id, cur_node_type, node_ref.id, ref_node_type, node.value, node_ref.value))
                         continue
-                    if attr == 'rt_info':
-                        if node.rt_info.info != node_ref.rt_info.info:
-                            stderr.append('Current node "{}" with type {} and reference node "{}" with type have '
-                                          'different rt_info \n{} \nand \n{}'.format(
-                                node.id, cur_node_type, node_ref.id, ref_node_type, node.rt_info.info, node_ref.rt_info.info))
-                        continue
                     compare_node(node_ref, node, graph_ref.node[node_ref.id][attr], graph.node[node.id][attr], attr,
                                  stderr)
         else:


### PR DESCRIPTION
Root cause analysis: After changing `rt_info` structure our old IREngine based comparator shows incorrect errors

Solution: Remove incorrect comparison code and skip `rt_info` section because old IREngine used firstly for graph structure check.

Ticket: 75782

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names


Validation:
* [x]  Unit tests: N/A - No new implemented functions;
* [x]  Framework operation tests: N/A - No new enabled operations;
* [x]  Transformation tests: N/A - No new implemented transformations;
* [x]  Model Optimizer IR Reader check: Done manually.

Documentation:
* [x]  Supported frameworks operations list: N/A - No new supported operations;
* [x]  Supported **public** models list: N/A - Nothing to add;
* [x]  User guide update: N/A - Nothing to update.