### PR TITLE
[MO] fix simplified MO import for PyCharm Debug

### DIFF
--- a/tools/mo/automation/package_BOM.txt
+++ b/tools/mo/automation/package_BOM.txt
@@ -1024,6 +1024,7 @@ openvino/tools/mo/subprocess_main.py
 openvino/tools/mo/utils/__init__.py
 openvino/tools/mo/utils/broadcasting.py
 openvino/tools/mo/utils/check_ie_bindings.py
+openvino/tools/mo/utils/check_mo_import.py
 openvino/tools/mo/utils/class_registration.py
 openvino/tools/mo/utils/cli_parser.py
 openvino/tools/mo/utils/custom_replacement_config.py

--- a/tools/mo/openvino/tools/mo/subprocess_main.py
+++ b/tools/mo/openvino/tools/mo/subprocess_main.py
@@ -4,7 +4,6 @@
 import logging as log
 import os
 import subprocess
-from multiprocessing import Process, Queue
 import sys
 
 
@@ -38,8 +37,15 @@ def setup_env():
     mo_root_path = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, os.pardir)
 
     # Check that MO root directory already set to the PYTHONPATH
-    status = subprocess.run([sys.executable, "-c", "try: import openvino.tools.mo \nexcept: exit(1)"], env=os.environ)
-    if status.returncode != 0:
+    def is_mo_imported():
+        try:
+            status = subprocess.run([sys.executable, os.path.join(mo_root_path, 'openvino/tools/mo/utils/check_mo_import.py')],
+                                    env=os.environ)
+            return status.returncode == 0
+        except:
+            return False
+
+    if not is_mo_imported():
         # If no, we try to set it manually based on relative path
         python_path_key = 'PYTHONPATH'
         if python_path_key not in os.environ:
@@ -49,8 +55,7 @@ def setup_env():
 
         sys.path.append(mo_root_path)
 
-        status = subprocess.run([sys.executable, "-c", "try: import openvino.tools.mo \nexcept: exit(1)"], env=os.environ)
-        if status.returncode != 0:
+        if not is_mo_imported():
             log_mo_root_dir_not_found()
             sys.exit(1)
 

--- a/tools/mo/openvino/tools/mo/utils/check_mo_import.py
+++ b/tools/mo/openvino/tools/mo/utils/check_mo_import.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2018-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 try:
     import openvino.tools.mo
 except:

--- a/tools/mo/openvino/tools/mo/utils/check_mo_import.py
+++ b/tools/mo/openvino/tools/mo/utils/check_mo_import.py
@@ -1,0 +1,4 @@
+try:
+    import openvino.tools.mo
+except:
+    exit(1)


### PR DESCRIPTION
### Details:
Fixes #9681

For some reason when subprocess is run with `-c` in PyCharm some extra values are added to command string and they cause problem in Debug mode. Replacing to run a separate file fixed this issue.

### Tickets:
 - CVS-76194
