### PR TITLE
[GPU] Fix eltwise's inputs indexes calculation and order of dimensions

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/eltwise/eltwise_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/eltwise/eltwise_kernel_base.cpp
@@ -398,6 +398,8 @@ JitConstants EltwiseKernelBase::MakeIndexJitConstants(const eltwise_params& para
                 bfyx_idx_order = { "d1", "d4", "d3", "d2" };
             } else if (l == DataLayout::byxf) {
                 bfyx_idx_order = { "d4", "d1", "d3", "d2" };
+            } else if (l == DataLayout::fs_b_yx_fsv32) {
+                bfyx_idx_order = { "d3", "d4", "d2", "d1" };
             } else {
                 bfyx_idx_order = { "d4", "d3", "d2", "d1" };
             }

--- a/src/plugins/intel_gpu/src/kernel_selector/core/cl_kernels/include/batch_headers/fetch_data.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/core/cl_kernels/include/batch_headers/fetch_data.cl
@@ -243,6 +243,19 @@ inline uint get_b_fs_yx_fsv_index_safe(uint b, uint f, uint y, uint x,
         CAT(prefix, _PAD_BEFORE_FEATURE_NUM),            \
         CAT(prefix, _BATCH_NUM))
 
+#define GET_DATA_FS_B_YX_FSV32_INDEX_SAFE(prefix, b, f, y, x) \
+    get_fs_b_yx_fsv32_index_safe(                             \
+        b, f, y, x,                                           \
+        CAT(prefix, _PAD_BEFORE_SIZE_X),                      \
+        CAT(prefix, _SIZE_X),                                 \
+        CAT(prefix, _PAD_AFTER_SIZE_X),                       \
+        CAT(prefix, _PAD_BEFORE_SIZE_Y),                      \
+        CAT(prefix, _SIZE_Y),                                 \
+        CAT(prefix, _PAD_AFTER_SIZE_Y),                       \
+        CAT(prefix, _PAD_BEFORE_FEATURE_NUM),                 \
+        CAT(prefix, _FEATURE_NUM),                            \
+        CAT(prefix, _BATCH_NUM))
+
 inline uint get_fs_b_yx_fsv32_index(uint b, uint f, uint y, uint x,
                                           uint x_pad_before, uint x_size, uint x_pad_after,
                                           uint y_pad_before, uint y_size, uint y_pad_after,
@@ -265,6 +278,40 @@ inline uint get_fs_b_yx_fsv32_index(uint b, uint f, uint y, uint x,
 
     const uint feature_tile_number = real_f / feature_tile_size;        // number of tile which feature belongs to
     const uint feature_local_number = real_f % feature_tile_size;       // local number of feature in tile
+
+    size_t index = 0;
+
+    index += feature_tile_number * f_tile_pitch; // locate beginning of feature tile
+    index += b * b_pitch;                        // locate beginning of batch
+    index += real_y * y_pitch;                   // locate beginning of y with respect to padding
+    index += real_x * x_pitch;                   // locate beginning of x with respect to padding
+    index += feature_local_number;               // find requested index by adding feature location in tile
+
+    return index;
+}
+
+inline uint get_fs_b_yx_fsv32_index_safe(uint b, uint f, uint y, uint x,
+                                         uint x_pad_before, uint x_size, uint x_pad_after,
+                                         uint y_pad_before, uint y_size, uint y_pad_after,
+                                         uint f_pad_before, uint f_size,
+                                         uint size_b)
+{
+    const uint feature_tile_size = 32;                             // size of the feature tile (slice)
+
+    const uint x_total_size = x_pad_before + x_size + x_pad_after; // total size of x before padding
+    const uint y_total_size = y_pad_before + y_size + y_pad_after; // total size of y before padding
+
+    const uint real_x = (x % x_size) + x_pad_before;               // x before padding
+    const uint real_y = (y % y_size) + y_pad_before;               // y before padding
+    const uint real_f = (f % f_size) + f_pad_before;               // f before padding
+
+    const uint x_pitch = feature_tile_size;                        // difference in location between (x+1) and (x)
+    const uint y_pitch = x_pitch * x_total_size;                   // difference in location between (y+1) and (y)
+    const uint b_pitch = y_pitch * y_total_size;                   // difference in location between (b+1) and (b)
+    const uint f_tile_pitch = b_pitch * size_b;                    // difference in location between (fs+1) and (fs)
+
+    const uint feature_tile_number = real_f / feature_tile_size;   // number of tile which feature belongs to
+    const uint feature_local_number = real_f % feature_tile_size;  // local number of feature in tile
 
     size_t index = 0;
 

--- a/src/plugins/intel_gpu/src/kernel_selector/core/common/jitter.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/core/common/jitter.cpp
@@ -349,7 +349,8 @@ JitDefinitions DataTensorJitConstant::GetDefinitions() const {
                     layout == DataLayout::bs_fs_yx_bsv4_fsv4  ||
                     layout == DataLayout::bs_fs_yx_bsv8_fsv4  ||
                     layout == DataLayout::bs_fs_yx_bsv4_fsv2  ||
-                    layout == DataLayout::bs_fs_yx_bsv16_fsv16)
+                    layout == DataLayout::bs_fs_yx_bsv16_fsv16 ||
+                    layout == DataLayout::fs_b_yx_fsv32)
                     safe_index_func_val = "GET_DATA_" + layout_str + "_INDEX_SAFE(" + _name + ", b, f, y, x)";
                 else
                     safe_index_func_val = "GET_DATA_" + layout_str + "_INDEX(" + _name + ", b, f, y, x)";

--- a/src/plugins/intel_gpu/tests/test_cases/eltwise_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/eltwise_gpu_test.cpp
@@ -2513,6 +2513,71 @@ TEST(eltwise_gpu_f16, fs_b_yx_fsv32_basic)
     }
 }
 
