### PR TITLE
[CPU] RNN node enforce bf16 mode does not work.

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/rnn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rnn.cpp
@@ -810,16 +810,14 @@ void MKLDNNRNN::prepareParams() {
 
     bool wFormatWasChanged = false;
     // WA To avoid different weights layer and iter formats in FP32 case.
-    if (dataPrecision == Precision::FP32) {
-        if (SL != 1 || B < optimalBatchSize) {
-            if (wFormat != mkldnn::memory::format_tag::ldigo) {
-                wFormat = mkldnn::memory::format_tag::ldigo;
-                wFormatWasChanged = true;
-            }
-        } else if (wFormat != mkldnn::memory::format_tag::any) {
-            wFormat = mkldnn::memory::format_tag::any;
+    if (SL != 1 || B < optimalBatchSize) {
+        if (wFormat != mkldnn::memory::format_tag::ldigo) {
+            wFormat = mkldnn::memory::format_tag::ldigo;
             wFormatWasChanged = true;
         }
+    } else if (wFormat != mkldnn::memory::format_tag::any) {
+        wFormat = mkldnn::memory::format_tag::any;
+        wFormatWasChanged = true;
     }
     if (wFormatWasChanged) {
         auto weightsDims = MKLDNNExtensionUtils::convertToDnnlDims(VectorDims{ L, D, DC, G, SC });

--- a/src/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
+++ b/src/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
@@ -66,8 +66,6 @@ std::vector<std::string> disabledTestPatterns() {
 
         // TODO: 57562 No dynamic output shape support
         R"(.*NonZeroLayerTest.*)",
-        // TODO: 74961.  Enforce precision via inType and outType does not work properly.
-        R"(.*(RNN|GRU|LSTM).*ENFORCE_BF16=YES.*)",
         // Not expected behavior
         R"(.*Behavior.*InferRequestIOBBlobSetLayoutTest.*layout=(95|OIHW).*)",
         R"(.*Behavior.*InferRequestIOBBlobSetLayoutTest.*layout=(95|OIHW).*)",

--- a/src/tests/functional/plugin/cpu/single_layer_tests/gru_cell.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/gru_cell.cpp
@@ -88,11 +88,10 @@ protected:
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
         if (additionalConfig[InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16] == InferenceEngine::PluginConfigParams::YES) {
-            inType = outType = ElementType::bf16;
+            selectedType = makeSelectedTypeStr(selectedType, ElementType::bf16);
         } else {
-            inType = outType = netPrecision;
+            selectedType = makeSelectedTypeStr(selectedType, netPrecision);
         }
-        selectedType = makeSelectedTypeStr(selectedType, outType);
 
         auto params = ngraph::builder::makeDynamicParams(netPrecision, inputDynamicShapes);
         std::vector<ngraph::Shape> WRB = {{3 * hiddenSize, inputSize}, {3 * hiddenSize, hiddenSize}, {(linearBeforeReset ? 4 : 3) * hiddenSize}};

--- a/src/tests/functional/plugin/cpu/single_layer_tests/gru_sequence.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/gru_sequence.cpp
@@ -105,15 +105,11 @@ protected:
         const size_t inputSize = targetStaticShapes.front()[0][2];
         const size_t numDirections = direction == ov::op::RecurrentSequenceDirection::BIDIRECTIONAL ? 2 : 1;
 
-        // 3rd input type must be an integer, thus it cannot be forced to BF16.
         if (additionalConfig[InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16] == InferenceEngine::PluginConfigParams::YES) {
-            if (inputDynamicShapes.size() > 2)
-                throw std::runtime_error("Invalid test case. Cannot enforce integer input to BF16.");
-            inType = outType = ElementType::bf16;
+            selectedType = makeSelectedTypeStr(selectedType, ElementType::bf16);
         } else {
-            outType = netPrecision;
+            selectedType = makeSelectedTypeStr(selectedType, netPrecision);
         }
-        selectedType = makeSelectedTypeStr(selectedType, outType);
 
         auto params = ngraph::builder::makeDynamicParams(netPrecision, inputDynamicShapes);
         const size_t batchSize = inputDynamicShapes[0][0].is_static() ? inputDynamicShapes[0][0].get_length() :
@@ -295,7 +291,7 @@ const std::vector<std::vector<InputShape>> dynamicShapes = {
         { {1, 2, 10}, {1, 4, 10}, {1, 8, 10} } },   // Target shapes
       { {1, 1, 10},                                 // Dynamic shape 1
         { {1, 1, 10}, {1, 1, 10}, {1, 1, 10} } },   // Target shapes
-      { {-1},                                        // Dynamic shape 2
+      { {-1},                                       // Dynamic shape 2
         { {1}, {1}, {1} } } },                      // Target shapes
     { { {-1, -1, -1},                               // #5. Dynamic shape 0
         { {1, 2, 10}, {1, 4, 10}, {1, 8, 10} } },   // Target shapes
@@ -304,7 +300,7 @@ const std::vector<std::vector<InputShape>> dynamicShapes = {
       { {-1},                                       // Dynamic shape 2
         { {1}, {1}, {1} } } },                      // Target shapes
     { { {2, {1, 5}, 10},                            // #6. Dynamic shape 0
-        { {10, 2, 10}, {2, 3, 10}, {2, 4, 10} } },  // Target shapes
+        { {2, 2, 10}, {2, 3, 10}, {2, 4, 10} } },   // Target shapes
       { {2, 1, 1},                                  // Dynamic shape 1
         { {2, 1, 1}, {2, 1, 1}, {2, 1, 1} } } },    // Target shapes
     { { {5, -1, 10},                                // #7. Dynamic shape 0

--- a/src/tests/functional/plugin/cpu/single_layer_tests/lstm_cell.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/lstm_cell.cpp
@@ -87,11 +87,10 @@ protected:
         const size_t inputSize = targetStaticShapes.front()[0][1];
 
         if (additionalConfig[InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16] == InferenceEngine::PluginConfigParams::YES) {
-            inType = outType = ElementType::bf16;
+            selectedType = makeSelectedTypeStr(selectedType, ElementType::bf16);
         } else {
-            inType = outType = netPrecision;
+            selectedType = makeSelectedTypeStr(selectedType, netPrecision);
         }
-        selectedType = makeSelectedTypeStr(selectedType, outType);
 
         auto params = ngraph::builder::makeDynamicParams(netPrecision, inputDynamicShapes);
         auto paramsOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ov::op::v0::Parameter>(params));

--- a/src/tests/functional/plugin/cpu/single_layer_tests/lstm_sequence.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/lstm_sequence.cpp
@@ -105,15 +105,11 @@ protected:
 
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
-        // 4th input type must be integer, thus it cannot be forced to BF16.
         if (additionalConfig[InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16] == InferenceEngine::PluginConfigParams::YES) {
-            if (inputDynamicShapes.size() > 3)
-                throw std::runtime_error("Invalid test case. Cannot enforce integer input to BF16.");
-            inType = outType = ElementType::bf16;
+            selectedType = makeSelectedTypeStr(selectedType, ElementType::bf16);
         } else {
-            outType = netPrecision;
+            selectedType = makeSelectedTypeStr(selectedType, netPrecision);
         }
-        selectedType = makeSelectedTypeStr(selectedType, outType);
 
         auto params = ngraph::builder::makeDynamicParams(netPrecision, inputDynamicShapes);
         const size_t batchSize = inputDynamicShapes[0][0].is_static() ? inputDynamicShapes[0][0].get_length() :

--- a/src/tests/functional/plugin/cpu/single_layer_tests/rnn_cell.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/rnn_cell.cpp
@@ -83,11 +83,10 @@ protected:
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
         if (additionalConfig[InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16] == InferenceEngine::PluginConfigParams::YES) {
-            inType = outType = ElementType::bf16;
+            selectedType = makeSelectedTypeStr(selectedType, ElementType::bf16);
         } else {
-            inType = outType = netPrecision;
+            selectedType = makeSelectedTypeStr(selectedType, netPrecision);
         }
-        selectedType = makeSelectedTypeStr(selectedType, outType);
 
         auto params = ngraph::builder::makeDynamicParams(netPrecision, inputDynamicShapes);
         auto paramsOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ov::op::v0::Parameter>(params));

--- a/src/tests/functional/plugin/cpu/single_layer_tests/rnn_sequence.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/rnn_sequence.cpp
@@ -94,15 +94,11 @@ protected:
 
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
-        // 3rd input type must be integer, thus it cannot be forced to BF16.
         if (additionalConfig[InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16] == InferenceEngine::PluginConfigParams::YES) {
-            if (inputDynamicShapes.size() > 2)
-                throw std::runtime_error("Invalid test case. Cannot enforce integer input to BF16.");
-            inType = outType = ElementType::bf16;
+            selectedType = makeSelectedTypeStr(selectedType, ElementType::bf16);
         } else {
-            outType = netPrecision;
+            selectedType = makeSelectedTypeStr(selectedType, netPrecision);
         }
-        selectedType = makeSelectedTypeStr(selectedType, outType);
 
         auto params = ngraph::builder::makeDynamicParams(netPrecision, inputDynamicShapes);
         const size_t batchSize = inputDynamicShapes[0][0].is_static() ? inputDynamicShapes[0][0].get_length() :


### PR DESCRIPTION
### Details:
 - *Enables enforce bf16 tests for RNN node.*
 - *Fix for division on zero was merged in scope of the PR9836*

### Tickets:
 - *74961*
