### PR TITLE
Fix memleak caused by SetupDiGetClassDevs() object

### DIFF
--- a/inference-engine/thirdparty/movidius/XLink/pc/protocols/pcie_host.c
+++ b/inference-engine/thirdparty/movidius/XLink/pc/protocols/pcie_host.c
@@ -382,6 +382,7 @@ int pci_count_devices(uint16_t vid, uint16_t pid)
             deviceCnt++;
         }
     }
+    SetupDiDestroyDeviceInfoList(hDevInfo);
     return deviceCnt;
 }
 #endif  // (defined(_WIN32) || defined(_WIN64))


### PR DESCRIPTION
To prevent leaks, object should be cleaned up
by calling SetupDiDestroyDeviceInfoList()
Refer to https://docs.microsoft.com/en-us/windows/win32/api/setupapi/nf-setupapi-setupdigetclassdevsw#remarks

### Tickets:
 - CVS-75871

### GitHub issue:
- https://github.com/openvinotoolkit/openvino/issues/9501
