### PR TITLE
Exit operation produces shape with -1000007

### DIFF
--- a/tools/mo/openvino/tools/mo/ops/Exit.py
+++ b/tools/mo/openvino/tools/mo/ops/Exit.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2018-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from openvino.tools.mo.front.common.partial_infer.utils import mo_array
 from openvino.tools.mo.graph.graph import Node, Graph
 from openvino.tools.mo.ops.op import Op
 
@@ -20,8 +19,11 @@ class Exit(Op):
 
     @staticmethod
     def exit_infer(node: Node):
-        output_shape = node.in_node(0).shape
-        output_value = node.in_node(0).value
-        for _, out_node in node.graph.out_edges(node.id):
-            node.graph.node[out_node]['shape'] = mo_array(output_shape)
-            node.graph.node[out_node]['value'] = None if output_value is None else mo_array(output_value)
+        output_shape = node.in_port(0).data.get_shape()
+        output_value = node.in_port(0).data.get_value()
+
+        for port in node.out_ports():
+            if not node.out_port(port).disconnected():
+                node.out_port(port).data.set_shape(output_shape)
+                if output_value is not None:
+                    node.out_port(port).data.set_value(output_value)

--- a/tools/mo/unit_tests/mo/ops/exit_test.py
+++ b/tools/mo/unit_tests/mo/ops/exit_test.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+import numpy as np
+import unittest
+
+from openvino.tools.mo.front.common.partial_infer.utils import int64_array, dynamic_dimension_value
+from openvino.tools.mo.graph.graph import Node
+from openvino.tools.mo.ops.Exit import Exit
+from unit_tests.utils.graph import build_graph, regular_op_with_empty_data, result, connect, shaped_parameter
+
+
+# test for TensorIterator
+graph_nodes = {
+    **shaped_parameter("input", int64_array([1, 4, 64, 54])),
+    **regular_op_with_empty_data("exit", {'op': "Exit"}),
+    **result("output")
+}
+
+
+class ExitTest(unittest.TestCase):
+    def test_exit_static(self):
+        graph = build_graph(nodes_attrs=graph_nodes,
+                            edges=[*connect('input', 'exit'),
+                                   *connect('exit', 'output')],
+                            nodes_with_edges_only=True)
+        exit_node = Node(graph, 'exit')
+        in_node = Node(graph, 'input')
+
+        Exit.exit_infer(exit_node)
+
+        self.assertTrue(np.ma.allequal(exit_node.out_port(0).data.get_shape(), in_node.shape))
+
+    def test_exit_dynamic(self):
+        graph = build_graph(nodes_attrs=graph_nodes,
+                            edges=[*connect('input', 'exit'),
+                                   *connect('exit', 'output')],
+                            nodes_with_edges_only=True)
+        exit_node = Node(graph, 'exit')
+        in_node = Node(graph, 'input')
+        shape = int64_array([-1, 36])
+        in_node.shape = np.ma.masked_array(shape, mask=shape == -1, fill_value=dynamic_dimension_value)
+        in_node.out_port(0).data.set_shape(in_node.shape)
+
+        Exit.exit_infer(exit_node)
+
+        self.assertTrue(np.ma.allequal(exit_node.out_port(0).data.get_shape(), in_node.shape))


### PR DESCRIPTION
Root cause analysis: TensorIterator output has shape [-1000007, 36], it produces node Exit. During partial shape infer shape from input node  before copiing to output converts to mo_array (np.array before mo_array creation) without correct unmasking.  

Solution: Partial shape infer function was re-written to new API to use get_shape/set_shape to avoid unneeded unmasking/masking of shape.

Ticket: 75732


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR **NA no transformations**
* [x]  Transformation preserves original framework node names **NA no transformations**


Validation:
* [x]  Unit tests
* [x]  Framework operation tests **Operation is old and simple, but creation test with While and Exit is pretty difficult. Code changes covered by unit test and e2e tests**
* [x]  Transformation tests **NA no transformations**
* [x]  Model Optimizer IR Reader check **NA no new ops**

Documentation:
* [x]  Supported frameworks operations list **NA no new ops**
* [x]  Guide on how to convert the **public** model **NA no new models**
* [x]  User guide update **NA no new models/ops**
