### PR TITLE
Add testcases of type i8, i16, u8, u16, bf16, and f64 for TopK

### DIFF
--- a/docs/template_plugin/tests/functional/op_reference/topk.cpp
+++ b/docs/template_plugin/tests/functional/op_reference/topk.cpp
@@ -184,11 +184,9 @@ std::vector<TopKParamsResnet50> generateParamsResnet50() {
 
 std::vector<TopKParamsResnet50> generateCombinedParamsResnet50() {
     const std::vector<std::vector<TopKParamsResnet50>> generatedParams {
-        generateParamsResnet50<element::Type_t::i8, element::Type_t::i32>(),
         generateParamsResnet50<element::Type_t::i16, element::Type_t::i32>(),
         generateParamsResnet50<element::Type_t::i32, element::Type_t::i32>(),
         generateParamsResnet50<element::Type_t::i64, element::Type_t::i32>(),
-        generateParamsResnet50<element::Type_t::u8, element::Type_t::i32>(),
         generateParamsResnet50<element::Type_t::u16, element::Type_t::i32>(),
         generateParamsResnet50<element::Type_t::u32, element::Type_t::i32>(),
         generateParamsResnet50<element::Type_t::u64, element::Type_t::i32>(),
@@ -511,11 +509,9 @@ std::vector<TopKParams> generateParamsMaxMinSort() {
 
 std::vector<TopKParams> generateCombinedParamsMaxMinSort() {
     const std::vector<std::vector<TopKParams>> generatedParams {
-        generateParamsMaxMinSort<element::Type_t::i8, element::Type_t::i64, element::Type_t::i32>(),
         generateParamsMaxMinSort<element::Type_t::i16, element::Type_t::i64, element::Type_t::i32>(),
         generateParamsMaxMinSort<element::Type_t::i32, element::Type_t::i64, element::Type_t::i32>(),
         generateParamsMaxMinSort<element::Type_t::i64, element::Type_t::i64, element::Type_t::i32>(),
-        generateParamsMaxMinSort<element::Type_t::u8, element::Type_t::i64, element::Type_t::i32>(),
         generateParamsMaxMinSort<element::Type_t::u16, element::Type_t::i64, element::Type_t::i32>(),
         generateParamsMaxMinSort<element::Type_t::u32, element::Type_t::i64, element::Type_t::i32>(),
         generateParamsMaxMinSort<element::Type_t::u64, element::Type_t::i64, element::Type_t::i32>(),
@@ -561,66 +557,11 @@ TEST_P(ReferenceTopKTestBackend, CompareWithRefs) {
     Exec();
 }
 
-template <element::Type_t ET, element::Type_t ET2, element::Type_t ET_OUT>
-std::vector<TopKParams> generateParamsV3() {
-    using T = typename element_type_traits<ET>::value_type;
-    using T2 = typename element_type_traits<ET2>::value_type;
-    using T_OUT = typename element_type_traits<ET_OUT>::value_type;
-    std::vector<TopKParams> params {
-        TopKParams(
-            reference_tests::Tensor(ET, {5}, std::vector<T>{3, 1, 2, 5, 4}),
-            reference_tests::Tensor(ET2, {}, std::vector<T2>{3}),
-            0,
-            opset1::TopK::Mode::MAX,
-            opset1::TopK::SortType::SORT_VALUES,
-            reference_tests::Tensor(ET, {3}, std::vector<T>{5, 4, 3}),
-            reference_tests::Tensor(ET_OUT, {3}, std::vector<T_OUT>{3, 4, 0}),
-            0,
-            "topk_mode_sort_order"),
-
-        TopKParams(
-            reference_tests::Tensor(ET, {5}, std::vector<T>{3, 1, 2, 5, 4}),
-            reference_tests::Tensor(ET2, {}, std::vector<T2>{3}),
-            0,
-            opset1::TopK::Mode::MAX,
-            opset1::TopK::SortType::SORT_INDICES,
-            reference_tests::Tensor(ET, {3}, std::vector<T>{3, 5, 4}),
-            reference_tests::Tensor(ET_OUT, {3}, std::vector<T_OUT>{0, 3, 4}),
-            0,
-            "topk_mode_sort_order_1"),
-
-        TopKParams(
-            reference_tests::Tensor(ET, {5}, std::vector<T>{3, 1, 2, 5, 4}),
-            reference_tests::Tensor(ET2, {}, std::vector<T2>{3}),
-            0,
-            opset1::TopK::Mode::MIN,
-            opset1::TopK::SortType::SORT_VALUES,
-            reference_tests::Tensor(ET, {3}, std::vector<T>{1, 2, 3}),
-            reference_tests::Tensor(ET_OUT, {3}, std::vector<T_OUT>{1, 2, 0}),
-            0,
-            "topk_mode_sort_order_2"),
-
-        TopKParams(
-            reference_tests::Tensor(ET, {5}, std::vector<T>{3, 1, 2, 5, 4}),
-            reference_tests::Tensor(ET2, {}, std::vector<T2>{3}),
-            0,
-            opset1::TopK::Mode::MIN,
-            opset1::TopK::SortType::SORT_INDICES,
-            reference_tests::Tensor(ET, {3}, std::vector<T>{3, 1, 2}),
-            reference_tests::Tensor(ET_OUT, {3}, std::vector<T_OUT>{0, 1, 2}),
-            0,
-            "topk_mode_sort_order_3"),
-    };
-    return params;
-}
-
 std::vector<TopKParams> generateCombinedParamsBackend() {
     const std::vector<std::vector<TopKParams>> generatedParams {
-        generateParamsMaxMinSort<element::Type_t::i8, element::Type_t::i64, element::Type_t::i32>(),
         generateParamsMaxMinSort<element::Type_t::i16, element::Type_t::i64, element::Type_t::i32>(),
         generateParamsMaxMinSort<element::Type_t::i32, element::Type_t::i64, element::Type_t::i32>(),
         generateParamsMaxMinSort<element::Type_t::i64, element::Type_t::i64, element::Type_t::i32>(),
-        generateParamsMaxMinSort<element::Type_t::u8, element::Type_t::i64, element::Type_t::i32>(),
         generateParamsMaxMinSort<element::Type_t::u16, element::Type_t::i64, element::Type_t::i32>(),
         generateParamsMaxMinSort<element::Type_t::u32, element::Type_t::i64, element::Type_t::i32>(),
         generateParamsMaxMinSort<element::Type_t::u64, element::Type_t::i64, element::Type_t::i32>(),

--- a/docs/template_plugin/tests/functional/skip_tests_config.cpp
+++ b/docs/template_plugin/tests/functional/skip_tests_config.cpp
@@ -91,13 +91,6 @@ std::vector<std::string> disabledTestPatterns() {
         // CVS-71381
         R"(.*ReferenceExpLayerTest.*u32.*)",
         R"(.*ReferenceExpLayerTest.*u64.*)",
-        // CVS-64054
-        R"(.*ReferenceTopKTest.*aType=i8.*)",
-        R"(.*ReferenceTopKTest.*aType=i16.*)",
-        R"(.*ReferenceTopKTest.*aType=u8.*)",
-        R"(.*ReferenceTopKTest.*aType=u16.*)",
-        R"(.*ReferenceTopKTest.*aType=bf16.*)",
-        R"(.*ReferenceTopKTest.*aType=f64.*)",
         // CVS-63947
         R"(.*ReferenceConcatTest.*concat_zero_.*)",
         // CVS-64096

--- a/src/core/src/op/topk.cpp
+++ b/src/core/src/op/topk.cpp
@@ -91,12 +91,18 @@ bool evaluate_topk(const HostTensorPtr& arg,
                    const element::Type index_et) {
     bool rc = true;
     switch (arg->get_element_type()) {
+        NGRAPH_TYPE_CASE(evaluate_topk, i8, arg, out_indices, out_values, out_shape, axis, k, max, sort, index_et);
+        NGRAPH_TYPE_CASE(evaluate_topk, i16, arg, out_indices, out_values, out_shape, axis, k, max, sort, index_et);
         NGRAPH_TYPE_CASE(evaluate_topk, i32, arg, out_indices, out_values, out_shape, axis, k, max, sort, index_et);
         NGRAPH_TYPE_CASE(evaluate_topk, i64, arg, out_indices, out_values, out_shape, axis, k, max, sort, index_et);
+        NGRAPH_TYPE_CASE(evaluate_topk, u8, arg, out_indices, out_values, out_shape, axis, k, max, sort, index_et);
+        NGRAPH_TYPE_CASE(evaluate_topk, u16, arg, out_indices, out_values, out_shape, axis, k, max, sort, index_et);
         NGRAPH_TYPE_CASE(evaluate_topk, u32, arg, out_indices, out_values, out_shape, axis, k, max, sort, index_et);
         NGRAPH_TYPE_CASE(evaluate_topk, u64, arg, out_indices, out_values, out_shape, axis, k, max, sort, index_et);
+        NGRAPH_TYPE_CASE(evaluate_topk, bf16, arg, out_indices, out_values, out_shape, axis, k, max, sort, index_et);
         NGRAPH_TYPE_CASE(evaluate_topk, f16, arg, out_indices, out_values, out_shape, axis, k, max, sort, index_et);
         NGRAPH_TYPE_CASE(evaluate_topk, f32, arg, out_indices, out_values, out_shape, axis, k, max, sort, index_et);
+        NGRAPH_TYPE_CASE(evaluate_topk, f64, arg, out_indices, out_values, out_shape, axis, k, max, sort, index_et);
     default:
         rc = false;
         break;


### PR DESCRIPTION
### Details:
 - *Add template plugin testcases of i8, i16, u8, u16, bf16, and f64 to op_reference/topk.cpp*
 - *Remove skip regex from skip_tests_config.cpp*
 - *Add types support to op/topk.cpp*

### Tickets:
 - *70525*
