### PR TITLE
Fixed compilation of user code with VS2015

### DIFF
--- a/src/core/include/openvino/core/attribute_visitor.hpp
+++ b/src/core/include/openvino/core/attribute_visitor.hpp
@@ -119,7 +119,7 @@ public:
     /// \brief Finish visiting a nested structure
     virtual std::string finish_structure();
     using node_id_t = std::string;
-    static constexpr char invalid_node_id[] = "";
+    static constexpr const char* invalid_node_id = "";
     /// \brief Associate a node with an id.
     ///
     /// No node may be used as an attribute unless it has already been registered with an ID.

--- a/src/core/src/attribute_visitor.cpp
+++ b/src/core/src/attribute_visitor.cpp
@@ -134,7 +134,7 @@ void ov::AttributeVisitor::on_adapter(const string& name, ValueAccessor<std::sha
     on_adapter(name, static_cast<ValueAccessor<void>&>(adapter));
 }
 
-constexpr char ov::AttributeVisitor::invalid_node_id[];
+constexpr const char* ov::AttributeVisitor::invalid_node_id;
 
 void ov::AttributeVisitor::register_node(const std::shared_ptr<ngraph::Node>& node, node_id_t id) {
     if (id == invalid_node_id) {


### PR DESCRIPTION
I've met an error when building OpenCV library with OpenVINO with VS2015 toolset:
```
C:\openvino\runtime\include\openvino/core/attribute_visitor.hpp(122): 
  error C2131: expression did not evaluate to a constant (compiling source file C:\opencv\modules\dnn\src\dnn.cpp) [C:\build_release\modules\dnn\opencv_dnn.vcxproj]
C:\openvino\runtime\include\openvino/core/attribute_visitor.hpp(122): 
  note: failure was caused by unevaluable pointer value (compiling source file C:\opencv\modules\dnn\src\dnn.cpp)
```

I understand that VS2015 is not supported by OpenVINO, but the change is very small and I hope it should not break anything.