### PR TITLE
[CPU] Migrated legacy post ops mechanism on runtime data pointers

### DIFF
--- a/src/plugins/intel_cpu/src/mkldnn_node.cpp
+++ b/src/plugins/intel_cpu/src/mkldnn_node.cpp
@@ -1076,11 +1076,27 @@ void MKLDNNNode::setDynamicBatchLim(int lim) {
 void MKLDNNNode::appendPostOpArgs(const mkldnn::primitive_attr& attr,
                                   std::unordered_map<int, mkldnn::memory>& primArgs,
                                   const std::vector<MKLDNNMemoryPtr>& postOpsArgs) {
+    constexpr size_t maxPrimArgsCapacity = 32;
     auto post_ops = attr.get_post_ops();
     int idx = 0;
     for (int i = 0; i < post_ops.len(); i++) {
         if (one_of(post_ops.kind(i), mkldnn::primitive::kind::binary, mkldnn::primitive::kind::depthwise, mkldnn::primitive::kind::quantization)) {
-            primArgs.insert({DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1, postOpsArgs[idx++]->GetPrimitive()});
+            if (idx >= postOpsArgs.size()) {
+                IE_THROW() << "Cannot initialize primitive arguments: invalid post-ops data pointers count";
+            }
+            // oneDNN has implicit limitation on number of supported post ops arguments
+            if (i >= maxPrimArgsCapacity) {
+                IE_THROW() << "Cannot initialize primitive arguments: post-ops data pointers count exceed max capacity";
+            }
+
+            primArgs[DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1] = postOpsArgs[idx++]->GetPrimitive();
+        } else if (post_ops.kind(i) == mkldnn::primitive::kind::convolution) {
+            if (idx + 1 >= postOpsArgs.size()) {
+                IE_THROW() << "Cannot initialize primitive arguments: invalid post-ops data pointers count";
+            }
+
+            primArgs[DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_WEIGHTS] = postOpsArgs[idx++]->GetPrimitive();
+            primArgs[DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_BIAS] = postOpsArgs[idx++]->GetPrimitive();
         }
     }
 }
@@ -1116,15 +1132,15 @@ Layout MKLDNNNode::getWeightsLayoutByDims(SizeVector dims, bool isGrouped) {
 }
 
 void MKLDNNNode::appendPostOps(mkldnn::post_ops& ops, const VectorDims &postOpDims, std::vector<MKLDNNMemoryPtr>& postOpsMem) {
-    IE_THROW() << "Fusing of " << this->getType() << " operation is not implemented";
+    IE_THROW() << "Fusing of " << NameFromType(this->getType()) << " operation is not implemented";
 }
 
 void MKLDNNNode::appendPostOps(mkldnn::post_ops& ops, const VectorDims &postOpDims, std::vector<const void*>& postOpsMem) {
-    IE_THROW() << "Fusing of " << this->getType() << " operation is not implemented";
+    IE_THROW() << "Fusing of " << NameFromType(this->getType()) << " operation is not implemented";
 }
 
 void MKLDNNNode::appendBinPostOps(mkldnn::post_ops& ops, const std::vector<size_t>& binaryShape, std::vector<MKLDNNMemoryPtr>& binaryPostOpsMem) {
-    IE_THROW() << "Binary fusing of " << this->getType() << " operation is not implemented";
+    IE_THROW() << "Binary fusing of " << NameFromType(this->getType()) << " operation is not implemented";
 }
 
 std::vector<InferenceEngine::Precision> MKLDNNNode::getInputPrecisions() const {

--- a/src/plugins/intel_cpu/src/mkldnn_node.h
+++ b/src/plugins/intel_cpu/src/mkldnn_node.h
@@ -182,7 +182,7 @@ public:
 
     static void appendPostOpArgs(const mkldnn::primitive_attr& attr,
                                  std::unordered_map<int, mkldnn::memory>& primArgs,
-                                 const std::vector<MKLDNNMemoryPtr>& binaryPostOpsArgs);
+                                 const std::vector<MKLDNNMemoryPtr>& postOpsArgs);
 
     bool isFusedWith(Type type) const;
 
@@ -563,7 +563,8 @@ public:
      * Seed node should call this routine and pass its post operations list as parameter.
      * @param ops List of fused post operations
      */
-    virtual void appendPostOps(mkldnn::post_ops& ops, const VectorDims& postOpDims);
+    virtual void appendPostOps(mkldnn::post_ops& ops, const VectorDims& postOpDims, std::vector<MKLDNNMemoryPtr>& postOpsMem);
+    virtual void appendPostOps(mkldnn::post_ops& ops, const VectorDims& postOpDims, std::vector<const void*>& postOpsMem);
 
     virtual void appendBinPostOps(mkldnn::post_ops& ops, const VectorDims& postOpDims, std::vector<MKLDNNMemoryPtr>& binaryPostOpsMem);
 
@@ -627,7 +628,7 @@ protected:
     std::vector<MKLDNNMemoryPtr> internalBlobMemory;
     std::vector<NodeDesc> supportedPrimitiveDescriptors;
     std::unordered_map<int, mkldnn::memory> primArgs;
-    std::vector<MKLDNNMemoryPtr> binaryPostOpsArgs;
+    std::vector<MKLDNNMemoryPtr> postOpsArgs;
     MKLDNNPrimitive prim;
     std::vector<MKLDNNDescriptor> descs;
 

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_bin_conv_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_bin_conv_node.cpp
@@ -64,7 +64,7 @@ struct jit_uni_bin_conv_kernel_f32 : public jit_uni_bin_conv_kernel, public jit_
                         this, post_op.eltwise, true, eltwise_reserved, mask_post_op_reserved));
             } else if (post_op.is_depthwise()) {
                 depthwise_injectors.push_back(new jit_uni_depthwise_injector_f32<isa>(
-                        this, post_op.depthwise.alg, mask_post_op_reserved));
+                        this, post_op, mask_post_op_reserved));
             }
         }
 
@@ -76,6 +76,7 @@ struct jit_uni_bin_conv_kernel_f32 : public jit_uni_bin_conv_kernel, public jit_
 
         mov(reg_kh, ptr[this->param1 + GET_OFF(kh_padding)]);
         mov(reg_oc_work, ptr[this->param1 + GET_OFF(oc_work)]);
+        mov(reg_post_ops_data, ptr[this->param1 + GET_OFF(post_op_data)]);
 
         mov(reg_oc_off,  ptr[param1 + GET_OFF(oc_off)]);
         mov(reg_table, l_table);
@@ -169,6 +170,7 @@ private:
     reg64_t reg_d_weights = aux_reg_input;
     reg64_t reg_d_bias = aux_reg_kernel;
     reg64_t reg_oc_off = kj;
+    reg64_t reg_post_ops_data = rbx;
     reg64_t reg_tmp2_64 = reg_oc_off;
     reg32_t reg_tmp2_32 = reg_oc_off.cvt32();
 
@@ -555,6 +557,7 @@ private:
 
             int eltwise_inj_idx = 0;
             int depthwise_inj_idx = 0;
