### PR TITLE
ONNX python tests cleanup (obsolete XFAILs)

### DIFF
--- a/src/bindings/python/tests_compatibility/__init__.py
+++ b/src/bindings/python/tests_compatibility/__init__.py
@@ -65,9 +65,6 @@ xfail_issue_38708 = xfail_test(reason="RuntimeError: While validating ONNX node 
 xfail_issue_38710 = xfail_test(reason="RuntimeError: data has zero dimension which is not allowed")
 xfail_issue_38713 = xfail_test(reason="RuntimeError: nGraph does not support the following ONNX operations: "
                                       "ai.onnx.preview.training.Momentum")
-xfail_issue_38722 = xfail_test(reason="RuntimeError: While validating ONNX nodes MatMulInteger "
-                                      "and QLinearMatMul "
-                                      "Input0 scale and input0 zero point shape must be same and 1")
 xfail_issue_38724 = xfail_test(reason="RuntimeError: While validating ONNX node '<Node(Resize): Y>': "
                                       "tf_crop_and_resize - this type of coordinate transformation mode "
                                       "is not supported. Choose one of the following modes: "


### PR DESCRIPTION
Cleanup of obsolete XFAILS in ONNX python tests. Verified both versions (legacy and new) - only one XFAIL marker found.

### Tickets:
 - 38722
