### PR TITLE
Update Model::reshape to rethrow currently handled exception

### DIFF
--- a/src/core/src/model.cpp
+++ b/src/core/src/model.cpp
@@ -877,10 +877,10 @@ void ov::Model::reshape(const std::map<ov::Output<ov::Node>, ov::PartialShape>& 
         ssr_manager.run_passes(shared_from_this());
 
         reshape_only(new_param_shapes);
-    } catch (std::exception& ex) {
+    } catch (...) {
         // restore shapes to original ones
         reshape_only(original_input_shapes);
-        throw ex;
+        throw;
     }
 }
 

--- a/src/core/tests/model.cpp
+++ b/src/core/tests/model.cpp
@@ -741,7 +741,7 @@ TEST(model_reshape, TestInvalidReshape) {
         f = std::make_shared<ov::Model>(ov::OutputVector{reshape}, ov::ParameterVector{input});
     }
 
-    EXPECT_ANY_THROW(f->reshape({{"tensor", ov::Shape({4})}}));
+    EXPECT_THROW(f->reshape({{"tensor", ov::Shape({4})}}), ov::Exception);
 
     auto param = f->get_parameters().front();
     EXPECT_EQ(param->get_output_shape(0), ov::Shape({1, 1000, 4}));


### PR DESCRIPTION
### Details:
Update `Model::reshape` to rethrow the currently handled exception like `ov::Exception` with meaningful error message
instead of simple `std::exception` without any info.

### Tickets:
 -  related to 74952
