### PR TITLE
[PYTHON] Callable CompiledModel

### DIFF
--- a/src/bindings/python/src/openvino/runtime/ie_api.py
+++ b/src/bindings/python/src/openvino/runtime/ie_api.py
@@ -89,6 +89,10 @@ class CompiledModel(CompiledModelBase):
         )
         return super().infer_new_request(inputs)
 
+    def __call__(self, inputs: Union[dict, list] = None) -> dict:
+        """Callable infer wrapper for CompiledModel."""
+        return self.infer_new_request(inputs)
+
 
 class AsyncInferQueue(AsyncInferQueueBase):
     """AsyncInferQueue wrapper."""

--- a/src/bindings/python/tests/test_inference_engine/test_compiled_model.py
+++ b/src/bindings/python/tests/test_inference_engine/test_compiled_model.py
@@ -307,3 +307,19 @@ def test_infer_tensor_model_from_buffer(device):
     exec_net = core.compile_model(func, device)
     res = exec_net.infer_new_request({"data": tensor})
     assert np.argmax(res[list(res)[0]]) == 2
+
+
+def test_direct_infer(device):
+    core = Core()
+    with open(test_net_bin, "rb") as f:
+        bin = f.read()
+    with open(test_net_xml, "rb") as f:
+        xml = f.read()
+    model = core.read_model(model=xml, weights=bin)
+    img = read_image()
+    tensor = Tensor(img)
+    comp_model = core.compile_model(model, device)
+    res = comp_model({"data": tensor})
+    assert np.argmax(res[comp_model.outputs[0]]) == 2
+    ref = comp_model.infer_new_request({"data": tensor})
+    assert np.array_equal(ref[comp_model.outputs[0]], res[comp_model.outputs[0]])


### PR DESCRIPTION
### Details:
 - `CompiledModel` class is now callable. User can omit `infer_new_request` by calling object directly:
 ```python
    core = Core()
    model = core.read_model(...)
    comp_model = core.compile_model(model, ...)
    res = comp_model({"data": tensor})
 ```
 - `infer_new_request` function is still valid and provide compatibility with already existing code.

### Tickets:
 - *76525*
