### PR TITLE
Fix for memory leak in MKLDNNTensorIteratorNode

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/mkldnn_tensoriterator_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_tensoriterator_node.cpp
@@ -152,7 +152,7 @@ public:
         reorder = {mem_holder_src, mem_holder_dst};
     }
 
-    void execute(mkldnn::stream strm, int iter) override {
+    void execute(mkldnn::stream strm, int iter = -1) override {
         if (iter != 0) {
             reorder.execute(strm, mem_holder_src, mem_holder_dst);
         }
@@ -682,8 +682,8 @@ void MKLDNNTensorIteratorNode::reshapeAndFillOutput(mkldnn::stream strm) {
             const auto desc = getBaseMemDescAtOutputPort(map_rule.from)->cloneWithNewDims(from_mem->getStaticDims());
             redefineToMemories(to_mems, desc);
 
-            PortMapHelper *mapper = new BackEdgePortHelper(from_mem, to_mems.front(), eng);
-            mapper->execute(strm);
+            BackEdgePortHelper mapper(from_mem, to_mems.front(), eng);
+            mapper.execute(strm);
         }
     }
 


### PR DESCRIPTION
### Details:
 - Fix for memory leak in MKLDNNTensorIteratorNode

### Tickets:
 - CVS-76087
