### PR TITLE
[CPU] Fixed TensorIterator/Loop dynamism leftovers

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/mkldnn_tensoriterator_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_tensoriterator_node.cpp
@@ -713,8 +713,8 @@ void MKLDNNTensorIteratorNode::reshapeAndFillOutput(mkldnn::stream strm) {
             redefineToMemories(to_mems, *desc);
 
             if (!newShape.isDynamic()) {
-                PortMapHelper *mapper = new BackEdgePortHelper(from_mem, to_mems.front(), eng);
-                mapper->execute(strm);
+                BackEdgePortHelper mapper(from_mem, to_mems.front(), eng);
+                mapper.execute(strm);
             }
         }
     }

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_tensoriterator_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_tensoriterator_node.cpp
@@ -549,9 +549,6 @@ void MKLDNNTensorIteratorNode::execute(mkldnn::stream strm) {
 }
 
 void MKLDNNTensorIteratorNode::executeDynamicImpl(mkldnn::stream strm) {
-    if (!isBodyExecutable())
-        return;
-
     const auto &eng = getEngine();
     sub_graph.ResetInferCount();
 
@@ -703,73 +700,28 @@ void MKLDNNTensorIteratorNode::reshapeAndFillOutput(mkldnn::stream strm) {
             auto to_mems = getToMemories(this, map_rule.from);
             auto &from_mem = output_mem[map_rule.to];
 
-            const auto desc = getBaseMemDescAtOutputPort(map_rule.from)->cloneWithNewDims(from_mem->getStaticDims());
+            // if Loop or TI isn't executed we should fill dynamic dims by zero
+            auto newShape = from_mem->GetShape();
+            auto newDims = newShape.getDims();
+            const bool isDynamic = newShape.isDynamic();
+            if (isDynamic) {
+                std::transform(newDims.begin(), newDims.end(), newDims.begin(), [](const size_t& dim) {
+                    return dim == Shape::UNDEFINED_DIM ? 0 : dim;
+                });
+            }
+            const auto desc = getBaseMemDescAtOutputPort(map_rule.from)->cloneWithNewDims(newDims);
             redefineToMemories(to_mems, *desc);
 
-            BackEdgePortHelper mapper(from_mem, to_mems.front(), eng);
-            mapper.execute(strm);
+            if (!isDynamic) {
+                BackEdgePortHelper mapper(from_mem, to_mems.front(), eng);
+                mapper.execute(strm);
+            }
         }
     }
 
     for (auto buffer : buffers) {
         buffer->transfer(this);
     }
