### PR TITLE
[CPU] Enabled brgemm matmul primitives avx512

### DIFF
--- a/src/tests/functional/plugin/cpu/single_layer_tests/mat_mul.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/mat_mul.cpp
@@ -188,6 +188,17 @@ std::vector<std::map<std::string, std::string>> additionalConfig {
     {{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES}}
 };
 
+std::vector<std::map<std::string, std::string>> filterAdditionalConfig_Brgemm() {
+    std::vector<std::map<std::string, std::string>> additionalConfig = {
+            std::map<std::string, std::string>{/* empty config */}
+    };
+    if (with_cpu_x86_bfloat16()) {
+        additionalConfig.push_back({{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES}});
+    }
+
+    return additionalConfig;
+}
+
 const std::vector<ElementType> netPRCs {
     ElementType::f32,
     ElementType::bf16
@@ -196,6 +207,15 @@ const std::vector<ElementType> netPRCs {
 std::vector<CPUSpecificParams> filterSpecificParams() {
     std::vector<CPUSpecificParams> specificParams;
     specificParams.push_back(CPUSpecificParams{{}, {}, {"jit_gemm"}, "jit_gemm"});
+
+    return specificParams;
+}
+
+std::vector<CPUSpecificParams> filterSpecificParams_Brgemm() {
+    std::vector<CPUSpecificParams> specificParams;
+    if (with_cpu_x86_avx512_core()) {
+        specificParams.push_back(CPUSpecificParams{{}, {}, {"brgemm_avx512"}, "brgemm_avx512"});
+    }
 
     return specificParams;
 }
@@ -484,17 +504,6 @@ const auto testParams3DBF16_nightly = ::testing::Combine(fullyConnectedParams3DB
 INSTANTIATE_TEST_SUITE_P(nightly_FC_3D, MatMulLayerCPUTest, testParams3D_nightly, MatMulLayerCPUTest::getTestCaseName);
 INSTANTIATE_TEST_SUITE_P(nightly_FC_3D_BF16, MatMulLayerCPUTest, testParams3DBF16_nightly, MatMulLayerCPUTest::getTestCaseName);
 
-std::vector<std::map<std::string, std::string>> filterAdditionalConfig_Brgemm() {
-    std::vector<std::map<std::string, std::string>> additionalConfig = {
-        std::map<std::string, std::string>{/* empty config */}
-    };
-    if (with_cpu_x86_bfloat16()) {
-        additionalConfig.push_back({{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES}});
-    }
-
-    return additionalConfig;
-}
-
 const std::vector<ShapeRelatedParams> IS2D_Brgemm_smoke = {
     {static_shapes_to_test_representation({{59, 16}, {16, 120}}), {true, false}},
     {static_shapes_to_test_representation({{59, 16}, {16, 120}}), {true, true}},
@@ -540,15 +549,6 @@ const std::vector<ShapeRelatedParams> IS2D_Brgemm_nightly = {
         {false, true}
     },
 };
-
-std::vector<CPUSpecificParams> filterSpecificParams_Brgemm() {
-    std::vector<CPUSpecificParams> specificParams;
-    if (with_cpu_x86_avx512_core()) {
-        specificParams.push_back(CPUSpecificParams{{}, {}, {"brgemm_avx512"}, "brgemm_avx512"});
-    }
-
-    return specificParams;
-}
 
 const auto fullyConnectedParams2D_Brgemm_smoke = ::testing::Combine(::testing::ValuesIn(IS2D_Brgemm_smoke),
                                                        ::testing::Values(ElementType::f32),
@@ -847,6 +847,147 @@ const auto testParamsDynamicFusing = ::testing::Combine(matMulParamsDynamicFusin
                                                   ::testing::ValuesIn(filterSpecificParams()));
 
 INSTANTIATE_TEST_SUITE_P(smoke_MM_Dynamic_Fusing, MatMulLayerCPUTest, testParamsDynamicFusing, MatMulLayerCPUTest::getTestCaseName);
+
+const std::vector<ShapeRelatedParams> IS_brgemm_smoke = {
+        {static_shapes_to_test_representation({{1, 2, 32, 120}, {120, 5}}), {false, false}},
+        {static_shapes_to_test_representation({{1, 2, 32, 120}, {120, 5}}), {true, false}},
+
+        {static_shapes_to_test_representation({{7, 32, 120}, {3, 7, 120, 50}}), {false, true}},
+        {static_shapes_to_test_representation({{7, 32, 120}, {3, 7, 120, 50}}), {true, true}},
+
+        {static_shapes_to_test_representation({{10, 10, 10}, {10, 10, 10}}), {false, false}},
+        {static_shapes_to_test_representation({{10, 10, 10}, {10, 10, 10}}), {true, false}},
+
+        {static_shapes_to_test_representation({{55, 12}, {12, 55}}), {false, true}},
+        {static_shapes_to_test_representation({{55, 12}, {12, 55}}), {true, true}},
+};
+
+const std::vector<ShapeRelatedParams> IS_brgemm_nightly = {
+        {static_shapes_to_test_representation({{1, 2, 32, 120}, {120, 5}}), {false, true}},
+        {static_shapes_to_test_representation({{1, 2, 32, 120}, {120, 5}}), {true, true}},
+
+        {static_shapes_to_test_representation({{7, 32, 120}, {3, 7, 120, 50}}), {false, false}},
+        {static_shapes_to_test_representation({{7, 32, 120}, {3, 7, 120, 50}}), {true, false}},
+
+        {static_shapes_to_test_representation({{10, 10, 10}, {10, 10, 10}}), {false, true}},
+        {static_shapes_to_test_representation({{10, 10, 10}, {10, 10, 10}}), {true, true}},
+
+        {static_shapes_to_test_representation({{55, 12}, {12, 55}}), {false, false}},
+        {static_shapes_to_test_representation({{55, 12}, {12, 55}}), {true, false}},
+};
+
+const auto matMulBrgemmParams_smoke = ::testing::Combine(::testing::ValuesIn(IS_brgemm_smoke),
+                                                         ::testing::Values(ElementType::f32),
+                                                         ::testing::Values(ElementType::undefined),
+                                                         ::testing::Values(ElementType::undefined),
+                                                         ::testing::Values(helpers::InputLayerType::PARAMETER),
+                                                         ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                                                         ::testing::ValuesIn(filterAdditionalConfig_Brgemm()));
+
+const auto testBrgemmParams_smoke = ::testing::Combine(matMulBrgemmParams_smoke,
+                                                       ::testing::Values(MatMulNodeType::MatMul),
+                                                       ::testing::ValuesIn(matmulFusingParams),
+                                                       ::testing::ValuesIn(filterSpecificParams_Brgemm()));
+
+INSTANTIATE_TEST_SUITE_P(smoke_MM_Brgemm_Static, MatMulLayerCPUTest, testBrgemmParams_smoke, MatMulLayerCPUTest::getTestCaseName);
+
+const auto matMulBrgemmParams_nightly = ::testing::Combine(::testing::ValuesIn(IS_brgemm_nightly),
+                                                         ::testing::Values(ElementType::f32),
+                                                         ::testing::Values(ElementType::undefined),
+                                                         ::testing::Values(ElementType::undefined),
+                                                         ::testing::Values(helpers::InputLayerType::PARAMETER),
+                                                         ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                                                         ::testing::ValuesIn(filterAdditionalConfig_Brgemm()));
+
+const auto testBrgemmParams_nightly = ::testing::Combine(matMulBrgemmParams_nightly,
+                                                       ::testing::Values(MatMulNodeType::MatMul),
+                                                       ::testing::ValuesIn(matmulFusingParams),
+                                                       ::testing::ValuesIn(filterSpecificParams_Brgemm()));
+
+INSTANTIATE_TEST_SUITE_P(nightly_MM_Brgemm_Static, MatMulLayerCPUTest, testBrgemmParams_nightly, MatMulLayerCPUTest::getTestCaseName);
+
+const std::vector<ShapeRelatedParams> IS_Brgemm_Dynamic = {
+        {
+                {
+                        {{-1, -1}, {{55, 12}, {33, 7}}},
+                        {{-1, -1}, {{12, 55}, {7, 33}}}
+                },
+                {false, false}
+        },
+        {
+                {
+                        {{-1, -1, -1, -1}, {{1, 2, 32, 60}, {1, 2, 32, 30}}},
+                        {{-1, -1}, {{60, 5}, {30, 5}}}
+                },
+                {true, false}
+        },
+        {
+                {
+                        {{-1, -1, -1}, {{7, 32, 60}, {7, 32, 30}}},
+                        {{-1, -1, -1, -1}, {{3, 7, 60, 25}, {3, 7, 30, 25}}}
+                },
+                {false, true}
+        },
+        {
+                {
+                        {{-1, -1, -1}, {{10, 10, 10}, {5, 5, 5}}},
+                        {{-1, -1, -1}, {{10, 10, 10}, {5, 5, 5}}}
+                },
+                {false, false}
+        },
+        {
+                {
+                        {{-1, -1, -1}, {{10, 10, 10}, {5, 5, 5}}},
+                        {{-1, -1, -1}, {{10, 10, 10}, {5, 5, 5}}}
+                },
+                {true, true}
+        },
+        {
+                {
+                        {{{1, 15}, {1, 15}, {1, 15}}, {{10, 10, 10}, {5, 5, 5}}},
+                        {{{1, 15}, {1, 15}, {1, 15}}, {{10, 10, 10}, {5, 5, 5}}}
+                },
+                {true, false}
+        },
+        {
+                {
+                        {{{1, 15}, {1, 15}, {1, 15}}, {{10, 10, 10}, {5, 5, 5}}},
+                        {{{1, 15}, {1, 15}, {1, 15}}, {{10, 10, 10}, {5, 5, 5}}}
+                },
+                {false, true}
+        },
+};
+
+const auto matMulBrgemmParamsDynamic = ::testing::Combine(::testing::ValuesIn(IS_Brgemm_Dynamic),
+                                                          ::testing::Values(ElementType::f32),
+                                                          ::testing::Values(ElementType::undefined),
+                                                          ::testing::Values(ElementType::undefined),
+                                                          ::testing::Values(helpers::InputLayerType::PARAMETER),
+                                                          ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                                                          ::testing::ValuesIn(filterAdditionalConfig_Brgemm()));
+
+const auto testBrgemmParamsDynamic = ::testing::Combine(matMulBrgemmParamsDynamic,
+                                                        ::testing::Values(MatMulNodeType::MatMul),
+                                                        ::testing::Values(emptyFusingSpec),
+                                                        ::testing::ValuesIn(filterSpecificParams_Brgemm()));
+
+INSTANTIATE_TEST_SUITE_P(smoke_MM_Brgemm_Dynamic, MatMulLayerCPUTest, testBrgemmParamsDynamic, MatMulLayerCPUTest::getTestCaseName);
+
+
+const auto matMulParamsBrgemmDynamicFusing = ::testing::Combine(::testing::ValuesIn(IS_Dynamic_Fusing),
+                                                                ::testing::Values(ElementType::f32),
+                                                                ::testing::Values(ElementType::undefined),
+                                                                ::testing::Values(ElementType::undefined),
+                                                                ::testing::Values(helpers::InputLayerType::PARAMETER),
+                                                                ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                                                                ::testing::ValuesIn(filterAdditionalConfig_Brgemm()));
+
+const auto testParamsBrgemmDynamicFusing = ::testing::Combine(matMulParamsBrgemmDynamicFusing,
+                                                              ::testing::Values(MatMulNodeType::MatMul),
+                                                              ::testing::ValuesIn(matmulFusingParams),
+                                                              ::testing::ValuesIn(filterSpecificParams_Brgemm()));
+
+INSTANTIATE_TEST_SUITE_P(smoke_MM_Brgemm_Dynamic_Fusing, MatMulLayerCPUTest, testParamsBrgemmDynamicFusing, MatMulLayerCPUTest::getTestCaseName);
 
 } // namespace matmul
 

--- a/src/tests/functional/plugin/cpu/subgraph_tests/src/align_matmul_input_ranks.cpp
+++ b/src/tests/functional/plugin/cpu/subgraph_tests/src/align_matmul_input_ranks.cpp
@@ -58,7 +58,7 @@ protected:
         const auto outputNodes = helpers::convert2OutputVector(helpers::castOps2Nodes<op::Parameter>(inputParams));
         const auto matMul = builder::makeMatMul(outputNodes[0], outputNodes[1], false, false);
 
-        selectedType = makeSelectedTypeStr("jit_gemm", ngPrec);
+        selectedType = makeSelectedTypeStr(with_cpu_x86_avx512_core() ? "brgemm_avx512" : "jit_gemm", ngPrec);
 
         function = makeNgraphFunction(ngPrec, inputParams, matMul, "AlignMatMulInputRanks");
     }


### PR DESCRIPTION
### Details:
 - *Enabled brgemm matmul primitives avx512*
 - *The PR is copy of PR#[9593](https://github.com/openvinotoolkit/openvino/pull/9593)*
 - *Tests are added. Time before: 13s 240ms. Time after: 14s 230ms*
 - *[PR](https://github.com/openvinotoolkit/oneDNN/pull/109) in oneDNN*

### Tickets:
 - *ticket-id*
