### PR TITLE
Friendly names setting in ONNX FE

### DIFF
--- a/src/core/tests/onnx/onnx_import.in.cpp
+++ b/src/core/tests/onnx/onnx_import.in.cpp
@@ -93,9 +93,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_node_names_check) {
     });
 
     EXPECT_EQ(additions.size(), 2);
-    EXPECT_EQ(additions.at(0)->get_friendly_name(), "add_node1");
+    EXPECT_EQ(additions.at(0)->get_friendly_name(), "X");
     EXPECT_EQ(additions.at(0)->get_output_tensor(0).get_names(), std::unordered_set<std::string>{"X"});
-    EXPECT_EQ(additions.at(1)->get_friendly_name(), "add_node2");
+    EXPECT_EQ(additions.at(1)->get_friendly_name(), "Y");
     EXPECT_EQ(additions.at(1)->get_output_tensor(0).get_names(), std::unordered_set<std::string>{"Y"});
 }
 

--- a/src/core/tests/onnx/onnx_tensor_names.cpp
+++ b/src/core/tests/onnx/onnx_tensor_names.cpp
@@ -40,8 +40,8 @@ NGRAPH_TEST(onnx_tensor_names, simple_model) {
 
     const auto ops = function->get_ordered_ops();
     EXPECT_TRUE(matching_node_found_in_graph<op::Parameter>(ops, "input", {"input", "identity_on_input"}));
-    EXPECT_TRUE(matching_node_found_in_graph<op::Relu>(ops, "relu", {"relu_t"}));
-    EXPECT_TRUE(matching_node_found_in_graph<op::v0::Abs>(ops, "abs", {"abs_t", "final_output"}));
+    EXPECT_TRUE(matching_node_found_in_graph<op::Relu>(ops, "relu_t", {"relu_t"}));
+    EXPECT_TRUE(matching_node_found_in_graph<op::v0::Abs>(ops, "abs_t", {"abs_t", "final_output"}));
     EXPECT_TRUE(matching_node_found_in_graph<op::Result>(function->get_results(),
                                                          "final_output/sink_port_0",
                                                          {"abs_t", "final_output"}));


### PR DESCRIPTION
### Details:
 - Node names from the ONNX models are ignored in the context of friendly names
 - All nodes in the graph use ONNX node output names as friendly names
 - This is the way MO behaves so this PR aligns the behavior between legacy and the new FE path
 - This should fix the problems in validation

### Tickets:
 - 75971
