### PR TITLE
Use clang-12 for U20

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Install Clang dependency
         run: |
           sudo apt update
-          sudo apt --assume-yes install libclang-11-dev
+          sudo apt --assume-yes install libclang-12-dev
 
       - name: Install Python-based dependencies
         run: python3 -m pip install -r cmake/developer_package/ncc_naming_style/requirements_dev.txt

--- a/cmake/developer_package/ncc_naming_style/ncc_naming_style.cmake
+++ b/cmake/developer_package/ncc_naming_style/ncc_naming_style.cmake
@@ -19,11 +19,13 @@ execute_process(
         "${CMAKE_COMMAND}" -S "${ncc_style_bin_dir}/source"
                            -B "${ncc_style_bin_dir}/build"
     RESULT_VARIABLE clang_find_result
-    OUTPUT_VARIABLE output
-    ERROR_VARIABLE output)
+    OUTPUT_VARIABLE output_var
+    ERROR_VARIABLE error_var)
 
 if(NOT clang_find_result EQUAL "0")
     message(WARNING "Please, install libclang-[N]-dev package (required for ncc naming style check)")
+    message(WARNING "find_package(Clang) output: ${output_var}")
+    message(WARNING "find_package(Clang) error: ${error_var}")
     set(ENABLE_NCC_STYLE OFF)
 endif()
 


### PR DESCRIPTION
### Details:
 - After update of MSFT Azure images, we have failed step for NCC style

### Tickets:
 - *ticket-id*
