### PR TITLE
[PyBind] Fix crash on destroying dtype_to_ov_type static map

### DIFF
--- a/src/bindings/python/src/pyopenvino/core/common.cpp
+++ b/src/bindings/python/src/pyopenvino/core/common.cpp
@@ -29,8 +29,8 @@ const std::map<ov::element::Type, py::dtype>& ov_type_to_dtype() {
     return ov_type_to_dtype_mapping;
 }
 
-const std::map<py::str, ov::element::Type>& dtype_to_ov_type() {
-    static const std::map<py::str, ov::element::Type> dtype_to_ov_type_mapping = {
+const std::map<std::string, ov::element::Type>& dtype_to_ov_type() {
+    static const std::map<std::string, ov::element::Type> dtype_to_ov_type_mapping = {
         {"float16", ov::element::f16},
         {"float32", ov::element::f32},
         {"float64", ov::element::f64},

--- a/src/bindings/python/src/pyopenvino/core/common.hpp
+++ b/src/bindings/python/src/pyopenvino/core/common.hpp
@@ -26,7 +26,7 @@ namespace py = pybind11;
 namespace Common {
 const std::map<ov::element::Type, py::dtype>& ov_type_to_dtype();
 
-const std::map<py::str, ov::element::Type>& dtype_to_ov_type();
+const std::map<std::string, ov::element::Type>& dtype_to_ov_type();
 
 ov::runtime::Tensor tensor_from_numpy(py::array& array, bool shared_memory);
 

--- a/src/bindings/python/tests/test_inference_engine/subprocess_test_tensor.py
+++ b/src/bindings/python/tests/test_inference_engine/subprocess_test_tensor.py
@@ -11,5 +11,5 @@ def test_run():
     assert t.element_type == Type.f32
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_run()

--- a/src/bindings/python/tests/test_inference_engine/subprocess_test_tensor.py
+++ b/src/bindings/python/tests/test_inference_engine/subprocess_test_tensor.py
@@ -1,0 +1,15 @@
+# Copyright (C) 2018-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+
+from openvino.runtime import Tensor, Type
+
+
+def test_run():
+    t = Tensor(np.random.randn(1, 3, 224, 224).astype(np.float32))
+    assert t.element_type == Type.f32
+
+
+if __name__ == '__main__':
+    test_run()

--- a/src/bindings/python/tests/test_inference_engine/test_tensor.py
+++ b/src/bindings/python/tests/test_inference_engine/test_tensor.py
@@ -1,12 +1,18 @@
 # Copyright (C) 2018-2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+import subprocess
+import sys
+
 import numpy as np
+
+import openvino.runtime as ov
+from openvino.runtime import Tensor
+
 import pytest
 
 from ..conftest import read_image
-from openvino.runtime import Tensor
-import openvino.runtime as ov
 
 
 @pytest.mark.parametrize("ov_type, numpy_dtype", [
@@ -33,6 +39,13 @@ def test_init_with_ngraph(ov_type, numpy_dtype):
     assert np.all(ov_tensor.element_type == ov_type for ov_tensor in ov_tensors)
     assert np.all(ov_tensor.data.dtype == numpy_dtype for ov_tensor in ov_tensors)
     assert np.all(ov_tensor.data.shape == (1, 3, 32, 32) for ov_tensor in ov_tensors)
+
+
+def test_subprocess():
+    args = [sys.executable, os.path.join(os.path.dirname(__file__), 'subprocess_test_tensor.py')]
+
+    status = subprocess.run(args, env=os.environ)
+    assert not status.returncode
 
 
 @pytest.mark.parametrize("ov_type, numpy_dtype", [

--- a/src/bindings/python/tests/test_inference_engine/test_tensor.py
+++ b/src/bindings/python/tests/test_inference_engine/test_tensor.py
@@ -42,7 +42,7 @@ def test_init_with_ngraph(ov_type, numpy_dtype):
 
 
 def test_subprocess():
-    args = [sys.executable, os.path.join(os.path.dirname(__file__), 'subprocess_test_tensor.py')]
+    args = [sys.executable, os.path.join(os.path.dirname(__file__), "subprocess_test_tensor.py")]
 
     status = subprocess.run(args, env=os.environ)
     assert not status.returncode


### PR DESCRIPTION
### Details:
 - Use std::string for static map instead of py::str
 - Probable reason is that this static map is destroyed after 'pybind' module is destoryed itself, thus py::str can't be cleaned up properly

### Testing:
 - Unfortunately when executing via 'pytest' - crash doesn't happen, looks like this static map is destroyed before python environment in this case. Thus, added test case which executes appropriate test as separate subprocess - with this approach test is failed when fix is not applied

### Tickets:
 - 76059
