### PR TITLE
Fix data type of inserted constants for means and scales

### DIFF
--- a/tools/mo/openvino/tools/mo/middle/AddMeanScaleValues.py
+++ b/tools/mo/openvino/tools/mo/middle/AddMeanScaleValues.py
@@ -56,13 +56,13 @@ class AddMeanScaleValues(MiddleReplacementPattern):
         shape[features_dim_idx] = value.size
         value = value.reshape(shape)
 
-        name = in_name + '/' + preprocessing_name
-        preprocessing = create_op_with_const_inputs(graph, op=op, port_value_dict={1: value}, op_attrs={'name': name})
-
         if input_node.op == 'Parameter' and input_node.has_and_set('data_type'):
             dtype = input_node.data_type
             if np.issubdtype(dtype, np.floating):
                 value = value.astype(dtype)
+
+        name = in_name + '/' + preprocessing_name
+        preprocessing = create_op_with_const_inputs(graph, op=op, port_value_dict={1: value}, op_attrs={'name': name})
 
         if input_node.is_out_port_connected(0) and len(input_node.out_port(0).get_destinations()) == 1:
             # There are models with pattern Parameter(uint8) -> Convert(float).

--- a/tools/mo/unit_tests/mo/middle/AddMeanScaleValues_test.py
+++ b/tools/mo/unit_tests/mo/middle/AddMeanScaleValues_test.py
@@ -16,9 +16,15 @@ from unit_tests.utils.graph import build_graph, regular_op_with_shaped_data, res
 
 nodes = {
     **regular_op_with_shaped_data('parameter', [1, 3, 227, 227],
-                                  {'type': 'Parameter', 'op': 'Parameter', 'shape': [1, 3, 227, 227]}),
+                                  {'type': 'Parameter',
+                                   'op': 'Parameter',
+                                   'shape': [1, 3, 227, 227],
+                                   'data_type': np.float32}),
     **regular_op_with_shaped_data('parameter_2', [1, 3, 227, 227],
-                                  {'type': 'Parameter', 'op': 'Parameter', 'shape': [1, 3, 227, 227]}),
+                                  {'type': 'Parameter',
+                                   'op': 'Parameter',
+                                   'shape': [1, 3, 227, 227],
+                                   'data_type': np.float32}),
 
     **regular_op_with_shaped_data('mul_scale', [1, 3, 227, 227], {'type': 'Multiply', 'op': 'Mul'}),
     **regular_op_with_shaped_data('add_mean', [1, 3, 227, 227], {'type': 'Add', 'op': 'Add'}),
@@ -45,6 +51,9 @@ class AddMeanScaleValuesTest(UnitTestWithMockedTelemetry):
                 out_node_ref = Node(graph_ref, node.id).out_node(0)
                 self.assertTrue(out_node['fw_tensor_debug_info'] == out_node_ref['fw_tensor_debug_info'])
             else:
+                if node.soft_get('type') == 'Const':
+                    value = node.out_port(0).data.get_value()
+                    self.assertTrue(value.dtype == np.float32)
                 if 0 in node.out_nodes():
                     out_node = node.out_node(0)
                     self.assertFalse('fw_tensor_debug_info' in out_node)


### PR DESCRIPTION
Root cause analysis: AddMeanScaleValues.py were inserting FP64 constants instead of inheriting the type from Parameter.

Solution: Inherit type from Parameter

Ticket: 76077


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests N/A
* [x]  Transformation tests N/A
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list N/A
* [x]  Guide on how to convert the **public** model N/A
* [x]  User guide update N/A