+            int post_ops_data_offset = 0;
             int end_idx = jcp_.with_dw_conv ? p.find(primitive_kind::convolution) : p.len();
             for (int i = 0; i < end_idx; i++) {
                 int start_idx = 1 + r * jcp_.ur_w * jcp_.nb_oc_blocking;
@@ -566,26 +569,22 @@ private:
                 } else if (post_op.is_depthwise()) {
                     pop(reg_oc_off);
 
-                    mov(reg_d_weights, reinterpret_cast<size_t>(post_op.depthwise.weights_data));
-                    mov(reg_d_bias, reinterpret_cast<size_t>(post_op.depthwise.biases_data));
-
+                    mov(reg_d_weights, ptr[reg_post_ops_data + post_ops_data_offset]);
                     add(reg_d_weights, reg_oc_off);
-                    add(reg_d_bias, reg_oc_off);
 
                     if (r == 1) {
                         add(reg_d_weights, (jcp_.oc_block / 2) * sizeof(float));
-                        add(reg_d_bias, (jcp_.oc_block / 2) * sizeof(float));
                     }
 
                     for (int ii = 0; ii < oc_blocks; ii++) {
                         depthwise_injectors[depthwise_inj_idx]->compute_vector_range(start_idx + ur_w * ii,
-                                                                                     start_idx + ur_w * ii + ur_w, reg_d_weights, reg_d_bias);
+                                                                                     start_idx + ur_w * ii + ur_w, reg_d_weights, reg_d_weights);
 
                         add(reg_d_weights, jcp_.oc_block * sizeof(float));
-                        add(reg_d_bias, jcp_.oc_block * sizeof(float));
                     }
 
                     depthwise_inj_idx++;
+                    post_ops_data_offset += depthwise_injectors[depthwise_inj_idx]->memoryStep();
 
                     push(reg_oc_off);
                 } else if (post_op.is_sum(false)) {
@@ -1125,6 +1124,7 @@ bool MKLDNNBinaryConvolutionNode::canFuse(const MKLDNNNodePtr& node) const {
 void MKLDNNBinaryConvolutionNode::setPostOps(mkldnn::primitive_attr &attr) {
     mkldnn::post_ops ops;
 
+    postOpsDataPtrs.clear();
     for (auto &node : fusedWith) {
         auto* eltwiseNode = dynamic_cast<MKLDNNEltwiseNode *>(node.get());
         if (eltwiseNode) {
@@ -1132,14 +1132,14 @@ void MKLDNNBinaryConvolutionNode::setPostOps(mkldnn::primitive_attr &attr) {
                 ops.append_sum(1.0);
             } else {
                 // TODO [DS]: change to shape from memory
-                eltwiseNode->appendPostOps(ops, getOutputShapeAtPort(0).getStaticDims());
+                eltwiseNode->appendPostOps(ops, getOutputShapeAtPort(0).getStaticDims(), postOpsDataPtrs);
             }
             continue;
         }
 
         auto* fakeQuantizeNode = dynamic_cast<MKLDNNFakeQuantizeNode *>(node.get());
         if (fakeQuantizeNode) {
-            fakeQuantizeNode->appendPostOps(ops, getOutputShapeAtPort(0).getStaticDims());
+            fakeQuantizeNode->appendPostOps(ops, getOutputShapeAtPort(0).getStaticDims(), postOpsDataPtrs);
             continue;
         }
 
@@ -1193,6 +1193,7 @@ void MKLDNNBinaryConvolutionNode::executeOptimized(const uint8_t* src, const uin
         par_conv.b_overflow = i_b_overflow;
 
         par_conv.oc_off = _oc * jcp.oc_block * sizeof(float);
+        par_conv.post_op_data = postOpsDataPtrs.data();
 
         (*bin_conv_kernel)(&par_conv);
     });

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_bin_conv_node.h
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_bin_conv_node.h
@@ -50,6 +50,7 @@ struct jit_bin_conv_call_args {
     size_t t_overflow;
     size_t b_overflow;
     size_t oc_off;
+    const void** post_op_data;
 };
 
 struct jit_uni_bin_conv_kernel {
@@ -108,6 +109,7 @@ private:
     std::shared_ptr<jit_uni_bin_conv_kernel> bin_conv_kernel = nullptr;
 
     mkldnn::primitive_attr attr;
+    std::vector<const void*> postOpsDataPtrs;
 
     impl_desc_type implType = impl_desc_type::ref;
 

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_conv_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_conv_node.cpp
@@ -372,21 +372,18 @@ void MKLDNNConvolutionNode::setPostOps(mkldnn::primitive_attr &attr, const Vecto
         auto* convolutionNode = dynamic_cast<MKLDNNConvolutionNode *>(node.get());
         if (convolutionNode) {
             if (initWeights) {
+                postOpsArgs.push_back(getParentEdgeAt(getOriginalInputsNumber() + 0)->getMemoryPtr());
+                postOpsArgs.push_back(getParentEdgeAt(getOriginalInputsNumber() + 1)->getMemoryPtr());
+
                 // todo: rewrite onto append_dw_k3s2p1
                 ops.append_dw_conv(dw_conv_ih, dw_conv_iw, dw_conv_kernel[Y_AXIS], dw_conv_kernel[X_AXIS],
                                    dw_conv_strides[Y_AXIS], dw_conv_strides[X_AXIS],
-                                   mkldnn::memory::convert_to_c(dw_conv_in_dt),
-                                   static_cast<const float *>(getParentEdgeAt(
-                                           getOriginalInputsNumber() + 0)->getMemory().GetData()),
-                                   static_cast<const float *>(getParentEdgeAt(
-                                           getOriginalInputsNumber() + 1)->getMemory().GetData()));
+                                   mkldnn::memory::convert_to_c(dw_conv_in_dt));
             } else {
                 // todo: rewrite onto append_dw_k3s2p1
                 ops.append_dw_conv(dw_conv_ih, dw_conv_iw, dw_conv_kernel[Y_AXIS], dw_conv_kernel[X_AXIS],
                                    dw_conv_strides[Y_AXIS], dw_conv_strides[X_AXIS],
-                                   mkldnn::memory::convert_to_c(dw_conv_in_dt),
-                                   nullptr,
-                                   nullptr);
+                                   mkldnn::memory::convert_to_c(dw_conv_in_dt));
             }
             continue;
         }
@@ -1106,13 +1103,13 @@ void MKLDNNConvolutionNode::updatePadding() {
 
 void MKLDNNConvolutionNode::appendZeroPointsArgs() {
     if (inputZeroPointsMemPtr != nullptr) {
-        primArgs.insert({DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, inputZeroPointsMemPtr->GetPrimitive()});
+        primArgs[DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC] = inputZeroPointsMemPtr->GetPrimitive();
     }
     if (weightsZeroPointsMemPtr != nullptr) {
-        primArgs.insert({DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS, weightsZeroPointsMemPtr->GetPrimitive()});
+        primArgs[DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS] = weightsZeroPointsMemPtr->GetPrimitive();
     }
     if (outputCompensationMemPtr != nullptr) {
-        primArgs.insert({DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_DST, outputCompensationMemPtr->GetPrimitive()});
+        primArgs[DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_DST] = outputCompensationMemPtr->GetPrimitive();
     }
 }
 

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_conv_node.h
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_conv_node.h
@@ -88,7 +88,7 @@ private:
     void execute(mkldnn::stream strm) override;
     void executeDynamicImpl(mkldnn::stream strm) override;
 
-    void addZeroPoints(mkldnn::primitive_attr& attr) const;
+    void addZeroPoints(mkldnn::primitive_attr& attr);
     void setPostOps(mkldnn::primitive_attr &attr, const VectorDims &dims, bool initWeights);
     void filterSupportedDescriptors();
     bool isPossibleToSkipInitConfig(MKLDNNDescriptor &desc) const;
@@ -106,6 +106,8 @@ private:
                              const mkldnn::memory::desc& outputDesc,
                              mkldnn::algorithm alg);
     void updatePadding();
+
+    void appendZeroPointsArgs();
 
     bool withBiases;
     bool withSum;
@@ -139,6 +141,10 @@ private:
     bool isWino = false;
     AttrPtr pAttr;
     bool autoPadding = false;
+
+    MKLDNNMemoryPtr inputZeroPointsMemPtr;
+    MKLDNNMemoryPtr weightsZeroPointsMemPtr;
+    MKLDNNMemoryPtr outputCompensationMemPtr;
 };
 
 }  // namespace MKLDNNPlugin

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_deconv_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_deconv_node.cpp
@@ -126,6 +126,8 @@ MKLDNNDeconvolutionNode::MKLDNNDeconvolutionNode(const std::shared_ptr<ngraph::N
     } else {
         IE_THROW(NotImplemented) << errorMessage;
     }
+
+    attr = std::make_shared<mkldnn::primitive_attr>();
 }
 
 InferenceEngine::Blob::Ptr MKLDNNDeconvolutionNode::createWeiBlobAsIO(InferenceEngine::SizeVector dims) {
@@ -319,7 +321,7 @@ void MKLDNNDeconvolutionNode::getSupportedDescriptors() {
             createDescriptor({in_candidate}, {out_candidate});
         }
     }
