### PR TITLE
[PYTHON] Allow ports as inputs for infer methods

### DIFF
--- a/src/bindings/python/src/pyopenvino/core/common.cpp
+++ b/src/bindings/python/src/pyopenvino/core/common.cpp
@@ -162,10 +162,17 @@ const Containers::TensorIndexMap cast_to_tensor_index_map(const py::dict& inputs
 void set_request_tensors(ov::InferRequest& request, const py::dict& inputs) {
     if (!inputs.empty()) {
         for (auto&& input : inputs) {
-            if (py::isinstance<py::str>(input.first)) {
-                request.set_tensor(input.first.cast<std::string>(), Common::cast_to_tensor(input.second));
+            // Cast second argument to tensor
+            auto tensor = Common::cast_to_tensor(input.second);
+            // Check if key is compatible, should be port/string/integer
+            if (py::isinstance<ov::Output<const ov::Node>>(input.first)) {
+                request.set_tensor(input.first.cast<ov::Output<const ov::Node>>(), tensor);
+            } else if (py::isinstance<ov::Output<ov::Node>>(input.first)) {
+                request.set_tensor(input.first.cast<ov::Output<ov::Node>>(), tensor);
+            } else if (py::isinstance<py::str>(input.first)) {
+                request.set_tensor(input.first.cast<std::string>(), tensor);
             } else if (py::isinstance<py::int_>(input.first)) {
-                request.set_input_tensor(input.first.cast<size_t>(), Common::cast_to_tensor(input.second));
+                request.set_input_tensor(input.first.cast<size_t>(), tensor);
             } else {
                 throw py::type_error("Incompatible key type for tensor named: " + input.first.cast<std::string>());
             }

--- a/src/bindings/python/tests/test_inference_engine/test_compiled_model.py
+++ b/src/bindings/python/tests/test_inference_engine/test_compiled_model.py
@@ -267,7 +267,7 @@ def test_infer_new_request_wrong_port_name(device):
     exec_net = ie.compile_model(func, device)
     with pytest.raises(KeyError) as e:
         exec_net.infer_new_request({"_data_": tensor})
-    assert "Port for tensor named _data_ was not found!" in str(e.value)
+    assert "Port for tensor _data_ was not found!" in str(e.value)
 
 
 def test_infer_tensor_wrong_input_data(device):
@@ -279,7 +279,7 @@ def test_infer_tensor_wrong_input_data(device):
     exec_net = ie.compile_model(func, device)
     with pytest.raises(TypeError) as e:
         exec_net.infer_new_request({0.: tensor})
-    assert "Incompatible key type for tensor named: 0." in str(e.value)
+    assert "Incompatible key type for tensor: 0." in str(e.value)
 
 
 def test_infer_numpy_model_from_buffer(device):


### PR DESCRIPTION
### Details:
 - Allow ports in dictionaries as inputs for infer methods.
 - Refactor test file with correct names.

### Tickets:
 - *76606*