### PR TITLE
Common utils change for better compatiblity with gtest test naming policy

### DIFF
--- a/src/tests/ie_test_utils/common_test_utils/common_utils.hpp
+++ b/src/tests/ie_test_utils/common_test_utils/common_utils.hpp
@@ -39,12 +39,12 @@ template<typename vecElementType>
 inline std::string vec2str(const std::vector<vecElementType> &vec) {
     if (!vec.empty()) {
         std::ostringstream result;
-        result << "(";
-        std::copy(vec.begin(), vec.end() - 1, std::ostream_iterator<vecElementType>(result, "."));
-        result << vec.back() << ")";
+        result << "vec";
+        std::copy(vec.begin(), vec.end() - 1, std::ostream_iterator<vecElementType>(result, "_"));
+        result << vec.back() << "_";
         return result.str();
     }
-    return std::string("()");
+    return std::string("vec_empty");
 }
 inline void replaceSubstringInString(std::string& str, const std::string& from, const std::string& to) {
     size_t pos;
@@ -65,7 +65,7 @@ inline std::string partialShape2str(const std::vector<ngraph::PartialShape>& par
 
 inline std::string pair2str(const std::pair<size_t, size_t>& p) {
     std::ostringstream result;
-    result << "(" << p.first << "." << p.second << ")";
+    result << "pair" << p.first << "_" << p.second << "__";
     return result.str();
 }
 
@@ -107,12 +107,12 @@ template<typename vecElementType>
 inline std::string set2str(const std::set<vecElementType> &set) {
     if (!set.empty()) {
         std::ostringstream result;
-        result << "(";
-        std::copy(set.begin(), std::prev(set.end()), std::ostream_iterator<vecElementType>(result, "."));
-        result << *set.rbegin() << ")";
+        result << "set";
+        std::copy(set.begin(), std::prev(set.end()), std::ostream_iterator<vecElementType>(result, "_"));
+        result << *set.rbegin() << "_";
         return result.str();
     }
-    return std::string("()");
+    return std::string("set_empty");
 }
 
 template <typename master, typename slave>
@@ -178,11 +178,11 @@ inline std::string GetTimestamp() {
 }
 
 inline std::ostream& operator<<(std::ostream& os, const std::map<std::string, std::string>& config) {
-    os << "(";
+    os << "map";
     for (const auto& configItem : config) {
-        os << configItem.first << "=" << configItem.second << "_";
+        os << configItem.first << "_" << configItem.second << "__";
     }
-    os << ")";
+    os << "_";
     return os;
 }
 }  // namespace CommonTestUtils

--- a/src/tests/ie_test_utils/common_test_utils/common_utils.hpp
+++ b/src/tests/ie_test_utils/common_test_utils/common_utils.hpp
@@ -4,18 +4,19 @@
 
 #pragma once
 
-#include <algorithm>
-#include <string>
-#include <sstream>
-#include <iterator>
-#include <vector>
-#include <set>
-#include <chrono>
-#include <ostream>
-#include <memory>
-
 #include <cpp/ie_cnn_network.h>
+
+#include <algorithm>
+#include <chrono>
+#include <iterator>
+#include <memory>
 #include <ngraph/function.hpp>
+#include <ostream>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
+
 
 namespace InferenceEngine {
 class CNNLayer;
@@ -23,20 +24,17 @@ class CNNLayer;
 
 namespace CommonTestUtils {
 
-enum class OpType {
-    SCALAR,
-    VECTOR
-};
+enum class OpType { SCALAR, VECTOR };
 
-std::ostream& operator<<(std::ostream & os, OpType type);
+std::ostream& operator<<(std::ostream& os, OpType type);
 
 IE_SUPPRESS_DEPRECATED_START
-std::shared_ptr<InferenceEngine::CNNLayer>
-getLayerByName(const InferenceEngine::CNNNetwork & network, const std::string & layerName);
+std::shared_ptr<InferenceEngine::CNNLayer> getLayerByName(const InferenceEngine::CNNNetwork& network,
+                                                          const std::string& layerName);
 IE_SUPPRESS_DEPRECATED_END
 
-template<typename vecElementType>
-inline std::string vec2str(const std::vector<vecElementType> &vec) {
+template <typename vecElementType>
+inline std::string vec2str(const std::vector<vecElementType>& vec) {
     if (!vec.empty()) {
         std::ostringstream result;
         result << "vec";
@@ -69,42 +67,42 @@ inline std::string pair2str(const std::pair<size_t, size_t>& p) {
     return result.str();
 }
 
-inline std::string vec2str(const std::vector<std::pair<size_t, size_t>> &vec) {
+inline std::string vec2str(const std::vector<std::pair<size_t, size_t>>& vec) {
     std::ostringstream result;
-    for (const auto &p : vec) {
+    for (const auto& p : vec) {
         result << pair2str(p);
     }
     return result.str();
 }
 
-inline std::string vec2str(const std::vector<std::vector<std::pair<size_t, size_t>>> &vec) {
+inline std::string vec2str(const std::vector<std::vector<std::pair<size_t, size_t>>>& vec) {
     std::ostringstream result;
-    for (const auto &v : vec) {
+    for (const auto& v : vec) {
         result << vec2str(v);
     }
     return result.str();
 }
 
-template<typename vecElementType>
-inline std::string vec2str(const std::vector<std::vector<vecElementType>> &vec) {
+template <typename vecElementType>
+inline std::string vec2str(const std::vector<std::vector<vecElementType>>& vec) {
     std::ostringstream result;
-    for (const auto &v : vec) {
+    for (const auto& v : vec) {
         result << vec2str<vecElementType>(v);
     }
     return result.str();
 }
 
-template<typename vecElementType>
-inline std::string vec2str(const std::vector<std::vector<std::vector<vecElementType>>> &vec) {
+template <typename vecElementType>
+inline std::string vec2str(const std::vector<std::vector<std::vector<vecElementType>>>& vec) {
     std::ostringstream result;
-    for (const auto &v : vec) {
+    for (const auto& v : vec) {
         result << vec2str<vecElementType>(v);
     }
     return result.str();
 }
 
-template<typename vecElementType>
-inline std::string set2str(const std::set<vecElementType> &set) {
+template <typename vecElementType>
+inline std::string set2str(const std::set<vecElementType>& set) {
     if (!set.empty()) {
         std::ostringstream result;
         result << "set";
@@ -116,8 +114,7 @@ inline std::string set2str(const std::set<vecElementType> &set) {
 }
 
 template <typename master, typename slave>
-std::vector<std::pair<master, slave>> combineParams(
-    const std::map<master, std::vector<slave>>& keyValueSets) {
+std::vector<std::pair<master, slave>> combineParams(const std::map<master, std::vector<slave>>& keyValueSets) {
     std::vector<std::pair<master, slave>> resVec;
     for (auto& keyValues : keyValueSets) {
         if (keyValues.second.empty()) {
@@ -131,41 +128,43 @@ std::vector<std::pair<master, slave>> combineParams(
 }
 
 inline bool endsWith(const std::string& source, const std::string& expectedSuffix) {
-    return expectedSuffix.size() <= source.size() && source.compare(source.size() - expectedSuffix.size(), expectedSuffix.size(), expectedSuffix) == 0;
+    return expectedSuffix.size() <= source.size() &&
+           source.compare(source.size() - expectedSuffix.size(), expectedSuffix.size(), expectedSuffix) == 0;
 }
 
-template<std::size_t... I>
+template <std::size_t... I>
 struct Indices {
     using next = Indices<I..., sizeof...(I)>;
 };
 
-template<std::size_t Size>
+template <std::size_t Size>
 struct MakeIndices {
     using value = typename MakeIndices<Size - 1>::value::next;
 };
 
-template<>
+template <>
 struct MakeIndices<0> {
     using value = Indices<>;
 };
 
-template<class Tuple>
+template <class Tuple>
 constexpr typename MakeIndices<std::tuple_size<typename std::decay<Tuple>::type>::value>::value makeIndices() {
     return {};
 }
 
-template<class Tuple, std::size_t... I>
-std::vector<typename std::tuple_element<0, typename std::decay<Tuple>::type>::type> tuple2Vector(Tuple&& tuple, Indices<I...>) {
+template <class Tuple, std::size_t... I>
+std::vector<typename std::tuple_element<0, typename std::decay<Tuple>::type>::type> tuple2Vector(Tuple&& tuple,
+                                                                                                 Indices<I...>) {
     using std::get;
-    return {{ get<I>(std::forward<Tuple>(tuple))... }};
+    return {{get<I>(std::forward<Tuple>(tuple))...}};
 }
 
-template<class Tuple>
+template <class Tuple>
 inline auto tuple2Vector(Tuple&& tuple) -> decltype(tuple2Vector(std::declval<Tuple>(), makeIndices<Tuple>())) {
     return tuple2Vector(std::forward<Tuple>(tuple), makeIndices<Tuple>());
 }
 
-template<class T>
+template <class T>
 inline T getTotal(const std::vector<T>& shape) {
     return shape.empty() ? 0 : std::accumulate(shape.cbegin(), shape.cend(), static_cast<T>(1), std::multiplies<T>());
 }


### PR DESCRIPTION
In a way to avoid using custiom gtest fork, I suggest to start from this utility functions. They used in functions `$testname::getTestCaseName`

Just with this change, we can reduce number of tests with forbidden symbols from 7'138'920 to 3'840'369 (cpuFuncTests)

Before and after example:
`IS=(1.3.224.224)_inPRC=FP32_netPRC=BF16_targetDevice=CPU` -> `IS=vec1_3_224_224__inPRC=FP32_netPRC=BF16_targetDevice=CPU`
(it still has `=` symbol, it's from other part of code)