-    setPostOps(attr, outShape.getStaticDims());
+    setPostOps(*attr, outShape.getStaticDims());
 }
 
 void MKLDNNDeconvolutionNode::initPaddingR(const Shape &inShape, const Shape &outShape) {
@@ -351,11 +353,11 @@ void MKLDNNDeconvolutionNode::setPostOps(mkldnn::primitive_attr &attr, const Vec
         if (auto* eltwiseNode = dynamic_cast<MKLDNNEltwiseNode *>(node.get())) {
             // TODO [DS]: change to shape from memory
             // use legacy depthwise since backprop convolution does not support binary post ops
-            eltwiseNode->appendPostOps(ops, dims);
+            eltwiseNode->appendPostOps(ops, dims, postOpsArgs);
             continue;
         }
         if (auto* fakeQuantizeNode = dynamic_cast<MKLDNNFakeQuantizeNode *>(node.get())) {
-            fakeQuantizeNode->appendBinPostOps(ops, getBinPostOpShape(), binaryPostOpsArgs);
+            fakeQuantizeNode->appendBinPostOps(ops, getBinPostOpShape(), postOpsArgs);
             continue;
         }
         IE_THROW() << "Fusing of " << NameFromType(node->getType()) << " operation to " << NameFromType(this->getType()) << " node is not implemented";
@@ -555,6 +557,18 @@ void MKLDNNDeconvolutionNode::createDeconvPrim(std::shared_ptr<MKLDNNDescriptor>
     IE_THROW() << "Primitive descriptor was not found for node " << getName() << ".";
 }
 
+MKLDNNNode::AttrPtr MKLDNNDeconvolutionNode::initPrimitiveAttr(const VectorDims &dims) {
+    auto attr = std::make_shared<mkldnn::primitive_attr>(mkldnn::primitive_attr());
+
+    setPostOps(*attr, dims);
+
+    return attr;
+}
+
+MKLDNNNode::AttrPtr MKLDNNDeconvolutionNode::initPrimitiveAttr() {
+    return attr;
+}
+
 void MKLDNNDeconvolutionNode::prepareParams() {
     auto srcMemPtr = getParentEdgesAtPort(0)[0]->getMemoryPtr();
     auto wghMemPtr = getParentEdgesAtPort(1)[0]->getMemoryPtr();
@@ -572,17 +586,10 @@ void MKLDNNDeconvolutionNode::prepareParams() {
     auto inMemoryDesc = getParentEdgesAtPort(0).front()->getMemory().GetDescWithType<DnnlMemoryDesc>();
     auto outMemoryDesc = getChildEdgesAtPort(0).front()->getMemory().GetDescWithType<DnnlMemoryDesc>();
 
-    auto initPrimitiveAttr = [&]() {
-        mkldnn::primitive_attr attr;
-        setPostOps(attr, dstMemPtr->getStaticDims());
-        return std::make_shared<mkldnn::primitive_attr>(std::move(attr));
-    };
-
     AttrPtr pAttrLocal;
-
     if (isDynamicNode()) {
         if (!pAttr) {
-            pAttr = initPrimitiveAttr();
+            pAttr = initPrimitiveAttr(dstMemPtr->getStaticDims());
         }
         pAttrLocal = pAttr;
         if (autoPad || externOutShape) {
@@ -591,7 +598,7 @@ void MKLDNNDeconvolutionNode::prepareParams() {
         }
         initPaddingR(inMemoryDesc->getShape(), outMemoryDesc->getShape());
     } else {
-        pAttrLocal = initPrimitiveAttr();
+        pAttrLocal = initPrimitiveAttr(dstMemPtr->getStaticDims());
     }
 
     const auto in_candidate = inMemoryDesc->getDnnlDesc();
@@ -627,7 +634,7 @@ void MKLDNNDeconvolutionNode::prepareParams() {
                     {DNNL_ARG_WEIGHTS, wghMemPtr->GetPrimitive()},
                     {DNNL_ARG_DIFF_SRC, dstMemPtr->GetPrimitive()}};
     }
-    MKLDNNNode::appendPostOpArgs(attr, primArgs, binaryPostOpsArgs);
+    MKLDNNNode::appendPostOpArgs(*pAttrLocal, primArgs, postOpsArgs);
 }
 
 void MKLDNNDeconvolutionNode::createPrimitive() {

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_deconv_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_deconv_node.cpp
@@ -557,7 +557,7 @@ void MKLDNNDeconvolutionNode::createDeconvPrim(std::shared_ptr<MKLDNNDescriptor>
     IE_THROW() << "Primitive descriptor was not found for node " << getName() << ".";
 }
 
-MKLDNNNode::AttrPtr MKLDNNDeconvolutionNode::initPrimitiveAttr(const VectorDims &dims) {
+MKLDNNNode::AttrPtr MKLDNNDeconvolutionNode::makePrimitiveAttr(const VectorDims &dims) {
     auto attr = std::make_shared<mkldnn::primitive_attr>(mkldnn::primitive_attr());
 
     setPostOps(*attr, dims);
@@ -589,7 +589,7 @@ void MKLDNNDeconvolutionNode::prepareParams() {
     AttrPtr pAttrLocal;
     if (isDynamicNode()) {
         if (!pAttr) {
-            pAttr = initPrimitiveAttr(dstMemPtr->getStaticDims());
+            pAttr = makePrimitiveAttr(dstMemPtr->getStaticDims());
         }
         pAttrLocal = pAttr;
         if (autoPad || externOutShape) {
@@ -598,7 +598,7 @@ void MKLDNNDeconvolutionNode::prepareParams() {
         }
         initPaddingR(inMemoryDesc->getShape(), outMemoryDesc->getShape());
     } else {
-        pAttrLocal = initPrimitiveAttr(dstMemPtr->getStaticDims());
+        pAttrLocal = makePrimitiveAttr(dstMemPtr->getStaticDims());
     }
 
     const auto in_candidate = inMemoryDesc->getDnnlDesc();

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_deconv_node.h
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_deconv_node.h
@@ -57,7 +57,7 @@ public:
 
 protected:
     AttrPtr initPrimitiveAttr() override;
-    AttrPtr initPrimitiveAttr(const VectorDims& dims);
+    AttrPtr makePrimitiveAttr(const VectorDims& dims);
 
 private:
     using executorPtr = std::shared_ptr<DnnlExecutor>;

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_deconv_node.h
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_deconv_node.h
@@ -55,6 +55,10 @@ public:
 
     void setDynamicBatchLim(int lim) override;
 
+protected:
+    AttrPtr initPrimitiveAttr() override;
+    AttrPtr initPrimitiveAttr(const VectorDims& dims);
+
 private:
     using executorPtr = std::shared_ptr<DnnlExecutor>;
     executorPtr execPtr = nullptr;
@@ -98,7 +102,7 @@ private:
 
     AttrPtr pAttr;
 
-    mkldnn::primitive_attr attr;
+    std::shared_ptr<mkldnn::primitive_attr> attr;
     void setPostOps(mkldnn::primitive_attr &attr, const VectorDims &dims);
 
     VectorDims shapeInferInternal(const VectorDims &inDims, std::vector<int32_t> outSpDims) const;

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_eltwise_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_eltwise_node.cpp
@@ -1907,6 +1907,7 @@ void MKLDNNEltwiseNode::prepareParams() {
 
     EltwiseKey key = {{thisOp}, {getType()}, currentOutBlkDims, outOrder, dims_in, inpPrc, outPrc, mkldnn::post_ops(), isDynBatchEnabled, canUseOptimizedImpl};
 
+    fqDataPtrs.clear();
     for (const auto &node : fusedWith) {
         key.ops_list.push_back(node->getType());
         if (node->getType() == Eltwise) {
@@ -1915,23 +1916,11 @@ void MKLDNNEltwiseNode::prepareParams() {
                                             eltwise->getBeta(), eltwise->getGamma()});
             }
         } else if (node->getType() == FakeQuantize) {
-            node->appendPostOps(key.postOps, {});
+            node->appendPostOps(key.postOps, {}, fqDataPtrs);
         } else {
             IE_THROW(Unexpected) << "Eltwise node with name '" << getName() << "' has unexpected fused op of type '" << node->getTypeStr() << "'";
         }
     }
-
-    // TODO: we need to rewrite quantization_t to remove the pointers from its content and update all the jit kernels at once
-    // together with the corresponding appendPostOps method to pass the scales and shifts pointers at runtime.
-    // Until then we have to read them from the quantization_t directly, store them somewhere
-    // and nullify them to get read of the address dependency in the key structure
-    fqDataPtrs.clear();
-    for (int i = 0; i < key.postOps.len(); ++i) {
-        auto &data = key.postOps.get()->entry_[i].quantization.data;
-        fqDataPtrs.insert(fqDataPtrs.end(), std::begin(data), std::end(data));
-        memset(data, 0, sizeof(data));
-    }
-    // end of TODO
 
     auto cache = getRuntimeCache();
     auto result = cache->getOrCreate(key, buildExecutor);
@@ -2038,7 +2027,22 @@ void MKLDNNEltwiseNode::fuseInto(MKLDNNNodePtr& parentNode) {
     MKLDNNNode::fuseInto(parentNode);
 }
 
-void MKLDNNEltwiseNode::appendPostOps(mkldnn::post_ops& ops, const VectorDims &postOpDims) {
+void MKLDNNEltwiseNode::appendMemory(const std::vector<float> &data, MKLDNNMemoryPtr &memPtr, std::vector<MKLDNNMemoryPtr>& postOpsMem) {
+    if (!memPtr) {
+        memPtr.reset(new MKLDNNMemory(getEngine()));
+        DnnlBlockedMemoryDesc memoryDesc(Precision::FP32, {data.size()});
+        memPtr->Create(memoryDesc, data.data());
+
+        postOpsMem.push_back(memPtr);
+    }
+}
+
+void MKLDNNEltwiseNode::appendMemory(const std::vector<float> &data, MKLDNNMemoryPtr &memPtr, std::vector<const void*>& postOpsMem) {
+    postOpsMem.push_back(data.data());
+}
+
+template <typename T>
+void MKLDNNEltwiseNode::appendPostOpsImpl(mkldnn::post_ops& ops, const VectorDims &postOpDims, std::vector<T>& postOpsMem) {
     const std::string errorPrefix = "Appending Eltwise node with name '" + getName() + "' ";
 
     if (getMKLDNNAlgorithm() != mkldnn::algorithm::undef) {
@@ -2069,11 +2073,31 @@ void MKLDNNEltwiseNode::appendPostOps(mkldnn::post_ops& ops, const VectorDims &p
         }
     } else {
         const size_t chIdx = postOpDims.size() > 1 ? getFusingAxis() : 0;
-        constexpr int align = 16; // always align for legacy scale/shift post ops
-        scalesBuffer = makeAlignedBuffer(postOpDims[chIdx], scales, align);
-        if (getAlgorithm() != EltwisePrelu) {
-            shiftsBuffer = makeAlignedBuffer(postOpDims[chIdx], shifts, align);
+        constexpr int bufferAlignment = 16; // always align for legacy scale/shift post ops
+        // since legacy depthwise post ops mechanism requires broadcasted data we need to reinitilize it in case of changed shape
+        if (depthwiseData.empty() || depthwiseDataSize != 2 * postOpDims[chIdx]) {
+            depthwiseData.clear();
+            depthwiseMemory.reset();
+
+            depthwiseData.insert(depthwiseData.end(), scales.begin(), scales.end());
+            if (scales.size() == 1) {
+                depthwiseData.resize(postOpDims[chIdx], depthwiseData.back());
+            }
+            depthwiseData.insert(depthwiseData.end(), shifts.begin(), shifts.end());
+            if (shifts.size() == 1) {
+                depthwiseData.resize(2 * postOpDims[chIdx], depthwiseData.back());
+            }
+            depthwiseDataSize = 2 * postOpDims[chIdx];
+
+            depthwiseData.resize(rnd_up(depthwiseData.size(), bufferAlignment), 0);
         }
+
+        if (depthwiseData.empty())
+            IE_THROW() << errorPrefix << "cannot be performed since buffers are not allocated";
+
+        std::array<size_t, 2> offsets = {0};
+        offsets[1] = offsets[0] + postOpDims[chIdx];
+
         /* @todo legacy depthwise post ops are kept for now
          * for performance reasons
          */
@@ -2084,19 +2108,25 @@ void MKLDNNEltwiseNode::appendPostOps(mkldnn::post_ops& ops, const VectorDims &p
         case EltwiseDivide:
         case EltwiseMulAdd:
         case EltwisePowerStatic:
-            if (scales.empty() || shifts.empty())
-                IE_THROW() << errorPrefix << "cannot be performed since buffers are not allocated";
-            ops.append_depthwise(mkldnn::algorithm::depthwise_scale_shift, &scalesBuffer[0], &shiftsBuffer[0]);
+            ops.append_depthwise(mkldnn::algorithm::depthwise_scale_shift, offsets);
             break;
         case EltwisePrelu:
-            if (scales.empty())
-                IE_THROW() << errorPrefix << "cannot be performed since buffers are not allocated";
-            ops.append_depthwise(mkldnn::algorithm::depthwise_prelu, &scalesBuffer[0], nullptr);
+            ops.append_depthwise(mkldnn::algorithm::depthwise_prelu, offsets);
             break;
         default:
             IE_THROW() << errorPrefix << "as post operation is not supported";
         }
+
+        appendMemory(depthwiseData, depthwiseMemory, postOpsMem);
     }
+}
+
+void MKLDNNEltwiseNode::appendPostOps(mkldnn::post_ops& ops, const VectorDims &postOpDims, std::vector<MKLDNNMemoryPtr>& postOpsMem) {
+    appendPostOpsImpl(ops, postOpDims, postOpsMem);
+}
+
+void MKLDNNEltwiseNode::appendPostOps(mkldnn::post_ops& ops, const VectorDims &postOpDims, std::vector<const void*>& postOpsMem) {
+    appendPostOpsImpl(ops, postOpDims, postOpsMem);
 }
 
 void MKLDNNEltwiseNode::appendBinPostOps(mkldnn::post_ops& ops, const VectorDims& postOpDims, std::vector<MKLDNNMemoryPtr>& binaryPostOpsMem) {

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_eltwise_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_eltwise_node.cpp
@@ -2082,10 +2082,17 @@ void MKLDNNEltwiseNode::appendPostOpsImpl(mkldnn::post_ops& ops, const VectorDim
             depthwiseData.insert(depthwiseData.end(), scales.begin(), scales.end());
             if (scales.size() == 1) {
                 depthwiseData.resize(postOpDims[chIdx], depthwiseData.back());
+            } else if (scales.size() != postOpDims[chIdx]) {
+                IE_THROW() << errorPrefix << "failed due to scales data size inconsistency";
             }
             depthwiseData.insert(depthwiseData.end(), shifts.begin(), shifts.end());
-            if (shifts.size() == 1) {
+            if (shifts.empty()) {
+                // in case of Prelu algorithm scales data is always empty
+                depthwiseData.resize(2 * postOpDims[chIdx], 0);
+            } else if (shifts.size() == 1) {
                 depthwiseData.resize(2 * postOpDims[chIdx], depthwiseData.back());
+            } else if (shifts.size() != postOpDims[chIdx]) {
+                IE_THROW() << errorPrefix << "failed due to shifts data size inconsistency";
             }
             depthwiseDataSize = 2 * postOpDims[chIdx];
 

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_eltwise_node.h
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_eltwise_node.h
@@ -97,7 +97,8 @@ public:
     bool created() const override;
     bool canBeInPlace() const override;
     bool canFuse(const MKLDNNNodePtr& node) const override;
-    void appendPostOps(mkldnn::post_ops& ops, const VectorDims &postOpDims) override;
+    void appendPostOps(mkldnn::post_ops& ops, const VectorDims &postOpDims, std::vector<MKLDNNMemoryPtr>& postOpsMem) override;
+    void appendPostOps(mkldnn::post_ops& ops, const VectorDims &postOpDims, std::vector<const void*>& postOpsMem) override;
     void appendBinPostOps(mkldnn::post_ops& ops, const VectorDims &postOpDims, std::vector<MKLDNNMemoryPtr>& binaryPostOpsMem) override;
     void fuseInto(MKLDNNNodePtr& parentNode) override;
     InferenceEngine::Precision getRuntimePrecision() const override;
@@ -105,8 +106,7 @@ public:
     float getAlpha() const { return alpha; }
     float getBeta() const { return beta; }
     float getGamma() const { return gamma; }
-    MKLDNNMemoryPtr scalesMemory;
-    MKLDNNMemoryPtr shiftsMemory;
+
     mkldnn::algorithm getMKLDNNAlgorithm() const { return mkldnnAlgorithm; }
 
     bool isWithBroadcast();
@@ -130,7 +130,6 @@ public:
 
     static bool isSupportedOperation(const std::shared_ptr<const ngraph::Node>& op, std::string& errorMessage) noexcept;
 
-
 private:
     executorPtr execPtr = nullptr;
     BroadcastingPolicy broadcastingPolicy;
@@ -153,8 +152,12 @@ private:
 
     std::vector<float> scales = {};
     std::vector<float> shifts = {};
-    std::vector<float> scalesBuffer = {};
-    std::vector<float> shiftsBuffer = {};
+    MKLDNNMemoryPtr scalesMemory;
+    MKLDNNMemoryPtr shiftsMemory;
+
+    std::vector<float> depthwiseData = {};
+    MKLDNNMemoryPtr depthwiseMemory;
+    size_t depthwiseDataSize = 0;
 
     std::vector<MKLDNNMemoryPtr> memPtrs = {};
     std::vector<const void*> fqDataPtrs;
@@ -165,6 +168,12 @@ private:
     static BroadcastingPolicy determineBroadcastingPolicy(const std::shared_ptr<ngraph::Node>& op);
 
     size_t getOpInputsNum() const;
+
+    template <typename T>
+    void appendPostOpsImpl(mkldnn::post_ops& ops, const VectorDims &postOpDims, std::vector<T>& postOpsMem);
+
+    void appendMemory(const std::vector<float> &data, MKLDNNMemoryPtr &memPtr, std::vector<MKLDNNMemoryPtr>& postOpsMem);
+    void appendMemory(const std::vector<float> &data, MKLDNNMemoryPtr &memPtr, std::vector<const void*>& postOpsMem);
 };
 
 }  // namespace MKLDNNPlugin

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_fake_quantize_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_fake_quantize_node.cpp
@@ -1763,21 +1763,99 @@ void MKLDNNFakeQuantizeNode::initializePostOpData(const VectorDims &dims, const 
     isPostOpDataInitialized = true;
 }
 
-void MKLDNNFakeQuantizeNode::appendPostOps(mkldnn::post_ops& ops, const VectorDims &postOpDims) {
+void MKLDNNFakeQuantizeNode::initializePostOpDataLegacy(const VectorDims &dims, const size_t bufferAlignment) {
+    if (isPostOpDataInitialized)
+        return;
+
+    if (getAlgorithm() == FQBinarization) {
+        const auto realAxisSize = dims[dims.size() > 1 ? 1 : 0];
+        const auto axisPaddedSize = rnd_up(realAxisSize, bufferAlignment);
+        if (!isPostOpDataInitialized) {
+            binarizationThresholds.resize(axisPaddedSize, 0);
+            binarizationOutputMask.resize(axisPaddedSize, 0);
+
+            if (isInputLowBroadcasted) {
+                std::fill(binarizationThresholds.begin() + 1, binarizationThresholds.begin() + realAxisSize, binarizationThresholds[0]);
+                std::fill(binarizationThresholds.begin() + realAxisSize, binarizationThresholds.end(), 0);
+            }
+            if (isOutputHighBroadcasted) {
+                std::fill(binarizationOutputMask.begin() + 1, binarizationOutputMask.begin() + realAxisSize, binarizationOutputMask[0]);
+                std::fill(binarizationThresholds.begin() + realAxisSize, binarizationThresholds.end(), 0);
+            }
+        }
+    } else {
+        quantizationData.insert(quantizationData.end(), cropLow.begin(), cropLow.end());
+        quantizationData.insert(quantizationData.end(), cropHigh.begin(), cropHigh.end());
+        quantizationData.insert(quantizationData.end(), inputScale.begin(), inputScale.end());
+        quantizationData.insert(quantizationData.end(), inputShift.begin(), inputShift.end());
+        quantizationData.insert(quantizationData.end(), outputScale.begin(), outputScale.end());
+        quantizationData.insert(quantizationData.end(), outputShift.begin(), outputShift.end());
+        quantizationDataSize = quantizationData.size();
+        quantizationData.resize(rnd_up(quantizationData.size(), bufferAlignment), 0);
+    }
+
+    isPostOpDataInitialized = true;
+}
+
+void MKLDNNFakeQuantizeNode::appendMemory(const size_t dataSize, const void *data, MKLDNNMemoryPtr &memPtr, std::vector<MKLDNNMemoryPtr>& postOpsMem) {
+    if (!memPtr) {
+        memPtr.reset(new MKLDNNMemory(getEngine()));
+        DnnlBlockedMemoryDesc memoryDesc(Precision::FP32, {dataSize});
+        memPtr->Create(memoryDesc, data);
+
+        postOpsMem.push_back(memPtr);
+    }
+}
+
+void MKLDNNFakeQuantizeNode::appendMemory(const size_t dataSize, const void *data, MKLDNNMemoryPtr &memPtr, std::vector<const void*>& postOpsMem) {
+    postOpsMem.push_back(data);
+}
+
+template <typename T>
+void MKLDNNFakeQuantizeNode::appendPostOpsImpl(mkldnn::post_ops& ops, const VectorDims &postOpDims, std::vector<T>& postOpsMem) {
     // MKLDNN quantization_injectors assumes that quantization data memory is always aligned on 16
     // by length of AVX512 vector register which is also enough for AVX2 and SSE42 implementations.
     // Otherwise it can lead to buffer over-read and performance penalties due to denormals.
     const size_t bufferAlignment = 16;
 
-    initializePostOpData(postOpDims, bufferAlignment);
+    initializePostOpDataLegacy(postOpDims, bufferAlignment);
 
     if (getAlgorithm() == FQBinarization) {
         ops.append_binarization(mkldnn::algorithm::binarization_depthwise, (const float*)&binarizationThresholds[0], (const float*)&binarizationOutputMask[0]);
     } else {
         mkldnn::algorithm alg = getAlgorithm() == FQCommon ? mkldnn::algorithm::quantization_quantize_dequantize :
                                                              mkldnn::algorithm::quantization_quantize;
-        ops.append_quantization(alg, &cropLowData, &cropHighData, &inputScaleData, &inputShiftData, &outputScaleData, &outputShiftData);
+
+        std::array<bool, 6> per_channel = {cropLowSize > 1, cropHighSize > 1, inputScaleSize > 1,
+                                           inputShiftSize > 1, outputScaleSize > 1, outputShiftSize > 1};
+
+        std::array<bool, 6> all_default = {false};
+        all_default[0] = std::all_of(cropLow.cbegin(), cropLow.cend(), [](float val){ return val == 0.f; });
+        all_default[1] = std::all_of(cropHigh.cbegin(), cropHigh.cend(), [](float val){ return val == 0.f; });
+        all_default[2] = std::all_of(inputScale.cbegin(), inputScale.cend(), [](float val){ return val == 1.f; });
+        all_default[3] = std::all_of(inputShift.cbegin(), inputShift.cend(), [](float val){ return val == 0.f; });
+        all_default[4] = std::all_of(outputScale.cbegin(), outputScale.cend(), [](float val){ return val == 1.f; });
+        all_default[5] = std::all_of(outputShift.cbegin(), outputShift.cend(), [](float val){ return val == 0.f; });
+
+        std::array<size_t, 6> offsets = {0};
+        offsets[1] = offsets[0] + cropLowSize;
+        offsets[2] = offsets[1] + cropHighSize;
+        offsets[3] = offsets[2] + inputScaleSize;
+        offsets[4] = offsets[3] + inputShiftSize;
+        offsets[5] = offsets[4] + outputScaleSize;
+
+        ops.append_quantization(alg, per_channel, all_default, offsets);
+
+        appendMemory(quantizationDataSize, quantizationData.data(), quantizationMemory, postOpsMem);
     }
+}
+
+void MKLDNNFakeQuantizeNode::appendPostOps(mkldnn::post_ops& ops, const VectorDims &postOpDims, std::vector<MKLDNNMemoryPtr>& postOpsMem) {
+    appendPostOpsImpl(ops, postOpDims, postOpsMem);
+}
+
+void MKLDNNFakeQuantizeNode::appendPostOps(mkldnn::post_ops& ops, const VectorDims &postOpDims, std::vector<const void*>& postOpsMem) {
+    appendPostOpsImpl(ops, postOpDims, postOpsMem);
 }
 
 void MKLDNNFakeQuantizeNode::appendBinPostOps(mkldnn::post_ops& ops, const VectorDims& postOpDims, std::vector<MKLDNNMemoryPtr>& binaryPostOpsMem) {

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_fullyconnected_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_fullyconnected_node.cpp
@@ -307,7 +307,7 @@ void MKLDNNFullyConnectedNode::prepareParams() {
         primArgs[DNNL_ARG_BIAS] = biasMemPtr->GetPrimitive();
     }
 
-    appendPostOpArgs(*attr, primArgs, binaryPostOpsArgs);
+    appendPostOpArgs(*attr, primArgs, postOpsArgs);
 
     auto reshapeMemory = [this](int argType) {
         auto param = primArgs.find(argType);
@@ -393,15 +393,15 @@ void MKLDNNFullyConnectedNode::setPostOps(mkldnn::primitive_attr &attr, const Ve
 
     for (auto &node : fusedWith) {
         if (auto* fakeQuantizeNode = dynamic_cast<MKLDNNFakeQuantizeNode *>(node.get())) {
-            fakeQuantizeNode->appendBinPostOps(ops, getBinPostOpShape(), binaryPostOpsArgs);
+            fakeQuantizeNode->appendBinPostOps(ops, getBinPostOpShape(), postOpsArgs);
             continue;
         }
 
         if (auto* eltwiseNode = dynamic_cast<MKLDNNEltwiseNode *>(node.get())) {
             if (eltwiseNode->getMKLDNNAlgorithm() != mkldnn::algorithm::undef) {
-                eltwiseNode->appendPostOps(ops, dims);
+                eltwiseNode->appendPostOps(ops, dims, postOpsArgs);
             } else {
-                eltwiseNode->appendBinPostOps(ops, getBinPostOpShape(), binaryPostOpsArgs);
+                eltwiseNode->appendBinPostOps(ops, getBinPostOpShape(), postOpsArgs);
             }
             continue;
         }

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_interpolate_node.h
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_interpolate_node.h
@@ -226,7 +226,7 @@ private:
             std::vector<float> dataScales;
     };
 
-    void setPostOps(mkldnn::primitive_attr &attr, const VectorDims &dims, bool initWeights = false);
+    void setPostOps(mkldnn::primitive_attr &attr, const VectorDims &dims);
 
     static SizeVector getPaddedInputShape(const VectorDims &srcDims, const std::vector<int> &padBegin, const std::vector<int> &padEnd);
     std::vector<float> getScales(const VectorDims &srcDimPad, const VectorDims &dstDim);

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_matmul_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_matmul_node.cpp
@@ -156,13 +156,13 @@ void MKLDNNMatMulNode::setPostOps(mkldnn::primitive_attr &attr, const VectorDims
     for (const auto &node : fusedWith) {
         if (auto* eltwiseNode = dynamic_cast<MKLDNNEltwiseNode *>(node.get())) {
             if (eltwiseNode->getMKLDNNAlgorithm() != mkldnn::algorithm::undef) {
-                eltwiseNode->appendPostOps(ops, dims);
+                eltwiseNode->appendPostOps(ops, dims, postOpsArgs);
             } else {
-                eltwiseNode->appendBinPostOps(ops, getBinPostOpShape(), binaryPostOpsArgs);
+                eltwiseNode->appendBinPostOps(ops, getBinPostOpShape(), postOpsArgs);
             }
             continue;
         } else if (auto* fakeQuantizeNode = dynamic_cast<MKLDNNFakeQuantizeNode *>(node.get())) {
-            fakeQuantizeNode->appendBinPostOps(ops, getBinPostOpShape(), binaryPostOpsArgs);
+            fakeQuantizeNode->appendBinPostOps(ops, getBinPostOpShape(), postOpsArgs);
             continue;
         }
 
@@ -560,7 +560,7 @@ void MKLDNNMatMulNode::prepareParams() {
     if (withBiases)
         primArgs[DNNL_ARG_BIAS] = getParentEdgeAt(2)->getMemoryPtr()->GetPrimitive();
 
-    appendPostOpArgs(*attr, primArgs, binaryPostOpsArgs);
+    appendPostOpArgs(*attr, primArgs, postOpsArgs);
 }
 
 void MKLDNNMatMulNode::executeDynamicImpl(dnnl::stream strm) {

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_normalize_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_normalize_node.cpp
@@ -220,7 +220,7 @@ struct jit_uni_normalize_kernel_f32 : public jit_uni_normalize_kernel, public ji
                         this, post_op.eltwise.alg, post_op.eltwise.alpha, post_op.eltwise.beta, post_op.eltwise.scale));
             } else if (post_op.is_depthwise()) {
                 depthwise_injectors.push_back(std::make_shared<jit_uni_depthwise_injector_f32<isa>>(
-                        this, post_op.depthwise.alg));
+                        this, post_op));
             } else if (post_op.is_quantization()) {
                 quantization_injectors.push_back(std::make_shared<jit_uni_quantization_injector_f32<isa>>(
                         this, post_op, vmm_d_weights, vmm_d_bias, reg_d_weights, reg_d_bias));
@@ -658,15 +658,13 @@ private:
                         || depthwise_injectors[depthwise_inj_idx] == nullptr)
                     assert(!"Invalid depthwise injectors.");
                 mov(reg_d_weights, ptr[reg_post_ops_data + post_ops_data_offset]);
-                post_ops_data_offset += sizeof(void*);
-
-                mov(reg_d_bias, ptr[reg_post_ops_data + post_ops_data_offset]);
-                post_ops_data_offset += sizeof(void*);
-
                 add(reg_d_weights, reg_oc_off);
-                add(reg_d_bias, reg_oc_off);
+
                 // weight and bias is padding. scalar as vector.
-                depthwise_injectors[depthwise_inj_idx]->compute_vector_range(vmm_val.getIdx(), vmm_val.getIdx() + 1, reg_d_weights, reg_d_bias, is_broadcast);
+                depthwise_injectors[depthwise_inj_idx]->compute_vector_range(
+                        vmm_val.getIdx(), vmm_val.getIdx() + 1, reg_d_weights, reg_d_weights, is_broadcast);
+
+                post_ops_data_offset += depthwise_injectors[depthwise_inj_idx]->memoryStep();
                 depthwise_inj_idx++;
             } else if (post_op.is_quantization()) {
                 if (quantization_injectors.size() <= quantization_inj_idx
@@ -853,16 +851,17 @@ bool MKLDNNNormalizeL2Node::canFuse(const MKLDNNNodePtr& node) const {
 void MKLDNNNormalizeL2Node::setPostOps(mkldnn::primitive_attr& kernel_attrs, const VectorDims& dims, bool initWeights) {
     mkldnn::post_ops ops;
 
+    postOpsDataPtrs.clear();
     for (auto &node : fusedWith) {
         auto* fakeQuantizeNode = dynamic_cast<MKLDNNFakeQuantizeNode *>(node.get());
         if (fakeQuantizeNode) {
-            fakeQuantizeNode->appendPostOps(ops);
+            fakeQuantizeNode->appendPostOps(ops, {}, postOpsDataPtrs);
             continue;
         }
 
         auto* eltwiseNode = dynamic_cast<MKLDNNEltwiseNode *>(node.get());
         if (eltwiseNode) {
-            eltwiseNode->appendPostOps(ops, dims);
+            eltwiseNode->appendPostOps(ops, dims, postOpsDataPtrs);
             continue;
         }
 
@@ -911,26 +910,6 @@ void MKLDNNNormalizeL2Node::prepareParams() {
     const auto& dims = getParentEdgeAt(DATA)->getMemoryPtr()->getStaticDims();
 
     setPostOps(kernel_attrs, dims, true);
-
-    // move pointer address from compile time kernel_attrs into runtime kernel args
-    // and clear pointer address to remove it from cache key
-    auto &postOps = (*kernel_attrs.get()).post_ops_;
-    postOpsDataPtrs.clear();
-    for (int i = 0; i < postOps.len(); ++i) {
-        auto &post_op = postOps.entry_[i];
-        if (post_op.is_quantization()) {
-            auto &data = post_op.quantization.data;
-            postOpsDataPtrs.insert(postOpsDataPtrs.end(), std::begin(data), std::end(data));
-            memset(data, 0, sizeof(data));
-        } else if (post_op.is_depthwise()) {
-            auto &weights = post_op.depthwise.weights_data;
-            auto &biases = post_op.depthwise.biases_data;
-            postOpsDataPtrs.push_back(weights);
-            postOpsDataPtrs.push_back(biases);
-            weights = 0;
-            biases = 0;
-        }
-    }
 
     NormalizeKey key = {attrs, kernel_attrs, dims};
 
@@ -1444,12 +1423,14 @@ private:
                 dst_value = eltwise_injectors_ref[eltwise_inj_idx]->compute_scalar(dst_value);
                 eltwise_inj_idx++;
             } else if (post_op.is_depthwise()) {
-                auto depthwise_weights = post_ops_data[0] + index_c;
-                auto depthwise_bias = post_ops_data[1] + index_c;
-                post_ops_data += 2;
+                auto depthwise_base = *post_ops_data;
+                auto depthwise_weights = depthwise_base + post_op.depthwise.offset[post_op.depthwise.scales] + index_c;
+                auto depthwise_bias = depthwise_base + post_op.depthwise.offset[post_op.depthwise.shifts] + index_c;
 
                 dst_value = depthwise_injectors_ref[depthwise_inj_idx]->compute_scalar(dst_value, depthwise_weights, depthwise_bias);
+
                 depthwise_inj_idx++;
+                post_ops_data++;
             } else if (post_op.is_quantization()) {
                 bool do_dequantization = post_op.quantization.alg == alg_kind::quantization_quantize_dequantize;
                 bool do_rounding = do_dequantization || attrs.output_prec == Precision::FP32 || i != p.len() - 1;
@@ -1458,8 +1439,9 @@ private:
 
                 using quantization_fields = post_ops_t::entry_t::quantization_t::quantization_fields;
                 auto dataVal = [&](const quantization_fields& field) -> float {
+                    auto dataPtr = *post_ops_data + post_op.quantization.offset[field];
                     const int channelIdx = quant.per_channel[field] ? index_c : 0;
-                    return post_ops_data[field][channelIdx];
+                    return dataPtr[channelIdx];
                 };
 
                 float crop_low = dataVal(quant.crop_low);
@@ -1480,7 +1462,7 @@ private:
                     dst_value = dst_value * output_scale + output_shift;
                 }
 
-                post_ops_data += quant.fields_count;
+                post_ops_data++;
             }
         }
     }

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_pooling_node.h
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_pooling_node.h
@@ -36,7 +36,7 @@ protected:
     AttrPtr initPrimitiveAttr() override;
 
 private:
-    void setPostOps(mkldnn::primitive_attr &attr, bool initWeights = false) const;
+    void setPostOps(mkldnn::primitive_attr &attr);
 
     void initEffectiveAttributes(const Shape &inDims, const Shape &outDims);
     mkldnn::algorithm getPoolingAlgorithm() const;

--- a/src/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
+++ b/src/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
@@ -160,6 +160,8 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*CTCLossLayerCPUTest.*ctcMergeRepeated=1.*)",
         // Issue: 71756
         R"(.*Deconv_.*D_(Blocked|DW|1x1)_.*DeconvolutionLayerCPUTest\.CompareWithRefs.*inFmts=(nChw16c|nCdhw16c)_outFmts=(nChw16c|nCdhw16c)_primitive=jit_avx512_.*Fused=Multiply\(PerChannel\)\.Add\(PerChannel\).*)",
+        R"(.*Deconv_.*D_(Blocked|DW|1x1)_.*DeconvolutionLayerCPUTest\.CompareWithRefs.*inFmts=(nChw8c|nCdhw8c)_outFmts=(nChw8c|nCdhw8c)_primitive=jit_avx2_.*Fused=Multiply\(PerChannel\)\.Add\(PerChannel\).*)",
+        R"(.*Deconv_.*D_(Blocked|1x1)_.*DeconvolutionLayerCPUTest\.CompareWithRefs.*inFmts=(nChw8c|nCdhw8c)_outFmts=(nChw8c|nCdhw8c)_primitive=jit_avx2.*)",
         R"(.*smoke_GroupDeconv_(2|3)D_Blocked_BF16.*S=(\(2\.2\)|\(2\.2\.2\))_PB=(\(0\.0\)|\(0\.0\.0\))_PE=(\(0\.0\)|\(0\.0\.0\))_D=(\(1\.1\)|\(1\.1\.1\))_.*_O=64_G=4.*)",
         // Issue: 59594
         R"(smoke_ConversionLayerTest/ConversionLayerTest.CompareWithRefs.*BOOL.*)",

--- a/src/tests/functional/plugin/cpu/single_layer_tests/convolution.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/convolution.cpp
@@ -203,7 +203,7 @@ const std::vector<fusingSpecificParams> fusingParamsSet{
         emptyFusingSpec,
         // eltwise
         fusingRelu,
-        fusingPRelu1D,
+        fusingPRelu1DScaleShift,
         // depthwise
         fusingReluScaleShift,
         // fake quantize
@@ -221,7 +221,7 @@ const std::vector<fusingSpecificParams> fusingParamsSetBF16{
         // eltwise
         fusingRelu,
         // depthwise
-        fusingReluScaleShift,
+        fusingPRelu1DScaleShift,
         // sum
         fusingSum,
         // bias

--- a/src/tests/functional/plugin/cpu/single_layer_tests/convolution_backprop_data.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/convolution_backprop_data.cpp
@@ -513,7 +513,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Deconv_2D_Blocked_FP32, DeconvolutionLayerCPUTest
         ::testing::ValuesIn(Blocked_2D_inputs_smoke),
         ::testing::Values(ElementType::f32),
         ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D})),
+        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D, conv_avx2_2D})),
         ::testing::Values(cpuEmptyPluginConfig)),
     DeconvolutionLayerCPUTest::getTestCaseName);
 
@@ -533,7 +533,7 @@ INSTANTIATE_TEST_SUITE_P(nightly_Deconv_2D_Blocked_FP32, DeconvolutionLayerCPUTe
         ::testing::ValuesIn(Blocked_2D_inputs_nightly),
         ::testing::Values(ElementType::f32),
         ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D})),
+        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D, conv_avx2_2D})),
         ::testing::Values(cpuEmptyPluginConfig)),
     DeconvolutionLayerCPUTest::getTestCaseName);
 