-}
-
-bool MKLDNNTensorIteratorNode::needShapeInfer() const {
-    return !isBodyExecutable();
-}
-
-std::vector<VectorDims> MKLDNNTensorIteratorNode::shapeInfer() const {
-    std::vector<Shape> shapes;
-    for (size_t i = 0; i < ngraphOp->get_input_size(); i++) {
-        shapes.push_back(ngraphOp->get_input_partial_shape(i).rank().get_length() == 0 ? Shape{} :
-                         getParentEdgesAtPort(i)[0]->getMemory().getDesc().getShape());
-    }
-
-    if (shapes.size() < ngraphOp->get_input_size()) {
-        IE_THROW(Unexpected) << "TensorIterator/Loop input shapes vector size is " << shapes.size() << ", but " << ngraphOp->get_input_size() <<
-                             " required for node with name: " << getName();
-    }
-
-    for (size_t i = 0; i < ngraphOp->get_input_size(); i++) {
-        if (!ov::is_type<ov::op::v0::Constant>(ngraphOp->get_input_node_shared_ptr(i))) {
-            ngraphOp->get_input_tensor(i).set_partial_shape(shapes[i].toPartialShape());
-        }
-    }
-
-    ngraphOp->validate_and_infer_types();
-
-    std::vector<VectorDims> newOutputShapes(ngraphOp->get_output_size());
-    for (size_t i = 0; i < newOutputShapes.size(); i++) {
-        const auto &partShape = ngraphOp->get_output_partial_shape(i);
-        bool isScalar = partShape.rank().get_length() == 0;
-        auto dims = Shape(isScalar ? ngraph::PartialShape{1} : partShape).getDims();
-
-        // we should fill dynamic output dims by zero
-        if (partShape.is_dynamic()) {
-            std::transform(dims.begin(), dims.end(), dims.begin(), [](const size_t& dim) {
-                return dim == Shape::UNDEFINED_DIM ? 0 : dim;
-            });
-        }
-        newOutputShapes[i] = dims;
-    }
-
-    return newOutputShapes;
-}
-
-bool MKLDNNTensorIteratorNode::isBodyExecutable() const {
-    int tripCount;
-    bool cond;
-    if (getAlgorithm() == TensorIteratorLoop) {
-        tripCount = reinterpret_cast<const uint32_t*>(getParentEdgesAtPort(loopTripCountIdx).front()->getMemoryPtr()->GetPtr())[0];
-        cond = static_cast<bool>(reinterpret_cast<const uint8_t*>(getParentEdgesAtPort(loopExecutionConditionIdx).front()->getMemoryPtr()->GetPtr())[0]);
-    } else {
-        tripCount = getNumIteration(inputPortMap, outputPortMap);
-        cond = true;
-    }
-
-    return tripCount != 0 && cond;
 }
 
 int MKLDNNTensorIteratorNode::getNumIteration(const std::vector<PortMap>& inputPortMap, const std::vector<PortMap>& outputPortMap) const {

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_tensoriterator_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_tensoriterator_node.cpp
@@ -509,7 +509,7 @@ void MKLDNNTensorIteratorNode::prepareParams() {
     before_mappers.clear();
     back_mappers.clear();
 
-    if (lastUsedCond && lastUsedTripCount != 0 || !isDynamicNode()) {
+    if ((lastUsedCond && lastUsedTripCount != 0) || !isDynamicNode()) {
         reshapeSubgraphInput();
 
         prepareInputPorts();

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_tensoriterator_node.h
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_tensoriterator_node.h
@@ -131,9 +131,6 @@ private:
     void reshapeAndFillOutput(mkldnn::stream strm);
     int getNumIteration(const std::vector<PortMap>& inputPortMap, const std::vector<PortMap>& outputPortMap) const;
 
-    // this method get all memory ptrs of childs of one port to redefine descs for them
-    std::vector<MKLDNNMemoryPtr> getToMemories(const MKLDNNNode* node, const size_t port) const;
-
     MKLDNNExtensionManager::Ptr ext_mng;
     MKLDNNGraph sub_graph;
     std::vector<std::vector<MKLDNNMemoryPtr>> input_mems;

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_tensoriterator_node.h
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_tensoriterator_node.h
@@ -107,9 +107,9 @@ public:
     void setExtManager(const MKLDNNExtensionManager::Ptr& extMgr) { ext_mng = extMgr; }
 
 protected:
-    //  needShapeInfer() should return false
-    //  because we cannot resolve the output dimensions before the inference is completed
-    bool needShapeInfer() const override { return false; };
+    // ShapeInfer should be used only when trip_count = 0 to get output shapes
+    bool needShapeInfer() const override;
+    std::vector<VectorDims> shapeInfer() const override;
 
     bool needPrepareParams() const override;
     void prepareParams() override;
@@ -129,6 +129,8 @@ private:
     /* Dynamic support */
     void reshapeSubgraphInput();
     void reshapeAndFillOutput(mkldnn::stream strm);
+    bool isBodyExecutable() const;
+
     int getNumIteration(const std::vector<PortMap>& inputPortMap, const std::vector<PortMap>& outputPortMap) const;
 
     MKLDNNExtensionManager::Ptr ext_mng;
@@ -148,7 +150,7 @@ private:
         initial_cond_check,    /// < Perform check of initial continue condition value. value [0, 1]
         continue_cond_check;   /// < Perform check of continue condition value of body. value [0, 1]
 
-    std::vector<std::shared_ptr<DynamicBuffer>> buffers;
+    std::vector<std::shared_ptr<DynamicBuffer>> buffers;   /// < Dynamic buffers for output memory when we use concatenation of output
 
     std::vector<PortMap> inputPortMap;  //!< Input ports map
     std::vector<PortMap> outputPortMap;  //!< Output ports map

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_tensoriterator_node.h
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_tensoriterator_node.h
@@ -62,7 +62,7 @@ protected:
  */
 class DynamicBuffer {
 public:
-    DynamicBuffer(const MKLDNNMemoryPtr &from, const std::vector<MKLDNNMemoryPtr> &to, const PortMap &map_rule);
+    DynamicBuffer(const MKLDNNMemoryPtr &from_, const std::vector<MKLDNNMemoryPtr> &to_, const PortMap &map_rule_);
     ~DynamicBuffer() = default;
 
     void execute(const mkldnn::engine& eng, const int iter);

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_tensoriterator_node.h
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_tensoriterator_node.h
@@ -107,9 +107,9 @@ public:
     void setExtManager(const MKLDNNExtensionManager::Ptr& extMgr) { ext_mng = extMgr; }
 
 protected:
-    // ShapeInfer should be used only when trip_count = 0 to get output shapes
-    bool needShapeInfer() const override;
-    std::vector<VectorDims> shapeInfer() const override;
+    //  needShapeInfer() should return false
+    //  because we cannot resolve the output dimensions before the inference is completed
+    bool needShapeInfer() const override { return false; };
 
     bool needPrepareParams() const override;
     void prepareParams() override;
@@ -129,8 +129,6 @@ private:
     /* Dynamic support */
     void reshapeSubgraphInput();
     void reshapeAndFillOutput(mkldnn::stream strm);
-    bool isBodyExecutable() const;
-
     int getNumIteration(const std::vector<PortMap>& inputPortMap, const std::vector<PortMap>& outputPortMap) const;
 
     MKLDNNExtensionManager::Ptr ext_mng;
@@ -150,7 +148,7 @@ private:
         initial_cond_check,    /// < Perform check of initial continue condition value. value [0, 1]
         continue_cond_check;   /// < Perform check of continue condition value of body. value [0, 1]
 
-    std::vector<std::shared_ptr<DynamicBuffer>> buffers;   /// < Dynamic buffers for output memory when we use concatenation of output
+    std::vector<std::shared_ptr<DynamicBuffer>> buffers;
 
     std::vector<PortMap> inputPortMap;  //!< Input ports map
     std::vector<PortMap> outputPortMap;  //!< Output ports map

--- a/src/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
+++ b/src/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
@@ -175,6 +175,11 @@ std::vector<std::string> disabledTestPatterns() {
         // Issue: 75022
         R"(.*OVExecutableNetworkBaseTest.*LoadNetworkToDefaultDeviceNoThrow.*)",
         R"(.*IEClassBasicTest.*LoadNetworkToDefaultDeviceNoThrow.*)",
+        // Issue: 77390
+        R"(.*LoopLayerCPUTest.*exec_cond=0.*)",
+        R"(.*LoopLayerCPUTest.*trip_count=0.*)",
+        R"(.*LoopForDiffShapesLayerCPUTest.*exec_cond=0.*)",
+        R"(.*LoopForDiffShapesLayerCPUTest.*trip_count=0.*)",
     };
 
 #define FIX_62820 0

--- a/src/tests/functional/plugin/cpu/single_layer_tests/loop.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/loop.cpp
@@ -323,7 +323,7 @@ std::vector<InputLayerType> trip_count_type { InputLayerType::CONSTANT, InputLay
 std::vector<int64_t> trip_count { 1, 5 }; // works only if trip_count_type is constant
 
 // dim[axis] = 1 because loop supports concatenation only with stride = part_size = 1
-// first loop suit test is with output concatenation
+// the first loop suit test is with output concatenation
 std::vector<std::vector<InputShape>> inputs = {
     {  //first test suit
         {   //dynamic shape for first input

--- a/src/tests/functional/plugin/cpu/single_layer_tests/loop.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/loop.cpp
@@ -22,6 +22,7 @@ enum LOOP_IN_TYPE {
 using LoopParams = typename std::tuple<
         InputLayerType,                                                    // TripCount is a constant?
         int64_t,                                                           // TripCount, -1 means infinity
+        bool,                                                              // Execution condition
         std::vector<InputShape>,                                           // InputShapes
         std::vector<LOOP_IN_TYPE>,                                         // Type
         ElementType>;                                                      // Input element type
@@ -33,10 +34,11 @@ public:
     static std::string getTestCaseName(testing::TestParamInfo<LoopParams> obj) {
         InputLayerType trip_count_type;
         int64_t trip_count;
+        bool exec_cond;
         std::vector<InputShape> shapes;
         std::vector<LOOP_IN_TYPE> types;
         ElementType netType;
-        std::tie(trip_count_type, trip_count, shapes, types, netType) = obj.param;
+        std::tie(trip_count_type, trip_count, exec_cond, shapes, types, netType) = obj.param;
 
         std::ostringstream result;
         for (size_t i = 0; i < shapes.size(); i++) {
@@ -52,6 +54,7 @@ public:
             result << type << "_";
         result << "trip_count_type=" << trip_count_type << "_";
         result << "trip_count=" << trip_count << "_";
+        result << "exec_cond=" << exec_cond << "_";
         result << "netType=" << netType;
         return result.str();
 }
@@ -83,10 +86,11 @@ protected:
     void SetUp() override {
         InputLayerType trip_count_type;
         int64_t trip_count;
+        bool exec_cond;
         std::vector<InputShape> shapes;
         std::vector<LOOP_IN_TYPE> types;
         ElementType netType;
-        std::tie(trip_count_type, trip_count, shapes, types, netType) = this->GetParam();
+        std::tie(trip_count_type, trip_count, exec_cond, shapes, types, netType) = this->GetParam();
 
         targetDevice = CommonTestUtils::DEVICE_CPU;
         init_input_shapes(shapes);
@@ -102,7 +106,7 @@ protected:
         }
 
         auto body_condition_const = std::make_shared<ngraph::opset5::Constant>(ngraph::element::boolean, ngraph::Shape{1}, true);
-        auto exec_condition = std::make_shared<ngraph::opset5::Constant>(ngraph::element::boolean, ngraph::Shape{1}, true);
+        auto exec_condition = std::make_shared<ngraph::opset5::Constant>(ngraph::element::boolean, ngraph::Shape{1}, exec_cond);
         std::shared_ptr<ngraph::Node> trip_count_input;
         int shift = 0;
         if (trip_count_type == InputLayerType::PARAMETER) {
@@ -163,9 +167,10 @@ protected:
     void SetUp() override {
         InputLayerType trip_count_type;
         int64_t trip_count;
+        bool exec_cond;
         std::vector<InputShape> shapes;
         std::vector<LOOP_IN_TYPE> types;
-        std::tie(trip_count_type, trip_count, shapes, types, inType) = this->GetParam();
+        std::tie(trip_count_type, trip_count, exec_cond, shapes, types, inType) = this->GetParam();
 
         targetDevice = CommonTestUtils::DEVICE_CPU;
         init_input_shapes(shapes);
@@ -181,7 +186,7 @@ protected:
             body_params.emplace_back(std::make_shared<ngraph::opset1::Parameter>(inType, pshape));
         }
 
-        auto exec_condition = std::make_shared<ngraph::opset5::Constant>(ngraph::element::boolean, ngraph::Shape{}, true);
+        auto exec_condition = std::make_shared<ngraph::opset5::Constant>(ngraph::element::boolean, ngraph::Shape{}, exec_cond);
         auto trip_count_input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::i64, ngraph::Shape{});
         trip_count_input->set_friendly_name("trip_count");
         params.insert(params.begin(), trip_count_input);
@@ -233,9 +238,10 @@ protected:
     void SetUp() override {
         InputLayerType trip_count_type;
         int64_t trip_count;
+        bool exec_cond;
         std::vector<InputShape> shapes;
         std::vector<LOOP_IN_TYPE> types;
-        std::tie(trip_count_type, trip_count, shapes, types, inType) = this->GetParam();
+        std::tie(trip_count_type, trip_count, exec_cond, shapes, types, inType) = this->GetParam();
 
         targetDevice = CommonTestUtils::DEVICE_CPU;
         init_input_shapes(shapes);
@@ -251,7 +257,7 @@ protected:
         }
 
         auto body_condition_const = std::make_shared<ngraph::opset5::Constant>(ngraph::element::boolean, ngraph::Shape{1}, true);
-        auto exec_condition = std::make_shared<ngraph::opset5::Constant>(ngraph::element::boolean, ngraph::Shape{1}, true);
+        auto exec_condition = std::make_shared<ngraph::opset5::Constant>(ngraph::element::boolean, ngraph::Shape{1}, exec_cond);
         std::shared_ptr<ngraph::Node> trip_count_input;
         int shift = 0;
         if (trip_count_type == InputLayerType::PARAMETER) {
@@ -320,7 +326,8 @@ const std::vector<ElementType> inputPrecisions = {
 };
 
 std::vector<InputLayerType> trip_count_type { InputLayerType::CONSTANT, InputLayerType::PARAMETER };
-std::vector<int64_t> trip_count { /*0,*/ 1, 5 }; // works only if trip_count_type is constant. Zero count of iteration not supported in reference
+std::vector<int64_t> trip_count { 0, 1, 5 };
+std::vector<bool> exec_cond { true, false };
 
 // dim[axis] = 1 because loop supports concatenation only with stride = part_size = 1
 // the first loop suit test is with output concatenation
@@ -393,6 +400,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_LoopForCommon, LoopLayerCPUTest,
                          ::testing::Combine(
                                  ::testing::ValuesIn(trip_count_type),
                                  ::testing::ValuesIn(trip_count),
+                                 ::testing::ValuesIn(exec_cond),
                                  ::testing::ValuesIn(inputs),
                                  ::testing::Values(types),
                                  ::testing::ValuesIn(inputPrecisions)),
@@ -428,6 +436,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_LoopWhileCommon, LoopWhileLayerCPUTest,
                          ::testing::Combine(
                                  ::testing::Values(trip_count_type[0]),
                                  ::testing::Values(-1),
+                                 ::testing::Values(true),
                                  ::testing::ValuesIn(inputs_2),
                                  ::testing::Values(std::vector<LOOP_IN_TYPE>{}),
                                  ::testing::ValuesIn(inputPrecisions)),
@@ -462,6 +471,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_LoopForDiffShapesConcat, LoopForDiffShapesLayerCP
                          ::testing::Combine(
                                  ::testing::ValuesIn(trip_count_type),
                                  ::testing::ValuesIn(trip_count),
+                                 ::testing::ValuesIn(exec_cond),
                                  ::testing::ValuesIn(inputs_3),
                                  ::testing::Values(std::vector<LOOP_IN_TYPE>{}),
                                  ::testing::ValuesIn(inputPrecisions)),

--- a/src/tests/functional/plugin/cpu/single_layer_tests/loop.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/loop.cpp
@@ -320,7 +320,7 @@ const std::vector<ElementType> inputPrecisions = {
 };
 
 std::vector<InputLayerType> trip_count_type { InputLayerType::CONSTANT, InputLayerType::PARAMETER };
-std::vector<int64_t> trip_count { 1, 5 }; // works only if trip_count_type is constant
+std::vector<int64_t> trip_count { /*0,*/ 1, 5 }; // works only if trip_count_type is constant. Zero count of iteration not supported in reference
 
 // dim[axis] = 1 because loop supports concatenation only with stride = part_size = 1
 // the first loop suit test is with output concatenation


### PR DESCRIPTION
### Details:
 - *Fixed last comments in [PR#8879](https://github.com/openvinotoolkit/openvino/pull/8879)*
 - *Added `trip_count = 0` and `exec_cond = false` support and removed exception throwing. Now if `TI/Loop` isn't executed output dynamic dims are filled by `0`. This PR doesn't include shape inference for body in these cases because it decreases performance (commit 2f6fce46a1e7e8894111afcd27aca1c3ea4f4818)*
 - *Fixed klockworks*
 - *Improved `prepareParams` to avoid overheads*

### Tickets:
 - *74819*
