### PR TITLE
Update undefined dimensions parsing in parameter extender

### DIFF
--- a/tools/mo/openvino/tools/mo/utils/ir_reader/extenders/parameter_extender.py
+++ b/tools/mo/openvino/tools/mo/utils/ir_reader/extenders/parameter_extender.py
@@ -26,7 +26,7 @@ class Parameter_extender(Extender):
                     shape[i] = -1
                     if ".." in dim:
                         has_shapes_with_boundaries = True
-            shape = shape_array([d if d != -1 else dynamic_dimension_value for d in shape])
+            shape = shape_array([d if d not in [-1, '?'] else dynamic_dimension_value for d in shape])
 
             if has_shapes_with_boundaries:
                 shape_list = []


### PR DESCRIPTION
Root cause analysis: Since we start to generate IRs with undefined dimensions we have 2 symbols to mark such dimensions: `-1` and `?`. But only `-1` was added to `Parameter` extender, and IRs with `?` breaks MO IR Reader.

Solution: Add `?` to `Parameter` extender for correct shape parsing.

Ticket: 75990

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names


Validation:
* [x]  Unit tests: N/A - No new implemented functions;
* [x]  Framework operation tests: N/A - No new enabled operations;
* [x]  Transformation tests: N/A - No new implemented transformations;
* [x]  Model Optimizer IR Reader check: Done manually.

Documentation:
* [x]  Supported frameworks operations list: N/A - No new supported operations;
* [x]  Supported **public** models list: N/A - Nothing to add;
* [x]  User guide update: N/A - Nothing to update.
