### PR TITLE
MO: Set additional tensor names only if necessary

### DIFF
--- a/tools/mo/openvino/tools/mo/moc_frontend/pipeline.py
+++ b/tools/mo/openvino/tools/mo/moc_frontend/pipeline.py
@@ -47,6 +47,9 @@ def moc_pipeline(argv: argparse.Namespace, moc_front_end: FrontEnd):
         :param places An object containing Places and names that will be used for model modification
         """
         for new_input in places:
+            if not hasattr(new_input, 'input_name'):
+                continue
+
             try:
                 model.add_name_for_tensor(new_input['node'], new_input['input_name'])
             except NotImplementedFailure as e:


### PR DESCRIPTION
Fix of the MO code which sets additional tensor names. In case a placeholder name is not specified in the `mo.py` parameters, the additional tensor setting is not required.

### Tickets:
 - 75679
