### PR TITLE
remove duplicated classifier from openvino-dev wheel package 

### DIFF
--- a/tools/benchmark_tool/setup.py
+++ b/tools/benchmark_tool/setup.py
@@ -38,7 +38,6 @@ setup(
     },
     classifiers=[
         'Programming Language :: Python :: 3',
-        'OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
     ],
     packages=find_packages(),

--- a/tools/openvino_dev/setup.py
+++ b/tools/openvino_dev/setup.py
@@ -207,7 +207,6 @@ setup(
     long_description_content_type='text/markdown',
     classifiers=[
         'Programming Language :: Python :: 3',
-        'OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
     ],
     cmdclass={


### PR DESCRIPTION
### Details:
 - *fix PyPI upload error: Invalid value for classifiers. Error: Classifier 'OSI Approved :: Apache Software License' is not a valid classifier*


