### PR TITLE
[GPU] Remove default bfyx quantize in get_preferred_format

### DIFF
--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1680,8 +1680,6 @@ format layout_optimizer::get_preferred_format(program_node& node) {
                 format expected_conv_fmt = get_expected_layout(conv_output_layout, conv, weights_layout).format;
                 if (layout.format.spatial_num() == 2 && layout.size.feature[0] % 32 == 0 && expected_conv_fmt == format::b_fs_yx_fsv32)
                     expected = expected_conv_fmt;
-                else
-                    expected = format::bfyx;
             }
         }
     } else if (node.is_type<reorder>() || node.is_type<input_layout>()) {

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1497,12 +1497,13 @@ impl_types layout_optimizer::get_preferred_impl_type(program_node& node, format 
 
         for (auto& dep : node.get_dependencies()) {
             if (dep->is_in_data_flow() && dep->get_preferred_impl_type() == impl_types::onednn) {
-                preferred_impl = impl_types::onednn;
-                break;
+                return impl_types::onednn;
             }
         }
-    // TODO: uncomment this code when onednn gemm implementations will have real perf improvements vs cldnn
-    } else if (node.is_type<fully_connected>()/* || node.is_type<gemm>()*/) {
+        if (format::is_blocked(node.get_output_layout().format)) {
+            return impl_types::onednn;
+        }
+    } else if (node.is_type<fully_connected>()) {
         if (!_optimization_attributes.use_onednn_impls)
             return impl_types::ocl;
 

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1497,11 +1497,9 @@ impl_types layout_optimizer::get_preferred_impl_type(program_node& node, format 
 
         for (auto& dep : node.get_dependencies()) {
             if (dep->is_in_data_flow() && dep->get_preferred_impl_type() == impl_types::onednn) {
-                return impl_types::onednn;
+                preferred_impl = impl_types::onednn;
+                break;
             }
-        }
-        if (format::is_blocked(node.get_output_layout().format)) {
-            return impl_types::onednn;
         }
     // TODO: uncomment this code when onednn gemm implementations will have real perf improvements vs cldnn
     } else if (node.is_type<fully_connected>()/* || node.is_type<gemm>()*/) {

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1503,7 +1503,8 @@ impl_types layout_optimizer::get_preferred_impl_type(program_node& node, format 
         if (format::is_blocked(node.get_output_layout().format)) {
             return impl_types::onednn;
         }
-    } else if (node.is_type<fully_connected>()) {
+    // TODO: uncomment this code when onednn gemm implementations will have real perf improvements vs cldnn
+    } else if (node.is_type<fully_connected>()/* || node.is_type<gemm>()*/) {
         if (!_optimization_attributes.use_onednn_impls)
             return impl_types::ocl;
 
@@ -1653,7 +1654,6 @@ format layout_optimizer::get_preferred_format(program_node& node) {
                     format expected_conv_fmt = get_expected_layout(conv_output_layout, conv, weights_layout).format;
                     if (expected == format::bfyx && expected_conv_fmt == format::bs_fs_yx_bsv32_fsv32 && layout.size.feature[0] % 32 == 0)
                         expected = expected_conv_fmt;
-                    }
                 }
             } else if (layout.size.feature[0] > 8) {
                 expected = format::b_fs_yx_fsv16;

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1652,8 +1652,7 @@ format layout_optimizer::get_preferred_format(program_node& node) {
                     format expected_conv_fmt = get_expected_layout(conv_output_layout, conv, weights_layout).format;
                     if (expected == format::bfyx && expected_conv_fmt == format::bs_fs_yx_bsv32_fsv32 && layout.size.feature[0] % 32 == 0)
                         expected = expected_conv_fmt;
-                } else {
-                    expected = format::bfyx;
+                    }
                 }
             } else if (layout.size.feature[0] > 8) {
                 expected = format::b_fs_yx_fsv16;
@@ -1682,8 +1681,6 @@ format layout_optimizer::get_preferred_format(program_node& node) {
                     expected = expected_conv_fmt;
                 else
                     expected = format::bfyx;
-            } else {
-                expected = format::bfyx;
             }
         }
     } else if (node.is_type<reorder>() || node.is_type<input_layout>()) {


### PR DESCRIPTION
Default bfyx occurs redundant reorder in fsv-format network.
And remove onednn concat limitation for depdendency input should be
onednn impl.

Signed-off-by: hyunback <hyunback.kim@intel.com>

### Tickets:
 - *74954*
 - *75591*
