### PR TITLE
[CPU] Fix out of bounds read/write in Gather op

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/mkldnn_gather_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_gather_node.cpp
@@ -63,7 +63,6 @@ MKLDNNGatherNode::MKLDNNGatherNode(const std::shared_ptr<ov::Node>& op, const mk
         if (axis < 0 || axis >= dataSrcRank || batchDims > axis)
             IE_THROW() << errorPrefix << "has incorrect input parameter axis value: " << axis;
     }
-    dataSize = getOriginalInputPrecisionAtPort(GATHER_DATA).size();
 }
 
 void MKLDNNGatherNode::initSupportedPrimitiveDescriptors() {
@@ -104,6 +103,7 @@ void MKLDNNGatherNode::prepareParams() {
     srcBatchStride = std::accumulate(srcDims.begin() + batchDims, srcDims.end(), 1, std::multiplies<size_t>());
     idxBatchStride = std::accumulate(idxDims.begin() + batchDims, idxDims.end(), 1, std::multiplies<size_t>());
     dstBatchStride = std::accumulate(dstDims.begin() + batchDims, dstDims.end(), 1, std::multiplies<size_t>());
+    dataSize = getOriginalInputPrecisionAtPort(GATHER_DATA).size();
     len = dataLength * dataSize;
     if (dataLength == 0)
         IE_THROW() << errorPrefix << "had incorrect input parameters dimension!";

--- a/src/tests/functional/plugin/cpu/single_layer_tests/gather_u8_input_blob.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/gather_u8_input_blob.cpp
@@ -1,0 +1,32 @@
+// Copyright (C) 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+#include <shared_test_classes/base/layer_test_utils.hpp>
+#include <ngraph/opsets/opset8.hpp>
+
+namespace {
+
+using namespace ngraph;
+
+// Validate scenario where a single Constant has multiple users (like one constant is used for Convolution, ConvolutionBackpropData, Multiply, etc.)
+class GatherU8InputBlob : virtual public LayerTestsUtils::LayerTestsCommon {
+protected:
+    void SetUp() override {
+        inPrc = InferenceEngine::Precision::U8;
+        outPrc = InferenceEngine::Precision::FP32;
+        targetDevice = CommonTestUtils::DEVICE_CPU;
+        auto input = std::make_shared<opset8::Parameter>(element::f32, Shape{1, 3, 10, 10});
+        auto indexes = opset8::Constant::create(element::i32, Shape{3}, {2, 1, 0});
+        auto axis = opset8::Constant::create(element::i32, Shape{1}, {1});
+        auto gather = std::make_shared<opset8::Gather>(input, indexes, axis);
+        function = std::make_shared<ngraph::Function>(gather, ParameterVector{input});
+    }
+};
+
+TEST_F(GatherU8InputBlob, smoke_GatherU8InputBlob) {
+    Run();
+}
+
+} // namespace


### PR DESCRIPTION
Fix case when Gather is connected to a model input and this input
has different type than Gather in ngraph function.

For example, when model input has type U8 and Gather input in ngraph function
has type f32, dataSize is set to 4 in MKLDNNGatherNode constructor.
dataSize is used to compute indexes and size of the memory chunk
to be copied during gather operation - and since the input has U8 type -
the indexes and size are 4 times bigger. That makes this operator to read
or write out of bounds.

Move call to getOriginalInputPrecisionAtPort from node's constructor to
prepareParams function. At this point getOriginalInputPrecisionAtPort
returns input's actual data type.

Ticket: 76726

