### PR TITLE
Fixed error in TF2/Keras model loading

### DIFF
--- a/tools/mo/openvino/tools/mo/front/tf/loader.py
+++ b/tools/mo/openvino/tools/mo/front/tf/loader.py
@@ -220,10 +220,13 @@ def load_tf_graph_def(graph_file_name: str = "", is_binary: bool = True, checkpo
                 # enable eager execution temporarily while TensorFlow 2 model is being loaded
                 tf_v1.enable_eager_execution()
 
-                # Code to extract Keras model.
-                # tf.keras.models.load_model function throws TypeError,KeyError or IndexError
-                # for TF 1.x SavedModel format in case TF 1.x installed
-                imported = tf.keras.models.load_model(model_dir, compile=False)
+                try:
+                    # Code to extract Keras model.
+                    # tf.keras.models.load_model function throws TypeError,KeyError or IndexError
+                    # for TF 1.x SavedModel format in case TF 1.x installed
+                    imported = tf.keras.models.load_model(model_dir, compile=False)
+                except:
+                    imported = tf.saved_model.load(model_dir, saved_model_tags)  # pylint: disable=E1120
 
                 # to get a signature by key throws KeyError for TF 1.x SavedModel format in case TF 2.x installed
                 concrete_func = imported.signatures[tf.saved_model.DEFAULT_SERVING_SIGNATURE_DEF_KEY]


### PR DESCRIPTION
Root cause analysis: 
During implementation of Keras inputs order alignment tf.saved_model.load method was replaced with tf.keras.models.load_model. This led to error, that in some cases tf.keras.models.load_model fails to load model while tf.saved_model.load loads it successfully. In this case MO falls back to tf_v1.saved_model.loader.load which adds 'serving_default_' prefix to input names. This leads to errors in conversion, as MO cannot find specified in command line input names.

Solution: 
In case when tf.keras.models.load_model fails to load model use tf.saved_model.load method.

Ticket: 

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR - N/A
* [x]  Transformation preserves original framework node names - N/A
* [x]  Transformation preserves tensor names - N/A

Validation:
* [x]  Unit tests - N/A
* [x]  Framework operation tests - N/A
* [x]  Transformation tests - N/A
* [x]  Model Optimizer IR Reader check - N/A

Documentation:
* [x]  Supported frameworks operations list - N/A
* [x]  Guide on how to convert the **public** model - N/A
* [x]  User guide update - N/A