### PR TITLE
Fix bug in AddReshapeTransposeAroundConvPool for Kaldi LSTM networks

### DIFF
--- a/tools/mo/openvino/tools/mo/front/kaldi/add_reshape_transpose_around_conv_pool.py
+++ b/tools/mo/openvino/tools/mo/front/kaldi/add_reshape_transpose_around_conv_pool.py
@@ -80,7 +80,7 @@ def update_time_dim_for_start_convolution(graph):
         for dest in param_node.out_port(0).get_destinations():
             if dest.node.op == 'Convolution':
                 conv_node = dest.node
-                assert param_node.time_dim == -1 or \
+                assert param_node.time_dim is None or \
                     param_node.time_dim == conv_node.soft_get('kernel')[1] - 1, \
                     "Kaldi model have 2 Convolutions after Parameter with different time dimensions"
                 # time_dim starts from 0, kernel from 1

--- a/tools/mo/openvino/tools/mo/front/kaldi/add_reshape_transpose_around_conv_pool.py
+++ b/tools/mo/openvino/tools/mo/front/kaldi/add_reshape_transpose_around_conv_pool.py
@@ -49,7 +49,6 @@ def set_time_dim(graph):
         if node.time_dim >= 0:
             continue
 
-        # MemoryOffset with default value does not change time delay
         if node.op == "MemoryOffset":
             # MemoryOffset can be splitted already and can be without input, time_dim = t in this case
             node.time_dim = node.in_port(0).get_source().node.time_dim + abs(node.t) if not node.in_port(0).disconnected() else abs(node.t)

--- a/tools/mo/openvino/tools/mo/front/kaldi/add_reshape_transpose_around_conv_pool.py
+++ b/tools/mo/openvino/tools/mo/front/kaldi/add_reshape_transpose_around_conv_pool.py
@@ -50,7 +50,7 @@ def set_time_dim(graph):
             continue
 
         # MemoryOffset with default value does not change time delay
-        if node.op == "MemoryOffset" and not node.has_default:
+        if node.op == "MemoryOffset":
             # MemoryOffset can be splitted already and can be without input, time_dim = t in this case
             node.time_dim = node.in_port(0).get_source().node.time_dim + abs(node.t) if not node.in_port(0).disconnected() else abs(node.t)
         elif node.op == "Splice":

--- a/tools/mo/openvino/tools/mo/front/kaldi/memory_offset_adjustment.py
+++ b/tools/mo/openvino/tools/mo/front/kaldi/memory_offset_adjustment.py
@@ -41,9 +41,13 @@ def align_frame_time(graph: Graph, node: Node, frame_time_max):
         # Adding MemoryOffset for Const does not make sense
         if in_node.frame_time < frame_time_max and in_node.op != 'Const':
             # Change existing MemoryOffset to avoid adding new one
-            if in_node.op == 'MemoryOffset':
+            if in_node.op == 'MemoryOffset' and not in_node.has_default:
                 in_node.t = in_node.frame_time - frame_time_max
                 in_node.frame_time = in_node.t
