### PR TITLE
[MO] Correct preprocessing block for TensorFlow OD 2.4+ models

### DIFF
--- a/tools/mo/unit_tests/mo/front/tf/ObjectDetectionAPI_test.py
+++ b/tools/mo/unit_tests/mo/front/tf/ObjectDetectionAPI_test.py
@@ -112,7 +112,7 @@ class TestObjectDetectionAPIPreprocessor2Replacement(unittest.TestCase):
         self.sub_const = float32_array([2.0, 3.0, 4.0])
 
         self.nodes = {
-            **regular_op('input', {'type': 'Parameter'}),
+            **regular_op('input', {'op': 'Parameter', 'type': 'Parameter'}),
 
             **regular_op('mul', {'op': 'Mul', 'type': 'Multiply', 'name': 'my_mul'}),
             **regular_op('sub', {'op': 'Sub', 'type': 'Subtract', 'name': 'my_sub'}),
@@ -238,7 +238,7 @@ class TestObjectDetectionAPIPreprocessor2Replacement(unittest.TestCase):
     def build_main_graph(self, pre_processing: str):
         def build_body_graph(pre_processing: str):
             nodes = {
-                **regular_op('input', {'type': 'Parameter'}),
+                **regular_op('input', {'type': 'Parameter', 'op': 'Parameter'}),
 
                 **regular_op('mul', {'op': 'Mul', 'type': 'Multiply', 'name': 'my_body_mul'}),
                 **regular_op('sub', {'op': 'Sub', 'type': 'Subtract', 'name': 'my_body_sub'}),


### PR DESCRIPTION
**Root cause analysis:** In some TensorFlow object detection 2.4+ models casting node to FP32 is located inside the body graph of the preprocessing block. This casting node must be stayed in the resulting graph along with the preprocessing mean/scale nodes since the preprocessing performs in FP32 data type.

**Solution:** Detect the casting node and leave it in the resulted graph, if the data is processed in FP32 data format

**Ticket:** 65298

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names

Validation:
* [x]  Unit tests - No tests for ObjectDetectionAPI, manually checked on the customer model
* [x]  Framework operation tests - No tests for ObjectDetectionAPI, manually checked on the customer model
* [x]  Transformation tests - No tests for ObjectDetectionAPI, manually checked on the customer model
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list - N/A
* [x]  Guide on how to convert the **public** model - N/A
* [x]  User guide update - N/A