@@ -648,7 +648,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Deconv_2D_1x1_FP32, DeconvolutionLayerCPUTest,
         ::testing::ValuesIn(Blocked_2D_inputs_smoke),
         ::testing::Values(ElementType::f32),
         ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D_1x1})),
+        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D_1x1, conv_avx2_2D_1x1})),
         ::testing::Values(cpuEmptyPluginConfig)),
     DeconvolutionLayerCPUTest::getTestCaseName);
 
@@ -658,7 +658,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Deconv_2D_1x1_BF16, DeconvolutionLayerCPUTest,
         ::testing::ValuesIn(Blocked_2D_inputs_smoke),
         ::testing::Values(ElementType::f32),
         ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D_1x1})),
+        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D_1x1, conv_avx2_2D_1x1})),
         ::testing::Values(cpuBF16PluginConfig)),
     DeconvolutionLayerCPUTest::getTestCaseName);
 

--- a/src/tests/functional/plugin/cpu/single_layer_tests/group_convolution_backprop_data.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/group_convolution_backprop_data.cpp
@@ -526,7 +526,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_2D_Blocked_FP32, GroupDeconvolutionLa
         ::testing::ValuesIn(Blocked_2D_inputs_smoke),
         ::testing::Values(ElementType::f32),
         ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D})),
+        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D, conv_avx2_2D})),
         ::testing::Values(cpuEmptyPluginConfig)),
     GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
