### PR TITLE
fixing mem leak by avoiding cyclic ref (when shared_ptr was captured in lambda)

### DIFF
--- a/src/plugins/auto_batch/auto_batch.cpp
+++ b/src/plugins/auto_batch/auto_batch.cpp
@@ -358,7 +358,7 @@ std::pair<AutoBatchExecutableNetwork::WorkerInferRequest&, int> AutoBatchExecuta
     auto batch_id = num % _device.batchForDevice;
     if (!batch_id) {  // need new request
         _workerRequests.push_back(std::make_shared<WorkerInferRequest>());
-        auto workerRequestPtr = _workerRequests.back();
+        auto workerRequestPtr = _workerRequests.back().get();
         workerRequestPtr->_inferRequestBatched = {_network->CreateInferRequest(), _network._so};
         workerRequestPtr->_batchSize = _device.batchForDevice;
         workerRequestPtr->_completionTasks.resize(workerRequestPtr->_batchSize);


### PR DESCRIPTION
CVS-76088