### PR TITLE
[MO IR Reader]Remove incorrect layout changing

### DIFF
--- a/tools/mo/openvino/tools/mo/utils/ir_engine/ir_engine.py
+++ b/tools/mo/openvino/tools/mo/utils/ir_engine/ir_engine.py
@@ -58,8 +58,12 @@ class IREngine(object):
         self.graph.graph['hashes'] = {}
 
         self.graph.graph['ir_version'] = int(xml_root.attrib['version']) if xml_root.attrib.get('version') is not None else None
-        self.graph.graph['layout'] = 'NCHW' # We set layout to NCHW as default value and
-                                            # changing it in __rt_info_check_layout if it will be necessary
+
+        # NOTE: THis is MO internal attribute, it cannot be used for
+        # defining graph input layout. We set it to NCHW as in MO back stage
+        # during conversion for correct shape inference of layout specific
+        # operations (ExtractImagePatches, SpaceToDepth, etc.)
+        self.graph.graph['layout'] = 'NCHW'
 
         self.graph.name = xml_root.attrib['name'] if xml_root.attrib.get('name') is not None else None
 
@@ -237,7 +241,6 @@ class IREngine(object):
                         if dim.tag == 'rt_info':
                             for attr in dim:
                                 port_rt_info.update(self.__read_rt_info_common(attr))
-                                self.__rt_info_check_layout(attr)
 
                     input_shape = shape_array([d if d != -1 else dynamic_dimension_value for d in input_shape])
 
@@ -259,7 +262,6 @@ class IREngine(object):
                         if dim.tag == 'rt_info':
                             for attr in dim:
                                 port_rt_info.update(self.__read_rt_info_common(attr))
-                                self.__rt_info_check_layout(attr)
 
                     output_shape = shape_array([d if d != -1 else dynamic_dimension_value for d in output_shape])
 
@@ -528,11 +530,3 @@ class IREngine(object):
             if key not in ('name', 'version'):
                 rt_info[key] = attr.attrib[key]
         return {(attr_name, version): rt_info}
-
-    def __rt_info_check_layout(self, attr):
-        graph_layout = None
-        for key in attr.attrib:
-            if key == 'layout':
-                graph_layout = attr.attrib[key].replace(',', '').strip('[] ')# .strip(']').strip(',').strip(' ')
-        if graph_layout is not None:
-            self.graph.graph['layout'] = graph_layout


### PR DESCRIPTION
Root cause analysis: Now we have incorrect layout while reading graph by MO IR Reader - we set `graph.graph['layout']` to same value as IR graph has. But it leads to errors in shape inference of layout specific operations.

Solution: Always set `graph.graph['layout'] = 'NCHW'` - the same as MO has on back convertation stage.

Ticket: 75689

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names


Validation:
* [x]  Unit tests: N/A - No new implemented functions;
* [x]  Framework operation tests: N/A - No new enabled operations;
* [x]  Transformation tests: N/A - No new implemented transformations;
* [x]  Model Optimizer IR Reader check: Done manually.

Documentation:
* [x]  Supported frameworks operations list: N/A - No new supported operations;
* [x]  Supported **public** models list: N/A - Nothing to add;
* [x]  User guide update: N/A - Nothing to update.
