### PR TITLE
Fixes of plugins.xml generation - clean old names

### DIFF
--- a/cmake/developer_package/plugins/plugins.cmake
+++ b/cmake/developer_package/plugins/plugins.cmake
@@ -187,6 +187,8 @@ macro(ie_register_plugins_dynamic)
     # Unregister <device_name>.xml files for plugins from current build tree
 
     set(plugins_to_remove ${IE_REGISTER_POSSIBLE_PLUGINS})
+    # Remove legacy plugin names from plugins.xml in case of incremental build
+    set(plugins_to_remove ${plugins_to_remove} AutoPlugin MultiDevicePlugin HeteroPlugin clDNNPlugin GNAPlugin MKLDNNPlugin myriadPlugin)
     set(config_output_file "$<TARGET_FILE_DIR:${IE_REGISTER_MAIN_TARGET}>/plugins.xml")
 
     foreach(plugin IN LISTS plugins_to_remove)

--- a/src/cmake/ov_runtime.cmake
+++ b/src/cmake/ov_runtime.cmake
@@ -48,7 +48,7 @@ ie_mark_target_as_cc(${TARGET_NAME})
 set_target_properties(${TARGET_NAME} PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE ${ENABLE_LTO})
 
 ie_register_plugins(MAIN_TARGET ${TARGET_NAME}
-                    POSSIBLE_PLUGINS ov_auto_plugin ov_hetero_plugin ov_intel_gpu_plugin ov_intel_gna_plugin ov_intel_cpu_plugin ov_intel_vpu_plugin)
+                    POSSIBLE_PLUGINS ov_auto_plugin ov_auto_batch_plugin ov_hetero_plugin ov_intel_gpu_plugin ov_intel_gna_plugin ov_intel_cpu_plugin ov_intel_vpu_plugin)
 
 # Export for build tree
 


### PR DESCRIPTION
### Details:
- Added registration (and unregistration) of ov_auto_batch_plugin. Otherwise 'BATCH' plugin will always produce new XML line without removing old one
- Added unregistration of legacy plugin names (<= 2021.4 release). Otherwise old lines like "libHeteroPlugin.so" will not be removed from plugins.xml file

### Tickets:
 - 76886
