### PR TITLE
Add testcases of index type i32 for NonMaxSuppression

### DIFF
--- a/docs/template_plugin/tests/functional/op_reference/non_max_suppression.cpp
+++ b/docs/template_plugin/tests/functional/op_reference/non_max_suppression.cpp
@@ -91,7 +91,8 @@ private:
                                                                      score_threshold,
                                                                      soft_nms_sigma,
                                                                      params.boxEncoding,
-                                                                     false);
+                                                                     false,
+                                                                     params.expectedSelectedIndices.type);
         const auto f = std::make_shared<Model>(nms->outputs(), ParameterVector{boxes, scores});
         return f;
     }
@@ -128,7 +129,8 @@ private:
                                                                      score_threshold,
                                                                      soft_nms_sigma,
                                                                      params.boxEncoding,
-                                                                     false);
+                                                                     false,
+                                                                     params.expectedSelectedIndices.type);
         const auto f = std::make_shared<Model>(nms->outputs(),
                                                ParameterVector{boxes, scores, max_output_boxes_per_class,
                                                                iou_threshold, score_threshold, soft_nms_sigma});
@@ -549,7 +551,8 @@ private:
                                                                      iou_threshold,
                                                                      score_threshold,
                                                                      params.boxEncoding,
-                                                                     false);
+                                                                     false,
+                                                                     params.expectedSelectedIndices.type);
         const auto f = std::make_shared<Model>(nms->outputs(), ParameterVector{boxes, scores});
         return f;
     }
@@ -581,7 +584,8 @@ private:
                                                                      iou_threshold,
                                                                      score_threshold,
                                                                      params.boxEncoding,
-                                                                     false);
+                                                                     false,
+                                                                     params.expectedSelectedIndices.type);
         const auto f = std::make_shared<Model>(nms->outputs(),
                                                ParameterVector{boxes, scores, max_output_boxes_per_class,
                                                                iou_threshold, score_threshold});
@@ -935,7 +939,8 @@ private:
                                                                      iou_threshold,
                                                                      score_threshold,
                                                                      params.boxEncoding,
-                                                                     false);
+                                                                     false,
+                                                                     params.expectedSelectedIndices.type);
         const auto f = std::make_shared<Model>(nms->outputs(), ParameterVector{boxes, scores});
         return f;
     }
@@ -967,7 +972,8 @@ private:
                                                                      iou_threshold,
                                                                      score_threshold,
                                                                      params.boxEncoding,
-                                                                     false);
+                                                                     false,
+                                                                     params.expectedSelectedIndices.type);
         const auto f = std::make_shared<Model>(nms->outputs(),
                                                ParameterVector{boxes, scores, max_output_boxes_per_class,
                                                                iou_threshold, score_threshold});
@@ -1528,9 +1534,6 @@ std::vector<NonMaxSuppression1Params> generateParams1() {
 
 std::vector<NonMaxSuppression1Params> generateCombinedParams1() {
     const std::vector<std::vector<NonMaxSuppression1Params>> generatedParams {
-        generateParams1<element::Type_t::bf16, element::Type_t::i32, element::Type_t::f32, element::Type_t::i32>(),
-        generateParams1<element::Type_t::f16, element::Type_t::i32, element::Type_t::f32, element::Type_t::i32>(),
-        generateParams1<element::Type_t::f32, element::Type_t::i32, element::Type_t::f32, element::Type_t::i32>(),
         generateParams1<element::Type_t::bf16, element::Type_t::i32, element::Type_t::f32, element::Type_t::i64>(),
         generateParams1<element::Type_t::f16, element::Type_t::i32, element::Type_t::f32, element::Type_t::i64>(),
         generateParams1<element::Type_t::f32, element::Type_t::i32, element::Type_t::f32, element::Type_t::i64>(),
@@ -1576,9 +1579,6 @@ std::vector<NonMaxSuppression1Params> generateParams1WithoutConstants() {
 
 std::vector<NonMaxSuppression1Params> generateCombinedParams1WithoutConstants() {
     const std::vector<std::vector<NonMaxSuppression1Params>> generatedParams {
-        generateParams1WithoutConstants<element::Type_t::bf16, element::Type_t::i32, element::Type_t::f32, element::Type_t::i32>(),
-        generateParams1WithoutConstants<element::Type_t::f16, element::Type_t::i32, element::Type_t::f32, element::Type_t::i32>(),
-        generateParams1WithoutConstants<element::Type_t::f32, element::Type_t::i32, element::Type_t::f32, element::Type_t::i32>(),
         generateParams1WithoutConstants<element::Type_t::bf16, element::Type_t::i32, element::Type_t::f32, element::Type_t::i64>(),
         generateParams1WithoutConstants<element::Type_t::f16, element::Type_t::i32, element::Type_t::f32, element::Type_t::i64>(),
         generateParams1WithoutConstants<element::Type_t::f32, element::Type_t::i32, element::Type_t::f32, element::Type_t::i64>(),

--- a/docs/template_plugin/tests/functional/skip_tests_config.cpp
+++ b/docs/template_plugin/tests/functional/skip_tests_config.cpp
@@ -100,14 +100,6 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*ReferenceTopKTest.*aType=f64.*)",
         // CVS-63947
         R"(.*ReferenceConcatTest.*concat_zero_.*)",
-        // CVS-64096
-        R"(.*ReferenceNonMaxSuppressionTest.*esiType=i32.*evoType=i32.*)",
-        // CVS-64081
-        R"(.*ReferenceNonMaxSuppression4Test.*esiType=i32.*)",
-        // CVS-64067
-        R"(.*ReferenceNonMaxSuppression3Test.*esiType=i32.*)",
-        // CVS-64034
-        R"(.*ReferenceNonMaxSuppression1Test.*esiType=i32.*)",
         // CVS-64102
         R"(.*ReferenceExperimentalPGGLayerTest.*iType=bf16.*stride_x=(32|64).*)",
         // CVS-72215


### PR DESCRIPTION
### Details:
 - *Add template plugin testcases of i32 to op_reference/non_max_suppression.cpp*
 - *Remove skip regex from skip_tests_config.cpp*

### Tickets:
 - *70324*
