### PR TITLE
[Compile tool] Default IO precision for vpux and myriad

### DIFF
--- a/tools/compile_tool/main.cpp
+++ b/tools/compile_tool/main.cpp
@@ -369,6 +369,39 @@ ov::element::Type getType(const std::string& value) {
     return getType(value, supported_types);
 }
 
+bool isFP32(const ov::element::Type& type) {
+    return type == ov::element::f32;
+}
+
+static void setDefaultIO(ov::preprocess::PrePostProcessor& preprocessor,
+                         const std::vector<ov::Output<ov::Node>>& inputs,
+                         const std::vector<ov::Output<ov::Node>>& outputs) {
+    const bool isMYRIAD = FLAGS_d.find("MYRIAD") != std::string::npos;
+    const bool isVPUX = FLAGS_d.find("VPUX") != std::string::npos;
+
+    if (isMYRIAD) {
+        for (size_t i = 0; i < inputs.size(); i++) {
+            if (isFP32(inputs[i].get_element_type())) {
+                preprocessor.input(i).tensor().set_element_type(ov::element::f16);
+            }
+        }
+        for (size_t i = 0; i < outputs.size(); i++) {
+            if (isFP32(outputs[i].get_element_type())) {
+                preprocessor.output(i).tensor().set_element_type(ov::element::f16);
+            }
+        }
+    }
+
+    if (isVPUX) {
+        for (size_t i = 0; i < inputs.size(); i++) {
+            preprocessor.input(i).tensor().set_element_type(ov::element::u8);
+        }
+        for (size_t i = 0; i < outputs.size(); i++) {
+            preprocessor.output(i).tensor().set_element_type(ov::element::f32);
+        }
+    }
+}
+
 void configurePrePostProcessing(std::shared_ptr<ov::Model>& model,
     const std::string& ip,
     const std::string& op,
@@ -382,6 +415,8 @@ void configurePrePostProcessing(std::shared_ptr<ov::Model>& model,
     auto preprocessor = ov::preprocess::PrePostProcessor(model);
     const auto inputs = model->inputs();
     const auto outputs = model->outputs();
+    setDefaultIO(preprocessor, inputs, outputs);
+
     if (!ip.empty()) {
         auto type = getType(ip);
         for (size_t i = 0; i < inputs.size(); i++) {


### PR DESCRIPTION
### Details:
 - Set default IO precision for vpux and myriad

### Tickets:
 - [29258](https://jira.devtools.intel.com/browse/EISW-29258)