+TEST(eltwise_gpu_f16, fs_b_yx_fsv32_broadcast)
+{
+    auto& engine = get_test_engine();
+    bool f16_supported = engine.get_device_info().supports_fp16;
+    if (!f16_supported) {
+        std::cout << "[ SKIPPED  ] float16 combinations are skipped (cl_khr_fp16 is not supported)." << std::endl;
+        return;
+    }
+
+    size_t input_b = 2;
+    size_t input_f = 72;
+    size_t input1_y = 10, input1_x = 10;
+    size_t input2_y = 1, input2_x = 1;
+
+    tensor input1_tensor(input_b, input_f, input1_x, input1_y);
+    tensor input2_tensor(input_b, input_f, input2_x, input2_y);
+
+    VVVVF<FLOAT16> input1_rnd = generate_random_4d<FLOAT16>(input_b, input_f, input1_y, input1_x, 1, 3);
+    VVVVF<FLOAT16> input2_rnd = generate_random_4d<FLOAT16>(input_b, input_f, input2_y, input2_x, 1, 3);
+
+    VF<FLOAT16> input1_flatten = flatten_4d<FLOAT16>(format::bfyx, input1_rnd);
+    VF<FLOAT16> input2_flatten = flatten_4d<FLOAT16>(format::bfyx, input2_rnd);
+
+    auto input1 = engine.allocate_memory({ data_types::f16,format::bfyx, input1_tensor });
+    auto input2 = engine.allocate_memory({ data_types::f16,format::bfyx, input2_tensor });
+
+    set_values(input1, input1_flatten);
+    set_values(input2, input2_flatten);
+
+    topology ref_topology;
+    ref_topology.add(input_layout("input1", input1->get_layout()));
+    ref_topology.add(input_layout("input2", input2->get_layout()));
+    ref_topology.add(eltwise("eltwise", "input1", "input2", eltwise_mode::prod));
+
+    network ref_network(engine, ref_topology);
+    ref_network.set_input_data("input1", input1);
+    ref_network.set_input_data("input2", input2);
+
+    auto ref_outputs = ref_network.execute();
+    auto ref_output = ref_outputs.at("eltwise").get_memory();
+    cldnn::mem_lock<FLOAT16> ref_ptr(ref_output, get_test_stream());
+
+    topology fsv32_topology;
+    fsv32_topology.add(input_layout("input1", input1->get_layout()));
+    fsv32_topology.add(input_layout("input2", input2->get_layout()));
+    fsv32_topology.add(reorder("reorder1", "input1", layout(data_types::f16, format::fs_b_yx_fsv32, input1_tensor)));
+    fsv32_topology.add(reorder("reorder2", "input2", layout(data_types::f16, format::fs_b_yx_fsv32, input2_tensor)));
+    fsv32_topology.add(eltwise("eltwise", "reorder1", "reorder2", eltwise_mode::prod));
+    fsv32_topology.add(reorder("reorder_bfyx", "eltwise", layout(data_types::f16, format::bfyx, input1_tensor)));
+
+    network fsv32_network(engine, fsv32_topology);
+    fsv32_network.set_input_data("input1", input1);
+    fsv32_network.set_input_data("input2", input2);
+
+    auto fsv32_outputs = fsv32_network.execute();
+    auto fsv32_output = fsv32_outputs.at("reorder_bfyx").get_memory();
+    cldnn::mem_lock<FLOAT16> fsv32_ptr(fsv32_output, get_test_stream());
+
+    ASSERT_EQ(ref_ptr.size(), fsv32_ptr.size());
+
+    for (size_t i = 0; i < ref_ptr.size(); i++) {
+        ASSERT_EQ(float(ref_ptr[i]), float(fsv32_ptr[i]));
+    }
+}
+
 TEST(eltwise_gpu_f32, broadcast_test_in4x4x2x2x2) {
     //  Input  : 2x2x2x2x1
     //  Input2 : 2x2x1x1x2


### PR DESCRIPTION
### Details:
 - Fixed indexes calculation in broadcast mode
 - Fixed order of dimensions in default mode
 - Added `get index safe` function for `fs_b_yx_fsv32` format
 - Added test case

### Tickets:
 - 74847
