### PR TITLE
[GPU] Adjust preferred format of resample operation

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/format.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/format.hpp
@@ -278,6 +278,33 @@ struct format {
                 fmt == bfyx || fmt == fyxb ||
                 fmt == bfzyx || fmt == bfwzyx);
     }
+
+    static format get_default_format(size_t rank, bool is_weights, bool is_grouped) {
+        auto default_fmt = cldnn::format::bfyx;
+        if (is_weights) {
+            if (is_grouped) {
+                if (rank == 5) {
+                    default_fmt = cldnn::format::goiyx;
+                } else if (rank == 6) {
+                    default_fmt = cldnn::format::goizyx;
+                }
+            } else {
+                if (rank == 4) {
+                    default_fmt = cldnn::format::oiyx;
+                } else if (rank == 5) {
+                    default_fmt = cldnn::format::oizyx;
+                }
+            }
+        } else {
+            if (rank == 5) {
+                default_fmt = cldnn::format::bfzyx;
+            } else if (rank == 6) {
+                default_fmt = cldnn::format::bfwzyx;
+            }
+        }
+       return default_fmt;
+    }
+
     /// @brief Checks if @p format is of grouped type
     static bool is_grouped(type fmt) { return group_num(fmt) != 0; }
     /// @brief Checks if @p format is of image type

--- a/src/plugins/intel_gpu/src/graph/include/layout_optimizer.h
+++ b/src/plugins/intel_gpu/src/graph/include/layout_optimizer.h
@@ -180,6 +180,7 @@ public:
     explicit layout_optimizer(bool output_size_handling_enabled = true);
 
     format get_preferred_format(program_node& node);
+    bool all_users_simple_format(program_node& origin_node, program_node& cur_node, int32_t cur_depth, int32_t max_depth);
     impl_types get_preferred_impl_type(program_node& node, format preferred_format);
 
     bool are_data_types_suitable_for_onednn(program_node& node);

--- a/src/plugins/intel_gpu/src/graph/include/layout_optimizer.h
+++ b/src/plugins/intel_gpu/src/graph/include/layout_optimizer.h
@@ -180,7 +180,7 @@ public:
     explicit layout_optimizer(bool output_size_handling_enabled = true);
 
     format get_preferred_format(program_node& node);
-    bool all_users_simple_format(program_node& origin_node, program_node& cur_node, int32_t cur_depth, int32_t max_depth);
+    bool all_users_simple_format_until_output(program_node& origin_node, program_node& cur_node, int32_t cur_depth, int32_t max_depth);
     impl_types get_preferred_impl_type(program_node& node, format preferred_format);
 
     bool are_data_types_suitable_for_onednn(program_node& node);

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1667,6 +1667,24 @@ bool layout_optimizer::all_users_simple_format_until_output(program_node& origin
     if (cur_node.is_output()) return true;
     if (cur_depth > max_depth) return false;
 
+    auto is_rotating_except_batch = [](const std::vector<uint16_t>& order) {
+        // Target transform: Rotate feature dim to back to be taken as inner-most axis
+        // ex) 0(b), 4(f), 1(z), 2(y), 3(x)
+        // ex) 0(b), 3(f), 1(y), 2(x)
+        if ((int32_t) order[1] != order.size() - 1) return false;
+        if ((int32_t) order[0] != 0) return false;
+        for (int32_t i = 2; i < (int32_t) order.size(); ++i) {
+            if ((int32_t)order[i] !=  (i - 1)) return false;
+        }
+        return true;
+    };
+
+    if (cur_node.is_type<permute>()) {
+        auto& permute_order = cur_node.as<permute>().get_primitive()->permute_order;
+        if (!is_rotating_except_batch(permute_order))
+            return false;
+    }
+
     if (cur_node.is_in_data_flow() && (cur_node.type() != origin_node.type())) {
         const auto& fmt = get_preferred_format(cur_node);
         if (fmt != format::any && !format::is_simple_data_format(fmt)) {

--- a/src/plugins/intel_gpu/src/runtime/layout.cpp
+++ b/src/plugins/intel_gpu/src/runtime/layout.cpp
@@ -86,39 +86,13 @@ tensor::value_type layout::ifm() const {
     return dims[dim_idx];
 }
 
-static format get_default_format(size_t rank, bool is_weights, bool is_grouped) {
-    auto default_fmt = cldnn::format::bfyx;
-    if (is_weights) {
-        if (is_grouped) {
-            if (rank == 5) {
-                default_fmt = cldnn::format::goiyx;
-            } else if (rank == 6) {
-                default_fmt = cldnn::format::goizyx;
-            }
-        } else {
-            if (rank == 4) {
-                default_fmt = cldnn::format::oiyx;
-            } else if (rank == 5) {
-                default_fmt = cldnn::format::oizyx;
-            }
-        }
-    } else {
-        if (rank == 5) {
-            default_fmt = cldnn::format::bfzyx;
-        } else if (rank == 6) {
-            default_fmt = cldnn::format::bfwzyx;
-        }
-    }
-
-    return default_fmt;
-}
 std::vector<tensor::value_type> layout::get_dims() const {
-    auto default_fmt = get_default_format(format.dimension(), format::is_weights_format(format), format::is_grouped(format));
+    auto default_fmt = format::get_default_format(format.dimension(), format::is_weights_format(format), format::is_grouped(format));
     return size.sizes(default_fmt);
 }
 
 std::vector<tensor::value_type> layout::get_padded_dims() const {
-    auto default_fmt = get_default_format(format.dimension(), format::is_weights_format(format), format::is_grouped(format));
+    auto default_fmt = format::get_default_format(format.dimension(), format::is_weights_format(format), format::is_grouped(format));
     auto padded_size = size.add(data_padding.lower_size()).add(data_padding.upper_size());
     return padded_size.sizes(default_fmt);
 }


### PR DESCRIPTION
### Details:
 - Fixed resample's format selection to simple formats when it is close to output layer and all the intermediate layers in between the resample and output layer are not preferring blocked format 
- The idea is that, if there is no users preferring blocked format, reordering to bfyx, which should be done before output layer, is better to be done before resample, otherwise reorder to bfyx should be done for larger (resampled) feature map.

### Tickets:
 - 59132
