### PR TITLE
Create CNNNetwork in AddOutputsTest body instead at program startup

### DIFF
--- a/src/tests/functional/plugin/cpu/shared_tests_instances/execution_graph_tests/add_output.cpp
+++ b/src/tests/functional/plugin/cpu/shared_tests_instances/execution_graph_tests/add_output.cpp
@@ -29,7 +29,7 @@ InferenceEngine::CNNNetwork getTargetNetwork() {
 }
 
 std::vector<addOutputsParams> testCases = {
-        addOutputsParams(getTargetNetwork(), {"Memory"}, CommonTestUtils::DEVICE_CPU)
+        addOutputsParams(getTargetNetwork, {"Memory"}, CommonTestUtils::DEVICE_CPU)
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_AddOutputBasic, AddOutputsTest,

--- a/src/tests/functional/plugin/gna/shared_tests_instances/execution_graph_tests/add_output.cpp
+++ b/src/tests/functional/plugin/gna/shared_tests_instances/execution_graph_tests/add_output.cpp
@@ -86,7 +86,7 @@ InferenceEngine::CNNNetwork getTargetNetwork() {
 }
 
 std::vector<addOutputsParams> testCases = {
-        addOutputsParams(getTargetNetwork(), {"Memory_1"}, CommonTestUtils::DEVICE_GNA)
+        addOutputsParams(getTargetNetwork, {"Memory_1"}, CommonTestUtils::DEVICE_GNA)
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_AddOutputBasic, AddOutputsTest,

--- a/src/tests/functional/plugin/shared/include/execution_graph_tests/add_output.hpp
+++ b/src/tests/functional/plugin/shared/include/execution_graph_tests/add_output.hpp
@@ -9,7 +9,7 @@
 #include <ie_core.hpp>
 
 typedef std::tuple<
-        InferenceEngine::CNNNetwork, // CNNNetwork to work with
+        InferenceEngine::CNNNetwork(*)(), // function that creates CNNNetwork
         std::vector<std::string>,    // Target layers to add as outputs
         std::string>                 // Target device name
         addOutputsParams;
@@ -17,7 +17,7 @@ typedef std::tuple<
 class AddOutputsTest : public CommonTestUtils::TestsCommon,
                        public testing::WithParamInterface<addOutputsParams> {
 protected:
-    InferenceEngine::CNNNetwork net;
+    InferenceEngine::CNNNetwork (*createNetwork)();
     std::vector<std::string> outputsToAdd;
     std::string deviceName;
 

--- a/src/tests/functional/plugin/shared/src/execution_graph_tests/add_output.cpp
+++ b/src/tests/functional/plugin/shared/src/execution_graph_tests/add_output.cpp
@@ -11,21 +11,20 @@
 
 std::string AddOutputsTest::getTestCaseName(const testing::TestParamInfo<addOutputsParams> &obj) {
     std::ostringstream results;
-    InferenceEngine::CNNNetwork net;
     std::vector<std::string> outputsToAdd;
-    std::string deviceName;
-    std::tie(net, outputsToAdd, deviceName) = obj.param;
+    std::tie(std::ignore, outputsToAdd, std::ignore) = obj.param;
     results << "Outputs:" << CommonTestUtils::vec2str<std::string>(outputsToAdd);
     return results.str();
 }
 
 void AddOutputsTest::SetUp() {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    std::tie(net, outputsToAdd, deviceName) = GetParam();
+    std::tie(createNetwork, outputsToAdd, deviceName) = GetParam();
 }
 
 TEST_P(AddOutputsTest, smoke_CheckOutputExist) {
     std::vector<std::string> expectedOutputs = outputsToAdd;
+    auto net = createNetwork();
     for (const auto &out : net.getOutputsInfo()) {
         expectedOutputs.push_back(out.first);
     }


### PR DESCRIPTION
Currently CNNNetwork for AddOutputsTest is created every time
cpuFuncTests starts regardless if AddOutputsTest is running or not.
This change defers CNNNetwork creation to AddOutputsTest body.