@@ -546,7 +546,7 @@ INSTANTIATE_TEST_SUITE_P(nightly_GroupDeconv_2D_Blocked_FP32, GroupDeconvolution
         ::testing::ValuesIn(Blocked_2D_inputs_nightly),
         ::testing::Values(ElementType::f32),
         ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D})),
+        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D, conv_avx2_2D})),
         ::testing::Values(cpuEmptyPluginConfig)),
     GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
@@ -694,7 +694,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_2D_DW_FP32, GroupDeconvolutionLayerCP
         ::testing::ValuesIn(dw_2D_inputs_smoke),
         ::testing::Values(ElementType::f32),
         ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_dw_2D})),
+        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_dw_2D, conv_avx2_dw_2D})),
         ::testing::Values(cpuEmptyPluginConfig)),
     GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
@@ -714,7 +714,7 @@ INSTANTIATE_TEST_SUITE_P(nightly_GroupDeconv_2D_DW_FP32, GroupDeconvolutionLayer
         ::testing::ValuesIn(dw_2D_inputs_nightly),
         ::testing::Values(ElementType::f32),
         ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_dw_2D})),
+        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_dw_2D, conv_avx2_dw_2D})),
         ::testing::Values(cpuEmptyPluginConfig)),
     GroupDeconvolutionLayerCPUTest::getTestCaseName);
 


### PR DESCRIPTION
### Details:
 - Currently post ops mechanism for depthwise and quantization operations assumes const data pointers are included into generated JIT code. This behavior makes impossible to use executor caching for Convolution and Deconvolution operations. The PR reworks post ops mechanism behavior to switch on runtime data pointers usage.
 - Additionally zero points attributes is reworked accrdingly to enable caching for INT8 Convolutions
 - oneDNN fork PR: https://github.com/openvinotoolkit/oneDNN/pull/110
### Tickets:
 - CVS-77102

### Leftovers
- [x] Update post ops for AMX primitives
- [x] Update post ops for Conv + DW fusing impl
- [x] Update post ops for Binary Convolution kernel