### PR TITLE
[GPU] Fix dependencies list in fused primitive descriptor

### DIFF
--- a/src/plugins/intel_gpu/src/graph/include/program_node.h
+++ b/src/plugins/intel_gpu/src/graph/include/program_node.h
@@ -64,7 +64,7 @@ struct fused_primitive_desc_onednn {
 struct fused_primitive_desc {
     std::shared_ptr<program_node> node;
     size_t dep_start_idx;
-    std::map<primitive_id, size_t> deps;
+    std::vector<std::pair<primitive_id, size_t>> deps;
     std::map<primitive_id, size_t> fused_deps;
     size_t total_num_deps = 0;
     activation_func activation;

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -1055,7 +1055,7 @@ void program::fuse_nodes(program_node &fused_node,
             }
         }
         fused_node.dependencies.push_back(&dep);
-        local_desc.deps.emplace(dep.id(), deps_idx++);
+        local_desc.deps.emplace_back(dep.id(), deps_idx++);
         dep.users.push_back(&fused_node);
     }
     local_desc.total_num_deps = std::min(local_desc.total_num_deps, deps_idx);

--- a/src/plugins/intel_gpu/src/runtime/kernels_cache.cpp
+++ b/src/plugins/intel_gpu/src/runtime/kernels_cache.cpp
@@ -436,6 +436,10 @@ void kernels_cache::build_all() {
     _task_executor->runAndWait(tasks);
     tasks.clear();
 
+    if (exception) {
+        std::rethrow_exception(exception);
+    }
+
     {
         std::lock_guard<std::mutex> lock(_mutex);
         _kernels_code.clear();


### PR DESCRIPTION
### Details:
 - Add rethrow_exception for parallel kernels compilation
 - Fix `deps` container so that it can store primitive ids with the same names
