### PR TITLE
Change libs name of vpux plugin

### DIFF
--- a/src/tests/functional/plugin/conformance/test_runner/api_conformance_runner/include/api_conformance_helpers.hpp
+++ b/src/tests/functional/plugin/conformance/test_runner/api_conformance_runner/include/api_conformance_helpers.hpp
@@ -16,9 +16,9 @@ namespace conformance {
 
 inline const std::string getPluginLibNameByDevice(const std::string& deviceName) {
     const std::map<std::string, std::string> devices{
-            { "AUTO", "AutoPlugin" },
+            { "AUTO", "ov_multi_plugin" },
             { "HDDL", "HDDLPlugin" },
-            { "VPUX", "VPUXPlugin" },
+            { "VPUX", "ov_intel_vpux_plugin" },
             { "AUTO", "ov_auto_plugin" },
             { "CPU", "ov_intel_cpu_plugin" },
             { "GNA", "ov_intel_gna_plugin" },


### PR DESCRIPTION
### Details:
 - Change lib name VPUXPlugin on: ov_intel_vpux_plugin

### Tickets:
 - EISW-29106
