### PR TITLE
[Python Bindings] Frontend test for telemetry extension

### DIFF
--- a/src/bindings/python/tests/mock/ov_mock_py_frontend/mock_py_frontend.hpp
+++ b/src/bindings/python/tests/mock/ov_mock_py_frontend/mock_py_frontend.hpp
@@ -6,6 +6,7 @@
 
 #include "ngraph/visibility.hpp"
 #include "openvino/frontend/manager.hpp"
+#include "openvino/frontend/extension/telemetry.hpp"
 #include "openvino/frontend/visibility.hpp"
 
 // Defined if we are building the plugin DLL (instead of using it)
@@ -619,11 +620,16 @@ struct MOCK_API FeStat {
 
 class MOCK_API FrontEndMockPy : public FrontEnd {
     static FeStat m_stat;
-
+    std::shared_ptr<ov::frontend::TelemetryExtension> m_telemetry;
 public:
     FrontEndMockPy() = default;
 
     InputModel::Ptr load_impl(const std::vector<ov::Any>& params) const override {
+        if (m_telemetry) {
+            m_telemetry->send_event("load_impl", "label", 42);
+            m_telemetry->send_error("load_impl_error");
+            m_telemetry->send_stack_trace("mock_stack_trace");
+        }
         if (!params.empty() && params[0].is<std::string>())
             m_stat.m_load_paths.push_back(params[0].as<std::string>());
         return std::make_shared<InputModelMockPy>();
@@ -666,6 +672,12 @@ public:
     std::string get_name() const override {
         m_stat.m_get_name++;
         return "mock_py";
+    }
+
+    void add_extension(const std::shared_ptr<ov::Extension>& extension) override {
+        if (auto p = std::dynamic_pointer_cast<TelemetryExtension>(extension)) {
+            m_telemetry = p;
+        }
     }
 
     static FeStat get_stat() {

--- a/src/bindings/python/tests/mock/ov_mock_py_frontend/mock_py_frontend.hpp
+++ b/src/bindings/python/tests/mock/ov_mock_py_frontend/mock_py_frontend.hpp
@@ -5,8 +5,8 @@
 #pragma once
 
 #include "ngraph/visibility.hpp"
-#include "openvino/frontend/manager.hpp"
 #include "openvino/frontend/extension/telemetry.hpp"
+#include "openvino/frontend/manager.hpp"
 #include "openvino/frontend/visibility.hpp"
 
 // Defined if we are building the plugin DLL (instead of using it)
@@ -621,6 +621,7 @@ struct MOCK_API FeStat {
 class MOCK_API FrontEndMockPy : public FrontEnd {
     static FeStat m_stat;
     std::shared_ptr<ov::frontend::TelemetryExtension> m_telemetry;
+
 public:
     FrontEndMockPy() = default;
 

--- a/src/bindings/python/tests/test_frontend/test_frontendmanager.py
+++ b/src/bindings/python/tests/test_frontend/test_frontendmanager.py
@@ -392,7 +392,7 @@ def test_model_set_element_type():
 
 @mock_needed
 def test_model_telemetry():
-    class MockTelemetry(object):
+    class MockTelemetry:
         def __init__(self, stat):
             self.stat = stat
 
@@ -405,10 +405,12 @@ def test_model_telemetry():
         def send_stack_trace(self, *arg, **kwargs):
             self.stat["send_stack_trace"] = 1
 
-    def add_ext(frontEnd, stat):
-        t = MockTelemetry(stat)
-        frontEnd.add_extension(TelemetryExtension("mock", t.send_event, t.send_error, t.send_stack_trace))
-        t = None
+    def add_ext(front_end, stat):
+        tel = MockTelemetry(stat)
+        front_end.add_extension(TelemetryExtension("mock",
+                                                   tel.send_event,
+                                                   tel.send_error,
+                                                   tel.send_stack_trace))
 
     clear_all_stat()
     tel_stat = {}
@@ -419,6 +421,7 @@ def test_model_telemetry():
     assert tel_stat["send_event"] == 1
     assert tel_stat["send_error"] == 1
     assert tel_stat["send_stack_trace"] == 1
+    assert model
 
 
 # ----------- Place test ------------

--- a/src/bindings/python/tests/test_frontend/test_frontendmanager.py
+++ b/src/bindings/python/tests/test_frontend/test_frontendmanager.py
@@ -4,7 +4,7 @@
 import pickle
 
 from openvino.runtime import PartialShape
-from openvino.frontend import FrontEndManager, InitializationFailure
+from openvino.frontend import FrontEndManager, InitializationFailure, TelemetryExtension
 from openvino.runtime.utils.types import get_element_type
 
 import numpy as np
@@ -388,6 +388,37 @@ def test_model_set_element_type():
     assert stat.set_element_type == 1
     assert stat.lastArgPlace == place
     assert stat.lastArgElementType == get_element_type(np.int32)
+
+
+@mock_needed
+def test_model_telemetry():
+    class MockTelemetry(object):
+        def __init__(self, stat):
+            self.stat = stat
+
+        def send_event(self, *arg, **kwargs):
+            self.stat["send_event"] = 1
+
+        def send_error(self, *arg, **kwargs):
+            self.stat["send_error"] = 1
+
+        def send_stack_trace(self, *arg, **kwargs):
+            self.stat["send_stack_trace"] = 1
+
+    def add_ext(frontEnd, stat):
+        t = MockTelemetry(stat)
+        frontEnd.add_extension(TelemetryExtension("mock", t.send_event, t.send_error, t.send_stack_trace))
+        t = None
+
+    clear_all_stat()
+    tel_stat = {}
+    fe = fem.load_by_framework(framework="mock_py")
+    # Ensure that MockTelemetry object is alive and can receive events (due to callbacks hold the object)
+    add_ext(fe, tel_stat)
+    model = fe.load(path="")
+    assert tel_stat["send_event"] == 1
+    assert tel_stat["send_error"] == 1
+    assert tel_stat["send_stack_trace"] == 1
 
 
 # ----------- Place test ------------


### PR DESCRIPTION
### Details:
 - This also ensures that actual 'Telemetry' object containing callbacks is still alive even there is no explicit Python objects holding it. So there is no such potential 'crash' when object holding callback on Python side is destroyed

### Tickets:
 - 72263
