### PR TITLE
Fusing of transpose and reorder is disabled for dynamic shapes

### DIFF
--- a/src/plugins/intel_cpu/src/mkldnn_graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/mkldnn_graph_optimizer.cpp
@@ -1855,11 +1855,15 @@ void MKLDNNGraphOptimizer::MergeTransposeAndReorder(MKLDNNGraph &graph) {
     auto& graphNodes = graph.GetNodes();
 
     auto isSuitableParentNode = [](MKLDNNNodePtr node) {
-        return node->getType() == Transpose && node->getChildEdges().size() == 1;
+        return node->getType() == Transpose
+                && node->getChildEdges().size() == 1
+                && !node->isDynamicNode();   // TODO [DS]: enable for dynamic shapes when inPlace in the dynamic case is available (CVS-74863)
     };
 
     auto isSuitableChildNode = [](MKLDNNNodePtr node) {
-        return node->getType() == Reorder && node->getChildEdges().size() == 1;
+        return node->getType() == Reorder
+                && node->getChildEdges().size() == 1
+                && !node->isDynamicNode();   // TODO [DS]: enable for dynamic shapes when inPlace in the dynamic case is available (CVS-74863)
     };
 
     // Method checkAscendingSummaryOrder() checks that after the sequential execution of Transpose and Reorder nodes,

--- a/src/tests/functional/plugin/cpu/subgraph_tests/src/fuse_transpose_reorder.cpp
+++ b/src/tests/functional/plugin/cpu/subgraph_tests/src/fuse_transpose_reorder.cpp
@@ -3,6 +3,8 @@
 //
 
 #include "subgraph_tests/include/fuse_transpose_reorder.hpp"
+#include <ngraph_functions/preprocess/preprocess_builders.hpp>
+#include <openvino/openvino.hpp>
 
 using namespace InferenceEngine;
 using namespace CPUTestUtils;
@@ -235,5 +237,17 @@ TEST_P(FuseTransposeAndReorderTest2, CompareWithRefs) {
 }
 
 INSTANTIATE_TEST_SUITE_P(smoke_Basic, FuseTransposeAndReorderTest2, fuseTransposeAndReorderCommonParams, FuseTransposeAndReorderTest::getTestCaseName);
+
+TEST(smoke_Basic, FuseDynamicTransposeAndReorderTest) {
+    auto model = ov::builder::preprocess::create_preprocess_1input(ov::element::u8, ov::PartialShape{1, 3, 224, 224});
+    auto p = ov::preprocess::PrePostProcessor(model);
+    p.input().tensor().set_spatial_dynamic_shape().set_layout("NHWC");
+    p.input().preprocess().resize(ov::preprocess::ResizeAlgorithm::RESIZE_LINEAR);
+    p.input().model().set_layout("NCHW");
+    model = p.build();
+
+    auto core = ov::runtime::Core();
+    ASSERT_NO_THROW(core.compile_model(model, "CPU"));
+}
 
 }  // namespace SubgraphTestsDefinitions


### PR DESCRIPTION
### Details:
 - Fusing of transpose and reorder is disabled for dynamic shapes

### Tickets:
 - CVS-74863
