### PR TITLE
[GNA] Fix handling reshapes around matmul with 3D/4D Add layer

### DIFF
--- a/src/plugins/intel_gna/transformations/insert_reshape_around_matmul.cpp
+++ b/src/plugins/intel_gna/transformations/insert_reshape_around_matmul.cpp
@@ -8,6 +8,7 @@
 #include <ngraph/opsets/opset8.hpp>
 #include <ngraph/pattern/op/or.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
+#include <transformations/utils/utils.hpp>
 #include <ie/ie_common.h>
 
 #include "gna_plugin_log.hpp"
@@ -46,6 +47,31 @@ static bool InsertReshape(
     }
 
     auto first_node = iter->second.get_node_shared_ptr();
+    size_t add_input_index = 0;
+    iter = pattern_map.find(add1);
+    std::shared_ptr<ngraph::Node> add_node = nullptr;
+    if (iter != pattern_map.end()) {
+        add_node = iter->second.get_node_shared_ptr();
+        add_input_index = std::dynamic_pointer_cast<ngraph::opset8::MatMul>(add_node->get_input_node_shared_ptr(0)) ? 1 : 0;
+    }
+
+    // If there is an Add layer, check if it doesn't require inserting a Reshape
+    // to align its dimensions with reshaped MatMul's dimensions
+    if (add_node) {
+        auto add_input = add_node->get_input_node_shared_ptr(add_input_index);
+        if (add_input->get_output_shape(0).size() != 2) {
+            auto consumers = add_input->output(0).get_target_inputs();
+            std::vector<int> before_shape = {-1, static_cast<int>(add_input->get_output_shape(0).back())};
+            auto reshape_add_input = ngraph::op::util::make_try_fold<ngraph::opset8::Reshape>(add_input,
+                std::make_shared<ngraph::opset8::Constant>(ngraph::element::Type_t::i64, ngraph::Shape{before_shape.size()}, before_shape), false);
+            reshape_add_input->set_friendly_name(reshape_add_input->get_friendly_name() + "/reshape_before_add");
+            ngraph::copy_runtime_info(add_node, reshape_add_input);
+            for (auto consumer : consumers) {
+                consumer.replace_source_output(reshape_add_input);
+            }
+        }
+    }
+
     std::vector<std::shared_ptr<ngraph::Node>> nodes = { matmul_node };
     for (auto node : {add2, add1, fake_quantize, transpose}) {
         iter = pattern_map.find(node);

--- a/src/tests/unit/gna/ngraph/transformations/gna_insert_reshape_around_matmul.cpp
+++ b/src/tests/unit/gna/ngraph/transformations/gna_insert_reshape_around_matmul.cpp
@@ -13,7 +13,7 @@
 #include <transformations/init_node_info.hpp>
 #include <numeric>
 
-template<bool ADD = false, bool ADD_FIRST_INPUT_NOT_CONSTANT = false, bool FQ = false, bool TRANSPOSE = false>
+template<bool ADD = false, bool ADD_FIRST_INPUT_NOT_CONSTANT = false, bool ADD_FULL_DIM = false, bool FQ = false, bool TRANSPOSE = false>
 struct InsertReshapeAroundMatmulTest {
     static std::shared_ptr<ngraph::Node> CreateAdd(std::shared_ptr<ngraph::Node> input, const ngraph::Shape& constant_shape) {
         std::vector<size_t> data(ngraph::shape_size(constant_shape));
@@ -33,12 +33,20 @@ struct InsertReshapeAroundMatmulTest {
         node = std::make_shared<ngraph::opset8::MatMul>(input, constant);
 
         if (ADD) {
+            std::vector<size_t> add_constant_shape(2, 1);
             auto matmul_shape = node->get_output_shape(0);
             data.resize(ngraph::shape_size(matmul_shape));
             std::iota(std::begin(data), std::end(data), 1);
-            std::vector<size_t> constant_add_shape(2, 1);
-            std::copy_if(matmul_shape.begin(), matmul_shape.end(), constant_add_shape.begin(), [](size_t e) { return e > 1; });
-            auto constant_add = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{constant_add_shape}, data);
+
+            if (ADD_FULL_DIM) {
+                add_constant_shape.resize(matmul_shape.size(), 1);
+                std::copy(matmul_shape.begin(), matmul_shape.end(), add_constant_shape.begin());
+            } else {
+                std::copy_if(matmul_shape.begin(), matmul_shape.end(), add_constant_shape.begin(), [](size_t e) { return e > 1; });
+            }
+
+            auto constant_add =
+                ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{add_constant_shape}, data);
             if (ADD_FIRST_INPUT_NOT_CONSTANT) {
                 node = std::make_shared<ngraph::opset8::Add>(node, constant_add);
             } else {
@@ -161,6 +169,11 @@ TEST(TransformationTests, InsertReshapeAroundMatmulWithAdd) {
         InsertReshapeAroundMatmulTest<true, true>::
             CreateReferenceFunction({1, 6, 8}, {-1, 8}, {8, 10}, {1, 6, 10}));
     RunTest(
+        InsertReshapeAroundMatmulTest<true, true, true>::
+            CreateFunction({1, 6, 8}, {8, 10}),
+        InsertReshapeAroundMatmulTest<true, true>::
+            CreateReferenceFunction({1, 6, 8}, {-1, 8}, {8, 10}, {1, 6, 10}));
+    RunTest(
         InsertReshapeAroundMatmulTest<true, true>::
             CreateReferenceFunction({1, 6, 8}, {-1, 8}, {8, 10}, {1, 6, 10}),
         InsertReshapeAroundMatmulTest<true, true>::
@@ -174,6 +187,11 @@ TEST(TransformationTests, InsertReshapeAroundMatmulWithAdd_AddFirstInputConstant
         InsertReshapeAroundMatmulTest<true>::
             CreateReferenceFunction({1, 6, 8}, {-1, 8}, {8, 10}, {1, 6, 10}));
     RunTest(
+        InsertReshapeAroundMatmulTest<true, false, true>::
+            CreateFunction({1, 6, 8}, {8, 10}),
+        InsertReshapeAroundMatmulTest<true>::
+            CreateReferenceFunction({1, 6, 8}, {-1, 8}, {8, 10}, {1, 6, 10}));
+    RunTest(
         InsertReshapeAroundMatmulTest<true>::
             CreateReferenceFunction({1, 6, 8}, {-1, 8}, {8, 10}, {1, 6, 10}),
         InsertReshapeAroundMatmulTest<true>::
@@ -182,85 +200,95 @@ TEST(TransformationTests, InsertReshapeAroundMatmulWithAdd_AddFirstInputConstant
 
 TEST(TransformationTests, InsertReshapeAroundMatmulWithFq) {
     RunTest(
-        InsertReshapeAroundMatmulTest<false, false, true>::
+        InsertReshapeAroundMatmulTest<false, false, false, true>::
             CreateFunction({1, 6, 8}, {8, 10}),
-        InsertReshapeAroundMatmulTest<false, false, true>::
+        InsertReshapeAroundMatmulTest<false, false, false, true>::
             CreateReferenceFunction({1, 6, 8}, {-1, 8}, {8, 10}, {1, 6, 10}));
     RunTest(
-        InsertReshapeAroundMatmulTest<false, false, true>::
+        InsertReshapeAroundMatmulTest<false, false, false, true>::
             CreateReferenceFunction({1, 6, 8}, {-1, 8}, {8, 10}, {1, 6, 10}),
-        InsertReshapeAroundMatmulTest<false, false, true>::
+        InsertReshapeAroundMatmulTest<false, false, false, true>::
             CreateReferenceFunction({1, 6, 8}, {-1, 8}, {8, 10}, {1, 6, 10}));
 }
 
 TEST(TransformationTests, InsertReshapeAroundMatmulWithAddAndFq) {
     RunTest(
-        InsertReshapeAroundMatmulTest<true, true, true>::
+        InsertReshapeAroundMatmulTest<true, true, false, true>::
             CreateFunction({1, 6, 8}, {8, 10}),
-        InsertReshapeAroundMatmulTest<true, true, true>::
+        InsertReshapeAroundMatmulTest<true, true, false, true>::
             CreateReferenceFunction({1, 6, 8}, {-1, 8}, {8, 10}, {1, 6, 10}));
     RunTest(
-        InsertReshapeAroundMatmulTest<true, true, true>::
+        InsertReshapeAroundMatmulTest<true, true, true, true>::
+            CreateFunction({1, 6, 8}, {8, 10}),
+        InsertReshapeAroundMatmulTest<true, true, false, true>::
+            CreateReferenceFunction({1, 6, 8}, {-1, 8}, {8, 10}, {1, 6, 10}));
+    RunTest(
+        InsertReshapeAroundMatmulTest<true, true, false, true>::
             CreateReferenceFunction({1, 6, 8}, {-1, 8}, {8, 10}, {1, 6, 10}),
-        InsertReshapeAroundMatmulTest<true, true, true>::
+        InsertReshapeAroundMatmulTest<true, true, false, true>::
             CreateReferenceFunction({1, 6, 8}, {-1, 8}, {8, 10}, {1, 6, 10}));
 }
 
 TEST(TransformationTests, InsertReshapeAroundMatmulWithTranspose) {
     RunTest(
-        InsertReshapeAroundMatmulTest<false, false, false, true>::
+        InsertReshapeAroundMatmulTest<false, false, false, false, true>::
             CreateFunction({1, 6, 8}, {8, 10}, {0, 2, 1}),
-        InsertReshapeAroundMatmulTest<false, false, false, true>::
+        InsertReshapeAroundMatmulTest<false, false, false, false, true>::
             CreateReferenceFunction({1, 6, 8}, {-1, 8}, {8, 10}, {1, 10, 6}, {1, 0}));
     RunTest(
-        InsertReshapeAroundMatmulTest<false, false, false, true>::
+        InsertReshapeAroundMatmulTest<false, false, false, false, true>::
             CreateReferenceFunction({1, 6, 8}, {-1, 8}, {8, 10}, {1, 10, 6}, {1, 0}),
-        InsertReshapeAroundMatmulTest<false, false, false, true>::
+        InsertReshapeAroundMatmulTest<false, false, false, false, true>::
             CreateReferenceFunction({1, 6, 8}, {-1, 8}, {8, 10}, {1, 10, 6}, {1, 0}));
     RunTest(
-        InsertReshapeAroundMatmulTest<false, false, false, true>::
+        InsertReshapeAroundMatmulTest<false, false, false, false, true>::
             CreateFunction({1, 1, 8}, {8, 10}, {0, 2, 1}),
-        InsertReshapeAroundMatmulTest<false, false, false, true>::
+        InsertReshapeAroundMatmulTest<false, false, false, false, true>::
             CreateReferenceFunction({1, 1, 8}, {-1, 8}, {8, 10}, {1, 10, 1}, {1, 0}));
     RunTest(
-        InsertReshapeAroundMatmulTest<false, false, false, true>::
+        InsertReshapeAroundMatmulTest<false, false, false, false, true>::
             CreateReferenceFunction({1, 1, 8}, {-1, 8}, {8, 10}, {1, 10, 1}, {1, 0}),
-        InsertReshapeAroundMatmulTest<false, false, false, true>::
+        InsertReshapeAroundMatmulTest<false, false, false, false, true>::
             CreateReferenceFunction({1, 1, 8}, {-1, 8}, {8, 10}, {1, 10, 1}, {1, 0}));
 }
 
 TEST(TransformationTests, InsertReshapeAroundMatmulWithFqAndTranspose) {
     RunTest(
-        InsertReshapeAroundMatmulTest<false, false, true, true>::
+        InsertReshapeAroundMatmulTest<false, false, false, true, true>::
             CreateFunction({1, 6, 8}, {8, 10}, {0, 2, 1}),
-        InsertReshapeAroundMatmulTest<false, false, true, true>::
+        InsertReshapeAroundMatmulTest<false, false, false, true, true>::
             CreateReferenceFunction({1, 6, 8}, {-1, 8}, {8, 10}, {1, 10, 6}, {1, 0}));
     RunTest(
-        InsertReshapeAroundMatmulTest<false, false, true, true>::
+        InsertReshapeAroundMatmulTest<false, false, false, true, true>::
             CreateReferenceFunction({1, 6, 8}, {-1, 8}, {8, 10}, {1, 10, 6}, {1, 0}),
-        InsertReshapeAroundMatmulTest<false, false, true, true>::
+        InsertReshapeAroundMatmulTest<false, false, false, true, true>::
             CreateReferenceFunction({1, 6, 8}, {-1, 8}, {8, 10}, {1, 10, 6}, {1, 0}));
     RunTest(
-        InsertReshapeAroundMatmulTest<false, false, true, true>::
+        InsertReshapeAroundMatmulTest<false, false, false, true, true>::
             CreateFunction({1, 1, 8}, {8, 10}, {0, 2, 1}),
-        InsertReshapeAroundMatmulTest<false, false, true, true>::
+        InsertReshapeAroundMatmulTest<false, false, false, true, true>::
             CreateReferenceFunction({1, 1, 8}, {-1, 8}, {8, 10}, {1, 10, 1}, {1, 0}));
     RunTest(
-        InsertReshapeAroundMatmulTest<false, false, true, true>::
+        InsertReshapeAroundMatmulTest<false, false, false, true, true>::
             CreateReferenceFunction({1, 1, 8}, {-1, 8}, {8, 10}, {1, 10, 1}, {1, 0}),
-        InsertReshapeAroundMatmulTest<false, false, true, true>::
+        InsertReshapeAroundMatmulTest<false, false, false, true, true>::
             CreateReferenceFunction({1, 1, 8}, {-1, 8}, {8, 10}, {1, 10, 1}, {1, 0}));
 }
 
 TEST(TransformationTests, InsertReshapeAroundMatmulWithAddAndFqAndTranspose) {
     RunTest(
-        InsertReshapeAroundMatmulTest<true, true, true, true>::
+        InsertReshapeAroundMatmulTest<true, true, false, true, true>::
             CreateFunction({1, 6, 8}, {8, 10}, {0, 2, 1}),
-        InsertReshapeAroundMatmulTest<true, true, true, true>::
+        InsertReshapeAroundMatmulTest<true, true, false, true, true>::
             CreateReferenceFunction({1, 6, 8}, {-1, 8}, {8, 10}, {1, 10, 6}, {1, 0}));
     RunTest(
-        InsertReshapeAroundMatmulTest<true, true, true, true>::
+        InsertReshapeAroundMatmulTest<true, true, true, true, true>::
+            CreateFunction({1, 6, 8}, {8, 10}, {0, 2, 1}),
+        InsertReshapeAroundMatmulTest<true, true, false, true, true>::
+            CreateReferenceFunction({1, 6, 8}, {-1, 8}, {8, 10}, {1, 10, 6}, {1, 0}));
+    RunTest(
+        InsertReshapeAroundMatmulTest<true, true, false, true, true>::
             CreateReferenceFunction({1, 6, 8}, {-1, 8}, {8, 10}, {1, 10, 6}, {1, 0}),
-        InsertReshapeAroundMatmulTest<true, true, true, true>::
+        InsertReshapeAroundMatmulTest<true, true, false, true, true>::
             CreateReferenceFunction({1, 6, 8}, {-1, 8}, {8, 10}, {1, 10, 6}, {1, 0}));
 }


### PR DESCRIPTION
### Details:
 - reshape Add's input from 4D/3D to 2D when Add follows MatMul and MatMul needs to be reshaped to 2D


### Tickets:
 - 76915
