### PR TITLE
Initialize cltools_setenv.sh before execute clc binary

### DIFF
--- a/docs/IE_DG/Extensibility_DG/VPU_Kernel.md
+++ b/docs/IE_DG/Extensibility_DG/VPU_Kernel.md
@@ -28,7 +28,9 @@ The OpenCL toolchain for the Intel® Neural Compute Stick 2 supports offline com
    * `SHAVE_MOVIASM_DIR=<INSTALL_DIR>/deployment_tools/tools/cl_compiler/bin/`
 2. Run the compilation with the command below. You should use `--strip-binary-header` to make an OpenCL runtime-agnostic binary runnable with the Inference Engine.
    ```bash
+   source <INSTALL_DIR>/bin/setupvars.sh
    cd <INSTALL_DIR>/deployment_tools/tools/cl_compiler/bin
+   source cltools_setenv.sh
    ./clc --strip-binary-header custom_layer.cl -o custom_layer.bin
    ```
 


### PR DESCRIPTION
linker errors for SHAVE_LDSCRIPT, SHAVE_MYRIAD_LD_DIR, and SHAVE_MOVIASM_DIR will be shown before initializing cltools_setenv.sh <device>

### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*