+                if in_node.has_and_set('splitted'):
+                    pair_node = Node(graph, in_node['pair_name'])
+                    pair_node.t = in_node.t
+                    pair_node.frame_time = in_node.frame_time
             else:
                 mem_name = graph.unique_id("align_" + node.id)
                 memory_align = MemoryOffset(graph, attrs={'id': mem_name,
@@ -87,7 +91,8 @@ class MemoryOffsetAdjustment(FrontReplacementSubgraph):
     enabled = True
     graph_condition = [lambda graph: graph.graph['fw'] == 'kaldi']
 
-    def run_before(self):
+    def run_after(self):
+        # remove cycles before memoryOffset adjustment to be able to apply transform for LSTM networks too
         from openvino.tools.mo.front.kaldi.split_recurrent_memoryoffset import SplitRecurrentMemoryOffset
         return [SplitRecurrentMemoryOffset]
 
@@ -114,8 +119,8 @@ class MemoryOffsetAdjustment(FrontReplacementSubgraph):
             # calculate frame_time (delay) that was not calculated
             if node.frame_time < 0:
                 # MemoryOffset with t>0 increases frame delay
-                if node.op == "MemoryOffset":
-                    node.frame_time = node.in_port(0).get_source().node.frame_time + node.t
+                if node.op == "MemoryOffset" and not node.has_default:
+                    node.frame_time = node.in_port(0).get_source().node.frame_time + node.t if not node.in_port(0).disconnected() else node.t
                 # for node with several inputs frame_time = maximum of delays from branches
                 # other branches should be synced by adding MemoryOffset(branch frame_time  - max)
                 # After that MemoryOffset with maximum delay should be deleted (t becomes 0)

--- a/tools/mo/openvino/tools/mo/front/kaldi/memory_offset_adjustment.py
+++ b/tools/mo/openvino/tools/mo/front/kaldi/memory_offset_adjustment.py
@@ -41,7 +41,7 @@ def align_frame_time(graph: Graph, node: Node, frame_time_max):
         # Adding MemoryOffset for Const does not make sense
         if in_node.frame_time < frame_time_max and in_node.op != 'Const':
             # Change existing MemoryOffset to avoid adding new one
-            if in_node.op == 'MemoryOffset' and not in_node.has_default:
+            if in_node.op == 'MemoryOffset':
                 in_node.t = in_node.frame_time - frame_time_max
                 in_node.frame_time = in_node.t
                 if in_node.has_and_set('splitted'):
@@ -119,7 +119,7 @@ class MemoryOffsetAdjustment(FrontReplacementSubgraph):
             # calculate frame_time (delay) that was not calculated
             if node.frame_time < 0:
                 # MemoryOffset with t>0 increases frame delay
-                if node.op == "MemoryOffset" and not node.has_default:
+                if node.op == "MemoryOffset":
                     node.frame_time = node.in_port(0).get_source().node.frame_time + node.t if not node.in_port(0).disconnected() else node.t
                 # for node with several inputs frame_time = maximum of delays from branches
                 # other branches should be synced by adding MemoryOffset(branch frame_time  - max)

--- a/tools/mo/unit_tests/mo/front/kaldi/add_reshape_transpose_around_conv_pool_test.py
+++ b/tools/mo/unit_tests/mo/front/kaldi/add_reshape_transpose_around_conv_pool_test.py
@@ -3,8 +3,6 @@
 
 import unittest
 
-import numpy as np
-
 from openvino.tools.mo.front.common.partial_infer.utils import int64_array
 from openvino.tools.mo.front.kaldi.add_reshape_transpose_around_conv_pool import AddReshapeTransposeAroundConvPool
 from openvino.tools.mo.utils.ir_engine.compare_graphs import compare_graphs
@@ -13,8 +11,9 @@ from unit_tests.utils.graph import build_graph, connect_front, const, regular_op
 
 class AddReshapeTransposeAroundConvPoolTests(unittest.TestCase):
     nodes = {
-        **shaped_parameter('input', [1, 30]),
-        **regular_op('splice', {'op': 'Splice', 'context': [-5, -4, -3, -2, -1 ,0, 1, 2, 3, 4, 5]}),
+        **shaped_parameter('input', [1, 33]),
+        **regular_op('some_op', {'op': 'some_op'}),
+        **regular_op('splice', {'op': 'Splice', 'context': [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5]}),
         **regular_op('conv', {'kind': 'op', 'op': 'Convolution', 'kernel': [1, 11, 1, 5], 'patch_stride': 5,
                               'kernel_spatial': [1, 5]}),
         **regular_op('pool', {'kind': 'op', 'op': 'Pooling', 'pool_stride': 5, 'pool_step': [1, 1, 1, 1]}),
@@ -22,7 +21,8 @@ class AddReshapeTransposeAroundConvPoolTests(unittest.TestCase):
     }
 
     ref_nodes = {
-        **shaped_parameter('input', [1, 30]),
+        **shaped_parameter('input', [1, 33]),
+        **regular_op('some_op', {}),
         **regular_op('splice', {'op': 'Splice', 'context': [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5]}),
 
         **regular_op('shapeof', {'op': 'ShapeOf', 'type': 'ShapeOf'}),
@@ -64,6 +64,47 @@ class AddReshapeTransposeAroundConvPoolTests(unittest.TestCase):
                                     *connect_front('splice', '0:reshape_in'),
 
                                     *connect_front('splice', 'shapeof'),
+                                    *connect_front('shapeof:0', '0:gather_batch'),
+                                    *connect_front('ind', '1:gather_batch'),
+                                    *connect_front('axis', '2:gather_batch'),
+                                    *connect_front('shapeof:0', '0:gather_h'),
+                                    *connect_front('ind_h', '1:gather_h'),
+                                    *connect_front('axis', '2:gather_h'),
+                                    *connect_front('gather_h', '0:div'),
+                                    *connect_front('th', '1:div'),
+                                    *connect_front('gather_batch', '0:concat'),
+                                    *connect_front('t', '1:concat'),
+                                    *connect_front('h', '2:concat'),
+                                    *connect_front('div', '3:concat'),
+                                    *connect_front('concat', '1:reshape_in'),
+
+                                    *connect_front('reshape_in', '0:transpose_in'),
+                                    *connect_front('transpose_in_order', "1:transpose_in"),
+                                    *connect_front('transpose_in', 'conv'),
+                                    *connect_front('conv', '0:transpose_out'),
+                                    *connect_front('transpose_out_order', '1:transpose_out'),
+                                    *connect_front('transpose_out', '0:reshape_out'),
+                                    *connect_front('reshape_out_shape', '1:reshape_out'),
+                                    *connect_front('reshape_out', 'out_op')
+                                ])
+
+        (flag, resp) = compare_graphs(graph, ref_graph, 'out_op', check_op_attrs=True)
+        self.assertTrue(flag, resp)
+
+    def test_simple_convolution_wo_splice(self):
+        graph = build_graph(self.nodes, [
+            *connect_front('input', 'conv'),
+            *connect_front('input', 'some_op'),
+            *connect_front('conv', 'out_op')
+        ], nodes_with_edges_only=True)
+        graph.stage = 'front'
+        AddReshapeTransposeAroundConvPool.find_and_replace_pattern(graph)
+
+        ref_graph = build_graph(self.ref_nodes,
+                                [
+                                    *connect_front('input', '0:reshape_in'),
+                                    *connect_front('input', 'some_op'),
+                                    *connect_front('input', 'shapeof'),
                                     *connect_front('shapeof:0', '0:gather_batch'),
                                     *connect_front('ind', '1:gather_batch'),
                                     *connect_front('axis', '2:gather_batch'),

--- a/tools/mo/unit_tests/mo/front/kaldi/memory_offset_adjustment_test.py
+++ b/tools/mo/unit_tests/mo/front/kaldi/memory_offset_adjustment_test.py
@@ -4,7 +4,6 @@
 import unittest
 
 from openvino.tools.mo.front.kaldi.memory_offset_adjustment import MemoryOffsetAdjustment
-from openvino.tools.mo.graph.graph import Node
 from openvino.tools.mo.utils.ir_engine.compare_graphs import compare_graphs
 from unit_tests.utils.graph import build_graph
 
@@ -37,50 +36,6 @@ class MemoruOffsetAdjustmentTests(unittest.TestCase):
                                  ('memory__2', 'concat', {'in': 2}),
                                  ('memory__1', 'concat', {'in': 1}),
                                  ('memory__5', 'concat', {'in': 3})],
-                                nodes_with_edges_only=True)
-
-        MemoryOffsetAdjustment().find_and_replace_pattern(graph)
-
-        (flag, resp) = compare_graphs(graph, ref_graph, 'concat', check_op_attrs=True)
-        self.assertTrue(flag, resp)
-
-    def test_several_memory_concat_splitted(self):
-        graph = build_graph({'in': {'kind': 'op', 'op': None},
-                             'memory_1': {'kind': 'op', 'op': 'MemoryOffset', 't': -1, 'splitted': True,
-                                          'pair_name': 'memory_1_pair'},
-                             'memory_2': {'kind': 'op', 'op': 'MemoryOffset', 't': 2},
-                             'memory__3': {'kind': 'op', 'op': 'MemoryOffset', 't': -3},
-                             'concat': {'kind': 'op', 'op': 'Concat'},
-                             'memory_1_pair': {'kind': 'op', 'op': 'MemoryOffset', 't': -1, 'splitted': True,
-                                               'pair_name': 'memory_1'},
-                             },
-                            [('in', 'memory_2', {'out': 1}),
-                             ('in', 'memory__3', {'out': 3}),
-                             ('memory_2', 'concat', {'in': 0}),
-                             ('memory_1', 'concat', {'in': 1}),
-                             ('in', 'concat', {'in': 2, 'out': 2}),
-                             ('memory__3', 'concat', {'in': 3}),
-                             ('concat', 'memory_1_pair', {'out': 0})],
-                            nodes_with_edges_only=True)
-        graph.stage = 'front'
-        mem_1 = Node(graph, 'memory_1')
-        mem_1.add_input_port(0)
-
-        ref_graph = build_graph({'in': {'kind': 'op', 'op': None},
-                                 'memory__5': {'kind': 'op', 'op': 'MemoryOffset', 't': -5},
-                                 'memory_1': {'kind': 'op', 'op': 'MemoryOffset', 't': -3, 'splitted': True,
-                                              'pair_name': 'memory_1_pair'},
-                                 'memory__2': {'kind': 'op', 'op': 'MemoryOffset', 't': -2},
-                                 'concat': {'kind': 'op', 'op': 'Concat'},
-                                 'memory_1_pair': {'kind': 'op', 'op': 'MemoryOffset', 't': -3, 'splitted': True,
-                                                   'pair_name': 'memory_1'}},
-                                [('in', 'memory__5', {'out': 3}),
-                                 ('in', 'memory__2', {'out': 1}),
-                                 ('in', 'concat', {'in': 0, 'out': 0}),
-                                 ('memory__2', 'concat', {'in': 2}),
-                                 ('memory_1', 'concat', {'in': 1}),
-                                 ('memory__5', 'concat', {'in': 3}),
-                                 ('concat', 'memory_1_pair', {'out': 0})],
                                 nodes_with_edges_only=True)
 
         MemoryOffsetAdjustment().find_and_replace_pattern(graph)


### PR DESCRIPTION
Root cause analysis: AddReshapeTransposeConvPool fails on param_node.out_port(0).get_destination() due to several detinations of Parameter. 2 Kaldi transformation add more destinations to Parameter but it can't be run after AddReshapeTransposeConvPool, so added processing of seral outputs for Parameter.
Also AddReshapeTransposeConvPool failed on topological_sort dur to cycle in model (in LSTM cell), so run transformation to remove cycles before AddReshapeTransposeConvPool.

Solution: 1. Process several outputs of Parameter
               2. Run transformation to remove cycles before AddReshapeTransposeConvPool
               3. Also MemoryOffsetAdjustment can be not done due to cycles inside model, so we assume that MemoryOffset can have t>0 or <0. time_dim now can be >0 or <0 and finding max value was changed too.

Ticket: 76537


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR **NA fix in existing code**
* [x]  Transformation preserves original framework node names **NA fix in existing code**


Validation:
* [x]  Unit tests 
* [x]  Framework operation tests **NA fix in existing code**
* [x]  Transformation tests **NA fix in existing code**
* [x]  Model Optimizer IR Reader check **NA fix in existing code**

Documentation:
* [x]  Supported frameworks operations list **NA fix in existing code**
* [x]  Guide on how to convert the **public** model **NA fix in existing code**
* [x]  User guide update **NA fix in existing code**